### PR TITLE
FTL ship, space vaults fix

### DIFF
--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2696,8 +2696,6 @@
 #include "maps\randomvaults\objects.dm"
 #include "maps\randomvaults\sokoban.dm"
 #include "maps\randomvaults\spessmart.dm"
-#include "maps\randomvaults\droneship.dmm"
-#include "maps\randomvaults\lightspeedship.dmm"
 #include "maps\randomvaults\snaxi\snaxivault_defines.dm"
 #include "maps\RandomZLevels\Academy.dm"
 #include "maps\RandomZLevels\challenge.dm"


### PR DESCRIPTION
<hotfix> Reverts a change to the .dme that was accidentally left in #29132 from unrelated testing which messed up the FTL and drone ship vaults.
:cl:
 * rscadd: ftl ship and drone ship generate correctly again