### PR TITLE
Improved baseball bat throwing logic

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1791,3 +1791,8 @@ var/list/weekend_days = list("Friday", "Saturday", "Sunday")
 #define IS_WEEKEND (weekend_days.Find(time2text(world.timeofday, "Day")))
 
 #define RECOMMENDED_CLIENT_FPS 100
+
+// /datum/reagent/var/sport
+#define SPORTINESS_NONE 1
+#define SPORTINESS_SUGAR 1.2
+#define SPORTINESS_SPORTS_DRINK 5

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -518,7 +518,7 @@
 				var/atom/movable/M = blocked
 				var/turf/Q = get_turf(M)
 				var/turf/target
-				var/throwdir = turn(M.dir, 180 + rand(-30, 30))
+				var/throwdir = turn(H.dir, pick(-45, 0, 45))
 				if(istype(Q, /turf/space)) // if ended in space, then range is unlimited
 					target = get_edge_target_turf(Q, throwdir)
 				else						// otherwise limit to 10 tiles

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -518,7 +518,12 @@
 				var/atom/movable/M = blocked
 				var/turf/Q = get_turf(M)
 				var/turf/target
-				var/throwdir = turn(H.dir, pick(-45, 0, 45))
+				var/list/throwdir_chances = list(
+					"-45" = 1,
+					"0" = H.reagents.get_sportiness(),
+					"45" = 1
+				)
+				var/throwdir = turn(H.dir, text2num(pickweight(throwdir_chances)))
 				if(istype(Q, /turf/space)) // if ended in space, then range is unlimited
 					target = get_edge_target_turf(Q, throwdir)
 				else						// otherwise limit to 10 tiles

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -26,7 +26,7 @@
 	var/volume = 0
 	var/nutriment_factor = 0
 	var/pain_resistance = 0
-	var/sport = 1 //High sport helps you show off on a treadmill. Multiplicative
+	var/sport = SPORTINESS_NONE //High sport helps you show off on a treadmill. Multiplicative
 	var/custom_metabolism = REAGENTS_METABOLISM
 	var/custom_plant_metabolism = HYDRO_SPEED_MULTIPLIER
 	var/overdose_am = 0
@@ -1493,7 +1493,7 @@
 	description = "The organic compound commonly known as table sugar and sometimes called saccharose. This white, odorless, crystalline powder has a pleasing, sweet taste."
 	reagent_state = REAGENT_STATE_SOLID
 	color = "#FFFFFF" //rgb: 255, 255, 255
-	sport = 1.2
+	sport = SPORTINESS_SUGAR
 	density = 1.59
 	specheatcap = 1.244
 
@@ -8564,7 +8564,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	description = "Take the leap... enjoy a Quantum!"
 	color = "#100800" //rgb: 16, 8, 0
 	adj_sleepy = -2
-	sport = 5
+	sport = SPORTINESS_SPORTS_DRINK
 
 /datum/reagent/drink/cold/quantum/on_mob_life(var/mob/living/M)
 
@@ -8577,7 +8577,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	name = "Sport Drink"
 	id = SPORTDRINK
 	description = "You like sports, and you don't care who knows."
-	sport = 5
+	sport = SPORTINESS_SPORTS_DRINK
 	color = "#CCFF66" //rgb: 204, 255, 51
 	custom_metabolism =  0.01
 	custom_plant_metabolism = HYDRO_SPEED_MULTIPLIER/5
@@ -9658,7 +9658,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	name = "Sporty Incense"
 	id = INCENSE_CRAVE
 	description = "This has what you crave. Electrolytes."
-	sport = 5
+	sport = SPORTINESS_SPORTS_DRINK
 	custom_metabolism = 0.15
 
 /datum/reagent/incense/cornoil


### PR DESCRIPTION
The original implementation tried to rotate the direction by a random number between -30 and 30, which doesn't work because `turn` only accepts multiples of 45.
I've changed it so the object is thrown in the direction the batter is facing, with a random rotation of either -45, 0 or 45 degrees.

:cl:
* tweak: Knocking things away with a baseball bat now throws them in the direction the batter is facing, with a chance to deviate 45 degrees in either direction. Being more sporty makes batting more accurate.