### PR TITLE
Improved vox raiders timer display

### DIFF
--- a/code/datums/gamemode/role/vox_raider.dm
+++ b/code/datums/gamemode/role/vox_raider.dm
@@ -23,5 +23,6 @@
 	var/datum/faction/vox_shoal/vox = faction
 	if (!istype(vox))
 		return
-	var/dat = "Raid time left: [num2text((vox.time_left /(2*60)))]:[add_zero(num2text(vox.time_left/2 % 60), 2)] minutes."
-	return dat
+	var/minutes = round(vox.time_left / (2*60), 1)
+	var/seconds = add_zero("[vox.time_left / 2 % 60]", 2)
+	return "Raid time left: [minutes]:[seconds] minutes."


### PR DESCRIPTION
I noticed while testing something else that the timer would read 28.3333:19 instead of 28:19 so this fixes that