### PR TITLE
Fixes various coffins issues and changes how buckling in one works

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -488,8 +488,10 @@
 		return 0
 	if(istype(O, /obj/structure/closet))
 		return 0
-	if(move_them)
-		step_towards(O, src.loc)
+	if(move_them)//We've already checked for ajacency so it's fine to use forceMove, it also guarrantees that they won't bump into us?
+		O.forceMove(user.loc)
+		sleep(1)
+		O.forceMove(src.loc)
 	if(show_message && user != O)
 		user.show_viewers("<span class='danger'>[user] stuffs [O] into [src]!</span>")
 	src.add_fingerprint(user)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -488,7 +488,7 @@
 		return 0
 	if(istype(O, /obj/structure/closet))
 		return 0
-	if(move_them)//We've already checked for ajacency so it's fine to use forceMove, it also guarrantees that they won't bump into us?
+	if(move_them)//We've already checked for adjacency so it's fine to use forceMove, it also guarrantees that they won't bump into us?
 		O.forceMove(user.loc)
 		sleep(1)
 		O.forceMove(src.loc)


### PR DESCRIPTION
Sho**u**t-out to Armadingus for bringing that one to my attention.

:cl:
* bugfix; Moving people inside closets via mouse-dragging is now more consistent, and no longer results in the person bumping into you.
* bugfix: Fixed issues where you could buckle ghosts and other non-tangible mobs (such as an AI holopad's virtualhearer) by using a coffin's AltClick property. Observers could also unbuckle mobs buckled inside coffins, and anyone could do it at any distance.
* tweak: Buckling and Un-buckling from a coffin is now done via mouse-dragging, just like in a sleeper. AltClicking does nothing anymore, and clicking toggles normally the coffin open or closed. On that note, you can now properly close coffins while people are buckled in them.