### PR TITLE
Traitor PDA Pinpointer can now change targets more than once

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -447,7 +447,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/device_tools/pdapinpointer
 	name = "PDA Pinpointer"
-	desc = "A pinpointer that can flawlessly track any PDA in the local space sector. Useful for locating assassination targets or other high-value targets that you can't find. Do note that it can only be set once and cannot track normal targets like the nuclear disk, and is obvious upon inspection."
+	desc = "A pinpointer that can flawlessly track any PDA in the local space sector. Useful for locating assassination targets or other high-value targets that you can't find. Do note that it cannot track normal targets like the nuclear disk, and is obvious upon inspection."
 	item = /obj/item/weapon/pinpointer/pdapinpointer
 	cost = 4
 

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -256,7 +256,6 @@ var/list/pinpointerpinpointer_list = list()
 /obj/item/weapon/pinpointer/pdapinpointer
 	name = "pda pinpointer"
 	desc = "A pinpointer that has been illegally modified to track the PDA of a crewmember for malicious reasons."
-	var/used = FALSE
 	watches_nuke = FALSE
 	pinpointable = FALSE
 
@@ -280,10 +279,6 @@ var/list/pinpointerpinpointer_list = list()
 	set name = "Select pinpointer target"
 	set src in view(1)
 
-	if(used)
-		to_chat(usr,"Target has already been set!")
-		return
-
 	var/list/L = list()
 	L["Cancel"] = "Cancel"
 	var/length = 1
@@ -292,7 +287,7 @@ var/list/pinpointerpinpointer_list = list()
 			L[text("([length]) [P.name]")] = P
 			length++
 
-	var/t = input("Select pinpointer target. WARNING: Can only set once.") as null|anything in L
+	var/t = input("Select pinpointer target.") as null|anything in L
 	if(t == "Cancel")
 		return
 	target = L[t]
@@ -302,8 +297,11 @@ var/list/pinpointerpinpointer_list = list()
 	active = TRUE
 	point_at(target)
 	to_chat(usr,"You set the pinpointer to locate [target]")
-	used = TRUE
 
+/obj/item/weapon/pinpointer/pdapinpointer/AltClick()
+	if(select_pda())
+		return
+	return ..()
 
 /obj/item/weapon/pinpointer/pdapinpointer/examine(mob/user)
 	..()

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -296,7 +296,8 @@ var/list/pinpointerpinpointer_list = list()
 		to_chat(usr, "<span class='warning'>The [src] refuses to operate.</span>")
 		return
 	else if(nextuse - world.time > 0)
-		to_chat(usr, "<span class='warning'>The [src] is still recalibrating.</span>")
+		to_chat(usr, "<span class='warning'>[src] is still recalibrating.</span>")
+		return
 
 	var/list/L = list()
 	L["Cancel"] = "Cancel"
@@ -310,11 +311,11 @@ var/list/pinpointerpinpointer_list = list()
 	var/t = input("Select pinpointer target.") as null|anything in L
 	if(t == "Cancel")
 		return
+	if(nextuse - world.time > 0)
+		return
 	target = L[t]
 	if(!target)
 		to_chat(usr,"Failed to locate [target]!")
-		return
-	if(nextuse - world.time > 0)
 		return
 	active = TRUE
 	point_at(target)

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -263,7 +263,7 @@ var/list/pinpointerpinpointer_list = list()
 
 /obj/item/weapon/pinpointer/pdapinpointer/examine(mob/user)
 	..()
-	to_chat(user, "<span class='notice'>The [src] can select a target again in [altFormatTimeDuration(nextuse-world.time)].</span>") 
+	to_chat(user, "<span class='notice'>[src] can select a target again in [altFormatTimeDuration(nextuse-world.time)].</span>") 
 	
 
 /obj/item/weapon/pinpointer/pdapinpointer/attack_self()
@@ -291,9 +291,9 @@ var/list/pinpointerpinpointer_list = list()
 	
 	if(!dna_profile)
 		dna_profile = usr.dna.unique_enzymes
-		to_chat(usr, "<span class='notice'>You submit a DNA sample to the [src]</span>")
+		to_chat(usr, "<span class='notice'>You submit a DNA sample to [src]</span>")
 	else if(dna_profile != usr.dna.unique_enzymes)
-		to_chat(usr, "<span class='warning'>The [src] refuses to operate.</span>")
+		to_chat(usr, "<span class='warning'>[src] refuses to operate.</span>")
 		return
 	else if(nextuse - world.time > 0)
 		to_chat(usr, "<span class='warning'>[src] is still recalibrating.</span>")

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -258,6 +258,7 @@ var/list/pinpointerpinpointer_list = list()
 	desc = "A pinpointer that has been illegally modified to track the PDA of a crewmember for malicious reasons."
 	watches_nuke = FALSE
 	pinpointable = FALSE
+	var/dna_profile
 
 /obj/item/weapon/pinpointer/pdapinpointer/attack_self()
 	if(!active)
@@ -278,12 +279,23 @@ var/list/pinpointerpinpointer_list = list()
 	set category = "Object"
 	set name = "Select pinpointer target"
 	set src in view(1)
+	
+	if(usr.stat || !src.Adjacent(usr))
+		return
+	
+	if(!dna_profile)
+		dna_profile = usr.dna.unique_enzymes
+		to_chat(usr, "<span class='notice'>You submit a DNA sample to the [src]</span>")
+	else if(dna_profile != usr.dna.unique_enzymes)
+		to_chat(usr, "<span class='warning'>The [src] refuses to operate.</span>")
+		return
 
 	var/list/L = list()
 	L["Cancel"] = "Cancel"
 	var/length = 1
 	for (var/obj/item/device/pda/P in PDAs)
-		if(P.name != "\improper PDA")
+		var/turf/T = get_turf(P)
+		if(P.name != "\improper PDA" && T.z != CENTCOMM_Z)
 			L[text("([length]) [P.name]")] = P
 			length++
 

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -259,6 +259,12 @@ var/list/pinpointerpinpointer_list = list()
 	watches_nuke = FALSE
 	pinpointable = FALSE
 	var/dna_profile
+	var/nextuse
+
+/obj/item/weapon/pinpointer/pdapinpointer/examine(mob/user)
+	..()
+	to_chat(user, "<span class='notice'>The [src] can select a target again in [altFormatTimeDuration(nextuse-world.time)].</span>") 
+	
 
 /obj/item/weapon/pinpointer/pdapinpointer/attack_self()
 	if(!active)
@@ -289,6 +295,8 @@ var/list/pinpointerpinpointer_list = list()
 	else if(dna_profile != usr.dna.unique_enzymes)
 		to_chat(usr, "<span class='warning'>The [src] refuses to operate.</span>")
 		return
+	else if(nextuse - world.time > 0)
+		to_chat(usr, "<span class='warning'>The [src] is still recalibrating.</span>")
 
 	var/list/L = list()
 	L["Cancel"] = "Cancel"
@@ -306,8 +314,11 @@ var/list/pinpointerpinpointer_list = list()
 	if(!target)
 		to_chat(usr,"Failed to locate [target]!")
 		return
+	if(nextuse - world.time > 0)
+		return
 	active = TRUE
 	point_at(target)
+	nextuse = world.time + 2 MINUTES
 	to_chat(usr,"You set the pinpointer to locate [target]")
 
 /obj/item/weapon/pinpointer/pdapinpointer/AltClick()


### PR DESCRIPTION
Closes #30674 

also lets you alt click the pda pinpointer to change targets (in addition to the usual right click menu method)
also also removes PDAs on centcomm from the list of selectable PDAs
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
:cl:
 * tweak: The Syndicate has modified their PDA Pinpointers to allow users to change the target every two minutes. Changing the target again requires having the same UE of the first person to set a target.
 
