### PR TITLE
Fixes Pass the Pumpkin/Summon Snacks

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -40,6 +40,7 @@
 	var/cant_remove_msg = " cannot be taken off!"
 	var/cant_drop = FALSE //If 1, can't drop it from hands!
 	var/cant_drop_msg = " sticks to your hand!"
+	var/laying_pickup = FALSE //Allows things to be placed in hands while the owner of those hands is laying
 
 	var/armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	var/armor_absorb = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)

--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -264,6 +264,7 @@
 	icon = 'icons/obj/clothing/hats.dmi'
 	icon_state = "hardhat1_pumpkin"
 	cant_drop = 1
+	laying_pickup = TRUE
 
 /obj/item/weapon/carnivorous_pumpkin/New()
 	..()

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -207,7 +207,7 @@
 	return put_in_hand(GRASP_RIGHT_HAND, W)
 
 /mob/proc/put_in_hand_check(var/obj/item/W, index)
-	if(lying) //&& !(W.flags & ABSTRACT))
+	if(lying && !W.laying_pickup) //&& !(W.flags & ABSTRACT))
 		return 0
 	if(!isitem(W))
 		return 0

--- a/code/modules/spells/targeted/summon_snacks.dm
+++ b/code/modules/spells/targeted/summon_snacks.dm
@@ -121,6 +121,7 @@
 	desc = "Magically delicious."
 	icon_state = "spellburger"
 	cant_drop = 1
+	laying_pickup = TRUE
 
 /obj/item/weapon/reagent_containers/food/snacks/summoned/proc/spellInherit(var/menu, var/biteS, var/diabeetus)
 	switch(menu)


### PR DESCRIPTION
Tweak to make it so items can be set to be allowed to be picked up when laying down. This means things like Pass the Pumpkin can be properly forced into laying people's hands.

[bugfix]

:cl:
 * bugfix: Pass the Pumpkin/Summon Snacks now work on laying targets