### PR TITLE
Fix shade cult HUD on re-login

### DIFF
--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -48,6 +48,9 @@
 /mob/living/simple_animal/shade/Login()
 	..()
 	hud_used.shade_hud()
+	var/datum/role/cultist/C = iscultist(src)
+	if (C)
+		C.update_cult_hud()
 	if (istype(loc, /obj/item/weapon/melee/soulblade))
 		client.CAN_MOVE_DIAGONALLY = 1
 		client.screen += list(


### PR DESCRIPTION
:cl:
* bugfix: Fixed shades missing their Cult HUD when re-login into the game.