### PR TITLE
Not more remote ore box unloading

### DIFF
--- a/code/modules/mining/machine_unloading.dm
+++ b/code/modules/mining/machine_unloading.dm
@@ -13,7 +13,7 @@
 	max_moved = 100
 	in_dir = EAST
 	out_dir = WEST
-	
+
 	var/selectable_types = list(/obj/item = "All items") //List of types we can move -kanef
 	var/item_moved = FALSE //Variable for loop detection, only used in chaining
 
@@ -101,7 +101,7 @@
 				return
 			// Otherwise, reset each one recursively, follow logic above
 			UM.reset_move_check()
-	
+
 // Couldn't inherit most of this sadly -kanef
 /obj/machinery/mineral/unloading_machine/process()
 	var/turf/in_T = get_step(src, in_dir)
@@ -109,10 +109,9 @@
 	if(!in_T.Cross(mover, in_T) || !in_T.Enter(mover))
 		return
 
-	var/obj/structure/ore_box/BOX = locate(/obj/structure/ore_box, in_T.loc)
-	if (BOX)
+	for (var/obj/structure/ore_box/BOX in in_T)
 		BOX.dump_everything(in_T)
-	
+
 	for(var/atom/movable/A in in_T)
 		if(A.anchored)
 			continue

--- a/code/modules/mining/ore_box.dm
+++ b/code/modules/mining/ore_box.dm
@@ -47,12 +47,16 @@
 /obj/structure/ore_box/Topic(href, href_list)
 	if(..())
 		return
-	usr.set_machine(src)
-	src.add_fingerprint(usr)
+	var/mob/user = usr
+	if (!Adjacent(user))
+		usr << browse(null, "window=orebox")
+		return
+	user.set_machine(src)
+	add_fingerprint(user)
 	if(href_list["removeall"])
 		dump_everything()
-		to_chat(usr, "<span class='notice'>You empty the box.</span>")
-	src.updateUsrDialog()
+		to_chat(user, "<span class='notice'>You empty the box.</span>")
+	updateUsrDialog()
 	return
 
 /obj/structure/ore_box/proc/dump_everything(var/atom/target)

--- a/code/modules/mining/ore_box.dm
+++ b/code/modules/mining/ore_box.dm
@@ -48,7 +48,7 @@
 	if(..())
 		return
 	var/mob/user = usr
-	if (!Adjacent(user))
+	if (!Adjacent(user) || user.incapacitated())
 		usr << browse(null, "window=orebox")
 		return
 	user.set_machine(src)


### PR DESCRIPTION
Fixes #29736
Fixes #29650

:cl:
* bugfix: Patched an exploit that allowed players to unload ore boxes using the pop-up window from any distance away or even adjacent but otherwise incapacitated, which apparently allowed a few people to mess with our shaft miner friends.
* bugfix: Also fixed ore unloading machines causing all ore boxes in their area to dump everything every second, instead of only those in front of them.