### PR TITLE
Adjust growth dish offset when coming out of a centrifuge

### DIFF
--- a/code/modules/virus2/centrifuge.dm
+++ b/code/modules/virus2/centrifuge.dm
@@ -542,6 +542,7 @@
 	visible_message("\The [src] prints a growth dish.")
 	spawn(10)
 		var/obj/item/weapon/virusdish/dish = new/obj/item/weapon/virusdish(src.loc)
+		dish.pixel_y = -7
 		dish.contained_virus = D.getcopy()
 		dish.contained_virus.infectionchance = dish.contained_virus.infectionchance_base
 		dish.update_icon()


### PR DESCRIPTION
Fixes #30087

:cl:
* tweak: Growth Dishes printed out of an Isolation Centrifuge now spawn offset south a bit so the centrifuge's light overlays don't hinder clicking on it. (Killette2)