### PR TITLE
Removes Sec Access from Custom Secways

### DIFF
--- a/code/game/objects/structures/vehicles/secway.dm
+++ b/code/game/objects/structures/vehicles/secway.dm
@@ -197,7 +197,6 @@ var/list/descriptive_sprites = list("I go for the classics", "A big donut", "A R
 	desc = "An elite secway, lovingly crafted by a security member."
 	icon_state = "secway-custom-classic"
 	keytype = /obj/item/key/security/spare
-	req_access = list(63)
 	health = 200
 	max_health = 200
 	var/knockdown_time = 1


### PR DESCRIPTION
I wanna ride the fun scooter. The secoffs cannot confiscate all my fun, I refuse!
The sec access isn't even communicated well. It seemed more like a bug, I had to code dive just to find out what was going on. Would make more sense to come in a lockbox that requires sec access rather than just refusing to move without it. 
[tweak]

:cl:
 * tweak: Custom secways no longer require sec access to move