### PR TITLE
Revert "Revert "Paroles *dab"". Don't be a selfmerging retard, Shifty. At least wait for another metamin to merge your PR.

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -220,10 +220,12 @@
 
 /datum/emote/living/carbon/human/dab/can_run_emote(mob/user, var/status_check = TRUE)
 	var/mob/living/carbon/human/H = user
-	if (iswizard(H))
+	if(iswizard(H))
 		to_chat(user, "<span class='warning'>The Wizard Federation has banned usage of the [key].</span>")
 		return FALSE
 	if(H.has_organ(LIMB_LEFT_ARM) && H.has_organ(LIMB_RIGHT_ARM))
+		if((Holiday == APRIL_FOOLS_DAY) || (IS_WEEKEND))
+			return TRUE
 		if(user.stat > stat_allowed)
 			to_chat(user, "<span class='warning'>You cannot [key] while unconscious.</span>")
 			return FALSE


### PR DESCRIPTION
Reverts vgstation-coders/vgstation13#29139
Shifty selfmerged the PR that removed the paroled *dab functionality. Here's to restoring it, since that's what the people wanted.
