### PR TITLE
Grey slime extract supply crates

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -2055,12 +2055,9 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/grey_extract
 	name = "Grey slime extracts"
 	contains = list(/obj/item/slime_extract/grey,
-					/obj/item/slime_extract/grey,
-					/obj/item/slime_extract/grey,
-					/obj/item/slime_extract/grey,
 					/obj/item/slime_extract/grey
 					)
-	cost = 100
+	cost = 200
 	containertype = /obj/structure/closet/crate/sci
 	containername = "gret slime extract crate"
 	access = list(access_science)

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -2052,6 +2052,20 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containername = "robot maintenance equipment crate"
 	group = "Science"
 
+/datum/supply_packs/grey_extract
+	name = "Grey slime extracts"
+	contains = list(/obj/item/slime_extract/grey,
+					/obj/item/slime_extract/grey,
+					/obj/item/slime_extract/grey,
+					/obj/item/slime_extract/grey,
+					/obj/item/slime_extract/grey
+					)
+	cost = 100
+	containertype = /obj/structure/closet/crate/sci
+	containername = "gret slime extract crate"
+	access = list(access_science)
+	group = "Science"
+
 /datum/supply_packs/suspension_gen
 	name = "Suspension field generator"
 	contains = list(/obj/machinery/suspension_gen)


### PR DESCRIPTION
[content]
Locked behind science access, 2 extracts for 200 credits.
Because otherwise, if all slimes die or all grey extracts are used up, the job ends. Let me know if the exact number or price should be changed.
:cl:
 * rscadd: Grey slime extracts are now available in crates from cargo