### PR TITLE
Enables local linter

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -1,1 +1,2 @@
-
+[langserver]
+dreamchecker = true


### PR DESCRIPTION
This turns on the Dreamchecker linter locally for anyone using the SpacemanDMM language server with VS Code (basically everybody using VS Code). This will report some things in the problems panel that would otherwise only be found by the CI's linter, making debugging easier. On the other hand, it also seems to detect some things that the CI's version of the linter does not, so it could potentially get annoying.
This is only a PR instead of a discussion because it was such a simple change to make. Discuss, emoji, etc.

~~My vote personally goes to merging this either after or soon before fixing all the problems it reports, to avoid the annoyance issue.~~ Those are now fixed.