### PR TITLE
Gives MoMMIs a solder. No self refueling though.

### DIFF
--- a/code/modules/mob/living/silicon/mommi/mommi_modules.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_modules.dm
@@ -29,6 +29,7 @@
 	modules += new /obj/item/device/holomap(src)
 	modules += new /obj/item/device/station_map(src)
 	modules += new /obj/item/device/silicate_sprayer(src)
+	modules += new /obj/item/tool/solder/pre_fueled(src)
 	modules += new /obj/item/borg/fire_shield
 
 	var/obj/item/stack/cable_coil/W = new /obj/item/stack/cable_coil/yellow(src)


### PR DESCRIPTION
Closes #29760. 
The autismo crabs now get a solder. No, it doesn't self refill. If the crab wants more sacid it will need to find or make some.
Given that the soldering irons aren't that useful (in comparison to the other tools), I see no reason to keep it away from them.
:cl:
 * rscadd: Gives a prefueled solder to the MoMMIs. It is not self refilling.