### PR TITLE
Just fucking kills the movement workaround

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -181,11 +181,6 @@
 		if (!(Dir & (Dir - 1))) //Cardinal move
 			could_bump = list()
 			. = ..()
-			//The following section is a workaround for a BYOND bug. Remove when the bug is fixed.
-			if((appearance_flags & TILE_MOVER) && (. > 0) && (. < step_size))
-				. = 0
-				forceMove(oldloc)
-			//End workaround
 			perform_bump()
 		else //Diagonal move, split it into cardinal moves
 			if (Dir & NORTH)


### PR DESCRIPTION
It's been causing more harm than good. Unfortunately, fixes #31227.
This also completely fucks collision between tile movers and non-tile-aligned pixel movers, but this only matters with bus. This is due to a BYOND bug that should be fixed Soon™. Due to an entirely separate BYOND bug, humans are almost always pixel movers anyway, so even in bus it wouldn't change much. (That one's already fixed in the current BYOND version, but not the version the server's running.)