### PR TITLE
Alt Title Antag Protection/Restriction Fix

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -279,14 +279,14 @@
 			candidates.Remove(P)
 			b1++//we only count banned ones if they actually wanted to play the role
 			continue
-		if ((protected_from_jobs.len > 0) && (P.mind.assigned_role && P.mind.assigned_role in protected_from_jobs) || (P.mind.role_alt_title && P.mind.role_alt_title in protected_from_jobs))
+		if ((protected_from_jobs.len > 0) && (P.mind.assigned_role && (P.mind.assigned_role in protected_from_jobs)) || (P.mind.role_alt_title && (P.mind.role_alt_title in protected_from_jobs)))
 			var/probability = initial(role_category.protected_traitor_prob)
 			if (prob(probability))
 				candidates.Remove(P)
 				c1++
 			c++
 			continue
-		if ((restricted_from_jobs.len > 0) && (P.mind.assigned_role && P.mind.assigned_role in restricted_from_jobs) || (P.mind.role_alt_title && P.mind.role_alt_title in restricted_from_jobs))//does their job allow for it?
+		if ((restricted_from_jobs.len > 0) && (P.mind.assigned_role && (P.mind.assigned_role in restricted_from_jobs)) || (P.mind.role_alt_title && (P.mind.role_alt_title in restricted_from_jobs)))//does their job allow for it?
 			candidates.Remove(P)
 			d++
 			continue
@@ -311,12 +311,12 @@
 		if (!P.client.desires_role(role_id) || jobban_isbanned(P, role_id) || isantagbanned(P) || (role_category_override && jobban_isbanned(P, role_category_override)))//are they willing and not antag-banned?
 			candidates.Remove(P)
 			continue
-		if ((P.mind.assigned_role && P.mind.assigned_role in protected_from_jobs) || (P.mind.role_alt_title && P.mind.role_alt_title in protected_from_jobs))
+		if ((P.mind.assigned_role && (P.mind.assigned_role in protected_from_jobs)) || (P.mind.role_alt_title && (P.mind.role_alt_title in protected_from_jobs)))
 			var/probability = initial(role_category.protected_traitor_prob)
 			if (prob(probability))
 				candidates.Remove(P)
 			continue
-		if ((P.mind.assigned_role && P.mind.assigned_role in restricted_from_jobs) || (P.mind.role_alt_title && P.mind.role_alt_title in restricted_from_jobs))//does their job allow for it?
+		if ((P.mind.assigned_role && (P.mind.assigned_role in restricted_from_jobs)) || (P.mind.role_alt_title && (P.mind.role_alt_title in restricted_from_jobs)))//does their job allow for it?
 			candidates.Remove(P)
 			continue
 		if ((exclusive_to_jobs.len > 0) && !(P.mind.assigned_role in exclusive_to_jobs))//is the rule exclusive to their job?

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -279,14 +279,14 @@
 			candidates.Remove(P)
 			b1++//we only count banned ones if they actually wanted to play the role
 			continue
-		if ((protected_from_jobs.len > 0) && P.mind.assigned_role && (P.mind.assigned_role in protected_from_jobs))
+		if ((protected_from_jobs.len > 0) && (P.mind.assigned_role && P.mind.assigned_role in protected_from_jobs) || (P.mind.role_alt_title && P.mind.role_alt_title in protected_from_jobs))
 			var/probability = initial(role_category.protected_traitor_prob)
 			if (prob(probability))
 				candidates.Remove(P)
 				c1++
 			c++
 			continue
-		if ((restricted_from_jobs.len > 0) && P.mind.assigned_role && (P.mind.assigned_role in restricted_from_jobs))//does their job allow for it?
+		if ((restricted_from_jobs.len > 0) && (P.mind.assigned_role && P.mind.assigned_role in restricted_from_jobs) || (P.mind.role_alt_title && P.mind.role_alt_title in restricted_from_jobs))//does their job allow for it?
 			candidates.Remove(P)
 			d++
 			continue
@@ -311,12 +311,12 @@
 		if (!P.client.desires_role(role_id) || jobban_isbanned(P, role_id) || isantagbanned(P) || (role_category_override && jobban_isbanned(P, role_category_override)))//are they willing and not antag-banned?
 			candidates.Remove(P)
 			continue
-		if (P.mind.assigned_role in protected_from_jobs)
+		if (P.mind.assigned_role in protected_from_jobs || P.mind.role_alt_title in protected_from_jobs)
 			var/probability = initial(role_category.protected_traitor_prob)
 			if (prob(probability))
 				candidates.Remove(P)
 			continue
-		if (P.mind.assigned_role in restricted_from_jobs)//does their job allow for it?
+		if (P.mind.assigned_role in restricted_from_jobs || P.mind.role_alt_title in restricted_from_jobs)//does their job allow for it?
 			candidates.Remove(P)
 			continue
 		if ((exclusive_to_jobs.len > 0) && !(P.mind.assigned_role in exclusive_to_jobs))//is the rule exclusive to their job?

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -311,12 +311,12 @@
 		if (!P.client.desires_role(role_id) || jobban_isbanned(P, role_id) || isantagbanned(P) || (role_category_override && jobban_isbanned(P, role_category_override)))//are they willing and not antag-banned?
 			candidates.Remove(P)
 			continue
-		if (P.mind.assigned_role in protected_from_jobs || P.mind.role_alt_title in protected_from_jobs)
+		if ((P.mind.assigned_role && P.mind.assigned_role in protected_from_jobs) || (P.mind.role_alt_title && P.mind.role_alt_title in protected_from_jobs))
 			var/probability = initial(role_category.protected_traitor_prob)
 			if (prob(probability))
 				candidates.Remove(P)
 			continue
-		if (P.mind.assigned_role in restricted_from_jobs || P.mind.role_alt_title in restricted_from_jobs)//does their job allow for it?
+		if ((P.mind.assigned_role && P.mind.assigned_role in restricted_from_jobs) || (P.mind.role_alt_title && P.mind.role_alt_title in restricted_from_jobs))//does their job allow for it?
 			candidates.Remove(P)
 			continue
 		if ((exclusive_to_jobs.len > 0) && !(P.mind.assigned_role in exclusive_to_jobs))//is the rule exclusive to their job?

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -14,12 +14,12 @@
 		if (!P.client.desires_role(role_pref) || jobban_isbanned(P, role_id) || isantagbanned(P) || (role_category_override && jobban_isbanned(P, role_category_override)))//are they willing and not antag-banned?
 			candidates.Remove(P)
 			continue
-		if (P.mind.assigned_role in protected_from_jobs)
+		if ((P.mind.assigned_role && P.mind.assigned_role in protected_from_jobs) || (P.mind.role_alt_title && P.mind.role_alt_title in protected_from_jobs))
 			var/probability = initial(role_category.protected_traitor_prob)
 			if (prob(probability))
 				candidates.Remove(P)
 			continue
-		if (P.mind.assigned_role in restricted_from_jobs)//does their job allow for it?
+		if ((P.mind.assigned_role && P.mind.assigned_role in restricted_from_jobs) || (P.mind.role_alt_title && P.mind.role_alt_title in restricted_from_jobs))//does their job allow for it?
 			candidates.Remove(P)
 			continue
 		if ((exclusive_to_jobs.len > 0) && !(P.mind.assigned_role in exclusive_to_jobs))//is the rule exclusive to their job?

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -14,12 +14,12 @@
 		if (!P.client.desires_role(role_pref) || jobban_isbanned(P, role_id) || isantagbanned(P) || (role_category_override && jobban_isbanned(P, role_category_override)))//are they willing and not antag-banned?
 			candidates.Remove(P)
 			continue
-		if ((P.mind.assigned_role && P.mind.assigned_role in protected_from_jobs) || (P.mind.role_alt_title && P.mind.role_alt_title in protected_from_jobs))
+		if ((P.mind.assigned_role && (P.mind.assigned_role in protected_from_jobs)) || (P.mind.role_alt_title && (P.mind.role_alt_title in protected_from_jobs)))
 			var/probability = initial(role_category.protected_traitor_prob)
 			if (prob(probability))
 				candidates.Remove(P)
 			continue
-		if ((P.mind.assigned_role && P.mind.assigned_role in restricted_from_jobs) || (P.mind.role_alt_title && P.mind.role_alt_title in restricted_from_jobs))//does their job allow for it?
+		if ((P.mind.assigned_role && (P.mind.assigned_role in restricted_from_jobs)) || (P.mind.role_alt_title && (P.mind.role_alt_title in restricted_from_jobs)))//does their job allow for it?
 			candidates.Remove(P)
 			continue
 		if ((exclusive_to_jobs.len > 0) && !(P.mind.assigned_role in exclusive_to_jobs))//is the rule exclusive to their job?

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -46,10 +46,10 @@
 			trimmed_list.Remove(M)
 			continue
 		if (M.mind)
-			if ((M.mind.assigned_role && M.mind.assigned_role in restricted_from_jobs) || (M.mind.role_alt_title && M.mind.role_alt_title in restricted_from_jobs))//does their job allow for it?
+			if ((M.mind.assigned_role && (M.mind.assigned_role in restricted_from_jobs)) || (M.mind.role_alt_title && (M.mind.role_alt_title in restricted_from_jobs)))//does their job allow for it?
 				trimmed_list.Remove(M)
 				continue
-			if ((M.mind.assigned_role && M.mind.assigned_role in protected_from_jobs) || (M.mind.role_alt_title && M.mind.role_alt_title in protected_from_jobs))
+			if ((M.mind.assigned_role && (M.mind.assigned_role in protected_from_jobs)) || (M.mind.role_alt_title && (M.mind.role_alt_title in protected_from_jobs)))
 				var/probability = initial(role_category.protected_traitor_prob)
 				if (prob(probability))
 					candidates.Remove(M)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -46,10 +46,10 @@
 			trimmed_list.Remove(M)
 			continue
 		if (M.mind)
-			if ((M.mind.assigned_role in restricted_from_jobs) || (M.mind.role_alt_title in restricted_from_jobs))//does their job allow for it?
+			if ((M.mind.assigned_role && M.mind.assigned_role in restricted_from_jobs) || (M.mind.role_alt_title && M.mind.role_alt_title in restricted_from_jobs))//does their job allow for it?
 				trimmed_list.Remove(M)
 				continue
-			if ((M.mind.assigned_role in protected_from_jobs) || (M.mind.role_alt_title in protected_from_jobs))
+			if ((M.mind.assigned_role && M.mind.assigned_role in protected_from_jobs) || (M.mind.role_alt_title && M.mind.role_alt_title in protected_from_jobs))
 				var/probability = initial(role_category.protected_traitor_prob)
 				if (prob(probability))
 					candidates.Remove(M)


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
[bugfix] 
Closes #29581 
When building a list of candidates for antag roles, Dynamic will now also check alt titles in addition to jobs for protection / restriction from a given antag role. This should also apply to merchants and any future alt title that has different protections from its parent job.

:cl:
 * bugfix: Dynamic now checks alt titles in addition to job titles for protection & restriction from antag roles