### PR TITLE
Makes workaround not go nuclear sometimes

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -182,7 +182,7 @@
 			could_bump = list()
 			. = ..()
 			//The following section is a workaround for a BYOND bug. Remove when the bug is fixed.
-			if((appearance_flags & TILE_MOVER) && (. < step_size))
+			if((appearance_flags & TILE_MOVER) && (. > 0) && (. < step_size))
 				. = 0
 				forceMove(oldloc)
 			//End workaround


### PR DESCRIPTION
Not sure *where* exactly this happens, but if a thrower throws something straight into a wall or something, this could cause an infinite loop