### PR TITLE
All players now have a 2% chance of spawning with a random disability (with a small chance of power on top)

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -407,7 +407,7 @@ var/datum/controller/gameticker/ticker
 						//No injection
 					else
 						data_core.manifest_inject(new_character)
-				player.FuckUpGenes(new_character)
+				new_character.DormantGenes(2,0,10,0) // 2% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
 				qdel(player)
 
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -407,7 +407,7 @@ var/datum/controller/gameticker/ticker
 						//No injection
 					else
 						data_core.manifest_inject(new_character)
-				new_character.DormantGenes(2,0,10,0) // 2% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
+				new_character.RandomGenes(2,10,0,0) // 2% chance of getting a bad gene, in which case they also get 10% chance of getting a good gene
 				qdel(player)
 
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2026,6 +2026,17 @@ mob/living/carbon/human/isincrit()
 /mob/living
 	var/hangman_score = 0 // For round end leaderboards
 
+/mob/living/carbon/human/proc/DormantGenes(var/badGeneProb = 2, var/goodGeneProb = 0, var/chanceForGoodIfBad = 10, var/chanceForBadIfGood = 0) // default values are those used on roundstart/latejoin
+	if(prob(badGeneProb))
+		dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_BAD)
+		if(prob(chanceForGoodIfBad))
+			dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_GOOD)
+
+	if(prob(goodGeneProb))
+		dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_GOOD)
+		if(prob(chanceForBadIfGood))
+			dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_BAD)
+
 /mob/living/carbon/human/Hear(var/datum/speech/speech, var/rendered_speech="")
 	..()
 	if(stat)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2026,7 +2026,7 @@ mob/living/carbon/human/isincrit()
 /mob/living
 	var/hangman_score = 0 // For round end leaderboards
 
-/mob/living/carbon/human/proc/DormantGenes(var/badGeneProb = 2, var/goodGeneProb = 0, var/chanceForGoodIfBad = 10, var/chanceForBadIfGood = 0) // default values are those used on roundstart/latejoin
+/mob/living/carbon/human/proc/RandomGenes(var/badGeneProb = 2, var/chanceForGoodIfBad = 10, var/goodGeneProb = 0, var/chanceForBadIfGood = 0) // default values are those used on roundstart/latejoin
 	if(prob(badGeneProb))
 		dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_BAD)
 		if(prob(chanceForGoodIfBad))
@@ -2036,6 +2036,8 @@ mob/living/carbon/human/isincrit()
 		dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_GOOD)
 		if(prob(chanceForBadIfGood))
 			dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_BAD)
+
+	check_mutations = 1
 
 /mob/living/carbon/human/Hear(var/datum/speech/speech, var/rendered_speech="")
 	..()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -347,14 +347,6 @@
 	mind.transfer_to(cluwne)
 	qdel(src)
 
-
-/mob/new_player/proc/FuckUpGenes(var/mob/living/carbon/human/H)
-	// 20% of players have bad genetic mutations.
-	if(prob(20))
-		H.dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_BAD)
-		if(prob(10)) // 10% of those have a good mut.
-			H.dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_GOOD)
-
 /mob/new_player/proc/AttemptLateSpawn(rank)
 	if (src != usr)
 		return 0
@@ -464,7 +456,7 @@
 			else
 				AnnounceArrival(character, rank)
 				CallHook("Arrival", list("character" = character, "rank" = rank))
-			FuckUpGenes(character)
+			character.DormantGenes(2,0,10,0) // 2% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
 		else
 			character.Robotize()
 	qdel(src)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -456,7 +456,7 @@
 			else
 				AnnounceArrival(character, rank)
 				CallHook("Arrival", list("character" = character, "rank" = rank))
-			character.DormantGenes(2,0,10,0) // 2% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
+			character.RandomGenes(2,10,0,0) // 2% chance of getting a bad gene, in which case they also get 10% chance of getting a good gene
 		else
 			character.Robotize()
 	qdel(src)


### PR DESCRIPTION
Alternative to #29869

If one PR gets merged I'll close the other one. Don't merge both (or they'll conflict anyway)

Originally suggested by @DamianX 

:cl:
* experiment: Instead of players having a 20% chance of spawning with "dormant" disabilities that would activate when any other gene would activate (or in the case of Bartenders and Gumshoes, immediately upon spawn), all players now have 2% chance of spawning with a genetic disability, in which case players have an additional 10% chance of getting a beneficial gene on top.