### PR TITLE
Fixes the 'default language' links and verb.

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -34,6 +34,12 @@
 	var/heat_protection = 0.5
 	var/list/can_only_pickup = list(/obj/item/clothing/mask/facehugger, /obj/item/weapon/grab) //What types of object can the alien pick up?
 
+/mob/living/carbon/alien/New()
+	add_language(LANGUAGE_XENO)
+	default_language = all_languages[LANGUAGE_XENO]
+	init_language = default_language
+	. = ..()
+
 /mob/living/carbon/alien/AdjustPlasma(amount)
 	plasma = min(max(plasma + amount,0),max_plasma) //upper limit of max_plasma, lower limit of 0
 	updatePlasmaHUD()

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
@@ -18,9 +18,6 @@
 		src.name = text("alien drone ([rand(1, 1000)])")
 	src.real_name = src.name
 	..()
-	add_language(LANGUAGE_XENO)
-	default_language = all_languages[LANGUAGE_XENO]
-	init_language = default_language
 
 /mob/living/carbon/alien/humanoid/drone/add_spells_and_verbs()
 	..()

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
@@ -20,6 +20,7 @@
 	..()
 	add_language(LANGUAGE_XENO)
 	default_language = all_languages[LANGUAGE_XENO]
+	init_language = default_language
 
 /mob/living/carbon/alien/humanoid/drone/add_spells_and_verbs()
 	..()

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -21,6 +21,7 @@
 	..()
 	add_language(LANGUAGE_XENO)
 	default_language = all_languages[LANGUAGE_XENO]
+	init_language = default_language
 
 /mob/living/carbon/alien/humanoid/hunter
 	handle_regular_hud_updates()

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -19,10 +19,7 @@
 		name = text("alien hunter ([rand(1, 1000)])")
 	real_name = name
 	..()
-	add_language(LANGUAGE_XENO)
-	default_language = all_languages[LANGUAGE_XENO]
-	init_language = default_language
-
+	
 /mob/living/carbon/alien/humanoid/hunter
 	handle_regular_hud_updates()
 

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
@@ -20,6 +20,7 @@
 	..()
 	add_language(LANGUAGE_XENO)
 	default_language = all_languages[LANGUAGE_XENO]
+	init_language = default_language
 
 /mob/living/carbon/alien/humanoid/sentinel/add_spells_and_verbs()
 	..()

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
@@ -18,9 +18,6 @@
 		name = text("alien sentinel ([rand(1, 1000)])")
 	real_name = name
 	..()
-	add_language(LANGUAGE_XENO)
-	default_language = all_languages[LANGUAGE_XENO]
-	init_language = default_language
 
 /mob/living/carbon/alien/humanoid/sentinel/add_spells_and_verbs()
 	..()

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -32,6 +32,7 @@
 	..()
 	add_language(LANGUAGE_XENO)
 	default_language = all_languages[LANGUAGE_XENO]
+	init_language = default_language
 
 /mob/living/carbon/alien/humanoid/queen/add_spells_and_verbs()
 	..()

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -30,9 +30,6 @@
 
 	real_name = src.name
 	..()
-	add_language(LANGUAGE_XENO)
-	default_language = all_languages[LANGUAGE_XENO]
-	init_language = default_language
 
 /mob/living/carbon/alien/humanoid/queen/add_spells_and_verbs()
 	..()

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -25,6 +25,7 @@
 	regenerate_icons()
 	add_language(LANGUAGE_XENO)
 	default_language = all_languages[LANGUAGE_XENO]
+	init_language = default_language
 	..()
 
 	add_spell(new /spell/aoe_turf/alien_hide, "alien_spell_ready", /obj/abstract/screen/movable/spell_master/alien)

--- a/code/modules/mob/living/carbon/complex/martian/martian.dm
+++ b/code/modules/mob/living/carbon/complex/martian/martian.dm
@@ -57,6 +57,7 @@
 	"bolitaenides","belemnites","astrocanthoteuthis","octodad","ocotillo","kalamarian")
 	add_language(LANGUAGE_MARTIAN)
 	default_language = all_languages[LANGUAGE_MARTIAN]
+	init_language = default_language
 	hud_list[STATUS_HUD]      = image('icons/mob/hud.dmi', src, "hudhealthy")
 	hud_list[HEALTH_HUD]      = image('icons/mob/hud.dmi', src, "hudhealth100")
 	..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -160,6 +160,7 @@
 	movement_speed_modifier = species.move_speed_multiplier
 
 	default_language = get_default_language()
+	init_language = default_language
 
 	create_reagents(1000)
 

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -82,6 +82,7 @@
 
 		add_language(languagetoadd)
 		default_language = all_languages[languagetoadd]
+		init_language = default_language
 
 	hud_list[HEALTH_HUD]      = image('icons/mob/hud.dmi', src, "hudhealth100")
 	hud_list[STATUS_HUD]      = image('icons/mob/hud.dmi', src, "hudhealthy")

--- a/code/modules/mob/living/default_language.dm
+++ b/code/modules/mob/living/default_language.dm
@@ -1,9 +1,15 @@
 /mob/living
 	var/datum/language/default_language
+	var/datum/language/init_language = null
 
 /mob/living/verb/set_default_language(language as null|anything in languages)
 	set name = "Set Default Language"
 	set category = "IC"
+
+	if (!language)
+		to_chat(src, "<span class='notice'>You will now speak whatever your standard default language is if you do not specify one when speaking.</span>")
+		default_language = init_language
+		return
 
 	if(!(language in languages))
 		to_chat(src, "<span class='warning'>You try mouthing a few words to yourself before realizing you have no idea how to speak [language]. Idiot.</span>")
@@ -11,8 +17,6 @@
 
 	if(language)
 		to_chat(src, "<span class='notice'>You will now speak [language] if you do not specify a language when speaking.</span>")
-	else
-		to_chat(src, "<span class='notice'>You will now speak whatever your standard default language is if you do not specify one when speaking.</span>")
 	default_language = language
 
 // Silicons can't neccessarily speak everything in their languages list

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -54,7 +54,7 @@ var/list/ai_list = list()
 
 	var/obj/machinery/power/apc/malfhack = null
 	var/explosive = FALSE //does the AI explode when it dies?
-	var/blackout_active = FALSE	
+	var/blackout_active = FALSE
 	var/explosive_cyborgs = FALSE	//Will any cyborgs slaved to the AI exploe when they die?
 
 	var/mob/living/silicon/ai/parent = null
@@ -95,6 +95,7 @@ var/list/ai_list = list()
 	//But gal common is restricted so let's add it manually.
 	add_language(LANGUAGE_GALACTIC_COMMON)
 	default_language = all_languages[LANGUAGE_GALACTIC_COMMON]
+	init_language = default_language
 
 	real_name = pickedName
 	name = real_name
@@ -536,7 +537,7 @@ var/list/ai_list = list()
 
 /mob/living/silicon/ai/bullet_act(var/obj/item/projectile/Proj)
 	if((ai_flags & COREFORTIFY) && Proj.damage_type == BURN)
-		return 
+		return
 	..(Proj)
 	updatehealth()
 	return 2

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -140,7 +140,7 @@
 
 	if(cyborg_detonation_time < world.time)	//Reset the global cyborg killswitch if it was already triggered, so an activated killswitch + missing robot consoles doesnt prevent all new borgs from instantly exploding. This probably isn't the best place for it but it should work.
 		cyborg_detonation_time = 0
-		
+
 	if(mind && !stored_freqs)
 		spawn(1)
 			mind.store_memory("Frequencies list: <br/><b>Command:</b> [COMM_FREQ] <br/> <b>Security:</b> [SEC_FREQ] <br/> <b>Medical:</b> [MED_FREQ] <br/> <b>Science:</b> [SCI_FREQ] <br/> <b>Engineering:</b> [ENG_FREQ] <br/> <b>Service:</b> [SER_FREQ] <b>Cargo:</b> [SUP_FREQ]<br/> <b>AI private:</b> [AIPRIV_FREQ]<br/>")
@@ -166,6 +166,7 @@
 			add_language(lang.name, can_speak = FALSE)
 
 	default_language = all_languages[LANGUAGE_GALACTIC_COMMON]
+	init_language = default_language
 
 /mob/living/silicon/robot/proc/connect_AI(var/mob/living/silicon/ai/new_AI)
 	if(istype(new_AI))

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -89,6 +89,7 @@
 	add_language(LANGUAGE_CULT)
 	add_language(LANGUAGE_GALACTIC_COMMON)
 	default_language = all_languages[LANGUAGE_CULT]
+	init_language = default_language
 	hud_list[CONSTRUCT_HUD] = image('icons/mob/hud.dmi', src, "consthealth100")
 	for(var/spell in construct_spells)
 		src.add_spell(new spell, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
@@ -99,7 +100,7 @@
 		if(!iscultist(creator))
 			universal_understand = 1
 			default_language = all_languages[LANGUAGE_GALACTIC_COMMON]
-
+			init_language = default_language
 			if(iswizard(creator) || isapprentice(creator))
 				construct_color = rgb(157, 1, 196)
 			else

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -55,6 +55,7 @@
 	initIcons()
 	add_language(LANGUAGE_MOUSE)
 	default_language = all_languages[LANGUAGE_MOUSE]
+	init_language = default_language
 	hud_list[STATUS_HUD]      = image('icons/mob/hud.dmi', src, "hudhealthy")
 
 	var/turf/T = get_turf(src)

--- a/code/modules/mob/living/simple_animal/hostile/mannequin.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mannequin.dm
@@ -140,6 +140,7 @@
 	..()
 	add_language(LANGUAGE_CULT)
 	default_language = all_languages[LANGUAGE_CULT]
+	init_language = default_language
 
 /mob/living/simple_animal/hostile/mannequin/cult/cultify()
 	return

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -37,6 +37,7 @@
 	add_language(LANGUAGE_CULT)
 	add_language(LANGUAGE_GALACTIC_COMMON)
 	default_language = all_languages[LANGUAGE_CULT]
+	init_language = default_language
 
 /mob/living/simple_animal/shade/death(var/gibbed = FALSE)
 	var/turf/T = get_turf(src)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1864,6 +1864,7 @@ obj/item/organ/external/head/proc/transfer_identity(var/mob/living/carbon/human/
 		H.mind.transfer_to(brainmob)
 	brainmob.languages = H.languages
 	brainmob.default_language = H.default_language
+	brainmob.init_language = brainmob.default_language
 	brainmob.container = src
 
 obj/item/organ/external/head/attackby(obj/item/weapon/W as obj, mob/user as mob)

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -197,7 +197,7 @@
 		B.brainmob.mind.transfer_to(target)
 	target.languages = B.brainmob.languages
 	target.default_language = B.brainmob.default_language
-
+	target.init_language = target.default_language
 	affected.attach(B)
 	target.decapitated = null
 

--- a/code/modules/virus2/effect/stage_2.dm
+++ b/code/modules/virus2/effect/stage_2.dm
@@ -588,7 +588,7 @@
 	name = "Oleum Syndrome"
 	desc = "Causes the infected to internally synthesize oil and other inorganic material."
 	stage = 2
-	badness = EFFECT_DANGER_ANNOYING 
+	badness = EFFECT_DANGER_ANNOYING
 	restricted = 2
 
 /datum/disease2/effect/cyborg_vomit/activate(var/mob/living/mob)
@@ -639,7 +639,7 @@
 	mob.pixel_y = -4 * PIXEL_MULTIPLIER
 
 	mob.pass_flags |= PASSTABLE
-	
+
 	activated = 1
 
 /datum/disease2/effect/mommi_shrink/deactivate(var/mob/living/mob)
@@ -700,7 +700,7 @@
 /datum/disease2/effect/wendigo_vomit/activate(var/mob/living/mob)
 	if(!ishuman(mob))
 		return
-	
+
 	var/mob/living/carbon/human/H = mob
 	if(prob(33))
 		H.vomit(instant = 1)


### PR DESCRIPTION
Closes #24222 (at least it was no longer an issue when testing)
Closes #20129

:cl:
- bugfix: The "Check-Known-Language" panel now work, and will change the default language you are speaking.
- bugfix: Using the "reset" link will revert your currently spoken language to the default for your species.
- bugfix: The verb "Set-Default-Language" works again. Use "`Set-Default-Language Galatic-Common`" (or any language name) to speak it as your default. You can use the space key to autocomplete the name of the language. Using "Set-Default-Language" with no parameter will revert your currently spoken language to the default for your species.