### PR TITLE
Fixed old cult hood

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -1317,6 +1317,10 @@ var/list/arcane_tomes = list()
 /obj/item/clothing/head/culthood/old/attack_self(var/mob/user)
 	return
 
+/obj/item/clothing/head/culthood/old/unequipped(mob/user, var/from_slot = null)
+	..()
+	icon_state = "culthood_old"
+
 /obj/item/clothing/suit/cultrobes/old
 	name = "forgotten cult robes"
 	icon_state = "cultrobes_old"


### PR DESCRIPTION
Fixes #29818

:cl:
* bugfix: Fixed Forgotten Cult Hoods (the red ones) turning into regular cult hoods when picked up.