### PR TITLE
Fix skellington + mechanical organs runtime

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1475,9 +1475,9 @@ Values up to 1000 are allowed.", "FPS", fps) as null|num
 			O.status &= ~ORGAN_ROBOT
 			O.status |= ORGAN_PEG
 		else if(status == "assisted")
-			I.mechassist()
+			I?.mechassist()
 		else if(status == "mechanical")
-			I.mechanize()
+			I?.mechanize()
 		else
 			continue
 	var/datum/species/chosen_species = all_species[species]


### PR DESCRIPTION
```
[08:56:35] Runtime in preferences.dm, line 1480: Cannot execute null.mechanize().
proc name: copy to (/datum/preferences/proc/copy_to)
src: /datum/preferences (/datum/preferences)
call stack:
/datum/preferences (/datum/preferences): copy to(Bonester Ghoulsby (/mob/living/carbon/human), 0)
Rubylips (/mob/new_player): create character()
/datum/controller/gameticker (/datum/controller/gameticker): create characters()
/datum/controller/gameticker (/datum/controller/gameticker): setup()
/datum/controller/gameticker (/datum/controller/gameticker): pregame()
Ticker (/datum/subsystem/ticker): Initialize(462938)
```