### PR TITLE
fixes misc sql errors

### DIFF
--- a/code/datums/feedback.dm
+++ b/code/datums/feedback.dm
@@ -144,7 +144,9 @@ var/datum/blackbox/blackbox = new
 		value = num
 
 /datum/feedback_variable/proc/get_value()
-	return value
+	var/to_copy = value
+	to_copy = replacetext(to_copy, "\"", "") // Get rid of double quotes (") in entries.
+	return to_copy
 
 /datum/feedback_variable/proc/get_variable()
 	return variable

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -40,7 +40,6 @@
 
 	var/role_alt_title
 
-	var/datum/job/assigned_job
 	var/job_priority // How much did we want the job we ended up having? Used for assistant rerolls.
 
 	var/datum/religion/faith

--- a/code/datums/statistics/statcollection.dm
+++ b/code/datums/statistics/statcollection.dm
@@ -146,7 +146,7 @@
 /datum/stat/manifest_entry/New(var/datum/mind/M)
 	key = ckey(M.key)
 	name = STRIP_NEWLINE(M.name)
-	assignment = STRIP_NEWLINE(M.assigned_job)
+	assignment = STRIP_NEWLINE(M.assigned_role)
 
 /datum/stat_collector/proc/get_valid_file(var/extension = "json")
 	var/filename_date = time2text(round_start_time, "YYYY-MM-DD")

--- a/code/defines/procs/statistics.dm
+++ b/code/defines/procs/statistics.dm
@@ -60,7 +60,7 @@
 		log_game("SQL ERROR during death reporting. Failed to connect.")
 	else
 		var/datum/DBQuery/query = SSdbcore.NewQuery("INSERT INTO death (name, byondkey, job, special, pod, tod, laname, lakey, gender, bruteloss, fireloss, brainloss, oxyloss, coord) VALUES (:name, :key, :job, :special, :pod, :time, :laname, :lakey, :gender, :bruteloss, :fireloss, :brainloss, :oxyloss, :coord)",
-		list("name" = H.name, "key" = H.key, "job" = H.mind.assigned_job, "special" = H.mind.assigned_role, "pod" = podname, "time" = sqltime, "laname" = laname, "lakey" = lakey, "gender" = "[H.gender]", "bruteloss" = "[H.getBruteLoss()]", "fireloss" = "[H.getFireLoss()]", "brainloss" = "[H.brainloss]", "oxyloss" = "[H.getOxyLoss()]", "coord" = "[coord]"))
+		list("name" = H.name, "key" = H.key, "job" = H.mind.assigned_role, "special" = (H.mind.assigned_role || "no role"), "pod" = podname, "time" = sqltime, "laname" = laname, "lakey" = lakey, "gender" = "[H.gender]", "bruteloss" = "[H.getBruteLoss()]", "fireloss" = "[H.getFireLoss()]", "brainloss" = "[H.brainloss]", "oxyloss" = "[H.getOxyLoss()]", "coord" = "[coord]"))
 		if(!query.Execute())
 			var/err = query.ErrorMsg()
 			log_game("SQL ERROR during death reporting. Error : \[[err]\]\n")

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -52,6 +52,9 @@
 		if(banned_mob.client)
 			computerid = banned_mob.client.computer_id
 			ip = banned_mob.client.address
+		else
+			computerid = banned_mob.computer_id
+			ip = banned_mob.lastKnownIP
 	else if(banckey)
 		ckey = ckey(banckey)
 

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -49,6 +49,8 @@
 
 	if(ismob(banned_mob))
 		ckey = banned_mob.ckey
+		if (!ckey && banned_mob.mind)
+			ckey = ckey(banned_mob.mind.key)
 		if(banned_mob.client)
 			computerid = banned_mob.client.computer_id
 			ip = banned_mob.client.address

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1508,7 +1508,8 @@
 			return
 
 		var/mob/M = locate(href_list["newban"])
-		if(!ismob(M))
+		if(!ismob(M) || !M.ckey)
+			to_chat(usr, "<span class='notice'>There is no mob, or no ckey, to ban. Perhaps the player has ghosted?</span>")
 			return
 
 		// now you can! if(M.client && M.client.holder)	return	//admins cannot be banned. Even if they could, the ban doesn't affect them anyway


### PR DESCRIPTION
One annoying error every time a mob died, due to the (no longer used) `assigned_job` variable being passed as null. This means deaths will actually be recorded now. I think they have silently failed to be recorded for a very, very long time.

One error for recording the "black box" of the round (how many traitor items being bought, what kind, etc...) which would fail if some entries had double quotes (`"`) in them.
```
[09:25:03]SQL: MySqlError { ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'Does Not Tip" database backdoor RN RN Power Sink Energized Bananium Sword Banana' at line 1 }
```

Most importantly for admins, one which would silently fail if a mob had left the game (`column "computerid" cannot be null`), and one which would silently fail if a mob had ghosted, but the admin was still using their player panel. (`column "ckey" cannot be null`). Closes #28978 