### PR TITLE
Summon magic gives out a spellbook of absorb

### DIFF
--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -413,6 +413,8 @@
 			new /obj/item/weapon/spellbook/oneuse/pie(get_turf(src))
 		if("ice_barrage")
 			new /obj/item/weapon/spellbook/oneuse/ice_barrage(get_turf(src))
+	new /obj/item/weapon/spellbook/oneuse/absorb(get_turf(src))
+
 	var/datum/role/wizard/summon_magic/S = R
 	if(istype(S))
 		S.summons_received = randomizemagic

--- a/code/modules/spells/targeted/absorb.dm
+++ b/code/modules/spells/targeted/absorb.dm
@@ -50,6 +50,8 @@
 									holderspell.apply_upgrade(Sp_SPEED)
 						*/			hasAbsorbed = TRUE
 						if(canAbsorb)
+							to_chat(target, "<span class='warning'>You feel the magical energy being drained from you!</span>")
+							to_chat(target, "<span class='warning'>You forget how to cast [targetspell.name]!</span>")
 							to_chat(holder, "<span class='notice'>You asborb the magical energies from your foe and have learned [targetspell.name]!</span>")
 							L.attack_log += text("\[[time_stamp()] <font color='orange'>[L.real_name] ([L.ckey]) absorbed the spell [targetspell.name] from [C.real_name] ([C.ckey]).</font>")
 							C.remove_spell(targetspell)

--- a/code/modules/spells/targeted/absorb.dm
+++ b/code/modules/spells/targeted/absorb.dm
@@ -28,8 +28,8 @@
 				to_chat(holder, "<span class='warning'>This being is devoid of any magic.</span>")
 			else if(!C.isDead() && !C.isInCrit())
 				to_chat(holder, "<span class='warning'>Your enemy is still full of life! Kill or maim them!</span>")
-			else if(!iswizard(target))	//Just in case the wizard manages to summon spells for the crew. No fun allowed.
-				to_chat(holder, "<span class='warning'>You can only absorb spells from other Wizards.</span>")
+			else if(isapprentice(target))	//So wizards with absorb don't abuse their own apprentices for double spells
+				to_chat(holder, "<span class='warning'>Only a fool would steal magic from an apprentice.</span>")
 			else
 				var/obj/effect/cult_ritual/feet_portal/P = new (holder.loc, holder, src)
 				if(do_after(holder, target, 5 SECONDS, use_user_turf = TRUE))
@@ -59,7 +59,8 @@
 					if(!hasAbsorbed)
 						to_chat(holder, "<span class='notice'>You find magical energy within your foe, but there is nothing new to learn.</span>")
 					L.visible_message("<span class='sinister'>[L.real_name] absorbs the magical energy from [C.real_name], causing their body to dissolve in a burst of light!</span>")
-					target.dust()
+					if(iswizard(target))	//Wizards aren't wizards without magic! Dust their asses if they're a wizard
+						target.dust()
 				if(P)		//Remove portal effect if the absorbtion is cancelled early.
 					qdel(P)
 

--- a/code/modules/spells/targeted/absorb.dm
+++ b/code/modules/spells/targeted/absorb.dm
@@ -62,7 +62,7 @@
 						to_chat(holder, "<span class='notice'>You find magical energy within your foe, but there is nothing new to learn.</span>")
 					if(iswizard(target))	//Wizards aren't wizards without magic! Dust their asses if they're a wizard
 						target.dust()
-						L.visible_message("<span class='sinister'>[C.rea_name] dissolves in a burst of light!</span>")
+						L.visible_message("<span class='sinister'>[C.real_name] dissolves in a burst of light!</span>")
 				if(P)		//Remove portal effect if the absorbtion is cancelled early.
 					qdel(P)
 

--- a/code/modules/spells/targeted/absorb.dm
+++ b/code/modules/spells/targeted/absorb.dm
@@ -60,9 +60,9 @@
 								hasAbsorbed = TRUE
 					if(!hasAbsorbed)
 						to_chat(holder, "<span class='notice'>You find magical energy within your foe, but there is nothing new to learn.</span>")
-					L.visible_message("<span class='sinister'>[L.real_name] absorbs the magical energy from [C.real_name], causing their body to dissolve in a burst of light!</span>")
 					if(iswizard(target))	//Wizards aren't wizards without magic! Dust their asses if they're a wizard
 						target.dust()
+						L.visible_message("<span class='sinister'>[C.rea_name] dissolves in a burst of light!</span>")
 				if(P)		//Remove portal effect if the absorbtion is cancelled early.
 					qdel(P)
 


### PR DESCRIPTION
While I created absorb with the idea of giving it to wizwar wizards, some people threw around the idea of having it be spawned by summon magic.

This is probably a very bad idea, but here it is anyway.
Previously you could only absorb spells from wizards, but so crewmembers can steal spells from each other the absorb spell now works on non-wizards. Only actual wizards will get ashed however, since the ability to delete other crewmen from the round easily feels lame. Just to clarify, once a spell is absorbed, the victim will not have it anymore.

[gamemode]
[tweak]

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
:cl:
 * rscadd: Summon Magic will now distribute spellbooks of absorb to crewmembers.
