### PR TITLE
Zombies should no longer be able to attack people while dead

### DIFF
--- a/code/game/gamemodes/wizard/spellbook_oneuse.dm
+++ b/code/game/gamemodes/wizard/spellbook_oneuse.dm
@@ -347,7 +347,7 @@
 
 /obj/item/weapon/spellbook/oneuse/timestop/recoil(mob/living/carbon/user as mob)
 	if(istype(user, /mob/living/carbon/human))
-		user.stunned = 5
+		user.AdjustStunned(5)
 		user.flash_eyes(visual = 1)
 		to_chat(user, "<span class = 'warning'>You have been turned into a statue!</span>")
 		new /obj/structure/closet/statue(user.loc, user) //makes the statue

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -383,8 +383,8 @@ About the new airlock wires panel:
 						src.justzap = 0
 		else if(user.hallucination > 50 && prob(10) && src.operating == 0)
 			to_chat(user, "<span class='danger'>You feel a powerful shock course through your body!</span>")
-			user.halloss += 10
-			user.stunned += 10
+			user.adjustHalLoss(10)
+			user.AdjustStunned(10)
 	..(user)
 
 /obj/machinery/door/airlock/proc/isElectrified()

--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -216,7 +216,7 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 				log_attack("<font color='red'>[user.name] ([user.ckey]) disarmed [name] ([ckey])</font>")
 				var/randn = rand(1,100)
 				if(randn <= 25)
-					knockdown = 3
+					AdjustKnockdown(3)
 					playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 					visible_message("<span class='danger'>[user] has pushed [src]!</span>")
 					var/obj/item/found = locate(tool_state) in module.modules

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -837,7 +837,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 		qdel(src)
 
 /mob/living/simple_animal/isStunned() //Used so that it allows clients to attack in code/_onclick/click.dm
-	if(client)
+	if(client && !isUnconscious()) //Don't attack while dead, baka
 		return 0
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -68,6 +68,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	mob_bump_flag = SIMPLE_ANIMAL
 	mob_swap_flags = MONKEY|SLIME|SIMPLE_ANIMAL
 	mob_push_flags = MONKEY|SLIME|SIMPLE_ANIMAL
+	status_flags = CANPUSH //They cannot be conventionally stunned. AIs normally ignore this but stuns used to be able to disable player-controlled ones
 
 	//LETTING SIMPLE ANIMALS ATTACK? WHAT COULD GO WRONG. Defaults to zero so Ian can still be cuddly
 	var/melee_damage_lower = 0
@@ -835,20 +836,5 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 		gib(meat = 0) //"meat" argument only exists for mob/living/simple_animal/gib()
 	else
 		qdel(src)
-
-/mob/living/simple_animal/isStunned() //Used so that it allows clients to attack in code/_onclick/click.dm
-	if(client && !isUnconscious()) //Don't attack while dead, baka
-		return 0
-	return ..()
-
-/mob/living/simple_animal/isJustStunned() //Used so that it allows clients to move in code/mobules/mob/mob.dm
-	if(client)
-		return 0
-	return ..()
-
-/mob/living/simple_animal/isKnockedDown() //Ditto
-	if(client)
-		return 0
-	return ..()
 
 /datum/locking_category/simple_animal

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1523,7 +1523,7 @@ Use this proc preferably at the end of an equipment loadout
 	return 1
 
 /mob/proc/isKnockedDown() //Check if the mob is knocked down
-	return isUnconscious() || knockdown || paralysis
+	return knockdown || paralysis
 
 /mob/proc/isJustStunned() //Some ancient coder (as of 2021) made it so that it checks directly for whether the variable has a positive number, and I'm too afraid of unintended consequences down the line to just change it to isStunned(), so instead you have this half-baked abomination of a barely-used proc just so that player simple_animal mobs can move. You're welcome!
 	return stunned
@@ -1536,7 +1536,7 @@ Use this proc preferably at the end of an equipment loadout
 			canmove = 0
 			lying = (category.flags & LOCKED_SHOULD_LIE) ? TRUE : FALSE //A lying value that !=1 will break this
 
-	else if(resting || !can_stand || isKnockedDown())
+	else if(resting || !can_stand || isKnockedDown() || isUnconscious())
 		stop_pulling()
 		lying = 1
 		canmove = 0

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -62,7 +62,7 @@
 			M.Dizzy(150)
 			M.dizziness = 150
 		for(var/datum/reagent/ethanol/A in M.reagents.reagent_list)
-			M.paralysis += 2
+			M.AdjustParalysis(2)
 			M.dizziness += 10
 			M:slurring += 10
 			M.confused += 10
@@ -360,7 +360,7 @@ obj/item/projectile/bullet/suffocationbullet
 	icon_state = "minigun"
 	damage = 30
 	fire_sound = 'sound/weapons/gatling_fire.ogg'
-	
+
 /obj/item/projectile/bullet/baton
 	name = "stun baton"
 	icon = 'icons/obj/projectiles_experimental.dmi'
@@ -375,7 +375,7 @@ obj/item/projectile/bullet/suffocationbullet
 	stutter = 10
 	agony = 10
 	var/rigged = null //if a rigged baton is loaded, it'll fire an explosive burst
-	
+
 /obj/item/projectile/bullet/baton/on_hit(var/atom/target, var/blocked = 0)
 	..()
 	playsound(target.loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
@@ -390,7 +390,7 @@ obj/item/projectile/bullet/suffocationbullet
 		var/flash_range = light_impact_range
 		explosion(target.loc, devastation_range, heavy_impact_range, light_impact_range, flash_range)
 	qdel(src)
-	
+
 /obj/item/projectile/bullet/osipr
 	name = "\improper OSIPR bullet"
 	icon = 'icons/obj/projectiles_experimental.dmi'

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -206,7 +206,7 @@
 ///	return
 ///datum/reagent/proc/on_update(var/atom/A)
 //	return
-	
+
 /datum/reagent/proc/on_overdose(var/mob/living/M)
 	M.adjustToxLoss(1)
 
@@ -479,7 +479,7 @@
 //	if(data["blood_colour"])
 //		color = data["blood_colour"]
 //	return ..()
-	
+
 /datum/reagent/blood/reaction_turf(var/turf/simulated/T, var/volume) //Splash the blood all over the place
 
 	var/datum/reagent/self = src
@@ -2070,7 +2070,7 @@
 	if(volume >= 3)
 		if(!(locate(/obj/effect/decal/cleanable/greenglow) in T))
 			new /obj/effect/decal/cleanable/greenglow(T)
-			
+
 /datum/reagent/diamond
 	name = "Diamond dust"
 	id = DIAMONDDUST
@@ -2079,16 +2079,16 @@
 	color = "c4d4e0" //196 212 224
 	density = 3.51
 	specheatcap = 6.57
-	
+
 /datum/reagent/diamond/on_mob_life(var/mob/living/M)
 
 	if(..())
 		return 1
-	
+
 	M.adjustBruteLoss(5 * REM) //Not a good idea to eat crystal powder
 	if(prob(30))
 		M.audible_scream()
-	
+
 /datum/reagent/phazon
 	name = "Phazon salt"
 	id = PHAZON
@@ -7614,7 +7614,7 @@
 	if(..())
 		return 1
 
-	M.stunned = 4
+	M.AdjustStunned(4)
 
 /datum/reagent/ethanol/drink/neurotoxin
 	name = "Neurotoxin"


### PR DESCRIPTION
A while ago [I made a change where player-controlled simple mobs can no longer be stunlocked to death,](https://github.com/vgstation-coders/vgstation13/pull/29328) but as a result this had the unintended consequence of allowing certain types of mobs to attack while they are supposed to be dead (zombies are already dead, but normally when you kill one they're dead for real but reanimate after a while to be only dead again), at least when controlled by players. This came as a result of isStunned(), something that is used in click code to determine whether someone can click or not (and it represents various checks such as "is the player stunned? Is the player DEAD? etc.) returning 0/"no, the entity is not stunned" if the entity was possessed by a client aka the player. Now that client check comes with an additional check to make sure that the mob is actually alive, because touching any aspect of click code itself would very likely break it, me, the codebase and BYOND as a whole.
Also changed the isKnockedDown() check to no longer include isUnconscious() by itself, instead where it was used now has isUnconscious() alongside it, so that isKnockedDown() does not return 0 regardless of isUnconscious(). This is a "just in case" change.
:cl:
 * bugfix: Fixed a bug where player-controlled zombies could attack while double dead (given that zombies are already dead and when you shoot one enough it becomes double-dead, although this time two negatives don't turn into a positive)