### PR TITLE
Makes the radiation gene better

### DIFF
--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -27,24 +27,25 @@
 
 /datum/dna/gene/disability/radioactive
 	name = "Radioactive"
-	desc = "The subject suffers from constant radiation sickness and causes the same on nearby organics."
-	activation_message = "You feel a strange sickness permeate your whole body."
-	deactivation_message = "You no longer feel awful and sick all over."
+	desc = "The subject emits radiation to nearby people, but rapidly gets rid of their own radiation."
+	activation_message = "You feel a strange warmth permeate your whole body."
+	deactivation_message = "You no longer feel strangely warm."
 	flags = GENE_UNNATURAL
 
 /datum/dna/gene/disability/radioactive/New()
 	..()
 	block = RADBLOCK
 
-/datum/dna/gene/disability/radioactive/OnMobLife(var/mob/owner)
-	owner.radiation = max(owner.radiation, 20)
-	for(var/mob/living/L in range(1, owner))
-		if(L == owner)
-			continue
-		to_chat(L, "<span class='warning'>You are enveloped by a soft green glow emanating from [owner].</span>")
-		L.apply_radiation(5, RAD_EXTERNAL)
-
-	emitted_harvestable_radiation(get_turf(owner), 1, range = 2) //Around 70W, nothing much really
+/datum/dna/gene/disability/radioactive/OnMobLife(var/mob/living/owner)
+	var/radiation = owner.radiation
+	owner.radiation = max(radiation - 30, 0)
+	if(owner.getarmor(null, "rad") < 100)
+		emitted_harvestable_radiation(get_turf(owner), radiation * 100, range = 3) //1 power = ~70W, are you ready for radiation engines?
+		for(var/mob/living/L in range(1, owner))
+			if(L == owner)
+				continue
+			to_chat(L, "<span class='warning'>You are enveloped by a soft green glow emanating from [owner].</span>")
+			L.apply_radiation(5, RAD_EXTERNAL)
 
 /datum/dna/gene/disability/radioactive/OnDrawUnderlays(var/mob/M,var/g,var/fat)
 	return "rads[fat]_s"

--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -41,9 +41,7 @@
 	owner.radiation = max(radiation - 30, 0)
 	if(owner.getarmor(null, "rad") < 100)
 		emitted_harvestable_radiation(get_turf(owner), radiation * 100, range = 3) //1 power = ~70W, are you ready for radiation engines?
-		for(var/mob/living/L in range(1, owner))
-			if(L == owner)
-				continue
+		for(var/mob/living/L in orange(1, owner)) //Everyone nearby except the user
 			to_chat(L, "<span class='warning'>You are enveloped by a soft green glow emanating from [owner].</span>")
 			L.apply_radiation(5, RAD_EXTERNAL)
 


### PR DESCRIPTION
- The radiation gene now makes its user shed a serious amount of radiation at a time, does not make them immune to overwhelming amounts of radiation.
- People with the radiation gene can wear clothing such as radiation suits to prevent irradiating everyone near them, but this also prevents emitting harvestable radiation.
- Massively improved the amount of harvestable radiation (the radiation that Collectors can use to generate power, the sort that are near Singularity engines) generated, it now depends on the user's total amount of radiation before shedding some of it, which means you can now capitalize on it for possibly massive power gains. Coincidentally I must inform people that the Particle Accelerator irradiates people.
- Increased range of harvestable radiation by 1.

No longer just an "i griff and die" gene, now this has actual uses for a disability.
:cl:
 * rscadd: The radiation gene now makes people shed off a massive amount of radiation instead of passively being irradiated.
 * tweak: Radiation emitted from the radiation gene can now be prevented by having the users wear hazmat suits. No longer involuntarily kill a lot of people by just standing near them! But at the same time it prevents users from emitting radiation that can be harvested.
 * tweak: Massively improved the amount of radiation from the radiation gene that can be harvested by radiation collectors, it now depends on how irradiated the user is. Yes, you can likely capitalize on this power production method. Wink wink, nudge nudge.
 * tweak: The range of radiation that can be harvested from the radiation gene has been increased by 1 tile.
 * tweak: Changed the activation and deactivation messages of the radiation gene.