### PR TITLE
Replaces the Zombie Syndrome GNA Disk traitor item with a collection of 3 random Deadly Stage 4 Syndromes GNA disks

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -722,10 +722,10 @@ var/list/uplink_items = list()
 	discounted_cost = 12
 	jobs_with_discount = list("Geneticist", "Chief Medical Officer")
 
-/datum/uplink_item/jobspecific/medical/zombievirus
-	name = "Zombie Virus Syndrome"
-	desc = "This syndrome will cause people to turn into zombies when the virus hits Stage 4. Comes in a virus data disk, requires full virus splicing and growth to deploy. Avoid ingesting end results if possible, and ensure you create spare virus data disks if needed."
-	item = /obj/item/weapon/disk/disease/zombie
+/datum/uplink_item/jobspecific/medical/viruscollection
+	name = "Deadly Syndrome Collection"
+	desc = "A diskette box filled with 3 random Deadly stage 4 syndromes GNA disks (the same syndrome won't show up twice) on top of a Waiting Syndrome GNA disk to help your disease spread undetected."
+	item = /obj/item/weapon/storage/lockbox/diskettebox/syndisease
 	cost = 20
 	discounted_cost = 12
 	jobs_with_discount = list("Virologist", "Chief Medical Officer")

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -17,7 +17,8 @@ mob/living/carbon/proc/dream()
 		"an abandoned laboratory","The Syndicate","blood","falling","flames","ice","the cold","an operating table","a war","red men","malfunctioning robots",
 		"a ship full of spiders","valids","hardcore","your mom","lewd","explosions","broken bones","clowns everywhere","features","a crash","a skrell","a unathi","a tajaran",
 		"a vox","a plasmaman","a skellington","a diona","the derelict","the end of the world","the thunderdome","a ship full of dead clowns","a chicken with godlike powers",
-		"a red bus that drives through space",
+		"a red bus that drives through space","an alien artifact","the mechanic","a newspaper","an insectoid","a slime","a slime person","a mushroom person",
+		"the Cult of Nar-Sie","the Wizard Federation","an impossibly gigantic lamprey floating through space, bending reality as it goes",
 		)
 	spawn(0)
 		for(var/i = rand(1,4),i > 0, i--)

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -442,7 +442,38 @@ var/list/virusdishes = list()
 		to_chat(user, "<span class='info'>Strength: [effect.multiplier]</span>")
 		to_chat(user, "<span class='info'>Occurrence: [effect.chance]</span>")
 
+/////////////TRAITOR STUFF//////////////////
+
+/obj/item/weapon/storage/lockbox/diskettebox/syndisease/New()
+	..()
+	new /obj/item/weapon/disk/disease/invisible(src)
+
+	var/list/potential_deadly_symptoms = list()
+
+	for (var/diseasetype in subtypesof(/datum/disease2/effect))
+		var/datum/disease2/effect/E = diseasetype
+		if (initial(E.restricted))
+			continue
+		if (initial(E.stage) == 4 && initial(E.badness) == EFFECT_DANGER_DEADLY)
+			potential_deadly_symptoms += diseasetype
+
+	for(var/i = 1 to 3)
+		if (potential_deadly_symptoms.len < 1)
+			break
+		var/obj/item/weapon/disk/disease/syndisk = new(src)
+		var/effect_type = pick(potential_deadly_symptoms)
+		syndisk.effect = new effect_type()
+		syndisk.name = "\improper [syndisk.effect.name] GNA disk (Stage: [syndisk.effect.stage])"
+		syndisk.stage = syndisk.effect.stage
+		potential_deadly_symptoms -= effect_type
+	update_icon()
+
+/obj/item/weapon/disk/disease/invisible
+	name = "\improper Waiting Syndrome GNA disk (Stage 1)"
+	effect = new /datum/disease2/effect/invisible
+	stage = 1
+
 /obj/item/weapon/disk/disease/zombie
-	name = "\improper Stubborn Brain Syndrome (Stage 4)"
+	name = "\improper Stubborn Brain Syndrome GNA disk (Stage 4)"
 	effect = new /datum/disease2/effect/zombie
 	stage = 4


### PR DESCRIPTION
The TC cost stays the same because 12 TC for the fucking useless Stuborn Brain syndrome was a fucking scam.

![image](https://user-images.githubusercontent.com/7573912/91474507-9a539d00-e89a-11ea-88a6-1325cfb90204.png)

If security asks you where you got that diskette box, just tell them you purchased it from the Merch computer, it does sell those.

:cl:
* rscdel: Removed the Zombie Virus Syndrome virologist traitor item.
* rscadd: Added the Deadly Syndrome Collection virologist traitor item, a diskette box filled with 3 random Deadly stage 4 syndromes GNA disks (the same syndrome won't show up twice) on top of a Waiting Syndrome GNA disk to help your disease spread undetected.