### PR TITLE
Fixed Diseases being borked due to an Out of Bounds error caused by the database forger

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -866,7 +866,7 @@ var/global/list/virusDB = list()
 	r += "<dl>"
 	var/i = 1
 	for(var/datum/disease2/effect/e in effects)
-		if(fake_effects[i] && !trueinfo)
+		if(fake_effects.len >= i && !trueinfo)
 			var/datum/disease2/effect/f_e = fake_effects[i]
 			r += "<dt> &#x25CF; <b>Stage [f_e.stage] - [f_e.name]</b> (Danger: [f_e.badness]). Strength: <b>[f_e.multiplier]</b>. Occurrence: <b>[f_e.chance]%</b>.</dt>"
 			r += "<dd>[f_e.desc]</dd>"


### PR DESCRIPTION
Fixes #31037

:cl:
* bugfix: Fixed Diseases being borked in general, with consequences such as the Disease Analyzer failing to properly get their info (tinysaturn)