### PR TITLE
There will be less broken lights roundstart

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -19,6 +19,8 @@ var/area/space_area
 
 	flags = 0
 
+	var/broken_lights = 0
+
 /area/New()
 	area_turfs = list()
 	icon_state = ""


### PR DESCRIPTION
Currently there's about 2% of tubes and 5% of bulbs that break roundstart.
In previous Goonlights, this meant nothing (or almost), because lights were so powerful that even missing one or two didn't mean true darkness.

This is no longer the case with the new lighting system, so I made those chances weaker to compensate. Additionally, only up to 3 + 2 per "viewscreen" (15 tiles x 15 tiles) lights in a given area may be broken at maximum - sometimes, three lights being broken in medbay meant the entire area was in the dark.