### PR TITLE
Fixed permanent statuefication

### DIFF
--- a/code/game/objects/structures/mannequin.dm
+++ b/code/game/objects/structures/mannequin.dm
@@ -142,7 +142,7 @@
 		captured.setOxyLoss(intialOxy)
 		if (timer >= 5)
 			captured.Paralyse(2)
-	if (timer <= 0)
+	if (timer == 0)
 		freeCaptive()
 		qdel(src)
 


### PR DESCRIPTION
If a mannequin was made with `timer = -1`, in order to make it permanent, it would instead immediately be destroyed the next tick.