### PR TITLE
You can now, once again, have nice things

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -38,10 +38,6 @@
 		return
 
 	var/list/modifiers = params2list(params)
-	if(modifiers["right"])
-		var/turf/T = get_turf(A)
-		if(!T || !cameranet.checkTurfVis(T))
-			return
 	if(modifiers["middle"])
 		if(modifiers["shift"])
 			MiddleShiftClickOn(A)
@@ -128,6 +124,16 @@
 /atom/proc/AIAltClick(var/mob/living/silicon/ai/user)
 	AltClick(user)
 	return
+
+/atom/MouseEntered(location,control,params)
+	if(istype(usr,/mob/living/silicon/ai))
+		var/mob/living/silicon/ai/AI = usr
+		var/turf/T = get_turf(src)
+		if(!T || !cameranet.checkTurfVis(T))
+			AI.client.show_popup_menus = FALSE
+		else
+			AI.client.show_popup_menus = TRUE
+	..()
 
 /obj/machinery/door/firedoor/AIShiftClick(var/mob/living/silicon/ai/user) // Allows examining firelocks
 	examine(user)

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -125,14 +125,13 @@
 	AltClick(user)
 	return
 
-/atom/MouseEntered(location,control,params)
+/client/MouseEntered(object,location,control,params)
 	if(istype(usr,/mob/living/silicon/ai))
-		var/mob/living/silicon/ai/AI = usr
-		var/turf/T = get_turf(src)
+		var/turf/T = get_turf(object)
 		if(!T || !cameranet.checkTurfVis(T))
-			AI.client.show_popup_menus = FALSE
+			show_popup_menus = FALSE
 		else
-			AI.client.show_popup_menus = TRUE
+			show_popup_menus = TRUE
 	..()
 
 /obj/machinery/door/firedoor/AIShiftClick(var/mob/living/silicon/ai/user) // Allows examining firelocks

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -38,6 +38,10 @@
 		return
 
 	var/list/modifiers = params2list(params)
+	if(modifiers["right"])
+		var/turf/T = get_turf(A)
+		if(!T || !cameranet.checkTurfVis(T))
+			return
 	if(modifiers["middle"])
 		if(modifiers["shift"])
 			MiddleShiftClickOn(A)

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -36,7 +36,6 @@
 /mob/living/silicon/ai/proc/life_handle_powered_core()
 	var/unblindme = FALSE
 	if(client && client.eye == eyeobj) // We are viewing the world through our "eye" mob.
-		//client.show_popup_menus = FALSE
 		change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 		see_in_dark = 8
 		see_invisible = SEE_INVISIBLE_LEVEL_TWO

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -36,7 +36,7 @@
 /mob/living/silicon/ai/proc/life_handle_powered_core()
 	var/unblindme = FALSE
 	if(client && client.eye == eyeobj) // We are viewing the world through our "eye" mob.
-		client.show_popup_menus = FALSE
+		//client.show_popup_menus = FALSE
 		change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 		see_in_dark = 8
 		see_invisible = SEE_INVISIBLE_LEVEL_TWO


### PR DESCRIPTION
[content][tested]
So the logic follows, if the right click menus show up before a click is registered, why not just do checks on them for the logical thing that follows before a click? And that is the mouse entering an atom.

Undoes #29587.

:cl:
 * rscadd: AIs can now view right click menus outside of core again.
 * bugfix: AIs can no longer right click to view contents hidden behind static.