### PR TITLE
Fixes midround rulesets picking logged out players

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -112,6 +112,10 @@
 			message_admins("[name]: Applicant was null. This may be caused if the mind changed bodies after applying.")
 			i++
 			continue
+		if(!applicant.key)
+			message_admins("[name] was chosen but he logged out, picking another...")
+			i++
+			continue
 		message_admins("DEBUG: Selected [applicant] for rule.")
 
 		var/mob/new_character = applicant


### PR DESCRIPTION
This should fix this runtime

[17:14:36] Runtime in catbeast.dm,137: Cannot read null.current
  proc name: process (/datum/role/catbeast/process)
  src: loose catbeast (/datum/role/catbeast)
  call stack:
  loose catbeast (/datum/role/catbeast): process()
  Dynamic Mode (/datum/gamemode/dynamic): process()
  Dynamic Mode (/datum/gamemode/dynamic): process()
  /datum/controller/gameticker (/datum/controller/gameticker): process()
  Ticker (/datum/subsystem/ticker): fire(0)
  Ticker (/datum/subsystem/ticker): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()

:cl:
 * bugfix: Midround rulesets no longer picks logged out ghosts