### PR TITLE
EMPing a mecha now disables most forms of power generation

### DIFF
--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -167,3 +167,6 @@
 
 /obj/item/mecha_parts/mecha_equipment/proc/alt_action()
 	return
+
+/obj/item/mecha_parts/mecha_equipment/emp_act(severity)
+	return

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -1074,6 +1074,12 @@
 		log_message("Deactivated.")
 		to_chat(chassis.occupant, "<span class='notice'>Relay disabled.</span>")
 
+/obj/item/mecha_parts/mecha_equipment/tesla_energy_relay/emp_act()
+	if(equip_ready)
+		set_ready_state(0)
+		log_message("Disabled.")
+		to_chat(chassis.occupant, "<span class='warning'>Relay shut down.</span>")
+
 /spell/mech/tesla
 	name = "Tesla Energy Relay"
 	desc = "Wirelessly drains energy from any available power channel in area. The performance index is quite low."
@@ -1165,6 +1171,12 @@
 			set_ready_state(1)
 			log_message("Deactivated.")
 	return
+
+/obj/item/mecha_parts/mecha_equipment/generator/emp_act()
+	if(equip_ready)
+		set_ready_state(0)
+		log_message("Disabled.")
+		to_chat(chassis.occupant, "<span class='warning'>Generator shut down.</span>")
 
 /obj/item/mecha_parts/mecha_equipment/generator/get_equip_info()
 	var/output = ..()

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -1076,7 +1076,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay/emp_act()
 	if(equip_ready)
-		set_ready_state(0)
+		set_ready_state(1)
 		log_message("Disabled.")
 		to_chat(chassis.occupant, "<span class='warning'>Relay shut down.</span>")
 
@@ -1174,7 +1174,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/generator/emp_act()
 	if(equip_ready)
-		set_ready_state(0)
+		set_ready_state(1)
 		log_message("Disabled.")
 		to_chat(chassis.occupant, "<span class='warning'>Generator shut down.</span>")
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -722,6 +722,8 @@
 		take_damage(50 / severity,"energy")
 	src.log_message("EMP detected",1)
 	check_for_internal_damage(list(MECHA_INT_FIRE,MECHA_INT_TEMP_CONTROL,MECHA_INT_CONTROL_LOST,MECHA_INT_SHORT_CIRCUIT),1)
+	for(var/obj/item/mecha_parts/mecha_equipment/M in equipment)
+		M.emp_act(severity)
 	return
 
 /obj/mecha/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)


### PR DESCRIPTION
So that the mecha stays more easily down when ion'd, instead of immediately getting back up at full capacity because of issues highlighted in #29492
What it does is disable the equipment when the mech is EMP'd so that they have to be manually toggled on

:cl:
 * tweak: Some power-generating mecha equipment such as the Energy Relay, Plasma Generator and Nuclear Generator will be deactivated when the mecha is affected by an EMP.