### PR TITLE
You can now detach extinguisher frames from walls without destroying them

### DIFF
--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -96,4 +96,6 @@
 	if(!WE.remove_fuel(1, user))
 		return
 	to_chat(user, "<span class='notice'>You cut \the [src] off of the wall.</span>")
+	WE.playtoolsound(src, 50)
+	new /obj/item/mounted/frame/extinguisher_cabinet(get_turf(src))
 	qdel(src)


### PR DESCRIPTION
Fixes #27591

:cl:
* rscadd: You can now detach extinguisher frames from walls without destroying them. (bungofungo)