### PR TITLE
Tackling some Balance

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -506,7 +506,7 @@
 
 /obj/item/clothing/shoes/defenseTackleBonus()
 	if(clothing_flags & MAGPULSE)
-		return 4
+		return 40
 
 //Called from human_defense.dm proc foot_impact
 /obj/item/clothing/shoes/proc/impact_dampen(atom/source, var/damage)

--- a/code/modules/clothing/head/tactical.dm
+++ b/code/modules/clothing/head/tactical.dm
@@ -31,10 +31,10 @@
 	eyeprot = 1
 
 /obj/item/clothing/head/helmet/tactical/riot/offenseTackleBonus()
-	return 1
+	return 10
 
 /obj/item/clothing/head/helmet/tactical/riot/defenseTackleBonus()
-	return 1
+	return 10
 
 /obj/item/clothing/head/helmet/tactical/swat
 	name = "\improper SWAT helmet"

--- a/code/modules/clothing/masks/boxing.dm
+++ b/code/modules/clothing/masks/boxing.dm
@@ -22,10 +22,10 @@
 	speech.message = message
 
 /obj/item/clothing/mask/luchador/offenseTackleBonus()
-	return 1
+	return 5
 
 /obj/item/clothing/mask/luchador/defenseTackleBonus()
-	return 1
+	return 5
 
 /obj/item/clothing/mask/luchador/tecnicos
 	name = "Tecnicos Mask"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -153,10 +153,10 @@
 	siemens_coefficient = 0.5
 
 /obj/item/clothing/suit/armor/riot/offenseTackleBonus()
-	return 1
+	return 15
 
 /obj/item/clothing/suit/armor/riot/defenseTackleBonus()
-	return 2
+	return 20
 
 /obj/item/clothing/suit/armor/rune
 	name = "rune platebody"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -994,7 +994,7 @@
 	species_fit = list(INSECT_SHAPED, VOX_SHAPED, GREY_SHAPED)
 
 /obj/item/clothing/under/football/offenseTackleBonus()
-	return 1
+	return 5
 
 /obj/item/clothing/under/football/New()
 	icon_state = "redfootball_[pick(23,13,69,56)]"

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -104,13 +104,13 @@
 	delayNextThrow(10)
 	throw_mode_off()
 	if(!get_turf(src) || istype(get_turf(src), /turf/space))
-		to_chat(src, "<span class='warning'>You need more footing to do that!")
+		to_chat(src, "<span class='warning'>You need more footing to do that!</span>")
 		return
 	if(restrained() || lying || locked_to || stat)
 		return
 	var/tRange = calcTackleRange()
 	isTackling = TRUE
-	knockdown = max(knockdown, 2)	//Not using the Knockdown() proc as it created odd behaviour with hulks and another knockdown immune
+	knockdown = max(knockdown, 3)	//Not using the Knockdown() proc as it created odd behaviour with hulks and another knockdown immune
 	update_canmove()
 	throw_at(A, tRange, 1)
 
@@ -123,14 +123,19 @@
 			if(isliving(hit_atom))
 				add_attacklogs(src, hit_atom, "tackled")
 				var/mob/living/L = hit_atom
+				to_chat(src, "<span class='warning'>Your tackle connects!</span>")
+				to_chat(L, "<span class='danger'>You are hit by [src]'s tackle!</span>")
+				playsound(src, 'sound/effects/bodyfall.ogg', 75, 1)
 				var/tackleDefense = L.calcTackleDefense()
 				var/rngForce = rand(tackleForce/2, tackleForce)	//RNG or else most people would just bounce off each other.
 				var/rngDefense = rand(tackleDefense/2, tackleDefense)
-				var/tKnock = max(0, rngDefense - rngForce)	//Calculating our knockdown, we always get knocked down at least a little
-				Knockdown(min(10, tKnock)) //To prevent eternity knockdown from tackling an 8 riot shield martian or something
+				var/tKnock = max(0, rngDefense - rngForce)
+				tKnock /= 10	//Numbers were inflated a digit to allow flexibility, now they need to be smaller
+				Knockdown(min(4, tKnock)) //To prevent eternity knockdown from tackling an 8 riot shield martian or something
 				tKnock = max(0, rngForce - rngDefense)	//Calculating their knockdown, they might not get knocked down at all
 				if(tKnock)
-					L.Knockdown(min(10, tKnock))
+					tKnock /= 10
+					L.Knockdown(min(3, tKnock))
 					if(M_HORNS in mutations)
 						tKnock += 5
 					L.adjustBruteLoss(tKnock)
@@ -144,7 +149,8 @@
 		if(!throwing)
 			isTackling = FALSE	//Safety from throw_at being a jerk
 		else
-			var/tPain = rand(1,10)
+			playsound(src, 'sound/items/trayhit1.ogg', 75, 1)
+			var/tPain = rand(5,15)
 			adjustBruteLoss(tPain)
 			Knockdown(tPain/2)
 
@@ -156,12 +162,12 @@
 		tR += 1
 	return tR
 
-/mob/living/carbon/calcTackleForce(var/tForce = 0)
+/mob/living/carbon/calcTackleForce(var/tForce = 50)
 	if(world.time > last_moved + 1 SECONDS)	//If you haven't moved in the last second you do a weaker "standing tackle"
-		tForce -= 1
+		tForce -= 20
 	else
-		tForce += 1
-	tForce += get_strength()*2
+		tForce += 10
+	tForce += get_strength()*10
 	tForce += offenseMutTackle()
 	tForce += bonusTackleForce()
 	return max(0, tForce)
@@ -170,20 +176,20 @@
 	for(var/M in mutations)
 		switch(M)
 			if(M_HULK)
-				tF += 2 //hulk also contributes to get_strength() so the bonus is higher than appears here
+				tF += 20 //hulk also contributes to get_strength() so the bonus is higher than appears here
 			if(M_FAT)
-				tF += 3
+				tF += 15
 			if(M_VEGAN)
-				tF -= 1
+				tF -= 15
 			if(M_DWARF)
-				tF -= 2
+				tF -= 20
 	return tF
 
-/mob/living/carbon/calcTackleDefense(var/tDef = 0)
-	tDef += get_strength()
+/mob/living/carbon/calcTackleDefense(var/tDef = 50)
+	tDef += get_strength()*10
 	for(var/obj/item/weapon/I in held_items)
 		if(I.IsShield())
-			tDef += 4
+			tDef += 35
 	tDef += defenseMutTackle()
 	tDef += bonusTackleDefense()
 	return max(0, tDef)
@@ -192,21 +198,21 @@
 	for(var/M in mutations)
 		switch(M)
 			if(M_FAT)
-				tD += 2
+				tD += 25
 			if(M_VEGAN)
-				tD -= 1
+				tD -= 15
 			if(M_CLUMSY)	//The clown fears fatsec
-				tD -= 2
+				tD -= 20
 				playsound(loc, 'sound/items/bikehorn.ogg', 20, 1)
 			if(M_DWARF)
-				tD -= 2
+				tD -= 20
 	return tD
 
-/mob/living/carbon/proc/bonusTackleForce(var/tF = 1)
+/mob/living/carbon/proc/bonusTackleForce(var/tF = 25)
 	return tF
 
-/mob/living/carbon/proc/bonusTackleDefense(var/tD = 1)
+/mob/living/carbon/proc/bonusTackleDefense(var/tD = 25)
 	return tD
 
-/mob/living/carbon/proc/bonusTackleRange(var/tR = 1)
+/mob/living/carbon/proc/bonusTackleRange(var/tR = 25)
 	return tR

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -214,5 +214,5 @@
 /mob/living/carbon/proc/bonusTackleDefense(var/tD = 25)
 	return tD
 
-/mob/living/carbon/proc/bonusTackleRange(var/tR = 25)
+/mob/living/carbon/proc/bonusTackleRange(var/tR = 3)
 	return tR

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -47,7 +47,7 @@ var/global/list/whitelisted_species = list("Human")
 	var/punch_sharpness = 0										// Slicing/cutting force of punches. Independent of the sharpness added by claws.
 	var/punch_throw_range = 0
 	var/punch_throw_speed = 1
-	var/tacklePower = 5
+	var/tacklePower = 50
 	var/tackleRange = 2
 	var/mutantrace											// Safeguard due to old code.
 	var/myhuman												// mob reference
@@ -417,7 +417,7 @@ var/global/list/whitelisted_species = list("Human")
 
 	default_mutations=list(M_SKELETON)
 	brute_mod = 2.0
-	tacklePower = 2
+	tacklePower = 20
 	tackleRange = 3		//How terribly spooky
 
 	has_organ = list(
@@ -594,7 +594,7 @@ var/global/list/whitelisted_species = list("Human")
 	eyes = "grey_eyes_s"
 
 	max_hurt_damage = 3 // From 5 (for humans)
-	tacklePower = 2
+	tacklePower = 25
 
 	primitive = /mob/living/carbon/monkey/grey
 
@@ -666,7 +666,7 @@ var/global/list/whitelisted_species = list("Human")
 	eyes = "eyes_s"
 
 	max_hurt_damage = 10
-	tacklePower = 9
+	tacklePower = 90
 
 	primitive = /mob/living/carbon/monkey // TODO
 
@@ -726,7 +726,7 @@ var/global/list/whitelisted_species = list("Human")
 	deform = 'icons/mob/human_races/vox/r_def_vox.dmi'
 	known_languages = list(LANGUAGE_VOX)
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/rawchicken/vox
-	tacklePower = 4
+	tacklePower = 40
 	anatomy_flags = HAS_SWEAT_GLANDS
 
 	survival_gear = /obj/item/weapon/storage/box/survival/vox
@@ -839,7 +839,7 @@ var/global/list/whitelisted_species = list("Human")
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/diona
 	attack_verb = "slashes"
 	punch_damage = 5
-	tacklePower = 7
+	tacklePower = 65
 	tackleRange = 1
 	primitive = /mob/living/carbon/monkey/diona
 
@@ -895,7 +895,7 @@ var/global/list/whitelisted_species = list("Human")
 	known_languages = list(LANGUAGE_GOLEM)
 	meat_type = /obj/item/stack/ore/diamond
 	attack_verb = "punches"
-	tacklePower = 8
+	tacklePower = 70
 	tackleRange = 1
 
 	flags = NO_BREATHE | NO_PAIN | HYPOTHERMIA_IMMUNE
@@ -1075,7 +1075,7 @@ var/list/has_died_as_golem = list()
 	known_languages = list(LANGUAGE_SLIME)
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/slime
 	attack_verb = "glomps"
-	tacklePower = 4
+	tacklePower = 35
 
 	flags = IS_WHITELISTED | NO_BREATHE | ELECTRIC_HEAL
 	anatomy_flags = NO_SKIN | NO_BLOOD | NO_BONES | NO_STRUCTURE | MULTICOLOR


### PR DESCRIPTION
Balances some aspects of tackling.

tl;dr: Tackle bonuses aren't as all or nothing. 

- Allows smaller and more specific bonuses. Essentially all deciding numbers are 10 times higher, then divided by 10 to allow for things like a +5 bonus, equivalent to the previously unusable 0.5 bonus. 
-  Tackle offense and defense all start at a base power of 50, rather than 0. This dilutes any bonuses to make them less all or nothing factors.
- The unavoidable knockdown you get when tackling is increased by 50%, so is the damage you receive for hitting something dense
- Adds chat messages to the tackler and tackle-y. Also adds sound effects for both hitting a mob and a dense object
- Balance tweaks to a bunch of bonuses. Notably the offense bonus of being fat is halved (3 -> 15, effectively 1.5)

I'm sure this won't be the last tweak but it's good progress.

-->
:cl:
 * tweak: Tackles are now, probably, more balanced. Things that provide a bonus to tackles aren't just guaranteed success.