### PR TITLE
Janitor overalls

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -20,7 +20,7 @@
 	item_state = "apron"
 	blood_overlay_type = "armor"
 	body_parts_covered = FULL_TORSO
-	allowed = list (/obj/item/weapon/reagent_containers/spray/plantbgone,/obj/item/device/analyzer/plant_analyzer,/obj/item/seeds,/obj/item/weapon/reagent_containers/glass,/obj/item/tool/wirecutters/clippers,/obj/item/weapon/minihoe)
+	allowed = list (/obj/item/weapon/reagent_containers/spray,/obj/item/device/analyzer/plant_analyzer,/obj/item/seeds,/obj/item/weapon/reagent_containers/glass,/obj/item/tool/wirecutters/clippers,/obj/item/weapon/minihoe,/obj/item/weapon/grenade/chem_grenade,/obj/item/device/lightreplacer,/obj/item/device/flashlight,/obj/item/weapon/soap,/obj/item/key/janicart,/obj/item/clothing/gloves,/obj/item/weapon/caution,/obj/item/weapon/mop,/obj/item/weapon/storage/bag/trash)
 	species_fit = list(VOX_SHAPED, INSECT_SHAPED)
 
 //Captain

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -325,6 +325,7 @@ var/list/tag_suits_list = list()
 	item_state = "overalls"
 	body_parts_covered = FULL_TORSO|LEGS
 	species_fit = list(INSECT_SHAPED)
+	allowed = list (/obj/item/weapon/reagent_containers/spray,/obj/item/device/analyzer/plant_analyzer,/obj/item/seeds,/obj/item/weapon/reagent_containers/glass,/obj/item/tool/wirecutters/clippers,/obj/item/weapon/minihoe,/obj/item/weapon/grenade/chem_grenade,/obj/item/device/lightreplacer,/obj/item/device/flashlight,/obj/item/weapon/soap,/obj/item/key/janicart,/obj/item/clothing/gloves,/obj/item/weapon/caution,/obj/item/weapon/mop,/obj/item/weapon/storage/bag/trash)
 
 
 /obj/item/clothing/suit/syndicatefake

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -325,7 +325,6 @@ var/list/tag_suits_list = list()
 	item_state = "overalls"
 	body_parts_covered = FULL_TORSO|LEGS
 	species_fit = list(INSECT_SHAPED)
-	allowed = list (/obj/item/weapon/reagent_containers/spray,/obj/item/device/analyzer/plant_analyzer,/obj/item/seeds,/obj/item/weapon/reagent_containers/glass,/obj/item/tool/wirecutters/clippers,/obj/item/weapon/minihoe,/obj/item/weapon/grenade/chem_grenade,/obj/item/device/lightreplacer,/obj/item/device/flashlight,/obj/item/weapon/soap,/obj/item/key/janicart,/obj/item/clothing/gloves,/obj/item/weapon/caution,/obj/item/weapon/mop,/obj/item/weapon/storage/bag/trash)
 
 
 /obj/item/clothing/suit/syndicatefake


### PR DESCRIPTION
Inspired by the fact that a set of overalls are included in lowfatbagel's janny office and the fact that the janitor doesn't really have any useful options in the suit slot right now, tweaks botany aprons and overalls to also accept the same items as the janibelt in their suit storage slot, notably the garbage bag which doesn't fit in the janibelt due to being too large.
:cl:
 * tweak: Overalls and aprons now accept the same items as the janibelt in their suit storage slot in addition to botany items