### PR TITLE
Cult Pamphlet in Xenoarch

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -1194,6 +1194,10 @@ var/list/arcane_tomes = list()
 	newCultist.OnPostSetup()
 	newCultist.Greet(GREET_PAMPHLET)
 
+/obj/item/weapon/bloodcult_pamphlet/oneuse/attack_self(var/mob/user)
+	..()
+	qdel(src)
+
 //Jaunter: creates a pylon on spawn, lets you teleport to it on use
 /obj/item/weapon/bloodcult_jaunter
 	name = "test jaunter"

--- a/code/modules/research/xenoarchaeology/artifact/artifact.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact.dm
@@ -18,6 +18,7 @@
 	//5;/obj/machinery/syndicate_beacon,
 	5;/obj/item/clothing/mask/stone,
 	5;/obj/item/changeling_vial,
+	5;/obj/item/weapon/bloodcult_pamphlet/oneuse,
 	10;/obj/structure/constructshell,
 	25;/obj/machinery/power/supermatter,
 	100;/obj/item/clothing/gloves/warping_claws,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7573912/90933211-bae5a800-e3ff-11ea-8d2b-bfcadedddcb3.png)

:cl:
* rscadd: a single use Cult Pamphlet can now spawn instead of a large artifact, just like Vampire stone masks and Changeling vials. Same rarity too, which is to say, extremely low.