### PR TITLE
Battering rams can ram firelocks

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -867,7 +867,7 @@ proc/GaussRandRound(var/sigma,var/roundto)
 		sleep(delayfraction)
 		var/success
 		if(custom_checks)
-			success = custom_checks.invoke(user, use_user_turf, Location, target, target_location)
+			success = custom_checks.invoke(user, use_user_turf, Location, target, target_location, needhand, holding)
 		else
 			success = do_after_default_checks(user, use_user_turf, Location, target, target_location, needhand, holding)
 		if(!success)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -793,7 +793,43 @@ proc/GaussRandRound(var/sigma,var/roundto)
 
 	return TRUE
 
-/proc/do_after(var/mob/user as mob, var/atom/target, var/delay as num, var/numticks = 10, var/needhand = TRUE, var/use_user_turf = FALSE)
+
+// Returns TRUE if the checks passed
+/proc/do_after_default_checks(mob/user, use_user_turf, user_original_location, atom/target, target_original_location, needhand, obj/item/originally_held_item)
+	if(!user)
+		return FALSE
+	if(user.isStunned())
+		return FALSE
+	var/user_loc_to_check = use_user_turf ? get_turf(user) : user.loc
+	if(user_loc_to_check != user_original_location)
+		return FALSE
+	if(target.loc != target_original_location)
+		return FALSE
+	if(needhand)
+		if(originally_held_item)
+			if(!user.is_holding_item(originally_held_item))
+				return FALSE
+		else
+			if(user.get_active_hand())
+				return FALSE
+	return TRUE
+
+/**
+  * Used to delay actions.
+  *
+  * Given a mob, a target atom and a duration,
+  * returns TRUE if the mob wasn't interrupted and stayed
+  * at the same position for the specified duration.
+  * Arguments:
+  * * mob/user - the user who will see the progress bar
+  * * atom/target - the atom the progress bar will be attached to
+  * * delay - duration in deciseconds of the delay
+  * * numticks - how many times the failure conditions will be checked throughout the duration
+  * * needhand - if TRUE, the item in the hands of the user needs to stay the same throughout the duration
+  * * use_user_turf - if TRUE, the turf of the user is checked instead of its location
+  * * custom_checks - if specified, the return value of this callback (called every `delay/numticks` seconds) will determine whether the action succeeded
+  */
+/proc/do_after(var/mob/user as mob, var/atom/target, var/delay as num, var/numticks = 10, var/needhand = TRUE, var/use_user_turf = FALSE, callback/custom_checks)
 	if(!user || isnull(user))
 		return 0
 	if(numticks == 0)
@@ -818,10 +854,6 @@ proc/GaussRandRound(var/sigma,var/roundto)
 			progbar.plane = HUD_PLANE
 			progbar.layer = HUD_ABOVE_ITEM_LAYER
 			progbar.appearance_flags = RESET_COLOR | RESET_TRANSFORM
-		//if(!barbar)
-			//barbar = image("icon" = 'icons/effects/doafter_icon.dmi', "loc" = target, "icon_state" = "none")
-			//barbar.pixel_y = 36
-	//var/oldstate
 	for (var/i = 1 to numticks)
 		if(user && user.client && user.client.prefs.progress_bars && target)
 			if(!progbar)
@@ -830,34 +862,17 @@ proc/GaussRandRound(var/sigma,var/roundto)
 				progbar.plane = HUD_PLANE
 				progbar.layer = HUD_ABOVE_ITEM_LAYER
 				progbar.appearance_flags = RESET_COLOR | RESET_TRANSFORM
-			//oldstate = progbar.icon_state
 			progbar.icon_state = "prog_bar_[round(((i / numticks) * 100), 10)]"
 			user.client.images |= progbar
 		sleep(delayfraction)
-		//if(user.client && progbar.icon_state != oldstate)
-			//user.client.images.Remove(progbar)
-		var/user_loc_to_check
-		if(use_user_turf)
-			user_loc_to_check = get_turf(user)
+		var/success
+		if(custom_checks)
+			success = custom_checks.invoke(user, use_user_turf, Location, target, target_location)
 		else
-			user_loc_to_check = user.loc
-		if(!user || user.isStunned() || !(user_loc_to_check == Location) || !(target.loc == target_location))
+			success = do_after_default_checks(user, use_user_turf, Location, target, target_location, needhand, holding)
+		if(!success)
 			if(progbar)
-				progbar.icon_state = "prog_bar_stopped"
-				spawn(2)
-					if(user && user.client)
-						user.client.images -= progbar
-					if(progbar)
-						progbar.loc = null
-			return 0
-		if(needhand && ((holding && !user.is_holding_item(holding)) || (!holding && user.get_active_hand())))	//Sometimes you don't want the user to have to use any hands
-			if(progbar)
-				progbar.icon_state = "prog_bar_stopped"
-				spawn(2)
-					if(user && user.client)
-						user.client.images -= progbar
-					if(progbar)
-						progbar.loc = null
+				stop_progress_bar(user, progbar)
 			return 0
 	if(user && user.client)
 		user.client.images -= progbar
@@ -1568,7 +1583,7 @@ var/mob/dview/tview/tview_mob = new()
 
 /proc/get_random_potion()	//Pulls up a random potion, excluding minor-types
 	return pick(subtypesof(/obj/item/potion) - /obj/item/potion/mutation)
-			
+
 //We check if a specific game mode is currently undergoing.
 //First by checking if it is the current main mode,
 //Secondly by checking if it is part of a Mixed game mode.

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -829,6 +829,13 @@
 		to_chat(user,"<span class='warning'>\The [src] is too bulky!</span>")
 		return FALSE
 
+// Used by do_after to play the sound and animation repeatedly while bashing stuff down
+/obj/item/weapon/batteringram/proc/on_do_after(mob/user, use_user_turf, user_original_location, atom/target, target_original_location, needhand, obj/item/originally_held_item)
+	. = do_after_default_checks(arglist(args))
+	if(.)
+		playsound(src, 'sound/effects/shieldbash.ogg', 50, 1)
+		target.shake_animation()
+
 /obj/item/weapon/caution
 	desc = "Caution! Wet Floor!"
 	name = "wet floor sign"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -93,6 +93,15 @@ var/global/list/ghdel_profiling = list()
 					contents.Add(new_value)
 					return 1
 
+/atom/proc/shake_animation(pixelshiftx = 3, pixelshifty = 3, duration = 0.2 SECONDS)
+	var/initialpixelx = pixel_x
+	var/initialpixely = pixel_y
+	var/shiftx = rand(-pixelshiftx,pixelshiftx)
+	var/shifty = rand(-pixelshifty,pixelshifty)
+	animate(src, pixel_x = pixel_x + shiftx, pixel_y = pixel_y + shifty, time = 0.2, loop = duration)
+	pixel_x = initialpixelx
+	pixel_y = initialpixely
+
 /atom/proc/shake(var/xy, var/intensity, mob/user) //Zth. SHAKE IT. Vending machines' kick uses this
 	var/old_pixel_x = pixel_x
 	var/old_pixel_y = pixel_y

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1196,18 +1196,16 @@ About the new airlock wires panel:
 		var/obj/item/weapon/batteringram/B = I
 		if(!B.can_ram(user))
 			return
-		user.delayNextAttack(30)
-		var/breaktime = 60 //Same amount of time as drilling a wall, then a girder
+		user.delayNextAttack(3 SECONDS)
+		var/breaktime = 6 SECONDS //Same amount of time as drilling a wall, then a girder
 		if(welded)
-			breaktime += 30 //Welding buys you a little time
+			breaktime += 3 SECONDS //Welding buys you a little time
 		src.visible_message("<span class='warning'>[user] is battering down [src]!</span>", "<span class='warning'>You begin to batter [src].</span>")
-		playsound(src, 'sound/effects/shieldbash.ogg', 50, 1)
-		if(do_after(user,src, breaktime))
+		if(do_after(user,src, breaktime, 3, custom_checks = new /callback(I, /obj/item/weapon/batteringram/proc/on_do_after)))
 			//Calculate bolts separtely, in case they dropped in the last 6-9 seconds.
 			if(src.locked == 1)
-				playsound(src, 'sound/effects/shieldbash.ogg', 50, 1)
 				src.visible_message("<span class='warning'>[user] is battering the bolts!</span>", "<span class='warning'>You begin to smash the bolts...</span>")
-				if(!do_after(user, src,190)) //Same amount as drilling an R-wall, longer if it was welded
+				if(!do_after(user, src, 19 SECONDS, 6, custom_checks = new /callback(I, /obj/item/weapon/batteringram/proc/on_do_after))) //Same amount as drilling an R-wall, longer if it was welded
 					return //If they moved, cancel us out
 				playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
 			src.visible_message("<span class='warning'>[user] broke down the door!</span>", "<span class='warning'>You broke the door!</span>")

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -277,6 +277,22 @@ var/global/list/alert_overlays_global = list()
 	if(operating)
 		return//Already doing something.
 
+	if(istype(C, /obj/item/weapon/batteringram))
+		var/obj/item/weapon/batteringram/ram = C
+		if(!ram.can_ram(user))
+			return
+		user.delayNextAttack(3 SECONDS)
+		var/breaktime = 4 SECONDS
+		visible_message("<span class='warning'>[user] is battering down [src]!</span>", "<span class='warning'>You begin to batter [src].</span>")
+		if(!do_after(user, src, breaktime, 2, custom_checks = new /callback(ram, /obj/item/weapon/batteringram/proc/on_do_after)))
+			return
+		playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
+		visible_message("<span class='warning'>[user] breaks down \the [src]!</span>", "<span class='warning'>You broke \the [src]!</span>")
+		var/obj/item/firedoor_frame/frame = new(get_turf(src))
+		frame.add_fingerprint(user)
+		qdel(src)
+		return
+
 	if(iswelder(C))
 		var/obj/item/weapon/weldingtool/W = C
 		if(W.remove_fuel(0, user))
@@ -321,7 +337,8 @@ var/global/list/alert_overlays_global = list()
 			user.visible_message("<span class='attack'>\The [user] starts to deconstruct \the [src] with \a [C].</span>",\
 			"You begin to deconstruct \the [src] with \the [C].")
 			if(do_after(user, src, 5 SECONDS))
-				new/obj/item/firedoor_frame(get_turf(src))
+				var/obj/item/firedoor_frame/frame = new(get_turf(src))
+				frame.add_fingerprint(user)
 				qdel(src)
 			return
 		else


### PR DESCRIPTION
I split the changes into atomic commits, they'd just be more painful to PR separately.
- Refactored `do_after`
- Added `shake_animation`
- and:

:cl:
 * tweak: Battering rams can now be applied to firelocks.
 * tweak: Things being battering-rammed now visually shake. The sound effect of the ram plays throughout the whole thing rather than only at the beginning.