### PR TITLE
Lowers revsquad threat cost

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -404,8 +404,8 @@
 	required_pop = list(25,25,25,25,25,20,15,15,10,10)
 	required_candidates = 3
 	weight = 10
-	cost = 45
-	requirements = list(101,101,90,60,45,45,45,45,45,45)
+	cost = 35
+	requirements = list(90, 90, 90, 80, 60, 40, 30, 20, 10, 10)
 	high_population_requirement = 50
 	my_fac = /datum/faction/revolution
 	logo = "rev-logo"


### PR DESCRIPTION
[gamemode]
[tweak]

As it currently stands, this midround rule has only fired thrice in the past year (6th June, 13th July and 5th November) without admins forcing it.
This reduces the overall cost and minimum threat requirements per population bracket to match nuclear assaults. (ie. Cost reduced from 45 to 35)
:cl:
 * tweak: Revolutionary squads now require less local threat to besiege your station