### PR TITLE
Shuttle wall smoothing update

### DIFF
--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -11,7 +11,7 @@
 /turf/simulated/wall/shuttle/canSmoothWith()
 	var/static/list/smoothables = list(
 		/turf/simulated/wall/shuttle,
-		/obj/machinery/door/unpowered/shuttle,
+		/obj/machinery/door,
 		/obj/structure/shuttle,
 		/obj/structure/grille,
 	)

--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -13,8 +13,15 @@
 		/turf/simulated/wall/shuttle,
 		/obj/machinery/door/unpowered/shuttle,
 		/obj/structure/shuttle,
+		/obj/structure/grille,
 	)
 	return smoothables
+
+/turf/simulated/wall/shuttle/isSmoothableNeighbor(atom/A)
+	if (get_area(A) != get_area(src))
+		return 0
+
+	return ..()
 
 /turf/simulated/wall/shuttle/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	user.delayNextAttack(8)


### PR DESCRIPTION
[tweak]
![image](https://user-images.githubusercontent.com/57303506/137598486-39c7d933-bbad-47a0-9ff2-286bd4142b8a.png)
:cl:
 * tweak: Shuttle walls can now smooth with all grilles and doors.
 * tweak: Shuttle walls now only smooth with things in the same "area". (ie. shuttle)