### PR TITLE
Fixes intercoms and hand radio modification

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -510,6 +510,13 @@
 /obj/item/device/radio/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
 	user.set_machine(src)
+	if (!(W.is_screwdriver(user)))
+		return
+	b_stat = !(b_stat)
+	if (b_stat)
+		user.show_message("<span class = 'notice'>\The [src] can now be attached and modified!</span>")
+	else
+		user.show_message("<span class = 'notice'>\The [src] can no longer be modified or attached!</span>")
 	updateDialog()
 	update_icon()
 	add_fingerprint(user)


### PR DESCRIPTION

Fixes #26936

For a while now, we have been unable to modify hand radios and intercoms due to some unforeseen consequences with #25804.  This returns the ability to modify both, along with associated construction/deconstruction.

Tested and what not.
[bugfix]


:cl:
 * rscadd: Adds modifying intercoms/hand-radios and construction/deconstruction back
 * bugfix: Fixes modifying intercoms/hand-radios