### PR TITLE
Fixes shelter giving a red attack message when clicked by animals dealing 0 damage such as mice

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -183,7 +183,11 @@
 	user.delayNextAttack(10)
 
 /obj/structure/inflatable/attack_animal(var/mob/living/simple_animal/M)
-	if(take_damage(rand(M.melee_damage_lower, M.melee_damage_upper)))
+	var/damage_dealt = rand(M.melee_damage_lower, M.melee_damage_upper)
+	if (!damage_dealt)
+		user.visible_message("<span class='notice'>\The [user] nuzzles \the [src].</span>")
+		return 1
+	if(take_damage(damage_dealt))
 		M.visible_message("<span class='danger'>[M] tears open \the [src]!</span>")
 	else
 		M.visible_message("<span class='danger'>[M] [M.attacktext] \the [src]!</span>")

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -185,7 +185,7 @@
 /obj/structure/inflatable/attack_animal(var/mob/living/simple_animal/M)
 	var/damage_dealt = rand(M.melee_damage_lower, M.melee_damage_upper)
 	if (!damage_dealt)
-		user.visible_message("<span class='notice'>\The [user] nuzzles \the [src].</span>")
+		M.visible_message("<span class='notice'>\The [M] nuzzles \the [src].</span>")
 		return 1
 	if(take_damage(damage_dealt))
 		M.visible_message("<span class='danger'>[M] tears open \the [src]!</span>")


### PR DESCRIPTION
Fixes #22556

:cl:
* bugfix: Mice and other no-damage animals clicking inflatable shelter will now nuzzle them instead of attacking them in vain.