### PR TITLE
Allows mass pipe painting to work with pipe end caps

### DIFF
--- a/code/ATMOSPHERICS/components/unary/cap.dm
+++ b/code/ATMOSPHERICS/components/unary/cap.dm
@@ -10,6 +10,7 @@
 	dir = SOUTH
 	initialize_directions = SOUTH
 	color = "#B4B4B4"
+	update_icon_ready = 1
 
 
 /obj/machinery/atmospherics/unary/cap/hide(var/i)
@@ -21,7 +22,9 @@
 	overlays = 0
 	alpha = invisibility ? 128 : 255
 	icon_state = "cap"
-	return
+
+	if (node1)
+		color = node1.color
 
 /obj/machinery/atmospherics/unary/cap/visible
 	level = 2

--- a/code/modules/RCD/schematics/pipe.dm
+++ b/code/modules/RCD/schematics/pipe.dm
@@ -118,7 +118,20 @@
 		selected_color = available_colors[selected_color]
 	if(mass_colour && world.timeofday < last_colouration + colouring_delay)
 		return "We aren't ready to mass paint again; please wait [(last_colouration+colouring_delay)-world.timeofday] more seconds!"
-	if(mass_colour && istype(O, /obj/machinery/atmospherics/pipe))
+	if(mass_colour && istype(O, /obj/machinery/atmospherics/unary/cap))
+		var/obj/machinery/atmospherics/unary/cap/cap = O
+		var/obj/machinery/atmospherics/pipe/maybe_pipe_to_colour = cap.node1
+		if (istype(maybe_pipe_to_colour))
+			var/datum/pipeline/pipe_line = maybe_pipe_to_colour.parent
+			var/list/pipeline_members = pipe_line.members
+			if(pipeline_members.len < 500)
+				last_colouration = world.timeofday
+				colouring_delay = (pipeline_members.len)/2
+				O.color = selected_color
+				maybe_pipe_to_colour.mass_colouration(selected_color)
+			else
+				return "That pipe network is simply too big to paint!"
+	else if(mass_colour && istype(O, /obj/machinery/atmospherics/pipe))
 		var/obj/machinery/atmospherics/pipe/pipe_to_colour = O
 		var/datum/pipeline/pipe_line = pipe_to_colour.parent
 		var/list/pipeline_members = pipe_line.members


### PR DESCRIPTION
Fixes #29948

:cl:
* bugfix: RPD Mass Coloration now works properly with pipe end-caps.