### PR TITLE
Alien weeds growth respects border objects

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -287,7 +287,7 @@
 	//			continue
 
 			for(var/obj/O in T)
-				if(O.density)
+				if(!O.Cross(src, get_turf(T)))
 					continue direction_loop
 
 			new /obj/effect/alien/weeds(T, linked_node)


### PR DESCRIPTION
Basically it does this 
![image](https://user-images.githubusercontent.com/6307265/134586006-4c6a92ec-6fdf-4ef9-9197-5c1da5816dbb.png)

instead of looking at a turf and going "Oh well, there's a window and it's dense so I will literally never be able to pass there"