### PR TITLE
Fixes catbeast language. Adds a language unit test

### DIFF
--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -40,9 +40,9 @@
 #define DEVELOPER_MODE 0
 
 // If 1, unit tests will be compiled
-#define UNIT_TESTS_ENABLED 0
+#define UNIT_TESTS_ENABLED 1
 // If 1, unit tests run automatically
-#define UNIT_TESTS_AUTORUN 0
+#define UNIT_TESTS_AUTORUN 1
 // If 1, the server stops after the tests are done
 #define UNIT_TESTS_STOP_SERVER_WHEN_DONE 0
 

--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -40,9 +40,9 @@
 #define DEVELOPER_MODE 0
 
 // If 1, unit tests will be compiled
-#define UNIT_TESTS_ENABLED 1
+#define UNIT_TESTS_ENABLED 0
 // If 1, unit tests run automatically
-#define UNIT_TESTS_AUTORUN 1
+#define UNIT_TESTS_AUTORUN 0
 // If 1, the server stops after the tests are done
 #define UNIT_TESTS_STOP_SERVER_WHEN_DONE 0
 

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -90,7 +90,7 @@
 	ask_verb = "warbles"
 	exclaim_verb = "warbles"
 	colour = "skrell"
-	key = "k"
+	key = "/"
 	syllables = list("qr","qrr","xuq","qil","quum","xuqm","vol","xrim","zaoo","qu-uu","qix","qoo","zix","*","!")
 
 /datum/language/vox

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -77,7 +77,7 @@
 	ask_verb = "mrowls"
 	exclaim_verb = "yowls"
 	colour = "tajaran"
-	key = "%"
+	key = "+"
 	syllables = list("rr","rr","tajr","kir","raj","kii","mir","kra","ahk","nal","vah","khaz","jri","ran","darr", \
 	"mi","jri","dynh","manq","rhe","zar","rrhaz","kal","chur","eech","thaa","dra","jurl","mah","sanu","dra","ii'r", \
 	"ka","aasi","far","wa","baq","ara","qara","zir","sam","mak","hrar","nja","rir","khan","jun","dar","rik","kah", \

--- a/code/modules/unit_tests/__unit_test_includes.dm
+++ b/code/modules/unit_tests/__unit_test_includes.dm
@@ -19,4 +19,5 @@
 #include "vector.dm"
 #include "reagent_ids.dm"
 #include "supermatter_airflow.dm"
+#include "languages.dm"
 #endif

--- a/code/modules/unit_tests/languages.dm
+++ b/code/modules/unit_tests/languages.dm
@@ -1,0 +1,16 @@
+/datum/unit_test/languages/start()
+	var/list/keys_used = list()
+	for (var/language in subtypesof(/datum/language))
+		var/datum/language/L = new language
+
+		// 1. Check the list
+		var/dupes = list()
+		for (var/name in keys_used)
+			if (keys_used[name] == L.key)
+				dupes += name
+		if (dupes.len)
+			fail("[L.name] ([L.key]) uses a duplicate key. Dupes: [english_list(dupes)]")
+
+		// 2. Add it
+		keys_used[L.name] = L.key
+

--- a/code/modules/unit_tests/languages.dm
+++ b/code/modules/unit_tests/languages.dm
@@ -4,7 +4,7 @@
 		var/datum/language/L = new language
 
 		// 1. Check the list
-		var/dupes = list()
+		var/list/dupes = list()
 		for (var/name in keys_used)
 			if (keys_used[name] == L.key)
 				dupes += name


### PR DESCRIPTION
Closes #28535 

:cl:
- bugfix: Catbeast language actually works now, and uses the key `:+`.