### PR TITLE
Hunting rifle in Trader's Coat suit slot

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -791,6 +791,7 @@ obj/item/clothing/suit/cassock
 	max_combined_w_class = 28
 	storage_slots = 14
 	actions_types = list(/datum/action/item_action/show_wares)
+	allowed = list(/obj/item/weapon/gun/projectile/hecate/hunting)
 
 /datum/action/item_action/show_wares/Trigger()
 	var/obj/item/clothing/suit/storage/trader/T = target


### PR DESCRIPTION
Added on request. The trader's coat can now fit a hunting rifle in its exosuit slot, so traders can actually leave their shop/ship without having to carry merchandise in their hands or on their back instead of a tank. That's it.
:cl:
 * rscadd: hunting rifle now fits in the trader's coat's exosuit slot