### PR TITLE
Fixes Admin Disease Copy

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -326,7 +326,7 @@ var/global/list/disease2_list = list()
 		if (!chosen_pathogen)
 			qdel(D)
 			return
-		var/datum/disease2/disease/dis = existing_pathogen[chosen_pathogen]
+		var/datum/disease2/disease/dis = disease2_list[existing_pathogen[chosen_pathogen]]
 		D = dis.getcopy()
 		D.origin = "[D.origin] (Badmin)"
 	else


### PR DESCRIPTION
Fixes a runtime that prevents admins from infecting people with an already existing disease. 
![image](https://user-images.githubusercontent.com/7573912/121081450-075a7280-c7dd-11eb-91d4-f8cba22bf425.png)
