### PR TITLE
Fixes Amorphous Mask interaction with Wraiths

### DIFF
--- a/code/modules/clothing/masks/transmog.dm
+++ b/code/modules/clothing/masks/transmog.dm
@@ -127,12 +127,12 @@
 	desc = "It appears to be modeled after a human."
 	target_type = /mob/living/carbon/human
 	icon_state = "human_mask"
-	
+
 /obj/item/clothing/mask/morphing/goat
 	name = "mask of the goat"
 	desc = "It appears to be modeled after a goat."
 	target_type = /mob/living/simple_animal/hostile/retaliate/goat
-	icon_state = "goat_mask"	
+	icon_state = "goat_mask"
 
 /obj/item/clothing/mask/morphing/amorphous
 	name = "amorphous mask"
@@ -143,7 +143,7 @@
 	..()
 	color = rgb(rand(0,255),rand(0,255),rand(0,255))
 	//Remove cockatrices because they're somewhat OP when player controlled
-	target_type = pick(existing_typesof(/mob/living/simple_animal) - (existing_typesof_list(blacklisted_mobs) + existing_typesof_list(boss_mobs)))
+	target_type = pick(existing_typesof(/mob/living/simple_animal) - (existing_typesof_list(blacklisted_mobs) + existing_typesof_list(boss_mobs) + /mob/living/simple_animal/scp_173 + existing_typesof(/mob/living/component)))
 /obj/item/clothing/mask/morphing/ghost
 	name = "mask of the phantom"
 	desc = "It appears to be modeled after a ghost. It looks as though it might disappear at any moment."

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -77,6 +77,9 @@
 
 	sleep(duration)
 
+	if (target.gcDestroyed)
+		return
+
 	//Begin unjaunting
 	mobloc = get_turf(target)
 	if(mist)
@@ -86,9 +89,12 @@
 	target.delayNextMove(25)
 	target.dir = SOUTH
 	sleep(20)
+	if (target.gcDestroyed)
+		return
 	anim(location = mobloc, a_icon = 'icons/mob/mob.dmi', flick_anim = exitanim, direction = target.dir, name = target.name,lay = target.layer+1,plane = target.plane)
 	sleep(5)
-
+	if (target.gcDestroyed)
+		return
 	//Forcemove him onto the tile and make him visible and vulnerable
 	target.forceMove(mobloc)
 	target.invisibility = 0


### PR DESCRIPTION
Fixes #17358
Fixes #21318

:cl:
* bugfix: Fixed mindless Wraiths appearing if you removed an amorphous mask that turns you into a Wraith when reaching the end of an Ethereal Jaunt.