### PR TITLE
Fixed baseball bat not updating throw UI button

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -505,8 +505,8 @@
 	return TRUE
 
 /obj/item/weapon/baseball_bat/on_block(damage, atom/movable/blocked)
-	if(ismob(loc))
-		var/mob/H = loc
+	if(isliving(loc))
+		var/mob/living/H = loc
 		if(!H.in_throw_mode || !wielded || damage > 15)
 			return FALSE
 		if(IsShield() < blocked.ignore_blocking)
@@ -524,7 +524,7 @@
 				else						// otherwise limit to 10 tiles
 					target = get_ranged_target_turf(Q, throwdir, 10)
 				M.throw_at(target,100,4)
-			H.in_throw_mode = FALSE
+			H.throw_mode_off()
 			return TRUE
 		return FALSE
 


### PR DESCRIPTION
Without this, after knocking something away with a baseball bat, the "throw" UI button will still be turned on, despite throw mode being turned off behind the scenes.