### PR TITLE
Fishtank boards can now be soldered to make them larger/smaller

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -376,6 +376,21 @@
 	to_chat(user, "<span class='warning'>You fiddle with a few random fuses but can't find a routing that doesn't short the board.</span>")
 	return
 
+
+/obj/item/weapon/circuitboard/fishtank/proc/solder_improve(mob/user as mob)
+	to_chat(user, "<span class='notice'>You modify the circuitry to support a larger tank.</span>")
+	var/obj/item/weapon/circuitboard/fishwall/A = new /obj/item/weapon/circuitboard/fishwall(src.loc)
+	user.put_in_hands(A)
+	qdel(src)
+	return	
+
+/obj/item/weapon/circuitboard/fishwall/proc/solder_improve(mob/user as mob)
+	to_chat(user, "<span class='notice'>You modify the circuitry to support a smaller tank.</span>")
+	var/obj/item/weapon/circuitboard/fishtank/A = new /obj/item/weapon/circuitboard/fishtank(src.loc)
+	user.put_in_hands(A)
+	qdel(src)
+	return
+
 /obj/item/weapon/circuitboard/supplycomp/solder_improve(mob/user as mob)
 	to_chat(user, "<span class='notice'>You [contraband_enabled ? "" : "un"]connect the mysterious fuse.</span>")
 	contraband_enabled = !contraband_enabled

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -372,31 +372,31 @@
 			return
 	return
 
-/obj/item/weapon/circuitboard/proc/solder_improve(mob/user as mob)
+/obj/item/weapon/circuitboard/proc/solder_improve(mob/user)
 	to_chat(user, "<span class='warning'>You fiddle with a few random fuses but can't find a routing that doesn't short the board.</span>")
 	return
 
 
-/obj/item/weapon/circuitboard/fishtank/solder_improve(mob/user as mob)
+/obj/item/weapon/circuitboard/fishtank/solder_improve(mob/user)
 	to_chat(user, "<span class='notice'>You modify the circuitry to support a larger tank.</span>")
 	var/obj/item/weapon/circuitboard/fishwall/A = new /obj/item/weapon/circuitboard/fishwall(src.loc)
 	user.put_in_hands(A)
 	qdel(src)
 	return	
 
-/obj/item/weapon/circuitboard/fishwall/solder_improve(mob/user as mob)
+/obj/item/weapon/circuitboard/fishwall/solder_improve(mob/user)
 	to_chat(user, "<span class='notice'>You modify the circuitry to support a smaller tank.</span>")
 	var/obj/item/weapon/circuitboard/fishtank/A = new /obj/item/weapon/circuitboard/fishtank(src.loc)
 	user.put_in_hands(A)
 	qdel(src)
 	return
 
-/obj/item/weapon/circuitboard/supplycomp/solder_improve(mob/user as mob)
+/obj/item/weapon/circuitboard/supplycomp/solder_improve(mob/user)
 	to_chat(user, "<span class='notice'>You [contraband_enabled ? "" : "un"]connect the mysterious fuse.</span>")
 	contraband_enabled = !contraband_enabled
 	return
 
-/obj/item/weapon/circuitboard/security/solder_improve(mob/user as mob)
+/obj/item/weapon/circuitboard/security/solder_improve(mob/user)
 	if(istype(src,/obj/item/weapon/circuitboard/security/advanced))
 		return ..()
 	if(istype(src,/obj/item/weapon/circuitboard/security/engineering))

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -374,7 +374,7 @@
 
 /obj/item/weapon/circuitboard/proc/solder_improve(mob/user)
 	to_chat(user, "<span class='warning'>You fiddle with a few random fuses but can't find a routing that doesn't short the board.</span>")
-	return
+
 
 
 /obj/item/weapon/circuitboard/fishtank/solder_improve(mob/user)
@@ -382,19 +382,19 @@
 	var/obj/item/weapon/circuitboard/fishwall/A = new /obj/item/weapon/circuitboard/fishwall(src.loc)
 	user.put_in_hands(A)
 	qdel(src)
-	return	
+
 
 /obj/item/weapon/circuitboard/fishwall/solder_improve(mob/user)
 	to_chat(user, "<span class='notice'>You modify the circuitry to support a smaller tank.</span>")
 	var/obj/item/weapon/circuitboard/fishtank/A = new /obj/item/weapon/circuitboard/fishtank(src.loc)
 	user.put_in_hands(A)
 	qdel(src)
-	return
+
 
 /obj/item/weapon/circuitboard/supplycomp/solder_improve(mob/user)
 	to_chat(user, "<span class='notice'>You [contraband_enabled ? "" : "un"]connect the mysterious fuse.</span>")
 	contraband_enabled = !contraband_enabled
-	return
+
 
 /obj/item/weapon/circuitboard/security/solder_improve(mob/user)
 	if(istype(src,/obj/item/weapon/circuitboard/security/advanced))
@@ -406,7 +406,6 @@
 		var/obj/item/weapon/circuitboard/security/advanced/A = new /obj/item/weapon/circuitboard/security/advanced(src.loc)
 		user.put_in_hands(A)
 		qdel(src)
-		return
 
 /obj/structure/computerframe/attackby(obj/item/P as obj, mob/user as mob)
 	switch(state)

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -377,14 +377,14 @@
 	return
 
 
-/obj/item/weapon/circuitboard/fishtank/proc/solder_improve(mob/user as mob)
+/obj/item/weapon/circuitboard/fishtank/solder_improve(mob/user as mob)
 	to_chat(user, "<span class='notice'>You modify the circuitry to support a larger tank.</span>")
 	var/obj/item/weapon/circuitboard/fishwall/A = new /obj/item/weapon/circuitboard/fishwall(src.loc)
 	user.put_in_hands(A)
 	qdel(src)
 	return	
 
-/obj/item/weapon/circuitboard/fishwall/proc/solder_improve(mob/user as mob)
+/obj/item/weapon/circuitboard/fishwall/solder_improve(mob/user as mob)
 	to_chat(user, "<span class='notice'>You modify the circuitry to support a smaller tank.</span>")
 	var/obj/item/weapon/circuitboard/fishtank/A = new /obj/item/weapon/circuitboard/fishtank(src.loc)
 	user.put_in_hands(A)


### PR DESCRIPTION
Closes #23731

Soldering a fishtank board will turn it into a fishtank wall board, and vice versa.

[tweak]

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
:cl:
 * tweak: You can now solder fishtank boards to convert them between their large and small sizes.
