### PR TITLE
Tradervend RNG Additions

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2635,7 +2635,6 @@ var/global/num_vending_terminals = 1
 	contraband = list(
 		/obj/item/clothing/mask/balaclava = 5,
 		/obj/item/clothing/head/bearpelt = 5,
-		/obj/item/clothing/head/bearpelt/brown = 5,
 		/obj/item/clothing/head/energy_dome = 5,
 		)
 	premium = list(
@@ -2710,7 +2709,6 @@ var/global/num_vending_terminals = 1
 	premium = list(
 		/obj/item/clothing/under/rainbow = 1,
 		/obj/item/clothing/suit/red_suit = 1,
-		/obj/item/clothing/suit/storage/wintercoat/fur = 1,
 		)
 
 	pack = /obj/structure/vendomatpack/suitdispenser
@@ -3140,6 +3138,13 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/fakeposter_kit = 1,
 		/obj/structure/closet/crate/flatpack/ancient/condiment_dispenser = 1,
 		/obj/structure/closet/crate/flatpack/ancient/chemmaster_electrolyzer = 1,
+		/obj/item/weapon/storage/box/mysterycubes = 2,
+		/obj/item/weapon/storage/box/mystery_vial = 5,
+		/obj/item/weapon/storage/box/mystery_circuit = 1,
+		/obj/item/weapon/storage/box/large/mystery_material = 5,
+		/obj/item/weapon/storage/box/large/mystery_material/odd = 5,
+		/obj/structure/closet/crate/freezer/bootlegpicnic = 3,
+		/obj/structure/vendomatpack/trader = 1,
 		)
 	prices = list(
 		/obj/item/clothing/suit/storage/trader = 100,
@@ -3179,7 +3184,15 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/fakeposter_kit = 50,
 		/obj/structure/closet/crate/flatpack/ancient/condiment_dispenser = 100,
 		/obj/structure/closet/crate/flatpack/ancient/chemmaster_electrolyzer = 100,
+		/obj/item/weapon/storage/box/mysterycubes = 75,
+		/obj/item/weapon/storage/box/mystery_vial = 25,
+		/obj/item/weapon/storage/box/mystery_circuit = 25,
+		/obj/item/weapon/storage/box/large/mystery_material = 50,
+		/obj/item/weapon/storage/box/large/mystery_material/odd = 25,
+		/obj/structure/closet/crate/freezer/bootlegpicnic = 50,
+		/obj/structure/vendomatpack/trader = 500,
 		)
+	pack = /obj/structure/vendomatpack/trader
 
 /obj/machinery/vending/trader/New()
 	load_dungeon(/datum/map_element/dungeon/mecha_graveyard)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3146,7 +3146,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/storage/box/large/mystery_material = 5,
 		/obj/item/weapon/storage/box/large/mystery_material/odd = 5,
 		/obj/structure/closet/crate/freezer/bootlegpicnic = 3,
-		/obj/structure/vendomatpack/trader = 1,
+		/obj/structure/vendomatpack/trader = 1
 		)
 	prices = list(
 		/obj/item/clothing/suit/storage/trader = 100,
@@ -3192,7 +3192,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/storage/box/large/mystery_material = 50,
 		/obj/item/weapon/storage/box/large/mystery_material/odd = 25,
 		/obj/structure/closet/crate/freezer/bootlegpicnic = 50,
-		/obj/structure/vendomatpack/trader = 500,
+		/obj/structure/vendomatpack/trader = 500
 		)
 	pack = /obj/structure/vendomatpack/trader
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3146,7 +3146,6 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/storage/box/large/mystery_material = 5,
 		/obj/item/weapon/storage/box/large/mystery_material/odd = 5,
 		/obj/structure/closet/crate/freezer/bootlegpicnic = 3,
-		/obj/structure/vendomatpack/trader = 1
 		)
 	prices = list(
 		/obj/item/clothing/suit/storage/trader = 100,
@@ -3192,7 +3191,6 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/storage/box/large/mystery_material = 50,
 		/obj/item/weapon/storage/box/large/mystery_material/odd = 25,
 		/obj/structure/closet/crate/freezer/bootlegpicnic = 50,
-		/obj/structure/vendomatpack/trader = 500
 		)
 	pack = /obj/structure/vendomatpack/trader
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2635,6 +2635,7 @@ var/global/num_vending_terminals = 1
 	contraband = list(
 		/obj/item/clothing/mask/balaclava = 5,
 		/obj/item/clothing/head/bearpelt = 5,
+		/obj/item/clothing/head/bearpelt/brown = 5,
 		/obj/item/clothing/head/energy_dome = 5,
 		)
 	premium = list(
@@ -2709,6 +2710,7 @@ var/global/num_vending_terminals = 1
 	premium = list(
 		/obj/item/clothing/under/rainbow = 1,
 		/obj/item/clothing/suit/red_suit = 1,
+		/obj/item/clothing/suit/storage/wintercoat/fur = 1,
 		)
 
 	pack = /obj/structure/vendomatpack/suitdispenser


### PR DESCRIPTION
This PR adds my RNG based items to the tradervend. I made these a bit ago then took a break before making this PR, for information on the actual items this adds look here:
https://github.com/vgstation-coders/vgstation13/pull/28049

Here's the prices:
Mob cubes - 75 credits, 2 in stock
Mystery chems - 25 credits, 5 in stock
Mystery circuits - 25 credits, 1 in stock
Mystery material box - 50 credits, 5 in stock
Odd mystery material box - 25 credits, 5 in stock
Mystery food box - 50 credits, 3 in stock
Tradervend restock - 500 credits, 1 in stock

This PR doesn't remove Mechanic's ability to scan the vendor. Bit unatomic to do that all at once. Once this is merged I'll put up another PR.

:cl:
 * rscadd: The tradervend now has access to several lootboxes, sponsored by EA. It's in the game.