### PR TITLE
Reduces roomba attack cooldown from 10 (TEN) seconds to 5

### DIFF
--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -38,7 +38,7 @@
 
 	//for attack code
 	var/coolingdown = FALSE
-	var/attackcooldown = 10 SECONDS // for admin cancer
+	var/attackcooldown = 5 SECONDS // for admin cancer
 	locked = FALSE
 	can_take_pai = TRUE
 	commanding_radio = /obj/item/radio/integrated/signal/bot/janitor


### PR DESCRIPTION
It used to be just one second, but that was too low. 
It was then changed all the way to TEN SECONDS.
That's so much time, holy shit. It feels like an eternity. So much can be done in ten seconds.
This halves it to five, which is still a shit-ton compared to the original one..

<!--
[tweak]
-->
:cl:
 * tweak: roomba stab cooldown is now five seconds as opposed to ten