### PR TITLE
Fixed a bug where supermatter crystals and shards could explode perpetually

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -125,6 +125,7 @@
 
 /obj/machinery/power/supermatter/proc/explode()
 	has_exploded++
+	var/turf/T = get_turf(src)
 	if (has_exploded <= 1)
 		if(!istype(universe,/datum/universal_state/supermatter_cascade))
 			var/turf/turff = get_turf(src)
@@ -133,7 +134,6 @@
 			explosion(turff, explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1)
 			empulse(turff, 100, 200, 1)
 	else if (has_exploded == 2)// yeah not gonna report it more than once to not flood the logs if it glitches badly
-		var/turf/T = get_turf(src)
 		log_admin("[name] at [T.loc] has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
 		message_admins("[name] at [T.loc]([x], [y], [z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
 
@@ -143,11 +143,11 @@
 
 /obj/machinery/power/supermatter/shard/explode()
 	has_exploded++
+	var/turf/T = get_turf(src)
 	if (has_exploded <= 1)
 		explosion(get_turf(src), explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1)
 		empulse(get_turf(src), 100, 200, 1)
 	else if (has_exploded == 2)// yeah not gonna report it more than once to not flood the logs if it glitches badly
-		var/turf/T = get_turf(src)
 		log_admin("[name] at [T.loc] has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
 		message_admins("[name] at [T.loc]([x], [y], [z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
 	qdel(src)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -138,6 +138,8 @@
 		message_admins("[name] at [T.loc]([x], [y], [z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
 
 	qdel(src)
+	if (has_exploded > 1)
+		stack_trace("[name] at [T.loc] has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
 
 /obj/machinery/power/supermatter/shard/explode()
 	has_exploded++
@@ -149,6 +151,8 @@
 		log_admin("[name] at [T.loc] has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
 		message_admins("[name] at [T.loc]([x], [y], [z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
 	qdel(src)
+	if (has_exploded > 1)
+		stack_trace("[name] at [T.loc] has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
 
 /obj/machinery/power/supermatter/conveyor_act(var/atom/movable/AM, var/obj/machinery/conveyor/CB)
 	Consume(AM)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -134,12 +134,12 @@
 			explosion(turff, explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1)
 			empulse(turff, 100, 200, 1)
 	else if (has_exploded == 2)// yeah not gonna report it more than once to not flood the logs if it glitches badly
-		log_admin("[name] at [T.loc] has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
-		message_admins("[name] at [T.loc]([x], [y], [z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
+		log_admin("[name] at [T.loc] has tried exploding despite having already exploded once. Looks like it wasn't properly deleted (gcDestroyed = [gcDestroyed]).")
+		message_admins("[name] at [T.loc]([x], [y], [z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) has tried exploding despite having already exploded once. Looks like it wasn't properly deleted (gcDestroyed = [gcDestroyed]).")
 
 	qdel(src)
 	if (has_exploded > 1)
-		stack_trace("[name] at [T.loc] has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
+		stack_trace("[name] at [T.loc] has tried exploding despite having already exploded once. Looks like it wasn't properly deleted (gcDestroyed = [gcDestroyed]).")
 
 /obj/machinery/power/supermatter/shard/explode()
 	has_exploded++
@@ -148,11 +148,11 @@
 		explosion(get_turf(src), explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1)
 		empulse(get_turf(src), 100, 200, 1)
 	else if (has_exploded == 2)// yeah not gonna report it more than once to not flood the logs if it glitches badly
-		log_admin("[name] at [T.loc] has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
-		message_admins("[name] at [T.loc]([x], [y], [z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
+		log_admin("[name] at [T.loc] has tried exploding despite having already exploded once. Looks like it wasn't properly deleted (gcDestroyed = [gcDestroyed]).")
+		message_admins("[name] at [T.loc]([x], [y], [z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) has tried exploding despite having already exploded once. Looks like it wasn't properly deleted (gcDestroyed = [gcDestroyed]).")
 	qdel(src)
 	if (has_exploded > 1)
-		stack_trace("[name] at [T.loc] has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
+		stack_trace("[name] at [T.loc] has tried exploding despite having already exploded once. Looks like it wasn't properly deleted (gcDestroyed = [gcDestroyed]).")
 
 /obj/machinery/power/supermatter/conveyor_act(var/atom/movable/AM, var/obj/machinery/conveyor/CB)
 	Consume(AM)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -71,6 +71,8 @@
 	var/list/message_exclusions = list(/obj/effect/sparks,/obj/effect/overlay/hologram)
 	machine_flags = MULTITOOL_MENU
 
+	var/has_exploded = 0 // increments each times it tries to explode so we may track how it may occur more than once
+
 /obj/machinery/power/supermatter/airflow_hit(atom/A)
 	if(ismovable(A))
 		var/atom/movable/movingA = A
@@ -122,17 +124,30 @@
 	. = ..()
 
 /obj/machinery/power/supermatter/proc/explode()
-	if(!istype(universe,/datum/universal_state/supermatter_cascade))
-		var/turf/turff = get_turf(src)
-		new /turf/unsimulated/wall/supermatter(turff)
-		SetUniversalState(/datum/universal_state/supermatter_cascade)
-		explosion(turff, explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1)
-		empulse(turff, 100, 200, 1)
+	has_exploded++
+	if (has_exploded <= 1)
+		if(!istype(universe,/datum/universal_state/supermatter_cascade))
+			var/turf/turff = get_turf(src)
+			new /turf/unsimulated/wall/supermatter(turff)
+			SetUniversalState(/datum/universal_state/supermatter_cascade)
+			explosion(turff, explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1)
+			empulse(turff, 100, 200, 1)
+	else if (has_exploded == 2)// yeah not gonna report it more than once to not flood the logs if it glitches badly
+		var/turf/T = get_turf(src)
+		log_admin("[name] at [T.loc] has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
+		message_admins("[name] at [T.loc]([x], [y], [z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
+
 	qdel(src)
 
 /obj/machinery/power/supermatter/shard/explode()
-	explosion(get_turf(src), explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1)
-	empulse(get_turf(src), 100, 200, 1)
+	has_exploded++
+	if (has_exploded <= 1)
+		explosion(get_turf(src), explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1)
+		empulse(get_turf(src), 100, 200, 1)
+	else if (has_exploded == 2)// yeah not gonna report it more than once to not flood the logs if it glitches badly
+		var/turf/T = get_turf(src)
+		log_admin("[name] at [T.loc] has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
+		message_admins("[name] at [T.loc]([x], [y], [z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) has tried exploding despite having already exploded once. Looks like it wasn't properly deleted.")
 	qdel(src)
 
 /obj/machinery/power/supermatter/conveyor_act(var/atom/movable/AM, var/obj/machinery/conveyor/CB)


### PR DESCRIPTION
Fixes #27999

:cl:
* bugfix: Fixed a bug where supermatter crystals and shards could explode perpetually. (gurfan)