### PR TITLE
A bug bug was bugging me. Rads radically less radioactive. Bugs slightly more radical.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -500,3 +500,6 @@ This function restores all organs.
 		if(reagents.has_reagent(LITHOTORCRAZINE))
 			rads = rads/2
 	return ..()
+
+/mob/living/carbon/human/insectoid/apply_radiation(var/rads, var/application = RAD_EXTERNAL)
+	..(rads/2, application)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -492,14 +492,12 @@ This function restores all organs.
 /mob/living/carbon/human/apply_radiation(var/rads, var/application = RAD_EXTERNAL)
 	if(species.flags & RAD_IMMUNE)
 		return
-
 	if(application == RAD_EXTERNAL)
 		lazy_invoke_event(/lazy_event/on_irradiate, list("user" = src, "rads" = rads))
-
 	if(reagents)
 		if(reagents.has_reagent(LITHOTORCRAZINE))
-			rads = rads/2
+			rads /= 2
+	if(isinsectoid(src))
+		rads /= 2
 	return ..()
 
-/mob/living/carbon/human/insectoid/apply_radiation(var/rads, var/application = RAD_EXTERNAL)
-	..(rads/2, application)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -497,7 +497,7 @@ This function restores all organs.
 	if(reagents)
 		if(reagents.has_reagent(LITHOTORCRAZINE))
 			rads /= 2
-	if(isinsectoid(src))
-		rads /= 2
+	if(species.rad_mod)
+		rads *= species.rad_mod
 	return ..()
 

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1201,6 +1201,7 @@ var/list/has_died_as_golem = list()
 
 	burn_mod = 1.1
 	tox_mod = 0.5
+	rad_mod = 0.5
 
 	blood_color = "#ebece6"
 	flesh_color = "#9c7f25"

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1198,7 +1198,6 @@ var/list/has_died_as_golem = list()
 	flags = IS_WHITELISTED
 	anatomy_flags = HAS_LIPS | HAS_SWEAT_GLANDS | NO_BALD | RGBSKINTONE
 
-	default_mutations=list(RAD_IMMUNE)
 	burn_mod = 1.1
 	tox_mod = 0.5
 
@@ -1247,6 +1246,7 @@ var/list/has_died_as_golem = list()
 
 /datum/species/insectoid/gib(mob/living/carbon/human/H) //changed from Skrell to Insectoid for testing
 	H.default_gib()
+
 
 
 /datum/species/mushroom

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -79,6 +79,7 @@ var/global/list/whitelisted_species = list("Human")
 	var/brute_mod 		// brute multiplier
 	var/burn_mod		// burn multiplier
 	var/tox_mod			// toxin multiplier
+	var/rad_mod			// radiation multiplier
 
 	var/body_temperature = 310.15
 


### PR DESCRIPTION
Insectoids were never immune or resistant to radiation. They had the wrong flag in the wrong place and I'm surprised it never caused any issues. 
This PR makes them receive 50% the radiation of other species. Since they were intended to be immune but we've all gotten used to a placebo 0% resistance I figure this is a good compromise. 

bugthemed [bugfix]

:cl:
 * bugfix: Bugfixes bugs fixing their lack of radiation resistance