### PR TITLE
Fixes shades in Soul or Chaos Blades taking damage while over space

### DIFF
--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -101,8 +101,7 @@
 		else if (SB.blood < SB.maxregenblood)
 			SB.blood++
 	else
-		var/turf/T = get_turf(src)
-		if (istype(T,/turf/space))
+		if (istype(loc,/turf/space))
 			if (!space_damage_warned)
 				space_damage_warned = TRUE
 				to_chat(src,"<span class='danger'>Your ghostly form suffers from the star's radiations. Remaining in space will slowly erase you.</span>")


### PR DESCRIPTION
Fixes #28696

:cl:
* bugfix: Fixed shades in Soul or Chaos Blades taking damage while over space.