### PR TITLE
Map element (vault etc) updates: Item overwriting option, rotation on loading

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -180,6 +180,7 @@
 	var/skip_minimap_generation = 0 //If 1, don't generate minimaps
 	var/skip_holominimap_generation = 0 //If 1, don't generate holominimaps
 	var/skip_vault_generation = 0 //If 1, don't generate vaults
+	var/disable_vault_rotation = 0 //If 1, don't load vaults rotated
 	var/shut_up_automatic_diagnostic_and_announcement_system = 0 //If 1, don't play the vox sounds at the start of every shift.
 	var/no_lobby_music = 0 //If 1, don't play lobby music, regardless of client preferences.
 	var/no_ambience = 0 //If 1, don't play ambience, regardless of client preferences.
@@ -598,6 +599,8 @@
 					skip_holominimap_generation = 1
 				if("skip_vault_generation")
 					skip_vault_generation = 1
+				if("disable_vault_rotation")
+					disable_vault_rotation = 1
 				if("shut_up_automatic_diagnostic_and_announcement_system")
 					shut_up_automatic_diagnostic_and_announcement_system = 1
 				if("no_lobby_music")

--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -14,6 +14,7 @@ var/list/datum/map_element/map_elements = list()
 
 	var/width //Width of the map element, in turfs
 	var/height //Height of the map element, in turfs
+	var/can_rotate = TRUE //Can this be rotated?
 
 /datum/map_element/proc/pre_load() //Called before loading the element
 	return

--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -35,7 +35,7 @@ var/list/datum/map_element/map_elements = list()
 	for(var/atom/A in objects)
 		A.spawned_by_map_element(src, objects)
 
-/datum/map_element/proc/load(x, y, z)
+/datum/map_element/proc/load(x, y, z, rotate=0)
 	//Location is always lower left corner.
 	//In some cases, location is set to null (when creating a new z-level, for example)
 	//To account for that, location is set again in maploader's load_map() proc
@@ -49,7 +49,7 @@ var/list/datum/map_element/map_elements = list()
 	if(file_path)
 		var/file = file(file_path)
 		if(isfile(file))
-			var/list/L = maploader.load_map(file, z, x, y, src)
+			var/list/L = maploader.load_map(file, z, x, y, src, rotate)
 			initialize(L)
 			return L
 	else //No file specified - empty map element

--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -15,6 +15,7 @@ var/list/datum/map_element/map_elements = list()
 	var/width //Width of the map element, in turfs
 	var/height //Height of the map element, in turfs
 	var/can_rotate = TRUE //Can this be rotated?
+	var/rotation = 0 //The map's rotation value
 
 /datum/map_element/proc/pre_load() //Called before loading the element
 	return
@@ -51,6 +52,7 @@ var/list/datum/map_element/map_elements = list()
 		var/file = file(file_path)
 		if(isfile(file))
 			var/list/L = maploader.load_map(file, z, x, y, src, rotate)
+			rotation = rotate
 			initialize(L)
 			return L
 	else //No file specified - empty map element

--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -42,6 +42,7 @@ var/list/datum/map_element/map_elements = list()
 	//In some cases, location is set to null (when creating a new z-level, for example)
 	//To account for that, location is set again in maploader's load_map() proc
 	location = locate(x+1, y+1, z)
+	rotation = rotate
 
 	if(!can_load(x,y))
 		return 0
@@ -52,7 +53,6 @@ var/list/datum/map_element/map_elements = list()
 		var/file = file(file_path)
 		if(isfile(file))
 			var/list/L = maploader.load_map(file, z, x, y, src, rotate)
-			rotation = rotate
 			initialize(L)
 			return L
 	else //No file specified - empty map element

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1221,9 +1221,11 @@ var/list/admin_verbs_mod = list(
 	var/rotate = input(usr, "Set the rotation offset: (0, 90, 180 or 270) ", "Map element loading") as null|num
 	if(rotate == null)
 		return
+	var/overwrite = alert("Overwrite original objects in area?","Map element loading","Yes","No") == "Yes"
+
 	log_admin("[key_name(src)] is loading [ME.file_path] at [x_coord], [y_coord], [z_coord] rotated by [rotate] degrees")
 	message_admins("[key_name_admin(src)] is loading [ME.file_path] at [x_coord], [y_coord], [z_coord] rotated by [rotate] degrees")
-	ME.load(x_coord - 1, y_coord - 1, z_coord, rotate) //Reduce X and Y by 1 because these arguments are actually offsets, and they're added to 1;1 in the map loader. Without this, spawning something at 1;1 would result in it getting spawned at 2;2
+	ME.load(x_coord - 1, y_coord - 1, z_coord, rotate, overwrite) //Reduce X and Y by 1 because these arguments are actually offsets, and they're added to 1;1 in the map loader. Without this, spawning something at 1;1 would result in it getting spawned at 2;2
 	message_admins("[ME.file_path] loaded at [ME.location ? formatJumpTo(ME.location) : "[x_coord], [y_coord], [z_coord]"] rotated by [rotate] degrees")
 
 /client/proc/create_awaymission()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1218,10 +1218,13 @@ var/list/admin_verbs_mod = list(
 			return
 
 
-	log_admin("[key_name(src)] is loading [ME.file_path] at [x_coord], [y_coord], [z_coord]")
-	message_admins("[key_name_admin(src)] is loading [ME.file_path] at [x_coord], [y_coord], [z_coord]")
-	ME.load(x_coord - 1, y_coord - 1, z_coord) //Reduce X and Y by 1 because these arguments are actually offsets, and they're added to 1;1 in the map loader. Without this, spawning something at 1;1 would result in it getting spawned at 2;2
-	message_admins("[ME.file_path] loaded at [ME.location ? formatJumpTo(ME.location) : "[x_coord], [y_coord], [z_coord]"]")
+	var/rotate = input(usr, "Set the rotation offset: (0, 90, 180 or 270) ", "Map element loading") as null|num
+	if(rotate == null)
+		return
+	log_admin("[key_name(src)] is loading [ME.file_path] at [x_coord], [y_coord], [z_coord] rotated by [rotate] degrees")
+	message_admins("[key_name_admin(src)] is loading [ME.file_path] at [x_coord], [y_coord], [z_coord] rotated by [rotate] degrees")
+	ME.load(x_coord - 1, y_coord - 1, z_coord, rotate) //Reduce X and Y by 1 because these arguments are actually offsets, and they're added to 1;1 in the map loader. Without this, spawning something at 1;1 would result in it getting spawned at 2;2
+	message_admins("[ME.file_path] loaded at [ME.location ? formatJumpTo(ME.location) : "[x_coord], [y_coord], [z_coord]"] rotated by [rotate] degrees")
 
 /client/proc/create_awaymission()
 	set category = "Admin"

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -126,7 +126,7 @@
 		var/list/vaults = list()
 
 		for(var/datum/map_element/V in map_elements)
-			var/name = "[V.type_abbreviation] [V.name ? V.name : V.file_path] @ [V.location ? "[V.location.x],[V.location.y],[V.location.z]" : "UNKNOWN"]"
+			var/name = "[V.type_abbreviation] [V.name ? V.name : V.file_path] @ [V.location ? "[V.location.x],[V.location.y],[V.location.z][V.rotation ? " (rotated by [V.rotation] degrees)" : ""]" : "UNKNOWN"]"
 
 			vaults[name] = V
 

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -60,6 +60,9 @@ var/list/map_dimension_cache = list()
 /dmm_suite/load_map(var/dmm_file as file, var/z_offset as num, var/x_offset as num, var/y_offset as num, var/datum/map_element/map_element as null, var/rotate as num)
 	if((rotate % 90) != 0) //If not divisible by 90, make it
 		rotate += (rotate % 90)
+
+	if(!map_element.can_rotate) //Abort rotation if disabled on map element
+		rotate = 0
 	
 	if(!z_offset)//what z_level we are creating the map on
 		z_offset = world.maxz+1

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -173,11 +173,11 @@ var/list/map_dimension_cache = list()
 					if(0)
 						spawned_atoms |= parse_grid(grid_models[model_key],xcrd,ycrd,zcrd+z_offset,rotate,overwrite)
 					if(90)
-						spawned_atoms |= parse_grid(grid_models[model_key],ycrd_flip_rotate,xcrd_rotate,zcrd+z_offset,rotate,overwrite)
+						spawned_atoms |= parse_grid(grid_models[model_key],ycrd_rotate,xcrd_flip_rotate,zcrd+z_offset,rotate,overwrite)
 					if(180)
 						spawned_atoms |= parse_grid(grid_models[model_key],xcrd_flip,ycrd_flip,zcrd+z_offset,rotate,overwrite)
 					if(270)
-						spawned_atoms |= parse_grid(grid_models[model_key],ycrd_rotate,xcrd_flip_rotate,zcrd+z_offset,rotate,overwrite)
+						spawned_atoms |= parse_grid(grid_models[model_key],ycrd_flip_rotate,xcrd_rotate,zcrd+z_offset,rotate,overwrite)
 				if (remove_lag)
 					CHECK_TICK
 			if(map_element)
@@ -367,10 +367,8 @@ var/list/map_dimension_cache = list()
 		_preloader.load(instance)
 
 	// Stolen from shuttlecode but very good to reuse here
-	if(rotate == 180)
+	if(rotate)
 		instance.shuttle_rotate(rotate)
-	else if(rotate == 90 || rotate == 270)
-		instance.shuttle_rotate((rotate + 180) % 360)
 
 	return instance
 

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -363,8 +363,10 @@ var/list/map_dimension_cache = list()
 		_preloader.load(instance)
 
 	// Stolen from shuttlecode but very good to reuse here
-	if(rotate)
+	if(rotate == 180)
 		instance.shuttle_rotate(rotate)
+	else if(rotate == 90 || rotate == 270)
+		instance.shuttle_rotate((rotate + 180) % 360)
 
 	return instance
 

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -57,7 +57,7 @@ var/list/map_dimension_cache = list()
  * A list of all atoms created
  *
  */
-/dmm_suite/load_map(var/dmm_file as file, var/z_offset as num, var/x_offset as num, var/y_offset as num, var/datum/map_element/map_element as null, var/rotate as num)
+/dmm_suite/load_map(var/dmm_file as file, var/z_offset as num, var/x_offset as num, var/y_offset as num, var/datum/map_element/map_element as null, var/rotate as num, var/overwrite = FALSE)
 	if((rotate % 90) != 0) //If not divisible by 90, make it
 		rotate += (rotate % 90)
 
@@ -171,13 +171,13 @@ var/list/map_dimension_cache = list()
 				var/model_key = copytext(grid_line,mpos,mpos+key_len)
 				switch(rotate)
 					if(0)
-						spawned_atoms |= parse_grid(grid_models[model_key],xcrd,ycrd,zcrd+z_offset,rotate)
+						spawned_atoms |= parse_grid(grid_models[model_key],xcrd,ycrd,zcrd+z_offset,rotate,overwrite)
 					if(90)
-						spawned_atoms |= parse_grid(grid_models[model_key],ycrd_flip_rotate,xcrd_rotate,zcrd+z_offset,rotate)
+						spawned_atoms |= parse_grid(grid_models[model_key],ycrd_flip_rotate,xcrd_rotate,zcrd+z_offset,rotate,overwrite)
 					if(180)
-						spawned_atoms |= parse_grid(grid_models[model_key],xcrd_flip,ycrd_flip,zcrd+z_offset,rotate)
+						spawned_atoms |= parse_grid(grid_models[model_key],xcrd_flip,ycrd_flip,zcrd+z_offset,rotate,overwrite)
 					if(270)
-						spawned_atoms |= parse_grid(grid_models[model_key],ycrd_rotate,xcrd_flip_rotate,zcrd+z_offset,rotate)
+						spawned_atoms |= parse_grid(grid_models[model_key],ycrd_rotate,xcrd_flip_rotate,zcrd+z_offset,rotate,overwrite)
 				if (remove_lag)
 					CHECK_TICK
 			if(map_element)
@@ -232,7 +232,7 @@ var/list/map_dimension_cache = list()
  * A list with all spawned atoms
  *
  */
-/dmm_suite/proc/parse_grid(var/model as text,var/xcrd as num,var/ycrd as num,var/zcrd as num,var/rotate as num)
+/dmm_suite/proc/parse_grid(var/model as text,var/xcrd as num,var/ycrd as num,var/zcrd as num,var/rotate as num,var/overwrite = FALSE)
 	/*Method parse_grid()
 	- Accepts a text string containing a comma separated list of type paths of the
 		same construction as those contained in a .dmm file, and instantiates them.
@@ -335,6 +335,10 @@ var/list/map_dimension_cache = list()
 	spawned_atoms.Add(T)
 
 	//finally instance all remainings objects/mobs
+	if(overwrite)
+		var/turf/T_old = locate(xcrd,ycrd,zcrd)
+		for(var/atom/thing in T_old)
+			qdel(T_old)
 	for(index=1,index < first_turf_index,index++)
 		var/atom/new_atom = instance_atom(members[index],members_attributes[index],xcrd,ycrd,zcrd,rotate)
 		spawned_atoms.Add(new_atom)

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -108,8 +108,12 @@ var/list/map_dimension_cache = list()
 	var/zcrd=-1
 	var/ycrd=x_offset
 	var/xcrd=y_offset
+	var/ycrd_rotate=x_offset
+	var/xcrd_rotate=y_offset
 	var/ycrd_flip=x_offset
 	var/xcrd_flip=y_offset
+	var/ycrd_flip_rotate=y_offset
+	var/xcrd_flip_rotate=x_offset
 
 	for(var/zpos=findtext(tfile,"\n(1,1,",lpos,0);zpos!=0;zpos=findtext(tfile,"\n(1,1,",zpos+1,0))	//in case there's several maps to load
 
@@ -144,27 +148,33 @@ var/list/map_dimension_cache = list()
 
 		//then proceed it line by line, starting from top
 		ycrd = y_offset + y_depth
+		ycrd_rotate = x_offset + map_width
 		ycrd_flip = y_offset
+		ycrd_flip_rotate = x_offset
 
 		for(var/gpos=1;gpos!=0;gpos=findtext(zgrid,"\n",gpos,0)+1)
 			var/grid_line = copytext(zgrid,gpos,findtext(zgrid,"\n",gpos,0))
 
 			//fill the current square using the model map
 			xcrd=x_offset
+			xcrd_rotate=y_offset
 			xcrd_flip=x_offset + map_width
+			xcrd_flip_rotate=y_offset + map_width
 			for(var/mpos=1;mpos<=x_depth;mpos+=key_len)
 				xcrd++
+				xcrd_rotate++
 				xcrd_flip--
+				xcrd_flip_rotate--
 				var/model_key = copytext(grid_line,mpos,mpos+key_len)
 				switch(rotate)
 					if(0)
 						spawned_atoms |= parse_grid(grid_models[model_key],xcrd,ycrd,zcrd+z_offset,rotate)
 					if(90)
-						spawned_atoms |= parse_grid(grid_models[model_key],ycrd_flip,xcrd,zcrd+z_offset,rotate)
+						spawned_atoms |= parse_grid(grid_models[model_key],ycrd_flip_rotate,xcrd_rotate,zcrd+z_offset,rotate)
 					if(180)
 						spawned_atoms |= parse_grid(grid_models[model_key],xcrd_flip,ycrd_flip,zcrd+z_offset,rotate)
 					if(270)
-						spawned_atoms |= parse_grid(grid_models[model_key],ycrd,xcrd_flip,zcrd+z_offset,rotate)
+						spawned_atoms |= parse_grid(grid_models[model_key],ycrd_rotate,xcrd_flip_rotate,zcrd+z_offset,rotate)
 				if (remove_lag)
 					CHECK_TICK
 			if(map_element)
@@ -175,7 +185,9 @@ var/list/map_dimension_cache = list()
 				break
 
 			ycrd--
+			ycrd_rotate--
 			ycrd_flip++
+			ycrd_flip_rotate++
 
 			if(remove_lag)
 				CHECK_TICK

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -152,8 +152,8 @@ var/list/map_dimension_cache = list()
 		//then proceed it line by line, starting from top
 		ycrd = y_offset + y_depth
 		ycrd_rotate = x_offset + map_width
-		ycrd_flip = y_offset
-		ycrd_flip_rotate = x_offset
+		ycrd_flip = y_offset + 1
+		ycrd_flip_rotate = x_offset + 1
 
 		for(var/gpos=1;gpos!=0;gpos=findtext(zgrid,"\n",gpos,0)+1)
 			var/grid_line = copytext(zgrid,gpos,findtext(zgrid,"\n",gpos,0))
@@ -161,8 +161,8 @@ var/list/map_dimension_cache = list()
 			//fill the current square using the model map
 			xcrd=x_offset
 			xcrd_rotate=y_offset
-			xcrd_flip=x_offset + map_width
-			xcrd_flip_rotate=y_offset + map_width
+			xcrd_flip=x_offset + map_width + 1
+			xcrd_flip_rotate=y_offset + map_width + 1
 			for(var/mpos=1;mpos<=x_depth;mpos+=key_len)
 				xcrd++
 				xcrd_rotate++

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -124,8 +124,8 @@ var/list/map_dimension_cache = list()
 		var/y_depth = z_depth / (x_depth+1) //x_depth + 1 because we're counting the '\n' characters in z_depth
 		var/map_width = x_depth / key_len //To get the map's width, divide the length of the line by the length of the key
 
-		var/x_check = rotate == 0 || rotate == 180 ? map_width + x_offset : map_width + x_offset
-		var/y_check = rotate == 0 || rotate == 180 ? y_depth + y_offset : y_depth + y_offset
+		var/x_check = rotate == 0 || rotate == 180 ? map_width + x_offset : y_depth + y_offset
+		var/y_check = rotate == 0 || rotate == 180 ? y_depth + y_offset : map_width + x_offset
 		if(world.maxx < x_check)
 			if(!map.can_enlarge)
 				WARNING("Cancelled load of [map_element] due to map bounds.")
@@ -157,9 +157,9 @@ var/list/map_dimension_cache = list()
 					if(90)
 						spawned_atoms |= parse_grid(grid_models[model_key],y_depth-ycrd,xcrd,zcrd+z_offset,rotate)
 					if(180)
-						spawned_atoms |= parse_grid(grid_models[model_key],x_depth-xcrd,y_depth-ycrd,zcrd+z_offset,rotate)
+						spawned_atoms |= parse_grid(grid_models[model_key],map_width-xcrd,y_depth-ycrd,zcrd+z_offset,rotate)
 					if(270)
-						spawned_atoms |= parse_grid(grid_models[model_key],ycrd,x_depth-xcrd,zcrd+z_offset,rotate)
+						spawned_atoms |= parse_grid(grid_models[model_key],ycrd,map_width-xcrd,zcrd+z_offset,rotate)
 				if (remove_lag)
 					CHECK_TICK
 			if(map_element)

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -57,7 +57,7 @@ var/list/map_dimension_cache = list()
  * A list of all atoms created
  *
  */
-/dmm_suite/load_map(var/dmm_file as file, var/z_offset as num, var/x_offset as num, var/y_offset as num, var/datum/map_element/map_element as null, var/rotate as num, var/overwrite = FALSE)
+/dmm_suite/load_map(var/dmm_file as file, var/z_offset as num, var/x_offset as num, var/y_offset as num, var/datum/map_element/map_element as null, var/rotate as num, var/overwrite as num)
 	if((rotate % 90) != 0) //If not divisible by 90, make it
 		rotate += (rotate % 90)
 
@@ -232,7 +232,7 @@ var/list/map_dimension_cache = list()
  * A list with all spawned atoms
  *
  */
-/dmm_suite/proc/parse_grid(var/model as text,var/xcrd as num,var/ycrd as num,var/zcrd as num,var/rotate as num,var/overwrite = FALSE)
+/dmm_suite/proc/parse_grid(var/model as text,var/xcrd as num,var/ycrd as num,var/zcrd as num,var/rotate as num,var/overwrite as num)
 	/*Method parse_grid()
 	- Accepts a text string containing a comma separated list of type paths of the
 		same construction as those contained in a .dmm file, and instantiates them.

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -363,12 +363,12 @@ var/list/map_dimension_cache = list()
 	else
 		instance = new path (locate(x,y,z))//first preloader pass
 
-	if(_preloader && instance)//second preloader pass, for those atoms that don't ..() in New()
-		_preloader.load(instance)
-
 	// Stolen from shuttlecode but very good to reuse here
 	if(rotate)
 		instance.shuttle_rotate(rotate)
+
+	if(_preloader && instance)//second preloader pass, for those atoms that don't ..() in New()
+		_preloader.load(instance)
 
 	return instance
 

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -364,7 +364,7 @@ var/list/map_dimension_cache = list()
 		instance = new path (locate(x,y,z))//first preloader pass
 
 	// Stolen from shuttlecode but very good to reuse here
-	if(rotate)
+	if(rotate && instance)
 		instance.shuttle_rotate(rotate)
 
 	if(_preloader && instance)//second preloader pass, for those atoms that don't ..() in New()

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -151,7 +151,7 @@ var/list/map_dimension_cache = list()
 
 			//fill the current square using the model map
 			xcrd=x_offset
-			xcrd_flip + x_offset + map_width
+			xcrd_flip=x_offset + map_width
 			for(var/mpos=1;mpos<=x_depth;mpos+=key_len)
 				xcrd++
 				xcrd_flip--

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -320,7 +320,7 @@ var/list/map_dimension_cache = list()
 		last_turf_index++
 
 	//instanciate the last /turf
-	var/turf/T = instance_atom(members[last_turf_index],members_attributes[last_turf_index],xcrd,ycrd,zcrd)
+	var/turf/T = instance_atom(members[last_turf_index],members_attributes[last_turf_index],xcrd,ycrd,zcrd,rotate)
 
 	if(first_turf_index != last_turf_index) //More than one turf is present - go from the lowest turf to the turf before the last one
 		var/turf_index = first_turf_index

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -108,6 +108,8 @@ var/list/map_dimension_cache = list()
 	var/zcrd=-1
 	var/ycrd=x_offset
 	var/xcrd=y_offset
+	var/ycrd_flip=x_offset
+	var/xcrd_flip=y_offset
 
 	for(var/zpos=findtext(tfile,"\n(1,1,",lpos,0);zpos!=0;zpos=findtext(tfile,"\n(1,1,",zpos+1,0))	//in case there's several maps to load
 
@@ -142,24 +144,27 @@ var/list/map_dimension_cache = list()
 
 		//then proceed it line by line, starting from top
 		ycrd = y_offset + y_depth
+		ycrd_flip = y_offset
 
 		for(var/gpos=1;gpos!=0;gpos=findtext(zgrid,"\n",gpos,0)+1)
 			var/grid_line = copytext(zgrid,gpos,findtext(zgrid,"\n",gpos,0))
 
 			//fill the current square using the model map
 			xcrd=x_offset
+			xcrd_flip + x_offset + map_width
 			for(var/mpos=1;mpos<=x_depth;mpos+=key_len)
 				xcrd++
+				xcrd_flip--
 				var/model_key = copytext(grid_line,mpos,mpos+key_len)
 				switch(rotate)
 					if(0)
 						spawned_atoms |= parse_grid(grid_models[model_key],xcrd,ycrd,zcrd+z_offset,rotate)
 					if(90)
-						spawned_atoms |= parse_grid(grid_models[model_key],y_depth-ycrd,xcrd,zcrd+z_offset,rotate)
+						spawned_atoms |= parse_grid(grid_models[model_key],ycrd_flip,xcrd,zcrd+z_offset,rotate)
 					if(180)
-						spawned_atoms |= parse_grid(grid_models[model_key],map_width-xcrd,y_depth-ycrd,zcrd+z_offset,rotate)
+						spawned_atoms |= parse_grid(grid_models[model_key],xcrd_flip,ycrd_flip,zcrd+z_offset,rotate)
 					if(270)
-						spawned_atoms |= parse_grid(grid_models[model_key],ycrd,map_width-xcrd,zcrd+z_offset,rotate)
+						spawned_atoms |= parse_grid(grid_models[model_key],ycrd,xcrd_flip,zcrd+z_offset,rotate)
 				if (remove_lag)
 					CHECK_TICK
 			if(map_element)
@@ -170,6 +175,7 @@ var/list/map_dimension_cache = list()
 				break
 
 			ycrd--
+			ycrd_flip++
 
 			if(remove_lag)
 				CHECK_TICK

--- a/code/modules/randomMaps/dungeons.dm
+++ b/code/modules/randomMaps/dungeons.dm
@@ -45,7 +45,7 @@ var/turf/dungeon_area = null
 
 #define MAXIMUM_DUNGEON_WIDTH 80
 
-proc/load_dungeon(dungeon_type)
+proc/load_dungeon(dungeon_type, var/rotate = 0)
 	if(!dungeon_area)
 		return 0
 
@@ -96,6 +96,6 @@ proc/load_dungeon(dungeon_type)
 	existing_dungeons.Add(ME) //Add it now, to prevent issues occuring when two dungeons are loaded at once
 
 	//Reduce X and Y by 1 because these arguments are actually offsets, and they're added to 1;1 in the map loader. Without this, spawning something at 1;1 would result in it getting spawned at 2;2
-	var/result = ME.load(spawn_x - 1, spawn_y - 1, dungeon_area.z)
+	var/result = ME.load(spawn_x - 1, spawn_y - 1, dungeon_area.z, rotate)
 
 	return result

--- a/code/modules/randomMaps/vault_definitions.dm
+++ b/code/modules/randomMaps/vault_definitions.dm
@@ -106,10 +106,8 @@ var/list/existing_vaults = list()
 /datum/map_element/vault/spacepond
 	file_path = "maps/randomvaults/spacepond.dmm"
 
-/datum/map_element/vault/spacepond/initialize(list/objects)
-	..()
-
-	load_dungeon(/datum/map_element/dungeon/wine_cellar)
+/datum/map_element/vault/spacepond/pre_load()
+	load_dungeon(/datum/map_element/dungeon/wine_cellar,rotation)
 
 /datum/map_element/dungeon/wine_cellar
 	file_path = "maps/randomvaults/dungeons/wine_cellar.dmm"
@@ -139,7 +137,7 @@ var/list/existing_vaults = list()
 	file_path = "maps/randomvaults/prison_ship.dmm"
 
 /datum/map_element/vault/prison/pre_load()
-	load_dungeon(/datum/map_element/dungeon/prison)
+	load_dungeon(/datum/map_element/dungeon/prison,rotation)
 
 /datum/map_element/dungeon/prison
 	file_path = "maps/randomvaults/dungeons/prison.dmm"
@@ -190,7 +188,7 @@ var/list/existing_vaults = list()
 	file_path = "maps/randomvaults/spy_satellite.dmm"
 
 /datum/map_element/vault/spy_sat/pre_load()
-	load_dungeon(/datum/map_element/dungeon/satellite_deployment)
+	load_dungeon(/datum/map_element/dungeon/satellite_deployment,rotation)
 
 /datum/map_element/dungeon/satellite_deployment
 	file_path = "maps/randomvaults/dungeons/satellite_deployment.dmm"

--- a/code/modules/randomMaps/vaults.dm
+++ b/code/modules/randomMaps/vaults.dm
@@ -202,16 +202,18 @@
 		var/vault_x = new_spawn_point.x
 		var/vault_y = new_spawn_point.y
 		var/vault_z = new_spawn_point.z
+		var/vault_rotate = config.disable_vault_rotation ? 0 : pick(0,90,180,270)
 
 		if(population_density == POPULATION_SCARCE)
 			var/turf/t1 = locate(max(1, vault_x - MAX_VAULT_WIDTH - 1), max(1, vault_y - MAX_VAULT_HEIGHT - 1), vault_z)
 			var/turf/t2 = locate(vault_x + new_width, vault_y + new_height, vault_z)
 			valid_spawn_points.Remove(block(t1, t2))
 
-		if(ME.load(vault_x, vault_y, vault_z))
+		if(ME.load(vault_x, vault_y, vault_z, vault_rotate))
 			spawned.Add(ME)
-			message_admins("<span class='info'>Loaded [ME.file_path]: [formatJumpTo(locate(vault_x, vault_y, vault_z))].")
-
+			message_admins("<span class='info'>Loaded [ME.file_path]: [formatJumpTo(locate(vault_x, vault_y, vault_z))] [config.disable_vault_rotation ? "" : ", rotated by [vault_rotate] degrees"].")
+			if(config.disable_vault_rotation)
+				message_admins("<span class='info'>[ME.file_path] was not rotated, DISABLE_VAULT_ROTATION enabled in config.</span>")
 			successes++
 			if(amount > 0)
 				amount--

--- a/config-example/config.txt
+++ b/config-example/config.txt
@@ -313,6 +313,10 @@ SKIP_HOLOMINIMAP_GENERATION
 ## Uncomment to disable generation of vaults (makes the server start faster!)
 SKIP_VAULT_GENERATION
 
+## DISABLE_VAULT_ROTATION
+## Uncomment to disable rotation of vaults
+#DISABLE_VAULT_ROTATION
+
 ## SHUT_UP_AUTOMATIC_DIAGNOSTIC_AND_ANNOUNCEMENT_SYSTEM
 ## Uncomment to disable the lovely robotic voice that tells you the time at the start of every shift.
 ## Recommended for your sanity if you start the server a lot for testing things.

--- a/maps/randomvaults/sokoban.dm
+++ b/maps/randomvaults/sokoban.dm
@@ -49,7 +49,7 @@
 		SL.file_path = pick_n_take(src.available_levels) //No duplicate levels
 		SL.parent = src
 
-		load_dungeon(SL)
+		load_dungeon(SL,rotation)
 		loaded_levels.Add(SL)
 
 	//Load ending


### PR DESCRIPTION
[vault][tested]
Examples below with hobo shack map element: (rotated 90, 180 and 270 degrees)
![image](https://user-images.githubusercontent.com/57303506/135492942-eedf0460-605a-448a-99fb-fe949dd8c60c.png)
![image](https://user-images.githubusercontent.com/57303506/135493128-db92da22-946c-4c3e-8071-6a091670cff4.png)
![image](https://user-images.githubusercontent.com/57303506/135493168-e914354d-3d08-4f6b-b092-877951bcccaa.png)
Item overwriting as an option means all movable atoms are deleted when a vault is loaded over them. It's currently only doable with custom map element loading.
:cl:
 * rscadd: Vaults, mining suprises and other elements of exploration can now be found rotated in any orientation