### PR TITLE
Removes Kitty Ears Update_icon call from human inventory code

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -195,8 +195,13 @@
 		if(anime || Holiday == APRIL_FOOLS_DAY)
 			speech.message = nekospeech(speech.message)
 
+/obj/item/clothing/head/kitty/equipped(var/mob/user, var/slot, hand_index = 0)
+	..()
+	if(haircolored)
+		update_icon(user)
+
 /obj/item/clothing/head/kitty/update_icon(var/mob/living/carbon/human/user)
-	if(!istype(user) || !haircolored)
+	if(!istype(user))
 		return
 	wear_override = new/icon("icon" = 'icons/mob/head.dmi', "icon_state" = "kitty")
 	wear_override.Blend(rgb(user.my_appearance.r_hair, user.my_appearance.g_hair, user.my_appearance.b_hair), ICON_ADD)

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -197,7 +197,7 @@
 
 /obj/item/clothing/head/kitty/equipped(var/mob/user, var/slot, hand_index = 0)
 	..()
-	if(haircolored)
+	if((haircolored) && (slot == slot_head))
 		update_icon(user)
 
 /obj/item/clothing/head/kitty/update_icon(var/mob/living/carbon/human/user)

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -208,6 +208,7 @@
 
 	var/icon/earbit = new/icon("icon" = 'icons/mob/head.dmi', "icon_state" = "kittyinner")
 	wear_override.Blend(earbit, ICON_OVERLAY)
+	user.update_inv_head()
 
 /obj/item/clothing/head/kitty/collectable
 	desc = "A pair of black kitty ears. Meow!"

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -463,11 +463,7 @@
 			update_inv_gloves(redraw_mob)
 		if(slot_head)
 			src.head = W
-			//if((head.flags & BLOCKHAIR) || (head.flags & BLOCKHEADHAIR)) //Makes people bald when switching to one with no Blocking flags
-			//	update_hair(redraw_mob)	//rebuild hair
 			update_hair(redraw_mob)
-			if(istype(W,/obj/item/clothing/head/kitty))
-				W.update_icon(src)
 			update_inv_head(redraw_mob)
 		if(slot_shoes)
 			src.shoes = W


### PR DESCRIPTION
Makes inventory code not do a istype check on all head items for cat ears to see if their update_icon should be called. Instead its now called on the cat ears equipped()