### PR TITLE
Plant-B-Gone and Bug Zapper spraybottle buff. Also replaced the Bug Zapper's Toxin with Insecticide.

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -150,11 +150,11 @@
 	icon = 'icons/obj/hydroponics/hydro_tools.dmi'
 	icon_state = "plantbgone"
 	item_state = "plantbgone"
-	volume = 100
+	volume = 250
 
 /obj/item/weapon/reagent_containers/spray/plantbgone/New()
 	..()
-	reagents.add_reagent(PLANTBGONE, 100)
+	reagents.add_reagent(PLANTBGONE, 250)
 
 /obj/item/weapon/reagent_containers/spray/bugzapper
 	name = "Bug Zapper"
@@ -162,11 +162,11 @@
 	icon = 'icons/obj/hydroponics/hydro_tools.dmi'
 	icon_state = "plantbgone"
 	item_state = "plantbgone"
-	volume = 100
+	volume = 250
 
 /obj/item/weapon/reagent_containers/spray/bugzapper/New()
 	..()
-	reagents.add_reagent(TOXIN, 100)
+	reagents.add_reagent(INSECTICIDE, 250)
 
 //chemsprayer
 /obj/item/weapon/reagent_containers/spray/chemsprayer


### PR DESCRIPTION
Bug Zapper bottles (from insect crates) had Toxin instead of Insecticide, so for [consistency], changed.
Also [tweak] to the bugzapper and PBG spray bottles. They are normal spray bottles with a different sprite, so they now have a max volume of 250.

:cl:
 * tweak: Plant-B-Gone bottles (like the ones on weed crates) now have a max volume of 250 (from 100).
 * tweak: Bug Zapper bottles (like the ones on insect crates) now have a max volume of 250 (from 100).
 * tweak: Bug Zapper bottles now contain Insecticide instead of Toxin.