### PR TITLE
Telesci telepad fixes

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -355,13 +355,6 @@
 	build_path = /obj/machinery/computer/stacking_unit
 	origin_tech = Tc_PROGRAMMING + "=2;" + Tc_MATERIALS + "=2"
 
-/obj/item/weapon/circuitboard/sci_telepad
-	name = "Circuit board (Telescience Pad)"
-	desc = "A rather unique circuit board designed for teleportation science, currently unable to be reproduced."
-	build_path = /obj/machinery/telepad
-	origin_tech = Tc_BLUESPACE + "=3;" + Tc_PROGRAMMING + "=2;" + Tc_MATERIALS + "=2"
-	mech_flags = MECH_SCAN_FAIL
-
 
 /obj/item/weapon/circuitboard/attackby(obj/item/I as obj, mob/user as mob)
 	if(issolder(I))

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -1471,3 +1471,16 @@ obj/item/weapon/circuitboard/rdserver
 		/obj/item/weapon/stock_parts/subspace/crystal = 1,
 		/obj/item/weapon/stock_parts/subspace/transmitter = 1
 		)
+
+/obj/item/weapon/circuitboard/sci_telepad
+	name = "Circuit board (Telescience Pad)"
+	desc = "A rather unique circuit board designed for teleportation science, currently unable to be reproduced."
+	build_path = /obj/machinery/telepad
+	board_type = MACHINE
+	origin_tech = Tc_BLUESPACE + "=3;" + Tc_PROGRAMMING + "=2;" + Tc_MATERIALS + "=2"
+	mech_flags = MECH_SCAN_FAIL
+	req_components = list(
+		/obj/item/weapon/stock_parts/scanning_module = 1,
+		/obj/item/weapon/stock_parts/manipulator = 1,
+		/obj/item/weapon/stock_parts/micro_laser = 2,
+	)


### PR DESCRIPTION
AS IT TURNS OUT I accidentally made the telepad a computer board, which meant that the telepad couldn't actually be upgraded (since it didn't have any defined components either) and when it was deconstructed it had to be added to a computer frame.


:cl:
 * bugfix: Fixed a bug where the telescience telepad was un-upgradeable because it was considered a computer board with no required components.
 * bugfix: Fixed a bug where the telescience telepad required a computer frame when rebuilt. Now it properly requires a machine frame and can actually be constructed.