### PR TITLE
Re-Adds Mouse Opacity to a bunch of effects

### DIFF
--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -18,6 +18,7 @@ var/list/blob_overminds = list()
 	opacity = 0
 	anchored = 1
 	penetration_dampening = 17
+	mouse_opacity = 1
 	var/health = 20
 	var/maxhealth = 20
 	var/health_timestamp = 0

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -14,6 +14,7 @@
 	name = "alien thing"
 	desc = "There's something alien about this."
 	icon = 'icons/mob/alien.dmi'
+	mouse_opacity = 1
 	w_type=NOT_RECYCLABLE
 
 /*

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -8,6 +8,7 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "glowshroomf"
 	layer = BELOW_TABLE_LAYER
+	mouse_opacity = 1
 	var/endurance = 30
 	var/potency = 30
 	var/delay = 1200

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -2,6 +2,7 @@
 	name = "overlay"
 	w_type=NOT_RECYCLABLE
 	plane = ABOVE_HUMAN_PLANE
+	mouse_opacity = 1
 	var/i_attached//Added for possible image attachments to objects. For hallucinations and the like.
 
 /obj/effect/overlay/cultify()

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -3,6 +3,7 @@
 	desc = "Looks stable, but still, best to test it with the clown first."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "portal0"
+	mouse_opacity = 1
 	var/mask = "portal_mask"
 	var/open_sound = 'sound/effects/portal_open.ogg'
 	var/close_sound = 'sound/effects/portal_close.ogg'

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -11,7 +11,7 @@
 	density = 0
 	plane = ABOVE_HUMAN_PLANE
 	pass_flags = PASSTABLE | PASSGRILLE | PASSGIRDER | PASSMACHINE
-	//mouse_opacity = 2
+	mouse_opacity = 1
 
 	var/health = 10
 	var/max_health = 100


### PR DESCRIPTION
Caused by #30138 , there could be further exceptions we didn't think of.

I was really temped to make it 1 by default for all effects @kane-f

Fixes #30212 
Fixes #30214 
Fixes #30185 

:cl:
* bugfix: Fixed several effects such as portals, xenomorph structures, space vines, blobs, and more no longer being clickable. (eneocho)