### PR TITLE
fix DIY shuttle engine weirdness and confusing bugs

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -503,12 +503,12 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 		if(D.anchored)
 			if(D.heater) // it has a heater, great, count it
 				active_engines++
-			else // fix for engines being bolted down yet not counting
-				// check for a heater that's A. bolted down   B. positioned correctly   C. not connected to the engine
-				// if so, there's no reason it SHOULDNT be connected, so connect it
+			else // fix for engines getting their internal state desyncronized from what is actually happening
 				if(D.try_connect())
 					active_engines++
-
+				else if (D.retard_checks() && D.try_connect())
+					active_engines++
+					
 	if(active_engines < 2 || area_size/active_engines > CUSTOM_SHUTTLE_TILES_PER_ENGINE) // 1 engine per 15 tiles, with a minimum of 2 engines.
 		to_chat(user, "<span class = 'warning'>This area is not a viable shuttle. Reason: Insufficient engine count.</span>")
 		to_chat(user, "<span class = 'notice'> Detected [active_engines] of [max(2, Ceiling(area_size/CUSTOM_SHUTTLE_TILES_PER_ENGINE))] engines required for a [area_size] square meter shuttle.<br>1 engine required for every [CUSTOM_SHUTTLE_TILES_PER_ENGINE] square meters, 2 engines minimum.</span>")

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -468,10 +468,14 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 	Turns the area the person is currently in into a shuttle if it meets to certian standards
 		- Is a custom area. No players turning the bar into a shuttle
 		- Has enough engines that are active
-			- 2 engines for every 25 tiles of area.
+			- 2 engines minimum
+			- 1 engine for every 15 tiles of area.
 			- Engines must be of the DIY variety, and have a connected heater.
 		- The point they are facing is outwards on the edge of the area
 */
+
+#define CUSTOM_SHUTTLE_TILES_PER_ENGINE 15 // centralized config thingy. #de[B]ines 4 lyfe, performance forever
+
 
 /obj/item/shuttle_license
 	name = "shuttle verification license"
@@ -496,12 +500,18 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 	var/area_size = A.area_turfs.len
 	var/active_engines = 0
 	for(var/obj/structure/shuttle/engine/propulsion/DIY/D in A)
-		if(D.heater && D.anchored)
-			active_engines++
+		if(D.anchored)
+			if(D.heater) // it has a heater, great, count it
+				active_engines++
+			else // fix for engines being bolted down yet not counting
+				// check for a heater that's A. bolted down   B. positioned correctly   C. not connected to the engine
+				// if so, there's no reason it SHOULDNT be connected, so connect it
+				if(D.try_connect())
+					active_engines++
 
-	if(active_engines < 2 || area_size/active_engines > 15) //2 engines per 30 tiles, with a minimum of 2 engines.
+	if(active_engines < 2 || area_size/active_engines > CUSTOM_SHUTTLE_TILES_PER_ENGINE) // 1 engine per 15 tiles, with a minimum of 2 engines.
 		to_chat(user, "<span class = 'warning'>This area is not a viable shuttle. Reason: Insufficient engine count.</span>")
-		to_chat(user, "<span class = 'notice'> Active engine count: [active_engines]. Area size: [area_size] meters squared.</span>")
+		to_chat(user, "<span class = 'notice'> Detected [active_engines] of [max(2, Ceiling(area_size/CUSTOM_SHUTTLE_TILES_PER_ENGINE))] engines required for a [area_size] square meter shuttle.<br>1 engine required for every [CUSTOM_SHUTTLE_TILES_PER_ENGINE] square meters, 2 engines minimum.</span>")
 		return
 
 	var/turf/check_turf = get_step(user, user.dir)
@@ -544,3 +554,4 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 	message_admins("<span class='notice'>[key_name_admin(user)] has turned [A.name] into a shuttle named [S.name]. [formatJumpTo(get_turf(user))]</span>")
 	log_admin("[key_name(user)]  has turned [A.name] into a shuttle named [S.name].")
 	qdel(src)
+#undef CUSTOM_SHUTTLE_TILES_PER_ENGINE

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -82,6 +82,15 @@
 	to_chat(user, "<span class = 'warning'>There is no engine within range of \the [src] it can connect to.</span>")
 	return FALSE
 	
+/obj/structure/shuttle/engine/heater/DIY/wrenchAnchor(var/mob/user, var/obj/item/I, var/obj/item/I, var/time_to_wrench = 3 SECONDS)
+	.=..()
+	if(.)
+		if(!anchored)
+			disconnect()
+		else if(!connected_engine)
+			try_connect()
+
+
 
 /obj/structure/shuttle/engine/propulsion/DIY
 	name = "shuttle engine"
@@ -107,7 +116,16 @@
 				return TRUE
 		src.desc = initial(src.desc)
 		return FALSE
-			
+	
+	proc/retard_checks()
+		if(!heater)
+			return
+		if(!heater.anchored) // uHhhhHh, it's somehow gotten desynchronized, ficksit
+			disconnect()
+			return
+		if(abs(heater.x - src.x) + abs(heater.y - src.y) != 1 || heater.z != src.z) // someone is trying to pull a fast one, it's not where it should be
+			disconnect()
+			return
 /obj/structure/shuttle/engine/propulsion/DIY/attackby(obj/item/I, mob/user)
 	if(I.is_wrench(user))
 		return wrenchAnchor(user, I, 5 SECONDS)

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -120,13 +120,15 @@
 	desc = initial(desc)
 	return FALSE
 	
+// find and rectify black-swan type weirdness, i.e. varedit / singuloo unanchoring the engine parts or a push wizard teleporting them away
+// the shuttle should NOT work if one of the heaters has been magicked halfway across the station, so check for it!
 /obj/structure/shuttle/engine/propulsion/DIY/proc/retard_checks()
-	if(!heater)
+	if(!heater) // no point disconnecting if there is no heater
 		return
-	if(!heater.anchored) // uHhhhHh, it's somehow gotten desynchronized, ficksit
+	if(!heater.anchored || anchored) // we've somehow gotten unanchored
 		disconnect()
 		return
-	if(loc != get_step(heater,heater.dir)) // someone is trying to pull a fast one, it's not where it should be
+	if(loc != get_step(heater,heater.dir)) // we're not next to the heater anymore
 		disconnect()
 		return
 		

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -1,276 +1,597 @@
-/obj/structure/shuttle
-	name = "shuttle"
-	icon = 'icons/turf/shuttle.dmi'
+//Docking port disks
+//Insert into a shuttle computer to unlock a new destination
+/obj/item/weapon/disk/shuttle_coords
+	name = "shuttle destination disk"
+	desc = "A small disk containing encrypted coordinates and tracking data."
+	icon = 'icons/obj/datadisks.dmi'
+	icon_state = "disk_shuttle"
 
-/obj/structure/shuttle/window
-	name = "shuttle window"
-	icon = 'icons/obj/podwindows.dmi'
-	icon_state = "1"
-	density = 1
-	opacity = 0
-	anchored = 1
+	var/obj/docking_port/destination/destination //Docking port linked to this disk.
+	//If this variable contains a path like (/obj/structure/docking_port/destination/my_dungeon), the disk will find a destination docking port of that type and automatically link to it
+	//See example below
 
-/obj/structure/shuttle/window/shuttle_rotate(angle) //WOW
-	src.transform = turn(src.transform, angle)
+	var/header = "SDC Data Disk" //Name of the disk, shown on the console. SDC stands Shuttle Destination Coordinates
 
-/obj/structure/shuttle/window/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	if(!height || air_group)
-		return 0
-	else
-		return ..()
+	var/list/allowed_shuttles = list() //List of allowed shuttles. Accepts paths (for example /datum/shuttle/arrival). If empty, all shuttles are allowed
+	starting_materials = list(MAT_GLASS = 1250)
 
-/obj/structure/shuttle/engine
-	name = "engine"
-	density = 1
-	anchored = 1.0
+//Example:
+/obj/item/weapon/disk/shuttle_coords/station_arrivals
+	destination = /obj/docking_port/destination/transport/station
+	header = "station arrivals"
 
-/obj/structure/shuttle/engine/heater
-	name = "heater"
-	icon_state = "heater"
+/obj/item/weapon/disk/shuttle_coords/station_auxillary
+	name = "auxillary docking disk"
+	header = "station auxillary docking"
+	destination = /obj/docking_port/destination/salvage/arrivals
+	allowed_shuttles = list(/datum/shuttle/custom)
 
-/obj/structure/shuttle/engine/heater/cultify()
-	new /obj/structure/cult_legacy/pylon(loc)
+/obj/item/weapon/disk/shuttle_coords/disk_jockey
+	name = "Russian propaganda station destination disk"
+	header = "DJ station"
+	destination = /obj/docking_port/destination/salvage/dj
+	starting_materials = list(MAT_GLASS = 1250, MAT_GOLD = 1250)
+
+/obj/item/weapon/disk/shuttle_coords/vault
+	allowed_shuttles = list(/datum/shuttle/mining, /datum/shuttle/research, /datum/shuttle/security)
+
+///obj/item/weapon/disk/shuttle_coords/vault/random -> leads to a random vault with a docking port!
+/obj/item/weapon/disk/shuttle_coords/vault/random/initialize()
+	var/list/L = list()
+	for(var/obj/docking_port/destination/vault/V in all_docking_ports)
+		if(!V.valid_random_destination)
+			continue
+		L.Add(V)
+
+	if(L.len)
+		destination = pick(L)
+
 	..()
 
-/obj/structure/shuttle/engine/platform
-	name = "platform"
-	icon_state = "platform"
+	if(!destination)
+		name = "blank shuttle destination disk"
+		desc = "A small disk containing nothing."
 
-/obj/structure/shuttle/engine/propulsion
-	name = "propulsion"
-	icon_state = "propulsion"
-	opacity = 1
-	var/exhaust_type = /obj/item/projectile/fire_breath/shuttle_exhaust
+//This disk will link to station's arrivals when spawned
 
-/obj/structure/shuttle/engine/heater/DIY
-	name = "shuttle engine pre-igniter"
-	var/obj/structure/shuttle/engine/propulsion/DIY/connected_engine
-	anchored = FALSE
-	
-	proc/try_connect()
-		if(!anchored) 
-			src.desc = initial(src.desc)
-			return FALSE
-		disconnect()
-		for(var/obj/structure/shuttle/engine/propulsion/DIY/D in range(1,src))
-			if(D.anchored && !D.heater && D.dir == src.dir)
-				D.heater = src
-				connected_engine = D
-				src.desc += " It is connected to an engine." // have to do both, because only one of the parts' try_connect()s runs
-				D.desc = initial(D.desc) + " It is connected to a preheater."
-				return TRUE
-		src.desc = initial(src.desc)
-		return FALSE
-		
-	proc/disconnect()
-		if(connected_engine)
-			connected_engine.heater = null // prevent infinite recursion and subsequent serb CPU fire
-			connected_engine.disconnect()
-		connected_engine = null
-		src.desc = initial(src.desc)
-			
-/obj/structure/shuttle/engine/heater/DIY/attackby(obj/item/I, mob/user)
-	if(I.is_wrench(user) && wrenchAnchor(user, I, 5 SECONDS))
-		return TRUE			
-	return ..()
+/obj/item/weapon/disk/shuttle_coords/New()
+	..()
 
-/obj/structure/shuttle/engine/heater/DIY/canAffixHere(var/mob/user)
-	if(src.anchored) // always allow unbolting, a la don't bug out if someone removes the engine
-		return ..()
-	for(var/obj/structure/shuttle/engine/propulsion/DIY/D in range(1,src))
-		if(D.anchored && !D.heater && D.dir == src.dir)
-			return ..()
-	to_chat(user, "<span class = 'warning'>There is no engine within range of \the [src] it can connect to.</span>")
-	return FALSE
-	
-/obj/structure/shuttle/engine/heater/DIY/wrenchAnchor(var/mob/user, var/obj/item/I, var/obj/item/I, var/time_to_wrench = 3 SECONDS)
-	.=..()
-	if(.)
-		if(!anchored)
-			disconnect()
-		else if(!connected_engine)
-			try_connect()
+	if(ticker)
+		initialize()
 
-
-
-/obj/structure/shuttle/engine/propulsion/DIY
-	name = "shuttle engine"
-	var/obj/structure/shuttle/engine/heater/DIY/heater = null
-	anchored = FALSE
-	
-	proc/disconnect()
-		if(heater)
-			heater.disconnect()
-		heater = null
-		src.desc = initial(src.desc)
-		
-	proc/try_connect()
-		if(!src.anchored)
-			src.desc = initial(src.desc)
-			return FALSE
-		disconnect()
-		for(var/obj/structure/shuttle/engine/heater/DIY/D in range(1,src))
-			if(D.anchored && !D.connected_engine && D.dir == src.dir)
-				heater = D
-				D.connected_engine = src
-				src.desc += " It is connected to a preheater."
-				D.desc = initial(D.desc) + " It is connected to an engine."
-				return TRUE
-		src.desc = initial(src.desc)
-		return FALSE
-	
-	proc/retard_checks()
-		if(!heater)
-			return
-		if(!heater.anchored) // uHhhhHh, it's somehow gotten desynchronized, ficksit
-			disconnect()
-			return
-		if(abs(heater.x - src.x) + abs(heater.y - src.y) != 1 || heater.z != src.z) // someone is trying to pull a fast one, it's not where it should be
-			disconnect()
-			return
-/obj/structure/shuttle/engine/propulsion/DIY/attackby(obj/item/I, mob/user)
-	if(I.is_wrench(user))
-		return wrenchAnchor(user, I, 5 SECONDS)
-	return ..()
-
-/obj/structure/shuttle/engine/propulsion/DIY/wrenchAnchor(var/mob/user, var/obj/item/I, var/obj/item/I, var/time_to_wrench = 3 SECONDS)
-	.=..()
-	if(.)
-		if(!anchored)
-			disconnect()
-		else if(!heater)
-			try_connect()
-
-/obj/structure/shuttle/engine/propulsion/DIY/canAffixHere(var/mob/user)
-	var/turf/T = get_step(src, dir)
-	if(!istype(T, /turf/space))
-		to_chat(user, "<span class = 'warning'>\The [src] must be facing and bordering space to be affixed.</span>")
-		return FALSE
-	for(var/obj/O in loc)
-		if(O.flow_flags & ON_BORDER && dir == O.dir)
-			to_chat(user, "<span class = 'warning''>\The [O] is blocking engine flow to space.</span>")
-			return FALSE
-	return ..()
-
-/obj/structure/shuttle/engine/propulsion/DIY/verb/rotate_cw()
-	set src in view(1)
-	set name = "Rotate suspension gen (Clockwise)"
-	set category = "Object"
-
-	if(anchored)
-		to_chat(usr, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
+/obj/item/weapon/disk/shuttle_coords/initialize()
+	if(ispath(destination))
+		spawn()
+			destination = locate(destination) in all_docking_ports
+			if(destination)
+				destination.disk_references.Add(src)
 	else
-		dir = turn(dir, -90)
+		header = "ERROR"
 
-/obj/structure/shuttle/engine/propulsion/DIY/verb/rotate_ccw()
-	set src in view(1)
-	set name = "Rotate suspension gen (Counter-Clockwise)"
-	set category = "Object"
+/obj/item/weapon/disk/shuttle_coords/Destroy()
+	// If a disk is destroyed before initialize() runs, `destination` could
+	// be a type path instead of an instance.
+	if(istype(destination))
+		destination.disk_references.Remove(src)
+		destination = null
 
-	if(anchored)
-		to_chat(usr, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
+	..()
+
+/obj/item/weapon/disk/shuttle_coords/proc/compactible(datum/shuttle/S)
+	if(!allowed_shuttles.len)
+		return TRUE
+
+	return is_type_in_list(S, allowed_shuttles)
+
+/obj/item/weapon/disk/shuttle_coords/proc/reset()
+	destination = null
+	header = "ERROR"
+
+/obj/item/weapon/disk/shuttle_coords/free_move
+	name = "shuttle free-movement driver"
+	desc = "This disk contains a piece of software which converts coordinates into subspace trajectories, which shuttle computers are able to use."
+	header = "FREE-MOVE DRIVER"
+
+/obj/item/weapon/disk/shuttle_coords/free_move/initialize()
+	..()
+	header = initial(header)
+
+/obj/docking_port/destination/coord //Specific subtype to hunt for when doing cleanup
+
+/obj/item/weapon/card/shuttle_pass
+	name = "shuttle pass"
+	desc = "A one-use shuttle activation pass, for limited access to high-security transportation."
+	icon_state = "data"
+	item_state = "card-id"
+	var/obj/docking_port/destination/destination
+	var/allowed_shuttle
+
+/obj/item/weapon/card/shuttle_pass/New()
+	..()
+	if(ticker)
+		initialize()
+
+/obj/item/weapon/card/shuttle_pass/initialize()
+	if(ispath(destination))
+		spawn()
+			destination = locate(destination) in all_docking_ports
+
+/obj/item/weapon/card/shuttle_pass/Destroy()
+	destination = null
+	..()
+
+/obj/item/weapon/card/shuttle_pass/ert
+	name = "\improper ERT shuttle pass"
+	destination = /obj/docking_port/destination/transport/station
+	allowed_shuttle = /datum/shuttle/transport
+
+#define MAX_SHUTTLE_NAME_LEN
+
+/obj/machinery/computer/shuttle_control
+	name = "shuttle console"
+	icon = 'icons/obj/computer.dmi'
+	icon_state = "shuttle"
+	req_access = null
+	circuit = "/obj/item/weapon/circuitboard/shuttle_control"
+
+	machine_flags = EMAGGABLE | SCREWTOGGLE
+
+	light_color = LIGHT_COLOR_BLUE
+
+	var/datum/shuttle/shuttle
+
+	var/obj/docking_port/selected_port
+
+	var/allow_selecting_all = 0 //if 1, allow selecting ALL ports, not only those of linked shuttle
+								//only abusable by admins
+
+	var/allow_silicons = 1		//If 0, AIs and cyborgs can't use this computer
+								//used for admin-only shuttles so that borgs cant hijack 'em
+
+	var/obj/item/weapon/disk/shuttle_coords/disk
+
+	//Variables used for custom destinations
+	var/custom_x = 0
+	var/custom_y = 0
+	var/custom_z = 0
+	var/custom_rot = 0
+
+/obj/machinery/computer/shuttle_control/New()
+	if(shuttle)
+		name = "[shuttle.name] console"
+
+	.=..()
+
+/obj/machinery/computer/shuttle_control/Destroy()
+	if(disk)
+		qdel(disk)
+		disk = null
+
+	..()
+
+/obj/machinery/computer/shuttle_control/proc/announce(var/message)
+	return say(message)
+
+/obj/machinery/computer/shuttle_control/proc/get_doc_href(var/obj/docking_port/D, var/bonus_parameters=null)
+	if(!D)
+		return "ERROR"
+	var/name = capitalize(D.areaname)
+	var/span_s = "<a href='?src=\ref[src];select=\ref[D][bonus_parameters]'>"
+	var/span_e = "</a>"
+	if(D == selected_port)
+		span_s += "<font color='blue'>"
+		span_e += "</font>"
 	else
-		dir = turn(dir, 90)
+		span_s += "<font color='green'>"
+		span_e += "</font>"
 
-/obj/structure/shuttle/engine/propulsion/DIY/AltClick(mob/user)
-	if(Adjacent(user))
-		return rotate_cw()
+	if(D.docked_with) //If used by somebody
+		span_s = "<i>"
+		span_e = "</i>"
+
+
+	return "[span_s][name][span_e]"
+
+/obj/machinery/computer/shuttle_control/attackby(obj/item/O, mob/user)
+	if(istype(O, /obj/item/weapon/disk/shuttle_coords))
+		insert_disk(O, user)
+
+	if(istype(O, /obj/item/weapon/card/shuttle_pass))
+		use_pass(O, user)
+
 	return ..()
 
-/obj/structure/shuttle/engine/propulsion/DIY/ShiftClick(mob/user)
-	if(Adjacent(user))
-		return rotate_ccw()
-	return ..()
-
-/obj/structure/shuttle/engine/propulsion/proc/shoot_exhaust(forward=9, backward=9, var/turf/source_turf)
-	if(!anchored)
+/obj/machinery/computer/shuttle_control/attack_hand(mob/user as mob)
+	if(..(user))
 		return
-	var/turf/target = get_edge_target_turf(src,dir)
-	var/turf/T = source_turf
-	if (!T)
-		T = get_turf(src)
-	var/obj/item/projectile/fire_breath/A = new exhaust_type(T)
-	A.max_range = forward
 
-	for(var/i=0, i<2, i++)
-		A.original = target
-		A.starting = T
-		A.shot_from = src
-		A.current = T
-		A.yo = target.y - T.y
-		A.xo = target.x - T.x
-		A.OnFired()
-		spawn()
-			A.process()
+	user.set_machine(src)
+	src.add_fingerprint(usr)
+	var/shuttle_name = "Unknown shuttle"
+	var/dat
 
-		target = get_edge_target_turf(src,reverse_direction(dir))
-		sleep(6)
-		A = new exhaust_type(T)
-		A.max_range = backward
+	if(selected_port)
+		if(!selected_port.loc) //If selected port was deleted, forget about it
+			selected_port = null
 
-/obj/structure/shuttle/engine/propulsion/left
-	icon_state = "propulsion_l"
+	if(shuttle)
+		shuttle_name = shuttle.name
+		if(shuttle.lockdown)
+			dat += "<h2><font color='red'>THIS SHUTTLE IS LOCKED DOWN</font></h2><br>"
+			if(istext(shuttle.lockdown))
+				dat += shuttle.lockdown
+			else
+				dat += "Additional information has not been provided."
+		else if(!shuttle.linked_area)
+			dat = "<h2><font color='red'>UNABLE TO FIND [uppertext(shuttle.name)]</font></h2>"
+		else if(shuttle.moving)
+			dat += "<center><h3>Currently moving [shuttle.destination_port.areaname ? "to [shuttle.destination_port.areaname]" : ""]</h3></center>"
+		else
+			dat += {"<a href='?src=\ref[src];link_to_port=1'>Scan for docking ports</a><br>"}
+			if(shuttle.current_port)
+				dat += "Location: <b>[shuttle.current_port.areaname]</b><br>"
+			else
+				dat += "Location: <font color='red'><b>unknown</b></font><br>"
+			dat += "Ready to move[max(shuttle.last_moved + shuttle.cooldown - world.time, 0) ? " in [max(round((shuttle.last_moved + shuttle.cooldown - world.time) * 0.1), 0)] seconds" : ": now"]<br>"
 
-/obj/structure/shuttle/engine/propulsion/right
-	icon_state = "propulsion_r"
+				//Write a list of all possible areas
+			var/text
+			if(allow_selecting_all)
+				for(var/obj/docking_port/destination/D in all_docking_ports)
+					if(D.docked_with)
+						continue
+					else
+						text = get_doc_href(D)
 
+					dat += " | [text] | "
+			else
+				for(var/obj/docking_port/destination/D in shuttle.docking_ports)
+					if(D.docked_with)
+						continue
+					else
+						text = get_doc_href(D)
 
-/obj/structure/shuttle/engine/propulsion/cultify()
-	var/turf/T = get_turf(src)
-	if(T)
-		T.ChangeTurf(/turf/simulated/wall/cult)
+					dat += " | [text] | "
+
+			if(disk && disk.destination)
+				if(disk.compactible(shuttle))
+					dat += " | <b>[get_doc_href(disk.destination)]</b> | "
+				else //Shuttle not allowed to use disk
+					dat += " | <b>ERROR: Unable to read coordinates from disk (unknown encryption key)</b>"
+
+			dat += " |<BR>"
+			dat += "<center>[shuttle_name]:<br> <b><A href='?src=\ref[src];move=[1]'>Send[selected_port ? " to [selected_port.areaname]" : ""]</A></b></center><BR>"
+			dat += "<div align=\"right\"><a href='?src=\ref[src];disk=1'>Disk: [disk ? disk.header : "--------"]</a></div>"
+
+			if(istype(disk, /obj/item/weapon/disk/shuttle_coords/free_move))
+				dat += {"<div align=\"left\"><b>COORDINATE INPUTS</b>:<br>
+				<a href='?src=\ref[src];custom_coord=x'>X Offset:</a> [custom_x]</a><br>
+				<a href='?src=\ref[src];custom_coord=y'>Y Offset:</a> [custom_y]</a><br>
+				<a href='?src=\ref[src];custom_coord=z'>Z Destination:</a> [custom_z]</a><br>
+				<a href='?src=\ref[src];custom_coord=a'>Rotate by:</a> [custom_rot]<br><br>
+				<a href='?src=\ref[src];process_custom_coord=1'><b>Calculate Course</b></a></div>"}
+	else //No shuttle
+		dat = "<h1>NO SHUTTLE LINKED</h1><br>"
+		dat += "<a href='?src=\ref[src];link_to_shuttle=1'>Link to a shuttle</a>"
+
+	if(isAdminGhost(user))
+		dat += "<br><hr><br>"
+		dat += "<b><font color='red'>SPECIAL OPTIONS</font></h1></b>"
+		dat += "<i>These are only available to administrators. Abuse may result in fun.</i><br><br>"
+		dat += "<a href='?src=\ref[src];admin_link_to_shuttle=1'>Link to a shuttle</a><br><i>This allows you to link this computer to any existing shuttle, even if it's normally impossible to do so.</i><br>"
+		if(shuttle)
+			dat += {"<a href='?src=\ref[src];admin_unlink_shuttle=1'>Unlink current shuttle</a><br><i>Unlink this computer from [shuttle.name]</i><br>
+			<a href='?src=\ref[src];admin_toggle_lockdown=1'>[shuttle.lockdown ? "Lift lockdown" : "Lock down"]</a><br>
+			<a href='?src=\ref[src];admin_toggle_select_all=1'>[allow_selecting_all ? "Select only from ports linked to [shuttle.name]" : "Select from ALL ports"]</a><br>
+			<a href='?src=\ref[src];admin_toggle_silicon_use=1'>[allow_silicons ? "Forbid silicons from using this computer" : "Allow silicons to use this computer"]</a><br>
+			<a href='?src=\ref[src];admin_reset=1'>Reset shuttle</a><br><i>Revert the shuttle's areas to initial state</i><br>"}
+
+	user << browse("[dat]", "window=shuttle_control;size=575x450")
+	onclose(user, "shuttle_control")
+
+/obj/machinery/computer/shuttle_control/Topic(href, href_list)
+	if(..())
+		return
+	if(issilicon(usr) && !allow_silicons)
+		to_chat(usr, "<span class='notice'>There seems to be a firewall preventing you from accessing this device.</span>")
+		return
+
+	usr.set_machine(src)
+	src.add_fingerprint(usr)
+	if(href_list["move"])
+		if(!shuttle)
+			to_chat(usr, "<span class = 'warning'>No shuttle detected.</span>")
+			return
+		if(!allowed(usr))
+			to_chat(usr, "<span class='red'>Access denied.</span>")
+			return
+
+		if(!selected_port && shuttle.docking_ports.len >= 2)
+			selected_port = pick(shuttle.docking_ports - shuttle.current_port)
+
+		//Check if the selected docking port is valid (can be selected)
+		if(!allow_selecting_all && !(selected_port in shuttle.docking_ports))
+			//Check disks too
+			if(!disk || !disk.compactible(shuttle) || (disk.destination != selected_port))
+				to_chat(usr, "<span class = 'warning'>[!disk?"No disk detected":!disk.compactible(shuttle)?"Current disk not conpatable with current shuttle.":"Currently selected docking port not valid."]</span>")
+				return
+
+		if(selected_port.docked_with) //If used by another shuttle, don't try to move this shuttle
+			to_chat(usr, "<span class = 'warning'>Selected port is currently in use.</span>")
+			return
+
+		//Send a message to the shuttle to move
+		shuttle.travel_to(selected_port, src, usr)
+
+		selected_port = null
+		src.updateUsrDialog()
+	if(href_list["link_to_port"])
+		if(!shuttle)
+			return
+		if(!shuttle.linked_area)
+			return
+		if(!allowed(usr))
+			to_chat(usr, "<span class='red'>Access denied.</span>")
+			return
+
+		var/list/ports = list()
+
+		for(var/obj/docking_port/shuttle/S in shuttle.linked_area)
+			var/name = capitalize(S.areaname)
+			ports += name
+			ports[name] = S
+
+		var/choice = input("Select a docking port to link this shuttle to","Shuttle maintenance") in ports
+		if(!Adjacent(usr) && !isAdminGhost(usr) && !isAI(usr))
+			return
+		var/obj/docking_port/shuttle/S = ports[choice]
+
+		if(S)
+			S.link_to_shuttle(shuttle)
+			to_chat(usr, "Successfully linked [capitalize(shuttle.name)] to the port.")
+			return src.updateUsrDialog()
+		to_chat(usr, "No docking ports found.")
+
+	if(href_list["select"])
+		if(!allowed(usr))
+			to_chat(usr, "<span class='red'>Access denied.</span>")
+			return
+		var/obj/docking_port/A = locate(href_list["select"]) in all_docking_ports
+		if(!A)
+			return
+
+		selected_port = A
+		src.updateUsrDialog()
+	if(href_list["link_to_shuttle"])
+		if(!allowed(usr))
+			to_chat(usr, "<span class='red'>Access denied.</span>")
+			return
+		var/list/L = list()
+		var/area/this_area = get_area(src)
+		for(var/datum/shuttle/S in shuttles)
+			var/name
+			if(S.can_link_to_computer == LINK_FORBIDDEN)
+				continue
+			else if(S.can_link_to_computer == LINK_FREE || this_area.get_shuttle() == S)
+				name = S.name
+			else if(S.password)
+				name = "[S.name] (requires password)"
+			else
+				continue
+			L += name
+			L[name] = S
+
+		var/choice = input(usr,"Select a shuttle to link this computer to", "Shuttle control console") as null|anything in L
+		if(!Adjacent(usr) && !isAdminGhost(usr) && !isAI(usr))
+			return
+		if(L[choice] && istype(L[choice],/datum/shuttle))
+			var/datum/shuttle/S = L[choice]
+
+			if(S.password)
+				var/password_attempt = input(usr,"Please input [capitalize(S.name)]'s interface password:", "Shuttle control console", 00000) as num
+
+				if(!Adjacent(usr) && !isAdminGhost(usr) && !isAI(usr))
+					return
+				if(S.password == password_attempt)
+					shuttle = L[choice]
+				else
+					return
+			else if(S.can_link_to_computer == LINK_FORBIDDEN)
+				return
+			else
+				link_to(L[choice])
+			to_chat(usr, "Successfully linked [src] to [capitalize(S.name)]!")
+			src.updateUsrDialog()
+
+	if(href_list["custom_coord"])
+		switch(href_list["custom_coord"])
+			if("x")
+				custom_x = input("Enter new X drift", "Course Plotting", custom_x) as num
+			if("y")
+				custom_y = input("Enter new Y drift", "Course Plotting", custom_y) as num
+			if("z")
+				custom_z = input("Enter new Z drift", "Course Plotting", custom_z) as num
+			if("a")
+				custom_rot=input("Enter rotation angle", "Course Plotting", custom_rot) as num
+
+		src.updateUsrDialog()
+
+	if(href_list["process_custom_coord"])
+		if(istype(disk, /obj/item/weapon/disk/shuttle_coords/free_move))
+			var/turf/dest = locate(\
+			shuttle.linked_port.x + custom_x,\
+			shuttle.linked_port.y + custom_y,\
+			shuttle.linked_port.z + custom_z
+			)
+
+			if(!dest || dest.z == CENTCOMM_Z || (!istype(dest, /turf/space) && !shuttle.destroy_everything))
+				to_chat(usr, "Error! Bad coordinates.")
+				return
+			if(istype(disk.destination, /obj/docking_port/destination/coord))
+				if(shuttle.current_port == disk.destination)
+					shuttle.current_port = null
+				qdel(disk.destination)
+				disk.destination = null
+			disk.destination = new /obj/docking_port/destination/coord(dest)
+			disk.destination.dir = angle2dir( dir2angle(shuttle.linked_port.dir) + custom_rot + 180)
+			//For instance, COURSE:06:06:2600:12:00
+			disk.destination.areaname = "COURSE:[time2text(world.timeofday, "MM:DD")]:[game_year]:[worldtime2text()]"
+
+			to_chat(usr, "Destination calculated!")
+
+		src.updateUsrDialog()
+
+	if(href_list["admin_link_to_shuttle"])
+		if(!isAdminGhost(usr))
+			to_chat(usr, "You must be an admin for this")
+			return
+
+		var/list/L = list()
+		var/area/this_area = get_area(src)
+		for(var/datum/shuttle/S in shuttles)
+			var/name
+			if(S.can_link_to_computer == LINK_FORBIDDEN)
+				continue
+			else if(S.can_link_to_computer == LINK_FREE || this_area.get_shuttle() == S)
+				name = S.name
+			else if(S.password)
+				name = "[S.name] (requires password)"
+			else
+				continue
+			L += name
+			L[name] = S
+
+		var/choice = input(usr,"Select a shuttle to link this computer to", "Admin abuse") as null|anything in L
+		if(L[choice] && istype(L[choice],/datum/shuttle))
+			shuttle = L[choice]
+
+	if(href_list["admin_unlink_shuttle"])
+		if(!isAdminGhost(usr))
+			to_chat(usr, "You must be an admin for this")
+			return
+
+		shuttle = null
+
+	if(href_list["admin_toggle_lockdown"])
+		if(!isAdminGhost(usr))
+			to_chat(usr, "You must be an admin for this")
+			return
+
+		if(!shuttle.lockdown)
+			var/choice = input(usr,"Would you like to specify a reason?", "Admin abuse") in list("Yes","No","Cancel")
+
+			if(choice == "Cancel")
+				return
+
+			shuttle.lockdown = 1
+			if(choice == "Yes")
+				shuttle.lockdown = input(usr,"Please write a reason for locking the [capitalize(shuttle.name)] down.", "Admin abuse")
+		else
+			shuttle.lockdown = 0
+
+		src.updateUsrDialog()
+	if(href_list["admin_toggle_select_all"])
+		if(!isAdminGhost(usr))
+			to_chat(usr, "You must be an admin for this")
+			return
+
+		if(allow_selecting_all)
+			allow_selecting_all = 0
+			to_chat(usr, "Now selecting from shuttle's docking ports.")
+		else
+			allow_selecting_all = 1
+			to_chat(usr, "Now selecting from all existing docking ports.")
+
+		src.updateUsrDialog()
+	if(href_list["admin_reset"])
+		if(!isAdminGhost(usr))
+			to_chat(usr, "You must be an admin for this")
+			return
+
+		shuttle.initialize()
+		to_chat(usr, "Shuttle's list of travel destinations has been reset")
+	if(href_list["admin_toggle_silicon_use"])
+		if(!isAdminGhost(usr))
+			to_chat(usr, "You must be an admin for this")
+			return
+
+		if(allow_silicons)
+			allow_silicons = 0
+			to_chat(usr, "Silicons can no longer use [src].")
+		else
+			allow_silicons = 1
+			to_chat(usr, "Silicons may now use [src] again.")
+
+		src.updateUsrDialog()
+	if(href_list["disk"])
+		if(!disk) //No disk inserted - grab one from user's hand
+			var/obj/item/weapon/disk/shuttle_coords/D = usr.get_active_hand()
+
+			insert_disk(D, usr)
+		else
+			disk.forceMove(get_turf(src))
+			usr.put_in_hands(disk)
+			to_chat(usr, "<span class='info'>You eject \the [disk] from \the [src].</span>")
+			if(disk.destination == selected_port)
+				selected_port = null
+			disk = null
+			src.updateUsrDialog()
+
+/obj/machinery/computer/shuttle_control/proc/insert_disk(obj/item/weapon/disk/shuttle_coords/SC, mob/user)
+	if(!shuttle)
+		to_chat(user, "<span class='info'>\The [src] is unresponsive.</span>")
+		return
+
+	if(!istype(SC))
+		if(istype(SC, /obj/item/weapon/disk)) //It's a disk, but not a compactible one
+			to_chat(user, "<span class='info'>The disk is rejected by \the [src].</span>")
+
+		return
+
+	if(disk)
+		//An old disk is already inserted.
+		to_chat(user, "<span class='warning'>The old [disk.name] pops out of the disk slot!</span>")
+		disk.forceMove(src.loc)
+		disk = null
+
+	if(user.drop_item(SC, src))
+		disk = SC
+		to_chat(user, "<span class='info'>You insert \the [SC] into \the [src].</span>")
+		src.updateUsrDialog()
+
+/obj/machinery/computer/shuttle_control/proc/use_pass(obj/item/weapon/card/shuttle_pass/P, mob/user)
+	if(!istype(P))
+		return
+
+	if(user.drop_item(P, src))
+		if(shuttle && shuttle.type == P.allowed_shuttle)
+			if(shuttle.travel_to(P.destination, src, user))
+				to_chat(user, "<span class='info'>You insert \the [P] into \the [src].</span>")
+				qdel(P)
+				return
+		to_chat(user, "<span class='info'>You insert \the [P] into \the [src], but it is rejected.</span>")
+		user.put_in_hands(P)
+
+/obj/machinery/computer/shuttle_control/bullet_act(var/obj/item/projectile/Proj)
+	visible_message("[Proj] ricochets off [src]!")
+	return ..() // Nothing happens (?)
+
+/obj/machinery/computer/shuttle_control/proc/link_to(var/datum/shuttle/S, var/add_to_list = 1)
+	if(shuttle)
+		if(src in shuttle.control_consoles)
+			shuttle.control_consoles -= src
+
+	shuttle = S
+	if(add_to_list)
+		shuttle.control_consoles |= src
+	src.req_access = shuttle.req_access
+	src.updateUsrDialog()
+
+/obj/machinery/computer/shuttle_control/emag(mob/user as mob)
 	..()
+	src.req_access = list()
+	if(user)
+		to_chat(user, "You disable the console's access requirement.")
 
-/obj/structure/shuttle/engine/propulsion/burst
-	name = "burst"
-
-/obj/structure/shuttle/engine/propulsion/burst/left
-	icon_state = "burst_l"
-
-/obj/structure/shuttle/engine/propulsion/burst/right
-	icon_state = "burst_r"
-
-/obj/structure/shuttle/engine/router
-	name = "router"
-	icon_state = "router"
-
-// -- NRV HORIZON --
-
-var/ship_has_power = TRUE
-var/list/large_engines = list()
-
-/obj/structure/shuttle/engine/propulsion/horizon
-	var/largeness = 0 // How much extra turfs we are on.
-
-	plane = EFFECTS_PLANE
-	layer = HORIZON_EXHAUST_LAYER
-	exhaust_type = /obj/item/projectile/fire_breath/shuttle_exhaust/horizon
-
-/obj/structure/shuttle/engine/propulsion/horizon/New()
-	. = ..()
-	large_engines += src
-
-/obj/structure/shuttle/engine/propulsion/horizon/Destroy()
-	large_engines -= src
-	. = ..()
-
-// Calls the parents on all the turfs we occupy.
-/obj/structure/shuttle/engine/propulsion/horizon/shoot_exhaust(forward=9, backward=9, var/turf/source_turf)
-	for (var/dx = 0 to largeness)
-		spawn()
-			var/turf/T = locate(src.x + dx, src.y, src.z)
-			..(forward, backward, T)
-
-/obj/structure/shuttle/engine/propulsion/horizon/large_engine
-	bound_height = 64
-	bound_width = 64
-	icon = 'icons/2x2.dmi'
-	icon_state = "large_engine"
-	largeness = 1
-
-/obj/structure/shuttle/engine/propulsion/horizon/huge_engine
-	bound_height = 96
-	bound_width = 96
-	icon = 'icons/3x3.dmi'
-	icon_state = "huge_engine"
-	largeness = 2
+#undef MAX_SHUTTLE_NAME_LEN

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -56,7 +56,8 @@
 			if(D.anchored && !D.heater && D.dir == src.dir)
 				D.heater = src
 				connected_engine = D
-				src.desc += " It is connected to an engine."
+				src.desc += " It is connected to an engine." // have to do both, because only one of the parts' try_connect()s runs
+				D.desc = initial(D.desc) + " It is connected to a preheater."
 				return TRUE
 		src.desc = initial(src.desc)
 		return FALSE
@@ -113,6 +114,7 @@
 				heater = D
 				D.connected_engine = src
 				src.desc += " It is connected to a preheater."
+				D.desc = initial(D.desc) + " It is connected to an engine."
 				return TRUE
 		src.desc = initial(src.desc)
 		return FALSE

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -1,597 +1,278 @@
-//Docking port disks
-//Insert into a shuttle computer to unlock a new destination
-/obj/item/weapon/disk/shuttle_coords
-	name = "shuttle destination disk"
-	desc = "A small disk containing encrypted coordinates and tracking data."
-	icon = 'icons/obj/datadisks.dmi'
-	icon_state = "disk_shuttle"
+/obj/structure/shuttle
+	name = "shuttle"
+	icon = 'icons/turf/shuttle.dmi'
 
-	var/obj/docking_port/destination/destination //Docking port linked to this disk.
-	//If this variable contains a path like (/obj/structure/docking_port/destination/my_dungeon), the disk will find a destination docking port of that type and automatically link to it
-	//See example below
+/obj/structure/shuttle/window
+	name = "shuttle window"
+	icon = 'icons/obj/podwindows.dmi'
+	icon_state = "1"
+	density = 1
+	opacity = 0
+	anchored = 1
 
-	var/header = "SDC Data Disk" //Name of the disk, shown on the console. SDC stands Shuttle Destination Coordinates
+/obj/structure/shuttle/window/shuttle_rotate(angle) //WOW
+	src.transform = turn(src.transform, angle)
 
-	var/list/allowed_shuttles = list() //List of allowed shuttles. Accepts paths (for example /datum/shuttle/arrival). If empty, all shuttles are allowed
-	starting_materials = list(MAT_GLASS = 1250)
-
-//Example:
-/obj/item/weapon/disk/shuttle_coords/station_arrivals
-	destination = /obj/docking_port/destination/transport/station
-	header = "station arrivals"
-
-/obj/item/weapon/disk/shuttle_coords/station_auxillary
-	name = "auxillary docking disk"
-	header = "station auxillary docking"
-	destination = /obj/docking_port/destination/salvage/arrivals
-	allowed_shuttles = list(/datum/shuttle/custom)
-
-/obj/item/weapon/disk/shuttle_coords/disk_jockey
-	name = "Russian propaganda station destination disk"
-	header = "DJ station"
-	destination = /obj/docking_port/destination/salvage/dj
-	starting_materials = list(MAT_GLASS = 1250, MAT_GOLD = 1250)
-
-/obj/item/weapon/disk/shuttle_coords/vault
-	allowed_shuttles = list(/datum/shuttle/mining, /datum/shuttle/research, /datum/shuttle/security)
-
-///obj/item/weapon/disk/shuttle_coords/vault/random -> leads to a random vault with a docking port!
-/obj/item/weapon/disk/shuttle_coords/vault/random/initialize()
-	var/list/L = list()
-	for(var/obj/docking_port/destination/vault/V in all_docking_ports)
-		if(!V.valid_random_destination)
-			continue
-		L.Add(V)
-
-	if(L.len)
-		destination = pick(L)
-
-	..()
-
-	if(!destination)
-		name = "blank shuttle destination disk"
-		desc = "A small disk containing nothing."
-
-//This disk will link to station's arrivals when spawned
-
-/obj/item/weapon/disk/shuttle_coords/New()
-	..()
-
-	if(ticker)
-		initialize()
-
-/obj/item/weapon/disk/shuttle_coords/initialize()
-	if(ispath(destination))
-		spawn()
-			destination = locate(destination) in all_docking_ports
-			if(destination)
-				destination.disk_references.Add(src)
+/obj/structure/shuttle/window/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+	if(!height || air_group)
+		return 0
 	else
-		header = "ERROR"
+		return ..()
 
-/obj/item/weapon/disk/shuttle_coords/Destroy()
-	// If a disk is destroyed before initialize() runs, `destination` could
-	// be a type path instead of an instance.
-	if(istype(destination))
-		destination.disk_references.Remove(src)
-		destination = null
+/obj/structure/shuttle/engine
+	name = "engine"
+	density = 1
+	anchored = 1.0
 
+/obj/structure/shuttle/engine/heater
+	name = "heater"
+	icon_state = "heater"
+
+/obj/structure/shuttle/engine/heater/cultify()
+	new /obj/structure/cult_legacy/pylon(loc)
 	..()
 
-/obj/item/weapon/disk/shuttle_coords/proc/compactible(datum/shuttle/S)
-	if(!allowed_shuttles.len)
-		return TRUE
+/obj/structure/shuttle/engine/platform
+	name = "platform"
+	icon_state = "platform"
 
-	return is_type_in_list(S, allowed_shuttles)
+/obj/structure/shuttle/engine/propulsion
+	name = "propulsion"
+	icon_state = "propulsion"
+	opacity = 1
+	var/exhaust_type = /obj/item/projectile/fire_breath/shuttle_exhaust
 
-/obj/item/weapon/disk/shuttle_coords/proc/reset()
-	destination = null
-	header = "ERROR"
-
-/obj/item/weapon/disk/shuttle_coords/free_move
-	name = "shuttle free-movement driver"
-	desc = "This disk contains a piece of software which converts coordinates into subspace trajectories, which shuttle computers are able to use."
-	header = "FREE-MOVE DRIVER"
-
-/obj/item/weapon/disk/shuttle_coords/free_move/initialize()
-	..()
-	header = initial(header)
-
-/obj/docking_port/destination/coord //Specific subtype to hunt for when doing cleanup
-
-/obj/item/weapon/card/shuttle_pass
-	name = "shuttle pass"
-	desc = "A one-use shuttle activation pass, for limited access to high-security transportation."
-	icon_state = "data"
-	item_state = "card-id"
-	var/obj/docking_port/destination/destination
-	var/allowed_shuttle
-
-/obj/item/weapon/card/shuttle_pass/New()
-	..()
-	if(ticker)
-		initialize()
-
-/obj/item/weapon/card/shuttle_pass/initialize()
-	if(ispath(destination))
-		spawn()
-			destination = locate(destination) in all_docking_ports
-
-/obj/item/weapon/card/shuttle_pass/Destroy()
-	destination = null
-	..()
-
-/obj/item/weapon/card/shuttle_pass/ert
-	name = "\improper ERT shuttle pass"
-	destination = /obj/docking_port/destination/transport/station
-	allowed_shuttle = /datum/shuttle/transport
-
-#define MAX_SHUTTLE_NAME_LEN
-
-/obj/machinery/computer/shuttle_control
-	name = "shuttle console"
-	icon = 'icons/obj/computer.dmi'
-	icon_state = "shuttle"
-	req_access = null
-	circuit = "/obj/item/weapon/circuitboard/shuttle_control"
-
-	machine_flags = EMAGGABLE | SCREWTOGGLE
-
-	light_color = LIGHT_COLOR_BLUE
-
-	var/datum/shuttle/shuttle
-
-	var/obj/docking_port/selected_port
-
-	var/allow_selecting_all = 0 //if 1, allow selecting ALL ports, not only those of linked shuttle
-								//only abusable by admins
-
-	var/allow_silicons = 1		//If 0, AIs and cyborgs can't use this computer
-								//used for admin-only shuttles so that borgs cant hijack 'em
-
-	var/obj/item/weapon/disk/shuttle_coords/disk
-
-	//Variables used for custom destinations
-	var/custom_x = 0
-	var/custom_y = 0
-	var/custom_z = 0
-	var/custom_rot = 0
-
-/obj/machinery/computer/shuttle_control/New()
-	if(shuttle)
-		name = "[shuttle.name] console"
-
-	.=..()
-
-/obj/machinery/computer/shuttle_control/Destroy()
-	if(disk)
-		qdel(disk)
-		disk = null
-
-	..()
-
-/obj/machinery/computer/shuttle_control/proc/announce(var/message)
-	return say(message)
-
-/obj/machinery/computer/shuttle_control/proc/get_doc_href(var/obj/docking_port/D, var/bonus_parameters=null)
-	if(!D)
-		return "ERROR"
-	var/name = capitalize(D.areaname)
-	var/span_s = "<a href='?src=\ref[src];select=\ref[D][bonus_parameters]'>"
-	var/span_e = "</a>"
-	if(D == selected_port)
-		span_s += "<font color='blue'>"
-		span_e += "</font>"
-	else
-		span_s += "<font color='green'>"
-		span_e += "</font>"
-
-	if(D.docked_with) //If used by somebody
-		span_s = "<i>"
-		span_e = "</i>"
-
-
-	return "[span_s][name][span_e]"
-
-/obj/machinery/computer/shuttle_control/attackby(obj/item/O, mob/user)
-	if(istype(O, /obj/item/weapon/disk/shuttle_coords))
-		insert_disk(O, user)
-
-	if(istype(O, /obj/item/weapon/card/shuttle_pass))
-		use_pass(O, user)
-
+/obj/structure/shuttle/engine/heater/DIY
+	name = "shuttle engine pre-igniter"
+	var/obj/structure/shuttle/engine/propulsion/DIY/connected_engine
+	anchored = FALSE
+	
+/obj/structure/shuttle/engine/heater/DIY/proc/try_connect()
+	if(!anchored) 
+		desc = initial(desc)
+		return FALSE
+	disconnect()
+	
+	for(var/obj/structure/shuttle/engine/propulsion/DIY/D in range(1,src))
+		if(D.anchored && !D.heater && D.dir == dir && D.loc == get_step(src,dir))
+			D.heater = src
+			connected_engine = D
+			desc += " It is connected to an engine." // have to do both, because only one of the parts' try_connect()s runs
+			D.desc = initial(D.desc) + " It is connected to a preheater."
+			return TRUE
+	desc = initial(desc)
+	return FALSE
+	
+/obj/structure/shuttle/engine/heater/DIY/proc/disconnect()
+	if(connected_engine)
+		connected_engine.heater = null // prevent infinite recursion and subsequent serb CPU fire
+		connected_engine.disconnect()
+	connected_engine = null
+	src.desc = initial(src.desc)
+			
+/obj/structure/shuttle/engine/heater/DIY/attackby(obj/item/I, mob/user)
+	if(I.is_wrench(user) && wrenchAnchor(user, I, 5 SECONDS))
+		return TRUE			
 	return ..()
 
-/obj/machinery/computer/shuttle_control/attack_hand(mob/user as mob)
-	if(..(user))
+/obj/structure/shuttle/engine/heater/DIY/canAffixHere(var/mob/user)
+	if(src.anchored) // always allow unbolting, a la don't bug out if someone removes the engine
+		return ..()
+	for(var/obj/structure/shuttle/engine/propulsion/DIY/D in range(1,src))
+		if(D.anchored && !D.heater && D.dir == dir && D.loc == get_step(src,dir))
+			return ..()
+	to_chat(user, "<span class = 'warning'>There is no engine within range of \the [src] it can connect to.</span>")
+	return FALSE
+	
+/obj/structure/shuttle/engine/heater/DIY/wrenchAnchor(var/mob/user, var/obj/item/I, var/obj/item/I, var/time_to_wrench = 3 SECONDS)
+	.=..()
+	if(.)
+		if(!anchored)
+			disconnect()
+		else if(!connected_engine)
+			try_connect()
+
+
+
+/obj/structure/shuttle/engine/propulsion/DIY
+	name = "shuttle engine"
+	var/obj/structure/shuttle/engine/heater/DIY/heater = null
+	anchored = FALSE
+	
+/obj/structure/shuttle/engine/propulsion/DIY/proc/disconnect()
+	if(heater)
+		heater.disconnect()
+	heater = null
+	desc = initial(desc)
+	
+/obj/structure/shuttle/engine/propulsion/DIY/proc/try_connect()
+	if(!anchored)
+		desc = initial(desc)
+		return FALSE
+	disconnect()
+	for(var/obj/structure/shuttle/engine/heater/DIY/D in range(1,src))
+		if(D.anchored && !D.connected_engine && D.dir == dir && loc == get_step(D,D.dir))
+			heater = D
+			D.connected_engine = src
+			desc += " It is connected to a preheater."
+			D.desc = initial(D.desc) + " It is connected to an engine."
+			return TRUE
+	desc = initial(desc)
+	return FALSE
+	
+/obj/structure/shuttle/engine/propulsion/DIY/proc/retard_checks()
+	if(!heater)
 		return
-
-	user.set_machine(src)
-	src.add_fingerprint(usr)
-	var/shuttle_name = "Unknown shuttle"
-	var/dat
-
-	if(selected_port)
-		if(!selected_port.loc) //If selected port was deleted, forget about it
-			selected_port = null
-
-	if(shuttle)
-		shuttle_name = shuttle.name
-		if(shuttle.lockdown)
-			dat += "<h2><font color='red'>THIS SHUTTLE IS LOCKED DOWN</font></h2><br>"
-			if(istext(shuttle.lockdown))
-				dat += shuttle.lockdown
-			else
-				dat += "Additional information has not been provided."
-		else if(!shuttle.linked_area)
-			dat = "<h2><font color='red'>UNABLE TO FIND [uppertext(shuttle.name)]</font></h2>"
-		else if(shuttle.moving)
-			dat += "<center><h3>Currently moving [shuttle.destination_port.areaname ? "to [shuttle.destination_port.areaname]" : ""]</h3></center>"
-		else
-			dat += {"<a href='?src=\ref[src];link_to_port=1'>Scan for docking ports</a><br>"}
-			if(shuttle.current_port)
-				dat += "Location: <b>[shuttle.current_port.areaname]</b><br>"
-			else
-				dat += "Location: <font color='red'><b>unknown</b></font><br>"
-			dat += "Ready to move[max(shuttle.last_moved + shuttle.cooldown - world.time, 0) ? " in [max(round((shuttle.last_moved + shuttle.cooldown - world.time) * 0.1), 0)] seconds" : ": now"]<br>"
-
-				//Write a list of all possible areas
-			var/text
-			if(allow_selecting_all)
-				for(var/obj/docking_port/destination/D in all_docking_ports)
-					if(D.docked_with)
-						continue
-					else
-						text = get_doc_href(D)
-
-					dat += " | [text] | "
-			else
-				for(var/obj/docking_port/destination/D in shuttle.docking_ports)
-					if(D.docked_with)
-						continue
-					else
-						text = get_doc_href(D)
-
-					dat += " | [text] | "
-
-			if(disk && disk.destination)
-				if(disk.compactible(shuttle))
-					dat += " | <b>[get_doc_href(disk.destination)]</b> | "
-				else //Shuttle not allowed to use disk
-					dat += " | <b>ERROR: Unable to read coordinates from disk (unknown encryption key)</b>"
-
-			dat += " |<BR>"
-			dat += "<center>[shuttle_name]:<br> <b><A href='?src=\ref[src];move=[1]'>Send[selected_port ? " to [selected_port.areaname]" : ""]</A></b></center><BR>"
-			dat += "<div align=\"right\"><a href='?src=\ref[src];disk=1'>Disk: [disk ? disk.header : "--------"]</a></div>"
-
-			if(istype(disk, /obj/item/weapon/disk/shuttle_coords/free_move))
-				dat += {"<div align=\"left\"><b>COORDINATE INPUTS</b>:<br>
-				<a href='?src=\ref[src];custom_coord=x'>X Offset:</a> [custom_x]</a><br>
-				<a href='?src=\ref[src];custom_coord=y'>Y Offset:</a> [custom_y]</a><br>
-				<a href='?src=\ref[src];custom_coord=z'>Z Destination:</a> [custom_z]</a><br>
-				<a href='?src=\ref[src];custom_coord=a'>Rotate by:</a> [custom_rot]<br><br>
-				<a href='?src=\ref[src];process_custom_coord=1'><b>Calculate Course</b></a></div>"}
-	else //No shuttle
-		dat = "<h1>NO SHUTTLE LINKED</h1><br>"
-		dat += "<a href='?src=\ref[src];link_to_shuttle=1'>Link to a shuttle</a>"
-
-	if(isAdminGhost(user))
-		dat += "<br><hr><br>"
-		dat += "<b><font color='red'>SPECIAL OPTIONS</font></h1></b>"
-		dat += "<i>These are only available to administrators. Abuse may result in fun.</i><br><br>"
-		dat += "<a href='?src=\ref[src];admin_link_to_shuttle=1'>Link to a shuttle</a><br><i>This allows you to link this computer to any existing shuttle, even if it's normally impossible to do so.</i><br>"
-		if(shuttle)
-			dat += {"<a href='?src=\ref[src];admin_unlink_shuttle=1'>Unlink current shuttle</a><br><i>Unlink this computer from [shuttle.name]</i><br>
-			<a href='?src=\ref[src];admin_toggle_lockdown=1'>[shuttle.lockdown ? "Lift lockdown" : "Lock down"]</a><br>
-			<a href='?src=\ref[src];admin_toggle_select_all=1'>[allow_selecting_all ? "Select only from ports linked to [shuttle.name]" : "Select from ALL ports"]</a><br>
-			<a href='?src=\ref[src];admin_toggle_silicon_use=1'>[allow_silicons ? "Forbid silicons from using this computer" : "Allow silicons to use this computer"]</a><br>
-			<a href='?src=\ref[src];admin_reset=1'>Reset shuttle</a><br><i>Revert the shuttle's areas to initial state</i><br>"}
-
-	user << browse("[dat]", "window=shuttle_control;size=575x450")
-	onclose(user, "shuttle_control")
-
-/obj/machinery/computer/shuttle_control/Topic(href, href_list)
-	if(..())
+	if(!heater.anchored) // uHhhhHh, it's somehow gotten desynchronized, ficksit
+		disconnect()
 		return
-	if(issilicon(usr) && !allow_silicons)
-		to_chat(usr, "<span class='notice'>There seems to be a firewall preventing you from accessing this device.</span>")
+	if(loc != get_step(heater,heater.dir)) // someone is trying to pull a fast one, it's not where it should be
+		disconnect()
 		return
+		
+/obj/structure/shuttle/engine/propulsion/DIY/attackby(obj/item/I, mob/user)
+	if(I.is_wrench(user))
+		return wrenchAnchor(user, I, 5 SECONDS)
+	return ..()
 
-	usr.set_machine(src)
-	src.add_fingerprint(usr)
-	if(href_list["move"])
-		if(!shuttle)
-			to_chat(usr, "<span class = 'warning'>No shuttle detected.</span>")
-			return
-		if(!allowed(usr))
-			to_chat(usr, "<span class='red'>Access denied.</span>")
-			return
+/obj/structure/shuttle/engine/propulsion/DIY/wrenchAnchor(var/mob/user, var/obj/item/I, var/obj/item/I, var/time_to_wrench = 3 SECONDS)
+	.=..()
+	if(.)
+		if(!anchored)
+			disconnect()
+		else if(!heater)
+			try_connect()
 
-		if(!selected_port && shuttle.docking_ports.len >= 2)
-			selected_port = pick(shuttle.docking_ports - shuttle.current_port)
+/obj/structure/shuttle/engine/propulsion/DIY/canAffixHere(var/mob/user)
+	var/turf/T = get_step(src, dir)
+	if(!istype(T, /turf/space))
+		to_chat(user, "<span class = 'warning'>\The [src] must be facing and bordering space to be affixed.</span>")
+		return FALSE
+	for(var/obj/O in loc)
+		if(O.flow_flags & ON_BORDER && dir == O.dir)
+			to_chat(user, "<span class = 'warning''>\The [O] is blocking engine flow to space.</span>")
+			return FALSE
+	return ..()
 
-		//Check if the selected docking port is valid (can be selected)
-		if(!allow_selecting_all && !(selected_port in shuttle.docking_ports))
-			//Check disks too
-			if(!disk || !disk.compactible(shuttle) || (disk.destination != selected_port))
-				to_chat(usr, "<span class = 'warning'>[!disk?"No disk detected":!disk.compactible(shuttle)?"Current disk not conpatable with current shuttle.":"Currently selected docking port not valid."]</span>")
-				return
+/obj/structure/shuttle/engine/propulsion/DIY/verb/rotate_cw()
+	set src in view(1)
+	set name = "Rotate suspension gen (Clockwise)"
+	set category = "Object"
 
-		if(selected_port.docked_with) //If used by another shuttle, don't try to move this shuttle
-			to_chat(usr, "<span class = 'warning'>Selected port is currently in use.</span>")
-			return
+	if(anchored)
+		to_chat(usr, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
+	else
+		dir = turn(dir, -90)
 
-		//Send a message to the shuttle to move
-		shuttle.travel_to(selected_port, src, usr)
+/obj/structure/shuttle/engine/propulsion/DIY/verb/rotate_ccw()
+	set src in view(1)
+	set name = "Rotate suspension gen (Counter-Clockwise)"
+	set category = "Object"
 
-		selected_port = null
-		src.updateUsrDialog()
-	if(href_list["link_to_port"])
-		if(!shuttle)
-			return
-		if(!shuttle.linked_area)
-			return
-		if(!allowed(usr))
-			to_chat(usr, "<span class='red'>Access denied.</span>")
-			return
+	if(anchored)
+		to_chat(usr, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
+	else
+		dir = turn(dir, 90)
 
-		var/list/ports = list()
+/obj/structure/shuttle/engine/propulsion/DIY/AltClick(mob/user)
+	if(Adjacent(user))
+		return rotate_cw()
+	return ..()
 
-		for(var/obj/docking_port/shuttle/S in shuttle.linked_area)
-			var/name = capitalize(S.areaname)
-			ports += name
-			ports[name] = S
+/obj/structure/shuttle/engine/propulsion/DIY/ShiftClick(mob/user)
+	if(Adjacent(user))
+		return rotate_ccw()
+	return ..()
 
-		var/choice = input("Select a docking port to link this shuttle to","Shuttle maintenance") in ports
-		if(!Adjacent(usr) && !isAdminGhost(usr) && !isAI(usr))
-			return
-		var/obj/docking_port/shuttle/S = ports[choice]
-
-		if(S)
-			S.link_to_shuttle(shuttle)
-			to_chat(usr, "Successfully linked [capitalize(shuttle.name)] to the port.")
-			return src.updateUsrDialog()
-		to_chat(usr, "No docking ports found.")
-
-	if(href_list["select"])
-		if(!allowed(usr))
-			to_chat(usr, "<span class='red'>Access denied.</span>")
-			return
-		var/obj/docking_port/A = locate(href_list["select"]) in all_docking_ports
-		if(!A)
-			return
-
-		selected_port = A
-		src.updateUsrDialog()
-	if(href_list["link_to_shuttle"])
-		if(!allowed(usr))
-			to_chat(usr, "<span class='red'>Access denied.</span>")
-			return
-		var/list/L = list()
-		var/area/this_area = get_area(src)
-		for(var/datum/shuttle/S in shuttles)
-			var/name
-			if(S.can_link_to_computer == LINK_FORBIDDEN)
-				continue
-			else if(S.can_link_to_computer == LINK_FREE || this_area.get_shuttle() == S)
-				name = S.name
-			else if(S.password)
-				name = "[S.name] (requires password)"
-			else
-				continue
-			L += name
-			L[name] = S
-
-		var/choice = input(usr,"Select a shuttle to link this computer to", "Shuttle control console") as null|anything in L
-		if(!Adjacent(usr) && !isAdminGhost(usr) && !isAI(usr))
-			return
-		if(L[choice] && istype(L[choice],/datum/shuttle))
-			var/datum/shuttle/S = L[choice]
-
-			if(S.password)
-				var/password_attempt = input(usr,"Please input [capitalize(S.name)]'s interface password:", "Shuttle control console", 00000) as num
-
-				if(!Adjacent(usr) && !isAdminGhost(usr) && !isAI(usr))
-					return
-				if(S.password == password_attempt)
-					shuttle = L[choice]
-				else
-					return
-			else if(S.can_link_to_computer == LINK_FORBIDDEN)
-				return
-			else
-				link_to(L[choice])
-			to_chat(usr, "Successfully linked [src] to [capitalize(S.name)]!")
-			src.updateUsrDialog()
-
-	if(href_list["custom_coord"])
-		switch(href_list["custom_coord"])
-			if("x")
-				custom_x = input("Enter new X drift", "Course Plotting", custom_x) as num
-			if("y")
-				custom_y = input("Enter new Y drift", "Course Plotting", custom_y) as num
-			if("z")
-				custom_z = input("Enter new Z drift", "Course Plotting", custom_z) as num
-			if("a")
-				custom_rot=input("Enter rotation angle", "Course Plotting", custom_rot) as num
-
-		src.updateUsrDialog()
-
-	if(href_list["process_custom_coord"])
-		if(istype(disk, /obj/item/weapon/disk/shuttle_coords/free_move))
-			var/turf/dest = locate(\
-			shuttle.linked_port.x + custom_x,\
-			shuttle.linked_port.y + custom_y,\
-			shuttle.linked_port.z + custom_z
-			)
-
-			if(!dest || dest.z == CENTCOMM_Z || (!istype(dest, /turf/space) && !shuttle.destroy_everything))
-				to_chat(usr, "Error! Bad coordinates.")
-				return
-			if(istype(disk.destination, /obj/docking_port/destination/coord))
-				if(shuttle.current_port == disk.destination)
-					shuttle.current_port = null
-				qdel(disk.destination)
-				disk.destination = null
-			disk.destination = new /obj/docking_port/destination/coord(dest)
-			disk.destination.dir = angle2dir( dir2angle(shuttle.linked_port.dir) + custom_rot + 180)
-			//For instance, COURSE:06:06:2600:12:00
-			disk.destination.areaname = "COURSE:[time2text(world.timeofday, "MM:DD")]:[game_year]:[worldtime2text()]"
-
-			to_chat(usr, "Destination calculated!")
-
-		src.updateUsrDialog()
-
-	if(href_list["admin_link_to_shuttle"])
-		if(!isAdminGhost(usr))
-			to_chat(usr, "You must be an admin for this")
-			return
-
-		var/list/L = list()
-		var/area/this_area = get_area(src)
-		for(var/datum/shuttle/S in shuttles)
-			var/name
-			if(S.can_link_to_computer == LINK_FORBIDDEN)
-				continue
-			else if(S.can_link_to_computer == LINK_FREE || this_area.get_shuttle() == S)
-				name = S.name
-			else if(S.password)
-				name = "[S.name] (requires password)"
-			else
-				continue
-			L += name
-			L[name] = S
-
-		var/choice = input(usr,"Select a shuttle to link this computer to", "Admin abuse") as null|anything in L
-		if(L[choice] && istype(L[choice],/datum/shuttle))
-			shuttle = L[choice]
-
-	if(href_list["admin_unlink_shuttle"])
-		if(!isAdminGhost(usr))
-			to_chat(usr, "You must be an admin for this")
-			return
-
-		shuttle = null
-
-	if(href_list["admin_toggle_lockdown"])
-		if(!isAdminGhost(usr))
-			to_chat(usr, "You must be an admin for this")
-			return
-
-		if(!shuttle.lockdown)
-			var/choice = input(usr,"Would you like to specify a reason?", "Admin abuse") in list("Yes","No","Cancel")
-
-			if(choice == "Cancel")
-				return
-
-			shuttle.lockdown = 1
-			if(choice == "Yes")
-				shuttle.lockdown = input(usr,"Please write a reason for locking the [capitalize(shuttle.name)] down.", "Admin abuse")
-		else
-			shuttle.lockdown = 0
-
-		src.updateUsrDialog()
-	if(href_list["admin_toggle_select_all"])
-		if(!isAdminGhost(usr))
-			to_chat(usr, "You must be an admin for this")
-			return
-
-		if(allow_selecting_all)
-			allow_selecting_all = 0
-			to_chat(usr, "Now selecting from shuttle's docking ports.")
-		else
-			allow_selecting_all = 1
-			to_chat(usr, "Now selecting from all existing docking ports.")
-
-		src.updateUsrDialog()
-	if(href_list["admin_reset"])
-		if(!isAdminGhost(usr))
-			to_chat(usr, "You must be an admin for this")
-			return
-
-		shuttle.initialize()
-		to_chat(usr, "Shuttle's list of travel destinations has been reset")
-	if(href_list["admin_toggle_silicon_use"])
-		if(!isAdminGhost(usr))
-			to_chat(usr, "You must be an admin for this")
-			return
-
-		if(allow_silicons)
-			allow_silicons = 0
-			to_chat(usr, "Silicons can no longer use [src].")
-		else
-			allow_silicons = 1
-			to_chat(usr, "Silicons may now use [src] again.")
-
-		src.updateUsrDialog()
-	if(href_list["disk"])
-		if(!disk) //No disk inserted - grab one from user's hand
-			var/obj/item/weapon/disk/shuttle_coords/D = usr.get_active_hand()
-
-			insert_disk(D, usr)
-		else
-			disk.forceMove(get_turf(src))
-			usr.put_in_hands(disk)
-			to_chat(usr, "<span class='info'>You eject \the [disk] from \the [src].</span>")
-			if(disk.destination == selected_port)
-				selected_port = null
-			disk = null
-			src.updateUsrDialog()
-
-/obj/machinery/computer/shuttle_control/proc/insert_disk(obj/item/weapon/disk/shuttle_coords/SC, mob/user)
-	if(!shuttle)
-		to_chat(user, "<span class='info'>\The [src] is unresponsive.</span>")
+/obj/structure/shuttle/engine/propulsion/proc/shoot_exhaust(forward=9, backward=9, var/turf/source_turf)
+	if(!anchored)
 		return
+	var/turf/target = get_edge_target_turf(src,dir)
+	var/turf/T = source_turf
+	if (!T)
+		T = get_turf(src)
+	var/obj/item/projectile/fire_breath/A = new exhaust_type(T)
+	A.max_range = forward
 
-	if(!istype(SC))
-		if(istype(SC, /obj/item/weapon/disk)) //It's a disk, but not a compactible one
-			to_chat(user, "<span class='info'>The disk is rejected by \the [src].</span>")
+	for(var/i=0, i<2, i++)
+		A.original = target
+		A.starting = T
+		A.shot_from = src
+		A.current = T
+		A.yo = target.y - T.y
+		A.xo = target.x - T.x
+		A.OnFired()
+		spawn()
+			A.process()
 
-		return
+		target = get_edge_target_turf(src,reverse_direction(dir))
+		sleep(6)
+		A = new exhaust_type(T)
+		A.max_range = backward
 
-	if(disk)
-		//An old disk is already inserted.
-		to_chat(user, "<span class='warning'>The old [disk.name] pops out of the disk slot!</span>")
-		disk.forceMove(src.loc)
-		disk = null
+/obj/structure/shuttle/engine/propulsion/left
+	icon_state = "propulsion_l"
 
-	if(user.drop_item(SC, src))
-		disk = SC
-		to_chat(user, "<span class='info'>You insert \the [SC] into \the [src].</span>")
-		src.updateUsrDialog()
+/obj/structure/shuttle/engine/propulsion/right
+	icon_state = "propulsion_r"
 
-/obj/machinery/computer/shuttle_control/proc/use_pass(obj/item/weapon/card/shuttle_pass/P, mob/user)
-	if(!istype(P))
-		return
 
-	if(user.drop_item(P, src))
-		if(shuttle && shuttle.type == P.allowed_shuttle)
-			if(shuttle.travel_to(P.destination, src, user))
-				to_chat(user, "<span class='info'>You insert \the [P] into \the [src].</span>")
-				qdel(P)
-				return
-		to_chat(user, "<span class='info'>You insert \the [P] into \the [src], but it is rejected.</span>")
-		user.put_in_hands(P)
-
-/obj/machinery/computer/shuttle_control/bullet_act(var/obj/item/projectile/Proj)
-	visible_message("[Proj] ricochets off [src]!")
-	return ..() // Nothing happens (?)
-
-/obj/machinery/computer/shuttle_control/proc/link_to(var/datum/shuttle/S, var/add_to_list = 1)
-	if(shuttle)
-		if(src in shuttle.control_consoles)
-			shuttle.control_consoles -= src
-
-	shuttle = S
-	if(add_to_list)
-		shuttle.control_consoles |= src
-	src.req_access = shuttle.req_access
-	src.updateUsrDialog()
-
-/obj/machinery/computer/shuttle_control/emag(mob/user as mob)
+/obj/structure/shuttle/engine/propulsion/cultify()
+	var/turf/T = get_turf(src)
+	if(T)
+		T.ChangeTurf(/turf/simulated/wall/cult)
 	..()
-	src.req_access = list()
-	if(user)
-		to_chat(user, "You disable the console's access requirement.")
 
-#undef MAX_SHUTTLE_NAME_LEN
+/obj/structure/shuttle/engine/propulsion/burst
+	name = "burst"
+
+/obj/structure/shuttle/engine/propulsion/burst/left
+	icon_state = "burst_l"
+
+/obj/structure/shuttle/engine/propulsion/burst/right
+	icon_state = "burst_r"
+
+/obj/structure/shuttle/engine/router
+	name = "router"
+	icon_state = "router"
+
+// -- NRV HORIZON --
+
+var/ship_has_power = TRUE
+var/list/large_engines = list()
+
+/obj/structure/shuttle/engine/propulsion/horizon
+	var/largeness = 0 // How much extra turfs we are on.
+
+	plane = EFFECTS_PLANE
+	layer = HORIZON_EXHAUST_LAYER
+	exhaust_type = /obj/item/projectile/fire_breath/shuttle_exhaust/horizon
+
+/obj/structure/shuttle/engine/propulsion/horizon/New()
+	. = ..()
+	large_engines += src
+
+/obj/structure/shuttle/engine/propulsion/horizon/Destroy()
+	large_engines -= src
+	. = ..()
+
+// Calls the parents on all the turfs we occupy.
+/obj/structure/shuttle/engine/propulsion/horizon/shoot_exhaust(forward=9, backward=9, var/turf/source_turf)
+	for (var/dx = 0 to largeness)
+		spawn()
+			var/turf/T = locate(src.x + dx, src.y, src.z)
+			..(forward, backward, T)
+
+/obj/structure/shuttle/engine/propulsion/horizon/large_engine
+	bound_height = 64
+	bound_width = 64
+	icon = 'icons/2x2.dmi'
+	icon_state = "large_engine"
+	largeness = 1
+
+/obj/structure/shuttle/engine/propulsion/horizon/huge_engine
+	bound_height = 96
+	bound_width = 96
+	icon = 'icons/3x3.dmi'
+	icon_state = "huge_engine"
+	largeness = 2


### PR DESCRIPTION
Anyone who has made (or tried to make) a DIY shuttle lately can tell you about the extremely confusing, annoying bugs involving the shuttle engines. They have to be built in a VERY specific and sterile way, otherwise they silently bug out and never work ever again. Upon investigating this I found a nightmarish web of shitcode that enabled the following dumbassery:

- one engine can be connected to by potentially multiple preigniters and vice versa due to a complete lack of unwrenching handling code in the preigniters
- engines can connect to preigniters in any direction and orientation, including on diagonals and backwards, potentially stealing preigniters from adjacent or staggered engines
- preigniters AND engines can stay linked to their counterpart even after being unwrenched and moved to a new position, preventing them from linking with a new engine/preigniter, bricking them forever
- preigniters regularly get glitched into an immovable state where they think they're unlinked and unanchored when in reality they're anchored and linked (and count towards the engine count as such)
- preigniters and engines have no visual indication of being linked, making finding bugged or unbolted engines a massive time-consuming brute-force-search nightmare


so this PR does the following:

- adds additional information about engine requirements to DIY shuttle permit error messages, telling you how many engines you need, not just how many you have.
- adds examine text to DIY shuttle engine parts telling you whether or not they're connected
- centralize the constant of how many tiles each engine can support into a single #define -- `CUSTOM_SHUTTLE_TILES_PER_ENGINE` Not sure where to put it, so it's in blueprints.dm alongside the rest of the shuttle permit code.
- most importantly fix most-if-not-all of the weird bugs involving constructing shuttle engines -  lots more checks, with part connecting/disconnecting stuff centralized into 3 procs instead of spread out everywhere. not performant, not pretty, but a damn sight better than what it's replacing. a lot of idiotproofing and sanity checks are built into the shuttle liscense verification process, so there shouldnt be any more internal state desync fuckiness. this fixes all of the horrific bugs listed above

I've stress-tested the shuttle engine parts quite a bit, they seem to be pretty solid and hard to bug out now. Probably still some bugs in there somewhere, but the most egregious and annoying ones are gone.

[bugfix]
[oversight]

:cl:
 * bugfix: Patched the severe, pervasive bugs in DIY shuttle engines.
 * tweak: Changed DIY shuttle permit error messages, it now directly tells you how many engines you need.
 * tweak: Examining DIY shuttle engine parts will now tell you if they're connected