### PR TITLE
Phazon tiles now randomly teleport between each other on clicking

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -58,6 +58,12 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 	else
 		icon_regular_floor = icon_state
 
+/turf/simulated/floor/Destroy()
+	//No longer phazon, not a teleport destination
+	if(material=="phazon")
+		phazontiles -= src
+	..()
+
 /turf/simulated/floor/ashify()
 	burn_tile()
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -632,6 +632,14 @@ turf/simulated/floor/update_icon()
 					spawn(200)
 						spam_flag = 0
 						update_icon()
+			if("phazon")
+				if(!spam_flag)
+					spam_flag = 1
+					if(prob(5))
+						turf/simulated/floor/mineral/phazon/destination = pick(phazontiles)
+						do_teleport(AM, destination)
+					spawn(20)
+						spam_flag = 0
 
 
 /turf/simulated/proc/is_wet() //Returns null if no puddle, otherwise returns the puddle

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -17,6 +17,10 @@ var/list/plating_icons = list("plating","platingdmg1","platingdmg2","platingdmg3
 				"ironsand8", "ironsand9", "ironsand10", "ironsand11",
 				"ironsand12", "ironsand13", "ironsand14", "ironsand15")
 var/list/wood_icons = list("wood","wood-broken")
+
+//For phazon tile teleportation
+var/global/list/turf/simulated/floor/phazontiles = list()
+
 /turf/simulated/floor
 
 	//Note to coders, the 'intact' var can no longer be used to determine if the floor is a plating or not.
@@ -395,6 +399,8 @@ turf/simulated/floor/update_icon()
 	floor_tile = null
 	floor_tile = new T.type(null)
 	material = floor_tile.material
+	if(material=="phazon")
+		phazontiles += src
 	intact = 1
 	plane = TURF_PLANE
 	if(istype(T,/obj/item/stack/tile/light))
@@ -541,6 +547,8 @@ turf/simulated/floor/update_icon()
 				floor_tile.forceMove(src)
 				floor_tile = null
 			else
+				if(material=="phazon")
+					phazontiles -= src
 				to_chat(user, "<span class='notice'>You remove the [floor_tile.name].</span>")
 				floor_tile.forceMove(src)
 				floor_tile = null
@@ -675,12 +683,16 @@ turf/simulated/floor/update_icon()
 
 /turf/simulated/floor/cultify()
 	if((icon_state != "cult")&&(icon_state != "cult-narsie"))
+		if(material=="phazon")
+			phazontiles -= src
 		name = "engraved floor"
 		icon = 'icons/turf/floors.dmi'
 		icon_state = "cult"
 		turf_animation('icons/effects/effects.dmi',"cultfloor",0,0,MOB_LAYER-1,anim_plane = OBJ_PLANE)
 
 /turf/simulated/floor/clockworkify()
+	if(material=="phazon")
+		phazontiles -= src
 	ChangeTurf(/turf/simulated/floor/mineral/clockwork)
 	turf_animation('icons/effects/effects.dmi',CLOCKWORK_GENERIC_GLOW, 0, 0, MOB_LAYER-1, anim_plane = TURF_PLANE)
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -221,7 +221,7 @@ turf/simulated/floor/update_icon()
 		if("phazon")
 			if(!spam_flag)
 				spam_flag = 1
-				var/turf/simulated/floor/destination = pick(phazontiles)
+				var/obj/item/stack/tile/mineral/phazon/destination = pick(phazontiles)
 				do_teleport(user, destination)
 				spawn(20)
 					spam_flag = 0

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -218,6 +218,14 @@ turf/simulated/floor/update_icon()
 				playsound(src, 'sound/items/bikehorn.ogg', 50, 1)
 				spawn(20)
 					spam_flag = 0
+		if("phazon")
+			if(!spam_flag)
+				spam_flag = 1
+				if(prob(5))
+					var/turf/simulated/floor/mineral/phazon/destination = pick(phazontiles)
+					do_teleport(user, destination)
+				spawn(20)
+					spam_flag = 0
 	..()
 
 /turf/simulated/floor/proc/gets_drilled()
@@ -632,14 +640,6 @@ turf/simulated/floor/update_icon()
 					spawn(200)
 						spam_flag = 0
 						update_icon()
-			if("phazon")
-				if(!spam_flag)
-					spam_flag = 1
-					if(prob(5))
-						var/turf/simulated/floor/mineral/phazon/destination = pick(phazontiles)
-						do_teleport(AM, destination)
-					spawn(20)
-						spam_flag = 0
 
 
 /turf/simulated/proc/is_wet() //Returns null if no puddle, otherwise returns the puddle

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -74,15 +74,24 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 	//set src in oview(1)
 	switch(severity)
 		if(1.0)
+			//No longer phazon, not a teleport destination
+			if(material=="phazon")
+				phazontiles -= src
 			src.ChangeTurf(get_underlying_turf())
 		if(2.0)
 			switch(pick(1,75;2,3))
 				if (1)
+					//No longer phazon, not a teleport destination
+					if(material=="phazon")
+						phazontiles -= src
 					src.ReplaceWithLattice()
 					if(prob(33))
 						var/obj/item/stack/sheet/metal/M = new /obj/item/stack/sheet/metal(get_turf(src))
 						M.amount = 1
 				if(2)
+					//No longer phazon, not a teleport destination
+					if(material=="phazon")
+						phazontiles -= src
 					src.ChangeTurf(get_underlying_turf())
 				if(3)
 					if(prob(80))
@@ -385,6 +394,9 @@ turf/simulated/floor/update_icon()
 	intact = 0
 	broken = 0
 	burnt = 0
+	//No longer phazon, not a teleport destination
+	if(material=="phazon")
+		phazontiles -= src
 	material = "metal"
 	plane = PLATING_PLANE
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -698,9 +698,6 @@ turf/simulated/floor/update_icon()
 		turf_animation('icons/effects/effects.dmi',"cultfloor",0,0,MOB_LAYER-1,anim_plane = OBJ_PLANE)
 
 /turf/simulated/floor/clockworkify()
-	//No longer phazon, not a teleport destination
-	if(material=="phazon")
-		phazontiles -= src
 	ChangeTurf(/turf/simulated/floor/mineral/clockwork)
 	turf_animation('icons/effects/effects.dmi',CLOCKWORK_GENERIC_GLOW, 0, 0, MOB_LAYER-1, anim_plane = TURF_PLANE)
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -221,9 +221,8 @@ turf/simulated/floor/update_icon()
 		if("phazon")
 			if(!spam_flag)
 				spam_flag = 1
-				if(prob(5))
-					var/turf/simulated/floor/mineral/phazon/destination = pick(phazontiles)
-					do_teleport(user, destination)
+				var/turf/simulated/floor/mineral/phazon/destination = pick(phazontiles)
+				do_teleport(user, destination)
 				spawn(20)
 					spam_flag = 0
 	..()

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -221,7 +221,7 @@ turf/simulated/floor/update_icon()
 		if("phazon")
 			if(!spam_flag)
 				spam_flag = 1
-				var/obj/item/stack/tile/mineral/phazon/destination = pick(phazontiles)
+				var/turf/simulated/floor/destination = pick(phazontiles)
 				do_teleport(user, destination)
 				spawn(20)
 					spam_flag = 0

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -74,24 +74,15 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 	//set src in oview(1)
 	switch(severity)
 		if(1.0)
-			//No longer phazon, not a teleport destination
-			if(material=="phazon")
-				phazontiles -= src
 			src.ChangeTurf(get_underlying_turf())
 		if(2.0)
 			switch(pick(1,75;2,3))
 				if (1)
-					//No longer phazon, not a teleport destination
-					if(material=="phazon")
-						phazontiles -= src
 					src.ReplaceWithLattice()
 					if(prob(33))
 						var/obj/item/stack/sheet/metal/M = new /obj/item/stack/sheet/metal(get_turf(src))
 						M.amount = 1
 				if(2)
-					//No longer phazon, not a teleport destination
-					if(material=="phazon")
-						phazontiles -= src
 					src.ChangeTurf(get_underlying_turf())
 				if(3)
 					if(prob(80))
@@ -394,9 +385,6 @@ turf/simulated/floor/update_icon()
 	intact = 0
 	broken = 0
 	burnt = 0
-	//No longer phazon, not a teleport destination
-	if(material=="phazon")
-		phazontiles -= src
 	material = "metal"
 	plane = PLATING_PLANE
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -222,6 +222,7 @@ turf/simulated/floor/update_icon()
 				playsound(src, 'sound/items/bikehorn.ogg', 50, 1)
 				spawn(20)
 					spam_flag = 0
+		//Phazon tiles teleport to another random one in the world when clicked
 		if("phazon")
 			if(!spam_flag)
 				spam_flag = 1
@@ -399,6 +400,7 @@ turf/simulated/floor/update_icon()
 	floor_tile = null
 	floor_tile = new T.type(null)
 	material = floor_tile.material
+	//Becomes a teleport destination for other phazon tiles
 	if(material=="phazon")
 		phazontiles += src
 	intact = 1
@@ -547,6 +549,7 @@ turf/simulated/floor/update_icon()
 				floor_tile.forceMove(src)
 				floor_tile = null
 			else
+				//No longer phazon, not a teleport destination
 				if(material=="phazon")
 					phazontiles -= src
 				to_chat(user, "<span class='notice'>You remove the [floor_tile.name].</span>")
@@ -683,6 +686,7 @@ turf/simulated/floor/update_icon()
 
 /turf/simulated/floor/cultify()
 	if((icon_state != "cult")&&(icon_state != "cult-narsie"))
+		//No longer phazon, not a teleport destination
 		if(material=="phazon")
 			phazontiles -= src
 		name = "engraved floor"
@@ -691,6 +695,7 @@ turf/simulated/floor/update_icon()
 		turf_animation('icons/effects/effects.dmi',"cultfloor",0,0,MOB_LAYER-1,anim_plane = OBJ_PLANE)
 
 /turf/simulated/floor/clockworkify()
+	//No longer phazon, not a teleport destination
 	if(material=="phazon")
 		phazontiles -= src
 	ChangeTurf(/turf/simulated/floor/mineral/clockwork)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -385,6 +385,9 @@ turf/simulated/floor/update_icon()
 	intact = 0
 	broken = 0
 	burnt = 0
+	//No longer phazon, not a teleport destination
+	if(material=="phazon")
+		phazontiles -= src
 	material = "metal"
 	plane = PLATING_PLANE
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -221,7 +221,7 @@ turf/simulated/floor/update_icon()
 		if("phazon")
 			if(!spam_flag)
 				spam_flag = 1
-				var/turf/simulated/floor/mineral/phazon/destination = pick(phazontiles)
+				var/turf/simulated/floor/destination = pick(phazontiles)
 				do_teleport(user, destination)
 				spawn(20)
 					spam_flag = 0

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -636,7 +636,7 @@ turf/simulated/floor/update_icon()
 				if(!spam_flag)
 					spam_flag = 1
 					if(prob(5))
-						turf/simulated/floor/mineral/phazon/destination = pick(phazontiles)
+						var/turf/simulated/floor/mineral/phazon/destination = pick(phazontiles)
 						do_teleport(AM, destination)
 					spawn(20)
 						spam_flag = 0

--- a/code/game/turfs/simulated/mineral.dm
+++ b/code/game/turfs/simulated/mineral.dm
@@ -86,12 +86,12 @@ var/global/list/turf/simulated/floor/mineral/phazon/phazontiles = list()
 
 /turf/simulated/floor/mineral/phazon/New()
 	floor_tile = new /obj/item/stack/tile/mineral/phazon(null)
-	phazontiles += src
 	..()
+	phazontiles += src
 
 /turf/simulated/floor/mineral/phazon/Destroy()
-	phazontiles -= src
 	..()
+	phazontiles -= src
 
 //BRASS
 

--- a/code/game/turfs/simulated/mineral.dm
+++ b/code/game/turfs/simulated/mineral.dm
@@ -78,12 +78,19 @@
 
 //PHAZON
 
+var/global/list/turf/simulated/floor/mineral/phazon/phazontiles = list()
+
 /turf/simulated/floor/mineral/phazon
 	name = "phazon floor"
 	icon_state = "phazon"
 
 /turf/simulated/floor/mineral/phazon/New()
 	floor_tile = new /obj/item/stack/tile/mineral/phazon(null)
+	phazontiles += src
+	..()
+
+/turf/simulated/floor/mineral/phazon/Destroy()
+	phazontiles -= src
 	..()
 
 //BRASS

--- a/code/game/turfs/simulated/mineral.dm
+++ b/code/game/turfs/simulated/mineral.dm
@@ -78,7 +78,7 @@
 
 //PHAZON
 
-var/global/list/turf/simulated/floor/mineral/phazon/phazontiles = list()
+var/global/list/turf/simulated/floor/phazontiles = list()
 
 /turf/simulated/floor/mineral/phazon
 	name = "phazon floor"

--- a/code/game/turfs/simulated/mineral.dm
+++ b/code/game/turfs/simulated/mineral.dm
@@ -78,8 +78,6 @@
 
 //PHAZON
 
-var/global/list/turf/simulated/floor/phazontiles = list()
-
 /turf/simulated/floor/mineral/phazon
 	name = "phazon floor"
 	icon_state = "phazon"
@@ -87,11 +85,6 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 /turf/simulated/floor/mineral/phazon/New()
 	floor_tile = new /obj/item/stack/tile/mineral/phazon(null)
 	..()
-	phazontiles += src
-
-/turf/simulated/floor/mineral/phazon/Destroy()
-	..()
-	phazontiles -= src
 
 //BRASS
 

--- a/code/game/turfs/simulated/mineral.dm
+++ b/code/game/turfs/simulated/mineral.dm
@@ -86,12 +86,12 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 
 /turf/simulated/floor/mineral/phazon/New()
 	floor_tile = new /obj/item/stack/tile/mineral/phazon(null)
+	phazontiles += floor_tile
 	..()
-	phazontiles += src
 
 /turf/simulated/floor/mineral/phazon/Destroy()
+	phazontiles -= floor_tile
 	..()
-	phazontiles -= src
 
 //BRASS
 

--- a/code/game/turfs/simulated/mineral.dm
+++ b/code/game/turfs/simulated/mineral.dm
@@ -86,12 +86,12 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 
 /turf/simulated/floor/mineral/phazon/New()
 	floor_tile = new /obj/item/stack/tile/mineral/phazon(null)
-	phazontiles += floor_tile
 	..()
+	phazontiles += src
 
 /turf/simulated/floor/mineral/phazon/Destroy()
-	phazontiles -= floor_tile
 	..()
+	phazontiles -= src
 
 //BRASS
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -383,6 +383,9 @@
 
 	if(istype(src,/turf/simulated/floor))
 		var/turf/simulated/floor/F = src
+		//No longer phazon, not a teleport destination
+		if(F.material=="phazon")
+			phazontiles -= src
 		if(F.floor_tile)
 			qdel(F.floor_tile)
 			F.floor_tile = null

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -32,6 +32,9 @@
 
 			playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
 			add_gamelogs(user, "deconstructed \the [T] with \the [master]", admin = TRUE, tp_link = TRUE, tp_link_short = FALSE, span_class = "danger")
+			//No longer phazon, not a teleport destination
+			if(T.material=="phazon")
+				phazontiles -= src
 			T.ChangeTurf(T.get_underlying_turf())
 			return 0
 

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -32,9 +32,6 @@
 
 			playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
 			add_gamelogs(user, "deconstructed \the [T] with \the [master]", admin = TRUE, tp_link = TRUE, tp_link_short = FALSE, span_class = "danger")
-			//No longer phazon, not a teleport destination
-			if(T.material=="phazon")
-				phazontiles -= src
 			T.ChangeTurf(T.get_underlying_turf())
 			return 0
 


### PR DESCRIPTION
[content]
[tested]

A feature idea I've had for a while now.
Original idea was to do this randomly while walking on a tile with a chance, but this seems much less annoying.
Creates a global list of all phazon tiles that gets added to when applied to plating, and removed when pried away, cultified or destroyed in any other manner. (in the code, this includes turf changes)
Calls the same process as science's teleporters, so makes sparks in the same manner.

:cl:
 * rscadd: Phazon tiles can now randomly teleport between each other when clicked with an empty hand