### PR TITLE
Borg banned people will now be turned into a free APC when autoborged

### DIFF
--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -180,6 +180,7 @@
 		O.self_destruct()
 		message_admins("[key_name(O)] was forcefully transformed into a [job] and had its self-destruct mechanism engaged due \his job ban or lack of player age.")
 		log_game("[key_name(O)] was forcefully transformed into a [job] and had its self-destruct mechanism engaged due \his job ban or lack of player age.")
+		return FALSE
 	if(!skipnaming)
 		spawn()
 			O.Namepick()


### PR DESCRIPTION
May or may not be inspired by recent events.
`Robotize` already checks if you are banned, or too young to be a borg, before putting you in one. 
If you meet those criterion, you get gibbed and put in an MMI.

I made it so the autoborger goes by those rules instead of just refusing the carbon being given to it.

If the borging fails, the AI will get a FREE apc instead. This might be too much, I don't know.

Do note that a different, more backend-type PR would need to be done for ghosted and AFK people.

:cl:
- tweak: The MalfAI's autoburger will no longer refuse borg-banned people. It will gib them and give a free APC to the AI instead.
