### PR TITLE
Changes how Old Vendotron Teleport Events Work

### DIFF
--- a/code/modules/events/old_vendotron_event/old_vendotron.dm
+++ b/code/modules/events/old_vendotron_event/old_vendotron.dm
@@ -148,6 +148,9 @@
 		/obj/item/weapon/storage/box/mysterycubes = 250,
 		/obj/item/weapon/glow_orb = 200,
 		/obj/item/stack/sheet/mineral/phazon = 300,
+		/obj/item/weapon/reagent_containers/spray/noreact = 750,	//This isn't nearly as broken as it sounds
+		/obj/item/weapon/circuitboard/mind_machine_hub = 400,
+		/obj/item/weapon/circuitboard/mind_machine_pod = 250,
 	)
 
 	var/list/rareStock = list(

--- a/code/modules/events/old_vendotron_event/vendor_teleport_event.dm
+++ b/code/modules/events/old_vendotron_event/vendor_teleport_event.dm
@@ -15,44 +15,41 @@
 	teleportVendor()
 
 /datum/event/old_vendotron_teleport/proc/teleportVendor()
-	var/turf/vendT = vendSpawnDecide()
-	fancyEntrance(vendT)
+	var/atom/chosenVend = vendSpawnDecide()
+	fancyEntrance(chosenVend)
 
 /datum/event/old_vendotron_teleport/proc/vendSpawnDecide()
-	var/list/dontSpawnHere = list(
-		/area/derelictparts,
-		/area/solar,
-		/area/assembly,	//Because I don't know what that is
-		/area/shuttle/administration/station,
-		/area/ai_monitored/storage/emergency,
-		/area/arrival,
-		/area/shuttle/escape_pod1,
-		/area/shuttle/escape_pod2,
-		/area/shuttle/escape_pod3,
-		/area/shuttle/escape_pod4,
-		/area/shuttle/escape_pod5,
-		/area/shuttle/prison/,
+	var/list/dontReplace = list(
+		/obj/machinery/vending/voxseeds,
+		/obj/machinery/vending/tradeoutfitter,
+		/obj/machinery/vending/sale/trader,
+		/obj/machinery/vending/sale,	//Oh boy can't wait to start sell- oh nooooo
+		/obj/machinery/vending/old_vendotron,
 	)
-	var/list/vendSpawnAreas = the_station_areas - dontSpawnHere
-	var/area/toSpawn = pick(vendSpawnAreas)
-	toSpawn = locate(toSpawn)
-	var/list/turf/simulated/floor/vendSpawn = list()
-	for(var/turf/simulated/floor/F in toSpawn)
-		if(!F.has_dense_content())
-			vendSpawn.Add(F)
-	if(!vendSpawn.len)	//Copy paste from infestation
-		message_admins("Old Vendotron event has failed! Could not find any viable turfs in [toSpawn].")
+	var/list/possibleVends = list()
+	for(var/obj/machinery/vending/aVendor in all_machines)
+		if(is_type_in_list(aVendor, dontReplace))
+			continue
+		if(aVendor.loc.z != STATION_Z)
+			continue
+		possibleVends.Add(aVendor)
+	if(!possibleVends.len)	//Copy paste from infestation
+		message_admins("Old Vendotron event has failed! Could not find any appropriate vending machines to replace.")
 		announceWhen = -1
 		endWhen = 0
 		return
-	return pick(vendSpawn)
+	var/toSpawn = pick(possibleVends)
+	return toSpawn
 
-/datum/event/old_vendotron_teleport/proc/fancyEntrance(var/turf/vendT)
-	var/obj/effect/old_vendotron_entrance/E = new /obj/effect/old_vendotron_entrance(vendT)
-	E.aestheticEntrance()
+/datum/event/old_vendotron_teleport/proc/fancyEntrance(var/obj/machinery/vending/vendToReplace)
+	var/obj/effect/old_vendotron_entrance/vendPortal = new /obj/effect/old_vendotron_entrance(vendToReplace.loc)
+	vendPortal.aestheticEntrance()
 	playsound(E, 'sound/effects/eleczap.ogg', 100, 1)
-	spawn(4 SECONDS)
-		var/obj/machinery/vending/old_vendotron/OV = new /obj/machinery/vending/old_vendotron(vendT)
+	spawn(3 SECONDS)
+		var/obj/machinery/vending/old_vendotron/OV = new /obj/machinery/vending/old_vendotron(vendToReplace.loc)
+		if(!vendToReplace.gcDestroyed)
+			vendToReplace.coinbox = null
+			qdel(vendToReplace)
 		playsound(OV, 'sound/effects/coins.ogg', 100, 1)
 
 /obj/effect/old_vendotron_entrance
@@ -70,4 +67,4 @@
 	spawn(3 SECONDS)
 		animate(src, icon_state = "bhole3", transform = matrix()*0.1, time = 3 SECONDS)
 	spawn(35)
-		qdel(E)
+		qdel(src)


### PR DESCRIPTION
The old vendotron event currently teleports a vendotron to a random area on the station. This PR makes it instead replace an existing vendor. There's a blacklist to make sure it doesn't replace anything trader related, custom vendors, or an existing old vendotron. 

I actually had the idea to do this, and liked it more, right as I finished how the current teleportation works but didn't want to waste the effort. So now that the sunk cost fallacy has released me, you get a [tweak] PR

**Why?**
Not only does this look better and is conceptually more fun, it's more reliable. The old version was prone to failure because of a few quirks with areas. This one only fails if there are no vendors on the station z level. This also gives more clue as to where to start looking for the vendor when an event is announced.

This PR also fixes a runtime with the event and adds mind machine circuits and a noreact spray bottle (tested most reactions, not nearly as broken as it sounds. Almost disappointingly so.) to the potential stock of an old vendotron.

:cl:
 * tweak: The old vendotron now consumes an existing vendor when teleporting, rather than just appearing from thin air.