### PR TITLE
Fixed gremlin runtime

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -520,7 +520,7 @@ Class Procs:
 		if(icon_state_open)	//don't need to reset the icon_state if it was never changed
 			icon_state = initial(icon_state)
 	to_chat(user, "<span class='notice'>[bicon(src)] You [panel_open ? "open" : "close"] the maintenance hatch of \the [src].</span>")
-	if(toggleitem.is_screwdriver(user))
+	if(toggleitem?.is_screwdriver(user))
 		toggleitem.playtoolsound(loc, 50)
 	update_icon()
 	return 1


### PR DESCRIPTION
```
[06:00:19] Runtime in machinery.dm, line 523: Cannot execute null.is screwdriver().
proc name: togglePanelOpen (/obj/machinery/proc/togglePanelOpen)
src: the Sapphire Cosmetics (/obj/machinery/vending/makeup)
src.loc: the floor (199,196,1) (/turf/simulated/floor)
call stack:
the Sapphire Cosmetics (/obj/machinery/vending/makeup): togglePanelOpen(null, the gremlin (/mob/living/simple_animal/hostile/gremlin))
the Sapphire Cosmetics (/obj/machinery/vending/makeup): npc tamper act(the gremlin (/mob/living/simple_animal/hostile/gremlin))
the gremlin (/mob/living/simple_animal/hostile/gremlin): tamper(the Sapphire Cosmetics (/obj/machinery/vending/makeup))
the gremlin (/mob/living/simple_animal/hostile/gremlin): AttackingTarget()
the gremlin (/mob/living/simple_animal/hostile/gremlin): MoveToTarget()
the gremlin (/mob/living/simple_animal/hostile/gremlin): Life()
the gremlin (/mob/living/simple_animal/hostile/gremlin): Life()
Mob (/datum/subsystem/mob): fire(0)
Mob (/datum/subsystem/mob): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing()
```