### PR TITLE
Mapped the Space Carp Cubes to all the maps' xenobiology.

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -554,8 +554,8 @@
 		new /obj/item/weapon/reagent_containers/food/snacks/monkeycube/wrapped/mousecube(src)
 
 /obj/item/weapon/storage/box/monkeycubes/spacecarpcube
-	name = "space carp baby cube box"
-	desc = "Drymate brand space carp baby cubes, shipped from F1SH-1NG. Just add water!"
+	name = "space carp cube box"
+	desc = "Drymate brand space carp cubes, shipped from F1SH-1NG. Just add water!"
 	icon_state = "spacecarpcubebox"
 
 /obj/item/weapon/storage/box/monkeycubes/spacecarpcube/New()

--- a/maps/test_box.dmm
+++ b/maps/test_box.dmm
@@ -71411,6 +71411,9 @@
 "cDs" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -71871,9 +71874,13 @@
 /area/science/xenobiology)
 "cEf" = (
 /obj/structure/table,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 5
+/obj/item/weapon/storage/box/monkeycubes/spacecarpcube{
+	name = "space carp cube box"
 	},
+/obj/item/weapon/storage/box/monkeycubes/spacecarpcube{
+	name = "space carp cube box"
+	},
+/obj/item/weapon/reagent_containers/glass/bottle/carppheromones,
 /turf/simulated/floor{
 	icon_state = "white"
 	},


### PR DESCRIPTION
Mapping side PR to #29994. Closes #28925. 
Xenobiology carp cubes mapped to:
Boxstation, OG Bagelstation, Defficiency, Low Fat Bagel, Lamprey, Metaclub, Horizon, Packed, Roid, Snaxi, Synergy, Castle, Xoq and test-box.
![Boxstation Carp Box](https://user-images.githubusercontent.com/67024428/126030848-3c59b118-dbf0-48fc-b727-9a2411a3d386.png)

Also fixed boxstation hydroponics being half-painted, as if forgotten. 
![Hydroponics Fix](https://user-images.githubusercontent.com/67024428/126030947-c8faa783-d4b3-430b-bfc0-d5690635a70d.png)

I know next to nothing about mapping PRs so dunno if this is correct, but I hope/assume it is.
[bagel][box][bus][deff][meta][packed][roid][snowmap][taxi][content]

:cl:
 * rscadd: Space Carp Cubes boxes and Carp Pheromone bottle mapped to all maps' Xenobiology and Centcom Xenobiology (that one pen with 1 slime at Centcom Science).
 * rscadd: Repainted Boxstation's Hydroponics to fix my OCD.