### PR TITLE
Fixed wires runtime

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -128,7 +128,7 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 				I = L.get_active_hand()
 			holder.add_hiddenprint(L)
 			if(href_list["cut"]) // Toggles the cut/mend status
-				if(I.is_wirecutter(L) || isswitchtool(I))
+				if(I?.is_wirecutter(L))
 					var/colour = href_list["cut"]
 					CutWireColour(colour)
 					holder.investigation_log(I_WIRES, "|| [GetWireName(wires[colour]) || colour] wire [IsColourCut(colour) ? "cut" : "mended"] by [key_name(usr)] ([src.type])")
@@ -136,7 +136,7 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 					to_chat(L, "<span class='error'>You need wirecutters!</span>")
 
 			else if(href_list["pulse"])
-				if(I.is_multitool(L) || isswitchtool(I))
+				if(I?.is_multitool(L))
 					var/colour = href_list["pulse"]
 					PulseColour(colour)
 					holder.investigation_log(I_WIRES, "|| [GetWireName(wires[colour]) || colour] wire pulsed by [key_name(usr)] ([src.type])")

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -257,6 +257,18 @@
 			return TRUE
 		return
 
+/obj/item/weapon/switchtool/is_screwdriver(mob/user)
+	return deployed?.is_screwdriver(user)
+
+/obj/item/weapon/switchtool/is_wrench(mob/user)
+	return deployed?.is_wrench(user)
+
+/obj/item/weapon/switchtool/is_wirecutter(mob/user)
+	return deployed?.is_wirecutter(user)
+
+/obj/item/weapon/switchtool/is_multitool(mob/user)
+	return deployed?.is_multitool(user)
+
 
 /obj/item/weapon/switchtool/surgery
 	name = "surgeon's switchtool"


### PR DESCRIPTION
```
[04:41:47] Runtime in wires.dm, line 139: Cannot execute null.is multitool().
proc name: Topic (/datum/wires/Topic)
usr: Admin (damianq) (/mob/living/carbon/human/dummy)
usr.loc: The floor (135, 140, 2) (/turf/unsimulated/floor)
src: /datum/wires/airlock (/datum/wires/airlock)
call stack:
/datum/wires/airlock (/datum/wires/airlock): Topic("src=\[0x21013125];action=1;pul...", /list (/list))
DamianQ (/client): Topic("src=\[0x21013125];action=1;pul...", /list (/list), /datum/wires/airlock (/datum/wires/airlock))
DamianQ (/client): Topic("src=\[0x21013125];action=1;pul...", /list (/list), /datum/wires/airlock (/datum/wires/airlock))
```

also fixes all switchtools acting like both a multitool and a wirecutter regardless of whether they even had any item deployed but don't tell anyone