### PR TITLE
Fixed a rare bug where breaking tape would send you to nullspace

### DIFF
--- a/code/game/objects/items/policetape.dm
+++ b/code/game/objects/items/policetape.dm
@@ -167,14 +167,14 @@
 /obj/item/tape/blocks_doors()
 	return TRUE
 
-/obj/item/tape/Bumped(M as mob)
-	if(src.allowed(M))
+/obj/item/tape/Bumped(var/atom/movable/AM)
+	if(allowed(AM))
 		var/turf/T = get_turf(src)
 		for(var/atom/A in T) //Check to see if there's anything solid on the tape's turf (it's possible to build on it)
 			if(A.density)
 				return
-		if (T) // no sending mobs into nullspace!
-			M:forceMove(T)
+		if (T) // no sending things into nullspace!
+			AM.forceMove(T)
 
 /obj/item/tape/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 	if(!density)

--- a/code/game/objects/items/policetape.dm
+++ b/code/game/objects/items/policetape.dm
@@ -173,7 +173,8 @@
 		for(var/atom/A in T) //Check to see if there's anything solid on the tape's turf (it's possible to build on it)
 			if(A.density)
 				return
-		M:forceMove(T)
+		if (T) // no sending mobs into nullspace!
+			M:forceMove(T)
 
 /obj/item/tape/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 	if(!density)


### PR DESCRIPTION
Fixes #28686

:cl:
* bugfix: Fixed a rare bug where breaking tape would send you to the shadow realm. (blithering)