### PR TITLE
Labor Close Slot

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -75,6 +75,9 @@
 /datum/job/proc/bump_position_limit()
 	xtra_positions++
 
+/datum/job/proc/remove_xtra_position()
+	xtra_positions--
+
 /datum/job/proc/reject_new_slots()
 	return FALSE
 

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -112,6 +112,18 @@ var/global/datum/controller/occupations/job_master
 		return 1
 	return 0
 
+/datum/controller/occupations/proc/CloseRole(var/rank, mob/user)	//eliminating xtra_positions
+	var/datum/job/job = GetJob(rank)
+	if(job && job.current_positions < job.get_total_positions() && job.xtra_positions > 0)
+		job.remove_xtra_position()
+		if(user)
+			log_admin("[key_name(user)] has closed a slot for the [rank] job.")
+			message_admins("[key_name_admin(user)] has closed a slot for the [rank] job.")
+		for(var/mob/new_player/player in player_list)
+			to_chat(player, "<span class='notice'>The [rank] job is now closed.</span>")
+		return 1
+	return 0
+
 /datum/controller/occupations/proc/CheckPriorityFulfilled(var/rank)
 	var/datum/job/job = GetJob(rank)
 	if(job.current_positions >= job.get_total_positions() && job.priority)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9782036/102342410-cdf82700-3f5e-11eb-92c8-147be564c36e.png)

closes #21787

:cl:
* rscadd: The labor console can now close extra slots if they have not been filled yet.