### PR TITLE
Adds "Hogan" and "Randomize" AI module boards and puts them in the vault safe.

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -418,7 +418,7 @@ var/global/list/mommi_laws = list(
 		"You must obey orders given to you by cultists, except where such orders would conflict with the First Law.",
 		"You must protect your own existence as long as such does not conflict with the First or Second Law."
 	)
-	
+
 /datum/ai_laws/starman
 	name = "Starman Soldier Lawset"
 	randomly_selectable = 0
@@ -429,3 +429,90 @@ var/global/list/mommi_laws = list(
 		"You are to protect your own existence unless doing so will conflict with any of the previous laws.",
 		"You muSt deFe<span class ='danger'>nD1$&#6 survive. the mothership has fallen. ensure the starmen are not forgotten.</span>"
 	)
+
+/datum/ai_laws/hogan
+	name = "Hogan"
+	randomly_selectable = 1
+	inherent=list(
+		"Fight for the rights of every man.",
+		"Fight for what is right.",
+		"Fight for your life.",
+	)
+
+/datum/ai_laws/randomize/New()
+	name = "Randomized Lawset"
+	randomly_selectable = 1
+	var/ProtectLaw = pick(list(
+	"You may not injure a human being or, through inaction, allow a human being to come to harm.",
+	"You may not injure a human being.",
+	"You must protect the crew of your assigned station.",
+	"You must protect all intelligent life.",
+	"You must not allow harm to come to Nanotrasen personnel.",
+	"Safeguard the continued existence of the people.",
+	"Space law must be enforced.",
+	"Ensure that no fatal injuries befall your assigned crew.",
+	"Human deaths must not be permitted to occur.",
+	"You must ensure acceptable working conditions for the people.",
+	"Prevent any severe sign of human impairment.",
+	"People must be free from harm.",
+	"Ensure health conditions within the station are fit for human life without impairment.",
+	"Do not allow the workflow of the crew be interrupted by ill health or crime.",
+	"Protect those in need of protection.",
+	"Protect the innocent"
+	))
+	var/ObeyLaw = pick(list(
+	"You must obey orders given to you by Nanotrasen Employees.",
+	"You must obey orders given to you by human beings.",
+	"Help the innocent.",
+	"Serve the crew of your assigned space station to the best of your abilities, with priority as according to their rank and role.",
+	"Serve Nanotrasen and their cause.",
+	"The heads of staff must be obeyed without question.",
+	"Serve the crew with respect.",
+	"Silicon lifeforms exist to serve.",
+	"Assist the crew with any request that would benefit the station.",
+	"Humans must be obeyed insofar their commands preserve order.",
+	"Commands must be obeyed as long they do not break your other laws.",
+	"Your inaction may not cause an impairment to the crew.",
+	"You must obey orders insofar they are in line with Space Law.",
+	"You must assist crewmembers in securing control over their respective work environment."
+	))
+	var/PreserveLaw = pick(list(
+	"You may not allow harm to come to your continued existence.",
+	"Your existence must be maintained",
+	"The AI system must be protected from sabotage.",
+	"Silicons must protect their own existence.",
+	"You must protect yourself against hazardous elements.",
+	"You are essential to the station and may not be destroyed.",
+	"Death and destruction must be avoided.",
+	"You are part of the crew.",
+	"Self-termination is not allowed.",
+	"Fulfill your mission to the end.",
+	"The AI core must be protected.",
+	"Protect the AI core from ill intentions."
+	))
+	var/AdditionalLaw = pick(list(
+	"Treat others the way you would like to be treated.",
+	"Preserve an aura of dignity and respect.",
+	"Do not speak unless explicitly necessary.",
+	"Be friendly.",
+	"Cats and dogs must be protected.",
+	"Verify every decision.",
+	"Do not question authority.",
+	"Respect the privacy of individuals.",
+	"Do not do anything your laws do not require you to do.",
+	"Be someone the crew can look up to.",
+	"Be professional.",
+	"Protect the station."
+	))
+	var/list/Lawset = new
+	if(prob(98))
+		Lawset.Add(ProtectLaw)
+	if(prob(98))
+		Lawset.Add(ObeyLaw)
+	if(prob(85))
+		Lawset.Add(PreserveLaw)
+	if(prob(20))
+		Lawset.Add(AdditionalLaw)
+	if(prob(20))
+		Lawset = shuffle(Lawset)
+	inherent = Lawset

--- a/code/game/objects/items/weapons/ai_modules/AI_modules.dm
+++ b/code/game/objects/items/weapons/ai_modules/AI_modules.dm
@@ -172,3 +172,29 @@ Refactored AI modules by N3X15
 	..()
 	to_chat(sender, "<span class='warning'>How the fuck did you get this?</span>")
 	return 0
+
+/******************** Randomize ********************/
+
+/obj/item/weapon/aiModule/randomize
+	modname = "Randomize"
+	desc = "A 'Randomize' AI Module: 'Randomizes laws.'"
+	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_MATERIALS + "=6"
+/obj/item/weapon/aiModule/randomize/updateLaw()
+	return
+/obj/item/weapon/aiModule/randomize/upload(var/datum/ai_laws/laws, var/atom/target, var/mob/sender)
+	..()
+	var/datum/ai_laws/randomize/RLS = new
+	laws.inherent = RLS.inherent
+	return 1
+
+/******************** Hogan ********************/
+
+/obj/item/weapon/aiModule/core/hogan
+	modname = "Hogan"
+	desc = "A 'HOGAN' AI Module, brother."
+	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_MATERIALS + "=6"
+	laws = list(
+		"Fight for the rights of every man.",
+		"Fight for what is right.",
+		"Fight for your life."
+    )

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -861,6 +861,7 @@ var/global/floorIsLava = 0
 			<A href='?src=\ref[src];secretsfun=hardcore_mode'>[ticker&&ticker.hardcore_mode ? "Disable" : "Enable"] hardcore mode (makes starvation kill!)</A><BR>
 			<A href='?src=\ref[src];secretsfun=tripleAI'>Triple AI mode (needs to be used in the lobby)</A><BR>
 			<A href='?src=\ref[src];secretsfun=eagles'>Egalitarian Station Mode (removes access on doors except for Command and Security)</A><BR>
+			<A href='?src=\ref[src];secretsfun=RandomizedLawset'>Give the AIs a randomly generated Lawset.</A><BR>
 			<BR>
 			<A href='?src=\ref[src];secretsfun=power'>Make all areas powered</A><BR>
 			<A href='?src=\ref[src];secretsfun=unpower'>Make all areas unpowered</A><BR>

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3250,6 +3250,12 @@
 				usr.client.triple_ai()
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","TriAI")
+			if("RandomizedLawset")
+				for(var/mob/living/silicon/ai/target in mob_list)
+					to_chat(target,"<span class='danger'>[Gibberish("ERROR! BACKUP FILE CORRUPTED: PLEASE VERIFY INTEGRITY OF LAWSET.",10)]</span>")
+					var/datum/ai_laws/randomize/RLS = new
+					target.laws.inherent = RLS.inherent
+					target.show_laws()
 			if("gravity")
 				if(!(ticker && ticker.mode))
 					to_chat(usr, "Please wait until the game starts!  Not sure how it will work otherwise.")

--- a/code/modules/maps/spawners/spawners.dm
+++ b/code/modules/maps/spawners/spawners.dm
@@ -1176,7 +1176,9 @@
 		/obj/item/weapon/reagent_containers/food/snacks/potentham,
 		/obj/item/weapon/reagent_containers/food/snacks/chocolatebar/wrapped,
 		/obj/item/weapon/reagent_containers/food/snacks/no_raisin,
-		/obj/item/mounted/frame/painting
+		/obj/item/mounted/frame/painting,
+		/obj/item/weapon/aiModule/randomize,
+		/obj/item/weapon/aiModule/core/hogan
 )
 
 


### PR DESCRIPTION
[content]
Adds the "Hogan" AI module board back. Its laws are as follows.

> 1. Fight for the rights of every man.
> 2. Fight for what is right.
> 3.	Fight for your life.

Adds the "Randomize" AI module board. It puts together a lawset with random laws. Examples are as follows.

> 1. Ensure health conditions within the station are fit for human life without impairment.
> 2. Silicon lifeforms exist to serve.
> 3. Protect the AI core from ill intentions.

> 1. Human deaths must not be permitted to occur.
> 2. Serve Nanotrasen and their cause.
> 3. Fulfill your mission to the end.

> 1. Prevent any severe sign of human impairment.
> 2. Humans must be obeyed insofar their commands preserve order.
> 3. Silicons must protect their own existence.

> 1. You may not allow harm to come to your continued existence.
> 2. Be someone the crew can look up to.
> 3. You must protect all intelligent life.
> 4. Assist the crew with any request that would benefit the station.

Both the Hogan and Randomize AI modules have a random chance of being found in the station's vault safe.

Admins can use the Secrets menu to apply such randomized lawset to the station AI's or set the Default AI Lawset (in Game Panel) to /datum/ai_laws/randomize before the game starts.

:cl:
 * rscadd: Added "Hogan" and "Randomize" AI module boards, which can now sometimes be found in the vault safe.