### PR TITLE
fix stoves/fireplaces being turned into campfire decals

### DIFF
--- a/code/ATMOSPHERICS/hvac/spaceheater.dm
+++ b/code/ATMOSPHERICS/hvac/spaceheater.dm
@@ -349,12 +349,14 @@
 
 /obj/machinery/space_heater/campfire/process()
 	..()
-	var/turf/T = get_turf(src)
+	if(!on)
+		return
+	var/turf/simulated/T = get_turf(loc)
 	var/datum/gas_mixture/env = T.return_air()
 	var/list/comfyfire = list('sound/misc/comfyfire1.ogg','sound/misc/comfyfire2.ogg','sound/misc/comfyfire3.ogg',)
 	if(Floor(cell.charge/10) != lastcharge)
 		update_icon()
-	if(!(cell && cell.charge > 0) && nocell != 2 | env.molar_density(GAS_OXYGEN) < 5 / CELL_VOLUME)
+	if((!(cell && cell.charge > 0) && nocell != 2) || !istype(T) || (env.molar_density(GAS_OXYGEN) < 5 / CELL_VOLUME))
 		extinguish()
 		return
 	lastcharge = Floor(cell.charge/10)
@@ -366,6 +368,8 @@
 	qdel(src)
 
 /obj/machinery/space_heater/campfire/stove/extinguish()
+	if(on)
+		loc.visible_message("<span class='warning'>\The [src] dies down.</span>")
 	on = FALSE
 	update_icon()
 

--- a/code/ATMOSPHERICS/hvac/spaceheater.dm
+++ b/code/ATMOSPHERICS/hvac/spaceheater.dm
@@ -351,8 +351,9 @@
 	..()
 	if(!on)
 		return
-	var/turf/simulated/T = get_turf(loc)
-	var/datum/gas_mixture/env = T.return_air()
+	var/turf/simulated/T = loc
+	if(istype(T))
+		var/datum/gas_mixture/env = T.return_air()
 	var/list/comfyfire = list('sound/misc/comfyfire1.ogg','sound/misc/comfyfire2.ogg','sound/misc/comfyfire3.ogg',)
 	if(Floor(cell.charge/10) != lastcharge)
 		update_icon()
@@ -369,7 +370,7 @@
 
 /obj/machinery/space_heater/campfire/stove/putOutFire()
 	if(on)
-		loc.visible_message("<span class='warning'>\The [src] dies down.</span>")
+		visible_message("<span class='warning'>\The [src] dies down.</span>")
 	on = FALSE
 	update_icon()
 

--- a/code/ATMOSPHERICS/hvac/spaceheater.dm
+++ b/code/ATMOSPHERICS/hvac/spaceheater.dm
@@ -352,8 +352,7 @@
 	if(!on)
 		return
 	var/turf/simulated/T = loc
-	if(istype(T))
-		var/datum/gas_mixture/env = T.return_air()
+	var/datum/gas_mixture/env = T.return_air()
 	var/list/comfyfire = list('sound/misc/comfyfire1.ogg','sound/misc/comfyfire2.ogg','sound/misc/comfyfire3.ogg',)
 	if(Floor(cell.charge/10) != lastcharge)
 		update_icon()

--- a/code/ATMOSPHERICS/hvac/spaceheater.dm
+++ b/code/ATMOSPHERICS/hvac/spaceheater.dm
@@ -367,6 +367,7 @@
 
 /obj/machinery/space_heater/campfire/stove/extinguish()
 	on = FALSE
+	update_icon()
 
 
 /obj/machinery/space_heater/campfire/Crossed(mob/user as mob)

--- a/code/ATMOSPHERICS/hvac/spaceheater.dm
+++ b/code/ATMOSPHERICS/hvac/spaceheater.dm
@@ -355,12 +355,18 @@
 	if(Floor(cell.charge/10) != lastcharge)
 		update_icon()
 	if(!(cell && cell.charge > 0) && nocell != 2 | env.molar_density(GAS_OXYGEN) < 5 / CELL_VOLUME)
-		new /obj/effect/decal/cleanable/campfire(get_turf(src))
-		qdel(src)
+		extinguish()
 		return
 	lastcharge = Floor(cell.charge/10)
 	if(on)
 		playsound(src, pick(comfyfire), (cell.charge/250)*5, 1, -1,channel = 124)
+
+/obj/machinery/space_heater/campfire/extinguish()
+	new /obj/effect/decal/cleanable/campfire(get_turf(src))
+	qdel(src)
+
+/obj/machinery/space_heater/campfire/stove/extinguish()
+	on = FALSE
 
 
 /obj/machinery/space_heater/campfire/Crossed(mob/user as mob)

--- a/code/ATMOSPHERICS/hvac/spaceheater.dm
+++ b/code/ATMOSPHERICS/hvac/spaceheater.dm
@@ -357,17 +357,17 @@
 	if(Floor(cell.charge/10) != lastcharge)
 		update_icon()
 	if((!(cell && cell.charge > 0) && nocell != 2) || !istype(T) || (env.molar_density(GAS_OXYGEN) < 5 / CELL_VOLUME))
-		extinguish()
+		putOutFire()
 		return
 	lastcharge = Floor(cell.charge/10)
 	if(on)
 		playsound(src, pick(comfyfire), (cell.charge/250)*5, 1, -1,channel = 124)
 
-/obj/machinery/space_heater/campfire/extinguish()
+/obj/machinery/space_heater/campfire/proc/putOutFire()
 	new /obj/effect/decal/cleanable/campfire(get_turf(src))
 	qdel(src)
 
-/obj/machinery/space_heater/campfire/stove/extinguish()
+/obj/machinery/space_heater/campfire/stove/putOutFire()
 	if(on)
 		loc.visible_message("<span class='warning'>\The [src] dies down.</span>")
 	on = FALSE


### PR DESCRIPTION
fixes #27987
this basically just turns off stoves and fireplaces rather than turning them into campfire decals when they dont have air/fuel or whatever
[easy] [bugfix]

:cl:
 * bugfix: stoves/fireplaces no longer turn into campfire decals when in space