### PR TITLE
Fixes some jukebox lag

### DIFF
--- a/code/modules/media/mediamanager.dm
+++ b/code/modules/media/mediamanager.dm
@@ -265,6 +265,9 @@ function SetMusic(url, time, volume) {
 		targetURL = M.media_url
 		targetStartTime = M.media_start_time
 		targetVolume = M.volume
+		if ((current_url == targetURL) && (volume == targetVolume) && (start_time == targetStartTime))
+			MP_DEBUG("<span class='good'>No cut off because there we're still hearing the same song.<span>")
+			return
 		var/check_samesong = ((targetURL == current_url) && (finish_time != M.media_finish_time))
 		var/check_harsh_skip = ((targetURL != current_url) && (finish_time > 0) && ((world.time - finish_time) < - 10 SECONDS))
 		if (check_samesong || check_harsh_skip) // We caught a music. Let's see if we can make a graceful fadeout for the music currently playing. If not, the other music is killed.


### PR DESCRIPTION
Barry was ranting nonsensically about things, including the juke, that he thought were laggy and dumb
This removes (some) client lag when switching between two areas with the same broadcasted song, and marginally decreases the juke's footprint on server performance