### PR TITLE
Canmove now kicks in the moment the stun kicks in

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1715,16 +1715,19 @@ Use this proc preferably at the end of an equipment loadout
 /mob/proc/Stun(amount)
 	if(status_flags & CANSTUN)
 		stunned = max(max(stunned,amount),0) //can't go below 0, getting a low amount of stun doesn't lower your current stun
+		update_canmove()
 	return
 
 /mob/proc/SetStunned(amount) //if you REALLY need to set stun to a set amount without the whole "can't go below current stunned"
 	if(status_flags & CANSTUN)
 		stunned = max(amount,0)
+		update_canmove()
 	return
 
 /mob/proc/AdjustStunned(amount)
 	if(status_flags & CANSTUN)
 		stunned = max(stunned + amount,0)
+		update_canmove()
 	return
 
 /mob/proc/Deafen(amount)
@@ -1766,16 +1769,19 @@ Use this proc preferably at the end of an equipment loadout
 /mob/proc/Paralyse(amount)
 	if(status_flags & CANPARALYSE)
 		paralysis = max(max(paralysis,amount),0)
+		update_canmove()
 	return
 
 /mob/proc/SetParalysis(amount)
 	if(status_flags & CANPARALYSE)
 		paralysis = max(amount,0)
+		update_canmove()
 	return
 
 /mob/proc/AdjustParalysis(amount)
 	if(status_flags & CANPARALYSE)
 		paralysis = max(paralysis + amount,0)
+		update_canmove()
 	return
 
 /mob/proc/Sleeping(amount)


### PR DESCRIPTION
Which means that the moment you get stunned/unstunned or anything it kicks in immediately instead of the next tick
I had this branch for almost a year and I almost forgot what it was about, but after one mental thing led to another I rediscovered it was so that the vampire rejuvenation ability kicks in immediately instead of the next tick, I'm not sure what else is affected but at least it's far more responsive now. I guess.

:cl:
 * tweak: Slightly tweaked several status effects such as stuns, now your movement is affected as soon as it kicks in or artificially wears off. Most notably it allows vampires to get up the moment they rejuvenate.