### PR TITLE
Turf bullshit

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -116,7 +116,7 @@
 		for(var/obj/obstacle in src)
 			/*if(ismob(mover) && mover:client)
 				world << "<span class='danger'>EXIT</span>origin: checking exit of mob [obstacle]"*/
-			if(!obstacle.Uncross(mover, target) && obstacle != mover && obstacle != target)
+			if(!obstacle.Uncross(mover, target) && obstacle != mover && obstacle != target && !(target in obstacle.locs))
 				/*if(ismob(mover) && mover:client)
 					world << "<span class='danger'>EXIT</span>Origin: We are bumping into [obstacle]"*/
 				mover.to_bump(obstacle, 1)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -116,7 +116,9 @@
 		for(var/obj/obstacle in src)
 			/*if(ismob(mover) && mover:client)
 				world << "<span class='danger'>EXIT</span>origin: checking exit of mob [obstacle]"*/
-			if(!obstacle.Uncross(mover, target) && obstacle != mover && obstacle != target && !(target in obstacle.locs))
+			if(obstacle in target) //If target is a turf and obstacle is a multitile object so that it covers target as well.
+				continue
+			if(!obstacle.Uncross(mover, target) && obstacle != mover && obstacle != target)
 				/*if(ismob(mover) && mover:client)
 					world << "<span class='danger'>EXIT</span>Origin: We are bumping into [obstacle]"*/
 				mover.to_bump(obstacle, 1)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -116,9 +116,7 @@
 		for(var/obj/obstacle in src)
 			/*if(ismob(mover) && mover:client)
 				world << "<span class='danger'>EXIT</span>origin: checking exit of mob [obstacle]"*/
-			if(target in obstacle.locs)
-				continue
-			if(!obstacle.Uncross(mover, target) && obstacle != mover && obstacle != target)
+			if(!obstacle.Uncross(mover, target) && obstacle != mover && obstacle != target && !(target in obstacle.locs))
 				/*if(ismob(mover) && mover:client)
 					world << "<span class='danger'>EXIT</span>Origin: We are bumping into [obstacle]"*/
 				mover.to_bump(obstacle, 1)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -116,7 +116,9 @@
 		for(var/obj/obstacle in src)
 			/*if(ismob(mover) && mover:client)
 				world << "<span class='danger'>EXIT</span>origin: checking exit of mob [obstacle]"*/
-			if(!obstacle.Uncross(mover, target) && obstacle != mover && obstacle != target && !(target in obstacle.locs))
+			if(target in obstacle.locs)
+				continue
+			if(!obstacle.Uncross(mover, target) && obstacle != mover && obstacle != target)
 				/*if(ismob(mover) && mover:client)
 					world << "<span class='danger'>EXIT</span>Origin: We are bumping into [obstacle]"*/
 				mover.to_bump(obstacle, 1)


### PR DESCRIPTION
As far as I am aware, this currently has no in-game effect, but is necessary for proper behavior of stairs in #30178.
`Uncross()` should only be checked if the movement would actually cause you to stop overlapping the object. There are similar problems with `Cross()` at the moment but they're more of a pain to fix and also potentially desirable, so I'm leaving them be.