### PR TITLE
Adds new episode names based on number of turfs on fire

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -259,7 +259,6 @@ var/list/score=list(
 	"deadpets"		= 0, //Only counts 'special' simple_mobs, like Ian, Poly, Runtime, Sasha etc
 	"buttbotfarts"  = 0, //Messages mimicked by buttbots.
 	"turfssingulod" = 0, //Amount of turfs eaten by singularities.
-	"turfsonfire" = 0, //Amount of turfs on fire.
 	"shardstouched" = 0, //+1 for each pair of shards that bump into eachother.
 	"kudzugrowth"   = 0, //Amount of kudzu tiles successfully grown, even if they were later eradicated.
 	"nukedefuse"	= 9999, //Seconds the nuke had left when it was defused.

--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -259,6 +259,7 @@ var/list/score=list(
 	"deadpets"		= 0, //Only counts 'special' simple_mobs, like Ian, Poly, Runtime, Sasha etc
 	"buttbotfarts"  = 0, //Messages mimicked by buttbots.
 	"turfssingulod" = 0, //Amount of turfs eaten by singularities.
+	"turfsonfire" = 0, //Amount of turfs on fire.
 	"shardstouched" = 0, //+1 for each pair of shards that bump into eachother.
 	"kudzugrowth"   = 0, //Amount of kudzu tiles successfully grown, even if they were later eradicated.
 	"nukedefuse"	= 9999, //Seconds the nuke had left when it was defused.

--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -269,11 +269,13 @@ Attach to transfer valve and open. BOOM.
 	dir = pick(cardinal)
 	set_light(3)
 	SSair.add_hotspot(src)
+	score["turfsonfire"]++
 
 /obj/effect/fire/Destroy()
 	SSair.remove_hotspot(src)
 
 	set_light(0)
+	score["turfsonfire"]--
 	..()
 
 turf/simulated/var/fire_protection = 0 //Protects newly extinguished tiles from being overrun again.

--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -269,13 +269,11 @@ Attach to transfer valve and open. BOOM.
 	dir = pick(cardinal)
 	set_light(3)
 	SSair.add_hotspot(src)
-	score["turfsonfire"]++
 
 /obj/effect/fire/Destroy()
 	SSair.remove_hotspot(src)
 
 	set_light(0)
-	score["turfsonfire"]--
 	..()
 
 turf/simulated/var/fire_protection = 0 //Protects newly extinguished tiles from being overrun again.

--- a/code/modules/credits/episode_name.dm
+++ b/code/modules/credits/episode_name.dm
@@ -144,7 +144,7 @@
 		episode_names += new /datum/episode_name/rare("[pick("REAP WHAT YOU SOW", "OUT OF THE WOODS", "SEEDY BUSINESS", "[uppr_name] AND THE BEANSTALK", "IN THE GARDEN OF EDEN")]", "[score["kudzugrowth"]] tiles worth of Kudzu were grown in total this round.", min(1500, score["kudzugrowth"]*2))
 	if(score["disease"] >= score["escapees"] && score["escapees"] > 5)
 		episode_names += new /datum/episode_name/rare("[pick("THE CREW GETS DOWN WITH THE SICKNESS", "THE CREW GETS AN INCURABLE DISEASE", "THE CREW'S SICK PUNS")]", "[score["disease"]] disease points this round.", min(500, (score["disease"]*25) * (score["disease"]/score["escapees"])))
-	if(processing_parts[SSAIR_HOTSPOT].len > 200) // List of turfs on fire length
+	if(SSAir.processing_parts[SSAIR_HOTSPOT].len > 200) // List of turfs on fire length
 		episode_names += new /datum/episode_name/rare("[pick("THE CREW LOSES THEIR CHILL", "DISCO INFERNO", "ASHES TO ASHES", "BURNING DOWN THE HOUSE")]", "[score["turfsonfire"]] turfs were on fire by the end of the round.", min(1000, score["turfsonfire"]/2))
 	//future idea: "a cold day in hell" if most of the station was freezing and threat was high
 	//future idea: "the crew has a blast" if six big explosions happen, "sitting ducks" if the escape shuttle is bombed and the would-be escapees were mostly vox, "on a wing and a prayer" if the shuttle is bombed but enough people survive anyways
@@ -290,7 +290,7 @@
 					if(H.is_wearing_item(/obj/item/clothing/under/rank/chef))
 						chance += 250
 					episode_names += new /datum/episode_name/rare("HAIL TO THE CHEF", "The Chef was the only survivor in the shuttle.", chance)
-					if(processing_parts[SSAIR_HOTSPOT].len > 200) // List of turfs on fire length
+					if(SSAir.processing_parts[SSAIR_HOTSPOT].len > 200) // List of turfs on fire length
 						episode_names += new /datum/episode_name/rare("IF YOU CAN'T STAND THE HEAT...", "The Chef was the only survivor in the shuttle and [score["turfsonfire"]] turfs were on fire.", min(chance, score["turfsonfire"]/2))
 				else if(!H.isUnconscious() && H.mind && H.mind.assigned_role == "Clown")
 					var/chance = 250

--- a/code/modules/credits/episode_name.dm
+++ b/code/modules/credits/episode_name.dm
@@ -144,7 +144,8 @@
 		episode_names += new /datum/episode_name/rare("[pick("REAP WHAT YOU SOW", "OUT OF THE WOODS", "SEEDY BUSINESS", "[uppr_name] AND THE BEANSTALK", "IN THE GARDEN OF EDEN")]", "[score["kudzugrowth"]] tiles worth of Kudzu were grown in total this round.", min(1500, score["kudzugrowth"]*2))
 	if(score["disease"] >= score["escapees"] && score["escapees"] > 5)
 		episode_names += new /datum/episode_name/rare("[pick("THE CREW GETS DOWN WITH THE SICKNESS", "THE CREW GETS AN INCURABLE DISEASE", "THE CREW'S SICK PUNS")]", "[score["disease"]] disease points this round.", min(500, (score["disease"]*25) * (score["disease"]/score["escapees"])))
-	//future idea: "the crew loses their chill"/"disco inferno"/"ashes to ashes"/"burning down the house" if most of the station is on fire, if the chef was the only survivor, "if you can't stand the heat..."
+	if(score["turfsonfire"] > 200)
+		episode_names += new /datum/episode_name/rare("[pick("THE CREW LOSES THEIR CHILL", "DISCO INFERNO", "ASHES TO ASHES", "BURNING DOWN THE HOUSE")]", "[score["turfsonfire"]] turfs were on fire by the end of the round.", min(1000, score["turfsonfire"]/2))
 	//future idea: "a cold day in hell" if most of the station was freezing and threat was high
 	//future idea: "the crew has a blast" if six big explosions happen, "sitting ducks" if the escape shuttle is bombed and the would-be escapees were mostly vox, "on a wing and a prayer" if the shuttle is bombed but enough people survive anyways
 
@@ -289,6 +290,8 @@
 					if(H.is_wearing_item(/obj/item/clothing/under/rank/chef))
 						chance += 250
 					episode_names += new /datum/episode_name/rare("HAIL TO THE CHEF", "The Chef was the only survivor in the shuttle.", chance)
+					if(score["turfsonfire"] > 200)
+						episode_names += new /datum/episode_name/rare("IF YOU CAN'T STAND THE HEAT...", "The Chef was the only survivor in the shuttle and [score["turfsonfire"]] turfs were on fire.", min(chance, score["turfsonfire"]/2))
 				else if(!H.isUnconscious() && H.mind && H.mind.assigned_role == "Clown")
 					var/chance = 250
 					if(H.is_wearing_item(/obj/item/clothing/mask/gas/clown_hat))

--- a/code/modules/credits/episode_name.dm
+++ b/code/modules/credits/episode_name.dm
@@ -144,7 +144,7 @@
 		episode_names += new /datum/episode_name/rare("[pick("REAP WHAT YOU SOW", "OUT OF THE WOODS", "SEEDY BUSINESS", "[uppr_name] AND THE BEANSTALK", "IN THE GARDEN OF EDEN")]", "[score["kudzugrowth"]] tiles worth of Kudzu were grown in total this round.", min(1500, score["kudzugrowth"]*2))
 	if(score["disease"] >= score["escapees"] && score["escapees"] > 5)
 		episode_names += new /datum/episode_name/rare("[pick("THE CREW GETS DOWN WITH THE SICKNESS", "THE CREW GETS AN INCURABLE DISEASE", "THE CREW'S SICK PUNS")]", "[score["disease"]] disease points this round.", min(500, (score["disease"]*25) * (score["disease"]/score["escapees"])))
-	if(score["turfsonfire"] > 200)
+	if(processing_parts[SSAIR_HOTSPOT].len > 200) // List of turfs on fire length
 		episode_names += new /datum/episode_name/rare("[pick("THE CREW LOSES THEIR CHILL", "DISCO INFERNO", "ASHES TO ASHES", "BURNING DOWN THE HOUSE")]", "[score["turfsonfire"]] turfs were on fire by the end of the round.", min(1000, score["turfsonfire"]/2))
 	//future idea: "a cold day in hell" if most of the station was freezing and threat was high
 	//future idea: "the crew has a blast" if six big explosions happen, "sitting ducks" if the escape shuttle is bombed and the would-be escapees were mostly vox, "on a wing and a prayer" if the shuttle is bombed but enough people survive anyways
@@ -290,7 +290,7 @@
 					if(H.is_wearing_item(/obj/item/clothing/under/rank/chef))
 						chance += 250
 					episode_names += new /datum/episode_name/rare("HAIL TO THE CHEF", "The Chef was the only survivor in the shuttle.", chance)
-					if(score["turfsonfire"] > 200)
+					if(processing_parts[SSAIR_HOTSPOT].len > 200) // List of turfs on fire length
 						episode_names += new /datum/episode_name/rare("IF YOU CAN'T STAND THE HEAT...", "The Chef was the only survivor in the shuttle and [score["turfsonfire"]] turfs were on fire.", min(chance, score["turfsonfire"]/2))
 				else if(!H.isUnconscious() && H.mind && H.mind.assigned_role == "Clown")
 					var/chance = 250

--- a/code/modules/credits/episode_name.dm
+++ b/code/modules/credits/episode_name.dm
@@ -144,7 +144,8 @@
 		episode_names += new /datum/episode_name/rare("[pick("REAP WHAT YOU SOW", "OUT OF THE WOODS", "SEEDY BUSINESS", "[uppr_name] AND THE BEANSTALK", "IN THE GARDEN OF EDEN")]", "[score["kudzugrowth"]] tiles worth of Kudzu were grown in total this round.", min(1500, score["kudzugrowth"]*2))
 	if(score["disease"] >= score["escapees"] && score["escapees"] > 5)
 		episode_names += new /datum/episode_name/rare("[pick("THE CREW GETS DOWN WITH THE SICKNESS", "THE CREW GETS AN INCURABLE DISEASE", "THE CREW'S SICK PUNS")]", "[score["disease"]] disease points this round.", min(500, (score["disease"]*25) * (score["disease"]/score["escapees"])))
-	if(SSair.processing_parts[SSAIR_HOTSPOT].len > 200) // List of turfs on fire length
+	var/list/p_hotspot = processing_parts[SSAIR_HOTSPOT]
+	if(p_hotspot.len > 200) // List of turfs on fire length
 		episode_names += new /datum/episode_name/rare("[pick("THE CREW LOSES THEIR CHILL", "DISCO INFERNO", "ASHES TO ASHES", "BURNING DOWN THE HOUSE")]", "[score["turfsonfire"]] turfs were on fire by the end of the round.", min(1000, score["turfsonfire"]/2))
 	//future idea: "a cold day in hell" if most of the station was freezing and threat was high
 	//future idea: "the crew has a blast" if six big explosions happen, "sitting ducks" if the escape shuttle is bombed and the would-be escapees were mostly vox, "on a wing and a prayer" if the shuttle is bombed but enough people survive anyways
@@ -290,7 +291,7 @@
 					if(H.is_wearing_item(/obj/item/clothing/under/rank/chef))
 						chance += 250
 					episode_names += new /datum/episode_name/rare("HAIL TO THE CHEF", "The Chef was the only survivor in the shuttle.", chance)
-					if(SSair.processing_parts[SSAIR_HOTSPOT].len > 200) // List of turfs on fire length
+					if(p_hotspot.len > 200) // List of turfs on fire length
 						episode_names += new /datum/episode_name/rare("IF YOU CAN'T STAND THE HEAT...", "The Chef was the only survivor in the shuttle and [score["turfsonfire"]] turfs were on fire.", min(chance, score["turfsonfire"]/2))
 				else if(!H.isUnconscious() && H.mind && H.mind.assigned_role == "Clown")
 					var/chance = 250

--- a/code/modules/credits/episode_name.dm
+++ b/code/modules/credits/episode_name.dm
@@ -144,7 +144,7 @@
 		episode_names += new /datum/episode_name/rare("[pick("REAP WHAT YOU SOW", "OUT OF THE WOODS", "SEEDY BUSINESS", "[uppr_name] AND THE BEANSTALK", "IN THE GARDEN OF EDEN")]", "[score["kudzugrowth"]] tiles worth of Kudzu were grown in total this round.", min(1500, score["kudzugrowth"]*2))
 	if(score["disease"] >= score["escapees"] && score["escapees"] > 5)
 		episode_names += new /datum/episode_name/rare("[pick("THE CREW GETS DOWN WITH THE SICKNESS", "THE CREW GETS AN INCURABLE DISEASE", "THE CREW'S SICK PUNS")]", "[score["disease"]] disease points this round.", min(500, (score["disease"]*25) * (score["disease"]/score["escapees"])))
-	if(SSAir.processing_parts[SSAIR_HOTSPOT].len > 200) // List of turfs on fire length
+	if(SSair.processing_parts[SSAIR_HOTSPOT].len > 200) // List of turfs on fire length
 		episode_names += new /datum/episode_name/rare("[pick("THE CREW LOSES THEIR CHILL", "DISCO INFERNO", "ASHES TO ASHES", "BURNING DOWN THE HOUSE")]", "[score["turfsonfire"]] turfs were on fire by the end of the round.", min(1000, score["turfsonfire"]/2))
 	//future idea: "a cold day in hell" if most of the station was freezing and threat was high
 	//future idea: "the crew has a blast" if six big explosions happen, "sitting ducks" if the escape shuttle is bombed and the would-be escapees were mostly vox, "on a wing and a prayer" if the shuttle is bombed but enough people survive anyways
@@ -290,7 +290,7 @@
 					if(H.is_wearing_item(/obj/item/clothing/under/rank/chef))
 						chance += 250
 					episode_names += new /datum/episode_name/rare("HAIL TO THE CHEF", "The Chef was the only survivor in the shuttle.", chance)
-					if(SSAir.processing_parts[SSAIR_HOTSPOT].len > 200) // List of turfs on fire length
+					if(SSair.processing_parts[SSAIR_HOTSPOT].len > 200) // List of turfs on fire length
 						episode_names += new /datum/episode_name/rare("IF YOU CAN'T STAND THE HEAT...", "The Chef was the only survivor in the shuttle and [score["turfsonfire"]] turfs were on fire.", min(chance, score["turfsonfire"]/2))
 				else if(!H.isUnconscious() && H.mind && H.mind.assigned_role == "Clown")
 					var/chance = 250

--- a/code/modules/credits/episode_name.dm
+++ b/code/modules/credits/episode_name.dm
@@ -144,7 +144,7 @@
 		episode_names += new /datum/episode_name/rare("[pick("REAP WHAT YOU SOW", "OUT OF THE WOODS", "SEEDY BUSINESS", "[uppr_name] AND THE BEANSTALK", "IN THE GARDEN OF EDEN")]", "[score["kudzugrowth"]] tiles worth of Kudzu were grown in total this round.", min(1500, score["kudzugrowth"]*2))
 	if(score["disease"] >= score["escapees"] && score["escapees"] > 5)
 		episode_names += new /datum/episode_name/rare("[pick("THE CREW GETS DOWN WITH THE SICKNESS", "THE CREW GETS AN INCURABLE DISEASE", "THE CREW'S SICK PUNS")]", "[score["disease"]] disease points this round.", min(500, (score["disease"]*25) * (score["disease"]/score["escapees"])))
-	var/list/p_hotspot = processing_parts[SSAIR_HOTSPOT]
+	var/list/p_hotspot = SSair.processing_parts[SSAIR_HOTSPOT]
 	if(p_hotspot.len > 200) // List of turfs on fire length
 		episode_names += new /datum/episode_name/rare("[pick("THE CREW LOSES THEIR CHILL", "DISCO INFERNO", "ASHES TO ASHES", "BURNING DOWN THE HOUSE")]", "[score["turfsonfire"]] turfs were on fire by the end of the round.", min(1000, score["turfsonfire"]/2))
 	//future idea: "a cold day in hell" if most of the station was freezing and threat was high


### PR DESCRIPTION
[content]
Noticed that this was in a future idea comment while scrolling through the episode_name.dm file, so I decided to implement it

:cl:
 * rscadd: New episode names for when you leave most of the station burning when the shuttle leaves