### PR TITLE
Material Value Balancing

### DIFF
--- a/__DEFINES/materials.dm
+++ b/__DEFINES/materials.dm
@@ -33,13 +33,13 @@
 
 #define VALUE_IRON 0.2
 #define VALUE_GLASS 0.2
-#define VALUE_DIAMOND 4
-#define VALUE_PLASMA 0.2
-#define VALUE_GOLD 1
-#define VALUE_SILVER 1
-#define VALUE_URANIUM 1
-#define VALUE_CLOWN 1
-#define VALUE_PHAZON 1
+#define VALUE_DIAMOND 50
+#define VALUE_PLASMA 1
+#define VALUE_GOLD 6
+#define VALUE_SILVER 6
+#define VALUE_URANIUM 6
+#define VALUE_CLOWN 20
+#define VALUE_PHAZON 50
 #define VALUE_MYTHRIL 1
 #define VALUE_TELECRYSTAL 1
 


### PR DESCRIPTION
As many of you know, material values were nerfed to oblivion a bit over a year ago, which was really needed as Miners could make obscene amounts of money in an absurdly small amount of time (think hundreds of thousands of credits)

In my opinion however, that crash was a bit of an overkill. A full stack of 50 plasma nets a miner a mere 10$.

As I am working on a revamp of the Centcomm Order feature, with new fun and interesting orders for all departments (cept Sec, you do your job dammit), we quickly noticed that Cargo/Mining orders looked really lame in comparison, as you'd ship 9 bananium sheets to be rewarded...9 credits? While the xenoarchaeologist would net the Science department 900 credits for a fully completed alien skeleton.

So I've decided that the new material values are definitely too low, and could use some tweaking. So I generated the map several times with a proc that gave me the exact amount of every materials on box so I could get an idea of how much money could theoretically be made through mining. Here are my findings, and my tweakings:

**=Iron= (found in 22.27% of all mine turfs, 15.425 iron ore harvestable on box on average)**
Price Before: 	0.2$	(10$ for a full stack)
Price After: 	**unchanged**. Iron is cheap and plenty available everywhere.(3.085$ potential)

**=Plasma= (found in 11.88% of all mine turfs, 8.230 plasma ore harvestable on box on average)**
Price Before: 	0.2$	(10$ for a full stack)
Price After: 	**1$**	(50$ for a full stack)(8.230$ potential) Cargo can still ship it for more

**=Gold/Silver/Uranium= (each found in 0.75% of all mine turfs, 525 ore of each harvestable on box on average)**
Price Before: 	1$	(50$ for a full stack)
Price After: 	**6$**	(300$ for a full stack)(3.150$ potential per mat, 9.450$ for all three)

**=Diamond= (found in 0.15% of all mine turfs, 105 diamond ore harvestable on box on average)**
Price Before:	4$	(200$ for a full stack)
Price After:	**50$**	(2.500$ for a full stack)(5.250$ potential)

///////Those can only be reliably harvested on RoidStation/////////
**=Bananium= (200 bananium ore harvestable on roid on average)**
Price Before:	1$	(50$ for a full stack)
Price After:	**20$**	(1.000$ for a full stack)(4.000$ potential)

**=Phazaon= (115 phazon ore harvestable on roid on average)**
Price Before:	1$	(50$ for a full stack)
Price After:	**50$**	(2.500$ for a full stack)(5.750$ potential)

:cl:
* tweak: Tweaked the monetary value of a few materials, so they're a bit more profitable (still way less than they were over a year ago)