### PR TITLE
Lolly lobber and liquorice whip in summon guns/swords + made them less gunky

### DIFF
--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -58,7 +58,7 @@
 			return equip_guns(R)
 
 /mob/living/carbon/human/proc/equip_guns(var/datum/role/R)
-	var/randomizeguns = pick("taser","stunrevolver","egun","laser","retro","laserak","revolver","detective","c20r","nuclear","deagle","gyrojet","pulse","silenced","cannon","doublebarrel","shotgun","combatshotgun","mateba","smg","uzi","microuzi","crossbow","saw","hecate","osipr","gatling","bison","ricochet","spur","mosin","obrez","beegun","beretta","usp","glock","luger","colt","plasmapistol","plasmarifle", "ionpistol", "ioncarbine", "bulletstorm", "combustioncannon", "laserpistol", "siren", "lawgiver", "nt12", "automag")
+	var/randomizeguns = pick("taser","stunrevolver","egun","laser","retro","laserak","revolver","detective","c20r","nuclear","deagle","gyrojet","pulse","silenced","cannon","doublebarrel","shotgun","combatshotgun","mateba","smg","uzi","microuzi","crossbow","saw","hecate","osipr","gatling","bison","ricochet","spur","mosin","obrez","beegun","beretta","usp","glock","luger","colt","plasmapistol","plasmarifle", "ionpistol", "ioncarbine", "bulletstorm", "combustioncannon", "laserpistol", "siren", "lawgiver", "nt12", "automag", "lolly_lobber")
 	switch (randomizeguns)
 		if("taser")
 			new /obj/item/weapon/gun/energy/taser(get_turf(src))
@@ -160,8 +160,11 @@
 			new /obj/item/weapon/gun/bulletstorm(get_turf(src))
 		if("nt12")
 			new /obj/item/weapon/gun/projectile/shotgun/nt12(get_turf(src))
-		if ("automag")
+		if("automag")
 			new /obj/item/weapon/gun/projectile/automag/prestige(get_turf(src))
+		if("lolly_lobber")
+			new /obj/item/weapon/gun/lolly_lobber(get_turf(src))
+
 	var/datum/role/survivor/S = R
 	if(istype(S))
 		S.summons_received = randomizeguns
@@ -169,7 +172,7 @@
 	score["gunsspawned"]++
 
 /mob/living/carbon/human/proc/equip_swords(var/datum/role/R)
-	var/randomizeswords = pick("unlucky", "misc", "throw", "armblade", "pickaxe", "pcutter", "esword", "alt-esword", "machete", "kitchen", "medieval", "katana", "axe", "boot", "saw", "scalpel", "switchtool", "shitcurity")
+	var/randomizeswords = pick("unlucky", "misc", "throw", "armblade", "pickaxe", "pcutter", "esword", "alt-esword", "machete", "kitchen", "medieval", "katana", "axe", "boot", "saw", "scalpel", "switchtool", "shitcurity", "whip")
 	var/randomizeknightcolor = pick("green", "yellow", "blue", "red", "templar", "roman")
 	switch (randomizeknightcolor) //everyone gets some armor as well
 		if("green")
@@ -212,10 +215,7 @@
 			new miscpick(get_turf(src))
 		if("throw")
 			if(prob(20))
-				if(prob(50))
-					new /obj/item/weapon/kitchen/utensil/knife/nazi(get_turf(src))
-				else
-					new /obj/item/weapon/gun/hookshot/whip(get_turf(src))
+				new /obj/item/weapon/kitchen/utensil/knife/nazi(get_turf(src))
 			else
 				new /obj/item/weapon/hatchet(get_turf(src))
 		if("armblade") // good luck getting it off. Maybe cut your own arm off :^)
@@ -303,6 +303,12 @@
 		if("shitcurity") //Might as well give the Redtide a taste of their own medicine.
 			var/shitcurity = pick(/obj/item/weapon/melee/telebaton, /obj/item/weapon/melee/classic_baton, /obj/item/weapon/melee/baton/loaded, /obj/item/weapon/melee/baton/cattleprod,/obj/item/weapon/melee/chainofcommand)
 			new shitcurity(get_turf(src))
+		if("whip")
+			if(prob(50))
+				new /obj/item/weapon/gun/hookshot/whip(get_turf(src))
+			else
+				new /obj/item/projectile/hookshot/whip/liquorice(get_turf(src))
+
 	var/datum/role/survivor/crusader/S = R
 	if(istype(S))
 		S.summons_received = randomizeswords
@@ -434,5 +440,5 @@
 			S.summons_received = P.name
 		if(istype(P, /obj/item/potion/deception))	//Warn someone if that healing potion they just got is a fake one.
 			to_chat(src, "You feel like it's a bad idea to drink the [P.name] yourself...")
-		
+
 	playsound(src,'sound/effects/summon_guns.ogg', 50, 1)

--- a/code/modules/projectiles/guns/projectile/lolly_lobber.dm
+++ b/code/modules/projectiles/guns/projectile/lolly_lobber.dm
@@ -3,13 +3,13 @@
 	desc = "A horrible combination of steel and sweets. Custom made to weaponize candy canes with questionable success."
 	icon = 'icons/obj/gun.dmi'
 	icon_state = "lolly_lobber"
-	item_state = "lolly_lobber"
+	item_state = "redtag"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guninhands_left.dmi', "right_hand" = 'icons/mob/in-hand/right/guninhands_right.dmi')
 	recoil = 0
 	slot_flags = SLOT_BELT
 	flags = FPRINT
 	w_class = W_CLASS_MEDIUM
-	fire_delay = 0
+	fire_delay = 3
 	fire_sound = 'sound/items/syringeproj.ogg'
 	var/max_ammo = 13 //baker's dozen
 	var/current_ammo = 13

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -993,12 +993,12 @@ obj/item/projectile/bullet/suffocationbullet
 	name = "Candycane"
 	icon_state = "candycane"
 	nodamage = 0
-	damage = 25
+	damage = 20
 	capacity = 15
 	decay_type = null
 	custom_impact = null
 
 /obj/item/projectile/bullet/syringe/candycane/New()
 	..()
-	reagents.add_reagent(DIABEETUSOL, 10)
-	reagents.add_reagent(CARAMEL, 5)
+	reagents.add_reagent(DIABEETUSOL, 4)
+	reagents.add_reagent(SUGAR, 5)

--- a/code/modules/projectiles/projectile/hookshot.dm
+++ b/code/modules/projectiles/projectile/hookshot.dm
@@ -214,7 +214,7 @@
 /obj/item/projectile/hookshot/whip/liquorice/to_bump(atom/A as mob)
 	create_reagents(5)
 	reagents.add_reagent(DIABEETUSOL, 2)
-	reagents.add_reagent(CARAMEL, 3)
+	reagents.add_reagent(SUGAR, 3)
 	var/mob/M = A
 	if(ishuman(M))
 		reagents.trans_to(M, reagents.total_volume)


### PR DESCRIPTION
When adding Summon Snacks I also overhauled diabeetusol, which previously only existed in weapons you get from the gingerbread vault. Those weapons were (poorly) balanced around the previous version of diabeetusol. The new version basically turns them into very, very good chloral syringe guns. So I tweaked them.

I replaced the caramel with sugar. This delays the hypoglycemic affects of diabeetusol until enough of the sugar is metabolized. It also makes you gain weight at a very high rate. Too fat with diabeetusol still in your system and your heart will explode just like corn oil. The lolly lobber now also gives significantly less diabeetusol on hit.

**But why? No one has ever or will ever go to that vault to traitor!**
Well of course not, that's why I added the lolly lobber to summon guns and the liquorice whip to summon swords. How awful.

[tweak]

:cl:
 * rscadd: Lolly lobber has been added to summon guns and liquorice whip to summon swords. 
 * tweak: Lolly lobber and liquorice whip will no longer put people into an immediate diabetic coma.