### PR TITLE
Areas without APCs can no longer have overlays

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -338,6 +338,9 @@ var/area/space_area
 		return ambience_list
 
 /area/proc/updateicon()
+	if (!areaapc)
+		icon_state = null
+		return
 	if ((fire || eject || party || radalert) && ((!requires_power)?(!requires_power):power_environ))//If it doesn't require power, can still activate this proc.
 		// Highest priority at the top.
 		if(radalert && !fire)


### PR DESCRIPTION
This means no more escape overlays on space when the singulo ate the station.

:cl:
 * tweak: Areas without APCs can no longer have overlays