### PR TITLE
Gives the ghosts of corpses enthralled by a vampire a notification

### DIFF
--- a/code/modules/spells/targeted/enthrall.dm
+++ b/code/modules/spells/targeted/enthrall.dm
@@ -70,7 +70,7 @@
 		if(ghost)
 			var/mob/ghostmob = ghost.get_top_transmogrification()
 			if(ghostmob) //A ghost has been found, and it still belongs to this corpse. There's nothing preventing them from being revived.
-				to_chat(ghostmob, "<span class='interface big'><span class='bold'>The vampire has enthralled your corpse.  You will be its servant when you return to the living.  Blood and power to your Lord.</span>")
+				to_chat(ghostmob, "<span class='interface big'><span class='bold'>The vampire has enthralled your corpse.  You will be its servant when you return to the living.  Blood and power to your Lord.  (Check your notes for the current identity of your master upon revival.)</span>")
 	
 	V.remove_blood(blood_cost)
 

--- a/code/modules/spells/targeted/enthrall.dm
+++ b/code/modules/spells/targeted/enthrall.dm
@@ -64,7 +64,14 @@
 	else
 		to_chat(user, "<span class='warning'>Either you or your target moved, and you couldn't finish enthralling them!</span>")
 		return FALSE
-
+	
+	if(!target.client) //There is not a player "in control" of this corpse, so there is no one to inform.
+		var/mob/dead/observer/ghost = mind_can_reenter(target.mind)
+		if(ghost)
+			var/mob/ghostmob = ghost.get_top_transmogrification()
+			if(ghostmob) //A ghost has been found, and it still belongs to this corpse. There's nothing preventing them from being revived.
+				to_chat(ghostmob, "<span class='interface big'><span class='bold'>The vampire has enthralled your corpse.  You will be its servant when you return to the living.  Blood and power to your Lord.</span>")
+	
 	V.remove_blood(blood_cost)
 
 /spell/targeted/enthrall/critfail(var/list/targets, var/mob/user)

--- a/code/modules/spells/targeted/enthrall.dm
+++ b/code/modules/spells/targeted/enthrall.dm
@@ -70,7 +70,7 @@
 		if(ghost)
 			var/mob/ghostmob = ghost.get_top_transmogrification()
 			if(ghostmob) //A ghost has been found, and it still belongs to this corpse. There's nothing preventing them from being revived.
-				to_chat(ghostmob, "<span class='interface big'><span class='bold'>The vampire has enthralled your corpse.  You will be its servant when you return to the living.  Blood and power to your Lord.  (Check your notes for the current identity of your master upon revival.)</span>")
+				to_chat(ghostmob, "<span class='interface big'><span class='bold'>The vampire has enthralled your corpse.  You will be their servant when you return to the living.  Blood and power to your Lord.  (Check your notes for the current identity of your master upon revival.)</span>")
 	
 	V.remove_blood(blood_cost)
 


### PR DESCRIPTION
Closes #28168 
Now ghosts will have a large notification when their dead body is enthralled, so they can avoid confusion upon returning to the living.
![image](https://user-images.githubusercontent.com/74737391/99902888-927f7b00-2c86-11eb-8ec4-0b2eb89f8e3e.png)
[qol]


:cl:
 * rscadd: Added a notification for ghosts who have their corpse enthralled by a vampire.
