### PR TITLE
Fixed DNA modifier New() runtime

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -461,13 +461,15 @@
 		buffers[i] = new /datum/dna2/record
 	for(var/i=1;i<=DNA_SE_LENGTH;i++)
 		labels[i] = new /datum/block_label
-	spawn(5)
-		connected = findScanner()
+	if(world.has_round_started())
+		initialize()
+	spawn(250)
+		setInjectorReady()
+
+/obj/machinery/computer/scan_consolenew/initialize()
+	connected = findScanner()
+	if(connected)
 		connected.connected = src
-		spawn(250)
-			setInjectorReady()
-		return
-	return
 
 /obj/machinery/computer/scan_consolenew/ex_act(severity)
 	switch(severity)


### PR DESCRIPTION
For the longest time, building a "DNA Modifier Access Console" not adjacent to a scanner would result in a runtime that prevented it from spawning injectors at all. This fixes that.