### PR TITLE
makes the advanced rigsuit rad absorber printable

### DIFF
--- a/code/modules/research/designs/boards/misc.dm
+++ b/code/modules/research/designs/boards/misc.dm
@@ -156,7 +156,7 @@
 /datum/design/rigsuit_radshield_adv
 	name = "Circut Design (Rigsuit high capacity radiation absorption device)"
 	desc = "An improved version of the R.A.D. featuring a higher capacity. When installed and activated, the suit protects the wearer from incoming radiation until its collectors are full."
-	id = "rigsuit_radshield"
+	id = "rigsuit_radshield_adv"
 	req_tech = list(Tc_PROGRAMMING = 4, Tc_MATERIALS = 6, Tc_POWERSTORAGE = 4, Tc_PLASMATECH = 3)
 	build_type = IMPRINTER
 	category = "Misc"


### PR DESCRIPTION
turns out the basic R.A.D. and the advanced R.A.D. shared a design ID, so the first one overwrote the second, or some shit
:cl:
 * rscadd: The advanced radiation absorption device for hardsuits is now printable, as it was probably intended to be.