### PR TITLE
Adds Origin Tech to Things: Mechanics and R&D Rejoice

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -82,6 +82,7 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "soap"
 	w_class = W_CLASS_TINY
+	origin_tech = Tc_MATERIALS + "=1"
 	siemens_coefficient = 0 //no conduct
 	throwforce = 0
 	throw_speed = 4
@@ -417,7 +418,7 @@
 	desc = "A trap used to catch bears and other legged creatures."
 	flags = FPRINT
 	origin_tech = Tc_MATERIALS + "=1"
-	starting_materials = list(MAT_IRON = 50000)
+	starting_materials = list(MAT_IRON = 5000)
 	w_type = RECYK_METAL
 	w_class = W_CLASS_LARGE
 	anchored = FALSE
@@ -749,6 +750,7 @@
 	throwforce = 3.0
 	throw_speed = 1
 	throw_range = 5
+	origin_tech = Tc_MATERIALS + "=2;" + Tc_ENGINEERING + "=1"
 	w_class = W_CLASS_SMALL
 	flags = FPRINT
 	attack_verb = list("warns", "cautions", "smashes")

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -5,6 +5,7 @@
 	icon_state = "candle1"
 	item_state = "candle1"
 	w_class = W_CLASS_TINY
+	origin_tech = Tc_MATERIALS + "=1"
 	heat_production = 1000
 	source_temperature = TEMPERATURE_FLAME
 	light_color = LIGHT_COLOR_FIRE

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -34,6 +34,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	item_state = "electronic"
 	w_class = W_CLASS_TINY
 	flags = FPRINT
+	origin_tech = Tc_POWERSTORAGE + "=2;" + Tc_BLUESPACE + "=1;" + Tc_PROGRAMMING  + "=4"
 	slot_flags = SLOT_ID | SLOT_BELT
 
 	//Main variables

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -8,6 +8,7 @@
 	throw_speed = 4
 	throw_range = 20
 	flags = FPRINT | NO_ATTACK_MSG
+	origin_tech = Tc_POWERSTORAGE + "=4;" + Tc_BLUESPACE + "=2;" + Tc_PROGRAMMING  + "=5;" + Tc_MAGNETS + "=3" //Expensive to replicate, good research boost if you chat with the detective though
 	var/c_tag = ""
 	var/active = FALSE
 	var/network = ""

--- a/code/game/objects/items/devices/handtv.dm
+++ b/code/game/objects/items/devices/handtv.dm
@@ -4,6 +4,7 @@ var/global/list/camera_bugs = list()
 	desc = "A handheld tv meant for remote viewing."
 	icon_state = "handtv"
 	w_class = W_CLASS_TINY
+	origin_tech = Tc_POWERSTORAGE + "=4;" + Tc_BLUESPACE + "=2;" + Tc_PROGRAMMING  + "=5;" + Tc_MAGNETS + "=3"
 	var/obj/item/device/camera_bug/current
 	var/network
 

--- a/code/game/objects/items/policetape.dm
+++ b/code/game/objects/items/policetape.dm
@@ -10,6 +10,7 @@
 	var/turf/end
 	var/tape_type = /obj/item/tape
 	var/icon_base
+	origin_tech = Tc_MATERIALS + "=2;" + Tc_ENGINEERING + "=1"
 
 /obj/item/tape
 	name = "tape"
@@ -260,6 +261,7 @@
 // -- /taperoll/syndie = contains all the things dealing with charges
 /obj/item/taperoll/syndie
 	var/charges_left = 12
+	mech_flags = MECH_SCAN_ILLEGAL
 
 /obj/item/taperoll/syndie/police
 	name = "police tape"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -238,9 +238,9 @@
 	icon_state = "fireworkslauncher"
 	item_state = "riotgun"
 	fire_sound = "sound/weapons/railgun_lowpower.ogg"
-	projectile_type = "/obj/item/projectile/meteor/firework"	
+	projectile_type = "/obj/item/projectile/meteor/firework"
 	charge_cost = 0 //infinite ammo!
-	
+
 /obj/item/weapon/gun/energy/fireworkslauncher/update_icon()
 	return
 
@@ -381,6 +381,7 @@
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "sword0"
 	item_state = "sword0"
+	origin_tech = Tc_COMBAT  + "=1"
 	var/active = 0.0
 	w_class = W_CLASS_SMALL
 	flags = FPRINT
@@ -474,6 +475,7 @@
 	icon = 'icons/obj/crayons.dmi'
 	icon_state = "crayonred"
 	w_class = W_CLASS_TINY
+	origin_tech = Tc_MATERIALS + "=1"
 	attack_verb = list("attacks", "colours", "colors")//teehee
 	var/colour = DEFAULT_BLOOD //RGB
 	var/shadeColour = "#220000" //RGB
@@ -503,6 +505,7 @@
 	desc = "Wow!"
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "snappop"
+	origin_tech = Tc_COMBAT  + "=1"
 	w_class = W_CLASS_TINY
 
 /obj/item/toy/snappop/throw_impact(atom/hit_atom)

--- a/code/modules/projectiles/guns/hookshot.dm
+++ b/code/modules/projectiles/guns/hookshot.dm
@@ -518,6 +518,7 @@
 	clumsy_check = 0 //Just makes sense
 	force = 5
 	maxlength = 0
+	mech_flags = MECH_SCAN_ILLEGAL
 	hooktype = /obj/item/projectile/hookshot/whip/windup_box
 	var/lengthDecider = 0 //replaces maxlength due to a needed reset
 	var/windUp = 0 //amount of times cranked

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -9,6 +9,7 @@
 	throwforce = 3
 	w_class = W_CLASS_SMALL
 	starting_materials = list(MAT_GLASS = 3500)
+	origin_tech = Tc_MATERIALS + "=2"
 	w_type = RECYK_GLASS
 	throw_speed = 2
 	throw_range = 10

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -14,6 +14,7 @@
 	possible_transfer_amounts = null //list(5,10,15)
 	volume = 15
 	starting_materials = list(MAT_GLASS = 1000)
+	origin_tech = Tc_BIOTECH  + "=2;" + Tc_COMBAT  + "=1"
 	w_type = RECYK_GLASS
 
 	var/mode = SYRINGE_DRAW
@@ -390,6 +391,8 @@
 /obj/item/weapon/reagent_containers/syringe/syndi
 	name = "syringe (syndicate mix)"
 	desc = "Contains cyanide, chloral hydrate and lexorin. Something tells you it might be lethal on arrival."
+	mech_flags = MECH_SCAN_ILLEGAL
+
 /obj/item/weapon/reagent_containers/syringe/syndi/New()
 	..()
 	reagents.add_reagent(CYANIDE, 5)


### PR DESCRIPTION
Adds origin tech to:

Soap
Wet Floor Sign
Candle
PDA
Camera Bug + handheld TV
Tapes (atmos, security, etc)
Toy Sword
Crayon
Snap Pop (non-syndie)
Spray Bottle
Syringe
Also changes bear trap's metal cost from 50000 to 5000 because that's stupid.

This is mostly so mechanics can replicate them for funzies, however PDAs and camera bugs may provide R&D with a very nice research boost, make sure to ask your local detective nicely first!
Tested them all, nothing silly like Captain PDAs allowing free spares. The tech level of camera bugs also limits how many you can make considerably.

Edit: Also makes something illegal that should have been previously, woopsy.

[tweak]

:cl:
 * tweak: Several items have been given origin tech for use by R&D and mechanics