### PR TITLE
Halves the cost for wizard cooldown upgrades

### DIFF
--- a/code/modules/spells/aoe_turf/blink.dm
+++ b/code/modules/spells/aoe_turf/blink.dm
@@ -15,6 +15,7 @@
 	cooldown_min = 5 //4 deciseconds reduction per rank
 	hud_state = "wiz_blink"
 	selection_type = "range"
+	quicken_price = Sp_BASE_PRICE
 
 /spell/aoe_turf/blink/cast(var/list/targets, mob/user)
 	if(!targets.len)

--- a/code/modules/spells/aoe_turf/conjure/pitbulls.dm
+++ b/code/modules/spells/aoe_turf/conjure/pitbulls.dm
@@ -18,6 +18,7 @@
 	override_icon = 'icons/mob/animal.dmi'
 	hud_state = "pitbull"
 	cast_sound = 'sound/voice/pitbullbark.ogg'
+	quicken_price = Sp_BASE_PRICE
 
 var/list/pitbulls_exclude_kinlist = list() //all pitbulls go in here so pitbulls won't attack other pitbulls when feeling treacherous (and instead attack the wizard)
 

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -24,6 +24,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	var/silenced = 0 //not a binary (though it seems that it is at the moment) - the length of time we can't cast this for, set by the spell_master silence_spells()
 
 	var/price = Sp_BASE_PRICE //How much does it cost to buy this spell from a spellbook
+	var/quicken_price = Sp_BASE_PRICE * 0.5 //How much lowering the spell cooldown costs in the spellbook
 	var/refund_price = 0 //If 0, non-refundable
 
 	var/holder_var_type = "bruteloss" //only used if charge_type equals to "holder_var"
@@ -229,13 +230,13 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 
 /spell/proc/channeled_spell(var/list/args)
 	var/event/E = args["event"]
-	
+
 	if(!currently_channeled)
 		E.handlers.Remove("\ref[src]:channeled_spell")
 		return 0
 
 	var/atom/A = args["atom"]
-	
+
 	if(E.holder != holder)
 		E.handlers.Remove("\ref[src]:channeled_spell")
 		return 0
@@ -600,6 +601,8 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 			return empower_spell()
 
 /spell/proc/get_upgrade_price(upgrade_type)
+	if(upgrade_type == Sp_SPEED)
+		return quicken_price
 	return src.price
 
 ///INFO


### PR DESCRIPTION
Finally, no more spending extra 80 points just to reduce the cooldown from 40 seconds to 30 (Mutate does this with a reduction of 2.5 seconds per cooldown upgrade)
For what it does this was ridiculously easy to add, just 3 lines. This could've been two lines but I wanted to add a variable for people to be able to tweak the spell's cost.
This was also done at 4:45AM so forgive me if there's any oversight, I'll rectify it tomorrow but I did test it and it works fine
Blink and Summon Pitbulls are not affected by this change.

:cl:
 * tweak: Wizards now pay half the spell's cost when upgrading the spell's cooldown instead of the entire spell cost, except for Blink and Summon Pitbulls which had their cooldown reduction price intact.