### PR TITLE
Fixed mech painter runtime

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -2122,6 +2122,8 @@
 	force = 0
 
 /obj/item/device/mech_painter/afterattack(var/obj/mecha/M, var/mob/user)
+	if(!istype(M))
+		return 0
 	if (!M.paintable)
 		to_chat(user, "<span class='warning'>This mech cannot be painted.</span>")
 		return 1


### PR DESCRIPTION
```
[14:16:26] Runtime in mecha.dm, line 2125: undefined variable /turf/simulated/floor/var/paintable
proc name: afterattack (/obj/item/device/mech_painter/afterattack)
usr: Kachichrai Vischus (jognvi) (/mob/living/carbon/human)
usr.loc: The floor (289, 234, 1) (/turf/simulated/floor)
src: the mecha painter (/obj/item/device/mech_painter)
src.loc: Kachichrai Vischus (/mob/living/carbon/human)
call stack:
the mecha painter (/obj/item/device/mech_painter): afterattack(the floor (296,235,1) (/turf/simulated/floor), Kachichrai Vischus (/mob/living/carbon/human), 0, "icon-x=9;icon-y=1;left=1;scree...")
Kachichrai Vischus (/mob/living/carbon/human): RangedClickOn(the floor (296,235,1) (/turf/simulated/floor), "icon-x=9;icon-y=1;left=1;scree...", the mecha painter (/obj/item/device/mech_painter))
Kachichrai Vischus (/mob/living/carbon/human): ClickOn(the floor (296,235,1) (/turf/simulated/floor), "icon-x=9;icon-y=1;left=1;scree...")
the floor (296,235,1) (/turf/simulated/floor): Click(null, "mapwindow.map", "icon-x=9;icon-y=1;left=1;scree...")
(/obj/abstract/screen/clicker): Click(null, "mapwindow.map", "icon-x=9;icon-y=1;left=1;scree...")
JognVI (/client): Click( (/obj/abstract/screen/clicker), null, "mapwindow.map", "icon-x=9;icon-y=1;left=1;scree...")
```