### PR TITLE
DNA Scanners and Cloning Pods are wrenchable.

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -68,7 +68,7 @@
 	var/mob/living/carbon/occupant = null
 	var/obj/item/weapon/reagent_containers/glass/beaker = null
 	var/injector_cooldown = 150 //Used by attachment
-	machine_flags = SCREWTOGGLE | CROWDESTROY
+	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE
 	var/obj/machinery/computer/connected
 	var/last_message // Used by go_out()
 

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -31,7 +31,7 @@
 	var/output_dir //Which direction to try to place our patients onto, should they eject naturally.
 
 
-	machine_flags = EMAGGABLE | SCREWTOGGLE | CROWDESTROY | MULTITOOL_MENU
+	machine_flags = EMAGGABLE | SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | MULTITOOL_MENU
 
 	light_color = LIGHT_COLOR_CYAN
 	use_auto_lights = 1


### PR DESCRIPTION
You couldn't make these machines at RnD or Mechanics, since you couldn't move 'em to medbay. And if you opened the Mechanic's flatpack in the wrong place, you'd need to disassemble the machine and reassemble on the correct place. 

[tweak]
:cl:
 * tweak: You can now wrench and unwrench the DNA Scanners and Cloning Pods.