### PR TITLE
Enhanced Lowfat Bagel's Nar-Sie altar

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -1768,6 +1768,16 @@ var/list/arcane_tomes = list()
 			I.plane = ABOVE_HUD_PLANE // inventory
 		overlays += I
 
+/obj/item/candle/blood/proximity	// lits itself up when someone comes close (intended for mapping purposes)
+	flags = FPRINT | PROXMOVE
+
+/obj/item/candle/blood/proximity/HasProximity(var/atom/movable/AM)
+	if(isliving(AM))
+		light("<span class='notice'>\The [src] mysteriously lights itself up as \the [AM] comes close.</span>")
+		return 1
+	return 0
+
+
 /obj/item/trash/blood_candle
 	name = "blood candle"
 	desc = "A candle made out of blood moth wax, burns much longer than regular candles. Used for moody lighting and occult rituals."

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runes.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runes.dm
@@ -606,6 +606,8 @@ var/list/rune_appearances_cache = list()
 /proc/write_full_rune(var/turf/T, var/spell_type, var/datum/reagent/blood/source, var/mob/caster = null)
 	if (!spell_type)
 		return
+	if (!rune_words_initialized)
+		initialize_rune_words()
 
 	var/datum/rune_spell/spell_instance = spell_type
 	var/datum/rune_word/word1_instance = initial(spell_instance.word1)
@@ -614,3 +616,27 @@ var/list/rune_appearances_cache = list()
 	write_rune_word(T, rune_words[initial(word1_instance.english)], source, caster)
 	write_rune_word(T, rune_words[initial(word2_instance.english)], source, caster)
 	write_rune_word(T, rune_words[initial(word3_instance.english)], source, caster)
+
+/obj/rune_spawner
+	name = "rune spawner"
+	icon = 'icons/obj/rune.dmi'
+	icon_state = "4"
+	var/rune_type = null
+	var/rune_activated = FALSE
+
+
+/obj/rune_spawner/New(turf/loc)
+	..()
+	var/turf/T = get_turf(src)
+	if (rune_type)
+		write_full_rune(T,rune_type,null,null)
+
+		var/obj/effect/rune/rune = locate() in T
+		if (rune && rune_activated)
+			rune.activated = 1
+			rune.update_icon()
+	qdel(src)
+
+/obj/rune_spawner/random/New(turf/loc)
+	rune_type = pick(subtypesof(/datum/rune_spell))
+	..()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7573912/137236347-8ca4c262-2846-4c5c-a555-86109849daf0.png)

* Replaced the bugged modified "blood" candles with actual cult 4 blood candles. Those spawn unlit, but magically lit up when someone comes adjacent.
* Removed the bugged invisible runes, instead added two "rune spawners" that spawn with a random rune (it's always an actual rune)
* Replaced the plating with cult floors
* Replaced the mysterious altar with an actual cult altar, which isn't a problem anymore now that altars aren't tied to cult progression