### PR TITLE
Lazy event portable holomaps

### DIFF
--- a/code/game/machinery/station_map.dm
+++ b/code/game/machinery/station_map.dm
@@ -227,7 +227,7 @@ var/list/station_holomaps = list()
 			if (prob(25))
 				set_broken()
 
-//Portable holomaps, currently AI/Borg/MoMMI only
+//Portable holomaps, used by Ghosts, Silicons, and PDA (using the Station Holomap app)
 /obj/item/device/station_map
 	name					= "portable station holomap"
 	desc					= "A virtual map of the surrounding station."

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -40,9 +40,10 @@
 
 			if(m_intent == "run")
 				burn_calories(HUNGER_FACTOR / 20)
-		//update_minimap()
-		if (displayed_holomap)
-			displayed_holomap.update_holomap()
+
+/mob/living/carbon/proc/update_holomaps()
+	if (displayed_holomap)
+		displayed_holomap.update_holomap()
 
 /mob/living/carbon/attack_animal(mob/living/simple_animal/M as mob)//humans and slimes have their own
 	M.unarmed_attack_mob(src)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -32,8 +32,10 @@
 /mob/living/carbon/New(var/new_loc, var/new_species_name = null, var/delay_ready_dna=0)
 	..()
 	hud_list[CONVERSION_HUD] = image('icons/mob/hud.dmi', src, "hudblank")
+	lazy_register_event(/lazy_event/on_after_move, src, /mob/living/carbon/proc/update_holomaps)
 
 /mob/living/carbon/Destroy()
+	lazy_unregister_event(/lazy_event/on_after_move, src, /mob/living/carbon/proc/update_holomaps)
 	if (mutual_handcuffs && mutual_handcuffed_to)
 		mutual_handcuffs.remove_mutual_cuff_events(mutual_handcuffed_to)
 	. = ..()


### PR DESCRIPTION
Fixes #25672

:cl:
* bugfix: The holomap on from the PDA Station Holomap app now properly updates when moving aboard a vehicle.