### PR TITLE
Reagent Dispenser Costs

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -288,7 +288,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/watertank
 	name = "Water tank"
 	contains = list(/obj/structure/reagent_dispensers/watertank)
-	cost = 8
+	cost = 15
 	containertype = /obj/structure/largecrate
 	containername = "water tank crate"
 	group = "Supplies"
@@ -296,7 +296,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/fueltank
 	name = "Fuel tank"
 	contains = list(/obj/structure/reagent_dispensers/fueltank)
-	cost = 8
+	cost = 30
 	containertype = /obj/structure/largecrate
 	containername = "fuel tank crate"
 	group = "Supplies"
@@ -304,7 +304,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/silicatetank
 	name = "Silicate tank"
 	contains = list(/obj/structure/reagent_dispensers/silicate)
-	cost = 8
+	cost = 15
 	containertype = /obj/structure/largecrate
 	containername = "silicate tank crate"
 	group = "Supplies"
@@ -312,7 +312,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/sacidtank
 	name = "Sulphuric acid tank"
 	contains = list(/obj/structure/reagent_dispensers/sacid)
-	cost = 8
+	cost = 30
 	containertype = /obj/structure/closet/crate/secure/large/reinforced/shard/empty
 	containername = "sulphuric acid tank crate"
 	group = "Supplies"


### PR DESCRIPTION
8 feels too low for such an order

Water and silicate raised to 15 per tank, 30 for fuel or acid.

🆑 
* tweak: Reagent dispensers cost slightly more.