### PR TITLE
maybe fix shuttle lag

### DIFF
--- a/code/modules/media/mediamanager.dm
+++ b/code/modules/media/mediamanager.dm
@@ -235,6 +235,7 @@ function SetMusic(url, time, volume) {
 
 // Scan for media sources and use them.
 /datum/media_manager/proc/update_music()
+	set waitfor = FALSE
 	var/targetURL = ""
 	var/targetStartTime = 0
 	var/targetVolume = 0


### PR DESCRIPTION
The idea here is that #26965 might not have addressed all paths that lead to `update_music` being called so I'm making it so the sleep in `update_music` itself doesn't block the proc. Might work, might not, I surely cannot test this locally.