### PR TITLE
Vampire Hypnotize now only fails on blinded people if their blindness is genetic or because of a blindfold.

### DIFF
--- a/code/modules/spells/targeted/hypnotise.dm
+++ b/code/modules/spells/targeted/hypnotise.dm
@@ -57,7 +57,7 @@
 
 	if(ishuman(target) || ismonkey(target))
 		var/mob/living/carbon/C = target
-		if (C.sdisabilities & BLIND)
+		if ((C.sdisabilities & BLIND) || (C.sight & BLIND))
 			to_chat(user, "<span class='warning'>\the [C] is blind!</span>")
 			return FALSE
 		if(do_mob(user, C, 10 - C.get_vamp_enhancements()))

--- a/code/modules/spells/targeted/hypnotise.dm
+++ b/code/modules/spells/targeted/hypnotise.dm
@@ -48,7 +48,7 @@
 		if (VAMP_FAILURE)
 			critfail(target, user)
 			return FALSE
-	
+
 /spell/targeted/hypnotise/cast(var/list/targets, var/mob/user)
 	if (targets.len > 1)
 		return FALSE
@@ -57,7 +57,7 @@
 
 	if(ishuman(target) || ismonkey(target))
 		var/mob/living/carbon/C = target
-		if (C.is_blind())
+		if (C.sdisabilities & BLIND)
 			to_chat(user, "<span class='warning'>\the [C] is blind!</span>")
 			return FALSE
 		if(do_mob(user, C, 10 - C.get_vamp_enhancements()))


### PR DESCRIPTION
Fixes #26924

:cl:
* tweak: Vampire Hypnotize now only fails on blinded people if their blindness is caused either by genetic or worn items. So you will no longer fail Hypnotized because you recently cast Glare. (mastercasual)