### PR TITLE
RCD window construction/deconstruction

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -46,6 +46,7 @@
 	icon = ourschematic.icon
 	icon_state = ourschematic.icon_state
 	name = ourschematic.name
+	overlays += ourschematic.overlays
 	transform = transform*0.8
 
 /obj/abstract/screen/schematics/Click()
@@ -54,6 +55,7 @@
 
 /obj/abstract/screen/schematics/Destroy()
 	ourschematic = null
+	overlays = list()
 	..()
 
 /obj/abstract/screen/inventory

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -347,7 +347,8 @@
 	/datum/rcd_schematic/decon,
 	/datum/rcd_schematic/con_floors,
 	/datum/rcd_schematic/con_walls,
-	/datum/rcd_schematic/con_airlock
+	/datum/rcd_schematic/con_airlock,
+	/datum/rcd_schematic/con_window,
 	)
 
 /obj/item/device/rcd/mech/attack_self(var/mob/living/user)

--- a/code/modules/RCD/engie.dm
+++ b/code/modules/RCD/engie.dm
@@ -36,7 +36,8 @@
 	/datum/rcd_schematic/decon,
 	/datum/rcd_schematic/con_floors,
 	/datum/rcd_schematic/con_walls,
-	/datum/rcd_schematic/con_airlock/borg
+	/datum/rcd_schematic/con_airlock/borg,
+	/datum/rcd_schematic/con_window/borg,
 	)
 
 /obj/item/device/rcd/matter/engineering/pre_loaded/admin

--- a/code/modules/RCD/engie.dm
+++ b/code/modules/RCD/engie.dm
@@ -4,7 +4,7 @@
 	/datum/rcd_schematic/con_floors,
 	/datum/rcd_schematic/con_walls,
 	/datum/rcd_schematic/con_airlock,
-	/datum/rcd_shematic/con_window,
+	/datum/rcd_schematic/con_window,
 	)
 
 

--- a/code/modules/RCD/engie.dm
+++ b/code/modules/RCD/engie.dm
@@ -3,7 +3,8 @@
 	/datum/rcd_schematic/decon,
 	/datum/rcd_schematic/con_floors,
 	/datum/rcd_schematic/con_walls,
-	/datum/rcd_schematic/con_airlock
+	/datum/rcd_schematic/con_airlock,
+	/datum/rcd_shematic/con_window,
 	)
 
 

--- a/code/modules/RCD/schematic.dm
+++ b/code/modules/RCD/schematic.dm
@@ -7,6 +7,7 @@
 	var/obj/item/device/rcd/master	//Okay all of the vars here are obvious...
 	var/icon
 	var/icon_state
+	var/list/overlays	= list()
 	var/obj/abstract/screen/schematics/ourobj
 	var/datum/selection_schematic/selected
 

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -467,7 +467,7 @@
 
 	playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
 
-	var/obj/effect/spawner/window/W = new selected.build_type(A)
+	new selected.build_type(A)
 
 /datum/selection_schematic
 	var/name			= "Selection"

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -45,7 +45,22 @@
 			playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
 			qdel(D)
 			return 0
+	
+	else if(istype(A,/obj/structure/window))
+		var/obj/structure/window/W = A
+		to_chat(user, "Deconstructing \the [W]...")
+		if(master.delay(user, W, 5 SECONDS))
+			if(master.get_energy(user) < energy_cost)
+				return 1
 
+			playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
+			for(var/obj/structure/grille/G in W.loc)
+				qdel(G)
+			for(var/obj/structure/window/WI in W.loc)
+				if(WI != W)
+					qdel(WI)
+			qdel(W)
+			return 0
 	return 1
 
 /datum/rcd_schematic/con_floors

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -446,7 +446,7 @@
 /datum/rcd_schematic/con_window/Topic(var/href, var/href_list)
 	if(href_list["set_selected"])
 		var/idx = clamp(text2num(href_list["set_selected"]), 1, schematics.len)
-		var/datum/selection_schematic/airlock_schematic/C = schematics[idx]
+		var/datum/selection_schematic/window_schematic/C = schematics[idx]
 
 		selected = C
 

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -389,13 +389,16 @@
 
 /datum/rcd_schematic/con_window
 	name						= "Build window"
-	icon						= 'icons/obj/doors/door.dmi'
-	icon_state					= "door_closed"
+	icon 						= 'icons/obj/window_grille_spawner.dmi'
+	icon_state 					= "window_grille"
 	category					= "Construction"
 	energy_cost					= 2
 
 	var/list/schematics			= list()
 	var/ready
+
+/datum/rcd_schematic/con_window/borg
+	energy_cost					= 20
 
 /datum/rcd_schematic/con_window/show(var/mob/living/user, close = 0)
 	if(!close)
@@ -619,6 +622,8 @@
 /datum/selection_schematic/window_schematic
 	name			= "window"						//Name of the window for the tooltip.
 	build_type		= /obj/effect/spawner/window	//Type of the window.
+	icon = 'icons/obj/window_grille_spawner.dmi'
+	icon_state = "window_grille"
 
 /datum/selection_schematic/window_schematic/northend
 	name			= "\improper north window"

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -624,6 +624,9 @@
 	icon = 'icons/obj/window_grille_spawner.dmi'
 	icon_state = "window_grille"
 
+/datum/selection_schematic/window_schematic/clicked(var/mob/user)
+	master.selected = src
+
 /datum/selection_schematic/window_schematic/northend
 	name			= "\improper north window"
 	build_type	= /obj/effect/spawner/window/northend

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -630,11 +630,11 @@
 	icon_state = "grille"
 
 /datum/selection_schematic/window_schematic/New()
+	overlays += image(icon,icon_state="rwindow",dir=NORTH)
+	overlays += image(icon,icon_state="rwindow",dir=EAST)
+	overlays += image(icon,icon_state="rwindow",dir=SOUTH)
+	overlays += image(icon,icon_state="rwindow",dir=WEST)
 	..()
-	overlays += image(icon,icon_state="window",dir=NORTH)
-	overlays += image(icon,icon_state="window",dir=EAST)
-	overlays += image(icon,icon_state="window",dir=SOUTH)
-	overlays += image(icon,icon_state="window",dir=WEST)
 
 /datum/selection_schematic/window_schematic/Destroy()
 	overlays = list()

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -518,3 +518,124 @@
 	name			= "\improper Glass Mining Airlock"
 	build_type	= /obj/machinery/door/airlock/glass_mining
 	icon			= 'icons/obj/doors/Doorminingglass.dmi'
+
+// ALL THE WINDOW TYPES.
+/datum/selection_schematic/window_schematic
+	name			= "window"						//Name of the window for the tooltip.
+	build_type		= /obj/effect/spawner/window	//Type of the window.
+
+/datum/selection_schematic/window_schematic/northend
+	name			= "\improper north window"
+	build_type	= /obj/effect/spawner/window/northend
+
+/datum/selection_schematic/window_schematic/eastend
+	name			= "\improper east window"
+	build_type	= /obj/effect/spawner/window/eastend
+
+/datum/selection_schematic/window_schematic/southend
+	name			= "\improper south window"
+	build_type	= /obj/effect/spawner/window/southend
+
+/datum/selection_schematic/window_schematic/westend
+	name			= "\improper west window"
+	build_type	= /obj/effect/spawner/window/westend
+
+/datum/selection_schematic/window_schematic/horizontal
+	name			= "\improper horizontal window"
+	build_type	= /obj/effect/spawner/window/horizontal
+
+/datum/selection_schematic/window_schematic/vertical
+	name			= "\improper vertical window"
+	build_type	= /obj/effect/spawner/window/vertical
+
+/datum/selection_schematic/window_schematic/necorner
+	name			= "\improper northeast window"
+	build_type	= /obj/effect/spawner/window/necorner
+
+/datum/selection_schematic/window_schematic/secorner
+	name			= "\improper southeast window"
+	build_type	= /obj/effect/spawner/window/secorner
+
+/datum/selection_schematic/window_schematic/swcorner
+	name			= "\improper southwest window"
+	build_type	= /obj/effect/spawner/window/swcorner
+
+/datum/selection_schematic/window_schematic/nwcorner
+	name			= "\improper northwest window"
+	build_type	= /obj/effect/spawner/window/nwcorner
+
+/datum/selection_schematic/window_schematic/northcap
+	name			= "\improper north window cap"
+	build_type	= /obj/effect/spawner/window/northcap
+
+/datum/selection_schematic/window_schematic/eastcap
+	name			= "\improper east window cap"
+	build_type	= /obj/effect/spawner/window/eastcap
+
+/datum/selection_schematic/window_schematic/southcap
+	name			= "\improper south window cap"
+	build_type	= /obj/effect/spawner/window/southcap
+
+/datum/selection_schematic/window_schematic/westcap
+	name			= "\improper west window cap"
+	build_type	= /obj/effect/spawner/window/westcap
+
+/datum/selection_schematic/window_schematic/full
+	name			= "\improper full window"
+	build_type	= /obj/effect/spawner/window/full
+
+/datum/selection_schematic/window_schematic/full/northend
+	name			= "\improper full north window"
+	build_type	= /obj/effect/spawner/window/full/northend
+
+/datum/selection_schematic/window_schematic/full/eastend
+	name			= "\improper full east window"
+	build_type	= /obj/effect/spawner/window/full/eastend
+
+/datum/selection_schematic/window_schematic/full/southend
+	name			= "\improper full south window"
+	build_type	= /obj/effect/spawner/window/full/southend
+
+/datum/selection_schematic/window_schematic/full/westend
+	name			= "\improper full west window"
+	build_type	= /obj/effect/spawner/window/full/westend
+
+/datum/selection_schematic/window_schematic/full/horizontal
+	name			= "\improper full horizontal window"
+	build_type	= /obj/effect/spawner/window/full/horizontal
+
+/datum/selection_schematic/window_schematic/full/vertical
+	name			= "\improper full vertical window"
+	build_type	= /obj/effect/spawner/window/full/vertical
+
+/datum/selection_schematic/window_schematic/full/necorner
+	name			= "\improper full northeast window"
+	build_type	= /obj/effect/spawner/window/full/necorner
+
+/datum/selection_schematic/window_schematic/full/secorner
+	name			= "\improper full southeast window"
+	build_type	= /obj/effect/spawner/window/full/secorner
+
+/datum/selection_schematic/window_schematic/full/swcorner
+	name			= "\improper full southwest window"
+	build_type	= /obj/effect/spawner/window/full/swcorner
+
+/datum/selection_schematic/window_schematic/full/nwcorner
+	name			= "\improper full northwest window"
+	build_type	= /obj/effect/spawner/window/full/nwcorner
+
+/datum/selection_schematic/window_schematic/full/northcap
+	name			= "\improper full north window cap"
+	build_type	= /obj/effect/spawner/window/full/northcap
+
+/datum/selection_schematic/window_schematic/full/eastcap
+	name			= "\improper full east window cap"
+	build_type	= /obj/effect/spawner/window/full/eastcap
+
+/datum/selection_schematic/window_schematic/full/southcap
+	name			= "\improper full south window cap"
+	build_type	= /obj/effect/spawner/window/full/southcap
+
+/datum/selection_schematic/window_schematic/full/westcap
+	name			= "\improper full west window cap"
+	build_type	= /obj/effect/spawner/window/full/westcap

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -627,6 +627,7 @@
 	build_type		= /obj/effect/spawner/window	//Type of the window.
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "grille"
+	overlays = list(image(icon="icons/obj/structures.dmi",icon_state="window")
 
 /datum/selection_schematic/window_schematic/clicked(var/mob/user)
 	master.selected = src

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -46,8 +46,10 @@
 			qdel(D)
 			return 0
 	
-	else if(istype(A,/obj/structure/window) && !istype(A,/obj/structure/window/reinforced/plasma))
+	else if(istype(A,/obj/structure/window))
 		var/obj/structure/window/W = A
+		if((is_type_in_list(W, list(/obj/structure/window/plasma,/obj/structure/window/reinforced/plasma,/obj/structure/window/full/plasma,/obj/structure/window/full/reinforced/plasma)) && !can_r_wall))
+			return "it cannot deconstruct plasma glass!"
 		to_chat(user, "Deconstructing \the [W]...")
 		if(master.delay(user, W, 5 SECONDS))
 			if(master.get_energy(user) < energy_cost)
@@ -57,7 +59,9 @@
 			for(var/obj/structure/grille/G in W.loc)
 				qdel(G)
 			for(var/obj/structure/window/WI in W.loc)
-				if(WI != W && !istype(WI,/obj/structure/window/reinforced/plasma))
+				if(is_type_in_list(W, list(/obj/structure/window/plasma,/obj/structure/window/reinforced/plasma,/obj/structure/window/full/plasma,/obj/structure/window/full/reinforced/plasma)) && !can_r_wall)
+					continue
+				if(WI != W)
 					qdel(WI)
 			qdel(W)
 			return 0

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -628,12 +628,11 @@
 	build_type		= /obj/effect/spawner/window	//Type of the window.
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "grille"
+	var/list/dirs = list(NORTH,EAST,WEST,SOUTH)
 
 /datum/selection_schematic/window_schematic/New()
-	overlays += image(icon,icon_state="rwindow",dir=NORTH)
-	overlays += image(icon,icon_state="rwindow",dir=EAST)
-	overlays += image(icon,icon_state="rwindow",dir=SOUTH)
-	overlays += image(icon,icon_state="rwindow",dir=WEST)
+	for(var/d in dirs)
+		overlays += image(icon,icon_state="rwindow",dir=d)
 	..()
 
 /datum/selection_schematic/window_schematic/Destroy()
@@ -646,115 +645,147 @@
 /datum/selection_schematic/window_schematic/northend
 	name			= "\improper north window"
 	build_type	= /obj/effect/spawner/window/northend
+	dirs = list(NORTH)
 
 /datum/selection_schematic/window_schematic/eastend
 	name			= "\improper east window"
 	build_type	= /obj/effect/spawner/window/eastend
+	dirs = list(EAST)
 
 /datum/selection_schematic/window_schematic/southend
 	name			= "\improper south window"
 	build_type	= /obj/effect/spawner/window/southend
+	dirs = list(SOUTH)
 
 /datum/selection_schematic/window_schematic/westend
 	name			= "\improper west window"
 	build_type	= /obj/effect/spawner/window/westend
+	dirs = list(WEST)
 
 /datum/selection_schematic/window_schematic/horizontal
 	name			= "\improper horizontal window"
 	build_type	= /obj/effect/spawner/window/horizontal
+	dirs = list(NORTH,SOUTH)
 
 /datum/selection_schematic/window_schematic/vertical
 	name			= "\improper vertical window"
 	build_type	= /obj/effect/spawner/window/vertical
+	dirs = list(EAST,WEST)
 
 /datum/selection_schematic/window_schematic/necorner
 	name			= "\improper northeast window"
 	build_type	= /obj/effect/spawner/window/necorner
+	dirs = list(NORTH,EAST)
 
 /datum/selection_schematic/window_schematic/secorner
 	name			= "\improper southeast window"
 	build_type	= /obj/effect/spawner/window/secorner
+	dirs = list(EAST,SOUTH)
 
 /datum/selection_schematic/window_schematic/swcorner
 	name			= "\improper southwest window"
 	build_type	= /obj/effect/spawner/window/swcorner
+	dirs = list(WEST,SOUTH)
 
 /datum/selection_schematic/window_schematic/nwcorner
 	name			= "\improper northwest window"
 	build_type	= /obj/effect/spawner/window/nwcorner
+	dirs = list(NORTH,WEST)
 
 /datum/selection_schematic/window_schematic/northcap
 	name			= "\improper north window cap"
 	build_type	= /obj/effect/spawner/window/northcap
+	dirs = list(NORTH,EAST,WEST)
 
 /datum/selection_schematic/window_schematic/eastcap
 	name			= "\improper east window cap"
 	build_type	= /obj/effect/spawner/window/eastcap
+	dirs = list(NORTH,EAST,SOUTH)
 
 /datum/selection_schematic/window_schematic/southcap
 	name			= "\improper south window cap"
 	build_type	= /obj/effect/spawner/window/southcap
+	dirs = list(EAST,WEST,SOUTH)
 
 /datum/selection_schematic/window_schematic/westcap
 	name			= "\improper west window cap"
 	build_type	= /obj/effect/spawner/window/westcap
+	dirs = list(NORTH,WEST,SOUTH)
 
 /datum/selection_schematic/window_schematic/full
 	name			= "\improper full window"
 	build_type	= /obj/effect/spawner/window/full
 
+/datum/selection_schematic/window_schematic/full/New()
+	overlays += image(icon,icon_state="rwindow0")
+	..()
+
 /datum/selection_schematic/window_schematic/full/northend
 	name			= "\improper full north window"
 	build_type	= /obj/effect/spawner/window/full/northend
+	dirs = list(NORTH)
 
 /datum/selection_schematic/window_schematic/full/eastend
 	name			= "\improper full east window"
 	build_type	= /obj/effect/spawner/window/full/eastend
+	dirs = list(EAST)
 
 /datum/selection_schematic/window_schematic/full/southend
 	name			= "\improper full south window"
 	build_type	= /obj/effect/spawner/window/full/southend
+	dirs = list(SOUTH)
 
 /datum/selection_schematic/window_schematic/full/westend
 	name			= "\improper full west window"
 	build_type	= /obj/effect/spawner/window/full/westend
+	dirs = list(WEST)
 
 /datum/selection_schematic/window_schematic/full/horizontal
 	name			= "\improper full horizontal window"
 	build_type	= /obj/effect/spawner/window/full/horizontal
+	dirs = list(NORTH,SOUTH)
 
 /datum/selection_schematic/window_schematic/full/vertical
 	name			= "\improper full vertical window"
 	build_type	= /obj/effect/spawner/window/full/vertical
+	dirs = list(EAST,WEST)
 
 /datum/selection_schematic/window_schematic/full/necorner
 	name			= "\improper full northeast window"
 	build_type	= /obj/effect/spawner/window/full/necorner
+	dirs = list(NORTH,EAST)
 
 /datum/selection_schematic/window_schematic/full/secorner
 	name			= "\improper full southeast window"
 	build_type	= /obj/effect/spawner/window/full/secorner
+	dirs = list(EAST,SOUTH)
 
 /datum/selection_schematic/window_schematic/full/swcorner
 	name			= "\improper full southwest window"
 	build_type	= /obj/effect/spawner/window/full/swcorner
+	dirs = list(WEST,SOUTH)
 
 /datum/selection_schematic/window_schematic/full/nwcorner
 	name			= "\improper full northwest window"
 	build_type	= /obj/effect/spawner/window/full/nwcorner
+	dirs = list(NORTH,WEST)
 
 /datum/selection_schematic/window_schematic/full/northcap
 	name			= "\improper full north window cap"
 	build_type	= /obj/effect/spawner/window/full/northcap
+	dirs = list(NORTH,EAST,WEST)
 
 /datum/selection_schematic/window_schematic/full/eastcap
 	name			= "\improper full east window cap"
 	build_type	= /obj/effect/spawner/window/full/eastcap
+	dirs = list(NORTH,EAST,SOUTH)
 
 /datum/selection_schematic/window_schematic/full/southcap
 	name			= "\improper full south window cap"
 	build_type	= /obj/effect/spawner/window/full/southcap
+	dirs = list(EAST,WEST,SOUTH)
 
 /datum/selection_schematic/window_schematic/full/westcap
 	name			= "\improper full west window cap"
 	build_type	= /obj/effect/spawner/window/full/westcap
+	dirs = list(NORTH,WEST,SOUTH)

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -48,7 +48,7 @@
 	
 	else if(istype(A,/obj/structure/window))
 		var/obj/structure/window/W = A
-		if((is_type_in_list(W, list(/obj/structure/window/plasma,/obj/structure/window/reinforced/plasma,/obj/structure/window/full/plasma,/obj/structure/window/full/reinforced/plasma)) && !can_r_wall))
+		if(is_type_in_list(W, list(/obj/structure/window/plasma,/obj/structure/window/reinforced/plasma,/obj/structure/window/full/plasma,/obj/structure/window/full/reinforced/plasma)) && !can_r_wall)
 			return "it cannot deconstruct plasma glass!"
 		to_chat(user, "Deconstructing \the [W]...")
 		if(master.delay(user, W, 5 SECONDS))

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -627,7 +627,7 @@
 	build_type		= /obj/effect/spawner/window	//Type of the window.
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "grille"
-	overlays = list(image(icon="icons/obj/structures.dmi",icon_state="window")
+	overlays = list(image(icon=src.icon,icon_state="window",dir=NORTH,image(icon=src.icon,icon_state="window",dir=EAST,image(icon=src.icon,icon_state="window",dir=SOUTH,image(icon=src.icon,icon_state="window",dir=WEST)
 
 /datum/selection_schematic/window_schematic/clicked(var/mob/user)
 	master.selected = src

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -478,6 +478,7 @@
 	var/build_type
 	var/icon_state
 	var/icon
+	var/list/overlays = list()
 	var/obj/abstract/screen/ourobj
 	var/datum/rcd_schematic/master
 
@@ -627,7 +628,6 @@
 	build_type		= /obj/effect/spawner/window	//Type of the window.
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "grille"
-	overlays = list(image(icon=src.icon,icon_state="window",dir=NORTH,image(icon=src.icon,icon_state="window",dir=EAST,image(icon=src.icon,icon_state="window",dir=SOUTH,image(icon=src.icon,icon_state="window",dir=WEST)
 
 /datum/selection_schematic/window_schematic/clicked(var/mob/user)
 	master.selected = src

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -449,7 +449,6 @@
 		var/datum/selection_schematic/airlock_schematic/C = schematics[idx]
 
 		selected = C
-		selected_name = C.name	//Reset the name.
 
 		master.update_options_menu()
 		return 1

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -478,7 +478,7 @@
 	var/build_type
 	var/icon_state
 	var/icon
-	var/list/overlays = list()
+	var/list/overlays 	= list()
 	var/obj/abstract/screen/ourobj
 	var/datum/rcd_schematic/master
 
@@ -629,6 +629,17 @@
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "grille"
 
+/datum/selection_schematic/window_schematic/New()
+	..()
+	overlays += image(icon,icon_state="window",dir=NORTH)
+	overlays += image(icon,icon_state="window",dir=EAST)
+	overlays += image(icon,icon_state="window",dir=SOUTH)
+	overlays += image(icon,icon_state="window",dir=WEST)
+
+/datum/selection_schematic/window_schematic/Destroy()
+	overlays = list()
+	..()
+	
 /datum/selection_schematic/window_schematic/clicked(var/mob/user)
 	master.selected = src
 

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -46,7 +46,7 @@
 			qdel(D)
 			return 0
 	
-	else if(istype(A,/obj/structure/window))
+	else if(istype(A,/obj/structure/window) && !istype(A,/obj/structure/window/reinforced/plasma))
 		var/obj/structure/window/W = A
 		to_chat(user, "Deconstructing \the [W]...")
 		if(master.delay(user, W, 5 SECONDS))
@@ -57,7 +57,7 @@
 			for(var/obj/structure/grille/G in W.loc)
 				qdel(G)
 			for(var/obj/structure/window/WI in W.loc)
-				if(WI != W)
+				if(WI != W && !istype(WI,/obj/structure/window/reinforced/plasma))
 					qdel(WI)
 			qdel(W)
 			return 0
@@ -621,8 +621,8 @@
 /datum/selection_schematic/window_schematic
 	name			= "window"						//Name of the window for the tooltip.
 	build_type		= /obj/effect/spawner/window	//Type of the window.
-	icon = 'icons/obj/window_grille_spawner.dmi'
-	icon_state = "window_grille"
+	icon = 'icons/obj/structures.dmi'
+	icon_state = "grille"
 
 /datum/selection_schematic/window_schematic/clicked(var/mob/user)
 	master.selected = src

--- a/code/modules/RCD/schematics/rcd_window_spawner.dm
+++ b/code/modules/RCD/schematics/rcd_window_spawner.dm
@@ -13,7 +13,11 @@
         if(!locate(/obj/structure/grille) in loc)
             new /obj/structure/grille(T)
         for(var/direction in dirs)
-            if(locate(/obj/structure/window/reinforced) in loc)
+            var/windowhere = FALSE
+            for(var/obj/structure/window/reinforced/R in loc)
+                if(R.dir == direction)
+                    windowhere = TRUE
+            if(windowhere)
                 continue
             var/obj/structure/window/reinforced/new_window = new /obj/structure/window/reinforced(loc)
             new_window.dir = direction

--- a/code/modules/RCD/schematics/rcd_window_spawner.dm
+++ b/code/modules/RCD/schematics/rcd_window_spawner.dm
@@ -1,15 +1,15 @@
 /obj/effect/spawner/window
 	name = "window spawner"
 	var/full = FALSE
-    var/list/dirs = list(NORTH,WEST.SOUTH.EAST)
+	var/list/dirs = list(NORTH,WEST.SOUTH,EAST)
 
 /obj/effect/spawner/window/New()
 	..()
 	spawn_window()
 
 /obj/effect/spawner/window/proc/spawn_window()
-	var/turf/T = get_turf(src)
-	if(T && !istype(T,/turf/simulated/wall) && !istype(T,/turf/unsimulated/wall))
+    var/turf/T = get_turf(src)
+    if(T && !istype(T,/turf/simulated/wall) && !istype(T,/turf/unsimulated/wall))
         if(!locate(/obj/structure/grille) in loc)
             new /obj/structure/grille(T)
         for(var/direction in dirs)
@@ -21,7 +21,7 @@
         if(full && !locate(/obj/structure/window/full/reinforced) in loc)
             var/obj/structure/window/reinforced/new_fullwindow = new /obj/structure/window/full/reinforced(loc)
             new_fullwindow.update_nearby_tiles()
-	qdel(src)
+    qdel(src)
 
 /obj/effect/spawner/window/northend
     dirs = list(NORTH)

--- a/code/modules/RCD/schematics/rcd_window_spawner.dm
+++ b/code/modules/RCD/schematics/rcd_window_spawner.dm
@@ -1,7 +1,7 @@
 /obj/effect/spawner/window
 	name = "window spawner"
 	var/full = FALSE
-	var/list/dirs = list(NORTH,WEST.SOUTH,EAST)
+	var/list/dirs = list(NORTH,WEST,SOUTH,EAST)
 
 /obj/effect/spawner/window/New()
 	..()

--- a/code/modules/RCD/schematics/rcd_window_spawner.dm
+++ b/code/modules/RCD/schematics/rcd_window_spawner.dm
@@ -5,7 +5,7 @@
 
 /obj/effect/spawner/window/New()
 	..()
-	spawn_winodw()
+	spawn_window()
 
 /obj/effect/spawner/window/proc/spawn_window()
 	var/turf/T = get_turf(src)

--- a/code/modules/RCD/schematics/rcd_window_spawner.dm
+++ b/code/modules/RCD/schematics/rcd_window_spawner.dm
@@ -1,0 +1,111 @@
+/obj/effect/spawner/window
+	name = "window spawner"
+	var/full = FALSE
+    var/list/dirs = list(NORTH,WEST.SOUTH.EAST)
+
+/obj/effect/spawner/window/New()
+	..()
+	spawn_winodw()
+
+/obj/effect/spawner/window/proc/spawn_window()
+	var/turf/T = get_turf(src)
+	if(T && !istype(T,/turf/simulated/wall) && !istype(T,/turf/unsimulated/wall))
+        if(!locate(/obj/structure/grille) in loc)
+            new /obj/structure/grille(T)
+        for(var/direction in dirs)
+            if(locate(/obj/structure/window/reinforced) in loc)
+                continue
+            var/obj/structure/window/reinforced/new_window = new /obj/structure/window/reinforced(loc)
+            new_window.dir = direction
+            new_window.update_nearby_tiles()
+        if(full && !locate(/obj/structure/window/full/reinforced) in loc)
+            var/obj/structure/window/reinforced/new_fullwindow = new /obj/structure/window/full/reinforced(loc)
+            new_fullwindow.update_nearby_tiles()
+	qdel(src)
+
+/obj/effect/spawner/window/northend
+    dirs = list(NORTH)
+
+/obj/effect/spawner/window/westend
+    dirs = list(WEST)
+
+/obj/effect/spawner/window/southend
+    dirs = list(SOUTH)
+
+/obj/effect/spawner/window/eastend
+    dirs = list(EAST)
+
+/obj/effect/spawner/window/horizontal
+    dirs = list(NORTH,SOUTH)
+
+/obj/effect/spawner/window/vertical
+    dirs = list(WEST,EAST)
+
+/obj/effect/spawner/window/nwcorner
+    dirs = list(NORTH,WEST)
+
+/obj/effect/spawner/window/swcorner
+    dirs = list(SOUTH,WEST)
+
+/obj/effect/spawner/window/secorner
+    dirs = list(SOUTH,EAST)
+
+/obj/effect/spawner/window/necorner
+    dirs = list(NORTH,EAST)
+
+/obj/effect/spawner/window/northcap
+    dirs = list(NORTH,EAST,WEST)
+
+/obj/effect/spawner/window/westcap
+    dirs = list(WEST,NORTH,SOUTH)
+
+/obj/effect/spawner/window/southcap
+    dirs = list(SOUTH,EAST,WEST)
+
+/obj/effect/spawner/window/eastcap
+    dirs = list(EAST,NORTH,SOUTH)
+
+/obj/effect/spawner/window/full
+    full = TRUE
+
+/obj/effect/spawner/window/full/northend
+    dirs = list(NORTH)
+
+/obj/effect/spawner/window/full/westend
+    dirs = list(WEST)
+
+/obj/effect/spawner/window/full/southend
+    dirs = list(SOUTH)
+
+/obj/effect/spawner/window/full/eastend
+    dirs = list(EAST)
+
+/obj/effect/spawner/window/full/horizontal
+    dirs = list(NORTH,SOUTH)
+
+/obj/effect/spawner/window/full/vertical
+    dirs = list(WEST,EAST)
+
+/obj/effect/spawner/window/full/nwcorner
+    dirs = list(NORTH,WEST)
+
+/obj/effect/spawner/window/full/swcorner
+    dirs = list(SOUTH,WEST)
+
+/obj/effect/spawner/window/full/secorner
+    dirs = list(SOUTH,EAST)
+
+/obj/effect/spawner/window/full/necorner
+    dirs = list(NORTH,EAST)
+
+/obj/effect/spawner/window/full/northcap
+    dirs = list(NORTH,EAST,WEST)
+
+/obj/effect/spawner/window/full/westcap
+    dirs = list(WEST,NORTH,SOUTH)
+
+/obj/effect/spawner/window/full/southcap
+    dirs = list(SOUTH,EAST,WEST)
+
+/obj/effect/spawner/window/full/eastcap
+    dirs = list(EAST,NORTH,SOUTH)

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2263,6 +2263,7 @@
 #include "code\modules\RCD\schematics\engi.dm"
 #include "code\modules\RCD\schematics\pipe.dm"
 #include "code\modules\RCD\schematics\service.dm"
+#include "code\modules\RCD\schematics\rcd_window_spawner.dm"
 #include "code\modules\RCD\schematics\test.dm"
 #include "code\modules\RCD\schematics\tile.dm"
 #include "code\modules\reagents\Chemistry-Colours.dm"


### PR DESCRIPTION
[tested][content][qol]
![output](https://user-images.githubusercontent.com/57303506/120109523-afc76180-c161-11eb-9b49-667a2af8498c.gif)
Does not allow deconstruction of plasma windows, 2 matter units per window (subject to change)
Applies for mech/borg ones too.
:cl:
 * rscadd: All RCDs are now equipped with modules to transform compressed matter into windows and deconstruct them, unless made of plasma.