### PR TITLE
AIs can right click again

### DIFF
--- a/code/_onclick/hud/ai.dm
+++ b/code/_onclick/hud/ai.dm
@@ -9,7 +9,7 @@
 	var/obj/abstract/screen/using
 
 //Camera list
-	using = new /obj/abstract/screen
+	using = new /obj/abstract/screen/nocontext
 	using.name = "Show Camera List"
 	using.icon = 'icons/mob/screen_ai.dmi'
 	using.icon_state = "camera"
@@ -17,7 +17,7 @@
 	adding += using
 
 //Track
-	using = new /obj/abstract/screen
+	using = new /obj/abstract/screen/nocontext
 	using.name = "Track With Camera"
 	using.icon = 'icons/mob/screen_ai.dmi'
 	using.icon_state = "track"
@@ -25,7 +25,7 @@
 	adding += using
 
 //Camera light
-	using = new /obj/abstract/screen
+	using = new /obj/abstract/screen/nocontext
 	using.name = "Toggle Camera Light"
 	using.icon = 'icons/mob/screen_ai.dmi'
 	using.icon_state = "camera_light"
@@ -33,7 +33,7 @@
 	adding += using
 
 //Crew Manifest
-	using = new /obj/abstract/screen
+	using = new /obj/abstract/screen/nocontext
 	using.name = "Show Crew Manifest"
 	using.icon = 'icons/mob/screen_ai.dmi'
 	using.icon_state = "manifest"
@@ -41,7 +41,7 @@
 	adding += using
 
 //Alerts
-	using = new /obj/abstract/screen
+	using = new /obj/abstract/screen/nocontext
 	using.name = "Show Alerts"
 	using.icon = 'icons/mob/screen_ai.dmi'
 	using.icon_state = "alerts"
@@ -49,7 +49,7 @@
 	adding += using
 
 //Announcement
-	using = new /obj/abstract/screen
+	using = new /obj/abstract/screen/nocontext
 	using.name = "Announcement"
 	using.icon = 'icons/mob/screen_ai.dmi'
 	using.icon_state = "announcement"
@@ -57,7 +57,7 @@
 	adding += using
 
 //Shuttle
-	using = new /obj/abstract/screen
+	using = new /obj/abstract/screen/nocontext
 	using.name = "(Re)Call Emergency Shuttle"
 	using.icon = 'icons/mob/screen_ai.dmi'
 	using.icon_state = "call_shuttle"
@@ -65,7 +65,7 @@
 	adding += using
 
 //Laws
-	using = new /obj/abstract/screen
+	using = new /obj/abstract/screen/nocontext
 	using.name = "State Laws"
 	using.icon = 'icons/mob/screen_ai.dmi'
 	using.icon_state = "state_laws"
@@ -73,7 +73,7 @@
 	adding += using
 
 //PDA message
-	using = new /obj/abstract/screen
+	using = new /obj/abstract/screen/nocontext
 	using.name = "PDA - Send Message"
 	using.icon = 'icons/mob/screen_ai.dmi'
 	using.icon_state = "pda_send"
@@ -81,7 +81,7 @@
 	adding += using
 
 //PDA log
-	using = new /obj/abstract/screen
+	using = new /obj/abstract/screen/nocontext
 	using.name = "PDA - Show Message Log"
 	using.icon = 'icons/mob/screen_ai.dmi'
 	using.icon_state = "pda_receive"
@@ -89,7 +89,7 @@
 	adding += using
 
 //Take image
-	using = new /obj/abstract/screen
+	using = new /obj/abstract/screen/nocontext
 	using.name = "Take Image"
 	using.icon = 'icons/mob/screen_ai.dmi'
 	using.icon_state = "take_picture"
@@ -97,7 +97,7 @@
 	adding += using
 
 //View images
-	using = new /obj/abstract/screen
+	using = new /obj/abstract/screen/nocontext
 	using.name = "View Images"
 	using.icon = 'icons/mob/screen_ai.dmi'
 	using.icon_state = "view_images"
@@ -105,7 +105,7 @@
 	adding += using
 
 //Radio Configuration
-	using = new /obj/abstract/screen
+	using = new /obj/abstract/screen/nocontext
 	using.name = "Configure Radio"
 	using.icon = 'icons/mob/screen_ai.dmi'
 	using.icon_state = "change_radio"

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -170,6 +170,12 @@
 			//usr.next_move = world.time+2
 	return 1
 
+/obj/abstract/screen/nocontext/MouseEntered(location, control, params)
+	usr?.client?.show_popup_menus = FALSE
+
+/obj/abstract/screen/nocontext/MouseExited(location, control, params)
+	usr?.client?.show_popup_menus = TRUE
+
 /obj/abstract/screen/gun
 	name = "gun"
 	icon = 'icons/mob/screen1.dmi'

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -74,6 +74,8 @@ var/list/ai_list = list()
 	var/cooldown = 0
 	var/acceleration = 1
 
+	var/static/obj/abstract/screen/nocontext/aistatic/aistatic = new()
+
 /mob/living/silicon/ai/New(loc, var/datum/ai_laws/L, var/obj/item/device/mmi/B, var/safety = FALSE)
 
 	var/list/possibleNames = ai_names

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -184,5 +184,6 @@
 	render_target = "*aistatic"
 	name = "obscured"
 	screen_loc = "1, 1"
+	globalscreen = TRUE
 
 #undef UPDATE_BUFFER

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -114,9 +114,7 @@
 		var/turf/t = turf
 		if(obscuredTurfs[t])
 			if(!t.obscured)
-				var/image/obscured_static = new /image/aistatic(null, t)
-				obscured_static.plane = STATIC_PLANE
-				t.obscured = obscured_static
+				t.obscured = new /image/aistatic(null, t)
 			obscured += t.obscured
 			for(var/eye in seenby)
 				var/mob/camera/aiEye/m = eye
@@ -169,14 +167,13 @@
 	for(var/turf in obscuredTurfs)
 		var/turf/t = turf
 		if(!t.obscured)
-			var/image/obscured_static = new /image/aistatic(null, t)
-			obscured_static.plane = STATIC_PLANE
-			t.obscured = obscured_static
+			t.obscured = new /image/aistatic(null, t)
 		obscured += t.obscured
 
 /image/aistatic
 	render_source = "*aistatic"
 	layer = STATIC_LAYER
+	plane = STATIC_PLANE
 	appearance_flags = PASS_MOUSE
 
 /obj/abstract/screen/nocontext/aistatic

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -114,7 +114,7 @@
 		var/turf/t = turf
 		if(obscuredTurfs[t])
 			if(!t.obscured)
-				var/image/obscured_static = image('icons/effects/cameravis.dmi', t, null, STATIC_LAYER)
+				var/image/obscured_static = new /image/aistatic(null, t)
 				obscured_static.plane = STATIC_PLANE
 				t.obscured = obscured_static
 			obscured += t.obscured
@@ -169,9 +169,20 @@
 	for(var/turf in obscuredTurfs)
 		var/turf/t = turf
 		if(!t.obscured)
-			var/image/obscured_static = image('icons/effects/cameravis.dmi', t, null, STATIC_LAYER)
+			var/image/obscured_static = new /image/aistatic(null, t)
 			obscured_static.plane = STATIC_PLANE
 			t.obscured = obscured_static
 		obscured += t.obscured
+
+/image/aistatic
+	render_source = "*aistatic"
+	layer = STATIC_LAYER
+	appearance_flags = PASS_MOUSE
+
+/obj/abstract/screen/nocontext/aistatic
+	icon = 'icons/effects/cameravis.dmi'
+	render_target = "*aistatic"
+	name = "obscured"
+	screen_loc = "1, 1"
 
 #undef UPDATE_BUFFER

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -133,7 +133,6 @@
 
 	if(client && client.eye) // Reset these things so the AI can't view through walls and stuff.
 		client.eye = src
-		client.show_popup_menus = TRUE
 		change_sight(removing = SEE_TURFS | SEE_MOBS | SEE_OBJS)
 		see_in_dark = 0
 		see_invisible = SEE_INVISIBLE_LIVING

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -36,7 +36,6 @@
 /mob/living/silicon/ai/proc/life_handle_powered_core()
 	var/unblindme = FALSE
 	if(client && client.eye == eyeobj) // We are viewing the world through our "eye" mob.
-		client.show_popup_menus = FALSE
 		change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 		see_in_dark = 8
 		see_invisible = SEE_INVISIBLE_LEVEL_TWO

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -27,3 +27,5 @@
 			mind.store_memory("Frequencies list: <br/><b>Command:</b> [COMM_FREQ] <br/> <b>Security:</b> [SEC_FREQ] <br/> <b>Medical:</b> [MED_FREQ] <br/> <b>Science:</b> [SCI_FREQ] <br/> <b>Engineering:</b> [ENG_FREQ] <br/> <b>Service:</b> [SER_FREQ] <b>Cargo:</b> [SUP_FREQ]<br/> <b>AI private:</b> [AIPRIV_FREQ]<br/>")
 		stored_freqs = 1
 	client.CAN_MOVE_DIAGONALLY = TRUE
+
+	client.screen += aistatic


### PR DESCRIPTION
Closes #31253
AIs can now right click on non-obscured turfs, much like in the above PR except without implementing `/client/MouseEntered()`.
This solution also removes their ability to see through static by hovering over the static. The static is now mouse opaque.
Also, to prevent exploits, they can't right click on (most of) their HUD buttons.

Reasonably tested but there's probably a way to break it somehow

Someone who knows more about HUDcode should look at this to make sure I'm adding things in the right places, etc.