### PR TITLE
Fixes RCD crash and character weirdness

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -80,12 +80,9 @@ forLineInText(text)
 		i = findtext(Haystack, Needle, i + 1, End)
 
 //Removes a few problematic characters
-/proc/sanitize_simple(var/t,var/list/repl_chars = list("\n"="#","\t"="#","�"="�"))
+/proc/sanitize_simple(var/t,var/list/repl_chars = list("\n"="#","\t"="#"))
 	for(var/char in repl_chars)
-		var/index = findtext(t, char)
-		while(index)
-			t = copytext(t, 1, index) + repl_chars[char] + copytext(t, index+1)
-			index = findtext(t, char)
+		t = replacetext(t, char, repl_chars[char])
 	return t
 
 //Runs byond's sanitization proc along-side sanitize_simple

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -353,7 +353,7 @@
 	playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
 
 	var/obj/machinery/door/airlock/D = new selected.build_type(A)
-	if(capitalize(selected_name) == selected_name)	//The name inputted is capitalized, so we add \improper.
+	if(selected_name && (capitalize(selected_name) == selected_name))	//The name inputted is capitalized, so we add \improper.
 		D.name	= "\improper [selected_name]"
 	else
 		D.name		= selected_name
@@ -404,8 +404,8 @@
 /datum/selection_schematic/airlock_schematic/clicked(var/mob/user)
 	if(master:selected == src)
 		master:selected_name = copytext(sanitize(input(usr,"What would you like to name this airlock?","Input a name",name) as text|null),1,MAX_NAME_LEN)
-		if(capitalize(master:selected_name) == master:selected_name)
-			master:selected_name = "\improper[master:selected_name]"
+		if(master:selected_name && (capitalize(master:selected_name) == master:selected_name))
+			master:selected_name = "\improper [master:selected_name]"
 	else
 		master.selected = src
 // Schematics for schematics, I know, but it's OOP!


### PR DESCRIPTION
Fun Fact: While changes in BYOND 513 are what caused that question mark character to show up in the name box, if you had pasted it there (or in fact into *any* sanitized input), it always would have caused a crash
This fixes both the character showing up and it causing a crash

Fixes #26983