### PR TITLE
You can no longer Apply Cell Upgrade at a Recharge Station when not a silicon

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -151,6 +151,9 @@
 	set src in range(0)
 
 	var/mob/user = usr
+	if(!issilicon(user))
+		to_chat(user, "<span class='warning'>You can't seem to find any cell to upgrade on your person, maybe because you're not a silicon you dummy.</span>")
+		return
 	if(user != occupant)
 		to_chat(user, "<span class='warning'>You must be inside \the [src] to do this.</span>")
 		return


### PR DESCRIPTION
Fixes #26970

:cl:
* bugfix: You can no longer Apply Cell Upgrade at a Recharge Station when not a silicon. (PrimeD)