### PR TITLE
Fixes targets not shot at checked outside turret view radius

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -342,7 +342,7 @@ Status: []<BR>"},
 	..()
 
 /obj/machinery/turret/portable/check_target(var/atom/movable/T as mob|obj)
-	if(T)
+	if(T && (T in view(7,src)))
 		if( isliving(T) )
 			var/mob/living/L = T
 			if(L.isDead() || isMoMMI(L))//mommis are always safe

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -342,7 +342,7 @@ Status: []<BR>"},
 	..()
 
 /obj/machinery/turret/portable/check_target(var/atom/movable/T as mob|obj)
-	if(T && (T in view(7,src)))
+	if(T && (T in view(7+emagged*5,src)))
 		if( isliving(T) )
 			var/mob/living/L = T
 			if(L.isDead() || isMoMMI(L))//mommis are always safe

--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -87,7 +87,7 @@
 	src.power_change()
 
 /obj/machinery/turret/proc/check_target(var/atom/movable/T as mob|obj)
-	if(T)
+	if(T && (T in view(7,src)))
 		if( ismob(T) )
 			var/mob/M = T
 			if((M.flags & INVULNERABLE) || M.faction == faction)


### PR DESCRIPTION
[bugfix]
Apparently I removed a bunch of code that checks if people enter and exit turret protected areas, so nothing made them stop until they were shot, this should work now
:cl:
 * bugfix: Turrets no longer keep checking for people not shot at yet if outside their range.