### PR TITLE
Adds More Mugs to Boozevender

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1256,12 +1256,13 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cola = 8,
 		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/sodawater = 15,
 		/obj/item/weapon/reagent_containers/food/drinks/drinkingglass = 30,
+		/obj/item/weapon/reagent_containers/food/drinks/mug = 30,
 		/obj/item/weapon/reagent_containers/food/drinks/ice = 9,
 		)
 	contraband = list(
 		/obj/item/weapon/reagent_containers/food/drinks/tea = 10,
 		/obj/item/weapon/reagent_containers/food/drinks/coffee = 10,
-		/obj/item/weapon/reagent_containers/food/drinks/mug = 10
+		/obj/item/device/breathalyzer = 1
 		)
 	premium = list(
 		/obj/item/weapon/reagent_containers/food/drinks/bottle/pwine = 1,


### PR DESCRIPTION
This PR adds thirty mugs to the regular selection of the boozevender as well as a breathalyzer to the contraband selection.
The coffee and tea drinks have unique sprites when put in a mug instead of a drinking glass, and both of those types of drinks have found themselves crept into the bars of our maps, so I have been requested to make things easier for those that wish to use them. They have been freed from behind the hacking wall, and increased to thirty to match drinking glasses. Further, I have replaced them with a breathalyzer in the contraband selection so the tea and coffee does not get lonely. This explanation took me more time than coding and testing combined.

This has been quickly tested on local.
Do NOT buy me a coffee.

:cl:
 * rscadd: Adds 30 mugs to the regular area of the boozevender
 * rscadd: Adds the breathalyzer to the contraband section of the boozevender