### PR TITLE
Sets world.movement_mode to TILE_MOVEMENT_MODE

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -10,6 +10,7 @@ var/world_startup_time
 	cache_lifespan = 0	//stops player uploaded stuff from being kept in the rsc past the current session
 	//loop_checks = 0
 	icon_size = WORLD_ICON_SIZE
+	movement_mode = TILE_MOVEMENT_MODE
 
 #define RECOMMENDED_VERSION 513
 


### PR DESCRIPTION
This causes the server to reject any changes to any of the `step`/`bounds` variables that do not correspond to full tiles. Therefore, no more worrying about accidentally turning the game into a slideshow.
I assume this works for pre-514 clients as well, but I don't really know how to go about testing that to make sure.
This changes how collision detection works internally, but we override all of that anyway. No changes to gameplay as far as I can tell.

Also, yes, I see that line two lines down.