### PR TITLE
Dynamic Ruleset Pseudo-RNG tweaking

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1827,6 +1827,34 @@ Game Mode config tags:
 	else
 		return null
 
+/proc/IsRoundAboutToEnd()
+	//Is the round even already over?
+	if (ticker.current_state == GAME_STATE_FINISHED)
+		return TRUE
+
+	//Is the shuttle on its way to the station? or to centcomm after having departed from the station?
+	if(emergency_shuttle.online && emergency_shuttle.direction > 0)
+		return TRUE
+
+	//Is a nuke currently ticking down?
+	for (var/obj/machinery/nuclearbomb/the_bomba in nuclear_bombs)
+		if (the_bomba.timing)
+			return TRUE
+
+	//Is reality fucked?
+	if (universe.name in list("Hell Rising", "Supermatter Cascade"))
+		return TRUE
+
+	//Is some faction about to end the round?
+	var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
+	if (istype(dynamic_mode))
+		for (var/datum/faction/faction in dynamic_mode.factions)
+			if (faction.stage >= FACTION_ENDGAME)
+				return TRUE
+
+	//All is well
+	return FALSE
+
 //Ported from TG
 /proc/window_flash(client/C, ignorepref = FALSE)
     if(ismob(C))

--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -128,12 +128,14 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 	if (!istype(dynamic_mode))
 		return
 	var/list/data = list(
-		"latest_rulesets" = list()
+		"one_round_ago" = list(),
+		"two_rounds_ago" = dynamic_mode.previously_executed_rules["one_round_ago"],
+		"three_rounds_ago" = dynamic_mode.previously_executed_rules["two_rounds_ago"]
 	)
 	for(var/datum/dynamic_ruleset/some_ruleset in dynamic_mode.executed_rules)
 		if(some_ruleset.calledBy)
 			continue
-		data["latest_rulesets"] |= "[some_ruleset.type]"
+		data["one_round_ago"] |= "[some_ruleset.type]"
 	write_file(data)
 
 // This task has a unit test on code/modules/unit_tests/highscores.dm

--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -133,7 +133,9 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 		"three_rounds_ago" = dynamic_mode.previously_executed_rules["two_rounds_ago"]
 	)
 	for(var/datum/dynamic_ruleset/some_ruleset in dynamic_mode.executed_rules)
-		if(some_ruleset.calledBy)
+		if(some_ruleset.calledBy)//forced by an admin
+			continue
+		if(some_ruleset.stillborn)//executed near the end of the round
 			continue
 		data["one_round_ago"] |= "[some_ruleset.type]"
 	write_file(data)

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -304,6 +304,7 @@ var/stacking_limit = 90
 						return pick_delay(rule)
 
 					if (rule.execute())//this should never fail since ready() returned 1
+						rule.stillborn = IsRoundAboutToEnd()
 						executed_rules += rule
 						if (rule.persistent)
 							current_rules += rule
@@ -457,6 +458,7 @@ var/stacking_limit = 90
 
 	threat_log += "[worldtime2text()]: Roundstart [the_rule.name] spent [the_rule.cost]"
 	if (the_rule.execute())//this should never fail since ready() returned 1
+		the_rule.stillborn = IsRoundAboutToEnd()
 		executed_rules += the_rule
 		if (the_rule.persistent)
 			current_rules += the_rule
@@ -471,6 +473,7 @@ var/stacking_limit = 90
 		rule.candidates = player_list.Copy()
 		rule.trim_candidates()
 		if (rule.execute())//this should never fail since ready() returned 1
+			rule.stillborn = IsRoundAboutToEnd()
 			executed_rules += rule
 			if (rule.persistent)
 				current_rules += rule
@@ -489,6 +492,7 @@ var/stacking_limit = 90
 		threat_log += "[worldtime2text()]: Latejoin [latejoin_rule.name] spent [latejoin_rule.cost] (midround budget)"
 		dynamic_stats.measure_threat(threat)
 		if (latejoin_rule.execute())//this should never fail since ready() returned 1
+			latejoin_rule.stillborn = IsRoundAboutToEnd()
 			var/mob/M = pick(latejoin_rule.assigned)
 			message_admins("DYNAMIC MODE: [key_name(M)] joined the station, and was selected by the <font size='3'>[latejoin_rule.name]</font> ruleset.")
 			log_admin("DYNAMIC MODE: [key_name(M)] joined the station, and was selected by the [latejoin_rule.name] ruleset.")
@@ -508,6 +512,7 @@ var/stacking_limit = 90
 		threat_log += "[worldtime2text()]: Midround [midround_rule.name] spent [midround_rule.cost] (midround budget)"
 		dynamic_stats.measure_threat(threat)
 		if (midround_rule.execute())//this should never fail since ready() returned 1
+			midround_rule.stillborn = IsRoundAboutToEnd()
 			message_admins("DYNAMIC MODE: Injecting some threats...<font size='3'>[midround_rule.name]</font>!")
 			log_admin("DYNAMIC MODE: Injecting some threats...[midround_rule.name]!")
 			dynamic_stats.successful_injection(midround_rule)
@@ -544,6 +549,7 @@ var/stacking_limit = 90
 			threat_log += "[worldtime2text()]: Forced rule [new_rule.name] spent [new_rule.cost]"
 			dynamic_stats.measure_threat(threat)
 			if (new_rule.execute())//this should never fail since ready() returned 1
+				new_rule.stillborn = IsRoundAboutToEnd()
 				message_admins("Making a call to a specific ruleset...<font size='3'>[new_rule.name]</font>!")
 				log_admin("Making a call to a specific ruleset...[new_rule.name]!")
 				executed_rules += new_rule
@@ -882,3 +888,7 @@ var/stacking_limit = 90
 			return
 
 	message_admins("The rule was accepted.")
+
+/datum/gamemode/dynamic/proc/update_stillborn_rulesets()
+	for (var/datum/dynamic_ruleset/ruleset in executed_rules)
+		ruleset.stillborn = IsRoundAboutToEnd()

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -39,7 +39,7 @@ var/stacking_limit = 90
 	var/list/candidates = list()
 	var/list/current_rules = list()
 	var/list/executed_rules = list()
-	var/list/last_round_executed_rules = list()
+	var/list/previously_executed_rules = list()
 	var/list/rules_text = list()
 
 	var/list/living_players = list()
@@ -222,22 +222,24 @@ var/stacking_limit = 90
 
 	return 1
 
-/datum/gamemode/dynamic/proc/read_last_round_rulesets()
+/datum/gamemode/dynamic/proc/read_previous_rounds_rulesets()
 	var/list/data = SSpersistence_misc.read_data(/datum/persistence_task/latest_dynamic_rulesets)
 	if(!length(data))
 		return
-	var/list/last_round_rulesets_text = data["latest_rulesets"]
-	if(!length(last_round_rulesets_text))
-		return
-	var/list/last_round_rulesets = list()
-	for(var/entry in last_round_rulesets_text)
-		var/entry_path = text2path(entry)
-		if(entry_path) // It's possible that a ruleset that existed last round doesn't exist anymore
-			last_round_rulesets += entry_path
-	last_round_executed_rules = last_round_rulesets
+
+	for (var/entries in data)
+		var/previous_rulesets_text = data[entries]
+		if(!length(previous_rulesets_text))
+			return
+		var/list/previous_rulesets = list()
+		for(var/entry in previous_rulesets_text)
+			var/entry_path = text2path(entry)
+			if(entry_path) // It's possible that a ruleset that existed last round doesn't exist anymore
+				previous_rulesets += entry_path
+		previously_executed_rules[entries] = previous_rulesets
 
 /datum/gamemode/dynamic/Setup()
-	read_last_round_rulesets()
+	read_previous_rounds_rulesets()
 	for (var/rule in subtypesof(/datum/dynamic_ruleset/roundstart) - /datum/dynamic_ruleset/roundstart/delayed/)
 		roundstart_rules += new rule()
 	for (var/rule in subtypesof(/datum/dynamic_ruleset/latejoin))

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -135,19 +135,24 @@
 	var/result = weight
 	result *= map.ruleset_multiplier(src)
 	result *= weight_time_day()
-	var/halve_result = FALSE
+
 	for(var/datum/dynamic_ruleset/DR in mode.executed_rules)
-		if(DR.role_category == src.role_category) // Same kind of antag.
-			halve_result = TRUE
+		if(DR.role_category == src.role_category) // If the same type of antag is already in this round, reduce the odds
+			result *= 0.5
 			break
-	if(!halve_result)
-		for(var/entry in mode.last_round_executed_rules)
-			var/datum/dynamic_ruleset/DR = entry
+
+	for (var/previous_round in mode.previously_executed_rules)
+		for(var/previous_ruleset in mode.previously_executed_rules[previous_round])
+			var/datum/dynamic_ruleset/DR = previous_ruleset
 			if(initial(DR.role_category) == src.role_category)
-				halve_result = TRUE
-				break
-	if(halve_result)
-		result /= 2
+				switch (previous_round)
+					if ("one_round_ago")
+						result *= 0.5
+					if ("two_rounds_ago")
+						result *= 0.75
+					if ("three_rounds_ago")
+						result *= 0.90
+
 	if (mode.highlander_rulesets_favoured && (flags & HIGHLANDER_RULESET))
 		result *= ADDITIONAL_RULESET_WEIGHT
 	message_admins("[name] had [result] weight (-[initial(weight) - result]).")

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -22,6 +22,8 @@
 
 	var/flags = 0
 
+	var/stillborn = FALSE//executed when the round was already about to end
+
 	//for midround polling
 	var/list/applicants = list()
 	var/searching = 0

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -141,6 +141,14 @@
 			result *= 0.5
 			break
 
+	result = previous_rounds_odds_reduction(result)
+
+	if (mode.highlander_rulesets_favoured && (flags & HIGHLANDER_RULESET))
+		result *= ADDITIONAL_RULESET_WEIGHT
+	message_admins("[name] had [result] weight (-[initial(weight) - result]).")
+	return result
+
+/datum/dynamic_ruleset/proc/previous_rounds_odds_reduction(var/result)
 	for (var/previous_round in mode.previously_executed_rules)
 		for(var/previous_ruleset in mode.previously_executed_rules[previous_round])
 			var/datum/dynamic_ruleset/DR = previous_ruleset
@@ -152,10 +160,6 @@
 						result *= 0.7
 					if ("three_rounds_ago")
 						result *= 0.9
-
-	if (mode.highlander_rulesets_favoured && (flags & HIGHLANDER_RULESET))
-		result *= ADDITIONAL_RULESET_WEIGHT
-	message_admins("[name] had [result] weight (-[initial(weight) - result]).")
 	return result
 
 //Return a multiplicative weight. 1 for nothing special.

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -147,11 +147,11 @@
 			if(initial(DR.role_category) == src.role_category)
 				switch (previous_round)
 					if ("one_round_ago")
-						result *= 0.5
+						result *= 0.4
 					if ("two_rounds_ago")
-						result *= 0.75
+						result *= 0.7
 					if ("three_rounds_ago")
-						result *= 0.90
+						result *= 0.9
 
 	if (mode.highlander_rulesets_favoured && (flags & HIGHLANDER_RULESET))
 		result *= ADDITIONAL_RULESET_WEIGHT

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -60,6 +60,9 @@
 	newTraitor.Greet(GREET_LATEJOIN)
 	return 1
 
+/datum/dynamic_ruleset/latejoin/infiltrator/previous_rounds_odds_reduction(var/result)
+	return result
+
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -226,6 +226,9 @@
 	newTraitor.AnnounceObjectives()
 	return 1
 
+/datum/dynamic_ruleset/midround/autotraitor/previous_rounds_odds_reduction(var/result)
+	return result
+
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -41,6 +41,9 @@
 		// Above 3 traitors, we start to cost a bit more.
 	return 1
 
+/datum/dynamic_ruleset/roundstart/traitor/previous_rounds_odds_reduction(var/result)
+	return result
+
 //////////////////////////////////////////////
 //                                          //
 //               CHALLENGERS                ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -163,7 +163,7 @@ var/global/global_anchor_bloodstone // Keeps track of what stone becomes the anc
 		command_alert(/datum/command_alert/bloodstones_broken)
 		var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
 		if (istype(dynamic_mode))
-			update_stillborn_rulesets()
+			dynamic_mode.update_stillborn_rulesets()
 		for (var/obj/structure/cult/bloodstone/B in bloodstone_list)
 			B.takeDamage(B.maxHealth+1)
 		for (var/obj/effect/rune/R in rune_set.rune_list)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -161,6 +161,9 @@ var/global/global_anchor_bloodstone // Keeps track of what stone becomes the anc
 		veil_thickness = CULT_MENDED
 		..()
 		command_alert(/datum/command_alert/bloodstones_broken)
+		var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
+		if (istype(dynamic_mode))
+			update_stillborn_rulesets()
 		for (var/obj/structure/cult/bloodstone/B in bloodstone_list)
 			B.takeDamage(B.maxHealth+1)
 		for (var/obj/effect/rune/R in rune_set.rune_list)

--- a/code/datums/gamemode/factions/malf.dm
+++ b/code/datums/gamemode/factions/malf.dm
@@ -44,6 +44,9 @@
 		if(!living_ais && stage<MALF_CHOOSING_NUKE)
 			command_alert(/datum/command_alert/malf_destroyed)
 			stage(FACTION_DEFEATED)
+			var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
+			if (istype(dynamic_mode))
+				dynamic_mode.update_stillborn_rulesets()
 			return
 		if(apcs >= 3 && can_malf_ai_takeover())
 			AI_win_timeleft -= ((apcs / 6) * SSticker.getLastTickerTimeDuration()) //Victory timer de-increments based on how many APCs are hacked.

--- a/code/datums/gamemode/factions/syndicate/rev.dm
+++ b/code/datums/gamemode/factions/syndicate/rev.dm
@@ -161,7 +161,7 @@
 			command_alert(/datum/command_alert/revolutiontoppled)
 			var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
 			if (istype(dynamic_mode))
-				update_stillborn_rulesets()
+				dynamic_mode.update_stillborn_rulesets()
 
 // Called on arrivals and emergency shuttle departure.
 /hook_handler/revs

--- a/code/datums/gamemode/factions/syndicate/rev.dm
+++ b/code/datums/gamemode/factions/syndicate/rev.dm
@@ -116,7 +116,7 @@
 	for(var/datum/objective/objective in objective_holder.GetObjectives())
 		if(objective.IsFulfilled())
 			remaining_targets--
-			
+
 	if(stage < FACTION_ENDGAME)
 		var/living_revs = 0
 		var/total_valid_living = 0
@@ -159,6 +159,9 @@
 		if(!anyone)
 			stage(FACTION_DEFEATED)
 			command_alert(/datum/command_alert/revolutiontoppled)
+			var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
+			if (istype(dynamic_mode))
+				update_stillborn_rulesets()
 
 // Called on arrivals and emergency shuttle departure.
 /hook_handler/revs

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -239,7 +239,7 @@ var/list/nuclear_bombs = list()
 						score["nukedefuse"] = min(src.timeleft, score["nukedefuse"])
 						var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
 						if (istype(dynamic_mode))
-							update_stillborn_rulesets()
+							dynamic_mode.update_stillborn_rulesets()
 				if (href_list["safety"])
 					src.safety = !( src.safety )
 					if(safety)
@@ -248,7 +248,7 @@ var/list/nuclear_bombs = list()
 						score["nukedefuse"] = min(src.timeleft, score["nukedefuse"])
 						var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
 						if (istype(dynamic_mode))
-							update_stillborn_rulesets()
+							dynamic_mode.update_stillborn_rulesets()
 				if (href_list["anchor"])
 
 					if(removal_stage == 5)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -1,6 +1,8 @@
 var/bomb_set
 var/obj/item/weapon/disk/nuclear/nukedisk
 
+var/list/nuclear_bombs = list()
+
 /obj/machinery/nuclearbomb
 	name = "\improper Nuclear Fission Explosive"
 	desc = "Uh oh. RUN!!!!"
@@ -24,7 +26,12 @@ var/obj/item/weapon/disk/nuclear/nukedisk
 
 /obj/machinery/nuclearbomb/New()
 	..()
+	nuclear_bombs += src
 	r_code = "[rand(10000, 99999)]"//Creates a random code upon object spawn.
+
+/obj/machinery/nuclearbomb/Destroy()
+	nuclear_bombs -= src
+	..()
 
 /obj/machinery/nuclearbomb/process()
 	if(timing)
@@ -230,12 +237,18 @@ var/obj/item/weapon/disk/nuclear/nukedisk
 						src.icon_state = "nuclearbomb1"
 						bomb_set = 0
 						score["nukedefuse"] = min(src.timeleft, score["nukedefuse"])
+						var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
+						if (istype(dynamic_mode))
+							update_stillborn_rulesets()
 				if (href_list["safety"])
 					src.safety = !( src.safety )
 					if(safety)
 						src.timing = 0
 						bomb_set = 0
 						score["nukedefuse"] = min(src.timeleft, score["nukedefuse"])
+						var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
+						if (istype(dynamic_mode))
+							update_stillborn_rulesets()
 				if (href_list["anchor"])
 
 					if(removal_stage == 5)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -655,7 +655,7 @@ var/list/shuttle_log = list()
 		emergency_shuttle.recall()
 		var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
 		if (istype(dynamic_mode))
-			update_stillborn_rulesets()
+			dynamic_mode.update_stillborn_rulesets()
 		log_game("[key_name(user)] has recalled the shuttle.")
 		message_admins("[key_name_admin(user)] has recalled the shuttle - [formatJumpTo(user)].", 1)
 	return

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -653,6 +653,9 @@ var/list/shuttle_log = list()
 
 	if(emergency_shuttle.direction != -1 && emergency_shuttle.online) //check that shuttle isn't already heading to centcomm
 		emergency_shuttle.recall()
+		var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
+		if (istype(dynamic_mode))
+			update_stillborn_rulesets()
 		log_game("[key_name(user)] has recalled the shuttle.")
 		message_admins("[key_name_admin(user)] has recalled the shuttle - [formatJumpTo(user)].", 1)
 	return


### PR DESCRIPTION
Previously rulesets had their weight halved if they fired in the previous round. Now the round before and the one even before are also considered:

* If a ruleset fired last round, it's weight is reduced by 60%
* If a ruleset fired two rounds ago, it's weight is reduced by 30%
* If a ruleset fired three rounds ago, it's weight is reduced by 10%

These modifiers can stack up.

The idea for this PR stems from the ascertainment that even if a ruleset has an average rate of occurrence, players will always hate seeing it occur several times in a row. I think that only checking the previous round isn't sufficient to smooth the curve.

:cl:
* experiment: Dynamic ruleset picking had its pseudo-RNG tweaked to now consider not just the previous round, but all 3 previous rounds, decreasing the odds of a ruleset being picked again in a short timespan. The odds are reduced more if the round was more recent, and if it fired several times in the previous three rounds the odd reductions will stack up. This should help prevent having the same ruleset firing several times in a short timespan.
* experiment: Although note that rulesets that fire when the round was already about to end will NOT affect future rounds' ruleset weights.
* experiment: Syndicate Traitors, both roundstart, latejoin, and midround, are also always exempt from this weight reduction.