### PR TITLE
Security gets extra access on higher alert levels

### DIFF
--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -214,46 +214,25 @@ var/global/maint_all_access = 0
 	//maint access for all during radstorm, or when enabled via keycard
 	if(maint_all_access && check_access_list(list(access_maint_tunnels)))
 		return 1
-	//bonus sec access on some alert levels
-	if (security_level > 0)
+	//sec gets basic department access on Code Red or Delta
+	if (security_level > 1)
 		if (can_access(M.GetAccess(),list(access_security)))
-			switch(security_level)
-				if(SEC_LEVEL_BLUE)//basic department access
-					if(check_access_list(list(access_medical,access_science,access_engine,access_cargo)))
-						return 1
-				if(SEC_LEVEL_RED)//full department access minus command & heads
-					if(check_access_list(get_all_accesses() - get_region_accesses(5) - access_ce - access_rd - access_cmo - access_hos))
-						return 1
-				if(SEC_LEVEL_DELTA)//total access
-					return 1
+			if(check_access_list(list(access_medical,access_science,access_engine_equip,access_mailsorting)))
+				return 1
 	return ..(M)
 
 /obj/machinery/door/window/allowed(mob/M)
-	//bonus sec access on some alert levels
-	if (security_level > 0)
+	//sec gets basic department access on Code Red or Delta
+	if (security_level > 1)
 		if (can_access(M.GetAccess(),list(access_security)))
-			switch(security_level)
-				if(SEC_LEVEL_BLUE)//basic department access
-					if(check_access_list(list(access_medical,access_science,access_engine_equip,access_mailsorting)))
-						return 1
-				if(SEC_LEVEL_RED)//full department access minus command & heads
-					if(check_access_list(get_all_accesses() - get_region_accesses(5) - access_ce - access_rd - access_cmo - access_hos))
-						return 1
-				if(SEC_LEVEL_DELTA)//total access
-					return 1
+			if(check_access_list(list(access_medical,access_science,access_engine_equip,access_mailsorting)))
+				return 1
 	return ..(M)
 
 /obj/machinery/access_button/allowed(mob/M)
-	//bonus sec access on some alert levels
-	if (security_level > 0)
+	//sec gets basic department access on Code Red or Delta
+	if (security_level > 1)
 		if (can_access(M.GetAccess(),list(access_security)))
-			switch(security_level)
-				if(SEC_LEVEL_BLUE)//basic department access
-					if(check_access_list(list(access_medical,access_science,access_engine_equip,access_mailsorting)))
-						return 1
-				if(SEC_LEVEL_RED)//full department access minus command & heads
-					if(check_access_list(get_all_accesses() - get_region_accesses(5) - access_ce - access_rd - access_cmo - access_hos))
-						return 1
-				if(SEC_LEVEL_DELTA)//total access
-					return 1
+			if(check_access_list(list(access_medical,access_science,access_engine_equip,access_mailsorting)))
+				return 1
 	return ..(M)

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -211,6 +211,49 @@ var/global/maint_all_access = 0
 	to_chat(world, "<span class='red'>The maintenance access requirement has been readded on all maintenance airlocks.</span>")
 
 /obj/machinery/door/airlock/allowed(mob/M)
-	if(maint_all_access && src.check_access_list(list(access_maint_tunnels)))
+	//maint access for all during radstorm, or when enabled via keycard
+	if(maint_all_access && check_access_list(list(access_maint_tunnels)))
 		return 1
+	//bonus sec access on some alert levels
+	if (security_level > 0)
+		if (can_access(M.GetAccess(),list(access_security)))
+			switch(security_level)
+				if(SEC_LEVEL_BLUE)//basic department access
+					if(check_access_list(list(access_medical,access_science,access_engine,access_cargo)))
+						return 1
+				if(SEC_LEVEL_RED)//full department access minus command & heads
+					if(check_access_list(get_all_accesses() - get_region_accesses(5) - access_ce - access_rd - access_cmo - access_hos))
+						return 1
+				if(SEC_LEVEL_DELTA)//total access
+					return 1
+	return ..(M)
+
+/obj/machinery/door/window/allowed(mob/M)
+	//bonus sec access on some alert levels
+	if (security_level > 0)
+		if (can_access(M.GetAccess(),list(access_security)))
+			switch(security_level)
+				if(SEC_LEVEL_BLUE)//basic department access
+					if(check_access_list(list(access_medical,access_science,access_engine_equip,access_mailsorting)))
+						return 1
+				if(SEC_LEVEL_RED)//full department access minus command & heads
+					if(check_access_list(get_all_accesses() - get_region_accesses(5) - access_ce - access_rd - access_cmo - access_hos))
+						return 1
+				if(SEC_LEVEL_DELTA)//total access
+					return 1
+	return ..(M)
+
+/obj/machinery/access_button/allowed(mob/M)
+	//bonus sec access on some alert levels
+	if (security_level > 0)
+		if (can_access(M.GetAccess(),list(access_security)))
+			switch(security_level)
+				if(SEC_LEVEL_BLUE)//basic department access
+					if(check_access_list(list(access_medical,access_science,access_engine_equip,access_mailsorting)))
+						return 1
+				if(SEC_LEVEL_RED)//full department access minus command & heads
+					if(check_access_list(get_all_accesses() - get_region_accesses(5) - access_ce - access_rd - access_cmo - access_hos))
+						return 1
+				if(SEC_LEVEL_DELTA)//total access
+					return 1
 	return ..(M)


### PR DESCRIPTION
While searching for issues to fix or close I came across (Fixes #12078) which indeed makes too much sense that I wonder how it's not a thing already.

The issue that suggested it got quite some support but of course I'm looking forward to your feedback below.

:cl:
* experiment: Security officers (or anyone with basic security access) now get basic department access on Code Red or Delta, allowing them to enter science, medbay, the cargo lobby or the engineering foyer. This only applies to airlocks, windoors, and access buttons. Remember to lynch sec if they abuse it.