### PR TITLE
Fixed hf machete runtime

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -390,6 +390,9 @@
 		user.lazy_unregister_event(/lazy_event/on_moved, src, .proc/mob_moved)
 	update_icon()
 
+/obj/item/weapon/melee/energy/hfmachete/dropped(mob/user)
+	user.lazy_unregister_event(/lazy_event/on_moved, src, .proc/mob_moved)
+
 /obj/item/weapon/melee/energy/hfmachete/throw_at(atom/target, range, speed, override = 1)
 	if(!usr)
 		return ..()


### PR DESCRIPTION
```
[00:39:24] Runtime in events.dm,60: Cannot execute null.mob moved().
  proc name: CallAsync (/proc/CallAsync)
  usr: Nicholas Blaine (juanototo2) (/mob/living/carbon/human)
  usr.loc: The floor (159, 184, 1) (/turf/simulated/floor)
  src: null
  call stack:
  CallAsync(null, /obj/item/weapon/melee/energy/... (/obj/item/weapon/melee/energy/hfmachete/proc/mob_moved), /list (/list))
  Nicholas Blaine (/mob/living/carbon/human): lazy invoke event(/lazy_event/on_moved (/lazy_event/on_moved), /list (/list))
  Nicholas Blaine (/mob/living/carbon/human): Move(the floor (159,184,1) (/turf/simulated/floor), 2, 0, 0, 0)
  Nicholas Blaine (/mob/living/carbon/human): Move(the floor (159,184,1) (/turf/simulated/floor), 2, 0, 0, 0)
  Nicholas Blaine (/mob/living/carbon/human): Move(the floor (159,184,1) (/turf/simulated/floor), 2, 0, 0, 0)
  Nicholas Blaine (/mob/living/carbon/human): Move(the floor (159,184,1) (/turf/simulated/floor), 2, 0, 0, 0)
  Juanototo2 (/client): Move(the floor (159,185,1) (/turf/simulated/floor), 2, 0, 0, 0)
  Juanototo2 (/client): move loop()
```