### PR TITLE
Nuke Op spawn with a Ryetalyn pill if they have some active genes

### DIFF
--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -88,6 +88,12 @@
 		N.antag.current.flavor_text = null
 
 		spawn()
+			if (synd_mind.current.active_genes.len > 0)
+				to_chat(synd_mind.current, "The Syndicate has provided you with a ryetalyn pill to cure your genetic defects. Use it at your own discretion.")
+				var/obj/item/weapon/reagent_containers/pill/ryetalyn/pill = new (synd_mind.current)
+				if (!synd_mind.current.equip_to_slot_or_drop(pill, slot_l_store))
+					synd_mind.current.put_in_hands(pill)
+
 			concrete_outfit.chosen_spec = equip_nuke_loadout(synd_mind.current)
 			concrete_outfit.equip_special_items(synd_mind.current)
 

--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -88,12 +88,6 @@
 		N.antag.current.flavor_text = null
 
 		spawn()
-			if (synd_mind.current.active_genes.len > 0)
-				to_chat(synd_mind.current, "The Syndicate has provided you with a ryetalyn pill to cure your genetic defects. Use it at your own discretion.")
-				var/obj/item/weapon/reagent_containers/pill/ryetalyn/pill = new (synd_mind.current)
-				if (!synd_mind.current.equip_to_slot_or_drop(pill, slot_l_store))
-					synd_mind.current.put_in_hands(pill)
-
 			concrete_outfit.chosen_spec = equip_nuke_loadout(synd_mind.current)
 			concrete_outfit.equip_special_items(synd_mind.current)
 

--- a/code/datums/outfit/striketeams/nukeop.dm
+++ b/code/datums/outfit/striketeams/nukeop.dm
@@ -166,6 +166,11 @@
 	R.set_frequency(SYND_FREQ)
 	if(H.mind.GetRole(NUKE_OP_LEADER))
 		H.equip_to_slot_or_del(new /obj/item/device/modkit/syndi_commander(H), slot_in_backpack)
+	if (H.active_genes.len > 0)
+		to_chat(H, "The Syndicate has provided you with a ryetalyn pill to cure your genetic defects. Use it at your own discretion.")
+		var/obj/item/weapon/reagent_containers/pill/ryetalyn/pill = new (H)
+		if (!H.equip_to_slot_or_drop(pill, slot_l_store))
+			H.put_in_hands(pill)
 
 /datum/outfit/striketeam/nukeops/pre_equip(var/mob/living/carbon/human/H)
 	if(H.overeatduration) //We need to do this here and now, otherwise a lot of gear will fail to spawn

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -270,6 +270,14 @@
 	..()
 	reagents.add_reagent(CREATINE, 5)
 
+/obj/item/weapon/reagent_containers/pill/ryetalyn
+	name = "Ryetalyn pill"
+	desc = "Eliminates genetic defects."
+	icon_state = "pill7" //grey oblong
+
+/obj/item/weapon/reagent_containers/pill/ryetalyn/New()
+	..()
+	reagents.add_reagent(RYETALYN, 1)
 
 /obj/item/weapon/storage/pill_bottle/time_release
 	name = "controlled release pill bottle"


### PR DESCRIPTION
:cl:
* rscadd: If a Nuclear Operative spawns with some active gene, such as near-sightedness or fatness because of character setup, they will now receive a ryetalyn pill in their pocket to offer them the ability to get rid of those defects by themselves.