### PR TITLE
Makes the mouser fit on the handgun holster.

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -153,6 +153,9 @@
 
 /obj/item/weapon/gun/energy/mouser/update_icon()
 	return
+	
+/obj/item/weapon/gun/energy/mouser/isHandgun()
+	return TRUE
 
 /obj/item/weapon/gun/energy/staff/sinterklaas
 	name = "staff of sinterklaas"


### PR DESCRIPTION
Closes #29766 
[hotfix][consistency]
:cl:
 * tweak: Makes the mouser fit inside the handgun holster.