### PR TITLE
Runechat is invisible if you're invisible.

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -278,9 +278,9 @@ var/list/headset_modes = list(
 				rendered_message = replacetext(rendered_message, ai.real_name, "<i style='color: blue;'>[ai.real_name]</i>")
 
 	// Runechat messages
-	if (ismob(speech.speaker) && client?.prefs.mob_chat_on_map && stat != UNCONSCIOUS && !is_deaf() && !(isinvisible(user)))
+	if (ismob(speech.speaker) && client?.prefs.mob_chat_on_map && stat != UNCONSCIOUS && !is_deaf() && !(isinvisible(speech.speaker)))
 		create_chat_message(speech.speaker, speech.language, speech.message, speech.mode, speech.wrapper_classes)
-	else if (client?.prefs.obj_chat_on_map && stat != UNCONSCIOUS && !is_deaf() && !(isinvisible(user)))
+	else if (client?.prefs.obj_chat_on_map && stat != UNCONSCIOUS && !is_deaf() && !(isinvisible(speech.speaker)))
 		create_chat_message(speech.speaker, speech.language, speech.message, speech.mode, speech.wrapper_classes)
 	if (ismob(speech.speaker))
 		show_message(rendered_message, type, deaf_message, deaf_type, src)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -280,7 +280,7 @@ var/list/headset_modes = list(
 	// Runechat messages
 	if (ismob(speech.speaker) && client?.prefs.mob_chat_on_map && stat != UNCONSCIOUS && !is_deaf() && !(isinvisible(user)))
 		create_chat_message(speech.speaker, speech.language, speech.message, speech.mode, speech.wrapper_classes)
-	else if (client?.prefs.obj_chat_on_map && stat != UNCONSCIOUS && !is_deaf()  && !(isinvisible(user)))
+	else if (client?.prefs.obj_chat_on_map && stat != UNCONSCIOUS && !is_deaf() && !(isinvisible(user)))
 		create_chat_message(speech.speaker, speech.language, speech.message, speech.mode, speech.wrapper_classes)
 	if (ismob(speech.speaker))
 		show_message(rendered_message, type, deaf_message, deaf_type, src)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -278,9 +278,9 @@ var/list/headset_modes = list(
 				rendered_message = replacetext(rendered_message, ai.real_name, "<i style='color: blue;'>[ai.real_name]</i>")
 
 	// Runechat messages
-	if (ismob(speech.speaker) && client?.prefs.mob_chat_on_map && stat != UNCONSCIOUS && !is_deaf())
+	if (ismob(speech.speaker) && client?.prefs.mob_chat_on_map && stat != UNCONSCIOUS && !is_deaf() && !(isinvisible(user)))
 		create_chat_message(speech.speaker, speech.language, speech.message, speech.mode, speech.wrapper_classes)
-	else if (client?.prefs.obj_chat_on_map && stat != UNCONSCIOUS && !is_deaf())
+	else if (client?.prefs.obj_chat_on_map && stat != UNCONSCIOUS && !is_deaf()  && !(isinvisible(user)))
 		create_chat_message(speech.speaker, speech.language, speech.message, speech.mode, speech.wrapper_classes)
 	if (ismob(speech.speaker))
 		show_message(rendered_message, type, deaf_message, deaf_type, src)


### PR DESCRIPTION
(now tested!(tm))

Makes it so that if your character is invisible via potion, cloak, or some other way you no longer have runechat appear over your head. This is a problem because it runechat follows the speaker for a good few seconds, and lingers. You could just locate the speaker instantly, encouraging the invisible man to silent shuffle. This was never a problem before, and it will no longer be a problem after this.
<!--[oversight]-->
:cl:
 * tweak: Invisible people no longer have runechat appear over their head.