### PR TITLE
ERTs cannot be called while the shuttle is enroute

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -195,7 +195,7 @@ var/list/shuttle_log = list()
 				to_chat(usr, "<span class='warning'>Warning: The evac shuttle has already arrived.</span>")
 				return
 
-			if(emergency_shuttle.online)
+			if(emergency_shuttle.online && !(emergency_shuttle.shutdown))
 				to_chat(usr, "The emergency shuttle is already on its way.")
 				return
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -195,6 +195,10 @@ var/list/shuttle_log = list()
 				to_chat(usr, "<span class='warning'>Warning: The evac shuttle has already arrived.</span>")
 				return
 
+			if(emergency_shuttle.online)
+				to_chat(usr, "The emergency shuttle is already on its way.")
+				return
+
 			if(!universe.OnShuttleCall(usr))
 				to_chat(usr, "<span class='notice'>\The [src.name] cannot establish a bluespace connection.</span>")
 				return


### PR DESCRIPTION
[tweak] [balance]
This PR helps avoid the disappointing situation where an ERT is called with 3-5 minutes left on the shuttle clock. As an emergency response team, their goal should be to resolve the problems facing the station. While that may involve evacuation, the ERT should be involved in that decision and shouldn't just be forced to babysit the crew as they run onto the shuttle, as that's unfun for the ghosts who signed up. This doesn't prevent the ERT from calling the shuttle, or prevent admin-called ERTs from spawning while the shuttle is enroute, it just helps encourage stubbed-toe captains to stick it out.

Note: This was actually part of the code pre-2017 and got taken out by #14841 amid a few other changes.
:cl:
 * tweak: ERTs can no longer be called while the shuttle is enroute.