### PR TITLE
gygax sprites now respect overload status or lack thereof

### DIFF
--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -94,6 +94,7 @@
 */
 
 /obj/mecha/combat/gygax/stopMechWalking()
+	return // ok
 
 /obj/mecha/combat/gygax/dyndomove(direction)
 	if(!..())

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -94,10 +94,6 @@
 */
 
 /obj/mecha/combat/gygax/stopMechWalking()
-		icon_state = initial_icon + "-gofast"
-
-/obj/mecha/combat/gygax/dark/stopMechWalking()
-	icon_state = initial_icon
 
 /obj/mecha/combat/gygax/dyndomove(direction)
 	if(!..())


### PR DESCRIPTION
closes #26903 (by deleting four whole lines, somehow)
:cl:
 * bugfix: Gygaxes should no longer look like they're stuck in the overload sprite.