### PR TITLE
Makes the CI not even try to run on pushes that only change the changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
   # Triggers the workflow on push or pull request events but only for the Bleeding-Edge branch
   push:
     branches: [ Bleeding-Edge ]
+    paths-ignore:
+    - 'html/changelogs/**'
   pull_request:
     branches: [ Bleeding-Edge ]
 


### PR DESCRIPTION
Pretty much just to reduce clutter in the actions tab. The `[ci skip]` method is left in as well, just in case.