### PR TITLE
Internal Affairs Agents now glow slightly

### DIFF
--- a/code/datums/outfit/civilian.dm
+++ b/code/datums/outfit/civilian.dm
@@ -669,9 +669,11 @@
 /datum/outfit/iaa/post_equip(var/mob/living/carbon/human/H)
 	..()
 	H.put_in_hands(new /obj/item/weapon/storage/briefcase/centcomm(H))
-	if(H.mind.role_alt_title == "Lawyer" || H.mind.role_alt_title == "Bridge Officer") //Lawyers and bridge officers are exempt
-		return
-	H.set_light(1, 3, "#006400") //Dark green, RGB(0,100,0)
+	equip_accessory(H, /obj/item/clothing/accessory/glowstick/nanotrasen, /obj/item/clothing/under)
+	if(Holiday == APRIL_FOOLS_DAY)
+		if(H.mind.role_alt_title == "Lawyer" || H.mind.role_alt_title == "Bridge Officer") //Lawyers and bridge officers are exempt
+			return
+		H.set_light(1, 4, "#006400") //Dark green, RGB(0,100,0)
 
 // -- Chaplain
 

--- a/code/datums/outfit/civilian.dm
+++ b/code/datums/outfit/civilian.dm
@@ -669,7 +669,9 @@
 /datum/outfit/iaa/post_equip(var/mob/living/carbon/human/H)
 	..()
 	H.put_in_hands(new /obj/item/weapon/storage/briefcase/centcomm(H))
-	H.set_light(1, 3, "#006400") //Green
+	if(H.mind.role_alt_title == "Lawyer" || H.mind.role_alt_title == "Bridge Officer") //Lawyers and bridge officers are exempt
+		return
+	H.set_light(1, 3, "#006400") //Dark green, RGB(0,100,0)
 
 // -- Chaplain
 

--- a/code/datums/outfit/civilian.dm
+++ b/code/datums/outfit/civilian.dm
@@ -669,6 +669,7 @@
 /datum/outfit/iaa/post_equip(var/mob/living/carbon/human/H)
 	..()
 	H.put_in_hands(new /obj/item/weapon/storage/briefcase/centcomm(H))
+	H.set_light(1, 3, "#006400") //Green
 
 // -- Chaplain
 

--- a/code/game/objects/items/weapons/glowstick.dm
+++ b/code/game/objects/items/weapons/glowstick.dm
@@ -113,3 +113,15 @@
 	color = rgb(r, g, b)
 	set_light(2, l_color = color)
 	update_icon()
+
+/obj/item/clothing/accessory/glowstick/nanotrasen
+	name = "IAA Identifier"
+	desc = "Provided to Internal Affairs Agents to allow them to distinguish each other during field operations, it emits a subtle green glow."
+	color = rgb(0, 100, 0) //Dark green, this is also pointless because you can't crack it.
+
+/obj/item/clothing/accessory/glowstick/nanotrasen/New()
+	..()
+	set_light(1, 3, "#006400")
+
+/obj/item/clothing/accessory/glowstick/nanotrasen/attack_self(mob/user)
+	return //It automatically glows


### PR DESCRIPTION
Doctor Pavlos? I'm IAA.
![IAA](https://i.imgur.com/SfPvqLx.png)
This is a serious PR.
IAAs will glow innately and slightly brighter during April Fools.

:cl:
 * tweak: Nanotrasen's Internal Affairs Agents are now provided with an object that allows them to identify each other in lower-light conditions, which is attached to the jumpsuit by default.