### PR TITLE
Soulstone Shards can now be used to perform ghetto surgery as efficiently as glass shards.

### DIFF
--- a/code/modules/surgery/butt.dm
+++ b/code/modules/surgery/butt.dm
@@ -57,8 +57,11 @@
 /datum/surgery_step/butt/seperate_anus
 	allowed_tools = list(
 		/obj/item/weapon/scalpel = 100,
+		/obj/item/weapon/melee/blood_dagger = 90,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/shard = 50,
+		/obj/item/weapon/soulstone/gem = 0,
+		/obj/item/weapon/soulstone = 50,
 		)
 
 	duration = 8 SECONDS

--- a/code/modules/surgery/butt.dm
+++ b/code/modules/surgery/butt.dm
@@ -60,8 +60,8 @@
 		/obj/item/weapon/melee/blood_dagger = 90,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/shard = 50,
-		/obj/item/weapon/soulstone/gem = 0,
-		/obj/item/weapon/soulstone = 50,
+		/obj/item/soulstone/gem = 0,
+		/obj/item/soulstone = 50,
 		)
 
 	duration = 8 SECONDS

--- a/code/modules/surgery/eye.dm
+++ b/code/modules/surgery/eye.dm
@@ -27,8 +27,11 @@
 /datum/surgery_step/eye/cut_open
 	allowed_tools = list(
 		/obj/item/weapon/scalpel = 100,
+		/obj/item/weapon/melee/blood_dagger = 90,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/shard = 50,
+		/obj/item/soulstone/gem = 0,
+		/obj/item/soulstone = 50,
 		)
 
 	duration = 9 SECONDS

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -27,8 +27,8 @@
 		/obj/item/weapon/melee/blood_dagger = 90,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/shard = 50,
-		/obj/item/weapon/soulstone/gem = 0,
-		/obj/item/weapon/soulstone = 50,
+		/obj/item/soulstone/gem = 0,
+		/obj/item/soulstone = 50,
 		)
 
 	duration = 9 SECONDS

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -24,8 +24,11 @@
 /datum/surgery_step/generic/cut_face
 	allowed_tools = list(
 		/obj/item/weapon/scalpel = 100,
+		/obj/item/weapon/melee/blood_dagger = 90,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/shard = 50,
+		/obj/item/weapon/soulstone/gem = 0,
+		/obj/item/weapon/soulstone = 50,
 		)
 
 	duration = 9 SECONDS

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -143,6 +143,8 @@
 		/obj/item/weapon/melee/blood_dagger = 90,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/shard = 50,
+		/obj/item/weapon/soulstone/gem = 0,
+		/obj/item/weapon/soulstone = 50,
 		)
 
 	priority = 0

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -143,8 +143,8 @@
 		/obj/item/weapon/melee/blood_dagger = 90,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/shard = 50,
-		/obj/item/weapon/soulstone/gem = 0,
-		/obj/item/weapon/soulstone = 50,
+		/obj/item/soulstone/gem = 0,
+		/obj/item/soulstone = 50,
 		)
 
 	priority = 0

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -247,8 +247,8 @@
 		/obj/item/weapon/melee/blood_dagger = 90,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/shard = 50,
-		/obj/item/weapon/soulstone/gem = 0,
-		/obj/item/weapon/soulstone = 50,
+		/obj/item/soulstone/gem = 0,
+		/obj/item/soulstone = 50,
 		)
 
 	duration = 9 SECONDS

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -244,8 +244,11 @@
 /datum/surgery_step/internal/detatch_organ
 	allowed_tools = list(
 		/obj/item/weapon/scalpel = 100,
+		/obj/item/weapon/melee/blood_dagger = 90,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/shard = 50,
+		/obj/item/weapon/soulstone/gem = 0,
+		/obj/item/weapon/soulstone = 50,
 		)
 
 	duration = 9 SECONDS

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -66,8 +66,11 @@
 	priority = 2
 	allowed_tools = list(
 		/obj/item/weapon/scalpel = 100,
+		/obj/item/weapon/melee/blood_dagger = 90,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/shard = 50,
+		/obj/item/weapon/soulstone/gem = 0,
+		/obj/item/weapon/soulstone = 50,
 		)
 
 	can_infect = 1

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -69,8 +69,8 @@
 		/obj/item/weapon/melee/blood_dagger = 90,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/shard = 50,
-		/obj/item/weapon/soulstone/gem = 0,
-		/obj/item/weapon/soulstone = 50,
+		/obj/item/soulstone/gem = 0,
+		/obj/item/soulstone = 50,
 		)
 
 	can_infect = 1

--- a/code/modules/surgery/robolimbs.dm
+++ b/code/modules/surgery/robolimbs.dm
@@ -31,8 +31,8 @@
 		/obj/item/weapon/melee/blood_dagger = 90,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/shard = 50,
-		/obj/item/weapon/soulstone/gem = 0,
-		/obj/item/weapon/soulstone = 50,
+		/obj/item/soulstone/gem = 0,
+		/obj/item/soulstone = 50,
 		)
 
 	duration = 8 SECONDS

--- a/code/modules/surgery/robolimbs.dm
+++ b/code/modules/surgery/robolimbs.dm
@@ -28,8 +28,11 @@
 /datum/surgery_step/limb/cut
 	allowed_tools = list(
 		/obj/item/weapon/scalpel = 100,
+		/obj/item/weapon/melee/blood_dagger = 90,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/shard = 50,
+		/obj/item/weapon/soulstone/gem = 0,
+		/obj/item/weapon/soulstone = 50,
 		)
 
 	duration = 8 SECONDS

--- a/code/modules/surgery/slimes.dm
+++ b/code/modules/surgery/slimes.dm
@@ -20,8 +20,11 @@
 /datum/surgery_step/slime/cut_flesh
 	allowed_tools = list(
 		/obj/item/weapon/scalpel = 100,
+		/obj/item/weapon/melee/blood_dagger = 90,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/shard = 50,
+		/obj/item/weapon/soulstone/gem = 0,
+		/obj/item/weapon/soulstone = 50,
 		)
 
 	duration = 3 SECONDS
@@ -53,8 +56,11 @@
 /datum/surgery_step/slime/cut_innards
 	allowed_tools = list(
 		/obj/item/weapon/scalpel = 100,
+		/obj/item/weapon/melee/blood_dagger = 90,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/shard = 50,
+		/obj/item/weapon/soulstone/gem = 0,
+		/obj/item/weapon/soulstone = 50,
 		)
 
 	duration = 3 SECONDS

--- a/code/modules/surgery/slimes.dm
+++ b/code/modules/surgery/slimes.dm
@@ -23,8 +23,8 @@
 		/obj/item/weapon/melee/blood_dagger = 90,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/shard = 50,
-		/obj/item/weapon/soulstone/gem = 0,
-		/obj/item/weapon/soulstone = 50,
+		/obj/item/soulstone/gem = 0,
+		/obj/item/soulstone = 50,
 		)
 
 	duration = 3 SECONDS
@@ -59,8 +59,8 @@
 		/obj/item/weapon/melee/blood_dagger = 90,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/shard = 50,
-		/obj/item/weapon/soulstone/gem = 0,
-		/obj/item/weapon/soulstone = 50,
+		/obj/item/soulstone/gem = 0,
+		/obj/item/soulstone = 50,
 		)
 
 	duration = 3 SECONDS


### PR DESCRIPTION
Not as efficient as blood daggers, but offers an alternative to cultists who want to use another tattoo. Also gives cultists a reason to break soulstone gems.
And obviously be sure to have your patient over an altar or table of sorts, lest you stone their soul instead.

:cl:
* rscadd: Soulstone Shards can now be used to perform surgery as efficiently as glass shards.