### PR TITLE
Band-aids closets spawning their items twice and adds some debug info to try and catch the bug in the act

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -32,6 +32,8 @@
 	w_type = RECYK_METAL
 	ignoreinvert = 1
 
+	var/time_initialized_at = 0
+
 /obj/structure/closet/New()
 	..()
 	if (has_lock_type)
@@ -66,7 +68,14 @@
 
 /obj/structure/closet/initialize()
 	..()
-	spawn_contents()
+	if (!time_initialized_at)
+		time_initialized_at = world.time
+		spawn_contents()
+	else
+		//haha, so you'd like to initialize twice huh? you got some explaining to do kid.
+		message_admins("[src] at ([L.x],[L.y],[L.z]) tried to initialize at time = [world.time] despite having already initialized at time = [time_initialized_at]")
+		ASSERT(!time_initialized_at)
+		return
 	if(!opened)		// if closed, any item at the crate's loc is put in the contents
 		if(!ticker || ticker.current_state < GAME_STATE_PLAYING)
 			take_contents()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -73,7 +73,7 @@
 		spawn_contents()
 	else
 		//haha, so you'd like to initialize twice huh? you got some explaining to do kid.
-		message_admins("[src] at ([L.x],[L.y],[L.z]) tried to initialize at time = [world.time] despite having already initialized at time = [time_initialized_at]")
+		message_admins("[src] at ([x],[y],[z]) tried to initialize at time = [world.time] despite having already initialized at time = [time_initialized_at]")
 		ASSERT(!time_initialized_at)
 		return
 	if(!opened)		// if closed, any item at the crate's loc is put in the contents


### PR DESCRIPTION
Fixes #29462
Fixes #28744

:cl:
* bugfix: Fixed supermatter shard crates (and other crates potentially) spawning their content twice. (mastercasual)