### PR TITLE
Reduce Blizzards

### DIFF
--- a/code/datums/climate.dm
+++ b/code/datums/climate.dm
@@ -200,7 +200,7 @@ var/list/snowstorm_ambience_volumes = list(30,40,60,80)
 /datum/weather/snow/blizzard
 	name = "<font color='red'>blizzard</font>"
 	snow_intensity = SNOW_BLIZZARD
-	next_weather = list(/datum/weather/snow/heavy = 50, /datum/weather/snow/blizzard = 50)
+	next_weather = list(/datum/weather/snow/heavy = 65, /datum/weather/snow/blizzard = 35)
 	tile_interval = 3
 	snowfall_prob = 12
 	snowfall_rate = list(3,20)

--- a/code/modules/events/blizzard.dm
+++ b/code/modules/events/blizzard.dm
@@ -21,7 +21,7 @@ var/blizzard_cooldown = 5 MINUTES
 	oneShot = 1
 
 /datum/event/omega_blizzard/can_start()
-	return 3 * istype(map.climate,/datum/climate/arctic)
+	return 0
 
 /datum/event/omega_blizzard/start() //Oh god oh fuck
 	if(blizzard_ready)


### PR DESCRIPTION
To explain what this does, I first need to briefly explain how climates work. On Snaxi, the climate always starts as calm weather. Each weather has a chance to stay the same or change into a different type.

> Calm: 60% no change, 40% light
> Light: 25% calm, 55% no change, 20% heavy
> Heavy: 30% light, 60% no change, 10% blizzard
> Blizzard: 50% heavy, 50% no change

As you can see, the weather cannot simply skip to blizzard (except in the random event). It has to climb up to heavy and then pass the 10% chance to evolve to blizzard. This PR does 2 things.

* Changes blizzard to 65% heavy, 35% no change. The effect of this is shorter blizzards on average.
* Moves Dark Season (Omega Blizzard) to adminbus only. It's a 2-hour blizzard with extra snowfall. This was a very rare (3 weight, compared to some events that have 50 to 100 weight) event on Snaxi only.

:cl:
* tweak: Blizzards should be shorter on average.
* rscdel: Dark Season / Omega Blizzard is now adminbus only.