### PR TITLE
Mechs can no longer deflect railgun projectiles

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -89,6 +89,7 @@
 
 	var/list/never_deflect = list(
 		/obj/item/projectile/ion,
+		/obj/item/projectile/bullet/APS,
 	)
 
 	var/list/mech_sprites = list() //sprites alternatives for a given mech. Only have to enter the name of the paint scheme


### PR DESCRIPTION
I have recently learned that it's possible for mechs to deflect all projectiles except ions. This cannot stand.
**THE PHAZON MUST FEAR THE RAILGUN**

:cl:
 * tweak: Mechs can no longer deflect railgun projectiles.