### PR TITLE
The color of Lantern Syndrome will now be a mix of the colors of the reagents in your body.

### DIFF
--- a/code/modules/virus2/effect/stage_2.dm
+++ b/code/modules/virus2/effect/stage_2.dm
@@ -260,25 +260,26 @@
 	badness = EFFECT_DANGER_HELPFUL
 	multiplier = 4
 	max_multiplier = 10
-	var/uncolored = FALSE
-	var/flavortext = FALSE
+	var/uncolored = 0
+	var/flavortext = 0
 	var/color = rgb(255, 255, 255)
 
 /datum/disease2/effect/lantern/activate(var/mob/living/mob)
 	if(mob.reagents.has_reagent(CLEANER))
-		uncolored = TRUE	//Having spacecleaner in your system when the effect activates will permanently make the color white.
+		uncolored = 1	//Having spacecleaner in your system when the effect activates will permanently make the color white.
 	if(mob.reagents.reagent_list.len == 0 || uncolored == TRUE)
 		color = rgb(255, 255, 255)
 	else
 		color = mix_color_from_reagents(mob.reagents.reagent_list)
 	if(!flavortext)
 		to_chat(mob, "<span class = 'notice'>You are glowing!</span>")
-		flavortext = TRUE
+		flavortext = 1
 	mob.set_light(multiplier, multiplier/3, l_color = color)
 
 /datum/disease2/effect/lantern/deactivate(var/mob/living/mob)
 	mob.set_light(0, 0, rgb(0,0,0))
 	to_chat(mob, "<span class = 'notice'>You don't feel as bright.</span>")
+	flavortext = 0
 
 
 /datum/disease2/effect/hangman

--- a/code/modules/virus2/effect/stage_2.dm
+++ b/code/modules/virus2/effect/stage_2.dm
@@ -264,7 +264,7 @@
 
 /datum/disease2/effect/lantern/activate(var/mob/living/mob)
 	var/color = rgb(rand(0,255), rand(0,255), rand(0,255))
-	mob.set_light(multiplier, multiplier/3,l_color = color)
+	mob.set_light(multiplier, multiplier/3, l_color = color)
 	to_chat(mob, "<span class = 'notice'>You are glowing!</span>")
 
 

--- a/code/modules/virus2/effect/stage_2.dm
+++ b/code/modules/virus2/effect/stage_2.dm
@@ -260,9 +260,11 @@
 	badness = EFFECT_DANGER_HELPFUL
 	multiplier = 4
 	max_multiplier = 10
+	max_count = 1
 
 /datum/disease2/effect/lantern/activate(var/mob/living/mob)
-	mob.set_light(multiplier)
+	var/color = rgb(rand(0,255), rand(0,255), rand(0,255))
+	mob.set_light(multiplier, l_color = color)
 	to_chat(mob, "<span class = 'notice'>You are glowing!</span>")
 
 

--- a/code/modules/virus2/effect/stage_2.dm
+++ b/code/modules/virus2/effect/stage_2.dm
@@ -267,6 +267,10 @@
 	mob.set_light(multiplier, multiplier/3, l_color = color)
 	to_chat(mob, "<span class = 'notice'>You are glowing!</span>")
 
+/datum/disease2/effect/lantern/deactivate(var/mob/living/mob)
+	mob.set_light(0, 0, rgb(0,0,0))
+	to_chat(mob, "<span class = 'notice'>You don't feel as bright.</span>")
+
 
 /datum/disease2/effect/hangman
 	name = "Hanging Man's Syndrome"

--- a/code/modules/virus2/effect/stage_2.dm
+++ b/code/modules/virus2/effect/stage_2.dm
@@ -260,12 +260,21 @@
 	badness = EFFECT_DANGER_HELPFUL
 	multiplier = 4
 	max_multiplier = 10
-	max_count = 1
+	var/uncolored = FALSE
+	var/flavortext = FALSE
+	var/color = rgb(255, 255, 255)
 
 /datum/disease2/effect/lantern/activate(var/mob/living/mob)
-	var/color = rgb(rand(0,255), rand(0,255), rand(0,255))
+	if(mob.reagents.has_reagent(CLEANER))
+		uncolored = TRUE	//Having spacecleaner in your system when the effect activates will permanently make the color white.
+	if(mob.reagents.reagent_list.len == 0 || uncolored == TRUE)
+		color = rgb(255, 255, 255)
+	else
+		color = mix_color_from_reagents(mob.reagents.reagent_list)
+	if(!flavortext)
+		to_chat(mob, "<span class = 'notice'>You are glowing!</span>")
+		flavortext = TRUE
 	mob.set_light(multiplier, multiplier/3, l_color = color)
-	to_chat(mob, "<span class = 'notice'>You are glowing!</span>")
 
 /datum/disease2/effect/lantern/deactivate(var/mob/living/mob)
 	mob.set_light(0, 0, rgb(0,0,0))

--- a/code/modules/virus2/effect/stage_2.dm
+++ b/code/modules/virus2/effect/stage_2.dm
@@ -264,7 +264,7 @@
 
 /datum/disease2/effect/lantern/activate(var/mob/living/mob)
 	var/color = rgb(rand(0,255), rand(0,255), rand(0,255))
-	mob.set_light(multiplier, l_color = color)
+	mob.set_light(multiplier, multiplier/3,l_color = color)
 	to_chat(mob, "<span class = 'notice'>You are glowing!</span>")
 
 


### PR DESCRIPTION
Because white light is boring. Now you can finally turn virology colorful with all those monkeymen you had standing around.

~~When lantern syndrome activates, the color of the light you emit will be randomized. The color is different for each activation, regardless of if its part of the same virus. Since there's not many variables in viruses that virologists could modify to produce their desired color, I had it randomized. If somebody has an idea for how virologists could possibly customize this color when creating viruses, let me know.~~

This PR also fixed a bug where lantern syndrome would causing chat to fill up with "You are glowing!" messages. Since the light was always white before, this never did anything visually, but when making the color randomized it caused the light being emitted from players to change repeatedly (a few times a minute for an average virus). I think people would get annoyed if the color of their light kept changing, so I removed it, but ~~if I'm wrong and people want their disco monkeymen then let me know.~~ It seems like most people don't want that.

I've changed the PR a bit since it was created. Whenever the effect "activates", which happens a few times a minute, the color of the light will be mixed from the colors of all the reagents within your body. Drinking a bit of space cleaner will permanently cause the color of the light you emit to be white, if colors aren't your thing. It's a bit of a snowflake exception, but I know things involving lots of color can get annoying quickly (see: colorful syndrome) and I'd like to give people a way to 'opt out'.

[tweak]

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
:cl:
 * tweak: The light you emit from Lantern Syndrome will now mixed from the colors of reagents in your system. Drinking space cleaner will permanently set the color to white. 
