### PR TITLE
IsAdvancedToolUser() removal / You can't fire guns anymore with warping claws or knuckles equipped as dexterity checks are now consistent.

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -636,7 +636,7 @@ var/global/list/alert_overlays_global = list()
 		return 0
 	if(!isturf(user.loc))
 		return 0
-	if(!user.IsAdvancedToolUser())
+	if(!user.dexterity_check())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return 0
 

--- a/code/game/objects/items/weapons/barricade_kit.dm
+++ b/code/game/objects/items/weapons/barricade_kit.dm
@@ -26,7 +26,7 @@
 	if(istype(user.loc, /turf/space))
 		to_chat(user, "<span class='warning'>You can't build barricades out in space.</span>")
 		return
-	if(!user.IsAdvancedToolUser())
+	if(!user.dexterity_check())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return 0
 	switch(alert("What do you want ([kit_uses] use\s left)", "Barricade Kit", "Directional", "Full Tile", "Cancel", null))

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -237,7 +237,7 @@
 	set category = "Object"
 	set src in oview(1)
 
-	if(!isliving(usr) || usr.incapacitated() || !usr.Adjacent(src) || !usr.IsAdvancedToolUser() || deflating)
+	if(!isliving(usr) || usr.incapacitated() || !usr.Adjacent(src) || !usr.dexterity_check() || deflating)
 		return
 
 	verbs -= /obj/structure/inflatable/verb/hand_deflate

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -365,7 +365,7 @@
 	..()
 
 /obj/structure/piano/attack_hand(mob/user)
-	if(!user.IsAdvancedToolUser())
+	if(!user.dexterity_check())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return 1
 	if(broken)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -282,7 +282,7 @@ proc/move_mining_shuttle()
 	to_chat(user, "<span class ='notice'>You toggle \the [src]'s safety [safety ? "on" : "off"].</span>")
 
 /obj/item/weapon/pickaxe/plasmacutter/accelerator/afterattack(var/atom/A, var/mob/living/user, var/proximity_flag, var/click_parameters)
-	if (!user.IsAdvancedToolUser() || isMoMMI(user) || istype(user, /mob/living/carbon/monkey/diona))
+	if (!user.dexterity_check() || isMoMMI(user) || istype(user, /mob/living/carbon/monkey/diona))
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 	if(proximity_flag)

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -19,7 +19,7 @@
 	var/neurotoxin_cooldown = 0
 
 	var/obj/item/weapon/card/id/wear_id = null // Fix for station bounced radios -- Skie
-	var/has_fine_manipulation = 0
+	var/has_fine_manipulation = 0//Deprecated, only used by /mob/living/carbon/alien/humanoid/special which isn't compiled
 
 	var/move_delay_add = 0 // movement delay to add
 
@@ -193,8 +193,8 @@ In all, this is a lot like the monkey code. /N
 	bodytemperature += BODYTEMP_HEATING_MAX //If you're on fire, you heat up!
 	return
 
-/mob/living/carbon/alien/IsAdvancedToolUser()
-	return has_fine_manipulation
+/mob/living/carbon/alien/dexterity_check()
+	return FALSE
 
 /mob/living/carbon/alien/Process_Spaceslipping()
 	return 0 // Don't slip in space.

--- a/code/modules/mob/living/carbon/complex/martian/martian.dm
+++ b/code/modules/mob/living/carbon/complex/martian/martian.dm
@@ -81,9 +81,8 @@
 	return 1
 
 /mob/living/carbon/complex/martian/dexterity_check()
-	return TRUE
-
-/mob/living/carbon/complex/martian/IsAdvancedToolUser()
+	if (stat != CONSCIOUS)
+		return FALSE
 	return TRUE
 
 /mob/living/carbon/complex/martian/Process_Spaceslipping()

--- a/code/modules/mob/living/carbon/human/catbeast/catbeast.dm
+++ b/code/modules/mob/living/carbon/human/catbeast/catbeast.dm
@@ -1,2 +1,2 @@
-/mob/living/carbon/human/tajaran/IsAdvancedToolUser()
-	return 0
+/mob/living/carbon/human/tajaran/dexterity_check()
+	return FALSE//catbeasts are dumb and their paws/claws prevent them from using machines

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -653,10 +653,6 @@
 
 	return clamp(., -2, 2)
 
-
-/mob/living/carbon/human/IsAdvancedToolUser()
-	return 1//Humans can use guns and such
-
 /mob/living/carbon/human/isGoodPickpocket()
 	var/obj/item/clothing/gloves/G = gloves
 	if(istype(G))
@@ -1449,20 +1445,15 @@
 
 /mob/living/carbon/human/dexterity_check()
 	if (stat != CONSCIOUS)
-		return 0
-
-	if(reagents.has_reagent(METHYLIN))
-		return 1
-
-	if(getBrainLoss() >= 60)
-		return 0
-
+		return FALSE
 	if(gloves && istype(gloves, /obj/item/clothing/gloves))
 		var/obj/item/clothing/gloves/G = gloves
-
-		return G.dexterity_check()
-
-	return 1
+		if(!G.dexterity_check())//some gloves might make it harder to interact with complex technologies, or fit your index in a gun's trigger
+			return FALSE
+	if(getBrainLoss() >= 60)
+		if(!reagents.has_reagent(METHYLIN))//methylin supercedes brain damage, but not uncomfortable gloves
+			return FALSE
+	return TRUE//humans are dexterous enough by default
 
 /mob/living/carbon/human/spook(mob/dead/observer/ghost)
 	if(!..(ghost, TRUE) || !client)

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -405,9 +405,6 @@
 		return
 
 
-/mob/living/carbon/monkey/IsAdvancedToolUser()//Unless its monkey mode monkeys cant use advanced tools
-	return dexterity_check()
-
 // Get ALL accesses available.
 /mob/living/carbon/monkey/GetAccess()
 	var/list/ACL=list()
@@ -455,12 +452,12 @@
 
 /mob/living/carbon/monkey/dexterity_check()
 	if(stat != CONSCIOUS)
-		return 0
-	if(ticker.mode.name == "monkey")
-		return 1
+		return FALSE
+	if(ticker.mode.name == "monkey")//monkey mode override
+		return TRUE
 	if(reagents.has_reagent(METHYLIN))
-		return 1
-	return 0
+		return TRUE
+	return FALSE//monkeys can't use complex things by default unless they're high on methylin
 
 /mob/living/carbon/monkey/reset_layer()
 	if(lying)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -160,9 +160,6 @@
 /mob/living/silicon/proc/damage_mob(var/brute = 0, var/fire = 0, var/tox = 0)
 	return
 
-/mob/living/silicon/IsAdvancedToolUser()
-	return 1
-
 /mob/living/silicon/bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj.nodamage)
 		adjustBruteLoss(Proj.damage)
@@ -326,7 +323,7 @@
 	return
 
 /mob/living/silicon/dexterity_check()
-	return 1
+	return TRUE
 
 /mob/living/silicon/html_mob_check(var/typepath)
 	for(var/atom/movable/AM in html_machines)

--- a/code/modules/mob/living/simple_animal/hostile/gremlin.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gremlin.dm
@@ -178,7 +178,5 @@ var/list/bad_gremlin_items = list()
 				divide()
 
 /mob/living/simple_animal/hostile/gremlin/dexterity_check()
-	return 1
+	return TRUE
 
-/mob/living/simple_animal/hostile/gremlin/IsAdvancedToolUser()
-	return 1

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1636,9 +1636,6 @@ Use this proc preferably at the end of an equipment loadout
 	..()
 	EndMoving()
 
-/mob/proc/IsAdvancedToolUser()//This might need a rename but it should replace the can this mob use things check
-	return 0
-
 /mob/proc/isGoodPickpocket() //If the mob gets bonuses when pickpocketing and such. Currently only used for humans with the Pickpocket's Gloves.
 	return 0
 
@@ -1826,8 +1823,8 @@ mob/proc/assess_threat()
 mob/proc/on_foot()
 	return !(lying || flying || locked_to)
 
-/mob/proc/dexterity_check()
-	return 0
+/mob/proc/dexterity_check()//can the mob use computers, guns, and other fine technologies
+	return FALSE
 
 /mob/proc/isTeleViewing(var/client_eye)
 	if(istype(client_eye,/obj/machinery/camera))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -145,7 +145,7 @@
 /obj/item/weapon/gun/proc/can_Fire(mob/user, var/display_message = 0)
 	var/firing_dexterity = 1
 	if(advanced_tool_user_check)
-		if (!user.IsAdvancedToolUser())
+		if (!user.dexterity_check())
 			firing_dexterity = 0
 	if(MoMMI_check)
 		if(isMoMMI(user))


### PR DESCRIPTION
Fixes #27474
Fixes #25337


:cl:
* experimental: Until now, the game's checks for dexterity were split between two different functions which caused various issues. Both functions have been merged together which should fix those issues, but keep an eye out for odd behaviours.
* tweak: As a consequence of this change, Warping Claws as well as Spiked/Brass Knuckles prevent you now not only from using computers, but also now from firing guns.
* tweak: Furthermore, methylin in humans counteracts the effects of brain damage, but no longer counteracts the handicap of wearing Warping Claws/Knuckles.
