### PR TITLE
Adds clarification in loyalty implant message

### DIFF
--- a/code/game/objects/items/weapons/implants/types/loyalty_implant.dm
+++ b/code/game/objects/items/weapons/implants/types/loyalty_implant.dm
@@ -37,7 +37,7 @@
 		var/datum/role/R = imp_in.mind.GetRole(REV)
 		R.Drop()
 
-	to_chat(imp_in, "<span class='notice'>You feel a surge of loyalty towards Nanotrasen.</span>")
+	to_chat(imp_in,"<span class='notice'>You feel a surge of loyalty towards Nanotrasen.</span><br><span class='sinister'>Note that you are not obliged to roleplay loyalty unless you choose to do so.</span>")
 
 /obj/item/weapon/implant/loyalty/handle_removal(mob/remover)
 	makeunusable(15)


### PR DESCRIPTION
because this shit is extremely confusing to new players

![dreamseeker_4P0rOfKAZ8](https://user-images.githubusercontent.com/8486564/142747523-8f3ce87a-bcc5-4157-a524-7dbbf4213b8b.png)

:cl:
 * tweak: Players are now given a message on loyalty implant letting them know loyalty roleplay is not required.