### PR TITLE
Adds Thermal Homeostasis Regulators to the Circuit Imprinter

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -534,8 +534,8 @@
 	component_parts = newlist(
 		/obj/item/weapon/circuitboard/sleeper/mancrowave,
 		/obj/item/weapon/stock_parts/scanning_module,
-		/obj/item/weapon/stock_parts/manipulator,
-		/obj/item/weapon/stock_parts/manipulator
+		/obj/item/weapon/stock_parts/micro_laser,
+		/obj/item/weapon/stock_parts/micro_laser
 	)
 	setting = "Thermoregulate"
 	available_options = list("Thermoregulate" = 50)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -719,6 +719,9 @@ obj/item/weapon/circuitboard/rdserver
 	name = "Circuit board (Thermal Homeostasis Regulator)"
 	desc = "A circuit board used to run a general purpose kit- err, a medical re-heating apparatus."
 	build_path = /obj/machinery/sleeper/mancrowave
+	req_components = list(
+							/obj/item/weapon/stock_parts/scanning_module = 1,
+							/obj/item/weapon/stock_parts/micro_laser = 2)
 
 /obj/item/weapon/circuitboard/biogenerator
 	name = "Circuit Board (Biogenerator)"

--- a/code/modules/research/designs/boards/machine_medical.dm
+++ b/code/modules/research/designs/boards/machine_medical.dm
@@ -87,6 +87,15 @@
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	build_path = /obj/item/weapon/circuitboard/sleeper
+	
+/datum/design/mancrowave
+	name = "Circuit Design (Mancrowave)"
+	desc = "Allows for the constuction of circuit boards used to build a Thermal Homeostasis Regulator."
+	id = "mancrowave"
+	req_tech = list(Tc_BIOTECH = 2)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 2000, SACID = 20)
+	build_path = /obj/item/weapon/circuitboard/sleeper/mancrowave
 
 /datum/design/bioprinter
 	name = "Circuit Design (Bioprinter)"

--- a/code/modules/research/designs/boards/machine_medical.dm
+++ b/code/modules/research/designs/boards/machine_medical.dm
@@ -89,7 +89,7 @@
 	build_path = /obj/item/weapon/circuitboard/sleeper
 	
 /datum/design/mancrowave
-	name = "Circuit Design (Mancrowave)"
+	name = "Circuit Design (Thermal Homeostasis Regulator)"
 	desc = "Allows for the constuction of circuit boards used to build a Thermal Homeostasis Regulator."
 	id = "mancrowave"
 	req_tech = list(Tc_BIOTECH = 2)


### PR DESCRIPTION
Because whoever made them didn't bother I guess.
Also changes the stock parts used in building and upgrading because they were just copied from sleepers and didn't make sense, upgrading still doesn't do anything though.

:cl:
 * rscadd: The circuit imprinter can print thermal homeostasis regulator boards
 * tweak: Thermal homeostasis regulators are built with micro lasers instead of manipulators