### PR TITLE
Fixes build mode checking space turfs instead of base turf type

### DIFF
--- a/code/modules/admin/buildmode.dm
+++ b/code/modules/admin/buildmode.dm
@@ -432,7 +432,7 @@ obj/effect/bmode/buildholder/New()
 	switch(buildmode)
 		if(1)
 			if(istype(object,/turf) && pa.Find("left") && !pa.Find("alt") && !pa.Find("ctrl") )
-				if(istype(object,/turf/space))
+				if(istype(object,get_base_turf(T.z)))
 					var/turf/T = object
 					T.ChangeTurf(/turf/simulated/floor)
 					log_admin("[key_name(usr)] made a floor at [formatJumpTo(T)]")
@@ -455,7 +455,7 @@ obj/effect/bmode/buildholder/New()
 					return
 				else if(istype(object,/turf/simulated/floor))
 					var/turf/T = object
-					T.ChangeTurf(/turf/space)
+					T.ChangeTurf(get_base_turf(T.z))
 					log_admin("[key_name(usr)] removed flooring at [formatJumpTo(T)]")
 					return
 				else if(istype(object,/turf/simulated/wall/r_wall))

--- a/code/modules/admin/buildmode.dm
+++ b/code/modules/admin/buildmode.dm
@@ -431,7 +431,6 @@ obj/effect/bmode/buildholder/New()
 	var/turf/RT = get_turf(object)
 	switch(buildmode)
 		if(1)
-			var/base_turf = get_base_turf()
 			if(istype(object,/turf) && pa.Find("left") && !pa.Find("alt") && !pa.Find("ctrl") )
 				var/turf/T = object
 				if(istype(T,get_base_turf(T.z)))

--- a/code/modules/admin/buildmode.dm
+++ b/code/modules/admin/buildmode.dm
@@ -434,17 +434,14 @@ obj/effect/bmode/buildholder/New()
 			if(istype(object,/turf) && pa.Find("left") && !pa.Find("alt") && !pa.Find("ctrl") )
 				var/turf/T = object
 				if(istype(T,get_base_turf(T.z)))
-					var/turf/T = object
 					T.ChangeTurf(/turf/simulated/floor)
 					log_admin("[key_name(usr)] made a floor at [formatJumpTo(T)]")
 					return
 				else if(istype(T,/turf/simulated/floor))
-					var/turf/T = object
 					T.ChangeTurf(/turf/simulated/wall)
 					log_admin("[key_name(usr)] made a wall at [formatJumpTo(T)]")
 					return
 				else if(istype(T,/turf/simulated/wall))
-					var/turf/T = object
 					T.ChangeTurf(/turf/simulated/wall/r_wall)
 					log_admin("[key_name(usr)] made an rwall at [formatJumpTo(T)]")
 					return

--- a/code/modules/admin/buildmode.dm
+++ b/code/modules/admin/buildmode.dm
@@ -431,18 +431,20 @@ obj/effect/bmode/buildholder/New()
 	var/turf/RT = get_turf(object)
 	switch(buildmode)
 		if(1)
+			var/base_turf = get_base_turf()
 			if(istype(object,/turf) && pa.Find("left") && !pa.Find("alt") && !pa.Find("ctrl") )
-				if(istype(object,get_base_turf(T.z)))
+				var/turf/T = object
+				if(istype(T,get_base_turf(T.z)))
 					var/turf/T = object
 					T.ChangeTurf(/turf/simulated/floor)
 					log_admin("[key_name(usr)] made a floor at [formatJumpTo(T)]")
 					return
-				else if(istype(object,/turf/simulated/floor))
+				else if(istype(T,/turf/simulated/floor))
 					var/turf/T = object
 					T.ChangeTurf(/turf/simulated/wall)
 					log_admin("[key_name(usr)] made a wall at [formatJumpTo(T)]")
 					return
-				else if(istype(object,/turf/simulated/wall))
+				else if(istype(T,/turf/simulated/wall))
 					var/turf/T = object
 					T.ChangeTurf(/turf/simulated/wall/r_wall)
 					log_admin("[key_name(usr)] made an rwall at [formatJumpTo(T)]")


### PR DESCRIPTION
[administration][bugfix]
:cl:
 * bugfix: Admin build mode no longer creates space tiles on the lowest level of deletion, or requires it for creation, instead it checks for the base turf (which can also be space)