### PR TITLE
Reworks floor_tile

### DIFF
--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -327,7 +327,7 @@ var/global/list/floorbot_targets=list()
 			visible_message("<span class='warning'>[src] begins to improve the floor.</span>")
 			repairing = 1
 			spawn(50)
-				F.make_plasteel_floor(new /obj/item/stack/tile/plasteel)
+				F.make_plasteel_floor()
 				repairing = 0
 				amount -= 1
 				update_icon()

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -448,10 +448,9 @@
 /turf/simulated/floor/holofloor/grass
 	name = "lush Grass"
 	icon_state = "grass1"
-	floor_tile = new/obj/item/stack/tile/grass
+	floor_tile = /obj/item/stack/tile/grass
 
 /turf/simulated/floor/holofloor/grass/New()
-	floor_tile.New() //I guess New() isn't run on objects spawned without the definition of a turf to house them, ah well.
 	icon_state = "grass[pick("1","2","3","4")]"
 	..()
 	spawn(4)

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -359,7 +359,7 @@
 		var/turf/simulated/floor/T = new_turf
 		if(!T.is_plating())
 			if(!T.broken && !T.burnt)
-				new T.floor_tile.type(T)
+				new T.floor_tile(T)
 			T.make_plating()
 	return !new_turf.intact
 

--- a/code/game/objects/items/stacks/tiles/mineral.dm
+++ b/code/game/objects/items/stacks/tiles/mineral.dm
@@ -139,10 +139,6 @@
 
 	material = "phazon"
 
-/obj/item/stack/tile/mineral/phazon/adjust_slowdown(mob/living/L, current_slowdown)
-	current_slowdown *= 0.75
-	..()
-
 /obj/item/stack/tile/mineral/brass
 	name = "brass tile"
 	singular_name = "brass floor tile"

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -9,9 +9,6 @@
 	var/material
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/sheets_n_ores.dmi', "right_hand" = 'icons/mob/in-hand/right/sheets_n_ores.dmi')
 
-/obj/item/stack/tile/proc/adjust_slowdown(mob/living/L, current_slowdown)
-	return current_slowdown
-
 /obj/item/stack/tile/ex_act(severity)
 	switch(severity)
 		if(1.0)
@@ -147,7 +144,7 @@
 
 	material = "fabric"
 
-obj/item/stack/tile/slime
+/obj/item/stack/tile/slime
 	name = "tile of slime"
 	desc = "A flat piece of slime made through xenobiology"
 	icon_state = "tile-slime"
@@ -159,10 +156,3 @@ obj/item/stack/tile/slime
 	flags = FPRINT
 	siemens_coefficient = 1
 	max_amount = 60
-
-/obj/item/stack/tile/slime/adjust_slowdown(mob/living/L, current_slowdown)
-	if(isslimeperson(L) || isslime(L))
-		current_slowdown *= 5
-	else
-		current_slowdown *= 0.01
-	..()

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -34,7 +34,7 @@ var/list/wood_icons = list("wood","wood-broken")
 	var/burnt = 0
 	var/material = "metal"
 	var/spam_flag = 0 //For certain interactions, like bananium floors honking when stepped on
-	var/obj/item/stack/tile/floor_tile
+	var/floor_tile = /obj/item/stack/tile/plasteel
 	var/image/floor_overlay
 
 	melt_temperature = 1643.15 // Melting point of steel
@@ -46,9 +46,6 @@ var/list/wood_icons = list("wood","wood-broken")
 
 /turf/simulated/floor/New()
 	..()
-	if(!floor_tile)
-		floor_tile = new /obj/item/stack/tile/plasteel(null)
-		floor_tile.amount = 1
 	if(icon_state in icons_to_ignore_at_floor_init) //so damaged/burned tiles or plating icons aren't saved as the default
 		icon_regular_floor = "floor"
 	else
@@ -115,7 +112,9 @@ turf/simulated/floor/update_icon()
 	else if(is_slime_floor())
 		icon_state = "tile-slime"
 	else if(is_light_floor())
-		var/obj/item/stack/tile/light/T = floor_tile
+		world.log << "TODO"
+		// TODO
+		/*var/obj/item/stack/tile/light/T = floor_tile
 		overlays -= floor_overlay //Removes overlay without removing other overlays. Replaces it a few lines down if on.
 		if(T.on)
 			set_light(5)
@@ -125,7 +124,7 @@ turf/simulated/floor/update_icon()
 			light_color = floor_overlay.color
 		else
 			set_light(0)
-			icon_state = "light_off"
+			icon_state = "light_off"*/
 	else if(is_grass_floor())
 		if(!broken && !burnt)
 			if(!(icon_state in list("grass1","grass2","grass3","grass4")))
@@ -182,11 +181,7 @@ turf/simulated/floor/update_icon()
 //				to_chat(world, "[icon_state]y's got [icon_state]")
 	else if(is_mineral_floor())
 		if(!broken && !burnt)
-			icon_state = floor_tile.material
-	/*spawn(1)
-		if(istype(src,/turf/simulated/floor)) //Was throwing runtime errors due to a chance of it changing to space halfway through.
-			if(air)
-				update_visuals(air)*/
+			icon_state = material
 
 /turf/simulated/floor/return_siding_icon_state()
 	..()
@@ -206,10 +201,11 @@ turf/simulated/floor/update_icon()
 	return src.attack_hand(user)
 
 /turf/simulated/floor/attack_hand(mob/user as mob)
-	if (is_light_floor())
+	world.log << "TODO"
+	/*if (is_light_floor())
 		var/obj/item/stack/tile/light/T = floor_tile
 		T.on = !T.on
-		update_icon()
+		update_icon()*/
 
 	switch(material)
 		if("bananium")
@@ -229,42 +225,42 @@ turf/simulated/floor/update_icon()
 	break_tile()
 
 /turf/simulated/floor/is_plasteel_floor()
-	if(istype(floor_tile,/obj/item/stack/tile/plasteel))
+	if(ispath(floor_tile, /obj/item/stack/tile/plasteel))
 		return 1
 	else
 		return 0
 
 /turf/simulated/floor/is_light_floor()
-	if(istype(floor_tile,/obj/item/stack/tile/light))
+	if(ispath(floor_tile, /obj/item/stack/tile/light))
 		return 1
 	else
 		return 0
 
 /turf/simulated/floor/is_grass_floor()
-	if(istype(floor_tile,/obj/item/stack/tile/grass))
+	if(ispath(floor_tile, /obj/item/stack/tile/grass))
 		return 1
 	else
 		return 0
 
 /turf/simulated/floor/is_wood_floor()
-	if(istype(floor_tile,/obj/item/stack/tile/wood))
+	if(ispath(floor_tile, /obj/item/stack/tile/wood))
 		return 1
 	else
 		return 0
 
 /turf/simulated/floor/is_carpet_floor()
-	if(istype(floor_tile,/obj/item/stack/tile/carpet))
+	if(ispath(floor_tile, /obj/item/stack/tile/carpet))
 		return 1
 	else
 		return 0
 
 /turf/simulated/floor/is_arcade_floor()
-	if(istype(floor_tile,/obj/item/stack/tile/arcade))
+	if(ispath(floor_tile, /obj/item/stack/tile/arcade))
 		return 1
 	return 0
 
 /turf/simulated/floor/is_slime_floor()
-	if(istype(floor_tile,/obj/item/stack/tile/slime))
+	if(ispath(floor_tile, /obj/item/stack/tile/slime))
 		return 1
 	else
 		return 0
@@ -275,7 +271,7 @@ turf/simulated/floor/update_icon()
 	return 0
 
 /turf/simulated/floor/is_mineral_floor()
-	if(istype(floor_tile,/obj/item/stack/tile/mineral))
+	if(ispath(floor_tile, /obj/item/stack/tile/mineral))
 		return 1
 	return 0
 
@@ -364,9 +360,6 @@ turf/simulated/floor/update_icon()
 						var/turf/simulated/floor/FF = get_step(src,direction)
 						FF.update_icon() //so siding get updated properly
 
-	if(floor_tile)
-		//qdel(floor_tile)
-		qdel(floor_tile)
 	icon_plating = "plating"
 	set_light(0)
 	floor_tile = null
@@ -382,27 +375,24 @@ turf/simulated/floor/update_icon()
 //This proc will make the turf a plasteel floor tile. The expected argument is the tile to make the turf with
 //If none is given it will make a new object. dropping or unequipping must be handled before or after calling
 //this proc.
-/turf/simulated/floor/proc/make_plasteel_floor(var/obj/item/stack/tile/plasteel/T = null)
-	if(floor_tile)
-		qdel(floor_tile)
-	floor_tile = null
-	floor_tile = new T.type(null)
-	material = floor_tile.material
+/turf/simulated/floor/proc/make_plasteel_floor(floortype = /obj/item/stack/tile/plasteel, material = "metal")
+	floor_tile = floortype
+	src.material = material
 	intact = 1
 	plane = TURF_PLANE
-	if(istype(T,/obj/item/stack/tile/light))
+	/*if(istype(T,/obj/item/stack/tile/light))
 		var/obj/item/stack/tile/light/L = T
 		var/obj/item/stack/tile/light/F = floor_tile
 		F.color_r = L.color_r
 		F.color_g = L.color_g
 		F.color_b = L.color_b
-		F.on = L.on
-	if(istype(T,/obj/item/stack/tile/grass))
+		F.on = L.on*/
+	if(ispath(floortype, /obj/item/stack/tile/grass))
 		for(var/direction in cardinal)
 			if(istype(get_step(src,direction),/turf/simulated/floor))
 				var/turf/simulated/floor/FF = get_step(src,direction)
 				FF.update_icon() //so siding gets updated properly
-	else if(istype(T,/obj/item/stack/tile/carpet))
+	else if(ispath(floortype, /obj/item/stack/tile/carpet))
 		for(var/direction in alldirs)
 			if(istype(get_step(src,direction),/turf/simulated/floor))
 				var/turf/simulated/floor/FF = get_step(src,direction)
@@ -410,89 +400,43 @@ turf/simulated/floor/update_icon()
 	update_icon()
 	levelupdate()
 	playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
+
 //This proc will make the turf a light floor tile. The expected argument is the tile to make the turf with
 //If none is given it will make a new object. dropping or unequipping must be handled before or after calling
 //this proc.
-/turf/simulated/floor/proc/make_light_floor(var/obj/item/stack/tile/light/T = null)
+/turf/simulated/floor/proc/make_light_floor()
 	broken = 0
 	burnt = 0
 	intact = 1
 	plane = TURF_PLANE
-	if(floor_tile)
-		qdel(floor_tile)
-	floor_tile = null
-	if(T)
-		if(istype(T,/obj/item/stack/tile/light))
-			floor_tile = T
-			update_icon()
-			levelupdate()
-			return
-	//if you gave a valid parameter, it won't get thisf ar.
-	floor_tile = new /obj/item/stack/tile/light(null)
-
+	floor_tile = /obj/item/stack/tile/light
 	update_icon()
 	levelupdate()
 
-//This proc will make a turf into a grass patch. Fun eh? Insert the grass tile to be used as the argument
-//If no argument is given a new one will be made.
-/turf/simulated/floor/proc/make_grass_floor(var/obj/item/stack/tile/grass/T = null)
+/turf/simulated/floor/proc/make_grass_floor()
 	broken = 0
 	burnt = 0
 	intact = 1
 	plane = TURF_PLANE
-	if(floor_tile)
-		qdel(floor_tile)
-	floor_tile = null
-	if(T)
-		if(istype(T,/obj/item/stack/tile/grass))
-			floor_tile = T
-			update_icon()
-			levelupdate()
-			return
-	//if you gave a valid parameter, it won't get thisf ar.
-	floor_tile = new /obj/item/stack/tile/wood(null)
+	floor_tile = /obj/item/stack/tile/wood
 	update_icon()
 	levelupdate()
 
-//This proc will make a turf into a wood floor. Fun eh? Insert the wood tile to be used as the argument
-//If no argument is given a new one will be made.
-/turf/simulated/floor/proc/make_wood_floor(var/obj/item/stack/tile/wood/T = null)
+/turf/simulated/floor/proc/make_wood_floor()
 	broken = 0
 	burnt = 0
 	intact = 1
 	plane = TURF_PLANE
-	if(floor_tile)
-		qdel(floor_tile)
-	floor_tile = null
-	if(T)
-		if(istype(T,/obj/item/stack/tile/wood))
-			floor_tile = T
-			update_icon()
-			levelupdate()
-			return
-	//if you gave a valid parameter, it won't get thisf ar.
-	floor_tile = new /obj/item/stack/tile/wood(null)
+	floor_tile = /obj/item/stack/tile/wood
 	update_icon()
 	levelupdate()
 
-//This proc will make a turf into a carpet floor. Fun eh? Insert the carpet tile to be used as the argument
-//If no argument is given a new one will be made.
-/turf/simulated/floor/proc/make_carpet_floor(var/obj/item/stack/tile/carpet/T = null)
+/turf/simulated/floor/proc/make_carpet_floor()
 	broken = 0
 	burnt = 0
 	intact = 1
 	plane = TURF_PLANE
-	if(floor_tile)
-		qdel(floor_tile)
-	floor_tile = null
-	if(T)
-		if(istype(T,/obj/item/stack/tile/carpet))
-			floor_tile = T
-			update_icon()
-			levelupdate()
-			return
-	//if you gave a valid parameter, it won't get thisf ar.
-	floor_tile = new /obj/item/stack/tile/carpet(null)
+	floor_tile = /obj/item/stack/tile/carpet
 
 	update_icon()
 	levelupdate()
@@ -501,16 +445,10 @@ turf/simulated/floor/update_icon()
 /turf/simulated/floor/singularity_pull(S, current_size)
 	if(current_size >= STAGE_FIVE)
 		if(prob(75))
-			if(floor_tile && !broken && !burnt)
-				floor_tile.forceMove(src)
-				floor_tile = null
 			make_plating()
 		return
 	if(current_size == STAGE_FOUR)
 		if(prob(30))
-			if(floor_tile && !broken && !burnt)
-				floor_tile.forceMove(src)
-				floor_tile = null
 			make_plating()
 
 /turf/simulated/floor/attackby(obj/item/C as obj, mob/user as mob)
@@ -531,11 +469,11 @@ turf/simulated/floor/update_icon()
 				var/obj/item/stack/tile/light/T = floor_tile
 				floor_overlay = T.get_turf_image()
 				overlays -= floor_overlay // This removes the light floor overlay, but not other floor overlays.
-				floor_tile.forceMove(src)
+				new floor_tile(src)
 				floor_tile = null
 			else
-				to_chat(user, "<span class='notice'>You remove the [floor_tile.name].</span>")
-				floor_tile.forceMove(src)
+				to_chat(user, "<span class='notice'>You remove the [name].</span>")
+				new floor_tile(src)
 				floor_tile = null
 
 		make_plating()
@@ -550,7 +488,7 @@ turf/simulated/floor/update_icon()
 			else
 				if(is_wood_floor())
 					to_chat(user, "<span class='notice'>You unscrew the planks.</span>")
-					new floor_tile.type(src)
+					new floor_tile(src)
 
 			make_plating()
 			C.playtoolsound(src, 80)
@@ -575,7 +513,7 @@ turf/simulated/floor/update_icon()
 			if(!broken && !burnt)
 				var/obj/item/stack/tile/T = C
 				if(T.use(1))
-					make_plasteel_floor(T)
+					make_plasteel_floor(T.type, T.material)
 			else
 				to_chat(user, "<span class='warning'>This section is too damaged to support a tile. Use a welder to fix the damage.</span>")
 	else if(isshovel(C))
@@ -675,10 +613,3 @@ turf/simulated/floor/update_icon()
 /turf/simulated/floor/clockworkify()
 	ChangeTurf(/turf/simulated/floor/mineral/clockwork)
 	turf_animation('icons/effects/effects.dmi',CLOCKWORK_GENERIC_GLOW, 0, 0, MOB_LAYER-1, anim_plane = TURF_PLANE)
-
-/turf/simulated/floor/adjust_slowdown(mob/living/L, current_slowdown)
-	//Phazon floors make movement faster
-	if(floor_tile)
-		current_slowdown = floor_tile.adjust_slowdown(L, current_slowdown)
-
-	return ..()

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -34,32 +34,20 @@
 
 /turf/simulated/floor/vox/wood
 	icon_state = "wood"
-	floor_tile
+	floor_tile = /obj/item/stack/tile/wood
 
 	autoignition_temperature = AUTOIGNITION_WOOD
 	fire_fuel = 10
 	soot_type = null
 	melt_temperature = 0 // Doesn't melt.
 
-/turf/simulated/floor/vox/wood/New()
-	if(floor_tile)
-		qdel(floor_tile)
-		floor_tile = null
-	floor_tile = new /obj/item/stack/tile/wood(null)
-	..()
-
 /turf/simulated/floor/light
 	name = "Light floor"
 	luminosity = 5
 	icon_state = "light_on"
-	floor_tile
+	floor_tile = /obj/item/stack/tile/light
 
 /turf/simulated/floor/light/New()
-	if(floor_tile)
-		qdel(floor_tile)
-		floor_tile = null
-	floor_tile = new /obj/item/stack/tile/light(null)
-	floor_tile.New() //I guess New() isn't run on objects spawned without the definition of a turf to house them, ah well.
 	var/n = name //just in case commands rename it in the ..() call
 	..()
 	spawn(4)
@@ -70,16 +58,12 @@
 /turf/simulated/floor/wood
 	name = "floor"
 	icon_state = "wood"
-	floor_tile
+	floor_tile = /obj/item/stack/tile/wood
 
 	autoignition_temperature = AUTOIGNITION_WOOD
 	fire_fuel = 10
 	soot_type = null
 	melt_temperature = 0 // Doesn't melt.
-
-/turf/simulated/floor/wood/New()
-	floor_tile = new /obj/item/stack/tile/wood(null)
-	..()
 
 /turf/simulated/floor/vault
 	icon_state = "rockvault"
@@ -218,13 +202,6 @@
 	..()
 	name = "deck"
 
-/turf/simulated/floor/plating/New()
-	..()
-	if(floor_tile)
-		qdel(floor_tile)
-		floor_tile = null
-
-
 /turf/simulated/floor/plating/airless
 	icon_state = "plating"
 	name = "airless plating"
@@ -283,14 +260,9 @@
 /turf/simulated/floor/grass
 	name = "Grass patch"
 	icon_state = "grass1"
-	floor_tile
+	floor_tile = /obj/item/stack/tile/grass
 
 /turf/simulated/floor/grass/New()
-	if(floor_tile)
-		qdel(floor_tile)
-		floor_tile = null
-	floor_tile = new /obj/item/stack/tile/grass(null)
-	floor_tile.New() //I guess New() isn't ran on objects spawned without the definition of a turf to house them, ah well.
 	icon_state = "grass[pick("1","2","3","4")]"
 	..()
 	spawn(4)
@@ -304,15 +276,10 @@
 /turf/simulated/floor/carpet
 	name = "Carpet"
 	icon_state = "carpet"
-	floor_tile
+	floor_tile = /obj/item/stack/tile/carpet
 	var/has_siding=1
 
 /turf/simulated/floor/carpet/New()
-	if(floor_tile)
-		qdel(floor_tile)
-		floor_tile = null
-	floor_tile = new /obj/item/stack/tile/carpet(null)
-	floor_tile.New() //I guess New() isn't ran on objects spawned without the definition of a turf to house them, ah well.
 	if(!icon_state)
 		icon_state = initial(icon_state)
 	..()
@@ -331,14 +298,7 @@
 /turf/simulated/floor/arcade
 	name = "Arcade Carpet"
 	icon_state = "arcade"
-	floor_tile
-
-/turf/simulated/floor/arcade/New()
-	if(floor_tile)
-		qdel(floor_tile)
-		floor_tile = null
-	floor_tile = new /obj/item/stack/tile/arcade(null)
-	..()
+	floor_tile = /obj/item/stack/tile/arcade
 
 /turf/simulated/floor/damaged
 	icon_state = "damaged1"

--- a/code/game/turfs/simulated/mineral.dm
+++ b/code/game/turfs/simulated/mineral.dm
@@ -1,100 +1,64 @@
-//MINERAL FLOORS ARE HERE
-//Includes: PLASMA, GOLD, SILVER, BANANIUM, DIAMOND, URANIUM, PHAZON
-
-//PLASMA
-
-/turf/simulated/floor/mineral/New()
-	if(floor_tile)
-		material = floor_tile.material
-	..()
-
 /turf/simulated/floor/mineral/plasma
 	name = "plasma floor"
 	icon_state = "plasma"
-
-/turf/simulated/floor/mineral/plasma/New()
-	floor_tile = new /obj/item/stack/tile/mineral/plasma(null)
-	..()
+	floor_tile = /obj/item/stack/tile/mineral/plasma
 
 //GOLD
 
 /turf/simulated/floor/mineral/gold
 	name = "gold floor"
 	icon_state = "gold"
-
-/turf/simulated/floor/mineral/gold/New()
-	floor_tile = new /obj/item/stack/tile/mineral/gold(null)
-	..()
+	floor_tile = /obj/item/stack/tile/mineral/gold
 
 //SILVER
 
 /turf/simulated/floor/mineral/silver
 	name = "silver floor"
 	icon_state = "silver"
-
-/turf/simulated/floor/mineral/silver/New()
-	floor_tile = new /obj/item/stack/tile/mineral/silver(null)
-	..()
+	floor_tile = /obj/item/stack/tile/mineral/silver
 
 //BANANIUM
 
 /turf/simulated/floor/mineral/clown
 	name = "bananium floor"
 	icon_state = "bananium"
-
-/turf/simulated/floor/mineral/clown/New()
-	floor_tile = new /obj/item/stack/tile/mineral/clown(null)
-	..()
+	floor_tile = /obj/item/stack/tile/mineral/clown
 
 //DIAMOND
 
 /turf/simulated/floor/mineral/diamond
 	name = "diamond floor"
 	icon_state = "diamond"
-
-/turf/simulated/floor/mineral/diamond/New()
-	floor_tile = new /obj/item/stack/tile/mineral/diamond(null)
-	..()
+	floor_tile = /obj/item/stack/tile/mineral/diamond
 
 //URANIUM
 
 /turf/simulated/floor/mineral/uranium
 	name = "uranium floor"
 	icon_state = "uranium"
-
-/turf/simulated/floor/mineral/uranium/New()
-	floor_tile = new /obj/item/stack/tile/mineral/uranium(null)
-	..()
+	floor_tile = /obj/item/stack/tile/mineral/uranium
 
 //PLASTIC
 
 /turf/simulated/floor/mineral/plastic
 	name = "plastic floor"
 	icon_state = "plastic"
-
-/turf/simulated/floor/mineral/plastic/New()
-	floor_tile = new /obj/item/stack/tile/mineral/plastic(null)
-	..()
+	floor_tile = /obj/item/stack/tile/mineral/plastic
 
 //PHAZON
 
 /turf/simulated/floor/mineral/phazon
 	name = "phazon floor"
 	icon_state = "phazon"
-
-/turf/simulated/floor/mineral/phazon/New()
-	floor_tile = new /obj/item/stack/tile/mineral/phazon(null)
-	..()
+	floor_tile = /obj/item/stack/tile/mineral/phazon
+	turf_speed_multiplier = 1.75
 
 //BRASS
 
 /turf/simulated/floor/mineral/clockwork
 	name = "brass floor"
 	icon_state = "brass"
-
-/turf/simulated/floor/mineral/clockwork/New()
-	floor_tile = new /obj/item/stack/tile/mineral/brass(null)
-	..()
+	floor_tile = /obj/item/stack/tile/mineral/brass
 
 /turf/simulated/floor/mineral/clockwork/cultify()
 	return
@@ -132,9 +96,5 @@
 /turf/simulated/floor/mineral/gingerbread
 	name = "gingerbread panel floor"
 	icon_state = "gingerbread"
-	floor_tile
+	floor_tile = /obj/item/stack/tile/mineral/gingerbread
 	//I spent 10 hours trying to figure out how to make this use the nice randomized floors with the little peppermints I was so proud of. I give up, fuck floor tiles.
-
-/turf/simulated/floor/mineral/gingerbread/New()
-	floor_tile = new /obj/item/stack/tile/mineral/gingerbread(null)
-	..()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -376,9 +376,6 @@
 
 	if(istype(src,/turf/simulated/floor))
 		var/turf/simulated/floor/F = src
-		if(F.floor_tile)
-			qdel(F.floor_tile)
-			F.floor_tile = null
 		F = null
 
 	if(ispath(N, /turf/simulated/floor))

--- a/code/modules/RCD/schematics/tile.dm
+++ b/code/modules/RCD/schematics/tile.dm
@@ -157,7 +157,7 @@
 /datum/paint_info/proc/validate(var/turf/simulated/floor/test)
 	switch (ftype)
 		if (PAINT_FLOOR) //why is it named plasteel anyway?
-			if (!(istype(test.floor_tile,/obj/item/stack/tile/plasteel)))
+			if (!(ispath(test.floor_tile,/obj/item/stack/tile/plasteel)))
 				return 0 //if it's carpet, wood or some other stuff, we aren't going to paint that
 			if (istype(test, /turf/simulated/floor/engine))
 				return 0 	//reinforced floor has plasteel in floor_tile too

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -50,8 +50,12 @@
 			light = new/datum/light_source(src, .)
 
 // Incase any lighting vars are on in the typepath we turn the light on in New().
+//var/global/list/mytypes = list()
 /atom/New()
 	. = ..()
+/*	if (!("[type]" in mytypes))
+		mytypes["[type]"] = 0
+	mytypes["[type]"] += 1*/
 
 	if (light_power && light_range)
 		update_light()

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -696,7 +696,6 @@ turf/unsimulated/mineral/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_l
 
 /turf/simulated/floor/asteroid/New()
 	..()
-	qdel(floor_tile)
 	floor_tile = null
 	if(prob(20))
 		icon_state = "asteroid[rand(0,12)]"

--- a/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
@@ -465,8 +465,7 @@
 				return
 			if(prob(15))
 				visible_message("<span class = 'warning'>\The [src] pries up \the [F]!</span>")
-			F.floor_tile.forceMove(src)
-			F.floor_tile = null
+			new F.floor_tile(src)
 			F.make_plating()
 
 /mob/living/simple_animal/hostile/syphoner/CanAttack(var/atom/the_target)


### PR DESCRIPTION
Did you know that `/obj/item/stack/tile/plasteel` is the second most spawned item with 18000 instances?

top5 most spawned shit on box:
```
/atom/movable/lighting_overlay : 44292
/obj/item/stack/tile/plasteel : 18972
/turf/unsimulated/mineral/random : 13496
/turf/simulated/floor : 8285
/obj/structure/window/reinforced : 6552
```

After this PR that number will drop to zero (0). Approx ~50 mb less memory usage and a few seconds faster init times on my computer.

Instead of spawning and storing a tile object now it stores the typepath of it

This PR breaks some shit and I'm opening this draft just in case I'm missing something

- [x] Placing and removing tiles
- [ ] Light tiles
- [ ] Speed modifiers
