### PR TITLE
Fixes items removed by monkeys from their backpack having a full-tile hitbox

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -255,7 +255,10 @@
 /obj/item/requires_dexterity(mob/user)
 	return TRUE
 
-/obj/item/attack_paw(mob/user as mob)
+/obj/item/attack_paw(var/mob/user)
+	attack_hand(user)
+
+/*
 	if (istype(loc, /obj/item/weapon/storage))
 		for(var/mob/M in range(1, loc))
 			if (M.s_active == loc)
@@ -276,7 +279,7 @@
 		//user.next_move = max(user.next_move+2,world.time + 2)
 
 	user.put_in_active_hand(src)
-	return
+*/
 
 // Due to storage type consolidation this should get used more now.
 // I have cleaned it up a little, but it could probably use more.  -Sayu

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -258,29 +258,6 @@
 /obj/item/attack_paw(var/mob/user)
 	attack_hand(user)
 
-/*
-	if (istype(loc, /obj/item/weapon/storage))
-		for(var/mob/M in range(1, loc))
-			if (M.s_active == loc)
-				if (M.client)
-					M.client.screen -= src
-	throwing = FALSE
-	if (loc == user)
-		if(!user.put_in_hand_check(src, user.get_active_hand()))
-			return
-		//canremove==0 means that object may not be removed. You can still wear it. This only applies to clothing. /N
-		if(istype(src, /obj/item/clothing) && !src:canremove)
-			return
-		else
-			user.u_equip(src,0)
-	else
-		if(istype(loc, /mob/living))
-			return
-		//user.next_move = max(user.next_move+2,world.time + 2)
-
-	user.put_in_active_hand(src)
-*/
-
 // Due to storage type consolidation this should get used more now.
 // I have cleaned it up a little, but it could probably use more.  -Sayu
 /obj/item/attackby(obj/item/weapon/W as obj, mob/user as mob)


### PR DESCRIPTION
Items now call the same attack_hand proc used by humans, I've tested and it seems to work perfectly fine.

This will probably fix that issue
Fixes #11976

:cl:
* bugfix: Fixed items removed by monkeys from their backpack having a full-tile hitbox.