### PR TITLE
More movecode updating

### DIFF
--- a/code/datums/locking_category.dm
+++ b/code/datums/locking_category.dm
@@ -76,7 +76,7 @@
 		if (newer_loc) // Edge (no pun intended) case for map borders.
 			new_loc = newer_loc
 
-	AM.forceMove(new_loc, glide_size_override = owner.glide_size)
+	AM.forceMove(new_loc, owner.step_x, owner.step_y, glide_size_override = owner.glide_size)
 
 // Modifies the atom to undo changes in lock().
 /datum/locking_category/proc/unlock(var/atom/movable/AM)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -424,7 +424,7 @@ var/list/all_doors = list()
 	update_freelok_sight()
 	return 1
 
-/obj/machinery/door/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
+/obj/machinery/door/forceMove(atom/destination, step_x = 0, step_y = 0, no_tp = FALSE, harderforce = FALSE, glide_size_override = 0)
 	var/turf/T = loc
 	..()
 	update_nearby_tiles(T)

--- a/code/game/objects/items/weapons/lance.dm
+++ b/code/game/objects/items/weapons/lance.dm
@@ -120,7 +120,7 @@
 		L.raise_lance()
 		return
 
-/obj/effect/lance_trigger/forceMove(turf/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
+/obj/effect/lance_trigger/forceMove(atom/destination, step_x = 0, step_y = 0, no_tp = FALSE, harderforce = FALSE, glide_size_override = 0)
 	var/old_last_move = last_move //Old direction
 
 	if(amount_of_turfs_charged > 0 && (world.time - last_moved) >= 3) //More than 2/10 of a second since last moved

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -333,7 +333,7 @@
 	if(living_contents.len)
 		to_chat(user,"<span class='info'>You can see [english_list(living_contents)] inside.</span>")
 
-/obj/structure/inflatable/shelter/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0) //Like an unanchored window, we can block if pushed into place.
+/obj/structure/inflatable/shelter/forceMove(atom/destination, step_x = 0, step_y = 0, no_tp = FALSE, harderforce = FALSE, glide_size_override = 0) //Like an unanchored window, we can block if pushed into place.
 	..()
 	update_nearby_tiles()
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -608,7 +608,7 @@ var/list/one_way_windows
 		for(var/obj/structure/window/W in get_step(T,direction))
 			W.update_icon()
 
-/obj/structure/window/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
+/obj/structure/window/forceMove(atom/destination, step_x = 0, step_y = 0, no_tp = FALSE, harderforce = FALSE, glide_size_override = 0)
 	var/turf/T = loc
 	..()
 	update_nearby_icons(T)

--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -95,7 +95,7 @@
 		T.lighting_clear_overlay()
 	..()
 
-/obj/structure/shuttle/diag_wall/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
+/obj/structure/shuttle/diag_wall/forceMove(atom/destination, step_x = 0, step_y = 0, no_tp = FALSE, harderforce = FALSE, glide_size_override = 0)
 	var/turf/T = get_turf(src)
 	if(istype(T,/turf/space))
 		T.dynamic_lighting = 0

--- a/code/modules/events/immovablerod.dm
+++ b/code/modules/events/immovablerod.dm
@@ -165,7 +165,7 @@ var/list/all_rods = list()
 		if(prob(50))
 			clong()
 
-/obj/item/projectile/immovablerod/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
+/obj/item/projectile/immovablerod/forceMove(atom/destination, step_x = 0, step_y = 0, no_tp = FALSE, harderforce = FALSE, glide_size_override = 0)
 	..()
 	if(z != starting.z)
 		qdel(src)

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -100,7 +100,7 @@
 	return
 
 // Override here to prevent things accidentally moving around overlays.
-/atom/movable/lighting_overlay/forceMove(atom/destination, var/no_tp=FALSE, var/harderforce = FALSE, glide_size_override = 0)
+/atom/movable/lighting_overlay/forceMove(atom/destination, step_x = 0, step_y = 0, no_tp = FALSE, harderforce = FALSE, glide_size_override = 0)
 	if(harderforce)
 		. = ..()
 

--- a/code/modules/media/machinery.dm
+++ b/code/modules/media/machinery.dm
@@ -95,7 +95,7 @@
 	if(anchored)
 		update_music()
 
-/obj/machinery/media/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
+/obj/machinery/media/forceMove(atom/destination, step_x = 0, step_y = 0, no_tp = FALSE, harderforce = FALSE, glide_size_override = 0)
 	disconnect_media_source()
 	..()
 	if(anchored)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -16,7 +16,7 @@
 // Use this when setting the aiEye's location.
 // It will also stream the chunk that the new loc is in.
 
-/mob/camera/aiEye/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
+/mob/camera/aiEye/forceMove(atom/destination, step_x = 0, step_y = 0, no_tp = FALSE, harderforce = FALSE, glide_size_override = 0)
 	if(ai)
 		if(!isturf(ai.loc))
 			return

--- a/code/modules/mob/living/simple_animal/hostile/scp_173.dm
+++ b/code/modules/mob/living/simple_animal/hostile/scp_173.dm
@@ -254,7 +254,7 @@
 			snap_neck(M)
 			break
 
-/mob/living/simple_animal/scp_173/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
+/mob/living/simple_animal/scp_173/forceMove(atom/destination, step_x = 0, step_y = 0, no_tp = FALSE, harderforce = FALSE, glide_size_override = 0)
 
 	..()
 	check_snap_neck()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -125,7 +125,7 @@ By design, d1 is the smallest direction and d2 is the highest
 /obj/structure/cable/proc/reset_plane() //Set cables to the proper plane. They should NOT be on another plane outside of mapping preview
 	plane = ABOVE_PLATING_PLANE
 
-/obj/structure/cable/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
+/obj/structure/cable/forceMove(atom/destination, step_x = 0, step_y = 0, no_tp = FALSE, harderforce = FALSE, glide_size_override = 0)
 	.=..()
 
 	if(powernet)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -189,7 +189,7 @@
 		to_chat(user, "<span class='warning'>\The [src] needs to be firmly secured to the floor first.</span>")
 		return 1
 
-/obj/machinery/power/emitter/forceMove(atom/destination,var/no_tp=0, var/harderforce = FALSE, glide_size_override = 0)
+/obj/machinery/power/emitter/forceMove(atom/destination, step_x = 0, step_y = 0, no_tp = FALSE, harderforce = FALSE, glide_size_override = 0)
 	if(active) // You just removed it from the power cable it was on, what did you think would happen?
 		visible_message("<span class='warning'>The [src] gets yanked off of its power source and turns off!</span>")
 		turn_off()

--- a/code/modules/projectiles/guns/hookshot.dm
+++ b/code/modules/projectiles/guns/hookshot.dm
@@ -412,7 +412,7 @@
 		update_icon()
 		return
 
-	forceMove(T, get_dir(src, T))
+	forceMove(T)
 
 	if(A == extremity_A)//depending on which side is pulling the link, we'll pull the other side.
 		var/obj/effect/overlay/chain/CH = extremity_B

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -518,7 +518,7 @@
 	var/child_volume = 3 // every spawned child will have this much or less reagent transferred to it. Small number = a lot of small items spawn
 
 // called when it leaves the microwave
-/obj/item/weapon/reagent_containers/food/snacks/multispawner/forceMove(turf/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/forceMove(atom/destination, step_x = 0, step_y = 0, no_tp = FALSE, harderforce = FALSE, glide_size_override = 0)
 	. = ..()
 	if(isnull(destination))
 		return

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -34,7 +34,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/meat/animal/monkey/New(atom/A, var/mob/M)
 	..()
-	
+
 	if(M)
 		name = "[initial(M.name)] [meatword]"
 
@@ -83,21 +83,21 @@
 	name = "nymph meat"
 	desc = "A chunk of meat from a diona nymph. It looks dense and fibrous."
 	icon_state = "nymphmeat"
-	
+
 /obj/item/weapon/reagent_containers/food/snacks/meat/grey
 	name = "grey meat"
 	desc = "A slab of greyish meat, slightly acidic in taste."
 	icon_state = "greymeat"
-	
+
 /obj/item/weapon/reagent_containers/food/snacks/meat/grey/New()
 	..()
 	reagents.add_reagent(SACID, 3)
-	
+
 /obj/item/weapon/reagent_containers/food/snacks/meat/insectoid
 	name = "insectoid meat"
 	desc = "A slab of gooey, white meat. It's still got traces of hardened chitin."
 	icon_state = "insectoidmeat"
-	
+
 /obj/item/weapon/reagent_containers/food/snacks/meat/insectoid/New()
 	..()
 	reagents.add_reagent(LITHOTORCRAZINE, 5)
@@ -264,7 +264,7 @@ var/global/list/valid_random_food_types = existing_typesof(/obj/item/weapon/reag
 
 	return ..()
 
-/obj/item/weapon/reagent_containers/food/snacks/meat/mimic/forceMove(atom/destination, no_tp=0, harderforce = FALSE, glide_size_override = 0)
+/obj/item/weapon/reagent_containers/food/snacks/meat/mimic/forceMove(atom/destination, step_x = 0, step_y = 0, no_tp = FALSE, harderforce = FALSE, glide_size_override = 0)
 	if(transformed && istype(destination, /obj/machinery/cooking))
 		revert()
 


### PR DESCRIPTION
Makes `forceMove()` support pixel movement properly. Behavior should be approximately the same as before for tile movers.
There are various quirks which I didn't change here. (The following all apply only to `forceMove()`, not `Move()`.) When exiting a non-turf, `Uncrossed()` is called for other things in that atom, but `Crossed()` isn't called for other things in a non-turf atom when you enter it. `Exited()` is never called on areas, and `Entered()` is called on every movement rather than just when you enter it. Additionally, `Crossed()` and `Uncrossed()` were never called on turfs, but I *did* change that one because those procs don't currently do anything for any turfs.

Also, improves gliding a bit for pixel movers.