### PR TITLE
Removes blank line from adjectives.txt

### DIFF
--- a/config/names/adjectives.txt
+++ b/config/names/adjectives.txt
@@ -109,7 +109,6 @@ vast
 wandering
 wild
 wrong
-
 angry
 annoyed
 anxious


### PR DESCRIPTION
Fixes #27712
Or actually it's already been fixed on live by a config change but this changes the default config to fix it
Which may or may not also affect live because of how `.gitignore` is set up I don't know