### PR TITLE
Fixed Maint PvP mode sending warnings in the chat when clicking even on help intent

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -7,7 +7,7 @@
 /mob/living/carbon/human/UnarmedAttack(var/atom/A, var/proximity, var/params)
 	var/obj/item/clothing/gloves/G = gloves // not typecast specifically enough in defines
 
-	if(!is_pacified() && a_intent == "hurt" && A.loc != src)
+	if(a_intent == "hurt" && !is_pacified() && A.loc != src)
 		var/special_attack_result = SPECIAL_ATTACK_SUCCESS
 		switch(attack_type) //Special attacks - kicks, bites
 			if(ATTACK_KICK)


### PR DESCRIPTION

:cl:
* bugfix: Fixed Maint PvP mode sending warnings in the chat when clicking even on help intent. (JazzStringz)