### PR TITLE
Fixes grey slime extract supply crates coming without locks

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -2058,7 +2058,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/slime_extract/grey
 					)
 	cost = 200
-	containertype = /obj/structure/closet/crate/sci
+	containertype = /obj/structure/closet/crate/secure/scisec
 	containername = "gret slime extract crate"
 	access = list(access_science)
 	group = "Science"


### PR DESCRIPTION
[bugfix]
Can't believe I forgot this.
:cl:
 * bugfix: Grey slime extract supply crates are now fitted the proper kinds of crates with locks, as they should be.