### PR TITLE
Disable post-processing for now

### DIFF
--- a/code/modules/lighting/light_effect_cast.dm
+++ b/code/modules/lighting/light_effect_cast.dm
@@ -408,7 +408,7 @@ If you feel like fixing it, try to find a way to calculate the bounds that is le
 	temp_appearance += I
 
 /atom/movable/light/proc/update_appearance()
-	post_processing()
+	//post_processing()
 	overlays = temp_appearance
 	temp_appearance = null
 	// Because movable lights do this two-lights-sources thing

--- a/code/modules/lighting/light_effect_cast.dm
+++ b/code/modules/lighting/light_effect_cast.dm
@@ -10,6 +10,7 @@
 #define MAX_LIGHT_RANGE 5
 
 var/light_power_multiplier = 5
+var/light_post_processing = 0 // Use writeglobal to change this
 
 // We actually see these "pseudo-light atoms" in order to ensure that wall shadows are only seen by people who can see the light.
 // Yes, this is stupid, but it's one of the limitations of TILE_BOUND, which cannot be chosen on an overlay-per-overlay basis.
@@ -408,7 +409,8 @@ If you feel like fixing it, try to find a way to calculate the bounds that is le
 	temp_appearance += I
 
 /atom/movable/light/proc/update_appearance()
-	//post_processing()
+	if (light_post_processing)
+		post_processing()
 	overlays = temp_appearance
 	temp_appearance = null
 	// Because movable lights do this two-lights-sources thing


### PR DESCRIPTION
We know that BYOND is not being reasonable with Hardware acceleration here.
Hopefully when/if Lummox fixes that we can go back to it, and maybe add cooler effects.

Apparently the renderer is completely rewritten in 515 too, so fingers crossed it'll be before we all die of old age.

[performance]

:cl:
- rscdel: Disabled lighting post-processing for now. Lights should look a bit more blocky. It will come back once Lummox fixes hardware rendering.