### PR TITLE
adds support for mushman silicons

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -115,6 +115,7 @@
 	access = list(access_mime, access_theatre, access_maint_tunnels)
 	minimal_access = list(access_mime, access_theatre)
 	outfit_datum = /datum/outfit/mime
+	species_blacklist = list() //for shrooms
 
 /datum/job/mime/reject_new_slots()
 	if(!xtra_positions)

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -115,7 +115,6 @@
 	access = list(access_mime, access_theatre, access_maint_tunnels)
 	minimal_access = list(access_mime, access_theatre)
 	outfit_datum = /datum/outfit/mime
-	species_blacklist = list() //for shrooms
 
 /datum/job/mime/reject_new_slots()
 	if(!xtra_positions)

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -42,6 +42,7 @@
 	spawn_positions = 2
 	supervisors = "your laws and the AI"
 	selection_color = "#ddffdd"
+	species_blacklist = list() //for shrooms
 
 /datum/job/mommi/equip(var/mob/living/carbon/human/H)
 	if(!H)

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -8,6 +8,7 @@
 	supervisors = "your laws"
 	req_admin_notify = 2
 	minimal_player_age = 30
+	species_blacklist = list() //for shrooms
 
 /datum/job/ai/equip(var/mob/living/carbon/human/H)
 	if(!H)
@@ -26,6 +27,7 @@
 	supervisors = "your laws and the AI"
 	selection_color = "#ddffdd"
 	minimal_player_age = 10
+	species_blacklist = list() //for shrooms
 
 /datum/job/cyborg/equip(var/mob/living/carbon/human/H)
 	if(!H)


### PR DESCRIPTION
closes #30574

:cl:
 - rscadd: Mushroom men can now be roundstart silicons.