### PR TITLE
Folding chair tweaks

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -591,6 +591,18 @@
 		unfolded = null
 	..()
 
+/obj/item/folding_chair/attack(mob/living/M, mob/living/user, def_zone, originator)
+	if(user.is_wearing_item(/obj/item/weapon/storage/belt/champion))
+		force *= 2 //Shitcode! There's no proc where the amount of force can be modified at least temporarily.
+		..()
+		force /= 2
+		return
+	..()
+
+/obj/item/folding_chair/on_attack(atom/attacked, mob/user)
+	hitsound = pick('sound/items/trayhit1.ogg', 'sound/items/trayhit2.ogg')
+	..()
+
 /obj/item/folding_chair/attack_self(mob/user)
 	unfolded.forceMove(user.loc)
 	unfolded.add_fingerprint(user)


### PR DESCRIPTION
Requested by @PrimeDSS13 
It now has hit sounds.
It deals double damage if you are wearing the champion's belt.
:cl:
 * soundadd: The folding chair now plays sounds when you hit things with it.
 * rscadd: Those who have the power of wrestling coursing through their belts are now far more effective wielders of folding chairs.