### PR TITLE
Unlocking air alarms and APC's by alt-clicking

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1584,6 +1584,11 @@ var/global/list/firealarms = list() //shrug
 	if(wires)
 		wires.npc_tamper(L)
 
-
+/obj/machinery/alarm/AltClick(mob/user)
+	if(!user.incapacitated() && Adjacent(user) && user.dexterity_check() && allowed(user))
+		locked = !locked
+		to_chat(user, "You [locked ? "" : "un"]lock \the [src] interface.")
+		update_icon()
+	return ..()
 
 #undef CHECKED_GAS

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1410,5 +1410,13 @@ obj/machinery/power/apc/proc/autoset(var/val, var/on)
 	if(wires)
 		wires.npc_tamper(L)
 
+/obj/machinery/power/apc/AltClick(mob/user)
+	if(!user.incapacitated() && Adjacent(user) && user.dexterity_check() && allowed(user))
+		locked = !locked
+		to_chat(user, "You [locked ? "" : "un"]lock \the [src] interface.")
+		update_icon()
+	return ..()
+
+
 
 #undef APC_UPDATE_ICON_COOLDOWN


### PR DESCRIPTION
What it says on the tin. No more will engineers be fumbling with their ID's when setting up a supermatter engine.
[tweak]

:cl:
 * rscadd: You can now lock/unlock APC's and air alarms by alt-clicking them.