### PR TITLE
Tweak to the Sacid ghetto chem recipe.

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -236,8 +236,8 @@
 	name = "Sulphuric Acid"
 	id = SACID
 	result = SACID
-	required_reagents = list(SULFUR = 2, OXYGEN = 3, WATER = 2)
-	result_amount = 2
+	required_reagents = list(SULFUR = 1, OXYGEN = 3, WATER = 1)
+	result_amount = 1
 
 /datum/chemical_reaction/thermite
 	name = "Thermite"


### PR DESCRIPTION
The original formula was 2u Sulphur (S), 3u Oxygen (O) and 2u Water (H2O) to make 2u of Sacid. This means you have 2u Sulphur, 5u Oxygen and 4u Hydrogen. The IRL formula for Sulphuric Acid is H2SO4. You use 1 Sulphur, 2 Hydrogen and 4 Oxygen to make 1 H2SO4. This left you with 1 Sulphur, 2 Hydrogen and 1 Oxygen (or 1 Sulphur and 1 Water) unused. 
The current formula is 1u Sulphur, 3u Oxygen and 1u Water to make 1u Sacid. This won't affect chem dispensers or formulas that use Sulphuric Acid as reagent in any way. 

Before: 
10u Sulphur, 15u Oxygen, 10u Water = 10u Sulphuric Acid
After:
10u Sulphur, 30u Oxygen, 10u Water = 10u Sulphuric Acid
In practice, you will still need the same amount of sulphur and water to Ghetto Chem your Sulphuric Acid, but will need twice as much oxygen as before.

[tweak]
:cl:
 * tweak: Changed the Sacid recipe for proper stochiometry. In practice, you'll need double the oxygen to make any amount. This won't affect chem dispensers or any sacid-using recipe, only the ghetto-chem manufacture (or electrolysis) of Sacid.