### PR TITLE
Fixes the RCD saying "Building wall" instead of "Building wall...".

### DIFF
--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -100,7 +100,7 @@
 		return 1
 
 	var/turf/simulated/floor/T = A
-	to_chat(user, "Building wall")
+	to_chat(user, "Building wall...")
 	playsound(master, 'sound/machines/click.ogg', 50, 1)
 	if(master.delay(user, A, 2 SECONDS))
 		if(master.get_energy(user) < energy_cost)


### PR DESCRIPTION
It says "Building windows..." or "Building floor..." so changed for consistency.
[grammar] [consistency]
:cl:
 * spellcheck: Changed the RCD's building wall to_chat() from "Building wall" to "Building wall...". 