### PR TITLE
Stops vines/powercreep/biomass events spawning in arrivals hallways

### DIFF
--- a/code/game/gamemodes/events/biomass.dm
+++ b/code/game/gamemodes/events/biomass.dm
@@ -194,6 +194,8 @@
 	var/list/turf/simulated/floor/Floors = new
 
 	for(var/type in typesof(/area/hallway))
+		if(istype(type,/area/hallway/secondary/entry)) // no spawn in arrivals, make it less annoying for latejoiners
+			continue
 		var/area/Hallway = locate(type)
 
 		for(var/turf/simulated/floor/Floor in Hallway.contents)

--- a/code/game/gamemodes/events/spacevines.dm
+++ b/code/game/gamemodes/events/spacevines.dm
@@ -3,6 +3,8 @@
 	spawn() //to stop the secrets panel hanging
 		var/list/turf/simulated/floor/turfs = list() //list of all the empty floor turfs in the hallway areas
 		for(var/areapath in typesof(/area/hallway))
+			if(istype(areapath,/area/hallway/secondary/entry)) //no spawn in arrivals, make it less annoying for latejoiners
+				continue
 			var/area/A = locate(areapath)
 			for(var/turf/simulated/floor/F in A.contents)
 				if(!is_blocked_turf(F) && !(locate(/obj/effect/plantsegment) in F))

--- a/code/modules/events/powercreeper.dm
+++ b/code/modules/events/powercreeper.dm
@@ -7,6 +7,8 @@
 	spawn()
 		var/list/turf/simulated/floor/turfs = list() //list of all the empty floor turfs in the hallway areas
 		for(var/areapath in typesof(/area/hallway))
+			if(istype(areapath,/area/hallway/secondary/entry)) //no spawn in arrivals, make it less annoying for latejoiners
+				continue
 			var/area/A = locate(areapath)
 			for(var/turf/simulated/floor/F in A.contents)
 				if(!is_blocked_turf(F))


### PR DESCRIPTION
[tweak][balance]
:cl:
 * tweak: The biomass, spacevine and powercreep random events no longer spawn their infestations in the arrivals shuttle hallway.