### PR TITLE
Glasses with ghoul blood are now "piccolyn" instead of "tomato juice".

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1627,6 +1627,7 @@ var/proccalls = 1
 #define MUSHROOM_BLOOD	"#D3D3D3"
 #define INSECT_BLOOD	"#EBECE6"
 #define PALE_BLOOD		"#272727"//Seek Paleblood to transcend the hunt.
+#define GHOUL_BLOOD		"#7FFF00"
 
 //Return values for /obj/machinery/proc/npc_tamper_act(mob/living/L)
 #define NPC_TAMPER_ACT_FORGET 1 //Don't try to tamper with this again

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1050,7 +1050,7 @@ var/list/has_died_as_golem = list()
 	brute_mod = 0.8
 	move_speed_multiplier = 2
 
-	blood_color = "#7FFF00"
+	blood_color = GHOUL_BLOOD
 
 	primitive = /mob/living/carbon/monkey //Just to keep them SoC friendly.
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -409,6 +409,8 @@
 			totally_not_blood = "Milk"
 		if (PALE_BLOOD)//#272727
 			totally_not_blood = "Carbon"
+		if (GHOUL_BLOOD)//#7FFF00
+			totally_not_blood = "Lime Juice"
 
 	glass_name = "glass of [totally_not_blood]"
 	glass_desc = "Are you sure this is [totally_not_blood]?"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -410,7 +410,7 @@
 		if (PALE_BLOOD)//#272727
 			totally_not_blood = "Carbon"
 		if (GHOUL_BLOOD)//#7FFF00
-			totally_not_blood = "Lime Juice"
+			totally_not_blood = "Piccolyn"
 
 	glass_name = "glass of [totally_not_blood]"
 	glass_desc = "Are you sure this is [totally_not_blood]?"


### PR DESCRIPTION
Closes #30119
[consistency]

:cl:
 * rscadd: Glasses and mugs with ghoul blood now say they're full of Piccolyn instead of tomato juice.