### PR TITLE
Trader Recruit Starter Gifts

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1124,7 +1124,7 @@ var/global/num_vending_terminals = 1
 			spawn(rand(0, 15))
 				stat |= NOPOWER
 				update_vicon()
-	
+
 
 //Oh no we're malfunctioning!  Dump out some product and break.
 /obj/machinery/vending/proc/malfunction()
@@ -3133,6 +3133,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/stamp/trader = 3,
 		/obj/item/crackerbox = 1,
 		/obj/item/weapon/storage/box/biscuit = 2,
+		/obj/item/talonprosthetic = 3,
 		)
 
 	prices = list(
@@ -3141,6 +3142,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/card/id/vox/extra = 100,
 		/obj/item/weapon/stamp/trader = 20,
 		/obj/item/crackerbox = 200,
+		/obj/item/talonprosthetic = 80,
 		)
 
 //trade vendor used to be here, now see trade_datums.dm

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -1670,11 +1670,3 @@ var/list/omnitoolable = list(/obj/machinery/alarm,/obj/machinery/power/apc)
 	for(var/i = 1 to 2)
 		var/bootlegDrink = pick(existing_typesof(/obj/item/weapon/reagent_containers/food/drinks))
 		new bootlegDrink(src)
-
-
-//Restock//////////////////////
-
-/obj/structure/vendomatpack/trader
-	name = "trader supply recharge pack"
-	targetvendomat = /obj/machinery/vending/trader
-	icon_state = "sale"

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -299,12 +299,12 @@ var/list/alldepartments = list("Central Command", "Nanotrasen HR")
 	P.stamps += "<HR><i>This paper has been stamped by the Central Command Quantum Relay.</i>"
 
 /proc/SendMerchantFax(mob/living/carbon/human/merchant)
-	var/obj/item/weapon/paper/merchantreport/P
+	var/obj/item/weapon/paper/merchant/report/P
 	for(var/obj/machinery/faxmachine/F in allfaxes)
 		if(F.department == "Internal Affairs" && !F.stat)
 			flick("faxreceive", F)
 			playsound(F.loc, "sound/effects/fax.ogg", 50, 1)
-			P = new /obj/item/weapon/paper/merchantreport(F,merchant)
+			P = new /obj/item/weapon/paper/merchant/report(F,merchant)
 			spawn(2 SECONDS)
 				P.forceMove(F.loc)
 	return P

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -620,42 +620,75 @@ var/global/list/paper_folding_results = list ( \
 	artifact = null
 	..()
 
-/obj/item/weapon/paper/merchantreport
+/obj/item/weapon/paper/merchant
 	var/identity
 	var/list/mugshots = list()
+	var/icon_updates = FALSE
+	display_y = 500
 
-/obj/item/weapon/paper/merchantreport/New(loc,mob/living/carbon/human/merchant)
+/obj/item/weapon/paper/merchant/update_icon()
+	if(icon_updates)
+		..()
+
+/obj/item/weapon/paper/merchant/New(loc,mob/living/carbon/human/merchant)
 	if(merchant)
-		identity = merchant.client.prefs.real_name
-		name = "Licensed Merchant Report - [identity]"
 		merchant.client.prefs.update_preview_icon(0) //This is necessary because if they don't check their character sheet it never generates!
 		mugshots += fcopy_rsc(merchant.client.prefs.preview_icon_front)
 		mugshots += fcopy_rsc(merchant.client.prefs.preview_icon_side)
-		info = {"<html><style>
-						body {color: #000000; background: #ccffff;}
-						h1 {color: #000000; font-size:30px;}
-						fieldset {width:140px;}
-						</style>
-						<body>
-						<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"> <h1>ATTN: Internal Affairs</h1></center>
-						Nanotrasen\'s commercial arm has noted the presence of a registered merchant who holds a license for corporate commerce, a process which includes a background check and Nanotrasen loyalty implant. The associate\'s image is enclosed. Please continue to monitor trade on an ongoing basis such that Nanotrasen can maintain highest standard small business enterprise (SBE) partners.<BR>
-						<fieldset>
-	  					<legend>Picture</legend>
-						<center><img src="previewicon-[identity]1.png" width="64" height="64"><img src="previewicon-[identity]2.png" width="64" height="64"></center>
-						</fieldset><BR>
-						Name: [identity]<BR>
-						Blood Type: [merchant.dna.b_type]<BR>
-						Fingerprint: [md5(merchant.dna.uni_identity)]</body></html>"}
-		display_y = 700
-		CentcommStamp(src)
+		apply_text(merchant)
 	..()
 
-/obj/item/weapon/paper/merchantreport/show_text(var/mob/user, var/links = FALSE, var/starred = FALSE)
+/obj/item/weapon/paper/merchant/show_text(var/mob/user, var/links = FALSE, var/starred = FALSE)
 	var/index = 1
 	for(var/image in mugshots)
 		user << browse_rsc(image, "previewicon-[identity][index].png")
 		index++
 	..()
+
+/obj/item/weapon/paper/merchant/proc/apply_text(mob/living/carbon/human/merchant)
+	identity = merchant.client.prefs.real_name
+	icon = 'icons/obj/items.dmi'
+	icon_state = "permit"
+	name = "Merchant's Licence - [identity]"
+	info = {"<html><style>
+			body {color: #000000; background: #ffff0d;}
+			h1 {color: #000000; font-size:30px;}
+			fieldset {width:140px;}
+			</style>
+			<body>
+			<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"> <h1>Merchant's Licence</h1></center>
+			Nanotrasen\'s commercial arm has authorized commercial activity for a merchant who holds a licence for corporate commerce, a process which includes a background check and Nanotrasen loyalty implant. The associate\'s image is displayed below.<BR>
+			<fieldset>
+	  		<legend>Picture</legend>
+			<center><img src="previewicon-[identity]1.png" width="64" height="64"><img src="previewicon-[identity]2.png" width="64" height="64"></center>
+			</fieldset><BR>
+			Name: [identity]<BR>
+			Blood Type: [merchant.dna.b_type]<BR>
+			Fingerprint: [md5(merchant.dna.uni_identity)]</body></html>"}
+
+/obj/item/weapon/paper/merchant/report
+	icon_updates = TRUE
+	display_y = 700
+
+/obj/item/weapon/paper/merchant/report/apply_text(mob/living/carbon/human/merchant)
+	identity = merchant.client.prefs.real_name
+	name = "Licensed Merchant Report - [identity]"
+	info = {"<html><style>
+			body {color: #000000; background: #ccffff;}
+			h1 {color: #000000; font-size:30px;}
+			fieldset {width:140px;}
+			</style>
+			<body>
+			<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"> <h1>ATTN: Internal Affairs</h1></center>
+			Nanotrasen\'s commercial arm has noted the presence of a registered merchant who holds a licence for corporate commerce, a process which includes a background check and Nanotrasen loyalty implant. The associate\'s image is enclosed. Please continue to monitor trade on an ongoing basis such that Nanotrasen can maintain highest standard small business enterprise (SBE) partners.<BR>
+			<fieldset>
+	  		<legend>Picture</legend>
+			<center><img src="previewicon-[identity]1.png" width="64" height="64"><img src="previewicon-[identity]2.png" width="64" height="64"></center>
+			</fieldset><BR>
+			Name: [identity]<BR>
+			Blood Type: [merchant.dna.b_type]<BR>
+			Fingerprint: [md5(merchant.dna.uni_identity)]</body></html>"}
+	CentcommStamp(src)
 
 /obj/item/weapon/paper/traderapplication
 	name = "trader application"

--- a/code/modules/trader/trade_datums.dm
+++ b/code/modules/trader/trade_datums.dm
@@ -1,6 +1,7 @@
 #define TRADE_SINGLE "Single Products"
 #define TRADE_VARIETY "Variety Packs"
 #define FLUX_CHANCE 3
+#define NEW_RECRUIT -1
 
 /datum/trade_product
 	var/name = "Abstract Product"

--- a/code/modules/trader/trade_gear.dm
+++ b/code/modules/trader/trade_gear.dm
@@ -1,0 +1,107 @@
+/obj/item/dictionary
+	name = "nanodictionary"
+	desc = "Prized communication tools, nanodictionaries let you learn a whole language extremely quickly. The process comes at the cost of destroying the nanodictionary itself -- this also means that only one person can make use of it, because pieces will be missing if someone else claims it."
+	icon = 'icons/obj/library.dmi'
+	icon_state ="book"
+	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/books.dmi', "right_hand" = 'icons/mob/in-hand/right/books.dmi')
+	item_state = "book"
+
+	var/mob/living/owner
+	var/datum/language/tongue
+	var/progress = 0
+	var/progress_goal = 6 //How many times do you need to progress to master the language?
+	var/progress_time = 10 SECONDS //How much time does it take to progress a step?
+	var/progress_fail_chance = 0 //Chance of failing to advance each step
+
+	var/list/fundamental_letters = list("a b c d e", "f g h i j", "k l m n o", "p q r s t", "u v w x y z")
+	var/list/basic_words = list("hello","goodbye","please","thank you","yes","no","what is that?","how are you?","I am","from","look","see","go to","where is","I like","I understand")
+	var/list/intermediate_phrases = list("How's it going?", "What have you been up to?", "How've you been?", "I've been cooking lately.", "How about we watch a movie?", "Sorry, I can't.", "Sure, it sounds good.", "Do you wanna visit the moon?", "I will not like, subscribe, or follow.", "How do I get to my hotel?", "In the restroom, is there soap in the dispenser?")
+	var/list/advanced_phrases = list("I am literally an autodidact, not merely idiomatically.", "The particular characteristics of the orangutan flustered the blustering entomologist.", "I saw a kitten eating chicken in the kitchen.", "I slit the sheet, the sheet I slit, and on the slitted sheet I sit.", "She rebuffed my agastopia with a scrumptious riposte: a jam to jam my romantic ambitions.")
+
+/obj/item/dictionary/vox/New()
+	..()
+	name = "pidgin nanodictionary"
+	tongue = all_languages[LANGUAGE_VOX]
+
+/obj/item/dictionary/Destroy()
+	master = null
+	tongue = null
+	..()
+
+/obj/item/dictionary/attack_self(mob/user)
+	if(!tongue)
+		to_chat(user,"<span class='danger'>This nanodictionary is blank!</span>")
+		return
+	if(!master)
+		master = user
+	if(master != user)
+		to_chat(user,"<span class='danger'>This nanodictionary is already partially used up. Useless. You need the fundamentals.</span>.")
+		return
+	if(do_after(user,src,progress_time, 10, custom_checks = new /callback(src, /obj/item/dictionary/proc/on_do_after)))
+		if(prob(progress_fail_chance))
+			to_chat(user,"<span class='danger'>Although you practiced your hardest, you didn't make any progress</span>.")
+		else
+			progress++
+			if(progress<progress_goal)
+				to_chat(user,"<span class='good'>You make some progress in learning.</span>")
+			else
+				to_chat(user,"<span class='good'>You have mastered the language!</span>")
+				user.languages += tongue
+				qdel(src)
+
+/obj/item/dictionary/proc/on_do_after(mob/user, use_user_turf, user_original_location, atom/target, target_original_location, needhand, obj/item/originally_held_item)
+	if(prob(35))
+		practice(user)
+	return do_after_default_checks(arglist(args))
+
+/obj/item/dictionary/proc/practice(mob/user)
+	var/phrase
+	switch(round(progress / progress_goal,0.01))
+		if(0 to 0.1) //Fundamentals - learning alphabet
+			say(pick(fundamental_letters), tongue)
+		if(0.11 to 0.4) //Basics - learning words, repeat in both languages
+			phrase = pick(basic_words)
+			say(phrase, tongue)
+			user.say(phrase, user.languages[1])
+		if(0.41 to 0.7) //As above, but phrases
+			phrase = pick(intermediate_phrases)
+			say(phrase, tongue)
+			user.say(phrase, user.languages[1])
+		if(0.71 to 1)
+			phrase = pick(advanced_phrases)
+			say(phrase, tongue)
+
+/obj/item/dictionary/GetVoice()
+	return master
+
+//Talonifier
+/obj/item/talonprosthetic
+	name = "mushroom-to-talon prosthetic"
+	desc = "Since the incorporation of Mushrooms into Vox culture, the more ambitious of their kind have sought the right to sign their own legal documents. In Vox culture, this requires a talon. This doesn't stop ambitious mushrooms. The wicked implement looks prepared to seize your arm by force: if you're not made of fungal matter, this will probably hurt a lot."
+	icon = 'icons/obj/robot_parts.dmi'
+	icon_state = "l_arm"
+	item_state = "buildpipe"
+
+/obj/item/talonprosthetic/attack_self(mob/living/carbon/human/H)
+	if(!istype(H))
+		to_chat(H, "<span class='warning'>You can't use this.</span>")
+	if(H.organ_has_mutation(H.get_active_hand_organ(), M_TALONS))
+		to_chat(H, "<span class='warning'>Your active hand is already a talon!</span>")
+		return
+	to_chat(H,"<span class='warning'>\The [src] begins burrowing into your arm - cutting it off to take its place!</span>")
+	playsound(src, "sound/weapons/bloodyslice.ogg", 50, 1, -1)
+	var/datum/organ/external/temp = H.get_active_hand_organ()
+	if(!(H.species.flags & IS_PLANT))
+		to_chat(H, "<span class='danger'>This was a bad idea!</span>")
+		temp.explode()
+		H.adjustBruteLoss(15)
+		return
+	if(!(H.species.flags & SPECIES_NO_MOUTH))
+		to_chat(H, "<span class='danger'>Your screaming disrupts the cauterizing process!</span>")
+		H.audible_scream()
+		H.adjustFireLoss(17)
+	temp.robotize()
+	temp.species = new /datum/species/vox
+	H.regenerate_icons()
+	to_chat(H, "<span class='good'>You have a robotic talon!</span>")
+	qdel(src)

--- a/code/modules/trader/trade_window.dm
+++ b/code/modules/trader/trade_window.dm
@@ -21,7 +21,8 @@
 	..()
 	merchant_name = capitalize("[pick(vox_name_syllables)][pick(vox_name_syllables)] the [capitalize(pick(adjectives))]")
 	processing_objects += src
-	trader_language = new /datum/language/vox
+	trader_language = all_languages[LANGUAGE_VOX]
+	SStrade.all_twindows += src
 
 /obj/structure/trade_window/Destroy()
 	SStrade.all_twindows -= src
@@ -84,19 +85,21 @@
 					return
 			//Haven't exited because of an invalid card.
 			var/obj/TA = new /obj/item/weapon/paper/traderapplication(loc, user.get_face_name())
-			TA.pixel_x = rand(-5,5) * PIXEL_MULTIPLIER
-			TA.pixel_y = -3 * PIXEL_MULTIPLIER
+			tableadjust(TA)
 			TA.shake(1,3)
 			playsound(TA, "pageturn", 50, 1)
 
 	if(istype(W,/obj/item/weapon/paper/traderapplication))
 		var/obj/item/weapon/paper/traderapplication/P = W
 		if(findtext(P.stamps,"inkpad"))
-			if(!(user.get_face_name() in SStrade.loyal_customers))
+			if(P.applicant in SStrade.loyal_customers)
+				say("Very funny. We've already done this, burn any extra papers.")
+			else if(!(user.get_face_name() in SStrade.loyal_customers))
 				say("So who's vouching for you? I want it from them.")
 			else
 				say("Well, that settles it then. [user.get_face_name()], [P.applicant] is your responsibility.")
-				SStrade.loyal_customers[P.applicant] = 0
+				SStrade.loyal_customers[P.applicant] = NEW_RECRUIT
+				qdel(P)
 		else
 			say("Go on, get that stamped.")
 
@@ -108,8 +111,7 @@
 
 /obj/structure/trade_window/proc/pay_with_cash(obj/item/weapon/spacecash/C, mob/user)
 	if(user.drop_item(C, loc))
-		C.pixel_x = rand(-5,5) * PIXEL_MULTIPLIER
-		C.pixel_y = -3 * PIXEL_MULTIPLIER
+		tableadjust(C)
 	/*if(product_selected && credits_held() >= product_selected.current_price(user))
 		trade(user)*/
 	nanomanager.update_uis(src)
@@ -277,8 +279,7 @@
 			qdel(O)
 		dispense_cash(total-price,loc)
 		for(var/obj/item/weapon/spacecash/C in loc)
-			C.pixel_x = rand(-5,5) * PIXEL_MULTIPLIER
-			C.pixel_y = -3 * PIXEL_MULTIPLIER
+			tableadjust(C)
 	return TRUE
 
 /obj/structure/trade_window/say(var/message)
@@ -289,3 +290,13 @@
 
 /obj/structure/trade_window/GetVoice()
 	return merchant_name
+
+/obj/structure/trade_window/proc/tablenew(var/path, var/shake=FALSE)
+	var/atom/A = new path(loc)
+	tableadjust(A)
+	if(shake)
+		A.shake(1,3)
+
+/obj/structure/trade_window/proc/tableadjust(var/atom/A)
+	A.pixel_x = rand(-5,5) * PIXEL_MULTIPLIER
+	A.pixel_y = -3 * PIXEL_MULTIPLIER

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2710,6 +2710,7 @@
 #include "code\modules\tgui\states\zlevel.dm"
 #include "code\modules\tooltip\tooltip.dm"
 #include "code\modules\trader\trade_datums.dm"
+#include "code\modules\trader\trade_gear.dm"
 #include "code\modules\trader\trade_responses.dm"
 #include "code\modules\trader\trade_system.dm"
 #include "code\modules\trader\trade_window.dm"


### PR DESCRIPTION
closes #30799
🆑 
* rscadd: Traders recruited with a trade pact application will now receive a gift. If they speak Vox, it will be the normal trader equipment. Otherwise, they get a nanodictionary to learn Pidgin.
* rscadd: Merchants now get a copy of their licence when first greeted at the trade window.
* rscadd: Mushroom men can now purchase the mushroom-to-talon prosthetic at the trade outfitter. This will convert one hand to a robotic talon with brutal efficiency, allowing them to stamp documents.