### PR TITLE
Wrecked RTGs become Broken Cells.

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -294,6 +294,6 @@
 	
 /obj/item/weapon/cell/broken/New()
 	..()
-	desc = "The inner circuitry have melted and it bulges at the sides. <span class='warning'>You feel it will explode any moment now.</span>"
+	desc = "The inner circuitry have melted and it bulges at the sides. <span class='warning'>It will explode any moment now.</span>"
 	if(prob(5))
-		rigged = true //since rigged uses maxcharge, the explosion should be 0-0-0
+		explosion(loc, 0, 1, 2, 2)//smallish explosion

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -259,9 +259,9 @@
 		charge = 0
 		maxcharge = 0
 		desc = "The inner circuitry melted and the paint flaked off. It bulges slightly at the sides. <span class='warning'>It's going to explode any moment now.</span>"
-		if(explodium = TRUE)
-			if(prob(5))
-				explosion(loc, 0, 1, 2, 2)//smallish explosion
+	if(explodium = TRUE)
+		if(prob(5))
+			explosion(loc, 0, 1, 2, 2)//smallish explosion
 		
 /obj/item/weapon/cell/rad/emp_act(severity)
 	..()

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -255,7 +255,7 @@
 		explodium = TRUE
 		name = "broken cell"
 		icon_state = "cell"
-		starting_materials = list(MAT_IRON = 200, MAT_GLASS = 30
+		starting_materials = list(MAT_IRON = 200, MAT_GLASS = 30)
 		charge = 0
 		maxcharge = 0
 		desc = "The inner circuitry melted and the paint flaked off. It bulges slightly at the sides. <span class='warning'>It's going to explode any moment now.</span>"

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -250,7 +250,7 @@
 	if(prob(5))
 		for(var/mob/living/L in view(get_turf(src), max(5,(maxcharge/charge))))
 			L.apply_radiation(charge_rate/10, RAD_EXTERNAL)
-	if(charge_rate < (initial(charge_rate)/10)) //if charge rate goes under 10% of the original value, deletes itself and spawns a broken cell in its place, broken cell has a 5% chance to "explode".
+	if(charge_rate < (initial(charge_rate)/10)) //if charge rate goes under 10% of the original value it transforms into broken cell which has no charge rate, 0 max charge and has a 5% chance to "explode".
 		empable = FALSE
 		explodium = TRUE
 		name = "broken cell"
@@ -258,6 +258,7 @@
 		starting_materials = list(MAT_IRON = 200, MAT_GLASS = 30)
 		charge = 0
 		maxcharge = 0
+		charge_rate = 0
 		desc = "The inner circuitry melted and the paint flaked off. It bulges slightly at the sides. <span class='warning'>It's going to explode any moment now.</span>"
 	if(explodium == TRUE)
 		if(prob(5))

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -241,6 +241,9 @@
 	return
 
 /obj/item/weapon/cell/rad/process()
+	if(!maxcharge && prob(5)) //5% chance to explode every 2 seconds if the cell is broken
+		explosion(loc, 0, 1, 2, 2)
+		qdel(src)
 	if(maxcharge <= charge)
 		return 0
 	var/power_used = min(maxcharge-charge,charge_rate)
@@ -248,7 +251,7 @@
 	if(prob(5))
 		for(var/mob/living/L in view(get_turf(src), max(5,(maxcharge/charge))))
 			L.apply_radiation(charge_rate/10, RAD_EXTERNAL)
-	if(charge_rate < (initial(charge_rate)/10)) //if charge rate goes under 10% of the original value it transforms into broken cell that has no charge rate, 0 max charge and a 5% chance to explode.
+	if(charge_rate < (initial(charge_rate)/10))	//turns into a broken cell with no charge rate, 0 max charge and a 5% chance to explode every 2s
 		name = "broken cell"
 		icon_state = "cell"
 		starting_materials = list(MAT_IRON = 200, MAT_GLASS = 30)
@@ -257,9 +260,7 @@
 		charge_rate = 0
 		damaged = FALSE //so you don't get the damaged examine if the cell is broken
 		desc = "The inner circuitry melted and the paint flaked off. It bulges slightly at the sides. <span class='warning'>It's going to explode any moment now.</span>"
-		if(prob(5))
-			explosion(loc, 0, 1, 2, 2)//smallish explosion
-			qdel(src) //in the  event the cell explodes but isn't destroyed somehow, it also self deletes
+
 		
 /obj/item/weapon/cell/rad/emp_act(severity)
 	..()

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -224,7 +224,9 @@
 	starting_materials = list(MAT_IRON = 600, MAT_GLASS = 90, MAT_URANIUM = 40)
 	var/charge_rate = 100
 	var/damaged = FALSE
-
+	var/empable = TRUE
+	var/explodium = FALSE
+	
 /obj/item/weapon/cell/rad/empty/New()
 	..()
 	charge = 0
@@ -249,25 +251,37 @@
 		for(var/mob/living/L in view(get_turf(src), max(5,(maxcharge/charge))))
 			L.apply_radiation(charge_rate/10, RAD_EXTERNAL)
 	if(charge_rate < (initial(charge_rate)/10)) //if charge rate goes under 10% of the original value, deletes itself and spawns a broken cell in its place, broken cell has a 5% chance to "explode".
-		qdel(src)
-		new /obj/item/weapon/cell/broken(get_turf(src)) //if I understand this correctly, it should spawn the cell inside whatever had it beforehand
+		empable = FALSE
+		explodium = TRUE
+		name = "broken cell"
+		icon_state = "cell"
+		starting_materials = list(MAT_IRON = 200, MAT_GLASS = 30
+		charge = 0
+		maxcharge = 0
+		desc = "The inner circuitry melted and the paint flaked off. It bulges slightly at the sides. <span class='warning'>It's going to explode any moment now.</span>"
+		if(explodium = TRUE)
+			if(prob(5))
+				explosion(loc, 0, 1, 2, 2)//smallish explosion
 		
 /obj/item/weapon/cell/rad/emp_act(severity)
 	..()
-	switch(rand(3))
-		if(0)
-			charge_rate *= severity*0.3
-			damaged = TRUE
-		if(1)
-			maxcharge *= severity*0.3
-			charge = 0
-		if(2)
-			maxcharge *= severity*0.3
-			charge = 0
-			charge_rate *= severity*0.3
-			damaged = TRUE
-		if(3)
-			return
+	if(empable = true)
+		switch(rand(3))
+			if(0)
+				charge_rate *= severity*0.2
+				damaged = TRUE
+			if(1)
+				maxcharge *= severity*0.2
+				charge = 0
+			if(2)
+				maxcharge *= severity*0.2
+				charge = 0
+				charge_rate *= severity*0.2
+				damaged = TRUE
+			if(3)
+				return
+	else
+		return
 
 /obj/item/weapon/cell/rad/examine(mob/user)
 	..()
@@ -285,15 +299,3 @@
 /obj/item/weapon/cell/rad/large/empty/New()
 	..()
 	charge = 0
-	
-/obj/item/weapon/cell/broken
-	name = "broken cell"
-	icon_state = "cell"
-	maxcharge = 0
-	starting_materials = list(MAT_IRON = 200, MAT_GLASS = 30)
-	
-/obj/item/weapon/cell/broken/New()
-	..()
-	desc = "The inner circuitry melted and the paint flaked off. It bulges slightly at the sides. <span class='warning'>It can explode any moment now.</span>"
-	if(prob(5))
-		explosion(loc, 0, 1, 2, 2)//smallish explosion

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -248,7 +248,7 @@
 	if(prob(5))
 		for(var/mob/living/L in view(get_turf(src), max(5,(maxcharge/charge))))
 			L.apply_radiation(charge_rate/10, RAD_EXTERNAL)
-	if(charge_rate < (initial(charge_rate)/10) //if charge rate goes under 10% of the original value, deletes itself and spawns a broken cell in its place, broken cell has a 5% chance to "explode".
+	if(charge_rate < (initial(charge_rate)/10)) //if charge rate goes under 10% of the original value, deletes itself and spawns a broken cell in its place, broken cell has a 5% chance to "explode".
 		qdel(src)
 		new /obj/item/weapon/cell/broken(get_turf(src)) //if I understand this correctly, it should spawn the cell inside whatever had it beforehand
 		

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -248,7 +248,10 @@
 	if(prob(5))
 		for(var/mob/living/L in view(get_turf(src), max(5,(maxcharge/charge))))
 			L.apply_radiation(charge_rate/10, RAD_EXTERNAL)
-
+	if(charge_rate < (initial(charge_rate)/10) //if charge rate goes under 10% of the original value, deletes itself and spawns a broken cell in its place, broken cell has a 5% chance to "explode".
+		qdel(src)
+		new /obj/item/weapon/cell/broken(get_turf(src)) //if I understand this correctly, it should spawn the cell inside whatever had it beforehand
+		
 /obj/item/weapon/cell/rad/emp_act(severity)
 	..()
 	switch(rand(3))
@@ -282,3 +285,15 @@
 /obj/item/weapon/cell/rad/large/empty/New()
 	..()
 	charge = 0
+	
+/obj/item/weapon/cell/broken
+	name = "broken cell"
+	icon_state = "cell"
+	maxcharge = 0
+	starting_materials = list(MAT_IRON = 200, MAT_GLASS = 30)
+	
+/obj/item/weapon/cell/broken/New()
+	..()
+	desc = "The inner circuitry have melted and it bulges at the sides. <span class='warning'>You feel it will explode any moment now.</span>"
+	if(prob(5))
+		rigged = true //since rigged uses maxcharge, the explosion should be 0-0-0

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -224,8 +224,6 @@
 	starting_materials = list(MAT_IRON = 600, MAT_GLASS = 90, MAT_URANIUM = 40)
 	var/charge_rate = 100
 	var/damaged = FALSE
-	var/empable = TRUE
-	var/explodium = FALSE
 	
 /obj/item/weapon/cell/rad/empty/New()
 	..()
@@ -250,23 +248,22 @@
 	if(prob(5))
 		for(var/mob/living/L in view(get_turf(src), max(5,(maxcharge/charge))))
 			L.apply_radiation(charge_rate/10, RAD_EXTERNAL)
-	if(charge_rate < (initial(charge_rate)/10)) //if charge rate goes under 10% of the original value it transforms into broken cell which has no charge rate, 0 max charge and has a 5% chance to "explode".
-		empable = FALSE
-		explodium = TRUE
+	if(charge_rate < (initial(charge_rate)/10)) //if charge rate goes under 10% of the original value it transforms into broken cell that has no charge rate, 0 max charge and a 5% chance to explode.
 		name = "broken cell"
 		icon_state = "cell"
 		starting_materials = list(MAT_IRON = 200, MAT_GLASS = 30)
 		charge = 0
 		maxcharge = 0
 		charge_rate = 0
+		damaged = FALSE //so you don't get the damaged examine if the cell is broken
 		desc = "The inner circuitry melted and the paint flaked off. It bulges slightly at the sides. <span class='warning'>It's going to explode any moment now.</span>"
-	if(explodium == TRUE)
 		if(prob(5))
 			explosion(loc, 0, 1, 2, 2)//smallish explosion
+			qdel(src) //in the  event the cell explodes but isn't destroyed somehow, it also self deletes
 		
 /obj/item/weapon/cell/rad/emp_act(severity)
 	..()
-	if(empable == TRUE)
+	if(maxcharge > 0)
 		switch(rand(3))
 			if(0)
 				charge_rate *= severity*0.2
@@ -279,11 +276,7 @@
 				charge = 0
 				charge_rate *= severity*0.2
 				damaged = TRUE
-			if(3)
-				return
-	else
-		return
-
+			
 /obj/item/weapon/cell/rad/examine(mob/user)
 	..()
 	if(damaged)

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -259,13 +259,13 @@
 		charge = 0
 		maxcharge = 0
 		desc = "The inner circuitry melted and the paint flaked off. It bulges slightly at the sides. <span class='warning'>It's going to explode any moment now.</span>"
-	if(explodium = TRUE)
+	if(explodium == TRUE)
 		if(prob(5))
 			explosion(loc, 0, 1, 2, 2)//smallish explosion
 		
 /obj/item/weapon/cell/rad/emp_act(severity)
 	..()
-	if(empable = true)
+	if(empable == TRUE)
 		switch(rand(3))
 			if(0)
 				charge_rate *= severity*0.2

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -294,6 +294,6 @@
 	
 /obj/item/weapon/cell/broken/New()
 	..()
-	desc = "The inner circuitry have melted and it bulges at the sides. <span class='warning'>It will explode any moment now.</span>"
+	desc = "The inner circuitry melted and the paint flaked off. It bulges slightly at the sides. <span class='warning'>It can explode any moment now.</span>"
 	if(prob(5))
 		explosion(loc, 0, 1, 2, 2)//smallish explosion


### PR DESCRIPTION
Fixes that exploit with the radcells and EMPs. If the radcells' self charge goes under 10% of the original value, the cell malfunctions and turns into a broken cell. Broken cells have a 5% chance to explode with a 1-2-2 explosion, but you can use an Autolathe to recycle them.

Closes #29512
Closes #29511
[bugfix][oversight]

:cl:
 * rscadd: Radcells that are too damaged become broken cells. Broken cells have a 5% chance to explode every 2 seconds.
 * rscadd: Broken radcells can be safely disposed of in recycling or an autolathe. Mind you that it can explode before you make it there in time.
 * tweak: Slightly reduced cell damage from EMPs, they still discharge as normal however.