### PR TITLE
Bugfix for autolathes

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -186,12 +186,18 @@
 			return 1
 
 
-		else if(allowed_materials && !((I.materials.storage & allowed_materials) ~= I.materials.storage))
-			var/output = "\The [src] can only accept objects made out of these: "
+		else if(allowed_materials)
+
+			var/allowed_materials_volume = 0
 			for(var/mat_id in allowed_materials)
-				output += (material_list[mat_id].processed_name + " ")
-			to_chat(user, output)
-			return 1
+				allowed_materials_volume += I.materials.storage[mat_id]
+
+			if (allowed_materials_volume != I.materials.getVolume())
+				var/output = "\The [src] can only accept objects made out of these: "
+				for(var/mat_id in allowed_materials)
+					output += (material_list[mat_id].processed_name + " ")
+				to_chat(user, output)
+				return 1
 
 		else if(isrobot(user))
 			if(isMoMMI(user))


### PR DESCRIPTION
[bugfix]
fixes #27291 

technical explanation for anyone interested:
before, I used this comparison to see if the item `I` had inappropriate materials,
 `if(allowed_materials && !((I.materials.storage & allowed_materials) ~= I.materials.storage))`

This would work if the list `I.materials.storage` only contained entries for materials that are actually present in the item. In actuality, this list contains entries for every material in the game, with the irrelevant ones set = 0. (This seems like a waste of space, but items already have a shit ton of vars anyway v0v) 

To fix it, we compare the total volume of materials in the item to the total volume of allowed materials in the item. This is the same style of comparison that was used prior to #27190, but this version actually respects the machine's `allowed_materials` list

:cl:
 * bugfix: The autolathe can recycle items properly again