### PR TITLE
Minor ZAS fixes

### DIFF
--- a/code/ZAS/Connection.dm
+++ b/code/ZAS/Connection.dm
@@ -77,10 +77,12 @@ Class Procs:
 
 /connection/proc/mark_direct()
 	state |= CONNECTION_DIRECT
+	++edge.direct
 //	to_chat(world, "Marked direct.")
 
 /connection/proc/mark_indirect()
 	state &= ~CONNECTION_DIRECT
+	--edge.direct
 //	to_chat(world, "Marked indirect.")
 
 /connection/proc/mark_space()
@@ -112,8 +114,8 @@ Class Procs:
 	else if(block_status & ZONE_BLOCKED)
 		if(direct())
 			mark_indirect()
-		else
-			mark_direct()
+	else if(!direct())
+		mark_direct()
 
 	var/b_is_space = (!istype(B,/turf/simulated))
 


### PR DESCRIPTION
Marking a connection as direct previously had no effect on whether or not its edge considered itself to be direct, other than decrementing the edge's `direct` when the connection was removed. This led to very common cases where two zones would fail to merge when they should have until something updated one of them, and *extremely* rare cases where two zones would merge when they should not have. In fact the latter is *so* unlikely to happen in normal gameplay, I doubt it ever has. It was possible to do on purpose, though.
Also, as an added bonus, connections were completely wrong about when to mark themselves as direct when updated.