### PR TITLE
Unfinished Clones Have Organ Problems

### DIFF
--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -441,7 +441,7 @@
 	var/mob/living/carbon/human/H = occupant
 	while(hits>0)
 		if (hits>=4)
-			qdel(pick(H.internal_organs - H.internal_organs["brain"]))
+			qdel(pick(H.internal_organs - H.internal_organs_by_name["brain"]))
 			hits -= 4
 		else
 			H.organs_by_name[pick(H.organs_by_name)].droplimb(override = 1, no_explode = 1, spawn_limb = 1, display_message = FALSE)

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -443,7 +443,7 @@
 		if (hits>=4)
 			qdel(pick(H.internal_organs - H.internal_organs_by_name["brain"]))
 			hits -= 4
-		else
+		else //if this pick lands on either torso part, those can't be droplimb'd. Get out of jail free, I guess
 			H.organs_by_name[pick(H.organs_by_name)].droplimb(override = 1, no_explode = 1, spawn_limb = 1, display_message = FALSE)
 			hits--
 

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -441,7 +441,7 @@
 	var/mob/living/carbon/human/H = occupant
 	while(hits>0)
 		if (hits>=4)
-			qdel(pick(H.internal_organs - H.internal_organs["heart"]))
+			qdel(pick(H.internal_organs - H.internal_organs["brain"]))
 			hits -= 4
 		else
 			H.organs_by_name[pick(H.organs_by_name)].droplimb(override = 1, no_explode = 1, spawn_limb = 1, display_message = FALSE)

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -429,6 +429,25 @@
 	occupant.forceMove(exit)
 	icon_state = "pod_0"
 	eject_wait = FALSE //If it's still set somehow.
+	//do early ejection damage
+	var/completion = 10*((occupant.health + 100) / (heal_level + 100)) //same way completion is calculated for examine text, but out of 10 instead of 100
+	var/damage_rolls = 10 - round(completion) - (round(resource_efficiency) - 1) // 1 roll for each 10% missing, each improved pair of manipulators reduces one roll
+	var/hits = 0
+	while(damage_rolls > 0)
+		if(prob(25))//each roll has a 25% chance to give the occupant a bad time
+			hits++
+		damage_rolls--
+	//apply the damage
+	var/mob/living/carbon/human/H = occupant
+	while(hits>0)
+		if (hits>=4)
+			H.organs_by_name[pick(H.organs_by_name)].droplimb(override = 1, no_explode = 1, spawn_limb = 0, display_message = FALSE)
+			hits -= 4
+		else
+			pick(H.internal_organs).Destroy()
+			hits--
+	occupant.updatehealth()
+
 	domutcheck(occupant) //Waiting until they're out before possible monkeyizing.
 	occupant.add_side_effect("Bad Stomach") // Give them an extra side-effect for free.
 	occupant = null

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -441,11 +441,12 @@
 	var/mob/living/carbon/human/H = occupant
 	while(hits>0)
 		if (hits>=4)
-			H.organs_by_name[pick(H.organs_by_name)].droplimb(override = 1, no_explode = 1, spawn_limb = 0, display_message = FALSE)
+			qdel(pick(H.internal_organs - H.internal_organs["heart"]))
 			hits -= 4
 		else
-			pick(H.internal_organs).Destroy()
+			H.organs_by_name[pick(H.organs_by_name)].droplimb(override = 1, no_explode = 1, spawn_limb = 1, display_message = FALSE)
 			hits--
+
 	occupant.updatehealth()
 
 	domutcheck(occupant) //Waiting until they're out before possible monkeyizing.


### PR DESCRIPTION
This is the patch I promised to write in my comment to #27341 . Here is the algorithm for those interested:

1. For each 10% (rounded up) missing progress, you have a 25% chance to have something in your body fucked up
1a. If the cloner's manipulators have been upgraded, you get a risk-free 10% per tier
2.  For each chance that hits, you lose an external organ. If you accumulated four or more 'hits' you lose an internal organ, besides your brain, instead (and that loss counts for those 4 hits)
2a. External organs will be spit out with you, for 'easy' reattachment

Tested and working, but I would encourage other people to check out the branch of my repo and play around with it to see if it is too punishing or not.


[discussion]
[controversial]
[tweak]
:cl:
 * rscadd: Ejecting clones early can be quite bad for their health!