### PR TITLE
Fixes some things no longer checking properly if they could enter a tile

### DIFF
--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -361,7 +361,7 @@ var/list/blob_looks_player = list(//Options available to players
 			num /= 10000
 			B.layer = layer - num
 
-	if(T.Enter(B,src))//Attempt to move into the tile
+	if(T.Enter(B, loc, TRUE))//Attempt to move into the tile //This should probably just actually call Move() instead
 		B.setDensity(initial(B.density))
 		if(icon_size == 64)
 			spawn(1)

--- a/code/game/gamemodes/events/biomass.dm
+++ b/code/game/gamemodes/events/biomass.dm
@@ -80,7 +80,7 @@
 		var/turf/Floor = location
 
 		if(isnull(locate(/obj/effect/biomass) in Floor))
-			if(Floor.Enter(src, loc))
+			if(Floor.Enter(src, loc, TRUE))
 				if(master)
 					master.spawn_biomass_piece(Floor)
 					return 1

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -164,7 +164,7 @@ var/global/list/floorbot_targets=list()
 		return 0
 	if(istype(T.loc, /turf/simulated/wall))
 		return 0
-	if(!T.loc.Enter(src))
+	if(!T.loc.Enter(src, loc, TRUE))
 		return 0
 	return 1
 

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -805,7 +805,7 @@ steam.start() -- spawns the effect
 		if(!T)
 			continue
 
-		if(!T.Enter(src))
+		if(!T.Enter(src, loc, TRUE))
 			continue
 
 		var/obj/effect/foam/F = locate() in T

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -109,6 +109,12 @@
 	..()
 	INVOKE_EVENT(src, /event/exited, "mover" = mover, "location" = src, "newloc" = newloc)
 
+/turf/Enter(atom/movable/mover, atom/oldloc, check_contents = FALSE)
+	. = ..()
+	if(check_contents && .)
+		for(var/atom/movable/AM in src)
+			if(!AM.Cross(mover))
+				return FALSE
 
 /turf/Entered(atom/movable/A as mob|obj, atom/OldLoc)
 	if(movement_disabled)

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -21,7 +21,7 @@
 				spawn(rand(5,25))
 					T.ex_act(prob(80) ? 3 : 2)
 			continue
-		if(!Adjacent(T) || !T.Enter(src))
+		if(!Adjacent(T) || !T.Enter(src, loc, TRUE))
 			continue
 		neighbors |= T
 	// Update all of our friends.

--- a/code/modules/mining/machine_base.dm
+++ b/code/modules/mining/machine_base.dm
@@ -33,9 +33,9 @@
 	var/turf/in_T = get_step(src, in_dir)
 	var/turf/out_T = get_step(src, out_dir)
 
-	if(!in_T.Cross(mover, in_T) || !in_T.Enter(mover) || !out_T.Cross(mover, out_T) || !out_T.Enter(mover))
+	if(!in_T.Enter(mover, mover.loc, TRUE) || !out_T.Enter(mover, mover.loc, TRUE))
 		return
-	
+
 	var/moved = 0
 	for(var/atom/movable/A in in_T)
 		if(A.anchored)
@@ -44,7 +44,7 @@
 		if(!is_type_in_list(A, allowed_types))
 			A.forceMove(out_T)
 			continue
-		
+
 		process_inside(A)
 		moved ++
 		if(moved >= max_moved)

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -400,7 +400,7 @@
 	var/turf/in_T = get_step(src, in_dir)
 	var/turf/out_T = get_step(src, out_dir)
 
-	if(!in_T.Cross(mover, in_T) || !in_T.Enter(mover) || !out_T.Cross(mover, out_T) || !out_T.Enter(mover))
+	if(!in_T.Enter(mover, mover.loc, TRUE) || !out_T.Enter(mover, mover.loc, TRUE))
 		return
 
 	grab_ores() //Grab some more ore to process this tick.

--- a/code/modules/mining/ore_redemption.dm
+++ b/code/modules/mining/ore_redemption.dm
@@ -38,7 +38,7 @@
 	var/turf/in_T = get_step(src, in_dir)
 	var/turf/out_T = get_step(src, out_dir)
 
-	if(!in_T.Cross(mover, in_T) || !in_T.Enter(mover) || !out_T.Cross(mover, out_T) || !out_T.Enter(mover))
+	if(!in_T.Enter(mover, mover.loc, TRUE) || !out_T.Enter(mover, mover.loc, TRUE))
 		return
 
 	for(var/atom/movable/A in in_T)

--- a/code/modules/projectiles/guns/hookshot.dm
+++ b/code/modules/projectiles/guns/hookshot.dm
@@ -295,9 +295,7 @@
 				extremity_B = null
 			else
 				var/turf/U = C1.loc
-				if(U && U.Enter(C2,C2.loc))//if we cannot pull the target through the turf, we just let him go.
-					C2.forceMove(C1.loc)
-				else
+				if(!(U && C2.Move(U)))//if we cannot pull the target through the turf, we just let him go.
 					extremity_B.tether = null
 					extremity_B = null
 					C1.extremity_B = null

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -295,7 +295,7 @@
 	var/turf/out_T = get_step(src, output_dir)
 	var/turf/filter_T = get_step(src, filter_dir)
 
-	if(!out_T.Cross(mover, out_T) || !out_T.Enter(mover) || !filter_T.Cross(mover, filter_T) || !filter_T.Enter(mover))
+	if(!out_T.Enter(mover, mover.loc, TRUE) || !filter_T.Enter(mover, mover.loc, TRUE))
 		return
 
 	var/affecting = in_T.contents


### PR DESCRIPTION
Fixes #31199, as well as several other things
In `LEGACY_MOVEMENT_MODE` (and maybe `TILE_MOVEMENT_MODE`?), `/turf/Enter()` checks the turf's contents by default, but not in `PIXEL_MOVEMENT_MODE`. So here's an argument to make it do so.