### PR TITLE
Get Unique Job

### DIFF
--- a/__DEFINES/preferences.dm
+++ b/__DEFINES/preferences.dm
@@ -2,6 +2,7 @@
 #define GET_RANDOM_JOB 0
 #define BE_ASSISTANT 1
 #define RETURN_TO_LOBBY 2
+#define GET_EMPTY_JOB 3
 
 // /datum/preferences/var/special_popup
 #define SPECIAL_POPUP_DISABLED 0 // only output to chat

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -269,6 +269,8 @@ var/global/datum/controller/occupations/job_master
 
 		// Loop through all unassigned players
 		for(var/mob/new_player/player in unassigned)
+			if(player.client.prefs.alternate_option == GET_EMPTY_JOB)
+				continue //This player doesn't want to share a job title. We need to deal with them last.
 
 			// Loop through all jobs
 			for(var/datum/job/job in shuffledoccupations)
@@ -282,23 +284,6 @@ var/global/datum/controller/occupations/job_master
 	for(var/mob/new_player/player in unassigned)
 		if(player.client.prefs.alternate_option == GET_RANDOM_JOB)
 			GiveRandomJob(player)
-	/*
-	Old job system
-	for(var/level = 1 to 3)
-		for(var/datum/job/job in occupations)
-			Debug("Checking job: [job]")
-			if(!job)
-				continue
-			if(!unassigned.len)
-				break
-			if((job.current_positions >= job.spawn_positions) && job.spawn_positions != -1)
-				continue
-			var/list/candidates = FindOccupationCandidates(job, level)
-			while(candidates.len && ((job.current_positions < job.spawn_positions) || job.spawn_positions == -1))
-				var/mob/new_player/candidate = pick(candidates)
-				Debug("Selcted: [candidate], for: [job.title]")
-				AssignRole(candidate, job.title)
-				candidates -= candidate*/
 
 	Debug("DO, Standard Check end")
 
@@ -344,9 +329,18 @@ var/global/datum/controller/occupations/job_master
 				UnassignRole(player)
 				AssignRole(player, "Assistant")
 
-	//For ones returning to lobby
-	for(var/mob/new_player/player in unassigned)
-		if(player.client.prefs.alternate_option == RETURN_TO_LOBBY)
+	//Final pass - first deal with the empty job group, otherwise send any leftovers to the lobby
+	final_pass: //this is a loop label
+		for(var/mob/new_player/player in unassigned)
+			if(player.client.prefs.alternate_option == GET_EMPTY_JOB)
+				for(var/level = 1 to 3)
+					for(var/datum/job/job in shuffledoccupations)
+						if(job.current_positions) //already someone in this job title
+							continue
+						if(TryAssignJob(player,level,job))
+							unassigned -= player
+							continue final_pass //move on to the next player entirely
+
 			to_chat(player, "<span class='danger'>You have been returned to lobby due to your job preferences being filled.")
 			player.ready = 0
 			unassigned -= player

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -624,6 +624,8 @@ var/const/MAX_SAVE_SLOTS = 16
 	HTML += {"</td'></tr></table>
 		</center></table>"}
 	switch(alternate_option)
+		if(GET_EMPTY_JOB)
+			HTML += "<center><br><a href='?_src_=prefs;preference=job;task=random'>Get unique job</a></center><br>"
 		if(GET_RANDOM_JOB)
 			HTML += "<center><br><a href='?_src_=prefs;preference=job;task=random'>Get random job if preferences unavailable</a></center><br>"
 		if(BE_ASSISTANT)
@@ -1025,9 +1027,9 @@ NOTE:  The change will take effect AFTER any current recruiting periods."}
 				ResetJobs()
 				SetChoices(user)
 			if("random")
-				if(alternate_option == GET_RANDOM_JOB || alternate_option == BE_ASSISTANT)
+				if(alternate_option == GET_RANDOM_JOB || alternate_option == BE_ASSISTANT || alternate_option == RETURN_TO_LOBBY)
 					alternate_option += 1
-				else if(alternate_option == RETURN_TO_LOBBY)
+				else if(alternate_option == GET_EMPTY_JOB)
 					alternate_option = 0
 				else
 					return 0


### PR DESCRIPTION
🆑 
* rscadd: Players may now use the "Get unique job" preference. This means it will not assign you to any job where someone else shares the same job slot. For example, if you high-pref botanist and there is already a botanist, it will try your medium preferences. If none of your preferences are empty, you will return to the lobby.