### PR TITLE
Fixes seeing two, unrelated, cancel options in the voting window

### DIFF
--- a/code/modules/html_interface/html_interface.dm
+++ b/code/modules/html_interface/html_interface.dm
@@ -198,7 +198,9 @@ mob/verb/test()
 			if (hclient.is_loaded)
 				hclient.client << output(list2params(arguments), "browser_\ref[src].browser:[func]")
 	else
-		for (var/client in src.clients) if (src.clients[client]) src.callJavaScript(func, arguments, src.clients[client])
+		for (var/client in src.clients)
+			if (src.clients[client])
+				src.callJavaScript(func, arguments, src.clients[client])
 
 /datum/html_interface/proc/updateLayout(nlayout)
 	src.layout = nlayout

--- a/code/modules/html_interface/voting/voting.js
+++ b/code/modules/html_interface/voting/voting.js
@@ -55,7 +55,10 @@ function update_mode(newMode, newQuestion, newTimeleft, vrestart, vmode){
 		$("#vote_main").hide();
 		$("#vote_choices").show();
 		$("#vote_choices").append($("<div class='item'></div>").append($("<div class='itemContent'></div>").html("<a "  +  "href='?src=" + hSrc + ";vote=cancel_vote" + "'>Cancel your vote</a>")));
-		if(admin > 0) $("#vote_admin").show();
+		if(admin > 0)
+			$("#vote_admin").show();
+		else
+			$("#vote_admin").hide();
 	}
 	else{
 		$("#vote_main").show();


### PR DESCRIPTION
Closes #29227. I tested if the dumbest solution possible worked and it did.
Apparently, since the `#vote_admin` section of the voting window is shown to admins (at the very least), and it's not hidden, players see it too. They cannot interact with it, but they still see the button that only admins should see.

I think, at least.