### PR TITLE
Fix bison runtime

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -813,6 +813,8 @@ var/list/laser_tag_vests = list(/obj/item/clothing/suit/tag/redtag, /obj/item/cl
 	..()
 
 /obj/item/projectile/beam/bison/proc/draw_ray(var/turf/lastloc)
+	if (!loc)
+		return
 	if(drawn)
 		return
 	drawn = 1

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -813,7 +813,7 @@ var/list/laser_tag_vests = list(/obj/item/clothing/suit/tag/redtag, /obj/item/cl
 	..()
 
 /obj/item/projectile/beam/bison/proc/draw_ray(var/turf/lastloc)
-	if (!loc)
+	if (gcDestroyed || disposed)
 		return
 	if(drawn)
 		return


### PR DESCRIPTION
Fixed the Bison's beams trying to draw themselves a second time after getting deleted, causing a runtime every time it was fired.