### PR TITLE
Customisable radio channel information

### DIFF
--- a/__DEFINES/communications.dm
+++ b/__DEFINES/communications.dm
@@ -41,3 +41,6 @@ var/list/radiochannelsreverse = list()
 
 //Only the channels that someone in the main station should have access to normally.
 var/list/stationchannels = list()
+
+//For custom stuff
+var/list/freqtocolor = list()

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1944,13 +1944,15 @@ Game Mode config tags:
 	"Supply" = SUP_FREQ
 	)
 
-/proc/update_radio_frequency(var/name, var/freq, var/mob/user, var/update_station = TRUE)
+/proc/update_radio_frequency(var/name, var/freq, var/color, var/mob/user, var/update_station = TRUE)
 	var/newspan = null
 	if(name in freqs)
 		newspan = freqtospan["[freqs[name]]"]
 	freqs[name] = freq
 	radiochannels[name] = freqs[name]
 	radiochannelsreverse["[freqs[name]]"] = name
+	if(color)
+		freqtocolor["[freqs[name]]"] = color
 	if(newspan)
 		freqtospan["[freqs[name]]"] = newspan
 	if(update_station)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1955,6 +1955,8 @@ Game Mode config tags:
 		freqtospan[freqs[name]] = newspan
 	if(update_station)
 		stationchannels[name] = freqs[name]
+	log_admin("freq [name] is now [freqs[name]]")
+	message_admins("freq [name] is now [freqs[name]]")
 
 /proc/getviewsize(view)
 	if(isnum(view))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1944,7 +1944,7 @@ Game Mode config tags:
 	"Supply" = SUP_FREQ
 	)
 
-/proc/update_radio_frequency(var/name, var/freq, var/update_station = TRUE)
+/proc/update_radio_frequency(var/name, var/freq, var/mob/user, var/update_station = TRUE)
 	var/newspan = null
 	if(name in freqs)
 		newspan = freqtospan["[freqs[name]]"]
@@ -1955,8 +1955,8 @@ Game Mode config tags:
 		freqtospan["[freqs[name]]"] = newspan
 	if(update_station)
 		stationchannels[name] = freqs[name]
-	log_admin("Radio frequency [name] is now [freqs[name]]")
-	message_admins("Radio frequency [name] is now [freqs[name]]")
+	log_admin("[update_station ? "World" : "Non-station"] radio frequency [name] is now [freqs[name]][user ? " set by [key_name(user)]": ""]")
+	message_admins("[update_station ? "World" : "Non-station"] radio frequency [name] is now [freqs[name]][user ? " set by [key_name(user)] ([formatJumpTo(user, "JMP")])" : ""]")
 
 /proc/getviewsize(view)
 	if(isnum(view))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1944,6 +1944,18 @@ Game Mode config tags:
 	"Supply" = SUP_FREQ
 	)
 
+/proc/update_radio_frequency(var/name, var/freq, var/update_station = TRUE)
+	var/newspan = null
+	if(name in freqs)
+		newspan = freqtospan[freqs[name]]
+	freqs[name] = freq
+	radiochannels[name] = freqs[name]
+	radiochannelsreverse[freqs[name]] = name
+	if(newspan)
+		freqtospan[freqs[name]] = newspan
+	if(update_station)
+		stationchannels[name] = freqs[name]
+
 /proc/getviewsize(view)
 	if(isnum(view))
 		var/totalviewrange = (view < 0 ? -1 : 1) + 2 * view

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1958,7 +1958,7 @@ Game Mode config tags:
 	if(update_station)
 		stationchannels[name] = freqs[name]
 	log_admin("[update_station ? "World" : "Non-station"] radio frequency [name] is now [freqs[name]][user ? " set by [key_name(user)]": ""]")
-	message_admins("[update_station ? "World" : "Non-station"] radio frequency [name] is now [freqs[name]][user ? " set by [key_name(user)] ([formatJumpTo(user, "JMP")])" : ""]")
+	message_admins("[update_station ? "World" : "Non-station"] radio frequency [color ? "<font color=[freqtocolor["[freqs[name]]"]]>" : ""][name][color ? "</font color>" : ""] is now [freqs[name]][user ? " set by [key_name(user)] ([formatJumpTo(user, "JMP")])" : ""]")
 
 /proc/getviewsize(view)
 	if(isnum(view))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1880,7 +1880,7 @@ Game Mode config tags:
 				continue
 			taken_freqs.Add(chosen_freq)
 			freqs[i] = chosen_freq
-			world.log << "freq [i] is now [chosen_freq]"
+			world.log << "Radio frequency [i] is now [chosen_freq]"
 			freq_found = TRUE
 
 	freqtospan = list(
@@ -1947,16 +1947,16 @@ Game Mode config tags:
 /proc/update_radio_frequency(var/name, var/freq, var/update_station = TRUE)
 	var/newspan = null
 	if(name in freqs)
-		newspan = freqtospan[freqs[name]]
+		newspan = freqtospan["[freqs[name]]"]
 	freqs[name] = freq
 	radiochannels[name] = freqs[name]
-	radiochannelsreverse[freqs[name]] = name
+	radiochannelsreverse["[freqs[name]]"] = name
 	if(newspan)
-		freqtospan[freqs[name]] = newspan
+		freqtospan["[freqs[name]]"] = newspan
 	if(update_station)
 		stationchannels[name] = freqs[name]
-	log_admin("freq [name] is now [freqs[name]]")
-	message_admins("freq [name] is now [freqs[name]]")
+	log_admin("Radio frequency [name] is now [freqs[name]]")
+	message_admins("Radio frequency [name] is now [freqs[name]]")
 
 /proc/getviewsize(view)
 	if(isnum(view))

--- a/code/datums/saycode/speech.dm
+++ b/code/datums/saycode/speech.dm
@@ -16,7 +16,6 @@
 	var/list/wrapper_classes=list("game","say")
 	// Custom channel stuff
 	var/freq_color_override = null
-	var/freq_name_override = null
 
 	var/mode = SPEECH_MODE_SAY
 
@@ -52,7 +51,6 @@
 	clone.message_classes=message_classes.Copy()
 	clone.wrapper_classes=wrapper_classes.Copy()
 	clone.freq_color_override = freq_color_override
-	clone.freq_name_override = freq_name_override
 	return clone
 
 /datum/speech/proc/scramble()
@@ -132,7 +130,6 @@
 	signal.data["r_quote"]  = rquote
 	signal.data["l_quote"]  = lquote
 
-	signal.data["freq_name_override"] = freq_name_override
 	signal.data["freq_color_override"] = freq_color_override
 
 	signal.frequency = frequency // Quick frequency set
@@ -164,7 +161,6 @@
 
 	wrapper_classes.Add("radio")
 
-	freq_name_override = signal.data["freq_name_override"]
 	freq_color_override = signal.data["freq_color_override"]
 
 /datum/speech/proc/set_language(var/lang_id)

--- a/code/datums/saycode/speech.dm
+++ b/code/datums/saycode/speech.dm
@@ -14,6 +14,9 @@
 	var/list/message_classes=list("message")
 	// CSS classes for the wrapper span
 	var/list/wrapper_classes=list("game","say")
+	// Custom channel stuff
+	var/freq_color_override = null
+	var/freq_name_override = null
 
 	var/mode = SPEECH_MODE_SAY
 
@@ -48,6 +51,8 @@
 
 	clone.message_classes=message_classes.Copy()
 	clone.wrapper_classes=wrapper_classes.Copy()
+	clone.freq_color_override = freq_color_override
+	clone.freq_name_override = freq_name_override
 	return clone
 
 /datum/speech/proc/scramble()
@@ -127,6 +132,9 @@
 	signal.data["r_quote"]  = rquote
 	signal.data["l_quote"]  = lquote
 
+	signal.data["freq_name_override"] = freq_name_override
+	signal.data["freq_color_override"] = freq_color_override
+
 	signal.frequency = frequency // Quick frequency set
 	return signal
 
@@ -155,6 +163,9 @@
 		wrapper_classes=data.Copy()
 
 	wrapper_classes.Add("radio")
+
+	freq_name_override = signal.data["freq_name_override"]
+	freq_color_override = signal.data["freq_color_override"]
 
 /datum/speech/proc/set_language(var/lang_id)
 	language = all_languages[lang_id]

--- a/code/datums/saycode/speech.dm
+++ b/code/datums/saycode/speech.dm
@@ -14,8 +14,6 @@
 	var/list/message_classes=list("message")
 	// CSS classes for the wrapper span
 	var/list/wrapper_classes=list("game","say")
-	// Custom channel stuff
-	var/freq_color_override = null
 
 	var/mode = SPEECH_MODE_SAY
 
@@ -50,7 +48,6 @@
 
 	clone.message_classes=message_classes.Copy()
 	clone.wrapper_classes=wrapper_classes.Copy()
-	clone.freq_color_override = freq_color_override
 	return clone
 
 /datum/speech/proc/scramble()
@@ -130,8 +127,6 @@
 	signal.data["r_quote"]  = rquote
 	signal.data["l_quote"]  = lquote
 
-	signal.data["freq_color_override"] = freq_color_override
-
 	signal.frequency = frequency // Quick frequency set
 	return signal
 
@@ -160,8 +155,6 @@
 		wrapper_classes=data.Copy()
 
 	wrapper_classes.Add("radio")
-
-	freq_color_override = signal.data["freq_color_override"]
 
 /datum/speech/proc/set_language(var/lang_id)
 	language = all_languages[lang_id]

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -243,13 +243,13 @@
 				if(!(newfreq in freq_names))
 					freq_names.Add(newfreq)
 					temp = "<font color = #666633>-% New frequency name assigned: \"[newfreq]\" %-</font color>"
+		
+					var/newcolor = input(usr, "Specify a new frequency color. Leave blank for defaults.", src, network) as null|color
+					if(newcolor && canAccess(usr))
+						freq_names[newfreq] = newcolor
+						temp = "<font color = [newcolor]>-% New frequency color assigned. %-</font color>"
 			else
 				temp = "<font color = #666633>-% Channel name denied. %-</font color>"
-		
-			var/newcolor = input(usr, "Specify a new frequency color. Leave blank for defaults.", src, network) as null|color
-			if(newcolor && canAccess(usr))
-				freq_names[newfreq] = newcolor
-				temp = "<font color = [newcolor]>-% New frequency color assigned. %-</font color>"
 
 /obj/machinery/telecomms/Topic(href, href_list)
 	if(..())

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -220,7 +220,7 @@
 	if(length(freq_names))
 		dat += "<ul>"
 		for(var/x in freq_names)
-			dat += "<li>[x]<a href='?src=\ref[src];delete_name=[x]'>\[X\]</a></li>"
+			dat += "<li><font color = [freq_names[x]]>[x]</font color><a href='?src=\ref[src];delete_name=[x]'>\[X\]</a></li>"
 		dat += "</ul>"
 	else
 		dat += "<li>NONE</li>"

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -214,6 +214,37 @@
 				change_frequency = 0
 				temp = "<font color = #666633>-% Frequency changing deactivated %-</font color>"
 
+/obj/machinery/telecomms/server/Options_Menu()
+	var/dat= {"</ol>
+			<h2>Frequency Names:</h2>"}
+	if(length(freq_names))
+		dat += "<ul>"
+		for(var/x in freq_names)
+			dat += "<li>[x]<a href='?src=\ref[src];delete_name=[x]'>\[X\]</a></li>"
+		dat += "</ul>"
+	else
+		dat += "<li>NONE</li>"
+	
+	dat += {"<p><a href='?src=\ref[src];input_name=1'>\[Add Frequency Name\]</a></p>
+			<hr />"}
+	return dat
+
+/obj/machinery/telecomms/server/Options_Topic(href, href_list)
+
+	if(href_list["delete_name"])
+		var/x = text2num(href_list["delete"])
+		temp = "<font color = #666633>-% Removed frequency name [x] %-</font color>"
+		freq_names.Remove(x)
+
+	if(href_list["input_name"])
+		var/newfreq = input(usr, "Specify a new frequency name.", src, network) as null|text
+		if(newfreq && canAccess(usr))
+			if(!(newfreq == SYND || newfreq == RAIDER || newfreq == REV_COMM))
+				if(!(newfreq in freq_names))
+					freq_names.Add(newfreq)
+					temp = "<font color = #666633>-% New frequency name assigned: \"[newfreq]\" %-</font color>"
+			else
+				temp = "<font color = #666633>-% Channel name denied. %-</font color>"
 
 /obj/machinery/telecomms/Topic(href, href_list)
 	if(..())

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -220,7 +220,7 @@
 	if(length(freq_names))
 		dat += "<ul>"
 		for(var/x in freq_names)
-			dat += "<li><font color = [freq_names[x]]>[x]</font color><a href='?src=\ref[src];delete_name=[x]'>\[X\]</a></li>"
+			dat += "<li>[freq_names[x] ? "<font color = [freq_names[x]]>" : ""][x][freq_names[x] ? "</font color>" : ""]<a href='?src=\ref[src];delete_name=[x]'>\[X\]</a></li>"
 		dat += "</ul>"
 	else
 		dat += "<li>NONE</li>"

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -245,19 +245,18 @@
 	if(href_list["input_name"])
 		var/newfreq = input(usr, "Specify a new frequency name.", src, network) as null|text
 		if(newfreq && canAccess(usr))
-			if(!(newfreq == SYND || newfreq == RAIDER || newfreq == REV_COMM))
-				if(!(newfreq in freq_names))
-					freq_names.Add(newfreq)
-					temp = "<font color = #666633>-% New frequency name assigned: \"[newfreq]\" %-</font color>"
-		
-					var/newcolor = input(usr, "Specify a new frequency color. Leave blank for defaults.", src, network) as null|color
-					if(newcolor && canAccess(usr))
-						freq_names[newfreq] = newcolor
-						temp = "<font color = [newcolor]>-% New frequency color assigned. %-</font color>"
+			if((!(newfreq == SYND || newfreq == RAIDER || newfreq == REV_COMM)) && (!(newfreq in freq_names)))
+				freq_names.Add(newfreq)
+				temp = "<font color = #666633>-% New frequency name assigned: \"[newfreq]\" %-</font color>"
+	
+				var/newcolor = input(usr, "Specify a new frequency color. Leave blank for defaults.", src, network) as null|color
+				if(newcolor && canAccess(usr))
+					freq_names[newfreq] = newcolor
+					temp = "<font color = [newcolor]>-% New frequency color assigned. %-</font color>"
 
-					var/indx = freq_names.Find(newfreq)
-					if(indx && indx <= freq_listening.len && freq_listening[indx])
-						update_radio_frequency(newfreq, freq_listening[indx], newcolor, usr)
+				var/indx = freq_names.Find(newfreq)
+				if(indx && indx <= freq_listening.len && freq_listening[indx])
+					update_radio_frequency(newfreq, freq_listening[indx], newcolor, usr)
 			else
 				temp = "<font color = #666633>-% Channel name denied. %-</font color>"
 
@@ -315,16 +314,15 @@
 				if(newfreq && canAccess(usr))
 					if(findtext(num2text(newfreq), "."))
 						newfreq *= 10 // shift the decimal one place
-					if(!(newfreq == SYND_FREQ || newfreq == RAID_FREQ || newfreq == REV_FREQ))
-						if(!(newfreq in freq_listening) && newfreq < 10000)
-							freq_listening.Add(newfreq)
-							temp = "<font color = #666633>-% New frequency filter assigned: \"[newfreq] GHz\" %-</font color>"
+					if((!(newfreq == SYND_FREQ || newfreq == RAID_FREQ || newfreq == REV_FREQ)) && (!(newfreq in freq_listening) && newfreq < 10000))
+						freq_listening.Add(newfreq)
+						temp = "<font color = #666633>-% New frequency filter assigned: \"[newfreq] GHz\" %-</font color>"
 
-							if(istype(src,/obj/machinery/telecomms/server))
-								var/obj/machinery/telecomms/server/TSM = src
-								var/indx = freq_listening.Find(newfreq)
-								if(indx && indx <= TSM.freq_names.len && TSM.freq_names[indx])
-									update_radio_frequency(TSM.freq_names[indx], newfreq, TSM.freq_names[TSM.freq_names[indx]], usr)
+						if(istype(src,/obj/machinery/telecomms/server))
+							var/obj/machinery/telecomms/server/TSM = src
+							var/indx = freq_listening.Find(newfreq)
+							if(indx && indx <= TSM.freq_names.len && TSM.freq_names[indx])
+								update_radio_frequency(TSM.freq_names[indx], newfreq, TSM.freq_names[TSM.freq_names[indx]], usr)
 					else
 						temp = "<font color = #666633>-% Encryption key denied. %-</font color>"
 

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -238,7 +238,7 @@
 /obj/machinery/telecomms/server/Options_Topic(href, href_list)
 
 	if(href_list["delete_name"])
-		var/x = text2num(href_list["delete_name"])
+		var/x = href_list["delete_name"]
 		temp = "<font color = #666633>-% Removed frequency name [x] %-</font color>"
 		freq_names.Remove(x)
 

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -257,7 +257,7 @@
 
 					var/indx = freq_names.Find(newfreq)
 					if(indx && indx <= freq_listening.len && freq_listening[indx])
-						update_radio_frequency(newfreq,freq_listening[indx])
+						update_radio_frequency(newfreq,freq_listening[indx],usr)
 			else
 				temp = "<font color = #666633>-% Channel name denied. %-</font color>"
 
@@ -324,7 +324,7 @@
 								var/obj/machinery/telecomms/server/TSM = src
 								var/indx = freq_listening.Find(newfreq)
 								if(indx && indx <= TSM.freq_names.len && TSM.freq_names[indx])
-									update_radio_frequency(TSM.freq_names[indx],newfreq)
+									update_radio_frequency(TSM.freq_names[indx],newfreq,usr)
 					else
 						temp = "<font color = #666633>-% Encryption key denied. %-</font color>"
 

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -245,6 +245,11 @@
 					temp = "<font color = #666633>-% New frequency name assigned: \"[newfreq]\" %-</font color>"
 			else
 				temp = "<font color = #666633>-% Channel name denied. %-</font color>"
+		
+			var/newcolor = input(usr, "Specify a new frequency color. Leave blank for defaults.", src, network) as null|color
+			if(newcolor && canAccess(usr))
+				freq_names[newfreq] = newcolor
+				temp = "<font color = [newcolor]>-% New frequency color assigned. %-</font color>"
 
 /obj/machinery/telecomms/Topic(href, href_list)
 	if(..())

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -256,7 +256,7 @@
 						temp = "<font color = [newcolor]>-% New frequency color assigned. %-</font color>"
 
 					var/indx = freq_names.Find(newfreq)
-					if(freq_listening[indx])
+					if(indx && indx <= freq_listening.len && freq_listening[indx])
 						update_radio_frequency(newfreq,freq_listening[indx])
 			else
 				temp = "<font color = #666633>-% Channel name denied. %-</font color>"
@@ -323,7 +323,7 @@
 							if(istype(src,/obj/machinery/telecomms/server))
 								var/obj/machinery/telecomms/server/TSM = src
 								var/indx = freq_listening.Find(newfreq)
-								if(TSM.freq_names[indx])
+								if(indx && indx <= TSM.freq_names.len && TSM.freq_names[indx])
 									update_radio_frequency(TSM.freq_names[indx],newfreq)
 					else
 						temp = "<font color = #666633>-% Encryption key denied. %-</font color>"

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -254,6 +254,10 @@
 					if(newcolor && canAccess(usr))
 						freq_names[newfreq] = newcolor
 						temp = "<font color = [newcolor]>-% New frequency color assigned. %-</font color>"
+
+					//var/indx = freq_names.Find(newfreq)
+					//if(freq_listening[indx])
+						//update_radio_frequency(newfreq,freq_listening[indx])
 			else
 				temp = "<font color = #666633>-% Channel name denied. %-</font color>"
 
@@ -315,6 +319,10 @@
 						if(!(newfreq in freq_listening) && newfreq < 10000)
 							freq_listening.Add(newfreq)
 							temp = "<font color = #666633>-% New frequency filter assigned: \"[newfreq] GHz\" %-</font color>"
+
+							//var/indx = freq_listening.Find(newfreq)
+							//if(freq_names[indx])
+								//update_radio_frequency(freq_names[indx],newfreq)
 					else
 						temp = "<font color = #666633>-% Encryption key denied. %-</font color>"
 

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -257,7 +257,7 @@
 
 					var/indx = freq_names.Find(newfreq)
 					if(indx && indx <= freq_listening.len && freq_listening[indx])
-						update_radio_frequency(newfreq,freq_listening[indx],usr)
+						update_radio_frequency(newfreq, freq_listening[indx], newcolor, usr)
 			else
 				temp = "<font color = #666633>-% Channel name denied. %-</font color>"
 
@@ -324,7 +324,7 @@
 								var/obj/machinery/telecomms/server/TSM = src
 								var/indx = freq_listening.Find(newfreq)
 								if(indx && indx <= TSM.freq_names.len && TSM.freq_names[indx])
-									update_radio_frequency(TSM.freq_names[indx],newfreq,usr)
+									update_radio_frequency(TSM.freq_names[indx], newfreq, TSM.freq_names[TSM.freq_names[indx]], usr)
 					else
 						temp = "<font color = #666633>-% Encryption key denied. %-</font color>"
 

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -238,7 +238,7 @@
 /obj/machinery/telecomms/server/Options_Topic(href, href_list)
 
 	if(href_list["delete_name"])
-		var/x = text2num(href_list["delete"])
+		var/x = text2num(href_list["delete_name"])
 		temp = "<font color = #666633>-% Removed frequency name [x] %-</font color>"
 		freq_names.Remove(x)
 

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -220,7 +220,13 @@
 	if(length(freq_names))
 		dat += "<ul>"
 		for(var/x in freq_names)
-			dat += "<li>[freq_names[x] ? "<font color = [freq_names[x]]>" : ""][x][freq_names[x] ? "</font color>" : ""]<a href='?src=\ref[src];delete_name=[x]'>\[X\]</a></li>"
+			dat += "<li>"
+			if(freq_names[x])
+				dat += "<font color = [freq_names[x]]>"
+			dat += "[x]"
+			if(freq_names[x])
+				dat += "</font color>"
+			dat += "<a href='?src=\ref[src];delete_name=[x]'>\[X\]</a></li>"
 		dat += "</ul>"
 	else
 		dat += "<li>NONE</li>"

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -255,9 +255,9 @@
 						freq_names[newfreq] = newcolor
 						temp = "<font color = [newcolor]>-% New frequency color assigned. %-</font color>"
 
-					//var/indx = freq_names.Find(newfreq)
-					//if(freq_listening[indx])
-						//update_radio_frequency(newfreq,freq_listening[indx])
+					var/indx = freq_names.Find(newfreq)
+					if(freq_listening[indx])
+						update_radio_frequency(newfreq,freq_listening[indx])
 			else
 				temp = "<font color = #666633>-% Channel name denied. %-</font color>"
 
@@ -320,9 +320,11 @@
 							freq_listening.Add(newfreq)
 							temp = "<font color = #666633>-% New frequency filter assigned: \"[newfreq] GHz\" %-</font color>"
 
-							//var/indx = freq_listening.Find(newfreq)
-							//if(freq_names[indx])
-								//update_radio_frequency(freq_names[indx],newfreq)
+							if(istype(src,/obj/machinery/telecomms/server))
+								var/obj/machinery/telecomms/server/TSM = src
+								var/indx = freq_listening.Find(newfreq)
+								if(TSM.freq_names[indx])
+									update_radio_frequency(TSM.freq_names[indx],newfreq)
 					else
 						temp = "<font color = #666633>-% Encryption key denied. %-</font color>"
 

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -163,7 +163,7 @@
 /obj/machinery/telecomms/server/presets/science/initialize()
 	..()
 	freq_listening = list(SCI_FREQ)
-	freq_names = list(SCIENCE)
+	freq_names = list(SCIENCE = "#993399")
 
 /obj/machinery/telecomms/server/presets/medical
 	id = "Medical Server"
@@ -172,7 +172,7 @@
 /obj/machinery/telecomms/server/presets/medical/initialize()
 	..()
 	freq_listening = list(MED_FREQ)
-	freq_names = list(MEDICAL)
+	freq_names = list(MEDICAL = "#3399CC")
 
 /obj/machinery/telecomms/server/presets/supply
 	id = "Supply Server"
@@ -181,7 +181,7 @@
 /obj/machinery/telecomms/server/presets/supply/initialize()
 	..()
 	freq_listening = list(SUP_FREQ)
-	freq_names = list(CARGO)
+	freq_names = list(CARGO = "#54F519")
 
 //Using old mining channel frequency for a service channel for the bartender, botanist and chef.
 //Also cleaned up all the references to the mining channel I could find, it most likely will never be used again anyway. - Duny
@@ -192,7 +192,7 @@
 /obj/machinery/telecomms/server/presets/service/initialize()
 	..()
 	freq_listening = list(SER_FREQ)
-	freq_names = list(SERVICE)
+	freq_names = list(SERVICE = "#A17A4E")
 
 /obj/machinery/telecomms/server/presets/common
 	id = "Common Server"
@@ -201,7 +201,7 @@
 /obj/machinery/telecomms/server/presets/common/initialize()
 	..()
 	freq_listening = list(COMMON_FREQ, AIPRIV_FREQ)	//just stick AI private frequency in there until somebody gives it its own server
-	freq_names = list(COMMON, AIPRIVATE) //ditto
+	freq_names = list(COMMON = "#008000", AIPRIVATE = "#ff00ff") //ditto
 
 	//Common and other radio frequencies for people to freely use
 	// 1441 to 1489
@@ -219,32 +219,32 @@
 /obj/machinery/telecomms/server/presets/command
 	id = "Command Server"
 	autolinkers = list("command")
-	freq_names = list(COMMAND)
 
 
 /obj/machinery/telecomms/server/presets/command/initialize()
 	..()
 	freq_listening = list(COMM_FREQ)
+	freq_names = list(COMMAND = "#193A7A")
 
 /obj/machinery/telecomms/server/presets/engineering
 	id = "Engineering Server"
 	autolinkers = list("engineering")
-	freq_names = list(ENGINEERING)
 
 
 /obj/machinery/telecomms/server/presets/engineering/initialize()
 	..()
 	freq_listening = list(ENG_FREQ)
+	freq_names = list(ENGINEERING = "#A66300")
 
 /obj/machinery/telecomms/server/presets/security
 	id = "Security Server"
 	autolinkers = list("security")
-	freq_names = list(SECURITY_COMM)
 
 
 /obj/machinery/telecomms/server/presets/security/initialize()
 	..()
 	freq_listening = list(SEC_FREQ)
+	freq_names = list(SECURITY_COMM = "#A30000")
 
 //Broadcasters
 

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -163,6 +163,7 @@
 /obj/machinery/telecomms/server/presets/science/initialize()
 	..()
 	freq_listening = list(SCI_FREQ)
+	freq_names = list(SCIENCE)
 
 /obj/machinery/telecomms/server/presets/medical
 	id = "Medical Server"
@@ -171,6 +172,7 @@
 /obj/machinery/telecomms/server/presets/medical/initialize()
 	..()
 	freq_listening = list(MED_FREQ)
+	freq_names = list(MEDICAL)
 
 /obj/machinery/telecomms/server/presets/supply
 	id = "Supply Server"
@@ -179,6 +181,7 @@
 /obj/machinery/telecomms/server/presets/supply/initialize()
 	..()
 	freq_listening = list(SUP_FREQ)
+	freq_names = list(CARGO)
 
 //Using old mining channel frequency for a service channel for the bartender, botanist and chef.
 //Also cleaned up all the references to the mining channel I could find, it most likely will never be used again anyway. - Duny
@@ -189,6 +192,7 @@
 /obj/machinery/telecomms/server/presets/service/initialize()
 	..()
 	freq_listening = list(SER_FREQ)
+	freq_names = list(SERVICE)
 
 /obj/machinery/telecomms/server/presets/common
 	id = "Common Server"
@@ -197,6 +201,8 @@
 /obj/machinery/telecomms/server/presets/common/initialize()
 	..()
 	freq_listening = list(COMMON_FREQ, AIPRIV_FREQ)	//just stick AI private frequency in there until somebody gives it its own server
+	freq_names = list(COMMON, AIPRIVATE) //ditto
+
 	//Common and other radio frequencies for people to freely use
 	// 1441 to 1489
 /obj/machinery/telecomms/server/presets/common/New()
@@ -213,6 +219,8 @@
 /obj/machinery/telecomms/server/presets/command
 	id = "Command Server"
 	autolinkers = list("command")
+	freq_names = list(COMMAND)
+
 
 /obj/machinery/telecomms/server/presets/command/initialize()
 	..()
@@ -221,6 +229,8 @@
 /obj/machinery/telecomms/server/presets/engineering
 	id = "Engineering Server"
 	autolinkers = list("engineering")
+	freq_names = list(ENGINEERING)
+
 
 /obj/machinery/telecomms/server/presets/engineering/initialize()
 	..()
@@ -229,6 +239,8 @@
 /obj/machinery/telecomms/server/presets/security
 	id = "Security Server"
 	autolinkers = list("security")
+	freq_names = list(SECURITY_COMM)
+
 
 /obj/machinery/telecomms/server/presets/security/initialize()
 	..()

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -635,6 +635,8 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	var/obj/item/device/radio/headset/server_radio = null
 	var/last_signal = 0 	// Last time it sent a signal
 
+	var/list/freq_names = list() // Names to associate each frequency with on broadcast, if any
+
 /obj/machinery/telecomms/server/New()
 	..()
 	Compiler = new()

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -681,10 +681,6 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 
 				var/datum/comm_log_entry/log = new
 				var/mob/M = signal.data["mob"]
-				var/override_index = freq_listening.Find(signal.frequency)
-				if(freq_names[freq_names[override_index]])
-					signal.data["freq_color_override"] = freq_names[freq_names[override_index]]
-					say_testing(M, "[src] relay_information freq_color_overridde [signal.data["freq_color_override"]]")
 				// Copy the signal.data entries we want
 				log.parameters["mobtype"] = signal.data["mobtype"]
 				log.parameters["job"] = signal.data["job"]

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -672,11 +672,6 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 			if(traffic > 0)
 				totaltraffic += traffic // add current traffic to total traffic
 
-			var/name_override_index = freq_listening.Find(signal.frequency)
-			if(freq_names[name_override_index])
-				signal.data["freq_name_override"] = freq_names[name_override_index]
-				if(freq_names[signal.data["freq_name_override"]])
-					signal.data["freq_color_override"] = freq_names[signal.data["freq_name_override"]]
 			//Is this a test signal? Bypass logging
 			if(signal.data["type"] != 4)
 
@@ -686,6 +681,13 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 
 				var/datum/comm_log_entry/log = new
 				var/mob/M = signal.data["mob"]
+				var/name_override_index = freq_listening.Find(signal.frequency)
+				if(freq_names[name_override_index])
+					signal.data["freq_name_override"] = freq_names[name_override_index]
+					say_testing(M, "[src] relay_information freq_name_overridde [signal.data["freq_name_override"]]")
+					if(freq_names[signal.data["freq_name_override"]])
+						signal.data["freq_color_override"] = freq_names[signal.data["freq_name_override"]]
+						say_testing(M, "[src] relay_information freq_color_overridde [signal.data["freq_color_override"]]")
 				// Copy the signal.data entries we want
 				log.parameters["mobtype"] = signal.data["mobtype"]
 				log.parameters["job"] = signal.data["job"]

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -672,6 +672,11 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 			if(traffic > 0)
 				totaltraffic += traffic // add current traffic to total traffic
 
+			var/name_override_index = freq_listening.Find(signal.frequency)
+			if(freq_names[name_override_index])
+				signal.data["freq_name_override"] = freq_names[name_override_index]
+				if(freq_names[signal.data["freq_name_override"]])
+					signal.data["freq_color_override"] = freq_names[signal.data["freq_name_override"]]
 			//Is this a test signal? Bypass logging
 			if(signal.data["type"] != 4)
 

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -681,13 +681,10 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 
 				var/datum/comm_log_entry/log = new
 				var/mob/M = signal.data["mob"]
-				var/name_override_index = freq_listening.Find(signal.frequency)
-				if(freq_names[name_override_index])
-					signal.data["freq_name_override"] = freq_names[name_override_index]
-					say_testing(M, "[src] relay_information freq_name_overridde [signal.data["freq_name_override"]]")
-					if(freq_names[signal.data["freq_name_override"]])
-						signal.data["freq_color_override"] = freq_names[signal.data["freq_name_override"]]
-						say_testing(M, "[src] relay_information freq_color_overridde [signal.data["freq_color_override"]]")
+				var/override_index = freq_listening.Find(signal.frequency)
+				if(freq_names[freq_names[override_index]])
+					signal.data["freq_color_override"] = freq_names[freq_names[override_index]]
+					say_testing(M, "[src] relay_information freq_color_overridde [signal.data["freq_color_override"]]")
 				// Copy the signal.data entries we want
 				log.parameters["mobtype"] = signal.data["mobtype"]
 				log.parameters["job"] = signal.data["job"]

--- a/code/game/machinery/telecomms/telemonitor.dm
+++ b/code/game/machinery/telecomms/telemonitor.dm
@@ -64,8 +64,11 @@
 				Selected Network Entity: [SelectedMachine.name] ([SelectedMachine.id])<br>
 				Machine Integrity: [SelectedMachine.get_integrity() < 100 ? "<font color = #D70B00><b>[SelectedMachine.get_integrity()]%</b></font color>" : "<b>100%</b>"]<br>
 				[SelectedMachine.stat & EMPED ? "<b>Local Interference Detected:</b><br>[SelectedMachine.emptime] seconds remaining <a href='?src=\ref[src];operation=boost'>\[Boost Signal\]</a><br>" : ""]
-				Filtering Frequencies: [json_encode(SelectedMachine.freq_listening)]<br>
-				Linked Entities: <ol>"}
+				Filtering Frequencies: [json_encode(SelectedMachine.freq_listening)]<br>"}
+			if(istype(SelectedMachine,/obj/machinery/telecomms/server))
+				var/obj/machinery/telecomms/server/TSM = SelectedMachine
+				dat += "Frequency Names: [json_encode(TSM.freq_names)]<br>"
+			dat += "Linked Entities: <ol>"
 			for(var/obj/machinery/telecomms/T in SelectedMachine.links)
 				if(!T.hide)
 					dat += "<li><a href='?src=\ref[src];viewmachine=[T.id]'>\ref[T.id] [T.name]</a> ([T.id])</li>"

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -102,12 +102,11 @@ var/global/lastDecTalkUse = 0
 /atom/movable/proc/render_speech(var/datum/speech/speech)
 	say_testing(src, "render_speech() - Freq: [speech.frequency], radio=\ref[speech.radio]")
 	var/freqpart = ""
+	var/colorpart
 	if(speech.frequency)
 		freqpart = " \[[get_radio_name(speech.frequency)]\]"
 		speech.wrapper_classes.Add(get_radio_span(speech.frequency))
-		var/override_color = get_radio_color(speech.frequency)
-		if(override_color)
-			speech.freq_color_override = override_color 
+		colorpart = get_radio_color(speech.frequency)
 	var/pooled=0
 	var/datum/speech/filtered_speech
 	if(speech.language)
@@ -142,17 +141,17 @@ var/global/lastDecTalkUse = 0
 	*/
 	// All this font_color spam is annoying but it's the only way to work it right.
 	. = "<span class='[filtered_speech.render_wrapper_classes()]'><span class='name'>"
-	if(filtered_speech.freq_color_override)
-		. += "<font color = [filtered_speech.freq_color_override]>"
-		say_testing(src, "render_speech() - freq_color_override = \[[filtered_speech.freq_color_override]\]")
+	if(colorpart)
+		. += "<font color = [colorpart]>"
+		say_testing(src, "render_speech() - colorpart = \[[colorpart]\]")
 	. += "[render_speaker_track_start(filtered_speech)][render_speech_name(filtered_speech)][render_speaker_track_end(filtered_speech)][freqpart][render_job(filtered_speech)]"
-	if(filtered_speech.freq_color_override)
+	if(colorpart)
 		. += "</font color>"
 	. += "</span>"
-	if(filtered_speech.freq_color_override)
-		. += "<font color = [filtered_speech.freq_color_override]>"
+	if(colorpart)
+		. += "<font color = [colorpart]>"
 	. += " [filtered_speech.render_message()]"
-	if(filtered_speech.freq_color_override)
+	if(colorpart)
 		. += "</font color>"
 	. += "</span>"
 	say_testing(src, html_encode(.))

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -138,19 +138,16 @@ var/global/lastDecTalkUse = 0
 		</span>"}
 	*/
 	// All this font_color spam is annoying but it's the only way to work it right.
-	if(filtered_speech.freq_name_override)
-		freqpart = " \[[filtered_speech.freq_name_override]\]"
-		say_testing(src, "render_speech() - freq_name_override = \[[filtered_speech.freq_name_override]\]")
 	. = "<span class='[filtered_speech.render_wrapper_classes()]'><span class='name'>"
 	if(filtered_speech.freq_color_override)
-		. += "<font color = '[filtered_speech.freq_color_override]'>"
+		. += "<font color = [filtered_speech.freq_color_override]>"
 		say_testing(src, "render_speech() - freq_color_override = \[[filtered_speech.freq_color_override]\]")
 	. += "[render_speaker_track_start(filtered_speech)][render_speech_name(filtered_speech)][render_speaker_track_end(filtered_speech)][freqpart][render_job(filtered_speech)]"
 	if(filtered_speech.freq_color_override)
 		. += "</font color>"
 	. += "</span>"
 	if(filtered_speech.freq_color_override)
-		. += "<font color = '[filtered_speech.freq_color_override]'>"
+		. += "<font color = [filtered_speech.freq_color_override]>"
 	. += " [filtered_speech.render_message()]"
 	if(filtered_speech.freq_color_override)
 		. += "</font color>"

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -139,9 +139,11 @@ var/global/lastDecTalkUse = 0
 	*/
 	if(filtered_speech.freq_name_override)
 		freqpart = " \[[filtered_speech.freq_name_override]\]"
+		say_testing(src, "render_speech() - freq_name_override = \[[filtered_speech.freq_name_override]\]")
 	. = "<span class='[filtered_speech.render_wrapper_classes()]'>"
 	if(filtered_speech.freq_color_override)
 		. += "<font color = [filtered_speech.freq_color_override]>"
+		say_testing(src, "render_speech() - freq_color_override = \[[filtered_speech.freq_color_override]\]")
 	. += "<span class='name'>[render_speaker_track_start(filtered_speech)][render_speech_name(filtered_speech)][render_speaker_track_end(filtered_speech)][freqpart][render_job(filtered_speech)]</span> [filtered_speech.render_message()]"
 	if(filtered_speech.freq_color_override)
 		. += "</font color>"

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -105,6 +105,9 @@ var/global/lastDecTalkUse = 0
 	if(speech.frequency)
 		freqpart = " \[[get_radio_name(speech.frequency)]\]"
 		speech.wrapper_classes.Add(get_radio_span(speech.frequency))
+		var/override_color = get_radio_color(speech.frequency)
+		if(override_color)
+			speech.freq_color_override = override_color 
 	var/pooled=0
 	var/datum/speech/filtered_speech
 	if(speech.language)
@@ -247,6 +250,11 @@ var/global/image/ghostimg = image("icon"='icons/mob/mob.dmi',"icon_state"="ghost
 	if(returntext)
 		return returntext
 	return "radio"
+
+/proc/get_radio_color(freq)
+	var/returntext = freqtocolor["[freq]"]
+	if(returntext)
+		return returntext
 
 /proc/get_radio_name(freq)
 	var/returntext = radiochannelsreverse["[freq]"]

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -125,7 +125,7 @@ var/global/lastDecTalkUse = 0
 	var/enc_wrapclass=jointext(filtered_speech.wrapper_classes, ", ")
 	say_testing(src, "render_speech() - wrapper_classes = \[[enc_wrapclass]\]")
 #endif
-	// Below, but formatted nicely.
+	// Below, but formatted nicely, and with the optional color override.
 	/*
 	return {"
 		<span class='[filtered_speech.render_wrapper_classes()]'>
@@ -137,7 +137,15 @@ var/global/lastDecTalkUse = 0
 			[filtered_speech.render_message()]
 		</span>"}
 	*/
-	. = "<span class='[filtered_speech.render_wrapper_classes()]'><span class='name'>[render_speaker_track_start(filtered_speech)][render_speech_name(filtered_speech)][render_speaker_track_end(filtered_speech)][freqpart][render_job(filtered_speech)]</span> [filtered_speech.render_message()]</span>"
+	if(filtered_speech.freq_name_override)
+		freqpart = " \[[filtered_speech.freq_name_override]\]"
+	. = "<span class='[filtered_speech.render_wrapper_classes()]'>"
+	if(filtered_speech.freq_color_override)
+		. += "<font color = [filtered_speech.freq_color_override]>"
+	. += "<span class='name'>[render_speaker_track_start(filtered_speech)][render_speech_name(filtered_speech)][render_speaker_track_end(filtered_speech)][freqpart][render_job(filtered_speech)]</span> [filtered_speech.render_message()]"
+	if(filtered_speech.freq_color_override)
+		. += "</font color>"
+	. += "</span>"
 	say_testing(src, html_encode(.))
 	if(pooled)
 		qdel(filtered_speech)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -137,14 +137,21 @@ var/global/lastDecTalkUse = 0
 			[filtered_speech.render_message()]
 		</span>"}
 	*/
+	// All this font_color spam is annoying but it's the only way to work it right.
 	if(filtered_speech.freq_name_override)
 		freqpart = " \[[filtered_speech.freq_name_override]\]"
 		say_testing(src, "render_speech() - freq_name_override = \[[filtered_speech.freq_name_override]\]")
-	. = "<span class='[filtered_speech.render_wrapper_classes()]'>"
+	. = "<span class='[filtered_speech.render_wrapper_classes()]'><span class='name'>"
 	if(filtered_speech.freq_color_override)
 		. += "<font color = '[filtered_speech.freq_color_override]'>"
 		say_testing(src, "render_speech() - freq_color_override = \[[filtered_speech.freq_color_override]\]")
-	. += "<span class='name'>[render_speaker_track_start(filtered_speech)][render_speech_name(filtered_speech)][render_speaker_track_end(filtered_speech)][freqpart][render_job(filtered_speech)]</span> [filtered_speech.render_message()]"
+	. += "[render_speaker_track_start(filtered_speech)][render_speech_name(filtered_speech)][render_speaker_track_end(filtered_speech)][freqpart][render_job(filtered_speech)]"
+	if(filtered_speech.freq_color_override)
+		. += "</font color>"
+	. += "</span>"
+	if(filtered_speech.freq_color_override)
+		. += "<font color = '[filtered_speech.freq_color_override]'>"
+	. += " [filtered_speech.render_message()]"
 	if(filtered_speech.freq_color_override)
 		. += "</font color>"
 	. += "</span>"

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -142,7 +142,7 @@ var/global/lastDecTalkUse = 0
 		say_testing(src, "render_speech() - freq_name_override = \[[filtered_speech.freq_name_override]\]")
 	. = "<span class='[filtered_speech.render_wrapper_classes()]'>"
 	if(filtered_speech.freq_color_override)
-		. += "<font color = [filtered_speech.freq_color_override]>"
+		. += "<font color = '[filtered_speech.freq_color_override]'>"
 		say_testing(src, "render_speech() - freq_color_override = \[[filtered_speech.freq_color_override]\]")
 	. += "<span class='name'>[render_speaker_track_start(filtered_speech)][render_speech_name(filtered_speech)][render_speaker_track_end(filtered_speech)][freqpart][render_job(filtered_speech)]</span> [filtered_speech.render_message()]"
 	if(filtered_speech.freq_color_override)


### PR DESCRIPTION
[content][system]
![image](https://user-images.githubusercontent.com/57303506/146487036-02c7016d-ec1c-4674-abf1-704880b2cfaa.png)
![image](https://user-images.githubusercontent.com/57303506/146615123-9cf45892-6797-4bb1-87e1-20ddabab6ce4.png)
![image](https://user-images.githubusercontent.com/57303506/146593221-a939dfc9-e45e-487f-acef-2d774a89de9e.png)
![image](https://user-images.githubusercontent.com/57303506/146644073-e251172a-8143-49d7-b0eb-0452af39d38f.png)

List of things to get working:
- [x] Custom names.
- [x] Custom colours.
- [x] Editing default channel frequencies.
- [x] Editing default channel names.
- [x] Editing default channel colours.

:cl:
 * rscadd: All telecommunication servers now have a list of frequency names and optional colours in their settings that can be edited with a multitool, corresponding in the order of the received frequency list, for customisable radio channel information.