### PR TITLE
Adds consistency to crab killing with scissors.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -45,8 +45,8 @@
 	response_harm   = "stomps"
 
 //LOOK AT THIS - ..()??
-/mob/living/simple_animal/crab/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if(O.is_wirecutter(user))
+/mob/living/simple_animal/crab/attackby(obj/item/O, mob/user)
+	if(O.is_wirecutter(user) || istype(O, /obj/item/weapon/pocket_mirror/scissors))
 		if(stat == DEAD)
 			return ..()
 		if(prob(50))

--- a/code/modules/mob/living/simple_animal/hostile/crab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/crab.dm
@@ -17,8 +17,16 @@
 	maxHealth = 300//So they don't die as quickly
 	health = 300
 
-
 	melee_damage_lower = 10
 	melee_damage_upper = 15
 	attacktext = "snips"
 	attack_sound = 'sound/weapons/toolhit.ogg'
+
+/mob/living/simple_animal/hostile/crab/attackby(obj/item/O, mob/user)
+	if(O.is_wirecutter(user) || istype(O, /obj/item/weapon/pocket_mirror/scissors))
+		if(stat == DEAD)
+			return ..()
+		if(prob(50))
+			to_chat(user, "<span class='danger'>This kills the megamadcrab.</span>")
+			health -= 300
+			death()

--- a/code/modules/mob/living/simple_animal/hostile/crab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/crab.dm
@@ -23,10 +23,10 @@
 	attack_sound = 'sound/weapons/toolhit.ogg'
 
 /mob/living/simple_animal/hostile/crab/attackby(obj/item/O, mob/user)
-	if(O.is_wirecutter(user) || istype(O, /obj/item/weapon/pocket_mirror/scissors))
+	if(istype(O, /obj/item/weapon/pocket_mirror/scissors))
 		if(stat == DEAD)
 			return ..()
 		if(prob(50))
-			to_chat(user, "<span class='danger'>This kills the megamadcrab.</span>")
+			to_chat(user, "<span class='danger'>This kills the [name].</span>")
 			health -= 300
 			death()


### PR DESCRIPTION
[consistency] [hotfix]
Fixes a CRITICAL oversight in the recent scissors PR. Where they forgot to touch them killing crabs.
Alongside that is adding consistent behavior to madcrabs since the pathing for them changes and didn't properly inherit the feature. ONLY ACTUAL SCISSORS APPLY, WIRECUTTERS DO NOT WORK FOR MEGAMADS.

:cl:
 * bugfix: Scissors will now kill the crab. Megamads also properly inherit the feature.