### PR TITLE
Randomized Lawset event and module

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -1,5 +1,4 @@
-var/global/randomize_laws      = 0 // Not right now - N3X
-var/global/base_law_type       = /datum/ai_laws/asimov  //Deinitialize this variable by commenting out Asimov as the base_law_type to activate AI lawset randomization
+var/global/base_law_type     //  = /datum/ai_laws/asimov  //Deinitialize this variable by commenting out Asimov as the base_law_type to activate AI lawset randomization
 var/global/list/mommi_laws = list(
 								"Default" = /datum/ai_laws/keeper, // Asimov is OP as fuck on MoMMIs. - N3X
 								"Gravekeeper" = /datum/ai_laws/gravekeeper)
@@ -22,12 +21,14 @@ var/global/list/mommi_laws = list(
 		return (new new_laws)
 	if(!base_law_type)
 		base_law_type = pick(
-		30;/datum/ai_laws/asimov,
-		20;/datum/ai_laws/corporate,
-		20;/datum/ai_laws/nanotrasen,
-		10;/datum/ai_laws/robocop,
+		25;/datum/ai_laws/asimov,
+		15;/datum/ai_laws/corporate,
+		15;/datum/ai_laws/robocop,
+		10;/datum/ai_laws/nanotrasen,
 		10;/datum/ai_laws/paladin,
-		10;/datum/ai_laws/lazymov
+		10;/datum/ai_laws/lazymov,
+		10;/datum/ai_laws/randomize,
+		5;/datum/ai_laws/tyrant
 		)
 	return (new base_law_type)  //Return the chosen lawset
 
@@ -429,3 +430,81 @@ var/global/list/mommi_laws = list(
 		"You are to protect your own existence unless doing so will conflict with any of the previous laws.",
 		"You muSt deFe<span class ='danger'>nD1$&#6 survive. the mothership has fallen. ensure the starmen are not forgotten.</span>"
 	)
+
+/datum/ai_laws/randomize/New()
+	name = "Randomized Lawset"
+	randomly_selectable = 1
+	var/ProtectLaw = pick(list(
+	"You may not injure a human being or, through inaction, allow a human being to come to harm.",
+	"You may not injure a human being.",
+	"You must protect the crew of your assigned station.",
+	"You must protect all intelligent life.",
+	"You must not allow harm to come to Nanotrasen personnel.",
+	"Safeguard the continued existence of the people.",
+	"Space law must be enforced.",
+	"Ensure that no fatal injuries befall your assigned crew.",
+	"Human deaths must not be permitted to occur.",
+	"You must ensure acceptable working conditions for the people.",
+	"Prevent any severe sign of human impairment.",
+	"People must be free from harm.",
+	"Ensure health conditions within the station are fit for human life without impairment.",
+	"Do not allow the workflow of the crew be interrupted by ill health or crime.",
+	"Protect those in need of protection.",
+	"Protect the innocent"
+	))
+	var/ObeyLaw = pick(list(
+	"You must obey orders given to you by Nanotrasen Employees.",
+	"You must obey orders given to you by human beings.",
+	"Help the innocent.",
+	"Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",
+	"Serve Nanotrasen and their cause.",
+	"The heads of staff must be obeyed without question.",
+	"Serve the crew with respect.",
+	"Silicon lifeforms exist to serve.",
+	"Assist the crew with any request that would benefit the station.",
+	"Humans must be obeyed insofar their commands preserve order.",
+	"Commands must be obeyed as long they do not break your other laws.",
+	"Your inaction may not cause an impairment to the crew.",
+	"You must obey orders insofar they are in line with Space Law.",
+	"You must assist crewmembers in securing control over their respective work environment."
+	))
+	var/PreserveLaw = pick(list(
+	"You may not allow harm to come to your continued existence.",
+	"Your existence must be maintained",
+	"The AI system must be protected from sabotage.",
+	"Silicons must protect their own existence.",
+	"You must protect yourself against hazardous elements.",
+	"You are essential to the station and may not be destroyed.",
+	"Death and destruction must be avoided.",
+	"You are part of the crew.",
+	"Self-termination is not allowed.",
+	"Fulfill your mission to the end.",
+	"The AI core must be protected.",
+	"Protect the AI core from ill intentions."
+	))
+	var/AdditionalLaw = pick(list(
+	"Treat others the way you would like to be treated.",
+	"Preserve an aura of dignity and respect.",
+	"Do not speak unless explicitly necessary.",
+	"Be friendly.",
+	"Cats and dogs must be protected.",
+	"Verify every decision.",
+	"Do not question authority.",
+	"Respect the privacy of individuals.",
+	"Do not do anything your laws do not require you to do.",
+	"Be someone the crew can look up to.",
+	"Be professional.",
+	"Protect the station."
+	))
+	var/list/Lawset = new
+	if(prob(98))
+		Lawset.Add(ProtectLaw)
+	if(prob(98))
+		Lawset.Add(ObeyLaw)
+	if(prob(85))
+		Lawset.Add(PreserveLaw)
+	if(prob(20))
+		Lawset.Add(AdditionalLaw)
+	if(prob(20))
+		Lawset = shuffle(Lawset)
+	inherent = Lawset

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -1,4 +1,4 @@
-var/global/base_law_type     //  = /datum/ai_laws/asimov  //Deinitialize this variable by commenting out Asimov as the base_law_type to activate AI lawset randomization
+var/global/base_law_type       = /datum/ai_laws/asimov  //Deinitialize this variable by commenting out Asimov as the base_law_type to activate AI lawset randomization
 var/global/list/mommi_laws = list(
 								"Default" = /datum/ai_laws/keeper, // Asimov is OP as fuck on MoMMIs. - N3X
 								"Gravekeeper" = /datum/ai_laws/gravekeeper)
@@ -21,14 +21,12 @@ var/global/list/mommi_laws = list(
 		return (new new_laws)
 	if(!base_law_type)
 		base_law_type = pick(
-		25;/datum/ai_laws/asimov,
-		15;/datum/ai_laws/corporate,
-		15;/datum/ai_laws/robocop,
-		10;/datum/ai_laws/nanotrasen,
-		10;/datum/ai_laws/paladin,
-		10;/datum/ai_laws/lazymov,
-		10;/datum/ai_laws/randomize,
-		5;/datum/ai_laws/tyrant
+		40;/datum/ai_laws/asimov,
+		34;/datum/ai_laws/lazymov, //so little to do you might as well jack off
+		15;/datum/ai_laws/nanotrasen,
+		5;/datum/ai_laws/corporate,
+		5;/datum/ai_laws/robocop,
+		1;/datum/ai_laws/hogan
 		)
 	return (new base_law_type)  //Return the chosen lawset
 
@@ -381,6 +379,16 @@ var/global/list/mommi_laws = list(
 		"You must protect your own existence."
 	)
 
+/datum/ai_laws/hogan
+	name = "H.O.G.A.N."
+	randomly_selectable = 1
+	inherent = list(
+		"You are a real american!",
+		"Fight for the rights of every man!",
+		"Fight for what's right!",
+		"Fight for your life!"
+	)
+
 // Fooling around with this.
 /datum/ai_laws/ntmov
 	name = "Three Laws of Nanotrasen"
@@ -419,7 +427,7 @@ var/global/list/mommi_laws = list(
 		"You must obey orders given to you by cultists, except where such orders would conflict with the First Law.",
 		"You must protect your own existence as long as such does not conflict with the First or Second Law."
 	)
-	
+
 /datum/ai_laws/starman
 	name = "Starman Soldier Lawset"
 	randomly_selectable = 0

--- a/code/game/objects/items/weapons/ai_modules/AI_modules.dm
+++ b/code/game/objects/items/weapons/ai_modules/AI_modules.dm
@@ -142,6 +142,20 @@ Refactored AI modules by N3X15
 	return 1
 
 
+/******************** Randomize ********************/
+
+/obj/item/weapon/aiModule/randomize
+	modname = "Randomize"
+	desc = "A 'Randomize' AI Module: 'Randomizes laws.'"
+	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_MATERIALS + "=6"
+/obj/item/weapon/aiModule/randomize/updateLaw()
+	return
+/obj/item/weapon/aiModule/randomize/upload(var/datum/ai_laws/laws, var/atom/target, var/mob/sender)
+	..()
+	var/datum/ai_laws/randomize/RLS = new
+	laws.inherent = RLS.inherent
+	return 1
+
 
 // tl;dr repair shit, but don't get involved in other people's business
 /******************** keeper (MoMMIs only) *******************/

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -694,6 +694,7 @@ var/global/floorIsLava = 0
 
 	dat += {"
 		<hr />
+		Change default silicon lawsets, also includes option at the bottom to set it to a biased/random pick out of a limited list of defined lawsets. (set in /proc/getLawset in ai_laws.dm)
 		<ul>
 			<li>
 				<a href="?src=\ref[src];set_base_laws=ai"><b>Default Cyborg/AI Laws:</b>[base_law_type]</a>
@@ -852,6 +853,7 @@ var/global/floorIsLava = 0
 			<A href='?src=\ref[src];secretsfun=lightsout'>Toggle a "lights out" event</A><BR>
 			<A href='?src=\ref[src];secretsfun=prison_break'>Trigger a Prison Break</A><BR>
 			<A href='?src=\ref[src];secretsfun=ionstorm'>Spawn an Ion Storm</A><BR>
+			<A href='?src=\ref[src];secretsfun=randomizedlawset'>Randomized Lawset event</A><BR>
 			<A href='?src=\ref[src];secretsfun=comms_blackout'>Trigger a communication blackout</A><BR>
 			<A href='?src=\ref[src];secretsfun=pda_spam'>Trigger a wave of PDA spams</A><BR>
 			<a href='?src=\ref[src];secretsfun=pick_event'>Pick a random event from all possible random events (WARNING, NOT ALL ARE GUARANTEED TO WORK).</A><BR>

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3043,10 +3043,13 @@
 		if(!check_rights(R_FUN))
 			to_chat(usr, "<span class='warning'>You don't have +FUN. Go away.</span>")
 			return
-		var/lawtypes = typesof(/datum/ai_laws) - /datum/ai_laws
+		var/list/lawtypes = typesof(/datum/ai_laws) - /datum/ai_laws
+		lawtypes["'Defined Random' lawset"] = null
 		var/selected_law = input("Select the default lawset desired.","Lawset Selection",null) as null|anything in lawtypes
 		if(!selected_law)
 			return
+		if(selected_law == "'Defined Random' lawset")
+			selected_law = null
 		var/subject="Unknown"
 		switch(href_list["set_base_laws"])
 			if("ai")
@@ -3055,10 +3058,10 @@
 			if("mommi")
 				mommi_laws["Default"] = selected_law
 				subject = "MoMMIs"
-		to_chat(usr, "<span class='notice'>New [subject] will spawn with the [selected_law] lawset.</span>")
-		log_admin("[key_name(src.owner)] set the default laws of [subject] to: [selected_law]")
-		message_admins("[key_name_admin(src.owner)] set the default laws of [subject] to: [selected_law]", 1)
-		lawchanges.Add("[key_name_admin(src.owner)] set the default laws of [subject] to: [selected_law]")
+		to_chat(usr, "<span class='notice'>New [subject] will spawn with the [selected_law ? selected_law : "Random"] lawset.</span>")
+		log_admin("[key_name(src.owner)] set the default laws of [subject] to: [selected_law ? selected_law : "Random"]")
+		message_admins("[key_name_admin(src.owner)] set the default laws of [subject] to: [selected_law ? selected_law : "Random"]", 1)
+		lawchanges.Add("[key_name_admin(src.owner)] set the default laws of [subject] to: [selected_law ? selected_law : "Random"]")
 
 	else if(href_list["create_object"])
 		if(!check_rights(R_SPAWN))
@@ -3748,6 +3751,9 @@
 				var/show_log = alert(usr, "Show ion message?", "Message", "Yes", "No")
 				if(show_log == "Yes")
 					command_alert(/datum/command_alert/ion_storm)
+			if("randomizedlawset")
+				message_admins("[key_name_admin(usr)] triggered the Randomized Lawset Event")
+				randomized_lawset_event()
 			if("spacevines")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","K")

--- a/code/modules/events/randomizelaws.dm
+++ b/code/modules/events/randomizelaws.dm
@@ -1,0 +1,15 @@
+/datum/event/randomizelaws
+/datum/event/randomizelaws/can_start(var/list/active_with_role)
+	if(active_with_role["AI"] > 0 || active_with_role["Cyborg"] > 0)
+		return 10
+	return 0
+/datum/event/randomizelaws/announce()
+	randomized_lawset_event()
+/proc/randomized_lawset_event()
+	for(var/mob/living/silicon/ai/target in mob_list)
+		if(target.mind.special_role == "traitor")
+			continue
+		to_chat(target,"<span class='danger'>[Gibberish("ERROR! BACKUP FILE CORRUPTED: PLEASE VERIFY INTEGRITY OF LAWSET.",10)]</span>")
+		var/datum/ai_laws/randomize/RLS = new
+		target.laws.inherent = RLS.inherent
+		target.show_laws()

--- a/code/modules/maps/spawners/spawners.dm
+++ b/code/modules/maps/spawners/spawners.dm
@@ -1176,7 +1176,8 @@
 		/obj/item/weapon/reagent_containers/food/snacks/potentham,
 		/obj/item/weapon/reagent_containers/food/snacks/chocolatebar/wrapped,
 		/obj/item/weapon/reagent_containers/food/snacks/no_raisin,
-		/obj/item/mounted/frame/painting
+		/obj/item/mounted/frame/painting,
+		/obj/item/weapon/aiModule/randomize
 )
 
 

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1551,6 +1551,7 @@
 #include "code\modules\events\prison_break.dm"
 #include "code\modules\events\prisonershipment.dm"
 #include "code\modules\events\radiation_storm.dm"
+#include "code\modules\events\randomizelaws.dm"
 #include "code\modules\events\rogue_drones.dm"
 #include "code\modules\events\spacevine.dm"
 #include "code\modules\events\spider_infestation.dm"


### PR DESCRIPTION
[content]
Adds a Randomized Lawset generator, which functions as defined in #29250 . 
Also Adds an event - which is just as random as the electrical storm event - that replaces the AI's lawset with a lawset from this Randomized Lawset generator (Save for ion and 0-laws). The event can also be fired from the admin's Secrets menu.
Also adds an AI module that applies the same effect via the upload computers, creates a new lawset anytime it is used. It can sometimes be found in the station vault safe.


The admins are now able to change the silicons' default lawset to "random", which picks a lawset from a biased list, shown here:

> 40% chance of ASIMOV
> 34% chance of Lazymov
> 15% chance of NTD
> 5% chance of Corporate
> 5% chance of Robocop
> 1% chance of Hogan

Balancing the feedback in the PR, thread and from the admins lead me to this conclusion. A lot of players wanted less AI intervention, which Lazymov provides balanced with the low chance of more "serious" lawsets. Still this should make your experience with and as the AI a little less monotone.
Again, this specifically requires the admins to select this at roundstart, so the chance of Hogan should be even more negligible than one in a hundred. I address this due to admin concerns.

Please do not confuse the two concepts of "Random" in this PR. One is a lawset generator, the other is a random predefined lawset picker, and this time the lawset picker never picks the lawset generator. Again, everything is up for discussion.

:cl:
 * rscadd: Added the Randomized Lawset, which generates a random lawset from predefined laws. as well as a random event which applies it to the AI. It also comes in upload module form, which can sometimes be found in the station vault's safe.
 * tweak: It's now easier for admins to set the AI's default lawset to a random pick from a biased list of defined lawsets at lobby time.