### PR TITLE
fixes AIs being able to see shuttles they shouldn't see

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -435,7 +435,8 @@ proc/process_adminbus_teleport_locs()
 /area/shuttle/vox/station
 	name = "\improper Vox Skipjack"
 	icon_state = "yellow"
-	requires_power = 0
+	dynamic_lighting = 1
+	holomap_draw_override = HOLOMAP_DRAW_EMPTY
 
 /area/shuttle/lightship
 	name = "\improper Lightspeed Ship"

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -435,6 +435,7 @@ proc/process_adminbus_teleport_locs()
 /area/shuttle/vox/station
 	name = "\improper Vox Skipjack"
 	icon_state = "yellow"
+	requires_power = 0
 	dynamic_lighting = 1
 	holomap_draw_override = HOLOMAP_DRAW_EMPTY
 

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -440,9 +440,12 @@ proc/process_adminbus_teleport_locs()
 /area/shuttle/lightship
 	name = "\improper Lightspeed Ship"
 	requires_power = 1
+	icon_state = "firingrange"
+	dynamic_lighting = 1
+	holomap_draw_override = HOLOMAP_DRAW_EMPTY
 
 /area/shuttle/lightship/start
-	icon_state = "yellow"
+	icon_state = "firingrange"
 
 /area/shuttle/salvage
 	name = "\improper Salvage Ship"


### PR DESCRIPTION
closes #12229

tested locally. the issue was (presumably) that the lightship was moved from being a vault to a shuttle, meaning its area no longer inherited from the vault parent which prevents AIs from seeing stuff without cameras. don't know why the skipjack did this too because it ... was always a shuttle afaik .... but whatever

if there's more shuttles or vaults AIs can randomly see, let me know and i'll look into it

:cl:
 * bugfix: the vox shuttle and the lightspeed ship are no longer visible to the AI without cameras
 * tweak: made the lightship area have the same icon as the other areas used in randomvaults because i felt like it