### PR TITLE
Fixes Observers Having Preview Backgrounds

### DIFF
--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -202,8 +202,8 @@
 	var/fat=""
 	if(disabilities&DISABILITY_FLAG_FAT && current_species.anatomy_flags & CAN_BE_FAT)
 		fat="_fat"
-	preview_icon = new /icon('icons/mob/previewbg.dmi',preview_background)
-	preview_icon.Blend(new /icon(icobase, "torso_[g][fat]"), ICON_OVERLAY)
+	
+	preview_icon = new /icon(icobase, "torso_[g][fat]")
 	preview_icon.Blend(new /icon(icobase, "groin_[g]"), ICON_OVERLAY)
 	preview_icon.Blend(new /icon(icobase, "head_[g]"), ICON_OVERLAY)
 
@@ -484,6 +484,8 @@
 					clothes_s = new /icon(uniform_dmi, "grey_s")
 					clothes_s.Blend(new /icon(feet_dmi, "black"), ICON_UNDERLAY)
 					clothes_s=blend_backpack(clothes_s,backbag,"satchel-norm",null,"courierbag")
+	
+		preview_icon.Blend(new /icon('icons/mob/previewbg.dmi',preview_background), ICON_UNDERLAY)
 
 	// Observers get tourist outfit.
 	else


### PR DESCRIPTION
[bugfix] Fixes observers having backgrounds, and the background changing brightness with skin tone, closes #26884.

~~Tested a bunch of edge cases but wasn't able to recreate the invisible observer sprite on local, this should fix it hopefully.~~ Figured it out, fixed.