### PR TITLE
When broken apart, giant spider egg clusters now drops eatable and cookable spider eggs.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/effects.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/effects.dm
@@ -115,6 +115,11 @@
 	processing_objects.Remove(src)
 	..()
 
+/obj/effect/spider/eggcluster/healthcheck()
+	if(health <= 0)
+		new /obj/item/weapon/reagent_containers/food/snacks/spidereggs(loc)
+		qdel(src)
+
 /obj/effect/spider/eggcluster/process()
 	amount_grown += rand(0,2)
 	if(amount_grown >= 100)
@@ -123,42 +128,7 @@
 			//new /obj/effect/spider/spiderling(src.loc)
 			new /mob/living/simple_animal/hostile/giant_spider/spiderling(src.loc)
 		qdel(src)
-/*s
-/obj/effect/spider/spiderling
-	name = "spiderling"
-	desc = "It never stays still for long."
-	icon_state = "spiderling"
-	anchored = 0
-	layer = HIDING_MOB_PLANE
-	health = 3
-	var/amount_grown = 0
-	var/obj/machinery/atmospherics/unary/vent_pump/entry_vent
-	var/travelling_in_vent = 0
 
-/obj/effect/spider/spiderling/New()
-	..()
-	pixel_x = rand(6,-6)
-	pixel_y = rand(6,-6)
-	processing_objects.Add(src)
-	//50% chance to grow up
-	if(prob(50))
-		amount_grown = 1
-
-/obj/effect/spider/spiderling/to_bump(atom/user)
-	if(istype(user, /obj/structure/table))
-		src.forceMove(user.loc)
-	else
-		..()
-
-/obj/effect/spider/spiderling/proc/die()
-	visible_message("<span class='alert'>[src] dies!</span>")
-	new /obj/effect/decal/cleanable/spiderling_remains(src.loc)
-	qdel(src)
-
-/obj/effect/spider/spiderling/healthcheck()
-	if(health <= 0)
-		die()
-*/
 /obj/effect/decal/cleanable/spiderling_remains
 	name = "spiderling remains"
 	desc = "Green squishy mess."


### PR DESCRIPTION
Fixes #22278

:cl:
* rscadd: When broken apart, giant spider egg clusters now drops eatable and cookable spider eggs. (turingwept)