### PR TITLE
Skeleton traders will no longer spawn naked

### DIFF
--- a/code/datums/outfit/trader.dm
+++ b/code/datums/outfit/trader.dm
@@ -29,8 +29,22 @@
 			slot_wear_suit_str = /obj/item/clothing/suit/space/vox/civ/mushmen,
 			slot_head_str = /obj/item/clothing/head/helmet/space/vox/civ/mushmen,
 			slot_wear_mask_str =  /obj/item/clothing/mask/breath,
+		),
+		/datum/species/skellington/skelevox = list(
+			slot_w_uniform_str =/obj/item/clothing/under/vox/vox_robes,
+			slot_shoes_str = /obj/item/clothing/shoes/magboots/vox,
+			slot_belt_str = /obj/item/device/radio,
+			slot_wear_suit_str = /obj/item/clothing/suit/space/vox/civ/trader,
+			slot_head_str = /obj/item/clothing/head/helmet/space/vox/civ/trader,
+			slot_wear_mask_str =  /obj/item/clothing/mask/breath/vox,
 		)
+
 	)
+
+	equip_survival_gear = list(
+		/datum/species/vox = /obj/item/weapon/storage/box/survival/engineer/vox,
+	)
+
 
 	items_to_collect = list(
 		/obj/item/weapon/storage/wallet/trader = SURVIVAL_BOX,


### PR DESCRIPTION
Contributed by an anonymous coder.
Also gives traders a slightly better survival gear roundstart. Did someone say powercreep?