### PR TITLE
Added admin buttons allowing them to easily contact an entire faction or individual role

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1428,7 +1428,9 @@ var/proccalls = 1
 
 #define log_cultspeak(text) diary << html_decode("\[[time_stamp()]]CULT: [text]")
 
-#define log_narspeak(text) diary << html_decode("\[[time_stamp()]]NARSIE: [text]")
+#define log_factionspeak(text) diary << html_decode("\[[time_stamp()]]FACTIONBROADCAST: [text]")
+
+#define log_rolespeak(text) diary << html_decode("\[[time_stamp()]]ROLEMESSAGE: [text]")
 
 #define log_emote(text) diary << html_decode("\[[time_stamp()]]EMOTE: [text]")
 

--- a/code/datums/gamemode/factions/blob.dm
+++ b/code/datums/gamemode/factions/blob.dm
@@ -26,6 +26,8 @@
 
 	roletype = /datum/role/blob_overmind/cerebrate
 	late_role = BLOBCEREBRATE
+	default_admin_voice = "Overmind Hivemind"
+	admin_voice_style = "blob"
 
 	var/datum/station_state/start
 

--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -54,6 +54,9 @@ var/global/global_anchor_bloodstone // Keeps track of what stone becomes the anc
 	roletype = /datum/role/cultist
 	logo_state = "cult-logo"
 	hud_icons = list("cult-chief-logo", "cult-logo")
+	default_admin_voice = "<span class='danger'>Nar-Sie</span>" // Nar-Sie's name always appear in red in the chat, makes it stand out.
+	admin_voice_style = "sinister"
+	admin_voice_say = "murmurs..."
 	var/list/bloody_floors = list()
 	//var/target_change = FALSE
 	//var/change_cooldown = 0
@@ -84,25 +87,11 @@ var/global/global_anchor_bloodstone // Keeps track of what stone becomes the anc
 
 /datum/faction/bloodcult/AdminPanelEntry(var/datum/admins/A)
 	var/list/dat = ..()
-	dat += "<br><a href='?src=\ref[src];cult_mindspeak_global=1'>Voice of Nar-Sie</a>"
 	dat += "<br><a href='?src=\ref[src];cult_progress=1'>(debug) Cult Progression Skip</a>"
 	return dat
 
 /datum/faction/bloodcult/Topic(href, href_list)
 	..()
-	if (href_list["cult_mindspeak_global"])
-		var/message = input("What message shall we send?",
-                    "Voice of Nar-Sie",
-                    "")
-		for (var/datum/role/R in members)
-			if (R.antag?.current && R.antag.GetRole(CULTIST))//failsafe for cultist brains put in MMIs
-				to_chat(R.antag.current, "<span class='danger'>Nar-Sie</span> murmurs... <span class='sinister'>[message]</span>")
-
-		for(var/mob/dead/observer/O in player_list)
-			to_chat(O, "<span class='game say'><span class='danger'>Nar-Sie</span> murmurs, <span class='sinister'>[message]</span></span>")
-
-		message_admins("Admin [key_name_admin(usr)] has talked with the Voice of Nar-Sie.")
-		log_narspeak("[key_name(usr)] Voice of Nar-Sie: [message]")
 	if (href_list["cult_progress"])
 		if (alert(usr, "Skip to the next Act?","Cult Progression Skip","Yes","No") == "No")
 			return

--- a/code/datums/gamemode/factions/clockwork.dm
+++ b/code/datums/gamemode/factions/clockwork.dm
@@ -4,3 +4,5 @@
 	logo_state = "clockwork-logo"
 	hud_icons = list("clockwork-logo")
 	roletype = /datum/role/clockwork
+	default_admin_voice = "Ratvar"
+	admin_voice_style = "radio"

--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -44,6 +44,10 @@ var/list/factions_with_hud_icons = list()
 	var/list/faction_scoreboard_data = list()
 	var/stage = FACTION_DORMANT //role_datums_defines.dm
 	var/playlist
+	var/default_admin_voice = "Supreme Leader"
+	var/admin_voice_style = "radio" // check stylesheet.dm for a list of all possible styles
+	var/list/voice_per_admin = list()
+	var/admin_voice_say = "says"
 
 	var/minor_victory = FALSE
 
@@ -196,14 +200,49 @@ var/list/factions_with_hud_icons = list()
 
 /datum/faction/Topic(href, href_list)
 	..()
+	if(!usr.check_rights(R_ADMIN))
+		message_admins("[usr] tried to access faction Topic() without permissions.")
+		return
+
 	if(href_list["destroyfac"])
-		if(!usr.check_rights(R_ADMIN))
-			message_admins("[usr] tried to destroy a faction without permissions.")
-			return
 		if(alert(usr, "Are you sure you want to destroy [name]?",  "Destroy Faction" , "Yes" , "No") != "Yes")
 			return
 		message_admins("[key_name(usr)] destroyed faction [name].")
 		Dismantle()
+
+	if (!ismob(usr))
+		return
+	var/mob/user = usr
+
+	if (href_list["faction_speak"])
+		if (!(user.ckey in voice_per_admin))
+			voice_per_admin[user.ckey] = default_admin_voice
+
+		var/message = input("What message shall we send as [voice_per_admin[user.ckey]]?",
+                    "Faction Broadcast",
+                    "")
+		if (!message)
+			return
+		for (var/datum/role/R in members)
+			if (R.antag?.current)
+				to_chat(R.antag.current, "<b>[voice_per_admin[user.ckey]]</b> [admin_voice_say] <span class='[admin_voice_style]'>[message]</span>")
+
+		for(var/mob/dead/observer/O in player_list)
+			to_chat(O, "<span class='game say'><b>[voice_per_admin[user.ckey]]</b> [admin_voice_say] <span class='[admin_voice_style]'>[message]</span></span>")
+
+		message_admins("Admin [key_name_admin(usr)] has talked to [name] as [voice_per_admin[user.ckey]].")
+		log_factionspeak("[key_name(usr)] as [voice_per_admin[user.ckey]]: [message]")
+
+	if (href_list["faction_set_speaker"])
+		if (!(user.ckey in voice_per_admin))
+			voice_per_admin[user.ckey] = default_admin_voice
+
+		var/new_name = input("What should you call yourself when broadcasting to [name]?",
+                    "Change Broadcaster Name",
+                    "[voice_per_admin[user.ckey]]")
+		if (new_name)
+			voice_per_admin[user.ckey] = new_name
+		user.client.holder.check_antagonists()
 
 /datum/faction/proc/IsSuccessful()
 	var/win = TRUE
@@ -219,6 +258,9 @@ var/list/factions_with_hud_icons = list()
 	return header
 
 /datum/faction/proc/AdminPanelEntry(var/datum/admins/A)
+	var/mob/user = usr
+	if (!(user.ckey in voice_per_admin))
+		voice_per_admin[user.ckey] = default_admin_voice
 	var/dat = "<br>"
 	dat += GetObjectivesMenuHeader()
 	dat += " <a href='?src=\ref[src];destroyfac=1'>\[Destroy\]</A><br>"
@@ -231,6 +273,7 @@ var/list/factions_with_hud_icons = list()
 		for(var/datum/role/R in members)
 			dat += R.AdminPanelEntry()
 			dat += "<br>"
+	dat += "<br><a href='?src=\ref[src];faction_speak=1'>Message faction as:</a><a href='?src=\ref[src];faction_set_speaker=1'>\[[voice_per_admin[user.ckey]]\]:</a>"
 	return dat
 
 /datum/faction/proc/process()
@@ -407,6 +450,8 @@ var/list/factions_with_hud_icons = list()
 	or simply wandering malignant vagrants happening upon a meal of identity that can carry them to further feeding grounds."
 	roletype = /datum/role/changeling
 	logo_state = "change-logoa"
+	default_admin_voice = "Changeling Hivemind"
+	admin_voice_style = "borer"
 
 	//Hivemind Bank, contains a list of DNA that changelings can share and use.
 	var/list/hivemind_bank = list()
@@ -424,6 +469,8 @@ var/list/factions_with_hud_icons = list()
 	name = "Custom Strike Team"//obviously this name is a placeholder getting replaced by the admin setting up the squad
 	ID = CUSTOMSQUAD
 	logo_state = "nano-logo"
+	default_admin_voice = "Commander"
+	admin_voice_style = "secradio"
 
 /datum/faction/strike_team/forgeObjectives(var/mission)
 	var/datum/objective/custom/c = new /datum/objective/custom
@@ -439,6 +486,8 @@ var/list/factions_with_hud_icons = list()
 	roletype = /datum/role/emergency_responder
 	logo_state = "ert-logo"
 	hud_icons = list("ert-logo")
+	default_admin_voice = "Nanotrasen Central Command"
+	admin_voice_style = "resteamradio"
 
 //________________________________________________
 
@@ -449,6 +498,8 @@ var/list/factions_with_hud_icons = list()
 	roletype = /datum/role/death_commando
 	logo_state = "death-logo"
 	hud_icons = list("death-logo","creed-logo")
+	default_admin_voice = "Nanotrasen Central Command"
+	admin_voice_style = "dsquadradio"
 
 //________________________________________________
 
@@ -458,11 +509,15 @@ var/list/factions_with_hud_icons = list()
 	initroletype = /datum/role/syndicate_elite_commando
 	roletype = /datum/role/syndicate_elite_commando
 	logo_state = "elite-logo"
+	default_admin_voice = "The Syndicate"
+	admin_voice_style = "syndradio"
 
 //________________________________________________
 
 /datum/faction/strike_team/custom
 	name = "Custom Strike Team"
+	default_admin_voice = "Commander"
+	admin_voice_style = "secradio"
 
 /datum/faction/strike_team/custom/New()
 	..()

--- a/code/datums/gamemode/factions/junglefever.dm
+++ b/code/datums/gamemode/factions/junglefever.dm
@@ -5,7 +5,7 @@
 	name = MADMONKEY
 	ID = MADMONKEY
 	logo_state = "monkey-logo"
-	default_admin_voice = "big monkey in the sky"
+	default_admin_voice = "Monkey King"
 	admin_voice_style = "rough"
 
 	initroletype = /datum/role/madmonkey

--- a/code/datums/gamemode/factions/junglefever.dm
+++ b/code/datums/gamemode/factions/junglefever.dm
@@ -5,6 +5,8 @@
 	name = MADMONKEY
 	ID = MADMONKEY
 	logo_state = "monkey-logo"
+	default_admin_voice = "big monkey in the sky"
+	admin_voice_style = "rough"
 
 	initroletype = /datum/role/madmonkey
 	initial_role = MADMONKEY

--- a/code/datums/gamemode/factions/legacy_cult/cult.dm
+++ b/code/datums/gamemode/factions/legacy_cult/cult.dm
@@ -26,6 +26,8 @@ var/global/list/rnwords = list("ire","ego","nahlizet","certum","veri","jatkaa","
 	From his teachings, they were granted the ability to perform blood magic rituals allowing them to fight and grow their ranks, and given the goal of pushing his agenda.\
 	Nar-Sie's ultimate goal is to tear open a breach through reality so he can pull the station into his realm and feast on the crew's blood and souls."
 	deity_name = "Nar-Sie"
+	default_admin_voice = "<span class='danger'>Nar-Sie</span>" // Nar-Sie's name always appear in red in the chat, makes it stand out.
+	admin_voice_style = "sinister"
 	var/list/allwords = list("travel","self","see","hell","blood","join","tech","destroy", "other", "hide")
 	var/list/startwords = list("blood","join","self","hell")
 	var/list/bloody_floors = list()

--- a/code/datums/gamemode/factions/malf.dm
+++ b/code/datums/gamemode/factions/malf.dm
@@ -10,6 +10,8 @@
 	initroletype = /datum/role/malfAI //First addition should be the AI
 	roletype = /datum/role/malfbot //Then anyone else should be bots
 	logo_state = "malf-logo"
+	default_admin_voice = "01100111 01101111 01100100" // god
+	admin_voice_style = "siliconsay"
 	var/apcs = 0
 	var/AI_win_timeleft = 1800
 	playlist = "malfdelta"

--- a/code/datums/gamemode/factions/plague_mice.dm
+++ b/code/datums/gamemode/factions/plague_mice.dm
@@ -10,6 +10,8 @@
 
 	roletype = /datum/role/plague_mouse
 	late_role = PLAGUEMOUSE
+	default_admin_voice = "Big Rat"
+	admin_voice_style = "skeleton" // grey, bold and italic
 
 	var/diseaseID = ""
 	var/datum/disease2/disease/bacteria/plague

--- a/code/datums/gamemode/factions/spider_clan.dm
+++ b/code/datums/gamemode/factions/spider_clan.dm
@@ -7,6 +7,8 @@
 	late_role = NINJA
 	roletype = /datum/role/ninja
 	initroletype = /datum/role/ninja
+	default_admin_voice = "Spider Clan"
+	admin_voice_style = "bold"
 	logo_state = "ninja-logo"
 	hud_icons = list("ninja-logo")
 

--- a/code/datums/gamemode/factions/spider_infestation.dm
+++ b/code/datums/gamemode/factions/spider_infestation.dm
@@ -2,6 +2,8 @@
 /datum/faction/spider_infestation
 	name = SPIDERINFESTATION
 	ID = SPIDERINFESTATION
+	default_admin_voice = "Your Spider Senses"
+	admin_voice_style = "skeleton"
 	logo_state = "spider-logo"
 	hud_icons = list("spider-logo")
 

--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -11,6 +11,8 @@
 	logo_state = "nuke-logo"
 	hud_icons = list("nuke-logo","nuke-logo-leader")
 	playlist = "nukesquad"
+	default_admin_voice = "The Syndicate"
+	admin_voice_style = "syndradio"
 
 	var/datum/outfit/striketeam/nukeops/our_outfit = /datum/outfit/striketeam/nukeops
 

--- a/code/datums/gamemode/factions/syndicate/rev.dm
+++ b/code/datums/gamemode/factions/syndicate/rev.dm
@@ -12,7 +12,7 @@
 	initroletype = /datum/role/revolutionary/leader
 	roletype = /datum/role/revolutionary
 	playlist = "nukesquad"
-	default_admin_voice = "The spirit of Revolution!"
+	default_admin_voice = "Union Boss"
 	admin_voice_style = "secradio"
 	var/discovered = 0
 

--- a/code/datums/gamemode/factions/syndicate/rev.dm
+++ b/code/datums/gamemode/factions/syndicate/rev.dm
@@ -12,6 +12,8 @@
 	initroletype = /datum/role/revolutionary/leader
 	roletype = /datum/role/revolutionary
 	playlist = "nukesquad"
+	default_admin_voice = "The spirit of Revolution!"
+	admin_voice_style = "secradio"
 	var/discovered = 0
 
 /datum/faction/revolution/HandleRecruitedMind(var/datum/mind/M)

--- a/code/datums/gamemode/factions/syndicate/traitor.dm
+++ b/code/datums/gamemode/factions/syndicate/traitor.dm
@@ -4,6 +4,8 @@
 	required_pref = TRAITOR
 	desc = "A coalition of companies that actively work against Nanotrasen's intentions. Seen as Freedom fighters by some, Rebels and Malcontents by others."
 	logo_state = "synd-logo"
+	default_admin_voice = "The Syndicate"
+	admin_voice_style = "syndradio"
 
 //________________________________________________
 

--- a/code/datums/gamemode/factions/time_agency.dm
+++ b/code/datums/gamemode/factions/time_agency.dm
@@ -9,6 +9,8 @@
 	initroletype = /datum/role/time_agent
 	logo_state = "time-logo"
 	hud_icons = list("time-logo")
+	default_admin_voice = "The Agency"
+	admin_voice_style = "notice"
 	var/datum/role/time_agent/primary_agent = null // first added is primary, any others added are doppelgangers.
 	var/list/eviltwins = list()
 

--- a/code/datums/gamemode/factions/vampire_faction.dm
+++ b/code/datums/gamemode/factions/vampire_faction.dm
@@ -7,6 +7,8 @@
 	late_role = VAMPIRE // Vampires do not change their role.
 	roletype = /datum/role/vampire
 	initroletype = /datum/role/vampire
+	default_admin_voice = "Vampire Overlord"
+	admin_voice_style = "danger"
 	logo_state = "vampire-logo"
 	hud_icons = list("vampire-logo", "thrall-logo")
 

--- a/code/datums/gamemode/factions/vox_shoal.dm
+++ b/code/datums/gamemode/factions/vox_shoal.dm
@@ -56,6 +56,8 @@ var/list/potential_bonus_items = list(
 	initroletype = /datum/role/vox_raider
 	logo_state = "vox-logo"
 	hud_icons = list("vox-logo")
+	default_admin_voice = "Vox Shoal"
+	admin_voice_style = "vox"
 
 	var/time_left = (60 MINUTES)/10
 	var/completed = FALSE

--- a/code/datums/gamemode/factions/wizard.dm
+++ b/code/datums/gamemode/factions/wizard.dm
@@ -11,6 +11,8 @@
 	roletype = /datum/role/wizard
 	logo_state = "wizard-logo"
 	hud_icons = list("wizard-logo","apprentice-logo")
+	default_admin_voice = "Wizard Federation"
+	admin_voice_style = "notice"
 
 /datum/faction/wizard/civilwar
 	var/enemy_faction

--- a/code/datums/gamemode/factions/wizard_apprenticeship.dm
+++ b/code/datums/gamemode/factions/wizard_apprenticeship.dm
@@ -7,6 +7,8 @@
 	roletype = /datum/role/wizard_apprentice
 	logo_state = "apprentice-logo"
 	hud_icons = list("wizard-logo", "apprentice-logo")
+	default_admin_voice = "Wizard Federation"
+	admin_voice_style = "notice"
 
 /datum/faction/wizard_contract/HandleNewMind(var/datum/mind/M)
 	. = ..()

--- a/code/datums/gamemode/factions/xenomorph.dm
+++ b/code/datums/gamemode/factions/xenomorph.dm
@@ -17,6 +17,8 @@
 	initroletype = /datum/role/xenomorph
 	roletype = /datum/role/xenomorph
 	playlist = "endgame"
+	default_admin_voice = "Alien Hivemind"
+	admin_voice_style = "alien"
 	var/squad_sent = FALSE
 	var/announceWhen = 0
 
@@ -48,16 +50,16 @@
 		var/living_humans = FALSE
 		for(var/mob/living/carbon/human/M in mob_list)
 			if(!M.mind || M.stat == DEAD)
-				continue 
+				continue
 			var/turf/T = get_turf(M)
 			if(!(T.z == STATION_Z || T.z == CENTCOMM_Z))
-				continue 
+				continue
 			living_humans = TRUE
 			break
 		if(!living_humans)
 			return win(HUMANS_WIPED_OUT)
 
-	
+
 */
 /datum/faction/xenomorph/process()
 	if(world.time >= announceWhen && stage < FACTION_ACTIVE)
@@ -87,14 +89,14 @@
 				livingcrew++
 
 
-		
+
 	var/xeno_to_living_ratio = 0
 	if(livingcrew > 0)
 		xeno_to_living_ratio = livingxenos / livingcrew
 
 
 
-	//Alert the crew once the xenos grow past four. 
+	//Alert the crew once the xenos grow past four.
 	if (stage < FACTION_ACTIVE)
 		if(livingxenos > ACTIVE_XENO)
 			stage(FACTION_ACTIVE)
@@ -218,10 +220,10 @@
 
 
 */
-#undef ACTIVE_XENO	
-#undef QUARANTINE_RATIO 
-#undef XENO_ENDGAME_RATIO 
-#undef DEATHSQUAD_RATIO 
+#undef ACTIVE_XENO
+#undef QUARANTINE_RATIO
+#undef XENO_ENDGAME_RATIO
+#undef DEATHSQUAD_RATIO
 
-#undef XENO_STATION_WAS_NUKED 
-#undef HUMANS_WIPED_OUT 
+#undef XENO_STATION_WAS_NUKED
+#undef HUMANS_WIPED_OUT

--- a/code/datums/gamemode/role/alien.dm
+++ b/code/datums/gamemode/role/alien.dm
@@ -5,5 +5,7 @@
 	required_pref = ROLE_ALIEN
 	wikiroute = ROLE_ALIEN
 	logo_state = "xeno-logo"
+	default_admin_voice = "Alien Hivemind"
+	admin_voice_style = "alien"
 
 	stat_datum_type = /datum/stat/role/xenomorph

--- a/code/datums/gamemode/role/blob.dm
+++ b/code/datums/gamemode/role/blob.dm
@@ -4,6 +4,8 @@
 	required_pref = BLOBOVERMIND
 	logo_state = "blob-logo"
 	greets = list(GREET_DEFAULT,GREET_CUSTOM)
+	default_admin_voice = "Overmind Hivemind"
+	admin_voice_style = "blob"
 	var/countdown = 60
 
 /datum/role/blob_overmind/cerebrate

--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -5,6 +5,8 @@
 	required_pref = ROLE_MINOR
 	wikiroute = ROLE_MINOR
 	logo_state = "catbeast-logo"
+	default_admin_voice = "Kingston"
+	admin_voice_style = "tajaran"
 	var/ticks_survived = 0
 	var/list/areas_defiled = list()
 	var/current_disease_tier = 1

--- a/code/datums/gamemode/role/changeling.dm
+++ b/code/datums/gamemode/role/changeling.dm
@@ -6,6 +6,8 @@
 						"Chief Engineer", "Chief Medical Officer", "Research Director")
 	protected_traitor_prob = PROB_PROTECTED_RARE
 	logo_state = "change-logoa"
+	default_admin_voice = "Changeling Hivemind"
+	admin_voice_style = "borer"
 	var/list/absorbed_dna = list()
 	var/list/absorbed_species = list()
 	var/list/absorbed_languages = list()

--- a/code/datums/gamemode/role/clockwork.dm
+++ b/code/datums/gamemode/role/clockwork.dm
@@ -1,5 +1,7 @@
 /datum/role/clockwork
 	logo_state = "clockwork-logo"
+	default_admin_voice = "Ratvar"
+	admin_voice_style = "radio"
 
 /datum/role/clockwork/gravekeeper
 	name = "clockwork gravekeeper"

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -7,6 +7,9 @@
 						"Internal Affairs Agent", "Merchant")
 	logo_state = "cult-logo"
 	greets = list(GREET_DEFAULT,GREET_CUSTOM,GREET_ROUNDSTART,GREET_ADMINTOGGLE)
+	default_admin_voice = "<span class='danger'>Nar-Sie</span>" // Nar-Sie's name always appear in red in the chat, makes it stand out.
+	admin_voice_style = "sinister"
+	admin_voice_say = "murmurs..."
 	var/list/tattoos = list()
 	var/holywarning_cooldown = 0
 	var/list/conversion = list()
@@ -249,11 +252,6 @@
 			return 1
 	return 0
 
-/datum/role/cultist/AdminPanelEntry(var/show_logo = FALSE,var/datum/admins/A)
-	var/dat = ..()
-	dat += " - <a href='?src=\ref[src]&mind=\ref[antag]&cult_privatespeak=\ref[antag.current]'>(Nar-Sie whispers)</a>"
-	return dat
-
 /datum/role/cultist/handle_reagent(var/reagent_id)
 	var/mob/living/carbon/human/H = antag.current
 	if (!istype(H))
@@ -395,21 +393,6 @@
 						H.confused = 6
 					H.adjustOxyLoss(20)
 					H.adjustToxLoss(10)
-
-/datum/role/cultist/RoleTopic(href, href_list, var/datum/mind/M, var/admin_auth)
-	if (href_list["cult_privatespeak"])
-		var/message = input("What message shall we send?",
-                    "Voice of Nar-Sie",
-                    "")
-		var/mob/mob = M.current
-		if (mob)
-			to_chat(mob, "<span class='danger'>Nar-Sie</span> murmurs to you... <span class='sinister'>[message]</span>")
-
-			for(var/mob/dead/observer/O in player_list)
-				to_chat(O, "<span class='game say'><span class='danger'>Nar-Sie</span> whispers to [mob.real_name], <span class='sinister'>[message]</span></span>")
-
-			message_admins("Admin [key_name_admin(usr)] has talked with the Voice of Nar-Sie.")
-			log_narspeak("[key_name(usr)] Voice of Nar-Sie (privately to [mob.real_name]): [message]")
 
 /datum/role/cultist/chief
 	id = CHIEF_CULTIST

--- a/code/datums/gamemode/role/giant_spider.dm
+++ b/code/datums/gamemode/role/giant_spider.dm
@@ -7,6 +7,8 @@
 	wikiroute = ROLE_MINOR
 	logo_state = "spider-logo"
 	greets = list(GREET_DEFAULT)
+	default_admin_voice = "Your Spider Senses"
+	admin_voice_style = "skeleton"
 
 datum/role/giant_spider/Greet(var/greeting,var/custom)
 	if(!greeting)

--- a/code/datums/gamemode/role/grinch.dm
+++ b/code/datums/gamemode/role/grinch.dm
@@ -1,12 +1,14 @@
 /datum/role/grinch
-    name = GRINCH
-    id = GRINCH
-    required_pref = GRINCH
-    logo_state = "synd-logo"
-    disallow_job = TRUE
+	name = GRINCH
+	id = GRINCH
+	required_pref = GRINCH
+	logo_state = "synd-logo"
+	disallow_job = TRUE
+	default_admin_voice = "Santa Claus"
+	admin_voice_style = "danger"
 
-    // -- Our bag
-    var/obj/item/weapon/storage/backpack/holding/grinch/our_bag = null
+	// -- Our bag
+	var/obj/item/weapon/storage/backpack/holding/grinch/our_bag = null
 
 // -- Transforms us into the devlish Grinch
 /datum/role/grinch/OnPostSetup(var/laterole = FALSE)

--- a/code/datums/gamemode/role/legacy_cultist.dm
+++ b/code/datums/gamemode/role/legacy_cultist.dm
@@ -7,6 +7,8 @@
 	logo_state = "cult-logo"
 	greets = list("default","custom","admintoggle")
 	required_pref = CULTIST
+	default_admin_voice = "<span class='danger'>Nar-Sie</span>" // Nar-Sie's name always appear in red in the chat, makes it stand out.
+	admin_voice_style = "sinister"
 
 /datum/role/legacy_cultist/OnPostSetup(var/equip = FALSE)
 	. = ..()

--- a/code/datums/gamemode/role/madmonkey.dm
+++ b/code/datums/gamemode/role/madmonkey.dm
@@ -33,7 +33,7 @@
 	special_role = MADMONKEY
 	logo_state = "monkey-logo"
 	greets = list(GREET_MASTER,GREET_DEFAULT,GREET_CUSTOM)
-	default_admin_voice = "big monkey in the sky"
+	default_admin_voice = "Monkey King"
 	admin_voice_style = "rough"
 	var/countdown = 60
 

--- a/code/datums/gamemode/role/madmonkey.dm
+++ b/code/datums/gamemode/role/madmonkey.dm
@@ -33,6 +33,8 @@
 	special_role = MADMONKEY
 	logo_state = "monkey-logo"
 	greets = list(GREET_MASTER,GREET_DEFAULT,GREET_CUSTOM)
+	default_admin_voice = "big monkey in the sky"
+	admin_voice_style = "rough"
 	var/countdown = 60
 
 datum/role/madmonkey/Greet(var/greeting,var/custom)

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -10,6 +10,8 @@
 	disallow_job = TRUE
 	restricted_jobs = list()
 	greets = list(GREET_DEFAULT,GREET_WEEB,GREET_CUSTOM)
+	default_admin_voice = "Spider Clan"
+	admin_voice_style = "bold"
 
 	stat_datum_type = /datum/stat/role/ninja
 
@@ -65,6 +67,7 @@
 	return dat
 
 /datum/role/ninja/RoleTopic(href, href_list, var/datum/mind/M, var/admin_auth)
+	..()
 	if(href_list["toggleweeb"])
 		if(href_list["toggleweeb"]=="ninja")
 			equip_ninja(antag.current)

--- a/code/datums/gamemode/role/plague_mouse.dm
+++ b/code/datums/gamemode/role/plague_mouse.dm
@@ -7,6 +7,8 @@
 	wikiroute = ROLE_MINOR
 	logo_state = "plague-logo"
 	greets = list(GREET_DEFAULT)
+	default_admin_voice = "Big Rat"
+	admin_voice_style = "skeleton" // grey, bold and italic
 
 datum/role/plague_mouse/Greet(var/greeting,var/custom)
 	if(!greeting)

--- a/code/datums/gamemode/role/prisoner.dm
+++ b/code/datums/gamemode/role/prisoner.dm
@@ -8,6 +8,8 @@
 	required_pref = ROLE_MINOR
 	wikiroute = ROLE_MINOR
 	logo_state = "prisoner-logo"
+	default_admin_voice = "The Syndicate"
+	admin_voice_style = "secradio"
 
 	var/moneyBonus = 100
 

--- a/code/datums/gamemode/role/rambler.dm
+++ b/code/datums/gamemode/role/rambler.dm
@@ -5,6 +5,8 @@
 	special_role = RAMBLER
 	logo_state = "rambler-logo"
 	wikiroute = ROLE_MINOR
+	default_admin_voice = "Xavier"
+	admin_voice_style = "rose"
 	var/remaining_vows = 3
 
 /datum/role/rambler/OnPostSetup(var/laterole = FALSE)

--- a/code/datums/gamemode/role/rambler.dm
+++ b/code/datums/gamemode/role/rambler.dm
@@ -5,7 +5,7 @@
 	special_role = RAMBLER
 	logo_state = "rambler-logo"
 	wikiroute = ROLE_MINOR
-	default_admin_voice = "Xavier"
+	default_admin_voice = "Chief Master Guru"
 	admin_voice_style = "rose"
 	var/remaining_vows = 3
 

--- a/code/datums/gamemode/role/rev.dm
+++ b/code/datums/gamemode/role/rev.dm
@@ -5,7 +5,7 @@
 	restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg","Mobile MMI","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer", "Internal Affairs Agent")
 	logo_state = "rev-logo"
 	greets = list(GREET_DEFAULT,GREET_CUSTOM,GREET_ROUNDSTART,GREET_MIDROUND,GREET_LATEJOIN,GREET_CONVERTED,GREET_PROVOC_CONVERTED,GREET_REVSQUAD_CONVERTED,GREET_ADMINTOGGLE)
-	default_admin_voice = "The spirit of Revolution!"
+	default_admin_voice = "Union Boss"
 	admin_voice_style = "secradio"
 
 // The ticker current state check is because revs are created, at roundstart, in the cuck cube.

--- a/code/datums/gamemode/role/rev.dm
+++ b/code/datums/gamemode/role/rev.dm
@@ -5,6 +5,8 @@
 	restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg","Mobile MMI","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer", "Internal Affairs Agent")
 	logo_state = "rev-logo"
 	greets = list(GREET_DEFAULT,GREET_CUSTOM,GREET_ROUNDSTART,GREET_MIDROUND,GREET_LATEJOIN,GREET_CONVERTED,GREET_PROVOC_CONVERTED,GREET_REVSQUAD_CONVERTED,GREET_ADMINTOGGLE)
+	default_admin_voice = "The spirit of Revolution!"
+	admin_voice_style = "secradio"
 
 // The ticker current state check is because revs are created, at roundstart, in the cuck cube.
 // Which is outside the z-level of the main station.

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -103,6 +103,11 @@
 
 	var/icon/logo_state = "synd-logo"
 
+	var/default_admin_voice = "Supreme Leader"
+	var/admin_voice_style = "radio" // check stylesheet.dm for a list of all possible styles
+	var/list/voice_per_admin = list()
+	var/admin_voice_say = "says"
+
 	var/list/greets = list(GREET_DEFAULT,GREET_CUSTOM)
 
 	var/wikiroute
@@ -284,17 +289,24 @@
 	var/icon/logo = icon('icons/logos.dmi', logo_state)
 	if(!antag || !antag.current)
 		return
+	if (!ismob(usr))
+		return
+	var/mob/user = usr
+	if (!(user.ckey in voice_per_admin))
+		voice_per_admin[user.ckey] = default_admin_voice
 	var/mob/M = antag.current
 	if (M)
 		return {"[show_logo ? "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> " : "" ]
 	[name] <a href='?_src_=holder;adminplayeropts=\ref[M]'>[M.real_name]/[M.key]</a>[M.client ? "" : " <i> - (logged out)</i>"][M.stat == DEAD ? " <b><font color=red> - (DEAD)</font></b>" : ""]
-	 - <a href='?src=\ref[usr];priv_msg=\ref[M]'>(priv msg)</a>
-	 - <a href='?_src_=holder;traitor=\ref[M]'>(role panel)</a>"}
+	 - <a href='?src=\ref[usr];priv_msg=\ref[M]'>(admin PM)</a>
+	 - <a href='?_src_=holder;traitor=\ref[M]'>(role panel)</a>
+	 - <a href='?src=\ref[src]&mind=\ref[antag]&role_speak=\ref[M]'>(Message as:</a><a href='?src=\ref[src]&mind=\ref[antag]&role_set_speaker=\ref[M]'>\[[voice_per_admin[user.ckey]]\])</a>"}
 	else
 		return {"[show_logo ? "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> " : "" ]
 	[name] [antag.name]/[antag.key]<b><font color=red> - (DESTROYED)</font></b>
 	 - <a href='?src=\ref[usr];priv_msg=\ref[M]'>(priv msg)</a>
-	 - <a href='?_src_=holder;traitor=\ref[M]'>(role panel)</a>"}
+	 - <a href='?_src_=holder;traitor=\ref[M]'>(role panel)</a>
+	 - <a href='?src=\ref[src]&mind=\ref[antag]&role_speak=\ref[M]'>(Message as:</a><a href='?src=\ref[src]&mind=\ref[antag]&role_set_speaker=\ref[M]'>\[[voice_per_admin[user.ckey]]\])</a>"}
 
 
 /datum/role/proc/Greet(var/greeting,var/custom)
@@ -477,6 +489,50 @@
 
 // USE THIS INSTEAD (global)
 /datum/role/proc/RoleTopic(href, href_list, var/datum/mind/M, var/admin_auth)
+	if (!ismob(usr))
+		return
+	var/mob/user = usr
+
+	if (href_list["role_speak"])
+		if(!usr.check_rights(R_ADMIN))
+			message_admins("[usr] tried to access RoleTopic() without permissions.")
+			return
+		if (!(user.ckey in voice_per_admin))
+			voice_per_admin[user.ckey] = default_admin_voice
+
+		var/message = input("What message shall we send as [voice_per_admin[user.ckey]]?",
+                    "Role Message",
+                    "")
+		if (!message)
+			return
+
+		var/mob/mob = M.current
+
+		if (mob)
+			to_chat(mob, "<b>[voice_per_admin[user.ckey]]</b> [admin_voice_say] <span class='[admin_voice_style]'>[message]</span>")
+
+		for(var/mob/dead/observer/O in player_list)
+			to_chat(O, "<span class='game say'><b>[voice_per_admin[user.ckey]]</b> [admin_voice_say] <span class='[admin_voice_style]'>[message]</span></span>")
+
+		message_admins("Admin [key_name_admin(usr)] has talked to [key_name(mob)] as [voice_per_admin[user.ckey]].")
+		log_rolespeak("[key_name(usr)] as [voice_per_admin[user.ckey]] to [key_name(mob)]: [message]")
+
+	if (href_list["role_set_speaker"])
+		if(!usr.check_rights(R_ADMIN))
+			message_admins("[usr] tried to access faction RoleTopic() without permissions.")
+			return
+		if (!(user.ckey in voice_per_admin))
+			voice_per_admin[user.ckey] = default_admin_voice
+
+		var/mob/mob = M.current
+
+		if (mob)
+			var/new_name = input("What should you call yourself when messaging [mob]?",
+	                    "Change Messager Name",
+	                    "[voice_per_admin[user.ckey]]")
+			if (new_name)
+				voice_per_admin[user.ckey] = new_name
+		user.client.holder.check_antagonists()
 
 /datum/role/proc/ShuttleDocked(state)
 	if(objectives.objectives.len)

--- a/code/datums/gamemode/role/streamer.dm
+++ b/code/datums/gamemode/role/streamer.dm
@@ -3,6 +3,8 @@
 	name = STREAMER
 	logo_state = "streamer-logo"
 	greets = list(GREET_DEFAULT, GREET_CUSTOM)
+	default_admin_voice = "PewDiePie"
+	admin_voice_style = "djradio"
 
 	var/list/followers = list()
 	var/list/subscribers = list()

--- a/code/datums/gamemode/role/summonsurvivors.dm
+++ b/code/datums/gamemode/role/summonsurvivors.dm
@@ -6,6 +6,8 @@
 	id = SURVIVOR
 	name = SURVIVOR
 	logo_state = "gun-logo"
+	default_admin_voice = "Common Sense"
+	admin_voice_style = "warning"
 	var/survivor_type = "survivor"
 	var/summons_received
 

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -4,6 +4,8 @@
 	required_pref = TRAITOR
 	logo_state = "synd-logo"
 	wikiroute = TRAITOR
+	default_admin_voice = "The Syndicate"
+	admin_voice_style = "syndradio"
 	var/can_be_smooth = TRUE //Survivors can't be smooth because they get nothing.
 	var/obj/item/device/uplink/hidden/uplink//so we keep track of where the uplink they spawn with ends up
 
@@ -88,6 +90,7 @@
 	return dat
 
 /datum/role/traitor/RoleTopic(href, href_list, var/datum/mind/M, var/admin_auth)
+	..()
 	if(href_list["giveuplink"])
 		equip_traitor(antag.current, 20, src)
 	if(href_list["telecrystalsSet"])
@@ -201,6 +204,8 @@
 	required_pref = NUKE_OP
 	disallow_job = TRUE
 	logo_state = "nuke-logo"
+	default_admin_voice = "The Syndicate"
+	admin_voice_style = "syndradio"
 
 /datum/role/nuclear_operative/leader
 	name = NUKE_OP_LEADER

--- a/code/datums/gamemode/role/time_agent.dm
+++ b/code/datums/gamemode/role/time_agent.dm
@@ -16,6 +16,8 @@
 	id = TIMEAGENT
 	required_pref = TIMEAGENT
 	logo_state = "time-logo"
+	default_admin_voice = "The Agency"
+	admin_voice_style = "notice"
 	var/list/objects_to_delete = list()
 	var/time_elapsed = 0
 	var/action_timer = 60

--- a/code/datums/gamemode/role/timeagenttwin.dm
+++ b/code/datums/gamemode/role/timeagenttwin.dm
@@ -10,6 +10,8 @@
 	id = TIMEAGENTTWIN
 	var/datum/role/time_agent/erase_target = null
 	is_twin = TRUE
+	default_admin_voice = "The Agency"
+	admin_voice_style = "notice"
 
 
 /datum/role/time_agent/eviltwin/Greet(var/greeting,var/custom)

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -14,6 +14,8 @@
 	greets = list(GREET_DEFAULT,GREET_CUSTOM,GREET_ADMINTOGGLE, GREET_MASTER)
 	required_pref = VAMPIRE
 	protected_traitor_prob = PROB_PROTECTED_RARE
+	default_admin_voice = "Vampire Overlord"
+	admin_voice_style = "danger"
 
 	var/ismenacing = FALSE
 	var/iscloaking = FALSE
@@ -95,19 +97,12 @@
 	..()
 
 /datum/role/vampire/AdminPanelEntry(var/show_logo = FALSE,var/datum/admins/A)
-	var/icon/logo = icon('icons/logos.dmi', logo_state)
-	var/mob/M = antag.current
-	var/text
-	if (!M) // Body destroyed
-		text = "[antag.name]/[antag.key] (BODY DESTROYED)"
-	else
-		text = {"[show_logo ? "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> " : "" ]
-[name] <a href='?_src_=holder;adminplayeropts=\ref[M]'>[key_name(M)]</a>[M.client ? "" : " <i> - (logged out)</i>"][M.stat == DEAD ? " <b><font color=red> - (DEAD)</font></b>" : ""]
- - <a href='?src=\ref[usr];priv_msg=\ref[M]'>(priv msg)</a>
- - <a href='?_src_=holder;traitor=\ref[M]'>(role panel)</a> - <a href='?src=\ref[src]&mind=\ref[antag]&giveblood=1'>Give blood</a>"}
-	return text
+	var/dat = ..()
+	dat += "  - <a href='?_src_=holder;traitor=\ref[M]'>(role panel)</a> - <a href='?src=\ref[src]&mind=\ref[antag]&giveblood=1'>Give blood</a>"
+	return dat
 
 /datum/role/vampire/RoleTopic(href, href_list, var/datum/mind/M, var/admin_auth)
+	..()
 	if (!usr.client.holder)
 		return FALSE
 	if (href_list["giveblood"])

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -98,7 +98,7 @@
 
 /datum/role/vampire/AdminPanelEntry(var/show_logo = FALSE,var/datum/admins/A)
 	var/dat = ..()
-	dat += "  - <a href='?_src_=holder;traitor=\ref[M]'>(role panel)</a> - <a href='?src=\ref[src]&mind=\ref[antag]&giveblood=1'>Give blood</a>"
+	dat += "  - <a href='?src=\ref[src]&mind=\ref[antag]&giveblood=1'>Give blood</a>"
 	return dat
 
 /datum/role/vampire/RoleTopic(href, href_list, var/datum/mind/M, var/admin_auth)

--- a/code/datums/gamemode/role/vox_raider.dm
+++ b/code/datums/gamemode/role/vox_raider.dm
@@ -5,6 +5,8 @@
 	required_pref = VOXRAIDER
 	disallow_job = TRUE
 	logo_state = "vox-logo"
+	default_admin_voice = "Vox Shoal"
+	admin_voice_style = "vox"
 
 /datum/role/vox_raider/OnPostSetup()
 	.=..()

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -6,6 +6,8 @@
 	disallow_job = TRUE
 	logo_state = "wizard-logo"
 	greets = list(GREET_CUSTOM,GREET_ROUNDSTART,GREET_MIDROUND)
+	default_admin_voice = "Wizard Federation"
+	admin_voice_style = "notice"
 
 	stat_datum_type = /datum/stat/role/wizard
 

--- a/code/datums/gamemode/role/wizard_apprentice.dm
+++ b/code/datums/gamemode/role/wizard_apprentice.dm
@@ -3,6 +3,8 @@
 	id = WIZAPP_MASTER
 	disallow_job = TRUE
 	logo_state = "wizard-logo"
+	default_admin_voice = "Wizard Federation"
+	admin_voice_style = "notice"
 
 /datum/role/wizard_apprentice
 	name = "wizard's apprentice"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2613,52 +2613,6 @@
 				message_admins("[key_name(usr)] attempted to set an unknown timer to 0.")
 		check_antagonists()
 
-	/*
-	else if(href_list["cult_nextobj"])
-		if(alert(usr, "Validate the current Cult objective and unlock the next one?", "Cult Cheat Code", "Yes", "No") != "Yes")
-			return
-
-		var/datum/game_mode/cult/cult_round = find_active_mode("cult")
-		if(!cult_round)
-			alert("Couldn't locate cult mode datum! This shouldn't ever happen, tell a coder!")
-			return
-
-		cult_round.bypass_phase()
-		message_admins("Admin [key_name_admin(usr)] has unlocked the Cult's next objective.")
-		log_admin("Admin [key_name_admin(usr)] has unlocked the Cult's next objective.")
-		check_antagonists()
-
-	else if(href_list["cult_mindspeak"])
-		var/input = stripped_input(usr, "Communicate to all the cultists with the voice of Nar-Sie", "Voice of Nar-Sie", "")
-		if(!input)
-			return
-
-		for(var/datum/mind/H in ticker.mode.cult)
-			if (H.current)
-				to_chat(H.current, "<span class='game say'><span class='danger'>Nar-Sie</span> murmurs, <span class='sinister'>[input]</span></span>")
-
-		for(var/mob/dead/observer/O in player_list)
-			to_chat(O, "<span class='game say'><span class='danger'>Nar-Sie</span> murmurs, <span class='sinister'>[input]</span></span>")
-
-		message_admins("Admin [key_name_admin(usr)] has talked with the Voice of Nar-Sie.")
-		log_narspeak("[key_name(usr)] Voice of Nar-Sie: [input]")
-
-	else if(href_list["cult_privatespeak"])
-		var/mob/M = locate(href_list["cult_privatespeak"])
-		if(!M)
-			return
-
-		var/input = stripped_input(usr, "Whisper to [M.real_name] with the voice of Nar-Sie", "Voice of Nar-Sie", "")
-		if(!input)
-			return
-
-		to_chat(M, "<span class='game say'><span class='danger'>Nar-Sie</span> whispers to you, <span class='sinister'>[input]</span></span>")
-
-		for(var/mob/dead/observer/O in player_list)
-			to_chat(O, "<span class='game say'><span class='danger'>Nar-Sie</span> whispers to [M.real_name], <span class='sinister'>[input]</span></span>")
-
-		message_admins("Admin [key_name_admin(usr)] has talked with the Voice of Nar-Sie.")
-	*/
 	else if(href_list["adminplayerobservecoodjump"])
 		if(!check_rights(R_ADMIN))
 			return


### PR DESCRIPTION
Fixes #30260

:cl:
* rscadd: Added admin buttons allowing them to easily contact an entire faction or individual role. Similarly to how they could already contact cultists as Nar-Sie (basically this feature has been expanded to all factions and roles). Admins can also set the name they use if they wish to use one different from the default.