### PR TITLE
Allows forges to smelt ores

### DIFF
--- a/code/game/objects/items/robot/robot_items/robot_furnace.dm
+++ b/code/game/objects/items/robot/robot_items/robot_furnace.dm
@@ -67,7 +67,7 @@
 			sleep(1) //Small delay between each ore so the animation plays and your immulshions don't get ruined.
 
 		for(var/datum/smelting_recipe/R in recipes)
-			while(R.checkIngredients(src)) //While we have materials for this
+			while(R.checkIngredients(ore)) //While we have materials for this
 				for(var/ore_id in R.ingredients)
 					ore.removeAmount(ore_id, R.ingredients[ore_id])
 					score["oremined"] += 1 //Count this ore piece as processed for the scoreboard

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -413,7 +413,7 @@
 	var/sheets_this_tick = 0
 
 	for(var/datum/smelting_recipe/R in recipes)
-		while(R.checkIngredients(src)) //While we have materials for this
+		while(R.checkIngredients(ore)) //While we have materials for this
 			for(var/ore_id in R.ingredients)
 				ore.removeAmount(ore_id, R.ingredients[ore_id]) //arg1 = ore name, arg2 = how much per sheet
 				score["oremined"] += 1 //Count this ore piece as processed for the scoreboard

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -362,6 +362,9 @@
 /obj/item/stack/ore/attempt_heating(atom/A, mob/user)
 	var/temperature = A.is_hot()
 	if(temperature)
+		var/list/recipes = list()
+		for(var/recipe in typesof(/datum/smelting_recipe) - /datum/smelting_recipe)
+			recipes += new recipe()
 		for(var/datum/smelting_recipe/R in recipes)
 			while(R.checkIngredients(materials)) //While we have materials for this
 				for(var/ore_id in R.ingredients)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -371,6 +371,7 @@
 					score["oremined"] += 1 //Count this ore piece as processed for the scoreboard
 
 				drop_stack(R.yieldtype,loc)
+				qdel(src)
 
 /*****************************Coin********************************/
 

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -370,9 +370,8 @@
 					if(temperature > R.ingredients[ore_id].melt_temperature)
 						ore.removeAmount(ore_id, R.ingredients[ore_id]) //arg1 = ore name, arg2 = how much per sheet
 						score["oremined"] += 1 //Count this ore piece as processed for the scoreboard
-
-				drop_stack(R.yieldtype,loc)
-				qdel(src)
+						drop_stack(R.yieldtype,loc)
+						qdel(src)
 
 /*****************************Coin********************************/
 

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -361,18 +361,17 @@
 
 /obj/item/stack/ore/attempt_heating(atom/A, mob/user)
 	var/temperature = A.is_hot()
-	if(temperature)
+	if(temperature && temperature > melt_temperature)
 		var/list/recipes = list()
 		for(var/recipe in typesof(/datum/smelting_recipe) - /datum/smelting_recipe)
 			recipes += new recipe()
 		for(var/datum/smelting_recipe/R in recipes)
 			while(R.checkIngredients(materials)) //While we have materials for this
 				for(var/ore_id in R.ingredients)
-					if(temperature > R.ingredients[ore_id].melt_temperature)
-						materials.removeAmount(ore_id, R.ingredients[ore_id]) //arg1 = ore name, arg2 = how much per sheet
-						score["oremined"] += 1 //Count this ore piece as processed for the scoreboard
-						drop_stack(R.yieldtype,loc)
-						qdel(src)
+					materials.removeAmount(ore_id, R.ingredients[ore_id]) //arg1 = ore name, arg2 = how much per sheet
+					score["oremined"] += 1 //Count this ore piece as processed for the scoreboard
+					drop_stack(R.yieldtype,loc)
+					qdel(src)
 
 /*****************************Coin********************************/
 

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -367,8 +367,9 @@
 		for(var/datum/smelting_recipe/R in recipes)
 			while(R.checkIngredients(ore)) //While we have materials for this
 				for(var/ore_id in R.ingredients)
-					ore.removeAmount(ore_id, R.ingredients[ore_id]) //arg1 = ore name, arg2 = how much per sheet
-					score["oremined"] += 1 //Count this ore piece as processed for the scoreboard
+					if(temperature > R.ingredients[ore_id].melt_temperature)
+						ore.removeAmount(ore_id, R.ingredients[ore_id]) //arg1 = ore name, arg2 = how much per sheet
+						score["oremined"] += 1 //Count this ore piece as processed for the scoreboard
 
 				drop_stack(R.yieldtype,loc)
 				qdel(src)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -370,8 +370,11 @@
 				for(var/ore_id in R.ingredients)
 					materials.removeAmount(ore_id, R.ingredients[ore_id]) //arg1 = ore name, arg2 = how much per sheet
 					score["oremined"] += 1 //Count this ore piece as processed for the scoreboard
-					drop_stack(R.yieldtype,loc)
-					qdel(src)
+					if(istype(loc,/obj/structure/forge))
+						drop_stack(R.yieldtype,loc.loc)
+					else
+						drop_stack(R.yieldtype,loc)
+		qdel(src)
 
 /*****************************Coin********************************/
 

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -359,6 +359,19 @@
 	else
 		return ..()
 
+/obj/item/stack/ore/attempt_heating(atom/A, mob/user)
+	var/temperature = A.is_hot()
+	if(temperature)
+		var/datum/materials/ore = new
+		ore.addFrom(src.materials,FALSE)
+		for(var/datum/smelting_recipe/R in recipes)
+			while(R.checkIngredients(ore)) //While we have materials for this
+				for(var/ore_id in R.ingredients)
+					ore.removeAmount(ore_id, R.ingredients[ore_id]) //arg1 = ore name, arg2 = how much per sheet
+					score["oremined"] += 1 //Count this ore piece as processed for the scoreboard
+
+				drop_stack(R.yieldtype,loc)
+
 /*****************************Coin********************************/
 
 /obj/item/weapon/coin

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -362,13 +362,11 @@
 /obj/item/stack/ore/attempt_heating(atom/A, mob/user)
 	var/temperature = A.is_hot()
 	if(temperature)
-		var/datum/materials/ore = new
-		ore.addFrom(src.materials,FALSE)
 		for(var/datum/smelting_recipe/R in recipes)
-			while(R.checkIngredients(ore)) //While we have materials for this
+			while(R.checkIngredients(materials)) //While we have materials for this
 				for(var/ore_id in R.ingredients)
 					if(temperature > R.ingredients[ore_id].melt_temperature)
-						ore.removeAmount(ore_id, R.ingredients[ore_id]) //arg1 = ore name, arg2 = how much per sheet
+						materials.removeAmount(ore_id, R.ingredients[ore_id]) //arg1 = ore name, arg2 = how much per sheet
 						score["oremined"] += 1 //Count this ore piece as processed for the scoreboard
 						drop_stack(R.yieldtype,loc)
 						qdel(src)

--- a/code/modules/mining/smelting.dm
+++ b/code/modules/mining/smelting.dm
@@ -4,11 +4,11 @@
 	var/yieldtype = null
 
 // Note: Returns -1 if not enough ore!
-/datum/smelting_recipe/proc/checkIngredients(var/obj/machinery/mineral/processing_unit/P)
-	for(var/ore_id in P.ore.storage)
+/datum/smelting_recipe/proc/checkIngredients(var/datum/materials/ore)
+	for(var/ore_id in ore.storage)
 		var/min_ore_required = ingredients[ore_id]
 
-		if(P.ore.getAmount(ore_id) < min_ore_required)
+		if(ore.getAmount(ore_id) < min_ore_required)
 			return 0
 
 	. = 1


### PR DESCRIPTION
[content]
Accepts one stack at a time, forge must be above melting temperature for ore to smelt and match recipe.
Let me know if it needs balancing.
:cl:
 * rscadd: Blacksmithing forges can now smelt ores, one pile at a time. (except plasma, the fuel)
 * tweak: Ingredients checking now only looks for the material datum instead of the entire parent ore processor object, for more flexibility.