### PR TITLE
Better multi-Z layer connection system

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -74,6 +74,9 @@
 	var/jobs_have_minimal_access = 0	//determines whether jobs use minimal access or expanded access.
 	var/copy_logs = null
 
+	
+	var/multiz_render_cap = 8			//how far down open spaces will render
+
 	// BSQL things
 	var/bsql_debug = 0
 	var/async_query_timeout = 10
@@ -575,6 +578,10 @@
 					blocking_query_timeout = text2num(value)
 				if("bsql_thread_limit")
 					bsql_thread_limit = text2num(value)
+
+				
+				if("multiz_render_cap")
+					multiz_render_cap = text2num(value)
 
 				if("media_base_url")
 					media_base_url = value

--- a/code/modules/multiz/_HELPERS.dm
+++ b/code/modules/multiz/_HELPERS.dm
@@ -32,6 +32,8 @@ var/global/list/visible_spaces = list(/turf/simulated/open, /turf/simulated/floo
 
 // Helper for the below
 /proc/get_zs_away(atom/Loc1,atom/Loc2)
+	if(Loc1.z == Loc2.z)
+		return 0
 	if(!AreConnectedZLevels(Loc1.z, Loc2.z))
 		return INFINITY
 
@@ -50,6 +52,7 @@ var/global/list/visible_spaces = list(/turf/simulated/open, /turf/simulated/floo
 			above_found = TRUE
 			break
 		dist_above++
+
 	if(above_found && below_found)
 		return min(dist_above,dist_below)
 	else if(above_found)

--- a/code/modules/multiz/_HELPERS.dm
+++ b/code/modules/multiz/_HELPERS.dm
@@ -31,14 +31,12 @@ var/global/list/visible_spaces = list(/turf/simulated/open, /turf/simulated/floo
 // BEGIN /VG/ CODE
 
 // Helper for the below
-
 /proc/get_zs_away(atom/Loc1,atom/Loc2)
 	if(!AreConnectedZLevels(Loc1.z, Loc2.z))
 		return INFINITY
 
 	var/dist_above = 0
 	var/dist_below = 0
-
 
 	for(var/level = Loc1.z, HasBelow(level), level = map.zLevels[level].z_below)
 		if(level == Loc2.z)
@@ -49,7 +47,7 @@ var/global/list/visible_spaces = list(/turf/simulated/open, /turf/simulated/floo
 			break
 		dist_above++
 	
-	return max(dist_above,dist_below)
+	return min(dist_above,dist_below)
 
 /**
  * Z-Distance functions

--- a/code/modules/multiz/_HELPERS.dm
+++ b/code/modules/multiz/_HELPERS.dm
@@ -33,13 +33,13 @@ var/global/list/visible_spaces = list(/turf/simulated/open, /turf/simulated/floo
 // Helper for the below
 /proc/get_zs_away(atom/Loc1,atom/Loc2)
 	if(Loc1.z == Loc2.z)
-		return 0
+		return 0 // Nip this in the bud to save performance maybe
 	if(!AreConnectedZLevels(Loc1.z, Loc2.z))
-		return INFINITY
+		return INFINITY // Redundant to below but sanity checking
 
 	var/dist_above = 0
 	var/dist_below = 0
-	var/above_found = FALSE
+	var/above_found = FALSE // Using booleans to see how we handle this later, don't want us hitting the ceiling and pulling a short distance when it wasn't found
 	var/below_found = FALSE
 
 	for(var/level = Loc1.z, HasBelow(level), level = map.zLevels[level].z_below)
@@ -47,19 +47,25 @@ var/global/list/visible_spaces = list(/turf/simulated/open, /turf/simulated/floo
 			below_found = TRUE
 			break
 		dist_below++
+		if(map.zLevels[level].z_below == Loc1.z) // If we end up where we started, get out of the infinite loop (called after value is upped)
+			break
+
 	for(var/level = Loc1.z, HasAbove(level), level = map.zLevels[level].z_above)
 		if(level == Loc2.z)
 			above_found = TRUE
 			break
 		dist_above++
+		if(map.zLevels[level].z_above == Loc1.z)
+			break
 
 	if(above_found && below_found)
-		return min(dist_above,dist_below)
+		return min(dist_above,dist_below) // Get minimum of each if found above AND below
 	else if(above_found)
-		return dist_above
+		return dist_above // Otherwise as normal
 	else if(below_found)
 		return dist_below
-	return INFINITY
+	return INFINITY // Yeah, redundant
+
 /**
  * Z-Distance functions
  *

--- a/code/modules/multiz/_HELPERS.dm
+++ b/code/modules/multiz/_HELPERS.dm
@@ -37,18 +37,26 @@ var/global/list/visible_spaces = list(/turf/simulated/open, /turf/simulated/floo
 
 	var/dist_above = 0
 	var/dist_below = 0
+	var/above_found = FALSE
+	var/below_found = FALSE
 
 	for(var/level = Loc1.z, HasBelow(level), level = map.zLevels[level].z_below)
 		if(level == Loc2.z)
+			below_found = TRUE
 			break
 		dist_below++
 	for(var/level = Loc1.z, HasAbove(level), level = map.zLevels[level].z_above)
 		if(level == Loc2.z)
+			above_found = TRUE
 			break
 		dist_above++
-	
-	return min(dist_above,dist_below)
-
+	if(above_found && below_found)
+		return min(dist_above,dist_below)
+	else if(above_found)
+		return dist_above
+	else if(below_found)
+		return dist_below
+	return INFINITY
 /**
  * Z-Distance functions
  *

--- a/code/modules/multiz/_HELPERS.dm
+++ b/code/modules/multiz/_HELPERS.dm
@@ -29,6 +29,28 @@ var/global/list/visible_spaces = list(/turf/simulated/open, /turf/simulated/floo
 	return 0
 
 // BEGIN /VG/ CODE
+
+// Helper for the below
+
+/proc/get_zs_away(atom/Loc1,atom/Loc2)
+	if(!AreConnectedZLevels(Loc1.z, Loc2.z))
+		return INFINITY
+
+	var/dist_above = 0
+	var/dist_below = 0
+
+
+	for(var/level = Loc1.z, HasBelow(level), level = map.zLevels[level].z_below)
+		if(level == Loc2.z)
+			break
+		dist_below++
+	for(var/level = Loc1.z, HasAbove(level), level = map.zLevels[level].z_above)
+		if(level == Loc2.z)
+			break
+		dist_above++
+	
+	return max(dist_above,dist_below)
+
 /**
  * Z-Distance functions
  *
@@ -36,23 +58,17 @@ var/global/list/visible_spaces = list(/turf/simulated/open, /turf/simulated/floo
  *
  * Euclidean follows suit for the proper formula
  */
-/proc/get_z_dist(atom/Loc1,atom/Loc2)
+/proc/get_z_dist(atom/Loc1, atom/Loc2)
 	var/dx = abs(Loc1.x - Loc2.x)
 	var/dy = abs(Loc1.y - Loc2.y)
-	var/dz = abs(Loc1.z - Loc2.z)
-
-	if(!AreConnectedZLevels(Loc1.z, Loc2.z))
-		return INFINITY
+	var/dz = get_zs_away(Loc1,Loc2)
 
 	return max(dx,dy,dz)
 
 /proc/get_z_dist_euclidian(atom/Loc1, atom/Loc2)
 	var/dx = Loc1.x - Loc2.x
 	var/dy = Loc1.y - Loc2.y
-	var/dz = Loc1.z - Loc2.z
-
-	if(!AreConnectedZLevels(Loc1.z, Loc2.z))
-		return INFINITY
+	var/dz = get_zs_away(Loc1,Loc2)
 
 	return sqrt(dx**2 + dy**2 + dz**2)
 
@@ -64,10 +80,8 @@ var/global/list/visible_spaces = list(/turf/simulated/open, /turf/simulated/floo
  * Use to compare distances. Used in component mobs.
  */
 /proc/get_z_dist_squared(var/atom/a, var/atom/b)
-	if(!AreConnectedZLevels(a.z, b.z))
-		return INFINITY
 
-	return ((b.x-a.x)**2) + ((b.y-a.y)**2) + ((b.z-a.z)**2)
+	return ((b.x-a.x)**2) + ((b.y-a.y)**2) + ((get_zs_away(a,b))**2)
 
 /proc/multi_z_spiral_block(var/turf/epicenter,var/max_range,var/inward=0,var/draw_red=0,var/cube=1)
 	var/list/spiraled_turfs = list()

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -10,13 +10,13 @@
 	var/turf/turf = get_turf(atom)
 	if(!turf)
 		return null
-	return HasAbove(turf.z) ? get_step(turf, UP) : null
+	return HasAbove(turf.z) ? locate(turf.x,turf.y,map.zLevels[z].z_above.z) : null
 
 /proc/GetBelow(var/atom/atom)
 	var/turf/turf = get_turf(atom)
 	if(!turf)
 		return null
-	return HasBelow(turf.z) ? get_step(turf, DOWN) : null
+	return HasBelow(turf.z) ? locate(turf.x,turf.y,map.zLevels[z].z_below.z) : null
 
 /proc/GetConnectedZlevels(z)
 	. = list(z)

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -10,19 +10,19 @@
 	var/turf/turf = get_turf(atom)
 	if(!turf)
 		return null
-	return HasAbove(turf.z) ? locate(turf.x,turf.y,map.zLevels[level].z_above) : null
+	return HasAbove(turf.z) ? locate(turf.x,turf.y,map.zLevels[turf.z].z_above) : null
 
 /proc/GetBelow(var/atom/atom)
 	var/turf/turf = get_turf(atom)
 	if(!turf)
 		return null
-	return HasBelow(turf.z) ? locate(turf.x,turf.y,map.zLevels[level].z_below) : null
+	return HasBelow(turf.z) ? locate(turf.x,turf.y,map.zLevels[turf.z].z_below) : null
 
 /proc/GetConnectedZlevels(z)
 	. = list(z)
-	for(var/level = z, HasBelow(level), level = map.zLevels[z].z_below)
+	for(var/level = z, HasBelow(level), level = map.zLevels[level].z_below)
 		. |= level
-	for(var/level = z, HasAbove(level), level = map.zLevels[z].z_above)
+	for(var/level = z, HasAbove(level), level = map.zLevels[level].z_above)
 		. |= level
 
 /proc/AreConnectedZLevels(var/zA, var/zB)

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -10,19 +10,19 @@
 	var/turf/turf = get_turf(atom)
 	if(!turf)
 		return null
-	return HasAbove(turf.z) ? locate(turf.x,turf.y,map.zLevels[turf.z].z_above.z) : null
+	return HasAbove(turf.z) ? locate(turf.x,turf.y,map.zLevels[turf.z].z_above) : null
 
 /proc/GetBelow(var/atom/atom)
 	var/turf/turf = get_turf(atom)
 	if(!turf)
 		return null
-	return HasBelow(turf.z) ? locate(turf.x,turf.y,map.zLevels[turf.z].z_below.z) : null
+	return HasBelow(turf.z) ? locate(turf.x,turf.y,map.zLevels[turf.z].z_below) : null
 
 /proc/GetConnectedZlevels(z)
 	. = list(z)
-	for(var/level = z, HasBelow(level), level = map.zLevels[z].z_below.z)
+	for(var/level = z, HasBelow(level), level = map.zLevels[z].z_below)
 		. |= level
-	for(var/level = z, HasAbove(level), level = map.zLevels[z].z_above.z)
+	for(var/level = z, HasAbove(level), level = map.zLevels[z].z_above)
 		. |= level
 
 /proc/AreConnectedZLevels(var/zA, var/zB)
@@ -33,9 +33,9 @@
 	if (!turf)
 		return list()
 	. = list(turf.z)
-	for(var/level = turf.z, HasBelow(level) && isvisiblespace(GetBelow(locate(turf.x,turf.y,level))), level = map.zLevels[z].z_below.z)
+	for(var/level = turf.z, HasBelow(level) && isvisiblespace(GetBelow(locate(turf.x,turf.y,level))), level = map.zLevels[z].z_below)
 		. |= level
-	for(var/level = turf.z, HasAbove(level) && isvisiblespace(GetAbove(locate(turf.x,turf.y,level))), level = map.zLevels[z].z_above.z)
+	for(var/level = turf.z, HasAbove(level) && isvisiblespace(GetAbove(locate(turf.x,turf.y,level))), level = map.zLevels[z].z_above)
 		. |= level
 
 /proc/AreOpenConnectedZLevels(var/zA, var/zB)

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -10,13 +10,13 @@
 	var/turf/turf = get_turf(atom)
 	if(!turf)
 		return null
-	return HasAbove(turf.z) ? locate(turf.x,turf.y,map.zLevels[turf.z].z_above) : null
+	return HasAbove(turf.z) ? locate(turf.x,turf.y,map.zLevels[level].z_above) : null
 
 /proc/GetBelow(var/atom/atom)
 	var/turf/turf = get_turf(atom)
 	if(!turf)
 		return null
-	return HasBelow(turf.z) ? locate(turf.x,turf.y,map.zLevels[turf.z].z_below) : null
+	return HasBelow(turf.z) ? locate(turf.x,turf.y,map.zLevels[level].z_below) : null
 
 /proc/GetConnectedZlevels(z)
 	. = list(z)
@@ -33,9 +33,9 @@
 	if (!turf)
 		return list()
 	. = list(turf.z)
-	for(var/level = turf.z, HasBelow(level) && isvisiblespace(GetBelow(locate(turf.x,turf.y,level))), level = map.zLevels[z].z_below)
+	for(var/level = turf.z, HasBelow(level) && isvisiblespace(GetBelow(locate(turf.x,turf.y,level))), level = map.zLevels[level].z_below)
 		. |= level
-	for(var/level = turf.z, HasAbove(level) && isvisiblespace(GetAbove(locate(turf.x,turf.y,level))), level = map.zLevels[z].z_above)
+	for(var/level = turf.z, HasAbove(level) && isvisiblespace(GetAbove(locate(turf.x,turf.y,level))), level = map.zLevels[level].z_above)
 		. |= level
 
 /proc/AreOpenConnectedZLevels(var/zA, var/zB)

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -1,9 +1,13 @@
 // If you add a more comprehensive system, just untick this file.
 
 /proc/HasAbove(var/z)
+	if(z >= world.maxz || z < 1)
+		return FALSE
 	return map.zLevels[z].z_above ? TRUE : FALSE
 
 /proc/HasBelow(var/z)
+	if(z > world.maxz || z < 2)
+		return FALSE
 	return map.zLevels[z].z_below ? TRUE : FALSE
 
 /proc/GetAbove(var/atom/atom)

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -10,13 +10,13 @@
 	var/turf/turf = get_turf(atom)
 	if(!turf)
 		return null
-	return HasAbove(turf.z) ? locate(turf.x,turf.y,map.zLevels[z].z_above.z) : null
+	return HasAbove(turf.z) ? locate(turf.x,turf.y,map.zLevels[turf.z].z_above.z) : null
 
 /proc/GetBelow(var/atom/atom)
 	var/turf/turf = get_turf(atom)
 	if(!turf)
 		return null
-	return HasBelow(turf.z) ? locate(turf.x,turf.y,map.zLevels[z].z_below.z) : null
+	return HasBelow(turf.z) ? locate(turf.x,turf.y,map.zLevels[turf.z].z_below.z) : null
 
 /proc/GetConnectedZlevels(z)
 	. = list(z)

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -1,26 +1,11 @@
 // If you add a more comprehensive system, just untick this file.
-// WARNING: Only works for up to 17 z-levels!
-var/z_levels = 0 // Each bit represents a connection between adjacent levels.  So the first bit means levels 1 and 2 are connected.
 
-// If the height is more than 1, we mark all contained levels as connected.
-/datum/map/proc/loadZLevelConnections(var/height,var/zPos)
-	ASSERT(height <= zPos)
-	// Due to the offsets of how connections are stored v.s. how z-levels are indexed, some magic number silliness happened.
-	for(var/i = (zPos - height) to (zPos - 2))
-		z_levels |= (1 << i)
-
-// The storage of connections between adjacent levels means some bitwise magic is needed.
 /proc/HasAbove(var/z)
-	if(z >= world.maxz || z > 16 || z < 1)
-		return 0
-	return z_levels & (1 << (z - 1))
+	return map.zLevels[z].z_above ? TRUE : FALSE
 
 /proc/HasBelow(var/z)
-	if(z > world.maxz || z > 17 || z < 2)
-		return 0
-	return z_levels & (1 << (z - 2))
+	return map.zLevels[z].z_below ? TRUE : FALSE
 
-// Thankfully, no bitwise magic is needed here.
 /proc/GetAbove(var/atom/atom)
 	var/turf/turf = get_turf(atom)
 	if(!turf)
@@ -35,10 +20,10 @@ var/z_levels = 0 // Each bit represents a connection between adjacent levels.  S
 
 /proc/GetConnectedZlevels(z)
 	. = list(z)
-	for(var/level = z, HasBelow(level), level--)
-		. |= level-1
-	for(var/level = z, HasAbove(level), level++)
-		. |= level+1
+	for(var/level = z, HasBelow(level), level = map.zLevels[z].z_below.z)
+		. |= level
+	for(var/level = z, HasAbove(level), level = map.zLevels[z].z_above.z)
+		. |= level
 
 /proc/AreConnectedZLevels(var/zA, var/zB)
 	return zA == zB || (zB in GetConnectedZlevels(zA))
@@ -48,10 +33,10 @@ var/z_levels = 0 // Each bit represents a connection between adjacent levels.  S
 	if (!turf)
 		return list()
 	. = list(turf.z)
-	for(var/level = turf.z, HasBelow(level) && isvisiblespace(GetBelow(locate(turf.x,turf.y,level))), level--)
-		. |= level-1
-	for(var/level = turf.z, HasAbove(level) && isvisiblespace(GetAbove(locate(turf.x,turf.y,level))), level++)
-		. |= level+1
+	for(var/level = turf.z, HasBelow(level) && isvisiblespace(GetBelow(locate(turf.x,turf.y,level))), level = map.zLevels[z].z_below.z)
+		. |= level
+	for(var/level = turf.z, HasAbove(level) && isvisiblespace(GetAbove(locate(turf.x,turf.y,level))), level = map.zLevels[z].z_above.z)
+		. |= level
 
 /proc/AreOpenConnectedZLevels(var/zA, var/zB)
 	return zA == zB || (zB in GetOpenConnectedZlevels(zA))

--- a/code/modules/multiz/turfs.dm
+++ b/code/modules/multiz/turfs.dm
@@ -96,8 +96,12 @@ var/static/list/no_spacemove_turfs = list(/turf/simulated/wall,/turf/unsimulated
 	overlays.Cut()
 	vis_contents.Cut()
 	var/turf/bottom
+	var/depth = 0
 	for(bottom = GetBelow(src); isopenspace(bottom); bottom = GetBelow(bottom))
 		alpha_to_subtract /= 2
+		depth++
+		if(depth > config.multiz_render_cap) // To stop getting caught on this in infinite loops
+			break
 
 	if(!bottom || bottom == src)
 		return

--- a/code/modules/multiz/turfs.dm
+++ b/code/modules/multiz/turfs.dm
@@ -213,8 +213,12 @@ var/static/list/no_spacemove_turfs = list(/turf/simulated/wall,/turf/unsimulated
 		vis_contents.Cut()
 		overlays.Cut()
 		var/turf/bottom
+		var/depth = 0
 		for(bottom = GetBelow(src); isopenspace(bottom); bottom = GetBelow(bottom))
 			alpha_to_subtract /= 2
+			depth++
+			if(depth > config.multiz_render_cap) // To stop getting caught on this in infinite loops
+				break
 
 		if(!bottom || bottom == src)
 			return

--- a/config-example/config.txt
+++ b/config-example/config.txt
@@ -362,3 +362,6 @@ BSQL_THREAD_LIMIT 50
 
 ## Uncomment to enable verbose BSQL communication logs
 #BSQL_DEBUG
+
+## The maximum number of z-levels rendered above or below in multi-z
+MULTIZ_RENDER_CAP 8

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -24,7 +24,7 @@
 
 	var/nameShort = ""
 	var/nameLong = ""
-	var/list/zLevels = list()
+	var/list/datum/zLevel/zLevels = list()
 	var/zMainStation = 1
 	var/zCentcomm = 2
 	var/zTCommSat = 3
@@ -197,6 +197,8 @@ var/global/list/accessable_z_levels = list()
 	var/base_turf //Our base turf, what shows under the station when destroyed. Defaults to space because it's fukken Space Station 13
 	var/base_area = null //default base area type, what blueprints erase into; if null, space; be careful with parent areas because locate() could find a child!
 	var/z //Number of the z-level (the z coordinate)
+	var/datum/zLevel/z_above //The linked zLevel above, for multiZ
+	var/datum/zLevel/z_below //Same, with below
 
 /datum/zLevel/proc/post_mapload()
 	return

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -197,8 +197,8 @@ var/global/list/accessable_z_levels = list()
 	var/base_turf //Our base turf, what shows under the station when destroyed. Defaults to space because it's fukken Space Station 13
 	var/base_area = null //default base area type, what blueprints erase into; if null, space; be careful with parent areas because locate() could find a child!
 	var/z //Number of the z-level (the z coordinate)
-	var/datum/zLevel/z_above //The linked zLevel above, for multiZ
-	var/datum/zLevel/z_below //Same, with below
+	var/z_above //The linked zLevel Z above, for multiZ
+	var/z_below //Same, with below
 
 /datum/zLevel/proc/post_mapload()
 	return

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -32,8 +32,6 @@
 	var/zAsteroid = 5
 	var/zDeepSpace = 6
 	var/multiz = FALSE //Don't even boot up multiz if we don't need it.
-	var/height = 1 //Height of connecting z levels
-	var/zLoc = 1 //Location of where to connect below from
 
 	//Center of thunderdome admin room
 	var/tDomeX = 0
@@ -113,8 +111,6 @@
 	. = ..()
 
 	src.loadZLevels(src.zLevels)
-	if(multiz)
-		src.loadZLevelConnections(height,zLoc)
 
 	//The spawn below is needed
 	spawn()

--- a/maps/test_multiz.dm
+++ b/maps/test_multiz.dm
@@ -37,8 +37,6 @@
 	tDomeY = 100
 	tDomeZ = 1
 	multiz = TRUE
-	height = 5
-	zLoc = 5
 	zLevels = list(
 		/datum/zLevel/centcomm,
 		/datum/zLevel/subterranean,

--- a/maps/test_multiz.dm
+++ b/maps/test_multiz.dm
@@ -7,21 +7,27 @@
 	name = "planet surface"
 	movementJammed = 1
 	base_turf = /turf/simulated/floor/plating/snow
+	z_above = 4
+	z_below = 2
 
 /datum/zLevel/subterranean
 	name = "subterranean"
 	movementJammed = 1
 	base_turf = /turf/unsimulated/floor/asteroid/air
+	z_above = 3
 
 /datum/zLevel/upper
 	name = "above ground level"
 	movementJammed = 1
 	base_turf = /turf/simulated/open
+	z_above = 5
+	z_below = 3
 
 /datum/zLevel/sky
 	name = "sky"
 	movementJammed = 1
 	base_turf = /turf/simulated/open
+	z_below = 4
 
 /datum/map/active
 	nameShort = "test_multiz"

--- a/maps/tgstation-snow.dm
+++ b/maps/tgstation-snow.dm
@@ -11,8 +11,6 @@
 	tDomeY = 58
 	tDomeZ = 3
 	multiz = TRUE
-	height = 2
-	zLoc = 2
 	zLevels = list(
 		/datum/zLevel/snowmine{
 			z_above = 2

--- a/maps/tgstation-snow.dm
+++ b/maps/tgstation-snow.dm
@@ -14,11 +14,14 @@
 	height = 2
 	zLoc = 2
 	zLevels = list(
-		/datum/zLevel/snowmine,
+		/datum/zLevel/snowmine{
+			z_above = 2
+		},
 		/datum/zLevel/snow{
 			name = "station"
 			movementChance = ZLEVEL_BASE_CHANCE * ZLEVEL_STATION_MODIFIER
 			base_turf = /turf/simulated/open
+			z_below = 1
 		},
 		/datum/zLevel/centcomm,
 		/datum/zLevel/snow{


### PR DESCRIPTION
[tweak][system][tested]
Originally, one had to specify the max height of the multi-Z portion of the map (zLoc) and the depth of it to the bottom (height)
Now, this changes it to a system where any Z-level can be linked to any level above or below in any order, including in infinite loops for possible fun effects. (though I wouldn't recommend it)
The main effect of this PR though, should allow easier groupings of sets of multiple connected Z levels in maps, for example the first and second sets of 4 z-levels in a group of 8 total out of 16 can now be seperate instead of bleeding into each other due to the bitflag system. This also removes the 16 z-level limitation that had.
Code also includes tons of sanity checks and even a server config capping open space depth rendering for easier support of the infinite loop multi-z concept, if anyone even wants to try map it.