### PR TITLE
Removed hunting rifle stuns

### DIFF
--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -76,6 +76,9 @@
 	actions_types = list(/datum/action/item_action/toggle_wielding)
 
 /obj/item/weapon/gun/projectile/hecate/hunting/bullet_hitting(var/obj/item/projectile/P,var/atom/atarget)
+	if(ishuman(atarget))
+		P.stun = 0
+		P.weaken = 0
 	if(isanimal(atarget))
 		P.damage *= 6
 


### PR DESCRIPTION
Another simple one. Hunting rifle bullets no longer have the detective revolver's stun/weaken effect when they hit humans, further reinforcing the hunting rifle's anti-simplemob niche.

:cl:
 * rscdel: removed stun/weaken effect from hunting rifle bullets on humans