### PR TITLE
Energy Swords and Energy Katanas Now Properly Cut Open Firelocks

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -323,13 +323,19 @@ var/global/list/alert_overlays_global = list()
 									"<span class='warning'>You hear slicing noises.</span>")
 				playsound(src, 'sound/items/Welder2.ogg', 100, 1)
 				blocked = !blocked
-				open(user)
+				force_open(user, C)
+				sleep(8)
+				blocked = TRUE
+				update_icon()
 			return
 		else
 			user.visible_message("<span class='warning'>[user] swiftly slices \the [src] open!</span>",\
 								"You slice \the [src] open in one clean cut!",\
 								"You hear the sound of a swift, sharp slice.")
-			open(user)
+			force_open(user, C)
+			sleep(8)
+			blocked = TRUE
+			update_icon()
 			return
 
 	if(C.is_wrench(user))


### PR DESCRIPTION
Fixes #28209 

Energy weapons that are capable of cutting open firelocks will now properly keep the fire locks in the cut open position.  This seems to be more along the line of a bugfix than a feature due to the behavior of those weapons cutting open and breaking doors already.

Tested and what not.

:cl:
 * bugfix: Energy cutting weapons now properly keep firelocks open after a successful cut.