### PR TITLE
Using a screwdriver on undeployed switchtool dumps out all modules, clicking on tools with an undeployed switchtool adds all tools on the tile into the switchtool

### DIFF
--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -58,7 +58,7 @@
 				success = 1
 
 		if(success)
-			to_chat(user, "You load everything into the [src].")
+			to_chat(user, "You load everything into \the [src].")
 
 
 

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -55,6 +55,8 @@
 		for(var/obj/item/I in T)
 			add_module(I, user, 0)
 
+		to_chat("You load everything into the [src].")
+
 
 
 

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -160,7 +160,7 @@
 		playsound(src, "sound/items/screwdriver.ogg", 10, 1)
 		return TRUE
 	else
-		to_chat(user, "The [src] is empty.")
+		to_chat(user, "<span class='warning'>\The [src] is empty.</span>")
 
 /obj/item/weapon/switchtool/proc/undeploy()
 	playsound(src, undeploy_sound, 10, 1)

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -148,13 +148,19 @@
 /obj/item/weapon/switchtool/proc/remove_all_modules(mob/user)
 	if(deployed)		//this shouldnt happen but just in case
 		undeploy()
+
+	var/success = 0
 	for(var/module in stored_modules)
 		if(stored_modules[module])
+			success = 1
 			stored_modules[module].forceMove(get_turf(user))
 			stored_modules[module] = null
-	to_chat(user, "You clear out everything from the [src].")
-	playsound(src, "sound/items/screwdriver.ogg", 10, 1)
-	return TRUE
+	if(success)
+		to_chat(user, "You clear out everything from the [src].")
+		playsound(src, "sound/items/screwdriver.ogg", 10, 1)
+		return TRUE
+	else
+		to_chat(user, "The [src] is empty.")
 
 /obj/item/weapon/switchtool/proc/undeploy()
 	playsound(src, undeploy_sound, 10, 1)

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -149,8 +149,9 @@
 	if(deployed)		//this shouldnt happen but just in case
 		undeploy()
 	for(var/module in stored_modules)
-		stored_modules[module].forceMove(get_turf(user))
-		stored_modules[module] = null
+		if(stored_modules[module])
+			stored_modules[module].forceMove(get_turf(user))
+			stored_modules[module] = null
 	to_chat(user, "You clear out everything from the [src].")
 	playsound(src, "sound/items/screwdriver.ogg", 10, 1)
 	return TRUE

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -58,7 +58,7 @@
 				success = 1
 
 		if(success)
-			to_chat("You load everything into the [src].")
+			to_chat(user, "You load everything into the [src].")
 
 
 

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -53,7 +53,7 @@
 			return 
 
 		for(var/obj/item/I in T)
-			add_module(I, user)
+			add_module(I, user, 0)
 
 
 
@@ -110,7 +110,7 @@
 			module_string += "\a [get_module_name(module)], "
 	return module_string
 
-/obj/item/weapon/switchtool/proc/add_module(var/obj/item/used_item, mob/user)
+/obj/item/weapon/switchtool/proc/add_module(var/obj/item/used_item, mob/user, var/message = 1)
 	if(!used_item || !user)
 		return FALSE
 
@@ -118,12 +118,14 @@
 		var/type_path = text2path(get_module_type(module))
 		if(istype(used_item, type_path))
 			if(stored_modules[module])
-				to_chat(user, "\The [src] already has a [get_module_name(module)].")
+				if(message)
+					to_chat(user, "\The [src] already has a [get_module_name(module)].")
 				return FALSE
 			else
 				if(user.drop_item(used_item, src))
 					stored_modules[module] = used_item
-					to_chat(user, "You successfully load \the [used_item] into \the [src]'s [get_module_name(module)] slot.")
+					if(message)
+						to_chat(user, "You successfully load \the [used_item] into \the [src]'s [get_module_name(module)] slot.")
 					return TRUE
 
 /obj/item/weapon/switchtool/proc/remove_module(mob/user)

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -54,7 +54,7 @@
 
 		var/success = FALSE
 		for(var/obj/item/I in T)
-			if(add_module(I, user, 0))
+			if(add_module(I, user, FALSE))
 				success = TRUE
 
 		if(success)

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -52,10 +52,10 @@
 		else
 			return 
 
-		var/success = 0
+		var/success = FALSE
 		for(var/obj/item/I in T)
 			if(add_module(I, user, 0))
-				success = 1
+				success = TRUE
 
 		if(success)
 			to_chat(user, "You load everything into \the [src].")
@@ -115,7 +115,7 @@
 			module_string += "\a [get_module_name(module)], "
 	return module_string
 
-/obj/item/weapon/switchtool/proc/add_module(var/obj/item/used_item, mob/user, var/message = 1)
+/obj/item/weapon/switchtool/proc/add_module(var/obj/item/used_item, mob/user, var/message = TRUE)
 	if(!used_item || !user)
 		return FALSE
 
@@ -149,10 +149,10 @@
 	if(deployed)		//this shouldnt happen but just in case
 		undeploy()
 
-	var/success = 0
+	var/success = FALSE
 	for(var/module in stored_modules)
 		if(stored_modules[module])
-			success = 1
+			success = TRUE
 			stored_modules[module].forceMove(get_turf(user))
 			stored_modules[module] = null
 	if(success)

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -156,7 +156,7 @@
 			stored_modules[module].forceMove(get_turf(user))
 			stored_modules[module] = null
 	if(success)
-		to_chat(user, "You clear out everything from the [src].")
+		to_chat(user, "<span class='notice'>You clear out everything from \the [src].</span>")
 		playsound(src, "sound/items/screwdriver.ogg", 10, 1)
 		return TRUE
 	else

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -52,10 +52,13 @@
 		else
 			return 
 
+		var/success = 0
 		for(var/obj/item/I in T)
-			add_module(I, user, 0)
+			if(add_module(I, user, 0))
+				success = 1
 
-		to_chat("You load everything into the [src].")
+		if(success)
+			to_chat("You load everything into the [src].")
 
 
 

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -42,6 +42,21 @@
 					stored_modules[module] = null
 			undeploy()
 		return TRUE
+	else
+		if(!proximity_flag)
+			return
+			
+		var/turf/T
+		if(isturf(target.loc))
+			T = target.loc
+		else
+			return 
+
+		for(var/obj/item/I in T)
+			add_module(I, user)
+
+
+
 
 /obj/item/weapon/switchtool/New()
 	..()
@@ -65,8 +80,12 @@
 		choose_deploy(user)
 
 /obj/item/weapon/switchtool/attackby(var/obj/item/used_item, mob/user)
-	if(istype(used_item, removing_item) && deployed) //if it's the thing that lets us remove tools and we have something to remove
-		return remove_module(user)
+	if(istype(used_item, removing_item)) //if it's the thing that lets us remove tools and we have something to remove
+		if(deployed)
+			return remove_module(user)
+		else
+			return remove_all_modules(user)
+
 	if(add_module(used_item, user))
 		return TRUE
 	else
@@ -117,6 +136,16 @@
 	to_chat(user, "You successfully remove \the [deployed] from \the [src].")
 	playsound(src, "sound/items/screwdriver.ogg", 10, 1)
 	undeploy()
+	return TRUE
+
+/obj/item/weapon/switchtool/proc/remove_all_modules(mob/user)
+	if(deployed)		//this shouldnt happen but just in case
+		undeploy()
+	for(var/module in stored_modules)
+		stored_modules[module].forceMove(get_turf(user))
+		stored_modules[module] = null
+	to_chat(user, "You clear out everything from the [src].")
+	playsound(src, "sound/items/screwdriver.ogg", 10, 1)
 	return TRUE
 
 /obj/item/weapon/switchtool/proc/undeploy()


### PR DESCRIPTION


what it says on the tin

using a screwdriver on a closed switchtool will dump out everything
using a closed switchtool on a pile of tools will attempt to load all the tools on that tile into the switchtool
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
:cl:
 * tweak: Using a screwdriver on a closed switchtool will dump out every module from it. Clicking on a pile of tools with a closed switchtool will attempt to load every tool in that pile into the switchtool.

