### PR TITLE
Fixes Timestop turning VirtualHearers dense, and making their associated mobs unable to pull dense objects

### DIFF
--- a/code/modules/mob/hearing/virtualhearer.dm
+++ b/code/modules/mob/hearing/virtualhearer.dm
@@ -68,6 +68,9 @@ var/list/stationary_hearers = list(	/obj/item/device/radio/intercom,
 /mob/virtualhearer/blob_act()
 	return
 
+/mob/virtualhearer/update_canmove()
+	return 1 // the default canmove value of virtualhearers
+
 /mob/proc/change_sight(adding, removing, copying)
 	var/oldsight = sight
 	if(copying)


### PR DESCRIPTION
Fixes #30114

:cl:
* bugfix; Fixed Timestop turning the invisible VirtualHearers dense, and thus making their associated mobs unable to pull dense objects, or causing "invisible walls" to appear over some objects such as tape recorders or AI holopads. (gurfan)