### PR TITLE
revert air rebuild change

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -375,7 +375,7 @@
 
 	//Rebuild turf
 	var/turf/T = src
-	env = T.return_air() //Better than just getting the air var because this factors in unsimmed turfs
+	env = T.air //Get the air before the change
 	if(istype(src,/turf/simulated))
 		var/turf/simulated/S = src
 		if(S.zone)


### PR DESCRIPTION
i suspect this fixes the problem of having air issues with airlocks, specifically with shuttles.
Because you can't trust a door to tell you which room it is in.
HYPOTHESIS; using return_air instead of using the turf's .air will usually just get you the zone.air, causing airlocks to set their turf to zone.air whenever they are opened. i believe this is where the problem lies, as airlock turfs have to choose between two zones, as they are situated in the wall.

this PR reverts to just using the turf's previous .air for rebuilding turfs.

:cl:
 * tweak: reverted change to turf air rebuilding