### PR TITLE
The delete verb now hard-deletes once again

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -1,5 +1,5 @@
 // reference: /client/proc/modify_variables(var/atom/O, var/param_var_name = null, var/autodetect_class = 0)
-/client/proc/debug_reagents(atom/D)
+/client/proc/debug_reagents(atom/D in world)
 	set category = "Debug"
 	set name = "Add Reagent"
 

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -21,7 +21,7 @@
 			log_admin("[key_name(usr)] added [reagentDatum] with [reagentAmount] units to [A] at [reagentTemp]K temperature.")
 			message_admins("[key_name(usr)] added [reagentDatum] with [reagentAmount] units to [A] at [reagentTemp]K temperature.")
 
-/client/proc/debug_variables(atom/D)
+/client/proc/debug_variables(atom/D in world)
 	set category = "Debug"
 	set name = "View Variables"
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -688,7 +688,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	message_admins("[key_name_admin(src)] has created a command report", 1)
 	feedback_add_details("admin_verb","CCR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/proc/cmd_admin_delete(atom/O)
+/client/proc/cmd_admin_delete(atom/O in world)
 	set category = "Admin"
 	set name = "Delete"
 


### PR DESCRIPTION
Reverts #27261
It causes weird issues such as:
- Unable to use the view-variables/delete verbs if the user's loc is not a turf
- Sometimes attempting to view-variables/delete an object on the ground will select a mob on its tile instead (???)

