### PR TITLE
Fix update_canmove() firing during TimeStop

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1533,6 +1533,9 @@ Use this proc preferably at the end of an equipment loadout
 
 //Updates canmove, lying and icons. Could perhaps do with a rename but I can't think of anything to describe it.
 /mob/proc/update_canmove()
+	if (timestopped)
+		return 0 // update_canmove() is called on all affected mobs right as the timestop ends
+
 	if (locked_to)
 		var/datum/locking_category/category = locked_to.get_lock_cat_for(src)
 		if (category && ~category.flags & LOCKED_CAN_LIE_AND_STAND)

--- a/code/modules/spells/aoe_turf/fall.dm
+++ b/code/modules/spells/aoe_turf/fall.dm
@@ -186,6 +186,9 @@ var/global/list/falltempoverlays = list()
 		falltempoverlays -= everything
 		everything.ignoreinvert = initial(everything.ignoreinvert)
 		everything.timestopped = 0
+		if (ismob(everything))
+			var/mob/M = everything
+			M.update_canmove()
 	affected.len = 0
 
 /mob/var/image/fallimage


### PR DESCRIPTION
Fixes #22171

:cl:
* bugfix: Mobs affected by timestop now have their movement capabilities updated right as the timestop ends, fixing issues related to status effects being acquired during timestop.