### PR TITLE
Fixes bleeding being broken for real this time

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -186,15 +186,14 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 				continue
 
 			for(var/datum/wound/W in temp.wounds)
-			if(W.bleeding())
-				blood_max += W.damage / 4
+				if(W.bleeding())
+					blood_max += W.damage / 4
 
 			if(temp.status & ORGAN_DESTROYED && !(temp.status & ORGAN_GAUZED) && !temp.amputated)
 				blood_max += 20 //Yer missing a fucking limb.
 
 			if (temp.open)
 				blood_max += 2 //Yer stomach is cut open
-
 
 		blood_max = blood_max * BLOODLOSS_SPEED_MULTIPLIER
 
@@ -207,7 +206,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 		if(reagents.has_reagent(INAPROVALINE))
 			blood_factor -= 0.3
 
-		drip(blood_max * blood_factor)
+		drip(blood_max * max(0, blood_factor))
 
 //Makes a blood drop, leaking amt units of blood from the mob
 /mob/living/carbon/human/proc/drip(var/amt as num)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -185,7 +185,8 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 			if(!(temp.status & ORGAN_BLEEDING) || temp.status & (ORGAN_ROBOT|ORGAN_PEG))
 				continue
 
-			for(var/datum/wound/W in temp.wounds) if(W.bleeding())
+			for(var/datum/wound/W in temp.wounds)
+			if(W.bleeding())
 				blood_max += W.damage / 4
 
 			if(temp.status & ORGAN_DESTROYED && !(temp.status & ORGAN_GAUZED) && !temp.amputated)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -196,14 +196,17 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 
 			blood_max = blood_max * BLOODLOSS_SPEED_MULTIPLIER
 
-			if(lying)
-				blood_factor -= 0.3
+		if(lying)
+			blood_factor -= 0.3
 
-			if(reagents.has_reagent(HYPERZINE)) //Hyperzine is an anti-coagulant :^)
-				blood_factor += 0.3
+		if(reagents.has_reagent(HYPERZINE)) //Hyperzine is an anti-coagulant :^)
+			blood_factor += 0.3
 
-			if(reagents.has_reagent(INAPROVALINE))
-				blood_factor -= 0.3
+		if(reagents.has_reagent(INAPROVALINE))
+			blood_factor -= 0.3
+
+		if(blood_factor < 1)
+			blood_factor = 1
 
 		drip(blood_max * blood_factor)
 

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -194,7 +194,8 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 			if (temp.open)
 				blood_max += 2 //Yer stomach is cut open
 
-			blood_max = blood_max * BLOODLOSS_SPEED_MULTIPLIER
+
+		blood_max = blood_max * BLOODLOSS_SPEED_MULTIPLIER
 
 		if(lying)
 			blood_factor -= 0.3
@@ -204,9 +205,6 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 
 		if(reagents.has_reagent(INAPROVALINE))
 			blood_factor -= 0.3
-
-		if(blood_factor < 1)
-			blood_factor = 1
 
 		drip(blood_max * blood_factor)
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -625,7 +625,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			if(owner.reagents.has_reagent(CLOTTING_AGENT) || owner.reagents.has_reagent(BIOFOAM)) //Clotting agent and biofoam stop bleeding entirely.
 				blood_factor = 0
 
-			owner.vessel.remove_reagent(BLOOD, W.damage * wound_update_accuracy * BLOODLOSS_SPEED_MULTIPLIER * max(0, blood_factor))
+			owner.vessel.remove_reagent(BLOOD, W.damage * wound_update_accuracy * 0.07 * max(0, blood_factor))
 
 			if(prob(1 * wound_update_accuracy))
 				owner.custom_pain("You feel a stabbing pain in your [display_name]!", 1)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -625,7 +625,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			if(owner.reagents.has_reagent(CLOTTING_AGENT) || owner.reagents.has_reagent(BIOFOAM)) //Clotting agent and biofoam stop bleeding entirely.
 				blood_factor = 0
 
-			owner.vessel.remove_reagent(BLOOD, W.damage * wound_update_accuracy * 0.07 * blood_factor)
+			owner.vessel.remove_reagent(BLOOD, W.damage * wound_update_accuracy * BLOODLOSS_SPEED_MULTIPLIER * max(0, blood_factor))
 
 			if(prob(1 * wound_update_accuracy))
 				owner.custom_pain("You feel a stabbing pain in your [display_name]!", 1)


### PR DESCRIPTION
This fixes bleeding modifiers from chems and lying down to be applied overall to a limb rather than for each wound. 

It also fixes the bleeding modifier from going negative which would cause you to regain blood in proportion to how much you should be bleeding. 

It also fixes some spaghetti code from oldcoders involving bad formatting.