### PR TITLE
Fixes a few edge cases of subjective lights

### DIFF
--- a/code/modules/lighting/light_effect.dm
+++ b/code/modules/lighting/light_effect.dm
@@ -21,6 +21,7 @@
 	blend_mode = BLEND_ADD
 
 	animate_movement = NO_STEPS
+	infra_luminosity = 25 // Visible no matter where
 
 	alpha = 180
 

--- a/code/modules/lighting/light_effect_cast.dm
+++ b/code/modules/lighting/light_effect_cast.dm
@@ -37,7 +37,7 @@ var/light_post_processing = 1 // Use writeglobal to change this
 	temp_appearance = list()
 	affecting_turfs = list()
 	affected_shadow_walls = list()
-	luminosity = 2*light_range
+	luminosity = light_range + 3
 
 	//cap light range to the max
 	light_range = min(MAX_LIGHT_RANGE, light_range)
@@ -535,9 +535,9 @@ If you feel like fixing it, try to find a way to calculate the bounds that is le
 
 	temp_appearance = list()
 	if (holder.lighting_flags & NO_LUMINOSITY)
-		luminosity = 3
+		luminosity = 1
 	else
-		luminosity = max(3, 2*light_range)
+		luminosity = 3
 
 	//cap light range to 5
 	light_range = min(5, light_range)


### PR DESCRIPTION
`infra_luminosity` is a big misnomer. It has absolutely nothing to do with infrared at all.

All it does is to signal to clients within distance that there's indeed something here and that they should render. 
In that respect, it's extremely similar to `luminosity`, except that it doesn't lift darkness.

In some edge cases of Europa lights, there's a light at the edge of your screen, but its `luminosity` radius wouldn't reach the player's `see_in_dark` and therefore would not render the full light source.


![image](https://user-images.githubusercontent.com/31417754/132958693-810a0782-ad68-4272-83e2-99859f2f42fb.png)
![image](https://user-images.githubusercontent.com/31417754/132958705-b70236b5-9c90-4d28-87e4-194989b84d9e.png)

This (should) fix that.

:cl:
- bugfix: Fixes edge cases in which light sources would suddenly appear at the edge of your screen if you moved one tile in their direction.