### PR TITLE
Adds silencer offsets to a bunch of ballistic weapons

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -16,6 +16,7 @@
 	var/burstfiring = 0
 	load_method = 2
 	mag_type = "/obj/item/ammo_storage/magazine/smg9mm"
+	silencer_offset = list(22,6)
 
 
 /obj/item/weapon/gun/projectile/automatic/isHandgun()
@@ -34,7 +35,7 @@
 
 /obj/item/weapon/gun/projectile/automatic/update_icon()
 	..()
-	icon_state = "[initial(icon_state)][stored_magazine ? "-[stored_magazine.max_ammo]" : ""][silenced ? "-silencer":""][chambered ? "" : "-e"]"
+	icon_state = "[initial(icon_state)][stored_magazine ? "-[stored_magazine.max_ammo]" : ""][chambered ? "" : "-e"]"
 	return
 
 /obj/item/weapon/gun/projectile/automatic/Fire(atom/target, mob/living/user, params, reflex = 0, struggle = 0, var/use_shooter_turf = FALSE)
@@ -88,6 +89,7 @@
 	ammo_type = "/obj/item/ammo_casing/c45"
 	mag_type = "/obj/item/ammo_storage/magazine/uzi45"
 	recoil = 2
+	silencer_offset = list(23,10)
 
 /obj/item/weapon/gun/projectile/automatic/uzi/isHandgun()
 	return TRUE
@@ -119,13 +121,14 @@
 	w_class = W_CLASS_SMALL
 	ammo_type = "/obj/item/ammo_casing/c9mm"
 	mag_type = "/obj/item/ammo_storage/magazine/microuzi9"
+	silencer_offset = list(20,8)
 
 /obj/item/weapon/gun/projectile/automatic/microuzi/isHandgun()
 	return TRUE
 
 /obj/item/weapon/gun/projectile/automatic/microuzi/update_icon()
 	..()
-	icon_state = "micro-uzi[silenced ? "-silencer" : ""][stored_magazine ? "" : "-e"]"
+	icon_state = "micro-uzi[stored_magazine ? "" : "-e"]"
 
 
 /obj/item/weapon/gun/projectile/automatic/c20r
@@ -146,7 +149,7 @@
 	automagdrop_delay_time = 0
 	load_method = 2
 	recoil = 2
-
+	silencer_offset = list(27,5)
 	gun_flags = AUTOMAGDROP | EMPTYCASINGS
 
 /obj/item/weapon/gun/projectile/automatic/c20r/isHandgun()
@@ -177,6 +180,7 @@
 	load_method = 2
 	recoil = 2
 	gun_flags = AUTOMAGDROP | EMPTYCASINGS
+	silencer_offset = list(26,5)
 
 /obj/item/weapon/gun/projectile/automatic/xcom/isHandgun()
 	return FALSE
@@ -203,12 +207,16 @@
 	fire_sound = 'sound/weapons/Gunshot_smg.ogg'
 	load_method = 2
 	recoil = 2
+	silencer_offset = list(27,6)
 	var/cover_open = 0
 
 /obj/item/weapon/gun/projectile/automatic/l6_saw/isHandgun()
 	return FALSE
 
 /obj/item/weapon/gun/projectile/automatic/l6_saw/attack_self(mob/user as mob)
+	if(silenced)
+		RemoveAttach(user)
+		return
 	cover_open = !cover_open
 	to_chat(user, "<span class='notice'>You [cover_open ? "open" : "close"] [src]'s cover.</span>")
 	update_icon()
@@ -243,12 +251,12 @@
 		to_chat(user, "<span class='notice'>You remove the magazine from [src].</span>")
 
 
-/obj/item/weapon/gun/projectile/automatic/l6_saw/attackby(obj/item/ammo_storage/magazine/a762/A as obj, mob/user as mob)
-	if(!cover_open)
-		to_chat(user, "<span class='notice'>[src]'s cover is closed! You can't insert a new mag!</span>")
-		return
-	else if(cover_open)
-		..()
+/obj/item/weapon/gun/projectile/automatic/l6_saw/attackby(var/obj/item/A, mob/user)
+	if(istype(A,/obj/item/ammo_storage/magazine))
+		if(!cover_open)
+			to_chat(user, "<span class='notice'>[src]'s cover is closed! You can't insert a new mag!</span>")
+			return
+	..()
 
 /obj/item/weapon/gun/projectile/automatic/l6_saw/force_removeMag() //special because of its cover
 	if(!cover_open)
@@ -273,6 +281,7 @@
 	burst_count = 2
 	origin_tech = Tc_COMBAT + "=5;" + Tc_MATERIALS + "=1"
 	starting_materials = list(MAT_IRON = 6250, MAT_GLASS = 1500, MAT_PLASTIC = 2500)
+	silencer_offset = list(25,4)
 	var/receiver
 
 /obj/item/weapon/gun/projectile/automatic/vector/isHandgun()

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -57,7 +57,7 @@
 	mag_type = "/obj/item/ammo_storage/magazine/a75"
 	load_method = 2
 	recoil = 4
-
+	silencer_offset = list(24,7) //please no
 	gun_flags = AUTOMAGDROP | EMPTYCASINGS
 
 	update_icon()
@@ -277,6 +277,7 @@
 	mag_type = "/obj/item/ammo_storage/magazine/beretta"
 	load_method = 2
 	gun_flags = AUTOMAGDROP | EMPTYCASINGS
+	silencer_offset = list(25,9)
 
 /obj/item/weapon/gun/projectile/beretta/update_icon()
 	..()
@@ -295,6 +296,7 @@
 	load_method = 2
 	recoil = 3
 	gun_flags = AUTOMAGDROP | EMPTYCASINGS
+	silencer_offset = list(27,4)
 
 /obj/item/weapon/gun/projectile/automag/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -79,6 +79,7 @@
 	max_shells = 8
 	origin_tech = Tc_COMBAT + "=5;" + Tc_MATERIALS + "=2"
 	ammo_type = "/obj/item/ammo_casing/shotgun"
+	silencer_offset = list(28,5)
 
 /obj/item/weapon/gun/projectile/shotgun/pump/combat/shorty //nuke op engineering special
 	name = "combat shorty"
@@ -87,6 +88,7 @@
 	w_class = W_CLASS_MEDIUM
 	slot_flags = SLOT_BELT
 	max_shells = 3
+	silencer_offset = list(22,5)
 
 //this is largely hacky and bad :(	-Pete
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel
@@ -194,6 +196,7 @@
 	load_method = 2
 	slot_flags = 0
 	gun_flags = EMPTYCASINGS
+	silencer_offset = list(28,5)
 
 /obj/item/weapon/gun/projectile/shotgun/nt12/update_icon()
 	..()


### PR DESCRIPTION
Note that this doesn't allow silencers to be mounted on those weapons - to do that, the gun_flags need to be modified.
All this does is add proper sprite support for if that flag is changed.
![dreamseeker_2020-09-05_13-31-37](https://user-images.githubusercontent.com/8468269/92304232-63f1de00-ef7c-11ea-9186-f9a07e18d783.png)

Admemes just need to add `1` to the `gun_flags` bitflag to add silencer support to these guns.
(Note: that means that 0 becomes 1, 4 becomes 5, 6 becomes 7, etcetera).