### PR TITLE
add screenshots to roundend credits

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1542,6 +1542,13 @@ proc/formatPlayerPanel(var/mob/U,var/text="PP")
 		return
 
 	var/dat = "<center><B>Credits Panel</B></center><hr>"
+	dat += "<center><B>Screenshot:</b></center>"
+	dat += "Chosen Screenshot: [end_credits.customized_ss || end_credits.ss] <A href='?src=\ref[src];credits=setss'>(Set Link)</A> "
+	if(end_credits.customized_ss != "" && !end_credits.drafted)
+		dat += "<A href='?src=\ref[src];credits=resetss'>(Reset)</A> "
+	if(!end_credits.drafted)
+		dat += "<span style='color:red'><br>The round isn't over, so the featured screenshot can still be set. Screenshots do not generate automatically.</span>"
+	dat += "<hr>"
 	dat += "<center><B>Star Of The Show:</b></center>"
 	dat += "Chosen Star: [end_credits.customized_star == "" && end_credits.star == "" ? "(Will Select Automatically)" : end_credits.customized_star || end_credits.star] <A href='?src=\ref[src];credits=setstartext'>(Set Plaintext)</A> <A href='?src=\ref[src];credits=setstarmob'>(Set Mob From List)</A> "
 	if(end_credits.customized_star != "" && !end_credits.drafted)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1543,7 +1543,7 @@ proc/formatPlayerPanel(var/mob/U,var/text="PP")
 
 	var/dat = "<center><B>Credits Panel</B></center><hr>"
 	dat += "<center><B>Screenshot:</b></center>"
-	dat += "Chosen Screenshot: [end_credits.customized_ss || end_credits.ss] <A href='?src=\ref[src];credits=setss'>(Set Link)</A> "
+	dat += "Chosen Screenshot: [end_credits.customized_ss && end_credits.ss] <A href='?src=\ref[src];credits=setss'>(Set Link)</A> "
 	if(end_credits.customized_ss != "" && !end_credits.drafted)
 		dat += "<A href='?src=\ref[src];credits=resetss'>(Reset)</A> "
 	if(!end_credits.drafted)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -5322,6 +5322,18 @@
 					log_admin("[key_name(usr)] forced the current round's featured star to be '[newstar]'")
 					message_admins("[key_name_admin(usr)] forced the current round's featured star to be '[newstar]'")
 
+			if("resetss")
+				if(!end_credits.drafted) //Just in case the button somehow gets clicked when it shouldn't
+					end_credits.customized_ss = ""
+					log_admin("[key_name(usr)] reset the current round's screenshot.")
+					message_admins("[key_name_admin(usr)] reset the current round's featured screenshot.")
+			if("setss")
+				var/newss = input(usr,"Please insert a direct image link. The maximum size is 600x600.") as text|null
+				if(newss)
+					end_credits.customized_ss = newss
+					log_admin("[key_name(usr)] forced the current round's featured screenshot to be '[newss]'")
+					message_admins("[key_name_admin(usr)] forced the current round's featured screenshot to be '[newss]'")
+
 			if("resetname")
 				if(!end_credits.drafted) //Just in case the button somehow gets clicked when it shouldn't
 					end_credits.customized_name = ""

--- a/code/modules/credits/credits.dm
+++ b/code/modules/credits/credits.dm
@@ -23,7 +23,7 @@ var/global/datum/credits/end_credits = new
 	var/star_string = ""
 	var/ss_string = ""
 
-	//If any of the following four are modified, the episode is considered "not a rerun".
+	//If any of the following five are modified, the episode is considered "not a rerun".
 	var/customized_name = ""
 	var/customized_star = ""
 	var/customized_ss = ""
@@ -197,7 +197,7 @@ var/global/datum/credits/end_credits = new
 	var/episode_count_data = SSpersistence_misc.read_data(/datum/persistence_task/round_count)
 	var/episodenum = episode_count_data[season]
 	episode_string = "<h1><span id='episodenumber'>SEASON [season] EPISODE [episodenum]</span><br><span id='episodename'>[episode_name]</span></h1><br><div style='padding-bottom: 75px;'></div>"
-	log_game("So ends [is_rerun() ? "another rerun of " : ""]SEASON [season] EPISODE [episodenum] - [episode_name]")
+	log_game("So ends [is_rerun() ? "another rerun of " : ""]SEASON [season] EPISODE [episodenum] - [episode_name] ... [customized_ss]")
 
 /datum/credits/proc/finalize_disclaimerstring()
 	disclaimers_string = "<div class='disclaimers'>"

--- a/code/modules/credits/credits.dm
+++ b/code/modules/credits/credits.dm
@@ -11,6 +11,7 @@ var/global/datum/credits/end_credits = new
 	var/director = "Pomf Chicken Productions"
 	var/list/producers = list()
 	var/star = ""
+	var/ss = ""
 	var/list/disclaimers = list()
 	var/list/datum/episode_name/episode_names = list()
 
@@ -20,10 +21,12 @@ var/global/datum/credits/end_credits = new
 	var/cast_string = ""
 	var/disclaimers_string = ""
 	var/star_string = ""
+	var/ss_string = ""
 
 	//If any of the following four are modified, the episode is considered "not a rerun".
 	var/customized_name = ""
 	var/customized_star = ""
+	var/customized_ss = ""
 	var/rare_episode_name = FALSE
 	var/theme = "NT"
 
@@ -53,7 +56,7 @@ var/global/datum/credits/end_credits = new
 		)
 
 /datum/credits/proc/is_rerun()
-	if(customized_name != "" || customized_star != "" || rare_episode_name == TRUE || theme != initial(theme))
+	if(customized_name != "" || customized_star != "" || customized_ss !="" || rare_episode_name == TRUE || theme != initial(theme))
 		return FALSE
 	else
 		return TRUE
@@ -89,9 +92,10 @@ var/global/datum/credits/end_credits = new
 	finalize_name()
 	finalize_episodestring()
 	finalize_starstring()
+	finalize_ssstring()
 	finalize_disclaimerstring() //finalize it after the admins have had time to edit them
 
-	var/scrollytext = episode_string + cast_string + disclaimers_string
+	var/scrollytext = ss_string + episode_string + cast_string + disclaimers_string
 	var/splashytext = producers_string + star_string
 
 	js_args = list(scrollytext, splashytext, theme, scroll_speed, splash_time) //arguments for the makeCredits function back in the javascript
@@ -238,6 +242,11 @@ var/global/datum/credits/end_credits = new
 	if(customized_star == "" && star == "")
 		return
 	star_string = "<h1>Starring<br>[customized_star != "" ? customized_star : star]</h1><br>%<splashbreak>" //%<splashbreak> being an arbitrary "new splash card" char we use to split this string back in the javascript
+
+/datum/credits/proc/finalize_ssstring()
+	if(customized_ss == "" && ss == "")
+		return
+	ss_string = "<div style='max-height:600px;overflow:hidden;text-align:center;'><img src='[customized_ss]' style='max-height:600px;'></div>"
 
 /datum/credits/proc/draft_caststring()
 	cast_string = "<h1>CAST:</h1><br><h2>(in order of appearance)</h2><br>"

--- a/code/modules/credits/credits.dm
+++ b/code/modules/credits/credits.dm
@@ -246,7 +246,7 @@ var/global/datum/credits/end_credits = new
 /datum/credits/proc/finalize_ssstring()
 	if(customized_ss == "" && ss == "")
 		return
-	ss_string = "<div style='max-height:600px;overflow:hidden;text-align:center;'><img src='[customized_ss]' style='max-height:600px;'></div>"
+	ss_string = "<div align='center'><div style='max-height:600px;overflow:hidden;max-width:600px;padding-bottom:20px;'><img src='[customized_ss]' style='max-height:600px;max-width:600px;'></div></div>"
 
 /datum/credits/proc/draft_caststring()
 	cast_string = "<h1>CAST:</h1><br><h2>(in order of appearance)</h2><br>"


### PR DESCRIPTION
closes #29044 YOU'RE WELCOME NIPPLES

admins may now add screenshots to the roundend credits, which slowly scroll onto your screen after the final splash card and appear right before the cast roll. 

to add a screenshot, first go to the credits panel, then get a direct link to an image and paste it into the input box. discord or pomf.cat both work for quickly uploading images and getting a link to them. if no image is uploaded, the credits will look exactly the same. images over the max width and height (600x600) will get automatically resized to fit these constraints.

:cl:
 * adds screenshots to credits

<qol>
