### PR TITLE
Stops new vaults rotating

### DIFF
--- a/code/modules/randomMaps/vault_definitions.dm
+++ b/code/modules/randomMaps/vault_definitions.dm
@@ -232,7 +232,6 @@ var/list/existing_vaults = list()
 
 /datum/map_element/vault/podstation
 	file_path = "maps/randomvaults/podstation.dmm"
-	can_rotate = TRUE
 
 /datum/map_element/vault/mini_station
 	file_path = "maps/randomvaults/mini_station.dmm"

--- a/code/modules/randomMaps/vault_definitions.dm
+++ b/code/modules/randomMaps/vault_definitions.dm
@@ -235,4 +235,3 @@ var/list/existing_vaults = list()
 
 /datum/map_element/vault/mini_station
 	file_path = "maps/randomvaults/mini_station.dmm"
-	can_rotate = TRUE


### PR DESCRIPTION
[tweak][hotfix]
Had issues with pipes and fences and etc.
Closes #31552.

:cl:
 * tweak: Pod station and mini station vaults can no longer be found rotated.