### PR TITLE
Spray bottles on the Protolathe. Also spraybottle fixes.

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -48,7 +48,6 @@
 		new /obj/item/device/analyzer(), \
 		new /obj/item/weapon/pickaxe/shovel/spade(), \
 		new /obj/item/device/silicate_sprayer/empty(), \
-		new /obj/item/weapon/reagent_containers/spray(), \
 		),
 		"Containers"=list(
 		new /obj/item/weapon/reagent_containers/glass/beaker(), \

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -48,6 +48,7 @@
 		new /obj/item/device/analyzer(), \
 		new /obj/item/weapon/pickaxe/shovel/spade(), \
 		new /obj/item/device/silicate_sprayer/empty(), \
+		new /obj/item/weapon/reagent_containers/spray(), \
 		),
 		"Containers"=list(
 		new /obj/item/weapon/reagent_containers/glass/beaker(), \

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -250,20 +250,20 @@
 
 /obj/item/weapon/reagent_containers/glass/beaker/noreact
 	name = "stasis beaker"
-	desc = "A beaker powered by experimental bluespace technology. Chemicals are held in stasis and do not react inside of it. Can hold up to 50 units."
+	desc = "A beaker powered by experimental bluespace technology. Chemicals are held in stasis and do not react inside of it. Can hold up to 100 units."
 	icon_state = "beakernoreact"
-	starting_materials = list(MAT_GLASS = 500)
-	volume = 50
+	starting_materials = list(MAT_GLASS = 2000)
+	volume = 100
 	flags = FPRINT  | OPENCONTAINER | NOREACT
 	origin_tech = Tc_BLUESPACE + "=3;" + Tc_MATERIALS + "=4"
 	opaque = TRUE
 
 /obj/item/weapon/reagent_containers/glass/beaker/noreact/large
 	name = "large stasis beaker"
-	desc = "A beaker powered by experimental bluespace technology. Chemicals are held in stasis and do not react inside of it. Can hold up to 100 units."
+	desc = "A beaker powered by experimental bluespace technology. Chemicals are held in stasis and do not react inside of it. Can hold up to 200 units."
 	icon_state = "beakernoreactlarge"
-	starting_materials = list(MAT_GLASS = 1500)
-	volume = 100
+	starting_materials = list(MAT_GLASS = 5000)
+	volume = 200
 	origin_tech = Tc_BLUESPACE + "=4;" + Tc_MATERIALS + "=6"
 
 /obj/item/weapon/reagent_containers/glass/beaker/bluespace

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -250,20 +250,20 @@
 
 /obj/item/weapon/reagent_containers/glass/beaker/noreact
 	name = "stasis beaker"
-	desc = "A beaker powered by experimental bluespace technology. Chemicals are held in stasis and do not react inside of it. Can hold up to 100 units."
+	desc = "A beaker powered by experimental bluespace technology. Chemicals are held in stasis and do not react inside of it. Can hold up to 50 units."
 	icon_state = "beakernoreact"
-	starting_materials = list(MAT_GLASS = 2000)
-	volume = 100
+	starting_materials = list(MAT_GLASS = 500)
+	volume = 50
 	flags = FPRINT  | OPENCONTAINER | NOREACT
 	origin_tech = Tc_BLUESPACE + "=3;" + Tc_MATERIALS + "=4"
 	opaque = TRUE
 
 /obj/item/weapon/reagent_containers/glass/beaker/noreact/large
 	name = "large stasis beaker"
-	desc = "A beaker powered by experimental bluespace technology. Chemicals are held in stasis and do not react inside of it. Can hold up to 200 units."
+	desc = "A beaker powered by experimental bluespace technology. Chemicals are held in stasis and do not react inside of it. Can hold up to 100 units."
 	icon_state = "beakernoreactlarge"
-	starting_materials = list(MAT_GLASS = 5000)
-	volume = 200
+	starting_materials = list(MAT_GLASS = 1500)
+	volume = 100
 	origin_tech = Tc_BLUESPACE + "=4;" + Tc_MATERIALS + "=6"
 
 /obj/item/weapon/reagent_containers/glass/beaker/bluespace

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -150,11 +150,11 @@
 	icon = 'icons/obj/hydroponics/hydro_tools.dmi'
 	icon_state = "plantbgone"
 	item_state = "plantbgone"
-	volume = 100
+	volume = 250
 
 /obj/item/weapon/reagent_containers/spray/plantbgone/New()
 	..()
-	reagents.add_reagent(PLANTBGONE, 100)
+	reagents.add_reagent(PLANTBGONE, 250)
 
 /obj/item/weapon/reagent_containers/spray/bugzapper
 	name = "Bug Zapper"
@@ -162,11 +162,11 @@
 	icon = 'icons/obj/hydroponics/hydro_tools.dmi'
 	icon_state = "plantbgone"
 	item_state = "plantbgone"
-	volume = 100
+	volume = 250
 
 /obj/item/weapon/reagent_containers/spray/bugzapper/New()
 	..()
-	reagents.add_reagent(TOXIN, 100)
+	reagents.add_reagent(INSECTICIDE, 250)
 
 //chemsprayer
 /obj/item/weapon/reagent_containers/spray/chemsprayer

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -228,7 +228,8 @@
 	A disclaimer towards the bottom states <span class = 'warning'>Warning: Do not use around the house, or in proximity of dogs|children|clowns</span>"
 	flags = OPENCONTAINER|FPRINT|NOREACT
 	origin_tech = Tc_BLUESPACE + "=3;" + Tc_MATERIALS + "=5"
-	amount_per_transfer_from_this = 25
+	amount_per_transfer_from_this = 10
+	volume = 150
 
 
 /obj/item/weapon/reagent_containers/spray/noreact/make_puff(var/atom/target, var/mob/user)

--- a/code/modules/research/designs/bluespace.dm
+++ b/code/modules/research/designs/bluespace.dm
@@ -64,7 +64,7 @@
 
 /datum/design/stasisbeaker
 	name = "Stasis Beaker"
-	desc = "A beaker powered by experimental bluespace technology. Chemicals are held in stasis and do not react inside of it. Can hold up to 100 units."
+	desc = "A beaker powered by experimental bluespace technology. Chemicals are held in stasis and do not react inside of it. Can hold up to 50 units."
 	id = "stasisbeaker_small"
 	req_tech = list(Tc_BLUESPACE = 3, Tc_MATERIALS = 4)
 	build_type = PROTOLATHE
@@ -75,7 +75,7 @@
 
 /datum/design/stasisbeaker_large
 	name = "Large Stasis Beaker"
-	desc = "A beaker powered by experimental bluespace technology. Chemicals are held in stasis and do not react inside of it. Can hold up to 200 units."
+	desc = "A beaker powered by experimental bluespace technology. Chemicals are held in stasis and do not react inside of it. Can hold up to 100 units."
 	id = "stasisbeaker_large"
 	req_tech = list(Tc_BLUESPACE = 4, Tc_MATERIALS = 6)
 	build_type = PROTOLATHE

--- a/code/modules/research/designs/bluespace.dm
+++ b/code/modules/research/designs/bluespace.dm
@@ -64,7 +64,7 @@
 
 /datum/design/stasisbeaker
 	name = "Stasis Beaker"
-	desc = "A beaker powered by experimental bluespace technology. Chemicals are held in stasis and do not react inside of it. Can hold up to 50 units."
+	desc = "A beaker powered by experimental bluespace technology. Chemicals are held in stasis and do not react inside of it. Can hold up to 100 units."
 	id = "stasisbeaker_small"
 	req_tech = list(Tc_BLUESPACE = 3, Tc_MATERIALS = 4)
 	build_type = PROTOLATHE
@@ -75,7 +75,7 @@
 
 /datum/design/stasisbeaker_large
 	name = "Large Stasis Beaker"
-	desc = "A beaker powered by experimental bluespace technology. Chemicals are held in stasis and do not react inside of it. Can hold up to 100 units."
+	desc = "A beaker powered by experimental bluespace technology. Chemicals are held in stasis and do not react inside of it. Can hold up to 200 units."
 	id = "stasisbeaker_large"
 	req_tech = list(Tc_BLUESPACE = 4, Tc_MATERIALS = 6)
 	build_type = PROTOLATHE
@@ -83,6 +83,17 @@
 	reliability = 100
 	category = "Bluespace"
 	build_path = /obj/item/weapon/reagent_containers/glass/beaker/noreact/large
+
+/datum/design/stasis_spray
+	name = "Stasis Spray"
+	desc = "A bluespace powered spraybottle. Chemicals are held in stasis and do not react inside of it. Can hold up to 150 units."
+	id = "stasis_spray"
+	req_tech = list(Tc_BLUESPACE = 5, Tc_MATERIALS = 6)
+	build_type = PROTOLATHE
+	materials = list(MAT_DIAMOND = 2500, MAT_IRON = 3750, MAT_GLASS = 3750, MAT_URANIUM = 1500, MAT_PLASTIC = 2500)
+	reliability = 100
+	category = "Bluespace"
+	build_path = /obj/item/weapon/reagent_containers/spray/noreact
 
 /datum/design/gps
 	name = "Global Positioning System"

--- a/code/modules/research/designs/bluespace.dm
+++ b/code/modules/research/designs/bluespace.dm
@@ -90,7 +90,7 @@
 	id = "stasis_spray"
 	req_tech = list(Tc_BLUESPACE = 5, Tc_MATERIALS = 6)
 	build_type = PROTOLATHE
-	materials = list(MAT_DIAMOND = 2500, MAT_IRON = 3750, MAT_GLASS = 3750, MAT_URANIUM = 1500, MAT_PLASTIC = 2500)
+	materials = list(MAT_DIAMOND = 2500, MAT_IRON = 3750, MAT_GLASS = 4000, MAT_URANIUM = 2000)
 	reliability = 100
 	category = "Bluespace"
 	build_path = /obj/item/weapon/reagent_containers/spray/noreact

--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -18,6 +18,16 @@
 	materials = list(MAT_IRON=10000)
 	category = "Misc"
 
+/datum/design/spraybottle
+	name = "Spray Bottle"
+	desc = "A regular run of the mill spray bottle. Fun for the whole family. Spray away!"
+	id = "spraybottle"
+	build_type = PROTOLATHE
+	build_path = /obj/item/weapon/reagent_containers/spray
+	req_tech = list(Tc_ENGINEERING = 2, Tc_MATERIALS = 3)
+	materials = list(MAT_GLASS = 3000, MAT_IRON=1500)
+	category = "Misc"
+
 /datum/design/chempack
 	name = "Chemical Pack"
 	desc = "Useful for the storage and transport of large volumes of chemicals. Can be used in conjunction with a wide range of chemical-dispensing devices."


### PR DESCRIPTION
Since you could get bottles from Janitorial supply crates, insect control crates and weed control crates, this just moves the middle man from cargo to science. You can now make spray bottles on the protolathe.
Also added the stasis spray bottles to the protolathe. Nerfed the stasis spray to 150u (something something, space is used on the stasis chamber).

Finally, buffed the Plant-B-Gone and Bug Zapper Spray bottles to 250u, since they are just regular spray bottles with specific compounds inside. Also replaced the Bug Zapper's Toxin with Insecticide, for consistency.

Sister PR to #29050, since the stasis beakers should be a tad bigger for the stasis spray to make sense.
[consistency] [qol] [tweak]

:cl:
 * rscadd: Basic Spray Bottles now available on the Protolathe, under Misc, requiring engineering 2 and materials 3. 
 * rscadd: Stasis Spray Bottles available on the Protolathe, under bluespace, requiring bluespace 5 and materials 6, can hold 150u.
 * tweak: Plant-B-Gone bottles (like the ones on weed crates) now have a max volume of 250 (from 100).
 * tweak: Bug Zapper bottles (like the ones on insect crates) now have a max volume of 250 (from 100).
 * tweak: Bug Zapper bottles now contain Insecticide instead of Toxin.