### PR TITLE
adds space law books to the secvend

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1969,6 +1969,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/storage/box/evidence = 6,
 		/obj/item/weapon/legcuffs/bolas = 8,
 		/obj/item/taperoll/police = 5,
+		/obj/item/weapon/book/manual/security_space_law = 2,
 		)
 	contraband = list(
 		/obj/item/clothing/glasses/sunglasses/security = 2,


### PR DESCRIPTION
Because having to interact with a "librarian" (God forgive me for uttering the word) to get their lawbooks is not something any honest and hard-working redshirt should be subjected to.

:cl:
 - rscadd: Secvends now have lawbooks in stock.