### PR TITLE
Phazon and Bananium solidification.

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -835,6 +835,27 @@
 /datum/chemical_reaction/solidification/uranium/product_to_spawn()
 	return /obj/item/stack/sheet/mineral/uranium
 
+/datum/chemical_reaction/solidification/clown
+	name = "Solid Bananium"
+	id = "solidbananium"
+	result = null
+	required_reagents = list(SILICATE = 10, FROSTOIL = 10, BANANA = 20)
+	required_catalysts = list(PHAZON = 1)
+	result_amount = 1
+
+/datum/chemical_reaction/solidification/clown/product_to_spawn()
+	return /obj/item/stack/sheet/mineral/clown
+	
+/datum/chemical_reaction/solidification/phazon
+	name = "Solid Phazon"
+	id = "solidphazon"
+	result = null
+	required_reagents = list(SILICATE = 10, FROSTOIL = 10, PHAZON = 1)
+	result_amount = 1
+
+/datum/chemical_reaction/solidification/phazon/product_to_spawn()
+	return /obj/item/stack/sheet/mineral/phazon
+
 /datum/chemical_reaction/solidification/plasteel
 	name = "Solid Plasteel"
 	id = "solidplasteel"


### PR DESCRIPTION
For [consistency], you can now solidify Bananium and Phazon. For Bananium, you also require 1u of Phazon salt as catalyst (since most Bananium formations are close to a Phazon vein).

🆑 
 * rscadd: You can now solidify Phazon Salt back to Phazon sheets, using 20u Silicate, 20u Frost Oil and 1u Phazon Salt per sheet.
 * rscadd: You can now solidify Banana Juice to Bananium Sheets, using 20u Silicate, 20u Frost Oil and 20u Banana Juice per sheet, this reaction also needs 1u of Phazon Salt as a catalyst.