### PR TITLE
Revert "Sets world.movement_mode to TILE_MOVEMENT_MODE"

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -10,7 +10,6 @@ var/world_startup_time
 	cache_lifespan = 0	//stops player uploaded stuff from being kept in the rsc past the current session
 	//loop_checks = 0
 	icon_size = WORLD_ICON_SIZE
-	movement_mode = TILE_MOVEMENT_MODE
 
 
 var/savefile/panicfile


### PR DESCRIPTION
Reverts vgstation-coders/vgstation13#29703

It broke `Move()`: with `TILE_MOVEMENT_MODE` you can only move up to one tile away, apparently, so all teleportation using `Move()` is broken. @Exxion says he will report this to L*mmox.