### PR TITLE
Hides hobo shacks from the holomap

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -2826,7 +2826,7 @@ var/list/the_station_areas = list (
 	icon_state = "firingrange"
 	dynamic_lighting = 1
 
-	holomap_draw_override = HOLOMAP_DRAW_EMPTY
+	holomap_draw_override = HOLOMAP_DRAW_FULL
 
 // BEGIN Horizon
 /area/hallway/primary/foreport


### PR DESCRIPTION

![HOBO](https://user-images.githubusercontent.com/7573912/124383391-79cf4d00-dccc-11eb-914f-41e2dcaa9e01.png)

:cl:
* bugfix: Hobo shacks are now hidden on the minimap.