### PR TITLE
Emaggable body scanners & sleepers

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -312,8 +312,6 @@
 		dat = format_occupant_data(get_occupant_data(occupant),scanning)
 		dat += "<HR><a href='?src=\ref[src];immunity=1'>View Immune System scan</a><br>"
 		dat += "<HR><A href='?src=\ref[src];print=1'>Print</A><BR>"
-		if (emagged)
-			dat+= "<HR><a href='?src=\ref[src];safety=1'>Re-enable Safeties</a><br>"
 
 	dat += text("<BR><A href='?src=\ref[];mach_close=scanconsole'>Close</A>", user)
 	user << browse(dat, "window=scanconsole;size=430x600")
@@ -337,11 +335,6 @@
 		var/obj/item/weapon/paper/R = new(loc)
 		R.name = "paper - 'body scan report'"
 		R.info = format_occupant_data(get_occupant_data(occupant),scanning)
-
-	else if(href_list["safety"])
-		emagged = 0
-		to_chat(usr, "<span class='warning'>You re-enable the dosage limiter on \the [src].</span>")
-		to_chat(usr, "<span class='notice'>\The [src] emits a quiet whine.</span>")
 
 	else if(href_list["immunity"])
 		if(!immune)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -201,10 +201,16 @@
 /obj/machinery/bodyscanner/emag(mob/user)
 	if(!emagged)
 		if(user)
-			to_chat(user, "<span class='warning'>You disable the X-ray dosage limiter on \the [src].	</span>")
+			to_chat(user, "<span class='warning'>You disable the X-ray dosage limiter on \the [src].</span>")
 		to_chat(user, "<span class='notice'>\The [src] emits an ominous hum.</span>")
 		emagged = 1
 		return 1
+	else if (emagged)
+		if(user)
+			to_chat(user, "<span class='warning'>You re-enable the dosage limiter on \the [src].</span>")
+		to_chat(user, "<span class='notice'>\The [src] emits a quiet whine.</span>")
+		emagged = 0
+		return 0
 	return -1
 
 /obj/machinery/bodyscanner/crowbarDestroy(mob/user, obj/item/weapon/crowbar/I)
@@ -309,6 +315,8 @@
 		dat = format_occupant_data(get_occupant_data(occupant),scanning)
 		dat += "<HR><a href='?src=\ref[src];immunity=1'>View Immune System scan</a><br>"
 		dat += "<HR><A href='?src=\ref[src];print=1'>Print</A><BR>"
+		if (emagged)
+			dat+= "<HR><a href='?src=\ref[src];safety=1'>Re-enable Safeties</a><br>"
 
 	dat += text("<BR><A href='?src=\ref[];mach_close=scanconsole'>Close</A>", user)
 	user << browse(dat, "window=scanconsole;size=430x600")
@@ -332,6 +340,11 @@
 		var/obj/item/weapon/paper/R = new(loc)
 		R.name = "paper - 'body scan report'"
 		R.info = format_occupant_data(get_occupant_data(occupant),scanning)
+
+	else if(href_list["safety"])
+		emagged = 0
+		to_chat(usr, "<span class='warning'>You re-enable the dosage limiter on \the [src].</span>")
+		to_chat(usr, "<span class='notice'>\The [src] emits a quiet whine.</span>")
 
 	else if(href_list["immunity"])
 		if(!immune)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -7,7 +7,7 @@
 	idle_power_usage = 125
 	active_power_usage = 250
 	var/scanning = 1
-	machine_flags = SCREWTOGGLE | CROWDESTROY | EJECTNOTDEL | WRENCHMOVE | FIXED2WORK
+	machine_flags = SCREWTOGGLE | CROWDESTROY | EJECTNOTDEL | WRENCHMOVE | FIXED2WORK | EMAGGABLE
 	component_parts = newlist(
 		/obj/item/weapon/circuitboard/fullbodyscanner,
 		/obj/item/weapon/stock_parts/scanning_module,
@@ -198,6 +198,15 @@
 	update_icon()
 	set_light(0)
 
+/obj/machinery/bodyscanner/emag(mob/user)
+	if(!emagged)
+		if(user)
+			to_chat(user, "<span class='warning'>You disable the X-ray dosage limiter on \the [src].	</span>")
+		to_chat(user, "<span class='notice'>\The [src] emits an ominous hum.</span>")
+		emagged = 1
+		return 1
+	return -1
+
 /obj/machinery/bodyscanner/crowbarDestroy(mob/user, obj/item/weapon/crowbar/I)
 	if(occupant)
 		to_chat(user, "<span class='warning'>You cannot disassemble \the [src], it's occupado.</span>")
@@ -268,6 +277,9 @@
 		return
 	if (occupant)
 		use_power = 2
+		if (emagged)
+			occupant.apply_radiation(12,RAD_EXTERNAL)
+
 	else
 		use_power = 1
 

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -200,18 +200,15 @@
 
 /obj/machinery/bodyscanner/emag(mob/user)
 	if(!emagged)
-		if(user)
-			to_chat(user, "<span class='warning'>You disable the X-ray dosage limiter on \the [src].</span>")
+		to_chat(user, "<span class='warning'>You disable the X-ray dosage limiter on \the [src].</span>")
 		to_chat(user, "<span class='notice'>\The [src] emits an ominous hum.</span>")
 		emagged = 1
 		return 1
 	else if (emagged)
-		if(user)
-			to_chat(user, "<span class='warning'>You re-enable the dosage limiter on \the [src].</span>")
+		to_chat(user, "<span class='warning'>You re-enable the dosage limiter on \the [src].</span>")
 		to_chat(user, "<span class='notice'>\The [src] emits a quiet whine.</span>")
 		emagged = 0
 		return 0
-	return -1
 
 /obj/machinery/bodyscanner/crowbarDestroy(mob/user, obj/item/weapon/crowbar/I)
 	if(occupant)


### PR DESCRIPTION
Gives traitors a some new ways to disrupt medbay. 

- Emagged body scanners deal a constant 12 rads/second to anybody inside them, enough to cause minor disruption to a competent medbay or kill somebody (slowly) if they're abandoned in the body scanner for a while. Emag the scanner a second time to make it safe again. 
- Emagged sleepers lose their usual overdose protection, can be used on patients in crit, and give fake feedback if a patient has more than 20u of a reagent in their bloodstream.

:cl:
 * rscadd: Body scanners can now be emagged to irradiate their occupant.
 * rscadd: Sleepers can now be emagged to disable overdose protection and give fake readouts if a patient is being overdosed.