### PR TITLE
Emergency shuttle won't leave without engines

### DIFF
--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -181,6 +181,14 @@
 	message = "The Emergency Shuttle has left the station. Estimate [round(emergency_shuttle.timeleft()/60,1)] minutes until the shuttle docks at Central Command."
 	..()
 
+/datum/command_alert/emergency_shuttle_could_not_leave
+	name = "Emergency Shuttle Could Not Leave"
+	alert_title = "Priority Announcement"
+	force_report = 1
+
+/datum/command_alert/emergency_shuttle_could_not_leave/announce()
+	message = "The Emergency Shuttle could not leave as it's lacking its engines! Nanotrasen will not be happy."
+	..()
 
 /datum/command_alert/FUBAR
 	name = "Complimentary escape shuttle sent."

--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -448,10 +448,12 @@
 
 	return
 
-/datum/shuttle/proc/close_all_doors()
+/datum/shuttle/proc/close_all_doors(lock_doors = FALSE)
 	for(var/obj/machinery/door/unpowered/shuttle/D in linked_area)
 		spawn(0)
 			D.close()
+			if(lock_doors)
+				D.locked = lock_doors
 
 /datum/shuttle/proc/open_all_doors()
 	for(var/obj/machinery/door/unpowered/shuttle/D in linked_area)
@@ -546,6 +548,12 @@
 		return locate(D.refill_area)
 	else
 		return get_space_area()
+
+/datum/shuttle/proc/has_working_engines()
+	for(var/obj/structure/shuttle/engine/propulsion/engine in linked_area)
+		if(engine.anchored)
+			return TRUE //just having one engine is good enough
+	return FALSE
 
 //The proc that does most of the work
 //RETURNS: 1 if everything is good, 0 if everything is bad


### PR DESCRIPTION
It needs a bit more of work, will finish if you guys think this is a good idea.
Also I can make it so pods can be sabotaged too (fuck you podbabies)

:cl:
 * tweak: Emergency shuttle won't leave without engines