### PR TITLE
Bundle of Syndicate Bundles

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -180,6 +180,7 @@
 			new /obj/item/weapon/glue(src)
 			new /obj/item/weapon/glue(src)
 			new /obj/item/weapon/gun/hookshot/whip/windup_box/clownbox(src)
+			new /obj/item/weapon/dnainjector/nofail/clumsymut(src)
 			for(var/i = 1 to 7)
 				new /obj/item/toy/balloon/long/living(src)
 			new /obj/item/weapon/spellbook/oneuse/shoesnatch(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -2,7 +2,7 @@
 	..()
 	var/tagname
 	if(!forced_bundle)
-		tagname = pickweight(list("bloodyspai" = 100, "stealth" = 100, "guns" = 100, "murder" = 100, "freedom" = 100, "hacker" = 100, "smoothoperator" = 100, "psycho" = 100, "hotline" = 100, "ocelot" = 100, "sith" = 100, "anarchist" = 50, "emagsandglue" = 10, "balloon" = 10, "bangerboy" = 100, "highlander" = 100, "clown" = 50, "druid" = 50, "actor" = 100, "jackpot" = 7, "Eugenics" = 50, "Alchemist" = 50))
+		tagname = pickweight(list("bloodyspai" = 100, "stealth" = 100, "screwed" = 25, "guns" = 100, "murder" = 100, "freedom" = 100, "hacker" = 100, "lordsingulo" = 25, "smoothoperator" = 100, "psycho" = 100, "hotline" = 100, "ocelot" = 100, "sith" = 100, "anarchist" = 50, "emagsandglue" = 10, "balloon" = 10, "bangerboy" = 100, "highlander" = 100, "clown" = 50, "druid" = 50, "actor" = 100, "jackpot" = 7, "Eugenics" = 50, "Alchemist" = 50))
 	else
 		tagname = forced_bundle
 
@@ -22,12 +22,12 @@
 			new /obj/item/device/chameleon(src)
 			new /obj/item/weapon/soap/syndie(src)
 
-//		if("screwed")//6?+6?+10+4=26
-//			new /obj/effect/spawner/newbomb/timer(src)
-//			new /obj/effect/spawner/newbomb/timer(src)
-//			new /obj/item/device/powersink(src)
-//			new /obj/item/clothing/suit/space/syndicate(src)
-//			new /obj/item/clothing/head/helmet/space/syndicate(src)
+		if("screwed")//6?+6?+10+4=26
+			new /obj/effect/spawner/newbomb/timer(src)
+			new /obj/effect/spawner/newbomb/timer(src)
+			new /obj/item/device/powersink(src)
+			new /obj/item/clothing/suit/space/syndicate(src)
+			new /obj/item/clothing/head/helmet/space/syndicate(src)
 
 		if("guns")//13+4+6+4=27
 			new /obj/item/weapon/gun/projectile/revolver(src)
@@ -58,11 +58,11 @@
 			new /obj/item/device/encryptionkey/binary(src)
 			new /obj/item/device/multitool/ai_detect(src)
 
-//		if("lordsingulo")//14+4+6=24
-//			new /obj/item/beacon/syndicate(src)
-//			new /obj/item/clothing/suit/space/syndicate(src)
-//			new /obj/item/clothing/head/helmet/space/syndicate(src)
-//			new /obj/item/weapon/card/emag(src)
+		if("lordsingulo")//14+4+6=24
+			new /obj/item/beacon/syndicate(src)
+			new /obj/item/clothing/suit/space/syndicate(src)
+			new /obj/item/clothing/head/helmet/space/syndicate(src)
+			new /obj/item/weapon/card/emag(src)
 
 		if("smoothoperator")//6?+2+2?+1+1?+1?+4+4=21
 			new /obj/item/weapon/gun/projectile/pistol(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -175,8 +175,9 @@
 			new /obj/item/weapon/vinyl/scotland(src)
 			new /obj/item/weapon/spellbook/oneuse/mutate/highlander(src)
 
-		if("clown") //4 + 6 + 14 + 6 + ? = 30?
+		if("clown") //4 + 4 + 6 + 14 + 6 + ? = 34?
 			new /obj/item/weapon/invisible_spray/permanent(src)
+			new /obj/item/weapon/glue(src)
 			new /obj/item/weapon/glue(src)
 			new /obj/item/weapon/gun/hookshot/whip/windup_box/clownbox(src)
 			for(var/i = 1 to 7)
@@ -189,17 +190,21 @@
 					/obj/item/weapon/grenade/spawnergrenade/beenade,
 					/obj/item/weapon/grenade/spawnergrenade/bearnade
 					)
-			for(var/i = 1 to 7)
+			for(var/i = 1 to 6)
 				var/obj/item/dS = pick(druidSummon)
 				new dS(src)
+				new /obj/item/weapon/reagent_containers/food/snacks/egg/chaos(src)
 			new /obj/item/clothing/suit/storage/wintercoat/druid(src)
 
-		if("actor")	//6*5 + 1 + 5 + 2 = 38
+		if("actor")	//6*5 + 1 + 5 + 2 + 6 + mask = 44^mask
 			for(var/i = 1 to 5)
 				new /obj/item/device/reportintercom(src)
 			new /obj/item/device/megaphone/madscientist(src)
 			new /obj/item/clothing/mask/gas/voice(src)
 			new /obj/item/weapon/card/id/syndicate(src)
+			new /obj/item/clothing/mask/morphing/amorphous(src)
+			new /obj/item/device/chameleon(src)
+
 
 		if("jackpot") //14*2 = 28
 			new /obj/item/weapon/storage/box/syndicate(src)
@@ -218,6 +223,8 @@
 		if("Alchemist")
 			new /obj/item/weapon/storage/bag/potion/lesser_predicted_potion_bundle(src)
 			new /obj/item/weapon/storage/bag/potion/lesser_bundle(src)
+			new /obj/item/weapon/storage/box/mystery_vial(src)
+			new /obj/item/weapon/storage/box/mystery_vial(src)
 
 	tag = tagname
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -2,7 +2,7 @@
 	..()
 	var/tagname
 	if(!forced_bundle)
-		tagname = pickweight(list("bloodyspai" = 100, "stealth" = 100, "screwed" = 100, "guns" = 100, "murder" = 100, "freedom" = 100, "hacker" = 100, "lordsingulo" = 100, "smoothoperator" = 100, "psycho" = 100, "hotline" = 100, "ocelot" = 100, "sith" = 100, "anarchist" = 50, "emagsandglue" = 10, "balloon" = 10, "bangerboy" = 100, "highlander" = 100))
+		tagname = pickweight(list("bloodyspai" = 100, "stealth" = 100, "guns" = 100, "murder" = 100, "freedom" = 100, "hacker" = 100, "smoothoperator" = 100, "psycho" = 100, "hotline" = 100, "ocelot" = 100, "sith" = 100, "anarchist" = 50, "emagsandglue" = 10, "balloon" = 10, "bangerboy" = 100, "highlander" = 100, "clown" = 50, "druid" = 50, "actor" = 100, "jackpot" = 7, "Eugenics" = 50, "Alchemist" = 50))
 	else
 		tagname = forced_bundle
 
@@ -22,12 +22,12 @@
 			new /obj/item/device/chameleon(src)
 			new /obj/item/weapon/soap/syndie(src)
 
-		if("screwed")//6?+6?+10+4=26
-			new /obj/effect/spawner/newbomb/timer(src)
-			new /obj/effect/spawner/newbomb/timer(src)
-			new /obj/item/device/powersink(src)
-			new /obj/item/clothing/suit/space/syndicate(src)
-			new /obj/item/clothing/head/helmet/space/syndicate(src)
+//		if("screwed")//6?+6?+10+4=26
+//			new /obj/effect/spawner/newbomb/timer(src)
+//			new /obj/effect/spawner/newbomb/timer(src)
+//			new /obj/item/device/powersink(src)
+//			new /obj/item/clothing/suit/space/syndicate(src)
+//			new /obj/item/clothing/head/helmet/space/syndicate(src)
 
 		if("guns")//13+4+6+4=27
 			new /obj/item/weapon/gun/projectile/revolver(src)
@@ -58,11 +58,11 @@
 			new /obj/item/device/encryptionkey/binary(src)
 			new /obj/item/device/multitool/ai_detect(src)
 
-		if("lordsingulo")//14+4+6=24
-			new /obj/item/beacon/syndicate(src)
-			new /obj/item/clothing/suit/space/syndicate(src)
-			new /obj/item/clothing/head/helmet/space/syndicate(src)
-			new /obj/item/weapon/card/emag(src)
+//		if("lordsingulo")//14+4+6=24
+//			new /obj/item/beacon/syndicate(src)
+//			new /obj/item/clothing/suit/space/syndicate(src)
+//			new /obj/item/clothing/head/helmet/space/syndicate(src)
+//			new /obj/item/weapon/card/emag(src)
 
 		if("smoothoperator")//6?+2+2?+1+1?+1?+4+4=21
 			new /obj/item/weapon/gun/projectile/pistol(src)
@@ -175,7 +175,52 @@
 			new /obj/item/weapon/vinyl/scotland(src)
 			new /obj/item/weapon/spellbook/oneuse/mutate/highlander(src)
 
+		if("clown") //4 + 6 + 14 + 6 + ? = 30?
+			new /obj/item/weapon/invisible_spray/permanent(src)
+			new /obj/item/weapon/glue(src)
+			new /obj/item/weapon/gun/hookshot/whip/windup_box/clownbox(src)
+			for(var/i = 1 to 7)
+				new /obj/item/toy/balloon/long/living(src)
+			new /obj/item/weapon/spellbook/oneuse/shoesnatch(src)
+
+		if("druid")	//bear*viscerator to the power of carp
+			var/list/druidSummon = list(
+					/obj/item/weapon/grenade/spawnergrenade/spesscarp,
+					/obj/item/weapon/grenade/spawnergrenade/beenade,
+					/obj/item/weapon/grenade/spawnergrenade/bearnade
+					)
+			for(var/i = 1 to 7)
+				var/obj/item/dS = pick(druidSummon)
+				new dS(src)
+			new /obj/item/clothing/suit/storage/wintercoat/druid(src)
+
+		if("actor")	//6*5 + 1 + 5 + 2 = 38
+			for(var/i = 1 to 5)
+				new /obj/item/device/reportintercom(src)
+			new /obj/item/device/megaphone/madscientist(src)
+			new /obj/item/clothing/mask/gas/voice(src)
+			new /obj/item/weapon/card/id/syndicate(src)
+
+		if("jackpot") //14*2 = 28
+			new /obj/item/weapon/storage/box/syndicate(src)
+			new /obj/item/weapon/storage/box/syndicate(src)
+
+		if("Eugenics")
+			new /obj/item/weapon/dnainjector/nofail/hulkmut(src)
+			new /obj/item/weapon/dnainjector/nofail/xraymut(src)
+			new /obj/item/weapon/dnainjector/nofail/telemut(src)
+			new /obj/item/weapon/dnainjector/nofail/nobreath(src)
+			new /obj/item/weapon/dnainjector/nofail/regenerate(src)
+			new /obj/item/weapon/dnainjector/nofail/runfast(src)
+			new /obj/item/weapon/dnainjector/nofail/jumpy(src)
+			new /obj/item/weapon/dnainjector/nofail/strong(src)
+
+		if("Alchemist")
+			new /obj/item/weapon/storage/bag/potion/lesser_predicted_potion_bundle(src)
+			new /obj/item/weapon/storage/bag/potion/lesser_bundle(src)
+
 	tag = tagname
+
 
 
 /obj/item/weapon/storage/box/syndie_kit
@@ -385,7 +430,7 @@ obj/item/weapon/storage/box/syndie_kit/cheaptide
 	new /obj/item/ammo_storage/box/BMG50(src)
 	new /obj/item/ammo_storage/box/BMG50(src)
 	new /obj/item/clothing/glasses/thermal/syndi(src)
-	
+
 /obj/item/weapon/storage/box/syndie_kit/spotter
 	name = "Spotter"
 
@@ -411,7 +456,7 @@ obj/item/weapon/storage/box/syndie_kit/cheaptide
 	new /obj/item/clothing/glasses/sunglasses/sechud/syndishades(src)
 	new /obj/item/device/reportintercom(src)
 	dispense_cash(10000, src)
-	
+
 /obj/item/weapon/storage/box/syndie_kit/shootershotty
 	name = "Shotgun"
 
@@ -464,11 +509,11 @@ obj/item/weapon/storage/box/syndie_kit/cheaptide
 		if("sniperspotter")
 			new /obj/item/weapon/storage/box/syndie_kit/sniper(src)
 			new /obj/item/weapon/storage/box/syndie_kit/spotter(src)
-		
+
 		if("scammers")
 			new /obj/item/weapon/storage/box/syndie_kit/scammer(src)
 			new /obj/item/weapon/storage/box/syndie_kit/scammer(src)
-		
+
 		if("workplaceshooter")
 			new /obj/item/weapon/storage/box/syndie_kit/shootershotty(src)
 			new /obj/item/weapon/storage/box/syndie_kit/shooteruzis(src)


### PR DESCRIPTION
Adds 6 new syndicate bundles and ~removes~ reduces the chances of 2 because they're awful and ~hated~ perplexingly tolerated.
I like bundles, if I can't think of a gimmick I'll pick a bundle and try to get creative with it. I tried to make these flexible rather than have a single obvious intention.

**~Removed~ Reduced Chance Of**
Screwed (powersink, bomb, space suit)
Lordsingulo (singulo-beacon, emag, space suit)

I've seen people say they specifically don't take bundles because these two exist just to waste their TC. Don't like em.
They now have 25% the chance they previously had of showing their stupid ugly faces.

### New Bundles
"Chance" is compared to other bundles. Not the chance of getting it when you buy a bundle. 

**Clown**
Chance: 50%
- Permanent invisible spray
- 2 Superglue
- Punchline
- Living long balloons (7, the same as buying it normally)
- One use spellbook for shoe snatch

**Druid**
Chance: 50%
- 6 Spawner grenades. Each having an equal chance of being a carpnade, bearnade, or beenade
- 6 Chaos eggs
- Druid wintercoat

**Actor**
Chance: 100%
- 5 NT report falsifiers
- A megaphone
- Voice changer
- Agent ID
- Chameleon projector
- A random amorphous mask

**Eugenics**
Chance: 50%
- 8 DNA injectors containing hulk, xray, telekinesis, no breath, regeneration, run, jump, and strong

**Alchemist**
Chance: 50%
- 1 lesser predicted potion bundle (10 identified potions)
- 1 less potion bundle (12 unidentified potions)
- 2 random chemical packs, the same ones Traders sell

**Jackpot**
Chance: 7%
- 2 Random syndicate bundles, they could even be jackpots!

:cl:
 * rscadd: Added 6 new Syndicate bundles
 * tweak: The singulo and screwed bundles are 75% less common