### PR TITLE
Prevent the map loader from messing with gliding

### DIFF
--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -444,6 +444,6 @@ var/list/map_dimension_cache = list()
 	target_path = path
 
 /dmm_suite/preloader/proc/load(atom/what)
-	for(var/attribute in attributes)
+	for(var/attribute in attributes - lockedvars)
 		what.vars[attribute] = attributes[attribute]
 	Del()


### PR DESCRIPTION
It's not like admins would just load a .dmm with step_x or step_y and turn the game into a powerpoint presentation haha.