### PR TITLE
Fixes custom shuttles not working most of the time

### DIFF
--- a/code/game/machinery/computer/shuttle_computers.dm
+++ b/code/game/machinery/computer/shuttle_computers.dm
@@ -14,6 +14,7 @@
 
 	var/list/allowed_shuttles = list() //List of allowed shuttles. Accepts paths (for example /datum/shuttle/arrival). If empty, all shuttles are allowed
 	starting_materials = list(MAT_GLASS = 1250)
+
 //Example:
 /obj/item/weapon/disk/shuttle_coords/station_arrivals
 	destination = /obj/docking_port/destination/transport/station

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -538,7 +538,7 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 	my_docking_port_dest.desc = "This disc links to the home base of [user]'s custom shuttle, [name]."
 	my_docking_port_dest.header = "[name] home port"
 	user.put_in_hands(my_docking_port_dest)
-	to_chat(user, "<span class='notice'>Congratulations! You have succesfully created a shuttle. You will find in your hands the destination disk linked to your home base, which is where you creatred the shuttle. Don't lose it, it cannot be replaced!</span>")
+	to_chat(user, "<span class='notice'>Congratulations! You have succesfully created a shuttle. You will find in your hands the destination disk linked to your home base, which is where you created the shuttle. Don't lose it, it cannot be replaced!</span>")
 	to_chat(user, "<span class='notice'><h3>Happy hunting!</h3></span>")
 
 	message_admins("<span class='notice'>[key_name_admin(user)] has turned [A.name] into a shuttle named [S.name]. [formatJumpTo(get_turf(user))]</span>")

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -520,14 +520,26 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 
 	var/obj/docking_port/shuttle/DP = new /obj/docking_port/shuttle(get_turf(src))
 	DP.dir = user.dir
-
+	// Link the custom shuttle to a basic homing port to return to.
+	var/turf/home_base = get_step(get_turf(DP), DP.dir)
+	var/obj/docking_port/destination/my_shuttle_home_base = new(home_base)
+	my_shuttle_home_base.name = "[name] home port"
+	my_shuttle_home_base.dir = reverse_direction(DP.dir)
 
 	var/datum/shuttle/custom/S = new(starting_area = A)
 	S.initialize()
 	S.name = name
+	S.linked_port.docked_with = my_shuttle_home_base
 
-	to_chat(user, "Shuttle created!")
-
+	to_chat(user, "<span class='notice'>Shuttle created!</span>")
+	var/obj/item/weapon/disk/shuttle_coords/my_docking_port_dest = new(get_turf(src))
+	my_docking_port_dest.destination = my_shuttle_home_base
+	my_docking_port_dest.name = "[name] home port"
+	my_docking_port_dest.desc = "This disc links to the home base of [user]'s custom shuttle, [name]."
+	my_docking_port_dest.header = "[name] home port"
+	user.put_in_hands(my_docking_port_dest)
+	to_chat(user, "<span class='notice'>Congratulations! You have succesfully created a shuttle. You will find in your hands the destination disk linked to your home base, which is where you creatred the shuttle. Don't lose it, it cannot be replaced!</span>")
+	to_chat(user, "<span class='notice'><h3>Happy hunting!</h3></span>")
 
 	message_admins("<span class='notice'>[key_name_admin(user)] has turned [A.name] into a shuttle named [S.name]. [formatJumpTo(get_turf(user))]</span>")
 	log_admin("[key_name(user)]  has turned [A.name] into a shuttle named [S.name].")


### PR DESCRIPTION
Fixes #26047.

As it turns out, the error message was misleading: the shuttle *did* attempt to move out successfully, and *did* set its docking port correctly, **but** there was no *home port* attached the custom shuttle upon build, unless you built your shuttle specifically in a place which overlapped with an existing shuttle (such as building your custom shuttle where the escape shuttle, the mining shuttle, or any other, would be).

As there was no home port, the shuttle would runtime when trying to actually move to its destination. This first runtime error described what the problem actually was: no docking port associated to the shuttle upon its building.

It would think it arrived safely, when the user would see it hadn't moved. Most of the time, the user would attempt to make it move again, which would produce an other error message: you can't move to a docking port which you are already docked to (as far as the shuttle is concerned).

I fixed this by giving the custom shuttle an "home base" port upon creation. I also gave the builder a destination disk for this home base, allowing them to go back and forth to their port of creation as they please.

Screenshots:

![shuttle_arrivals](https://user-images.githubusercontent.com/31417754/115221906-71726780-a10a-11eb-9844-ded9fc5c4829.png)
![shuttle_working](https://user-images.githubusercontent.com/31417754/115221914-720afe00-a10a-11eb-88e3-e6f514357ea0.png)

:cl:
- bugfix: Custom shuttles now work no matter you build them. Previously, they would only work if you build them next to an already existing docking port.
- rscadd: Building a custom shuttle will now give you a unique destination disk associated to its port of creation, allowing you to go back and forth to existing docking ports and the place where you build your shuttle.