### PR TITLE
Fix palette color mixing

### DIFF
--- a/code/modules/html_interface/paintTool/paintTool.js
+++ b/code/modules/html_interface/paintTool/paintTool.js
@@ -50,19 +50,11 @@
  * If you'd rather forego this, you may use 'paint_color = "#ffaa22";' instead, at your own peril.
  *
  *
- * --- setStrength() ---
+ * --- setOpacity() ---
  *
  * Updates the tool strenght to that of the 'Tool Strenght' input, sanitizing it's value in the process. Turns
  *  NaNs to 0, rounds the value to the second decimal and clamps it to the min. and max. values.
  * Useful if you wish to let the user modify the strength directly.
- *
- *
- * --- changeStrength(diff) ---
- *
- * Modifies the tool strenght by 'diff', sanitizes the result and updates the value of the 'Tool Strenght' input.
- * 'diff' should be no lower than 0.01, any values lower than that will end up ignored once the result's sanitized.
- * Useful if placing buttons to increase/decrease the tool strenght, rather than modifying it directly.
- *
  *
  * --- hexToRgba(hex), rgbaToHex(r, g, b) ---
  *

--- a/code/modules/painting/palette.dm
+++ b/code/modules/painting/palette.dm
@@ -134,7 +134,6 @@ interactions:
 				if (!PB.paint_color)
 					PB.paint_color = colour.base_color
 					to_chat(usr, "<span class='notice'>You apply the color to \the [PB].</span>")
-					PB.update_icon()
 				else
 					to_chat(usr, "<span class='notice'>You start mixing colours...</span>")
 					var/strengh = input("How much do you want to mix the colours? 0.5 is for an even mixing. Values toward 0 get a stronger shade of the colour in the palette, value toward 1 get a stronger shade of the colour in the pencil.", "Strenght of mixing", 0.5) as null|num
@@ -146,6 +145,7 @@ interactions:
 					colour.palette = list(blend_rgb)
 					colour.base_color = blend_rgb
 					PB.paint_color = blend_rgb
+				PB.update_icon()
 			if ("duplicate")
 				var/datum/painting_utensil/PU_new = colour.duplicate()
 				stored_colours += PU_new
@@ -192,15 +192,20 @@ interactions:
 	ryb["b"] = (tmpRgb[3] + tmpRgb[2] - min(tmpRgb[1], tmpRgb[2]))/2
 
 	// Normalize
-	var/n = max(ryb["r"], ryb["y"], ryb["b"])/max(tmpRgb[1], tmpRgb[2], tmpRgb[3])
-	if (n > 0.000001) // Should be zero, but floating point error could be an issue
-		ryb["r"] /= n;
-		ryb["y"] /= n;
-		ryb["b"] /= n;
-
+	var/tmpMax = max(tmpRgb[1], tmpRgb[2], tmpRgb[3])
+	if (tmpMax > 0) // Avoid division by zero
+		var/n = max(ryb["r"], ryb["y"], ryb["b"])/tmpMax
+		if (n > 0.000001) // Should be zero, but floating point error could be an issue
+			ryb["r"] /= n;
+			ryb["y"] /= n;
+			ryb["b"] /= n;
+	else
+		ryb["r"] = 0;
+		ryb["y"] = 0;
+		ryb["b"] = 0;
 
 	// Add black component, and round floating point errors
-	i = min(255 - rgb["r"], 255 - rgb["g"], 255 - rgb["b"])
+	i = min(255 - rgb[1], 255 - rgb[2], 255 - rgb[3])
 	ryb["r"] = round(ryb["r"] + i)
 	ryb["y"] = round(ryb["y"] + i)
 	ryb["b"] = round(ryb["b"] + i)
@@ -232,14 +237,20 @@ interactions:
 	 */
 
 	// Normalize
-	var/n = max(rgb[1], rgb[2], rgb[3])/max(tmpRyb["r"], tmpRyb["y"], tmpRyb["b"])
-	if (n > 0.000001) // Should be zero, but floating point error could be an issue
-		rgb[1] /= n;
-		rgb[2] /= n;
-		rgb[3] /= n;
+	var/tmpMax = max(tmpRyb["r"], tmpRyb["y"], tmpRyb["b"])
+	if (tmpMax > 0) // Avoid division by zero
+		var/n = max(rgb[1], rgb[2], rgb[3])/max(tmpRyb["r"], tmpRyb["y"], tmpRyb["b"])
+		if (n > 0.000001) // Should be zero, but floating point error could be an issue
+			rgb[1] /= n;
+			rgb[2] /= n;
+			rgb[3] /= n;
+	else
+		rgb[1] = 0;
+		rgb[2] = 0;
+		rgb[3] = 0;
 
 	// Add white component, and round floating point errors
-	i = max(0, min(255 - ryb["r"], 255 - ryb["y"], 255 - ryb["b"]))
+	i = min(255 - ryb["r"], 255 - ryb["y"], 255 - ryb["b"])
 	rgb[1] = round(rgb[1] + i)
 	rgb[2] = round(rgb[2] + i)
 	rgb[3] = round(rgb[3] + i)


### PR DESCRIPTION
Fixes palette color mixing and makes brushes update their icon on color change properly after mixing.
Actually closes  #31628 this time.
[bugfix]
:cl:
 * bugfix: Fixes color palettes sometimes not responding to color mixing.