### PR TITLE
Better Tree Transparency

### DIFF
--- a/code/_hooks/events.dm
+++ b/code/_hooks/events.dm
@@ -176,6 +176,20 @@
 // atom/item: the item
 /lazy_event/on_unequipped
 
+//Called when movable moves into a new turf
+// Arguments:
+// atom/movable/mover: thing that moved
+// location: turf it entered
+// oldloc: atom it exited
+/lazy_event/on_entered
+
+//Called when movable moves from a turf
+// Arguments:
+// atom/movable/mover: thing that moved
+// location: turf it exited
+// newloc: atom it is entering
+/lazy_event/on_exited
+
 
 /datum
 	/// Associative list of type path -> list(),

--- a/code/game/objects/structures/flora/flora.dm
+++ b/code/game/objects/structures/flora/flora.dm
@@ -84,6 +84,7 @@
 	var/const/randomize_on_creation = 1
 	var/const/log_type = /obj/item/weapon/grown/log/tree
 	var/holo = FALSE
+	var/image/transparent
 
 /obj/structure/flora/tree/New()
 	..()
@@ -109,6 +110,42 @@
 	var/rangevalue = 0.1 //Range over which the values spread. We don't want it to collide with "true" layer differences
 
 	layer += rangevalue * (1 - (y + 0.5 * (x & 1)) / world.maxy)
+
+	update_transparency()
+
+	for(var/turf/T in range(2,src))
+		T.lazy_register_event(/lazy_event/on_entered, src, .proc/give_transparency)
+		T.lazy_register_event(/lazy_event/on_exited, src, .proc/remove_transparency)
+
+
+/obj/structure/flora/tree/Destroy()
+	for(var/turf/T in range(2,src))
+		T.lazy_unregister_event(/lazy_event/on_entered, src, .proc/give_transparency)
+		T.lazy_register_event(/lazy_event/on_exited, src, .proc/remove_transparency)
+	..()
+
+/obj/structure/flora/tree/proc/update_transparency()
+	transparent = image(icon,src,icon_state)
+	transparent.color = "[color ? color : "#FFFFFF"]"+"7F"
+	transparent.override = TRUE
+
+/obj/structure/flora/tree/proc/give_transparency(mover, location, oldloc)
+	if(!ismob(mover))
+		return
+	var/mob/M = mover
+	if(!M.client)
+		return
+	var/client/C = M.client
+	C.images += transparent
+
+/obj/structure/flora/tree/proc/remove_transparency(mover, location, newloc)
+	if(!ismob(mover))
+		return
+	var/mob/M = mover
+	if(!M.client)
+		return
+	var/client/C = M.client
+	C.images -= transparent
 
 /obj/structure/flora/tree/examine(mob/user)
 	.=..()
@@ -191,6 +228,7 @@
 /obj/structure/flora/tree/pine/New()
 	..()
 	icon_state = "pine_[rand(1, 3)]"
+	update_transparency()
 
 /obj/structure/flora/tree/pine/xmas
 	name = "xmas tree"
@@ -203,6 +241,8 @@
 /obj/structure/flora/tree/pine/xmas/New()
 	..()
 	icon_state = "pine_c"
+	update_transparency()
+
 
 /obj/structure/flora/tree/dead
 	name = "dead tree"
@@ -215,6 +255,7 @@
 /obj/structure/flora/tree/dead/New()
 	..()
 	icon_state = "tree_[rand(1, 6)]"
+	update_transparency()
 
 /obj/structure/flora/tree_stump
 	name = "tree stump"

--- a/code/game/objects/structures/flora/flora.dm
+++ b/code/game/objects/structures/flora/flora.dm
@@ -123,7 +123,7 @@
 	for(var/turf/T in circlerange(src,2))
 		if(T.y > y)
 			T.lazy_unregister_event(/lazy_event/on_entered, src, .proc/give_transparency)
-			T.lazy_register_event(/lazy_event/on_exited, src, .proc/remove_transparency)
+			T.lazy_unregister_event(/lazy_event/on_exited, src, .proc/remove_transparency)
 	..()
 
 /obj/structure/flora/tree/proc/update_transparency()

--- a/code/game/objects/structures/flora/flora.dm
+++ b/code/game/objects/structures/flora/flora.dm
@@ -113,15 +113,17 @@
 
 	update_transparency()
 
-	for(var/turf/T in range(2,src))
-		T.lazy_register_event(/lazy_event/on_entered, src, .proc/give_transparency)
-		T.lazy_register_event(/lazy_event/on_exited, src, .proc/remove_transparency)
+	for(var/turf/T in circlerange(src,2))
+		if(T.y > y)
+			T.lazy_register_event(/lazy_event/on_entered, src, .proc/give_transparency)
+			T.lazy_register_event(/lazy_event/on_exited, src, .proc/remove_transparency)
 
 
 /obj/structure/flora/tree/Destroy()
-	for(var/turf/T in range(2,src))
-		T.lazy_unregister_event(/lazy_event/on_entered, src, .proc/give_transparency)
-		T.lazy_register_event(/lazy_event/on_exited, src, .proc/remove_transparency)
+	for(var/turf/T in circlerange(src,2))
+		if(T.y > y)
+			T.lazy_unregister_event(/lazy_event/on_entered, src, .proc/give_transparency)
+			T.lazy_register_event(/lazy_event/on_exited, src, .proc/remove_transparency)
 	..()
 
 /obj/structure/flora/tree/proc/update_transparency()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -120,6 +120,10 @@
 				return 0
 	return 1
 
+/turf/Exited(atom/movable/mover, atom/newloc)
+	..()
+	lazy_invoke_event(/lazy_event/on_exited, list("mover" = mover, "location" = src, "newloc" = newloc))
+
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
 	if (!mover)
 		return 1
@@ -155,7 +159,7 @@
 	return 1 //Nothing found to block so return success!
 
 
-/turf/Entered(atom/movable/A as mob|obj)
+/turf/Entered(atom/movable/A as mob|obj, atom/OldLoc)
 	if(movement_disabled)
 		to_chat(usr, "<span class='warning'>Movement is admin-disabled.</span>")//This is to identify lag problems
 		return
@@ -168,6 +172,7 @@
 		A.inertia_dir = 0
 
 	..()
+	lazy_invoke_event(/lazy_event/on_entered, list("mover" = A, "location" = src, "oldloc" = OldLoc))
 	var/objects = 0
 	if(A && A.flags & PROXMOVE)
 		for(var/atom/Obj in range(1, src))


### PR DESCRIPTION
This PR has a few advantages over #28289

* You can see behind trees from 2 tiles away in any direction
* No invisible object that appears when you right click
* Expands our event system
* You can hide yourself or an item behind a tree until someone gets fairly close to the tree


🆑 
* rscadd: Trees (such as those on Snaxi) become transparent when you are within 2 tiles