### PR TITLE
Increases double energy sword damage from 30 to 33

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -242,7 +242,7 @@
 
 /obj/item/weapon/melee/energy/sword/dualsaber/update_wield(mob/user)
 	..()
-	force = wielded ? 30 : 3
+	force = wielded ? 33 : 3
 	w_class = wielded ? 5 : 2
 	sharpness_flags = wielded ? SHARP_TIP | SHARP_BLADE | INSULATED_EDGE | HOT_EDGE | CHOPWOOD | CUT_WALL | CUT_AIRLOCK : 0
 	sharpness = wielded ? 1.5 : 0


### PR DESCRIPTION
It has zero advantages over a regular energy sword, they have the same damage too, with the only difference that a wielded dual esword counts as having 2 shields, aka 2 separate 50% chance to block, which isn't a worthwhile investment for 8 TC. With 33 damage it allows the double e-sword to put someone down in 3 hits compared to the energy sword's 4.

Remember that e-swords are typically paired with the mini energy crossbow, which costs 4 TC more than an e-sword but is a far, far more useful weapon as it gives you plenty of time to kill someone with your energy sword.

:cl:
 * tweak: The double energy sword (which you get by combining two energy swords) deals more damage, enough to noticeably kill faster than the energy sword.