### PR TITLE
Gives plastic to derelict MoMMIs. 

### DIFF
--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -63,7 +63,8 @@
 							 "gold" = /obj/item/stack/sheet/mineral/gold,
 							 "diamond" = /obj/item/stack/sheet/mineral/diamond,
 							 "plasma" = /obj/item/stack/sheet/mineral/plasma,
-							 "uranium" = /obj/item/stack/sheet/mineral/uranium)
+							 "uranium" = /obj/item/stack/sheet/mineral/uranium,
+							 "plastic" = /obj/item/stack/sheet/mineral/plastic)
 
 /obj/item/device/material_synth/update_icon()
 	icon_state = "mat_synth[mode ? "on" : "off"]"


### PR DESCRIPTION
Mass production of machinery and items via mechanics is a great streamline to repairing the station, but derelict MoMMIs can't use the machinery due to lack of plastic.
The main argument against giving plastic to derelict MoMMIs was that they could build a teleporter with it, but the derelict is mapped with a teleporter anyway. Teleporters can't teleport derelict MoMMIs if they're currently targeting a beacon outside the derelict's Z-level so there's that too.
Closes #11454
:cl:
 * rscadd: Adds plastic to the derelict MoMMI Material Synth. 