### PR TITLE
Adds sound to priority announcements

### DIFF
--- a/code/defines/procs/captain_announce.dm
+++ b/code/defines/procs/captain_announce.dm
@@ -2,4 +2,6 @@
 	to_chat(world, "<h1 class='alert'>Priority Announcement</h1>")
 	to_chat(world, "<span class='alert'>[html_encode(text)]</span>")
 	to_chat(world, "<br>")
-
+	for(var/mob/M in player_list)
+		if(!istype(M,/mob/new_player) && M.client)
+			M << sound('sound/vox/_doop.wav')


### PR DESCRIPTION
Because it felt weird to see them with no sound when even RC and generic announcements get them
Sound is _doop.wav from the vox sounds, to fit the theme of RC announcements
[tweak]
[sound]

:cl:
 * tweak: Priority announcements now make a sound when they appear in chat