### PR TITLE
Added setting to change client fps

### DIFF
--- a/SQL/players2.sql
+++ b/SQL/players2.sql
@@ -127,6 +127,10 @@ CREATE TABLE client (
 	obj_chat_on_map INTEGER,
 	no_goonchat_for_obj INTEGER,
 	tgui_fancy INTEGER,
+	show_warning_next_time INTEGER DEFAULT 0,
+	last_warned_message TEXT DEFAULT '',
+	warning_admin TEXT DEFAULT '',
+	fps INTEGER DEFAULT 0
 );
 
 

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1776,3 +1776,5 @@ var/list/bank_security_text2num_associative = list(
 
 var/list/weekend_days = list("Friday", "Saturday", "Sunday")
 #define IS_WEEKEND (weekend_days.Find(time2text(world.timeofday, "Day")))
+
+#define RECOMMENDED_CLIENT_FPS 100

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -185,7 +185,6 @@
 	prefs.client = src
 	prefs.initialize_preferences(client_login = 1)
 
-
 	. = ..()	//calls mob.Login()
 	chatOutput.start()
 
@@ -284,6 +283,7 @@
 		verbs += /client/proc/readmin
 		deadmins += ckey
 		to_chat(src, "<span class='interface'>You are now de-admined.</span>")
+	fps = (prefs.fps < 0) ? RECOMMENDED_CLIENT_FPS : prefs.fps
 	//////////////
 	//DISCONNECT//
 	//////////////

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1351,6 +1351,7 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 			switch(href_list["preference"])
 				if("fps")
 					var/desired_fps = input(user, "Choose your desired frames per second.\n\
+WARNING: BYOND versions earlier than 513.1323 might not work properly with values other than 0.\n\
 Set this to -1 to use the recommended value.\n\
 Set this to 0 to use the server's FPS (currently [world.fps])\n\
 Values up to 1000 are allowed.", "FPS", fps) as null|num

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1351,7 +1351,7 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 			switch(href_list["preference"])
 				if("fps")
 					var/desired_fps = input(user, "Choose your desired frames per second.\n\
-WARNING: BYOND versions earlier than 513.1323 might not work properly with values other than 0.\n\
+WARNING: BYOND versions earlier than 513.1523 might not work properly with values other than 0.\n\
 Set this to -1 to use the recommended value.\n\
 Set this to 0 to use the server's FPS (currently [world.fps])\n\
 Values up to 1000 are allowed.", "FPS", fps) as null|num

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -225,6 +225,7 @@ var/const/MAX_SAVE_SLOTS = 16
 	var/no_goonchat_for_obj = FALSE
 
 	var/tgui_fancy = TRUE
+	var/fps = 0
 
 	var/client/client
 	var/saveloaded = 0
@@ -362,6 +363,8 @@ var/const/MAX_SAVE_SLOTS = 16
 	<h1>General Settings</h1>
 <div id="container" style="border:1px solid #000; width:96; padding-left:2%; padding-right:2%; overflow:auto; padding-top:5px; padding-bottom:5px;">
   <div id="leftDiv" style="width:50%;height:100%;float:left;">
+	<b>FPS:</b>
+	<a href='?_src_=prefs;preference=fps'><b>[fps]</b></a><br>
 	<b>Space Parallax:</b>
 	<a href='?_src_=prefs;preference=parallax'><b>[space_parallax ? "Enabled" : "Disabled"]</b></a><br>
 	<b>Parallax Speed:</b>
@@ -1346,6 +1349,18 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 
 		else
 			switch(href_list["preference"])
+				if("fps")
+					var/desired_fps = input(user, "Choose your desired frames per second.\n\
+Set this to -1 to use the recommended value.\n\
+Set this to 0 to use the server's FPS (currently [world.fps])\n\
+Values up to 1000 are allowed.", "FPS", fps) as null|num
+					if(isnull(desired_fps))
+						return
+					if(desired_fps < 0)
+						desired_fps = -1
+					desired_fps = sanitize_integer(desired_fps, -1, 1000, fps)
+					fps = desired_fps
+					client.fps = (fps < 0) ? RECOMMENDED_CLIENT_FPS : fps
 				if("gender")
 					if(gender == MALE)
 						gender = FEMALE

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -75,6 +75,7 @@
 	show_warning_next_time = text2num(preference_list_client["show_warning_next_time"])
 	last_warned_message = preference_list_client["last_warned_message"]
 	warning_admin = preference_list_client["warning_admin"]
+	fps = preference_list_client["fps"]
 
 	ooccolor		= 	sanitize_hexcolor(ooccolor, initial(ooccolor))
 	lastchangelog	= 	sanitize_text(lastchangelog, initial(lastchangelog))
@@ -111,6 +112,7 @@
 	no_goonchat_for_obj  =  sanitize_integer(no_goonchat_for_obj, 0, 1, initial(no_goonchat_for_obj))
 	tgui_fancy           =  sanitize_integer(tgui_fancy, 0, 1, initial(tgui_fancy))
 	show_warning_next_time = sanitize_integer(show_warning_next_time, 0, 1, initial(show_warning_next_time))
+	fps = sanitize_integer(fps, -1, 1000, initial(fps))
 	initialize_preferences()
 	return 1
 
@@ -131,15 +133,15 @@
 	check.Add("SELECT ckey FROM client WHERE ckey = ?", ckey)
 	if(check.Execute(db))
 		if(!check.NextRow())
-			q.Add("INSERT into client (ckey, ooc_color, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume, window_flashing, antag_objectives, typing_indicator, mob_chat_on_map, max_chat_length, obj_chat_on_map, no_goonchat_for_obj, tgui_fancy, show_warning_next_time, last_warned_message, warning_admin) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",\
-			ckey, ooccolor, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special_popup, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume, window_flashing, antag_objectives, typing_indicator, mob_chat_on_map, max_chat_length, obj_chat_on_map, no_goonchat_for_obj, tgui_fancy, show_warning_next_time, last_warned_message, warning_admin)
+			q.Add("INSERT into client (ckey, ooc_color, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume, window_flashing, antag_objectives, typing_indicator, mob_chat_on_map, max_chat_length, obj_chat_on_map, no_goonchat_for_obj, tgui_fancy, show_warning_next_time, last_warned_message, warning_admin, fps) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",\
+			ckey, ooccolor, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special_popup, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume, window_flashing, antag_objectives, typing_indicator, mob_chat_on_map, max_chat_length, obj_chat_on_map, no_goonchat_for_obj, tgui_fancy, show_warning_next_time, last_warned_message, warning_admin, fps)
 			if(!q.Execute(db))
 				message_admins("Error in save_preferences_sqlite [__FILE__] ln:[__LINE__] #: [q.Error()] - [q.ErrorMsg()]")
 				WARNING("Error in save_preferences_sqlite [__FILE__] ln:[__LINE__] #:[q.Error()] - [q.ErrorMsg()]")
 				return 0
 		else
-			q.Add("UPDATE client SET ooc_color=?,lastchangelog=?,UI_style=?,default_slot=?,toggles=?,UI_style_color=?,UI_style_alpha=?,warns=?,warnbans=?,randomslot=?,volume=?,usewmp=?,special=?,usenanoui=?,tooltips=?,progress_bars=?,space_parallax=?,space_dust=?,parallax_speed=?, stumble=?, attack_animation=?, pulltoggle=?, credits=?, jingle=?, hear_voicesound=?, hear_instruments=?, ambience_volume=?, credits_volume=?, window_flashing=?, antag_objectives=? , typing_indicator=? , mob_chat_on_map=? , max_chat_length=?, obj_chat_on_map=?, no_goonchat_for_obj=?, tgui_fancy=?, show_warning_next_time=?, last_warned_message=?, warning_admin=? WHERE ckey = ?",\
-			ooccolor, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special_popup, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume, window_flashing, antag_objectives, typing_indicator, mob_chat_on_map, max_chat_length, obj_chat_on_map,no_goonchat_for_obj, tgui_fancy, show_warning_next_time, last_warned_message, warning_admin, ckey)
+			q.Add("UPDATE client SET ooc_color=?,lastchangelog=?,UI_style=?,default_slot=?,toggles=?,UI_style_color=?,UI_style_alpha=?,warns=?,warnbans=?,randomslot=?,volume=?,usewmp=?,special=?,usenanoui=?,tooltips=?,progress_bars=?,space_parallax=?,space_dust=?,parallax_speed=?, stumble=?, attack_animation=?, pulltoggle=?, credits=?, jingle=?, hear_voicesound=?, hear_instruments=?, ambience_volume=?, credits_volume=?, window_flashing=?, antag_objectives=? , typing_indicator=? , mob_chat_on_map=? , max_chat_length=?, obj_chat_on_map=?, no_goonchat_for_obj=?, tgui_fancy=?, show_warning_next_time=?, last_warned_message=?, warning_admin=?, fps=? WHERE ckey = ?",\
+			ooccolor, lastchangelog, UI_style, default_slot, toggles, UI_style_color, UI_style_alpha, warns, warnbans, randomslot, volume, usewmp, special_popup, usenanoui, tooltips, progress_bars, space_parallax, space_dust, parallax_speed, stumble, attack_animation, pulltoggle, credits, jingle, hear_voicesound, hear_instruments, ambience_volume, credits_volume, window_flashing, antag_objectives, typing_indicator, mob_chat_on_map, max_chat_length, obj_chat_on_map,no_goonchat_for_obj, tgui_fancy, show_warning_next_time, last_warned_message, warning_admin, fps, ckey)
 			if(!q.Execute(db))
 				message_admins("Error in save_preferences_sqlite [__FILE__] ln:[__LINE__] #: [q.Error()] - [q.ErrorMsg()]")
 				WARNING("Error in save_preferences_sqlite [__FILE__] ln:[__LINE__] #:[q.Error()] - [q.ErrorMsg()]")

--- a/code/modules/migrations/SS13_Prefs/026-add-fps.dm
+++ b/code/modules/migrations/SS13_Prefs/026-add-fps.dm
@@ -1,0 +1,13 @@
+/datum/migration/sqlite/ss13_prefs/_026
+	id = 26
+	name = "Add FPS"
+
+/datum/migration/sqlite/ss13_prefs/_026/up()
+	if(!hasColumn("client","fps"))
+		return execute("ALTER TABLE `client` ADD COLUMN fps INTEGER DEFAULT 0")
+	return TRUE
+
+/datum/migration/sqlite/ss13_prefs/_026/down()
+	if(hasColumn("client","fps"))
+		return execute("ALTER TABLE `client` DROP COLUMN fps")
+	return TRUE

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1664,6 +1664,7 @@
 #include "code\modules\migrations\SS13_Prefs\023-runechat.dm"
 #include "code\modules\migrations\SS13_Prefs\024-add-tgui-fancy.dm"
 #include "code\modules\migrations\SS13_Prefs\025-warning_notif.dm"
+#include "code\modules\migrations\SS13_Prefs\026-add-fps.dm"
 #include "code\modules\migrations\SS13_Prefs\_base.dm"
 #include "code\modules\mining\abandonedcrates.dm"
 #include "code\modules\mining\debug_shit.dm"


### PR DESCRIPTION
This does nothing by default, so that all the boomer luddites who prefer the old way don't have to do anything.

I based these changes on https://github.com/tgstation/tgstation/pull/52850. Follow the links if you care about the details.

TG's recommendation is 40 FPS, but in my testing (both local and on the main serb) 100 worked better, so that's what I set as the recommended.

![image](https://user-images.githubusercontent.com/6307265/95697268-711a8080-0c3e-11eb-855c-86029e9def09.png)

:cl:
 * rscadd: Added an option under General Settings to change the client's FPS.