### PR TITLE
Converted my Perception features from #29935 for Europa Lights

### DIFF
--- a/__DEFINES/planes+layers.dm
+++ b/__DEFINES/planes+layers.dm
@@ -97,7 +97,7 @@ Why is FLOAT_PLANE added to a bunch of these?
 
 #define TURF_PLANE				(-1 + FLOAT_PLANE)
 	#define MAPPING_TURF_LAYER			-999
-	
+
 #define GLASSTILE_PLANE			-1						// Another one that won't behave, since it's an overlay
 
 #define ABOVE_TURF_PLANE 		(0 + FLOAT_PLANE)			// For items which should appear above turfs but below other objects and hiding mobs, eg: wires & pipes
@@ -203,7 +203,7 @@ Why is FLOAT_PLANE added to a bunch of these?
 
 	#define GHOST_LAYER 				1
 
-#define LIGHTING_PLANE_MASTER 	(13)	// Don't put anything other than lighting_overlays in there please
+								//13	//	THIS PLANE FOR RENT
 
 #define LIGHTING_PLANE 			(14)	// Don't put anything other than lighting_overlays in there please
 	#define SELF_VISION_LAYER 		   -1
@@ -221,7 +221,7 @@ Why is FLOAT_PLANE added to a bunch of these?
 
 #define BASE_PLANE 				(16)		//  this is where darkness is! see "how planes work" - needs SEE_BLACKNESS or SEE_PIXEL (see blackness is better for ss13)
 
-#define MISC_HUD_MARKERS_PLANE	16
+#define LIGHT_SOURCE_PLANE		16	// For Spiders to be able to click them despite being blinded
 
 #define ANTAG_HUD_PLANE		 	17
 
@@ -330,27 +330,3 @@ var/noir_master = list(new /obj/abstract/screen/plane_master/noir_master(),new /
 	ghost_planemaster_dummy = new /obj/abstract/screen/plane_master/ghost_planemaster_dummy
 	screen |= ghost_planemaster_dummy
 
-
-// DARKNESS PLANEMASTER
-// One planemaster for each client, which they gain during mob/login()
-/obj/abstract/screen/plane_master/darkness_planemaster
-	plane = LIGHTING_PLANE
-	blend_mode    = BLEND_MULTIPLY
-	alpha = 255
-
-/obj/abstract/screen/plane_master/darkness_planemaster_dummy
-	alpha = 0
-	appearance_flags = 0
-	plane = LIGHTING_PLANE
-
-/client/proc/initialize_darkness_planemaster()
-	if(darkness_planemaster)
-		screen -= darkness_planemaster
-		qdel(darkness_planemaster)
-	if(darkness_planemaster_dummy)
-		screen -= darkness_planemaster_dummy
-		qdel(darkness_planemaster_dummy)
-	darkness_planemaster = new /obj/abstract/screen/plane_master/darkness_planemaster
-	screen |= darkness_planemaster
-	darkness_planemaster_dummy = new /obj/abstract/screen/plane_master/darkness_planemaster_dummy
-	screen |= darkness_planemaster_dummy

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -337,4 +337,5 @@ proc/process_construct_hud(var/mob/M, var/mob/eye)
 				holder.icon_state = "consthealth0"
 			else
 				holder.icon_state = "consthealth[10*round((construct.health/construct.maxHealth)*10)]"
+			holder.plane = ABOVE_LIGHTING_PLANE
 			C.images += holder

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -52,6 +52,13 @@
 	update_brightness(user)
 	return 1
 
+/obj/item/device/flashlight/attack_animal(mob/living/simple_animal/M)
+	if(M.melee_damage_upper == 0)
+		return
+	else if (on && isspider(M))
+		on = FALSE
+		M.do_attack_animation(src, M)
+		update_brightness(M,1)
 
 /obj/item/device/flashlight/attack(mob/living/M as mob, mob/living/user as mob)
 	add_fingerprint(user)
@@ -236,6 +243,10 @@
 	// All good, turn it on.
 	user.visible_message("<span class='notice'>[user] activates the flare.</span>", "<span class='notice'>You pull the cord on the flare, activating it!</span>")
 	Light(user)
+
+
+/obj/item/device/flashlight/flare/attack_animal(mob/living/simple_animal/M)
+	return
 
 /obj/item/device/flashlight/flare/proc/Light(var/mob/user as mob)
 	on = 1

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1338,7 +1338,7 @@ var/list/admin_verbs_mod = list(
 		return
 
 	if (holder.see_lightmap)
-		usr.dark_plane.plane = LIGHTING_PLANE_MASTER
+		usr.dark_plane.plane = LIGHTING_PLANE
 		usr.dark_plane.alphas["light_map"] = 0
 	else
 		usr.dark_plane.plane = initial(usr.dark_plane.plane)

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -75,8 +75,6 @@
 	var/obj/abstract/screen/plane_master/parallax_spacemaster/parallax_spacemaster = null
 	var/obj/abstract/screen/plane_master/ghost_planemaster/ghost_planemaster = null
 	var/obj/abstract/screen/plane_master/ghost_planemaster_dummy/ghost_planemaster_dummy = null
-	var/obj/abstract/screen/plane_master/darkness_planemaster/darkness_planemaster = null
-	var/obj/abstract/screen/plane_master/ghost_planemaster_dummy/darkness_planemaster_dummy = null
 
 	// This gets set by goonchat.
 	var/encoding = "1252"

--- a/code/modules/lighting/light_planes.dm
+++ b/code/modules/lighting/light_planes.dm
@@ -37,7 +37,7 @@
 /obj/abstract/screen/plane/self_vision
 	blend_mode = BLEND_ADD
 	mouse_opacity = 0
-	plane = LIGHTING_PLANE_MASTER
+	plane = LIGHTING_PLANE
 	layer = SELF_VISION_LAYER
 	icon = 'icons/lighting/self_vision_default.dmi'
 	icon_state = "default"
@@ -54,6 +54,7 @@
 	alpha = 10
 	appearance_flags = RESET_TRANSFORM | RESET_COLOR | RESET_ALPHA
 	var/list/alphas = list()
+	var/colours = null // will animate() to that colour next check_dark_vision()
 
 /obj/abstract/screen/plane/dark/New()
 	..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1441,7 +1441,15 @@
 	return id
 
 /mob/living/carbon/human/update_perception()
-	if(client && client.darkness_planemaster)
+	if (dark_plane)
+		dark_plane.alphas = list()
+		dark_plane.colours = null
+		dark_plane.blend_mode = BLEND_ADD
+
+	if (master_plane)
+		master_plane.blend_mode = BLEND_MULTIPLY
+
+	if(client && dark_plane)
 		var/datum/organ/internal/eyes/E = src.internal_organs_by_name["eyes"]
 		if(E)
 			E.update_perception(src)
@@ -1449,9 +1457,11 @@
 		for(var/ID in virus2)
 			var/datum/disease2/disease/D = virus2[ID]
 			for (var/datum/disease2/effect/catvision/catvision in D.effects)
-				if (catvision.count)//if catulism has activated at least once, we can see much better in the dark.
-					client.darkness_planemaster.alpha = min(100, client.darkness_planemaster.alpha)
+				if (catvision.count)
+					dark_plane.alphas["cattulism"] = clamp(15 + (catvision.count * 20),15,155) // The more it activates, the better we see, until we see as well as a tajaran would.
 					break
+
+	check_dark_vision()
 
 /mob/living/carbon/human/assess_threat(var/obj/machinery/bot/secbot/judgebot, var/lasercolor)
 	if(judgebot.emagged == 2)

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -35,7 +35,7 @@
 				if (N)
 					if (i > V.cached_images.len)
 						var/image/I = image('icons/mob/mob.dmi', loc = C, icon_state = "vampnullrod")
-						I.plane = MISC_HUD_MARKERS_PLANE
+						I.plane = ABOVE_LIGHTING_PLANE
 						V.cached_images += I
 						src.client.images += I
 					else

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -65,16 +65,17 @@
 		src.add_spell(new spell, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
 
 /mob/living/simple_animal/construct/update_perception()
-	if(client)
-		if(client.darkness_planemaster)
-			client.darkness_planemaster.blend_mode = BLEND_MULTIPLY
-			client.darkness_planemaster.alpha = 180
+	if(dark_plane)
+		dark_plane.alphas["construct"] = 75
+		//client.darkness_planemaster.blend_mode = BLEND_MULTIPLY
 		client.color = list(
 					1,0,0,0,
 					0,1.3,0,0,
 	 				0,0,1.3,0,
 		 			0,-0.3,-0.3,1,
 		 			0,0,0,0)
+
+	check_dark_vision()
 
 
 /mob/living/simple_animal/construct/Move(NewLoc,Dir=0,step_x=0,step_y=0,var/glide_size_override = 0)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -87,6 +87,10 @@
 	var/a_54 = 0
 
 
+/mob/living/simple_animal/hostile/giant_spider/Login()
+	..()
+	client.images += light_source_images
+
 /mob/living/simple_animal/hostile/giant_spider/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover, /obj/item/projectile/web))//Queen Spider webs pass through other spiders
 		return 1
@@ -161,10 +165,10 @@
 	standard_damage_overlay_updates()
 
 /mob/living/simple_animal/hostile/giant_spider/update_perception()
-	if(client)
-		if(client.darkness_planemaster)
-			client.darkness_planemaster.blend_mode = BLEND_ADD
-			client.darkness_planemaster.alpha = 100
+	if(dark_plane)
+		if (master_plane)
+			master_plane.blend_mode = BLEND_ADD
+		dark_plane.alphas["spider"] = 15 // with the master_plane at BLEND_ADD, shadows appear well lit while actually well lit places appear blinding.
 		client.color = list(
 					1,0,0,0,
 					0,1,0,0,
@@ -178,6 +182,8 @@
 		 						a_31,a_32,a_33,a_34,
 			 					a_41,a_42,a_43,a_44,
 			 					a_51,a_52,a_53,a_54)
+
+	check_dark_vision()
 
 /mob/living/simple_animal/hostile/giant_spider/regular_hud_updates()
 	if (!client)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -62,7 +62,6 @@
 	client.screen += clickmaster // click catcher planesmaster on plane 0 with mouse opacity 0 - allows click catcher to work with SEE_BLACKNESS
 	client.screen += clickmaster_dummy // honestly fuck you lummox
 	client.initialize_ghost_planemaster() //We want to explicitly reset the planemaster's visibility on login() so if you toggle ghosts while dead you can still see cultghosts if revived etc.
-	client.initialize_darkness_planemaster()
 	update_perception()
 	create_lighting_planes()
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1589,17 +1589,17 @@ Use this proc preferably at the end of an equipment loadout
 		var/max_alpha = 0
 		for (var/key in dark_plane.alphas)
 			max_alpha = max(dark_plane.alphas[key], max_alpha)
-		dark_plane.alpha = max_alpha
-	else
-		dark_plane?.alpha = initial(dark_plane.alpha)
+		animate(dark_plane, alpha = max_alpha, color = dark_plane.colours, time = 10)
+	else if (dark_plane)
+		animate(dark_plane, alpha = initial(dark_plane.alpha), color = dark_plane.colours, time = 10)
 
 	if (self_vision)
 		if (isturf(loc))
 			var/turf/T = loc
-			if (T.get_lumcount() > 0)
-				self_vision.alpha = 0
+			if (T.get_lumcount() <= 0 && (dark_plane.alpha <= 15) && (master_plane.blend_mode == BLEND_MULTIPLY))
+				animate(self_vision, alpha = self_vision.target_alpha, time = 10)
 			else
-				self_vision.alpha = self_vision.target_alpha
+				animate(self_vision, alpha = 0, time = 10)
 
 //Like forceMove(), but for dirs! used in atoms_movable.dm, mainly with chairs and vehicles
 /mob/change_dir(new_dir, var/changer)

--- a/code/modules/organs/internal/eyes/eyes.dm
+++ b/code/modules/organs/internal/eyes/eyes.dm
@@ -31,7 +31,7 @@
 	removed_type = /obj/item/organ/internal/eyes/tajaran
 
 /datum/organ/internal/eyes/tajaran/update_perception(var/mob/living/carbon/human/M)
-	M.client.darkness_planemaster.alpha = 100
+	M.dark_plane.alphas["tajaran"] = 155
 
 /datum/organ/internal/eyes/grey
 	name = "huge eyes"
@@ -69,9 +69,10 @@
 
 /datum/organ/internal/eyes/mushroom/update_perception(var/mob/living/carbon/human/M)
 	if (dark_mode)
-		M.client.darkness_planemaster.blend_mode = BLEND_SUBTRACT
-		M.client.darkness_planemaster.alpha = 100
-		M.client.darkness_planemaster.color = "#FF0000"
+		M.master_plane.blend_mode = BLEND_SUBTRACT
+		M.dark_plane.alphas["mushroom_darkmode"] = 155
+		M.dark_plane.blend_mode = BLEND_MULTIPLY
+		M.dark_plane.colours = "#FF0000"
 		M.client.color = list(
 			1,0,0,0,
 			0,1,0,0,
@@ -79,9 +80,10 @@
 			0,-0.1,0,1,
 			0,0,0,0)
 	else
-		M.client.darkness_planemaster.blend_mode = BLEND_MULTIPLY
-		M.client.darkness_planemaster.alpha = 150
-		M.client.darkness_planemaster.color = null
+		M.dark_plane.alphas["mushroom_normal"] = 105
+		M.master_plane.blend_mode = BLEND_MULTIPLY
+		M.dark_plane.blend_mode = BLEND_ADD
+		M.dark_plane.colours = null
 		M.client.color = list(
 			1,0,0,0,
 			0,1,0,0,

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -101,6 +101,8 @@
 
 var/global/list/obj/machinery/light/alllights = list()
 
+var/list/light_source_images = list()
+
 // the standard tube light fixture
 /obj/machinery/light
 	name = "light fixture"
@@ -121,6 +123,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	var/obj/item/weapon/light/current_bulb = null
 	var/spawn_with_bulb = /obj/item/weapon/light/tube
 	var/fitting = "tube"
+	var/image/source_image = null
 
 	// No ghost interaction.
 	ghost_read=0
@@ -231,7 +234,11 @@ var/global/list/obj/machinery/light/alllights = list()
 	alllights -= src
 
 /obj/machinery/light/update_icon()
-
+	if (source_image)
+		light_source_images -= source_image
+		for (var/mob/living/simple_animal/hostile/giant_spider/GS in player_list)
+			if (GS.client)
+				GS.client.images -= source_image
 	if(current_bulb)
 		switch(current_bulb.status)		// set icon_states
 			if(LIGHT_OK)
@@ -245,6 +252,12 @@ var/global/list/obj/machinery/light/alllights = list()
 	else
 		icon_state = "l[fitting]-empty"
 		on = 0
+	source_image = image(icon,src,icon_state)
+	source_image.plane = LIGHT_SOURCE_PLANE
+	light_source_images += source_image
+	for (var/mob/living/simple_animal/hostile/giant_spider/GS in player_list)
+		if (GS.client)
+			GS.client.images += source_image
 
 // update the icon_state and luminosity of the light depending on its state
 /obj/machinery/light/proc/update(var/trigger = 1)
@@ -476,7 +489,6 @@ var/global/list/obj/machinery/light/alllights = list()
 				if (S)
 					S.broken_lights++
 		broken()
-	return
 // attack with hand - remove tube/bulb
 // if hands aren't protected and the light is on, burn the player
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -6550,10 +6550,10 @@
 					imageloc = M.current.loc
 					imagelocB = M.current.loc
 				var/image/I = image('icons/mob/HUD.dmi', loc = imageloc, icon_state = "metaclub")
-				I.plane = MISC_HUD_MARKERS_PLANE
+				I.plane = ANTAG_HUD_PLANE
 				M.current.client.images += I
 				var/image/J = image('icons/mob/HUD.dmi', loc = imagelocB, icon_state = "metaclub")
-				J.plane = MISC_HUD_MARKERS_PLANE
+				J.plane = ANTAG_HUD_PLANE
 				new_buddy.current.client.images += J
 
 /datum/reagent/ethanol/waifu

--- a/code/modules/virus2/effect/stage_3.dm
+++ b/code/modules/virus2/effect/stage_3.dm
@@ -504,8 +504,11 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/mob)
 
 	if (mob.see_in_dark_override < 9)
 		mob.see_in_dark_override = night_vision_strength + 1
-		if (count == 1)
+		if (count == 0)
 			to_chat(mob, "<span class = 'notice'>Your pupils dilate as they adjust for low-light environments.</span>")
+		else if (count == 6)
+			to_chat(mob, "<span class = 'notice'>Your pupils reach their maximum dilation.</span>")
+			mob.see_in_dark_override = 9
 		else
 			to_chat(mob, "<span class = 'notice'>Your pupils dilate further.</span>")
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/7573912/132421835-1a7f8692-3c3d-481e-8367-64dec8444a47.png)
![image](https://user-images.githubusercontent.com/7573912/132421839-ac7959d1-277e-4f1f-a406-27cd86f6cad1.png)
![image](https://user-images.githubusercontent.com/7573912/132421844-d5e724b1-e492-45e0-9cb9-5678f066da5f.png)
![image](https://user-images.githubusercontent.com/7573912/132421847-5010b397-09db-45a4-9f66-6fae9c51483c.png)
![image](https://user-images.githubusercontent.com/7573912/132421849-2e43d022-9de9-43aa-a81b-69ec4779ac0f.png)
![image](https://user-images.githubusercontent.com/7573912/132421851-38ff9dce-c273-4f72-bf1c-516beac1b589.png)

:cl:
* experiment: Tajaran, Mushmen, Giant Spiders, Constructs and humans with Cattulism Syndrome once again have better perception in dark areas. For some of them it's slightly different than it used to be but it's overall still pretty close and good looking.
* experiment: Lights appear slightly more blinding to Giant Spiders than before, however they can now easily see light bulbs through the light, allowing them to more easily break them. They can also attack flash lights and desk lamps to turn those off.
* bugfix: Fixed the small disc of vision that appears around players when they are in the dark so it uses the proper blend mode. That disc now also appears and disappears progressively as you enter or leave dark areas.
