### PR TITLE
Now actually stops vines/powercreep/biomass spawning in arrivals

### DIFF
--- a/code/game/gamemodes/events/biomass.dm
+++ b/code/game/gamemodes/events/biomass.dm
@@ -194,7 +194,7 @@
 	var/list/turf/simulated/floor/Floors = new
 
 	for(var/type in typesof(/area/hallway))
-		if(istype(type,/area/hallway/secondary/entry)) // no spawn in arrivals, make it less annoying for latejoiners
+		if(ispath(type,/area/hallway/secondary/entry)) // no spawn in arrivals, make it less annoying for latejoiners
 			continue
 		var/area/Hallway = locate(type)
 

--- a/code/game/gamemodes/events/spacevines.dm
+++ b/code/game/gamemodes/events/spacevines.dm
@@ -3,7 +3,7 @@
 	spawn() //to stop the secrets panel hanging
 		var/list/turf/simulated/floor/turfs = list() //list of all the empty floor turfs in the hallway areas
 		for(var/areapath in typesof(/area/hallway))
-			if(istype(areapath,/area/hallway/secondary/entry)) //no spawn in arrivals, make it less annoying for latejoiners
+			if(ispath(areapath,/area/hallway/secondary/entry)) //no spawn in arrivals, make it less annoying for latejoiners
 				continue
 			var/area/A = locate(areapath)
 			for(var/turf/simulated/floor/F in A.contents)

--- a/code/modules/events/powercreeper.dm
+++ b/code/modules/events/powercreeper.dm
@@ -7,7 +7,7 @@
 	spawn()
 		var/list/turf/simulated/floor/turfs = list() //list of all the empty floor turfs in the hallway areas
 		for(var/areapath in typesof(/area/hallway))
-			if(istype(areapath,/area/hallway/secondary/entry)) //no spawn in arrivals, make it less annoying for latejoiners
+			if(ispath(areapath,/area/hallway/secondary/entry)) //no spawn in arrivals, make it less annoying for latejoiners
 				continue
 			var/area/A = locate(areapath)
 			for(var/turf/simulated/floor/F in A.contents)


### PR DESCRIPTION
[bugfix]
Thanks @Kurfursten 
:cl:
 * bugfix: The biomass, spacevine and powercreep random events now actually no longer spawn their infestations in the arrivals shuttle hallway.