### PR TITLE
Reintroduces the Need for Antiseptic Procedures

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -151,12 +151,12 @@
 			druggy = max(druggy - 1, 0)
 			if(!druggy)
 				to_chat(src, "It looks like you are back in Kansas.")
-/*
+
 		// Increase germ_level regularly
 		if(prob(40))
 			germ_level += 1
 		// If you're dirty, your gloves will become dirty, too.
 		if(gloves && germ_level > gloves.germ_level && prob(10))
 			gloves.germ_level += 1
-*/
+
 	return 1


### PR DESCRIPTION
I don't really know how to read code, but a cursory glance makes it appear as though this will make it so that germs build up on crewmen's hands and/or gloves, making it so that performing a particularly grungy surgery risks sepsis and other kinds of nasty things that remain responsible for the deaths of hundreds of people on Real Earth and in Game Space who are incapable of developing or maintaining rudimentary hygiene functions. This is probably going to affect [gameplay], so it might be [controversial]. I extend my personal thanks to DeityLink for finding the code that Nutcracker!CBT was referring to, and especially to the latter for being too lazy to make this [featurerequest] so that I get to take at least 50% of the credit for it.

:cl:
 * tweak: It is now no longer safe to perform surgery without washing first washing your hands, as germs will now build up on them over time and can spread to gloves. Neglecting to do so will risk sepsis. No more removing the clown's ass after showering Runtime with belly rubs!