### PR TITLE
Fixes Challengers and Elite Syndies not getting their job-exclusive uplink items

### DIFF
--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -361,7 +361,6 @@
 			traitor_mob.mind.total_TC += R.hidden_uplink.uses
 		if (role && T)
 			role.uplink = T
-			T.job = role.name_for_uplink
 
 /datum/mind/proc/find_syndicate_uplink(var/obj/item/device/uplink/true_uplink)
 	var/uplink = null

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -361,6 +361,7 @@
 			traitor_mob.mind.total_TC += R.hidden_uplink.uses
 		if (role && T)
 			role.uplink = T
+			T.job = role.job_for_uplink
 
 /datum/mind/proc/find_syndicate_uplink(var/obj/item/device/uplink/true_uplink)
 	var/uplink = null

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -361,7 +361,6 @@
 			traitor_mob.mind.total_TC += R.hidden_uplink.uses
 		if (role && T)
 			role.uplink = T
-			T.job = role.job_for_uplink
 
 /datum/mind/proc/find_syndicate_uplink(var/obj/item/device/uplink/true_uplink)
 	var/uplink = null

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -50,9 +50,6 @@
 
 	var/plural_name = null
 
-	// role name assigned to the antag's potential uplink
-	var/name_for_uplink = null
-
 	// Various flags and things.
 	var/flags = 0
 

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -50,9 +50,6 @@
 
 	var/plural_name = null
 
-	// job override to allow for specific uplink items. Used by Elite Syndicate Strike Team members.
-	var/job_for_uplink = null
-
 	// Various flags and things.
 	var/flags = 0
 
@@ -547,7 +544,6 @@
 	id = SYNDIESQUADIE
 	special_role = SYNDIESQUADIE
 	logo_state = "elite-logo"
-	job_for_uplink = SYNDIESQUADIE
 
 //________________________________________________
 

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -50,6 +50,9 @@
 
 	var/plural_name = null
 
+	// job override to allow for specific uplink items. Used by Elite Syndicate Strike Team members.
+	var/job_for_uplink = null
+
 	// Various flags and things.
 	var/flags = 0
 
@@ -544,6 +547,7 @@
 	id = SYNDIESQUADIE
 	special_role = SYNDIESQUADIE
 	logo_state = "elite-logo"
+	job_for_uplink = SYNDIESQUADIE
 
 //________________________________________________
 

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -136,7 +136,6 @@
 /datum/role/traitor/challenger
 	name = CHALLENGER
 	id = CHALLENGER
-	name_for_uplink = CHALLENGER
 	required_pref = CHALLENGER
 	wikiroute = CHALLENGER
 	logo_state = "synd-logo"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -40,6 +40,8 @@ var/list/uplink_items = list()
 	var/list/jobs_with_discount = list() //Jobs in this list get the discount price.
 	var/list/jobs_exclusive = list() //If empty, does nothing. If not empty, ONLY jobs in this list can buy this item.
 	var/list/jobs_excluded = list() //Jobs in this list cannot buy this item at all.
+	var/list/roles_exclusive = list() //If empty, does nothing. If not empty, ONLY roles in this list can buy this item.
+	var/list/roles_excluded = list() //Roles in this list cannot buy this item at all.
 
 	var/only_on_month	//two-digit month as string
 	var/only_on_day		//two-digit day as string
@@ -62,6 +64,18 @@ var/list/uplink_items = list()
 /datum/uplink_item/proc/available_for_job(var/user_job)
 	return user_job && !(jobs_exclusive.len && !jobs_exclusive.Find(user_job)) && !(jobs_excluded.len && jobs_excluded.Find(user_job))
 
+/datum/uplink_item/proc/available_for_role(var/list/roles)
+	if (roles_exclusive.len)
+		for (var/role in roles_exclusive)
+			if (role in roles)
+				return TRUE
+		return FALSE
+	else
+		for (var/role in roles_excluded)
+			if (role in roles)
+				return FALSE
+		return TRUE
+
 //This will get called that is essentially a New() by default.
 //Use this to make New()s that have extra conditions, such as bundles
 //Make sure to add a return or else it will break a part of buy()
@@ -71,6 +85,14 @@ var/list/uplink_items = list()
 /datum/uplink_item/proc/spawn_item(var/turf/loc, var/obj/item/device/uplink/U, mob/user)
 	if(!available_for_job(U.job))
 		message_admins("[key_name(user)] tried to purchase \the [src.name] from their uplink despite not being available to their job! (Job: [U.job]) ([formatJumpTo(get_turf(U))])")
+		return
+	if(!available_for_role(U.roles))
+		var/dat = ""
+		for (var/role in roles_exclusive)
+			if (dat)
+				dat+= ", "
+			dat += role
+		message_admins("[key_name(user)] tried to purchase \the [src.name] from their uplink despite not being available to their role! (Role: [dat]) ([formatJumpTo(get_turf(U))])")
 		return
 	U.uses -= max(get_cost(U.job), 0)
 	feedback_add_details("traitor_uplink_items_bought", name)
@@ -595,6 +617,8 @@ var/list/uplink_items = list()
 				continue
 			if(!I.available_for_job(U.job))
 				continue
+			if(!I.available_for_role(U.roles))
+				continue
 			if(I.get_cost(U.job, 0.5) > U.uses)
 				continue
 			possible_items += I
@@ -1082,7 +1106,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/syndie_coop
 	category = "Cooperative Cell"
-	jobs_excluded = list("Nuclear Operative", CHALLENGER)
+	roles_exclusive = list(TRAITOR)
 
 /datum/uplink_item/syndie_coop/elite_bundle
 	name = "Elite Syndicate Bundle"

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -14,6 +14,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	var/show_description = null
 	var/active = 0
 	var/job = null
+	var/list/roles = list()
 
 /obj/item/device/uplink/New()
 	..()
@@ -53,9 +54,12 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	return FALSE
 
 //Let's build a menu!
-/obj/item/device/uplink/proc/generate_menu(mob/user as mob)
+/obj/item/device/uplink/proc/generate_menu(var/mob/user)
 	if(!job)
 		job = user.mind.assigned_role
+		roles = list()
+		for (var/datum/role/role in user.mind.antag_roles)
+			roles += role.id
 
 	var/dat = list()
 	dat += "<B>[src.welcome]</B><BR>"


### PR DESCRIPTION
Fixes #29896

Dear coders, don't be afraid of coding a new system when appropriate instead of piggy-backing onto other systems. This is the secret to avoid this kind of bugs.

:cl:
* bugfix: Fixed both Challengers and Elite Syndicate Strike Teams not getting their job-exclusive uplink items.