### PR TITLE
Ghost asteroid mob possession

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -441,7 +441,7 @@
 	var/list/critters = existing_typesof(/mob/living/simple_animal/hostile) - (existing_typesof_list(blacklisted_mobs) + existing_typesof_list(boss_mobs)) // list of possible hostile mobs
 	critters = shuffle(critters)
 	while(contents.len < 6)
-		var/obj/item/device/mobcapsule/MC = new /obj/item/device/mobcapsule(src)
+		var/obj/item/device/mobcapsule/antag/MC = new /obj/item/device/mobcapsule/antag(src)
 		var/chosen = pick(critters)
 		critters -= chosen
 		var/mob/living/simple_animal/hostile/NM = new chosen(MC)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -976,7 +976,7 @@ proc/move_mining_shuttle()
 	if(..())
 		if(istype(contained_mob,/mob/living/simple_animal/hostile/asteroid))
 			var/mob/living/simple_animal/hostile/asteroid/AM = contained_mob
-			AM.can_leave_roid = TRUE
+			AM.can_leave_roid_posessed = TRUE
 			return 1
 	return 0
 /**********************Mining Scanner**********************/

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -979,6 +979,7 @@ proc/move_mining_shuttle()
 			HM.can_leave_roid_posessed = TRUE
 			return 1
 	return 0
+
 /**********************Mining Scanner**********************/
 
 /obj/item/device/mining_scanner

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -975,8 +975,8 @@ proc/move_mining_shuttle()
 /obj/item/device/mobcapsule/antag/insert(var/atom/movable/AM, mob/user)
 	if(..())
 		if(istype(contained_mob,/mob/living/simple_animal/hostile/asteroid))
-			var/mob/living/simple_animal/hostile/asteroid/AM = contained_mob
-			AM.can_leave_roid_posessed = TRUE
+			var/mob/living/simple_animal/hostile/asteroid/HM = contained_mob
+			HM.can_leave_roid_posessed = TRUE
 			return 1
 	return 0
 /**********************Mining Scanner**********************/

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -972,6 +972,13 @@ proc/move_mining_shuttle()
 				if(insert(AM, user) == -1) //Limit reached
 					break
 
+/obj/item/device/mobcapsule/antag/insert(var/atom/movable/AM, mob/user)
+	if(..())
+		if(istype(contained_mob,/mob/living/simple_animal/hostile/asteroid))
+			var/mob/living/simple_animal/hostile/asteroid/AM = contained_mob
+			AM.can_leave_roid = TRUE
+			return 1
+	return 0
 /**********************Mining Scanner**********************/
 
 /obj/item/device/mining_scanner

--- a/code/modules/mob/dead/observer/verbs.dm
+++ b/code/modules/mob/dead/observer/verbs.dm
@@ -555,6 +555,36 @@
 	to_chat(hobo, "<b>Despite not being a member of the crew, by default you are <u>not</u> an antagonist. Cooperating with antagonists is allowed - within reason. Ask admins via adminhelp if you're not sure.</b>")
 	hoboamount++
 
+/mob/dead/observer/verb/haunt_roidmob()
+	set name = "Posess Asteroid Mob"
+	set category = "Ghost"
+	var/timedifference = world.time - client.time_died_as_mouse
+	if(client.time_died_as_mouse && timedifference <= mouse_respawn_time * 600)
+		var/timedifference_text
+		timedifference_text = time2text(mouse_respawn_time * 600 - timedifference,"mm:ss")
+		to_chat(src, "<span class='warning'>You may only posess an asteroid mob more than [mouse_respawn_time] minutes after the last. You have [timedifference_text] left.</span>")
+		return
+	if(!world.has_round_started())
+		to_chat(src, "<span class='warning'>The game has not started yet.</span>")
+		return
+
+	var/response = alert(src, "Are you -sure- you want to posess a mob? You will not be able to leave the asteroid while doing so","Possess asteroid mob","Yeah!","Nope!")
+	if(response != "Yeah!")
+		return  //Hit the wrong key...again.
+	
+	//find a viable mouse candidate
+	var/list/roidmobs = list()
+	for(var/mob/living/simple_animal/hostile/asteroid/AM in mob_list)
+		roidmobs += AM
+	var/mob/living/simple_animal/hostile/asteroid/roidmob = pick(roidmobs)
+	
+	roidmob.ghostize(0) //boot the old mob out
+
+	message_admins("<span class='adminnotice'>[key_name(src)] has become a [roidmob.name].</span>")
+	log_admin("[key_name(src)] has become a [roidmob.name].")
+	roidmob.ckey = ckey
+	qdel(src)
+
 /mob/dead/observer/verb/pai_signup()
 	set name = "Sign up as pAI"
 	set category = "Ghost"

--- a/code/modules/mob/dead/observer/verbs.dm
+++ b/code/modules/mob/dead/observer/verbs.dm
@@ -575,7 +575,11 @@
 	//find a viable mouse candidate
 	var/list/roidmobs = list()
 	for(var/mob/living/simple_animal/hostile/asteroid/AM in mob_list)
-		roidmobs += AM
+		if(istype(get_area(AM), /area/mine/unexplored))
+			roidmobs += AM
+	if(!roidmobs.len)
+		to_chat(src, "<span class='warning'>No asteroid mobs have been found to possess.</span>")
+		return
 	var/mob/living/simple_animal/hostile/asteroid/roidmob = pick(roidmobs)
 	
 	roidmob.ghostize(0) //boot the old mob out

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -55,8 +55,11 @@
 /mob/living/simple_animal/hostile/asteroid/Life()
 	..()
 	if(client && !check_rights(R_ADMIN) && mind && !istype(get_area(src), /area/mine/unexplored) && !can_leave_roid_posessed)
-		client.time_died_as_mouse = world.time
 		ghostize(0) // Prevents player controlled ones from leaving mines
+
+/mob/living/simple_animal/hostile/asteroid/ghostize(var/flags = GHOST_CAN_REENTER,var/deafmute = 0)
+	client.time_died_as_mouse = world.time
+	..()
 
 /mob/living/simple_animal/hostile/asteroid/update_perception()
 	if(client && client.darkness_planemaster)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -51,6 +51,17 @@
 			visible_message("<span class='notice'>\The [T] [src.throw_message] \the [src]!</span>")
 			return
 
+/mob/living/simple_animal/hostile/asteroid/Life()
+	..()
+	if(!istype(get_area(src), /area/mine/unexplored) && mind && client && !client.check_rights(R_ADMIN))
+		client.time_died_as_mouse = world.time
+		ghostize(0) // Prevents player controlled ones from leaving mines
+
+/mob/living/simple_animal/hostile/asteroid/death(var/gibbed = FALSE)
+	if(client)
+		client.time_died_as_mouse = world.time
+	..(gibbed)
+
 /mob/living/simple_animal/hostile/asteroid/basilisk
 	name = "basilisk"
 	desc = "A territorial beast, covered in a thick shell that absorbs energy. Its stare causes victims to freeze from the inside."

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -57,6 +57,11 @@
 		client.time_died_as_mouse = world.time
 		ghostize(0) // Prevents player controlled ones from leaving mines
 
+/mob/living/simple_animal/hostile/asteroid/update_perception()
+	if(client && client.darkness_planemaster)
+		client.darkness_planemaster.blend_mode = BLEND_ADD
+		client.darkness_planemaster.alpha = 100
+
 /mob/living/simple_animal/hostile/asteroid/death(var/gibbed = FALSE)
 	if(client)
 		client.time_died_as_mouse = world.time

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -60,7 +60,6 @@
 
 /mob/living/simple_animal/hostile/asteroid/update_perception()
 	if(client && client.darkness_planemaster)
-		client.darkness_planemaster.blend_mode = BLEND_ADD
 		client.darkness_planemaster.alpha = 100
 
 /mob/living/simple_animal/hostile/asteroid/death(var/gibbed = FALSE)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -53,7 +53,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/Life()
 	..()
-	if(!istype(get_area(src), /area/mine/unexplored) && mind && client && !client.check_rights(R_ADMIN))
+	if(!istype(get_area(src), /area/mine/unexplored) && mind && client && !check_rights(R_ADMIN))
 		client.time_died_as_mouse = world.time
 		ghostize(0) // Prevents player controlled ones from leaving mines
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -20,6 +20,7 @@
 	a_intent = I_HURT
 	var/throw_message = "bounces off of"
 	var/icon_aggro = null // for swapping to when we get aggressive
+	var/can_leave_roid = FALSE
 	held_items = list()
 	status_flags = CANSTUN|CANKNOCKDOWN|CANPARALYSE|CANPUSH
 
@@ -53,7 +54,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/Life()
 	..()
-	if(client && !check_rights(R_ADMIN) && mind && !istype(get_area(src), /area/mine/unexplored))
+	if(client && !check_rights(R_ADMIN) && mind && !istype(get_area(src), /area/mine/unexplored) && !can_leave_roid)
 		client.time_died_as_mouse = world.time
 		ghostize(0) // Prevents player controlled ones from leaving mines
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -54,7 +54,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/Life()
 	..()
-	if(client && !check_rights(R_ADMIN) && mind && !istype(get_area(src), /area/mine/unexplored) && !can_leave_roid)
+	if(client && !check_rights(R_ADMIN) && mind && !istype(get_area(src), /area/mine/unexplored) && !can_leave_roid_posessed)
 		client.time_died_as_mouse = world.time
 		ghostize(0) // Prevents player controlled ones from leaving mines
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -53,7 +53,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/Life()
 	..()
-	if(!istype(get_area(src), /area/mine/unexplored) && mind && client && !check_rights(R_ADMIN))
+	if(client && !check_rights(R_ADMIN) && mind && !istype(get_area(src), /area/mine/unexplored))
 		client.time_died_as_mouse = world.time
 		ghostize(0) // Prevents player controlled ones from leaving mines
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -20,7 +20,7 @@
 	a_intent = I_HURT
 	var/throw_message = "bounces off of"
 	var/icon_aggro = null // for swapping to when we get aggressive
-	var/can_leave_roid = FALSE
+	var/can_leave_roid_posessed = FALSE
 	held_items = list()
 	status_flags = CANSTUN|CANKNOCKDOWN|CANPARALYSE|CANPUSH
 


### PR DESCRIPTION
[content]
PR adds a ghost verb that lets them possess any asteroid mob at random.
Will ghost any non-admin player that tries to leave the unexplored mining areas.
Time delay in between each after dying or leaving the body.
Lazarus capsule functionality remains the exact same for traitor trainer's belts so do not question that at all.
:cl:
 * rscadd: Ghost players can now possess any asteroid mob at random, with a time delay between each possessing. Master trainer's belt lazarus capsules are completely unaffected by this change.