### PR TITLE
Clone damage is transferred as brute damage upon monkey transformation

### DIFF
--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -71,7 +71,7 @@
 	if(isliving(src))
 		var/mob/living/L = src
 		Mo.suiciding = L.suiciding
-		Mo.take_overall_damage(L.getBruteLoss(), L.getFireLoss())
+		Mo.take_overall_damage(L.getBruteLoss() + L.getCloneLoss(), L.getFireLoss())
 		Mo.setToxLoss(L.getToxLoss())
 		Mo.setOxyLoss(L.getOxyLoss())
 		Mo.stat = L.stat


### PR DESCRIPTION
### Why
Because it's currently possible to eject a clone, monkeify it, humanize it, and have a fully-working human in less than 5 seconds. This makes medbay irrelevant.

:cl:
 * tweak: Transforming a spessman into a monkey now transfers their clone damage to the monkey in the form of brute damage.