### PR TITLE
Prevents nuke disk carriers from trying to ride a gravpult

### DIFF
--- a/code/game/objects/structures/gravpult.dm
+++ b/code/game/objects/structures/gravpult.dm
@@ -72,7 +72,11 @@ var/list/gravpults = list()
 		if (M.occupant)
 			mech = M
 			user = M.occupant
-			setup(user)
+			if(!isemptylist(mech.search_contents_for(/obj/item/weapon/disk/nuclear)))
+				playsound(src, 'sound/machines/buzz-two.ogg', 50, 0, null, FALLOFF_SOUNDS, 0)
+				to_chat(user, "<span class='warning'>\The [src]'s interface won't appear because the nuclear authentification disk that you are carrying would interfere with the Mech Teleporter. Those who carry it must reach the station by shuttle.</span>")
+			else
+				setup(user)
 	..()
 
 /obj/structure/deathsquad_gravpult/Uncrossed(var/atom/movable/AM)
@@ -152,6 +156,7 @@ var/list/gravpults = list()
 	if (!D)
 		return
 
+	mech.dir = dir
 	if (istype(mech,/obj/mecha/combat/marauder))
 		mech.icon_state = mech.initial_icon + "-dash"
 

--- a/code/game/objects/structures/gravpult.dm
+++ b/code/game/objects/structures/gravpult.dm
@@ -152,6 +152,14 @@ var/list/gravpults = list()
 /obj/structure/deathsquad_gravpult/proc/launch()
 	if (!mech)
 		return
+
+	hud_off()
+
+	if(!isemptylist(mech.search_contents_for(/obj/item/weapon/disk/nuclear)))
+		playsound(src, 'sound/machines/buzz-two.ogg', 50, 0, null, FALLOFF_SOUNDS, 0)
+		to_chat(user, "<span class='warning'>\The [src]'s gravpult won't launch you because the nuclear authentification disk that you are carrying would interfere with the Mech Teleporter. Those who carry it must reach the station by shuttle.</span>")
+		return
+
 	var/obj/machinery/door/poddoor/D = locate() in get_step(loc,WEST)
 	if (!D)
 		return
@@ -164,7 +172,6 @@ var/list/gravpults = list()
 	mech.set_control_lock(1)
 	mech.set_control_lock(0,50)
 
-	hud_off()
 	//opening the portal
 	new /obj/effect/overlay/mechaportal(locate(x-portal_dist,y,z),world.maxx - TRANSITIONEDGE - rand(10,20),aim+1,map.zMainStation)
 	sleep(10)


### PR DESCRIPTION

:cl:
* bugfix: Marauder or Seraph pilots carrying the Nuke Disk can no longer try to ride the Deathsquad Gravpults, which would cause them to bounce off the Mech Teleporters and become stranded. (SoyConsumer)