### PR TITLE
Civil Wars of Casters is now a round-ending ruleset

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -236,6 +236,7 @@
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 40
 	persistent = 1
+	flags = HIGHLANDER_RULESET
 //	var/wizard_cd = 210 //7 minutes
 	var/total_wizards = 4
 


### PR DESCRIPTION
... meaning it won't be executed alongside other round-ending rulesets such as Cult, Nuke Ops, Revs, or Blob except in very rare circumstances.

:cl:
- bugfix: CWC is properly considered a round-ending rulesets and will not run concurrently with other round-ending rulesets.