### PR TITLE
Rocket-Dash spell icon fix & Mecha-mounted teleporter tweak

### DIFF
--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -187,13 +187,6 @@
 	charge_max = 30
 	charge_counter = 30
 
-/spell/mech/marauder/dash/New()
-	..()
-	hud_state = linked_mech.initial_icon + "-dash"
-
-/spell/mech/marauder/dash/update_spell_icon()
-	hud_state = "[linked_mech.initial_icon]-dash"
-
 /spell/mech/marauder/dash/cast_check(skipcharge = FALSE, mob/user = usr)
 	if(linked_mech.lock_controls)
 		return FALSE

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -602,7 +602,7 @@
 	if(T)
 		set_ready_state(0)
 		chassis.use_power(energy_drain)
-		do_teleport(chassis, T, 4)
+		do_teleport(chassis, T)
 		do_after_cooldown()
 	return
 

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -19,7 +19,7 @@ mob/living/carbon/proc/dream()
 		"a vox","a plasmaman","a skellington","a diona","the derelict","the end of the world","the thunderdome","a ship full of dead clowns","a chicken with godlike powers",
 		"a red bus that drives through space","an alien artifact","the mechanic","a newspaper","an insectoid","a slime","a slime person","a mushroom person",
 		"the Cult of Nar-Sie","the Wizard Federation","an impossibly gigantic lamprey floating through space, bending reality as it goes","a sword that talks",
-		"an eclipse","a sandwhich so tall that it pierces the heavens"
+		"an eclipse","a sandwich so tall that it pierces the heavens"
 		)
 	spawn(0)
 		for(var/i = rand(1,4),i > 0, i--)

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -19,7 +19,7 @@ mob/living/carbon/proc/dream()
 		"a vox","a plasmaman","a skellington","a diona","the derelict","the end of the world","the thunderdome","a ship full of dead clowns","a chicken with godlike powers",
 		"a red bus that drives through space","an alien artifact","the mechanic","a newspaper","an insectoid","a slime","a slime person","a mushroom person",
 		"the Cult of Nar-Sie","the Wizard Federation","an impossibly gigantic lamprey floating through space, bending reality as it goes","a sword that talks",
-		"an eclipse",
+		"an eclipse","a sandwhich so tall that it pierces the heavens"
 		)
 	spawn(0)
 		for(var/i = rand(1,4),i > 0, i--)


### PR DESCRIPTION
Can't believe the icon remained blank for so long

:cl:
* bugfix: Fixed the Rocket-Dash mecha spell icon being blank
* tweak: The Exosuit-Mounted Teleporter is now precise. Previously it had a 4-tile precision radius, meaning you could land anywhere in one of the 81 tiles (in a 9x9 area) surrounding the tile you clicked, which made it utterly unreliable on top of having a long cooldown. Often you'd even teleport right where you started from.