### PR TITLE
Harmbaton Tator Item is now more similar to a normal stun baton.

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -286,8 +286,7 @@
 			R.cell.use(hitcost)
 
 /obj/item/weapon/melee/baton/harm
-	name = "harm baton"
-	desc = "A harm baton for incapacitating people with."
+	desc = "A baton for permanently incapacitating people with."
 	icon_state = "harmbaton"
 	item_state = "baton0"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/swords_axes.dmi', "right_hand" = 'icons/mob/in-hand/right/swords_axes.dmi')


### PR DESCRIPTION
harmbaton now looks like a normal baton, so it doesn't immediately out you as a syndicate agent if you use it once
code is written by sonixapache but I have stolen it 
<!--<tweak>-->

:cl:
 * tweak: harmbaton is more stealthy