### PR TITLE
Better botany logs

### DIFF
--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -51,6 +51,8 @@
 	var/internal_light = 1
 	var/light_on = 0
 
+	var/key_name_last_user = ""
+
 	// Seed details/line data.
 	var/datum/seed/seed = null // The currently planted seed
 
@@ -197,6 +199,7 @@
 		return 0
 
 	add_fingerprint(user)
+	key_name_last_user = key_name(user)
 
 	if (istype(O, /obj/item/seeds))
 
@@ -214,10 +217,10 @@
 			switch(S.seed.spread)
 				if(1)
 					var/turf/T = get_turf(src)
-					msg_admin_attack("[key_name(user)] has planted a creeper packet. <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a>")
+					msg_admin_attack("[key_name(user)] has planted a creeper packet. <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a> ([bad_stuff()])")
 				if(2)
 					var/turf/T = get_turf(src)
-					msg_admin_attack("[key_name(user)] has planted a spreading vine packet. <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a>")
+					msg_admin_attack("[key_name(user)] has planted a spreading vine packet. <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a> ([bad_stuff()])")
 			if(S.seed.exude_gasses && S.seed.exude_gasses.len)
 				add_gamelogs(user, "planted a packet exuding [english_list(S.seed.exude_gasses)]", tp_link = TRUE)
 
@@ -583,5 +586,17 @@
 	if((usr.incapacitated() || !Adjacent(usr)))
 		return
 	close_lid()
+
+// See no evil, hear no evil. Returns all the potentially bad things on a hydroponic tray.
+/obj/machinery/portable_atmospherics/hydroponics/proc/bad_stuff()
+	var/list/things = list()
+	if (seed.thorny)
+		things += "thorny"
+	if (seed.carnivorous)
+		things += "carnivorous"
+	for (var/chemical_id in seed.chems)
+		if (chemical_id in reagents_to_log)
+			things += chemical_id
+	return english_list(things, "nothing")
 
 /datum/locking_category/hydro_tray

--- a/code/modules/hydroponics/hydro_tray_process.dm
+++ b/code/modules/hydroponics/hydro_tray_process.dm
@@ -250,9 +250,9 @@
 				new /obj/effect/plantsegment(T, seed)
 				switch(seed.spread)
 					if(1)
-						msg_admin_attack("limited growth creeper vines ([seed.display_name]) have spread out of a tray. <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a>")
+						msg_admin_attack("limited growth creeper vines ([seed.display_name]) have spread out of a tray. <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a>, last touched by [key_name_last_user]. Seed id: [seed.uid]. ([bad_stuff()])")
 					if(2)
-						msg_admin_attack("space vines ([seed.display_name]) have spread out of a tray. <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a>")
+						msg_admin_attack("space vines ([seed.display_name]) have spread out of a tray. <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a>, last touched by [key_name_last_user]. Seed id: [seed.uid]. ([bad_stuff()])")
 
 	check_level_sanity()
 	if(update_icon_after_process)

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -68,6 +68,7 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 	var/mob_drop					// Seed type dropped by the mobs when it dies without an host
 
 	var/large = 1					// Is the plant large? For clay pots.
+	var/list/mutation_log = list() // Who did what
 
 /datum/seed/New()
 	..()
@@ -255,7 +256,7 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 //Random mutations moved to hydroponics_mutations.dm!
 
 //Mutates a specific trait/set of traits. Used by the Bioballistic Delivery System.
-/datum/seed/proc/apply_gene(var/datum/plantgene/gene, var/mode)
+/datum/seed/proc/apply_gene(var/datum/plantgene/gene, var/mode, var/mob/user)
 
 	if(!gene || !gene.values || immutable > 0)
 		return
@@ -397,6 +398,15 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 					spread 				= max(gene.values[3], spread)
 					harvest_repeat 		= max(gene.values[4], harvest_repeat)
 					yield				= round(mix(gene.values[5], yield,		rand(40, 60)/100), 0.1)
+
+	var/text = "([timestamp()]) Plant engineered by [key_name(usr)], mode: [mode] (cf __DEFINES/hydroponics.dm). |"
+	text += " Plant is now [carnivorous ? "carnivorous" : "NO LONGER carnivorous."] |"
+	text += " Plant is now [thorny ? "thorny" : "NO LONGER thorny."] |"
+	text += " Plant chems: "
+	for (var/chemical in chems)
+		text += "[chemical], vol: [chems[chemical][1]], potency: [chems[chemical][2]]."
+
+	mutation_log += text
 
 //Returns a list of the desired trait values.
 /datum/seed/proc/get_gene(var/genetype)
@@ -656,6 +666,8 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 	new_seed.biolum_colour =        biolum_colour
 	new_seed.alter_temp = 			alter_temp
 	new_seed.plant_dmi =			plant_dmi
+	new_seed.mutation_log =			mutation_log
+	new_seed.mutation_log += "([timestamp()]) Diverged from seed with uid: [uid]."
 
 	ASSERT(istype(new_seed)) //something happened... oh no...
 	return new_seed

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -365,7 +365,7 @@
 			loaded_seed.modified = 101
 
 		for(var/datum/plantgene/gene in loaded_disk.genes)
-			loaded_seed.seed.apply_gene(gene, mode)
+			loaded_seed.seed.apply_gene(gene, mode, usr)
 
 	else if(href_list["toggle_mode"])
 		switch(mode)


### PR DESCRIPTION
[administration]

Right now, if someone kudzulooses (or unleashes creeper wines, or whatever), we only know that a kudzuloose happened at time t in place xyz. We don't directly know who did it (can only infer it from the log `mob M placed a creeper wine in some tray`), we don't know how dangerous the vines are.

This PR remedies that by giving more detailed and explicit messages about the generosity of creeper vines, who actually unleashed them, and who engineered the vines in the first place.