### PR TITLE
Civil War of Casters changes

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -172,7 +172,7 @@
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 40
 	persistent = 1
-	var/wizard_cd = 210 //7 minutes
+//	var/wizard_cd = 210 //7 minutes
 	var/total_wizards = 4
 
 /*

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -203,7 +203,7 @@
 		if (M)
 			assigned += M
 			candidates -= M
-			var/datum/role/wizard/newWizard = new		//TODO: ENSURE WIZARDS DONT GET SENT TO THE CUCK CUBE
+			var/datum/role/wizard/newWizard = new		
 			newWizard.AssignToRole(M.mind,1)
 			if(wizards_number % 2)
 				WPF.HandleRecruitedRole(newWizard)//this will give the wizard their icon

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -166,7 +166,7 @@
 	restricted_from_jobs = list("Head of Security", "Captain")//just to be sure that a wizard getting picked won't ever imply a Captain or HoS not getting drafted
 	enemy_jobs = list("Security Officer","Detective","Warden","Head of Security", "Captain")
 	required_pop = list(25,25,20,20,20,20,15,15,15,5)
-	required_candidates = 1
+	required_candidates = 4
 	weight = 1
 	cost = 45
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
@@ -175,6 +175,7 @@
 	var/wizard_cd = 210 //7 minutes
 	var/total_wizards = 4
 
+/*
 /datum/dynamic_ruleset/roundstart/cwc/process()
 	..()
 	if (wizard_cd)
@@ -192,18 +193,23 @@
 		message_admins("Dynamic Mode: Civil War rages on. Trying to send mage [sent_wizards+1] for [initial(RM.my_fac.name)].")
 		RM.cost = 0
 		mode.picking_specific_rule(RM,TRUE) //forced
+*/
 
 /datum/dynamic_ruleset/roundstart/cwc/execute()
-	var/mob/M = pick(candidates)
-	if (M)
-		assigned += M
-		candidates -= M
-		var/datum/role/wizard/newWizard = new
-		newWizard.AssignToRole(M.mind,1)
-		var/datum/faction/wizard/civilwar/wpf/WPF = ticker.mode.CreateFaction(/datum/faction/wizard/civilwar/wpf, null, 1)
-		ticker.mode.CreateFaction(/datum/faction/wizard/civilwar/pfw, null, 1)
-		WPF.HandleRecruitedRole(newWizard)//this will give the wizard their icon
-		newWizard.Greet(GREET_MIDROUND)
+	var/datum/faction/wizard/civilwar/wpf/WPF = ticker.mode.CreateFaction(/datum/faction/wizard/civilwar/wpf, null, 1)
+	var/datum/faction/wizard/civilwar/wpf/PFW = ticker.mode.CreateFaction(/datum/faction/wizard/civilwar/pfw, null, 1)
+	for(var/wizards_number = 1 to total_wizards)
+		var/mob/M = pick(candidates)
+		if (M)
+			assigned += M
+			candidates -= M
+			var/datum/role/wizard/newWizard = new		//TODO: ENSURE WIZARDS DONT GET SENT TO THE CUCK CUBE
+			newWizard.AssignToRole(M.mind,1)
+			if(wizards_number % 2)
+				WPF.HandleRecruitedRole(newWizard)//this will give the wizard their icon
+			else
+				PFW.HandleRecruitedRole(newWizard)
+			newWizard.Greet(GREET_MIDROUND)
 	return 1
 
 //////////////////////////////////////////////

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -168,7 +168,7 @@
 	required_pop = list(25,25,20,20,20,20,15,15,15,5)
 	required_candidates = 4
 	weight = 1
-	cost = 45
+	cost = 55
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 40
 	persistent = 1

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -168,7 +168,7 @@
 	required_pop = list(25,25,20,20,20,20,15,15,15,5)
 	required_candidates = 4
 	weight = 1
-	cost = 55
+	cost = 45
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 40
 	persistent = 1

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -165,16 +165,23 @@
 	qdel(wizard_mob.shoes)
 	qdel(wizard_mob.r_store)
 	qdel(wizard_mob.l_store)
-
 	if(!wizard_mob.find_empty_hand_index())
 		wizard_mob.u_equip(wizard_mob.held_items[GRASP_LEFT_HAND])
-
 	wizard_mob.equip_to_slot_or_del(new /obj/item/device/radio/headset(wizard_mob), slot_ears)
 	wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/under/lightpurple(wizard_mob), slot_w_uniform)
 	disable_suit_sensors(wizard_mob)
 	wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(wizard_mob), slot_shoes)
-	wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)
-	wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(wizard_mob), slot_head)
+	var/datum/faction/wizard/civilwar/wpf/WPF = find_active_faction_by_type(/datum/faction/wizard/civilwar/wpf)
+	if(WPF)
+		if(WPF.get_member_by_mind(wizard_mob.mind))
+			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe/red(wizard_mob), slot_wear_suit)
+			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard/red(wizard_mob), slot_head)
+		else
+			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)
+			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(wizard_mob), slot_head)
+	else
+		wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)
+		wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(wizard_mob), slot_head)
 	if(wizard_mob.backbag == 2)
 		wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(wizard_mob), slot_back)
 	if(wizard_mob.backbag == 3)

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -178,15 +178,18 @@
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe/red(wizard_mob), slot_wear_suit)
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard/red(wizard_mob), slot_head)
 			wizard_mob.add_spell(new /spell/targeted/absorb)
+			var/obj/item/weapon/spellbook/S = new /obj/item/weapon/spellbook(wizard_mob)
 			S.uses = Sp_BASE_PRICE * 3.5
-			S.maxuses = Sp_BASE_PRICE * 3.5
+			S.max_uses = Sp_BASE_PRICE * 3.5
+			wizard_mob.put_in_hands(S)
 		else if(PFW.get_member_by_mind(wizard_mob.mind))  //PFW get blue
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(wizard_mob), slot_head)
 			wizard_mob.add_spell(new /spell/targeted/absorb)
 			var/obj/item/weapon/spellbook/S = new /obj/item/weapon/spellbook(wizard_mob)
 			S.uses = Sp_BASE_PRICE * 3.5
-			S.maxuses = Sp_BASE_PRICE * 3.5
+			S.max_uses = Sp_BASE_PRICE * 3.5
+			wizard_mob.put_in_hands(S)
 		else //An ordinary wizard spawned after the wizwar ruleset was called, this shouldn't happen unless someone forces ragin' mages. Give them normal robes but no absorb spell.
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(wizard_mob), slot_head)

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -178,17 +178,25 @@
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe/red(wizard_mob), slot_wear_suit)
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard/red(wizard_mob), slot_head)
 			wizard_mob.add_spell(new /spell/targeted/absorb)
+			S.uses = Sp_BASE_PRICE * 3.5
+			S.maxuses = Sp_BASE_PRICE * 3.5
 		else if(PFW.get_member_by_mind(wizard_mob.mind))  //PFW get blue
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(wizard_mob), slot_head)
 			wizard_mob.add_spell(new /spell/targeted/absorb)
+			var/obj/item/weapon/spellbook/S = new /obj/item/weapon/spellbook(wizard_mob)
+			S.uses = Sp_BASE_PRICE * 3.5
+			S.maxuses = Sp_BASE_PRICE * 3.5
 		else //An ordinary wizard spawned after the wizwar ruleset was called, this shouldn't happen unless someone forces ragin' mages. Give them normal robes but no absorb spell.
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(wizard_mob), slot_head)
+			if(!apprentice)
+				wizard_mob.put_in_hands(new /obj/item/weapon/spellbook(wizard_mob))
 	else //No wizwar, give them normal robes
 		wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)
 		wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(wizard_mob), slot_head)
-
+		if(!apprentice)
+			wizard_mob.put_in_hands(new /obj/item/weapon/spellbook(wizard_mob))
 	if(wizard_mob.backbag == 2)
 		wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(wizard_mob), slot_back)
 	if(wizard_mob.backbag == 3)
@@ -200,8 +208,6 @@
 //	wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/scrying_gem(wizard_mob), slot_l_store) For scrying gem.
 	var/scroll_type = apprentice ? /obj/item/weapon/teleportation_scroll/apprentice : /obj/item/weapon/teleportation_scroll
 	wizard_mob.equip_to_slot_or_del(new scroll_type(wizard_mob), slot_r_store)
-	if(!apprentice)
-		wizard_mob.put_in_hands(new /obj/item/weapon/spellbook(wizard_mob))
 
 	wizard_mob.make_all_robot_parts_organic()
 

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -172,16 +172,23 @@
 	disable_suit_sensors(wizard_mob)
 	wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(wizard_mob), slot_shoes)
 	var/datum/faction/wizard/civilwar/wpf/WPF = find_active_faction_by_type(/datum/faction/wizard/civilwar/wpf)
-	if(WPF)
-		if(WPF.get_member_by_mind(wizard_mob.mind))
+	var/datum/faction/wizard/civilwar/wpf/PFW = find_active_faction_by_type(/datum/faction/wizard/civilwar/pfw)
+	if(WPF && PFW)  //Are there wizwar factions?
+		if(WPF.get_member_by_mind(wizard_mob.mind))  //WPF get red
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe/red(wizard_mob), slot_wear_suit)
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard/red(wizard_mob), slot_head)
-		else
+			wizard_mob.add_spell(new /spell/targeted/absorb)
+		else if(PFW.get_member_by_mind(wizard_mob.mind))  //PFW get blue
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(wizard_mob), slot_head)
-	else
+			wizard_mob.add_spell(new /spell/targeted/absorb)
+		else //An ordinary wizard spawned after the wizwar ruleset was called, this shouldn't happen unless someone forces ragin' mages. Give them normal robes but no absorb spell.
+			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)
+			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(wizard_mob), slot_head)
+	else //No wizwar, give them normal robes
 		wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)
 		wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(wizard_mob), slot_head)
+
 	if(wizard_mob.backbag == 2)
 		wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(wizard_mob), slot_back)
 	if(wizard_mob.backbag == 3)

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -179,16 +179,16 @@
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard/red(wizard_mob), slot_head)
 			wizard_mob.add_spell(new /spell/targeted/absorb)
 			var/obj/item/weapon/spellbook/S = new /obj/item/weapon/spellbook(wizard_mob)
-			S.uses = Sp_BASE_PRICE * 3.5
-			S.max_uses = Sp_BASE_PRICE * 3.5
+		//	S.uses = Sp_BASE_PRICE * 3.5
+		//	S.max_uses = Sp_BASE_PRICE * 3.5
 			wizard_mob.put_in_hands(S)
 		else if(PFW.get_member_by_mind(wizard_mob.mind))  //PFW get blue
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(wizard_mob), slot_head)
 			wizard_mob.add_spell(new /spell/targeted/absorb)
 			var/obj/item/weapon/spellbook/S = new /obj/item/weapon/spellbook(wizard_mob)
-			S.uses = Sp_BASE_PRICE * 3.5
-			S.max_uses = Sp_BASE_PRICE * 3.5
+		//	S.uses = Sp_BASE_PRICE * 3.5
+		//	S.max_uses = Sp_BASE_PRICE * 3.5
 			wizard_mob.put_in_hands(S)
 		else //An ordinary wizard spawned after the wizwar ruleset was called, this shouldn't happen unless someone forces ragin' mages. Give them normal robes but no absorb spell.
 			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -48,7 +48,8 @@
 			switch(faction.name)
 				if("The Manajerks","The Quickvillains")
 					to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='info'>You are a Space Wizard!</br></span>")
-					to_chat(antag.current, "<span class='danger'>The Wizard Federation is in civil war! You have 7 minutes to leave your den - choose quickly and leave, you MUST NOT fight here. You are part of [faction]. Enemy wizards will not have a visible wizard icon, but friendly wizards will.</br></span>")
+					to_chat(antag.current, "<span class='danger'>The Wizard Federation is in civil war! Plan your strategy in the den and coordinate with your teammate! You are part of [faction]. Enemy wizards will not have a visible wizard icon, but friendly wizards will.</br></span>")
+					to_chat(antag.current, "<span class='danger' style='font-size:22pt'>The den is neutral ground! Do NOT fight here!</br></span>")
 					to_chat(antag.current, "<span class='info'>[faction.desc]</span>")
 				else
 					to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='danger'>You are a Space Wizard!!</br></span>")

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -46,7 +46,7 @@
 			to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> [custom]")
 		if(GREET_MIDROUND)
 			switch(faction.name)
-				if("The Manajerks","The Quickvillains")
+				if("The Wizardly Peoples' Front","The Peoples' Front for Wizards")
 					to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='info'>You are a Space Wizard!</br></span>")
 					to_chat(antag.current, "<span class='danger'>The Wizard Federation is in civil war! Plan your strategy in the den and coordinate with your teammate! You are part of [faction]. Enemy wizards will not have a visible wizard icon, but friendly wizards will.</br></span>")
 					to_chat(antag.current, "<span class='danger' style='font-size:14pt'>The den is neutral ground! Do NOT fight here!</br></span>")

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -49,7 +49,7 @@
 				if("The Manajerks","The Quickvillains")
 					to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='info'>You are a Space Wizard!</br></span>")
 					to_chat(antag.current, "<span class='danger'>The Wizard Federation is in civil war! Plan your strategy in the den and coordinate with your teammate! You are part of [faction]. Enemy wizards will not have a visible wizard icon, but friendly wizards will.</br></span>")
-					to_chat(antag.current, "<span class='danger' style='font-size:22pt'>The den is neutral ground! Do NOT fight here!</br></span>")
+					to_chat(antag.current, "<span class='danger' style='font-size:14pt'>The den is neutral ground! Do NOT fight here!</br></span>")
 					to_chat(antag.current, "<span class='info'>[faction.desc]</span>")
 				else
 					to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='danger'>You are a Space Wizard!!</br></span>")


### PR DESCRIPTION
Civil War of Casters has been a somewhat loathed gamemode. (see #27096) Rather than being a proper "civil war" it usually feels like ragin' mages times four. This PR will hopefully improve on some aspects of the gamemode.

The big changes are as follows:

- Wizards no longer spawn in 8 minute intervals. All four wizards will be at the den roundstart. (Killing enemy wizards at the den has always been haram, so hopefully this doesn't make it a problem). This gives the wizards the opportunity to plan together and taunt the enemy side.
- Wizards now start with a brand new spell: Absorb. This spell can be used on any dead/dying wizard to steal their spells and ash their body, This spell _can_ be used on teammates, if they've fallen during battle. Hopefully the inclusion of this spell will give a good incentive for wizards to fight eachother.
- ~~Wizards now start with **70** spell points in their book, rather than 100.~~
- The Wizardly People's front will start will red robes, rather than the usual blue ones. Regardless of what robes they're wearing though, teammates will always have the hat icon above them. (Just like in ops/cult/revs/ect.)
- ~~The threat level has been raised from 45 to 55.~~

None of these changes apply to normal, not-at-war wizards.

The maps also now have four spawnpoints in the den, so wizards don't start on top of eachother.

Since four wizards are being thrown at the start, I considered creating a command report so the station isn't suddenly met with four wizards destroying everything. Most people dislike ITS [GAMEMODE] announcements though (and for good reason), so I didn't include that.

[tweak]
[balance]
[content]

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
:cl:
 * rscadd: Wizards at war no longer spawn in 8-minute intervals. Instead, they all start at the den together!
 * rscadd: Wizards at war will now start with the absorb spell.
 * tweak: The Wizardly People's Front has begun dressing their members up in red robes, rather than the usual blue ones.
