### PR TITLE
Double the time allocated to vox raiders

### DIFF
--- a/code/datums/gamemode/factions/vox_shoal.dm
+++ b/code/datums/gamemode/factions/vox_shoal.dm
@@ -57,7 +57,7 @@ var/list/potential_bonus_items = list(
 	logo_state = "vox-logo"
 	hud_icons = list("vox-logo")
 
-	var/time_left = (30 MINUTES)/10
+	var/time_left = (60 MINUTES)/10
 	var/completed = FALSE
 	var/results = "The Shoal didn't return yet."
 	var/list/dept_objective = list()


### PR DESCRIPTION
I like the raider gameplay as it is right now, with abductions, targetted steals, and other interesting things happening.
However, I realised that 30 minutes, on the scale of an ss13 round, is almost nothing and doesn't give enough time to rescue the hostages or to actually steal anything valuable.

This PR fixes that by giving the raiders twice as much time to do their stuff.

:cl:
- tweak: The time limit for the vox raiders heist has been doubled. (From 30 minutes to 60 minutes)