### PR TITLE
Fixes extra large sheet stacks coming out of dismantled R&D machines

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1652,6 +1652,8 @@ var/proccalls = 1
 #define VIOLENCE_DEFAULT	1
 #define VIOLENCE_GUN		2
 
+#define MAX_SHEET_STACK_AMOUNT	50
+
 // Used to determine which HUD is in use
 #define HUD_NONE 0
 #define HUD_MEDICAL 1

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -1,10 +1,12 @@
+
+
 /obj/item/stack/sheet
 	name = "sheet"
 	flags = FPRINT
 	w_class = W_CLASS_MEDIUM
 	force = 5
 	throwforce = 5
-	max_amount = 50
+	max_amount = MAX_SHEET_STACK_AMOUNT
 	throw_speed = 3
 	throw_range = 3
 	attack_verb = list("bashes", "batters", "bludgeons", "thrashes", "smashes")

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -122,10 +122,15 @@ var/global/list/rnd_machines = list()
 				if (materials.storage[matID] == 0) // No materials of this type
 					continue
 				var/datum/material/M = materials.getMaterial(matID)
-				var/obj/item/stack/sheet/sheet = new M.sheettype(src.loc)
+				var/obj/item/stack/sheet/sheet = new M.sheettype(loc)
 				if(sheet)
 					var/available_num_sheets = round(materials.storage[matID]/sheet.perunit)
 					if(available_num_sheets>0)
+						while (available_num_sheets > MAX_SHEET_STACK_AMOUNT)
+							available_num_sheets -= MAX_SHEET_STACK_AMOUNT
+							var/obj/item/stack/sheet/bonus_sheet = new M.sheettype(loc)
+							bonus_sheet.amount = MAX_SHEET_STACK_AMOUNT
+							materials.removeAmount(matID, MAX_SHEET_STACK_AMOUNT * sheet.perunit)
 						sheet.amount = available_num_sheets
 						materials.removeAmount(matID, sheet.amount * sheet.perunit)
 					else


### PR DESCRIPTION
Fixes #13737

:cl:
* bugfix: Dismantling a machine containing more than 50 sheets of a given material type now properly gives several sheet stacks.