### PR TITLE
Lamprey is now MUCH MORE difficult to get it to be votable.

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -87,9 +87,14 @@
 				continue
 		if(potential == "Lamprey/") //Available if the station is wrecked enough
 			var/crew_score = score["crewscore"] //So that we can use this in the admin messaging
-			if(crew_score > -20000)
-				message_admins("Skipping map [potential], station requires lower than -20000 score (is [crew_score]).")
-				warning("Skipping map [potential], station requires lower than -20000 score (is [crew_score]).")
+			if(crew_score > -50000)
+				message_admins("Skipping map [potential], station requires lower than -50000 score (is [crew_score]).")
+				warning("Skipping map [potential], station requires lower than -50000 score (is [crew_score]).")
+				binary = null
+				continue
+			if(map.nameShort == "lamprey")
+				message_admins("Skipping map [potential], [map.nameLong] cannot happen more than once in a row.")
+				warning("Skipping map [potential], [map.nameLong] cannot happen more than once in a row.")
 				binary = null
 				continue
 		if(potential == "Castle Station/") //Available if revolutionaries won


### PR DESCRIPTION
It requires -50000 crew score, which would be an achievement in itself without the use of cheese
It also cannot play several times in a row, meaning that if the current round is Lamprey it can't be Lamprey the next round

:cl:
 * tweak: Lamprey is far harder to enable being voted for.
 * tweak: Lamprey can no longer be voted for if the current map is Lamprey.