### PR TITLE
Tackling

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -118,7 +118,7 @@
 		return
 
 	if(in_throw_mode)
-		if(!get_active_hand() && a_intent != I_HELP)
+		if(!get_active_hand() && (a_intent == I_GRAB || a_intent == I_DISARM))
 			doTackle(A)
 		else
 			throw_item(A)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -118,7 +118,10 @@
 		return
 
 	if(in_throw_mode)
-		throw_item(A)
+		if(!get_active_hand() && a_intent != I_HELP)
+			doTackle(A)
+		else
+			throw_item(A)
 		return
 
 	var/obj/item/held_item = get_active_hand()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -284,6 +284,9 @@
 /obj/item/clothing/proc/get_armor_absorb(var/type)
 	return armor_absorb[type]
 
+/obj/item/clothing/proc/getTackleBonus()
+	return
+
 //Ears: headsets, earmuffs and tiny objects
 /obj/item/clothing/ears
 	name = "ears"
@@ -498,6 +501,10 @@
 /obj/item/clothing/shoes/proc/on_kick(mob/living/user, mob/living/victim)
 	return
 
+/obj/item/clothing/shoes/getTackleBonus()
+	if(clothing_flags & MAGPULSE)
+		return 4
+
 //Called from human_defense.dm proc foot_impact
 /obj/item/clothing/shoes/proc/impact_dampen(atom/source, var/damage)
 	return damage
@@ -543,7 +550,7 @@
 	sterility = 30
 
 /obj/item/clothing/suit/proc/vine_protected()
-	return FALSE 
+	return FALSE
 
 //Spacesuit
 //Note: Everything in modules/clothing/spacesuits should have the entire suit grouped together.

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -284,7 +284,10 @@
 /obj/item/clothing/proc/get_armor_absorb(var/type)
 	return armor_absorb[type]
 
-/obj/item/clothing/proc/getTackleBonus()
+/obj/item/clothing/proc/offenseTackleBonus()
+	return
+
+/obj/item/clothing/proc/defenseTackleBonus()
 	return
 
 //Ears: headsets, earmuffs and tiny objects
@@ -501,7 +504,7 @@
 /obj/item/clothing/shoes/proc/on_kick(mob/living/user, mob/living/victim)
 	return
 
-/obj/item/clothing/shoes/getTackleBonus()
+/obj/item/clothing/shoes/defenseTackleBonus()
 	if(clothing_flags & MAGPULSE)
 		return 4
 

--- a/code/modules/clothing/head/tactical.dm
+++ b/code/modules/clothing/head/tactical.dm
@@ -30,6 +30,9 @@
 	body_parts_covered = FULL_HEAD|MASKHEADHAIR
 	eyeprot = 1
 
+/obj/item/clothing/head/helmet/tactical/riot/getTackleBonus()
+	return 2
+
 /obj/item/clothing/head/helmet/tactical/swat
 	name = "\improper SWAT helmet"
 	desc = "They're often used by highly trained Swat Members."

--- a/code/modules/clothing/head/tactical.dm
+++ b/code/modules/clothing/head/tactical.dm
@@ -30,8 +30,11 @@
 	body_parts_covered = FULL_HEAD|MASKHEADHAIR
 	eyeprot = 1
 
-/obj/item/clothing/head/helmet/tactical/riot/getTackleBonus()
-	return 2
+/obj/item/clothing/head/helmet/tactical/riot/offenseTackleBonus()
+	return 1
+
+/obj/item/clothing/head/helmet/tactical/riot/defenseTackleBonus()
+	return 1
 
 /obj/item/clothing/head/helmet/tactical/swat
 	name = "\improper SWAT helmet"

--- a/code/modules/clothing/masks/boxing.dm
+++ b/code/modules/clothing/masks/boxing.dm
@@ -21,6 +21,12 @@
 		message += " OLE!"
 	speech.message = message
 
+/obj/item/clothing/mask/luchador/offenseTackleBonus()
+	return 1
+
+/obj/item/clothing/mask/luchador/defenseTackleBonus()
+	return 1
+
 /obj/item/clothing/mask/luchador/tecnicos
 	name = "Tecnicos Mask"
 	desc = "Worn by robust fighters who uphold justice and fight honorably."

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -153,7 +153,7 @@
 	siemens_coefficient = 0.5
 
 /obj/item/clothing/suit/armor/riot/getTackleBonus()
-	return 3
+	return 2
 
 /obj/item/clothing/suit/armor/rune
 	name = "rune platebody"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -152,6 +152,9 @@
 	armor = list(melee = 80, bullet = 10, laser = 10, energy = 10, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.5
 
+/obj/item/clothing/suit/armor/riot/getTackleBonus()
+	return 3
+
 /obj/item/clothing/suit/armor/rune
 	name = "rune platebody"
 	desc = "Provides excellent protection."

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -152,7 +152,10 @@
 	armor = list(melee = 80, bullet = 10, laser = 10, energy = 10, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.5
 
-/obj/item/clothing/suit/armor/riot/getTackleBonus()
+/obj/item/clothing/suit/armor/riot/offenseTackleBonus()
+	return 1
+
+/obj/item/clothing/suit/armor/riot/defenseTackleBonus()
 	return 2
 
 /obj/item/clothing/suit/armor/rune

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -993,6 +993,9 @@
 	clothing_flags = ONESIZEFITSALL
 	species_fit = list(INSECT_SHAPED, VOX_SHAPED, GREY_SHAPED)
 
+/obj/item/clothing/under/football/offenseTackleBonus()
+	return 1
+
 /obj/item/clothing/under/football/New()
 	icon_state = "redfootball_[pick(23,13,69,56)]"
 	item_state = icon_state

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -28,6 +28,7 @@
 	var/obj/item/device/station_map/displayed_holomap = null
 
 	var/target_zone = null
+	var/isTackling = FALSE
 
 /mob/living/carbon/New(var/new_loc, var/new_species_name = null, var/delay_ready_dna=0)
 	..()

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -101,41 +101,51 @@
 /mob/living/carbon/doTackle(var/atom/A)
 	if(throw_delayer.blocked())
 		return
-	delayNextThrow(3)
+	delayNextThrow(10)
 	throw_mode_off()
 	if(!get_turf(src) || istype(get_turf(src), /turf/space))
 		to_chat(src, "<span class='warning'>You need more footing to do that!")
 		return
-	if(restrained() || lying || stat)
+	if(restrained() || lying || locked_to || stat)
 		return
 	var/tRange = calcTackleRange()
 	isTackling = TRUE
-	Knockdown(2)
-	throw_at(A, tRange, 3)
+	knockdown = max(knockdown, 2)	//Not using the Knockdown() proc as it created odd behaviour with hulks and another knockdown immune
+	update_canmove()
+	throw_at(A, tRange, 1)
 
 /mob/living/carbon/throw_impact(atom/hit_atom, speed, user)
 	if(isTackling)
-		var/tackleForce = calcTackleForce()
-		if(isliving(hit_atom))
-			var/mob/living/L = hit_atom
-			var/tackleDefense = L.calcTackleDefense()
-			var/rngForce = rand(tackleForce/2, tackleForce)	//RNG or else most people would just bounce off each other.
-			var/rngDefense = rand(tackleDefense/2, tackleDefense)
-			var/tKnock = max(0, rngDefense - rngForce)	//Calculating our knockdown, we always get knocked down at least a little
-			Knockdown(tKnock)
-			tKnock = max(0, rngForce - rngDefense)	//Calculating their knockdown, they might not get knocked down at all
-			if(tKnock)
-				L.Knockdown(tKnock)
-				if(M_HORNS in mutations)
-					tKnock += 5
-				L.adjustBruteLoss(tKnock)
-		else if(hit_atom.density)
+		if(!throwing)
+			isTackling = FALSE	//Safety from throw_at being a jerk
+		else
+			var/tackleForce = calcTackleForce()
+			if(isliving(hit_atom))
+				var/mob/living/L = hit_atom
+				var/tackleDefense = L.calcTackleDefense()
+				var/rngForce = rand(tackleForce/2, tackleForce)	//RNG or else most people would just bounce off each other.
+				var/rngDefense = rand(tackleDefense/2, tackleDefense)
+				var/tKnock = max(0, rngDefense - rngForce)	//Calculating our knockdown, we always get knocked down at least a little
+				Knockdown(tKnock)
+				tKnock = max(0, rngForce - rngDefense)	//Calculating their knockdown, they might not get knocked down at all
+				if(tKnock)
+					L.Knockdown(tKnock)
+					if(M_HORNS in mutations)
+						tKnock += 5
+					L.adjustBruteLoss(tKnock)
+			spawn(3)	//Just to let throw_impact stop throwing a tantrum
+				isTackling = FALSE
+	..()
+
+/mob/living/carbon/to_bump(atom/Obstacle)
+	..()
+	if(isTackling)
+		if(!throwing)
+			isTackling = FALSE	//Safety from throw_at being a jerk
+		else
 			var/tPain = rand(1,10)
 			adjustBruteLoss(tPain)
 			Knockdown(tPain/2)
-		spawn(3)	//Just to let throw_impact stop throwing a tantrum
-			isTackling = FALSE
-	..()
 
 /mob/living/carbon/calcTackleRange(var/tR = 0)
 	tR += bonusTackleRange()
@@ -146,6 +156,10 @@
 	return tR
 
 /mob/living/carbon/calcTackleForce(var/tForce = 0)
+	if(world.time > last_moved + 1 SECONDS)	//If you haven't moved in the last second you do a weaker "standing tackle"
+		tForce -= 1
+	else
+		tForce += 1
 	tForce += get_strength()*2
 	if(M_HULK in mutations)
 		tForce += 2	//hulk also contributes to get_strength() so the bonus is higher than appears here
@@ -162,12 +176,13 @@
 		tDef += 2
 	for(var/obj/item/weapon/I in held_items)
 		if(I.IsShield())
-			tDef += 5
+			tDef += 4
 	tDef += bonusTackleDefense()
 	if(M_VEGAN in mutations)
 		tDef -= 1
 	if(M_CLUMSY in mutations)	//The clown fears fatsec
 		tDef -= 2
+		playsound(loc, 'sound/items/bikehorn.ogg', 20, 1)
 	return max(0, tDef)
 
 /mob/living/carbon/proc/bonusTackleForce(var/tF = 1)

--- a/code/modules/mob/living/carbon/human/combat.dm
+++ b/code/modules/mob/living/carbon/human/combat.dm
@@ -265,3 +265,40 @@
 /mob/living/carbon/human/on_dodge(attacker, attacking_object)
 	if(isninja(src))
 		emote("smirks", message = TRUE)
+
+//Tackle procs//////
+
+/mob/living/carbon/human/bonusTackleForce(var/tF = 0)
+	if(wear_suit)
+		var/obj/item/clothing/suit/S = wear_suit
+		if(istype(S))
+			tF += S.getTackleBonus()
+	if(head)
+		var/obj/item/clothing/head/H = head
+		if(istype(H))
+			tF += H.getTackleBonus()
+	if(species)
+		tF += species.tacklePower
+	return tF
+
+/mob/living/carbon/human/bonusTackleDefense(var/tD = 0)
+	if(shoes)
+		var/obj/item/clothing/shoes/B = shoes
+		if(istype(B))
+			tD += B.getTackleBonus()
+	if(wear_suit)
+		var/obj/item/clothing/suit/S = wear_suit
+		if(istype(S))
+			tD += S.getTackleBonus()
+	if(head)
+		var/obj/item/clothing/head/H = head
+		if(istype(H))
+			tD += H.getTackleBonus()
+	if(species)
+		tD += species.tacklePower
+	return tD
+
+/mob/living/carbon/human/bonusTackleRange(var/tR = 0)
+	if(species)
+		tR += species.tackleRange
+	return tR

--- a/code/modules/mob/living/carbon/human/combat.dm
+++ b/code/modules/mob/living/carbon/human/combat.dm
@@ -269,31 +269,17 @@
 //Tackle procs//////
 
 /mob/living/carbon/human/bonusTackleForce(var/tF = 0)
-	if(wear_suit)
-		var/obj/item/clothing/suit/S = wear_suit
-		if(istype(S))
-			tF += S.getTackleBonus()
-	if(head)
-		var/obj/item/clothing/head/H = head
-		if(istype(H))
-			tF += H.getTackleBonus()
+	for(var/obj/item/clothing/C in get_all_slots())
+		if(istype(C))
+			tF += C.offenseTackleBonus()
 	if(species)
 		tF += species.tacklePower
 	return tF
 
 /mob/living/carbon/human/bonusTackleDefense(var/tD = 0)
-	if(shoes)
-		var/obj/item/clothing/shoes/B = shoes
-		if(istype(B))
-			tD += B.getTackleBonus()
-	if(wear_suit)
-		var/obj/item/clothing/suit/S = wear_suit
-		if(istype(S))
-			tD += S.getTackleBonus()
-	if(head)
-		var/obj/item/clothing/head/H = head
-		if(istype(H))
-			tD += H.getTackleBonus()
+	for(var/obj/item/clothing/C in get_all_slots())
+		if(istype(C))
+			tD += C.defenseTackleBonus()
 	if(species)
 		tD += species.tacklePower
 	return tD

--- a/code/modules/mob/living/carbon/human/combat.dm
+++ b/code/modules/mob/living/carbon/human/combat.dm
@@ -301,4 +301,8 @@
 /mob/living/carbon/human/bonusTackleRange(var/tR = 0)
 	if(species)
 		tR += species.tackleRange
-	return tR
+	if(wear_suit)
+		var/obj/item/slowSuit = wear_suit
+		if(slowSuit.slowdown > NO_SLOWDOWN)
+			tR -= 1
+	return max(0, tR)

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -417,7 +417,7 @@ var/global/list/whitelisted_species = list("Human")
 
 	default_mutations=list(M_SKELETON)
 	brute_mod = 2.0
-	tacklePower = 3
+	tacklePower = 2
 	tackleRange = 3		//How terribly spooky
 
 	has_organ = list(

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -47,6 +47,8 @@ var/global/list/whitelisted_species = list("Human")
 	var/punch_sharpness = 0										// Slicing/cutting force of punches. Independent of the sharpness added by claws.
 	var/punch_throw_range = 0
 	var/punch_throw_speed = 1
+	var/tacklePower = 5
+	var/tackleRange = 2
 	var/mutantrace											// Safeguard due to old code.
 	var/myhuman												// mob reference
 
@@ -415,6 +417,8 @@ var/global/list/whitelisted_species = list("Human")
 
 	default_mutations=list(M_SKELETON)
 	brute_mod = 2.0
+	tacklePower = 3
+	tackleRange = 3		//How terribly spooky
 
 	has_organ = list(
 		"brain" =    /datum/organ/internal/brain,
@@ -590,6 +594,7 @@ var/global/list/whitelisted_species = list("Human")
 	eyes = "grey_eyes_s"
 
 	max_hurt_damage = 3 // From 5 (for humans)
+	tacklePower = 2
 
 	primitive = /mob/living/carbon/monkey/grey
 
@@ -661,6 +666,7 @@ var/global/list/whitelisted_species = list("Human")
 	eyes = "eyes_s"
 
 	max_hurt_damage = 10
+	tacklePower = 9
 
 	primitive = /mob/living/carbon/monkey // TODO
 
@@ -720,7 +726,7 @@ var/global/list/whitelisted_species = list("Human")
 	deform = 'icons/mob/human_races/vox/r_def_vox.dmi'
 	known_languages = list(LANGUAGE_VOX)
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/rawchicken/vox
-
+	tacklePower = 4
 	anatomy_flags = HAS_SWEAT_GLANDS
 
 	survival_gear = /obj/item/weapon/storage/box/survival/vox
@@ -833,6 +839,8 @@ var/global/list/whitelisted_species = list("Human")
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/diona
 	attack_verb = "slashes"
 	punch_damage = 5
+	tacklePower = 7
+	tackleRange = 1
 	primitive = /mob/living/carbon/monkey/diona
 
 	spells = list(/spell/targeted/transfer_reagents)
@@ -887,6 +895,8 @@ var/global/list/whitelisted_species = list("Human")
 	known_languages = list(LANGUAGE_GOLEM)
 	meat_type = /obj/item/stack/ore/diamond
 	attack_verb = "punches"
+	tacklePower = 8
+	tackleRange = 1
 
 	flags = NO_BREATHE | NO_PAIN | HYPOTHERMIA_IMMUNE
 	anatomy_flags = HAS_LIPS | NO_SKIN | NO_BLOOD | IS_BULKY | NO_STRUCTURE
@@ -1065,6 +1075,7 @@ var/list/has_died_as_golem = list()
 	known_languages = list(LANGUAGE_SLIME)
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/slime
 	attack_verb = "glomps"
+	tacklePower = 4
 
 	flags = IS_WHITELISTED | NO_BREATHE | ELECTRIC_HEAL
 	anatomy_flags = NO_SKIN | NO_BLOOD | NO_BONES | NO_STRUCTURE | MULTICOLOR

--- a/code/modules/mob/living/combat.dm
+++ b/code/modules/mob/living/combat.dm
@@ -145,3 +145,12 @@
 //Chance is multiplied by the returned value
 /mob/living/proc/knockout_chance_modifier()
 	return 0
+
+/mob/living/proc/calcTackleForce()
+	return 0
+
+/mob/living/proc/calcTackleDefense()
+	return 0
+
+/mob/living/proc/calcTackleRange()
+	return 0


### PR DESCRIPTION
This PR adds the ability for spessmen to tackle. The evolution of combat will revolutionize ~runescape~ spess as an e-sport.

To perform a tackle you just need to be on either grab or disarm intent, then throw with an empty hand. This will immediately knock you over and throw you forward. If you hit a living creature along the way it **may** be knocked over as well.

![bettertackle](https://user-images.githubusercontent.com/64218965/132570302-63fb7e5a-5820-4362-bbf4-8c677833fd84.gif)

### How it Works

Different factors affect how strong your tackle, or ability to resist being tackled is:

- Several mutations affect it positively or negatively. 
- Species has an effect of varying significance
- Equipment helps. Riot gear for example.
- Being fat 

These factors are summed up for both the tackler and tackle-y then some RNG is applied. The tackler is always knocked down, but if the tackle-y wins the dice roll they aren't knocked down. The difference in the two numbers defines how long both people involved are knocked down. Due to rounding both parties will likely be knocked down for the same amount of time, but if one number is much higher this can change. 

### Why Though and/or Reee Free Stun!

The chef shouldn't feel obligated to carry a taser. Due to the limitations of our combat system and how, aside from very lucky disarm attempts, the only means of defense is based on equipment, the chef is probably a lot happier with a taser if he knows there's a cult around. 
The idea here is to give unarmed spessmen a sort of delay tactic when caught alone. Screaming for help while you desperately tackle a school shooter, both of you scrambling to pick up his gun first only to have the other immediately tackle you back will do a lot to improve that sort of encounter.

Additionally there's a lot to be said for what it can do for other aspects of the game:
-  Two man sec teams can RP a little better with minor criminals. Rather than taze cuffing immediately, they'll have the option of tackling and screaming HALT HALT while hoping the tackle was enough for their partner to cuff them. 
- Rage cages will be very dramatic
- A third thing probably!

Tackling generally favors the person on defense. This is by design as the intention isn't to give people an I-win button but instead a minor counter to the existing I-win buttons we already have.

I understand this will probably trigger a lot of twitch reflex reactions against it due to sounding like a free stun, but after testing it consistently for a few days I'm confident it won't function that way live. If I'm wrong I made sure to make it easy to tweak.
I'll include a more detailed list of how tackling is calculated in a comment below to avoid a wall of text here. 

:cl:
 * rscadd: Spessmen can now perform a tackle by being on a grab/disarm intent and throwing with an empty hand. Knocking themselves and maybe someone else to the ground.