### PR TITLE
You can no longer keep spawning hand labeler rolls out of thin air after removing its roll from a labeler once

### DIFF
--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -95,7 +95,7 @@
 			icon_state = "labeler0"
 
 /obj/item/weapon/hand_labeler/attack_hand(mob/user) //Shamelessly stolen from stack.dm.
-	if (!mode && user.get_inactive_hand() == src && > chars_left)
+	if (!mode && user.get_inactive_hand() == src && chars_left > 0)
 		var/obj/item/device/label_roll/LR = new(user, amount=chars_left)
 		user.put_in_hands(LR)
 		to_chat(user, "<span class='notice'>You remove the label roll.</span>")

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -95,10 +95,9 @@
 			icon_state = "labeler0"
 
 /obj/item/weapon/hand_labeler/attack_hand(mob/user) //Shamelessly stolen from stack.dm.
-	if (!mode && user.get_inactive_hand() == src)
+	if (!mode && user.get_inactive_hand() == src && > chars_left)
 		var/obj/item/device/label_roll/LR = new(user, amount=chars_left)
 		user.put_in_hands(LR)
-		LR = null
 		to_chat(user, "<span class='notice'>You remove the label roll.</span>")
 		chars_left = 0
 		icon_state = "labeler_e"

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -98,6 +98,7 @@
 	if (!mode && user.get_inactive_hand() == src)
 		var/obj/item/device/label_roll/LR = new(user, amount=chars_left)
 		user.put_in_hands(LR)
+		LR = null
 		to_chat(user, "<span class='notice'>You remove the label roll.</span>")
 		chars_left = 0
 		icon_state = "labeler_e"


### PR DESCRIPTION
Fixes #31245

:cl:
* bugfix: You can no longer keep spawning hand labeler rolls out of thin air after removing its roll from a labeler once. (shiftyrail)