### PR TITLE
adds shorthands for long emotes + does other stuff

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -6,6 +6,7 @@
 /datum/emote
 	var/key = "" //What calls the emote
 	var/key_third_person = "" //This will also call the emote
+	var/key_shorthand = "" //This will also call the emote
 	var/message = "" //Message displayed when emote is used
 	var/message_mime = "" //Message displayed if the user is a mime
 	var/message_alien = "" //Message displayed if the user is a grown alien
@@ -35,6 +36,8 @@
 /datum/emote/New()
 	if(key_third_person)
 		emote_list[key_third_person] = src
+	if(key_shorthand)
+		emote_list[key_shorthand] = src
 	if(!message_mommi)
 		message_mommi = message_robot
 

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,6 +1,5 @@
 //The code execution of the emote datum is located at code/datums/emotes.dm
 /mob/proc/emote(act, m_type = null, message = null, ignore_status = FALSE, var/arguments)
-	act = lowertext(act)
 	var/param = message
 	var/custom_param = findtext(act, " ") // Someone was given as a parameter
 	if(custom_param)

--- a/code/modules/mob/living/carbon/alien/emote.dm
+++ b/code/modules/mob/living/carbon/alien/emote.dm
@@ -1,10 +1,11 @@
 /datum/emote/living/alien
 	mob_type_allowed_typelist = list(/mob/living/carbon/alien)
 
-/datum/emote/living/alien/gnarl
-	key = "gnarl"
-	key_third_person = "gnarls"
-	message = "gnarls and shows its teeth..."
+/datum/emote/living/alien/snarl
+	key = "snarl"
+	key_third_person = "snarls"
+	key_shorthand = "sna"
+	message = "snarls and bares its teeth."
 
 /datum/emote/living/alien/hiss
 	key = "hiss"

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -9,10 +9,12 @@
 /datum/emote/living/carbon/blink
 	key = "blink"
 	key_third_person = "blinks"
+	key_shorthand = "bli"
 	message = "blinks."
 
 /datum/emote/living/carbon/blink_r
 	key = "blink_r"
+	key_shorthand = "blir"
 	message = "blinks rapidly."
 
 /datum/emote/living/carbon/clap
@@ -23,10 +25,11 @@
 	restraint_check = TRUE
 	emote_type = EMOTE_AUDIBLE
 
-/datum/emote/living/carbon/gnarl
-	key = "gnarl"
-	key_third_person = "gnarls"
-	message = "gnarls and shows its teeth..."
+/datum/emote/living/carbon/snarl
+	key = "snarl"
+	key_third_person = "snarls"
+	key_shorthand = "sna"
+	message = "snarls and bares its teeth."
 	mob_type_allowed_typelist = list(/mob/living/carbon/monkey, /mob/living/carbon/alien)
 
 /datum/emote/living/carbon/moan
@@ -46,6 +49,7 @@
 /datum/emote/living/carbon/scratch
 	key = "scratch"
 	key_third_person = "scratches"
+	key_shorthand = "scra"
 	message = "scratches."
 	mob_type_allowed_typelist = list(/mob/living/carbon/monkey, /mob/living/carbon/alien)
 	restraint_check = TRUE
@@ -53,6 +57,7 @@
 /datum/emote/living/carbon/screech
 	key = "screech"
 	key_third_person = "screeches"
+	key_shorthand = "scre"
 	message = "screeches."
 	mob_type_allowed_typelist = list(/mob/living/carbon/monkey, /mob/living/carbon/alien)
 
@@ -71,6 +76,7 @@
 /datum/emote/living/carbon/sign/signal
 	key = "signal"
 	key_third_person = "signals"
+	key_shorthand = "sig"
 	message_param = "raises %t fingers."
 	mob_type_allowed_typelist = list(/mob/living/carbon/human)
 	restraint_check = TRUE
@@ -88,10 +94,12 @@
 /datum/emote/living/carbon/twitch
 	key = "twitch"
 	key_third_person = "twitches"
+	key_shorthand = "twi"
 	message = "twitches violently."
 
 /datum/emote/living/carbon/twitch_s
 	key = "twitch_s"
+	key_shorthand = "twis"
 	message = "twitches."
 
 /datum/emote/living/carbon/wave
@@ -102,12 +110,14 @@
 /datum/emote/living/carbon/whimper
 	key = "whimper"
 	key_third_person = "whimpers"
+	key_shorthand = "whim"
 	message = "whimpers."
 	message_mime = "appears hurt."
 
 /datum/emote/living/carbon/wsmile
 	key = "wsmile"
 	key_third_person = "wsmiles"
+	key_shorthand = "wsmi"
 	message = "smiles weakly."
 
 /datum/emote/living/carbon/yawn
@@ -119,12 +129,14 @@
 /datum/emote/living/carbon/sniff
 	key = "sniff"
 	key_third_person = "sniffs"
+	key_shorthand = "sni"
 	message = "sniffs."
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/carbon/snore
 	key = "snore"
 	key_third_person = "snores"
+	key_shorthand = "sno"
 	message = "snores."
 	message_mime = "sleeps soundly."
 	emote_type = EMOTE_AUDIBLE
@@ -139,18 +151,21 @@
 /datum/emote/living/carbon/scowl
 	key = "scowl"
 	key_third_person = "scowls"
+	key_shorthand = "sco"
 	message = "scowls."
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/shake
 	key = "shake"
 	key_third_person = "shakes"
+	key_shorthand = "sha"
 	message = "shakes their head."
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/carbon/shiver
 	key = "shiver"
 	key_third_person = "shiver"
+	key_shorthand = "shi"
 	message = "shivers."
 	emote_type = EMOTE_AUDIBLE
 
@@ -164,6 +179,7 @@
 /datum/emote/living/carbon/laugh
 	key = "laugh"
 	key_third_person = "laughs"
+	key_shorthand = "lau"
 	message = "laughs."
 	message_mime = "laughs silently!"
 	emote_type = EMOTE_AUDIBLE
@@ -186,6 +202,7 @@
 /datum/emote/living/carbon/giggle
 	key = "giggle"
 	key_third_person = "giggles"
+	key_shorthand = "gig"
 	message = "giggles."
 	message_mime = "giggles silently!"
 	emote_type = EMOTE_AUDIBLE
@@ -198,12 +215,14 @@
 /datum/emote/living/carbon/groan
 	key = "groan"
 	key_third_person = "groans"
+	key_shorthand = "gro"
 	message = "groans!"
 	message_mime = "appears to groan!"
 
 /datum/emote/living/carbon/grimace
 	key = "grimace"
 	key_third_person = "grimaces"
+	key_shorthand = "gri"
 	message = "grimaces."
 
 /datum/emote/living/carbon/burp
@@ -216,12 +235,14 @@
 /datum/emote/living/carbon/choke
 	key = "choke"
 	key_third_person = "chokes"
+	key_shorthand = "cho"
 	message = "chokes!"
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/carbon/chuckle
 	key = "chuckle"
 	key_third_person = "chuckles"
+	key_shorthand = "chu"
 	message = "chuckles."
 	message_mime = "imitates a smug chuckle."
 	emote_type = EMOTE_AUDIBLE
@@ -229,11 +250,13 @@
 /datum/emote/living/carbon/blush
 	key = "blush"
 	key_third_person = "blushes"
+	key_shorthand = "blu"
 	message = "blushes."
 
 /datum/emote/living/carbon/smirk
 	key = "smirk"
 	key_third_person = "smirks"
+	key_shorthand = "smir"
 	message = "smirks."
 
 /datum/emote/living/carbon/fear
@@ -242,6 +265,71 @@
 	message = "screams in fear!"
 	message_mime = "acts out a fearful scream!"
 	emote_type = EMOTE_AUDIBLE
+
+/datum/emote/living/carbon/beckon
+	key = "beckon"
+	key_third_person = "beckons"
+	key_shorthand = "bec"
+	message_param = "beckons %t closer."
+
+/datum/emote/living/carbon/dismiss
+	key = "dismiss"
+	key_third_person = "dismisses"
+	key_shorthand = "dis"
+	message = "waves dimissively."
+	message_param = "dismisses %t."
+
+/datum/emote/living/carbon/snap
+	key = "snap"
+	key_third_person = "snaps"
+	message = "snaps their fingers."
+
+/datum/emote/living/carbon/knuckle
+	key = "knuckle"
+	key_third_person = "knuckles"
+	key_shorthand = "knu"
+	message = "cracks their knuckles."
+
+/datum/emote/living/carbon/flipoff
+	key = "flipoff"
+	key_shorthand = "flipo"
+	message = "flips the bird."
+	message_param = "flips %t off!"
+
+/datum/emote/living/carbon/whistle
+	key = "whistle"
+	key_third_person = "whistles"
+	key_shorthand = "whis"
+	message = "whistles."
+	emote_type = EMOTE_AUDIBLE
+
+/datum/emote/living/carbon/wolfwhistle
+	key = "wolfwhistle"
+	key_third_person = "wolfwhistles"
+	key_shorthand = "wwhi"
+	message = "wolfwhistles."
+	message_param = "wolfwhistles at %t."
+	emote_type = EMOTE_AUDIBLE
+
+/datum/emote/living/carbon/rubhands
+	key = "rubhands"
+	key_shorthand = "rubh"
+	message = "rubs their hands deviously."
+
+/datum/emote/living/carbon/wringhands
+	key = "wringhands"
+	key_shorthand = "wrih"
+	message = "wrings their hands."
+
+/datum/emote/living/carbon/headache
+	key = "headache"
+	key_shorthand = "hea"
+	message = "holds their head in frustration."
+
+/datum/emote/living/carbon/eyerub
+	key = "eyerub"
+	key_shorthand = "eyer"
+	message = "rubs their eyes."
 
 /datum/emote/living/carbon/sound
 	var/sound_message = null
@@ -254,6 +342,7 @@
 /datum/emote/living/carbon/sound/scream
 	key = "scream"
 	key_third_person = "screams"
+	key_shorthand = "scr"
 	message = "screams!"
 	message_mime = "acts out a scream!"
 	emote_type = EMOTE_AUDIBLE
@@ -275,6 +364,7 @@
 /datum/emote/living/carbon/sound/shriek
 	key = "shriek"
 	key_third_person = "shrieks"
+	key_shorthand = "shr"
 	message = "shrieks!"
 	message_mime = "acts out a shriek!"
 	emote_type = EMOTE_AUDIBLE
@@ -291,6 +381,7 @@
 /datum/emote/living/carbon/sound/chitter
 	key = "chitter"
 	key_third_person = "chitters"
+	key_shorthand = "chi"
 	message = "chitters!"
 	message_mime = "chitters silently!"
 	emote_type = EMOTE_AUDIBLE
@@ -307,6 +398,7 @@
 /datum/emote/living/carbon/sound/cough
 	key = "cough"
 	key_third_person = "coughs"
+	key_shorthand = "cou"
 	message = "coughs!"
 	message_mime = "coughs silently!"
 	emote_type = EMOTE_AUDIBLE

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -277,7 +277,7 @@
 	key_third_person = "dismisses"
 	key_shorthand = "dis"
 	message = "waves dimissively."
-	message_param = "dismisses %t."
+	message_param = "waves dismissively to %t."
 
 /datum/emote/living/carbon/snap
 	key = "snap"

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -30,11 +30,13 @@
 
 /datum/emote/living/carbon/human/eyebrow
 	key = "eyebrow"
+	key_shorthand = "eyeb"
 	message = "raises an eyebrow."
 
 /datum/emote/living/carbon/human/grumble
 	key = "grumble"
 	key_third_person = "grumbles"
+	key_shorthand = "gru"
 	message = "grumbles!"
 	message_mime = "grumbles silently!"
 	emote_type = EMOTE_AUDIBLE
@@ -58,8 +60,8 @@
 /datum/emote/living/carbon/human/mumble
 	key = "mumble"
 	key_third_person = "mumbles"
-	message = "mumbles!"
-	message_mime = "mumbles silently!"
+	message = "mumbles under their breath."
+	message_mime = "mumbles silently."
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/carbon/human/pale
@@ -69,18 +71,21 @@
 /datum/emote/living/carbon/human/raise
 	key = "raise"
 	key_third_person = "raises"
+	key_shorthand = "rai"
 	message = "raises a hand."
 	restraint_check = TRUE
 
 /datum/emote/living/carbon/human/salute
 	key = "salute"
 	key_third_person = "salutes"
+	key_shorthand = "sal"
 	message = "salutes."
 	message_param = "salutes to %t."
 	restraint_check = TRUE
 
 /datum/emote/living/carbon/human/peace
 	key = "peace"
+	key_shorthand = "pea"
 	message = "makes a peace sign."
 	message_param = "makes a peace sign to %t."
 	restraint_check = TRUE
@@ -88,6 +93,7 @@
 
 /datum/emote/living/carbon/human/doublepeace
 	key = "doublepeace"
+	key_shorthand = "dpea"
 	message = "makes a double peace sign."
 	message_param = "makes a double peace sign to %t."
 	restraint_check = TRUE
@@ -96,16 +102,18 @@
 /datum/emote/living/carbon/human/thumbsup
 	key = "thumbup"
 	key_third_person = "thumbsup"
-	message = "makes a thumbs up."
-	message_param = "makes a thumbs up to %t."
+	key_shorthand = "thuu"
+	message = "gives a thumbs up."
+	message_param = "gives a thumbs up to %t."
 	restraint_check = TRUE
 	hands_needed = 1
 
 /datum/emote/living/carbon/human/thumbsdown
 	key = "thumbdown"
 	key_third_person = "thumbsdown"
-	message = "makes a thumbs down."
-	message_param = "makes a thumbs down to %t."
+	key_shorthand = "thud"
+	message = "gives a thumbs down."
+	message_param = "gives a thumbs down to %t."
 	restraint_check = TRUE
 	hands_needed = 1
 
@@ -120,6 +128,7 @@
 /datum/emote/living/carbon/human/shrug
 	key = "shrug"
 	key_third_person = "shrugs"
+	key_shorthand = "shr"
 	message = "shrugs."
 
 // Effin /vg/ fart Fetishists

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -356,9 +356,9 @@ var/list/animals_with_wings = list(
 	var/datum/emote/E
 
 	for(var/e in emote_list)
-		if(e in keys)
-			continue
 		E = emote_list[e]
+		if(E.key in keys)
+			continue
 		if(E.can_run_emote(user, status_check = FALSE))
 			keys += E.key
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -13,6 +13,7 @@
 /datum/emote/living/cross
 	key = "cross"
 	key_third_person = "crosses"
+	key_shorthand = "cro"
 	message = "crosses their arms."
 	message_mommi = "crosses their utility arms."
 	restraint_check = TRUE
@@ -20,12 +21,14 @@
 /datum/emote/living/collapse
 	key = "collapse"
 	key_third_person = "collapses"
+	key_shorthand = "col"
 	message = "collapses!"
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/glare
 	key = "glare"
 	key_third_person = "glares"
+	key_shorthand = "gla"
 	message = "glares."
 	message_mommi = "glares as best a robot spider can glare."
 	message_param = "glares at %t."
@@ -41,12 +44,14 @@
 /datum/emote/living/dance
 	key = "dance"
 	key_third_person = "dances"
+	key_shorthand = "dan"
 	message = "dances around happily."
 	restraint_check = TRUE
 
 /datum/emote/living/dance/cult
 	key = "cultdance"
 	key_third_person = "cultdances"
+	key_shorthand = "cultd"
 	message = "displays the dance of their people."
 	restraint_check = TRUE
 	replace_pronouns = FALSE
@@ -74,7 +79,7 @@
 	message_AI = "lets out a flurry of sparks, its screen flickering as its systems slowly halt."
 	message_alien = "lets out a waning guttural screech, green blood bubbling from its maw..."
 	message_larva = "lets out a sickly hiss of air and falls limply to the floor..."
-	message_pulsedemon = "fizzles out into faint sparks before vanishing with slight trails of smoke..."
+	message_pulsedemon = "fizzles out into faint sparks, leaving only a slight trail of smoke..."
 	message_monkey = "lets out a faint chimper as it collapses and stops moving..."
 	message_simple =  "stops moving..."
 	stat_allowed = UNCONSCIOUS
@@ -97,11 +102,13 @@
 /datum/emote/living/carbon/drool
 	key = "drool"
 	key_third_person = "drools"
+	key_shorthand = "dro"
 	message = "drools."
 
 /datum/emote/living/faint
 	key = "faint"
 	key_third_person = "faints"
+	key_shorthand = "fai"
 	message = "faints."
 
 /datum/emote/living/faint/run_emote(mob/user, params)
@@ -162,6 +169,7 @@ var/list/animals_with_wings = list(
 /datum/emote/living/frown
 	key = "frown"
 	key_third_person = "frowns"
+	key_shorthand = "fro"
 	message = "frowns."
 
 /datum/emote/living/jump
@@ -181,6 +189,11 @@ var/list/animals_with_wings = list(
 	key_third_person = "looks"
 	message = "looks."
 	message_param = "looks at %t."
+
+/datum/emote/living/nervous
+	key = "nervous"
+	key_shorthand = "ner"
+	message = "looks around nervously."
 
 /datum/emote/living/nod
 	key = "nod"
@@ -203,6 +216,14 @@ var/list/animals_with_wings = list(
 	message_mime = "performs a silent theatrical sigh."
 	emote_type = EMOTE_AUDIBLE
 
+/datum/emote/living/scoff
+	key = "scoff"
+	key_third_person = "scoffs"
+	key_shorthand = "sco"
+	message = "scoffs."
+	message_mime = "silently scoffs."
+	emote_type = EMOTE_AUDIBLE
+
 /datum/emote/living/sit
 	key = "sit"
 	key_third_person = "sits"
@@ -211,11 +232,19 @@ var/list/animals_with_wings = list(
 /datum/emote/living/smile
 	key = "smile"
 	key_third_person = "smiles"
+	key_shorthand = "smi"
 	message = "smiles."
+
+/datum/emote/living/squint
+	key = "squint"
+	key_third_person = "squints"
+	key_shorthand = "squ"
+	message = "squints."
 
 /datum/emote/living/carbon/sneeze
 	key = "sneeze"
 	key_third_person = "sneezes"
+	key_shorthand = "sne"
 	message = "sneezes."
 	emote_type = EMOTE_AUDIBLE
 
@@ -227,12 +256,14 @@ var/list/animals_with_wings = list(
 /datum/emote/living/stare
 	key = "stare"
 	key_third_person = "stares"
+	key_shorthand = "sta"
 	message = "stares."
 	message_param = "stares at %t."
 
 /datum/emote/living/strech
 	key = "stretch"
 	key_third_person = "stretches"
+	key_shorthand = "str"
 	message = "stretches their arms."
 
 /datum/emote/living/sulk
@@ -243,6 +274,7 @@ var/list/animals_with_wings = list(
 /datum/emote/living/surrender
 	key = "surrender"
 	key_third_person = "surrenders"
+	key_shorthand = "sur"
 	message = "puts their hands on their head and falls to the ground. They surrender%s!"
 	emote_type = EMOTE_AUDIBLE
 
@@ -261,6 +293,7 @@ var/list/animals_with_wings = list(
 /datum/emote/living/tremble
 	key = "tremble"
 	key_third_person = "trembles"
+	key_shorthand = "tre"
 	message = "trembles in fear!"
 
 /datum/emote/living/custom


### PR DESCRIPTION
ARE YOU SLOW AT TYPING? ARE YOU A TERMINAL ROLEPLAYER? BOY HAVE I GOT A CHANGE FOR YOU!
you can now type THREE (SOMETIMES FOUR) letters for most emotes and it will do the SAME THING. WOW
also some other stuff


:cl:
 * rscadd: added the following emotes: beckon, dismiss, squint, scoff, snap, knucklecrack, flipoff, whistle, wolfwhistle, rubhands, wringhands, headache, eyerub, nervous. (beckon, dismiss, flipoff, and wolfwhistle have params.) 
 * tweak: changed phrasing for pulse demon's death because it bothered me
 * tweak: changed *gnarl into *snarl because it bothered me
 * rscadd: added shorthands for most emotes over 4 characters long
 * tweak: params can now be uppercase because it bothered me