### PR TITLE
Adds emag effect for magboots

### DIFF
--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -100,19 +100,23 @@
 /obj/item/clothing/shoes/magboots/attackby(var/obj/item/O, var/mob/user)
 	..()
 	if(isEmag(O))
-		emagged = !emagged
+		emagged = TRUE
 		new/obj/effect/effect/sparks(get_turf(src))
 		playsound(loc,"sparks",50,1)
 		clothing_flags &= ~(NOSLIP | MAGPULSE)
-		if(emagged)
-			slowdown = SHACKLE_SHOES_SLOWDOWN
-			icon_state = "[base_state]1"
-			to_chat(user, "<span class='danger'>You override the mag-pulse traction system!</span>")
-		else
+		slowdown = SHACKLE_SHOES_SLOWDOWN
+		icon_state = "[base_state]1"
+		to_chat(user, "<span class='danger'>You override the mag-pulse traction system!</span>")
+		user.update_inv_shoes()	//so our mob-overlays update
+	if(issolder(O) && emagged)
+		var/obj/item/weapon/solder/S = O
+		if(S.remove_fuel(10,user))
+			O.playtoolsound(user.loc, 25)
+			emagged = FALSE
 			slowdown = NO_SLOWDOWN
 			icon_state = "[base_state]0"
 			to_chat(user, "<span class='notice'>You restore the mag-pulse traction system.</span>")
-		user.update_inv_shoes()	//so our mob-overlays update
+			user.update_inv_shoes()	//so our mob-overlays update
 
 /obj/item/clothing/shoes/magboots/togglemagpulse(var/mob/user = usr)
 	if(user.isUnconscious())

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -110,7 +110,7 @@
 /obj/item/clothing/shoes/magboots/attackby(var/obj/item/O, var/mob/user)
 	..()
 	if(issolder(O) && emagged)
-		var/obj/item/weapon/solder/S = O
+		var/obj/item/tool/solder/S = O
 		if(S.remove_fuel(10,user))
 			O.playtoolsound(user.loc, 25)
 			emagged = FALSE

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -104,7 +104,7 @@
 		new/obj/effect/effect/sparks(get_turf(src))
 		playsound(loc,"sparks",50,1)
 		clothing_flags &= ~(NOSLIP | MAGPULSE)
-		if(!emagged)
+		if(emagged)
 			slowdown = SHACKLE_SHOES_SLOWDOWN
 			icon_state = "[base_state]1"
 			to_chat(user, "<span class='danger'>You override the mag-pulse traction system!</span>")

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -99,7 +99,7 @@
 
 /obj/item/clothing/shoes/magboots/attackby(var/obj/item/O, var/mob/user)
 	..()
-	if(isemag(O))
+	if(isEmag(O))
 		emagged = TRUE
 		new/obj/effect/effect/sparks(get_turf(src))
 		playsound(loc,"sparks",50,1)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -14,6 +14,7 @@
 	var/stomp_boot = "magboot"
 	var/stomp_hit = "crushes"
 	var/anchoring_system_examine = "Its mag-pulse traction system appears to be"
+	var/emagged = FALSE
 
 	var/obj/item/clothing/shoes/stored_shoes = null	//Shoe holder
 
@@ -96,8 +97,22 @@
 	..()
 	return
 
+/obj/item/clothing/shoes/magboots/attackby(var/obj/item/O, var/mob/user)
+	..()
+	if(isemag(O))
+		emagged = TRUE
+		new/obj/effect/effect/sparks(get_turf(src))
+		playsound(loc,"sparks",50,1)
+		slowdown = SHACKLE_SHOES_SLOWDOWN
+		icon_state = "[base_state]1"
+		to_chat(user, "<span class='danger'>You override the mag-pulse traction system!</span>")
+		user.update_inv_shoes()	//so our mob-overlays update
+
 /obj/item/clothing/shoes/magboots/togglemagpulse(var/mob/user = usr)
 	if(user.isUnconscious())
+		return
+	if(emagged)
+		to_chat(user, "<span class='warning'>The mag-pulse traction system cannot be turned off!</span>")
 		return
 	if(clothing_flags & MAGPULSE)
 		clothing_flags &= ~(NOSLIP | MAGPULSE)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -14,7 +14,7 @@
 	var/stomp_boot = "magboot"
 	var/stomp_hit = "crushes"
 	var/anchoring_system_examine = "Its mag-pulse traction system appears to be"
-	var/emagged = FALSE
+	var/emagged = 0
 
 	var/obj/item/clothing/shoes/stored_shoes = null	//Shoe holder
 
@@ -100,12 +100,18 @@
 /obj/item/clothing/shoes/magboots/attackby(var/obj/item/O, var/mob/user)
 	..()
 	if(isEmag(O))
-		emagged = TRUE
+		emagged = !emagged
 		new/obj/effect/effect/sparks(get_turf(src))
 		playsound(loc,"sparks",50,1)
-		slowdown = SHACKLE_SHOES_SLOWDOWN
-		icon_state = "[base_state]1"
-		to_chat(user, "<span class='danger'>You override the mag-pulse traction system!</span>")
+		clothing_flags &= ~(NOSLIP | MAGPULSE)
+		if(!emagged)
+			slowdown = SHACKLE_SHOES_SLOWDOWN
+			icon_state = "[base_state]1"
+			to_chat(user, "<span class='danger'>You override the mag-pulse traction system!</span>")
+		else
+			slowdown = NO_SLOWDOWN
+			icon_state = "[base_state]0"
+			to_chat(user, "<span class='notice'>You restore the mag-pulse traction system.</span>")
 		user.update_inv_shoes()	//so our mob-overlays update
 
 /obj/item/clothing/shoes/magboots/togglemagpulse(var/mob/user = usr)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -14,7 +14,7 @@
 	var/stomp_boot = "magboot"
 	var/stomp_hit = "crushes"
 	var/anchoring_system_examine = "Its mag-pulse traction system appears to be"
-	var/emagged = 0
+	var/emagged = FALSE
 
 	var/obj/item/clothing/shoes/stored_shoes = null	//Shoe holder
 
@@ -97,17 +97,18 @@
 	..()
 	return
 
+/obj/item/clothing/shoes/magboots/emag_act(var/mob/user)
+	emagged = TRUE
+	new/obj/effect/effect/sparks(get_turf(src))
+	playsound(loc,"sparks",50,1)
+	clothing_flags &= ~(NOSLIP | MAGPULSE)
+	slowdown = SHACKLE_SHOES_SLOWDOWN
+	icon_state = "[base_state]1"
+	to_chat(user, "<span class='danger'>You override the mag-pulse traction system!</span>")
+	user.update_inv_shoes()	//so our mob-overlays update
+
 /obj/item/clothing/shoes/magboots/attackby(var/obj/item/O, var/mob/user)
 	..()
-	if(isEmag(O))
-		emagged = TRUE
-		new/obj/effect/effect/sparks(get_turf(src))
-		playsound(loc,"sparks",50,1)
-		clothing_flags &= ~(NOSLIP | MAGPULSE)
-		slowdown = SHACKLE_SHOES_SLOWDOWN
-		icon_state = "[base_state]1"
-		to_chat(user, "<span class='danger'>You override the mag-pulse traction system!</span>")
-		user.update_inv_shoes()	//so our mob-overlays update
 	if(issolder(O) && emagged)
 		var/obj/item/weapon/solder/S = O
 		if(S.remove_fuel(10,user))

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -189,6 +189,9 @@
 	species_fit = list(VOX_SHAPED, INSECT_SHAPED)
 	mag_slow = MAGBOOTS_SLOWDOWN_LOW
 
+/obj/item/clothing/shoes/magboots/syndie/emag_act() // not emaggable
+	return
+
 //Captain
 /obj/item/clothing/shoes/magboots/captain
 	desc = "A relic predating magboots, these ornate greaves have retractable spikes in the soles to maintain grip."


### PR DESCRIPTION
[content]

Once applied, really high amount of item slowdown is applied without any of the benefits of magpulse or not slipping, can only be fixed with a solder

:cl:
 * rscadd: Applying a cryptographic sequencer to magboots will now disrupt their mag pulse attraction system. Use a solder to fix