### PR TITLE
Cult 4 changes

### DIFF
--- a/code/_onclick/mindUI/bloodcult/cultist.dm
+++ b/code/_onclick/mindUI/bloodcult/cultist.dm
@@ -91,12 +91,14 @@
 	if (M)
 
 		var/list/available_runes = list()
+		var/i = 1
 		for(var/blood_spell in subtypesof(/datum/rune_spell))
 			var/datum/rune_spell/instance = blood_spell
 			if (initial(instance.secret))
 				continue
-			available_runes.Add("[initial(instance.name)]")
-			available_runes["[initial(instance.name)]"] = instance
+			available_runes.Add("[initial(instance.name)] - \Roman[i]")
+			available_runes["[initial(instance.name)] - \Roman[i]"] = instance
+			i++
 		var/spell_name = input(M,"Remember how to trace a given rune.", "Trace Rune with a Guide", null) as null|anything in available_runes
 
 		if (spell_name)

--- a/code/_onclick/mindUI/bloodcult/cultist.dm
+++ b/code/_onclick/mindUI/bloodcult/cultist.dm
@@ -91,14 +91,12 @@
 	if (M)
 
 		var/list/available_runes = list()
-		var/i = 1
 		for(var/blood_spell in subtypesof(/datum/rune_spell))
 			var/datum/rune_spell/instance = blood_spell
 			if (initial(instance.secret))
 				continue
-			available_runes.Add("\Roman[i]-[initial(instance.name)]")
-			available_runes["\Roman[i]-[initial(instance.name)]"] = instance
-			i++
+			available_runes.Add("[initial(instance.name)]")
+			available_runes["[initial(instance.name)]"] = instance
 		var/spell_name = input(M,"Remember how to trace a given rune.", "Trace Rune with a Guide", null) as null|anything in available_runes
 
 		if (spell_name)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -1584,7 +1584,7 @@ var/list/confusion_victims = list()
 	//	if (dist <= effect_range+0.5)
 	//		U.color = "red"
 	to_chat(activator, "<span class='notice'>All runes and cult structures in range hide themselves behind a thin layer of reality.</span>")
-	playsound(T, 'sound/effects/conceal.ogg', 50, 0, -4)
+	//playsound(T, 'sound/effects/conceal.ogg', 50, 0, -4)
 
 	for(var/obj/structure/cult/S in range(effect_range,T))
 		var/dist = cheap_pythag(S.x - T.x, S.y - T.y)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_spells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_spells.dm
@@ -28,7 +28,7 @@
 	var/obj/effect/rune/rune = null
 	var/datum/rune_spell/spell = null
 	var/continue_drawing = 0
-	var/blood_cost = 2
+	var/blood_cost = 1
 
 
 /spell/cult/trace_rune/choose_targets(var/mob/user = usr)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_spells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_spells.dm
@@ -10,7 +10,7 @@
 /*
 /spell/cult/trace_rune
 	name = "Trace Rune"
-	desc = "(2 BLOOD) Use available blood to write down words. Three words form a rune."
+	desc = "(1 BLOOD) Use available blood to write down words. Three words form a rune."
 	hud_state = "cult_word"
 
 	invocation_type = SpI_NONE

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_spells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_spells.dm
@@ -10,7 +10,7 @@
 /*
 /spell/cult/trace_rune
 	name = "Trace Rune"
-	desc = "(1 BLOOD) Use available blood to write down words. Three words form a rune."
+	desc = "(2 BLOOD) Use available blood to write down words. Three words form a rune."
 	hud_state = "cult_word"
 
 	invocation_type = SpI_NONE
@@ -28,7 +28,7 @@
 	var/obj/effect/rune/rune = null
 	var/datum/rune_spell/spell = null
 	var/continue_drawing = 0
-	var/blood_cost = 1
+	var/blood_cost = 2
 
 
 /spell/cult/trace_rune/choose_targets(var/mob/user = usr)


### PR DESCRIPTION
the Roman numbers on the trace runes guide got placed at the end of the phrase rather then the start (it makes searching for the rune you want a pain unless you memorized the number).
Conceal Rune no longer makes a sound (a rune that has the sole purpose of hiding something shouldn't make a loud ass noise that goes through walls alerting everyone).


🆑 
* rscdel: removed the sound of the conceal rune.
* rscadd: placed the Roman numbers that show up when you draw a rune using the guide at the end of the phrase rather then the start.