### PR TITLE
Medical Staff and the Clown now spawn with autoinjectors full of saltwater

### DIFF
--- a/code/datums/outfit/civilian.dm
+++ b/code/datums/outfit/civilian.dm
@@ -360,6 +360,7 @@
 		/obj/item/toy/crayon/rainbow = null,
 		/obj/item/weapon/storage/fancy/crayons = null,
 		/obj/item/toy/waterflower = null,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/saltwater = null
 	)
 
 	pda_type = /obj/item/device/pda/clown

--- a/code/datums/outfit/medical.dm
+++ b/code/datums/outfit/medical.dm
@@ -42,6 +42,10 @@
 		),
 	)
 
+	items_to_collect = list(
+		/obj/item/weapon/storage/box/autoinjectors/saltwater = slot_r_store_str
+	)
+
 	race_items_to_collect = list(
 		/datum/species/vox/ = list(
 			/obj/item/clothing/suit/storage/labcoat/cmo,
@@ -131,6 +135,10 @@
 			slot_head_str = /obj/item/clothing/head/helmet/space/vox/civ/medical,
 			slot_wear_mask_str =  /obj/item/clothing/mask/breath/vox,
 		),
+	)
+
+	items_to_collect = list(
+		/obj/item/weapon/storage/box/autoinjectors/saltwater = slot_r_store_str
 	)
 
 	race_items_to_collect = list(
@@ -240,6 +248,10 @@
 			slot_head_str = /obj/item/clothing/head/helmet/space/vox/civ/medical/chemist,
 			slot_wear_mask_str = /obj/item/clothing/mask/breath/vox,
 		),
+	)
+
+	items_to_collect = list(
+		/obj/item/weapon/storage/box/autoinjectors/saltwater = slot_r_store_str
 	)
 
 	race_items_to_collect = list(
@@ -413,6 +425,10 @@
 		),
 	)
 
+	items_to_collect = list(
+		/obj/item/weapon/storage/box/autoinjectors/saltwater = slot_r_store_str
+	)
+
 	race_items_to_collect = list(
 		/datum/species/vox/ = list(
 			/obj/item/clothing/suit/storage/labcoat/genetics,
@@ -478,6 +494,10 @@
 			slot_head_str = /obj/item/clothing/head/helmet/space/vox/civ/medical/virologist,
 			slot_wear_mask_str =  /obj/item/clothing/mask/breath/vox,
 		),
+	)
+
+	items_to_collect = list(
+		/obj/item/weapon/storage/box/autoinjectors/saltwater = slot_r_store_str
 	)
 
 	race_items_to_collect = list(

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -805,6 +805,14 @@
 	for (var/i; i < BOX_SPACE; i++)
 		new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
 
+/obj/item/weapon/storage/box/autoinjectors/saltwater
+	desc = "Contains saltwater."
+
+/obj/item/weapon/storage/box/autoinjectors/saltwater/New()
+	..()
+	for (var/i; i < BOX_SPACE; i++)
+		new /obj/item/weapon/reagent_containers/hypospray/autoinjector/saltwater(src)
+
 /obj/item/weapon/storage/box/antiviral_syringes
 	name = "box of anti-viral syringes"
 	desc = "Contains anti-viral syringes."

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -124,3 +124,11 @@
 		icon_state = "biofoam1"
 	else
 		icon_state = "biofoam0"
+
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/saltwater
+
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/saltwater/New()
+	..()
+	reagents.remove_reagent(DOCTORSDELIGHT, 30)
+	reagents.add_reagent(SALTWATER, 5)
+	return


### PR DESCRIPTION
This PR gives medical staff, with the exception of the paramedic, a box full of saltwater injectors. It also gives the clown a singular autoinjector so that he can make exactly one person vomit per round. The paramedic has been spared the box as they already have a lot to deal with and if for some reason this PR gets any amount of support and a request for paramedics to also get them I can easily add them. Please let me know if you have any feedback, insights, suggestions, or problems with this PR in the comments below.

-->
:cl:
 * rscadd: Medical staff now spawn with a box full of saltwater autoinjectors
 * rscadd: Clowns now spawn with one saltwater autoinjectors