### PR TITLE
Xenoarch triangulation has no maximum artifact distance.

### DIFF
--- a/code/modules/research/xenoarchaeology/geosample.dm
+++ b/code/modules/research/xenoarchaeology/geosample.dm
@@ -69,7 +69,7 @@
 	for(var/turf/unsimulated/mineral/T in SSxenoarch.artifact_spawning_turfs)
 		if(T.artifact_find)
 			var/cur_dist = sqrt(get_dist_squared(container, T))
-			if( (artifact_distance < 0 || cur_dist < artifact_distance) && cur_dist <= T.artifact_find.artifact_detect_range )
+			if(artifact_distance < 0 || cur_dist < artifact_distance)
 				artifact_distance = cur_dist + rand() * 2 - 1
 				artifact_id = T.artifact_find.artifact_id
 		else


### PR DESCRIPTION
Each artifact has a random max distance within which it can be detected.
Triangulation now ignores this distance. Alden saraspovas still uphold it.
The idea here is to make triangulation useful "late-game" when you're having trouble finding anything with Alden Saraspovas. You can do triangulation again to locate ones you missed or confirm you found everything.

:cl:
 * tweak: Xenoarch triangulation has no more maximum distance to find artifacts. Alden-Saraspovas still do like before. The idea here is that triangulation can now be used as a late-game tool if you're having trouble locating further artifacts with Saraspovas.

