### PR TITLE
Snow Survival Guide

### DIFF
--- a/code/datums/outfit/outfit.dm
+++ b/code/datums/outfit/outfit.dm
@@ -109,6 +109,7 @@
 	species_final_equip(H)
 	spawn_id(H)
 	post_equip(H) // Accessories, IDs, etc.
+	map.map_equip(H) //Does this map give special gear?
 	if (priority)
 		post_equip_priority(H)
 	give_disabilities_equipment(H)

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -920,3 +920,28 @@ var/virology_encyclopedia = ""
 				</html>"}
 
 	dat = virology_encyclopedia
+
+/obj/item/weapon/book/manual/snow
+	name = "\improper Snow Survival Guide"
+	icon_state ="triangulate"
+	author = "The Abominable Snowman"
+	title = "Snow Survival Guide"
+	wiki_page = "Guide_to_Snow_Map"
+	desc = "A guide to surviving on the surface of a snow planet. It even comes with a magnesium strip to ignite for emergency heating when applied to snow!</span>"
+
+/obj/item/weapon/book/manual/snow/afterattack(atom/A, mob/user as mob)
+	if(!user.Adjacent(A) || !istype(A,/turf/unsimulated/floor/snow))
+		return
+	trigger(user)
+
+/obj/item/weapon/book/manual/snow/proc/trigger(var/mob/living/L)
+	if(!L)
+		L = get_holder_of_type(src,/mob/living)
+	visible_message("<span class='danger'>The magnesium in \the [src]'s emergency strip flash-ignites!</span>")
+	var/turf/T = get_turf(src)
+	new /obj/effect/decal/cleanable/ash(T)
+	playsound(src, 'sound/items/lighter1.ogg', 50, 1)
+	if(L)
+		L.bodytemperature = L.bodytemperature + 10 //This is enough to push someone from the edge of passing out to safe
+		to_chat(L, "<span class='warning'>You feel a jolt of warmth from the flash-incineration of \the [src].")
+	qdel(src)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -631,6 +631,9 @@
 	else if(istype(O,/obj/machinery/space_heater/campfire))
 		var/obj/machinery/space_heater/campfire/campfire = O
 		campfire.snuff()
+	else if(istype(O, /obj/item/weapon/book/manual/snow))
+		var/obj/item/weapon/book/manual/snow/S = O
+		S.trigger()
 	else if(O.on_fire) // For extinguishing objects on fire
 		O.extinguish()
 	else if(O.molten) // Molten shit.

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -203,6 +203,8 @@ var/global/list/accessable_z_levels = list()
 /datum/map/proc/generate_mapvaults()
 	return FALSE
 
+/datum/map/proc/map_equip(var/mob/living/carbon/human/H)
+	return
 
 ////////////////////////////////////////////////////////////////
 

--- a/maps/snaxi.dm
+++ b/maps/snaxi.dm
@@ -199,6 +199,11 @@
 
 	return TRUE
 
+/datum/map/active/map_equip(var/mob/living/carbon/human/H)
+	if(!istype(H))
+		return
+	H.equip_or_collect(new /obj/item/weapon/book/manual/snow(H.back), slot_in_backpack)
+
 ////////////////////////////////////////////////////////////////
 #include "snaxi.dmm"
 #endif


### PR DESCRIPTION
I realized after adding the heat up feature that you could spam these at the library. But if you were going to do that, you could just get leporazine at chemistry. Besides, library could use a new toy.

Since it's magnesium, spilling water on it sets it off too.

Backend: Can now have map-specific equipment. Free cyanide pill on Lamprey, perhaps?

🆑 
* rscadd: On Snaxi, everyone spawns with a Snow Survival Guide (which links to the wiki page) in their backpack. The guide also reacts with snow to flash-ignite for a quick boost of heat.