### PR TITLE
The RUST's EM Field is now anchored and not dense

### DIFF
--- a/code/modules/power/rust/core_field.dm
+++ b/code/modules/power/rust/core_field.dm
@@ -13,6 +13,7 @@ Deuterium-tritium fusion: 4.5 x 10^7 K
 	icon_state = "emfield_s1"
 	alpha = 50
 	anchored = 1
+	density = 0
 
 	var/major_radius = 0	//longer radius in meters = field_strength * 0.21875, max = 8.75
 	var/minor_radius = 0	//shorter radius in meters = field_strength * 0.2125, max = 8.625

--- a/code/modules/power/rust/core_field.dm
+++ b/code/modules/power/rust/core_field.dm
@@ -12,6 +12,7 @@ Deuterium-tritium fusion: 4.5 x 10^7 K
 	icon = 'icons/obj/machines/rust.dmi'
 	icon_state = "emfield_s1"
 	alpha = 50
+	anchored = 1
 
 	var/major_radius = 0	//longer radius in meters = field_strength * 0.21875, max = 8.75
 	var/minor_radius = 0	//shorter radius in meters = field_strength * 0.2125, max = 8.625


### PR DESCRIPTION
Fixes #26978

:cl:
* bugfix: The RUST's EM Field is now anchored and no longer dense. (davidblanc5)