### PR TITLE
Revert "Small Blob Attack Buff (mostly just reducing frustration)"

### DIFF
--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -311,7 +311,7 @@
 		return
 
 	delayNextAttack(5)
-	OB.expand(T, 0, src, manual = TRUE)
+	OB.expand(T, 0) //Doesn't give source because we don't care about passive restraint
 
 
 /mob/camera/blob/verb/rally_spores_power()

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -334,12 +334,10 @@ var/list/blob_looks_player = list(//Options available to players
 /obj/effect/blob/proc/run_action()
 	return 0
 
-/obj/effect/blob/proc/expand(var/turf/T = null, var/prob = 1, var/mob/camera/blob/source, var/manual = FALSE)
+/obj/effect/blob/proc/expand(var/turf/T = null, var/prob = 1, var/mob/camera/blob/source)
 	if(prob && !prob(health))
 		return
 	if(istype(T, /turf/space) && prob(75))
-		if (source && manual)
-			source.add_points(round(2*BLOBATTCOST/3))
 		return
 	if(!T)
 		var/list/dirs = cardinal.Copy()
@@ -382,8 +380,6 @@ var/list/blob_looks_player = list(//Options available to players
 	else //If we cant move in hit the turf
 		if(!source || !source.restrain_blob)
 			T.blob_act(0,src) //Don't attack the turf if our source mind has that turned off.
-		if (source && manual)
-			source.add_points(round(2*BLOBATTCOST/3))
 		B.manual_remove = 1
 		B.Delete()
 


### PR DESCRIPTION
Blob is just way too tough, and this killed off its only weakness by allowing the blob to make fortresses of solitude in the middle of space surrounded by strong blobs. I've seen multiple blob rounds where they just inhale any emitters in space by moving over to them (one where two men with eguns couldn't stop them), then turn their attention to the crew as a juggernaut. 