### PR TITLE
Fixes PDA messages only being sendable with a photo

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -2505,7 +2505,7 @@ var/global/msg_id = 0
 			imglist["[msg_id]"] = current_photo.img
 			P.imglist["[msg_id]"] = current_photo.img
 		
-		useMS.send_pda_message("[P.owner]","[owner]","[t]",current_photo.img)
+		useMS.send_pda_message("[P.owner]","[owner]","[t]",imglist["[msg_id]"])
 
 		tnote["[msg_id]"] = "<i><b>&rarr; To [P.owner]:</b></i><br>[t]<br>"
 		P.tnote["[msg_id]"] = "<i><b>&larr; From <a href='byond://?src=\ref[P];choice=Message;target=\ref[reply_to]'>[owner]</a> ([ownjob]):</b></i><br>[t]<br>"


### PR DESCRIPTION
[bugfix]
It was runtiming when it was creating the logged message, here's a sanity check for it.
:cl:
* bugfix: PDA messages no longer require a photo to send.