### PR TITLE
Fixed the name of both ectoplasm and diabeetusol

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -8758,7 +8758,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 
 
 /datum/reagent/diabeetusol
-	name = "diabeetusol"
+	name = "Diabeetusol"
 	id = DIABEETUSOL
 	description = "The mistaken byproduct of confectionery science. Targets the beta pancreatic cells, or equivalent, in carbon based life to not only cease insulin production but begin producing what medical science can only describe as 'the concept of obesity given tangible form'."
 	reagent_state = REAGENT_STATE_LIQUID
@@ -8799,7 +8799,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 
 
 /datum/reagent/ectoplasm
-	name = "ectoplasm"
+	name = "Ectoplasm"
 	id = ECTOPLASM
 	description = "Pure, distilled spooky"
 	reagent_state = REAGENT_STATE_LIQUID


### PR DESCRIPTION
It was rustling my jimmies that Ectoplasm was named "ectoplasm" in game instead of "Ectoplasm". Noticed that Diabeetusol had the same problem, so fixed too.
[tweak]
:cl:
 * rscadd: Capitalised the first letter on "Ectoplasm" and "Diabeetusol" so they match the naming scheme (first letter uppercase)