### PR TITLE
Cleans up monkeyization and stuff

### DIFF
--- a/code/game/dna/genes/monkey.dm
+++ b/code/game/dna/genes/monkey.dm
@@ -42,8 +42,9 @@
 		animation.icon = 'icons/mob/mob.dmi'
 		animation.master = M
 		var/anim_name = M.get_unmonkey_anim()
+		var/anim_duration = M.get_unmonkey_anim_duration()
 		flick(anim_name, animation)
-		sleep(48)
+		sleep(anim_duration)
 		animation.master = null
 		qdel(animation)
 
@@ -122,3 +123,9 @@
 
 /mob/living/carbon/monkey/get_unmonkey_anim()
 	return unmonkey_anim
+
+/mob/proc/get_unmonkey_anim_duration()
+	return 22
+
+/mob/living/carbon/monkey/get_unmonkey_anim_duration()
+	return unmonkey_anim_duration

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -528,8 +528,9 @@
 	animation.icon = 'icons/mob/mob.dmi'
 	animation.master = src
 	var/anim_name = C.get_unmonkey_anim()
+	var/anim_duration = C.get_unmonkey_anim_duration()
 	flick(anim_name, animation)
-	sleep(48)
+	sleep(anim_duration)
 	qdel(animation)
 	animation = null
 

--- a/code/modules/mob/living/carbon/human/plasmaman/species.dm
+++ b/code/modules/mob/living/carbon/human/plasmaman/species.dm
@@ -34,6 +34,7 @@
 		"eyes" =     /datum/organ/internal/eyes
 	)
 	monkey_anim = "p2monkey"
+	monkey_anim_duration = 18
 
 /datum/species/plasmaman/handle_speech(var/datum/speech/speech, mob/living/carbon/human/H)
 	speech.message = replacetext(speech.message, "s", "s-s") //not using stutter("s") because it likes adding more s's.

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -42,6 +42,7 @@
 	var/alien = 0								//Used for reagent metabolism.
 	var/canPossess = FALSE
 	var/unmonkey_anim = "monkey2h"
+	var/unmonkey_anim_duration = 22 //This should be equal to the frames of the animation!!!
 
 /mob/living/carbon/monkey/New()
 	var/datum/reagents/R = new/datum/reagents(1000)

--- a/code/modules/mob/living/carbon/monkey/skeleton.dm
+++ b/code/modules/mob/living/carbon/monkey/skeleton.dm
@@ -43,3 +43,4 @@
 	light_color = "#FAA019"
 	species_type = /mob/living/carbon/monkey/skellington/plasma
 	unmonkey_anim = "monkey2p"
+	unmonkey_anim_duration = 17

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -143,6 +143,7 @@ var/global/list/whitelisted_species = list("Human")
 
 	var/species_intro //What intro you're given when you become this species.
 	var/monkey_anim = "h2monkey" // Animation from monkeyisation.
+	var/monkey_anim_duration = 22 //Animation duration for monkeyization, THIS SHOULD BE EQUAL TO THE FRAMES IN THE ANIMATION
 
 /datum/species/New()
 	..()

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -1,5 +1,3 @@
-#define MONKEY_ANIM_TIME 22
-
 // A standardized proc for turning a mob into a monkey
 // ignore_primitive will force the mob to specifically become a monkey and not its primitive type
 // returns the monkey mob
@@ -50,9 +48,10 @@
 		animation.icon_state = "blank"
 		animation.icon = 'icons/mob/mob.dmi'
 		animation.master = src
-		var/moneky_anim = get_monkey_anim()
-		flick(moneky_anim, animation)
-		sleep(MONKEY_ANIM_TIME)
+		var/monkey_anim = get_monkey_anim()
+		var/monkey_anim_duration = get_monkey_anim_duration()
+		flick(monkey_anim, animation)
+		sleep(monkey_anim_duration)
 		animation.master = null
 		qdel(animation)
 	var/mob/living/carbon/monkey/Mo
@@ -89,9 +88,17 @@
 /mob/proc/get_monkey_anim()
 	return "h2monkey"
 
+/mob/proc/get_monkey_anim_duration()
+	return 22 //Let's just go with the default of h2monkey
+
 /mob/living/carbon/human/get_monkey_anim()
 	if (species)
 		return species.monkey_anim
+	return ..()
+
+/mob/living/carbon/human/get_monkey_anim_duration()
+	if(species)
+		return species.monkey_anim_duration
 	return ..()
 
 /mob/proc/Cluwneize()

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -373,6 +373,3 @@
 		my_appearance.g_facial = my_appearance.g_hair = 5
 		my_appearance.b_facial = my_appearance.b_hair = 5
 		update_hair() //wie zal dat zijn?
-
-
-#undef MONKEY_ANIM_TIME


### PR DESCRIPTION
There should no longer be a period of time in which someone disappears into the void only to reappear as a human or monkey
Added arbitrary duration checks that SHOULD be as long as the animation lasts

:cl:
 * bugfix: Monkeyized and humanized people should no longer disappear for an invisible delay after the animation ends, and will be able to act as soon as the animation ends.