### PR TITLE
Fixes jukebox lag

### DIFF
--- a/code/modules/media/mediamanager.dm
+++ b/code/modules/media/mediamanager.dm
@@ -102,10 +102,11 @@ function SetMusic(url, time, volume) {
 
 
 /hook_handler/shuttlejukes/proc/OnEmergencyShuttleDeparture(var/list/args)
-	for(var/obj/machinery/media/jukebox/superjuke/shuttle/SJ in machines)
-		SJ.playing=1
-		SJ.update_music()
-		SJ.update_icon()
+	spawn(0)
+		for(var/obj/machinery/media/jukebox/superjuke/shuttle/SJ in machines)
+			SJ.playing=1
+			SJ.update_music()
+			SJ.update_icon()
 
 /mob/proc/update_music()
 	if (client && client.media && !client.media.forced)


### PR DESCRIPTION
It would cause the shuttle to fracture in two sometimes
Tested & fixed
Fixes #26842

:cl:
- bugfix: Added an extra layer of superglue in the emergency shuttle spare parts