### PR TITLE
Makes manifest predictions sort by department and look much nicer

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -220,16 +220,26 @@
 We don't care about names, DNA, accounts, activity, any of that. We're just gonna loop through high job prefs.*/
 
 /datum/controller/occupations/proc/display_prediction()
+	var/list/heads = new()
+	var/list/sec = new()
+	var/list/eng = new()
+	var/list/med = new()
+	var/list/sci = new()
+	var/list/cgo = new()
+	var/list/civ = new()
+	var/list/bot = new()
+	var/list/misc = new()
 	predict_manifest()
 	if(!crystal_ball.len)
 		return "No prediction has been made!" //This only gets shown the first time ever. If everyone unreadies it's blank.
 	var/dat = {"
-	<head><style>
-	{border-collapse:collapse;}
-	td, th {border:1px solid "#DEF; background-color:white; color:black"; padding:.25em}
-	th {height: 2em; "background-color: #48C; color:white";}
-	tr.head th {"background-color: #488";}
-	tr.alt td {"background-color: #DEF"]}
+	<head><head><style>
+		.manifest {border-collapse:collapse;}
+		.manifest td, th {border:1px solid [monochrome?"black":"#DEF; background-color:white; color:black"]; padding:.25em}
+		.manifest th {height: 2em; [monochrome?"border-top-width: 3px":"background-color: #48C; color:white"]}
+		.manifest tr.head th { [monochrome?"border-top-width: 1px":"background-color: #488;"] }
+		.manifest td:first-child {text-align:right}
+		.manifest tr.alt td {[monochrome?"border-top-width: 2px":"background-color: #DEF"]}
 	</style></head>
 	<table class="manifest" width='350px'>
 	<tr class='head'><th>Rank</th><th>Quantity</th></tr>
@@ -239,8 +249,90 @@ We don't care about names, DNA, accounts, activity, any of that. We're just gonn
 	for(var/job in crystal_ball)
 		if(!crystal_ball[job])
 			continue //If 0, skip
-		dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
-		color = !color
+		var/department = 0
+		if(job in command_positions)
+			heads[job] = crystal_ball[job]
+			department = 1
+		if(job in security_positions)
+			sec[job] = crystal_ball[job]
+			department = 1
+		if(job in engineering_positions)
+			eng[job] = crystal_ball[job]
+			department = 1
+		if(job in medical_positions)
+			med[job] = crystal_ball[job]
+			department = 1
+		if(job in science_positions)
+			sci[job] = crystal_ball[job]
+			department = 1
+		if(job in cargo_positions)
+			cgo[job] = crystal_ball[job]
+			department = 1
+		if(job in civilian_positions)
+			civ[job] = crystal_ball[job]
+			department = 1
+		if(job in nonhuman_positions)
+			bot[job] = crystal_ball[job]
+			department = 1
+		if(!department && !(job in heads))
+			misc[job] = crystal_ball[job]
+
+	if(heads.len > 0)
+		dat += "<tr><th colspan=3>Heads</th></tr>"
+		for(name in heads)
+			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
+			color = !color
+
+	if(sec.len > 0)
+		dat += "<tr><th colspan=3>Security</th></tr>"
+		for(name in sec)
+			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
+			color = !color
+
+	if(eng.len > 0)
+		dat += "<tr><th colspan=3>Engineering</th></tr>"
+		for(name in eng)
+			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
+			color = !color
+
+	if(med.len > 0)
+		dat += "<tr><th colspan=3>Medical</th></tr>"
+		for(name in med)
+			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
+			color = !color
+
+	if(sci.len > 0)
+		dat += "<tr><th colspan=3>Science</th></tr>"
+		for(name in sci)
+			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
+			color = !color
+
+	if(cgo.len > 0)
+		dat += "<tr><th colspan=3>Cargo</th></tr>"
+		for(name in cgo)
+			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
+			color = !color
+
+	if(civ.len > 0)
+		dat += "<tr><th colspan=3>Civilian</th></tr>"
+		for(name in civ)
+			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
+			color = !color
+
+	// misc guys
+	if(misc.len > 0)
+		dat += "<tr><th colspan=3>Miscellaneous</th></tr>"
+		for(name in misc)
+			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
+			color = !color
+
+	if(bot.len > 0)
+		dat += "<tr><th colspan=3>Silicon</th></tr>"
+		for(name in bot)
+			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
+			color = !color
+
+	dat += "</table>"
 
 	return dat
 

--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -235,11 +235,11 @@ We don't care about names, DNA, accounts, activity, any of that. We're just gonn
 	var/dat = {"
 	<head><head><style>
 		.manifest {border-collapse:collapse;}
-		.manifest td, th {border:1px solid [monochrome?"black":"#DEF; background-color:white; color:black"]; padding:.25em}
-		.manifest th {height: 2em; [monochrome?"border-top-width: 3px":"background-color: #48C; color:white"]}
-		.manifest tr.head th { [monochrome?"border-top-width: 1px":"background-color: #488;"] }
+		.manifest td, th {border:1px solid #DEF; background-color:white; color:black; padding:.25em}
+		.manifest th {height: 2em; background-color: #48C; color:white}
+		.manifest tr.head th {background-color: #488}
 		.manifest td:first-child {text-align:right}
-		.manifest tr.alt td {[monochrome?"border-top-width: 2px":"background-color: #DEF"]}
+		.manifest tr.alt td {background-color: #DEF}
 	</style></head>
 	<table class="manifest" width='350px'>
 	<tr class='head'><th>Rank</th><th>Quantity</th></tr>
@@ -279,56 +279,56 @@ We don't care about names, DNA, accounts, activity, any of that. We're just gonn
 
 	if(heads.len > 0)
 		dat += "<tr><th colspan=3>Heads</th></tr>"
-		for(name in heads)
+		for(var/job in heads)
 			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
 			color = !color
 
 	if(sec.len > 0)
 		dat += "<tr><th colspan=3>Security</th></tr>"
-		for(name in sec)
+		for(var/job in sec)
 			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
 			color = !color
 
 	if(eng.len > 0)
 		dat += "<tr><th colspan=3>Engineering</th></tr>"
-		for(name in eng)
+		for(var/job in eng)
 			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
 			color = !color
 
 	if(med.len > 0)
 		dat += "<tr><th colspan=3>Medical</th></tr>"
-		for(name in med)
+		for(var/job in med)
 			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
 			color = !color
 
 	if(sci.len > 0)
 		dat += "<tr><th colspan=3>Science</th></tr>"
-		for(name in sci)
+		for(var/job in sci)
 			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
 			color = !color
 
 	if(cgo.len > 0)
 		dat += "<tr><th colspan=3>Cargo</th></tr>"
-		for(name in cgo)
+		for(var/job in cgo)
 			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
 			color = !color
 
 	if(civ.len > 0)
 		dat += "<tr><th colspan=3>Civilian</th></tr>"
-		for(name in civ)
+		for(var/job in civ)
 			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
 			color = !color
 
 	// misc guys
 	if(misc.len > 0)
 		dat += "<tr><th colspan=3>Miscellaneous</th></tr>"
-		for(name in misc)
+		for(var/job in misc)
 			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
 			color = !color
 
 	if(bot.len > 0)
 		dat += "<tr><th colspan=3>Silicon</th></tr>"
-		for(name in bot)
+		for(var/job in bot)
 			dat += "<tr[color ? " class='alt'" : ""]><td>[job]</td><td>[crystal_ball[job]]</td></tr>"
 			color = !color
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -174,12 +174,9 @@
 		create_cluwne()
 
 	if(href_list["predict"])
-		var/dat = {"<html><body>
-		<h4>High Job Preferences</h4>"}
-		dat += job_master.display_prediction()
-
-		src << browse(dat, "window=manifest;size=400x420;can_close=1")
+		ViewPrediction()
 		return 1
+
 	if(href_list["manifest"])
 		ViewManifest()
 
@@ -655,9 +652,14 @@ Round Duration: [round(hours)]h [round(mins)]m<br>"}
 		new_character.Namepick()
 	return new_character
 
+/mob/new_player/proc/ViewPrediction()
+	var/dat = {"<html><body>
+	<h4>High Job Preferences</h4>"}
+	dat += job_master.display_prediction()
+
+	src << browse(dat, "window=manifest;size=370x420;can_close=1")
+	
 /mob/new_player/proc/ViewManifest()
-
-
 	var/dat = {"<html><body>
 <h4>Crew Manifest</h4>"}
 	dat += data_core.get_manifest(OOC = 1)


### PR DESCRIPTION
[ui][tweak]
![image](https://user-images.githubusercontent.com/57303506/125179806-db6e4a80-e1e9-11eb-8394-d7273283b9f8.png)

:cl:
 * tweak: Manifest predictions in pre-game lobby are now sorted by department.
 * bugfix: Manifest prediction CSS now displays properly.