### PR TITLE
Shard conveyor_act() fix

### DIFF
--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -21,6 +21,7 @@
 		"the Cult of Nar-Sie","the Wizard Federation","an impossibly gigantic lamprey floating through space, bending reality as it goes","a sword that talks",
 		"an eclipse","a sandwich so tall that it pierces the heavens","things you people wouldn't believe","attack ships on fire off the shoulder of Orion","C-beams glittering in the dark near the Tannhäuser Gate",
 		"the xenoarchaeologist", "the xenobiologist", "getting reincarnated in another world","a hat pile so tall that it pierces the heavens","a wheelchair ride pile so tall that it pierces the heavens",
+		"bees","a cryptographic sequencer","the singularity","mr. clean","a dual sword made of pure energy","a welding tool being held to a fuel tank","a cascading supermatter sea",
 		)
 	spawn(0)
 		for(var/i = rand(1,4),i > 0, i--)

--- a/code/modules/multiz/fall_hit.dm
+++ b/code/modules/multiz/fall_hit.dm
@@ -100,7 +100,7 @@
 
 /obj/machinery/power/supermatter/fall_impact(var/atom/hit_atom)
 	..()
-	Consume(hit_atom)
+	Bumped(hit_atom)
 
 var/global/list/non_items = list(/obj/machinery,/obj/structure)
 

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -155,7 +155,7 @@
 		stack_trace("[name] at [T.loc] has tried exploding despite having already exploded once. Looks like it wasn't properly deleted (gcDestroyed = [gcDestroyed]).")
 
 /obj/machinery/power/supermatter/conveyor_act(var/atom/movable/AM, var/obj/machinery/conveyor/CB)
-	Consume(AM)
+	Bumped(AM)
 	return TRUE
 
 /obj/machinery/power/supermatter/ex_act(severity,var/mob/whodunnit)


### PR DESCRIPTION
[bugfix][consistency]
:cl:
 * bugfix: Shards now do all bump types when an item is fed on a conveyor, instead of just ashing everything. (including shard touch explosions and shard splinter fusion)