### PR TITLE
Fixes admin PM mute bypass

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -22,6 +22,10 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	msg = trim_left(trim_right(sanitize(copytext(msg,1,MAX_MESSAGE_LEN))))
 	if(!msg)
 		return
+	//sanity check, do it twice
+	if(prefs.muted & MUTE_ADMINHELP)
+		to_chat(src, "<span class='red'>Error: Admin-PM: You cannot send adminhelps (Muted).</span>")
+		return
 	if(src.handle_spam_prevention(msg,MUTE_ADMINHELP))
 		return
 	var/original_msg = msg


### PR DESCRIPTION
[bugfix][sanity]
Closes #27011.
:cl:
 * bugfix: Admin PM mutes can no longer be bypassed while the PM box is open.