### PR TITLE
Re-tgui-ified GPS, added potential bug workaround

### DIFF
--- a/code/modules/admin/verbs/SDQL_2/SDQL_2_std.dm
+++ b/code/modules/admin/verbs/SDQL_2/SDQL_2_std.dm
@@ -182,3 +182,9 @@
 
 /proc/_list_swap(var/list/L, var/Index1, var/Index2)
 	L.Swap(Index1, Index2)
+
+/proc/_winset(player, control_id, params)
+	winset(player, control_id, params)
+
+/proc/_winget(player, control_id, params)
+	return winget(player, control_id, params)

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -563,6 +563,12 @@ nanoui is used to open and update nano browser uis
 		close()
 		return
 
+	if(!winexists(user, window_id))
+		var/template = templates.len ? templates[1] : "None"
+		world.log << "BUG: window with ID [window_id] and interface [template] for [key_name(user)] does not exist."
+		close()
+		return
+
 	if (status && (update || is_auto_updating))
 		update() // Update the UI (update_status() is called whenever a UI is updated)
 	else

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -49,12 +49,17 @@ var/list/SPS_list = list()
 	emped = TRUE
 	transmitting = FALSE
 	update_icon()
+	SStgui.update_uis(src)
 	spawn(30 SECONDS)
 		emped = FALSE
 		update_icon()
+		SStgui.update_uis(src)
 
 /obj/item/device/gps/attack_self(mob/user)
-	ui_interact(user)
+	if(user.client.prefs.tgui_fancy)
+		tgui_interact(user)
+	else
+		ui_interact(user)
 
 /obj/item/device/gps/examine(mob/user)
 	if(Adjacent(user) || isobserver(user))
@@ -74,7 +79,65 @@ var/list/SPS_list = list()
 	else
 		return "[format_text(device_area.name)] ([device_turf.x-WORLD_X_OFFSET[device_turf.z]], [device_turf.y-WORLD_Y_OFFSET[device_turf.z]], [device_turf.z])"
 
+// Begin tgui
+/obj/item/device/gps/tgui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = global.adjacent_state)
+	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
+	if(!ui)
+		ui = new(user, src, ui_key, "Gps", name, 500, 500, master_ui, state)
+		ui.open()
+	ui.set_autoupdate(autorefreshing)
 
+/obj/item/device/gps/ui_data()
+	var/list/data = list()
+	data["emped"] = emped
+	data["transmitting"] = transmitting
+	data["gpstag"] = gpstag
+	data["autorefresh"] = autorefreshing
+	data["location_text"] = get_location_name()
+	var/list/devices = list()
+	if(!emped && transmitting)
+		for(var/obj/item/device/gps/other in gps_list)
+			if(!other.transmitting || other == src)
+				continue
+			var/list/device_data = list()
+			device_data["tag"] = other.gpstag
+			device_data["location_text"] = other.get_location_name()
+			devices += list(device_data)
+	data["devices"] = devices
+	return data
+
+/obj/item/device/gps/ui_act(action, list/params)
+	if(..())
+		return
+	switch(action)
+		if("turn_on")
+			if(emped || transmitting || !Adjacent(usr) || usr.incapacitated())
+				return FALSE
+			transmitting = TRUE
+			update_icon()
+			return TRUE
+		if("set_tag")
+			if(isobserver(usr))
+				to_chat(usr, "No way.")
+				return FALSE
+			if(!builtin && (usr.get_active_hand() != src || usr.incapacitated())) //no silicons allowed
+				to_chat(usr, "<span class='caution'>You need to have the GPS in your hand to do that!</span>")
+				return TRUE
+			var/new_tag = params["new_tag"]
+			if(!new_tag)
+				return TRUE
+			if(length(new_tag) > 5)
+				to_chat(usr, "<span class='caution'>The tag must have a maximum of five characters!</span>")
+			else
+				gpstag = new_tag
+				update_name()
+			return TRUE
+		if("toggle_refresh")
+			autorefreshing = !autorefreshing
+			return TRUE
+// end tgui
+
+// Begin NanoUI
 /obj/item/device/gps/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open=NANOUI_FOCUS)
 	var/data[0]
 	if(emped)
@@ -101,6 +164,8 @@ var/list/SPS_list = list()
 	ui.set_auto_update(autorefreshing)
 
 /obj/item/device/gps/Topic(href, href_list)
+	if(..())
+		return FALSE
 	if(href_list["turn_on"])
 		if(emped || transmitting || !Adjacent(usr) || usr.incapacitated())
 			return FALSE
@@ -131,9 +196,7 @@ var/list/SPS_list = list()
 	if(href_list["toggle_refresh"])
 		autorefreshing = !autorefreshing
 		return TRUE
-	if(..())
-		return FALSE
-
+// End NanoUI
 /obj/item/device/gps/science
 	icon_state = "gps-s"
 	base_tag = "SCI"

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -281,10 +281,15 @@
  * optional force bool If the UI should be forced to update.
  */
 /datum/tgui/proc/process(force = FALSE)
+	set waitfor = FALSE
 	var/datum/host = src_object.ui_host(user)
 	if(!src_object || !host || !user) // If the object or user died (or something else), abort.
 		close()
 		return
+
+	if(!winexists(user, window_id))
+		log_tgui("BUG: window with ID [window_id] and interface [interface] for [key_name(user)] does not exist.")
+		close()
 
 	if(status && (force || autoupdate))
 		update() // Update the UI if the status and update settings allow it.


### PR DESCRIPTION
**Issue:**
we need to set the on-close parameter of windows through a winset(), which sometimes fails because BYOND
**Workaround implemented here:**
check if the window exists with winexists(), if it doesn't, close the ui server-side

- Implemented the above for both nano and tgui
- GPS now temporarily uses both UI frameworks
- Briefly tested locally but it doesn't mean anything because it might fail catastrophically on live
- Also added winset and winget helpers so they can be admin-proc-called

I'm abusing the "fancy tgui" setting but I don't really give a damn

:cl:
- rscadd: You can now choose whether to use tgui or NanoUI for GPSs, by changing the "Fancy tgui" option under "General Settings".
- rscadd: Implemented a potential workaround for a BYOND bug that prevents nanoui and tgui windows from opening.