### PR TITLE
Fixes the Master Trainer Belt's mobs attacking the agent who bought the belt

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
@@ -282,7 +282,7 @@
 
 /mob/living/simple_animal/hostile/hex/New()
 	..()
-
+	setupglow(rgb(255,255,255))
 	animate(src, pixel_y = 4 * PIXEL_MULTIPLIER , time = 10, loop = -1, easing = SINE_EASING)
 	animate(pixel_y = 2 * PIXEL_MULTIPLIER, time = 10, loop = -1, easing = SINE_EASING)
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -866,6 +866,9 @@ var/list/uplink_items = list()
 	discounted_cost = 8
 	jobs_with_discount = list("Shaft Miner")
 
+/datum/uplink_item/jobspecific/cargo/mastertrainer/new_uplink_item(var/new_item, var/turf/location, mob/user)
+	return new new_item(location, user)
+
 /datum/uplink_item/jobspecific/service
 	category = "Service Specials"
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -81,6 +81,8 @@
 	if(timestopped)
 		return 0 //under effects of time magick
 
+	var/in_capsule = istype(loc, /obj/item/device/mobcapsule)
+
 	//emps and lots of damage can temporarily shut us down
 	if(disabled > 0)
 		stat = UNCONSCIOUS
@@ -97,24 +99,27 @@
 
 	//repair a bit of damage
 	if(health != maxHealth && prob(3))
-		src.visible_message("<span class='warning'>  [bicon(src)] [src] shudders and shakes as some of it's damaged systems come back online.</span>")
-		spark(src)
+		if (!in_capsule)
+			src.visible_message("<span class='warning'>  [bicon(src)] [src] shudders and shakes as some of it's damaged systems come back online.</span>")
+			spark(src)
 		health += rand(25,100)
 
 	//spark for no reason
-	if(prob(5))
+	if(prob(5) && !in_capsule)
 		spark(src)
 
 	//sometimes our targetting sensors malfunction, and we attack anyone nearby
 	if(prob(disabled ? 0 : 1) && hostile == 0)
-		src.visible_message("<span class='warning'> [bicon(src)] [src] suddenly lights up, and additional targeting vanes slide into place.</span>")
+		if (!in_capsule)
+			src.visible_message("<span class='warning'> [bicon(src)] [src] suddenly lights up, and additional targeting vanes slide into place.</span>")
 		hostile = 1
 		hostile_time = rand(20,35)
 	else if(hostile == 1)
 		hostile_time--
 		if(hostile_time == 0)
 			hostile = 0
-			src.visible_message("<span class='notice'> [bicon(src)] [src] retracts several targeting vanes, and dulls it's running lights.</span>")
+			if (!in_capsule)
+				src.visible_message("<span class='notice'> [bicon(src)] [src] retracts several targeting vanes, and dulls it's running lights.</span>")
 			LoseTarget()
 
 	if(health / maxHealth > 0.9)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -395,7 +395,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 				someone_in_earshot=1
 				break
 
-	if(someone_in_earshot)
+	if(someone_in_earshot && !istype(loc, /obj/item/device/mobcapsule))
 		if(rand(0,200) < speak_chance)
 			var/mode = pick(
 			speak.len;      1,


### PR DESCRIPTION
Fixes #29975
Fixes #29155
Fixes #28094

:cl:
* bugfix: The mobs coming out of a Master Trainer Belt's capsules finally ignore the agent who bought the belt as intended.
* tweak: Mobs in capsules no longer have a chance to perform their random emotes or say their random lines. Rogue Drones in capsules also no longer emit sparks randomly.
* bugfix: Fixed Hex spawned by the Master Trainer Belt having invisible lights