### PR TITLE
A Wrench in the Engine

### DIFF
--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -151,6 +151,8 @@
 		to_chat(user, "<span class='warning'>You jam \the [W] into \the [src]'s ignition and feel like a genius as you try turning it!</span>")
 		playsound(src, "sound/items/screwdriver.ogg", 10, 1)
 		H.adjustBrainLoss(10)
+	else if(W.is_wrench(user))
+		return
 	else
 		return ..()
 


### PR DESCRIPTION
This has been a thing for years.

🆑 
* bugfix: You can't deconstruct any vehicle (e.g.: janicart, firebird, gigadrill, snowmobile) instantaneously with a wrench anymore.