### PR TITLE
Fixes projectiles infinitely looping between windows

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -130,7 +130,9 @@ var/list/one_way_windows
 	health -= Proj.damage
 	..()
 	healthcheck(Proj.firer)
-	return
+	if (health > 0)
+		return PROJECTILE_COLLISION_BLOCKED
+	return PROJECTILE_COLLISION_DEFAULT
 
 //This ex_act just removes health to be fully modular with "bomb-proof" windows
 /obj/structure/window/ex_act(severity)


### PR DESCRIPTION
This happened because #28705 tweaked projectile code by using (and expecting) `bullet_act` to return various hints, without changing the code for windows (which always returned `null`).

This resulted in weird behaviours such as any non-laser projectile randomly phasing through a window, then getting stuck on the second window on the tile, thus constantly calling its `bullet_act`, which could cause infinite noise (for non-damaging projectiles, such as a taser) or infinite explosions (for low-yield rockets).

In some weirder cases, a taser electrode could, after a very long time banging at the window, break it and continue its journey in space.

Fixed it by making windows return proper hints on `bullet_act`.

### Tested

Lasers still pass through windows, tasers are blocked, damaging projectiles are blocked and break the window.