### PR TITLE
The Manifest Prediction button now appears to new players right away

### DIFF
--- a/code/controllers/subsystem/init/job.dm
+++ b/code/controllers/subsystem/init/job.dm
@@ -14,6 +14,8 @@ var/datum/subsystem/job/SSjob
 	job_master = new /datum/controller/occupations()
 	job_master.SetupOccupations()
 	job_master.LoadJobs("config/jobs.txt")
+	for (var/mob/new_player/player in player_list)
+		player.new_player_panel_proc() // adds the Manifest Prediction button to players who were already connected
 	if(!syndicate_code_phrase)
 		syndicate_code_phrase	= generate_code_phrase()
 	if(!syndicate_code_response)


### PR DESCRIPTION
Fixes #29106

:cl:
* rscadd: The Manifest Prediction button now appears to new players as soon as the job master has initialized, so no longer need to ready up and off or click another button to see it appear.