### PR TITLE
Makes pdiff checks more accurate on border windows

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -34,13 +34,14 @@ var/list/false_wall_images = list()
 * Gets the highest and lowest pressures from the list of turfs provided
 * around us, then checks the difference.
 */
-/proc/getPressureDifferentialFromTurfList(var/list/turf/simulated/turf_list)
+/proc/getPressureDifferentialFromTurfList(var/list/turf/turf_list)
 	var/minp=SHORT_REAL_LIMIT; // Lowest recorded pressure.
 	var/maxp=0;        // Highest recorded pressure.
-	for(var/turf/simulated/T in turf_list)
+	for(var/turf/T in turf_list)
 		var/cp = 0
-		if(T.zone)
-			var/datum/gas_mixture/environment = T.return_air()
+		var/turf/simulated/TS = T
+		if(TS && istype(TS) && TS.zone)
+			var/datum/gas_mixture/environment = TS.return_air()
 			cp = environment.return_pressure()
 		else
 			if(istype(T,/turf/simulated))
@@ -75,7 +76,7 @@ var/list/false_wall_images = list()
 		return pdiff
 	return 0
 
-/proc/performWallPressureCheckFromTurfList(var/list/turf/simulated/turf_list)
+/proc/performWallPressureCheckFromTurfList(var/list/turf/turf_list)
 	var/pdiff = getPressureDifferentialFromTurfList(turf_list)
 	if(pdiff > FALSEDOOR_MAX_PRESSURE_DIFF)
 		return pdiff

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -75,6 +75,12 @@ var/list/false_wall_images = list()
 		return pdiff
 	return 0
 
+/proc/performWallPressureCheckFromTurfList(var/list/turf/simulated/turf_list)
+	var/pdiff = getOPressureDifferentialFromTurfList(turf_list)
+	if(pdiff > FALSEDOOR_MAX_PRESSURE_DIFF)
+		return pdiff
+	return 0
+
 /client/proc/pdiff()
 	set name = "Get PDiff"
 	set category = "Debug"

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -76,7 +76,7 @@ var/list/false_wall_images = list()
 	return 0
 
 /proc/performWallPressureCheckFromTurfList(var/list/turf/simulated/turf_list)
-	var/pdiff = getOPressureDifferentialFromTurfList(turf_list)
+	var/pdiff = getPressureDifferentialFromTurfList(turf_list)
 	if(pdiff > FALSEDOOR_MAX_PRESSURE_DIFF)
 		return pdiff
 	return 0

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -104,7 +104,11 @@ var/list/one_way_windows
 
 	if(health <= 0)
 		if(M) //Did someone pass a mob ? If so, perform a pressure check
-			var/pdiff = performWallPressureCheck(src.loc)
+			var/pdiff = 0
+			if(flow_flags & ON_BORDER)
+				pdiff = performWallPressureCheckFromTurfList(list(get_step(loc, dir), loc))
+			else
+				pdiff = performWallPressureCheck(loc)
 			if(pdiff > 0)
 				investigation_log(I_ATMOS, "with a pdiff of [pdiff] has been destroyed by [M.real_name] ([formatPlayerPanel(M, M.ckey)]) at [formatJumpTo(get_turf(src))]!")
 				if(M.ckey) //Only send an admin message if it's an actual players, admins don't need to know what the carps are doing
@@ -453,7 +457,11 @@ var/list/one_way_windows
 							smart_toggle()
 						drop_stack(/obj/item/stack/light_w, get_turf(src), 1, user)
 					//Perform pressure check since window no longer blocks air
-					var/pdiff = performWallPressureCheck(src.loc)
+					var/pdiff = 0
+					if(flow_flags & ON_BORDER)
+						pdiff = performWallPressureCheckFromTurfList(list(get_step(loc, dir), loc))
+					else
+						pdiff = performWallPressureCheck(loc)
 					if(pdiff > 0)
 						message_admins("Window with pdiff [pdiff] deanchored by [user.real_name] ([formatPlayerPanel(user,user.ckey)]) at [formatJumpTo(loc)]!")
 						log_admin("Window with pdiff [pdiff] deanchored by [user.real_name] ([user.ckey]) at [loc]!")


### PR DESCRIPTION
[administration][tweak][bugfix]

This should now absolutely make sure dismantling windows only logs on actual breaches, since border ones block only the tile they're on and the dir they face from each other.