### PR TITLE
atom locking anchor flag and shower fix

### DIFF
--- a/__DEFINES/atom_locking_and_control.dm
+++ b/__DEFINES/atom_locking_and_control.dm
@@ -8,7 +8,7 @@
 
 // Flags for atom.lockflags
 #define DENSE_WHEN_LOCKED            1
-
+#define UNANCHOR_AFTER_UNLOCK		2
 
 /* Atom Control */
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -295,6 +295,9 @@
 	category.unlock(AM)
 	//AM.reset_glide_size() // FIXME: Currently broken.
 
+	if (AM.lockflags & UNANCHOR_AFTER_UNLOCK)
+		AM.anchored = 0
+
 	return TRUE
 
 /atom/movable/proc/unlock_from()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -119,6 +119,7 @@ Class Procs:
 
 	penetration_dampening = 5
 
+	lockflags = UNANCHOR_AFTER_UNLOCK
 	var/stat = 0
 	var/emagged = 0
 	var/use_power = 1

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -301,18 +301,21 @@
 				add_fingerprint(user)
 	else
 		if(I.is_wrench(user))
-			user.visible_message("<span class='warning'>[user] starts adjusting the bolts on \the [src].</span>", \
-								 "<span class='notice'>You start adjusting the bolts on \the [src].</span>")
-			playsound(src, 'sound/items/Ratchet.ogg', 100, 1)
-			if(do_after(user, src, 50))
-				if(anchored)
-					src.visible_message("<span class='warning'>[user] unbolts \the [src] from the floor.</span>", \
-								 "<span class='notice'>You unbolt \the [src] from the floor.</span>")
-					anchored = 0
-				else
-					src.visible_message("<span class='warning'>[user] bolts \the [src] to the floor.</span>", \
+			if(!on)
+				user.visible_message("<span class='warning'>[user] starts adjusting the bolts on \the [src].</span>", \
+									 "<span class='notice'>You start adjusting the bolts on \the [src].</span>")
+				playsound(src, 'sound/items/Ratchet.ogg', 100, 1)
+				if(do_after(user, src, 50))
+					if(anchored)
+						src.visible_message("<span class='warning'>[user] unbolts \the [src] from the floor.</span>", \
+									 "<span class='notice'>You unbolt \the [src] from the floor.</span>")
+						anchored = 0
+					else
+						src.visible_message("<span class='warning'>[user] bolts \the [src] to the floor.</span>", \
 								 "<span class='notice'>You bolt \the [src] to the floor.</span>")
-					anchored = 1
+						anchored = 1
+			else
+				to_chat(user,"Turn it off first.")
 
 /obj/machinery/shower/update_icon()	//This is terribly unreadable, but basically it makes the shower mist up
 	overlays.len = 0 //Once it's been on for a while, in addition to handling the water overlay.


### PR DESCRIPTION
[tweak][bugfix]
after completely failing to understand why cargo carts refuse to unanchor machinery after they're unloaded, I decided to add a lockflag that just unanchors shit after its unlocked/unloaded, because it doesn't do that by default for some reason? i don't want to break anything so adding a flag seemed like the better option. It's not great, but it works in a way™ plus it might be a useful flag. Another option would be to add a var to /atom to keep track of its anchor state before and after locking but i'm too lowgrade a programmer to make such a call.

also fixed the damn showers.

:cl:
 * tweak: machinery is no longer anchored after unloading from cargo carts
 * bugfix: showers can no longer be moved while they're turned on