### PR TITLE
Re-adds the Autoborger Cooldown. (Reverts #26158)

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -151,19 +151,13 @@
 // -- Vampire mechanics --
 
 /datum/role/vampire/proc/can_suck(var/mob/living/carbon/human/H)
-	var/mob/living/M = antag.current
-	var/datum/butchering_product/teeth/vampire_teeth = locate(/datum/butchering_product/teeth) in M.butchering_drops
-
+	var/mob/M = antag.current
 	if(M.lying || M.incapacitated())
 		to_chat(M, "<span class='warning'> You cannot do this while on the ground!</span>")
 		return FALSE
 
 	if(H.check_body_part_coverage(MOUTH))
 		to_chat(M, "<span class='warning'>Remove their mask!</span>")
-		return FALSE
-
-	if(vampire_teeth.amount == 0)
-		to_chat(M, "<span class='warning'>You cannot suck blood with no teeth!</span>")
 		return FALSE
 
 	if(ishuman(M))
@@ -175,7 +169,6 @@
 			else
 				to_chat(H, "<span class='notice'>With practiced ease, you shift aside your mask for each gulp of blood.</span>")
 	return TRUE
-
 
 /datum/role/vampire/proc/handle_bloodsucking(var/mob/living/carbon/human/target)
 	draining = target

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -152,18 +152,12 @@
 
 /datum/role/vampire/proc/can_suck(var/mob/living/carbon/human/H)
 	var/mob/living/M = antag.current
-	var/datum/butchering_product/teeth/vampire_teeth = locate(/datum/butchering_product/teeth) in M.butchering_drops
-
 	if(M.lying || M.incapacitated())
 		to_chat(M, "<span class='warning'> You cannot do this while on the ground!</span>")
 		return FALSE
 
 	if(H.check_body_part_coverage(MOUTH))
 		to_chat(M, "<span class='warning'>Remove their mask!</span>")
-		return FALSE
-
-	if(vampire_teeth.amount == 0)
-		to_chat(M, "<span class='warning'>You cannot suck blood with no teeth!</span>")
 		return FALSE
 
 	if(ishuman(M))

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -151,7 +151,7 @@
 // -- Vampire mechanics --
 
 /datum/role/vampire/proc/can_suck(var/mob/living/carbon/human/H)
-	var/mob/living/M = antag.current
+	var/mob/M = antag.current
 	if(M.lying || M.incapacitated())
 		to_chat(M, "<span class='warning'> You cannot do this while on the ground!</span>")
 		return FALSE
@@ -169,7 +169,6 @@
 			else
 				to_chat(H, "<span class='notice'>With practiced ease, you shift aside your mask for each gulp of blood.</span>")
 	return TRUE
-
 
 /datum/role/vampire/proc/handle_bloodsucking(var/mob/living/carbon/human/target)
 	draining = target

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -151,13 +151,19 @@
 // -- Vampire mechanics --
 
 /datum/role/vampire/proc/can_suck(var/mob/living/carbon/human/H)
-	var/mob/M = antag.current
+	var/mob/living/M = antag.current
+	var/datum/butchering_product/teeth/vampire_teeth = locate(/datum/butchering_product/teeth) in M.butchering_drops
+
 	if(M.lying || M.incapacitated())
 		to_chat(M, "<span class='warning'> You cannot do this while on the ground!</span>")
 		return FALSE
 
 	if(H.check_body_part_coverage(MOUTH))
 		to_chat(M, "<span class='warning'>Remove their mask!</span>")
+		return FALSE
+
+	if(vampire_teeth.amount == 0)
+		to_chat(M, "<span class='warning'>You cannot suck blood with no teeth!</span>")
 		return FALSE
 
 	if(ishuman(M))
@@ -169,6 +175,7 @@
 			else
 				to_chat(H, "<span class='notice'>With practiced ease, you shift aside your mask for each gulp of blood.</span>")
 	return TRUE
+
 
 /datum/role/vampire/proc/handle_bloodsucking(var/mob/living/carbon/human/target)
 	draining = target

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1584,7 +1584,7 @@
 		return 1
 
 	var/datum/butchering_product/teeth/T = locate(/datum/butchering_product/teeth) in src.butchering_drops
-	if(T && T.amount >= -1)
+	if(T && T.amount >= 2)
 		return 1
 
 	return 0

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1584,7 +1584,7 @@
 		return 1
 
 	var/datum/butchering_product/teeth/T = locate(/datum/butchering_product/teeth) in src.butchering_drops
-	if(T && T.amount >= 2)
+	if(T && T.amount >= -1)
 		return 1
 
 	return 0

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -44,14 +44,22 @@
 		if(2) //Full block
 			damage = 0
 
+	var/attacktype = "bitten"
+	var/datum/butchering_product/teeth/T = locate(/datum/butchering_product/teeth) in M.butchering_drops
+
 	damage = run_armor_absorb(affecting, "melee", damage)
+
+	if(T.amount == 0)
+		attacktype = "gummed"
+		damage = 1
+
 	if(!damage && dam_check)
 		playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 		visible_message("<span class='danger'>\The [M] has attempted to bite \the [src]!</span>")
 		return 0
 
 	playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
-	src.visible_message("<span class='danger'>\The [M] has bitten \the [src]!</span>", "<span class='userdanger'>You were bitten by \the [M]!</span>")
+	src.visible_message("<span class='danger'>\The [M] has [attacktype] \the [src]!</span>", "<span class='userdanger'>You were [attacktype] by \the [M]!</span>")
 	M.do_attack_animation(src, M)
 
 	for(var/datum/disease/D in M.viruses)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -44,22 +44,14 @@
 		if(2) //Full block
 			damage = 0
 
-	var/attacktype = "bitten"
-	var/datum/butchering_product/teeth/T = locate(/datum/butchering_product/teeth) in M.butchering_drops
-
 	damage = run_armor_absorb(affecting, "melee", damage)
-
-	if(T.amount == 0)
-		attacktype = "gummed"
-		damage = 1
-
 	if(!damage && dam_check)
 		playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 		visible_message("<span class='danger'>\The [M] has attempted to bite \the [src]!</span>")
 		return 0
 
 	playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
-	src.visible_message("<span class='danger'>\The [M] has [attacktype] \the [src]!</span>", "<span class='userdanger'>You were [attacktype] by \the [M]!</span>")
+	src.visible_message("<span class='danger'>\The [M] has bitten \the [src]!</span>", "<span class='userdanger'>You were bitten by \the [M]!</span>")
 	M.do_attack_animation(src, M)
 
 	for(var/datum/disease/D in M.viruses)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -176,15 +176,7 @@
 
 //BITES
 /mob/living/bite_act(mob/living/carbon/human/M as mob)
-	var/datum/butchering_product/teeth/T = locate(/datum/butchering_product/teeth) in M.butchering_drops
-	var/damage = 0
-	var/attacktype = "bitten"
-
-	if(T.amount > 0)
-		damage = rand(1, 5)
-	else //no teeth time to GUM
-		damage = 1
-		attacktype = "gummed"
+	var/damage = rand(1, 5)
 
 	if(M.organ_has_mutation(LIMB_HEAD, M_BEAK)) //Beaks = stronger bites
 		damage += 4
@@ -196,7 +188,7 @@
 		return 0
 
 	playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
-	src.visible_message("<span class='danger'>\The [M] has [attacktype] \the [src]!</span>", "<span class='userdanger'>You were [attacktype] by \the [M]!</span>")
+	src.visible_message("<span class='danger'>\The [M] has bitten \the [src]!</span>", "<span class='userdanger'>You were bitten by \the [M]!</span>")
 
 	add_logs(M, src, "bit", admin=0, object=null, addition="DMG: [damage]")
 	adjustBruteLoss(damage)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -176,7 +176,15 @@
 
 //BITES
 /mob/living/bite_act(mob/living/carbon/human/M as mob)
-	var/damage = rand(1, 5)
+	var/datum/butchering_product/teeth/T = locate(/datum/butchering_product/teeth) in M.butchering_drops
+	var/damage = 0
+	var/attacktype = "bitten"
+
+	if(T.amount > 0)
+		damage = rand(1, 5)
+	else //no teeth time to GUM
+		damage = 1
+		attacktype = "gummed"
 
 	if(M.organ_has_mutation(LIMB_HEAD, M_BEAK)) //Beaks = stronger bites
 		damage += 4
@@ -188,7 +196,7 @@
 		return 0
 
 	playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
-	src.visible_message("<span class='danger'>\The [M] has bitten \the [src]!</span>", "<span class='userdanger'>You were bitten by \the [M]!</span>")
+	src.visible_message("<span class='danger'>\The [M] has [attacktype] \the [src]!</span>", "<span class='userdanger'>You were [attacktype] by \the [M]!</span>")
 
 	add_logs(M, src, "bit", admin=0, object=null, addition="DMG: [damage]")
 	adjustBruteLoss(damage)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -278,9 +278,9 @@ var/list/headset_modes = list(
 				rendered_message = replacetext(rendered_message, ai.real_name, "<i style='color: blue;'>[ai.real_name]</i>")
 
 	// Runechat messages
-	if (ismob(speech.speaker) && client?.prefs.mob_chat_on_map && stat != UNCONSCIOUS && !is_deaf() && !(isinvisible(speech.speaker)))
+	if (ismob(speech.speaker) && client?.prefs.mob_chat_on_map && stat != UNCONSCIOUS && !is_deaf())
 		create_chat_message(speech.speaker, speech.language, speech.message, speech.mode, speech.wrapper_classes)
-	else if (client?.prefs.obj_chat_on_map && stat != UNCONSCIOUS && !is_deaf() && !(isinvisible(speech.speaker)))
+	else if (client?.prefs.obj_chat_on_map && stat != UNCONSCIOUS && !is_deaf())
 		create_chat_message(speech.speaker, speech.language, speech.message, speech.mode, speech.wrapper_classes)
 	if (ismob(speech.speaker))
 		show_message(rendered_message, type, deaf_message, deaf_type, src)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -278,9 +278,9 @@ var/list/headset_modes = list(
 				rendered_message = replacetext(rendered_message, ai.real_name, "<i style='color: blue;'>[ai.real_name]</i>")
 
 	// Runechat messages
-	if (ismob(speech.speaker) && client?.prefs.mob_chat_on_map && stat != UNCONSCIOUS && !is_deaf())
+	if (ismob(speech.speaker) && client?.prefs.mob_chat_on_map && stat != UNCONSCIOUS && !is_deaf() && !(isinvisible(speech.speaker)))
 		create_chat_message(speech.speaker, speech.language, speech.message, speech.mode, speech.wrapper_classes)
-	else if (client?.prefs.obj_chat_on_map && stat != UNCONSCIOUS && !is_deaf())
+	else if (client?.prefs.obj_chat_on_map && stat != UNCONSCIOUS && !is_deaf() && !(isinvisible(speech.speaker)))
 		create_chat_message(speech.speaker, speech.language, speech.message, speech.mode, speech.wrapper_classes)
 	if (ismob(speech.speaker))
 		show_message(rendered_message, type, deaf_message, deaf_type, src)


### PR DESCRIPTION
Reverts #26158

Going from a 90 second autoborger to a 0 second autoborger was a huge mistake. Nobody likes speedrun rounds where the malf borgs 4 people rapidly, and then it spirals into an infinite cyborg army that is impossible to defeat where everyone has to wait 10 minutes for the timer to tick down because no APC's are hacked.
<!--[tweak][balance]-->

:cl:
 * tweak: autoborgers have a cooldown again