### PR TITLE
gourmonger cubes are now only available through cooking

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1821,15 +1821,6 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containertype = /obj/structure/closet/crate/flatpack/suit_modifier
 	group = "Engineering"
 
-/datum/supply_packs/gourmonger
-	name = "dehydrated gourmonger"
-	contains = list(/obj/item/weapon/reagent_containers/food/snacks/monkeycube/gourmonger)
-	cost = 75
-	containertype = /obj/structure/closet/crate/secure/engisec
-	containername = "Gourmonger Crate"
-	access = list(access_engine_equip)
-	group = "Engineering"
-
 //////MEDICAL//////
 
 /datum/supply_packs/medical

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -36,8 +36,7 @@
 		/obj/item/device/gps/engineering,
 		/obj/item/weapon/storage/belt/utility/chief,
 		/obj/item/clothing/glasses/scanner/material,
-		/obj/item/weapon/card/debit/preferred/department/engineering,
-		/obj/item/weapon/reagent_containers/food/snacks/monkeycube/gourmonger
+		/obj/item/weapon/card/debit/preferred/department/engineering
 	)
 
 /obj/structure/closet/secure_closet/engineering_electrical

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -850,7 +850,7 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/buchedenoel
 
 /datum/recipe/popoutcake
-	reagents = list("milk" = 15, "flour" = 45)
+	reagents = list(MILK = 15, FLOUR = 45)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/egg,
 		/obj/item/weapon/reagent_containers/food/snacks/egg,
@@ -2948,3 +2948,14 @@
 		/obj/item/weapon/reagent_containers/food/snacks/grown/apple
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/dionaroast
+
+/datum/recipe/gourmongercube
+	reagents = list(PLASMA = 10, NUTRIMENT = 50)
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/meat,
+		/obj/item/weapon/reagent_containers/food/snacks/meat,
+		/obj/item/weapon/reagent_containers/food/snacks/meat,
+		/obj/item/weapon/reagent_containers/food/snacks/meat,
+		/obj/item/weapon/reagent_containers/food/snacks/meat,
+		)
+	result = /obj/item/weapon/reagent_containers/food/snacks/monkeycube/gourmonger


### PR DESCRIPTION
A sort of answer to my own comment regarding the gourmonger issue, https://github.com/vgstation-coders/vgstation13/issues/29843#issuecomment-864526292
This removes gourmonger cubes from the CE's locker and cargo, but adds them as a relatively affordable microwave recipe.
The idea is that if they become less prevalent (and slightly more time-consuming and/or expensive to make) AND have to be made through the production of nutrients in the first place, they should become a less common destructive force.

This of course doesn't actually fix the issues with the mongers, but it makes them slightly less annoying, and gives people more time to carefully find out how to best fix them.

Too cheap? Too expensive? Initial write-up included nanobots but i felt like that would make them painfully annoying to get for engineers who just want to experiment.

:cl:
 * rscadd: Gourmongers are no longer available from cargo and the CE's locker
 * rscdel: Gourmonger cubes can now be produced through a microwave