### PR TITLE
Removes the runechat grey background

### DIFF
--- a/code/datums/chat_message.dm
+++ b/code/datums/chat_message.dm
@@ -103,12 +103,14 @@
 	// We dim italicized text to make it more distinguishable from regular text
 	var/tgt_color = extra_classes.Find("italics") ? target.chat_color_darkened : target.chat_color
 
+	var/div_colour = owned_by.toggle_runechat_backgrounddiv ? "runechatdiv" : ""
+
 	// Approximate text height
 	// Note we have to replace HTML encoded metacharacters otherwise MeasureText will return a zero height
 	// BYOND Bug #2563917
 	// Construct text
 	var/static/regex/html_metachars = new(@"&[A-Za-z]{1,7};", "g")
-	var/complete_text = "<div class='runechatdiv'><span class='center maptext [extra_classes != null ? extra_classes.Join(" ") : ""]' style='color: [tgt_color];'>[text]</span></div>"
+	var/complete_text = "<div class='[div_colour]'><span class='center maptext [extra_classes != null ? extra_classes.Join(" ") : ""]' style='color: [tgt_color];'>[text]</span></div>"
 	var/mheight = WXH_TO_HEIGHT(owned_by.MeasureText(replacetext(complete_text, html_metachars, "m"), null, CHAT_MESSAGE_WIDTH))
 	approx_lines = max(1, mheight / CHAT_MESSAGE_APPROX_LHEIGHT)
 
@@ -184,7 +186,7 @@
 		extra_classes |= "small"
 
 	if (client.toggle_runechat_outlines)
-		extra_classes |= "black_outline"
+		extra_classes += "black_outline"
 
 	var/dist = get_dist(src, speaker)
 	switch (dist)
@@ -256,3 +258,9 @@
 	set name = "Toggle Runechat Outlines"
 	toggle_runechat_outlines = !toggle_runechat_outlines
 	to_chat(mob, "<span class='notice'>Runechat outlines are now [toggle_runechat_outlines ? "enabled" : "disabled"].</span>")
+
+/client/verb/toggle_runechat_backgrounddiv()
+	set category = "OOC"
+	set name = "Toggle Runechat Outlines"
+	toggle_runechat_backgrounddiv = !toggle_runechat_backgrounddiv
+	to_chat(mob, "<span class='notice'>Runechat background colour is now [toggle_runechat_backgrounddiv ? "enabled" : "disabled"].</span>")

--- a/code/datums/chat_message.dm
+++ b/code/datums/chat_message.dm
@@ -261,6 +261,6 @@
 
 /client/verb/toggle_runechat_backgrounddiv()
 	set category = "OOC"
-	set name = "Toggle Runechat Outlines"
+	set name = "Toggle Runechat Backgrounddiv"
 	toggle_runechat_backgrounddiv = !toggle_runechat_backgrounddiv
 	to_chat(mob, "<span class='notice'>Runechat background colour is now [toggle_runechat_backgrounddiv ? "enabled" : "disabled"].</span>")

--- a/code/datums/chat_message.dm
+++ b/code/datums/chat_message.dm
@@ -102,15 +102,12 @@
 
 	// We dim italicized text to make it more distinguishable from regular text
 	var/tgt_color = extra_classes.Find("italics") ? target.chat_color_darkened : target.chat_color
-
-	var/div_colour = owned_by.toggle_runechat_backgrounddiv ? "runechatdiv" : ""
-
 	// Approximate text height
 	// Note we have to replace HTML encoded metacharacters otherwise MeasureText will return a zero height
 	// BYOND Bug #2563917
 	// Construct text
 	var/static/regex/html_metachars = new(@"&[A-Za-z]{1,7};", "g")
-	var/complete_text = "<div class='[div_colour]'><span class='center maptext [extra_classes != null ? extra_classes.Join(" ") : ""]' style='color: [tgt_color];'>[text]</span></div>"
+	var/complete_text = "<span class='center maptext [extra_classes != null ? extra_classes.Join(" ") : ""]' style='color: [tgt_color];'>[text]</span>"
 	var/mheight = WXH_TO_HEIGHT(owned_by.MeasureText(replacetext(complete_text, html_metachars, "m"), null, CHAT_MESSAGE_WIDTH))
 	approx_lines = max(1, mheight / CHAT_MESSAGE_APPROX_LHEIGHT)
 
@@ -258,9 +255,3 @@
 	set name = "Toggle Runechat Outlines"
 	toggle_runechat_outlines = !toggle_runechat_outlines
 	to_chat(mob, "<span class='notice'>Runechat outlines are now [toggle_runechat_outlines ? "enabled" : "disabled"].</span>")
-
-/client/verb/toggle_runechat_backgrounddiv()
-	set category = "OOC"
-	set name = "Toggle Runechat Backgrounddiv"
-	toggle_runechat_backgrounddiv = !toggle_runechat_backgrounddiv
-	to_chat(mob, "<span class='notice'>Runechat background colour is now [toggle_runechat_backgrounddiv ? "enabled" : "disabled"].</span>")

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -94,7 +94,6 @@
 	// Runechat messages
 	var/list/seen_messages = list()
 	var/toggle_runechat_outlines = TRUE
-	var/toggle_runechat_backgrounddiv = FALSE
 
 var/list/person_animation_viewers = list()
 var/list/item_animation_viewers = list()

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -94,6 +94,7 @@
 	// Runechat messages
 	var/list/seen_messages = list()
 	var/toggle_runechat_outlines = TRUE
+	var/toggle_runechat_backgrounddiv = FALSE
 
 var/list/person_animation_viewers = list()
 var/list/item_animation_viewers = list()


### PR DESCRIPTION
Originally meant as a way to get more consistent contrast, it looks awful with more than one player. 

![image](https://user-images.githubusercontent.com/31417754/84827711-2a68a100-b025-11ea-9c3d-77eab3d8deae.png)
