### PR TITLE
Re-adds post-processing for wall shadows

### DIFF
--- a/code/modules/lighting/light_effect_cast.dm
+++ b/code/modules/lighting/light_effect_cast.dm
@@ -10,7 +10,7 @@
 #define MAX_LIGHT_RANGE 5
 
 var/light_power_multiplier = 5
-var/light_post_processing = 0 // Use writeglobal to change this
+var/light_post_processing = 1 // Use writeglobal to change this
 
 // We actually see these "pseudo-light atoms" in order to ensure that wall shadows are only seen by people who can see the light.
 // Yes, this is stupid, but it's one of the limitations of TILE_BOUND, which cannot be chosen on an overlay-per-overlay basis.


### PR DESCRIPTION
This should obviously be tested by as much people as possible.
#30681 seemed to have improved performance for a lot of people, perhaps even more so than #30676.

Given how pretty blurring shadows look (making them look they merge continuously, avoiding sharp edges, and basically masking a lot of rendering artefacts on the wall), it is worth trying to see if the `render_source` optimisation helped.

The goal is to merge this to test, ask people who had problems before to join, and see if they notice a significant dip in performance.

If they can't, well, we'll have to wait for a renderer update or a bugfix.

Remember that you can try PJB's hooker if you want your daily dose of spess without BYOND's stupid quirks. Nobody will ever force you to do that, though.