### PR TITLE
Synergy EVA Marker

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -1874,6 +1874,7 @@ proc/process_adminbus_teleport_locs()
 	name = "EVA Storage"
 	icon_state = "eva"
 	holomap_color = HOLOMAP_AREACOLOR_COMMAND
+	holomap_marker = "eva"
 	jammed=1
 
 /area/storage/secure


### PR DESCRIPTION
Because it uses /area/storage/eva instead of /area/ai_monitored/storage/eva

:cl:
* bugfix: Fixed the EVA holomap marker missing from Synergy station.