### PR TITLE
Fixes one consistency issue and one gramatical error.

### DIFF
--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -72,7 +72,7 @@
 	theme = "endgame"
 
 /datum/command_alert/xenomorph_station_nuke/announce()
-	message = "Hostile lifeforms are continuing to spread unchecked throughout [station_name()], total quarantine failure is now possibile. As such, Directive 7-12 has now been authorized."
+	message = "Hostile lifeforms are continuing to spread unchecked throughout [station_name()], total quarantine failure is now possible. As such, Directive 7-12 has now been authorized."
 	..()
 
 /datum/command_alert/xenomorph_station_unlock
@@ -126,7 +126,7 @@
 	theme = "endgame"
 
 /datum/command_alert/biohazard_station_nuke/announce()
-	message = "Biohazard outbreak containment status reaching critical mass, total quarantine failure is now possibile. As such, Directive 7-12 has now been authorized for [station_name()]."
+	message = "Biohazard outbreak containment status reaching critical mass, total quarantine failure is now possible. As such, Directive 7-12 has now been authorized for [station_name()]."
 	..()
 
 /datum/command_alert/biohazard_station_unlock

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -104,7 +104,7 @@
 			max_number = 2
 		if(VERM_GREMTIDE)
 			spawn_types = /mob/living/simple_animal/hostile/gremlin/greytide
-			vermstring = "greymlins"
+			vermstring = "gremlin assistants"
 			max_number = 3
 		if(VERM_CRABS)
 			spawn_types = list(/mob/living/simple_animal/crab, /mob/living/simple_animal/crab/kickstool, /mob/living/simple_animal/crab/snowy)

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -104,7 +104,7 @@
 			max_number = 2
 		if(VERM_GREMTIDE)
 			spawn_types = /mob/living/simple_animal/hostile/gremlin/greytide
-			vermstring = "gremlin assistants"
+			vermstring = "greymlins"
 			max_number = 3
 		if(VERM_CRABS)
 			spawn_types = list(/mob/living/simple_animal/crab, /mob/living/simple_animal/crab/kickstool, /mob/living/simple_animal/crab/snowy)


### PR DESCRIPTION
[consistency] [grammar]
Closes #29661
Closes #29663
:cl:
 * spellcheck: Fixes the nuke option command alert against blob/benos saying "possibile" instead of "possible".
 * tweak: Changes the greymlin vermin text from "gremlin assistant" to "greymlin".