### PR TITLE
Fixes Mad Scientist Megaphone users being trackable

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -170,6 +170,8 @@
 				return FALSE
 			if(target_human.is_wearing_item(/obj/item/clothing/head/tinfoil))
 				return FALSE
+			if(target_human.is_holding_item(/obj/item/device/megaphone/madscientist))
+				return FALSE
 
 		if(isalien(target))
 			return FALSE


### PR DESCRIPTION
Fixes #28134 
Much like all of the other anonymity syndicate items such as the voice changer and the agent ID, the megaphone is not intended to be tracked.  This fixes being able to track people using the mad scientist megaphone for anonymous demands.
[bugfix]

:cl:
 * bugfix: The mad scientist megaphone user can no longer be tracked on cameras by silicons.
