### PR TITLE
Disable TGUI window pooling to prevent the loading mouse cursor thingy

### DIFF
--- a/__DEFINES/tgui.dm
+++ b/__DEFINES/tgui.dm
@@ -8,7 +8,11 @@
 #define UI_CLOSE -1
 
 /// Maximum number of windows that can be suspended/reused
-#define TGUI_WINDOW_SOFT_LIMIT 5
+/// Normally 5.
+/// There's an issue that causes the cursor to always show the loading animation
+/// if tgui windows are open (pooled hidden windows count as well).
+#define TGUI_WINDOW_SOFT_LIMIT 0
+
 /// Maximum number of open windows
 #define TGUI_WINDOW_HARD_LIMIT 9
 


### PR DESCRIPTION
~~Bandaids~~ Closes #30787
This should result in opening tgui windows taking a few moments longer to load, as a side effect.