### PR TITLE
Allows trophy belts to hold limbs, fixes incorrect uplink description

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -582,7 +582,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/badass/trophybelt
  	name = "Trophy Belt"
- 	desc = "An unremarkable leather belt specially crafted to hold whole heads in storage, perfect for serial killers with something to prove. Comes with seven storage slots. Will not accept brains, so behead mindfully."
+ 	desc = "An unremarkable leather belt specially crafted to hold whole heads and limbs in storage, perfect for serial killers and maimers with something to prove. Comes with seven storage slots. Will not accept brains, so behead mindfully."
  	item = /obj/item/weapon/storage/belt/skull
  	cost = 4
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -582,7 +582,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/badass/trophybelt
  	name = "Trophy Belt"
- 	desc = "An unremarkable leather belt specially crafted to hold whole heads and limbs in storage, perfect for serial killers and maimers with something to prove. Comes with seven storage slots. Will not accept brains, so behead mindfully."
+ 	desc = "An unremarkable leather belt specially crafted to hold whole heads and limbs in storage, perfect for serial killers and maimers with something to prove. Will not accept brains, so behead mindfully."
  	item = /obj/item/weapon/storage/belt/skull
  	cost = 4
 

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -319,13 +319,21 @@
 
 /obj/item/weapon/storage/belt/skull
 	name = "trophy-belt" //FATALITY
-	desc = "Excellent for holding the heads of your fallen foes."
+	desc = "Excellent for holding the heads and limbs of your fallen foes."
 	icon_state = "utilitybelt"
 	item_state = "utility"
 	fits_max_w_class = 4
 	max_combined_w_class = 28
 	can_only_hold = list(
- 		"/obj/item/organ/external/head"
+ 		"/obj/item/organ/external/head",
+ 		"/obj/item/organ/external/r_arm",
+ 		"/obj/item/organ/external/r_hand",
+ 		"/obj/item/organ/external/r_foot",
+ 		"/obj/item/organ/external/r_leg",
+ 		"/obj/item/organ/external/l_arm",
+ 		"/obj/item/organ/external/l_hand",
+ 		"/obj/item/organ/external/l_foot",
+ 		"/obj/item/organ/external/l_leg"
  	)
 
 /obj/item/weapon/storage/belt/silicon


### PR DESCRIPTION
Have you ever bought a trophy belt? I haven't, and for good reason: it's stuck in a weird place where it's more of an RP/gimmick item than a functional one, but it can only hold the product of outright murderboning. I think this change will make it see a bit more use as you can use it as part of a gimmick that doesn't require you to actually murder people.
Also, I noticed that the uplink description for the trophy belt says that it has 7 slots, which isn't true based on my testing, so I deleted that sentence.

🆑

- tweak: Trophy belts can now hold legs, feet, arms and hands, for the traitor who's more into dismemberment than murder. The uplink description also now accurately reflects that there is no 7-head limit on the trophy belt's capacity (which was the case prior to this PR).