### PR TITLE
Fixes IAA's outfit datum

### DIFF
--- a/code/datums/outfit/civilian.dm
+++ b/code/datums/outfit/civilian.dm
@@ -611,7 +611,7 @@
 	pda_slot = slot_belt
 	id_type = /obj/item/weapon/card/id/centcom
 
-/datum/outfit/lawyer/post_equip(var/mob/living/carbon/human/H)
+/datum/outfit/iaa/post_equip(var/mob/living/carbon/human/H)
 	H.put_in_hands(new /obj/item/weapon/storage/briefcase/centcomm(H))
 	if (!H.mind)
 		return


### PR DESCRIPTION
Fixes shifty's IAA fuckup so they actually get their notes and briefcase.


:cl:
 * bugfix: NT will now remember to send IAA, Lawyers, and Bridge Officers to work with their communication channel clearances and work briefcase.