### PR TITLE
Curb your speedrunning, xenoarchaeology.

### DIFF
--- a/code/modules/research/designs/anomaly.dm
+++ b/code/modules/research/designs/anomaly.dm
@@ -70,17 +70,6 @@
 	category = "Anomaly"
 	build_path = /obj/item/device/xenoarch_scanner
 
-//ANOMALY LEVEL 4
-/datum/design/xenoarch_scanner_adv//lets you find large artifacts buried in view
-	name = "Advanced xenoarchaeology digsite locator"
-	desc = "Shows digsites in vicinity, whether they're hidden or not. Shows you their material via highlighting them a specific colour"
-	id = "xenoarch_scanner_adv"
-	req_tech  =list(Tc_MAGNETS = 3, Tc_ANOMALY = 4)
-	build_type = PROTOLATHE
-	materials = list(MAT_GLASS=2500, MAT_IRON = 2500, MAT_PLASMA = 300)
-	category = "Anomaly"
-	build_path = /obj/item/device/xenoarch_scanner/adv
-
 /datum/design/anodevice
 	name = "Anomaly power utilizer"
 	desc = "Offers a measure of control over the exotic energies extracted from alien artifacts."
@@ -101,14 +90,24 @@
 	category = "Anomaly"
 	build_path = /obj/item/weapon/anobattery
 
-//ANOMALY LEVEL 5
+//ANOMALY LEVEL 7
 /datum/design/ano_scanner//easily lets you quickly find every large artifact buried on the Z-Level
 	name = "Alden-Saraspova Counter"
 	desc = "Aids in triangulation of exotic particles. Useful to locate large alien artifacts."
 	id = "ano_scanner"
-	req_tech = list(Tc_MATERIALS = 6, Tc_BLUESPACE = 4, Tc_ANOMALY = 5)
+	req_tech = list(Tc_MATERIALS = 6, Tc_BLUESPACE = 7, Tc_ANOMALY = 5)
 	build_type = PROTOLATHE
 	materials = list(MAT_IRON = 2500, MAT_GLASS = 2500, MAT_GOLD = 200, MAT_URANIUM = 200)
 	category = "Anomaly"
 	build_path = /obj/item/device/ano_scanner
+
+/datum/design/xenoarch_scanner_adv//lets you find large artifacts buried in view
+	name = "Advanced xenoarchaeology digsite locator"
+	desc = "Shows digsites in vicinity, whether they're hidden or not. Shows you their material via highlighting them a specific colour"
+	id = "xenoarch_scanner_adv"
+	req_tech  =list(Tc_MAGNETS = 3, Tc_ANOMALY = 7)
+	build_type = PROTOLATHE
+	materials = list(MAT_GLASS=2500, MAT_IRON = 2500, MAT_PLASMA = 300)
+	category = "Anomaly"
+	build_path = /obj/item/device/xenoarch_scanner/adv
 

--- a/code/modules/research/designs/anomaly.dm
+++ b/code/modules/research/designs/anomaly.dm
@@ -95,7 +95,7 @@
 	name = "Alden-Saraspova Counter"
 	desc = "Aids in triangulation of exotic particles. Useful to locate large alien artifacts."
 	id = "ano_scanner"
-	req_tech = list(Tc_MATERIALS = 6, Tc_BLUESPACE = 7, Tc_ANOMALY = 5)
+	req_tech = list(Tc_MATERIALS = 6, Tc_BLUESPACE = 4, Tc_ANOMALY = 7)
 	build_type = PROTOLATHE
 	materials = list(MAT_IRON = 2500, MAT_GLASS = 2500, MAT_GOLD = 200, MAT_URANIUM = 200)
 	category = "Anomaly"

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -260,7 +260,7 @@ datum/tech/anomaly
 	name = "Anomaly Research"
 	desc = "The study of high energy materials and technology reconstruction."
 	id = "anomaly"
-	max_level=6
+	max_level=7
 
 /*
 datum/tech/arcane

--- a/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
+++ b/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
@@ -5,7 +5,7 @@ var/anomaly_report_num = 0
 /obj/item/weapon/disk/hdd/anomaly
 	name = "Encrypted HDD"
 	desc = "Additional Anomaly data has been encrypted into this HDD, pertaining to the Alden-Saraspova equation. A Deconstructive Analyzer can decipher it."
-	origin_tech = Tc_ANOMALY+"=5"
+	origin_tech = Tc_ANOMALY+"=6"
 	mech_flags = MECH_SCAN_FAIL
 
 //////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Xenoarchaeology has lost a lot of its charm with how easy it is to find ALL of the larges on the map after recent updates. These larges were never intended to be found this easily and the round frequently suffers because of it. This PR does a couple things to slow down the current all larges any% speedruns plaguing xenoarchaeology. It changes the requirement of TC_anomaly 4 & 5 both to 7 and it changes the hard drive research level given to 6. So now you can get to both of the large finding tools via finding 3 larges or by finding smalls to 5 TC_anomaly and then two large hard drives. No longer can you scan for one large, find a bunch of smalls and then get every large easily within the hour.

The reason being for both of these tools being at 7 is due to the fact that they're both incredibly powerful and one quickly leads to the other. Also, as there was no formal discussion prior to making this PR I'd appreciate it if discussion was done here and we paid mind to emojicracy before merging.

Also, credit to Holyshiznignog for suggestions on the tweaks.

🆑 
* tweak: Changed "Alden-Saraspova Counter" required Tc_ANOMALY from 5 to 7
* tweak: Changed "Advanced xenoarchaeology digsite locator" required Tc_ANOMALY from 4 to 7
* tweak: Changed "Encrypted HDD" origin Tc_ANOMALY from 5 to 6

[discussion][tweak]