### PR TITLE
Fixes CWC's multi powered wizards

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -299,16 +299,16 @@
 /datum/dynamic_ruleset/roundstart/cwc/execute()
 	var/datum/faction/wizard/civilwar/wpf/WPF = ticker.mode.CreateFaction(/datum/faction/wizard/civilwar/wpf, null, 1)
 	var/datum/faction/wizard/civilwar/wpf/PFW = ticker.mode.CreateFaction(/datum/faction/wizard/civilwar/pfw, null, 1)
-	for(var/wizards_number = 1 to assigned.len)
-		var/mob/M = pick(assigned)
-		if (M)
-			var/datum/role/wizard/newWizard = new
-			if(wizards_number % 2)
-				WPF.HandleRecruitedRole(newWizard)//this will give the wizard their icon
-			else
-				PFW.HandleRecruitedRole(newWizard)
-			newWizard.AssignToRole(M.mind,1)
-			newWizard.Greet(GREET_MIDROUND)
+	var/wizards_number = 1
+	for(var/mob/M in assigned)
+		var/datum/role/wizard/newWizard = new
+		if(wizards_number % 2)
+			WPF.HandleRecruitedRole(newWizard)//this will give the wizard their icon
+		else
+			PFW.HandleRecruitedRole(newWizard)
+		newWizard.AssignToRole(M.mind,1)
+		newWizard.Greet(GREET_MIDROUND)
+		wizards_number++
 	return 1
 
 //////////////////////////////////////////////

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -311,7 +311,6 @@
 			PFW.HandleRecruitedRole(newWizard)
 		newWizard.AssignToRole(M.mind,1)
 		newWizard.Greet(GREET_MIDROUND)
-		wizards_number++
 	return 1
 
 //////////////////////////////////////////////

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -299,11 +299,14 @@
 /datum/dynamic_ruleset/roundstart/cwc/execute()
 	var/datum/faction/wizard/civilwar/wpf/WPF = ticker.mode.CreateFaction(/datum/faction/wizard/civilwar/wpf, null, 1)
 	var/datum/faction/wizard/civilwar/wpf/PFW = ticker.mode.CreateFaction(/datum/faction/wizard/civilwar/pfw, null, 1)
-	var/wizards_number = 1
 	for(var/mob/M in assigned)
 		var/datum/role/wizard/newWizard = new
-		if(wizards_number % 2)
-			WPF.HandleRecruitedRole(newWizard)//this will give the wizard their icon
+		if (WPF.members.len < PFW.members.len)
+			WPF.HandleRecruitedRole(newWizard)
+		else if (WPF.members.len > PFW.members.len)
+			PFW.HandleRecruitedRole(newWizard)
+		else if(prob(50))
+			WPF.HandleRecruitedRole(newWizard)
 		else
 			PFW.HandleRecruitedRole(newWizard)
 		newWizard.AssignToRole(M.mind,1)


### PR DESCRIPTION
Fixes #29950

:cl:
* bugfix: Fixed the same player being picked several times at once to be a wizard during Civil War of Casters, and ending up with more Spell Books at their disposal while other players get cucked out of their antag roll.
