### PR TITLE
Head Reattachment Surgery Fixes

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1067,6 +1067,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 		src.status = organ.status
 		src.brute_dam = organ.brute_dam
 		src.burn_dam = organ.burn_dam
+		owner.internal_organs += organ.internal_organs
+		owner.internal_organs_by_name += organ.internal_organs
+
 
 		//Process attached parts (i.e. if attaching an arm with a hand, this will process the hand)
 		for(var/obj/item/organ/external/attached in organ.children)
@@ -1077,11 +1080,11 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 			OE.attach(attached)
 
-		if(organ.organ_data && !owner.internal_organs_by_name[organ.organ_data.organ_type])
-			owner.internal_organs_by_name[organ.organ_data.organ_type] = organ.organ_data.Copy()
-			owner.internal_organs += owner.internal_organs_by_name[organ.organ_data.organ_type]
-			internal_organs += owner.internal_organs_by_name[organ.organ_data.organ_type]
-			owner.internal_organs_by_name[organ.organ_data.organ_type].owner = owner
+//		if(organ.organ_data && !owner.internal_organs_by_name[organ.organ_data.organ_type])
+//			owner.internal_organs_by_name[organ.organ_data.organ_type] = organ.organ_data.Copy()
+//			owner.internal_organs += owner.internal_organs_by_name[organ.organ_data.organ_type]
+//			internal_organs += owner.internal_organs_by_name[organ.organ_data.organ_type]
+//			owner.internal_organs_by_name[organ.organ_data.organ_type].owner = owner
 
 
 	else if(istype(I, /obj/item/weapon/peglimb)) //Attaching a peg limb
@@ -1473,6 +1476,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		current_organ = new /obj/item/organ/external/head(owner.loc, owner, src)
 		owner.decapitated = current_organ
 	var/datum/organ/internal/brain/B = eject_brain()
+	eject_eyes()
 	var/obj/item/organ/external/head/H = current_organ
 	if(B)
 		H.organ_data = B
@@ -1487,9 +1491,17 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(B)
 		owner.internal_organs_by_name.Remove("brain")
 		owner.internal_organs.Remove(B)
-		src.internal_organs.Remove(B)
 
 	return B
+
+/datum/organ/external/head/proc/eject_eyes()
+	var/datum/organ/internal/brain/E = owner.internal_organs_by_name["eyes"]
+
+	if(E)
+		owner.internal_organs_by_name.Remove("eyes")
+		owner.internal_organs.Remove(E)
+
+	return
 
 /datum/organ/external/head/explode()
 	owner.remove_internal_organ(owner, owner.internal_organs_by_name["brain"], src)
@@ -1551,7 +1563,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 /obj/item/organ/external
 	icon = 'icons/mob/human_races/r_human.dmi'
-	var/datum/organ/internal/organ_data
+	var/datum/organ/internal/organ_data //Harvestable organs
+	var/list/datum/organ/internal/internal_organs //Actual organs (for surgery)
 	var/datum/dna/owner_dna
 	var/part = "organ"
 
@@ -1591,6 +1604,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	wounds = source.wounds.Copy()
 	burn_dam = source.burn_dam
 	brute_dam = source.brute_dam
+	internal_organs = source.internal_organs
 
 	//Copy status flags except for ORGAN_CUT_AWAY and ORGAN_DESTROYED
 	status = source.status & ~(ORGAN_CUT_AWAY | ORGAN_DESTROYED)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1928,6 +1928,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 					msg_admin_attack("[user] ([user.ckey]) debrained [brainmob] ([brainmob.ckey]) (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
 
 					//TODO: ORGAN REMOVAL UPDATE.
+
+					for(var/datum/organ/internal/brain/B in src.internal_organs)
+						src.internal_organs -= B
 					var/turf/T = get_turf(src)
 					if(isatom(organ_data.removed_type))
 						var/obj/I = organ_data.removed_type

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -27,7 +27,8 @@
 		)
 
 	duration = 8 SECONDS
-
+/datum/surgery_step/head/peel/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	return ..() && target.op_stage.head_reattach == 0
 
 /datum/surgery_step/head/peel/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("[user] starts peeling back tattered flesh where [target]'s head used to be with \the [tool].", \
@@ -39,6 +40,7 @@
 	user.visible_message("<span class='notice'>[user] peels back tattered flesh where [target]'s head used to be with \the [tool].</span>",	\
 	"<span class='notice'>You peel back tattered flesh where [target]'s head used to be with \the [tool].</span>")
 	affected.status |= ORGAN_CUT_AWAY
+	target.op_stage.head_reattach = 1
 
 /datum/surgery_step/head/peel/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
@@ -62,7 +64,7 @@
 
 /datum/surgery_step/head/shape/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
-	return ..() && (affected.status & ORGAN_CUT_AWAY) && affected.open != 3
+	return ..() && (affected.status & ORGAN_CUT_AWAY) && target.op_stage.head_reattach == 1
 
 /datum/surgery_step/head/shape/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
@@ -71,10 +73,9 @@
 	..()
 
 /datum/surgery_step/head/shape/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/datum/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has finished repositioning flesh and tissue to something anatomically recognizable where [target]'s head used to be with \the [tool].</span>",	\
 	"<span class='notice'>You have finished repositioning flesh and tissue to something anatomically recognizable where [target]'s head used to be with \the [tool].</span>")
-	affected.open = 3
+	target.op_stage.head_reattach = 2
 
 /datum/surgery_step/head/shape/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
@@ -97,8 +98,7 @@
 	duration = 8 SECONDS
 
 /datum/surgery_step/head/suture/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/datum/organ/external/affected = target.get_organ(target_zone)
-	return ..() && affected.open == 3
+	return ..() && target.op_stage.head_reattach == 2
 
 /datum/surgery_step/head/suture/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("[user] is stapling and suturing flesh into place in [target]'s esophagal and vocal region with \the [tool].", \
@@ -106,10 +106,9 @@
 	..()
 
 /datum/surgery_step/head/suture/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/datum/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has finished stapling [target]'s neck into place with \the [tool].</span>",	\
 	"<span class='notice'>You have finished stapling [target]'s neck into place with \the [tool].</span>")
-	affected.open = 4
+	target.op_stage.head_reattach = 3
 
 /datum/surgery_step/head/suture/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
@@ -140,8 +139,7 @@
 	duration = 6 SECONDS
 
 /datum/surgery_step/head/prepare/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/datum/organ/external/affected = target.get_organ(target_zone)
-	return ..() && affected.open == 4
+	return ..() && target.op_stage.head_reattach == 3
 
 /datum/surgery_step/head/prepare/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("[user] starts adjusting area around [target]'s neck with \the [tool].", \
@@ -156,6 +154,7 @@
 	affected.amputated = 1
 	affected.setAmputatedTree()
 	affected.open = 0
+	target.op_stage.head_reattach = 4
 
 /datum/surgery_step/head/prepare/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)
@@ -179,7 +178,7 @@
 
 /datum/surgery_step/head/attach/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/head = target.get_organ(target_zone)
-	return ..() && head.status & ORGAN_ATTACHABLE
+	return ..() && head.status & ORGAN_ATTACHABLE && target.op_stage.head_reattach == 4
 
 /datum/surgery_step/head/attach/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("[user] starts attaching [tool] to [target]'s reshaped neck.", \
@@ -200,6 +199,7 @@
 	target.init_language = target.default_language
 	affected.attach(B)
 	target.decapitated = null
+	target.op_stage.head_reattach = 0
 
 
 /datum/surgery_step/head/attach/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -220,7 +220,7 @@
 
 /datum/surgery_step/head/attach_robot/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/head = target.get_organ(target_zone)
-	return ..() && head.status & ORGAN_ATTACHABLE
+	return ..() && head.status & ORGAN_ATTACHABLE && target.op_stage.head_reattach == 4
 
 /datum/surgery_step/head/attach_robot/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("[user] starts attaching [tool] to [target]'s reshaped neck.", \
@@ -234,6 +234,7 @@
 	affected.destspawn = 0
 	affected.attach(tool)
 	target.decapitated = null
+	target.op_stage.head_reattach = 0
 
 /datum/surgery_step/head/attach_robot/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -398,7 +398,7 @@
 			to_chat(user, "<span class='warning'>\The [target] already has [o_a][O.organ_tag].</span>")
 			return 0
 
-		if(O.organ_data && affected.name == O.organ_data.parent_organ)
+		if(O.organ_data && affected.name == O.organ_data.parent_organ && affected.destspawn == 0)
 			organ_compatible = 1
 		else
 			to_chat(user, "<span class='warning'>\The [O.organ_tag] [o_do] normally go in \the [affected.display_name].</span>")


### PR DESCRIPTION
[bugfix]
Adds an internal_organs list to the head when removed, and removes brain and eyes from the internal_organs list from the body; when reattached, the list from the head is imported into the body.
Fixes the repeatable steps for head reattachment like the eye surgery PR I merged prior; if I should be using affected.open instead of target.op_stage.head_reattach to track surgery progress, please let me know.
Fixes brain insertion working when headless by checking if the head has been dropped.

Fixes #9528
Fixes #9394
Fixes #17533
Closes #23381 (Could not reproduce in testing)
Closes #24411 (Could not reproduce in testing)
:cl:
 * bugfix: Eyes will now stay with their head when it's dismembered and not be stuck to the body of the victim
 * bugfix: Fixes unintended repeatable steps in head reattachment surgery
 * bugfix: Brains can no longer be inserted into headless bodies