### PR TITLE
Resin (Alien) and Cult doors now require proper access from Mechas, Bots, and Vehicles

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -94,7 +94,7 @@ var/list/all_doors = list()
 	if (istype(AM, /obj/machinery/bot))
 		var/obj/machinery/bot/bot = AM
 
-		if (check_access(bot.botcard) && !operating)
+		if (check_access(bot.botcard) && !operating && SpecialAccess(AM))
 			open()
 
 		return
@@ -103,7 +103,7 @@ var/list/all_doors = list()
 		var/obj/mecha/mecha = AM
 
 		if (density)
-			if (mecha.occupant && !operating && (allowed(mecha.occupant) || check_access_list(mecha.operation_req_access)))
+			if (mecha.occupant && !operating && SpecialAccess(mecha.occupant) && (allowed(mecha.occupant) || check_access_list(mecha.operation_req_access)))
 				open()
 			else if(!operating)
 				denied()
@@ -112,7 +112,7 @@ var/list/all_doors = list()
 		var/obj/structure/bed/chair/vehicle/vehicle = AM
 
 		if (density)
-			if (vehicle.is_locking(/datum/locking_category/buckle/chair/vehicle, subtypes=TRUE) && !operating && allowed(vehicle.get_locked(/datum/locking_category/buckle/chair/vehicle, subtypes=TRUE)[1]))
+			if (vehicle.is_locking(/datum/locking_category/buckle/chair/vehicle, subtypes=TRUE) && !operating && SpecialAccess(vehicle.get_locked(/datum/locking_category/buckle/chair/vehicle, subtypes=TRUE)[1]) && allowed(vehicle.get_locked(/datum/locking_category/buckle/chair/vehicle, subtypes=TRUE)[1]))
 				if(istype(vehicle, /obj/structure/bed/chair/vehicle/firebird))
 					vehicle.forceMove(get_step(vehicle,vehicle.dir))//Firebird doesn't wait for no slowpoke door to fully open before dashing through!
 				open()
@@ -151,6 +151,9 @@ var/list/all_doors = list()
 		open()
 	else if(!operating)
 		denied()
+
+/obj/machinery/door/proc/SpecialAccess(var/atom/user)
+	return TRUE
 
 /obj/machinery/door/attack_ai(mob/user as mob)
 	add_hiddenprint(user)

--- a/code/game/machinery/doors/mineral.dm
+++ b/code/game/machinery/doors/mineral.dm
@@ -254,6 +254,11 @@
 	var/close_delay = 100
 	soundeffect = 'sound/effects/attackblob.ogg'
 
+/obj/machinery/door/mineral/resin/SpecialAccess(var/atom/user)
+	if (isalien(user))
+		return TRUE
+	return FALSE
+
 /obj/machinery/door/mineral/resin/TryToSwitchState(atom/user)
 	if(isalien(user) && !operating)
 		add_fingerprint(user)
@@ -343,6 +348,11 @@
 		playsound(loc, 'sound/effects/stone_crumble.ogg', 100, 1)
 	anim(location = loc,target = loc.loc,a_icon = 'icons/obj/doors/doorcult.dmi', flick_anim = "cultdoor_breakdown")
 	..()
+
+/obj/machinery/door/mineral/cult/SpecialAccess(var/atom/user)
+	if (isanycultist(user))
+		return TRUE
+	return FALSE
 
 /obj/machinery/door/mineral/cult/Uncrossed(var/atom/movable/mover)
 	if (!density && !operating && !(locate(/mob/living) in loc))

--- a/code/game/machinery/doors/mineral.dm
+++ b/code/game/machinery/doors/mineral.dm
@@ -255,8 +255,10 @@
 	soundeffect = 'sound/effects/attackblob.ogg'
 
 /obj/machinery/door/mineral/resin/SpecialAccess(var/atom/user)
-	if (isalien(user))
-		return TRUE
+	if (ismob(user))
+		var/mob/M = user
+		if (isalien(M))
+			return TRUE
 	return FALSE
 
 /obj/machinery/door/mineral/resin/TryToSwitchState(atom/user)
@@ -350,8 +352,10 @@
 	..()
 
 /obj/machinery/door/mineral/cult/SpecialAccess(var/atom/user)
-	if (isanycultist(user))
-		return TRUE
+	if (ismob(user))
+		var/mob/M = user
+		if (isanycultist(M))
+			return TRUE
 	return FALSE
 
 /obj/machinery/door/mineral/cult/Uncrossed(var/atom/movable/mover)


### PR DESCRIPTION
Fixes #30167

:cl:
* bugfix: Resin (Alien) and Cult doors now require proper access from Mechas, Bots, and Vehicles. That is to say, Resin doors can now only be open by aliens, and Cult doors will only open for Mechas or Vehicles if they are piloted by a cultist. (west3436)