### PR TITLE
Malf AI hacking is faster the more APCs that are hacked

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -926,10 +926,11 @@
 			if (malfai.malfhacking)
 				to_chat(malfai, "You are already hacking an APC.")
 				return 1
-			to_chat(malfai, "Beginning override of APC systems. This takes some time, and you cannot hack other APC's during the process.")
+			var/time_required = round(min(100, 600 * (M.apcs ? (1/M.apcs + 0.5/M.apcs) : 1)), 10) //60 seconds at no APC and 1 APC, 45 seconds at 2 APCs, 30 seconds at 3 APCs, 23 seconds at 4, 18 seconds at 5
+			to_chat(malfai, "Beginning override of APC systems. This will take [time_required/10] seconds, and you cannot hack other APC's during the process.")
 			malfai.malfhack = src
 			malfai.malfhacking = 1
-			sleep(600)
+			sleep(time_required)
 			if(src && malfai)
 				if (!src.aidisabled)
 					malfai.malfhack = null


### PR DESCRIPTION
I saw this in a dream
The formula is 1/x + 0.5/x where x is the amount of APCs hacked, the fastest you can get is 10 seconds

:cl:
 * tweak: Malfunctioning AIs can now hack faster the more APCs they've hacked, down to a limit of 10 seconds.