### PR TITLE
Fixed a Bug With Monkey Madness

### DIFF
--- a/code/datums/gamemode/factions/junglefever.dm
+++ b/code/datums/gamemode/factions/junglefever.dm
@@ -28,7 +28,7 @@
 	var/alive = FALSE
 	for(var/datum/role/R in members)
 		var/mob/M = R.antag.current
-		if(M && M.stat && isbadmonkey(M))
+		if(M && !M.isDead() && isbadmonkey(M))
 			alive = TRUE
 	if(!alive && stage >= FACTION_ENDGAME)
 		stage(FACTION_DEFEATED)


### PR DESCRIPTION
I was looking over the code and I noticed this coding slip where MM could in victory if no apes are dead, because of an inverted check

🆑 
* bugfix: Monkey madness now properly counts living apes.