### PR TITLE
Telecomms Traffic Console Explicitation on Scan Failure

### DIFF
--- a/code/game/machinery/telecomms/traffic_control.dm
+++ b/code/game/machinery/telecomms/traffic_control.dm
@@ -224,6 +224,7 @@
 
 					if(!servers.len)
 						temp = "<font color = #D70B00>- FAILED: UNABLE TO LOCATE SERVERS IN \[[network]\] -</font color>"
+						temp += "<br><font color = #D70B00>- DOUBLE-CHECK NETWORK ID OR REDUCE RANGE FROM SERVERS (25 TILES AT MOST) -</font color>"
 					else
 						temp = "<font color = #336699>- [servers.len] SERVERS PROBED & BUFFERED -</font color>"
 


### PR DESCRIPTION
Fixes #30098

:cl:
* rscadd: When the Telecomms Traffic Console fails to find a network's servers you now get an explicit message telling you to either double check the network ID or the range from the servers. (west3436)