### PR TITLE
Enables emoji in OOC and allows any typepath to be used as an emoji

### DIFF
--- a/code/game/objects/items/devices/PDA/emoji.dm
+++ b/code/game/objects/items/devices/PDA/emoji.dm
@@ -22,8 +22,21 @@
 	"sunglasses"
 )
 
-/proc/parse_emoji(input_text)
+/proc/parse_emoji(input_text, var/ooc_mode = FALSE)
 	var/parsed = input_text
 	for(var/emoji in emoji_list)
 		parsed = replacetext(parsed, ":" + emoji + ":", "<img src='emoji-[emoji].png'>")
+
+	if(ooc_mode)
+		//entering cursed regex zone
+		var/regex/emoji_path_regex = new(@"(:(/[^:]*):)")
+		while(emoji_path_regex.Find(parsed))
+			parsed = emoji_path_regex.Replace(parsed, /proc/validate_emoji_path)
+
 	return parsed
+
+/proc/validate_emoji_path(match, group1, group2)
+	var/emoji_path = text2path(group2)
+	if(ispath(emoji_path, /atom))
+		var/atom/emoji_atom = emoji_path
+		return bicon(icon(initial(emoji_atom.icon), initial(emoji_atom.icon_state)))

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -13,6 +13,7 @@
 		return
 
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
+	msg = parse_emoji(msg, ooc_mode = TRUE)
 	if(!msg)
 		return
 
@@ -109,6 +110,7 @@
 		return
 
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
+	msg = parse_emoji(msg, ooc_mode = TRUE)
 	if(!msg)
 		return
 


### PR DESCRIPTION
Idea stolen from @silicons over at Citadel: [Citadel#12808](https://github.com/Citadel-Station-13/Citadel-Station-13/pull/12808)

You can now use all emoji in (L)OOC, and you can now use any atom in the code as an emoji by putting its typepath in colons, ie `:/obj/machinery/power/supermatter/shard:` will display the supermatter icon. Icons are automatically scaled at some point so they're all uniformly 16x16 when posted in chat.

A lot of icons will be broken because this handles overlays and animation poorly, but they'll just look funny at a small scale when it happens.

The typepath functionality is only enabled in OOC, PDAs can only use PDA emoji.

:cl:
 * rscadd: Emoji capabilities have been expanded immensely. Putting any atom's type path inside colons in the OOC channel will output a 16x16 version of its default icon.