### PR TITLE
Default language is now preserved on cloning

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -15,6 +15,7 @@
 	var/ckey=null
 	var/mind=null
 	var/list/languages = list()
+	var/default_language=null
 	var/times_cloned=0
 	var/talkcount
 
@@ -45,6 +46,7 @@
 	new_copy.ckey = ckey
 	new_copy.mind = mind
 	new_copy.languages = languages.Copy()
+	new_copy.default_language = default_language
 	new_copy.times_cloned = times_cloned
 
 	return new_copy

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -282,6 +282,9 @@
 	H.update_mutantrace()
 	for(var/datum/language/L in R.languages)
 		H.add_language(L.name)
+		if (L == R.default_language)
+			H.default_language = R.default_language
+
 	H.real_name = H.dna.real_name
 	H.flavor_text = H.dna.flavor_text
 

--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -494,6 +494,7 @@
 	R.name=R.dna.real_name
 	R.types=DNA2_BUF_UI|DNA2_BUF_UE|DNA2_BUF_SE
 	R.languages = subject.languages.Copy()
+	R.default_language = subject.default_language
 	R.times_cloned = subject.times_cloned
 	R.talkcount = subject.talkcount
 


### PR DESCRIPTION
Fixes #29733

:cl:
* rscadd: When cloned you now keep the default language you had when you were scanned.