### PR TITLE
Adds a medical robot surgery upgrade board

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -11,6 +11,7 @@
 	var/list/required_modules = list()
 	var/list/required_upgrades = list()
 	var/list/modules_to_add = list()
+	var/list/modules_to_remove = list() //Use this if you want to replace or disable items that the borg might already have
 	var/multi_upgrades = FALSE
 	w_type = RECYK_ELECTRONIC
 
@@ -62,6 +63,13 @@
 		for(var/module_to_add in modules_to_add)
 			if(!locate_component(module_to_add, R))
 				R.module.modules += new module_to_add(R.module)
+
+	if(modules_to_remove.len)
+		for(var/module_to_remove in modules_to_remove)
+			var/delete_object = locate_component(module_to_remove, R)
+			if(delete_object)
+				R.module.modules -= delete_object
+				qdel(delete_object)
 
 	to_chat(user, "<span class='notice'>You successfully apply \the [src] to \the [R].</span>")
 	user.drop_item(src, R)
@@ -225,6 +233,16 @@
 	icon_state = "cyborg_upgrade"
 	required_modules = list(MEDICAL_MODULE, SYNDIE_CRISIS_MODULE)
 	modules_to_add = list(/obj/item/weapon/melee/defibrillator,/obj/item/weapon/reagent_containers/borghypo/upgraded)
+
+/obj/item/borg/upgrade/medical/surgery
+	name = "medical cyborg advanced surgery pack"
+	desc = "Enables a medical cyborg to have advanced surgery tools."
+	modules_to_add = list(/obj/item/weapon/scalpel/laser/tier2, /obj/item/weapon/circular_saw/plasmasaw,
+	/obj/item/weapon/retractor/manager, /obj/item/weapon/hemostat/pico, /obj/item/weapon/surgicaldrill/diamond,
+	/obj/item/weapon/bonesetter/bone_mender, /obj/item/weapon/FixOVein/clot)
+	modules_to_remove = list(/obj/item/weapon/scalpel, /obj/item/weapon/hemostat, /obj/item/weapon/retractor,
+	/obj/item/weapon/circular_saw, /obj/item/weapon/cautery, /obj/item/weapon/surgicaldrill, /obj/item/weapon/bonesetter,
+	/obj/item/weapon/FixOVein)
 
 /obj/item/borg/upgrade/medical/organ_gripper
 	name = "medical cyborg organ gripper upgrade"

--- a/code/modules/research/designs/borg_upgrades.dm
+++ b/code/modules/research/designs/borg_upgrades.dm
@@ -88,14 +88,24 @@
 	category = "Robotic_Upgrade_Modules"
 	materials = list(MAT_IRON=80000, MAT_PLASMA=50000, MAT_URANIUM=5000, MAT_DIAMOND=5000, MAT_PLASTIC=5000)
 
-/datum/design/medical_module_surgery
+/datum/design/medical_module_improved
 	name = "Medical cyborg MK-2 upgrade"
 	desc = "Used to give a medical cyborg advanced care tools."
-	id = "medical_module_surgery"
+	id = "medical_module_upgrade"
 	req_tech = list(Tc_BIOTECH = 3, Tc_ENGINEERING = 3)
 	build_type = MECHFAB
 	materials = list(MAT_IRON=80000, MAT_GLASS=20000, MAT_SILVER=5000)
 	build_path = /obj/item/borg/upgrade/medical
+	category = "Robotic_Upgrade_Modules"
+
+/datum/design/medical_module_surgery
+	name = "Medical cyborg surgery tools upgrade"
+	desc = "Replaces the medical robot's surgery tools with advanced ones."
+	id = "medical_module_surgery"
+	req_tech = list(Tc_MATERIALS = 5, Tc_ENGINEERING = 4, Tc_BIOTECH = 5, Tc_PLASMATECH = 3) //Same as a plasma saw
+	build_type = MECHFAB
+	materials = list(MAT_IRON = 70000, MAT_GLASS = 38000, MAT_SILVER = 1750, MAT_GOLD = 500, MAT_URANIUM = 750, MAT_PLASMA = 580) //Diamonds are on the house
+	build_path = /obj/item/borg/upgrade/medical/surgery
 	category = "Robotic_Upgrade_Modules"
 
 /datum/design/borg_organ_gripper_board


### PR DESCRIPTION
Done by request @iFlashYou 
Replaces the medical cyborg's tools with advanced ones, costs as much as all the advanced surgery tools combined (minus diamonds, per request) and requires enough research to unlock the plasma saw
Added support for removing cyborg modules
Renamed the MK-2 upgrade module a little in the code

:cl:
 * rscadd: Added a new medical robot board that upgrades its surgery tools.