### PR TITLE
Security Centcomm order: Captured antags

### DIFF
--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -314,7 +314,12 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 		M.angry = 0
 		M.apply_disguise()
 	for(var/mob/living/M in contents)
-		if(!istype(M, /mob/living/simple_animal/hostile/mimic))
+		if(isanyantag(M))
+			for(var/datum/centcomm_order/O in centcomm_orders)
+				if(istype(O,/datum/centcomm_order/department/security/criminal))
+					return FALSE
+			return TRUE
+		else if(!istype(M, /mob/living/simple_animal/hostile/mimic))
 			return TRUE
 
 	if (locate(/obj/item/weapon/disk/nuclear) in contents)

--- a/code/game/centcomm_orders/orders_security.dm
+++ b/code/game/centcomm_orders/orders_security.dm
@@ -1,0 +1,23 @@
+/datum/centcomm_order/department/security
+	acct_by_string = "Security"
+	request_consoles_to_notify = list(
+		"Head of Security's Desk",
+		"Security"
+		)
+
+/datum/centcomm_order/department/security/criminal/New()
+	..()
+	must_be_in_crate = 0
+	requested = list(
+		/mob/living = 1
+	)
+	name_override = list(
+		/mob/living = "Captured Enemy of the Corporation"
+	)
+	extra_requirements = "Dead or alive, dead paying half."
+	worth = 1200
+
+/datum/centcomm_order/department/security/criminal/ExtraChecks(var/mob/living/L)
+    if(!isanyantag(L))
+        return 0
+    return 1

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -542,6 +542,7 @@
 #include "code\game\centcomm_orders\orders_engineering.dm"
 #include "code\game\centcomm_orders\orders_medical.dm"
 #include "code\game\centcomm_orders\orders_science.dm"
+#include "code\game\centcomm_orders\orders_security.dm"
 #include "code\game\centcomm_orders\orders_service.dm"
 #include "code\game\dna\dna2.dm"
 #include "code\game\dna\dna2_domutcheck.dm"


### PR DESCRIPTION
[content]

Todo:
- [ ] Check for dead antagonists, and halve credit payout
- [ ] Move ghost of qdel'd player back to z1
- [ ] Testing in general

:cl:
 * rscadd: Captured antagonists may now be sent to centcomm when an order is requested for them, for credits