### PR TITLE
Mining Scanner Activation via Alt-Click

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -971,6 +971,12 @@ proc/move_mining_shuttle()
 	var/cooldown = 0
 
 /obj/item/device/mining_scanner/attack_self(mob/user)
+	scan(user)
+
+/obj/item/device/mining_scanner/AltClick(mob/user)
+	scan(user)
+
+/obj/item/device/mining_scanner/proc/scan(mob/user)
 	if(!user.client)
 		return
 	if(!cooldown)


### PR DESCRIPTION
wanted to shitcode in a mining scanner for mechs but that's a bit too much for 4 in the morning
:cl:
 * tweak: Alt-click can now be used to activate a mining scanner.