### PR TITLE
Rigsuits Fix, Tweaks & New Modules

### DIFF
--- a/code/game/machinery/suit_modifier.dm
+++ b/code/game/machinery/suit_modifier.dm
@@ -12,7 +12,7 @@
 **/
 
 /obj/machinery/suit_modifier
-	name = "Rigsuit modification station"
+	name = "\improper Rigsuit modification station"
 	desc = "A man-sized machine, akin to a coffin, meant to install modifications into a worn rigsuit."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "suitmodifier"
@@ -40,11 +40,11 @@
 
 /obj/machinery/suit_modifier/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/rig_module) && user.drop_item(I, src))
-		say("Module installed.", class = "binaryradio")
+		say("\The [I] installed.", class = "binaryradio")
 		modules_to_install.Add(I)
 		return
 	if(istype(I, /obj/item/weapon/cell) && !cell && user.drop_item(I, src))
-		say("Cell installed.", class = "binaryradio")
+		say("\The [I] installed.", class = "binaryradio")
 		cell = I
 		return
 	.=..()
@@ -56,17 +56,30 @@
 		playsound(src, 'sound/machines/buzz-two.ogg', 50, 0)
 		say("Unit Occupied.", class = "binaryradio")
 		return
-	if(!modules_to_install.len)
-		say("No modules available.", class = "binaryradio")
+	if(!modules_to_install.len && !cell)
+		say("No upgrade available.", class = "binaryradio")
 		return
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(!H.is_wearing_item(/obj/item/clothing/suit/space/rig, slot_wear_suit))
-			say("Unable to detect rigsuit on person.", class = "binaryradio")
+			say("Unable to detect rigsuit on [H].", class = "binaryradio")
 			return
 		if(H.loc == loc) //Same turf
 			lock_atom(H)
 			process_module_installation(H)
+			return
+	if((modules_to_install.len || cell) && !activated)
+		var/obj/removed = input(user, "Choose an upgrade to remove from [src].", src) as null|anything in modules_to_install + cell
+		if(!removed || activated)
+			return
+		user.put_in_hands(removed)
+		if(removed.loc == src)
+			removed.forceMove(get_turf(src))
+		if(removed == cell)
+			cell = null
+			return
+		modules_to_install -= removed
+		
 
 /obj/machinery/suit_modifier/proc/process_module_installation(var/mob/living/carbon/human/H)
 	if(activated)
@@ -85,7 +98,7 @@
 		if(locate(RM.type) in R.modules) //One already installed
 			continue
 		if(do_after(H, src, 5 SECONDS, needhand = FALSE))
-			say("Module installed to \the [R].", class = "binaryradio")
+			say("Installing [RM] into \the [R].", class = "binaryradio")
 			R.modules.Add(RM)
 			RM.rig = R
 			RM.forceMove(R)
@@ -98,11 +111,15 @@
 	suit_overlay.icon_state = "suitmodifier_closed"
 	overlays.Add(suit_overlay)
 	sleep(20)
-	if(get_cell() && R.cell.charge < cell.charge)
-		R.cell.forceMove(get_turf(src))
-		cell.forceMove(R)
-		R.cell = cell
-		cell = null
+	if(cell)
+		var/choice = input(H, "Do you wish to install [cell]?", src) in list("Yes", "No")
+		if(choice == "Yes")
+			say("Installing [cell] into to \the [R].", class = "binaryradio")
+			if(R.cell)
+				R.cell.forceMove(get_turf(src))
+			cell.forceMove(R)
+			R.cell = cell
+			cell = null
 	playsound(src, 'sound/machines/pressurehiss.ogg', 40, 1)
 	new /obj/effect/effect/smoke(get_turf(src))
 	unlock_atom(H)

--- a/code/game/machinery/suit_modifier.dm
+++ b/code/game/machinery/suit_modifier.dm
@@ -70,7 +70,7 @@
 			return
 	if((modules_to_install.len || cell) && !activated)
 		var/obj/removed = input(user, "Choose an upgrade to remove from [src].", src) as null|anything in modules_to_install + cell
-		if(!removed || activated)
+		if(!removed || activated || !user.Adjacent(src) || user.incapacitated())
 			return
 		user.put_in_hands(removed)
 		if(removed.loc == src)
@@ -111,9 +111,9 @@
 	suit_overlay.icon_state = "suitmodifier_closed"
 	overlays.Add(suit_overlay)
 	sleep(20)
-	if(cell)
-		var/choice = input(H, "Do you wish to install [cell]?", src) in list("Yes", "No")
-		if(choice == "Yes")
+	if(cell) //Can't answer the prompt if you're incapacitated.
+		var/choice = alert(H, "Do you wish to install [cell]?", src, "Yes", "No")
+		if((choice == "Yes") && H.Adjacent(src) && !H.incapacitated())
 			say("Installing [cell] into to \the [R].", class = "binaryradio")
 			if(R.cell)
 				R.cell.forceMove(get_turf(src))

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -477,6 +477,10 @@
 						if(rigsuit.MB) //Internal Boots
 							rigsuit.MB.clean_blood()
 							rigsuit.MB.decontaminate()
+						for(var/module in rigsuit.modules)
+							if(istype(module, /obj/item/rig_module/rad_shield))
+								var/obj/item/rig_module/rad_shield/rad = module
+								rad.current_capacity = initial(rad.current_capacity)
 				if(mask)
 					mask.clean_blood()
 					mask.decontaminate()

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -169,12 +169,15 @@ var/list/all_hardsuit_pieces = list(HARDSUIT_HEADGEAR,HARDSUIT_GLOVES,HARDSUIT_B
 	processing_objects |= src
 
 /obj/item/clothing/suit/space/rig/emp_act(severity)
-	if(activated)
-		deactivate_suit(FALSE)
-	if(cell)
-		cell.emp_act(severity)
+	for(var/obj/item/rig_module/M in modules)
+		if(M.emp_act(severity)) //EMP shielding module returns TRUE if it has charges.
+			return
 	for(var/obj/item/I in all_hardsuit_parts)
 		I.emp_act(severity)
+	if(cell)
+		cell.emp_act(severity)
+	if(activated)
+		deactivate_suit(FALSE)
 	..(severity)
 
 /obj/item/clothing/suit/space/rig/Destroy()

--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -253,7 +253,7 @@
 	var/mob/user = arguments["user"]
 	var/rads = arguments["rads"]
 
-	if(!rig?.wearer == user) //Well lad.
+	if(rig?.wearer != user) //Well lad.
 		user.on_irradiate.Remove(event_key)
 		event_key = null
 		return

--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/module.dmi'
 	icon_state = "std_mod"
 	var/obj/item/clothing/suit/space/rig/rig
-	var/requires_component = TRUE //This module needs a removable component(helmet,gloves,boot,tank) and should be activated before they're deployed from the suit.
 	var/activated = FALSE
 	var/active_power_usage = 0 //Energy consumption per tick
 
@@ -15,7 +14,24 @@
 /obj/item/rig_module/proc/examine_addition(mob/user)
 	return
 
-/obj/item/rig_module/proc/activate(var/mob/user)//We do not set activated to TRUE in the default activate() proc.
+/obj/item/rig_module/emp_act(severity)
+	return FALSE
+
+/obj/item/rig_module/proc/check_activate(var/requires_human=FALSE)
+	if(!rig || activated)
+		return FALSE
+	if(requires_human && !ishuman(rig.wearer))
+		return FALSE
+	return TRUE
+
+/obj/item/rig_module/proc/check_deactivate(var/requires_human=FALSE)
+	if(!rig || !activated)
+		return FALSE
+	if(requires_human && !ishuman(rig.wearer))
+		return FALSE
+	return TRUE
+
+/obj/item/rig_module/proc/activate()
 	activated = TRUE
 
 /obj/item/rig_module/proc/deactivate()
@@ -25,24 +41,32 @@
 	return
 
 /obj/item/rig_module/proc/say_to_wearer(var/string)
-	if(!ishuman(rig.wearer))
+	if(!rig?.wearer)
 		return
 	to_chat(rig.wearer, "\The [src] reports: <span class = 'binaryradio'>[string]</span>")
 
+
+//Speed boost module
 /obj/item/rig_module/speed_boost
 	name = "rig speed module"
 	desc = "Self-lubricating joints allow for ease of movement when walking in a rigsuit."
 	active_power_usage = 10
 
 /obj/item/rig_module/speed_boost/activate()
+	if(!check_activate())
+		return
 	say_to_wearer("Speed module engaged.")
 	rig.slowdown = max(1, slowdown/1.25)
 	..()
 
 /obj/item/rig_module/speed_boost/deactivate()
+	if(!check_deactivate())
+		return
 	rig.slowdown = initial(rig.slowdown)
 	..()
 
+
+//Health readout module
 /obj/item/rig_module/health_readout
 	name = "articulated spine"
 	desc = "Lets passers by read your health from a distance"
@@ -53,6 +77,8 @@
 	var/mob/living/carbon/human/H = rig.wearer
 	to_chat(user, "<span class = 'notice'>The embedded health readout reads: [H.isDead()?"0%":"[(H.health/H.maxHealth)*100]%"]</span>")
 
+
+//Tank-refiller module
 /obj/item/rig_module/tank_refiller
 	name = "tank pressurizer"
 	desc = "When in atmosphere, syphons from the air to refill the tank connected to your internals."
@@ -61,7 +87,7 @@
 	active_power_usage = 50
 
 /obj/item/rig_module/tank_refiller/activate()
-	if(!ishuman(rig.wearer))
+	if(!check_activate(TRUE))
 		return
 	var/mob/living/carbon/human/H = rig.wearer
 	if(H.internal)
@@ -109,12 +135,15 @@
 		//pressure_delta = target_moles * 8.314 * sample_temperature / internals.volume
 
 
+//Plasmaproof module
 /obj/item/rig_module/plasma_proof
 	name = "plasma-proof sealing authority"
 	desc = "Brings the suit it is installed into up to plasma environment standards."
 	active_power_usage = 5
 
 /obj/item/rig_module/plasma_proof/activate()
+	if(!check_activate())
+		return
 	say_to_wearer("Plasma seal initialized.")
 	rig.clothing_flags |= PLASMAGUARD
 	if(rig.H)
@@ -122,19 +151,23 @@
 	..()
 
 /obj/item/rig_module/plasma_proof/deactivate()
+	if(!check_deactivate())
+		return
 	say_to_wearer("Plasma seal disengaged.")
 	rig.clothing_flags &= ~PLASMAGUARD
 	if(rig.H)
 		rig.H.clothing_flags &= ~PLASMAGUARD
 	..()
 
+
+//Muscle tissue/Hulk module
 /obj/item/rig_module/muscle_tissue
 	name = "artificial muscle tissue"
 	desc = "A flexible tissue with a number of sensors stretched between its surface and interior of the suit. When these sensors detected an impact, the artificial muscle reacts instantaneously, contracting and diffusing the damage."
 	active_power_usage = 100
 
 /obj/item/rig_module/muscle_tissue/activate()
-	if(!ishuman(rig.wearer))
+	if(!check_activate(TRUE))
 		return
 	var/mob/living/carbon/human/H = rig.wearer
 	H.mutations.Add(M_HULK) //I'M FUCKING INVINCIBLE!
@@ -143,10 +176,9 @@
 	rig.canremove = FALSE
 	say_to_wearer("Safety lock enabled.")
 	..()
-	
 
 /obj/item/rig_module/muscle_tissue/deactivate()
-	if(!ishuman(rig.wearer))
+	if(!check_deactivate(TRUE))
 		return
 	var/mob/living/carbon/human/H = rig.wearer
 	H.mutations.Remove(M_HULK)
@@ -155,3 +187,80 @@
 	rig.canremove = TRUE
 	say_to_wearer("Safety lock disabled.")
 	..()
+
+
+//EMP shield module
+/obj/item/rig_module/emp_shield
+	name = "\improper EMP dissipation module"
+	desc = "A bewilderingly complex bundle of optic fibers and silicon photonic circuitry."
+	active_power_usage = 1
+
+/obj/item/rig_module/emp_shield/emp_act(severity)
+	if(activated && rig?.cell?.use(round(300/severity, 50))) // 300/150/100 cell drain to shield the suit. It might sound bad but at least the suit is keeping itself activated.
+		return TRUE
+	return FALSE
+
+
+//Rad shield module
+/obj/item/rig_module/rad_shield
+	name = "\improper R.A.D."
+	desc = "An radiation absorption device. Its acronym and true name both convey the application of this module."
+	active_power_usage = 1
+	var/event_key
+	var/initial_suit = 0
+	var/initial_helmet = 0
+	var/max_capacity = 250
+	var/current_capacity = 0
+
+/obj/item/rig_module/rad_shield/examine_addition(mob/user)
+	var/current_status = round((current_capacity/max_capacity) * 100)
+	to_chat(user, "<span class = 'notice'>The embedded [name] capacity readout reads: <font color='[current_status <= 50 ? "green" : (current_status >= 85 ? "red" : "yellow")]'>[current_status]%</font></span>")
+
+/obj/item/rig_module/rad_shield/check_activate(requires_human=FALSE)
+	if(current_capacity >= max_capacity)
+		return FALSE
+	. = ..(requires_human)
+
+/obj/item/rig_module/rad_shield/activate()
+	if(!check_activate(TRUE))
+		return
+
+	if(rig.H)
+		initial_helmet = rig.H.armor["rad"]
+		rig.H.armor["rad"] = 100
+	initial_suit = rig.armor["rad"]
+	rig.armor["rad"] = 100
+
+	say_to_wearer("[src] enabled.")
+	event_key = rig.wearer.on_irradiate.Add(src, "absorb_rads")
+	..()
+
+/obj/item/rig_module/rad_shield/deactivate()
+	if(!check_deactivate())
+		return
+
+	if(rig?.H)
+		rig.H.armor["rad"] = initial_helmet
+	rig?.armor["rad"] = initial_suit
+
+	say_to_wearer("[src] disabled.")
+	if(event_key)
+		rig.wearer?.on_irradiate.Remove(event_key)
+		event_key = null
+	..()
+
+/obj/item/rig_module/rad_shield/proc/absorb_rads(list/arguments)
+	var/mob/user = arguments["user"]
+	var/rads = arguments["rads"]
+
+	if(!rig?.wearer == user) //Well lad.
+		user.on_irradiate.Remove(event_key)
+		event_key = null
+		return
+
+	if(rig.H)
+		current_capacity += min(max_capacity, (rads * ((100 - initial_helmet) / 100)))
+	current_capacity += min(max_capacity, (rads * ((100 - initial_suit) / 100)))
+
+	if(current_capacity >= max_capacity)
+		deactivate()


### PR DESCRIPTION
New toys. Not actually giving them to the players yet, because i don't want to litter this PR with balance theorycrafting and this is already super unatomic.

The **EMP dissipation module** will consume your suit's charge(300/150/100 based on EMP severity) to prevent it from getting disabled/its battery damaged
The **R.A.D.** will shield your suit and helmet until it's filter is full(It will fill based on the amount of radiation and the suit's initial radiation shielding). You can use a SSU to clean the filter.

![image](https://user-images.githubusercontent.com/17928298/85578469-752f7d80-b610-11ea-9390-4a5620a024c8.png)
![image](https://user-images.githubusercontent.com/17928298/85578508-7e204f00-b610-11ea-8c1f-b926fd5d05f0.png)
![image](https://user-images.githubusercontent.com/17928298/85578526-824c6c80-b610-11ea-836a-fd44db51e373.png)

:cl:
 * rscadd: You can now remove upgrades from suit modifiers
 * bugfix: Fixed suit modifiers not installing cell upgrades if the modifier had no rig module installed
 * tweak: You may now choose if you want to apply any cell upgrade while the machine is upgrading your suit
 * rscadd: Adds two new rig modules: The EMP dissipation module and the R.A.D.(radiation absorption device)
 * rscadd: SSUs will now clean the suit's R.A.D. radiation filter on
 * rscadd: The new modules will be added to cargo/science in a later PR.