### PR TITLE
Assistant job limit includes heads of staff

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -162,7 +162,7 @@
 	var/python_path = "" //Path to the python executable.  Defaults to "python" on windows and "/usr/bin/env python2" on unix
 
 	var/assistantlimit = 0 //enables assistant limiting
-	var/assistantratio = 2 //how many assistants to security members
+	var/assistantratio = 2 //how many assistants to security+command members
 
 	var/emag_energy = -1
 	var/emag_starts_charged = 1

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -26,12 +26,9 @@
 	if(!config.assistantlimit)
 		return 99
 
-	var/datum/job/officer = job_master.GetJob("Security Officer")
-	var/datum/job/warden = job_master.GetJob("Warden")
-	var/datum/job/hos = job_master.GetJob("Head of Security")
-	var/sec_jobs = (officer.current_positions + warden.current_positions + hos.current_positions)
+	var/count = job_master.getCommandPlusSecCount()
 
-	if(sec_jobs > 5)
+	if(count > 5)
 		return 99
 
-	return clamp(sec_jobs * config.assistantratio + xtra_positions, total_positions, 99)
+	return clamp(count * config.assistantratio + xtra_positions, total_positions, 99)

--- a/config-example/config.txt
+++ b/config-example/config.txt
@@ -222,7 +222,7 @@ GATEWAY_DELAY 18000
 ## Remove the # to enable assistant limiting.
 #ASSISTANT_LIMIT
 
-## If you enabled assistant limiting set the ratio of assistants to security members default is 2 assistants to 1 officer
+## If you enabled assistant limiting set the ratio of assistants to security members and command positions. Default is 2 assistants to 1 officer/command
 ASSISTANT_RATIO 2
 
 ## Remove the # to make rounds which end instantly (Rev, Wizard, Malf) to continue until the shuttle is called or the station is nuked.


### PR DESCRIPTION
Apparently a bunch of people thought this was already how it worked.
### Why?
Feels like 90% of the time, when people complain that people are playing assistant, it's because the regular departments are understaffed, not because of some epic greytide scenario where there isn't enough sec to contain them.
The current assistant cap factors in only security roles. Including heads of staff should make the cap closer to the actual issue. If the cap is too high after this change, Pomf can change the config to a lower multiplier.

I would also be willing to try redoing the cap so that it changes based on how many departments are understaffed, but I'm not sure if the job controller is advanced enough for that.

:cl:
 * tweak: The Assistant job limit now also takes into account heads of staff.