### PR TITLE
Fixes prisonners sometimes given the wrong outfits

### DIFF
--- a/code/datums/gamemode/role/prisoner.dm
+++ b/code/datums/gamemode/role/prisoner.dm
@@ -36,11 +36,6 @@
 	))
 
 	H.set_species(species)
-
-	//Give them their outfit
-	var/datum/outfit/special/prisoner/outfit = new /datum/outfit/special/prisoner
-	outfit.equip(H)
-
 	//Randomize their looks (but let them pick a name)
 	H.randomise_appearance_for()
 	var/randname = random_name(H.gender, H.species.name)
@@ -48,6 +43,10 @@
 	H.regenerate_icons()
 	H.dna.ResetUIFrom(H)
 	H.dna.ResetSE()
+
+	//Give them their outfit
+	var/datum/outfit/special/prisoner/outfit = new /datum/outfit/special/prisoner
+	outfit.equip(H)
 	mob_rename_self(H, "prisoner")
 
 	//Send them to the starting location.


### PR DESCRIPTION
Closes #29149 
Closes #28829 
Closes #28921 
Closes #28899 

All of those because the game selects the race of the prisoner, equips him according to that race, and then scrambles the DNA/UI/UE which can in (rare?) some cases change their race.

I fix this by giving them their outfit when and only when their body has been fully generated.