### PR TITLE
Altar adjacency sanity check

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -353,7 +353,11 @@
 		return
 	if (!istype(O))
 		return
-	if (!O.anchored && (istype(O, /obj/item) || user.get_active_hand() == O))
+	if(user.incapacitated() || user.lying)
+		return
+	if(O.anchored || !Adjacent(user) || !user.Adjacent(O))
+		return
+	if (user.get_active_hand() == O)
 		if(!user.drop_item(O))
 			return
 	else
@@ -361,13 +365,7 @@
 			return
 		if(O.loc == user || !isturf(O.loc) || !isturf(user.loc))
 			return
-		if(user.incapacitated() || user.lying)
-			return
-		if(O.anchored || !Adjacent(user) || !user.Adjacent(O))
-			return
 		if(istype(O, /mob/living/simple_animal) || istype(O, /mob/living/silicon))
-			return
-		if(!user.loc)
 			return
 		var/mob/living/L = O
 		if(!istype(L) || L.locked_to || L == user)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -363,7 +363,7 @@
 			return
 		if(user.incapacitated() || user.lying)
 			return
-		if(O.anchored || !Adjacent(user) || !user.Adjacent(src))
+		if(O.anchored || !Adjacent(user) || !user.Adjacent(O))
 			return
 		if(istype(O, /mob/living/simple_animal) || istype(O, /mob/living/silicon))
 			return


### PR DESCRIPTION
Fixes #27303

:cl:
* bugfix: You can no longer drag n drop stuff onto a cult altar with a complete disregard for where you or the stuff are standing, or whether you're even alive or dead.