### PR TITLE
Energy Walls now have the same explosion blocking properties as Forcewalls

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -136,6 +136,9 @@ var/explosion_shake_message_cooldown = 0
 					for (var/obj/effect/forcefield/F in Trajectory.contents)
 						dist += F.explosion_block
 
+					for (var/obj/effect/energy_field/E in Trajectory.contents)
+						dist += E.explosion_block
+
 			if(dist < devastation_range)
 				dist = 1
 				pushback = 5

--- a/code/modules/power/ShieldGen/energy_field.dm
+++ b/code/modules/power/ShieldGen/energy_field.dm
@@ -12,6 +12,8 @@
 	invisibility = 101
 	var/strength = 0
 
+	var/explosion_block = 20
+
 /obj/effect/energy_field/ex_act(var/severity)
 	Stress(0.5 + severity)
 


### PR DESCRIPTION
:cl:
* tweak: Energy Walls that are produced by the Starscreen shield generators as well as some large alien artifacts now share the same explosion blocking properties that wizard Forcewalls have. Also making starscreen shield way better at actually protecting the station from asteroids.