### PR TITLE
Supermatter Consume() tweaks

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -435,28 +435,23 @@
 				new /obj/machinery/power/supermatter(T)
 
 
-/obj/machinery/power/supermatter/proc/Consume(var/mob/living/user)
-	if(istype(user))
-		. = user.supermatter_act(src, SUPERMATTER_DUST)
-		if(istype(user,/mob/living/simple_animal/mouse)) //>implying mice are going to follow the rules
-			return
+/obj/machinery/power/supermatter/proc/Consume(atom/A)
+	if(isliving(A))
+		. = A.supermatter_act(src, SUPERMATTER_DUST)
+		if(ismouse(A)) //>implying mice are going to follow the rules
+			return .
 		power += 200
-	else if(istype(user, /atom))
-		var/atom/A = user
+	else
 		. = A.supermatter_act(src, SUPERMATTER_DELETE)
 
 	power += 200
 
-		//Some poor sod got eaten, go ahead and irradiate people nearby.
-	for(var/mob/living/l in range(10,src))
-		if(l in view())
-			l.show_message("<span class=\"warning\">As \the [src] slowly stops resonating, you find your skin covered in new radiation burns.</span>", 1,\
-				"<span class=\"warning\">The unearthly ringing subsides and you notice you have new radiation burns.</span>", 2)
-		else
-			l.show_message("<span class=\"warning\">You hear an uneartly ringing and notice your skin is covered in fresh radiation burns.</span>", 2)
+	for(var/mob/living/l in range(10,src)) //Some poor sod got eaten, go ahead and irradiate people nearby.
+		if(l == A) //It's the guy that just died.
+			continue
 		var/rads = 75 * sqrt( 1 / (get_dist(l, src) + 1) )
-		l.apply_radiation(rads, RAD_EXTERNAL) // Permit blocking
-
+		if(l.apply_radiation(rads, RAD_EXTERNAL))
+			visible_message("<span class=\"warning\">As \the [src] slowly stops resonating, you find yourself covered in fresh radiation burns.</span>", "<span class=\"warning\">The unearthly ringing subsides and you notice you have fresh radiation burns.</span>")
 
 /obj/machinery/power/supermatter/blob_act()
 	explode()


### PR DESCRIPTION
Tweaked Consume() a little to fix two(three?) little issues:

* The burn message will only appear if you actually got irradiated by apply_radiation()
* The guy that just touched supermatter also won't get it, since he already got the 'oh fuck' one and his body is well, gone.
* If a mice is being consumed, actually supermatter_act() it (This still won't make mice able to bump supermatter by themselves, another thing prevents it.)

closes: #28367

:cl:
 * tweak: Cyborgs and mobs that are immune to radiation shouldn't get their 'skin' burned anymore.