### PR TITLE
Syndicate disease disks box upgrade: Effect database forger

### DIFF
--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -46,7 +46,7 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 	D1.origin = "Loose Catbeast"
 	D1.makerandom(str, rob, anti, bad)
 	H.infect_disease2(D1, 1, "Loose Catbeast")
-	antag.store_memory(D1.get_info(), forced = 1)
+	antag.store_memory(D1.get_info(TRUE), forced = 1)
 	antag.store_memory("<hr>")
 
 /datum/role/catbeast/proc/infect_catbeast_tier1(mob/living/carbon/human/H)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -767,7 +767,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/jobspecific/medical/viruscollection
 	name = "Deadly Syndrome Collection"
-	desc = "A diskette box filled with 3 random Deadly stage 4 syndromes GNA disks (the same syndrome won't show up twice) on top of a Waiting Syndrome GNA disk to help your disease spread undetected."
+	desc = "A diskette box filled with 3 random Deadly stage 4 syndromes GNA disks (the same syndrome won't show up twice) on top of a Waiting Syndrome GNA disk to help your disease spread undetected, and a GNA forging disk for masking deadly syndromes in the database."
 	item = /obj/item/weapon/storage/lockbox/diskettebox/syndisease
 	cost = 20
 	discounted_cost = 12

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -776,7 +776,7 @@ var/list/uplink_items = list()
 /datum/uplink_item/jobspecific/medical/symptomforger
 	name = "GNA Database Forger Disk"
 	desc = "A disk that looks almost exactly like a normal GNA disk, with the exception of being able to copy the symptom from any other normal one to splice into a disk. Splicing this in does not affect the disease, but instead creates a forged symptom onto the database, obscuring the original effect."
-	item = /obj/item/disk/disease/spoof
+	item = /obj/item/weapon/disk/disease/spoof
 	cost = 12
 	discounted_cost = 6
 	jobs_with_discount = list("Virologist", "Chief Medical Officer")

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -773,6 +773,14 @@ var/list/uplink_items = list()
 	discounted_cost = 12
 	jobs_with_discount = list("Virologist", "Chief Medical Officer")
 
+/datum/uplink_item/jobspecific/medical/symptomforger
+	name = "GNA Database Forger Disk"
+	desc = "A disk that looks almost exactly like a normal GNA disk, with the exception of being able to copy the symptom from any other normal one to splice into a disk. Splicing this in does not affect the disease, but instead creates a forged symptom onto the database, obscuring the original effect."
+	item = /obj/item/disk/disease/spoof
+	cost = 12
+	discounted_cost = 6
+	jobs_with_discount = list("Virologist", "Chief Medical Officer")
+
 /datum/uplink_item/jobspecific/medical/syndietape_viro
 	name = "Syndicate Biohazard Tape"
 	desc = "A length of biohazard tape coated in an engineered bacterium that forcibly ejects explosive goo when disturbed, but can be handled safely with latex gloves. Can be used 3 times."

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -496,7 +496,7 @@
 		var/datum/disease2/disease/D = locate(href_list["diseasepanel_examine"])
 
 		var/datum/browser/popup = new(usr, "\ref[D]", "[D.form] #[add_zero("[D.uniqueID]", 4)]-[add_zero("[D.subID]", 4)]", 600, 300, src)
-		popup.set_content(D.get_info())
+		popup.set_content(D.get_info(TRUE))
 		popup.open()
 
 	else if(href_list["diseasepanel_toggledb"])

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -857,7 +857,7 @@ var/global/list/virusDB = list()
 		dat += "[A]"
 	return dat
 
-/datum/disease2/disease/proc/get_info()
+/datum/disease2/disease/proc/get_info(var/trueinfo = FALSE)
 	var/r = "GNAv3 [name()]"
 	r += "<BR>Strength / Robustness : <b>[strength]% / [robustness]%</b> - [get_subdivisions_string()]"
 	r += "<BR>Infectability : <b>[infectionchance]%</b>"
@@ -866,7 +866,7 @@ var/global/list/virusDB = list()
 	r += "<dl>"
 	var/i = 1
 	for(var/datum/disease2/effect/e in effects)
-		if(fake_effects[i])
+		if(fake_effects[i] && !trueinfo)
 			var/datum/disease2/effect/f_e = fake_effects[i]
 			r += "<dt> &#x25CF; <b>Stage [f_e.stage] - [f_e.name]</b> (Danger: [f_e.badness]). Strength: <b>[f_e.multiplier]</b>. Occurrence: <b>[f_e.chance]%</b>.</dt>"
 			r += "<dd>[f_e.desc]</dd>"

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -7,6 +7,7 @@ var/global/list/disease2_list = list()
 	var/subID = 0// 000 to 9999, set if the pathogen underwent effect or antigen mutation
 	var/childID = 0// 01 to 99, incremented as the pathogen gets analyzed after a mutation
 	var/list/datum/disease2/effect/effects = list()
+	var/list/datum/disease2/effect/fake_effects = list()
 
 	//When an opportunity for the disease to spread to a mob arrives, runs this percentage through prob()
 	//Ignored if infected materials are ingested (injected with infected blood, eating infected meat)
@@ -863,9 +864,16 @@ var/global/list/virusDB = list()
 	r += "<BR>Spread forms : <b>[get_spread_string()]</b>"
 	r += "<BR>Progress Speed : <b>[stageprob]%</b>"
 	r += "<dl>"
+	var/i = 1
 	for(var/datum/disease2/effect/e in effects)
-		r += "<dt> &#x25CF; <b>Stage [e.stage] - [e.name]</b> (Danger: [e.badness]). Strength: <b>[e.multiplier]</b>. Occurrence: <b>[e.chance]%</b>.</dt>"
-		r += "<dd>[e.desc]</dd>"
+		if(fake_effects[i])
+			var/datum/disease2/effect/f_e = fake_effects[i]
+			r += "<dt> &#x25CF; <b>Stage [f_e.stage] - [f_e.name]</b> (Danger: [f_e.badness]). Strength: <b>[f_e.multiplier]</b>. Occurrence: <b>[f_e.chance]%</b>.</dt>"
+			r += "<dd>[f_e.desc]</dd>"
+		else
+			r += "<dt> &#x25CF; <b>Stage [e.stage] - [e.name]</b> (Danger: [e.badness]). Strength: <b>[e.multiplier]</b>. Occurrence: <b>[e.chance]%</b>.</dt>"
+			r += "<dd>[e.desc]</dd>"
+		i++
 	r += "</dl>"
 	r += "<BR>Antigen pattern: [get_antigen_string()]"
 	r += "<BR><i>last analyzed at: [worldtime2text()]</i>"

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -901,6 +901,7 @@ var/global/list/virusDB = list()
 	v.fields["name"] = name()
 	v.fields["nickname"] = ""
 	v.fields["description"] = get_info()
+	v.fields["description_hidden"] = get_info(TRUE)
 	v.fields["custom_desc"] = "No comments yet."
 	v.fields["antigen"] = get_antigen_string()
 	v.fields["spread type"] = get_spread_string()

--- a/code/modules/virus2/diseasesplicer.dm
+++ b/code/modules/virus2/diseasesplicer.dm
@@ -208,8 +208,7 @@
 		var/datum/disease2/effect/e = effects[x]
 		if(e.stage == memorybank.stage)
 			if(e.spoof)
-				var/datum/disease2/effect/fake_effect = dish.contained_virus.fake_effects[x]
-				fake_effect = memorybank.getcopy(dish.contained_virus)
+				dish.contained_virus.fake_effects[x] = memorybank.getcopy(dish.contained_virus)
 				log_debug("[dish.contained_virus.form] #[add_zero("[dish.contained_virus.uniqueID]", 4)][dish.contained_virus.childID ? "-[add_zero("[dish.contained_virus.childID]", 2)]" : ""] had [memorybank.name] falsely spliced into to replace [e.name] in databases by [key_name(usr)].")
 				dish.contained_virus.log += "<br />[timestamp()] [memorybank.name] spoof spliced in by [key_name(usr)] (replaces [e.name] in database listing)"
 			else

--- a/code/modules/virus2/diseasesplicer.dm
+++ b/code/modules/virus2/diseasesplicer.dm
@@ -207,9 +207,15 @@
 	for(var/x = 1 to effects.len)
 		var/datum/disease2/effect/e = effects[x]
 		if(e.stage == memorybank.stage)
-			effects[x] = memorybank.getcopy(dish.contained_virus)
-			log_debug("[dish.contained_virus.form] #[add_zero("[dish.contained_virus.uniqueID]", 4)][dish.contained_virus.childID ? "-[add_zero("[dish.contained_virus.childID]", 2)]" : ""] had [memorybank.name] spliced into to replace [e.name] by [key_name(usr)].")
-			dish.contained_virus.log += "<br />[timestamp()] [memorybank.name] spliced in by [key_name(usr)] (replaces [e.name])"
+			if(e.spoof)
+				var/datum/disease2/effect/fake_effect = dish.contained_virus.fake_effects[x]
+				fake_effect = memorybank.getcopy(dish.contained_virus)
+				log_debug("[dish.contained_virus.form] #[add_zero("[dish.contained_virus.uniqueID]", 4)][dish.contained_virus.childID ? "-[add_zero("[dish.contained_virus.childID]", 2)]" : ""] had [memorybank.name] falsely spliced into to replace [e.name] in databases by [key_name(usr)].")
+				dish.contained_virus.log += "<br />[timestamp()] [memorybank.name] spoof spliced in by [key_name(usr)] (replaces [e.name] in database listing)"
+			else
+				effects[x] = memorybank.getcopy(dish.contained_virus)
+				log_debug("[dish.contained_virus.form] #[add_zero("[dish.contained_virus.uniqueID]", 4)][dish.contained_virus.childID ? "-[add_zero("[dish.contained_virus.childID]", 2)]" : ""] had [memorybank.name] spliced into to replace [e.name] by [key_name(usr)].")
+				dish.contained_virus.log += "<br />[timestamp()] [memorybank.name] spliced in by [key_name(usr)] (replaces [e.name])"
 			break
 
 	splicing = DISEASE_SPLICER_SPLICING_TICKS

--- a/code/modules/virus2/effect/effect.dm
+++ b/code/modules/virus2/effect/effect.dm
@@ -42,6 +42,9 @@
 	var/datum/disease2/disease/virus
 		// Parent virus. Plans to generalize these are underway.
 
+	var/spoof = 0
+		// If this effect is used to hide a true effect on a database.
+
 	var/restricted = 0
 	// If 1, will never appear randomly in a disease, requiring instead to be manually set in the code. If 2, will not either appear in the encyclopedia.
 // The actual guts of the effect. Has a prob(chance)% to get called per tick.

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -200,7 +200,7 @@ var/list/infected_contact_mobs = list()
 			plague.update_hud_icons()
 			for(var/datum/role/plague_mouse/M in plague.members)
 				var/datum/mind/mouse_mind = M.antag
-				mouse_mind.store_memory(D.get_info(), forced = 1)
+				mouse_mind.store_memory(D.get_info(TRUE), forced = 1)
 				mouse_mind.store_memory("<hr>")
 		//----------------
 

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -447,7 +447,7 @@ var/list/virusdishes = list()
 /obj/item/weapon/storage/lockbox/diskettebox/syndisease/New()
 	..()
 	new /obj/item/weapon/disk/disease/invisible(src)
-	new /obj/item/weapon/disk/disease/spoof(src)
+	new /obj/item/weapon/disk/disease/spoof/premade(src)
 
 	var/list/potential_deadly_symptoms = list()
 
@@ -472,7 +472,7 @@ var/list/virusdishes = list()
 /obj/item/weapon/disk/disease/spoof
 	desc = "A disk for storing the structure of a pathogen's Glycol Nucleic Acid pertaining to a specific symptom. <span class='warning'>This one has some strange wiring on its back.</span>"
 
-/obj/item/weapon/disk/disease/spoof/New()
+/obj/item/weapon/disk/disease/spoof/premade/New()
 	..()
 	var/list/potential_nice_symptoms = list()
 

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -484,7 +484,7 @@ var/list/virusdishes = list()
 			potential_nice_symptoms += diseasetype
 
 	if (potential_nice_symptoms.len < 1)
-		break
+		return
 	var/effect_type = pick(potential_nice_symptoms)
 	effect = new effect_type()
 	name = "\improper [effect.name] GNA disk (Stage: [effect.stage])"

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -472,6 +472,24 @@ var/list/virusdishes = list()
 /obj/item/weapon/disk/disease/spoof
 	desc = "A disk for storing the structure of a pathogen's Glycol Nucleic Acid pertaining to a specific symptom. <span class='warning'>This one has some strange wiring on its back.</span>"
 
+/obj/item/weapon/disk/disease/spoof/New()
+	..()
+	var/list/potential_nice_symptoms = list()
+
+	for (var/diseasetype in subtypesof(/datum/disease2/effect))
+		var/datum/disease2/effect/E = diseasetype
+		if (initial(E.restricted))
+			continue
+		if (initial(E.stage) == 4 && initial(E.badness) <= EFFECT_DANGER_FLAVOR)
+			potential_nice_symptoms += diseasetype
+
+	if (potential_nice_symptoms.len < 1)
+		break
+	var/effect_type = pick(potential_nice_symptoms)
+	effect = new effect_type()
+	name = "\improper [effect.name] GNA disk (Stage: [effect.stage])"
+	stage = effect.stage
+
 /obj/item/weapon/disk/disease/spoof/afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
 	if(istype(target,/obj/item/weapon/disk/disease))
 		var/obj/item/weapon/disk/disease/D = target

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -470,7 +470,7 @@ var/list/virusdishes = list()
 	update_icon()
 
 /obj/item/weapon/disk/disease/spoof
-	name = "strange GNA disk"
+	desc = "A disk for storing the structure of a pathogen's Glycol Nucleic Acid pertaining to a specific symptom. <span class='warning'>This one has some strange wiring on its back.</span>"
 
 /obj/item/weapon/disk/disease/spoof/afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
 	if(istype(target,/obj/item/weapon/disk/disease))

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -447,6 +447,7 @@ var/list/virusdishes = list()
 /obj/item/weapon/storage/lockbox/diskettebox/syndisease/New()
 	..()
 	new /obj/item/weapon/disk/disease/invisible(src)
+	new /obj/item/weapon/disk/disease/spoof(src)
 
 	var/list/potential_deadly_symptoms = list()
 
@@ -467,6 +468,18 @@ var/list/virusdishes = list()
 		syndisk.stage = syndisk.effect.stage
 		potential_deadly_symptoms -= effect_type
 	update_icon()
+
+/obj/item/weapon/disk/disease/spoof
+	name = "strange GNA disk"
+
+/obj/item/weapon/disk/disease/spoof/afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
+	if(istype(target,/obj/item/weapon/disk/disease))
+		var/obj/item/weapon/disk/disease/D = target
+		effect = D.effect
+		to_chat(user,"<span class='notice'>Effect copied.</span>")
+		name = "\improper [D.effect.name] GNA disk (Stage: [D.effect.stage])"
+		stage = D.effect.stage
+		effect.spoof = 1
 
 /obj/item/weapon/disk/disease/invisible
 	name = "\improper Waiting Syndrome GNA disk (Stage 1)"


### PR DESCRIPTION
[content]
Scan on a disease disk to get the effect information, starts with harmless or beneficial stage 4 symptom loaded if found in diskette box.
Then, when loaded into a disease splicer, does not replace the effect on the disease, but its listing in the database, as to mask a deadly syndrome with a harmless or beneficial one.
:cl:
 * rscadd: Syndicate disease disk collections now come with a disease effect database information forger, for masking deadly syndromes, preloaded with a harmless or beneficial stage 4 symptom. It can also be bought by itself at an uplink for half price.