### PR TITLE
Reagent Dispenser Tweaks

### DIFF
--- a/code/game/objects/effects/fire_blast.dm
+++ b/code/game/objects/effects/fire_blast.dm
@@ -91,8 +91,8 @@
 					L.adjustFireLoss(adjusted_fire_damage)
 
 			for(var/obj/O in get_turf(A))
-				if(istype(O, /obj/structure/reagent_dispensers/fueltank))
-					var/obj/structure/reagent_dispensers/fueltank/F = O
+				if(istype(O, /obj/structure/reagent_dispensers/))
+					var/obj/structure/reagent_dispensers/F = O
 					if(blast_temperature >= 561.15) //561.15 is welderfuel's autoignition temperature.
 						F.explode()
 				else if(O.autoignition_temperature)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -829,8 +829,18 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 /obj/item/weapon/lighter/afterattack(obj/O, mob/user, proximity)
 	if(!proximity)
 		return 0
-	if(istype(O, /obj/structure/reagent_dispensers/fueltank))
-		fuel += O.reagents.remove_any(initial(fuel) - fuel)
+	if(istype(O, /obj/structure/reagent_dispensers/))
+		var/obj/structure/reagent_dispensers/tank = O
+		if(!tank.can_fill_tools())
+			to_chat(user, "<span class='notice'>\The [tank] doesn't have a nozzle to fuel \the [src] from.</span>")
+			return
+		else if(!tank.reagents.get_reagent_amount(FUEL))
+			to_chat(user, "<span class='notice'>\The [tank] doesn't have fuel in it!</span>")
+			return
+		else if(tank.reagents.reagent_list.len > 1)
+			to_chat(user, "<span class='notice'>The fuel in \the [tank] is too diluted to use.</span>")
+			return
+		fuel += tank.reagents.remove_any(initial(fuel) - fuel)
 		user.visible_message("<span class='notice'>[user] refuels \the [src].</span>", \
 		"<span class='notice'>You refuel \the [src].</span>")
 		playsound(src, 'sound/effects/refill.ogg', 50, 1, -6)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -360,21 +360,31 @@
 /obj/item/weapon/weldingtool/afterattack(atom/A, mob/user as mob, proximity)
 	if(!proximity)
 		return
-	if (istype(A, /obj/structure/reagent_dispensers/fueltank) && get_dist(src,A) <= 1 && !src.welding)
-		if(A.reagents.trans_to(src, max_fuel))
+	if (istype(A, /obj/structure/reagent_dispensers/) && get_dist(src,A) <= 1 && !src.welding)
+		var/obj/structure/reagent_dispensers/tank = A
+		if(!tank.can_fill_tools())
+			to_chat(user, "<span class='notice'>\The [tank] doesn't have a nozzle to fuel \the [src] from.</span>")
+			return
+		else if(!tank.reagents.get_reagent_amount(FUEL))
+			to_chat(user, "<span class='notice'>\The [tank] doesn't have fuel in it!</span>")
+			return
+		else if(tank.reagents.reagent_list.len > 1)
+			to_chat(user, "<span class='notice'>The fuel in \the [tank] is too diluted to use.</span>")
+			return
+		else if(tank.reagents.trans_to(src, max_fuel))
 			to_chat(user, "<span class='notice'>Welder refueled.</span>")
 			playsound(src, 'sound/effects/refill.ogg', 50, 1, -6)
-		else if(!A.reagents)
-			to_chat(user, "<span class='notice'>\The [A] is empty.</span>")
+		else if(!tank.reagents)
+			to_chat(user, "<span class='notice'>\The [tank] is empty.</span>")
 		else
 			to_chat(user, "<span class='notice'>\The [src] is already full.</span>")
 		return
-	else if (istype(A, /obj/structure/reagent_dispensers/fueltank) && get_dist(src,A) <= 1 && src.welding)
-		message_admins("[key_name_admin(user)] triggered a fueltank explosion.")
-		log_game("[key_name(user)] triggered a fueltank explosion.")
-		to_chat(user, "<span class='warning'>That was stupid of you.</span>")
-		var/obj/structure/reagent_dispensers/fueltank/tank = A
-		tank.explode()
+	else if (istype(A, /obj/structure/reagent_dispensers/) && get_dist(src,A) <= 1 && src.welding)
+		var/obj/structure/reagent_dispensers/tank = A
+		if(tank.explode())
+			message_admins("[key_name_admin(user)] triggered a fueltank explosion.")
+			log_game("[key_name(user)] triggered a fueltank explosion.")
+			to_chat(user, "<span class='warning'>That was stupid of you.</span>")
 		return
 	if (src.welding)
 		if(isliving(A))

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -24,8 +24,8 @@
 		spark(src)
 
 		if (istype(src.loc,/obj/item/device/assembly_holder))
-			if (istype(src.loc.loc, /obj/structure/reagent_dispensers/fueltank/))
-				var/obj/structure/reagent_dispensers/fueltank/tank = src.loc.loc
+			if (istype(src.loc.loc, /obj/structure/reagent_dispensers/))
+				var/obj/structure/reagent_dispensers/tank = src.loc.loc
 				if (tank && tank.modded)
 					tank.explode()
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -15,6 +15,9 @@
 
 	var/amount_per_transfer_from_this = 10
 	var/possible_transfer_amounts = list(10,25,50,100)
+	var/can_attach = 0
+	var/modded = 0
+	var/obj/item/device/assembly_holder/rig = null
 
 /obj/structure/reagent_dispensers/AltClick(mob/user)
 	if(!user.incapacitated() && user.Adjacent(get_turf(src)) && possible_transfer_amounts)
@@ -22,13 +25,59 @@
 		return
 	return ..()
 
+/obj/structure/reagent_dispensers/attack_hand()
+	if (rig)
+		usr.visible_message("[usr] begins to detach [rig] from \the [src].", "You begin to detach [rig] from \the [src]")
+		if(do_after(usr, src, 20))
+			usr.visible_message("<span class='notice'>[usr] detaches [rig] from \the [src].", "<span class='notice'>You detach [rig] from \the [src]</span>")
+			if(rig)
+				rig.forceMove(get_turf(usr))
+				rig.master = null
+				rig = null
+			overlays = new/list()
+	..()
+
 /obj/structure/reagent_dispensers/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if (W.is_wrench(user) && can_attach)
+		user.visible_message("[user] wrenches [src]'s faucet [modded ? "closed" : "open"].", \
+			"You wrench [src]'s faucet [modded ? "closed" : "open"]")
+		modded = modded ? 0 : 1
+	if (istype(W,/obj/item/device/assembly_holder) && can_attach)
+		if (rig)
+			to_chat(user, "<span class='warning'>There is another device in the way.</span>")
+			return ..()
+		user.visible_message("[user] begins rigging [W] to \the [src].", "You begin rigging [W] to \the [src]")
+		if(do_after(user, src, 20))
+			if(rig)
+				to_chat(user, "<span class='warning'>Somebody already attached something to \the [src].</span>")
+				return
+			if(!user.drop_item(W, src))
+				to_chat(user,"<span class='warning'>Oops! You can't let go of \the [W]!</span>")
+				return
+
+			user.visible_message("<span class='notice'>[user] rigs [W] to \the [src].", "<span class='notice'>You rig [W] to \the [src]</span>")
+
+			var/obj/item/device/assembly_holder/H = W
+			if (istype(H.a_left,/obj/item/device/assembly/igniter) || istype(H.a_right,/obj/item/device/assembly/igniter))
+				message_admins("[key_name_admin(user)] rigged reagent tank at ([loc.x],[loc.y],[loc.z]) for explosion.")
+				log_game("[key_name(user)] rigged reagent tank at ([loc.x],[loc.y],[loc.z]) for explosion.")
+
+			rig = W
+			rig.master = src
+
+			var/image/test = image(W.appearance, src, "pixel_x" = 6, "pixel_y" = -1)
+			overlays += test
+
 	if(W.is_wrench(user) && wrenchable())
 		return wrenchAnchor(user, W)
 
 /obj/structure/reagent_dispensers/examine(mob/user)
 	..()
 	reagents.get_examine(user)
+	if (modded)
+		to_chat(user, "<span class='warning'>The faucet is wrenched open, leaking the the contents of \the [src]!</span>")
+	if(rig)
+		to_chat(user, "<span class='notice'>There is some kind of device rigged to the tank.</span>")
 
 /obj/structure/reagent_dispensers/cultify()
 	new /obj/structure/reagent_dispensers/bloodkeg(get_turf(src))
@@ -85,6 +134,7 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "watertank"
 	amount_per_transfer_from_this = 10
+	can_attach = 1
 
 /obj/structure/reagent_dispensers/watertank/New()
 	. = ..()
@@ -96,64 +146,12 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "weldtank"
 	amount_per_transfer_from_this = 10
-	var/modded = 0
-	var/obj/item/device/assembly_holder/rig = null
+	can_attach = 1
 
 /*/obj/structure/reagent_dispensers/fueltank/hear_talk(mob/living/M, text)
 	if(rig)
 		rig.hear_talk(M,text)
 */
-
-/obj/structure/reagent_dispensers/fueltank/examine(mob/user)
-	..()
-	if (modded)
-		to_chat(user, "<span class='warning'>Fuel faucet is wrenched open, leaking the fuel!</span>")
-	if(rig)
-		to_chat(user, "<span class='notice'>There is some kind of device rigged to the tank.</span>")
-
-/obj/structure/reagent_dispensers/fueltank/attack_hand()
-	if (rig)
-		usr.visible_message("[usr] begins to detach [rig] from \the [src].", "You begin to detach [rig] from \the [src]")
-		if(do_after(usr, src, 20))
-			usr.visible_message("<span class='notice'>[usr] detaches [rig] from \the [src].", "<span class='notice'>You detach [rig] from \the [src]</span>")
-			if(rig)
-				rig.forceMove(get_turf(usr))
-				rig.master = null
-				rig = null
-			overlays = new/list()
-
-/obj/structure/reagent_dispensers/fueltank/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if (W.is_wrench(user))
-		user.visible_message("[user] wrenches [src]'s faucet [modded ? "closed" : "open"].", \
-			"You wrench [src]'s faucet [modded ? "closed" : "open"]")
-		modded = modded ? 0 : 1
-	if (istype(W,/obj/item/device/assembly_holder))
-		if (rig)
-			to_chat(user, "<span class='warning'>There is another device in the way.</span>")
-			return ..()
-		user.visible_message("[user] begins rigging [W] to \the [src].", "You begin rigging [W] to \the [src]")
-		if(do_after(user, src, 20))
-			if(rig)
-				to_chat(user, "<span class='warning'>Somebody already attached something to \the [src].</span>")
-				return
-			if(!user.drop_item(W, src))
-				to_chat(user,"<span class='warning'>Oops! You can't let go of \the [W]!</span>")
-				return
-
-			user.visible_message("<span class='notice'>[user] rigs [W] to \the [src].", "<span class='notice'>You rig [W] to \the [src]</span>")
-
-			var/obj/item/device/assembly_holder/H = W
-			if (istype(H.a_left,/obj/item/device/assembly/igniter) || istype(H.a_right,/obj/item/device/assembly/igniter))
-				message_admins("[key_name_admin(user)] rigged fueltank at ([loc.x],[loc.y],[loc.z]) for explosion.")
-				log_game("[key_name(user)] rigged fueltank at ([loc.x],[loc.y],[loc.z]) for explosion.")
-
-			rig = W
-			rig.master = src
-
-			var/image/test = image(W.appearance, src, "pixel_x" = 6, "pixel_y" = -1)
-			overlays += test
-
-	return ..()
 
 /obj/structure/reagent_dispensers/fueltank/beam_connect(var/obj/effect/beam/B)
 	..()
@@ -319,6 +317,7 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "cornoiltank"
 	amount_per_transfer_from_this = 50
+	can_attach = 1
 
 /obj/structure/reagent_dispensers/corn_oil_tank/New()
 	. = ..()
@@ -330,6 +329,7 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "silicate tank"
 	amount_per_transfer_from_this = 50
+	can_attach = 1
 
 /obj/structure/reagent_dispensers/silicate/New()
 	. = ..()
@@ -357,6 +357,7 @@
 	desc = "A tank filled with ethanol, used in the degreasing of engines."
 	icon_state = "degreasertank"
 	amount_per_transfer_from_this = 5
+	can_attach = 1
 
 /obj/structure/reagent_dispensers/degreaser/New()
 	. = ..()
@@ -368,6 +369,7 @@
 	icon = 'icons/obj/halloween.dmi'
 	icon_state = "spooktank"
 	amount_per_transfer_from_this = 10
+	can_attach = 1
 
 /obj/structure/reagent_dispensers/spooktank/New()
 	. = ..()


### PR DESCRIPTION
Makes a number of tweaks to reagent dispenser code and adds some new features to the most common reagent dispensers, making them more consistent with other types of reagent containers found in the game. 
"Tank"-type reagent dispensers like water, fuel, ethanol and corn oil tanks can now be crowbarred to refill them with arbitrary reagents, wrenched open, and rigged with assemblies just like welder fuel tanks. tanks containing ethanol and corn oil also explode in all the same situations as welder fuel tanks, but less violently. if you somehow fill a tank with liquid plasma instead, the explosion is more powerful. welders and lighters can only refuel from tanks containing only welding fuel (other reagents will dilute the fuel).

:cl:
 * rscadd: Added refilling & assembly attachment to "tank"-type reagent dispensers
 * rscadd: ethanol and corn oil tanks explode less violently than fuel, plasma more violently
 * tweak: moved several procs up to apply to reagent dispensers in general instead of specific subtypes