### PR TITLE
Removes some unnecessary code

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -200,10 +200,6 @@
 
 #define isatom(A) isloc(A)
 
-#if DM_VERSION < 513
-#define ismovable(A) (istype(A, /atom/movable))
-#endif
-
 #define isrealobject(A) (istype(A, /obj/item) || istype(A, /obj/structure) || istype(A, /obj/machinery) || istype(A, /obj/mecha))
 
 #define iscleanaway(A) (istype(A,/obj/effect/decal/cleanable) || (istype(A,/obj/effect/overlay) && !istype(A,/obj/effect/overlay/puddle) && !istype(A, /obj/effect/overlay/hologram)) || istype(A,/obj/effect/rune_legacy))
@@ -338,12 +334,6 @@ proc/get_space_area()
 	return 0
 
 //1 line helper procs compressed into defines.
-#if DM_VERSION < 513
-#define clamp(x, y, z) 	min(max(x, y), z)
-//x is the number you want to clamp
-//y is the minimum
-//z is the maximum
-#endif
 
 //Returns 1 if the variable contains a protected list that can't be edited
 #define variable_contains_protected_list(var_name) (((var_name) == "contents") || ((var_name) == "locs") || ((var_name) == "vars"))

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1,6 +1,6 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
-#if DM_VERSION < 512
-#error Your version of byond is too old, you need version 512 or higher
+#if DM_VERSION < 513
+#error Your version of byond is too old, you need version 513 or higher
 #endif
 #define RUNWARNING // disable if they re-enable run() in 507 or newer.
                    // They did, tested in 508.1296 - N3X

--- a/code/ZAS/Atom.dm
+++ b/code/ZAS/Atom.dm
@@ -1,13 +1,7 @@
 /atom/movable/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	return (!density || !height || air_group)
 
-#ifdef DM_BUILD //Checking the actual value of this macro is unnecessary, since the required build is 1438 and the macro was first added in 1443.
-                //This means that the code can't compile in builds 1438-1442, but there's not a way around that.
-                //(Not a good way, at least.)
 /turf/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-#else
-/turf/proc/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-#endif
 
 	if(!target)
 		return 0

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -40,13 +40,6 @@
 			return L[index]
 	return
 
-#if DM_VERSION < 513
-/proc/islist(list/L)
-	if(istype(L))
-		return 1
-	return 0
-#endif
-
 //Return either pick(list) or null if list is not of type /list or is empty
 /proc/safepick(list/L)
 	if(istype(L) && L.len)

--- a/code/__HELPERS/maths.dm
+++ b/code/__HELPERS/maths.dm
@@ -25,12 +25,6 @@ var/list/sqrtTable = list(1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 
 	var/invcos = arccos(x / sqrt(x * x + y * y))
 	return y >= 0 ? invcos : -invcos
 
-#if DM_VERSION < 513
-proc/arctan(x)
-	var/y=arcsin(x/sqrt(1+x*x))
-	return y
-#endif
-
 /proc/Ceiling(x, y = 1)
 	. = -round(-x / y) * y
 


### PR DESCRIPTION
Now that the code requires 513 to compile, we don't need these backwards-compatibility sections anymore.
There's one more version check in the code which should also be unnecessary, but it's a bit more complicated and a lot older and I'm not 100% sure I wouldn't fuck up when trying to remove it
This is 0% tested but none of the code changed here even gets compiled if you're running 513, so if it doesn't fail to compile there's no way it could break anything