### PR TITLE
Fixed extra whitespace characters in names breaking runechat highlights

### DIFF
--- a/code/datums/chat_message.dm
+++ b/code/datums/chat_message.dm
@@ -104,7 +104,8 @@ var/runechat_icon = null
 	// If we heard our name, it's important
 	var/list/names = splittext(owner.name, " ")
 	for (var/word in names)
-		text = replacetext(text, word, "<b>[word]</b>")
+		if(word)
+			text = replacetext(text, word, "<b>[word]</b>")
 
 	// Append radio icon if comes from a radio
 	if (extra_classes.Find("spoken_into_radio"))


### PR DESCRIPTION
No longer does this:
![pic](https://cdn.discordapp.com/attachments/239823463802470400/891119300197351444/dreamseeker_6U7aUFU3Ta.png)