### PR TITLE
Suspension Field Generator Construction

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -1484,3 +1484,15 @@ obj/item/weapon/circuitboard/rdserver
 		/obj/item/weapon/stock_parts/manipulator = 1,
 		/obj/item/weapon/stock_parts/micro_laser = 2,
 	)
+
+/obj/item/weapon/circuitboard/suspension_gen
+	name = "Circuit Board (Suspension Field Generator)"
+	desc = "A circuit board used to run a suspension field generator"
+	build_path = /obj/machinery/suspension_gen
+	board_type = MACHINE
+	origin_tech = Tc_ENGINEERING + "=3;"+ Tc_POWERSTORAGE + "=1;" + Tc_MAGNETS + "=4"
+	req_components = list(
+		/obj/item/weapon/stock_parts/micro_laser = 2,
+		/obj/item/weapon/stock_parts/manipulator = 1,
+		/obj/item/weapon/stock_parts/capacitor = 1,
+	)

--- a/code/modules/research/designs/boards/machine_science.dm
+++ b/code/modules/research/designs/boards/machine_science.dm
@@ -102,3 +102,13 @@
 	name = "Circuit Design (Hyperspectral Imager)"
 	id = "hyperspectral"
 	build_path = /obj/item/weapon/circuitboard/anom/hyper
+
+/datum/design/suspensionfieldgen
+	name = "Circuit Design (Suspension Field Generator)"
+	desc = "The circuit board for a suspension field generator"
+	id = "suspensionfieldgen"
+	req_tech = list(Tc_ENGINEERING = 3, Tc_POWERSTORAGE = 1, Tc_MAGNETS = 4)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 2000, SACID = 20)
+	category = "Console Boards"
+	build_path = /obj/item/weapon/circuitboard/suspension_gen

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -27,6 +27,20 @@
 /obj/machinery/suspension_gen/New()
 	src.cell = new/obj/item/weapon/cell/high(src)
 	..()
+	component_parts = newlist(
+		/obj/item/weapon/circuitboard/suspension_gen,
+		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/micro_laser,
+		/obj/item/weapon/stock_parts/micro_laser,
+		/obj/item/weapon/stock_parts/capacitor
+	)
+	RefreshParts()
+
+/obj/machinery/suspension_gen/RefreshParts()
+	for(var/obj/item/weapon/stock_parts/parts in component_parts)
+		if(istype(parts, /obj/item/weapon/stock_parts/capacitor))
+			var/pSave = parts.rating*2
+			power_use = 27 - pSave
 
 /obj/machinery/suspension_gen/process()
 	//set background = 1


### PR DESCRIPTION
I've been playing with suspension field generators a lot lately. They're fun. They also don't have parts and can't be constructed despite being machines. This adds a circuit to the imprinter and a basic construction recipe for them.
They consume slightly less power based on the rating of the capacitor they're using. The manipulator and micro-lasers offer no difference when upgraded. 

[tweak]

:cl:
 * tweak: Suspension Field Generator circuits now exist