### PR TITLE
Request consoles no longer consider their message as read when read by ghosts

### DIFF
--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -194,7 +194,7 @@ var/list/obj/machinery/requests_console/requests_consoles = list()
 				dat += text("<A href='?src=\ref[src];setScreen=0'>Continue</A><BR>")
 
 			if(8)	//view messages
-				if(!isAdminGhost(user)) //Do not clear if admin
+				if(!isobserver(user)) //Do not clear if ghost
 					for (var/obj/machinery/requests_console/Console in requests_consoles)
 						if (Console.department == department)
 							Console.newmessagepriority = 0


### PR DESCRIPTION
Fixes #28721

:cl:
* bugfix: Request consoles no longer consider their message as read when read by ghosts. (jellyveggie2)