### PR TITLE
Europa Lights client-side optimisation pass 4

### DIFF
--- a/code/modules/lighting/light_effect.dm
+++ b/code/modules/lighting/light_effect.dm
@@ -44,6 +44,8 @@
 	appearance_flags = KEEP_TOGETHER | TILE_BOUND
 	animate_movement = NO_STEPS
 
+	var/list/connex_turf_shadows = list()
+
 /atom/movable/light/New(..., var/atom/newholder)
 	holder = newholder
 	if(istype(holder, /atom))

--- a/code/modules/lighting/light_effect.dm
+++ b/code/modules/lighting/light_effect.dm
@@ -44,8 +44,6 @@
 	appearance_flags = KEEP_TOGETHER | TILE_BOUND
 	animate_movement = NO_STEPS
 
-	var/list/connex_turf_shadows = list()
-
 /atom/movable/light/New(..., var/atom/newholder)
 	holder = newholder
 	if(istype(holder, /atom))

--- a/code/modules/lighting/light_effect_cast.dm
+++ b/code/modules/lighting/light_effect_cast.dm
@@ -70,10 +70,6 @@ var/light_post_processing = 1 // Use writeglobal to change this
 		affecting_turfs.Cut()
 		return
 
-/atom/movable/light/shadow/cast_light_init()
-	connex_turf_shadows = list()
-	. = ..()
-
 /*
 
 Commented out as this doesn't works well with performance currently.

--- a/code/modules/lighting/light_effect_cast.dm
+++ b/code/modules/lighting/light_effect_cast.dm
@@ -468,7 +468,7 @@ If you feel like fixing it, try to find a way to calculate the bounds that is le
 	var/last_pixel_x_im = -50000
 	var/last_pixel_y_im = -50000
 	for (var/image/image_component in temp_appearance)
-		// Non-connex images
+		// The next image is not connected (ie, further than 32 pixels away) from the last current image? Means we are in a new group.
 		if ( abs(image_component.pixel_x - last_pixel_x_im) + abs(image_component.pixel_y - last_pixel_y_im) > WORLD_ICON_SIZE && image_result.temp_appearance.len)
 			image_result.overlays = image_result.temp_appearance
 			image_result.filters += filter(type = "blur", size = BLUR_SIZE)


### PR DESCRIPTION
This time I directly target post-processing as this could be thing causing issues to players.
Basically, rather than applying a filter on a big image, I apply a filter on some smaller groups of sprites belonging to the same connex walls (more or less).

It doesn't work all the time but there's no jarring major glitches.