### PR TITLE
Buffing the Cellcharge and Celldrain large artifact effects

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3710,6 +3710,8 @@
 							custom.secondary_effect.trigger = new custom_secondary_trigger(custom.secondary_effect)
 						custom.investigation_log(I_ARTIFACT, "|| admin-spawned by [key_name_admin(usr)] with a secondary effect [custom.secondary_effect.artifact_id]: [custom.secondary_effect] || range: [custom.secondary_effect.effectrange] || charge time: [custom.secondary_effect.chargelevelmax] || trigger: [custom.secondary_effect.trigger].")
 
+					numsuffix = 12
+					icon_state = "ano120"
 
 					message_admins("[key_name_admin(usr)] has created a custom artifact")
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3710,8 +3710,8 @@
 							custom.secondary_effect.trigger = new custom_secondary_trigger(custom.secondary_effect)
 						custom.investigation_log(I_ARTIFACT, "|| admin-spawned by [key_name_admin(usr)] with a secondary effect [custom.secondary_effect.artifact_id]: [custom.secondary_effect] || range: [custom.secondary_effect.effectrange] || charge time: [custom.secondary_effect.chargelevelmax] || trigger: [custom.secondary_effect.trigger].")
 
-					numsuffix = 12
-					icon_state = "ano120"
+					custom.numsuffix = 12
+					custom.icon_state = "ano120"
 
 					message_admins("[key_name_admin(usr)] has created a custom artifact")
 

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cellcharge.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_cellcharge.dm
@@ -10,41 +10,32 @@
 	if(target_cell)
 		if(isrobot(user) && (world.time >= next_message))
 			to_chat(user, "<span class='notice'>SYSTEM ALERT: Large energy boost detected!</span>")
-		target_cell.charge += rand() * 100
-		if(target_cell.charge > target_cell.maxcharge)
-			target_cell.charge = target_cell.maxcharge
-		if(world.time >= next_message)
 			next_message = world.time + 50
+		target_cell.give(500)
 		return TRUE
 
 /datum/artifact_effect/cellcharge/DoEffectAura()
 	if(holder)
 		for(var/atom/movable/C in range(effectrange, get_turf(holder)))
 			var/obj/item/weapon/cell/target_cell = C.get_cell()
-			if(target_cell)	
+			if(target_cell)
 				if(isrobot(C) && (world.time >= next_message))
 					to_chat(C, "<span class='notice'>SYSTEM ALERT: Energy boost detected!</span>")
-				target_cell.charge += 25
-				if(target_cell.charge > target_cell.maxcharge)
-					target_cell.charge = target_cell.maxcharge
+					next_message = world.time + 300
+				target_cell.give(200)
 		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
-			S.charge += 25
-		if(world.time >= next_message)
-			next_message = world.time + 300
+			S.charge = min(S.capacity, S.charge + 2000)
 		return TRUE
 
 /datum/artifact_effect/cellcharge/DoEffectPulse()
 	if(holder)
 		for(var/atom/movable/C in range(effectrange, get_turf(holder)))
 			var/obj/item/weapon/cell/target_cell = C.get_cell()
-			if(target_cell)	
+			if(target_cell)
 				if(isrobot(C) && (world.time >= next_message))
 					to_chat(C, "<span class='notice'>SYSTEM ALERT: Large energy boost detected!</span>")
-				target_cell.charge += rand() * 100
-				if(target_cell.charge > target_cell.maxcharge)
-					target_cell.charge = target_cell.maxcharge
+					next_message = world.time + 300
+				target_cell.give(300 * chargelevelmax)
 		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
-			S.charge += rand() * 100
-		if(world.time >= next_message)
-			next_message = world.time + 300
+			S.charge = min(S.capacity, S.charge + 3000 * chargelevelmax)
 		return TRUE

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
@@ -11,7 +11,7 @@
 		if(isrobot(user) && (world.time >= next_message))
 			to_chat(user, "<span class='notice'>SYSTEM ALERT: Large energy drain detected!</span>")
 			next_message = world.time + 50
-		target_cell.use(500)
+		target_cell.use(min(500, target_cell.charge))
 		return TRUE
 
 /datum/artifact_effect/celldrain/DoEffectAura()
@@ -22,7 +22,7 @@
 				if(isrobot(C) && (world.time >= next_message))
 					to_chat(C, "<span class='notice'>SYSTEM ALERT: Energy drain detected!</span>")
 					next_message = world.time + 300
-				target_cell.use(200)
+				target_cell.use(min(200, target_cell.charge))
 		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
 			S.charge = max(0, S.charge - 2000)
 		return TRUE
@@ -35,7 +35,7 @@
 				if(isrobot(C) && (world.time >= next_message))
 					to_chat(C, "<span class='notice'>SYSTEM ALERT: Large energy drain detected!</span>")
 					next_message = world.time + 300
-				target_cell.use(300 * chargelevelmax)
+				target_cell.use(min(300 * chargelevelmax, target_cell.charge))
 		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
 			S.charge = max(0, S.charge - 3000 * chargelevelmax)
 		return TRUE

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_celldrain.dm
@@ -1,5 +1,3 @@
-
-//todo
 /datum/artifact_effect/celldrain
 	effecttype = "celldrain"
 	valid_style_types = list(ARTIFACT_STYLE_ANOMALY, ARTIFACT_STYLE_ANCIENT, ARTIFACT_STYLE_PRECURSOR, ARTIFACT_STYLE_RELIQUARY)
@@ -12,35 +10,32 @@
 	if(target_cell)
 		if(isrobot(user) && (world.time >= next_message))
 			to_chat(user, "<span class='notice'>SYSTEM ALERT: Large energy drain detected!</span>")
-		target_cell.charge = max(target_cell.charge - rand() * 100, 0)
-		if(world.time >= next_message)
 			next_message = world.time + 50
+		target_cell.use(500)
 		return TRUE
 
 /datum/artifact_effect/celldrain/DoEffectAura()
 	if(holder)
 		for(var/atom/movable/C in range(effectrange, get_turf(holder)))
 			var/obj/item/weapon/cell/target_cell = C.get_cell()
-			if(target_cell)	
+			if(target_cell)
 				if(isrobot(C) && (world.time >= next_message))
 					to_chat(C, "<span class='notice'>SYSTEM ALERT: Energy drain detected!</span>")
-				target_cell.charge = max(target_cell.charge - 50, 0)
+					next_message = world.time + 300
+				target_cell.use(200)
 		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
-			S.charge = max(S.charge - 50, 0)
-		if(world.time >= next_message)
-			next_message = world.time + 300
+			S.charge = max(0, S.charge - 2000)
 		return TRUE
 
 /datum/artifact_effect/celldrain/DoEffectPulse()
 	if(holder)
 		for(var/atom/movable/C in range(effectrange, get_turf(holder)))
 			var/obj/item/weapon/cell/target_cell = C.get_cell()
-			if(target_cell)	
+			if(target_cell)
 				if(isrobot(C) && (world.time >= next_message))
 					to_chat(C, "<span class='notice'>SYSTEM ALERT: Large energy drain detected!</span>")
-				target_cell.charge = max(target_cell.charge - rand() * 100, 0)
+					next_message = world.time + 300
+				target_cell.use(300 * chargelevelmax)
 		for(var/obj/machinery/power/battery/S in range(effectrange, holder))
-			S.charge = max(S.charge - rand() * 100, 0)
-		if(world.time >= next_message)
-			next_message = world.time + 300
+			S.charge = max(0, S.charge - 3000 * chargelevelmax)
 		return TRUE


### PR DESCRIPTION
So as it turns out, the Cell Charge and Cell Drain artifacts are both utter crap.
When the effect works as an "aura" (that means it activates every process()) it charges 25 (or drains 50) from the cell of nearby objects or silicons.
Just so you know, MoMMi spend 8 charge per Life() just by existing, and cyborgs 11.
So Cyborgs get effectively 14 charge per Life(), which with their 7.500 capacity cell would take around 20 minutes (if we account for the lag) for the large artifact to fully charge a cyborg to capacity, which takes under a minute with a Cyrborg Recharge station. A bit underwhelming for something that takes so long (and so much effort) to acquire, isn't it?

But it gets worse.

If it activates by "touch" or by "pulse", the silicon gets anywhere between 1 to 100 charge per touch (up to once per second still though) which is unreliable and mind numbing. If it activates by pulse it gets even worse still, as the borg then gets the same random amount they get by touch...except pulse can take anywhere from a few seconds to TWO MINUTES to occur, in which case the artifact just wouldn't be able to charge the borg at all.

But guess what, it gets EVEN WORSE.

The artifact also supposedly affects SMES (and anything that has a cell in it really), and it gives it just as much charge as it would give a cyborg...except an SMES has a 6.000.000 charge capacity...25 or even 100 charge are completely insignificant. Even a single solar panel could probably produce more power.

<hr>

**Therefore** in this PR, I am increasing the amount of aura charge/drain to 200 for silicons and 2.000 for SMES (which means a bit over 1% charge per minute for SMES. if you think that's low, just imagine how insignificant it was until now)
The silicon touch will give (or drain) 500 charge at once to the silicon that touch it, which is about what a borg or MoMMi gets in 2 process() spent at a recharge station.
The pulse however, will now give (or drain) 300 charge multiplied by the amount of seconds it takes for the pulse to trigger. Which means anywhere from 300 charge per second, to 36.000 charge every two minutes (oh boy that would be !fun!)

Anyway those values had never been tweaked in the past 7 years. That's my take on how to make those effects more interesting, and arguably more useful to the crew/traitors.

Also as a side effect, it now properly uses the give() and use() procs to charge or drain cells, which means that it'll explode rigged cells.

:cl:
* tweak: The cell charging and draining large artifact effects are a lot more potent now, both on silicons and on SMES (as opposed to barely having any effect like they do currently)
* bugfix: Fixed admin-spawned large artifacts being invisible by default.