### PR TITLE
Removes Maintenance Access from all of those who do not Maintain.

### DIFF
--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -17,9 +17,6 @@
 	outfit_datum = /datum/outfit/assistant
 
 /datum/job/assistant/get_access()
-	if(config.assistant_maint)
-		return list(access_maint_tunnels)
-	else
 		return list()
 
 /datum/job/assistant/get_total_positions()

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -54,8 +54,8 @@
 	supervisors = "the head of personnel"
 	wage_payout = 65
 	selection_color = "#dddddd"
-	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
-	minimal_access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
+	access = list(access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
+	minimal_access = list(access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
 	outfit_datum = /datum/outfit/qm
 
 /datum/job/cargo_tech
@@ -68,8 +68,8 @@
 	supervisors = "the quartermaster and the head of personnel"
 	wage_payout = 20
 	selection_color = "#dddddd"
-	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
-	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
+	access = list(access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
+	minimal_access = list(access_cargo, access_cargo_bot, access_mailsorting)
 	outfit_datum = /datum/outfit/cargo_tech
 
 /datum/job/mining
@@ -82,7 +82,7 @@
 	supervisors = "the quartermaster and the head of personnel"
 	wage_payout = 30
 	selection_color = "#dddddd"
-	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
+	access = list(access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
 	minimal_access = list(access_mining, access_mint, access_mining_station, access_mailsorting)
 	outfit_datum = /datum/outfit/mining
 
@@ -96,7 +96,7 @@
 	supervisors = "the head of personnel"
 	wage_payout = 15
 	selection_color = "#dddddd"
-	access = list(access_clown, access_theatre, access_maint_tunnels)
+	access = list(access_clown, access_theatre)
 	minimal_access = list(access_clown, access_theatre)
 	alt_titles = list("Jester")
 	outfit_datum = /datum/outfit/clown
@@ -128,7 +128,7 @@
 	supervisors = "the head of personnel"
 	wage_payout = 15
 	selection_color = "#dddddd"
-	access = list(access_mime, access_theatre, access_maint_tunnels)
+	access = list(access_mime, access_theatre)
 	minimal_access = list(access_mime, access_theatre)
 	outfit_datum = /datum/outfit/mime
 
@@ -194,7 +194,7 @@
 	supervisors = "the head of personnel"
 	wage_payout = 25
 	selection_color = "#dddddd"
-	access = list(access_library, access_maint_tunnels)
+	access = list(access_library)
 	minimal_access = list(access_library)
 	alt_titles = list("Journalist", "Game Master")
 	outfit_datum = /datum/outfit/librarian
@@ -224,7 +224,7 @@
 	supervisors = "The God(s), the Head of Personnel too"
 	wage_payout = 35
 	selection_color = "#dddddd"
-	access = list(access_morgue, access_chapel_office, access_crematorium, access_maint_tunnels)
+	access = list(access_morgue, access_chapel_office, access_crematorium)
 	minimal_access = list(access_morgue, access_chapel_office, access_crematorium)
 	outfit_datum = /datum/outfit/chaplain
 	var/datum/religion/chap_religion

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -59,7 +59,7 @@
 	supervisors = "the research director and the chief engineer"
 	wage_payout = 45
 	selection_color = "#fff5cc"
-	access = list(access_eva, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_mechanic, access_tcomsat, access_science)
-	minimal_access = list(access_maint_tunnels, access_emergency_storage, access_construction, access_engine_equip, access_external_airlocks, access_mechanic, access_tcomsat, access_science)
+	access = list(access_eva, access_engine_equip, access_tech_storage, access_external_airlocks, access_construction, access_mechanic, access_tcomsat, access_science)
+	minimal_access = list(access_emergency_storage, access_construction, access_engine_equip, access_external_airlocks, access_mechanic, access_tcomsat, access_science)
 	alt_titles = list("Telecommunications Technician", "Spacepod Mechanic", "Greasemonkey")
 	outfit_datum = /datum/outfit/mechanic

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -90,8 +90,8 @@
 	supervisors = "the chief medical officer"
 	wage_payout = 55
 	selection_color = "#ffeef0"
-	access = list(access_paramedic, access_medical, access_sec_doors, access_maint_tunnels, access_external_airlocks, access_eva, access_morgue, access_surgery)
-	minimal_access=list(access_paramedic, access_medical, access_sec_doors, access_maint_tunnels, access_external_airlocks, access_eva, access_morgue, access_surgery)
+	access = list(access_paramedic, access_medical, access_sec_doors, access_external_airlocks, access_eva, access_morgue, access_surgery)
+	minimal_access=list(access_paramedic, access_medical, access_sec_doors, access_external_airlocks, access_eva, access_morgue, access_surgery)
 	outfit_datum = /datum/outfit/paramedic
 
 /*

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -10,11 +10,11 @@
 	selection_color = "#ffdddd"
 	req_admin_notify = 1
 	access = list(access_weapons, access_security, access_sec_doors, access_brig, access_armory, access_court,
-			            access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
+			            access_forensics_lockers, access_morgue, access_all_personal_lockers,
 			            access_science, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway, access_eva)
 	minimal_access = list(access_weapons, access_security, access_sec_doors, access_brig, access_armory, access_court,
-			            access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
+			            access_forensics_lockers, access_morgue, access_all_personal_lockers,
 			            access_science, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway)
 	minimal_player_age = 30
@@ -39,8 +39,8 @@
 	supervisors = "the head of security"
 	wage_payout = 65
 	selection_color = "#ffeeee"
-	access = list(access_weapons, access_security, access_sec_doors, access_brig, access_armory, access_court, access_maint_tunnels, access_morgue, access_eva)
-	minimal_access = list(access_weapons, access_security, access_sec_doors, access_brig, access_armory, access_court, access_maint_tunnels)
+	access = list(access_weapons, access_security, access_sec_doors, access_brig, access_armory, access_court, access_morgue, access_eva)
+	minimal_access = list(access_weapons, access_security, access_sec_doors, access_brig, access_armory, access_court)
 	outfit_datum = /datum/outfit/warden
 	minimal_player_age = 7
 
@@ -54,8 +54,8 @@
 	supervisors = "the head of security"
 	wage_payout = 55
 	selection_color = "#ffeeee"
-	access = list(access_weapons, access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_court, access_eva)
-	minimal_access = list(access_weapons, access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_court)
+	access = list(access_weapons, access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_court, access_eva)
+	minimal_access = list(access_weapons, access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_court)
 	alt_titles = list("Forensic Technician","Gumshoe", "Private Eye")
 	outfit_datum = /datum/outfit/detective
 	minimal_player_age = 7
@@ -70,8 +70,8 @@
 	supervisors = "the head of security"
 	wage_payout = 55
 	selection_color = "#ffeeee"
-	access = list(access_weapons, access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels, access_morgue, access_eva)
-	minimal_access = list(access_weapons, access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels)
+	access = list(access_weapons, access_security, access_sec_doors, access_brig, access_court, access_morgue, access_eva)
+	minimal_access = list(access_weapons, access_security, access_sec_doors, access_brig, access_court)
 	minimal_player_age = 7
 	outfit_datum = /datum/outfit/officer
 


### PR DESCRIPTION
[discussion][controversial]

We are quick to hate things like space bases in certain game modes, but do not acknowledge that they are a symptom of nearly everyone having free access to what should be the derelict areas of the station and a large number of roles ruthlessly hunting through and digging for valids round after round.  The purpose of this PR is to provide all game modes with more breathing room for antagonistic things to occur station side, as well as for station roles to contribute more towards the actual functioning parts of the station.  Additionally makes illicit hacking into there and maintenance access on agent IDs a lot more meaningful.

Assistant:  Currently acts more like psychotic Mad Max-esque vagrants than actually working as interns for a top-of-the-line research facility.  Should be participating in common areas instead of being a tunnel rat.

HoP: Absolutely no reason to be here.  Needs to handling Command duties and their office.

Quartermaster: In a quasi-head of staff and needs to be tending to cargo.  Absolutely no reason to be a tunnel rat.

Cargo Technician: Has a duty within cargo and has no reason to have this has a basic form of access

Shaft Miner: Makes the least sense of all of the cargo roles with maintenance access.  Has a duty to the asteroid and should not be freely maintenance crawling ever.

Chaplain:  A civilian role who tends to the chapel.  Why the hell would civilians have access to the maintenance tunnels of a secure research facility?

Mechanic: A hybrid role with duties to be upgrading departments and dealing with lesser and more public aspects of research and engineering.  One of the worst offenders of being a maint-crawling valid hunter and already has ludicrous levels of access.

Clown:  Civilian staff that is tailored to the crew.  Why the hell would civilians have access to the maintenance tunnels of a secure research facility?

Mime Civilian staff that is tailored to the crew.  Why the hell would civilians have access to the maintenance tunnels of a secure research facility?

Librarian:  A librarian of all things.  Why the hell would civilians have access to the maintenance tunnels of a secure research facility?

Paramedic:  Should not be running gung hoe into secure maintenance tunnels without a security team getting access and security the scene first.

HoS:  Needs to be handing Command matters and their department.  Crawling through maintenance alone is the last thing this role ever needs to be doing.

Security Officer:  The absolute worst offender of maint crawling valid hunting for the sake of such and the biggest reason for this PR to exist.  If we hate space bases so much then we need to actually give antagonists room to function and not have people pushing every wall in there and eyeballing every tumor out of place until the antagonists have had time to be noticed and for there to be a reason to get maintenance access and to go clear it out.

Detective:  Should not be digging in there until it becomes a security matter.  Give antagonists some room to breathe.

Warden:  No.  And blocking off all of maintenance round start with those barriers is not a valid reason.  That is part of the reason for this PR to exist.


:cl:
 * rscdel: Removes maintenance access from all of those who do not maintain the station