### PR TITLE
Fixed a bug where offhanded weapons with shields didn't actually count as having an additional shield

### DIFF
--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -79,7 +79,7 @@
 
 /mob/living/carbon/proc/check_shields(var/damage = 0, var/atom/A)
 	if(!incapacitated())
-		for(var/obj/item/weapon/I in held_items)
+		for(var/obj/item/I in held_items)
 			if(I.IsShield() && I.on_block(damage, A))
 				return 1
 


### PR DESCRIPTION
This bug came as a result of the "count the items in your hands and roll the check for each" code searching for /obj/item/weapon rather than /obj/item, which caused it to skip over obj/item/offhand. Wielded weapons with blocking properties should now properly block as much as they should again.

:cl:
 * bugfix: Fixed a NEARLY SEVEN YEAR OLD BUG where the offhand that comes from wielding weapons that you can block with was not counting as a shield itself.