### PR TITLE
Admins can now easily reset mobs' bodies using the Body Archive

### DIFF
--- a/code/datums/body_archive.dm
+++ b/code/datums/body_archive.dm
@@ -9,12 +9,13 @@
 		return
 	..()
 	mob_type = source.type
+	log_debug("[key_name(src)] has has had their body ([mob_type]) archived.")
 	if (ishuman(source))
 		var/mob/living/carbon/human/H = source
 		var/datum/organ/internal/brain/Brain = H.internal_organs_by_name["brain"]
 
 		var/datum/dna2/record/R = new /datum/dna2/record()
-		if(!isnull(Brain.owner_dna) && Brain.owner_dna != H.dna)
+		if(Brain && !isnull(Brain.owner_dna) && Brain.owner_dna != H.dna)
 			R.dna = Brain.owner_dna.Clone()
 		else
 			R.dna = H.dna.Clone()

--- a/code/datums/body_archive.dm
+++ b/code/datums/body_archive.dm
@@ -1,99 +1,185 @@
 
-/datum/body_archive // basically /datum/mind scans its mob when first created, allowing the original body to be re-created if needed
-	var/mob_type
-	var/datum/dna2/record/dna_records
+var/list/body_archives = list()
 
-/datum/body_archive/New(var/mob/source)
+// basically /datum/mind scans its mob when first created, allowing the original body to be re-created if needed
+/datum/body_archive
+	var/mob_type
+
+	// those of the source mind
+	var/name
+	var/key
+
+	// just an empty list where you can store extra data, such as human DNA records
+	var/list/data = list()
+
+/datum/body_archive/New(var/mob/source)//created in mind_initialize()
 	if (!source)
 		qdel(src)
 		return
 	..()
+	body_archives += src
 	mob_type = source.type
-	log_debug("[key_name(src)] has has had their body ([mob_type]) archived.")
-	if (ishuman(source))
-		var/mob/living/carbon/human/H = source
-		var/datum/organ/internal/brain/Brain = H.internal_organs_by_name["brain"]
+	name = source.mind.name
+	key = source.mind.key
+	log_debug("[key_name(source)] has has had their body ([mob_type]) archived.")
+	source.archive_body(src)
 
-		var/datum/dna2/record/R = new /datum/dna2/record()
-		if(Brain && !isnull(Brain.owner_dna) && Brain.owner_dna != H.dna)
-			R.dna = Brain.owner_dna.Clone()
-		else
-			R.dna = H.dna.Clone()
-		R.ckey = H.ckey
-		R.id= copytext(md5(R.dna.real_name), 2, 6)
-		R.name=R.dna.real_name
-		R.types=DNA2_BUF_UI|DNA2_BUF_UE|DNA2_BUF_SE
-		R.languages = H.languages.Copy()
-		R.attack_log = H.attack_log.Copy()
-		R.default_language = H.default_language
-		R.times_cloned = H.times_cloned
-		R.talkcount = H.talkcount
+/datum/body_archive/proc/spawn_copy(var/turf/T)//admin toy
+	var/mob/M = new mob_type(T)
+	M.reset_body(src)
 
-		dna_records = R
+////////////////////////////////////////////////////////////////////
+//																  //
+//							MOB PROCS							  //
+//																  //
+////////////////////////////////////////////////////////////////////
 
-/////////////////////////////////////////////
+/mob/proc/archive_body(var/datum/body_archive/archive)
 
-/mob/proc/reset_body(var/datum/body_archive/archive)
+/mob/proc/reset_body(var/datum/body_archive/archive,var/keep_clothes = FALSE)
 	if (!archive)
 		if (mind && mind.body_archive)
 			archive = mind.body_archive
 		else
 			return
 
-	var/mob/new_mob
-	// can't just do a /mob/living/carbon/human/reset_body() since the mob might have changed to a non-human since then
-	if (archive.mob_type in typesof(/mob/living/carbon/human))
-		var/datum/dna2/record/R = archive.dna_records
-		var/mob/living/carbon/human/H = new /mob/living/carbon/human(loc, R.dna.species, delay_ready_dna = TRUE)
-		H.times_cloned = 0
-		H.talkcount = R.talkcount
-		if(isplasmaman(H))
-			H.fire_sprite = "Plasmaman"
-		H.dna = R.dna.Clone()
-		H.dna.flavor_text = R.dna.flavor_text
-		H.dna.species = R.dna.species
-		if(H.dna.species != "Human")
-			H.set_species(H.dna.species, TRUE)
-		H.check_mutations = TRUE
-		H.updatehealth()
-		has_been_shade -= mind
-		mind.transfer_to(H)
-		H.ckey = R.ckey
-		if (H.mind.miming)
-			H.add_spell(new /spell/aoe_turf/conjure/forcewall/mime, "grey_spell_ready")
-			if (H.mind.miming == MIMING_OUT_OF_CHOICE)
-				H.add_spell(new /spell/targeted/oathbreak/)
-		if (isvampire(H))
-			var/datum/role/vampire/V = isvampire(H)
-			V.check_vampire_upgrade()
-			V.update_vamp_hud()
-		H.UpdateAppearance()
-		H.set_species(R.dna.species)
-		H.dna.mutantrace = R.dna.mutantrace
-		H.update_mutantrace()
-		for(var/datum/language/L in R.languages)
-			H.add_language(L.name)
-			if (L == R.default_language)
-				H.default_language = R.default_language
-		H.attack_log = R.attack_log
-		H.real_name = H.dna.real_name
-		H.name = H.real_name
-		H.flavor_text = H.dna.flavor_text
-		if(H.mind)
-			H.mind.suiciding = FALSE
-		H.update_name()
-		if (H.client)
-			H.client.eye = H.client.mob
-			H.client.perspective = MOB_PERSPECTIVE
-		H.updatehealth()
-		domutcheck(H)
-		new_mob = H
-
-	else
-
-		new_mob = new archive.mob_type(loc)
-		mind.transfer_to(new_mob)
+	var/mob/temp_mob = new archive.mob_type(loc)
+	var/mob/new_mob = temp_mob.actually_reset_body(archive, keep_clothes, src, mind)
 
 	drop_all()
+	qdel(temp_mob)
 	qdel(src)
 	return new_mob
+
+// With this proc we're guarranted that the mob_type in the archive is the same as src
+/mob/proc/actually_reset_body(var/datum/body_archive/archive,var/keep_clothes = FALSE, var/mob/old_mob, var/datum/mind/our_mind)
+	var/mob/new_mob = new archive.mob_type(loc)
+	if (our_mind)
+		our_mind.transfer_to(new_mob)
+	return new_mob
+
+
+////////////////////////////////////////////////////////////////////
+//																  //
+//					MOB TYPE-SPECIFIC ARCHIVES					  //
+//																  //
+////////////////////////////////////////////////////////////////////
+
+/////////////////////// HUMAN //////////////////////
+
+/mob/living/carbon/human/archive_body(var/datum/body_archive/archive)
+	var/datum/organ/internal/brain/Brain = internal_organs_by_name["brain"]
+	var/datum/dna2/record/R = new /datum/dna2/record()
+	if(Brain && !isnull(Brain.owner_dna) && Brain.owner_dna != dna)
+		R.dna = Brain.owner_dna.Clone()
+	else
+		R.dna = dna.Clone()
+	R.ckey = ckey
+	R.id= copytext(md5(R.dna.real_name), 2, 6)
+	R.name=R.dna.real_name
+	R.types=DNA2_BUF_UI|DNA2_BUF_UE|DNA2_BUF_SE
+	R.languages = languages.Copy()
+	R.attack_log = attack_log.Copy()
+	R.default_language = default_language
+	R.times_cloned = times_cloned
+	R.talkcount = talkcount
+
+	archive.data["dna_records"] = R
+	archive.data["underwear"] = underwear
+
+	//I gave a shot at preserving limb status (destroyed, peg, mechanized) then decided I was too tired and it's too much trouble, so TODO for anyone with the determination
+
+/mob/living/carbon/human/actually_reset_body(var/datum/body_archive/archive,var/keep_clothes = FALSE, var/mob/old_mob, var/datum/mind/our_mind)
+
+	//Creating our new body
+	var/datum/dna2/record/R = archive.data["dna_records"]
+	var/mob/living/carbon/human/H = new /mob/living/carbon/human(loc, R.dna.species, delay_ready_dna = TRUE)
+	H.times_cloned = 0
+	H.talkcount = R.talkcount
+	if(isplasmaman(H))
+		H.fire_sprite = "Plasmaman"
+	H.dna = R.dna.Clone()
+	H.dna.flavor_text = R.dna.flavor_text
+	H.dna.species = R.dna.species
+	if(H.dna.species != "Human")
+		H.set_species(H.dna.species, TRUE)
+	H.check_mutations = TRUE
+	H.updatehealth()
+	if (our_mind)
+		has_been_shade -= our_mind
+		our_mind.transfer_to(H)
+		//H.ckey = R.ckey
+	if (H.mind && H.mind.miming)
+		H.add_spell(new /spell/aoe_turf/conjure/forcewall/mime, "grey_spell_ready")
+		if (H.mind.miming == MIMING_OUT_OF_CHOICE)
+			H.add_spell(new /spell/targeted/oathbreak/)
+	if (isvampire(H))
+		var/datum/role/vampire/V = isvampire(H)
+		V.check_vampire_upgrade()
+		V.update_vamp_hud()
+	H.UpdateAppearance()
+	H.set_species(R.dna.species)
+	H.dna.mutantrace = R.dna.mutantrace
+	H.update_mutantrace()
+	for(var/datum/language/L in R.languages)
+		H.add_language(L.name)
+		if (L == R.default_language)
+			H.default_language = R.default_language
+	H.attack_log = R.attack_log
+	H.real_name = H.dna.real_name
+	H.name = H.real_name
+	H.flavor_text = H.dna.flavor_text
+	if(H.mind)
+		H.mind.suiciding = FALSE
+	H.update_name()
+	if (H.client)
+		H.client.eye = H.client.mob
+		H.client.perspective = MOB_PERSPECTIVE
+	H.updatehealth()
+	domutcheck(H)
+
+	//Optionally transferring items
+	if (ishuman(old_mob) && keep_clothes)
+		//taking care of those items separately so they don't fall on the floor
+		var/obj/item/transfered_uniform = old_mob.get_item_by_slot(slot_w_uniform)
+		var/obj/item/transfered_suit = old_mob.get_item_by_slot(slot_wear_suit)
+		var/obj/item/transfered_id = old_mob.get_item_by_slot(slot_wear_id)
+		var/obj/item/transfered_belt = old_mob.get_item_by_slot(slot_belt)
+		var/obj/item/transfered_suit_storage = old_mob.get_item_by_slot(slot_s_store)
+		var/obj/item/transfered_left_pocket = old_mob.get_item_by_slot(slot_l_store)
+		var/obj/item/transfered_right_pocket = old_mob.get_item_by_slot(slot_r_store)
+		if (transfered_uniform)
+			old_mob.u_equip(transfered_uniform)
+			H.equip_to_slot_or_drop(transfered_uniform,slot_w_uniform)
+		if (transfered_suit)
+			old_mob.u_equip(transfered_suit)
+			H.equip_to_slot_or_drop(transfered_suit,slot_wear_suit)
+		//no need to unequip those since they fell off when removing the previous two
+		if (transfered_id)
+			H.equip_to_slot_or_drop(transfered_id,slot_wear_id)
+		if (transfered_belt)
+			H.equip_to_slot_or_drop(transfered_belt,slot_belt)
+		if (transfered_suit_storage)
+			H.equip_to_slot_or_drop(transfered_suit_storage,slot_s_store)
+		if (transfered_left_pocket)
+			H.equip_to_slot_or_drop(transfered_left_pocket,slot_l_store)
+		if (transfered_right_pocket)
+			H.equip_to_slot_or_drop(transfered_right_pocket,slot_r_store)
+		var/list/other_slots = list(slot_back,slot_wear_mask,slot_handcuffed,slot_ears,slot_glasses,slot_gloves,slot_head,slot_shoes,slot_in_backpack,slot_legcuffed,slot_legs)
+		for(var/slot in other_slots)
+			var/obj/item/transfered_worn_item = old_mob.get_item_by_slot(slot)
+			if (transfered_worn_item)
+				old_mob.u_equip(transfered_worn_item)
+				H.equip_to_slot_or_drop(transfered_worn_item,slot)
+		for (var/i = 1 to old_mob.held_items.len)
+			if (i > H.held_items.len)
+				break
+			var/obj/transfered_held_item = old_mob.held_items[i]
+			if (transfered_held_item)
+				old_mob.drop_item(transfered_held_item,loc,TRUE)
+				H.put_in_hands(transfered_held_item)
+
+	//Maybe putting some pants on too
+	H.underwear = archive.data["underwear"]
+
+	return H

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -889,8 +889,12 @@ function loadPage(list) {
 		if(!M.mind)
 			to_chat(usr, "Only mobs with a /mind have their original body archived")
 			return
+		if (ishuman(M) && alert("Since you are resetting a human, do you want them to keep their current inventory equipped or drop it all on the floor?", "Body Resetting", "Keep Inventory", "Drop Everything") == "Keep Inventory")
+			M.reset_body(keep_clothes = TRUE)
+		else
+			M.reset_body()
 		add_gamelogs(usr, " reset [(M == usr) ? "their own" : "[key_name(M)]'s"] body from its archive.", admin = TRUE, tp_link = TRUE)
-		M.reset_body()
+
 
 	else if(href_list["adjustDamage"] && href_list["mobToDamage"])
 		if(!check_rights(R_DEBUG|R_ADMIN|R_FUN))

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -151,6 +151,7 @@
 			<option value='?_src_=vars;build_mode=\ref[D]'>Toggle Build Mode</option>
 			<option value='?_src_=vars;drop_everything=\ref[D]'>Drop Everything</option>
 			<option value='?_src_=vars;regenerateicons=\ref[D]'>Regenerate Icons</option>
+			<option value='?_src_=vars;resetbody=\ref[D]'>Reset Body From Archive</option>
 		if(ishuman(D))
 
 			body += {"<option value>---</option>
@@ -876,6 +877,20 @@ function loadPage(list) {
 			to_chat(usr, "This can only be done to instances of type /mob")
 			return
 		M.regenerate_icons()
+
+	else if(href_list["resetbody"])
+		if(!check_rights(0))
+			return
+
+		var/mob/M = locate(href_list["resetbody"])
+		if(!ismob(M))
+			to_chat(usr, "This can only be done to instances of type /mob")
+			return
+		if(!M.mind)
+			to_chat(usr, "Only mobs with a /mind have their original body archived")
+			return
+		add_gamelogs(usr, " reset [(M == usr) ? "their own" : "[key_name(M)]'s"] body from its archive.", admin = TRUE, tp_link = TRUE)
+		M.reset_body()
 
 	else if(href_list["adjustDamage"] && href_list["mobToDamage"])
 		if(!check_rights(R_DEBUG|R_ADMIN|R_FUN))

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -97,12 +97,13 @@
 
 	nanomanager.user_transferred(current, new_character)
 
-	if(active)
-		new_character.key = key		//now transfer the key to link the client to our new body
-
 	var/mob/old_character = current
 	current = new_character		//link ourself to our new body
 	new_character.mind = src	//and link our new body to ourself
+
+	if(active)
+		new_character.key = key		//now transfer the key to link the client to our new body
+									//gotta do that after linking the mind to the body or we'll create an extra mind on Login()
 
 	for (var/role in antag_roles)
 		var/datum/role/R = antag_roles[role]
@@ -559,10 +560,10 @@
 			ticker.minds += mind
 		else
 			world.log << "## DEBUG: mind_initialize(): No ticker ready yet! Please inform Carn"
-	if (!mind.body_archive)
-		mind.body_archive = new(src)
 	if(!mind.name)
 		mind.name = real_name
+	if (!mind.body_archive)
+		mind.body_archive = new(src)
 	mind.current = src
 
 //HUMAN

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -88,6 +88,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/persistence_panel,			/*lets you check out the kind of shit that will persist to the next round and say "holy fuck no"*/
 	/client/proc/diseases_panel,
 	/client/proc/artifacts_panel,
+	/client/proc/body_archive_panel,
 	/client/proc/climate_panel,
 	/datum/admins/proc/ashInvokedEmotions	/*Ashes all paper from the invoke emotion spell. An emergency purge.*/
 )

--- a/code/modules/admin/body_archive_panel.dm
+++ b/code/modules/admin/body_archive_panel.dm
@@ -1,0 +1,48 @@
+/datum/admins/proc/body_archive_panel()
+	if (!body_archives || !body_archives.len)
+		alert("No body archive has been created yet. Either nobody has spawned yet or something has gone wrong.")
+		return
+
+	var/dat = {"<html>
+		<head>
+		<style>
+		table,h2 {
+		font-family: Arial, Helvetica, sans-serif;
+		border-collapse: collapse;
+		}
+		td, th {
+		border: 1px solid #dddddd;
+		padding: 8px;
+		}
+		tr:nth-child(even) {
+		background-color: #dddddd;
+		}
+		</style>
+		</head>
+		<body>
+		<h2 style="text-align:center">Body Archive Panel</h2>
+		<table>
+		<tr>
+		<th style="width:1%">Key</th>
+		<th style="width:1%">Name</th>
+		<th style="width:0.5%">Spawn Copy</th>
+		<th style="width:1%">Mob Type</th>
+		</tr>
+		"}
+
+	for (var/datum/body_archive/archive in body_archives)
+		dat += {"<tr>
+			<td>[archive.key]</td>
+			<td>[archive.name]</td>
+			<td><a href='?src=\ref[src];bodyarchivepanel_spawncopy=\ref[archive]'>\[SPAWN\]</a></td>
+			<td><i>[archive.mob_type]</i></td>
+			</tr>
+			"}
+
+	dat += {"</table>
+		</body>
+		</html>
+		"}
+
+	usr << browse(dat, "window=bodyarchivepanel;size=705x450")
+

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -626,6 +626,14 @@
 			O.manual_stop_follow(O.locked_to)
 		O.forceMove(T)
 
+	else if(href_list["bodyarchivepanel_spawncopy"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		var/datum/body_archive/archive = locate(href_list["bodyarchivepanel_spawncopy"])
+
+		archive.spawn_copy(get_turf(usr))
+
 	else if(href_list["climate_timeleft"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1399,6 +1399,14 @@ var/global/blood_virus_spreading_disabled = 0
 		log_admin("[key_name(usr)] checked the Artifacts Panel.")
 	feedback_add_details("admin_verb","ART")
 
+/client/proc/body_archive_panel()
+	set name = "Body Archive Panel"
+	set category = "Admin"
+	if(holder)
+		holder.body_archive_panel()
+		log_admin("[key_name(usr)] checked the Body Archive Panel.")
+	feedback_add_details("admin_verb","BAP")
+
 /client/proc/climate_panel()
 	set name = "Climate Panel"
 	set category = "Admin"

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1313,6 +1313,7 @@
 #include "code\modules\admin\banappearance.dm"
 #include "code\modules\admin\banjob.dm"
 #include "code\modules\admin\banooc.dm"
+#include "code\modules\admin\body_archive_panel.dm"
 #include "code\modules\admin\buildmode.dm"
 #include "code\modules\admin\check_antagonists.dm"
 #include "code\modules\admin\climate_panel.dm"


### PR DESCRIPTION
Fixes #31127


https://user-images.githubusercontent.com/7573912/138987325-9d87ccec-25dd-48a4-98a0-5237239b7672.mp4

https://user-images.githubusercontent.com/7573912/138987347-cd11e5d5-437f-49c8-80bd-58f7ac8823b7.mp4


Admins can now use a mob's View Variables drop down menu to give them back their original body (a feature created for Cult 4's new reincarnation rune). This works even on ghosts, the only requirement is that the mob has a mind, as the body is archived when the mind is initialized.

Note that this drops all of a mob's currently equipped clothes and belonging.

Also fixed a runtime I guess.

:cl:
* rscadd: Admins now have the power to give players back their original body, even if it gets destroyed or transformed.