### PR TITLE
Improves advanced security camera zoom function

### DIFF
--- a/code/modules/html_interface/map/map_shared.js
+++ b/code/modules/html_interface/map/map_shared.js
@@ -263,7 +263,8 @@ function changeZoom(offset){
 	var uiMapWidth = uiMapObject.width() * defaultzoom;
 	var uiMapHeight = uiMapObject.height() * defaultzoom;
 	var ourpos = uiMapObject.position();
-
+	$('.mapIcon16').css({ zoom: 1/(defaultzoom) });
+	
 	uiMapObject.css({
 		zoom: defaultzoom,
 		left: ourpos["left"],


### PR DESCRIPTION
[bugfix] 
[qol] 

Currently the more you zoom in on a security console the harder it becomes to accurately switch to the cameras that you need to. This nifty little fix will allow sec cameras to support zooming in a lot better. Secmains and would be greyshit peeping toms rejoice!

Note that a few of these icons are still skewed off by a few pixels/coordinates, and I encourage someone with more brain cells to tackle that. 

ZOOMED IN UNCLICKABLE CAMERA VIEW BEFORE THIS CHANGE

![unknown](https://user-images.githubusercontent.com/24867955/104231926-9c6b6200-541d-11eb-9bb0-69a30861df82.png)

SEXY NEW ZOOM IN CAMERA VIEW

https://webmshare.com/gLGz3

BIG THANKS to that shitmin Kufrost and Clusterfack for the help

:cl: 
-  bugfix: Advanced Security cameras now scale correctly as you zoom in and out
