### PR TITLE
Hardsuit RAD and EMP shield module implementations.

### DIFF
--- a/code/datums/outfit/special_outfits/special.dm
+++ b/code/datums/outfit/special_outfits/special.dm
@@ -47,7 +47,7 @@
 	outfit_name = "Engineer rig suit"
 	items_to_spawn = list(
 		"Default" = list(
-			slot_wear_suit_str = /obj/item/clothing/suit/space/rig,
+			slot_wear_suit_str = /obj/item/clothing/suit/space/rig/engineer,
 			slot_wear_mask_str = /obj/item/clothing/mask/breath,
 			slot_s_store_str = /obj/item/weapon/tank/jetpack/oxygen,
 		),
@@ -57,7 +57,7 @@
 	outfit_name = "Chief engineer rig suit"
 	items_to_spawn = list(
 		"Default" = list(
-			slot_wear_suit_str = /obj/item/clothing/suit/space/rig/elite,
+			slot_wear_suit_str = /obj/item/clothing/suit/space/rig/engineer/elite,
 			slot_wear_mask_str = /obj/item/clothing/mask/breath,
 			slot_s_store_str = /obj/item/weapon/tank/jetpack/oxygen,
 		),
@@ -132,6 +132,7 @@
 			slot_wear_mask_str = /obj/item/clothing/mask/breath,
 			slot_s_store_str = /obj/item/weapon/tank/jetpack/oxygen,
 		),
+	//Maybe replace with civilian rig whenever that becomes a truely unique rig.
 	)
 
 // ----- THUNDERDOME TOURNAMENT

--- a/code/game/machinery/suit_dispenser.dm
+++ b/code/game/machinery/suit_dispenser.dm
@@ -269,7 +269,7 @@ var/list/dispenser_presets = list()
 
 /datum/suit/dorf/head/chiefengie
 	name = "Chief Engineer"
-	to_spawn = (/obj/item/clothing/suit/space/rig/elite,/obj/item/clothing/shoes/magboots/elite)*/
+	to_spawn = (/obj/item/clothing/suit/space/rig/engineer/elite,/obj/item/clothing/shoes/magboots/elite)*/
 
 
 /obj/machinery/suit_dispenser/dorf

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -58,14 +58,14 @@
 /obj/machinery/suit_storage_unit/engie
 	name = "Engineering Suit Storage Unit"
 	department = "engie"
-	suit_type = /obj/item/clothing/suit/space/rig
+	suit_type = /obj/item/clothing/suit/space/rig/engineer
 	mask_type = /obj/item/clothing/mask/breath
 	boot_type = /obj/item/clothing/shoes/magboots
 
 /obj/machinery/suit_storage_unit/elite
 	name = "Advanced Suit Storage Unit"
 	department = "ce"
-	suit_type = /obj/item/clothing/suit/space/rig/elite
+	suit_type = /obj/item/clothing/suit/space/rig/engineer/elite
 	mask_type = /obj/item/clothing/mask/breath
 	boot_type = /obj/item/clothing/shoes/magboots/elite
 

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -544,7 +544,7 @@
 	corpseidaccess = "Station Engineer"
 
 /obj/effect/landmark/corpse/engineer/rig
-	corpsesuit = /obj/item/clothing/suit/space/rig
+	corpsesuit = /obj/item/clothing/suit/space/rig/engineer
 	corpseback = /obj/item/weapon/tank/oxygen
 	corpsemask = /obj/item/clothing/mask/breath
 
@@ -591,7 +591,7 @@
 	corpseidaccess = "Chief Engineer"
 
 /obj/effect/landmark/corpse/chiefengineer/rig
-	corpsesuit = /obj/item/clothing/suit/space/rig/elite
+	corpsesuit = /obj/item/clothing/suit/space/rig/engineer/elite
 	corpseback = /obj/item/weapon/tank/oxygen
 	corpsemask = /obj/item/clothing/mask/breath
 

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -8,7 +8,7 @@ var/list/all_hardsuit_pieces = list(HARDSUIT_HEADGEAR,HARDSUIT_GLOVES,HARDSUIT_B
 
 //Regular rig suits
 /obj/item/clothing/head/helmet/space/rig
-	name = "engineering hardsuit helmet"
+	name = "civilian hardsuit helmet"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment. Has radiation shielding."
 	icon_state = "rig0-engineering"
 	item_state = "eng_helm"
@@ -60,7 +60,7 @@ var/list/all_hardsuit_pieces = list(HARDSUIT_HEADGEAR,HARDSUIT_GLOVES,HARDSUIT_B
 		actions_types |= /datum/action/item_action/toggle_rig_light //Make sure we restore the action button
 
 /obj/item/clothing/head/helmet/space/rig/process() //Helmets are directly linked to the suit's power cell, they don't need it to be activated at all.
-	if(on && rig)	
+	if(on && rig)
 		if(!rig.cell.use(1) || rig.loc != loc)
 			toggle_light()
 
@@ -111,7 +111,7 @@ var/list/all_hardsuit_pieces = list(HARDSUIT_HEADGEAR,HARDSUIT_GLOVES,HARDSUIT_B
 			RS.all_hardsuit_parts.Add(src)
 
 /obj/item/clothing/suit/space/rig
-	name = "engineering hardsuit"
+	name = "civilian hardsuit"
 	desc = "A special suit that protects against hazardous, low pressure environments. Has radiation shielding."
 	icon_state = "rig-engineering"
 	item_state = "eng_hardsuit"
@@ -254,7 +254,7 @@ var/list/all_hardsuit_pieces = list(HARDSUIT_HEADGEAR,HARDSUIT_GLOVES,HARDSUIT_B
 		if(R.activated && R.active_power_usage)
 			if(!cell.use(R.active_power_usage))
 				R.say_to_wearer("Not enough power available in [src]!")
-				R.deactivate()	
+				R.deactivate()
 				continue
 			R.do_process()
 
@@ -358,7 +358,7 @@ var/list/all_hardsuit_pieces = list(HARDSUIT_HEADGEAR,HARDSUIT_GLOVES,HARDSUIT_B
 	set src = usr.contents
 
 	if(!wearer || !wearer.is_wearing_item(src, slot_wear_suit))
-		to_chat(usr,"<span class='warning'>\The [src] is not being worn.</span>") 
+		to_chat(usr,"<span class='warning'>\The [src] is not being worn.</span>")
 		return
 
 	toggle_piece(HARDSUIT_HEADGEAR,wearer)
@@ -372,7 +372,7 @@ var/list/all_hardsuit_pieces = list(HARDSUIT_HEADGEAR,HARDSUIT_GLOVES,HARDSUIT_B
 	set src = usr.contents
 
 	if(!wearer || !wearer.is_wearing_item(src, slot_wear_suit))
-		to_chat(usr,"<span class='warning'>\The [src] is not being worn.</span>") 
+		to_chat(usr,"<span class='warning'>\The [src] is not being worn.</span>")
 		return
 
 	toggle_piece(HARDSUIT_BOOTS,wearer)
@@ -386,7 +386,7 @@ var/list/all_hardsuit_pieces = list(HARDSUIT_HEADGEAR,HARDSUIT_GLOVES,HARDSUIT_B
 	set src = usr.contents
 
 	if(!wearer || !wearer.is_wearing_item(src, slot_wear_suit))
-		to_chat(usr,"<span class='warning'>\The [src] is not being worn.</span>") 
+		to_chat(usr,"<span class='warning'>\The [src] is not being worn.</span>")
 		return
 
 	toggle_piece(HARDSUIT_GLOVES,wearer)

--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -261,5 +261,5 @@
 
 /obj/item/rig_module/rad_shield/adv
 	name = "high capacity radiation absorption device"
-	desc = "Its acronym, R.A.D., and full name both convey the application of this module. By using similar technology as radiation collectors, it protects the suit wearer from incoming radiation until its collectors are full. It can be reset by using a suit storage unit's cleaning operation."
+	desc = "Its acronym, R.A.D., and full name both convey the application of this module. By using similar technology as radiation collectors, it protects the suit wearer from incoming radiation until its collectors are full. This model features a higher capacity than the basic version. It can be reset by using a suit storage unit's cleaning operation."
 	max_capacity = 800 //About 3-4 "item touches" worth based on the same conditions as the above testing.

--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -209,7 +209,7 @@
 	var/event_key
 	var/initial_suit = 0
 	var/initial_helmet = 0
-	var/max_capacity = 250 //Just barely over 1 "item touch" worth of rads when standing right next to the shard with a suit with only 10 rad resist. Based on in-game tests on 14/08/2020.
+	var/max_capacity = 250 //Just barely over 1 "item touch" worth of rads when standing right next to the shard with a suit with only 10 rad resist. About 5-6 items at 50. Based on in-game tests on Aug. 2020.
 	var/current_capacity = 0
 
 /obj/item/rig_module/rad_shield/examine_addition(mob/user)

--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -203,13 +203,13 @@
 
 //Rad shield module
 /obj/item/rig_module/rad_shield
-	name = "\improper R.A.D."
-	desc = "An radiation absorption device. Its acronym and true name both convey the application of this module."
+	name = "radiation absorption device"
+	desc = "Its acronym, R.A.D., and full name both convey the application of this module. By using similar technology as radiation collectors it protects the suit wearer from incoming radiation until its collectors are full. It can be reset by using a suit storage unit's cleaning operation."
 	active_power_usage = 1
 	var/event_key
 	var/initial_suit = 0
 	var/initial_helmet = 0
-	var/max_capacity = 250
+	var/max_capacity = 250 //Just barely over 1 "item touch" worth of rads when standing right next to the shard with a suit with only 10 rad resist. Based on in-game tests on 14/08/2020.
 	var/current_capacity = 0
 
 /obj/item/rig_module/rad_shield/examine_addition(mob/user)
@@ -258,3 +258,8 @@
 
 	if(current_capacity >= max_capacity)
 		deactivate()
+
+/obj/item/rig_module/rad_shield/adv
+	name = "high capacity radiation absorption device"
+	desc = "Its acronym, R.A.D., and full name both convey the application of this module. By using similar technology as radiation collectors, it protects the suit wearer from incoming radiation until its collectors are full. It can be reset by using a suit storage unit's cleaning operation."
+	max_capacity = 800 //About 3-4 "item touches" worth based on the same conditions as the above testing.

--- a/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
+++ b/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
@@ -1,7 +1,31 @@
+//Engineer rig
+/obj/item/clothing/head/helmet/space/rig/engineer
+	name = "engineering hardsuit helmet"
+	desc = "A special helmet designed for work in a hazardous, low-pressure environment. Has radiation shielding."
+	icon_state = "rig0-engineering"
+	item_state = "eng_helm"
+	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 50)
+	_color = "engineering"
+	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	pressure_resistance = 200 * ONE_ATMOSPHERE
+	eyeprot = 3
+
+/obj/item/clothing/suit/space/rig/engineer
+	name = "engineering hardsuit"
+	desc = "A special suit that protects against hazardous, low pressure environments. Has radiation shielding."
+	icon_state = "rig-engineering"
+	item_state = "eng_hardsuit"
+	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 50)
+	allowed = list(/obj/item/device/flashlight, /obj/item/weapon/tank, /obj/item/weapon/storage/bag/ore, /obj/item/device/t_scanner, /obj/item/weapon/pickaxe, /obj/item/device/rcd, /obj/item/weapon/wrench/socket)
+	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	pressure_resistance = 200 * ONE_ATMOSPHERE
+	head_type = /obj/item/clothing/head/helmet/space/rig/engineer
+	initial_modules = list(/obj/item/rig_module/rad_shield)
+
 //Chief Engineer's rig
-/obj/item/clothing/head/helmet/space/rig/elite
+/obj/item/clothing/head/helmet/space/rig/engineer/elite
 	name = "advanced hardsuit helmet"
-	desc = "An advanced helmet designed for work in a hazardous, low pressure environment. Shines with a high polish."
+	desc = "An advanced helmet designed for work in a hazardous, low pressure environment. Shines with a high polish making it plasma proof."
 	icon_state = "rig0-white"
 	item_state = "ce_helm"
 	_color = "white"
@@ -10,29 +34,29 @@
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	clothing_flags = PLASMAGUARD
 
-/obj/item/clothing/suit/space/rig/elite
-	icon_state = "rig-white"
+/obj/item/clothing/suit/space/rig/engineer/elite
 	name = "advanced hardsuit"
+	desc = "An advanced suit that protects against hazardous, low pressure environments. Shines with a high polish making it plasma proof."
+	icon_state = "rig-white"
+	item_state = "ce_hardsuit"
 	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
 	species_restricted = list("exclude",VOX_SHAPED)
-	desc = "An advanced suit that protects against hazardous, low pressure environments. Shines with a high polish."
-	item_state = "ce_hardsuit"
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	clothing_flags = PLASMAGUARD
 	cell_type = /obj/item/weapon/cell/super
-	head_type = /obj/item/clothing/head/helmet/space/rig/elite
+	head_type = /obj/item/clothing/head/helmet/space/rig/engineer/elite
 
-/obj/item/clothing/head/helmet/space/rig/elite/test
+/obj/item/clothing/head/helmet/space/rig/engineer/elite/test
 	name = "prototype advanced hardsuit helmet"
 	desc = "A bleeding-edge helmet designed to protect its wearer against extreme environments. The armored padding in this helmet was totally removed to give place for its experimental plasmovsky alloy."
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 100, bomb = 100, bio = 100, rad = 100)
 
 //Self-charging, auto-refiller high-test suit.
-/obj/item/clothing/suit/space/rig/elite/test
+/obj/item/clothing/suit/space/rig/engineer/elite/test
 	name = "prototype advanced hardsuit"
 	desc = "A bleeding-edge prototype designed to protect its wearer against extreme environments. The armored padding in this suit was totally removed to give place for its experimental plasmovsky alloy."
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 100, bomb = 100, bio = 100, rad = 100)
-	head_type = /obj/item/clothing/head/helmet/space/rig/elite/test
+	head_type = /obj/item/clothing/head/helmet/space/rig/engineer/elite/test
 	gloves_type = /obj/item/clothing/gloves/yellow
 	boots_type = /obj/item/clothing/shoes/magboots/elite
 	tank_type = /obj/item/weapon/tank/oxygen
@@ -240,7 +264,7 @@
 	head_type = /obj/item/clothing/head/helmet/space/rig/medical
 
 
-	//Security
+//Security
 /obj/item/clothing/head/helmet/space/rig/security
 	name = "security hardsuit helmet"
 	desc = "A special helmet designed for work in a hazardous low pressure environment. Has an additional layer of armor."
@@ -315,7 +339,7 @@
 
 //Atmospherics Rig (BS12)
 /obj/item/clothing/head/helmet/space/rig/atmos
-	desc = "A special helmet designed for work in hazardous low pressure environments. Has reduced radiation shielding to allow for greater mobility."
+	desc = "A special helmet designed for work in hazardous low pressure environments. Trades radiation shielding for plasma proofing compared to engineering hardsuits."
 	name = "atmospherics hardsuit helmet"
 	icon_state = "rig0-atmos"
 	item_state = "atmos_helm"
@@ -327,7 +351,7 @@
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/suit/space/rig/atmos
-	desc = "A special suit that protects against hazardous low pressure environments. Has reduced radiation shielding to allow for greater mobility."
+	desc = "A special suit that protects against hazardous low pressure environments. Trades radiation shielding for plasma proofing compared to engineering hardsuits."
 	icon_state = "rig-atmos"
 	name = "atmos hardsuit"
 	item_state = "atmos_hardsuit"

--- a/code/modules/research/designs/boards/misc.dm
+++ b/code/modules/research/designs/boards/misc.dm
@@ -140,7 +140,7 @@
 	req_tech = list(Tc_PROGRAMMING = 4, Tc_POWERSTORAGE = 3, Tc_MAGNETS = 3)
 	build_type = IMPRINTER
 	category = "Misc"
-	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_GOLD = 2000) //Needs carbon.
+	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_GOLD = 2000)
 	build_path = /obj/item/rig_module/emp_shield
 
 /datum/design/rigsuit_radshield

--- a/code/modules/research/designs/boards/misc.dm
+++ b/code/modules/research/designs/boards/misc.dm
@@ -91,6 +91,8 @@
 	category = "Engineering Boards"
 	build_path = /obj/item/weapon/circuitboard/ecb/advanced_airlock_controller
 
+//RIG suit modules
+
 /datum/design/rigsuit_health
 	name = "Circuit Design (Rigsuit health display)"
 	desc = "When installed, allows for onlookers to see the health of a person wearing a rigsuit."
@@ -98,7 +100,7 @@
 	req_tech = list(Tc_PROGRAMMING = 3)
 	build_type = IMPRINTER
 	category = "Misc"
-	materials = list(MAT_GLASS = 1000, SACID = 15, MAT_SILVER = 150)
+	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_SILVER = 150)
 	build_path = /obj/item/rig_module/health_readout
 
 /datum/design/rigsuit_autorefill
@@ -108,7 +110,7 @@
 	req_tech = list(Tc_PROGRAMMING = 3)
 	build_type = IMPRINTER
 	category = "Misc"
-	materials = list(MAT_GLASS = 1000, SACID = 15, MAT_SILVER = 150)
+	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_SILVER = 150)
 	build_path = /obj/item/rig_module/tank_refiller
 
 /datum/design/rigsuit_gottagofast
@@ -118,15 +120,45 @@
 	req_tech = list(Tc_PROGRAMMING = 3)
 	build_type = IMPRINTER
 	category = "Misc"
-	materials = list(MAT_GLASS = 1000, SACID = 15, MAT_SILVER = 150)
+	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_SILVER = 150)
 	build_path = /obj/item/rig_module/speed_boost
 
-/datum/design/rigsuit_powercreep
+/datum/design/rigsuit_plasmaproof
 	name = "Circut Design (Rigsuit plasma sealant)"
 	desc = "When installed and activated, ensures that the suit is now resistant to plasma contamination."
 	id = "rigsuit_plasma"
 	req_tech = list(Tc_PROGRAMMING = 4, Tc_PLASMATECH = 4)
 	build_type = IMPRINTER
 	category = "Misc"
-	materials = list(MAT_GLASS = 2500, SACID = 25, MAT_SILVER = 1000, MAT_PLASMA = 1000)
+	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_SILVER = 1000, MAT_PLASMA = 1000)
 	build_path = /obj/item/rig_module/plasma_proof
+
+/datum/design/rigsuit_empshield
+	name = "Circut Design (Rigsuit EMP dissipation module)"
+	desc = "When installed and activated, the suit is protected from EMPs but at the cost of additional cell charge depending on the severity."
+	id = "rigsuit_empshield"
+	req_tech = list(Tc_PROGRAMMING = 4, Tc_POWERSTORAGE = 3, Tc_MAGNETS = 3)
+	build_type = IMPRINTER
+	category = "Misc"
+	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_GOLD = 2000) //Needs carbon.
+	build_path = /obj/item/rig_module/emp_shield
+
+/datum/design/rigsuit_radshield
+	name = "Circut Design (Rigsuit radiation absorption device)"
+	desc = "When installed and activated, the suit protects the wearer from incoming radiation until its collectors are full."
+	id = "rigsuit_radshield"
+	req_tech = list(Tc_PROGRAMMING = 4, Tc_MATERIALS = 4, Tc_POWERSTORAGE = 3, Tc_PLASMATECH = 2)
+	build_type = IMPRINTER
+	category = "Misc"
+	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_PLASMA = 1000)
+	build_path = /obj/item/rig_module/rad_shield
+
+/datum/design/rigsuit_radshield_adv
+	name = "Circut Design (Rigsuit high capacity radiation absorption device)"
+	desc = "An improved version of the R.A.D. featuring a higher capacity. When installed and activated, the suit protects the wearer from incoming radiation until its collectors are full."
+	id = "rigsuit_radshield"
+	req_tech = list(Tc_PROGRAMMING = 4, Tc_MATERIALS = 6, Tc_POWERSTORAGE = 4, Tc_PLASMATECH = 3)
+	build_type = IMPRINTER
+	category = "Misc"
+	materials = list(MAT_GLASS = 2000, SACID = 20, MAT_GOLD = 1000, MAT_PLASMA = 1000)
+	build_path = /obj/item/rig_module/rad_shield/adv

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -192,7 +192,7 @@ datum/tech/materials
 
 datum/tech/engineering
 	name = "Engineering Research"
-	desc = "Development of new and improved engineering parts and."
+	desc = "Development of new and improved engineering parts and equipment."
 	id = "engineering"
 	max_level=5
 
@@ -210,9 +210,9 @@ datum/tech/powerstorage
 
 datum/tech/bluespace
 	name = "'Blue-space' Research"
-	desc = "Research into the sub-reality known as 'blue-space'"
+	desc = "Research into the sub-reality known as 'blue-space'."
 	id = "bluespace"
-	max_level =10
+	max_level=10
 	goal_level=4 // Without phazon.
 
 datum/tech/biotech

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -203,7 +203,7 @@ var/list/shop_prices = list( //Cost in space credits
 
 var/list/circuitboards = existing_typesof(/obj/item/weapon/circuitboard) - /obj/item/weapon/circuitboard/card/centcom //All circuit boards can be bought in Spessmart
 var/list/circuitboard_prices = list()	//gets filled on initialize()
-var/list/clothing = existing_typesof(/obj/item/clothing) - typesof(/obj/item/clothing/suit/space/ert) - typesof(/obj/item/clothing/head/helmet/space/ert) - typesof(/obj/item/clothing/head/helmet/space/rig) - list(/obj/item/clothing/suit/space/rig/elite, /obj/item/clothing/suit/space/rig/deathsquad, /obj/item/clothing/suit/space/rig/wizard, /obj/item/clothing/head/helmet/space/bomberman, /obj/item/clothing/suit/space/bomberman, /obj/item/clothing/mask/stone/infinite, /obj/item/clothing/suit/armor/laserproof/advanced) //What in the world could go wrong
+var/list/clothing = existing_typesof(/obj/item/clothing) - typesof(/obj/item/clothing/suit/space/ert) - typesof(/obj/item/clothing/head/helmet/space/ert) - typesof(/obj/item/clothing/head/helmet/space/rig) - list(/obj/item/clothing/suit/space/rig/engineer/elite, /obj/item/clothing/suit/space/rig/deathsquad, /obj/item/clothing/suit/space/rig/wizard, /obj/item/clothing/head/helmet/space/bomberman, /obj/item/clothing/suit/space/bomberman, /obj/item/clothing/mask/stone/infinite, /obj/item/clothing/suit/armor/laserproof/advanced) //What in the world could go wrong
 var/list/clothing_prices = list()	//gets filled on initialize()
 
 /area/vault/supermarket


### PR DESCRIPTION
[balance] [content] [tweak]
A while back in #26951 a few new hardsuit modules were added but not implemented due to atomic and balance reasons. This is the (late) follow up PR to that one.

**From before:**
To restate what the modules do.
- The EMP dissipation module will consume your suit's charge(300/150/100 based on EMP severity) to prevent it from getting disabled/its battery damaged.
- The R.A.D. will shield your suit and helmet until it's filter is full (It will fill based on the amount of radiation and the suit's initial radiation shielding). You can use a SSU to clean the filter.
The RAD has a normal and advanced form each holding 250 and 800 rads respectively. To put it in perspective a suit with 10 rad armor to start will absorb about 1 blast of radiation if you were right next to a shard. A suit with 50 rad armor to start will absorb about 5-6 item blasts worth. The advanced one is about 3x that so you do the math. 
**TLDR** suits with better rad armor to start can take on more rads with the module. 

For people who are wondering if dragging the shard behind them while spraying it in the hall with this will be a cool idea:
<h3>You get two sprays and then your module gives in.</h3>
</br>

**Balance stuff:**
- Engineer and CE hard suits: -30 (80 -> 50) rad armor, +round start basic RAD module. This rad armor is in line with existing "good" rad armor amounts where they used to be the "best" rad armor on normally available hard suits.
- EMP module costs gold and the usual circuit materials. 
- RAD module costs plasma and usual circuit materials. 
- Advanced RAD module costs plasma, gold, and usual circuit materials. 
- All require mid level research and the RAD modules need plasma research.

**Why:**
When the shard is yelling 99% and you decide to take one for the team and enter the hot box to try and deal with the shard you are basically accepting your death sentence by internal bleeding because 80 rad armor means not much when standing next to an over stimmed shard. An actual rad suit means you die before you even get next to the shard from whatever is over stimming it in the first place. This makes engineering suits a happy medium between rad suits and pressure suits by being a rad suit for only a limited time.
Shard dragging and spraying in the halls is not a great idea since it's limited time (about 2 sprays worth). Atmos suits lack rad armor so they tank even less with the RAD.

**Coder stuff you won't care about:**
- Engineering hard suits are now a child of a basic hard suit under the name civilian suit. Nothing has changed stat wise besides the already mentioned changes and exist for cleaner tweaking of hard suits without having to touch the engineering hard suit always.
- Children of related parents have been updated where needed.
- I have updated references to engineering hard suits where appropriate in the code. Yell at me if you think I'm blind and I missed one.

:cl:
 * rscadd: EMP and RAD shield modules are now available in game by means similar to existing hard suit modules.
 * tweak: Engineer and CE hard suits have undergone these changes.
 * rscadd: Both are equipped with a basic RAD module at round start
 * rscdel: Both have lost some (80 -> 50) rad armor as balance. This amount is similar to most "good" rad armor hard suits.