### PR TITLE
Makes vampire glare cause blinding visual effect on targets like flash

### DIFF
--- a/code/modules/spells/aoe_turf/glare.dm
+++ b/code/modules/spells/aoe_turf/glare.dm
@@ -72,7 +72,7 @@
 					C.blinded = 1
 				C.blinded += max(1, distance_value)
 		to_chat(C, "<span class='warning'>You are blinded by [user]'s glare.</span>")
-		C.flash_eyes(affect_silicon = 1)
+		C.flash_eyes()
 	V.remove_blood(blood_cost)
 
 /spell/aoe_turf/glare/critfail(var/list/targets, var/mob/user)

--- a/code/modules/spells/aoe_turf/glare.dm
+++ b/code/modules/spells/aoe_turf/glare.dm
@@ -72,6 +72,7 @@
 					C.blinded = 1
 				C.blinded += max(1, distance_value)
 		to_chat(C, "<span class='warning'>You are blinded by [user]'s glare.</span>")
+		C.flash_eyes(affect_silicon = 1)
 	V.remove_blood(blood_cost)
 
 /spell/aoe_turf/glare/critfail(var/list/targets, var/mob/user)


### PR DESCRIPTION
[tweak]
Closes #30518.
:cl:
 * rscadd: Vampire glare spell now makes its targets view the same blinding visual effect as a flash on success.