### PR TITLE
Removes the big gaps between MC tab items

### DIFF
--- a/code/controllers/mc/admin.dm
+++ b/code/controllers/mc/admin.dm
@@ -1,6 +1,7 @@
 // Clickable stat() button.
 /obj/effect/statclick
 	var/target
+	icon = null
 
 /obj/effect/statclick/New(text, target)
 	name = text


### PR DESCRIPTION
Unfortunately has no apparent effect on the awful lag you get with the MC tab open, but at least it looks better.
#30138 gave `/obj/effect` some default var values it previously didn't have, including `icon`. The `icon` for `statclick` objects was invisible but still took up space in the statpanel. Or something. There are also some other vars that `statclick` objects have now that they didn't before, but I don't think they cause any problems.