### PR TITLE
Fixes sql errors with rust_g

### DIFF
--- a/code/defines/procs/statistics.dm
+++ b/code/defines/procs/statistics.dm
@@ -60,7 +60,7 @@
 		log_game("SQL ERROR during death reporting. Failed to connect.")
 	else
 		var/datum/DBQuery/query = SSdbcore.NewQuery("INSERT INTO death (name, byondkey, job, special, pod, tod, laname, lakey, gender, bruteloss, fireloss, brainloss, oxyloss, coord) VALUES (:name, :key, :job, :special, :pod, :time, :laname, :lakey, :gender, :bruteloss, :fireloss, :brainloss, :oxyloss, :coord)",
-		list("name" = H.name, "key" = H.key, "special" = H.mind.assigned_role, "pod" = podname, "time" = sqltime, "laname" = laname, "lakey" = lakey, "gender" = "[H.gender]", "bruteloss" = "[H.getBruteLoss()]", "fireloss" = "[H.getFireLoss()]", "brainloss" = "[H.brainloss]", "oxyloss" = "[H.getOxyLoss()]", "coord" = "[coord]"))
+		list("name" = H.name, "key" = H.key, "job" = H.mind.assigned_job, "special" = H.mind.assigned_role, "pod" = podname, "time" = sqltime, "laname" = laname, "lakey" = lakey, "gender" = "[H.gender]", "bruteloss" = "[H.getBruteLoss()]", "fireloss" = "[H.getFireLoss()]", "brainloss" = "[H.brainloss]", "oxyloss" = "[H.getOxyLoss()]", "coord" = "[coord]"))
 		if(!query.Execute())
 			var/err = query.ErrorMsg()
 			log_game("SQL ERROR during death reporting. Error : \[[err]\]\n")
@@ -89,7 +89,7 @@
 		log_game("SQL ERROR during death reporting. Failed to connect.")
 	else
 		var/datum/DBQuery/query = SSdbcore.NewQuery("INSERT INTO death (name, byondkey, job, special, pod, tod, laname, lakey, gender, bruteloss, fireloss, brainloss, oxyloss, coord) VALUES (:name, :key, :job, :special, :pod, :time, :laname, :lakey, :gender, :bruteloss, :fireloss, :brainloss, :oxyloss, :coord)",
-			list("name" = H.name, "key" = H.key, "special" = H.mind.assigned_role, "pod" = podname, "time" = sqltime, "laname" = laname, "lakey" = lakey, "gender" = "[H.gender]", "bruteloss" = "[H.getBruteLoss()]", "fireloss" = "[H.getFireLoss()]", "brainloss" = "[H.brainloss]", "oxyloss" = "[H.getOxyLoss()]", "coord" = "[coord]")
+			list("name" = H.name, "key" = H.key, "job" = H.mind.assigned_role, "special" = H.mind.assigned_role, "pod" = podname, "time" = sqltime, "laname" = laname, "lakey" = lakey, "gender" = "[H.gender]", "bruteloss" = "[H.getBruteLoss()]", "fireloss" = "[H.getFireLoss()]", "brainloss" = "[H.brainloss]", "oxyloss" = "[H.getOxyLoss()]", "coord" = "[coord]")
 		)
 		if(!query.Execute())
 			var/err = query.ErrorMsg()

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -104,7 +104,7 @@
 	var/sqlid = text2num(id)
 	if(!sqlid)
 		return
-	var/datum/DBQuery/query = SSdbcore.NewQuery("SELECT  id, author, title, category, ckey  FROM library WHERE :id", list("id" = sqlid))
+	var/datum/DBQuery/query = SSdbcore.NewQuery("SELECT  id, author, title, category, ckey  FROM library WHERE id=:id", list("id" = sqlid))
 	if(!query.Execute())
 		message_admins("Error: [query.ErrorMsg()]")
 		log_sql("Error: [query.ErrorMsg()]")


### PR DESCRIPTION
Notably allows librarians to print other books than WGW.

:cl:
- bugfix: The Intergalatic Archives have finally expunged the extra copies of Woody Got Wood that were erroneously sent to NT-affiliated Librarians. An estimate of 0.3 trillions books have been destroyed.