### PR TITLE
Cluwnebans

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -304,7 +304,7 @@
 //Banning someone from the Syndicate role bans them from all antagonist roles
 #define isantagbanned(H) (jobban_isbanned(H, "Syndicate"))
 
-
+#define iscluwnebanned(H) (jobban_isbanned(H, "Cluwne"))
 
 //Macro for AREAS!
 

--- a/code/game/machinery/mind_machine.dm
+++ b/code/game/machinery/mind_machine.dm
@@ -759,6 +759,9 @@
 	var/mob/L = O
 	if(!istype(L))
 		return
+	if(iscluwnebanned(L))
+		to_chat(user, "<span class='notice'>You consider loading the pod, but something tells you that would be a bad idea.</span>")
+		return
 	for(var/mob/living/carbon/slime/M in range(1,L))
 		if(M.Victim == L)
 			to_chat(usr, "<span class='notice'>[L] will not fit into the pod because they have a slime latched onto their head.</span>")

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -31,7 +31,7 @@
 		if(prefs.muted & MUTE_OOC)
 			to_chat(src, "<span class='warning'>You cannot use OOC (muted).</span>")
 			return
-		if(oocban_isbanned(ckey))
+		if(oocban_isbanned(ckey) || iscluwnebanned(mob))
 			to_chat(src, "<span class='warning'>You cannot use OOC (banned).</span>")
 			return
 		if(handle_spam_prevention(msg,MUTE_OOC))
@@ -61,7 +61,7 @@
 				display_colour = "#b82e00"	//orange
 
 	for(var/client/C in clients)
-		if(C.prefs.toggles & CHAT_OOC)
+		if((C.prefs.toggles & CHAT_OOC) && !iscluwnebanned(C.mob))
 			var/display_name = src.key
 			if(holder)
 				if(holder.fakekey)
@@ -128,7 +128,7 @@
 		if(prefs.muted & MUTE_OOC)
 			to_chat(src, "<span class='warning'>You cannot use LOOC (muted).</span>")
 			return
-		if(oocban_isbanned(ckey))
+		if(oocban_isbanned(ckey) || iscluwnebanned(mob))
 			to_chat(src, "<span class='warning'>You cannot use LOOC (banned).</span>")
 			return
 		if(handle_spam_prevention(msg,MUTE_OOC))

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -367,7 +367,7 @@
 		output += "<option value='[j]'>[j]</option>"
 	for(var/j in nonhuman_positions)
 		output += "<option value='[j]'>[j]</option>"
-	for(var/j in list("traitor","changeling","operative","revolutionary","cultist","wizard"))
+	for(var/j in list("traitor","changeling","operative","revolutionary","cultist","wizard","cluwne"))
 		output += "<option value='[j]'>[j]</option>"
 
 	output += {"</select></td></tr></table>

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
@@ -156,6 +156,13 @@
 		else
 			playsound(src, "clownstep", 20, 1)
 
+/mob/living/simple_animal/hostile/retaliate/cluwne/death(var/gibbed = FALSE)
+	..(gibbed)
+	if(client && iscluwnebanned(src))
+		to_chat(src, "<big><span class='danger'>You have died, and will not be able to rejoin the game until the next round.</span><big>")
+		sleep(1)
+		del(client)
+
 /mob/living/simple_animal/hostile/retaliate/cluwne/goblin
 	name = "clown goblin"
 	desc = "A tiny walking mask and clown shoes. You want to honk his nose!"

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -119,7 +119,7 @@
 	if(client)
 		client.CAN_MOVE_DIAGONALLY = 0
 
-	if(iscluwnebanned(src) && timeofdeath > 0)
+	if(iscluwnebanned(src) && (timeofdeath > 0 || !iscluwne(src)))
 		log_admin("Cluwnebanned player [key_name(src)] attempted to join and was kicked.")
 		message_admins("<span class='notice'>Cluwnebanned player [key_name(src)] attempted to join and was kicked.</span>", 1)
 		del(client)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -118,3 +118,8 @@
 
 	if(client)
 		client.CAN_MOVE_DIAGONALLY = 0
+
+	if(iscluwnebanned(src) && timeofdeath > 0)
+		log_admin("Cluwnebanned player [key_name(src)] attempted to join and was kicked.")
+		message_admins("<span class='notice'>Cluwnebanned player [key_name(src)] attempted to join and was kicked.</span>", 1)
+		del(client)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -162,6 +162,9 @@
 
 		LateChoices()
 	if(href_list["cluwnebanned"])
+		if(!iscluwnebanned(usr))
+			to_chat(usr, "<span class='warning'>honk</span>")
+			return
 		if(!ticker || ticker.current_state <= GAME_STATE_PREGAME)
 			to_chat(usr, "<span class='warning'>The round is either not ready, or has already finished...</span>")
 			return

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -61,6 +61,10 @@
 
 	output += "</div>"
 
+	//dumb but doesn't require rewriting this menu
+	if(iscluwnebanned(src))
+		output = "<div align='center'><p><a href='byond://?src=\ref[src];cluwnebanned=1'>cluwne</a></p></div>"
+
 	var/datum/browser/popup = new(src, "playersetup", "<div align='center'>New Player Options</div>", 210, 250)
 	popup.set_content(output)
 	popup.set_window_options("focus=0;can_close=0;can_minimize=1;can_maximize=0;can_resize=1;titlebar=1;")
@@ -157,6 +161,15 @@
 				return 0
 
 		LateChoices()
+	if(href_list["cluwnebanned"])
+		if(!ticker || ticker.current_state <= GAME_STATE_PREGAME)
+			to_chat(usr, "<span class='warning'>The round is either not ready, or has already finished...</span>")
+			return
+		if(!client)
+			return 1
+		sleep(1)
+		create_cluwne()
+
 	if(href_list["predict"])
 		var/dat = {"<html><body>
 		<h4>High Job Preferences</h4>"}
@@ -283,6 +296,8 @@
 		return 0
 	if(jobban_isbanned(src,rank))
 		return 0
+	if(jobban_isbanned(src,"cluwne")) //not totally necessary but prevents someone from joining if they were cluwnebanned in the lobby
+		return 0
 	if(!job.player_old_enough(src.client))
 		return 0
 	. = 1
@@ -316,6 +331,16 @@
 		observer.verbs -= /mob/dead/observer/verb/toggle_antagHUD        // Poor guys, don't know what they are missing!
 	mind.transfer_to(observer)
 	qdel(src)
+
+/mob/new_player/proc/create_cluwne()
+	var/mob/living/simple_animal/hostile/retaliate/cluwne/cluwne = new()
+	spawning = 1
+	src << sound(null, repeat = 0, wait = 0, volume = 85, channel = CHANNEL_LOBBY)
+	close_spawn_windows()
+	cluwne.forceMove(pick(latejoin))
+	mind.transfer_to(cluwne)
+	qdel(src)
+
 
 /mob/new_player/proc/FuckUpGenes(var/mob/living/carbon/human/H)
 	// 20% of players have bad genetic mutations.

--- a/code/modules/projectiles/projectile/change.dm
+++ b/code/modules/projectiles/projectile/change.dm
@@ -16,7 +16,7 @@
 
 /obj/item/projectile/change/proc/wabbajack(var/mob/living/M,var/type) //WHY: as mob in living_mob_list
 	if(istype(M, /mob/living) && M.stat != DEAD)
-		if(ismanifested(M))
+		if(ismanifested(M) || iscluwnebanned(M))
 			visible_message("<span class='caution'>The bolt of change doesn't seem to affect [M] in any way.</span>")
 			return
 		var/mob/living/new_mob
@@ -64,7 +64,7 @@
 	flag = "energy"
 	var/changetype=null
 	fire_sound = 'sound/weapons/radgun.ogg'
-	
+
 /obj/item/projectile/zwartepiet/on_hit(var/atom/pietje)
 	var/type = changetype
 	spawn(1)

--- a/code/modules/spells/targeted/mind_transfer.dm
+++ b/code/modules/spells/targeted/mind_transfer.dm
@@ -27,15 +27,16 @@
 
 	for(var/mob/living/target in targets)
 		if(target.stat == DEAD)
-			to_chat(user, "You didn't study necromancy back at the Space Wizard Federation academy.")
+			to_chat(user, "<span class='notice>You didn't study necromancy back at the Space Wizard Federation academy.<span class='notice>")
 			continue
-
 		else if(!target.key || !target.mind)
-			to_chat(user, "They appear to be catatonic. Not even magic can affect their vacant mind.")
+			to_chat(user, "<span class='notice>They appear to be catatonic. Not even magic can affect their vacant mind.<span class='notice>")
 			continue
-
 		else if(target.mind.special_role in protected_roles)
 			to_chat(user, "Their mind is resisting your spell.")
+			continue
+		else if(iscluwnebanned(target))
+			to_chat(user, "<span class='notice>A powerful curse is anchoring their soul to their body.<span class='notice>")
 			continue
 		else
 			var/mob/living/victim = target//The target of the spell whos body will be transferred to.


### PR DESCRIPTION
how it works:
- cluwnebanned players can only latejoin as a cluwne
- cluwnebanned players cannot use or read (L)OOC
- cluwnebanned players are kicked upon death, and cannot rejoin the game until the next round
- cluwnebanned players can not have their minds swapped or be transformed in any way

(sneaky cluwnebanned players can click observe while the server is initializing, but because this sets their time of death it also immediately kicks them from the server and prevents rejoining)

this is necessarily(?) hacky but seems to work fine