### PR TITLE
Powered Cargo Carts

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -135,7 +135,9 @@ Class Procs:
 	var/custom_aghost_alerts=0
 	var/panel_open = 0
 	var/state = 0 //0 is unanchored, 1 is anchored and unwelded, 2 is anchored and welded for most things
-	var/obj/item/weapon/cell/connected_cell = null
+	
+	var/obj/item/weapon/cell/connected_cell = null 		//The battery connected to this machine
+	var/battery_dependent = 0	//Requires a battery to run
 
 	//These are some values to automatically set the light power/range on machines if they have power
 	var/light_range_on = 0
@@ -378,7 +380,7 @@ Class Procs:
 
 /obj/machinery/Topic(href, href_list)
 	..()
-	if(stat & (NOPOWER|BROKEN))
+	if(stat & (BROKEN|NOPOWER))
 		return 1
 	if(href_list["close"])
 		return

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -135,6 +135,7 @@ Class Procs:
 	var/custom_aghost_alerts=0
 	var/panel_open = 0
 	var/state = 0 //0 is unanchored, 1 is anchored and unwelded, 2 is anchored and welded for most things
+	var/obj/item/weapon/cell/connected_cell = null
 
 	//These are some values to automatically set the light power/range on machines if they have power
 	var/light_range_on = 0
@@ -242,7 +243,7 @@ Class Procs:
 		qdel(src)
 
 /obj/machinery/proc/auto_use_power()
-	if(!powered(power_channel))
+	if(!powered(power_channel) && !connected_cell)
 		return 0
 
 	switch (use_power)

--- a/code/game/objects/structures/vehicles/carts/cargo.dm
+++ b/code/game/objects/structures/vehicles/carts/cargo.dm
@@ -4,11 +4,55 @@
 /obj/machinery/cart/cargo
 	name = "cargo cart"
 	desc = "A cart for transporting crates. Designed to attach to a tractor."
+	var/obj/item/weapon/cell/internal_battery = null
+	var/enabled = 0
+	var/maintenance = 0
+	var/obj/machinery/loaded_machine = null
 
 /obj/machinery/cart/cargo/toboggan
 	name = "toboggan"
 	desc = "A toboggan designed to transport crates and injured crewmen through the snow. Designed to attach to a snowmobile."
 	icon_state = "toboggan"
+
+/obj/machinery/cart/cargo/get_cell()
+	return internal_battery
+
+/obj/machinery/cart/cargo/examine(mob/user)
+	..()
+	if(internal_battery)
+		to_chat(user, "<span class='info'>The battery meter reads: [round(internal_battery.percent(),1)]%</span>")
+	else
+		to_chat(user, "<span class='warning'>There is no battery inserted.</span>")
+
+
+/obj/machinery/cart/cargo/attack_hand(mob/user)
+	if(ishuman(user))
+		if(enabled)
+			to_chat(user, "<span class='notice'>You turn the cart off.</span>")
+			enabled = !enabled
+		else
+			to_chat(user, "<span class='notice'>You turn the cart on.</span>")
+			enabled = !enabled
+
+/obj/machinery/cart/cargo/attackby(obj/item/weapon/W as obj, mob/user)
+	if(W.is_screwdriver(user))
+		user.visible_message("<span class='notice'>[user] screws [maintenance ? "closed" : "open"] \the [src]'s battery compartment.</span>", "<span class='notice'>You screw [maintenance ? "closed" : "open"] the battery compartment.</span>", "You hear screws being loosened.")
+		maintenance = !maintenance
+	else if(iscrowbar(W)&&maintenance)
+		if(internal_battery)
+			user.put_in_hands(internal_battery)
+			internal_battery = null
+			if(loaded_machine)
+				loaded_machine.connected_cell = null
+		user.visible_message("<span class='notice'>[user] pries out \the [src]'s battery.</span>", "<span class='notice'>You pry out \the [src]'s battery.</span>", "You hear a clunk.")
+	else if(istype(W,/obj/item/weapon/cell)&&maintenance&&!internal_battery)
+		if(user.drop_item(W,src))
+			internal_battery = W
+			user.visible_message("<span class='notice'>[user] inserts \the [W] into the \the [src].</span>", "<span class='notice'>You insert \the [W] into \the [src].</span>", "You hear something being slid into place.")
+			if(loaded_machine)
+				loaded_machine.connected_cell = internal_battery
+	else
+		..()
 
 /obj/machinery/cart/cargo/relaymove(mob/user)
 	unload()
@@ -28,7 +72,7 @@
 		return
 	if(is_locking(/datum/locking_category/cargocart) || istype(C, /obj/machinery/cart/))
 		return
-
+	
 	load(C)
 
 /obj/machinery/cart/cargo/MouseDropFrom(obj/over_object as obj, src_location, over_location)
@@ -58,6 +102,12 @@
 	if(istype(C,/obj/structure/closet/crate))
 		var/obj/structure/closet/crate/crate = C
 		crate.close()
+	
+	if(istype(C, /obj/machinery))
+		loaded_machine = C
+		if(internal_battery)
+			loaded_machine.connected_cell = internal_battery
+		loaded_machine.state = 1
 
 	lock_atom(C, /datum/locking_category/cargocart)
 	return TRUE
@@ -69,6 +119,12 @@
 	var/atom/movable/load = get_locked(/datum/locking_category/cargocart)[1]
 	unlock_atom(load)
 
+	if(istype(load, /obj/machinery))
+		if(internal_battery && loaded_machine)
+			loaded_machine.connected_cell = null
+		loaded_machine.state = 0
+		loaded_machine = null
+
 	if(dirn)
 		var/turf/T = src.loc
 		T = get_step(T,dirn)
@@ -78,7 +134,8 @@
 			load.forceMove(src.loc)
 
 	for(var/atom/movable/AM in src)
-		AM.forceMove(src.loc)
+		if(AM != internal_battery)
+			AM.forceMove(src.loc)
 
 /obj/machinery/cart/cargo/lock_atom(var/atom/movable/AM, var/datum/locking_category/category)
 	. = ..()

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -142,7 +142,7 @@
 /obj/machinery/proc/use_power(amount, chan = power_channel)
 	var/area/this_area = get_area(src)
 	if(connected_cell && connected_cell.charge > 0)   //If theres a cell directly providing power use it, only for cargo carts at the moment
-		if(connected_cell.charge < amount*0.75))	//Let them squeeze the last bit of power out.
+		if(connected_cell.charge < amount*0.75)	//Let them squeeze the last bit of power out.
 			connected_cell.charge = 0
 		else
 			connected_cell.use(amount*0.75)				

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -116,6 +116,15 @@
 /obj/machinery/proc/powered(chan = power_channel)
 	if(!src.loc)
 		return 0
+		
+	if(battery_dependent && !connected_cell)
+		return 0
+
+	if(connected_cell)
+		if(connected_cell.charge > 0)
+			return 1
+		else
+			return 0
 
 	if(!use_power)
 		return 1
@@ -132,8 +141,11 @@
 // defaults to power_channel
 /obj/machinery/proc/use_power(amount, chan = power_channel)
 	var/area/this_area = get_area(src)
-	if(connected_cell)   //If theres a cell directly providing power use it, only for cargo carts at the moment
-		connected_cell.use(amount)
+	if(connected_cell && connected_cell.charge > 0)   //If theres a cell directly providing power use it, only for cargo carts at the moment
+		if(connected_cell.charge < amount*.75)	//Let them squeeze the last bit of power out.
+			connected_cell.charge = 0
+		else
+			connected_cell.use(amount*.75)				
 	else
 		if(!this_area)
 			return 0						// if not, then not powered.

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -132,13 +132,15 @@
 // defaults to power_channel
 /obj/machinery/proc/use_power(amount, chan = power_channel)
 	var/area/this_area = get_area(src)
-	if(!this_area)
-		return 0						// if not, then not powered.
+	if(connected_cell)   //If theres a cell directly providing power use it, only for cargo carts at the moment
+		connected_cell.use(amount)
+	else
+		if(!this_area)
+			return 0						// if not, then not powered.
+		if(!powered(chan)) //no point in trying if we don't have power
+			return 0
 
-	if(!powered(chan)) //no point in trying if we don't have power
-		return 0
-
-	this_area.use_power(amount, chan)
+		this_area.use_power(amount, chan)
 
 // called whenever the power settings of the containing area change
 // by default, check equipment channel & set flag

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -142,10 +142,10 @@
 /obj/machinery/proc/use_power(amount, chan = power_channel)
 	var/area/this_area = get_area(src)
 	if(connected_cell && connected_cell.charge > 0)   //If theres a cell directly providing power use it, only for cargo carts at the moment
-		if(connected_cell.charge < amount*.75)	//Let them squeeze the last bit of power out.
+		if(connected_cell.charge < amount*0.75))	//Let them squeeze the last bit of power out.
 			connected_cell.charge = 0
 		else
-			connected_cell.use(amount*.75)				
+			connected_cell.use(amount*0.75)				
 	else
 		if(!this_area)
 			return 0						// if not, then not powered.


### PR DESCRIPTION
Created to address #26735 and #26696

Cargo carts being able to move anchored machines with no cost was broken, albeit fun for many. This PR brings it back but with a few changes.

- Each individual cargo cart now has a slot for a power cell. The cell can be inserted/removed the usual way (screwdriver open, put in cell, or pry out cell with crowbar).
- If there is a power cell inserted into the cargo cart, the machine will be able to function while loaded on top of it. Power will be drawn from the power cell instead of the APC. If the power cell runs out of charge, the machine will shut down. If the machine does not require power then it will work regardless of whether or not the cart has a cell.
- Cargo carts now have a blacklist of certain machines that won't function on top of cargo carts, even with a cell. The only thing on this list currently is the atmospherics miners.

This PR also adds connected_cell and battery_dependent variables to the obj/machinery parent, in case battery-powered machines become a thing later on.

Anchored objects can't be loaded onto carts, you need to un-anchor it before loading it onto the cart.

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
:cl:
 * rscadd: Machines will now function on top of cargo-carts again, so long as the cart has a power cell installed.

