### PR TITLE
A PR to remove the Snow Taxi map from the rotation except for certain months

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -80,6 +80,12 @@
 				var/String = file2text(http["CONTENT"])
 				var/tempPos = findtext(String, "\"temp_min\":")+11
 				temperature = text2num(copytext(String, tempPos, tempPos+4))
+			var/MM = text2num(time2text(world.timeofday, "MM")) 	// get the current month
+			if (MM != 1 && MM != 12)
+				message_admins("Skipping map [potential] as this is no longer the Christmas season.")
+				warning("Skipping map [potential] as this is no longer the Christmas season.")
+				binary = null
+				continue
 			if(temperature > 40)
 				message_admins("Skipping map [potential] due to it being too hot outside. Ideal temp is below 40F, found [temperature].")
 				warning("Skipping map [potential] due to  it being too hot outside. Ideal temp is below 40F, found [temperature].")

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -81,7 +81,8 @@
 				var/tempPos = findtext(String, "\"temp_min\":")+11
 				temperature = text2num(copytext(String, tempPos, tempPos+4))
 			var/MM = text2num(time2text(world.timeofday, "MM")) 	// get the current month
-			if (MM != 1 && MM != 12)
+			var/allowed_months = list(1, 2, 7, 12)
+			if (!(MM in allowed_months))
 				message_admins("Skipping map [potential] as this is no longer the Christmas season.")
 				warning("Skipping map [potential] as this is no longer the Christmas season.")
 				binary = null

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -74,22 +74,11 @@
 			binary = null
 			continue
 		if(potential == "Snow Taxi/")
-			var/list/http[] = world.Export("http://api.openweathermap.org/data/2.5/weather?id=5128581&APPID=449d31cebb806dfdb8c3d0a682591983&units=imperial")
-			var/temperature = 90
-			if(http && http.len && ("CONTENT" in http))
-				var/String = file2text(http["CONTENT"])
-				var/tempPos = findtext(String, "\"temp_min\":")+11
-				temperature = text2num(copytext(String, tempPos, tempPos+4))
 			var/MM = text2num(time2text(world.timeofday, "MM")) 	// get the current month
 			var/allowed_months = list(1, 2, 7, 12)
 			if (!(MM in allowed_months))
 				message_admins("Skipping map [potential] as this is no longer the Christmas season.")
 				warning("Skipping map [potential] as this is no longer the Christmas season.")
-				binary = null
-				continue
-			if(temperature > 40)
-				message_admins("Skipping map [potential] due to it being too hot outside. Ideal temp is below 40F, found [temperature].")
-				warning("Skipping map [potential] due to  it being too hot outside. Ideal temp is below 40F, found [temperature].")
 				binary = null
 				continue
 		if(potential == "Lamprey/") //Available if the station is wrecked enough


### PR DESCRIPTION
Said months being January and December. Let's be honest, 4°C is way too hot for New York City and we have Snaxi as early as October sometimes, and it can get stick around as late as April. Let's stop this madness once and for all. The days are getting longer, the sun is shining, birds start to sing and the first trees blossom by April. We do not need an arctic station map this late in the year and it is madness it is able to stay in rotation this long.

:cl:
- tweak: Snow Taxi is now only available during the months of December, January, February, and July.