### PR TITLE
Possibly fix runechat lag

### DIFF
--- a/code/datums/chat_message.dm
+++ b/code/datums/chat_message.dm
@@ -73,6 +73,7 @@ var/runechat_icon = null
   * * lifespan - The lifespan of the message in deciseconds
   */
 /datum/chatmessage/proc/generate_image(text, atom/target, mob/owner, list/extra_classes, lifespan)
+	set waitfor = FALSE
 	// Register client who owns this message
 	owned_by = owner.client
 	destroyed_ev_key = owner.on_destroyed.Add(src, .proc/qdel_self)


### PR DESCRIPTION
It's possible that sending images to client is sleep()ing, so this should make the lag magically go away