### PR TITLE
Deadminning updates

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -382,6 +382,29 @@ var/list/admin_verbs_mod = list(
 		/client/proc/readmin,
 		/proc/generateMiniMaps,
 		/client/proc/maprender
+		/client/proc/cmd_admin_rejuvenate
+		/datum/admins/proc/show_role_panel
+		/client/proc/print_jobban_old
+		/client/proc/print_jobban_old_filter
+		/client/proc/forceEvent
+		///client/proc/break_all_air_groups
+		///client/proc/regroup_all_air_groups
+		///client/proc/kill_pipe_processing
+		///client/proc/kill_air_processing
+		///client/proc/disable_communication
+		///client/proc/disable_movement
+		/client/proc/Zone_Info
+		/client/proc/Test_ZAS_Connection
+		/client/proc/SDQL2_query
+		/client/proc/check_sim_unsim
+		/client/proc/start_line_profiling
+		/client/proc/stop_line_profiling
+		/client/proc/show_line_profiling
+		/client/proc/check_wires
+		/client/proc/check_pipes
+		#if UNIT_TESTS_ENABLED
+		/client/proc/unit_test_panel
+		#endif
 		)
 	if (isobserver(mob))
 		mob.verbs -= /mob/dead/observer/verb/toggle_antagHUD
@@ -778,6 +801,18 @@ var/list/admin_verbs_mod = list(
 			return
 		log_admin("[src] deadminned themself.")
 		message_admins("[src] deadminned themself.")
+		if (ticker && ticker.current_state == GAME_STATE_PLAYING) //Only report this stuff if we are currently playing.
+			var/admins_number = admins.len
+			var/admin_number_afk = 0
+			for(var/client/X in admins)
+				if(X.is_afk())
+					admin_number_afk++
+
+			var/available_admins = admins_number - admin_number_afk
+
+			if(available_admins == 0) // Apparently the admin logging out is no longer an admin at this point, so we have to check this towards 0 and not towards 1. Awell.
+					send2adminirc("[key_name(src, showantag = FALSE)] deadminned themself - no more non-AFK admins online. - [admin_number_afk] AFK.")
+					send2admindiscord("[key_name(src, showantag = FALSE)] deadminned themself. **No more non-AFK admins online.** - **[admin_number_afk]** AFK", TRUE)
 		deadmin()
 		verbs += /client/proc/readmin
 		deadmins += ckey

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -381,30 +381,30 @@ var/list/admin_verbs_mod = list(
 		/client/proc/cmd_admin_areatest,
 		/client/proc/readmin,
 		/proc/generateMiniMaps,
-		/client/proc/maprender
-		/client/proc/cmd_admin_rejuvenate
-		/datum/admins/proc/show_role_panel
-		/client/proc/print_jobban_old
-		/client/proc/print_jobban_old_filter
-		/client/proc/forceEvent
-		///client/proc/break_all_air_groups
-		///client/proc/regroup_all_air_groups
-		///client/proc/kill_pipe_processing
-		///client/proc/kill_air_processing
-		///client/proc/disable_communication
-		///client/proc/disable_movement
-		/client/proc/Zone_Info
-		/client/proc/Test_ZAS_Connection
-		/client/proc/SDQL2_query
-		/client/proc/check_sim_unsim
-		/client/proc/start_line_profiling
-		/client/proc/stop_line_profiling
-		/client/proc/show_line_profiling
-		/client/proc/check_wires
-		/client/proc/check_pipes
+		/client/proc/maprender,
+		/client/proc/cmd_admin_rejuvenate,
+		/datum/admins/proc/show_role_panel,
+		/client/proc/print_jobban_old,
+		/client/proc/print_jobban_old_filter,
+		/client/proc/forceEvent,
+		///client/proc/break_all_air_groups,
+		///client/proc/regroup_all_air_groups,
+		///client/proc/kill_pipe_processing,
+		///client/proc/kill_air_processing,
+		///client/proc/disable_communication,
+		///client/proc/disable_movement,
+		/client/proc/Zone_Info,
+		/client/proc/Test_ZAS_Connection,
+		/client/proc/SDQL2_query,
+		/client/proc/check_sim_unsim,
+		/client/proc/start_line_profiling,
+		/client/proc/stop_line_profiling,
+		/client/proc/show_line_profiling,
+		/client/proc/check_wires,
 		#if UNIT_TESTS_ENABLED
-		/client/proc/unit_test_panel
+		/client/proc/unit_test_panel,
 		#endif
+		/client/proc/check_pipes
 		)
 	if (isobserver(mob))
 		mob.verbs -= /mob/dead/observer/verb/toggle_antagHUD

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -811,8 +811,8 @@ var/list/admin_verbs_mod = list(
 			var/available_admins = admins_number - admin_number_afk
 
 			if(available_admins == 0) // Apparently the admin logging out is no longer an admin at this point, so we have to check this towards 0 and not towards 1. Awell.
-					send2adminirc("[key_name(src, showantag = FALSE)] deadminned themself - no more non-AFK admins online. - [admin_number_afk] AFK.")
-					send2admindiscord("[key_name(src, showantag = FALSE)] deadminned themself. **No more non-AFK admins online.** - **[admin_number_afk]** AFK", TRUE)
+				send2adminirc("[key_name(src, showantag = FALSE)] deadminned themself - no more non-AFK admins online. - [admin_number_afk] AFK.")
+				send2admindiscord("[key_name(src, showantag = FALSE)] deadminned themself. **No more non-AFK admins online.** - **[admin_number_afk]** AFK", TRUE)
 		deadmin()
 		verbs += /client/proc/readmin
 		deadmins += ckey

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -53,7 +53,7 @@
 
 			message_admins("Admin logout: [key_name(src)]")
 			if(available_admins == 0) // Apparently the admin logging out is no longer an admin at this point, so we have to check this towards 0 and not towards 1. Awell.
-				send2adminirc("[key_name(src, showantag = FALSE)] logged out - no more admins online.")
+				send2adminirc("[key_name(src, showantag = FALSE)] logged out - no more non-AFK admins online. - [admin_number_afk] AFK.")
 				send2admindiscord("[key_name(src, showantag = FALSE)] logged out. **No more non-AFK admins online.** - **[admin_number_afk]** AFK", TRUE)
 
 	lazy_invoke_event(/lazy_event/on_logout, list("user" = src))

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -42,6 +42,7 @@
 		client.media.stop_music()
 
 	if(admin_datums[src.ckey])
+		message_admins("Admin logout: [key_name(src)]")
 		if (ticker && ticker.current_state == GAME_STATE_PLAYING) //Only report this stuff if we are currently playing.
 			var/admins_number = admins.len
 			var/admin_number_afk = 0
@@ -51,7 +52,6 @@
 
 			var/available_admins = admins_number - admin_number_afk
 
-			message_admins("Admin logout: [key_name(src)]")
 			if(available_admins == 0) // Apparently the admin logging out is no longer an admin at this point, so we have to check this towards 0 and not towards 1. Awell.
 				send2adminirc("[key_name(src, showantag = FALSE)] logged out - no more non-AFK admins online. - [admin_number_afk] AFK.")
 				send2admindiscord("[key_name(src, showantag = FALSE)] logged out. **No more non-AFK admins online.** - **[admin_number_afk]** AFK", TRUE)


### PR DESCRIPTION
[administration][bugfix]
:cl:
 * rscadd: An external message is now sent to admin chat clients when an admin deadmins with 0 other non-afk admins online.
 * bugfix: All debug verbs are now hidden on deadminning.