### PR TITLE
Fixed afterattack runtime

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -150,7 +150,7 @@
 				resolved = A.attackby(held_item, src, params)
 				if((ismob(A) || istype(A, /obj/mecha) || istype(held_item, /obj/item/weapon/grab)) && !A.gcDestroyed)
 					delayNextAttack(item_attack_delay)
-				if(!resolved && A && !A.gcDestroyed && held_item)
+				if(!resolved && A && !A.gcDestroyed && held_item && !held_item.gcDestroyed)
 					held_item.afterattack(A,src,1,params) // 1 indicates adjacency
 		else
 			if(ismob(A) || istype(held_item, /obj/item/weapon/grab))


### PR DESCRIPTION
```
[17:36:27] Runtime in reagent_containers.dm, line 267: Cannot read null.total_volume
proc name: transfer (/obj/item/weapon/reagent_containers/proc/transfer)
usr: Yerkarovna Khabiyevna (gatanotoah) (/mob/living/carbon/human)
usr.loc: The floor (275, 308, 5) (/turf/simulated/floor)
src: the bucket (/obj/item/weapon/reagent_containers/glass/bucket)
src.loc: null
call stack:
the bucket (/obj/item/weapon/reagent_containers/glass/bucket): transfer(the farmbot assembly with buck... (/obj/item/weapon/farmbot_arm_assembly), Yerkarovna Khabiyevna (/mob/living/carbon/human), 1, 1, -1)
the bucket (/obj/item/weapon/reagent_containers/glass/bucket): afterattack(the farmbot assembly with buck... (/obj/item/weapon/farmbot_arm_assembly), Yerkarovna Khabiyevna (/mob/living/carbon/human), 1, "icon-x=24;icon-y=17;left=1;scr...")
Yerkarovna Khabiyevna (/mob/living/carbon/human): ClickOn(the farmbot assembly with buck... (/obj/item/weapon/farmbot_arm_assembly), "icon-x=24;icon-y=17;left=1;scr...")
the farmbot assembly with buck... (/obj/item/weapon/farmbot_arm_assembly): Click(the floor (275,309,5) (/turf/simulated/floor), "mapwindow.map", "icon-x=24;icon-y=17;left=1;scr...")
Gatanotoah (/client): Click(the farmbot assembly with buck... (/obj/item/weapon/farmbot_arm_assembly), the floor (275,309,5) (/turf/simulated/floor), "mapwindow.map", "icon-x=24;icon-y=17;left=1;scr...")
```