### PR TITLE
Adds a period to the vending machines' "You hear a whirr" and "The [src.name] whirrs as it vends" messages.

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1069,7 +1069,7 @@ var/global/num_vending_terminals = 1
 		flick(src.icon_vend,src)
 	R.amount--
 	src.updateUsrDialog()
-	visible_message("\The [src.name] whirrs as it vends", "You hear a whirr")
+	visible_message("\The [src.name] whirrs as it vends.", "You hear a whirr.")
 	spawn(vend_delay)
 		if(!R.custom)
 			new R.product_path(get_turf(src))


### PR DESCRIPTION
It's a small thing but it bothered me.
[grammar]
:cl:
 * spellcheck: Adds the missing period to the vending machines' vending messages. The "You hear a whirr" and "The [src.name] whirrs as it vends" ones.