### PR TITLE
The vials in an Isolation Centrifuge now stop spinning if it breaks/runs out of power.

### DIFF
--- a/code/modules/virus2/centrifuge.dm
+++ b/code/modules/virus2/centrifuge.dm
@@ -161,9 +161,12 @@
 
 
 /obj/machinery/disease2/centrifuge/proc/add_vial_sprite(var/obj/item/weapon/reagent_containers/glass/beaker/vial/vial, var/slot)
-	overlays += "centrifuge_vial[slot][on ? "_moving" : ""]"
+	var/spin = on
+	if(stat & (BROKEN|NOPOWER))
+		spin = FALSE
+	overlays += "centrifuge_vial[slot][spin ? "_moving" : ""]"
 	if (vial.reagents.total_volume)
-		var/image/filling = image(icon, "centrifuge_vial[slot]_filling[on ? "_moving" : ""]")
+		var/image/filling = image(icon, "centrifuge_vial[slot]_filling[spin ? "_moving" : ""]")
 		filling.icon += mix_color_from_reagents(vial.reagents.reagent_list)
 		filling.alpha = mix_alpha_from_reagents(vial.reagents.reagent_list)
 		overlays += filling


### PR DESCRIPTION
:cl:
* bugfix: Vials in an Isolation Centrifuge no longer spin if the machine breaks or runs out of power.