### PR TITLE
Expands Emagged Cloner Options

### DIFF
--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -16,7 +16,7 @@
 	var/datum/dna2/record/active_record = null
 	var/obj/item/weapon/disk/data/diskette = null //Mostly so the geneticist can steal everything.
 	var/loading = 0 // Nice loading text
-	var/available_species = list("Human","Tajaran","Skrell","Unathi","Grey","Plasmamen","Vox", "Insectoid")
+	var/available_species = list("Human","Tajaran","Skrell","Unathi","Grey","Plasmamen","Vox", "Insectoid", "Undead", "Skellington", "Skeletal Vox", "Muton", "Grue", "Ghoul", "Mushroom", "Slime", "Golem", "Diona")
 
 	light_color = LIGHT_COLOR_BLUE
 


### PR DESCRIPTION
Emagging a cloning computer lets you change the corpse's species and name. Currently it only lets you pick from the more common species. This allows you to pick from almost every humanoid species, including grue, lich, and ghoul. 
Just seems more fun.

[tweak]

:cl:
 * tweak: Emagged cloners now have more options.