### PR TITLE
Trade Window Upgrade

### DIFF
--- a/code/modules/trader/trade_datums.dm
+++ b/code/modules/trader/trade_datums.dm
@@ -1,21 +1,41 @@
 #define TRADE_SINGLE "Single Products"
 #define TRADE_VARIETY "Variety Packs"
-#define FLUX_CHANCE 3
+#define FLUX_CHANCE 9
 #define NEW_RECRUIT -1
 
 /datum/trade_product
 	var/name = "Abstract Product"
 	var/path = null
 	var/baseprice = 50
-	var/maxunits = 1
+	var/maxunits = 1 //How many times you can buy it normally
+	var/restocks_left = 0 //How many times it can be restocked
 	var/totalsold = 0
 	var/flux_rate = 1
 	var/sales_category = TRADE_SINGLE
 
 /datum/trade_product/proc/current_price(mob/user)
-	if(isAdminGhost(user))
-		return round(baseprice * flux_rate * SStrade.shoal_prestige_factor()) //Don't factor in personal discount
-	return round(baseprice * flux_rate * SStrade.shoal_prestige_factor() * SStrade.loyal_customer(user))
+	var/loyalty_multiplier = 1
+	if(!isAdminGhost(user)) //admin ghosts don't have customer data
+		loyalty_multiplier = SStrade.loyal_customer(user)
+	return round(baseprice * flux_rate * SStrade.shoal_prestige_factor() * loyalty_multiplier * isflashed())
+
+/datum/trade_product/proc/can_restock()
+	if(!totalsold || !restocks_left)
+		return FALSE
+	return TRUE
+
+/datum/trade_product/proc/restock_weight()
+	//Increase weight: more restocks left, Decrease: difference between sold and maxunits
+	return restocks_left / (1+maxunits-totalsold)
+
+/datum/trade_product/proc/restock()
+	restocks_left--
+	maxunits++
+
+/datum/trade_product/proc/isflashed()
+	if(SStrade.flash_sale_target == src)
+		return 0.7
+	return 1
 
 /datum/trade_product/wardrobe
 	name = "Wonderful Wardrobe"
@@ -54,17 +74,20 @@
 	path = /obj/item/weapon/mech_expansion_kit
 	baseprice = 50
 	maxunits = 3
+	restocks_left = 3
 
 /datum/trade_product/wetdryvac
 	name = "wet/dry vacuum"
 	path = /obj/structure/wetdryvac
 	baseprice = 50
+	restocks_left = 1
 
 /datum/trade_product/huntingrifle
 	name = "hunting rifle"
 	path = /obj/item/weapon/gun/projectile/hecate/hunting
 	baseprice = 100
 	maxunits = 2
+	restocks_left = 3
 
 /datum/trade_product/fakeposter
 	name = "cargo cache kit"
@@ -88,6 +111,7 @@
 	path = /obj/item/weapon/storage/box/mysterycubes
 	baseprice = 80
 	maxunits = 2
+	restocks_left = 2
 	sales_category = TRADE_VARIETY
 
 /datum/trade_product/randomchems
@@ -95,12 +119,14 @@
 	path = /obj/item/weapon/storage/box/mystery_vial
 	baseprice = 30
 	maxunits = 5
+	restocks_left = 5
 	sales_category = TRADE_VARIETY
 
 /datum/trade_product/randomcircuits
 	name = "children's circuitry booster pack"
 	path = /obj/item/weapon/storage/box/mystery_circuit
 	baseprice = 30
+	restocks_left = 2
 	sales_category = TRADE_VARIETY
 
 /datum/trade_product/randommats
@@ -108,6 +134,7 @@
 	path = /obj/item/weapon/storage/box/large/mystery_material
 	baseprice = 50
 	maxunits = 5
+	restocks_left = 5
 	sales_category = TRADE_VARIETY
 
 /datum/trade_product/oddmats
@@ -115,6 +142,7 @@
 	path = /obj/item/weapon/storage/box/large/mystery_material/odd
 	baseprice = 30
 	maxunits = 5
+	restocks_left = 5
 	sales_category = TRADE_VARIETY
 
 /datum/trade_product/randomfood
@@ -122,5 +150,6 @@
 	path = /obj/structure/closet/crate/freezer/bootlegpicnic
 	baseprice = 50
 	maxunits = 3
+	restocks_left = 3
 	sales_category = TRADE_VARIETY
 

--- a/code/modules/trader/trade_responses.dm
+++ b/code/modules/trader/trade_responses.dm
@@ -44,6 +44,13 @@ var/static/list/tw_advice = list("remember, buy low, sell high.", "hey, there's 
 var/static/list/tw_induct_cantspeak = list("If you don't speak the language, this is going to be tough. ", "These words are lost on you, eh? ","This book has what you need to get started. ")
 var/static/list/tw_induct_traditional = list("I dub thee, trader. Here, you get these, too. ", "These are for you. Little gift. ", "Something else - traditional for starting out. ")
 
+var/static/tw_deposit_zero = list("Yeah, yeah, push the button all you like, you've got nothing there.", "Is this supposed to be funny?", "No money on the table.", "Put some cash on the table if you want me to deposit it for you.", "There's nothing here to deposit.", "Hey, contributing to the Shoal isn't a joke!", "Keh, you forget something?")
+var/static/tw_deposit_low = list("Keep the change, eh? Well, I will. ", "Couple bucks here and there adds up. ", "Not much, but in it goes. ", "Keh? Oh, sure, I'll put it in. ", "Just zero out the scraps then, eh? ")
+var/static/tw_deposit_notable = list("This is a good amount. Feel the heft in the creds, yeah? ", "Building up your reputation. Let this deposit be the next brick, eh? ", "That's the way. That's not petty cash. ", "Good cut. Doing well for yourself? ", "Pleasure's all mine. ")
+var/static/tw_deposit_large = list("Keh, keh. Very good! Let's stash that away... ", "Well now, don't mind if I do. Let's just move aaaaall this into the account. ", "Keh, don't tease me, you better not just withdraw this right away! ", "The Shoal appreciates your contributions. ", "A very good pleasure doing business with you. ")
+
+var/static/tw_deposit_firsttime = list("Remember, you can still withdraw this later, if you need.", "This is everyone's money - it's shared. Don't forget the PIN.", "This money will be put to good use - don't worry, you can still take it out!")
+
 /obj/structure/trade_window/proc/greet(mob/living/carbon/human/user)
 	var/buildgreet
 	var/username = user.get_face_name()
@@ -98,15 +105,7 @@ var/static/list/tw_induct_traditional = list("I dub thee, trader. Here, you get 
 		switch(rand(1,20))
 			if(1 to 7) //33% chance to say nothing else.
 			if(8 to 10) //Comment on shoal account
-				switch(trader_account.money)
-					if(0)
-						buildgreet += pick(tw_empty_shoal)
-					if(1 to 499)
-						buildgreet += pick(tw_low_shoal)
-					if(500 to 999)
-						buildgreet += pick(tw_satisfied_shoal)
-					if(1000 to INFINITY)
-						buildgreet += pick(tw_high_shoal)
+				buildgreet += shoal_account_commentary()
 			if(11 to 13) //Comment on sales
 				switch(SStrade.loyal_customers[username])
 					if(0 to 299)
@@ -138,3 +137,40 @@ var/static/list/tw_induct_traditional = list("I dub thee, trader. Here, you get 
 		return replacetext(replacetext(pick(tw_advertise_low_price),"TWPRODUCT",target_product), "TWRATE",readable_rate)
 	else
 		return pick(tw_advertise_generic)
+
+/obj/structure/trade_window/proc/comment_deposit(mob/living/carbon/human/user, value)
+	if(!trader_account.money)
+		say(pick(tw_deposit_firsttime))
+		return
+	var/newtotal = trader_account.money + value
+	var/buildcomment
+	switch(value)
+		if(1 to 49)
+			buildcomment = pick(tw_deposit_low)
+			if(prob(75))
+				buildcomment += shoal_account_commentary(newtotal)
+		if(50 to 199)
+			buildcomment = pick(tw_deposit_notable)
+			if(prob(33))
+				buildcomment += shoal_account_commentary(newtotal)
+		if(200 to INFINITY)
+			buildcomment = pick(tw_deposit_large)
+			if(prob(15))
+				buildcomment += shoal_account_commentary(newtotal)
+	buildcomment = trim(buildcomment)
+	say(buildcomment)
+
+/obj/structure/trade_window/proc/shoal_account_commentary(value = null)
+	if(!value)
+		value = trader_account.money
+	var/reply
+	switch(value)
+		if(0)
+			reply += pick(tw_empty_shoal)
+		if(1 to 499)
+			reply += pick(tw_low_shoal)
+		if(500 to 999)
+			reply += pick(tw_satisfied_shoal)
+		if(1000 to INFINITY)
+			reply += pick(tw_high_shoal)
+	return reply

--- a/code/modules/trader/trade_system.dm
+++ b/code/modules/trader/trade_system.dm
@@ -29,6 +29,8 @@ var/datum/subsystem/trade_system/SStrade
 		market_flux()
 	restock_chance()
 	flash_sale()
+	for(var/obj/structure/trade_window/TW in all_twindows)
+		nanomanager.update_uis(TW)
 
 /datum/subsystem/trade_system/proc/market_flux(var/update_windows = TRUE)
 	for(var/datum/trade_product/TP in all_trade_merch)
@@ -48,8 +50,6 @@ var/datum/subsystem/trade_system/SStrade
 				continue
 			flash_sale_target = TP
 			return
-	for(var/obj/structure/trade_window/TW in all_twindows)
-		nanomanager.update_uis(TW)
 
 /datum/subsystem/trade_system/proc/restock_chance()
 	//Every 100 in the account gives a 1% chance for a restocked item, up to 10%

--- a/code/modules/trader/trade_system.dm
+++ b/code/modules/trader/trade_system.dm
@@ -8,7 +8,8 @@ var/datum/subsystem/trade_system/SStrade
 	name       = "Trade System"
 	init_order    = SS_INIT_OBJECT+0.1 //Always initialize just before objects
 	flags = SS_TICKER
-	wait       = SS_WAIT_ENGINES //check in no more than once every thirty seconds
+	wait       = (3*SS_WAIT_ENGINES) //check in no more than once every thirty seconds
+	var/datum/trade_product/flash_sale_target = null //An extra 30% off!
 	var/list/all_twindows = list() //All trade windows
 	var/list/all_trade_merch = list() //The list of all trade products, kept as elements
 	var/list/trade_databank = list() //The above, converted to associative list format for use in UI
@@ -26,6 +27,8 @@ var/datum/subsystem/trade_system/SStrade
 /datum/subsystem/trade_system/fire(resumed = FALSE)
 	if(prob(FLUX_CHANCE))
 		market_flux()
+	restock_chance()
+	flash_sale()
 
 /datum/subsystem/trade_system/proc/market_flux(var/update_windows = TRUE)
 	for(var/datum/trade_product/TP in all_trade_merch)
@@ -33,6 +36,40 @@ var/datum/subsystem/trade_system/SStrade
 	if(update_windows)
 		for(var/obj/structure/trade_window/TW in all_twindows)
 			TW.market_flux()
+
+/datum/subsystem/trade_system/proc/flash_sale()
+	//Every 10 in the account gives a 1% chance for a flash sale, up to 100% at 1000
+	flash_sale_target = null
+	var/prestige = trader_account.money
+	if(prestige >= 1000 || prob(round(prestige/10)))
+		var/shuffled = shuffle(all_trade_merch)
+		for(var/datum/trade_product/TP in shuffled)
+			if(TP.totalsold >= TP.maxunits)
+				continue
+			flash_sale_target = TP
+			return
+	for(var/obj/structure/trade_window/TW in all_twindows)
+		nanomanager.update_uis(TW)
+
+/datum/subsystem/trade_system/proc/restock_chance()
+	//Every 100 in the account gives a 1% chance for a restocked item, up to 10%
+	//In excess of 1000, you get extra rolls, up to three rolls.
+	var/sector_prestige = min(3000,trader_account.money)
+	while(sector_prestige>1000)
+		restock()
+		sector_prestige -= 1000
+	if(sector_prestige && prob(round(sector_prestige/100)))
+		restock()
+
+/datum/subsystem/trade_system/proc/restock()
+	var/list/weighted_restocks = list()
+	for(var/datum/trade_product/TP in all_trade_merch)
+		if(!TP.can_restock())
+			continue
+		weighted_restocks[TP] = TP.restock_weight()
+	var/datum/trade_product/tostock = pickweight(weighted_restocks)
+	if(tostock)
+		tostock.restock()
 
 /datum/subsystem/trade_system/proc/rebuild_databank(mob/user)
 	trade_databank.Cut() //empty the list
@@ -46,6 +83,7 @@ var/datum/subsystem/trade_system/SStrade
 		product_to_list["name"] = TP.name
 		product_to_list["price"] = TP.current_price(user)
 		product_to_list["marketforces"] = round(100*(TP.flux_rate - 1))
+		product_to_list["flashed"] = (TP.isflashed() == 1 ? FALSE : TRUE)
 		product_to_list["category"] = TP.sales_category
 		product_to_list["remaining"] = TP.maxunits - TP.totalsold
 		trade_databank += list(product_to_list)

--- a/nano/templates/tradewindow.tmpl
+++ b/nano/templates/tradewindow.tmpl
@@ -8,18 +8,26 @@
 	<div class="itemLabel">
 		Credits in Shoal fund:
 	</div>
-	<div class="itemContent">
+	<div class="itemContentSmall">
 		{{:data.shoalmoney}} ({{:data.shoaldiscount}}% price)
+	</div>
+	<div class="itemContentSmall">
+		{{:helper.link("Deposit to Account", 'arrowthick-1-s', {'deposit' : 1})}}
 	</div>
 	<div class="itemLabel">
 		Past business:
 	</div>
-	<div class="itemContent">
-		{{:data.pastbusiness}} ({{:data.pastdiscount}}% price)
+	<div class="itemContentSmall">
+		{{:data.pastbusiness}} ({{:data.pastdiscount}}% price) 
+	</div>
+	<div class="itemContentSmall">
+		{{if data.pastbusiness == "Admin"}}
+			{{:helper.link("Admin: Add New", null, {'additem' : 1},null, 'yellowButton')}}
+		{{/if}}
 	</div>
 </div>
 {{for data.categories}}
-	<div class="itemContent">
+	<div class="itemContentSmall">
 		{{:helper.link(value.category, 'folder-collapsed', {'category' : value.category}, value.category == data.selectedCategory ? 'selected' : null)}}
 	</div>
 {{for}}
@@ -28,7 +36,11 @@
 	{{for data.databank}}
 		{{if value.category == data.selectedCategory}}
 			<div class="item">
-				{{:helper.link(value.name, 'cart', {'product' : value.name})}} {{:value.price}} credits ({{:value.marketforces}}% market forces)
+				{{if value.flashed}}
+					{{:helper.link(value.name, 'cart', {'product' : value.name})}} {{:value.price}} credits ({{:value.marketforces}}% market) <div class="average">(-30% Flash Sale!)</div>
+				{{else}}
+					{{:helper.link(value.name, 'cart', {'product' : value.name})}} {{:value.price}} credits ({{:value.marketforces}}% market)
+				{{/if}}
 			</div>
 		{{/if}}
 	{{for}}


### PR DESCRIPTION
Admins: when aghosting there is an "add new" button on the trade window, you can add whatever you want for sale with this.

Flash sale is picked randomly from something not sold out. It's always -30%.
1% chance to have a flash sale per system fire (30 seconds) for every 10 credits, up to 100% at 1000

Restock can happen to any product which has remaining restocks and has been purchased at least once. It's weighted to favor things you've bought more of and have more remaining restocks.
1% chance for a restock for each 100 credits, up to 10% at 1000; excess starts a new restock chance up to 3000, so potentially you get three 10% rolls to restock.

Tidied up the trade window a bit too, and also fixed a bug with the trade system firing too often (raised market flux chance to compensate)

🆑 
* rscadd: The trade window now has a button to quick-deposit anything on the table into the shoal account. This also has associated responses.
* rscadd: Having money in the shoal account now causes a chance to restock items and for flash sales.