### PR TITLE
Adds Elite Syndicate Bundles

### DIFF
--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -342,6 +342,7 @@
 
 			T = new(R)
 			T.uses = uses
+			T.job = role.name_for_uplink
 			target_radio.hidden_uplink = T
 			target_radio.traitor_frequency = freq
 			to_chat(traitor_mob, "The Syndicate have cunningly disguised a Syndicate Uplink as your [R.name] [loc]. Simply dial the frequency [format_frequency(freq)] to unlock its hidden features.")
@@ -352,6 +353,7 @@
 			var/pda_pass = "[rand(100,999)] [pick("Alpha","Bravo","Delta","Omega")]"
 
 			T = new(R)
+			T.job = role.name_for_uplink
 			R.hidden_uplink = T
 			var/obj/item/device/pda/P = R
 			P.lock_code = pda_pass

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -361,7 +361,7 @@
 			traitor_mob.mind.total_TC += R.hidden_uplink.uses
 		if (role && T)
 			role.uplink = T
-		T.job = role.name
+		T.job = role.name_for_uplink
 
 /datum/mind/proc/find_syndicate_uplink(var/obj/item/device/uplink/true_uplink)
 	var/uplink = null

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -361,7 +361,7 @@
 			traitor_mob.mind.total_TC += R.hidden_uplink.uses
 		if (role && T)
 			role.uplink = T
-		T.job = role.name_for_uplink
+			T.job = role.name_for_uplink
 
 /datum/mind/proc/find_syndicate_uplink(var/obj/item/device/uplink/true_uplink)
 	var/uplink = null

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -361,7 +361,7 @@
 			traitor_mob.mind.total_TC += R.hidden_uplink.uses
 		if (role && T)
 			role.uplink = T
-		T.job = role.name_for_uplink
+		T.job = role.name
 
 /datum/mind/proc/find_syndicate_uplink(var/obj/item/device/uplink/true_uplink)
 	var/uplink = null

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -342,7 +342,6 @@
 
 			T = new(R)
 			T.uses = uses
-			T.job = role.name_for_uplink
 			target_radio.hidden_uplink = T
 			target_radio.traitor_frequency = freq
 			to_chat(traitor_mob, "The Syndicate have cunningly disguised a Syndicate Uplink as your [R.name] [loc]. Simply dial the frequency [format_frequency(freq)] to unlock its hidden features.")
@@ -353,7 +352,6 @@
 			var/pda_pass = "[rand(100,999)] [pick("Alpha","Bravo","Delta","Omega")]"
 
 			T = new(R)
-			T.job = role.name_for_uplink
 			R.hidden_uplink = T
 			var/obj/item/device/pda/P = R
 			P.lock_code = pda_pass
@@ -363,7 +361,7 @@
 			traitor_mob.mind.total_TC += R.hidden_uplink.uses
 		if (role && T)
 			role.uplink = T
-
+		T.job = role.name_for_uplink
 
 /datum/mind/proc/find_syndicate_uplink(var/obj/item/device/uplink/true_uplink)
 	var/uplink = null

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -49,6 +49,9 @@
 	var/name = null
 
 	var/plural_name = null
+	
+	// role name assigned to the antag's potential uplink
+	var/name_for_uplink = null
 
 	// Various flags and things.
 	var/flags = 0

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -49,9 +49,7 @@
 	var/name = null
 
 	var/plural_name = null
-	
-	// role name assigned to the antag's potential uplink
-	var/name_for_uplink = null
+
 
 	// Various flags and things.
 	var/flags = 0

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -50,7 +50,6 @@
 
 	var/plural_name = null
 
-
 	// Various flags and things.
 	var/flags = 0
 

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -136,6 +136,7 @@
 /datum/role/traitor/challenger
 	name = CHALLENGER
 	id = CHALLENGER
+	name_for_uplink = CHALLENGER
 	required_pref = CHALLENGER
 	wikiroute = CHALLENGER
 	logo_state = "synd-logo"

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -136,6 +136,7 @@
 /datum/role/traitor/challenger
 	name = CHALLENGER
 	id = CHALLENGER
+	name_for_uplink = "Challenger"
 	required_pref = CHALLENGER
 	wikiroute = CHALLENGER
 	logo_state = "synd-logo"

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -136,7 +136,6 @@
 /datum/role/traitor/challenger
 	name = CHALLENGER
 	id = CHALLENGER
-	name_for_uplink = "Challenger"
 	required_pref = CHALLENGER
 	wikiroute = CHALLENGER
 	logo_state = "synd-logo"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1067,12 +1067,6 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/storage/box/syndicate_team
 	cost = 28
 
-/datum/uplink_item/syndie_coop/elite_bundle/new_uplink_item(new_item, location, user)
-	var/list/conditions = list()
-	if(isplasmaman(user))
-		conditions += "plasmaman"
-	return new new_item(location, conditions)
-
 /datum/uplink_item/syndie_coop/stone
 	name = "SG-VPR-23 Pathogenic Medium"
 	desc = "A closely guarded artifact leveraged from the Vampire Lords.  It possesses an active sample of the SG-VPR-23 strain that is the source of all known cases of vampirism within the galaxy.  This piece is only to be granted to an operative cell that wishes to execute, and accepts the risk, of an SG-VPR-23 outbreak.  It is brittle in its old age, and may only survive one use."

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1060,7 +1060,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/syndie_coop
 	category = "Cooperative Cell"
-	jobs_excluded = list("Nuclear Operative", "Challenger")
+	jobs_excluded = list("Nuclear Operative", "challenger")
 	
 /datum/uplink_item/syndie_coop/elite_bundle
 	name = "Elite Syndicate Bundle"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1063,7 +1063,7 @@ var/list/uplink_items = list()
 	
 /datum/uplink_item/syndie_coop/elite_bundle
 	name = "Elite Syndicate Bundle"
-	desc = "A Syndicate bundle designed for a team two agents."
+	desc = "A Syndicate bundle designed for a team of two agents."
 	item = /obj/item/weapon/storage/box/syndicate_team
 	cost = 28
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1066,8 +1066,7 @@ var/list/uplink_items = list()
 	desc = "A Syndicate bundle designed for a team of two agents."
 	item = /obj/item/weapon/storage/box/syndicate_team
 	cost = 28
-	discounted_cost = 80
-	jobs_with_discount = list("Nuclear Operative")
+	jobs_excluded = list("Nuclear Operative", "Challenger")
 
 /datum/uplink_item/syndie_coop/stone
 	name = "SG-VPR-23 Pathogenic Medium"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1060,6 +1060,18 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/syndie_coop
 	category = "Cooperative Cell"
+	
+/datum/uplink_item/syndie_coop/elite_bundle
+	name = "Elite Syndicate Bundle"
+	desc = "A Syndicate bundle designed for a team two agents."
+	item = /obj/item/weapon/storage/box/syndicate_team
+	cost = 28
+
+/datum/uplink_item/syndie_coop/elite_bundle/new_uplink_item(new_item, location, user)
+	var/list/conditions = list()
+	if(isplasmaman(user))
+		conditions += "plasmaman"
+	return new new_item(location, conditions)
 
 /datum/uplink_item/syndie_coop/stone
 	name = "SG-VPR-23 Pathogenic Medium"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1060,37 +1060,31 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/syndie_coop
 	category = "Cooperative Cell"
+	jobs_excluded = list("Nuclear Operative", "Challenger")
 	
 /datum/uplink_item/syndie_coop/elite_bundle
 	name = "Elite Syndicate Bundle"
 	desc = "A Syndicate bundle designed for a team of two agents."
 	item = /obj/item/weapon/storage/box/syndicate_team
 	cost = 28
-	jobs_excluded = list("Nuclear Operative", "Challenger")
 
 /datum/uplink_item/syndie_coop/stone
 	name = "SG-VPR-23 Pathogenic Medium"
 	desc = "A closely guarded artifact leveraged from the Vampire Lords.  It possesses an active sample of the SG-VPR-23 strain that is the source of all known cases of vampirism within the galaxy.  This piece is only to be granted to an operative cell that wishes to execute, and accepts the risk, of an SG-VPR-23 outbreak.  It is brittle in its old age, and may only survive one use."
 	item = /obj/item/clothing/mask/stone
 	cost = 60
-	discounted_cost = 100
-	jobs_with_discount = list("Nuclear Operative")
 	
 /datum/uplink_item/syndie_coop/changeling_vial
 	name = "CH-L1-NG Bioweapon Sample"
 	desc = "A securely contained vial of the experimental mutagen 'CH-L1-NG'.  Originally designed as a transhumanist super-soldier serum, the mutagen was reclassified as a bioweapon when research showed that the afflicted would completely dissociate from their identity and loyalties.  Victims of 'CH-L1-NG' were found to be the perfect killing machines to be released upon enemies of the Syndicate."
 	item = /obj/item/changeling_vial
 	cost = 60
-	discounted_cost = 100
-	jobs_with_discount = list("Nuclear Operative")
 	
 /datum/uplink_item/syndie_coop/bloodcult_pamphlet
 	name = "Esoteric Propaganda Pamphlet"
 	desc = "A pamphlet found within the controlled literature archives detailing what appears to be a communication ritual to contact the celestial NRS-1.  Exposure to NRS-1 is known to induce the formation of a hive-like social structure among the afflicted, delusions of grandeur, and collective suicidal tendencies.  An operative cell wishing to weaponize contact with NRS-1 should proceed with extreme caution."
 	item = /obj/item/weapon/bloodcult_pamphlet/oneuse
 	cost = 60
-	discounted_cost = 100
-	jobs_with_discount = list("Nuclear Operative")
 	
 /datum/uplink_item/syndie_coop/codebreaker
 	name = "Codebreaker"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1066,7 +1066,7 @@ var/list/uplink_items = list()
 	desc = "A Syndicate bundle designed for a team of two agents."
 	item = /obj/item/weapon/storage/box/syndicate_team
 	cost = 28
-	discounted_cost = 40
+	discounted_cost = 80
 	jobs_with_discount = list("Nuclear Operative")
 
 /datum/uplink_item/syndie_coop/stone

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1066,6 +1066,8 @@ var/list/uplink_items = list()
 	desc = "A Syndicate bundle designed for a team of two agents."
 	item = /obj/item/weapon/storage/box/syndicate_team
 	cost = 28
+	discounted_cost = 40
+	jobs_with_discount = list("Nuclear Operative")
 
 /datum/uplink_item/syndie_coop/stone
 	name = "SG-VPR-23 Pathogenic Medium"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1060,7 +1060,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/syndie_coop
 	category = "Cooperative Cell"
-	jobs_excluded = list("Nuclear Operative", "challenger")
+	jobs_excluded = list("Nuclear Operative", CHALLENGER)
 	
 /datum/uplink_item/syndie_coop/elite_bundle
 	name = "Elite Syndicate Bundle"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -214,11 +214,6 @@
 	item_state = "earmuffs"
 
 /obj/item/device/radio/headset/headset_earmuffs/syndie
-	name = "headset earmuffs"
-	desc = "Protective earmuffs for sound technicians that allow one to speak on radio channels."
-	icon = 'icons/obj/items.dmi'
-	icon_state = "headset_earmuffs"
-	item_state = "earmuffs"
 	origin_tech = Tc_SYNDICATE + "=3"
 	syndie = 1
 	init_keyslot1_type = /obj/item/device/encryptionkey/syndicate

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -213,7 +213,7 @@
 	icon_state = "headset_earmuffs"
 	item_state = "earmuffs"
 
-/obj/item/device/radio/headset/syndie_headset_earmuffs
+/obj/item/device/radio/headset/headset_earmuffs/syndie
 	name = "headset earmuffs"
 	desc = "Protective earmuffs for sound technicians that allow one to speak on radio channels."
 	icon = 'icons/obj/items.dmi'

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -213,6 +213,16 @@
 	icon_state = "headset_earmuffs"
 	item_state = "earmuffs"
 
+/obj/item/device/radio/headset/syndie_headset_earmuffs
+	name = "headset earmuffs"
+	desc = "Protective earmuffs for sound technicians that allow one to speak on radio channels."
+	icon = 'icons/obj/items.dmi'
+	icon_state = "headset_earmuffs"
+	item_state = "earmuffs"
+	origin_tech = Tc_SYNDICATE + "=3"
+	syndie = 1
+	init_keyslot1_type = /obj/item/device/encryptionkey/syndicate
+
 /obj/item/device/radio/headset/deathsquad
 	name = "Deathsquad headset"
 	desc = "A headset used by the dark side of Nanotrasen's Spec Ops. Channels are as follows: :0 - Deathsquad :c - command, :s - security, :e - engineering, :d - mining, :q - cargo, :m - medical, :n - science."

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -384,6 +384,7 @@ obj/item/weapon/storage/box/syndie_kit/cheaptide
 	new /obj/item/ammo_storage/box/BMG50(src)
 	new /obj/item/ammo_storage/box/BMG50(src)
 	new /obj/item/ammo_storage/box/BMG50(src)
+	new /obj/item/clothing/glasses/thermal/syndi(src)
 	return
 	
 /obj/item/weapon/storage/box/syndie_kit/spotter
@@ -396,6 +397,7 @@ obj/item/weapon/storage/box/syndie_kit/cheaptide
 	new /obj/item/weapon/gun/projectile/deagle/camo(src)
 	new /obj/item/clothing/accessory/holster/handgun(src)
 	new /obj/item/ammo_storage/box/a50(src)
+	new /obj/item/clothing/glasses/thermal/syndi(src)
 	return
 
 /obj/item/weapon/storage/box/syndicate_team/New()

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -368,3 +368,40 @@ obj/item/weapon/storage/box/syndie_kit/cheaptide
 	..()
 	new /obj/item/device/telepad_beacon(src)
 	new /obj/item/weapon/rcs/salvage/syndicate(src)
+
+
+//Elite Syndicate Bundles
+//for all of the team bundles
+
+/obj/item/weapon/storage/box/syndie_kit/sniper
+	name = "Sniper"
+
+/obj/item/weapon/storage/box/syndie_kit/sniper/New()
+	..()
+	new /obj/item/device/radio/headset/syndie_headset_earmuffs(src)
+	new /obj/item/weapon/gun/projectile/hecate(src)
+	new /obj/item/clothing/accessory/storage/webbing(src)
+	new /obj/item/ammo_storage/box/BMG50(src)
+	new /obj/item/ammo_storage/box/BMG50(src)
+	new /obj/item/ammo_storage/box/BMG50(src)
+	return
+	
+/obj/item/weapon/storage/box/syndie_kit/spotter
+	name = "Spotter"
+
+/obj/item/weapon/storage/box/syndie_kit/spotter/New()
+	..()
+	new /obj/item/device/radio/headset/syndie_headset_earmuffs(src)
+	new /obj/item/binoculars(src)
+	new /obj/item/weapon/gun/projectile/deagle/camo(src)
+	new /obj/item/clothing/accessory/holster/handgun(src)
+	new /obj/item/ammo_storage/box/a50(src)
+	return
+
+/obj/item/weapon/storage/box/syndicate_team/New()
+	..()
+	var/team_kit = pick("sniperspotter")
+	switch(team_kit)
+		if("sniperspotter")
+			new /obj/item/weapon/storage/box/syndie_kit/sniper(src)
+			new /obj/item/weapon/storage/box/syndie_kit/spotter(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -400,10 +400,82 @@ obj/item/weapon/storage/box/syndie_kit/cheaptide
 	new /obj/item/clothing/glasses/thermal/syndi(src)
 	return
 
+/obj/item/weapon/storage/box/syndie_kit/scammer
+	name = "Legitimate Businessman"
+
+/obj/item/weapon/storage/box/syndie_kit/scammer/New()
+	..()
+	new /obj/item/clothing/mask/gas/voice(src)
+	new /obj/item/weapon/storage/briefcase/false_bottomed/smg(src)
+	new /obj/item/clothing/under/chameleon(src)
+	new /obj/item/clothing/shoes/syndigaloshes(src)
+	new /obj/item/weapon/card/id/syndicate(src)
+	new /obj/item/clothing/glasses/sunglasses/sechud/syndishades(src)
+	new /obj/item/device/reportintercom(src)
+	dispense_cash(10000, src)
+	return
+	
+/obj/item/weapon/storage/box/syndie_kit/shootershotty
+	name = "Shotgun"
+
+/obj/item/weapon/storage/box/syndie_kit/shootershotty/New()
+	..()
+	new /obj/item/clothing/accessory/holster/knife/boot/preloaded/tactical(src)
+	new /obj/item/clothing/shoes/combat(src)
+	new /obj/item/clothing/gloves/neorussian/fingerless(src)
+	new /obj/item/clothing/under/sl_suit/armored(src)
+	new /obj/item/clothing/suit/armor/hos/jensen(src)
+	new /obj/item/clothing/glasses/sunglasses/prescription(src)
+	new /obj/item/clothing/head/beanie/black(src)
+	new /obj/item/clothing/accessory/storage/bandolier(src)
+	new /obj/item/weapon/gun/projectile/shotgun/pump/combat(src)
+	new /obj/item/weapon/storage/box/buckshotshells(src)
+	new /obj/item/weapon/storage/box/buckshotshells(src)
+	new /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel(src)
+	new /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel(src)
+	new /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel(src)
+	new /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel(src)
+	
+	return
+
+/obj/item/weapon/storage/box/syndie_kit/shooteruzis
+	name = "Dual Uzis"
+
+/obj/item/weapon/storage/box/syndie_kit/shooteruzis/New()
+	..()
+	new /obj/item/clothing/accessory/holster/knife/boot/preloaded/tactical(src)
+	new /obj/item/clothing/shoes/combat(src)
+	new /obj/item/clothing/gloves/neorussian/fingerless(src)
+	new /obj/item/clothing/under/syndicate(src)
+	new /obj/item/clothing/suit/armor/hos/jensen(src)
+	new /obj/item/clothing/glasses/sunglasses/prescription(src)
+	new /obj/item/clothing/head/soft/black(src)
+	new /obj/item/clothing/accessory/storage/webbing(src)
+	new /obj/item/weapon/gun/projectile/automatic/microuzi(src)
+	new /obj/item/weapon/gun/projectile/automatic/microuzi(src)
+	new /obj/item/ammo_storage/box/c9mm(src)
+	new /obj/item/ammo_storage/box/c9mm(src)
+	new /obj/item/ammo_storage/box/c9mm(src)
+	new /obj/item/ammo_storage/box/c9mm(src)
+	new /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel(src)
+	new /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel(src)
+	new /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel(src)
+	new /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel(src)
+	
+	return
+
 /obj/item/weapon/storage/box/syndicate_team/New()
 	..()
-	var/team_kit = pick("sniperspotter")
+	var/team_kit = pick("sniperspotter", "scammers", "workplaceshooter")
 	switch(team_kit)
 		if("sniperspotter")
 			new /obj/item/weapon/storage/box/syndie_kit/sniper(src)
 			new /obj/item/weapon/storage/box/syndie_kit/spotter(src)
+		
+		if("scammers")
+			new /obj/item/weapon/storage/box/syndie_kit/scammer(src)
+			new /obj/item/weapon/storage/box/syndie_kit/scammer(src)
+		
+		if("workplaceshooter")
+			new /obj/item/weapon/storage/box/syndie_kit/shootershotty(src)
+			new /obj/item/weapon/storage/box/syndie_kit/shooteruzis(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -385,7 +385,6 @@ obj/item/weapon/storage/box/syndie_kit/cheaptide
 	new /obj/item/ammo_storage/box/BMG50(src)
 	new /obj/item/ammo_storage/box/BMG50(src)
 	new /obj/item/clothing/glasses/thermal/syndi(src)
-	return
 	
 /obj/item/weapon/storage/box/syndie_kit/spotter
 	name = "Spotter"
@@ -398,7 +397,6 @@ obj/item/weapon/storage/box/syndie_kit/cheaptide
 	new /obj/item/clothing/accessory/holster/handgun(src)
 	new /obj/item/ammo_storage/box/a50(src)
 	new /obj/item/clothing/glasses/thermal/syndi(src)
-	return
 
 /obj/item/weapon/storage/box/syndie_kit/scammer
 	name = "Legitimate Businessman"
@@ -413,7 +411,6 @@ obj/item/weapon/storage/box/syndie_kit/cheaptide
 	new /obj/item/clothing/glasses/sunglasses/sechud/syndishades(src)
 	new /obj/item/device/reportintercom(src)
 	dispense_cash(10000, src)
-	return
 	
 /obj/item/weapon/storage/box/syndie_kit/shootershotty
 	name = "Shotgun"
@@ -435,8 +432,6 @@ obj/item/weapon/storage/box/syndie_kit/cheaptide
 	new /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel(src)
 	new /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel(src)
 	new /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel(src)
-	
-	return
 
 /obj/item/weapon/storage/box/syndie_kit/shooteruzis
 	name = "Dual Uzis"
@@ -461,8 +456,6 @@ obj/item/weapon/storage/box/syndie_kit/cheaptide
 	new /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel(src)
 	new /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel(src)
 	new /obj/item/weapon/grenade/iedcasing/preassembled/withshrapnel(src)
-	
-	return
 
 /obj/item/weapon/storage/box/syndicate_team/New()
 	..()

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -378,7 +378,7 @@ obj/item/weapon/storage/box/syndie_kit/cheaptide
 
 /obj/item/weapon/storage/box/syndie_kit/sniper/New()
 	..()
-	new /obj/item/device/radio/headset/syndie_headset_earmuffs(src)
+	new /obj/item/device/radio/headset/headset_earmuffs/syndie(src)
 	new /obj/item/weapon/gun/projectile/hecate(src)
 	new /obj/item/clothing/accessory/storage/webbing(src)
 	new /obj/item/ammo_storage/box/BMG50(src)
@@ -392,7 +392,7 @@ obj/item/weapon/storage/box/syndie_kit/cheaptide
 
 /obj/item/weapon/storage/box/syndie_kit/spotter/New()
 	..()
-	new /obj/item/device/radio/headset/syndie_headset_earmuffs(src)
+	new /obj/item/device/radio/headset/headset_earmuffs/syndie(src)
 	new /obj/item/binoculars(src)
 	new /obj/item/weapon/gun/projectile/deagle/camo(src)
 	new /obj/item/clothing/accessory/holster/handgun(src)


### PR DESCRIPTION
The team bundle selection costs 28TC and let's two traitors pool their points and buy a 2-man bundle pack.  The first of these is sniper/spotter kit.  The selection provides you with two separate boxes to split up the gear and keep to the spirit of the bundle.

We also didn't have earmuff radios that had a syndie chip, so I added those as well.

![boxes](https://user-images.githubusercontent.com/74737391/108108799-b4ef1d80-7056-11eb-9634-496101a74f42.png)
![image](https://user-images.githubusercontent.com/74737391/108110747-54adab00-7059-11eb-99cd-a933885beea3.png)
![image](https://user-images.githubusercontent.com/74737391/108110773-5b3c2280-7059-11eb-9db2-af945d5b0937.png)

EDIT: Two additional bundles

Workplace Shooters:
there is a dual uzis and a shotgun kit
 both have four IEDS, tactical knives, combat boots, fingerless gloves, armored amish/tactical clothes, sunglasses, beanie/hat.  but with specific weapons for each.

![image](https://user-images.githubusercontent.com/74737391/108164928-54dc9380-70b7-11eb-9798-46a87042cd6f.png)
![image](https://user-images.githubusercontent.com/74737391/108164950-5b6b0b00-70b7-11eb-98c9-560781792a61.png)

Scammers:
voice changers, smg briefcases, cham jumpsuit, noslips, agent ids, syndieshades, report falsifiers, and 10k in credits each.
![image](https://user-images.githubusercontent.com/74737391/108164964-60c85580-70b7-11eb-9d06-8f0ed35d214f.png)

:cl:
 * rscadd: Adds the Sniper/Spotter team bundle to the uplink under the new Elite Syndie Bundle option
