### PR TITLE
Heat caps tweaks

### DIFF
--- a/code/ATMOSPHERICS/components/unary/cap.dm
+++ b/code/ATMOSPHERICS/components/unary/cap.dm
@@ -107,6 +107,13 @@
 	return 1
 
 
+/obj/machinery/atmospherics/unary/cap/heat/process()
+	. = ..()
+	if(node1)
+		animate(src, color = node1.color, time = 2 SECONDS, easing = SINE_EASING)
+	else if (color != "#B4B4B4")
+		animate(src, color = "#B4B4B4", time = 2 SECONDS, easing = SINE_EASING)
+
 /obj/machinery/atmospherics/unary/cap/heat/getNodeType(var/node_id)
 	return PIPE_TYPE_HE
 


### PR DESCRIPTION
So I found out that heat pipes change color based on their current heat. This makes it so the caps have the same color as the pipe they're connected to. Also replaces the straight heat pipe in lowfatbagel's TEG incinerator with a cap.
![image](https://user-images.githubusercontent.com/7573912/117562010-fa424a80-b09b-11eb-9615-8c4bdb6b29b9.png)
