### PR TITLE
Fixes Mining Rig Suit Storage

### DIFF
--- a/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
+++ b/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
@@ -61,6 +61,13 @@
 	pressure_resistance = 40 * ONE_ATMOSPHERE
 	clothing_flags = GOLIATHREINFORCE
 	head_type = /obj/item/clothing/head/helmet/space/rig/mining
+	allowed = list(
+		/obj/item/device/flashlight,
+		/obj/item/weapon/tank,
+		/obj/item/weapon/storage/bag/ore,
+		/obj/item/device/mining_scanner,
+		/obj/item/weapon/pickaxe,
+		/obj/item/weapon/gun/energy/kinetic_accelerator)
 
 //Syndicate rig
 /obj/item/clothing/head/helmet/space/rig/syndi


### PR DESCRIPTION
[bugfix] Fixes something from #26767 that made mining rigsuits lose their suit storage allowed list. Mining rigsuits can now hold: 
```
/obj/item/device/flashlight,
/obj/item/weapon/tank,
/obj/item/weapon/storage/bag/ore,
/obj/item/device/mining_scanner,
/obj/item/weapon/pickaxe,
/obj/item/weapon/gun/energy/kinetic_accelerator
```

:cl:
 * bugfix: Mining rigsuits can hold mining items in their suit storage slot again.