### PR TITLE
Shutters are now layered below tables while open

### DIFF
--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -9,7 +9,10 @@
 
 /obj/machinery/door/poddoor/shutters/New()
 	..()
-	layer = ABOVE_DOOR_LAYER
+	if(density)
+		layer = closed_layer
+	else
+		layer = open_layer
 
 /obj/machinery/door/poddoor/shutters/preopen
 	icon_state = "shutter0"
@@ -17,7 +20,7 @@
 	opacity = 0
 
 /obj/machinery/door/poddoor/shutters/preopen/toplayer
-	layer = 5
+	open_layer = ABOVE_DOOR_LAYER
 
 /obj/machinery/door/poddoor/shutters/attackby(obj/item/weapon/C as obj, mob/user as mob)
 	add_fingerprint(user)


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7573912/131049302-e090ae62-4c30-49b7-87e3-b7abde2c0b9e.png)

After:
![image](https://user-images.githubusercontent.com/7573912/131049275-63adc071-94a6-4eef-8b55-f207fceda29e.png)

:cl:
* tweak: Shutters are now layered below tables while open so they stop hiding display of items on counters.