### PR TITLE
Mice keep the number in their name in deadchat

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -432,6 +432,7 @@
 	// Mice IDs
 	if(namenumbers)
 		name = "[name] ([rand(1, 1000)])"
+		real_name = name
 	if(!_color)
 		_color = pick( list("brown","gray","white") )
 		initIcons()


### PR DESCRIPTION
anonymity was a mistake
I think it used to work like this before deity changed mice for virology