### PR TITLE
Hostile mobs no longer destroy firelocks that are either open, or welded down

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -457,6 +457,10 @@
 						var/obj/machinery/door/airlock/AIR = A
 						if(!AIR.density || AIR.locked || AIR.welded || AIR.operating)
 							continue
+					if(istype(A, /obj/machinery/door/firedoor))
+						var/obj/machinery/door/firedoor/FIR = A
+						if(!FIR.density || FIR.locked || FIR.welded || FIR.operating)
+							continue
 					UnarmedAttack(A, Adjacent(A))
 	return
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -459,7 +459,7 @@
 							continue
 					if(istype(A, /obj/machinery/door/firedoor))
 						var/obj/machinery/door/firedoor/FIR = A
-						if(!FIR.density || FIR.locked || FIR.blocked || FIR.operating)
+						if(!FIR.density || FIR.lockdown || FIR.blocked || FIR.operating)
 							continue
 					UnarmedAttack(A, Adjacent(A))
 	return

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -459,7 +459,7 @@
 							continue
 					if(istype(A, /obj/machinery/door/firedoor))
 						var/obj/machinery/door/firedoor/FIR = A
-						if(!FIR.density || FIR.locked || FIR.welded || FIR.operating)
+						if(!FIR.density || FIR.locked || FIR.blocked || FIR.operating)
 							continue
 					UnarmedAttack(A, Adjacent(A))
 	return

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -459,7 +459,7 @@
 							continue
 					if(istype(A, /obj/machinery/door/firedoor))
 						var/obj/machinery/door/firedoor/FIR = A
-						if(!FIR.density || FIR.lockdown || FIR.blocked || FIR.operating)
+						if(!FIR.density || FIR.blocked || FIR.operating)
 							continue
 					UnarmedAttack(A, Adjacent(A))
 	return


### PR DESCRIPTION
It's annoying watching them spawn dismantled firelocks everywhere, so I gave them parity with regular airlocks.

:cl:
* tweak: Hostile mobs no longer destroy firelocks that are either open, or welded down.