### PR TITLE
Fixed items slowing you down when worn on the back but not when wielded

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -253,6 +253,7 @@
 	desc = "A veritable wall of defense."
 	icon_state = "tower_shield"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/shields.dmi', "right_hand" = 'icons/mob/in-hand/right/shields.dmi')
+	flags = FPRINT | SLOWDOWN_WHEN_CARRIED
 	slowdown = 4
 
 /obj/item/weapon/shield/riot/rune

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -675,7 +675,10 @@
 			if(I.slowdown <= 0)
 				testing("[I] HAD A SLOWDOWN OF <=0 OH DEAR")
 			else
-				. *= I.slowdown
+				if(I.flags & SLOWDOWN_WHEN_CARRIED)
+					. *= max(1,I.slowdown / 2) // heavy items worn on the back. those shouldn't slow you down as much.
+				else
+					. *= I.slowdown
 
 		for(var/obj/item/I in held_items)
 			if(I.flags & SLOWDOWN_WHEN_CARRIED)

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -8,6 +8,7 @@
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guns_experimental.dmi', "right_hand" = 'icons/mob/in-hand/right/guns_experimental.dmi')
 	recoil = 16
 	slot_flags = SLOT_BACK
+	flags = FPRINT | SLOWDOWN_WHEN_CARRIED
 	fire_delay = 30
 	w_class = W_CLASS_LARGE
 	fire_sound = 'sound/weapons/hecate_fire.ogg'
@@ -15,7 +16,7 @@
 	ammo_type = "/obj/item/ammo_casing/BMG50"
 	max_shells = 1
 	load_method = 0
-	slowdown = 10
+	slowdown = 2
 	var/backup_view = 7
 
 /obj/item/weapon/gun/projectile/hecate/isHandgun()
@@ -49,8 +50,10 @@
 
 /obj/item/weapon/gun/projectile/hecate/attack_self(mob/user)
 	if(wielded)
+		slowdown = 2
 		unwield(user)
 	else
+		slowdown = 10
 		wield(user)
 
 /obj/item/weapon/gun/projectile/hecate/hunting


### PR DESCRIPTION
Fixes #28666

:cl:
* bugfix: Fixed items slowing you down when worn on the back but not when actually wielded. (PrimeD)
* tweak: Items that slow you when wielded only slow you half as much when worn on the back.
* tweak: Hecate now only slows you down as much as it did before when you aim down its sight, it slightly slows you down otherwise, and basically not at all when worn on the back.