### PR TITLE
Faster sign function

### DIFF
--- a/code/__HELPERS/maths.dm
+++ b/code/__HELPERS/maths.dm
@@ -28,13 +28,8 @@ var/list/sqrtTable = list(1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 
 /proc/Ceiling(x, y = 1)
 	. = -round(-x / y) * y
 
-/proc/sgn(const/i)
-	if(i > 0)
-		return 1
-	else if(i < 0)
-		return -1
-	else
-		return 0
+// Returns the sign of the given number (1 or -1)
+#define sgn(x) ((x) != 0 ? (x) / abs(x) : 0)
 
 // -- Returns a Lorentz-distributed number.
 // -- The probability density function has centre x0 and width s.


### PR DESCRIPTION
Uses a define, less logic

Couldn't see any labels that were applicable to this, it's just a performance tweak.


![image](https://user-images.githubusercontent.com/4741640/103488338-ed99a700-4dc8-11eb-89e5-d34d7d128cfc.png)

<details>
<summary>Performance test code:</summary>

	var/list/my_list = list()

	#define sign(x) ((x) != 0 ? (x) / abs(x) : 0)

	/proc/sgn(const/i)
		if(i > 0)
			return 1
		else if(i < 0)
			return -1
		else
			return 0

	/proc/main()
		set background = 1
		var/t1
		var/t2
		
		var/const/loops = 50000

		var/time1 = world.timeofday 
		for(var/i in 1 to loops)
			one()
		t1 = world.timeofday-time1
		world.log << "faster: [t1]"

		var/time2 = world.timeofday
		for(var/i in 1 to loops)
			two()
		t2 = world.timeofday-time2
		world.log << "vg: [t2]"
		
		world.log << "t1/t2 = [t1/t2]"
	   
	/proc/one()
		for (var/x in 1 to 200)
			my_list["[x]"] = sign(x)

	/proc/two()
		for (var/x in 1 to 200)
			my_list["[x]"] = sgn(x)
</details>