### PR TITLE
Fixed vending machine runtime

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -660,7 +660,7 @@ Class Procs:
 /obj/machinery/proc/can_overload(mob/user) //used for AI machine overload
 	return 1
 
-/obj/machinery/proc/shock(mob/user, prb, var/siemenspassed = -1)
+/obj/machinery/proc/shock(mob/living/user, prb, var/siemenspassed = -1)
 	if(stat & (BROKEN|NOPOWER))		// unpowered, no shock
 		return 0
 	if(!istype(user) || !user.Adjacent(src))


### PR DESCRIPTION
```
[07:48:50] Runtime in powernet.dm, line 351: undefined proc or verb /mob/dead/observer/electrocute act(). 
proc name: electrocute mob (/proc/electrocute_mob)
usr: Chitaki (armadingus) (/mob/dead/observer)
usr.loc: The floor (211, 261, 1) (/turf/simulated/floor)
src: null
call stack:
electrocute mob(Chitaki (/mob/dead/observer), /datum/powernet (/datum/powernet), the Groans Soda (/obj/machinery/vending/groans), 0.7)
the Groans Soda (/obj/machinery/vending/groans): shock(Chitaki (/mob/dead/observer), 100, 0.7)
the Groans Soda (/obj/machinery/vending/groans): attack hand(Chitaki (/mob/dead/observer))
the Groans Soda (/obj/machinery/vending/groans): attack ai(Chitaki (/mob/dead/observer))
the Groans Soda (/obj/machinery/vending/groans): attack ghost(Chitaki (/mob/dead/observer))
Chitaki (/mob/dead/observer): ClickOn(the Groans Soda (/obj/machinery/vending/groans), "icon-x=18;icon-y=13;left=1;scr...")
the Groans Soda (/obj/machinery/vending/groans): Click(the floor (211,260,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=18;icon-y=13;left=1;scr...")
Armadingus (/client): Click(the Groans Soda (/obj/machinery/vending/groans), the floor (211,260,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=18;icon-y=13;left=1;scr...")
```