### PR TITLE
Xenomorphs can no longer spam screams by deathgasping

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -64,7 +64,7 @@
 	if(!issilent(user) && (M_HARDCORE in user.mutations))
 		message = "whispers with their final breath, <i>'i told u i was hardcore..'</i>"
 	. = ..()
-	if(. && isalienadult(user))
+	if(params && isalienadult(user))
 		playsound(user.loc, 'sound/voice/hiss6.ogg', 80, 1, 1)
 	if (. && user.stat == UNCONSCIOUS && !params)
 		user.succumb_proc(0, 1)


### PR DESCRIPTION


:cl:
 * bugfix: Aliens can no longer spam screams by deathgasping.