### PR TITLE
Pulse demon fixes

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -53,7 +53,7 @@
 	var/pitch = 30
 	penetration_dampening = 10
 	var/image/shuttle_warning_lights
-
+	var/list/remote_control_access = list(/mob/living/silicon, /mob/living/simple_animal/hostile/pulse_demon) //Mobs with access to directly controlling the airlock
 	explosion_block = 1
 
 	emag_cost = 1 // in MJ
@@ -776,7 +776,7 @@ About the new airlock wires panel:
 	if(!nowindow)
 		..()
 	if(!isAdminGhost(usr))
-		if(usr.stat || usr.restrained() || (usr.size < SIZE_SMALL))
+		if((usr.stat || usr.restrained()) || (!ispulsedemon(usr) && usr.size < SIZE_SMALL))
 			//testing("Returning: Not adminghost, stat=[usr.stat], restrained=[usr.restrained()], small=[usr.small]")
 			return
 	add_fingerprint(usr)
@@ -791,7 +791,7 @@ About the new airlock wires panel:
 			usr.unset_machine()
 			return
 
-	if(isAdminGhost(usr) || (istype(usr, /mob/living/silicon) && src.canAIControl() && operating != -1))
+	if(isAdminGhost(usr) || (is_type_in_list(usr, remote_control_access) && src.canAIControl() && operating != -1))
 		//AI
 		//aiDisable - 1 idscan, 2 disrupt main power, 3 disrupt backup power, 4 drop door bolts, 5 un-electrify door, 7 close door, 8 door safties, 9 door speed
 		//aiEnable - 1 idscan, 4 raise door bolts, 5 electrify door for 30 seconds, 6 electrify door indefinitely, 7 open door,  8 door safties, 9 door speed

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -281,6 +281,10 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 					is_in_use = 1
 					src.attack_ai(M)
 
+				else if(ispulsedemon(M))
+					is_in_use = 1
+					src.attack_pulsedemon(M)
+
 				else if(!(M in nearby)) // NOT NEARBY
 					// check for TK users
 					if(M.mutations && M.mutations.len)
@@ -306,8 +310,8 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 			if (!M || !M.client || M.machine != src)
 				_using.Remove(M)
 				continue
-			// Not robot or AI, and not nearby?
-			if(!isAI(M) && !isrobot(M) && !(M in nearby))
+			// Not robot or AI, not nearby and not pulse demon?
+			if(!isAI(M) && !isrobot(M) && !(M in nearby) && !ispulsedemon(M))
 				_using.Remove(M)
 				continue
 			is_in_use = 1

--- a/code/modules/mob/living/simple_animal/hostile/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulsedemon.dm
@@ -172,7 +172,7 @@
         moved = TRUE
     if(!is_under_tile() && prob(25))
         spark(src,rand(2,4))
-    if(new_power && !current_power)
+    if(new_power)
         current_power = new_power
         current_cable = null
         loc = new_power

--- a/code/modules/mob/living/simple_animal/hostile/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulsedemon.dm
@@ -86,7 +86,7 @@
 /mob/living/simple_animal/hostile/pulse_demon/update_perception()
     // So we can see in maint better
     if(client && client.darkness_planemaster)
-        client.darkness_planemaster.alpha = 192    
+        client.darkness_planemaster.alpha = 192
     update_cableview()
 
 /mob/living/simple_animal/hostile/pulse_demon/regular_hud_updates()
@@ -118,7 +118,7 @@
 		stat(null, text("Charge stored: [charge]W"))
 		stat(null, text("Max charge stored: [maxcharge]W"))
 
-/mob/living/simple_animal/hostile/pulse_demon/Life()    
+/mob/living/simple_animal/hostile/pulse_demon/Life()
     // Add the regen rate unless it puts us over max health, then just cap it off
     var/health_to_add = maxHealth - health < health_regen_rate ? maxHealth - health : health_regen_rate
     if(current_cable)
@@ -369,7 +369,7 @@
         // Go in instantly if already compromised, else hijack timer
         if(!R.pulsecompromised)
             to_chat(user,"<span class='notice'>You are now attempting to hijack \the [R]'s targeting module, this will take approximately [user.takeover_time] seconds.</span>")
-            to_chat(R,"<span class='danger'>ALERT: ELECTRIAL MALEVOLANCE DETECTED, TARGETING SYSTEMS HIJACK IN PROGRESS</span>")
+            to_chat(R,"<span class='danger'>ALERT: ELECTRICAL MALEVOLENCE DETECTED, TARGETING SYSTEMS HIJACK IN PROGRESS</span>")
             if(do_after(user,src,user.takeover_time*10))
                 if(occupant)
                     to_chat(user,"<span class='notice'>You are now inside \the [R], in control of its targeting.</span>")
@@ -409,7 +409,7 @@
         log_say("[key_name(src)] (@[T.x],[T.y],[T.z]) made [current_robot]([key_name(current_robot)]) say: [speech.message]")
         log_admin("[key_name(src)] made [key_name(current_robot)] say: [speech.message]")
         message_admins("<span class='notice'>[key_name(src)] made [key_name(current_robot)] say: [speech.message]</span>")
-        
+
     else
         to_chat(src, "You have no hijacked robot to speak with.")
         return 1 //this ensures we don't end up speaking out loud

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -168,7 +168,7 @@ nanoui is used to open and update nano browser uis
 		if(nano.src_object in view(7, nano.user))
 			can_interactive = 1
 	else
-		can_interactive = (isAI(nano.user) || !nano.distance_check || isAdminGhost(nano.user) || OMNI_LINK(nano.user,nano.src_object))
+		can_interactive = (isAI(nano.user) || ispulsedemon(nano.user) || !nano.distance_check || isAdminGhost(nano.user) || OMNI_LINK(nano.user,nano.src_object))
 
 	if (can_interactive)
 		return STATUS_INTERACTIVE // interactive (green visibility)


### PR DESCRIPTION
Fixed an issue where Pulse Demons couldn't interact with a lot of machinery due to the way Topic() was handled in most cases.
Pulse Demons should be able to interact with airlocks properly now.
Instead of having a long list of airlock remote control exceptions, I just made a list that checks for types instead

Known Issues:
- Some machinery still cannot be interacted with, this is due to specific machinery behavior, known ones include the fire alarm (UI closes) and the atmospheric alarms (they require sliding an ID card, which the Pulse Demon doesn't have)
- Arcade machine UI doesn't update properly

:cl:
 * bugfix: Pulse Demons should be able to interact with a lot of machinery properly now, including most machinery that used TGUI such as Autolathes. Please report any machinery that can't be interacted with.
 * bugfix: Fixed a bug where Pulse Demons couldn't interact with airlocks, not just because only silicons could do it but also because the Pulse Demon was too small to be allowed to interact with the airlock. Remotely.
 * tweak: Pulse Demons can now hop directly from one power source or another, rather than being forced in the cable of an adjacent power machinery. This is most noticeable with SMES units as they are bundled together.
 * spellcheck: Fixed a typo shown to a cyborg when it is hijacked by a Pulse Demon.