### PR TITLE
Better ironrot smoke damage to borgs

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -7995,8 +7995,9 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 
 	if(method == TOUCH)
 		if(issilicon(M))//borgs are hurt on touch by this chem
-			M.adjustFireLoss(5*REM)
-			M.adjustBruteLoss(5*REM)
+			M.adjustFireLoss(10)
+			M.adjustBruteLoss(10)
+//todo : mech and pod damage
 
 
 /datum/reagent/diabeetusol


### PR DESCRIPTION
When I originally made ironrot I intended for it to be the equivalent of pacid smoke for borgs, but turns out I was comparing the wrong damage stats in pacid and made it woefully underpowered. this fixes that so now borgs can join in on the fun.

also added a todo comment for my sake.

[tweak]

:cl:
 * tweak: Ironrot smoke is buffed to do more effective damage against borgs.