### PR TITLE
Fireball no longer breaches floors, does more damage in proximity to compensate

### DIFF
--- a/code/modules/spells/targeted/projectile/fireball.dm
+++ b/code/modules/spells/targeted/projectile/fireball.dm
@@ -20,8 +20,8 @@
 	duration = 20
 	projectile_speed = 1
 
-	amt_dam_brute = 20
-	amt_dam_fire = 25
+	amt_dam_brute = 40
+	amt_dam_fire = 45
 
 	var/ex_severe = -1
 	var/ex_heavy = 0

--- a/code/modules/spells/targeted/projectile/fireball.dm
+++ b/code/modules/spells/targeted/projectile/fireball.dm
@@ -24,8 +24,8 @@
 	amt_dam_fire = 25
 
 	var/ex_severe = -1
-	var/ex_heavy = 1
-	var/ex_light = 2
+	var/ex_heavy = 0
+	var/ex_light = 3
 	var/ex_flash = 5
 
 	level_max = list(Sp_TOTAL = 5, Sp_SPEED = 4, Sp_POWER = 1)


### PR DESCRIPTION
[gameplay] [controversial]

:cl:
 * tweak: Fireball no longer creates heavy explosions, meaning it both deals less damage and will not breach floors.
 * tweak: Fireball now does double its previous damage to those in direct proximity to the explosion - enough for crit in one hit.

## Most recent change in video form: (edited in video from my last comment)
https://user-images.githubusercontent.com/2076607/116465434-17685500-a822-11eb-9904-9fe428e3995b.mp4

While I didn't demo this on armored targets, sec in vests and helmets took the same damage in testing.

##  Why?
Hull breach as a 2 second cooldown button doesn't make for a very fun antagonist, at least for anyone but the wizard. ZAS can be fun but blowing out the entire station's air so rapidly for so little investment isn't. Fireball remains an important damage dealing spell, however, and so I've buffed the damage here to compensate for the changes to the explosion itself.

Some other ideas which are different enough to warrant a separate PR rather than editing this one:
 - Make fireball able to be upgraded into a wall-breaching version at a higher cost, making it necessary to choose that upgrade over other spells
 - Higher default and/or minimum cooldown, possibly in combination with above

Prior work:
https://github.com/vgstation-coders/vgstation13/pull/27416 - failed, but useful for discussion possibly