### PR TITLE
Added a safety timeout to BSQL connect operations

### DIFF
--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -216,7 +216,7 @@ var/datum/subsystem/dbcore/SSdbcore
 	while ( (!_connection || _connection.gcDestroyed) || !op.IsComplete() ) // Waiting we have a real connection and that it's complete
 		stoplag()
 		ticker++
-		if (ticker > 30 && (!connection || !connectOperation || connection.gcDestroyed))
+		if (ticker > 100 && (!connection || !connectOperation || connection.gcDestroyed))
 			message_admins("Error getting connection status. Attempting to reconnect.")
 			Disconnect()
 			Connect()

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -123,8 +123,9 @@ var/datum/subsystem/dbcore/SSdbcore
 		last_error = error
 		log_sql("Connect() failed | [error]")
 		++failed_connections
-		qdel(connection)
-		qdel(connectOperation)
+		BSQL_DEL_CALL(connection)
+		BSQL_DEL_CALL(connectOperation)
+		initialized = 0
 		connection = null
 		connectOperation = null
 
@@ -198,6 +199,7 @@ var/datum/subsystem/dbcore/SSdbcore
 */
 
 /datum/subsystem/dbcore/proc/Disconnect()
+	initialized = 0
 	failed_connections = 0
 	BSQL_DEL_CALL(connectOperation)
 	BSQL_DEL_CALL(connection)
@@ -210,8 +212,15 @@ var/datum/subsystem/dbcore/SSdbcore
 	//block until any connect operations finish
 	var/datum/BSQL_Connection/_connection = connection
 	var/datum/BSQL_Operation/op = connectOperation
+	var/ticker = 0
 	while ( (!_connection || _connection.gcDestroyed) || !op.IsComplete() ) // Waiting we have a real connection and that it's complete
 		stoplag()
+		ticker++
+		if (ticker > 30 && (!connection || !connectOperation || connection.gcDestroyed))
+			message_admins("Error getting connection status. Attempting to reconnect.")
+			Disconnect()
+			Connect()
+			return
 	return connection && !(connection.gcDestroyed && !op.GetError()) // Connect
 
 /datum/subsystem/dbcore/proc/Quote(str)


### PR DESCRIPTION
Sometimes, BSQL can get stuck in an old sweet nothing state in which it waits eternally for a connect operation to resolve,  even though this operation no longer exists.

This adds a failsafe for this particular case. If the connect operation doesn't exist anymore, the library will now try to connect again from a clean state.

I tested it moderately locally. My local DB is responsive enough for this not to matter, but I don't really know how it will look like on server.