### PR TITLE
Fixed glass floor tile stacks being incorrectly labeled when examined

### DIFF
--- a/code/game/objects/items/stacks/tiles/tiles.dm
+++ b/code/game/objects/items/stacks/tiles/tiles.dm
@@ -132,6 +132,7 @@
 
 /obj/item/stack/glass_tile/rglass
 	name = "glass tile"
+	singular_name = "tile"
 	desc = "A relatively clear reinforced glass tile."
 	icon_state = "tile_rglass"
 	max_amount = 60
@@ -152,6 +153,7 @@
 
 /obj/item/stack/glass_tile/rglass/plasma
 	name = "plasma glass tile"
+	singular_name = "tile"
 	desc = "A relatively clear reinforced plasma glass tile."
 	icon_state = "tile_plasmarglass"
 


### PR DESCRIPTION
Fixes #27102

:cl:
* bugfix: Fixed glass floor tile stacks being incorrectly labeled when examined. (ithet)