### PR TITLE
No cargo shuttle on castle station

### DIFF
--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -133,6 +133,9 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 	if(moving)
 		return 0
 
+	if (!map.supply_shuttle_check())
+		return 0
+
 	if(forbidden_atoms_check(cargo_shuttle.linked_area))
 		return 0
 

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -206,6 +206,10 @@ var/global/list/accessable_z_levels = list()
 /datum/map/proc/map_equip(var/mob/living/carbon/human/H)
 	return
 
+// -- Can we move the supply shuttle around?
+/datum/map/proc/supply_shuttle_check()
+	return TRUE
+
 ////////////////////////////////////////////////////////////////
 
 /datum/zLevel

--- a/maps/tgstation-sec.dm
+++ b/maps/tgstation-sec.dm
@@ -95,6 +95,10 @@
 		return FALSE
 	return TRUE
 
+// -- Castle doesn't have a centcomm connection because they separated
+/datum/map/active/supply_shuttle_check()
+	return FALSE
+
 ////////////////////////////////////////////////////////////////
 #include "tgstation-sec.dmm"
 #endif


### PR DESCRIPTION
After the revolutionary victory on the 16th of June, 2564, Nanotrasen has halted all support of the rogue installation known as Space Station 13. The most immediately noticeable effect of this is that  the cargo department is now unable to order supplies from outside the station, and instead they must work hand in hand with their comrades to collect resources and produce anything that the station may need.

This does what it says on the tin. Cargo can't send the shuttle anymore. The intent of this PR is to foster some semblance of cooperation between cargo, science, and the other departments on Castle station rather than the usual Cargonia independence memes. 

:cl:
* rscdel: Removes the ability to use the cargo shuttle on castle station