### PR TITLE
Allows all assemblies to be attached to wires

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -20,7 +20,7 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 
 	var/list/wires = list()
 	var/list/wire_names = null
-	var/list/signallers = list()
+	var/list/assemblies = list()
 
 	var/table_options = " align='center'"
 	var/row_options1 = " width='80px'"
@@ -103,7 +103,7 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 		html += "<td[row_options2]>"
 		html += "<A href='?src=\ref[src];action=1;cut=[colour]'>[IsColourCut(colour) ? "Mend" :  "Cut"]</A>"
 		html += " <A href='?src=\ref[src];action=1;pulse=[colour]'>Pulse</A>"
-		html += " <A href='?src=\ref[src];action=1;attach=[colour]'>[IsAttached(colour) ? "Detach" : "Attach"] Signaller</A></td></tr>"
+		html += " <A href='?src=\ref[src];action=1;attach=[colour]'>[IsAttached(colour) ? "Detach" : "Attach"] Assembly</A></td></tr>"
 	html += "</table>"
 	html += "</div>"
 
@@ -154,12 +154,12 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 
 				// Attach
 				else
-					if(istype(I, /obj/item/device/assembly/signaler))
+					if(istype(I, /obj/item/device/assembly))
 						if(L.drop_item(I))
 							Attach(colour, I)
 							holder.investigation_log(I_WIRES, "|| [I] \ref[I] attached to [GetWireName(wires[colour]) || colour] wire by [key_name(usr)] ([src.type])")
 					else
-						to_chat(L, "<span class='error'>You need a remote signaller!</span>")
+						to_chat(L, "<span class='error'>You need an assembly!</span>")
 
 
 
@@ -253,19 +253,19 @@ var/const/POWER = 8
 //
 
 /datum/wires/proc/IsAttached(var/colour)
-	if(signallers[colour])
+	if(assemblies[colour])
 		return 1
 	return 0
 
 /datum/wires/proc/GetAttached(var/colour)
-	if(signallers[colour])
-		return signallers[colour]
+	if(assemblies[colour])
+		return assemblies[colour]
 	return null
 
-/datum/wires/proc/Attach(var/colour, var/obj/item/device/assembly/signaler/S)
+/datum/wires/proc/Attach(var/colour, var/obj/item/device/assembly/S)
 	if(colour && S)
 		if(!IsAttached(colour))
-			signallers[colour] = S
+			assemblies[colour] = S
 			S.forceMove(holder)
 			S.connected = src
 			return S
@@ -274,15 +274,15 @@ var/const/POWER = 8
 	if(colour)
 		var/obj/item/device/assembly/signaler/S = GetAttached(colour)
 		if(S)
-			signallers -= colour
+			assemblies -= colour
 			S.connected = null
 			S.forceMove(holder.loc)
 			return S
 
 
 /datum/wires/proc/Pulse(var/obj/item/device/assembly/signaler/S)
-	for(var/colour in signallers)
-		if(S == signallers[colour])
+	for(var/colour in assemblies)
+		if(S == assemblies[colour])
 			PulseColour(colour)
 			holder.investigation_log(I_WIRES, "|| [GetWireName(wires[colour]) || colour] wire pulsed by \a [S] \ref[S] ([src.type])")
 			break

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -36,6 +36,7 @@ var/global/list/assembly_short_name_to_type = list() //Please, I beg you, don't 
 	var/list/attached_overlays = list()
 	var/obj/item/device/assembly_holder/holder = null
 	var/cooldown = 0//To prevent spam
+	var/datum/wires/connected = null
 	var/wires = WIRE_RECEIVE | WIRE_PULSE
 
 	var/const/WIRE_RECEIVE = 1			//Allows Pulsed(0) to call Activate()
@@ -228,7 +229,9 @@ var/global/list/assembly_short_name_to_type = list() //Please, I beg you, don't 
 
 
 /obj/item/device/assembly/pulse(var/radio = 0)
-	if(istype(holder, /obj/item/device/assembly_frame))
+	if(src.connected && src.wires)
+		connected.Pulse(src)
+	else if(istype(holder, /obj/item/device/assembly_frame))
 		var/obj/item/device/assembly_frame/AB = holder
 
 		AB.receive_pulse(src)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -101,7 +101,7 @@
 			T = holder.loc
 		else if (holder.master && isturf(holder.loc.loc)) //or in an assembly rigging something that's on the floor?
 			T = holder.loc.loc
-	else if(ismovable(loc) && isturf(loc.loc)) // or in a grenade on the floor/wired item? (can it even activate grenades without igniters?)
+	else if(isobj(loc) && isturf(loc.loc)) // or in a grenade on the floor/wired item? (can it even activate grenades without igniters?)
 		T = loc.loc
 	if(T)
 		if(!beam)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -101,7 +101,7 @@
 			T = holder.loc
 		else if (holder.master && isturf(holder.loc.loc)) //or in an assembly rigging something that's on the floor?
 			T = holder.loc.loc
-	else if(istype(loc,/obj/item/weapon/grenade) && isturf(loc.loc)) // or in a grenade that's on the floor? (can it even activate grenades without igniters?)
+	else if(istype(loc,/atom/movable) && isturf(loc.loc)) // or in a grenade on the floor/wired item? (can it even activate grenades without igniters?)
 		T = loc.loc
 	if(T)
 		if(!beam)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -101,7 +101,7 @@
 			T = holder.loc
 		else if (holder.master && isturf(holder.loc.loc)) //or in an assembly rigging something that's on the floor?
 			T = holder.loc.loc
-	else if(ismovable(loc)) && isturf(loc.loc)) // or in a grenade on the floor/wired item? (can it even activate grenades without igniters?)
+	else if(ismovable(loc) && isturf(loc.loc)) // or in a grenade on the floor/wired item? (can it even activate grenades without igniters?)
 		T = loc.loc
 	if(T)
 		if(!beam)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -101,7 +101,7 @@
 			T = holder.loc
 		else if (holder.master && isturf(holder.loc.loc)) //or in an assembly rigging something that's on the floor?
 			T = holder.loc.loc
-	else if(istype(loc,/atom/movable) && isturf(loc.loc)) // or in a grenade on the floor/wired item? (can it even activate grenades without igniters?)
+	else if(ismovable(loc)) && isturf(loc.loc)) // or in a grenade on the floor/wired item? (can it even activate grenades without igniters?)
 		T = loc.loc
 	if(T)
 		if(!beam)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -18,7 +18,6 @@
 	var/code = 30
 	var/frequency = 1457
 	var/delay = 0
-	var/datum/wires/connected = null
 	var/datum/radio_frequency/radio_connection
 	var/deadman = 0
 
@@ -157,14 +156,6 @@
 				if(S)
 					S.pulse(0)
 	return 0*/
-
-
-/obj/item/device/assembly/signaler/pulse(var/radio = 0)
-	if(src.connected && src.wires)
-		connected.Pulse(src)
-	else
-		return ..(radio)
-
 
 /obj/item/device/assembly/signaler/receive_signal(datum/signal/signal)
 	if(!signal)


### PR DESCRIPTION
[content][consistency]
I don't know why this wasn't already a thing
Should open up a ton of more gimmicks, like voice activated door bolts and etc
:cl:
 * rscadd: All assemblies can now be attached to wires, not just signallers