### PR TITLE
Buffs roentgen energy uranium content

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -834,8 +834,9 @@
 	..()
 	reagents.add_reagent(CAFFEINE, 5)
 	reagents.add_reagent(COCAINE, 5)
+	reagents.add_reagent(COCAINE, 3.6)
 	reagents.add_reagent(URANIUM, 15)
-	reagents.add_reagent(SPORTDRINK, 5)
+	reagents.add_reagent(SPORTDRINK, 1.4)
 
 /obj/item/weapon/reagent_containers/food/drinks/coloring
 	name = "\improper vial of food coloring"

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -834,7 +834,7 @@
 	..()
 	reagents.add_reagent(CAFFEINE, 5)
 	reagents.add_reagent(COCAINE, 5)
-	reagents.add_reagent(COCAINE, 3.6)
+	reagents.add_reagent(RADIUM, 3.6)
 	reagents.add_reagent(URANIUM, 15)
 	reagents.add_reagent(SPORTDRINK, 1.4)
 

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -828,7 +828,7 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/roentgen_energy
 	name = "Roentgen Energy"
-	desc = "Roentgen Energy, a meltdown in your mouth! Contains real actinides!"
+	desc = "Roentgen Energy, a meltdown in your mouth! Contains real actinides! Doesn't really taste great, nor terrible."
 	icon_state = "roentgenenergy"
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/roentgen_energy/New()
 	..()

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -833,9 +833,9 @@
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/roentgen_energy/New()
 	..()
 	reagents.add_reagent(CAFFEINE, 5)
-	reagents.add_reagent(COCAINE, 1.4)
-	reagents.add_reagent(URANIUM, 3.6)
-	reagents.add_reagent(SPORTDRINK, 20)
+	reagents.add_reagent(COCAINE, 5)
+	reagents.add_reagent(URANIUM, 15)
+	reagents.add_reagent(SPORTDRINK, 5)
 
 /obj/item/weapon/reagent_containers/food/drinks/coloring
 	name = "\improper vial of food coloring"


### PR DESCRIPTION
[tweak]
Mainly changing uranium content to 15u from 3.6, now beating the Discount Dan chcolate bars containing 8u.
:cl:
* tweak: Roentgen energy drinks are now much more worth a premium coin to drink.