### PR TITLE
Fixes the outward lime couch being grey instead of lime

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -484,6 +484,7 @@
 /obj/structure/bed/chair/comfy/couch/turn/inward/lime
 	color = CHAIR_LIME
 /obj/structure/bed/chair/comfy/couch/turn/outward/lime
+	color = CHAIR_LIME
 
 // #ae774c brown
 /obj/structure/bed/chair/comfy/couch/left/brown


### PR DESCRIPTION
Fixes #28872

:cl:
* bugfix: Fixed the outward lime couch being grey instead of lime. (loppu)