### PR TITLE
adds sleeps to coinflip to fix animation

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -413,15 +413,15 @@
 	var/matrix/flipit = matrix()
 	flipit.Scale(0.2,1)
 	animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
-	sleep 1.2 //sleeps because otherwise the scale/invert transforms get skipped
+	sleep 2 //sleeps because otherwise the scale/invert transforms get skipped
 	flipit.Scale(5,1)
 	flipit.Invert()
 	flipit.Turn(rand(1,359))
 	animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
-	sleep 1.2
+	sleep 2
 	flipit.Scale(0.2,1)
 	animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
-	sleep 1.2
+	sleep 2
 	if (pick(0,1))
 		sideup = "heads-up."
 		flipit.Scale(5,1)
@@ -437,7 +437,7 @@
 		flipit.Scale(0.2,1)
 		animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
 		sideup = "on the side!"
-	sleep 1.2
+	sleep 2
 	if(!thrown)
 		user.visible_message("<span class='notice'>[user] flips [src]. It lands [sideup]</span>", \
 							 "<span class='notice'>You flip [src]. It lands [sideup]</span>", \

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -413,15 +413,15 @@
 	var/matrix/flipit = matrix()
 	flipit.Scale(0.2,1)
 	animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
-	sleep 2 //sleeps because otherwise the scale/invert transforms get skipped
+	sleep(1.2) //sleeps because otherwise the scale/invert transforms get skipped
 	flipit.Scale(5,1)
 	flipit.Invert()
 	flipit.Turn(rand(1,359))
 	animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
-	sleep 2
+	sleep(1.2)
 	flipit.Scale(0.2,1)
 	animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
-	sleep 2
+	sleep(1.2)
 	if (pick(0,1))
 		sideup = "heads-up."
 		flipit.Scale(5,1)
@@ -437,7 +437,7 @@
 		flipit.Scale(0.2,1)
 		animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
 		sideup = "on the side!"
-	sleep 2
+	sleep(1.2)
 	if(!thrown)
 		user.visible_message("<span class='notice'>[user] flips [src]. It lands [sideup]</span>", \
 							 "<span class='notice'>You flip [src]. It lands [sideup]</span>", \

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -413,12 +413,15 @@
 	var/matrix/flipit = matrix()
 	flipit.Scale(0.2,1)
 	animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
+	sleep 1.2 //sleeps because otherwise the scale/invert transforms get skipped
 	flipit.Scale(5,1)
 	flipit.Invert()
 	flipit.Turn(rand(1,359))
 	animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
+	sleep 1.2
 	flipit.Scale(0.2,1)
 	animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
+	sleep 1.2
 	if (pick(0,1))
 		sideup = "heads-up."
 		flipit.Scale(5,1)
@@ -434,6 +437,7 @@
 		flipit.Scale(0.2,1)
 		animate(src, transform = flipit, time = 2, easing = QUAD_EASING)
 		sideup = "on the side!"
+	sleep 1.2
 	if(!thrown)
 		user.visible_message("<span class='notice'>[user] flips [src]. It lands [sideup]</span>", \
 							 "<span class='notice'>You flip [src]. It lands [sideup]</span>", \


### PR DESCRIPTION
Without these sleeps, the coin flip animation which is supposed to look like this
![coinflip](https://user-images.githubusercontent.com/8468269/58764496-00525700-8568-11e9-83b2-564d212a2a13.gif) just rotates  without the flips and inversions.

I feel like this is a shitty way to do this but I can't figure out what caused the change.