### PR TITLE
Inactive gene fix for bartenders and detectives

### DIFF
--- a/code/datums/outfit/civilian.dm
+++ b/code/datums/outfit/civilian.dm
@@ -119,7 +119,7 @@
 	..()
 	H.put_in_hands(new /obj/item/weapon/storage/bag/plasticbag(H))
 	H.dna.SetSEState(SOBERBLOCK,1)
-	H.check_mutations = 1
+	genemutcheck(H, SOBERBLOCK)
 
 /datum/outfit/bartender/pre_equip_priority(var/mob/living/carbon/human/H, var/species)
 	items_to_collect[/obj/item/weapon/circuitboard/chem_dispenser/soda_dispenser] = SURVIVAL_BOX

--- a/code/datums/outfit/security.dm
+++ b/code/datums/outfit/security.dm
@@ -269,7 +269,8 @@
 	H.dna.SetSEState(SOBERBLOCK,1)
 	if (H.mind.role_alt_title == "Gumshoe" || H.mind.role_alt_title == "Private Eye")
 		H.dna.SetSEState(NOIRBLOCK,1)
-	H.check_mutations = 1
+		genemutcheck(H, NOIRBLOCK)
+	genemutcheck(H, SOBERBLOCK)
 
 /datum/outfit/detective/post_equip_priority(var/mob/living/carbon/human/H)
 	equip_accessory(H, /obj/item/clothing/accessory/holster/knife/boot/preloaded/tactical, /obj/item/clothing/shoes, 5)


### PR DESCRIPTION
This PR changes the mutation check for the jobs of detectives and bartenders so that they only activate the specific gene block they receive for their job. This means they will no longer spawn 20% of the time with genetic defects active, and will only have them inactive as anyone else does. To be clear, everyone has a 20% chance to spawn with inactive genetic defects, if you were not aware.

Greys, and vox for some reason, still suffer from spawning with the mutations due to how DeferredSpeciesSetup() works and will need to be fixed themselves, thus this is just a draft. While I was able to get DeferredSpeciesSetup() so work with roundspawn greys, I was unable to get them to work with latejoin greys as they would spawn with the remote talk gene deactivated and removed the changes I made. I will work on thus further later though if there are any problems or criticism you have for this PR or the methods it uses or will use please let me know.
It was incredibly tempting to not even mention greys or vox and leave them to their genetically defected fate but as there are already two alternate PRs made to fix this issue in different ways it is only fair to present this PR only when it is fully, correctly made.

:cl:
 * rscadd: Bartenders and detectives no longer spawn with their inactive genetic defects activated