### PR TITLE
Fixes missing items from the merch computer

### DIFF
--- a/code/game/machinery/computer/store.dm
+++ b/code/game/machinery/computer/store.dm
@@ -17,6 +17,7 @@
 		"Tools" = list(
 			/datum/storeitem/pen,
 			/datum/storeitem/wrapping_paper,
+			/datum/storeitem/cheap_soap,
 			/datum/storeitem/swiss_army_knife,
 			),
 		"Electronics" = list(
@@ -33,6 +34,9 @@
 			/datum/storeitem/roganbot,
 			),
 		"Clothing" = list(
+			/datum/storeitem/sterilemask,
+			/datum/storeitem/sterilemask_black,
+			/datum/storeitem/sterilemask_colorful,
 			/datum/storeitem/robotnik_labcoat,
 			/datum/storeitem/robotnik_jumpsuit,
 			),


### PR DESCRIPTION
Fixes #28986

:cl:
* bugfix: Fixed the new cheap soap and face mask items being conspicuously absent from the merch computer.