### PR TITLE
ctrl+clicking firelocks as silicon opens them without popup

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -222,7 +222,6 @@ var/global/list/alert_overlays_global = list()
 		var/obj/item/I = M.get_active_hand()
 		if((iscrowbar(I)||istype(I,/obj/item/weapon/fireaxe)) && M.a_intent == I_HURT)
 			attackby(I,M)
-			isrobot(user)
 	return 0
 
 /obj/machinery/door/firedoor/power_change()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -222,6 +222,7 @@ var/global/list/alert_overlays_global = list()
 		var/obj/item/I = M.get_active_hand()
 		if((iscrowbar(I)||istype(I,/obj/item/weapon/fireaxe)) && M.a_intent == I_HURT)
 			attackby(I,M)
+			isrobot(user)
 	return 0
 
 /obj/machinery/door/firedoor/power_change()
@@ -667,6 +668,8 @@ var/global/list/alert_overlays_global = list()
 		drop_stack(/obj/item/stack/sheet/metal, get_turf(src), 5, user)
 		qdel(src)
 
+/obj/machinery/door/firedoor/AICtrlClick(mob/user)
+	attack_ai(user,TRUE)
 
 //Removed pending a fix for atmos issues caused by full tile firelocks.
 /*

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -250,10 +250,10 @@ var/global/list/alert_overlays_global = list()
 		investigation_log(I_ATMOS, "[density ? "closed" : "opened"] [alarmed ? "while alarming" : ""] by [user.real_name] ([formatPlayerPanel(user, user.ckey)]) at [formatJumpTo(get_turf(src))]")
 
 /obj/machinery/door/firedoor/CtrlClick(mob/user)
-	if(isAdminGhost(user))
-		attack_ai(user,TRUE)
-	else
-		..()
+    if(isrobot(user) || isAdminGhost(user))
+        attack_ai(user, TRUE)
+    else
+        ..()
 
 /obj/machinery/door/firedoor/attack_hand(mob/user as mob)
 	return do_interaction(user)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -250,10 +250,10 @@ var/global/list/alert_overlays_global = list()
 		investigation_log(I_ATMOS, "[density ? "closed" : "opened"] [alarmed ? "while alarming" : ""] by [user.real_name] ([formatPlayerPanel(user, user.ckey)]) at [formatJumpTo(get_turf(src))]")
 
 /obj/machinery/door/firedoor/CtrlClick(mob/user)
-    if(isrobot(user) || isAdminGhost(user))
-        attack_ai(user, TRUE)
-    else
-        ..()
+	if(isrobot(user) || isAdminGhost(user))
+		attack_ai(user, TRUE)
+	else
+		..()
 
 /obj/machinery/door/firedoor/attack_hand(mob/user as mob)
 	return do_interaction(user)


### PR DESCRIPTION
**imagine the following:**

the survivors of the latest depressurization event are trying to reach escape, but all these pesky firelocks are in their way! you, a good, humble AI player, are trying to open these firelocks, but you get this prompt that's like 'are you SURE???' and it takes you too many seconds to click yes before people just pause and crowbar them open anyways. now you feel like a useless piece of shit because your super special role of interfacing with the station just got replaced by a bent piece of metal. what if i told you it didn't have to be this way?

:cl:
 * rscadd: new hotkey — ctrl+clicking firedoors allows silicons to quickly open them