### PR TITLE
Failing surgery steps because of using a table or roller bed now causes proper surgery step failure

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -817,6 +817,9 @@ SEE_PIXELS	256
 #define ORGAN_PEG			4096 // ROB'S MAGICAL PEGLEGS v2
 #define ORGAN_MALFUNCTIONING 8192
 
+#define SURGERY_SUCCESS_NORMAL 0
+#define SURGERY_SUCCESS_ALWAYS 1
+#define SURGERY_SUCCESS_NEVER  2
 
 //Admin Permissions
 //Please don't edit these values without speaking to [current /vg/ host here] first

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1263,7 +1263,7 @@ var/global/list/common_tools = list(
 	)
 
 //check if mob is lying down on something we can operate him on.
-/proc/can_operate(mob/living/carbon/M, mob/U)
+/proc/can_operate(mob/living/carbon/M, mob/U, var/obj/item/tool) // tool arg only needed if you actually intend to perform surgery (and not for instance, just do an autopsy)
 	if(U == M)
 		return 0
 	var/too_bad = FALSE
@@ -1283,8 +1283,8 @@ var/global/list/common_tools = list(
 				return 1
 
 	//if we failed when trying to use a table or roller bed, let's at least check if it was a valid surgery step
-	if (too_bad)
-		if (do_surgery(M,U,I,SURGERY_SUCCESS_NEVER))
+	if (too_bad && tool)
+		if (do_surgery(M,U,tool,SURGERY_SUCCESS_NEVER))
 			return 1
 
 	return 0

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1266,16 +1266,27 @@ var/global/list/common_tools = list(
 /proc/can_operate(mob/living/carbon/M, mob/U)
 	if(U == M)
 		return 0
+	var/too_bad = FALSE
 	if((ishuman(M) || isslime(M)) && M.lying)
 		if(locate(/obj/machinery/optable,M.loc) || locate(/obj/structure/bed/roller/surgery, M.loc))
 			return 1
 		if(iscultist(U) && locate(/obj/structure/cult/altar, M.loc))
 			return 1
-		if(locate(/obj/structure/bed/roller, M.loc) && prob(75))
-			return 1
+		if(locate(/obj/structure/bed/roller, M.loc))
+			too_bad = TRUE
+			if (prob(75))
+				return 1
 		var/obj/structure/table/T = locate(/obj/structure/table/, M.loc)
-		if(T && !T.flipped && prob(66))
+		if(T && !T.flipped)
+			too_bad = TRUE
+			if (prob(66))
+				return 1
+
+	//if we failed when trying to use a table or roller bed, let's at least check if it was a valid surgery step
+	if (too_bad)
+		if (do_surgery(M,user,I,SURGERY_SUCCESS_NEVER))
 			return 1
+
 	return 0
 
 /*

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1284,7 +1284,7 @@ var/global/list/common_tools = list(
 
 	//if we failed when trying to use a table or roller bed, let's at least check if it was a valid surgery step
 	if (too_bad)
-		if (do_surgery(M,user,I,SURGERY_SUCCESS_NEVER))
+		if (do_surgery(M,U,I,SURGERY_SUCCESS_NEVER))
 			return 1
 
 	return 0

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -70,7 +70,7 @@ obj/item/proc/get_clamped_volume()
 	if (!istype(M)) // not sure if this is the right thing...
 		return 0
 	//var/messagesource = M
-	if (can_operate(M, user))        //Checks if mob is lying down on table for surgery
+	if (can_operate(M, user, I))        //Checks if mob is lying down on table for surgery
 		if (do_surgery(M,user,I))
 			return 1
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -103,7 +103,7 @@
 										"<span class='notice'>You place a bandaid over \the [W.desc] on [M]'s [affecting.display_name].</span>")
 				use(1)
 		else
-			if(can_operate(H, user))        //Checks if mob is lying down on table for surgery
+			if(can_operate(H, user, src))        //Checks if mob is lying down on table for surgery
 				if(do_surgery(H,user,src))
 					return
 			else
@@ -134,7 +134,7 @@
 										"<span class='notice'>You salve the wounds on [M]'s [affecting.display_name].</span>" )
 				use(1)
 		else
-			if(can_operate(H, user))        //Checks if mob is lying down on table for surgery
+			if(can_operate(H, user, src))        //Checks if mob is lying down on table for surgery
 				if(do_surgery(H,user,src))
 					return
 			else
@@ -194,7 +194,7 @@
 				affecting.heal_damage(rand(heal_brute, heal_brute + 5), 0)
 				use(1)
 		else
-			if(can_operate(H, user))        //Checks if mob is lying down on table for surgery
+			if(can_operate(H, user, src))        //Checks if mob is lying down on table for surgery
 				if(do_surgery(H,user,src))
 					return
 			else
@@ -227,7 +227,7 @@
 				affecting.heal_damage(0, rand(heal_burn, heal_burn + 5))
 				use(1)
 		else
-			if(can_operate(H, user))        //Checks if mob is lying down on table for surgery
+			if(can_operate(H, user, src))        //Checks if mob is lying down on table for surgery
 				if(do_surgery(H,user,src))
 					return
 			else

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -37,7 +37,7 @@
 				else
 					to_chat(user, "<span class='notice'>Nothing to fix here.</span>")
 		else
-			if(can_operate(H, user))
+			if(can_operate(H, user, src))
 				if(do_surgery(H,user,src))
 					return
 			else

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -146,7 +146,7 @@
 /obj/item/tool/screwdriver/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M))
 		return ..()
-	if(can_operate(M, user))
+	if(can_operate(M, user, src))
 		return ..()
 	if(user.zone_sel.selecting != "eyes" && user.zone_sel.selecting != LIMB_HEAD)
 		return ..()
@@ -361,7 +361,7 @@
 
 /obj/item/tool/weldingtool/attack(mob/M as mob, mob/user as mob)
 	if(hasorgans(M))
-		if(can_operate(M, user))
+		if(can_operate(M, user, src))
 			if(do_surgery(M, user, src))
 				return
 		var/datum/organ/external/S = M:organs_by_name[user.zone_sel.selecting]

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -101,7 +101,7 @@ proc/spread_germs_to_organ(datum/organ/external/E, mob/living/carbon/human/user)
 	if(!(E.status & (ORGAN_ROBOT|ORGAN_PEG))) //Germs on robotic limbs bad
 		E.germ_level = max(germ_level,E.germ_level) //as funny as scrubbing microbes out with clean gloves is - no.
 
-proc/do_surgery(mob/living/M, mob/living/user, obj/item/tool)
+proc/do_surgery(mob/living/M, mob/living/user, obj/item/tool, var/success_override = SURGERY_SUCCESS_NORMAL)
 	if(!ishuman(M) && !isslime(M))
 		return 0
 	if (user.a_intent == I_HURT)	//check for Hippocratic Oath
@@ -134,7 +134,7 @@ proc/do_surgery(mob/living/M, mob/living/user, obj/item/tool)
 
 				var/selection = user.zone_sel ? user.zone_sel.selecting : null //Check if the zone selection hasn't changed
 				//We had proper tools! (or RNG smiled.) and user did not move or change hands.
-				if(do_mob(user, M, S.duration * tool.toolspeed) && (prob(S.tool_quality(tool) / (sleep_fail + clumsy + 1))) && (!user.zone_sel || selection == user.zone_sel.selecting)) //Last part checks whether the zone selection hasn't changed
+				if(do_mob(user, M, S.duration * tool.toolspeed) && (success_override == SURGERY_SUCCESS_ALWAYS || (success_override == SURGERY_SUCCESS_NORMAL && (prob(S.tool_quality(tool) / (sleep_fail + clumsy + 1))))) && (!user.zone_sel || selection == user.zone_sel.selecting)) //Last part checks whether the zone selection hasn't changed
 					M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had surgery [S.type] with \the [tool] successfully completed by [user.name] ([user.ckey])</font>")
 					user.attack_log += text("\[[time_stamp()]\] <font color='red'>Successfully completed surgery [S.type] with \the [tool] on [M.name] ([M.ckey])</font>")
 					log_attack("<font color='red'>[user.name] ([user.ckey]) used \the [tool] to successfully complete surgery type [S.type] on [M.name] ([M.ckey])</font>")

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -124,7 +124,7 @@ proc/do_surgery(mob/living/M, mob/living/user, obj/item/tool, var/success_overri
 			if(canuse == -1)
 				sleep_fail = 1
 			if(canuse && S.is_valid_mutantrace(M) && !(M in S.doing_surgery))
-				if(!can_operate(M, user))
+				if(!can_operate(M, user))//never give the tool as 3rd arg here or you might cause an infinite loop
 					return 1
 				M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had surgery [S.type] with \the [tool] started by [user.name] ([user.ckey])</font>")
 				user.attack_log += text("\[[time_stamp()]\] <font color='red'>Started surgery [S.type] with \the [tool] on [M.name] ([M.ckey])</font>")


### PR DESCRIPTION
Fixes #16169

:cl:
* tweak: When failing a surgery step because you were operating on a table, or a regular roller bed, you will now trigger an actual surgery step failure instead of attacking the patient with your tool.