### PR TITLE
Adds a single Holy and Exile implant lockbox to the brig on all maps, and holy interference prevents shading out

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -415,7 +415,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		var/response = alert(src, "It doesn't have to end here, the veil is thin and the dark energies in you soul cling to this plane. You may forsake this body and materialize as a Shade.","Sacrifice Body","Shade","Ghost","Stay in body")
 		switch (response)
 			if ("Shade")
-				dust(TRUE)
+				if (occult_muted())
+					to_chat(src, "<span class='danger'>Holy interference within your body prevents you from separating your shade from your body.</span>")
+				else
+					dust(TRUE)
 				return
 			if ("Stay in body")
 				return

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -57462,11 +57462,19 @@
 "edC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/table/reinforced,
-/obj/item/weapon/storage/lockbox/loyalty,
 /obj/effect/decal/warning_stripes{
 	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
+	},
+/obj/item/weapon/storage/lockbox/holy{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/lockbox/exile,
+/obj/item/weapon/storage/lockbox/loyalty{
+	pixel_x = -2;
+	pixel_y = 5
 	},
 /turf/simulated/floor,
 /area/security/warden)


### PR DESCRIPTION

:cl:
* tweak: Cultists can no longer shade out if their powers are muted by holy water or an holy implant.
* rscadd: Added a single lockbox of holy implants to the brig on every map, usually at the Warden's office or armory.
* rscadd: Also added a lockbox of exile implants to remind players that those do exist and aren't used much.