### PR TITLE
Movecode update for 514 except it works this time

### DIFF
--- a/code/ZAS/Atom.dm
+++ b/code/ZAS/Atom.dm
@@ -4,24 +4,28 @@
 /turf/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 
 	if(!target)
-		return 0
+		return FALSE
 
-	if(istype(mover)) // turf/Enter(...) will perform more advanced checks
+	if(istype(mover))
+		for(var/atom/movable/border_object in border_objects)
+			if(!border_object.Cross(mover, target, height, air_group))
+				bump_target = border_object
+				return FALSE
 		return !density
 
 	else // Now, doing more detailed checks for air movement and air group formation
 		if(target.blocks_air||blocks_air)
-			return 0
+			return FALSE
 
 		for(var/obj/obstacle in src)
 			if(!obstacle.Cross(mover, target, height, air_group))
-				return 0
+				return FALSE
 		if(target != src)
 			for(var/obj/obstacle in target)
 				if(!obstacle.Cross(mover, src, height, air_group))
-					return 0
+					return FALSE
 
-		return 1
+		return TRUE
 
 //Basically another way of calling Cross(null, other, 0, 0) and Cross(null, other, 1.5, 1).
 //Returns:

--- a/code/ZAS/Atom.dm
+++ b/code/ZAS/Atom.dm
@@ -4,13 +4,9 @@
 /turf/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 
 	if(!target)
-		return FALSE
+		return ..()
 
 	if(istype(mover))
-		for(var/atom/movable/border_object in border_objects)
-			if(!border_object.Cross(mover, target, height, air_group))
-				bump_target = border_object
-				return FALSE
 		return !density
 
 	else // Now, doing more detailed checks for air movement and air group formation

--- a/code/ZAS/Atom.dm
+++ b/code/ZAS/Atom.dm
@@ -3,10 +3,7 @@
 
 /turf/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 
-	if(!target)
-		return ..()
-
-	if(istype(mover))
+	if(!target || istype(mover))
 		return !density
 
 	else // Now, doing more detailed checks for air movement and air group formation

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -841,9 +841,9 @@ function loadPage(list) {
 
 		switch(href_list["rotatedir"])
 			if("right")
-				A.dir = turn(A.dir, -45)
+				A.change_dir(turn(A.dir, -45))
 			if("left")
-				A.dir = turn(A.dir, 45)
+				A.change_dir(turn(A.dir, 45))
 		href_list["datumrefresh"] = href_list["rotatedatum"]
 
 	else if(href_list["setspecies"])

--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -777,13 +777,12 @@
 	return 1
 
 /datum/shuttle/proc/move_atom(var/atom/movable/AM, var/new_turf, var/rotate)
-	if(AM.bound_width > WORLD_ICON_SIZE || AM.bound_height > WORLD_ICON_SIZE) //If the moved object's bounding box is more than the default, move it after everything else (using spawn())
+	if(AM.locs.len > 1) //If the moved object is on multiple tiles, move it after everything else (using spawn())
 		AM.forceMove(null) //Without this, ALL neighbouring turfs attempt to move this object too, resulting in the object getting shifted to north/east
 
 		spawn()
 			AM.forceMove(new_turf)
 
-		//TODO: Make this compactible with bound_x and bound_y.
 	else
 		AM.forceMove(new_turf)
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -640,7 +640,7 @@ var/list/moved_landmarks = list(latejoin, wizardstart) //Landmarks that are move
 
 						SX.air.copy_from(ST.zone.air)
 						ST.zone.remove(ST)
-					
+
 					/* Quick visual fix for transit space tiles */
 					if(direction && (locate(/obj/structure/shuttle/diag_wall) in X))
 						// Find a new turf to take on the property of
@@ -653,8 +653,6 @@ var/list/moved_landmarks = list(latejoin, wizardstart) //Landmarks that are move
 						X.icon_state = nextturf.icon_state
 
 					for(var/obj/O in T)
-						if(!istype(O,/obj))
-							continue
 						O.forceMove(X)
 					for(var/mob/M in T)
 						if(!M.can_shuttle_move())

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -771,9 +771,6 @@ its easier to just keep the beam vertical.
 /atom/movable/proc/checkpass(passflag)
 	return pass_flags&passflag
 
-/atom/proc/can_pass(atom/movable/mover) //Can mover pass through src regardless of density, etc.?
-	return istype(mover)
-
 /datum/proc/setGender(gend = FEMALE)
 	if(!("gender" in vars))
 		CRASH("Oh shit you stupid nigger the [src] doesn't have a gender variable.")

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -514,7 +514,7 @@ its easier to just keep the beam vertical.
 
 //Called on every object in a shuttle which rotates
 /atom/proc/shuttle_rotate(var/angle)
-	src.dir = turn(src.dir, -angle)
+	change_dir(turn(src.dir, -angle))
 
 	if(canSmoothWith()) //Smooth the smoothable
 		spawn //Usually when this is called right after an atom is moved. Not having this "spawn" here will cause this atom to look for its neighbours BEFORE they have finished moving, causing bad stuff.

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -41,7 +41,7 @@ var/global/list/ghdel_profiling = list()
 	var/ignoreinvert = 0
 	var/timestopped
 
-	appearance_flags = TILE_BOUND|LONG_GLIDE
+	appearance_flags = TILE_BOUND|LONG_GLIDE|TILE_MOVER
 
 	var/slowdown_modifier //modified on how fast a person can move over the tile we are on, see turf.dm for more info
 	/// Last name used to calculate a color for the chatmessage overlays

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -192,6 +192,10 @@ var/global/list/ghdel_profiling = list()
 /atom/proc/Bumped(atom/movable/AM)
 	return
 
+//When this object is bumped by BYOND, what should actually get bumped? Usually itself but there are some cases where it differs.
+/atom/proc/get_bump_target()
+	return src
+
 /atom/proc/setDensity(var/density)
 	if (density == src.density)
 		return FALSE // No need to invoke the event when we're not doing any actual change

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -193,6 +193,8 @@ var/global/list/ghdel_profiling = list()
 	return
 
 //When this object is bumped by BYOND, what should actually get bumped? Usually itself but there are some cases where it differs.
+//When not returning src, it should generally be called recursively on the found target in case that one also returns something else. Just don't make a cycle.
+//Yes it would be more logical to handle that elsewhere but it would also be more complicated
 /atom/proc/get_bump_target()
 	return src
 
@@ -768,6 +770,9 @@ its easier to just keep the beam vertical.
 
 /atom/movable/proc/checkpass(passflag)
 	return pass_flags&passflag
+
+/atom/proc/can_pass(atom/movable/mover) //Can mover pass through src regardless of density, etc.?
+	return istype(mover)
 
 /datum/proc/setGender(gend = FEMALE)
 	if(!("gender" in vars))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -213,10 +213,9 @@
 
 
 	if(. && locked_atoms && locked_atoms.len)	//The move was succesful, update locked atoms.
-		spawn(0)
-			for(var/atom/movable/AM in locked_atoms)
-				var/datum/locking_category/category = locked_atoms[AM]
-				category.update_lock(AM)
+		for(var/atom/movable/AM in locked_atoms)
+			var/datum/locking_category/category = locked_atoms[AM]
+			category.update_lock(AM)
 
 	update_dir()
 
@@ -254,6 +253,8 @@
 	for(var/atom/movable/AM in locked_atoms)
 		if(dir != AM.dir)
 			AM.change_dir(dir, src)
+			var/datum/locking_category/category = locked_atoms[AM]
+			category.update_lock(AM)
 
 //Like forceMove(), but for dirs!
 /atom/movable/proc/change_dir(new_dir, var/changer)
@@ -397,10 +398,7 @@
 	return
 
 // Always override this proc instead of BYOND-provided Bump().
-// This is a workaround for some dumb BYOND behavior:
-// The `Obstacle` argument passed to Bump() is the first dense object
-// in the turf's `contents`. The argument we provide to this proc
-// is instead the actual object that's blocking movement.
+// This gives us better control over what actually gets bumped instead of being stuck with BYOND's decision.
 /atom/movable/proc/to_bump(atom/Obstacle)
 	if(airflow_speed > 0 && airflow_dest)
 		airflow_hit(Obstacle)
@@ -416,6 +414,7 @@
 
 //As it says above, don't override this. Override to_bump() and/or Obstacle's get_bump_target() instead.
 /atom/movable/Bump(atom/Obstacle)
+	to_chat(src, "[Obstacle]")
 	if(!can_bump)
 		return
 	to_bump(Obstacle.get_bump_target())
@@ -432,6 +431,13 @@
 		unlock_atom(border_dummy)
 		qdel(border_dummy)
 		border_dummy = null
+
+/atom/movable/proc/border_dummy_Cross(atom/movable/mover) //border_dummy calls this in its own Cross() to detect collision
+	if(can_pass(mover))
+		return TRUE
+	if(!density)
+		return TRUE
+	return bounds_dist(src, mover) >= 0
 
 // harderforce is for things like lighting overlays which should only be moved in EXTREMELY specific sitations.
 /atom/movable/proc/forceMove(atom/destination,var/no_tp=0, var/harderforce = FALSE, glide_size_override = 0)
@@ -1186,16 +1192,17 @@
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "window"
 	color = "red"
+	flow_flags = ON_BORDER
 
 /atom/movable/border_dummy/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(!istype(mover))
 		return TRUE //The parent object will handle airflow calculations.
 	if(!locked_to)
 		CRASH("border_dummy was collision checked while not locked to anything! ([x], [y], [z])")
-	return (mover == locked_to) || locked_to.Uncross(mover, target) //An object will hit its own border_dummy if the (mover == locked_to) isn't included.
+	return (mover == locked_to) || locked_to.border_dummy_Cross(mover) //An object will hit its own border_dummy if the (mover == locked_to) isn't included.
 
 /atom/movable/border_dummy/get_bump_target()
-	return locked_to //I don't think it's possible for this line to execute if locked_to is null due to Cross() above.
+	return locked_to.get_bump_target() //I don't think it's possible for this line to execute if locked_to is null due to Cross() above.
 
 
 /datum/locking_category/border_dummy

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -419,6 +419,7 @@
 
 //As it says above, don't override this. Override to_bump() and/or Obstacle's get_bump_target() instead. Assumes could_bump is already a list (not null).
 /atom/movable/Bump(atom/Obstacle)
+	SHOULD_NOT_OVERRIDE(TRUE)
 	could_bump += Obstacle
 
 //Choose an actual bump target from the list of potential bump targets, and to_bump() it.

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -55,6 +55,8 @@
 	var/last_explosion_push = 0
 	var/mob/virtualhearer/virtualhearer
 
+	var/can_bump //Workaround to make things only bump one object per movement
+
 /atom/movable/New()
 	. = ..()
 	if((flags & HEAR) && !ismob(src))
@@ -122,7 +124,7 @@
 	if(!glide_size_override || glide_size_override > max)
 		glide_size = 0
 	else
-		glide_size = max(min, glide_size_override)
+		glide_size = max(min, glide_size_override) * step_size / WORLD_ICON_SIZE //This should probably go in DELAY2GLIDESIZE() instead but that would be a lot of changed macros
 
 /atom/movable/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, var/glide_size_override = 0)
 	if(!loc || !NewLoc)
@@ -169,6 +171,7 @@
 		set_glide_size(glide_size_override)
 
 	var/atom/oldloc = loc
+	can_bump = TRUE
 	if((bound_height != WORLD_ICON_SIZE || bound_width != WORLD_ICON_SIZE) && (loc == NewLoc))
 		. = ..()
 
@@ -406,6 +409,17 @@
 		if(Obstacle)
 			Obstacle.Bumped(src)
 	sound_override = 0
+
+/atom/movable/Bump(atom/Obstacle)
+	if(!can_bump)
+		return
+	if(isturf(Obstacle))
+		var/turf/T = Obstacle
+		if(T.bump_target)
+			Obstacle = T.bump_target
+			T.bump_target = null
+	to_bump(Obstacle)
+	can_bump = FALSE
 
 // harderforce is for things like lighting overlays which should only be moved in EXTREMELY specific sitations.
 /atom/movable/proc/forceMove(atom/destination,var/no_tp=0, var/harderforce = FALSE, glide_size_override = 0)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -175,18 +175,11 @@
 		set_glide_size(glide_size_override)
 
 	var/atom/oldloc = loc
-	could_bump = list()
-	if((bound_height != WORLD_ICON_SIZE || bound_width != WORLD_ICON_SIZE) && (loc == NewLoc))
-		. = ..()
-
-		perform_bump()
-		update_dir()
-		INVOKE_EVENT(src, /event/after_move)
-		return
 
 	//We always split up movements into cardinals for issues with diagonal movements.
 	if(Dir || (loc != NewLoc))
 		if (!(Dir & (Dir - 1))) //Cardinal move
+			could_bump = list()
 			. = ..()
 			perform_bump()
 		else //Diagonal move, split it into cardinal moves
@@ -442,6 +435,7 @@
 		return
 	border_dummy = new()
 	lock_atom(border_dummy, /datum/locking_category/border_dummy)
+	border_dummy.update_dir()
 
 /atom/movable/proc/remove_border_dummy()
 	if(border_dummy)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -81,7 +81,7 @@
 
 	remove_border_dummy()
 
-	INVOKE_EVENT(src, /lazy_event/on_destroyed, "thing" = src)
+	INVOKE_EVENT(src, /event/destroyed, "thing" = src)
 
 	for (var/atom/movable/AM in locked_atoms)
 		unlock_atom(AM)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -181,6 +181,11 @@
 		if (!(Dir & (Dir - 1))) //Cardinal move
 			could_bump = list()
 			. = ..()
+			//The following section is a workaround for a BYOND bug. Remove when the bug is fixed.
+			if((appearance_flags & TILE_MOVER) && (. < step_size))
+				. = 0
+				forceMove(oldloc)
+			//End workaround
 			perform_bump()
 		else //Diagonal move, split it into cardinal moves
 			if (Dir & NORTH)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -446,7 +446,7 @@
 		border_dummy = null
 
 /atom/movable/proc/border_dummy_Cross(atom/movable/mover) //border_dummy calls this in its own Cross() to detect collision
-	if(can_pass(mover))
+	if(istype(mover) && mover.checkpass(pass_flags_self))
 		return TRUE
 	if(!density)
 		return TRUE

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -131,7 +131,7 @@
 		glide_size = max(min, glide_size_override) * step_size / WORLD_ICON_SIZE //This should probably go in DELAY2GLIDESIZE() instead but that would be a lot of changed macros
 
 /atom/movable/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, var/glide_size_override = 0)
-	if(!loc || !NewLoc)
+	if(!loc || !NewLoc || locked_to)
 		return 0
 	INVOKE_EVENT(src, /event/before_move)
 
@@ -803,7 +803,7 @@
 
 //Can it be moved by a shuttle?
 /atom/movable/proc/can_shuttle_move(var/datum/shuttle/S)
-	return 1
+	return !locked_to
 
 /atom/movable/proc/Process_Spacemove(check_drift)
 	var/dense_object = 0
@@ -1249,6 +1249,9 @@
 	if(!locked_to)
 		CRASH("border_dummy was collision checked while not locked to anything! ([x], [y], [z])")
 	return (mover == locked_to) || locked_to.border_dummy_Cross(mover) //An object will hit its own border_dummy if the (mover == locked_to) isn't included.
+
+/atom/movable/border_dummy/throw_at(atom/target, range, speed, override = 1, var/fly_speed = 0)
+	return //It wouldn't actually move even without this override, but it would still hit things on its own tile.
 
 /atom/movable/border_dummy/get_bump_target()
 	return locked_to.get_bump_target() //I don't think it's possible for this line to execute if locked_to is null due to Cross() above.

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -259,7 +259,10 @@
 			category.update_lock(AM)
 
 //Like forceMove(), but for dirs!
-/atom/movable/proc/change_dir(new_dir, var/changer)
+/atom/proc/change_dir(new_dir, changer)
+	dir = new_dir
+
+/atom/movable/change_dir(new_dir, changer)
 	if(locked_to && changer != locked_to)
 		return
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -57,6 +57,8 @@
 
 	var/can_bump //Workaround to make things only bump one object per movement
 
+	var/atom/movable/border_dummy/border_dummy //Used for border objects. The old Uncross() method fails miserably with pixel movement or large hitboxes.
+
 /atom/movable/New()
 	. = ..()
 	if((flags & HEAR) && !ismob(src))
@@ -77,7 +79,9 @@
 		qdel(materials)
 		materials = null
 
-	INVOKE_EVENT(src, /event/destroyed, "thing" = src)
+	remove_border_dummy()
+
+	lazy_invoke_event(/lazy_event/on_destroyed, list("thing" = src))
 
 	for (var/atom/movable/AM in locked_atoms)
 		unlock_atom(AM)
@@ -410,16 +414,24 @@
 			Obstacle.Bumped(src)
 	sound_override = 0
 
+//As it says above, don't override this. Override to_bump() and/or Obstacle's get_bump_target() instead.
 /atom/movable/Bump(atom/Obstacle)
 	if(!can_bump)
 		return
-	if(isturf(Obstacle))
-		var/turf/T = Obstacle
-		if(T.bump_target)
-			Obstacle = T.bump_target
-			T.bump_target = null
-	to_bump(Obstacle)
+	to_bump(Obstacle.get_bump_target())
 	can_bump = FALSE
+
+/atom/movable/proc/setup_border_dummy()
+	if(border_dummy)
+		return
+	border_dummy = new()
+	lock_atom(border_dummy, /datum/locking_category/border_dummy)
+
+/atom/movable/proc/remove_border_dummy()
+	if(border_dummy)
+		unlock_atom(border_dummy)
+		qdel(border_dummy)
+		border_dummy = null
 
 // harderforce is for things like lighting overlays which should only be moved in EXTREMELY specific sitations.
 /atom/movable/proc/forceMove(atom/destination,var/no_tp=0, var/harderforce = FALSE, glide_size_override = 0)
@@ -1167,6 +1179,29 @@
 	else
 		return
 	forceMove(picked)
+
+
+/atom/movable/border_dummy
+	//invisibility = 101
+	icon = 'icons/obj/structures.dmi'
+	icon_state = "window"
+	color = "red"
+
+/atom/movable/border_dummy/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+	if(!istype(mover))
+		return TRUE //The parent object will handle airflow calculations.
+	if(!locked_to)
+		CRASH("border_dummy was collision checked while not locked to anything! ([x], [y], [z])")
+	return (mover == locked_to) || locked_to.Uncross(mover, target) //An object will hit its own border_dummy if the (mover == locked_to) isn't included.
+
+/atom/movable/border_dummy/get_bump_target()
+	return locked_to //I don't think it's possible for this line to execute if locked_to is null due to Cross() above.
+
+
+/datum/locking_category/border_dummy
+	y_offset = 1
+	rotate_offsets = TRUE
+
 
 // -- trackers
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1240,7 +1240,7 @@
 			bound_y = -WORLD_ICON_SIZE
 			bound_height = 3 * WORLD_ICON_SIZE
 		else //Shouldn't happen
-			stack_trace("border_dummy has invalid dir [dir]")
+			CRASH("border_dummy has invalid dir [dir]")
 
 
 /atom/movable/border_dummy/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -81,7 +81,7 @@
 
 	remove_border_dummy()
 
-	lazy_invoke_event(/lazy_event/on_destroyed, list("thing" = src))
+	INVOKE_EVENT(src, /lazy_event/on_destroyed, "thing" = src)
 
 	for (var/atom/movable/AM in locked_atoms)
 		unlock_atom(AM)
@@ -436,6 +436,8 @@
 	if(can_pass(mover))
 		return TRUE
 	if(!density)
+		return TRUE
+	if(locate(/obj/effect/unwall_field) in loc) //Annoying workaround for this -kanef
 		return TRUE
 	return bounds_dist(src, mover) >= 0
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -601,16 +601,14 @@ var/global/list/alert_overlays_global = list()
 	heat_proof = 1
 	air_properties_vary_with_direction = 1
 	flow_flags = ON_BORDER
+	pass_flags_self = PASSDOOR|PASSGLASS
 
 /obj/machinery/door/firedoor/border_only/New()
 	..()
 	setup_border_dummy()
 
-/obj/machinery/door/firedoor/border_only/can_pass(atom/movable/mover)
-	return ..() && mover.checkpass(PASSDOOR | PASSGLASS)
-
 /obj/machinery/door/firedoor/border_only/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	if(can_pass(mover))
+	if(istype(mover) && mover.checkpass(pass_flags_self))
 		return TRUE
 	if(!density)
 		return TRUE

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -606,14 +606,21 @@ var/global/list/alert_overlays_global = list()
 	..()
 	setup_border_dummy()
 
+/obj/machinery/door/firedoor/border_only/can_pass(atom/movable/mover)
+	return ..() && mover.checkpass(PASSDOOR | PASSGLASS)
+
 /obj/machinery/door/firedoor/border_only/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+	if(can_pass(mover))
+		return TRUE
+	if(!density)
+		return TRUE
 	if(locate(/obj/effect/unwall_field) in loc) //Annoying workaround for this -kanef
-		return 1
-	if(istype(mover) && (mover.checkpass(PASSDOOR|PASSGLASS)))
-		return 1
-	if(get_dir(loc, target) == dir || get_dir(loc, mover) == dir)
-		return !density
-	return 1
+		return TRUE
+	if(istype(mover))
+		return bounds_dist(border_dummy, mover) >= 0
+	else if(get_dir(loc, target) == dir)
+		return FALSE
+	return TRUE
 
 //used in the AStar algorithm to determinate if the turf the door is on is passable
 /obj/machinery/door/firedoor/CanAStarPass()
@@ -624,21 +631,6 @@ var/global/list/alert_overlays_global = list()
 		open()
 	else
 		close()
-
-/obj/machinery/door/firedoor/border_only/Uncross(atom/movable/mover as mob|obj, turf/target as turf)
-	if(locate(/obj/effect/unwall_field) in loc) //Annoying workaround for this -kanef
-		return 1
-	if(istype(mover) && (mover.checkpass(PASSDOOR|PASSGLASS)))
-		return 1
-	if(flow_flags & ON_BORDER)
-		if(target) //Are we doing a manual check to see
-			if(get_dir(loc, target) == dir)
-				return !density
-		else if(mover.dir == dir) //Or are we using move code
-			if(density)
-				mover.to_bump(src)
-			return !density
-	return 1
 
 /obj/machinery/door/firedoor/border_only/is_fulltile()
 	return 0

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -602,6 +602,10 @@ var/global/list/alert_overlays_global = list()
 	air_properties_vary_with_direction = 1
 	flow_flags = ON_BORDER
 
+/obj/machinery/door/firedoor/border_only/New()
+	..()
+	setup_border_dummy()
+
 /obj/machinery/door/firedoor/border_only/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(locate(/obj/effect/unwall_field) in loc) //Annoying workaround for this -kanef
 		return 1

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -1,7 +1,7 @@
 //Terribly sorry for the code doubling, but things go derpy otherwise.
 /obj/machinery/door/airlock/multi_tile
 	width = 2
-	appearance_flags = 0
+	appearance_flags = TILE_MOVER
 
 /obj/machinery/door/airlock/multi_tile/glass
 	name = "Glass Airlock"

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -28,6 +28,7 @@
 
 /obj/machinery/door/window/New()
 	..()
+	setup_border_dummy()
 	if((istype(req_access) && req_access.len) || istext(req_access))
 		icon_state = "[icon_state]"
 		base_state = icon_state

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -10,6 +10,7 @@
 	flow_flags = ON_BORDER
 	plane = ABOVE_HUMAN_PLANE //Make it so it appears above all mobs (AI included), it's a border object anyway
 	layer = WINDOOR_LAYER //Below curtains
+	pass_flags_self = PASSDOOR|PASSGLASS
 	opacity = 0
 	var/obj/item/weapon/circuitboard/airlock/electronics = null
 	var/secure = FALSE
@@ -106,7 +107,7 @@
 		close()
 
 /obj/machinery/door/window/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	if(can_pass(mover))
+	if(istype(mover) && mover.checkpass(pass_flags_self))
 		return TRUE
 	if(locate(/obj/effect/unwall_field) in loc) //Annoying workaround for this -kanef
 		return TRUE
@@ -117,9 +118,6 @@
 			return FALSE
 		return !density
 	return TRUE
-
-/obj/machinery/door/window/can_pass(atom/movable/mover)
-	return ..() && mover.checkpass(PASSDOOR | PASSGLASS)
 
 //used in the AStar algorithm to determinate if the turf the door is on is passable
 /obj/machinery/door/window/CanAStarPass(var/obj/item/weapon/card/id/ID, var/to_dir)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -118,12 +118,12 @@
 		return !density
 	return TRUE
 
+/obj/machinery/door/window/can_pass(atom/movable/mover)
+	return ..() && mover.checkpass(PASSDOOR | PASSGLASS)
+
 //used in the AStar algorithm to determinate if the turf the door is on is passable
 /obj/machinery/door/window/CanAStarPass(var/obj/item/weapon/card/id/ID, var/to_dir)
 	return !density || (dir != to_dir) || check_access(ID)
-
-/obj/machinery/door/window/can_pass(atom/movable/mover)
-	return ..() && mover.checkpass(PASSDOOR | PASSGLASS)
 
 /obj/machinery/door/window/open()
 	if(!density) //it's already open you silly cunt

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -338,7 +338,7 @@
 	return WA
 
 /obj/machinery/door/window/proc/set_assembly(var/obj/structure/windoor_assembly/WA)
-	WA.dir = dir
+	WA.change_dir(dir)
 	WA.anchored = TRUE
 	WA.wired = TRUE
 	WA.facing = (is_left_opening() ? "l" : "r")

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -106,35 +106,24 @@
 		close()
 
 /obj/machinery/door/window/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	if(locate(/obj/effect/unwall_field) in loc) //Annoying workaround for this -kanef
-		return 1
-	if(istype(mover) && (mover.checkpass(PASSDOOR|PASSGLASS)))
+	if(can_pass(mover))
 		return TRUE
-	if(get_dir(loc, target) == dir || get_dir(loc, mover) == dir)
+	if(locate(/obj/effect/unwall_field) in loc) //Annoying workaround for this -kanef
+		return TRUE
+	if(istype(mover))
+		return !density || (bounds_dist(border_dummy, mover) >= 0)
+	else if(get_dir(loc, target) == dir)
 		if(air_group)
 			return FALSE
 		return !density
-	else
-		return TRUE
+	return TRUE
 
 //used in the AStar algorithm to determinate if the turf the door is on is passable
 /obj/machinery/door/window/CanAStarPass(var/obj/item/weapon/card/id/ID, var/to_dir)
 	return !density || (dir != to_dir) || check_access(ID)
 
-/obj/machinery/door/window/Uncross(atom/movable/mover, turf/target)
-	if(locate(/obj/effect/unwall_field) in loc) //Annoying workaround for this -kanef
-		return 1
-	if(istype(mover) && (mover.checkpass(PASSDOOR|PASSGLASS)))
-		return TRUE
-	if(flow_flags & ON_BORDER) //but it will always be on border tho
-		if(target) //Are we doing a manual check to see
-			if(get_dir(loc, target) == dir)
-				return !density
-		else if(mover.dir == dir) //Or are we using move code
-			if(density)
-				mover.to_bump(src)
-			return !density
-	return TRUE
+/obj/machinery/door/window/can_pass(atom/movable/mover)
+	return ..() && mover.checkpass(PASSDOOR | PASSGLASS)
 
 /obj/machinery/door/window/open()
 	if(!density) //it's already open you silly cunt

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -15,7 +15,7 @@ var/global/list/blood_list = list()
 	random_icon_states = list("mfloor1", "mfloor2", "mfloor3", "mfloor4", "mfloor5", "mfloor6", "mfloor7")
 	plane = ABOVE_TURF_PLANE
 	layer = BLOOD_LAYER
-	appearance_flags = TILE_BOUND|LONG_GLIDE
+	appearance_flags = TILE_BOUND|LONG_GLIDE|TILE_MOVER
 	throwforce = 0
 	var/base_icon = 'icons/effects/blood.dmi'
 

--- a/code/game/objects/effects/spawners/grille_window_spawner.dm
+++ b/code/game/objects/effects/spawners/grille_window_spawner.dm
@@ -43,7 +43,7 @@
 					break
 		if(!found_connection)
 			var/obj/structure/window/new_window = new window_path(loc)
-			new_window.dir = direction
+			new_window.change_dir(direction)
 			new_window.update_nearby_tiles()
 
 	for(var/obj/window_grille_spawner/other in neighbours)

--- a/code/game/objects/items/stacks/stack_recipes.dm
+++ b/code/game/objects/items/stacks/stack_recipes.dm
@@ -93,7 +93,7 @@
 		for(var/i = 1 to (max_res_amount>1 ? res_amount*multiplier : 1))
 			O = new result_type(usr.loc)
 
-	O.dir = usr.dir
+	O.change_dir(usr.dir)
 	if(start_unanchored)
 		var/obj/A = O
 		A.anchored = 0

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -139,6 +139,9 @@
 	..(loc)
 	flow_flags &= ~ON_BORDER
 
+/obj/structure/window/barricade/full/setup_border_dummy()
+	return
+
 /obj/structure/window/barricade/full/blocks_doors()
 	return TRUE
 

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -145,10 +145,6 @@
 /obj/structure/window/barricade/full/blocks_doors()
 	return TRUE
 
-/obj/structure/window/barricade/full/Uncross(atom/movable/O as mob|obj, target as turf)
-
-	return 1
-
 /obj/structure/window/barricade/full/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 	if(air_group || !height) //The mover is an airgroup
 		return 1 //We aren't airtight, only exception to PASSGLASS

--- a/code/game/objects/structures/fullwindow.dm
+++ b/code/game/objects/structures/fullwindow.dm
@@ -24,15 +24,12 @@
 /obj/structure/window/full/setup_border_dummy()
 	return
 
-/obj/structure/window/full/Uncross(atom/movable/O as mob|obj, target as turf)
-
-	return 1
 
 /obj/structure/window/full/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 	if(istype(mover) && mover.checkpass(pass_flags_self))
 		dim_beam(mover)
-		return 1
-	return 0
+		return TRUE
+	return !density
 
 /obj/structure/window/full/can_be_reached(mob/user)
 

--- a/code/game/objects/structures/fullwindow.dm
+++ b/code/game/objects/structures/fullwindow.dm
@@ -21,6 +21,9 @@
 	..(loc)
 	flow_flags |= ON_BORDER
 
+/obj/structure/window/full/setup_border_dummy()
+	return
+
 /obj/structure/window/full/Uncross(atom/movable/O as mob|obj, target as turf)
 
 	return 1

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -200,7 +200,7 @@
 					var/obj/structure/window/S = SR.build(user,G,1,loc)
 					if(S)
 						S.forceMove(get_turf(src))
-						S.dir = get_dir(src, user)
+						S.change_dir(get_dir(src, user))
 						return
 		else
 			to_chat(user, "<span class='warning'>You need to stand properly in front of the grille to place windows on it.</span>")

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -315,10 +315,7 @@
 	if(istype(mover) && mover.checkpass(pass_flags_self))
 		return 1
 	if(flipped)
-		if(get_dir(loc, target) == dir || get_dir(loc, mover) == dir)
-			return !density
-		else
-			return 1
+		return bounds_dist(border_dummy, mover) >= 0
 	return 0
 
 /obj/structure/table/Bumped(atom/movable/AM)
@@ -348,21 +345,6 @@
 			visible_message("<span class='warning'>[src] breaks down!</span>")
 			destroy()
 			return 1
-	return 1
-
-/obj/structure/table/Uncross(atom/movable/mover as mob|obj, target as turf)
-	if(locate(/obj/effect/unwall_field) in loc) //Annoying workaround for this -kanef
-		return 1
-	if(istype(mover) && mover.checkpass(pass_flags_self))
-		return 1
-	if(flow_flags & ON_BORDER)
-		if(target) //Are we doing a manual check to see
-			if(get_dir(loc, target) == dir)
-				return !density
-		else if(mover.dir == dir) //Or are we using move code
-			if(density)
-				mover.to_bump(src)
-			return !density
 	return 1
 
 /obj/structure/table/MouseDropTo(atom/movable/O,mob/user,src_location,over_location,src_control,over_control,params)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -526,6 +526,7 @@
 		plane = ABOVE_HUMAN_PLANE
 	flipped = 1
 	flow_flags |= ON_BORDER
+	setup_border_dummy()
 	for(var/D in list(turn(direction, 90), turn(direction, -90)))
 		var/obj/structure/table/T = locate() in get_step(src,D)
 		if(T && !T.flipped)
@@ -542,6 +543,7 @@
 	reset_plane_and_layer()
 	flipped = 0
 	flow_flags &= ~ON_BORDER
+	remove_border_dummy()
 	for(var/D in list(turn(dir, 90), turn(dir, -90)))
 		var/obj/structure/table/T = locate() in get_step(src.loc,D)
 		if(T && T.flipped && T.dir == src.dir)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -234,9 +234,9 @@
 			if(6)
 				icon_state = "[initial(icon_state)]_dir3"
 		if (dir_sum in alldirs)
-			dir = dir_sum
+			change_dir(dir_sum)
 		else
-			dir = 2
+			change_dir(SOUTH)
 
 /obj/structure/table/ex_act(severity)
 	switch(severity)
@@ -503,7 +503,7 @@
 			spawn(0)
 				A.throw_at(pick(targets),1,1)
 
-	dir = direction
+	change_dir(direction)
 	if(dir != NORTH)
 		plane = ABOVE_HUMAN_PLANE
 	flipped = 1

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -60,7 +60,7 @@
 /obj/structure/windoor_assembly/proc/make_windoor(var/mob/user)
 	var/spawn_type = secure ? secure_type : windoor_type
 	var/obj/machinery/door/window/windoor = new spawn_type(loc)
-	windoor.dir = dir
+	windoor.change_dir(dir)
 	windoor.base_state = (facing == "l" ? "left" : "right")
 	windoor.icon_state = windoor.base_state
 	transfer_fingerprints_to(windoor)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -239,7 +239,7 @@
 	if(anchored)
 		to_chat(usr, "It is fastened to the floor; therefore, you can't rotate it!")
 		return FALSE
-	dir = turn(dir, 270)
+	change_dir(turn(dir, 270))
 	update_nearby_tiles()
 	update_icon()
 

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -36,6 +36,7 @@
 /obj/structure/windoor_assembly/New()
 	..()
 	update_nearby_tiles()
+	setup_border_dummy() //I guess? It's not dense anyway but whatever
 
 /obj/structure/windoor_assembly/Destroy()
 	setDensity(FALSE)
@@ -48,25 +49,16 @@
 /obj/structure/windoor_assembly/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover) && mover.checkpass(pass_flags_self))
 		return TRUE
-	if(get_dir(target, mover) == dir) //Make sure looking at appropriate border
+	if(istype(mover))
+		return !density || (bounds_dist(border_dummy, mover) >= 0)
+	else if(get_dir(loc, target) == dir)
 		if(air_group)
-			return FALSE
+			return FALSE //There's no especially compelling reason for this here but it's copied from windoors
 		return !density
-	else
-		return TRUE
-
-/obj/structure/windoor_assembly/Uncross(atom/movable/mover, turf/target)
-	if(istype(mover) && mover.checkpass(pass_flags_self))
-		return TRUE
-	if(flow_flags & ON_BORDER)
-		if(target) //Are we doing a manual check to see
-			if(get_dir(loc, target) == dir)
-				return !density
-		else if(mover.dir == dir) //Or are we using move code
-			if(density)
-				mover.to_bump(src)
-			return !density
 	return TRUE
+
+/obj/structure/windoor_assembly/can_pass(atom/movable/mover)
+	return ..() && mover.checkpass(PASSDOOR | PASSGLASS)
 
 /obj/structure/windoor_assembly/proc/make_windoor(var/mob/user)
 	var/spawn_type = secure ? secure_type : windoor_type

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -57,9 +57,6 @@
 		return !density
 	return TRUE
 
-/obj/structure/windoor_assembly/can_pass(atom/movable/mover)
-	return ..() && mover.checkpass(PASSDOOR | PASSGLASS)
-
 /obj/structure/windoor_assembly/proc/make_windoor(var/mob/user)
 	var/spawn_type = secure ? secure_type : windoor_type
 	var/obj/machinery/door/window/windoor = new spawn_type(loc)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -43,6 +43,7 @@ var/list/one_way_windows
 
 	..(loc)
 	flow_flags |= ON_BORDER
+	setup_border_dummy()
 
 	update_nearby_tiles()
 	update_nearby_icons()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -184,13 +184,10 @@ var/list/one_way_windows
 			"<span class='danger'>Your kick [pick("bounces","gleams")] off \the [src] harmlessly.</span>")
 		healthcheck()
 
-/obj/structure/window/can_pass(atom/movable/mover)
-	return ..() && mover.checkpass(PASSGLASS)
-
 /obj/structure/window/Cross(atom/movable/mover, turf/target, height = 0)
 	if(locate(/obj/effect/unwall_field) in loc) //Annoying workaround for this
 		return TRUE
-	if(can_pass(mover))//checking for beam dispersion both in and out, since beams do not trigger Uncross.
+	if(istype(mover) && mover.checkpass(pass_flags_self))//checking for beam dispersion both in and out, since beams do not trigger Uncross.
 		if((get_dir(loc, target) | get_dir(loc, mover)) & (dir | reverse_direction(dir)))
 			dim_beam(mover)
 		return TRUE

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -190,12 +190,9 @@ var/list/one_way_windows
 /obj/structure/window/Cross(atom/movable/mover, turf/target, height = 0)
 	if(locate(/obj/effect/unwall_field) in loc) //Annoying workaround for this
 		return TRUE
-	if(can_pass(mover))
-		if(istype(mover,/obj/item/projectile/beam))
-			var/obj/item/projectile/beam/B = mover
-			B.damage *= disperse_coeff
-			if(B.damage <= 1)
-				B.bullet_die()
+	if(can_pass(mover))//checking for beam dispersion both in and out, since beams do not trigger Uncross.
+		if((get_dir(loc, target) | get_dir(loc, mover)) & (dir | reverse_direction(dir)))
+			dim_beam(mover)
 		return TRUE
 	if(!density)
 		return TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -113,7 +113,7 @@
 		border_objects -= mover //Don't bother checking for the flag, in case it lost it.
 		if(!border_objects.len)
 			border_objects = null
-	lazy_invoke_event(/lazy_event/on_exited, list("mover" = mover, "location" = src, "newloc" = newloc))
+	INVOKE_EVENT(src, /lazy_event/on_exited, "mover" = mover, "location" = src, "newloc" = newloc)
 
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
 	return Cross(mover, src)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -71,8 +71,6 @@
 	var/holomap_draw_override = HOLOMAP_DRAW_NORMAL
 
 	var/last_beam_damage = 0
-	var/list/border_objects //Only exists when there are border objects on the turf.
-	var/atom/movable/bump_target //If this var is not null, bumping this turf bumps this object instead. Used for border objects. Unset immediately when bumped.
 
 /turf/examine(mob/user)
 	..()
@@ -109,25 +107,16 @@
 
 /turf/Exited(atom/movable/mover, atom/newloc)
 	..()
-	if(border_objects)
-		border_objects -= mover //Don't bother checking for the flag, in case it lost it.
-		if(!border_objects.len)
-			border_objects = null
 	INVOKE_EVENT(src, /event/exited, "mover" = mover, "location" = src, "newloc" = newloc)
 
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
-	return Cross(mover, src)
+	return ..()
 
 
 /turf/Entered(atom/movable/A as mob|obj, atom/OldLoc)
 	if(movement_disabled)
 		to_chat(usr, "<span class='warning'>Movement is admin-disabled.</span>")//This is to identify lag problems
 		return
-
-	if(A.flow_flags & ON_BORDER)
-		if(!border_objects)
-			border_objects = list()
-		border_objects += A
 
 	//THIS IS OLD TURF ENTERED CODE
 	var/loopsanity = 100
@@ -251,10 +240,6 @@
 	if(A && A.opacity)
 		has_opaque_atom = TRUE // Make sure to do this before reconsider_lights(), incase we're on instant updates. Guaranteed to be on in this case.
 		reconsider_lights()
-
-/turf/get_bump_target()
-	. = bump_target?.get_bump_target() || ..()
-	bump_target = null
 
 /turf/proc/is_plating()
 	return 0

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -103,6 +103,7 @@
 	return 0
 
 /turf/Exit(atom/movable/mover, atom/target)
+<<<<<<< HEAD
 	if(!mover)
 		return 1
 	// First, make sure it can leave its square
@@ -119,44 +120,16 @@
 				mover.to_bump(obstacle, 1)
 				return 0
 	return 1
+=======
+	return TRUE
+>>>>>>> da8a8ff543 (This stuff)
 
 /turf/Exited(atom/movable/mover, atom/newloc)
 	..()
 	INVOKE_EVENT(src, /event/exited, "mover" = mover, "location" = src, "newloc" = newloc)
 
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
-	if (!mover)
-		return 1
-
-	var/list/large_dense = list()
-	//Next, check objects to block entry that are on the border
-	for(var/atom/movable/border_obstacle in src)
-		if(border_obstacle.flow_flags&ON_BORDER)
-			/*if(ismob(mover) && mover:client)
-				world << "<span class='danger'>ENTER</span>Target(border): checking Cross of [border_obstacle]"*/
-			if(!border_obstacle.Cross(mover, mover.loc) && (forget != border_obstacle) && mover != border_obstacle)
-				/*if(ismob(mover) && mover:client)
-					world << "<span class='danger'>ENTER</span>Target(border): We are bumping into [border_obstacle]"*/
-				mover.to_bump(border_obstacle, 1)
-				return 0
-		else
-			large_dense += border_obstacle
-
-	//Then, check the turf itself
-	if (!src.Cross(mover, src))
-		mover.to_bump(src, 1)
-		return 0
-
-	//Finally, check objects/mobs to block entry that are not on the border
-	for(var/atom/movable/obstacle in large_dense)
-		/*if(ismob(mover) && mover:client)
-			world << "<span class='danger'>ENTER</span>target(large_dense): [mover] checking Cross of [obstacle]"*/
-		if(!obstacle.Cross(mover, mover.loc) && (forget != obstacle) && mover != obstacle)
-			/*if(ismob(mover) && mover:client)
-				world << "<span class='danger'>ENTER</span>target(large_dense): checking: We are bumping into [obstacle]"*/
-			mover.to_bump(obstacle, 1)
-			return 0
-	return 1 //Nothing found to block so return success!
+	return Cross(mover, src)
 
 
 /turf/Entered(atom/movable/A as mob|obj, atom/OldLoc)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -252,6 +252,10 @@
 		has_opaque_atom = TRUE // Make sure to do this before reconsider_lights(), incase we're on instant updates. Guaranteed to be on in this case.
 		reconsider_lights()
 
+/turf/get_bump_target()
+	. = bump_target || ..()
+	bump_target = null
+
 /turf/proc/is_plating()
 	return 0
 /turf/proc/can_place_cables()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -113,7 +113,7 @@
 		border_objects -= mover //Don't bother checking for the flag, in case it lost it.
 		if(!border_objects.len)
 			border_objects = null
-	INVOKE_EVENT(src, /lazy_event/on_exited, "mover" = mover, "location" = src, "newloc" = newloc)
+	INVOKE_EVENT(src, /event/exited, "mover" = mover, "location" = src, "newloc" = newloc)
 
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
 	return Cross(mover, src)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -109,9 +109,6 @@
 	..()
 	INVOKE_EVENT(src, /event/exited, "mover" = mover, "location" = src, "newloc" = newloc)
 
-/turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
-	return ..()
-
 
 /turf/Entered(atom/movable/A as mob|obj, atom/OldLoc)
 	if(movement_disabled)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -253,7 +253,7 @@
 		reconsider_lights()
 
 /turf/get_bump_target()
-	. = bump_target || ..()
+	. = bump_target?.get_bump_target() || ..()
 	bump_target = null
 
 /turf/proc/is_plating()

--- a/code/modules/RCD/schematics/rcd_window_spawner.dm
+++ b/code/modules/RCD/schematics/rcd_window_spawner.dm
@@ -8,108 +8,108 @@
 	spawn_window()
 
 /obj/effect/spawner/window/proc/spawn_window()
-    var/turf/T = get_turf(src)
-    if(T && !istype(T,/turf/simulated/wall) && !istype(T,/turf/unsimulated/wall))
-        if(!locate(/obj/structure/grille) in loc)
-            new /obj/structure/grille(T)
-        for(var/direction in dirs)
-            var/windowhere = FALSE
-            for(var/obj/structure/window/reinforced/R in loc)
-                if(R.dir == direction)
-                    windowhere = TRUE
-            if(windowhere)
-                continue
-            var/obj/structure/window/reinforced/new_window = new /obj/structure/window/reinforced(loc)
-            new_window.dir = direction
-            new_window.update_nearby_tiles()
-        if(full && !locate(/obj/structure/window/full/reinforced) in loc)
-            var/obj/structure/window/reinforced/new_fullwindow = new /obj/structure/window/full/reinforced(loc)
-            new_fullwindow.update_nearby_tiles()
-    qdel(src)
+	var/turf/T = get_turf(src)
+	if(T && !istype(T,/turf/simulated/wall) && !istype(T,/turf/unsimulated/wall))
+		if(!locate(/obj/structure/grille) in loc)
+			new /obj/structure/grille(T)
+		for(var/direction in dirs)
+			var/windowhere = FALSE
+			for(var/obj/structure/window/reinforced/R in loc)
+				if(R.dir == direction)
+					windowhere = TRUE
+			if(windowhere)
+				continue
+			var/obj/structure/window/reinforced/new_window = new /obj/structure/window/reinforced(loc)
+			new_window.change_dir(direction)
+			new_window.update_nearby_tiles()
+		if(full && !locate(/obj/structure/window/full/reinforced) in loc)
+			var/obj/structure/window/reinforced/new_fullwindow = new /obj/structure/window/full/reinforced(loc)
+			new_fullwindow.update_nearby_tiles()
+	qdel(src)
 
 /obj/effect/spawner/window/northend
-    dirs = list(NORTH)
+	dirs = list(NORTH)
 
 /obj/effect/spawner/window/westend
-    dirs = list(WEST)
+	dirs = list(WEST)
 
 /obj/effect/spawner/window/southend
-    dirs = list(SOUTH)
+	dirs = list(SOUTH)
 
 /obj/effect/spawner/window/eastend
-    dirs = list(EAST)
+	dirs = list(EAST)
 
 /obj/effect/spawner/window/horizontal
-    dirs = list(NORTH,SOUTH)
+	dirs = list(NORTH,SOUTH)
 
 /obj/effect/spawner/window/vertical
-    dirs = list(WEST,EAST)
+	dirs = list(WEST,EAST)
 
 /obj/effect/spawner/window/nwcorner
-    dirs = list(NORTH,WEST)
+	dirs = list(NORTH,WEST)
 
 /obj/effect/spawner/window/swcorner
-    dirs = list(SOUTH,WEST)
+	dirs = list(SOUTH,WEST)
 
 /obj/effect/spawner/window/secorner
-    dirs = list(SOUTH,EAST)
+	dirs = list(SOUTH,EAST)
 
 /obj/effect/spawner/window/necorner
-    dirs = list(NORTH,EAST)
+	dirs = list(NORTH,EAST)
 
 /obj/effect/spawner/window/northcap
-    dirs = list(NORTH,EAST,WEST)
+	dirs = list(NORTH,EAST,WEST)
 
 /obj/effect/spawner/window/westcap
-    dirs = list(WEST,NORTH,SOUTH)
+	dirs = list(WEST,NORTH,SOUTH)
 
 /obj/effect/spawner/window/southcap
-    dirs = list(SOUTH,EAST,WEST)
+	dirs = list(SOUTH,EAST,WEST)
 
 /obj/effect/spawner/window/eastcap
-    dirs = list(EAST,NORTH,SOUTH)
+	dirs = list(EAST,NORTH,SOUTH)
 
 /obj/effect/spawner/window/full
-    full = TRUE
+	full = TRUE
 
 /obj/effect/spawner/window/full/northend
-    dirs = list(NORTH)
+	dirs = list(NORTH)
 
 /obj/effect/spawner/window/full/westend
-    dirs = list(WEST)
+	dirs = list(WEST)
 
 /obj/effect/spawner/window/full/southend
-    dirs = list(SOUTH)
+	dirs = list(SOUTH)
 
 /obj/effect/spawner/window/full/eastend
-    dirs = list(EAST)
+	dirs = list(EAST)
 
 /obj/effect/spawner/window/full/horizontal
-    dirs = list(NORTH,SOUTH)
+	dirs = list(NORTH,SOUTH)
 
 /obj/effect/spawner/window/full/vertical
-    dirs = list(WEST,EAST)
+	dirs = list(WEST,EAST)
 
 /obj/effect/spawner/window/full/nwcorner
-    dirs = list(NORTH,WEST)
+	dirs = list(NORTH,WEST)
 
 /obj/effect/spawner/window/full/swcorner
-    dirs = list(SOUTH,WEST)
+	dirs = list(SOUTH,WEST)
 
 /obj/effect/spawner/window/full/secorner
-    dirs = list(SOUTH,EAST)
+	dirs = list(SOUTH,EAST)
 
 /obj/effect/spawner/window/full/necorner
-    dirs = list(NORTH,EAST)
+	dirs = list(NORTH,EAST)
 
 /obj/effect/spawner/window/full/northcap
-    dirs = list(NORTH,EAST,WEST)
+	dirs = list(NORTH,EAST,WEST)
 
 /obj/effect/spawner/window/full/westcap
-    dirs = list(WEST,NORTH,SOUTH)
+	dirs = list(WEST,NORTH,SOUTH)
 
 /obj/effect/spawner/window/full/southcap
-    dirs = list(SOUTH,EAST,WEST)
+	dirs = list(SOUTH,EAST,WEST)
 
 /obj/effect/spawner/window/full/eastcap
-    dirs = list(EAST,NORTH,SOUTH)
+	dirs = list(EAST,NORTH,SOUTH)

--- a/code/modules/admin/buildmode.dm
+++ b/code/modules/admin/buildmode.dm
@@ -357,13 +357,13 @@ var/global/list/obj/effect/bmode/buildholder/buildmodeholders = list()
 								if(!v_typechk(thing,chosen,strict))
 									continue
 								var/atom/A = new whatfill(T)
-								A.dir = thing.dir
+								A.change_dir(thing.dir)
 								qdel(thing)
 								CHECK_TICK
 						else
 							var/obj/A = new whatfill(T)
 							if(istype(A))
-								A.dir = holder.builddir.dir
+								A.change_dir(holder.builddir.dir)
 				CHECK_TICK
 			if(deletions)
 				to_chat(usr, "<span class='info'>Successfully deleted [deletions] [chosen]'\s</span>")
@@ -470,16 +470,16 @@ var/global/list/obj/effect/bmode/buildholder/buildmodeholders = list()
 				switch(holder.builddir.dir)
 					if(NORTH)
 						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
-						WIN.dir = NORTH
+						WIN.change_dir(NORTH)
 					if(SOUTH)
 						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
-						WIN.dir = SOUTH
+						WIN.change_dir(SOUTH)
 					if(EAST)
 						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
-						WIN.dir = EAST
+						WIN.change_dir(EAST)
 					if(WEST)
 						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
-						WIN.dir = WEST
+						WIN.change_dir(WEST)
 					if(SOUTHWEST)
 						new/obj/structure/window/full/reinforced(get_turf(object))
 		if(2)
@@ -593,13 +593,13 @@ var/global/list/obj/effect/bmode/buildholder/buildmodeholders = list()
 													if(!istype(thing, chosen))
 														continue
 												var/atom/A = new holder.buildmode.objholder(T)
-												A.dir = thing.dir
+												A.change_dir(thing.dir)
 												qdel(thing)
 												CHECK_TICK
 										else
 											var/obj/A = new holder.buildmode.objholder(T)
 											if(istype(A))
-												A.dir = holder.builddir.dir
+												A.change_dir(holder.builddir.dir)
 								CHECK_TICK
 							holder.fill_left = null
 							holder.fill_right = null
@@ -621,7 +621,7 @@ var/global/list/obj/effect/bmode/buildholder/buildmodeholders = list()
 						var/atom/movable/A = new holder.buildmode.copycat.type(get_turf(object))
 						if(istype(A))
 							A.appearance = holder.buildmode.copycat.appearance
-							A.dir = holder.builddir.dir
+							A.change_dir(holder.builddir.dir)
 					log_admin("[key_name(usr)] made a [holder.buildmode.copycat.type] at [formatJumpTo(RT)]")
 				else
 					if(ispath(holder.buildmode.objholder,/turf)) //Handle turf changing
@@ -634,7 +634,7 @@ var/global/list/obj/effect/bmode/buildholder/buildmodeholders = list()
 					else //Handle object spawning
 						var/obj/A = new holder.buildmode.objholder (get_turf(object))
 						if(istype(A))
-							A.dir = holder.builddir.dir
+							A.change_dir(holder.builddir.dir)
 					log_admin("[key_name(usr)] made a [holder.buildmode.objholder] at [formatJumpTo(RT)]")
 			else if(pa.Find("right"))
 				log_admin("[key_name(usr)] deleted a [object] at [formatJumpTo(RT)]")

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -209,12 +209,6 @@ var/list/forbidden_varedit_object_types = list(
 			else
 				to_chat(user, "Unknown type: [selected_type]")
 
-	switch(edited_variable)
-		if("bound_width", "bound_height", "bound_x", "bound_y")
-			if(new_value % world.icon_size) //bound_width/height must be a multiple of 32, otherwise movement breaks - BYOND issue
-				to_chat(usr, "[edited_variable] can only be a multiple of [world.icon_size]!")
-				return
-
 	if(edited_datum && edited_variable)
 		if(isdatum(edited_datum) && edited_datum.variable_edited(edited_variable, old_value, new_value))
 		//variable_edited() can block the edit in case there's special behavior for a variable (for example, updating lights after they're changed)

--- a/code/modules/components/ai/controller.dm
+++ b/code/modules/components/ai/controller.dm
@@ -19,7 +19,6 @@
 /datum/component/controller/Destroy()
 	parent.unregister_event(/event/comp_ai_cmd_set_busy, src, .proc/cmd_set_busy)
 	parent.unregister_event(/event/comp_ai_cmd_get_busy, src, .proc/cmd_get_busy)
-	..()
 
 	parent.unregister_event(/event/comp_ai_cmd_set_target, src, .proc/cmd_set_target)
 	parent.unregister_event(/event/comp_ai_cmd_get_target, src, .proc/cmd_get_target)

--- a/code/modules/components/ai/controller.dm
+++ b/code/modules/components/ai/controller.dm
@@ -19,12 +19,7 @@
 /datum/component/controller/Destroy()
 	parent.unregister_event(/event/comp_ai_cmd_set_busy, src, .proc/cmd_set_busy)
 	parent.unregister_event(/event/comp_ai_cmd_get_busy, src, .proc/cmd_get_busy)
-
-// Called when we bump another movable atom.
-/datum/component/controller/proc/OnBump(var/atom/A)
-	if(istype(A, /atom/movable))
-		var/atom/movable/AM = A
-		SendSignal(COMSIG_BUMP, list("movable"=AM))
+	..()
 
 	parent.unregister_event(/event/comp_ai_cmd_set_target, src, .proc/cmd_set_target)
 	parent.unregister_event(/event/comp_ai_cmd_get_target, src, .proc/cmd_get_target)

--- a/code/modules/components/ai/controller.dm
+++ b/code/modules/components/ai/controller.dm
@@ -20,6 +20,12 @@
 	parent.unregister_event(/event/comp_ai_cmd_set_busy, src, .proc/cmd_set_busy)
 	parent.unregister_event(/event/comp_ai_cmd_get_busy, src, .proc/cmd_get_busy)
 
+// Called when we bump another movable atom.
+/datum/component/controller/proc/OnBump(var/atom/A)
+	if(istype(A, /atom/movable))
+		var/atom/movable/AM = A
+		SendSignal(COMSIG_BUMP, list("movable"=AM))
+
 	parent.unregister_event(/event/comp_ai_cmd_set_target, src, .proc/cmd_set_target)
 	parent.unregister_event(/event/comp_ai_cmd_get_target, src, .proc/cmd_get_target)
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -28,7 +28,7 @@ var/list/global_singularity_pool
 	var/last_movement_dir = 0 //Log the singularity's last movement to produce biased movement (singularity prefers constant movement due to inertia)
 	var/last_failed_movement = 0 //Will not move in the same dir if it couldnt before, will help with the getting stuck on fields thing.
 	var/last_warning
-	appearance_flags = LONG_GLIDE
+	appearance_flags = LONG_GLIDE|TILE_MOVER
 	var/chained = 0 //Adminbus chain-grab
 	var/modifier = "" //for memes
 
@@ -695,7 +695,7 @@ var/list/global_singularity_pool
 	var/democracy_cooldown = 120
 	var/list/inputs = list("UP","DOWN","LEFT","RIGHT")
 	var/deadchat_active = 1
-	appearance_flags = 0
+	appearance_flags = TILE_MOVER
 
 /obj/machinery/singularity/deadchat_controlled/Destroy()
 	..()

--- a/code/modules/power/treadmill.dm
+++ b/code/modules/power/treadmill.dm
@@ -124,7 +124,7 @@
 	if (usr.isUnconscious() || usr.restrained()  || anchored)
 		return
 
-	src.dir = turn(src.dir, -90)
+	change_dir(turn(src.dir, -90))
 
 /obj/machinery/power/treadmill/verb/rotate_anticlock()
 	set category = "Object"
@@ -135,4 +135,4 @@
 		to_chat(usr, "It is fastened to the floor!")
 		return
 
-	src.dir = turn(src.dir, 90)
+	change_dir(turn(src.dir, 90))

--- a/code/modules/power/treadmill.dm
+++ b/code/modules/power/treadmill.dm
@@ -84,11 +84,8 @@
 	else
 		to_chat(runner,"<span class='warning'>You're exhausted! You can't run anymore!</span>")
 
-/obj/machinery/power/treadmill/can_pass(var/atom/movable/mover)
-	return ..() && mover.checkpass(PASSGLASS)
-
 /obj/machinery/power/treadmill/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	if(can_pass(mover))
+	if(istype(mover) && mover.checkpass(pass_flags_self))
 		return TRUE
 	if(!density)
 		return TRUE

--- a/code/modules/power/treadmill.dm
+++ b/code/modules/power/treadmill.dm
@@ -84,26 +84,21 @@
 	else
 		to_chat(runner,"<span class='warning'>You're exhausted! You can't run anymore!</span>")
 
-/obj/machinery/power/treadmill/Uncross(var/atom/movable/mover, var/turf/target)
-	if(locate(/obj/effect/unwall_field) in loc) //Annoying workaround for this -kanef
-		return 1
-	if(istype(mover) && mover.checkpass(pass_flags_self))
-		return 1
-	if((flow_flags & ON_BORDER) && (mover.dir == dir))
-		return !density
-	return 1
+/obj/machinery/power/treadmill/can_pass(var/atom/movable/mover)
+	return ..() && mover.checkpass(PASSGLASS)
 
 /obj/machinery/power/treadmill/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+	if(can_pass(mover))
+		return TRUE
+	if(!density)
+		return TRUE
 	if(locate(/obj/effect/unwall_field) in loc) //Annoying workaround for this -kanef
-		return 1
-	if(istype(mover) && mover.checkpass(pass_flags_self))
-		return 1
-	if(get_dir(loc, target) == dir || get_dir(loc, mover) == dir)
-		if(air_group)
-			return 1
-		return 0
-	else
-		return 1
+		return TRUE
+	if(istype(mover))
+		return bounds_dist(border_dummy, mover) >= 0
+	else if(get_dir(loc, target) == dir)
+		return FALSE
+	return TRUE
 
 /obj/machinery/power/treadmill/Bumped(atom/movable/AM)
 	if(AM.loc == loc)

--- a/code/modules/power/treadmill.dm
+++ b/code/modules/power/treadmill.dm
@@ -30,10 +30,11 @@
 	)
 
 /obj/machinery/power/treadmill/New()
+	..()
+	setup_border_dummy()
 	if(anchored)
 		connect_to_network()
 	RefreshParts()
-	..()
 
 /obj/machinery/power/treadmill/RefreshParts()
 	var/calc = 0
@@ -89,7 +90,6 @@
 	if(istype(mover) && mover.checkpass(pass_flags_self))
 		return 1
 	if((flow_flags & ON_BORDER) && (mover.dir == dir))
-		powerwalk(mover)
 		return !density
 	return 1
 
@@ -104,6 +104,10 @@
 		return 0
 	else
 		return 1
+
+/obj/machinery/power/treadmill/Bumped(atom/movable/AM)
+	if(AM.loc == loc)
+		powerwalk(AM)
 
 /obj/machinery/power/treadmill/wrenchAnchor(var/mob/user, var/obj/item/I)
 	. = ..()

--- a/code/modules/spacepods/spacepods.dm
+++ b/code/modules/spacepods/spacepods.dm
@@ -44,7 +44,7 @@
 	var/lights_enabled = FALSE
 	light_power = 2
 	light_range = SPACEPOD_LIGHTS_RANGE_OFF
-	appearance_flags = LONG_GLIDE
+	appearance_flags = LONG_GLIDE|TILE_MOVER
 
 	var/datum/delay_controller/move_delayer = new(0.1, ARBITRARILY_LARGE_NUMBER) //See setup.dm, 12
 	var/passenger_fire = 0 //Whether or not a passenger can fire weapons attached to this pod

--- a/code/world.dm
+++ b/code/world.dm
@@ -10,7 +10,7 @@ var/world_startup_time
 	cache_lifespan = 0	//stops player uploaded stuff from being kept in the rsc past the current session
 	//loop_checks = 0
 	icon_size = WORLD_ICON_SIZE
-	movement_mode = TILE_MOVEMENT_MODE
+	movement_mode = PIXEL_MOVEMENT_MODE
 
 
 var/savefile/panicfile


### PR DESCRIPTION
See #28857
I figured out a solution that I really should have figured out back then

This has a few parts.
First, it moves us *internally* to pixel movement. Everything is still tile-locked. Bugs aside, there's no (significant, at least) in-game difference. It's just different BYOND movecode.
Second, it removes a bunch of our manual reimplementation of BYOND movecode and twists BYOND's movecode into more or less the same behavior as we had written.
Third, it rewrites border objects. This new method is absolutely fucking insane, but is the most "correct" method I'm aware of within BYOND, aside from just fully moving to pixel movement and simply making border objects into thin normal objects. The engine is just really not built to have border objects. This fixes bugs relating to multitile objects phasing through windows. I also absolutely *guarantee* it will cause new bugs, but I don't know what they will be.

It also fixes a couple bugs, somewhere. I don't remember.

Since this moves everything *internally* to pixel movement, it is possible to varedit mobs/objects to use pixel movement. I provide no guarantees this will interact properly with anything, but it does technically work.

This is tested in that nothing immediately obvious is broken but there are definitely bugs in here. Also this branch is pretty old so I might have missed something while resolving conflicts.

:cl:
* experiment: Movecode has been overhauled. There shouldn't be any significant differences by default, but watch out for bugs.
* rscadd: This overhaul allows admins to do some new movement-related things. Details elsewhere.