### PR TITLE
Tunes up zone rebuilding again

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -187,7 +187,7 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 	switch(part)
 		if(SSAIR_TILES)
 			LOOP_DECLARATION(turf, T)
-				if(T.c_airblock(T) & ZONE_BLOCKED)
+				if(T.c_airblock(T) == ZONE_BLOCKED) //== instead of & because if it's also AIR_BLOCKED, it doesn't need to be deferred since it's just going to rebuild the zone.
 					processing_parts[SSAIR_DEFERRED] += T
 					continue
 


### PR DESCRIPTION
I guess I only tested #28874 with windows? I swear I tested shelters but I must not have because they didn't work. Anyway, now zones rebuild immediately if a fulltile air-blocking object is moved, not just a border object. Also if a non-airlock door is closed.
I have no idea why `AIR_BLOCKED` and `ZONE_BLOCKED` are bitflags, since there is no logical way something could be `AIR_BLOCKED` but not `ZONE_BLOCKED`, and in fact nowhere in the code is `ZONE_BLOCKED` even checked if the thing is `AIR_BLOCKED`.