### PR TITLE
Secbot cuffs (Beepsky, ED-209) tweak

### DIFF
--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -385,7 +385,7 @@ Auto Patrol: []"},
 							return
 						if (M.handcuffed)
 							return
-						M.handcuffed = new /obj/item/weapon/handcuffs(M)
+						M.handcuffed = new /obj/item/weapon/handcuffs/cyborg/ed209(M)
 						M.update_inv_handcuffed()	//update handcuff overlays
 			if(declare_arrests)
 				var/area/location = get_area(src)

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -296,7 +296,7 @@ Auto Patrol: []"},
 							return
 						if (M.handcuffed)
 							return
-						M.handcuffed = new /obj/item/weapon/handcuffs(M)
+						M.handcuffed = new /obj/item/weapon/handcuffs/cyborg/beepsky(M)
 						M.update_inv_handcuffed()	//update handcuff overlays
 						playsound(src, pick('sound/voice/bgod.ogg', 'sound/voice/biamthelaw.ogg', 'sound/voice/bsecureday.ogg', 'sound/voice/bradio.ogg', 'sound/voice/binsult.ogg', 'sound/voice/bcreep.ogg'), 50, 0)
 						spawn (1.5 SECONDS)

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -26,16 +26,28 @@
 	for (var/mob/living/carbon/cuffed_mob in mutual_handcuffed_mobs)
 		src.remove_mutual_cuff_events(cuffed_mob)
 	. = ..()
-	
+
 /obj/item/weapon/handcuffs/restraint_apply_intent_check(mob/user)
 	return 1
 
 /obj/item/weapon/handcuffs/cyborg
-//This space intentionally left blank
+	name = "3D-printed handcuffs"
+	desc = "A pair of 3D-printed handcuffs, they are designed to break apart once opened to prevent re-usage by criminals."
 
 /obj/item/weapon/handcuffs/cyborg/on_restraint_removal(var/mob/living/carbon/C)
+	visible_message("<span class='warning'>The [src] break apart!</span>")
 	spawn(1)
 		qdel(src)
+
+/obj/item/weapon/handcuffs/cyborg/beepsky
+	name = "Officer Beep O'sky!-brand handcuffs"
+	desc = "A pair of 3D-printed handcuffs, imprinted on them are the words 'You can't outrun a radio'. These are quite brittle, but are designed to break apart upon being opened."
+	restraint_resist_time = 45 SECONDS
+
+/obj/item/weapon/handcuffs/cyborg/ed209
+	name = "ED-209!-brand handcuffs"
+	desc = "A pair of 3D-printed handcuffs, imprinted on it is a stylized depiction of an ED-209. These are a bit tougher than the average 3D-printed object, but are designed to break apart upon being opened."
+	restraint_resist_time = 1 MINUTES
 
 //Syndicate Cuffs. Disguised as regular cuffs, they are pretty explosive
 /obj/item/weapon/handcuffs/syndicate


### PR DESCRIPTION
This idea came while doing stuff on a test server, yes I attempted to nerf beepsky cuffs in the past but in hindsight that was excessive. Here's something more reasonable:
- Beepsky cuffs can now be broken out of in 45 seconds, ED-209 cuffs in a minute.
- To compensate, they now break apart when opened. No reusable cuffs for criminals!

Broken cuff sprites appreciated, there's an ugly behavior that existed before the change where the cuffs appear for a brief moment before vanishing into the ether, so having the cuffs replaced with broken unusable variants instead of being deleted would be a boon. I will be extra thankful if you sprite wearable broken cuffs for hands.

:cl:
 * tweak: Beepsky and ED-209 bots have weaker cuffs, but to compensate the cuffs break apart when opened.