### PR TITLE
Health Analyzer Heat Warning

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -159,7 +159,7 @@ proc/healthanalyze(mob/living/M as mob, mob/living/user as mob, var/mode = 0, va
 			to_chat(user, {"<span class='notice'>Analyzing Results for the floor:<br>Overall Status: Healthy</span>
 Key: <span class='notice'>Suffocation</span>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<span class='red'>Brute</span>
 Damage Specifics: <span class='notice'>0</span> - <font color='green'>0</font> - <font color='#FFA500'>0</font> - <span class='red'>0</span>
-[(M.undergoing_hypothermia()) ?  "<span class='warning'>" : "<span class='notice'>"]Body Temperature: ???&deg;C (???&deg;F)</span>
+[(M.undergoing_hypothermia() || M.undergoing_hyperthermia()) ?  "<span class='warning'>" : "<span class='notice'>"]Body Temperature: ???&deg;C (???&deg;F)</span>
 <span class='notice'>Localized Damage, Brute/Burn:</span>
 <span class='notice'>No limb damage detected.</span>
 Blood Level Unknown: ???% ???cl
@@ -183,7 +183,7 @@ Subject's pulse: ??? BPM"})
 		return message
 	message += "<br>Key: <span class='notice'>Suffocation</span>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<span class='red'>Brute</span>"
 	message += "<br>Damage Specifics: <span class='notice'>[OX]</span> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <span class='red'>[BR]</span>"
-	message += "<br>[(M.undergoing_hypothermia()) ?  "<span class='warning'>" : "<span class='notice'>"]Body Temperature: [round(M.bodytemperature-T0C,0.1)]&deg;C ([round(M.bodytemperature*1.8-459.67,0.1)]&deg;F)</span>"
+	message += "<br>[(M.undergoing_hypothermia() || M.undergoing_hyperthermia()) ?  "<span class='warning'>" : "<span class='notice'>"]Body Temperature: [round(M.bodytemperature-T0C,0.1)]&deg;C ([round(M.bodytemperature*1.8-459.67,0.1)]&deg;F)</span>"
 	if(M.tod && M.isDead())
 		message += "<br><span class='notice'>Time of Death: [M.tod]</span>"
 	if(istype(M, /mob/living/carbon/human) && mode)

--- a/code/modules/mob/living/handle_hyperthermia.dm
+++ b/code/modules/mob/living/handle_hyperthermia.dm
@@ -1,0 +1,5 @@
+//there is no real system for hyperthermia and I don't have any plans to make one, this is just a stub so I can check if someone is too hot from /mob/living/, might be better placed in handle_hypothermia or something
+/mob/living/proc/undergoing_hyperthermia()
+	return FALSE
+/mob/living/carbon/human/undergoing_hyperthermia()
+	return bodytemperature > species.heat_level_1

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1742,6 +1742,7 @@
 #include "code\modules\mob\living\death.dm"
 #include "code\modules\mob\living\default_language.dm"
 #include "code\modules\mob\living\emote.dm"
+#include "code\modules\mob\living\handle_hyperthermia.dm"
 #include "code\modules\mob\living\handle_hypothermia.dm"
 #include "code\modules\mob\living\helper_procs.dm"
 #include "code\modules\mob\living\holders.dm"


### PR DESCRIPTION
Let's try this again, again. I've got to figure it out eventually.
The temperature reading turns red if the target is too hot, it already did this when they were too cold.
:cl:
 * rscadd: Health analyzers highlight their heat reading in red if the target is too hot.