### PR TITLE
Remains layer increase

### DIFF
--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -1,6 +1,10 @@
 /obj/effect/decal/remains/cultify()
 	return
 
+/obj/effect/decal/remains
+	layer = MACHINERY_LAYER
+	plane = OBJ_PLANE
+
 /obj/effect/decal/remains/human
 	name = "remains"
 	desc = "They look like human remains. They have a strange aura about them."


### PR DESCRIPTION
Fixes #22987

:cl:
* tweak: Increased the layer at which remains appear. They appear now above tables but still below objects. As such they are no longer hidden by things like vents, scrubbers and pipe.