### PR TITLE
Blood Diseases transmission through biting, and a some contact transmission consistency

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -173,6 +173,15 @@
 		hand_hud_object.icon_state = "hand_inactive"
 
 /mob/living/carbon/proc/help_shake_act(mob/living/carbon/M)
+	if (src != M)
+		// we assume that they use their hands to shake us from our torso
+		var/block = 0
+		var/bleeding = 0
+		if (M.check_contact_sterility(HANDS) || check_contact_sterility(FULL_TORSO))//only one side has to wear protective clothing to prevent contact infection
+			block = 1
+		if (M.check_bodypart_bleeding(HANDS) && check_bodypart_bleeding(FULL_TORSO))//both sides have to be bleeding to allow for blood infections
+			bleeding = 1
+		share_contact_diseases(M,block,bleeding)
 	if (src.health >= config.health_threshold_crit)
 		if(src == M && istype(src, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = src

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -72,6 +72,7 @@
 			contract_disease(D,1,0)
 
 	apply_damage(damage, BRUTE, affecting)
+	attack_hand_contact_diseases(M, affecting, FALSE, TRUE)
 
 	M.attack_log += text("\[[time_stamp()]\] <font color='red'>bit [src.name] ([src.ckey]) for [damage] damage</font>")
 	src.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been bitten by [M.name] ([M.ckey]) for [damage] damage</font>")
@@ -156,6 +157,7 @@
 		M.say(pick("Take that!", "Taste the pain!"))
 
 	apply_damage(damage, BRUTE, affecting)
+	attack_hand_contact_diseases(M, affecting, TRUE)
 
 	if(!stomping) //Kicking somebody while holding them with a grab sends the victim flying
 		var/obj/item/weapon/grab/G = M.get_inactive_hand()
@@ -180,6 +182,26 @@
 		assaulted_by(M)
 	log_attack("[src.name] ([src.ckey]) kicked by [M.name] ([M.ckey])")
 
+/mob/living/carbon/human/proc/attack_hand_contact_diseases(var/mob/living/carbon/human/M, var/datum/organ/external/affecting_override = null, var/kick = FALSE, var/bite = FALSE)
+	var/datum/organ/external/S
+	if (affecting_override)
+		S = affecting_override
+	else
+		S = get_organ(M.zone_sel.selecting)
+	if (!(!S || S.status & ORGAN_DESTROYED))
+		var/touch_zone = S.body_part
+		var/used_bodypart = HANDS
+		if (kick)
+			used_bodypart = FEET
+		var/block = 0
+		var/bleeding = 0
+		// biting causes the check to consider that both sides are bleeding, allowing for blood-only disease transmission through biting.
+		if ((!bite && M.check_contact_sterility(used_bodypart)) || check_contact_sterility(touch_zone))//only one side has to wear protective clothing to prevent contact infection
+			block = 1
+		if ((bite || M.check_bodypart_bleeding(used_bodypart)) && (bite || check_bodypart_bleeding(touch_zone)))//both sides have to be bleeding to allow for blood infections
+			bleeding = 1
+		share_contact_diseases(M,block,bleeding)
+
 /mob/living/carbon/human/attack_hand(var/mob/living/carbon/human/M)
 	//M.delayNextAttack(10)
 	if (istype(loc, /turf) && istype(loc.loc, /area/start))
@@ -196,17 +218,6 @@
 	if((M != src) && check_shields(0, M))
 		visible_message("<span class='borange'>[M] attempts to touch [src]!</span>")
 		return 0
-
-	var/datum/organ/external/S = src.get_organ(M.zone_sel.selecting)
-	if (!(!S || S.status & ORGAN_DESTROYED))
-		var/touch_zone = get_part_from_limb(M.zone_sel.selecting)
-		var/block = 0
-		var/bleeding = 0
-		if (M.check_contact_sterility(HANDS) || check_contact_sterility(touch_zone))//only one side has to wear protective clothing to prevent contact infection
-			block = 1
-		if (M.check_bodypart_bleeding(HANDS) && check_bodypart_bleeding(touch_zone))//both sides have to be bleeding to allow for blood infections
-			bleeding = 1
-		share_contact_diseases(M,block,bleeding)
 
 	// CHEATER CHECKS
 	if(M.mind)
@@ -259,24 +270,31 @@
 				help_shake_act(M)
 				return 1
 			else if(ishuman(M))
+				attack_hand_contact_diseases(M)
 				M.perform_cpr(src)
 
 		if(I_GRAB)
+			attack_hand_contact_diseases(M)
 			return M.grab_mob(src)
 
 		if(I_HURT)
 			var/punch_damage = M.unarmed_attack_mob(src)
-			if (punch_damage)
+			if (punch_damage >= 0)
 				var/punch_zone = M.zone_sel.selecting
 				if (punch_zone == TARGET_EYES || punch_zone == TARGET_MOUTH)
 					punch_zone = LIMB_HEAD
 				var/datum/organ/external/limb = organs_by_name[punch_zone]
 				if(limb.status & ORGAN_BLEEDING)
 					M.bloody_hands(src,1)
-			return punch_damage
+				return punch_damage
+			else // dodged
+				return 0
 
 		if(I_DISARM)
-			return M.disarm_mob(src)
+			var/disarm_attempt = M.disarm_mob(src)
+			if (disarm_attempt)
+				attack_hand_contact_diseases(M)
+			return disarm_attempt
 	return
 
 /mob/living/carbon/human/proc/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, inrange, params)

--- a/code/modules/mob/living/carbon/monkey/combat.dm
+++ b/code/modules/mob/living/carbon/monkey/combat.dm
@@ -18,6 +18,21 @@
 	return ..()
 
 /mob/living/carbon/monkey/after_unarmed_attack(mob/living/target, damage, damage_type, organ, armor)
+	var/datum/organ/external/S = organ
+	if (organ)
+		S = organ
+	else
+		S = target.get_organ(zone_sel.selecting)
+	if (!(!S || S.status & ORGAN_DESTROYED))
+		var/touch_zone = S.body_part
+		var/block = 0
+		var/bleeding = 0
+		// biting causes the check to consider that both sides are bleeding, allowing for blood-only disease transmission through biting.
+		if (target.check_contact_sterility(touch_zone))//only one side has to wear protective clothing to prevent contact infection
+			block = 1
+		bleeding = 1 // monkeys always bite
+		share_contact_diseases(target,block,bleeding)
+
 	if(iscarbon(target))
 		for(var/datum/disease/D in viruses)
 

--- a/code/modules/mob/living/carbon/monkey/combat.dm
+++ b/code/modules/mob/living/carbon/monkey/combat.dm
@@ -23,15 +23,16 @@
 		S = organ
 	else
 		S = target.get_organ(zone_sel.selecting)
+	var/touch_zone = FULL_TORSO
 	if (!(!S || S.status & ORGAN_DESTROYED))
-		var/touch_zone = S.body_part
-		var/block = 0
-		var/bleeding = 0
-		// biting causes the check to consider that both sides are bleeding, allowing for blood-only disease transmission through biting.
-		if (target.check_contact_sterility(touch_zone))//only one side has to wear protective clothing to prevent contact infection
-			block = 1
-		bleeding = 1 // monkeys always bite
-		share_contact_diseases(target,block,bleeding)
+		touch_zone = S.body_part
+	var/block = 0
+	var/bleeding = 0
+	// biting causes the check to consider that both sides are bleeding, allowing for blood-only disease transmission through biting.
+	if (target.check_contact_sterility(touch_zone))//only one side has to wear protective clothing to prevent contact infection
+		block = 1
+	bleeding = 1 // monkeys always bite
+	share_contact_diseases(target,block,bleeding)
 
 	if(iscarbon(target))
 		for(var/datum/disease/D in viruses)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -210,7 +210,11 @@
 
 	add_logs(M, src, "bit", admin=1, object=null, addition="DMG: [damage]")
 	adjustBruteLoss(damage)
-	return
+	var/block = 0
+	// biting causes the check to consider that both sides are bleeding, allowing for blood-only disease transmission through biting.
+	if (check_contact_sterility(FULL_TORSO))//only one side has to wear protective clothing to prevent contact infection
+		block = 1
+	share_contact_diseases(M,block,1)
 
 //KICKS
 /mob/living/kick_act(mob/living/carbon/human/M)
@@ -264,6 +268,13 @@
 
 	add_logs(M, src, "kicked", admin=1, object=null, addition="DMG: [damage]")
 	adjustBruteLoss(damage)
+	var/block = 0
+	var/bleeding = 0
+	if ( M.check_contact_sterility(FEET) || check_contact_sterility(FULL_TORSO))//only one side has to wear protective clothing to prevent contact infection
+		block = 1
+	if ( M.check_bodypart_bleeding(FEET) && check_bodypart_bleeding(FULL_TORSO))//both sides have to be bleeding to allow for blood infections
+		bleeding = 1
+	share_contact_diseases(M,block,bleeding)
 
 /mob/living/proc/near_wall(var/direction,var/distance=1)
 	var/turf/T = get_step(get_turf(src),direction)


### PR DESCRIPTION
Fixes #8625

:cl:
* bugfix: You no longer share contact diseases with someone after a punch or disarm that missed.
* bugfix: Biting and Kicking can now properly transmit contact diseases, checking sterility on your feet instead of your hands in the case of kicking, and bypassing bleeding checks (and sterility checks on your own face) in the case of biting, which means that you can now bite people to transmit them your own (or get their) blood-only diseases (still needs to pass the sterility check on the target as well as the infection chance roll though). This applies to monkeys as well since they always attack by biting, but not to mice whose teeth aren't quite big enough.