### PR TITLE
fixes skeletons having asthma attacks

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1482,7 +1482,7 @@
 	Jitter(jitter_duration)
 
 /mob/living/carbon/human/proc/asthma_attack()
-	if(disabilities & ASTHMA && !(M_NO_BREATH in mutations) && !(has_reagent_in_blood(ALBUTEROL)))
+	if(disabilities & ASTHMA && !(M_NO_BREATH in mutations) && !(species && species.flags & NO_BREATHE) && !(has_reagent_in_blood(ALBUTEROL)))
 		forcesay("-")
 		visible_message("<span class='danger'>\The [src] begins wheezing and grabbing at their throat!</span>", \
 									"<span class='warning'>You begin wheezing and grabbing at your throat!</span>")


### PR DESCRIPTION
[bugfix] 
fixes #18338
think this fixes it, added species NO_BREATHE flag check in asthma_attack().

:cl:
 * bugfix: nonbreathing species no longer suffer asthma attacks