### PR TITLE
Removed announcement upon rev conversion

### DIFF
--- a/code/datums/gamemode/factions/syndicate/rev.dm
+++ b/code/datums/gamemode/factions/syndicate/rev.dm
@@ -12,7 +12,6 @@
 	initroletype = /datum/role/revolutionary/leader
 	roletype = /datum/role/revolutionary
 	playlist = "nukesquad"
-	var/discovered = 0
 
 /datum/faction/revolution/HandleRecruitedMind(var/datum/mind/M)
 	if(M.assigned_role in command_positions)
@@ -116,28 +115,6 @@
 	for(var/datum/objective/objective in objective_holder.GetObjectives())
 		if(objective.IsFulfilled())
 			remaining_targets--
-
-	if(stage < FACTION_ENDGAME)
-		var/living_revs = 0
-		var/total_valid_living = 0
-		for (var/mob/living/L in player_list)
-			if (issilicon(L)||isborer(L))
-				continue
-			if (L.stat == DEAD)
-				continue
-			if (isrev(L))
-				living_revs++
-			total_valid_living++
-		var/threshold = 50 //the percentage of living revs at which point the announcement is triggered
-		if(living_revs > 0 && total_valid_living > 0)
-			var/revs_percentage = round((living_revs * 100)/total_valid_living)
-			if(revs_percentage >= threshold && !discovered)
-				for (var/datum/role/revolutionary/leader/comrade in members)
-					to_chat(comrade.antag.current, "<span class='warning'>The time to act is upon us. Nanotrasen must have noticed us by now. Let's waste no time!</span>")
-				discovered = 1
-				spawn(60 SECONDS)
-					stage(FACTION_ENDGAME)
-					command_alert(/datum/command_alert/revolution)
 
 	switch(remaining_targets)
 		if(0)


### PR DESCRIPTION
I'll take what I can get
Alternative to #27367
:cl:
 * tweak: Converting 50% of the crew to the revolution will no longer send an announcement about it.