### PR TITLE
Fixes emitter beams not being updated when forceMoved

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -191,7 +191,7 @@
 
 /obj/machinery/power/emitter/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
 	if(active)
-		visible_message("<span class='warning'>\the [src] gets yanked off of it's power cable and turns off!</span>")
+		visible_message("<span class='warning'>\the [src] gets yanked off of its power source and turns off!</span>")
 		turn_off()
 	..()
 

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -189,6 +189,12 @@
 		to_chat(user, "<span class='warning'>\The [src] needs to be firmly secured to the floor first.</span>")
 		return 1
 
+/obj/machinery/power/emitter/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
+	if(active)
+		visible_message("<span class='warning'>\the [src] gets yanked off of it's power cable and turns off!</span>")
+		turn_off()
+	..()
+
 //Important note, those procs not log the emitter being turned on or off, so please use the logs in attack_hand above
 /obj/machinery/power/emitter/proc/turn_on()
 	active = 1

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -190,8 +190,10 @@
 		return 1
 
 /obj/machinery/power/emitter/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
-	if(active)
-		visible_message("<span class='warning'>\the [src] gets yanked off of its power source and turns off!</span>")
+	if(active) // You just removed it from the power cable it was on, what did you think would happen?
+		visible_message("<span class='warning'>The [src] gets yanked off of its power source and turns off!</span>")
+		state = 0 // Reset these too
+		anchored = 0
 		turn_off()
 	..()
 

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -192,8 +192,6 @@
 /obj/machinery/power/emitter/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
 	if(active) // You just removed it from the power cable it was on, what did you think would happen?
 		visible_message("<span class='warning'>The [src] gets yanked off of its power source and turns off!</span>")
-		state = 0 // Reset these too
-		anchored = 0
 		turn_off()
 	..()
 


### PR DESCRIPTION
[bugfix][tested]
Closes #28621.
:cl:
 * bugfix: Emitters no longer leave their beam in place when teleported away, instead instantly shutting off.