### PR TITLE
Maybe fix dynamic picking people it shouldn't be picking.

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -289,7 +289,7 @@
 	//------------------------------------------------
 	var/role_id = initial(role_category.id)
 	var/role_pref = initial(role_category.required_pref)
-	for(var/mob/new_player/P in candidates)
+	for(var/mob/P in candidates)
 		if (!P.client || !P.mind || !P.mind.assigned_role)//are they connected?
 			candidates.Remove(P)
 			a++

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -7,7 +7,7 @@
 /datum/dynamic_ruleset/latejoin/trim_candidates()
 	var/role_id = initial(role_category.id)
 	var/role_pref = initial(role_category.required_pref)
-	for(var/mob/new_player/P in candidates)
+	for(var/mob/P in candidates)
 		if (!P.client || !P.mind || !P.mind.assigned_role)//are they connected?
 			candidates.Remove(P)
 			continue

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -513,7 +513,7 @@ Assign your candidates in choose_candidates() instead.
 /datum/dynamic_ruleset/roundstart/malf/choose_candidates()
 	var/mob/M = progressive_job_search() //dynamic_rulesets.dm. Handles adding the guy to assigned.
 	if(M.mind.assigned_role != "AI")
-		for(var/mob/new_player/player in mode.candidates) //mode.candidates is everyone readied up, not to be confused with candidates
+		for(var/mob/player in mode.candidates) //mode.candidates is everyone readied up, not to be confused with candidates
 			if(player.mind.assigned_role == "AI")
 				//We have located an AI to replace
 				displace_AI(player)


### PR DESCRIPTION
0% tested because I have no clue how to test dynamic shit.
Probably Closes #31355 and #31346

mode.candidates was changed to be a list of /mob/living/carbon/human instead of /mob/new_player 
I checked the logs and immediately saw [20:45:15]ADMIN: DYNAMIC MODE: Blood Cult has 25 valid candidates out of 25 players () so I knew something was wrong here.

:cl: 
* bugfix: Fixed certain jobs rolling antagonists that they should not be rolling.