### PR TITLE
Totally Radical Radiation Collectors

### DIFF
--- a/code/datums/wires/jukebox.dm
+++ b/code/datums/wires/jukebox.dm
@@ -69,7 +69,7 @@ var/const/JUKE_SETTING = 128 //Cut shocks. Pulse toggles settings menu.
 		if(JUKE_TRANSMIT)
 			J.rad_pulse()
 			interference = 1
-			sleep(50)
+			sleep(3 SECONDS)
 			interference = 0
 		if(JUKE_CONFIG)
 			playsound(J.loc, pick(static_list), 100, 1)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -264,6 +264,7 @@
 	..()
 
 /obj/machinery/door/airlock/uranium/proc/radiate()
+	emitted_harvestable_radiation(get_turf(src), 3, range = 5)
 	for(var/mob/living/L in range (3,src))
 		L.apply_radiation(15,RAD_EXTERNAL)
 	return

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -623,6 +623,7 @@ turf/simulated/floor/update_icon()
 					spam_flag = 1
 					set_light(3)
 					icon_state = "uranium_inactive"
+					emitted_harvestable_radiation(src, 2, range = 5)
 					for(var/mob/living/L in range(2,src)) //Weak radiation
 						L.apply_radiation(3,RAD_EXTERNAL)
 					flick("uranium_active",src)

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -100,6 +100,7 @@
 	if(!active)
 		if(world.time > last_event+15)
 			active = 1
+			emitted_harvestable_radiation(src, 3, range = 5)
 			for(var/mob/living/L in range(3,src))
 				L.apply_radiation(12,RAD_EXTERNAL)
 			for(var/turf/simulated/wall/mineral/uranium/T in range(3,src))

--- a/code/modules/media/broadcast/transmitters/broadcast.dm
+++ b/code/modules/media/broadcast/transmitters/broadcast.dm
@@ -219,6 +219,7 @@
 			update_on()
 
 		// Radiation
+		emitted_harvestable_radiation(get_turf(src), 50, range = 10)	//Transmitters apply 51 rad doses to nearby humans so we're using that.
 		for(var/mob/living/carbon/M in view(src,3))
 			var/rads = RADS_PER_TICK * sqrt( 1 / (get_dist(M, src) + 1) ) //Distance/rads: 1 = 27, 2 = 21, 3 = 19
 			M.apply_radiation(round(rads*count_rad_wires()/2),RAD_EXTERNAL)

--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -513,6 +513,7 @@ var/global/list/loopModeNames=list(
 		screen = JUKEBOX_SCREEN_MAIN
 
 /obj/machinery/media/jukebox/proc/rad_pulse() //Called by pulsing the transmit wire
+	emitted_harvestable_radiation(get_turf(src), 20, range = 5)	//Standing by a juke applies a dose of 17 rads to humans so we'll round based on that. 1/5th the power of a freshly born stage 1 singularity.
 	for(var/mob/living/carbon/M in view(src,3))
 		var/rads = 50 * sqrt( 1 / (get_dist(M, src) + 1) ) //It's like a transmitter, but 1/3 as powerful.
 		M.apply_radiation(round(rads/2),RAD_EXTERNAL) //Distance/rads: 1 = 18, 2 = 14, 3 = 12

--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -519,6 +519,8 @@ var/global/list/loopModeNames=list(
 		M.apply_radiation(round(rads/2),RAD_EXTERNAL) //Distance/rads: 1 = 18, 2 = 14, 3 = 12
 
 /obj/machinery/media/jukebox/Topic(href, href_list)
+	if(wires.interference)
+		return
 	if(isobserver(usr) && !isAdminGhost(usr))
 		to_chat(usr, "<span class='warning'>You can't push buttons when your fingers go right through them, dummy.</span>")
 		return


### PR DESCRIPTION
Allows Jukebox radiation bursts, radio transmitters, and uranium floors, walls, and doors to generate power via radiation collectors. 
**Edit for clarity: This does not add radiation damage or effects to these things. All this radiation already existed. This just makes it harvestable.**

The power generated is very small. Each also has a significantly smaller range the collector must be within than the shard/singulo, limiting how many collectors each is able to affect. 

![kindarad](https://user-images.githubusercontent.com/64218965/108426379-ad23aa80-7209-11eb-8b5f-9b0305c8e2e0.png)

Jukeboxes emit about 1/5th the power of a baby singulo and have a few second cooldown between radiation bursts. Sprinting around on uranium floor wasn't able to break even on power generation:use on the empty station I tested this on. Bigger setups with more collectors will do much better.

>Why

This allows for limited freeform radiation engines to be made. Monkeymen on conveyor belts activating uranium floors while triggering infrared assemblies that release jukebox radiation, for example. Setting up the same engine is a chore. That's why people like goofy spider engines. 

**This doesn't let the particle accelerator, self charging batteries, etc generate power. Only what is listed above.** Baby steps and all that. 
[tweak]

:cl:
 * rscadd: Jukeboxes, transmitters, and uranium tiles/walls/doors now provide power to radiation collectors. Jukebox engine patent pending. 