### PR TITLE
Fixes Holomaps on Synergy being way too offset on Z-Level 4

### DIFF
--- a/maps/synergy.dm
+++ b/maps/synergy.dm
@@ -31,7 +31,7 @@
 	)
 
 	holomap_offset_x = list(0,0,0,86,4,0,0,)
-	holomap_offset_y = list(0,0,0,94,10,0,0,)
+	holomap_offset_y = list(0,0,0,-41,10,0,0,)
 
 	center_x = 226
 	center_y = 254


### PR DESCRIPTION
the Derelict looks way too high there: 
![image](https://user-images.githubusercontent.com/7573912/90064639-62b9f200-dceb-11ea-92af-9126b4321a5f.png)

anyway this fixes that.

:cl:
* bugfix: Synergy: Fixed Z-Level 4 showing too high up on holomaps 
