### PR TITLE
Snaxi Dock Changes

### DIFF
--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2669,7 +2669,7 @@
 #include "maprendering\maprendering.dm"
 #include "maps\_map.dm"
 #include "maps\_map_override.dm"
-#include "maps\tgstation.dm"
+#include "maps\snaxi.dm"
 #include "maps\defficiency\areas.dm"
 #include "maps\lampreystation\lamprey.dm"
 #include "maps\packedstation\telecomms.dm"


### PR DESCRIPTION
A very small mapping PR for snaxi before Kharkov does his brig rework. Small features
* Added a missing door button on the trader outpost
* Replaced unsimulated tiles that would drain the trade shuttle every time you boarded from the trade dock side
* Re-positioned walls near the surface dock for trade shuttle so you can actually see out the windows
* Instead of 2 normal space heaters on the trader side, trade shuttle gets 1 vesta heater on the customer/exit door side.
* Added docking lights for trade shuttle
* Removed the access to the lower door on the south station taxi shuttle, meaning you can exit from both sides when docking at south station now and shortcut to the autolathe room.
* Added airless plating under the taxi shuttles at the space port, hopefully giving people more control if ZAS'd

closes https://github.com/vgstation-coders/vgstation13/issues/28461

:cl:
* tweak: Improved Snaxi shuttles. Of particular interest, you can now exit the taxi on both sides when docked at south station.