### PR TITLE
[MDB IGNORE] Moves random borg upgrades from old trade vendor to trade window

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3195,14 +3195,6 @@ var/global/num_vending_terminals = 1
 
 //trade vendor used to be here, now see trade_datums.dm
 
-/obj/machinery/vending/trader/New()
-	load_dungeon(/datum/map_element/dungeon/mecha_graveyard)
-	var/list/upgrades = existing_typesof(/obj/item/borg/upgrade) - /obj/item/borg/upgrade/magnetic_gripper
-	for(var/i = 1 to 3)
-		premium.Add(pick_n_take(upgrades))
-
-	..()
-
 /obj/machinery/vending/barber
 	name = "\improper BarberVend"
 	desc = "The ultimate vendor for any aspiring space stylist."

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -1781,6 +1781,22 @@ var/list/omnitoolable = list(/obj/machinery/alarm,/obj/machinery/power/apc)
 	info = "The purchaser or purchasers of this or any other Circuitry Circus Education Toy Booster Pack <i>TM</i> recognizes, accepts, and is bound to the terms and conditions found within any Circuitry Circus Education Toy Starter Pack <i>TM</i>. This includes but is not limited to: <BR>the relinquishment of any state, country, nation, or planetary given rights protecting those of select ages from legal action based on misuse of the product.<BR>All: injuries, dismemberments, trauma (mental or physical), diseases, invasive species, deaths, memory loss, time loss, genetic recombination, or quantum displacement is the sole responsibility of the owner of the Circuitry Circus Education Toy Booster Pack <i>TM</i> <BR><BR>Please ask for your parent or guardian's permission before playing. Have fun."
 
 
+//Mystery upgrades////////////
+
+/obj/item/weapon/storage/box/mystery_upgrade
+	name = "random cyborg upgrade pack"
+	desc = "Magnetic gripper not included. Ever."
+	icon = 'icons/obj/storage/storage.dmi'
+	icon_state = "circuit"
+
+/obj/item/weapon/storage/box/mystery_upgrade/New()
+	..()
+	var/list/legalCircuits = existing_typesof(/obj/item/borg/upgrade) - /obj/item/borg/upgrade/magnetic_gripper //Moved from old trade vendor
+	for(var/i = 1 to 3)
+		var/boosterPack = pick(legalCircuits)
+		new boosterPack(src)
+
+
 //Mystery material//////////////////////
 
 /obj/item/weapon/storage/box/large/mystery_material

--- a/code/modules/trader/trade_datums.dm
+++ b/code/modules/trader/trade_datums.dm
@@ -129,7 +129,7 @@
 	restocks_left = 2
 	sales_category = TRADE_VARIETY
 
-/datum/trade_product/randomcircuits
+/datum/trade_product/randomupgrades
 	name = "assorted cyborg upgrade pack"
 	path = /obj/item/weapon/storage/box/mystery_upgrade
 	baseprice = 60

--- a/code/modules/trader/trade_datums.dm
+++ b/code/modules/trader/trade_datums.dm
@@ -129,6 +129,13 @@
 	restocks_left = 2
 	sales_category = TRADE_VARIETY
 
+/datum/trade_product/randomcircuits
+	name = "assorted cyborg upgrade pack"
+	path = /obj/item/weapon/storage/box/mystery_upgrade
+	baseprice = 60
+	restocks_left = 2
+	sales_category = TRADE_VARIETY
+
 /datum/trade_product/randommats
 	name = "surplus material scrap box"
 	path = /obj/item/weapon/storage/box/large/mystery_material

--- a/code/modules/trader/trade_window.dm
+++ b/code/modules/trader/trade_window.dm
@@ -23,6 +23,7 @@
 
 /obj/structure/trade_window/New()
 	..()
+	load_dungeon(/datum/map_element/dungeon/mecha_graveyard)
 	merchant_name = capitalize("[pick(vox_name_syllables)][pick(vox_name_syllables)] the [capitalize(pick(adjectives))]")
 	processing_objects += src
 

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -20322,11 +20322,9 @@
 	},
 /area/vox_trading_post/vault)
 "aWD" = (
-/obj/machinery/vending/trader,
-/turf/simulated/floor/vox{
-	icon_state = "dark"
-	},
-/area/vox_trading_post/vault)
+/obj/structure/trade_window,
+/turf/simulated/floor/plating/vox,
+/area/vox_trading_post/hallway)
 "aWE" = (
 /obj/machinery/cooking/grill,
 /turf/simulated/floor/vox{
@@ -284128,7 +284126,7 @@ aYv
 bpt
 bsR
 aWi
-aXs
+aWD
 bJW
 bPa
 bRF
@@ -290161,7 +290159,7 @@ bZp
 bZp
 bZp
 aWh
-aWD
+aXv
 aXv
 aXv
 bpr


### PR DESCRIPTION
[tweak][content][general]
:cl:
 * rscadd: Trade windows now have a random pack of 3 different borg upgrades in a box for sale.
 * rscdel: The last remnants of the trade vendor are now gone, and removed from all maps.
 * tweak: Trade windows have now been added to boxes, lamprey, xoq, nrv horizon and island, where they were missing before.