### PR TITLE
Some Cult shading tweaks

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -405,7 +405,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		var/response = alert(src, "It doesn't have to end here, the veil is thin and the dark energies in you soul cling to this plane. You may forsake this body and materialize as a Shade.","Sacrifice Body","Shade","Ghost","Stay in body")
 		switch (response)
 			if ("Shade")
-				dust()
+				dust(TRUE)
 				return
 			if ("Stay in body")
 				return

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -778,6 +778,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 		if(spawn_limb)
 			organ = get_organ_item()
+			if (!organ)
+				return null
 
 			//If any organs are attached to this, attach them to the dropped organ item
 			for(var/datum/organ/external/O in children)
@@ -1464,6 +1466,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 /datum/organ/external/head/generate_dropped_organ(current_organ)
 	if(!current_organ)
 		current_organ = new /obj/item/organ/external/head(owner.loc, owner, src)
+		if (!current_organ)
+			return null
 		owner.decapitated = current_organ
 	var/datum/organ/internal/brain/B = eject_brain()
 	var/obj/item/organ/external/head/H = current_organ
@@ -1785,6 +1789,18 @@ obj/item/organ/external/head/New(loc, mob/living/carbon/human/H)
 	origin_body = H
 
 	if(istype(H))
+		if(iscultist(H) && veil_thickness > CULT_PROLOGUE)
+			//spawning a skull where the head would have been
+			var/randomdir = pick(cardinal)
+			step(src, randomdir)
+			new /obj/item/weapon/skull(get_turf(src))
+			//turning the body into skull-less remains, the dusting will take care of the shade's creation.
+			var/datum/organ/external/head_organ = H.get_organ(LIMB_HEAD)
+			head_organ.status |= ORGAN_DESTROYED
+			H.dust(TRUE)
+			qdel(src)
+			return
+
 		src.icon_state = H.gender == MALE? "head_m" : "head_f"
 	..()
 	if(isgolem(H)) //Golems don't inhabit their severed heads, they turn to dust when they die.

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -766,6 +766,16 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(body_part == (UPPER_TORSO || LOWER_TORSO)) //We can't lose either, those cannot be amputated and will cause extremely serious problems
 		return
 
+	if(body_part == HEAD && iscultist(owner) && veil_thickness > CULT_PROLOGUE)
+		//spawning a skull where the head would have been
+		var/obj/item/weapon/skull/sk = new (get_turf(owner))
+		var/randomdir = pick(cardinal)
+		step(sk, randomdir)
+		//turning the body into skull-less remains, the dusting will take care of the shade's creation.
+		status |= ORGAN_DESTROYED
+		owner.dust(TRUE)
+		return
+
 	var/datum/species/species = src.species || owner.species
 	var/obj/item/organ/external/organ //Dropped limb object
 
@@ -778,8 +788,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 		if(spawn_limb)
 			organ = get_organ_item()
-			if (!organ)
-				return null
 
 			//If any organs are attached to this, attach them to the dropped organ item
 			for(var/datum/organ/external/O in children)
@@ -1466,8 +1474,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 /datum/organ/external/head/generate_dropped_organ(current_organ)
 	if(!current_organ)
 		current_organ = new /obj/item/organ/external/head(owner.loc, owner, src)
-		if (!current_organ)
-			return null
 		owner.decapitated = current_organ
 	var/datum/organ/internal/brain/B = eject_brain()
 	var/obj/item/organ/external/head/H = current_organ
@@ -1789,18 +1795,6 @@ obj/item/organ/external/head/New(loc, mob/living/carbon/human/H)
 	origin_body = H
 
 	if(istype(H))
-		if(iscultist(H) && veil_thickness > CULT_PROLOGUE)
-			//spawning a skull where the head would have been
-			var/randomdir = pick(cardinal)
-			step(src, randomdir)
-			new /obj/item/weapon/skull(get_turf(src))
-			//turning the body into skull-less remains, the dusting will take care of the shade's creation.
-			var/datum/organ/external/head_organ = H.get_organ(LIMB_HEAD)
-			head_organ.status |= ORGAN_DESTROYED
-			H.dust(TRUE)
-			qdel(src)
-			return
-
 		src.icon_state = H.gender == MALE? "head_m" : "head_f"
 	..()
 	if(isgolem(H)) //Golems don't inhabit their severed heads, they turn to dust when they die.


### PR DESCRIPTION
Fixes #26955
Fixes #26919

:cl:
* bugfix: Cultists turning into shades now properly drop all their items
* tweak: Beheading cultists or otherwise destroying their heads now also turns them into shades