### PR TITLE
Logs server updates on external chat broadcasts

### DIFF
--- a/code/modules/ext_scripts/watchdog.dm
+++ b/code/modules/ext_scripts/watchdog.dm
@@ -14,6 +14,8 @@ var/global/datum/watchdog/watchdog = new
 		waiting=1
 		testing("[time_stamp()] - Watchdog has detected an update.")
 		to_chat(world, "<span class='notice'>\[AUTOMATIC ANNOUNCEMENT\] Update received.  Server will restart automatically after the round ends.</span>")
+		send2mainirc("Update received.  Server will restart automatically after the round ends.")
+		send2maindiscord("**Update received.**  Server will restart automatically after the round ends.")
 
 /datum/watchdog/proc/signal_ready() //This apparently uses some magic non-DM thing that kills the server process directly.
 	world.pre_shutdown()


### PR DESCRIPTION
[administration]
:cl:
 * rscadd: Server update notifications are now sent outside of the game to external chats.