### PR TITLE
Shuttle and ERT are now called if no players are alive

### DIFF
--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -412,7 +412,7 @@ datum/emergency_shuttle/proc/process()
 		else
 			return 1
 
-/proc/shuttle_autocall()
+/proc/shuttle_autocall(var/reason = "None")
 	if (emergency_shuttle.departed)
 		return
 
@@ -420,7 +420,7 @@ datum/emergency_shuttle/proc/process()
 		return
 
 	emergency_shuttle.incall(2)
-	log_game("All the AIs, comm consoles and boards are destroyed. Shuttle called.")
-	message_admins("All the AIs, comm consoles and boards are destroyed. Shuttle called.", 1)
-	captain_announce("The emergency shuttle has been called. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.")
+	log_game("[reason]. Shuttle called.")
+	message_admins("[reason]. Shuttle called.", 1)
+	captain_announce("The emergency shuttle has been called. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes. Justification: [reason].")
 	world << sound('sound/AI/shuttlecalled.ogg')

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -644,7 +644,7 @@ var/stacking_limit = 90
 					continue
 			dead_players.Add(M)//Players who actually died (and admins who ghosted, would be nice to avoid counting them somehow)
 	
-	if(!living_players.len && dead_players.len && world.time > 15 MINUTES && emergency_shuttle.direction == 0)//if nobody is around and alive in the current round and enough time has passed and the shuttle isnt already coming
+	if(!living_players.len && dead_players.len && world.time > 15 MINUTES && emergency_shuttle.direction == 0 && !sentStrikeTeams(TEAM_ERT))//if nobody is around and alive in the current round and enough time has passed and the shuttle/ERT isnt already coming
 		shuttle_autocall("All sentient life in the station and nearby system show no signs of life")
 		var/datum/striketeam/ert/response_team = new()
 		response_team.mission = "Attempt to revive or recover all dead life from the station"

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -643,6 +643,12 @@ var/stacking_limit = 90
 					living_players.Add(M)//yes we're adding a ghost to "living_players", so make sure to properly check for type when testing midround rules
 					continue
 			dead_players.Add(M)//Players who actually died (and admins who ghosted, would be nice to avoid counting them somehow)
+	
+	if(!living_players.len && dead_players.len && world.time > 15 MINUTES && emergency_shuttle.direction == 0)//if nobody is around and alive in the current round and enough time has passed and the shuttle isnt already coming
+		shuttle_autocall("All sentient life in the station and nearby system show no signs of life")
+		var/datum/striketeam/ert/response_team = new()
+		response_team.mission = "Attempt to revive or recover all dead life from the station"
+		response_team.trigger_strike()
 
 /datum/gamemode/dynamic/proc/GetInjectionChance()
 	var/chance = 0

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -715,7 +715,7 @@ var/list/shuttle_log = list()
 	if(ticker.mode.name == "revolution" || ticker.mode.name == "AI malfunction")
 		return ..()
 
-	shuttle_autocall()
+	shuttle_autocall("All the AIs, comm consoles and boards are destroyed")
 	..()
 
 // -- Blob defcon 1 things
@@ -817,6 +817,6 @@ var/list/shuttle_log = list()
 	if(ticker.mode.name == "revolution" || ticker.mode.name == "AI malfunction")
 		return ..()
 
-	shuttle_autocall()
+	shuttle_autocall("All the AIs, comm consoles and boards are destroyed")
 
 	..()

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -46,8 +46,11 @@
 			spell_master.on_holder_death(src)
 	if(transmogged_from)
 		transmog_death()
-	if(!living_players.len && world.time > 15 MINUTES) //if nobody is around and alive in the current round and enough time has passed
+	if(!living_players.len && dead_players.len && world.time > 15 MINUTES) //if nobody is around and alive in the current round and enough time has passed
 		shuttle_autocall("All sentient life in the station and nearby system show no signs of life")
+		var/datum/striketeam/ert/response_team = new()
+		response_team.mission = "Attempt to revive or recover all dead life from the station"
+		response_team.trigger_strike()
 
 /mob/proc/transmog_death()
 	var/obj/transmog_body_container/C = transmogged_from

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -46,11 +46,6 @@
 			spell_master.on_holder_death(src)
 	if(transmogged_from)
 		transmog_death()
-	if(!living_players.len && dead_players.len && world.time > 15 MINUTES) //if nobody is around and alive in the current round and enough time has passed
-		shuttle_autocall("All sentient life in the station and nearby system show no signs of life")
-		var/datum/striketeam/ert/response_team = new()
-		response_team.mission = "Attempt to revive or recover all dead life from the station"
-		response_team.trigger_strike()
 
 /mob/proc/transmog_death()
 	var/obj/transmog_body_container/C = transmogged_from

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -46,6 +46,8 @@
 			spell_master.on_holder_death(src)
 	if(transmogged_from)
 		transmog_death()
+	if(!living_players.len && world.time > 15 MINUTES) //if nobody is around and alive in the current round and enough time has passed
+		shuttle_autocall("All sentient life in the station and nearby system show no signs of life")
 
 /mob/proc/transmog_death()
 	var/obj/transmog_body_container/C = transmogged_from

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -42,7 +42,7 @@
 		callshuttle = 0
 
 	if(callshuttle == 3) //if all three conditions are met
-		shuttle_autocall()
+		shuttle_autocall("All the AIs, comm consoles and boards are destroyed")
 
 	if(explosive && !gibbed && !istype(loc, /obj/machinery/power/apc))
 		visible_message("<span class='danger'>[name] begins to spark violently!</span>")


### PR DESCRIPTION
Closes #29460 
Also updates shuttle_autocall() to accept a reason instead of a hardcoded one
:cl:
 * rscadd: The emergency shuttle and response team are now called to your station if there are no signs of sentient life.