### PR TITLE
Card Trick is now available in regular spellbooks, cooldown lowered by 33.(3)%

### DIFF
--- a/code/modules/spells/targeted/card.dm
+++ b/code/modules/spells/targeted/card.dm
@@ -2,13 +2,15 @@
 	name = "Card Trick"
 	desc = "Ask a person about whether a random card is theirs. Their whole inventory is filled with copies of the card."
 	abbreviation = "CT"
-	user_type = USER_TYPE_SPELLBOOK //It's quite the exquisite meme
+	user_type = USER_TYPE_WIZARD // Now it's a meme available for wizards! //It's quite the exquisite meme
+	specialization = SSUTILITY
 	school = "transmutation"
-	charge_max = 150 //15 seconds
+	charge_max = 100 //10 seconds
 	spell_flags = WAIT_FOR_CLICK
 	invocation_type = SpI_SHOUT
 	max_targets = 1
 	compatible_mobs = list(/mob/living/carbon/human)
+	level_max = list(Sp_TOTAL = 0, Sp_SPEED = 0, Sp_POWER = 0) //You can't quicken this, this would be kind of useless
 	hud_state = "card_trick"
 	var/current_card
 	var/list/card_type = list("Hearts", "Spades", "Clubs", "Diamonds")


### PR DESCRIPTION
Done by request.
Card Trick (the spell that floods an user's inventory with copies of a card) is now available in the Utility section of the regular spellbook, instead of as a chance to get from the ancient spellbook under two layers of RNG (getting the ancient spellbook and rolling the spell).
The cooldown has also been lowered to 10 seconds, but as a trade-off the cooldown cannot be lowered.

:cl:
 * tweak: The Card Trick spell has been moved from the Ancient Spellbook to regular Spellbooks under the Utility category.
 * tweak: Card Trick's cooldown has been lowered to 10 seconds from 15, but it cannot have its cooldown lowered.