### PR TITLE
Allows plasma glass to reinforce computers from EMPs

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -9,6 +9,7 @@
 	icon_state = "0"
 	var/state = 0
 	var/obj/item/weapon/circuitboard/circuit = null
+	var/empproof = FALSE // For type of glass installed
 //	weight = 1.0E8
 
 /obj/structure/computerframe/Destroy()
@@ -488,8 +489,12 @@
 				new /obj/item/stack/cable_coil(get_turf(src), 5)
 				return 1
 
-			if(istype(P, /obj/item/stack/sheet/glass/glass))
-				var/obj/item/stack/sheet/glass/glass/G = P
+			if(istype(P, /obj/item/stack/sheet/glass))
+				var/obj/item/stack/sheet/glass/G = P
+				if(istype(G, /obj/item/stack/sheet/glass/rglass) || )istype(G, /obj/item/stack/sheet/glass/plasmarglass) // Don't use t hese
+					return
+				if(istype(G, /obj/item/stack/sheet/glass/plasmaglass)) // For EMP proofing
+					empproof = TRUE
 				if (G.amount < 2)
 					to_chat(user, "<span class='warning'>You need at least 2 sheets of glass for this!</span>")
 					return 1
@@ -508,7 +513,10 @@
 				user.visible_message("[user] removes the glass panel from the frame.", "You remove the glass panel from the frame.", "You hear metallic sounds.")
 				src.state = 3
 				src.icon_state = "3"
-				new /obj/item/stack/sheet/glass/glass( src.loc, 2 )
+				if(empproof) // Return plasma or normal glass if variable is set or not
+					new /obj/item/stack/sheet/glass/plasmaglass( src.loc, 2 )
+				else
+					new /obj/item/stack/sheet/glass/glass( src.loc, 2 )
 				return 1
 			if(P.is_screwdriver(user))
 				P.playtoolsound(src, 50)
@@ -536,6 +544,9 @@
 				var/obj/machinery/MA = B
 				if(istype(MA))
 					MA.power_change()
+				if(istype(MA,/obj/machinery/computer))
+					var/obj/machinery/computer/CM = MA
+					CM.empproof = empproof // Transfer status to new item
 				qdel(src)
 				return 1
 	return 0

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -501,9 +501,9 @@
 				if(do_after(user, src, 20) && state == 3 && G.amount >= 2)
 					playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
 					G.use(2)
-					user.visible_message("[user] installs the [empproof ? "plasma" : ""] glass panel onto the frame.", "You install the [empproof ? "plasma" : ""] glass panel onto the frame.", "You hear metallic sounds.")	
 					if(istype(G, /obj/item/stack/sheet/glass/plasmaglass)) // For EMP proofing
 						empproof = TRUE
+					user.visible_message("[user] installs the [empproof ? "plasma" : ""] glass panel onto the frame.", "You install the [empproof ? "plasma" : ""] glass panel onto the frame.", "You hear metallic sounds.")
 					src.state = 4
 					src.icon_state = "4"
 
@@ -516,6 +516,7 @@
 				src.icon_state = "3"
 				if(empproof) // Return plasma or normal glass if variable is set or not
 					new /obj/item/stack/sheet/glass/plasmaglass( src.loc, 2 )
+					empproof = FALSE // No glass, set to
 				else
 					new /obj/item/stack/sheet/glass/glass( src.loc, 2 )
 				return 1

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -491,7 +491,8 @@
 
 			if(istype(P, /obj/item/stack/sheet/glass))
 				var/obj/item/stack/sheet/glass/G = P
-				if(istype(G, /obj/item/stack/sheet/glass/rglass) || istype(G, /obj/item/stack/sheet/glass/plasmarglass)) // Don't use t hese
+				if(istype(G, /obj/item/stack/sheet/glass/rglass) || istype(G, /obj/item/stack/sheet/glass/plasmarglass)) // Don't use these
+					to_chat(user, "<span class='warning'>Sheets of glass must not have rods in them!</span>")
 					return
 				if(istype(G, /obj/item/stack/sheet/glass/plasmaglass)) // For EMP proofing
 					empproof = TRUE

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -494,8 +494,6 @@
 				if(istype(G, /obj/item/stack/sheet/glass/rglass) || istype(G, /obj/item/stack/sheet/glass/plasmarglass)) // Don't use these
 					to_chat(user, "<span class='warning'>Sheets of glass must not have rods in them!</span>")
 					return
-				if(istype(G, /obj/item/stack/sheet/glass/plasmaglass)) // For EMP proofing
-					empproof = TRUE
 				if (G.amount < 2)
 					to_chat(user, "<span class='warning'>You need at least 2 sheets of glass for this!</span>")
 					return 1
@@ -503,7 +501,9 @@
 				if(do_after(user, src, 20) && state == 3 && G.amount >= 2)
 					playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
 					G.use(2)
-					user.visible_message("[user] installs the glass panel onto the frame.", "You install the glass panel onto the frame.", "You hear metallic sounds.")
+					user.visible_message("[user] installs the [empproof ? "reinforced" : ""] glass panel onto the frame.", "You install the [empproof ? "reinforced" : ""] glass panel onto the frame.", "You hear metallic sounds.")	
+					if(istype(G, /obj/item/stack/sheet/glass/plasmaglass)) // For EMP proofing
+						empproof = TRUE
 					src.state = 4
 					src.icon_state = "4"
 

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -501,7 +501,7 @@
 				if(do_after(user, src, 20) && state == 3 && G.amount >= 2)
 					playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
 					G.use(2)
-					user.visible_message("[user] installs the [empproof ? "reinforced" : ""] glass panel onto the frame.", "You install the [empproof ? "reinforced" : ""] glass panel onto the frame.", "You hear metallic sounds.")	
+					user.visible_message("[user] installs the [empproof ? "plasma" : ""] glass panel onto the frame.", "You install the [empproof ? "plasma" : ""] glass panel onto the frame.", "You hear metallic sounds.")	
 					if(istype(G, /obj/item/stack/sheet/glass/plasmaglass)) // For EMP proofing
 						empproof = TRUE
 					src.state = 4

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -491,7 +491,7 @@
 
 			if(istype(P, /obj/item/stack/sheet/glass))
 				var/obj/item/stack/sheet/glass/G = P
-				if(istype(G, /obj/item/stack/sheet/glass/rglass) || )istype(G, /obj/item/stack/sheet/glass/plasmarglass) // Don't use t hese
+				if(istype(G, /obj/item/stack/sheet/glass/rglass) || istype(G, /obj/item/stack/sheet/glass/plasmarglass)) // Don't use t hese
 					return
 				if(istype(G, /obj/item/stack/sheet/glass/plasmaglass)) // For EMP proofing
 					empproof = TRUE

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -516,7 +516,7 @@
 				src.icon_state = "3"
 				if(empproof) // Return plasma or normal glass if variable is set or not
 					new /obj/item/stack/sheet/glass/plasmaglass( src.loc, 2 )
-					empproof = FALSE // No glass, set to
+					empproof = FALSE // No glass, set to false
 				else
 					new /obj/item/stack/sheet/glass/glass( src.loc, 2 )
 				return 1

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -130,6 +130,7 @@
 			to_chat(user, "<span class='notice'>[bicon(src)] The broken glass falls out.</span>")
 			if(empproof) // Return plasma or normal glass shard if variable is set or not
 				new /obj/item/weapon/shard/plasma(loc)
+				A.empproof = FALSE // Since there's no type of glass now
 			else
 				new /obj/item/weapon/shard(loc)
 			A.state = 3

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -8,6 +8,7 @@
 	active_power_usage = 300
 	var/obj/item/weapon/circuitboard/circuit = null //if circuit==null, computer can't disassembly
 	var/processing = 0
+	var/empproof = FALSE // For plasma glass builds
 	machine_flags = EMAGGABLE | SCREWTOGGLE | WRENCHMOVE | FIXED2WORK | MULTITOOL_MENU | SHUTTLEWRENCH
 
 	use_auto_lights = 1
@@ -38,7 +39,7 @@
 	return 1
 
 /obj/machinery/computer/emp_act(severity)
-	if(prob(20/severity))
+	if(prob(20/severity) && !empproof) // Don't EMP if proofed
 		set_broken()
 	..()
 
@@ -103,6 +104,8 @@
 	update_icon()
 
 /obj/machinery/computer/proc/set_broken()
+	if(empproof && prob(50)) // Halves chance if reinforced with plasma glass
+		return
 	stat |= BROKEN
 	update_icon()
 
@@ -120,11 +123,15 @@
 			CC.forceMove(A)
 		A.circuit = CC
 		A.anchored = 1
+		A.empproof = empproof // Transfer status
 		for (var/obj/C in src)
 			C.forceMove(src.loc)
 		if (src.stat & BROKEN)
 			to_chat(user, "<span class='notice'>[bicon(src)] The broken glass falls out.</span>")
-			new /obj/item/weapon/shard(loc)
+			if(empproof) // Return plasma or normal glass shard if variable is set or not
+				new /obj/item/weapon/shard/plasma(loc)
+			else
+				new /obj/item/weapon/shard(loc)
 			A.state = 3
 			A.icon_state = "3"
 		else


### PR DESCRIPTION
[content]

EMP proofing completely blocks all EMP effects from breaking the screen and halves any chances to do it in general.
Should give shaft miners/engineer/science/mechanics/whoever else something to do with that stuff now that isn't the solars.

:cl:
 * rscadd: Computers can now be reinforced from EMPs with plasma glass screens