### PR TITLE
Allow PDA ringtone to be changed while inside closets

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -2110,7 +2110,7 @@ var/global/msg_id = 0
 			tnote.Cut()
 		if("Ringtone")
 			var/t = input(U, "Please enter new ringtone", name, ttone) as text
-			if (in_range(U, src) && loc == U)
+			if (loc == U)
 				if (t)
 					if(INVOKE_EVENT(src, /event/pda_change_ringtone, "user" = U, "new_ringtone" = t))
 						to_chat(U, "The PDA softly beeps.")


### PR DESCRIPTION
It's just an annoying restriction for no reason.

:cl:
 * tweak: PDA ringtone can now be changed while standing inside lockers or other objects.