### PR TITLE
Xenobiology QoL tweaks

### DIFF
--- a/code/game/centcomm_orders/orders_science.dm
+++ b/code/game/centcomm_orders/orders_science.dm
@@ -333,6 +333,10 @@
 //High-tier slime cores
 /datum/centcomm_order/department/science/pyrite/New()
 	..()
+	request_consoles_to_notify = list(
+		"Research Director's Desk",
+		"Xenobiology",
+		)
 	must_be_in_crate = 0
 	requested = list(
 		/obj/item/slime_extract/pyrite = rand(1,3)
@@ -341,6 +345,10 @@
 
 /datum/centcomm_order/department/science/cerulean/New()
 	..()
+	request_consoles_to_notify = list(
+		"Research Director's Desk",
+		"Xenobiology",
+		)
 	must_be_in_crate = 0
 	requested = list(
 		/obj/item/slime_extract/cerulean = rand(1,3)
@@ -349,6 +357,10 @@
 
 /datum/centcomm_order/department/science/sepia/New()
 	..()
+	request_consoles_to_notify = list(
+		"Research Director's Desk",
+		"Xenobiology",
+		)
 	must_be_in_crate = 0
 	requested = list(
 		/obj/item/slime_extract/sepia = rand(1,3)
@@ -357,6 +369,10 @@
 
 /datum/centcomm_order/department/science/bluespace/New()
 	..()
+	request_consoles_to_notify = list(
+		"Research Director's Desk",
+		"Xenobiology",
+		)
 	must_be_in_crate = 0
 	requested = list(
 		/obj/item/slime_extract/bluespace = rand(1,3)
@@ -365,6 +381,10 @@
 
 /datum/centcomm_order/department/science/adamantine/New()
 	..()
+	request_consoles_to_notify = list(
+		"Research Director's Desk",
+		"Xenobiology",
+		)
 	must_be_in_crate = 0
 	requested = list(
 		/obj/item/slime_extract/adamantine = rand(1,3)
@@ -373,6 +393,10 @@
 
 /datum/centcomm_order/department/science/oil/New()
 	..()
+	request_consoles_to_notify = list(
+		"Research Director's Desk",
+		"Xenobiology",
+		)
 	must_be_in_crate = 0
 	requested = list(
 		/obj/item/slime_extract/oil = rand(1,3)
@@ -381,6 +405,10 @@
 
 /datum/centcomm_order/department/science/black/New()
 	..()
+	request_consoles_to_notify = list(
+		"Research Director's Desk",
+		"Xenobiology",
+		)
 	must_be_in_crate = 0
 	requested = list(
 		/obj/item/slime_extract/black = rand(1,3)
@@ -389,6 +417,10 @@
 
 /datum/centcomm_order/department/science/lightpink/New()
 	..()
+	request_consoles_to_notify = list(
+		"Research Director's Desk",
+		"Xenobiology",
+		)
 	must_be_in_crate = 0
 	requested = list(
 		/obj/item/slime_extract/lightpink = rand(1,3)

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -234,7 +234,16 @@
 	name = "\improper Slime Extract Storage"
 	desc = "A refrigerated storage unit for slime extracts."
 
-	accepted_types = list(/obj/item/slime_extract)
+	accepted_types = list(
+		/obj/item/slime_extract,
+		/obj/item/weapon/slimepotion,
+		/obj/item/weapon/slimepotion2,
+		/obj/item/weapon/slimesteroid,
+		/obj/item/weapon/slimesteroid2,
+		/obj/item/weapon/slimenutrient,
+		/obj/item/weapon/slimedupe,
+		/obj/item/weapon/slimeres
+	)
 
 /obj/machinery/smartfridge/extract/New()
 	. = ..()

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -518,7 +518,10 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 	if(!proximity)
 		return
 	if(target.slime_act(primarytype,user))
-		qdel(src)
+		if (Uses > 0)
+			Uses -= 1
+		if(Uses == 0)
+			qdel(src)
 
 /obj/item/slime_extract/New()
 	..()

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -642,36 +642,36 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 	w_class = W_CLASS_TINY
 
 /obj/item/weapon/slimepotion/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
-		if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
-			to_chat(user, "<span class='warning'>The potion only works on baby slimes!</span>")
-			return ..()
-		if(istype(M, /mob/living/carbon/slime/adult)) //Can't tame adults
-			to_chat(user, "<span class='warning'>Only baby slimes can be tamed!</span>")
-			return..()
-		if(M.stat)
-			to_chat(user, "<span class='warning'>The [M] is dead!</span>")
-			return..()
-		var/mob/living/simple_animal/slime/pet = new /mob/living/simple_animal/slime(M.loc)
-		pet.icon_state = "[M.colour] baby slime"
-		pet.icon_living = "[M.colour] baby slime"
-		pet.icon_dead = "[M.colour] baby slime dead"
-		pet.colour = "[M.colour]"
-		to_chat(user, "You feed \the [M] the potion, removing its powers and calming it.")
-		if(M.mind)
-			M.mind.transfer_to(pet)
-		qdel (M)
-		M = null
-		var/newname = ""
-		if(pet.client)//leaving the player-controlled slimes the ability to choose their new name
-			newname = copytext(sanitize(input(pet, "You have been fed a docility potion, what shall we call you?", "Give yourself a new name", "pet slime") as null|text),1,MAX_NAME_LEN)
-		else
-			newname = copytext(sanitize(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text),1,MAX_NAME_LEN)
+	if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
+		to_chat(user, "<span class='warning'>The potion only works on baby slimes!</span>")
+		return ..()
+	if(istype(M, /mob/living/carbon/slime/adult)) //Can't tame adults
+		to_chat(user, "<span class='warning'>Only baby slimes can be tamed!</span>")
+		return..()
+	if(M.stat)
+		to_chat(user, "<span class='warning'>The [M] is dead!</span>")
+		return..()
+	var/mob/living/simple_animal/slime/pet = new /mob/living/simple_animal/slime(M.loc)
+	pet.icon_state = "[M.colour] baby slime"
+	pet.icon_living = "[M.colour] baby slime"
+	pet.icon_dead = "[M.colour] baby slime dead"
+	pet.colour = "[M.colour]"
+	to_chat(user, "You feed \the [M] the potion, removing its powers and calming it.")
+	if(M.mind)
+		M.mind.transfer_to(pet)
+	qdel (M)
+	M = null
+	var/newname = ""
+	if(pet.client)//leaving the player-controlled slimes the ability to choose their new name
+		newname = copytext(sanitize(input(pet, "You have been fed a docility potion, what shall we call you?", "Give yourself a new name", "pet slime") as null|text),1,MAX_NAME_LEN)
+	else
+		newname = copytext(sanitize(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text),1,MAX_NAME_LEN)
 
-		if (!newname)
-			newname = "pet slime"
-		pet.name = newname
-		pet.real_name = newname
-		qdel (src)
+	if (!newname)
+		newname = "pet slime"
+	pet.name = newname
+	pet.real_name = newname
+	qdel (src)
 
 /obj/item/weapon/slimepotion2
 	name = "advanced docility potion"
@@ -681,33 +681,33 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 	w_class = W_CLASS_TINY
 
 /obj/item/weapon/slimepotion2/attack(mob/living/carbon/slime/adult/M as mob, mob/user as mob)
-		if(!istype(M, /mob/living/carbon/slime/adult))//If target is not a slime.
-			to_chat(user, "<span class='warning'>The potion only works on adult slimes!</span>")
-			return ..()
-		if(M.stat)
-			to_chat(user, "<span class='warning'>The [M] is dead!</span>")
-			return..()
-		var/mob/living/simple_animal/slime/adult/pet = new /mob/living/simple_animal/slime/adult(M.loc)
-		pet.icon_state = "[M.colour] adult slime"
-		pet.icon_living = "[M.colour] adult slime"
-		pet.icon_dead = "[M.colour] baby slime dead"
-		pet.colour = "[M.colour]"
-		to_chat(user, "You feed \the [M] the potion, removing its powers and calming it.")
-		if(M.mind)
-			M.mind.transfer_to(pet)
-		qdel (M)
-		M = null
-		var/newname = ""
-		if(pet.client)//leaving the player-controlled slimes the ability to choose their new name
-			newname = copytext(sanitize(input(pet, "You have been fed an advanced docility potion, what shall we call you?", "Give yourself a new name", "pet slime") as null|text),1,MAX_NAME_LEN)
-		else
-			newname = copytext(sanitize(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text),1,MAX_NAME_LEN)
+	if(!istype(M, /mob/living/carbon/slime/adult))//If target is not a slime.
+		to_chat(user, "<span class='warning'>The potion only works on adult slimes!</span>")
+		return ..()
+	if(M.stat)
+		to_chat(user, "<span class='warning'>The [M] is dead!</span>")
+		return..()
+	var/mob/living/simple_animal/slime/adult/pet = new /mob/living/simple_animal/slime/adult(M.loc)
+	pet.icon_state = "[M.colour] adult slime"
+	pet.icon_living = "[M.colour] adult slime"
+	pet.icon_dead = "[M.colour] baby slime dead"
+	pet.colour = "[M.colour]"
+	to_chat(user, "You feed \the [M] the potion, removing its powers and calming it.")
+	if(M.mind)
+		M.mind.transfer_to(pet)
+	qdel (M)
+	M = null
+	var/newname = ""
+	if(pet.client)//leaving the player-controlled slimes the ability to choose their new name
+		newname = copytext(sanitize(input(pet, "You have been fed an advanced docility potion, what shall we call you?", "Give yourself a new name", "pet slime") as null|text),1,MAX_NAME_LEN)
+	else
+		newname = copytext(sanitize(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text),1,MAX_NAME_LEN)
 
-		if (!newname)
-			newname = "pet slime"
-		pet.name = newname
-		pet.real_name = newname
-		qdel (src)
+	if (!newname)
+		newname = "pet slime"
+	pet.name = newname
+	pet.real_name = newname
+	qdel (src)
 
 /obj/item/weapon/slimesteroid
 	name = "slime steroid"
@@ -717,22 +717,22 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 	w_class = W_CLASS_TINY
 
 /obj/item/weapon/slimesteroid/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
-		if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
-			to_chat(user, "<span class='warning'>The steroid only works on baby slimes!</span>")
-			return ..()
-		if(istype(M, /mob/living/carbon/slime/adult)) //Can't tame adults
-			to_chat(user, "<span class='warning'>Only baby slimes can use the steroid!</span>")
-			return..()
-		if(M.stat)
-			to_chat(user, "<span class='warning'>The [M] is dead!</span>")
-			return..()
-		if(M.cores == 3)
-			to_chat(user, "<span class='warning'>The [M] already has the maximum amount of extract!</span>")
-			return..()
+	if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
+		to_chat(user, "<span class='warning'>The steroid only works on baby slimes!</span>")
+		return ..()
+	if(istype(M, /mob/living/carbon/slime/adult)) //Can't tame adults
+		to_chat(user, "<span class='warning'>Only baby slimes can use the steroid!</span>")
+		return..()
+	if(M.stat)
+		to_chat(user, "<span class='warning'>The [M] is dead!</span>")
+		return..()
+	if(M.cores == 3)
+		to_chat(user, "<span class='warning'>The [M] already has the maximum amount of extract!</span>")
+		return..()
 
-		to_chat(user, "You feed \the [M] the steroid. It now has triple the amount of extract.")
-		M.cores = 3
-		qdel (src)
+	to_chat(user, "You feed \the [M] the steroid. It now has triple the amount of extract.")
+	M.cores = 3
+	qdel (src)
 
 
 /obj/item/weapon/slimenutrient

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -498,7 +498,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 		if(enhanced == 1)
 			to_chat(user, "<span class='warning'>This extract has already been enhanced!</span>")
 			return ..()
-		to_chat(user, "You apply the enhancer. It now has triple the amount of uses.")
+		to_chat(user, "You apply the enhancer to \the [src]. It now has triple the amount of uses.")
 		Uses = 3
 		enhanced = 1
 		qdel(O)
@@ -508,7 +508,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 		if(Uses == 0)
 			to_chat(user, "<span class='warning'>The solution doesn't work on used extracts!</span>")
 			return ..()
-		to_chat(user, "You splash the Slime Resurrection Serum onto the extract causing it to quiver and come to life.")
+		to_chat(user, "You splash the Slime Resurrection Serum onto \the [src] causing it to quiver and come to life.")
 		new primarytype(get_turf(src))
 		Uses--
 		qdel(O)
@@ -641,7 +641,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 	icon_state = "bottle19"
 	w_class = W_CLASS_TINY
 
-	attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+/obj/item/weapon/slimepotion/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
 		if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
 			to_chat(user, "<span class='warning'>The potion only works on baby slimes!</span>")
 			return ..()
@@ -649,14 +649,14 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 			to_chat(user, "<span class='warning'>Only baby slimes can be tamed!</span>")
 			return..()
 		if(M.stat)
-			to_chat(user, "<span class='warning'>The slime is dead!</span>")
+			to_chat(user, "<span class='warning'>The [M] is dead!</span>")
 			return..()
 		var/mob/living/simple_animal/slime/pet = new /mob/living/simple_animal/slime(M.loc)
 		pet.icon_state = "[M.colour] baby slime"
 		pet.icon_living = "[M.colour] baby slime"
 		pet.icon_dead = "[M.colour] baby slime dead"
 		pet.colour = "[M.colour]"
-		to_chat(user, "You feed the slime the potion, removing its powers and calming it.")
+		to_chat(user, "You feed \the [M] the potion, removing its powers and calming it.")
 		if(M.mind)
 			M.mind.transfer_to(pet)
 		qdel (M)
@@ -680,19 +680,19 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 	icon_state = "bottle19"
 	w_class = W_CLASS_TINY
 
-	attack(mob/living/carbon/slime/adult/M as mob, mob/user as mob)
+/obj/item/weapon/slimepotion2/attack(mob/living/carbon/slime/adult/M as mob, mob/user as mob)
 		if(!istype(M, /mob/living/carbon/slime/adult))//If target is not a slime.
 			to_chat(user, "<span class='warning'>The potion only works on adult slimes!</span>")
 			return ..()
 		if(M.stat)
-			to_chat(user, "<span class='warning'>The slime is dead!</span>")
+			to_chat(user, "<span class='warning'>The [M] is dead!</span>")
 			return..()
 		var/mob/living/simple_animal/slime/adult/pet = new /mob/living/simple_animal/slime/adult(M.loc)
 		pet.icon_state = "[M.colour] adult slime"
 		pet.icon_living = "[M.colour] adult slime"
 		pet.icon_dead = "[M.colour] baby slime dead"
 		pet.colour = "[M.colour]"
-		to_chat(user, "You feed the slime the potion, removing its powers and calming it.")
+		to_chat(user, "You feed \the [M] the potion, removing its powers and calming it.")
 		if(M.mind)
 			M.mind.transfer_to(pet)
 		qdel (M)
@@ -716,7 +716,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 	icon_state = "bottle16"
 	w_class = W_CLASS_TINY
 
-	attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+/obj/item/weapon/slimesteroid/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
 		if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
 			to_chat(user, "<span class='warning'>The steroid only works on baby slimes!</span>")
 			return ..()
@@ -724,13 +724,13 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 			to_chat(user, "<span class='warning'>Only baby slimes can use the steroid!</span>")
 			return..()
 		if(M.stat)
-			to_chat(user, "<span class='warning'>The slime is dead!</span>")
+			to_chat(user, "<span class='warning'>The [M] is dead!</span>")
 			return..()
 		if(M.cores == 3)
-			to_chat(user, "<span class='warning'>The slime already has the maximum amount of extract!</span>")
+			to_chat(user, "<span class='warning'>The [M] already has the maximum amount of extract!</span>")
 			return..()
 
-		to_chat(user, "You feed the slime the steroid. It now has triple the amount of extract.")
+		to_chat(user, "You feed \the [M] the steroid. It now has triple the amount of extract.")
 		M.cores = 3
 		qdel (src)
 
@@ -748,13 +748,13 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 		to_chat(user, "<span class='warning'>The steroid only works on slimes!</span>")
 		return ..()
 	if(M.stat)
-		to_chat(user, "<span class='warning'>The slime is dead!</span>")
+		to_chat(user, "<span class='warning'>The [M] is dead!</span>")
 		return..()
 	if(M.amount_grown == 10)
-		to_chat(user, "<span class='warning'>The slime has already fed enough!</span>")
+		to_chat(user, "<span class='warning'>The [M] has already fed enough!</span>")
 		return..()
 
-	to_chat(user, "You feed the slime the nutrient. It now appears ready to grow.")
+	to_chat(user, "You feed \the [M] the nutrient. It now appears ready to grow.")
 	M.amount_grown = 10
 
 	if (Uses > 0)
@@ -784,15 +784,15 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 		to_chat(user, "<span class='warning'>Only baby slimes can be duplicated!</span>")
 		return ..()
 	if(M.stat)//dunno if this should be allowed but i think it's probably better this way
-		to_chat(user, "<span class='warning'>That slime is dead!</span>")
+		to_chat(user, "<span class='warning'>The [M] is dead!</span>")
 		return ..()
 
-	to_chat(user, "You splash the cloning juice onto the slime.")
+	to_chat(user, "You splash the cloning juice onto \the [M].")
 
 	var/mob/living/carbon/slime/S = new M.primarytype // don't let's start
-	S.tame = M.tame
-	S.forceMove(get_turf(M))
-	qdel(src)
+	S.tame = M.tame // this is the worst part
+	S.forceMove(get_turf(M)) // could believe for all the world
+	qdel(src) // that you're my precious little girl
 
 /obj/item/weapon/slimeres
 	name = "slime resurrection serum"

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -520,7 +520,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 	if(target.slime_act(primarytype,user))
 		if (Uses > 0)
 			Uses -= 1
-		if(Uses == 0)
+		if (Uses == 0)
 			qdel(src)
 
 /obj/item/slime_extract/New()

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -80,6 +80,7 @@
 	speak_emote = list("screams")
 	emote_hear = list("screams")
 	emote_see = list("screams")
+	emote_sound = male_scream_sound
 	friendly = "bites"
 	canRegenerate = 1
 	minRegenTime = 30 //It's just a crab, might as well give it quick regen

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -80,22 +80,24 @@
 	speak_emote = list("screams")
 	emote_hear = list("screams")
 	emote_see = list("screams")
-	emote_sound = list('sound/misc/malescream1.ogg',
-					'sound/misc/malescream2.ogg',
-					'sound/misc/malescream3.ogg',
-					'sound/misc/malescream4.ogg',
-					'sound/misc/malescream5.ogg',
-					'sound/misc/wilhelm.ogg', 
-					'sound/misc/goofy.ogg',
-					'sound/misc/femalescream1.ogg',
-					'sound/misc/femalescream2.ogg',
-					'sound/misc/femalescream3.ogg',
-					'sound/misc/femalescream4.ogg',
-					'sound/misc/femalescream5.ogg',
-					'sound/misc/shriek1.ogg',
-					'sound/misc/hiss1.ogg',
-					'sound/misc/hiss2.ogg',
-					'sound/misc/hiss3.ogg')
+	emote_sound = list(
+		'sound/misc/malescream1.ogg',
+		'sound/misc/malescream2.ogg',
+		'sound/misc/malescream3.ogg',
+		'sound/misc/malescream4.ogg',
+		'sound/misc/malescream5.ogg',
+		'sound/misc/wilhelm.ogg', 
+		'sound/misc/goofy.ogg',
+		'sound/misc/femalescream1.ogg',
+		'sound/misc/femalescream2.ogg',
+		'sound/misc/femalescream3.ogg',
+		'sound/misc/femalescream4.ogg',
+		'sound/misc/femalescream5.ogg',
+		'sound/misc/shriek1.ogg',
+		'sound/misc/hiss1.ogg',
+		'sound/misc/hiss2.ogg',
+		'sound/misc/hiss3.ogg'
+	)
 	friendly = "bites"
 	canRegenerate = 1
 	minRegenTime = 30 //It's just a crab, might as well give it quick regen

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -80,7 +80,22 @@
 	speak_emote = list("screams")
 	emote_hear = list("screams")
 	emote_see = list("screams")
-	emote_sound = male_scream_sound
+	emote_sound = list('sound/misc/malescream1.ogg',
+					'sound/misc/malescream2.ogg',
+					'sound/misc/malescream3.ogg',
+					'sound/misc/malescream4.ogg',
+					'sound/misc/malescream5.ogg',
+					'sound/misc/wilhelm.ogg', 
+					'sound/misc/goofy.ogg',
+					'sound/misc/femalescream1.ogg',
+					'sound/misc/femalescream2.ogg',
+					'sound/misc/femalescream3.ogg',
+					'sound/misc/femalescream4.ogg',
+					'sound/misc/femalescream5.ogg',
+					'sound/misc/shriek1.ogg',
+					'sound/misc/hiss1.ogg',
+					'sound/misc/hiss2.ogg',
+					'sound/misc/hiss3.ogg')
 	friendly = "bites"
 	canRegenerate = 1
 	minRegenTime = 30 //It's just a crab, might as well give it quick regen

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -136,6 +136,7 @@
 	dat += "<FONT color=[powercostcolor]><B>[powercost]</B></FONT>"
 
 /obj/item/weapon/gun/energy/temperature/examine(mob/user)
+	..()
 	to_chat(user, "Current output temperature: <FONT color=[tempcolor]><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F) </FONT>")
 	if(temperature > 500)
 		to_chat(user, "<FONT color=red><B>SEARING!!</B></FONT>")

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -137,10 +137,9 @@
 
 /obj/item/weapon/gun/energy/temperature/examine(mob/user)
 	desc = "A gun that changes the body temperature of its targets.")
-	to_chat(user, "Current output temperature: ")
-	to_chat(user, "<FONT color=[tempcolor]><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F) </FONT>"
+	to_chat(user, "Current output temperature: <FONT color=[tempcolor]><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F) </FONT>")
 	if(temperature > 500)
-		to_chat(user, "<FONT color=red><B>SEARING!!</B></FONT>"
+		to_chat(user, "<FONT color=red><B>SEARING!!</B></FONT>")
 	to_chat(user, "Target output temperature: [target_temperature]")
 	to_chat(user, "Power cost: <FONT color=[powercostcolor]><B>[powercost]</B></FONT>")
 

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -17,6 +17,7 @@
 
 	var/powercost = ""
 	var/powercostcolor = ""
+	var/tempcolor = ""
 
 	var/emagged = 0			//ups the temperature cap from 500 to 1000, targets hit by beams over 500 Kelvin will burst into flames
 	var/dat = ""
@@ -68,18 +69,23 @@
 		if(0 to 100)
 			charge_cost = 300
 			powercost = "High"
+			tempcolor = "blue"
 		if(100 to 250)
 			charge_cost = 180
 			powercost = "Medium"
+			tempcolor = "green"
 		if(251 to 300)
 			charge_cost = 90
 			powercost = "Low"
+			tempcolor = "black"
 		if(301 to 400)
 			charge_cost = 180
 			powercost = "Medium"
+			tempcolor = "yellow"
 		if(401 to 1000)
 			charge_cost = 300
 			powercost = "High"
+			tempcolor = "red"
 	switch(powercost)
 		if("High")
 			powercostcolor = "orange"
@@ -97,7 +103,6 @@
 		else
 			temperature = target_temperature
 		update_icon()
-		update_desc()
 
 		if (istype(loc, /mob/living/carbon))
 			var /mob/living/carbon/M = loc
@@ -109,21 +114,14 @@
 	if(power_supply)
 		power_supply.give(50)
 		update_icon()
-		update_desc()
 	return
 
 /obj/item/weapon/gun/energy/temperature/proc/update_dat()
 	dat = ""
 	dat += "Current output temperature: "
+	dat += "<FONT color=[tempcolor]><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F) </FONT>"
 	if(temperature > 500)
-		dat += "<FONT color=red><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F) </FONT>"
 		dat += "<FONT color=red><B>SEARING!!</B></FONT>"
-	else if(temperature > (T0C + 50))
-		dat += "<FONT color=red><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F)</FONT>"
-	else if(temperature > (T0C - 50))
-		dat += "<FONT color=black><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F)</FONT>"
-	else
-		dat += "<FONT color=blue><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F)</FONT>"
 	dat += "<BR>"
 	dat += "Target output temperature: "	//might be string idiocy, but at least it's easy to read
 	dat += "<A href='?src=\ref[src];temp=-100'>-</A> "
@@ -137,24 +135,14 @@
 	dat += "Power cost: "
 	dat += "<FONT color=[powercostcolor]><B>[powercost]</B></FONT>"
 
-/obj/item/weapon/gun/energy/temperature/proc/update_desc()
-	desc = "A gun that changes the body temperature of its targets."
-	desc += "<BR>"
-	desc += "Current output temperature: "
+/obj/item/weapon/gun/energy/temperature/examine(mob/user)
+	desc = "A gun that changes the body temperature of its targets.")
+	to_chat(user, "Current output temperature: ")
+	to_chat(user, "<FONT color=[tempcolor]><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F) </FONT>"
 	if(temperature > 500)
-		desc += "<FONT color=red><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F) </FONT>"
-		desc += "<FONT color=red><B>SEARING!!</B></FONT>"
-	else if(temperature > (T0C + 50))
-		desc += "<FONT color=red><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F)</FONT>"
-	else if(temperature > (T0C - 50))
-		desc += "<FONT color=black><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F)</FONT>"
-	else
-		desc += "<FONT color=blue><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F)</FONT>"
-	desc += "<BR>"
-	desc += "Target output temperature: [target_temperature]"
-	desc += "<BR>"
-	desc += "Power cost: "
-	desc += "<FONT color=[powercostcolor]><B>[powercost]</B></FONT>"
+		to_chat(user, "<FONT color=red><B>SEARING!!</B></FONT>"
+	to_chat(user, "Target output temperature: [target_temperature]")
+	to_chat(user, "Power cost: <FONT color=[powercostcolor]><B>[powercost]</B></FONT>")
 
 /obj/item/weapon/gun/energy/temperature/proc/update_temperature()
 	switch(temperature)

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -97,6 +97,7 @@
 		else
 			temperature = target_temperature
 		update_icon()
+		update_desc()
 
 		if (istype(loc, /mob/living/carbon))
 			var /mob/living/carbon/M = loc
@@ -108,6 +109,7 @@
 	if(power_supply)
 		power_supply.give(50)
 		update_icon()
+		update_desc()
 	return
 
 /obj/item/weapon/gun/energy/temperature/proc/update_dat()
@@ -134,6 +136,25 @@
 	dat += "<BR>"
 	dat += "Power cost: "
 	dat += "<FONT color=[powercostcolor]><B>[powercost]</B></FONT>"
+
+/obj/item/weapon/gun/energy/temperature/proc/update_desc()
+	desc = "A gun that changes the body temperature of its targets."
+	desc += "<BR>"
+	desc += "Current output temperature: "
+	if(temperature > 500)
+		desc += "<FONT color=red><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F) </FONT>"
+		desc += "<FONT color=red><B>SEARING!!</B></FONT>"
+	else if(temperature > (T0C + 50))
+		desc += "<FONT color=red><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F)</FONT>"
+	else if(temperature > (T0C - 50))
+		desc += "<FONT color=black><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F)</FONT>"
+	else
+		desc += "<FONT color=blue><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F)</FONT>"
+	desc += "<BR>"
+	desc += "Target output temperature: [target_temperature]"
+	desc += "<BR>"
+	desc += "Power cost: "
+	desc += "<FONT color=[powercostcolor]><B>[powercost]</B></FONT>"
 
 /obj/item/weapon/gun/energy/temperature/proc/update_temperature()
 	switch(temperature)

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -136,7 +136,6 @@
 	dat += "<FONT color=[powercostcolor]><B>[powercost]</B></FONT>"
 
 /obj/item/weapon/gun/energy/temperature/examine(mob/user)
-	desc = "A gun that changes the body temperature of its targets.")
 	to_chat(user, "Current output temperature: <FONT color=[tempcolor]><B>[temperature]</B> ([round(temperature-T0C)]&deg;C) ([round(temperature*1.8-459.67)]&deg;F) </FONT>")
 	if(temperature > 500)
 		to_chat(user, "<FONT color=red><B>SEARING!!</B></FONT>")

--- a/maps/test_box.dmm
+++ b/maps/test_box.dmm
@@ -69337,12 +69337,6 @@
 	},
 /area/science/xenobiology)
 "czI" = (
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	name = "Science Requests Console";
-	pixel_y = 30
-	},
 /obj/machinery/camera{
 	c_tag = "Xenobiology Module North"
 	},
@@ -69351,6 +69345,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Xenobiology";
+	departmentType = 2;
+	name = "Xenobiology Requests Console";
+	pixel_y = 30
 	},
 /turf/simulated/floor{
 	icon_state = "white"


### PR DESCRIPTION
[tweak][qol][grammar][consistency]
![image](https://user-images.githubusercontent.com/57303506/128554204-f4b5b452-3ed7-4910-bb72-0d8ef0bf596b.png)
![image](https://user-images.githubusercontent.com/57303506/128554425-a1b310a0-64bb-4c1b-b6ab-b014be7a7f65.png)
:cl:
 * rscadd: Information about temperature guns now also shows up in item descriptions.
 * tweak: Slime enhancing chemicals now refer to the specific slime when used on them.
 * tweak: Xenobiology Centcomm requests are now assigned to the specific job instead of science in general.
 * rscadd: Slime extract enhancers now allow triple the use of extracts on items around the station.
 * rscadd: Extract smartfridges can now store docility potions, slime steroids, slime enhancers, slime duplicators and slime resurrectors.
 * rscadd: Norris now actually screams.