### PR TITLE
Fixed a bug where you could not build cyborgs if the cyborg jobs did not exist

### DIFF
--- a/code/game/machinery/autoborger.dm
+++ b/code/game/machinery/autoborger.dm
@@ -70,7 +70,7 @@
 		return
 
 	var/datum/job/job_datum = job_master.GetJob("Cyborg")
-	if((job_datum && !job_datum.player_old_enough(H.client)) || jobban_isbanned(H, "Cyborg"))
+	if((job_datum ? !job_datum.player_old_enough(H.client) : 0) || jobban_isbanned(H, "Cyborg"))
 		src.visible_message("<span class='danger'>\The [src.name] throws an exception. Lifeform not compatible with factory.</span>")
 		return
 

--- a/code/game/machinery/autoborger.dm
+++ b/code/game/machinery/autoborger.dm
@@ -70,7 +70,7 @@
 		return
 
 	var/datum/job/job_datum = job_master.GetJob("Cyborg")
-	if(!job_datum.player_old_enough(H.client) || jobban_isbanned(H, "Cyborg"))
+	if((job_datum && !job_datum.player_old_enough(H.client)) || jobban_isbanned(H, "Cyborg"))
 		src.visible_message("<span class='danger'>\The [src.name] throws an exception. Lifeform not compatible with factory.</span>")
 		return
 

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -202,7 +202,7 @@
 				return
 
 			var/datum/job/job_datum = job_master.GetJob("Cyborg")
-			if(job_datum && !job_datum.player_old_enough(M.brainmob.client))
+			if(job_datum ? !job_datum.player_old_enough(M.brainmob.client) : 0)
 				to_chat(user, "<span class='warning'>This [W] is too inexperienced to handle being a cyborg</span>")
 				return
 

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -202,7 +202,7 @@
 				return
 
 			var/datum/job/job_datum = job_master.GetJob("Cyborg")
-			if(!job_datum.player_old_enough(M.brainmob.client))
+			if(job_datum && !job_datum.player_old_enough(M.brainmob.client))
 				to_chat(user, "<span class='warning'>This [W] is too inexperienced to handle being a cyborg</span>")
 				return
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -173,7 +173,8 @@
 	O.forceMove(loc)
 	O.mmi = new /obj/item/device/mmi(O)
 	O.mmi.transfer_identity(src)//Does not transfer key/client.
-	if(jobban_isbanned(O, "Cyborg") || !job_master.GetJob("Cyborg").player_old_enough(O.client)) //You somehow managed to get borged, congrats.
+	var/datum/job/job_datum = job_master.GetJob("Cyborg")
+	if(jobban_isbanned(O, "Cyborg") || (job_datum && !job_datum.player_old_enough(O.client))) //You somehow managed to get borged, congrats.
 		to_chat(src, "<span class='warning' style=\"font-family:Courier\">WARNING: Illegal operation detected.</span>")
 		to_chat(src, "<span class='danger'>Self-destruct mechanism engaged.</span>")
 		O.self_destruct()

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -174,7 +174,7 @@
 	O.mmi = new /obj/item/device/mmi(O)
 	O.mmi.transfer_identity(src)//Does not transfer key/client.
 	var/datum/job/job_datum = job_master.GetJob("Cyborg")
-	if(jobban_isbanned(O, "Cyborg") || (job_datum && !job_datum.player_old_enough(O.client))) //You somehow managed to get borged, congrats.
+	if(jobban_isbanned(O, "Cyborg") || (job_datum ? !job_datum.player_old_enough(O.client) : 0)) //You somehow managed to get borged, congrats.
 		to_chat(src, "<span class='warning' style=\"font-family:Courier\">WARNING: Illegal operation detected.</span>")
 		to_chat(src, "<span class='danger'>Self-destruct mechanism engaged.</span>")
 		O.self_destruct()


### PR DESCRIPTION
Castlestation doesn't have the Cyborg job which the building of checks for, so it would try to check for player age even if the value was null, and since the result was also null it would cause borg building to fail since it returned a 0 value on the "is this player old enough" check
Also for some reason the same age check doesn't exist for AIs
Can I stop being dragged out of the retirement home now
Fixes #28544 

:cl:
 * bugfix: Fixed a bug where you could literally not build cyborgs on Castlestation. Yes, this is a bug, this is not a feature, this is an unintended gameplay element that has been unfortunately cut out of the final product. You may now jeer as the only thing that kept security cyborgs on Castle at bay(station) was this bug, which is now gone, and now so is the fun.