### PR TITLE
Fixes examining people wearing accessories indicating "it has nothing" when there are in fact accessories

### DIFF
--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -79,10 +79,7 @@
 
 /obj/item/clothing/description_accessories()
 	if(accessories.len)
-		. = list()
-		for(var/obj/item/clothing/accessory/accessory in accessories)
-			. += "[bicon(accessory)] \a [accessory]"
-		return " It has [counted_english_list(.)]."
+		return " It has [counted_english_list(accessories)]."
 
 /obj/item/clothing/accessory/pinksquare
 	name = "pink square"


### PR DESCRIPTION
Fixes #29483

:cl:
* bugfix: Fixes examining people wearing accessories indicating "it has nothing" when there are in fact accessories