### PR TITLE
Makes the CI not run on PRs that can't possibly change whether or not it passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
     - 'html/changelogs/**'
   pull_request:
     branches: [ Bleeding-Edge ]
+    paths:
+    - '**.dm'
+    - '**.dmm'
+    - '**.dmi'
+    - 'vgstation13.dme'
+    - '.github/workflows/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
I was going to do more things to the CI but didn't. Hence the branch name.

Makes it so that the CI only runs on PRs that change the dme, code files, map files, icon files, or files relating to the CI. I'm pretty sure it's impossible for any of the CI's checks to fail based only on changes to files other than those.

In theory it could be set up so that only relevant parts of the CI run on PRs instead of running the whole thing on any PR that any part of it looks at, but it's a surprisingly significant pain to do that. It would involve separating it out into multiple separate workflows.