### PR TITLE
fix AI PDA icon

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -522,7 +522,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 // Special AI/pAI PDAs that cannot explode.
 /obj/item/device/pda/ai
-	icon_state = "NONE"
+	icon = 'icons/obj/machines/telecomms.dmi'
+	icon_state = "pda_server-on"
 	ttone = "data"
 	detonate = 0
 


### PR DESCRIPTION
whenever AI gets a message it just shows the entire icon file atm, this makes the AI's PDA icon into the icon for the PDA messaging server.