### PR TITLE
Allow vox/plasmamen to use the essence printer.

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact/artifact_essenceprinter.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_essenceprinter.dm
@@ -77,10 +77,15 @@
 
 	H.maxHealth = round(previous.maxHealth/2)
 
-	// Prevent vox from dying in an O2 atmosphere.
-	// Because the body is created and has anywhere from 30 to 60 seconds to soak up JUICY oxygen.
+	// Prevent nonhumans from dying immediately in non-ideal atmospheres.
 	if (isvox(H))
+		// Nitrogen heals tox damage from O2 in environment and is also what cloner uses.
 		H.reagents.add_reagent(NITROGEN, 60)
+
+	else if (isplasmaman(H))
+		// Plasmamen both catch on fire AND have no plasma to breathe, so...
+		H.reagents.add_reagent(LEPORAZINE, 60)
+		H.reagents.add_reagent(DEXALIN, 60)
 
 	spawn(rand(30 SECONDS,60 SECONDS))
 		do_flick(src,"Essence_imprinter_scan_complete",8)

--- a/code/modules/research/xenoarchaeology/artifact/artifact_essenceprinter.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_essenceprinter.dm
@@ -76,6 +76,12 @@
 	H.flavor_text = H.dna.flavor_text
 
 	H.maxHealth = round(previous.maxHealth/2)
+
+	// Prevent vox from dying in an O2 atmosphere.
+	// Because the body is created and has anywhere from 30 to 60 seconds to soak up JUICY oxygen.
+	if (isvox(H))
+		H.reagents.add_reagent(NITROGEN, 60)
+
 	spawn(rand(30 SECONDS,60 SECONDS))
 		do_flick(src,"Essence_imprinter_scan_complete",8)
 		icon_state = "Essence_imprinter_idle"


### PR DESCRIPTION
So that they don't come out of the damn thing already in crit.

🆑 
* tweak: Vox and plasmamen can now safely use the xenoarchaeology essence printer.