### PR TITLE
Windoors can now be hit/worked on by basic tools.

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -248,7 +248,7 @@
 	visible_message("<span class='warning'>\The [M.name] [M.attacktext] against \the [name].</span>", 1)
 	take_damage(M.melee_damage_upper)
 
-/obj/machinery/door/window/attackby(obj/item/weapon/I, mob/living/user)
+/obj/machinery/door/window/attackby(obj/item/I, mob/living/user)
 	// Make emagged/open doors able to be deconstructed
 	if(!density && operating != 1 && iscrowbar(I))
 		user.visible_message("[user] is removing \the [electronics.name] from \the [name].", "You start to remove \the [electronics.name] from \the [name].")
@@ -287,7 +287,7 @@
 		return
 
 	//If it's a weapon, smash windoor. Unless it's an id card, agent card, ect.. then ignore it (Cards really shouldnt damage a door anyway)
-	if(density && istype(I, /obj/item/weapon) && !istype(I, /obj/item/weapon/card))
+	if(density && istype(I, /obj/item) && !istype(I, /obj/item/weapon/card))
 		var/aforce = I.force
 		user.do_attack_animation(src, I)
 		user.delayNextAttack(8)


### PR DESCRIPTION
[bugfix]
Take your meds window hitters.
_Surely there won't be any other cases like this in the future due to the tool repathing._
Resolves #29486

:cl:
 * bugfix: You can now use/work/hit windoors with basic tools again.