### PR TITLE
[MDB IGNORE] Snowbox fixes

### DIFF
--- a/maps/tgstation-snow.dm
+++ b/maps/tgstation-snow.dm
@@ -34,8 +34,8 @@
 	holomap_offset_x = list(0,0,0,86,4,0,0,)
 	holomap_offset_y = list(0,0,0,94,10,0,0,)
 
-	center_x = 226
-	center_y = 254
+	center_x = 150
+	center_y = 150
 	only_spawn_map_exclusive_vaults = TRUE
 
 	event_blacklist = list(/datum/event/radiation_storm,/datum/event/carp_migration,/datum/event/rogue_drone,/datum/event/immovable_rod,

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -25943,6 +25943,18 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"bAM" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/cable/orange,
+/turf/simulated/floor/plating,
+/area/security/prison)
 "bAO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
@@ -43274,6 +43286,19 @@
 	},
 /turf/space/transit/north,
 /area)
+"cWf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/security/prison)
 "cWh" = (
 /obj/machinery/cooking/still,
 /turf/simulated/floor/plating,
@@ -55852,20 +55877,6 @@
 	icon_state = "barber"
 	},
 /area/medical/cmo)
-"dQa" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "redcorner"
-	},
-/area/security/prison)
 "dQe" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/machinery/light/small{
@@ -56768,7 +56779,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/glass/plasma,
 /area/security/prison)
 "eaQ" = (
 /obj/machinery/alarm{
@@ -56776,10 +56787,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "red"
-	},
+/turf/simulated/floor/glass/plasma,
 /area/security/prison)
 "eaR" = (
 /turf/simulated/floor{
@@ -66583,17 +66591,6 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine)
-"flx" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/security/prison)
 "flH" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
@@ -67044,6 +67041,18 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/fore)
+"fur" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/plasma{
+	dir = 8
+	},
+/obj/structure/window/reinforced/plasma{
+	dir = 4
+	},
+/obj/structure/window/reinforced/plasma,
+/obj/structure/cable/orange,
+/turf/simulated/floor/plating,
+/area/prison/cell_block/A)
 "fus" = (
 /obj/machinery/light{
 	dir = 4
@@ -87010,6 +87019,24 @@
 	},
 /turf/simulated/floor,
 /area/supply/miningdock)
+"msY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/security/prison)
 "mtA" = (
 /obj/machinery/door_control{
 	id_tag = "Dorm1";
@@ -87779,6 +87806,14 @@
 	icon_state = "red"
 	},
 /area/security/checkpoint2)
+"mHz" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/prison/cell_block/A)
 "mHG" = (
 /obj/machinery/atm{
 	pixel_y = 32
@@ -87944,6 +87979,21 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/simulated/floor,
 /area/supply/storage)
+"mJp" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	canSpawnMice = 0;
+	dir = 4;
+	on = 1
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/security/prison)
 "mJN" = (
 /obj/item/weapon/shard{
 	icon_state = "small"
@@ -88982,14 +89032,6 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai_upload)
-"nbX" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/prison/cell_block/A)
 "ncn" = (
 /obj/machinery/vending/engivend,
 /turf/simulated/floor,
@@ -89220,18 +89262,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"nhy" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/plasma{
-	dir = 8
-	},
-/obj/structure/window/reinforced/plasma{
-	dir = 4
-	},
-/obj/structure/window/reinforced/plasma,
-/obj/structure/cable/orange,
-/turf/simulated/floor/plating,
-/area/prison/cell_block/A)
 "nib" = (
 /obj/machinery/light{
 	dir = 1
@@ -98079,19 +98109,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating/airless,
 /area/solar/derelict_aft)
-"qlg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/security/prison)
 "qlz" = (
 /turf/unsimulated/wall{
 	icon_state = "plasma2"
@@ -98669,27 +98686,6 @@
 	icon_state = "floor3"
 	},
 /area/centcom/evac)
-"qvT" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/plasma{
-	dir = 8
-	},
-/obj/structure/window/reinforced/plasma{
-	dir = 4
-	},
-/obj/structure/window/reinforced/plasma{
-	dir = 1
-	},
-/obj/structure/cable/orange{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/orange{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/prison/cell_block/A)
 "qvY" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -98961,18 +98957,6 @@
 	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
-"qBs" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable/orange,
-/turf/simulated/floor/plating,
-/area/security/prison)
 "qBt" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
@@ -100311,6 +100295,17 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
+"raO" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/security/prison)
 "raR" = (
 /obj/effect/decal/warning_stripes{
 	dir = 1;
@@ -101319,6 +101314,18 @@
 "ruS" = (
 /turf/simulated/wall/r_wall,
 /area/derelict/hallway/primary)
+"rvc" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable/orange,
+/turf/simulated/floor/plating,
+/area/security/prison)
 "rvl" = (
 /obj/structure/window{
 	dir = 1
@@ -102244,6 +102251,27 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
+"rMe" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/plasma{
+	dir = 8
+	},
+/obj/structure/window/reinforced/plasma{
+	dir = 4
+	},
+/obj/structure/window/reinforced/plasma{
+	dir = 1
+	},
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/orange{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/prison/cell_block/A)
 "rML" = (
 /obj/effect/decal/warning_stripes{
 	dir = 8;
@@ -103667,6 +103695,10 @@
 	icon_state = "white"
 	},
 /area/medical/patient_room1)
+"srW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/simulated/floor/glass/plasma,
+/area/security/prison)
 "srX" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
@@ -105037,21 +105069,6 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
-"sSs" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	canSpawnMice = 0;
-	dir = 4;
-	on = 1
-	},
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/security/prison)
 "sSB" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -109187,18 +109204,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/locker/locker_toilet)
-"upF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/cable/orange,
-/turf/simulated/floor/plating,
-/area/security/prison)
 "uqk" = (
 /obj/item/stack/sheet/cardboard,
 /turf/simulated/floor{
@@ -109250,6 +109255,10 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/engineering/engine)
+"usa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/simulated/floor/glass/plasma,
+/area/security/prison)
 "usb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -117639,24 +117648,6 @@
 	icon_state = "redyellowfull"
 	},
 /area/tdome/tdomeadmin)
-"xpQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/security/prison)
 "xqf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -153043,8 +153034,8 @@ edy
 edy
 aaI
 aaQ
-sSs
-upF
+mJp
+bAM
 edy
 evh
 dYP
@@ -153344,9 +153335,9 @@ aaI
 aaI
 aaI
 aaI
-flx
-xpQ
-qBs
+raO
+msY
+rvc
 edy
 evh
 dYP
@@ -153647,7 +153638,7 @@ oeU
 aaQ
 abR
 aaS
-qlg
+cWf
 aaI
 edy
 evh
@@ -153949,7 +153940,7 @@ aaQ
 aaQ
 abR
 aaS
-qlg
+cWf
 aaI
 edy
 edy
@@ -154256,8 +154247,8 @@ aac
 aac
 aac
 aac
-qvT
-nhy
+rMe
+fur
 aac
 edy
 evh
@@ -154854,7 +154845,7 @@ abK
 abS
 abS
 acm
-nbX
+mHz
 ruo
 acM
 add
@@ -243643,7 +243634,7 @@ cTw
 cOK
 cXR
 dar
-dQa
+eaO
 eaO
 ecR
 ees
@@ -243945,8 +243936,8 @@ cIE
 cVk
 cXT
 daY
-cON
-cVk
+usa
+usa
 ecW
 cON
 efQ
@@ -244247,7 +244238,7 @@ cTz
 cVy
 cXU
 dbd
-cVy
+srW
 eaQ
 ecX
 cVy

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -984,6 +984,12 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/device/radio/intercom{
+	desc = "Talk... listen through this.";
+	name = "Station Intercom (Brig Radio)";
+	pixel_x = -28;
+	wires = 2
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1388,9 +1394,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plating,
 /area/prison/cell_block/A)
 "acX" = (
 /obj/structure/bed/chair,
@@ -1619,6 +1623,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -55805,9 +55814,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/structure/cable/orange{
+	d2 = 8;
+	icon_state = "0-8"
 	},
+/turf/simulated/floor/plating,
 /area/prison/cell_block/A)
 "dPA" = (
 /obj/structure/table,
@@ -66572,6 +66583,17 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine)
+"flx" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/security/prison)
 "flH" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
@@ -88960,6 +88982,14 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai_upload)
+"nbX" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/prison/cell_block/A)
 "ncn" = (
 /obj/machinery/vending/engivend,
 /turf/simulated/floor,
@@ -89190,6 +89220,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
+"nhy" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/plasma{
+	dir = 8
+	},
+/obj/structure/window/reinforced/plasma{
+	dir = 4
+	},
+/obj/structure/window/reinforced/plasma,
+/obj/structure/cable/orange,
+/turf/simulated/floor/plating,
+/area/prison/cell_block/A)
 "nib" = (
 /obj/machinery/light{
 	dir = 1
@@ -89744,14 +89786,6 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine)
-"ntz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/prison/cell_block/A)
 "ntA" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -91727,16 +91761,13 @@
 /turf/simulated/floor,
 /area/storage/primary)
 "oeU" = (
-/obj/item/device/radio/intercom{
-	desc = "Talk... listen through this.";
-	name = "Station Intercom (Brig Radio)";
-	pixel_x = -28;
-	wires = 2
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/prison/cell_block/A)
+/area/security/prison)
 "oeZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -98048,6 +98079,19 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating/airless,
 /area/solar/derelict_aft)
+"qlg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/security/prison)
 "qlz" = (
 /turf/unsimulated/wall{
 	icon_state = "plasma2"
@@ -98625,6 +98669,27 @@
 	icon_state = "floor3"
 	},
 /area/centcom/evac)
+"qvT" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/plasma{
+	dir = 8
+	},
+/obj/structure/window/reinforced/plasma{
+	dir = 4
+	},
+/obj/structure/window/reinforced/plasma{
+	dir = 1
+	},
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/orange{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/prison/cell_block/A)
 "qvY" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -98896,6 +98961,18 @@
 	icon_state = "neutral"
 	},
 /area/hallway/primary/central)
+"qBs" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable/orange,
+/turf/simulated/floor/plating,
+/area/security/prison)
 "qBt" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
@@ -102458,16 +102535,6 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
-"rSC" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	canSpawnMice = 0;
-	dir = 4;
-	on = 1
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/security/prison)
 "rSE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -104970,6 +105037,21 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
+"sSs" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	canSpawnMice = 0;
+	dir = 4;
+	on = 1
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/security/prison)
 "sSB" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -106494,17 +106576,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/science/storage)
-"tsz" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/security/prison)
 "tsA" = (
 /obj/effect/decal/warning_stripes{
 	dir = 2;
@@ -109116,6 +109187,18 @@
 	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/locker/locker_toilet)
+"upF" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/cable/orange,
+/turf/simulated/floor/plating,
+/area/security/prison)
 "uqk" = (
 /obj/item/stack/sheet/cardboard,
 /turf/simulated/floor{
@@ -110662,14 +110745,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/storage/tools)
-"uSS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/security/prison)
 "uSW" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -110979,14 +111054,6 @@
 	tag = "icon-caution (WEST)"
 	},
 /area/hallway/primary/aft)
-"uYv" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/security/prison)
 "uYG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -117572,6 +117639,24 @@
 	icon_state = "redyellowfull"
 	},
 /area/tdome/tdomeadmin)
+"xpQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/security/prison)
 "xqf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -152958,8 +153043,8 @@ edy
 edy
 aaI
 aaQ
-rSC
-aaI
+sSs
+upF
 edy
 evh
 dYP
@@ -153259,9 +153344,9 @@ aaI
 aaI
 aaI
 aaI
-tsz
-uSS
-aaI
+flx
+xpQ
+qBs
 edy
 evh
 dYP
@@ -153558,11 +153643,11 @@ edy
 edy
 edy
 aaI
-uYv
+oeU
 aaQ
 abR
 aaS
-uSS
+qlg
 aaI
 edy
 evh
@@ -153864,7 +153949,7 @@ aaQ
 aaQ
 abR
 aaS
-uSS
+qlg
 aaI
 edy
 edy
@@ -154171,8 +154256,8 @@ aac
 aac
 aac
 aac
-aac
-aac
+qvT
+nhy
 aac
 edy
 evh
@@ -154473,7 +154558,7 @@ acl
 rXa
 adc
 adj
-oeU
+acS
 adE
 adK
 edy
@@ -154769,7 +154854,7 @@ abK
 abS
 abS
 acm
-ntz
+nbX
 ruo
 acM
 add

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -779,7 +779,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/prison/cell_block/A)
+/area/security/prison)
 "abS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
@@ -1082,7 +1082,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/prison/cell_block/A)
+/area/security/prison)
 "acv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
@@ -96939,6 +96939,14 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/trade/start)
+"pPH" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/security/prison)
 "pPV" = (
 /obj/structure/rack,
 /obj/item/weapon/kitchen/utensil/knife/large/ritual,
@@ -151993,10 +152001,10 @@ dYP
 dYP
 evh
 edy
-aac
-aac
-aac
-aac
+aaI
+aaI
+aaI
+aaI
 edy
 evh
 dYP
@@ -152295,10 +152303,10 @@ dYP
 dYP
 evh
 edy
-aac
+aaI
 acu
 acu
-aac
+aaI
 edy
 evh
 dYP
@@ -152597,10 +152605,10 @@ evh
 evh
 evh
 edy
-aac
-aca
-aca
-aac
+aaI
+aaQ
+aaQ
+aaI
 edy
 evh
 dYP
@@ -152899,10 +152907,10 @@ edy
 edy
 edy
 edy
-aac
-aca
-aca
-aac
+aaI
+aaQ
+aaQ
+aaI
 edy
 evh
 dYP
@@ -153198,13 +153206,13 @@ evh
 evh
 evh
 edy
-aac
-aac
-aac
-aac
-aca
-aca
-aac
+aaI
+aaI
+aaI
+aaI
+pPH
+aaQ
+aaI
 edy
 evh
 dYP
@@ -153500,13 +153508,13 @@ edy
 edy
 edy
 edy
-aac
-aca
-aca
+aaI
+pPH
+aaQ
 abR
-aca
-aca
-aac
+aaQ
+aaQ
+aaI
 edy
 evh
 evh
@@ -153802,13 +153810,13 @@ aaI
 aaI
 aaI
 aaI
-aac
-aca
-aca
+aaI
+aaQ
+aaQ
 abR
-aca
-aca
-aac
+aaQ
+aaQ
+aaI
 edy
 edy
 edy

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -662,8 +662,18 @@
 	},
 /area/security/prison)
 "abJ" = (
-/obj/machinery/status_display,
-/turf/simulated/wall,
+/obj/machinery/door/airlock/glass_security{
+	name = "Permanent Detention";
+	normalspeed = 0;
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "Firelock West"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/prison/cell_block/A)
 "abK" = (
 /obj/structure/grille,
@@ -740,7 +750,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/prison/cell_block/A)
 "abP" = (
 /obj/item/clothing/head/cowboy,
@@ -758,7 +768,14 @@
 /turf/unsimulated/floor/asteroid/underground,
 /area/mine/explored)
 "abR" = (
-/obj/machinery/portable_atmospherics/scrubber/huge/stationary,
+/obj/machinery/door/airlock/glass_security{
+	name = "Permanent Detention";
+	normalspeed = 0;
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	name = "Firelock South"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1061,11 +1078,7 @@
 	},
 /area/prison/cell_block/A)
 "acu" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	pixel_y = 16
-	},
-/obj/item/weapon/soap/nanotrasen,
+/obj/structure/stairs/west,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1151,6 +1164,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1198,6 +1216,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1350,21 +1371,20 @@
 /turf/simulated/floor/plating,
 /area/prison/cell_block/A)
 "acW" = (
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
+/obj/structure/grille,
+/obj/structure/window/reinforced/plasma{
 	dir = 8
 	},
-/obj/item/device/radio/intercom{
-	desc = "Talk... listen through this.";
-	name = "Station Intercom (Brig Radio)";
-	pixel_x = -28;
-	wires = 2
+/obj/structure/window/reinforced/plasma{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/window/reinforced/plasma{
+	dir = 1
+	},
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -16281,11 +16301,6 @@
 /turf/simulated/wall/r_wall,
 /area/medical/virology_break)
 "aLs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	master_tag = "virology_airlock_control";
@@ -16357,14 +16372,9 @@
 /area/medical/virology_break)
 "aLy" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -17008,6 +17018,11 @@
 	dir = 6
 	},
 /obj/machinery/meter,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/virology_maint)
 "aMO" = (
@@ -17020,6 +17035,11 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/virology_maint)
 "aMP" = (
@@ -17190,11 +17210,37 @@
 /area/mine/explored)
 "aNf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/virology_maint)
 "aNg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/virology_maint)
@@ -17573,12 +17619,14 @@
 	},
 /area/science/xenobiology)
 "aNT" = (
-/obj/structure/table,
 /obj/machinery/camera{
 	dir = 1;
 	name = "Virology Maintenance"
 	},
 /obj/machinery/light/small,
+/obj/machinery/power/battery/smes{
+	charge = 5e+006
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/virology_maint)
 "aNU" = (
@@ -29176,14 +29224,14 @@
 	dir = 8;
 	name = "Virology Access North"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/item/weapon/bedsheet/medical,
 /obj/structure/bed,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -32041,6 +32089,26 @@
 	icon_state = "dark"
 	},
 /area/vox_trading_post/armory)
+"bYN" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Cyborg Station";
+	req_access_txt = "16"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "Firelock West"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/comms{
+	name = "\improper Cyborg Station"
+	})
 "bYR" = (
 /obj/structure/table,
 /obj/item/device/mmi,
@@ -35750,6 +35818,21 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine)
+"cmM" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/prison/cell_block/A)
 "cmT" = (
 /turf/simulated/wall/r_wall,
 /area/teleporter)
@@ -35836,11 +35919,6 @@
 	},
 /area/medical/genetics)
 "cnh" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -42813,8 +42891,8 @@
 /turf/simulated/wall,
 /area/medical/medbay)
 "cUp" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -43008,11 +43086,6 @@
 	},
 /area/security/prison)
 "cVl" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -55713,11 +55786,23 @@
 /turf/simulated/floor/plating,
 /area/derelict/atmos)
 "dOC" = (
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "red"
+/obj/structure/grille,
+/obj/structure/window/reinforced/plasma{
+	dir = 8
 	},
-/area/security/prison)
+/obj/structure/window/reinforced/plasma{
+	dir = 4
+	},
+/obj/structure/window/reinforced/plasma,
+/obj/structure/cable/orange{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/orange,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/prison/cell_block/A)
 "dPA" = (
 /obj/structure/table,
 /obj/item/device/radio/intercom{
@@ -55755,6 +55840,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -55979,6 +56067,10 @@
 	},
 /turf/simulated/floor,
 /area/derelict/bridge)
+"dWa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/unsimulated/floor/snow/asphalt,
+/area/surface/snow)
 "dWE" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -56635,9 +56727,17 @@
 	},
 /area/security/prison)
 "eax" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
 /turf/simulated/floor,
 /area/security/prison)
 "eaH" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -56647,6 +56747,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/security/prison)
@@ -68717,6 +68820,12 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint3)
+"gbS" = (
+/obj/machinery/portable_atmospherics/scrubber/huge/stationary,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/prison/cell_block/A)
 "gbV" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
@@ -69187,6 +69296,10 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/hop)
+"glA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/unsimulated/floor/snow/asphalt,
+/area/surface/snow)
 "glC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -72702,6 +72815,27 @@
 	icon_state = "gravsnow_corner"
 	},
 /area/syndicate_mothership)
+"hyd" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Integrity Restorer";
+	req_access_txt = "16"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "Firelock East"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/server)
 "hyf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/wall/r_wall,
@@ -74791,6 +74925,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/djstation)
+"iib" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/virology_maint)
 "iim" = (
 /obj/machinery/vending/boozeomat,
 /turf/simulated/floor/wood,
@@ -78158,6 +78301,19 @@
 	icon_state = "barber"
 	},
 /area/medical/cmo)
+"jqK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/prison/cell_block/A)
 "jqO" = (
 /obj/machinery/telecomms/processor/preset_one,
 /turf/simulated/floor/bluegrid{
@@ -79741,6 +79897,17 @@
 	icon_state = "white"
 	},
 /area/science/hallway)
+"jUa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/prison/cell_block/A)
 "jUb" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -82936,6 +83103,15 @@
 	icon_state = "bluecorner"
 	},
 /area/hallway/primary/fore)
+"kXn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/virology_maint)
 "kXo" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -83846,11 +84022,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "lof" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
 	on = 1
@@ -91538,6 +91709,17 @@
 	},
 /turf/simulated/floor,
 /area/storage/primary)
+"oeU" = (
+/obj/item/device/radio/intercom{
+	desc = "Talk... listen through this.";
+	name = "Station Intercom (Brig Radio)";
+	pixel_x = -28;
+	wires = 2
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/prison/cell_block/A)
 "oeZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -95977,13 +96159,9 @@
 	name = "AI Integrity Restorer";
 	req_access_txt = "16"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/door/firedoor/border_only{
+	dir = 4;
+	name = "Firelock East"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -101006,6 +101184,17 @@
 	},
 /turf/simulated/floor/airless,
 /area/derelict/hallway/primary)
+"ruo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/prison/cell_block/A)
 "ruq" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -102445,6 +102634,16 @@
 	},
 /turf/simulated/floor,
 /area/medical/sleeper)
+"rXa" = (
+/obj/item/weapon/soap/nanotrasen,
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/prison/cell_block/A)
 "rYe" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	on = 1
@@ -102460,7 +102659,6 @@
 /turf/simulated/floor,
 /area/derelict/arrival)
 "rYm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitegreen"
@@ -104098,10 +104296,9 @@
 	name = "Cyborg Station";
 	req_access_txt = "16"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "Firelock West"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -150285,14 +150482,14 @@ edy
 edy
 edy
 edy
-evh
-evh
-evh
-evh
-evh
-evh
-evh
-evh
+edy
+edy
+edy
+edy
+edy
+edy
+edy
+edy
 edy
 edy
 edy
@@ -150587,13 +150784,13 @@ edy
 evh
 evh
 evh
-evh
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
+edy
+edy
+edy
+edy
+edy
+edy
+edy
 evh
 evh
 evh
@@ -150888,15 +151085,15 @@ aaG
 evh
 evh
 dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
+evh
+evh
+edy
+edy
+edy
+edy
+evh
+evh
+evh
 dYP
 dYP
 dYP
@@ -151190,14 +151387,14 @@ bgQ
 evh
 dYP
 dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
+evh
+evh
+edy
+edy
+edy
+edy
+evh
+evh
 dYP
 dYP
 dYP
@@ -151492,14 +151689,14 @@ evh
 dYP
 dYP
 dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
+evh
+edy
+edy
+edy
+edy
+edy
+edy
+evh
 dYP
 dYP
 dYP
@@ -151794,14 +151991,14 @@ dYP
 dYP
 dYP
 dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
+evh
+edy
+aac
+aac
+aac
+aac
+edy
+evh
 dYP
 dYP
 dYP
@@ -152096,14 +152293,14 @@ dYP
 dYP
 dYP
 dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
+evh
+edy
+aac
+acu
+acu
+aac
+edy
+evh
 dYP
 dYP
 dYP
@@ -152395,17 +152592,17 @@ edy
 edy
 evh
 dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
+evh
+evh
+evh
+evh
+edy
+aac
+aca
+aca
+aac
+edy
+evh
 dYP
 dYP
 dYP
@@ -152697,17 +152894,17 @@ edy
 edy
 evh
 dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
+evh
+edy
+edy
+edy
+edy
+aac
+aca
+aca
+aac
+edy
+evh
 dYP
 dYP
 dYP
@@ -153000,16 +153197,16 @@ edy
 evh
 evh
 evh
+edy
+aac
+aac
+aac
+aac
+aca
+aca
+aac
+edy
 evh
-evh
-evh
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
-dYP
 dYP
 dYP
 dYP
@@ -153303,14 +153500,14 @@ edy
 edy
 edy
 edy
+aac
+aca
+aca
+abR
+aca
+aca
+aac
 edy
-evh
-evh
-evh
-evh
-evh
-evh
-evh
 evh
 evh
 evh
@@ -153605,13 +153802,13 @@ aaI
 aaI
 aaI
 aaI
-edy
-edy
-edy
-edy
-edy
-edy
-edy
+aac
+aca
+aca
+abR
+aca
+aca
+aac
 edy
 edy
 edy
@@ -153908,11 +154105,11 @@ aaR
 abd
 aaI
 aac
+abJ
+abJ
 aac
-aac
-aac
-aac
-aac
+acW
+dOC
 aac
 aac
 aac
@@ -154208,18 +154405,18 @@ edy
 aaI
 aaS
 abe
-abq
-abJ
-abR
+aaI
+adK
+aca
 aca
 acl
-acu
-acl
 aca
+acS
 acl
+rXa
 adc
 adj
-aca
+oeU
 adE
 adK
 edy
@@ -154516,9 +154713,9 @@ abS
 abS
 acm
 abS
-acm
+ruo
 acM
-acW
+add
 add
 adk
 ads
@@ -154818,7 +155015,7 @@ abT
 acb
 acn
 acv
-acv
+jUa
 acN
 aca
 aca
@@ -155120,7 +155317,7 @@ abU
 acc
 aco
 aca
-acF
+jqK
 acO
 aca
 aca
@@ -155724,7 +155921,7 @@ abW
 ace
 acq
 acw
-acq
+cmM
 acQ
 aca
 acF
@@ -156932,7 +157129,7 @@ abY
 ach
 ach
 acA
-aca
+gbS
 acS
 aca
 adh
@@ -167619,10 +167816,10 @@ aLE
 aLE
 aMN
 aNf
-aNf
-aNf
-aNf
-aNf
+iib
+iib
+iib
+kXn
 aOk
 aOv
 edy
@@ -242700,8 +242897,8 @@ cTg
 aaQ
 cXN
 aaI
-dOC
-eax
+cFR
+cFR
 eaH
 eeq
 efN
@@ -243002,8 +243199,8 @@ cTv
 cVj
 cXP
 abq
-dOC
-eaH
+cFR
+cFR
 eax
 eer
 efN
@@ -246997,7 +247194,7 @@ bTN
 bZr
 ccW
 rfT
-pBF
+hyd
 rVd
 cmj
 cpG
@@ -248205,7 +248402,7 @@ bTP
 iHX
 ccY
 eRH
-sHt
+bYN
 rTX
 cmq
 lwh
@@ -259699,7 +259896,7 @@ cQD
 cSu
 cUp
 rYm
-cQD
+cUo
 qIF
 qIF
 qIF
@@ -260303,7 +260500,7 @@ ckK
 cSv
 csH
 bOZ
-ckK
+cUo
 qIF
 qIF
 qIF
@@ -268761,33 +268958,33 @@ ctJ
 fMU
 pdG
 bPk
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
+dWa
 hYF
 jIr
 rtc
@@ -269063,33 +269260,33 @@ gLh
 vrS
 dYQ
 ooJ
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
 usu
 jIy
 cvn
@@ -269365,33 +269562,33 @@ fQr
 lle
 cGc
 wfe
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
+glA
 fdy
 jzg
 mQJ

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -14412,12 +14412,11 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "55"
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13";
+	req_one_access_txt = "13"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plating,
 /area/science/xenobiology)
 "aHu" = (
 /obj/structure/closet/secure_closet/excavation,
@@ -90144,6 +90143,13 @@
 	icon_state = "dark"
 	},
 /area/storage/tech)
+"nyP" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13";
+	req_one_access_txt = "13"
+	},
+/turf/simulated/floor/plating,
+/area/science/xenobiology)
 "nyU" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
@@ -95767,6 +95773,9 @@
 	icon_state = "floor3"
 	},
 /area/centcom/evac)
+"psb" = (
+/turf/simulated/floor/plating,
+/area/science/xenobiology)
 "psl" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -176704,10 +176713,10 @@ edy
 edy
 edy
 edy
-evh
-evh
 bgQ
 evh
+dYP
+dYP
 oeI
 aHI
 aOg
@@ -177006,10 +177015,10 @@ edy
 edy
 edy
 edy
-edy
-edy
 aaH
-evh
+edy
+xUD
+xUD
 oeI
 aHJ
 aOh
@@ -177310,8 +177319,8 @@ edy
 edy
 edy
 edy
-edy
-edy
+nyP
+psb
 oeI
 aNR
 aOi
@@ -177612,8 +177621,8 @@ edy
 edy
 edy
 edy
-edy
-edy
+xUD
+psb
 xUD
 jvP
 jvP
@@ -177914,8 +177923,8 @@ evh
 evh
 evh
 edy
-edy
-edy
+xUD
+psb
 aHt
 aNS
 aOj
@@ -178216,8 +178225,8 @@ dYP
 dYP
 evh
 evh
-evh
-evh
+xUD
+xUD
 xUD
 xUD
 xUD

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -1385,6 +1385,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -55799,6 +55802,9 @@
 	icon_state = "0-4"
 	},
 /obj/structure/cable/orange,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -79898,11 +79904,14 @@
 	},
 /area/science/hallway)
 "jUa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/orange{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4;
+	initialize_directions = 13
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -89735,6 +89744,14 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine)
+"ntz" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/prison/cell_block/A)
 "ntA" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -96939,14 +96956,6 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/trade/start)
-"pPH" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/security/prison)
 "pPV" = (
 /obj/structure/rack,
 /obj/item/weapon/kitchen/utensil/knife/large/ritual,
@@ -101199,6 +101208,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -102446,6 +102458,16 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
+"rSC" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	canSpawnMice = 0;
+	dir = 4;
+	on = 1
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/security/prison)
 "rSE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -106472,6 +106494,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/science/storage)
+"tsz" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/security/prison)
 "tsA" = (
 /obj/effect/decal/warning_stripes{
 	dir = 2;
@@ -110629,6 +110662,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/storage/tools)
+"uSS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/security/prison)
 "uSW" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -110938,6 +110979,14 @@
 	tag = "icon-caution (WEST)"
 	},
 /area/hallway/primary/aft)
+"uYv" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/security/prison)
 "uYG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -152909,7 +152958,7 @@ edy
 edy
 aaI
 aaQ
-aaQ
+rSC
 aaI
 edy
 evh
@@ -153210,8 +153259,8 @@ aaI
 aaI
 aaI
 aaI
-pPH
-aaQ
+tsz
+uSS
 aaI
 edy
 evh
@@ -153509,11 +153558,11 @@ edy
 edy
 edy
 aaI
-pPH
+uYv
 aaQ
 abR
-aaQ
-aaQ
+aaS
+uSS
 aaI
 edy
 evh
@@ -153814,8 +153863,8 @@ aaI
 aaQ
 aaQ
 abR
-aaQ
-aaQ
+aaS
+uSS
 aaI
 edy
 edy
@@ -154418,8 +154467,8 @@ adK
 aca
 aca
 acl
-aca
-acS
+adu
+acP
 acl
 rXa
 adc
@@ -154720,7 +154769,7 @@ abK
 abS
 abS
 acm
-abS
+ntz
 ruo
 acM
 add

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -16288,13 +16288,21 @@
 	},
 /area/medical/virology_break)
 "aLo" = (
-/turf/simulated/wall/r_wall,
-/area/maintenance/virology_maint)
-"aLp" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/medical/virology_break)
+"aLp" = (
+/obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -16337,12 +16345,16 @@
 	},
 /area/medical/virology_break)
 "aLt" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13";
-	req_one_access_txt = "13"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/virology_maint)
+/area/medical/virology_break)
 "aLu" = (
 /obj/item/device/radio/intercom/medbay{
 	pixel_x = -30
@@ -16382,32 +16394,21 @@
 	},
 /area/medical/virology_break)
 "aLy" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
+/obj/structure/z_ladder/up,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/medical/virology_break)
+/area/medical/virology)
 "aLz" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/atmospherics/pipe/zpipe/up/supply/hidden,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/medical/virology_break)
 "aLA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/bed/chair/comfy/black,
 /obj/machinery/light{
 	dir = 1
@@ -16417,14 +16418,10 @@
 	},
 /area/medical/virology_break)
 "aLB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -16433,11 +16430,6 @@
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -16445,22 +16437,20 @@
 "aLD" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/green,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	pixel_x = 27
-	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitegreencorner"
 	},
 /area/medical/virology_break)
 "aLE" = (
-/turf/simulated/floor/plating,
-/area/maintenance/virology_maint)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/medical/virology)
 "aLF" = (
 /obj/machinery/camera{
 	dir = 4;
@@ -16487,11 +16477,6 @@
 	},
 /area/medical/virology_break)
 "aLI" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
@@ -16500,8 +16485,8 @@
 	},
 /area/medical/virology_break)
 "aLJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -16561,11 +16546,6 @@
 	},
 /area/medical/virology_break)
 "aLQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "white"
@@ -16625,11 +16605,6 @@
 /turf/simulated/wall,
 /area/medical/virology_break)
 "aLX" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor/border_only{
 	name = "Firelock South"
@@ -16655,34 +16630,27 @@
 /turf/simulated/wall/r_wall,
 /area/medical/virology)
 "aMa" = (
-/obj/machinery/light_switch{
-	pixel_x = -23
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/virology_maint)
-"aMb" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plating,
-/area/maintenance/virology_maint)
-"aMc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/machinery/light/small{
+/obj/structure/window/reinforced,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/plating,
-/area/maintenance/virology_maint)
-"aMd" = (
-/obj/effect/decal/cleanable/cobweb2,
-/obj/machinery/atmospherics/unary/tank/air{
-	dir = 8
+/area/medical/virology)
+"aMb" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13";
+	req_one_access_txt = "13"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/virology_maint)
+/area/medical/virology)
 "aMe" = (
-/turf/simulated/wall,
-/area/maintenance/virology_maint)
+/obj/machinery/atmospherics/unary/vent{
+	dir = 1
+	},
+/turf/unsimulated/floor/asteroid/cave/permafrost,
+/area/mine/explored)
 "aMf" = (
 /obj/machinery/shower{
 	dir = 4
@@ -16711,11 +16679,6 @@
 	},
 /area/medical/virology)
 "aMg" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
@@ -16778,47 +16741,21 @@
 	},
 /area/medical/virology)
 "aMq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/maintenance/virology_maint)
 "aMr" = (
 /obj/structure/cable{
-	d1 = 2;
+	d1 = 1;
 	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/turf/simulated/floor{
+	icon_state = "white"
 	},
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/maintenance/virology_maint)
-"aMs" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/simulated/floor/plating,
-/area/maintenance/virology_maint)
+/area/medical/virology_break)
 "aMt" = (
-/obj/machinery/atmospherics/unary/tank/air{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
-/area/maintenance/virology_maint)
+/area/medical/virology)
 "aMu" = (
 /obj/structure/sink{
 	dir = 8;
@@ -16839,19 +16776,15 @@
 	},
 /area/medical/virology)
 "aMv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/medical/virology)
+/area/medical/virology_break)
 "aMw" = (
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -16892,22 +16825,23 @@
 	},
 /area/medical/virology)
 "aMA" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	name = "Virology Maintenance";
+	req_access_txt = "39"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/virology_maint)
+/area/medical/virology_break)
 "aMB" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/binary/valve,
 /turf/simulated/floor/plating,
 /area/maintenance/virology_maint)
 "aMC" = (
@@ -16923,11 +16857,6 @@
 /area/medical/virology)
 "aMD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/window{
 	base_state = "right";
 	dir = 2;
@@ -17014,72 +16943,48 @@
 /turf/simulated/floor/plating,
 /area/medical/virology)
 "aMM" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/maintenance/virology_maint)
 "aMN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/machinery/meter,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/virology_maint)
-"aMO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/simulated/floor/plating,
+/area/maintenance/virology_maint)
+"aMO" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 27
+	},
 /obj/structure/cable{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/virology_maint)
 "aMP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Virology Maintenance";
-	req_access_txt = "39"
-	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/virology_maint)
 "aMQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/newscaster{
-	pixel_x = 0;
-	pixel_y = 30
+	dir = 4;
+	pixel_x = -28
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -17090,77 +16995,43 @@
 	pixel_x = -5;
 	pixel_y = 30
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
+/obj/machinery/meter,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/medical/virology)
 "aMS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor/plating,
+/area/maintenance/virology_maint)
+"aMT" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
-/area/medical/virology)
-"aMT" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
-/area/medical/virology)
+/turf/simulated/floor/plating,
+/area/maintenance/virology_maint)
 "aMU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/medical/virology)
 "aMV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 24
-	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
-/area/medical/virology)
+/obj/structure/table,
+/turf/simulated/floor/plating,
+/area/maintenance/virology_maint)
 "aMW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -17220,47 +17091,35 @@
 	},
 /area/mine/explored)
 "aNf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/virology_maint)
 "aNg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/virology_maint)
+/area/medical/virology_break)
 "aNh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/simulated/wall/r_wall,
-/area/maintenance/virology_maint)
+/area/medical/virology)
 "aNi" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -17345,9 +17204,19 @@
 	},
 /area/mine/explored)
 "aNt" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/virology_maint)
+/area/medical/virology_break)
 "aNu" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/syringes{
@@ -17383,6 +17252,7 @@
 /area/medical/virology)
 "aNw" = (
 /obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -17475,9 +17345,16 @@
 	},
 /area/medical/virology)
 "aNF" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/virology_maint)
+/area/medical/virology_break)
 "aNG" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/latex{
@@ -17543,15 +17420,22 @@
 	},
 /area/medical/virology)
 "aNL" = (
-/obj/structure/table,
-/obj/item/weapon/storage/box/labels,
-/obj/item/weapon/hand_labeler,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/virology_maint)
 "aNM" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
-/area/maintenance/virology_maint)
+/area/medical/virology)
 "aNN" = (
 /obj/structure/table,
 /obj/item/weapon/virusdish/random{
@@ -17630,14 +17514,9 @@
 	},
 /area/science/xenobiology)
 "aNT" = (
-/obj/machinery/camera{
-	dir = 1;
-	name = "Virology Maintenance"
-	},
-/obj/machinery/light/small,
-/obj/machinery/power/battery/smes{
-	charge = 5e+006
-	},
+/obj/structure/table,
+/obj/item/weapon/storage/box/labels,
+/obj/item/weapon/hand_labeler,
 /turf/simulated/floor/plating,
 /area/maintenance/virology_maint)
 "aNU" = (
@@ -17673,6 +17552,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -17821,13 +17701,9 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/virology_maint)
 "aOl" = (
@@ -17851,6 +17727,7 @@
 /area/medical/virology)
 "aOm" = (
 /obj/machinery/computer/diseasesplicer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "whitegreen"
 	},
@@ -17955,11 +17832,11 @@
 	},
 /area/science/xenobiology)
 "aOv" = (
-/obj/machinery/atmospherics/unary/vent{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
-/turf/unsimulated/floor/asteroid/cave/permafrost,
-/area/mine/explored)
+/turf/simulated/floor/plating,
+/area/medical/virology_break)
 "aOw" = (
 /obj/structure/sign/biohazard,
 /turf/simulated/wall/r_wall,
@@ -23308,6 +23185,12 @@
 	icon_state = "dark"
 	},
 /area/vox_trading_post/hallway)
+"bog" = (
+/obj/machinery/atmospherics/unary/tank/air{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/medical/virology_break)
 "boi" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -32860,6 +32743,10 @@
 	},
 /turf/simulated/floor,
 /area/supply/storage)
+"cbr" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/medical/virology)
 "cbs" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
@@ -35958,6 +35845,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -43111,6 +43003,11 @@
 "cVl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -73217,6 +73114,10 @@
 /mob/living/simple_animal/mouse/common,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"hCQ" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/plating,
+/area/maintenance/virology_maint)
 "hCV" = (
 /obj/structure/sign/double/barsign,
 /turf/simulated/wall,
@@ -74962,14 +74863,11 @@
 /turf/simulated/floor/plating,
 /area/djstation)
 "iib" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/virology_maint)
+/area/medical/virology_break)
 "iim" = (
 /obj/machinery/vending/boozeomat,
 /turf/simulated/floor/wood,
@@ -77219,6 +77117,11 @@
 /obj/machinery/door/airlock/external{
 	name = "Outer Snow Airlock"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -79351,6 +79254,17 @@
 	icon_state = "dark"
 	},
 /area/science/xenobiology)
+"jIC" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/virology_maint)
 "jIN" = (
 /obj/structure/window{
 	dir = 1
@@ -81699,6 +81613,10 @@
 	},
 /turf/simulated/floor,
 /area/crew_quarters/fitness)
+"kzf" = (
+/obj/structure/z_ladder,
+/turf/simulated/floor/plating,
+/area/medical/virology)
 "kzu" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
@@ -83143,14 +83061,12 @@
 	},
 /area/hallway/primary/fore)
 "kXn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/zpipe/down/supply/hidden{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/virology_maint)
+/turf/simulated/open,
+/area/medical/virology_break)
 "kXo" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -84065,6 +83981,11 @@
 	dir = 4;
 	on = 1
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -84868,6 +84789,9 @@
 	icon_state = "neutral"
 	},
 /area/crew_quarters/sleep)
+"lBW" = (
+/turf/simulated/floor/plating,
+/area/medical/virology_break)
 "lCc" = (
 /obj/structure/window/full/reinforced,
 /turf/unsimulated/wall/fakeglass{
@@ -89777,6 +89701,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/checkpoint2)
+"nsp" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/virology_maint)
 "nsr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/warning_stripes{
@@ -95977,6 +95912,20 @@
 	},
 /turf/simulated/floor,
 /area/supply/miningdock)
+"pvS" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/medical/virology)
 "pvX" = (
 /obj/structure/closet/secure_closet/exile,
 /obj/machinery/light{
@@ -103727,6 +103676,14 @@
 	},
 /turf/simulated/floor/airless,
 /area/derelict/hallway/primary)
+"ssK" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/medical/virology)
 "ssL" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -107576,6 +107533,22 @@
 	icon_state = "cult"
 	},
 /area/library)
+"tIt" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/virology_maint)
 "tIR" = (
 /turf/simulated/wall/r_wall,
 /area/construction/mommi_nest)
@@ -109278,6 +109251,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/central)
+"ush" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/medical/virology)
 "usl" = (
 /obj/machinery/computer/prisoner,
 /obj/machinery/light{
@@ -112650,6 +112639,11 @@
 /obj/machinery/door/airlock/external{
 	name = "Outer Snow Airlock";
 	req_access_txt = "5"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/unsimulated/floor/snow/asphalt,
 /area/medical/virology_break)
@@ -116409,6 +116403,17 @@
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
+"wPK" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/plating,
+/area/medical/virology)
 "wPQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -117487,6 +117492,10 @@
 	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/locker/locker_toilet)
+"xkE" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/simulated/floor/plating,
+/area/maintenance/virology_maint)
 "xkH" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor,
@@ -166750,13 +166759,13 @@ evh
 evh
 evh
 evh
-bgQ
 evh
 evh
-evh
-evh
-evh
-evh
+dYP
+dYP
+dYP
+dYP
+dYP
 dYP
 dYP
 dYP
@@ -167052,14 +167061,14 @@ edy
 edy
 edy
 edy
-aaH
-edy
-edy
-edy
-edy
-edy
+bgQ
 evh
 evh
+evh
+evh
+dYP
+dYP
+dYP
 dYP
 dYP
 dYP
@@ -167354,15 +167363,15 @@ edy
 edy
 edy
 edy
-edy
-edy
-edy
-edy
+aaH
 edy
 edy
 edy
 evh
 evh
+evh
+evh
+dYP
 dYP
 dYP
 dYP
@@ -167647,23 +167656,23 @@ edy
 edy
 edy
 edy
-aLo
-aLo
-aLo
-aLo
-aLo
-aMq
-aMA
-aMM
-aLo
-aMq
-aMA
-aMM
-aLo
-aLo
 edy
 edy
 edy
+edy
+edy
+edy
+edy
+edy
+edy
+edy
+edy
+edy
+edy
+edy
+edy
+edy
+evh
 evh
 dYP
 dYP
@@ -167949,21 +167958,21 @@ edy
 edy
 edy
 edy
-aLt
-aLE
-aLE
-aLt
-aMa
-aLE
-aLE
-aMN
-aNf
-iib
-iib
-iib
-kXn
-aOk
-aOv
+edy
+edy
+edy
+edy
+edy
+edy
+edy
+edy
+edy
+edy
+edy
+edy
+edy
+edy
+edy
 edy
 edy
 evh
@@ -168250,21 +168259,21 @@ evh
 edy
 edy
 edy
+aLq
+aLq
+aLq
 aLo
-aLo
-aLo
-aLo
-aLo
+aLq
 aMb
-aMr
-aMB
-aMO
-aNg
-aNt
-aNF
-aNL
-aNT
-aLo
+aLZ
+aLZ
+edy
+edy
+edy
+edy
+edy
+edy
+edy
 edy
 edy
 edy
@@ -168556,17 +168565,17 @@ aLp
 aLu
 aLF
 aLN
-aLo
-aMc
-aMs
-aLo
-aMP
+aLq
+aMt
+aMt
+aLZ
+aLZ
 aNh
-aLo
-aLo
+aLZ
+aLZ
 aNM
-aLo
-aLo
+aLZ
+aLZ
 edy
 edy
 edy
@@ -168854,14 +168863,14 @@ evh
 evh
 edy
 edy
-aLq
+aLt
 aLv
 aLG
 aLN
-aLo
-aMd
+aLq
 aMt
-aLo
+aMt
+aMb
 aMQ
 aNi
 aNu
@@ -169160,10 +169169,10 @@ aLr
 aLw
 aLH
 aLO
-aLo
-aMe
-aMe
-aMe
+aLq
+aMi
+aMi
+aMi
 aMR
 aNj
 aNv
@@ -169466,15 +169475,15 @@ aLW
 aMf
 aMu
 aMC
-aMS
-aNk
+aMX
+aLE
 aNw
-aMk
-aMk
+aNo
+aNo
 aNW
 aOm
-aMG
-edy
+aMa
+aMe
 edy
 edy
 edy
@@ -169761,14 +169770,14 @@ aLm
 xue
 xue
 aLs
-aLy
+xue
 aLI
 aLQ
 aLX
 aMg
-aMv
+aNj
 aMD
-aMT
+aMY
 aNl
 aNx
 aMk
@@ -170372,7 +170381,7 @@ aLq
 aMi
 aMi
 aMi
-aMV
+aMW
 aNk
 aNz
 aNI
@@ -170674,7 +170683,7 @@ aLq
 aMk
 aMl
 aMF
-aMW
+aLy
 aNk
 aNA
 aNJ
@@ -259757,10 +259766,10 @@ aLq
 aLq
 aLq
 aLq
-bZp
-bZp
-bZp
-bZp
+aLq
+aLq
+aLq
+aLq
 bZp
 bZp
 bZp
@@ -260059,10 +260068,10 @@ xue
 lBO
 fNL
 aLq
-bZp
-bZp
-bZp
-bZp
+aNg
+aOv
+bog
+aLq
 bZp
 bZp
 bZp
@@ -260341,30 +260350,30 @@ cnh
 cVl
 lof
 iVb
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
-qIF
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
+usu
 vDr
-xue
+aMr
 fNL
 fNL
 aLq
-bZp
-bZp
-bZp
-bZp
+aNt
+iib
+bog
+aLq
 bZp
 bZp
 bZp
@@ -260659,21 +260668,21 @@ qIF
 qIF
 qIF
 aLq
-xue
+aMv
 fNL
 fNL
 aLq
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
+aNF
+kXn
+lBW
+aLq
+qIF
+qIF
+aLZ
+aLZ
+aLZ
+aLZ
+aLZ
 bZp
 bZp
 bZp
@@ -260961,21 +260970,21 @@ qIF
 qIF
 qIF
 aLq
+aMA
 aLq
 aLq
 aLq
+aMA
 aLq
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
+aLq
+aLq
+qIF
+qIF
+aLZ
+wPK
+aMt
+aMt
+aLZ
 bZp
 bZp
 bZp
@@ -261262,22 +261271,22 @@ bZp
 qIF
 qIF
 qIF
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
+aMq
+aMB
+aMN
+aMP
+aMP
+aNL
+nsp
+aMP
+tIt
+usu
+usu
+ush
+ssK
+kzf
+cbr
+aLZ
 bZp
 bZp
 bZp
@@ -261564,22 +261573,22 @@ bZp
 qIF
 qIF
 qIF
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
+aMq
+aMM
+aMO
+aMS
+aMV
+aNT
+xkE
+hCQ
+jIC
+qIF
+qIF
+aML
+aMt
+aMt
+aMt
+aLZ
 bZp
 bZp
 bZp
@@ -261866,22 +261875,22 @@ bZp
 qIF
 qIF
 qIF
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
-bZp
+aMq
+aMq
+aMq
+aMT
+aNf
+aOk
+aMq
+aMq
+aMq
+qIF
+qIF
+aLZ
+aLZ
+pvS
+aLZ
+aLZ
 bZp
 bZp
 bZp


### PR DESCRIPTION
[general][tweak]
![image](https://user-images.githubusercontent.com/57303506/134605805-d3a31789-c586-4219-9e0f-d1cd58c85b60.png)
![image](https://user-images.githubusercontent.com/57303506/134605848-4ea86d93-118f-4323-9d13-83523a1dad61.png)
![image](https://user-images.githubusercontent.com/57303506/134408954-bcca8963-02c5-4fae-936d-92cf55800815.png)
![image](https://user-images.githubusercontent.com/57303506/134407983-c4fc36af-bcce-413d-9327-a4c475ea5882.png)
![image](https://user-images.githubusercontent.com/57303506/134527133-000f241a-8dcb-4b4e-bd53-a6d5c27edd14.png)
:cl:
 * rscadd: Snowbox: The AI integrity restoring chamber and cyborg chamber lower areas now have firelocks.
 * rscadd: Snowbox: Permabrig now has an easier way to access it.
 * tweak: Snowbox: Virology is now connected to the powernet.
 * rscadd: Snowbox: Xenobiology now has connected atmospherics, power and a proper lower external airlock.
 * tweak: Snowbox: The map center values are now proper.