### PR TITLE
Magnitis buff

### DIFF
--- a/code/modules/virus2/effect/stage_4.dm
+++ b/code/modules/virus2/effect/stage_4.dm
@@ -792,50 +792,27 @@
 	encyclopedia = "Injections of iron help temporarily stabilize the magnetic field."
 	stage = 4
 	badness = EFFECT_DANGER_HARMFUL
+	chance = 5
+	max_chance = 20
 
 /datum/disease2/effect/magnitis/activate(var/mob/living/mob)
 	if(mob.reagents.has_reagent(IRON))
 		return
 
-	switch(count)
-		if(0 to 10)
-			if(prob(2))
-				to_chat(mob, "<span class='warning'>You feel a slight shock course through your body.</span>")
-				for(var/obj/M in orange(2,mob))
-					if(!M.anchored && (M.is_conductor()))
-						step_towards(M,mob)
-				for(var/mob/living/silicon/S in orange(2,mob))
-					if(istype(S, /mob/living/silicon/ai))
-						continue
-					step_towards(S,mob)
-		if(11 to 20)
-			if(prob(4))
-				to_chat(mob, "<span class='warning'>You feel a strong shock course through your body.</span>")
-				for(var/obj/M in orange(4,mob))
-					if(!M.anchored && (M.is_conductor()))
-						var/iter = rand(1,2)
-						for(var/i=0,i<iter,i++)
-							step_towards(M,mob)
-				for(var/mob/living/silicon/S in orange(4,mob))
-					if(istype(S, /mob/living/silicon/ai))
-						continue
-					var/iter = rand(1,2)
-					for(var/i=0,i<iter,i++)
-						step_towards(S,mob)
-		if(21 to INFINITY)
-			if(prob(8))
-				to_chat(mob, "<span class='warning'>You feel a powerful shock course through your body.</span>")
-				for(var/obj/M in orange(6,mob))
-					if(!M.anchored && (M.is_conductor()))
-						var/iter = rand(1,3)
-						for(var/i=0,i<iter,i++)
-							step_towards(M,mob)
-				for(var/mob/living/silicon/S in orange(6,mob))
-					if(istype(S, /mob/living/silicon/ai))
-						continue
-					var/iter = rand(1,3)
-					for(var/i=0,i<iter,i++)
-						step_towards(S,mob)
+	var/intensity = 1 + (intensity > 10) + (intensity > 20)
+	if (prob(20))
+		to_chat(mob, "<span class='warning'>You feel a [intensity < 3 ? "slight" : "powerful"] shock course through your body.</span>")
+	for(var/obj/M in orange(3 * intensity,mob))
+		if(!M.anchored && (M.is_conductor()))
+			var/iter = rand(1,intensity)
+			for(var/i=0,i<iter,i++)
+				step_towards(M,mob)
+	for(var/mob/living/silicon/S in orange(3 * intensity,mob))
+		if(istype(S, /mob/living/silicon/ai))
+			continue
+		var/iter = rand(1,intensity)
+		for(var/i=0,i<iter,i++)
+			step_towards(S,mob)
 
 /datum/disease2/effect/emitter
 	name = "Afflictus Emittus"

--- a/code/modules/virus2/effect/stage_4.dm
+++ b/code/modules/virus2/effect/stage_4.dm
@@ -799,7 +799,7 @@
 	if(mob.reagents.has_reagent(IRON))
 		return
 
-	var/intensity = 1 + (intensity > 10) + (intensity > 20)
+	var/intensity = 1 + (count > 10) + (count > 20)
 	if (prob(20))
 		to_chat(mob, "<span class='warning'>You feel a [intensity < 3 ? "slight" : "powerful"] shock course through your body.</span>")
 	for(var/obj/M in orange(3 * intensity,mob))


### PR DESCRIPTION
:cl:
* tweak: Magnitis has been buffed quite a lot from the near-invisible symptom it was until now. The Symptom no longer has to pass two probability checks to activate instead of one. Its area of effect has also been increased by 1 tile for each three levels of intensity (which increases after the first 10 and 20 activations, to 3 tiles, to 6 tiles, to 9 tiles.)