### PR TITLE
Clicking the Unbuckle button on a shuttle chair while holding an item no longer makes you hit yourself

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -621,7 +621,7 @@
 
 /obj/structure/bed/chair/shuttle/attackby(var/obj/item/W, var/mob/user)
 	var/mob/M = locate() in loc//so attacking people isn't made harder by the seats' bulkiness
-	if (M)
+	if (M && M != user)
 		return M.attackby(W,user)
 	if(istype(W, /obj/item/assembly/shock_kit))
 		to_chat(user,"<span class='warning'>\The [W] cannot be rigged onto \the [src].</span>")


### PR DESCRIPTION
Fixes #28946

:cl:
* bugfix: Clicking the Unbuckle button on a shuttle chair while holding an item no longer makes you hit yourself. (PrimeD)