### PR TITLE
Fixes Stackable Porokeratosis Acanthus and other bumpable symptoms

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -628,11 +628,14 @@
 	if (toucher == touched)
 		return
 	if(virus2.len)
+		var/list/symptom_types = list()
 		for(var/I in virus2)
 			var/datum/disease2/disease/D = virus2[I]
 			if(D.effects.len)
 				for(var/datum/disease2/effect/E in D.effects)
-					E.on_touch(src, toucher, touched, touch_type)
+					if (!(E.type in symptom_types))
+						symptom_types += E.type
+						E.on_touch(src, toucher, touched, touch_type)
 
 /mob/living/carbon/proc/check_handcuffs()
 	return handcuffed || istype(locked_to, /obj/structure/bed/nest)


### PR DESCRIPTION
Fixes #17073
Fixes #29266

:cl:
* bugfix: When infected with several diseases all featuring the same symptoms that activate when touching or bumping into someone (namely Porokeratosis Acanthus and Epidermolysis Bullosa), only the first instance of each symptom type will activate per bump. So no more crit'ing people in a single bump while infected with 50 duplicates of the same disease, that symptom is deadly enough on its own already.