### PR TITLE
Minor implant fixes

### DIFF
--- a/code/datums/outfit/striketeams/nt_deathsquad.dm
+++ b/code/datums/outfit/striketeams/nt_deathsquad.dm
@@ -34,7 +34,7 @@
 
 	implant_types = list(
 		/obj/item/weapon/implant/loyalty/,
-		/obj/item/weapon/implant/explosive/,
+		/obj/item/weapon/implant/explosive/nuclear,
 	)
 
 	id_type = /obj/item/weapon/card/id/death_commando

--- a/code/datums/outfit/striketeams/syndie_deathsquad.dm
+++ b/code/datums/outfit/striketeams/syndie_deathsquad.dm
@@ -36,7 +36,7 @@
 	)
 
 	implant_types = list(
-		/obj/item/weapon/implant/explosive/,
+		/obj/item/weapon/implant/explosive/nuclear,
 	)
 
 	id_type = /obj/item/weapon/card/id/syndicate/commando

--- a/code/game/objects/items/weapons/implants/types/chemical_implant.dm
+++ b/code/game/objects/items/weapons/implants/types/chemical_implant.dm
@@ -38,7 +38,7 @@ the implant may become unstable and either pre-maturely inject the subject or si
 /obj/item/weapon/implant/chem/implanted(mob/implanter)
 	imp_in.register_event(/event/emote, src, .proc/trigger)
 
-/obj/item/weapon/implant/explosive/handle_removal(mob/remover)
+/obj/item/weapon/implant/chem/handle_removal(mob/remover)
 	imp_in?.unregister_event(/event/emote, src, .proc/trigger)
 	makeunusable(75)
 


### PR DESCRIPTION
The deathsquads' outfit datums were using the non-EMP shielded explosive implant, and chem implants weren't properly handling being removed.