### PR TITLE
Fixed pAI emp runtime

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -179,7 +179,7 @@
 	overlays.Cut()
 
 /obj/item/device/paicard/emp_act(severity)
-	pai.emp_act(severity)
+	pai?.emp_act(severity)
 	..()
 
 /obj/item/device/paicard/dropped(mob/user)


### PR DESCRIPTION
```
[07:14:06] Runtime in paicard.dm, line 182: Cannot execute null.emp act().
proc name: emp act (/obj/item/device/paicard/emp_act)
usr: Carl Greenawalt (jefferyjefferson) (/mob/living/carbon/human)
usr.loc: The floor (221, 254, 1) (/turf/simulated/floor)
src: the personal AI device (/obj/item/device/paicard)
src.loc: the floor (218,256,1) (/turf/simulated/floor)
call stack:
the personal AI device (/obj/item/device/paicard): emp act(2)
empulse(the floor (215,263,1) (/turf/simulated/floor), 4, 10, 0)
```