### PR TITLE
Yet another attempt at fixing the missing scrollbar for admins

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -344,6 +344,7 @@ var/list/admin_verbs_mod = list(
 		mob.verbs |= /mob/dead/observer/verb/toggle_antagHUD
 
 /client/proc/remove_admin_verbs()
+	show_mc_tab = FALSE
 	verbs.Remove(
 		admin_verbs_default,
 		/client/proc/togglebuildmodeself,

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -121,13 +121,14 @@ var/intercom_range_display_status = 0
 
 	feedback_add_details("admin_verb","mIRD") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/var/show_mc_tab = FALSE
+
 /client/proc/enable_debug_verbs()
 	set category = "Debug"
 	set name = "Debug verbs"
-
 	if(!check_rights(R_DEBUG))
 		return
-
+	show_mc_tab = TRUE
 	src.verbs += /client/proc/do_not_use_these 			//-errorage
 	src.verbs += /client/proc/camera_view 				//-errorage
 	src.verbs += /client/proc/sec_camera_report 		//-errorage

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1434,7 +1434,7 @@ Use this proc preferably at the end of an equipment loadout
 	..()
 
 	statpanel("Status") //Default tab
-	if(client && client.holder && client.inactivity < 1200)
+	if(client && client.show_mc_tab && client.holder && client.inactivity < 1200)
 		if(statpanel("MC"))
 			stat("Location:", "([x], [y], [z])")
 			stat("CPU:", "[world.cpu]")


### PR DESCRIPTION
http://www.byond.com/forum/post/2415811
only 90's admins will understand

This prevents the MC tab from showing up unless "debug verbs" have been enabled