### PR TITLE
Fixed nuke ops uplink

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -492,6 +492,9 @@
 
 
 /obj/item/device/radio/attack_self(mob/user)
+	. = ..()
+	if(.)
+		return
 	user.set_machine(src)
 	interact(user)
 

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -10,6 +10,8 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 
 // PRESET UPLINKS
 // A collection of preset uplinks.
+/obj/item/device/radio/uplink
+	icon_state = "radio"
 
 /obj/item/device/radio/uplink/New()
 	..()


### PR DESCRIPTION
#30641 accidentally made the uplink look like a regular radio, and attempting to use it resulted in the regular radio menu opening.
It was *technically* still possible to unlock it by entering the correct frequency, but the operatives were never given said frequency so uhhh.
closes #30808
:cl:
* bugfix: Nuke ops can use their uplink once again.