### PR TITLE
Clientless simple mobs no longer spams observers

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -56,19 +56,27 @@
 	var/msg_runechat = msg
 	msg = "<b>[user]</b> " + msg
 
-	for(var/mob/M in dead_mob_list)
-		if(!M.client || isnewplayer(M))
-			continue
-		var/T = get_turf(user)
-		if(isobserver(M) && M.client && (M.client.prefs.toggles & CHAT_GHOSTSIGHT) && !(M in viewers(T)))
-			M.show_message("<a href='?src=\ref[M];follow=\ref[user]'>(Follow)</a> " + msg)
-			if (user.client && M?.client?.prefs.mob_chat_on_map && get_dist(M, user) < M?.client.view)
-				M.create_chat_message(user, null, msg_runechat, "", list("italics"))
+	var/obs_pass = TRUE
+	// Don't hear simple mobs without a client.
+	if (istype(user, /mob/living/simple_animal))
+		var/mob/living/simple_animal/animal = source
+		if (!animal.client)
+			obs_pass = FALSE
+
+	if (obs_pass)
+		for(var/mob/M in dead_mob_list)
+			if(!M.client || isnewplayer(M))
+				continue
+			var/T = get_turf(user)
+			if(isobserver(M) && M.client && (M.client.prefs.toggles & CHAT_GHOSTSIGHT) && !(M in viewers(T)))
+				M.show_message("<a href='?src=\ref[M];follow=\ref[user]'>(Follow)</a> " + msg)
+				if (user.client && M?.client?.prefs.mob_chat_on_map && get_dist(M, user) < M?.client.view)
+					M.create_chat_message(user, null, msg_runechat, "", list("italics"))
 
 	if (emote_type == EMOTE_VISIBLE)
 		user.visible_message(msg)
 		for (var/mob/O in viewers(world.view, user))
-			if (user.client && O?.client?.prefs.mob_chat_on_map && O.stat != UNCONSCIOUS && !(isinvisible(user))) 
+			if (user.client && O?.client?.prefs.mob_chat_on_map && O.stat != UNCONSCIOUS && !(isinvisible(user)))
 				O.create_chat_message(user, null, msg_runechat, "", list("italics"))
 	else
 		for(var/mob/O in get_hearers_in_view(world.view, user))

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -58,10 +58,8 @@
 
 	var/obs_pass = TRUE
 	// Don't hear simple mobs without a client.
-	if (istype(user, /mob/living/simple_animal))
-		var/mob/living/simple_animal/animal = source
-		if (!animal.client)
-			obs_pass = FALSE
+	if (istype(user, /mob/living/simple_animal) && !user.client)
+		obs_pass = FALSE
 
 	if (obs_pass)
 		for(var/mob/M in dead_mob_list)

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -31,6 +31,12 @@
 	var/source = speech.speaker.GetSource()
 	var/source_turf = get_turf(source)
 
+	// Don't hear simple mobs without a client.
+	if (istype(source, /mob/living/simple_animal) && (get_dist(source_turf, src) > get_view_range()))
+		var/mob/living/simple_animal/animal = source
+		if (!animal.client)
+			return
+
 	say_testing(src, "/mob/dead/observer/Hear(): source=[source], frequency=[speech.frequency], source_turf=[formatJumpTo(source_turf)]")
 
 	if (get_dist(source_turf, src) <= get_view_range())


### PR DESCRIPTION
As an observer, you will no longer hear a simple mob, or see its emotes, unless there is client controlling it, or it's in your vision.

This PR is sponsored with the anti-snowmen and anti-Russians gang.