### PR TITLE
Fixes magboots

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -163,7 +163,7 @@
 	. = ..()
 
 	// We have magboots, and magboots can protect us
-	if (. && magboots_slip_factor)
+	if (magboots_slip_factor)
 		return SLIP_HAS_MAGBOOTS
 	// We don't have magboots, or magboots can't protect us
 	return (. && !shoes_slip_factor)


### PR DESCRIPTION
Fixes #30353. ~~I'm not sure what's going on with #30752.~~ Fixes #30752.
I have no idea why it was originally written like this. Magboots only protected you if without them you would have slipped on water. I don't think this will break anything but who knows