### PR TITLE
Body scanners will now show the dangerosity of virus

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1015,6 +1015,22 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define EFFECT_DANGER_HARMFUL	"4"
 #define EFFECT_DANGER_DEADLY	"5"
 
+#define EFFECT_DANGER_HELPFUL_TXT "<span class='good'>Helpful</span>"
+#define EFFECT_DANGER_FLAVOR_TXT "Benign"
+#define EFFECT_DANGER_ANNOYING_TXT "Annoyance"
+#define EFFECT_DANGER_HINDERANCE_TXT "<span class='notice'>Hinderance</span>"
+#define EFFECT_DANGER_HARMFUL_TXT "<span class='red'>Harmful</span>"
+#define EFFECT_DANGER_DEADLY_TXT "<span class='danger'>DEADLY</span>"
+
+var/list/effect_code_to_text = list(
+	EFFECT_DANGER_HELPFUL = EFFECT_DANGER_HELPFUL_TXT,
+	EFFECT_DANGER_FLAVOR = EFFECT_DANGER_FLAVOR_TXT,
+	EFFECT_DANGER_ANNOYING = EFFECT_DANGER_ANNOYING_TXT,
+	EFFECT_DANGER_HINDERANCE = EFFECT_DANGER_HINDERANCE_TXT,
+	EFFECT_DANGER_HARMFUL = EFFECT_DANGER_HARMFUL_TXT,
+	EFFECT_DANGER_DEADLY = EFFECT_DANGER_DEADLY_TXT,
+)
+
 #define	ANTIGEN_BLOOD	"blood"
 #define	ANTIGEN_COMMON	"common"
 #define	ANTIGEN_RARE	"rare"

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -424,7 +424,7 @@
 							total_harmful++
 						if (EFFECT_DANGER_DEADLY)
 							total_deadly++
-			dat += "[total_harmful > 0 ? "<span class='red'>[total_harmful]</span>" : total_harmful] harmful symptom(s) - [total_deadly > 0 ? "<span class='red'>[total_deadly]</span>" : total_deadly] deadly symptom(s). <br/>"
+			dat += "[total_harmful > 0 ? "<span class='warning'>[total_harmful]</span>" : total_harmful] harmful symptom(s) - [total_deadly > 0 ? "<span class='danger'>[total_deadly]</span>" : total_deadly] deadly symptom(s). <br/>"
 
 	dat += text("[]\t-Brute Damage %: []</font><br>", (occ["bruteloss"] < 60 ? "<font color='blue'>" : "<font color='red'>"), occ["bruteloss"])
 	dat += text("[]\t-Respiratory Damage %: []</font><br>", (occ["oxyloss"] < 60 ? "<font color='blue'>" : "<font color='red'>"), occ["oxyloss"])

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -379,7 +379,8 @@
 		"tg_diseases_list" = H.viruses,
 		"lung_ruptured" = H.is_lung_ruptured(),
 		"external_organs" = H.organs.Copy(),
-		"internal_organs" = H.internal_organs.Copy()
+		"internal_organs" = H.internal_organs.Copy(),
+		"virus2_data" = H.virus2.Copy(),
 		)
 	return health_data
 
@@ -398,7 +399,33 @@
 			aux = "Dead"
 	dat += text("[]\tHealth %: [] ([])</font><br>", (occ["health"] > 50 ? "<font color='blue'>" : "<font color='red'>"), occ["health"], aux)
 	if(occ["virus_present"])
-		dat += "<font color='red'>Pathogen detected in blood stream.</font><br>"
+		dat += "<font color='red'>[occ["virus_present"]] pathogen(s) detected in blood stream.</font><br>"
+		var/list/virus2 = occ["virus2_data"]
+		// High quality
+		if (efficiency > 2)
+			var/i = 1
+			for (var/id in virus2)
+				var/datum/disease2/disease/D = virus2[id]
+				dat += "Pathogen #[i]: "
+				var/list/effects_text = list()
+				for (var/datum/disease2/effect/E in D.effects)
+					effects_text += effect_code_to_text[E.badness]
+				dat += english_list(effects_text, "UNKNOWN", " - ", " - ", " - ")
+				dat += ". </br/>"
+				i++
+		else // Basic thing
+			var/total_harmful = 0
+			var/total_deadly = 0
+			for (var/id in virus2)
+				var/datum/disease2/disease/D = virus2[id]
+				for (var/datum/disease2/effect/E in D.effects)
+					switch (E.badness)
+						if (EFFECT_DANGER_HARMFUL)
+							total_harmful++
+						if (EFFECT_DANGER_DEADLY)
+							total_deadly++
+			dat += "[total_harmful > 0 ? "<span class='red'>[total_harmful]</span>" : total_harmful] harmful symptom(s) - [total_deadly > 0 ? "<span class='red'>[total_deadly]</span>" : total_deadly] deadly symptom(s). <br/>"
+
 	dat += text("[]\t-Brute Damage %: []</font><br>", (occ["bruteloss"] < 60 ? "<font color='blue'>" : "<font color='red'>"), occ["bruteloss"])
 	dat += text("[]\t-Respiratory Damage %: []</font><br>", (occ["oxyloss"] < 60 ? "<font color='blue'>" : "<font color='red'>"), occ["oxyloss"])
 	dat += text("[]\t-Toxin Content %: []</font><br>", (occ["toxloss"] < 60 ? "<font color='blue'>" : "<font color='red'>"), occ["toxloss"])


### PR DESCRIPTION
![scan](https://user-images.githubusercontent.com/31417754/118056817-e4c66c80-b38a-11eb-9f93-931a01a820f2.png)

The symptoms themselves are not described, but the quick diagnostic gives medbay an idea of the urgency of a virus.
An improved scanner shows more info - including precisely at which stage the virus gets harmful, and if there are beneficial symptoms, without showing what those symptoms are. (use the virologist's machines for that)

Had the idea while reading the thread. Access to this information helps medbay to chose if they prioritise the virus or the pile of bodies near the cloner.

:cl:
- tweak: The body scanner in medbay will now help you diagnose the lethality of a virus outbreak. 