### PR TITLE
ironman donut storage fix

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -62,7 +62,8 @@
 	name = "donut box"
 	storage_slots = 6
 	can_only_hold = list("/obj/item/weapon/reagent_containers/food/snacks/donut", \
-					"/obj/item/weapon/reagent_containers/food/snacks/customizable/candy/donut")
+					"/obj/item/weapon/reagent_containers/food/snacks/customizable/candy/donut", \
+					"/obj/item/weapon/reagent_containers/food/snacks/donutiron")
 
 	foldable = /obj/item/stack/sheet/cardboard
 	starting_materials = list(MAT_CARDBOARD = 3750)


### PR DESCRIPTION
Fixes #28215

![image](https://user-images.githubusercontent.com/74737391/99723102-56c29680-2a77-11eb-84d4-ecc2c465a821.png)


:cl:
 * bugfix: ironman donuts can be put into donut boxes now.