### PR TITLE
allows most atmos stuff to be colored again

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -30,7 +30,7 @@ Pipelines + Other Objects -> Pipe network
 	var/initialize_directions = 0
 	var/initialize_directions_he = 0 // Same, but for HE pipes.
 
-	var/can_be_coloured = 0
+	var/can_be_coloured = 1 //set to 0 to blacklist your atmos thing from being colored
 	var/image/centre_overlay = null
 	// Investigation logs
 	var/log

--- a/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
@@ -2,6 +2,7 @@ obj/machinery/atmospherics/trinary
 	dir = SOUTH
 	initialize_directions = SOUTH|NORTH|WEST
 	use_power = 1
+	can_be_coloured = 0
 
 	var/datum/gas_mixture/air1
 	var/datum/gas_mixture/air2

--- a/code/ATMOSPHERICS/components/unary/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary/unary_base.dm
@@ -2,7 +2,7 @@
 	dir = SOUTH
 	initialize_directions = SOUTH
 	layer = UNARY_PIPE_LAYER
-
+	can_be_coloured = 0
 	var/datum/gas_mixture/air_contents
 	var/obj/machinery/atmospherics/node1
 	var/datum/pipe_network/network
@@ -11,7 +11,6 @@
 	..()
 	initialize_directions = dir
 	air_contents = new
-
 	air_contents.temperature = T0C
 	air_contents.volume = starting_volume
 


### PR DESCRIPTION
another request from dedchet
turns the whitelist into a blacklist
may have unforeseen consequences

🆑 
 - tweak: Pipe coloring is now a blacklist instead of a whitelist; you should be able to color more stuff now.