### PR TITLE
Turning a wheelchair into an assembly no longer makes it lose its motorization and such

### DIFF
--- a/code/game/objects/structures/vehicles/wheelchair.dm
+++ b/code/game/objects/structures/vehicles/wheelchair.dm
@@ -28,6 +28,7 @@
 	if(istype(W, /obj/item/weapon/gun_barrel))
 		to_chat(user, "You place \the [W] on \the [src].")
 		var/obj/structure/bed/chair/vehicle/wheelchair/wheelchair_assembly/I = new (get_turf(src.loc))
+		I.base_wheelchair = type
 		I.dir = dir
 		qdel(src)
 		qdel(W)

--- a/code/game/objects/structures/vehicles/wheelchair.dm
+++ b/code/game/objects/structures/vehicles/wheelchair.dm
@@ -30,6 +30,8 @@
 		var/obj/structure/bed/chair/vehicle/wheelchair/wheelchair_assembly/I = new (get_turf(src.loc))
 		I.base_wheelchair = src
 		I.dir = dir
+		for (var/atom/movable/AM in locked_atoms)
+			unlock_atom(AM)
 		forceMove(I)
 		qdel(W)
 

--- a/code/game/objects/structures/vehicles/wheelchair.dm
+++ b/code/game/objects/structures/vehicles/wheelchair.dm
@@ -28,9 +28,9 @@
 	if(istype(W, /obj/item/weapon/gun_barrel))
 		to_chat(user, "You place \the [W] on \the [src].")
 		var/obj/structure/bed/chair/vehicle/wheelchair/wheelchair_assembly/I = new (get_turf(src.loc))
-		I.base_wheelchair = type
+		I.base_wheelchair = src
 		I.dir = dir
-		qdel(src)
+		forceMove(I)
 		qdel(W)
 
 /obj/structure/bed/chair/vehicle/wheelchair/unlock_atom(var/atom/movable/AM)

--- a/code/modules/projectiles/guns/projectile/constructable/gunsmithing.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/gunsmithing.dm
@@ -803,7 +803,7 @@
 	icon_state = "wheelchair_assembly"
 	var/cannon_assembly = 0
 	var/siege_assembly = FALSE
-	var/base_wheelchair_type = /obj/structure/bed/chair/vehicle/wheelchair
+	var/obj/structure/bed/chair/vehicle/wheelchair/base_wheelchair = null
 
 /obj/structure/bed/chair/vehicle/wheelchair/wheelchair_assembly/proc/update_wheelchair_assembly()
 	if(cannon_assembly)
@@ -824,8 +824,12 @@
 	to_chat(usr, "You remove the barrel from \the [src].")
 	var/obj/item/weapon/gun_barrel/I = new (get_turf(usr))
 	usr.put_in_hands(I)
-	var/obj/structure/bed/chair/vehicle/wheelchair/Q = new base_wheelchair_type(get_turf(src.loc))
-	Q.dir = dir
+	if (!base_wheelchair)
+		base_wheelchair = new (get_turf(src.loc))
+	else
+		base_wheelchair.forceMove(get_turf(src.loc))
+	base_wheelchair.dir = dir
+	base_wheelchair = null
 	qdel(src)
 
 /obj/structure/bed/chair/vehicle/wheelchair/wheelchair_assembly/attackby(obj/item/weapon/W, mob/user)

--- a/code/modules/projectiles/guns/projectile/constructable/gunsmithing.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/gunsmithing.dm
@@ -803,6 +803,7 @@
 	icon_state = "wheelchair_assembly"
 	var/cannon_assembly = 0
 	var/siege_assembly = FALSE
+	var/base_wheelchair_type = /obj/structure/bed/chair/vehicle/wheelchair
 
 /obj/structure/bed/chair/vehicle/wheelchair/wheelchair_assembly/proc/update_wheelchair_assembly()
 	if(cannon_assembly)
@@ -823,7 +824,7 @@
 	to_chat(usr, "You remove the barrel from \the [src].")
 	var/obj/item/weapon/gun_barrel/I = new (get_turf(usr))
 	usr.put_in_hands(I)
-	var/obj/structure/bed/chair/vehicle/wheelchair/Q = new (get_turf(src.loc))
+	var/obj/structure/bed/chair/vehicle/wheelchair/Q = new base_wheelchair_type(get_turf(src.loc))
 	Q.dir = dir
 	qdel(src)
 


### PR DESCRIPTION
Fixes #31118

:cl:
* bugfix: Turning a wheelchair into an assembly no longer makes it lose its motorization and such. (killette3)