### PR TITLE
Prevent casting more than one spell at a time

### DIFF
--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -296,3 +296,4 @@
 
 	var/forced_density = 0 // If the mob was made non-dense by an admin.
 	var/old_assigned_role // If they ghosted, what role did they have?
+	var/is_casting_a_spell = FALSE

--- a/code/modules/spells/aoe_turf/aoe_turf.dm
+++ b/code/modules/spells/aoe_turf/aoe_turf.dm
@@ -34,6 +34,6 @@ Aoe turf spells have two useful flags: IGNOREDENSE and IGNORESPACE. These are ex
 		spell_center = center
 	return ((target in view_or_range(range, spell_center, selection_type)))
 
-/spell/aoe_turf/perform(mob/user = usr, skipcharge = 0, list/target_override)
+/spell/aoe_turf/actual_perform(mob/user = usr, skipcharge = 0, list/target_override)
 	. = ..()
 	center = null

--- a/code/modules/spells/aoe_turf/fall.dm
+++ b/code/modules/spells/aoe_turf/fall.dm
@@ -70,7 +70,7 @@ var/global/list/falltempoverlays = list()
 		for(i = -x, i <= x, i++)
 			. += "[x],[y]"
 
-/spell/aoe_turf/fall/perform(mob/user = usr, skipcharge = 0, list/target_override, var/ignore_timeless = FALSE, var/ignore_path = null) //if recharge is started is important for the trigger spells
+/spell/aoe_turf/fall/actual_perform(mob/user = usr, skipcharge = 0, list/target_override, var/ignore_timeless = FALSE, var/ignore_path = null) //if recharge is started is important for the trigger spells
 	if(!holder)
 		set_holder(user) //just in case
 	if(!cast_check(skipcharge, user))

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -148,7 +148,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 		return (target in options)
 	return ((target in view_or_range(range, user, selection_type)) && istype(target, /mob/living))
 
-/spell/proc/perform(mob/user = usr, skipcharge = 0, list/target_override) //if recharge is started is important for the trigger spells
+/spell/proc/actual_perform(mob/user = usr, skipcharge = 0, list/target_override)
 	if(!holder)
 		set_holder(user) //just in case
 
@@ -201,6 +201,14 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 			take_charge(user, skipcharge)
 		after_cast(targets) //generates the sparks, smoke, target messages etc.
 
+/spell/proc/perform(mob/user = usr, skipcharge = 0, list/target_override) //if recharge is started is important for the trigger spells
+	if(user.is_casting_a_spell)
+		to_chat(user, "<span class='warning'>You're already casting a spell.</span>")
+		return
+	user.is_casting_a_spell = TRUE
+	actual_perform(arglist(args))
+	user.is_casting_a_spell = FALSE
+
 //This is used with the wait_for_click spell flag to prepare spells to be cast on your next click
 /spell/proc/channel_spell(mob/user = usr, skipcharge = 0, force_remove = 0)
 	if(!holder)
@@ -229,13 +237,13 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 
 /spell/proc/channeled_spell(var/list/args)
 	var/event/E = args["event"]
-	
+
 	if(!currently_channeled)
 		E.handlers.Remove("\ref[src]:channeled_spell")
 		return 0
 
 	var/atom/A = args["atom"]
-	
+
 	if(E.holder != holder)
 		E.handlers.Remove("\ref[src]:channeled_spell")
 		return 0


### PR DESCRIPTION
I don't know why this is now necessary but it does prevent autoclickers from spamming spells in my local testing.