### PR TITLE
Makes window movement not suck again

### DIFF
--- a/code/game/objects/structures/fullwindow.dm
+++ b/code/game/objects/structures/fullwindow.dm
@@ -86,7 +86,6 @@
 			if("northwest")
 				dir = NORTHWEST
 		update_nearby_tiles()
-		ini_dir = dir
 
 /obj/structure/window/full/AltClick(var/mob/user)
 	. = ..()

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -169,7 +169,6 @@
 				if(S)
 					S.forceMove(get_turf(src))
 					S.dir = get_dir(src, user)
-					S.ini_dir = S.dir
 					return
 		return
 	if(iswirecutter(W))

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -16,7 +16,6 @@
 	density = FALSE
 	dir = NORTH
 
-	var/ini_dir
 	var/obj/item/weapon/circuitboard/airlock/electronics = null
 	var/windoor_type = /obj/machinery/door/window
 	var/secure_type = /obj/machinery/door/window/brigdoor
@@ -33,9 +32,8 @@
 	if(anchored && wired && electronics) //We're almost there bros
 		name = "near finished [secure ? "secure ":""][initial(name)]"
 
-/obj/structure/windoor_assembly/New(dir=NORTH)
+/obj/structure/windoor_assembly/New()
 	..()
-	ini_dir = dir
 	update_nearby_tiles()
 
 obj/structure/windoor_assembly/Destroy()
@@ -240,7 +238,6 @@ obj/structure/windoor_assembly/Destroy()
 		return FALSE
 	dir = turn(dir, 270)
 	update_nearby_tiles()
-	ini_dir = dir
 	update_icon()
 
 //Flips the windoor assembly, determines whather the door opens to the left or the right

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -19,7 +19,6 @@ var/list/one_way_windows
 	pressure_resistance = 4*ONE_ATMOSPHERE
 	anchored = 1
 	var/health = 10 //This window is so bad blowing on it would break it, sucks for it
-	var/ini_dir = null //This really shouldn't exist, but it does and I don't want to risk deleting it because it's likely mapping-related
 	var/d_state = WINDOWLOOSEFRAME //Normal windows have one step (unanchor), reinforced windows have three
 	var/shardtype = /obj/item/weapon/shard
 	var/reinforcetype = /obj/item/stack/rods
@@ -43,7 +42,6 @@ var/list/one_way_windows
 
 	..(loc)
 	flow_flags |= ON_BORDER
-	ini_dir = dir
 
 	update_nearby_tiles()
 	update_nearby_icons()
@@ -359,7 +357,6 @@ var/list/one_way_windows
 				else
 					change_dir(turn(dir,315))
 			update_nearby_tiles()
-			ini_dir = dir
 		var/obj/item/stack/sheet/mineral/plastic/P = W
 		toggle_one_way()
 		P.use(1)
@@ -540,7 +537,6 @@ var/list/one_way_windows
 	update_nearby_tiles() //Compel updates before
 	dir = turn(dir, 90)
 	update_nearby_tiles()
-	ini_dir = dir
 	return
 
 /obj/structure/window/verb/revrotate()
@@ -555,7 +551,6 @@ var/list/one_way_windows
 	update_nearby_tiles() //Compel updates before
 	dir = turn(dir, 270)
 	update_nearby_tiles()
-	ini_dir = dir
 	return
 
 /obj/structure/window/Destroy()
@@ -582,6 +577,7 @@ var/list/one_way_windows
 /obj/structure/window/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 
 	update_nearby_tiles()
+	Dir = dir
 	..()
 	update_nearby_tiles()
 


### PR DESCRIPTION
But does so without the shitcode with which this had previously been achieved.
Before #20883, windows maintained their direction when moved. After that, they rotated to face their movement direction. The old behavior was far less painful and more sensible. The old behavior was also achieved through shitcode, but I managed to fix that.

:cl:
* tweak: Windows are back to their pre-late-2018 behavior when moved: They maintain their direction again when moved instead of turning to face the direction of movement.