### PR TITLE
Fixes accessing a destroyed object

### DIFF
--- a/code/_onclick/hud/spell_screen_objects.dm
+++ b/code/_onclick/hud/spell_screen_objects.dm
@@ -134,7 +134,7 @@
 
 	spell.connected_button = null
 
-	if(spell_objects.len)
+	if(spell_objects?.len)
 		toggle_open(showing + 1)
 	else
 		qdel(src)


### PR DESCRIPTION
Every time a player was deleted a runtime would appear, this is a simple fix