### PR TITLE
Fixed Generic Signaler Cartridges not actually giving you the signaler app.

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1554,7 +1554,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 				var/turf/T = loc
 				if(ismob(T))
 					T = T.loc
-				cartridge.forceMove(T)
+				U.put_in_hands(cartridge)
 				scanmode = SCANMODE_NONE
 				if (cartridge.radio)
 					cartridge.radio.hostpda = null

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -169,6 +169,7 @@
 /obj/item/weapon/cartridge/signal
 	name = "\improper Generic signaler cartridge"
 	desc = "A data cartridge with an integrated radio signaler module."
+	radio_type = /obj/item/radio/integrated/signal
 
 /obj/item/weapon/cartridge/signal/toxins
 	name = "\improper Signal Ace 2"


### PR DESCRIPTION
Fixes #28879

:cl:
* bugfix: Fixed Generic Signaler Cartridges not actually giving you the signaler app. (kernikov)
* tweak: Removing a cartridge from your PDA now tries to place it in one of your hands.