### PR TITLE
Cleaner VV Options

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -130,7 +130,6 @@
 		body += "<option value='?_src_=vars;mob_player_panel=\ref[D]'>Show player panel</option>"
 
 	if(istype(D,/atom/movable))
-		body += "<option value='?_src_=vars;throw_a_fucking_rod_at_it=\ref[D]'>Throw a rod at it</option>"
 		body += "<option value='?_src_=vars;teleport_here=\ref[D]'>Teleport Here</option>"
 
 	if(istype(D,/atom))
@@ -150,29 +149,15 @@
 	if(ismob(D))
 
 		body += {"<option value='?_src_=vars;give_spell=\ref[D]'>Give Spell</option>
-			<option value='?_src_=vars;give_disease=\ref[D]'>Give Old Disease</option>
 			<option value='?_src_=vars;give_disease2=\ref[D]'>Give New Disease</option>
-			<option value='?_src_=vars;addcancer=\ref[D]'>Inflict Cancer</option>
 			<option value='?_src_=vars;godmode=\ref[D]'>Toggle Godmode</option>
 			<option value='?_src_=vars;build_mode=\ref[D]'>Toggle Build Mode</option>
-			<option value='?_src_=vars;make_skeleton=\ref[D]'>Make 2spooky</option>
-			<option value='?_src_=vars;direct_control=\ref[D]'>Assume Direct Control</option>
 			<option value='?_src_=vars;drop_everything=\ref[D]'>Drop Everything</option>
 			<option value='?_src_=vars;regenerateicons=\ref[D]'>Regenerate Icons</option>
-			<option value='?_src_=vars;addlanguage=\ref[D]'>Add Language</option>
-			<option value='?_src_=vars;remlanguage=\ref[D]'>Remove Language</option>
-			<option value='?_src_=vars;make_invisible=\ref[D]'>Make invisible</option>"}
 		if(ishuman(D))
 
 			body += {"<option value>---</option>
-				<option value='?_src_=vars;setmutantrace=\ref[D]'>Set Mutantrace</option>
-				<option value='?_src_=vars;setspecies=\ref[D]'>Set Species</option>
-				<option value='?_src_=vars;makeai=\ref[D]'>Make AI</option>
-				<option value='?_src_=vars;makerobot=\ref[D]'>Make cyborg</option>
-				<option value='?_src_=vars;makemonkey=\ref[D]'>Make monkey</option>
-				<option value='?_src_=vars;makealien=\ref[D]'>Make alien</option>
-				<option value='?_src_=vars;makeslime=\ref[D]'>Make slime</option>
-				<option value='?_src_=vars;makecluwne=\ref[D]'>Make cluwne</option>"}
+				<option value='?_src_=vars;setspecies=\ref[D]'>Set Species</option>}
 
 		body += {"<option value>---</option>
 			<option value='?_src_=vars;gib=\ref[D]'>Gib</option>"}
@@ -180,8 +165,9 @@
 		body += "<option value='?_src_=vars;delete=\ref[D]'>Delete</option>"
 	if(isobj(D))
 		body += "<option value='?_src_=vars;delall=\ref[D]'>Delete all of type</option>"
+	if(ismovable(D))
+		body += "<option value='?_src_=vars;throw_a_fucking_rod_at_it=\ref[D]'>Throw a rod at it</option>"
 	if(isobj(D) || ismob(D) || isturf(D))
-
 		body += {"<option value='?_src_=vars;explode=\ref[D]'>Trigger explosion</option>
 			<option value='?_src_=vars;emp=\ref[D]'>Trigger EM pulse</option>"}
 

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -590,30 +590,6 @@ function loadPage(list) {
 		src.give_spell(M)
 		href_list["datumrefresh"] = href_list["give_spell"]
 
-	else if(href_list["make_invisible"])
-		if(!check_rights(R_ADMIN|R_FUN))
-			return
-
-		var/mob/M = locate(href_list["make_invisible"])
-		if(!istype(M))
-			to_chat(usr, "This can only be used on instances of type /mob")
-			return
-
-		src.toggle_invisible(M)
-		href_list["datumrefresh"] = href_list["make_invisible"]
-
-	else if(href_list["give_disease"])
-		if(!check_rights(R_ADMIN|R_FUN))
-			return
-
-		var/mob/M = locate(href_list["give_disease"])
-		if(!istype(M))
-			to_chat(usr, "This can only be used on instances of type /mob")
-			return
-
-		src.give_disease(M)
-		href_list["datumrefresh"] = href_list["give_disease"]
-
 	else if(href_list["give_disease2"])
 		if(!check_rights(R_ADMIN|R_FUN|R_DEBUG))
 			return
@@ -625,22 +601,6 @@ function loadPage(list) {
 
 		virus2_make_custom(src,M)
 		href_list["datumrefresh"] = href_list["give_disease2"]
-
-	else if(href_list["addcancer"])
-		if(!check_rights(R_FUN))
-			return
-
-		var/mob/living/carbon/human/H = locate(href_list["addcancer"])
-		if(!ishuman(H))
-			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
-			return
-
-		if(alert(usr, "Are you sure you wish to inflict cancer upon [key_name(H)]?",  "Confirm Cancer?" , "Yes" , "No") != "Yes")
-			return
-
-		log_admin("[key_name(H)] was inflicted with cancer, courtesy of [key_name(usr)]")
-		message_admins("[key_name(H)] was inflicted with cancer, courtesy of [key_name(usr)]")
-		H.add_cancer()
 
 	else if(href_list["godmode"])
 		if(!check_rights(R_REJUVINATE))
@@ -688,30 +648,6 @@ function loadPage(list) {
 
 		if(usr.client)
 			usr.client.cmd_admin_drop_everything(M)
-
-	else if(href_list["direct_control"])
-		if(!check_rights(0))
-			return
-
-		var/mob/M = locate(href_list["direct_control"])
-		if(!istype(M))
-			to_chat(usr, "This can only be used on instances of type /mob")
-			return
-
-		if(usr.client)
-			usr.client.cmd_assume_direct_control(M)
-
-	else if(href_list["make_skeleton"])
-		if(!check_rights(R_FUN))
-			return
-
-		var/mob/living/carbon/human/H = locate(href_list["make_skeleton"])
-		if(!istype(H))
-			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
-			return
-
-		H.makeSkeleton()
-		href_list["datumrefresh"] = href_list["make_skeleton"]
 
 	else if(href_list["delall"])
 		if(!check_rights(R_DEBUG|R_SERVER))
@@ -912,179 +848,6 @@ function loadPage(list) {
 			if("left")
 				A.dir = turn(A.dir, 45)
 		href_list["datumrefresh"] = href_list["rotatedatum"]
-
-	else if(href_list["makemonkey"])
-		if(!check_rights(R_SPAWN))
-			return
-
-		var/mob/living/carbon/human/H = locate(href_list["makemonkey"])
-		if(!istype(H))
-			to_chat(usr, "This can only be done to instances of type /mob/living/carbon/human")
-			return
-
-		if(alert("Confirm mob type change?",,"Transform","Cancel") != "Transform")
-			return
-		if(!H)
-			to_chat(usr, "Mob doesn't exist anymore")
-			return
-		holder.Topic(href, list("monkeyone"=href_list["makemonkey"]))
-
-	else if(href_list["makerobot"])
-		if(!check_rights(R_SPAWN))
-			return
-
-		var/mob/living/carbon/human/H = locate(href_list["makerobot"])
-		if(!istype(H))
-			to_chat(usr, "This can only be done to instances of type /mob/living/carbon/human")
-			return
-
-		if(alert("Confirm mob type change?",,"Transform","Cancel") != "Transform")
-			return
-		if(!H)
-			to_chat(usr, "Mob doesn't exist anymore")
-			return
-		holder.Topic(href, list("makerobot"=href_list["makerobot"]))
-
-	else if(href_list["makealien"])
-		if(!check_rights(R_SPAWN))
-			return
-
-		var/mob/living/carbon/human/H = locate(href_list["makealien"])
-		if(!istype(H))
-			to_chat(usr, "This can only be done to instances of type /mob/living/carbon/human")
-			return
-
-		if(alert("Confirm mob type change?",,"Transform","Cancel") != "Transform")
-			return
-		if(!H)
-			to_chat(usr, "Mob doesn't exist anymore")
-			return
-		holder.Topic(href, list("makealien"=href_list["makealien"]))
-
-	else if(href_list["makeslime"])
-		if(!check_rights(R_SPAWN))
-			return
-
-		var/mob/living/carbon/human/H = locate(href_list["makeslime"])
-		if(!istype(H))
-			to_chat(usr, "This can only be done to instances of type /mob/living/carbon/human")
-			return
-
-		if(alert("Confirm mob type change?",,"Transform","Cancel") != "Transform")
-			return
-		if(!H)
-			to_chat(usr, "Mob doesn't exist anymore")
-			return
-		holder.Topic(href, list("makeslime"=href_list["makeslime"]))
-
-	else if(href_list["makeai"])
-		if(!check_rights(R_SPAWN))
-			return
-
-		var/mob/living/carbon/human/H = locate(href_list["makeai"])
-		if(!istype(H))
-			to_chat(usr, "This can only be done to instances of type /mob/living/carbon/human")
-			return
-
-		if(alert("Confirm mob type change?",,"Transform","Cancel") != "Transform")
-			return
-		if(!H)
-			to_chat(usr, "Mob doesn't exist anymore")
-			return
-		holder.Topic(href, list("makeai"=href_list["makeai"]))
-
-	else if(href_list["setmutantrace"])
-		if(!check_rights(R_SPAWN))
-			return
-
-		var/mob/living/carbon/human/H = locate(href_list["setmutantrace"])
-		if(!istype(H))
-			to_chat(usr, "This can only be done to instances of type /mob/living/carbon/human")
-			return
-
-		var/new_mutantrace = input("Please choose a new mutantrace","Mutantrace",null) as null|anything in list("NONE","golem","lizard","slime","plant","shadow","tajaran","skrell","vox")
-		switch(new_mutantrace)
-			if(null)
-				return
-			if("NONE")
-				new_mutantrace = ""
-		if(!H)
-			to_chat(usr, "Mob doesn't exist anymore")
-			return
-		if(H.dna)
-			H.dna.mutantrace = new_mutantrace
-			H.update_mutantrace()
-
-	else if(href_list["setspecies"])
-		if(!check_rights(R_SPAWN))
-			return
-
-		var/mob/living/carbon/human/H = locate(href_list["setspecies"])
-		if(!istype(H))
-			to_chat(usr, "This can only be done to instances of type /mob/living/carbon/human")
-			return
-
-		var/new_species = input("Please choose a new species.","Species",null) as null|anything in all_species
-
-		if(!H)
-			to_chat(usr, "Mob doesn't exist anymore")
-			return
-
-		if(H.set_species(new_species, force_organs=1))
-			to_chat(usr, "Set species of [H] to [H.species].")
-			H.regenerate_icons()
-		else
-			to_chat(usr, "Failed! Something went wrong.")
-
-	else if(href_list["addlanguage"])
-		if(!check_rights(R_SPAWN))
-			return
-
-		var/mob/H = locate(href_list["addlanguage"])
-		if(!istype(H))
-			to_chat(usr, "This can only be done to instances of type /mob")
-			return
-
-		var/new_language = input("Please choose a language to add.","Language",null) as null|anything in all_languages
-
-		if(!new_language)
-			return
-
-		if(!H)
-			to_chat(usr, "Mob doesn't exist anymore")
-			return
-
-		if(H.add_language(new_language))
-			to_chat(usr, "Added [new_language] to [H].")
-		else
-			to_chat(usr, "Mob already knows that language.")
-
-	else if(href_list["remlanguage"])
-		if(!check_rights(R_SPAWN))
-			return
-
-		var/mob/H = locate(href_list["remlanguage"])
-		if(!istype(H))
-			to_chat(usr, "This can only be done to instances of type /mob")
-			return
-
-		if(!H.languages.len)
-			to_chat(usr, "This mob knows no languages.")
-			return
-
-		var/datum/language/rem_language = input("Please choose a language to remove.","Language",null) as null|anything in H.languages
-
-		if(!rem_language)
-			return
-
-		if(!H)
-			to_chat(usr, "Mob doesn't exist anymore")
-			return
-
-		if(H.remove_language(rem_language.name))
-			to_chat(usr, "Removed [rem_language] from [H].")
-		else
-			to_chat(usr, "Mob doesn't know that language.")
 
 	else if(href_list["regenerateicons"])
 		if(!check_rights(0))


### PR DESCRIPTION
This removes a lot of the options that are already on the player panel from the VV dropdown (e.g.: cluwne, cancer, make AI). It also moves the rod button down near the DANGER zone with delete, explosion, etc.

![image](https://user-images.githubusercontent.com/9782036/88758051-27d18f00-d12d-11ea-8cbe-3c248cd01490.png)

The result I feel is much easier to navigate and more useful when you're adminning.