### PR TITLE
DNA modifiers and injectors properly transfer unique enzymes

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -1046,6 +1046,7 @@
 
 			if ((buf.types & DNA2_BUF_UI))
 				if ((buf.types & DNA2_BUF_UE))
+					src.connected.occupant.dna.unique_enzymes = buf.dna.unique_enzymes
 					src.connected.occupant.real_name = buf.dna.real_name
 					src.connected.occupant.name = buf.dna.real_name
 					src.connected.occupant.flavor_text = buf.dna.flavor_text

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -105,6 +105,7 @@
 				if(!block) //isolated block?
 					M.UpdateAppearance(buf.dna.UI.Copy())
 					if (buf.types & DNA2_BUF_UE) //unique enzymes? yes
+						M.dna.unique_enzymes = buf.dna.unique_enzymes
 						M.real_name = buf.dna.real_name
 						M.flavor_text = buf.dna.flavor_text
 						M.name = buf.dna.real_name


### PR DESCRIPTION
Closes #12436 I guess

:cl:
 * bugfix: DNA injectors and DNA modifiers will now transfer unique enzymes if they are in the DNA buffer, as intended. This means stealing someone's identity will let one through DNA locks such as those used by mechs.