### PR TITLE
Fixed Ghosts no longer haunting mobs going through portals

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -129,7 +129,8 @@
 		return FALSE
 
 	playSpecials(curturf,effectin,soundin)
-	teleatom.unlock_from()
+	if (!isobserver(teleatom))
+		teleatom.unlock_from()
 
 	if(istype(teleatom,/obj/item/projectile))
 		var/Xchange = destturf.x - curturf.x


### PR DESCRIPTION
Fixes #30352
Fixes #30854

:cl:
* bugfix: Fixed Ghosts no longer haunting mobs going through portals. (Eneocho)