### PR TITLE
Headset microphones can be turned off

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -9,7 +9,8 @@
 	melt_temperature = MELTPOINT_PLASTIC
 	subspace_transmission = 1
 	canhear_range = 0 // can't hear headsets from very far away
-
+	flags = FPRINT // No HEAR. Headsets should only work when being used explicitly.
+	broadcasting = TRUE
 	slot_flags = SLOT_EARS
 	var/translate_binary = 0
 	var/translate_hive = 0
@@ -28,6 +29,11 @@
 
 /obj/item/device/radio/headset/initialize()
 	recalculateChannels()
+	return ..()
+
+/obj/item/device/radio/headset/talk_into(datum/speech/speech_orig, channel=null)
+	if(!broadcasting)
+		return
 	return ..()
 
 /obj/item/device/radio/headset/receive_range(freq, level)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -90,8 +90,7 @@
 
 	var/dat = "<html><head><title>[src]</title></head><body><TT>"
 
-	if(!istype(src, /obj/item/device/radio/headset)) //Headsets dont get a mic button
-		dat += "Microphone: [broadcasting ? "<A href='byond://?src=\ref[src];talk=0'>Engaged</A>" : "<A href='byond://?src=\ref[src];talk=1'>Disengaged</A>"]<BR>"
+	dat += "Microphone: [broadcasting ? "<A href='byond://?src=\ref[src];talk=0'>Engaged</A>" : "<A href='byond://?src=\ref[src];talk=1'>Disengaged</A>"]<BR>"
 
 	dat += {"
 				Speaker: [listening ? "<A href='byond://?src=\ref[src];listen=0'>Engaged</A>" : "<A href='byond://?src=\ref[src];listen=1'>Disengaged</A>"]<BR>


### PR DESCRIPTION
Closes #26575

:cl:
 * tweak: Radio headset microphones can now be turned on and off, just like with regular radios. This means that EMPs can disrupt them.