### PR TITLE
Makes loaded map element atoms initialise if loaded after object subsystem

### DIFF
--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -367,7 +367,7 @@ var/list/map_dimension_cache = list()
 	if(use_preloader && instance)//second preloader pass, for those atoms that don't ..() in New()
 		_preloader.load(instance)
 
-	if(SSobj.initalized && !(instance.flags & ATOM_INITIALIZED)) // If object subsystem is initialised and instance is not initialised
+	if(SSobj.initialized && !(instance.flags & ATOM_INITIALIZED)) // If object subsystem is initialised and instance is not initialised
 		instance.initialize()
 
 	return instance

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -367,6 +367,9 @@ var/list/map_dimension_cache = list()
 	if(use_preloader && instance)//second preloader pass, for those atoms that don't ..() in New()
 		_preloader.load(instance)
 
+	if(SSobj.initalized && !(instance.flags & ATOM_INITIALIZED)) // If object subsystem is initialised and instance is not initialised
+		instance.initialize()
+
 	return instance
 
 //text trimming (both directions) helper proc

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -367,7 +367,7 @@ var/list/map_dimension_cache = list()
 	if(use_preloader && instance)//second preloader pass, for those atoms that don't ..() in New()
 		_preloader.load(instance)
 
-	if(SSobj.initialized && !(instance.flags & ATOM_INITIALIZED)) // If object subsystem is initialised and instance is not initialised
+	if(SSobj.initialized) // If object subsystem is initialised, since they missed this one
 		instance.initialize()
 
 	return instance


### PR DESCRIPTION
[bugfix]
:cl:
 * bugfix: Map elements loaded after the objects system is initialised will now initialise all their loaded atoms properly.