### PR TITLE
Fixes extra html_encode() in pray and rambler vows

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -35,14 +35,11 @@
  */
 
 //Simply removes < and > and limits the length of the message
-/proc/strip_html_simple(var/t,var/limit=MAX_MESSAGE_LEN)
+/proc/strip_html_simple(var/t, var/limit=MAX_MESSAGE_LEN)
 	var/list/strip_chars = list("<",">")
-	t = copytext(t,1,limit)
+	t = copytext(t, 1, limit)
 	for(var/char in strip_chars)
-		var/index = findtext(t, char)
-		while(index)
-			t = copytext(t, 1, index) + copytext(t, index+1)
-			index = findtext(t, char)
+		t = replacetext(t, char, "")
 	return t
 
 /proc/strip_html_properly(input = "")

--- a/code/datums/gamemode/role/rambler.dm
+++ b/code/datums/gamemode/role/rambler.dm
@@ -153,7 +153,7 @@
 		if(!target.mind)
 			to_chat(user,"<span class='warning'>[target] has no mind!</span>")
 			continue
-		var/vow = copytext(sanitize(input(user, "Enter your vow. You have [R.remaining_vows] left.", "VOW LOCK IN") as null|text),1,MAX_MESSAGE_LEN)
+		var/vow = stripped_input(user, "Enter your vow. You have [R.remaining_vows] left.", "VOW LOCK IN")
 		if(vow)
 			user.say("[target], I vow [vow].")
 			user.say("VOW LOCKED IN!")

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -7,7 +7,7 @@
 		to_chat(usr, "<span class='warning'>Speech is currently admin-disabled.</span>")
 		return
 
-	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
+	msg = copytext(strip_html_simple(msg), 1, MAX_MESSAGE_LEN)
 	if(!msg)
 		return
 

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -7,7 +7,7 @@
 		to_chat(usr, "<span class='warning'>Speech is currently admin-disabled.</span>")
 		return
 
-	msg = copytext(strip_html_simple(msg), 1, MAX_MESSAGE_LEN)
+	msg = strip_html_simple(msg)
 	if(!msg)
 		return
 


### PR DESCRIPTION
Fixes #27084, for the cases listed specifically in it. Open a new issue with other specific instances if there are more.
Also removes (justified, for once) oldcode from `strip_html_simple()` just in case