### PR TITLE
Supermatter splinter interactions

### DIFF
--- a/code/modules/research/xenoarchaeology/finds/finds_splinter.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_splinter.dm
@@ -22,35 +22,51 @@
 	icon = original
 
 /obj/item/supermatter_splinter/prepickup(mob/living/user)
-	var/datum/organ/external/external = user.get_active_hand_organ()
-	if(external)
-		user.visible_message("<span class = 'warning>As \the [user] grasps onto \the [src], their [external.display_name] begins rapidly combusting!</span>", "<span class = 'warning'>As you try to get a grip onto \the [src], you feel your [external.display_name] tingle and glow, before it rapidly dissipates into ash.</span>")
-		playsound(src, 'sound/effects/supermatter.ogg', 50, 1)
-		external.dust()
-	return 1
+	var/obj/item/supermatter_shielding/SS = locate(/obj/item/supermatter_shielding) in contents
+	if(SS)
+		SS.supermatter_act(source)
+	else
+		var/obj/item/clothing/gloves/golden/G = user.get_item_by_slot(slot_gloves)
+			if(istype(G))
+				user.visible_message("<span class='notice'>The special lubrication on \the [G] prevents your hand from melting, but also prevents you from getting a grip.</span>")
+				return 1
+		var/datum/organ/external/external = user.get_active_hand_organ()
+		if(external)
+			user.visible_message("<span class='warning'>As \the [user] grasps onto \the [src], their [external.display_name] begins rapidly combusting!</span>", "<span class = 'warning'>As you try to get a grip onto \the [src], you feel your [external.display_name] tingle and glow, before it rapidly dissipates into ash.</span>")
+			playsound(src, 'sound/effects/supermatter.ogg', 50, 1)
+			external.dust()
+		return 1
 
 /obj/item/supermatter_splinter/kick_act(mob/living/carbon/human/user)
-	var/obj/shoes = user.shoes
-	if(shoes)
-		user.visible_message("<span class = 'warning'>As \the [user] goes to kick \the [src], their [shoes] collide with \the [src] and rapidly flash into ash.</span>")
-		user.u_equip(shoes, 1)
-		var/obj/O = shoes.ashtype()
-		new O(user.loc)
-		qdel(shoes)
-	else //Oh nooo
-		var/datum/organ/external/external = user.get_organ(pick(LIMB_RIGHT_LEG, LIMB_LEFT_LEG, LIMB_RIGHT_FOOT, LIMB_LEFT_FOOT))
-		user.visible_message("<span class = 'warning>As \the [user] goes to punt \the [src], their [external.display_name] begins rapidly combusting!</span>", "<span class = 'warning'>As you try to kick \the [src], you feel your [external.display_name] tingle and glow, before it rapidly dissipates into ash.</span>")
-		playsound(src, 'sound/effects/supermatter.ogg', 50, 1)
-		external.dust()
-	return 0
+	var/obj/item/supermatter_shielding/SS = locate(/obj/item/supermatter_shielding) in contents
+	if(SS)
+		SS.supermatter_act(source)
+	else
+		var/obj/shoes = user.shoes
+		if(shoes)
+			user.visible_message("<span class = 'warning'>As \the [user] goes to kick \the [src], their [shoes] collide with \the [src] and rapidly flash into ash.</span>")
+			user.u_equip(shoes, 1)
+			var/obj/O = shoes.ashtype()
+			new O(user.loc)
+			qdel(shoes)
+		else //Oh nooo
+			var/datum/organ/external/external = user.get_organ(pick(LIMB_RIGHT_LEG, LIMB_LEFT_LEG, LIMB_RIGHT_FOOT, LIMB_LEFT_FOOT))
+			user.visible_message("<span class = 'warning>As \the [user] goes to punt \the [src], their [external.display_name] begins rapidly combusting!</span>", "<span class = 'warning'>As you try to kick \the [src], you feel your [external.display_name] tingle and glow, before it rapidly dissipates into ash.</span>")
+			playsound(src, 'sound/effects/supermatter.ogg', 50, 1)
+			external.dust()
+		return 0
 
 /obj/item/supermatter_splinter/bite_act(mob/living/carbon/human/user)
-	var/datum/organ/external/head = user.get_organ(LIMB_HEAD)
-	if(head)
-		user.visible_message("<span class = 'warning'>As \the [user] bites down into \the [src], their [head.display_name] begins glowing a deep crimson before turning to dust.","<span class = 'warning'>As you bite down onto \the [src], you realize that supermatter tastes oddly like cheese and pickles before your tastebuds, then your tongue, and finally your entire head ceases to be.</span>")
-		playsound(src, 'sound/effects/supermatter.ogg', 50, 1)
-		head.dust()
-	return 0
+	var/obj/item/supermatter_shielding/SS = locate(/obj/item/supermatter_shielding) in contents
+	if(SS)
+		SS.supermatter_act(source)
+	else
+		var/datum/organ/external/head = user.get_organ(LIMB_HEAD)
+		if(head)
+			user.visible_message("<span class = 'warning'>As \the [user] bites down into \the [src], their [head.display_name] begins glowing a deep crimson before turning to dust.","<span class = 'warning'>As you bite down onto \the [src], you realize that supermatter tastes oddly like cheese and pickles before your tastebuds, then your tongue, and finally your entire head ceases to be.</span>")
+			playsound(src, 'sound/effects/supermatter.ogg', 50, 1)
+			head.dust()
+		return 0
 
 /obj/item/supermatter_splinter/can_be_stored(var/obj/item/weapon/storage/S)
 	if(istype(S, /obj/item/weapon/storage/backpack/holding))

--- a/code/modules/research/xenoarchaeology/finds/finds_splinter.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_splinter.dm
@@ -24,12 +24,12 @@
 /obj/item/supermatter_splinter/prepickup(mob/living/user)
 	var/obj/item/supermatter_shielding/SS = locate(/obj/item/supermatter_shielding) in contents
 	if(SS)
-		SS.supermatter_act(source)
+		SS.supermatter_act(src)
 	else
 		var/obj/item/clothing/gloves/golden/G = user.get_item_by_slot(slot_gloves)
-			if(istype(G))
-				user.visible_message("<span class='notice'>The special lubrication on \the [G] prevents your hand from melting, but also prevents you from getting a grip.</span>")
-				return 1
+		if(istype(G))
+			to_chat(user,"<span class='notice'>The special lubrication on \the [G] prevents your hand from melting, but also prevents you from getting a grip.</span>")
+			return 1
 		var/datum/organ/external/external = user.get_active_hand_organ()
 		if(external)
 			user.visible_message("<span class='warning'>As \the [user] grasps onto \the [src], their [external.display_name] begins rapidly combusting!</span>", "<span class = 'warning'>As you try to get a grip onto \the [src], you feel your [external.display_name] tingle and glow, before it rapidly dissipates into ash.</span>")
@@ -40,7 +40,7 @@
 /obj/item/supermatter_splinter/kick_act(mob/living/carbon/human/user)
 	var/obj/item/supermatter_shielding/SS = locate(/obj/item/supermatter_shielding) in contents
 	if(SS)
-		SS.supermatter_act(source)
+		SS.supermatter_act(src)
 	else
 		var/obj/shoes = user.shoes
 		if(shoes)
@@ -59,7 +59,7 @@
 /obj/item/supermatter_splinter/bite_act(mob/living/carbon/human/user)
 	var/obj/item/supermatter_shielding/SS = locate(/obj/item/supermatter_shielding) in contents
 	if(SS)
-		SS.supermatter_act(source)
+		SS.supermatter_act(src)
 	else
 		var/datum/organ/external/head = user.get_organ(LIMB_HEAD)
 		if(head)


### PR DESCRIPTION
closes #29479
closes #29480

:cl:
* bugfix: FRASS and SASS spheres will prevent you from injuring yourself on a supermatter splinter. Golden gloves will also stop you from picking it up with your hand, though it won't charge it or allow you to carry it.