### PR TITLE
Removes access requirement to fax HR.

### DIFF
--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -1,7 +1,7 @@
 //Updated by Cutelildick
 
 var/list/obj/machinery/faxmachine/allfaxes = list()
-var/list/alldepartments = list("Central Command")
+var/list/alldepartments = list("Central Command", "Nanotrasen HR")
 
 /obj/machinery/faxmachine
 	name = "fax machine"
@@ -187,13 +187,9 @@ var/list/alldepartments = list("Central Command")
 		if ( (!( authenticated ) && (scan)) )
 			if (check_access(scan))
 				authenticated = 1
-				if(access_lawyer in scan.access)
-					alldepartments += "Nanotrasen HR"
 
 	if(href_list["logout"])
 		authenticated = 0
-		if(access_lawyer in scan.access)
-			alldepartments -= "Nanotrasen HR"
 
 	updateUsrDialog()
 


### PR DESCRIPTION
You can't use the demotion fax paper in the heads of staff lockers without the ability to fax HR in the first place, this PR fixes an oversight in #28515. Now the CE/RD/HOS/CMO can fax Nanotrasen HR.

[easy][oversight][tested]

:cl:
* bugfix: All heads of staff can now fax Nanotrasen HR to demote or commend employees.