### PR TITLE
Removed a bunch of spawn()s from human code

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -228,8 +228,7 @@
 
 	update_colour(0)
 
-	spawn()
-		update_mutantrace()
+	update_mutantrace()
 
 /mob/living/carbon/human/player_panel_controls()
 	var/html=""
@@ -1169,7 +1168,7 @@
 		to_chat(usr, "<span class='info'>You moved while counting. Try again.</span>")
 
 /mob/living/carbon/human/proc/set_species(var/new_species_name, var/force_organs, var/default_colour)
-
+	set waitfor = FALSE
 
 	if(new_species_name)
 		if(src.species && src.species.name && (src.species.name == new_species_name))
@@ -1232,13 +1231,13 @@
 	if((src.species.default_mutations.len > 0) || (src.species.default_blocks.len > 0))
 		src.do_deferred_species_setup = 1
 	meat_type = species.meat_type
-	spawn()
-		src.movement_speed_modifier = species.move_speed_multiplier
-		src.dna.species = new_species_name
-		src.species.handle_post_spawn(src)
-		src.update_icons()
-		if(species.species_intro)
-			to_chat(src, "<span class = 'notice'>[species.species_intro]</span>")
+	src.movement_speed_modifier = species.move_speed_multiplier
+	if(dna)
+		dna.species = new_species_name
+	src.species.handle_post_spawn(src)
+	src.update_icons()
+	if(species.species_intro)
+		to_chat(src, "<span class = 'notice'>[species.species_intro]</span>")
 	return 1
 
 /mob/living/carbon/human/proc/bloody_doodle()
@@ -1887,7 +1886,7 @@ mob/living/carbon/human/isincrit()
 		T.virus2 = virus_copylist(virus2)
 		T.get_clothes(src, T)
 		T.name = real_name
-		T.host = src	
+		T.host = src
 		forceMove(null)
 		return T
 	else

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -37,8 +37,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 		return
 
 	vessel.add_reagent(BLOOD,560)
-	spawn(1)
-		fixblood()
+	fixblood()
 
 //Resets blood data
 /mob/living/carbon/human/proc/fixblood()


### PR DESCRIPTION
Something is interacting with qdeleted humans but we can't know what it is because the call trace gets cucked by spawn().
These changes, which I have briefly tested and found no issue, should make the following runtimes debuggable:
```
[14:31:20] Runtime in human.dm, line 1236: Cannot read null.move_speed_multiplier
proc name: set species (/mob/living/carbon/human/proc/set_species)
usr: () (/mob/living/carbon/human)
usr.loc: (nullspace)
src: (/mob/living/carbon/human)
src.loc: null
call stack:
(/mob/living/carbon/human): set species("Human", null, null)
```

```
[14:31:20] Runtime in update_icons.dm, line 465: Cannot read null.icobase
proc name: update mutantrace (/mob/living/carbon/human/proc/update_mutantrace)
usr: () (/mob/living/carbon/human)
usr.loc: (nullspace)
src: (/mob/living/carbon/human)
src.loc: null
call stack:
(/mob/living/carbon/human): update mutantrace(1)
(/mob/living/carbon/human): New(the floor (8,95,2) (/turf/unsimulated/floor), null, 0)
```

```
[14:31:20] Runtime in blood.dm, line 45: Cannot read null.reagent_list
proc name: fixblood (/mob/living/carbon/human/proc/fixblood)
usr: () (/mob/living/carbon/human)
usr.loc: (nullspace)
src: (/mob/living/carbon/human)
src.loc: null
call stack:
(/mob/living/carbon/human): fixblood()
(/mob/living/carbon/human): make blood()
```