### PR TITLE
Wallets Pickup Cash, Coins, Etc On Click

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/wallet.dmi'
 	icon_state = "wallet"
 	w_class = W_CLASS_SMALL
+	use_to_pickup = TRUE
 	can_only_hold = list(
 		"/obj/item/weapon/spacecash",
 		"/obj/item/weapon/card",
@@ -68,6 +69,8 @@
 		return I.GetAccess()
 	else
 		return ..()
+
+
 
 /obj/item/weapon/storage/wallet/random/New()
 	..()


### PR DESCRIPTION
Clicking a pile of cash with a wallet now picks it up. Doesn't stack the cash but still more convenient. 

[tweak]
:cl:
 * tweak: Wallets can now pickup cash with a click