### PR TITLE
Better crit logging

### DIFF
--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -81,8 +81,7 @@
  * Helper proc to log attacks or similar events between two mobs.
  */
 /proc/add_attacklogs(var/mob/user, var/mob/target, var/what_done, var/object = null, var/addition = null, var/admin_warn = TRUE)
-	if (!user) // That should never happen
-		return
+	ASSERT(istype(user))
 	var/user_txt = "[user][user.ckey ? " ([user.ckey])" : " (no key)"]"
 	var/target_txt = (target ? ismob(target) ? "[target][target.ckey ? " ([target.ckey])" : " (no key)"]" : "[target]" : "")
 	var/object_txt = (object ? " with \the [object]" : "")

--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -81,8 +81,10 @@
  * Helper proc to log attacks or similar events between two mobs.
  */
 /proc/add_attacklogs(var/mob/user, var/mob/target, var/what_done, var/object = null, var/addition = null, var/admin_warn = TRUE)
-	var/user_txt = (user ? "[user][user.ckey ? " ([user.ckey])" : ""]" : "\<NULL USER\>")
-	var/target_txt = (target ? ismob(target) ? "[target][target.ckey ? " ([target.ckey])" : ""]" : "[target]" : "\<NULL TARGET\>")
+	if (!user) // That should never happen
+		return
+	var/user_txt = "[user][user.ckey ? " ([user.ckey])" : " (no key)"]"
+	var/target_txt = (target ? ismob(target) ? "[target][target.ckey ? " ([target.ckey])" : " (no key)"]" : "[target]" : "")
 	var/object_txt = (object ? " with \the [object]" : "")
 	var/intent_txt = (user ? " (INTENT: [uppertext(user.a_intent)])" : "")
 	var/addition_txt = (addition ? " ([addition])" : "")

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -54,10 +54,19 @@
 
 
 /mob/living/proc/critlog(curH,prevH)
-	var/do_we_care_about_it = mind != null
-	if(curH <= 0 && prevH > 0)
-		if (curH > -95)
-			add_attacklogs(src,null,"has gone into CRIT!", admin_warn = do_we_care_about_it)
+	if (istype(loc, /obj/machinery/cloning/clonepod))
+		return FALSE // Mob probably just spawned
+	return TRUE
+
+/mob/living/carbon/critlog(curH,prevH)
+	. == ..()
+	if (.)
+		var/do_we_care_about_it = mind != null
+		if(curH <= config.health_threshold_crit && prevH > config.health_threshold_crit)
+			if (curH <= config.health_threshold_dead)
+				add_attacklogs(src,null,"took so much damage they became DEAD before even being in crit!", admin_warn = do_we_care_about_it)
+			else
+				add_attacklogs(src,null,"has gone into CRIT!", admin_warn = do_we_care_about_it)
 
 
 /mob/living/proc/apply_effect(var/effect = 0,var/effecttype = STUN, var/blocked = 0)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -59,7 +59,7 @@
 	return TRUE
 
 /mob/living/carbon/critlog(curH,prevH)
-	. == ..()
+	. = ..()
 	if (.)
 		var/do_we_care_about_it = mind != null
 		if(curH <= config.health_threshold_crit && prevH > config.health_threshold_crit)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -53,9 +53,11 @@
 	return 1
 
 
-/mob/living/proc/critlog(curH,prevH) //current health, previous health
-	if(stat == UNCONSCIOUS && curH < 0 && curH > -95.0 && prevH > 0)
-		add_attacklogs(src,null,"has gone into CRIT!")
+/mob/living/proc/critlog(curH,prevH)
+	var/do_we_care_about_it = mind != null
+	if(curH <= 0 && prevH > 0)
+		if (curH > -95)
+			add_attacklogs(src,null,"has gone into CRIT!", admin_warn = do_we_care_about_it)
 
 
 /mob/living/proc/apply_effect(var/effect = 0,var/effecttype = STUN, var/blocked = 0)


### PR DESCRIPTION
Fixes #29489

* logs for mobs going into crit no longer fire if the mob is in a cloning pod (since they always go immediately into crit when they spawn)
* only carbon mobs can go into crit so only them will produce logs when going into crit
* their logs will not be sent to admins though if the mob had no mind
* fixed critlogs to be more consistent and always appear when a mob falls into crit regardless of status