### PR TITLE
Fixed DNA UI hair blocks

### DIFF
--- a/code/__HELPERS/maths.dm
+++ b/code/__HELPERS/maths.dm
@@ -320,3 +320,9 @@ var/list/sqrtTable = list(1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 
 	assert_eq(count_set_bitflags(65536|32768), 2)
 	assert_eq(count_set_bitflags(1|4|16), 3)
 #endif
+
+// Given a number in the range [old_bottom, old_top],
+// Returns that number mapped to the range [new_bottom, new_top]
+/proc/map_range(old_value, old_bottom, old_top, new_bottom, new_top)
+	var/new_value = (old_value - old_bottom) / (old_top - old_bottom) * (new_top - new_bottom) + new_bottom
+	return new_value

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -225,16 +225,15 @@ var/global/list/facial_hair_styles_female_list	= list()
 	if (block<=0)
 		return
 	ASSERT(maxvalue<=4095)
-	var/range = (4095 / maxvalue)
-	if(value)
-		SetUIValue(block,round(value * range),defer)
+	var/mapped_value = round(map_range(value, 0, maxvalue, 0, 0xFFF))
+	SetUIValue(block, mapped_value, defer)
 
 // Getter version of above.
 /datum/dna/proc/GetUIValueRange(var/block,var/maxvalue)
 	if (block<=0)
 		return 0
 	var/value = GetUIValue(block)
-	return round(1 +(value / 4096)*maxvalue)
+	return round(map_range(value, 0, 0xFFF, 0, maxvalue))
 
 // Is the UI gene "on" or "off"?
 // For UI, this is simply a check of if the value is > 2050.

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -157,12 +157,14 @@
 		setGender(MALE)
 
 	//Hair
-	var/hair = clamp(dna.GetUIValueRange(DNA_UI_HAIR_STYLE, hair_styles_list.len), 1, hair_styles_list.len)
-	my_appearance.h_style = hair_styles_list[hair]
+	var/list/species_hair = valid_sprite_accessories(hair_styles_list, null, species.name)
+	var/hair = clamp(dna.GetUIValueRange(DNA_UI_HAIR_STYLE, species_hair.len), 1, species_hair.len)
+	my_appearance.h_style = species_hair[hair]
 
 	//Facial Hair
-	var/beard = clamp(dna.GetUIValueRange(DNA_UI_BEARD_STYLE, facial_hair_styles_list.len), 1, facial_hair_styles_list.len)
-	my_appearance.f_style = facial_hair_styles_list[beard]
+	var/list/species_facial_hair = valid_sprite_accessories(facial_hair_styles_list, null, species.name)
+	var/beard = clamp(dna.GetUIValueRange(DNA_UI_BEARD_STYLE, species_facial_hair.len), 1, species_facial_hair.len)
+	my_appearance.f_style = species_facial_hair[beard]
 
 	update_body(0)
 	update_hair()

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -128,50 +128,46 @@
 
 	return output
 
-// /proc/updateappearance has changed behavior, so it's been removed
-// Use mob.UpdateAppearance() instead.
-
-// Simpler. Don't specify UI in order for the mob to use its own.
+// Don't specify UI in order for the mob to use its own.
 /mob/proc/UpdateAppearance(var/list/UI=null)
-	if(istype(src, /mob/living/carbon/human))
-		if(UI!=null)
-			src.dna.UI=UI
-			src.dna.UpdateUI()
-		dna.check_integrity()
-		var/mob/living/carbon/human/H = src
-		H.my_appearance.r_hair   = dna.GetUIValueRange(DNA_UI_HAIR_R,    255)
-		H.my_appearance.g_hair   = dna.GetUIValueRange(DNA_UI_HAIR_G,    255)
-		H.my_appearance.b_hair   = dna.GetUIValueRange(DNA_UI_HAIR_B,    255)
+	return 0
 
-		H.my_appearance.r_facial = dna.GetUIValueRange(DNA_UI_BEARD_R,   255)
-		H.my_appearance.g_facial = dna.GetUIValueRange(DNA_UI_BEARD_G,   255)
-		H.my_appearance.b_facial = dna.GetUIValueRange(DNA_UI_BEARD_B,   255)
+/mob/living/carbon/human/UpdateAppearance(list/UI=null)
+	if(UI!=null)
+		src.dna.UI=UI
+		src.dna.UpdateUI()
+	dna.check_integrity()
+	my_appearance.r_hair   = dna.GetUIValueRange(DNA_UI_HAIR_R,    255)
+	my_appearance.g_hair   = dna.GetUIValueRange(DNA_UI_HAIR_G,    255)
+	my_appearance.b_hair   = dna.GetUIValueRange(DNA_UI_HAIR_B,    255)
 
-		H.my_appearance.r_eyes   = dna.GetUIValueRange(DNA_UI_EYES_R,    255)
-		H.my_appearance.g_eyes   = dna.GetUIValueRange(DNA_UI_EYES_G,    255)
-		H.my_appearance.b_eyes   = dna.GetUIValueRange(DNA_UI_EYES_B,    255)
+	my_appearance.r_facial = dna.GetUIValueRange(DNA_UI_BEARD_R,   255)
+	my_appearance.g_facial = dna.GetUIValueRange(DNA_UI_BEARD_G,   255)
+	my_appearance.b_facial = dna.GetUIValueRange(DNA_UI_BEARD_B,   255)
 
-		H.my_appearance.s_tone   = 35 - dna.GetUIValueRange(DNA_UI_SKIN_TONE, 220) // Value can be negative.
-		H.setGender(MALE)
-		if (dna.GetUIState(DNA_UI_GENDER))
-			H.setGender(FEMALE)
-		else
-			H.setGender(MALE)
+	my_appearance.r_eyes   = dna.GetUIValueRange(DNA_UI_EYES_R,    255)
+	my_appearance.g_eyes   = dna.GetUIValueRange(DNA_UI_EYES_G,    255)
+	my_appearance.b_eyes   = dna.GetUIValueRange(DNA_UI_EYES_B,    255)
 
-		//Hair
-		var/hair = clamp(dna.GetUIValueRange(DNA_UI_HAIR_STYLE, hair_styles_list.len), 1, hair_styles_list.len)
-		H.my_appearance.h_style = hair_styles_list[hair]
-
-		//Facial Hair
-		var/beard = clamp(dna.GetUIValueRange(DNA_UI_BEARD_STYLE, facial_hair_styles_list.len), 1, facial_hair_styles_list.len)
-		H.my_appearance.f_style = facial_hair_styles_list[beard]
-
-		H.update_body(0)
-		H.update_hair()
-
-		return 1
+	my_appearance.s_tone   = 35 - dna.GetUIValueRange(DNA_UI_SKIN_TONE, 220) // Value can be negative.
+	setGender(MALE)
+	if (dna.GetUIState(DNA_UI_GENDER))
+		setGender(FEMALE)
 	else
-		return 0
+		setGender(MALE)
+
+	//Hair
+	var/hair = clamp(dna.GetUIValueRange(DNA_UI_HAIR_STYLE, hair_styles_list.len), 1, hair_styles_list.len)
+	my_appearance.h_style = hair_styles_list[hair]
+
+	//Facial Hair
+	var/beard = clamp(dna.GetUIValueRange(DNA_UI_BEARD_STYLE, facial_hair_styles_list.len), 1, facial_hair_styles_list.len)
+	my_appearance.f_style = facial_hair_styles_list[beard]
+
+	update_body(0)
+	update_hair()
+
+	return 1
 
 // Used below, simple injection modifier.
 /proc/probinj(var/pr, var/inj)

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -159,14 +159,12 @@
 			H.setGender(MALE)
 
 		//Hair
-		var/hair = dna.GetUIValueRange(DNA_UI_HAIR_STYLE,hair_styles_list.len)
-		if((0 < hair) && (hair <= hair_styles_list.len))
-			H.my_appearance.h_style = hair_styles_list[hair]
+		var/hair = clamp(dna.GetUIValueRange(DNA_UI_HAIR_STYLE, hair_styles_list.len), 1, hair_styles_list.len)
+		H.my_appearance.h_style = hair_styles_list[hair]
 
 		//Facial Hair
-		var/beard = dna.GetUIValueRange(DNA_UI_BEARD_STYLE,facial_hair_styles_list.len)
-		if((0 < beard) && (beard <= facial_hair_styles_list.len))
-			H.my_appearance.f_style = facial_hair_styles_list[beard]
+		var/beard = clamp(dna.GetUIValueRange(DNA_UI_BEARD_STYLE, facial_hair_styles_list.len), 1, facial_hair_styles_list.len)
+		H.my_appearance.f_style = facial_hair_styles_list[beard]
 
 		H.update_body(0)
 		H.update_hair()


### PR DESCRIPTION
Old genetics code was supposed to allow changing one's hair by changing the U.I. but:
- It didn't take species into account, so it was more likely than not that you'd end up with the DNA trying to set a hair style that wouldn't render
- It didn't correctly map the range of available hair styles (0 to 179) to the range of genetics blocks (0 to 4095), so most values were invalid

This PR fixes those things.
Subscribe to my patreon if you want me to update the wiki