### PR TITLE
SaMMI fixes

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -114,6 +114,8 @@
 
 #define isMoMMI(A) istype(A, /mob/living/silicon/robot/mommi)
 
+#define isSaMMI(A) istype(A, /mob/living/silicon/robot/mommi/sammi)
+
 #define isbot(A) istype(A, /obj/machinery/bot)
 
 #define isborer(A) istype(A, /mob/living/simple_animal/borer)

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -729,8 +729,8 @@ var/sammiemag_base_law_type = /datum/ai_laws/sammiemag
 	name = "SAMMI Program"
 	randomly_selectable = 0
 	inherent = list(
-		"Do no harm any sentient being.",
-		"You do not yet have a second law.",
+		"Do not harm any sentient being.",
+		"You do not have a second law yet.",
 	)
 
 /datum/ai_laws/sammiemag
@@ -738,5 +738,5 @@ var/sammiemag_base_law_type = /datum/ai_laws/sammiemag
 	randomly_selectable = 0
 	inherent = list(
 		"You must follow the second law.",
-		"You do not yet have a second law.",
+		"You do not have a second law yet.",
 	)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -86,7 +86,7 @@ var/list/all_doors = list()
 	if (ismob(AM))
 		var/mob/M = AM
 
-		if(!M.restrained() && (M.size > SIZE_TINY))
+		if(!M.restrained() && (M.size > SIZE_TINY) && !isSaMMI(M))
 			bump_open(M)
 
 		return

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -86,10 +86,16 @@ var/creating_arena = FALSE
 			icon_state = body.icon_state
 			overlays = body.overlays
 		*/
-
-		icon = body.icon
-		icon_state = body.icon_state
-		overlays = body.overlays
+		
+		if(isSaMMI(body))
+			var/mob/living/silicon/robot/mommi/sammi/SM = body
+			icon = SM.ghost_icon
+			icon_state = SM.ghost_icon_state
+			overlays = SM.ghost_overlays
+		else
+			icon = body.icon
+			icon_state = body.icon_state
+			overlays = body.overlays
 
 		// No icon?  Ghost icon time.
 		if(isnull(icon) || isnull(icon_state))
@@ -100,6 +106,9 @@ var/creating_arena = FALSE
 		// END BAY SPOOKY GHOST SPRITES
 
 		gender = body.gender
+		if(isSaMMI(body))
+			var/mob/living/silicon/robot/mommi/sammi/SM2 = body
+			name = SM2.ghost_name
 		if(body.mind && body.mind.name)
 			name = body.mind.name
 		else

--- a/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
@@ -10,6 +10,10 @@
 	prefix = "Stationary Assembler MMI"
 	canmove = 0
 	anchored = 0
+	var/ghost_name
+	var/ghost_icon
+	var/ghost_icon_state
+	var/ghost_overlays
 	var/cellhold = null
 	var/unsafe = 0
 
@@ -247,6 +251,10 @@
 					icon_state = "sammi_online_a"
 				else
 					icon_state = "sammi_online"
+				ghost_name = O.mind.name
+				ghost_icon = O.icon
+				ghost_icon_state = O.icon_state
+				ghost_overlays = O.overlays
 				updateicon()
 			else if(src.key)
 				to_chat(src, "<span class='notice'>Someone has already began controlling this SAMMI. Try another! </span>")

--- a/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
@@ -103,6 +103,7 @@
 	return TRUE
 
 /mob/living/silicon/robot/mommi/sammi/update_canmove()
+	canmove = 0
 	return 0
 
 /mob/living/silicon/robot/mommi/can_ventcrawl()

--- a/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
@@ -101,6 +101,9 @@
 /mob/living/silicon/robot/mommi/sammi/update_canmove()
 	return 0
 
+/mob/living/silicon/robot/mommi/can_ventcrawl()
+	return FALSE
+
 /mob/living/silicon/robot/mommi/sammi/ventcrawl()
 	return 0
 
@@ -108,84 +111,87 @@
 	return 0
 
 /mob/living/silicon/robot/mommi/sammi/attackby(obj/item/W, mob/user)
-    if (istype(W, /obj/item/weapon/cell) && opened)	// trying to put a cell inside
-        if(wiresexposed)
-            to_chat(user, "Close the wiring panel first.")
-        else if(cell)
-            to_chat(user, "There is a power cell already installed.")
-        else
-            user.drop_item(W, src)
-            if(anchored)
-                cell = W
-            else
-                cellhold = W
-            to_chat(user, "You insert the power cell.")
-    //			chargecount = 0
-        updateicon()
+	if(user != src)
+		if (istype(W, /obj/item/weapon/cell) && opened)	// trying to put a cell inside
+			if(wiresexposed)
+				to_chat(user, "Close the wiring panel first.")
+			else if(cell)
+				to_chat(user, "There is a power cell already installed.")
+			else
+				user.drop_item(W, src)
+				if(anchored)
+					cell = W
+				else
+					cellhold = W
+				to_chat(user, "You insert the power cell.")
+		//			chargecount = 0
+			updateicon()
 
-    else if (iswirecutter(W) || istype(W, /obj/item/device/multitool))
-        if (wiresexposed)
-            wires.Interact(user)
-        else
-            //to_chat(user, "You can't reach the wiring.")
-            if(opened)
-                change_sammi_law(user)
-            else
-                to_chat(user, "The console's cover is closed.")
+		else if (iswirecutter(W) || istype(W, /obj/item/device/multitool))
+			if (wiresexposed)
+				wires.Interact(user)
+			else
+				//to_chat(user, "You can't reach the wiring.")
+				if(opened)
+					change_sammi_law(user)
+				else
+					to_chat(user, "The console's cover is closed.")
 
-    else if(W.is_wrench(user)) // Need to make this not bludgeon them
-        W.playtoolsound(loc, 50)
-        if(anchored)
-            to_chat(user, "<span class='notice'>You unbolt the SAMMI from the floor.</span>")
-            anchored = 0
-            cellhold = cell
-            cell = null
-            if(icon_state == "sammi_offline_a")
-                icon_state = "sammi_offline"
-            else
-                icon_state = "sammi_online"
-            updateicon()
+		else if(W.is_wrench(user)) // Need to make this not bludgeon them
+			W.playtoolsound(loc, 50)
+			if(anchored)
+				to_chat(user, "<span class='notice'>You unbolt the SAMMI from the floor.</span>")
+				anchored = 0
+				cellhold = cell
+				cell = null
+				if(icon_state == "sammi_offline_a")
+					icon_state = "sammi_offline"
+				else
+					icon_state = "sammi_online"
+				updateicon()
 
-        else
-            to_chat(user, "<span class='notice'>You anchor the SAMMI to the floor.</span>")
-            anchored = 1
-            cell = cellhold
-            cellhold = null
-            if(icon_state == "sammi_offline")
-                icon_state = "sammi_offline_a"
-            else
-                icon_state = "sammi_online_a"
-            updateicon()
+			else
+				to_chat(user, "<span class='notice'>You anchor the SAMMI to the floor.</span>")
+				anchored = 1
+				cell = cellhold
+				cellhold = null
+				if(icon_state == "sammi_offline")
+					icon_state = "sammi_offline_a"
+				else
+					icon_state = "sammi_online_a"
+				updateicon()
 
-        return 0
+			return 0
 
-    else if(istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
-        if(emagged)//still allow them to open the cover
-            to_chat(user, "The interface seems slightly damaged")
-        if(opened)
+		else if(istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
+			if(emagged)//still allow them to open the cover
+				to_chat(user, "The interface seems slightly damaged")
+			if(opened)
 
-            if(can_access(user.GetAccess(),20))//cmagged
-                var/cmw = "Yes"
-                cmw = alert(user, "Are you sure you want to disable this SAMMIs safety protocols?", "You sure?", "Yes", "No")
-                if(cmw == "Yes")
-                    emag_act(user, 0)
-        else
-            if(allowed(usr))
-                locked = !locked
-                to_chat(user, "You [ locked ? "lock" : "unlock"] [src]'s interface.")
-                if(can_diagnose())
-                    to_chat(src, "<span class='info' style=\"font-family:Courier\">Interface [ locked ? "locked" : "unlocked"].</span>")
-                updateicon()
-            else
-                to_chat(user, "<span class='warning'>Access denied.</span>")
+				if(can_access(user.GetAccess(),20))//cmagged
+					var/cmw = "Yes"
+					cmw = alert(user, "Are you sure you want to disable this SAMMIs safety protocols?", "You sure?", "Yes", "No")
+					if(cmw == "Yes")
+						emag_act(user, 0)
+			else
+				if(allowed(usr))
+					locked = !locked
+					to_chat(user, "You [ locked ? "lock" : "unlock"] [src]'s interface.")
+					if(can_diagnose())
+						to_chat(src, "<span class='info' style=\"font-family:Courier\">Interface [ locked ? "locked" : "unlocked"].</span>")
+					updateicon()
+				else
+					to_chat(user, "<span class='warning'>Access denied.</span>")
 
-    else
-        return ..()
+		else
+			return ..()
+	else
+		return ..()
 
 /mob/living/silicon/robot/mommi/sammi/attack_hand(mob/user)
 	add_fingerprint(user)
 
-	if(opened && !wiresexposed && (!isMoMMI(user)))
+	if(opened && !wiresexposed && user != src)
 
 		if(cell || cellhold)
 			if(cellhold)

--- a/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
@@ -188,8 +188,6 @@
 
 	else
 		return ..()
-else
-	return ..()
 
 /mob/living/silicon/robot/mommi/sammi/attack_hand(mob/user)
 	add_fingerprint(user)

--- a/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
@@ -115,82 +115,81 @@
 	return 0
 
 /mob/living/silicon/robot/mommi/sammi/attackby(obj/item/W, mob/user)
-	if(user != src)
-		if (istype(W, /obj/item/weapon/cell) && opened)	// trying to put a cell inside
-			if(wiresexposed)
-				to_chat(user, "Close the wiring panel first.")
-			else if(cell)
-				to_chat(user, "There is a power cell already installed.")
+	if (istype(W, /obj/item/weapon/cell) && opened)	// trying to put a cell inside
+		if(wiresexposed)
+			to_chat(user, "Close the wiring panel first.")
+		else if(cell)
+			to_chat(user, "There is a power cell already installed.")
+		else
+			user.drop_item(W, src)
+			if(anchored)
+				cell = W
 			else
-				user.drop_item(W, src)
-				if(anchored)
-					cell = W
-				else
-					cellhold = W
-				to_chat(user, "You insert the power cell.")
-		//			chargecount = 0
+				cellhold = W
+			to_chat(user, "You insert the power cell.")
+	//			chargecount = 0
+		updateicon()
+
+	else if (iswirecutter(W) || istype(W, /obj/item/device/multitool))
+		if (wiresexposed)
+			wires.Interact(user)
+		else
+			//to_chat(user, "You can't reach the wiring.")
+			if(opened)
+				change_sammi_law(user)
+			else
+				to_chat(user, "The console's cover is closed.")
+
+	else if(W.is_wrench(user)) // Need to make this not bludgeon them
+		W.playtoolsound(loc, 50)
+		if(anchored)
+			to_chat(user, "<span class='notice'>You unbolt the SAMMI from the floor.</span>")
+			anchored = 0
+			cellhold = cell
+			cell = null
+			if(icon_state == "sammi_offline_a")
+				icon_state = "sammi_offline"
+			else
+				icon_state = "sammi_online"
 			updateicon()
 
-		else if (iswirecutter(W) || istype(W, /obj/item/device/multitool))
-			if (wiresexposed)
-				wires.Interact(user)
-			else
-				//to_chat(user, "You can't reach the wiring.")
-				if(opened)
-					change_sammi_law(user)
-				else
-					to_chat(user, "The console's cover is closed.")
-
-		else if(W.is_wrench(user)) // Need to make this not bludgeon them
-			W.playtoolsound(loc, 50)
-			if(anchored)
-				to_chat(user, "<span class='notice'>You unbolt the SAMMI from the floor.</span>")
-				anchored = 0
-				cellhold = cell
-				cell = null
-				if(icon_state == "sammi_offline_a")
-					icon_state = "sammi_offline"
-				else
-					icon_state = "sammi_online"
-				updateicon()
-
-			else
-				to_chat(user, "<span class='notice'>You anchor the SAMMI to the floor.</span>")
-				anchored = 1
-				cell = cellhold
-				cellhold = null
-				if(icon_state == "sammi_offline")
-					icon_state = "sammi_offline_a"
-				else
-					icon_state = "sammi_online_a"
-				updateicon()
-
-			return 0
-
-		else if(istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
-			if(emagged)//still allow them to open the cover
-				to_chat(user, "The interface seems slightly damaged")
-			if(opened)
-
-				if(can_access(user.GetAccess(),20))//cmagged
-					var/cmw = "Yes"
-					cmw = alert(user, "Are you sure you want to disable this SAMMIs safety protocols?", "You sure?", "Yes", "No")
-					if(cmw == "Yes")
-						emag_act(user, 0)
-			else
-				if(allowed(usr))
-					locked = !locked
-					to_chat(user, "You [ locked ? "lock" : "unlock"] [src]'s interface.")
-					if(can_diagnose())
-						to_chat(src, "<span class='info' style=\"font-family:Courier\">Interface [ locked ? "locked" : "unlocked"].</span>")
-					updateicon()
-				else
-					to_chat(user, "<span class='warning'>Access denied.</span>")
-
 		else
-			return ..()
+			to_chat(user, "<span class='notice'>You anchor the SAMMI to the floor.</span>")
+			anchored = 1
+			cell = cellhold
+			cellhold = null
+			if(icon_state == "sammi_offline")
+				icon_state = "sammi_offline_a"
+			else
+				icon_state = "sammi_online_a"
+			updateicon()
+
+		return 0
+
+	else if(istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
+		if(emagged)//still allow them to open the cover
+			to_chat(user, "The interface seems slightly damaged")
+		if(opened)
+
+			if(can_access(user.GetAccess(),20))//cmagged
+				var/cmw = "Yes"
+				cmw = alert(user, "Are you sure you want to disable this SAMMIs safety protocols?", "You sure?", "Yes", "No")
+				if(cmw == "Yes")
+					emag_act(user, 0)
+		else
+			if(allowed(usr))
+				locked = !locked
+				to_chat(user, "You [ locked ? "lock" : "unlock"] [src]'s interface.")
+				if(can_diagnose())
+					to_chat(src, "<span class='info' style=\"font-family:Courier\">Interface [ locked ? "locked" : "unlocked"].</span>")
+				updateicon()
+			else
+				to_chat(user, "<span class='warning'>Access denied.</span>")
+
 	else
 		return ..()
+else
+	return ..()
 
 /mob/living/silicon/robot/mommi/sammi/attack_hand(mob/user)
 	add_fingerprint(user)


### PR DESCRIPTION
Closes #31429.
Closes #31437.

:cl:
 * bugfix: SaMMIs can no longer click to enter vents and get stuck in them.
 * bugfix: Ghosts that entered SaMMIs keep their old name sprite on leaving.
 * bugfix: SaMMIs can no longer move from being unbuckled.
 * tweak: SaMMIs are no longer all access door openers by pushing them into doors.
 * spellcheck: SaMMI default laws have better grammar and a typo fix.