### PR TITLE
Removes the ability to grab anvils with TK.

### DIFF
--- a/code/modules/blacksmithing/anvil.dm
+++ b/code/modules/blacksmithing/anvil.dm
@@ -42,3 +42,19 @@
 		if(W.loc == src.loc && params)
 			W.setPixelOffsetsFromParams(params, user)
 			return 1
+
+/obj/item/anvil/attack_tk(mob/user)
+	if (istype(user,/mob/living/carbon/human))
+		var/mob/living/carbon/human/H = user
+		if (prob(85))
+			H.adjustBrainLoss(5)
+			to_chat(user, "<span class='danger'>Your mind strains painfully trying to pick up \the [src]!</span")
+		else
+			H.audible_scream()
+			H.adjustBruteLossByPart(10,LIMB_HEAD,src)
+			if (!(H.species.anatomy_flags & NO_BLOOD))
+				var/datum/organ/external/head/head = H.get_organ(LIMB_HEAD)
+				var/datum/wound/W = new /datum/wound/internal_bleeding(10)
+				head.wounds += W
+			to_chat(user, "<span class='danger'>Your mind strains trying to pick up \the [src], you feel something rip in your head!</span")
+	return attack_hand(user)

--- a/code/modules/blacksmithing/anvil.dm
+++ b/code/modules/blacksmithing/anvil.dm
@@ -44,17 +44,4 @@
 			return 1
 
 /obj/item/anvil/attack_tk(mob/user)
-	if (istype(user,/mob/living/carbon/human))
-		var/mob/living/carbon/human/H = user
-		if (prob(85))
-			H.adjustBrainLoss(5)
-			to_chat(user, "<span class='danger'>Your mind strains painfully trying to pick up \the [src]!</span")
-		else
-			H.audible_scream()
-			H.adjustBruteLossByPart(10,LIMB_HEAD,src)
-			if (!(H.species.anatomy_flags & NO_BLOOD))
-				var/datum/organ/external/head/head = H.get_organ(LIMB_HEAD)
-				var/datum/wound/W = new /datum/wound/internal_bleeding(10)
-				head.wounds += W
-			to_chat(user, "<span class='danger'>Your mind strains trying to pick up \the [src], you feel something rip in your head!</span")
 	return attack_hand(user)


### PR DESCRIPTION
We removed being able to throw barrels via telekinesis in #28628 and I don't see why we should still have it for anvils. The original intent was for BIG guys with both hulk AND strength to be able to whip these things around, not for scrawny gene nerds to slam them into people through walls without any of the risk (Yes, this is grudge code).

Shoutout to ancientpower and jknpjr for answering my dumb questions.

:cl:
* bugfix: Removed the ability to throw anvils with telekinesis.