### PR TITLE
Fix photobooth board

### DIFF
--- a/code/modules/research/designs/boards/machine_misc.dm
+++ b/code/modules/research/designs/boards/machine_misc.dm
@@ -191,13 +191,12 @@
 	id = "booze_dispenser"
 	build_path = /obj/item/weapon/circuitboard/chem_dispenser/booze_dispenser
 
-
-/datum/design/teleconsole
+/datum/design/photobooth
 	name = "Circuit Design (Photo Booth)"
-	desc = "Allows for the construction of circuit boards used to build a teleporter control console."
-	id = "teleconsole"
-	req_tech = list(Tc_PROGRAMMING = 3, Tc_BLUESPACE = 2)
+	desc = "Allows for the construction of circuit boards used to build a photo booth."
+	id = "photobooth"
+	req_tech = list(Tc_PROGRAMMING = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, SACID = 20)
-	category = "Console Boards"
-	build_path = /obj/item/weapon/circuitboard/teleporter
+	category = "Machine Boards"
+	build_path = /obj/item/weapon/circuitboard/photobooth


### PR DESCRIPTION
Fixes #29995 

:cl:
* bugfix: Fixed the photo booth board appearing in the wrong category and printing a teleporter console board instead