### PR TITLE
To use a stethoscope on a Safe, you now need to be able to hear sounds, duh.

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -129,7 +129,8 @@ FLOOR SAFES
 /obj/structure/safe/proc/turn_dial(var/mob/user, var/task)
 	var/canhear = 0
 	if(user.find_held_item_by_type(/obj/item/clothing/accessory/stethoscope))
-		canhear = 1
+		if (!(user.sdisabilities & DEAF) && !user.ear_deaf && !user.earprot())
+			canhear = 1
 
 	switch (task)
 		if ("Rotate Clockwise")

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -126,7 +126,7 @@ FLOOR SAFES
 	else
 		radial.finish()
 
-/obj/structure/safe/proc/turn_dial(var/mob/user, var/task)
+/obj/structure/safe/proc/turn_dial(var/mob/living/user, var/task)
 	var/canhear = 0
 	if(user.find_held_item_by_type(/obj/item/clothing/accessory/stethoscope))
 		if (!(user.sdisabilities & DEAF) && !user.ear_deaf && !user.earprot())


### PR DESCRIPTION
Fixes #30550

:cl:
* bugfix: To use a stethoscope on a Safe, you now need to be able to hear sounds, duh. (Armadingus)