### PR TITLE
simple_animal flap and aflap

### DIFF
--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -19,7 +19,8 @@ mob/living/carbon/proc/dream()
 		"a vox","a plasmaman","a skellington","a diona","the derelict","the end of the world","the thunderdome","a ship full of dead clowns","a chicken with godlike powers",
 		"a red bus that drives through space","an alien artifact","the mechanic","a newspaper","an insectoid","a slime","a slime person","a mushroom person",
 		"the Cult of Nar-Sie","the Wizard Federation","an impossibly gigantic lamprey floating through space, bending reality as it goes","a sword that talks",
-		"an eclipse","a sandwich so tall that it pierces the heavens","attack ships on fire off the shoulder of Orion","C-beams glittering in the dark near the Tannhäuser Gate"
+		"an eclipse","a sandwich so tall that it pierces the heavens","attack ships on fire off the shoulder of Orion","C-beams glittering in the dark near the Tannhäuser Gate",
+		"and exploding computer",
 		)
 	spawn(0)
 		for(var/i = rand(1,4),i > 0, i--)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -108,6 +108,18 @@
 		var/mob/living/L = user
 		L.sleeping += 10 // You can't faint when you're asleep.
 
+var/list/animals_with_wings = list(
+	/mob/living/simple_animal/parrot,
+	/mob/living/simple_animal/bee,
+	/mob/living/simple_animal/penguin,
+	/mob/living/simple_animal/chick,
+	/mob/living/simple_animal/chicken,
+	/mob/living/simple_animal/hostile/retaliate/cockatrice,
+	/mob/living/simple_animal/hostile/scarybat,
+	/mob/living/simple_animal/hostile/bigroach,
+	/mob/living/simple_animal/hostile/viscerator,
+	)
+
 /datum/emote/living/flap
 	key = "flap"
 	key_third_person = "flaps"
@@ -123,6 +135,8 @@
 
 /datum/emote/living/flap/can_run_emote(var/mob/user, var/status_check)
 	if (isMoMMI(user))
+		return TRUE
+	if (is_type_in_list(user,animals_with_wings))
 		return TRUE
 	if (ishuman(user))
 		var/mob/living/carbon/human/H = user


### PR DESCRIPTION
Fixes #27990

:cl:
* rscadd: Animals with wings can now use the flap and aflap emotes.