### PR TITLE
announce name changes for silicons + name change confirmation

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -248,7 +248,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	return 1
 
 //Generalised helper proc for letting mobs rename themselves. Used to be clname() and ainame()
-//Last modified by Carn
+//Also used for the screen alarm rename option
 /mob/proc/rename_self(var/role, var/allow_numbers=0, var/namepick_message = "You are a [role]. Would you like to change your name to something else?")
 	spawn(0)
 		var/oldname = real_name
@@ -275,6 +275,9 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		if(cmptext("ai",role))
 			if(isAI(src))
 				var/mob/living/silicon/ai/A = src
+				if(A.connected_robots.len) //let the borgs know what their master's new name is
+					for(var/mob/living/silicon/robot/robitt in A.connected_robots)
+						to_chat(robitt, "<span class='notice' style=\"font-family:Courier\">Notice: Linked AI [oldname] renamed to [newname].</span>")
 				oldname = null//don't bother with the records update crap
 //				to_chat(world, "<b>[newname] is the AI!</b>")
 //				world << sound('sound/AI/newAI.ogg')
@@ -286,8 +289,9 @@ Turf and target are seperate in case you want to teleport some distance from a t
 				if(A.aiPDA)
 					A.aiPDA.owner = newname
 					A.aiPDA.name = newname + " (" + A.aiPDA.ownjob + ")"
+				
 
-
+		to_chat(src, "<span class='notice'>You will now be known as [newname].</span>")
 		fully_replace_character_name(oldname,newname)
 
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -298,6 +298,8 @@ var/list/cyborg_list = list()
 		changed_name = custom_name
 	else
 		changed_name = "[modtype] [braintype]-[num2text(ident)]"
+	if(connected_ai)
+		to_chat(connected_ai, "<span class='notice' style=\"font-family:Courier\">Notice: unit [name] renamed to [changed_name].</span>")
 	real_name = changed_name
 	name = real_name
 


### PR DESCRIPTION
Has as semi-intended side-effect that any other use of the name change screen alarm now gets a notification of what they changed their name to.
![AI_message](https://user-images.githubusercontent.com/8468269/85335145-cb030900-b4dc-11ea-904e-d49007aebf7f.png)
![borg_message](https://user-images.githubusercontent.com/8468269/85335147-cb9b9f80-b4dc-11ea-9ee3-93a5c5fec1b5.png)
![wiz_message](https://user-images.githubusercontent.com/8468269/85335490-64cab600-b4dd-11ea-8d1f-e2ab7e801008.png)



🆑 
 - tweak: Silicons will now announce their name changes to their linked master / slave units.
 - tweak: Using the name change screen alarm to change your name now gives you a confirmation of your new name.