### PR TITLE
Ectoplasm tweak

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3651,7 +3651,6 @@
 	id = AMINOMICIAN
 	result = AMINOMICIAN
 	required_reagents = list(AMINOMICIN = 1, BONEMARROW = 3)
-	required_catalysts = list(RADIUM = 5)
 	result_amount = 1
 
 /datum/chemical_reaction/synthcorgi
@@ -3751,7 +3750,7 @@
 	name = "Ectoplasm"
 	id = ECTOPLASM
 	result = ECTOPLASM
-	required_reagents = list(AMINOMICIN = 1, BONEMARROW = 2, FROSTOIL = 1)
+	required_reagents = list(AMINOMICIAN = 1, FROSTOIL = 1)
 	result_amount = 1
 
 /datum/chemical_reaction/synthskeleton

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3783,6 +3783,9 @@
 				H.visible_message("<span class='danger'>[H.name]'s skeleton jumps right out of their skin, forcefully!</span>")
 				H.drop_all()
 			gibs(H.loc, H.virus2, H.dna)
+	else
+		var/L = get_turf(holder.my_atom)
+		new /mob/living/simple_animal/hostile/humanoid/skellington(L) //Should spawn skeletons normally if the holder isn't human.
 	
 /datum/chemical_reaction/synthskeleton/proc/bigBoned(var/mob/living/carbon/human/theSkel, var/volume)
 	for(var/datum/organ/external/E in theSkel.organs)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3784,8 +3784,9 @@
 				H.drop_all()
 			gibs(H.loc, H.virus2, H.dna)
 	else
-		var/L = get_turf(holder.my_atom)
-		new /mob/living/simple_animal/hostile/humanoid/skellington(L) //Should spawn skeletons normally if the holder isn't human.
+		for(var/i = 1 to created_volume)
+			var/L = get_turf(holder.my_atom)
+			new /mob/living/simple_animal/hostile/humanoid/skellington(L) //Should spawn skeletons normally if the holder isn't human.
 	
 /datum/chemical_reaction/synthskeleton/proc/bigBoned(var/mob/living/carbon/human/theSkel, var/volume)
 	for(var/datum/organ/external/E in theSkel.organs)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3766,8 +3766,10 @@
 		var/mob/living/carbon/human/H = holder.my_atom
 		if(created_volume <= 9)
 			for(var/i = 1 to created_volume)
+				var/L = get_turf(holder.my_atom)
+				new /mob/living/simple_animal/hostile/humanoid/skellington(L)
 				var/datum/organ/external/E = pick(H.organs)
-				E.fracture()
+				E.fracture() //Hopefully this means that under 10u the skellingtons still get spawned, but AT 10u you turn into one.
 		else
 			if(isskellington(H) || isskelevox(H) || islich(H))
 				bigBoned(H, created_volume)
@@ -3781,10 +3783,7 @@
 				H.visible_message("<span class='danger'>[H.name]'s skeleton jumps right out of their skin, forcefully!</span>")
 				H.drop_all()
 			gibs(H.loc, H.virus2, H.dna)
-	for(var/i = 1 to created_volume)
-		var/L = get_turf(holder.my_atom)
-		new /mob/living/simple_animal/hostile/humanoid/skellington(L)
-
+	
 /datum/chemical_reaction/synthskeleton/proc/bigBoned(var/mob/living/carbon/human/theSkel, var/volume)
 	for(var/datum/organ/external/E in theSkel.organs)
 		if(!E.is_organic() || (E.min_broken_damage >= E.max_damage))

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3750,7 +3750,7 @@
 	name = "Ectoplasm"
 	id = ECTOPLASM
 	result = ECTOPLASM
-	required_reagents = list(AMINOMICIAN = 1, FROSTOIL = 1)
+	required_reagents = list(AMINOMICIN = 1, FROSTOIL = 1)
 	result_amount = 1
 
 /datum/chemical_reaction/synthskeleton

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3651,6 +3651,7 @@
 	id = AMINOMICIAN
 	result = AMINOMICIAN
 	required_reagents = list(AMINOMICIN = 1, BONEMARROW = 3)
+	required_catalysts = list(RADIUM = 5)
 	result_amount = 1
 
 /datum/chemical_reaction/synthcorgi
@@ -3750,7 +3751,7 @@
 	name = "Ectoplasm"
 	id = ECTOPLASM
 	result = ECTOPLASM
-	required_reagents = list(AMINOMICIN = 1, FROSTOIL = 1)
+	required_reagents = list(AMINOMICIN = 1, BONEMARROW = 2, FROSTOIL = 1)
 	result_amount = 1
 
 /datum/chemical_reaction/synthskeleton


### PR DESCRIPTION
If you consumed one unit of ectoplasm and ten units of degencalcium, you'd spawn a hostile skeleton and break a bone. However, if you consumed 10 units of ectoplasn and a hundred units of degencalcium you'd turn into a skeleman or skelevox. The problem was that you turned, yes, but you also spawned 10 skelemen that were hostile and would kill you, thus making the reaction not only dangerous to you, but the crew as well.
[oversight][bugfix]
:cl:
 * tweak: Consuming 10u Ectoplasm and 100u Degenerate Calcium simultaneously no longer spawns 10 hostile skeletons and transforms you (which ensured you died thanks to the brute damage and vulnerability). Instead it now only transforms you. If you react anything below those two values simultaneously, the skeletons will still be spawned.