### PR TITLE
Reorders quick equip priority; Suit Storage above Belt slot

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -617,8 +617,8 @@ var/list/slot_equipment_priority = list( \
 		slot_gloves,\
 		slot_ears,\
 		slot_glasses,\
-		slot_belt,\
 		slot_s_store,\
+		slot_belt,\
 		slot_l_store,\
 		slot_r_store\
 	)


### PR DESCRIPTION
Fixes #11654 by reordering the quick equip priority list - moves belt slot below suit storage slot, which effectively makes belts just above pockets. I personally think this produces better behaviour as now things that are relatively unique to the suit storage slot (like the socket wrench, air tanks, guns, etc) will want to go there first, and very rarely do people want to replace their belt. 

I have tested this and I didn't find any obvious negative or unintended behaviour, however I also didn't test literally every single item.
[tweak] [bugfix]
:cl:
 * tweak: When using the quick equip hotkey, items will prefer the suit storage slot over the belt slot