### PR TITLE
Siege Cannon Bug Fix

### DIFF
--- a/code/modules/projectiles/guns/projectile/constructable/siegecannon.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/siegecannon.dm
@@ -64,11 +64,14 @@
 				to_chat(user,"<span class='notice'>You add [tF] units of fuel to \the [src].</span>" )
 
 /obj/structure/siege_cannon/proc/loadCannon(var/obj/item/cAmmo, var/mob/user)
-	if(loadedItem || loadedMob)
+	if(loadedItem || loadedMob || istype(cAmmo, /obj/item/weapon/grab))
 		return
 	if(cAmmo.w_class > maxSize)
-		to_chat(user,"<span class='warning'>The [cAmmo] is too large to fit in \the [src].</span>")
-		return
+		if(istype(cAmmo, /obj/item/anvil))
+			to_chat(user,"<span class='warning'>You force \the [cAmmo] into \the [src], somehow.</span>")	//Terrifying
+		else
+			to_chat(user,"<span class='warning'>The [cAmmo] is too large to fit in \the [src].</span>")
+			return
 	if(user.drop_item(cAmmo, src))
 		loadedItem = cAmmo
 		to_chat(user,"<span class='notice'>You load \the [cAmmo] into \the [src].</span>" )
@@ -86,6 +89,9 @@
 		loadMob(C, user)
 
 /obj/structure/siege_cannon/proc/loadMob(var/mob/living/mLoad, mob/user)
+	if(loadedMob || loadedItem)
+		to_chat(user,"<span class='warning'>\The [src] is already full.</span>" )
+		return
 	mLoad.forceMove(src)
 	loadedMob = mLoad
 
@@ -153,7 +159,7 @@
 	return 1
 
 
-//Cannonball////////
+//CANNONBALLS/////
 
 /obj/item/cannonball
 	name = "cannonball"

--- a/code/modules/projectiles/guns/projectile/constructable/siegecannon.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/siegecannon.dm
@@ -44,6 +44,7 @@
 
 /obj/structure/siege_cannon/proc/fillCannon(var/obj/item/weapon/reagent_containers/G, mob/user)
 	if(G.is_empty() || G.reagents.reagent_list.len > 1)
+		loadCannon(G, user)
 		return
 	if(!G.is_open_container())
 		loadCannon(G, user)
@@ -53,7 +54,8 @@
 		return
 	for(var/datum/reagent/R in G.reagents.reagent_list)
 		if(R.id != FUEL)
-			to_chat(user,"<span class='warning'>The [src] can't accept that as fuel.</span>" )
+			loadCannon(G, user)
+			break //Just in case
 		else
 			var/tF = clamp(G.amount_per_transfer_from_this, 0, maxFuel - wFuel)
 			G.reagents.remove_reagent(FUEL, tF)

--- a/code/modules/projectiles/guns/projectile/constructable/siegecannon.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/siegecannon.dm
@@ -66,8 +66,14 @@
 				to_chat(user,"<span class='notice'>You add [tF] units of fuel to \the [src].</span>" )
 
 /obj/structure/siege_cannon/proc/loadCannon(var/obj/item/cAmmo, var/mob/user)
-	if(loadedItem || loadedMob || istype(cAmmo, /obj/item/weapon/grab))
+	if(loadedItem || loadedMob)
+		to_chat(user,"<span class='warning'>\The [src] is already loaded.</span>")
 		return
+	if(istype(cAmmo, /obj/item/weapon/grab))
+		var/obj/item/weapon/grab/G = cAmmo
+		if(G.affecting)
+			loadMob(G.affecting, user)
+			return
 	if(cAmmo.w_class > maxSize)
 		if(istype(cAmmo, /obj/item/anvil))
 			to_chat(user,"<span class='warning'>You force \the [cAmmo] into \the [src], somehow.</span>")	//Terrifying
@@ -83,19 +89,19 @@
 		return
 	if(!isliving(C))
 		return
-	if(loadedMob || loadedItem)
-		to_chat(user,"<span class='warning'>\The [src] is already full.</span>" )
-		return
-	visible_message("<span class='warning'>\The [user] is stuffing [C] into \the [src].</span>")
-	if(do_after(user, C, 3 SECONDS))
-		loadMob(C, user)
+	loadMob(C, user)
 
 /obj/structure/siege_cannon/proc/loadMob(var/mob/living/mLoad, mob/user)
 	if(loadedMob || loadedItem)
-		to_chat(user,"<span class='warning'>\The [src] is already full.</span>" )
+		to_chat(user,"<span class='warning'>\The [src] is already loaded.</span>")
 		return
-	mLoad.forceMove(src)
-	loadedMob = mLoad
+	visible_message("<span class='warning'>\The [user] is stuffing [mLoad] into \the [src].</span>")
+	if(do_after(user, mLoad, 3 SECONDS))
+		if(loadedMob || loadedItem)
+			to_chat(user,"<span class='warning'>\The [src] is already loaded.</span>")
+			return
+		mLoad.forceMove(src)
+		loadedMob = mLoad
 
 /obj/structure/siege_cannon/relaymove(mob/user)
 	if(do_after(user, src, 1 SECONDS))


### PR DESCRIPTION
Fixes three bugs with siege cannon:
1. You could load the "grab" item
2. You could load multiple mobs as long as you attempted to load them before the first finished
3. Food items can now be loaded properly. So can open containers containing more than 1 reagent, like jars.

By popular demand also allows anvils to be loaded if you manage to pick one up. This, shockingly, somehow isn't an instant-gib.
[bugfix] Fixes #29207

:cl:
 * bugfix: Siege cannons can no longer load "grabs" but can load anvils and banana cream pies.