### PR TITLE
Trader (and other) radio uplinks can now be loaded with telecrystals

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -509,6 +509,8 @@
 
 /obj/item/device/radio/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
+	if(hidden_uplink && hidden_uplink.active && hidden_uplink.refund(user, W))
+		return
 	user.set_machine(src)
 	if (!(W.is_screwdriver(user)))
 		return


### PR DESCRIPTION
Closes #28927 

Since this check is similar to the ones in the PDA and headsets, and hidden_uplink is a property of /obj/item, should this check be moved there or parent more things instead of handle each case?

[bugfix]
:cl:
 * bugfix: Trader uplinks can now be loaded with telecrystals to refund.