### PR TITLE
Mouse Ops explode (IED sized) on death

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -517,5 +517,6 @@
 
 /mob/living/simple_animal/mouse/mouse_op/death(var/gibbed = FALSE)
 	..(TRUE)
-	if(gibbed == FALSE)
-		src.gib()
+	if(!gibbed && !suiciding && loc != null)
+		explosion(get_turf(loc),-1,0,2)
+		gib()


### PR DESCRIPTION
I originally didn't do this because they were supposed to be a meme, but they're admin only anyways so I guess it doesn't matter. Explosion is identical to an IED so it doesn't destroy tiles or gib, but it specifically gibs the mouse after it completes.

Fixes #26891

:cl:
* tweak: Mouse Operatives now create an IED-sized explosion on death, assuming they did not gib or commit suicide.