### PR TITLE
Voting cancelling clarification

### DIFF
--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -469,6 +469,8 @@ var/global/datum/controller/vote/vote = new()
 			if(usr.client.holder)
 				if(alert("Are you sure you want to cancel this vote? This will not the results, and for a map vote, re-use the current map.","Confirm","Yes","No") != "Yes")
 					return
+				log_admin("[key_name(usr)] has cancelled a vote currently taking place. Vote type: [mode], question, [question].")
+				message_admins("[key_name(usr)] has cancelled a vote currently taking place. Vote type: [mode], question, [question].")
 				reset()
 				update()
 				currently_voting = FALSE

--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -467,6 +467,8 @@ var/global/datum/controller/vote/vote = new()
 			return 0
 		if("cancel")
 			if(usr.client.holder)
+				if(alert("Are you sure you want to cancel this vote? This will not the results, and for a map vote, re-use the current map.","Confirm","Yes","No") != "Yes")
+					return
 				reset()
 				update()
 				currently_voting = FALSE

--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -467,7 +467,7 @@ var/global/datum/controller/vote/vote = new()
 			return 0
 		if("cancel")
 			if(usr.client.holder)
-				if(alert("Are you sure you want to cancel this vote? This will not the results, and for a map vote, re-use the current map.","Confirm","Yes","No") != "Yes")
+				if(alert("Are you sure you want to cancel this vote? This will not display the results, and for a map vote, re-use the current map.","Confirm","Yes","No") != "Yes")
 					return
 				log_admin("[key_name(usr)] has cancelled a vote currently taking place. Vote type: [mode], question, [question].")
 				message_admins("[key_name(usr)] has cancelled a vote currently taking place. Vote type: [mode], question, [question].")

--- a/code/modules/html_interface/voting/voting.js
+++ b/code/modules/html_interface/voting/voting.js
@@ -13,7 +13,7 @@ function clearAll(){
 	clearallup += 1;
 	$("#vote_main").empty();
 	$("#vote_choices").empty();
-	$("#vote_admin").html("<br />(<a href='?src="+hSrc+";vote=cancel;'>Cancel Vote</a>)");
+	$("#vote_admin").html("<br />(<a href='?src="+hSrc+";vote=cancel;'>Abort the current vote.</a>)");
 
 }
 


### PR DESCRIPTION
Should avoid confusion between individually cancelling your vote and doing the same for the entire server.
This adds a confirmation prompt to the button, and also rewords the link to further clarify what it does.

This also logs admins who cancel votes.

What as it changes nothing.