### PR TITLE
The round-end score will no longer keep track of infected NPCs

### DIFF
--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -80,6 +80,8 @@
 						score["disease_good"]++
 		else
 			for (var/mob/living/L in mob_list)
+				if(!L.mind) //No ballooning the negative score with infected monkeymen
+					continue
 				if (ID in L.virus2)
 					disease_spread_count++
 					if (L.stat != DEAD)
@@ -360,7 +362,7 @@
 	//Bad Things
 	score["crewscore"] -= deathpoints
 
-	var/multi = find_active_faction_by_type(/datum/faction/malf) ? 1 : -1 //Dead silicons on malf are good	
+	var/multi = find_active_faction_by_type(/datum/faction/malf) ? 1 : -1 //Dead silicons on malf are good
 	score["crewscore"] += (siliconpoints*multi)
 	if(score["deadaipenalty"])
 		score["crewscore"] += (1000*multi) //Give a harsh punishment for killing the AI


### PR DESCRIPTION
It turns out this was used to force Lamprey, so I came out of the retirement home to fix it
Not even sure if this is the right way to do it, forgot how mind works, so I'm going to need a collab to check it, but in theory it should prevent things like monkeys from counting towards the negative score, because as it turns out if you gave a monkey 15 strains of AIDS all of the strains would get counted and that monkey alone would slap the score with -750 to the score, and since you can easily make a ton of monkeys with both the virology monkeys and monkey cubes and most viruses spread by themselves just 10 monkeys like this could statistically turn a perfectly fine station into a hellhole with -7500 score, even if it's still perfectly fine.
I'm still asking for a collab review because I don't know if it will count dead players, since dead players are ghosts

:cl:
 * rscdel: Entities that aren't possessed by a player will no longer count towards the station's infected members score, previously it was used in an exploit to make the station's score incredibly low, which would allow Lamprey to be selected