### PR TITLE
Standardises opposite directional returns.

### DIFF
--- a/code/__HELPERS/angles_dirs.dm
+++ b/code/__HELPERS/angles_dirs.dm
@@ -4,8 +4,7 @@ var/static/list/opposite_dirs = list(SOUTH,NORTH,NORTH|SOUTH,WEST,SOUTHWEST,NORT
 var/static/list/counterclockwise_perpendicular_dirs = list(EAST,WEST,EAST|WEST,SOUTH,SOUTHEAST,SOUTHWEST,EAST|WEST|SOUTH,NORTH,NORTHEAST,NORTHWEST,EAST|WEST|NORTH,NORTH|SOUTH,NORTH|SOUTH|EAST,NORTH|SOUTH|WEST,NORTH|SOUTH|EAST|WEST)
 
 // Saves writing a whole new list
-/proc/clockwise_perpendicular_dir(var/dir)
-	return opposite_dirs[counterclockwise_perpendicular_dirs[dir]]
+#define clockwise_perpendicular_dirs(A) opposite_dirs[counterclockwise_perpendicular_dirs[A]]
 
 /proc/Get_Angle(atom/movable/start,atom/movable/end)//For beams.
 	if(!start || !end)

--- a/code/__HELPERS/angles_dirs.dm
+++ b/code/__HELPERS/angles_dirs.dm
@@ -77,26 +77,6 @@ var/list/opposite_dirs = list(SOUTH,NORTH,NORTH|SOUTH,WEST,SOUTHWEST,NORTHWEST,N
 			return null
 
 
-/proc/reverse_direction(var/dir)
-	switch(dir)
-		if(NORTH)
-			return SOUTH
-		if(NORTHEAST)
-			return SOUTHWEST
-		if(EAST)
-			return WEST
-		if(SOUTHEAST)
-			return NORTHWEST
-		if(SOUTH)
-			return NORTH
-		if(SOUTHWEST)
-			return NORTHEAST
-		if(WEST)
-			return EAST
-		if(NORTHWEST)
-			return SOUTHEAST
-
-
 /proc/counter_clockwise_perpendicular_direction(var/dir)
 	switch(dir)
 		if(NORTH)

--- a/code/__HELPERS/angles_dirs.dm
+++ b/code/__HELPERS/angles_dirs.dm
@@ -1,3 +1,5 @@
+var/list/opposite_dirs = list(SOUTH,NORTH,null,WEST,SOUTHWEST,NORTHWEST,null,EAST,SOUTHEAST,NORTHEAST)
+
 /proc/Get_Angle(atom/movable/start,atom/movable/end)//For beams.
 	if(!start || !end)
 		return 0

--- a/code/__HELPERS/angles_dirs.dm
+++ b/code/__HELPERS/angles_dirs.dm
@@ -1,4 +1,5 @@
-var/list/opposite_dirs = list(SOUTH,NORTH,null,WEST,SOUTHWEST,NORTHWEST,null,EAST,SOUTHEAST,NORTHEAST)
+// Moved from move_loop file, now has full inverted bitflag support!
+var/list/opposite_dirs = list(SOUTH,NORTH,NORTH|SOUTH,WEST,SOUTHWEST,NORTHWEST,NORTH|SOUTH|WEST,EAST,SOUTHEAST,NORTHEAST,NORTH|SOUTH|EAST,WEST|EAST,WEST|EAST|NORTH,WEST|EAST|SOUTH,WEST|EAST|NORTH|SOUTH)
 
 /proc/Get_Angle(atom/movable/start,atom/movable/end)//For beams.
 	if(!start || !end)

--- a/code/__HELPERS/angles_dirs.dm
+++ b/code/__HELPERS/angles_dirs.dm
@@ -1,5 +1,7 @@
 // Moved from move_loop file, now has full inverted bitflag support!
-var/list/opposite_dirs = list(SOUTH,NORTH,NORTH|SOUTH,WEST,SOUTHWEST,NORTHWEST,NORTH|SOUTH|WEST,EAST,SOUTHEAST,NORTHEAST,NORTH|SOUTH|EAST,WEST|EAST,WEST|EAST|NORTH,WEST|EAST|SOUTH,WEST|EAST|NORTH|SOUTH)
+var/static/list/opposite_dirs = list(SOUTH,NORTH,NORTH|SOUTH,WEST,SOUTHWEST,NORTHWEST,NORTH|SOUTH|WEST,EAST,SOUTHEAST,NORTHEAST,NORTH|SOUTH|EAST,WEST|EAST,WEST|EAST|NORTH,WEST|EAST|SOUTH,WEST|EAST|NORTH|SOUTH)
+// This was originally a function too, both are now cut down to these.
+var/static/list/counterclockwise_perpendicular_dirs = list(EAST,WEST,EAST|WEST,SOUTH,SOUTHEAST,SOUTHWEST,EAST|WEST|SOUTH,NORTH,NORTHEAST,NORTHWEST,EAST|WEST|NORTH,NORTH|SOUTH,NORTH|SOUTH|EAST,NORTH|SOUTH|WEST,NORTH|SOUTH|EAST|WEST)
 
 /proc/Get_Angle(atom/movable/start,atom/movable/end)//For beams.
 	if(!start || !end)
@@ -76,25 +78,6 @@ var/list/opposite_dirs = list(SOUTH,NORTH,NORTH|SOUTH,WEST,SOUTHWEST,NORTHWEST,N
 		else
 			return null
 
-
-/proc/counter_clockwise_perpendicular_direction(var/dir)
-	switch(dir)
-		if(NORTH)
-			return EAST
-		if(SOUTH)
-			return WEST
-		if(EAST)
-			return SOUTH
-		if(WEST)
-			return NORTH
-		if(NORTHEAST)
-			return NORTHWEST
-		if(SOUTHEAST)
-			return NORTHEAST
-		if(SOUTHWEST)
-			return SOUTHEAST
-		if(NORTHWEST)
-			return SOUTHWEST
 
 /proc/widen_dir(var/dir, var/angle = 45)
 	var/list/dirs = list()

--- a/code/__HELPERS/angles_dirs.dm
+++ b/code/__HELPERS/angles_dirs.dm
@@ -3,6 +3,10 @@ var/static/list/opposite_dirs = list(SOUTH,NORTH,NORTH|SOUTH,WEST,SOUTHWEST,NORT
 // This was originally a function too, both are now cut down to these.
 var/static/list/counterclockwise_perpendicular_dirs = list(EAST,WEST,EAST|WEST,SOUTH,SOUTHEAST,SOUTHWEST,EAST|WEST|SOUTH,NORTH,NORTHEAST,NORTHWEST,EAST|WEST|NORTH,NORTH|SOUTH,NORTH|SOUTH|EAST,NORTH|SOUTH|WEST,NORTH|SOUTH|EAST|WEST)
 
+// Saves writing a whole new list
+/proc/clockwise_perpendicular_dir(var/dir)
+	return opposite_dirs[counterclockwise_perpendicular_dirs[dir]]
+
 /proc/Get_Angle(atom/movable/start,atom/movable/end)//For beams.
 	if(!start || !end)
 		return 0

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -400,7 +400,7 @@ var/list/camera_messages = list()
 		T = get_ranged_target_turf(src, direction, 1)
 
 		if (istype(T))
-			dir = reverse_direction(direction)
+			dir = opposite_dirs[direction]
 			break
 
 //Return a working camera that can see a given mob

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -538,7 +538,7 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 	var/turf/home_base = get_step(get_turf(DP), DP.dir)
 	var/obj/docking_port/destination/my_shuttle_home_base = new(home_base)
 	my_shuttle_home_base.name = "[name] home port"
-	my_shuttle_home_base.dir = reverse_direction(DP.dir)
+	my_shuttle_home_base.dir = opposite_dirs[DP.dir]
 
 	var/datum/shuttle/custom/S = new(starting_area = A)
 	S.initialize()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -188,7 +188,7 @@ var/list/one_way_windows
 	if(locate(/obj/effect/unwall_field) in loc) //Annoying workaround for this
 		return TRUE
 	if(istype(mover) && mover.checkpass(pass_flags_self))//checking for beam dispersion both in and out, since beams do not trigger Uncross.
-		if((get_dir(loc, target) | get_dir(loc, mover)) & (dir | reverse_direction(dir)))
+		if((get_dir(loc, target) | get_dir(loc, mover)) & (dir | opposite_dirs[dir]))
 			dim_beam(mover)
 		return TRUE
 	if(!density)

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -207,7 +207,7 @@
 		spawn()
 			A.process()
 
-		target = get_edge_target_turf(src,reverse_direction(dir))
+		target = get_edge_target_turf(src,opposite_dirs[dir])
 		sleep(6)
 		A = new exhaust_type(T)
 		A.max_range = backward

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -54,7 +54,7 @@
 
 			if (bloodDNA)
 				src.AddTracks(H.get_footprint_type(),bloodDNA,H.dir,0,bloodcolor) // Coming
-				var/turf/simulated/from = get_step(H,reverse_direction(H.dir))
+				var/turf/simulated/from = get_step(H,opposite_dirs[H.dir])
 				if(istype(from) && from)
 					from.AddTracks(H.get_footprint_type(),bloodDNA,0,H.dir,bloodcolor) // Going
 

--- a/code/modules/client/edge_sliding/move_loop.dm
+++ b/code/modules/client/edge_sliding/move_loop.dm
@@ -1,5 +1,3 @@
-var/list/opposite_dirs = list(SOUTH,NORTH,null,WEST,SOUTHWEST,NORTHWEST,null,EAST,SOUTHEAST,NORTHEAST)
-
 /client
 	var/tmp
 		mloop = 0

--- a/code/modules/client/edge_sliding/move_loop.dm
+++ b/code/modules/client/edge_sliding/move_loop.dm
@@ -1,4 +1,4 @@
-var/list/opposite_dirs = list(SOUTH,NORTH,null,WEST,null,null,null,EAST)
+var/list/opposite_dirs = list(SOUTH,NORTH,null,WEST,SOUTHWEST,NORTHWEST,null,EAST,SOUTHEAST,NORTHEAST)
 
 /client
 	var/tmp

--- a/code/modules/mining/machine_unloading.dm
+++ b/code/modules/mining/machine_unloading.dm
@@ -26,7 +26,7 @@
 		/obj/item/weapon/stock_parts/capacitor
 	)
 	RefreshParts()
-	in_dir = reverse_direction(dir)
+	in_dir = opposite_dirs[dir]
 	out_dir = dir
 
 /obj/machinery/mineral/unloading_machine/RefreshParts()
@@ -48,16 +48,16 @@
 			return 1
 		newdir = text2dir(newdir)
 		if (changingdir == 1)
-			dir = reverse_direction(newdir)
+			dir = opposite_dirs[newdir]
 		else
 			dir = newdir
-		in_dir = reverse_direction(dir)
+		in_dir = opposite_dirs[dir]
 		out_dir = dir
 		return MT_UPDATE
 	return ..()
 
 /obj/machinery/mineral/unloading_machine/process()
-	var/turf/T = get_step(src,reverse_direction(dir))
+	var/turf/T = get_step(src,opposite_dirs[dir])
 
 	for(var/atom/movable/A in T)
 		if(A.anchored)
@@ -140,7 +140,7 @@
 			qdel(src)
 			return
 		icon_state = "grabber-retract-3"
-		for (var/atom/movable/AM in get_step(src,reverse_direction(dir)))
+		for (var/atom/movable/AM in get_step(src,opposite_dirs[dir]))
 			if (Adjacent(AM) && is_type_in_list(AM, unloader.allowed_types))
 				stack_of_items.overlays +=  image(AM.icon,src,AM.icon_state)
 				AM.forceMove(src)

--- a/code/modules/mining/surprise.dm
+++ b/code/modules/mining/surprise.dm
@@ -82,7 +82,7 @@ var/global/list/mining_surprises = typesof(/mining_surprise)-/mining_surprise
 			UpdateTurf(AT, no_adjacent=1)
 		var/surprise_turf_info/ATi = turf_info[AT]
 		// By-Ref so shit gets updated.
-		ATi.adjacents["[reverse_direction(dir)]"]=Ti.types
+		ATi.adjacents["[opposite_dirs[dir)]"]=Ti.types
 
 
 	// Common stuff

--- a/code/modules/mining/surprise.dm
+++ b/code/modules/mining/surprise.dm
@@ -82,7 +82,7 @@ var/global/list/mining_surprises = typesof(/mining_surprise)-/mining_surprise
 			UpdateTurf(AT, no_adjacent=1)
 		var/surprise_turf_info/ATi = turf_info[AT]
 		// By-Ref so shit gets updated.
-		ATi.adjacents["[opposite_dirs[dir)]"]=Ti.types
+		ATi.adjacents["[opposite_dirs[dir]"]=Ti.types
 
 
 	// Common stuff

--- a/code/modules/mining/surprise.dm
+++ b/code/modules/mining/surprise.dm
@@ -82,7 +82,7 @@ var/global/list/mining_surprises = typesof(/mining_surprise)-/mining_surprise
 			UpdateTurf(AT, no_adjacent=1)
 		var/surprise_turf_info/ATi = turf_info[AT]
 		// By-Ref so shit gets updated.
-		ATi.adjacents["[opposite_dirs[dir]"]=Ti.types
+		ATi.adjacents["[opposite_dirs[dir]]"]=Ti.types
 
 
 	// Common stuff

--- a/code/modules/power/rust/fuel_injector.dm
+++ b/code/modules/power/rust/fuel_injector.dm
@@ -266,7 +266,7 @@
 		stop_injecting()
 
 /obj/machinery/power/rust_fuel_injector/proc/attempt_fuel_swap()
-	var/rev_dir = reverse_direction(dir)
+	var/rev_dir = opposite_dirs[dir]
 	var/turf/mid = get_step(src, rev_dir)
 	var/success = 0
 	for(var/obj/machinery/rust_fuel_assembly_port/check_port in get_step(mid, rev_dir))

--- a/code/modules/projectiles/guns/lawgiver.dm
+++ b/code/modules/projectiles/guns/lawgiver.dm
@@ -314,7 +314,7 @@ var/list/lawgiver_modes = list(
 	var/orientation = get_dir(origin_turf, target_turf)
 	// Turfs to the "left" and to the "right" of the clicked target
 	var/projectile1_target = get_step(target_turf, counter_clockwise_perpendicular_direction(orientation))
-	var/projectile2_target = get_step(target_turf, reverse_direction(counter_clockwise_perpendicular_direction(orientation)))
+	var/projectile2_target = get_step(target_turf, opposite_dirs[counter_clockwise_perpendicular_direction(orientation)])
 	Fire(projectile1_target, user, params, struggle)
 	if(!in_chamber)
 		in_chamber = new projectile_type(src)

--- a/code/modules/projectiles/guns/lawgiver.dm
+++ b/code/modules/projectiles/guns/lawgiver.dm
@@ -314,7 +314,7 @@ var/list/lawgiver_modes = list(
 	var/orientation = get_dir(origin_turf, target_turf)
 	// Turfs to the "left" and to the "right" of the clicked target
 	var/projectile1_target = get_step(target_turf, counterclockwise_perpendicular_dirs[orientation])
-	var/projectile2_target = get_step(target_turf, opposite_dirs[counterclockwise_perpendicular_dirs[orientation]])
+	var/projectile2_target = get_step(target_turf, clockwise_perpendicular_dirs(orientation))
 	Fire(projectile1_target, user, params, struggle)
 	if(!in_chamber)
 		in_chamber = new projectile_type(src)

--- a/code/modules/projectiles/guns/lawgiver.dm
+++ b/code/modules/projectiles/guns/lawgiver.dm
@@ -313,8 +313,8 @@ var/list/lawgiver_modes = list(
 	var/turf/target_turf = get_turf(target)
 	var/orientation = get_dir(origin_turf, target_turf)
 	// Turfs to the "left" and to the "right" of the clicked target
-	var/projectile1_target = get_step(target_turf, counter_clockwise_perpendicular_direction(orientation))
-	var/projectile2_target = get_step(target_turf, opposite_dirs[counter_clockwise_perpendicular_direction(orientation)])
+	var/projectile1_target = get_step(target_turf, counterclockwise_perpendicular_dirs[orientation])
+	var/projectile2_target = get_step(target_turf, opposite_dirs[counterclockwise_perpendicular_dirs[orientation]])
 	Fire(projectile1_target, user, params, struggle)
 	if(!in_chamber)
 		in_chamber = new projectile_type(src)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -160,7 +160,7 @@
 			var/obj/machinery/conveyor/C = locate() in T
 			if(C && (C.dir & C.dir-1) && !C.smoothed) //found an unsmoothed diagonal conveyor belt
 				var/list/secondarydirections = conveyor_directions(C.dir) //retrieve its dirs
-				if(directions[i] == reverse_direction(secondarydirections[i])) //check if the direction it is pointing is towards/away from us, if necessary reverse it
+				if(directions[i] == opposite_dirs[secondarydirections[i]]) //check if the direction it is pointing is towards/away from us, if necessary reverse it
 					in_reverse = 1
 					C.smoothed = 1
 					C.update_nearby_conveyors() //For diagonal to smooth out the other connected diagonals


### PR DESCRIPTION
[tweak]
Reverse_direction is merged into opposite_dirs, which is moved out of the move loop file into the angles and dirs helpers.
Counter_clockwise_perpendicular_direction is also converted to a list return, counterclockwise_perpendicular_dirs.
These should be functionally identical in returns, and hopefully not mess with anything, lest I jinx it.
Also adds bitflag "manifold" direction inversion support to opposite_dirs and counterclockwise_perpendicular_dirs.
Opposite_dirs is also made into a static list for less overhead, since there's no reason to change the contents.
Finally, adds a clockwise_perpendicular_dirs(A) macro for a short hand to access the inversion of the counterclockwise one.

Tested and confirmed working, no issues cropped up.