### PR TITLE
Fixes reagent check saycode runtime

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -474,10 +474,11 @@ var/list/headset_modes = list(
 	if(stuttering || (undergoing_hypothermia() == MODERATE_HYPOTHERMIA && prob(25)) )
 		speech.message = stutter(speech.message)
 
-	if(reagents.has_any_reagents(HYPERZINES))
+	if(reagents && reagents.has_any_reagents(HYPERZINES))
 		speech.message = replacetext(speech.message," ","") // motor mouth
 		speech.message = replacetext(speech.message,",","") // motor mouth
 		speech.message = replacetext(speech.message,";","") // motor mouth
+		speech.message = replacetext(speech.message,"-","") // motor mouth
 
 /mob/living/proc/get_speech_flags(var/message_mode)
 	switch(message_mode)


### PR DESCRIPTION
[runtime]
> Runtime in say.dm, line 477: Cannot execute null.has any reagents().

:cl:
 * bugfix: Fixes saycode checking for reagents in mobs with none.