### PR TITLE
Show Flavor Text Length Tweak

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1201,7 +1201,7 @@ Use this proc preferably at the end of an equipment loadout
 	if(length(msg) <= 32)
 		return "<font color='#ffa000'><b>[msg]</b></font>"
 	else
-		return "<font color='#ffa000'><b>[copytext(msg, 1, 32)]...<a href='?src=\ref[src];show_flavor_text=1'>More</a></b></font>"
+		return "<font color='#ffa000'><b>[copytext(msg, 1, 64)]...<a href='?src=\ref[src];show_flavor_text=1'>More</a></b></font>"
 
 /mob/verb/abandon_mob()
 	set name = "Respawn"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1198,7 +1198,7 @@ Use this proc preferably at the end of an equipment loadout
 	var/msg = strip_html(flavor_text)
 	if(findtext(msg, "http:") || findtext(msg, "https:") || findtext(msg, "www."))
 		return "<font color='#ffa000'><b><a href='?src=\ref[src];show_flavor_text=1'>Show flavor text</a></b></font>"
-	if(length(msg) <= 32)
+	if(length(msg) <= 64)
 		return "<font color='#ffa000'><b>[msg]</b></font>"
 	else
 		return "<font color='#ffa000'><b>[copytext(msg, 1, 64)]...<a href='?src=\ref[src];show_flavor_text=1'>More</a></b></font>"


### PR DESCRIPTION
[tweak] Changes the threshold for flavor texts to show a "more" button from 32 characters -> 64, so that you don't have to click the stupid button to read a 35 character flavor text. Sponsored by Bay and HRP shitters.

![image](https://user-images.githubusercontent.com/23635874/107273472-1c84e780-6a1d-11eb-9824-05270a386d10.png)

:cl:
 * tweak: Changes threshold for flavor text to show a "more" button from 32 characters -> 64 characters.