### PR TITLE
Re-Added mouse opacity to biomass and spider webs, cocoons, etc...

### DIFF
--- a/code/datums/gamemode/objectives/time_agent_extract.dm
+++ b/code/datums/gamemode/objectives/time_agent_extract.dm
@@ -36,6 +36,7 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "time_anomaly"
 	anchored = 1
+	mouse_opacity = 1
 	var/last_effect
 
 /obj/effect/time_anomaly/New()

--- a/code/game/gamemodes/events/biomass.dm
+++ b/code/game/gamemodes/events/biomass.dm
@@ -10,6 +10,7 @@
 	density = 0
 	plane = ABOVE_HUMAN_PLANE
 	pass_flags = PASSTABLE | PASSGRILLE
+	mouse_opacity = 1
 	var/energy = 0
 	var/obj/effect/biomass_controller/master = null
 	var/health = 15

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/effects.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/effects.dm
@@ -9,6 +9,7 @@
 	var/health = 15
 	gender = NEUTER
 	w_type=NOT_RECYCLABLE
+	mouse_opacity = 1
 
 //similar to weeds, but only barfed out by nurses manually
 /obj/effect/spider/ex_act(severity)


### PR DESCRIPTION
Fixes #30246

:cl:
* bugfix: Re-Added mouse opacity to biomass and spider webs, cocoons, as well as time anomalies (bobthepigslayer & eneocho)