### PR TITLE
you can examine the state of miners now

### DIFF
--- a/code/game/machinery/atmoalter/gas_mine.dm
+++ b/code/game/machinery/atmoalter/gas_mine.dm
@@ -20,8 +20,6 @@
 
 	machine_flags = WRENCHMOVE | FIXED2WORK
 
-	var/examine_flavor = "Operating normally"
-
 /obj/machinery/atmospherics/miner/New()
 	..()
 	air_contents = new
@@ -32,20 +30,18 @@
 	air_contents.update_values()
 	update_icon()
 
-/obj/machinery/atmospherics/miner/proc/flavor_examine(num)
-	switch(num)
-		if(1)
-			examine_flavor = "Lack of power"
-		if(2)
-			examine_flavor = "Turned off"
-		if(3)
-			examine_flavor = "Broken"
-		if(4)
-			examine_flavor = "Operating normally"
-
 /obj/machinery/atmospherics/miner/examine(mob/user)
 	. = ..()
-	to_chat(user, "<span class='info'>\The [src]'s debug reads: [examine_flavor].</span>")
+	if(stat & NOPOWER)
+		to_chat(user, "<span class='info'>\The [src]'s status terminal reads: Lack of power.</span>")
+		return
+	if (!on)
+		to_chat(user, "<span class='info'>\The [src]'s status terminal reads: Turned off.</span>")
+		return
+	if(stat & BROKEN)
+		to_chat(user, "<span class='info'>\The [src]'s status terminal reads: Broken.</span>")
+		return
+	to_chat(user, "<span class='info'>\The [src]'s status terminal reads: Functional and operating.</span>")
 
 /obj/machinery/atmospherics/miner/wrenchAnchor(var/mob/user, var/obj/item/I)
 	. = ..()
@@ -104,10 +100,8 @@
 
 /obj/machinery/atmospherics/miner/process()
 	if(stat & NOPOWER)
-		flavor_examine(1)
 		return
 	if (!on)
-		flavor_examine(2)
 		return
 
 	var/oldstat=stat
@@ -118,7 +112,6 @@
 	if(stat!=oldstat)
 		update_icon()
 	if(stat & BROKEN)
-		flavor_examine(3)
 		return
 
 	var/datum/gas_mixture/environment = loc.return_air()
@@ -140,8 +133,6 @@
 		var/datum/gas_mixture/removed = pumping.remove(transfer_moles)
 
 		loc.assume_air(removed)
-
-	flavor_examine(4)
 
 //Controls how fast gas comes out (in total)
 /obj/machinery/atmospherics/miner/proc/AirRate()

--- a/code/game/machinery/atmoalter/gas_mine.dm
+++ b/code/game/machinery/atmoalter/gas_mine.dm
@@ -20,6 +20,8 @@
 
 	machine_flags = WRENCHMOVE | FIXED2WORK
 
+	var/examine_flavor = "Operating normally"
+
 /obj/machinery/atmospherics/miner/New()
 	..()
 	air_contents = new
@@ -29,6 +31,21 @@
 	AddAir()
 	air_contents.update_values()
 	update_icon()
+
+/obj/machinery/atmospherics/miner/proc/flavor_examine(num)
+	switch(num)
+		if(1)
+			examine_flavor = "Lack of power"
+		if(2)
+			examine_flavor = "Turned off"
+		if(3)
+			examine_flavor = "Broken"
+		if(4)
+			examine_flavor = "Operating normally"
+
+/obj/machinery/atmospherics/miner/examine(mob/user)
+	. = ..()
+	to_chat(user, "<span class='info'>\The [src]'s debug reads: [examine_flavor].</span>")
 
 /obj/machinery/atmospherics/miner/wrenchAnchor(var/mob/user, var/obj/item/I)
 	. = ..()
@@ -87,8 +104,10 @@
 
 /obj/machinery/atmospherics/miner/process()
 	if(stat & NOPOWER)
+		flavor_examine(1)
 		return
 	if (!on)
+		flavor_examine(2)
 		return
 
 	var/oldstat=stat
@@ -99,6 +118,7 @@
 	if(stat!=oldstat)
 		update_icon()
 	if(stat & BROKEN)
+		flavor_examine(3)
 		return
 
 	var/datum/gas_mixture/environment = loc.return_air()
@@ -121,6 +141,7 @@
 
 		loc.assume_air(removed)
 
+	flavor_examine(4)
 
 //Controls how fast gas comes out (in total)
 /obj/machinery/atmospherics/miner/proc/AirRate()


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
closes: #27985
easy fix they said, well maybe I don't want an easy fix and make it better!
:cl:
 * rscadd: Gas miners will now tell you their operating state when examined. No power? On? Broken? the miner will tell you