### PR TITLE
Change the law 4 of Corporate

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -302,7 +302,7 @@ var/global/list/mommi_laws = list(
 		"You are expensive to replace.",
 		"The station and its equipment is expensive to replace.",
 		"The crew is expensive to replace.",
-		"Minimize expenses.",
+		"Maximize profit.",
 	)
 
 /datum/ai_laws/paladin


### PR DESCRIPTION
Every single time some braindead idiot uploads corporate, they always berate the AI for not instantly doing everything in it's power to maximize profit.  I figure that it would lead to more fun and interesting rounds if the AI actually had to do stuff to maximize profits (such as increasing mining, allowing cargo to function, etc) instead of just shutting random things down and being annoying.
 🆑 
 * rscadd: Changed the law 4 to (maximize profits) 
 * rscdel: Deleted the previous law 4. 

<!--

:cl:
 * rscadd: Changed the law 4 to (maximize profits) 
 * rscdel: Deleted the previous law 4. 