### PR TITLE
Re-adds extended

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -369,77 +369,99 @@ var/stacking_limit = 90
 	else
 		message_admins("DYNAMIC MODE: [i] rulesets qualify for the current pop and threat level, including [drafted_rules.len] with eligible candidates.")
 		log_admin("DYNAMIC MODE: [i] rulesets qualify for the current pop and threat level, including [drafted_rules.len] with eligible candidates.")
-	if (drafted_rules.len > 0 && picking_roundstart_rule(drafted_rules))
-		if (extra_rulesets_amount > 0)//we've got enough population and threat for a second rulestart rule
-			for (var/datum/dynamic_ruleset/roundstart/rule in drafted_rules)
-				if (rule.cost > threat)
-					drafted_rules -= rule
-			message_admins("DYNAMIC MODE: The current pop and threat level allow for a second round start ruleset, there remains [candidates.len] eligible candidates and [drafted_rules.len] eligible rulesets")
-			log_admin("DYNAMIC MODE: The current pop and threat level allow for a second round start ruleset, there remains [candidates.len] eligible candidates and [drafted_rules.len] eligible rulesets")
-			if (drafted_rules.len > 0 && picking_roundstart_rule(drafted_rules))
-				if (extra_rulesets_amount > 1)//we've got enough population and threat for a third rulestart rule
-					for (var/datum/dynamic_ruleset/roundstart/rule in drafted_rules)
-						if (rule.cost > threat)
-							drafted_rules -= rule
-					message_admins("DYNAMIC MODE: The current pop and threat level allow for a third round start ruleset, there remains [candidates.len] eligible candidates and [drafted_rules.len] eligible rulesets")
-					log_admin("DYNAMIC MODE: The current pop and threat level allow for a third round start ruleset, there remains [candidates.len] eligible candidates and [drafted_rules.len] eligible rulesets")
-					if (!drafted_rules.len > 0 || !picking_roundstart_rule(drafted_rules))
-						message_admins("DYNAMIC MODE: The mode failed to pick a third ruleset.")
-						log_admin("DYNAMIC MODE: The mode failed to pick a third ruleset.")
+
+	var/list/datum/dynamic_ruleset/roundstart/candidate_rules = list()
+
+	for (var/j = 1 to (1 + extra_rulesets_amount))
+		// 1. Scrapping all the rules with cost above remaining threat level
+		for (var/datum/dynamic_ruleset/roundstart/rule in drafted_rules)
+			if (rule.cost > threat)
+				drafted_rules -= rule
+
+		// 2. No rules left? Abort.
+		if (drafted_rules.len <= 0)
+			break
+
+		// 3. Picking up the CHOSEN ONE.
+		var/datum/dynamic_ruleset/chosen_one = picking_roundstart_rule(drafted_rules, candidate_rules)
+
+		// 4. Adding to the LIST.
+		if (chosen_one)
+			message_admins("DYNAMIC MODE: Picking a [istype(chosen_one, /datum/dynamic_ruleset/roundstart/delayed/) ? " delayed " : ""] ruleset...<font size='3'>[chosen_one.name]</font>!")
+			log_admin("DYNAMIC MODE: Picking a [istype(chosen_one, /datum/dynamic_ruleset/roundstart/delayed/) ? " delayed " : ""] ruleset...<font size='3'>[chosen_one.name]</font>!")
+			candidate_rules += chosen_one
+			drafted_rules -= chosen_one
+			drafted_rules = trimming_remaining_rules(chosen_one, drafted_rules)
+
+	// Is THE LIST non-empty ?
+	if (candidate_rules.len > 0)
+		var/datum/dynamic_ruleset/roundstart/extended/stendo = (locate(/datum/dynamic_ruleset/roundstart/extended) in candidate_rules)
+		// eggstanded
+		if (stendo)
+			if (executing_roundstart_rule(stendo))
+				return 1
 			else
-				message_admins("DYNAMIC MODE: The mode failed to pick a second ruleset.")
-				log_admin("DYNAMIC MODE: The mode failed to pick a second ruleset.")
+				candidate_rules =- stendo
+
+		for (var/datum/dynamic_ruleset/roundstart/DR in candidate_rules)
+			executing_roundstart_rule(DR)
 	else
 		message_admins("DYNAMIC MODE: The mode failed to pick a first ruleset. The round will begin without any roles assigned.")
 		log_admin("DYNAMIC MODE: The mode failed to pick a first ruleset. The round will begin without any roles assigned.")
 		return 0
-	return 1
 
-/datum/gamemode/dynamic/proc/picking_roundstart_rule(var/list/drafted_rules = list())
-	var/datum/dynamic_ruleset/roundstart/starting_rule
-
-	while(!starting_rule && drafted_rules.len > 0)
+// -- PICKING a rule, which means checking if you can do it.
+// drafted_rules : the eligible rules for this round, after the threat cost of other rules has been taken into account and they have enough candidates
+// returns : the chosen dynamic ruleset.
+/datum/gamemode/dynamic/proc/picking_roundstart_rule(var/list/drafted_rules = list(), var/list/candidate_rules = list())
+	var/datum/dynamic_ruleset/my_rule = null
+	while(!my_rule && drafted_rules.len > 0)
 		message_admins("DYNAMIC MODE: Drafted rules: [json_encode(drafted_rules)]")
 		log_admin("DYNAMIC MODE: Drafted rules: [json_encode(drafted_rules)]")
-		starting_rule = pickweight(drafted_rules)
+		my_rule = pickweight(drafted_rules)
 		if (threat < stacking_limit && no_stacking)
-			for (var/datum/dynamic_ruleset/roundstart/DR in executed_rules)
-				if ((DR.flags & HIGHLANDER_RULESET) && (starting_rule.flags & HIGHLANDER_RULESET))
-					message_admins("DYNAMIC MODE: Ruleset [starting_rule.name] refused as we already have a round-ending ruleset.")
-					log_admin("DYNAMIC MODE: Ruleset [starting_rule.name] refused as we already have a round-ending ruleset.")
-					drafted_rules -= starting_rule
-					starting_rule = null
+			for (var/datum/dynamic_ruleset/roundstart/DR in candidate_rules + executed_rules)
+				if ((DR.flags & HIGHLANDER_RULESET) && (my_rule.flags & HIGHLANDER_RULESET))
+					message_admins("DYNAMIC MODE: Ruleset [my_rule.name] refused as we already have a round-ending ruleset.")
+					log_admin("DYNAMIC MODE: Ruleset [my_rule.name] refused as we already have a round-ending ruleset.")
+					drafted_rules -= my_rule
+					my_rule = null
+	return my_rule
 
-	if (starting_rule)
-		message_admins("DYNAMIC MODE: Picking a [istype(starting_rule, /datum/dynamic_ruleset/roundstart/delayed/) ? " delayed " : ""] ruleset...<font size='3'>[starting_rule.name]</font>!")
-		log_admin("DYNAMIC MODE: Picking a [istype(starting_rule, /datum/dynamic_ruleset/roundstart/delayed/) ? " delayed " : ""] ruleset...<font size='3'>[starting_rule.name]</font>!")
+// -- A rule has been picked. We have to clean its assigned candidates from other rules to avoid someone getting multiple antags. We also check if that new rule has enough remaining candidates.
+// choosen_one : the rule who has just been picked.
+// drafted_rules : the rules currently drafted.
+// returns : the new drafted rules.
+/datum/gamemode/dynamic/proc/trimming_remaining_rules(var/datum/dynamic_ruleset/choosen_one, var/list/drafted_rules)
+	for(var/mob/M in choosen_one.assigned)
+		candidates -= M
+		for (var/datum/dynamic_ruleset/roundstart/rule in roundstart_rules)
+			rule.candidates -= M//removing the assigned players from the candidates for the other rules
+			if (!rule.ready())
+				drafted_rules -= rule//and removing rules that are no longer eligible
+	return drafted_rules
 
-		roundstart_rules -= starting_rule
-		drafted_rules -= starting_rule
+// -- Executing a rule, which means spawning the traitor, removing the threat cost, etc.
+// the_rule: the rule being executed
+// returns: 0 or 1 depending on success. (failure meaning something runtimed mid-code.)
+/datum/gamemode/dynamic/proc/executing_roundstart_rule(var/datum/dynamic_ruleset/the_rule)
+	if (istype(the_rule, /datum/dynamic_ruleset/roundstart/delayed/))
+		message_admins("DYNAMIC MODE: Delayed ruleset, with a delay of [the_rule:delay/10] seconds.")
+		log_admin("DYNAMIC MODE: Delayed ruleset, with a delay of [the_rule:delay/10] seconds.")
+		spend_threat(the_rule.cost)
+		threat_log += "[worldtime2text()]: Roundstart [the_rule.name] spent [the_rule.cost]"
+		return pick_delay(the_rule)
 
-		if (istype(starting_rule, /datum/dynamic_ruleset/roundstart/delayed/))
-			message_admins("DYNAMIC MODE: Delayed ruleset, with a delay of [starting_rule:delay/10] seconds.")
-			log_admin("DYNAMIC MODE: Delayed ruleset, with a delay of [starting_rule:delay/10] seconds.")
-			spend_threat(starting_rule.cost)
-			return pick_delay(starting_rule)
-
-		spend_threat(starting_rule.cost)
-		threat_log += "[worldtime2text()]: Roundstart [starting_rule.name] spent [starting_rule.cost]"
-		if (starting_rule.execute())//this should never fail since ready() returned 1
-			executed_rules += starting_rule
-			if (starting_rule.persistent)
-				current_rules += starting_rule
-			for(var/mob/M in starting_rule.assigned)
-				candidates -= M
-				for (var/datum/dynamic_ruleset/roundstart/rule in roundstart_rules)
-					rule.candidates -= M//removing the assigned players from the candidates for the other rules
-					if (!rule.ready())
-						drafted_rules -= rule//and removing rules that are no longer eligible
-			return 1
-		else
-			message_admins("DYNAMIC MODE: ....except not because whomever coded that ruleset forgot some cases in ready() apparently! execute() returned 0.")
-			log_admin("DYNAMIC MODE: ....except not because whomever coded that ruleset forgot some cases in ready() apparently! execute() returned 0.")
-	return 0
+	spend_threat(the_rule.cost)
+	threat_log += "[worldtime2text()]: Roundstart [the_rule.name] spent [the_rule.cost]"
+	if (the_rule.execute())//this should never fail since ready() returned 1
+		executed_rules += the_rule
+		if (the_rule.persistent)
+			current_rules += the_rule
+	else
+		message_admins("DYNAMIC MODE: ....except not because whomever coded that ruleset forgot some cases in ready() apparently! execute() returned 0.")
+		log_admin("DYNAMIC MODE: ....except not because whomever coded that ruleset forgot some cases in ready() apparently! execute() returned 0.")
+		return 0
 
 /datum/gamemode/dynamic/proc/pick_delay(var/datum/dynamic_ruleset/roundstart/delayed/rule)
 	spawn()

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -276,10 +276,6 @@ var/stacking_limit = 90
 	var/forced_rules = 0
 
 	for (var/datum/forced_ruleset/forced_rule in forced_roundstart_ruleset)//By checking in this order we allow admins to set up priorities among the forced rulesets.
-		// Admins forcing extended.
-		if (istype(forced_rule, /datum/dynamic_ruleset/roundstart/extended))
-			return forced_rule.execute()
-
 		for (var/datum/dynamic_ruleset/roundstart/rule in roundstart_rules)
 			if (forced_rule.name == rule.name)
 				rule.candidates = candidates.Copy()

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -276,6 +276,10 @@ var/stacking_limit = 90
 	var/forced_rules = 0
 
 	for (var/datum/forced_ruleset/forced_rule in forced_roundstart_ruleset)//By checking in this order we allow admins to set up priorities among the forced rulesets.
+		// Admins forcing extended.
+		if (istype(forced_rule, /datum/dynamic_ruleset/roundstart/extended))
+			return forced_rule.execute()
+
 		for (var/datum/dynamic_ruleset/roundstart/rule in roundstart_rules)
 			if (forced_rule.name == rule.name)
 				rule.candidates = candidates.Copy()

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -546,6 +546,11 @@
 	requirements = list(0,0,0,0,0,0,0,0,0,0)
 	high_population_requirement = 101
 
+// 70% chance of allowing extended at 0-30 threat, then (100-threat)% chance.
+/datum/dynamic_ruleset/roundstart/extended/acceptable(population, threat_level)
+	var/probability = clamp(threat_level, 30, 100)
+	return !prob(probability)
+
 /datum/dynamic_ruleset/roundstart/extended/execute()
 	message_admins("Starting a round of extended.")
 	log_admin("Starting a round of extended.")
@@ -662,7 +667,7 @@
 	weight = 10
 	cost = 10
 	requirements = list(101,101,101,101,101,101,101,101,101,101) // So that's not possible to roll it naturally
-	high_population_requirement = 10
+	high_population_requirement = 101
 	flags = MINOR_RULESET
 
 /datum/dynamic_ruleset/roundstart/tag_mode/execute()

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -543,12 +543,13 @@
 	required_candidates = 0
 	weight = 10
 	cost = 0
-	requirements = list(101,101,101,101,101,101,101,101,101,101) // So that's not possible to roll it naturally
+	requirements = list(0,0,0,0,0,0,0,0,0,0)
 	high_population_requirement = 101
 
 /datum/dynamic_ruleset/roundstart/extended/execute()
 	message_admins("Starting a round of extended.")
 	log_admin("Starting a round of extended.")
+	mode.forced_extended = TRUE
 	return TRUE
 
 //////////////////////////////////////////////


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31417754/116460690-9d5abf00-a867-11eb-89b9-a97291fe91f3.png)

## Historical note

When Dynamic was first coded it was (literally) impossible for it to roll extended. It was also very hard for admins to force it.
Long ago, I coded a way for admins to easily force extended, but coding a way to naturally roll extended and not allow non-extended roundstart rulesets to roll was a little more difficult.

The "intended" way for dynamic to roll extended was to roll a low threat score. Unfortunately, with low costs for roundstart and especially midround traitors, this never happened. The last natural fully extended gamemode happened in June 2019.

Now, it is possible for extended to roll again naturally, overriding any other roundstart rulesets and forcing future rulesets to not spawn antagonists.
It also means that manually picking this ruleset will work as intended.

Admins can disable this state of things easily simply by using the `Check Antagonists` verb.

## Rolling extended : the maths

It was also complicated to get the correct weights and requirements for extended to roll. I chose to make it : 
- **independent of population**, in the sense that the raw chance of rolling extended is not affected by pop ;
- **dependant of threat level**, which means that between 0% and 30% threat level, extended has a 70% probability of being allowed, and between 30% and 100%, it has a `100 - threat_level`% probability.
- **with the same weight as other rulesets**, which means that if extended is allowed, it has the same raw chance of being picked by Dynamic as autotraitor, malf, Nuke Ops, etc.

But Dynamic being Dynamic, there are other indirect factors at play. Population affects the probability of rolling extended indirect in two ways :
- If there's more people, more rulesets are drafted, which means that extended has more chance of being picked.
- If there's more people, more rulesets are eligible for draft (example: malfAI is only eligible if there's an AI and a certain pop level), which means extended has other rulesets to compete with.

I have zero ways to accurately predict how this is going to play out at high pop. We will have to test fire it. I'm sorry.
In lowpop, I tested this by reading it up as an Assistant and letting Dynamic chose for me. In 8 out of 10 cases, it rolled traitor. In 2 out of 10 cases, it rolled extended.
I also discovered that reading up as security or captain in lowpop literally "eats" the antag rolls of other people : you can get picked for traitor, but the game realises you're a seccie, you fail the random check. If this happens to all the candidates of the traitor rule, the ruleset is dropped. God bless dynamic.

## Code note

It took some refactoring for this to work. Code-wise, instead of three successive ifs, dynamic mode now uses a `for` loop to pick and execute rulesets. It will first pick, then executes, the rulesets it chose. If it picked extended, it will execute it first.

For clarity, I have cut most of the rounstart procs into smaller, more self-contained and descriptive subprocs. Those are also documented.

:cl: 
- rscadd: Extended is back! It can roll depending on the threat level. If extended is rolled, no antags will spawn in the round until an admin decides so.
