### PR TITLE
Minor window fixes

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -212,10 +212,11 @@ var/MAX_EXPLOSION_RANGE = 14
 #define ALL ~0
 #define NONE 0
 
-//airflow flags!
+//These go in flow_flags but don't really have anything in particular to do with airflow. Bad name.
 
 #define ON_BORDER 1   // item has priority to check when entering or leaving
 #define IMPASSABLE 2  // item will make things auto_fail on prox checks through it
+#define KEEP_DIR 4 //When moved, object will not turn to face its direction of movement.
 
 
 //sharpness flags

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -180,7 +180,10 @@
 	if(Dir || (loc != NewLoc))
 		if (!(Dir & (Dir - 1))) //Cardinal move
 			could_bump = list()
+			var/old_dir = dir
 			. = ..()
+			if(flow_flags & KEEP_DIR)
+				dir = old_dir //We can set it directly instead of calling change_dir() because update_dir() gets called later anyway. Also change_dir() wasn't called to change it in the supercall.
 			perform_bump()
 		else //Diagonal move, split it into cardinal moves
 			if (Dir & NORTH)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -183,7 +183,9 @@
 			var/old_dir = dir
 			. = ..()
 			if(flow_flags & KEEP_DIR)
-				dir = old_dir //We can set it directly instead of calling change_dir() because update_dir() gets called later anyway. Also change_dir() wasn't called to change it in the supercall.
+				dir = old_dir //We can set it directly instead of calling change_dir() because:
+					//1. It wasn't changed through change_dir() in the supercall
+					//2. update_dir() is called later anyway
 			perform_bump()
 		else //Diagonal move, split it into cardinal moves
 			if (Dir & NORTH)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -42,7 +42,7 @@ var/list/one_way_windows
 /obj/structure/window/New(loc)
 
 	..(loc)
-	flow_flags |= ON_BORDER
+	flow_flags |= ON_BORDER | KEEP_DIR
 	setup_border_dummy()
 
 	update_nearby_tiles()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -590,8 +590,7 @@ var/list/one_way_windows
 /obj/structure/window/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 
 	update_nearby_tiles()
-	Dir = dir
-	..()
+	. = ..()
 	update_nearby_tiles()
 
 //This proc is used to update the icons of nearby windows. It should not be confused with update_nearby_tiles(), which is an atmos proc!


### PR DESCRIPTION
These actually predate the movement overhaul, but most of them were my fault anyway. Just from longer ago.
This fixes some minor unreported bugs, such as windows only floating through space toward their `dir`s and windows being draggable through diagonal gaps. Also a harmless runtime when Dimensional Pushing them.