### PR TITLE
You can now re-insert screwdrivers in switchtools

### DIFF
--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -46,12 +46,12 @@
 	else
 		if(!proximity_flag)
 			return
-			
+
 		var/turf/T
 		if(isturf(target.loc))
 			T = target.loc
 		else
-			return 
+			return
 
 		var/success = FALSE
 		for(var/obj/item/I in T)
@@ -87,10 +87,16 @@
 
 /obj/item/weapon/switchtool/attackby(var/obj/item/used_item, mob/user)
 	if(istype(used_item, removing_item)) //if it's the thing that lets us remove tools and we have something to remove
-		if(deployed)
-			return remove_module(user)
-		else
-			return remove_all_modules(user)
+		var/no_modules = TRUE
+		for(var/module in stored_modules)
+			if(stored_modules[module])
+				no_modules = FALSE
+				break
+		if (!no_modules)
+			if(deployed)
+				return remove_module(user)
+			else
+				return remove_all_modules(user)
 
 	if(add_module(used_item, user))
 		return TRUE


### PR DESCRIPTION
Fixes #28853
Fixes #28305

:cl:
* bugfix: You can now re-insert screwdrivers in switchtools, although you must remove other modules first. (eneocho & cyrix01)