### PR TITLE
Fixed Pathogenic Clouds "visibly" slamming into windows and grilles when getting ZAS'd, or dealing damage when thrown in general

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -70,13 +70,15 @@
 		var/mob/M = AM
 		health -= 10
 		healthcheck(TRUE)
-		visible_message("<span class='danger'>\The [M] slams into \the [src].</span>", \
-		"<span class='danger'>You slam into \the [src].</span>")
+		if (AM.invisibility < 101)
+			visible_message("<span class='danger'>\The [M] slams into \the [src].</span>", \
+			"<span class='danger'>You slam into \the [src].</span>")
 	else if(isobj(AM))
 		var/obj/item/I = AM
 		health -= I.throwforce
 		healthcheck(TRUE)
-		visible_message("<span class='danger'>\The [I] slams into \the [src].</span>")
+		if (AM.invisibility < 101)
+			visible_message("<span class='danger'>\The [I] slams into \the [src].</span>")
 
 /obj/structure/grille/attack_paw(mob/user as mob)
 	attack_hand(user)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -62,7 +62,7 @@
 	if(ismob(user))
 		shock(user, 60) //Give the user the benifit of the doubt
 
-/obj/structure/grille/hitby(AM as mob|obj)
+/obj/structure/grille/hitby(var/atom/movable/AM)
 	. = ..()
 	if(.)
 		return

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -214,13 +214,15 @@ var/list/one_way_windows
 		var/mob/M = AM //Duh
 		health -= 10 //We estimate just above a slam but under a crush, since mobs can't carry a throwforce variable
 		healthcheck(M)
-		visible_message("<span class='danger'>\The [M] slams into \the [src].</span>", \
-		"<span class='danger'>You slam into \the [src].</span>")
+		if (AM.invisibility < 101)
+			visible_message("<span class='danger'>\The [M] slams into \the [src].</span>", \
+			"<span class='danger'>You slam into \the [src].</span>")
 	else if(isobj(AM))
 		var/obj/item/I = AM
 		health -= I.throwforce
 		healthcheck()
-		visible_message("<span class='danger'>\The [I] slams into \the [src].</span>")
+		if (AM.invisibility < 101)
+			visible_message("<span class='danger'>\The [I] slams into \the [src].</span>")
 
 /obj/structure/window/attack_hand(mob/living/user as mob)
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -206,7 +206,7 @@ var/list/one_way_windows
 	return 1
 
 //Someone threw something at us, please advise
-/obj/structure/window/hitby(AM as mob|obj)
+/obj/structure/window/hitby(var/atom/movable/AM)
 	. = ..()
 	if(.)
 		return

--- a/code/modules/virus2/pathogen_cloud.dm
+++ b/code/modules/virus2/pathogen_cloud.dm
@@ -11,6 +11,7 @@ var/list/pathogen_clouds = list()
 	anchored = 0
 	density = 0
 	invisibility = 101
+	throwforce = 0
 	var/mob/source = null
 	var/sourceIsCarrier = TRUE
 	var/list/viruses = list()


### PR DESCRIPTION
:cl:
* bugfix: Pathogenic Clouds no longer deal damage when thrown (by ZAS or anything else) and no long display a visible message when slamming into windows and grilles.