### PR TITLE
Coffin unbuckle alarm button

### DIFF
--- a/code/_onclick/hud/screen_alarms.dm
+++ b/code/_onclick/hud/screen_alarms.dm
@@ -194,6 +194,17 @@ var/global/list/screen_alarms_locs = list(
 	name = "Buckled"
 	desc = "You've been buckled to something and can't move. Click on this alert to unbuckle."
 
+/obj/abstract/screen/alert/object/buckled/coffin/Click(location, control, params)
+	if(!usr || !usr.client)
+		return
+	var/paramslist = params2list(params)
+	if(paramslist["shift"])
+		to_chat(usr, "<span class='notice'>[name]</span> - <span class='info'>[desc]</span>")
+		return
+	if(master && istype(master, /obj/structure/closet/coffin))
+		var/obj/structure/closet/coffin/C = master
+		C.unbuckle_to(get_turf(C))
+
 //Carbon Alarms
 /obj/abstract/screen/alert/carbon/breath
 	name = "Suffocating"

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -25,6 +25,23 @@
 		locked.handle_alpha()
 	..()
 
+/obj/structure/closet/coffin/lock_atom(atom/movable/AM)
+	. = ..()
+	if(!.)
+		return
+	if(ismob(AM))
+		var/mob/dude = AM
+		dude.throw_alert(SCREEN_ALARM_BUCKLE, /obj/abstract/screen/alert/object/buckled, new_master = src)
+
+/obj/structure/closet/coffin/unlock_atom(var/atom/movable/AM)
+	if(current_glue_state != GLUE_STATE_NONE && ismob(AM))
+		return FALSE
+	. = ..()
+	if(.)
+		if(ismob(AM))
+			var/mob/dude = AM
+			dude.clear_alert(SCREEN_ALARM_BUCKLE)
+
 /obj/structure/closet/coffin/update_icon()
 	if(!opened)
 		icon_state = icon_closed

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -31,7 +31,7 @@
 		return
 	if(ismob(AM))
 		var/mob/dude = AM
-		dude.throw_alert(SCREEN_ALARM_BUCKLE, /obj/abstract/screen/alert/object/buckled, new_master = src)
+		dude.throw_alert(SCREEN_ALARM_BUCKLE, /obj/abstract/screen/alert/object/buckled/coffin, new_master = src)
 
 /obj/structure/closet/coffin/unlock_atom(var/atom/movable/AM)
 	if(current_glue_state != GLUE_STATE_NONE && ismob(AM))
@@ -66,6 +66,9 @@
 		buckle_mob(O, user)
 
 /obj/structure/closet/coffin/MouseDropFrom(over_object, src_location, var/turf/over_location, src_control, over_control, params)
+	unbuckle_to(over_location)
+
+/obj/structure/closet/coffin/proc/unbuckle_to(var/turf/over_location)
 	if (opened && !is_locking(mob_lock_type))
 		return
 	if (!opened && !mob_inside_thats_buckled)


### PR DESCRIPTION
:cl:
* rscadd: Added a screen alarm button that players can click when buckled to a coffin to unbuckle themselves, similar to when buckled to a chair or bed.