### PR TITLE
GitHub Actions-based CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  BYOND_MAJOR: 513
+  BYOND_MINOR: 1523
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   lint:
@@ -35,8 +39,6 @@ jobs:
 
       - name: Compile all maps
         run: |
-          export BYOND_MAJOR="513"
-          export BYOND_MINOR="1523"
           export ALL_MAPS="tgstation metaclub defficiency packedstation roidstation nrvhorizon test_box test_tiny snaxi tgstation-sec LampreyStation xoq boxesstation synergy bagelstation"
           export DM_UNIT_TESTS="0"
           tools/travis/install-byond.sh
@@ -44,8 +46,6 @@ jobs:
           tools/travis/build.py
       - name: Compile and test
         run: |
-           export BYOND_MAJOR="513"
-           export BYOND_MINOR="1523"
            export DM_UNIT_TESTS="1"
            tools/travis/install-byond.sh
            source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,14 +71,11 @@ jobs:
           path: ~/BYOND-${{env.BYOND_MAJOR}}.${{env.BYOND_MINOR}}
           key: BYOND-${{runner.os}}-${{env.BYOND_MAJOR}}.${{env.BYOND_MINOR}}
 
-      - name: Compile
+      - name: ${{matrix.job-name}}
         env:
           DM_UNIT_TESTS: ${{matrix.dm-unit-tests}}
         run: |
           tools/travis/install-byond.sh
           source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
           tools/travis/build.py
-
-      - name: Run tests
-        if: ${{matrix.dm-unit-tests}}
-        run: tools/travis/run_tests.py
+          tools/travis/run_tests.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ env:
   BYOND_MAJOR: 513
   BYOND_MINOR: 1523
 
+  #This can be declared here because build.py will ignore it if DM_UNIT_TESTS is true.
+  ALL_MAPS: tgstation metaclub defficiency packedstation roidstation nrvhorizon test_box test_tiny snaxi tgstation-sec LampreyStation xoq boxesstation synergy bagelstation
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   lint:
@@ -34,20 +37,18 @@ jobs:
   build:
     name: Compile and run tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - dm-unit-tests: 0
+          - dm-unit-tests: 1
     steps:
       - uses: actions/checkout@v2
 
       - name: Compile all maps
+        env:
+          DM_UNIT_TESTS: ${{dm-unit-tests}}
         run: |
-          export ALL_MAPS="tgstation metaclub defficiency packedstation roidstation nrvhorizon test_box test_tiny snaxi tgstation-sec LampreyStation xoq boxesstation synergy bagelstation"
-          export DM_UNIT_TESTS="0"
           tools/travis/install-byond.sh
           source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
           tools/travis/build.py
-      - name: Compile and test
-        run: |
-           export DM_UNIT_TESTS="1"
-           tools/travis/install-byond.sh
-           source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
-           tools/travis/build.py
-           tools/travis/run_tests.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,4 +78,5 @@ jobs:
           tools/travis/install-byond.sh
           source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
           tools/travis/build.py 2>&1 | tee /dev/stderr | awk '/warning:|error:/ { exit 1 }'
+          cp tools/travis/config/config.txt config/
           tools/travis/run_tests.py 2>&1 | tee /dev/stderr | awk '/UNIT TEST FAIL/ { exit 1 }'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,5 +77,5 @@ jobs:
         run: |
           tools/travis/install-byond.sh
           source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
-          tools/travis/build.py
-          tools/travis/run_tests.py
+          tools/travis/build.py 2>&1 | tee /dev/stderr | sponge | awk '/warning:|error:/ { exit 1 }'
+          tools/travis/run_tests.py 2>&1 | tee /dev/stderr | sponge | awk '/UNIT TEST FAIL/ { exit 1 }'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-          with:
-            python-version: '3.x'
+        with:
+          python-version: '3.x'
 
       - name: Run dreamchecker
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Compile all maps
         env:
-          DM_UNIT_TESTS: ${{dm-unit-tests}}
+          DM_UNIT_TESTS: ${{matrix.dm-unit-tests}}
         run: |
           tools/travis/install-byond.sh
           source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/cache@v2
         name: Cache BYOND installation
         with:
-          path: $HOME/BYOND-${{env.BYOND_MAJOR}}.${{env.BYOND_MINOR}}
+          path: ${{env.HOME}}/BYOND-${{env.BYOND_MAJOR}}.${{env.BYOND_MINOR}}
           key: BYOND-${{runner.os}}-${{env.BYOND_MAJOR}}.${{env.BYOND_MINOR}}
 
       - name: ${{matrix.job-name}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,9 @@ jobs:
         run: python3 tools/travis/check_map_files.py maps/
 
       - name: Validhunt DMIs
-        run: python3 tools/dmi-validhunt/dmi-validhunt.py icons/ || true
+        run: |
+          pip install pil
+          python3 tools/dmi-validhunt/dmi-validhunt.py icons/ || true
 
       - name: Make sure test maps aren't ticked
         run: find -name '*.dme' -exec cat {} \; | awk '/maps\\test.*/ { exit 1 }'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the Bleeding-Edge branch
+  push:
+    branches: [ Bleeding-Edge ]
+  pull_request:
+    branches: [ Bleeding-Edge ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Run dreamchecker
+        run: |
+          SPACEMAN_DMM_GIT_TAG="suite-1.6" tools/travis/install_spaceman_dmm.sh dreamchecker
+          ~/dreamchecker
+
+      - name: Compile all maps
+        run: |
+          export BYOND_MAJOR="513"
+          export BYOND_MINOR="1523"
+          export ALL_MAPS="tgstation metaclub defficiency packedstation roidstation nrvhorizon test_box test_tiny snaxi tgstation-sec LampreyStation xoq boxesstation synergy bagelstation"
+          export DM_UNIT_TESTS="0"
+          tools/travis/install-byond.sh
+          source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
+          tools/travis/build.py
+      - name: Compile and test
+        run: |
+           export BYOND_MAJOR="513"
+           export BYOND_MINOR="1523"
+           export DM_UNIT_TESTS="1"
+           tools/travis/install-byond.sh
+           source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
+           tools/travis/build.py
+           tools/travis/run_tests.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,5 +77,5 @@ jobs:
         run: |
           tools/travis/install-byond.sh
           source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
-          tools/travis/build.py 2>&1 | tee /dev/stderr | sponge | awk '/warning:|error:/ { exit 1 }'
-          tools/travis/run_tests.py 2>&1 | tee /dev/stderr | sponge | awk '/UNIT TEST FAIL/ { exit 1 }'
+          tools/travis/build.py 2>&1 | awk '/warning:|error:/ { exit 1 }'
+          tools/travis/run_tests.py 2>&1 | awk '/UNIT TEST FAIL/ { exit 1 }'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Run map checker
         run: python3 tools/travis/check_map_files.py maps/
 
+      - name: Validhunt DMIs
+        run: python3 tools/dmi-validhunt/dmi-validhunt.py icons/ || true
+
+      - name: Make sure test maps aren't ticked
+        run: find -name '*.dme' -exec cat {} \; | awk '/maps\\test.*/ { exit 1 }'
+
   build:
     name: ${{matrix.job-name}}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/cache@v2
         name: Cache BYOND installation
         with:
-          path: ${{env.HOME}}/BYOND-${{env.BYOND_MAJOR}}.${{env.BYOND_MINOR}}
+          path: ~/BYOND-${{env.BYOND_MAJOR}}.${{env.BYOND_MINOR}}
           key: BYOND-${{runner.os}}-${{env.BYOND_MAJOR}}.${{env.BYOND_MINOR}}
 
       - name: ${{matrix.job-name}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,14 @@ jobs:
       matrix:
         include:
           - dm-unit-tests: 0
+            job-name: Compile all maps
+
           - dm-unit-tests: 1
+            job-name: Compile and run tests
     steps:
       - uses: actions/checkout@v2
 
-      - name: Compile all maps
+      - name: ${{matrix.job-name}}
         env:
           DM_UNIT_TESTS: ${{matrix.dm-unit-tests}}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+          with:
+            python-version: '3.x'
 
       - name: Run dreamchecker
         run: |
@@ -35,7 +38,7 @@ jobs:
           ~/dreamchecker
 
       - name: Run map checker
-        run: python3 tools/travis/check_map_files.py maps/
+        run: python tools/travis/check_map_files.py maps/
 
       - name: Validhunt DMIs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Validhunt DMIs
         run: |
-          pip install pil
+          pip install Pillow
           python3 tools/dmi-validhunt/dmi-validhunt.py icons/ || true
 
       - name: Make sure test maps aren't ticked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,10 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
+  lint:
+    name: Run linters
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -27,6 +26,12 @@ jobs:
         run: |
           SPACEMAN_DMM_GIT_TAG="suite-1.6" tools/travis/install_spaceman_dmm.sh dreamchecker
           ~/dreamchecker
+
+  build:
+    name: Compile and run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
 
       - name: Compile all maps
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           ~/dreamchecker
 
   build:
-    name: Compile and run tests
+    name: ${{matrix.job-name}}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,5 +77,5 @@ jobs:
         run: |
           tools/travis/install-byond.sh
           source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
-          tools/travis/build.py 2>&1 | awk '/warning:|error:/ { exit 1 }'
-          tools/travis/run_tests.py 2>&1 | awk '/UNIT TEST FAIL/ { exit 1 }'
+          tools/travis/build.py 2>&1 | tee /dev/stderr | awk '/warning:|error:/ { exit 1 }'
+          tools/travis/run_tests.py 2>&1 | tee /dev/stderr | awk '/UNIT TEST FAIL/ { exit 1 }'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           python-version: '3.x'
 
+        #TODO: Cache Dreamchecker install
       - name: Run dreamchecker
         run: |
           SPACEMAN_DMM_GIT_TAG="suite-1.6" tools/travis/install_spaceman_dmm.sh dreamchecker
@@ -40,6 +41,7 @@ jobs:
       - name: Run map checker
         run: python tools/travis/check_map_files.py maps/
 
+        #TODO: Cache pip directory
       - name: Validhunt DMIs
         run: |
           pip install Pillow
@@ -69,10 +71,14 @@ jobs:
           path: ~/BYOND-${{env.BYOND_MAJOR}}.${{env.BYOND_MINOR}}
           key: BYOND-${{runner.os}}-${{env.BYOND_MAJOR}}.${{env.BYOND_MINOR}}
 
-      - name: ${{matrix.job-name}}
+      - name: Compile
         env:
           DM_UNIT_TESTS: ${{matrix.dm-unit-tests}}
         run: |
           tools/travis/install-byond.sh
           source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
           tools/travis/build.py
+
+      - name: Run tests
+        if: ${{matrix.dm-unit-tests}}
+        run: tools/travis/run_tests.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Validhunt DMIs
         run: |
           pip install Pillow
-          python3 tools/dmi-validhunt/dmi-validhunt.py icons/ || true
+          python tools/dmi-validhunt/dmi-validhunt.py icons/ || true
 
       - name: Make sure test maps aren't ticked
         run: find -name '*.dme' -exec cat {} \; | awk '/maps\\test.*/ { exit 1 }'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,15 @@ jobs:
 
           - dm-unit-tests: 1
             job-name: Compile and run tests
+
     steps:
       - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        name: Cache BYOND installation
+        with:
+          path: $HOME/BYOND-${{env.BYOND_MAJOR}}.${{env.BYOND_MINOR}}
+          key: BYOND-${{runner.os}}-${{env.BYOND_MAJOR}}.${{env.BYOND_MINOR}}
 
       - name: ${{matrix.job-name}}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
           SPACEMAN_DMM_GIT_TAG="suite-1.6" tools/travis/install_spaceman_dmm.sh dreamchecker
           ~/dreamchecker
 
+      - name: Run map checker
+        run: python3 tools/travis/check_map_files.py maps/
+
   build:
     name: ${{matrix.job-name}}
     runs-on: ubuntu-latest

--- a/tools/dmi-validhunt/dmi-validhunt.py
+++ b/tools/dmi-validhunt/dmi-validhunt.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import sys
 import os
-from Pillow import Image
+from PIL import Image
 
 """
 Find duplicate icon states in DMI files.

--- a/tools/dmi-validhunt/dmi-validhunt.py
+++ b/tools/dmi-validhunt/dmi-validhunt.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import sys
 import os
-from PIL import Image
+from Pillow import Image
 
 """
 Find duplicate icon states in DMI files.


### PR DESCRIPTION
1. The free Travis CI plan is going away in under a month.
2. Travis has been preposterously slow recently.

This is a mostly-finished replacement for Travis. Initial setup by @DamianX, lots of changes by me. Just needs some finishing touches to bring it up to equivalence with Travis's current setup.
In addition to not having fucking hour-long queues, the actual time to perform the job is almost three times faster on this service, as well.
Once this is done we can drop Travis whenever we decide.

~~For some reason, one of the unit tests passes on Travis but fails on this. I think it's because the misc. persistence subsystem is not guaranteed to be initialized before roundstart. I do not know why it always seems to pass on Travis and always seems to fail on this, because it seems like it should just be completely random.~~