### PR TITLE
You should no longer be able to roll malf AI on Castle, an AI-less map

### DIFF
--- a/maps/tgstation-sec.dm
+++ b/maps/tgstation-sec.dm
@@ -76,6 +76,10 @@
 	center_x = 226
 	center_y = 254
 
+/datum/map/active/map_ruleset(var/datum/dynamic_ruleset/DR)
+	if(ispath(DR.role_category, /datum/role/malfAI))
+		return FALSE
+
 ////////////////////////////////////////////////////////////////
 #include "tgstation-sec.dmm"
 #endif


### PR DESCRIPTION
Fixes #28112 

As per self-imposed obligation of being responsible for whatever bugs, glitches and general problems that may arise as a consequence of my changes to the codebase, I had to fix this error. I do not care if the AI could be malf, because malf AIs are antagonists and antagonists are cool, but what really irked me was that it was, at the end of the day, an AI that spawned even for a few microseconds, and as we all know AIs are terrible additions to the game around which the game has gradually warped around the existence of AI, creating what is essentially job security when it previously had none. To say that an AI is terrible is an understatement, because it is either a validhungry prick that completely shuts down any criminal activity within its sight or a round-ender by virtue of being able to vent the station and literally flood the station with deadly fiery plasma on a moment's notice. The AI is allowed to be an antagonist as long as its laws allow it to do so except for the roundstart laws that nobody really bothered to address so the unofficial policy is that you do not loophole around roundstart laws or else you eat a ban, which, in my humble opinion, is terrible. Anyone who changes the AI's laws and the AI finds a loophole to suddenly start mass-murdering everyone is entirely the uploader's fault unless the AI directly broke its laws, meaning the only law changes that tend to happen is the clown making funny but ultimately useless laws, the powergaming captain giving it NTD for the nth time in order to kill all valids, or the antagonist subverting it and telling it to flood the station with fiery plasma. All this talk about how the AI is terrible reminds me of Fallout 4, an action game first and foremost and RPG tertiary, because Bethesda has gone on to casualize the game even more for casual audiences, which I have come to call the Skyrim treatment, named after the titular Skyrim videogame that was a dumbed down version of Oblivion, while also trying to acquire a casual audience because casuals have no other quality videogames to compare videogames to, which is the equivalent of eating shit because you've never eaten any actual food. The perks suck, the side-quests suck, the RPG elements suck, the settlement mechanic sucks, and the story sucks too. The story boils down to choosing between the evil irredeemable Institute whose only redeeming feature is that your son became its leader due to time-skip cryogenics bullshit, the "free all synths" faction that turns out to actually be pretty bad because they put synth lives over human lives just because they are synths, the Brotherhood of Steel which used to be bros in Fallout 3 but Bethesda wanted an edgier variant so in the lore they had its current leader return it to its far more secular roots of toaster-hoarding pricks that ended up going virtually extinct throughout most of post-war America just like the Enclave, and the Minutemen who are literally the backup faction in case you managed to piss off every other faction and whose quests are full of randomly-generated "radiant" quests, even if they are objectively the best faction. The issue of synths is actually pretty terrible because it's entirely the Institute being dumb as rocks because they are the evil poorly-written faction that would make synths with human intelligence and then claim they don't have human intelligence, only for them to repeatedly escape out into the wasteland and the Institute wonders "How could this be?!", but this idiocy doesn't stop here, no, if you follow the Institute questline you also end up the Director of the whole place over every other actual scientist that lived there entirely through nepotism even if you could be a genuine dimwit character-wise. Fallout 4's qualities are so bad it actually makes Fallout 3 look great by comparison, or at least would've if it wasn't for New Vegas.

:cl:
 * bugfix: Fixed a bug where you could roll a malfunctioning AI on Castle, a map that did not have any AIs, promptly returning you back to the lobby when the game realized there was nowhere to spawn the malf AI on