### PR TITLE
Two budgets for dynamic mode

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -21,8 +21,14 @@ var/stacking_limit = 90
 	//Threat logging vars
 	var/threat_level = 0//the "threat cap", threat shouldn't normally go above this and is used in ruleset calculations
 	var/starting_threat = 0 //threat_level's initially rolled value. Threat_level isn't changed by many things.
-	var/threat = 0//set at the beginning of the round. Spent by the mode to "purchase" rules.
+	var/threat = 0//set at the beginning of the round. Spent by the mode to "purchase"  roundstart rules.
 	var/list/threat_log = list() //Running information about the threat. Can store text or datum entries.
+
+	// Midround threat
+	var/midround_threat_level = 0
+	var/midround_starting_threat = 0
+	var/midround_threat = 0
+	var/list/midround_threat_log = list()
 
 	var/list/roundstart_rules = list()
 	var/list/latejoin_rules = list()
@@ -64,8 +70,8 @@ var/stacking_limit = 90
 /datum/gamemode/dynamic/AdminPanelEntry()
 	var/dat = list()
 	dat += "Dynamic Mode <a href='?_src_=vars;Vars=\ref[src]'>\[VV\]</A><BR>"
-	dat += "Threat Level: <b>[threat_level]</b><br/>"
-	dat += "Threat to Spend: <b>[threat]</b> <a href='?_src_=holder;adjustthreat=1'>\[Adjust\]</A> <a href='?_src_=holder;threatlog=1'>\[View Log\]</a><br/>"
+	dat += "Threat Level: <b>[threat_level]</b>, in-round injection threat level: <b>[midround_threat_level]</b><br/>"
+	dat += "Threat to Spend: <b>[midround_threat]</b> <a href='?_src_=holder;adjustthreat=1'>\[Adjust\]</A> <a href='?_src_=holder;threatlog=1'>\[View Log\]</a><br/>"
 	dat += "<br/>"
 	dat += "Parameters: centre = [curve_centre_of_round] ; width = [curve_width_of_round].<br/>"
 	dat += "<i>On average, <b>[peaceful_percentage]</b>% of the rounds are more peaceful.</i><br/>"
@@ -123,7 +129,7 @@ var/stacking_limit = 90
 	if(!admin.check_rights(R_ADMIN) && (ticker.current_state != GAME_STATE_FINISHED))
 		return
 
-	var/out = "<TITLE>Threat Log</TITLE><B><font size='3'>Threat Log</font></B><br><B>Starting Threat:</B> [starting_threat]<BR>"
+	var/out = "<TITLE>Threat Log</TITLE><B><font size='3'>Threat Log</font></B><br><B>Starting Threat:</B> [starting_threat], <b>midround</b>: [midround_starting_threat]<BR>"
 
 	for(var/entry in threat_log)
 		if(istext(entry))
@@ -132,7 +138,8 @@ var/stacking_limit = 90
 			var/datum/role/catbeast/C = entry
 			out += "Catbeast threat regenerated/threat_level inflated: [C.threat_generated]/[C.threat_level_inflated]<BR>"
 
-	out += "<B>Remaining threat/threat_level:</B> [threat]/[threat_level]"
+	out += "<B>Remaining threat/threat_level:</B> [threat]/[threat_level]<br/>"
+	out += "<B>Remaining midround threat/threat_level:</B> [midround_threat]/[midround_threat_level]"
 
 	usr << browse(out, "window=threatlog;size=700x500")
 
@@ -187,8 +194,8 @@ var/stacking_limit = 90
 	var/midround_injection_cooldown_middle = 0.5*(MIDROUND_DELAY_MAX + MIDROUND_DELAY_MIN)
 	midround_injection_cooldown = round(clamp(exp_distribution(midround_injection_cooldown_middle), MIDROUND_DELAY_MIN, MIDROUND_DELAY_MAX))
 
-	message_admins("Dynamic Mode initialized with a Threat Level of... <font size='8'>[threat_level]</font>!")
-	log_admin("Dynamic Mode initialized with a Threat Level of... [threat_level]!")
+	message_admins("Dynamic Mode initialized with a Threat Level of... <font size='8'>[threat_level]</font> and <font size='8'>[midround_threat_level]</font> for midround!")
+	log_admin("Dynamic Mode initialized with a Threat Level of... [threat_level] and [midround_threat_level]</font> for midround!")
 
 	message_admins("Parameters were: centre = [curve_centre_of_round], width = [curve_width_of_round].")
 	log_admin("Parameters were: centre = [curve_centre_of_round], width = [curve_width_of_round].")
@@ -454,8 +461,8 @@ var/stacking_limit = 90
 	if (latejoin_rule)
 		if (!latejoin_rule.repeatable)
 			latejoin_rules = remove_rule(latejoin_rules,latejoin_rule.type)
-		spend_threat(latejoin_rule.cost)
-		threat_log += "[worldtime2text()]: Latejoin [latejoin_rule.name] spent [latejoin_rule.cost]"
+		spend_midround_threat(latejoin_rule.cost)
+		threat_log += "[worldtime2text()]: Latejoin [latejoin_rule.name] spent [latejoin_rule.cost] (midround budget)"
 		dynamic_stats.measure_threat(threat)
 		if (latejoin_rule.execute())//this should never fail since ready() returned 1
 			var/mob/M = pick(latejoin_rule.assigned)
@@ -473,8 +480,8 @@ var/stacking_limit = 90
 	if (midround_rule)
 		if (!midround_rule.repeatable)
 			midround_rules = remove_rule(midround_rules,midround_rule.type)
-		spend_threat(midround_rule.cost)
-		threat_log += "[worldtime2text()]: Midround [midround_rule.name] spent [midround_rule.cost]"
+		spend_midround_threat(midround_rule.cost)
+		threat_log += "[worldtime2text()]: Midround [midround_rule.name] spent [midround_rule.cost] (midround budget)"
 		dynamic_stats.measure_threat(threat)
 		if (midround_rule.execute())//this should never fail since ready() returned 1
 			message_admins("DYNAMIC MODE: Injecting some threats...<font size='3'>[midround_rule.name]</font>!")
@@ -562,13 +569,13 @@ var/stacking_limit = 90
 			current_players[CURRENT_DEAD_PLAYERS] = dead_players.Copy()
 			current_players[CURRENT_OBSERVERS] = list_observers.Copy()
 			for (var/datum/dynamic_ruleset/midround/rule in midround_rules)
-				if (rule.acceptable(living_players.len,threat_level) && threat >= rule.cost)
+				if (rule.acceptable(living_players.len,midround_threat_level) && midround_threat >= rule.cost)
 					// Classic secret : only autotraitor/minor roles
 					if (classic_secret && !((rule.flags & TRAITOR_RULESET) || (rule.flags & MINOR_RULESET)))
 						message_admins("[rule] was refused because we're on classic secret mode.")
 						continue
 					// No stacking : only one round-enter, unless > stacking_limit threat.
-					if (threat < stacking_limit && no_stacking)
+					if (midround_threat < stacking_limit && no_stacking)
 						var/skip_ruleset = 0
 						for (var/datum/dynamic_ruleset/DR in executed_rules)
 							if ((DR.flags & HIGHLANDER_RULESET) && (rule.flags & HIGHLANDER_RULESET))
@@ -677,13 +684,13 @@ var/stacking_limit = 90
 	else if (!latejoin_injection_cooldown && injection_attempt())
 		var/list/drafted_rules = list()
 		for (var/datum/dynamic_ruleset/latejoin/rule in latejoin_rules)
-			if (rule.acceptable(living_players.len,threat_level) && threat >= rule.cost)
+			if (rule.acceptable(living_players.len,midround_threat_level) && midround_threat >= rule.cost)
 				// Classic secret : only autotraitor/minor roles
 				if (classic_secret && !((rule.flags & TRAITOR_RULESET) || (rule.flags & MINOR_RULESET)))
 					message_admins("[rule] was refused because we're on classic secret mode.")
 					continue
 				// No stacking : only one round-enter, unless > stacking_limit threat.
-				if (threat < stacking_limit && no_stacking)
+				if (midround_threat < stacking_limit && no_stacking)
 					var/skip_ruleset = 0
 					for (var/datum/dynamic_ruleset/DR in executed_rules)
 						if ((DR.flags & HIGHLANDER_RULESET) && (rule.flags & HIGHLANDER_RULESET))
@@ -718,6 +725,18 @@ var/stacking_limit = 90
 //Expend threat, but do not fall below 0.
 /datum/gamemode/dynamic/proc/spend_threat(var/cost)
 	threat = max(threat-cost,0)
+
+// Same as above, but for midround
+/datum/gamemode/dynamic/proc/refund_midround_threat(var/regain)
+	threat = min(midround_threat_level,midround_threat+regain)
+
+/datum/gamemode/dynamic/proc/create_midround_threat(var/gain)
+	midround_threat = min(100, midround_threat+gain)
+	if(midround_threat>midround_threat_level)
+		midround_threat_level = midround_threat
+
+/datum/gamemode/dynamic/proc/spend_midround_threat(var/cost)
+	midround_threat = max(midround_threat-cost,0)
 
 // -- For the purpose of testing & simulation.
 /datum/gamemode/dynamic/proc/simulate_roundstart(var/mob/user = usr)

--- a/code/datums/gamemode/dynamic/dynamic_maths.dm
+++ b/code/datums/gamemode/dynamic/dynamic_maths.dm
@@ -22,7 +22,7 @@
 		// Porportional conversion from the lorentz variable to the threat.
 
 		// First, we use a rule of three to get a number from -40 to -30.
-		// Then we shift it by 50 to get a number from 10 to 20. 
+		// Then we shift it by 50 to get a number from 10 to 20.
 		// The same process is done for other intervalls.
 		if (-20 to -10)
 			y = RULE_OF_THREE(-40, -20, x) + 50
@@ -45,7 +45,7 @@
 
 		if (20 to INFINITY)
 			y = rand(90, 100)
-	
+
 	return y
 
 // Same as above, but for a Gaussian law, which has much shorter tails.
@@ -78,7 +78,7 @@
 
 		if (20 to INFINITY)
 			y = rand(90, 100)
-	
+
 	return y
 
 // Exp gives us something between 0 and 5 ; we just convert it to something between 0 and 100.
@@ -110,6 +110,11 @@
 			threat = threat_level
 			starting_threat = threat_level
 
+			relative_threat = lorentz_distribution(dynamic_curve_centre, dynamic_curve_width)
+			midround_threat_level = lorentz2threat(relative_threat)
+			midround_threat = midround_threat_level
+			midround_starting_threat = midround_threat_level
+
 		if (GAUSS)
 			relative_threat = dynamic_curve_centre + GaussRand(dynamic_curve_width)
 			threat_level = Gauss2threat(relative_threat)
@@ -122,10 +127,20 @@
 			threat = threat_level
 			starting_threat = threat_level
 
+			relative_threat = lorentz_distribution(dynamic_curve_centre, dynamic_curve_width)
+			midround_threat_level = Gauss2threat(relative_threat)
+			midround_threat = midround_threat_level
+			midround_starting_threat = midround_threat_level
+
 		if (DIRAC)
 			threat = dynamic_curve_centre
 			threat_level = dynamic_curve_centre
 			starting_threat = threat_level
+
+			midround_threat = dynamic_curve_centre
+			midround_threat_level = dynamic_curve_centre
+			midround_starting_threat = threat_level
+
 			peaceful_percentage = "Undefined"
 
 		if (EXPONENTIAL)
@@ -140,8 +155,16 @@
 			threat = threat_level
 			starting_threat = threat_level
 
+			relative_threat = exp_distribution(dynamic_curve_centre)
+			midround_threat_level = exp2threat(relative_threat)
+			midround_starting_threat = midround_threat_level
+			midround_threat = midround_threat_level
+
 		if (UNIFORM)
 			threat_level = rand(1, 100)
 			threat = threat_level
 			starting_threat = threat_level
+			midround_threat_level = rand(1, 100)
+			midround_threat = threat_level
+			midround_starting_threat = threat_level
 			peaceful_percentage = "Undefined"

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -57,7 +57,6 @@
 
 /datum/dynamic_ruleset/latejoin//Can be drafted when a player joins the server
 
-
 /datum/dynamic_ruleset/proc/acceptable(var/population=0,var/threat_level=0)
 	//by default, a rule is acceptable if it satisfies the threat level/population requirements.
 	//If your rule has extra checks, such as counting security officers, do that in ready() instead
@@ -181,7 +180,7 @@
 		if(!applicants || applicants.len <= 0)
 			log_admin("DYNAMIC MODE: [name] received no applications.")
 			message_admins("DYNAMIC MODE: [name] received no applications.")
-			mode.refund_threat(cost)
+			mode.refund_midround_threat(cost)
 			mode.threat_log += "[worldtime2text()]: Rule [name] refunded [cost] (no applications)"
 			mode.executed_rules -= src
 			return

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -90,7 +90,7 @@
 		if(applicants.len <= 0)
 			if(i == candidate_checks)
 				//We have found no candidates so far and we are out of applicants.
-				mode.refund_threat(cost)
+				mode.refund_midround_threat(cost)
 				mode.threat_log += "[worldtime2text()]: Rule [name] refunded [cost] (all applications invalid)"
 				mode.executed_rules -= src
 			break
@@ -178,7 +178,7 @@
 	var/player_count = mode.living_players.len
 	var/antag_count = mode.living_antags.len
 	var/max_traitors = round(player_count / 10) + 1
-	if ((antag_count < max_traitors) && prob(mode.threat_level))//adding traitors if the antag population is getting low
+	if ((antag_count < max_traitors) && prob(mode.midround_threat_level))//adding traitors if the antag population is getting low
 		return ..()
 	else
 		return 0
@@ -452,7 +452,7 @@
 	var/player_count = mode.living_players.len
 	var/antag_count = mode.living_antags.len
 	var/max_traitors = round(player_count / 10) + 1
-	if ((antag_count < max_traitors) && prob(mode.threat_level))
+	if ((antag_count < max_traitors) && prob(mode.midround_threat_level))
 		return ..()
 	else
 		return 0
@@ -552,8 +552,8 @@
 	flags = MINOR_RULESET
 
 /datum/dynamic_ruleset/midround/from_ghosts/catbeast/acceptable(var/population=0,var/threat=0)
-	if(mode.threat>50) //We're threatening enough!
-		message_admins("Rejected catbeast ruleset, [mode.threat] threat was over 50.")
+	if(mode.midround_threat>50) //We're threatening enough!
+		message_admins("Rejected catbeast ruleset, [mode.midround_threat] threat was over 50.")
 		return FALSE
 	if(!..())
 		message_admins("Rejected catbeast ruleset. Not enough threat somehow??")
@@ -662,7 +662,7 @@
 		if(temp_vent.loc.z == map.zMainStation && !temp_vent.welded && temp_vent.network)
 			if(temp_vent.network.normal_members.len > 50)	//Stops Aliens getting stuck in small networks. See: Security, Virology
 				vents += temp_vent
-	
+
 
 	if (vents.len == 0)
 		message_admins("A suitable vent couldn't be found for alien larva. That's bad.")
@@ -703,7 +703,7 @@
 	required_candidates = 1
 	weight = 1
 	cost = 0
-	requirements = list(5,5,15,15,20,20,20,20,40,70) 
+	requirements = list(5,5,15,15,20,20,20,20,40,70)
 	high_population_requirement = 10
 	flags = MINOR_RULESET
 	makeBody = FALSE
@@ -748,16 +748,16 @@
 			sleep(150)
 			if(!can_move_shuttle())
 				continue
-		
+
 			sleep(50)	//everyone is off, wait 5 more seconds so people don't get ZAS'd out the airlock
-			if(!can_move_shuttle())	
+			if(!can_move_shuttle())
 				continue
 			if(!transport_shuttle.move_to_dock(centcomdock))
 				message_admins("The transport shuttle couldn't return to centcomm for some reason.")
 				return
 
 /datum/dynamic_ruleset/midround/from_ghosts/prisoner/proc/can_move_shuttle()
-	var/contents = get_contents_in_object(transport_shuttle.linked_area)	
+	var/contents = get_contents_in_object(transport_shuttle.linked_area)
 	if (locate(/mob/living) in contents)
 		return FALSE
 	if (locate(/obj/item/weapon/disk/nuclear) in contents)

--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -172,13 +172,13 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 	if(!istype(D))
 		return //It's not dynamic!
 	threat_generated += amount
-	if(D.threat >= D.threat_level)
-		D.create_threat(amount)
+	if(D.midround_threat >= D.midround_threat_level)
+		D.create_midround_threat(amount)
 		if(!threat_level_inflated) //Our first time raising the cap
 			D.threat_log += "[worldtime2text()]: A catbeast started increasing the threat cap."
 		threat_level_inflated += amount
 	else
-		D.refund_threat(amount)
+		D.refund_midround_threat(amount)
 
 /datum/role/catbeast/GetScoreboard()
 	. = ..()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2550,9 +2550,9 @@
 		if(!threatadd)
 			return
 		if(threatadd>0)
-			D.create_threat(threatadd)
+			D.create_midround_threat(threatadd)
 		else
-			D.spend_threat(-threatadd) //Spend a positive value. Negative the negative.
+			D.spend_midround_threat(-threatadd) //Spend a positive value. Negative the negative.
 		D.threat_log += "[worldtime2text()]: Admin [key_name(usr)] adjusted threat by [threatadd]."
 		message_admins("[key_name(usr)] adjusted threat by [threatadd].")
 		check_antagonists()


### PR DESCRIPTION
## Foreword

Dynamic is probably the biggest change ever made on this server. For all the tweaks we did, for all the avenues we tried and abandoned, for all the bitching and whining about it, it is undeniably the most important part of our codebase.

So why can't we get it right ? After two and a half year of dynamic mode and antag datums (#19788), 185 PRs related to it in one way or another, why another PR ?

The problem of dynamic is that there's simply too many variables. Changing one number is not guaranteed at all to result in the change you would like : the complicated details of the code make any meaningful result hard to predict.

One such complicated detail is the fact that *roundstart rules* and *midround rules* draw from the same pool of threat. The number is generated at roundstart, buys the game some roundstart rulesets, and then attempts to draft midround or latejoin rules.

In imaged terms, midround rules - such as midround nuke ops, midround blob, or revolutionary agents - must make do with the leftovers of the threat budget. To give an analogy, it is like coming to a party at 7am after everyone already left.

## About this PR

This PR attempts to rectify this by giving a second, independent threat budget for midround and latejoin rulesets. It removes one of the greatest unknowns for gauging whether midround rules are finely tuned or not : their dependency on roundstart rulesets.

At roundstart, two budgets are generated : one for midround events, and one for the roundstart rules. Midround rules will calculate if they can be drafted or not based on this "midround budget".

## Why ?

As said, this will make the numbers associated with midround rules - weight, cost, requirements - dissociated from the roundstart rules, making it easier to see what they do and if they need to be tweaked.

A greater threat budget will naturally enable a more varied selection of midround and latejoin antagonists instead of always ninjas & traitors.

## Problems

This PR will also naturally increase the number of antags in a given round, as it gives them more total threat for the mode to play with. This is a problem that will need to be fixed separately, in another PR.

Feel free to give feedbacks or ask questions if there's something you would like to know.

Moderately tested.

:cl:
- tweak: Dynamic mode changed yet again! Midround antagonists should appear more frequently and be more varied than always ninjas or traitors.