### PR TITLE
Pay2Use Xenoarch Large Artifact Trigger Tweaking

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
@@ -51,7 +51,7 @@ var/list/razed_large_artifacts = list()//destroyed while still inside a rock wal
 		//75% chance to have a secondary effect
 		if(prob(75))
 			effecttype = pick(typesof(/datum/artifact_effect) - /datum/artifact_effect)
-			secondary_effect = new effecttype(src, 1)
+			secondary_effect = new effecttype(src, 1, FALSE)
 			secondary_effect.artifact_id = "[artifact_id]b"
 			spawn(1)
 				if(secondary_effect)	//incase admin tools or something deleted the secondary
@@ -245,6 +245,6 @@ var/list/razed_large_artifacts = list()//destroyed while still inside a rock wal
 			if(prob(50))
 				M.Stun(5)
 		M.apply_radiation(25, RAD_EXTERNAL)
-		
+
 /obj/machinery/artifact/can_overload()
 	return 0

--- a/code/modules/research/xenoarchaeology/artifact/effect.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effect.dm
@@ -26,7 +26,7 @@
 //7 = Atomic synthesis
 
 //send 1 after location to generate a trigger for the effect, only do this on objects that have the required events!
-/datum/artifact_effect/New(var/atom/location, var/generate_trigger = 0)
+/datum/artifact_effect/New(var/atom/location, var/generate_trigger = 0, var/primary_effect = TRUE)
 	..()
 	holder = location
 	effect = pick(effect) //If effect is defined as a list, pick one of the options from the list. If it's defined specifically, pick that.
@@ -62,7 +62,7 @@
 			effectrange = rand(20, 200)
 
 	if(generate_trigger)
-		GenerateTrigger()
+		GenerateTrigger(primary_effect)
 
 /datum/artifact_effect/proc/ToggleActivate(var/reveal_toggle = 1)
 	//so that other stuff happens first
@@ -183,14 +183,16 @@ proc/GetAnomalySusceptibility(var/mob/living/carbon/human/H)
 			return 1
 	return 0
 
-/datum/artifact_effect/proc/GenerateTrigger()
+/datum/artifact_effect/proc/GenerateTrigger(var/primary_effect = TRUE)
 	if(trigger)
 		qdel(trigger); trigger = null
 	var/triggertype
 	if(effect == ARTIFACT_EFFECT_TOUCH)
 		triggertype = /datum/artifact_trigger/touch
-	else
+	else if (primary_effect)
 		triggertype = pick(typesof(/datum/artifact_trigger) - /datum/artifact_trigger)
+	else
+		triggertype = pick(typesof(/datum/artifact_trigger) - /datum/artifact_trigger - /datum/artifact_trigger/pay2use)
 
 	trigger = new triggertype(src)
 

--- a/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_pay2use.dm
+++ b/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_pay2use.dm
@@ -16,6 +16,14 @@
 	my_artifact.lazy_register_event(/lazy_event/on_attackhand, src, .proc/owner_attackhand)
 	key_attackby = my_artifact.on_attackby.Add(src, "owner_attackby")
 	mode = rand(0,2)
+	var/where = pick("on one of its sides","at the top","hidden underneath", "on the front")
+	switch(mode)
+		if (COIN)
+			my_artifact.desc += " There appears to be a coin slot [where]."
+		if (CREDIT)
+			my_artifact.desc += " There appears to be what looks like a bill acceptor [where]."
+		if (BANK_CARD)
+			my_artifact.desc += " There appears to be a card slot [where]."
 	reconnect_database()
 
 /datum/artifact_trigger/pay2use/proc/reconnect_database()

--- a/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_pay2use.dm
+++ b/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_pay2use.dm
@@ -23,7 +23,7 @@
 		if (CREDIT)
 			my_artifact.desc += " There appears to be what looks like a bill acceptor [where]."
 		if (BANK_CARD)
-			my_artifact.desc += " There appears to be a card slot [where]."
+			my_artifact.desc += " There appears to be a card reader [where]."
 	reconnect_database()
 
 /datum/artifact_trigger/pay2use/proc/reconnect_database()


### PR DESCRIPTION
Everyone making Xenoarch PRs all of a sudden got me inspired.

Part of me wanted to remove this trigger altogether but I'm ready to give it another chance with the following changes:

:cl:
* tweak: The Pay2Use Large Artifact effect trigger can now only appear in a Primary Effect, never a Secondary Effect (because paying money is annoying enough that you shouldn't on top of that have only a 25% chance for it to activate the effect)
* tweak: Large Artifacts featuring a Pay2Use primary effect trigger can now be summarily examined to see if they appear to feature a coin slot, bill acceptor, or card reader, since the Anomaly Analysis will otherwise give you the same results as a Touch or Reagent trigger, and such features should be noticeable to the naked eye anyway.