### PR TITLE
Hand-gun no longer causes shrapnel to materialize

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -917,6 +917,7 @@ obj/item/projectile/bullet/suffocationbullet
 	icon_state = null
 	damage = 25
 	fire_sound = null
+	embed = 0
 
 /obj/item/projectile/bullet/invisible/on_hit(var/atom/target, var/blocked = 0) //silence the target for a few seconds on hit
 	if (..(target, blocked))


### PR DESCRIPTION
Fixes #29723

:cl:
* tweak: The traitor mime hand-gun's bullets no longer cause shrapnel to appear out of thin air.