### PR TITLE
Small Blob Attack Buff (mostly just reducing frustration)

### DIFF
--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -311,7 +311,7 @@
 		return
 
 	delayNextAttack(5)
-	OB.expand(T, 0) //Doesn't give source because we don't care about passive restraint
+	OB.expand(T, 0, src, manual = TRUE)
 
 
 /mob/camera/blob/verb/rally_spores_power()

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -382,7 +382,7 @@ var/list/blob_looks_player = list(//Options available to players
 		if(!source || !source.restrain_blob)
 			T.blob_act(0,src) //Don't attack the turf if our source mind has that turned off.
 		if (source && manual)
-			source.add_points(round(BLOBATTCOST/3))
+			source.add_points(round(2*BLOBATTCOST/3))
 		B.manual_remove = 1
 		B.Delete()
 

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -333,10 +333,12 @@ var/list/blob_looks_player = list(//Options available to players
 /obj/effect/blob/proc/run_action()
 	return 0
 
-/obj/effect/blob/proc/expand(var/turf/T = null, var/prob = 1, var/mob/camera/blob/source)
+/obj/effect/blob/proc/expand(var/turf/T = null, var/prob = 1, var/mob/camera/blob/source, var/manual = FALSE)
 	if(prob && !prob(health))
 		return
 	if(istype(T, /turf/space) && prob(75))
+		if (source && manual)
+			source.add_points(round(BLOBATTCOST/3))
 		return
 	if(!T)
 		var/list/dirs = cardinal.Copy()
@@ -379,6 +381,8 @@ var/list/blob_looks_player = list(//Options available to players
 	else //If we cant move in hit the turf
 		if(!source || !source.restrain_blob)
 			T.blob_act(0,src) //Don't attack the turf if our source mind has that turned off.
+		if (source && manual)
+			source.add_points(round(BLOBATTCOST/3))
 		B.manual_remove = 1
 		B.Delete()
 

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -338,7 +338,7 @@ var/list/blob_looks_player = list(//Options available to players
 		return
 	if(istype(T, /turf/space) && prob(75))
 		if (source && manual)
-			source.add_points(round(BLOBATTCOST/3))
+			source.add_points(round(2*BLOBATTCOST/3))
 		return
 	if(!T)
 		var/list/dirs = cardinal.Copy()


### PR DESCRIPTION
:cl:
* tweak: When manually expanding their blob, Overminds will spend only 5 points instead of 15 if the expansion didn't lead to a new blob getting created. This includes cases such as failing to expand over space, or trying and failing (often repeatedly) to break a wall/structure. (You still need 15 points to expand, but 10 points get reimbursed in case of failure)