### PR TITLE
Fixed meat necromancy runtime

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -240,7 +240,7 @@
 
 
 /obj/item/weapon/gun/energy/staff/necro/proc/meatRaise(var/obj/item/weapon/reagent_containers/food/snacks/meat/M, mob/living/user)
-	var/mob/living/simple_animal/hostile/necro/meat_ghoul/mG = new /mob/living/simple_animal/hostile/necro/meat_ghoul(get_turf(M), user, M)
+	var/mob/living/simple_animal/hostile/necro/meat_ghoul/mG = new /mob/living/simple_animal/hostile/necro/meat_ghoul(get_turf(M), user)
 	make_tracker_effects(get_turf(M), user)
 	mG.ghoulifyMeat(M)
 	mG.faction = "\ref[user]"


### PR DESCRIPTION
```
[16:37:11] Runtime in necro.dm,9: undefined variable /obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh/var/mind
  proc name: New (/mob/living/simple_animal/hostile/necro/New)
  usr: The meat ghoul () (/mob/living/simple_animal/hostile/necro/meat_ghoul)
  usr.loc: The floor (303, 251, 1) (/turf/simulated/floor)
  src: the meat ghoul (/mob/living/simple_animal/hostile/necro/meat_ghoul)
  src.loc: the floor (303,251,1) (/turf/simulated/floor)
  call stack:
  the meat ghoul (/mob/living/simple_animal/hostile/necro/meat_ghoul): New(the floor (303,251,1) (/turf/simulated/floor), Boxer Grigsby (/mob/living/carbon/human), the synthetic meat (/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh), null)
  the staff of necromancy (/obj/item/weapon/gun/energy/staff/necro): meatRaise(the synthetic meat (/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh), Boxer Grigsby (/mob/living/carbon/human))
  the staff of necromancy (/obj/item/weapon/gun/energy/staff/necro): afterattack(the synthetic meat (/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh), Boxer Grigsby (/mob/living/carbon/human), 1, "icon-x=19;icon-y=15;left=1;scr...", 0)
  Boxer Grigsby (/mob/living/carbon/human): ClickOn(the synthetic meat (/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh), "icon-x=19;icon-y=15;left=1;scr...")
  the synthetic meat (/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh): Click(the floor (303,251,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=19;icon-y=15;left=1;scr...")
  Rubylips (/client): Click(the synthetic meat (/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh), the floor (303,251,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=19;icon-y=15;left=1;scr...")
```