### PR TITLE
Pianos in supply crates and Hydro Trays in mining surprises now come unanchored

### DIFF
--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -346,6 +346,8 @@
 
 /obj/structure/piano/New()
 	..()
+	if (isobj(loc))//we probably spawned inside a supply crate
+		anchored = FALSE
 	song = new("piano", src)
 
 /obj/structure/piano/random/New()

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -56,6 +56,9 @@
 	// Seed details/line data.
 	var/datum/seed/seed = null // The currently planted seed
 
+/obj/machinery/portable_atmospherics/hydroponics/loose
+	anchored = FALSE
+
 /obj/machinery/portable_atmospherics/hydroponics/New()
 	..()
 	create_reagents(200)

--- a/code/modules/mining/abandoned_crates/bay12.dm
+++ b/code/modules/mining/abandoned_crates/bay12.dm
@@ -22,8 +22,7 @@
 /obj/structure/closet/crate/secure/loot/bay_05/New()
 	..()
 	for(var/i = 0, i < 3, i++)
-		var/obj/machinery/portable_atmospherics/hydroponics/tray = new(src)
-		tray.anchored = FALSE
+		new/obj/machinery/portable_atmospherics/hydroponics/loose(src)
 
 /obj/structure/closet/crate/secure/loot/bay_06/New()
 	..()

--- a/code/modules/mining/surprises/tg.dm
+++ b/code/modules/mining/surprises/tg.dm
@@ -181,7 +181,7 @@
 	fluffitems = list(
 		// /obj/structure/flora/kirbyplants=1,
 		/obj/structure/table/reinforced=2,
-		/obj/machinery/portable_atmospherics/hydroponics=1,
+		/obj/machinery/portable_atmospherics/hydroponics/loose=1,
 		/obj/effect/glowshroom/single=2,
 		/obj/item/weapon/reagent_containers/syringe/antitoxin=2,
 		/obj/item/weapon/reagent_containers/glass/bottle/diethylamine=3,


### PR DESCRIPTION
Fixes #11715

:cl:
* tweak: Pianos, Space Minimoog and Xylophones that come out of the random instrument or big band instrument collection supply packs are no longer anchored and can be immediately pulled around.
* tweak: Hydroponic Trays found inside mining surprises on the asteroid no longer spawn anchored.