### PR TITLE
Gives heads of staff ability to demote independently

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -29,6 +29,7 @@
 
 /obj/structure/closet/secure_closet/quartermaster/atoms_to_spawn()
 	return list(
+		/obj/item/weapon/paper/demotion_key,
 		/obj/item/clothing/under/rank/cargo,
 		/obj/item/clothing/shoes/brown,
 		/obj/item/device/radio/headset/headset_cargo,

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -16,6 +16,7 @@
 			/obj/item/weapon/storage/backpack/messenger/engi,
 			),
 		/obj/item/blueprints/primary,
+		/obj/item/weapon/paper/demotion_key,
 		/obj/item/clothing/under/rank/chief_engineer,
 		/obj/item/clothing/head/hardhat/white,
 		/obj/item/clothing/head/welding,

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -109,6 +109,7 @@
 			/obj/item/weapon/storage/backpack/medic,
 			/obj/item/weapon/storage/backpack/satchel_med,
 			/obj/item/weapon/storage/backpack/messenger/med),
+		/obj/item/weapon/paper/demotion_key,
 		/obj/item/clothing/head/bio_hood/cmo,
 		/obj/item/clothing/suit/bio_suit/cmo,
 		/obj/item/clothing/shoes/white,

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -35,6 +35,7 @@
 
 /obj/structure/closet/secure_closet/RD/atoms_to_spawn()
 	return list(
+		/obj/item/weapon/paper/demotion_key,
 		/obj/item/clothing/head/bio_hood/scientist,
 		/obj/item/clothing/suit/bio_suit/scientist,
 		/obj/item/clothing/under/rank/research_director,

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -109,6 +109,7 @@
 		pick(
 			/obj/item/clothing/suit/armor/hos/jensen,
 			/obj/item/clothing/suit/armor/hos/sundowner),
+		/obj/item/weapon/paper/demotion_key,
 		/obj/item/clothing/suit/armor/hos,
 		/obj/item/clothing/head/HoS/dermal,
 		/obj/item/weapon/cartridge/hos,


### PR DESCRIPTION
This tweak will now spawn demotion chips in departmental heads of staff lockers. 

Of course, the biggest downside to this is that this weakens the IAA even more than it already is. It is not lost on anyone that the current state of IAA is sad.  If that wasnt enough, most demotions are carried out through the ID console by command, either because IAA is absent, dead, or forgotten. What the IAA needs is an overhaul, and sadly, I don't think keeping the demotion chip an IAA exclusive item is going to help.

The upsides of this is that enabling heads of staff to operate their departments with more freedom and independence may make these roles more attractive to play. This will give heads of staff more ability to act on insubordination and general retardation of their colleagues without having to hack into captains room to get the spare or beg their fellow heads for access to the ID console (especially nice for low-mid pop head players). This change would also give heads of staff some much needed legitimacy to their role. CMO should not be a doctor with a tricky pen and a blue coat, he should be your boss.

<Tweak>

:cl:
 * rscadd: Demotion chips now spawn in departmental heads of staff lockers!
