### PR TITLE
fixes a second way to get blank votes

### DIFF
--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -449,6 +449,8 @@ var/global/datum/controller/vote/vote = new()
 	switch(href_list["vote"])
 		if ("cancel_vote")
 			var/mob_ckey = usr.ckey
+			if (!(mob_ckey in voted))
+				return
 			voted -= mob_ckey
 			choices[choices[current_votes[mob_ckey]]]--
 			current_votes[mob_ckey] = null


### PR DESCRIPTION
Closes #29305. It's perhaps not the best way, but it works.

I tested it, it does prevent blank votes while still allowing users who did vote to click the cancel button.