### PR TITLE
Fixes abnormal extravagant wage increases

### DIFF
--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -64,6 +64,8 @@ var/latejoiner_allowance = 0//Added to station_allowance and reset before every 
 	department_account.transaction_log.Add(T)
 	all_money_accounts.Add(department_account)
 
+	all_station_accounts.Add(department_account)
+
 	department_accounts[department] = department_account
 
 //the current ingame time (hh:mm) can be obtained by calling:


### PR DESCRIPTION
:cl:
* bugfix: Fixed unintended wage increases that resulted from station department wages not being counted when splitting the allowance, leading to higher and higher wage increases the less players there are online.