### PR TITLE
Hostile Mobs and Blockage

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -135,7 +135,6 @@ var/global/list/alert_overlays_global = list()
 				A.all_doors |= src
 				areas_added |= A
 
-
 /obj/machinery/door/firedoor/initialize()
 	if (twin) // Already paired with something
 		return
@@ -361,6 +360,18 @@ var/global/list/alert_overlays_global = list()
 		return
 
 	do_interaction(user, C)
+
+/obj/machinery/door/firedoor/attack_animal(var/mob/living/simple_animal/M as mob)
+	M.delayNextAttack(8)
+	if(M.melee_damage_upper == 0)
+		return
+	M.do_attack_animation(src, M)
+	M.visible_message("<span class='warning'>[M] smashes against \the [src].</span>", \
+					  "<span class='warning'>You smash against \the [src].</span>", \
+					  "You hear twisting metal.")
+	if(prob(33))
+		new /obj/item/firedoor_frame(get_turf(src))
+		qdel(src)
 
 /obj/machinery/door/firedoor/proc/do_interaction(var/mob/user, var/obj/item/weapon/C, var/no_reruns = FALSE)
 	if(operating)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -29,6 +29,8 @@
 	var/attack_faction = null //Put a faction string here to have a mob only ever attack a specific faction
 	var/friendly_fire = 0 //If set to 1, they won't hesitate to shoot their target even if a friendly is in the way.
 	var/armor_modifier = 1 //The higher this is, the more effect armor has on melee attacks
+	var/hostile_interest = 2 //How long will we wait in the same spot trying to chase something before giving up?
+	var/atom/lastloc //Where we were last time we were moving toward a target.
 
 	var/list/target_rules = list()
 
@@ -236,6 +238,16 @@
 		LoseTarget()
 		return
 
+	if(loc == lastloc)
+		hostile_interest--
+		if(hostile_interest <= 0)
+			LoseTarget()
+			return
+	else
+		hostile_interest = initial(hostile_interest)
+
+	lastloc = loc
+
 	if(isturf(loc))
 		if(target in ListTargets())
 			var/target_distance = get_dist(src,target)
@@ -438,7 +450,8 @@
 					 /obj/machinery/door/window,
 					 /obj/item/tape,
 					 /obj/item/toy/balloon/inflated/decoy,
-					 /obj/machinery/door/airlock)
+					 /obj/machinery/door/airlock,
+					 /obj/machinery/door/firedoor)
 				if(is_type_in_list(A, destructible_objects) && Adjacent(A))
 					if(istype(A, /obj/machinery/door/airlock))
 						var/obj/machinery/door/airlock/AIR = A

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -279,6 +279,7 @@ obj/item/asteroid/basilisk_hide/New()
 	retreat_distance = 3
 	minimum_distance = 3
 	pass_flags = PASSTABLE
+	hostile_interest = 15 //Very persistent
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/OpenFire(var/the_target)
 	var/mob/living/simple_animal/hostile/asteroid/hivelordbrood/A = new /mob/living/simple_animal/hostile/asteroid/hivelordbrood(src.loc)


### PR DESCRIPTION
Adds some very basic improvements to our hostile mobs' ability to deal with common blockers.

They will now attempt to smash down firedoors blocking them (1/3 chance, might be better to scale chance based on damage?)
If a mob is chasing something and stays in the same location for 2 full life ticks (4 seconds) then it will give up on the chase. This will help with situations like where a spider is fixated on a lightbulb it can't reach behind some plastic flaps and so it ignores the spaceman fireaxing it. The amount of time a mob will chase is easily modifiable per type if you wanted to make something that is very patient (or bullheaded).

In a perfect world, we'd see a PR that can do pathfinding through destructible objects (grilles, windows, etc.) so that spiders blocked by girders might pick a new route through windows. In an even better world we'd have retreat logic when a melee enemy, lacking a path to the target, is fired upon by ranged weapons like lasers. But this seems like a decent start and it was easy.

Not yet tested.

🆑 
* rscadd: Hostile mobs are now able to break open firedoors and will fixate less on things they cannot reach.