### PR TITLE
Makes SDQL understand typepaths

### DIFF
--- a/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
@@ -366,7 +366,7 @@
 	else if(expression[i] == "null")
 		val = null
 
-	else if(isnum(expression[i]))
+	else if(isnum(expression[i]) || ispath(expression[i]))
 		val = expression[i]
 
 	else if(copytext(expression[i], 1, 2) in list("'", "\""))

--- a/code/modules/admin/verbs/SDQL_2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL_2/SDQL_2_parser.dm
@@ -570,11 +570,15 @@
 		node += text2num(token(i))
 		i++
 
+	else if(text2path(token(i)))
+		node += text2path(token(i++))
+
 	else if(copytext(token(i), 1, 2) in list("'", "\""))
 		i = string(i, node)
 
 	else if(copytext(token(i), 1, 2) == "\[") // Start a list.
 		i = array(i, node)
+
 	else
 		i = variable(i, node)
 

--- a/code/modules/admin/verbs/SDQL_2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL_2/SDQL_2_parser.dm
@@ -556,7 +556,7 @@
 	return i + 1
 
 
-//value:	variable | string | number | 'null'
+//value:	variable | string | number | 'null' | typepath
 /datum/SDQL_parser/proc/value(i, list/node)
 	if(token(i) == "null")
 		node += "null"

--- a/code/modules/admin/verbs/SDQL_2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL_2/SDQL_2_parser.dm
@@ -34,7 +34,7 @@
 //	expression			:	( unary_expression | '(' expression ')' | value ) [binary_operator expression]
 //	unary_expression	:	unary_operator ( unary_expression | value | '(' expression ')' )
 //	comparitor			:	'=' | '==' | '!=' | '<>' | '<' | '<=' | '>' | '>='
-//	value				:	variable | string | number | 'null'
+//	value				:	variable | string | number | 'null' | typepath
 //	unary_operator		:	'!' | '-' | '~'
 //	binary_operator		:	comparitor | '+' | '-' | '/' | '*' | '&' | '|' | '^'
 //	bool_operator		:	'AND' | '&&' | 'OR' | '||'


### PR DESCRIPTION
:cl:
* rscadd: SDQL can now understand typepaths in variable assignments, comparisons, etc.