### PR TITLE
Tweaks to make ghoulification possible. 

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
@@ -109,7 +109,7 @@
 			Necrosis - After Limb mutation
 			Glowing slightly green - Extremely rare, practically terminal, glowing increases with radiation level
 		600
-			Ghoulification if extremely lucky - We're talking 1 in 1000
+			Ghoulification if lucky - We're talking 1 in 100
 
 		For anything affecting internal or external organs, if it's robotic, exempt them.
 		*/
@@ -164,7 +164,7 @@
 				if(organ_to_damage.len)
 					var/datum/organ/internal/victim = pick(organ_to_damage)
 					if(istype(victim, /datum/organ/internal/brain))
-						adjustBrainLoss(rand(1,4)*major_rad_multiplier)
+						adjustBrainLoss(rand(1,4))
 					else
 						victim.take_damage(rand(1,5)*rad_multiplier,silent = 0)
 			if(prob(0.5*major_rad_multiplier))
@@ -271,9 +271,9 @@
 					to_chat(src, "<span class = 'blob'>You start glowing!</span>")
 					species.flags |= RAD_GLOW
 		if(rad_tick > RADDOSEFATAL)
-			if(prob(0.01*extreme_rad_multiplier))
+			if(prob(0.1*extreme_rad_multiplier))
 				//Ghoulification
-				if(prob(5*getBrainLoss())) //Ferality
+				if(prob(.5*getBrainLoss())) //Ferality, 50% to go feral at 100 brain damage
 					to_chat(src, "[pick("<span class = 'notice'>You feel yourself fading away.","<span class = 'danger'>You try to keep a hold of what you once were, but your mind shatters as you sink into the darkness.","<span class = 'notice'>You are no more. All that is left is a twisted husk of your former self, and it hungers.")]</span>")
 					var/mob/living/simple_animal/hostile/necro/zombie/to_spawn
 					if(species.flags & RAD_GLOW && prob(20*extreme_rad_multiplier))

--- a/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
@@ -164,7 +164,7 @@
 				if(organ_to_damage.len)
 					var/datum/organ/internal/victim = pick(organ_to_damage)
 					if(istype(victim, /datum/organ/internal/brain))
-						adjustBrainLoss(rand(1,4))
+						adjustBrainLoss(rand(1,3))
 					else
 						victim.take_damage(rand(1,5)*rad_multiplier,silent = 0)
 			if(prob(0.5*major_rad_multiplier))
@@ -183,7 +183,7 @@
 					var/datum/organ/external/O = pick(candidates)
 					O.mutate()
 					to_chat(src, "<span class = 'notice'>Something is not right with your [O.display_name].</span>")
-			if(prob(5*rad_multiplier))
+			if(prob(3*rad_multiplier))
 				//Minor clone damage
 				adjustCloneLoss(rand(1,5))
 				to_chat(src, "<span class='warning'>[pick("You can feel your body becoming weak!", \
@@ -273,7 +273,7 @@
 		if(rad_tick > RADDOSEFATAL)
 			if(prob(0.1*extreme_rad_multiplier))
 				//Ghoulification
-				if(prob(.5*getBrainLoss())) //Ferality, 50% to go feral at 100 brain damage
+				if(prob(0.5*getBrainLoss())) //Ferality, 50% to go feral at 100 brain damage
 					to_chat(src, "[pick("<span class = 'notice'>You feel yourself fading away.","<span class = 'danger'>You try to keep a hold of what you once were, but your mind shatters as you sink into the darkness.","<span class = 'notice'>You are no more. All that is left is a twisted husk of your former self, and it hungers.")]</span>")
 					var/mob/living/simple_animal/hostile/necro/zombie/to_spawn
 					if(species.flags & RAD_GLOW && prob(20*extreme_rad_multiplier))


### PR DESCRIPTION
Been experimenting with ghoulification lately. Even with tons of all the appropiate meds and constantly healing the damages with VV it was still pretty hard to achieve a normal ghoul, let alone a sentient one. The main problem is brain damage. There's only 2 brainmeds, and them combined can't outheal the ghoul's braindamage in any decent way, so the ghoul always comes very braindamaged and thus feral.
I get that the idea is that it should be something hard to achieve, but it's currently impossible to get a sentient ghoul (which would be the point when trying to ghoulify someone). This feels balanced enough to be hard to achieve but possible.
:cl:
 * tweak: Reduced the braindamage acquired at advanced rad poisoning. 
 * tweak: Slightly reduced the chance for clone damage at critical rad poisoning.
 * tweak: Increased the ghoulification chance when at fatal rad poisoning from 1 in 1000 to 1 in 100.
 * tweak: You now have a 50% chance (instead of 500%) to go feral when at 100 brain damage.
