### PR TITLE
fixes wall smash text

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -106,7 +106,7 @@
 				M.visible_message("<span class='danger'>[M] smashes through \the [src].</span>", \
 				"<span class='attack'>You smash through \the [src].</span>")
 			else
-				to_chat(M, "<span class='info'>This [src] is far too strong for you to destroy.</span>")
+				to_chat(M, "<span class='info'>\The [src] is far too strong for you to destroy.</span>")
 		else
 			playsound(src, 'sound/weapons/heavysmash.ogg', 75, 1)
 			dismantle_wall(1)


### PR DESCRIPTION
closes #29675

:cl:
 * spellcheck: 'this the reinforced wall' now just says 'the reinforced wall'