### PR TITLE
AI can no longer track people who changed identity

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -304,10 +304,7 @@ var/list/camera_messages = list()
 		for(var/mob/living/silicon/ai/O in living_mob_list)
 			if(!O.client)
 				continue
-			if(U.name == "Unknown")
-				to_chat(O, "<span class='name'>[U]</span> holds <a href='byond://?src=\ref[src];message_id=[key]'>[W]</a> up to one of your cameras ...")
-			else
-				to_chat(O, "<span class='name'><a href='byond://?src=\ref[O];track2=\ref[O];track=\ref[U]'>[U]</a></span> holds <a href='byond://?src=\ref[src];message_id=[key]'>[W]</a> up to one of your cameras ...")
+			to_chat(O, "<span class='name'><a href='byond://?src=\ref[O];track=[U.name]'>[U.name]</a></span> holds <a href='byond://?src=\ref[src];message_id=[key]'>[W]</a> up to one of your cameras ...")
 
 		for(var/mob/O in player_list)
 			if (istype(O.machine, /obj/machinery/computer/security))

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -267,7 +267,6 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	virt.job = speech.job
 	//virt.languages = AM.languages
 	virt.source = speech.speaker
-	virt.faketrack = (data == 4) ? 1 : 0
 	virt.radio = speech.radio
 
 	if (compression > 0)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -142,30 +142,6 @@
 			A.open_nearest_door(target)
 		return
 
-	if (href_list["track"])
-		var/mob/target = locate(href_list["track"])
-		var/mob/living/silicon/ai/A = locate(href_list["track2"])
-		if(A && target)
-			A.ai_actual_track(target)
-		return
-
-	else if (href_list["faketrack"])
-		var/mob/target = locate(href_list["track"])
-		var/mob/living/silicon/ai/A = locate(href_list["track2"])
-		if(A && target)
-
-			A:cameraFollow = target
-			to_chat(A, text("Now tracking [] on camera.", target.name))
-			if (usr.machine == null)
-				usr.machine = usr
-
-			while (usr:cameraFollow == target)
-				to_chat(usr, "Target is not on or near any active cameras on the station. We'll check again in 5 seconds (unless you use the cancel-camera verb).")
-				sleep(40)
-				continue
-
-		return
-
 	else if("set_freq" in href_list)
 		var/new_frequency
 		new_frequency = input(usr, "Set a new frequency (1200-1600 kHz).", src, frequency) as null|num

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -275,13 +275,6 @@ var/global/image/ghostimg = image("icon"='icons/mob/mob.dmi',"icon_state"="ghost
 	return
 
 /**
- * Probably used for getting tracking coordinates?
- * TODO: verify
- */
-/atom/movable/proc/GetTrack()
-	return
-
-/**
  * What is speaking for us?  Usually src.
  */
 /atom/movable/proc/GetSource()
@@ -294,15 +287,12 @@ var/global/image/ghostimg = image("icon"='icons/mob/mob.dmi',"icon_state"="ghost
 
 /atom/movable/virtualspeaker
 	var/job
-	var/faketrack
 	var/atom/movable/source
 	var/obj/item/device/radio/radio
 
 /atom/movable/virtualspeaker/GetJob()
 	return job
 
-/atom/movable/virtualspeaker/GetTrack()
-	return faketrack
 
 /atom/movable/virtualspeaker/GetSource()
 	return source

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -570,7 +570,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		var/mob/target = locate(href_list["jump"])
 		var/mob/A = usr;
 		to_chat(A, "Teleporting to [target]...")
-		//var/mob/living/silicon/ai/A = locate(href_list["track2"]) in mob_list
 		if(target && target != usr)
 			var/turf/pos = get_turf(A)
 			var/turf/T=get_turf(target)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -479,27 +479,15 @@ var/list/ai_list = list()
 	#endif
 
 	if(href_list["track"])
-		var/mob/target = locate(href_list["track"]) in mob_list
-		var/mob/living/silicon/ai/A = locate(href_list["track2"]) in mob_list
-		if(A && target)
-			A.ai_actual_track(target)
-		return
-
-	else if(href_list["faketrack"])
-		var/mob/target = locate(href_list["track"]) in mob_list
-		var/mob/living/silicon/ai/A = locate(href_list["track2"]) in mob_list
-		if(A && target)
-
-			A.cameraFollow = target
-			to_chat(A, text("Now tracking [] on camera.", target.name))
-			if(usr.machine == null)
-				usr.machine = usr
-
-			while (src.cameraFollow == target)
-				to_chat(usr, "Target is not on or near any active cameras on the station. We'll check again in 5 seconds (unless you use the cancel-camera verb).")
-				sleep(40)
+		var/name_to_track = href_list["track"]
+		for(var/mob/some_mob in mob_list)
+			if(some_mob.name != name_to_track)
 				continue
-
+			if(!can_track_atom(some_mob))
+				continue
+			ai_actual_track(some_mob)
+			return
+		to_chat(src, "<span class='warning'>Unable to track [name_to_track].</span>")
 		return
 
 	if(href_list["open"])
@@ -830,12 +818,12 @@ var/list/ai_list = list()
 		return
 
 	mentions_on = !mentions_on
-	
-	if(!mentions_on)		
+
+	if(!mentions_on)
 		to_chat(src, "AI mentions deactivated.")
 	else
 		to_chat(src, "AI mentions activated.")
-	
+
 
 /mob/living/silicon/ai/verb/toggle_station_map()
 	set name = "Toggle Station Holomap"

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -17,11 +17,8 @@
 		virt_speaker = src
 	if(speech.speaker != src && M != src)
 		if(M)
-			var/faketrack = "byond://?src=\ref[virt_speaker];track2=\ref[src];track=\ref[M]"
-			if(speech.speaker.GetTrack())
-				faketrack = "byond://?src=\ref[virt_speaker];track2=\ref[src];faketrack=\ref[M]"
-
-			return "<a href='byond://?src=\ref[virt_speaker];open2=\ref[src];open=\ref[M]'>\[OPEN\]</a> <a href='[faketrack]'>"
+			var/track_link = "byond://?src=\ref[src];track=[M.name]"
+			return "<a href='byond://?src=\ref[virt_speaker];open2=\ref[src];open=\ref[M]'>\[OPEN\]</a> <a href='[track_link]'>"
 	return ""
 
 /mob/living/silicon/ai/render_speaker_track_end(var/datum/speech/speech)

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -25,7 +25,7 @@
 
 	for (var/mob/S in player_list)
 		if(istype(S , /mob/living/silicon/ai))
-			var/renderedAI = "<i><span class='binaryradio'>Robotic Talk, <a href='byond://?src=\ref[S];track2=\ref[S];track=\ref[src]'><span class='name'>[name]</span></a> <span class='message'>[message_a]</span></span></i>"
+			var/renderedAI = "<i><span class='binaryradio'>Robotic Talk, <a href='byond://?src=\ref[S];track=[name]'><span class='name'>[name]</span></a> <span class='message'>[message_a]</span></span></i>"
 			to_chat(S, renderedAI)
 		else if(S.binarycheck() || ((S in dead_mob_list) && !istype(S, /mob/new_player)))
 			handle_render(S,rendered,src)

--- a/code/modules/mob/say_readme.dm
+++ b/code/modules/mob/say_readme.dm
@@ -46,7 +46,7 @@ global procs
 
 	mob/languages
 		list of languages
-		What language(s) the speaker speaks, and the hearer understands. 
+		What language(s) the speaker speaks, and the hearer understands.
 		If the hearer doesn't understand it will be treated in lang_treat()
 
 	mob/universal_speak
@@ -65,7 +65,7 @@ global procs
 	Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq)
 		This proc handles hearing. What it does varies. For mobs, it treats the message with hearer-specific things
 		like language and deafness, then outputs it to the hearer.
-		
+
 		IMPORTANT NOTE: If radio_freq is not null, the code will assume that the speaker is virtual! (more info on this in the Radios section below)
 
 	send_speech(message, range, datum/language/speaking)
@@ -166,8 +166,6 @@ If radio_freq is not null, the code will rely on the fact that the speaker is vi
 	(all of these procs are defined at the atom/movable level and return "" at that level.)
 	GetJob()
 		Returns the job string variable of the virtual speaker.
-	GetTrack()
-		Returns wether the tracking href should be fake or not.
 	GetSource()
 		Returns the source of the virtual speaker.
 	GetRadio()

--- a/code/modules/scripting/Implementations/Telecomms.dm
+++ b/code/modules/scripting/Implementations/Telecomms.dm
@@ -323,7 +323,6 @@
 	var/atom/movable/virtualspeaker/virt = new /atom/movable/virtualspeaker(null)
 	virt.name = source
 	virt.job = job
-	virt.faketrack = 1
 	//END SAY REWRITE RELATED CODE.
 
 


### PR DESCRIPTION
Fixes #18122

:cl:
 * bugfix: AIs will no longer be able to track people after they changed identity. AI tracking now looks for the name that was used in radio messages instead.