### PR TITLE
Make end-round credits invisible only after init is done

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -286,8 +286,6 @@
 	if (runescape_pvp)
 		to_chat(src, "<span class='userdanger'>WARNING: Wilderness mode is enabled; players can only harm one another in maintenance areas!</span>")
 
-	clear_credits() //Otherwise these persist if the client doesn't close the game between rounds
-
 	if(!winexists(src, "asset_cache_browser")) // The client is using a custom skin, tell them.
 		to_chat(src, "<span class='warning'>Unable to access asset cache browser, if you are using a custom skin file, please allow DS to download the updated version, if you are not, then make a bug report. This is not a critical issue but can cause issues with resource downloading, as it is impossible to know when extra resources arrived to you.</span>")
 	//This is down here because of the browse() calls in tooltip/New()

--- a/code/world.dm
+++ b/code/world.dm
@@ -124,6 +124,9 @@ var/auxtools_path
 
 	Master.Setup()
 
+	for(var/client/C in clients)
+		C.clear_credits() //Otherwise these persist if the client doesn't close the game between rounds
+
 	SortAreas()							//Build the list of all existing areas and sort it alphabetically
 
 	return ..()


### PR DESCRIPTION
Probably closes #31287

0% tested