### PR TITLE
Fix usage of runtime operator in age old wallrot code

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -7973,7 +7973,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	if(..())
 		return 1
 
-	if(volume >= 5 && istype(T, /turf/simulated/wall/) && T.can_thermite)
+	if(volume >= 5 && T.can_thermite && istype(T, /turf/simulated/wall))
 		var/turf/simulated/wall/W = T
 		W.rot()
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -7973,8 +7973,9 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	if(..())
 		return 1
 
-	if(volume >= 5 && T.can_thermite)
-		T:rot()
+	if(volume >= 5 && istype(T, /turf/simulated/wall/) && T.can_thermite)
+		var/turf/simulated/wall/W = T
+		W.rot()
 
 /datum/reagent/ironrot/on_mob_life(var/mob/living/M)
 	if(..())


### PR DESCRIPTION
[hotfix]
No changelog unless someone wants it since this is invisible to players afaik

Introduced in https://github.com/vgstation-coders/vgstation13/pull/24276 because it got merged with this line even though they were told to change it
rot proc is only defined on walls
As of yesterday:
`x4027 Chemistry-Reagents.dm,7977: undefined proc or verb /turf/simulated/floor/rot().`
Those runtimes are caused primarily by ironrot reagent on floors. I wasn't sure if the intent was to have iron rot persist on non-walls, so I've left it otherwise functionally identical to how it was prior to fix.