### PR TITLE
Fixes glass floors making a space turf instead of base when destroyed

### DIFF
--- a/code/game/turfs/simulated/floor_glass.dm
+++ b/code/game/turfs/simulated/floor_glass.dm
@@ -77,7 +77,7 @@
 	// TODO: Break all pipes/wires? //Maybe not, N3X.
 
 	spawnBrokenPieces(src)
-	ChangeTurf(/turf/space)
+	ChangeTurf(get_base_turf(src.z))
 
 /turf/simulated/floor/glass/proc/spawnBrokenPieces(var/turf/T)
 	new shardtype(T, sheetamount)


### PR DESCRIPTION
[bugfix][consistency]
Just another unatomic thing I noticed while coding mutil-z support.
:cl:
 * bugfix: Glass floors will now attempt to create the base turf underneath when destroyed instead of always space turfs. (Again, this can be space if it wants)