### PR TITLE
Fixed a bug where muzzles could prevent casting spells that didn't require invocation

### DIFF
--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -390,7 +390,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 			to_chat(user, "Not when you're incapacitated.")
 			return 0
 
-		if(ishuman(user) || ismonkey(user) && !(invocation_type in list(SpI_EMOTE, SpI_NONE)))
+		if((ishuman(user) || ismonkey(user)) && !(invocation_type in list(SpI_EMOTE, SpI_NONE)))
 			if(istype(user.wear_mask, /obj/item/clothing/mask/muzzle))
 				to_chat(user, "Mmmf mrrfff!")
 				return 0


### PR DESCRIPTION
Closes #30651

:cl:
 * bugfix: Fixed a bug where muzzles could prevent casting spells that didn't require invocation