### PR TITLE
Allow players to change their vote after they cast it

### DIFF
--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -45,7 +45,7 @@
 	desc = "Charred circuit in melted plastic case. Wonder what that used to be..."
 	icon_state = "implant_melted"
 	malfunction = IMPLANT_MALFUNCTION_PERMANENT
-	
+
 /obj/item/weapon/implant/proc/makeunusable(var/probability=50)
 	if(prob(probability))
 		visible_message("<span class='warning'>\The [src] fizzles and sparks!</span>")
@@ -53,7 +53,7 @@
 		desc = "Charred circuit in melted plastic case."
 		icon_state = "implant_melted"
 		malfunction = IMPLANT_MALFUNCTION_PERMANENT
-	
+
 /obj/item/weapon/implant/Destroy()
 	if(part)
 		part.implants.Remove(src)
@@ -147,7 +147,7 @@
 
 /obj/item/weapon/implant/explosive/islegal()
 	return 0
-	
+
 /obj/item/weapon/implant/explosive/handle_removal(var/mob/remover)
 	makeunusable(75)
 
@@ -355,7 +355,7 @@ the implant may become unstable and either pre-maturely inject the subject or si
 		return
 	log_admin("[key_name(remover)] has removed a greytide implant from [key_name(imp_in)].")
 	R.Drop(FALSE)
-	
+
 	makeunusable(90)
 
 /obj/item/weapon/implant/adrenalin
@@ -507,7 +507,7 @@ the implant may become unstable and either pre-maturely inject the subject or si
 /obj/item/weapon/implant/compressed/trigger(emote, mob/source as mob)
 	if(malfunction == IMPLANT_MALFUNCTION_PERMANENT)
 		return 0
-		
+
 	if (src.scanned == null)
 		return 0
 
@@ -640,6 +640,6 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	else
 		to_chat(H, "<span class = 'notice'>You hear the soothing millennia-old Gregorian chants of the clergy.</span>")
 	return 1
-	
+
 /obj/item/weapon/implant/holy/handle_removal(var/mob/remover)
 	makeunusable(15)

--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -270,7 +270,7 @@ var/global/datum/controller/vote/vote = new()
 						return 0
 		if(current_votes[mob_ckey])
 			choices[choices[current_votes[mob_ckey]]]--
-		if(vote && 1<=vote && vote<=choices.len)
+		if(vote && vote != "Cancel" && 1<=vote && vote<=choices.len)
 			voted += mob_ckey
 			choices[choices[vote]]++	//check this
 			current_votes[mob_ckey] = vote
@@ -445,6 +445,13 @@ var/global/datum/controller/vote/vote = new()
 	if(!usr || !usr.client)
 		return	//not necessary but meh...just in-case somebody does something stupid
 	switch(href_list["vote"])
+		if ("cancel_vote")
+			var/mob_ckey = usr.ckey
+			voted -= mob_ckey
+			choices[choices[current_votes[mob_ckey]]]--
+			current_votes[mob_ckey] = null
+			src.updateFor(usr.client)
+			return 0
 		if("cancel")
 			if(usr.client.holder)
 				reset()

--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -270,7 +270,7 @@ var/global/datum/controller/vote/vote = new()
 						return 0
 		if(current_votes[mob_ckey])
 			choices[choices[current_votes[mob_ckey]]]--
-		if(vote && vote != "Cancel" && 1<=vote && vote<=choices.len)
+		if(vote && vote != "cancel_vote" && 1<=vote && vote<=choices.len)
 			voted += mob_ckey
 			choices[choices[vote]]++	//check this
 			current_votes[mob_ckey] = vote

--- a/code/modules/html_interface/voting/voting.js
+++ b/code/modules/html_interface/voting/voting.js
@@ -44,7 +44,6 @@ function update_mode(newMode, newQuestion, newTimeleft, vrestart, vmode){
 		$("#vote_main").append($("<div  class='item'></div>").append($("<div class='itemContent'></div>").html("<font color='grey'>Restart</font>")));
 		$("#vote_main").append($("<div  class='item'></div>").append($("<div class='itemContent'></div>").html("<font color='grey'>Crew Transfer</font>")));
 	}
-	
 	if(admin > 0 || allow_mode > 0){
 		$("#vote_main").append($("<div  class='item'></div>").append($("<div class='itemContent'></div>").html("<a href='?src=" + hSrc + ";vote=gamemode'>GameMode</a>" + (admin == 2 ? "(<a href='?src=" + hSrc + ";vote=toggle_gamemode'>" + (allow_mode?"Allowed":"Disallowed") + "</a>)" : ""))));
 	}
@@ -55,6 +54,7 @@ function update_mode(newMode, newQuestion, newTimeleft, vrestart, vmode){
 	if(mode != null && mode != ""){
 		$("#vote_main").hide();
 		$("#vote_choices").show();
+		$("#vote_choices").append($("<div class='item'></div>").append($("<div class='itemContent'></div>").html("<a "  +  "href='?src=" + hSrc + ";vote=cancel_vote" + "'>Cancel your vote</a>")));
 		if(admin > 0) $("#vote_admin").show();
 	}
 	else{
@@ -62,7 +62,7 @@ function update_mode(newMode, newQuestion, newTimeleft, vrestart, vmode){
 		$("#vote_choices").hide();
 		$("#vote_admin").hide();
 	}
-	
+
 }
 
 function update_choices(ID, choice, votes){

--- a/nano/templates/vote.tmpl
+++ b/nano/templates/vote.tmpl
@@ -1,7 +1,7 @@
 <!--
 Title: Vote UI
 Used in File(s): \code\controllers\voting.dm
---> 
+-->
 <style type='text/css'>
 	p {
 		white-space: normal;
@@ -40,6 +40,11 @@ Used in File(s): \code\controllers\voting.dm
 			</div>
 		</div>
 	{{/for}}
+	<div class = "item">
+		<div class = "itemContent">
+			{{:helper.link('Cancel your vote', null, { 'cancel_vote' : 1})}}
+		</div>
+	</div>
 	{{if data.admin == 1}}
 		<div class = "item">
 			<div class="itemContent">

--- a/nano/templates/vote.tmpl
+++ b/nano/templates/vote.tmpl
@@ -42,7 +42,7 @@ Used in File(s): \code\controllers\voting.dm
 	{{/for}}
 	<div class = "item">
 		<div class = "itemContent">
-			{{:helper.link('Cancel your vote', null, { 'cancel_vote' : 1})}}
+			{{:helper.link('Cancel your vote', null, { 'vote' : 'cancel_vote'})}}
 		</div>
 	</div>
 	{{if data.admin == 1}}


### PR DESCRIPTION
Made after gathering feedback related to that. You will now be able to cancel your vote by clicking on a button next to the vote options.
I tested this by also implementing also for custom votes.

On a more technical note, the nanoUI interface for voting is outdated and not used anymore. The voting panel uses the HTML+JS Ui abomination instead. In the event that someone re-uses the oven-ready nanoUI interface template instead, the function is also implemented there.

:cl:
- tweak: Players can now cancel their vote in a custom vote or a map vote.