### PR TITLE
Fixes Roundstart Assistants

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -381,7 +381,7 @@ var/global/datum/controller/occupations/job_master
 	count = (officer.current_positions + warden.current_positions + hos.current_positions)
 	Debug("DO, Running Assistant Check 1 for [player]")
 	var/datum/job/master_assistant = GetJob("Assistant")
-	var/enough_sec = (master_assistant.current_positions + 1) > (config.assistantratio * count)
+	var/enough_sec = (master_assistant.current_positions - 1) > (config.assistantratio * count)
 	if(enough_sec && (count < 5))
 		Debug("AC1 failed, not enough sec.")
 		// Does he want anything else...?


### PR DESCRIPTION
[bugfix]

### Purpose
Fixes #27100 

### How & Why
In the job controller, there are two loops where you can become an assistant at roundstart. In the first loop, more assistants are allowed if `#Assistants+1<SecStaff*ratio` . This doesn't make any sense (I guess it was a typo?), and very probably (unless the order in which jobs are assigned is favorable to those who want to be assistants) always false. 

In the second loop, which goes back and gives people who had assistant higher than the job they got the chance to be assistants. Here the correct logic is in place, which is `#Assistants-1<SecStaff*ratio` . 

The issue at hand was the edge case where someone with only assistant preference remained unassigned throughout the first loop. The second loop only considers assigned players, so it misses the assistant-only player.

The commit fixes the bad logic in the first loop. Tested and working.

:cl:
 * bugfix: Dedicated greytiders with no other jobprefs now properly join at roundstart