### PR TITLE
Allows artificers to conjure floors over space tiles at a range

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -680,16 +680,13 @@ turf/simulated/floor/update_icon()
 			return
 		qdel(P)
 
-
-/turf/simulated/floor/attack_construct(mob/user as mob)
+/turf/simulated/floor/attack_construct(var/mob/user)
 	if(istype(src,/turf/simulated/floor/carpet))
 		return//carpets are cool
 	if(istype(user,/mob/living/simple_animal/construct/builder))
 		if((icon_state != "cult")&&(icon_state != "cult-narsie"))
 			var/spell/aoe_turf/conjure/floor/S = locate() in user.spell_list
 			S.perform(user, 0, list(src))
-			//var/obj/abstract/screen/spell/SS = S.connected_button
-			//SS.update_charge(1)
 			return 1
 	return 0
 

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -214,3 +214,10 @@
 /turf/space/can_place_cables()
 	var/obj/structure/catwalk/support = locate() in src
 	return !isnull(support)
+
+/turf/space/attack_construct(var/mob/user)
+	if(istype(user,/mob/living/simple_animal/construct/builder))
+		var/spell/aoe_turf/conjure/floor/S = locate() in user.spell_list
+		S.perform(user, 0, list(src))
+		return 1
+	return 0


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7573912/120925280-24f1e400-c6d8-11eb-9a6d-d91b3c634425.png)

Fixes #18254

:cl:
* rscadd: Just like artificers can click floors up to 3 tiles away to convert them into cult floors, they can now click space tiles to conjure floors over them. As when done by clicking the spell button, conjuring a tile instead of converting one leads to a longer cooldown.