### PR TITLE
Here, here, here we go!

### DIFF
--- a/__DEFINES/game.dm
+++ b/__DEFINES/game.dm
@@ -40,3 +40,9 @@
 #define SPEECH_MODE_SAY     1
 #define SPEECH_MODE_WHISPER 2
 #define SPEECH_MODE_FINAL   3
+
+#define MINIMUM_NON_SUS_ACCOUNT_AGE 14 // If the connecting account is older than this many days, admins don't get notified
+
+#define APE_MODE_OFF 0 // He has no style
+#define APE_MODE_EVERYONE 1 // He has no grace
+#define APE_MODE_NEW_PLAYERS 2 // This Kong has a funny face

--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -182,3 +182,17 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 /datum/persistence_task/highscores/proc/clear_records()
 	data = list()
 	fdel(file(file_path))
+
+
+/datum/persistence_task/ape_mode
+	execute = TRUE
+	name = "Ape mode"
+	file_path = "data/persistence/ape_mode.json"
+
+/datum/persistence_task/ape_mode/on_init()
+	data = read_file()
+	if(length(data))
+		ape_mode = data["ape_mode"]
+
+/datum/persistence_task/ape_mode/on_shutdown()
+	write_file(list("ape_mode" = ape_mode))

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -422,6 +422,7 @@ var/datum/controller/gameticker/ticker
 			if(player.mind.assigned_role != "MODE")
 				job_master.EquipRank(player, player.mind.assigned_role, 0)
 				EquipCustomItems(player)
+			player.apeify()
 	if(captainless)
 		for(var/mob/M in player_list)
 			if(!istype(M,/mob/new_player))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -132,6 +132,7 @@ var/list/admin_verbs_fun = list(
 	/client/proc/deadchat_singularity,
 	/client/proc/view_all_rods,
 	/client/proc/add_centcomm_order,
+	/client/proc/apes,
 	)
 var/list/admin_verbs_spawn = list(
 	/datum/admins/proc/spawn_atom, // Allows us to spawn instances

--- a/code/modules/admin/verbs/apes.dm
+++ b/code/modules/admin/verbs/apes.dm
@@ -1,0 +1,33 @@
+var/ape_mode = APE_MODE_OFF
+
+/client/proc/apes()
+	set category = "Fun"
+	set name = "Configure Apes"
+
+	switch(alert(usr, "Configure apes:", "Configure Apes", "Turn it off, no apes", "EVERYONE IS APE", "Only new players are apes"))
+		if("Turn it off, no apes")
+			ape_mode = APE_MODE_OFF
+			message_admins("<span class='notice'>[key_name_admin(usr)] turned off ape mode.</span>")
+		if("EVERYONE IS APE")
+			ape_mode = APE_MODE_EVERYONE
+			message_admins("<span class='notice'>[key_name_admin(usr)] turned on ape mode: EVERYONE IS APE.</span>")
+		if("Only new players are apes")
+			ape_mode = APE_MODE_NEW_PLAYERS
+			message_admins("<span class='notice'>[key_name_admin(usr)] turned on ape mode: Only new players are apes.</span>")
+	var/datum/persistence_task/task = SSpersistence_misc.tasks[/datum/persistence_task/ape_mode]
+	task.on_shutdown()
+
+/mob/proc/apeify()
+	if(ape_mode == APE_MODE_OFF)
+		return
+	ASSERT(client)
+	if(ape_mode == APE_MODE_NEW_PLAYERS && client.account_age >= MINIMUM_NON_SUS_ACCOUNT_AGE)
+		return
+	var/mob/monke = monkeyize()
+	ASSERT(monke)
+	monke.name = monke.mind.name
+
+/hook_handler/apes/proc/OnArrival(list/args)
+	var/mob/living/dude = args["character"]
+	ASSERT(dude)
+	dude.apeify()

--- a/code/modules/admin/verbs/apes.dm
+++ b/code/modules/admin/verbs/apes.dm
@@ -21,7 +21,7 @@ var/ape_mode = APE_MODE_OFF
 	if(ape_mode == APE_MODE_OFF)
 		return
 	ASSERT(client)
-	if(ape_mode == APE_MODE_NEW_PLAYERS && client.account_age >= MINIMUM_NON_SUS_ACCOUNT_AGE)
+	if(ape_mode == APE_MODE_NEW_PLAYERS && client.player_age >= MINIMUM_NON_SUS_ACCOUNT_AGE)
 		return
 	var/mob/monke = monkeyize()
 	ASSERT(monke)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -405,7 +405,7 @@
 		qdel(query_age)
 	if(!isnum(player_age))
 		player_age = 0
-	if(age < 14)
+	if(age < MINIMUM_NON_SUS_ACCOUNT_AGE)
 		message_admins("[ckey(key)]/([src]) is a relatively new player, may consider watching them. AGE = [age]  First seen = [player_age]")
 		log_admin(("[ckey(key)]/([src]) is a relatively new player, may consider watching them. AGE = [age] First seen = [player_age]"))
 	testing("[src]/[ckey(key)] logged in with age of [age]/[player_age]/[Joined]")

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1302,6 +1302,7 @@
 #include "code\modules\admin\verbs\adminjump.dm"
 #include "code\modules\admin\verbs\adminpm.dm"
 #include "code\modules\admin\verbs\adminsay.dm"
+#include "code\modules\admin\verbs\apes.dm"
 #include "code\modules\admin\verbs\atmosdebug.dm"
 #include "code\modules\admin\verbs\BrokenInhands.dm"
 #include "code\modules\admin\verbs\check_customitem_activity.dm"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6307265/120957312-bbb0b600-c755-11eb-8982-f356447a317c.png)

This adds an admin button that requires +FUN that lets you set ape mode.
Ape mode has three settings: off, on, on but only for new players.
The setting persists through restarts.
It turns players into monkeys when they spawn.