### PR TITLE
Fixed notes being attributed to Adminbot

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -568,7 +568,7 @@ var/list/admin_verbs_mod = list(
 	var/warn_reason = input("Reason for warning?", "Admin abuuuuuuuse") as null|text
 	if(!warn_reason)
 		return
-	notes_add(warned_ckey,warn_reason,src.mob)
+	holder.notes_add(warned_ckey, warn_reason)
 	if(++D.warns >= MAX_WARNS)					//uh ohhhh...you'reee iiiiin trouuuubble O:)
 		var/bantime = AUTOBANTIME//= (++D.warnbans * AUTOBANTIME)
 		D.warns = 0

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -1,4 +1,4 @@
-/proc/notes_add(var/key, var/note, var/mob/usr)
+/datum/admins/proc/notes_add(var/key, var/note)
 	if (!key || !note)
 		return
 
@@ -25,20 +25,21 @@
 	var/day_loc = findtext(full_date, time2text(world.timeofday, "DD"))
 
 	var/datum/player_info/P = new
-	if (usr)
-		P.author = usr.ckey
-		P.rank = usr.client.holder.rank
+	if (owner)
+		P.author = owner.ckey
+		P.rank = rank
 	else
 		P.author = "Adminbot"
 		P.rank = "Friendly Robot"
+		stack_trace("notes_add called on a /datum/admins with no owner.")
 	P.content = note
 	P.timestamp = "[copytext(full_date,1,day_loc)][day_string][copytext(full_date,day_loc+2)]"
 
 	infos += P
 	info << infos
 
-	message_admins("<span class='notice'>[key_name_admin(usr)] has edited [key]'s notes.</span>")
-	log_admin("[key_name(usr)] has edited [key]'s notes.")
+	message_admins("<span class='notice'>[key_name_admin(owner)] has edited [key]'s notes.</span>")
+	log_admin("[key_name(owner)] has edited [key]'s notes.")
 
 	del info
 
@@ -54,7 +55,7 @@
 	del note_list
 
 
-/proc/notes_del(var/key, var/index)
+/datum/admins/proc/notes_del(var/key, var/index)
 	var/savefile/info = new("data/player_saves/[copytext(key, 1, 2)]/[key]/info.sav")
 	var/list/infos
 	info >> infos
@@ -65,7 +66,7 @@
 	infos.Remove(item)
 	info << infos
 
-	message_admins("<span class='notice'>[key_name_admin(usr)] deleted one of [key]'s notes.</span>")
-	log_admin("[key_name(usr)] deleted one of [key]'s notes.")
+	message_admins("<span class='notice'>[key_name_admin(owner)] deleted one of [key]'s notes.</span>")
+	log_admin("[key_name(owner)] deleted one of [key]'s notes.")
 
 	del info

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1487,25 +1487,6 @@
 			message_admins("<span class='notice'>[key_name_admin(usr)] booted [key_name_admin(M)].</span>", 1)
 			//M.client = null
 			del(M.client)
-/*
-	//Player Notes
-	else if(href_list["notes"])
-		var/ckey = href_list["ckey"]
-		if(!ckey)
-			var/mob/M = locate(href_list["mob"])
-			if(ismob(M))
-				ckey = M.ckey
-
-		switch(href_list["notes"])
-			if("show")
-				notes_show(ckey)
-			if("add")
-				notes_add(ckey,href_list["text"])
-				notes_show(ckey)
-			if("remove")
-				notes_remove(ckey,text2num(href_list["from"]),text2num(href_list["to"]))
-				notes_show(ckey)
-*/
 	else if(href_list["removejobban"])
 		if(!check_rights(R_BAN))
 			return
@@ -4607,7 +4588,7 @@
 		if(!add)
 			return
 
-		notes_add(key,add,usr)
+		notes_add(key, add)
 		show_player_info(key)
 
 	if(href_list["remove_player_info"])


### PR DESCRIPTION
Closes #27919
The reason why this was tricky to reproduce is that after an atom (the mob of the admin in this case) is qdel'd, the Garbage SS waits 30 seconds before actually hard-deleting it.
Changed `notes_add` to no longer take a `usr` parameter. It looks up the `datum/admins`'s `owner` instead, which persists even if the admin's mob changes.
Subscribe to patreon etc...