### PR TITLE
Oxyloss from suffocation is now proportional to how much gas you didn't get

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -251,7 +251,7 @@ var/global/list/whitelisted_species = list("Human")
 		return moles/GAS_CONSUME_TO_WASTE_DENOMINATOR
 	else
 		//testing("  ratio < 1, adding oxyLoss.")
-		H.adjustOxyLoss(min(5*ratio, HUMAN_MAX_OXYLOSS)) // Don't fuck them up too fast (space only does HUMAN_MAX_OXYLOSS after all!)
+		H.adjustOxyLoss(HUMAN_MAX_OXYLOSS * (1 - ratio)) //Damage proportional to how much gas you didn't get
 		H.failed_last_breath = 1
 		H.oxygen_alert = 1
 		return moles*ratio/GAS_CONSUME_TO_WASTE_DENOMINATOR


### PR DESCRIPTION
Instead of proportional to how much you *did*. Fixes #27616.

:cl:
* bugfix: Oxyloss from suffocation is now proportional to how much gas you needed but did not get, instead of proportional to how much gas you DID get. In comparison to the current behavior, this decreases suffocation damage when you have almost enough air, and increases it when you have much less than enough air.