### PR TITLE
Ruleset chance to fire is halved if it fired last or current round

### DIFF
--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -114,3 +114,24 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 		data["MM"] = time2text(world.realtime,"MM")
 		data["YY"] = time2text(world.realtime,"YY")
 		write_file(data)
+
+/datum/persistence_task/latest_dynamic_rulesets
+	execute = TRUE
+	name = "Latest dynamic rulesets"
+	file_path = "data/persistence/latest_dynamic_rulesets.json"
+
+/datum/persistence_task/latest_dynamic_rulesets/on_init()
+	data = read_file()
+
+/datum/persistence_task/latest_dynamic_rulesets/on_shutdown()
+	var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
+	if (!istype(dynamic_mode))
+		return
+	var/list/data = list(
+		"latest_rulesets" = list()
+	)
+	for(var/datum/dynamic_ruleset/some_ruleset in dynamic_mode.executed_rules)
+		if(some_ruleset.calledBy)
+			continue
+		data["latest_rulesets"] |= "[some_ruleset.type]"
+	write_file(data)

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -220,7 +220,9 @@ var/stacking_limit = 90
 		return
 	var/list/last_round_rulesets = list()
 	for(var/entry in last_round_rulesets_text)
-		last_round_rulesets += text2path(entry)
+		var/entry_path = text2path(entry)
+		if(entry_path) // It's possible that a ruleset that existed last round doesn't exist anymore
+			last_round_rulesets += entry_path
 	last_round_executed_rules = last_round_rulesets
 
 /datum/gamemode/dynamic/Setup()

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -33,6 +33,7 @@ var/stacking_limit = 90
 	var/list/candidates = list()
 	var/list/current_rules = list()
 	var/list/executed_rules = list()
+	var/list/last_round_executed_rules = list()
 
 	var/list/living_players = list()
 	var/list/living_antags = list()
@@ -210,7 +211,20 @@ var/stacking_limit = 90
 
 	return 1
 
+/datum/gamemode/dynamic/proc/read_last_round_rulesets()
+	var/list/data = SSpersistence_misc.read_data(/datum/persistence_task/latest_dynamic_rulesets)
+	if(!length(data))
+		return
+	var/list/last_round_rulesets_text = data["latest_rulesets"]
+	if(!length(last_round_rulesets_text))
+		return
+	var/list/last_round_rulesets = list()
+	for(var/entry in last_round_rulesets_text)
+		last_round_rulesets += text2path(entry)
+	last_round_executed_rules = last_round_rulesets
+
 /datum/gamemode/dynamic/Setup()
+	read_last_round_rulesets()
 	for (var/rule in subtypesof(/datum/dynamic_ruleset/roundstart) - /datum/dynamic_ruleset/roundstart/delayed/)
 		roundstart_rules += new rule()
 	for (var/rule in subtypesof(/datum/dynamic_ruleset/latejoin))

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -116,13 +116,22 @@
 	return FALSE
 
 /datum/dynamic_ruleset/proc/get_weight()
+	var/weight = src.weight
 	weight *= weight_time_day()
-	if(repeatable && weight > 1)
+	if(repeatable)
+		var/halve_weight = FALSE
 		for(var/datum/dynamic_ruleset/DR in mode.executed_rules)
-			if(istype(DR,src.type))
-				weight = max(weight-2,1)
 			if(DR.role_category == src.role_category) // Same kind of antag.
-				weight = max(weight-1,1)
+				halve_weight = TRUE
+				break
+		if(!halve_weight)
+			for(var/entry in mode.last_round_executed_rules)
+				var/datum/dynamic_ruleset/DR = entry
+				if(initial(DR.role_category) == src.role_category)
+					halve_weight = TRUE
+					break
+		if(halve_weight)
+			weight /= 2
 	message_admins("[name] had [weight] weight (-[initial(weight) - weight]).")
 	return weight
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -116,24 +116,23 @@
 	return FALSE
 
 /datum/dynamic_ruleset/proc/get_weight()
-	var/weight = src.weight
-	weight *= weight_time_day()
-	if(repeatable)
-		var/halve_weight = FALSE
-		for(var/datum/dynamic_ruleset/DR in mode.executed_rules)
-			if(DR.role_category == src.role_category) // Same kind of antag.
-				halve_weight = TRUE
+	var/result = weight
+	result *= weight_time_day()
+	var/halve_result = FALSE
+	for(var/datum/dynamic_ruleset/DR in mode.executed_rules)
+		if(DR.role_category == src.role_category) // Same kind of antag.
+			halve_result = TRUE
+			break
+	if(!halve_result)
+		for(var/entry in mode.last_round_executed_rules)
+			var/datum/dynamic_ruleset/DR = entry
+			if(initial(DR.role_category) == src.role_category)
+				halve_result = TRUE
 				break
-		if(!halve_weight)
-			for(var/entry in mode.last_round_executed_rules)
-				var/datum/dynamic_ruleset/DR = entry
-				if(initial(DR.role_category) == src.role_category)
-					halve_weight = TRUE
-					break
-		if(halve_weight)
-			weight /= 2
-	message_admins("[name] had [weight] weight (-[initial(weight) - weight]).")
-	return weight
+	if(halve_result)
+		result /= 2
+	message_admins("[name] had [result] weight (-[initial(weight) - result]).")
+	return result
 
 //Return a multiplicative weight. 1 for nothing special.
 /datum/dynamic_ruleset/proc/weight_time_day()


### PR DESCRIPTION
Also fixed `get_weight()` modifying the `weight` variable with each call, which seemed to be unintended.

There was already some logic that was supposed to reduce the chance of a given ruleset to fire it had already executed during the current round but since #26412 it didn't work because it was given a lower bound of 1 while I set the default weight to 1. That logic has now been replaced.

:cl:
 * tweak: Dynamic rulesets will have their weight (chance to fire relative to others) halved if they already fired during the current or last round.