### PR TITLE
Research Outpost area ambience tweaks

### DIFF
--- a/code/modules/mining/mine_areas.dm
+++ b/code/modules/mining/mine_areas.dm
@@ -46,6 +46,10 @@
 /area/mine/maintenance
 	name = "Mining Station Communications"
 	holomap_color = HOLOMAP_AREACOLOR_COMMAND
+	ambient_sounds = list(
+		/datum/ambience/tcomms1,
+		/datum/ambience/tcomms2,
+		/datum/ambience/tcomms3)
 
 /area/mine/cafeteria
 	name = "Mining station Cafeteria"

--- a/code/modules/research/xenoarchaeology/areas.dm
+++ b/code/modules/research/xenoarchaeology/areas.dm
@@ -21,15 +21,20 @@
 	name = "Research Outpost Power"
 	icon_state = "engine"
 	holomap_color = HOLOMAP_AREACOLOR_ENGINEERING
+	ambient_sounds = list(/datum/ambience/engi1,/datum/ambience/engi2,/datum/ambience/engi3,/datum/ambience/engi4)
 
 /area/research_outpost/atmos
 	name = "Research Outpost Atmospherics"
 	icon_state = "atmos"
 	holomap_color = HOLOMAP_AREACOLOR_ENGINEERING
+	ambient_sounds = list(/datum/ambience/engi1,/datum/ambience/engi2,/datum/ambience/engi3,/datum/ambience/engi4)
 
 /area/research_outpost/maint
 	name = "Research Outpost Maintenance"
 	icon_state = "maintcentral"
+	ambient_sounds = list(
+		/datum/ambience/maint1,
+		/datum/ambience/maint2)
 
 /area/research_outpost/iso1
 	name = "Isolation Cell"
@@ -55,6 +60,8 @@
 	name = "Mass Spectrometry Lab"
 	icon_state = "anospectro"
 	lightswitch = FALSE
+	ambient_sounds = list(
+		/datum/ambience/ded2)
 
 /area/research_outpost/anomaly
 	name = "Anomalous Materials Lab"
@@ -76,14 +83,23 @@
 /area/research_outpost/tempstorage
 	name = "Temporary Storage"
 	icon_state = "storage"
+	ambient_sounds = list(
+		/datum/ambience/maint1,
+		/datum/ambience/maint2)
 
 /area/research_outpost/maintstore1
 	name = "Auxiliary Storage"
 	icon_state = "auxstorage"
+	ambient_sounds = list(
+		/datum/ambience/maint1,
+		/datum/ambience/maint2)
 
 /area/research_outpost/maintstore2
 	name = "Maintenance Storage"
 	icon_state = "auxstorage"
+	ambient_sounds = list(
+		/datum/ambience/maint1,
+		/datum/ambience/maint2)
 
 /area/research_outpost/breakroom
 	name = "Break Room"


### PR DESCRIPTION
:cl:
* tweak: Tweaked the ambience sounds of the Research Outpost. The Outpost Engineering/Atmos rooms now properly emit the same ambience as those on the station.