### PR TITLE
You can now build lights on top of windows

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -192,6 +192,8 @@
 
 #define iswindow(A) (istype(A, /obj/structure/window))
 
+#define isfullwindow(A) (istype(A, /obj/structure/window/full))
+
 #define isgripper(G) (istype(G, /obj/item/weapon/gripper))
 
 #define isholyweapon(I) (istype(I, /obj/item/weapon/nullrod) || istype(I, /obj/item/weapon/gun/hookshot/whip/vampkiller))

--- a/code/game/objects/items/mountable_frames/lights.dm
+++ b/code/game/objects/items/mountable_frames/lights.dm
@@ -7,6 +7,16 @@
 	var/fixture_type = "tube"
 	mount_reqs = list("simfloor")
 
+/obj/item/mounted/frame/light_fixture/check_buildon(var/atom/A, mob/user)
+	for (var/obj/structure/window/W in A)
+		if (isfullwindow(W))
+			return 1
+		else
+			if (user.dir == opposite_dirs[W.dir]) // At least one border window can support us
+				return 1
+
+	return 0
+
 /obj/item/mounted/frame/light_fixture/do_build(turf/on_wall, mob/user)
 	to_chat(user, "You begin attaching [src] to \the [on_wall].")
 	playsound(src, 'sound/machines/click.ogg', 75, 1)

--- a/code/game/objects/items/mountable_frames/mountables.dm
+++ b/code/game/objects/items/mountable_frames/mountables.dm
@@ -9,11 +9,18 @@
 			found_type = 1
 			break
 
+	if (!found_type)
+		found_type = check_buildon(A, user)
+
 	if(found_type)
 		if(try_build(A, user, proximity_flag))
 			return do_build(A, user)
 	else
 		..()
+
+// Override for special mounted frames...
+/obj/item/mounted/proc/check_buildon(var/atom/A, mob/user)
+	return FALSE
 
 /obj/item/mounted/proc/try_build(turf/on_wall, mob/user, proximity_flag) //checks
 	if(!on_wall || !user)


### PR DESCRIPTION
Such lights are already placed on top of some windows in most maps.

Arguably this was always an ugly hack used by mappers with a window fetish, but I would argue that it doesn't look too out of place if you do it carefully.

Regardless, if mappers can use this tasteless hack, so should players.

I'm pushing this change because I (regrettably) had to use this hack a lot on my mapping pass to get Europa Lights to not be so dark. 

:cl:
- tweak: You can now place mounted frames on top of full-tile windows or directional windows oriented in a way to support the light frame.