### PR TITLE
Airshield QOL

### DIFF
--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -1385,7 +1385,7 @@ var/global/list/cloudnine_stuff = list(
 
 /obj/item/airshield_projector/preattack(atom/target, mob/user , proximity)
 	var/turf/to_shield = get_turf(target)
-	if(is_type_in_list(target, ignore_types) && get_dist(to_shield,src))
+	if(is_type_in_list(target, ignore_types) && Adjacent(to_shield))
 		return TRUE
 	if(projected.len < max_proj && istype(to_shield) && (!locate(/obj/effect/airshield) in to_shield))
 		playsound(loc, 'sound/machines/hiss.ogg', 75, 1)

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -1381,9 +1381,12 @@ var/global/list/cloudnine_stuff = list(
 	icon_state = "airprojector"
 	var/list/projected = list()
 	var/max_proj = 6
+	var/list/ignore_types = list(/obj/structure/table, /obj/structure/rack, /obj/item/weapon/storage)
 
 /obj/item/airshield_projector/preattack(atom/target, mob/user , proximity)
 	var/turf/to_shield = get_turf(target)
+	if(is_type_in_list(target, ignore_types) && get_dist(to_shield,src))
+		return TRUE
 	if(projected.len < max_proj && istype(to_shield) && (!locate(/obj/effect/airshield) in to_shield))
 		playsound(loc, 'sound/machines/hiss.ogg', 75, 1)
 		var/obj/effect/airshield/A = new(to_shield)


### PR DESCRIPTION
closes #29592

:cl:
* tweak: Airshield projectors will not deploy an airshield when aimed at a storage container (like a backpack), table, or rack if adjacent to that object (includes wearing).