### PR TITLE
Players can now properly use the resist verb to get out of a sticky web or blood nail trap.

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_effects.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_effects.dm
@@ -50,7 +50,7 @@
 	var/jump_dir = get_dir(T,loc)
 	shadow(loc,T,"sigil_jaunt")
 	spawn(1)
-		new /obj/effect/afterimage/red(T,user)
+		new /obj/effect/red_afterimage(T,user)
 		user.forceMove(loc)
 		sleep(1)
 		new /obj/effect/afterimage/red(loc,user)
@@ -574,4 +574,25 @@ var/bloodstone_backup = 0
 /obj/effect/stun_indicator/singularity_act()
 	return
 
-////////////////////////////////////////////////////////////////
+///////////////////////////////////THROWN DAGGER TRAP////////////////////////////
+
+/obj/effect/rooting_trap/bloodnail
+	name = "blood nail"
+	desc = "A pointy red nail, appearing to pierce not through what it rests upon, but through the fabric of reality itself."
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "bloodnail"
+
+/obj/effect/rooting_trap/bloodnail/New()
+	..()
+	pixel_x = rand(-4, 4) * PIXEL_MULTIPLIER
+	pixel_y = rand(-4, 4) * PIXEL_MULTIPLIER
+
+/obj/effect/rooting_trap/bloodnail/proc/stick_to(var/atom/A, var/side = null)
+	pixel_x = rand(-4, 4) * PIXEL_MULTIPLIER
+	pixel_y = rand(-4, 4) * PIXEL_MULTIPLIER
+	playsound(A, 'sound/items/metal_impact.ogg', 30, 1)
+	var/turf/T = get_turf(A)
+	playsound(T, 'sound/weapons/hivehand_empty.ogg', 75, 1)
+	. = ..()
+	if (.)
+		visible_message("<span class='warning'>\the [src] nails \the [A] to \the [T].</span>")

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_effects.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_effects.dm
@@ -587,7 +587,7 @@ var/bloodstone_backup = 0
 	pixel_x = rand(-4, 4) * PIXEL_MULTIPLIER
 	pixel_y = rand(-4, 4) * PIXEL_MULTIPLIER
 
-/obj/effect/rooting_trap/bloodnail/proc/stick_to(var/atom/A, var/side = null)
+/obj/effect/rooting_trap/bloodnail/stick_to(var/atom/A, var/side = null)
 	pixel_x = rand(-4, 4) * PIXEL_MULTIPLIER
 	pixel_y = rand(-4, 4) * PIXEL_MULTIPLIER
 	playsound(A, 'sound/items/metal_impact.ogg', 30, 1)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_effects.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_effects.dm
@@ -50,7 +50,7 @@
 	var/jump_dir = get_dir(T,loc)
 	shadow(loc,T,"sigil_jaunt")
 	spawn(1)
-		new /obj/effect/red_afterimage(T,user)
+		new /obj/effect/afterimage/red(T,user)
 		user.forceMove(loc)
 		sleep(1)
 		new /obj/effect/afterimage/red(loc,user)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_projectiles.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_projectiles.dm
@@ -263,7 +263,7 @@
 			setDensity(FALSE)
 			invisibility = 101
 			kill_count = 0
-			var/obj/effect/overlay/bloodnail/nail = new (A.loc)
+			var/obj/effect/rooting_trap/bloodnail/nail = new (A.loc)
 			nail.transform = transform
 			if (color)
 				nail.color = color
@@ -314,55 +314,3 @@
 
 /obj/item/projectile/blooddagger/cultify()
 	return
-
-
-/obj/effect/overlay/bloodnail
-	name = "blood nail"
-	desc = "A pointy red nail, appearing to pierce not through what it rests upon, but through the fabric of reality itself."
-	icon = 'icons/effects/effects.dmi'
-	icon_state = "bloodnail"
-	anchored = 1
-	density = 0
-	plane = ABOVE_HUMAN_PLANE
-	layer = CLOSED_CURTAIN_LAYER
-	var/atom/stuck_to = null
-	var/duration = 100
-
-/obj/effect/overlay/bloodnail/New()
-	..()
-	pixel_x = rand(-4, 4) * PIXEL_MULTIPLIER
-	pixel_y = rand(-4, 4) * PIXEL_MULTIPLIER
-
-/obj/effect/overlay/bloodnail/Destroy()
-	if(stuck_to)
-		unlock_atom(stuck_to)
-	stuck_to = null
-	..()
-
-/obj/effect/overlay/bloodnail/cultify()
-	return
-
-/obj/effect/overlay/bloodnail/proc/stick_to(var/atom/A, var/side = null)
-	pixel_x = rand(-4, 4) * PIXEL_MULTIPLIER
-	pixel_y = rand(-4, 4) * PIXEL_MULTIPLIER
-	playsound(A, 'sound/items/metal_impact.ogg', 30, 1)
-	var/turf/T = get_turf(A)
-	playsound(T, 'sound/weapons/hivehand_empty.ogg', 75, 1)
-
-	if(isliving(A) && !isspace(T))//can't nail people down unless there's a turf to nail them to.
-		stuck_to = A
-		visible_message("<span class='warning'>\the [src] nails \the [A] to \the [T].</span>")
-		lock_atom(A, /datum/locking_category/buckle)
-
-	spawn(duration)
-		qdel(src)
-
-
-/obj/effect/overlay/bloodnail/attack_hand(var/mob/user)
-	if (do_after(user,src,15))
-		unstick()
-
-/obj/effect/overlay/bloodnail/proc/unstick()
-	if(stuck_to)
-		unlock_atom(stuck_to)
-	qdel(src)

--- a/code/game/objects/effects/rooting_trap.dm
+++ b/code/game/objects/effects/rooting_trap.dm
@@ -1,0 +1,57 @@
+
+/obj/effect/rooting_trap
+	name = "trap"
+	desc = "How did you get trapped in that? Try resisting."
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "energynet"
+	w_type=NOT_RECYCLABLE
+	anchored = 1
+	density = 0
+	plane = ABOVE_HUMAN_PLANE
+	layer = CLOSED_CURTAIN_LAYER
+	var/atom/stuck_to = null
+	var/duration = 10 SECONDS
+
+/obj/effect/rooting_trap/cultify()
+	return
+
+/obj/effect/rooting_trap/singularity_act()
+	return
+
+/obj/effect/rooting_trap/singularity_pull()
+	return
+
+/obj/effect/rooting_trap/blob_act()
+	return
+
+
+/obj/effect/rooting_trap/Destroy()
+	if(stuck_to)
+		unlock_atom(stuck_to)
+	stuck_to = null
+	..()
+
+/obj/effect/rooting_trap/proc/stick_to(var/atom/A, var/side = null)
+	var/turf/T = get_turf(A)
+
+	if(isliving(A) && !isspace(T))//can't nail people down unless there's a turf to nail them to.
+		stuck_to = A
+		lock_atom(A, /datum/locking_category/buckle)
+
+		spawn(duration)
+			qdel(src)
+
+		return TRUE
+	return FALSE
+
+/obj/effect/rooting_trap/attack_hand(var/mob/user)
+	unstick_attempt()
+
+/obj/effect/rooting_trap/proc/unstick_attempt()
+	if (do_after(user,src,1.5 SECONDS))
+		unstick()
+
+/obj/effect/rooting_trap/proc/unstick()
+	if(stuck_to)
+		unlock_atom(stuck_to)
+	qdel(src)

--- a/code/game/objects/effects/rooting_trap.dm
+++ b/code/game/objects/effects/rooting_trap.dm
@@ -45,9 +45,9 @@
 	return FALSE
 
 /obj/effect/rooting_trap/attack_hand(var/mob/user)
-	unstick_attempt()
+	unstick_attempt(user)
 
-/obj/effect/rooting_trap/proc/unstick_attempt()
+/obj/effect/rooting_trap/proc/unstick_attempt(var/mob/user)
 	if (do_after(user,src,1.5 SECONDS))
 		unstick()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -782,6 +782,8 @@ Thanks.
 	if(!isliving(usr) || usr.special_delayer.blocked())
 		return
 
+	var/turf/T = get_turf(src)
+
 	lazy_invoke_event(/lazy_event/on_resist, list("user" = src))
 
 	delayNextSpecial(10) // Special delay, a cooldown to prevent spamming too much.
@@ -806,7 +808,7 @@ Thanks.
 	//Getting out of someone's inventory.
 	if(istype(src.loc,/obj/item/weapon/holder))
 		var/obj/item/weapon/holder/H = src.loc
-		forceMove(get_turf(src))
+		forceMove(T)
 		if(istype(H.loc, /mob/living))
 			var/mob/living/Location = H.loc
 			Location.drop_from_inventory(H)
@@ -815,7 +817,7 @@ Thanks.
 		return
 	else if(istype(src.loc, /obj/structure/strange_present))
 		var/obj/structure/strange_present/present = src.loc
-		forceMove(get_turf(src))
+		forceMove(T)
 		qdel(present)
 		playsound(src.loc, 'sound/items/poster_ripped.ogg', 100, 1)
 		return
@@ -825,7 +827,7 @@ Thanks.
 		if(do_after(src, src, 2 MINUTES))
 			L.visible_message("<span class='danger'>[L] successfully breaks out of [package]!</span>",\
 							  "<span class='notice'>You successfully break out!</span>")
-			forceMove(get_turf(src))
+			forceMove(T)
 			qdel(package)
 			playsound(src.loc, 'sound/items/poster_ripped.ogg', 100, 1)
 		return
@@ -1230,6 +1232,11 @@ Thanks.
 					else
 						CM.simple_message("<span class='warning'>Your attempt to remove \the [HC] was interrupted.</span>",
 							"<span class='warning'>Your attempt to regain control of your hands was interrupted. Damn it!</span>")
+
+	//unsticking from a rooting trap, such as a sticky web or a blood nail
+	if (istype(L.locked_to, /obj/effect/rooting_trap/))
+		var/obj/effect/overlay/rooting_trap/RT = L.locked_to
+		RT.unstick_attempt()
 
 /mob/living/verb/lay_down()
 	set name = "Rest"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1235,8 +1235,8 @@ Thanks.
 
 	//unsticking from a rooting trap, such as a sticky web or a blood nail
 	if (istype(L.locked_to, /obj/effect/rooting_trap/))
-		var/obj/effect/overlay/rooting_trap/RT = L.locked_to
-		RT.unstick_attempt()
+		var/obj/effect/rooting_trap/RT = L.locked_to
+		RT.unstick_attempt(L)
 
 /mob/living/verb/lay_down()
 	set name = "Rest"

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/effects.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/effects.dm
@@ -181,45 +181,20 @@
 		A.forceMove(src.loc)
 	..()
 
+/////////////////////////////////////SPIDER QUEEN STICKY PROJECTILE TRAP////////////////////////////////
 
 //Spawns on top of mobs hit with the queen's web projectile
-/obj/effect/overlay/stickyweb
+/obj/effect/rooting_trap/stickyweb
 	name = "sticky web"
 	desc = "A mess of sticky strings."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "stickyweb"
-	anchored = 1
-	density = 0
-	plane = ABOVE_HUMAN_PLANE
-	layer = CLOSED_CURTAIN_LAYER
-	var/atom/stuck_to = null
-	var/duration = 10 SECONDS
 
-/obj/effect/overlay/stickyweb/Destroy()
-	if(stuck_to)
-		unlock_atom(stuck_to)
-	stuck_to = null
-	..()
-
-/obj/effect/overlay/stickyweb/proc/stick_to(var/atom/A, var/side = null)
+/obj/effect/rooting_trap/stickyweb/proc/stick_to(var/atom/A, var/side = null)
 	var/turf/T = get_turf(A)
 	playsound(T, 'sound/weapons/hivehand_empty.ogg', 75, 1)
-
-	if(isliving(A) && !isspace(T))//can't nail people down unless there's a turf to nail them to.
-		stuck_to = A
+	. = ..()
+	if (.)
 		visible_message("<span class='warning'>\the sticky ball splatters over \the [A]'s legs, sticking them to \the [T].</span>")
-		lock_atom(A, /datum/locking_category/buckle)
-
-	spawn(duration)
-		qdel(src)
-
-/obj/effect/overlay/stickyweb/attack_hand(var/mob/user)
-	if (do_after(user,src,1.5 SECONDS))
-		unstick()
-
-/obj/effect/overlay/stickyweb/proc/unstick()
-	if(stuck_to)
-		unlock_atom(stuck_to)
-	qdel(src)
 
 #undef SPIDERWEB_BRUTE_DIVISOR

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/effects.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/effects.dm
@@ -190,7 +190,7 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "stickyweb"
 
-/obj/effect/rooting_trap/stickyweb/proc/stick_to(var/atom/A, var/side = null)
+/obj/effect/rooting_trap/stickyweb/stick_to(var/atom/A, var/side = null)
 	var/turf/T = get_turf(A)
 	playsound(T, 'sound/weapons/hivehand_empty.ogg', 75, 1)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
@@ -225,7 +225,7 @@
 		setDensity(FALSE)
 		invisibility = 101
 		kill_count = 0
-		var/obj/effect/overlay/stickyweb/web = new (A.loc)
+		var/obj/effect/rooting_trap/stickyweb/web = new (A.loc)
 		web.stick_to(A)
 		var/mob/living/L = A
 		L.take_overall_damage(damage,0)

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -840,6 +840,7 @@
 #include "code\game\objects\effects\mines.dm"
 #include "code\game\objects\effects\overlays.dm"
 #include "code\game\objects\effects\portals.dm"
+#include "code\game\objects\effects\rooting_trap.dm"
 #include "code\game\objects\effects\step_triggers.dm"
 #include "code\game\objects\effects\trackers.dm"
 #include "code\game\objects\effects\traps.dm"


### PR DESCRIPTION
I also made a parent for both effects since they're basically identical.

:cl:
* bugfix: Players are now properly able to use the resist verb to escape the sticky webs from a Spider Queen's projectile, or a thrown Blood Dagger. Previously players had to click the trap, now both options are available as intended.