### PR TITLE
Fixes hits on a randomized zone giving the wrong zone in chat

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -27,6 +27,8 @@
 	status_flags = CANSTUN|CANKNOCKDOWN|CANPARALYSE|CANPUSH
 	var/obj/item/device/station_map/displayed_holomap = null
 
+	var/target_zone = null
+
 /mob/living/carbon/New(var/new_loc, var/new_species_name = null, var/delay_ready_dna=0)
 	..()
 	hud_list[CONVERSION_HUD] = image('icons/mob/hud.dmi', src, "hudblank")

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -25,10 +25,11 @@
 /mob/living/carbon/proc/attacked_by(var/obj/item/I, var/mob/living/user, var/def_zone, var/originator = null, var/crit = FALSE)
 	if(!I || !user)
 		return FALSE
-	var/target_zone = null
+	target_zone = null
 	var/power = I.force
 	if (crit)
 		power *= CRIT_MULTIPLIER
+
 	if(def_zone)
 		target_zone = get_zone_with_miss_chance(def_zone, src)
 	else if(originator)
@@ -37,6 +38,7 @@
 			target_zone = get_zone_with_miss_chance(M.zone_sel.selecting, src)
 	else
 		target_zone = get_zone_with_miss_chance(user.zone_sel.selecting, src)
+
 	if(user == src) // Attacking yourself can't miss
 		target_zone = user.zone_sel.selecting
 	if(!target_zone && !src.stat)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -192,16 +192,6 @@ emp_act
 	if (crit)
 		power *= CRIT_MULTIPLIER
 
-	var/target_zone = null
-	if(def_zone)
-		target_zone = def_zone
-	else if(originator)
-		if(ismob(originator))
-			var/mob/M = originator
-			target_zone = get_zone_with_miss_chance(M.zone_sel.selecting, src)
-	else
-		target_zone = get_zone_with_miss_chance(user.zone_sel.selecting, src)
-
 	var/datum/organ/external/affecting = get_organ(target_zone)
 	if (!affecting)
 		return FALSE


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7573912/120569070-7b7bcb80-c415-11eb-8603-15b52d762eef.png)

before:
>target zone A
>"You hit the guy in zone B"
>guy is hurt on zone C

after:
>target zone A
>"You hit the guy in zone C"
>guy is hurt on zone C

:cl:
* bugfix: When hitting someone with a weapon, should you miss the intended target limb and hit another limb, the chat will now correctly report which limb has been hit.