### PR TITLE
Fixed human meat and burgers not properly carrying the source human's name

### DIFF
--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -224,7 +224,7 @@ obj/machinery/gibber/New()
 	for (var/i=1 to totalslabs)
 		//first we spawn the meat
 		var/obj/item/weapon/newmeat
-		if(istype(occupant.meat_type, /obj/item/weapon/reagent_containers))
+		if(ispath(occupant.meat_type, /obj/item/weapon/reagent_containers))
 			newmeat = new occupant.meat_type(src, occupant)
 			newmeat.reagents.add_reagent (NUTRIMENT, sourcenutriment / totalslabs) // Thehehe. Fat guys go first
 		else

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -307,21 +307,22 @@
 // Human ///////////////////////////////////////////////////////
 
 /datum/recipe/human //Parent datum only
-	make_food(var/obj/container as obj)
-		var/human_name
-		var/human_job
-		for(var/obj/item/weapon/reagent_containers/food/snacks/meat/human/HM in container)
-			if(HM.subjectname)
-				human_name = HM.subjectname
-				human_job = HM.subjectjob
-				break
-		var/lastname_index = findtext(human_name, " ")
-		if(lastname_index)
-			human_name = copytext(human_name,lastname_index+1)
-		var/obj/item/weapon/reagent_containers/food/snacks/human/HB = ..(container)
-		HB.name = human_name+HB.name
-		HB.job = human_job
-		return HB
+
+/datum/recipe/human/proc/make_food(var/obj/container)
+	var/human_name
+	var/human_job
+	for(var/obj/item/weapon/reagent_containers/food/snacks/meat/human/HM in container)
+		if(HM.subjectname)
+			human_name = HM.subjectname
+			human_job = HM.subjectjob
+			break
+	var/lastname_index = findtext(human_name, " ")
+	if(lastname_index)
+		human_name = copytext(human_name,lastname_index+1)
+	var/obj/item/weapon/reagent_containers/food/snacks/human/HB = ..(container)
+	HB.name = human_name+HB.name
+	HB.job = human_job
+	return HB
 
 /datum/recipe/human/burger
 	reagents = list(FLOUR = 5)

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -321,7 +321,6 @@
 		human_name = copytext(human_name,lastname_index+1)
 	var/obj/item/weapon/reagent_containers/food/snacks/human/HB = ..(container)
 	HB.name = human_name+HB.name
-	HB.job = human_job
 	return HB
 
 /datum/recipe/human/burger

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -308,13 +308,11 @@
 
 /datum/recipe/human //Parent datum only
 
-/datum/recipe/human/proc/make_food(var/obj/container)
+/datum/recipe/human/make_food(var/obj/container)
 	var/human_name
-	var/human_job
 	for(var/obj/item/weapon/reagent_containers/food/snacks/meat/human/HM in container)
 		if(HM.subjectname)
 			human_name = HM.subjectname
-			human_job = HM.subjectjob
 			break
 	var/lastname_index = findtext(human_name, " ")
 	if(lastname_index)

--- a/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
@@ -228,7 +228,6 @@
 							var/obj/item/weapon/reagent_containers/food/snacks/meat/human/newmeat = new(get_turf(src))
 							newmeat.name = sourcename + " " + newmeat.name
 							newmeat.subjectname = sourcename
-							newmeat.subjectjob = sourcejob
 							newmeat.reagents.add_reagent(NUTRIMENT, sourcenutriment)
 							var/turf/Tx = get_turf(src)
 							newmeat.throw_at(get_step(Tx,src.dir), 1, 3)

--- a/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
@@ -222,7 +222,6 @@
 							//Drop some meat
 							to_chat(src, "<span class='warning'>A chunk of meat falls off of you!</span>")
 							var/sourcename = real_name
-							var/sourcejob = job
 
 
 							var/obj/item/weapon/reagent_containers/food/snacks/meat/human/newmeat = new(get_turf(src))

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1015,10 +1015,6 @@
 
 
 /obj/item/weapon/reagent_containers/food/snacks/human
-	var/hname = ""
-	var/job = null
-
-
 	name = "-burger"
 	desc = "A bloody burger."
 	icon_state = "hburger"

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -6,7 +6,6 @@
 	icon_state = "meat"
 	food_flags = FOOD_MEAT | FOOD_SKELETON_FRIENDLY
 	var/subjectname = ""
-	var/subjectjob = null
 	var/meatword = "meat"
 
 	var/obj/item/poisonsacs = null //This is what will contain the poison
@@ -19,9 +18,6 @@
 		if(uppertext(M.name) != "UNKNOWN")
 			name = "[M.name] [meatword]"
 		subjectname = M.name
-		if(istype(M, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = M
-			subjectjob = H.job
 
 /obj/item/weapon/reagent_containers/food/snacks/meat/Destroy()
 	..()

--- a/code/modules/virus2/effect/stage_4.dm
+++ b/code/modules/virus2/effect/stage_4.dm
@@ -239,7 +239,6 @@
 				var/totalslabs = 1
 				var/obj/item/weapon/reagent_containers/food/snacks/meat/allmeat[totalslabs]
 				var/sourcename = H.real_name
-				var/sourcejob = H.job
 				var/sourcenutriment = H.nutrition / 15
 				//var/sourcetotalreagents = mob.reagents.total_volume
 

--- a/code/modules/virus2/effect/stage_4.dm
+++ b/code/modules/virus2/effect/stage_4.dm
@@ -247,7 +247,6 @@
 					var/obj/item/weapon/reagent_containers/food/snacks/meat/human/newmeat = new
 					newmeat.name = sourcename + newmeat.name
 					newmeat.subjectname = sourcename
-					newmeat.subjectjob = sourcejob
 					newmeat.reagents.add_reagent(NUTRIMENT, sourcenutriment / totalslabs) //Thehehe. Fat guys go first
 					//src.occupant.reagents.trans_to(newmeat, round (sourcetotalreagents / totalslabs, 1)) // Transfer all the reagents from the
 					allmeat[i] = newmeat


### PR DESCRIPTION
Fixes #27544

:cl:
* bugfix: Fixed human meat, burgers and kabobs not properly carrying their originator's name, as well as not carrying over their nutrition as extra nutriments. (theophrastus)