### PR TITLE
Some bloody doodle tweaks

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -97,12 +97,19 @@ var/global/list/blood_list = list()
 	desc = "It looks like a writing in blood."
 	gender = NEUTER
 	icon = 'icons/effects/effects.dmi'
-	icon_state = ""
+	icon_state = "nothing"
+	random_icon_states = list()
 	amount = 0
 	maptext_height = 32
 	maptext_width = 64
 	maptext_x = -16
 	maptext_y = -2
+	var/turf/original_bloodsource//the turf where was the original blood splatter
+	var/original_amount = 0//the amount of blood there was in the original blood splatter
+
+/obj/effect/decal/cleanable/blood/writing/update_icon()
+	..()
+	color = null
 
 
 /obj/effect/decal/cleanable/blood/gibs

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1277,7 +1277,7 @@
 		doodle_color = bloody_hands_data["blood_colour"]
 
 	if (!doodle_color)
-		to_chat(src, "<span class='warning'>There is no blood on your hands or gloves.</span>")
+		to_chat(src, "<span class='warning'>There is no blood on your [actual_gloves ? "gloves" : "hands"].</span>")
 		return
 
 
@@ -1315,6 +1315,19 @@
 	if(continue_drawing != "Yes" || !Adjacent(T))
 		return
 
+	//One last sanity check
+	var/can_still_doodle = FALSE
+	var/obj/item/clothing/gloves/actual_gloves2
+	if (istype(gloves, /obj/item/clothing/gloves))
+		actual_gloves2 = gloves
+		if(actual_gloves2.transfer_blood > 0 && actual_gloves2.blood_DNA?.len)
+			can_still_doodle = TRUE
+	if(!actual_gloves2 && bloody_hands > 0 && bloody_hands_data?.len)
+		can_still_doodle = TRUE
+	if(!can_still_doodle)
+		to_chat(src, "<span class='warning'>There is no blood left on your [actual_gloves2 ? "gloves" : "hands"].</span>")
+		return
+
 	//Finally writing our message
 	var/obj/effect/decal/cleanable/blood/writing/W = new /obj/effect/decal/cleanable/blood/writing(T)
 	W.basecolor = doodle_color
@@ -1324,8 +1337,8 @@
 	W.visible_message("<span class='warning'>[invisible ? "Invisible fingers" : "\The [src]"] crudely paint[invisible ? "" : "s"] something in blood on \the [T]...</span>")
 	W.blood_DNA[doodle_DNA] = doodle_type
 
-	if (actual_gloves)
-		actual_gloves.transfer_blood = max(0,actual_gloves.transfer_blood - 1)
+	if (actual_gloves2)
+		actual_gloves2.transfer_blood = max(0,actual_gloves2.transfer_blood - 1)
 	else
 		bloody_hands = max(0,bloody_hands - 1)
 	update_inv_gloves()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -706,6 +706,9 @@ var/global/list/damage_icon_parts = list()
 				bloodsies.color = actual_gloves.blood_color
 				standing.overlays	+= bloodsies
 				O.overlays += bloodsies
+			else
+				if (actual_gloves.blood_overlay)
+					actual_gloves.overlays.Remove(actual_gloves.blood_overlay)
 		gloves.screen_loc = ui_gloves
 
 		gloves.generate_accessory_overlays(O)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7573912/120866634-ae969a00-c590-11eb-8e6f-b962a46b962d.png)

:cl:
* bugfix: You can no longer write in blood as a ghost if the source blood disappeared before you finished writing your message.
* bugfix: You can no longer write in blood if there is no blood left on your hands or glove by the time you finish writing your message.
* tweak: Ghosts can now only write in blood up to a certain amount of tiles from the original blood source (before they could daisy-chain messages ad nauseam). The max distance depends of the original source's amount of blood. A drip will only have a radius of 1. Splatters a radius of 2. Gibs a radius of 5. (Same distance as footprints)