### PR TITLE
yet more critical cult fixes, seriously chief cultists are a riot!

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -265,7 +265,7 @@
 
 #define islegacycultist(H) (H.mind && H.mind.GetRole(LEGACY_CULTIST))
 
-#define isanycultist(H) (H.mind && (H.mind.GetRole(LEGACY_CULTIST) || H.mind.GetRole(CULTIST)))
+#define isanycultist(H) (islegacycultist(H) || iscultist(H))
 
 #define ischangeling(H) (H.mind && H.mind.GetRole(CHANGELING))
 

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -1287,12 +1287,16 @@ var/list/arcane_tomes = list()
 	mech_flags = MECH_SCAN_FAIL
 
 /obj/item/weapon/bloodcult_pamphlet/attack_self(var/mob/user)
-	var/datum/role/cultist/chief/newCultist = new
-	newCultist.AssignToRole(user.mind,1)
 	var/datum/faction/bloodcult/cult = find_active_faction_by_type(/datum/faction/bloodcult)
 	if (!cult)
 		cult = ticker.mode.CreateFaction(/datum/faction/bloodcult, null, 1)
 		cult.OnPostSetup()
+	var/datum/role/cultist/newCultist
+	if (cult.members.len > 0)
+		newCultist = new /datum/role/cultist()
+	else
+		newCultist = new /datum/role/cultist/chief()
+	newCultist.AssignToRole(user.mind,1)
 	cult.HandleRecruitedRole(newCultist)
 	newCultist.OnPostSetup()
 	newCultist.Greet(GREET_PAMPHLET)

--- a/code/game/machinery/doors/mineral.dm
+++ b/code/game/machinery/doors/mineral.dm
@@ -352,6 +352,9 @@
 				M.pulling.forceMove(loc)//so we don't stop pulling stuff when moving through cult doors
 		close()
 
+/obj/machinery/door/mineral/cult/attack_construct(var/mob/user)
+	return TryToSwitchState(user)
+
 /obj/machinery/door/mineral/cult/TryToSwitchState(atom/user)
 	if (ismob(user))
 		var/mob/M = user


### PR DESCRIPTION
How were chief cultists even playable at all until now? How were none of those bugs even reported at all either? I mean before #29251 they couldn't even listen to cult comms or use tattoos. Whatever.

Fixes #29327 

:cl:
* bugfix: Fixed even more chief cultist related critical bugs, including them being unable to operate cult doors at all, or getting targeted by hex constructs.
* bugfix: Using a cult pamphlet when there is already a cult established does no longer turn the player into a second chief cultist.
* bugfix: Constructs are now able to operate cult doors by clicking on them