### PR TITLE
Fixed PathNode runtime

### DIFF
--- a/code/defines/procs/AStar.dm
+++ b/code/defines/procs/AStar.dm
@@ -138,8 +138,8 @@ length to avoid portals or something i guess?? Not that they're counted right no
 	total_node_cost = distance_from_start + distance_from_end
 
 /PathNode/Destroy()
-	source.PathNodes[id] = null
-	source.PathNodes.Remove(id)
+	if(source.PathNodes)
+		source.PathNodes -= id
 	source = null
 	prevNode = null
 	..()


### PR DESCRIPTION
@ShiftyRail I have no idea what this does, but this seems correct
```
[01:55:17] Runtime in AStar.dm, line 141: bad index
proc name: Destroy (/PathNode/Destroy)
usr: Anaya Wallick (damianq) (/mob/living/carbon/human)
usr.loc: The floor (226, 253, 1) (/turf/simulated/floor)
src: /PathNode (/PathNode)
call stack:
/PathNode (/PathNode): Destroy()
qdel(/PathNode (/PathNode))
/datum/path_maker (/datum/path_maker): Destroy()
qdel(/datum/path_maker (/datum/path_maker))
Officer Beepsky (/obj/machinery/bot/secbot/beepsky): Destroy()
Officer Beepsky (/obj/machinery/bot/secbot/beepsky): Destroy()
qdel(Officer Beepsky (/obj/machinery/bot/secbot/beepsky))
Officer Beepsky (/obj/machinery/bot/secbot/beepsky): explode()
Officer Beepsky (/obj/machinery/bot/secbot/beepsky): ex act(1)
explosion(the floor (226,253,1) (/turf/simulated/floor), 3, 5, 7, 5, 1, 0, 1)
```