### PR TITLE
Wolves are less hungry, take two

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/wolf.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wolf.dm
@@ -296,11 +296,11 @@
 
 		if(health < maxHealth/2)
 			if(nutrition >= WOLF_REGENCOST)
-				health += rand(1,3)
+				health += 3
 				adjust_nutrition(-WOLF_REGENCOST)
 		else
-			if(hunger_status >= WOLF_WELLFED)
-				health += 1
+			if((hunger_status >= WOLF_WELLFED) && (health < maxHealth))
+				health += min(3,maxHealth-health)
 				adjust_nutrition(-WOLF_REGENCOST)
 
 /mob/living/simple_animal/hostile/wolf/proc/handle_hunger()


### PR DESCRIPTION
Fixes wolves spending nutrition on regen while at full health and increases the rate of healing to nutrition so regen does more for its cost.

fixes #29601

:cl:
* bugfix: wolves no longer spend nutrition to regen while at full health
* tweak: wolf regen from 1-3 -> 3 at less than half health and 1 -> 3 while well fed