### PR TITLE
Hardsuit Tweaks

### DIFF
--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -113,13 +113,13 @@ var/list/all_hardsuit_pieces = list(HARDSUIT_HEADGEAR,HARDSUIT_GLOVES,HARDSUIT_B
 
 /obj/item/clothing/suit/space/rig
 	name = "civilian hardsuit"
-	desc = "A special suit that protects against hazardous, low pressure environments. Has radiation shielding."
+	desc = "A special suit that protects against hazardous, low pressure environments."
 	icon_state = "rig-engineering"
 	item_state = "eng_hardsuit"
 	slowdown = HARDSUIT_SLOWDOWN_LOW
 	species_fit = list(GREY_SHAPED, TAJARAN_SHAPED, INSECT_SHAPED)
 	species_restricted = list("exclude",VOX_SHAPED)
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 80)
+	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 10)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/bag/ore,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/device/rcd, /obj/item/tool/wrench/socket)
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	pressure_resistance = 200 * ONE_ATMOSPHERE

--- a/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
+++ b/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
@@ -72,6 +72,7 @@
 	_color = "mining"
 	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
 	species_restricted = list("exclude",VOX_SHAPED)
+	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 10)
 	pressure_resistance = 40 * ONE_ATMOSPHERE
 	clothing_flags = GOLIATHREINFORCE
 
@@ -82,6 +83,7 @@
 	item_state = "rig-mining"
 	species_fit = list(INSECT_SHAPED)
 	species_restricted = list("exclude",VOX_SHAPED)
+	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 10)
 	pressure_resistance = 40 * ONE_ATMOSPHERE
 	clothing_flags = GOLIATHREINFORCE
 	head_type = /obj/item/clothing/head/helmet/space/rig/mining
@@ -250,6 +252,7 @@
 	_color = "medical"
 	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
 	species_restricted = list("exclude",VOX_SHAPED)
+	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 30)
 	pressure_resistance = 40 * ONE_ATMOSPHERE
 
 /obj/item/clothing/suit/space/rig/medical
@@ -259,6 +262,7 @@
 	item_state = "medical_hardsuit"
 	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
 	species_restricted = list("exclude",VOX_SHAPED)
+	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 30)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/firstaid,/obj/item/device/healthanalyzer,/obj/item/stack/medical, /obj/item/roller)
 	pressure_resistance = 40 * ONE_ATMOSPHERE
 	head_type = /obj/item/clothing/head/helmet/space/rig/medical


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
Fixes a bug with the medical and mining hardsuits that caused them to inherit an absurd 80 radiation armor (compared to the engineer and CE suits' 50) from the suit/space/rig class due to not having their own armor values assigned. Reduces the unused base rig's radiation armor as well as the mining rig's radiation armor to 10, and sets the medical rig's radiation armor to 30 to reflect the "minor" radiation shielding mentioned in its description. The other armor values (melee, bullet, laser etc) are unchanged from before and are identical to the engineering rigsuit's armor.

:cl:
 * tweak: Adjusted med and mining hardsuit radiation armor values 
 * tweak: Made the base rigsuit type less insanely radproof