### PR TITLE
Fix/rework droppers

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -569,6 +569,16 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 					R.reaction_obj(A, R.volume+volume_modifier)
 	return
 
+/datum/reagents/proc/reaction_dropper(var/atom/A, var/volume_modifier=0)
+
+	if(ismob(A))
+		for(var/datum/reagent/R in reagent_list)
+			R.reaction_dropper_mob(A)
+
+	if(istype(A, /obj))
+		for(var/datum/reagent/R in reagent_list)
+			R.reaction_dropper_obj(A, R.volume+volume_modifier)
+
 /datum/reagents/proc/add_reagent(var/reagent, var/amount, var/list/data=null, var/reagtemp = T0C+20)
 	if(!my_atom)
 		return 0

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -91,6 +91,20 @@
 			var/datum/role/R = M.mind.antag_roles[role]
 			R.handle_splashed_reagent(self.id)
 
+/datum/reagent/proc/reaction_dropper_mob(var/mob/living/M, var/method = TOUCH, var/volume)
+	var/datum/reagent/self = src //Note : You need to declare self again (before the parent call) to use it in your chemical, see blood
+	src = null
+	if(M.reagents)
+		M.reagents.add_reagent(self.id, self.volume) //Hardcoded, transfer half of volume
+
+	if (M.mind)
+		for (var/role in M.mind.antag_roles)
+			var/datum/role/R = M.mind.antag_roles[role]
+			R.handle_splashed_reagent(self.id)
+
+/datum/reagent/proc/reaction_dropper_obj(var/obj/O, var/volume)
+	reaction_obj(O, volume)
+
 /datum/reagent/proc/reaction_animal(var/mob/living/simple_animal/M, var/method=TOUCH, var/volume)
 	set waitfor = 0
 
@@ -2911,6 +2925,22 @@
 						E.damage = 0 //cosmic technologies
 					to_chat(H,"<span class='notice'>Your eyes feel better.</span>")
 
+/datum/reagent/imidazoline/reaction_dropper_mob(var/mob/living/M)
+	. = ..()
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/obj/item/eyes_covered = H.get_body_part_coverage(EYES)
+		if(eyes_covered)
+			return
+		else //eyedrops, why not
+			var/datum/organ/internal/eyes/E = H.internal_organs_by_name["eyes"]
+			if(istype(E) && !E.robotic)
+				M.eye_blurry = 0
+				M.eye_blind = 0
+				if(E.damage > 0)
+					E.damage = 0 //cosmic technologies
+				to_chat(H,"<span class='notice'>Your eyes feel better.</span>")
+
 /datum/reagent/inacusiate
 	name = "Inacusiate"
 	id = INACUSIATE
@@ -3647,6 +3677,11 @@
 	if((prob(10) && method == TOUCH) || method == INGEST)
 		M.infect_disease2_predefined(disease_type, 1, "Robotic Nanites")
 
+/datum/reagent/nanites/reaction_dropper_mob(var/mob/living/M)
+	if(prob(30))
+		M.infect_disease2_predefined(disease_type, 1, "Robotic Nanites")
+	return ..()
+
 /datum/reagent/nanites/autist
 	name = "Autist nanites"
 	id = AUTISTNANITES
@@ -3666,6 +3701,11 @@
 		return 1
 	if((prob(10) && method == TOUCH) || method == INGEST)
 		M.infect_disease2_predefined(DISEASE_XENO, 1, "Xenimicrobes")
+
+/datum/reagent/xenomicrobes/reaction_dropper_mob(var/mob/living/M)
+	if(prob(30))
+		M.infect_disease2_predefined(DISEASE_XENO, 1, "Xenimicrobes")
+	return ..()
 
 /datum/reagent/nanobots
 	name = "Nanobots"
@@ -4290,11 +4330,22 @@
 				return
 			else //Oh dear
 				H.audible_scream()
-				H << "<span class='danger'>You are sprayed directly in the eyes with pepperspray!</span>"
+				to_chat(H, "<span class='danger'>You are sprayed directly in the eyes with pepperspray!</span>")
 				H.eye_blurry = max(M.eye_blurry, 25)
 				H.eye_blind = max(M.eye_blind, 10)
 				H.Paralyse(1)
 				H.drop_item()
+
+/datum/reagent/condensedcapsaicin/reaction_dropper_mob(var/mob/living/M)
+	M.audible_scream()
+	to_chat(M, "<span class='danger'>Pure solid peppespray is dropped directly in your eyes!</span>")
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.eye_blurry = max(M.eye_blurry, 25)
+		H.eye_blind = max(M.eye_blind, 10)
+		H.Paralyse(1)
+		H.drop_item()
+	return ..()
 
 /datum/reagent/condensedcapsaicin/on_mob_life(var/mob/living/M)
 	if(..())

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -26,13 +26,9 @@
 	if(!reagents.total_volume && M.is_open_container())
 		to_chat(user, "<span class='warning'>That doesn't make much sense.</span>")
 		return
-	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been squirted with [src.name] by [user.name] ([user.ckey]). Reagents: [reagents.get_reagent_ids(1)]</font>")
-	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to squirt [M.name] ([M.key]). Reagents: [reagents.get_reagent_ids(1)]</font>")
-	msg_admin_attack("[user.name] ([user.ckey]) squirted [M.name] ([M.key]) with [src.name]. Reagents: [reagents.get_reagent_ids(1)] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
-	if(!iscarbon(user))
-		M.LAssailant = null
-	else
-		M.LAssailant = user
+	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Squirt attempt with [src.name] by [user.name] ([user.ckey]). Reagents: [reagents.get_reagent_ids(1)]</font>")
+	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Attempted to use the [src.name] to squirt [M.name] ([M.key]). Reagents: [reagents.get_reagent_ids(1)]</font>")
+	user.visible_message("<span class='notice'>[user] tries to squirt something into [M]'s eyes.</span>", "<span class='notice'>You try to squirt something into [M]'s eyes.</span>")
 	if (!do_mob(user, M, 2 SECONDS))
 		user.visible_message("<span class='danger'>[user] tries to squirt something into [M]'s eyes, but fails!</span>", "<span class='danger'>You try to squirt something into [M]'s eyes, but fails!</span>")
 		return
@@ -45,9 +41,16 @@
 			src.reagents.remove_any(amount_per_transfer_from_this)
 			update_icon()
 			return
-	user.visible_message("<span class='danger'>[user] squirts something into [M]'s eyes!</span>", "<span class='danger'>You squirt something into [M]'s eyes!</span>")
+	user.visible_message("<span class='danger'>[user] squirts something into [M]'s eyes!</span>", "<span class='notice'>You squirt something into [M]'s eyes.</span>")
 	src.reagents.reaction_dropper(M)
 	src.reagents.remove_any(amount_per_transfer_from_this)
+	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been squirted with [src.name] by [user.name] ([user.ckey]). Reagents: [reagents.get_reagent_ids(1)]</font>")
+	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to squirt [M.name] ([M.key]). Reagents: [reagents.get_reagent_ids(1)]</font>")
+	msg_admin_attack("[user.name] ([user.ckey]) squirted [M.name] ([M.key]) with [src.name]. Reagents: [reagents.get_reagent_ids(1)] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+	if(!iscarbon(user))
+		M.LAssailant = null
+	else
+		M.LAssailant = user
 	update_icon()
 	return
 

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -22,7 +22,7 @@
 /obj/item/weapon/reagent_containers/dropper/update_icon()
 	icon_state = "dropper[(reagents.total_volume ? 1 : 0)]"
 
-/obj/item/weapon/reagent_containers/dropper/attack(mob/M as mob, mob/user as mob)
+/obj/item/weapon/reagent_containers/dropper/attack(var/mob/M, var/mob/user)
 	if(!reagents.total_volume && M.is_open_container())
 		to_chat(user, "<span class='warning'>That doesn't make much sense.</span>")
 		return
@@ -33,17 +33,20 @@
 		M.LAssailant = null
 	else
 		M.LAssailant = user
+	if (!do_mob(user, M, 2 SECONDS))
+		user.visible_message("<span class='danger'>[user] tries to squirt something into [M]'s eyes, but fails!</span>", "<span class='danger'>You try to squirt something into [M]'s eyes, but fails!</span>")
+		return
 	if(ishuman(M))
 		var/mob/living/carbon/human/victim = M
 		var/obj/item/safe_thing = victim.get_body_part_coverage(EYES)
 		if(safe_thing)
-			user.visible_message("<span class='danger'>[user] tries to squirt something into [M]'s eyes, but fails!</span>")
-			src.reagents.reaction(safe_thing, TOUCH)
+			user.visible_message("<span class='danger'>[user] tries to squirt something into [M]'s eyes, but fails!</span>", "<span class='danger'>You try to squirt something into [M]'s eyes, but fails!</span>")
+			src.reagents.reaction_dropper(safe_thing)
 			src.reagents.remove_any(amount_per_transfer_from_this)
 			update_icon()
 			return
-	user.visible_message("<span class='danger'>[user] squirts something into [M]'s eyes!</span>")
-	src.reagents.reaction(M, TOUCH)
+	user.visible_message("<span class='danger'>[user] squirts something into [M]'s eyes!</span>", "<span class='danger'>You squirt something into [M]'s eyes!</span>")
+	src.reagents.reaction_dropper(M)
 	src.reagents.remove_any(amount_per_transfer_from_this)
 	update_icon()
 	return


### PR DESCRIPTION
Closes #28526.

I thought this was a simple-enough bug to fix, but in fact, the proper way to do it was to code yet another method for reagent transfer specific to droppers.

Droppers now transfer all the volume of the reagent, except of course if the patient/victim is wearing eyewear. To make them different from harmsyringes or old-school injectors, you need to stand still 2 seconds - more than enough if you slipped the victim - for the squirting to work.

For a few things - nanites, xenomicrobes, and pepperspray -, I copypasted a stronger version of the `TOUCH` reaction.