### PR TITLE
Runechat images containing your name will now be highlighted

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -305,6 +305,13 @@ proc/checkhtml(var/t)
 			return copytext(text, 1, i)
 	return text
 
+//Returns the last word in a string.
+/proc/get_last_word(text)
+	for(var/i = 1 to length(text))
+		if(text2ascii(text, length(text)-i) == 32)
+			return copytext(text, length(text)-i, length(text))
+	return text
+
 //Returns a string with the first element of the string capitalized.
 /proc/capitalize(var/t as text)
 	return uppertext(copytext_char(t, 1, 2)) + copytext_char(t, 2)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -309,7 +309,7 @@ proc/checkhtml(var/t)
 /proc/get_last_word(text)
 	for(var/i = 1 to length(text))
 		if(text2ascii(text, length(text)-i) == 32)
-			return copytext(text, length(text)-i, length(text))
+			return copytext(text, length(text)-i, length(text)+1)
 	return text
 
 //Returns a string with the first element of the string capitalized.

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -300,17 +300,13 @@ proc/checkhtml(var/t)
 
 //Returns the first word in a string.
 /proc/get_first_word(text)
-	for(var/i = 1 to length(text))
-		if(text2ascii(text, i) == 32)
-			return copytext(text, 1, i)
-	return text
+	var/list/L = splittext(text, " ")
+	return L[1]
 
 //Returns the last word in a string.
 /proc/get_last_word(text)
-	for(var/i = 1 to length(text))
-		if(text2ascii(text, length(text)-i) == 32)
-			return copytext(text, length(text)-i, length(text)+1)
-	return text
+	var/list/L = splittext(text, " ")
+	return L[L.len]
 
 //Returns a string with the first element of the string capitalized.
 /proc/capitalize(var/t as text)

--- a/code/datums/chat_message.dm
+++ b/code/datums/chat_message.dm
@@ -103,6 +103,10 @@ var/runechat_icon = null
 	if (!ismob(target))
 		extra_classes |= "small"
 
+	// If we heard our name, it's important
+	if (findtext(text, get_first_word(owner.name) || findtext(text, get_last_word(owner.name))))
+		extra_classes |= "boldtext"
+
 	// Append radio icon if comes from a radio
 	if (extra_classes.Find("spoken_into_radio"))
 		if (!runechat_icon)

--- a/code/datums/chat_message.dm
+++ b/code/datums/chat_message.dm
@@ -104,10 +104,9 @@ var/runechat_icon = null
 		extra_classes |= "small"
 
 	// If we heard our name, it's important
-	var/first_word = get_first_word(owner.name)
-	var/last_word = get_last_word(owner.name)
-	text = replacetext_char(text, first_word, "<b>[first_word]</b>")
-	text = replacetext_char(text, last_word, "<b>[last_word]</b>")
+	var/list/names = splittext(owner.name, " ")
+	for (var/word in names)
+		text = replacetext(text, word, "<b>[word]</b>")
 
 	// Append radio icon if comes from a radio
 	if (extra_classes.Find("spoken_into_radio"))

--- a/code/datums/chat_message.dm
+++ b/code/datums/chat_message.dm
@@ -104,8 +104,10 @@ var/runechat_icon = null
 		extra_classes |= "small"
 
 	// If we heard our name, it's important
-	if (findtext(text, get_first_word(owner.name) || findtext(text, get_last_word(owner.name))))
-		extra_classes |= "boldtext"
+	var/first_word = get_first_word(owner.name)
+	var/last_word = get_last_word(owner.name)
+	text = replacetext_char(text, first_word, "<b>[first_word]</b>")
+	text = replacetext_char(text, last_word, "<b>[last_word]</b>")
 
 	// Append radio icon if comes from a radio
 	if (extra_classes.Find("spoken_into_radio"))

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -782,7 +782,7 @@ window "mapwindow"
 		text-color = none
 		is-default = true
 		saved-params = "icon-size"
-		style=".center { text-align: center; } .runechatdiv {background-color: #20202070} .black_outline { -dm-text-outline: 1px black } .maptext { font-family: 'Small Fonts'; font-size: 7px; color: white; line-height: 1.1; } .command_headset { font-weight: bold;	font-size: 8px; } .small { font-size: 6px; } .very_small { font-size: 5px;} .big { font-size: 8px; } .reallybig { font-size: 8px; } .extremelybig { font-size: 8px; } .greentext { color: #00FF00; font-size: 7px; } .redtext { color: #FF0000; font-size: 7px; } .clown { color: #FF69Bf; font-size: 7px;  font-weight: bold; } .his_grace { color: #15D512; } .hypnophrase { color: #0d0d0d; font-weight: bold; } .yell { font-weight: bold; } .italics { font-size: 6px; }"
+		style=".center { text-align: center; } .runechatdiv {background-color: #20202070} .black_outline { -dm-text-outline: 1px black } .boldtext { font-weight: bold; } .maptext { font-family: 'Small Fonts'; font-size: 7px; color: white; line-height: 1.1; } .command_headset { font-weight: bold;	font-size: 8px; } .small { font-size: 6px; } .very_small { font-size: 5px;} .big { font-size: 8px; } .reallybig { font-size: 8px; } .extremelybig { font-size: 8px; } .greentext { color: #00FF00; font-size: 7px; } .redtext { color: #FF0000; font-size: 7px; } .clown { color: #FF69Bf; font-size: 7px;  font-weight: bold; } .his_grace { color: #15D512; } .hypnophrase { color: #0d0d0d; font-weight: bold; } .yell { font-weight: bold; } .italics { font-size: 6px; }"
 	elem "credits"
 		type = BROWSER
 		pos = 0,0


### PR DESCRIPTION
Requested on the thread. See below : 

![88434472-854d9f00-ce00-11ea-91cf-ad620d2bd4d0](https://user-images.githubusercontent.com/31417754/88456426-0434ed00-ce7e-11ea-926f-6459d153a854.png)


Only the person with the matching name sees the highlight.

:cl:
- rscadd: Chat-on-map messages containing your name will now be displayed in bold.