### PR TITLE
Revised space ninja

### DIFF
--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -136,7 +136,6 @@ var/list/valid_ninja_suits = list(
 			if(amount>1)
 				use(1)
 				var/obj/item/stack/shuriken/S = new(loc)
-				N.thrown_shuriken += makeweakref(S)
 				S.throw_at(A, throw_range, throw_speed)
 				H.put_in_hands(src)
 				//statistics collection: ninja shuriken thrown
@@ -145,7 +144,7 @@ var/list/valid_ninja_suits = list(
 					ND.shuriken_thrown++
 			else
 				N.thrown_shuriken += makeweakref(src)
-				..(A, throw_range, throw_speed)
+				..()
 		else
 			to_chat(usr,"<span class='warning'>You fumble with \the [src]!</span>")
 			//It drops to the ground in throwcode already

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -14,7 +14,7 @@
 	admin_voice_style = "bold"
 
 	stat_datum_type = /datum/stat/role/ninja
-
+	var/list/datum/weakref/thrown_shuriken = list()
 	var/last_star_throw = 0
 
 /datum/role/ninja/OnPostSetup(var/laterole = FALSE)
@@ -108,7 +108,7 @@ var/list/valid_ninja_suits = list(
 	)
 
 /obj/item/stack/shuriken
-	name = "3D printed shuriken"
+	name = "EM shuriken"
 	desc = "A specially designed shuriken that can only be used to its full potential by one trained in Spider Clan techniques. Highly effective against unarmored targets."
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "shuriken"
@@ -129,21 +129,23 @@ var/list/valid_ninja_suits = list(
 		var/mob/living/carbon/human/H = usr
 		var/datum/role/ninja/N = H.mind.GetRole(NINJA)
 		if(N)
-			var/suited = is_type_in_list(H.wear_suit,valid_ninja_suits) ? TRUE : FALSE
-			if(N.last_star_throw > world.time + (10-8*suited)) //10 deciseconds if unsuited, 2 otherwise
+			if(N.last_star_throw > world.time + 0.8 SECONDS)
+				N.last_star_throw = world.time
 				to_chat(H, "<span class='danger'>You can't throw \the [src] until you finish throwing the last one.</span>")
 				return
 			if(amount>1)
 				use(1)
 				var/obj/item/stack/shuriken/S = new(loc)
-				S.throw_at(A,throw_range,throw_speed*(1+suited)) //double speed if suited
+				N.thrown_shuriken += makeweakref(S)
+				S.throw_at(A, throw_range, throw_speed)
 				H.put_in_hands(src)
 				//statistics collection: ninja shuriken thrown
 				if(istype(N.stat_datum, /datum/stat/role/ninja))
 					var/datum/stat/role/ninja/ND = N.stat_datum
 					ND.shuriken_thrown++
 			else
-				..(A,throw_range,throw_speed*(1+suited)) //double speed if suited
+				N.thrown_shuriken += makeweakref(src)
+				..(A, throw_range, throw_speed)
 		else
 			to_chat(usr,"<span class='warning'>You fumble with \the [src]!</span>")
 			//It drops to the ground in throwcode already
@@ -151,6 +153,13 @@ var/list/valid_ninja_suits = list(
 		if(ismob(usr))
 			to_chat(usr,"<span class='warning'>You fumble with \the [src]!</span>")
 		//Sometimes things are thrown by objects like vending machines or pneumatic cannons
+
+/obj/item/stack/shuriken/pickup(mob/user)
+	var/datum/role/ninja/weeb = isninja(user)
+	if(!weeb)
+		return
+	// Prevents "pulse shuriken" from blowing up shuriken that were thrown then picked back up
+	weeb.thrown_shuriken -= src.weakref
 
 /obj/item/stack/shuriken/Crossed(atom/movable/A)
 	if(!ishuman(A))
@@ -261,7 +270,11 @@ var/list/valid_ninja_suits = list(
 	pressure_resistance = 200 * ONE_ATMOSPHERE
 	var/cooldown = 0
 	var/shuriken_icon = "radial_print"
-	actions_types = list(/datum/action/item_action/make_shuriken, /datum/action/item_action/charge_sword)
+	actions_types = list(
+		/datum/action/item_action/make_shuriken,
+		/datum/action/item_action/pulse_shuriken,
+		/datum/action/item_action/charge_sword)
+	var/list/thrown_shuriken = list()
 
 /obj/item/clothing/gloves/ninja/examine(mob/user)
 	..()
@@ -335,6 +348,19 @@ var/list/valid_ninja_suits = list(
 	var/obj/item/clothing/gloves/ninja/I = target
 	I.make_shuriken(owner)
 
+/datum/action/item_action/pulse_shuriken
+	name = "Pulse Shuriken"
+	desc = "Release an electromagnetic pulse from all thrown shuriken."
+	icon_icon = 'icons/mob/screen_spells.dmi'
+	button_icon_state = "wiz_tech"
+
+/datum/action/item_action/pulse_shuriken/Trigger()
+	if (!owner.mind.GetRole(NINJA))
+		to_chat(owner, "<span class='warning'>Only a true ninja can do that!</span>")
+		return FALSE
+	var/obj/item/clothing/gloves/ninja/I = target
+	I.pulse_shuriken(owner)
+
 /datum/action/item_action/charge_sword
 	name = "Charge Sword"
 	desc = "Reset the cooldown on your blade's teleport."
@@ -387,6 +413,19 @@ var/list/valid_ninja_suits = list(
 			user.put_in_hands(new /obj/item/stack/shuriken(user))
 	else
 		to_chat(user,"<span class='warning'>You need [MAKE_SHURIKEN_COST] charge to make a shuriken!</span>")
+
+/obj/item/clothing/gloves/ninja/proc/pulse_shuriken(mob/user)
+	var/datum/role/ninja/weeb = isninja(user)
+	if(!weeb)
+		return
+	for(var/datum/weakref/maybe_star in weeb.thrown_shuriken)
+		var/obj/item/stack/shuriken/star = maybe_star.get()
+		if(!istype(star))
+			continue
+		empulse(star, -1, 1)
+		new /obj/effect/decal/cleanable/ash(get_turf(star))
+		qdel(star)
+	weeb.thrown_shuriken.Cut()
 
 /obj/item/clothing/gloves/ninja/proc/charge_sword(mob/user)
 	var/obj/item/weapon/oursword = GetNinjaWeapon(user)
@@ -554,7 +593,7 @@ Helpers For Both Variants
 
 /obj/item/weapon/melee/energy/sword/ninja/New()
 	..()
-	daemon = new /datum/daemon/teleport(src,"Weakness",null)
+	daemon = new /datum/daemon/teleport(src, pick("Weakness", "Nothing personnel kid"),null)
 
 /obj/item/weapon/melee/energy/sword/ninja/toggleActive(mob/user, var/togglestate = "")
 	if(togglestate) //override

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -25,7 +25,6 @@
 	power_channel = ENVIRON
 
 	custom_aghost_alerts=1
-
 	var/aiControlDisabled = 0 //If 1, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.
 	var/hackProof = 0 // if 1, this door can't be hacked by the AI
 	var/secondsMainPowerLost = 0 //The number of seconds until power is restored.
@@ -1176,21 +1175,9 @@ About the new airlock wires panel:
 			if (shock(user, 75, I.siemens_coefficient))
 				user.delayNextAttack(10)
 
-	if((I.sharpness_flags & (CUT_AIRLOCK)) && user.a_intent == I_HURT && density)
-		user.visible_message("<span class='warning'>[user] begins slicing through \the [src]!</span>", \
-		"<span class='notice'>You begin slicing through \the [src].</span>", \
-		"<span class='warning'>You hear slicing noises.</span>")
-		playsound(src, 'sound/items/Welder2.ogg', 100, 1)
-
-		if(do_after(user, src, 200))
-			if(!istype(src))
-				return
-			user.visible_message("<span class='warning'>[user] slices through \the [src]!</span>", \
-			"<span class='notice'>You slice through \the [src].</span>", \
-			"<span class='warning'>You hear slicing noises.</span>")
-			playsound(src, 'sound/items/Welder2.ogg', 100, 1)
-			bashed_in(user, FALSE)
-
+	if(!being_cut && (I.sharpness_flags & CUT_AIRLOCK) && density)
+		attempt_slicing(user)
+		return
 	if(istype(I, /obj/item/weapon/batteringram))
 		var/obj/item/weapon/batteringram/B = I
 		if(!B.can_ram(user))
@@ -1286,7 +1273,7 @@ About the new airlock wires panel:
 	add_fingerprint(user)
 	return
 
-/obj/machinery/door/airlock/proc/bashed_in(var/mob/user, var/throw_circuit = TRUE)
+/obj/machinery/door/airlock/bashed_in(var/mob/user, var/throw_circuit = TRUE)
 	playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
 	operating = -1
 	var/obj/structure/door_assembly/DA = revert(user,throw_circuit ? user.dir : null)
@@ -1321,7 +1308,7 @@ About the new airlock wires panel:
 			A.one_access = 1
 		if(req_access_dir)
 			A.dir_access = req_access_dir
-		if(access_not_dir) 
+		if(access_not_dir)
 			A.access_nodir = access_not_dir
 	else
 		A = electronics

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -56,7 +56,28 @@ var/list/all_doors = list()
 	var/soundeffect = 'sound/machines/airlock.ogg'
 	var/soundpitch = 30
 
+	var/being_cut = FALSE
 	var/explosion_block = 0 //regular airlocks are 1, blast doors are 3, higher values mean increasingly effective at blocking explosions.
+
+/obj/machinery/door/proc/bashed_in(mob/user)
+	playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
+	new /obj/effect/decal/cleanable/dirt(get_turf(src))
+	qdel(src)
+
+/obj/machinery/door/proc/attempt_slicing(mob/user)
+	being_cut = TRUE
+	user.visible_message("<span class='warning'>[user] begins slicing through \the [src]!</span>", \
+	"<span class='notice'>You begin slicing through \the [src].</span>", \
+	"<span class='warning'>You hear slicing noises.</span>")
+	playsound(src, 'sound/items/Welder2.ogg', 100, 1)
+
+	if(do_after(user, src, 20 SECONDS))
+		user.visible_message("<span class='warning'>[user] slices through \the [src]!</span>", \
+		"<span class='notice'>You slice through \the [src].</span>", \
+		"<span class='warning'>You hear slicing noises.</span>")
+		playsound(src, 'sound/items/Welder2.ogg', 100, 1)
+		bashed_in(user, FALSE)
+	being_cut = FALSE
 
 /obj/machinery/door/projectile_check()
 	if(opacity)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -74,21 +74,22 @@ var/list/poddoors = list()
 		denied()
 		return FALSE
 
-/obj/machinery/door/poddoor/attackby(var/obj/item/weapon/C, var/mob/user)
-	src.add_fingerprint(user)
-	if (!( iscrowbar(C) || (istype(C, /obj/item/weapon/fireaxe) && C.wielded == 1) ))
+/obj/machinery/door/poddoor/attackby(obj/item/weapon/C, mob/user)
+	add_fingerprint(user)
+	if(!density)
 		return
-	if ((density && (stat & NOPOWER) && !( operating )))
-		spawn()
-			src.operating = 1
-			flick(openingicon, src)
-			src.icon_state = openicon
-			src.set_opacity(0)
-			sleep(animation_delay)
-			setDensity(FALSE)
-			src.operating = 0
-			return
-	return
+	if(istype(C, /obj/item/weapon/melee/energy/sword/ninja))
+		attempt_slicing(user)
+	else if(iscrowbar(C) || istype(C, /obj/item/weapon/fireaxe) && C.wielded)
+		if(!operating && stat & NOPOWER)
+			spawn()
+				operating = TRUE
+				flick(openingicon, src)
+				icon_state = openicon
+				set_opacity(FALSE)
+				sleep(animation_delay)
+				setDensity(FALSE)
+				operating = FALSE
 
 /obj/machinery/door/poddoor/allowed(mob/M)
 	return 0

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -346,9 +346,8 @@
 	fits_max_w_class = 4
 	max_combined_w_class = 28
 	can_only_hold = list(
- 		"/obj/item/device/aicard",
- 		"/obj/item/device/mmi",
-		"/obj/item/organ/external/head"
+ 		/obj/item/device/aicard,
+ 		/obj/item/device/mmi,
  	)
 
 /obj/item/weapon/storage/belt/silicon/New()


### PR DESCRIPTION
The intent behind these changes is to turn space ninja into something that's more in line with the original anti-technology guy idea and less like a generally edgy murderer.
![image](https://user-images.githubusercontent.com/6307265/143764258-cb162306-e045-44fc-a555-fa313b335961.png)

:cl:
 * rscadd: Ninja gloves grant a new ability: "Pulse Shuriken": detonates all thrown shuriken, releasing a small EM pulse, and destroying the shuriken.
 * rscadd: Energy katanas can now slice open shutters, such as those protecting the AI core. This is exclusive to energy katanas.
 * bugfix: Fixed a bug that allowed ninjas to throw shuriken with no delay. There is now a 0.8 seconds delay.
 * tweak: Wearing the ninja suit no longer doubles the throwing speed of shuriken.
 * rscdel: The cyber trophy belt can no longer hold humanoid heads.