### PR TITLE
allows firedoor frame deconstruction

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -639,11 +639,11 @@ var/global/list/alert_overlays_global = list()
 
 /obj/item/firedoor_frame/attackby(var/obj/item/weapon/C, var/mob/user)
 	if(C.is_wrench(user))
-		user.visible_message("<span class='attack'>\The [user] deconstructs \the [src] with \a [C].</span>",\
+		user.visible_message("<span class='notice'>\The [user] deconstructs \the [src] with \a [C].</span>",\
 		"You deconstruct \the [src] with \the [C]!")
 		drop_stack(/obj/item/stack/sheet/metal, get_turf(src), 5, user)
 		qdel(src)
-		return
+
 
 //Removed pending a fix for atmos issues caused by full tile firelocks.
 /*

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -637,6 +637,14 @@ var/global/list/alert_overlays_global = list()
 		B.change_dir(user.dir)
 		qdel(src)
 
+/obj/item/firedoor_frame/attackby(var/obj/item/weapon/C, var/mob/user)
+	if(C.is_wrench(user))
+		user.visible_message("<span class='attack'>\The [user] deconstructs \the [src] with \a [C].</span>",\
+		"You deconstruct \the [src] with \the [C]!")
+		drop_stack(/obj/item/stack/sheet/metal, get_turf(src), 5, user)
+		qdel(src)
+		return
+
 //Removed pending a fix for atmos issues caused by full tile firelocks.
 /*
 	switch(alert("firedoor construction", "Would you like to construct a full tile firedoor or one direction?", "One Direction", "Full Firedoor", "Cancel", null))


### PR DESCRIPTION
[consistency]

This allows firelock frames to be deconstructed back into sheets with a wrench, just like girders and machine frames.

:cl:
rscadd: Firelock Frames can now be deconstructed with a wrench.