### PR TITLE
Fixes autoprofiler

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -40,10 +40,10 @@ var/auxtools_path = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
 		// warn on missing library
 		warning("There is no auxtools library for this system included with SpacemanDMM. Debugging will not work. Pester them to add one.")
 	#endif
+	world.Profile(PROFILE_START)
 
 /world/New()
 	world_startup_time = world.timeofday
-	Profile(PROFILE_START)
 	// Honk honk, fuck you science
 	for(var/i=1, i<=map.zLevels.len, i++)
 		WORLD_X_OFFSET += rand(-50,50)

--- a/code/world.dm
+++ b/code/world.dm
@@ -43,7 +43,7 @@ var/auxtools_path = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
 
 /world/New()
 	world_startup_time = world.timeofday
-	Profile(world_startup_time)
+	Profile(PROFILE_START)
 	// Honk honk, fuck you science
 	for(var/i=1, i<=map.zLevels.len, i++)
 		WORLD_X_OFFSET += rand(-50,50)


### PR DESCRIPTION
Makes the profiler always start when the server starts. Previously it had a 50% chance of starting only if the server started within about 25 seconds after midnight. Also makes it start earlier in startup in order to profile more stuff.