### PR TITLE
Fixes windows absorbing any and all rockets

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -272,6 +272,8 @@ var/list/impact_master = list()
 
 	if (special_collision != PROJECTILE_COLLISION_MISS)
 		special_collision = A.bullet_act(src, def_zone) // searches for return value
+		if (A.gcDestroyed) // We killed the poor thing
+			A = A_turf
 	if(special_collision != PROJECTILE_COLLISION_DEFAULT && special_collision != PROJECTILE_COLLISION_BLOCKED) // the bullet is still flying, either from missing its target, bouncing off it, or going through a portal
 		bumped = 0 // reset bumped variable!
 

--- a/code/modules/projectiles/projectile/rocket.dm
+++ b/code/modules/projectiles/projectile/rocket.dm
@@ -32,8 +32,9 @@
 		sleep(picked_up_speed)
 
 /obj/item/projectile/rocket/to_bump(var/atom/A)
+	var/A_turf = get_turf(A)
 	..()
-	explosion(A, exdev, exheavy, exlight, exflash)
+	explosion(A_turf, exdev, exheavy, exlight, exflash)
 	if(!gcDestroyed)
 		qdel(src)
 


### PR DESCRIPTION
A rather strange but interesting bug rendered possible by shitcode on both sides of the codebase combining their powers.

Rocket bumps a window. It destroys it. It should then start an explosion, but since the explosion is `spawn()`d, the window-breaking code happens first, which deletes and sends the window to null space. The explosion then happens in nullspace.

This bug appeared because of a slight re-arrangement of the proc call order in Deity's projectile refactor. I fix it by making sure the rocket knows where it landed BEFORE actually exploding.