### PR TITLE
Data HUD range increase

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -136,6 +136,9 @@ var/MAX_EXPLOSION_RANGE = 14
 #define ALIEN_SELECT_AFK_BUFFER 1 // How many minutes that a person can be AFK before not being allowed to be an alien.
 #define ROLE_SELECT_AFK_BUFFER  1 // Default value.
 
+#define DATAHUD_RANGE_OVERHEAD	7	//how many tiles away from the edge of the client's view do the HUD icons start appearing
+									//necessary due to them only being updated on Life()
+
 //WEIGHT CLASSES
 #define W_CLASS_TINY 1
 #define W_CLASS_SMALL 2

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -1814,7 +1814,7 @@ var/list/blind_victims = list()
 		caster.client.images -= propension
 		propension.len = 0
 
-		for(var/mob/living/carbon/C in dview(caster.client.view+7, get_turf(src), INVISIBILITY_MAXIMUM))
+		for(var/mob/living/carbon/C in dview(caster.client.view+DATAHUD_RANGE_OVERHEAD, get_turf(src), INVISIBILITY_MAXIMUM))
 			C.update_convertibility()
 			propension += C.hud_list[CONVERSION_HUD]
 

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -1814,7 +1814,7 @@ var/list/blind_victims = list()
 		caster.client.images -= propension
 		propension.len = 0
 
-		for(var/mob/living/carbon/C in dview(world.view, get_turf(src), INVISIBILITY_MAXIMUM))
+		for(var/mob/living/carbon/C in dview(caster.client.view+7, get_turf(src), INVISIBILITY_MAXIMUM))
 			C.update_convertibility()
 			propension += C.hud_list[CONVERSION_HUD]
 

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -46,7 +46,7 @@ proc/process_med_hud(var/mob/M, var/mob/eye)
 		T = get_turf(eye)
 	else
 		T = get_turf(M)
-	for(var/mob/living/simple_animal/mouse/patient in range(C.view+7,T))
+	for(var/mob/living/simple_animal/mouse/patient in range(C.view+DATAHUD_RANGE_OVERHEAD,T))
 		if(!check_HUD_visibility(patient, M))
 			continue
 		if(!C)
@@ -72,7 +72,7 @@ proc/process_med_hud(var/mob/M, var/mob/eye)
 						holder.icon_state = "hudhealthy"
 			C.images += holder
 
-	for(var/mob/living/simple_animal/hostile/necro/zombie/patient in range(C.view+7,T))
+	for(var/mob/living/simple_animal/hostile/necro/zombie/patient in range(C.view+DATAHUD_RANGE_OVERHEAD,T))
 		if(!check_HUD_visibility(patient, M))
 			continue
 		if(!C)
@@ -85,7 +85,7 @@ proc/process_med_hud(var/mob/M, var/mob/eye)
 				holder.icon_state = "hudundead"
 			C.images += holder
 
-	for(var/mob/living/carbon/patient in range(C.view+7,T))
+	for(var/mob/living/carbon/patient in range(C.view+DATAHUD_RANGE_OVERHEAD,T))
 		if (ishuman(patient))
 			var/mob/living/carbon/human/H = patient
 			if(H.head && istype(H.head,/obj/item/clothing/head/tinfoil)) //Tinfoil hat? Move along.
@@ -162,7 +162,7 @@ proc/process_sec_hud(var/mob/M, var/advanced_mode,var/mob/eye)
 		T = get_turf(eye)
 	else
 		T = get_turf(M)
-	for(var/mob/living/carbon/human/perp in range(C.view+7,T))
+	for(var/mob/living/carbon/human/perp in range(C.view+DATAHUD_RANGE_OVERHEAD,T))
 		if(!check_HUD_visibility(perp, M))
 			continue
 		holder = perp.hud_list[ID_HUD]
@@ -224,7 +224,7 @@ proc/process_sec_hud(var/mob/M, var/advanced_mode,var/mob/eye)
 	var/image/holder
 	var/turf/T = eye ? get_turf(eye) : get_turf(M)
 
-	for(var/mob/living/silicon/robot/borg in range(C.view+7,T))
+	for(var/mob/living/silicon/robot/borg in range(C.view+DATAHUD_RANGE_OVERHEAD,T))
 		if(!check_HUD_visibility(borg, M))
 			continue
 
@@ -246,7 +246,7 @@ proc/process_sec_hud(var/mob/M, var/advanced_mode,var/mob/eye)
 				var/charge_ratio = borg_cell.charge / borg_cell.maxcharge
 				holder.icon_state = power_cell_charge_to_icon_state(charge_ratio)
 
-	for(var/obj/mecha/exosuit in range(C.view+7,T))
+	for(var/obj/mecha/exosuit in range(C.view+DATAHUD_RANGE_OVERHEAD,T))
 		if(!check_HUD_visibility(exosuit, M))
 			continue
 
@@ -309,7 +309,7 @@ proc/process_construct_hud(var/mob/M, var/mob/eye)
 		T = get_turf(eye)
 	else
 		T = get_turf(M)
-	for(var/mob/living/simple_animal/construct/construct in range(C.view+7,T))
+	for(var/mob/living/simple_animal/construct/construct in range(C.view+DATAHUD_RANGE_OVERHEAD,T))
 		if(!check_HUD_visibility(construct, M))
 			continue
 

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -46,7 +46,7 @@ proc/process_med_hud(var/mob/M, var/mob/eye)
 		T = get_turf(eye)
 	else
 		T = get_turf(M)
-	for(var/mob/living/simple_animal/mouse/patient in range(T))
+	for(var/mob/living/simple_animal/mouse/patient in range(C.view+7,T))
 		if(!check_HUD_visibility(patient, M))
 			continue
 		if(!C)
@@ -72,7 +72,7 @@ proc/process_med_hud(var/mob/M, var/mob/eye)
 						holder.icon_state = "hudhealthy"
 			C.images += holder
 
-	for(var/mob/living/simple_animal/hostile/necro/zombie/patient in range(T))
+	for(var/mob/living/simple_animal/hostile/necro/zombie/patient in range(C.view+7,T))
 		if(!check_HUD_visibility(patient, M))
 			continue
 		if(!C)
@@ -85,7 +85,7 @@ proc/process_med_hud(var/mob/M, var/mob/eye)
 				holder.icon_state = "hudundead"
 			C.images += holder
 
-	for(var/mob/living/carbon/patient in range(T))
+	for(var/mob/living/carbon/patient in range(C.view+7,T))
 		if (ishuman(patient))
 			var/mob/living/carbon/human/H = patient
 			if(H.head && istype(H.head,/obj/item/clothing/head/tinfoil)) //Tinfoil hat? Move along.
@@ -162,7 +162,7 @@ proc/process_sec_hud(var/mob/M, var/advanced_mode,var/mob/eye)
 		T = get_turf(eye)
 	else
 		T = get_turf(M)
-	for(var/mob/living/carbon/human/perp in range(T))
+	for(var/mob/living/carbon/human/perp in range(C.view+7,T))
 		if(!check_HUD_visibility(perp, M))
 			continue
 		holder = perp.hud_list[ID_HUD]
@@ -224,7 +224,7 @@ proc/process_sec_hud(var/mob/M, var/advanced_mode,var/mob/eye)
 	var/image/holder
 	var/turf/T = eye ? get_turf(eye) : get_turf(M)
 
-	for(var/mob/living/silicon/robot/borg in range(T))
+	for(var/mob/living/silicon/robot/borg in range(C.view+7,T))
 		if(!check_HUD_visibility(borg, M))
 			continue
 
@@ -246,7 +246,7 @@ proc/process_sec_hud(var/mob/M, var/advanced_mode,var/mob/eye)
 				var/charge_ratio = borg_cell.charge / borg_cell.maxcharge
 				holder.icon_state = power_cell_charge_to_icon_state(charge_ratio)
 
-	for(var/obj/mecha/exosuit in range(T))
+	for(var/obj/mecha/exosuit in range(C.view+7,T))
 		if(!check_HUD_visibility(exosuit, M))
 			continue
 
@@ -309,7 +309,7 @@ proc/process_construct_hud(var/mob/M, var/mob/eye)
 		T = get_turf(eye)
 	else
 		T = get_turf(M)
-	for(var/mob/living/simple_animal/construct/construct in range(T))
+	for(var/mob/living/simple_animal/construct/construct in range(C.view+7,T))
 		if(!check_HUD_visibility(construct, M))
 			continue
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -241,7 +241,7 @@ Works together with spawning an observer, noted above.
 
 	if(antagHUD)
 		var/list/target_list = list()
-		for(var/mob/living/target in oview(src))
+		for(var/mob/living/target in oview(client.view+7, src))
 			if( target.mind&&(target.mind.antag_roles.len > 0 || issilicon(target) || target.hud_list[SPECIALROLE_HUD]) )
 				target_list += target
 		if(target_list.len)
@@ -249,7 +249,7 @@ Works together with spawning an observer, noted above.
 
 	if(conversionHUD)
 		var/list/target_list = list()
-		for(var/mob/living/carbon/target in oview(src))
+		for(var/mob/living/carbon/target in oview(client.view+7, src))
 			if(target.mind && target.hud_list[CONVERSION_HUD])
 				target_list += target
 		if(target_list.len)
@@ -294,7 +294,7 @@ Works together with spawning an observer, noted above.
 /mob/dead/proc/process_medHUD(var/mob/M)
 	var/client/C = M.client
 	var/image/holder
-	for(var/mob/living/carbon/patient in oview(M))
+	for(var/mob/living/carbon/patient in oview(client.view+7, M))
 		if(!check_HUD_visibility(patient, M))
 			continue
 		if(!C)
@@ -339,7 +339,7 @@ Works together with spawning an observer, noted above.
 
 			C.images += holder
 
-	for(var/mob/living/simple_animal/mouse/patient in oview(M))
+	for(var/mob/living/simple_animal/mouse/patient in oview(client.view+7, M))
 		if(!check_HUD_visibility(patient, M))
 			continue
 		if(!C)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -241,7 +241,7 @@ Works together with spawning an observer, noted above.
 
 	if(antagHUD)
 		var/list/target_list = list()
-		for(var/mob/living/target in oview(client.view+7, src))
+		for(var/mob/living/target in oview(client.view+DATAHUD_RANGE_OVERHEAD, src))
 			if( target.mind&&(target.mind.antag_roles.len > 0 || issilicon(target) || target.hud_list[SPECIALROLE_HUD]) )
 				target_list += target
 		if(target_list.len)
@@ -249,7 +249,7 @@ Works together with spawning an observer, noted above.
 
 	if(conversionHUD)
 		var/list/target_list = list()
-		for(var/mob/living/carbon/target in oview(client.view+7, src))
+		for(var/mob/living/carbon/target in oview(client.view+DATAHUD_RANGE_OVERHEAD, src))
 			if(target.mind && target.hud_list[CONVERSION_HUD])
 				target_list += target
 		if(target_list.len)
@@ -294,7 +294,7 @@ Works together with spawning an observer, noted above.
 /mob/dead/proc/process_medHUD(var/mob/M)
 	var/client/C = M.client
 	var/image/holder
-	for(var/mob/living/carbon/patient in oview(client.view+7, M))
+	for(var/mob/living/carbon/patient in oview(client.view+DATAHUD_RANGE_OVERHEAD, M))
 		if(!check_HUD_visibility(patient, M))
 			continue
 		if(!C)
@@ -339,7 +339,7 @@ Works together with spawning an observer, noted above.
 
 			C.images += holder
 
-	for(var/mob/living/simple_animal/mouse/patient in oview(client.view+7, M))
+	for(var/mob/living/simple_animal/mouse/patient in oview(client.view+DATAHUD_RANGE_OVERHEAD, M))
 		if(!check_HUD_visibility(patient, M))
 			continue
 		if(!C)


### PR DESCRIPTION

![datahudrange](https://user-images.githubusercontent.com/7573912/98936721-a2a89500-24e5-11eb-9afe-7532ea662ec8.gif)

:cl:
* tweak: Data HUD range now depends on the client's view plus an overhead of 7 tiles, instead of a fixed 7 tiles. This overhead gives the HUD icons time to appear before the mob comes into view, drastically reducing the situations where you have to wait a second or two for it to appear.