### PR TITLE
 Fixes identity not updating when removing your ID/PDA with an obscured face

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -200,7 +200,7 @@ proc/process_sec_hud(var/mob/M, var/advanced_mode,var/mob/eye)
 
 		var/perpname = perp.get_face_name()
 		if(lowertext(perpname) == "unknown" || !perpname)
-			perpname = perp.get_id_name("Unknown")
+			perpname = perp.get_worn_id_name("Unknown")
 		if(perpname)
 			var/datum/data/record/R = find_record("name", perpname, data_core.security)
 			if(R)

--- a/code/game/dna/genes/monkey.dm
+++ b/code/game/dna/genes/monkey.dm
@@ -111,7 +111,7 @@
 	O.adjustToxLoss(M.getToxLoss())
 	O.adjustOxyLoss(M.getOxyLoss())
 	O.stat = M.stat
-	O.name = O.get_visible_name()
+	O.update_name()
 //		O.update_icon = 1	//queue a full icon update at next life() call
 	Mo.monkeyizing = 0
 	qdel(M)

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -151,7 +151,7 @@
 			qdel(src)
 	if (ishuman(M))
 		var/mob/living/carbon/human/H = M
-		H.name = H.get_visible_name()
+		H.update_name()
 	return uses
 
 /obj/item/weapon/dnainjector/attack(mob/M as mob, mob/user as mob)

--- a/code/modules/admin/verbs/possess.dm
+++ b/code/modules/admin/verbs/possess.dm
@@ -41,7 +41,7 @@
 		usr.name = usr.real_name
 		if(ishuman(usr))
 			var/mob/living/carbon/human/H = usr
-			H.name = H.get_visible_name()
+			H.update_name()
 //		usr.regenerate_icons() //So the name is updated properly
 
 	usr.forceMove(O.loc) // Appear where the object you were controlling is -- TLE

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -285,7 +285,7 @@
 	H.flavor_text = H.dna.flavor_text
 
 	H.suiciding = FALSE
-	H.name = H.get_visible_name()
+	H.update_name()
 	return TRUE
 
 //Grow clones to maturity then kick them out.  FREELOADERS

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -363,7 +363,6 @@
 	if(!W)
 		return 0
 	var/success = 0
-	lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	var/index = is_holding_item(W)
 	if(index)
 		held_items[index] = null
@@ -379,7 +378,7 @@
 		update_inv_wear_mask()
 	else
 		return 0
-
+	lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	if(success)
 		if(client)
 			client.screen -= W

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -291,7 +291,6 @@
 
 		//W.dropped(src)
 		//update_icons() // Redundant as u_equip will handle updating the specific overlay
-	lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	return 1
 
 
@@ -364,7 +363,7 @@
 	if(!W)
 		return 0
 	var/success = 0
-
+	lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	var/index = is_holding_item(W)
 	if(index)
 		held_items[index] = null

--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -19,7 +19,7 @@
 			if (istype(cuffs) && cuffs.mutual_handcuffed_mobs.len) //if those are regular cuffs, and there are mobs cuffed to each other, do the mutual handcuff logic
 				src.mutual_handcuffs = cuffs
 				update_inv_mutual_handcuffed(redraw_mob)
-			else 
+			else
 				src.handcuffed = cuffs
 				update_inv_handcuffed(redraw_mob)
 		else
@@ -52,13 +52,15 @@
 		success = 1
 		slot = slot_r_store
 		update_inv_pockets()
+		lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	else if (W == l_store)
 		l_store = null
 		success = 1
 		slot = slot_l_store
 		update_inv_pockets()
+		lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	else
-		..()
+		success = ..()
 
 	if(success)
 		if (W)

--- a/code/modules/mob/living/carbon/alien/larva/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/larva/inventory.dm
@@ -8,13 +8,13 @@
 		return
 	if(!istype(W))
 		return
-
+	lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	switch(slot)
 		if(slot_handcuffed)
 			var/obj/item/weapon/handcuffs/cuffs = W
 			if (istype(cuffs) && cuffs.mutual_handcuffed_mobs.len) //if those are regular cuffs, and there are mobs cuffed to each other, do the mutual handcuff logic
 				src.mutual_handcuffs = cuffs
-			else 
+			else
 				src.handcuffed = W
 		else
 			return

--- a/code/modules/mob/living/carbon/alien/larva/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/larva/inventory.dm
@@ -8,7 +8,6 @@
 		return
 	if(!istype(W))
 		return
-	lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	switch(slot)
 		if(slot_handcuffed)
 			var/obj/item/weapon/handcuffs/cuffs = W

--- a/code/modules/mob/living/carbon/complex/martian/inventory.dm
+++ b/code/modules/mob/living/carbon/complex/martian/inventory.dm
@@ -85,8 +85,9 @@
 		head = null
 		success = 1
 		update_inv_head()
+		lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	else
-		..()
+		success = ..()
 
 	if(success)
 		if (W)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -386,17 +386,17 @@
 	else
 		return if_no_id
 	return
-//repurposed proc. Now it combines get_id_name() and get_face_name() to determine a mob's name variable. Made into a seperate proc as it'll be useful elsewhere
+//repurposed proc. Now it combines get_worn_id_name() and get_face_name() to determine a mob's name variable. Made into a seperate proc as it'll be useful elsewhere
 /mob/living/carbon/human/proc/get_visible_name()
 	if( wear_mask && wear_mask.is_hidden_identity())	//Wearing a mask which hides our face, use id-name if possible
-		return get_id_name("Unknown")
+		return get_worn_id_name("Unknown")
 	if( head && head.is_hidden_identity())
-		return get_id_name("Unknown")	//Likewise for hats
+		return get_worn_id_name("Unknown")	//Likewise for hats
 	var/datum/role/vampire/V = isvampire(src)
 	if(V && (/datum/power/vampire/shadow in V.current_powers) && V.ismenacing)
-		return get_id_name("Unknown")
+		return get_worn_id_name("Unknown")
 	var/face_name = get_face_name()
-	var/id_name = get_id_name("")
+	var/id_name = get_worn_id_name("")
 	if(id_name && (id_name != face_name))
 		return "[face_name] (as [id_name])"
 	return face_name
@@ -409,7 +409,7 @@
 
 //gets name from ID or PDA itself, ID inside PDA doesn't matter
 //Useful when player is being seen by other mobs
-/mob/living/carbon/human/proc/get_id_name(var/if_no_id = "Unknown")
+/mob/living/carbon/human/proc/get_worn_id_name(var/if_no_id = "Unknown")
 	if(wear_id)
 		. = wear_id.get_owner_name_from_ID()
 	if(!.)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -237,7 +237,6 @@
 	if(!W)
 		return 0
 	var/success
-	lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	var/index = is_holding_item(W)
 	if(index)
 		held_items[index] = null
@@ -348,7 +347,8 @@
 		update_inv_legcuffed()
 	else
 		return 0
-
+	// Call update_name AFTER the inventory gets updated.
+	lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	if(success)
 		update_hidden_item_icons(W)
 

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -237,6 +237,7 @@
 	if(!W)
 		return 0
 	var/success
+	lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	var/index = is_holding_item(W)
 	if(index)
 		held_items[index] = null

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -165,7 +165,7 @@
 
 /mob/living/carbon/human/get_alt_name()
 	if(name != GetVoice())
-		return get_id_name("Unknown")
+		return get_worn_id_name("Unknown")
 	return null
 
 /mob/living/carbon/human/say_understands(var/mob/other,var/datum/language/speaking = null)

--- a/code/modules/mob/living/carbon/monkey/inventory.dm
+++ b/code/modules/mob/living/carbon/monkey/inventory.dm
@@ -101,20 +101,20 @@
 		hat = null
 		success = 1
 		slot = slot_head
-		lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 		update_inv_hat()
+		lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	else if(W == glasses)
 		glasses = null
 		success = 1
 		slot = slot_glasses
-		lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 		update_inv_glasses()
+		lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	else if(W == uniform)
 		uniform = null
 		success = 1
 		slot = slot_w_uniform
-		lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 		update_inv_uniform()
+		lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	else
 		success = ..()
 	if(success)

--- a/code/modules/mob/living/carbon/monkey/inventory.dm
+++ b/code/modules/mob/living/carbon/monkey/inventory.dm
@@ -30,7 +30,7 @@
 			if (istype(cuffs) && cuffs.mutual_handcuffed_mobs.len) //if those are regular cuffs, and there are mobs cuffed to each other, do the mutual handcuff logic
 				src.mutual_handcuffs = cuffs
 				update_inv_mutual_handcuffed(redraw_mob)
-			else 
+			else
 				src.handcuffed = W
 				update_inv_handcuffed(redraw_mob)
 		if(slot_legcuffed)
@@ -101,19 +101,22 @@
 		hat = null
 		success = 1
 		slot = slot_head
+		lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 		update_inv_hat()
 	else if(W == glasses)
 		glasses = null
 		success = 1
 		slot = slot_glasses
+		lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 		update_inv_glasses()
 	else if(W == uniform)
 		uniform = null
 		success = 1
 		slot = slot_w_uniform
+		lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 		update_inv_uniform()
 	else
-		..()
+		success = ..()
 	if(success)
 		if (W)
 			if (client)

--- a/code/modules/mob/living/silicon/mommi/mommi_inventory.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_inventory.dm
@@ -42,7 +42,6 @@
 	return TRUE
 
 /mob/living/silicon/robot/mommi/u_equip(W as obj)
-	lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	if(W == tool_state)
 		if(module_active == tool_state)
 			module_active = null
@@ -54,6 +53,7 @@
 		head_state = null
 		// Update the MoMMI's head inventory icons
 		update_inv_head()
+	lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 
 // Override the default /mob version since we only have one hand slot.
 /mob/living/silicon/robot/mommi/put_in_active_hand(var/obj/item/W)

--- a/code/modules/mob/living/silicon/mommi/mommi_inventory.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_inventory.dm
@@ -42,6 +42,7 @@
 	return TRUE
 
 /mob/living/silicon/robot/mommi/u_equip(W as obj)
+	lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	if(W == tool_state)
 		if(module_active == tool_state)
 			module_active = null

--- a/code/modules/mob/living/simple_animal/hologram/hologram_inventory.dm
+++ b/code/modules/mob/living/simple_animal/hologram/hologram_inventory.dm
@@ -8,16 +8,19 @@
 		head = null
 		success = 1
 		update_inv_head()
+		lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	if (W == w_uniform)
 		w_uniform = null
 		success = 1
 		update_inv_w_uniform()
+		lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	if (W == wear_suit)
 		wear_suit = null
 		success = 1
 		update_inv_wear_suit()
+		lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	else
-		..()
+		success = ..()
 
 	if(success)
 		if (W)
@@ -30,7 +33,7 @@
 			if(W)
 				W.reset_plane_and_layer()
 
-	return
+	return success
 
 /mob/living/simple_animal/hologram/advanced/equip_to_slot(obj/item/W, slot, redraw_mob = 1)
 	if(!istype(W))

--- a/code/modules/mob/living/simple_animal/hostile/grinch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grinch.dm
@@ -44,9 +44,9 @@
 		back = null
 		success = 1
 		update_inv_back()
-
+		lazy_invoke_event(/lazy_event/on_unequipped, list(W))
 	else
-		..()
+		success = ..()
 
 	if(success)
 		if (W)
@@ -59,7 +59,7 @@
 			if(W)
 				W.reset_plane_and_layer()
 
-	return
+	return success
 
 /mob/living/simple_animal/hostile/gremlin/grinch/equip_to_slot(obj/item/W, slot, redraw_mob = 1)
 	if(!istype(W))

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -154,7 +154,7 @@
 		target.visible_message("<span class='notice'>[target]'s face has been repaired.</span>")
 	target.op_stage.face = 0
 	target.op_stage.tooth_replace = 0
-	target.name = target.get_visible_name()
+	target.update_name()
 
 /datum/surgery_step/face/cauterize/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)


### PR DESCRIPTION
Closes #28657
It actually took me some time to understand and tackle the bug, so I did some housekeeping while I was at it.

1. Changed a `X.name = X.get_visible_name()` by `X.update_name()` which is what is called elsewhere, and should be called for consistency.
2. Changed a `lazy_invoke_event(/lazy_event/on_unequipped, list(W))` from a specific `drop_from_inventory` to a more generic `u_equip`. In the meantime, I made sure it is called in every possible "path" of the `u_equip` proc call, *after* making sure the item is no longer worn by the user. I also made the parent calls of `u_equip` return whether or not it succeeded, which wasn't the case before. This may or may not fix some issues with item icons not updating. Some copypaste still remain but I wasted enough time on this
3. Changed a proc name (`get_id_name()`) shared by a global proc and a human-specific proc, which could cause ambiguity in reading the code.
4. 
🆑 
* bugfix: Fixed a bug where identity would sometimes not update with concealed face.