### PR TITLE
Adds some more clothing to the wonderful wardrobe

### DIFF
--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -1,4 +1,4 @@
-oc/*
+/*
  *	Here defined the boxes contained in the trader vending machine.
  *	Feel free to add stuff. Don't forget to add them to the vmachine afterwards.
 */

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -1,4 +1,4 @@
-/*
+oc/*
  *	Here defined the boxes contained in the trader vending machine.
  *	Feel free to add stuff. Don't forget to add them to the vmachine afterwards.
 */
@@ -59,6 +59,8 @@
 	list(/obj/item/clothing/head/wizard/lich, /obj/item/clothing/suit/wizrobe/lich, /obj/item/clothing/suit/wizrobe/skelelich),
 	list(/obj/item/clothing/suit/space/plasmaman/cultist, /obj/item/clothing/head/helmet/space/plasmaman/cultist),
 	list(/obj/item/clothing/head/helmet/space/plasmaman/security/captain, /obj/item/clothing/suit/space/plasmaman/security/captain),
+	list(/obj/item/clothing/head/helmet/space/plasmaman/security/hos, /obj/item/clothing/head/helmet/space/plasmaman/security/hos),
+	list(/obj/item/clothing/head/helmet/space/plasmaman/security/hop, /obj/item/clothing/head/helmet/space/plasmaman/security/hop),
 	/obj/item/clothing/under/skelesuit,
 	list(/obj/item/clothing/suit/storage/wintercoat/engineering/ce, /obj/item/clothing/suit/storage/wintercoat/medical/cmo, /obj/item/clothing/suit/storage/wintercoat/security/hos, /obj/item/clothing/suit/storage/wintercoat/hop, /obj/item/clothing/suit/storage/wintercoat/security/captain, /obj/item/clothing/suit/storage/wintercoat/clown, /obj/item/clothing/suit/storage/wintercoat/slimecoat),
 	list(/obj/item/clothing/suit/space/rig/wizard, /obj/item/clothing/gloves/purple/wizard, /obj/item/clothing/shoes/sandal),

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -71,7 +71,7 @@
 	list(/obj/item/clothing/under/rank/security/sneaksuit, /obj/item/clothing/head/headband),
 	/obj/item/clothing/under/galo,
 	/obj/item/clothing/suit/raincoat,
-	list(/obj/item/clothing/accessory/armband, /obj/item/clothing/accessory/armband/cargo, /obj/item/clothing/accessory/armband/engine, /obj/item/clothing/accessory/armband/science, /obj/item/clothing/accessory/armband/hydro, /obj/item/clothing/accessory/armband/med)
+	list(/obj/item/clothing/accessory/armband, /obj/item/clothing/accessory/armband/cargo, /obj/item/clothing/accessory/armband/engine, /obj/item/clothing/accessory/armband/science, /obj/item/clothing/accessory/armband/hydro, /obj/item/clothing/accessory/armband/medgreen)
 	)
 
 /obj/structure/closet/secure_closet/wonderful/spawn_contents()

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -65,7 +65,13 @@
 	list(/obj/item/clothing/suit/space/ancient, /obj/item/clothing/suit/space/ancient),
 	list(/obj/item/clothing/shoes/clockwork_boots, /obj/item/clothing/head/clockwork_hood, /obj/item/clothing/suit/clockwork_robes),
 	/obj/item/clothing/mask/necklace/xeno_claw,
-	/obj/item/clothing/under/newclothes
+	/obj/item/clothing/under/newclothes,
+	/obj/item/clothing/suit/storage/draculacoat,
+	list(/obj/item/clothing/head/helmet/richard, /obj/item/clothing/under/jacketsuit),
+	list(/obj/item/clothing/under/rank/security/sneaksuit, /obj/item/clothing/head/headband),
+	/obj/item/clothing/under/galo,
+	/obj/item/clothing/suit/raincoat,
+	list(/obj/item/clothing/accessory/armband, /obj/item/clothing/accessory/armband/cargo, /obj/item/clothing/accessory/armband/engine, /obj/item/clothing/accessory/armband/science, /obj/item/clothing/accessory/armband/hydro, /obj/item/clothing/accessory/armband/med)
 	)
 
 /obj/structure/closet/secure_closet/wonderful/spawn_contents()

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -55,16 +55,12 @@ oc/*
 	/obj/item/clothing/shoes/clown_shoes/advanced,
 	list(/obj/item/clothing/suit/space/clown, /obj/item/clothing/head/helmet/space/clown),
 	/obj/item/clothing/shoes/magboots/magnificent,
-	list(/obj/item/clothing/suit/space/plasmaman/bee, /obj/item/clothing/head/helmet/space/plasmaman/bee),
+	list(/obj/item/clothing/suit/space/plasmaman/bee, /obj/item/clothing/head/helmet/space/plasmaman/bee, /obj/item/clothing/suit/space/plasmaman/cultist, /obj/item/clothing/head/helmet/space/plasmaman/cultist, /obj/item/clothing/head/helmet/space/plasmaman/security/captain, /obj/item/clothing/suit/space/plasmaman/security/captain, /obj/item/clothing/head/helmet/space/plasmaman/security/hos, /obj/item/clothing/suit/space/plasmaman/security/hos, /obj/item/clothing/head/helmet/space/plasmaman/security/hop, /obj/item/clothing/suit/space/plasmaman/security/hop),
 	list(/obj/item/clothing/head/wizard/lich, /obj/item/clothing/suit/wizrobe/lich, /obj/item/clothing/suit/wizrobe/skelelich),
-	list(/obj/item/clothing/suit/space/plasmaman/cultist, /obj/item/clothing/head/helmet/space/plasmaman/cultist),
-	list(/obj/item/clothing/head/helmet/space/plasmaman/security/captain, /obj/item/clothing/suit/space/plasmaman/security/captain),
-	list(/obj/item/clothing/head/helmet/space/plasmaman/security/hos, /obj/item/clothing/head/helmet/space/plasmaman/security/hos),
-	list(/obj/item/clothing/head/helmet/space/plasmaman/security/hop, /obj/item/clothing/head/helmet/space/plasmaman/security/hop),
 	/obj/item/clothing/under/skelesuit,
 	list(/obj/item/clothing/suit/storage/wintercoat/engineering/ce, /obj/item/clothing/suit/storage/wintercoat/medical/cmo, /obj/item/clothing/suit/storage/wintercoat/security/hos, /obj/item/clothing/suit/storage/wintercoat/hop, /obj/item/clothing/suit/storage/wintercoat/security/captain, /obj/item/clothing/suit/storage/wintercoat/clown, /obj/item/clothing/suit/storage/wintercoat/slimecoat),
 	list(/obj/item/clothing/suit/space/rig/wizard, /obj/item/clothing/gloves/purple/wizard, /obj/item/clothing/shoes/sandal),
-	list(/obj/item/clothing/suit/space/ancient, /obj/item/clothing/suit/space/ancient),
+	list(/obj/item/clothing/suit/space/ancient, /obj/item/clothing/head/helmet/space/ancient),
 	list(/obj/item/clothing/shoes/clockwork_boots, /obj/item/clothing/head/clockwork_hood, /obj/item/clothing/suit/clockwork_robes),
 	/obj/item/clothing/mask/necklace/xeno_claw,
 	/obj/item/clothing/under/newclothes,
@@ -73,7 +69,14 @@ oc/*
 	list(/obj/item/clothing/under/rank/security/sneaksuit, /obj/item/clothing/head/headband),
 	/obj/item/clothing/under/galo,
 	/obj/item/clothing/suit/raincoat,
-	list(/obj/item/clothing/accessory/armband, /obj/item/clothing/accessory/armband/cargo, /obj/item/clothing/accessory/armband/engine, /obj/item/clothing/accessory/armband/science, /obj/item/clothing/accessory/armband/hydro, /obj/item/clothing/accessory/armband/medgreen)
+	list(/obj/item/clothing/accessory/armband, /obj/item/clothing/accessory/armband/cargo, /obj/item/clothing/accessory/armband/engine, /obj/item/clothing/accessory/armband/science, /obj/item/clothing/accessory/armband/hydro, /obj/item/clothing/accessory/armband/medgreen),
+	list(/obj/item/clothing/head/helmet/space/grey, /obj/item/clothing/suit/space/grey),
+	list(/obj/item/clothing/under/bikersuit, /obj/item/clothing/gloves/bikergloves, /obj/item/clothing/head/helmet/biker, /obj/item/clothing/shoes/mime/biker),
+	list(/obj/item/clothing/monkeyclothes/space, /obj/item/clothing/head/helmet/space),
+	/obj/item/device/radio/headset/headset_earmuffs,
+	/obj/item/clothing/under/vault13,
+	list(/obj/item/clothing/head/leather/xeno, /obj/item/clothing/suit/leather/xeno),
+	/obj/item/clothing/accessory/rabbit_foot
 	)
 
 /obj/structure/closet/secure_closet/wonderful/spawn_contents()


### PR DESCRIPTION
Very lazily adds some new clothing options to the wonderful wardrobe, listed below:
- Vampire coat
- Richard outfit and mask
- Sneaking suit and headband (otherwise unobtainable!)
- Galo Sengan outfit
- Raincoat
- Departmental armband set
- HoP and HoS plasmaman suits (same armor values as plasmaman captain suit)
- Grey spacesuit
- Biker outfit
- Monkey softsuit and a helmet
- Headset earmuffs
- Vault 13 jumpsuit
- Xeno leather suit & helmet (similar armor values to gem-studded hardsuit)
- Rabbit foot charm

Additionally bundles the plasmaman suits into one 'item' and replaces one of the ancient spacesuits with a helmet. My reasoning for this change is that you get the same few sets of items every time and that it would be cool to see some otherwise hard to obtain clothing in-game. Open to suggestions for more items to add.

:cl:
 * rscadd: Adds more variety to the wonderful wardrobe.