### PR TITLE
Primetime REdux

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -159,7 +159,7 @@
 	if(time2text(world.timeofday, "DDD") in weekday_rule_boost)
 		weigh *= 2
 		for(var/i = 1 to requirements.len)
-			requirements[i] = clamp(requirements[i] - 10,10,90)
+			requirements[i] = clamp(requirements[i] - 20,10,90)
 		for(var/i = 1 to required_pop.len)
 			required_pop[i] = clamp(required_pop[i] - 5,0,100)
 	if(getTimeslot() in timeslot_rule_boost)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -10,7 +10,7 @@
 	var/list/exclusive_to_jobs = list()//if set, rule will only accept candidates from those jobs
 	var/list/job_priority = list() //May be used by progressive_job_search for prioritizing some jobs for a role. Order matters.
 	var/list/enemy_jobs = list()//if set, there needs to be a certain amount of players doing those jobs (among the players who won't be drafted) for the rule to be drafted
-	var/required_pop = list(10,10,0,0,0,0,0,0,0,0)//if enemy_jobs was set, this is the amount of population required for the ruleset to fire. enemy jobs count double
+	var/list/required_pop = list(10,10,0,0,0,0,0,0,0,0)//if enemy_jobs was set, this is the amount of population required for the ruleset to fire. enemy jobs count double
 	var/required_enemies = list(0,0,0,0,0,0,0,0,0,0)		//If set, the ruleset requires this many enemy jobs to be filled in order to fire (per threat level)
 	var/required_candidates = 0//the rule needs this many candidates (post-trimming) to be executed (example: Cult need 4 players at round start)
 	var/weight = 5//1 -> 9, probability for this rule to be picked against other rules

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -158,6 +158,10 @@
 	var/weigh = 1
 	if(time2text(world.timeofday, "DDD") in weekday_rule_boost)
 		weigh *= 2
+		for(var/i = 1 to requirements.len)
+			requirements[i] = clamp(requirements[i] - 10,10,90)
+		for(var/i = 1 to required_pop.len)
+			required_pop[i] = clamp(required_pop[i] - 5,0,100)
 	if(getTimeslot() in timeslot_rule_boost)
 		weigh *= 2
 	return weigh

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -159,6 +159,8 @@
 	if(time2text(world.timeofday, "DDD") in weekday_rule_boost)
 		weigh *= 2
 		for(var/i = 1 to requirements.len)
+			if ((i < requirements.len) && (requirements[i+1] == 90))//let's not actually reduce the requirement on low pop.
+				continue
 			requirements[i] = clamp(requirements[i] - 20,10,90)
 		for(var/i = 1 to required_pop.len)
 			required_pop[i] = clamp(required_pop[i] - 5,0,100)


### PR DESCRIPTION
I love the concept of @Kurfursten's Primetime, but while the current implementation doubles the weight, it doesn't actually lower the actual requirements (which in the case of the only ruleset actually using the feature, blob, is very high) (no rambler doesn't count). This causes the boosted ruleset to not fire noticeably more often because it still relies on Dynamic to roll a threat level high enough.

This PR lowers said threat and pop requirements slightly, putting them on par with slightly less dangerous rulesets. **Low pop won't be affected by that change.**

reminder: the threat requirements are set in increments of 5 pop (0-4 , 5-9 , etc)
```
default blob :      90,90,90,80,60,40,30,20,10,10
primetime blob :    90,90,70,60,40,20,10,10,10,10
```
for comparison:
```
default malf:       90,80,70,60,50,40,40,30,30,20
default wiz:        90,90,70,40,30,20,10,10,10,10
default cult:       90,80,60,30,20,10,10,10,10,10
```

Might want to wait for #29753 to be merged first to avoid a case of "blob every round on tuesday" though.

:cl:
* experiment: Primetime rulesets now have lowered threat requirement, which should allow them to actually fire if the pop allows it but the Threat is average. Basically this means that Blob Tuesdays can finally be a thing. Also note that this doesn't affect low pop (if the threat requirement is 90, it will remain 90 in most cases)