### PR TITLE
Teleporter Frequencies

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -3,6 +3,7 @@
 	desc = "Used to control a linked teleportation Hub and Station."
 	icon_state = "teleport"
 	circuit = "/obj/item/weapon/circuitboard/teleporter"
+	var/frequency = 1459
 	var/obj/item/locked = null
 	var/id = null
 	var/one_time_use = 0 //Used for one-time-use teleport cards (such as clown planet coordinates.)
@@ -13,6 +14,7 @@
 
 /obj/machinery/computer/teleporter/New()
 	. = ..()
+	frequency = format_frequency(sanitize_frequency(frequency))
 	id = "[rand(1000, 9999)]"
 
 /obj/machinery/computer/teleporter/attackby(I as obj, mob/living/user as mob)
@@ -75,6 +77,10 @@
 
 /obj/machinery/computer/teleporter/interact(var/mob/user)
 	var/area/locked_area
+	if(frequency)
+		. = {"
+		<b>Frequency:</b> <a href='?src=\ref[src];freq=1'>[frequency]</a><br><br>
+		"}
 	if(locked)
 		locked_area = get_area(locked)
 		if(!locked_area)
@@ -84,12 +90,13 @@
 			locked_area = get_area(locked)
 			if(!locked_area)
 				locked = null
-			. = {"
+
+			. += {"
 			<b>Destination:</b> [sanitize(locked_area.name)]<br>
 			<a href='?src=\ref[src];clear=1'>Clear destination</a><br>
 			"}
 	else
-		. = {"
+		. += {"
 		<b>Destination unset!</b><br>
 		"}
 
@@ -117,6 +124,12 @@
 	if(.)
 		return
 
+	if(href_list["freq"])
+		change_freq()
+		say("Frequency set")
+		updateUsrDialog()
+		return 1
+
 	if(href_list["clear"])
 		locked = null
 		updateUsrDialog()
@@ -136,6 +149,8 @@
 
 	for(var/obj/item/beacon/R in beacons)
 		var/turf/T = get_turf(R)
+		if(R.frequency != src.frequency)
+			continue
 		if (!T)
 			continue
 		if(T.z == CENTCOMM_Z || T.z > map.zLevels.len)
@@ -168,6 +183,12 @@
 			L[tmpname] = I
 
 	. = L
+
+/obj/machinery/computer/teleporter/proc/change_freq(var/mob/user)
+	var/newfreq = input("Input a new frequency for the teleporter", "Frequency", null) as num
+	if(!newfreq)
+		return
+	frequency = format_frequency(sanitize_frequency(newfreq))
 
 /obj/machinery/computer/teleporter/verb/set_id(t as text)
 	set category = "Object"

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -125,8 +125,8 @@
 		return
 
 	if(href_list["freq"])
-		change_freq()
-		say("Frequency set")
+		if(change_freq())
+			say("Frequency set")
 		updateUsrDialog()
 		return 1
 
@@ -185,10 +185,29 @@
 	. = L
 
 /obj/machinery/computer/teleporter/proc/change_freq(var/mob/user)
-	var/newfreq = input("Input a new frequency for the teleporter", "Frequency", null) as num
-	if(!newfreq)
-		return
+	var/newfreq = input("Input a new frequency for the teleporter", "Frequency", null) as null|num
+	if(stat & (BROKEN|NOPOWER))
+		return 0
+	var/ghost_flags=0
+	if(ghost_write)
+		ghost_flags |= PERMIT_ALL
+	if(!canGhostWrite(usr,src,"",ghost_flags))
+		if(usr.restrained() || usr.lying || usr.stat)
+			return 0
+		if (!usr.dexterity_check())
+			to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
+			return 0
+		if(!is_on_same_z(usr))
+			to_chat(usr, "<span class='warning'>WARNING: Unable to interface with \the [src.name].</span>")
+			return 0
+		if(!is_in_range(usr))
+			to_chat(usr, "<span class='warning'>WARNING: Connection failure. Reduce range.</span>")
+			return 0
+	else if(!newfreq)
+		return 0
+
 	frequency = format_frequency(sanitize_frequency(newfreq))
+	return 1
 
 /obj/machinery/computer/teleporter/verb/set_id(t as text)
 	set category = "Object"

--- a/code/game/objects/items/beacon.dm
+++ b/code/game/objects/items/beacon.dm
@@ -20,9 +20,17 @@ var/global/list/obj/item/beacon/beacons = list()
 	..()
 	beacons -= src
 
+/obj/item/beacon/examine(mob/user)
+	..()
+	to_chat(user,"<span class='notice'>The frequency of the [src] is set to [frequency].</span>")
+
 /obj/item/beacon/attack_self(mob/user as mob)
 	..()
-	var/newfreq = input(user, "Input a new frequency for the beacon", "Frequency", null) as num
+	var/newfreq = input(user, "Input a new frequency for the beacon", "Frequency", null) as null|num
+	if(!src.Adjacent(user))
+		return
+	if(usr.restrained() || usr.lying || usr.stat)
+		return 0
 	if(!newfreq)
 		return
 	frequency = format_frequency(sanitize_frequency(newfreq))

--- a/code/game/objects/items/beacon.dm
+++ b/code/game/objects/items/beacon.dm
@@ -13,6 +13,7 @@ var/global/list/obj/item/beacon/beacons = list()
 
 /obj/item/beacon/New()
 	..()
+	frequency = format_frequency(sanitize_frequency(frequency))
 	beacons += src
 
 /obj/item/beacon/Destroy()


### PR DESCRIPTION
Gives the frequency setting on beacons a reason to exist and changes teleporters (the stationary ones, not telescience) to detect radio beacons based on frequency instead of automatically detecting every single beacon on the map. Allows for the creation of private teleportation points (both for normal purposes like space exploration and as a way for antags to move around) and even parallel teleporter networks separate from the station's normal set of beacons.
![telemenu](https://user-images.githubusercontent.com/60533805/114265077-a57bb900-99a3-11eb-8c74-3e2c31441e01.png)

:cl:
 * rscadd: Teleporter consoles now only detect beacons set to the same frequency as the console
 * rscadd: Examine beacons to view current frequency