### PR TITLE
La Fragrance du Café Noir

### DIFF
--- a/__DEFINES/planes+layers.dm
+++ b/__DEFINES/planes+layers.dm
@@ -285,11 +285,12 @@ var/obj/abstract/screen/plane_master/clickmaster_dummy/clickmaster_dummy = new()
 // (only one planemaster for everybody, they gain or lose the unique planemaster depending on whether they want the effect or not)
 /obj/abstract/screen/plane_master/noir_master
 	plane = NOIR_BLOOD_PLANE
-	color = list(1,0,0,0,
-				 0,1,0,0,
-				 0,0,1,0,
-				 0,0,0,1)
-	appearance_flags = NO_CLIENT_COLOR|PLANE_MASTER
+	color = list("#0000",
+				 "#0000",
+				 "#0000",
+				 "#000F",
+				 "#A110")//turns everything in the plane to the color human blood. unfortunate side effect is the loss of detail on gibs
+	appearance_flags = NO_CLIENT_COLOR|PLANE_MASTER//NO_CLIENT_COLOR sadly doesn't prevent the blood itself from turning grey, which is why it has to be recolored with the above matrix
 
 /obj/abstract/screen/plane_master/noir_dummy
 	// this avoids a bug which means plane masters which have nothing to control get angry and mess with the other plane masters out of spite

--- a/code/datums/outfit/civilian.dm
+++ b/code/datums/outfit/civilian.dm
@@ -119,7 +119,6 @@
 	..()
 	H.put_in_hands(new /obj/item/weapon/storage/bag/plasticbag(H))
 	H.dna.SetSEState(SOBERBLOCK,1)
-	H.mutations += M_SOBER
 	H.check_mutations = 1
 
 /datum/outfit/bartender/pre_equip_priority(var/mob/living/carbon/human/H, var/species)

--- a/code/datums/outfit/security.dm
+++ b/code/datums/outfit/security.dm
@@ -267,9 +267,7 @@
 /datum/outfit/detective/post_equip(var/mob/living/carbon/human/H)
 	..()
 	H.dna.SetSEState(SOBERBLOCK,1)
-	H.mutations += M_SOBER
 	if (H.mind.role_alt_title == "Gumshoe" || H.mind.role_alt_title == "Private Eye")
-		H.mutations += M_NOIR
 		H.dna.SetSEState(NOIRBLOCK,1)
 	H.check_mutations = 1
 

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -156,7 +156,6 @@ Obviously, requires DNA2.
 	..()
 	M.update_colour(NOIR_ANIM_TIME)
 	if(M.client) // wow it's almost like non-client mobs can get mutations!
-		//M.client.screen += noir_master   Now added by update_colour()
 		M << sound('sound/misc/noirdarkcoffee.ogg')
 
 /datum/dna/gene/basic/noir/deactivate(var/mob/M,var/connected,var/flags)

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -156,7 +156,7 @@ Obviously, requires DNA2.
 	..()
 	M.update_colour(NOIR_ANIM_TIME)
 	if(M.client) // wow it's almost like non-client mobs can get mutations!
-		M.client.screen += noir_master
+		//M.client.screen += noir_master   Now added by update_colour()
 		M << sound('sound/misc/noirdarkcoffee.ogg')
 
 /datum/dna/gene/basic/noir/deactivate(var/mob/M,var/connected,var/flags)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -81,6 +81,8 @@ mob/proc/remove_internal_organ()
 		return
 	if(!colour_to_apply)
 		colour_to_apply = get_screen_colour()
+	if((M_NOIR in mutations) && client)
+		client.screen += noir_master
 	// We can't compare client.color directly because Byond will force set client.color to null
 	// when assigning the default_colour_matrix to it
 	var/list/colour_initial = (client.color ? client.color : default_colour_matrix)


### PR DESCRIPTION
_It's back_

![Noir](https://user-images.githubusercontent.com/7573912/116316575-7098a000-a7b2-11eb-902c-a43c9fbde2cb.png)

Fixes #21866
Fixes #22146
Fixes #26007

:cl:
* bugfix: After many years, the Noir mutation once again properly displays red blood normally.
* bugfix: Fixed the Noir plane master not coming back if the player disconnected-reconnected.
* bugfix: Fixed Gumshoe detectives spawning with double Sober and Noir mutations, making ryetalyn unable to deactivate either.
* bugfix: Fixed Bartenders spawning with double Sober mutations, making ryetalyn unable to deactivate it. THIS MEANS THAT BARTENDERS CAN FINALLY GET DRUNK.