### PR TITLE
Makes stacked runechat messages fade out slightly slower.

### DIFF
--- a/code/datums/chat_message.dm
+++ b/code/datums/chat_message.dm
@@ -1,8 +1,8 @@
 #define CHAT_MESSAGE_SPAWN_TIME		0.2 SECONDS
 #define CHAT_MESSAGE_LIFESPAN		5 SECONDS
 #define CHAT_MESSAGE_EOL_FADE		0.7 SECONDS
-#define CHAT_MESSAGE_EXP_DECAY		0.7 // Messages decay at pow(factor, idx in stack)
-#define CHAT_MESSAGE_HEIGHT_DECAY	0.6 // Increase message decay based on the height of the message
+#define CHAT_MESSAGE_EXP_DECAY		0.8 // Messages decay at pow(factor, idx in stack)
+#define CHAT_MESSAGE_HEIGHT_DECAY	0.7 // Increase message decay based on the height of the message
 #define CHAT_MESSAGE_APPROX_LHEIGHT	11 // Approximate height in pixels of an 'average' line, used for height decay
 #define CHAT_MESSAGE_WIDTH			96 // pixels
 #define CHAT_MESSAGE_MAX_LENGTH		68 // characters


### PR DESCRIPTION
The exponential decay was initially very high because I feared it would encourage people to hash out their sentences too much and result in spam. This apparently wasn't the case. I did a few votes in game and the reception was either positive or "don't know". 

Some people did felt that the messages fade out too fast to read. This PR adds some time before stacked messages decay. Do note that because it multiplicative, it only really affects the first two stacked messages.

[tweak]

:cl:
- tweak: Runechat messages will now fade out slightly slower.