### PR TITLE
Should fix most of the remaining bugs with projectiles

### DIFF
--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -531,7 +531,7 @@
 		if(!istype(P, /obj/item/projectile/beam))
 			P.reflected = 1
 			P.rebound(src)
-		return -1
+		return PROJECTILE_COLLISION_BLOCKED
 	react()
 	return ..()
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -181,6 +181,7 @@
 	if(Proj.damage)
 		health -= Proj.damage
 		healthcheck()
+	return PROJECTILE_COLLISION_DEFAULT
 
 /obj/item/clothing/mask/facehugger/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature > 300)
@@ -219,7 +220,7 @@
 	..()
 	if(stat == CONSCIOUS)
 		icon_state = "[initial(icon_state)]"
-		if(ishuman(hit_atom))	
+		if(ishuman(hit_atom))
 			var/mob/living/carbon/human/H = hit_atom
 			if(!H.isUnconscious())
 				Attach(H)
@@ -422,7 +423,7 @@
 
 	if(F && (!F.sterile || hugger.sterile) && F != hugger) // Lamarr won't fight over faces and neither will normal huggers.
 		return FALSE
-	if(F2 && (!F2.sterile || hugger.sterile) && F2 != hugger) 
+	if(F2 && (!F2.sterile || hugger.sterile) && F2 != hugger)
 		return FALSE
 
 	return TRUE
@@ -433,8 +434,8 @@
 
 
 
-//////////////////////////////////////////////////// 
-////////////////  HEADCRABS  /////////////////////// 
+////////////////////////////////////////////////////
+////////////////  HEADCRABS  ///////////////////////
 ////////////////////////////////////////////////////
 
 /obj/item/clothing/mask/facehugger/headcrab
@@ -481,11 +482,11 @@
 	processing_objects.Remove(src)
 	icon_state = "[initial(icon_state)]_dead"
 	stat = DEAD
-	sterile = TRUE 
+	sterile = TRUE
 	canremove = 1
 
 	visible_message("<span class='danger'>\The [src] curls up into a ball!</span>")
-	
+
 
 /obj/item/clothing/mask/facehugger/headcrab/findtarget()
 	if(!real)
@@ -561,7 +562,7 @@
 	if(stat != CONSCIOUS)
 		return FALSE
 	if(!CanHug(L, src))
-		return FALSE	
+		return FALSE
 	if(!sterile)
 		L.take_organ_damage(strength, 0) //done here so that even borgs and humans in helmets take damage
 
@@ -614,8 +615,8 @@
 		Assimilate(target)
 		return TRUE
 
-	
-	GoIdle(TIME_IDLE_AFTER_ATTACH_DENIED) 
+
+	GoIdle(TIME_IDLE_AFTER_ATTACH_DENIED)
 
 
 	return FALSE
@@ -650,7 +651,7 @@
 			hgibs(target.loc, target.virus2, target.dna)
 			var/mob/living/simple_animal/hostile/necro/zombie/headcrab/Z = target.make_zombie(retain_mind = 1, crabzombie = 1)
 			Z.crab = src
-		
-	
 
-	
+
+
+

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -213,7 +213,7 @@
 /mob/living/carbon/slime/bullet_act(var/obj/item/projectile/Proj)
 	attacked += 10
 	..(Proj)
-	return 0
+	return PROJECTILE_COLLISION_DEFAULT
 
 
 /mob/living/carbon/slime/emp_act(severity)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -66,7 +66,7 @@
 	var/absorb = run_armor_check(def_zone, P.flag, armor_penetration = P.armor_penetration)
 	if(absorb >= 100)
 		P.on_hit(src,2)
-		return 2
+		return PROJECTILE_COLLISION_BLOCKED
 	if(!P.nodamage)
 		var/damage = run_armor_absorb(def_zone, P.flag, P.damage)
 		apply_damage(damage, P.damage_type, def_zone, absorb, P.is_sharp(), used_weapon = P)
@@ -75,7 +75,7 @@
 	if(istype(P, /obj/item/projectile/beam/lightning))
 		if(P.damage >= 200)
 			src.dust()
-	return absorb
+	return PROJECTILE_COLLISION_DEFAULT
 
 /mob/living/hitby(atom/movable/AM as mob|obj,var/speed = 5,var/dir)//Standardization and logging -Sieve
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -487,7 +487,7 @@
 			last_high_damage_taken_timeofday = world.timeofday
 	if(prob(75) && Proj.damage > 0)
 		spark(src, 5, FALSE)
-	return 2
+	return PROJECTILE_COLLISION_DEFAULT
 
 /mob/living/silicon/robot/emp_act(severity)
 	..()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -164,7 +164,7 @@
 	if(!Proj.nodamage)
 		adjustBruteLoss(Proj.damage)
 	Proj.on_hit(src,2)
-	return 2
+	return PROJECTILE_COLLISION_DEFAULT
 
 /mob/living/silicon/apply_effect(var/effect = 0,var/effecttype = STUN, var/blocked = 0)
 	return 0//The only effect that can hit them atm is flashes and they still directly edit so this works for now

--- a/code/modules/mob/living/simple_animal/bees/bees_mob.dm
+++ b/code/modules/mob/living/simple_animal/bees/bees_mob.dm
@@ -188,7 +188,7 @@ var/bee_mobs_count = 0
 	panic_attack(M)
 
 /mob/living/simple_animal/bee/bullet_act(var/obj/item/projectile/P)
-	..()
+	. = ..()
 	if(P && P.firer)
 		panic_attack(P.firer)
 

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -388,14 +388,14 @@
 		return 0
 
 /mob/living/simple_animal/mouse/bullet_act(var/obj/item/projectile/Proj)
-	..()
+	. = ..()
 	if(!Proj)
 		return
 	var/mob/living/simple_animal/mouse/M = src
 	if((Proj.stun + Proj.weaken + Proj.paralyze + Proj.agony) > M.maxHealth)
 		to_chat(M, "<span class='warning'>The force of the projectile completely overwhelms your tiny body...</span>")
 		M.splat()
-		return 0
+		return PROJECTILE_COLLISION_DEFAULT
 
 /*
  * Common mouse types

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/effects.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/effects.dm
@@ -63,7 +63,7 @@
 
 
 /obj/effect/spider/bullet_act(var/obj/item/projectile/Proj)
-	..()
+	. = ..()
 	health -= Proj.damage
 	healthcheck()
 
@@ -109,7 +109,7 @@
 	pixel_x = rand(3,-3) * PIXEL_MULTIPLIER
 	pixel_y = rand(3,-3) * PIXEL_MULTIPLIER
 	processing_objects.Add(src)
-	
+
 /obj/effect/spider/eggcluster/Destroy()
 	processing_objects.Remove(src)
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/glow_orb.dm
+++ b/code/modules/mob/living/simple_animal/hostile/glow_orb.dm
@@ -114,7 +114,7 @@ If hit by lightning, overpowers and explodes like a flashbang, blinding everyone
 			detonate()
 		return
 
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/glow_orb/DestroySurroundings()
 	if(!melee_damage_lower)

--- a/code/modules/mob/living/simple_animal/hostile/human/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/syndicate.dm
@@ -54,12 +54,12 @@
 
 /mob/living/simple_animal/hostile/humanoid/syndicate/melee/bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj)
-		return
+		return PROJECTILE_COLLISION_DEFAULT
 	if(prob(65))
 		src.health -= Proj.damage
 	else
 		visible_message("<span class='danger'>[src] blocks [Proj] with its shield!</span>")
-	return 0
+	return PROJECTILE_COLLISION_DEFAULT
 
 
 /mob/living/simple_animal/hostile/humanoid/syndicate/melee/space

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -242,7 +242,7 @@ var/global/list/crate_mimic_disguises = list(\
 		visible_message("<span class='danger'>\The [src] roars in rage!</span>")
 
 /mob/living/simple_animal/hostile/mimic/crate/bullet_act(obj/item/projectile/P, def_zone)
-	..()
+	. = ..()
 
 	if(P.damage > 0) //The projectile isn't a dummy
 		if(!angry)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -37,7 +37,7 @@
 	if(P.damage < 30)
 		P.damage = (P.damage / 2)
 		visible_message("<span class='danger'>\The [P] has a reduced effect on \the [src]!</span>")
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/asteroid/hitby(atom/movable/AM, speed)//No floor tiling them to death, wiseguy
 	. = ..()
@@ -243,7 +243,7 @@ obj/item/asteroid/basilisk_hide/New()
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/bullet_act(var/obj/item/projectile/P)
 	visible_message("<span class='danger'>\The [P] was repelled by \the [src]'s girth!</span>")
-	return
+	return PROJECTILE_COLLISION_DEFAULT
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/death(var/gibbed = FALSE)
 	alerted = 0

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -155,5 +155,5 @@
 			Bruise()
 
 /mob/living/simple_animal/hostile/mushroom/bullet_act()
-	..()
+	. = ..()
 	Bruise()

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -369,7 +369,7 @@
 
 //Bullets
 /mob/living/simple_animal/parrot/bullet_act(var/obj/item/projectile/Proj)
-	..()
+	. = ..()
 	if(!stat && !client)
 		if(parrot_state == PARROT_PERCH)
 			parrot_sleep_dur = parrot_sleep_max //Reset it's sleep timer if it was perched

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -408,10 +408,10 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 
 /mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj)
-		return
+		return PROJECTILE_COLLISION_DEFAULT
 	Proj.on_hit(src, 0)
 	adjustBruteLoss(Proj.damage)
-	return 0
+	return PROJECTILE_COLLISION_DEFAULT
 
 /mob/living/simple_animal/attack_hand(mob/living/carbon/human/M as mob)
 	. = ..()


### PR DESCRIPTION
Main issue was that `/mob/living/bullet_act(var/obj/item/projectile/P, var/def_zone)` was not returning an expected hint, but the armor value of the guy, which I suspect could return a value that other parts of the code read as `missed projectile`.

Same thing with simple animals, they were just not returning the correct value.
It works on my machine anyway.

Closes #28775 (I hope)