### PR TITLE
Some Strike team logging

### DIFF
--- a/code/game/striketeams/striketeam_datums.dm
+++ b/code/game/striketeams/striketeam_datums.dm
@@ -26,6 +26,8 @@ var/list/sent_strike_teams = list()
 /datum/striketeam/proc/trigger_strike(var/mob/user, var/missiontext)
 	mission = missiontext
 
+	var/user_key_name = key_name(user)
+
 	//Is the game started
 	if(!ticker)
 		if(user)
@@ -41,7 +43,7 @@ var/list/sent_strike_teams = list()
 		return
 
 	//Logging
-	message_admins("<span class='notice'>[key_name(user)] is preparing a [striketeam_name].</span>", 1)
+	message_admins("<span class='notice'>[user_key_name] is preparing a [striketeam_name].</span>", 1)
 
 
 	if(user)
@@ -105,6 +107,7 @@ var/list/sent_strike_teams = list()
 		message_admins("[applicants.len] players volunteered for [striketeam_name].")
 
 		var/list/commando_spawns = list_commando_spawns()
+		var/turf/T = get_turf(pick(commando_spawns))
 		var/commando_count = min(applicants.len,team_size)
 		var/leader = FALSE
 
@@ -152,6 +155,8 @@ var/list/sent_strike_teams = list()
 				new_commando.update_action_buttons_icon()
 
 				greet_commando(new_commando)
+		log_admin("The [striketeam_name] called by [user_key_name] has been created with [team_composition.len] member[team_composition.len > 1 "s":""] and is now preparing at [T.loc].")
+		message_admins("<span class='notice'>The [striketeam_name] called by [user_key_name] has been created with [team_composition.len] member[team_composition.len > 1 "s":""] and is now preparing at [T.loc] <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a>.</span>")
 		extras()
 
 /datum/striketeam/proc/create_commando(var/obj/spawn_location,var/leader_selected=0,var/mob_key = "")

--- a/code/game/striketeams/striketeam_datums.dm
+++ b/code/game/striketeams/striketeam_datums.dm
@@ -155,8 +155,8 @@ var/list/sent_strike_teams = list()
 				new_commando.update_action_buttons_icon()
 
 				greet_commando(new_commando)
-		log_admin("The [striketeam_name] called by [user_key_name] has been created with [team_composition.len] member[team_composition.len > 1 "s":""] and is now preparing at [T.loc].")
-		message_admins("<span class='notice'>The [striketeam_name] called by [user_key_name] has been created with [team_composition.len] member[team_composition.len > 1 "s":""] and is now preparing at [T.loc] <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a>.</span>")
+		log_admin("The [striketeam_name] called by [user_key_name] has been created with [team_composition.len] member[team_composition.len > 1 ? "s":""] and is now preparing at [T.loc].")
+		message_admins("<span class='notice'>The [striketeam_name] called by [user_key_name] has been created with [team_composition.len] member[team_composition.len > 1 ? "s":""] and is now preparing at [T.loc] <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a>.</span>")
 		extras()
 
 /datum/striketeam/proc/create_commando(var/obj/spawn_location,var/leader_selected=0,var/mob_key = "")


### PR DESCRIPTION
Admins now get a message after applications for a strike team have been processed, including a count of how many commando spawned, and a button to let them quickly jump to the Strike Team's spawn location.

Fixes #9504