### PR TITLE
listen kiddo, we don't have much time, the disk is i-

### DIFF
--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -23,7 +23,7 @@
 // roidstation.dm
 //#define MAP_OVERRIDE 4
 // test_box.dm:
-#define MAP_OVERRIDE 5
+//#define MAP_OVERRIDE 5
 // test_tiny.dm:
 //#define MAP_OVERRIDE 6
 // tgstation.dm:

--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -23,7 +23,7 @@
 // roidstation.dm
 //#define MAP_OVERRIDE 4
 // test_box.dm:
-//#define MAP_OVERRIDE 5
+#define MAP_OVERRIDE 5
 // test_tiny.dm:
 //#define MAP_OVERRIDE 6
 // tgstation.dm:

--- a/code/modules/mob/living/carbon/alien/death.dm
+++ b/code/modules/mob/living/carbon/alien/death.dm
@@ -1,4 +1,6 @@
 /mob/living/carbon/alien/gib(animation = FALSE, meat = TRUE)
+	if(!isUnconscious())
+		forcesay("-")
 	death(1)
 	monkeyizing = 1
 	canmove = 0

--- a/code/modules/mob/living/carbon/brain/death.dm
+++ b/code/modules/mob/living/carbon/brain/death.dm
@@ -80,6 +80,8 @@
 		..()
 
 /mob/living/carbon/brain/gib(animation = FALSE, meat = TRUE)
+	if(!isUnconscious())
+		forcesay("-")
 	death(1)
 	monkeyizing = 1
 	canmove = 0

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -1,4 +1,6 @@
 /mob/living/carbon/human/gib(animation = FALSE, meat = TRUE)
+	if(!isUnconscious())
+		forcesay("-")
 	if(species)
 		species.gib(src)
 		return

--- a/code/modules/mob/living/carbon/monkey/death.dm
+++ b/code/modules/mob/living/carbon/monkey/death.dm
@@ -1,4 +1,6 @@
 /mob/living/carbon/monkey/gib(animation = FALSE, meat = TRUE)
+	if(!isUnconscious())
+		forcesay("-")
 	death(1)
 	monkeyizing = 1
 	canmove = 0

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -12,6 +12,8 @@
 	..()
 
 /mob/living/gib(animation = FALSE, meat = TRUE)
+	if(!isUnconscious())
+		forcesay("-")
 	death(1)
 	monkeyizing = 1
 	canmove = 0

--- a/code/modules/mob/living/silicon/death.dm
+++ b/code/modules/mob/living/silicon/death.dm
@@ -1,4 +1,6 @@
 /mob/living/silicon/gib(animation = FALSE, meat = TRUE)
+	if(!isUnconscious())
+		forcesay("-")
 	death(1)
 	monkeyizing = 1
 	canmove = 0

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -1,5 +1,7 @@
 /mob/living/silicon/robot/gib(animation = FALSE, meat = TRUE)
 	//robots don't die when gibbed. instead they drop their MMI'd brain
+	if(!isUnconscious())
+		forcesay("-")
 	disconnect_AI()
 	monkeyizing = TRUE
 	canmove = FALSE
@@ -39,7 +41,7 @@
 	if(stat == DEAD)
 		return
 	if(connected_ai)
-		if(connected_ai.explosive_cyborgs) 
+		if(connected_ai.explosive_cyborgs)
 			visible_message("<span class='notice'>You hear a soft beep.</span>")
 			spawn(10)
 				explosion(src.loc, 1, 4, 5, 6)

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -102,6 +102,8 @@
 #undef HEAR_CULT_CHAT
 
 /mob/living/simple_animal/construct/gib(var/animation = 0, var/meat = 1)
+	if(!isUnconscious())
+		forcesay("-")
 	death(1)
 	monkeyizing = 1
 	canmove = 0

--- a/code/modules/mob/living/simple_animal/hostile/shade.dm
+++ b/code/modules/mob/living/simple_animal/hostile/shade.dm
@@ -59,6 +59,8 @@
 	alpha = 255
 
 /mob/living/simple_animal/hostile/shade/gib(var/animation = 0, var/meat = 1)
+	if(!isUnconscious())
+		forcesay("-")
 	death(TRUE)
 	monkeyizing = TRUE
 	canmove = FALSE

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -61,6 +61,8 @@
 	. = ..(message, "C")
 
 /mob/living/simple_animal/shade/gib(var/animation = 0, var/meat = 1)
+	if(!isUnconscious())
+		forcesay("-")
 	death(TRUE)
 	monkeyizing = TRUE
 	canmove = FALSE


### PR DESCRIPTION
Simple change: If you're typing while you are gibbed by any means, you are forced to say your last words out loud, same as if someone had shushed you via disarm intent to mouth. As much as you were able to type before the explosion, anyways.

This text will not go through headsets. So ";the bomber is omar ke-" will result in you simply saying "The bomber is omar ke-" normally and not into your headset's radio. Same for ":s the bomb-"

I apologize for the copypaste but gib()code is already copypasted in this way and I am not qualified to sort out the inheritance code debt.

:cl:
 * rscadd: If you are gibbed while typing, you will say your last words right before you are disintegrated.