### PR TITLE
Plasma Cutter Safeties (for hitting rocks)

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -273,8 +273,13 @@ proc/move_mining_shuttle()
 	desc = "A rock cutter that's powerful enough to cut through rocks and xenos with ease. Ingeniously, it's powered by putting solid plasma directly into it - even plasma ore, for those miners on the go."
 	toolspeed = 0.05
 	diggables = DIG_ROCKS | DIG_SOIL | DIG_WALLS | DIG_RWALLS
+	var/safety = FALSE // sometimes you just wanna hit rocks, not shoot them
 	var/max_ammo = 15
 	var/current_ammo = 15
+
+/obj/item/weapon/pickaxe/plasmacutter/accelerator/attack_self(mob/user)
+	safety = !safety
+	to_chat(user, "<span class ='notice'>You toggle \the [src]'s safety [safety ? "on" : "off"].</span>")
 
 /obj/item/weapon/pickaxe/plasmacutter/accelerator/afterattack(var/atom/A, var/mob/living/user, var/proximity_flag, var/click_parameters)
 	if (!user.IsAdvancedToolUser() || isMoMMI(user) || istype(user, /mob/living/carbon/monkey/diona))
@@ -284,9 +289,13 @@ proc/move_mining_shuttle()
 		return
 	if(user.is_pacified(VIOLENCE_SILENT,A,src))
 		return
+	if(safety)
+		to_chat(user, "<span class='warning'>The safety's on!</span>")
+		playsound(src, 'sound/weapons/empty.ogg', 100, 1)
+		return
 	if(current_ammo >0)
 		current_ammo--
-		generic_projectile_fire(A, src, /obj/item/projectile/kinetic/cutter/, 'sound/weapons/Taser.ogg', user)
+		generic_projectile_fire(A, src, /obj/item/projectile/kinetic/cutter, 'sound/weapons/Taser.ogg', user)
 		user.delayNextAttack(4)
 	else
 		src.visible_message("*click click*")
@@ -315,7 +324,7 @@ proc/move_mining_shuttle()
 
 /obj/item/weapon/pickaxe/plasmacutter/accelerator/examine(mob/user)
 	..()
-	to_chat(user, "<span class='info'>Has [current_ammo] round\s remaining.</span>")
+	to_chat(user, "<span class='info'>It has [current_ammo] round\s remaining. The safety is [safety ? "on" : "off"].</span>")
 
 /obj/item/weapon/pickaxe/diamond
 	name = "diamond pickaxe"


### PR DESCRIPTION
i was also tempted to make plasma sheets reload much more efficiently than raw ore, but that's neither here nor there

:cl:
 * rscadd: Plasma cutters (the ones that shoot, from experimental tech) now have a safety; for when you want to hit rocks, not shoot them. Toggle it by using it in your hand.