### PR TITLE
Fixes forcesay() often not working

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -165,7 +165,7 @@ var/list/global_deadchat_listeners
 		if(client)
 			var/virgin = 1	//has the text been modified yet?
 			var/temp = winget(client, "input", "text")
-			if(findtext(temp, "Say \"", 1, 7) && length(temp) > 5)	//case sensitive means
+			if(findtext(temp, "Say \"", 1, 7) && length(temp) > 5) //NOT case sensitive, because both "say" and "Say" can happen
 
 				temp = replacetext(temp, ";", "")	//general radio
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -165,7 +165,7 @@ var/list/global_deadchat_listeners
 		if(client)
 			var/virgin = 1	//has the text been modified yet?
 			var/temp = winget(client, "input", "text")
-			if(findtextEx(temp, "Say \"", 1, 7) && length(temp) > 5)	//case sensitive means
+			if(findtextEx(lowertext(temp), "say \"", 1, 7) && length(temp) > 5)	//case sensitive means
 
 				temp = replacetext(temp, ";", "")	//general radio
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -165,7 +165,7 @@ var/list/global_deadchat_listeners
 		if(client)
 			var/virgin = 1	//has the text been modified yet?
 			var/temp = winget(client, "input", "text")
-			if(findtextEx(lowertext(temp), "say \"", 1, 7) && length(temp) > 5)	//case sensitive means
+			if(findtext(temp, "Say \"", 1, 7) && length(temp) > 5)	//case sensitive means
 
 				temp = replacetext(temp, ";", "")	//general radio
 


### PR DESCRIPTION
it was hardcoded to check for "Say "", so if you had "say "" it wouldn't work
:cl:
 * bugfix: Fixed some instances of forcesay (from open-hand-disarm-to-mouth, among other things) not working.