### PR TITLE
This is why we can't have nice things

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -124,17 +124,17 @@
 	cameraFollow = null
 	unset_machine()
 
-	if(src.eyeobj && src.loc)
-		//src.eyeobj.loc = src.loc
-		src.eyeobj.forceMove(src.loc)
+	if(!loc)
+		return
+
+	if(!eyeobj)
+		make_eyeobj()
 	else
-		src.eyeobj = new(src.loc)
-		src.eyeobj.ai = src
-		src.eyeobj.name = "[src.name] (AI Eye)" // Give it a name
-		src.eyeobj.forceMove(src.loc)
+		eyeobj.forceMove(loc)
 
 	if(client && client.eye) // Reset these things so the AI can't view through walls and stuff.
 		client.eye = src
+		client.show_popup_menus = TRUE
 		change_sight(removing = SEE_TURFS | SEE_MOBS | SEE_OBJS)
 		see_in_dark = 0
 		see_invisible = SEE_INVISIBLE_LIVING
@@ -142,14 +142,20 @@
 	for(var/datum/camerachunk/c in eyeobj.visibleCameraChunks)
 		c.remove(eyeobj)
 
+/mob/living/silicon/ai/proc/make_eyeobj()
+	eyeobj = new(loc)
+	eyeobj.ai = src
+	refresh_eyeobj_name()
+	eyeobj.forceMove(loc)
+
+/mob/living/silicon/ai/proc/refresh_eyeobj_name()
+	eyeobj.name = "[name] (AI Eye)"
+
 /mob/living/silicon/ai/proc/jump_to_area(var/area/A)
 	if(!A)
 		return
 	if(!eyeobj)
-		eyeobj = new(loc)
-		eyeobj.ai = src
-		eyeobj.name = "[name] (AI Eye)"
-		eyeobj.forceMove(loc)
+		make_eyeobj()
 	var/list/turfs = list()
 	for(var/turf/T in A)
 		turfs.Add(T)
@@ -159,7 +165,7 @@
 		return
 	cameraFollow = null
 	eyeobj.forceMove(T)
-	
+
 /mob/living/silicon/ai/proc/toggleholopadoverlays() //shows holopads above all static
 	if (!holopadoverlays.len)
 		for(var/obj/machinery/hologram/holopad/holopads in machines)

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -36,6 +36,7 @@
 /mob/living/silicon/ai/proc/life_handle_powered_core()
 	var/unblindme = FALSE
 	if(client && client.eye == eyeobj) // We are viewing the world through our "eye" mob.
+		client.show_popup_menus = FALSE
 		change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 		see_in_dark = 8
 		see_invisible = SEE_INVISIBLE_LEVEL_TWO
@@ -189,9 +190,9 @@
 		var/damage_taken
 		if(ai_flags & COREFIRERESIST)
 			damage_taken = getToxLoss() + getBruteLoss() + getOxyLoss()
-		else 
+		else
 			damage_taken = getToxLoss() + getFireLoss() + getBruteLoss() + getOxyLoss()
- 
+
 		health = maxHealth - damage_taken
 
 /mob/living/silicon/ai/update_canmove() //If the AI dies, mobs won't go through it anymore
@@ -200,5 +201,5 @@
 /mob/living/silicon/ai/handle_regular_hud_updates()
 	if(malfhacking)
 		throw_alert(SCREEN_ALARM_APC_HACKING, /obj/abstract/screen/alert/robot/apc_hacking)
-	else 
+	else
 		clear_alert(SCREEN_ALARM_APC_HACKING)


### PR DESCRIPTION
Removes this:
![image](https://user-images.githubusercontent.com/17928298/119388188-51e9d400-bca0-11eb-891b-cd6905f0511b.png)

But since BYOND is a steaming piece of HONK and the context popup menu comes BEFORE the click is even registered, AIs also lost the ability to use right click when they're out of their core view.

:cl:
 * rscdel: AIs can no longer use right click to examine turfs when they're outside their core view.