### PR TITLE
Fixes roboticist PDA showing up in backpack

### DIFF
--- a/code/datums/outfit/science.dm
+++ b/code/datums/outfit/science.dm
@@ -238,7 +238,7 @@
 	)
 
 	pda_type = /obj/item/device/pda/roboticist
-	pda_slot = slot_belt
+	pda_slot = slot_l_store
 	id_type = /obj/item/weapon/card/id/research
 
 /datum/outfit/roboticist/post_equip(var/mob/living/carbon/human/H)


### PR DESCRIPTION
[tweak]
Now in the left pocket, like engineers.
:cl:
 * tweak: Roboticist PDAs are no longer tucked away inside backpacks instead of in pockets