### PR TITLE
You can now use the hydroponics biogenerator to make xenobio slime bags.

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -162,6 +162,12 @@
 	name="Gadget Bag"
 	result=/obj/item/weapon/storage/bag/gadgets
 
+/datum/biogen_recipe/leather/slime
+	cost=350
+	id="slime"
+	name="Slime Bag"
+	result=/obj/item/weapon/storage/bag/xenobio
+
 /datum/biogen_recipe/leather/plants
 	cost=350
 	id="plants"


### PR DESCRIPTION
Been asked to make some more than once, and since you can make most other bags with the biogenerator, it makes sense you should be able to make slime bags too.
:cl:
 * rscadd: The Biogenerators can make extra slime bags as an alternative source of said bags.