### PR TITLE
Adding a 1 sec cooldown to the Gravity Artifact effect when activated by Touch

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_gravity.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_gravity.dm
@@ -5,6 +5,7 @@
 	effect_type = 1
 
 	var/pull_strength
+	var/touch_pull_cooldown = FALSE
 	copy_for_battery = list("pull_strength")
 
 /datum/artifact_effect/gravity/New()
@@ -13,7 +14,11 @@
 	pull_strength = pick(STAGE_ONE,STAGE_TWO,STAGE_THREE,STAGE_FOUR,10;STAGE_FIVE)
 
 /datum/artifact_effect/gravity/DoEffectTouch()
-	gravitypull(effectrange)
+	if (!touch_pull_cooldown)
+		touch_pull_cooldown = TRUE
+		gravitypull(effectrange)
+		spawn(10)
+			touch_pull_cooldown = FALSE
 
 /datum/artifact_effect/gravity/DoEffectAura()
 	gravitypull(round(effectrange/3))


### PR DESCRIPTION
And no I added neither this effect nor artifacts activating when YOU bump into THEM, stop pinging me.

:cl:
* bugfix: The Gravity artifact effect now has a one second cooldown if activated through touch to prevent server-crashing infinite loops. Also this has technically been a feature since 2016, interesting it took this long to cause a crash.