### PR TITLE
improved a qdel warning message

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -244,7 +244,7 @@ List of hard deletions:"}
 		return
 
 	if(istype(D, /atom) && !istype(D, /atom/movable))
-		warning("qdel() passed object of type [D.type]. qdel() cannot handle unmovable atoms.")
+		stack_trace("qdel() passed object of type [D.type]. qdel() cannot handle unmovable atoms.")
 		del(D)
 		SSgarbage.hard_dels++
 		SSgarbage.dels_count++

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -244,11 +244,10 @@ List of hard deletions:"}
 		return
 
 	if(istype(D, /atom) && !istype(D, /atom/movable))
-		stack_trace("qdel() passed object of type [D.type]. qdel() cannot handle unmovable atoms.")
 		del(D)
 		SSgarbage.hard_dels++
 		SSgarbage.dels_count++
-		return
+		CRASH("qdel() passed object of type [D.type]. qdel() cannot handle unmovable atoms.")
 
 	if(isnull(D.gcDestroyed))
 		// Let our friend know they're about to get fucked up.


### PR DESCRIPTION
Because `## WARNING: qdel() passed object of type /turf/simulated/floor/plating. qdel() cannot handle unmovable atoms.` is useless