### PR TITLE
More outfit datums fixes

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -55,8 +55,9 @@
 	// the world.time since the mob has been brigged, or -1 if not at all
 	var/brigged_since = -1
 
-		//put this here for easier tracking ingame
+	//put this here for easier tracking ingame
 	var/datum/money_account/initial_account
+	var/initial_wallet_funds = 0
 
 	var/total_TC = 0
 	var/spent_TC = 0

--- a/code/datums/outfit/civilian.dm
+++ b/code/datums/outfit/civilian.dm
@@ -243,7 +243,8 @@
 
 /datum/outfit/hydro/post_equip(var/mob/living/carbon/human/H)
 	H.put_in_hands(new /obj/item/weapon/storage/bag/plasticbag(H))
-	H.mind.store_memory("Frequencies list: <br/> <b>Service:</b> [SER_FREQ]<br/>")
+	if (!H.mind)
+		H.mind.store_memory("Frequencies list: <br/> <b>Service:</b> [SER_FREQ]<br/>")
 
 // -- Clown
 
@@ -383,8 +384,9 @@
 /datum/outfit/mime/post_equip(var/mob/living/carbon/human/H)
 	H.add_spell(new /spell/aoe_turf/conjure/forcewall/mime, "grey_spell_ready")
 	H.add_spell(new /spell/targeted/oathbreak/)
-	H.mind.miming = MIMING_OUT_OF_CHOICE
 	mob_rename_self(H,"mime")
+	if (H.mind)
+		H.mind.miming = MIMING_OUT_OF_CHOICE
 	return 1
 
 // -- Janitor
@@ -604,6 +606,8 @@
 
 /datum/outfit/lawyer/post_equip(var/mob/living/carbon/human/H)
 	H.put_in_hands(new /obj/item/weapon/storage/briefcase/centcomm(H))
+	if (!H.mind)
+		return
 	H.mind.store_memory("Frequencies list: <br/><b>Command:</b> [COMM_FREQ] <br/> <b>Security:</b> [SEC_FREQ] <br/>")
 
 // -- Chaplain

--- a/code/datums/outfit/civilian.dm
+++ b/code/datums/outfit/civilian.dm
@@ -244,7 +244,8 @@
 /datum/outfit/hydro/post_equip(var/mob/living/carbon/human/H)
 	H.put_in_hands(new /obj/item/weapon/storage/bag/plasticbag(H))
 	if (!H.mind)
-		H.mind.store_memory("Frequencies list: <br/> <b>Service:</b> [SER_FREQ]<br/>")
+		return
+	H.mind.store_memory("Frequencies list: <br/> <b>Service:</b> [SER_FREQ]<br/>")
 
 // -- Clown
 

--- a/code/datums/outfit/engineering.dm
+++ b/code/datums/outfit/engineering.dm
@@ -45,7 +45,7 @@
 	)
 
 	equip_survival_gear = list(
-		"Default" = /obj/item/weapon/storage/box/survival/engineer,
+		/datum/species/human = /obj/item/weapon/storage/box/survival/engineer,
 		/datum/species/plasmaman = /obj/item/weapon/storage/box/survival/engineer,
 		/datum/species/diona = /obj/item/weapon/storage/box/survival/engineer,
 		/datum/species/insectoid = /obj/item/weapon/storage/box/survival/engineer,
@@ -124,7 +124,7 @@
 	)
 
 	equip_survival_gear = list(
-		"Default" = /obj/item/weapon/storage/box/survival/engineer,
+		/datum/species/human = /obj/item/weapon/storage/box/survival/engineer,
 		/datum/species/plasmaman = /obj/item/weapon/storage/box/survival/engineer,
 		/datum/species/diona = /obj/item/weapon/storage/box/survival/engineer,
 		/datum/species/insectoid = /obj/item/weapon/storage/box/survival/engineer,
@@ -237,7 +237,7 @@
 	)
 
 	equip_survival_gear = list(
-		"Default" = /obj/item/weapon/storage/box/survival/engineer,
+		/datum/species/human = /obj/item/weapon/storage/box/survival/engineer,
 		/datum/species/plasmaman = /obj/item/weapon/storage/box/survival/engineer,
 		/datum/species/diona = /obj/item/weapon/storage/box/survival/engineer,
 		/datum/species/insectoid = /obj/item/weapon/storage/box/survival/engineer,

--- a/code/datums/outfit/medical.dm
+++ b/code/datums/outfit/medical.dm
@@ -258,7 +258,7 @@
 	)
 
 	equip_survival_gear = list(
-		"Default" = /obj/item/weapon/storage/box/survival/engineer,
+		/datum/species/human = /obj/item/weapon/storage/box/survival/engineer,
 		/datum/species/plasmaman = /obj/item/weapon/storage/box/survival/engineer,
 		/datum/species/diona = /obj/item/weapon/storage/box/survival/engineer,
 		/datum/species/insectoid = /obj/item/weapon/storage/box/survival/engineer,

--- a/code/datums/outfit/outfit.dm
+++ b/code/datums/outfit/outfit.dm
@@ -20,8 +20,10 @@
 	PROCS :
 	-- "Static" procs
 		- equip(var/mob/living/carbon/human/H): tries to equip everything on the list to the relevant slots. This is the "master proc".
+		- equip_items(var/list/L, var/mob/living/carbon/human/H, var/species): equips the items in the list L to the human H of the given species.
 		- equip_backbag(var/mob/living/carbon/human/H): equip the backbag with the correct pref, and tries to put items in it if possible.
-		- pre_equip_disabilities(var/mob/living/carbon/human/H, var/list/items_to_equip) : changes items based on disabilities registered
+		- pre_equip_disabilities(var/mob/living/carbon/human/H, var/list/items_to_equip): changes items based on disabilities registered
+		- give_implants(var/mob/living/carbon/human/H): automatically implants the guy with the implants in the list.
 		- give_disabilities_equipment(var/mob/living/carbon/human/H): give the correct equipement for the disabilities the mob has, in the correct slots.
 
 	-- Procs you can override
@@ -29,7 +31,6 @@
 		- post_equip(var/mob/living/carbon/human/H): after the mob is fully dressed.
 		- spawn_id(var/mob/living/carbon/human/H, rank): give an ID to the mob. Overriden by striketeams.
 		- species_final_equip(var/mob/living/carbon/human/H): give internals/a tank to species as needed.
-
 		- special_equip(var/title, var/slot, var/mob/living/carbon/human/H): for the more exotic item slots.
 */
 
@@ -62,7 +63,7 @@
 	var/pda_type = null
 	var/id_type = null
 
-	// For job-slot combinations that require a bit more work than just equipping a string
+	// For job-slot combinations that require a bit more work than just equipping an item at a given slot
 	// Formatting  :
 	/*
 		special_snowflakes = list(
@@ -79,10 +80,33 @@
 /datum/outfit/New()
 	return
 
+// -- Equip mindless: if we're going to give the outfit to a mob without a mind
+/datum/outfit/proc/equip(var/mob/living/carbon/human/H, var/equip_mindless = FALSE)
+	if (!H || (!H.mind && !equip_mindless) )
+		return
 
+	pre_equip(H)
+	var/species = H.species.type
+	var/list/L = items_to_spawn[species]
+	if (!L) // Couldn't find the particular species
+		species = "Default"
+		L = items_to_spawn["Default"]
+
+	pre_equip_disabilities(H, L)
+	equip_items(L, H, species)
+	equip_backbag(H, species)
+	give_implants(H)
+	species_final_equip(H)
+	spawn_id(H)
+	post_equip(H) // Accessories, IDs, etc.
+	give_disabilities_equipment(H)
+	H.update_icons()
+
+// -- Modify mob or loadout before giving items
 /datum/outfit/proc/pre_equip(var/mob/living/carbon/human/H)
 	return
 
+// -- Handle disabilities
 /datum/outfit/proc/pre_equip_disabilities(var/mob/living/carbon/human/H, var/list/items_to_equip)
 	if (H.client?.IsByondMember())
 		to_chat(H, "Thank you for supporting BYOND!")
@@ -95,19 +119,8 @@
 	if (!items_to_equip[slot_glasses_str] && (H.disabilities & NEARSIGHTED))
 		items_to_equip[slot_glasses_str] = /obj/item/clothing/glasses/regular
 
-// -- Equip mindless: if we're going to give the outfit to a mob without a mind
-/datum/outfit/proc/equip(var/mob/living/carbon/human/H, var/equip_mindless = FALSE)
-	if (!H || (!H.mind && !equip_mindless) )
-		return
-
-	pre_equip(H)
-	var/species = H.species.type
-	var/list/L = items_to_spawn[species]
-	if (!L) // Couldn't find the particular species
-		species = "Default"
-		L = items_to_spawn["Default"]
-	pre_equip_disabilities(H, L)
-
+// Spawning the actual items contained in L
+/datum/outfit/proc/equip_items(var/list/L, var/mob/living/carbon/human/H, var/species)
 	for (var/slot in L)
 
 		var/list/snowflake_items = special_snowflakes[species]
@@ -130,22 +143,7 @@
 		slot = text2num(slot)
 		H.equip_to_slot_or_del(new obj_type(get_turf(H)), slot, TRUE)
 
-	equip_backbag(H, species)
-
-	for (var/imp_type in implant_types)
-		var/obj/item/weapon/implant/I = new imp_type(H)
-		I.imp_in = H
-		I.implanted = 1
-		var/datum/organ/external/affected = H.get_organ(LIMB_HEAD) // By default, all implants go to the head.
-		affected.implants += I
-		I.part = affected
-
-	species_final_equip(H)
-	spawn_id(H)
-	post_equip(H) // Accessories, IDs, etc.
-	give_disabilities_equipment(H)
-	H.update_icons()
-
+// -- Give out backbag and items to be collected in the backpack
 /datum/outfit/proc/equip_backbag(var/mob/living/carbon/human/H, var/species)
 	// -- Backbag
 	var/obj/item/chosen_backpack = null
@@ -164,11 +162,13 @@
 		H.equip_to_slot_or_del(new chosen_backpack(H), slot_back, 1)
 		for (var/item_type in items_to_collect)
 			H.equip_or_collect(new item_type(H.back), slot_in_backpack)
+		// -- Special surival gear for that species
 		if (equip_survival_gear.len)
-			if (ispath(equip_survival_gear[species]))
-				var/path = equip_survival_gear[species]
+			var/my_species = H.species.type // This temporary var is necessary.
+			if (ispath(equip_survival_gear[my_species]))
+				var/path = equip_survival_gear[my_species]
 				H.equip_or_collect(new path(H.back), slot_in_backpack)
-		else if (equip_survival_gear) //
+		else if (equip_survival_gear) // -- No special path, but the outfit still needs to give out a surival box => we give out the default one
 			H.equip_or_collect(new H.species.survival_gear(H.back), slot_in_backpack)
 
 		// Special alt-title items
@@ -208,10 +208,22 @@
 				var/chosen_slot = special_items[item_type]
 				H.equip_to_slot_if_possible(new item_type(get_turf(H)), chosen_slot)
 
+// -- Implant the dude
+/datum/outfit/proc/give_implants(var/mob/living/carbon/human/H)
+	for (var/imp_type in implant_types)
+		var/obj/item/weapon/implant/I = new imp_type(H)
+		I.imp_in = H
+		I.implanted = 1
+		var/datum/organ/external/affected = H.get_organ(LIMB_HEAD) // By default, all implants go to the head.
+		affected.implants += I
+		I.part = affected
+
+// -- Species-related equip (turning on internals, etc)
 /datum/outfit/proc/species_final_equip(var/mob/living/carbon/human/H)
 	if (H.species)
 		H.species.final_equip(H)
 
+// -- Spawn correct ID and PDA
 /datum/outfit/proc/spawn_id(var/mob/living/carbon/human/H, rank)
 	if (!associated_job)
 		CRASH("Outfit [outfit_name] has no associated job, and the proc to spawn the ID is not overriden.")
@@ -226,6 +238,8 @@
 	C.name = "[C.registered_name]'s ID Card ([C.assignment])"
 	C.associated_account_number = H?.mind?.initial_account?.account_number
 	H.equip_or_collect(C, slot_wear_id)
+	if(C.virtual_wallet && H.mind)
+		C.update_virtual_wallet(H.mind.initial_wallet_funds)
 
 	if (pda_type)
 		var/obj/item/device/pda/pda = new pda_type(H)
@@ -234,18 +248,16 @@
 		pda.name = "PDA-[H.real_name] ([pda.ownjob])"
 		H.equip_or_collect(pda, pda_slot)
 
-
+// -- Things to do AFTER all the equipment is given (ex: accessories)
 /datum/outfit/proc/post_equip(var/mob/living/carbon/human/H)
 	return // Empty
 
-// Special snowflakes.
-/datum/outfit/proc/special_equip(var/title, var/slot, var/mob/living/carbon/human/H)
-	return
-
+// -- Final disabilities things, after all is given
 /datum/outfit/proc/give_disabilities_equipment(var/mob/living/carbon/human/H)
 	if (!give_disabilities_equipment)
 		return
 
+	// -- Automatically giving out a wheelchair if the guy can't stand
 	if(!H.check_stand_ability())
 		var/obj/structure/bed/chair/vehicle/wheelchair/W = new(H.loc)
 		W.buckle_mob(H,H)
@@ -255,6 +267,10 @@
 		G.prescription = 1
 
 	return 1
+
+// Special snowflakes : handle special cases for a given title and a given slot
+/datum/outfit/proc/special_equip(var/title, var/slot, var/mob/living/carbon/human/H)
+	return
 
 // Strike teams have 2 particularities : a leader, and several specialised roles.
 // Give the concrete (instancied) outfit datum the right "specialisation" after the player made his choice.

--- a/code/datums/outfit/security.dm
+++ b/code/datums/outfit/security.dm
@@ -262,7 +262,7 @@
 			slot_shoes_str = /obj/item/clothing/shoes/jackboots,
 			slot_gloves_str = /obj/item/clothing/gloves/black,
 			slot_glasses_str = /obj/item/clothing/glasses/sunglasses/sechud,
-			slot_wear_suit_str = /obj/item/clothing/suit/armor,
+			slot_wear_suit_str = /obj/item/clothing/suit/armor/vest/security,
 			slot_s_store_str = /obj/item/weapon/gun/energy/taser,
 			slot_l_store_str = /obj/item/device/flash,
 		),
@@ -305,6 +305,6 @@
 	id_type = /obj/item/weapon/card/id/security
 
 /datum/outfit/officer/post_equip(var/mob/living/carbon/human/H)
-	if (H.mind)
+	if (!H.mind)
 		return
 	H.mind.store_memory("Frequencies list: <b>Security:</b> [SEC_FREQ]<br/>")

--- a/code/datums/outfit/trader.dm
+++ b/code/datums/outfit/trader.dm
@@ -18,8 +18,8 @@
 			slot_w_uniform_str =/obj/item/clothing/under/vox/vox_robes,
 			slot_shoes_str = /obj/item/clothing/shoes/magboots/vox,
 			slot_belt_str = /obj/item/device/radio,
-			slot_wear_suit_str = /obj/item/clothing/suit/space/vox/civ,
-			slot_head_str = /obj/item/clothing/head/helmet/space/vox/civ,
+			slot_wear_suit_str = /obj/item/clothing/suit/space/vox/civ/trader,
+			slot_head_str = /obj/item/clothing/head/helmet/space/vox/civ/trader,
 			slot_wear_mask_str =  /obj/item/clothing/mask/breath,
 		),
 		/datum/species/mushroom = list(
@@ -41,7 +41,7 @@
 	id_type = /obj/item/weapon/card/id/vox
 
 /datum/outfit/trader/pre_equip(var/mob/living/carbon/human/H)
-	if (H.mind)
+	if (!H.mind)
 		return
 	switch(H.mind.role_alt_title) // Add to the survival box in case we don't have a backbag.
 		if("Trader") //Traders get snacks and a coin

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -414,12 +414,11 @@ var/global/datum/controller/occupations/job_master
 		if(istype(S, /obj/effect/landmark/start) && istype(S.loc, /turf))
 			H.forceMove(S.loc)
 
-	var/balance_wallet = 0
 	if(job && !job.no_starting_money)
 		//give them an account in the station database
 		// Total between $200 and $500
 		var/balance_bank = rand(100,250)
-		balance_wallet = rand(100,250)
+		var/balance_wallet = rand(100,250)
 		var/bank_pref_number = H.client.prefs.bank_security
 		var/bank_pref = bank_security_num2text(bank_pref_number)
 		if(centcomm_account_db)
@@ -438,6 +437,7 @@ var/global/datum/controller/occupations/job_master
 				H.mind.store_memory(remembered_info)
 
 				H.mind.initial_account = M
+				H.mind.initial_wallet_funds = balance_wallet
 
 			// If they're head, give them the account info for their department
 			if(H.mind && job.head_position)


### PR DESCRIPTION
Bugs:

- Fixes typos/oversights preventing proper `pre_equip/post_equip` calls (closes #27455)
- Fixes security armour being invisible (closes #27454)
- Fixes roundstart wallets being empty (closes #27450)

Improvments

- More documentation/comments
- Made an `equip_items` and `give_implants` procs to improve readability of the code
- `equip_survival_gear` now correctly says `/datum/species/human` instead of `"Default"`, which only ever worked for humans.