### PR TITLE
Gourmonger is now considered a Boss Mob and will no longer spawn from gold slime reactions

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -401,7 +401,8 @@ var/list/boss_mobs = list(
 	/mob/living/simple_animal/hostile/humanoid/surgeon/skeleton,	// Second stage of Doctor Placeholder
 	/mob/living/simple_animal/hostile/roboduck,						// The bringer of the end times
 	/mob/living/simple_animal/hostile/bear/spare,					// Captain bear
-	/mob/living/simple_animal/hostile/ginger/gingerbroodmother		// Gingerbominations...
+	/mob/living/simple_animal/hostile/ginger/gingerbroodmother,		// Gingerbominations...
+	/mob/living/simple_animal/hostile/gourmonger					// Insatiable Glutton
 	)
 
 // Set by traitor item, affects cargo supplies


### PR DESCRIPTION
Fixes #29094

:cl:
* tweak: Gourmongers will no longer spawn from Gold Slime reactions, as they are now considered a boss mob.