### PR TITLE
You can no longer build robots on Castlestation

### DIFF
--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -58,3 +58,6 @@
 
 #define EXTOOLS_REFERENCE_TRACKING DEVELOPER_MODE
 #define EXTOOLS_DEBUGGER DEVELOPER_MODE
+
+//Map-specific defines
+#define ROBOT_CHECK "robot check"

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -101,6 +101,9 @@
 				if(!prison.brainmob)
 					to_chat(user, "<span class='warning'>Sticking an empty [P] into the frame would sort of defeat the purpose.</span>")
 					return
+				if(!map.map_specific_conditions("robot check"))
+					to_chat(user, "<span class='warning'>The station prevents you from kickstarting the tyranny of the AI!</span>")
+					return
 				if(prison.brainmob.stat == DEAD)
 					to_chat(user, "<span class='warning'>Sticking a dead [P] into the frame would sort of defeat the purpose.</span>")
 					return
@@ -299,7 +302,7 @@ That prevents a few funky behaviors.
 							else if (C.contents.len)
 								to_chat(U, "<span class='danger'>ERROR:</span> Artificial intelligence detected on terminal.")
 							else if (!T.occupant)
-								to_chat(U, "<span class='danger'>ERROR:</span> Unable to locate artificial intelligence.")		
+								to_chat(U, "<span class='danger'>ERROR:</span> Unable to locate artificial intelligence.")
 	else
 		to_chat(U, "<span class='danger'>ERROR:</span> AI flush is in progress, cannot execute transfer protocol.")
 	return

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -101,7 +101,7 @@
 				if(!prison.brainmob)
 					to_chat(user, "<span class='warning'>Sticking an empty [P] into the frame would sort of defeat the purpose.</span>")
 					return
-				if(!map.map_specific_conditions("robot check"))
+				if(!map.map_specific_conditions(ROBOT_CHECK))
 					to_chat(user, "<span class='warning'>The station prevents you from kickstarting the tyranny of the AI!</span>")
 					return
 				if(prison.brainmob.stat == DEAD)

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -181,6 +181,9 @@
 			if(!istype(loc,/turf))
 				to_chat(user, "<span class='warning'>You can't put the [W] in, the frame has to be standing on the ground to be perfectly precise.</span>")
 				return
+			if(!map.map_specific_conditions("robot check"))
+				to_chat(user, "<span class='warning'>The station will not allow you to create oppressive mechanical minions!</span>")
+				return
 			if(!M.brainmob)
 				to_chat(user, "<span class='warning'>Sticking an empty [W] into the frame would sort of defeat the purpose.</span>")
 				return

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -181,7 +181,7 @@
 			if(!istype(loc,/turf))
 				to_chat(user, "<span class='warning'>You can't put the [W] in, the frame has to be standing on the ground to be perfectly precise.</span>")
 				return
-			if(!map.map_specific_conditions("robot check"))
+			if(!map.map_specific_conditions(ROBOT_CHECK))
 				to_chat(user, "<span class='warning'>The station will not allow you to create oppressive mechanical minions!</span>")
 				return
 			if(!M.brainmob)

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -182,6 +182,10 @@ var/global/list/accessable_z_levels = list()
 
 /datum/map/proc/map_specific_init()
 
+//Set map-specific conditions here
+/datum/map/proc/map_specific_conditions(var/condition)
+	return 1
+
 //For any map-specific UI, like AI jumps
 /datum/map/proc/special_ui(var/obj/abstract/screen/S, mob/user)
 	return FALSE

--- a/maps/tgstation-sec.dm
+++ b/maps/tgstation-sec.dm
@@ -95,6 +95,11 @@
 		return FALSE
 	return ..()
 
+/datum/map/active/map_specific_conditions(text)
+	if("robot check") //Cannot build robots on Castle
+		return 0
+	return ..()
+
 ////////////////////////////////////////////////////////////////
 #include "tgstation-sec.dmm"
 #endif

--- a/maps/tgstation-sec.dm
+++ b/maps/tgstation-sec.dm
@@ -97,7 +97,7 @@
 
 /datum/map/active/map_specific_conditions(condition)
 	switch(condition)
-		if("robot check") //Cannot build robots on Castle
+		if(ROBOT_CHECK) //Cannot build robots on Castle
 			return 0
 	return ..()
 

--- a/maps/tgstation-sec.dm
+++ b/maps/tgstation-sec.dm
@@ -95,9 +95,10 @@
 		return FALSE
 	return ..()
 
-/datum/map/active/map_specific_conditions(text)
-	if("robot check") //Cannot build robots on Castle
-		return 0
+/datum/map/active/map_specific_conditions(condition)
+	switch(condition)
+		if("robot check") //Cannot build robots on Castle
+			return 0
 	return ..()
 
 ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Kept you waiting, huh?
As I mentioned in #28545 I was gonna work on this, and now Castletation's Will prevents people from building AI and Cyborgs. After all, why would you WANT machines if they're the bread and butter of tyranny?

![robots](https://pbs.twimg.com/media/EVrgQBHXQAEoysg.jpg)

:cl:
 * tweak: Castlestation will now prevent you from creating AI and Cyborgs. Unholy magics that mess with the fabric of reality are unaffected.