### PR TITLE
Fixes the endgame scoreboard not calling traitors who don't spend TCs "smooth operators"

### DIFF
--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -123,7 +123,7 @@
 /datum/role/traitor/GetScoreboard()
 	. = ..()
 	if(can_be_smooth)
-		if(uplink_items_bought)
+		if(uplink_items_bought?.len)
 			. += "The traitor bought:<BR>"
 			for(var/entry in uplink_items_bought)
 				. += "[entry]<BR>"


### PR DESCRIPTION
https://www.youtube.com/watch?v=6_qqp87-3J4

:cl:
* bugfix; Fixed a bug that caused the scoreboard to not label traitors who don't spend TCs as smooth operators.