### PR TITLE
Removed rev announcements

### DIFF
--- a/code/datums/gamemode/factions/syndicate/rev.dm
+++ b/code/datums/gamemode/factions/syndicate/rev.dm
@@ -114,40 +114,12 @@
 
 	// -- 2. Are all the heads dead ?
 	for(var/datum/objective/objective in objective_holder.GetObjectives())
-		if(objective.IsFulfilled())
-			remaining_targets--
+		if(!objective.IsFulfilled())
+			return FALSE
 
-	if(stage < FACTION_ENDGAME)
-		var/living_revs = 0
-		var/total_valid_living = 0
-		for (var/mob/living/L in player_list)
-			if (issilicon(L)||isborer(L))
-				continue
-			if (L.stat == DEAD)
-				continue
-			if (isrev(L))
-				living_revs++
-			total_valid_living++
-		var/threshold = 50 //the percentage of living revs at which point the announcement is triggered
-		if(living_revs > 0 && total_valid_living > 0)
-			var/revs_percentage = round((living_revs * 100)/total_valid_living)
-			if(revs_percentage >= threshold && !discovered)
-				for (var/datum/role/revolutionary/leader/comrade in members)
-					to_chat(comrade.antag.current, "<span class='warning'>The time to act is upon us. Nanotrasen must have noticed us by now. Let's waste no time!</span>")
-				discovered = 1
-				spawn(60 SECONDS)
-					stage(FACTION_ENDGAME)
-					command_alert(/datum/command_alert/revolution)
-
-	switch(remaining_targets)
-		if(0)
-			if(stage < FACTION_VICTORY)
-				stage(FACTION_VICTORY)
-				return end(ALL_HEADS_DEAD)
-		if(1)
-			if(stage < FACTION_ENDGAME)
-				stage(FACTION_ENDGAME)
-				command_alert(/datum/command_alert/revolution)
+	if(stage < FACTION_VICTORY)
+		stage(FACTION_VICTORY)
+		return end(ALL_HEADS_DEAD)
 
 /datum/faction/revolution/process()
 	..()

--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -103,12 +103,6 @@
 
 /// REVS
 
-/datum/command_alert/revolution
-	name = "Revolution"
-	alert_title = "Subversive Elements"
-	force_report = 1
-	message = "Subversive Union-aligned elements have been detected aboard the station. According to latest reports, targeted removal of heads of staff is already underway. Loyal crew should take immediate action to secure station against revolutionaries."
-
 /datum/command_alert/revolutiontoppled
 	name = "Revolution Defeated"
 	alert_title = "Order Restored"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3909,11 +3909,6 @@
 						message_admins("[key_name_admin(usr)] triggered a FAKE Carp Migration Alert.")
 						log_admin("[key_name_admin(usr)] triggered a FAKE Carp Migration Alert.")
 						return
-					if("Revs")
-						command_alert(/datum/command_alert/revolution)
-						message_admins("[key_name_admin(usr)] triggered a FAKE revolution alert.")
-						log_admin("[key_name_admin(usr)] triggered a FAKE revolution alert.")
-						return
 					if("Bloodstones raised")
 						command_alert(/datum/command_alert/bloodstones_raised)
 						message_admins("[key_name_admin(usr)] triggered a FAKE Bloodstones Alert (raised).")


### PR DESCRIPTION
### What
Announcements used to be sent whenever only one head of staff was left or whenever a certain percentage of the crew was converted to the revolution. With this change, neither of those things happen anymore.
### Why
Non-revolutionaries are currently not incentivized to keep an eye out for what's going on around them. Security can just sit in the brig doing nothing until the gamer announcement plays. That's assumed to be bad.

:cl:
 * tweak: Announcements are no longer sent whenever revolutionaries kill all heads of staff but one, or convert the majority of the crew.