### PR TITLE
Locks rapid syringe gun behind medical access, adds normal one to protolathe

### DIFF
--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -154,6 +154,17 @@
 	build_path = /obj/item/weapon/reagent_containers/spray/chemsprayer
 	req_lock_access = list(access_medical, access_cmo)
 
+/datum/design/syringegun
+	name = "Basic Syringe Gun"
+	desc = "A gun that fires a single syringe."
+	id = "syringegun"
+	req_tech = list(Tc_COMBAT = 2, Tc_MATERIALS = 2, Tc_ENGINEERING = 2, Tc_BIOTECH = 2)
+	build_type = PROTOLATHE
+	materials = list(MAT_IRON = 2000, MAT_GLASS = 500)
+	category = "Weapons"
+	build_path = /obj/item/weapon/gun/syringe
+	req_lock_access = list(access_medical, access_cmo)
+
 /datum/design/rapidsyringe
 	name = "Rapid Syringe Gun"
 	desc = "A gun that fires many syringes."
@@ -163,6 +174,7 @@
 	materials = list(MAT_IRON = 5000, MAT_GLASS = 1000)
 	category = "Weapons"
 	build_path = /obj/item/weapon/gun/syringe/rapidsyringe
+	req_lock_access = list(access_medical, access_cmo)
 
 /datum/design/largecrossbow
 	name = "Energy Crossbow"

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -163,7 +163,6 @@
 	materials = list(MAT_IRON = 2000, MAT_GLASS = 500)
 	category = "Weapons"
 	build_path = /obj/item/weapon/gun/syringe
-	req_lock_access = list(access_medical, access_cmo)
 
 /datum/design/rapidsyringe
 	name = "Rapid Syringe Gun"
@@ -174,6 +173,7 @@
 	materials = list(MAT_IRON = 5000, MAT_GLASS = 1000)
 	category = "Weapons"
 	build_path = /obj/item/weapon/gun/syringe/rapidsyringe
+	locked = TRUE
 	req_lock_access = list(access_medical, access_cmo)
 
 /datum/design/largecrossbow


### PR DESCRIPTION
[tweak]

Basic syringe gun design:
* 2000 iron, 500 glass
* Combat 2, materials 2, engineering 2, biological 2

Let me know if I should change this, lockbox it too, or scrap the lockboxes altogether.

:cl:
 * rscadd: Basic syringe guns are now available on protolathes
 * tweak: Rapid syringe guns are now lockboxed for medical access