### PR TITLE
Ghosts no longer change icon state of security alerts computer

### DIFF
--- a/code/game/machinery/computer/security_alert.dm
+++ b/code/game/machinery/computer/security_alert.dm
@@ -39,6 +39,9 @@ TODO: literally every alarm but SPS alarms.
 	add_hiddenprint(user)
 	return attack_hand(user)
 
+/obj/machinery/computer/security_alerts/attack_ghost(mob/user as mob)
+	ui_interact(user)
+
 /obj/machinery/computer/security_alerts/attack_hand(mob/user as mob)
 	add_fingerprint(user)
 	ui_interact(user)


### PR DESCRIPTION
Closes #28951.
[bugfix]
:cl:
 * bugfix: Ghosts no longer make security alerts screens hide warnings by interacting with them.