### PR TITLE
Fixes amount of wires returned from windoor assemblies

### DIFF
--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -173,7 +173,7 @@ obj/structure/windoor_assembly/Destroy()
 			if(gcDestroyed)
 				return
 			to_chat(user, "<span class='notice'>You cut \the [name] wires!</span>")
-			new /obj/item/stack/cable_coil(get_turf(user), 1)
+			new /obj/item/stack/cable_coil(get_turf(user), 2)
 			wired = FALSE
 			update_name()
 


### PR DESCRIPTION
Closes #29526 
[bugfix]
:cl:
 * bugfix: Windoor assemblies now return the same amount of wires installed when cut, as opposed to 1