### PR TITLE
Fix & tweak Toxic Compensation

### DIFF
--- a/code/modules/virus2/effect/stage_3.dm
+++ b/code/modules/virus2/effect/stage_3.dm
@@ -616,7 +616,7 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/mob)
 	max_chance = 50
 
 /datum/disease2/effect/damage_converter/activate(var/mob/living/mob)
-	if(mob.getFireLoss() < mob.getMaxHealth() || mob.getBruteLoss() < mob.getMaxHealth())
+	if(mob.getFireLoss() > 0 || mob.getBruteLoss() > 0)
 		var/get_damage = rand(1, 3)
 		mob.adjustFireLoss(-get_damage)
 		mob.adjustBruteLoss(-get_damage)
@@ -646,8 +646,8 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/mob)
 		if(I.name != "brain" && !I.robotic)
 			valid_internal_organs += I
 
-	if(prob(75) || valid_external_organs.len) 
-		
+	if(prob(75) || valid_external_organs.len)
+
 		var/datum/organ/external/E = pick(valid_external_organs)
 		E.robotize()
 		H.update_body()
@@ -670,7 +670,7 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/mob)
 		mob << sound('sound/effects/supermatter.ogg')
 
 	var/mob/living/silicon/robot/mommi/mommi = /mob/living/silicon/robot/mommi
-	for(var/mob/living/M in viewers(mob))	
+	for(var/mob/living/M in viewers(mob))
 		if(M == mob)
 			continue
 
@@ -685,10 +685,10 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/mob)
 		if(C)
 			C.images += crab
 		var/duration = rand(60 SECONDS, 120 SECONDS)
-		
+
 		spawn(duration)
 			if(C)
-				C.images.Remove(crab) 
+				C.images.Remove(crab)
 
 	var/list/turf_list = list()
 	for(var/turf/T in spiral_block(get_turf(mob), 40))
@@ -702,7 +702,7 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/mob)
 			if(C)
 				C.images += supermatter
 			var/duration = rand(60 SECONDS, 120 SECONDS)
-			
+
 			spawn(duration)
 				if(C)
 					C.images.Remove(supermatter)
@@ -767,7 +767,7 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/mob)
 	var/activated = 0
 
 /datum/disease2/effect/wendigo_hallucination/activate(var/mob/living/mob)
-	if(!ishuman(mob))	
+	if(!ishuman(mob))
 		return
 	var/mob/living/carbon/human/H = mob
 	H.Jitter(100)

--- a/code/modules/virus2/effect/stage_3.dm
+++ b/code/modules/virus2/effect/stage_3.dm
@@ -610,17 +610,20 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/mob)
 /datum/disease2/effect/damage_converter
 	name = "Toxic Compensation"
 	desc = "Stimulates cellular growth within the body, causing it to regenerate tissue damage. Repair done by these cells causes toxins to build up in the body."
+	encyclopedia = "Manipulation of the symptom's strength can be used to either reduce or amplify the toxic feedback."
 	badness = EFFECT_DANGER_FLAVOR
 	stage = 3
 	chance = 10
 	max_chance = 50
+	multiplier = 5
+	max_multiplier = 10
 
 /datum/disease2/effect/damage_converter/activate(var/mob/living/mob)
 	if(mob.getFireLoss() > 0 || mob.getBruteLoss() > 0)
 		var/get_damage = rand(1, 3)
 		mob.adjustFireLoss(-get_damage)
 		mob.adjustBruteLoss(-get_damage)
-		mob.adjustToxLoss(get_damage)
+		mob.adjustToxLoss(max(1,get_damage * multiplier / 5))
 
 
 /datum/disease2/effect/cyborg_limbs


### PR DESCRIPTION
Fixes #28220

:cl:
* bugfix: Fixed Toxic Compensation disease symptom that was creating toxic damage out of nothing.
* rscadd: You can now strengthen or weaken the Toxic Compensation symptom to amplify or reduce the toxic feedback.