### PR TITLE
Adds parts and upgrades to suit modification stations

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -633,6 +633,17 @@ obj/item/weapon/circuitboard/rdserver
 							/obj/item/weapon/stock_parts/manipulator = 1,
 							/obj/item/weapon/stock_parts/matter_bin = 1)
 
+/obj/item/weapon/circuitboard/suit_modifier
+	name = "Circuit Board (Spacesuit Modification Station)"
+	desc = "A circuit board used to run a spacesuit modification station."
+	build_path = /obj/machinery/suit_modifier
+	board_type = MACHINE
+	origin_tech = Tc_POWERSTORAGE + "=4;" + Tc_PROGRAMMING + "=3"
+	req_components = list (
+							/obj/item/weapon/stock_parts/manipulator = 2,
+							/obj/item/weapon/stock_parts/scanning_module = 1,
+							/obj/item/weapon/stock_parts/micro_laser = 1)
+
 /obj/item/weapon/circuitboard/heater
 	name = "Circuit Board (Heater)"
 	desc = "A circuit board used to run a gas heater."

--- a/code/game/machinery/suit_modifier.dm
+++ b/code/game/machinery/suit_modifier.dm
@@ -73,7 +73,7 @@
 	if(world.has_round_started())
 		initialize()
 
-/obj/machinery/recharge_station/RefreshParts()
+/obj/machinery/suit_modifier/RefreshParts()
 	var/avg_rate = 0
 	var/amount = 0
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)

--- a/code/game/machinery/suit_modifier.dm
+++ b/code/game/machinery/suit_modifier.dm
@@ -19,6 +19,7 @@
 	desc = "A man-sized machine, akin to a coffin, meant to install modifications into a worn spacesuit."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "suitmodifier"
+	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE
 
 	var/list/modules_to_install = list()
 	var/obj/item/weapon/cell/cell = null
@@ -26,6 +27,7 @@
 	var/activated = FALSE
 	var/static/list/plasmaman_suits
 	var/static/list/vox_suits
+	var/apply_multiplier = 1
 	idle_power_usage = 50
 	active_power_usage = 300
 
@@ -61,8 +63,29 @@
 
 /obj/machinery/suit_modifier/New()
 	..()
+	component_parts = newlist(
+		/obj/item/weapon/circuitboard/suit_modifier,
+		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/scanning_module,
+		/obj/item/weapon/stock_parts/micro_laser
+	)
 	if(world.has_round_started())
 		initialize()
+
+/obj/machinery/recharge_station/RefreshParts()
+	var/avg_rate = 0
+	var/amount = 0
+	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
+		avg_rate += M.rating
+		amount++
+	apply_multiplier = (avg_rate / amount)
+	avg_rate = 0
+	amount = 0
+	for(var/obj/item/weapon/stock_parts/micro_laser/ML in component_parts)
+		avg_rate += ML.rating
+		amount++
+	active_power_usage = 300 / (avg_rate / amount)
 
 /obj/machinery/suit_modifier/initialize()
 	suit_overlay = new
@@ -212,7 +235,7 @@
 	for(var/obj/item/rig_module/RM in modules_to_install)
 		if(locate(RM.type) in R.modules) //One already installed
 			continue
-		if(do_after(H, src, 5 SECONDS, needhand = FALSE))
+		if(do_after(H, src, 8 SECONDS / apply_multiplier, needhand = FALSE))
 			say("Installing [RM] into \the [R].", class = "binaryradio")
 			R.modules.Add(RM)
 			RM.rig = R
@@ -252,7 +275,7 @@
 			return
 		working_animation()
 		say("Uninstalling [RM] from \the [R].", class = "binaryradio")
-		if(do_after(H, src, 5 SECONDS, needhand = FALSE))
+		if(do_after(H, src, 8 SECONDS / apply_multiplier, needhand = FALSE))
 			R.modules.Remove(RM)
 			RM.rig = null
 			RM.forceMove(get_turf(src))


### PR DESCRIPTION
[content]
Manipulators decrease application/removal times, base time is now 8 seconds but divides by average rating.
Active power usage remains 300, but is now divided by average rating of micro lasers.
Does not add the circuitboard to R&D consoles.
:cl:
 * rscadd: Suit modification stations now have upgradable parts, allowing faster module application/removal and less power usage.
 * tweak: Suit application times on modification stations have been increased to 8 seconds, from 5, but can be brought down to 2.667 seconds with normal upgrades.