### PR TITLE
Fixes #27058

### DIFF
--- a/code/modules/virus2/analyser.dm
+++ b/code/modules/virus2/analyser.dm
@@ -82,6 +82,9 @@
 	if (scanner)
 		to_chat(user, "<span class='warning'>\The [scanner] is currently busy using this analyser.</span>")
 		return
+	if(!ghost.can_poltergeist())
+		to_chat(ghost, "Your poltergeist abilities are still cooling down.")
+		return FALSE
 	add_hiddenprint(user)
 	icon_state = "analyser_processing"
 	flick("analyser_turnon",src)

--- a/code/modules/virus2/analyser.dm
+++ b/code/modules/virus2/analyser.dm
@@ -87,7 +87,7 @@
 	flick("analyser_turnon",src)
 	set_light(2,2)
 	playsound(loc, "sound/machines/heps.ogg", 50, 1)
-	spawn(1)
+	spawn(1 SECONDS)
 		update_icon()
 		flick("analyser_turnoff",src)
 

--- a/code/modules/virus2/analyser.dm
+++ b/code/modules/virus2/analyser.dm
@@ -73,6 +73,24 @@
 			else
 				to_chat(user, "<span class='warning'>You must open the dish's lid before it can be analysed. Be sure to wear proper protection first (at least a sterile mask and latex gloves).</span>")
 
+/obj/machinery/disease2/diseaseanalyser/attack_ghost(var/mob/user)
+	if(!can_spook())
+		return FALSE
+	if(stat & (BROKEN))
+		to_chat(user, "<span class='warning'>\The [src] is broken.</span>")
+		return
+	if (scanner)
+		to_chat(user, "<span class='warning'>\The [scanner] is currently busy using this analyser.</span>")
+		return
+	add_hiddenprint(user)
+	icon_state = "analyser_processing"
+	flick("analyser_turnon",src)
+	set_light(2,2)
+	playsound(loc, "sound/machines/heps.ogg", 50, 1)
+	spawn(1)
+		update_icon()
+		flick("analyser_turnoff",src)
+
 /obj/machinery/disease2/diseaseanalyser/attack_hand(var/mob/user)
 	. = ..()
 	if(stat & (BROKEN))

--- a/code/modules/virus2/analyser.dm
+++ b/code/modules/virus2/analyser.dm
@@ -83,7 +83,7 @@
 		to_chat(user, "<span class='warning'>\The [scanner] is currently busy using this analyser.</span>")
 		return
 	if(!user.can_poltergeist())
-		to_chat(ghost, "Your poltergeist abilities are still cooling down.")
+		to_chat(user, "Your poltergeist abilities are still cooling down.")
 		return FALSE
 	add_hiddenprint(user)
 	icon_state = "analyser_processing"

--- a/code/modules/virus2/analyser.dm
+++ b/code/modules/virus2/analyser.dm
@@ -73,7 +73,7 @@
 			else
 				to_chat(user, "<span class='warning'>You must open the dish's lid before it can be analysed. Be sure to wear proper protection first (at least a sterile mask and latex gloves).</span>")
 
-/obj/machinery/disease2/diseaseanalyser/attack_ghost(var/mob/user)
+/obj/machinery/disease2/diseaseanalyser/attack_ghost(var/mob/dead/observer/user)
 	if(!can_spook())
 		return FALSE
 	if(stat & (BROKEN))
@@ -82,7 +82,7 @@
 	if (scanner)
 		to_chat(user, "<span class='warning'>\The [scanner] is currently busy using this analyser.</span>")
 		return
-	if(!ghost.can_poltergeist())
+	if(!user.can_poltergeist())
 		to_chat(ghost, "Your poltergeist abilities are still cooling down.")
 		return FALSE
 	add_hiddenprint(user)


### PR DESCRIPTION
Fixes #27058

:cl:
* bugfix: Ghosts can now properly haunt Virology's disease analyzer, without preventing the Virologist from using the machine or getting their name known.