### PR TITLE
Fixes Vox Medical Doctors spawning with a duplicate uniform in their backpack instead of their job-specific labcoat. 

### DIFF
--- a/code/datums/outfit/medical.dm
+++ b/code/datums/outfit/medical.dm
@@ -135,14 +135,14 @@
 
 	race_items_to_collect = list(
 		/datum/species/vox/ = list(
-			"Emergency Physician" = list(/obj/item/clothing/under/rank/medical),
-			"Surgeon" =  list(/obj/item/clothing/under/rank/medical/blue),
-			"Medical Doctor" = list(/obj/item/clothing/under/rank/medical),
+			"Emergency Physician" = /obj/item/clothing/suit/storage/fr_jacket,
+			"Surgeon" =  /obj/item/clothing/suit/storage/labcoat,
+			"Medical Doctor" =  /obj/item/clothing/suit/storage/labcoat,
 		),
 		/datum/species/plasmaman/ = list(
-			"Emergency Physician" = list(/obj/item/clothing/under/rank/medical),
-			"Surgeon" =  list(/obj/item/clothing/under/rank/medical/blue),
-			"Medical Doctor" = list(/obj/item/clothing/under/rank/medical),
+			"Emergency Physician" = /obj/item/clothing/suit/storage/fr_jacket,
+			"Surgeon" =  /obj/item/clothing/suit/storage/labcoat,
+			"Medical Doctor" =  /obj/item/clothing/suit/storage/labcoat,
 		)
 	)
 


### PR DESCRIPTION
Fixes #30123 

:cl:
* bugfix: Fixed Vox Medical Doctors spawning with a duplicate uniform in their backpack instead of their job-specific labcoat. (loppu)