### PR TITLE
Supply Forms now display your alt title properly if you chose one

### DIFF
--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -47,7 +47,7 @@ For vending packs, see vending_packs.dm*/
 			acc_info["card"] = using_debit ? debit_card : usr_id
 			acc_info["check"] = TRUE
 		acc_info["idname"] = usr_id.registered_name
-		acc_info["idrank"] = usr_id.GetJobName()
+		acc_info["idrank"] = usr_id.assignment
 		acc_info["account"] = bank_account
 	else if(isAdminGhost(user))
 		acc_info["idname"] = "Commander Green"


### PR DESCRIPTION
Fixes #28571

:cl:
* bugfix: Supply Forms now display your alt title properly if you chose one. (suchai)