### PR TITLE
Fixed Revolutionary Squads ending the round right as they spawn

### DIFF
--- a/code/datums/gamemode/objectives/target/assassinate.dm
+++ b/code/datums/gamemode/objectives/target/assassinate.dm
@@ -73,6 +73,8 @@ var/list/assassination_objectives = list()
 		if(target.current.stat == DEAD || issilicon(target.current) || isbrain(target.current) || target.current.z > 6 || !target.current.ckey || isborer(target.current))
 			return TRUE
 		return FALSE
+	if (delayed_target) // our target hasn't been revealed yet
+		return FALSE
 	return TRUE
 
 /datum/objective/target/assassinate/proc/SyndicateCertification()

--- a/code/datums/gamemode/objectives/target/target.dm
+++ b/code/datums/gamemode/objectives/target/target.dm
@@ -18,8 +18,9 @@
 	if(delay && (emergency_shuttle.location || emergency_shuttle.direction == 2))
 		PostDelay() //If the shuttle is docked or en route to centcomm, no delay
 		return TRUE
-	spawn(delay)
-		PostDelay()
+	if (delay)
+		spawn(delay)
+			PostDelay()
 	return TRUE
 
 /datum/objective/target/ShuttleDocked(state)


### PR DESCRIPTION
Fixes #30341

:cl:
* bugfix: Fixed Revolutionary Squads ending the round right as they spawn. (driftingskies)