### PR TITLE
Fixed Ornament boxes allowing players to farm infinite glass from Autolathes

### DIFF
--- a/code/game/objects/items/ornaments.dm
+++ b/code/game/objects/items/ornaments.dm
@@ -62,7 +62,11 @@
 	if(get_turf(src))
 		playsound(src, 'sound/effects/hit_on_shattered_glass.ogg', 70, 1)
 	if(prob(33))
-		new /obj/item/weapon/shard(get_turf(src)) // Create a glass shard at the hit location)
+		var/obj/effect/decal/cleanable/crumbs/C = new (get_turf(src))
+		for (var/ball_color in ornaments_list)
+			if (type == ornaments_list[ball_color])
+				C.color = ball_color
+				break
 	qdel(src)
 
 /obj/item/ornament/red

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -898,7 +898,7 @@
 	desc = "A box of seven glass Christmas ornaments. Color not included."
 	icon_state = "ornament_box"
 	foldable = null
-	starting_materials = list(MAT_GLASS = 2500)		//needed for autolathe production
+	starting_materials = list(MAT_GLASS = 2000)		//needed for autolathe production
 
 /obj/item/weapon/storage/box/ornaments/New()
 	..()


### PR DESCRIPTION
Fixes #30549

:cl:
* bugfix: Fixed Ornament boxes allowing players to farm infinite glass from Autolathes. When they break after being thrown, they now leave some debris of the same colour, and the box they come in now gives back a bit less glass when recycled than it cost to print a new one. 2000 down from 2500. (Armadingus)