### PR TITLE
Fixed borer shield runtime

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -243,8 +243,10 @@
 		return
 	if(!parent_borer.channeling_bone_shield) //the borer has stopped sustaining the sword
 		qdel(src)
+		return
 	if(parent_borer.chemicals < 3) //the parent borer no longer has the chemicals required to sustain the shield
 		qdel(src)
+		return
 	else
 		parent_borer.chemicals -= 3
 


### PR DESCRIPTION
```
[18:21:11] Runtime in shields.dm, line 246: Cannot read null.chemicals
proc name: process (/obj/item/weapon/shield/riot/bone/process)
src: the bone shield (/obj/item/weapon/shield/riot/bone)
src.loc: null
call stack:
the bone shield (/obj/item/weapon/shield/riot/bone): process()
Objects (/datum/subsystem/obj): fire(0)
Objects (/datum/subsystem/obj): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing()
```