### PR TITLE
Fixes thrown objects hitting windows they shouldn't

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -711,6 +711,8 @@ a {
 
 //Return true if thrown object misses
 /obj/PreImpact(atom/movable/A, speed)
+	if(flow_flags & ON_BORDER) //If the object should hit this, it will just by normal collision detection.
+		return ..()
 	if(density && !throwpass)
 		return FALSE
 	return TRUE


### PR DESCRIPTION
Extremely old bug. Turns out it wasn't very hard to fix.
Fixes #8136