### PR TITLE
Fixed metallica syndrome runtime

### DIFF
--- a/code/modules/virus2/effect/stage_3.dm
+++ b/code/modules/virus2/effect/stage_3.dm
@@ -648,12 +648,10 @@ datum/disease2/effect/lubefoot/deactivate(var/mob/living/mob)
 		if(I.name != "brain" && !I.robotic)
 			valid_internal_organs += I
 
-	if(prob(75) || valid_external_organs.len)
-
+	if(prob(75) && valid_external_organs.len)
 		var/datum/organ/external/E = pick(valid_external_organs)
 		E.robotize()
 		H.update_body()
-
 	else if(valid_internal_organs.len)
 
 		var/datum/organ/internal/I = pick(valid_internal_organs)


### PR DESCRIPTION
```
[04:25:24] Runtime in stage_3.dm, line 653: pick() from empty list
 proc name: activate (/datum/disease2/effect/cyborg_limbs/activate)
src: Metallica Syndrome (/datum/disease2/effect/cyborg_limbs)
call stack:
Metallica Syndrome (/datum/disease2/effect/cyborg_limbs): activate(the unknown (/mob/living/carbon/human))
Metallica Syndrome (/datum/disease2/effect/cyborg_limbs): run effect(the unknown (/mob/living/carbon/human))
/datum/disease2/disease (/datum/disease2/disease): activate(the unknown (/mob/living/carbon/human), 0)
the unknown (/mob/living/carbon/human): activate diseases()
the unknown (/mob/living/carbon/human): handle virus updates()
the unknown (/mob/living/carbon/human): Life()
Mob (/datum/subsystem/mob): fire(0)
Mob (/datum/subsystem/mob): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing()
```