### PR TITLE
Fixes beams just breaking constantly

### DIFF
--- a/code/game/objects/effects/beam.dm
+++ b/code/game/objects/effects/beam.dm
@@ -404,10 +404,6 @@
 		returnToPool(src)
 		return
 
-	var/turf/T = get_turf(src)
-	if(T && T.on_density_change)
-		locDensity = T.on_density_change.Add(src, "turf_density_change")
-
 	if((x == 1 || x == world.maxx || y == 1 || y == world.maxy))
 		//BEAM_DEL(src)
 		beam_testing("\ref[src] end of world")
@@ -452,6 +448,10 @@
 			src._re_emit = 0
 			returnToPool(src)
 			return
+
+	var/turf/T = get_turf(src)
+	if(T && T.on_density_change)
+		locDensity = T.on_density_change.Add(src, "turf_density_change")
 
 	next = spawn_child()
 	if(next)


### PR DESCRIPTION
They now place the turf density change event on the correct turf. This means they no longer prevent any other beams of the same type anywhere else from working if they travel over any significant number of non-space tiles. It also means that they might not hard del once pooling is removed, though if memory serves they have a super secret hidden reference somewhere else that I never managed to find so they still might