### PR TITLE
Blobtel Core 2 Duo

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -427,6 +427,7 @@ var/list/blob_candidates = list()
 	..()
 
 /obj/item/projectile/meteor/blob/core/do_blob_stuff(var/turf/T)
+	did_blob_stuff = TRUE
 	log_admin("Blob core meteor impacted at [formatJumpTo(T)] controlled by [key_name(blob_candidate)].")
 	message_admins("Blob core meteor impacted at [formatJumpTo(T)] controlled by [key_name(blob_candidate)].")
 	if(blob_candidate && istype(blob_candidate.mob, /mob/dead/observer))


### PR DESCRIPTION
This fixes the issue of anywhere between 2 to 4 (!!!) blob core spawning from a single meteor impact. As these blob cores naturally produce blobs on the surrounding area, this is probably the indirect cause of blob-stacking that makes these cores so difficult to kill.

This is a nightmare of spawns and sleeps and `to_bump` in there. There is a "has done its stuff" var which was supposed to prevent this case from happening, but it's behind a spawn or something.

This is a lazy fix, but a tested one.