### PR TITLE
Optimized Body Archive

### DIFF
--- a/code/datums/body_archive.dm
+++ b/code/datums/body_archive.dm
@@ -25,8 +25,9 @@ var/list/body_archives = list()
 	source.archive_body(src)
 
 /datum/body_archive/proc/spawn_copy(var/turf/T)//admin toy
-	var/mob/M = new mob_type(T)
-	M.reset_body(src)
+	var/mob/temp_mob = new mob_type(T)
+	temp_mob.actually_reset_body(src, FALSE, null, null)
+	qdel(temp_mob)
 
 ////////////////////////////////////////////////////////////////////
 //																  //
@@ -43,11 +44,16 @@ var/list/body_archives = list()
 		else
 			return
 
-	var/mob/temp_mob = new archive.mob_type(loc)
-	var/mob/new_mob = temp_mob.actually_reset_body(archive, keep_clothes, src, mind)
+	var/mob/new_mob
+
+	if (type == archive.mob_type)
+		new_mob = actually_reset_body(archive, keep_clothes, src, mind)
+	else
+		var/mob/temp_mob = new archive.mob_type(loc)
+		new_mob = temp_mob.actually_reset_body(archive, keep_clothes, src, mind)
+		qdel(temp_mob)
 
 	drop_all()
-	qdel(temp_mob)
 	qdel(src)
 	return new_mob
 

--- a/code/datums/body_archive.dm
+++ b/code/datums/body_archive.dm
@@ -114,7 +114,7 @@ var/list/body_archives = list()
 	if (our_mind)
 		has_been_shade -= our_mind
 		our_mind.transfer_to(H)
-		//H.ckey = R.ckey
+		H.ckey = R.ckey // Maybe needed to put things like ghosts back in bodies
 	if (H.mind && H.mind.miming)
 		H.add_spell(new /spell/aoe_turf/conjure/forcewall/mime, "grey_spell_ready")
 		if (H.mind.miming == MIMING_OUT_OF_CHOICE)

--- a/code/modules/admin/body_archive_panel.dm
+++ b/code/modules/admin/body_archive_panel.dm
@@ -44,5 +44,4 @@
 		</html>
 		"}
 
-	usr << browse(dat, "window=bodyarchivepanel;size=705x450")
-
+	usr << browse(dat, "window=bodyarchivepanel;size=860x500")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7573912/139556076-ede96177-1261-44a7-bd25-8c5376db3d2c.png)

Got some ideas after speaking with @DamianX 

Basically:

* A temp mob is now only created if we observed that the mob we want to reset has a different type from the one archived.
* Creating a copy from the body archive panel now directly spawns a temp mob, instead of _temp_ temp mob on which it calls reset_body()