### PR TITLE
Faster surgeries: cutting open, clamp bleeders, cauterize

### DIFF
--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -41,8 +41,8 @@
 
 	priority = 0.1 //so the tool checks for this step before /generic/cut_open
 
-	min_duration = 90
-	max_duration = 110
+	min_duration = 40
+	max_duration = 50
 
 /datum/surgery_step/generic/cut_with_laser/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
@@ -148,8 +148,8 @@
 
 	priority = 0
 
-	min_duration = 90
-	max_duration = 110
+	min_duration = 40
+	max_duration = 50
 
 /datum/surgery_step/generic/cut_open/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	. = ..()
@@ -193,8 +193,8 @@
 		/obj/item/device/assembly/mousetrap = 20,
 		)
 
-	min_duration = 40
-	max_duration = 60
+	min_duration = 30
+	max_duration = 40
 
 /datum/surgery_step/generic/clamp_bleeders/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
@@ -305,8 +305,8 @@
 	/obj/item/weapon/weldingtool = 25,
 	)
 
-	min_duration = 70
-	max_duration = 100
+	min_duration = 30
+	max_duration = 40
 
 /datum/surgery_step/generic/cauterize/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())


### PR DESCRIPTION
### Why
Cloning is always better than surgery without upgraded tools, and only sometimes worse than surgery with upgraded tools. That's assumed to be bad. If surgery is made faster, it might be worth doing compared to cloning.

:cl:
 * tweak: Some surgery steps are now faster: cutting open with a scalpel takes 4-5 seconds (down from 9-11), clamping bleeders takes 3-4 seconds (down from 4-6), cauterizing takes 3-4 seconds (down from 7-10).