### PR TITLE
Adds midround threat intercept paper and announcement

### DIFF
--- a/__DEFINES/role_datums_defines.dm
+++ b/__DEFINES/role_datums_defines.dm
@@ -238,6 +238,11 @@
 #define INTERCEPT_TIME_LOW 10 MINUTES
 #define INTERCEPT_TIME_HIGH 18 MINUTES
 
+// -- The other paper
+
+#define INTERCEPT_MID_TIME_LOW 60 MINUTES
+#define INTERCEPT_MID_TIME_HIGH 90 MINUTES
+
 // -- Injection delays (in ticks, ie, you need the /20 to get the real result)
 
 #define LATEJOIN_DELAY_MIN (5 MINUTES)/20

--- a/code/datums/gamemode/gamemode.dm
+++ b/code/datums/gamemode/gamemode.dm
@@ -188,10 +188,10 @@
 		display_roundstart_logout_report()
 
 	spawn (rand(INTERCEPT_TIME_LOW , INTERCEPT_TIME_HIGH))
-		send_intercept(starting_threat)
+		send_intercept(TRUE)
 
 	spawn (rand(INTERCEPT_MID_TIME_LOW , INTERCEPT_MID_TIME_HIGH))
-		send_intercept(midround_starting_threat)
+		send_intercept(FALSE)
 
 	feedback_set_details("round_start","[time2text(world.realtime)]")
 	if(ticker && ticker.mode)

--- a/code/datums/gamemode/gamemode.dm
+++ b/code/datums/gamemode/gamemode.dm
@@ -188,7 +188,10 @@
 		display_roundstart_logout_report()
 
 	spawn (rand(INTERCEPT_TIME_LOW , INTERCEPT_TIME_HIGH))
-		send_intercept()
+		send_intercept(starting_threat)
+
+	spawn (rand(INTERCEPT_MID_TIME_LOW , INTERCEPT_MID_TIME_HIGH))
+		send_intercept(midround_starting_threat)
 
 	feedback_set_details("round_start","[time2text(world.realtime)]")
 	if(ticker && ticker.mode)

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -102,7 +102,7 @@
 
 	command_alert(/datum/command_alert/enemy_comms_interception)
 
-/datum/gamemode/dynamic/send_intercept()
+/datum/gamemode/dynamic/send_intercept(var/threat)
 	var/intercepttext = {"<html><style>
 						body {color: #000000; background: #EDD6B6;}
 						h1 {color: #000000; font-size:30px;}
@@ -110,7 +110,7 @@
 						<body>
 						<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"><BR>"}
 
-	var/list/threat_detected = round(starting_threat)
+	var/list/threat_detected = round(threat)
 
 	switch(threat_detected)
 		if(0 to 19)

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -102,7 +102,7 @@
 
 	command_alert(/datum/command_alert/enemy_comms_interception)
 
-/datum/gamemode/dynamic/send_intercept(var/threat)
+/datum/gamemode/dynamic/send_intercept(var/roundstart = TRUE)
 	var/intercepttext = {"<html><style>
 						body {color: #000000; background: #EDD6B6;}
 						h1 {color: #000000; font-size:30px;}
@@ -110,7 +110,7 @@
 						<body>
 						<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"><BR>"}
 
-	var/list/threat_detected = round(threat)
+	var/list/threat_detected = roundstart ? round(starting_threat) : round(midround_starting_threat)
 
 	switch(threat_detected)
 		if(0 to 19)


### PR DESCRIPTION
Within 60-90 minutes of a round, timing subject to change to 45-60 unless this is fine

:cl:
 * rscadd: Midround threat is now intercepted by command reports