### PR TITLE
Cargo Crate: Skeletal Remains

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1914,6 +1914,22 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containername = "lab mouse crate"
 	group = "Medical"
 
+/datum/supply_packs/remains
+	name = "Skeletal remains"
+	contains = list (
+					/obj/item/stack/sheet/bone,
+					/obj/item/stack/sheet/bone,
+					/obj/item/stack/sheet/bone,
+					/obj/item/stack/sheet/bone,
+					/obj/item/stack/sheet/bone,
+					/obj/item/stack/sheet/bone,
+					/obj/item/weapon/skull
+					)
+	cost = 20
+	containertype = /obj/structure/closet/coffin
+	containername = "skeletal remains container"
+	group = "Medical"
+
 //////SCIENCE//////
 
 /datum/supply_packs/research_parts


### PR DESCRIPTION
Adds a crate to cargo containing a skull and a stack of 6 bones. 
Costs 20, it's not ID restricted and comes in a coffin. Classified under medical because it makes the most sense.

:cl:
 * rscadd: Added a spooky crate full of spooky bones to cargo