### PR TITLE
Fixes an organ_external.dm runtime

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -192,6 +192,7 @@ var/global/list/whitelisted_species = list("Human")
 		H.internal_organs_by_name.len=0
 	if(H.grasp_organs)
 		H.grasp_organs.len = 0
+	H.bad_external_organs.Cut()
 
 
 /datum/species/proc/create_organs(var/mob/living/carbon/human/H) //Handles creation of mob organs.


### PR DESCRIPTION
This one was hard to find

```
[13:22:49] Runtime in organ_external.dm,429: Cannot read null.life_tick
  proc name: process (/datum/organ/external/process)
  src: chest (/datum/organ/external/chest)
  call stack:
  chest (/datum/organ/external/chest): process()
  Tom Dick (/mob/living/carbon/human): handle organs(0)
  Tom Dick (/mob/living/carbon/human): handle regular status updates()
  Tom Dick (/mob/living/carbon/human): Life()
  Mob (/datum/subsystem/mob): fire(0)
  Mob (/datum/subsystem/mob): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```