### PR TITLE
Turned zombies are now referred to as looking quite fresh, instead of quite human

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -395,7 +395,7 @@
 	icon_state = "zombie_turned" //Looks almost not unlike just a naked guy to potentially catch others off guard
 	icon_living = "zombie_turned"
 	icon_dead = "zombie_turned"
-	desc = "A reanimated corpse that looks like it has seen better days. This one still appears quite human."
+	desc = "A reanimated corpse that looks like it has seen better days. This one still appears quite fresh."
 	maxHealth = 50
 	health = 50
 	can_evolve = TRUE


### PR DESCRIPTION
Fixes #28907

:cl:
* bugfix: Turned zombies are now referred to as looking quite fresh, instead of quite human. (turingwept)