### PR TITLE
Phazon solidification tweak.

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -876,6 +876,7 @@
 	id = "solidphazon"
 	result = null
 	required_reagents = list(SILICATE = 10, FROSTOIL = 10, PHAZON = 1)
+	required_catalysts = list(MUTAGEN = 5)
 	result_amount = 1
 
 /datum/chemical_reaction/solidification/phazon/product_to_spawn()


### PR DESCRIPTION
To solidify Bananium you need to use 1u Phazon Salt as a catalyst. The problem is that the Phazon solidification recipe takes priority most of the time, meaning you solidify your 1u of Phazon and not the Bananium. This should fix that oversight.

[oversight]
:cl:
 * tweak: Phazon solidification now requires 5u Mutagen as catalyst. 