### PR TITLE
Better airlock electronics UI

### DIFF
--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -84,7 +84,7 @@
 
 		for(var/i = 1; i <= 7; i++)
 			t1 += "<div style='float: left'>"
-			t1 += "[get_region_accesses_name(i)]<br><br>"
+			t1 += "<b>[get_region_accesses_name(i)]</b><br>"
 			for(var/access in get_region_accesses(i))
 				var/aname = get_access_desc(access)
 

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -53,7 +53,10 @@
 	interact(user)
 
 /obj/item/weapon/circuitboard/airlock/interact(mob/user as mob)
-	var/t1 = ""
+	var/t1 = {"<style>
+			.parent {clear: both}
+			.row {float: left}
+			</style>"}
 
 	if (last_configurator)
 		t1 += "Operator: [last_configurator]<br>"
@@ -81,6 +84,10 @@
 		t1 += "<br>"
 
 		for(var/i = 1; i <= 7; i++)
+			if(i % 4 == 1)
+				t1 += "<div class='parent'>"
+
+			t1 += "<div class='row'>"
 			t1 += "[get_region_accesses_name(i)]<br><br>"
 			for(var/access in get_region_accesses(i))
 				var/aname = get_access_desc(access)
@@ -91,9 +98,13 @@
 					t1 += "<a style='color: green' href='?src=\ref[src];access=[access]'>[aname]</a><br>"
 				else
 					t1 += "<a style='color: red' href='?src=\ref[src];access=[access]'>[aname]</a><br>"
-			t1 += "<br>"
+			t1 += "<br>"4
+			t1 += "</div>"
 
-	var/datum/browser/popup = new(user, "airlock_electronics", "Access Control")
+			if(i % 4 == 0 || i == 7)
+				t1 += "</div>"
+
+	var/datum/browser/popup = new(user, "airlock_electronics", "Access Control", 640, 480)
 	popup.set_content(t1)
 	popup.open()
 

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -53,10 +53,7 @@
 	interact(user)
 
 /obj/item/weapon/circuitboard/airlock/interact(mob/user as mob)
-	var/t1 = {"<style>
-			.parent {clear: both}
-			.row {float: left}
-			</style>"}
+	var/t1 = ""
 
 	if (last_configurator)
 		t1 += "Operator: [last_configurator]<br>"
@@ -70,14 +67,14 @@
 		t1 += "<a href='?src=\ref[src];logout=1'>Finish</a><hr>"
 
 		t1 += "Access requirement is set to "
-		t1 += one_access ? "<a style='color: green' href='?src=\ref[src];one_access=1'>ONE</a><hr>" : "<a style='color: red' href='?src=\ref[src];one_access=1'>ALL</a><hr>"
+		t1 += one_access ? "<a style='background: green' href='?src=\ref[src];one_access=1'>ONE</a><hr>" : "<a style='background: red' href='?src=\ref[src];one_access=1'>ALL</a><hr>"
 
 		t1 += "Access direction is set to "
 		t1 += "<a href='?src=\ref[src];access_dir=1'>[dir_access]</a><hr>"
 
 		if(dir_access)
 			t1 += "Accessing not in dir is set to "
-			t1 += access_nodir ? "<a style='color: green' href='?src=\ref[src];notdir=1'>TRUE</a><hr>" : "<a style='color: red' href='?src=\ref[src];notdir=1'>FALSE</a><hr>"
+			t1 += access_nodir ? "<a style='background: green' href='?src=\ref[src];notdir=1'>TRUE</a><hr>" : "<a style='background: red' href='?src=\ref[src];notdir=1'>FALSE</a><hr>"
 
 		t1 += conf_access == null ? "<font color=red>All</font><br>" : "<a href='?src=\ref[src];access=all'>All</a><br>"
 
@@ -85,9 +82,9 @@
 
 		for(var/i = 1; i <= 7; i++)
 			if(i % 4 == 1)
-				t1 += "<div class='parent'>"
+				t1 += "<div style='clear: both'>"
 
-			t1 += "<div class='row'>"
+			t1 += "<div style='float: left'>"
 			t1 += "[get_region_accesses_name(i)]<br><br>"
 			for(var/access in get_region_accesses(i))
 				var/aname = get_access_desc(access)
@@ -95,10 +92,10 @@
 				if (!conf_access || !conf_access.len || !(access in conf_access))
 					t1 += "<a href='?src=\ref[src];access=[access]'>[aname]</a><br>"
 				else if(one_access)
-					t1 += "<a style='color: green' href='?src=\ref[src];access=[access]'>[aname]</a><br>"
+					t1 += "<a style='background: green' href='?src=\ref[src];access=[access]'>[aname]</a><br>"
 				else
-					t1 += "<a style='color: red' href='?src=\ref[src];access=[access]'>[aname]</a><br>"
-			t1 += "<br>"4
+					t1 += "<a style='background: red' href='?src=\ref[src];access=[access]'>[aname]</a><br>"
+			t1 += "<br>"
 			t1 += "</div>"
 
 			if(i % 4 == 0 || i == 7)

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -70,20 +70,19 @@
 		t1 += one_access ? "<a style='background: green' href='?src=\ref[src];one_access=1'>ONE</a><hr>" : "<a style='background: red' href='?src=\ref[src];one_access=1'>ALL</a><hr>"
 
 		t1 += "Access direction is set to "
-		t1 += "<a href='?src=\ref[src];access_dir=1'>[dir_access]</a><hr>"
+		t1 += "<a href='?src=\ref[src];access_dir=1'>[dir2arrow(dir_access)]</a><hr>"
 
 		if(dir_access)
-			t1 += "Accessing not in dir is set to "
+			t1 += "Accessing while not in access direction is set to "
 			t1 += access_nodir ? "<a style='background: green' href='?src=\ref[src];notdir=1'>TRUE</a><hr>" : "<a style='background: red' href='?src=\ref[src];notdir=1'>FALSE</a><hr>"
 
-		t1 += conf_access == null ? "<font color=red>All</font><br>" : "<a href='?src=\ref[src];access=all'>All</a><br>"
+		t1 += conf_access == null ? "<font style='background: red'>All</font><br>" : "<a href='?src=\ref[src];access=all'>All</a><br>"
 
 		t1 += "<br>"
 
-		for(var/i = 1; i <= 7; i++)
-			if(i % 4 == 1)
-				t1 += "<div style='clear: both'>"
+		t1 += "<div style='clear: both'>"
 
+		for(var/i = 1; i <= 7; i++)
 			t1 += "<div style='float: left'>"
 			t1 += "[get_region_accesses_name(i)]<br><br>"
 			for(var/access in get_region_accesses(i))
@@ -98,8 +97,7 @@
 			t1 += "<br>"
 			t1 += "</div>"
 
-			if(i % 4 == 0 || i == 7)
-				t1 += "</div>"
+		t1 += "</div>"
 
 	var/datum/browser/popup = new(user, "airlock_electronics", "Access Control", 640, 480)
 	popup.set_content(t1)

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -80,29 +80,27 @@
 
 		t1 += "<br>"
 
-		var/list/accesses = get_all_accesses()
-		for (var/acc in accesses)
-			var/aname = get_access_desc(acc)
+		for(var/i = 1; i <= 7; i++)
+			t1 += "[get_region_accesses_name(i)]<br><br>"
+			for(var/access in get_region_accesses(i))
+				var/aname = get_access_desc(access)
 
-			if (!conf_access || !conf_access.len || !(acc in conf_access))
-				t1 += "<a href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
-			else if(one_access)
-				t1 += "<a style='color: green' href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
-			else
-				t1 += "<a style='color: red' href='?src=\ref[src];access=[acc]'>[aname]</a><br>"
+				if (!conf_access || !conf_access.len || !(access in conf_access))
+					t1 += "<a href='?src=\ref[src];access=[access]'>[aname]</a><br>"
+				else if(one_access)
+					t1 += "<a style='color: green' href='?src=\ref[src];access=[access]'>[aname]</a><br>"
+				else
+					t1 += "<a style='color: red' href='?src=\ref[src];access=[access]'>[aname]</a><br>"
+			t1 += "<br>"
 
-	t1 += text("<p><a href='?src=\ref[];close=1'>Close</a></p>\n", src)
-
-	user << browse(t1, "window=airlock_electronics")
-	onclose(user, "airlock")
+    var/datum/browser/popup = new(src, "airlock_electronics", "Airlock Electronics Access")
+    popup.set_content(t1)
+    popup.open()
 
 /obj/item/weapon/circuitboard/airlock/Topic(href, href_list)
 	if(..())
 		return 1 //Its not as though this does ANYTHING
 	if(!Adjacent(usr) || usr.incapacitated() || (!ishigherbeing(usr) && !isrobot(usr)) || icon_state == "door_electronics_smoked" || installed)
-		return
-	if(href_list["close"])
-		usr << browse(null, "window=airlock")
 		return
 
 	if(href_list["login"])

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -134,10 +134,10 @@
 
 	if(href_list["access_dir"])
 		var/setdir = dir_access
-		var/static/list/allowed_dirs = list(FALSE,NORTH,SOUTH,EAST,WEST)
-		setdir = input(usr,"Enter a new access dir (Valid options: 0, 1, 2, 4, 8)", src, dir_access) as num
-		if(setdir in allowed_dirs)
-			dir_access = setdir
+		var/static/list/allowed_dirs = list("None","NORTH","SOUTH","EAST","WEST")
+		setdir = input(usr,"Enter a new access dir", "Access direction") as null|anything in allowed_dirs
+		if(setdir && setdir != "None")
+			dir_access = text2dir(setdir)
 		else
 			dir_access = 0
 

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -53,7 +53,7 @@
 	interact(user)
 
 /obj/item/weapon/circuitboard/airlock/interact(mob/user as mob)
-	var/t1 = text("<B>Access control</B><br>\n")
+	var/t1 = ""
 
 	if (last_configurator)
 		t1 += "Operator: [last_configurator]<br>"
@@ -93,9 +93,9 @@
 					t1 += "<a style='color: red' href='?src=\ref[src];access=[access]'>[aname]</a><br>"
 			t1 += "<br>"
 
-    var/datum/browser/popup = new(src, "airlock_electronics", "Airlock Electronics Access")
-    popup.set_content(t1)
-    popup.open()
+	var/datum/browser/popup = new(user, "airlock_electronics", "Access Control")
+	popup.set_content(t1)
+	popup.open()
 
 /obj/item/weapon/circuitboard/airlock/Topic(href, href_list)
 	if(..())


### PR DESCRIPTION
[UI][QoL]
![image](https://user-images.githubusercontent.com/57303506/142785738-791b6e8e-09e6-4a78-8042-e34e55a95857.png)
Sorts by department, and makes them rows. Wanted to do this in #31211 but atomicity.
:cl:
 * tweak: The UI for airlock electronics boards is now much nicer and more organised.
 * tweak: Setting an input dir for airlock electronics no longer relies on numbers, is now a selection from a list.