### PR TITLE
New flavor text upon dormant gene awakening

### DIFF
--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -131,6 +131,8 @@ var/global/list/facial_hair_styles_female_list	= list()
 	// New stuff
 	var/species = "Human"
 
+	var/list/dormant_genes = list()
+
 // Make a copy of this strand.
 // USE THIS WHEN COPYING STUFF OR YOU'LL GET CORRUPTION!
 /datum/dna/proc/Clone()
@@ -149,8 +151,11 @@ var/global/list/facial_hair_styles_female_list	= list()
 	new_dna.UpdateSE()
 	return new_dna
 
-/datum/dna/proc/GiveRandomSE(var/notflags = 0, var/flags = 0, var/genetype = -1)
-	SetSEState(pick(query_genes(notflags,flags,genetype)), 1)
+/datum/dna/proc/GiveRandomSE(var/notflags = 0, var/flags = 0, var/genetype = -1, var/dormant = FALSE)
+	var/chosen_gene = pick(query_genes(notflags,flags,genetype))
+	if (dormant)
+		dormant_genes += "[chosen_gene]"
+	SetSEState(chosen_gene, 1)
 
 ///////////////////////////////////////
 // UNIQUE IDENTITY

--- a/code/game/dna/dna2_domutcheck.dm
+++ b/code/game/dna/dna2_domutcheck.dm
@@ -95,6 +95,11 @@
 				return 0
 
 			//testing("[gene.name] activated!")
+
+			if ("[gene.block]" in M.dna.dormant_genes)
+				M.dna.dormant_genes -= "[gene.block]"
+				to_chat(M, "<span class='rose'>You shiver, something in this environment has awakened a mutation that laid dormant in you, until now.</span>")
+
 			gene.activate(M,connected,flags)
 			if(M)
 				M.active_genes |= gene.type

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -407,7 +407,7 @@ var/datum/controller/gameticker/ticker
 						//No injection
 					else
 						data_core.manifest_inject(new_character)
-				new_character.RandomGenes(2,10,0,0) // 2% chance of getting a bad gene, in which case they also get 10% chance of getting a good gene
+				new_character.DormantGenes(20,10,0,0) // 20% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
 				qdel(player)
 
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -407,7 +407,7 @@ var/datum/controller/gameticker/ticker
 						//No injection
 					else
 						data_core.manifest_inject(new_character)
-				player.FuckUpGenes(new_character)
+				new_character.DormantGenes(2,0,10,0) // 2% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
 				qdel(player)
 
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -407,7 +407,7 @@ var/datum/controller/gameticker/ticker
 						//No injection
 					else
 						data_core.manifest_inject(new_character)
-				new_character.DormantGenes(2,0,10,0) // 2% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
+				new_character.RandomGenes(2,10,0,0) // 2% chance of getting a bad gene, in which case they also get 10% chance of getting a good gene
 				qdel(player)
 
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2026,6 +2026,17 @@ mob/living/carbon/human/isincrit()
 /mob/living
 	var/hangman_score = 0 // For round end leaderboards
 
+/mob/living/carbon/human/proc/DormantGenes(var/badGeneProb = 2, var/goodGeneProb = 0, var/chanceForGoodIfBad = 10, var/chanceForBadIfGood = 0) // default values are those used on roundstart/latejoin
+	if(prob(badGeneProb))
+		dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_BAD)
+		if(prob(chanceForGoodIfBad))
+			dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_GOOD)
+
+	if(prob(goodGeneProb))
+		dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_GOOD)
+		if(prob(chanceForBadIfGood))
+			dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_BAD)
+
 /mob/living/carbon/human/Hear(var/datum/speech/speech, var/rendered_speech="")
 	..()
 	if(stat)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2028,16 +2028,16 @@ mob/living/carbon/human/isincrit()
 
 /mob/living/carbon/human/proc/RandomGenes(var/badGeneProb = 2, var/chanceForGoodIfBad = 10, var/goodGeneProb = 0, var/chanceForBadIfGood = 0) // default values are those used on roundstart/latejoin
 	if(prob(badGeneProb))
-		dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_BAD)
+		dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_BAD, dormant = TRUE)
 		if(prob(chanceForGoodIfBad))
-			dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_GOOD)
+			dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_GOOD, dormant = TRUE)
 
 	if(prob(goodGeneProb))
-		dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_GOOD)
+		dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_GOOD, dormant = TRUE)
 		if(prob(chanceForBadIfGood))
-			dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_BAD)
+			dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_BAD, dormant = TRUE)
 
-	check_mutations = 1
+
 
 /mob/living/carbon/human/Hear(var/datum/speech/speech, var/rendered_speech="")
 	..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2026,7 +2026,7 @@ mob/living/carbon/human/isincrit()
 /mob/living
 	var/hangman_score = 0 // For round end leaderboards
 
-/mob/living/carbon/human/proc/DormantGenes(var/badGeneProb = 2, var/goodGeneProb = 0, var/chanceForGoodIfBad = 10, var/chanceForBadIfGood = 0) // default values are those used on roundstart/latejoin
+/mob/living/carbon/human/proc/RandomGenes(var/badGeneProb = 2, var/chanceForGoodIfBad = 10, var/goodGeneProb = 0, var/chanceForBadIfGood = 0) // default values are those used on roundstart/latejoin
 	if(prob(badGeneProb))
 		dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_BAD)
 		if(prob(chanceForGoodIfBad))
@@ -2036,6 +2036,8 @@ mob/living/carbon/human/isincrit()
 		dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_GOOD)
 		if(prob(chanceForBadIfGood))
 			dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_BAD)
+
+	check_mutations = 1
 
 /mob/living/carbon/human/Hear(var/datum/speech/speech, var/rendered_speech="")
 	..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2026,7 +2026,7 @@ mob/living/carbon/human/isincrit()
 /mob/living
 	var/hangman_score = 0 // For round end leaderboards
 
-/mob/living/carbon/human/proc/RandomGenes(var/badGeneProb = 2, var/chanceForGoodIfBad = 10, var/goodGeneProb = 0, var/chanceForBadIfGood = 0) // default values are those used on roundstart/latejoin
+/mob/living/carbon/human/proc/DormantGenes(var/badGeneProb = 2, var/chanceForGoodIfBad = 10, var/goodGeneProb = 0, var/chanceForBadIfGood = 0) // default values are those used on roundstart/latejoin
 	if(prob(badGeneProb))
 		dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_BAD, dormant = TRUE)
 		if(prob(chanceForGoodIfBad))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -347,14 +347,6 @@
 	mind.transfer_to(cluwne)
 	qdel(src)
 
-
-/mob/new_player/proc/FuckUpGenes(var/mob/living/carbon/human/H)
-	// 20% of players have bad genetic mutations.
-	if(prob(20))
-		H.dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_BAD)
-		if(prob(10)) // 10% of those have a good mut.
-			H.dna.GiveRandomSE(notflags = GENE_UNNATURAL,genetype = GENETYPE_GOOD)
-
 /mob/new_player/proc/AttemptLateSpawn(rank)
 	if (src != usr)
 		return 0
@@ -464,7 +456,7 @@
 			else
 				AnnounceArrival(character, rank)
 				CallHook("Arrival", list("character" = character, "rank" = rank))
-			FuckUpGenes(character)
+			character.DormantGenes(2,0,10,0) // 2% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
 		else
 			character.Robotize()
 	qdel(src)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -456,7 +456,7 @@
 			else
 				AnnounceArrival(character, rank)
 				CallHook("Arrival", list("character" = character, "rank" = rank))
-			character.RandomGenes(2,10,0,0) // 2% chance of getting a bad gene, in which case they also get 10% chance of getting a good gene
+			character.DormantGenes(20,10,0,0) // 20% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
 		else
 			character.Robotize()
 	qdel(src)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -456,7 +456,7 @@
 			else
 				AnnounceArrival(character, rank)
 				CallHook("Arrival", list("character" = character, "rank" = rank))
-			character.DormantGenes(2,0,10,0) // 2% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
+			character.RandomGenes(2,10,0,0) // 2% chance of getting a bad gene, in which case they also get 10% chance of getting a good gene
 		else
 			character.Robotize()
 	qdel(src)


### PR DESCRIPTION
Since many people seem to like the concept of dormant genes and I like that @bathosbathtime is taking care of at least fixing them activating upon spawn for Bartenders etc, I've decided to not change anything else gameplay wise but instead add some flavor text when those activate so players understand better what's happening to them.

This PR doesn't change the % chance of a dormant gene appearing in you, which is still 20%. If it has to change, it'll be in a different PR.

![image](https://user-images.githubusercontent.com/7573912/123414435-2c5c2d00-d5b4-11eb-8f7b-f54f493e03b6.png)

:cl:
* rscadd: If you got a dormant gene at roundstart or latejoin and it activates, you now get some flavor text informing you about it.