### PR TITLE
Adds candy machine and cereal maker circuits.

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -300,7 +300,9 @@ to destroy them and players will be able to make replacements.
 	"fishtank filter"=/obj/item/weapon/circuitboard/fishtank,
 	"large fishtank filter"=/obj/item/weapon/circuitboard/fishwall,
 	"data"=/obj/item/weapon/circuitboard/disk_duplicator,
-	"Ez-bake oven"=/obj/item/weapon/circuitboard/cooking,)
+	"Ez-bake oven"=/obj/item/weapon/circuitboard/cooking,
+	"candy machine"=/obj/item/weapon/circuitboard/cooking/candy,
+	"cereal maker"=/obj/item/weapon/circuitboard/cooking/cerealmaker)
 	var/soldering = 0 //Busy check
 
 /obj/item/weapon/circuitboard/blank/New()
@@ -1385,7 +1387,6 @@ obj/item/weapon/circuitboard/rdserver
 	build_path = /obj/machinery/anomaly/hyperspectral
 
 /obj/item/weapon/circuitboard/confectionator
-
 	name = "circuit board (confectionator)"
 	desc = "A circuit board used to run a kitchen appliance."
 	board_type = MACHINE
@@ -1416,6 +1417,26 @@ obj/item/weapon/circuitboard/rdserver
 						/obj/item/weapon/stock_parts/capacitor = 2,
 						/obj/item/weapon/stock_parts/micro_laser = 3,
 						/obj/item/weapon/stock_parts/console_screen = 1)
+						
+/obj/item/weapon/circuitboard/cooking/candy
+	name = "circuit board (candy machine)"
+	desc = "A circuit board for a candy machine."
+	board_type = MACHINE
+	build_path = /obj/machinery/cooking/candy
+	origin_tech = Tc_ENGINEERING + "=1;" + Tc_POWERSTORAGE + "=2"
+	req_components = list(
+						/obj/item/weapon/stock_parts/manipulator = 3,
+						/obj/item/weapon/stock_parts/console_screen = 1) //boring recipe I know, but they're very simple machines
+						
+/obj/item/weapon/circuitboard/cooking/cerealmaker
+	name = "circuit board (cereal maker)"
+	desc = "A circuit board for a cereal maker."
+	board_type = MACHINE
+	build_path = /obj/machinery/cooking/cerealmaker
+	origin_tech = Tc_ENGINEERING + "=1;" + Tc_POWERSTORAGE + "=2"
+	req_components = list(
+						/obj/item/weapon/stock_parts/manipulator = 3,
+						/obj/item/weapon/stock_parts/console_screen = 1) //boring recipe I know, but they're very simple machines
 
 /obj/item/weapon/circuitboard/medal_printer
 	name = "Circuit board (Medal Printer)"

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -114,6 +114,12 @@ var/global/ingredientLimit = 10
 	if(cooks_in_reagents)
 		return TRUE
 
+/obj/machinery/cooking/RefreshParts()
+	var/T = 0
+	for(var/obj/item/weapon/stock_parts/micro_laser/M in component_parts)
+		T += M.rating-1
+	cookTime = initial(cookTime)-(25 * T) //150 ticks minus 25 ticks per every laser tier, T4s make it 75 ticks.
+
 // Interactions ////////////////////////////////////////////////
 
 /obj/machinery/cooking/examine(mob/user)
@@ -299,7 +305,13 @@ var/global/ingredientLimit = 10
 	icon_state = "mixer_off"
 	icon_state_on = "mixer_on"
 	cookSound = 'sound/machines/juicer.ogg'
+	machine_flags = WRENCHMOVE | FIXED2WORK | SCREWTOGGLE | CROWDESTROY
 
+/obj/machinery/cooking/candy/RefreshParts()						
+	T = 0
+	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
+		T += M.rating-1
+	cookTime = initial(cookTime)-(10 * T) //150 ticks minus 10 ticks per every tier level, T4s make it 60 ticks.
 
 /obj/machinery/cooking/candy/validateIngredient(var/obj/item/I)
 	. = ..()
@@ -346,6 +358,13 @@ var/global/ingredientLimit = 10
 	icon_state = "cereal_off"
 	icon_state_on = "cereal_on"
 	foodChoices = null
+	machine_flags = WRENCHMOVE | FIXED2WORK | SCREWTOGGLE | CROWDESTROY
+	
+/obj/machinery/cooking/cerealmaker/RefreshParts()
+	T = 0
+	for(var/obj/item/weapon/stock_parts/micro_laser/M in component_parts)
+		T += M.rating-1
+	cookTime = initial(cookTime)-(10 * T) //150 ticks minus 10 ticks per every tier level, T4s make it 60 ticks.
 
 /obj/machinery/cooking/cerealmaker/validateIngredient(var/obj/item/I)
 	. = ..()

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -308,7 +308,7 @@ var/global/ingredientLimit = 10
 	machine_flags = WRENCHMOVE | FIXED2WORK | SCREWTOGGLE | CROWDESTROY
 
 /obj/machinery/cooking/candy/RefreshParts()						
-	T = 0
+	var/T = 0
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
 		T += M.rating-1
 	cookTime = initial(cookTime)-(10 * T) //150 ticks minus 10 ticks per every tier level, T4s make it 60 ticks.
@@ -361,7 +361,7 @@ var/global/ingredientLimit = 10
 	machine_flags = WRENCHMOVE | FIXED2WORK | SCREWTOGGLE | CROWDESTROY
 	
 /obj/machinery/cooking/cerealmaker/RefreshParts()
-	T = 0
+	var/T = 0
 	for(var/obj/item/weapon/stock_parts/micro_laser/M in component_parts)
 		T += M.rating-1
 	cookTime = initial(cookTime)-(10 * T) //150 ticks minus 10 ticks per every tier level, T4s make it 60 ticks.


### PR DESCRIPTION
You can now use a solder to make your very own candy machine or cereal maker circuits. Also adds an upgrade effect to them.

:cl:
 * rscadd: You can make candy machine circuits with a blank circuitboard and a fueled solder.
 * rscadd: You can also make cereal maker circuits with a blank circuitboard and a fueled solder.
 * rscadd: Upgrading the EZ-bake oven, candy maker or cereal maker machines with better parts will make them cook faster.
