### PR TITLE
Adds the codebreaker to the traitor uplink

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1076,3 +1076,9 @@ var/list/uplink_items = list()
 	cost = 60
 	discounted_cost = 100
 	jobs_with_discount = list("Nuclear Operative")
+	
+/datum/uplink_item/syndie_coop/codebreaker
+	name = "Codebreaker"
+	desc = "The be-all-end-all solution to halting Nanotrasen's expansion into free space.  This piece of Gorlex tech will allow a cell that is sufficiently large enough to decrypt the authentication key for their target station's failsafe thermonuclear warhead.  Good luck, operatives."
+	item = /obj/item/device/codebreaker
+	cost = 100


### PR DESCRIPTION
As asked for and as promised.  Adds the codebreaker to the traitor uplink for the full telecrystal price of five syndicate agents working together.


:cl:
 * rscadd: Adds the codebreaker to the 'cooperative cell' tab of the traitor uplink