### PR TITLE
Floor pills now have black coloring

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -311,6 +311,7 @@
 /obj/item/weapon/reagent_containers/pill/random
 	name = "unknown pill"
 	desc = "Dare you enter my chemical realm?"
+	var/hidereagents = FALSE
 	/* Possible choices:
 	Good: Hyperzine, Oxycodone, Doctor's Delight, Leporazine
 	Neutral: Corn Oil, Ryetalyn, Tonio, Space Drugs
@@ -336,10 +337,13 @@
 	var/list/to_spawn = pickweight(possible_combinations)
 	for(var/index in to_spawn)
 		reagents.add_reagent(index, to_spawn[index])
+	if(hidereagents)
+		reagents.add_reagent(BLACKCOLOR, 1)
 
 
 /obj/item/weapon/reagent_containers/pill/random/maintenance
 	flags = FPRINT | NOREACT
+	hidereagents = TRUE
 	possible_combinations = list(
 		list(SYNTHOCARISOL = 10, BICARIDINE = 10) = 2, // = 2 means 2 times as common, = 0.5 means 50% as common
 		list(KELOTANE = 10, DERMALINE = 10) = 2,


### PR DESCRIPTION
I always thought they did, turns out they don't.
This means you won't be able to crush the pill into a soda can to identify its contents, you gotta chug it blind or seek expert help (someone with a chemmaster/centrifuge) to identify it.
I think this is more mysterious and fun, but it's technically a nerf, so leave thoughts below.

:cl:
 * rscadd: Floor pills from Maintenance now come with black coloring, to make them more mysterious. A chemmaster can still identify their contents.
