### PR TITLE
3rd state to Scientist's Serendipity.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -6307,7 +6307,7 @@
 		glass_name = "\improper Scientist's Surprise"
 		glass_desc = "There is as yet insufficient data for a meaningful answer."
 
-	if(volume > 10) && (volume < 50)
+	else if(volume < 50)
 		glass_icon_state = "scientists_serendipity"
 		glass_name = "\improper Scientist's Serendipity"
 		glass_desc = "Knock back a cold glass of R&D."

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -6302,21 +6302,22 @@
 	dupeable = FALSE
 
 /datum/reagent/ethanol/scientists_serendipity/handle_special_behavior(var/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/D)
-		switch(volume)
-			if(1 to 9)
-				glass_icon_state = "scientists_surprise"
-				glass_name = "\improper Scientist's Surprise"
-				glass_desc = "There is as yet insufficient data for a meaningful answer."
-			if(10 to 49)
-				glass_icon_state = "scientists_serendipity"
-				glass_name = "\improper Scientist's Serendipity"
-				glass_desc = "Knock back a cold glass of R&D."
-				D.origin_tech = "materials=7;engineering=3;plasmatech=2;powerstorage=4;bluespace=6;combat=3;magnets=6;programming=3"
-			if(50 to INFINITY) //Infinity on the offchance you somehow acquire a glass with more than 50 max volume.
-				glass_icon_state = "scientists_serendipity"
-				glass_name = \improper Scientist's Lucky Datadisk"
-				glass_desc = "Why research what has already been catalogued?"
-				D.origin_tech = "materials=10;engineering=5;plasmatech=4;powerstorage=5;bluespace=10;biotech=5;combat=6;magnets=6;programming=5" //Maxes everything but NT, Illegal and anomaly
+	if(volume < 10)
+		glass_icon_state = "scientists_surprise"
+		glass_name = "\improper Scientist's Surprise"
+		glass_desc = "There is as yet insufficient data for a meaningful answer."
+
+	if(volume > 10) && (volume < 50)
+		glass_icon_state = "scientists_serendipity"
+		glass_name = "\improper Scientist's Serendipity"
+		glass_desc = "Knock back a cold glass of R&D."
+		D.origin_tech = "materials=7;engineering=3;plasmatech=2;powerstorage=4;bluespace=6;combat=3;magnets=6;programming=3"
+
+	else
+		glass_icon_state = "scientists_serendipity"
+		glass_name = \improper Scientist's Lucky Datadisk"
+		glass_desc = "Why research what has already been catalogued?"
+		D.origin_tech = "materials=10;engineering=5;plasmatech=4;powerstorage=5;bluespace=10;biotech=5;combat=6;magnets=6;programming=5" //Maxes everything but NT, Illegal and anomaly
 				
 /datum/reagent/ethanol/beepskyclassic
 	name = "Beepsky Classic"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -6306,7 +6306,8 @@
 		glass_icon_state = "scientists_surprise"
 		glass_name = "\improper Scientist's Surprise"
 		glass_desc = "There is as yet insufficient data for a meaningful answer."
-
+		D.origin_tech = ""
+		
 	else if(volume < 50)
 		glass_icon_state = "scientists_serendipity"
 		glass_name = "\improper Scientist's Serendipity"
@@ -6315,9 +6316,9 @@
 
 	else
 		glass_icon_state = "scientists_serendipity"
-		glass_name = "\improper Scientist's Lucky Datadisk"
+		glass_name = "\improper Scientist's Sapience"
 		glass_desc = "Why research what has already been catalogued?"
-		D.origin_tech = "materials=10;engineering=5;plasmatech=4;powerstorage=5;bluespace=10;biotech=5;combat=6;magnets=6;programming=5" //Maxes everything but NT, Illegal and anomaly
+		D.origin_tech = "materials=10;engineering=5;plasmatech=4;powerstorage=5;bluespace=10;biotech=5;combat=6;magnets=6;programming=5;illegal=1;nanotrasen=1;syndicate=2" //Maxes everything but Illegal and Anomaly
 				
 /datum/reagent/ethanol/beepskyclassic
 	name = "Beepsky Classic"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -6302,16 +6302,22 @@
 	dupeable = FALSE
 
 /datum/reagent/ethanol/scientists_serendipity/handle_special_behavior(var/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/D)
-	if(volume<10)
-		glass_icon_state = "scientists_surprise"
-		glass_name = "\improper Scientist's Surprise"
-		glass_desc = "There is as yet insufficient data for a meaningful answer."
-	else
-		glass_icon_state = "scientists_serendipity"
-		glass_name = "\improper Scientist's Serendipity"
-		glass_desc = "Knock back a cold glass of R&D."
-		D.origin_tech = "materials=7;engineering=3;plasmatech=2;powerstorage=4;bluespace=6;combat=3;magnets=6;programming=3"
-
+		switch(volume)
+			if(1 to 9)
+				glass_icon_state = "scientists_surprise"
+				glass_name = "\improper Scientist's Surprise"
+				glass_desc = "There is as yet insufficient data for a meaningful answer."
+			if(10 to 49)
+				glass_icon_state = "scientists_serendipity"
+				glass_name = "\improper Scientist's Serendipity"
+				glass_desc = "Knock back a cold glass of R&D."
+				D.origin_tech = "materials=7;engineering=3;plasmatech=2;powerstorage=4;bluespace=6;combat=3;magnets=6;programming=3"
+			if(50 to INFINITY) //Infinity on the offchance you somehow acquire a glass with more than 50 max volume
+				glass_icon_state = "scientists_serendipity"
+				glass_name = \improper Scientist's Lucky Datadisk"
+				glass_desc = "Why research what has already been catalogued?"
+				D.origin_tech = "materials=10;engineering=5;plasmatech=4;powerstorage=5;bluespace=10;biotech=5;combat=6;magnets=6;programming=5" //Maxes everything but NT, Illegal and anomaly
+				
 /datum/reagent/ethanol/beepskyclassic
 	name = "Beepsky Classic"
 	id = BEEPSKY_CLASSIC

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -6312,7 +6312,7 @@
 				glass_name = "\improper Scientist's Serendipity"
 				glass_desc = "Knock back a cold glass of R&D."
 				D.origin_tech = "materials=7;engineering=3;plasmatech=2;powerstorage=4;bluespace=6;combat=3;magnets=6;programming=3"
-			if(50 to INFINITY) //Infinity on the offchance you somehow acquire a glass with more than 50 max volume
+			if(50 to INFINITY) //Infinity on the offchance you somehow acquire a glass with more than 50 max volume.
 				glass_icon_state = "scientists_serendipity"
 				glass_name = \improper Scientist's Lucky Datadisk"
 				glass_desc = "Why research what has already been catalogued?"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -6315,7 +6315,7 @@
 
 	else
 		glass_icon_state = "scientists_serendipity"
-		glass_name = \improper Scientist's Lucky Datadisk"
+		glass_name = "\improper Scientist's Lucky Datadisk"
 		glass_desc = "Why research what has already been catalogued?"
 		D.origin_tech = "materials=10;engineering=5;plasmatech=4;powerstorage=5;bluespace=10;biotech=5;combat=6;magnets=6;programming=5" //Maxes everything but NT, Illegal and anomaly
 				


### PR DESCRIPTION
Scientist's Serendipity felt a bit underwhelming when compared to it's supposed effect, since you would already have a decent chunk of the research it provides (if not all) by the time you make some. Therefore, if you make/acquire 50u of the stuff on a drinking glass, you get Scientist's Sapience, which maxes all research to their limits, except for Anomaly, which isn't affected (so i don't fuck up xenoarch) and Illegal Tech, which only gets to level 2 (Enough to give you a headstart).

Serendipity has Materials 7, Engineering 3, Plasma 2, Power 4, Bluespace 6, Combat 3, Electromagnetic 6 and Data Theory 3.
Sapience has Materials 10, Engineering 5, Plasma 4, Power 5, Bluespace 10, Medical 5, Combat 6, Electromagnetic 6, Data Theory 5, NT Experimental 1 and Illegal Tech 2.

:cl:
 * rscadd: Added another variant for Scientist's Serendipity, which maxes all research, except Anomaly, which isn't affected and Illegal, which only gets to level 2.