### PR TITLE
Pillow Bugs can no longer smash tables and walls as if they were a goliath or something

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -892,11 +892,11 @@ obj/item/asteroid/basilisk_hide/New()
 	holder_type = /obj/item/weapon/holder/animal/pillow
 	size = SIZE_SMALL
 	pacify_aura = TRUE
+	environment_smash_flags = 0
 	var/image/eyes
 
 /mob/living/simple_animal/hostile/asteroid/pillow/no_pacify
 	pacify_aura = FALSE
-	environment_smash_flags = 0
 	response_help = "pets"
 
 /mob/living/simple_animal/hostile/asteroid/pillow/examine(mob/user)


### PR DESCRIPTION
Fixes #27795

:cl:
* tweak: Pillow Bugs can no longer smash tables and walls as if they were a goliath or something. (calzilla1)