### PR TITLE
Fixed mapped intercoms being on the common frequency

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -61,7 +61,11 @@
 
 /obj/item/device/radio/initialize()
 	. = ..()
-	frequency = COMMON_FREQ //common chat
+	// Mapped radios may have their frequency set.
+	// This prevents it from getting reset.
+	if(frequency == initial(frequency))
+		frequency = COMMON_FREQ //common chat
+
 	if(freerange)
 		if(frequency < 1200 || frequency > 1600)
 			frequency = sanitize_frequency(frequency, maxf)


### PR DESCRIPTION
Closes #27276

:cl:
 * bugfix: Intercoms that were meant to have a special frequency such as those in the brig's interrogation room or the chapel's confessionals, are now on their intended frequency rather than on the common channel.