### PR TITLE
Removes Miner Maintenance Access

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -82,7 +82,7 @@
 	supervisors = "the quartermaster and the head of personnel"
 	wage_payout = 30
 	selection_color = "#dddddd"
-	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
+	access = list(access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
 	minimal_access = list(access_mining, access_mint, access_mining_station, access_mailsorting)
 	outfit_datum = /datum/outfit/mining
 


### PR DESCRIPTION
Why would a miner need maint access besides validhunting I don't understand
<!-- [gameplay] -->
-->
:cl:
 * tweak: miners no longer have maint access