### PR TITLE
Cult reincarnation change

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -2727,12 +2727,12 @@ var/list/bloodcult_exitportals = list()
 	word2 = /datum/rune_word/join
 	word3 = /datum/rune_word/hell
 	page = "This rune lets you provide a shade with a body replicated from the one they originally had (or at least the one their soul remembers them having)\
-		<br><br>The shade must stand above the rune for the ritual to begin. However mind that this rune has a very steep cost in blood of 300u that have to be paid over 60 seconds of channeling. \
+		<br><br>The shade must stand above the rune for the ritual to begin. However mind that this rune has a very steep cost in blood of 1200u that have to be paid over 60 seconds of channeling. \
 		Other cultists can join in the ritual to help you share the burden you might prefer having a construct use their connection to the other side to bypass the blood cost entirely.\
 		<br><br>Note that the resulting body might look much paler than the original, this is an unfortunate side-effect that you may have to resolve on your own.\
 		<br><br>This rune persists upon use, allowing repeated usage."
-	cost_upkeep = 5
-	remaining_cost = 300
+	cost_upkeep = 20
+	remaining_cost = 1200
 	var/obj/effect/cult_ritual/resurrect/husk = null
 	var/mob/living/simple_animal/shade/shade = null
 


### PR DESCRIPTION
As it stand right now, cultists have access to all of their spells at the start of the round with no real barriers. This means that cultists now have the ability to access Reincarnation, which gives them the power to bring any dead cultist back from the dead and conjure a new body out of thin air for a mere 300 blood and 60 seconds of their time.
I personally saw cultists doing this multiple times in a row, and this included toolboxing and reincarnating their injured buddies since there's no reason not to.
This PR quadruples the price of the spell (bloodwise) so cultists will either have to collect blood or bring multiple living cultists together for the process instead of just being able to duck into maint and respawn their dead friends whenever they like.

 * rscadd: Increased the cost of reincarnation
