### PR TITLE
Fixes Delivery Chutes interaction with conveyor belts

### DIFF
--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -19,7 +19,7 @@ mob/living/carbon/proc/dream()
 		"a vox","a plasmaman","a skellington","a diona","the derelict","the end of the world","the thunderdome","a ship full of dead clowns","a chicken with godlike powers",
 		"a red bus that drives through space","an alien artifact","the mechanic","a newspaper","an insectoid","a slime","a slime person","a mushroom person",
 		"the Cult of Nar-Sie","the Wizard Federation","an impossibly gigantic lamprey floating through space, bending reality as it goes","a sword that talks",
-		"an eclipse","a sandwich so tall that it pierces the heavens"
+		"an eclipse","a sandwich so tall that it pierces the heavens","attack ships on fire off the shoulder of Orion","C-beams glittering in the dark near the Tannhäuser Gate"
 		)
 	spawn(0)
 		for(var/i = rand(1,4),i > 0, i--)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -149,15 +149,25 @@
 	//testing("[src] FUCKING BUMPED BY \a [AM]")
 
 	if(istype(AM, /obj))
-		var/obj/O = AM
-		O.forceMove(src)
+		receive_atom(AM)
 	else if(istype(AM, /mob))
-		var/mob/M = AM
-		M.forceMove(src)
-	//src.flush() This spams audio like fucking crazy.
-	// Instead, we queue up for the next process.
-	doFlushIn=5 // Ticks, adjust if delay is too long or too short
+		receive_atom(AM)
+
+
+/obj/machinery/disposal/deliveryChute/conveyor_act(var/atom/movable/AM, var/obj/machinery/conveyor/CB)
+	if(istype(AM,/obj/item))
+		if(stat & BROKEN || !AM || mode <=0 || !deconstructable)
+			return FALSE
+		receive_atom(AM)
+		return TRUE
+	return FALSE
+
+
+/obj/machinery/disposal/deliveryChute/proc/receive_atom(var/atom/movable/AM)
+	AM.forceMove(src)
+	doFlushIn = 5
 	num_contents++
+
 
 /obj/machinery/disposal/deliveryChute/flush()
 	flushing = 1


### PR DESCRIPTION
Fixes #29785

:cl:
* bugfix: Fixed Delivery Chutes not activating if items where inserted via conveyor belts.