### PR TITLE
Fixes all problems detected by Dreamchecker locally

### DIFF
--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -331,7 +331,7 @@
 						to_chat(user, "[A.name] is preventing the shuttle from departing.")
 				moving = 0
 				destination_port = null
-				return 0
+				return
 			for(var/atom/movable/AA in linked_area)
 				AA.lazy_invoke_event(/lazy_event/on_z_transition, list("user" = AA, "to_z" = D.z, "from_z" = linked_port.z))
 

--- a/code/game/gamemodes/events/dust.dm
+++ b/code/game/gamemodes/events/dust.dm
@@ -108,7 +108,7 @@ The "dust" will damage the hull of the station causin minor hull breaches.
 				walk(src,0)
 				spawn(1)
 					qdel(src)
-				return 0
+				return
 	return
 
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -368,7 +368,7 @@
 	var/sleeptime = min(5 SECONDS, 4*max(occupant.sleeping, occupant.paralysis))
 	spawn(sleeptime)
 		if(!src || !on) //the !src check is redundant from the nature of spawn() if I understand correctly, but better be safe than sorry
-			return 0
+			return
 		if(occupant)
 			occupant.sleeping = 0
 			occupant.paralysis = 0

--- a/code/game/machinery/martian_printer.dm
+++ b/code/game/machinery/martian_printer.dm
@@ -63,7 +63,7 @@
 		// Player has already been made into another mob before this one spawned, so let's reset the spawner
 		building = FALSE
 		update_icon()
-		return FALSE
+		return
 	if(istype(print_path,/mob/living/carbon/complex/martian))
 		flick("m_pad_active", src) //Martians get a special animation
 	else
@@ -72,7 +72,7 @@
 		if(!user || !istype(user) || !user.client)
 			// Player disappeared between clicking on the spawner and now, so we have no one to turn tentacle!
 			building = FALSE
-			return FALSE
+			return
 
 		var/mob/M = new print_path(get_turf(src))
 
@@ -81,4 +81,3 @@
 
 
 		building = FALSE
-		return TRUE

--- a/code/game/machinery/mommi_spawner.dm
+++ b/code/game/machinery/mommi_spawner.dm
@@ -66,11 +66,11 @@
 	if(building)
 		to_chat(user, "<span class='warning'>\The [src] is busy building something already.</span>")
 		return FALSE
-	
+
 	if(metal < metalPerMoMMI)
 		to_chat(user, "<span class='warning'>\The [name] doesn't have enough metal to complete this task.</span>")
 		return FALSE
-	
+
 	if(user.client)
 		var/timedifference = world.time - user.client.time_died_as_mouse
 		if(user.client.time_died_as_mouse && timedifference <= mouse_respawn_time * 600)
@@ -78,11 +78,11 @@
 			timedifference_text = time2text(mouse_respawn_time * 600 - timedifference,"mm:ss")
 			to_chat(user, "<span class='warning'>You may only spawn again as a mouse or MoMMI more than [mouse_respawn_time] minutes after your death. You have [timedifference_text] left.</span>")
 			return FALSE
-	
+
 	if(jobban_isbanned(user, "Mobile MMI"))
 		to_chat(user, "<span class='warning'>\The [name] lets out an annoyed buzz.</span>")
 		return FALSE
-	
+
 	return TRUE
 
 /obj/machinery/mommi_spawner/attack_ghost(var/mob/dead/observer/user)
@@ -103,7 +103,7 @@
 				if(!mind_can_reenter(mmi.brainmob.mind))
 					to_chat(user, "<span class='notice'>\The [src] indicates that [O.name]'s mind is completely unresponsive; there's no point.</span>")
 					return TRUE
-			
+
 			if(mmi.brainmob.stat == DEAD)
 				to_chat(user, "<span class='warning'>Yeah, good idea. Give something deader than the pizza in your fridge legs.  Mom would be so proud.</span>")
 				return TRUE
@@ -123,14 +123,14 @@
 		// Player has already been made into another mob before this one spawned, so let's reset the spawner
 		building = FALSE
 		update_icon()
-		return FALSE
+		return
 
 	spawn(50)
 		if(!user || !istype(user) || !user.client)
 			// Player disappeared between clicking on the spawner and now, so we have no one to give a MoMMI to!
 			building = FALSE
 			update_icon()
-			return FALSE
+			return
 
 		// Make the MoMMI!
 		var/mob/living/silicon/robot/mommi/M = new mommi_type(loc)
@@ -147,7 +147,7 @@
 		metal = 0
 		building = FALSE
 		update_icon()
-		
+
 
 /obj/machinery/mommi_spawner/proc/PostMoMMIMaking(var/mob/living/silicon/robot/mommi/M)
 	if(!M)

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -640,7 +640,8 @@
 /obj/item/weapon/tray/dropped(mob/user)
 	spawn() //because throwing drops items before setting their throwing var, and a lot of other zany bullshit
 		if(throwing)
-			return ..()
+			..()
+			return
 		//This is so monumentally bad that I have to leave it in as a comment
 		/*var/mob/living/M
 		for(M in src.loc) //to handle hand switching
@@ -648,7 +649,8 @@
 		if(isturf(loc))
 			for(var/obj/structure/table/T in loc)
 				remove_items()
-				return ..()
+				..()
+				return
 			// if no table, presume that the person just shittily dropped the tray on the ground and made a mess everywhere!
 			whoops()
 		..()

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -22,11 +22,11 @@
 /obj/item/weapon/storage/bible/suicide_act(mob/living/user)
 	user.visible_message("<span class='danger'>[user] is farting on \the [src]! It looks like \he's trying to commit suicide!</span>")
 	user.emote("fart")
-	spawn(10) //Wait for it
-		user.fire_stacks += 5
-		user.IgniteMob()
-		user.audible_scream()
-		return SUICIDE_ACT_FIRELOSS //Set ablaze and burned to crisps
+	sleep(1 SECONDS) //Wait for it
+	user.fire_stacks += 5
+	user.IgniteMob()
+	user.audible_scream()
+	return SUICIDE_ACT_FIRELOSS //Set ablaze and burned to crisps
 
 //"Special" Bible with a little gift on introduction
 /obj/item/weapon/storage/bible/booze

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -100,7 +100,7 @@
 					icon_state = icon_state+"-"
 				if (tabledirs & turn(dir,-90))
 					icon_state = icon_state+"+"
-			return 1
+			return
 
 		var/dir_sum = 0
 		for(var/direction in alldirs)

--- a/code/modules/admin/ToRban.dm
+++ b/code/modules/admin/ToRban.dm
@@ -18,32 +18,30 @@
 		F["last_update"] >> last_update
 		if((last_update + TOR_UPDATE_INTERVAL) < world.realtime)	//we haven't updated for a while
 			ToRban_update()
-	return
 
 /proc/ToRban_update()
-	spawn(0)
-		diary << "Downloading updated ToR data..."
-		var/http[] = world.Export("http://exitlist.torproject.org/exit-addresses")
+	diary << "Downloading updated ToR data..."
+	var/http[] = world.Export("http://exitlist.torproject.org/exit-addresses")
 
-		var/list/rawlist = file2list(http["CONTENT"])
-		if(rawlist.len)
-			fdel(TORFILE)
-			var/savefile/F = new(TORFILE)
-			for( var/line in rawlist )
-				if(!line)
+	var/list/rawlist = file2list(http["CONTENT"])
+	if(rawlist.len)
+		fdel(TORFILE)
+		var/savefile/F = new(TORFILE)
+		for( var/line in rawlist )
+			if(!line)
+				continue
+			if( copytext(line,1,12) == "ExitAddress" )
+				var/cleaned = copytext(line,13,length(line)-19)
+				if(!cleaned)
 					continue
-				if( copytext(line,1,12) == "ExitAddress" )
-					var/cleaned = copytext(line,13,length(line)-19)
-					if(!cleaned)
-						continue
-					F[cleaned] << 1
-			F["last_update"] << world.realtime
-			diary << "ToR data updated!"
-			if(usr)
-				to_chat(usr, "ToRban updated.")
-			return 1
-		diary << "ToR data update aborted: no data."
-		return 0
+				F[cleaned] << 1
+		F["last_update"] << world.realtime
+		diary << "ToR data updated!"
+		if(usr)
+			to_chat(usr, "ToRban updated.")
+		return 1
+	diary << "ToR data update aborted: no data."
+	return 0
 
 /client/proc/ToRban(task in list("update","toggle","show","remove","remove all","find"))
 	set name = "ToRban"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -75,7 +75,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 			to_chat(usr, "<span class='red'>Never use atom proc call to inject SQL.</span>")
 			message_admins("[key_name(usr)] used atom proc call on the db controller.")
 			log_admin("[key_name(usr)] used atom proc call on the db controller.")
-			return FALSE
+			return
 
 		if(target && !hascall(target, procname))
 			to_chat(usr, "<span class='red'>Error: callproc(): target has no such call [procname].</span>")
@@ -274,10 +274,11 @@ Pressure: [env.pressure]"}
 		alert("Wait until the game starts")
 		return
 	if(ishuman(M))
-		log_admin("[key_name(src)] has alienized [M.key].")
+		var/mob/living/carbon/human/H = M
+		log_admin("[key_name(src)] has alienized [H.key].")
 		spawn(10)
 			feedback_add_details("admin_verb","MKAL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-			return M:Alienize()
+			H.Alienize()
 
 		log_admin("[key_name(usr)] made [key_name(M)] into an alien.")
 		message_admins("<span class='notice'>[key_name_admin(usr)] made [key_name(M)] into an alien.</span>", 1)
@@ -292,10 +293,12 @@ Pressure: [env.pressure]"}
 		alert("Wait until the game starts")
 		return
 	if(ishuman(M))
-		log_admin("[key_name(src)] has slimeized [M.key].")
+		var/mob/living/carbon/human/H = M
+		log_admin("[key_name(src)] has slimeized [H.key].")
 		spawn(10)
 			feedback_add_details("admin_verb","MKMET") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-			return M:slimeize()
+			H.slimeize()
+
 		log_admin("[key_name(usr)] made [key_name(M)] into a slime.")
 		message_admins("<span class='notice'>[key_name_admin(usr)] made [key_name(M)] into a slime.</span>", 1)
 	else

--- a/code/modules/awaymissions/maploader/writer.dm
+++ b/code/modules/awaymissions/maploader/writer.dm
@@ -76,26 +76,17 @@
 		dmm_text += "\"[keys[key_pos]]\" = ([templates[key_pos]])\n"
 
 	var/z_level = 0
-	for(var/z_pos = 1, TRUE, z_pos = findtext(template_buffer, ".", z_pos) + 1)
-		if(z_pos >= length(template_buffer))
-			break
-
+	for(var/z_pos = 1, z_pos < length(template_buffer), z_pos = findtext(template_buffer, ".", z_pos) + 1)
 		if(z_level)
 			dmm_text += "\n"
 
 		dmm_text += "\n(1,1,[++z_level]) = {\"\n"
 
 		var/z_block = copytext(template_buffer, z_pos, findtext(template_buffer, ".", z_pos))
-		for(var/y_pos = 1, TRUE, y_pos = findtext(z_block, ";", y_pos) + 1)
-			if(y_pos >= length(z_block))
-				break
-
+		for(var/y_pos = 1, y_pos < length(z_block), y_pos = findtext(z_block, ";", y_pos) + 1)
 			var/y_block = copytext(z_block, y_pos, findtext(z_block, ";", y_pos))
 
-			for(var/x_pos = 1, TRUE, x_pos = findtext(y_block, ",", x_pos) + 1)
-				if(x_pos >= length(y_block))
-					break
-
+			for(var/x_pos = 1, x_pos < length(y_block), x_pos = findtext(y_block, ",", x_pos) + 1)
 				var/x_block = copytext(y_block, x_pos, findtext(y_block, ",", x_pos))
 				var/key_number = text2num(x_block)
 				var/temp_key = keys[key_number]

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -27,10 +27,8 @@ mob/living/carbon/proc/dream()
 			to_chat(src, "<span class='notice'><i>... [dream_image] ...</i></span>")
 			sleep(rand(40,70))
 			if(paralysis <= 0)
-				dreaming = 0
-				return 0
+				break
 		dreaming = 0
-		return 1
 
 mob/living/carbon/proc/handle_dreams()
 	if(prob(5) && !dreaming)

--- a/code/modules/projectiles/guns/projectile/rocketlauncher.dm
+++ b/code/modules/projectiles/guns/projectile/rocketlauncher.dm
@@ -79,15 +79,14 @@
 /obj/item/weapon/gun/projectile/rocketlauncher/suicide_act(var/mob/user)
 	if(!src.process_chambered()) //No rocket in the rocket launcher
 		user.visible_message("<span class='danger'>[user] jams down \the [src]'s trigger before noticing it isn't loaded and starts bashing \his head in with it! It looks like \he's trying to commit suicide.</span>")
-		return(SUICIDE_ACT_BRUTELOSS)
+		return SUICIDE_ACT_BRUTELOSS
 	else //Needed to get that shitty default suicide_act out of the way
 		user.visible_message("<span class='danger'>[user] fiddles with \the [src]'s safeties and suddenly aims it at \his feet! It looks like \he's trying to commit suicide.</span>")
-		spawn(10) //RUN YOU IDIOT, RUN
-			explosion(src.loc, -1, 1, 4, 8)
-			if(src) //Is the rocket launcher somehow still here ?
-				qdel(src) //This never happened
-			return(SUICIDE_ACT_BRUTELOSS)
-	return
+		sleep(1 SECONDS) //RUN YOU IDIOT, RUN
+		explosion(src.loc, -1, 1, 4, 8)
+		if(src) //Is the rocket launcher somehow still here ?
+			qdel(src) //This never happened
+		return SUICIDE_ACT_BRUTELOSS
 
 /obj/item/weapon/gun/projectile/rocketlauncher/nanotrasen
 	name = "rocket launcher"
@@ -149,13 +148,12 @@
 /obj/item/weapon/gun/projectile/rocketlauncher/nikita/suicide_act(var/mob/user)
 	if(!loaded)
 		user.visible_message("<span class='danger'>[user] jams down \the [src]'s trigger before noticing it isn't loaded and starts bashing \his head in with it! It looks like \he's trying to commit suicide.</span>")
-		return(SUICIDE_ACT_BRUTELOSS)
+		return SUICIDE_ACT_BRUTELOSS
 	else
 		user.visible_message("<span class='danger'>[user] fiddles with \the [src]'s safeties and suddenly aims it at \his feet! It looks like \he's trying to commit suicide.</span>")
-		spawn(10) //RUN YOU IDIOT, RUN
-			explosion(src.loc, 1, 3, 5, 8) //Using the actual rocket damage, instead of the very old, super nerfed value
-			return(SUICIDE_ACT_BRUTELOSS)
-	return
+		sleep(1 SECONDS) //RUN YOU IDIOT, RUN
+		explosion(src.loc, 1, 3, 5, 8) //Using the actual rocket damage, instead of the very old, super nerfed value
+		return SUICIDE_ACT_BRUTELOSS
 
 /obj/item/weapon/gun/projectile/rocketlauncher/nikita/attackby(var/obj/item/A as obj, mob/user as mob)
 	if(istype(A, /obj/item/weapon/card/emag) && !emagged)

--- a/code/modules/spells/general/undeath.dm
+++ b/code/modules/spells/general/undeath.dm
@@ -58,7 +58,6 @@
 		else
 			to_chat(H, "<span class = 'warning'>It seems you couldn't complete the spell.</span>")
 			V.reviving = FALSE
-			return FALSE
 
 // Action button for actual revival
 


### PR DESCRIPTION
Also fixes a couple minor bugs with custom suicides for bibles and rocket launchers
Most of the detected problems were return values in `spawn()`s, but there were three of another. Check out the changed lines in `writer.dm` for some bizarre oldcode.

I'm not really sure why the version we use for CI doesn't detect this stuff. I guess the version included with the VS Code extension is different from the release on GitHub.