### PR TITLE
Default religion voice fix

### DIFF
--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -14,7 +14,7 @@
 		return "Shoalmother"
 	else if(issilicon(H))
 		return "MAINFRAME"
-	else if(!ishuman(H) || !isobserver(H))
+	else if(!ishuman(H) && !isobserver(H))
 		return "Animal Jesus"
 	else
 		return "a voice"


### PR DESCRIPTION
[bugfix][oversight]
:cl:
 * bugfix: Animal Jesus is no longer the default religion for anyone not actually an non-human.