### PR TITLE
Blunts now use the entirety of the ambrosia's reagents.

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -619,7 +619,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 
 	lit_attack_verb = list("burns", "singes", "blunts")
 	smoketime = 420
-	chem_volume = 50 //It's a fat blunt, a really fat blunt
+	chem_volume = 100 //It's a fat blunt, a really fat blunt
 
 /obj/item/clothing/mask/cigarette/blunt/rolled //grown.dm handles reagents for these
 


### PR DESCRIPTION
An ambrosia leaf can have up to 100u of reagents, but you lose 50u when turning it into a blunt, so, for [consistency], the blunts now have a volume of 100u. 
[bugfix]
:cl:
 * tweak: Blunts have a reagent capacity of 100u now.