### PR TITLE
remove red "armband" from player preview icons

### DIFF
--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -206,13 +206,16 @@
 	preview_icon = new /icon(icobase, "torso_[g][fat]")
 	preview_icon.Blend(new /icon(icobase, "groin_[g]"), ICON_OVERLAY)
 	preview_icon.Blend(new /icon(icobase, "head_[g]"), ICON_OVERLAY)
-
-	for(var/name in list(LIMB_LEFT_ARM,LIMB_RIGHT_ARM,LIMB_LEFT_LEG,LIMB_RIGHT_LEG,LIMB_LEFT_FOOT,LIMB_RIGHT_FOOT,LIMB_LEFT_HAND,LIMB_RIGHT_HAND))
+	
+	var/list/limbies = list(LIMB_LEFT_ARM,LIMB_RIGHT_ARM,LIMB_LEFT_LEG,LIMB_RIGHT_LEG,LIMB_LEFT_FOOT,LIMB_RIGHT_FOOT,LIMB_LEFT_HAND,LIMB_RIGHT_HAND)
+	for(var/name in limbies)
 		// make sure the organ is added to the list so it's drawn
 		if(organ_data[name] == null)
 			organ_data[name] = null
 
 	for(var/name in organ_data)
+		if(!(name in limbies)) // will try to overlay internal organs otherwise, leading to fucky behavior.
+			continue
 		if(organ_data[name] == "amputated")
 			continue
 


### PR DESCRIPTION
fixes player preview icon generation so that it no longer tries to draw your internal organs onto your character.
the function draws limbs (external organs) one by one, but it also grabs internal organs, which are last on the list of things to be drawn. since organ names like kidneys are not defined in the icon file, it would pick the first icon_state, being r_arm. r_arm has blood on it in human icons, which is usually hidden by the hand, but since it is drawn after the hand, it'd shows up as a strange little red armband.
This fixes that.

:cl:
 * bugfix: removed the infamous red armband bug from the preferences and ghost preview icon generation.