### PR TITLE
Makes some wooden objects flammable that previously were not

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -89,13 +89,28 @@
 	irregular_plural = "wooden plank"
 	icon_state = "sheet-wood"
 	origin_tech = Tc_MATERIALS + "=1;" + Tc_BIOTECH + "=1"
-	autoignition_temperature=AUTOIGNITION_WOOD
+	autoignition_temperature = AUTOIGNITION_WOOD
+	fire_fuel = 1 //Not used here the same way as elsewhere; see burnFireFuel() below.
 	sheettype = "wood"
 	w_type = RECYK_WOOD
 	siemens_coefficient = 0 //no conduct
 	mat_type = MAT_WOOD
 	perunit = CC_PER_SHEET_WOOD
 
+/obj/item/stack/sheet/wood/getFireFuel()
+	return (amount - 1 + fire_fuel) / 5 //Each plank essentially has 0.2 fire_fuel.
+
+/obj/item/stack/sheet/wood/burnFireFuel(used_fuel_ratio, used_reactants_ratio)
+	var/expected_to_burn = used_fuel_ratio * used_reactants_ratio * amount //The expected number of planks to burn. Can be fractional.
+	var/actually_burned = round(expected_to_burn) //Definitely burn the floor of that many.
+	fire_fuel -= expected_to_burn - actually_burned //Subtract the remainder from fire_fuel.
+	if(fire_fuel <= 0) //If that brings it below zero, burn another plank and increase fire_fuel to track the next fractional plank burned.
+		++actually_burned
+		++fire_fuel
+	if(actually_burned)
+		var/ashtype = ashtype()
+		new ashtype(loc) //use() will delete src without calling ashify(), so here we spawn ashes if any planks burned, whether or not the object was destroyed.
+	use(actually_burned)
 
 /obj/item/stack/sheet/wood/afterattack(atom/Target, mob/user, adjacent, params)
 	..()

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -5,6 +5,9 @@
 	icon_closed = "coffin"
 	icon_opened = "coffin_open"
 
+	autoignition_temperature = AUTOIGNITION_WOOD
+	fire_fuel = 2
+
 	starting_materials = list(MAT_WOOD = 5*CC_PER_SHEET_MISC)
 	var/mob_lock_type = /datum/locking_category/buckle/closet/coffin
 

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -15,7 +15,7 @@
 /obj/structure/closet/coffin/Destroy()
 	new /obj/item/stack/sheet/wood(loc,3) //This will result in 3 dropped if destroyed, or 5 if deconstructed
 	if (is_locking(mob_lock_type)) //if someone is strapped in and this gets destroyed make them visible again
-		var/mob/locked = get_locked(mob_lock_type)[1]	
+		var/mob/locked = get_locked(mob_lock_type)[1]
 		locked.alphas["coffin_invis"] = 255
 		locked.handle_alpha()
 	..()
@@ -48,7 +48,7 @@
 /obj/structure/closet/coffin/proc/handle_buckle(var/mob/user) //needs src.opened otherwise bugs might occur because closet eats the items when its closed
 	if (src.opened && is_locking(mob_lock_type)) //only unbuckle if you are buckled in in the first place
 		manual_unbuckle(user)
-		setDensity(FALSE) //this is needed for some reason 
+		setDensity(FALSE) //this is needed for some reason
 		return
 	var/mob/closet_dweller = locate() in src.loc
 	if (src.opened && closet_dweller) //buckle only the mob inside the closet
@@ -57,11 +57,11 @@
 /obj/structure/closet/coffin/proc/handle_user_visibility() //after each open/close action assert the correct user visibility
 	if (!is_locking(mob_lock_type))
 		return
-	var/mob/locked = get_locked(mob_lock_type)[1]	
-	if (src.opened)  
+	var/mob/locked = get_locked(mob_lock_type)[1]
+	if (src.opened)
 		locked.alphas["coffin_invis"] = 255
 		locked.handle_alpha()
-	else 
+	else
 		locked.alphas["coffin_invis"] = 1
 		locked.handle_alpha()
 

--- a/code/game/objects/structures/mannequin.dm
+++ b/code/game/objects/structures/mannequin.dm
@@ -690,6 +690,8 @@
 	health = 30
 	maxHealth = 30
 	trueForm = /mob/living/simple_animal/hostile/mannequin/wood
+	autoignition_temperature = AUTOIGNITION_WOOD
+	fire_fuel = 2.5
 
 /obj/structure/mannequin/wood/breakDown()
 	new /obj/item/stack/sheet/wood(loc, 5)//You get half the materials used to make a block bac)
@@ -808,6 +810,8 @@
 		"monkey"	=	/obj/structure/mannequin/wood/monkey,
 		"vox"		=	/obj/structure/mannequin/wood/vox,
 		)
+	autoignition_temperature = AUTOIGNITION_WOOD
+	fire_fuel = 5
 
 
 


### PR DESCRIPTION
As requested in the thread.
I said I would do it if someone gave me `fire_fuel` values. Someone did and I promptly ignored those values and did this instead.
No, there's no internal consistency here. Yes, you magically get more `fire_fuel` by building stuff out of wood than from the wood itself. Let's call that game balance.

Burning a full stack of wood in a moderately-sized room such as Box hydroponics results in an increase of temperature of about 140C. Toasty. You'd get a lot more than that by building a bunch of chairs out of the wood, so doesn't seem too bad to me.

This also reminded me of a bit of shitcode in object-burning code, which I'll fix separately.

:cl:
* rscadd: Several wooden objects that were not previously flammable are now. These include coffins, wooden mannequins, the blocks said mannequins are made of, and raw wood planks.