### PR TITLE
Crayon font replacement

### DIFF
--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -4,6 +4,10 @@
 	icon = 'icons/obj/rune.dmi'
 	reagent = COLORFUL_REAGENT
 	persistence_type = null //todo
+	maptext_height = 32
+	maptext_width = 64
+	maptext_x = -16
+	maptext_y = -2
 
 /obj/effect/decal/cleanable/crayon/New(loc,age,icon_state,color,dir,pixel_x,pixel_y,main = "#FFFFFF",shade = "#000000",var/type = "rune")
 	..()

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -104,8 +104,8 @@ var/global/list/all_graffitis = list(
 	shadeColour = input(user, "Please select the shade colour.", "Crayon colour") as color
 	return
 
-#define FONT_SIZE "6pt"
-#define FONT_NAME "Comic Sans MS"
+#define FONT_SIZE "9pt"
+#define FONT_NAME "Ink Free"
 /obj/item/toy/crayon/afterattack(atom/target, mob/user as mob, proximity)
 	if(!proximity)
 		return
@@ -143,7 +143,7 @@ var/global/list/all_graffitis = list(
 			if("rune")
 				to_chat(user, "You start drawing a rune on \the [target].")
 			if("text")
-				#define MAX_LETTERS 15
+				#define MAX_LETTERS 30
 				preference = input("Write some text here (maximum [MAX_LETTERS] letters).", "Crayon scribbles") as null|text
 				preference = copytext(preference, 1, MAX_LETTERS)
 				#undef MAX_LETTERS
@@ -159,7 +159,7 @@ var/global/list/all_graffitis = list(
 
 				if(user.client)
 					var/image/I = image(icon = null) //Create an empty image. You can't just do "image()" for some reason, at least one argument is needed
-					I.maptext = {"<span style="color:[colour];font-size:[FONT_SIZE];font-family:'[FONT_NAME]';" valign="[alignment]">[preference]</span>"}
+					I.maptext = {"<span style="color:[colour];font-size:[FONT_SIZE];font-family:'[FONT_NAME]';" align="center" valign="[alignment]">[preference]</span>"}
 					I.loc = get_turf(target)
 					animate(I, alpha = 100, 10, -1)
 					animate(alpha = 255, 10, -1)
@@ -190,7 +190,7 @@ var/global/list/all_graffitis = list(
 				C.name = "written text"
 				C.desc = "\"[preference]\", written in crayon."
 
-				var/maptext_start = {"<span style="color:[colour];font-size:[FONT_SIZE];font-family:'[FONT_NAME]';" valign="[alignment]">"}
+				var/maptext_start = {"<span style="color:[colour];font-size:[FONT_SIZE];font-family:'[FONT_NAME]';" align="center" valign="[alignment]">"}
 				var/maptext_end = "</span>"
 				C.maptext = "[maptext_start][preference][maptext_end]"
 


### PR DESCRIPTION
:cl:
* tweak: Writing with a crayon now uses the Ink Free font at 9pt, like bloody writing did at first. Players who aren't on Windows 10 will see it appear as arial instead.