### PR TITLE
Improved roundstart spawn

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -402,6 +402,7 @@ var/global/datum/controller/occupations/job_master
 	var/datum/job/job = GetJob(rank)
 	if(!joined_late)
 		var/obj/S = null
+		// Find a spawn point that wasn't given to anyone
 		for(var/obj/effect/landmark/start/sloc in landmarks_list)
 			if(sloc.name != rank)
 				continue
@@ -410,9 +411,23 @@ var/global/datum/controller/occupations/job_master
 			S = sloc
 			break
 		if(!S)
-			S = locate("start*[rank]") // use old stype
-		if(istype(S, /obj/effect/landmark/start) && istype(S.loc, /turf))
+			// Find a spawn point that was already given to someone else
+			for(var/obj/effect/landmark/start/sloc in landmarks_list)
+				if(sloc.name != rank)
+					continue
+				S = sloc
+				stack_trace("not enough spawn points for [rank]")
+				break
+		if(!S)
+			// Find a spawn point that's using the ancient landmarks. Do we even have these anymore?
+			S = locate("start*[rank]")
+		if(S)
+			// Use the given spawn point
 			H.forceMove(S.loc)
+		else
+			// Use the arrivals shuttle spawn point
+			stack_trace("no spawn points for [rank]")
+			H.forceMove(pick(latejoin))
 
 	if(job && !job.no_starting_money)
 		//give them an account in the station database


### PR DESCRIPTION
Instead of cuck cubing players attempting to spawn as a job for which there aren't enough spawn points, now:
- Spawn points are re-used, meaning the player will spawn on top of someone else, as long as there is at least one spawner for the job
- Failing that, the player will spawn in the arrivals shuttle like a latejoiner would.

Runtime errors are thrown in both cases, so that the underlying issue doesn't go unnoticed.
Subscribe to my patreon for more