### PR TITLE
Fix light objects showing on map renders.

### DIFF
--- a/maprendering/maprendering.dm
+++ b/maprendering/maprendering.dm
@@ -48,7 +48,8 @@
 						var/list/allturfcontents = currentturf.contents.Copy()
 
 						//Remove the following line to allow lighting to be considered, if you do this it must be blended with BLEND_MULTIPLY instead of ICON_OVERLAY
-						allturfcontents -= locate(/atom/movable/light) in allturfcontents
+						for (var/atom/movable/light/L in allturfcontents)
+							allturfcontents -= L
 
 						for(var/atom/movable/A in allturfcontents)
 							if(A.locs.len > 1) //Fix for multitile objects I wish I didn't have to do this its probably slow


### PR DESCRIPTION
There can now be multiple overlapping light objects per tile, so we have to make sure to remove ALL of them in map rendering.
Map renders still seem very broken currently, but this at least makes them *somewhat* usable.
