### PR TITLE
Fixes Cyborg Examine Text

### DIFF
--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -38,7 +38,8 @@
 		if(UNCONSCIOUS)
 			msg += "<span class='warning'>It doesn't seem to be responding.</span>\n"
 		if(DEAD)
-			msg += "<span class='warning'>It is broken, please check internal components.  A cyborg emergency restart board will required once the necessary components are replaced.</span>\n"
+			msg += "<span class='warning'>It is broken, please check internal components.</span>\n"
+			msg += "<spn class='deadsay'>A cyborg emergency restart board will required once the necessary components are replaced.</span>\n"
 	msg += "*---------*</span>"
 
 	to_chat(user, msg)

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -39,7 +39,7 @@
 			msg += "<span class='warning'>It doesn't seem to be responding.</span>\n"
 		if(DEAD)
 			msg += "<span class='warning'>It is broken, please check internal components.</span>\n"
-			msg += "<spn class='deadsay'>A cyborg emergency restart board will required once the necessary components are replaced.</span>\n"
+			msg += "<spn class='deadsay'>A cyborg emergency restart board will be required once the necessary components are replaced.</span>\n"
 	msg += "*---------*</span>"
 
 	to_chat(user, msg)

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -38,9 +38,7 @@
 		if(UNCONSCIOUS)
 			msg += "<span class='warning'>It doesn't seem to be responding.</span>\n"
 		if(DEAD)
-			msg += "<span class='warning'>It is broken beyond functioning.</span>\n"
-			if(!client)
-				msg += "<span class='deadsay'>It looks completely unsalvageable.</span>\n" //ghosted
+			msg += "<span class='warning'>It is broken, please check internal components.  A cyborg emergency restart board will required once the necessary components are replaced.</span>\n"
 	msg += "*---------*</span>"
 
 	to_chat(user, msg)

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -38,8 +38,8 @@
 		if(UNCONSCIOUS)
 			msg += "<span class='warning'>It doesn't seem to be responding.</span>\n"
 		if(DEAD)
-			msg += "<span class='warning'>It is broken, please check internal components.</span>\n"
-			msg += "<spn class='deadsay'>A cyborg emergency restart board will be required once the necessary components are replaced.</span>\n"
+			msg += "<span class='warning'>It is broken, 'Please Check Internal Components' is flashing on its diagnostics display.</span>\n"
+			msg += "<spn class='deadsay'>'Emergency Restart Required' is scrolling repeatedly across the top of its diagnostics display.</span>\n"
 	msg += "*---------*</span>"
 
 	to_chat(user, msg)


### PR DESCRIPTION
Cyborg examine text is absolutely awful.  'Completely Unsalvageable' has caused many borgs to be round removed after simply getting components upgraded or were ghosted and looking around after being murdered.  This changes the text to the following.

![image](https://user-images.githubusercontent.com/74737391/104673223-e7e47100-56a6-11eb-9087-ddfd99b64848.png)

[tweak]

:cl:
 * tweak: Cyborg examine text upon death is more useful