### PR TITLE
Makes object burning slightly less bad

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -41,9 +41,8 @@ Attach to transfer valve and open. BOOM.
 			in_fire = TRUE
 			break
 		if(!in_fire)
-			fire_fuel -= 0.2
-			if(fire_fuel<=0.1)
-				ashify()
+			var/used_ratio = min(0.2 / getFireFuel(), 1) //To maintain the previous behavior of just using 0.2 fire_fuel
+			burnFireFuel(1, used_ratio) //1 is valid as used_fuel_ratio and the two arguments should multiply to used_ratio, so this is simplest.
 		sleep(2 SECONDS)
 
 /atom/proc/ashify()

--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -28,9 +28,9 @@ Attach to transfer valve and open. BOOM.
 /atom/proc/getFireFuel()
 	return fire_fuel
 
-/atom/proc/burnFireFuel(var/used_fuel_ratio,var/used_reactants_ratio)
+/atom/proc/burnFireFuel(used_fuel_ratio, used_reactants_ratio)
 	fire_fuel -= (fire_fuel * used_fuel_ratio * used_reactants_ratio) //* 5
-	if(fire_fuel<=0.1)
+	if(fire_fuel <= 0.1)
 		//testing("[src] ashifying (BFF)!")
 		ashify()
 


### PR DESCRIPTION
The proc that handled objects burning outside fires didn't take into account that not all objects that burn actually use the `fire_fuel` var. This makes that proc actually use `getFireFuel()` and `burnFireFuel()` instead of just directly manipulating `fire_fuel`. The behavior should be exactly the same as before for objects that do not override `getFireFuel()`/`burnFireFuel()` but will now work properly for those that do.