### PR TITLE
Make palettes open only if used in hand, rather than when picked up.

### DIFF
--- a/code/modules/painting/palette.dm
+++ b/code/modules/painting/palette.dm
@@ -71,10 +71,6 @@ interactions:
 	// Paint stuff
 	var/list/datum/painting_utensil/stored_colours = list()
 
-/obj/item/weapon/palette/attack_hand(mob/user)
-	. = ..()
-	ui_interact(user)
-
 /obj/item/weapon/palette/attack_self(mob/user)
 	. = ..()
 	ui_interact(user)


### PR DESCRIPTION
Closes #31660
[tweak]
:cl:
 * tweak: Palette window will now only open if you use the palette in hand, rather than every time you pick it up.