### PR TITLE
Fixes vine/biomass spreading as well as registered lazy events disappearing on ChangeTurf

### DIFF
--- a/code/game/gamemodes/events/biomass.dm
+++ b/code/game/gamemodes/events/biomass.dm
@@ -75,8 +75,8 @@
 /obj/effect/biomass/proc/spread()
 	var/location = get_step(src, pick(alldirs))
 
-	if(istype(location, /turf/simulated/floor))
-		var/turf/simulated/floor/Floor = location
+	if(isfloor(location) && Adjacent(location))
+		var/turf/Floor = location
 
 		if(isnull(locate(/obj/effect/biomass) in Floor))
 			if(Floor.Enter(src, loc))

--- a/code/game/gamemodes/events/spacevines.dm
+++ b/code/game/gamemodes/events/spacevines.dm
@@ -5,7 +5,7 @@
 		for(var/areapath in typesof(/area/hallway))
 			var/area/A = locate(areapath)
 			for(var/turf/simulated/floor/F in A.contents)
-				if(!is_blocked_turf(F))
+				if(!is_blocked_turf(F) && !(locate(/obj/effect/plantsegment) in F))
 					turfs += F
 
 		if(turfs.len) //Pick a turf to spawn at if we can

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -362,6 +362,7 @@
 	var/old_corners = corners
 	var/old_density = density
 	var/old_holomap_draw_override = holomap_draw_override
+	var/old_registered_events = registered_events
 
 	var/old_holomap = holomap_data
 //	to_chat(world, "Replacing [src.type] with [N]")
@@ -452,7 +453,9 @@
 		holomap_draw_override = old_holomap_draw_override//we don't want roid/snowmap cave tunnels appearing on holomaps
 	holomap_data = old_holomap // Holomap persists through everything...
 	update_holomap_planes() // But we might need to recalculate it.
+	registered_events = old_registered_events
 	if(density != old_density)
+		to_chat(world, "([x],[y],[z])densityChanged()")
 		densityChanged()
 
 /turf/proc/AddDecal(const/image/decal)

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -41,6 +41,10 @@
 	if(is_locking_type(/mob, /datum/locking_category/plantsegment))
 		var/mob/V = locate(/mob) in get_locked(/datum/locking_category/plantsegment)
 		unlock_atom(V)
+
+	for(var/direc in cardinal)
+		var/turf/T = get_step(src, direc)
+		T.lazy_unregister_event(/lazy_event/on_density_change, src, .proc/proxDensityChange)
 	..()
 
 /obj/effect/plantsegment/New(var/newloc, var/datum/seed/newseed, var/turf/newepicenter, var/start_fully_mature = 0)
@@ -76,6 +80,11 @@
 	if(start_fully_mature)
 		health = max_health
 		mature_time = 0
+
+
+	for(var/direc in cardinal)
+		var/turf/U = get_step(src, direc)
+		U.lazy_register_event(/lazy_event/on_density_change, src, .proc/proxDensityChange)
 
 	spawn(1) // Plants will sometimes be spawned in the turf adjacent to the one they need to end up in, for the sake of correct dir/etc being set.
 		SSplant.add_plant(src)

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -42,10 +42,20 @@
 		var/mob/V = locate(/mob) in get_locked(/datum/locking_category/plantsegment)
 		unlock_atom(V)
 
+	lazy_unregister_event(/lazy_event/on_before_move, src, /obj/effect/plantsegment/proc/before_moving)
+	lazy_unregister_event(/lazy_event/on_after_move, src, /obj/effect/plantsegment/proc/after_moving)
+	before_moving()
+	..()
+
+/obj/effect/plantsegment/proc/before_moving()
 	for(var/direc in cardinal)
 		var/turf/T = get_step(src, direc)
 		T.lazy_unregister_event(/lazy_event/on_density_change, src, .proc/proxDensityChange)
-	..()
+
+/obj/effect/plantsegment/proc/after_moving()
+	for(var/direc in cardinal)
+		var/turf/T = get_step(src, direc)
+		T.lazy_register_event(/lazy_event/on_density_change, src, .proc/proxDensityChange)
 
 /obj/effect/plantsegment/New(var/newloc, var/datum/seed/newseed, var/turf/newepicenter, var/start_fully_mature = 0)
 	..()
@@ -81,10 +91,9 @@
 		health = max_health
 		mature_time = 0
 
-
-	for(var/direc in cardinal)
-		var/turf/U = get_step(src, direc)
-		U.lazy_register_event(/lazy_event/on_density_change, src, .proc/proxDensityChange)
+	lazy_register_event(/lazy_event/on_before_move, src, /obj/effect/plantsegment/proc/before_moving)
+	lazy_register_event(/lazy_event/on_after_move, src, /obj/effect/plantsegment/proc/after_moving)
+	after_moving()
 
 	spawn(1) // Plants will sometimes be spawned in the turf adjacent to the one they need to end up in, for the sake of correct dir/etc being set.
 		SSplant.add_plant(src)

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -136,7 +136,7 @@
 
 /obj/effect/plantsegment/proc/proxDensityChange(atom/atom)
 	var/turf/T = get_turf(atom)
-	if(!T.density && !T.has_dense_content())
+	if(!is_blocked_turf(T))
 		SSplant.add_plant(src)
 
 #undef NEIGHBOR_REFRESH_TIME

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -134,4 +134,9 @@
 			SSplant.add_plant(neighbor)
 	qdel(src)
 
+/obj/effect/plantsegment/proc/proxDensityChange(atom/atom)
+	var/turf/T = get_turf(atom)
+	if(!T.density && !T.has_dense_content())
+		SSplant.add_plant(src)
+
 #undef NEIGHBOR_REFRESH_TIME


### PR DESCRIPTION
Fixes #20161
Fixes #29378
Fixes #29687
Fixes #29688
![image](https://user-images.githubusercontent.com/7573912/120851670-6e77ed00-c579-11eb-8011-9bb2232a0860.png)

![image](https://user-images.githubusercontent.com/7573912/120848779-82215480-c575-11eb-9a4b-3ff21395b72a.png)

:cl:
* bugfix: Mature Space Vines (kudzu) will now properly spread when an adjacent door opens or an adjacent wall is dismantled.
* bugfix: Fixed Biomass spreading through one-directional windows and firelocks.