### PR TITLE
Patching yet another Centcomm invasion exploit

### DIFF
--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -191,6 +191,9 @@
 		return 0
 	if(move_delayer.blocked())
 		return 0
+	if (istype(locked_to, /obj/machinery/bot/mulebot))
+		var/obj/machinery/bot/mulebot/M = locked_to
+		M.unload(0)
 
 	//If we're in space or our area has no gravity...
 	var/turf/T = loc


### PR DESCRIPTION
Fixes #30542

:cl:
* bugfix: Driving a vehicle such as a wheelchair while on top of a Mulebot will now properly unload the vehicle from the Mulebot. (Armadingus)