### PR TITLE
Fixes alt-click not working on some grilles

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -247,7 +247,6 @@
 	reset_vars_after_duration(resettable_vars, duration)
 
 /obj/structure/grille/AltClick(var/mob/user)
-	. = ..()
 	var/turf/T = loc
 	if (istype(T))
 		if (user.listed_turf == T)


### PR DESCRIPTION
Closes #24116. Original code didn't work for accessible grilles (without a window in front of them).
Thank you Exxion.