### PR TITLE
Allows gremlins to ventcrawl (and spiderling ventcrawl fixes)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
@@ -108,7 +108,7 @@
 
 /mob/living/simple_animal/hostile/giant_spider/spiderling/AttackingTarget()
 	if(istype(target, /obj/machinery/atmospherics/unary/vent_pump) && !client)
-		get_vent(target)
+		can_ventcrawl = TRUE
 
 /mob/living/simple_animal/hostile/giant_spider/spiderling/proc/growth()
 	if(isturf(loc) && (client || amount_grown > 0))//player-controlled spiderlings will always eventually mature, others have a 75% chance.

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
@@ -14,8 +14,6 @@
 	density = 0
 
 	var/amount_grown = 0
-	var/obj/machinery/atmospherics/unary/vent_pump/entry_vent
-	var/travelling_in_vent = 0
 
 	butchering_drops = null
 
@@ -84,50 +82,6 @@
 /mob/living/simple_animal/hostile/giant_spider/spiderling/Life()
 	if(timestopped)
 		return 0 //under effects of time magick
-	if(!client || deny_client_move)
-		if(travelling_in_vent)
-			if(istype(src.loc, /turf))
-				travelling_in_vent = 0
-				entry_vent = null
-		else if(entry_vent)
-			if(get_dist(src, entry_vent) <= 1)
-				if(entry_vent.network && entry_vent.network.normal_members.len)
-					var/list/vents = list()
-					for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in entry_vent.network.normal_members)
-						vents.Add(temp_vent)
-					if(!vents.len)
-						entry_vent = null
-						return
-					var/obj/machinery/atmospherics/unary/vent_pump/exit_vent = pick(vents)
-					/*if(prob(50))
-						src.visible_message("<B>[src] scrambles into the ventillation ducts!</B>")*/
-					LoseAggro()
-					spawn(rand(20,60))
-						loc = exit_vent
-						var/travel_time = round(get_dist(loc, exit_vent.loc) / 2)
-						spawn(travel_time)
-
-							if(!exit_vent || exit_vent.welded)
-								loc = entry_vent
-								entry_vent = null
-								return
-
-							if(prob(50))
-								src.visible_message("<span class='notice'>You hear something squeezing through the ventilation ducts.</span>",2)
-							sleep(travel_time)
-
-							if(!exit_vent || exit_vent.welded)
-								loc = entry_vent
-								entry_vent = null
-								return
-							loc = exit_vent.loc
-							entry_vent = null
-							var/area/new_area = get_area(loc)
-							if(new_area)
-								new_area.Entered(src)
-				else
-					entry_vent = null
-	//=================
 
 	if (growth())
 		return
@@ -154,7 +108,7 @@
 
 /mob/living/simple_animal/hostile/giant_spider/spiderling/AttackingTarget()
 	if(istype(target, /obj/machinery/atmospherics/unary/vent_pump))
-		ventcrawl(target)
+		get_vent(target)
 
 /mob/living/simple_animal/hostile/giant_spider/spiderling/proc/growth()
 	if(isturf(loc) && (client || amount_grown > 0))//player-controlled spiderlings will always eventually mature, others have a 75% chance.
@@ -194,12 +148,6 @@
 			grow_up(/mob/living/simple_animal/hostile/giant_spider/hunter)
 		if ("Guard")
 			grow_up(/mob/living/simple_animal/hostile/giant_spider)
-
-/mob/living/simple_animal/hostile/giant_spider/spiderling/proc/ventcrawl(var/obj/machinery/atmospherics/unary/vent_pump/v)
-	//ventcrawl!
-	if(!v.welded)
-		entry_vent = v
-		Goto(get_turf(v),move_to_delay)
 
 
 //Virologist's little friend!

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
@@ -34,6 +34,7 @@
 	//status_flags = CANPUSH
 	search_objects = 0
 	wanted_objects = list(/obj/machinery/atmospherics/unary/vent_pump)
+	can_ventcrawl = TRUE
 
 	environment_smash_flags = 0//spiderlings cannot smash tables and windows anymore when getting stomped
 	var/static/list/spider_types = list(/mob/living/simple_animal/hostile/giant_spider, /mob/living/simple_animal/hostile/giant_spider/nurse, /mob/living/simple_animal/hostile/giant_spider/hunter)
@@ -105,10 +106,6 @@
 		target = new_target
 		Aggro()
 		visible_message("<span class='danger'>The [src.name] tries to flee from [target.name]!</span>")
-
-/mob/living/simple_animal/hostile/giant_spider/spiderling/AttackingTarget()
-	if(istype(target, /obj/machinery/atmospherics/unary/vent_pump) && !client)
-		can_ventcrawl = TRUE
 
 /mob/living/simple_animal/hostile/giant_spider/spiderling/proc/growth()
 	if(isturf(loc) && (client || amount_grown > 0))//player-controlled spiderlings will always eventually mature, others have a 75% chance.

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
@@ -107,7 +107,7 @@
 		visible_message("<span class='danger'>The [src.name] tries to flee from [target.name]!</span>")
 
 /mob/living/simple_animal/hostile/giant_spider/spiderling/AttackingTarget()
-	if(istype(target, /obj/machinery/atmospherics/unary/vent_pump))
+	if(istype(target, /obj/machinery/atmospherics/unary/vent_pump) && !client)
 		get_vent(target)
 
 /mob/living/simple_animal/hostile/giant_spider/spiderling/proc/growth()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
@@ -149,6 +149,13 @@
 		if ("Guard")
 			grow_up(/mob/living/simple_animal/hostile/giant_spider)
 
+/mob/living/simple_animal/hostile/giant_spider/spiderling/verb/ventcrawl()
+	set name = "Crawl through Vent"
+	set desc = "Enter an air vent and crawl through the pipe system."
+	set category = "Object"
+	var/pipe = start_ventcrawl()
+	if(pipe)
+		handle_ventcrawl(pipe)
 
 //Virologist's little friend!
 /mob/living/simple_animal/hostile/giant_spider/spiderling/salk

--- a/code/modules/mob/living/simple_animal/hostile/gremlin.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gremlin.dm
@@ -42,7 +42,7 @@ var/list/bad_gremlin_items = list()
 
 /mob/living/simple_animal/hostile/gremlin/AttackingTarget()
 	if(istype(target, /obj/machinery/atmospherics/unary/vent_pump) && !client) // So clients don't do this too
-		get_vent(target)
+		can_ventcrawl = TRUE
 	else if(istype(target, /obj))
 		var/obj/M = target
 

--- a/code/modules/mob/living/simple_animal/hostile/gremlin.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gremlin.dm
@@ -40,6 +40,10 @@ var/list/bad_gremlin_items = list()
 	var/list/hear_memory = list()
 	var/const/max_hear_memory = 20
 
+	//For ventcrawling
+	var/obj/machinery/atmospherics/unary/vent_pump/entry_vent
+	var/travelling_in_vent = 0
+
 /mob/living/simple_animal/hostile/gremlin/AttackingTarget()
 	if(istype(target, /obj))
 		var/obj/M = target
@@ -123,6 +127,47 @@ var/list/bad_gremlin_items = list()
 		if(++time_chasing_target > max_time_chasing_target)
 			LoseTarget()
 			time_chasing_target = 0
+
+	//Ventcrawling stuff from spiderling code
+	if(travelling_in_vent)
+		if(istype(src.loc, /turf))
+			travelling_in_vent = 0
+			entry_vent = null
+	else if(entry_vent)
+		if(get_dist(src, entry_vent) <= 1)
+			if(entry_vent.network && entry_vent.network.normal_members.len)
+				var/list/vents = list()
+				for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in entry_vent.network.normal_members)
+					vents.Add(temp_vent)
+				if(!vents.len)
+					entry_vent = null
+					return
+				var/obj/machinery/atmospherics/unary/vent_pump/exit_vent = pick(vents)
+				spawn(rand(20,60))
+					loc = exit_vent
+					var/travel_time = round(get_dist(loc, exit_vent.loc) / 2)
+					spawn(travel_time)
+
+						if(!exit_vent || exit_vent.welded)
+							loc = entry_vent
+							entry_vent = null
+							return
+
+						if(prob(50))
+							src.visible_message("<span class='notice'>You hear something squeezing through the ventilation ducts.</span>",2)
+						sleep(travel_time)
+
+						if(!exit_vent || exit_vent.welded)
+							loc = entry_vent
+							entry_vent = null
+							return
+						loc = exit_vent.loc
+						entry_vent = null
+						var/area/new_area = get_area(loc)
+						if(new_area)
+							new_area.Entered(src)
+			else
+				entry_vent = null
 
 	.=..()
 

--- a/code/modules/mob/living/simple_animal/hostile/gremlin.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gremlin.dm
@@ -42,7 +42,7 @@ var/list/bad_gremlin_items = list()
 	var/const/max_hear_memory = 20
 
 /mob/living/simple_animal/hostile/gremlin/AttackingTarget()
-	if(istype(target, /obj) && (!istype(target, /obj/machinery/atmospherics/unary/vent_pump) && !client)) // If no client, ignore vents
+	if(istype(target, /obj) && (!istype(target, /obj/machinery/atmospherics/unary/vent_pump) && !(client || deny_client_move))) // If no client, ignore vents
 		var/obj/M = target
 
 		tamper(M)

--- a/code/modules/mob/living/simple_animal/hostile/gremlin.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gremlin.dm
@@ -41,7 +41,7 @@ var/list/bad_gremlin_items = list()
 	var/const/max_hear_memory = 20
 
 /mob/living/simple_animal/hostile/gremlin/AttackingTarget()
-	if(istype(target, /obj/machinery/atmospherics/unary/vent_pump))
+	if(istype(target, /obj/machinery/atmospherics/unary/vent_pump) && !client) // So clients don't do this too
 		get_vent(target)
 	else if(istype(target, /obj))
 		var/obj/M = target

--- a/code/modules/mob/living/simple_animal/hostile/gremlin.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gremlin.dm
@@ -40,10 +40,6 @@ var/list/bad_gremlin_items = list()
 	var/list/hear_memory = list()
 	var/const/max_hear_memory = 20
 
-	//For ventcrawling
-	var/obj/machinery/atmospherics/unary/vent_pump/entry_vent
-	var/travelling_in_vent = 0
-
 /mob/living/simple_animal/hostile/gremlin/AttackingTarget()
 	if(istype(target, /obj/machinery/atmospherics/unary/vent_pump))
 		get_vent(target)
@@ -112,12 +108,6 @@ var/list/bad_gremlin_items = list()
 	if(pipe)
 		handle_ventcrawl(pipe)
 
-/mob/living/simple_animal/hostile/gremlin/proc/get_vent(var/obj/machinery/atmospherics/unary/vent_pump/v)
-	//ventcrawl!
-	if(!v.welded)
-		entry_vent = v
-		Goto(get_turf(v),move_to_delay)
-
 /mob/living/simple_animal/hostile/gremlin/CanAttack(atom/new_target)
 	if(bad_gremlin_items.Find(new_target.type))
 		return FALSE
@@ -143,45 +133,6 @@ var/list/bad_gremlin_items = list()
 		if(++time_chasing_target > max_time_chasing_target)
 			LoseTarget()
 			time_chasing_target = 0
-
-	//Ventcrawling stuff from spiderling code
-	if(!client || deny_client_move)
-		if(travelling_in_vent)
-			if(istype(src.loc, /turf))
-				travelling_in_vent = 0
-				entry_vent = null
-		else if(entry_vent)
-			if(get_dist(src, entry_vent) <= 1)
-				if(entry_vent.network && entry_vent.network.normal_members.len)
-					var/list/vents = list()
-					for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in entry_vent.network.normal_members)
-						vents.Add(temp_vent)
-					if(!vents.len)
-						entry_vent = null
-						return
-					var/obj/machinery/atmospherics/unary/vent_pump/exit_vent = pick(vents)
-					spawn(rand(20,60))
-						var/travel_time = round(get_dist(loc, exit_vent.loc) / 2)
-						forceMove(exit_vent)
-						spawn(travel_time)
-
-							if(!exit_vent || exit_vent.welded)
-								forceMove(entry_vent)
-								entry_vent = null
-								return
-
-							if(prob(50))
-								src.visible_message("<span class='notice'>You hear something squeezing through the ventilation ducts.</span>",2)
-							sleep(travel_time)
-
-							if(!exit_vent || exit_vent.welded)
-								forceMove(entry_vent)
-								entry_vent = null
-								return
-							forceMove(exit_vent.loc)
-							entry_vent = null
-				else
-					entry_vent = null
 
 	.=..()
 

--- a/code/modules/mob/living/simple_animal/hostile/gremlin.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gremlin.dm
@@ -46,7 +46,7 @@ var/list/bad_gremlin_items = list()
 
 /mob/living/simple_animal/hostile/gremlin/AttackingTarget()
 	if(istype(target, /obj/machinery/atmospherics/unary/vent_pump))
-		ventcrawl(target)
+		get_vent(target)
 	else if(istype(target, /obj))
 		var/obj/M = target
 
@@ -104,7 +104,7 @@ var/list/bad_gremlin_items = list()
 /mob/living/simple_animal/hostile/gremlin/proc/stand_still(var/tick_amount)
 	time_chasing_target -= tick_amount
 
-/mob/living/simple_animal/hostile/gremlin/proc/ventcrawl(var/obj/machinery/atmospherics/unary/vent_pump/v)
+/mob/living/simple_animal/hostile/gremlin/proc/get_vent(var/obj/machinery/atmospherics/unary/vent_pump/v)
 	//ventcrawl!
 	if(!v.welded)
 		entry_vent = v

--- a/code/modules/mob/living/simple_animal/hostile/gremlin.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gremlin.dm
@@ -104,6 +104,14 @@ var/list/bad_gremlin_items = list()
 /mob/living/simple_animal/hostile/gremlin/proc/stand_still(var/tick_amount)
 	time_chasing_target -= tick_amount
 
+/mob/living/simple_animal/hostile/gremlin/verb/ventcrawl()
+	set name = "Crawl through Vent"
+	set desc = "Enter an air vent and crawl through the pipe system."
+	set category = "Object"
+	var/pipe = start_ventcrawl()
+	if(pipe)
+		handle_ventcrawl(pipe)
+
 /mob/living/simple_animal/hostile/gremlin/proc/get_vent(var/obj/machinery/atmospherics/unary/vent_pump/v)
 	//ventcrawl!
 	if(!v.welded)

--- a/code/modules/mob/living/simple_animal/hostile/gremlin.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gremlin.dm
@@ -145,45 +145,43 @@ var/list/bad_gremlin_items = list()
 			time_chasing_target = 0
 
 	//Ventcrawling stuff from spiderling code
-	if(travelling_in_vent)
-		if(istype(src.loc, /turf))
-			travelling_in_vent = 0
-			entry_vent = null
-	else if(entry_vent)
-		if(get_dist(src, entry_vent) <= 1)
-			if(entry_vent.network && entry_vent.network.normal_members.len)
-				var/list/vents = list()
-				for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in entry_vent.network.normal_members)
-					vents.Add(temp_vent)
-				if(!vents.len)
-					entry_vent = null
-					return
-				var/obj/machinery/atmospherics/unary/vent_pump/exit_vent = pick(vents)
-				spawn(rand(20,60))
-					loc = exit_vent
-					var/travel_time = round(get_dist(loc, exit_vent.loc) / 2)
-					spawn(travel_time)
-
-						if(!exit_vent || exit_vent.welded)
-							loc = entry_vent
-							entry_vent = null
-							return
-
-						if(prob(50))
-							src.visible_message("<span class='notice'>You hear something squeezing through the ventilation ducts.</span>",2)
-						sleep(travel_time)
-
-						if(!exit_vent || exit_vent.welded)
-							loc = entry_vent
-							entry_vent = null
-							return
-						loc = exit_vent.loc
-						entry_vent = null
-						var/area/new_area = get_area(loc)
-						if(new_area)
-							new_area.Entered(src)
-			else
+	if(!client || deny_client_move)
+		if(travelling_in_vent)
+			if(istype(src.loc, /turf))
+				travelling_in_vent = 0
 				entry_vent = null
+		else if(entry_vent)
+			if(get_dist(src, entry_vent) <= 1)
+				if(entry_vent.network && entry_vent.network.normal_members.len)
+					var/list/vents = list()
+					for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in entry_vent.network.normal_members)
+						vents.Add(temp_vent)
+					if(!vents.len)
+						entry_vent = null
+						return
+					var/obj/machinery/atmospherics/unary/vent_pump/exit_vent = pick(vents)
+					spawn(rand(20,60))
+						var/travel_time = round(get_dist(loc, exit_vent.loc) / 2)
+						forceMove(exit_vent)
+						spawn(travel_time)
+
+							if(!exit_vent || exit_vent.welded)
+								forceMove(entry_vent)
+								entry_vent = null
+								return
+
+							if(prob(50))
+								src.visible_message("<span class='notice'>You hear something squeezing through the ventilation ducts.</span>",2)
+							sleep(travel_time)
+
+							if(!exit_vent || exit_vent.welded)
+								forceMove(entry_vent)
+								entry_vent = null
+								return
+							forceMove(exit_vent.loc)
+							entry_vent = null
+				else
+					entry_vent = null
 
 	.=..()
 

--- a/code/modules/mob/living/simple_animal/hostile/gremlin.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gremlin.dm
@@ -18,6 +18,7 @@ var/list/bad_gremlin_items = list()
 	maxHealth = 18
 	size = SIZE_SMALL
 	search_objects = 3 //Completely ignore mobs
+	can_ventcrawl = TRUE
 
 	//Tampering is handled by the 'npc_tamper()' obj proc
 	wanted_objects = list(
@@ -41,9 +42,7 @@ var/list/bad_gremlin_items = list()
 	var/const/max_hear_memory = 20
 
 /mob/living/simple_animal/hostile/gremlin/AttackingTarget()
-	if(istype(target, /obj/machinery/atmospherics/unary/vent_pump) && !client) // So clients don't do this too
-		can_ventcrawl = TRUE
-	else if(istype(target, /obj))
+	if(istype(target, /obj) && (!istype(target, /obj/machinery/atmospherics/unary/vent_pump) && !client)) // If no client, ignore vents
 		var/obj/M = target
 
 		tamper(M)

--- a/code/modules/mob/living/simple_animal/hostile/gremlin.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gremlin.dm
@@ -45,7 +45,9 @@ var/list/bad_gremlin_items = list()
 	var/travelling_in_vent = 0
 
 /mob/living/simple_animal/hostile/gremlin/AttackingTarget()
-	if(istype(target, /obj))
+	if(istype(target, /obj/machinery/atmospherics/unary/vent_pump))
+		ventcrawl(target)
+	else if(istype(target, /obj))
 		var/obj/M = target
 
 		tamper(M)
@@ -101,6 +103,12 @@ var/list/bad_gremlin_items = list()
 
 /mob/living/simple_animal/hostile/gremlin/proc/stand_still(var/tick_amount)
 	time_chasing_target -= tick_amount
+
+/mob/living/simple_animal/hostile/gremlin/proc/ventcrawl(var/obj/machinery/atmospherics/unary/vent_pump/v)
+	//ventcrawl!
+	if(!v.welded)
+		entry_vent = v
+		Goto(get_turf(v),move_to_delay)
 
 /mob/living/simple_animal/hostile/gremlin/CanAttack(atom/new_target)
 	if(bad_gremlin_items.Find(new_target.type))

--- a/code/modules/mob/living/simple_animal/hostile/grinch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grinch.dm
@@ -166,14 +166,6 @@
 		update_icons()
 
 
-/mob/living/simple_animal/hostile/gremlin/grinch/verb/ventcrawl()
-	set name = "Crawl through Vent"
-	set desc = "Enter an air vent and crawl through the pipe system."
-	set category = "Object"
-	var/pipe = start_ventcrawl()
-	if(pipe)
-		handle_ventcrawl(pipe)
-
 // -- Clearing of refs
 /mob/living/simple_animal/hostile/gremlin/grinch/Destroy()
 	back = null

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -69,6 +69,8 @@
 						entry_vent = null
 						return
 					var/obj/machinery/atmospherics/unary/vent_pump/exit_vent = pick(vents)
+					if(prob(50))
+						src.visible_message("<span class='notice'>[src] scrambles into the ventillation ducts!</span>")
 					LoseAggro()
 					spawn(rand(20,60))
 						var/travel_time = round(get_dist(loc, exit_vent.loc) / 2)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -59,7 +59,7 @@
 		return 0 //under effects of time magick
 	if(!client || deny_client_move) //Ventcrawling stuff
 		if(entry_vent)
-			if(get_dist(src, entry_vent) <= 1)
+			if(Adjacent(entry_vent))
 				if(entry_vent.network && entry_vent.network.normal_members.len)
 					var/list/vents = list()
 					for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in entry_vent.network.normal_members)
@@ -70,7 +70,7 @@
 						return
 					var/obj/machinery/atmospherics/unary/vent_pump/exit_vent = pick(vents)
 					if(prob(50))
-						src.visible_message("<span class='notice'>[src] scrambles into the ventillation ducts!</span>")
+						visible_message("<span class='notice'>[src] scrambles into the ventillation ducts!</span>")
 					LoseAggro()
 					spawn(rand(20,60))
 						var/travel_time = round(get_dist(loc, exit_vent.loc) / 2)
@@ -83,7 +83,7 @@
 								return
 
 							if(prob(50))
-								src.visible_message("<span class='notice'>You hear something squeezing through the ventilation ducts.</span>",2)
+								visible_message("<span class='notice'>You hear something squeezing through the ventilation ducts.</span>",2)
 							sleep(travel_time)
 
 							if(!exit_vent)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -33,7 +33,6 @@
 	var/list/target_rules = list()
 
 	var/obj/machinery/atmospherics/unary/vent_pump/entry_vent // The vent to target for ventcrawling
-	var/travelling_in_vent = 0 // If set to 1, is in a vent
 
 /mob/living/simple_animal/hostile/New()
 	..()
@@ -59,11 +58,7 @@
 	if(timestopped)
 		return 0 //under effects of time magick
 	if(!client || deny_client_move) //Ventcrawling stuff
-		if(travelling_in_vent)
-			if(istype(src.loc, /turf))
-				travelling_in_vent = 0
-				entry_vent = null
-		else if(entry_vent)
+		if(entry_vent)
 			if(get_dist(src, entry_vent) <= 1)
 				if(entry_vent.network && entry_vent.network.normal_members.len)
 					var/list/vents = list()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -60,36 +60,34 @@
 	if(!client || deny_client_move) //Ventcrawling stuff
 		if(can_ventcrawl && istype(target,/obj/machinery/atmospherics/unary/vent_pump))
 			var/obj/machinery/atmospherics/unary/vent_pump/entry_vent = target
-			if(!entry_vent.welded)
-				Goto(get_turf(entry_vent),move_to_delay)
-				if(Adjacent(entry_vent) && entry_vent.network && entry_vent.network.normal_members.len)
-					var/list/vents = list()
-					for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in entry_vent.network.normal_members)
-						if(!temp_vent.welded)
-							vents.Add(temp_vent)
-					if(!vents.len)
-						return
-					var/obj/machinery/atmospherics/unary/vent_pump/exit_vent = pick(vents)
-					if(prob(50))
-						visible_message("<span class='notice'>[src] scrambles into the ventillation ducts!</span>")
-					LoseAggro()
-					spawn(rand(20,60))
-						var/travel_time = round(get_dist(loc, exit_vent.loc) / 2)
-						forceMove(exit_vent)
-						spawn(travel_time)
+			if(Adjacent(entry_vent) && !entry_vent.welded && entry_vent.network && entry_vent.network.normal_members.len)
+				var/list/vents = list()
+				for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in entry_vent.network.normal_members)
+					if(!temp_vent.welded)
+						vents.Add(temp_vent)
+				if(!vents.len)
+					return
+				var/obj/machinery/atmospherics/unary/vent_pump/exit_vent = pick(vents)
+				if(prob(50))
+					visible_message("<span class='notice'>[src] scrambles into the ventillation ducts!</span>")
+				LoseAggro()
+				spawn(rand(20,60))
+					var/travel_time = round(get_dist(loc, exit_vent.loc) / 2)
+					forceMove(exit_vent)
+					spawn(travel_time)
 
-							if(!exit_vent)
-								forceMove(entry_vent)
-								return
+						if(!exit_vent)
+							forceMove(entry_vent)
+							return
 
-							if(prob(50))
-								visible_message("<span class='notice'>You hear something squeezing through the ventilation ducts.</span>",2)
-							sleep(travel_time)
+						if(prob(50))
+							visible_message("<span class='notice'>You hear something squeezing through the ventilation ducts.</span>",2)
+						sleep(travel_time)
 
-							if(!exit_vent)
-								forceMove(entry_vent)
-								return
-							forceMove(exit_vent.loc)
+						if(!exit_vent)
+							forceMove(entry_vent)
+							return
+						forceMove(exit_vent.loc)
 	. = ..()
 	//Cooldowns
 	if(ranged)
@@ -300,7 +298,10 @@
 		return 1
 
 /mob/living/simple_animal/hostile/proc/AttackingTarget()
-	UnarmedAttack(target, Adjacent(target))
+	if(can_ventcrawl && istype(target,/obj/machinery/atmospherics/unary/vent_pump))
+		Goto(get_turf(target),move_to_delay)
+	else
+		UnarmedAttack(target, Adjacent(target))
 
 /mob/living/simple_animal/hostile/proc/Aggro()
 	vision_range = aggro_vision_range

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -63,7 +63,8 @@
 				if(entry_vent.network && entry_vent.network.normal_members.len)
 					var/list/vents = list()
 					for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in entry_vent.network.normal_members)
-						vents.Add(temp_vent)
+						if(!temp_vent.welded)
+							vents.Add(temp_vent)
 					if(!vents.len)
 						entry_vent = null
 						return
@@ -74,7 +75,7 @@
 						forceMove(exit_vent)
 						spawn(travel_time)
 
-							if(!exit_vent || exit_vent.welded)
+							if(!exit_vent)
 								forceMove(entry_vent)
 								entry_vent = null
 								return
@@ -83,7 +84,7 @@
 								src.visible_message("<span class='notice'>You hear something squeezing through the ventilation ducts.</span>",2)
 							sleep(travel_time)
 
-							if(!exit_vent || exit_vent.welded)
+							if(!exit_vent)
 								forceMove(entry_vent)
 								entry_vent = null
 								return

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -73,6 +73,7 @@
 						entry_vent = null
 						return
 					var/obj/machinery/atmospherics/unary/vent_pump/exit_vent = pick(vents)
+					LoseAggro()
 					spawn(rand(20,60))
 						var/travel_time = round(get_dist(loc, exit_vent.loc) / 2)
 						forceMove(exit_vent)


### PR DESCRIPTION
[tweak]
And other hostile mobs too, but only those that have can_ventcrawl set to true (so far only gremlins and spiderlings)
Player controlled gremlins just ventcrawl as normal, grinch ventcrawl verb was moved up to all gremlins
Bugfix was done during code refactor

:cl:
 * tweak: Gremlins have learned how to ventcrawl now. Keep them away from airvents at all costs!
 * tweak: Player controlled spiderlings now normally ventcrawl.
 * bugfix: Spiderlings no longer instantaneously travel to other vents on the network while ventcrawling
 * tweak: Spiderlings no longer abort ventcrawling altogether if it detects the exit vent is welded