### PR TITLE
Make ALL bullet_act() calls in the game return something

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -85,7 +85,7 @@
 
 /obj/structure/cult/bullet_act(var/obj/item/projectile/Proj)
 	takeDamage(Proj.damage)
-	..()
+	return ..()
 
 /obj/structure/cult/attackby(var/obj/item/weapon/W, var/mob/user)
 	if (istype(W, /obj/item/weapon/grab))

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -942,7 +942,7 @@ var/list/arcane_tomes = list()
 		takeDamage(O.throwforce)
 
 /obj/item/weapon/melee/soulblade/bullet_act(var/obj/item/projectile/P)
-	..()
+	. = ..()
 	takeDamage(P.damage)
 
 /obj/item/weapon/melee/soulblade/proc/capture_shade(var/mob/living/simple_animal/shade/target, var/mob/user)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_projectiles.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_projectiles.dm
@@ -177,6 +177,7 @@
 	if (blade)
 		return blade.hitby(AM)
 
+SHOULD_CALL_PARENT(FALSE)
 /obj/item/projectile/soulbullet/bullet_act(var/obj/item/projectile/P)
 	if (blade)
 		return blade.bullet_act(P)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_projectiles.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_projectiles.dm
@@ -177,7 +177,6 @@
 	if (blade)
 		return blade.hitby(AM)
 
-SHOULD_CALL_PARENT(FALSE)
 /obj/item/projectile/soulbullet/bullet_act(var/obj/item/projectile/P)
 	if (blade)
 		return blade.bullet_act(P)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -250,7 +250,7 @@ var/global/list/ghdel_profiling = list()
 	return 1
 
 /atom/proc/bullet_act(var/obj/item/projectile/Proj)
-	return 0
+	return PROJECTILE_COLLISION_DEFAULT
 
 /atom/proc/in_contents_of(container)//can take class or object instance as argument
 	if(ispath(container))

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -172,7 +172,7 @@ var/list/blob_overminds = list()
 	return
 
 /obj/effect/blob/bullet_act(var/obj/item/projectile/Proj)
-	..()
+	. = ..()
 	switch(Proj.damage_type)
 		if(BRUTE)
 			health -= (Proj.damage/brute_resist)
@@ -181,7 +181,7 @@ var/list/blob_overminds = list()
 
 	update_health()
 	update_icon()
-	return 0
+	return
 
 /obj/effect/blob/attackby(var/obj/item/weapon/W, var/mob/living/user)
 	user.do_attack_animation(src, W)

--- a/code/game/gamemodes/endgame/xmas/snowman.dm
+++ b/code/game/gamemodes/endgame/xmas/snowman.dm
@@ -43,6 +43,7 @@
 
 /obj/structure/snowman/bullet_act(var/obj/item/projectile/Proj)
 	takedamage(Proj.damage)
+	return ..()
 
 /obj/structure/snowman/proc/takedamage(var/dam)
 	health -= dam

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1210,7 +1210,8 @@ FIRE ALARM
 	return src.attack_hand(user)
 
 /obj/machinery/firealarm/bullet_act(BLAH)
-	return src.alarm()
+	src.alarm()
+	return ..()
 
 /obj/machinery/firealarm/CtrlClick(var/mob/user)
 	if(user.incapacitated() || (!in_range(src, user) && !issilicon(user)))

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -255,7 +255,7 @@
 	if(Proj.damage)
 		src.health -= round(Proj.damage / 2)
 		healthcheck()
-	..()
+	return ..()
 
 /obj/machinery/portable_atmospherics/canister/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	if(iswelder(W) && src.destroyed)

--- a/code/game/machinery/bees_apiary.dm
+++ b/code/game/machinery/bees_apiary.dm
@@ -138,10 +138,9 @@ var/list/apiaries_list = list()
 		else if (prob(1/(yieldmod * yieldmod) *100))//This formula gives you diminishing returns based on yield. 100% with 1 yield, decreasing to 25%, 11%, 6, 4, 2...
 			yieldmod += 1
 	else
-		..()
 		if(src)
 			angry_swarm()
-		return
+	return ..()
 
 /obj/machinery/apiary/hitby(AM as mob|obj)
 	. = ..()
@@ -539,7 +538,7 @@ var/list/apiaries_list = list()
 
 
 /obj/structure/wild_apiary/bullet_act(var/obj/item/projectile/P)
-	..()
+	. = ..()
 	if(P.damage && P.damtype != HALLOSS)
 		health -= P.damage
 		updateHealth()
@@ -573,7 +572,7 @@ var/list/apiaries_list = list()
 	var/health = 100
 
 /obj/machinery/apiary/wild/bullet_act(var/obj/item/projectile/P)
-	..()
+	. = ..()
 	if(P.damage && P.damtype != HALLOSS)
 		health -= P.damage
 		updateHealth()

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -675,7 +675,7 @@
 	if(flags & INVULNERABLE)
 		return
 	health -= Proj.damage
-	..()
+	. = ..()
 	healthcheck()
 
 /obj/machinery/bot/blob_act()

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -681,7 +681,7 @@ Auto Patrol: []"},
 			sleep(100)
 			disabled = 0
 		else
-			..()
+			. = ..()
 	else if((lasercolor == "r") && (disabled == 0))
 		if(istype(Proj, /obj/item/projectile/beam/lasertag/blue))
 			disabled = 1
@@ -690,9 +690,9 @@ Auto Patrol: []"},
 			sleep(100)
 			disabled = 0
 		else
-			..()
+			. = ..()
 	else
-		..()
+		return ..()
 
 /obj/machinery/bot/ed209/proc/check_for_weapons(var/obj/item/slot_item) //Unused anywhere, copypasted in secbot.dm
 	if(istype(slot_item, /obj/item/weapon/gun) || istype(slot_item, /obj/item/weapon/melee))

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -417,7 +417,7 @@
 /obj/machinery/bot/medbot/bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.flag == "taser")
 		stunned = min(stunned+10,20)
-	..()
+	return ..()
 
 /obj/machinery/bot/medbot/explode()
 	on = 0

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -190,7 +190,7 @@ var/global/mulebot_count = 0
 	if(prob(25))
 		src.visible_message("<span class='warning'>Something shorts out inside [src]!</span>")
 		wires.RandomCut()
-	..()
+	return ..()
 
 
 /obj/machinery/bot/mulebot/attack_ai(var/mob/user)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -202,9 +202,10 @@ var/list/camera_messages = list()
 
 /obj/machinery/camera/bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.damtype == HALLOSS)
-		return
+		return ..()
 
 	take_damage(Proj.damage)
+	return ..()
 
 /obj/machinery/camera/proc/dismantle()
 	if(assembly)
@@ -540,7 +541,7 @@ var/list/camera_messages = list()
 	return
 
 /obj/machinery/camera/arena/bullet_act(var/obj/item/projectile/Proj)
-	return
+	return ..()
 
 /obj/machinery/camera/arena/spesstv
 	name = "\improper Spess.TV camera"

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -67,7 +67,7 @@
 /obj/machinery/computer/bullet_act(var/obj/item/projectile/Proj)
 	if(prob(Proj.damage))
 		set_broken()
-	..()
+	return ..()
 
 /obj/machinery/computer/attack_construct(var/mob/user)
 	if (!Adjacent(user))

--- a/code/game/machinery/computer/shuttle_computers.dm
+++ b/code/game/machinery/computer/shuttle_computers.dm
@@ -574,6 +574,7 @@
 
 /obj/machinery/computer/shuttle_control/bullet_act(var/obj/item/projectile/Proj)
 	visible_message("[Proj] ricochets off [src]!")
+	return ..() // Nothing happens (?)
 
 /obj/machinery/computer/shuttle_control/proc/link_to(var/datum/shuttle/S, var/add_to_list = 1)
 	if(shuttle)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -58,7 +58,7 @@
 		take_damage(W.force, W.damtype)
 
 /obj/machinery/deployable/barrier/bullet_act(var/obj/item/projectile/Proj)
-	..()
+	. = ..()
 	if(Proj.damage)
 		take_damage(Proj.damage, Proj.damage_type)
 

--- a/code/game/machinery/doors/mineral.dm
+++ b/code/game/machinery/doors/mineral.dm
@@ -230,7 +230,7 @@
 		if(!try_closing)
 			try_closing = TRUE
 			process()
- 
+
 /obj/machinery/door/mineral/wood/log/close()
 	..()
 	if(density) //successful, cease processing
@@ -263,6 +263,7 @@
 	if(Proj.damage_type == BRUTE || Proj.damage_type == BURN)
 		hardness -= Proj.damage/100
 		CheckHardness()
+	return ..()
 
 /obj/machinery/door/mineral/resin/open()
 	..()
@@ -370,6 +371,7 @@
 	if(Proj.damage_type == BRUTE || Proj.damage_type == BURN)
 		health -= Proj.damage
 		CheckHardness()
+	return ..()
 
 /obj/machinery/door/mineral/cult/attackby(var/obj/item/weapon/W, var/mob/user)
 	if(istype(W, /obj/item/weapon/card))

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -195,10 +195,7 @@
 /obj/machinery/door/window/bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.damage)
 		take_damage(round(Proj.damage / 2))
-	..()
-	if (health > 0)
-		return PROJECTILE_COLLISION_BLOCKED
-	return PROJECTILE_COLLISION_DEFAULT
+	return ..()
 
 //When an object is thrown at the window
 /obj/machinery/door/window/hitby(atom/movable/AM)

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -243,6 +243,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			else
 				playsound(src, 'sound/effects/Glasshit.ogg', 100, 1)
 			update_icon()
+	return ..()
 
 /obj/machinery/newscaster/attack_ai(mob/user as mob)
 	add_hiddenprint(user)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -296,7 +296,7 @@ Status: []<BR>"},
 		attacked += 5
 
 	src.health -= Proj.damage
-	..()
+	. = ..()
 	if(prob(45) && Proj.damage > 0)
 		spark(src, 5, FALSE)
 	if (src.health <= 0)

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -75,7 +75,7 @@
 
 /obj/machinery/shield/bullet_act(var/obj/item/projectile/Proj)
 	health -= Proj.damage
-	..()
+	. = ..()
 	if(health <=0)
 		visible_message("<span class='notice'>The [src] dissapates</span>")
 		qdel(src)
@@ -522,7 +522,7 @@
 
 /obj/machinery/shieldwallgen/bullet_act(var/obj/item/projectile/Proj)
 	storedpower -= Proj.damage
-	..()
+	return ..()
 
 //////////////Containment Field START
 /obj/machinery/shieldwall
@@ -583,7 +583,7 @@
 		else
 			G = gen_secondary
 		G.storedpower -= Proj.damage
-	..()
+	return ..()
 
 
 /obj/machinery/shieldwall/ex_act(severity)

--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -163,7 +163,7 @@
 			shootAt(cur_target)
 			cur_target = get_new_target()
 		else
-			cur_target = get_new_target() 
+			cur_target = get_new_target()
 	if(cur_target) //if it's found, proceed
 //		to_chat(world, "[cur_target]")
 		if(!isPopping())
@@ -251,7 +251,7 @@
 
 /obj/machinery/turret/bullet_act(var/obj/item/projectile/Proj)
 	src.health -= Proj.damage
-	..()
+	. = ..()
 	if(prob(45) && Proj.damage > 0)
 		spark(src, 5, FALSE)
 
@@ -542,9 +542,7 @@
 
 /obj/structure/turret/gun_turret/bullet_act(var/obj/item/projectile/Proj)
 	src.take_damage(Proj.damage)
-	..()
-	return
-
+	return ..()
 
 /obj/structure/turret/gun_turret/attack_hand(mob/user as mob)
 	user.set_machine(src)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -649,8 +649,7 @@
 /obj/mecha/bullet_act(var/obj/item/projectile/Proj) //wrapper
 	src.log_message("Hit by projectile. Type: [Proj.name]([Proj.flag]).",1)
 	call((proc_res["dynbulletdamage"]||src), "dynbulletdamage")(Proj) //calls equipment
-	..()
-	return
+	return ..()
 
 /obj/mecha/proc/dynbulletdamage(var/obj/item/projectile/Proj)
 	if(prob(src.deflect_chance) && !is_type_in_list(Proj, never_deflect))

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -55,7 +55,7 @@
 		qdel(E)
 
 /obj/effect/decal/mecha_wreckage/bullet_act(var/obj/item/projectile/Proj)
-	return
+	return null
 
 /obj/effect/decal/mecha_wreckage/examine(var/mob/user)
 	..()

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -62,7 +62,7 @@
 
 /obj/effect/alien/resin/bullet_act(var/obj/item/projectile/Proj)
 	health -= Proj.damage
-	..()
+	. = ..()
 	healthcheck()
 
 /obj/effect/alien/resin/ex_act(severity)
@@ -528,7 +528,7 @@
 
 /obj/effect/alien/egg/bullet_act(var/obj/item/projectile/Proj)
 	health -= Proj.damage
-	..()
+	. = ..()
 	healthcheck()
 
 

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -914,6 +914,7 @@ steam.start() -- spawns the effect
 /obj/structure/foamedmetal/bullet_act()
 	if(metal==1 || prob(50))
 		qdel(src)
+	return ..()
 
 /obj/structure/foamedmetal/attack_paw(var/mob/user)
 	attack_hand(user)

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -160,6 +160,7 @@
 
 /obj/effect/dummy/chameleon/bullet_act()
 	disrupt()
+	return ..()
 
 /obj/effect/dummy/chameleon/relaymove(var/mob/user, direction)
 	if(istype(loc, /turf/space))

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -148,9 +148,9 @@
 
 		icon = virtualIcon // apply bulletholes over decals
 
-		return
+		return ..()
 
-	return -1 // the bullet/projectile goes through the target! Ie, you missed
+	return PROJECTILE_COLLISION_MISS // the bullet/projectile goes through the target! Ie, you missed
 
 
 // Small memory holder entity for transparent bullet holes

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1269,6 +1269,7 @@
 
 /obj/item/toy/balloon/inflated/bullet_act()
 	pop()
+	return ..()
 
 /obj/item/toy/balloon/inflated/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature > T0C+100)

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -117,7 +117,7 @@
 	if(istype(Proj ,/obj/item/projectile/beam)||istype(Proj,/obj/item/projectile/bullet))
 		if(!istype(Proj ,/obj/item/projectile/beam/lasertag) && !istype(Proj ,/obj/item/projectile/beam/practice) && !Proj.nodamage)
 			health -= Proj.damage
-	..()
+	. = ..()
 	if(health <= 0)
 		for(var/atom/movable/A in src)
 			remove_from_storage(A, get_turf(src))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -358,7 +358,7 @@
 
 /obj/structure/closet/bullet_act(var/obj/item/projectile/Proj)
 	health -= Proj.damage
-	..()
+	. = ..()
 	if(health <= 0)
 		broken = 1
 		if(has_electronics)

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -157,7 +157,7 @@
 		for(var/mob/M in src)
 			shatter(M)
 
-	return
+	return ..()
 
 /obj/structure/closet/statue/attack_animal(mob/living/simple_animal/user as mob)
 	if(user.environment_smash_flags & SMASH_CONTAINERS)

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -32,8 +32,9 @@
 	if(!P.nodamage)
 		visible_message("<span class='warning'>[P] tears \the [src] down!</span>")
 		qdel(src)
+		return // Blank, nothing happening
 	else
-		..()
+		return ..()
 
 /obj/structure/curtain/attack_hand(mob/user)
 	playsound(loc, "rustle", 15, 1, -5)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -98,7 +98,7 @@
 
 /obj/structure/displaycase/bullet_act(var/obj/item/projectile/Proj)
 	health -= Proj.damage
-	..()
+	. = ..()
 	src.healthcheck()
 	return
 

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -324,8 +324,7 @@
 /obj/structure/girder/bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.destroy)
 		src.ex_act(2)
-	..()
-	return 0
+	return ..()
 
 /obj/structure/girder/ex_act(severity)
 	switch(severity)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -157,7 +157,7 @@
 		return
 	health -= Proj.damage //Just use the projectile damage, it already has high odds of "missing"
 	healthcheck(hitsound = 1)
-	return 0
+	return ..()
 
 /obj/structure/grille/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	user.delayNextAttack(8)

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -154,7 +154,7 @@
 	..()
 
 /obj/structure/inflatable/bullet_act(var/obj/item/projectile/Proj)
-	..()
+	. = ..()
 	if(Proj.damage)
 		take_damage(Proj.damage)
 

--- a/code/game/objects/structures/lamarr_cage.dm
+++ b/code/game/objects/structures/lamarr_cage.dm
@@ -27,7 +27,7 @@
 
 /obj/structure/lamarr/bullet_act(var/obj/item/projectile/Proj)
 	health -= Proj.damage
-	..()
+	. = ..()
 	src.healthcheck()
 	return
 

--- a/code/game/objects/structures/mannequin.dm
+++ b/code/game/objects/structures/mannequin.dm
@@ -210,8 +210,7 @@
 
 /obj/structure/mannequin/bullet_act(var/obj/item/projectile/Proj)
 	getDamage(Proj.damage)
-	..()
-
+	return ..()
 
 /obj/structure/mannequin/blob_act()
 	if (prob(75))

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -129,7 +129,7 @@
 			shatter()
 		else
 			playsound(src, 'sound/effects/hit_on_shattered_glass.ogg', 70, 1)
-	..()
+	return ..()
 
 
 /obj/structure/mirror/attackby(obj/item/I as obj, mob/living/user as mob)
@@ -230,5 +230,5 @@
 
 			if("Appearance")
 				targ.pick_appearance(M)
-				
+
 		to_chat(targ, "<span class='notice'>You gaze into the [src].</span>")

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -427,6 +427,7 @@
 	else if(!istype(Proj ,/obj/item/projectile/beam/lasertag) && !istype(Proj ,/obj/item/projectile/beam/practice) )
 		if(prob(Proj.damage))
 			src.ex_act(2)
+	return ..()
 
 /obj/structure/piano/xylophone
 	name = "xylophone"

--- a/code/game/objects/structures/popout_cake.dm
+++ b/code/game/objects/structures/popout_cake.dm
@@ -171,8 +171,8 @@
 
 /obj/structure/popout_cake/bullet_act(var/obj/item/projectile/Proj)
 	slices_amount -= clamp(round(Proj.damage / 3), 1, 4)
-
 	check_slices()
+	return ..()
 
 //When spawned, stuffs the corpse underneath it inside
 /obj/structure/popout_cake/corpse_grabber/New()

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -82,7 +82,7 @@
 
 /obj/structure/bed/nest/bullet_act(var/obj/item/projectile/Proj)
 	health -= Proj.damage
-	..()
+	. = ..()
 	healthcheck()
 
 /obj/structure/bed/nest/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -60,8 +60,7 @@
 /obj/structure/table/bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.destroy)
 		src.ex_act(1)
-	..()
-	return 0
+	return ..()
 
 /obj/structure/table/proc/destroy()
 	if(parts)
@@ -731,8 +730,7 @@ obj/structure/table/plastic
 /obj/structure/rack/bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.destroy)
 		src.ex_act(1)
-	..()
-	return 0
+	return ..()
 
 /obj/structure/rack/ex_act(severity)
 	switch(severity)

--- a/code/game/objects/structures/vehicles/adminbus.dm
+++ b/code/game/objects/structures/vehicles/adminbus.dm
@@ -407,7 +407,7 @@
 
 /obj/structure/bed/chair/vehicle/adminbus/bullet_act(var/obj/item/projectile/Proj)
 	visible_message("<span class='warning'>The projectile harmlessly bounces off the bus.</span>")
-	return
+	return ..()
 
 /obj/structure/bed/chair/vehicle/adminbus/ex_act(severity)
 	visible_message("<span class='warning'>The bus withstands the explosion with no damage.</span>")

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -128,11 +128,8 @@ var/list/one_way_windows
 /obj/structure/window/bullet_act(var/obj/item/projectile/Proj)
 
 	health -= Proj.damage
-	..()
+	. = ..()
 	healthcheck(Proj.firer)
-	if (health > 0)
-		return PROJECTILE_COLLISION_BLOCKED
-	return PROJECTILE_COLLISION_DEFAULT
 
 //This ex_act just removes health to be fully modular with "bomb-proof" windows
 /obj/structure/window/ex_act(severity)

--- a/code/modules/optics/mirrors/mirror.dm
+++ b/code/modules/optics/mirrors/mirror.dm
@@ -255,9 +255,9 @@ var/global/list/obj/machinery/mirror/mirror_list = list()
 
 /obj/machinery/mirror/bullet_act(var/obj/item/projectile/P, var/def_zone)
 	if(!istype(P, /obj/item/projectile/beam))
-		return
+		return ..()
 	if(P.damage < initial(P.damage)/4)  //Can only be reflected 5 times, let's say
-		return
+		return ..()
 	var/list/deflections = get_deflections(get_dir(src,P))
 	var/turf/T = get_turf(src)
 	for(var/i=1 to nsplits)
@@ -275,3 +275,4 @@ var/global/list/obj/machinery/mirror/mirror_list = list()
 		B.damage = P.damage/2
 		spawn()
 			B.process()
+	return ..()

--- a/code/modules/power/ShieldGen/energy_field.dm
+++ b/code/modules/power/ShieldGen/energy_field.dm
@@ -19,6 +19,7 @@
 
 /obj/effect/energy_field/bullet_act(var/obj/item/projectile/Proj)
 	Stress(Proj.damage / 10)
+	return ..()
 
 /obj/effect/energy_field/proc/Stress(var/severity)
 	strength -= severity

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -151,8 +151,7 @@
 /obj/machinery/power/am_control_unit/bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.flag != "bullet")
 		stability -= Proj.force
-	return 0
-
+	return ..()
 
 /obj/machinery/power/am_control_unit/power_change()
 	..()

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -95,7 +95,7 @@ proc/cardinalrange(var/center)
 			if(!priorscan)
 				sleep(20)
 				controllerscan(1)
-				return 
+				return
 
 // Find surrounding unconnected shielding and add them to our controller
 /obj/machinery/am_shielding/proc/assimilate()
@@ -153,7 +153,7 @@ proc/cardinalrange(var/center)
 /obj/machinery/am_shielding/bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.flag != "bullet")
 		stability -= Proj.force/2
-	return 0
+	return ..()
 
 
 /obj/machinery/am_shielding/update_icon()

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -169,6 +169,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	if(istype(Proj ,/obj/item/projectile/beam)||istype(Proj,/obj/item/projectile/bullet)||istype(Proj,/obj/item/projectile/ricochet))
 		if(!istype(Proj ,/obj/item/projectile/beam/lasertag) && !istype(Proj ,/obj/item/projectile/beam/practice) )
 			broken()
+	return ..()
 
 /obj/machinery/light/kick_act(mob/living/carbon/human/H)
 	H.visible_message("<span class='danger'>[H] attempts to kick \the [src].</span>", "<span class='danger'>You attempt to kick \the [src].</span>")

--- a/code/modules/power/meteor_battery.dm
+++ b/code/modules/power/meteor_battery.dm
@@ -212,7 +212,7 @@
 
 /obj/machinery/meteor_battery/bullet_act(var/obj/item/projectile/Proj)
 	src.health -= Proj.damage
-	..()
+	. = ..()
 	if(prob(45) && Proj.damage > 0)
 		spark(src, 5, FALSE)
 	if (src.health <= 0)

--- a/code/modules/power/rust/core_field.dm
+++ b/code/modules/power/rust/core_field.dm
@@ -443,4 +443,4 @@ Deuterium-tritium fusion: 4.5 x 10^7 K
 	if(Proj.flag != "bullet")
 		AddEnergy(Proj.damage * 100, 0, 1)
 		update_icon()
-	return 0
+	return ..()

--- a/code/modules/power/rust/virtual_particle_catcher.dm
+++ b/code/modules/power/rust/virtual_particle_catcher.dm
@@ -40,7 +40,7 @@
 	if(Proj.flag != "bullet" && parent)
 		parent.AddEnergy(Proj.damage * 100, 0, 1)
 		update_icon()
-	return 0
+	return ..()
 
 /obj/effect/rust_particle_catcher/Bumped(atom/AM)
 	if(ismob(AM) && density && prob(10))

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -123,8 +123,7 @@ var/global/list/obj/machinery/field_generator/field_gen_list = list()
 	if(Proj.flag != "bullet")
 		power += Proj.damage
 		update_icon()
-	return 0
-
+	return ..()
 
 /obj/machinery/field_generator/Destroy()
 	src.cleanup()

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -52,17 +52,17 @@ var/list/global_singularity_pool
 	if(!global_singularity_pool)
 		global_singularity_pool = list()
 	global_singularity_pool += src
-	
+
 /obj/machinery/singularity/attack_hand(mob/user as mob)
 	consume(user)
 	return 1
 
 /obj/machinery/singularity/blob_act(severity)
 	return
-	
+
 /obj/machinery/singularity/supermatter_act(atom/source, severity)
 	return
-	
+
 /obj/machinery/singularity/ex_act(severity)
 	if(current_size > 10) //IT'S UNSTOPPABLE
 		return
@@ -77,9 +77,6 @@ var/list/global_singularity_pool
 		if(2.0 to 3.0)
 			energy += round((rand(20, 60)/2), 1)
 			return
-
-/obj/machinery/singularity/bullet_act(obj/item/projectile/P)
-	return 0 //Will there be an impact? Who knows. Will we see it? No.
 
 /obj/machinery/singularity/to_bump(atom/A)
 	consume(A)
@@ -289,7 +286,7 @@ var/list/global_singularity_pool
 			if(chained)
 				overlays += image(icon = icon, icon_state = "chain_s9")
 			visible_message("<span class='sinister'><font size='3'>You witness the creation of a destructive force that cannot possibly be stopped by human hands.</font></span>")
-		
+
 		if(STAGE_SSGSS) //SUPER SINGULO GOD SUPER SINGULO
 			name = "[name] god [name]" //it gets worse
 			desc = "The true final form of Lord Singuloth. <b>It has the power to destroy galaxies.</b> It can most likely still be used to power arcades too, <b>if you dare.</b>"
@@ -396,13 +393,13 @@ var/list/global_singularity_pool
 	if(current_size == STAGE_SSGSS)
 		return 1
 	return 0
-	
+
 /obj/machinery/singularity/proc/makeSuperMatterSea(atom/A)
 	if(isturf(A.loc))
 		var/turf/newsea = A.loc
 		if(!istype(newsea, /turf/unsimulated/wall/supermatter))
 			newsea.ChangeTurf(/turf/unsimulated/wall/supermatter)
-	
+
 /obj/machinery/singularity/proc/consume(const/atom/A)
 	var/gain = A.singularity_act(current_size,src)
 	src.energy += gain
@@ -680,18 +677,18 @@ var/list/global_singularity_pool
 	name = "deadchat-controlled singularity listener"
 	var/obj/machinery/singularity/deadchat_controlled/parent
 
-/datum/deadchat_listener/singulo_listener/deadchat_event(var/ckey, var/message) 
+/datum/deadchat_listener/singulo_listener/deadchat_event(var/ckey, var/message)
 	parent.process_deadchat(ckey,message)
-	
+
 /obj/machinery/singularity/deadchat_controlled
 	desc = "The destructive, murderous Lord Singuloth, patron saint of Engineering. This one seems... unstable. Oh god."
 	var/deadchat_mode = "Anarchy"
 	var/list/ckey_to_cooldown = list()
 	var/datum/deadchat_listener/singulo_listener/listener
 	move_self = 0
-	
+
 	var/input_cooldown = 60 //In deca-seconds
-	var/democracy_cooldown = 120 
+	var/democracy_cooldown = 120
 	var/list/inputs = list("UP","DOWN","LEFT","RIGHT")
 	var/deadchat_active = 1
 	appearance_flags = 0
@@ -711,7 +708,7 @@ var/list/global_singularity_pool
 			var/mob/living/carbon/brain/B = M
 			if(B.brain_dead_chat())
 				to_chat(M, message)
-	global_deadchat_listeners -= listener	
+	global_deadchat_listeners -= listener
 	global_singularity_pool -= src
 	qdel(listener)
 
@@ -757,8 +754,8 @@ var/list/global_singularity_pool
 		message = uppertext(message)
 		if(inputs.Find(message))
 			ckey_to_cooldown[ckey] = message
-			
-/obj/machinery/singularity/deadchat_controlled/proc/eat_no_pull() //Copied from proc/eat() and altered		
+
+/obj/machinery/singularity/deadchat_controlled/proc/eat_no_pull() //Copied from proc/eat() and altered
 	for(var/atom/X in orange(consume_range, src))
 		if(X.type == /atom/movable/lighting_overlay)
 			continue
@@ -771,7 +768,7 @@ var/list/global_singularity_pool
 		democracy_cooldown = 1 //setting it to 0 kills the serb so let's not ever let that happen again
 	spawn(democracy_cooldown)
 		if(!deadchat_active) //Bit gunky but I'm not entirely certain how src/self works in byond, would if(src == null) work?
-			return 
+			return
 		var/result = count_democracy_votes()
 		if(result != 5)
 			set_glide_size(DELAY2GLIDESIZE(0.1 SECONDS))
@@ -796,7 +793,7 @@ var/list/global_singularity_pool
 				else if(M.client && istype(M,/mob/living/carbon/brain) && (M.client.prefs.toggles & CHAT_DEAD))
 					var/mob/living/carbon/brain/B = M
 					if(B.brain_dead_chat())
-						to_chat(M, message)		
+						to_chat(M, message)
 		else
 			var/message = "<span class='recruit'>No votes were cast this cycle. Remember, type UP, DOWN, LEFT, or RIGHT to cast a vote!"
 			for(var/mob/M in player_list)
@@ -811,7 +808,7 @@ var/list/global_singularity_pool
 					if(B.brain_dead_chat())
 						to_chat(M, message)
 		begin_democracy_loop()
-			
+
 /obj/machinery/singularity/deadchat_controlled/proc/count_democracy_votes()	//Will return 5 if empty list
 	var/list/votes = list(0,0,0,0)
 	var/found_vote = 0
@@ -838,8 +835,8 @@ var/list/global_singularity_pool
 		return WEST
 	else
 		return EAST
-	
-				
+
+
 /client/proc/deadchat_singularity()
 	set category = "Fun"
 	set name = "Spawn Deadchat-Controlled Singularity"
@@ -856,7 +853,7 @@ var/list/global_singularity_pool
 		organized_list[organized_hash] = singularity
 	if(!global_singularity_pool.len)
 		to_chat(holder, "There are no singularities to be transformed into a deadchat-controlled one. Spawn one first... if you dare.")
-		return 0		
+		return 0
 	var/singulo_name = input(src,"Select a singularity.", "Confirm", null) as null|anything in organized_list
 	var/obj/machinery/singularity/target_singulo = organized_list[singulo_name]
 	if(target_singulo)
@@ -891,7 +888,7 @@ var/list/global_singularity_pool
 				else if(M.client && istype(M,/mob/living/carbon/brain) && (M.client.prefs.toggles & CHAT_DEAD))
 					var/mob/living/carbon/brain/B = M
 					if(B.brain_dead_chat())
-						to_chat(M, message + "<a href='?src=\ref[M];follow=\ref[new_singulo]'>(Follow)</a>")	
+						to_chat(M, message + "<a href='?src=\ref[M];follow=\ref[new_singulo]'>(Follow)</a>")
 		else if(option_chosen == "Democracy")
 			var/interval = input("Please enter the interval that the singulo makes a move in seconds.", "Interval") as num
 			if(!interval)
@@ -925,7 +922,7 @@ var/list/global_singularity_pool
 				else if(M.client && istype(M,/mob/living/carbon/brain) && (M.client.prefs.toggles & CHAT_DEAD))
 					var/mob/living/carbon/brain/B = M
 					if(B.brain_dead_chat())
-						to_chat(M, message + "<a href='?src=\ref[M];follow=\ref[new_singulo]'>(Follow)</a>")	
+						to_chat(M, message + "<a href='?src=\ref[M];follow=\ref[new_singulo]'>(Follow)</a>")
 
 /obj/machinery/singularity/special
 	name = "specialarity"

--- a/code/modules/power/solars/panel.dm
+++ b/code/modules/power/solars/panel.dm
@@ -65,7 +65,7 @@
 	if(Proj.damage)
 		health -= Proj.damage
 		healthcheck()
-	..()
+	return ..()
 
 /obj/machinery/power/solar/panel/proc/healthcheck()
 	if(health <= 0)

--- a/code/modules/projectiles/guns/projectile/stickylauncher.dm
+++ b/code/modules/projectiles/guns/projectile/stickylauncher.dm
@@ -95,7 +95,7 @@
 
 /obj/item/weapon/gun/stickybomb/can_discharge()
 	return loaded.len
-	
+
 /obj/item/stickybomb
 	name = "anti-personnel stickybomb"
 	desc = "Ammo for a stickybomb launcher. Only affects living beings, produces a decent amount of knockback."
@@ -254,5 +254,6 @@
 	if(istype(Proj ,/obj/item/projectile/beam)||istype(Proj,/obj/item/projectile/bullet)||istype(Proj,/obj/item/projectile/ricochet))
 		if(!istype(Proj ,/obj/item/projectile/beam/lasertag) && !istype(Proj ,/obj/item/projectile/beam/practice) )
 			detonate()
+	return ..()
 
 #undef MAX_STICKYBOMBS

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -621,7 +621,7 @@ var/list/impact_master = list()
 	return
 
 /obj/item/projectile/bullet_act(/obj/item/projectile/bullet)
-	return -1
+	return PROJECTILE_COLLISION_MISS
 
 /obj/item/projectile/proc/reset()
 	starting = get_turf(src)

--- a/code/modules/projectiles/projectile/rocket.dm
+++ b/code/modules/projectiles/projectile/rocket.dm
@@ -149,6 +149,7 @@
 	if(istype(Proj ,/obj/item/projectile/beam)||istype(Proj,/obj/item/projectile/bullet)||istype(Proj,/obj/item/projectile/ricochet))
 		if(!istype(Proj ,/obj/item/projectile/beam/lasertag) && !istype(Proj ,/obj/item/projectile/beam/practice) )
 			detonate()
+	return ..()
 
 /obj/item/projectile/rocket/nikita/Destroy()
 	reset_view()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -178,6 +178,7 @@
 			else
 				msg_admin_attack("[src] was shot by a [Proj.type] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)") //BS12 EDIT ALG
 			explode()
+	return ..()
 
 /obj/structure/reagent_dispensers/fueltank/blob_act()
 	explode()
@@ -518,7 +519,7 @@
 	..()
 
 /obj/structure/reagent_dispensers/cauldron/barrel/bullet_act(var/obj/item/projectile/Proj)
-	..()
+	. = ..()
 	if(Proj.damage)
 		take_damage(Proj.damage)
 

--- a/code/modules/research/xenoarchaeology/artifact/artifact_autocloner.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_autocloner.dm
@@ -105,6 +105,7 @@
 			explosion(get_turf(src), 1, 2, 3, 3)
 			src.investigation_log(I_ARTIFACT, "|| blew up after taking damage from || [Proj.type] || fired by [Proj.firer ? "[key_name(Proj.firer)]" : "something"].")
 			qdel(src)
+	return ..()
 
 /obj/machinery/auto_cloner/attackby(var/obj/item/O, var/mob/user)
 	if(O.is_wrench(user))

--- a/code/modules/research/xenoarchaeology/artifact/artifact_replicator.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_replicator.dm
@@ -147,6 +147,7 @@
 			explosion(get_turf(src), -1, 2, 3, 3)
 			src.investigation_log(I_ARTIFACT, "|| blew up after taking damage from || [Proj.type] || fired by [Proj.firer ? "[key_name(Proj.firer)]" : "something"].")
 			qdel(src)
+	return ..()
 
 /obj/machinery/replicator/attackby(var/obj/item/O, var/mob/user)
 	if(O.is_wrench(user))

--- a/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
@@ -188,6 +188,7 @@ var/list/razed_large_artifacts = list()//destroyed while still inside a rock wal
 
 /obj/machinery/artifact/bullet_act(var/obj/item/projectile/P)
 	on_projectile.Invoke(list(P.firer, "PROJECTILE",P))
+	return ..()
 
 /obj/machinery/artifact/beam_connect(var/obj/effect/beam/B)
 	..()
@@ -245,6 +246,6 @@ var/list/razed_large_artifacts = list()//destroyed while still inside a rock wal
 			if(prob(50))
 				M.Stun(5)
 		M.apply_radiation(25, RAD_EXTERNAL)
-		
+
 /obj/machinery/artifact/can_overload()
 	return 0

--- a/code/modules/research/xenoarchaeology/tools/anomaly_container.dm
+++ b/code/modules/research/xenoarchaeology/tools/anomaly_container.dm
@@ -104,7 +104,7 @@
 
 /obj/structure/anomaly_container/bullet_act(var/obj/item/projectile/Proj)
 	health -= Proj.damage
-	..()
+	. = ..()
 	if(!broken && health <= 0)
 		breakdown()
 

--- a/code/modules/spacepods/spacepods.dm
+++ b/code/modules/spacepods/spacepods.dm
@@ -135,6 +135,7 @@
 /obj/spacepod/bullet_act(var/obj/item/projectile/P)
 	if(P.damage && !P.nodamage)
 		adjust_health(P.damage)
+	return ..()
 
 /obj/spacepod/proc/adjust_health(var/damage)
 	var/oldhealth = health

--- a/code/modules/spells/aoe_turf/conjure/forcewall.dm
+++ b/code/modules/spells/aoe_turf/conjure/forcewall.dm
@@ -49,7 +49,7 @@
 	if(T)
 		for(var/mob/M in T)
 			Proj.on_hit(M,M.bullet_act(Proj, def_zone))
-	return
+	return ..()
 
 /obj/effect/forcefield/wizard
 	invisibility = 0

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -325,7 +325,7 @@
 /obj/machinery/power/supermatter/bullet_act(var/obj/item/projectile/Proj)
 	var/turf/L = loc
 	if(!istype(L))		// We don't run process() when we are in space
-		return 0	// This stops people from being able to really power up the supermatter
+		return ..()	// This stops people from being able to really power up the supermatter
 				// Then bring it inside to explode instantly upon landing on a valid turf.
 
 
@@ -334,6 +334,7 @@
 	else
 		damage += Proj.damage * config_bullet_energy
 
+	return ..()
 
 /obj/machinery/power/supermatter/attack_paw(mob/user as mob)
 	return attack_hand(user)


### PR DESCRIPTION
Turns out until #28705, `bullet_act()` returned `null` almost everytime, not 0.

As far as BYOND is concerned, `null != 0`. This caused a few issues.
Closes #28759, closes #28745, and probably many, many, more undiscovered things. 

Undoes #28753 and #28739 because I misunderstood what `PROJECTILE_COLLISION_BLOCKED` meant.

I regret looking at some of that old code. Holy molly.