### PR TITLE
Gas overlays no longer capture clicks

### DIFF
--- a/code/ZAS/XGM_gases.dm
+++ b/code/ZAS/XGM_gases.dm
@@ -13,6 +13,7 @@
 //This should probably be in a different file, but currently it's only used here.
 /image/effect
 	plane = EFFECTS_PLANE
+	mouse_opacity = 0
 
 /datum/gas/proc/is_human_safe(var/moles, var/datum/gas_mixture/mixture)
 	return TRUE


### PR DESCRIPTION
The tiny squares that showed N2O and plasma in the air used to be clickable, so they would prevent clicking on what was underneath them. No longer the case.