### PR TITLE
Teleport Not Wearing Tinfoil

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -233,7 +233,4 @@
 				MM.visible_message("<span class='danger'>\The [teleatom] bounces off the portal!</span>", "<span class='warning'>You're unable to go to that destination!</span>")
 				return FALSE
 
-	if(!isemptylist(recursive_type_check(teleatom, /obj/item/clothing/head/tinfoil)))
-		return FALSE
-
 	return TRUE


### PR DESCRIPTION
fixes #22317
holiday fix 7

🆑 
* bugfix: Fixed a bug where you couldn't be teleported when a tinfoil hat was anywhere on your person, not just on your head.