### PR TITLE
Fix admin vermin infestation

### DIFF
--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -1,4 +1,5 @@
 /datum/event/infestation
+	startWhen = 5// so overrides have time to be processed
 	announceWhen = 15
 	endWhen = 20
 	var/locstring


### PR DESCRIPTION
:cl:
* bugfix: Fixed admins being unable to specify the species and location of a bussed vermin infestation.