### PR TITLE
Geyser Spawn Tweak

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -1919,6 +1919,13 @@ proc/process_adminbus_teleport_locs()
 	name = "\improper Planet Surface"
 	icon_state = "sno2"
 
+/area/surface/snow/make_geyser(turf/T)
+	switch (rand(99))
+		if (0 to 39)
+			new /obj/structure/geyser(T)
+		else
+			new /obj/structure/geyser/vent(T)
+
 /area/surface/blizzard
 	name = "The Blizzard"
 	icon_state = "sno"
@@ -1932,6 +1939,15 @@ proc/process_adminbus_teleport_locs()
 	name = "\improper Junk Yard"
 	icon_state = "disposal"
 	construction_zone = FALSE
+
+/area/surface/forest/make_geyser(turf/T)
+	switch (rand(99))
+		if (0 to 59)
+			new /obj/structure/geyser(T)
+		if (60 to 79)
+			new /obj/structure/geyser/unstable(T)
+		else
+			new /obj/structure/geyser/vent(T)
 
 /area/surface/forest/deer
 	name = "\improper Enclosed Forest"
@@ -1953,6 +1969,15 @@ proc/process_adminbus_teleport_locs()
 /area/surface/mine
 	name = "\improper Surface Mine"
 	icon_state = "mine"
+
+/area/surface/outer/make_geyser(turf/T)
+	switch (rand(99))
+		if (0 to 39)
+			new /obj/structure/geyser(T)
+		if (40 to 79)
+			new /obj/structure/geyser/unstable(T)
+		else
+			new /obj/structure/geyser/critical(T)
 
 /area/surface/outer/nw
 	name = "\improper Northwest Reaches"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -752,3 +752,6 @@ var/list/transparent_icons = list("diagonalWall3","swall_f5","swall_f6","swall_f
 
 	for(var/obj/machinery/door/D in doors)
 		D.update_nearby_tiles()
+
+/area/proc/make_geyser(turf/T)
+	return

--- a/maps/snaxi.dm
+++ b/maps/snaxi.dm
@@ -137,31 +137,21 @@
 			CHECK_TICK
 
 /proc/gaussian_geyser(var/x, var/y)
-	var/turf/T = locate(x, y, 1)
-	if (!istype(T,/turf/unsimulated/floor/snow/))
-		return
-	if (locate(/obj/structure/snow_flora/tree/pine) in T)
-		return
-	if (istype(T, /turf/unsimulated/floor/snow/asphalt))
-		return
 	if (prob(30))
 		return
 	var/dx = round(16*GaussRand(1))
 	var/dy = round(16*GaussRand(1))
-	var/turf/T2 = locate(x + dx, y + dy, 1)
-	if (!istype(T2,/turf/unsimulated/floor/snow/))
+	var/turf/T = locate(x + dx, y + dy, 1)
+	if (!istype(T,/turf/unsimulated/floor/snow/))
 		return
-	if (istype(T2, /turf/unsimulated/floor/snow/asphalt))
+	if (istype(T, /turf/unsimulated/floor/snow/asphalt))
 		return
-	if (locate(/obj/structure/snow_flora/tree/pine) in T2)
+	if (locate(/obj/structure/snow_flora/tree/pine) in T)
 		return
-	switch (rand(100))
-		if (0 to 60)
-			new /obj/structure/geyser(T2)
-		if (60 to 80)
-			new /obj/structure/geyser/unstable(T2)
-		else
-			new /obj/structure/geyser/vent(T2)
+	if (locate(/obj/glacier) in T)
+		return
+	var/area/A = get_area(T)
+	A.make_geyser(T)
 
 /datum/map/active/map_ruleset(var/datum/dynamic_ruleset/DR)
 	if(ispath(DR.role_category,/datum/role/blob_overmind))


### PR DESCRIPTION
"Forest" regions have the old geyser spawn rates (60% normal, 20% vent, 20% unstable).
The central area around the main roads will now be 60% vents and 40% normal geysers with no unstables.
Outer reaches will be 40% normal, 40% unstable, 20% critical. (Geyser spawns here are very rare due to @ShiftyRail 's Gauss pattern)
No more geysers on the glacier.

* For those not familiar with technical terms: vents don't make smoke and don't put out as much heat or melt snow. Geysers make the most smoke and heat you faster. Unstable geysers can very quickly heat you to dangerous temperatures, quickly melt snow, and their smoke is less common but extra spicy. Critical geysers don't smoke but put out very dangerous amounts of heat.

🆑 
* tweak: Geysers very close to the center path on Snaxi will generally be safer.