### PR TITLE
Players no longer spawn with dormant active genes

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -407,7 +407,6 @@ var/datum/controller/gameticker/ticker
 						//No injection
 					else
 						data_core.manifest_inject(new_character)
-				player.FuckUpGenes(new_character)
 				qdel(player)
 
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -347,14 +347,6 @@
 	mind.transfer_to(cluwne)
 	qdel(src)
 
-
-/mob/new_player/proc/FuckUpGenes(var/mob/living/carbon/human/H)
-	// 20% of players have bad genetic mutations.
-	if(prob(20))
-		H.dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_BAD)
-		if(prob(10)) // 10% of those have a good mut.
-			H.dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_GOOD)
-
 /mob/new_player/proc/AttemptLateSpawn(rank)
 	if (src != usr)
 		return 0
@@ -464,7 +456,6 @@
 			else
 				AnnounceArrival(character, rank)
 				CallHook("Arrival", list("character" = character, "rank" = rank))
-			FuckUpGenes(character)
 		else
 			character.Robotize()
 	qdel(src)


### PR DESCRIPTION
Fixes #28469
Fixes #6920

You see, players were intended to have 20% chance to spawn (roundstart or latejoin) with a genetic disability. And you thought 5% roundstart virus chance was bad. However due to the way gene code works, domutcheck() has to be called for genes to actually activate after SE are set. This not being done, players would carry "dormant" disabilities that would then activate as soon as something else triggered domutcheck, such as a dna injector, a virus that triggers a genetic power/disability, even lings using transform. But the most interesting part is that Gumshoes and Bartenders, who DO spawn with extra active genes end up being the only jobs that have the 20% chance of actually having a disability on top. If you ever latejoined blind, or clumsy, etc, as a bartender, this is why. And this was originally intended to be a possibility for ALL players. This sucks. Let's save bartenders and gumshoes from this hell, and fix bugs related to this unintended behaviour.

:cl:
* bugfix: Fixed a bug that caused Bartenders and Gumshoes to often spawn with extra genetic disabilities.