### PR TITLE
Fixes catbeast objectives

### DIFF
--- a/code/datums/gamemode/objectives/catbeast.dm
+++ b/code/datums/gamemode/objectives/catbeast.dm
@@ -6,7 +6,7 @@
 	if (..())
 		return TRUE
 	var/datum/role/catbeast/C = owner.GetRole(CATBEAST)
-	return C.ticks_survived > 150
+	return C.ticks_survived >= 150
 
 /datum/objective/catbeast/defile
 	explanation_text = "Defile 30 rooms by entering them."
@@ -16,4 +16,4 @@
 	if (..())
 		return TRUE
 	var/datum/role/catbeast/C = owner.GetRole(CATBEAST)
-	return C.areas_defiled.len > 30
+	return C.areas_defiled.len >= 30


### PR DESCRIPTION
>Objective #2: Defile 30 rooms by entering them. Fail.
>The loose catbeast has failed.The catbeast survived on station for 572 seconds, defiled 30 rooms

:cl:
 * rscadd: Fixed catbeast objectives getting redtext if they met the requirements.
