### PR TITLE
Allows players to un-bloody fountain pens

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -595,6 +595,14 @@
 				"<span class='warning'>You have wet \the [O.name], it shocks you!</span>")
 			return
 
+	else if (istype(O, /obj/item/weapon/pen/fountain))
+		..()
+		var/obj/item/weapon/pen/fountain/P = O
+		if (P.bloodied)
+			to_chat(user, "<span class='notice'>You clean the blood out of the nib of \the [P].</span>")
+			P.colour = "black"
+			P.bloodied = FALSE
+
 	if (!isturf(user.loc))
 		return
 
@@ -607,8 +615,9 @@
 			if(O.current_glue_state == GLUE_STATE_TEMP)
 				O.unglue()
 			user.visible_message( \
-				"<span class='notice'>[user] washes \a [O] using \the [src].</span>", \
-				"<span class='notice'>You wash \a [O] using \the [src].</span>")
+				"<span class='notice'>[user] washes \the [O] using \the [src].</span>", \
+				"<span class='notice'>You wash \the [O] using \the [src].</span>")
+			..()
 
 		busy = FALSE
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -333,8 +333,26 @@ var/paperwork_library
 	throwforce = 5
 	attack_verb = list("stabs")
 	style_type = /datum/writing_style/script
+	var/bloodied = null
+
+/obj/item/weapon/pen/fountain/examine(mob/user)
+	. = ..()
+	if(bloodied)
+		to_chat(user, "<span class='info'>The nib is dripping with a viscous substance.</span>")
+
+/obj/item/weapon/pen/fountain/afterattack(obj/reagentholder, mob/user as mob)
+	..()
+	if(!bloodied)
+		return
+	if(reagentholder.is_open_container() && !ismob(reagentholder) && reagentholder.reagents)
+		if(reagentholder.reagents.has_only_any(list(WATER,CLEANER,BLEACH))) //cannot contain any reagent except water bleach or cleaner
+			to_chat(user, "<span class='notice'>You dip \the [src] into \the [reagentholder], cleaning out the nib.</span>")
+			bloodied = FALSE
+			colour = "black"
 
 /obj/item/weapon/pen/fountain/cap
+	name = "captain's fountain pen"
+	desc = "A fancy fountain pen, for when you really want to impress. This one comes in a commanding navy and gold. The nib is quite sharp."
 	icon_state = "pen_fountain_cap"
 
 /obj/item/weapon/pen/tactical
@@ -349,12 +367,14 @@ var/paperwork_library
 
 /obj/item/weapon/pen/tactical/is_screwdriver(mob/user)
 	return TRUE
+
 /obj/item/weapon/pen/attack(mob/M as mob, mob/user as mob)
 	if(istype(src, /obj/item/weapon/pen/fountain))
+		var/obj/item/weapon/pen/fountain/P = src
 		if(user.zone_sel.selecting == "eyes" || user.zone_sel.selecting == LIMB_HEAD)
 			if(!istype(M))
 				return ..()
-			if(can_operate(M, user, src))
+			if(can_operate(M, user, P))
 				return ..()
 			if(clumsy_check(user) && prob(50))
 				M = user
@@ -363,7 +383,8 @@ var/paperwork_library
 		var/mob/living/carbon/human/H = M
 		var/datum/reagent/blood/B = get_blood(H.vessel)
 		if(B)
-			colour = B.data["blood_colour"]
+			P.bloodied = TRUE
+			P.colour = B.data["blood_colour"]
 
 	if(!ismob(M))
 		return

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -345,7 +345,7 @@ var/paperwork_library
 	if(!bloodied)
 		return
 	if(reagentholder.is_open_container() && !ismob(reagentholder) && reagentholder.reagents)
-		if(reagentholder.reagents.has_only_any(list(WATER,CLEANER,BLEACH))) //cannot contain any reagent except water bleach or cleaner
+		if(reagentholder.reagents.has_only_any(list(WATER,CLEANER,BLEACH,ETHANOL))) //cannot contain any reagent outside of this list, but can contain the list in any proportion
 			to_chat(user, "<span class='notice'>You dip \the [src] into \the [reagentholder], cleaning out the nib.</span>")
 			bloodied = FALSE
 			colour = "black"

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -345,7 +345,7 @@ var/paperwork_library
 	if(!bloodied)
 		return
 	if(reagentholder.is_open_container() && !ismob(reagentholder) && reagentholder.reagents)
-		if(reagentholder.reagents.has_only_any(list(WATER,CLEANER,BLEACH,ETHANOL))) //cannot contain any reagent outside of this list, but can contain the list in any proportion
+		if(reagentholder.reagents.has_only_any(list(WATER,CLEANER,BLEACH,ETHANOL, HOLYWATER))) //cannot contain any reagent outside of this list, but can contain the list in any proportion
 			to_chat(user, "<span class='notice'>You dip \the [src] into \the [reagentholder], cleaning out the nib.</span>")
 			bloodied = FALSE
 			colour = "black"

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -725,6 +725,14 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 		return amount_cache[reagent] >= max(0,amount)
 	return 0
 
+/datum/reagents/proc/has_only_any(list/good_reagents)
+    var/found_any_good_reagent = FALSE
+    for(var/reagent in amount_cache)
+        if(!good_reagents.Find(reagent))
+            return FALSE
+        found_any_good_reagent = TRUE
+    return found_any_good_reagent
+
 /datum/reagents/proc/has_reagent_type(var/reagent_type, var/amount = -1, var/strict = 0)
 	if(!ispath(reagent_type,/datum/reagent))
 		return 0

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -91,6 +91,10 @@
 
 /obj/item/weapon/reagent_containers/glass/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/pen) || istype(W, /obj/item/device/flashlight/pen))
+		if(istype(W, /obj/item/weapon/pen/fountain))
+			var/obj/item/weapon/pen/fountain/P = W
+			if(P.bloodied)
+				..()
 		set_tiny_label(user)
 	attempt_heating(W, user)
 


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
Bloodied fountain pens can now be restored to their default black text color by running them under a sink or dipping them in a beaker containing water, ethanol, space cleaner, or bleach, and no other reagents besides those.

Also adds a proc to reagents, has_only_any(), that accepts a list as an argument and returns true if a container contains any reagent from that list and no reagents outside of it.

:cl:
 * rscadd: Fountain pens can now be restored to black ink with a sink or a beaker containing only water, ethanol, cleaner, or bleach.