### PR TITLE
Fixed discrepancy between glide speed of a mob and that of its anchored vehicle/chair/etc

### DIFF
--- a/code/datums/locking_category.dm
+++ b/code/datums/locking_category.dm
@@ -76,7 +76,7 @@
 		if (newer_loc) // Edge (no pun intended) case for map borders.
 			new_loc = newer_loc
 
-	AM.forceMove(new_loc, 0, 0, owner.glide_size)
+	AM.forceMove(new_loc, glide_size_override = owner.glide_size)
 
 // Modifies the atom to undo changes in lock().
 /datum/locking_category/proc/unlock(var/atom/movable/AM)

--- a/code/game/objects/structures/vehicles/adminbus.dm
+++ b/code/game/objects/structures/vehicles/adminbus.dm
@@ -11,6 +11,7 @@
 	plane = ABOVE_HUMAN_PLANE
 	pixel_x = -WORLD_ICON_SIZE
 	pixel_y = -WORLD_ICON_SIZE
+	noghostspin = 1
 	var/can_move=1
 	var/list/passengers = list()
 	var/unloading = 0
@@ -206,9 +207,9 @@
 	update_lightsource()
 	handle_mob_bumping()
 	if(warp)
-		warp.forceMove(loc)
+		warp.forceMove(loc, glide_size_override = glide_size)
 	if(busjuke)
-		busjuke.forceMove(loc)
+		busjuke.forceMove(loc, glide_size_override = glide_size)
 		busjuke.change_dir(dir)
 		if(busjuke.icon_state)
 			busjuke.repack()
@@ -218,17 +219,17 @@
 		var/atom/A = passengers[i]
 		if(isliving(A))
 			var/mob/living/M = A
-			M.forceMove(loc)
+			M.forceMove(loc, glide_size_override = glide_size)
 		else if(isbot(A))
 			var/obj/machinery/bot/B = A
-			B.forceMove(loc)
+			B.forceMove(loc, glide_size_override = glide_size)
 	for(var/obj/structure/hookshot/H in hookshot)
-		H.forceMove(get_step(H,src.dir))
+		H.forceMove(get_step(H,src.dir), glide_size_override = glide_size)
 
 /obj/structure/bed/chair/vehicle/adminbus/proc/update_lightsource()
 	var/turf/T = get_step(src,src.dir)
 	if(T.opacity)
-		lightsource.forceMove(T)
+		lightsource.forceMove(T, glide_size_override = glide_size)
 		switch(roadlights)							//if the bus is right against a wall, only the wall's tile is lit
 			if(0)
 				if(lightsource.light_range != 0)
@@ -239,7 +240,7 @@
 	else
 		T = get_step(T,src.dir)						//if there is a wall two tiles in front of the bus, the lightsource is right in front of the bus, though weaker
 		if(T.opacity)
-			lightsource.forceMove(get_step(src,src.dir))
+			lightsource.forceMove(get_step(src,src.dir), glide_size_override = glide_size)
 			switch(roadlights)
 				if(0)
 					if(lightsource.light_range != 0)
@@ -251,7 +252,7 @@
 					if(lightsource.light_range != 2)
 						lightsource.set_light(2)
 		else
-			lightsource.forceMove(T)
+			lightsource.forceMove(T, glide_size_override = glide_size)
 			switch(roadlights)						//otherwise, the lightsource position itself two tiles in front of the bus and with regular light_range
 				if(0)
 					if(lightsource.light_range != 0)
@@ -493,7 +494,7 @@
 		H.max_distance = max_distance
 		H.abus = abus
 	if(max_distance > 0)
-		forceMove(get_step(src,toward))
+		forceMove(get_step(src,toward), glide_size_override = glide_size)
 		sleep(2)
 		var/obj/machinery/singularity/S2 = hook_throw(toward)
 		if(S2)
@@ -504,7 +505,7 @@
 		return null
 
 /obj/structure/hookshot/proc/hook_back()
-	forceMove(get_step_towards(src,abus))
+	forceMove(get_step_towards(src,abus), glide_size_override = glide_size)
 	max_distance++
 	if(max_distance >= 7)
 		abus.hookshot -= src
@@ -522,7 +523,7 @@
 				var/mob/living/M = abus.occupant
 				M.UpdateUIElementIcon(/obj/abstract/mind_ui_element/hoverable/adminbus_hook)
 			return
-	forceMove(get_step_towards(src,abus))
+	forceMove(get_step_towards(src,abus), glide_size_override = glide_size)
 	max_distance++
 	if(max_distance >= 7)
 		abus.hookshot -= src
@@ -569,7 +570,7 @@
 /obj/structure/singulo_chain/proc/move_child(var/turf/parent)
 	var/turf/T = get_turf(src)
 	if(parent)//I don't see how this could be null but a sanity check won't hurt
-		src.forceMove(parent)
+		forceMove(parent, glide_size_override = glide_size)
 	if(child)
 		if(get_dist(src,child) > 1)
 			child.move_child(T)
@@ -580,11 +581,11 @@
 /obj/structure/singulo_chain/anchor/move_child(var/turf/parent)
 	var/turf/T = get_turf(src)
 	if(parent)
-		src.forceMove(parent)
+		forceMove(parent, glide_size_override = glide_size)
 	else
 		dir = get_dir(T,src)
 	if(target)
-		target.forceMove(src.loc)
+		target.forceMove(loc, glide_size_override = glide_size)
 
 /obj/structure/singulo_chain/cultify()
 	return


### PR DESCRIPTION
Fixes #20909
Fixes #30626

Turns out it had nothing to do with #30573 somehow, in fact I'm curious this bug hasn't been observed more often until now.

:cl:
* bugfix: Fixed discrepancy between glide speed of a mob and that of its anchored vehicle, chair, etc. (Bomber Harris)
* bugfix: Passengers of the Adminbus now always move as smoothly as the bus itself. (9600bauds)