### PR TITLE
Monkey cubes inside of monkey cube boxes now start unwrapped in Xenobiology.

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -501,7 +501,7 @@
 	..()
 	if(src.type == /obj/item/weapon/storage/box/monkeycubes)
 		for(var/i = 1; i <= 6; i++)
-			new /obj/item/weapon/reagent_containers/food/snacks/monkeycube/wrapped(src)
+			new /obj/item/weapon/reagent_containers/food/snacks/monkeycube/(src)
 
 /obj/item/weapon/storage/box/monkeycubes/farwacubes
 	name = "farwa cube box"


### PR DESCRIPTION
PREVIOUS TITLE: Monkey cubes inside of monkey cube boxes now start unwrapped.

Monkey cubes inside of monkey cube boxes now start unwrapped. 

This should make playing Xenobiologist a slightly less tedious experience by saving two clicks per cube. This has little to no impact on the time duration of progression of Xenobiology, as the amount of time saved is negligible. It is not necessarily about the time, but the mental effort and tedium of an unnecessarily repetitive process.  <qol>

:cl:
 * tweak: Monkey cubes are no longer wrapped.