### PR TITLE
Fixed Scoreboard icons for good

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -28,7 +28,6 @@ var/list/protected_global_vars = list(
 var/round_end_info = ""
 var/round_end_info_no_img = ""
 var/last_round_end_info = ""
-var/list/last_scoreboard_images = list()
 
 //List of ckeys that have de-adminned themselves during this round
 var/global/list/deadmins = list()
@@ -315,9 +314,6 @@ var/global/bomberman_destroy = 0
 var/global/list/volunteer_gladiators = list()
 var/global/list/ready_gladiators = list()
 var/global/list/never_gladiators = list()
-
-//icons that appear on the Round End pop-up browser
-var/global/list/end_icons = list()
 
 var/global/list/arena_leaderboard = list()
 var/arena_rounds = 0

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -559,16 +559,6 @@ proc/sql_sanitize_text(var/text)
 	dat = image_finder.Replace(dat, "")
 	return dat
 
-/proc/convert_scoreboard_images_to_base64(var/dat)
-	if(!dat)
-		return
-	if (!last_scoreboard_images?.len)
-		return remove_images(dat)
-	var/static/regex/magic = new(@"(<img src..logo_.*?>)")
-	for (var/i = 1 to last_scoreboard_images.len)
-		dat = magic.Replace(dat, "<img class='icon' src='data:image/png;base64,[last_scoreboard_images[i]]'>")
-	return dat
-
 /proc/nekospeech(var/speech)
 	if(!speech)
 		return

--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -125,8 +125,7 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 	if(!to_read)
 		log_debug("[name] task found an empty file on [file_path]")
 		return
-	last_scoreboard_images = to_read["round_images"]
-	last_round_end_info = convert_scoreboard_images_to_base64(to_read["round_info"])
+	last_round_end_info = to_read["round_info"]
 	for (var/client/C in clients)
 		winset(C, "rpane.round_end", "is-visible=false")
 		winset(C, "rpane.last_round_end", "is-visible=true")
@@ -134,8 +133,6 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 /datum/persistence_task/round_end_data/on_shutdown()
 	if (round_end_info)
 		data["round_info"] = round_end_info
-	if (last_scoreboard_images?.len)
-		data["round_images"] = last_scoreboard_images
 	write_file(data)
 
 /datum/persistence_task/latest_dynamic_rulesets

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -335,11 +335,14 @@
 				flat.Turn(90)
 			var/icon/ded = icon('icons/effects/blood.dmi', "floor1-old")
 			ded.Blend(flat,ICON_OVERLAY)
-			end_icons += ded
+			//end_icons += ded
+
+			text += "<img class='icon' src='data:image/png;base64,[iconsouth2base64(ded)]' style='position:relative; top:10px;'>"
 		else
-			end_icons += flat
-		var/tempstate = end_icons.len
-		text += "<img src='logo_[tempstate].png' style='position:relative; top:10px;'/>"
+			text += "<img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]' style='position:relative; top:10px;'>"
+			//end_icons += flat
+		//var/tempstate = end_icons.len
+		//text += "<img src='logo_[tempstate].png' style='position:relative; top:10px;'/>"
 
 	var/icon/logo = icon('icons/logos.dmi', logo_state)
 	text += "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative;top:10px;'/><b>[antag ? "[antag.key]" : "(somebody)"]</b> was <b>[antag ? "[antag.name]" : "(someone)"]</b> ("

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -97,7 +97,6 @@
 	var/destroyed = FALSE //Whether or not it has been gibbed
 
 	var/list/uplink_items_bought = list() //migrated from mind, used in GetScoreboard()
-	var/list/artifacts_bought = list() //migrated from mind
 
 	// The host (set if NEED_HOST)
 	var/datum/mind/host=null
@@ -335,14 +334,9 @@
 				flat.Turn(90)
 			var/icon/ded = icon('icons/effects/blood.dmi', "floor1-old")
 			ded.Blend(flat,ICON_OVERLAY)
-			//end_icons += ded
-
 			text += "<img class='icon' src='data:image/png;base64,[iconsouth2base64(ded)]' style='position:relative; top:10px;'>"
 		else
 			text += "<img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]' style='position:relative; top:10px;'>"
-			//end_icons += flat
-		//var/tempstate = end_icons.len
-		//text += "<img src='logo_[tempstate].png' style='position:relative; top:10px;'/>"
 
 	var/icon/logo = icon('icons/logos.dmi', logo_state)
 	text += "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative;top:10px;'/><b>[antag ? "[antag.key]" : "(somebody)"]</b> was <b>[antag ? "[antag.name]" : "(someone)"]</b> ("

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -78,9 +78,9 @@
 			. += "<BR>The wizard knew:<BR>"
 			for(var/spell/S in H.spell_list)
 				var/icon/tempimage = icon('icons/mob/screen_spells.dmi', S.hud_state)
-				end_icons += tempimage
-				var/tempstate = end_icons.len
-				. += "<img src='logo_[tempstate].png'> [S.name]<BR>"
+				//end_icons += tempimage
+				//var/tempstate = end_icons.len
+				. += "<img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [S.name]<BR>"
 		if(artifacts_bought)
 			bought_nothing = FALSE
 			. += "<BR>Additionally, the wizard brought:<BR>"

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -9,6 +9,9 @@
 
 	stat_datum_type = /datum/stat/role/wizard
 
+	var/list/artifacts_bought = list()
+	var/list/potions_bought = list()
+
 /datum/role/wizard/ForgeObjectives()
 	if(!antag.current.client.prefs.antag_objectives)
 		AppendObjective(/datum/objective/freeform/wizard)
@@ -78,13 +81,13 @@
 			. += "<BR>The wizard knew:<BR>"
 			for(var/spell/S in H.spell_list)
 				var/icon/tempimage = icon('icons/mob/screen_spells.dmi', S.hud_state)
-				//end_icons += tempimage
-				//var/tempstate = end_icons.len
 				. += "<img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [S.name]<BR>"
-		if(artifacts_bought)
+		if(artifacts_bought || potions_bought)
 			bought_nothing = FALSE
 			. += "<BR>Additionally, the wizard brought:<BR>"
 			for(var/entry in artifacts_bought)
+				. += "[entry]<BR>"
+			for(var/entry in potions_bought)
 				. += "[entry]<BR>"
 		if(bought_nothing)
 			. += "The wizard used only the magic of charisma this round."

--- a/code/datums/gamemode/role/wizard_apprentice.dm
+++ b/code/datums/gamemode/role/wizard_apprentice.dm
@@ -47,6 +47,4 @@
 		if(S.user_type != USER_TYPE_WIZARD)
 			continue
 		var/icon/tempimage = icon('icons/mob/screen_spells.dmi', S.hud_state)
-		end_icons += tempimage
-		var/tempstate = end_icons.len
-		. += "<img src='logo_[tempstate].png'> [S.name]<BR>"
+		. += "<img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [S.name]<BR>"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -101,8 +101,6 @@ var/list/uplink_items = list()
 			return 0
 		on_item_spawned(I,user)
 		var/icon/tempimage = icon(I.icon, I.icon_state)
-		end_icons += tempimage
-		var/tempstate = end_icons.len
 
 		var/bundlename = name
 		if(name == "Random Item" || name == "For showing that you are The Boss")
@@ -116,7 +114,7 @@ var/list/uplink_items = list()
 			if(istype(I, /obj/item))
 				A.put_in_any_hand_if_possible(I)
 
-			U.purchase_log += {"[user] ([user.ckey]) bought <img src="logo_[tempstate].png"> [name] for [get_cost(U.job)]."}
+			U.purchase_log += {"[user] ([user.ckey]) bought <img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [name] for [get_cost(U.job)]."}
 			stat_collection.uplink_purchase(src, I, user)
 			times_bought += 1
 
@@ -125,11 +123,11 @@ var/list/uplink_items = list()
 				//First, try to add the uplink buys to any operative teams they're on. If none, add to a traitor role they have.
 				var/datum/role/R = user.mind.GetRole(NUKE_OP)
 				if(R)
-					R.faction.faction_scoreboard_data += {"<img src="logo_[tempstate].png"> [bundlename] for [get_cost(U.job)] TC<BR>"}
+					R.faction.faction_scoreboard_data += {"<img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [bundlename] for [get_cost(U.job)] TC<BR>"}
 				else
 					R = user.mind.GetRole(TRAITOR)
 					if(R)
-						R.uplink_items_bought += {"<img src="logo_[tempstate].png"> [bundlename] for [get_cost(U.job)] TC<BR>"}
+						R.uplink_items_bought += {"<img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [bundlename] for [get_cost(U.job)] TC<BR>"}
 		U.interact(user)
 
 		return 1

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -552,87 +552,12 @@ var/datum/controller/gameticker/ticker
 	scoreboard()
 	return 1
 
-/*
-/datum/controller/gameticker/proc/ert_declare_completion()
-	var/text = ""
-	if( ticker.mode.ert.len )
-		var/icon/logo = icon('icons/logos.dmi', "ert-logo")
-		end_icons += logo
-		var/tempstate = end_icons.len
-		text += {"<br><img src="logo_[tempstate].png"> <FONT size = 2><B>The emergency responders were:</B></FONT> <img src="logo_[tempstate].png">"}
-		for(var/datum/mind/ert in ticker.mode.ert)
-			if(ert.current)
-				var/icon/flat = getFlatIcon(ert.current, SOUTH, 1, 1)
-				end_icons += flat
-				tempstate = end_icons.len
-				text += {"<br><img src="logo_[tempstate].png"> <b>[ert.key]</b> was <b>[ert.name]</b> ("}
-				if(ert.current.stat == DEAD)
-					text += "died"
-					flat.Turn(90)
-					end_icons[tempstate] = flat
-				else
-					text += "survived"
-				if(ert.current.real_name != ert.name)
-					text += " as [ert.current.real_name]"
-			else
-				var/icon/sprotch = icon('icons/effects/blood.dmi', "floor1-old")
-				end_icons += sprotch
-				tempstate = end_icons.len
-				text += {"<br><img src="logo_[tempstate].png"> [ert.key] was [ert.name] ("}
-				text += "body destroyed"
-			text += ")"
-		text += "<BR><HR>"
-
-	return text
-
-/datum/controller/gameticker/proc/deathsquad_declare_completion()
-	var/text = ""
-	if( ticker.mode.deathsquad.len )
-		var/icon/logo = icon('icons/logos.dmi', "death-logo")
-		end_icons += logo
-		var/tempstate = end_icons.len
-		text += {"<br><img src="logo_[tempstate].png"> <FONT size = 2><B>The death commando were:</B></FONT> <img src="logo_[tempstate].png">"}
-		for(var/datum/mind/deathsquad in ticker.mode.deathsquad)
-			if(deathsquad.current)
-				var/icon/flat = getFlatIcon(deathsquad.current, SOUTH, 1, 1)
-				end_icons += flat
-				tempstate = end_icons.len
-				text += {"<br><img src="logo_[tempstate].png"> <b>[deathsquad.key]</b> was <b>[deathsquad.name]</b> ("}
-				if(deathsquad.current.stat == DEAD)
-					text += "died"
-					flat.Turn(90)
-					end_icons[tempstate] = flat
-				else
-					text += "survived"
-				if(deathsquad.current.real_name != deathsquad.name)
-					text += " as [deathsquad.current.real_name]"
-			else
-				var/icon/sprotch = icon('icons/effects/blood.dmi', "floor1-old")
-				end_icons += sprotch
-				tempstate = end_icons.len
-				text += {"<br><img src="logo_[tempstate].png"> [deathsquad.key] was [deathsquad.name] ("}
-				text += "body destroyed"
-			text += ")"
-		text += "<BR><HR>"
-
-	return text
-*/
 /datum/controller/gameticker/proc/bomberman_declare_completion()
 	var/icon/bomberhead = icon('icons/obj/clothing/hats.dmi', "bomberman")
-	end_icons += bomberhead
-	var/tempstatebomberhead = end_icons.len
 	var/icon/bronze = icon('icons/obj/bomberman.dmi', "bronze")
-	end_icons += bronze
-	var/tempstatebronze = end_icons.len
 	var/icon/silver = icon('icons/obj/bomberman.dmi', "silver")
-	end_icons += silver
-	var/tempstatesilver = end_icons.len
 	var/icon/gold = icon('icons/obj/bomberman.dmi', "gold")
-	end_icons += gold
-	var/tempstategold = end_icons.len
 	var/icon/platinum = icon('icons/obj/bomberman.dmi', "platinum")
-	end_icons += platinum
-	var/tempstateplatinum = end_icons.len
 
 	var/list/bronze_tier = list()
 	for (var/mob/living/carbon/M in player_list)
@@ -663,44 +588,34 @@ var/datum/controller/gameticker/ticker
 		if(istype(M.head_state, /obj/item/clothing/head/helmet/space/bomberman) && istype(M.tool_state, /obj/item/weapon/bomberman/))
 			special_tier += M
 
-	var/text = {"<img src="logo_[tempstatebomberhead].png"> <font size=5><b>Bomberman Mode Results</b></font> <img src="logo_[tempstatebomberhead].png">"}
+	var/text = {"<img class='icon' src='data:image/png;base64,[iconsouth2base64(bomberhead)]'> <font size=5><b>Bomberman Mode Results</b></font> <img class='icon' src='data:image/png;base64,[iconsouth2base64(bomberhead)]'>"}
 	if(!platinum_tier.len && !gold_tier.len && !silver_tier.len && !bronze_tier.len)
 		text += "<br><span class='danger'>DRAW!</span>"
 	if(platinum_tier.len)
-		text += {"<br><img src="logo_[tempstateplatinum].png"> <b>Platinum Trophy</b> (never removed his clothes, kept his bomb dispenser until the end, and escaped on the shuttle):"}
+		text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(platinum)]'> <b>Platinum Trophy</b> (never removed his clothes, kept his bomb dispenser until the end, and escaped on the shuttle):"}
 		for (var/mob/M in platinum_tier)
 			var/icon/flat = getFlatIcon(M, SOUTH, 1, 1)
-			end_icons += flat
-			var/tempstate = end_icons.len
-			text += {"<br><img src="logo_[tempstate].png"> <b>[M.key]</b> as <b>[M.real_name]</b>"}
+			text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> <b>[M.key]</b> as <b>[M.real_name]</b>"}
 	if(gold_tier.len)
-		text += {"<br><img src="logo_[tempstategold].png"> <b>Gold Trophy</b> (kept his bomb dispenser until the end, and escaped on the shuttle):"}
+		text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(gold)]'> <b>Gold Trophy</b> (kept his bomb dispenser until the end, and escaped on the shuttle):"}
 		for (var/mob/M in gold_tier)
 			var/icon/flat = getFlatIcon(M, SOUTH, 1, 1)
-			end_icons += flat
-			var/tempstate = end_icons.len
-			text += {"<br><img src="logo_[tempstate].png"> <b>[M.key]</b> as <b>[M.real_name]</b>"}
+			text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> <b>[M.key]</b> as <b>[M.real_name]</b>"}
 	if(silver_tier.len)
-		text += {"<br><img src="logo_[tempstatesilver].png"> <b>Silver Trophy</b> (kept his bomb dispenser until the end, and escaped in a pod):"}
+		text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(silver)]'> <b>Silver Trophy</b> (kept his bomb dispenser until the end, and escaped in a pod):"}
 		for (var/mob/M in silver_tier)
 			var/icon/flat = getFlatIcon(M, SOUTH, 1, 1)
-			end_icons += flat
-			var/tempstate = end_icons.len
-			text += {"<br><img src="logo_[tempstate].png"> <b>[M.key]</b> as <b>[M.real_name]</b>"}
+			text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> <b>[M.key]</b> as <b>[M.real_name]</b>"}
 	if(bronze_tier.len)
-		text += {"<br><img src="logo_[tempstatebronze].png"> <b>Bronze Trophy</b> (kept his bomb dispenser until the end):"}
+		text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(bronze)]'> <b>Bronze Trophy</b> (kept his bomb dispenser until the end):"}
 		for (var/mob/M in bronze_tier)
 			var/icon/flat = getFlatIcon(M, SOUTH, 1, 1)
-			end_icons += flat
-			var/tempstate = end_icons.len
-			text += {"<br><img src="logo_[tempstate].png"> <b>[M.key]</b> as <b>[M.real_name]</b>"}
+			text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> <b>[M.key]</b> as <b>[M.real_name]</b>"}
 	if(special_tier.len)
 		text += "<br><b>Special Mention</b> to those adorable MoMMis:"
 		for (var/mob/M in special_tier)
 			var/icon/flat = getFlatIcon(M, SOUTH, 1, 1)
-			end_icons += flat
-			var/tempstate = end_icons.len
-			text += {"<br><img src="logo_[tempstate].png"> <b>[M.key]</b> as <b>[M.name]</b>"}
+			text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> <b>[M.key]</b> as <b>[M.name]</b>"}
 
 	return text
 

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -20,12 +20,10 @@
 	var/ai_completions = ""
 	for(var/mob/living/silicon/ai/ai in mob_list)
 		var/icon/flat = getFlatIcon(ai)
-		end_icons += flat
-		var/tempstate = end_icons.len
 		if(ai.stat != 2)
-			ai_completions += {"<br><b><img src="logo_[tempstate].png"> [ai.name] (Played by: [get_key(ai)])'s laws at the end of the game were:</b>"}
+			ai_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [ai.name] (Played by: [get_key(ai)])'s laws at the end of the game were:</b>"}
 		else
-			ai_completions += {"<br><b><img src="logo_[tempstate].png"> [ai.name] (Played by: [get_key(ai)])'s laws when it was deactivated were:</b>"}
+			ai_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [ai.name] (Played by: [get_key(ai)])'s laws when it was deactivated were:</b>"}
 		ai_completions += "<br>[ai.write_laws()]"
 
 		if (ai.connected_robots.len)
@@ -40,23 +38,18 @@
 		if(!robo)
 			continue
 		var/icon/flat = getFlatIcon(robo)
-		end_icons += flat
-		var/tempstate = end_icons.len
 		if (!robo.connected_ai)
 			if (robo.stat != 2)
-				ai_completions += {"<br><b><img src="logo_[tempstate].png"> [robo.name] (Played by: [get_key(robo)]) survived as an AI-less [isMoMMI(robo)?"MoMMI":"borg"]! Its laws were:</b>"}
+				ai_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [robo.name] (Played by: [get_key(robo)]) survived as an AI-less [isMoMMI(robo)?"MoMMI":"borg"]! Its laws were:</b>"}
 			else
-				ai_completions += {"<br><b><img src="logo_[tempstate].png"> [robo.name] (Played by: [get_key(robo)]) was unable to survive the rigors of being a [isMoMMI(robo)?"MoMMI":"cyborg"] without an AI. Its laws were:</b>"}
+				ai_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [robo.name] (Played by: [get_key(robo)]) was unable to survive the rigors of being a [isMoMMI(robo)?"MoMMI":"cyborg"] without an AI. Its laws were:</b>"}
 		else
-			ai_completions += {"<br><b><img src="logo_[tempstate].png"> [robo.name] (Played by: [get_key(robo)]) [robo.stat!=2?"survived":"perished"] as a [isMoMMI(robo)?"MoMMI":"cyborg"] slaved to [robo.connected_ai]! Its laws were:</b>"}
+			ai_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [robo.name] (Played by: [get_key(robo)]) [robo.stat!=2?"survived":"perished"] as a [isMoMMI(robo)?"MoMMI":"cyborg"] slaved to [robo.connected_ai]! Its laws were:</b>"}
 		ai_completions += "<br>[robo.write_laws()]"
 
 	for(var/mob/living/silicon/pai/pAI in mob_list)
-		var/icon/flat
-		flat = getFlatIcon(pAI)
-		end_icons += flat
-		var/tempstate = end_icons.len
-		ai_completions += {"<br><b><img src="logo_[tempstate].png"> [pAI.name] (Played by: [get_key(pAI)]) [pAI.stat!=2?"survived":"perished"] as a pAI whose master was [pAI.master]! Its directives were:</b><br>[pAI.write_directives()]"}
+		var/icon/flat = getFlatIcon(pAI)
+		ai_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [pAI.name] (Played by: [get_key(pAI)]) [pAI.stat!=2?"survived":"perished"] as a pAI whose master was [pAI.master]! Its directives were:</b><br>[pAI.write_directives()]"}
 
 	if (ai_completions)
 		completions += "<h2>Silicons Laws</h2>"
@@ -685,18 +678,12 @@
 
 	round_end_info = dat
 	round_end_info_no_img = remove_images(dat)
-	last_scoreboard_images = list()
-	for(var/i = 1 to end_icons.len)
-		last_scoreboard_images += iconsouth2base64(end_icons[i])
 	log_game(round_end_info_no_img)
 	stat_collection.crew_score = score["crewscore"]
 
 /mob/proc/display_round_end_scoreboard()
 	if (!client)
 		return
-
-	for(var/i = 1 to end_icons.len)
-		src << browse_rsc(end_icons[i],"logo_[i].png")
 
 	var/datum/browser/popup = new(src, "roundstats", "Round End Summary", 1000, 600)
 	popup.set_content(round_end_info)

--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -15,9 +15,7 @@
 			var/datum/role/wizard/W = user.mind.GetRole(WIZARD)
 			if(W)
 				var/icon/tempimage = icon(I.icon, I.icon_state)
-				end_icons += tempimage
-				var/tempstate = end_icons.len
-				W.artifacts_bought += {"<img src="logo_[tempstate].png"> [name]<BR>"}
+				W.artifacts_bought += {"<img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [name]<BR>"}
 
 /datum/spellbook_artifact/proc/can_buy(var/mob/user)
 	return TRUE

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -332,11 +332,15 @@
 			if(buy_type in available_potions)
 				if(use(available_potions[buy_type]))
 					var/atom/item = new buy_type(get_turf(usr))
+					to_chat(usr, "<span class='info'>You have purchased [item].</span>")
 					feedback_add_details("wizard_spell_learned", "PT")
 					var/datum/role/wizard/W = usr.mind.GetRole(WIZARD)
-					if(istype(W) && istype(W.stat_datum, /datum/stat/role/wizard))
-						var/datum/stat/role/wizard/WD = W.stat_datum
-						WD.spellbook_purchases.Add(item.name)
+					if(istype(W))
+						var/icon/tempimage = icon(item.icon, item.icon_state)
+						W.potions_bought += {"<img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [item]<BR>"}
+						if (istype(W.stat_datum, /datum/stat/role/wizard))
+							var/datum/stat/role/wizard/WD = W.stat_datum
+							WD.spellbook_purchases.Add(item.name)
 
 		else //Passed an artifact reference
 			var/datum/spellbook_artifact/SA = locate(href_list["spell"])

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -226,7 +226,7 @@ For the main html chat area
 	if (!isicon(icon))
 		return 0
 
-	iconCache[iconKey] << icon(icon, dir = SOUTH)
+	iconCache[iconKey] << icon(icon, dir = SOUTH, frame = 1)
 	var/iconData = iconCache.ExportText(iconKey)
 	var/list/partial = splittext(iconData, "{")
 	return replacetext(copytext(partial[2], 3, -5), "\n", "")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7573912/121777547-0afe4880-cb93-11eb-9e5c-ef7c7a8b684f.png)

:cl:
* rscadd: The round end scoreboard now indicates which potions were bought by a wizard.
* bugfix: Fixed scoreboard icons either missing or being wrong.