### PR TITLE
Tentative fix for latejoin rulesets firing without the player being properly assigned

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -708,8 +708,8 @@ var/stacking_limit = 90
 		forced_latejoin_rule.trim_candidates()
 		message_admins("Forcing ruleset [forced_latejoin_rule]")
 		if (forced_latejoin_rule.ready(1))
-			forced_latejoin_rule.choose_candidates()
-			picking_latejoin_rule(list(forced_latejoin_rule))
+			if (forced_latejoin_rule.choose_candidates())
+				picking_latejoin_rule(list(forced_latejoin_rule))
 		forced_latejoin_rule = null
 
 	else if (!latejoin_injection_cooldown && injection_attempt())
@@ -733,8 +733,8 @@ var/stacking_limit = 90
 				rule.candidates = list(newPlayer)
 				rule.trim_candidates()
 				if (rule.ready())
-					rule.choose_candidates()
-					drafted_rules[rule] = rule.get_weight()
+					if (rule.choose_candidates())
+						drafted_rules[rule] = rule.get_weight()
 
 		if (drafted_rules.len > 0 && picking_latejoin_rule(drafted_rules))
 			var/latejoin_injection_cooldown_middle = 0.5*(LATEJOIN_DELAY_MAX + LATEJOIN_DELAY_MIN)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -79,8 +79,9 @@
 // returns: 0 or 1 depending on success. (failure meaning something runtimed mid-code.)
 /datum/dynamic_ruleset/proc/choose_candidates()
 	var/mob/M = pick(candidates)
-	assigned += M
-	candidates -= M
+	if (istype(M))
+		assigned += M
+		candidates -= M
 	return (assigned.len > 0)
 
 /datum/dynamic_ruleset/proc/process()


### PR DESCRIPTION
Fixes #30216

:cl:
* bugfix: Potentially fixed a bug where Dynamic tried to run latejoin ruleset despite the player not being properly assigned. (kanef)