### PR TITLE
Head revs get a loyalty implant pinpointer

### DIFF
--- a/code/datums/gamemode/role/rev.dm
+++ b/code/datums/gamemode/role/rev.dm
@@ -68,22 +68,26 @@
 		equip_revsquad(mob)
 		mob.fully_replace_character_name("Cargonian",random_name(mob.gender)) //This will change the ID name, it MUST be Cargonian!
 	else
-		var/obj/item/device/flash/rev/T = new(mob)
-		if(istype(mob))
-			var/list/slots = list (
-				"backpack" = slot_in_backpack,
-				"left pocket" = slot_l_store,
-				"right pocket" = slot_r_store,
-			)
-			var/where = mob.equip_in_one_of_slots(T, slots, put_in_hand_if_fail = 1)
+		maybe_equip(new /obj/item/device/flash/rev(get_turf(mob)))
+	maybe_equip(new /obj/item/weapon/pinpointer/implant)
 
-			if (!where)
-				to_chat(mob, "\The [faction.name] were unfortunately unable to get you \a [T].")
-			else
-				to_chat(mob, "\The [T] in your [where] will help you to persuade the crew to join your cause.")
+/datum/role/revolutionary/proc/maybe_equip(obj/item/thing)
+	var/mob/living/carbon/human/mob = antag.current
+	if(ishuman(mob))
+		var/list/slots = list(
+			"backpack" = slot_in_backpack,
+			"left pocket" = slot_l_store,
+			"right pocket" = slot_r_store,
+		)
+		var/where = mob.equip_in_one_of_slots(thing, slots, put_in_hand_if_fail = 1)
+
+		if (!where)
+			to_chat(mob, "\The [faction.name] were unfortunately unable to get you \a [thing].")
 		else
-			T.forceMove(get_turf(mob))
-			to_chat(mob, "\The [faction.name] were able to get you \a [T], but could not find anywhere to slip it onto you, so it is now on the floor.")
+			to_chat(mob, "\The [thing] in your [where] will help you with your cause.")
+	else
+		thing.forceMove(get_turf(mob))
+		to_chat(mob, "\The [faction.name] were able to get you \a [thing], but could not find anywhere to slip it onto you, so it is now on the floor.")
 
 /datum/role/revolutionary/Drop(var/borged = FALSE)
 	if (!antag)

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -333,3 +333,21 @@ var/list/pinpointerpinpointer_list = list()
 			target = P
 	point_at(target)
 	..()
+
+/obj/item/weapon/pinpointer/implant
+	name = "implant pinpointer"
+	watches_nuke = FALSE
+
+/obj/item/weapon/pinpointer/implant/process()
+	var/closest_distance = INFINITY
+	var/turf/this_pos = get_turf(src)
+	target = null
+	for(var/mob/living/dude in living_mob_list)
+		if(dude.stat == DEAD || !dude.is_implanted(/obj/item/weapon/implant/loyalty))
+			continue
+		var/turf/dude_pos = get_turf(dude)
+		var/distance = abs(cheap_pythag(this_pos.x - dude_pos.x, this_pos.y - dude_pos.y))
+		if(distance < closest_distance)
+			closest_distance = distance
+			target = dude
+	point_at(target)

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -343,7 +343,7 @@ var/list/pinpointerpinpointer_list = list()
 	var/turf/this_pos = get_turf(src)
 	target = null
 	for(var/mob/living/dude in living_mob_list)
-		if(dude.stat == DEAD || !dude.is_implanted(/obj/item/weapon/implant/loyalty))
+		if(dude.z != this_pos.z || dude.stat == DEAD || !dude.is_implanted(/obj/item/weapon/implant/loyalty))
 			continue
 		var/turf/dude_pos = get_turf(dude)
 		var/distance = abs(cheap_pythag(this_pos.x - dude_pos.x, this_pos.y - dude_pos.y))


### PR DESCRIPTION
## Why
Heads hiding in closets is annoying for everyone.
## Concerns
Heads that lose their implant, for instance through cloning, will be immune to this. The obvious solution is to remove cloning.
Unlike a flash, it's a dead giveaway that one is undoubtedly a revolutionary, so it's one more thing to stash if getting caught is part of the plan.
Here is a picture of bane: 
![image](https://user-images.githubusercontent.com/6307265/88778728-259d1e00-d189-11ea-955e-790ea3e90217.png)


:cl:
 * rscadd: Head revolutionaries now get a pinpointer that tracks the closest living creature with a loyalty implant.