### PR TITLE
Revert "Blob Meteor Penetration (#30107)"

### DIFF
--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -12,7 +12,7 @@
 	icon_classic = "blob_idle"
 
 //obj/effect/blob/shield/New(loc,newlook = "new")
-/obj/effect/blob/shield/New(turf/loc,newlook = null,no_morph = 0)
+/obj/effect/blob/shield/New(loc,newlook = null)
 	..()
 	flick("morph_strong",src)
 

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -334,7 +334,7 @@
 		return
 
 	if(ismob(A))
-		forceMove(A.loc)
+		src.forceMove(A.loc)
 		A.blob_act()
 		return
 
@@ -351,29 +351,15 @@
 
 	var/turf/T = get_turf(A)
 
-	var/obj/effect/blob/is_there_a_blob = (locate(/obj/effect/blob) in T)
-
-	if(penetration && !is_there_a_blob)
-		if(penetration >= A.penetration_dampening)	//if the obstacle is too resistant, we don't go through it.
-			penetration = max(0, penetration - A.penetration_dampening)
-
-			new/obj/effect/blob/shield(T, no_morph = 1) // if the meteor goes through, we leave a strong blob on it to prevent sudden airflow
-			forceMove(T)
-			update_pixel()
-			pixel_x = PixelX
-			pixel_y = PixelY
-			return
-
 	for(var/atom/AT in T)
 		AT.blob_act(1)
 
 	T.blob_act(1)
 
+	var/obj/effect/blob/is_there_a_blob = (locate(/obj/effect/blob) in T)
+
 	if(is_there_a_blob)
-		if (loc)
-			do_blob_stuff(loc)
-		else
-			do_blob_stuff(get_step(T,dir))
+		do_blob_stuff(loc)
 	else
 		do_blob_stuff(T)
 
@@ -388,7 +374,6 @@
 	name = "Blob Node"
 	icon = 'icons/obj/meteor_64x64.dmi'
 	icon_state = "meteornode"
-	penetration = 10
 
 /obj/item/projectile/meteor/blob/node/do_blob_stuff(var/turf/T)
 	new/obj/effect/blob/node(T, no_morph = 1)
@@ -399,7 +384,6 @@ var/list/blob_candidates = list()
 	name = "Blob Core"
 	icon = 'icons/obj/meteor_64x64.dmi'
 	icon_state = "meteorcore"
-	penetration = 20
 	var/client/blob_candidate = null
 	var/could_reenter_corpse = FALSE
 
@@ -427,8 +411,8 @@ var/list/blob_candidates = list()
 	..()
 
 /obj/item/projectile/meteor/blob/core/do_blob_stuff(var/turf/T)
-	log_admin("Blob core meteor impacted at [formatJumpTo(T)] controlled by [key_name(blob_candidate)].")
-	message_admins("Blob core meteor impacted at [formatJumpTo(T)] controlled by [key_name(blob_candidate)].")
+	log_admin("Blob core meteor impacted at [formatJumpTo(loc)] controlled by [key_name(blob_candidate)].")
+	message_admins("Blob core meteor impacted at [formatJumpTo(loc)] controlled by [key_name(blob_candidate)].")
 	if(blob_candidate && istype(blob_candidate.mob, /mob/dead/observer))
 		new/obj/effect/blob/core(T, new_overmind = blob_candidate, no_morph = 1)
 	else

--- a/code/modules/power/solars/panel.dm
+++ b/code/modules/power/solars/panel.dm
@@ -1,7 +1,6 @@
 /obj/machinery/power/solar/panel
 	icon_state = "sp_base"
 	id_tag = 0
-	penetration_dampening = 1 // Fragile
 	var/health = 15 //Fragile shit, even with state-of-the-art reinforced glass
 	var/maxhealth = 15 //If ANYONE ever makes it so that solars can be directly repaired without glass, also used for fancy calculations
 	var/obscured = 0


### PR DESCRIPTION
This reverts commit 22c6617bdf7ccf783edb8013528863aa54036b22.
I died.

And I think it gives too much of an edge to blobs. Alternatively we can revert #30104 which has a much more general effect.
Really, as much as I like to find firing solutions and coordinate the crew against the blob (I do like it), it's just not fun to see them go dual core and stack 18 strong blobs on a given tile.