### PR TITLE
Fixed being able to identify falsewalls by right clicking them

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -94,7 +94,7 @@
 
 /obj/structure/falsewall
 	name = "wall"
-	desc = "A huge chunk of metal used to seperate rooms."
+	desc = "A huge chunk of metal used to separate rooms."
 	anchored = 1
 	icon = 'icons/turf/walls.dmi'
 	var/mineral = "metal"
@@ -121,7 +121,7 @@
 /obj/structure/falsewall/Destroy()
 
 	var/temploc = src.loc
-	loc.invisibility = 0
+	loc.mouse_opacity = 1
 
 	spawn(10)
 		for(var/turf/simulated/wall/W in range(temploc,1))
@@ -157,7 +157,7 @@
 		opening = 1
 		icon_state = "[mineral]fwall_open"
 		flick("[mineral]fwall_opening", src)
-		loc.invisibility = 0
+		loc.mouse_opacity = 1
 		sleep(15)
 		setDensity(FALSE)
 		set_opacity(0)
@@ -171,7 +171,7 @@
 		set_opacity(1)
 		src.relativewall()
 		opening = 0
-		loc.invisibility = 101
+		loc.mouse_opacity = 0
 
 /obj/structure/falsewall/update_icon()//Calling icon_update will refresh the smoothwalls if it's closed, otherwise it will make sure the icon is correct if it's open
 	..()
@@ -242,7 +242,7 @@
 
 /obj/structure/falserwall	// why isn't this a child type?
 	name = "reinforced wall"
-	desc = "A huge chunk of reinforced metal and anchored rods used to seperate rooms and keep all but the most equipped crewmen out."
+	desc = "A huge chunk of reinforced metal and anchored rods used to separate rooms and keep all but the most equipped crewmen out."
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "r_wall"
 	density = 1
@@ -267,7 +267,7 @@
 /obj/structure/falserwall/Destroy()
 
 	var/temploc = src.loc
-	loc.invisibility = 0
+	loc.mouse_opacity = 1
 
 	spawn(10)
 		for(var/turf/simulated/wall/W in range(temploc,1))
@@ -295,7 +295,7 @@
 		// Open wall
 		icon_state = "frwall_open"
 		flick("frwall_opening", src)
-		loc.invisibility = 0
+		loc.mouse_opacity = 1
 		sleep(15)
 		setDensity(FALSE)
 		set_opacity(0)
@@ -309,7 +309,7 @@
 		set_opacity(1)
 		relativewall()
 		opening = 0
-		loc.invisibility = 101
+		loc.mouse_opacity = 0
 
 /obj/structure/falserwall/relativewall()
 

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -113,6 +113,12 @@
 	density = 1
 	opacity = 1
 
+
+/obj/structure/falsewall/examine(var/mob/user)
+	..()
+	if(Adjacent(user))
+		to_chat(user, "<span class='rose'>Now that you're standing close to it, that wall appears a bit odd.</span>")
+
 /obj/structure/falsewall/New()
 	..()
 	relativewall()
@@ -250,6 +256,11 @@
 	anchored = 1
 	var/mineral = "metal"
 	var/opening = 0
+
+/obj/structure/falserwall/examine(var/mob/user)
+	..()
+	if(Adjacent(user))
+		to_chat(user, "<span class='rose'>Now that you're standing close to it, that wall appears a bit odd.</span>")
 
 /obj/structure/falserwall/canSmoothWith()
 	var/static/list/smoothables = list(

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -242,7 +242,7 @@
 
 /obj/structure/falserwall	// why isn't this a child type?
 	name = "reinforced wall"
-	desc = "A huge chunk of reinforced metal used to seperate rooms."
+	desc = "A huge chunk of reinforced metal and anchored rods used to seperate rooms and keep all but the most equipped crewmen out."
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "r_wall"
 	density = 1

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -121,6 +121,7 @@
 /obj/structure/falsewall/Destroy()
 
 	var/temploc = src.loc
+	loc.invisibility = 0
 
 	spawn(10)
 		for(var/turf/simulated/wall/W in range(temploc,1))
@@ -156,6 +157,7 @@
 		opening = 1
 		icon_state = "[mineral]fwall_open"
 		flick("[mineral]fwall_opening", src)
+		loc.invisibility = 0
 		sleep(15)
 		setDensity(FALSE)
 		set_opacity(0)
@@ -169,6 +171,7 @@
 		set_opacity(1)
 		src.relativewall()
 		opening = 0
+		loc.invisibility = 101
 
 /obj/structure/falsewall/update_icon()//Calling icon_update will refresh the smoothwalls if it's closed, otherwise it will make sure the icon is correct if it's open
 	..()
@@ -237,7 +240,7 @@
  * False R-Walls
  */
 
-/obj/structure/falserwall
+/obj/structure/falserwall	// why isn't this a child type?
 	name = "reinforced wall"
 	desc = "A huge chunk of reinforced metal used to seperate rooms."
 	icon = 'icons/turf/walls.dmi'
@@ -247,7 +250,7 @@
 	anchored = 1
 	var/mineral = "metal"
 	var/opening = 0
-// WHY DO WE SMOOTH WITH FALSE R-WALLS WHEN WE DON'T SMOOTH WITH REAL R-WALLS.
+
 /obj/structure/falserwall/canSmoothWith()
 	var/static/list/smoothables = list(
 		/turf/simulated/wall,
@@ -260,6 +263,22 @@
 	..()
 	relativewall()
 	relativewall_neighbours()
+
+/obj/structure/falserwall/Destroy()
+
+	var/temploc = src.loc
+	loc.invisibility = 0
+
+	spawn(10)
+		for(var/turf/simulated/wall/W in range(temploc,1))
+			W.relativewall()
+
+		for(var/obj/structure/falsewall/W in range(temploc,1))
+			W.relativewall()
+
+		for(var/obj/structure/falserwall/W in range(temploc,1))
+			W.relativewall()
+	..()
 
 
 /obj/structure/falserwall/attack_ai(mob/user as mob)
@@ -276,6 +295,7 @@
 		// Open wall
 		icon_state = "frwall_open"
 		flick("frwall_opening", src)
+		loc.invisibility = 0
 		sleep(15)
 		setDensity(FALSE)
 		set_opacity(0)
@@ -289,6 +309,7 @@
 		set_opacity(1)
 		relativewall()
 		opening = 0
+		loc.invisibility = 101
 
 /obj/structure/falserwall/relativewall()
 

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -7,7 +7,7 @@
 #define WALLRODSCUT 6
 /turf/simulated/wall/r_wall
 	name = "reinforced wall"
-	desc = "A huge chunk of reinforced metal and anchored rods used to seperate rooms and keep all but the most equipped crewmen out."
+	desc = "A huge chunk of reinforced metal and anchored rods used to separate rooms and keep all but the most equipped crewmen out."
 	icon_state = "r_wall"
 	opacity = 1
 	density = 1

--- a/code/modules/clothing/glasses/scanners.dm
+++ b/code/modules/clothing/glasses/scanners.dm
@@ -222,16 +222,15 @@
 		apply()
 		return
 
-	if (new_mob != viewing)
-		clear()
+	clear()
 
-		if (viewing)
-			viewing.unregister_event(/event/logout, src, .proc/mob_logout)
-			viewing = null
+	if (viewing)
+		viewing.unregister_event(/event/logout, src, .proc/mob_logout)
+		viewing = null
 
-		if (new_mob)
-			new_mob.register_event(/event/logout, src, .proc/mob_logout)
-			viewing = new_mob
+	if (new_mob)
+		new_mob.register_event(/event/logout, src, .proc/mob_logout)
+		viewing = new_mob
 
 /obj/item/clothing/glasses/scanner/material/proc/mob_logout(mob/user)
 	if (user != viewing)


### PR DESCRIPTION
Fixes #30512

:cl:
* bugfix: Fixed being able to identify falsewalls by right clicking them.
* bugfix: Fixed false reinforced walls not having the same description as reinforced walls.
* rscadd: False walls now give an extra message on examination when standing adjacent to them.