### PR TITLE
[Hotfix] Fixing a Challenger objective confirmation issue

### DIFF
--- a/code/datums/gamemode/objectives/target/assassinate.dm
+++ b/code/datums/gamemode/objectives/target/assassinate.dm
@@ -92,5 +92,5 @@ var/list/assassination_objectives = list()
 			if(new_kill_target.set_target(A.target))
 				self.AppendObjective(new_kill_target)
 				to_chat(owner.current, "<b>New Objective</b>: [new_kill_target.explanation_text]<br>")
-			A.syndicate_checked = SYNDICATE_CANCELED
-			to_chat(target.current, "<span class='warning'>The Syndicate has taken note of your demise. You are therefore ineligible for victory this time around. Better luck next time!</span>")
+		A.syndicate_checked = SYNDICATE_CANCELED
+		to_chat(target.current, "<span class='warning'>The Syndicate has taken note of your demise. You are therefore ineligible for victory this time around. Better luck next time!</span>")


### PR DESCRIPTION
Fixes the defeated challenger's objective not being set as permanently failed if they were the last other challenger alive.