### PR TITLE
Disabled spark spawning for most regular forms of teleportation.

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -31,6 +31,8 @@
 		return FALSE
 	if(!setPrecision(aprecision))
 		return FALSE
+	var/turf/T = get_turf(adestination)
+	log_debug("TELEPORTATION: ateleatom: [ateleatom], adestination: [adestination][T ? "([T.x],[T.y],[T.z])" : ""]")
 	setEffects(aeffectin,aeffectout)
 	setForceTeleport(afteleport)
 	setIgnoreJamming(aijamming)

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -175,10 +175,13 @@
 
 /datum/teleport/instant/science/setEffects(datum/effect/system/aeffectin,datum/effect/system/aeffectout)
 	if(!aeffectin || !aeffectout)
+		//De-activated sparks by order of Pomf. Too easily exploited to create lag machines.
+		/*
 		var/datum/effect/system/spark_spread/aeffect = new
 		aeffect.set_up(5, TRUE, teleatom)
 		effectin = effectin || aeffect
 		effectout = effectout || aeffect
+		*/
 		return TRUE
 	else
 		return ..()


### PR DESCRIPTION


:cl:
* experimental: Spark no longer spawn at all from most regular forms of teleportation. This is a temporary measure due to their recent abuse in the creation of lag machines. A suitable replacement will be introduced later.