### PR TITLE
Fixes smelting runtime

### DIFF
--- a/code/modules/blacksmithing/forge.dm
+++ b/code/modules/blacksmithing/forge.dm
@@ -134,6 +134,8 @@
 		return
 	if(heating)
 		heating.attempt_heating(src, null)
+		if(heating.gcDestroyed)
+			heating = null
 
 
 //Prefer to burn through sheets over ores

--- a/code/modules/unit_tests/__unit_test_includes.dm
+++ b/code/modules/unit_tests/__unit_test_includes.dm
@@ -17,6 +17,7 @@
 #include "ray.dm"
 #include "vector.dm"
 #include "reagent_ids.dm"
+#include "smelting.dm"
 #include "supermatter_airflow.dm"
 #include "languages.dm"
 #include "hour_calculations.dm"

--- a/code/modules/unit_tests/smelting.dm
+++ b/code/modules/unit_tests/smelting.dm
@@ -1,0 +1,20 @@
+/datum/unit_test/smelting/start()
+/datum/unit_test/smelting/forge/start()
+	var/turf/centre = locate(101, 101, 1)
+
+	var/obj/item/stack/ore/gold/gold = new(centre, 20)
+	var/mob/living/carbon/human/human = new(centre)
+	var/obj/structure/forge/forge = new(centre)
+
+	human.put_in_active_hand(gold)
+	assert_eq(forge.attackby(gold, human), 1)
+
+	forge.fuel_time = 100
+	forge.current_temp = TEMPERATURE_PLASMA
+	forge.toggle_lit()
+	assert_eq(forge.status, TRUE)
+	assert_eq(forge.heating, gold)
+
+	forge.process()
+	assert_eq(forge.heating, null)
+	assert_eq(gold.gcDestroyed, "Bye, world!")


### PR DESCRIPTION
Closes #31079

Sand and metal are smeltable, they need plasma as fuel

This fixes the invisible ore, unit test included

`attempt_heating()` is still a mess

:cl:
 * bugfix: Fixed forge ore being invisible after smelting