### PR TITLE
Removes "/" from ends of map names in voting options

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -64,7 +64,7 @@
 		if(skipping < 3)
 			var/fullpath = path+binary
 			if(copytext(fullpath,-4,0) == ".dmb")
-				all_maps[copytext(potential,1,-1)] = path + binary
+				all_maps[copytext(potential,1,length(potential))] = path + binary // Makes key not have / at end, looks better in lists
 			else
 				binary = null
 				continue
@@ -103,7 +103,7 @@
 		if(!binary)
 			warning("Map folder [path] does not contain a valid byond binary, skipping.")
 		else
-			maps[copytext(potential,1,-1)] = path + binary
+			maps[copytext(potential,1,length(potential))] = path + binary // Makes key not have / at end, looks better in lists
 			binary = null
 		recursion_limit--
 	var/list/maplist = get_list_of_keys(maps)

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -64,7 +64,7 @@
 		if(skipping < 3)
 			var/fullpath = path+binary
 			if(copytext(fullpath,-4,0) == ".dmb")
-				all_maps[potential] = path + binary
+				all_maps[copytext(potential,1,-1)] = path + binary
 			else
 				binary = null
 				continue
@@ -103,7 +103,7 @@
 		if(!binary)
 			warning("Map folder [path] does not contain a valid byond binary, skipping.")
 		else
-			maps[potential] = path + binary
+			maps[copytext(potential,1,-1)] = path + binary
 			binary = null
 		recursion_limit--
 	var/list/maplist = get_list_of_keys(maps)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -471,7 +471,7 @@ var/datum/controller/gameticker/ticker
 					choices.Add(key)
 				var/mapname=pick(choices)
 				vote.chosen_map = maps[mapname] // Hack, but at this point I could not give a shit.
-				watchdog.chosen_map = copytext(mapname,1,(length(mapname)))
+				watchdog.chosen_map = mapname
 				log_game("Server chose [watchdog.chosen_map]!")
 
 


### PR DESCRIPTION
[grammar]
This is something I've wanted to do for months.
Example, before:
"A map vote was initiated with these options: Box Station/, Defficiency/, lowfatbagel/, Metaclub/, RoidStation/ and Synergy/."
And after:
"A map vote was initiated with these options: Box Station, Defficiency, lowfatbagel, Metaclub, RoidStation and Synergy."
:cl:
 * tweak: Removes erroneous "/" from map names in vote lists