### PR TITLE
Turns lightswitches off by default.

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -534,3 +534,20 @@ proc/isInSight(var/atom/A, var/atom/B)
 	//	return 0
 	// that's not the kind of operation we are running here, nerd
 	return clamp(round(mixedcolor), 0, 255)
+
+//Gets all areas within a department
+/proc/get_department_areas(atom/AM)
+	var/department_type
+	var/area/our_area = get_area(AM)
+	var/all_master_types = direct_subtypesof(/area)
+	for(var/checkable in all_master_types)
+		if(istype(our_area,checkable))
+			department_type = checkable
+			break
+	if(!department_type)
+		department_type = our_area.type
+	var/list/department_areas = list()
+	for(var/area/A in areas)
+		if(istype(A,department_type))
+			department_areas += A
+	return department_areas

--- a/code/__HELPERS/typeof.dm
+++ b/code/__HELPERS/typeof.dm
@@ -123,6 +123,5 @@ var/global/list/existing_typesof_cache = list()
 proc/direct_subtypesof(path)
 	var/list/out = subtypesof(path)
 	for(var/type in out)
-		for(var/stype in subtypesof(type))
-			out -= stype //remove any subtypes of our current entry from the list
+		out -= subtypesof(type) //remove any subtypes of our current entry from the list
 	return out

--- a/code/__HELPERS/typeof.dm
+++ b/code/__HELPERS/typeof.dm
@@ -119,3 +119,10 @@ var/global/list/existing_typesof_cache = list()
 		if(istype(A, path))
 			return TRUE
 	return FALSE
+//Finds types that are subtypes of a type, but only 1 level down.
+proc/direct_subtypesof(path)
+	var/list/out = subtypesof(path)
+	for(var/type in out)
+		for(var/stype in subtypesof(type))
+			out -= stype //remove any subtypes of our current entry from the list
+	return out

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -736,6 +736,16 @@ var/datum/controller/gameticker/ticker
 				to_chat(R, R.connected_ai?"<b>You have synchronized with an AI. Their name will be stated shortly. Other AIs can be ignored.</b>":"<b>You are not synchronized with an AI, and therefore are not required to heed the instructions of any unless you are synced to them.</b>")
 			R.lawsync()
 
+	//Toggle lightswitches on in occupied departments
+	var/discrete_areas = list()
+	for(var/mob/living/carbon/human/H in player_list)
+		var/area/A = get_area(H)
+		if(!(A in discrete_areas)) //We've already added their department
+			discrete_areas += get_department_areas(H)
+	for(var/area/DA in discrete_areas)
+		for(var/obj/machinery/light_switch/LS in DA)
+			LS.toggle_switch(1)
+
 // -- Tag mode!
 
 /datum/controller/gameticker/proc/tag_mode(var/mob/user)

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -120,8 +120,8 @@
 /obj/machinery/light_switch/attack_hand(mob/user)
 	toggle_switch()
 
-/obj/machinery/light_switch/toggle_switch(var/newstate = null)
-	if(newstate && on == newstate)
+/obj/machinery/light_switch/proc/toggle_switch(var/newstate = null)
+	if(!isnull(newstate) && on == newstate)
 		return
 	if(buildstage != 2)
 		return

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -16,7 +16,7 @@
 
 /obj/machinery/light_switch/initialize()
 	add_self_to_holomap()
-	toggle_switch(0)
+	toggle_switch(newstate = 0)
 
 /obj/machinery/light_switch/New(var/loc, var/ndir, var/building = 2)
 	..()

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -122,7 +122,7 @@
 
 /obj/machinery/light_switch/toggle_switch(var/newstate = null)
 	if(newstate && on == newstate)
-      return
+		return
 	if(buildstage != 2)
 		return
 	on = !on

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -16,6 +16,7 @@
 
 /obj/machinery/light_switch/initialize()
 	add_self_to_holomap()
+	toggle_switch(0)
 
 /obj/machinery/light_switch/New(var/loc, var/ndir, var/building = 2)
 	..()
@@ -105,7 +106,7 @@
 	return ..()
 
 /obj/machinery/light_switch/attack_paw(mob/user)
-	src.attack_hand(user)
+	toggle_switch()
 
 /obj/machinery/light_switch/attack_ghost(var/mob/dead/observer/ghost)
 	if(!can_spook())
@@ -117,6 +118,11 @@
 	return ..()
 
 /obj/machinery/light_switch/attack_hand(mob/user)
+	toggle_switch()
+
+/obj/machinery/light_switch/toggle_switch(var/newstate = null)
+	if(newstate && on == newstate)
+      return
 	if(buildstage != 2)
 		return
 	on = !on


### PR DESCRIPTION
Turns lightswitches off by default in empty departments, saving power and more importantly giving a visual indicator that a department is not staffed. Maybe now we'll spend less time standing in front of an empty RnD, cargo, or medbay hammering that bell.

EDIT: Since it's been brought up a few times, **this only affects areas with lightswitches.** Hallways, maint, and areas like medbay & brig lobby on most maps will not be affected.

:cl:
 * tweak: Lightswitches are now turned off by default.
 * tweak: Lightswitches check for players at roundstart and turn on if there are any present.