### PR TITLE
Alternate Titles Plus - Useless Bloat Edition

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -11,7 +11,7 @@
 	selection_color = "#dddddd"
 	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue, access_weapons)
 	minimal_access = list(access_bar,access_weapons)
-
+	alt_titles = list("Barista", "Barman", "Barkeep")
 	pdaslot=slot_belt
 	pdatype=/obj/item/device/pda/bar
 
@@ -230,7 +230,7 @@
 	idtype = /obj/item/weapon/card/id/supply
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
 	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
-
+	alt_titles = list("Mailman", "Mailwoman")
 	pdaslot=slot_belt
 	pdatype=/obj/item/device/pda/cargo
 

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -134,7 +134,7 @@
 	idtype = /obj/item/weapon/card/id/engineering
 	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics)
 	minimal_access = list(access_atmospherics, access_maint_tunnels, access_emergency_storage, access_construction, access_engine_equip, access_external_airlocks)
-	alt_titles = list("Life Support Specialist", "Firefighter")
+	alt_titles = list("Life Support Specialist", "Fire Suppression Crew")
 	pdaslot=slot_l_store
 	pdatype=/obj/item/device/pda/atmos
 

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -134,7 +134,7 @@
 	idtype = /obj/item/weapon/card/id/engineering
 	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics)
 	minimal_access = list(access_atmospherics, access_maint_tunnels, access_emergency_storage, access_construction, access_engine_equip, access_external_airlocks)
-
+	alt_titles = list("Life Support Specialist", "Firefighter")
 	pdaslot=slot_l_store
 	pdatype=/obj/item/device/pda/atmos
 
@@ -181,7 +181,7 @@
 	idtype = /obj/item/weapon/card/id/engineering
 	access = list(access_eva, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_mechanic, access_tcomsat, access_science)
 	minimal_access = list(access_maint_tunnels, access_emergency_storage, access_construction, access_engine_equip, access_external_airlocks, access_mechanic, access_tcomsat, access_science)
-	alt_titles = list("Telecommunications Technician", "Spacepod Mechanic", "Greasemonkey")
+	alt_titles = list("Telecommunications Technician", "System Administrator", "Spacepod Mechanic", "Greasemonkey", "IT Professional")
 
 	pdaslot=slot_l_store
 	pdatype=/obj/item/device/pda/mechanic

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -74,7 +74,7 @@
 	idtype = /obj/item/weapon/card/id/medical
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_eva)
 	minimal_access = list(access_medical, access_morgue, access_surgery, access_virology)
-	alt_titles = list("Emergency Physician", "Nurse", "Surgeon")
+	alt_titles = list("Emergency Physician", "Nurse", "Surgeon", "Resident")
 
 	pdaslot=slot_belt
 	pdatype=/obj/item/device/pda/medical
@@ -199,6 +199,7 @@
 	idtype = /obj/item/weapon/card/id/medical
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_science, access_eva)
 	minimal_access = list(access_medical, access_morgue, access_genetics, access_science)
+	alt_titles = list("Cloning Technician")
 
 	pdaslot=slot_belt
 	pdatype=/obj/item/device/pda/geneticist

--- a/code/game/jobs/job/paramedic.dm
+++ b/code/game/jobs/job/paramedic.dm
@@ -11,6 +11,7 @@
 	idtype = /obj/item/weapon/card/id/medical
 	access = list(access_paramedic, access_medical, access_sec_doors, access_maint_tunnels, access_external_airlocks, access_eva, access_morgue, access_surgery)
 	minimal_access=list(access_paramedic, access_medical, access_sec_doors, access_maint_tunnels, access_external_airlocks, access_eva, access_morgue, access_surgery)
+	alt_titles = list("Emergency Medical Technician")
 
 	pdaslot=slot_belt
 	pdatype=/obj/item/device/pda/medical

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -10,7 +10,7 @@
 	supervisors = "your laws"
 	req_admin_notify = 2
 	minimal_player_age = 30
-	alt_title = list("Computer")
+	alt_titles = list("Computer")
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -10,6 +10,7 @@
 	supervisors = "your laws"
 	req_admin_notify = 2
 	minimal_player_age = 30
+	alt_title = list("Computer")
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)


### PR DESCRIPTION
[wip]
[dnm]

Hello there.

This is a small PR that adds more alternate titles to some jobs. I'll probably add some special loadout stuff for the alt titles that it'd make sense for. The current list is:

- Atmos Tech - Firefighter and Life Support Specialist
- Mechanic - IT Professional and System Administrator
- Medical Doctor - Resident
- Geneticist - Cloning Technician
- Paramedic - Emergency Medical Technician
-  AI - Computer (hopefully works)
- Bartender - Barista, Barman, Barkeeper (probably should change it to Barkeep)
- Cargo Technician - Mailman, Mailwoman

Some alt titles I'd consider adding are:

- Chemist - Druggist (an actual name for chemists in some places)
- Internal Affairs Agent - Attorney

:cl:
 * rscadd: Added alternate titles to many jobs. Variety is the spice of life, some random idiot said.
