### PR TITLE
Ammotree Fix

### DIFF
--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -249,7 +249,7 @@ var/global/list/alcatraz_stuff = list(
 	/obj/item/clothing/under/securityskirt/elite,
 	/obj/item/clothing/head/helmet/donutgiver,
 	/obj/item/clothing/accessory/bangerboy,
-	/obj/item/key/security/spare,
+	/obj/structure/ammotree,
 	/obj/item/weapon/ram_kit,
 	/obj/item/device/vampirehead,
 	/obj/item/weapon/storage/lockbox/unlockable/peace,
@@ -1198,6 +1198,7 @@ var/global/list/alcatraz_stuff = list(
 	pixel_x = -16
 	plane = ABOVE_HUMAN_PLANE
 	var/state = AT_SEED
+	var/pity_timer = 0
 
 /obj/structure/ammotree/attackby(obj/item/I, mob/user)
 	if(state == AT_SEED && istype(I, /obj/item/weapon/batteringram))
@@ -1236,9 +1237,12 @@ var/global/list/alcatraz_stuff = list(
 	if(state >= AT_FLOWERING)
 		processing_objects -= src
 		return
-	if(prob(1))
+	if(prob(1) || pity_timer > 99)
 		state++
+		pity_timer = 0
 		update_icon()
+	else
+		pity_timer++
 
 /obj/item/ammofruit
 	name = "ammofruit"


### PR DESCRIPTION
🆑 
* bugfix: The ammo tree now properly appears in the Alcatraz IV crates instead of a second spare secway key.
* tweak: The ammo tree now has a 100 tick pity timer so it's not purely chance if it advances to the next stage.