### PR TITLE
disable AI use of camera computers

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -51,8 +51,14 @@ var/list/obj/machinery/camera/cyborg_cams = list(
 	..()
 
 /obj/machinery/computer/security/attack_ai(var/mob/user)
-	to_chat(user, "You have your built-in camera systems for this!") //currently too buggy to allow AI to use camera computers
-	//src.add_hiddenprint(user)
+	if(istype(user, /mob/living/silicon/robot) || isMoMMI(user))
+		if(Adjacent(user))
+			src.add_hiddenprint(user)
+			return attack_hand(user)
+		else
+			to_chat(user, "You need to get closer to the computer first.")
+	else
+		to_chat(user, "You have your built-in camera systems for this!") //currently too buggy to allow AI to use camera computers
 	return //attack_hand(user)
 
 

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -51,8 +51,9 @@ var/list/obj/machinery/camera/cyborg_cams = list(
 	..()
 
 /obj/machinery/computer/security/attack_ai(var/mob/user)
-	src.add_hiddenprint(user)
-	return attack_hand(user)
+	to_chat(user, "You have your built-in camera systems for this!") //currently too buggy to allow AI to use camera computers
+	//src.add_hiddenprint(user)
+	return //attack_hand(user)
 
 
 /obj/machinery/computer/security/attack_paw(var/mob/user)


### PR DESCRIPTION
[tweak]
Currently only works in a buggy fashion, leaves actionbuttons on the screen that cant be gotten rid of, and becomes even buggier upon a client restart, not allowing you to switch to different cameras with the actionbuttons and always bringing your field of view back to the AI core.
Seems like a hassle to fix, /mob/living/silicon/ai/cancel_camera() needs a work-over, obj/machinery/computer/security/proc/set_camera should make use of /mob/living/silicon/ai/proc/switchCamera and checks all over camera.dm seem to forgo taking AI interaction into account.

AI has built-in systems. Until fixed, this should be disabled.
I don't think any functionality will be lost with this, since AI has access to all cameras anyway, in a better way, too.

:cl:
 * tweak: disabled AI use of camera computers