### PR TITLE
Changed maximum name length from 26 to 52

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1703,7 +1703,7 @@ var/proccalls = 1
 #define MAX_MESSAGE_LEN 1024
 #define MAX_PAPER_MESSAGE_LEN 3072
 #define MAX_BOOK_MESSAGE_LEN 9216
-#define MAX_NAME_LEN 26
+#define MAX_NAME_LEN 52
 #define MAX_BROADCAST_LEN		512
 
 #define shuttle_time_in_station 1800 // 3 minutes in the station


### PR DESCRIPTION
Alternative to #28063.
I don't know if 52 is the right number but I don't see the harm in it: if someone wanted to have a dumb name they'd have a dumb name regardless.
To get a feel for it, "Richard Phillip Henry John Benson The Pre-Sequel Two" is 52 characters. TG's limit is 42.

:cl:
 * tweak: Changed maximum name length from 26 to 52.