### PR TITLE
Fixes countless Beam-related bugs, along with some extras

### DIFF
--- a/code/__HELPERS/math/ray/ray.dm
+++ b/code/__HELPERS/math/ray/ray.dm
@@ -2,7 +2,7 @@
 #define RAY_CAST_DEFAULT_MAX_DISTANCE 50
 
 //step size of a raycast, used to calculate one step by multiplying with floored direction vector
-#define RAY_CAST_STEP 0.01
+#define RAY_CAST_STEP 0.25
 
 //used to tell cast() to not have a hit limit (default value of max_hits)
 #define RAY_CAST_UNLIMITED_HITS 0
@@ -21,6 +21,7 @@
 	var/vector/origin //the origin of the ray
 	var/vector/origin_floored //the floored origin vector
 	var/vector/direction //direction of the ray
+	var/original_damage //original damage of the ray when applicable
 
 /ray/proc/toString()
 	return "\[Ray\](\n- origin = " + origin.toString() + "\n- origin_floored = "+ origin_floored.toString() + "\n- direction = " + direction.toString() + "\n- z-level = " + num2text(z) + "\n)"
@@ -191,7 +192,7 @@ var/list/ray_draw_icon_cache = list()
 
 		var/turf/T = locate(point_floored.x, point_floored.y, z)
 
-		var/obj/effect/overlay/beam/I = new (T, lifetime=lifetime, fade=fade, src_icon = icon, icon_state = icon_state)
+		var/obj/effect/overlay/beam/I = new (T, lifetime=lifetime, fade=fade, src_icon = icon, icon_state = icon_state, base_damage = original_damage)
 		I.transform = matrix().Turn(angle)
 		I.pixel_x = pixels.x
 		I.pixel_y = pixels.y

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -24,8 +24,9 @@
 	anchored = 1
 	var/tmp/atom/BeamSource
 
-/obj/effect/overlay/beam/New(var/turf/loc, var/lifetime = 10, var/fade = 0, var/src_icon = 'icons/effects/beam.dmi', var/icon_state = "b_beam")
+/obj/effect/overlay/beam/New(var/turf/loc, var/lifetime = 10, var/fade = 0, var/src_icon = 'icons/effects/beam.dmi', var/icon_state = "b_beam", var/base_damage = 30)
 	..()
+	alpha = round(255*(loc.last_beam_damage/base_damage))
 	icon = src_icon
 	src.icon_state = icon_state
 	spawn if(fade)

--- a/code/game/objects/structures/fullwindow.dm
+++ b/code/game/objects/structures/fullwindow.dm
@@ -14,6 +14,7 @@
 	penetration_dampening = 1
 	cracked_base = "fcrack"
 	is_fulltile = TRUE
+	disperse_coeff = 0.95
 
 /obj/structure/window/full/New(loc)
 
@@ -27,6 +28,7 @@
 /obj/structure/window/full/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 
 	if(istype(mover) && mover.checkpass(PASSGLASS))
+		dim_beam(mover)
 		return 1
 	return 0
 
@@ -114,6 +116,7 @@
 	penetration_dampening = 3
 	d_state = WINDOWSECURE
 	reinforced = 1
+	disperse_coeff = 0.8
 
 /obj/structure/window/full/reinforced/loose
 	anchored = 0
@@ -129,6 +132,7 @@
 	sheet_type = /obj/item/stack/sheet/glass/plasmaglass
 	health = 120
 	penetration_dampening = 5
+	disperse_coeff = 0.75
 
 	fire_temp_threshold = 32000
 	fire_volume_mod = 1000
@@ -147,6 +151,7 @@
 	sheet_type = /obj/item/stack/sheet/glass/plasmarglass
 	health = 160
 	penetration_dampening = 7
+	disperse_coeff = 0.6
 
 /obj/structure/window/full/reinforced/plasma/loose
 	anchored = 0

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -173,8 +173,6 @@ var/list/one_way_windows
 		healthcheck()
 
 /obj/structure/window/Uncross(var/atom/movable/mover, var/turf/target)
-	if(istype(mover) && mover.checkpass(PASSGLASS))
-		return 1
 	if(flow_flags & ON_BORDER)
 		if(target) //Are we doing a manual check to see
 			if(get_dir(loc, target) == dir)
@@ -186,16 +184,21 @@ var/list/one_way_windows
 	return 1
 
 /obj/structure/window/Cross(atom/movable/mover, turf/target, height = 0)
-	if(istype(mover) && mover.checkpass(PASSGLASS))
-		if(istype(mover,/obj/item/projectile/beam))
-			var/obj/item/projectile/beam/B = mover
-			B.damage *= disperse_coeff
-			if(B.damage <= 1)
-				B.bullet_die()
+	if(istype(mover) && mover.checkpass(PASSGLASS))//checking for beam dispersion both in and out, since beams do not trigger Uncross.
+		if((get_dir(loc, target) & dir) || (get_dir(loc, mover) & dir) || (get_dir(loc, target) & reverse_direction(dir)) || (get_dir(loc, mover) & reverse_direction(dir)))
+			dim_beam(mover)
 		return 1
 	if(get_dir(loc, target) == dir || get_dir(loc, mover) == dir)
 		return !density
 	return 1
+
+
+/obj/structure/window/proc/dim_beam(var/obj/item/projectile/beam/B)
+	if(istype(B))
+		B.damage *= disperse_coeff
+		if(B.damage <= 1)
+			B.bullet_die()
+
 
 //Someone threw something at us, please advise
 /obj/structure/window/hitby(var/atom/movable/AM)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -75,6 +75,8 @@
 
 	var/holomap_draw_override = HOLOMAP_DRAW_NORMAL
 
+	var/last_beam_damage = 0
+
 /turf/examine(mob/user)
 	..()
 	if(bullet_marks)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -13,7 +13,7 @@
 
 var/list/beam_master = list()
 
-#define MAX_BEAM_DISTANCE 100
+#define MAX_BEAM_DISTANCE 50
 
 #define RAY_CAST_REBOUND 1.5
 
@@ -27,6 +27,7 @@ var/list/beam_master = list()
 /ray/beam_ray/New(var/vector/p_origin, var/vector/p_direction, var/obj/item/projectile/beam/fired_beam)
 	..(p_origin, p_direction, fired_beam.starting.z)
 	src.fired_beam = fired_beam
+	original_damage = fired_beam.damage
 
 /ray/beam_ray/Destroy()
 	fired_beam = null
@@ -45,6 +46,8 @@ var/list/beam_master = list()
 
 	if(isnull(A))
 		return new /rayCastHit(info, RAY_CAST_NO_HIT_CONTINUE)
+
+	T.last_beam_damage = fired_beam.damage
 
 	if(!A.Cross(fired_beam, T) || (!isturf(fired_beam.original) && A == fired_beam.original))
 		var/ret = fired_beam.to_bump(A)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7573912/120910502-b719ce00-c67f-11eb-84e4-d3b3568656f8.png)
Fixes #24922
Fixes #29620
Fixes #29699

:cl:
* rscadd: Egun beams now have their alpha reduced proportionally to their damage when they get dispersed by windows.
* bugfix: beams no longer lag when firing through a large corridor or into space.
* bugfix: Fixed full-tile windows not reducing beam damage. It now does it with the same efficiency as a single directional window.
* bugfix: Firing beams straight through a tile featuring directional windows will no longer reduce its damage if the window isn't oriented toward (or away) from the source of the beam (which means that in most cases, if the beam crosses a tile with a window without intersecting with it, it shouldn't lose some of its damage)