### PR TITLE
Player-controlled mobs are no longer stunned

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -836,5 +836,14 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	else
 		qdel(src)
 
+/mob/living/simple_animal/isStunned() //Used so that it allows attacking in code/_onclick/click.dm
+	if(client)
+		return 0
+	return ..()
+
+/mob/living/simple_animal/isJustStunned() //Used so that it allows moving in code/mobules/mob/mob.dm
+	if(client)
+		return 0
+	return ..()
 
 /datum/locking_category/simple_animal

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -836,12 +836,17 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	else
 		qdel(src)
 
-/mob/living/simple_animal/isStunned() //Used so that it allows attacking in code/_onclick/click.dm
+/mob/living/simple_animal/isStunned() //Used so that it allows clients to attack in code/_onclick/click.dm
 	if(client)
 		return 0
 	return ..()
 
-/mob/living/simple_animal/isJustStunned() //Used so that it allows moving in code/mobules/mob/mob.dm
+/mob/living/simple_animal/isJustStunned() //Used so that it allows clients to move in code/mobules/mob/mob.dm
+	if(client)
+		return 0
+	return ..()
+
+/mob/living/simple_animal/isKnockedDown() //Ditto
 	if(client)
 		return 0
 	return ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1534,11 +1534,7 @@ Use this proc preferably at the end of an equipment loadout
 			canmove = 0
 			lying = (category.flags & LOCKED_SHOULD_LIE) ? TRUE : FALSE //A lying value that !=1 will break this
 
-	else if(resting || !can_stand)
-		stop_pulling()
-		lying = 1
-		canmove = 0
-	else if(isKnockedDown())
+	else if(resting || !can_stand || isKnockedDown())
 		stop_pulling()
 		lying = 1
 		canmove = 0

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1521,9 +1521,9 @@ Use this proc preferably at the end of an equipment loadout
 	return 1
 
 /mob/proc/isKnockedDown() //Check if the mob is knocked down
-	return isUnconscious() || knockdown || paralysis || resting || !can_stand
+	return isUnconscious() || knockdown || paralysis
 
-/mob/proc/isJustStunned() //Some ancient coder (as of 2021) made it so that it checks directly for whether the variable has a positive number, and I'm too afraid of unintended consequences down the line to just change it to isStunned(), so instead you have this half-baked abomination of a barely-used proc just so that player simple_animal mobs can move and do things. You're welcome!
+/mob/proc/isJustStunned() //Some ancient coder (as of 2021) made it so that it checks directly for whether the variable has a positive number, and I'm too afraid of unintended consequences down the line to just change it to isStunned(), so instead you have this half-baked abomination of a barely-used proc just so that player simple_animal mobs can move. You're welcome!
 	return stunned
 
 //Updates canmove, lying and icons. Could perhaps do with a rename but I can't think of anything to describe it.
@@ -1534,7 +1534,10 @@ Use this proc preferably at the end of an equipment loadout
 			canmove = 0
 			lying = (category.flags & LOCKED_SHOULD_LIE) ? TRUE : FALSE //A lying value that !=1 will break this
 
-
+	else if(resting || !can_stand)
+		stop_pulling()
+		lying = 1
+		canmove = 0
 	else if(isKnockedDown())
 		stop_pulling()
 		lying = 1

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1520,6 +1520,12 @@ Use this proc preferably at the end of an equipment loadout
 		return 0
 	return 1
 
+/mob/proc/isKnockedDown() //Check if the mob is knocked down
+	return isUnconscious() || knockdown || paralysis || resting || !can_stand
+
+/mob/proc/isJustStunned() //Some ancient coder (as of 2021) made it so that it checks directly for whether the variable has a positive number, and I'm too afraid of unintended consequences down the line to just change it to isStunned(), so instead you have this half-baked abomination of a barely-used proc just so that player simple_animal mobs can move and do things. You're welcome!
+	return stunned
+
 //Updates canmove, lying and icons. Could perhaps do with a rename but I can't think of anything to describe it.
 /mob/proc/update_canmove()
 	if (locked_to)
@@ -1529,11 +1535,11 @@ Use this proc preferably at the end of an equipment loadout
 			lying = (category.flags & LOCKED_SHOULD_LIE) ? TRUE : FALSE //A lying value that !=1 will break this
 
 
-	else if(isUnconscious() || knockdown || paralysis || resting || !can_stand)
+	else if(isKnockedDown())
 		stop_pulling()
 		lying = 1
 		canmove = 0
-	else if(stunned)
+	else if(isJustStunned())
 //		lying = 0
 		canmove = 0
 	else if(captured)


### PR DESCRIPTION
This has been long overdue ever since that Snaxi round a year ago with the wendigo
As it turns out simple_animal mobs never have to worry about stuns because their rudimentary AI brute-forces it and moves mobs around itself, ignoring things such as whether the mob is stunned.
Clients on the other hand do not have such privilege, both the player-controlled movement and clicking are blocked if the mob is incapacitated in any way, meaning that in the end you COULD destroy all those admin-spawned player-controlled robo-hitlers at roundend Centcomm if you had a trusty taser with you.

:cl:
 * tweak: Player-controlled creatures (including russians) now ignore stuns as their AI-controlled counterparts do.