### PR TITLE
Fixing the Previous Rounds Ruleset panel

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -223,6 +223,11 @@ var/stacking_limit = 90
 	return 1
 
 /datum/gamemode/dynamic/proc/read_previous_rounds_rulesets()
+	previously_executed_rules = list(
+		"one_round_ago" = list(),
+		"two_rounds_ago" = list(),
+		"three_rounds_ago" = list()
+	)
 	var/list/data = SSpersistence_misc.read_data(/datum/persistence_task/latest_dynamic_rulesets)
 	if(!length(data))
 		return

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -28,14 +28,21 @@
 		dat += "<i>No orphaned roles are currently active.</i>"
 
 	var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
-
-	if (dynamic_mode?.previously_executed_rules.len)
-		dat += "<h3><b>Last executed rulesets</b></h3>"
-		dat += "<br/>"
-		for (var/type in dynamic_mode.previously_executed_rules)
-			var/datum/dynamic_ruleset/DR = type
-			dat += "- [initial(DR.name)] <br/>"
-		dat += "<br/>"
+	if (istype(dynamic_mode))
+		dat += "<h3><b>Previously executed rulesets:</b></h3>"
+		for (var/previous_round in dynamic_mode.previously_executed_rules)
+			switch(previous_round)
+				if ("one_round_ago")
+					dat += "<h4><b>Last Round:</b></h4>"
+				if ("two_rounds_ago")
+					dat += "<h4><b>Two Rounds ago:</b></h4>"
+				if ("three_rounds_ago")
+					dat += "<h4><b>Three Rounds ago:</b></h4>"
+			dat += "<br/>"
+			for(var/previous_ruleset in dynamic_mode.previously_executed_rules[previous_round])
+				var/datum/dynamic_ruleset/DR = previous_ruleset
+				dat += "- [initial(DR.name)] <br/>"
+			dat += "<br/>"
 
 	dat += "</body></html>"
 	usr << browse(dat, "window=roundstatus;size=700x500")

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -38,7 +38,6 @@
 					dat += "<h4><b>Two Rounds ago:</b></h4>"
 				if ("three_rounds_ago")
 					dat += "<h4><b>Three Rounds ago:</b></h4>"
-			dat += "<br/>"
 			for(var/previous_ruleset in dynamic_mode.previously_executed_rules[previous_round])
 				var/datum/dynamic_ruleset/DR = previous_ruleset
 				dat += "- [initial(DR.name)] <br/>"


### PR DESCRIPTION
Shifty added the feature while I was replacing the variable, instead of being a list of last round's rulesets, it's a list that contains 3 lists of each previous three rounds' rulesets.