### PR TITLE
Adds admin logging for Silicon/Trader characters joining the round

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -384,14 +384,17 @@ var/datum/controller/gameticker/ticker
 		if(player.ready && player.mind)
 			if(player.mind.assigned_role=="AI")
 				player.close_spawn_windows()
+				log_admin("([player.ckey]) started the game as a [player.mind.assigned_role].")
 				player.AIize()
 			else if(player.mind.assigned_role=="Cyborg")
+				log_admin("([player.ckey]) started the game as a [player.mind.assigned_role].")
 				player.create_roundstart_cyborg()
 
 			else if(!player.mind.assigned_role)
 				continue
 			else
-
+				if(player.mind.assigned_role=="Mobile MMI")
+					log_admin("([player.ckey]) started the game as a [player.mind.assigned_role].")
 				var/mob/living/carbon/human/new_character = player.create_character()
 				switch(new_character.mind.assigned_role)
 					if("MODE","Mobile MMI","Trader")

--- a/code/game/jobs/job/whitelisted.dm
+++ b/code/game/jobs/job/whitelisted.dm
@@ -36,6 +36,8 @@
 		trader_account = create_trader_account
 	M.mind.store_memory("<b>The joint trader account is:</b> #[trader_account.account_number]<br><b>Your shared account pin is:</b> [trader_account.remote_access_pin]<br>")
 
+	log_admin("([M.ckey]/[M]) started the game as a [job_title].")
+
 	to_chat(M, "<B>You are a [job_title].</B>")
 
 	to_chat(M, "<b>You should do your best to sell what you can to fund new product sales. Ultimately, the mark of a good trader is profit -- but public relations are an important component of that end goal.</b>")


### PR DESCRIPTION
`[20:26:10]ADMIN: (dilt/) started the game as a Pharmacist.`

Lines like this are all over the admin log. It's a nice easy record of who joined the round as what job. This does not currently function for anyone joining as a silicon role or as a trader. This PR fixes this. Behold, the fruits of a few seconds of code (and more minutes getting git set up properly):

`[23:55:40]ADMIN: (dilt) started the game as a Cyborg.`
`[00:00:32]ADMIN: (dilt) started the game as a Mobile MMI.`
`[00:05:19]ADMIN: (dilt) started the game as a AI.`
`[00:13:34]ADMIN: (dilt/) started the game as a Trader.`
`[00:14:41]ADMIN: (dilt/) started the game as a Merchant.`
`[00:15:57]ADMIN: (dilt/) started the game as a Salvage Broker.`

[logging]
[tested]