### PR TITLE
Fixes invisible fruits

### DIFF
--- a/__DEFINES/subsystem.dm
+++ b/__DEFINES/subsystem.dm
@@ -5,11 +5,11 @@
 #define SS_INIT_DBCORE			   900
 #define SS_INIT_SSdbcore	       800
 #define SS_INIT_RUST               26
+#define SS_INIT_PLANT              25.5
 #define SS_INIT_SUPPLY_SHUTTLE     25
 #define SS_INIT_SUN                24
 #define SS_INIT_GARBAGE            23
 #define SS_INIT_JOB                22
-#define SS_INIT_PLANT              21.5
 #define SS_INIT_HUMANS             21
 #define SS_INIT_MAP                20
 #define SS_INIT_COMPONENT          19.5

--- a/code/controllers/subsystem/plant.dm
+++ b/code/controllers/subsystem/plant.dm
@@ -11,6 +11,7 @@ var/datum/subsystem/plant/SSplant
 	var/list/processing_plants = list()
 	var/list/currentrun
 	var/list/datum/seed/seeds = list() // All seed data stored here.
+	var/roundstart_seeds
 
 /datum/subsystem/plant/New()
 	NEW_SS_GLOBAL(SSplant)
@@ -26,6 +27,7 @@ var/datum/subsystem/plant/SSplant
 		seeds[S.name] = S
 		S.uid = "[seeds.len]"
 		S.roundstart = TRUE
+	roundstart_seeds = seeds.len
 	..()
 
 /datum/subsystem/plant/proc/create_random_seed(var/survive_on_station)

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -59,7 +59,7 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 
 	// Cosmetics.
 	var/plant_dmi = 'icons/obj/hydroponics/apple.dmi'// DMI  to use for the plant growing in the tray.
-	var/plant_icon                  // Icon to use for the plant growing in the tray.
+	var/plant_icon_state = "produce"                 // icon_state to use for the product
 	var/packet_icon = "seed"        // Icon to use for physical seed packet item.
 	var/biolum                      // Plant is bioluminescent.
 	var/biolum_colour               // The colour of the plant's radiance.
@@ -82,7 +82,7 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 	mysterious = 1
 
 	seed_noun = pick("spores","nodes","cuttings","seeds")
-	products = list(pick(typesof(/obj/item/weapon/reagent_containers/food/snacks/grown)-/obj/item/weapon/reagent_containers/food/snacks/grown))
+	products = list(pick(subtypesof(/obj/item/weapon/reagent_containers/food/snacks/grown)))
 	potency = rand(5,30)
 
 	randomize_icon()
@@ -243,73 +243,15 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 
 //Gives the plant a new, random icon from a list, with matching growth stages number.
 /datum/seed/proc/randomize_icon()
-	var/list/plant_icons = pick(list(
-		list('icons/obj/hydroponics/chili.dmi',				6),
-		list('icons/obj/hydroponics/chiliice.dmi',			6),
-		list('icons/obj/hydroponics/berry.dmi',				6),
-		list('icons/obj/hydroponics/glowberry.dmi',			6),
-		list('icons/obj/hydroponics/poisonberry.dmi',			6),
-		list('icons/obj/hydroponics/deathberry.dmi',			6),
-		list('icons/obj/hydroponics/nettle.dmi',				6),
-		list('icons/obj/hydroponics/deathnettle.dmi',			6),
-		list('icons/obj/hydroponics/tomato.dmi',				6),
-		list('icons/obj/hydroponics/bloodtomato.dmi',			6),
-		list('icons/obj/hydroponics/killertomato.dmi',		2),
-		list('icons/obj/hydroponics/bluetomato.dmi',			6),
-		list('icons/obj/hydroponics/bluespacetomato.dmi',		6),
-		list('icons/obj/hydroponics/eggplant.dmi',			6),
-		list('icons/obj/hydroponics/eggy.dmi',				6),
-		list('icons/obj/hydroponics/apple.dmi',				6),
-		list('icons/obj/hydroponics/goldapple.dmi',			6),
-		list('icons/obj/hydroponics/ambrosiavulgaris.dmi',	6),
-		list('icons/obj/hydroponics/ambrosiadeus.dmi',		6),
-		list('icons/obj/hydroponics/chanter.dmi',				3),
-		list('icons/obj/hydroponics/plump.dmi',				3),
-		list('icons/obj/hydroponics/reishi.dmi',				4),
-		list('icons/obj/hydroponics/liberty.dmi',				3),
-		list('icons/obj/hydroponics/amanita.dmi',				3),
-		list('icons/obj/hydroponics/angel.dmi',				3),
-		list('icons/obj/hydroponics/towercap.dmi',			3),
-		list('icons/obj/hydroponics/glowshroom.dmi',			4),
-		list('icons/obj/hydroponics/walkingmushroom.dmi',		3),
-		list('icons/obj/hydroponics/plastellium.dmi',		3),
-		list('icons/obj/hydroponics/harebell.dmi',				4),
-		list('icons/obj/hydroponics/poppy.dmi',				3),
-		list('icons/obj/hydroponics/sunflower.dmi',			3),
-		list('icons/obj/hydroponics/moonflower.dmi',			3),
-		list('icons/obj/hydroponics/novaflower.dmi',			3),
-		list('icons/obj/hydroponics/grape.dmi',				2),
-		list('icons/obj/hydroponics/greengrape.dmi',			2),
-		list('icons/obj/hydroponics/peanut.dmi',				6),
-		list('icons/obj/hydroponics/cabbage.dmi',				1),
-		list('icons/obj/hydroponics/shand.dmi',				3),
-		list('icons/obj/hydroponics/mtear.dmi',				4),
-		list('icons/obj/hydroponics/banana.dmi',				6),
-		list('icons/obj/hydroponics/corn.dmi',					3),
-		list('icons/obj/hydroponics/potato.dmi',				4),
-		list('icons/obj/hydroponics/soybean.dmi',				6),
-		list('icons/obj/hydroponics/soybean.dmi',				6),
-		list('icons/obj/hydroponics/wheat.dmi',				6),
-		list('icons/obj/hydroponics/rice.dmi',					4),
-		list('icons/obj/hydroponics/carrot.dmi',				3),
-		list('icons/obj/hydroponics/weeds.dmi',				4),
-		list('icons/obj/hydroponics/whitebeet.dmi',			6),
-		list('icons/obj/hydroponics/sugarcane.dmi',			3),
-		list('icons/obj/hydroponics/watermelon.dmi',			6),
-		list('icons/obj/hydroponics/pumpkin.dmi',				2),
-		list('icons/obj/hydroponics/lime.dmi',					6),
-		list('icons/obj/hydroponics/lemon.dmi',				6),
-		list('icons/obj/hydroponics/orange.dmi',				6),
-		list('icons/obj/hydroponics/grass.dmi',				2),
-		list('icons/obj/hydroponics/cocoapod.dmi',				5),
-		list('icons/obj/hydroponics/cherry.dmi',				5),
-		list('icons/obj/hydroponics/kudzu.dmi',				4),
-		list('icons/obj/hydroponics/pear.dmi', 				6),
-		))
+	var/random = rand(1, SSplant.roundstart_seeds)
+	var/random_key = SSplant.seeds[random]
+	var/datum/seed/random_seed = SSplant.seeds[random_key]
+	set_icon(random_seed)
 
-	plant_dmi = plant_icons[1]
-	growth_stages = plant_icons[2]
-
+/datum/seed/proc/set_icon(datum/seed/seed)
+	plant_dmi = seed.plant_dmi
+	plant_icon_state = "produce"
+	growth_stages = seed.growth_stages
 
 //Random mutations moved to hydroponics_mutations.dm!
 
@@ -708,7 +650,7 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 	new_seed.ligneous =             ligneous
 	new_seed.teleporting =          teleporting
 	new_seed.juicy =        	    juicy
-	new_seed.plant_icon =           plant_icon
+	new_seed.plant_icon_state =     plant_icon_state
 	new_seed.splat_type =           splat_type
 	new_seed.packet_icon =          packet_icon
 	new_seed.biolum =               biolum

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -241,7 +241,6 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 	chems[new_chem] = list(rand(1,severity/3),rand(10-Ceiling(severity/3),15))
 	return 1
 
-//Gives the plant a new, random icon from a list, with matching growth stages number.
 /datum/seed/proc/randomize_icon()
 	var/random = rand(1, SSplant.roundstart_seeds)
 	var/random_key = SSplant.seeds[random]

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -1587,25 +1587,6 @@
 	potency = 30
 	ideal_light = 0
 
-
-/datum/seed/test
-	name = "test"
-	seed_name = "testing"
-	seed_noun = "data"
-	display_name = "runtimes"
-	products = list(/mob/living/simple_animal/cat/Runtime)
-
-	nutrient_consumption = 0
-	water_consumption = 0
-	pest_tolerance = 11
-	weed_tolerance = 11
-	lifespan = 1000
-	endurance = 100
-	maturation = 1
-	production = 1
-	yield = 1
-	potency = 1
-
 /datum/seed/nofruit
 	name = "nofruit"
 	seed_name = "no-fruit"

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -41,6 +41,7 @@ var/list/special_fruits = list()
 		if(!seed)
 			return
 		icon = seed.plant_dmi
+		icon_state = seed.plant_icon_state
 		potency = round(seed.potency)
 		force = seed.thorny ? 5+seed.carnivorous*3 : 0
 		throwforce = seed.thorny ? 5+seed.carnivorous*3 : 0


### PR DESCRIPTION
Closes #27442

It's possible to get a random exotic fruit with the path of an avocado (and random stats ofc) with the sprite of an apple and use a knife to slice it and get a sliced avocado. Some would say it's a bug but after some thought I consider this a feature.

:cl:
 * rscdel: There should be no more invisible exotic fruits
 * rscadd: Exotic fruits can have about 90 different sprites (up from 60)