### PR TITLE
Player spawn reworks

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -205,8 +205,8 @@ var/stacking_limit = 90
 	log_admin("Parameters were: centre = [curve_centre_of_round], width = [curve_width_of_round].")
 
 	var/rst_pop = 0
-	for(var/mob/new_player/player in player_list)
-		if(player.ready && player.mind)
+	for(var/mob/living/carbon/human/player in player_list)
+		if(player.mind)
 			rst_pop++
 	if (rst_pop >= high_pop_limit)
 		message_admins("DYNAMIC MODE: Mode: High Population Override is in effect! ([rst_pop]/[high_pop_limit]) Threat Level will have more impact on which roles will appear, and player population less.")
@@ -253,8 +253,8 @@ var/stacking_limit = 90
 		var/datum/dynamic_ruleset/midround/DR = rule
 		if (initial(DR.weight))
 			midround_rules += new rule()
-	for(var/mob/new_player/player in player_list)
-		if(player.ready && player.mind)
+	for(var/mob/living/carbon/human/player in player_list)
+		if(player.mind)
 			roundstart_pop_ready++
 			candidates.Add(player)
 	message_admins("DYNAMIC MODE: Listing [roundstart_rules.len] round start rulesets, and [candidates.len] players ready.")
@@ -338,8 +338,8 @@ var/stacking_limit = 90
 		extra_rulesets_amount = 0
 	else
 		var/rst_pop = 0
-		for(var/mob/new_player/player in player_list)
-			if(player.ready && player.mind)
+		for(var/mob/living/carbon/human/player in player_list)
+			if(player.mind)
 				rst_pop++
 		if (rst_pop > high_pop_limit)
 			if (threat_level > 50)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -127,6 +127,13 @@
 /datum/dynamic_ruleset/latejoin/ninja/execute()
 	var/mob/M = pick(assigned)
 	var/turf/oldloc = get_turf(M)
+	var/obj/effect/landmark/templand
+	for(var/obj/effect/landmark/start/S in landmarks_list)
+		if(A.name == "start")
+			templand = S
+			break
+	if(templand)
+		M.forceMove(get_turf(templand))
 	if(!latejoinprompt(M,src))
 		message_admins("[M.key] has opted out of becoming a ninja.")
 		M.forceMove(oldloc)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -96,6 +96,7 @@
 		federation = ticker.mode.CreateFaction(/datum/faction/wizard, null, 1)
 	var/mob/M = pick(assigned)
 	var/datum/role/wizard/newWizard = new
+	M.forceMove(pick(wizardstart))
 	newWizard.AssignToRole(M.mind,1)
 	federation.HandleRecruitedRole(newWizard)
 	newWizard.Greet(GREET_LATEJOIN)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -129,6 +129,7 @@
 	if(!latejoinprompt(M,src))
 		message_admins("[M.key] has opted out of becoming a ninja.")
 		return 0
+	M.forceMove(pick(ninjastart))
 	var/datum/role/ninja/newninja = new
 	newninja.AssignToRole(M.mind,1)
 	var/datum/faction/spider_clan/spoider = find_active_faction_by_type(/datum/faction/spider_clan)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -127,16 +127,16 @@
 /datum/dynamic_ruleset/latejoin/ninja/execute()
 	var/mob/M = pick(assigned)
 	var/turf/oldloc = get_turf(M)
-	M.forceMove(pick(ninjastart))
 	if(!latejoinprompt(M,src))
 		message_admins("[M.key] has opted out of becoming a ninja.")
 		M.forceMove(oldloc)
 		return 0
-	var/datum/role/ninja/newninja = new
-	newninja.AssignToRole(M.mind,1)
 	var/datum/faction/spider_clan/spoider = find_active_faction_by_type(/datum/faction/spider_clan)
 	if (!spoider)
 		spoider = ticker.mode.CreateFaction(/datum/faction/spider_clan, null, 1)
+	var/datum/role/ninja/newninja = new
+	M.forceMove(pick(ninjastart))
+	newninja.AssignToRole(M.mind,1)
 	spoider.HandleRecruitedRole(newninja)
 	newninja.Greet(GREET_DEFAULT)
 	return 1

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -127,13 +127,7 @@
 /datum/dynamic_ruleset/latejoin/ninja/execute()
 	var/mob/M = pick(assigned)
 	var/turf/oldloc = get_turf(M)
-	var/obj/effect/landmark/templand
-	for(var/obj/effect/landmark/start/S in landmarks_list)
-		if(S.name == "start")
-			templand = S
-			break
-	if(templand)
-		M.forceMove(get_turf(templand))
+	M.forceMove(null)
 	if(!latejoinprompt(M,src))
 		message_admins("[M.key] has opted out of becoming a ninja.")
 		M.forceMove(oldloc)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -129,7 +129,7 @@
 	var/turf/oldloc = get_turf(M)
 	var/obj/effect/landmark/templand
 	for(var/obj/effect/landmark/start/S in landmarks_list)
-		if(A.name == "start")
+		if(S.name == "start")
 			templand = S
 			break
 	if(templand)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -126,10 +126,12 @@
 
 /datum/dynamic_ruleset/latejoin/ninja/execute()
 	var/mob/M = pick(assigned)
+	var/turf/oldloc = get_turf(M)
+	M.forceMove(pick(ninjastart))
 	if(!latejoinprompt(M,src))
 		message_admins("[M.key] has opted out of becoming a ninja.")
+		M.forceMove(oldloc)
 		return 0
-	M.forceMove(pick(ninjastart))
 	var/datum/role/ninja/newninja = new
 	newninja.AssignToRole(M.mind,1)
 	var/datum/faction/spider_clan/spoider = find_active_faction_by_type(/datum/faction/spider_clan)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -544,7 +544,7 @@
 //////////////////////////////////////////////
 
 /datum/dynamic_ruleset/midround/from_ghosts/time_agent
-	name = "time agent anomaly"
+	name = "Time Agent Anomaly"
 	role_category = /datum/role/time_agent
 	required_candidates = 1
 	weight = 4
@@ -563,8 +563,6 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/time_agent/setup_role(var/datum/role/newagent)
 	var/datum/faction/time_agent/agency = find_active_faction_by_type(/datum/faction/time_agent)
-	if (!agency)
-		agency = ticker.mode.CreateFaction(/datum/faction/time_agent, null, 1)
 	agency.HandleRecruitedRole(newagent)
 
 	return ..()
@@ -574,6 +572,11 @@
 		return 0
 	return ..()
 
+/datum/dynamic_ruleset/midround/from_ghosts/time_agent/finish_setup(var/mob/new_character, var/index)
+	if (!find_active_faction_by_type(/datum/faction/time_agent))
+		ticker.mode.CreateFaction(/datum/faction/time_agent, null, 1)
+	new_character.forceMove(pick(timeagentstart))
+	..()
 
 //////////////////////////////////////////////
 //                                          //
@@ -833,6 +836,8 @@
 
 	new_character = generate_ruleset_body(new_character)
 	var/datum/role/new_role = new role_category
+	var/obj/structure/bed/chair/chair = pick(prisonerstart)
+	new_character.forceMove(get_turf(chair))
 	new_role.AssignToRole(new_character.mind,1)
 	setup_role(new_role)
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -358,7 +358,23 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/nuclear/finish_setup(var/mob/new_character, var/index)
 	var/datum/faction/syndicate/nuke_op/nuclear = find_active_faction_by_type(/datum/faction/syndicate/nuke_op)
+	if(!nuclear)
+		nuclear = ticker.mode.CreateFaction(/datum/faction/syndicate/nuke_op, null, 1)
 	nuclear.forgeObjectives()
+
+	var/list/turf/synd_spawn = list()
+
+	for(var/obj/effect/landmark/A in landmarks_list)
+		if(A.name == "Syndicate-Spawn")
+			synd_spawn += get_turf(A)
+			continue
+	
+	var/spawnpos = 1
+	for(var/mob/M in assigned)
+		if(spawnpos > synd_spawn.len)
+			spawnpos = 1
+		M.forceMove(synd_spawn[spawnpos])
+		spawnpos++
 	if(index == 1) //Our first guy is the leader
 		var/datum/role/nuclear_operative/leader/new_role = new
 		new_role.AssignToRole(new_character.mind, 1)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -372,7 +372,7 @@
 	var/spawnpos = index
 	if(spawnpos > synd_spawn.len)
 		spawnpos = 1
-	M.forceMove(synd_spawn[spawnpos])
+	new_character.forceMove(synd_spawn[spawnpos])
 	if(index == 1) //Our first guy is the leader
 		var/datum/role/nuclear_operative/leader/new_role = new
 		new_role.AssignToRole(new_character.mind, 1)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -671,6 +671,18 @@
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/heist/finish_setup(var/mob/new_character, var/index)
 	var/datum/faction/vox_shoal/shoal = find_active_faction_by_type(/datum/faction/vox_shoal)
 	shoal.forgeObjectives()
+
+	var/list/turf/vox_spawn = list()
+
+	for(var/obj/effect/landmark/A in landmarks_list)
+		if(A.name == "voxstart")
+			vox_spawn += get_turf(A)
+			continue
+	
+	var/spawn_count = index
+	if(spawn_count > vox_spawn.len)
+		spawn_count = 1
+	new_character.forceMove(synd_spawn[spawn_count])
 	if (index == 1) // Our first guy is the leader
 		var/datum/role/vox_raider/chief_vox/new_role = new
 		new_role.AssignToRole(new_character.mind,1)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -369,12 +369,10 @@
 			synd_spawn += get_turf(A)
 			continue
 	
-	var/spawnpos = 1
-	for(var/mob/M in assigned)
-		if(spawnpos > synd_spawn.len)
-			spawnpos = 1
-		M.forceMove(synd_spawn[spawnpos])
-		spawnpos++
+	var/spawnpos = index
+	if(spawnpos > synd_spawn.len)
+		spawnpos = 1
+	M.forceMove(synd_spawn[spawnpos])
 	if(index == 1) //Our first guy is the leader
 		var/datum/role/nuclear_operative/leader/new_role = new
 		new_role.AssignToRole(new_character.mind, 1)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -488,12 +488,15 @@
 	else
 		return 0
 
+/datum/dynamic_ruleset/midround/from_ghosts/ninja/finish_setup(var/mob/new_character, var/index)
+	if (!find_active_faction_by_type(/datum/faction/spider_clan))
+		ticker.mode.CreateFaction(/datum/faction/spider_clan, null, 1)
+	new_character.forceMove(pick(ninjastart))
+	..()
+
 /datum/dynamic_ruleset/midround/from_ghosts/ninja/setup_role(var/datum/role/newninja)
 	var/datum/faction/spider_clan/spoider = find_active_faction_by_type(/datum/faction/spider_clan)
-	if (!spoider)
-		spoider = ticker.mode.CreateFaction(/datum/faction/spider_clan, null, 1)
 	spoider.HandleRecruitedRole(newninja)
-
 	return ..()
 
 //////////////////////////////////////////////

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -317,6 +317,9 @@
 		new_role.OnPostSetup() //Each individual role to show up gets a postsetup
 	..()
 
+/datum/dynamic_ruleset/midround/from_ghosts/faction_based/raginmages/finish_setup(var/mob/new_character, var/index)
+	new_character.forceMove(pick(wizardstart))
+	..()
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -682,7 +682,7 @@
 	var/spawn_count = index
 	if(spawn_count > vox_spawn.len)
 		spawn_count = 1
-	new_character.forceMove(synd_spawn[spawn_count])
+	new_character.forceMove(vox_spawn[spawn_count])
 	if (index == 1) // Our first guy is the leader
 		var/datum/role/vox_raider/chief_vox/new_role = new
 		new_role.AssignToRole(new_character.mind,1)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -458,8 +458,21 @@ Assign your candidates in choose_candidates() instead.
 	var/datum/faction/syndicate/nuke_op/nuclear = find_active_faction_by_type(/datum/faction/syndicate/nuke_op)
 	if(!nuclear)
 		nuclear = ticker.mode.CreateFaction(/datum/faction/syndicate/nuke_op, null, 1)
+	var/list/turf/synd_spawn = list()
+
+	for(var/obj/effect/landmark/A in landmarks_list)
+		if(A.name == "Syndicate-Spawn")
+			synd_spawn += get_turf(A)
+			qdel(A)
+			A = null
+			continue
+
+	var/spawnpos = 1
 	var/leader = 1
 	for(var/mob/M in assigned)
+		if(spawnpos > synd_spawn.len)
+			spawnpos = 1
+		M.forceMove(synd_spawn[spawnpos])
 		if(leader)
 			leader = 0
 			var/datum/role/nuclear_operative/leader/newCop = new
@@ -471,6 +484,7 @@ Assign your candidates in choose_candidates() instead.
 			newCop.AssignToRole(M.mind, 1)
 			nuclear.HandleRecruitedRole(newCop)
 			newCop.Greet(GREET_ROUNDSTART)
+		spawnpos++
 	for(var/obj/effect/spawner/newbomb/timer/syndicate/bomb in syndicate_bomb_spawners)
 		bomb.spawnbomb()
 	return 1

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -238,6 +238,7 @@
 	var/mob/M = pick(assigned)
 	if (M)
 		var/datum/role/wizard/newWizard = new
+		M.forceMove(pick(wizardstart))
 		newWizard.AssignToRole(M.mind,1)
 		roundstart_wizards += newWizard
 		var/datum/faction/wizard/federation = find_active_faction_by_type(/datum/faction/wizard)
@@ -309,6 +310,7 @@
 			WPF.HandleRecruitedRole(newWizard)
 		else
 			PFW.HandleRecruitedRole(newWizard)
+		M.forceMove(pick(wizardstart))
 		newWizard.AssignToRole(M.mind,1)
 		newWizard.Greet(GREET_MIDROUND)
 	return 1

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -521,6 +521,8 @@ Assign your candidates in choose_candidates() instead.
 
 	//Now that we've replaced the eventual other AIs, we make sure this chosen candidate has the proper roles.
 	M.mind.assigned_role = "AI"
+	if(!isAI(M))
+		M.AIize()
 	return (assigned.len > 0)
 
 /datum/dynamic_ruleset/roundstart/malf/execute()

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -522,7 +522,9 @@ Assign your candidates in choose_candidates() instead.
 	//Now that we've replaced the eventual other AIs, we make sure this chosen candidate has the proper roles.
 	M.mind.assigned_role = "AI"
 	if(!isAI(M))
-		M.AIize()
+		assigned.Remove(M)
+		M = M.AIize()
+		assigned.Add(M)
 	return (assigned.len > 0)
 
 /datum/dynamic_ruleset/roundstart/malf/execute()

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -463,8 +463,6 @@ Assign your candidates in choose_candidates() instead.
 	for(var/obj/effect/landmark/A in landmarks_list)
 		if(A.name == "Syndicate-Spawn")
 			synd_spawn += get_turf(A)
-			qdel(A)
-			A = null
 			continue
 
 	var/spawnpos = 1

--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -57,7 +57,12 @@
 	var/nuke_code = "[rand(10000, 99999)]"
 	var/leader_selected = 0
 	var/agent_number = 1
+	var/list/turf/synd_spawn = list()
 
+	for(var/obj/effect/landmark/A in landmarks_list)
+		if(A.name == "Syndicate-Spawn")
+			synd_spawn += get_turf(A)
+			continue
 	for(var/datum/role/nuclear_operative/N in members)
 		var/datum/mind/synd_mind = N.antag
 

--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -75,7 +75,7 @@
 
 		var/datum/outfit/striketeam/nukeops/concrete_outfit = new our_outfit
 
-		concrete_outfit.equip(synd_mind.current)
+		concrete_outfit.equip(synd_mind.current, strip = TRUE, delete = TRUE)
 
 		share_syndicate_codephrase(N.antag.current)
 		N.antag.current << sound('sound/voice/syndicate_intro.ogg')

--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -50,14 +50,6 @@
 
 /datum/faction/syndicate/nuke_op/OnPostSetup()
 	. = ..()
-	var/list/turf/synd_spawn = list()
-
-	for(var/obj/effect/landmark/A in landmarks_list)
-		if(A.name == "Syndicate-Spawn")
-			synd_spawn += get_turf(A)
-			qdel(A)
-			A = null
-			continue
 
 	var/obj/effect/landmark/uplinklocker = locate("landmark*Syndicate-Uplink") //I will be rewriting this shortly
 	var/obj/effect/landmark/nuke_spawn = locate("landmark*Nuclear-Bomb")
@@ -65,13 +57,9 @@
 	var/nuke_code = "[rand(10000, 99999)]"
 	var/leader_selected = 0
 	var/agent_number = 1
-	var/spawnpos = 1
 
 	for(var/datum/role/nuclear_operative/N in members)
-		if(spawnpos > synd_spawn.len)
-			spawnpos = 1
 		var/datum/mind/synd_mind = N.antag
-		synd_mind.current.forceMove(synd_spawn[spawnpos])
 
 		var/datum/outfit/striketeam/nukeops/concrete_outfit = new our_outfit
 
@@ -86,7 +74,6 @@
 		else
 			synd_mind.current.real_name = "[syndicate_name()] Operative #[agent_number]"
 			agent_number++
-		spawnpos++
 		N.antag.current.flavor_text = null
 
 		spawn()

--- a/code/datums/gamemode/factions/vox_shoal.dm
+++ b/code/datums/gamemode/factions/vox_shoal.dm
@@ -132,14 +132,8 @@ var/list/potential_bonus_items = list(
 
 /datum/faction/vox_shoal/OnPostSetup()
 	..()
-	var/list/turf/vox_spawn = list()
 
 	for(var/obj/effect/landmark/A in landmarks_list)
-		if(A.name == "voxstart")
-			vox_spawn += get_turf(A)
-			qdel(A)
-			A = null
-			continue
 		if (A.name == "vox_locker")
 			var/obj/structure/closet/loot/L = new(get_turf(A))
 			our_bounty_lockers += L
@@ -150,11 +144,7 @@ var/list/potential_bonus_items = list(
 	var/spawn_count = 1
 
 	for(var/datum/role/vox_raider/V in members)
-		if(spawn_count > vox_spawn.len)
-			spawn_count = 1
 		var/datum/mind/synd_mind = V.antag
-		synd_mind.current.forceMove(vox_spawn[spawn_count])
-		spawn_count++
 		equip_raider(synd_mind.current, spawn_count)
 
 /datum/faction/vox_shoal/proc/equip_raider(var/mob/living/carbon/human/vox, var/index)

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -163,57 +163,29 @@
 	var/list/dropped_items = wizard_mob.unequip_everything()
 	for(var/atom/A in dropped_items)
 		qdel(A)
-	if(!wizard_mob.find_empty_hand_index())
-		wizard_mob.u_equip(wizard_mob.held_items[GRASP_LEFT_HAND])
-	wizard_mob.equip_to_slot_or_del(new /obj/item/device/radio/headset(wizard_mob), slot_ears)
-	wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/under/lightpurple(wizard_mob), slot_w_uniform)
-	disable_suit_sensors(wizard_mob)
-	wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(wizard_mob), slot_shoes)
 	var/datum/faction/wizard/civilwar/wpf/WPF = find_active_faction_by_type(/datum/faction/wizard/civilwar/wpf)
 	var/datum/faction/wizard/civilwar/wpf/PFW = find_active_faction_by_type(/datum/faction/wizard/civilwar/pfw)
 	if(WPF && PFW)  //Are there wizwar factions?
 		if(WPF.get_member_by_mind(wizard_mob.mind))  //WPF get red
-			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe/red(wizard_mob), slot_wear_suit)
-			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard/red(wizard_mob), slot_head)
 			wizard_mob.add_spell(new /spell/targeted/absorb)
-			var/obj/item/weapon/spellbook/S = new /obj/item/weapon/spellbook(wizard_mob)
-		//	S.uses = Sp_BASE_PRICE * 3.5
-		//	S.max_uses = Sp_BASE_PRICE * 3.5
-			wizard_mob.put_in_hands(S)
+			var/datum/outfit/special/wizard/red/W = new
+			if(apprentice)
+				W.apprentice = TRUE
+			W.equip(wizard_mob)
+			W.post_equip(wizard_mob)
 		else if(PFW.get_member_by_mind(wizard_mob.mind))  //PFW get blue
-			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)
-			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(wizard_mob), slot_head)
 			wizard_mob.add_spell(new /spell/targeted/absorb)
-			var/obj/item/weapon/spellbook/S = new /obj/item/weapon/spellbook(wizard_mob)
-		//	S.uses = Sp_BASE_PRICE * 3.5
-		//	S.max_uses = Sp_BASE_PRICE * 3.5
-			wizard_mob.put_in_hands(S)
-		else //An ordinary wizard spawned after the wizwar ruleset was called, this shouldn't happen unless someone forces ragin' mages. Give them normal robes but no absorb spell.
-			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)
-			wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(wizard_mob), slot_head)
-			if(!apprentice)
-				wizard_mob.put_in_hands(new /obj/item/weapon/spellbook(wizard_mob))
+			var/datum/outfit/special/wizard/W = new
+			if(apprentice)
+				W.apprentice = TRUE
+			W.equip(wizard_mob)
+			W.post_equip(wizard_mob)
 	else //No wizwar, give them normal robes
-		wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(wizard_mob), slot_wear_suit)
-		wizard_mob.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(wizard_mob), slot_head)
-		if(!apprentice)
-			wizard_mob.put_in_hands(new /obj/item/weapon/spellbook(wizard_mob))
-	if(wizard_mob.backbag == 2)
-		wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(wizard_mob), slot_back)
-	if(wizard_mob.backbag == 3)
-		wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_norm(wizard_mob), slot_back)
-	if(wizard_mob.backbag == 4)
-		wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(wizard_mob), slot_back)
-	wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(wizard_mob), slot_in_backpack)
-	wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/hair_dye/skin_dye(wizard_mob), slot_in_backpack)
-//	wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/scrying_gem(wizard_mob), slot_l_store) For scrying gem.
-	var/scroll_type = apprentice ? /obj/item/weapon/teleportation_scroll/apprentice : /obj/item/weapon/teleportation_scroll
-	wizard_mob.equip_to_slot_or_del(new scroll_type(wizard_mob), slot_r_store)
-
-	wizard_mob.make_all_robot_parts_organic()
-
-	// For Vox and plasmadudes.
-	//wizard_mob.species.handle_post_spawn(wizard_mob)
+		var/datum/outfit/special/wizard/W = new
+		if(apprentice)
+			W.apprentice = TRUE
+		W.equip(wizard_mob)
+		W.post_equip(wizard_mob)
 
 	if(!apprentice)
 		to_chat(wizard_mob, "You will find a list of available spells in your spell book. Choose your magic arsenal carefully.")

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -165,19 +165,16 @@
 		if(WPF.get_member_by_mind(wizard_mob.mind))  //WPF get red
 			wizard_mob.add_spell(new /spell/targeted/absorb)
 			var/datum/outfit/special/wizard/red/W = new
-			if(apprentice)
-				W.apprentice = TRUE
+			W.apprentice = apprentice
 			W.equip(wizard_mob, strip = TRUE, delete = TRUE)
 		else if(PFW.get_member_by_mind(wizard_mob.mind))  //PFW get blue
 			wizard_mob.add_spell(new /spell/targeted/absorb)
 			var/datum/outfit/special/wizard/W = new
-			if(apprentice)
-				W.apprentice = TRUE
+			W.apprentice = apprentice
 			W.equip(wizard_mob, strip = TRUE, delete = TRUE)
 	else //No wizwar, give them normal robes
 		var/datum/outfit/special/wizard/W = new
-		if(apprentice)
-			W.apprentice = TRUE
+		W.apprentice = apprentice
 		W.equip(wizard_mob, strip = TRUE, delete = TRUE)
 
 	if(!apprentice)

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -172,20 +172,17 @@
 			if(apprentice)
 				W.apprentice = TRUE
 			W.equip(wizard_mob)
-			W.post_equip(wizard_mob)
 		else if(PFW.get_member_by_mind(wizard_mob.mind))  //PFW get blue
 			wizard_mob.add_spell(new /spell/targeted/absorb)
 			var/datum/outfit/special/wizard/W = new
 			if(apprentice)
 				W.apprentice = TRUE
 			W.equip(wizard_mob)
-			W.post_equip(wizard_mob)
 	else //No wizwar, give them normal robes
 		var/datum/outfit/special/wizard/W = new
 		if(apprentice)
 			W.apprentice = TRUE
 		W.equip(wizard_mob)
-		W.post_equip(wizard_mob)
 
 	if(!apprentice)
 		to_chat(wizard_mob, "You will find a list of available spells in your spell book. Choose your magic arsenal carefully.")

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -159,10 +159,6 @@
 	if (!istype(wizard_mob))
 		return
 
-	//So zards properly get their items when they are admin-made.
-	var/list/dropped_items = wizard_mob.unequip_everything()
-	for(var/atom/A in dropped_items)
-		qdel(A)
 	var/datum/faction/wizard/civilwar/wpf/WPF = find_active_faction_by_type(/datum/faction/wizard/civilwar/wpf)
 	var/datum/faction/wizard/civilwar/wpf/PFW = find_active_faction_by_type(/datum/faction/wizard/civilwar/pfw)
 	if(WPF && PFW)  //Are there wizwar factions?
@@ -171,18 +167,18 @@
 			var/datum/outfit/special/wizard/red/W = new
 			if(apprentice)
 				W.apprentice = TRUE
-			W.equip(wizard_mob)
+			W.equip(wizard_mob, strip = TRUE, delete = TRUE)
 		else if(PFW.get_member_by_mind(wizard_mob.mind))  //PFW get blue
 			wizard_mob.add_spell(new /spell/targeted/absorb)
 			var/datum/outfit/special/wizard/W = new
 			if(apprentice)
 				W.apprentice = TRUE
-			W.equip(wizard_mob)
+			W.equip(wizard_mob, strip = TRUE, delete = TRUE)
 	else //No wizwar, give them normal robes
 		var/datum/outfit/special/wizard/W = new
 		if(apprentice)
 			W.apprentice = TRUE
-		W.equip(wizard_mob)
+		W.equip(wizard_mob, strip = TRUE, delete = TRUE)
 
 	if(!apprentice)
 		to_chat(wizard_mob, "You will find a list of available spells in your spell book. Choose your magic arsenal carefully.")

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -160,11 +160,9 @@
 		return
 
 	//So zards properly get their items when they are admin-made.
-	qdel(wizard_mob.wear_suit)
-	qdel(wizard_mob.head)
-	qdel(wizard_mob.shoes)
-	qdel(wizard_mob.r_store)
-	qdel(wizard_mob.l_store)
+	dropped_items = wizard_mob.unequip_everything()
+	for(var/atom/A in dropped_items)
+		qdel(A)
 	if(!wizard_mob.find_empty_hand_index())
 		wizard_mob.u_equip(wizard_mob.held_items[GRASP_LEFT_HAND])
 	wizard_mob.equip_to_slot_or_del(new /obj/item/device/radio/headset(wizard_mob), slot_ears)

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -160,7 +160,7 @@
 		return
 
 	//So zards properly get their items when they are admin-made.
-	dropped_items = wizard_mob.unequip_everything()
+	var/dropped_items = wizard_mob.unequip_everything()
 	for(var/atom/A in dropped_items)
 		qdel(A)
 	if(!wizard_mob.find_empty_hand_index())

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -184,7 +184,6 @@
 		to_chat(wizard_mob, "You will find a list of available spells in your spell book. Choose your magic arsenal carefully.")
 		to_chat(wizard_mob, "In your pockets you will find a teleport scroll. Use it as needed.")
 		wizard_mob.mind.store_memory("<B>Remember:</B> do not forget to prepare your spells.")
-	wizard_mob.update_icons()
 	return 1
 
 /proc/name_wizard(mob/living/carbon/human/wizard_mob, role_name = "Space Wizard")

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -160,7 +160,7 @@
 		return
 
 	//So zards properly get their items when they are admin-made.
-	var/dropped_items = wizard_mob.unequip_everything()
+	var/list/dropped_items = wizard_mob.unequip_everything()
 	for(var/atom/A in dropped_items)
 		qdel(A)
 	if(!wizard_mob.find_empty_hand_index())

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -21,7 +21,6 @@
 	. =..()
 	if(!.)
 		return
-	antag.current.forceMove(pick(ninjastart))
 	if(ishuman(antag.current))
 		antag.current << sound('sound/effects/yooooooooooo.ogg')
 		equip_ninja(antag.current)

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -163,11 +163,12 @@
 	M.antag_roles.Add(id)
 	M.antag_roles[id] = src
 	objectives.owner = M
-	if(msg_admins)
-		message_admins("[key_name(M)] is now \an [id].[M.current ? " [formatJumpTo(M.current)]" : ""]")
 
 	if (!OnPreSetup())
 		return FALSE
+
+	if(msg_admins)
+		message_admins("[key_name(M)] is now \an [id].[M.current ? " [formatJumpTo(M.current)]" : ""]")
 	return 1
 
 /datum/role/proc/RemoveFromRole(var/datum/mind/M, var/msg_admins = TRUE) //Called on deconvert

--- a/code/datums/gamemode/role/tag_mode.dm
+++ b/code/datums/gamemode/role/tag_mode.dm
@@ -30,7 +30,7 @@ var/list/tag_mode_non_used_spawns = list()
 		// Give them the outfit
 		var/datum/outfit/mime/clown_ling/concrete_outfit = new
 		concrete_outfit.items_to_collect[/obj/item/weapon/card/id/captains_spare] = SURVIVAL_BOX // Everyone gets a spare in tagmode.
-		concrete_outfit.equip(antag.current)
+		concrete_outfit.equip(antag.current, strip = TRUE, delete = TRUE)
 
 	// Give them the changeling powers
 	. = ..()
@@ -124,7 +124,7 @@ var/spawned_mimes_tag_mode = 1
 	// Give them the outfit
 	var/datum/outfit/mime/concrete_outfit = new
 	concrete_outfit.items_to_collect[/obj/item/weapon/card/id/captains_spare] = SURVIVAL_BOX // Everyone gets a spare in tagmode.
-	concrete_outfit.equip(antag.current)
+	concrete_outfit.equip(antag.current, strip = TRUE, delete = TRUE)
 
 	// Objective
 	ForgeObjectives()

--- a/code/datums/gamemode/role/time_agent.dm
+++ b/code/datums/gamemode/role/time_agent.dm
@@ -147,7 +147,7 @@
 
 /datum/role/time_agent/proc/recruiter_not_recruiting(mob/dead/observer/player, controls)
 	if(player.client && get_role_desire_str(player.client.prefs.roles[TIMEAGENT]) != "Never")
-		to_chat(player, "<span class=\"recruit\">\a [src] is going to get shot by his evil twin. ([controls])</span>")
+		to_chat(player, "<span class=\"recruit\">A [src] is being targeted by his evil twin. ([controls])</span>")
 
 
 /datum/role/time_agent/proc/recruiter_recruited(mob/dead/observer/player)
@@ -168,7 +168,6 @@
 	.=..()
 	var/mob/living/carbon/human/H = antag.current
 	equip_time_agent(H, src, is_twin)
-	H.forceMove(pick(timeagentstart))
 
 
 /datum/role/time_agent/proc/extract()

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -33,11 +33,16 @@
 			AppendObjective(/datum/objective/hijack)
 	return
 
-/datum/role/wizard/OnPostSetup()
+/datum/role/wizard/OnPreSetup()
 	. = ..()
 	if(!.)
 		return
 	antag.current.forceMove(pick(wizardstart))
+
+/datum/role/wizard/OnPostSetup()
+	. = ..()
+	if(!.)
+		return
 	equip_wizard(antag.current)
 	name_wizard(antag.current)
 	antag.current.flavor_text = null

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -33,12 +33,6 @@
 			AppendObjective(/datum/objective/hijack)
 	return
 
-/datum/role/wizard/OnPreSetup()
-	. = ..()
-	if(!.)
-		return
-	antag.current.forceMove(pick(wizardstart))
-
 /datum/role/wizard/OnPostSetup()
 	. = ..()
 	if(!.)

--- a/code/datums/outfit/outfit.dm
+++ b/code/datums/outfit/outfit.dm
@@ -103,7 +103,7 @@
 		L = items_to_spawn["Default"]
 
 	if(strip)
-		var/dropped_items = M.unequip_everything()
+		var/list/dropped_items = H.unequip_everything()
 		if(delete)
 			for(var/atom/A in dropped_items)
 				qdel(A)

--- a/code/datums/outfit/outfit.dm
+++ b/code/datums/outfit/outfit.dm
@@ -90,7 +90,7 @@
 	return
 
 // -- Equip mindless: if we're going to give the outfit to a mob without a mind
-/datum/outfit/proc/equip(var/mob/living/carbon/human/H, var/equip_mindless = FALSE, var/priority = FALSE)
+/datum/outfit/proc/equip(var/mob/living/carbon/human/H, var/equip_mindless = FALSE, var/priority = FALSE, var/strip = FALSE, var/delete = FALSE)
 	if (!H || (!H.mind && !equip_mindless) )
 		return
 
@@ -101,6 +101,12 @@
 	if (!L) // Couldn't find the particular species
 		species = "Default"
 		L = items_to_spawn["Default"]
+
+	if(strip)
+		var/dropped_items = M.unequip_everything()
+		if(delete)
+			for(var/atom/A in dropped_items)
+				qdel(A)
 
 	if (priority)
 		pre_equip_priority(H, species)

--- a/code/datums/outfit/special_outfits/special.dm
+++ b/code/datums/outfit/special_outfits/special.dm
@@ -641,7 +641,6 @@
 			slot_head_str = /obj/item/clothing/head/wizard,
 			slot_wear_suit_str = /obj/item/clothing/suit/wizrobe,
 			slot_ears_str = /obj/item/device/radio/headset,
-			slot_l_store_str = /obj/item/weapon/spellbook,
 		),
 	)
 

--- a/code/datums/outfit/special_outfits/special.dm
+++ b/code/datums/outfit/special_outfits/special.dm
@@ -623,11 +623,16 @@
 
 // Wizards
 
-/datum/outfit/special/blue_wizard
+/datum/outfit/special/wizard
 	equip_survival_gear = list() // Default survival gear
+	use_pref_bag = TRUE
+	var/apprentice = FALSE // Apprentice wiz?
 	outfit_name = "Blue wizard"
 	backpack_types = list(
 		BACKPACK_STRING = /obj/item/weapon/storage/backpack,
+		SATCHEL_NORM_STRING = /obj/item/weapon/storage/backpack/satchel_norm,
+		SATCHEL_ALT_STRING = /obj/item/weapon/storage/backpack/satchel,
+		MESSENGER_BAG_STRING = /obj/item/weapon/storage/backpack/messenger,
 	)
 	items_to_spawn = list(
 		"Default" = list(
@@ -636,21 +641,22 @@
 			slot_head_str = /obj/item/clothing/head/wizard,
 			slot_wear_suit_str = /obj/item/clothing/suit/wizrobe,
 			slot_ears_str = /obj/item/device/radio/headset,
-			slot_r_store_str = /obj/item/weapon/teleportation_scroll,
 			slot_l_store_str = /obj/item/weapon/spellbook,
 		),
 	)
 
-/datum/outfit/special/blue_wizard/post_equip(var/mob/living/carbon/human/H)
+/datum/outfit/special/wizard/post_equip(var/mob/living/carbon/human/H)
 	..()
-	H.put_in_hands(new /obj/item/weapon/staff(H))
+	disable_suit_sensors(H)
+	if(!apprentice)
+		H.put_in_hands(new /obj/item/weapon/teleportation_scroll(H))
+		H.put_in_hands(new /obj/item/weapon/spellbook(H))
+	else
+		H.put_in_hands(new /obj/item/weapon/teleportation_scroll/apprentice(H))
+	H.equip_to_slot_or_del(new /obj/item/weapon/hair_dye/skin_dye(H), slot_in_backpack)
 
-/datum/outfit/special/red_wizard
-	equip_survival_gear = list() // Default survival gear
+/datum/outfit/special/wizard/red
 	outfit_name = "Red wizard"
-	backpack_types = list(
-		BACKPACK_STRING = /obj/item/weapon/storage/backpack,
-	)
 	items_to_spawn = list(
 		"Default" = list(
 			slot_w_uniform_str =/obj/item/clothing/under/lightpurple,
@@ -658,21 +664,12 @@
 			slot_head_str = /obj/item/clothing/head/wizard/red,
 			slot_wear_suit_str = /obj/item/clothing/suit/wizrobe/red,
 			slot_ears_str = /obj/item/device/radio/headset,
-			slot_r_store_str = /obj/item/weapon/teleportation_scroll,
 			slot_l_store_str = /obj/item/weapon/spellbook,
 		),
 	)
 
-/datum/outfit/special/red_wizard/post_equip(var/mob/living/carbon/human/H)
-	..()
-	H.put_in_hands(new /obj/item/weapon/staff(H))
-
-/datum/outfit/special/marisa_wizard
-	equip_survival_gear = list() // Default survival gear
+/datum/outfit/special/wizard/marisa
 	outfit_name = "Marisa wizard"
-	backpack_types = list(
-		BACKPACK_STRING = /obj/item/weapon/storage/backpack,
-	)
 	items_to_spawn = list(
 		"Default" = list(
 			slot_w_uniform_str =/obj/item/clothing/under/lightpurple,
@@ -684,10 +681,6 @@
 			slot_l_store_str = /obj/item/weapon/spellbook,
 		),
 	)
-
-/datum/outfit/special/marisa_wizard/post_equip(var/mob/living/carbon/human/H)
-	..()
-	H.put_in_hands(new /obj/item/weapon/staff(H))
 
 
 /datum/outfit/special/prisoner

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -171,7 +171,6 @@ var/datum/controller/gameticker/ticker
 	init_PDAgames_leaderboard()
 	create_characters() //Create player characters and transfer them
 	collect_minds()
-	equip_characters()
 
 	var/can_continue = src.mode.Setup()//Setup special modes
 	if(!can_continue)
@@ -193,6 +192,8 @@ var/datum/controller/gameticker/ticker
 		else
 			to_chat(world, "<B>The current game mode is - Secret!</B>")
 			to_chat(world, "<B>Possibilities:</B> [english_list(modes)]")
+
+	equip_characters()
 
 	for(var/mob/living/carbon/human/player in player_list)
 		switch(player.mind.assigned_role)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -164,6 +164,15 @@ var/datum/controller/gameticker/ticker
 
 	//Configure mode and assign player to special mode stuff
 	job_master.DivideOccupations() //Distribute jobs
+
+	gamestart_time = world.time / 10
+
+	init_mind_ui()
+	init_PDAgames_leaderboard()
+	create_characters() //Create player characters and transfer them
+	collect_minds()
+	equip_characters()
+
 	var/can_continue = src.mode.Setup()//Setup special modes
 	if(!can_continue)
 		current_state = GAME_STATE_PREGAME
@@ -184,14 +193,6 @@ var/datum/controller/gameticker/ticker
 		else
 			to_chat(world, "<B>The current game mode is - Secret!</B>")
 			to_chat(world, "<B>Possibilities:</B> [english_list(modes)]")
-
-	gamestart_time = world.time / 10
-
-	init_mind_ui()
-	init_PDAgames_leaderboard()
-	create_characters() //Create player characters and transfer them
-	collect_minds()
-	equip_characters()
 
 	for(var/mob/living/carbon/human/player in player_list)
 		switch(player.mind.assigned_role)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -394,7 +394,7 @@ var/datum/controller/gameticker/ticker
 			else
 				if(player.mind.assigned_role=="Mobile MMI")
 					log_admin("([player.ckey]) started the game as a [player.mind.assigned_role].")
-				var/mob/living/carbon/human/new_character = player.create_character()
+				var/mob/living/carbon/human/new_character = player.create_character(0)
 				new_character.DormantGenes(20,10,0,0) // 20% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
 				qdel(player)
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -383,19 +383,12 @@ var/datum/controller/gameticker/ticker
 /datum/controller/gameticker/proc/create_characters()
 	for(var/mob/new_player/player in player_list)
 		if(player.ready && player.mind)
-			if(player.mind.assigned_role=="AI")
-				player.close_spawn_windows()
+			if(player.mind.assigned_role=="AI" || player.mind.assigned_role=="Cyborg" || player.mind.assigned_role=="Mobile MMI")
 				log_admin("([player.ckey]) started the game as a [player.mind.assigned_role].")
-				player.AIize()
-			else if(player.mind.assigned_role=="Cyborg")
-				log_admin("([player.ckey]) started the game as a [player.mind.assigned_role].")
-				player.create_roundstart_cyborg()
-
+				player.create_roundstart_silicon(player.mind.assigned_role)
 			else if(!player.mind.assigned_role)
 				continue
 			else
-				if(player.mind.assigned_role=="Mobile MMI")
-					log_admin("([player.ckey]) started the game as a [player.mind.assigned_role].")
 				var/mob/living/carbon/human/new_character = player.create_character(0)
 				new_character.DormantGenes(20,10,0,0) // 20% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
 				qdel(player)

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -470,11 +470,6 @@ var/global/datum/controller/occupations/job_master
 	if(H.mind)
 		H.mind.assigned_role = rank
 		alt_title = H.mind.role_alt_title
-
-		switch(rank)
-			if("Mobile MMI")
-				H.MoMMIfy()
-				return 1
 	if(job)
 		job.introduce(H, (alt_title ? alt_title : rank))
 	else

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -410,35 +410,6 @@ var/global/datum/controller/occupations/job_master
 	if(!H)
 		return 0
 	var/datum/job/job = GetJob(rank)
-	if(!joined_late)
-		var/obj/S = null
-		// Find a spawn point that wasn't given to anyone
-		for(var/obj/effect/landmark/start/sloc in landmarks_list)
-			if(sloc.name != rank)
-				continue
-			if(locate(/mob/living) in sloc.loc)
-				continue
-			S = sloc
-			break
-		if(!S)
-			// Find a spawn point that was already given to someone else
-			for(var/obj/effect/landmark/start/sloc in landmarks_list)
-				if(sloc.name != rank)
-					continue
-				S = sloc
-				stack_trace("not enough spawn points for [rank]")
-				break
-		if(!S)
-			// Find a spawn point that's using the ancient landmarks. Do we even have these anymore?
-			S = locate("start*[rank]")
-		if(S)
-			// Use the given spawn point
-			H.forceMove(S.loc)
-		else
-			// Use the arrivals shuttle spawn point
-			stack_trace("no spawn points for [rank]")
-			H.forceMove(pick(latejoin))
-
 	if(job && !job.no_starting_money)
 		//give them an account in the station database
 		// Total between $200 and $500

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1086,7 +1086,6 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		return
 	if(!mob)
 		return
-	var/list/dropped_items
 	var/delete_text
 	var/strip_text = input(usr,"Do you want to strip \the [M]'s current equipment?","Equip Outfit","") as null|anything in list("Yes","No")
 	if(!strip_text)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1100,12 +1100,15 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!outfit_type || !ispath(outfit_type))
 		return
 	if(strip_items == "Yes")
-		dropped_items = M.unequip_everything()
-		if(delete_items == "Yes")
-			for(var/atom/A in dropped_items)
-				qdel(A)
+		strip_items = TRUE
+	else
+		strip_items = FALSE
+	if(delete_items == "Yes")
+		delete_items = TRUE
+	else
+		delete_items = FALSE
 	var/datum/outfit/concrete_outfit = new outfit_type
-	concrete_outfit.equip(M, TRUE)
+	concrete_outfit.equip(M, TRUE, strip = strip_items, delete = delete_items)
 	log_admin("[key_name(usr)] has equipped an loadout of type [outfit_type] to [key_name(M)].")
 	message_admins("<span class='notice'>[key_name(usr)] has equipped an loadout of type [outfit_type] to [key_name(M)].</span>", 1)
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1087,26 +1087,24 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!mob)
 		return
 	var/list/dropped_items
-	var/delete_items
-	var/strip_items = input(usr,"Do you want to strip \the [M]'s current equipment?","Equip Outfit","") as null|anything in list("Yes","No")
-	if(!strip_items)
+	var/delete_text
+	var/strip_text = input(usr,"Do you want to strip \the [M]'s current equipment?","Equip Outfit","") as null|anything in list("Yes","No")
+	if(!strip_text)
 		return
-	if(strip_items == "Yes")
-		delete_items = input(usr,"Delete stripped items?","Equip Outfit","") as null|anything in list("Yes","No")
-		if(!delete_items)
+	if(strip_text == "Yes")
+		delete_text = input(usr,"Delete stripped items?","Equip Outfit","") as null|anything in list("Yes","No")
+		if(!delete_text)
 			return
 	var/list/outfits = (typesof(/datum/outfit/) - /datum/outfit/ - /datum/outfit/striketeam/)
 	var/outfit_type = input(usr,"Outfit Type","Equip Outfit","") as null|anything in outfits
 	if(!outfit_type || !ispath(outfit_type))
 		return
-	if(strip_items == "Yes")
+	var/strip_items = FALSE
+	var/delete_items = FALSE
+	if(strip_text == "Yes")
 		strip_items = TRUE
-	else
-		strip_items = FALSE
-	if(delete_items == "Yes")
+	if(delete_text == "Yes")
 		delete_items = TRUE
-	else
-		delete_items = FALSE
 	var/datum/outfit/concrete_outfit = new outfit_type
 	concrete_outfit.equip(M, TRUE, strip = strip_items, delete = delete_items)
 	log_admin("[key_name(usr)] has equipped an loadout of type [outfit_type] to [key_name(M)].")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -787,26 +787,13 @@
 		message_admins("WARNING! Couldn't find a spawn location for a [type]. They will spawn at the arrival shuttle.")
 
 	//Create the robot and move over prefs
-	if(type != "AI")
-		var/mob/living/silicon/robot/new_character
-		if(type == "Cyborg")
-			new_character = new(spawn_loc)
-		else if(type == "Mobile MMI")
-			new_character = new /mob/living/silicon/robot/mommi(spawn_loc)
-		new_character.mmi = new /obj/item/device/mmi(new_character)
-		new_character.mmi.create_identity(client.prefs) //Uses prefs to create a brain mob
-
-		//Handles transferring the mind and key manually.
-		if (mind)
-			mind.active = 0 //This prevents mind.transfer_to from setting new_character.key = key
-			mind.transfer_to(new_character)
-		new_character.key = key //Do this after. For reasons known only to oldcoders.
-		spawn()
-			new_character.Namepick()
-		return new_character
-	else
-		var/mob/living/silicon/ai/new_character = AIize()
-		return new_character
+	switch(type)
+		if("Cyborg")
+			return Robotize()
+		if("AI")
+			return AIize()
+		if("Mobile MMI")
+			return MoMMIfy()
 
 /mob/new_player/proc/ViewPrediction()
 	var/dat = {"<html><body>

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -792,11 +792,12 @@
 	else
 		forceMove(spawn_loc)
 		var/mob/living/silicon/robot/new_character
+		var/datum/preferences/prefs = client.prefs
 		if(type == "Mobile MMI")
 			new_character = MoMMIfy()
 		else
 			new_character = Robotize()
-		new_character.mmi.create_identity(client.prefs) //Uses prefs to create a brain mob
+		new_character.mmi.create_identity(prefs) //Uses prefs to create a brain mob
 		return new_character
 
 /mob/new_player/proc/ViewPrediction()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -368,11 +368,20 @@
 
 	job_master.AssignRole(src, rank, 1)
 
-	ticker.mode.latespawn(src)//can we make them a latejoin antag?
-
 	var/mob/living/carbon/human/character = create_character(1)	//creates the human and transfers vars and mind
 	if(character.client.prefs.randomslot)
 		character.client.prefs.random_character_sqlite(character, character.ckey)
+
+	var/atom/movable/what_to_move = character.locked_to || character
+
+	var/datum/job/J = job_master.GetJob(rank)
+	if(J.spawns_from_edge)
+		Meteortype_Latejoin(what_to_move, rank)
+	else
+		// TODO:  Job-specific latejoin overrides.
+		what_to_move.forceMove(pick((assistant_latejoin.len > 0 && rank == "Assistant") ? assistant_latejoin : latejoin))
+
+	ticker.mode.latespawn(character)//can we make them a latejoin antag?
 
 	// Very hacky. Sorry about that
 	if(ticker.tag_mode_enabled == TRUE)
@@ -403,15 +412,6 @@
 
 
 	EquipCustomItems(character)
-
-	var/atom/movable/what_to_move = character.locked_to || character
-
-	var/datum/job/J = job_master.GetJob(rank)
-	if(J.spawns_from_edge)
-		Meteortype_Latejoin(what_to_move, rank)
-	else
-		// TODO:  Job-specific latejoin overrides.
-		what_to_move.forceMove(pick((assistant_latejoin.len > 0 && rank == "Assistant") ? assistant_latejoin : latejoin))
 
 	character.store_position()
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -387,7 +387,7 @@
 	if(ticker.tag_mode_enabled == TRUE)
 		character.mind.assigned_role = "MODE"
 		var/datum/outfit/mime/mime_outfit = new
-		mime_outfit.equip(character)
+		mime_outfit.equip(character, strip = TRUE, delete = TRUE)
 		var/datum/role/tag_mode_mime/mime = new
 		mime.AssignToRole(character.mind,1)
 		mime.Greet(GREET_ROUNDSTART)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -763,7 +763,9 @@
 	return new_character
 
 //Basically, a stripped down version of create_character(). We don't care about DNA, prefs, species, etc. and we skip some rather lengthy setup for each step.
-/mob/new_player/proc/create_roundstart_cyborg()
+/mob/new_player/proc/create_roundstart_silicon(var/type)
+	if(type != "Cyborg" && type != "AI" && type != "Mobile MMI")
+		return
 	//End lobby
 	spawning = 1
 	close_spawn_windows()
@@ -772,7 +774,7 @@
 	//Find a spawnloc
 	var/turf/spawn_loc
 	for(var/obj/effect/landmark/start/sloc in landmarks_list)
-		if (sloc.name != "Cyborg")
+		if (sloc.name != type)
 			continue
 		if (locate(/mob/living) in sloc.loc)
 			if(!spawn_loc)
@@ -782,21 +784,36 @@
 		break
 	if(!spawn_loc)
 		spawn_loc = pick(latejoin) //If we absolutely can't find spawns
-		message_admins("WARNING! Couldn't find a spawn location for a cyborg. They will spawn at the arrival shuttle.")
+		message_admins("WARNING! Couldn't find a spawn location for a [type]. They will spawn at the arrival shuttle.")
 
 	//Create the robot and move over prefs
-	var/mob/living/silicon/robot/new_character = new(spawn_loc)
-	new_character.mmi = new /obj/item/device/mmi(new_character)
-	new_character.mmi.create_identity(client.prefs) //Uses prefs to create a brain mob
+	if(type != "AI")
+		var/mob/living/silicon/robot/new_character
+		if(type == "Cyborg")
+			new_character = new(spawn_loc)
+		else if(type == "Mobile MMI")
+			new_character = new /mob/living/silicon/robot/mommi(spawn_loc)
+		new_character.mmi = new /obj/item/device/mmi(new_character)
+		new_character.mmi.create_identity(client.prefs) //Uses prefs to create a brain mob
 
-	//Handles transferring the mind and key manually.
-	if (mind)
-		mind.active = 0 //This prevents mind.transfer_to from setting new_character.key = key
-		mind.transfer_to(new_character)
-	new_character.key = key //Do this after. For reasons known only to oldcoders.
-	spawn()
-		new_character.Namepick()
-	return new_character
+		//Handles transferring the mind and key manually.
+		if (mind)
+			mind.active = 0 //This prevents mind.transfer_to from setting new_character.key = key
+			mind.transfer_to(new_character)
+		new_character.key = key //Do this after. For reasons known only to oldcoders.
+		spawn()
+			new_character.Namepick()
+		return new_character
+	else
+		var/mob/living/silicon/ai/new_character = new(spawn_loc)
+		//Handles transferring the mind and key manually.
+		if (mind)
+			mind.active = 0 //This prevents mind.transfer_to from setting new_character.key = key
+			mind.transfer_to(new_character)
+		new_character.key = key //Do this after. For reasons known only to oldcoders.
+		spawn()
+			new_character.Namepick()
+		return new_character
 
 /mob/new_player/proc/ViewPrediction()
 	var/dat = {"<html><body>

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -787,18 +787,17 @@
 		message_admins("WARNING! Couldn't find a spawn location for a [type]. They will spawn at the arrival shuttle.")
 
 	//Create the robot and move over prefs
-	switch(type)
-		if("AI")
-			return AIize()
+	if(type == "AI")
+		return AIize()
+	else
+		forceMove(spawn_loc)
+		var/mob/living/silicon/robot/new_character
+		if(type == "Mobile MMI")
+			new_character = MoMMIfy()
 		else
-			forceMove(spawn_loc)
-			var/mob/living/silicon/robot/new_character
-			if("Mobile MMI")
-				new_character = MoMMIfy()
-			else
-				new_character = Robotize()
-			new_character.mmi.create_identity(client.prefs) //Uses prefs to create a brain mob
-			return new_character
+			new_character = Robotize()
+		new_character.mmi.create_identity(client.prefs) //Uses prefs to create a brain mob
+		return new_character
 
 /mob/new_player/proc/ViewPrediction()
 	var/dat = {"<html><body>

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -805,14 +805,7 @@
 			new_character.Namepick()
 		return new_character
 	else
-		var/mob/living/silicon/ai/new_character = new(spawn_loc)
-		//Handles transferring the mind and key manually.
-		if (mind)
-			mind.active = 0 //This prevents mind.transfer_to from setting new_character.key = key
-			mind.transfer_to(new_character)
-		new_character.key = key //Do this after. For reasons known only to oldcoders.
-		spawn()
-			new_character.Namepick()
+		var/mob/living/silicon/ai/new_character = AIize()
 		return new_character
 
 /mob/new_player/proc/ViewPrediction()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -788,12 +788,17 @@
 
 	//Create the robot and move over prefs
 	switch(type)
-		if("Cyborg")
-			return Robotize()
 		if("AI")
 			return AIize()
-		if("Mobile MMI")
-			return MoMMIfy()
+		else
+			forceMove(spawn_loc)
+			var/mob/living/silicon/robot/new_character
+			if("Mobile MMI")
+				new_character = MoMMIfy()
+			else
+				new_character = Robotize()
+			new_character.mmi.create_identity(client.prefs) //Uses prefs to create a brain mob
+			return new_character
 
 /mob/new_player/proc/ViewPrediction()
 	var/dat = {"<html><body>

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -392,17 +392,17 @@
 		mime.AssignToRole(character.mind,1)
 		mime.Greet(GREET_ROUNDSTART)
 
-	if(character.mind.assigned_role != "MODE")
-		job_master.EquipRank(character, rank, 1) //Must come before OnPostSetup for uplinks
-
-	job_master.CheckPriorityFulfilled(rank)
-
 	var/turf/T = character.loc
 	for(var/role in character.mind.antag_roles)
 		var/datum/role/R = character.mind.antag_roles[role]
 		R.OnPostSetup(TRUE) // Latejoiner post-setup.
 		R.ForgeObjectives()
 		R.AnnounceObjectives()
+
+	if(character.mind.assigned_role != "MODE")
+		job_master.EquipRank(character, rank, 1) //Must come before OnPostSetup for uplinks
+
+	job_master.CheckPriorityFulfilled(rank)
 
 	if (character.loc != T) //Offstation antag. Continue no further, as there will be no announcement or manifest injection.
 		//Removal of job slot is in role/role.dm

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -120,9 +120,6 @@
 		return
 	if(client)
 		src << sound(null, repeat = FALSE, wait = FALSE, volume = 85, channel = CHANNEL_LOBBY)// stop the jams for AIs
-	var/mob/living/silicon/ai/O = new (get_turf(src), base_law_type,,1)//No MMI but safety is in effect.
-	O.invisibility = 0
-	O.aiRestorePowerRoutine = 0
 	var/obj/loc_landmark
 	if(!spawn_here)
 		for(var/obj/effect/landmark/start/sloc in landmarks_list)
@@ -138,11 +135,15 @@
 						continue
 					loc_landmark = tripai
 		if (!loc_landmark)
-			to_chat(O, "Oh god sorry we can't find an unoccupied AI spawn location, so we're spawning you on top of someone.")
+			to_chat(src, "Oh god sorry we can't find an unoccupied AI spawn location, so we're spawning you on top of someone.")
 			for(var/obj/effect/landmark/start/sloc in landmarks_list)
 				if (sloc.name == "AI")
 					loc_landmark = sloc
-		O.forceMove(loc_landmark.loc)
+		forceMove(loc_landmark.loc)
+	var/mob/living/silicon/ai/O = new (get_turf(src), base_law_type,,1)//No MMI but safety is in effect.
+	O.invisibility = 0
+	O.aiRestorePowerRoutine = 0
+	if(!spawn_here)
 		for (var/obj/item/device/radio/intercom/comm in O.loc)
 			comm.ai += O
 	if(mind)


### PR DESCRIPTION
[administration][bugfix]
![image](https://user-images.githubusercontent.com/57303506/137658264-d84dca6a-5443-4ef5-afac-e376d0a8d14d.png)
![image](https://user-images.githubusercontent.com/57303506/137658976-95adc3c7-f881-4dff-b6e1-19f814a885f7.png)
Should also fix logging issues only showing players in the starting area as new player mobs in the above too.
Also tidies up wizard equip code to make it actually use outfit datums.
:cl:
 * bugfix: Active human mobs in the world are no longer teleported to their player pref job role on roundstart.
 * bugfix: New players no longer hear the AI bootup sound when the game starts with one.