### PR TITLE
Storage items don't auto-collapse at 7 items if not full

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -209,8 +209,10 @@
 	var/col_count = min(7,storage_slots) -1
 	if(col_count < 0)
 		col_count = 6 //Show 7 inventory slots instead of breaking the inventory
-	if (adjusted_contents > 7)
+	if(adjusted_contents > 7)
 		row_num = round((adjusted_contents-1) / 7) // 7 is the maximum allowed width.
+	if((adjusted_contents % 7 == 0) && !is_full())
+		row_num++
 	src.standard_orient_objs(row_num, col_count, numbered_contents)
 
 //This proc return 1 if the item can be picked up and 0 if it can't.
@@ -675,3 +677,9 @@
 	for (var/i in no_storage_slot)
 		if(contents.len && (slot == i))
 			return CANNOT_EQUIP
+
+/obj/item/weapon/storage/proc/is_full()
+	var/sum_w_class = 0 //Given BYOND's horrid memory limit, which is worse for performance: Recalculating this, or storing it in memory? Who knows.
+	for(var/obj/item/I in contents)
+		sum_w_class += I.w_class
+	return (storage_slots && (contents.len >= storage_slots)) || (sum_w_class >= max_combined_w_class)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -211,8 +211,8 @@
 		col_count = 6 //Show 7 inventory slots instead of breaking the inventory
 	if(adjusted_contents > 7)
 		row_num = round((adjusted_contents-1) / 7) // 7 is the maximum allowed width.
-	if((adjusted_contents % 7 == 0) && !is_full())
-		row_num++
+		if((adjusted_contents % 7 == 0) && !is_full())
+			row_num++
 	src.standard_orient_objs(row_num, col_count, numbered_contents)
 
 //This proc return 1 if the item can be picked up and 0 if it can't.

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -211,8 +211,8 @@
 		col_count = 6 //Show 7 inventory slots instead of breaking the inventory
 	if(adjusted_contents > 7)
 		row_num = round((adjusted_contents-1) / 7) // 7 is the maximum allowed width.
-		if((adjusted_contents % 7 == 0) && !is_full())
-			row_num++
+	if(adjusted_contents && (adjusted_contents % 7 == 0) && !is_full())
+		row_num++ //If we have a full row of items, but we still have leftover space... Don't collapse the row, so people can still put stuff inside
 	src.standard_orient_objs(row_num, col_count, numbered_contents)
 
 //This proc return 1 if the item can be picked up and 0 if it can't.


### PR DESCRIPTION
Bear with me, because it's hard to explain what this PR does, why it's needed, and why it's not optimal.

Now that most containers have a storage limit based on the size of the items inside (rather than a static number of slots), you can run into issues trying to use storage that has 8 items inside.
For example, this box that is inside my backpack:
![dreamseeker_11_04_2021_06_11_11_50](https://user-images.githubusercontent.com/81891904/114298452-db489c80-9a8c-11eb-8cff-892f30047b8c.png)
If you remove one of the pieces of paper, the inventory collapses back into 1 row. And now if you want to put the paper back, you have to find the box's icon again, because there is no "empty inventory slot" you can click anymore.
![mspaint_11_04_2021_06_20_20_06](https://user-images.githubusercontent.com/81891904/114298676-fc5dbd00-9a8d-11eb-8469-c7ab41736a8c.png)
This can range from 'annoying but doable' in the case of backpacks, since you're wearing them and thus are always somewhere on your HUD, to 'just plain fucking annoying' for nested storage (box inside a backpack inside a toolbox inside a BoH: you have to close the box, open the BoH, open the toolbox, open the backpack, and then finally click the box, and you need to do this every time you want to remove an item from this box and then put it back).

What this PR does is leave an empty row on-screen if your storage still has leftover room, and has 7, 14, or 21 items inside.
![dreamseeker_11_04_2021_05_56_56_53](https://user-images.githubusercontent.com/81891904/114298662-e18b4880-9a8d-11eb-85cb-cdbc7ce9db0e.png)
This solves the problem, but it's not perfect, because there are cases where your backpack may have 7 items inside but only enough space for 1 more TINY item. And you may not actually have a tiny item that you want to put inside, so you're probably thinking "wtf why is this empty space here if I can't put anything inside?".

Other servers solve this better by having inventory icons have different sizes depending on the size of the item, so that they always add up to a full bar. Until someone ports that, this is the 2nd best option.


:cl:
 * tweak: Storage items won't collapse if they're not full, so you can always remove the 8th item and then put it back by clicking the same spot it was in.