### PR TITLE
remove special harmbaton name for stealth

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -286,8 +286,7 @@
 			R.cell.use(hitcost)
 
 /obj/item/weapon/melee/baton/harm
-	name = "harm baton"
-	desc = "A harm baton for incapacitating people with."
+	desc = "A baton for permanently incapacitating people with."
 	icon_state = "harmbaton"
 	item_state = "baton0"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/swords_axes.dmi', "right_hand" = 'icons/mob/in-hand/right/swords_axes.dmi')


### PR DESCRIPTION
for @PrimeDSS13 

🆑 
 - tweak: the syndicate harm baton no longer has a name that is different from a normal stun baton.