### PR TITLE
Movecode update for 514

### DIFF
--- a/code/ZAS/Atom.dm
+++ b/code/ZAS/Atom.dm
@@ -4,24 +4,28 @@
 /turf/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 
 	if(!target)
-		return 0
+		return FALSE
 
-	if(istype(mover)) // turf/Enter(...) will perform more advanced checks
+	if(istype(mover))
+		for(var/atom/movable/border_object in border_objects)
+			if(!border_object.Cross(mover, target, height, air_group))
+				bump_target = border_object
+				return FALSE
 		return !density
 
 	else // Now, doing more detailed checks for air movement and air group formation
 		if(target.blocks_air||blocks_air)
-			return 0
+			return FALSE
 
 		for(var/obj/obstacle in src)
 			if(!obstacle.Cross(mover, target, height, air_group))
-				return 0
+				return FALSE
 		if(target != src)
 			for(var/obj/obstacle in target)
 				if(!obstacle.Cross(mover, src, height, air_group))
-					return 0
+					return FALSE
 
-		return 1
+		return TRUE
 
 //Basically another way of calling Cross(null, other, 0, 0) and Cross(null, other, 1.5, 1).
 //Returns:

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -192,6 +192,8 @@ var/global/list/ghdel_profiling = list()
 	return
 
 //When this object is bumped by BYOND, what should actually get bumped? Usually itself but there are some cases where it differs.
+//When not returning src, it should generally be called recursively on the found target in case that one also returns something else. Just don't make a cycle.
+//Yes it would be more logical to handle that elsewhere but it would also be more complicated
 /atom/proc/get_bump_target()
 	return src
 
@@ -757,6 +759,9 @@ its easier to just keep the beam vertical.
 
 /atom/movable/proc/checkpass(passflag)
 	return pass_flags&passflag
+
+/atom/proc/can_pass(atom/movable/mover) //Can mover pass through src regardless of density, etc.?
+	return istype(mover)
 
 /datum/proc/setGender(gend = FEMALE)
 	if(!("gender" in vars))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -191,6 +191,10 @@ var/global/list/ghdel_profiling = list()
 /atom/proc/Bumped(atom/movable/AM)
 	return
 
+//When this object is bumped by BYOND, what should actually get bumped? Usually itself but there are some cases where it differs.
+/atom/proc/get_bump_target()
+	return src
+
 /atom/proc/setDensity(var/density)
 	if (density == src.density)
 		return FALSE // No need to invoke the event when we're not doing any actual change

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -40,7 +40,7 @@ var/global/list/ghdel_profiling = list()
 	var/ignoreinvert = 0
 	var/timestopped
 
-	appearance_flags = TILE_BOUND|LONG_GLIDE
+	appearance_flags = TILE_BOUND|LONG_GLIDE|TILE_MOVER
 
 	var/slowdown_modifier //modified on how fast a person can move over the tile we are on, see turf.dm for more info
 	/// Last name used to calculate a color for the chatmessage overlays

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -595,12 +595,19 @@ var/global/list/alert_overlays_global = list()
 	..()
 	setup_border_dummy()
 
+/obj/machinery/door/firedoor/border_only/can_pass(atom/movable/mover)
+	return ..() && mover.checkpass(PASSDOOR | PASSGLASS)
+
 /obj/machinery/door/firedoor/border_only/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	if(istype(mover) && (mover.checkpass(PASSDOOR|PASSGLASS)))
-		return 1
-	if(get_dir(loc, target) == dir || get_dir(loc, mover) == dir)
-		return !density
-	return 1
+	if(can_pass(mover))
+		return TRUE
+	if(!density)
+		return TRUE
+	if(istype(mover))
+		return bounds_dist(border_dummy, mover) >= 0
+	else if(get_dir(loc, target) == dir)
+		return FALSE
+	return TRUE
 
 //used in the AStar algorithm to determinate if the turf the door is on is passable
 /obj/machinery/door/firedoor/CanAStarPass()
@@ -611,19 +618,6 @@ var/global/list/alert_overlays_global = list()
 		open()
 	else
 		close()
-
-/obj/machinery/door/firedoor/border_only/Uncross(atom/movable/mover as mob|obj, turf/target as turf)
-	if(istype(mover) && (mover.checkpass(PASSDOOR|PASSGLASS)))
-		return 1
-	if(flow_flags & ON_BORDER)
-		if(target) //Are we doing a manual check to see
-			if(get_dir(loc, target) == dir)
-				return !density
-		else if(mover.dir == dir) //Or are we using move code
-			if(density)
-				mover.to_bump(src)
-			return !density
-	return 1
 
 /obj/machinery/door/firedoor/border_only/is_fulltile()
 	return 0

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -591,6 +591,10 @@ var/global/list/alert_overlays_global = list()
 	air_properties_vary_with_direction = 1
 	flow_flags = ON_BORDER
 
+/obj/machinery/door/firedoor/border_only/New()
+	..()
+	setup_border_dummy()
+
 /obj/machinery/door/firedoor/border_only/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover) && (mover.checkpass(PASSDOOR|PASSGLASS)))
 		return 1

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -1,7 +1,7 @@
 //Terribly sorry for the code doubling, but things go derpy otherwise.
 /obj/machinery/door/airlock/multi_tile
 	width = 2
-	appearance_flags = 0
+	appearance_flags = TILE_MOVER
 
 /obj/machinery/door/airlock/multi_tile/glass
 	name = "Glass Airlock"

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -28,6 +28,7 @@
 
 /obj/machinery/door/window/New()
 	..()
+	setup_border_dummy()
 	if((istype(req_access) && req_access.len) || istext(req_access))
 		icon_state = "[icon_state]"
 		base_state = icon_state

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -106,31 +106,22 @@
 		close()
 
 /obj/machinery/door/window/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	if(istype(mover) && (mover.checkpass(PASSDOOR|PASSGLASS)))
+	if(can_pass(mover))
 		return TRUE
-	if(get_dir(loc, target) == dir || get_dir(loc, mover) == dir)
+	if(istype(mover))
+		return !density || (bounds_dist(border_dummy, mover) >= 0)
+	else if(get_dir(loc, target) == dir)
 		if(air_group)
 			return FALSE
 		return !density
-	else
-		return TRUE
+	return TRUE
 
 //used in the AStar algorithm to determinate if the turf the door is on is passable
 /obj/machinery/door/window/CanAStarPass(var/obj/item/weapon/card/id/ID, var/to_dir)
 	return !density || (dir != to_dir) || check_access(ID)
 
-/obj/machinery/door/window/Uncross(atom/movable/mover, turf/target)
-	if(istype(mover) && (mover.checkpass(PASSDOOR|PASSGLASS)))
-		return TRUE
-	if(flow_flags & ON_BORDER) //but it will always be on border tho
-		if(target) //Are we doing a manual check to see
-			if(get_dir(loc, target) == dir)
-				return !density
-		else if(mover.dir == dir) //Or are we using move code
-			if(density)
-				mover.to_bump(src)
-			return !density
-	return TRUE
+/obj/machinery/door/window/can_pass(atom/movable/mover)
+	return ..() && mover.checkpass(PASSDOOR | PASSGLASS)
 
 /obj/machinery/door/window/open()
 	if(!density) //it's already open you silly cunt

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -15,7 +15,7 @@ var/global/list/blood_list = list()
 	random_icon_states = list("mfloor1", "mfloor2", "mfloor3", "mfloor4", "mfloor5", "mfloor6", "mfloor7")
 	plane = ABOVE_TURF_PLANE
 	layer = BLOOD_LAYER
-	appearance_flags = TILE_BOUND|LONG_GLIDE
+	appearance_flags = TILE_BOUND|LONG_GLIDE|TILE_MOVER
 	throwforce = 0
 	var/base_icon = 'icons/effects/blood.dmi'
 

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -145,15 +145,11 @@
 /obj/structure/window/barricade/full/blocks_doors()
 	return TRUE
 
-/obj/structure/window/barricade/full/Uncross(atom/movable/O as mob|obj, target as turf)
-
-	return 1
-
 /obj/structure/window/barricade/full/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 
 	if(air_group || !height) //The mover is an airgroup
 		return 1 //We aren't airtight, only exception to PASSGLASS
-	if(istype(mover) && mover.checkpass(PASSGLASS))
+	if(can_pass(mover))
 		return 1
 	return 0
 

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -139,6 +139,9 @@
 	..(loc)
 	flow_flags &= ~ON_BORDER
 
+/obj/structure/window/barricade/full/setup_border_dummy()
+	return
+
 /obj/structure/window/barricade/full/blocks_doors()
 	return TRUE
 

--- a/code/game/objects/structures/fullwindow.dm
+++ b/code/game/objects/structures/fullwindow.dm
@@ -23,15 +23,12 @@
 /obj/structure/window/full/setup_border_dummy()
 	return
 
-/obj/structure/window/full/Uncross(atom/movable/O as mob|obj, target as turf)
-
-	return 1
 
 /obj/structure/window/full/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 
-	if(istype(mover) && mover.checkpass(PASSGLASS))
+	if(can_pass(mover))
 		return 1
-	return 0
+	return !density
 
 /obj/structure/window/full/can_be_reached(mob/user)
 

--- a/code/game/objects/structures/fullwindow.dm
+++ b/code/game/objects/structures/fullwindow.dm
@@ -20,6 +20,9 @@
 	..(loc)
 	flow_flags |= ON_BORDER
 
+/obj/structure/window/full/setup_border_dummy()
+	return
+
 /obj/structure/window/full/Uncross(atom/movable/O as mob|obj, target as turf)
 
 	return 1

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -505,6 +505,7 @@
 		plane = ABOVE_HUMAN_PLANE
 	flipped = 1
 	flow_flags |= ON_BORDER
+	setup_border_dummy()
 	for(var/D in list(turn(direction, 90), turn(direction, -90)))
 		var/obj/structure/table/T = locate() in get_step(src,D)
 		if(T && !T.flipped)
@@ -521,6 +522,7 @@
 	reset_plane_and_layer()
 	flipped = 0
 	flow_flags &= ~ON_BORDER
+	remove_border_dummy()
 	for(var/D in list(turn(dir, 90), turn(dir, -90)))
 		var/obj/structure/table/T = locate() in get_step(src.loc,D)
 		if(T && T.flipped && T.dir == src.dir)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -309,13 +309,10 @@
 		var/mob/M = mover
 		if(M.flying)
 			return 1
-	if(istype(mover) && mover.checkpass(PASSTABLE))
+	if(can_pass(mover))
 		return 1
 	if(flipped)
-		if(get_dir(loc, target) == dir || get_dir(loc, mover) == dir)
-			return !density
-		else
-			return 1
+		return bounds_dist(border_dummy, mover) >= 0
 	return 0
 
 /obj/structure/table/bumped_by_firebird(obj/structure/bed/chair/vehicle/firebird/F)
@@ -345,18 +342,8 @@
 			return 1
 	return 1
 
-/obj/structure/table/Uncross(atom/movable/mover as mob|obj, target as turf)
-	if(istype(mover) && mover.checkpass(PASSTABLE))
-		return 1
-	if(flow_flags & ON_BORDER)
-		if(target) //Are we doing a manual check to see
-			if(get_dir(loc, target) == dir)
-				return !density
-		else if(mover.dir == dir) //Or are we using move code
-			if(density)
-				mover.to_bump(src)
-			return !density
-	return 1
+/obj/structure/table/can_pass(atom/movable/mover)
+	return ..() && mover.checkpass(PASSTABLE)
 
 /obj/structure/table/MouseDropTo(atom/movable/O,mob/user,src_location,over_location,src_control,over_control,params)
 	if(O == user)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -35,6 +35,7 @@
 /obj/structure/windoor_assembly/New()
 	..()
 	update_nearby_tiles()
+	setup_border_dummy() //I guess? It's not dense anyway but whatever
 
 obj/structure/windoor_assembly/Destroy()
 	setDensity(FALSE)
@@ -45,27 +46,18 @@ obj/structure/windoor_assembly/Destroy()
 	icon_state = "[facing]_[secure ? "secure_":""]windoor_assembly[wired ? "02":"01"]"
 
 /obj/structure/windoor_assembly/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	if(istype(mover) && (mover.checkpass(PASSDOOR|PASSGLASS)))
+	if(can_pass(mover))
 		return TRUE
-	if(get_dir(target, mover) == dir) //Make sure looking at appropriate border
+	if(istype(mover))
+		return !density || (bounds_dist(border_dummy, mover) >= 0)
+	else if(get_dir(loc, target) == dir)
 		if(air_group)
-			return FALSE
+			return FALSE //There's no especially compelling reason for this here but it's copied from windoors
 		return !density
-	else
-		return TRUE
-
-/obj/structure/windoor_assembly/Uncross(atom/movable/mover, turf/target)
-	if(istype(mover) && mover.checkpass(PASSGLASS))
-		return TRUE
-	if(flow_flags & ON_BORDER)
-		if(target) //Are we doing a manual check to see
-			if(get_dir(loc, target) == dir)
-				return !density
-		else if(mover.dir == dir) //Or are we using move code
-			if(density)
-				mover.to_bump(src)
-			return !density
 	return TRUE
+
+/obj/structure/windoor_assembly/can_pass(atom/movable/mover)
+	return ..() && mover.checkpass(PASSDOOR | PASSGLASS)
 
 /obj/structure/windoor_assembly/proc/make_windoor(var/mob/user)
 	var/spawn_type = secure ? secure_type : windoor_type

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -173,30 +173,24 @@ var/list/one_way_windows
 		health -= damage
 		healthcheck()
 
-/obj/structure/window/Uncross(var/atom/movable/mover, var/turf/target)
-	if(istype(mover) && mover.checkpass(PASSGLASS))
-		return 1
-	if(flow_flags & ON_BORDER)
-		if(target) //Are we doing a manual check to see
-			if(get_dir(loc, target) == dir)
-				return !density
-		else if(mover.dir == dir) //Or are we using move code
-			if(density)
-				mover.to_bump(src)
-			return !density
-	return 1
+/obj/structure/window/can_pass(atom/movable/mover)
+	return ..() && mover.checkpass(PASSGLASS)
 
 /obj/structure/window/Cross(atom/movable/mover, turf/target, height = 0)
-	if(istype(mover) && mover.checkpass(PASSGLASS))
+	if(can_pass(mover))
 		if(istype(mover,/obj/item/projectile/beam))
 			var/obj/item/projectile/beam/B = mover
 			B.damage *= disperse_coeff
 			if(B.damage <= 1)
 				B.bullet_die()
-		return 1
-	if(get_dir(loc, target) == dir || get_dir(loc, mover) == dir)
-		return !density
-	return 1
+		return TRUE
+	if(!density)
+		return TRUE
+	if(istype(mover))
+		return bounds_dist(border_dummy, mover) >= 0
+	else if(get_dir(loc, target) == dir)
+		return FALSE
+	return TRUE
 
 //Someone threw something at us, please advise
 /obj/structure/window/hitby(var/atom/movable/AM)
@@ -533,7 +527,7 @@ var/list/one_way_windows
 		return 0
 
 	update_nearby_tiles() //Compel updates before
-	dir = turn(dir, 90)
+	change_dir(turn(dir, 90))
 	update_nearby_tiles()
 	return
 
@@ -547,7 +541,7 @@ var/list/one_way_windows
 		return 0
 
 	update_nearby_tiles() //Compel updates before
-	dir = turn(dir, 270)
+	change_dir(turn(dir, 270))
 	update_nearby_tiles()
 	return
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -42,6 +42,7 @@ var/list/one_way_windows
 
 	..(loc)
 	flow_flags |= ON_BORDER
+	setup_border_dummy()
 
 	update_nearby_tiles()
 	update_nearby_icons()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -107,58 +107,14 @@
 	return 0
 
 /turf/Exit(atom/movable/mover, atom/target)
-	if(!mover)
-		return 1
-	// First, make sure it can leave its square
-	if(mover.loc == src)
-		// Nothing but border objects stop you from leaving a tile, only one loop is needed
-		for(var/obj/obstacle in src)
-			/*if(ismob(mover) && mover:client)
-				world << "<span class='danger'>EXIT</span>origin: checking exit of mob [obstacle]"*/
-			if(!obstacle.Uncross(mover, target) && obstacle != mover && obstacle != target)
-				/*if(ismob(mover) && mover:client)
-					world << "<span class='danger'>EXIT</span>Origin: We are bumping into [obstacle]"*/
-				mover.to_bump(obstacle, 1)
-				return 0
-	return 1
+	return TRUE
 
 /turf/Exited(atom/movable/mover, atom/newloc)
 	..()
 	lazy_invoke_event(/lazy_event/on_exited, list("mover" = mover, "location" = src, "newloc" = newloc))
 
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
-	if (!mover)
-		return 1
-
-	var/list/large_dense = list()
-	//Next, check objects to block entry that are on the border
-	for(var/atom/movable/border_obstacle in src)
-		if(border_obstacle.flow_flags&ON_BORDER)
-			/*if(ismob(mover) && mover:client)
-				world << "<span class='danger'>ENTER</span>Target(border): checking Cross of [border_obstacle]"*/
-			if(!border_obstacle.Cross(mover, mover.loc) && (forget != border_obstacle) && mover != border_obstacle)
-				/*if(ismob(mover) && mover:client)
-					world << "<span class='danger'>ENTER</span>Target(border): We are bumping into [border_obstacle]"*/
-				mover.to_bump(border_obstacle, 1)
-				return 0
-		else
-			large_dense += border_obstacle
-
-	//Then, check the turf itself
-	if (!src.Cross(mover, src))
-		mover.to_bump(src, 1)
-		return 0
-
-	//Finally, check objects/mobs to block entry that are not on the border
-	for(var/atom/movable/obstacle in large_dense)
-		/*if(ismob(mover) && mover:client)
-			world << "<span class='danger'>ENTER</span>target(large_dense): [mover] checking Cross of [obstacle]"*/
-		if(!obstacle.Cross(mover, mover.loc) && (forget != obstacle) && mover != obstacle)
-			/*if(ismob(mover) && mover:client)
-				world << "<span class='danger'>ENTER</span>target(large_dense): checking: We are bumping into [obstacle]"*/
-			mover.to_bump(obstacle, 1)
-			return 0
-	return 1 //Nothing found to block so return success!
+	return Cross(mover, src)
 
 
 /turf/Entered(atom/movable/A as mob|obj, atom/OldLoc)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -258,7 +258,7 @@
 		reconsider_lights()
 
 /turf/get_bump_target()
-	. = bump_target || ..()
+	. = bump_target?.get_bump_target() || ..()
 	bump_target = null
 
 /turf/proc/is_plating()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -75,6 +75,9 @@
 
 	var/holomap_draw_override = HOLOMAP_DRAW_NORMAL
 
+	var/list/border_objects //Only exists when there are border objects on the turf.
+	var/atom/movable/bump_target //If this var is not null, bumping this turf bumps this object instead. Used for border objects. Unset immediately when bumped.
+
 /turf/examine(mob/user)
 	..()
 	if(bullet_marks)
@@ -111,6 +114,10 @@
 
 /turf/Exited(atom/movable/mover, atom/newloc)
 	..()
+	if(border_objects)
+		border_objects -= mover //Don't bother checking for the flag, in case it lost it.
+		if(!border_objects.len)
+			border_objects = null
 	lazy_invoke_event(/lazy_event/on_exited, list("mover" = mover, "location" = src, "newloc" = newloc))
 
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
@@ -121,6 +128,12 @@
 	if(movement_disabled)
 		to_chat(usr, "<span class='warning'>Movement is admin-disabled.</span>")//This is to identify lag problems
 		return
+
+	if(A.flow_flags & ON_BORDER)
+		if(!border_objects)
+			border_objects = list()
+		border_objects += A
+
 	//THIS IS OLD TURF ENTERED CODE
 	var/loopsanity = 100
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -257,6 +257,10 @@
 		has_opaque_atom = TRUE // Make sure to do this before reconsider_lights(), incase we're on instant updates. Guaranteed to be on in this case.
 		reconsider_lights()
 
+/turf/get_bump_target()
+	. = bump_target || ..()
+	bump_target = null
+
 /turf/proc/is_plating()
 	return 0
 /turf/proc/can_place_cables()

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -209,12 +209,6 @@ var/list/forbidden_varedit_object_types = list(
 			else
 				to_chat(user, "Unknown type: [selected_type]")
 
-	switch(edited_variable)
-		if("bound_width", "bound_height", "bound_x", "bound_y")
-			if(new_value % world.icon_size) //bound_width/height must be a multiple of 32, otherwise movement breaks - BYOND issue
-				to_chat(usr, "[edited_variable] can only be a multiple of [world.icon_size]!")
-				return
-
 	if(edited_datum && edited_variable)
 		if(isdatum(edited_datum) && edited_datum.variable_edited(edited_variable, old_value, new_value))
 		//variable_edited() can block the edit in case there's special behavior for a variable (for example, updating lights after they're changed)

--- a/code/modules/components/ai/controller.dm
+++ b/code/modules/components/ai/controller.dm
@@ -21,7 +21,7 @@
 		SendSignal(COMSIG_BUMPED, list("movable"=AM))
 
 // Called when we bump another movable atom.
-/datum/component/controller/proc/Onto_bump(var/atom/A)
+/datum/component/controller/proc/OnBump(var/atom/A)
 	if(istype(A, /atom/movable))
 		var/atom/movable/AM = A
 		SendSignal(COMSIG_BUMP, list("movable"=AM))

--- a/code/modules/components/ai/hostile/hunt.dm
+++ b/code/modules/components/ai/hostile/hunt.dm
@@ -1,7 +1,7 @@
 // Hunting controller from spiders
 /datum/component/ai/hunt
 	var/last_dir=0 // cardinal direction
-	var/last_was_bumped=0 // Boolean, indicates whether the last movement resulted in a to_bump().
+	var/last_was_bumped=0 // Boolean, indicates whether the last movement resulted in a Bump().
 	var/life_tick=0
 
 	var/movement_range=20 // Maximum range of points we move to (20 in spiders)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -28,7 +28,7 @@ var/list/global_singularity_pool
 	var/last_movement_dir = 0 //Log the singularity's last movement to produce biased movement (singularity prefers constant movement due to inertia)
 	var/last_failed_movement = 0 //Will not move in the same dir if it couldnt before, will help with the getting stuck on fields thing.
 	var/last_warning
-	appearance_flags = LONG_GLIDE
+	appearance_flags = LONG_GLIDE|TILE_MOVER
 	var/chained = 0 //Adminbus chain-grab
 	var/modifier = "" //for memes
 
@@ -691,7 +691,7 @@ var/list/global_singularity_pool
 	var/democracy_cooldown = 120
 	var/list/inputs = list("UP","DOWN","LEFT","RIGHT")
 	var/deadchat_active = 1
-	appearance_flags = 0
+	appearance_flags = TILE_MOVER
 
 /obj/machinery/singularity/deadchat_controlled/Destroy()
 	..()

--- a/code/modules/power/treadmill.dm
+++ b/code/modules/power/treadmill.dm
@@ -29,10 +29,11 @@
 	)
 
 /obj/machinery/power/treadmill/New()
+	..()
+	setup_border_dummy()
 	if(anchored)
 		connect_to_network()
 	RefreshParts()
-	..()
 
 /obj/machinery/power/treadmill/RefreshParts()
 	var/calc = 0
@@ -86,7 +87,6 @@
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return 1
 	if((flow_flags & ON_BORDER) && (mover.dir == dir))
-		powerwalk(mover)
 		return !density
 	return 1
 
@@ -99,6 +99,10 @@
 		return 0
 	else
 		return 1
+
+/obj/machinery/power/treadmill/Bumped(atom/movable/AM)
+	if(AM.loc == loc)
+		powerwalk(AM)
 
 /obj/machinery/power/treadmill/wrenchAnchor(var/mob/user, var/obj/item/I)
 	. = ..()

--- a/code/modules/power/treadmill.dm
+++ b/code/modules/power/treadmill.dm
@@ -83,22 +83,19 @@
 	else
 		to_chat(runner,"<span class='warning'>You're exhausted! You can't run anymore!</span>")
 
-/obj/machinery/power/treadmill/Uncross(var/atom/movable/mover, var/turf/target)
-	if(istype(mover) && mover.checkpass(PASSGLASS))
-		return 1
-	if((flow_flags & ON_BORDER) && (mover.dir == dir))
-		return !density
-	return 1
+/obj/machinery/power/treadmill/can_pass(var/atom/movable/mover)
+	return ..() && mover.checkpass(PASSGLASS)
 
 /obj/machinery/power/treadmill/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	if(istype(mover) && mover.checkpass(PASSGLASS))
-		return 1
-	if(get_dir(loc, target) == dir || get_dir(loc, mover) == dir)
-		if(air_group)
-			return 1
-		return 0
-	else
-		return 1
+	if(can_pass(mover))
+		return TRUE
+	if(!density)
+		return TRUE
+	if(istype(mover))
+		return bounds_dist(border_dummy, mover) >= 0
+	else if(get_dir(loc, target) == dir)
+		return FALSE
+	return TRUE
 
 /obj/machinery/power/treadmill/Bumped(atom/movable/AM)
 	if(AM.loc == loc)

--- a/code/modules/spacepods/spacepods.dm
+++ b/code/modules/spacepods/spacepods.dm
@@ -44,7 +44,7 @@
 	var/lights_enabled = FALSE
 	light_power = 2
 	light_range = SPACEPOD_LIGHTS_RANGE_OFF
-	appearance_flags = LONG_GLIDE
+	appearance_flags = LONG_GLIDE|TILE_MOVER
 
 	var/datum/delay_controller/move_delayer = new(0.1, ARBITRARILY_LARGE_NUMBER) //See setup.dm, 12
 	var/passenger_fire = 0 //Whether or not a passenger can fire weapons attached to this pod

--- a/code/world.dm
+++ b/code/world.dm
@@ -10,6 +10,7 @@ var/world_startup_time
 	cache_lifespan = 0	//stops player uploaded stuff from being kept in the rsc past the current session
 	//loop_checks = 0
 	icon_size = WORLD_ICON_SIZE
+	movement_mode = PIXEL_MOVEMENT_MODE
 
 #define RECOMMENDED_VERSION 513
 


### PR DESCRIPTION
In addition to obviously requiring 514, this is unfinished and not fully functional yet. I'm pushing it at this point just so that others can see my pain, and possibly suggest better organization since I made no real attempt to put the new code in the most appropriate places

It pretty much works fine if everything is tile-locked, but some behavior is a bit weird for pixel movers. Windows get bumped twice, mob bump swapping lets you phase through walls, etc. You can also probably phase through walls with lockers or anything else you can get inside, too. Most of that shouldn't be too hard to fix.
Sadly, this does not fully remove the bump hack. It reduces its scope, though. Now we only have to reimplement BYOND collision checking for border objects, instead of for absolutely everything.

The `border_dummy` stuff should technically be a separate PR as it's relevant to pre-514 stuff, but it's easier to implement with changes I had already made for 514 movecode, so it's in here too. Spacepods no longer phase through windows! This comes at the cost of more bugs which I'm working on, as well as assuredly more bugs I haven't found yet.