### PR TITLE
Reworks cryopod naming

### DIFF
--- a/code/game/objects/structures/ancient_cryopod.dm
+++ b/code/game/objects/structures/ancient_cryopod.dm
@@ -92,8 +92,7 @@
 	M.eye_blurry = 15
 
 	var/podname = copytext(sanitize(input(M, "Pick your name","Name") as null|text), 1, 2*MAX_NAME_LEN)
-	M.real_name = podname
-	M.name = podname
+	M.fully_replace_character_name(null,podname)
 
 	message_admins("[key_name_admin(M)] has spawned as a [title] from an ancient cryopod.")
 	log_game("[key_name(M)] has spawned as a [title] from an ancient cryopod.")

--- a/code/game/objects/structures/ancient_cryopod.dm
+++ b/code/game/objects/structures/ancient_cryopod.dm
@@ -95,7 +95,8 @@
 		M.generate_name()
 	else
 		M.fully_replace_character_name(null,pick(preset_names))
-		mob_rename_self(M,title,"Pick your name")
+	
+	mob_rename_self(M,title,"Pick your name")
 
 	message_admins("[key_name_admin(M)] has spawned as a [title] from an ancient cryopod.")
 	log_game("[key_name(M)] has spawned as a [title] from an ancient cryopod.")
@@ -121,7 +122,6 @@
 		"Quick-Draw Billy"
 	)
 
-
 /datum/cryorole/pirate
 	title = "pirate"
 	outfit_datum = /datum/outfit/special/piratealt
@@ -138,7 +138,8 @@
 	preset_names = list(
 		"Udon Ramenatsu",
 		"Onigiri Wasabishi",
-		"Honda Subaru"
+		"Honda Subaru",
+		"Musashi"
 	)
 
 /datum/cryorole/prisoner
@@ -169,7 +170,10 @@
 	title = "cosmonaut"
 	outfit_datum = /datum/outfit/special/cosmonaut
 	preset_names = list(
-		"placeholder"
+		"Pilot Gagarin",
+		"Commander Laika",
+		"Officer Chernushka",
+		"Pilot Leonov"
 	)
 
 /datum/cryorole/gangster
@@ -179,7 +183,8 @@
 		"Tony Ravioli",
 		"Fabrizio Marinara",
 		"Giovanni Tortellini",
-		"Johnny Shanks"
+		"Johnny Shanks",
+		"Jackie Pott"
 	)
 
 /datum/cryorole/pizzaman

--- a/code/game/objects/structures/ancient_cryopod.dm
+++ b/code/game/objects/structures/ancient_cryopod.dm
@@ -158,7 +158,8 @@
 	preset_names = list(
 		"Naughtius Maximus",
 		"Biggus Dickus",
-		"Marcus Cocceius Firmus"
+		"Marcus Cocceius Firmus",
+		"Incontinentia Buttocks"
 	)
 
 /datum/cryorole/tourist

--- a/code/game/objects/structures/ancient_cryopod.dm
+++ b/code/game/objects/structures/ancient_cryopod.dm
@@ -91,8 +91,11 @@
 	M.confused = 5
 	M.eye_blurry = 15
 
-	var/podname = copytext(sanitize(input(M, "Pick your name","Name") as null|text), 1, 2*MAX_NAME_LEN)
-	M.fully_replace_character_name(null,podname)
+	if(getrandomname)
+		M.generate_name()
+	else
+		M.fully_replace_character_name(null,pick(preset_names))
+		mob_rename_self(M,title,"Pick your name")
 
 	message_admins("[key_name_admin(M)] has spawned as a [title] from an ancient cryopod.")
 	log_game("[key_name(M)] has spawned as a [title] from an ancient cryopod.")
@@ -102,6 +105,8 @@
 /datum/cryorole
 	var/title
 	var/outfit_datum
+	var/preset_names
+	var/getrandomname = FALSE
 
 /datum/cryorole/proc/special_behavior(var/mob/living/carbon/human/M) //for special behavior like giving roles genetic mutations
 	return
@@ -109,42 +114,83 @@
 /datum/cryorole/cowboy
 	title = "cowboy"
 	outfit_datum = /datum/outfit/special/cowboy
+	preset_names = list(
+		"Deadwood Cassidy",
+		"Rick O'Shea",
+		"Loan Ranger",
+		"Quick-Draw Billy"
+	)
+
 
 /datum/cryorole/pirate
 	title = "pirate"
 	outfit_datum = /datum/outfit/special/piratealt
+	preset_names = list(
+		"Scurvy Sam",
+		"One-Eyed Johnny",
+		"Barnacle Doubloons",
+		"Gary the Pirate"
+	)
 
 /datum/cryorole/samurai
 	title = "samurai"
 	outfit_datum = /datum/outfit/special/samurai
+	preset_names = list(
+		"Udon Ramenatsu",
+		"Onigiri Wasabishi",
+		"Honda Subaru"
+	)
 
 /datum/cryorole/prisoner
 	title = "prisoner"
 	outfit_datum = /datum/outfit/special/prisoneralt
+	preset_names = list(
+		"Tiny",
+		"King Cocaine",
+		"Slim Pickle",
+		"Stranglin' Steve"
+	)
 
 /datum/cryorole/roman
 	title = "roman legionare"
 	outfit_datum = /datum/outfit/special/roman
+	preset_names = list(
+		"Naughtius Maximus",
+		"Biggus Dickus",
+		"Marcus Cocceius Firmus"
+	)
 
 /datum/cryorole/tourist
 	title = "tourist"
 	outfit_datum = /datum/outfit/special/tourist
+	getrandomname = TRUE
 
 /datum/cryorole/cosmonaut
 	title = "cosmonaut"
 	outfit_datum = /datum/outfit/special/cosmonaut
+	preset_names = list(
+		"placeholder"
+	)
 
 /datum/cryorole/gangster
 	title = "gangster"
 	outfit_datum = /datum/outfit/special/gangster
+	preset_names = list(
+		"Tony Ravioli",
+		"Fabrizio Marinara",
+		"Giovanni Tortellini",
+		"Johnny Shanks"
+	)
 
 /datum/cryorole/pizzaman
 	title = "pizza delivery guy"
 	outfit_datum = /datum/outfit/special/pizzaman
+	getrandomname = TRUE
 
 /datum/cryorole/sportsfan
 	title = "sports fan"
 	outfit_datum = /datum/outfit/special/sports
+	getrandomname = TRUE
 
 /datum/cryorole/sportsfan/special_behavior(var/mob/living/carbon/human/M)
 	if(prob(50))


### PR DESCRIPTION
[bugfix] Reworks ancient cryopods to give the newly spawned occupant a preset name and a screen alarm to change it (like clowns/mimes/ninjas/wizards) rather than a prompt as soon as they spawn. Fixes cryopod occupants showing up as 'unknown' in deadchat or being able to have blank names.

Open to suggestions for more preset names!

:cl:
 * tweak: Ancient cryopod survivors now spawn with a random preset name, as well as a screen alarm to choose their name rather than an immediate prompt. Fixes cryopod survivors showing up as 'unknown' in deadchat.