### PR TITLE
Fixed a bunch of errors when loading vaults

### DIFF
--- a/code/modules/randomMaps/vaults.dm
+++ b/code/modules/randomMaps/vaults.dm
@@ -124,7 +124,7 @@
 	if(ispath(A, /area))
 		A = locate(A)
 	if(isarea(A))
-		area_turfs = A.contents
+		area_turfs = A.contents.Copy()
 	else if(istype(A, /list))
 		area_turfs = A
 	ASSERT(area_turfs)


### PR DESCRIPTION
```
[23:31:21] Runtime in atoms_movable.dm, line 480: Cannot execute null.Entered().
proc name: forceMove (/atom/movable/proc/forceMove)
src: the border dummy (/atom/movable/border_dummy)
src.loc: space (462,160,5) (/turf/space)
call stack:
the border dummy (/atom/movable/border_dummy): forceMove(space (462,160,5) (/turf/space), 0, 0, 0)
/datum/locking_category/border... (/datum/locking_category/border_dummy): update lock(the border dummy (/atom/movable/border_dummy))
the reinforced plasma window (/obj/structure/window/reinforced/plasma): update dir()
the reinforced plasma window (/obj/structure/window/reinforced/plasma): change dir(1, null)
the reinforced plasma window (/obj/structure/window/reinforced/plasma): shuttle rotate(180)
/dmm_suite (/dmm_suite): instance atom(/obj/structure/window/reinforc... (/obj/structure/window/reinforced/plasma), /list (/list), 462, 159, 5, 180)
/dmm_suite (/dmm_suite): parse grid("/obj/structure/girder/reinforc...", 462, 159, 5, 180, null)
/dmm_suite (/dmm_suite): load map(maps/randomvaults/zoo_truck.dm..., 5, 451, 147, /datum/map_element/vault/zoo_t... (/datum/map_element/vault/zoo_truck), 180, null)
/datum/map_element/vault/zoo_t... (/datum/map_element/vault/zoo_truck): load(451, 147, 5, 180)
populate area with vaults(the random vault area (/area/random_vault), /list (/list), 4, 2, /proc/stay_on_map (/proc/stay_on_map))
generate vaults()
Map (/datum/subsystem/map): Initialize(810786)
Master (/datum/controller/master): Setup()
```