### PR TITLE
Allows ghosts access to OOC manifest from lobby

### DIFF
--- a/code/modules/mob/dead/observer/verbs.dm
+++ b/code/modules/mob/dead/observer/verbs.dm
@@ -277,7 +277,7 @@
 
 	var/dat
 	dat += "<h4>Crew Manifest</h4>"
-	dat += data_core.get_manifest()
+	dat += data_core.get_manifest(OOC = 1)
 
 	src << browse(dat, "window=manifest;size=370x420;can_close=1")
 


### PR DESCRIPTION
[tweak]
Namely, the ability to view borgs/AI on the manifest
Let me know if everyone should see them, because I don't understand why they're restricted from it normally.
:cl:
 * rscadd: Ghosts can now view the full OOC crew manifest, with borgs and AIs.