### PR TITLE
adds medal printer flatpack to IAA closet and allows IAA to use it

### DIFF
--- a/code/game/machinery/medal_printer.dm
+++ b/code/game/machinery/medal_printer.dm
@@ -7,7 +7,7 @@
 	nano_file = "medalprinter.tmpl"
 	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK | EMAGGABLE
 	research_flags = NANOTOUCH | TAKESMATIN | HASOUTPUT | IGNORE_CHEMS | HASMAT_OVER | ACCESS_EMAG
-	req_access = list(access_hop)
+	req_access = list(access_lawyer)
 
 	allowed_materials = list(
 						MAT_IRON,

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -64,6 +64,7 @@
 
 /obj/structure/closet/lawcloset/atoms_to_spawn()
 	return list(
+		/obj/structure/closet/crate/flatpack/medalmaker,
 		/obj/item/clothing/under/cia,
 		/obj/item/clothing/under/lawyer/female,
 		/obj/item/clothing/under/lawyer/black,

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -63,8 +63,7 @@
 	icon_closed = "blue"
 
 /obj/structure/closet/lawcloset/atoms_to_spawn()
-	return list(
-		/obj/structure/closet/crate/flatpack/medalmaker,
+	var/list/R = list(
 		/obj/item/clothing/under/cia,
 		/obj/item/clothing/under/lawyer/female,
 		/obj/item/clothing/under/lawyer/black,
@@ -76,6 +75,9 @@
 		/obj/item/clothing/shoes/brown,
 		/obj/item/clothing/shoes/black,
 	)
+	if(istype(loc.loc,/area/lawoffice))
+		R += /obj/structure/closet/crate/flatpack/medalmaker
+	return R
 
 /obj/structure/closet/paramedic
 	name = "Paramedic Wardrobe"

--- a/code/modules/research/mechanic/flatpack.dm
+++ b/code/modules/research/mechanic/flatpack.dm
@@ -317,3 +317,9 @@
 	..()
 	name = "ancient flatpack (electrolytic chemmaster)"
 	machine = new /obj/machinery/chem_master/electrolytic(src)
+
+/obj/structure/closet/crate/flatpack/medalmaker/New()
+	..()
+	name = "flatpack (medal printer)"
+	machine = new /obj/machinery/r_n_d/fabricator/mechanic_fab/autolathe/medal_printer(src)
+	storage_capacity = 1 //cuz it's a crate subtype it'll try to suck up everything on its loc otherwise


### PR DESCRIPTION
adds a medal printer flatpack to IAA's legal closet
IAA will be able to use medal printers, lowering the req access.

:cl:
 * rscadd: Added medal printer flatpack to IAA closet, which they can now use.