### PR TITLE
Fixes being unable to buckle people to chairs

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -10,7 +10,7 @@
 	sheet_type = /obj/item/stack/sheet/metal
 	sheet_amt = 1
 	var/mob_lock_type = /datum/locking_category/buckle/bed
-	var/buckle_range = 0 // The distance a spessman needs to be within in order
+	var/buckle_range = 1 // The distance a spessman needs to be within in order
 						 // to be able to use the buckle_in_out verb
 /obj/structure/bed/New()
 	..()

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -164,14 +164,16 @@
 	return 1
 
 /obj/structure/bed/chair/AltClick(mob/user as mob)
-	buckle_chair(user,user)
+	buckle_chair(user,user, 0) // Require to stand on the chair in order to do that
 
 /obj/structure/bed/chair/MouseDropTo(mob/M as mob, mob/user as mob)
 	buckle_chair(M,user)
 
-/obj/structure/bed/chair/proc/buckle_chair(mob/M as mob, mob/user as mob)
+/obj/structure/bed/chair/proc/buckle_chair(mob/M as mob, mob/user as mob, var/override_buckle_range = null)
 	if(!istype(M))
 		return
+
+	var/effective_buckle_range = (override_buckle_range ? override_buckle_range : buckle_range)
 
 	var/mob/living/carbon/human/target = null
 	if(ishuman(M))
@@ -180,7 +182,7 @@
 	if(user!=M && (!user.Adjacent(M) || !user.Adjacent(src)))
 		return
 
-	if(get_dist(src,user) > buckle_range)
+	if(get_dist(src,user) > effective_buckle_range)
 		return
 
 	if(target && target.op_stage.butt == 4 && Adjacent(target) && user.Adjacent(src) && !user.incapacitated()) //Butt surgery is at stage 4

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -173,7 +173,7 @@
 	if(!istype(M))
 		return
 
-	var/effective_buckle_range = (override_buckle_range ? override_buckle_range : buckle_range)
+	var/effective_buckle_range = (isnull(override_buckle_range) ? buckle_range : override_buckle_range)
 
 	var/mob/living/carbon/human/target = null
 	if(ishuman(M))

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -64,6 +64,9 @@
 /obj/structure/bed/chair/vehicle/proc/getMovementDelay()
 	return movement_delay
 
+/obj/structure/bed/chair/AltClick(mob/user as mob)
+	buckle_chair(user,user, 1) // Can drag self to it.
+
 /obj/structure/bed/chair/vehicle/proc/delayNextMove(var/delay, var/additive=0)
 	move_delayer.delayNext(delay,additive)
 


### PR DESCRIPTION
https://github.com/vgstation-coders/vgstation13/commit/287923ec2fa67caeae5e146c3710e3df7926724f#diff-2f81b81039627bd08e88a7f714af6e9d24fe68b069178946dd56d148d33044cdR183

Accidentally made people unable to buckle someone other than themselves to chair. I fixed this, while preserving the behaviour that you need to stand on top of a chair to buckle yourself to it using alt-click. A similar sanity exists for mouse-dragging yourself to it.