### PR TITLE
Fixes newscasters deleting photos when made into frame

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -992,6 +992,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				if(do_after(user, src,10))
 					to_chat(user, "<span class='notice'>You pry off the [src]!.</span>")
 					new /obj/item/mounted/frame/newscaster(loc)
+					EjectPhoto(user)
 					qdel(src)
 					return
 


### PR DESCRIPTION
Closes #30007.
-->
:cl:
 * bugfix: Newscasters no longer delete their photos from existence when made into frames.