### PR TITLE
Moving lights are now smooth as hell

### DIFF
--- a/code/modules/lighting/__lighting_docs.dm
+++ b/code/modules/lighting/__lighting_docs.dm
@@ -47,6 +47,9 @@ atom: (lighting_atom.dm)
   - var/atom/movable/light/light_obj; light source object for this atom, only present if light_range && light_power
   - var/atom/movable/light/shadow/shadow_obj; wall shadow source object for this atom, with TILE_BOUND to prevent it from bleeding over other walls
 
+	Movable lights only :
+  - var/atom/movable/light/smooth/smooth_light_obj; light_source for this atom, but with smooth movement.
+
 	NB: this means that the object casts its light twice, one for the people who can see it, another for those who can't.
     NB2: due to additive colour mixing, this means a normal colour would be shifted to white. To prevent this, light atoms have RGB numbers halved.
 	.... when they recombine, we see the original light.

--- a/code/modules/lighting/light_atom.dm
+++ b/code/modules/lighting/light_atom.dm
@@ -6,6 +6,9 @@
 	var/light_range = 1
 	var/light_color = "#F4FFFA"
 
+	// Movable lights only
+	var/atom/movable/light/smooth/smooth_light_obj
+
 // Used to change hard BYOND opacity; this means a lot of updates are needed.
 /atom/proc/set_opacity(var/newopacity)
 	opacity = newopacity ? 1 : 0

--- a/code/modules/lighting/light_atom_set.dm
+++ b/code/modules/lighting/light_atom_set.dm
@@ -6,6 +6,9 @@
 	if (shadow_obj)
 		qdel(shadow_obj)
 		shadow_obj = null
+	if (smooth_light_obj)
+		qdel(smooth_light_obj)
+		smooth_light_obj = null
 
 // Updates all appropriate lighting values and then applies all changed values
 // to the objects light_obj overlay atom.
@@ -17,6 +20,9 @@
 			qdel(shadow_obj)
 			light_obj = null
 			shadow_obj = null
+		if (smooth_light_obj)
+			qdel(smooth_light_obj)
+			smooth_light_obj = null
 		return
 
 	if (moody_light_type)
@@ -41,10 +47,21 @@
 
 	light_atom_update(shadow_obj, update_cast_shadow)
 
+	var/update_cast_smooth_light
+	if (lighting_flags & MOVABLE_LIGHT)
+		if(!smooth_light_obj)
+			update_cast_smooth_light = 1
+			smooth_light_obj = new(newholder = src)
+
+
+	if (smooth_light_obj)
+		light_atom_update(smooth_light_obj, update_cast_smooth_light)
+
 	// Rare enough that we can probably get away with calling animate().
 	if(fadeout)
 		animate(light_obj, alpha = 0, time = fadeout)
 		animate(shadow_obj, alpha = 0, time = fadeout)
+		animate(smooth_light_obj, alpha = 0, time = fadeout)
 
 /atom/proc/light_value_inits(var/l_range, var/l_power, var/l_color, var/l_type)
 	// Update or retrieve our variable data.

--- a/code/modules/lighting/light_effect.dm
+++ b/code/modules/lighting/light_effect.dm
@@ -1,7 +1,7 @@
 #define LIGHT_CPU_THRESHOLD 80
 
 /atom/movable/light
-	name = null
+	name = ""
 	mouse_opacity = 0
 	plane = LIGHTING_PLANE
 
@@ -19,7 +19,7 @@
 	glide_size = WORLD_ICON_SIZE
 	blend_mode = BLEND_ADD
 
-	animate_movement = SLIDE_STEPS
+	animate_movement = NO_STEPS
 
 	alpha = 180
 
@@ -33,11 +33,13 @@
 
 	var/light_swallowed = 0
 
+/atom/movable/light/smooth
+	animate_movement = SLIDE_STEPS
+
 /atom/movable/light/shadow
-	name = null
 	base_light_color_state = "black"
 	appearance_flags = KEEP_TOGETHER | TILE_BOUND
-	animate_movement = SLIDE_STEPS
+	animate_movement = NO_STEPS
 
 /atom/movable/light/New(..., var/atom/newholder)
 	holder = newholder

--- a/code/modules/lighting/light_effect.dm
+++ b/code/modules/lighting/light_effect.dm
@@ -1,6 +1,7 @@
 #define LIGHT_CPU_THRESHOLD 80
 
 /atom/movable/light
+	name = null
 	mouse_opacity = 0
 	plane = LIGHTING_PLANE
 
@@ -33,6 +34,7 @@
 	var/light_swallowed = 0
 
 /atom/movable/light/shadow
+	name = null
 	base_light_color_state = "black"
 	appearance_flags = KEEP_TOGETHER | TILE_BOUND
 	animate_movement = SLIDE_STEPS

--- a/code/modules/lighting/light_effect.dm
+++ b/code/modules/lighting/light_effect.dm
@@ -1,7 +1,6 @@
 #define LIGHT_CPU_THRESHOLD 80
 
 /atom/movable/light
-	name = ""
 	mouse_opacity = 0
 	plane = LIGHTING_PLANE
 

--- a/code/modules/lighting/light_effect_cast.dm
+++ b/code/modules/lighting/light_effect_cast.dm
@@ -147,13 +147,11 @@ If you feel like fixing it, try to find a way to calculate the bounds that is le
 		pixel_y = -(world.icon_size * light_range)
 
 	// This to avoid TILE_BOUND corner light effects while keeping smooth movement for movable light sources
-	// Basically, for movable lights, we always do white square + masking
-	// But for fixed lights, we wall-shadows-only lights do not cast a white square
-	// Probably not the smartest way around this
-	if (holder.lighting_flags & MOVABLE_LIGHT)
-		icon_state = "white"
-	else
-		icon_state = base_light_color_state
+	// There are THREE light atoms on an object
+	// - the white square (not TILE_BOUND)
+	// - the shadow square (TILE_BOUND)
+	// - the smooth white square (not TILE_BOUND)
+	icon_state = base_light_color_state
 
 	if (icon_state == "white") // This mask only makes sense if we are casting a white light
 		alpha = min(255,max(0,round(light_power*light_power_multiplier*25)))
@@ -178,6 +176,9 @@ If you feel like fixing it, try to find a way to calculate the bounds that is le
 	for(var/turf/T in view(light_range, src))
 		if(CHECK_OCCLUSION(T))
 			CastShadow(T)
+
+/atom/movable/light/smooth/cast_shadows()
+	return
 
 /atom/movable/light/proc/CastShadow(var/turf/target_turf)
 	//get the x and y offsets for how far the target turf is from the light
@@ -397,7 +398,7 @@ If you feel like fixing it, try to find a way to calculate the bounds that is le
 	overlays = temp_appearance
 	temp_appearance = null
 	// Because movable lights do this two-lights-sources thing
-	if (holder.lighting_flags & MOVABLE_LIGHT)
+	if ((holder.lighting_flags & MOVABLE_LIGHT) && icon_state == "white")
 		var/list/RGB = rgb2num(light_color)
 		color = rgb(round(RGB[1]/2), round(RGB[2]/2), round(RGB[3]/2))
 	else


### PR DESCRIPTION
It's a bit hacky, to say the least, but visually it works.

This decomposes a moving light atom in three parts:
- lights + shaows, not TILE_BOUND and making discrete jumps
- wall lights, not TILE_BOUND, making discrete jumps
- smooth light, making a continuos jump

It's not that bad on perf since only moving atoms will have one, and moving atoms defer to SS updates rather than instant updates if the load is too heavy anyway.