### PR TITLE
Suicide is stored in the mind

### DIFF
--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -17,7 +17,7 @@
 				msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (<font color='#ffcc00'><b>Connected, Inactive</b></font>)\n"
 				continue //AFK client
 			if(L.stat)
-				if(L.suiciding)	//Suicider
+				if(L.mind && L.mind.suiciding)	//Suicider
 					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (<span class='red'><b>Suicide</b></span>)\n"
 					continue //Disconnected client
 				if(L.stat == UNCONSCIOUS)
@@ -31,7 +31,7 @@
 		for(var/mob/dead/observer/D in mob_list)
 			if(D.mind && D.mind.current == L)
 				if(L.stat == DEAD)
-					if(L.suiciding)	//Suicider
+					if(L.mind.suiciding)	//Suicider
 						msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] (<span class='red'><b>Suicide</b></span>)\n"
 						continue //Disconnected client
 					else

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -69,6 +69,7 @@
 	var/hasbeensacrificed = FALSE
 
 	var/miming = null //Toggle for the mime's abilities.
+	var/suiciding = FALSE //Do not allow revives for this person if they have sudoku'd
 
 /datum/mind/New(var/key)
 	src.key = key

--- a/code/datums/statistics/stat_helpers.dm
+++ b/code/datums/statistics/stat_helpers.dm
@@ -49,7 +49,6 @@
 
 	d.mob_typepath = M.type
 	d.mind_name = M.name
-	d.from_suicide = M.suiciding
 
 	d.damage["BRUTE"] = M.bruteloss
 	d.damage["FIRE"]  = M.fireloss
@@ -67,6 +66,7 @@
 			d.key = ckey(M.mind.key) // To prevent newlines in keys
 		if(M.mind.name)
 			d.mind_name = M.mind.name
+		d.from_suicide = M.mind.suiciding
 	deaths.Add(d)
 
 /datum/stat_collector/proc/add_survivor_stat(var/mob/living/M)

--- a/code/game/dna/genes/monkey.dm
+++ b/code/game/dna/genes/monkey.dm
@@ -66,10 +66,6 @@
 			O.dna = M.dna
 			M.dna = null
 
-		if (M.suiciding)
-			O.suiciding = M.suiciding
-			M.suiciding = null
-
 	for(var/datum/disease/D in M.viruses)
 		O.viruses += D
 		D.affected_mob = O

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -507,7 +507,7 @@ var/list/firstaid_exceptions = list(
 	if(C.isDead())
 		return 0 //welp too late for them!
 
-	if(C.suiciding)
+	if(C.mind && C.mind.suiciding)
 		return 0 //Kevorkian school of robotic medical assistants.
 
 	if(emagged == 2) //Everyone needs our medicine. (Our medicine is toxins)

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -103,7 +103,8 @@
 				else
 					flush = 1
 					for(var/mob/living/silicon/ai/A in src)
-						A.suiciding = 1
+						if(A.mind)
+							A.mind.suiciding = 1 //Is this actually intended?
 						to_chat(A, "Your core files are being wiped!")
 						A.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been wiped with an [src.name] by [U.name] ([U.ckey])</font>")
 						U.attack_log += text("\[[time_stamp()]\] <font color='red'>Used an [src.name] to wipe [A.name] ([A.ckey])</font>")

--- a/code/game/objects/items/potions.dm
+++ b/code/game/objects/items/potions.dm
@@ -104,7 +104,8 @@
 
 /obj/item/potion/healing/imbibe_effect(mob/living/user)
 	user.rejuvenate(1)
-	user.suiciding = 0
+	if(user.mind)
+		user.mind.suiciding = 0
 
 /obj/item/potion/mana
 	name = "potion of mana"

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -149,8 +149,8 @@
 		if(!target.has_brain())
 			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. No central nervous system detected.</span>")
 			return
-		if(target.suiciding)
-			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. Severe nerve trauma detected.</span>") // They suicided so they fried their brain. Space Magic.
+		if(target.mind && target.mind.suiciding)
+			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. Unrecoverable nerve trauma detected.</span>") // They suicided so they fried their brain. Space Magic.
 			return
 		if(istype(target.wear_suit,/obj/item/clothing/suit/armor) && (target.wear_suit.body_parts_covered & UPPER_TORSO) && prob(95)) //75 ? Let's stay realistic here
 			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. Please apply on bare skin.</span>")

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -40,7 +40,7 @@
 		icon_state = "morgue3" // no mobs at all, but objects inside
 		return
 	for(var/mob/living/body in inside)
-		if(body && body.client && !body.suiciding)
+		if(body && body.client && !(body.mind && body.mind.suiciding))
 			icon_state = "morgue4" // clone that mofo
 			return
 	icon_state = "morgue2" // dead no-client mob

--- a/code/game/objects/structures/vehicles/adminbus_powers.dm
+++ b/code/game/objects/structures/vehicles/adminbus_powers.dm
@@ -201,7 +201,8 @@
 
 	for(var/mob/living/M in orange(src,3))
 		M.revive(1)
-		M.suiciding = 0
+		if(M.mind)
+			M.mind.suiciding = 0
 		to_chat(M, "<span class='notice'>THE ADMINBUS IS LOVE. THE ADMINBUS IS LIFE.</span>")
 		sleep(2)
 	update_rearview()

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -1,5 +1,3 @@
-/mob/living/var/suiciding = 0
-
 /mob/living/verb/suicide()
 	set hidden = 1
 
@@ -68,8 +66,8 @@
 
 		log_attack("<font color='red'>[key_name(src)] has committed suicide via the suicide verb.</font>")
 
-	if(suicide_set)
-		suiciding = 1
+	if(suicide_set && mind)
+		mind.suiciding = 1
 
 	var/obj/item/held_item = get_active_hand()
 
@@ -100,8 +98,8 @@
 
 		log_attack("<font color='red'>[key_name(src)] has committed suicide via the suicide verb.</font>")
 
-	if(suicide_set)
-		suiciding = 1
+	if(suicide_set && mind)
+		mind.suiciding = 1
 
 	if(!container)
 		visible_message("<span class='danger'>[src]'s brain is growing dull and lifeless. It looks like \he's trying to commit suicide.</span>")
@@ -132,8 +130,8 @@
 
 		log_attack("<font color='red'>[key_name(src)] has committed suicide via the suicide verb.</font>")
 
-	if(suicide_set)
-		suiciding = 1
+	if(suicide_set && mind)
+		mind.suiciding = 1
 
 	var/obj/item/held_item = get_active_hand()
 	attempt_item_suicide(held_item)
@@ -161,8 +159,8 @@
 
 		log_attack("<font color='red'>[key_name(src)] has committed suicide via the suicide verb.</font>")
 
-	if(suicide_set)
-		suiciding = 1
+	if(suicide_set && mind)
+		mind.suiciding = 1
 
 	adjustBruteLoss(-(maxHealth - health) + 2*maxHealth) // kill it dead; set our health to -100 instantly
 	updatehealth()
@@ -207,8 +205,8 @@
 
 		log_attack("<font color='red'>[key_name(src)] has committed suicide via the suicide verb.</font>")
 
-	if(suicide_set)
-		suiciding = 1
+	if(suicide_set && mind)
+		mind.suiciding = 1
 
 	visible_message(pick("<span class='danger'>[src] suddenly starts thrashing around wildly! It looks like \he's trying to commit suicide.</span>", \
 						 "<span class='danger'>[src] suddenly starts mauling \himself! It looks like \he's trying to commit suicide.</span>"))
@@ -229,8 +227,8 @@
 
 		log_attack("<font color='red'>[key_name(src)] has committed suicide via the suicide verb.</font>")
 
-	if(suicide_set)
-		suiciding = 1
+	if(suicide_set && mind)
+		mind.suiciding = 1
 
 	visible_message("<span class='danger'>[src] starts vibrating uncontrollably! It looks like \he's trying to commit suicide.</span>")
 	setOxyLoss(100)
@@ -254,8 +252,8 @@
 
 		log_attack("<font color='red'>[key_name(src)] has committed suicide via the suicide verb.</font>")
 
-	if(suicide_set)
-		suiciding = 1
+	if(suicide_set && mind)
+		mind.suiciding = 1
 
 	visible_message(pick("<span class='danger'>[src] suddenly starts thrashing around wildly! It looks like \he's trying to commit suicide.</span>", \
 						 "<span class='danger'>[src] suddenly starts mauling \himself! It looks like \he's trying to commit suicide.</span>"))

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -635,7 +635,8 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		if(!M)
 			return
 		M.revive(0)
-		M.suiciding = 0
+		if(M.mind)
+			M.mind.suiciding = 0
 
 		log_admin("[key_name(usr)] healed / revived [key_name(M)]")
 		message_admins("<span class='warning'>Admin [key_name_admin(usr)] healed / revived [key_name_admin(M)]!</span>", 1)

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -285,7 +285,8 @@
 	H.real_name = H.dna.real_name
 	H.flavor_text = H.dna.flavor_text
 
-	H.suiciding = FALSE
+	if(H.mind)
+		H.mind.suiciding = FALSE
 	H.update_name()
 	return TRUE
 
@@ -299,7 +300,7 @@
 		return
 
 	if((occupant) && (occupant.loc == src))
-		if((occupant.stat == DEAD) || (occupant.suiciding) || !occupant.key)  //Autoeject corpses and suiciding dudes.
+		if((occupant.stat == DEAD) || (occupant.mind && occupant.mind.suiciding) || !occupant.key)  //Autoeject corpses and suiciding dudes.
 			locked = FALSE
 			go_out()
 			connected_message("Clone Rejected: Deceased.")

--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -420,7 +420,7 @@
 		scantemp = "Error: Mental interface failure."
 		return
 
-	if(subject.suiciding) //We cannot clone this guy because he suicided. Believe it or not, some people who suicide don't know about this. Let's tell them what's wrong.
+	if(subject.mind && subject.mind.suiciding) //We cannot clone this guy because he suicided. Believe it or not, some people who suicide don't know about this. Let's tell them what's wrong.
 		scantemp = "Error: Mental interface failure."
 		if(subject.client)
 			to_chat(subject, "<span class='warning'>Someone is trying to clone your corpse, but you may not be revived as you committed suicide.</span>")

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -129,7 +129,7 @@
 	tod = worldtime2text() //Weasellos time of death patch
 	if(mind)
 		mind.store_memory("Time of death: [tod]", 0)
-		if(!suiciding) //Cowards don't count
+		if(!(mind && mind.suiciding)) //Cowards don't count
 			score["deadcrew"]++ //Someone died at this point, and that's terrible
 	if(ticker && ticker.mode)
 		sql_report_death(src)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -248,7 +248,8 @@
 		var/confirm = alert("Are you sure you want to [key]? This action cannot be undone and you will not able to be revived.", "Confirm Suicide", "Yes", "No")
 		if(confirm != "Yes")
 			return
-		H.suiciding = 1
+		if(H.mind)
+			H.mind.suiciding = 1
 		H.visible_message("<span class='danger'>[H] holds one arm up and slams \his other arm into \his face! It looks like \he's trying to commit suicide.</span>",)
 		for(var/datum/organ/external/breakthis in H.get_organs(LIMB_LEFT_ARM, LIMB_RIGHT_ARM, LIMB_HEAD))
 			H.apply_damage(50, BRUTE, breakthis)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -15,7 +15,7 @@
 
 	if(wear_mask)
 		skipface |= check_hidden_head_flags(HIDEFACE)
-	
+
 	if(wear_mask?.is_hidden_identity() || head?.is_hidden_identity())
 		is_gender_visible = 0
 
@@ -181,7 +181,7 @@
 		if(o && o.status & ORGAN_SPLINTED)
 			msg += "<span class='warning'>[t_He] [t_has] a splint on [t_his] [o.display_name]!</span>\n"
 
-	if(suiciding)
+	if(mind && mind.suiciding)
 		msg += "<span class='warning'>[t_He] appear[t_s] to have committed suicide... there is no hope of recovery.</span>\n"
 
 	if(M_DWARF in mutations)

--- a/code/modules/mob/living/carbon/human/life/handle_breath.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_breath.dm
@@ -132,10 +132,10 @@
 	if((status_flags & GODMODE) || (flags & INVULNERABLE))
 		return 0
 	var/datum/organ/internal/lungs/L = internal_organs_by_name["lungs"]
-	if(!breath || (breath.total_moles() == 0) || suiciding || !L)
+	if(!breath || (breath.total_moles() == 0) || (mind && mind.suiciding) || !L)
 		if(reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 			return 0
-		if(suiciding)
+		if(mind && mind.suiciding)
 			adjustOxyLoss(2) //If you are suiciding, you should die a little bit faster
 			failed_last_breath = 1
 			oxygen_alert = 1

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1635,8 +1635,7 @@ Thanks.
 		"fire_stacks",
 		"specialsauce",
 		"silent",
-		"is_ventcrawling",
-		"suiciding")
+		"is_ventcrawling")
 
 	reset_vars_after_duration(resettable_vars, duration)
 

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -65,7 +65,7 @@
 	tod = worldtime2text() //weasellos time of death patch
 	if(mind)
 		mind.store_memory("Time of death: [tod]", 0)
-		if(!suiciding) //Cowards don't count
+		if(!mind.suiciding) //Cowards don't count
 			score["deadaipenalty"] += 1
 
 	return ..(gibbed)

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -12,7 +12,7 @@
 	robogibs(loc, virus2)
 
 	if(mind) //To make sure we're gibbing a player, who knows
-		if(!suiciding) //I don't know how that could happen, but you can't be too sure
+		if(!mind.suiciding) //I don't know how that could happen, but you can't be too sure
 			score["deadsilicon"] += 1
 
 	living_mob_list -= src
@@ -73,7 +73,7 @@
 	tod = worldtime2text() //weasellos time of death patch
 	if(mind)
 		mind.store_memory("Time of death: [tod]", 0)
-		if(!suiciding)
+		if(!mind.suiciding)
 			score["deadsilicon"] += 1
 
 	sql_report_cyborg_death(src)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -518,7 +518,7 @@
 
 /mob/living/simple_animal/mouse/mouse_op/death(var/gibbed = FALSE)
 	..(TRUE)
-	if(!gibbed && !suiciding && loc != null)
+	if(!gibbed && !(mind && mind.suiciding) && loc != null)
 		explosion(get_turf(loc),-1,0,2)
 		gib()
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -377,7 +377,7 @@ obj/item/asteroid/basilisk_hide/New()
 		return
 
 	// revive() requires a check for suiciding
-	if (target.suiciding)
+	if (target.mind && target.mind.suiciding)
 		to_chat(user, "<span class='notice'>\The [target] refuses \the [src].</span>")
 		return
 

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -217,8 +217,8 @@
 
 		log_attack("<span class='danger'>[key_name(src)] has sealed itself via the suicide verb.</span>")
 
-	if(suicide_set)
-		suiciding = TRUE
+	if(suicide_set && mind)
+		mind.suiciding = TRUE
 
 	visible_message("<span class='danger'>[src] shudders violently for a moment, then becomes motionless, its aura fading and eyes slowly darkening.</span>")
 	death()

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -72,7 +72,6 @@
 			Mo.dna.SetSEValueRange(MONKEYBLOCK, 0xDAC, 0xFFF)
 	if(isliving(src))
 		var/mob/living/L = src
-		Mo.suiciding = L.suiciding
 		Mo.take_overall_damage(L.getBruteLoss() + L.getCloneLoss(), L.getFireLoss())
 		Mo.setToxLoss(L.getToxLoss())
 		Mo.setOxyLoss(L.getOxyLoss())

--- a/code/modules/spells/changeling/regenerative_stasis.dm
+++ b/code/modules/spells/changeling/regenerative_stasis.dm
@@ -12,13 +12,13 @@
 /spell/changeling/regenerate/cast(var/list/targets, var/mob/living/carbon/human/user)
 	var/datum/role/changeling/changeling = user.mind.GetRole(CHANGELING)
 
-	if(changeling.isreviving) 
-		to_chat(changeling.antag.current, "<span class='warning'>We are already regenerating!</span>") 
+	if(changeling.isreviving)
+		to_chat(changeling.antag.current, "<span class='warning'>We are already regenerating!</span>")
 		return
 
 	var/mob/living/carbon/C = user
 
-	if(C.suiciding)			//no reviving from suicides
+	if(C.mind && C.mind.suiciding)			//no reviving from suicides
 		to_chat(C, "<span class='warning'>Why would we wish to regenerate if we have already committed suicide?")
 		return
 
@@ -43,10 +43,10 @@
 		to_chat(C, "<span class='warning'>We are now ready to regenerate.</span>")
 
 		feedback_add_details("changeling_powers","FD")
-	else 
+	else
 		var/time_to_take = 1200
-		to_chat(C, "<span class='notice'>We begin to regenerate. This will take [round((time_to_take/10))] seconds.</span>")	
-		changeling.isreviving = TRUE	
+		to_chat(C, "<span class='notice'>We begin to regenerate. This will take [round((time_to_take/10))] seconds.</span>")
+		changeling.isreviving = TRUE
 		sleep(time_to_take)
 		to_chat(C, "<span class='warning'>We are now ready to regenerate.</span>")
 


### PR DESCRIPTION
Fixes #22891
Fixes #21458

15% tested because the interactions of suicided bodies are random, inconsistent, legacy bugs, and/or bordering on undefined behavior

:cl:
 * bugfix: Fixed that transplanting a head/brain onto the body of someone who had suicided would not let you revive them due to the game thinking they had suicided too. Also fixed being able to revive suiciders by headswapping them to a monkeyman body.