### PR TITLE
Remove references to mob/new_player after roundstart

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -241,6 +241,7 @@ var/stacking_limit = 90
 	dynamic_stats.round_start_pop = candidates.len
 	dynamic_stats.round_start_rulesets = starting_rulesets
 	dynamic_stats.measure_threat(threat)
+	candidates.Cut()
 	return 1
 
 /datum/gamemode/dynamic/proc/rigged_roundstart()


### PR DESCRIPTION
it still hard-dels but that's probably a BYOND bug