### PR TITLE
Re-Adds Fun

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -65,11 +65,11 @@
 			return
 		buckle_mob(usr, usr)
 
-/obj/structure/bed/proc/manual_unbuckle(var/mob/user)
+/obj/structure/bed/proc/manual_unbuckle(var/mob/user, var/resisting = FALSE)
 	if(user.isStunned())
 		return FALSE
 
-	if (user.restrained())
+	if (user.restrained() && !resisting)
 		to_chat(user, "<span class='warning'>Uncuff yourself first!</span>")
 		return FALSE
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -969,7 +969,7 @@ Thanks.
 								C.visible_message("<span class='danger'>[C] manages to unbuckle themself!</span>",\
 								                  "<span class='notice'>You successfully unbuckle yourself.</span>",\
 								self_drugged_message="<span class='notice'>You successfully regain control of your legs and stand up.</span>")
-								B.manual_unbuckle(C)
+								B.manual_unbuckle(C, resisting = TRUE)
 							else
 								C.simple_message("<span class='warning'>Your unbuckling attempt was interrupted.</span>", \
 									"<span class='warning'>Your attempt to regain control of your legs was interrupted. Damn it!</span>")


### PR DESCRIPTION
Followup PR to #28203 

Based on Kromkar's request I've not only removed bear circles, but the entire letter O from crayons. No longer will we be taunted by clowns making fun of us botanists. They'll have to settle for batanists or something.

![image](https://user-images.githubusercontent.com/9782036/99843835-c4ce9280-2b37-11eb-823e-7fc8926508d7.png)