### PR TITLE
Fixes Soymilk Being Invisible in a Drinking Glass

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -5362,7 +5362,6 @@
 	description = "An opaque white liquid made from soybeans."
 	color = "#e8e8d8" //rgb: 232, 232, 216
 	nutriment_factor = 5 * REAGENTS_METABOLISM
-	glass_icon_state = "glass_white"
 	glass_desc = "White and nutritious soy goodness!"
 
 /datum/reagent/drink/milk/cream


### PR DESCRIPTION
[bugfix] it still used the `glass_white` icon state which was deleted, now it uses the reagent color overlay. Closes #28129.