### PR TITLE
Fix Prism Runtime

### DIFF
--- a/code/modules/optics/prism.dm
+++ b/code/modules/optics/prism.dm
@@ -134,5 +134,6 @@ var/list/obj/machinery/prism/prism_list = list()
 		icon_state = "prism_on"
 	else
 		icon_state = "prism_off"
-		returnToPool(beam)
-		beam=null
+		if (beam)
+			returnToPool(beam)
+			beam=null


### PR DESCRIPTION
Fixes a prism related runtime. If you see huge CPU usage again @ShiftyRail try to get the engineer or whoever set them up tell you how they set them up.

I ran tests with a single prism and 2-3 emitters in different configurations and nothing weird occurred.