### PR TITLE
Teleports stop accepting sparks from nearby ones

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -192,6 +192,9 @@
 	return TRUE
 
 /datum/teleport/instant/science/teleportChecks(var/ignore_jamming = FALSE)
+	if(istype(teleatom, /obj/effect/effect/sparks)) // Don't teleport sparks or the server dies
+		return FALSE
+	
 	if(istype(teleatom, /obj/item/weapon/disk/nuclear)) // Don't let nuke disks get teleported --NeoFite
 		teleatom.visible_message("<span class='danger'>\The [teleatom] bounces off of the portal!</span>")
 		return FALSE


### PR DESCRIPTION
Closes #29110.
[bugfix]
Pretty sure sparks are movable atoms and that's why they get teleported, this hopefully fixes it

:cl:
 * bugfix: Sparks from nearby items (including other teleportations) no longer get caught up in nearby teleporters