### PR TITLE
Custom cyanide pill suicide

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -150,6 +150,15 @@
 	..()
 	reagents.add_reagent(CYANIDE, 50)
 
+/obj/item/weapon/reagent_containers/pill/suicide_act(mob/user)
+	to_chat(viewers(user), "<span class='danger'>[user] bites onto a [src.name] and swallows it! It looks like \he's trying to commit suicide.</span>")
+	var/mob/living/carbon/C = user
+	C.adjustToxLoss(500)//the maximum damage that a 50u cyanide pill could deal. Guarrantees an instant death.
+	C.adjustOxyLoss(500)
+	spawn(1)
+		qdel(src)
+	return(SUICIDE_ACT_TOXLOSS | SUICIDE_ACT_OXYLOSS)
+
 /obj/item/weapon/reagent_containers/pill/adminordrazine
 	name = "Adminordrazine pill"
 	desc = "It's magic. We don't have to explain it."

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -150,7 +150,7 @@
 	..()
 	reagents.add_reagent(CYANIDE, 50)
 
-/obj/item/weapon/reagent_containers/pill/suicide_act(mob/user)
+/obj/item/weapon/reagent_containers/pill/cyanide/suicide_act(mob/user)
 	to_chat(viewers(user), "<span class='danger'>[user] bites onto a [src.name] and swallows it! It looks like \he's trying to commit suicide.</span>")
 	var/mob/living/carbon/C = user
 	C.adjustToxLoss(500)//the maximum damage that a 50u cyanide pill could deal. Guarrantees an instant death.


### PR DESCRIPTION
:cl:
* tweak: Suiciding while holding one of the cyanide pills that Nuke Ops spawn with now instantly deals you all the damage that it would have done to you over time. That's 500 toxloss and 500 oxyloss, so basically an instant death without having to suicide AND succumb.