### PR TITLE
Space Helmets/Hardsuit Helmets that should hide eyes (and thus gender) now properly do

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -1195,6 +1195,7 @@ var/list/arcane_tomes = list()
 	clothing_flags = PLASMAGUARD|CONTAINPLASMAMAN
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	mech_flags = MECH_SCAN_FAIL
+	body_parts_visible_override = 0
 
 
 /obj/item/clothing/head/helmet/space/cult/get_cult_power()

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -594,6 +594,7 @@ Suit and assorted
 	species_restricted = list("Human")
 	eyeprot = 3
 	body_parts_covered = HEAD|EARS|HIDEHAIR
+	body_parts_visible_override = 0
 
 /obj/item/clothing/head/helmet/space/ninja/apprentice
 	name = "ninja hood"

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -112,6 +112,7 @@
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	species_restricted = list(VOX_SHAPED)
 	species_fit = list(VOX_SHAPED)
+	body_parts_visible_override = 0
 
 /obj/item/clothing/head/helmet/space/vox
 	armor = list(melee = 60, bullet = 50, laser = 30, energy = 15, bomb = 30, bio = 30, rad = 30)

--- a/code/modules/clothing/spacesuits/ert.dm
+++ b/code/modules/clothing/spacesuits/ert.dm
@@ -11,6 +11,7 @@
 	species_restricted = list("exclude",VOX_SHAPED)
 	pressure_resistance = 200 * ONE_ATMOSPHERE
 	eyeprot = 3
+	body_parts_visible_override = 0
 	var/id_suffix = "ERT_empty"
 
 /obj/item/clothing/head/helmet/space/ert/equipped(var/mob/M)

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -75,6 +75,7 @@
 	desc = "Take your protein pills and put your helmet on."
 	armor = list(melee = 10, bullet = 10, laser = 10,energy = 10, bomb = 50, bio = 100, rad = 100)
 	species_restricted =list("Human", "Insectoid")
+	body_parts_visible_override = 0
 
 //Clown Space Suit
 /obj/item/clothing/head/helmet/space/clown
@@ -84,6 +85,7 @@
 	item_state = "clown-eva-helmet"
 	species_fit = list(INSECT_SHAPED)
 	species_restricted = list("exclude",VOX_SHAPED)
+	body_parts_visible_override = 0
 
 /obj/item/clothing/suit/space/clown
 	name = "clown spacesuit"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -50,6 +50,7 @@
 	var/on = 0
 	var/no_light=0 // Disable the light on the atmos suit
 	actions_types = list(/datum/action/item_action/toggle_light)
+	body_parts_visible_override = 0//I mean technically the eyes are visible on the sprite, but they're manually drawn, the helmet itself not having any transparency, so w/e
 
 /obj/item/clothing/head/helmet/space/plasmaman/attack_self(mob/user)
 	if(no_light)

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -27,6 +27,7 @@ var/list/all_hardsuit_pieces = list(HARDSUIT_HEADGEAR,HARDSUIT_GLOVES,HARDSUIT_B
 	species_fit = list(GREY_SHAPED, TAJARAN_SHAPED, INSECT_SHAPED)
 	species_restricted = list("exclude",VOX_SHAPED)
 	var/obj/item/clothing/suit/space/rig/rig
+	body_parts_visible_override = 0
 
 /obj/item/clothing/head/helmet/space/rig/New()
 	check_light() //Needed to properly handle helmets with no lights

--- a/code/modules/clothing/spacesuits/time.dm
+++ b/code/modules/clothing/spacesuits/time.dm
@@ -10,6 +10,7 @@
 	clothing_flags = PLASMAGUARD
 	pressure_resistance = 200 * ONE_ATMOSPHERE
 	eyeprot = 3
+	body_parts_visible_override = 0
 
 /obj/item/clothing/head/helmet/space/time/equipped(mob/living/carbon/human/H, equipped_slot)
 	..()


### PR DESCRIPTION
Fixes #28200

:cl:
* bugfix: Fixed an issue where some helmets whose sprites supposedly completely hid the face with no transparency would somehow still let you know someone's gender/identity.