### PR TITLE
Buffs the fists of the rockernaut

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -391,6 +391,7 @@
 	desc = "Start 'em up and rock and roll!"
 	icon_state = "rockernaut_gloves"
 	item_state = "rockernaut_gloves"
+	bonus_knockout = 12
 	damage_added = 5
 	hitsound_added = 'sound/weapons/heavysmash.ogg'
 

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -398,12 +398,53 @@
 	return FALSE
 
 /obj/item/clothing/gloves/mining/Touch(var/atom/A, mob/user, proximity)
-	if(proximity && istype(A, /turf/unsimulated/mineral))
-		var/turf/unsimulated/mineral/M = A
-		if(do_after(user, A, max(M.minimum_mine_time,4 SECONDS*M.mining_difficulty)))
+	if(proximity)
+		if(istype(A, /turf/unsimulated/mineral))
+			var/turf/unsimulated/mineral/M = A
 			playsound(src, hitsound_added, 100, 1, vary = 0)
 			user.do_attack_animation(M, src)
 			M.GetDrilled(0)
+		else if(istype(A, /obj/structure/table))
+			var/obj/structure/table/T = A
+			playsound(src, hitsound_added, 100, 1, vary = 0)
+			user.do_attack_animation(T, src)
+			visible_message("<span class='danger'>[user] smashes \the [T] apart!</span>")
+			user.delayNextAttack(8)
+			T.destroy()
+		else if(istype(A, /obj/structure/rack))
+			var/obj/structure/rack/R = A
+			playsound(src, hitsound_added, 100, 1, vary = 0)
+			user.do_attack_animation(R, src)
+			visible_message("<span class='danger'>[user] smashes \the [R] apart!</span>")
+			R.destroy()
+		else if(istype(A, /obj/structure/window))
+			var/obj/structure/window/W = A
+			playsound(src, hitsound_added, 100, 1, vary = 0)
+			user.do_attack_animation(W, src)
+			visible_message("<span class='danger'>[user] smashes \the [W]!</span>")
+			if(!W.adjustHealthLoss(25))
+				user.visible_message("<span class='danger'>[user]'s punch [pick("bounces","gleams")] off \the [W] harmlessly.</span>")
+			W.healthcheck()
+			user.delayNextAttack(8)
+		else if(istype(A, /turf/simulated/wall))
+			var/turf/simulated/wall/WL = A
+			playsound(src, hitsound_added, 100, 1, vary = 0)
+			user.do_attack_animation(WL, src)
+			if(prob(100 - WL.hardness) || WL.rotting)
+				WL.dismantle_wall(1)
+				user.visible_message("<span class='danger'>[user] smashes through \the [WL].</span>", \
+				"<span class='notice'>You smash through \the [WL].</span>")
+			else
+				user.visible_message("<span class='warning'>[user] punches \the [WL].</span>", \
+				"<span class='notice'>You punch \the [WL].</span>")
+		else if(istype(A, /turf/simulated/floor/glass))
+			var/turf/simulated/floor/glass/G = A
+			playsound(src, hitsound_added, 100, 1, vary = 0)
+			user.do_attack_animation(G, src)
+			user.visible_message("<span class='danger'>[user] smashes \the [G]!</span>")
+			G.health -= 25
+			G.healthcheck(user, TRUE, "attack_hand hulk")
+			user.delayNextAttack(8)
 
 /obj/item/clothing/gloves/mining/attack_icon()
 	return image(icon = 'icons/mob/attackanims.dmi', icon_state = "rockernaut")

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -215,6 +215,11 @@ var/list/icon_state_to_appearance = list()
 	. = ..()
 	if(istype(AM,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = AM
+		if(H.gloves)
+			var/obj/item/clothing/gloves/G = H.gloves
+			if(istype(G,/obj/item/clothing/gloves/mining))
+				G.Touch(AM,H,1)
+			return
 		if(istype(H.get_active_hand(),/obj/item/weapon/pickaxe))
 			attackby(H.get_active_hand(), H)
 		else if(istype(H.get_inactive_hand(),/obj/item/weapon/pickaxe))


### PR DESCRIPTION
[tweak][content]
Because having the only use of the angie boss defeat item being mining turfs slower than most drills is a pain.
:cl:
 * tweak: Fists of the rockernaut now destroy mining turfs instantly and on bump.
 * rscadd: Fists of the rockernaut can now also punch through windows, tables, racks and lastly walls with a bit of extra effort.
 * rscadd: Fists of the rockernaut now also have bonus knockdown, in addition to their extra damage.