### PR TITLE
Windoors can now be renamed just like normal doors

### DIFF
--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -26,6 +26,7 @@
 	var/reinforce_material = /obj/item/stack/sheet/plasteel
 	var/wired = FALSE	//How hard was to make a fucking var to check this jesus christ old coders.
 	var/glass_type = /obj/item/stack/sheet/glass/rglass
+	var/created_name = null
 
 /obj/structure/windoor_assembly/proc/update_name()
 	name = "[secure ? "secure ":""][anchored ? "anchored ":""][anchored && wired ? "and ":""][wired ? "wired ":""][initial(name)]"
@@ -92,6 +93,17 @@ obj/structure/windoor_assembly/Destroy()
 
 
 /obj/structure/windoor_assembly/attackby(obj/item/W, mob/user)
+
+	// Now can be renamed like doors
+	if(istype(W, /obj/item/weapon/pen))
+		var/t = copytext(stripped_input(user, "Enter the name for the windoor.", src.name, src.created_name),1,MAX_NAME_LEN)
+		if(!t)
+			return
+		if(!in_range(src, usr) && src.loc != usr)
+			return
+		created_name = t
+		return
+	
 	if(iswelder(W) && (!anchored && !wired && !electronics))
 		var/obj/item/weapon/weldingtool/WT = W
 		user.visible_message("[user] dissassembles [src].", "You start to dissassemble [src].")
@@ -218,6 +230,8 @@ obj/structure/windoor_assembly/Destroy()
 			if(gcDestroyed)
 				return
 			var/obj/machinery/door/window/windoor = make_windoor()
+			if(created_name)
+				windoor.name = created_name
 			to_chat(user, "<span class='notice'>You finish the [windoor.name]!</span>")
 			qdel(src)
 


### PR DESCRIPTION
Closes #29070.

Code acts similar to door naming, on assemblies at any point during construction, adds similar variable handling.

:cl:
 * rscadd: Windoors can now be named with pens during construction like regular doors.