### PR TITLE
Fixes glass tile overlays not displaying properly

### DIFF
--- a/__DEFINES/planes+layers.dm
+++ b/__DEFINES/planes+layers.dm
@@ -97,6 +97,8 @@ Why is FLOAT_PLANE added to a bunch of these?
 
 #define TURF_PLANE				(-1 + FLOAT_PLANE)
 	#define MAPPING_TURF_LAYER			-999
+	
+#define GLASSTILE_PLANE			-1						// Another one that won't behave, since it's an overlay
 
 #define ABOVE_TURF_PLANE 		(0 + FLOAT_PLANE)			// For items which should appear above turfs but below other objects and hiding mobs, eg: wires & pipes
 

--- a/code/game/turfs/simulated/floor_glass.dm
+++ b/code/game/turfs/simulated/floor_glass.dm
@@ -28,7 +28,7 @@
 	icon_state = "[((x + y) ^ ~(x * y) + z) % 25]"
 	if(!floor_overlays[glass_state])
 		var/image/floor_overlay = image('icons/turf/overlays.dmi', glass_state)
-		floor_overlay.plane = TURF_PLANE
+		floor_overlay.plane = GLASSTILE_PLANE
 		floor_overlay.layer = TURF_LAYER
 		floor_overlays[glass_state] = floor_overlay
 	overlays += floor_overlays[glass_state]
@@ -46,7 +46,7 @@
 	var/icon_state = "[cracked_base][damage_fraction]"
 	if(!damage_overlays[icon_state])
 		var/image/_damage_overlay = image('icons/obj/structures.dmi', icon_state)
-		_damage_overlay.plane = TURF_PLANE
+		_damage_overlay.plane = GLASSTILE_PLANE
 		_damage_overlay.layer = TURF_LAYER
 		damage_overlays[icon_state] = _damage_overlay
 	var/damage_overlay = damage_overlays[icon_state]

--- a/code/game/turfs/simulated/floor_glass.dm
+++ b/code/game/turfs/simulated/floor_glass.dm
@@ -28,7 +28,7 @@
 	icon_state = "[((x + y) ^ ~(x * y) + z) % 25]"
 	if(!floor_overlays[glass_state])
 		var/image/floor_overlay = image('icons/turf/overlays.dmi', glass_state)
-		floor_overlay.plane = GLASSTILE_PLANE
+		floor_overlay.plane = relative_plane(GLASSTILE_PLANE)
 		floor_overlay.layer = TURF_LAYER
 		floor_overlays[glass_state] = floor_overlay
 	overlays += floor_overlays[glass_state]
@@ -46,7 +46,7 @@
 	var/icon_state = "[cracked_base][damage_fraction]"
 	if(!damage_overlays[icon_state])
 		var/image/_damage_overlay = image('icons/obj/structures.dmi', icon_state)
-		_damage_overlay.plane = GLASSTILE_PLANE
+		_damage_overlay.plane = relative_plane(GLASSTILE_PLANE)
 		_damage_overlay.layer = TURF_LAYER
 		damage_overlays[icon_state] = _damage_overlay
 	var/damage_overlay = damage_overlays[icon_state]

--- a/code/modules/multiz/turfs.dm
+++ b/code/modules/multiz/turfs.dm
@@ -194,7 +194,7 @@
 	icon = 'icons/turf/overlays.dmi'
 	icon_state = ""
 	layer = TURF_LAYER
-	plane = GLASSTILE_PLANE
+	plane = BASE_PLANE
 
 /obj/effect/open_overlay/glass/damage
 	name = "glass open overlay cracks"

--- a/code/modules/multiz/turfs.dm
+++ b/code/modules/multiz/turfs.dm
@@ -193,8 +193,8 @@
 	desc = "The window over the darkness of the abyss below"
 	icon = 'icons/turf/overlays.dmi'
 	icon_state = ""
-	layer = 0
-	plane = BASE_PLANE
+	layer = TURF_LAYER
+	plane = GLASSTILE_PLANE
 
 /obj/effect/open_overlay/glass/damage
 	name = "glass open overlay cracks"

--- a/code/modules/multiz/turfs.dm
+++ b/code/modules/multiz/turfs.dm
@@ -193,8 +193,8 @@
 	desc = "The window over the darkness of the abyss below"
 	icon = 'icons/turf/overlays.dmi'
 	icon_state = ""
-	layer = TURF_LAYER
-	plane = BASE_PLANE
+	layer = 0
+	plane = GLASSTILE_PLANE
 
 /obj/effect/open_overlay/glass/damage
 	name = "glass open overlay cracks"
@@ -215,6 +215,7 @@
 			return
 		var/obj/effect/open_overlay/overimage = new /obj/effect/open_overlay
 		overimage.alpha = 255 - alpha_to_subtract
+		overimage.color = rgb(0,0,0,overimage.alpha)
 		vis_contents += bottom
 		if(!istype(bottom,/turf/space)) // Space below us
 			vis_contents.Add(overimage)


### PR DESCRIPTION
[bugfix][tested]
Closes #30472
:cl:
 * bugfix: Glass floors are no longer invisible over space.
 * bugfix: Glass floors now have proper dark overlays underneath for open spaces, and show pipes as being underneath them.