### PR TITLE
Renames "Anti-Toxin (Dylovene)" to just "Dylovene".

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -424,7 +424,7 @@
 	..()
 	flags |= NOREACT
 	syringes = new
-	known_reagents = list(INAPROVALINE="Inaprovaline",ANTI_TOXIN="Anti-Toxin (Dylovene)")
+	known_reagents = list(INAPROVALINE="Inaprovaline",ANTI_TOXIN="Dylovene")
 	processed_reagents = new
 	create_reagents(max_volume)
 	synth = new (list(src),0)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -674,7 +674,7 @@
 		T.dry(TURF_WET_LUBE) //Absorbs water or lube
 
 /datum/reagent/anti_toxin
-	name = "Anti-Toxin (Dylovene)"
+	name = "Dylovene"
 	id = ANTI_TOXIN
 	description = "Dylovene is a broad-spectrum antitoxin."
 	reagent_state = REAGENT_STATE_LIQUID

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -173,7 +173,7 @@
 	result_amount = 3
 
 /datum/chemical_reaction/anti_toxin
-	name = "Anti-Toxin (Dylovene)"
+	name = "Dylovene"
 	id = ANTI_TOXIN
 	result = ANTI_TOXIN
 	required_reagents = list(SILICON = 1, POTASSIUM = 1, NITROGEN = 1)


### PR DESCRIPTION
Copy of #16996

The (Anti-Toxin) prefix is a bit odd, and is not used on any other type of medicine. 
On a side note, it's really annoying renaming your pills for fridge consistency.

[consistency] [tweak]
-->
:cl:
 * tweak: Anti-Toxin (Dylovene) is now just Dylovene.