### PR TITLE
Food press

### DIFF
--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -872,6 +872,4 @@ var/global/ingredientLimit = 10
 			types = typesof(/obj/item/weapon/reagent_containers/food/snacks/customizable/cook)-(/obj/item/weapon/reagent_containers/food/snacks/customizable/cook)
 		if("Cereal")
 			types = list(/obj/item/weapon/reagent_containers/food/snacks/cereal)
-	
-	to_chat(world, "[types]")
 	return types

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -821,25 +821,6 @@ var/global/ingredientLimit = 10
 				. = "It's already pressed into that shape."
 				break
 
-/*/obj/machinery/cooking/foodpress/takeIngredient(var/obj/item/I,mob/user,var/force_cook)
-	. = src.validateIngredient(I, force_cook)
-	if(. == "transto")
-		return
-	if(. == "valid")
-		if(src.foodChoices)
-			. = src.foodChoices[(input("Select production.") in src.foodChoices)]
-		if (!Adjacent(user) || user.stat || ((user.get_active_hand() != (I) && !isgripper(user.get_active_hand())) && !force_cook))
-			return FALSE
-
-		if(user.drop_item(I, src))
-			src.ingredient = I
-			spawn() src.cook(.)
-			to_chat(user, "<span class='notice'>You add \the [I.name] to \the [src.name].</span>")
-			return TRUE
-	else
-		to_chat(user, "<span class='warning'>You can't put that in \the [src.name]. \n[.]</span>")
-	return FALSE*/
-
 /obj/machinery/cooking/foodpress/attack_hand(mob/user)
 	if(!active)
 		if(Adjacent(user) && !user.stat && !user.incapacitated() && !isobserver(user))


### PR DESCRIPTION
Food press. Does the same thing the goofcook machines do, except it's a 3-in-1. Using it with an empty hand prompts this:
![1637707054 Food_press](https://user-images.githubusercontent.com/8468269/143140579-e672e7ac-10ca-478f-aedf-e27e5bd2e817.png)
Beyond that it just takes food as normal.

Icon is just the generic oven model, unchanged. Couldn't come up with anything better. If any spriters want to take a swing at it, be my guest.

I didn't do island because island is getting constant changes and I accidentally didn't close SDMM before switching away from my kitchen rework branch. Can add it to island in the next batch of changes, if this gets merged by that time.

:cl:
 * rscadd: Added the food press, a condensed version of the cereal maker / candy maker / ezbake oven
 * wip: Replaced the uncondensed  cooking machines with a single condensed machine.