### PR TITLE
No Gun Allowed Fix

### DIFF
--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -321,3 +321,20 @@
 	abbreviation = "BS"
 	desc = "Makes you much faster, but blinds you while you move."
 	spawned_items = list(/obj/item/clothing/shoes/blindingspeed)
+
+/datum/spellbook_artifact/nogunallowed
+	name = "No Gun Allowed"
+	abbreviation = "NGA"
+	desc = "Forgo the use of guns in exchange for magical power. Some within the Wizard Federation have lobbied to make this spell a legal obligation."
+	price = -0.5 * Sp_BASE_PRICE
+
+/datum/spellbook_artifact/nogunallowed/can_buy(var/mob/user)
+	if(iswizard(user) || isapprentice(user) || ismagician(user))
+		if(!locate(/spell/passive/nogunallowed) in user.spell_list)
+			return TRUE
+	else
+		return FALSE
+
+/datum/spellbook_artifact/purchased(mob/living/carbon/human/H)
+	..()
+	H.add_spell (new/spell/passive/nogunallowed)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -535,7 +535,7 @@ proc/is_blind(A)
 				return TRUE
 			if(isninja(user) && (honorable & HONORABLE_NINJA))
 				return TRUE
-			if(iswizard(user) && (user.flags & HONORABLE_NOGUNALLOWED))
+			if((iswizard(user) || isapprentice(user) || ismagician(user)) && (user.flags & HONORABLE_NOGUNALLOWED))
 				return TRUE
 	return FALSE
 

--- a/code/modules/spells/passive/no_gun_allowed.dm
+++ b/code/modules/spells/passive/no_gun_allowed.dm
@@ -1,12 +1,9 @@
 /spell/passive/nogunallowed
 	name = "No Gun Allowed"
 	abbreviation = "NG"
-	user_type = USER_TYPE_WIZARD
 	desc = "Forgo the use of guns in exchange for magical power. Some within the Wizard Federation have lobbied to make this spell a legal obligation."
 	hud_state = "wiz_noclothes"
 	spell_flags = NO_BUTTON
-	price = -0.5 * Sp_BASE_PRICE
-	specialization = SSUTILITY
 
 /spell/passive/nogunallowed/on_added(mob/user)
 	user.flags += HONORABLE_NOGUNALLOWED


### PR DESCRIPTION
The way I made No Gun Allowed accidentally created a pretty big exploit. This fixes it.
As a result No Gun Allowed was moved to the artifact category. The intended function of the spell is otherwise identical. 

[bugfix] [oversight]
