### PR TITLE
Windoors facing the other direction and such no longer prevent you from throwing someone on a table

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -117,7 +117,7 @@
 	for (var/atom/A in loc)
 		if (A == src)
 			continue
-		if (A.density)
+		if (!A.Cross(victim,get_turf(victim)))
 			to_chat(user, "<span class='warning'>\The [A] prevents you from dragging \the [victim] on top of \the [src]</span>")
 			return FALSE
 	victim.forceMove(loc)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -385,7 +385,7 @@
 	for (var/atom/A in loc)
 		if (A == src)
 			continue
-		if (A.density)
+		if (!A.Cross(victim,get_turf(victim)))
 			to_chat(user, "<span class='warning'>\The [A] prevents you from dragging \the [victim] on top of \the [src]</span>")
 			return FALSE
 	victim.forceMove(loc)


### PR DESCRIPTION
Fixes #30822

:cl:
* bugfix: Windoors facing the other direction and such no longer prevent you from throwing someone on a table. (DamianX)