### PR TITLE
Trader medical crate item: Suit sensing wand

### DIFF
--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -634,6 +634,25 @@ var/global/list/alcatraz_stuff = list(
 	playsound(user, 'sound/items/healthanalyzer.ogg', 50, 1)
 	to_chat(user,"<span class='info'>Pocket Scan Results:<BR>Left: [H.l_store ? H.l_store : "empty"]<BR>Right: [H.r_store ? H.r_store : "empty"]</span>")
 
+/obj/item/weapon/suit_wand
+	name = "suit sensing wand"
+	desc = "Used by medical staff to ensure compliance with vitals tracking regulations."
+	icon_state = "telebaton_1"
+	item_state = "telebaton_1"
+	w_class = W_CLASS_SMALL
+
+/obj/item/weapon/suit_wand/attack(mob/living/M, mob/living/user)
+
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.handcuffed || H.is_wearing_item(/obj/item/clothing/suit/straight_jacket, slot_wear_suit))
+			H.toggle_sensors(H,user)
+		else
+			user.visible_message("<span class='danger'>[user] begins waving \the [src] over [M].</span>","<span class='danger'>You begin waving \the [src] over [M].</span>")
+			if(do_after(user,H, 2 SECONDS))
+				H.toggle_sensors(user)
+	else
+		..()
 
 
 #define VAMP_FLASH_CD 50
@@ -835,6 +854,8 @@ var/global/list/alcatraz_stuff = list(
 	has_lock_type = null
 
 var/global/list/yantar_stuff = list(
+	//3 of a kind
+	/obj/item/weapon/suit_wand,/obj/item/weapon/suit_wand,/obj/item/weapon/suit_wand,
 	//1 of a kind
 	/obj/item/weapon/storage/trader_chemistry,
 	/obj/structure/closet/crate/flatpack/ancient/chemmaster_electrolyzer,

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -648,13 +648,13 @@ var/global/list/alcatraz_stuff = list(
 
 	switch(wand_mode)
 		if(0)
-			to_chat(user, "<span class='notice'>The [src] will now disable suit remote sensing equipment.</span>")
+			to_chat(user, "<span class='notice'>\The [src] will now disable suit remote sensing equipment.</span>")
 		if(1)
-			to_chat(user, "<span class='notice'>The [src] will now make suits report whether the wearer is live or dead.</span>")
+			to_chat(user, "<span class='notice'>\The [src] will now make suits report whether the wearer is live or dead.</span>")
 		if(2)
-			to_chat(user, "<span class='notice'>The [src] will now make suits report vital lifesigns.</span>")
+			to_chat(user, "<span class='notice'>\The [src] will now make suits report vital lifesigns.</span>")
 		if(3)
-			to_chat(user, "<span class='notice'>The [src] will now make suits report vital lifesigns as well as coordinate positions.</span>")
+			to_chat(user, "<span class='notice'>\The [src] will now make suits report vital lifesigns as well as coordinate positions.</span>")
 
 /obj/item/weapon/depocket_wand/suit/scan(mob/living/carbon/human/H, mob/living/user)
 	var/obj/item/clothing/under/suit = H.w_uniform

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -634,25 +634,56 @@ var/global/list/alcatraz_stuff = list(
 	playsound(user, 'sound/items/healthanalyzer.ogg', 50, 1)
 	to_chat(user,"<span class='info'>Pocket Scan Results:<BR>Left: [H.l_store ? H.l_store : "empty"]<BR>Right: [H.r_store ? H.r_store : "empty"]</span>")
 
-/obj/item/weapon/suit_wand
+/obj/item/weapon/depocket_wand/suit
 	name = "suit sensing wand"
 	desc = "Used by medical staff to ensure compliance with vitals tracking regulations."
-	icon_state = "telebaton_1"
-	item_state = "telebaton_1"
-	w_class = W_CLASS_SMALL
+	var/wand_mode = 3
 
-/obj/item/weapon/suit_wand/attack(mob/living/M, mob/living/user)
+/obj/item/weapon/depocket_wand/suit/attack_self(mob/user)
+	var/list/modes = list("Off", "Binary sensors", "Vitals tracker", "Tracking beacon")
+	var/switchMode = input("Select a sensor mode:", "Suit Sensor Mode", modes[sensor_mode + 1]) in modes
+	if(user.incapacitated())
+		return
+	wand_mode = modes.Find(switchMode) - 1
 
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(H.handcuffed || H.is_wearing_item(/obj/item/clothing/suit/straight_jacket, slot_wear_suit))
-			H.toggle_sensors(H,user)
-		else
-			user.visible_message("<span class='danger'>[user] begins waving \the [src] over [M].</span>","<span class='danger'>You begin waving \the [src] over [M].</span>")
-			if(do_after(user,H, 2 SECONDS))
-				H.toggle_sensors(user)
-	else
-		..()
+	switch(wand_mode)
+		if(0)
+			to_chat(user, "<span class='notice'>The [src] will now disable suit remote sensing equipment.</span>")
+		if(1)
+			to_chat(user, "<span class='notice'>The [src] will now make suits report whether the wearer is live or dead.</span>")
+		if(2)
+			to_chat(user, "<span class='notice'>The [src] will now make suits report vital lifesigns.</span>")
+		if(3)
+			to_chat(user, "<span class='notice'>The [src] will now make suits report vital lifesigns as well as coordinate positions.</span>")
+
+/obj/item/weapon/depocket_wand/suit/scan(mob/living/carbon/human/H, mob/living/user)
+	var/obj/item/clothing/under/suit = H.w_uniform
+	if(!suit)
+		to_chat(user, "<span class='warning'>\The [H] is not wearing a suit.</span>")
+		return
+	if(!suit.has_sensor)
+		to_chat(user, "<span class='warning'>\The [H]'s suit does not have sensors.</span>")
+		return
+	if(suit.has_sensor >= 2)
+		to_chat(user, "<span class='warning'>\The [H]'s suit sensor controls are locked.</span>")
+		return
+	suit.sensor_mode = wand_mode
+	switch(suit.sensor_mode)
+		if(0)
+			user.visible_message("<span class='danger'>[user] has set [M]'s suit sensors to disable suit remote sensing equipment with \the [src].</span>",\
+								"<span class='danger'>You set [M]'s sensors to disable suit remote sensing equipment.</span>")
+		if(1)
+			user.visible_message("<span class='danger'>[user] has set [M]'s suit sensors to whether the wearer is live or dead with \the [src].</span>",\
+								"<span class='danger'>You set [M]'s sensors to report whether the wearer is live or dead.</span>")
+		if(2)
+			user.visible_message("<span class='danger'>[user] has set [M]'s suit sensors to report vital lifesigns with \the [src].</span>",\
+								"<span class='danger'>You set [M]'s sensors to report vital lifesigns.</span>")
+		if(3)
+			user.visible_message("<span class='danger'>[user] has set [M]'s suit sensors to report vital lifesigns as well as coordinate positions with \the [src].</span>",\
+								"<span class='danger'>You set [M]'s sensors to report vital lifesigns as well as coordinate positions.</span>")
+	src.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had their sensors set to [wand_mode] by [user.name] ([user.ckey])</font>")
+	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Set [H.name]'s suit sensors ([H.ckey]).</font>")
+	log_attack("[user.name] ([user.ckey]) has set [H.name]'s suit sensors ([H.ckey]) to [wand_mode].")
 
 
 #define VAMP_FLASH_CD 50
@@ -855,7 +886,7 @@ var/global/list/alcatraz_stuff = list(
 
 var/global/list/yantar_stuff = list(
 	//3 of a kind
-	/obj/item/weapon/suit_wand,/obj/item/weapon/suit_wand,/obj/item/weapon/suit_wand,
+	/obj/item/weapon/depocket_wand/suit,/obj/item/weapon/depocket_wand/suit,/obj/item/weapon/depocket_wand/suit,
 	//1 of a kind
 	/obj/item/weapon/storage/trader_chemistry,
 	/obj/structure/closet/crate/flatpack/ancient/chemmaster_electrolyzer,

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -636,7 +636,7 @@ var/global/list/alcatraz_stuff = list(
 
 /obj/item/weapon/depocket_wand/suit
 	name = "suit sensing wand"
-	desc = "Used by medical staff to ensure compliance with vitals tracking regulations."
+	desc = "Used by medical staff to ensure compliance with vitals tracking regulations and to save vocal cord wear from demanding it over communications systems."
 	var/wand_mode = 3
 
 /obj/item/weapon/depocket_wand/suit/attack_self(mob/user)

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -640,7 +640,7 @@ var/global/list/alcatraz_stuff = list(
 	var/wand_mode = 3
 
 /obj/item/weapon/depocket_wand/suit/attack_self(mob/user)
-	var/list/modes = list("Off", "Binary sensors", "Vitals tracker", "Tracking beacon")
+	var/static/list/modes = list("Off", "Binary sensors", "Vitals tracker", "Tracking beacon")
 	var/switchMode = input("Select a sensor mode:", "Suit Sensor Mode", modes[wand_mode + 1]) in modes
 	if(user.incapacitated())
 		return

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -641,7 +641,7 @@ var/global/list/alcatraz_stuff = list(
 
 /obj/item/weapon/depocket_wand/suit/attack_self(mob/user)
 	var/list/modes = list("Off", "Binary sensors", "Vitals tracker", "Tracking beacon")
-	var/switchMode = input("Select a sensor mode:", "Suit Sensor Mode", modes[1]) in modes
+	var/switchMode = input("Select a sensor mode:", "Suit Sensor Mode", modes[wand_mode + 1]) in modes
 	if(user.incapacitated())
 		return
 	wand_mode = modes.Find(switchMode) - 1

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -641,7 +641,7 @@ var/global/list/alcatraz_stuff = list(
 
 /obj/item/weapon/depocket_wand/suit/attack_self(mob/user)
 	var/list/modes = list("Off", "Binary sensors", "Vitals tracker", "Tracking beacon")
-	var/switchMode = input("Select a sensor mode:", "Suit Sensor Mode", modes[sensor_mode + 1]) in modes
+	var/switchMode = input("Select a sensor mode:", "Suit Sensor Mode", modes[1]) in modes
 	if(user.incapacitated())
 		return
 	wand_mode = modes.Find(switchMode) - 1
@@ -670,17 +670,17 @@ var/global/list/alcatraz_stuff = list(
 	suit.sensor_mode = wand_mode
 	switch(suit.sensor_mode)
 		if(0)
-			user.visible_message("<span class='danger'>[user] has set [M]'s suit sensors to disable suit remote sensing equipment with \the [src].</span>",\
-								"<span class='danger'>You set [M]'s sensors to disable suit remote sensing equipment.</span>")
+			user.visible_message("<span class='danger'>[user] has set [H]'s suit sensors to disable suit remote sensing equipment with \the [src].</span>",\
+								"<span class='danger'>You set [H]'s sensors to disable suit remote sensing equipment.</span>")
 		if(1)
-			user.visible_message("<span class='danger'>[user] has set [M]'s suit sensors to whether the wearer is live or dead with \the [src].</span>",\
-								"<span class='danger'>You set [M]'s sensors to report whether the wearer is live or dead.</span>")
+			user.visible_message("<span class='danger'>[user] has set [H]'s suit sensors to whether the wearer is live or dead with \the [src].</span>",\
+								"<span class='danger'>You set [H]'s sensors to report whether the wearer is live or dead.</span>")
 		if(2)
-			user.visible_message("<span class='danger'>[user] has set [M]'s suit sensors to report vital lifesigns with \the [src].</span>",\
-								"<span class='danger'>You set [M]'s sensors to report vital lifesigns.</span>")
+			user.visible_message("<span class='danger'>[user] has set [H]'s suit sensors to report vital lifesigns with \the [src].</span>",\
+								"<span class='danger'>You set [H]'s sensors to report vital lifesigns.</span>")
 		if(3)
-			user.visible_message("<span class='danger'>[user] has set [M]'s suit sensors to report vital lifesigns as well as coordinate positions with \the [src].</span>",\
-								"<span class='danger'>You set [M]'s sensors to report vital lifesigns as well as coordinate positions.</span>")
+			user.visible_message("<span class='danger'>[user] has set [H]'s suit sensors to report vital lifesigns as well as coordinate positions with \the [src].</span>",\
+								"<span class='danger'>You set [H]'s sensors to report vital lifesigns as well as coordinate positions.</span>")
 	src.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had their sensors set to [wand_mode] by [user.name] ([user.ckey])</font>")
 	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Set [H.name]'s suit sensors ([H.ckey]).</font>")
 	log_attack("[user.name] ([user.ckey]) has set [H.name]'s suit sensors ([H.ckey]) to [wand_mode].")

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -681,7 +681,7 @@ var/global/list/alcatraz_stuff = list(
 		if(3)
 			user.visible_message("<span class='danger'>[user] has set [H]'s suit sensors to report vital lifesigns as well as coordinate positions with \the [src].</span>",\
 								"<span class='danger'>You set [H]'s sensors to report vital lifesigns as well as coordinate positions.</span>")
-	src.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had their sensors set to [wand_mode] by [user.name] ([user.ckey])</font>")
+	H.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had their sensors set to [wand_mode] by [user.name] ([user.ckey])</font>")
 	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Set [H.name]'s suit sensors ([H.ckey]).</font>")
 	log_attack("[user.name] ([user.ckey]) has set [H.name]'s suit sensors ([H.ckey]) to [wand_mode].")
 

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -174,7 +174,8 @@
 		"/obj/item/weapon/switchtool/surgery",
 		"/obj/item/weapon/grenade/chem_grenade",
 		"/obj/item/weapon/electrolyzer",
-		"/obj/item/weapon/autopsy_scanner/healthanalyzerpro"
+		"/obj/item/weapon/autopsy_scanner/healthanalyzerpro",
+		"/obj/item/weapon/suit_wand"
 	)
 
 /obj/item/weapon/storage/belt/slim

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -175,7 +175,7 @@
 		"/obj/item/weapon/grenade/chem_grenade",
 		"/obj/item/weapon/electrolyzer",
 		"/obj/item/weapon/autopsy_scanner/healthanalyzerpro",
-		"/obj/item/weapon/suit_wand"
+		"/obj/item/weapon/depocket_wand/suit"
 	)
 
 /obj/item/weapon/storage/belt/slim

--- a/code/modules/trader/trade_datums.dm
+++ b/code/modules/trader/trade_datums.dm
@@ -75,6 +75,7 @@
 	name = "Yantar medical crate"
 	path = /obj/structure/closet/crate/medical/yantar
 	baseprice = 220
+	maxunits = 2
 	sales_category = TRADE_VARIETY
 
 /datum/trade_product/condidisp


### PR DESCRIPTION
[content]
Activate in hand to set the suit sensor to set to.
:cl:
 * rscadd: Traders have now found a new item inside yantar security crates: the suit sensing wand. Waving this over a restrained person instantly sets their suit sensors to a given value, otherwise applies after a delay of 2 seconds.
 * tweak: Trade windows now offer 2 yantar crates.