### PR TITLE
Fixes AIs being difficult to revive (due to a bug)

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -150,7 +150,7 @@
 /mob/living/silicon/attempt_suicide(forced = 0, suicide_set = 1)
 
 	if(!forced)
-		var/confirm = alert("Are you sure you want to commit suicide? This action cannot be undone and reving you might be difficult for humans. It may also go against your laws.", "Confirm Suicide", "Yes", "No")
+		var/confirm = alert("Are you sure you want to commit suicide? This action cannot be undone and reviving you might be difficult for humans. It may also go against your laws.", "Confirm Suicide", "Yes", "No")
 
 		if(confirm != "Yes")
 			return

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -150,7 +150,7 @@
 /mob/living/silicon/attempt_suicide(forced = 0, suicide_set = 1)
 
 	if(!forced)
-		var/confirm = alert("Are you sure you want to commit suicide? This action cannot be undone and you will not able to be revived.", "Confirm Suicide", "Yes", "No")
+		var/confirm = alert("Are you sure you want to commit suicide? This action cannot be undone and reving you might be difficult for humans. It may also go against your laws.", "Confirm Suicide", "Yes", "No")
 
 		if(confirm != "Yes")
 			return

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -164,6 +164,9 @@
 	if(suicide_set)
 		suiciding = 1
 
+	adjustBruteLoss(2*maxHealth) // kill it dead
+	updatehealth()
+
 	visible_message(pick("<span class='danger'>[src] is powering down. It looks like \he's trying to commit suicide.</span>", \
 						 "<span class='danger'>[src] is force-deleting \his system files. It looks like \he's trying to commit suicide.</span>", \
 						 "<span class='danger'>[src] is turning off \his runtime safety. It looks like \he's trying to commit suicide.</span>", \

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -164,7 +164,7 @@
 	if(suicide_set)
 		suiciding = 1
 
-	adjustBruteLoss(2*maxHealth) // kill it dead
+	adjustBruteLoss(-(maxHealth - health) + 2*maxHealth) // kill it dead; set our health to -100 instantly
 	updatehealth()
 
 	visible_message(pick("<span class='danger'>[src] is powering down. It looks like \he's trying to commit suicide.</span>", \

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -6,6 +6,8 @@
 		if(!explosive)
 			playsound(src, 'sound/machines/WXP_shutdown.ogg', 75, FALSE)
 	stat = DEAD
+	adjustBruteLoss(2*maxHealth) // kill it dead
+	updatehealth()
 	update_icon()
 
 	update_canmove()

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -6,8 +6,6 @@
 		if(!explosive)
 			playsound(src, 'sound/machines/WXP_shutdown.ogg', 75, FALSE)
 	stat = DEAD
-	adjustBruteLoss(2*maxHealth) // kill it dead
-	updatehealth()
 	update_icon()
 
 	update_canmove()


### PR DESCRIPTION
An AI which had committed suicide could always be revived, but only if their shell had sustained damage in some way before. Simply hitting with a wrench would be enough. 

This, however, wasn't very intuitive. This PR fixes that by nuking the health of the AI when it commits suicide.

I also clarified the message in the "suicide" prompt to make it clearer that, yes, AI can be recovered if they use the suicide verb. It's just difficult to do so. 