### PR TITLE
Fixed dojo and time agent's place being dark

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -177,7 +177,7 @@ proc/process_adminbus_teleport_locs()
 	name = "\improper Spider Clan Dojo"
 	icon_state = "dojo"
 	requires_power = 0
-	dynamic_lighting = 1
+	dynamic_lighting = FALSE
 	shuttle_can_crush = FALSE
 	flags = NO_PERSISTENCE
 
@@ -185,7 +185,7 @@ proc/process_adminbus_teleport_locs()
 	name = "\improper Void Between Timelines"
 	icon_state = "time_void"
 	requires_power = 0
-	dynamic_lighting = 1
+	dynamic_lighting = FALSE
 	shuttle_can_crush = FALSE
 	flags = NO_PERSISTENCE
 


### PR DESCRIPTION
Fixes #30988
Fixes #30825

:cl:
 * bugfix: The ninja dojo and the time agent's void are no longer shrouded in darkness