### PR TITLE
AI holopad overlays verb

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -123,9 +123,20 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	master = A//AI is the master.
 	use_power = 2//Active power usage.
 	move_hologram()
+	if(A && A.holopadoverlays.len)
+		for(var/image/ol in A.holopadoverlays)
+			if(ol.loc == src)
+				ol.icon_state = "holopad1"
+				break
+		
 	return 1
 
 /obj/machinery/hologram/holopad/proc/clear_holo()
+	if(master && master.holopadoverlays.len)
+		for(var/image/ol in master.holopadoverlays)
+			if(ol.loc == src)
+				ol.icon_state = "holopad0"
+				break
 	qdel(holo)//Get rid of hologram.
 	qdel(ray)
 	holo = null

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -39,6 +39,7 @@ var/list/ai_list = list()
 	var/chosen_core_icon_state = "ai"
 	var/datum/intercom_settings/intercom_clipboard = null //Clipboard for copy/pasting intercom settings
 	var/mentions_on = FALSE
+	var/list/holopadoverlays = list()
 
 	// See VOX_AVAILABLE_VOICES for available values
 	var/vox_voice = "fem";
@@ -172,6 +173,15 @@ var/list/ai_list = list()
 		anchored = !anchored
 		to_chat(src, "You are now <b>[anchored ? "" : "un"]anchored</b>.")
 	busy = FALSE
+
+/mob/living/silicon/ai/verb/toggle_holopadoverlays()
+	set category = "AI Commands"
+	set name = "Toggle Holopad Overlays"
+	
+	if(incapacitated() || aiRestorePowerRoutine || !isturf(loc) || busy)
+		return
+	toggleholopadoverlays()
+	to_chat(src, "<span class='notice' style=\"font-family:Courier\">Holopad overlays <b>[holopadoverlays.len ? "en" : "dis"]abled</b>.</span>")
 
 /mob/living/silicon/ai/verb/radio_interact()
 	set category = "AI Commands"

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -159,6 +159,21 @@
 		return
 	cameraFollow = null
 	eyeobj.forceMove(T)
+	
+/mob/living/silicon/ai/proc/toggleholopadoverlays() //shows holopads above all static
+	if (!holopadoverlays.len)
+		for(var/obj/machinery/hologram/holopad/holopads in machines)
+			var/image/holopadoverlay = image('icons/obj/stationobjs.dmi',holopads,"holopad0", ABOVE_HUD_PLANE)
+			holopadoverlay.plane = ABOVE_HUD_PLANE
+			if(client)
+				client.images += holopadoverlay
+				holopadoverlays += holopadoverlay
+	else
+		if(client)
+			for(var/image/ol in holopadoverlays)
+				client.images -= ol
+			holopadoverlays.Cut()
+
 
 /mob/living/silicon/ai/verb/toggle_acceleration()
 	set category = "AI Commands"


### PR DESCRIPTION
![smallpic](https://user-images.githubusercontent.com/8468269/85800685-b07d9980-b741-11ea-84cd-d3923a1bc100.png) ![litup](https://user-images.githubusercontent.com/8468269/85799891-4adcdd80-b740-11ea-90ba-fce9351503e3.png)
AI verb that adds overlays for holopads. Only AIs see the overlay. Using the verb again hides them.
They light up when in use, and the overlay automatically gets deleted when a holopad is destroyed.



🆑 
 - rscadd: New verb for AIs: Toggle Holopad Overlays.