### PR TITLE
Improved auto-deadmin

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -137,18 +137,6 @@
 
 	TopicData = null							//Prevent calls to client.Topic from connect
 
-	//Admin Authorisation
-	holder = admin_datums[ckey]
-	if(holder)
-		admins += src
-		holder.owner = src
-
-	var/static/list/localhost_addresses = list("127.0.0.1","::1")
-	if(config.localhost_autoadmin)
-		if((!address && !world.port) || (address in localhost_addresses))
-			var/datum/admins/D = new /datum/admins("Host", R_HOST, src.ckey)
-			D.associate(src)
-
 	if(connection != "seeker")			//Invalid connection type.
 		if(connection == "web")
 			if(!holder)
@@ -201,11 +189,6 @@
 	if( (world.address == address || !address) && !host )
 		host = key
 		world.update_status()
-
-	if(holder)
-		add_admin_verbs()
-		admin_memo_show()
-		holder.add_menu_items()
 
 	log_client_to_db()
 
@@ -294,12 +277,25 @@
 	if(!tooltips)
 		tooltips = new /datum/tooltip(src)
 
-	if(holder && prefs.toggles & AUTO_DEADMIN)
-		message_admins("[src] was automatically de-admined.")
-		deadmin()
-		verbs += /client/proc/readmin
-		deadmins += ckey
-		to_chat(src, "<span class='interface'>You are now de-admined.</span>")
+	//Admin Authorisation
+	var/static/list/localhost_addresses = list("127.0.0.1","::1")
+	if(config.localhost_autoadmin)
+		if((!address && !world.port) || (address in localhost_addresses))
+			holder = new /datum/admins("Host", R_HOST, src.ckey)
+	else
+		holder = admin_datums[ckey]
+
+	if(holder)
+		if(prefs.toggles & AUTO_DEADMIN)
+			message_admins("[src] was automatically de-admined.")
+			deadmin()
+			verbs += /client/proc/readmin
+			deadmins += ckey
+			to_chat(src, "<span class='interface'>You are now de-admined.</span>")
+		else
+			holder.associate(src)
+			admin_memo_show()
+
 	fps = (prefs.fps < 0) ? RECOMMENDED_CLIENT_FPS : prefs.fps
 	//////////////
 	//DISCONNECT//


### PR DESCRIPTION
This makes it so admins who have auto-deadmin ON in their preferences no longer start admined, then wait for a while and then get deadmined. Instead, they get deadmined instantly, meaning they no longer see admin logs or receive ahelps while connecting.

I actually went into this to sort out the mess that sends verbs multiple times to the client, which is one of the things that could be behind the missing scrollbar bug, so this may kill two birds with one stone.