### PR TITLE
Now watch and learn, here's the deal, don't slip and slide on this banana peel!

### DIFF
--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -11,9 +11,22 @@
 /obj/item/weapon/bananapeel/Crossed(AM as mob|obj)
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
-		if (M.Slip(2, 2, 1))
+		if(slip_n_slide(M))
 			M.simple_message("<span class='notice'>You slipped on the [name]!</span>",
 				"<span class='userdanger'>Something is scratching at your feet! Oh god!</span>")
+
+/obj/item/weapon/bananapeel/proc/slip_n_slide(var/mob/living/carbon/M)
+	if(!M.Slip(2,2,1))
+		return 0
+	var/tiles_to_slip = rand(0,3)
+	if(tiles_to_slip && !locked_to) //The banana peel will not be dragged along so stop the ride
+		M.lock_atom(src)
+		for(var/i = 1 to tiles_to_slip)
+			if(!M.locked_to)
+				step(M, M.dir)
+				sleep(1)
+		spawn(1) M.unlock_atom(src)
+	return 1
 
 /*
  * Soap

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -15,12 +15,14 @@
 			M.simple_message("<span class='notice'>You slipped on the [name]!</span>",
 				"<span class='userdanger'>Something is scratching at your feet! Oh god!</span>")
 
+/datum/locking_category/banana_peel
+
 /obj/item/weapon/bananapeel/proc/slip_n_slide(var/mob/living/carbon/M)
 	if(!M.Slip(2,2,1))
 		return 0
 	var/tiles_to_slip = rand(0,3)
 	if(tiles_to_slip && !locked_to) //The banana peel will not be dragged along so stop the ride
-		M.lock_atom(src)
+		M.lock_atom(src, /datum/locking_category/banana_peel)
 		for(var/i = 1 to tiles_to_slip)
 			if(!M.locked_to)
 				step(M, M.dir)


### PR DESCRIPTION
Banana peels can now slip you a few spaces forward, it's a dice roll between slipping only on the spot and slipping up to 3 spaces away, and the banana peel follows you too
Bluespace peels and syndicate peels are not affected
RIP Stefan
:cl:
 * tweak: Banana peels are now more slippery, meaning you can slide a few tiles forward if you walk into one.