### PR TITLE
Fixes blob_act runtime

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -483,15 +483,20 @@ its easier to just keep the beam vertical.
 /atom/proc/can_mech_drill()
 	return acidable()
 
-/atom/proc/blob_act(destroy = 0,var/obj/effect/blob/source = null)
-	//DEBUG to_chat(pick(player_list),"blob_act() on [src] ([src.type])")
+/atom/proc/blob_act(destroy = 0, var/obj/effect/blob/source = null)
 	if(flags & INVULNERABLE)
 		return
-	if (source)
-		anim(target = loc, a_icon = source.icon, flick_anim = "blob_act", sleeptime = 15, direction = get_dir(source, src), lay = BLOB_SPORE_LAYER, plane = BLOB_PLANE)
+	var/_target
+
+	if(isturf(src))
+		_target = src
 	else
-		anim(target = loc, a_icon = 'icons/mob/blob/blob.dmi', flick_anim = "blob_act", sleeptime = 15, lay = BLOB_SPORE_LAYER, plane = BLOB_PLANE)
-	return
+		_target = loc
+
+	if(source)
+		anim(target = _target, a_icon = source.icon, flick_anim = "blob_act", sleeptime = 15, direction = get_dir(source, src), lay = BLOB_SPORE_LAYER, plane = BLOB_PLANE)
+	else
+		anim(target = _target, a_icon = 'icons/mob/blob/blob.dmi', flick_anim = "blob_act", sleeptime = 15, lay = BLOB_SPORE_LAYER, plane = BLOB_PLANE)
 
 /atom/proc/singularity_act()
 	return


### PR DESCRIPTION
```
[12:46:11] Runtime in atoms_movable.dm,667: /atom/movable/overlay created in nullspace.
  proc name: New (/atom/movable/overlay/New)
  src: the overlay (/atom/movable/overlay)
  src.loc: null
  call stack:
  the overlay (/atom/movable/overlay): New(null)
  anim(null, Aft Starboard Solar Maintenanc... (/area/maintenance/astarboardsolar), 'icons/mob/blob/blob_64x64.dmi', null, "blob_act", 15, 8, null, 6, null, null, null, null, -32757, null, null)
  the reinforced wall (312,200,1) (/turf/simulated/wall/r_wall): blob act(0, the blob (/obj/effect/blob/normal))
  the reinforced wall (312,200,1) (/turf/simulated/wall/r_wall): blob act(0, the blob (/obj/effect/blob/normal))
  the blob (/obj/effect/blob/normal): expand(the reinforced wall (312,200,1) (/turf/simulated/wall/r_wall), 1, null, 0)
  the blob (/obj/effect/blob/normal): Pulse(12, 1, null)
  the blob (/obj/effect/blob/normal): Pulse(11, 4, null)
```

turf's loc is /area so calling anim() on an area wasn't gonna work