### PR TITLE
Made a Bananium Solidification Recipe.

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -816,6 +816,16 @@
 /datum/chemical_reaction/solidification/gold/product_to_spawn()
 	return /obj/item/stack/sheet/mineral/gold
 
+/datum/chemical_reaction/solidification/clown
+	name = "Solid Bananium"
+	id = "solidbananium"
+	result = null
+	required_reagents = list(SILICATE = 10, FROSTOIL = 10, BANANA = 20)
+	result_amount = 1
+
+/datum/chemical_reaction/solidification/clown/product_to_spawn()
+	return /obj/item/stack/sheet/mineral/clown
+
 /datum/chemical_reaction/solidification/uranium
 	name = "Solid Uranium"
 	id = "soliduranium"


### PR DESCRIPTION
We have solidification recipes (I.E: turn powdered/liquid minerals to their solid form) for Gold, Uranium, Iron, Silver and Plasma. Bananium, being a "metal", should, for consistency, have a solidification recipe as well.
You can farm for all solidifiable metals, bananium should be solidifiable too.

You need 10 Silicate, 10 Frost Oil and 20 Banana Juice. The same proportion as in the other recipes. 
Sure, this may allow some clown shittery, but any clown that takes the time to acquire large quantities of both Frost Oil and Silicate deserves the bananium.

:cl:
 * rscadd: added a bananium solidification recipe
[qol] [consistency]