### PR TITLE
Allowing projectiles to hit mobs in cages

### DIFF
--- a/code/game/objects/structures/cage.dm
+++ b/code/game/objects/structures/cage.dm
@@ -69,6 +69,23 @@
 		else
 			toggle_door(user)
 
+
+/obj/structure/cage/bullet_act(var/obj/item/projectile/Proj)
+	if (!locked_atoms?.len)
+		return PROJECTILE_COLLISION_DEFAULT
+	if(cover_state != C_OPENED)
+		return PROJECTILE_COLLISION_DEFAULT
+	var/mob/victim = pick(locked_atoms)
+	if (!istype(victim))
+		return PROJECTILE_COLLISION_DEFAULT
+	if(prob(75))
+		var/act = victim.bullet_act(Proj)
+		if(act == PROJECTILE_COLLISION_DEFAULT)
+			visible_message("<span class='warning'>\The [victim] is hit by \the [Proj]!")
+		return act
+	return PROJECTILE_COLLISION_DEFAULT
+
+
 /obj/structure/cage/verb/toggle_cover_v()
 	set name = "Toggle Cover"
 	set category = "Object"


### PR DESCRIPTION
Fixes #18790

:cl:
* tweak: Projectiles now have a 75 percent chance of hitting mobs in cages, as long as the cover is up.