### PR TITLE
Allows slime extracts to act as upgrades for stuff around the station

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -427,6 +427,7 @@
 #define DIETINE			"dietine"
 #define GATORMIX		"gatormix"
 #define BLISTEROL		"blisterol"
+#define DSYRUP			"dsyrup"
 
 #define TUNGSTEN 			"tungsten"
 #define LITHIUMSODIUMTUNGSTATE 			"lithiumsodiumtungstate"

--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -327,8 +327,10 @@ Pipelines + Other Objects -> Pipe network
 			user.visible_message("[user] vents \the [src].",
 								"You have vented \the [src].",
 								"You hear a ratchet.")
+			var/obj/item/weapon/wrench/socket/thewrench = W
 			var/datum/gas_mixture/internal_removed = int_air.remove_volume(starting_volume)
-			env_air.merge(internal_removed)
+			if(!thewrench.has_slime)
+				env_air.merge(internal_removed)
 		else
 			to_chat(user, "<span class='warning'>You cannot unwrench this [src], it's too exerted due to internal pressure.</span>")
 			return 1

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -715,6 +715,9 @@ steam.start() -- spawns the effect
 /obj/effect/effect/foam/fire
 	name = "fire supression foam"
 	icon_state = "mfoam"
+	
+/obj/effect/effect/foam/fire/enhanced
+	lowest_temperature = 0
 
 /obj/effect/effect/foam/New(loc, var/ismetal=0)
 	. = ..(loc)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -717,7 +717,7 @@ steam.start() -- spawns the effect
 	icon_state = "mfoam"
 	
 /obj/effect/effect/foam/fire/enhanced
-	lowest_temperature = 0
+	lowest_temperature = 16
 
 /obj/effect/effect/foam/New(loc, var/ismetal=0)
 	. = ..(loc)

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -86,10 +86,12 @@
 	if(istype(W, /obj/item/slime_extract/blue))
 		if(has_slime)
 			to_chat(user, "This extinguisher already has \a [W] attached.")
+			return
 		else
 			has_slime=1
 			to_chat(user, "You attach \the [W] to the extinguisher's funnel.")
 			qdel(W)
+			return
 	..()
 	
 /obj/item/weapon/extinguisher/attackby(obj/item/W, mob/user)

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -53,7 +53,7 @@
 	item_state = "foam_extinguisher"
 	sprite_name = "foam_extinguisher"
 	var/has_slime = 0
-	
+
 /proc/pack_check(mob/user, var/obj/item/weapon/extinguisher/E) //Checks the user for a nonempty chempack.
 	var/mob/living/M = user
 	if (M && M.back && istype(M.back,/obj/item/weapon/reagent_containers/chempack))
@@ -93,7 +93,7 @@
 			qdel(W)
 			return
 	..()
-	
+
 /obj/item/weapon/extinguisher/attackby(obj/item/W, mob/user)
 	if(user.stat || user.restrained() || user.lying)
 		return
@@ -279,10 +279,11 @@
 				var/datum/reagents/R = new/datum/reagents(5)
 				R.my_atom = src
 				reagents.trans_to_holder(R,1)
+				var/obj/effect/effect/foam/fire/W
 				if(has_slime)
-					var/obj/effect/effect/foam/fire/W=new /obj/effect/effect/foam/fire/enhanced(get_turf(src),R)
+					W=new /obj/effect/effect/foam/fire/enhanced(get_turf(src),R)
 				else
-					var/obj/effect/effect/foam/fire/W = new /obj/effect/effect/foam/fire(get_turf(src),R)
+					W = new /obj/effect/effect/foam/fire(get_turf(src),R)
 				var/turf/my_target = pick(the_targets)
 				if(!W || !src)
 					return

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -52,7 +52,8 @@
 	icon_state = "foam_extinguisher0"
 	item_state = "foam_extinguisher"
 	sprite_name = "foam_extinguisher"
-
+	var/has_slime = 0
+	
 /proc/pack_check(mob/user, var/obj/item/weapon/extinguisher/E) //Checks the user for a nonempty chempack.
 	var/mob/living/M = user
 	if (M && M.back && istype(M.back,/obj/item/weapon/reagent_containers/chempack))
@@ -81,6 +82,16 @@
 	to_chat(user, "The safety is [safety ? "on" : "off"].")
 	return
 
+/obj/item/weapon/extinguisher/foam/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/slime_extract/blue))
+		if(has_slime)
+			to_chat(user, "This extinguisher already has \a [W] attached.")
+		else
+			has_slime=1
+			to_chat(user, "You attach \the [W] to the extinguisher's funnel.")
+			qdel(W)
+	..()
+	
 /obj/item/weapon/extinguisher/attackby(obj/item/W, mob/user)
 	if(user.stat || user.restrained() || user.lying)
 		return
@@ -98,7 +109,6 @@
 				W.playtoolsound(src, 100)
 				flags &= ~OPENCONTAINER
 		return
-
 	if (istype(W, /obj/item) && !is_open_container() && !istype(src, /obj/item/weapon/extinguisher/foam) && !istype(W, /obj/item/weapon/storage/evidencebag))
 		if(W.is_open_container())
 			return //We're probably trying to fill it
@@ -267,7 +277,10 @@
 				var/datum/reagents/R = new/datum/reagents(5)
 				R.my_atom = src
 				reagents.trans_to_holder(R,1)
-				var/obj/effect/effect/foam/fire/W = new /obj/effect/effect/foam/fire( get_turf(src) , R)
+				if(has_slime)
+					var/obj/effect/effect/foam/fire/W=new /obj/effect/effect/foam/fire/enhanced(get_turf(src),R)
+				else
+					var/obj/effect/effect/foam/fire/W = new /obj/effect/effect/foam/fire(get_turf(src),R)
 				var/turf/my_target = pick(the_targets)
 				if(!W || !src)
 					return

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -81,7 +81,7 @@
 /obj/item/weapon/wrench/socket/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/slime_extract/bluespace))
 		if(has_slime)
-			to_chat(user, "This wrench  already has \a [W] inside it's head.")
+			to_chat(user, "\the [src] already has \a [W] inside it's head.")
 			return
 		else
 			has_slime=1

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -76,7 +76,19 @@
 	w_class = W_CLASS_LARGE //big shit, to balance its power
 	force = 15.0
 	throwforce = 12.0
+	var/has_slime = 0
 
+/obj/item/weapon/wrench/socket/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/slime_extract/bluespace))
+		if(has_slime)
+			to_chat(user, "This wrench  already has \a [W] inside it's head.")
+			return
+		else
+			has_slime=1
+			to_chat(user, "You shove \the [W] inside the wrench's head.")
+			qdel(W)
+			return
+	..()
 /*
  * Screwdriver
  */

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -85,7 +85,7 @@
 			return
 		else
 			has_slime=1
-			to_chat(user, "You shove \the [W] inside the wrench's head.")
+			to_chat(user, "You shove \the [W] inside \the [src]'s head.")
 			qdel(W)
 			return
 	..()

--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -7,7 +7,7 @@
 	starting_materials = list(MAT_IRON = 75000, MAT_GLASS = 37500)
 	var/build_all = 0
 	var/autowrench = 0
-	var/obj/item/weapon/wrench/internal = new()
+	var/obj/item/weapon/wrench/internal_wrench = new()
 	var/hook_key
 
 	schematics = list(

--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -4,7 +4,7 @@
 	icon_state = "rpd"
 	var/has_slime = 0
 	starting_materials = list(MAT_IRON = 75000, MAT_GLASS = 37500)
-
+	var/build_all = 0
 	var/hook_key
 
 	schematics = list(
@@ -151,53 +151,68 @@
 			qdel(W)
 			return
 	..()
-	
+
 /obj/item/device/rcd/rpd/afterattack(var/atom/A, var/mob/user)
 	if(!selected)
 		return 1
-	
+
 	if(~selected.flags & (RCD_SELF_SANE | RCD_RANGE) && !(user.Adjacent(A) && A.Adjacent(user))) // If RCD_SELF_SANE and RCD_RANGE are disabled we use adjacency.
 		return 1
-	
+
 	if(selected.flags & RCD_RANGE && ~selected.flags & RCD_SELF_SANE && get_dist(A, user) > 1) // RCD_RANGE is used AND we're NOT SELF_SANE, use range(1)
 		return 1
-	
+
 	if(selected.flags & RCD_GET_TURF) // Get the turf because RCD_GET_TURF is on.
 		A = get_turf(A)
 		if (!A)
 			return // Thing clicked was in nullspace, so we won't pass a null turf.
-	
+
 	if(~selected.flags & RCD_SELF_SANE && get_energy(user) < selected.energy_cost) // Handle energy amounts, but only if not SELF_SANE.
 		return 1
-	if(build_all && istype(selected, /datum/rcd_schematic/pipe) && selected.layer)
-		for(var/layer in 1 to 5)
-			busy  = TRUE // Busy to prevent switching schematic while it's in use.
-			/datum/rcd_schematic/pipe/our_schematic = selected //typecast
-			our_schematic.set_layer(layer)
-			var/t = our_schematic.attack(A, user)
-			if(!t) // No errors
-				if(~our_schematic.flags & RCD_SELF_COST) // Handle energy costs unless the schematic does it itself.
-					use_energy(our_schematic.energy_cost, user)
-			else
-				if(istext(t))
-					to_chat(user, "<span class='warning'>\the [src]'s error light flickers: [t]</span>")
+	if(build_all && istype(selected, /datum/rcd_schematic/pipe))
+		var/datum/rcd_schematic/pipe/our_schematic = selected //typecast
+		if(!our_schematic.layer) // this is needed because disposal pipe schematic datums are retarded
+			for(var/layer in 1 to 5)
+				busy  = TRUE // Busy to prevent switching schematic while it's in use.
+				our_schematic.set_layer(layer)
+				var/t = our_schematic.attack(A, user)
+				if(!t) // No errors
+					if(~our_schematic.flags & RCD_SELF_COST) // Handle energy costs unless the schematic does it itself.
+						use_energy(our_schematic.energy_cost, user)
 				else
-					to_chat(user, "<span class='warning'>\the [src]'s error light flickers.</span>")
-			
-			busy = FALSE
-	return 1				
+					if(istext(t))
+						to_chat(user, "<span class='warning'>\the [src]'s error light flickers: [t]</span>")
+					else
+						to_chat(user, "<span class='warning'>\the [src]'s error light flickers.</span>")
+
+				busy = FALSE
+			return 1
+
+	busy  = TRUE // Busy to prevent switching schematic while it's in use.
+	var/t = selected.attack(A, user)
+	if(!t) // No errors
+		if(~selected.flags & RCD_SELF_COST) // Handle energy costs unless the schematic does it itself.
+			use_energy(selected.energy_cost, user)
+	else
+		if(istext(t))
+			to_chat(user, "<span class='warning'>\the [src]'s error light flickers: [t]</span>")
+		else
+			to_chat(user, "<span class='warning'>\the [src]'s error light flickers.</span>")
+
+	busy = FALSE
+	return 1
 
 /obj/item/device/rcd/rpd/verb/multilayer()
 	set category = "Object"
 	set name = "Multilayer Mode"
-	
+
 	if(usr.incapacitated())
 		return
 
 	src.build_all = !src.build_all
-	
-	to_chat(usr, "You toggle the multilayer building mode on the RPD")		
-	
+
+	to_chat(usr, "You toggle the multilayer building mode on the RPD")
+
 /obj/item/device/rcd/rpd/admin
 	name = "experimental Rapid-Piping-Device (RPD)"
 

--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -3,7 +3,7 @@
 	desc       = "A device used to rapidly pipe things."
 	icon_state = "rpd"
 	var/has_metal_slime = 0
-	var/has_red_slime = 0
+	var/has_yellow_slime = 0
 	starting_materials = list(MAT_IRON = 75000, MAT_GLASS = 37500)
 	var/build_all = 0
 	var/autowrench = 0
@@ -153,18 +153,18 @@
 			to_chat(user, "You jam \the [W] into the RPD's fabricator.")
 			qdel(W)
 			return
-					
-	if(istype(W, /obj/item/slime_extract/red))
-		if(has_red_slime)
+
+	if(istype(W, /obj/item/slime_extract/yellow))
+		if(has_yellow_slime)
 			to_chat(user, "It already has \a [W] attached.")
 			return
 		else
-			has_metal_slime=1
+			has_yellow_slime=1
 			verbs += /obj/item/device/rcd/rpd/proc/autowrench
 			to_chat(user, "You jam \the [W] into the RPD's output nozzle.")
 			qdel(W)
 			return
-	
+
 	..()
 
 /obj/item/device/rcd/rpd/afterattack(var/atom/A, var/mob/user)
@@ -234,15 +234,15 @@
 /obj/item/device/rcd/rpd/proc/autowrench()
 	set category = "Object"
 	set name = "Autowrench Mode"
-	
+
 	if(usr.incapacitated())
 		return
-	
+
 	src.autowrench = !src.autowrench
-	
+
 	to_chat(usr, "You toggle the automatic wrenching feature on the RPD")
 
-	
+
 /obj/item/device/rcd/rpd/admin
 	name = "experimental Rapid-Piping-Device (RPD)"
 

--- a/code/modules/RCD/schematics/pipe.dm
+++ b/code/modules/RCD/schematics/pipe.dm
@@ -391,7 +391,7 @@
 	P.add_fingerprint(user)
 	var/obj/item/device/rcd/rpd/ourmaster = master
 	if(ourmaster.autowrench)
-		P.attackby(ourmaster.internal, user)
+		P.attackby(ourmaster.internal_wrench, user)
 
 /datum/rcd_schematic/pipe/select(var/mob/user, var/datum/rcd_schematic/old_schematic)
 	if(!istype(old_schematic, /datum/rcd_schematic/pipe))

--- a/code/modules/RCD/schematics/pipe.dm
+++ b/code/modules/RCD/schematics/pipe.dm
@@ -389,6 +389,9 @@
 	P.setPipingLayer(thislayer)
 	P.update()
 	P.add_fingerprint(user)
+	var/obj/item/device/rcd/rpd/ourmaster = master
+	if(ourmaster.autowrench)
+		P.attackby(ourmaster.internal, user)
 
 /datum/rcd_schematic/pipe/select(var/mob/user, var/datum/rcd_schematic/old_schematic)
 	if(!istype(old_schematic, /datum/rcd_schematic/pipe))

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -397,7 +397,7 @@
 	else if(istype(O, /obj/item/slime_extract/green))
 		
 		if(has_slime)
-			to_chat(user, "This hydroponics tray already has \a [O] inside.")
+			to_chat(user, "\the [src] already has \a [O] inside.")
 			return
 		else
 			has_slime=1

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -401,7 +401,7 @@
 			return
 		else
 			has_slime=1
-			to_chat(user, "You attach \the [O] to the tray's internal mechanisms.")
+			to_chat(user, "You attach \the [O] to \the [src]'s internal mechanisms.")
 			qdel(O)
 			return
 		

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -42,7 +42,7 @@
 	var/closed_system          // If set, the tray will attempt to take atmos from a pipe.
 	var/force_update           // Set this to bypass the cycle time check.
 	var/skip_aging = 0		   // Don't advance age for the next N cycles.
-
+	var/has_slime = 0		   // Green slime extract applied; plants don't age.
 	var/pollination = 0
 	var/bees = 0				//Are the trays currently affected by the bees' pollination?
 
@@ -394,6 +394,15 @@
 		O.reagents.trans_to(src, O.reagents.total_volume, log_transfer = TRUE, whodunnit = user)
 		qdel(O)
 
+	else if(istype(O, /obj/item/slime_extract/green))
+		
+		if(has_slime)
+			to_chat(user, "This hydroponics tray already has \a [O] inside.")
+		else
+			has_slime=1
+			to_chat(user, "You attach \the [O] to the tray's internal mechanisms.")
+			qdel(O)
+		
 	else
 		return ..()
 

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -398,10 +398,12 @@
 		
 		if(has_slime)
 			to_chat(user, "This hydroponics tray already has \a [O] inside.")
+			return
 		else
 			has_slime=1
 			to_chat(user, "You attach \the [O] to the tray's internal mechanisms.")
 			qdel(O)
+			return
 		
 	else
 		return ..()

--- a/code/modules/hydroponics/hydro_tray_process.dm
+++ b/code/modules/hydroponics/hydro_tray_process.dm
@@ -56,12 +56,12 @@
 
 	// Advance plant age.
 	if(!has_slime)
-			if(skip_aging)
-				skip_aging--
-			else
-				if(prob(80))
-					age += 1 * HYDRO_SPEED_MULTIPLIER
-					update_icon_after_process = 1
+		if(skip_aging)
+			skip_aging--
+		else
+			if(prob(80))
+				age += 1 * HYDRO_SPEED_MULTIPLIER
+				update_icon_after_process = 1
 
 	//Highly mutable plants have a chance of mutating every tick.
 	if(seed.immutable == -1)

--- a/code/modules/hydroponics/hydro_tray_process.dm
+++ b/code/modules/hydroponics/hydro_tray_process.dm
@@ -55,12 +55,13 @@
 			lastproduce--
 
 	// Advance plant age.
-	if(skip_aging)
-		skip_aging--
-	else
-		if(prob(80))
-			age += 1 * HYDRO_SPEED_MULTIPLIER
-		update_icon_after_process = 1
+	if(!has_slime)
+			if(skip_aging)
+				skip_aging--
+			else
+				if(prob(80))
+					age += 1 * HYDRO_SPEED_MULTIPLIER
+					update_icon_after_process = 1
 
 	//Highly mutable plants have a chance of mutating every tick.
 	if(seed.immutable == -1)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -204,9 +204,21 @@ proc/move_mining_shuttle()
 	toolsounds = list('sound/weapons/Genhit.ogg')
 	var/drill_verb = "picking"
 	var/diggables = DIG_ROCKS
-
+	var/has_slime = 0
 	var/excavation_amount = 100
 
+/obj/item/weapon/pickaxe/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/slime_extract/oil))
+		if(has_slime)
+			to_chat(user, "It already has \a [W] at its point.")
+			return
+		else
+			has_slime=1
+			to_chat(user, "You mold \the [W] around the tip of the tool.")
+			qdel(W)
+			return
+	..()
+	
 /obj/item/weapon/pickaxe/hammer
 	name = "sledgehammer"
 	//icon_state = "sledgehammer" Waiting on sprite
@@ -309,8 +321,10 @@ proc/move_mining_shuttle()
 			A.use(loading_ammo)
 			current_ammo += loading_ammo
 			to_chat(user, "<span class='notice'>You load \the [src].</span>")
+			return
 		else
 			to_chat(user, "<span class='notice'>\The [src] is already loaded.</span>")
+			return
 
 	if(proximity_flag && istype(target, /obj/item/stack/sheet/mineral/plasma))
 		var/obj/item/stack/sheet/mineral/plasma/A = target
@@ -319,8 +333,11 @@ proc/move_mining_shuttle()
 			A.use(loading_ammo)
 			current_ammo += loading_ammo
 			to_chat(user, "<span class='notice'>You load \the [src].</span>")
+			return
 		else
 			to_chat(user, "<span class='notice'>\The [src] is already loaded.</span>")
+			return
+	..()
 
 /obj/item/weapon/pickaxe/plasmacutter/accelerator/examine(mob/user)
 	..()

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -214,7 +214,7 @@ proc/move_mining_shuttle()
 			return
 		else
 			has_slime=1
-			to_chat(user, "You mold \the [W] around the tip of the tool.")
+			to_chat(user, "You mold \the [W] around the tip of \the [src].")
 			qdel(W)
 			return
 	..()

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -383,6 +383,12 @@ turf/unsimulated/mineral/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_l
 				else if(excavation_level > 0 && prob(15))
 					B = new /obj/structure/boulder(src)
 					B.geological_data = geologic_data
+				
+					
+				if(P.has_slime)
+					for(var/turf/unsimulated/mineral/M in range(src,1))
+							M.GetDrilled(safety_override = TRUE, driller = user)
+					return
 
 				GetDrilled(artifact_destroyed)
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -383,11 +383,11 @@ turf/unsimulated/mineral/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_l
 				else if(excavation_level > 0 && prob(15))
 					B = new /obj/structure/boulder(src)
 					B.geological_data = geologic_data
-				
-					
+
+
 				if(P.has_slime)
 					for(var/turf/unsimulated/mineral/M in range(src,1))
-							M.GetDrilled(safety_override = TRUE, driller = user)
+						M.GetDrilled(safety_override = TRUE, driller = user)
 					return
 
 				GetDrilled(artifact_destroyed)
@@ -790,7 +790,7 @@ turf/unsimulated/mineral/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_l
 	if (prob(mineralChance) && !mineral && mineralPool)
 		if(!name_to_mineral)
 			SetupMinerals()
-		
+
 		var/mineral_name = pickweight(mineralSpawnChance[mineralPool]) //temp mineral name
 
 		if (mineral_name)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -386,7 +386,7 @@ turf/unsimulated/mineral/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_l
 
 
 				if(P.has_slime)
-					for(var/turf/unsimulated/mineral/M in range(src,1))
+					for(var/turf/unsimulated/mineral/M in range(user,1))
 						M.GetDrilled(safety_override = TRUE, driller = user)
 					return
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -8225,10 +8225,10 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 		M.reagents.add_reagent(NUTRIMENT, 2)
 
 /datum/reagent/dsyrup
-name = "Delightful Syrup"
-id = DSYRUP
-description = "This syrup is everyone's favorite tricord additive."
-reagent_state = REAGENT_STATE_LIQUID
-color = "#571212" //like a dark red
-density = 1.00 //basically water
-specheatcap = 4.184
+	name = "Delightful Syrup"
+	id = DSYRUP
+	description = "This syrup is everyone's favorite tricord additive."
+	reagent_state = REAGENT_STATE_LIQUID
+	color = "#571212" //like a dark red
+	density = 1.00 //basically water
+	specheatcap = 4.184

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -8225,9 +8225,9 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 		M.reagents.add_reagent(NUTRIMENT, 2)
 
 /datum/reagent/dsyrup
-	name = "Delightful Syrup"
+	name = "Delightful Mix"
 	id = DSYRUP
-	description = "This syrup is everyone's favorite tricord additive."
+	description = "This syrupy stuff is everyone's favorite tricord additive."
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#571212" //like a dark red
 	density = 1.00 //basically water

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -8223,3 +8223,12 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	if(prob(5))
 		to_chat(M,"<span class='warning'>[pick("You feel fuller.", "You no longer feel snackish.")]</span>")
 		M.reagents.add_reagent(NUTRIMENT, 2)
+
+/datum/reagent/dsyrup
+name = "Delightful Syrup"
+id = DSYRUP
+description = "This syrup is everyone's favorite tricord additive."
+reagent_state = REAGENT_STATE_LIQUID
+color = "#571212" //like a dark red
+density = 1.00 //basically water
+specheatcap = 4.184

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2540,6 +2540,13 @@
 	required_reagents = list(LIMEJUICE = 1, TOMATOJUICE = 1, ORANGEJUICE = 1, CREAM = 1, TRICORDRAZINE = 1)
 	result_amount = 5
 
+/datum/chemical_reaction/doctor_delight_from_syrup
+	name = "The Dector's Delight from pre-mix"
+	id= "p_doctordelight"
+	result = DOCTORSDELIGHT
+	required_reagents = list(DSYRUP = 1, TRICORDRAZINE = 1)
+	result_amount = 2
+	
 /datum/chemical_reaction/irish_cream
 	name = "Irish Cream"
 	id = IRISHCREAM

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -294,18 +294,18 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 	if(isrobot(user))
 		if(!can_use(user))
 			return
-					
+
 	if(istype(D, /obj/item/slime_extract/black))
 		if(has_slime)
 			to_chat(user, "There's already slime in the tank!")
 			return
 		else
 			has_slime=1
-			dispensable_reagents.add(DSYRUP)
+			dispensable_reagents.Add(DSYRUP)
 			to_chat(user, "You throw the slime into the dispenser's tank.")
-			qdel(W)
+			qdel(D)
 			return
-					
+
 	if(can_insert(D))
 		if(src.container)
 			to_chat(user, "\A [src.container] is already loaded into the machine.")

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -44,7 +44,7 @@
 		SACID,
 		TUNGSTEN
 		)
-
+	var/has_slime = 0
 	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK
 
 /*
@@ -286,7 +286,7 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 /obj/machinery/chem_dispenser/proc/can_insert(var/obj/item/I)
 	return istype(I, /obj/item/weapon/reagent_containers/glass) || istype(I, /obj/item/weapon/reagent_containers/food/drinks)
 
-/obj/machinery/chem_dispenser/attackby(var/obj/item/weapon/D as obj, var/mob/user as mob) //to be worked on
+/obj/machinery/chem_dispenser/attackby(var/obj/item/D as obj, var/mob/user as mob) //to be worked on
 
 	if(..())
 		return 1
@@ -294,7 +294,18 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 	if(isrobot(user))
 		if(!can_use(user))
 			return
-
+					
+	if(istype(D, /obj/item/slime_extract/black))
+		if(has_slime)
+			to_chat(user, "There's already slime in the tank!")
+			return
+		else
+			has_slime=1
+			dispensable_reagents.add(DSYRUP)
+			to_chat(user, "You throw the slime into the dispenser's tank.")
+			qdel(W)
+			return
+					
 	if(can_insert(D))
 		if(src.container)
 			to_chat(user, "\A [src.container] is already loaded into the machine.")

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -123,16 +123,35 @@
 //pepperspray
 /obj/item/weapon/reagent_containers/spray/pepper
 	name = "pepperspray"
-	desc = "Manufactured by UhangInc, used to blind and down an opponent quickly."
+	desc = "A pepper spray manufactured by UhangInc, used to blind and down an opponent quickly."
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "pepperspray"
 	item_state = "pepperspray"
 	volume = 40
 	amount_per_transfer_from_this = 10
-
+	var/has_slime = 0
+	
 /obj/item/weapon/reagent_containers/spray/pepper/New()
 	..()
 	reagents.add_reagent(CONDENSEDCAPSAICIN, 40)
+
+/obj/item/weapon/reagent_containers/spray/pepper/attackby(obj/item/weapon/W, mob/user)
+	if(istype(W, /obj/item/slime_extract/orange))
+		if(has_slime)
+			to_chat(user, "The bottle already has \a [W] inside.")
+			return
+		else
+			has_slime=1
+			reagents.add_reagent(CONDENSEDCAPSAICIN, 40)//in a perfect world, we'd calculate how much to add, but the add_reagents() already has sanity checking for max volume
+			to_chat(user, "You drop \the [W] down into the spray canister, and liquid capsaicin swells up to the brim.")
+			qdel(W)
+			return
+	..()
+
+/obj/item/weapon/reagent_containers/spray/pepper/proc/make_puff(var/atom/target, var/mob/user))
+	if(has_slime)
+		reagents.add_reagent(CONDENSEDCAPSAICIN, 10)
+	..()
 
 // Luminol
 /obj/item/weapon/reagent_containers/spray/luminol

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -135,7 +135,7 @@
 	..()
 	reagents.add_reagent(CONDENSEDCAPSAICIN, 40)
 
-/obj/item/weapon/reagent_containers/spray/pepper/attackby(obj/item/weapon/W, mob/user)
+/obj/item/weapon/reagent_containers/spray/pepper/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/slime_extract/orange))
 		if(has_slime)
 			to_chat(user, "The bottle already has \a [W] inside.")

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -130,7 +130,7 @@
 	volume = 40
 	amount_per_transfer_from_this = 10
 	var/has_slime = 0
-	
+
 /obj/item/weapon/reagent_containers/spray/pepper/New()
 	..()
 	reagents.add_reagent(CONDENSEDCAPSAICIN, 40)
@@ -148,7 +148,7 @@
 			return
 	..()
 
-/obj/item/weapon/reagent_containers/spray/pepper/proc/make_puff(var/atom/target, var/mob/user))
+/obj/item/weapon/reagent_containers/spray/pepper/make_puff(var/atom/target, var/mob/user)
 	if(has_slime)
 		reagents.add_reagent(CONDENSEDCAPSAICIN, 10)
 	..()


### PR DESCRIPTION
[content] [tested]

This adds several uses for xenobio products around the station. This should encourage people to do it more often. I think that's positive.

While all the changes are tested and working, I would appreciate input on if there is a more efficient implementation for any of the changes. 

:cl:
 * rscadd: Green Slime Extract can be applied to hydroponics trays to prevent aging
 * rscadd: Yellow Slime Extract can be applied to an RPD to enable it's autowrench feature. Rightclick on the RPD to toggle
 * rscadd: Metal Slime Extract can be applied to an RPD to enable multilayer building. Rightclick on the RPD to toggle
 * rscadd: Black Slime Extract can be applied to chemistry dispenser to make creating doctor's delight a little easier
 * rscadd: Blue Slime Extract can be applied to foam fire extinguishers to make them really cold
 * rscadd: Orange Slime Extract can be applied to a pepper spray to make it refill automatically
 * rscadd: Oil Slime Extract can be applied to any pickaxe or drill to make it mine in an AoE
 * rscadd: Bluespace Slime Extract can be applied to a socket wrench, allowing it to vent the excess gas into space, instead of into the room