### PR TITLE
Fixed anomaly container runtime

### DIFF
--- a/code/modules/research/xenoarchaeology/tools/anomaly_container.dm
+++ b/code/modules/research/xenoarchaeology/tools/anomaly_container.dm
@@ -148,8 +148,9 @@
 	playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
 
 /obj/structure/anomaly_container/proc/release()
-	contained.forceMove(get_turf(src))
-	contained = null
+	if(contained)
+		contained.forceMove(get_turf(src))
+		contained = null
 	update_icon()
 	playsound(loc, 'sound/machines/click.ogg', 50, 1)
 


### PR DESCRIPTION
```
[09:06:10] Runtime in anomaly_container.dm, line 151: Cannot execute null.forceMove().
proc name: release (/obj/structure/anomaly_container/proc/release)
src: the anomaly container (/obj/structure/anomaly_container)
src.loc: Asteroid (227,148,5) (/turf/unsimulated/floor/asteroid)
call stack:
the anomaly container (/obj/structure/anomaly_container): release()
the anomaly container (/obj/structure/anomaly_container): breakdown()
the anomaly container (/obj/structure/anomaly_container): bullet act(the pulse (/obj/item/projectile/beam/pulse), "")
the pulse (/obj/item/projectile/beam/pulse): to bump(the anomaly container (/obj/structure/anomaly_container))
/ray/beam_ray (/ray/beam_ray): raycast hit check(/rayCastHitInfo (/rayCastHitInfo))
/ray/beam_ray (/ray/beam_ray): cast(50, 0, 1)
/ray/beam_ray (/ray/beam_ray): cast(50, null, null)
the pulse (/obj/item/projectile/beam/pulse): fireto(/vector (/vector), /vector (/vector))
the pulse (/obj/item/projectile/beam/pulse): process()
generic projectile fire(Asteroid (231,142,5) (/turf/unsimulated/floor/asteroid), the alien artifact (/obj/machinery/artifact), the pulse (/obj/item/projectile/beam/pulse), null, null)
```