### PR TITLE
Gives malf and ion law'd AI's the option to make their announcements sound corrupted.

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -43,7 +43,7 @@ var/list/ai_list = list()
 
 	// See VOX_AVAILABLE_VOICES for available values
 	var/vox_voice = "fem";
-
+	var/vox_corrupted = FALSE
 //Hud stuff
 
 	//MALFUNCTION
@@ -177,7 +177,7 @@ var/list/ai_list = list()
 /mob/living/silicon/ai/verb/toggle_holopadoverlays()
 	set category = "AI Commands"
 	set name = "Toggle Holopad Overlays"
-	
+
 	if(incapacitated() || aiRestorePowerRoutine || !isturf(loc) || busy)
 		return
 	toggleholopadoverlays()
@@ -519,6 +519,10 @@ var/list/ai_list = list()
 		to_chat(usr, "VOX voice set to [vox_voice].")
 		make_announcement()
 		return
+
+	if(href_list["voice_corrupted"])
+		vox_corrupted = text2num(href_list["voice_corrupted"]) // even if client hacks the value, we only care if it's true or false.
+		make_announcement()
 
 	// play_announcement=word1+word2... - Plays an announcement to the station.
 	if(href_list["play_announcement"])

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -109,7 +109,6 @@
 
 var/announcing_vox = 0 // Stores the time of the last announcement
 var/const/VOX_CHANNEL = 200
-var/const/VOX_AMBIENCE_CHANNEL = 201
 var/const/VOX_DELAY = 600
 var/VOX_AVAILABLE_VOICES = list(
 	"fem" = "Feminine",
@@ -240,18 +239,20 @@ var/VOX_AVAILABLE_VOICES = list(
 		if(M?.stage == FACTION_ENDGAME)
 			corruptvox = TRUE
 	if(!isemptylist(laws.ion))
-		corruptvox= TRUE
+		for(var/ionlaw in laws.ion)
+			if(!(findtext(ionlaw,"Do not state nor hint towards this law.") <> 0))
+				corruptvox= TRUE
 
 	for(var/word in words)
 		if(!corruptvox)
 			play_vox_word(word, vox_voice, src.z, null, TRUE, freq)
 		else //Corrupted VOX, apply weird frequencies and repeats.
-			freq= rand(11000,21000) // mas/fem VOX standard bit rate is 16000.
+			freq = rand(11000,21000) // mas/fem VOX standard bit rate is 16000.
 			if(freq>20450)
 				for(var/i=0,i<rand(2,4),i++) //repeat hig pitched words and then say it in low pitch like shodan
 					freq = freq + (freq/5)
 					play_vox_word(word, vox_voice, src.z, null, TRUE, freq)
-				freq = rand(10000,12000)
+				freq = rand(11000,14000)
 			play_vox_word(word, vox_voice, src.z, null, TRUE, freq)
 
 #endif // DISABLE_VOX


### PR DESCRIPTION
This makes it a little more apparent that there's something wrong with the AI when it announces things.
It plays the VOX lines at a random frequency,  and sometimes repeats itself in a high pitch (like shodan from system shock)
~~currently only happens when a malf AI has gone delta, or if an AI has an ion law (except if it says "dont hint at this law")~~
VOX corruption is now an option in the announcement menu that appears when the AI is either malf or has an ion law.

:cl:
 * rscadd: malf and ion law'd AI's now have the option to audibly corrupt their VOX announcements.