### PR TITLE
Fixed Teleport Scrolls, Ghost Teleports, and Adminbus Teleports missing most if not all destination areas.

### DIFF
--- a/code/controllers/subsystem/init/more_init_stuff.dm
+++ b/code/controllers/subsystem/init/more_init_stuff.dm
@@ -39,7 +39,7 @@ var/datum/subsystem/more_init/SSmore_init
 	..()
 
 	watch=start_watch()
-	log_startup_progress("Finishing last few initializations...")
+	log_startup_progress("Doing the other misc. initializations...")
 	process_teleport_locs()				//Sets up the wizard teleport locations
 	process_ghost_teleport_locs()		//Sets up ghost teleport locations.
 	process_adminbus_teleport_locs()	//Sets up adminbus teleport locations.
@@ -50,7 +50,7 @@ var/datum/subsystem/more_init/SSmore_init
 	init_wizard_apprentice_setups()
 	machinery_rating_cache = cache_machinery_components_rating()
 	typing_indicator = new
-	log_startup_progress("Finished last few initializations in [stop_watch(watch)]s.")
+	log_startup_progress("Finished doing the other misc. initializations in [stop_watch(watch)]s.")
 
 /proc/cache_machinery_components_rating()
 	var/list/cache = list()

--- a/code/controllers/subsystem/init/more_init_stuff.dm
+++ b/code/controllers/subsystem/init/more_init_stuff.dm
@@ -38,16 +38,19 @@ var/datum/subsystem/more_init/SSmore_init
 		log_startup_progress("  Finished caching jukebox playlists in [stop_watch(watch)]s.")
 	..()
 
+	watch=start_watch()
+	log_startup_progress("Finishing last few initializations...")
+	process_teleport_locs()				//Sets up the wizard teleport locations
+	process_ghost_teleport_locs()		//Sets up ghost teleport locations.
+	process_adminbus_teleport_locs()	//Sets up adminbus teleport locations.
 	camera_sort(cameranet.cameras)
-
 	for (var/obj/machinery/computer/security/S in tv_monitors)
 		S.init_cams()
-
 	create_global_diseases()
-
 	init_wizard_apprentice_setups()
 	machinery_rating_cache = cache_machinery_components_rating()
 	typing_indicator = new
+	log_startup_progress("Finished last few initializations in [stop_watch(watch)]s.")
 
 /proc/cache_machinery_components_rating()
 	var/list/cache = list()

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -140,7 +140,7 @@ proc/process_adminbus_teleport_locs()
 			adminbusteleportlocs += AR.name
 			adminbusteleportlocs[AR.name] = AR
 
-	sortTim(adminbusteleportlocs, /proc/cmp_text_dsc)
+	sortTim(adminbusteleportlocs, /proc/cmp_text_asc)
 
 
 /*-----------------------------------------------------------------------------*/

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -49,8 +49,8 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 
 
 /turf/simulated/floor/New()
-	..()
 	create_floor_tile()
+	..()
 	if(icon_state in icons_to_ignore_at_floor_init) //so damaged/burned tiles or plating icons aren't saved as the default
 		icon_regular_floor = "floor"
 	else

--- a/code/world.dm
+++ b/code/world.dm
@@ -146,9 +146,6 @@ var/auxtools_path = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
 
 	Master.Setup()
 
-	process_teleport_locs()				//Sets up the wizard teleport locations
-	process_ghost_teleport_locs()		//Sets up ghost teleport locations.
-	process_adminbus_teleport_locs()	//Sets up adminbus teleport locations.
 	SortAreas()							//Build the list of all existing areas and sort it alphabetically
 
 	spawn(2000)		//so we aren't adding to the round-start lag


### PR DESCRIPTION
Fixes #30224

:cl:
* bugfix: Fixed Teleport Scrolls, Ghost Teleports, and Adminbus Teleports missing most if not all destination areas. (personable)