### PR TITLE
Fixed undeleted query in /client/New

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -218,7 +218,6 @@
 	if(!query.Execute())
 		message_admins("Error: [query.ErrorMsg()]")
 		log_sql("Error: [query.ErrorMsg()]")
-		qdel(query)
 	else
 		while(query.NextRow())
 			var/id = query.item[1]
@@ -252,7 +251,8 @@
 			if(!update_query.Execute())
 				message_admins("Error: [update_query.ErrorMsg()]")
 				log_sql("Error: [update_query.ErrorMsg()]")
-				qdel(update_query)
+			qdel(update_query)
+	qdel(query)
 
 	if (prefs && prefs.show_warning_next_time)
 		to_chat(src, "<span class='notice'><b>You, or another user of this ckey ([ckey]) were warned by [prefs.warning_admin].</b></span>")


### PR DESCRIPTION
```
[03:48:02]ADMINWARN: <span class="admin"><span class="prefix">ADMIN LOG:</span> <span class="message">Found undeleted query, please check the server logs and notify coders.</span></span>
[03:48:02]SQL: Undeleted query: "SELECT id, ckey, ip, computerid, a_ckey, reason, expiration_time, duration, bantime, bantype, unbanned, unbanned_ckey, unbanned_datetime FROM erro_ban WHERE (ckey = :ckey OR ip = :address  OR computerid = :computer_id) AND unbanned_notification = 0;" LA: NextRow LAT: 146
```