### PR TITLE
Fixed air alarm runtime

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1005,7 +1005,7 @@ var/global/list/airalarm_presets = list(
 				var/list/selected = TLV[env]
 				var/list/thresholds = list("lower bound", "low warning", "high warning", "upper bound")
 				var/newval = input("Enter [thresholds[threshold]] for [env]", "Alarm triggers", selected[threshold]) as num|null
-				if (isnull(newval) || ..() || !buttonCheck())
+				if (isnull(newval) || ..() || !buttonCheck(usr))
 					return 1
 				set_threshold(env, threshold, newval, 1)
 		return 1


### PR DESCRIPTION
```
[19:38:10] Runtime in alarm.dm, line 914: Cannot execute null.hasFullAccess().
proc name: buttonCheck (/obj/machinery/alarm/proc/buttonCheck)
usr: PPU (streptomutans) (/mob/living/silicon/robot/mommi/nt)
usr.loc: The floor (171, 231, 1) (/turf/simulated/floor)
src: the MoMMI Nest Air Alarm (/obj/machinery/alarm)
src.loc: the floor (171,233,1) (/turf/simulated/floor)
call stack:
the MoMMI Nest Air Alarm (/obj/machinery/alarm): buttonCheck(null)
the MoMMI Nest Air Alarm (/obj/machinery/alarm): Topic("src=\[0x210079e6];command=set_...", /list (/list))
/datum/nanoui (/datum/nanoui): Topic("src=\[0x210079e6];command=set_...", /list (/list))
StreptoMutans (/client): Topic("src=\[0x210079e6];command=set_...", /list (/list), /datum/nanoui (/datum/nanoui))
StreptoMutans (/client): Topic("src=\[0x210079e6];command=set_...", /list (/list), /datum/nanoui (/datum/nanoui))
```