### PR TITLE
Re-adds Holodeck Space and Library simulations

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -1236,6 +1236,8 @@ proc/process_adminbus_teleport_locs()
 	name = "\improper Holodeck - Checkers"
 /area/holodeck/source_gym
 	name = "\improper Holodeck - Gym"
+/area/holodeck/source_library
+	name = "\improper Holodeck - Library"
 
 /area/holodeck/source_catnip
 	name = "\improper Holodeck - Club Catnip"

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -16,11 +16,13 @@
 		"Firing Range" = /area/holodeck/source_firingrange,
 		"Gym" = /area/holodeck/source_gym,
 		"Laser Tag Arena" = /area/holodeck/source_lasertag,
+		"Library" = /area/holodeck/source_library,
 		"Maze" = /area/holodeck/source_maze,
 		"Meeting Hall" = /area/holodeck/source_meetinghall,
 		"Panic Bunker" = /area/holodeck/source_panic,
 		"Picnic Area" = /area/holodeck/source_picnicarea,
 		"Snow Field" = /area/holodeck/source_snowfield,
+		"Space" = /area/holodeck/source_space,
 		"Theatre" = /area/holodeck/source_theatre,
 		"Thunderdome Court" = /area/holodeck/source_thunderdomecourt,
 		"Wild Ride" = /area/holodeck/source_wildride,
@@ -46,10 +48,12 @@
 		"Empty Court" = /area/holodeck/source_emptycourt,
 		"Firing Range" = /area/holodeck/source_firingrange,
 		"Gym" = /area/holodeck/source_gym,
+		"Library" = /area/holodeck/source_library,
 		"Meeting Hall" = /area/holodeck/source_meetinghall,
 		"Panic Bunker" = /area/holodeck/source_panic,
 		"Picnic Area" = /area/holodeck/source_picnicarea,
 		"Snow Field" = /area/holodeck/source_snowfield,
+		"Space" = /area/holodeck/source_space,
 		"Theatre" = /area/holodeck/source_theatre,
 		"Thunderdome Court" = /area/holodeck/source_thunderdomecourt,
 		"Wild Ride" = /area/holodeck/source_wildride,
@@ -430,6 +434,47 @@
 /turf/simulated/floor/holofloor/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	return
 	// HOLOFLOOR DOES NOT GIVE A FUCK
+
+/turf/simulated/floor/holofloor/space
+	name = "space"
+	desc = "The final frontier! Or a very convincing projection of it."
+
+	icon = 'icons/turf/space.dmi'
+	icon_state = "0"
+
+	plane = SPACE_BACKGROUND_PLANE
+	dynamic_lighting = 0
+	luminosity = 1
+	intact = 0
+
+/turf/simulated/floor/holofloor/space/New(loc)
+	..(loc)
+	icon_state = "[((x + y) ^ ~(x * y) + z) % 25]"
+	/*
+/turf/simulated/floor/glass/holodeck
+
+/turf/simulated/floor/glass/holodeck/update_icon()
+	overlays.len = 0
+
+/turf/simulated/floor/glass/holodeck/attack_generic(var/mob/living/user, var/damage = 0)
+	return
+
+/turf/simulated/floor/glass/holodeck/attack_hand(var/mob/living/user)
+	return
+
+/turf/simulated/floor/glass/holodeck/hitby(var/atom/movable/AM)
+	return TRUE
+
+/turf/simulated/floor/glass/holodeck/Entered(var/atom/movable/mover)
+	return 1
+
+/turf/simulated/floor/glass/holodeck/bullet_act(var/obj/item/projectile/Proj)
+	return
+
+/turf/simulated/floor/glass/holodeck/ex_act(severity)
+	return
+*/
+/obj/structure/bookcase/holodeck	// TODO: Spawn random books on load? have those books despawn along with the bookcase?
 
 /obj/structure/table/holotable
 	parts = null

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -450,30 +450,7 @@
 /turf/simulated/floor/holofloor/space/New(loc)
 	..(loc)
 	icon_state = "[((x + y) ^ ~(x * y) + z) % 25]"
-	/*
-/turf/simulated/floor/glass/holodeck
 
-/turf/simulated/floor/glass/holodeck/update_icon()
-	overlays.len = 0
-
-/turf/simulated/floor/glass/holodeck/attack_generic(var/mob/living/user, var/damage = 0)
-	return
-
-/turf/simulated/floor/glass/holodeck/attack_hand(var/mob/living/user)
-	return
-
-/turf/simulated/floor/glass/holodeck/hitby(var/atom/movable/AM)
-	return TRUE
-
-/turf/simulated/floor/glass/holodeck/Entered(var/atom/movable/mover)
-	return 1
-
-/turf/simulated/floor/glass/holodeck/bullet_act(var/obj/item/projectile/Proj)
-	return
-
-/turf/simulated/floor/glass/holodeck/ex_act(severity)
-	return
-*/
 /obj/structure/bookcase/holodeck	// TODO: Spawn random books on load? have those books despawn along with the bookcase?
 
 /obj/structure/table/holotable

--- a/code/game/turfs/simulated/floor_glass.dm
+++ b/code/game/turfs/simulated/floor_glass.dm
@@ -175,8 +175,6 @@
 		"You hear banging.")
 		healthcheck(user, TRUE, "attack_hand hurt")
 
-	return
-
 /turf/simulated/floor/glass/attack_paw(mob/user as mob)
 	return attack_hand(user)
 

--- a/maps/misc/holodeck.dmm
+++ b/maps/misc/holodeck.dmm
@@ -269,9 +269,6 @@
 "fi" = (/turf/simulated/floor/holofloor{dir = 5; icon_state = "red"},/area/holodeck/source_basketball)
 "fj" = (/obj/item/weapon/stool/hologram,/obj/structure/window/holo{dir = 8},/turf/simulated/floor/holofloor{icon_state = "cult"},/area/holodeck/source_basketball)
 "fk" = (/obj/item/weapon/stool/hologram,/turf/simulated/floor/holofloor{icon_state = "cult"},/area/holodeck/source_basketball)
-"fl" = (/turf/space,/area/holodeck/source_space)
-"fm" = (/obj/item/toy/minimeteor,/turf/space,/area/holodeck/source_space)
-"fn" = (/obj/structure/window/reinforced/holo,/turf/space,/area/holodeck/source_space)
 "fo" = (/turf/simulated/floor/holofloor{icon_state = "snow"},/area/holodeck/source_snowfield)
 "fp" = (/obj/structure/snow_flora,/turf/simulated/floor/holofloor{icon_state = "snow"},/area/holodeck/source_snowfield)
 "fq" = (/obj/structure/flora/grass/both,/turf/simulated/floor/holofloor{icon_state = "snow"},/area/holodeck/source_snowfield)
@@ -297,13 +294,13 @@
 "fK" = (/turf/simulated/floor/holofloor/light,/area/holodeck/source_lasertag)
 "fL" = (/turf/simulated/shuttle/wall{icon_state = "wall3"},/area/holodeck/source_lasertag)
 "fM" = (/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_ragecage)
-"fN" = (/obj/structure/table/holotable/wood,/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet6-2"},/area)
-"fO" = (/obj/structure/table/holotable/wood,/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet14-10"},/area)
-"fP" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet10-8"},/area)
-"fQ" = (/obj/structure/bookcase,/turf/simulated/floor/holofloor{dir = 4; icon_state = "wood"},/area)
-"fR" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet6-2"},/area)
-"fS" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet14-10"},/area)
-"fT" = (/obj/structure/table/holotable/wood,/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet10-8"},/area)
+"fN" = (/obj/structure/table/holotable/wood,/obj/item/device/flashlight/lamp/green{pixel_x = 1; pixel_y = 5},/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet6-2"},/area/holodeck/source_library)
+"fO" = (/obj/structure/table/holotable/wood,/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet14-10"},/area/holodeck/source_library)
+"fP" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet10-8"},/area/holodeck/source_library)
+"fQ" = (/obj/structure/bookcase/holodeck,/turf/simulated/floor/holofloor{dir = 4; icon_state = "wood"},/area/holodeck/source_library)
+"fR" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet6-2"},/area/holodeck/source_library)
+"fS" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet14-10"},/area/holodeck/source_library)
+"fT" = (/obj/structure/table/holotable/wood,/obj/item/device/flashlight/lamp/green{pixel_x = 1; pixel_y = 5},/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet10-8"},/area/holodeck/source_library)
 "fU" = (/turf/simulated/floor/holofloor{icon_state = "grass1"; name = "Holodeck Projector Floor"},/area/holodeck/source_medieval)
 "fV" = (/turf/simulated/floor/holofloor{icon_state = "asteroid"},/area/holodeck/source_medieval)
 "fW" = (/obj/structure/flora/ausbushes/ywflowers,/turf/simulated/floor/holofloor{icon_state = "grass1"; name = "Holodeck Projector Floor"},/area/holodeck/source_medieval)
@@ -320,10 +317,6 @@
 "gh" = (/turf/simulated/floor/holofloor{icon_state = "red"},/area/holodeck/source_basketball)
 "gi" = (/turf/simulated/floor/holofloor{dir = 6; icon_state = "red"},/area/holodeck/source_basketball)
 "gj" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "red"},/area/holodeck/source_basketball)
-"gk" = (/obj/structure/window/reinforced/holo{dir = 4},/turf/space,/area/holodeck/source_space)
-"gl" = (/turf/simulated/floor/holofloor,/area/holodeck/source_space)
-"gm" = (/obj/structure/window/reinforced/holo{dir = 8},/turf/space,/area/holodeck/source_space)
-"gn" = (/obj/item/toy/spinningtoy,/turf/space,/area/holodeck/source_space)
 "go" = (/turf/simulated/floor/holofloor{icon_state = "carpet7-3"},/area/holodeck/source_meetinghall)
 "gp" = (/obj/structure/table/holotable/wood,/turf/simulated/floor/holofloor{icon_state = "carpet15-15"},/area/holodeck/source_meetinghall)
 "gq" = (/obj/structure/bed/chair/holowood/wings,/turf/simulated/floor/holofloor{icon_state = "carpet15-15"},/area/holodeck/source_meetinghall)
@@ -342,15 +335,11 @@
 "gD" = (/obj/structure/grille,/obj/structure/window/reinforced/holo{dir = 1},/obj/structure/window/reinforced/holo{dir = 8},/obj/structure/cable/white,/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_ragecage)
 "gE" = (/obj/structure/grille,/obj/structure/window/reinforced/holo,/obj/structure/window/reinforced/holo{dir = 1},/obj/structure/cable/white,/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_ragecage)
 "gF" = (/obj/structure/grille,/obj/structure/window/reinforced/holo{dir = 4},/obj/structure/window/reinforced/holo{dir = 1},/obj/structure/cable/white,/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_ragecage)
-"gG" = (/obj/structure/bed/chair/holowood/normal{dir = 1},/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet5-1"},/area)
-"gH" = (/obj/structure/bed/chair/holowood/normal{dir = 1},/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet13-5"},/area)
-"gI" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet9-4"},/area)
-"gJ" = (/turf/simulated/floor/holofloor{icon_state = "carpet7-3"},/area)
-"gK" = (/turf/simulated/floor/holofloor{icon_state = "carpet15-15"},/area)
-"gL" = (/turf/simulated/floor/holofloor{icon_state = "carpet11-12"},/area)
-"gM" = (/obj/structure/bookcase/manuals/research_and_development,/turf/simulated/floor/holofloor{dir = 4; icon_state = "wood"},/area)
-"gN" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet5-1"},/area)
-"gO" = (/obj/structure/bed/chair/holowood/normal{dir = 1},/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet9-4"},/area)
+"gG" = (/obj/structure/bed/chair/holowood/normal{dir = 1},/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet5-1"},/area/holodeck/source_library)
+"gH" = (/obj/structure/bed/chair/holowood/normal{dir = 1},/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet13-5"},/area/holodeck/source_library)
+"gI" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet9-4"},/area/holodeck/source_library)
+"gN" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet5-1"},/area/holodeck/source_library)
+"gO" = (/obj/structure/bed/chair/holowood/normal{dir = 1},/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet9-4"},/area/holodeck/source_library)
 "gP" = (/obj/structure/fence/corner{dir = 8},/turf/simulated/floor/holofloor{icon_state = "grass1"; name = "Holodeck Projector Floor"},/area/holodeck/source_medieval)
 "gQ" = (/obj/structure/fence{dir = 4},/turf/simulated/floor/holofloor{dir = 4; icon_state = "asteroid2"},/area/holodeck/source_medieval)
 "gR" = (/obj/structure/fence{dir = 4},/turf/simulated/floor/holofloor{icon_state = "grass1"; name = "Holodeck Projector Floor"},/area/holodeck/source_medieval)
@@ -363,12 +352,6 @@
 "gY" = (/obj/structure/window/reinforced/holo{dir = 1},/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor/holofloor,/area/holodeck/source_catnip)
 "gZ" = (/obj/structure/window/reinforced/holo{dir = 1},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/holofloor,/area/holodeck/source_catnip)
 "ha" = (/obj/structure/window/reinforced/holo{dir = 4},/obj/structure/window/reinforced/holo{dir = 1},/turf/simulated/floor/holofloor,/area/holodeck/source_catnip)
-"hb" = (/obj/structure/window/reinforced/holo,/obj/structure/window/reinforced/holo{dir = 4},/turf/space,/area/holodeck/source_space)
-"hc" = (/turf/simulated/floor/holofloor{icon_state = "rampbottom"},/area/holodeck/source_space)
-"hd" = (/obj/structure/window/reinforced/holo,/obj/structure/window/reinforced/holo{dir = 8},/obj/structure/window/reinforced/holo{dir = 1},/turf/space,/area/holodeck/source_space)
-"he" = (/obj/structure/window/reinforced/holo,/obj/structure/window/reinforced/holo{dir = 1},/turf/space,/area/holodeck/source_space)
-"hf" = (/obj/structure/window/reinforced/holo,/obj/structure/window/reinforced/holo{dir = 1},/obj/structure/window/reinforced/holo{dir = 4},/turf/space,/area/holodeck/source_space)
-"hg" = (/obj/structure/window/reinforced/holo,/obj/structure/window/reinforced/holo{dir = 8},/turf/space,/area/holodeck/source_space)
 "hh" = (/obj/structure/flora/rock/pile/snow,/turf/simulated/floor/holofloor{icon_state = "snow"},/area/holodeck/source_snowfield)
 "hi" = (/obj/structure/table/holotable/wood,/obj/item/weapon/gavelblock,/obj/item/weapon/gavelhammer,/turf/simulated/floor/holofloor{icon_state = "carpet15-15"},/area/holodeck/source_meetinghall)
 "hj" = (/obj/structure/table/holotable,/obj/item/device/deskbell{name = "bell"},/obj/item/clothing/under/mime{name = "referee's outfit"},/obj/item/weapon/storage/belt/champion,/obj/item/device/megaphone,/turf/simulated/floor/holofloor{icon_state = "cult"},/area/holodeck/source_boxingcourt)
@@ -383,9 +366,8 @@
 "hs" = (/obj/structure/table/holotable,/obj/item/clothing/shoes/roman,/obj/item/clothing/under/gladiator,/obj/item/clothing/head/helmet/gladiator,/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_ragecage)
 "ht" = (/obj/structure/table/holotable,/obj/item/clothing/shoes/roman,/obj/item/clothing/under/roman,/obj/item/clothing/head/helmet/roman,/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_ragecage)
 "hu" = (/obj/structure/table/holotable,/obj/item/clothing/suit/armor/knight/templar,/obj/item/clothing/head/helmet/knight/templar,/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_ragecage)
-"hv" = (/obj/structure/bookcase/manuals/engineering,/turf/simulated/floor/holofloor{dir = 4; icon_state = "wood"},/area)
-"hw" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "wood"},/area)
-"hx" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet13-5"},/area)
+"hw" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "wood"},/area/holodeck/source_library)
+"hx" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet13-5"},/area/holodeck/source_library)
 "hy" = (/obj/structure/fence,/turf/simulated/floor/holofloor{icon_state = "grass1"; name = "Holodeck Projector Floor"},/area/holodeck/source_medieval)
 "hz" = (/obj/structure/table/holotable/wood,/obj/item/clothing/suit/armor/knight/red,/obj/item/clothing/head/helmet/knight/red,/turf/simulated/floor/holofloor{icon_state = "asteroid"},/area/holodeck/source_medieval)
 "hA" = (/obj/structure/table/holotable/wood,/obj/item/weapon/claymore{pixel_x = -5},/obj/item/weapon/claymore{pixel_x = 5},/turf/simulated/floor/holofloor{icon_state = "grass1"; name = "Holodeck Projector Floor"},/area/holodeck/source_medieval)
@@ -413,9 +395,6 @@
 "hW" = (/obj/structure/window/reinforced/holo,/turf/simulated/floor/holofloor,/area/holodeck/source_catnip)
 "hX" = (/obj/structure/window/reinforced/holo,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/holofloor,/area/holodeck/source_catnip)
 "hY" = (/obj/structure/window/reinforced/holo{dir = 4},/obj/structure/window/reinforced/holo,/turf/simulated/floor/holofloor,/area/holodeck/source_catnip)
-"hZ" = (/obj/structure/window/reinforced/holo{dir = 1},/turf/space,/area/holodeck/source_space)
-"ia" = (/obj/structure/window/reinforced/holo{dir = 1},/obj/structure/window/reinforced/holo{dir = 4},/turf/space,/area/holodeck/source_space)
-"ib" = (/obj/structure/window/reinforced/holo{dir = 8},/obj/structure/window/reinforced/holo{dir = 1},/turf/space,/area/holodeck/source_space)
 "ic" = (/turf/simulated/floor/holofloor{icon_state = "carpet15-15"},/area/holodeck/source_meetinghall)
 "id" = (/obj/item/clothing/under/rainbow,/turf/simulated/floor/beach/sand,/area/holodeck/source_beach)
 "ie" = (/obj/item/clothing/glasses/sunglasses/holo,/turf/simulated/floor/beach/sand,/area/holodeck/source_beach)
@@ -449,7 +428,6 @@
 "iG" = (/obj/structure/window/reinforced/holo{dir = 1},/turf/simulated/floor/holofloor,/area/holodeck/source_thunderdomecourt)
 "iH" = (/obj/structure/window/reinforced/holo{dir = 1},/turf/simulated/floor/holofloor{dir = 4; icon_state = "green"},/area/holodeck/source_thunderdomecourt)
 "iI" = (/obj/structure/grille,/obj/structure/window/reinforced/holo{dir = 8},/obj/item/weapon/shard,/obj/structure/cable/white,/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_ragecage)
-"iJ" = (/obj/structure/bookcase/manuals/xenoarchaeology,/turf/simulated/floor/holofloor{dir = 4; icon_state = "wood"},/area)
 "iK" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "asteroid2"},/area/holodeck/source_medieval)
 "iL" = (/obj/item/trash/cigbutt,/turf/simulated/floor/holofloor/light,/area/holodeck/source_catnip)
 "iM" = (/turf/simulated/floor/holofloor{dir = 8; icon_state = "green"},/area/holodeck/source_basketball)
@@ -463,8 +441,7 @@
 "iU" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "asteroid3"},/area/holodeck/source_medieval)
 "iV" = (/obj/structure/window/reinforced/holo,/obj/item/trash/popcorn,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/holofloor/light,/area/holodeck/source_catnip)
 "iW" = (/obj/structure/window/reinforced/holo,/turf/simulated/floor/holofloor/light,/area/holodeck/source_catnip)
-"iX" = (/obj/structure/window/reinforced/holo{dir = 1},/obj/item/toy/minimeteor,/turf/space,/area/holodeck/source_space)
-"iY" = (/turf/simulated/floor/holofloor{dir = 1; icon_state = "rampbottom"},/area/holodeck/source_space)
+"iY" = (/turf/simulated/floor/holofloor/space,/area/holodeck/source_space)
 "iZ" = (/turf/simulated/floor/beach/coastline,/area/holodeck/source_beach)
 "ja" = (/turf/simulated/floor/holofloor{dir = 10; icon_state = "green"},/area/holodeck/source_boxingcourt)
 "jb" = (/obj/structure/window/reinforced/holo,/turf/simulated/floor/holofloor{icon_state = "green"},/area/holodeck/source_boxingcourt)
@@ -480,7 +457,6 @@
 "jl" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/holofloor{dir = 8; icon_state = "rampbottom"},/area/holodeck/source_catnip)
 "jm" = (/obj/structure/window/reinforced/holo{dir = 4},/turf/simulated/floor/holofloor,/area/holodeck/source_catnip)
 "jn" = (/obj/item/weapon/stool/hologram,/obj/item/clothing/accessory/armband/hydro{name = "green armband"},/obj/item/clothing/under/shorts/green,/turf/simulated/floor/holofloor{icon_state = "cult"},/area/holodeck/source_basketball)
-"jo" = (/obj/structure/window/reinforced/holo{dir = 4},/obj/item/toy/minimeteor,/turf/space,/area/holodeck/source_space)
 "jp" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet1-0"},/area/holodeck/source_meetinghall)
 "jq" = (/turf/simulated/floor/beach/water,/area/holodeck/source_beach)
 "jr" = (/obj/structure/table/holotable,/obj/item/clothing/gloves/boxing/hologlove{icon_state = "boxinggreen"; item_state = "boxinggreen"},/obj/item/clothing/gloves/boxing/hologlove{icon_state = "boxinggreen"; item_state = "boxinggreen"},/obj/item/clothing/under/shorts/green,/obj/item/clothing/under/shorts/green,/turf/simulated/floor/holofloor{icon_state = "cult"},/area/holodeck/source_boxingcourt)
@@ -489,10 +465,9 @@
 "ju" = (/obj/machinery/door/airlock/glass{id_tag = "holorage"},/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_ragecage)
 "jv" = (/obj/structure/grille,/obj/structure/window/reinforced/holo,/obj/structure/window/reinforced/holo{dir = 1},/obj/structure/cable/white,/obj/structure/window/reinforced/holo{dir = 8},/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_ragecage)
 "jw" = (/obj/structure/grille,/obj/structure/window/reinforced/holo,/obj/structure/window/reinforced/holo{dir = 4},/obj/structure/cable/white,/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_ragecage)
-"jx" = (/obj/structure/bed/chair/holowood/normal,/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet6-2"},/area)
-"jy" = (/obj/structure/bed/chair/holowood/normal,/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet14-10"},/area)
-"jz" = (/obj/structure/bookcase/manuals/medical,/turf/simulated/floor/holofloor{dir = 4; icon_state = "wood"},/area)
-"jA" = (/obj/structure/bed/chair/holowood/normal,/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet10-8"},/area)
+"jx" = (/obj/structure/bed/chair/holowood/normal,/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet6-2"},/area/holodeck/source_library)
+"jy" = (/obj/structure/bed/chair/holowood/normal,/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet14-10"},/area/holodeck/source_library)
+"jA" = (/obj/structure/bed/chair/holowood/normal,/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet10-8"},/area/holodeck/source_library)
 "jB" = (/obj/structure/fence/corner,/turf/simulated/floor/holofloor{icon_state = "asteroid"},/area/holodeck/source_medieval)
 "jC" = (/obj/structure/window/reinforced/holo,/obj/structure/window/reinforced/holo{dir = 8},/turf/simulated/floor/holofloor,/area/holodeck/source_catnip)
 "jD" = (/obj/structure/window/reinforced/holo{dir = 1},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/holofloor/light,/area/holodeck/source_catnip)
@@ -506,9 +481,9 @@
 "jL" = (/obj/item/toy/gasha/carptoy,/turf/simulated/floor/beach/water,/area/holodeck/source_beach)
 "jM" = (/obj/structure/table/holotable,/obj/item/clothing/head/helmet/thunderdome,/obj/item/clothing/suit/armor/tdome/green,/obj/item/clothing/under/color/green,/obj/item/weapon/holo/esword/green,/turf/simulated/floor/holofloor{icon_state = "green"},/area/holodeck/source_thunderdomecourt)
 "jN" = (/obj/structure/table/holotable,/obj/machinery/readybutton{pixel_y = 0},/turf/simulated/floor/holofloor{icon_state = "green"},/area/holodeck/source_thunderdomecourt)
-"jO" = (/obj/structure/table/holotable/wood,/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet5-1"},/area)
-"jP" = (/obj/structure/table/holotable/wood,/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet13-5"},/area)
-"jQ" = (/obj/structure/table/holotable/wood,/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet9-4"},/area)
+"jO" = (/obj/structure/table/holotable/wood,/obj/item/device/flashlight/lamp/green{pixel_x = 1; pixel_y = 5},/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet5-1"},/area/holodeck/source_library)
+"jP" = (/obj/structure/table/holotable/wood,/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet13-5"},/area/holodeck/source_library)
+"jQ" = (/obj/structure/table/holotable/wood,/obj/item/device/flashlight/lamp/green{pixel_x = 1; pixel_y = 5},/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet9-4"},/area/holodeck/source_library)
 "jR" = (/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/holofloor{icon_state = "asteroid"},/area/holodeck/source_medieval)
 "jS" = (/turf/unsimulated/wall{icon_state = "iron13"},/area)
 "jT" = (/obj/structure/window/reinforced{dir = 1},/turf/unsimulated/wall{icon_state = "iron12"},/area)
@@ -526,15 +501,15 @@ acadaTadadadadadadadaTadaeafaWafaidQafafbXafafafaeaYbaaZaYbaaYbaaYaYbaaYaedududu
 acadadaTadadadadadaTadadaeafbXafafaiafafeoafagaWaeaZaYbaaZaYaZaYaZaZaYaZaedududuepeqeqeqerdududuaeaxaxaxaxaxaxaxaxaxaxaxaeayayayayayayayayayayayaedabdbdbdbdbdbdbdbdbddbaedUdUdUdUdUdUdUdUdUdUdUaeaDaDeseteuevewexeyezaDaeaEaFaFaFaFeAaFaFaFaFaEaeeBeBeBeCeBaJbqaGaGeDaGaeeEeEeEeEaOeFaOeGeGeGeGaeaQaQaQaQefaQbsbsbsaQaQaeaRaReHeIeJeKeLeMeNeOaRaeaSaSaSaSaSaSaSaSaSaSaSae
 acadadadadadadadadadadadaeePafaiafePaiafafafagafaealeQajalakajeQalalakalaedududududududududududuaeaxaxaxaxaxaxaxaxaxaxaxaeayayayayayayayayayayayaeeReSeSeSeSeSeSeSeSeSeTaeeUdUdUeVdUeWdUeXdUdUeYaeaDaDaDaDaDaDaDaDaDaDaDaeaEaEaEaFaFaFaFaFaEaEaEaeeZeCeBeBeBaJeDaGbpaGfaaeeEeEeEeEaOaOaOeGeGeGeGaeaQaQaQaQaQaQaQaQaQaQaQaeaRaRaRaRaRaRaRaRaRaRaRaeaSaSaSaSaSaSaSaSaSaSaSae
 fbfcfcfcfcfcfcfcfcfcfcfcfbfcfcfcfcfcfcfcfcfcfcfcfbfcfcfcfcfcfcfcfcfcfcfcfbfcfcfcfcfcfcfcfcfcfcfcfbfcfcfcfcfcfcfcfcfcfcfcfbfcfcfcfcfcfcfcfcfcfcfcfbfcfcfcfcfcfcfcfcfcfcfcfbfcfcfcfcfcfcfcfcfcfcfcfbfcfcfcfcfcfcfcfcfcfcfcfbfcfcfcfcfcfcfcfcfcfcfcfbfcfcfcfcfcfcfcfcfcfcfcaaabababababababababababfbfcfcfcfcfcfcfcfcfcfcfcaaabababababababababababaaabababababababababababaa
-acfdfefffgfffhfifgfifjfkaeflflfmfnfnfnfnfnflflflaefofofofofofofpfofofqfraefsfsfsftfufufufvfsfsfsaefwfwfwfwfxfyfzfxfwfwfwaefAfBfCfDfDfDfDfDfDfEfAaefFfFfFfFfFfFfFfFfFfFfFaefGfHfHfHfHfHfHfHfHfHfIaefJfJfJfJfJfJfJfJfJfJfJaefKfKfKfKfKfLfKfKfKfKfKaefMfMfMfMfMfMfMfMfMfMfMaefNfOfPfQfRfSfPfQfRfOfTaefUfVfUfWfUfUfUfUfUfUfXaefYfZgafYgbgagafYgcfYfYaeaSaSaSaSaSaSaSaSaSaSaSae
-acfdgdgegfggghgigfgjfjfkaeflflgkglglglglglgmgnflaefrfofofofqfofofofofrfoaefsfsfsgogpgqgpgrfsfsfsaefwgsfwgtfwfwfwfwfwfwfwaefAfBgugvgvgvgvgvgwfEfAaefFfFfFfFfFfFfFfFfFfFfFaegxgygzgzgAgygAgygzgAgBaefJgCfJgCgCfJgCgCgCgCfJaefKfKfKfKfKfKfKfKfKfKfKaefMfMgDgEgEgEgEgEgFfMfMaegGgHgIfQgJgKgLgMgNgHgOaefUgPgQgRgRgSgTgRgRgUfXaefZgVgWgXgXgWgYgZgWhafYaeaSaSaSaSaSaSaSaSaSaSaSae
-acfkgdgegfgfgfgfgfgjfjfkaefnfnhbhchdhehfhchgfnfnaefofofofofofofofofohhfoaefsfsfsgogphigpgrfsfsfsaefwfwfwfwfwfwfwfwfwgsfwaefAfBgugvgvgvgvgvgwfEfAaefFfFhjfFhkhkhkfFhlfFfFaegxhmfHfIhnhogxhmfIgxgBaefJgCfJgCfJfJgCfJfJfJgCaefKfKfLfKfKfLfKfKfLfKfKaefMhphqhrhshthufMhqhpfMaefQhvhwfQgNhxgIfQhwfQfQaefUhyhzhAfUfUfVhBhChyfUaegbhDhEhFhGhHhGhGhIhJgaaeaSaSaSaSaSaSaSaSaSaSaSae
-achKhKgegfgfghgfgfgjhKhKaeglglglglglglglglglglglaefrfohLfofofofofohMfofoaefsfsfsgohNhOhPgrfsfsfsaefwfwfwfwfwfwfwfwfwfwfwaehQhQgugvgvgvgvgvgwhQhQaefFfFfFhRhShShShTfFfFfFaegxgygzhofGfIgxgyhogxgBaefJgCfJgCfJgCgCgCgCfJfJaefKfKfKfKfKfKfKfKfKfKfKaefMhphqfMfMfMfMfMhqhpfMaehwhwhwfQfQfQfQfQhwhwhwaefXhyfVfVfVfVfVfUfVhUfUaefYhVhGhWhWhWhXhWhGhYfZaeaSaSaSaSaSaSaSaSaSaSaSae
-acfkgdggghgighggghgifjfkaehZhZhZhZiaglibhZhZhZhZaefofofofofofofqfofofofoaeftfufuicicicicicfufufvaefwidiefwfwifigfwihfwfwaefAfBiiijijijijijikfEfAaefFfFhkilimimiminhkfFfFaegxhmfHfIgxhmiohmfIgxgBaegCfJfJgCfJfJfJfJgCfJgCaefKfKfKfLfKfKfKfKfKfKfLaefMhphqipfMiqfMfMhqhpfMaefQhwfRfSfSfSfSfSfPhwfQaefUhUirfVfVisfVfVfVhUfUaegaitiuivgafYfZiwiuivfYaeaSaSaSaSaSaSaSaSaSaSaSae
-acfkgdixiyiziAixiyizfjfkaefnfnfnfnhbglhgfnfnfnfnaefohMfoiBhhiCfofofofofoaegogpgpgpgpiDgpgpgpgpgraefwfwfwiEfwfwfwfwfwfwfwaefAfBiFiGiGiGiGiGiHfEfAaefFfFhkilimimiminhkfFfFaegxgygzhohngzgAgyhogxgBaefJgCgCfJgCfJgCgCgCfJgCaefLfKfKfKfKfKfKfLfKfKfKaefMhpiIfMfMfMfMfMhqhpfMaefQhwgNhxhxhxhxhxgIhwiJaefUhUfVfVfVfVfVfVfVhUiKaefZfYfYfYfYfYgafZiLfYgaaeaSaSaSaSaSaSaSaSaSaSaSae
-achKhKiMgfgfiygfgfiNhKhKaeglglglglglglglglglglglaefofofofofohhfofofohLfoaegoiOiOiOiOiPiOiOiOiOgraeiQiQiQiQiQiQiQiQiQiQiQaehQhQiRgvgvgvgvgviShQhQaefFfFhkilimimiminhkfFfFaegxhmfHfHfHfIgxhmfIgxgBaegCfJgCfJfJfJgCfJfJfJgCaefKfKfKfKfKfKfKfKfKfKfKaefMhphqfMiTfMfMfMhqhpfMaehwhwhwfQfQfQfQfQhwhwhwaefUhyfViUfVfVfVfVfVhUfUaegagVgWhaiVfYiWgVgWhafYaeaSaSaSaSaSaSaSaSaSaSaSae
-acfkgdiMgfgfgfgfgfiNfjfkaeiXhZiaiYhdhehfiYibhZhZaefoiBfofofofofofrfofofoaegogpgpgpgpiPgpgpgpgpgraeiZiZiZiZiZiZiZiZiZiZiZaefAfBiRgvgvgvgvgviSfEfAaefFfFfFjajbjbjbjcfFfFfFaegxgygAgygAgBgxgyhogxgBaefJfJfJfJfJgCfJgCgCfJgCaefKfKfLfKfKfLfKfKfLfKfKaefMhphqfMfMfMfMjdhqhpfMaefQfQhwfQfRfSfPfQhwfQfQaefUhUjejffXfUfUjgjhhyfUaefZhDjijjjkfYjlhGjijmfYaeaSaSaSaSaSaSaSaSaSaSaSae
-acfkgdiMgfixiyizgfiNfjjnaeflfljoglglglglglgmflflaefoiBfohMfofofofofofofoaegoiOiOiOiOjpiOiOiOiOgraejqjqjqjqjqjqjqjqjqjqjqaefAfBiRgvgvgvgvgviSfEfAaefFfFjrfFhkhkhkfFfFfFfFaegxgBgxgBgxgBgxhmfIgxgBaefJgCgCgCgCgCfJgCgCfJgCaefKfKfKfKfKfKfKfKfKfKfKaefMfMjsgEjtjujvgEjwfMfMaejxjyfPjzgJgKgLfQfRjyjAaefVgPgTgRgRgSgRgRgRjBfUaefYjChWhYjDfYjDjChWhYgbaeaSaSaSaSaSaSaSaSaSaSaSae
-acfkgdjEjFjEjGjHjFjHjIjnaefmflflhZhZhZhZhZflflflaefohLfofofrfohLfofohMfoaejJhOhOhOhOhOhOhOhOhOjKaejqjqjqjqjLjqjqjqjqjqjqaefAfBjMjMjMjMjMjMjNfEfAaefFfFfFfFfFfFfFfFfFfFfFaehnhohnhohnhohngzhohnhoaefJfJfJfJfJfJfJfJfJfJgCaefKfKfKfKfKfLfKfKfKfKfKaefMfMfMfMfMfMfMfMfMfMfMaejOjPgIfQgNhxgIfQgNjPjQaejRfUfUfXfUfUfVfUfUfUfUaegafYfYfZfYfYgafYfYgagbaeaSaSaSaSaSaSaSaSaSaSaSae
+acfdfefffgfffhfifgfifjfkaeiYiYiYiYiYiYiYiYiYiYiYaefofofofofofofpfofofqfraefsfsfsftfufufufvfsfsfsaefwfwfwfwfxfyfzfxfwfwfwaefAfBfCfDfDfDfDfDfDfEfAaefFfFfFfFfFfFfFfFfFfFfFaefGfHfHfHfHfHfHfHfHfHfIaefJfJfJfJfJfJfJfJfJfJfJaefKfKfKfKfKfLfKfKfKfKfKaefMfMfMfMfMfMfMfMfMfMfMaefNfOfPfQfQfQfQfQfRfOfTaefUfVfUfWfUfUfUfUfUfUfXaefYfZgafYgbgagafYgcfYfYaeaSaSaSaSaSaSaSaSaSaSaSae
+acfdgdgegfggghgigfgjfjfkaeiYiYiYiYiYiYiYiYiYiYiYaefrfofofofqfofofofofrfoaefsfsfsgogpgqgpgrfsfsfsaefwgsfwgtfwfwfwfwfwfwfwaefAfBgugvgvgvgvgvgwfEfAaefFfFfFfFfFfFfFfFfFfFfFaegxgygzgzgAgygAgygzgAgBaefJgCfJgCgCfJgCgCgCgCfJaefKfKfKfKfKfKfKfKfKfKfKaefMfMgDgEgEgEgEgEgFfMfMaegGgHgIfQfRfSfPhwgNgHgOaefUgPgQgRgRgSgTgRgRgUfXaefZgVgWgXgXgWgYgZgWhafYaeaSaSaSaSaSaSaSaSaSaSaSae
+acfkgdgegfgfgfgfgfgjfjfkaeiYiYiYiYiYiYiYiYiYiYiYaefofofofofofofofofohhfoaefsfsfsgogphigpgrfsfsfsaefwfwfwfwfwfwfwfwfwgsfwaefAfBgugvgvgvgvgvgwfEfAaefFfFhjfFhkhkhkfFhlfFfFaegxhmfHfIhnhogxhmfIgxgBaefJgCfJgCfJfJgCfJfJfJgCaefKfKfLfKfKfLfKfKfLfKfKaefMhphqhrhshthufMhqhpfMaefQfQhwfQgNhxgIfQhwfQfQaefUhyhzhAfUfUfVhBhChyfUaegbhDhEhFhGhHhGhGhIhJgaaeaSaSaSaSaSaSaSaSaSaSaSae
+achKhKgegfgfghgfgfgjhKhKaeiYiYiYiYiYiYiYiYiYiYiYaefrfohLfofofofofohMfofoaefsfsfsgohNhOhPgrfsfsfsaefwfwfwfwfwfwfwfwfwfwfwaehQhQgugvgvgvgvgvgwhQhQaefFfFfFhRhShShShTfFfFfFaegxgygzhofGfIgxgyhogxgBaefJgCfJgCfJgCgCgCgCfJfJaefKfKfKfKfKfKfKfKfKfKfKaefMhphqfMfMfMfMfMhqhpfMaehwhwhwfQfQfQfQfQhwhwhwaefXhyfVfVfVfVfVfUfVhUfUaefYhVhGhWhWhWhXhWhGhYfZaeaSaSaSaSaSaSaSaSaSaSaSae
+acfkgdggghgighggghgifjfkaeiYiYiYiYiYiYiYiYiYiYiYaefofofofofofofqfofofofoaeftfufuicicicicicfufufvaefwidiefwfwifigfwihfwfwaefAfBiiijijijijijikfEfAaefFfFhkilimimiminhkfFfFaegxhmfHfIgxhmiohmfIgxgBaegCfJfJgCfJfJfJfJgCfJgCaefKfKfKfLfKfKfKfKfKfKfLaefMhphqipfMiqfMfMhqhpfMaefQfQfRfSfSfSfSfSfPfQfQaefUhUirfVfVisfVfVfVhUfUaegaitiuivgafYfZiwiuivfYaeaSaSaSaSaSaSaSaSaSaSaSae
+acfkgdixiyiziAixiyizfjfkaeiYiYiYiYiYiYiYiYiYiYiYaefohMfoiBhhiCfofofofofoaegogpgpgpgpiDgpgpgpgpgraefwfwfwiEfwfwfwfwfwfwfwaefAfBiFiGiGiGiGiGiHfEfAaefFfFhkilimimiminhkfFfFaegxgygzhohngzgAgyhogxgBaefJgCgCfJgCfJgCgCgCfJgCaefLfKfKfKfKfKfKfLfKfKfKaefMhpiIfMfMfMfMfMhqhpfMaefQfQgNhxhxhxhxhxgIfQfQaefUhUfVfVfVfVfVfVfVhUiKaefZfYfYfYfYfYgafZiLfYgaaeaSaSaSaSaSaSaSaSaSaSaSae
+achKhKiMgfgfiygfgfiNhKhKaeiYiYiYiYiYiYiYiYiYiYiYaefofofofofohhfofofohLfoaegoiOiOiOiOiPiOiOiOiOgraeiQiQiQiQiQiQiQiQiQiQiQaehQhQiRgvgvgvgvgviShQhQaefFfFhkilimimiminhkfFfFaegxhmfHfHfHfIgxhmfIgxgBaegCfJgCfJfJfJgCfJfJfJgCaefKfKfKfKfKfKfKfKfKfKfKaefMhphqfMiTfMfMfMhqhpfMaehwhwhwfQfQfQfQfQhwhwhwaefUhyfViUfVfVfVfVfVhUfUaegagVgWhaiVfYiWgVgWhafYaeaSaSaSaSaSaSaSaSaSaSaSae
+acfkgdiMgfgfgfgfgfiNfjfkaeiYiYiYiYiYiYiYiYiYiYiYaefoiBfofofofofofrfofofoaegogpgpgpgpiPgpgpgpgpgraeiZiZiZiZiZiZiZiZiZiZiZaefAfBiRgvgvgvgvgviSfEfAaefFfFfFjajbjbjbjcfFfFfFaegxgygAgygAgBgxgyhogxgBaefJfJfJfJfJgCfJgCgCfJgCaefKfKfLfKfKfLfKfKfLfKfKaefMhphqfMfMfMfMjdhqhpfMaefQfQhwfQfRfSfPfQhwfQfQaefUhUjejffXfUfUjgjhhyfUaefZhDjijjjkfYjlhGjijmfYaeaSaSaSaSaSaSaSaSaSaSaSae
+acfkgdiMgfixiyizgfiNfjjnaeiYiYiYiYiYiYiYiYiYiYiYaefoiBfohMfofofofofofofoaegoiOiOiOiOjpiOiOiOiOgraejqjqjqjqjqjqjqjqjqjqjqaefAfBiRgvgvgvgvgviSfEfAaefFfFjrfFhkhkhkfFfFfFfFaegxgBgxgBgxgBgxhmfIgxgBaefJgCgCgCgCgCfJgCgCfJgCaefKfKfKfKfKfKfKfKfKfKfKaefMfMjsgEjtjujvgEjwfMfMaejxjyfPhwgNhxgIfQfRjyjAaefVgPgTgRgRgSgRgRgRjBfUaefYjChWhYjDfYjDjChWhYgbaeaSaSaSaSaSaSaSaSaSaSaSae
+acfkgdjEjFjEjGjHjFjHjIjnaeiYiYiYiYiYiYiYiYiYiYiYaefohLfofofrfohLfofohMfoaejJhOhOhOhOhOhOhOhOhOjKaejqjqjqjqjLjqjqjqjqjqjqaefAfBjMjMjMjMjMjMjNfEfAaefFfFfFfFfFfFfFfFfFfFfFaehnhohnhohnhohngzhohnhoaefJfJfJfJfJfJfJfJfJfJgCaefKfKfKfKfKfLfKfKfKfKfKaefMfMfMfMfMfMfMfMfMfMfMaejOjPgIfQfQfQfQfQgNjPjQaejRfUfUfXfUfUfVfUfUfUfUaegafYfYfZfYfYgafYfYgagbaeaSaSaSaSaSaSaSaSaSaSaSae
 jSjTjTjTjTjTjTjTjTjTjTjTjSjTjTjTjTjTjTjTjTjTjTjTjSjTjTjTjTjTjTjTjTjTjTjTjSjTjTjTjTjTjTjTjTjTjTjTjSjTjTjTjTjTjTjTjTjTjTjTjSjTjTjTjTjTjTjTjTjTjTjTjSjTjTjTjTjTjTjTjTjTjTjTjSjTjTjTjTjTjTjTjTjTjTjTjSjTjTjTjTjTjTjTjTjTjTjTjSjTjTjTjTjTjTjTjTjTjTjTjSjTjTjTjTjTjTjTjTjTjTjTfbfcfcfcfcfcfcfcfcfcfcfcfbfcfcfcfcfcfcfcfcfcfcfcfbfcfcfcfcfcfcfcfcfcfcfcfbfcfcfcfcfcfcfcfcfcfcfcfb
 "}

--- a/maps/misc/holodeck_3x3.dmm
+++ b/maps/misc/holodeck_3x3.dmm
@@ -11,11 +11,11 @@
 "eh" = (/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_plating)
 "ej" = (/obj/structure/flora/ausbushes/grassybush,/turf/simulated/floor/holofloor/grass,/area/holodeck/source_picnicarea)
 "ez" = (/turf/simulated/floor/holofloor{dir = 9; icon_state = "red"},/area/holodeck/source_emptycourt)
-"fy" = (/turf/simulated/floor/holofloor,/area/holodeck/source_space)
 "fA" = (/obj/machinery/conveyor/auto{dir = 10},/obj/machinery/conveyor/auto{dir = 10},/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_wildride)
 "hk" = (/obj/machinery/conveyor/auto{dir = 1},/obj/machinery/conveyor/auto,/obj/machinery/conveyor/auto,/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_wildride)
 "hn" = (/obj/structure/table/holotable/wood,/obj/item/weapon/kitchen/utensil/fork{pixel_x = 16},/obj/item/weapon/kitchen/utensil/fork{pixel_x = 14},/obj/item/weapon/kitchen/utensil/fork{pixel_x = 12},/obj/item/weapon/kitchen/utensil/fork{pixel_x = 10},/obj/item/weapon/kitchen/utensil/knife{pixel_x = -16},/obj/item/weapon/kitchen/utensil/knife{pixel_x = -14},/obj/item/weapon/kitchen/utensil/knife{pixel_x = -12},/obj/item/weapon/kitchen/utensil/knife{pixel_x = -10},/obj/item/trash/plate{pixel_y = -12},/obj/item/trash/plate{pixel_y = 12},/obj/item/trash/plate{pixel_y = -6},/obj/item/trash/plate{pixel_y = 6},/obj/item/candle,/turf/simulated/floor/holofloor{dir = 4; icon_state = "wood"},/area/holodeck/source_dining)
 "hK" = (/obj/machinery/conveyor/auto{dir = 5},/obj/machinery/conveyor/auto{dir = 5},/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_wildride)
+"hV" = (/obj/structure/table/holotable/wood,/obj/item/device/flashlight/lamp/green{pixel_x = 1; pixel_y = 5},/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet14-10"},/area/holodeck/source_library)
 "ii" = (/obj/structure/window/reinforced,/turf/unsimulated/wall{icon_state = "iron12"},/area)
 "iO" = (/turf/simulated/floor/holofloor,/area/holodeck/source_basketball)
 "iX" = (/obj/structure/flora/ausbushes/fullgrass,/turf/simulated/floor/holofloor{icon_state = "asteroid"},/area/holodeck/source_desert)
@@ -37,16 +37,16 @@
 "rJ" = (/obj/structure/curtain/black/holo,/turf/simulated/floor/holofloor{icon_state = "cult"},/area/holodeck/source_theatre)
 "rT" = (/turf/simulated/floor/holofloor{dir = 6; icon_state = "green"},/area/holodeck/source_basketball)
 "sU" = (/obj/structure/table/holotable,/obj/item/clothing/under/color/red,/obj/item/clothing/suit/armor/tdome/red,/obj/item/clothing/head/helmet/thunderdome,/obj/item/weapon/holo/esword/red,/obj/machinery/readybutton,/turf/simulated/floor/holofloor{dir = 1; icon_state = "red"},/area/holodeck/source_thunderdomecourt)
+"tl" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "wood"},/area/holodeck/source_library)
 "tY" = (/obj/structure/flora/grass/both,/turf/simulated/floor/holofloor{icon_state = "snow"},/area/holodeck/source_snowfield)
 "vf" = (/turf/simulated/floor/holofloor{dir = 1; icon_state = "red"},/area/holodeck/source_thunderdomecourt)
 "vZ" = (/obj/machinery/conveyor/auto{dir = 4},/obj/machinery/conveyor/auto{dir = 8},/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_wildride)
-"xc" = (/obj/structure/window/reinforced/holo,/turf/space,/area/holodeck/source_space)
 "xj" = (/obj/structure/bed/chair/holowood/normal{dir = 1},/turf/simulated/floor/holofloor{dir = 4; icon_state = "wood"},/area/holodeck/source_dining)
 "xk" = (/obj/structure/rack/holo,/obj/item/clothing/suit/bomb_suit,/obj/item/clothing/suit/bomb_suit,/obj/item/clothing/head/bomb_hood,/obj/item/clothing/head/bomb_hood,/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_panic)
 "xw" = (/turf/simulated/floor/holofloor/grass,/area/holodeck/source_zoo)
 "xP" = (/obj/structure/bed/chair/holowood/wings,/turf/simulated/floor/holofloor{dir = 4; icon_state = "wood"},/area/holodeck/source_dining)
+"xS" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet13-5"},/area/holodeck/source_library)
 "ys" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "red"},/area/holodeck/source_boxingcourt)
-"yw" = (/obj/structure/window/reinforced/holo,/obj/item/toy/spinningtoy,/turf/space,/area/holodeck/source_space)
 "yx" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "wood"},/area/holodeck/source_dining)
 "yI" = (/obj/item/weapon/beach_ball/holoball,/turf/simulated/floor/holofloor,/area/holodeck/source_basketball)
 "yM" = (/turf/simulated/floor/holofloor{dir = 8; icon_state = "ramptop"},/area/holodeck/source_panic)
@@ -58,20 +58,20 @@
 "CG" = (/turf/simulated/floor/holofloor,/area/holodeck/source_emptycourt)
 "CT" = (/obj/item/toy/gasha/carptoy,/turf/simulated/floor/beach/coastline,/area/holodeck/source_beach)
 "Da" = (/obj/structure/snow_flora,/turf/simulated/floor/holofloor{icon_state = "snow"},/area/holodeck/source_snowfield)
+"Db" = (/obj/structure/bed/chair/holowood/normal{dir = 8},/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet10-8"},/area/holodeck/source_library)
 "Dh" = (/turf/unsimulated/wall{icon_state = "iron14"},/area)
 "Do" = (/obj/structure/holohoop{dir = 1},/turf/simulated/floor/holofloor{icon_state = "green"},/area/holodeck/source_basketball)
 "DU" = (/turf/simulated/floor/beach/coastline,/area/holodeck/source_beach)
 "EN" = (/obj/item/weapon/stool/hologram,/turf/simulated/floor/holofloor{icon_state = "asteroid"},/area/holodeck/source_picnicarea)
 "ER" = (/turf/simulated/floor/holofloor{dir = 5; icon_state = "red"},/area/holodeck/source_firingrange)
 "Fv" = (/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area)
-"FJ" = (/obj/structure/window/reinforced/holo,/obj/item/toy/minimeteor,/turf/space,/area/holodeck/source_space)
 "FV" = (/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/holofloor/grass,/area/holodeck/source_picnicarea)
 "Gb" = (/obj/structure/rack/holo,/obj/item/clothing/mask/gas/monkeymask,/obj/item/clothing/suit/monkeysuit,/obj/item/clothing/head/cowboy,/obj/item/clothing/under/gokugi,/obj/item/clothing/head/collectable/wizard,/obj/item/clothing/suit/wizrobe/fake,/obj/item/clothing/mask/gas/owl_mask,/obj/item/clothing/under/owl,/obj/item/clothing/under/darkholme,/obj/item/clothing/head/collectable/pirate,/obj/item/clothing/under/pirate,/obj/item/clothing/under/wedding/bride_white,/obj/item/clothing/shoes/rottenshoes,/obj/item/clothing/under/rottensuit,/obj/item/clothing/under/schoolgirl,/obj/item/clothing/head/collectable/xenom,/obj/item/clothing/suit/xenos,/turf/simulated/floor/holofloor{icon_state = "cult"},/area/holodeck/source_theatre)
 "Gc" = (/obj/structure/skele_stand/mrbones{anchored = 1},/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_wildride)
 "Gf" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "asteroid3"},/area/holodeck/source_desert)
 "Gi" = (/obj/structure/bed/chair/holowood/normal{dir = 8},/turf/simulated/floor/holofloor{dir = 4; icon_state = "wood"},/area/holodeck/source_dining)
 "Gr" = (/obj/structure/foamedmetal,/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_panic)
-"GQ" = (/obj/structure/window/reinforced/holo{dir = 1},/turf/space,/area/holodeck/source_space)
+"GQ" = (/turf/simulated/floor/holofloor/space,/area/holodeck/source_space)
 "GU" = (/mob/living/simple_animal/hologram/tajaran_dancer,/turf/simulated/floor/holofloor/grass,/area/holodeck/source_zoo)
 "Hk" = (/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_panic)
 "HN" = (/obj/effect/landmark{name = "Holocarp Spawn"},/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_wildlife)
@@ -87,7 +87,9 @@
 "LN" = (/obj/structure/target_stake,/obj/item/target/alien,/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_firingrange)
 "Mh" = (/turf/simulated/floor/holofloor{dir = 9; icon_state = "red"},/area/holodeck/source_firingrange)
 "Mr" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced,/turf/unsimulated/wall{icon_state = "iron12"},/area)
+"Mu" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet5-1"},/area/holodeck/source_library)
 "ML" = (/turf/simulated/floor/holofloor{dir = 6; icon_state = "green"},/area/holodeck/source_emptycourt)
+"Np" = (/obj/structure/bed/chair/holowood/normal{dir = 4},/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet6-2"},/area/holodeck/source_library)
 "Ny" = (/turf/simulated/floor/holofloor,/area/holodeck/source_gym)
 "NM" = (/obj/structure/table/holotable/wood,/obj/item/clothing/under/swimsuit/blue{pixel_x = 4; pixel_y = 4},/obj/item/clothing/under/swimsuit/purple,/obj/item/clothing/under/swimsuit/green{pixel_x = -6; pixel_y = 2},/obj/item/clothing/under/shorts/red{pixel_x = 5; pixel_y = 8},/obj/item/clothing/under/shorts/green{pixel_x = -3; pixel_y = 3},/obj/item/clothing/under/shorts/blue{pixel_x = 2; pixel_y = -2},/turf/simulated/floor/beach/sand,/area/holodeck/source_beach)
 "NO" = (/turf/simulated/floor/holofloor{icon_state = "green"},/area/holodeck/source_gym)
@@ -109,6 +111,7 @@
 "SV" = (/turf/simulated/floor/holofloor{dir = 10; icon_state = "green"},/area/holodeck/source_basketball)
 "Tt" = (/obj/structure/rack/holo,/obj/item/clothing/suit/bio_suit,/obj/item/clothing/suit/bio_suit,/obj/item/clothing/head/bio_hood,/obj/item/clothing/head/bio_hood,/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_panic)
 "Ur" = (/turf/simulated/floor/holofloor,/area/holodeck/source_firingrange)
+"UF" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "carpet9-4"},/area/holodeck/source_library)
 "Va" = (/obj/structure/rack/holo,/obj/item/clothing/suit/radiation,/obj/item/clothing/suit/radiation,/obj/item/clothing/head/radiation,/obj/item/clothing/head/radiation,/turf/simulated/floor/holofloor{icon_state = "engine"; name = "Holodeck Projector Floor"},/area/holodeck/source_panic)
 "Vb" = (/obj/structure/fence,/turf/simulated/floor/holofloor{icon_state = "asteroid"},/area/holodeck/source_zoo)
 "Vf" = (/obj/structure/stacklifter/holo,/turf/simulated/floor/holofloor{dir = 1; icon_state = "green"},/area/holodeck/source_gym)
@@ -122,18 +125,19 @@
 "Xt" = (/obj/structure/flora/ausbushes/ywflowers,/turf/simulated/floor/holofloor/grass,/area/holodeck/source_zoo)
 "XB" = (/turf/simulated/floor/holofloor{dir = 8; icon_state = "green"},/area/holodeck/source_emptycourt)
 "XD" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "wood"},/area/holodeck/source_theatre)
+"XE" = (/obj/structure/bookcase/holodeck,/turf/simulated/floor/holofloor{dir = 4; icon_state = "wood"},/area/holodeck/source_library)
 "Ya" = (/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/holofloor{icon_state = "asteroid"},/area/holodeck/source_desert)
 "Zo" = (/turf/simulated/floor/holofloor{dir = 4; icon_state = "red"},/area/holodeck/source_emptycourt)
 "ZH" = (/obj/structure/flora/ausbushes/lavendergrass,/turf/simulated/floor/holofloor/grass,/area/holodeck/source_picnicarea)
 
 (1,1,1) = {"
 DhiiiiiiDhiiiiiiDhiiiiiiDhiiiiiiDhiiiiiiDhiiiiiiDhiiiiiiDhiiiiiiDhiiiiiiDhiiiiiiDhiiiiiiDhiiiiiiDhiiiiiiDhiiiiiiDhiiiiiiDhiiiiiiDh
-cEHNcSHNcEiXHWGfcEZHKBejcEBFrJGbcEehehehcEKSOXKScEezKrjUcESKLNrdcEFvFvFvcEyxxPyxcEXtxwxwcEVfbzREcEGrVaGrcEFvFvFvcEFvFvFvcEFvFvFvcE
-cEcScScScEHWOQGfcEENVUENcEBFBFrJcEehehehcEOXKSOXcEXBCGZocEMhLlERcEFvFvFvcEBChnGicExwpYRGcENyNyNycEyMHkxkcEFvFvFvcEFvFvFvcEFvFvFvcE
-cEHNcSHNcElGHWYacEIyFVlicEXDXDXDcEehehehcEKSOXKScEWtSdMLcELtUrIIcEFvFvFvcEyxxjyxcExwVbGUcEnFNOaccEGrTtGrcEFvFvFvcEFvFvFvcEFvFvFvcE
+cEHNcSHNcEiXHWGfcEZHKBejcEBFrJGbcEehehehcEKSOXKScEezKrjUcESKLNrdcENphVDbcEyxxPyxcEXtxwxwcEVfbzREcEGrVaGrcEFvFvFvcEFvFvFvcEFvFvFvcE
+cEcScScScEHWOQGfcEENVUENcEBFBFrJcEehehehcEOXKSOXcEXBCGZocEMhLlERcEMuxSUFcEBChnGicExwpYRGcENyNyNycEyMHkxkcEFvFvFvcEFvFvFvcEFvFvFvcE
+cEHNcSHNcElGHWYacEIyFVlicEXDXDXDcEehehehcEKSOXKScEWtSdMLcELtUrIIcEXEtlXEcEyxxjyxcExwVbGUcEnFNOaccEGrTtGrcEFvFvFvcEFvFvFvcEFvFvFvcE
 bGMrMrMrbGMrMrMrbGMrMrMrbGMrMrMrbGMrMrMrbGMrMrMrbGMrMrMrbGMrMrMrbGMrMrMrbGMrMrMrbGMrMrMrbGMrMrMrbGMrMrMrbGMrMrMrbGMrMrMrbGMrMrMrbG
-cErsdCNZcEFJxcywcEjpOatYcElWSekDcENMPKpGcEsUvfvfcEVPauQKcEAYpTfAcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcE
-cEiOyIiOcEfyfyfycEOajKOacElWlWlWcEWnQVLbcEpopopocEzvWgyscEdoGchkcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcE
+cErsdCNZcEGQGQGQcEjpOatYcElWSekDcENMPKpGcEsUvfvfcEVPauQKcEAYpTfAcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcE
+cEiOyIiOcEGQGQGQcEOajKOacElWlWlWcEWnQVLbcEpopopocEzvWgyscEdoGchkcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcE
 cESVDorTcEGQGQGQcEjpCFDacEXgXgXgcEDUCTDUcEcWcWStcEqPPgdvcEhKvZVQcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcEFvFvFvcE
 bGOdOdOdbGOdOdOdbGOdOdOdbGOdOdOdbGOdOdOdbGOdOdOdbGOdOdOdbGOdOdOdbGOdOdOdbGOdOdOdbGOdOdOdbGOdOdOdbGOdOdOdbGOdOdOdbGOdOdOdbGOdOdOdbG
 "}


### PR DESCRIPTION
Fixes #16558
Fixes #27379

![Space](https://user-images.githubusercontent.com/7573912/131712459-e609e8d4-d8ca-4c43-884f-ded2dbca2b4b.gif)
![image](https://user-images.githubusercontent.com/7573912/131712493-1bb04169-39bc-44fb-b19f-c3c67c62acb2.png)

Those bookshelves are empty but they're also a subtype so later down the road we can have them spawn random books I guess.

:cl:
* bugfix: Re-added Holodeck Space and Library simulations. (Killette2 & SonixApache)