### PR TITLE
Fixes PDA alarm app

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1591,9 +1591,14 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		if("setAlarm")
 			var/datum/pda_app/alarm/app = locate(/datum/pda_app/alarm) in applications
 			if(app)
-				var/nutime = round(input("How long before the alarm triggers, in minutes?", "Alarm", 1) as num)
+				var/nutime = round(input("How long before the alarm triggers, in seconds?", "Alarm", 1) as num)
 				if(app.set_alarm(nutime))
-					to_chat(usr, "[bicon(src)]<span class='info'>The PDA confirms your [nutime] minute timer.</span>")
+					to_chat(usr, "[bicon(src)]<span class='info'>The PDA confirms your [nutime] second timer.</span>")
+		if("restartAlarm")
+			var/datum/pda_app/alarm/app = locate(/datum/pda_app/alarm) in applications
+			if(app && app.restart_alarm())
+				to_chat(usr, "[bicon(src)]<span class='info'>The PDA confirms your [app.lasttimer] second timer.</span>")
+				no_refresh = 1
 		if("101")//PDA_APP_RINGER
 			mode = PDA_APP_RINGER
 		if("toggleDeskRinger")
@@ -2140,7 +2145,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 								difficulty += P.cartridge.access_manifest * 2
 							else
 								difficulty += 2
-							
+
 							if(P.hidden_uplink)
 								U.show_message("<span class='warning'>An error flashes on your [src]; [pick(syndicate_code_response)]</span>", 1)
 								U << browse(null, "window=pda")

--- a/code/game/objects/items/devices/PDA/apps.dm
+++ b/code/game/objects/items/devices/PDA/apps.dm
@@ -51,21 +51,29 @@ var/global/list/pda_app_menus = list(
 	icon = "pda_clock"
 	var/target = 0
 	var/status = 1			//	0=off 1=on
+	var/lasttimer = 0
 
 /datum/pda_app/alarm/proc/set_alarm(var/await)
 	if(await<=0)
 		return FALSE
-	target = world.time + (await MINUTES)
-	spawn((await MINUTES) + 1 SECONDS)
+	target = world.time + (await SECONDS)
+	lasttimer = await
+	spawn((await SECONDS) + 1 SECONDS)
 		alarm()
 	return TRUE
 
 /datum/pda_app/alarm/proc/alarm()
 	if(!status || world.time < target)
-		return //End the loop if if was disabled or if the target isn't here yet. e.g.: target changed
+		return //End the loop if it was disabled or if the target isn't here yet. e.g.: target changed
 	playsound(pda_device, 'sound/machines/chime.ogg', 200, FALSE)
-	sleep(1 SECONDS)
-	alarm()
+	var/mob/living/L = get_holder_of_type(pda_device,/mob/living)
+	if(L)
+		to_chat(usr, "[bicon(pda_device)]<span class='info'>Timer for [lasttimer] seconds has finished. <a href='byond://?src=\ref[pda_device];choice=restartAlarm'>(Restart?)</a></span>")
+
+/datum/pda_app/alarm/proc/restart_alarm()
+	if(!status || world.time < target || lasttimer <= 0)
+		return //End the loop if it was disabled or already active
+	return set_alarm(lasttimer)
 
 /datum/pda_app/light_upgrade
 	name = "PDA Flashlight Enhancer"

--- a/code/game/objects/items/devices/PDA/apps.dm
+++ b/code/game/objects/items/devices/PDA/apps.dm
@@ -65,7 +65,7 @@ var/global/list/pda_app_menus = list(
 /datum/pda_app/alarm/proc/alarm()
 	if(!status || world.time < target)
 		return //End the loop if it was disabled or if the target isn't here yet. e.g.: target changed
-	playsound(pda_device, 'sound/machines/chime.ogg', 200, FALSE)
+	playsound(pda_device, 'sound/machines/chime.ogg', 40, FALSE, -2)
 	var/mob/living/L = get_holder_of_type(pda_device,/mob/living)
 	if(L)
 		to_chat(usr, "[bicon(pda_device)]<span class='info'>Timer for [lasttimer] seconds has finished. <a href='byond://?src=\ref[pda_device];choice=restartAlarm'>(Restart?)</a></span>")


### PR DESCRIPTION
Apparently nobody has ever used the alarm app, or they would have noticed that it just turns your PDA into a nonstop noise machine

Fixes #25147

:cl:
 * bugfix: Fixed the PDA alarm app. It also now supports time in seconds and has a fast reset button.