### PR TITLE
Makes the Cargo Merch vendor say "credits" instead of "cr"

### DIFF
--- a/tgui/packages/tgui/interfaces/Merch.js
+++ b/tgui/packages/tgui/interfaces/Merch.js
@@ -24,7 +24,7 @@ export const Merch = (props, context) => {
 
 export const MerchUplink = (props, context) => {
   const {
-    currencySymbol = 'cr',
+    currencySymbol = 'credits',
   } = props;
   const { data } = useBackend(context);
   const {


### PR DESCRIPTION
Judging by damian's reaction when mentioned on #30961, he intended to change it to credits but didn't before it got merged.
[ui]
:cl:
 * tweak: The cargo merch vendor now says credits instead of cr.