### PR TITLE
New Folders & Paperbins (Box Edition)

### DIFF
--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -18,30 +18,43 @@
 
 /obj/item/weapon/folder/black
 	crayon = "black"
+	icon_state = "folder_black" //previews for mapper sanity
 
 /obj/item/weapon/folder/blue
 	crayon = "blue"
+	icon_state = "folder_blue"
 
 /obj/item/weapon/folder/red
 	crayon = "red"
+	icon_state = "folder_red"
 
 /obj/item/weapon/folder/white
 	crayon = "sterile"
+	icon_state = "folder_sterile"
 
 /obj/item/weapon/folder/yellow
 	crayon = "yellow"
+	icon_state = "folder_yellow"
 
 /obj/item/weapon/folder/purple
 	crayon = "purple"
+	icon_state = "folder_purple"
 
 /obj/item/weapon/folder/orange
 	crayon = "orange"
+	icon_state = "folder_orange"
 
 /obj/item/weapon/folder/green
 	crayon = "green"
+	icon_state = "folder_green"
 
 /obj/item/weapon/folder/rainbow
 	crayon = "rainbow"
+	icon_state = "folder_rainbow"
+
+/obj/item/weapon/folder/mime
+	crayon = "mime"
+	icon_state = "folder_mime"
 
 /obj/item/weapon/folder/update_icon()
 	overlays.len = 0

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -1,7 +1,7 @@
 /obj/item/weapon/paper_bin
 	name = "paper bin"
 	icon = 'icons/obj/bureaucracy.dmi'
-	icon_state = "paper_bin_black"
+	icon_state = "paper_bin_"
 	item_state = "sheet-metal"
 	throwforce = 1
 	w_class = W_CLASS_MEDIUM
@@ -19,32 +19,45 @@
 	..()
 	update_icon()
 
+/obj/item/weapon/paper_bin/black
+	crayon = "black"
+	icon_state = "paper_bin_black" //previews for mapper sanity
+
 /obj/item/weapon/paper_bin/blue
 	crayon = "blue"
+	icon_state = "paper_bin_blue"
 
 /obj/item/weapon/paper_bin/red
 	crayon = "red"
+	icon_state = "paper_bin_red"
 
 /obj/item/weapon/paper_bin/white
 	crayon = "sterile"
+	icon_state = "paper_bin_sterile"
 
 /obj/item/weapon/paper_bin/yellow
 	crayon = "yellow"
+	icon_state = "paper_bin_yellow"
 
 /obj/item/weapon/paper_bin/purple
 	crayon = "purple"
+	icon_state = "paper_bin_purple"
 
 /obj/item/weapon/paper_bin/orange
 	crayon = "orange"
+	icon_state = "paper_bin_orange"
 
 /obj/item/weapon/paper_bin/green
 	crayon = "green"
+	icon_state = "paper_bin_green"
 
 /obj/item/weapon/paper_bin/rainbow
 	crayon = "rainbow"
+	icon_state = "paper_bin_rainbow"
 
 /obj/item/weapon/paper_bin/mime
 	crayon = "mime"
+	icon_state = "paper_bin_mime"
 
 /obj/item/weapon/paper_bin/ignite()
 	if(amount || papers.len)


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
Replaces the paper bins and folders on Boxstation with appropriate variants for each department to take advantage of the new paper bin and folder colors. Also adds a couple of folder and bin types (for mapping purposes, not new icons) I missed in the original PR.

:cl:
 * tweak: Folders and paper bins on Boxstation are now colored to match their department.