### PR TITLE
Extended rounds are now less likely if there's been an extended round in the last three days

### DIFF
--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -182,3 +182,34 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 /datum/persistence_task/highscores/proc/clear_records()
 	data = list()
 	fdel(file(file_path))
+
+// -- Extended
+
+/datum/persistence_task/latest_extended_round
+	execute = TRUE
+	name = "Latest extended round"
+	file_path = "data/persistence/latest_extended_round.json"
+
+/datum/persistence_task/latest_extended_round/on_init()
+	data = read_file()
+
+/datum/persistence_task/latest_extended_round/on_shutdown()
+	var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
+	if (!istype(dynamic_mode))
+		return
+	var/write_data = FALSE
+	var/list/data = list(
+		"latest_extended_dd" = null,
+		"latest_extended_mm" = null,
+		"latest_extended_yy" = null,
+	)
+	for(var/datum/dynamic_ruleset/roundstart/extened/some_ruleset in dynamic_mode.executed_rules)
+		if (some_ruleset.calledBy)
+			continue
+		write_data = TRUE
+		data["latest_extended_dd"] = time2text(world.realtime, "DD")
+		data["latest_extended_mm"] = time2text(world.realtime, "MM")
+		data["latest_extended_yy"] = time2text(world.realtime, "YYYY")
+		break
+	if (write_data)
+		write_file(data)

--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -203,7 +203,7 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 		"latest_extended_mm" = null,
 		"latest_extended_yy" = null,
 	)
-	for(var/datum/dynamic_ruleset/roundstart/extened/some_ruleset in dynamic_mode.executed_rules)
+	for(var/datum/dynamic_ruleset/roundstart/extended/some_ruleset in dynamic_mode.executed_rules)
 		if (some_ruleset.calledBy)
 			continue
 		write_data = TRUE

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -598,6 +598,23 @@ Assign your candidates in choose_candidates() instead.
 	requirements = list(0,0,0,0,0,0,0,0,0,0)
 	high_population_requirement = 101
 
+/datum/dynamic_ruleset/roundstart/extended/get_weight()
+	. = ..()
+	var/list/data = SSpersistence_misc.read_data(/datum/persistence_task/latest_extended_round)
+	if (!length(data))
+		return
+	var/yy = text2num(time2text(world.realtime, "YYYY"))
+	var/mm = text2num(time2text(world.realtime, "MM"))
+	var/dd = text2num(time2text(world.realtime, "DD"))
+	var/ex_yy = text2num(data["latest_extended_yy"])
+	var/ex_mm = text2num(data["latest_extended_mm"])
+	var/ex_dd = text2num(data["latest_extended_dd"])
+	// This is approximate because I don't want to recode bisextile years and all that trash
+	var/delta_days = (yy - ex_yy)*365 + (mm - ex_mm)*31 + (dd - ex_dd)
+	if (delta_days < 3)
+		. *= 0.5
+
+
 // 70% chance of allowing extended at 0-30 threat, then (100-threat)% chance.
 /datum/dynamic_ruleset/roundstart/extended/acceptable(population, threat_level)
 	var/probability = clamp(threat_level, 30, 100)


### PR DESCRIPTION
Because apparently people are going insane if there's no valids to kill.

:cl:
- rscadd: Weight of the Extended ruleset is halved if there's been another extended ruleset in the last days.