### PR TITLE
Fixes vampire cloning losing spells

### DIFF
--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -267,6 +267,12 @@
 		if (H.mind.miming == MIMING_OUT_OF_CHOICE)
 			H.add_spell(new /spell/targeted/oathbreak/)
 
+	// Check for any powers that goes missing after cloning, in case of reviving after ashing
+	if (isvampire(H))
+		var/datum/role/vampire/V = isvampire(H)
+		V.check_vampire_upgrade()
+		V.update_vamp_hud()
+
 	H.UpdateAppearance()
 	H.set_species(R.dna.species)
 	if(!upgraded)


### PR DESCRIPTION
Closes #29003.
[bugfix]
Noticed this when it happened to me in a round, found a function in the role that easily checks for powers, so did this.

:cl:
 * bugfix: Vampires no longer lose their powers if revived as a scanned clone after ashing