### PR TITLE
Evidence forgers can now scan computer record data

### DIFF
--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -142,16 +142,31 @@
 
 
 /obj/machinery/computer/med_data/attackby(var/obj/item/O, var/mob/living/user)
-	if (istype(user) && authenticated && istype(O, /obj/item/weapon/photo/id) && (screen == 4.0) && active1)
-		var/obj/item/weapon/photo/id/photo_id = O
-		if (photo_id.four_sides)
-			if (alert("Do you want to update the records with this ID photo?",,"Yes","No") == "Yes")
-				if (user && !user.incapacitated() && Adjacent(user) && photo_id && (photo_id == user.get_active_hand()) && authenticated && (screen == 4.0) && active1)
-					active1.fields["photo"] = photo_id.four_sides
-					visible_message("<span class='notice'>[bicon(src)] Database updated.</span>")
-					playsound(src, 'sound/machines/twobeep.ogg', 50, 0)
-					updateUsrDialog()
-
+	if (istype(user) && authenticated && (screen == 4.0) && active1)
+		if(istype(O, /obj/item/weapon/photo/id))
+			var/obj/item/weapon/photo/id/photo_id = O
+			if (photo_id.four_sides)
+				if (alert("Do you want to update the records with this ID photo?",,"Yes","No") == "Yes")
+					if (user && !user.incapacitated() && Adjacent(user) && photo_id && (photo_id == user.get_active_hand()) && authenticated && (screen == 4.0) && active1)
+						active1.fields["photo"] = photo_id.four_sides
+						visible_message("<span class='notice'>[bicon(src)] Database updated.</span>")
+						playsound(src, 'sound/machines/twobeep.ogg', 50, 0)
+						updateUsrDialog()
+		if(istype(O,/obj/item/device/detective_scanner/forger))
+			var/obj/item/device/detective_scanner/forger/F = O
+			if(active1.fields["fingerprint"])
+				var/list/customprints = list()
+				var/print = active1.fields["fingerprint"]
+				to_chat(user,"<span class='notice'>You scan the fingerprints from the active record and add them to the custom fingerprints.</span>")
+				customprints[print] = print
+				F.custom_forgery[1] = customprints ? customprints.Copy() : null
+			if(active2 && active2.fields["b_dna"] && active2.fields["b_type"])
+				var/list/customblood = list()
+				var/blood = active2.fields["b_dna"]
+				var/bloodtype = active2.fields["b_type"]
+				to_chat(user,"<span class='notice'>You scan the blood type and DNA from the active record and add them to the custom blood data.</span>")
+				customblood[blood] = bloodtype
+				F.custom_forgery[3] = customblood ? customblood.Copy() : null
 	..()
 
 /obj/machinery/computer/med_data/proc/pathogen_dat(var/datum/data/record/v)

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -157,14 +157,14 @@
 			if(active1.fields["fingerprint"])
 				var/list/customprints = list()
 				var/print = active1.fields["fingerprint"]
-				to_chat(user,"<span class='notice'>You scan the fingerprints from the active record and add them to the custom fingerprints.</span>")
+				to_chat(user,"<span class='notice'>You scan the fingerprints from the active record and add them to the custom fingerprints. It will be tied to the next applicable scanned item.</span>")
 				customprints[print] = print
 				F.custom_forgery[1] = customprints ? customprints.Copy() : null
 			if(active2 && active2.fields["b_dna"] && active2.fields["b_type"])
 				var/list/customblood = list()
 				var/blood = active2.fields["b_dna"]
 				var/bloodtype = active2.fields["b_type"]
-				to_chat(user,"<span class='notice'>You scan the blood type and DNA from the active record and add them to the custom blood data.</span>")
+				to_chat(user,"<span class='notice'>You scan the blood type and DNA from the active record and add them to the custom blood data. It will be tied to the next applicable scanned item.</span>")
 				customblood[blood] = bloodtype
 				F.custom_forgery[3] = customblood ? customblood.Copy() : null
 	..()

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -43,7 +43,7 @@
 			if(active1.fields["fingerprint"])
 				var/list/customprints = list()
 				var/print = active1.fields["fingerprint"]
-				to_chat(user,"<span class='notice'>You scan the fingerprints from the active record and add them to the custom fingerprints.</span>")
+				to_chat(user,"<span class='notice'>You scan the fingerprints from the active record and add them to the custom fingerprints. will be tied to the next applicable scanned item.</span>")
 				customprints[print] = print
 				F.custom_forgery[1] = customprints ? customprints.Copy() : null
 	..()

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -28,15 +28,24 @@
 		if(usr.drop_item(O, src))
 			scan = O
 			to_chat(user, "You insert \the [O].")
-	if (istype(user) && authenticated && istype(O, /obj/item/weapon/photo/id) && (screen == 3.0) && active1)
-		var/obj/item/weapon/photo/id/photo_id = O
-		if (photo_id.four_sides)
-			if (alert("Do you want to update the records with this ID photo?",,"Yes","No") == "Yes")
-				if (user && !user.incapacitated() && Adjacent(user) && photo_id && (photo_id == user.get_active_hand()) && authenticated && (screen == 3.0) && active1)
-					active1.fields["photo"] = photo_id.four_sides
-					visible_message("<span class='notice'>[bicon(src)] Database updated.</span>")
-					playsound(src, 'sound/machines/twobeep.ogg', 50, 0)
-					updateUsrDialog()
+	if (istype(user) && authenticated && (screen == 3.0) && active1)
+		if(istype(O, /obj/item/weapon/photo/id))
+			var/obj/item/weapon/photo/id/photo_id = O
+			if (photo_id.four_sides)
+				if (alert("Do you want to update the records with this ID photo?",,"Yes","No") == "Yes")
+					if (user && !user.incapacitated() && Adjacent(user) && photo_id && (photo_id == user.get_active_hand()) && authenticated && (screen == 3.0) && active1)
+						active1.fields["photo"] = photo_id.four_sides
+						visible_message("<span class='notice'>[bicon(src)] Database updated.</span>")
+						playsound(src, 'sound/machines/twobeep.ogg', 50, 0)
+						updateUsrDialog()
+		if(istype(O,/obj/item/device/detective_scanner/forger))
+			var/obj/item/device/detective_scanner/forger/F = O
+			if(active1.fields["fingerprint"])
+				var/list/customprints = list()
+				var/print = active1.fields["fingerprint"]
+				to_chat(user,"<span class='notice'>You scan the fingerprints from the active record and add them to the custom fingerprints.</span>")
+				customprints[print] = print
+				F.custom_forgery[1] = customprints ? customprints.Copy() : null
 	..()
 
 /obj/machinery/computer/secure_data/attack_ai(mob/user as mob)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -43,7 +43,7 @@
 			if(active1.fields["fingerprint"])
 				var/list/customprints = list()
 				var/print = active1.fields["fingerprint"]
-				to_chat(user,"<span class='notice'>You scan the fingerprints from the active record and add them to the custom fingerprints. will be tied to the next applicable scanned item.</span>")
+				to_chat(user,"<span class='notice'>You scan the fingerprints from the active record and add them to the custom fingerprints. It will be tied to the next applicable scanned item.</span>")
 				customprints[print] = print
 				F.custom_forgery[1] = customprints ? customprints.Copy() : null
 	..()

--- a/code/modules/detectivework/detective_scanner.dm
+++ b/code/modules/detectivework/detective_scanner.dm
@@ -279,6 +279,14 @@
 
 //shameless copy pasting
 /obj/item/device/detective_scanner/forger/afterattack(atom/A as obj|turf|area, mob/user as mob)
+	if(istype(A,/obj/machinery/computer/secure_data))
+		var/obj/machinery/computer/secure_data/SD = A
+		if (istype(user) && SD.authenticated && (SD.screen == 3.0) && SD.active1)
+			return //already grabbing info from this screen, don't do anything
+	if(istype(A,/obj/machinery/computer/med_data))
+		var/obj/machinery/computer/med_data/MD = A
+		if (istype(user) && MD.authenticated && (MD.screen == 4.0) && MD.active1)
+			return //already grabbing info from this screen, don't do anything
 	var/list/custom_finger = list()
 	var/list/custom_fiber = list()
 	var/list/custom_blood = list()


### PR DESCRIPTION
[content][qol]
Requires clicking on computer with screen open, much like updating the photo ID, saves manually typing it out or copy/pasting.

:cl:
 * rscadd: Evidence forgers can now scan fingerprint and blood DNA data from a security or medical records computer with a given record open and on screen, adding it to the custom forgery data.