### PR TITLE
Fixes enemy job check runtimes and threat checking

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -101,7 +101,7 @@
 	return TRUE
 
 // Returns TRUE if there is enough pop to execute this ruleset
-/datum/dynamic_ruleset/proc/check_enemy_jobs(var/dead_dont_count = FALSE)
+/datum/dynamic_ruleset/proc/check_enemy_jobs(var/dead_dont_count = FALSE, var/midround = FALSE)
 	var/enemies_count = 0
 	if (dead_dont_count)
 		for (var/mob/M in mode.living_players)
@@ -122,7 +122,11 @@
 
 	pop_and_enemies += enemies_count // Enemies count twice
 
-	var/threat = round(mode.threat_level/10)
+	var/threat = 0
+	if(midround)
+		threat = mode.midround_threat_level == 100 ? round(mode.midround_threat_level/10)+1 : 10
+	else
+		threat = mode.threat_level == 100 ? round(mode.threat_level/10)+1 : 10
 	if (enemies_count < required_enemies[threat] && !map.ignore_enemy_requirement(src))
 		message_admins("Dynamic Mode: There are not enough enemy jobs ready for [name]. ([enemies_count] out of [required_enemies[threat]])")
 		log_admin("Dynamic Mode: There are not enough enemy jobs ready for [name]. ([enemies_count] out of [required_enemies[threat]])")

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -28,7 +28,7 @@
 
 /datum/dynamic_ruleset/latejoin/ready(var/forced = 0)
 	if (!forced)
-		if(!check_enemy_jobs(TRUE))
+		if(!check_enemy_jobs(TRUE,TRUE))
 			return 0
 	return ..()
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -65,7 +65,7 @@
 // (see /datum/dynamic_ruleset/midround/autotraitor/ready(var/forced = 0) for example)
 /datum/dynamic_ruleset/midround/ready(var/forced = 0)
 	if (!forced)
-		if(!check_enemy_jobs(TRUE))
+		if(!check_enemy_jobs(TRUE,TRUE))
 			return 0
 	return 1
 


### PR DESCRIPTION
[gamemode][bugfix][consistency]
Closes #30096
This should fix cases where roundstart threat is low and midround high but antag spawns stay low, ideally. (since very low threat makes it call index 0, which is out of bounds. t-thanks BYOND)
:cl:
 * bugfix: Enemy jobs checks now make sure of midround threat and no longer go out of bounds in list checks.