### PR TITLE
Fix confusion runes not affecting mobs and cameras in the dark

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -1324,6 +1324,12 @@ var/list/blind_victims = list()
 	mouse_opacity = 0
 	var/duration = 5
 	var/hallucination_radius=25
+	var/mob/virtualhearer/virtualviewer = null
+
+/obj/effect/cult_ritual/confusion/Destroy()//just in case
+	qdel(virtualviewer)
+	virtualviewer = null
+	..()
 
 /obj/effect/cult_ritual/confusion/New(turf/loc,var/duration=300,var/radius=25,var/mob/specific_victim=null)
 	..()
@@ -1381,8 +1387,11 @@ var/list/blind_victims = list()
 			spawn(5)
 				M.clear_fullscreen("blindblack", animate = 0)
 				M.flash_eyes(visual = 1)
+
+	//now to blind cameras, the effects on cameras do not time out, but they can be fixed
 	if (!specific_victim)
-		for(var/obj/machinery/camera/C in view(T))//the effects on cameras do not time out, but they can be fixed
+		virtualviewer = new(src)//first we need to spawn a fake mob that can see in the dark
+		for(var/obj/machinery/camera/C in view(virtualviewer))
 			shadow(C,T)
 			var/col = C.color
 			animate(C, color = col, time = 4)
@@ -1390,6 +1399,8 @@ var/list/blind_victims = list()
 			animate(color = col, time = 5)
 			C.vision_flags = BLIND//Anyone using a security cameras computer will only see darkness
 			C.setViewRange(-1)//The camera won't reveal the area for the AI anymore
+		qdel(virtualviewer)
+		virtualviewer = null
 
 	spawn(10)
 		for(var/mob/living/carbon/C in victims)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -1326,9 +1326,10 @@ var/list/blind_victims = list()
 	var/hallucination_radius=25
 	var/mob/virtualhearer/virtualviewer = null
 
-/obj/effect/cult_ritual/confusion/Destroy()//just in case
-	qdel(virtualviewer)
-	virtualviewer = null
+/obj/effect/cult_ritual/confusion/Destroy()
+	if (virtualviewer)
+		qdel(virtualviewer)
+		virtualviewer = null
 	..()
 
 /obj/effect/cult_ritual/confusion/New(turf/loc,var/duration=300,var/radius=25,var/mob/specific_victim=null)
@@ -1358,10 +1359,12 @@ var/list/blind_victims = list()
 	var/list/potential_victims = list()
 	var/list/victims = list()
 
+	virtualviewer = new(src)//first we need to spawn a fake mob that can see in the dark
+
 	if (specific_victim)
 		potential_victims.Add(specific_victim)
 	else
-		for(var/mob/living/M in viewers(T))
+		for(var/mob/living/M in view(virtualviewer))
 			potential_victims.Add(M)
 
 	for(var/mob/living/M in potential_victims)
@@ -1390,7 +1393,6 @@ var/list/blind_victims = list()
 
 	//now to blind cameras, the effects on cameras do not time out, but they can be fixed
 	if (!specific_victim)
-		virtualviewer = new(src)//first we need to spawn a fake mob that can see in the dark
 		for(var/obj/machinery/camera/C in view(virtualviewer))
 			shadow(C,T)
 			var/col = C.color
@@ -1399,8 +1401,6 @@ var/list/blind_victims = list()
 			animate(color = col, time = 5)
 			C.vision_flags = BLIND//Anyone using a security cameras computer will only see darkness
 			C.setViewRange(-1)//The camera won't reveal the area for the AI anymore
-		qdel(virtualviewer)
-		virtualviewer = null
 
 	spawn(10)
 		for(var/mob/living/carbon/C in victims)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -1324,13 +1324,6 @@ var/list/blind_victims = list()
 	mouse_opacity = 0
 	var/duration = 5
 	var/hallucination_radius=25
-	var/mob/virtualhearer/virtualviewer = null
-
-/obj/effect/cult_ritual/confusion/Destroy()
-	if (virtualviewer)
-		qdel(virtualviewer)
-		virtualviewer = null
-	..()
 
 /obj/effect/cult_ritual/confusion/New(turf/loc,var/duration=300,var/radius=25,var/mob/specific_victim=null)
 	..()
@@ -1359,12 +1352,10 @@ var/list/blind_victims = list()
 	var/list/potential_victims = list()
 	var/list/victims = list()
 
-	virtualviewer = new(src)//first we need to spawn a fake mob that can see in the dark
-
 	if (specific_victim)
 		potential_victims.Add(specific_victim)
 	else
-		for(var/mob/living/M in view(virtualviewer))
+		for(var/mob/living/M in dview(world.view, T, INVISIBILITY_MAXIMUM))
 			potential_victims.Add(M)
 
 	for(var/mob/living/M in potential_victims)
@@ -1393,7 +1384,7 @@ var/list/blind_victims = list()
 
 	//now to blind cameras, the effects on cameras do not time out, but they can be fixed
 	if (!specific_victim)
-		for(var/obj/machinery/camera/C in view(virtualviewer))
+		for(var/obj/machinery/camera/C in dview(world.view, T, INVISIBILITY_MAXIMUM))
 			shadow(C,T)
 			var/col = C.color
 			animate(C, color = col, time = 4)


### PR DESCRIPTION
I'd like to thank those who reported that they could still see in Virology last round, even if their deduction was wrong it gave me the right hunch.

:cl:
* bugfix; Confusion runes now properly affect cameras that are in the dark, as well as invisible mobs.