### PR TITLE
Un-feature castle station

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -93,9 +93,9 @@
 				binary = null
 				continue
 		if(potential == "Castle Station/") //Available if revolutionaries won
-			if(!ticker.revolutionary_victory)
-				message_admins("Skipping map [potential], revolutionaries have not won.")
-				warning("Skipping map [potential], revolutionaries have not won.")
+			if(!ticker.revolutionary_victory && !config.castle_station_allowed)
+				message_admins("Skipping map [potential], revolutionaries have not won/not enabled in config file.")
+				warning("Skipping map [potential], revolutionaries have not won/not enabled in config file.")
 				binary = null
 				continue
 		if(potential == "Bagel Station/")

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -135,6 +135,8 @@
 	var/revival_cloning = 1
 	var/revival_brain_life = -1
 
+	var/castle_station_allowed = 0 // Can you vote for tgstation-sec.dmm after a rev victory ? Off by
+
 	//Used for modifying movement speed for mobs.
 	//Unversal modifiers
 	var/run_speed = 0
@@ -675,6 +677,8 @@
 					hardcore_mode = value
 				if("humans_speak")
 					voice_noises = 1
+				if("castle_station_allowed")
+					castle_station_allowed = 1
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 

--- a/config-example/config.txt
+++ b/config-example/config.txt
@@ -247,6 +247,9 @@ RESPAWN_AS_MOMMI
 ## Uncomment to use the paperwork library
 #PAPERWORK_LIBRARY
 
+## Uncomment to allow tgstation-sec.dmm to be voted after a rev victory
+#CASTLE_STATION_ALLOWED
+
 ## Uncomment to enable sending data to the IRC bot.
 #USE_IRC_BOT
 


### PR DESCRIPTION
This PR locks castle station behind a config setting, **off by default**. In essence, it removes it from votable maps while making it fairly easy to enable for downstream servers or any other reason in the future.

Meant as an alternative of #28713. Made for the same reasons : an openly TDM map that isn't explicitly TDM. 
The former PR made it clear that Castle does not follow the same escalation rules as other maps, wheras this PR just removes Castle station.

Feel free to vote or voice your concerns on any alternative.

:cl:
- rscdel: Castle Station is no longer a selectable map.