### PR TITLE
Fixed examining worn items as a ghost showing the examined item twice

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -605,8 +605,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		else
 			to_chat(usr, "That arena doesn't seem to exist anymore.")
 
-	..()
-
 //END TELEPORT HREF CODE
 
 /mob/dead/observer/html_mob_check()


### PR DESCRIPTION
Fixes #22426
Fixes #24155

:cl:
 * bugfix: Examining a worn item as a ghost will no longer show it twice.