### PR TITLE
Ghosts can now read papers at a distance when left-clicking.

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -160,6 +160,11 @@
 		show_text(user, starred = TRUE)
 	return
 
+//Normally ghosts can read at any range, but nobody bothered to actually make attack_ghost not be attack_ai who
+//normally can't read at any range. This fixes it.
+/obj/item/weapon/paper/attack_ghost(mob/user)
+	user.examination(src)
+
 /obj/item/weapon/paper/proc/addtofield(var/id, var/text, var/links = 0)
 	var/locid = 0
 	var/laststart = 1


### PR DESCRIPTION

:cl:
 * bugfix: Fixed a bug where ghosts couldn't read papers at a distance if they left-clicked the paper instead of shift-clicking. This had to do with ghost clicks being counted as AI clicks.