### PR TITLE
Fixed light switches emitting some light even when unpowered.

### DIFF
--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -39,6 +39,7 @@
 	overlays.Cut()
 	if((stat & NOPOWER) || buildstage != 2)
 		icon_state = "light-p"
+		set_light(0)
 	else
 		icon_state = on ? "light1" : "light0"
 		overlay.icon_state = "[icon_state]-overlay"


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/7573912/88226982-30c5ea80-cc6d-11ea-99bc-533f83547c00.png)

The point in the first place was that they could be found in a dark room, but while they are unpowered reaching them wouldn't help you much.

:cl:
* bugfix: Light switches now only emit light when powered (when either their green or red LED is visible)