### PR TITLE
Fixes mugs becoming breakable when filled with certain reagents

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
@@ -123,9 +123,8 @@
 
 		var/datum/reagent/R = reagents.get_master_reagent()
 
-		name = R.mug_name ? R.mug_name : "\improper [R.name]"
+		name = R.mug_name ? R.mug_name : "mug of " + R.name
 		desc = R.mug_desc ? R.mug_desc : R.description
-		isGlass = R.glass_isGlass
 
 		if(R.mug_icon_state)
 			icon_state = R.mug_icon_state


### PR DESCRIPTION
[bugfix] also changes the formatting of naming for reagents without a specific name in a mug from "[reagent name]" to "mug of [reagent name]".

closes #28417 

🆑 
 - bugfix: Mugs no longer become breakable when filled with certain reagents.