### PR TITLE
One handed gloves

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -215,7 +215,7 @@
 		if(slot_glasses)
 			return has_organ(LIMB_HEAD)
 		if(slot_gloves)
-			return has_organ(LIMB_LEFT_HAND) && has_organ(LIMB_RIGHT_HAND)
+			return has_organ(LIMB_LEFT_HAND) || has_organ(LIMB_RIGHT_HAND)
 		if(slot_head)
 			return has_organ(LIMB_HEAD)
 		if(slot_shoes)

--- a/code/modules/unit_tests/__unit_test_includes.dm
+++ b/code/modules/unit_tests/__unit_test_includes.dm
@@ -7,6 +7,7 @@
 #include "examine.dm"
 #include "hexadecimal.dm"
 #include "highscores.dm"
+#include "human.dm"
 #include "icons.dm"
 #include "lazy_events.dm"
 #include "names.dm"

--- a/code/modules/unit_tests/human.dm
+++ b/code/modules/unit_tests/human.dm
@@ -1,0 +1,33 @@
+
+/datum/unit_test/human/start()
+
+/datum/unit_test/human/wear_gloves_with_one_hand/start()
+	var/mob/living/carbon/human/test_human = new()
+	var/obj/item/clothing/gloves/yellow/test_gloves = new()
+
+	var/datum/organ/external/organ = test_human.get_organ(LIMB_RIGHT_HAND)
+	organ.droplimb(1)
+	test_human.equip_to_slot_if_possible(test_gloves, slot_gloves)
+	assert_eq(test_human.gloves, test_gloves)
+
+	test_human.drop_from_inventory(test_human.gloves)
+	assert_eq(test_human.gloves, null)
+
+	organ = test_human.get_organ(LIMB_RIGHT_ARM)
+	organ.droplimb(1)
+	test_human.equip_to_slot_if_possible(test_gloves, slot_gloves)
+	assert_eq(test_human.gloves, test_gloves)
+
+// you CANNOT handcuff a person without both hands. This tests that
+/datum/unit_test/human/handcuff_guy_with_one_hand/start()
+	var/turf/centre = locate(100, 100, 1)
+	var/mob/living/carbon/human/test_human = new(centre)
+	var/mob/living/carbon/human/test_shitcurity = new(centre)
+	var/obj/item/weapon/handcuffs/test_handcuffs = new(centre)
+
+	var/datum/organ/external/organ = test_human.get_organ(LIMB_RIGHT_ARM)
+	organ.droplimb(1)
+
+	var/can_handcuff = test_handcuffs.attempt_apply_restraints(test_human, test_shitcurity)
+
+	assert_eq(can_handcuff, FALSE)


### PR DESCRIPTION
Closes #13312

Sprites will show both hands as wearing gloves though, I tried to come up with something simple to fix that but icon operations are inevitable and it's kind of a boring work tbh

:cl:
 * bugfix: Players missing one arm or hand can wear gloves