### PR TITLE
Lists of contents as viewed by ghost now looks a lot nicer

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -11,7 +11,7 @@
 
 //Returns a list in plain english as a string
 /proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
-	var/list/datum/types = uniquetypelist(input)
+	var/list/types = uniquetypelist(input)
 	var/list/pruneList
 	var/uniquetotal = types.len
 	var/typecount = 0

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -11,27 +11,23 @@
 
 //Returns a list in plain english as a string
 /proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
-	var/list/atom/types = uniquetypelist(input)
-	var/list/pruneList
-	var/uniquetotal = types.len
-	var/typecount = 0
+	var/list/names = uniquenamelist(input)
+	var/uniquetotal = names.len
+	var/namecount = 0
 	var/currentName = ""
 	if (!uniquetotal)
 		return "[nothing_text]"
 	else if (uniquetotal == 1)
-		pruneList = prune_list_to_type(input, types[1])
-		typecount = pruneList.len
-		currentName = typecount == 1 ? "\a [types[1].name]" : "[types[1].name]\s"
-		return "[typecount == 1 ? "" : typecount] [currentName]"
+		namecount = count_by_name(input, names[1])
+		currentName = namecount == 1 ? "\a [names[1]]" : "[names[1]]\s"
+		return "[namecount == 1 ? "" : namecount] [currentName]"
 	else if (uniquetotal == 2)
-		pruneList = prune_list_to_type(input, types[1])
-		typecount = pruneList.len
-		currentName = typecount == 1 ? "\a [types[1].name]" : "[types[1].name]\s"
-		pruneList = prune_list_to_type(input, types[2])
-		var/typecount2 = pruneList.len
+		namecount = count_by_name(input, names[1])
+		currentName = namecount == 1 ? "\a [names[1]]" : "[names[1]]\s"
+		var/namecount2 = count_by_name(input, names[2])
 		var/currentName2 = ""
-		currentName2 = typecount2 == 1 ? "\a [types[2].name]" : "[types[2].name]\s"
-		return "[typecount == 1 ? "" : typecount] [currentName][and_text][typecount2 == 1 ? "" : typecount2] [currentName2]"
+		currentName2 = namecount2 == 1 ? "\a [names[2]]" : "[names[2]]\s"
+		return "[namecount == 1 ? "" : namecount] [currentName][and_text][namecount2 == 1 ? "" : namecount2] [currentName2]"
 	else
 		var/output = ""
 		var/index = 1
@@ -39,16 +35,14 @@
 			if (index == uniquetotal - 1)
 				comma_text = final_comma_text
 
-			pruneList = prune_list_to_type(input, types[index])
-			typecount = pruneList.len
-			currentName = typecount == 1 ? "\a [types[index].name]" : "[types[index].name]\s"
-			output += "[typecount == 1 ? "" : typecount] [currentName][comma_text]"
+			namecount = count_by_name(input, names[index])
+			currentName = namecount == 1 ? "\a [names[index]]" : "[names[index]]\s"
+			output += "[namecount == 1 ? "" : namecount] [currentName][comma_text]"
 			index++
 
-		pruneList = prune_list_to_type(input, types[index])
-		typecount = pruneList.len
-		currentName = typecount == 1 ? "\a [types[index].name]" : "[types[index].name]\s"
-		return "[output][and_text][typecount == 1 ? "" : typecount] [currentName]"
+		namecount = count_by_name(input, names[index])
+		currentName = namecount == 1 ? "\a [names[index]]" : "[names[index]]\s"
+		return "[output][and_text][namecount == 1 ? "" : namecount] [currentName]"
 
 //Returns list element or null. Should prevent "index out of bounds" error.
 /proc/listgetindex(list/L, index)
@@ -265,13 +259,13 @@
 			K += item
 	return K
 
-//Return a list with no duplicate types
-/proc/uniquetypelist(list/L)
+//Return a list with no duplicate names
+/proc/uniquenamelist(var/list/atom/L)
 	var/list/K = list()
-	for(var/datum/item in L)
-		if(!(is_type_in_list(item,K)))
-			K += item
-	return K &= L
+	for(var/atom/item in L)
+		if(!(item.name in K))
+			K += item.name
+	return K
 
 //for sorting clients or mobs by ckey
 /proc/sortKey(list/L, order=1)
@@ -343,6 +337,13 @@
 	var/i = 0
 	for(var/T in L)
 		if(istype(T, type))
+			i++
+	return i
+
+/proc/count_by_name(var/list/atom/L, name)
+	var/i = 0
+	for(var/atom/T in L)
+		if(T.name == name)
 			i++
 	return i
 

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -256,9 +256,9 @@
 /proc/uniquetypelist(list/L)
 	var/list/K = list()
 	for(var/datum/item in L)
-		if(!(is_type_in_list(item.type,K)))
+		if(!(is_type_in_list(item,K)))
 			K += item
-	return K
+	return K &= L
 
 //for sorting clients or mobs by ckey
 /proc/sortKey(list/L, order=1)

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -20,15 +20,15 @@
 		return "[nothing_text]"
 	else if (uniquetotal == 1)
 		pruneList = prune_list_to_type(input, types[1])
-		typecount = pruneList.len
+		typecount = L.len
 		currentName = typecount == 1 ? "\a [types[1].name]" : "[types[1].name]\s"
 		return "[typecount == 1 ? "" : typecount] [currentName]"
 	else if (uniquetotal == 2)
 		pruneList = prune_list_to_type(input, types[1])
-		typecount = pruneList.len
+		typecount = L.len
 		currentName = typecount == 1 ? "\a [types[1].name]" : "[types[1].name]\s"
 		pruneList = prune_list_to_type(input, types[2])
-		var/typecount2 = pruneList.len
+		var/typecount2 = L.len
 		var/currentName2 = ""
 		currentName2 = typecount2 == 1 ? "\a [types[2].name]" : "[types[2].name]\s"
 		return "[typecount == 1 ? "" : typecount] [currentName][and_text][typecount2 == 1 ? "" : typecount2] [currentName2]"
@@ -40,13 +40,13 @@
 				comma_text = final_comma_text
 
 			pruneList = prune_list_to_type(input, types[index])
-			typecount = pruneList.len
+			typecount = L.len
 			currentName = typecount == 1 ? "\a [types[index].name]" : "[types[index].name]\s"
 			output += "[typecount == 1 ? "" : typecount] [currentName][comma_text]"
 			index++
 
 		pruneList = prune_list_to_type(input, types[index])
-		typecount = pruneList.len
+		typecount = L.len
 		currentName = typecount == 1 ? "\a [types[index].name]" : "[types[index].name]\s"
 		return "[output][and_text][typecount == 1 ? "" : typecount] [currentName]"
 

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -11,7 +11,7 @@
 
 //Returns a list in plain english as a string
 /proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
-	var/list/types = uniquetypelist(input)
+	var/list/datum/types = uniquetypelist(input)
 	var/list/pruneList
 	var/uniquetotal = types.len
 	var/typecount = 0

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -11,24 +11,31 @@
 
 //Returns a list in plain english as a string
 /proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
-	var/total = input.len
-	if (!total)
+	var/list/types = uniquetypelist(input)
+	var/uniquetotal = types.len
+	var/typecount = 0
+	if (!uniquetotal)
 		return "[nothing_text]"
-	else if (total == 1)
-		return "[input[1]]"
-	else if (total == 2)
-		return "[input[1]][and_text][input[2]]"
+	else if (uniquetotal == 1)
+		typecount = prune_list_to_type(input, types[1]).len
+		return "[typecount] [types[1]]"
+	else if (uniquetotal == 2)
+		typecount = prune_list_to_type(input, types[1]).len
+		var/typecount2 = prune_list_to_type(input, types[2]).len
+		return "[typecount] [types[1]][and_text][typecount2] [types[2]]"
 	else
 		var/output = ""
 		var/index = 1
-		while (index < total)
-			if (index == total - 1)
+		while (index < uniquetotal)
+			if (index == uniquetotal - 1)
 				comma_text = final_comma_text
 
-			output += "[input[index]][comma_text]"
+			typecount = prune_list_to_type(input, types[index]).len
+			output += "[typecount] [types[index]][comma_text]"
 			index++
 
-		return "[output][and_text][input[index]]"
+		typecount = prune_list_to_type(input, types[index]).len
+		return "[output][and_text][typecount] [types[index]]"
 
 //Returns list element or null. Should prevent "index out of bounds" error.
 /proc/listgetindex(list/L, index)
@@ -242,6 +249,14 @@
 	var/list/K = list()
 	for(var/item in L)
 		if(!(item in K))
+			K += item
+	return K
+
+//Return a list with no duplicate types
+/proc/uniquetypelist(list/L)
+	var/list/K = list()
+	for(var/datum/item in L)
+		if(!(is_type_in_list(item.type,K)))
 			K += item
 	return K
 

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -14,15 +14,19 @@
 	var/list/types = uniquetypelist(input)
 	var/uniquetotal = types.len
 	var/typecount = 0
+	var/currentName = ""
 	if (!uniquetotal)
 		return "[nothing_text]"
 	else if (uniquetotal == 1)
 		typecount = prune_list_to_type(input, types[1]).len
-		return "[typecount == 1 ? "a" : typecount] [types[1].name][typecount != 1 ? "s" : ""]"
+		currentName = types[1].name
+		return "[typecount == 1 ? "" : typecount] [currentName][typecount != 1 ? "s" : ""]"
 	else if (uniquetotal == 2)
 		typecount = prune_list_to_type(input, types[1]).len
+		currentName = types[1].name
 		var/typecount2 = prune_list_to_type(input, types[2]).len
-		return "[typecount == 1 ? "a" : typecount] [types[1].name][typecount != 1 ? "s" : ""][and_text][typecount2 == 1 ? "a" : typecount2] [types[2].name][typecount2 != 1 ? "s" : ""]"
+		var/currentName2 = types[2].name
+		return "[typecount == 1 ? "" : typecount] [currentName][typecount != 1 ? "s" : ""][and_text][typecount2 == 1 ? "" : typecount2] [currentName2][typecount2 != 1 ? "s" : ""]"
 	else
 		var/output = ""
 		var/index = 1
@@ -31,11 +35,13 @@
 				comma_text = final_comma_text
 
 			typecount = prune_list_to_type(input, types[index]).len
-			output += "[typecount == 1 ? "a" : typecount] [types[index].name][typecount != 1 ? "s" : ""][comma_text]"
+			currentName = types[index].name
+			output += "[typecount == 1 ? "" : typecount] [currentName][typecount != 1 ? "s" : ""][comma_text]"
 			index++
 
 		typecount = prune_list_to_type(input, types[index]).len
-		return "[output][and_text][typecount == 1 ? "a" : typecount] [types[index].name][typecount != 1 ? "s" : ""]"
+		currentName = types[index].name
+		return "[output][and_text][typecount == 1 ? "" : typecount] [currentName][typecount != 1 ? "s" : ""]"
 
 //Returns list element or null. Should prevent "index out of bounds" error.
 /proc/listgetindex(list/L, index)

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -11,38 +11,32 @@
 
 //Returns a list in plain english as a string
 /proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
-	var/list/names = uniquenamelist(input)
-	var/uniquetotal = names.len
-	var/namecount = 0
-	var/currentName = ""
-	if (!uniquetotal)
-		return "[nothing_text]"
-	else if (uniquetotal == 1)
-		namecount = count_by_name(input, names[1])
-		currentName = namecount == 1 ? "\a [names[1]]" : "[names[1]]\s"
-		return "[namecount == 1 ? "" : namecount] [currentName]"
-	else if (uniquetotal == 2)
-		namecount = count_by_name(input, names[1])
-		currentName = namecount == 1 ? "\a [names[1]]" : "[names[1]]\s"
-		var/namecount2 = count_by_name(input, names[2])
-		var/currentName2 = ""
-		currentName2 = namecount2 == 1 ? "\a [names[2]]" : "[names[2]]\s"
-		return "[namecount == 1 ? "" : namecount] [currentName][and_text][namecount2 == 1 ? "" : namecount2] [currentName2]"
-	else
-		var/output = ""
-		var/index = 1
-		while (index < uniquetotal)
-			if (index == uniquetotal - 1)
-				comma_text = final_comma_text
+	var/list/names = uniquenamelist(input) // First, get the items to list
+	var/uniquetotal = names.len // And the amount
+	var/namecount = 0 // Variable for how often an item occurs
+	var/currentName = "" // Current name worked with in loop
+	
+	if (!uniquetotal) // If the list of names is empty
+		return "[nothing_text]" // Return "nothing"
+	else if (uniquetotal == 1) // If there is only one item
+		namecount = count_by_name(input, names[1]) // Count how many of this item occurs
+		currentName = namecount == 1 ? "\a [names[1]]" : "[names[1]]\s" // Make it say "an item" or "x items" if singular or plural
+		return "[namecount == 1 ? "" : namecount] [currentName]" // Return this
+	else // If more than one item
+		var/output = "" // Output string to work on
+		var/index = 1 // Loop index
+		while (index < uniquetotal) // While in loop
+			if (index == uniquetotal - 1) // If second to last element
+				comma_text = final_comma_text // Remove the comma
 
-			namecount = count_by_name(input, names[index])
-			currentName = namecount == 1 ? "\a [names[index]]" : "[names[index]]\s"
-			output += "[namecount == 1 ? "" : namecount] [currentName][comma_text]"
-			index++
+			namecount = count_by_name(input, names[index]) // Count as before
+			currentName = namecount == 1 ? "\a [names[index]]" : "[names[index]]\s" // And make grammatically correct
+			output += "[namecount == 1 ? "" : namecount] [currentName][comma_text]" // And put together as before, with comma this time
+			index++ // Iterate
 
-		namecount = count_by_name(input, names[index])
-		currentName = namecount == 1 ? "\a [names[index]]" : "[names[index]]\s"
-		return "[output][and_text][namecount == 1 ? "" : namecount] [currentName]"
+		namecount = count_by_name(input, names[index]) // Count again on last one
+		currentName = namecount == 1 ? "\a [names[index]]" : "[names[index]]\s" // Singular or plural
+		return "[output][and_text][namecount == 1 ? "" : namecount] [currentName]" // Put "and" before very last item in list
 
 //Returns list element or null. Should prevent "index out of bounds" error.
 /proc/listgetindex(list/L, index)

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -12,19 +12,23 @@
 //Returns a list in plain english as a string
 /proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
 	var/list/types = uniquetypelist(input)
+	var/list/pruneList
 	var/uniquetotal = types.len
 	var/typecount = 0
 	var/currentName = ""
 	if (!uniquetotal)
 		return "[nothing_text]"
 	else if (uniquetotal == 1)
-		typecount = prune_list_to_type(input, types[1]).len
+		pruneList = prune_list_to_type(input, types[1])
+		typecount = L.len
 		currentName = typecount == 1 ? "\a [types[1].name]" : "[types[1].name]\s"
 		return "[typecount == 1 ? "" : typecount] [currentName]"
 	else if (uniquetotal == 2)
-		typecount = prune_list_to_type(input, types[1]).len
+		pruneList = prune_list_to_type(input, types[1])
+		typecount = L.len
 		currentName = typecount == 1 ? "\a [types[1].name]" : "[types[1].name]\s"
-		var/typecount2 = prune_list_to_type(input, types[2]).len
+		pruneList = prune_list_to_type(input, types[2])
+		var/typecount2 = L.len
 		var/currentName2 = ""
 		currentName2 = typecount2 == 1 ? "\a [types[2].name]" : "[types[2].name]\s"
 		return "[typecount == 1 ? "" : typecount] [currentName][and_text][typecount2 == 1 ? "" : typecount2] [currentName2]"
@@ -35,12 +39,14 @@
 			if (index == uniquetotal - 1)
 				comma_text = final_comma_text
 
-			typecount = prune_list_to_type(input, types[index]).len
+			pruneList = prune_list_to_type(input, types[index])
+			typecount = L.len
 			currentName = typecount == 1 ? "\a [types[index].name]" : "[types[index].name]\s"
 			output += "[typecount == 1 ? "" : typecount] [currentName][comma_text]"
 			index++
 
-		typecount = prune_list_to_type(input, types[index]).len
+		pruneList = prune_list_to_type(input, types[index])
+		typecount = L.len
 		currentName = typecount == 1 ? "\a [types[index].name]" : "[types[index].name]\s"
 		return "[output][and_text][typecount == 1 ? "" : typecount] [currentName]"
 

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -20,15 +20,15 @@
 		return "[nothing_text]"
 	else if (uniquetotal == 1)
 		pruneList = prune_list_to_type(input, types[1])
-		typecount = L.len
+		typecount = pruneList.len
 		currentName = typecount == 1 ? "\a [types[1].name]" : "[types[1].name]\s"
 		return "[typecount == 1 ? "" : typecount] [currentName]"
 	else if (uniquetotal == 2)
 		pruneList = prune_list_to_type(input, types[1])
-		typecount = L.len
+		typecount = pruneList.len
 		currentName = typecount == 1 ? "\a [types[1].name]" : "[types[1].name]\s"
 		pruneList = prune_list_to_type(input, types[2])
-		var/typecount2 = L.len
+		var/typecount2 = pruneList.len
 		var/currentName2 = ""
 		currentName2 = typecount2 == 1 ? "\a [types[2].name]" : "[types[2].name]\s"
 		return "[typecount == 1 ? "" : typecount] [currentName][and_text][typecount2 == 1 ? "" : typecount2] [currentName2]"
@@ -40,13 +40,13 @@
 				comma_text = final_comma_text
 
 			pruneList = prune_list_to_type(input, types[index])
-			typecount = L.len
+			typecount = pruneList.len
 			currentName = typecount == 1 ? "\a [types[index].name]" : "[types[index].name]\s"
 			output += "[typecount == 1 ? "" : typecount] [currentName][comma_text]"
 			index++
 
 		pruneList = prune_list_to_type(input, types[index])
-		typecount = L.len
+		typecount = pruneList.len
 		currentName = typecount == 1 ? "\a [types[index].name]" : "[types[index].name]\s"
 		return "[output][and_text][typecount == 1 ? "" : typecount] [currentName]"
 

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -19,14 +19,15 @@
 		return "[nothing_text]"
 	else if (uniquetotal == 1)
 		typecount = prune_list_to_type(input, types[1]).len
-		currentName = types[1].name
-		return "[typecount == 1 ? "" : typecount] [currentName][typecount != 1 ? "s" : ""]"
+		currentName = typecount == 1 ? "\a [types[1].name]" : "[types[1].name]\s"
+		return "[typecount == 1 ? "" : typecount] [currentName]"
 	else if (uniquetotal == 2)
 		typecount = prune_list_to_type(input, types[1]).len
-		currentName = types[1].name
+		currentName = typecount == 1 ? "\a [types[1].name]" : "[types[1].name]\s"
 		var/typecount2 = prune_list_to_type(input, types[2]).len
-		var/currentName2 = types[2].name
-		return "[typecount == 1 ? "" : typecount] [currentName][typecount != 1 ? "s" : ""][and_text][typecount2 == 1 ? "" : typecount2] [currentName2][typecount2 != 1 ? "s" : ""]"
+		var/currentName2 = ""
+		currentName2 = typecount2 == 1 ? "\a [types[2].name]" : "[types[2].name]\s"
+		return "[typecount == 1 ? "" : typecount] [currentName][and_text][typecount2 == 1 ? "" : typecount2] [currentName2]"
 	else
 		var/output = ""
 		var/index = 1
@@ -35,13 +36,13 @@
 				comma_text = final_comma_text
 
 			typecount = prune_list_to_type(input, types[index]).len
-			currentName = types[index].name
-			output += "[typecount == 1 ? "" : typecount] [currentName][typecount != 1 ? "s" : ""][comma_text]"
+			currentName = typecount == 1 ? "\a [types[index].name]" : "[types[index].name]\s"
+			output += "[typecount == 1 ? "" : typecount] [currentName][comma_text]"
 			index++
 
 		typecount = prune_list_to_type(input, types[index]).len
-		currentName = types[index].name
-		return "[output][and_text][typecount == 1 ? "" : typecount] [currentName][typecount != 1 ? "s" : ""]"
+		currentName = typecount == 1 ? "\a [types[index].name]" : "[types[index].name]\s"
+		return "[output][and_text][typecount == 1 ? "" : typecount] [currentName]"
 
 //Returns list element or null. Should prevent "index out of bounds" error.
 /proc/listgetindex(list/L, index)

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -11,7 +11,7 @@
 
 //Returns a list in plain english as a string
 /proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
-	var/list/types = uniquetypelist(input)
+	var/list/atom/types = uniquetypelist(input)
 	var/list/pruneList
 	var/uniquetotal = types.len
 	var/typecount = 0

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -18,11 +18,11 @@
 		return "[nothing_text]"
 	else if (uniquetotal == 1)
 		typecount = prune_list_to_type(input, types[1]).len
-		return "[typecount] [types[1]]"
+		return "[typecount != 1 ? "a" : typecount] [types[1].name][typecount != 1 ? "s" : ""]"
 	else if (uniquetotal == 2)
 		typecount = prune_list_to_type(input, types[1]).len
 		var/typecount2 = prune_list_to_type(input, types[2]).len
-		return "[typecount] [types[1]][and_text][typecount2] [types[2]]"
+		return "[typecount == 1 ? "a" : typecount] [types[1].name][typecount != 1 ? "s" : ""][and_text][typecount2 == 1 ? "a" : typecount2] [types[2].name][typecount2 != 1 ? "s" : ""]"
 	else
 		var/output = ""
 		var/index = 1
@@ -31,11 +31,11 @@
 				comma_text = final_comma_text
 
 			typecount = prune_list_to_type(input, types[index]).len
-			output += "[typecount] [types[index]][comma_text]"
+			output += "[typecount == 1 ? "a" : typecount] [types[index].name][typecount != 1 ? "s" : ""][comma_text]"
 			index++
 
 		typecount = prune_list_to_type(input, types[index]).len
-		return "[output][and_text][typecount] [types[index]]"
+		return "[output][and_text][typecount == 1 ? "a" : typecount] [types[index].name][typecount != 1 ? "s" : ""]"
 
 //Returns list element or null. Should prevent "index out of bounds" error.
 /proc/listgetindex(list/L, index)

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -11,6 +11,27 @@
 
 //Returns a list in plain english as a string
 /proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
+	var/total = input.len
+	if (!total)
+		return "[nothing_text]"
+	else if (total == 1)
+		return "[input[1]]"
+	else if (total == 2)
+		return "[input[1]][and_text][input[2]]"
+	else
+		var/output = ""
+		var/index = 1
+		while (index < total)
+			if (index == total - 1)
+				comma_text = final_comma_text
+
+			output += "[input[index]][comma_text]"
+			index++
+
+		return "[output][and_text][input[index]]"
+
+//Returns a counted list of atom names in plain english as a string
+/proc/counted_english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
 	var/list/names = uniquenamelist(input) // First, get the items to list
 	var/uniquetotal = names.len // And the amount
 	var/namecount = 0 // Variable for how often an item occurs
@@ -20,7 +41,7 @@
 		return "[nothing_text]" // Return "nothing"
 	else if (uniquetotal == 1) // If there is only one item
 		namecount = count_by_name(input, names[1]) // Count how many of this item occurs
-		currentName = namecount == 1 ? "[names[1]]" : "[names[1]]\s" // Make it say "an item" or "x items" if singular or plural
+		currentName = namecount == 1 ? "\a [names[1]]" : "[names[1]]\s" // Make it say "an item" or "x items" if singular or plural
 		return "[namecount == 1 ? "" : namecount] [currentName]" // Return this
 	else // If more than one item
 		var/output = "" // Output string to work on
@@ -30,12 +51,12 @@
 				comma_text = final_comma_text // Remove the comma
 
 			namecount = count_by_name(input, names[index]) // Count as before
-			currentName = namecount == 1 ? "[names[index]]" : "[names[index]]\s" // And make grammatically correct
+			currentName = namecount == 1 ? "\a [names[index]]" : "[names[index]]\s" // And make grammatically correct
 			output += "[namecount == 1 ? "" : namecount] [currentName][comma_text]" // And put together as before, with comma this time
 			index++ // Iterate
 
 		namecount = count_by_name(input, names[index]) // Count again on last one
-		currentName = namecount == 1 ? "[names[index]]" : "[names[index]]\s" // Singular or plural
+		currentName = namecount == 1 ? "\a [names[index]]" : "[names[index]]\s" // Singular or plural
 		return "[output][and_text][namecount == 1 ? "" : namecount] [currentName]" // Put "and" before very last item in list
 
 //Returns list element or null. Should prevent "index out of bounds" error.

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -18,7 +18,7 @@
 		return "[nothing_text]"
 	else if (uniquetotal == 1)
 		typecount = prune_list_to_type(input, types[1]).len
-		return "[typecount != 1 ? "a" : typecount] [types[1].name][typecount != 1 ? "s" : ""]"
+		return "[typecount == 1 ? "a" : typecount] [types[1].name][typecount != 1 ? "s" : ""]"
 	else if (uniquetotal == 2)
 		typecount = prune_list_to_type(input, types[1]).len
 		var/typecount2 = prune_list_to_type(input, types[2]).len

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -20,7 +20,7 @@
 		return "[nothing_text]" // Return "nothing"
 	else if (uniquetotal == 1) // If there is only one item
 		namecount = count_by_name(input, names[1]) // Count how many of this item occurs
-		currentName = namecount == 1 ? "\a [names[1]]" : "[names[1]]\s" // Make it say "an item" or "x items" if singular or plural
+		currentName = namecount == 1 ? "[names[1]]" : "[names[1]]\s" // Make it say "an item" or "x items" if singular or plural
 		return "[namecount == 1 ? "" : namecount] [currentName]" // Return this
 	else // If more than one item
 		var/output = "" // Output string to work on
@@ -30,12 +30,12 @@
 				comma_text = final_comma_text // Remove the comma
 
 			namecount = count_by_name(input, names[index]) // Count as before
-			currentName = namecount == 1 ? "\a [names[index]]" : "[names[index]]\s" // And make grammatically correct
+			currentName = namecount == 1 ? "[names[index]]" : "[names[index]]\s" // And make grammatically correct
 			output += "[namecount == 1 ? "" : namecount] [currentName][comma_text]" // And put together as before, with comma this time
 			index++ // Iterate
 
 		namecount = count_by_name(input, names[index]) // Count again on last one
-		currentName = namecount == 1 ? "\a [names[index]]" : "[names[index]]\s" // Singular or plural
+		currentName = namecount == 1 ? "[names[index]]" : "[names[index]]\s" // Singular or plural
 		return "[output][and_text][namecount == 1 ? "" : namecount] [currentName]" // Put "and" before very last item in list
 
 //Returns list element or null. Should prevent "index out of bounds" error.

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -648,7 +648,7 @@
 		if(!isAdminGhost(ghost) && ghost.mind && ghost.mind.current)
 			if(ghost.mind.isScrying || ghost.mind.current.ajourn) //Scrying or astral travel, fuck them.
 				return
-		to_chat(ghost, "It contains: <span class='info'>[english_list(contents)]</span>.")
+		to_chat(ghost, "It contains: <span class='info'>[counted_english_list(contents)]</span>.")
 		investigation_log(I_GHOST, "|| had its contents checked by [key_name(ghost)][ghost.locked_to ? ", who was haunting [ghost.locked_to]" : ""]")
 
 // -- Vox raiders.

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -82,7 +82,7 @@
 		. = list()
 		for(var/obj/item/clothing/accessory/accessory in accessories)
 			. += "[bicon(accessory)] \a [accessory]"
-		return " It has [english_list(.)]."
+		return " It has [counted_english_list(.)]."
 
 /obj/item/clothing/accessory/pinksquare
 	name = "pink square"


### PR DESCRIPTION
This uses the \a and \s macros for listing singular and plural items, with the caveat of \s not being grammatically correct all the time (though \a seemingly is)

This makes a list of all unique item types in a list, counts items of each type, and displays them numerated as opposed to just every single item no matter how many times it gets repeated.

Example: A list that would normally say "It contains: the multitool, the multitool, the jackboots, the jackboots and the oxygen tank" would now say something like "It contains: 2 multitools, 2 jackbootss and a oxygen tank" (or "an oxygen tank", hopefully)
[tweak][grammar]

:cl:
 * tweak: Certain item lists now display a much nicer, counted list of items when examined as a ghost