### PR TITLE
Fix Vox Armalis taking the whole MC with them when they die

### DIFF
--- a/code/modules/mob/living/simple_animal/vox.dm
+++ b/code/modules/mob/living/simple_animal/vox.dm
@@ -33,7 +33,10 @@
 	var/quills = 3
 
 /mob/living/simple_animal/vox/armalis/death(var/gibbed = FALSE)
-	..(TRUE)
+	if (gibbed)
+		..()
+		return
+
 	var/turf/gloc = get_turf(loc)
 	visible_message("<span class='danger'><B>[src] shudders violently and explodes!</B>","<span class='warning'>You feel your body rupture!</span></span>")
 	gib()


### PR DESCRIPTION
`gib()` calls `death(1)` so this used to stack overflow. Fixed now.