### PR TITLE
Fixed switching hands during organ implant surgery causing organs to go shroedinger.

### DIFF
--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -423,7 +423,7 @@
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has transplanted \the [tool] into [target]'s [affected.display_name].</span>", \
 	"<span class='notice'>You have transplanted \the [tool] into [target]'s [affected.display_name].</span>")
-	user.drop_item()
+	user.drop_item(tool)
 	var/obj/item/organ/internal/O = tool
 
 	if(istype(O))


### PR DESCRIPTION
Fixes #30587

:cl:
* bugfix: Fixed switching hands during organ implant surgery causing organs to still appear in your hand despite being the step succeeding and them being supposedly inside your patient. (Armadingus)