### PR TITLE
Makes Xenoarch Energy guns more varied

### DIFF
--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -564,10 +564,7 @@
 	new_gun.desc = ""
 
 	//Randomize it!
-	var/delay = rand(1, 20)
-	new_gun.fire_delay = delay		//Randomize the fire delay
-	new_gun.attack_delay = delay
-	new_gun.charge_cost = rand(25, 225)		//Randomize the cost-per-fire (how many shots it has)
+	
 	new_gun.projectile_type = pickweight(list(		//Randomize the beam it fires. Standard laser deals 30 burn.
 
 		/obj/item/projectile/beam 							= 250,	
@@ -607,14 +604,21 @@
 		/obj/item/projectile/energy/rad						= 50,	//30 damage, irradiates
 		/obj/item/projectile/gravitywell					= 10,	//uh oh
 		/obj/item/projectile/beam/pulse						= 40,	//50 damage, destroys walls
-		/obj/item/projectile/energy/electrode/scatter/sun 	= 10,	//holy christ
+//		/obj/item/projectile/energy/electrode/scatter/sun 	= 10,	//holy christ
 		/obj/item/projectile/swap							= 50,	//swap staff bolts
 		/obj/item/projectile/forcebolt						= 50,	//mental focus bolts
 		/obj/item/projectile/beam/mindflayer				= 50,	//deals brain damage
 	))	
+	
+	var/delay = rand(1, 20)	
+	new_gun.fire_delay = delay		//Randomize the fire delay
+	new_gun.attack_delay = delay
+	new_gun.charge_cost = rand(25, 225)		//Randomize the cost-per-fire (how many shots it has)
 
-	if(istype(new_gun.projectile_type, /obj/item/projectile/gravitywell))
-		new_gun.charge_cost = 200			//If its a gravity gun set the charge to the max so the game doesnt break.
+	if(istype(new_gun.projectile_type, /obj/item/projectile/gravitywell))	//If its a gravity gun set the charge to 200 so the game doesnt break.
+		new_gun.charge_cost = 200			
+	if(istype(new_gun.projectile_type, /obj/item/projectile/beam/white))	//If its a rainbow laser give it a random color, the color wont change after this, though.
+		new_gun.projectile_type.projectile_color= pick(list("#FF0000","#FF8C00","#FFFF00","#00FF00","#00BFFF","#0000FF","#9400D3"))
 
 	new_gun.fire_sound = pick(list(				//Randomize the sound it makes
 		'sound/weapons/alien_laser1.ogg',

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -555,7 +555,7 @@
 		/obj/item/weapon/gun/energy/laser/captain	=	15,		//15% chance to be self-recharging
 		/obj/item/weapon/gun/energy/bison			= 	5,		//5% chance to be pump-charge
 	))
-	var/obj/item/weapon/gun/energy/new_gun = new /obj/item/weapon/gun/energy
+	var/obj/item/weapon/gun/energy/new_gun = new gun_base
 	new_gun.icon = 'icons/obj/xenoarchaeology.dmi'
 	new_gun.icon_state = "egun[rand(1,6)]"
 	new_gun.item_state = new_gun.icon_state
@@ -564,14 +564,15 @@
 	new_gun.desc = ""
 
 	//Randomize it!
-	new_gun.fire_delay = rand(1, 5)			//Randomize the fire delay
-	new_gun.charge_cost = rand(25, 200)		//Randomize the cost-per-fire (how many shots it has)
+	var/delay = rand(1, 20)
+	new_gun.fire_delay = delay		//Randomize the fire delay
+	new_gun.attack_delay = delay
+	new_gun.charge_cost = rand(25, 225)		//Randomize the cost-per-fire (how many shots it has)
 	new_gun.projectile_type = pickweight(list(		//Randomize the beam it fires. Standard laser deals 30 burn.
 
 		/obj/item/projectile/beam 							= 250,	
 		/obj/item/projectile/beam/captain					= 80,	//40 damage
 		/obj/item/projectile/beam/retro						= 120,
-		/obj/item/projectile/beam/lightning 				= 70,	//Will this break anything?
 		/obj/item/projectile/beam/practice					= 130,	//Deals no damage.
 		/obj/item/projectile/beam/lightlaser				= 120,	//25 damage
 		/obj/item/projectile/beam/weaklaser					= 130,	//15 damage
@@ -602,35 +603,38 @@
 		/obj/item/projectile/energy/electrode/fast			= 80,	//fast tasers
 		/obj/item/projectile/energy/electrode/scatter		= 80,	//3-way tasers
 		//DUMB SHIT
-		/obj/item/projectile/energy/osipr					= 20,	//oh no
+		/obj/item/projectile/energy/osipr					= 10,	//oh no
 		/obj/item/projectile/energy/rad						= 50,	//30 damage, irradiates
-		/obj/item/projectile/gravitywell					= 5,	//uh oh
+		/obj/item/projectile/gravitywell					= 10,	//uh oh
 		/obj/item/projectile/beam/pulse						= 40,	//50 damage, destroys walls
 		/obj/item/projectile/energy/electrode/scatter/sun 	= 10,	//holy christ
 		/obj/item/projectile/swap							= 50,	//swap staff bolts
 		/obj/item/projectile/forcebolt						= 50,	//mental focus bolts
-		/obj/item/projectile/beam/mindflayer				= 60,	//deals brain damage
+		/obj/item/projectile/beam/mindflayer				= 50,	//deals brain damage
 	))	
 
-	new_gun.fire_sound = pick(				//Randomize the sound it makes
-		'sound/weapons/alien_laser1.ogg'
-		'sound/weapons/alien_laser2.ogg'
-		'sound/weapons/blaster.ogg'
-		'sound/weapons/electriczap.ogg'
-		'sound/weapons/hivehand.ogg'
-		'sound/weapons/kinetic_accelerator.ogg'
-		'sound/weapons/Laser.ogg'
-		'sound/weapons/Laser2.ogg'
-		'sound/weapons/laser3.ogg'
-		'sound/weapons/lasercannonfire.ogg'
-		'sound/weapons/ion.ogg'
-		'sound/weapons/megabuster.ogg'
-		'sound/weapons/pulse.ogg'
-		'sound/weapons/pulse2.ogg'
-		'sound/weapons/pulse3.ogg'
-		'sound/weapons/Taser.ogg'
+	if(istype(new_gun.projectile_type, /obj/item/projectile/gravitywell))
+		new_gun.charge_cost = 200			//If its a gravity gun set the charge to the max so the game doesnt break.
+
+	new_gun.fire_sound = pick(list(				//Randomize the sound it makes
+		'sound/weapons/alien_laser1.ogg',
+		'sound/weapons/alien_laser2.ogg',
+		'sound/weapons/blaster.ogg',
+		'sound/weapons/electriczap.ogg',
+		'sound/weapons/hivehand.ogg',
+		'sound/weapons/kinetic_accelerator.ogg',
+		'sound/weapons/Laser.ogg',
+		'sound/weapons/Laser2.ogg',
+		'sound/weapons/laser3.ogg',
+		'sound/weapons/lasercannonfire.ogg',
+		'sound/weapons/ion.ogg',
+		'sound/weapons/megabuster.ogg',
+		'sound/weapons/pulse.ogg',
+		'sound/weapons/pulse2.ogg',
+		'sound/weapons/pulse3.ogg',
+		'sound/weapons/Taser.ogg',
 		'sound/weapons/Taser2.ogg'
-	)
+	))
 	
 
 	//5% chance to explode when first fired
@@ -649,7 +653,6 @@
 
 /datum/find/laser/additional_description(var/obj/item/I)
 	I.desc += "Looks like an antique energy weapon, you're not sure if it will fire or not."
-	var/obj/item/
 	if(istype(I, /obj/item/weapon/gun/energy/bison))
 		I.desc += "There seems to be some sort of pump on the back of the stock."
 	if(prob(10)) // 10% chance to be a smart gun

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -549,23 +549,89 @@
 	responsive_reagent = IRON
 
 /datum/find/laser/spawn_item()
-	var/spawn_type = pick(
-		/obj/item/weapon/gun/energy/laser/practice,
-		/obj/item/weapon/gun/energy/laser,
-		/obj/item/weapon/gun/energy/xray,
-		/obj/item/weapon/gun/energy/laser/captain,
-		/obj/item/weapon/gun/energy/ionrifle,
-		/obj/item/weapon/gun/energy/plasma/pistol,
-		/obj/item/weapon/gun/energy/floragun,
-		/obj/item/weapon/gun/energy/laser/rainbow,
-		/obj/item/weapon/gun/energy/taser)
-	var/obj/item/weapon/gun/energy/new_gun = new spawn_type
+
+	var/gun_base = pickweight(list(
+		/obj/item/weapon/gun/energy/laser			=	70,		//70% chance to be a normal gun
+		/obj/item/weapon/gun/energy/laser/captain	=	15,		//15% chance to be self-recharging
+		/obj/item/weapon/gun/energy/bison			= 	5,		//5% chance to be pump-charge
+	))
+	var/obj/item/weapon/gun/energy/new_gun = new /obj/item/weapon/gun/energy
 	new_gun.icon = 'icons/obj/xenoarchaeology.dmi'
 	new_gun.icon_state = "egun[rand(1,6)]"
 	new_gun.item_state = new_gun.icon_state
 	new_gun.inhand_states = list("left_hand" = 'icons/mob/in-hand/left/xenoarch.dmi', "right_hand" = 'icons/mob/in-hand/right/xenoarch.dmi')
 	new_gun.charge_states = 0 //let's prevent it from losing that great icon if we charge it
 	new_gun.desc = ""
+
+	//Randomize it!
+	new_gun.fire_delay = rand(1, 5)			//Randomize the fire delay
+	new_gun.charge_cost = rand(25, 200)		//Randomize the cost-per-fire (how many shots it has)
+	new_gun.projectile_type = pickweight(list(		//Randomize the beam it fires. Standard laser deals 30 burn.
+
+		/obj/item/projectile/beam 							= 250,	
+		/obj/item/projectile/beam/captain					= 80,	//40 damage
+		/obj/item/projectile/beam/retro						= 120,
+		/obj/item/projectile/beam/lightning 				= 70,	//Will this break anything?
+		/obj/item/projectile/beam/practice					= 130,	//Deals no damage.
+		/obj/item/projectile/beam/lightlaser				= 120,	//25 damage
+		/obj/item/projectile/beam/weaklaser					= 130,	//15 damage
+		/obj/item/projectile/beam/veryweaklaser				= 140,	//5 damage
+		/obj/item/projectile/beam/heavylaser				= 40,	//60 damage
+		/obj/item/projectile/beam/heavylaser/lawgiver		= 80,	//40 damage
+		/obj/item/projectile/beam/xray						= 80,	//Shoots through walls.
+		/obj/item/projectile/beam/bison						= 110,	//15 damage, pierces
+		/obj/item/projectile/beam/white						= 100 ,	//Injects HONK serum and spacedrugs
+		/obj/item/projectile/beam/combustion				= 70,	//Creates a small explosion on impact, not all that powerful really
+		/obj/item/projectile/energy/declone					= 70,	//Decloner bolts
+		/obj/item/projectile/energy/bolt					= 70 ,	//Ebow bolts
+		/obj/item/projectile/energy/buster					= 120,	//20 damage
+		/obj/item/projectile/energy/floramut				= 100,	//floral somatray bolts
+		/obj/item/projectile/kinetic						= 100,	//KA bolts
+		/obj/item/projectile/ricochet						= 100,	//Richochet lasers
+		/obj/item/projectile/spur/polarstar					= 100,	//Polar star
+		/obj/item/weapon/gun/energy/polarstar/spur			= 80,	//Spur
+		//ION BOLTS
+		/obj/item/projectile/ion							= 120,	//Its an ion bolt.
+		/obj/item/projectile/ion/small						= 110,	//Its a small ion bolt.
+		//PLASMA BOLTS
+		/obj/item/projectile/energy/plasma/light			= 90,	//35 damage, contaminates
+		/obj/item/projectile/energy/plasma/rifle			= 50,	//50 damage, contaminates
+		/obj/item/projectile/energy/plasma/pistol			= 120,	//25 damage, contaminates
+		//TASERS
+		/obj/item/projectile/energy/electrode				= 180,	//Its a taser electrode
+		/obj/item/projectile/energy/electrode/fast			= 80,	//fast tasers
+		/obj/item/projectile/energy/electrode/scatter		= 80,	//3-way tasers
+		//DUMB SHIT
+		/obj/item/projectile/energy/osipr					= 20,	//oh no
+		/obj/item/projectile/energy/rad						= 50,	//30 damage, irradiates
+		/obj/item/projectile/gravitywell					= 5,	//uh oh
+		/obj/item/projectile/beam/pulse						= 40,	//50 damage, destroys walls
+		/obj/item/projectile/energy/electrode/scatter/sun 	= 10,	//holy christ
+		/obj/item/projectile/swap							= 50,	//swap staff bolts
+		/obj/item/projectile/forcebolt						= 50,	//mental focus bolts
+		/obj/item/projectile/beam/mindflayer				= 60,	//deals brain damage
+	))	
+
+	new_gun.fire_sound = pick(				//Randomize the sound it makes
+		'sound/weapons/alien_laser1.ogg'
+		'sound/weapons/alien_laser2.ogg'
+		'sound/weapons/blaster.ogg'
+		'sound/weapons/electriczap.ogg'
+		'sound/weapons/hivehand.ogg'
+		'sound/weapons/kinetic_accelerator.ogg'
+		'sound/weapons/Laser.ogg'
+		'sound/weapons/Laser2.ogg'
+		'sound/weapons/laser3.ogg'
+		'sound/weapons/lasercannonfire.ogg'
+		'sound/weapons/ion.ogg'
+		'sound/weapons/megabuster.ogg'
+		'sound/weapons/pulse.ogg'
+		'sound/weapons/pulse2.ogg'
+		'sound/weapons/pulse3.ogg'
+		'sound/weapons/Taser.ogg'
+		'sound/weapons/Taser2.ogg'
+	)
+	
 
 	//5% chance to explode when first fired
 	//10% chance to have an unchargeable cell
@@ -583,6 +649,9 @@
 
 /datum/find/laser/additional_description(var/obj/item/I)
 	I.desc += "Looks like an antique energy weapon, you're not sure if it will fire or not."
+	var/obj/item/
+	if(istype(I, /obj/item/weapon/gun/energy/bison))
+		I.desc += "There seems to be some sort of pump on the back of the stock."
 	if(prob(10)) // 10% chance to be a smart gun
 		I.can_take_pai = TRUE
 		I.desc += " There seems to be some sort of slot in the handle."

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -617,9 +617,7 @@
 
 	if(istype(new_gun.projectile_type, /obj/item/projectile/gravitywell))	//If its a gravity gun set the charge to 200 so the game doesnt break.
 		new_gun.charge_cost = 200			
-	if(istype(new_gun.projectile_type, /obj/item/projectile/beam/white))	//If its a rainbow laser give it a random color, the color wont change after this, though.
-		new_gun.projectile_type.projectile_color= pick(list("#FF0000","#FF8C00","#FFFF00","#00FF00","#00BFFF","#0000FF","#9400D3"))
-
+		
 	new_gun.fire_sound = pick(list(				//Randomize the sound it makes
 		'sound/weapons/alien_laser1.ogg',
 		'sound/weapons/alien_laser2.ogg',


### PR DESCRIPTION
Previously Xenoarcheology energy guns were copies of pre-existing energy guns with a different icon slapped on top, this PR changes that.

Before, the guns were selected randomly from this list:

		/obj/item/weapon/gun/energy/laser/practice,
		/obj/item/weapon/gun/energy/laser,
		/obj/item/weapon/gun/energy/xray,
		/obj/item/weapon/gun/energy/laser/captain,
		/obj/item/weapon/gun/energy/ionrifle,
		/obj/item/weapon/gun/energy/plasma/pistol,
		/obj/item/weapon/gun/energy/floragun,
		/obj/item/weapon/gun/energy/laser/rainbow,
		/obj/item/weapon/gun/energy/taser

Now, xenoarch energy guns are more varied and random, which can result in guns that are very weak or very strong.

Found guns will have:

- 70% to be a regular energy weapon.
- 15% to be self-recharging
- 5% to be pump-charging (like the bison)

- The type of projectile fired now has much, much more variety. The list of possible projectiles and the weights for each can be found by looking at the files changed, as its too long to list in this description. Weaker projectiles are more common, stronger ones are less common.

- A randomized firing sound.

- A randomized fire delay between 1 and 20.  (20 being the laser-cannon delay, 1 being the standard delay) This won't impact it much from what I found out in testing.

- A randomized cost-per-shot. The power cell in the gun is always a standard one with a charge of 1000. Standard laser guns use up 100 charge per shot, xenoarch energy guns will now have that cost randomized between 25-225 (125 on average).

Like before, the guns found have a 5% chance to have a rigged (explosive) power cell, a 10% chance to be unrechargable, and a 15% chance to start with a random amount of charge.

This PR does not touch the bullet-based xenoarcheology guns, but those might be changed in the future.

[tweak]

<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
:cl:
 * tweak: Energy weapons found in xenoarcheology will now have more varying statistics and attributes.
