### PR TITLE
Vendor Languages

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -7,6 +7,8 @@
 //Maximum price you can assign to an item
 #define MAX_ITEM_PRICE 1000000000
 
+#define BASE_SLOGAN_CHANCE 40
+
 var/global/num_vending_terminals = 1
 
 /obj/machinery/vending
@@ -50,7 +52,8 @@ var/global/num_vending_terminals = 1
 	var/vend_reply				//Thank you for shopping!
 	var/last_reply = 0
 	var/last_slogan = 0			//When did we last pitch?
-	var/slogan_delay = 6000		//How long until we can pitch again?
+	var/slogan_delay = (2 MINUTES)	//How long until we can pitch again?
+	var/list/slogan_languages = list()
 	var/icon_vend				//Icon_state when vending!
 	var/icon_deny				//Icon_state when vending!
 	//var/emagged = 0			//Ignores if somebody doesn't have card access to that machine.
@@ -136,11 +139,16 @@ var/global/num_vending_terminals = 1
 		// So not all machines speak at the exact same time.
 		// The first time this machine says something will be at slogantime + this random value,
 		// so if slogantime is 10 minutes, it will say it at somewhere between 10 and 20 minutes after the machine is crated.
-		src.last_slogan = world.time + rand(0, slogan_delay)
+		last_slogan = world.time + rand(0, slogan_delay)
 
 		power_change()
 
 	coinbox = new(src)
+
+	for(var/spath in slogan_languages)
+		if(ispath(spath))
+			slogan_languages -= spath
+			slogan_languages += new spath //convert paths into language datums
 
 	if(ticker)
 		initialize()
@@ -1063,8 +1071,8 @@ var/global/num_vending_terminals = 1
 
 	if(((src.last_reply + (src.vend_delay + 200)) <= world.time) && src.vend_reply)
 		spawn(0)
-			src.speak(src.vend_reply)
-			src.last_reply = world.time
+			speak(vend_reply, user)
+			last_reply = world.time
 
 	use_power(5)
 	if (src.icon_vend) //Show the vending animation if needed
@@ -1096,21 +1104,46 @@ var/global/num_vending_terminals = 1
 		src.seconds_electrified--
 
 	//Pitch to the people!  Really sell it!
-	if(((src.last_slogan + src.slogan_delay) <= world.time) && (src.product_slogans.len > 0) && (!src.shut_up) && prob(5))
-		var/slogan = pick(src.product_slogans)
-		src.speak(slogan)
-		src.last_slogan = world.time
+	if((last_slogan + slogan_delay <= world.time) && (product_slogans.len > 0) && !shut_up)
+		var/mob/living/carbon/human/target
+		var/target_dist
+		for(var/mob/living/carbon/human/H in view(7, src)) //We are only going to look for customers that can probably pay
+			var/H_dist = get_dist(H,src)
+			if(!target || (H_dist < target_dist))
+				target = H //pick the closest human
+				target_dist = H_dist
+				if(target_dist == 1)
+					break //close as we can expect to get
+		if(target)
+			//No target, don't advertise at all
+			if(prob(BASE_SLOGAN_CHANCE - (target_dist*5))) //35% chance if you are right in front of it, -5% for each tile away
+				var/slogan = pick_slogan(target)
+				speak(slogan,target)
+				last_slogan = world.time
 
 	if(src.shoot_inventory && prob(shoot_chance))
 		src.throw_item()
 
-/obj/machinery/vending/proc/speak(var/message)
+//This CAN be null, so have a plan if there's noone in view
+/obj/machinery/vending/proc/pick_slogan(mob/target)
+	return pick(product_slogans)
+
+/obj/machinery/vending/proc/speak(var/message, var/mob/living/M)
 	if(stat & NOPOWER)
 		return
 
-	if (!message)
+	if(!message)
 		return
-	say(message)
+	var/datum/language/L = null
+	if(slogan_languages.len)
+		L = get_language(M)
+	say(message, L)
+
+/obj/machinery/vending/proc/get_language(var/mob/living/M)
+	if(slogan_languages.len == 0)
+		return null
+	return pick(slogan_languages)
+
 
 /obj/machinery/vending/say_quote(text)
 	return "beeps, [text]"
@@ -1124,7 +1157,7 @@ var/global/num_vending_terminals = 1
 			spawn(rand(0, 15))
 				stat |= NOPOWER
 				update_vicon()
-	
+
 
 //Oh no we're malfunctioning!  Dump out some product and break.
 /obj/machinery/vending/proc/malfunction()
@@ -1554,6 +1587,12 @@ var/global/num_vending_terminals = 1
 		)
 
 	pack = /obj/structure/vendomatpack/offlicence
+	slogan_languages = list(/datum/language/gutter)
+
+/obj/machinery/vending/offlicence/get_language(mob/target)
+	if(prob(25))
+		return slogan_languages[1]
+	return null
 
 //This one's from bay12
 /obj/machinery/vending/cart
@@ -2178,6 +2217,7 @@ var/global/num_vending_terminals = 1
 	premium = list(
 		/obj/item/weapon/storage/box/boxen = 1
 		)
+	slogan_languages = list(/datum/language/vox)
 
 /obj/machinery/vending/magivend
 	name = "\improper MagiVend"
@@ -3142,6 +3182,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/stamp/trader = 20,
 		/obj/item/crackerbox = 200,
 		)
+	slogan_languages = (/datum/language/vox)
 
 //trade vendor used to be here, now see trade_datums.dm
 
@@ -3556,16 +3597,23 @@ var/global/num_vending_terminals = 1
 	desc = "A relatively new vending machine with snacks for Grey crewmembers, sponsored by labs located on the elusive mothership."
 	product_slogans = list(
 		"Do you still hunger? Try Zam microwave meals, now available at all cargo merchandise computers.",
-		"Tell your human friends to try Tannic Thunder, Nitro Freeze, and Moon Cheese.",
 		"Humans! Buy some NotRaisins for a bite of something new. Acid purified!",
-		"Zam is your friend far from home.",
 		"Life is short between cloning cycles. Enjoy some Zam!",
 		"The mothership is always watching.",
 		"Zam products are superior.",
 		"Slurp and burp!",
 		"Why Dan when you could Zam?",
-		"All products are approved by Administrators."
+		"All products are approved by Administrators.",
+		"Some humans may enjoy Zam products with sodium chloride."
 	)
+	var/grey_slogans = list("Please do not drink the water.",
+		"Tell your human friends to try Tannic Thunder, Nitro Freeze, and Moon Cheese.",
+		"Zam is your friend far from home.",
+		"Do not forget to send quarterly reports on human behavior.",
+		"Zam: The fuel you need to continue observations.",
+		"Zam products remind you of our superior digestive systems.",
+		"Have you met your Zam purchase quota yet?")
+
 	product_ads = list(
 		"Glory to the mothership, and all hail the chairman!"
 	)
@@ -3605,3 +3653,16 @@ var/global/num_vending_terminals = 1
 		)
 
 	pack = /obj/structure/vendomatpack/zamsnax
+	slogan_languages = list(/datum/language/grey)
+
+/obj/machinery/vending/zamsnax/get_language(var/mob/living/M)
+	if(isgrey(M))
+		return slogan_languages[1] //Speak grey when targeting a grey, otherwise just speak universal
+	else
+		return null
+
+/obj/machinery/vending/zamsnax/pick_slogan(mob/target)
+	if(isgrey(target))
+		return pick(grey_slogans)
+	else
+		return pick(product_slogans)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -145,10 +145,10 @@ var/global/num_vending_terminals = 1
 
 	coinbox = new(src)
 
-	for(var/spath in slogan_languages)
-		if(ispath(spath))
-			slogan_languages -= spath
-			slogan_languages += new spath //convert paths into language datums
+	for(var/langname in slogan_languages)
+		if(istext(langname))
+			slogan_languages -= langname
+			slogan_languages += all_languages[langname] //pull the language datum from its name
 
 	if(ticker)
 		initialize()
@@ -1587,7 +1587,7 @@ var/global/num_vending_terminals = 1
 		)
 
 	pack = /obj/structure/vendomatpack/offlicence
-	slogan_languages = list(/datum/language/gutter)
+	slogan_languages = list(LANGUAGE_GUTTER)
 
 /obj/machinery/vending/offlicence/get_language(mob/target)
 	if(prob(25))
@@ -2217,7 +2217,7 @@ var/global/num_vending_terminals = 1
 	premium = list(
 		/obj/item/weapon/storage/box/boxen = 1
 		)
-	slogan_languages = list(/datum/language/vox)
+	slogan_languages = list(LANGUAGE_VOX)
 
 /obj/machinery/vending/magivend
 	name = "\improper MagiVend"
@@ -3182,7 +3182,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/stamp/trader = 20,
 		/obj/item/crackerbox = 200,
 		)
-	slogan_languages = (/datum/language/vox)
+	slogan_languages = list(LANGUAGE_VOX)
 
 //trade vendor used to be here, now see trade_datums.dm
 
@@ -3653,7 +3653,7 @@ var/global/num_vending_terminals = 1
 		)
 
 	pack = /obj/structure/vendomatpack/zamsnax
-	slogan_languages = list(/datum/language/grey)
+	slogan_languages = list(LANGUAGE_GREY)
 
 /obj/machinery/vending/zamsnax/get_language(var/mob/living/M)
 	if(isgrey(M))


### PR DESCRIPTION
Ad cooldown lowered 10 minutes -> 2 minutes
Vox outfitter and vox seed vendor now speak vox
Off license drinks will speak gutter 25% of the time
Zamsnax will speak Grey if it is addressing a Grey (nearest customer for ad or actively purchasing)

Codeside: it is now trivially easy to make a vendor speak a language of your choice, and you can also very easily set bonus lines for speaking only in one language. Zam is the example here with unique grey-only lines.

:cl:
* rscadd: Vendors now may speak in specific languages in the right circumstances.
* tweak: Vendors will not advertise to an empty room, and will be more likely to advertise the closer a person is. The cooldown for advertising is now lower, as well.