### PR TITLE
Sends a discord killphrase after a round has ended

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -113,7 +113,7 @@
 	var/list/maplist = get_list_of_keys(maps)
 	send2maindiscord("A map vote was initiated with these options: [english_list(maplist)].")
 	send2mainirc("A map vote was initiated with these options: [english_list(maplist)].")
-	send2ickdiscord("round_end_thread_remind") // This the magic kill phrase
+	send2ickdiscord(config.kill_phrase) // This the magic kill phrase
 	vote.allmaps = all_maps
 	return maps
 

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -113,6 +113,7 @@
 	var/list/maplist = get_list_of_keys(maps)
 	send2maindiscord("A map vote was initiated with these options: [english_list(maplist)].")
 	send2mainirc("A map vote was initiated with these options: [english_list(maplist)].")
+	send2ickdiscord("round_end_thread_remind") // This the magic kill phrase
 	vote.allmaps = all_maps
 	return maps
 

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -194,6 +194,7 @@
 	// Discord crap.
 	var/discord_url
 	var/discord_password
+	var/kill_phrase = "All your bases are belong to us."
 
 	// Weighted Votes
 	var/weighted_votes = 0
@@ -617,6 +618,9 @@
 					discord_password = value
 				if("weighted_votes")
 					weighted_votes = TRUE
+
+				if ("kill_phrase")
+					kill_phrase = value
 
 				else
 					diary << "Unknown setting in configuration: '[name]'"

--- a/code/modules/ext_scripts/discord.dm
+++ b/code/modules/ext_scripts/discord.dm
@@ -8,6 +8,9 @@
 /proc/send2admindiscord(var/msg, var/ping = FALSE)
 	send2discord(msg, "adminhelp", ping)
 
+/proc/send2ickdiscord(var/msg, var/ping = FALSE)
+	send2discord(msg, "ick", ping)
+
 // Meta argument here is the MoMMI meta argument to send to the gamenudge route.
 // AKA the MoMMI config file chooses where to send it based on this key.
 /proc/send2discord(var/msg, var/meta, var/ping = FALSE)


### PR DESCRIPTION
## About this PR

With https://github.com/PJB3005/MoMMI/pull/42/files, this, and a small secret-repo change (notably, telling the MoMMi what is the discord identifier to the #ick channel), this will allow the server to send a kill phrase to the discord. 

This kill phrase will lock the #ick channel of the discord (meant for """game discussion""") for a duration of **5** minutes, and post a link to the 4chan thread.
After that time, the channel will be opened again.

## Reasoning for this PR

The idea is to revitalise the 4channel thread by moving post-round discussion here.
The idea of this PR was suggested by Bomber Harris. It is also authorised by Pomf.