### PR TITLE
gives rig mod stations the ability to remove a user's rig modules when empty

### DIFF
--- a/code/game/machinery/suit_modifier.dm
+++ b/code/game/machinery/suit_modifier.dm
@@ -109,9 +109,10 @@
 	if(H.loc == loc)
 		var/obj/worn_suit = H.get_item_by_slot(slot_wear_suit)
 		if(istype(worn_suit, /obj/item/clothing/suit/space/rig))
+			var/obj/item/clothing/suit/space/rig/worn_rig = worn_suit
 			if(!modules_to_install.len && !cell)
-				if(H.a_intent == I_HURT)
-					say("Preparing module uninstallation subroutines...", class = "binaryradio")
+				if(worn_rig.modules.len)
+					say("Installed modules detected.", class = "binaryradio")
 					process_module_removal(H)
 					return
 				say("No upgrade available.", class = "binaryradio")
@@ -242,6 +243,7 @@
 		// if we have something that's not a rig_module here we have a problem
 		var/obj/item/rig_module/RM = input(H, "Choose an upgrade to remove from [R].", R) as null|anything in R.modules
 		if(!RM|| !H.Adjacent(src) || H.incapacitated())
+			unlock_atom(H)
 			return
 		working_animation()
 		say("Uninstalling [RM] from \the [R].", class = "binaryradio")

--- a/code/game/machinery/suit_modifier.dm
+++ b/code/game/machinery/suit_modifier.dm
@@ -244,6 +244,7 @@
 		var/obj/item/rig_module/RM = input(H, "Choose an upgrade to remove from [R].", R) as null|anything in R.modules
 		if(!RM|| !H.Adjacent(src) || H.incapacitated())
 			unlock_atom(H)
+			activated = FALSE
 			return
 		working_animation()
 		say("Uninstalling [RM] from \the [R].", class = "binaryradio")

--- a/code/game/machinery/suit_modifier.dm
+++ b/code/game/machinery/suit_modifier.dm
@@ -110,6 +110,10 @@
 		var/obj/worn_suit = H.get_item_by_slot(slot_wear_suit)
 		if(istype(worn_suit, /obj/item/clothing/suit/space/rig))
 			if(!modules_to_install.len && !cell)
+				if(H.a_intent == I_HURT)
+					say("Preparing module uninstallation subroutines...", class = "binaryradio")
+					process_module_removal(H)
+					return
 				say("No upgrade available.", class = "binaryradio")
 				return
 			process_module_installation(H)
@@ -220,6 +224,32 @@
 			R.cell = cell
 			cell = null
 	finished_animation()
+	unlock_atom(H)
+	R.initialize_suit()
+	use_power = 1
+	activated = FALSE
+
+/obj/machinery/suit_modifier/proc/process_module_removal(var/mob/living/carbon/human/H)
+	if(activated)
+		return
+	lock_atom(H)
+	activated = TRUE
+	use_power = 2
+	activation_animation()
+	var/obj/item/clothing/suit/space/rig/R = H.is_wearing_item(/obj/item/clothing/suit/space/rig, slot_wear_suit)
+	R.deactivate_suit()
+	if(R.modules.len)
+		// if we have something that's not a rig_module here we have a problem
+		var/obj/item/rig_module/RM = input(H, "Choose an upgrade to remove from [R].", R) as null|anything in R.modules
+		if(!RM|| !H.Adjacent(src) || H.incapacitated())
+			return
+		working_animation()
+		say("Uninstalling [RM] from \the [R].", class = "binaryradio")
+		if(do_after(H, src, 5 SECONDS, needhand = FALSE))
+			R.modules.Remove(RM)
+			RM.rig = null
+			RM.forceMove(get_turf(src))
+		finished_animation()
 	unlock_atom(H)
 	R.initialize_suit()
 	use_power = 1


### PR DESCRIPTION
[tweak]
~~Making it an intent thing is kinda fucked up on my part regardless but~~ it just checks if the user's rig has modules now

Empty (nothing in modules_to_install) spacesuit mod stations can be used (while standing inside them, of course) to uninstall modules from the wearer's suit. This only happens if your suit has modules to remove.
This takes the same time as it takes to install it, and puts the uninstalled module on the floor.

:cl:
 * rscadd: Rigsuit modification stations can now uninstall modules when empty. Use harm intent.