### PR TITLE
Fixes runechat messages 'hard-deleteing'

### DIFF
--- a/code/datums/chat_message.dm
+++ b/code/datums/chat_message.dm
@@ -52,7 +52,7 @@
 		owned_by.images.Remove(message)
 	owned_by = null
 	message_loc = null
-	message = null
+	del message // Images must be del'd by byond internally. It does not lag as much as a datum hard-del.
 	return ..()
 
 /**


### PR DESCRIPTION
I doubt it's a real hard-del since you can easily get thousands of those not counting as soft-deleted without any impact on performance, most likely BYOND is just performing the `del` thing itself.

Still, it did show up on the hard-del list as undeleted, so this fixes that. Tested.