### PR TITLE
wrapping messages & boxes

### DIFF
--- a/code/game/objects/items/stacks/packagewrap.dm
+++ b/code/game/objects/items/stacks/packagewrap.dm
@@ -38,9 +38,7 @@
 		to_chat(user, "<span class='notice'>You start wrapping \the [target] with \the [src].</span>")
 		if(do_after(user, target, 10))
 			afterattack(target, user, proximity_flag)//this item is now wrapped!
-			return 1
-		else
-			return 1
+		return 1
 	else
 		to_chat(user, "<span class='notice'>You can't wrap that.</span>")
 	

--- a/code/game/objects/items/stacks/packagewrap.dm
+++ b/code/game/objects/items/stacks/packagewrap.dm
@@ -21,6 +21,7 @@
 		/obj/item/weapon/gift,
 		/obj/item/weapon/winter_gift,
 		/obj/item/weapon/storage/evidencebag,
+		/obj/item/weapon/storage/backpack/holding,
 		/obj/item/weapon/legcuffs/bolas
 		)
 

--- a/code/game/objects/items/stacks/packagewrap.dm
+++ b/code/game/objects/items/stacks/packagewrap.dm
@@ -35,10 +35,12 @@
 	if(!istype(target, /atom/movable) || !proximity_flag)
 		return
 	if(!is_type_in_list(target, cannot_wrap))
-		to_chat(user, "<span class='notice'>You start wrapping \the [target] with \the [src].</span>")
-		if(do_after(user, target, 10))
-			afterattack(target, user, proximity_flag)//this item is now wrapped!
-		return 1
+		if(istype(target, /obj/item/weapon/storage))
+			to_chat(user, "<span class='notice'>You start wrapping \the [target] with \the [src].</span>")
+			if(do_after(user, target, 10))
+				afterattack(target, user, proximity_flag)//this item is now wrapped!
+				return 1 //don't put wrap in box after you wrap it
+		return 0//proceed as normally (put wrap in box)
 	else
 		to_chat(user, "<span class='notice'>You can't wrap that.</span>")
 	

--- a/code/game/objects/items/stacks/packagewrap.dm
+++ b/code/game/objects/items/stacks/packagewrap.dm
@@ -21,8 +21,7 @@
 		/obj/item/weapon/gift,
 		/obj/item/weapon/winter_gift,
 		/obj/item/weapon/storage/evidencebag,
-		/obj/item/weapon/legcuffs/bolas,
-		/obj/item/weapon/storage
+		/obj/item/weapon/legcuffs/bolas
 		)
 
 	var/list/wrappable_big_stuff = list(
@@ -36,12 +35,16 @@
 	if(!istype(target))
 		return
 	if(is_type_in_list(target, cannot_wrap))
+		to_chat(user, "<span class='notice'>You can't wrap that.</span>")
 		return
 	if(target.anchored)
+		to_chat(user, "<span class='notice'>You can't get the wrapping around \the [target].</span>")
 		return
 	if(target in user)
+		to_chat(user, "<span class='notice'>That's not gonna work.</span>")
 		return
 	if(!proximity_flag)
+		to_chat(user, "<span class='notice'>You're not close enough.</span>")
 		return
 	if(ishuman(attacked))
 		return try_wrap_human(attacked,user)
@@ -62,6 +65,7 @@
 			target.forceMove(P)
 			P.add_fingerprint(user)
 			use(1)
+			to_chat(user, "<span class='notice'>You wrap \the [target] with \the [src].</span>")
 		else
 			to_chat(user, "<span class='warning'>You need more paper!</span>")
 	else if(is_type_in_list(target,wrappable_big_stuff) && bigpath)
@@ -74,6 +78,7 @@
 			target.forceMove(P)
 			P.add_fingerprint(user)
 			use(3)
+			to_chat(user, "<span class='notice'>You wrap \the [target] with \the [src].</span>")
 		else
 			to_chat(user, "<span class='warning'>You need more paper!</span>")
 	else

--- a/code/game/objects/items/stacks/packagewrap.dm
+++ b/code/game/objects/items/stacks/packagewrap.dm
@@ -31,6 +31,20 @@
 		/obj/structure/stackopacks
 		)
 
+/obj/item/stack/package_wrap/preattack(var/obj/target, var/mob/user, var/proximity_flag)
+	if(!istype(target, /atom/movable) || !proximity_flag)
+		return
+	if(!is_type_in_list(target, cannot_wrap))
+		to_chat(user, "<span class='notice'>You start wrapping \the [target] with \the [src].</span>")
+		if(do_after(user, target, 10))
+			afterattack(target, user, proximity_flag)//this item is now wrapped!
+			return 1
+		else
+			return 1
+	else
+		to_chat(user, "<span class='notice'>You can't wrap that.</span>")
+	
+
 /obj/item/stack/package_wrap/afterattack(var/attacked, mob/user as mob, var/proximity_flag)
 	var/atom/movable/target = attacked
 	if(!istype(target))

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -417,6 +417,14 @@
 		return
 	..()
 
+	if(istype(W,/obj/item/stack/package_wrap))
+		if(!is_type_in_list(src, W.cannot_wrap))
+			to_chat(user, "<span class='notice'>You start wrapping \the [src] with \the [W].</span>")
+			if(do_after(user, src, 10 * W.w_class))
+				return//this item is now wrapped!
+		else
+			to_chat(user, "<span class='notice'>You can't wrap that.</span>")
+
 	// /vg/ #11: Recursion.
 	/*if(istype(W,/obj/item/weapon/implanter/compressed))
 		return*/

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -417,15 +417,6 @@
 		return
 	..()
 
-	if(istype(W,/obj/item/stack/package_wrap))
-		var/obj/item/stack/package_wrap/wrap = W
-		if(!is_type_in_list(src, wrap.cannot_wrap))
-			to_chat(user, "<span class='notice'>You start wrapping \the [src] with \the [wrap].</span>")
-			if(do_after(user, src, 10 * wrap.w_class))
-				return//this item is now wrapped!
-		else
-			to_chat(user, "<span class='notice'>You can't wrap that.</span>")
-
 	// /vg/ #11: Recursion.
 	/*if(istype(W,/obj/item/weapon/implanter/compressed))
 		return*/

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -418,9 +418,10 @@
 	..()
 
 	if(istype(W,/obj/item/stack/package_wrap))
-		if(!is_type_in_list(src, W.cannot_wrap))
-			to_chat(user, "<span class='notice'>You start wrapping \the [src] with \the [W].</span>")
-			if(do_after(user, src, 10 * W.w_class))
+		var/obj/item/stack/package_wrap/wrap = W
+		if(!is_type_in_list(src, wrap.cannot_wrap))
+			to_chat(user, "<span class='notice'>You start wrapping \the [src] with \the [wrap].</span>")
+			if(do_after(user, src, 10 * wrap.w_class))
 				return//this item is now wrapped!
 		else
 			to_chat(user, "<span class='notice'>You can't wrap that.</span>")


### PR DESCRIPTION
i wonder why storage items were in the forbidden list in the first place
prepare for unforeseen consequences i guess

the delay exists to assist in putting wrappers in storages (so you can click on a box/backpack/etc and then walk away to put it in the there)

closes #25206

🆑 
 - rscadd: You can now gift- and packagewrap boxes, backpacks, briefcases and other storage stuff. 
 - wip: If you want to put your wrapping stuff IN the box/backpack/whatever, just click it into an empty slot, or move while you're wrapping it.
 - tweak: Added messages for wrapping items, and for failing to wrap items.