### PR TITLE
Supermatter Cascade Extended

### DIFF
--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -318,7 +318,7 @@ There's been a galaxy-wide electromagnetic pulse.  All of our systems are heavil
 
 [station_name()], you are the only facility nearby a bluespace rift, which is near your research outpost.  You are hereby directed to enter the rift using all means necessary, quite possibly as the last humans alive.
 
-You have five minutes before the universe collapses. Good l\[\[###!!!-
+You have eight minutes before the universe collapses. Good l\[\[###!!!-
 
 AUTOMATED ALERT: Link to [command_name()] lost.
 

--- a/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
@@ -83,7 +83,7 @@
 			if(istype(C.shuttle,/datum/shuttle/mining) || istype(C.shuttle,/datum/shuttle/research))
 				C.req_access = null
 
-		sleep(5 MINUTES)
+		sleep(8 MINUTES)
 		ticker.declare_completion()
 		ticker.station_explosion_cinematic(0,null) // TODO: Custom cinematic
 


### PR DESCRIPTION
Simple change, the supermatter sea happens once in a blue moon and since it only lasts 5 minutes you never see the sea spread very far into the station at all. Since a lot of the fun surrounding the super matter sea is trying to escape the madness it seems silly to have a timer so short you probably won't even see it. Sure, this might make it so people might have to sit around for 3 more minutes if the station pulls off a speedy full evacuation but with how rare the event is I believe its worth it.

<tweak>
:cl:

 * tweak: Extended supermatter cascade event from 5 minutes to 8. 