### PR TITLE
Autoinjectors Slightly Better

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -194,7 +194,7 @@
 			25;/obj/item/toy/syndicateballoon/ntballoon,
 			25;/obj/item/weapon/reagent_containers/food/snacks/chococoin,
 			25;/obj/item/weapon/tank/emergency_oxygen/engi,
-			25;/obj/item/weapon/reagent_containers/hypospray/autoinjector,
+			25;/obj/item/weapon/reagent_containers/hypospray/autoinjector/doctors_delight,
 			25;/obj/item/weapon/reagent_containers/food/drinks/thermos/full
 		)
 		new toSpawn(src)
@@ -803,7 +803,7 @@
 /obj/item/weapon/storage/box/autoinjectors/New()
 	..()
 	for (var/i; i < BOX_SPACE; i++)
-		new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
+		new /obj/item/weapon/reagent_containers/hypospray/autoinjector/doctors_delight(src)
 
 /obj/item/weapon/storage/box/antiviral_syringes
 	name = "box of anti-viral syringes"
@@ -1543,5 +1543,5 @@
 	new /obj/item/clothing/glasses/scanner/meson(src)
 	new /obj/item/blueprints/construction_permit(src)
 	new /obj/item/weapon/reagent_containers/food/snacks/dorfbiscuit(src)
-	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
+	new /obj/item/weapon/reagent_containers/hypospray/autoinjector/doctors_delight(src)
 	new /obj/item/weapon/grenade/chem_grenade/metalfoam(src)

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -35,7 +35,7 @@
 	icon_state = pick("ointment","firefirstaid")
 
 	new /obj/item/device/healthanalyzer(src)
-	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
+	new /obj/item/weapon/reagent_containers/hypospray/autoinjector/doctors_delight(src)
 	new /obj/item/stack/medical/ointment(src)
 	new /obj/item/stack/medical/ointment(src)
 	new /obj/item/weapon/reagent_containers/pill/kelotane(src)
@@ -57,7 +57,7 @@
 	new /obj/item/stack/medical/ointment(src)
 	new /obj/item/stack/medical/ointment(src)
 	new /obj/item/device/healthanalyzer(src)
-	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
+	new /obj/item/weapon/reagent_containers/hypospray/autoinjector/doctors_delight(src)
 	return
 
 /obj/item/weapon/storage/firstaid/toxin
@@ -100,7 +100,7 @@
 		return
 	for (var/i = 1 to 4)
 		new /obj/item/weapon/reagent_containers/pill/dexalin(src)
-	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
+	new /obj/item/weapon/reagent_containers/hypospray/autoinjector/doctors_delight(src)
 	new /obj/item/weapon/reagent_containers/syringe/inaprovaline(src)
 	new /obj/item/device/healthanalyzer(src)
 	return
@@ -115,7 +115,7 @@
 	..()
 	if (empty)
 		return
-	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
+	new /obj/item/weapon/reagent_containers/hypospray/autoinjector/doctors_delight(src)
 	new /obj/item/stack/medical/advanced/bruise_pack(src)
 	new /obj/item/stack/medical/advanced/bruise_pack(src)
 	new /obj/item/stack/medical/advanced/bruise_pack(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -133,7 +133,7 @@
 		/obj/item/device/radio/headset/heads/cmo,
 		/obj/item/weapon/storage/belt/medical,
 		/obj/item/device/flash,
-		/obj/item/weapon/reagent_containers/hypospray,
+		/obj/item/weapon/reagent_containers/hypospray/doctors_delight,
 		/obj/item/weapon/card/debit/preferred/department/medical,
 		/obj/item/weapon/switchtool/surgery,
 		/obj/item/weapon/autopsy_scanner/healthanalyzerpro

--- a/code/modules/maps/spawners/spawners.dm
+++ b/code/modules/maps/spawners/spawners.dm
@@ -62,7 +62,7 @@
 		/obj/item/weapon/storage/pill_bottle/inaprovaline,
 		/obj/item/weapon/storage/pill_bottle/kelotane,
 		/obj/item/weapon/reagent_containers/blood/OMinus,
-		/obj/item/weapon/reagent_containers/hypospray/autoinjector,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/doctors_delight,
 		)
 
 /obj/abstract/map/spawner/medical/pills

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -17,15 +17,16 @@
 /obj/item/weapon/reagent_containers/hypospray/attack_paw(mob/user as mob)
 	return src.attack_hand(user)
 
+/obj/item/weapon/reagent_containers/hypospray/medical
 
-/obj/item/weapon/reagent_containers/hypospray/New() //comment this to make hypos start off empty
+/obj/item/weapon/reagent_containers/hypospray/doctors_delight/New() //comment this to make hypos start off empty
 	..()
 	reagents.add_reagent(DOCTORSDELIGHT, 30)
 	return
 
 /obj/item/weapon/reagent_containers/hypospray/creatine/New() // TESTING!
 	..()
-	reagents.remove_reagent(DOCTORSDELIGHT, 30)
+	//reagents.remove_reagent(DOCTORSDELIGHT, 30)
 	reagents.add_reagent(CREATINE, 30)
 	return
 
@@ -105,6 +106,12 @@
 	else
 		to_chat(user, "<span class='info'>The [name] has been spent.</span>")
 
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/doctors_delight
+
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/doctors_delight/New()
+	..()
+	reagents.add_reagent(DOCTORSDELIGHT, 5)
+
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biofoam_injector
 	name = "biofoam injector"
 	desc = "A small, single-use device used to administer biofoam in the field."
@@ -115,7 +122,6 @@
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biofoam_injector/New()
 	..()
-	reagents.remove_reagent(DOCTORSDELIGHT, 30)
 	reagents.add_reagent(BIOFOAM, 15)
 	return
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -17,8 +17,6 @@
 /obj/item/weapon/reagent_containers/hypospray/attack_paw(mob/user as mob)
 	return src.attack_hand(user)
 
-/obj/item/weapon/reagent_containers/hypospray/medical
-
 /obj/item/weapon/reagent_containers/hypospray/doctors_delight/New() //comment this to make hypos start off empty
 	..()
 	reagents.add_reagent(DOCTORSDELIGHT, 30)
@@ -105,8 +103,6 @@
 		to_chat(user, "<span class='info'>It is ready for injection.</span>")
 	else
 		to_chat(user, "<span class='info'>The [name] has been spent.</span>")
-
-/obj/item/weapon/reagent_containers/hypospray/autoinjector/doctors_delight
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/doctors_delight/New()
 	..()


### PR DESCRIPTION
Autoinjector code is now ugly in a new and horrific way. This allows the creation of custom reagent filled autoinjectors and hyposprays in the code without having to remove reagents from them when they spawn. There shouldn't be any in game changes unless I missed something so there is no change log. Please let me know if you have any comments, questions, concerns, or terrors in the comments below.

Compiled and tested locally on box station with a CMO spawn medkit autoinjector, the locker hypospray, and nothing else.