### PR TITLE
Runechat emotes fixes

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -67,7 +67,7 @@
 
 	if (emote_type == EMOTE_VISIBLE)
 		user.visible_message(msg)
-		for (var/mob/O in (viewers(world.view, user) + user))
+		for (var/mob/O in viewers(world.view, user))
 			if (user.client && O?.client?.prefs.mob_chat_on_map && O.stat != UNCONSCIOUS)
 				O.create_chat_message(user, null, msg_runechat, "", list("italics"))
 	else

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -53,7 +53,7 @@
 	if(!msg)
 		return
 
-	var/msg_runechat = "[user] " + msg
+	var/msg_runechat = msg
 	msg = "<b>[user]</b> " + msg
 
 	for(var/mob/M in dead_mob_list)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6307265/89099845-88452280-d3f2-11ea-9397-8804256934d1.png)

Closes #27298

:cl:
- bugfix: Runechat emotes are no longer shown twice. Additionally, the name of the mob is no longer shown.