### PR TITLE
SASS Doesn't Explode

### DIFF
--- a/maps/RandomZLevels/hive.dm
+++ b/maps/RandomZLevels/hive.dm
@@ -830,10 +830,6 @@ var/list/hive_pylons = list()
 	var/infinite = 0
 
 /obj/item/supermatter_shielding/supermatter_act(atom/source)
-	var/turf/T = get_turf(src)
-
-	if(T)
-		explosion(T, -1, -1, 1)
 
 	if(istype(loc, /mob/living))
 		var/mob/living/L = loc


### PR DESCRIPTION
I was testing the SASS today and boy they're bad. They're either rare finds in the Hive or bought at Spessmart for $200 -- super rare to come by either way. When it activates, it hits you with a light explosion, often breaking a bone or causing a bleed (maybe even two), hits you with a stun, then deletes the sphere.

The sphere is still one use and still stuns you. It just doesn't hit you with a explosion anymore.

🆑 
* tweak: SASS spheres (spherical anti-supermatter shielding spheres) are now less unhealthy to use.