### PR TITLE
Fixed emagged cargo console runtime

### DIFF
--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -192,8 +192,6 @@ For vending packs, see vending_packs.dm*/
 		to_chat(user, "<span class='notice'>Special supplies unlocked.</span>")
 		hacked = 1
 		can_order_contraband = 1
-		var/obj/item/weapon/circuitboard/supplycomp/C = circuit
-		C.contraband_enabled = 1
 		return
 	if(I.is_screwdriver(user))
 		I.playtoolsound(loc, 50)


### PR DESCRIPTION
I didn't `git blame` but I'm sure barry did this
```
[15:05:34] Runtime in cargo.dm, line 196: Cannot modify /obj/item/weapon/circuitboard/supplycomp.contraband_enabled.
proc name: attackby (/obj/machinery/computer/supplycomp/attackby)
usr: Miguel Sanchez (mrflarg) (/mob/living/carbon/human)
usr.loc: The floor (248, 248, 1) (/turf/simulated/floor)
src: Supply shuttle console (/obj/machinery/computer/supplycomp)
src.loc: the floor (247,248,1) (/turf/simulated/floor)
call stack:
Supply shuttle console (/obj/machinery/computer/supplycomp): attackby(the cryptographic sequencer (/obj/item/weapon/card/emag), Miguel Sanchez (/mob/living/carbon/human), "icon-x=22;icon-y=3;left=1;scre...")
Miguel Sanchez (/mob/living/carbon/human): ClickOn(Supply shuttle console (/obj/machinery/computer/supplycomp), "icon-x=22;icon-y=3;left=1;scre...")
Supply shuttle console (/obj/machinery/computer/supplycomp): Click(the floor (247,248,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=22;icon-y=3;left=1;scre...")
MRflarg (/client): Click(Supply shuttle console (/obj/machinery/computer/supplycomp), the floor (247,248,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=22;icon-y=3;left=1;scre...")
```