### PR TITLE
Being asleep now makes you unable to hear sounds

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -326,6 +326,7 @@
 			stat = UNCONSCIOUS
 		else if(sleeping)
 			sleeping = max(sleeping-1, 0)
+			ear_deaf = max(sleeping-1, 0)
 			blinded = 1
 			stat = UNCONSCIOUS
 			if( prob(10) && health )

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -254,6 +254,7 @@
 			stat = UNCONSCIOUS
 		else if(sleeping)
 			sleeping = max(sleeping-1, 0)
+			ear_deaf = max(sleeping-1, 0)
 			blinded = 1
 			stat = UNCONSCIOUS
 			if( prob(10) && health )

--- a/code/modules/mob/living/carbon/complex/life.dm
+++ b/code/modules/mob/living/carbon/complex/life.dm
@@ -301,6 +301,7 @@
 			handle_dreams()
 			adjustHalLoss(-3)
 			sleeping = max(sleeping-1, 0)
+			ear_deaf = max(sleeping-1, 0)
 			blinded = 1
 			stat = UNCONSCIOUS
 			if( prob(10) && health && !hal_crit )

--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -70,6 +70,7 @@
 			handle_dreams()
 			adjustHalLoss(-3)
 			sleeping = max(sleeping-1, 0)
+			ear_deaf = max(sleeping-1, 0)
 			blinded = 1
 			stat = UNCONSCIOUS
 			if(prob(2) && health && !hal_crit)

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -552,6 +552,7 @@
 			handle_dreams()
 			adjustHalLoss(-3)
 			sleeping = max(sleeping-1, 0)
+			ear_deaf = max(sleeping-1, 0)
 			blinded = 1
 			stat = UNCONSCIOUS
 			if( prob(10) && health && !hal_crit )


### PR DESCRIPTION
[tweak]

An example would be hearing mysterious biting sounds while asleep during surgery, when I adminhelped about if the character should know about this happening, I was told they shouldn't and shouldn't act on it, so this should help.

:cl:
 * tweak: Being asleep now makes sure that you don't hear anything happening around you