### PR TITLE
Implanter and implant QoL

### DIFF
--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -45,7 +45,15 @@
 	desc = "Charred circuit in melted plastic case. Wonder what that used to be..."
 	icon_state = "implant_melted"
 	malfunction = IMPLANT_MALFUNCTION_PERMANENT
-
+	
+/obj/item/weapon/implant/proc/makeunusable(var/probability=50)
+	if(prob(probability))
+		visible_message("<span class='warning'>\The [src] fizzles and sparks as you remove it!</span>")
+		name = "melted " + initial(name)
+		desc = "Charred circuit in melted plastic case."
+		icon_state = "implant_melted"
+		malfunction = IMPLANT_MALFUNCTION_PERMANENT
+	
 /obj/item/weapon/implant/Destroy()
 	if(part)
 		part.implants.Remove(src)
@@ -137,6 +145,9 @@
 
 /obj/item/weapon/implant/explosive/islegal()
 	return 0
+	
+/obj/item/weapon/implant/explosive/handle_removal(var/mob/remover)
+	makeunusable(75)
 
 /obj/item/weapon/implant/explosive/proc/small_boom()
 	if(iscarbon(imp_in))
@@ -265,8 +276,8 @@ the implant may become unstable and either pre-maturely inject the subject or si
 
 	to_chat(H, "<span class = 'notice'>You feel a surge of loyalty towards Nanotrasen.</span>")
 	return 1
-
-
+/obj/item/weapon/implant/loyalty/handle_removal(var/mob/remover)
+	makeunusable(15)
 
 /obj/item/weapon/implant/traitor
 	name = "greytide implant"
@@ -336,6 +347,8 @@ the implant may become unstable and either pre-maturely inject the subject or si
 		return
 	log_admin("[key_name(remover)] has removed a greytide implant from [key_name(imp_in)].")
 	R.Drop(FALSE)
+	
+	makeunusable(90)
 
 /obj/item/weapon/implant/adrenalin
 	name = "adrenalin implant"
@@ -372,8 +385,8 @@ the implant may become unstable and either pre-maturely inject the subject or si
 		to_chat(source, "The implanted freedom implant can be activated by using the pale emote, <B>say *pale</B> to attempt to activate.")
 		return 1
 
-
-
+/obj/item/weapon/implant/adrenalin/handle_removal(var/mob/remover)
+	makeunusable(75)
 
 /obj/item/weapon/implant/death_alarm
 	name = "death alarm implant"
@@ -458,7 +471,8 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	processing_objects.Add(src)
 	return 1
 
-
+/obj/item/weapon/implant/death_alarm/handle_removal(var/mob/remover)
+	makeunusable(75)
 
 /obj/item/weapon/implant/compressed
 	name = "compressed matter implant"
@@ -506,7 +520,8 @@ the implant may become unstable and either pre-maturely inject the subject or si
 /obj/item/weapon/implant/compressed/islegal()
 	return 0
 
-
+/obj/item/weapon/implant/compressed/handle_removal(var/mob/remover)
+	makeunusable(75)
 
 /obj/item/weapon/implant/cortical
 	name = "cortical stack"
@@ -577,6 +592,8 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	else
 		return 0
 
+/obj/item/weapon/implant/peace/handle_removal(var/mob/remover)
+	meltdown()
 
 /obj/item/weapon/implant/holy
 	name = "holy implant"
@@ -592,7 +609,7 @@ the implant may become unstable and either pre-maturely inject the subject or si
 <b>Implant Details:</b><BR>
 <b>Function:</b> Submits its subject to the chants of a thousand chaplains.<BR>
 <b>Special Features:</b> Prevents cultists from using their runes and talismans, or from being the target of some of their peers' rituals.<BR>
-<b>Integrity:</b> Implant anchors itself inside the subject's bones to prevent blood pressure induced ejections."}
+<b>Integrity:</b> Implant anchors itself against the subject's bones to prevent blood pressure induced ejections."}
 	return dat
 
 /obj/item/weapon/implant/holy/implanted(mob/M)
@@ -608,3 +625,6 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	else
 		to_chat(H, "<span class = 'notice'>You hear the soothing millennia-old Gregorian chants of the clergy.</span>")
 	return 1
+	
+/obj/item/weapon/implant/holy/handle_removal(var/mob/remover)
+	makeunusable(15)

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -160,7 +160,7 @@
 
 /obj/item/weapon/implant/chem
 	name = "chem implant"
-	desc = "Injects things."
+	desc = "Injects chemicals."
 	allow_reagents = 1
 
 /obj/item/weapon/implant/chem/get_data()

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -48,7 +48,7 @@
 	
 /obj/item/weapon/implant/proc/makeunusable(var/probability=50)
 	if(prob(probability))
-		visible_message("<span class='warning'>\The [src] fizzles and sparks as you remove it!</span>")
+		visible_message("<span class='warning'>\The [src] fizzles and sparks!</span>")
 		name = "melted " + initial(name)
 		desc = "Charred circuit in melted plastic case."
 		icon_state = "implant_melted"
@@ -114,6 +114,8 @@
 		qdel(src)
 
 /obj/item/weapon/implant/explosive/implanted(mob/source as mob)
+	if(malfunction == IMPLANT_MALFUNCTION_PERMANENT)
+		return 0
 	phrase = input("Choose activation phrase:") as text
 	var/list/replacechars = list("'" = "", "\"" = "", ">" = "", "<" = "", "(" = "", ")" = "")
 	phrase = sanitize_simple(phrase, replacechars)
@@ -208,6 +210,8 @@ the implant may become unstable and either pre-maturely inject the subject or si
 
 
 /obj/item/weapon/implant/chem/activate(var/cause)
+	if(malfunction == IMPLANT_MALFUNCTION_PERMANENT)
+		return 0
 	if((!cause) || (!src.imp_in))
 		return 0
 	var/mob/living/carbon/R = src.imp_in
@@ -254,6 +258,8 @@ the implant may become unstable and either pre-maturely inject the subject or si
 
 
 /obj/item/weapon/implant/loyalty/implanted(mob/M)
+	if(malfunction == IMPLANT_MALFUNCTION_PERMANENT)
+		return 0
 	if(!iscarbon(M))
 		return 0
 	var/mob/living/carbon/H = M
@@ -298,6 +304,8 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	return dat
 
 /obj/item/weapon/implant/traitor/implanted(mob/M, mob/user)
+	if(malfunction == IMPLANT_MALFUNCTION_PERMANENT)
+		return 0
 	if(!iscarbon(M))
 		to_chat(user, "<span class='danger'>The implant doesn't seem to be compatible with [M]!</span>")
 		return 0
@@ -369,6 +377,8 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	return dat
 
 /obj/item/weapon/implant/adrenalin/trigger(emote, mob/source as mob)
+	if(malfunction == IMPLANT_MALFUNCTION_PERMANENT)
+		return 0
 	if (src.uses < 1)
 		return 0
 	if (emote == "pale")
@@ -495,6 +505,9 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	return dat
 
 /obj/item/weapon/implant/compressed/trigger(emote, mob/source as mob)
+	if(malfunction == IMPLANT_MALFUNCTION_PERMANENT)
+		return 0
+		
 	if (src.scanned == null)
 		return 0
 
@@ -613,6 +626,8 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	return dat
 
 /obj/item/weapon/implant/holy/implanted(mob/M)
+	if(malfunction == IMPLANT_MALFUNCTION_PERMANENT)
+		return 0
 	if(!iscarbon(M))
 		return 0
 	var/mob/living/carbon/H = M

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -23,6 +23,9 @@
 		set_tiny_label(user, " - '", "'")
 	else if (istype(I, /obj/item/weapon/implant) && !imp)
 		var/obj/item/weapon/implant/timp = I
+		if(timp.malfunction == IMPLANT_MALFUNCTION_PERMANENT)
+			user.show_message("<span class='warning'>You can't load a broken implant back into a case.</span>")
+			return 0
 		user.drop_item(timp, force_drop = 1)
 		if(timp.implanted) 
 			timp.implanted = null

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -10,8 +10,10 @@
 	var/obj/item/weapon/implant/imp = null
 
 /obj/item/weapon/implantcase/proc/update()
+	desc = initial(desc)
 	if (imp)
 		icon_state = text("implantcase-[]", imp._color)
+		desc += "<br>It is loaded with a [imp.name]."
 	else
 		icon_state = "implantcase-0"
 
@@ -19,6 +21,17 @@
 	..()
 	if (istype(I, /obj/item/weapon/pen))
 		set_tiny_label(user, " - '", "'")
+	else if (istype(I, /obj/item/weapon/implant) && !imp)
+		var/obj/item/weapon/implant/timp = I
+		user.drop_item(timp, force_drop = 1)
+		if(timp.implanted) 
+			timp.implanted = null
+		if(timp.implanted) 
+			timp.imp_in = null
+		timp.forceMove(src)
+		user.show_message("<span class='warning'>You load \the [timp] into \the [src].</span>")
+		imp = timp
+		update()
 	else if (istype(I, /obj/item/weapon/implanter))
 		var/obj/item/weapon/implanter/the_implanter = I
 		if (the_implanter.imp)

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -1,5 +1,6 @@
 /obj/item/weapon/implanter
 	name = "implanter"
+	desc = "A small device used to apply implants to people."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "implanter0"
 	item_state = "syringe_0"
@@ -10,12 +11,31 @@
 	var/imp_type = null
 
 /obj/item/weapon/implanter/proc/update()
+	desc = initial(desc)
 	icon_state = "implanter[imp? 1:0]"
+	if(imp)
+		desc += "<br>It is loaded with a [imp.name]."
 
-/obj/item/weapon/implanter/attack(mob/M as mob, mob/user as mob)
-	if(!istype(M, /mob/living/carbon))
+/obj/item/weapon/implanter/attack(var/atom/target, mob/user as mob)
+	if(!user)
 		return
-	if(user && imp)
+	var/mob/living/carbon/M = null
+	if(istype(target, /mob/living/carbon))
+		M = target
+	if(!imp)
+		if(istype(target, /obj/item/weapon/implant/))
+			var/obj/item/weapon/implant/timp = target
+			timp.forceMove(src)
+			user.show_message("<span class='warning'>You load \the [timp] into \the [src].</span>")
+			imp = timp
+			imp.implanted = null
+			imp.imp_in = null
+			update()
+			return
+		if(ismob(target))
+			user.show_message("<span class='warning'>There is no implant in \the [src].</span>")
+			return
+	if(M)
 		for (var/mob/O in viewers(M, null))
 			O.show_message("<span class='warning'>[user] is attempting to implant [M].</span>", 1)
 
@@ -59,31 +79,35 @@
 	desc = "Any humanoid injected with this implant will become loyal to the injector and the greytide, unless of course the host is already loyal to someone else."
 	imp_type = /obj/item/weapon/implant/traitor
 
-
 /obj/item/weapon/implanter/loyalty
 	name = "implanter-loyalty"
+	desc = "Any humanoid injected with this implant will become somewhat loyal to Nanotrasen and the local Heads of Staff."
 	imp_type = /obj/item/weapon/implant/loyalty
 
 /obj/item/weapon/implanter/explosive
 	name = "implanter (E)"
+	desc = "A small device used to apply implants to people. This one has a microphone and some circuitry attached for some reason."
 	imp_type = /obj/item/weapon/implant/explosive
 
 /obj/item/weapon/implanter/adrenalin
 	name = "implanter-adrenalin"
+	desc = "A small device used to apply implants to people. This one has a microphone and some circuitry attached for some reason."
 	imp_type = /obj/item/weapon/implant/adrenalin
 
 /obj/item/weapon/implanter/peace
 	name = "implanter-pax"
-	desc = "An implanter containing a pax implant"
+	desc = "Any humanoid injected with this implant will become unable to perform most physical acts of aggression."
 	imp_type = /obj/item/weapon/implant/peace
 
 /obj/item/weapon/implanter/holy
 	name = "implanter-holy"
+	desc = "This microscripture implanter helps those affected by the Occult from manifesting unwanted abilities."
 	imp_type = /obj/item/weapon/implant/holy
 
 /obj/item/weapon/implanter/compressed
 	name = "implanter (C)"
 	icon_state = "cimplanter1"
+	desc = "A small device used to apply implants to people. This one has a microphone and some circuitry attached for some reason."
 	imp_type = /obj/item/weapon/implant/compressed
 
 	var/list/forbidden_types=list(

--- a/code/game/objects/items/weapons/implants/implantfreedom.dm
+++ b/code/game/objects/items/weapons/implants/implantfreedom.dm
@@ -32,6 +32,8 @@
 	to_chat(source, "The implanted freedom implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate.")
 	return 1
 
+/obj/item/weapon/implant/freedom/handle_removal(var/mob/remover)
+	makeunusable(75)
 
 /obj/item/weapon/implant/freedom/get_data()
 	var/dat = {"

--- a/code/game/objects/items/weapons/implants/implantuplink.dm
+++ b/code/game/objects/items/weapons/implants/implantuplink.dm
@@ -16,6 +16,8 @@
 	to_chat(source, "The implanted uplink implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate.")
 	return 1
 
+/obj/item/weapon/implant/uplink/handle_removal(var/mob/remover)
+	makeunusable(75)
 
 /obj/item/weapon/implant/uplink/trigger(emote, mob/source as mob)
 	if(hidden_uplink && usr == source) // Let's not have another people activate our uplink

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -152,9 +152,14 @@
 	tool.forceMove(target)
 
 	if(istype(tool, /obj/item/weapon/implant))
-		var/obj/item/weapon/implant/disobj = tool
-		disobj.part = affected
-		affected.implants += disobj
+		var/obj/item/weapon/implant/timp = tool
+		timp.part = affected
+		affected.implants += timp
+		timp.implanted(target, user)
+		timp.forceMove(target)
+		timp.imp_in = target
+		timp.implanted = 1
+		timp.part = affected
 	affected.cavity = 0
 
 /datum/surgery_step/cavity/place_item/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -155,11 +155,11 @@
 		var/obj/item/weapon/implant/timp = tool
 		timp.part = affected
 		affected.implants += timp
-		timp.implanted(target, user)
-		timp.forceMove(target)
-		timp.imp_in = target
-		timp.implanted = 1
-		timp.part = affected
+		if(timp.implanted(target, user))
+			timp.forceMove(target)
+			timp.imp_in = target
+			timp.implanted = 1
+			timp.part = affected
 	affected.cavity = 0
 
 /datum/surgery_step/cavity/place_item/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)


### PR DESCRIPTION
+ Implanters and implant cases now tell you what implant is loaded in them upon examination
+ Implants now work properly when surgically implanted into people
+ Implants can be applied to implant cases to re-use them
+ Added descriptions to some implanters.

🆑 
- rscadd: Implanters and implant cases now tell you what implant is loaded in them upon examination.
- rscadd: Implants now work properly when surgically implanted into people.
- rscadd: Surgically removed implants can be put back into implant cases to make them implanter-compatible again.
- rscdel: (syndicate) Implants now have a (high) chance to fizzle out upon removal.
- bugfix: Implants no longer work when broken.