### PR TITLE
Fixed power_connection runtime

### DIFF
--- a/code/modules/power/components.dm
+++ b/code/modules/power/components.dm
@@ -16,7 +16,6 @@
 	var/machine_flags = 0 // Emulate machinery flags.
 	var/inMachineList = 0
 
-	var/parentMoveKey = null
 	var/turf/turf = null // Updated in addToTurf()/removeFromTurf()
 
 /datum/power_connection/New(var/obj/parent)
@@ -39,7 +38,7 @@
 // CALLBACK from /lazy_event/on_moved.
 // This should never happen, except when Singuloth is doing its shenanigans, as rebuilding
 //  powernets is extremely slow.
-/datum/power_connection/proc/parent_moved()
+/datum/power_connection/proc/parent_moved(atom/movable/mover)
 	removeFromTurf() // Removes old ref
 	addToTurf() // Adds new one
 


### PR DESCRIPTION
```
[19:43:42] Runtime in ,: bad arg name 'mover'
  proc name: parent moved (/datum/power_connection/proc/parent_moved)
  usr: Jazz Bel (nukas) (/mob/living/carbon/human)
  usr.loc: The reinforced floor (273, 271, 1) (/turf/simulated/floor/engine)
  src: /datum/power_connection/consum... (/datum/power_connection/consumer/cable)
  call stack:
  /datum/power_connection/consum... (/datum/power_connection/consumer/cable): parent moved(null)
  CallAsync(/datum/power_connection/consum... (/datum/power_connection/consumer/cable), /datum/power_connection/proc/p... (/datum/power_connection/proc/parent_moved), /list (/list))
  Radio Transmitter (/obj/machinery/media/transmitter/broadcast): lazy invoke event(/lazy_event/on_moved (/lazy_event/on_moved), /list (/list))
  Radio Transmitter (/obj/machinery/media/transmitter/broadcast): Move(the reinforced floor (272,271,1) (/turf/simulated/floor/engine), 4, 0, 0, 2.90909)
  Radio Transmitter (/obj/machinery/media/transmitter/broadcast): Move(the reinforced floor (272,271,1) (/turf/simulated/floor/engine), 4, 0, 0, 2.90909)
  Jazz Bel (/mob/living/carbon/human): Move(the reinforced floor (273,271,1) (/turf/simulated/floor/engine), 4, 0, 0, 0)
  Jazz Bel (/mob/living/carbon/human): Move(the reinforced floor (273,271,1) (/turf/simulated/floor/engine), 4, 0, 0, 0)
  Jazz Bel (/mob/living/carbon/human): Move(the reinforced floor (273,271,1) (/turf/simulated/floor/engine), 4, 0, 0, 0)
  Nukas (/client): Move(the reinforced floor (272,271,1) (/turf/simulated/floor/engine), 4, 0, 0, 0)
  Nukas (/client): move loop()
  Nukas (/client): MoveKey(4, 1)
```