### PR TITLE
Omnitool Cleanup

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -423,3 +423,5 @@ proc/get_space_area()
 
 #define istransformable(A) (isatom(A))
 #define isapperanceeditable(A) (isatom(A))
+
+#define OMNI_LINK(A,B) isliving(A) && A:omnitool_connect(B)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -832,7 +832,7 @@ var/global/list/airalarm_presets = list(
 	//   Not sent from atmos console AND
 	//   Not silicon AND locked AND
 	//   NOT adminghost.
-	data["locked"]=!fromAtmosConsole && (!(istype(user, /mob/living/silicon)) && locked) && !isAdminGhost(user)
+	data["locked"]=!fromAtmosConsole && (!(istype(user, /mob/living/silicon)) && locked) && !isAdminGhost(user) && !(OMNI_LINK(user,src))
 
 	data["rcon"]=rcon_setting
 	data["rcon_enabled"] = remote_control
@@ -906,6 +906,19 @@ var/global/list/airalarm_presets = list(
 	if(!shorted)
 		ui_interact(user)
 
+/obj/machinery/alarm/proc/buttonCheck(mob/user)
+	if(!locked)
+		return 1
+	if(issilicon(user))
+		return 1
+	if(user.hasFullAccess())
+		return 1
+	if(OMNI_LINK(user,src))
+		return 1
+	if(isAdminGhost(user))
+		return 1
+	return 0
+
 /obj/machinery/alarm/Topic(href, href_list)
 	if(href_list["close"])
 		if(usr.machine == src)
@@ -913,9 +926,40 @@ var/global/list/airalarm_presets = list(
 		return 1
 	if(..())
 		return 1
-	if(href_list["rcon"])
-		if(locked && !issilicon(usr) && !usr.hasFullAccess())
+
+	add_fingerprint(usr)
+
+
+	//These options MUST be first in Topic() because they do not require access check as below
+	if(href_list["screen"])
+		screen = text2num(href_list["screen"])
+		return 1
+
+	if(href_list["temperature"])
+		var/list/selected = TLV["temperature"]
+		var/max_temperature
+		var/min_temperature
+		if(buttonCheck(usr))
+			max_temperature = MAX_TARGET_TEMPERATURE - T0C
+			min_temperature = MIN_TARGET_TEMPERATURE - T0C
+		else
+			max_temperature = selected[3] - T0C
+			min_temperature = selected[2] - T0C
+		var/input_temperature = input("What temperature (in C) would you like the system to target? (Capped between [min_temperature]C and [max_temperature]C).\n\nNote that the cooling unit in this air alarm can not go below [MIN_TEMPERATURE]C or above [MAX_TEMPERATURE]C by itself. ", "Thermostat Controls") as num|null
+		if(input_temperature==null)
 			return 1
+		if(!input_temperature || input_temperature >= max_temperature || input_temperature <= min_temperature)
+			to_chat(usr, "<span class='warning'>Temperature must be between [min_temperature]C and [max_temperature]C.</span>")
+		else
+			input_temperature = input_temperature + T0C
+			set_temperature(input_temperature)
+		return 1
+
+	if(!buttonCheck(usr))
+		to_chat(usr, "<span class='warning'>It's locked!</span>")
+		return 1
+
+	if(href_list["rcon"])
 		rcon_setting = text2num(href_list["rcon"])
 		//propagate to other AAs in the area
 		var/area/this_area = get_area(src)
@@ -924,12 +968,7 @@ var/global/list/airalarm_presets = list(
 				AA.rcon_setting = rcon_setting
 		return 1
 
-	add_fingerprint(usr)
-
-	//testing(href)
 	if(href_list["command"])
-		if(locked && !issilicon(usr) && !usr.hasFullAccess())
-			return 1
 		var/device_id = href_list["id_tag"]
 		switch(href_list["command"])
 			if( "power",
@@ -966,35 +1005,23 @@ var/global/list/airalarm_presets = list(
 				var/list/selected = TLV[env]
 				var/list/thresholds = list("lower bound", "low warning", "high warning", "upper bound")
 				var/newval = input("Enter [thresholds[threshold]] for [env]", "Alarm triggers", selected[threshold]) as num|null
-				if (isnull(newval) || ..() || (locked && !issilicon(usr) && !usr.hasFullAccess()))
+				if (isnull(newval) || ..() || !buttonCheck())
 					return 1
 				set_threshold(env, threshold, newval, 1)
 		return 1
 	if(href_list["reset_thresholds"])
-		if(locked && !issilicon(usr) && !usr.hasFullAccess())
-			return 1
 		apply_preset(1) //just apply the preset without cycling
 		return 1
 
-	if(href_list["screen"])
-		screen = text2num(href_list["screen"])
-		return 1
-
 	if(href_list["atmos_alarm"])
-		if(locked && !issilicon(usr) && !usr.hasFullAccess())
-			return 1
 		set_alarm(1)
 		return 1
 
 	if(href_list["atmos_reset"])
-		if(locked && !issilicon(usr) && !usr.hasFullAccess())
-			return 1
 		set_alarm(0)
 		return 1
 
 	if(href_list["enable_override"])
-		if(locked && !issilicon(usr) && !usr.hasFullAccess())
-			return 1
 		var/area/this_area = get_area(src)
 		this_area.doors_overridden = 1
 		this_area.UpdateFirelocks()
@@ -1002,8 +1029,6 @@ var/global/list/airalarm_presets = list(
 		return 1
 
 	if(href_list["disable_override"])
-		if(locked && !issilicon(usr) && !usr.hasFullAccess())
-			return 1
 		var/area/this_area = get_area(src)
 		this_area.doors_overridden = 0
 		this_area.UpdateFirelocks()
@@ -1011,44 +1036,18 @@ var/global/list/airalarm_presets = list(
 		return 1
 
 	if(href_list["mode"])
-		if(locked && !issilicon(usr) && !usr.hasFullAccess())
-			return 1
 		mode = text2num(href_list["mode"])
 		apply_mode()
 		return 1
 
 	if(href_list["toggle_cycle_after_preset"])
-		if(locked && !issilicon(usr) && !usr.hasFullAccess())
-			return 1
 		cycle_after_preset = !cycle_after_preset
 		return 1
 
 	if(href_list["preset"])
-		if(locked && !issilicon(usr) && !usr.hasFullAccess())
-			return 1
 		if(href_list["preset"] in airalarm_presets)
 			preset = href_list["preset"]
 			apply_preset(!cycle_after_preset)
-		return 1
-
-	if(href_list["temperature"])
-		var/list/selected = TLV["temperature"]
-		var/max_temperature
-		var/min_temperature
-		if(!locked || issilicon(usr) || usr.hasFullAccess())
-			max_temperature = MAX_TARGET_TEMPERATURE - T0C
-			min_temperature = MIN_TARGET_TEMPERATURE - T0C
-		else
-			max_temperature = selected[3] - T0C
-			min_temperature = selected[2] - T0C
-		var/input_temperature = input("What temperature (in C) would you like the system to target? (Capped between [min_temperature]C and [max_temperature]C).\n\nNote that the cooling unit in this air alarm can not go below [MIN_TEMPERATURE]C or above [MAX_TEMPERATURE]C by itself. ", "Thermostat Controls") as num|null
-		if(input_temperature==null)
-			return 1
-		if(!input_temperature || input_temperature >= max_temperature || input_temperature <= min_temperature)
-			to_chat(usr, "<span class='warning'>Temperature must be between [min_temperature]C and [max_temperature]C.</span>")
-		else
-			input_temperature = input_temperature + T0C
-			set_temperature(input_temperature)
 		return 1
 
 /obj/machinery/alarm/attackby(obj/item/W as obj, mob/user as mob)
@@ -1150,11 +1149,8 @@ var/global/list/airalarm_presets = list(
 	return 0
 
 /obj/machinery/alarm/is_in_range(var/mob/user)
-	if((!in_range(src, user) || !istype(loc, /turf)) && !istype(user, /mob/living/silicon))
-		var/obj/item/device/multitool/omnitool/O = user.get_active_hand()
-		if(istype(O))
-			return O.can_connect(src,user)
-		return FALSE
+	if(!..())
+		return OMNI_LINK(user,src)
 	return TRUE
 
 /*

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -1455,6 +1455,7 @@ var/list/decelerators = list()
 	origin_tech = Tc_ENGINEERING + "=4"
 	sharpness = 1
 	force = 6
+	req_access = list(access_engine_equip)
 	var/mode = OMNIMODE_TOOL
 
 /obj/item/device/multitool/omnitool/attack_self(mob/user)
@@ -1494,6 +1495,8 @@ var/list/omnitoolable = list(/obj/machinery/alarm,/obj/machinery/power/apc)
 			return FALSE
 		C = M.client
 	if(!C)
+		return FALSE
+	if(!allowed(user))
 		return FALSE
 	return get_dist(target,src) <= C.view
 

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -1471,10 +1471,18 @@ var/list/omnitoolable = list(/obj/machinery/alarm,/obj/machinery/power/apc)
 
 /obj/item/device/multitool/omnitool/preattack(atom/target, mob/user, proximity)
 	if(proximity)
+		if(is_type_in_list(target.type,omnitoolable))
+			target.attack_hand(user)
 		return FALSE //immediately continue if in reach
 	if(can_connect(target, user) && is_type_in_list(target.type,omnitoolable))
 		target.attack_hand(user)
 		return TRUE
+
+/mob/living/proc/omnitool_connect(atom/target)
+	var/obj/item/device/multitool/omnitool/O = get_active_hand()
+	if(istype(O))
+		return O.can_connect(target,src)
+	return FALSE
 
 /obj/item/device/multitool/omnitool/proc/can_connect(atom/target, mob/user)
 	var/client/C

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -168,7 +168,7 @@ nanoui is used to open and update nano browser uis
 		if(nano.src_object in view(7, nano.user))
 			can_interactive = 1
 	else
-		can_interactive = (isAI(nano.user) || !nano.distance_check || isAdminGhost(nano.user))
+		can_interactive = (isAI(nano.user) || !nano.distance_check || isAdminGhost(nano.user) || OMNI_LINK(nano.user,nano.src_object))
 
 	if (can_interactive)
 		return STATUS_INTERACTIVE // interactive (green visibility)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -740,7 +740,7 @@
 		"chargingStatus" = charging,
 		"totalLoad" = lastused_equip + lastused_light + lastused_environ,
 		"coverLocked" = coverlocked,
-		"siliconUser" = istype(user, /mob/living/silicon) || isAdminGhost(user), // Allow aghosts to fuck with APCs
+		"siliconUser" = istype(user, /mob/living/silicon) || isAdminGhost(user) || OMNI_LINK(user,src), // Allow aghosts to fuck with APCs
 		"malfLocked"= malflocked,
 		"malfStatus" = get_malf_status(user),
 
@@ -855,7 +855,7 @@
 			return 0
 
 	else
-		if ((!in_range(src, user) || !istype(src.loc, /turf)))
+		if ((!is_in_range(user) || !istype(src.loc, /turf)))
 			nanomanager.close_user_uis(user, src)
 
 		if (wiresexposed)
@@ -876,11 +876,8 @@
 	return 1
 
 /obj/machinery/power/apc/is_in_range(var/mob/user)
-	if((!in_range(src, usr) || !istype(src.loc, /turf)) && !istype(usr, /mob/living/silicon))
-		var/obj/item/device/multitool/omnitool/O = user.get_active_hand()
-		if(istype(O))
-			return O.can_connect(src,user)
-		return FALSE
+	if(!..())
+		return OMNI_LINK(user,src)
 	return TRUE
 
 /obj/machinery/power/apc/Topic(href, href_list)
@@ -895,7 +892,7 @@
 		return 0
 	if(!can_use(usr, 1))
 		return 0
-	if(!(istype(usr, /mob/living/silicon) || isAdminGhost(usr)) && locked)
+	if(!(istype(usr, /mob/living/silicon) || isAdminGhost(usr) || OMNI_LINK(usr, src)) && locked)
 	// Shouldn't happen, this is here to prevent href exploits
 		to_chat(usr, "You must unlock the panel to use this!")
 		return 1


### PR DESCRIPTION
closes #29762

This is the triumphant return of the omnitool as more than a curiosity, but a great tool. Man this was a pain to get working.

🆑 
* tweak: The omnitool (from the cloud ix crate) now properly allows you to remote control any APC or air alarm as though you were a silicon, as long as you have the appropriate access. This means it will be "unlocked" even remotely when the omnitool is in your active hand.
* bugfix: Fixed the bugs with using the omnitool at range.