### PR TITLE
Places surgery extracted items in hands on removal

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1770,7 +1770,7 @@ mob/living/carbon/human/isincrit()
 	return internal_organs_by_name["appendix"]
 
 //Moved from internal organ surgery
-//Removes organ from src, places organ object under user
+//Removes organ from src, places organ object in user's hands
 //example: H.remove_internal_organ(H,H.internal_organs_by_name["heart"],H.get_organ(LIMB_CHEST))
 /mob/living/carbon/human/remove_internal_organ(var/mob/living/user, var/datum/organ/internal/targetorgan, var/datum/organ/external/affectedarea)
 	var/obj/item/organ/internal/extractedorgan
@@ -1791,6 +1791,7 @@ mob/living/carbon/human/isincrit()
 			internal_organs -= extractedorgan.organ_data
 			affectedarea.internal_organs -= extractedorgan.organ_data
 			extractedorgan.removed(src,user)
+			user.put_in_hands(extractedorgan)
 
 			return extractedorgan
 

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -207,12 +207,14 @@
 		if(istype(obj,/obj/item/weapon/implant))
 			var/obj/item/weapon/implant/imp = obj
 			imp.remove(user)
+			user.put_in_hands(imp)
 		else
 			obj.forceMove(get_turf(target))
 	else if (affected.hidden)
 		user.visible_message("<span class='notice'>[user] takes something out of incision on [target]'s [affected.display_name] with \the [tool].</span>", \
 		"<span class='notice'>You take something out of incision on [target]'s [affected.display_name]s with \the [tool].</span>" )
 		affected.hidden.forceMove(get_turf(target))
+		user.put_in_hands(affected.hidden)
 		if(!affected.hidden.blood_DNA)
 			affected.hidden.blood_DNA = list()
 		affected.hidden.blood_DNA[target.dna.unique_enzymes] = target.dna.b_type


### PR DESCRIPTION
[qol][tweak]
:cl:
 * tweak: Surgery extracted internal items such as organs and implants now appear in the user's hands after being removed, if possible.