### PR TITLE
Reverts thehyperzinemotormouththing

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -474,11 +474,6 @@ var/list/headset_modes = list(
 	if(stuttering || (undergoing_hypothermia() == MODERATE_HYPOTHERMIA && prob(25)) )
 		speech.message = stutter(speech.message)
 
-	if(reagents && reagents.has_any_reagents(HYPERZINES))
-		speech.message = replacetext(speech.message," ","") // motor mouth
-		speech.message = replacetext(speech.message,",","") // motor mouth
-		speech.message = replacetext(speech.message,";","") // motor mouth
-		speech.message = replacetext(speech.message,"-","") // motor mouth
 
 /mob/living/proc/get_speech_flags(var/message_mode)
 	switch(message_mode)


### PR DESCRIPTION
It's dumb and annoying, especially when there's a zine disease and everyoneistalkinglikethisoncommon. I can't do a normal revert since some sneakycoder removed the ability to speak with dashes after the PR was merged.

The PR is #30001 

 * rscdel: Hyperzine no longer removes spaces from sentences.
