### PR TITLE
Advanced reagent scanners now display time reagents have been in system, if has effects

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -540,7 +540,7 @@ Subject's pulse: ??? BPM"})
 		if(O.reagents.reagent_list.len)
 			for(var/datum/reagent/R in O.reagents.reagent_list)
 				var/reagent_percent = (R.volume/O.reagents.total_volume)*100
-				dat += "<br><span class='notice'>[R] [details ? "([R.volume] units, [reagent_percent]%[R.data && !istype(R,/datum/reagent/citalopram) && !istype(R,/datum/reagent/paroxetine) && !istype(R,/datum/reagent/incense) && !istype(R,/datum/reagent/antipathogenic) && !istype(R,/datum/reagent/vaccine) ? ", time in system: [R.data] seconds" : ""])" : ""]</span>"
+				dat += "<br><span class='notice'>[R] [details ? "([R.volume] units, [reagent_percent]%[R.data && !istype(R,/datum/reagent/citalopram) && !istype(R,/datum/reagent/paroxetine) && !istype(R,/datum/reagent/incense) && !istype(R,/datum/reagent/antipathogenic) && !istype(R,/datum/reagent/vaccine) ? ", time in system: [R.data*2] seconds" : ""])" : ""]</span>"
 		if(dat)
 			to_chat(user, "<span class='notice'>Chemicals found in \the [O]:[dat]</span>")
 		else

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -540,7 +540,7 @@ Subject's pulse: ??? BPM"})
 		if(O.reagents.reagent_list.len)
 			for(var/datum/reagent/R in O.reagents.reagent_list)
 				var/reagent_percent = (R.volume/O.reagents.total_volume)*100
-				dat += "<br><span class='notice'>[R] [details ? "([R.volume] units, [reagent_percent]%)" : ""]</span>"
+				dat += "<br><span class='notice'>[R] [details ? "([R.volume] units, [reagent_percent]%[R.data ? ", time in system: [R.data] seconds" : ""])" : ""]</span>"
 		if(dat)
 			to_chat(user, "<span class='notice'>Chemicals found in \the [O]:[dat]</span>")
 		else

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -540,7 +540,7 @@ Subject's pulse: ??? BPM"})
 		if(O.reagents.reagent_list.len)
 			for(var/datum/reagent/R in O.reagents.reagent_list)
 				var/reagent_percent = (R.volume/O.reagents.total_volume)*100
-				dat += "<br><span class='notice'>[R] [details ? "([R.volume] units, [reagent_percent]%[R.data ? ", time in system: [R.data] seconds" : ""])" : ""]</span>"
+				dat += "<br><span class='notice'>[R] [details ? "([R.volume] units, [reagent_percent]%[R.data && !istype(R,/datum/reagent/citalopram) && !istype(R,/datum/reagent/paroxetine) && !istype(R,/datum/reagent/incense) && !istype(R,/datum/reagent/antipathogenic) && !istype(R,/datum/reagent/vaccine) ? ", time in system: [R.data] seconds" : ""])" : ""]</span>"
 		if(dat)
 			to_chat(user, "<span class='notice'>Chemicals found in \the [O]:[dat]</span>")
 		else


### PR DESCRIPTION
Specifically, it accesses the data variable which is only ever set and called in on_mob_life() of these reagents, so it's not possible to display it for everything. (since it defaults to null and there's a check to display nothing if it's null)

:cl:
 * rscadd: Advanced reagent scanners will now show you how long a reagent has been in the subject's system, if it has a time based effect.