### PR TITLE
EMPing a mech actually EMPs the power cell

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -718,7 +718,7 @@
 
 /obj/mecha/emp_act(severity)
 	if(get_charge())
-		cell.emp_act((severity*0.75))
+		cell.emp_act(round(severity*0.75))
 		take_damage(50 / severity,"energy")
 	src.log_message("EMP detected",1)
 	check_for_internal_damage(list(MECHA_INT_FIRE,MECHA_INT_TEMP_CONTROL,MECHA_INT_CONTROL_LOST,MECHA_INT_SHORT_CIRCUIT),1)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -718,7 +718,7 @@
 
 /obj/mecha/emp_act(severity)
 	if(get_charge())
-		cell.emp_act(round(severity*0.75))
+		cell.emp_act(severity*1.25)
 		take_damage(50 / severity,"energy")
 	src.log_message("EMP detected",1)
 	check_for_internal_damage(list(MECHA_INT_FIRE,MECHA_INT_TEMP_CONTROL,MECHA_INT_CONTROL_LOST,MECHA_INT_SHORT_CIRCUIT),1)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -718,7 +718,7 @@
 
 /obj/mecha/emp_act(severity)
 	if(get_charge())
-		use_power((cell.charge/2)/severity)
+		cell.emp_act((severity*0.75))
 		take_damage(50 / severity,"energy")
 	src.log_message("EMP detected",1)
 	check_for_internal_damage(list(MECHA_INT_FIRE,MECHA_INT_TEMP_CONTROL,MECHA_INT_CONTROL_LOST,MECHA_INT_SHORT_CIRCUIT),1)


### PR DESCRIPTION
[bugfix] EMPing a mech now calls emp_act() on the mech's power cell instead of just reducing cell charge directly, meaning that a mech's power cell is now vulnerable to degraded performance if it's an RTG or any other cell type that can develop faults. In line with mech EMPs prior to this fix having a weaker drain on the power cell than a cell getting EMPed in the open, mechs reduce the effects of an EMP on their cell by 25% (value subject to change based on further input).

:cl:
 * bugfix: EMPing a mech now actually EMPs its cell