### PR TITLE
Dragonshell Buff

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -683,6 +683,7 @@
 	bounce_sound = null
 	custom_impact = 1
 	penetration_message = 0
+	var/effect_type = /obj/effect/fire_blast
 	var/has_O2_in_mix = 0
 	var/datum/gas_mixture/gas_jet = null
 	var/max_range = 10
@@ -775,7 +776,7 @@
 	var/initial_burn_damage = burn_strength/100
 	burn_damage = ((((-(10 * (0.9**((initial_burn_damage/10) * 5))) + 10) * 0.4) * 20)/5) //Exponential decay function 20*(y=(-(10*(0.9^(x/10)))+10)*0.4)
 	//assuming the target stays in the fire for its duration, the total burn damage will be roughly 5 * burn_damage
-	new /obj/effect/fire_blast(get_turf(src.loc), burn_damage, stepped_range, 1, jet_pressure, burn_strength)
+	new effect_type(get_turf(src.loc), burn_damage, stepped_range, 1, jet_pressure, burn_strength, 1 SECONDS, firer.loc)
 
 /obj/item/projectile/bullet/fire_plume/process_step()
 	..()
@@ -804,6 +805,7 @@
 	burn_damage = 10
 	jet_pressure = 0
 	gas_jet = null
+	effect_type = /obj/effect/fire_blast/dragonbreath
 
 /obj/item/projectile/bullet/fire_plume/dragonsbreath/New()
 	..()

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -383,7 +383,7 @@
 	desc = "A 12 gauge shell filled with an incendiary mixture, for lighting up dark areas or setting things on fire."
 	id = "dragonshell"
 	build_type = AMMOLATHE
-	materials = list(MAT_IRON = 500, MAT_PLASMA = 2000)
+	materials = list(MAT_IRON = 500, MAT_PLASMA = 500)
 	build_path = /obj/item/ammo_casing/shotgun/dragonsbreath
 
 /datum/design/shotgun_shell/frag
@@ -496,7 +496,7 @@
 	desc = "A box of 12-gauge dragon's breath shells."
 	id = "ammo_12ga_flare"
 	build_type = AMMOLATHE
-	materials = list(MAT_IRON = 8000, MAT_PLASMA = 32000)
+	materials = list(MAT_IRON = 8000, MAT_PLASMA = 8000)
 	build_path = /obj/item/weapon/storage/box/dragonsbreathshells
 
 /datum/design/ammo_shotgun/frag


### PR DESCRIPTION
People have told me for ages these are useless so what about a situational bonus?

Dragonbreath shells and boxes now cost 1/4 as much plasma to produce at the ammolathe (four sheets can now make one box instead of 16 sheets)
Dragonbreath flame plumes now disorient victims caught in the blast *very* briefly. It's only 2 ticks and it does not stack.

I tried to think about what fire is good at in real life and it's mostly spooking people and making them break ranks. Dragonshells will still be pretty garbage compared to tase'n'lase but now they embrace their status as a weapon of terror.

🆑 
* Dragonbreath shells now cost less plasma and their flame plume disorients victims very briefly.