### PR TITLE
Clown Language colour from yellow to mild pink - Mimes can now understand clown language.

### DIFF
--- a/__DEFINES/stylesheet.dm
+++ b/__DEFINES/stylesheet.dm
@@ -83,7 +83,7 @@ h1.alert, h2.alert		{color: #000000;}
 .slime					{color: #34A7Af;}
 .orange					{color: #ffa500;}
 .maroon					{color: #800000;}
-.clown 					{color: #FBFF35; font-family: Comic Sans MS, Comic Sans, cursive;}
+.clown 					{color: #ff9fef; font-family: Comic Sans MS, Comic Sans, cursive;}
 /* If you're adding a new class here, add it to browserOutput.css too! */
 
 /* /vg/ */

--- a/code/datums/outfit/civilian.dm
+++ b/code/datums/outfit/civilian.dm
@@ -424,6 +424,8 @@
 		H.add_spell(new /spell/aoe_turf/conjure/forcewall/mime, "grey_spell_ready")
 		H.add_spell(new /spell/targeted/oathbreak/)
 		mob_rename_self(H,"mime")
+		H.add_language(LANGUAGE_CLOWN)
+		to_chat(H, "<span class = 'notice'>The Clown-Mime war may have ended, but you were still taught their language. You can understand clownspeak as well as speak it, but a Mime wouldn't stoop so low, right?</span>")
 		if (H.mind)
 			H.mind.miming = MIMING_OUT_OF_CHOICE
 

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -126,7 +126,7 @@ h1.alert, h2.alert		{color: #000000;}
 .orange					{color: #ffa500;}
 .borange				{color: #ffa500; font-weight: bold;}
 .maroon					{color: #800000;}
-.clown 					{color: #FBFF35; font-family: Comic Sans MS, Comic Sans, cursive;}
+.clown 					{color: #ff9fef; font-family: Comic Sans MS, Comic Sans, cursive;}
 
 .good					{color: green;}
 .average				{color: #FF8000;}

--- a/goon/browserassets/css/browserOutput_dark.css
+++ b/goon/browserassets/css/browserOutput_dark.css
@@ -35,6 +35,7 @@ a:visited {color: #7c00e6;}
 .mushroom {color: #ab62b1;}
 .alien {color: #b162a9;}
 .solcom	{color: #256194;}
+.clown {color: #FBFF35; font-family: Comic Sans MS, Comic Sans, cursive;}
 
 .radio {color: #1ecc43;}
 .comradio {color: #5177ff;}


### PR DESCRIPTION
No fun if people get actually annoyed by the yellow. So colour change. Also, to avoid that whole Clown Sekrit Klub thing, gave Clown language to the mime as well, as Dacendeth suggested on #28678.
Closes both #28724 and #28737.
[tweak]

:cl:
 * rscadd: Mimes now also know the Clown language, as per that whole "Clown-Mime War" thing.
 * tweak: Changed the Clown Language's colour from #FBFF35 (Bright yellow) to #FF9FEF (Light Pink).