### PR TITLE
Fixes lighting overlay stuff

### DIFF
--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -34,6 +34,7 @@
 
 /atom/movable/lighting_overlay/Destroy()
 	global.lighting_update_overlays     -= src
+	SSlighting.currentrun_overlays -= src
 
 	var/turf/T   = loc
 	if (istype(T))


### PR DESCRIPTION
Under some circumstances currentrun_overlays is not emptied so it holds references to overlays that get deleted, so this mesage spams the logs:

`## WARNING: A lighting overlay realised it was in nullspace in update_overlay() and got pooled!`

This fixes it. Probably fixes hard dels too