### PR TITLE
The Brig Cell timer control now explicitely tells you when Access Denied

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -173,6 +173,7 @@
 	if(..())
 		return
 	if(!src.allowed(usr))
+		to_chat(usr, "<span class='warning'>Access denied.</span>")
 		return
 
 	usr.set_machine(src)


### PR DESCRIPTION
Fixes #24212

https://www.youtube.com/watch?v=hq_ivuq4PvM

:cl:
* The Brig Cell timer controls now explicitely tells you Access Denied if you try to trigger its flash or set its timer without proper access.