### PR TITLE
Set a default hitsound for all items

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -7,7 +7,7 @@
 	var/list/inhand_states = list("left_hand" = 'icons/mob/in-hand/left/items_lefthand.dmi', "right_hand" = 'icons/mob/in-hand/right/items_righthand.dmi')
 	var/r_speed = 1.0
 	var/health = null
-	var/hitsound = null
+	var/hitsound = 'sound/weapons/smash.ogg'
 	var/armor_penetration = 0 // Chance from 0 to 100 to reduce absorb by one, and then rolls the same value. Check living_defense.dm
 
 	var/w_class = W_CLASS_MEDIUM

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -79,10 +79,11 @@
 
 /obj/item/New()
 	..()
-	if(force < 5) // Arbitrarily chosen
-		hitsound = 'sound/effects/slap1.ogg'
-	else
-		hitsound = 'sound/weapons/smash.ogg'
+	if(!hitsound)
+		if(force < 5) // Arbitrarily chosen
+			hitsound = 'sound/effects/slap1.ogg'
+		else
+			hitsound = 'sound/weapons/smash.ogg'
 	for(var/path in actions_types)
 		new path(src)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -7,7 +7,7 @@
 	var/list/inhand_states = list("left_hand" = 'icons/mob/in-hand/left/items_lefthand.dmi', "right_hand" = 'icons/mob/in-hand/right/items_righthand.dmi')
 	var/r_speed = 1.0
 	var/health = null
-	var/hitsound = 'sound/weapons/smash.ogg'
+	var/hitsound
 	var/armor_penetration = 0 // Chance from 0 to 100 to reduce absorb by one, and then rolls the same value. Check living_defense.dm
 
 	var/w_class = W_CLASS_MEDIUM
@@ -79,6 +79,10 @@
 
 /obj/item/New()
 	..()
+	if(force < 5) // Arbitrarily chosen
+		hitsound = 'sound/effects/slap1.ogg'
+	else
+		hitsound = 'sound/weapons/smash.ogg'
 	for(var/path in actions_types)
 		new path(src)
 


### PR DESCRIPTION
~~It's the CLANG that wrenches and extinguishers already use.~~
It's either a clang sound or a slapping sound depending on the damage.

:cl:
 * tweak: Items that previously played no sound when hitting someone with them will now play a generic hit sound instead.