### PR TITLE
Allows portable turrets to actually be deconstructed

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -275,6 +275,7 @@ Status: []<BR>"},
 				TurretFrame.build_step = 7 // Reset to final step
 				TurretFrame.icon_state = "turret_frame2" // Update icon
 				I.forceMove(TurretFrame)
+				installed = null
 				qdel(src)
 
 	else if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -264,6 +264,7 @@ Status: []<BR>"},
 
 		else if(iswelder(W))
 			var/obj/item/weapon/weldingtool/WT = W
+			to_chat(user, "<span class='notice'>You begin unwelding the turret's armor.</span>")
 			if(WT.do_weld(user, src, 30,5))
 				to_chat(user, "<span class='notice'>You unweld the turret's armor.</span>")
 			
@@ -273,6 +274,7 @@ Status: []<BR>"},
 				TurretFrame.finish_name = src.name
 				TurretFrame.installed = src.installed // Keep installed gun
 				TurretFrame.build_step = 7 // Reset to final step
+				TurretFrame.icon_state = "turret_frame2" // Update icon
 				installed.forceMove(TurretFrame)
 				qdel(src)
 

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -267,7 +267,7 @@ Status: []<BR>"},
 			to_chat(user, "<span class='notice'>You begin unwelding the turret's armor.</span>")
 			if(WT.do_weld(user, src, 30,5))
 				to_chat(user, "<span class='notice'>You unweld the turret's armor.</span>")
-			
+
 				// Deconstruct into frame
 				var/obj/machinery/porta_turret_construct/TurretFrame = new/obj/machinery/porta_turret_construct(locate(x,y,z))
 				TurretFrame.name = src.name
@@ -276,7 +276,7 @@ Status: []<BR>"},
 				TurretFrame.installed = I // Keep installed gun
 				TurretFrame.build_step = 7 // Reset to final step
 				TurretFrame.icon_state = "turret_frame2" // Update icon
-				installed.forceMove(TurretFrame)
+				I.forceMove(TurretFrame)
 				qdel(src)
 
 	else if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -834,6 +834,7 @@ Status: []<BR>"},
 			build_step = 3
 
 			if(!installed) // Skip to build_step 3 if no gun
+				to_chat(user, "<span class='notice'>Somehow, this turret had no gun???</span>")
 				return
 
 			to_chat(user, "You remove \the [installed] from the turret frame.")

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -274,6 +274,7 @@ Status: []<BR>"},
 				TurretFrame.installed = I // Keep installed gun
 				TurretFrame.build_step = 7 // Reset to final step
 				TurretFrame.icon_state = "turret_frame2" // Update icon
+				TurretFrame.anchored = 1 // As in build_step 1 and onwards
 				I.forceMove(TurretFrame)
 				installed = null // Workaround for qdel() deleting references to the installed gun too in the process
 				qdel(src)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -247,19 +247,34 @@ Status: []<BR>"},
 
 	..()
 
-	if(W.is_wrench(user) && !on && !raised && wrenchAnchor(user, W))
-		// This code handles moving the turret around. After all, it's a portable turret!
+	if(!on && !raised)
+		if(W.is_wrench(user) && wrenchAnchor(user, W))
+			// This code handles moving the turret around. After all, it's a portable turret!
 
-		if(anchored)
-			invisibility = INVISIBILITY_LEVEL_TWO
-			icon_state = "[lasercolor]grey_target_prism"
-			cover=new/obj/machinery/porta_turret_cover(src.loc) // create a new turret cover. While this is handled in process(), this is to workaround a bug where the turret becomes invisible for a split second
-			cover.Parent_Turret = src // make the cover's parent src
-			power_change()
-		else
-			icon_state = "turretCover"
-			invisibility = 0
-			qdel(cover) // deletes the cover, and the turret instance itself becomes its own cover.
+			if(anchored)
+				invisibility = INVISIBILITY_LEVEL_TWO
+				icon_state = "[lasercolor]grey_target_prism"
+				cover=new/obj/machinery/porta_turret_cover(src.loc) // create a new turret cover. While this is handled in process(), this is to workaround a bug where the turret becomes invisible for a split second
+				cover.Parent_Turret = src // make the cover's parent src
+				power_change()
+			else
+				icon_state = "turretCover"
+				invisibility = 0
+				qdel(cover) // deletes the cover, and the turret instance itself becomes its own cover.
+
+		else if(iswelder(W))
+			var/obj/item/weapon/weldingtool/WT = W
+			if(WT.do_weld(user, src, 30,5))
+				to_chat(user, "<span class='notice'>You unweld the turret's armor.</span>")
+			
+				// Deconstruct into frame
+				var/obj/machinery/porta_turret_construct/TurretFrame = new/obj/machinery/porta_turret_construct(locate(x,y,z))
+				TurretFrame.name = src.name
+				TurretFrame.finish_name = src.name
+				TurretFrame.installed = src.installed // Keep installed gun
+				TurretFrame.build_step = 7 // Reset to final step
+				installed.forceMove(TurretFrame)
+				qdel(src)
 
 	else if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
 		// Behavior lock/unlock mangement

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -270,8 +270,6 @@ Status: []<BR>"},
 
 				// Deconstruct into frame
 				var/obj/machinery/porta_turret_construct/TurretFrame = new/obj/machinery/porta_turret_construct(locate(x,y,z))
-				TurretFrame.name = src.name
-				TurretFrame.finish_name = src.name
 				var/obj/item/I = installed
 				TurretFrame.installed = I // Keep installed gun
 				TurretFrame.build_step = 7 // Reset to final step

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -826,8 +826,8 @@ Status: []<BR>"},
 /obj/machinery/porta_turret_construct/attack_hand(mob/user as mob)
 	switch(build_step)
 		if(4)
-			if(!installed)
-				return
+			if(!installed)	// if for some reason the frame has no gun, it resorts to containing a basic taser
+				installed = new /obj/item/weapon/gun/energy/taser(src)
 			build_step = 3
 
 			to_chat(user, "You remove \the [installed] from the turret frame.")

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -272,7 +272,8 @@ Status: []<BR>"},
 				var/obj/machinery/porta_turret_construct/TurretFrame = new/obj/machinery/porta_turret_construct(locate(x,y,z))
 				TurretFrame.name = src.name
 				TurretFrame.finish_name = src.name
-				TurretFrame.installed = src.installed // Keep installed gun
+				var/obj/item/I = installed
+				TurretFrame.installed = I // Keep installed gun
 				TurretFrame.build_step = 7 // Reset to final step
 				TurretFrame.icon_state = "turret_frame2" // Update icon
 				installed.forceMove(TurretFrame)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -831,9 +831,10 @@ Status: []<BR>"},
 /obj/machinery/porta_turret_construct/attack_hand(mob/user as mob)
 	switch(build_step)
 		if(4)
-			if(!installed)	// if for some reason the frame has no gun, it resorts to containing a basic taser
-				installed = new /obj/item/weapon/gun/energy/taser(src)
 			build_step = 3
+
+			if(!installed) // Skip to build_step 3 if no gun
+				return
 
 			to_chat(user, "You remove \the [installed] from the turret frame.")
 			var/obj/item/I = installed

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -275,7 +275,7 @@ Status: []<BR>"},
 				TurretFrame.build_step = 7 // Reset to final step
 				TurretFrame.icon_state = "turret_frame2" // Update icon
 				I.forceMove(TurretFrame)
-				installed = null
+				installed = null // Workaround for qdel() deleting references to the installed gun too in the process
 				qdel(src)
 
 	else if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
@@ -695,6 +695,7 @@ Status: []<BR>"},
 			if(istype(W, /obj/item/stack/sheet/metal))
 				var/obj/item/stack/sheet/metal/stack = W
 				if(stack.use(2)) // requires 2 metal sheets
+					playsound(src, 'sound/items/Deconstruct.ogg', 100, 1)
 					to_chat(user, "<span class='notice'>You add some metal armor to the interior frame.</span>")
 					build_step = 2
 					icon_state = "turret_frame2"
@@ -771,6 +772,7 @@ Status: []<BR>"},
 			if(istype(W, /obj/item/stack/sheet/metal))
 				var/obj/item/stack/sheet/metal/stack = W
 				if(stack.use(2))
+					playsound(src, 'sound/items/Deconstruct.ogg', 100, 1)
 					to_chat(user, "<span class='notice'>You add some metal armor to the exterior frame.</span>")
 					build_step = 7
 					return
@@ -787,6 +789,7 @@ Status: []<BR>"},
 		if(7)
 			if(iswelder(W))
 				var/obj/item/weapon/weldingtool/WT = W
+				to_chat(user, "<span class='notice'>You begin welding the turret's armor down.</span>")
 				if(WT.do_weld(user, src, 30,5))
 					build_step = 8
 					to_chat(user, "<span class='notice'>You weld the turret's armor down.</span>")


### PR DESCRIPTION
Because this wasn't already a thing for some reason.

Using a welding tool on a turret that isn't on turns it back into a turret frame with a build_step of 7, just before it was completed. (ie. it unwelds the frame)

[tweak][tested]

:cl:
 * tweak: Turrets can now be deconstructed in final form once turned off