### PR TITLE
fix electric chair

### DIFF
--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -57,11 +57,6 @@
 
 /obj/item/device/radio/electropack/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
-	if (W.is_screwdriver())
-		b_stat = !b_stat
-		if (b_stat)
-			to_chat(user, "<span class='notice'>[src] is now ready to be attached!</span>")
-		return
 	if(istype(W, /obj/item/clothing/head/helmet))
 		if(!b_stat)
 			to_chat(user, "<span class='notice'>[src] is not ready to be attached!</span>")


### PR DESCRIPTION
Closes #28279.
Essentially a revert of #26012.
I didn't actually look into it any further but i assume `..()` does everything this code is supposed to do.
Tested.

There *is* an issue with electropack wiring, which is that it uses a radio wire datum, but that's a whole different can of worms.