### PR TITLE
Make MindSwap not crash people

### DIFF
--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -9,6 +9,8 @@
 
 	stat_datum_type = /datum/stat/role/wizard
 
+	var/spell_list_backup
+
 /datum/role/wizard/ForgeObjectives()
 	if(!antag.current.client.prefs.antag_objectives)
 		AppendObjective(/datum/objective/freeform/wizard)
@@ -85,4 +87,4 @@
 			for(var/entry in artifacts_bought)
 				. += "[entry]<BR>"
 		if(bought_nothing)
-			. += "The wizard used only the magic of charisma this round."
+			. += "The wizard used only the magic of charisma this round.

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -9,8 +9,6 @@
 
 	stat_datum_type = /datum/stat/role/wizard
 
-	var/spell_list_backup
-
 /datum/role/wizard/ForgeObjectives()
 	if(!antag.current.client.prefs.antag_objectives)
 		AppendObjective(/datum/objective/freeform/wizard)

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -87,4 +87,4 @@
 			for(var/entry in artifacts_bought)
 				. += "[entry]<BR>"
 		if(bought_nothing)
-			. += "The wizard used only the magic of charisma this round.
+			. += "The wizard used only the magic of charisma this round."

--- a/code/modules/mob/spells.dm
+++ b/code/modules/mob/spells.dm
@@ -27,12 +27,7 @@
 		new_spell_master.icon_state = spell_base
 	spell_masters.Add(new_spell_master)
 	spell_list.Add(spell_to_add)
-	spell_to_add.on_added(src)
-	if(mind && iswizard)
-		if(!mind.wizard_spells)
-			mind.wizard_spells = list()
-		mind.wizard_spells += spell_to_add
-	return 1
+	return spell_to_add
 
 /mob/proc/cast_spell(spell/spell_to_cast, list/targets)
 	if(ispath(spell_to_cast, /spell))

--- a/code/modules/spells/targeted/mind_transfer.dm
+++ b/code/modules/spells/targeted/mind_transfer.dm
@@ -65,6 +65,11 @@
 			qdel(dummy)
 			qdel(dummy2)
 
+			for(var/spell/S in caster_spells)
+				victim.add_spell(S)
+			for(var/spell/S in victim_spells)
+				caster.add_spell(S)
+
 			if(victim.mind.special_verbs.len)//To add all the special verbs for the original caster.
 				for(var/V in caster.mind.special_verbs)//Not too important but could come into play.
 					caster.verbs += V

--- a/code/modules/spells/targeted/mind_transfer.dm
+++ b/code/modules/spells/targeted/mind_transfer.dm
@@ -57,15 +57,13 @@
 				victim.remove_spell(S)
 
 			var/mob/living/dummy = new(caster.loc)
+			var/mob/living/dummy2 = new(victim.loc)
 			caster.mind.transfer_to(dummy)
-			victim.mind.transfer_to(caster)
+			victim.mind.transfer_to(dummy2)
 			dummy.mind.transfer_to(victim)
+			dummy2.mind.transfer_to(caster)
 			qdel(dummy)
-
-			for(var/spell/S in caster_spells)
-				victim.add_spell(S)
-			for(var/spell/S in victim_spells)
-				caster.add_spell(S)
+			qdel(dummy2)
 
 			if(victim.mind.special_verbs.len)//To add all the special verbs for the original caster.
 				for(var/V in caster.mind.special_verbs)//Not too important but could come into play.


### PR DESCRIPTION
Fixes #26423 (hopefully). I originally wanted to rework the way spells are given to make more use of our mind transfer procs and potentially fix a few mind swap abuses but it would cause a lot of hassle for other cases (genetic powers not transfered, etc), so I decided not to.