### PR TITLE
Gives the paramedic science access (for telescience)

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -90,8 +90,8 @@
 	supervisors = "the chief medical officer"
 	wage_payout = 55
 	selection_color = "#ffeef0"
-	access = list(access_paramedic, access_medical, access_sec_doors, access_maint_tunnels, access_external_airlocks, access_eva, access_morgue, access_surgery)
-	minimal_access=list(access_paramedic, access_medical, access_sec_doors, access_maint_tunnels, access_external_airlocks, access_eva, access_morgue, access_surgery)
+	access = list(access_paramedic, access_medical, access_sec_doors, access_maint_tunnels, access_external_airlocks, access_eva, access_morgue, access_surgery, access_science)
+	minimal_access=list(access_paramedic, access_medical, access_sec_doors, access_maint_tunnels, access_external_airlocks, access_eva, access_morgue, access_surgery, access_science)
 	alt_titles = list("Brig Medic")
 	outfit_datum = /datum/outfit/paramedic
 


### PR DESCRIPTION
Am I doing this right? I have no idea because I'm not used to this github witchcraft.
This PR is intended to give Paramedics access to telescience, but that's just generic science access so that's what I've done. 
Our most popular map, Box, has no telescience setup in medbay (unlike its cooler brother, Roid). This is a quick way to remedy that issue.

Pros: Increases your chances of being recovered if you get killed or injured  
This will probably make science mains angry

Cons: None

Requested by PrimeD

https://cdn.discordapp.com/attachments/245856976217702400/846601757798957076/unknown.png