### PR TITLE
Adds some Game Panel admin toggles

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -71,6 +71,9 @@ var/eventchance = 10 //% per 5 mins
 var/event = 0
 var/hadevent = 0
 var/blobevent = 0
+
+var/admin_disable_rulesets = FALSE
+var/admin_disable_events = FALSE
 	///////////////
 var/starticon = null
 var/midicon = null

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -92,9 +92,13 @@
 	return 1
 
 /datum/dynamic_ruleset/proc/ready(var/forced = 0)	//Here you can perform any additional checks you want. (such as checking the map, the amount of certain jobs, etc)
+	if (admin_disable_rulesets && !forced)
+		message_admins("Dynamic Mode: [name] was prevented from firing by admins.")
+		log_admin("Dynamic Mode: [name] was prevented from firing by admins.")
+		return FALSE
 	if (required_candidates > candidates.len)		//IMPORTANT: If ready() returns 1, that means execute() should never fail!
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 // Returns TRUE if there is enough pop to execute this ruleset
 /datum/dynamic_ruleset/proc/check_enemy_jobs(var/dead_dont_count = FALSE)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -691,7 +691,9 @@ var/global/floorIsLava = 0
 				if (mode.forced_latejoin_rule)
 					dat += {"<A href='?src=\ref[src];f_dynamic_latejoin_clear=1'>-> [mode.forced_latejoin_rule.name] <-</A><br>"}
 			dat += "<A href='?src=\ref[src];f_dynamic_midround=1'>(Execute Midround Ruleset!)</A><br>"
+		dat += "Rulesets are <A href='?src=\ref[src];toggle_rulesets=1'>[admin_disable_rulesets ? "DISABLED" : "ENABLED"]</A><br>"
 		dat += "<hr/>"
+	dat += "Random Events are <A href='?src=\ref[src];toggle_events=1'>[admin_disable_events ? "DISABLED" : "ENABLED"]</A><br>"
 
 	dat += {"
 		<hr />

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -683,7 +683,6 @@ var/global/floorIsLava = 0
 				for(var/datum/forced_ruleset/rule in forced_roundstart_ruleset)
 					dat += {"<A href='?src=\ref[src];f_dynamic_roundstart_remove=\ref[rule]'>-> [rule.name] <-</A><br>"}
 				dat += "<A href='?src=\ref[src];f_dynamic_roundstart_clear=1'>(Clear Rulesets)</A><br>"
-			dat += "<A href='?src=\ref[src];f_dynamic_options=1'>Dynamic mode options</A><br/>"
 		else
 			dat += "<A href='?src=\ref[src];f_dynamic_latejoin=1'>(Force Next Latejoin Ruleset)</A><br>"
 			if (ticker && ticker.mode && istype(ticker.mode,/datum/gamemode/dynamic))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1807,6 +1807,27 @@
 		message_admins("[key_name(usr)] set 'forced_extended' to [dynamic_forced_extended].")
 		dynamic_mode_options(usr)
 
+	else if(href_list["toggle_rulesets"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		if(master_mode != "Dynamic Mode")
+			return alert(usr, "The game mode has to be Dynamic Mode!", null, null, null, null)
+
+		admin_disable_rulesets = !admin_disable_rulesets
+		log_admin("[key_name(usr)] toggled Dynamic rulesets <b>[admin_disable_rulesets ? "OFF" : "ON"]</b>.")
+		message_admins("[key_name(usr)] toggled Dynamic rulesets <b>[admin_disable_rulesets ? "OFF" : "ON"]</b>.")
+		Game()
+
+	else if(href_list["toggle_events"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		admin_disable_events = !admin_disable_events
+		log_admin("[key_name(usr)] toggled random events <b>[admin_disable_events ? "OFF" : "ON"]</b>.")
+		message_admins("[key_name(usr)] toggled random events <b>[admin_disable_events ? "OFF" : "ON"]</b>.")
+		Game()
+
 	else if(href_list["no_stacking"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -7,6 +7,12 @@ var/list/event_last_fired = list()
 
 	var/minutes_passed = world.time/600
 	var/roundstart_delay = 50
+
+	if (admin_disable_events)
+		message_admins("A random event was prevented from firing by admins.")
+		log_admin("A random event was prevented from firing by admins.")
+		return
+
 	if(minutes_passed < roundstart_delay) //Self-explanatory
 		message_admins("Too early to trigger random event, aborting.")
 		return


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7573912/124289371-862f9a80-db52-11eb-9e8a-f73aa222c018.png)

:cl:
* rscadd: Added some admin buttons allowing them to manually toggle off random events or dynamic rulesets. Both rulesets and events can still be forced manually by admins while the toggle is off.