### PR TITLE
Fridges cool

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -13,6 +13,7 @@
 	idle_power_usage = 5
 	active_power_usage = 100
 	flags = NOREACT
+	source_temperature = T0C + 4
 	var/icon_on = "smartfridge"
 	var/icon_off = "smartfridge-off"
 	var/list/datum/fridge_pile/piles = list()
@@ -104,6 +105,16 @@
 	for(var/ac_type in accepted_types)
 		if(istype(O, ac_type))
 			return 1
+
+/obj/machinery/smartfridge/thermal_energy_transfer()
+	return -75 //slow
+
+/obj/machinery/smartfridge/process()
+	if(stat & (NOPOWER|BROKEN) || !anchored)
+		return
+
+	for(var/obj/item/I in contents)
+		I.attempt_heating(src)
 
 /obj/machinery/smartfridge/seeds
 	name = "\improper MegaSeed Servitor"


### PR DESCRIPTION
### What?
Fridges will now slowly cool items inside them.

### Why?
There is absolutely no desirable reason for this, and no practical application. In fact, this is actively undesirable, since all but one of the chemical reactions require heating, not cooling. However, it doesn't even matter, because there's not a single time where this will ever be relevant or even noticeable.
Literally the only reason I coded this is because >>335169127's immulsions got hurt.
![335169127](https://user-images.githubusercontent.com/81891904/117908531-f0446580-b2ae-11eb-98eb-fb31b26db347.png)

:cl:
 * tweak: Fridges now slowly cool items inside them. This serves no practical purpose and will virtually never be relevant or noticeable.