### PR TITLE
Blink's smoke is no longer opaque

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -357,6 +357,10 @@ steam.start() -- spawns the effect
 	R.burn_skin(2)
 	R.bodytemperature = min(60, R.bodytemperature + (30 * TEMPERATURE_DAMAGE_COEFFICIENT))
 
+
+/obj/effect/effect/smoke/transparent
+	opacity = FALSE
+
 /////////////////////////////////////////////
 // Smoke spread
 /////////////////////////////////////////////
@@ -416,6 +420,9 @@ steam.start() -- spawns the effect
 
 /datum/effect/effect/system/smoke_spread/heat
 	smoke_type = /obj/effect/effect/smoke/heat
+
+/datum/effect/effect/system/smoke_spread/transparent
+	smoke_type = /obj/effect/effect/smoke/transparent
 
 /////////////////////////////////////////////
 // Chem smoke

--- a/code/modules/spells/aoe_turf/blink.dm
+++ b/code/modules/spells/aoe_turf/blink.dm
@@ -31,7 +31,7 @@
 	return
 
 /spell/aoe_turf/blink/proc/makeAnimation(var/turf/T, var/turf/starting)
-	var/datum/effect/effect/system/smoke_spread/smoke = new /datum/effect/effect/system/smoke_spread()
+	var/datum/effect/effect/system/smoke_spread/transparent/smoke = new
 	smoke.set_up(1, 0, T)
 	smoke.start()
 


### PR DESCRIPTION
### Why
A lot of people seem to think Blink is too good not to take it, so this makes it slightly worse, letting you see the wizard after he teleports, while the smoke still signals where the wizard ended up.

I would like to thank my toilet for providing the inspiration for this idea.

:cl:
 * tweak: The smoke produced by the Blink spell is no longer opaque, so that it's possible to see through it.