### PR TITLE
Increases minimum amount of challenger candidates from 2 to 3, made it less likely to roll during lowpop

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -57,10 +57,10 @@
 	protected_from_jobs = list("Security Officer", "Merchant", "Warden", "Head of Personnel", "Detective",
 							"Head of Security", "Captain", "Chief Engineer", "Chief Medical Officer", "Research Director", "Brig Medic")
 	restricted_from_jobs = list("AI","Cyborg","Mobile MMI")
-	required_candidates = 2
+	required_candidates = 4
 	weight = BASE_RULESET_WEIGHT
 	cost = 15
-	var/traitor_threshold = 3
+	var/traitor_threshold = 4
 	var/additional_cost = 5
 	requirements = list(10,10,10,10,10,10,10,10,10,10)
 	high_population_requirement = 15

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -62,7 +62,6 @@
 	cost = 15
 	var/traitor_threshold = 4
 	var/additional_cost = 5
-	requirements = list(10,10,10,10,10,10,10,10,10,10)
 	high_population_requirement = 15
 
 // -- Currently a copypaste of traitors. Could be fixed to be less copy & paste.

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -57,10 +57,10 @@
 	protected_from_jobs = list("Security Officer", "Merchant", "Warden", "Head of Personnel", "Detective",
 							"Head of Security", "Captain", "Chief Engineer", "Chief Medical Officer", "Research Director", "Brig Medic")
 	restricted_from_jobs = list("AI","Cyborg","Mobile MMI")
-	required_candidates = 4
+	required_candidates = 3
 	weight = BASE_RULESET_WEIGHT
 	cost = 15
-	var/traitor_threshold = 5
+	var/traitor_threshold = 4
 	var/additional_cost = 5
 	high_population_requirement = 15
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -60,7 +60,7 @@
 	required_candidates = 4
 	weight = BASE_RULESET_WEIGHT
 	cost = 15
-	var/traitor_threshold = 4
+	var/traitor_threshold = 5
 	var/additional_cost = 5
 	high_population_requirement = 15
 


### PR DESCRIPTION
"2 traitors that are tasked to kill each other" is hardly exciting, is it?

:cl:
 * tweak: The minimum amount of candidates required for the Challenger ruleset (traitors are tasked to kill each other) was increased from 2 to 3.
 * tweak: Reduced the likelihood of the Challenger traitors to roll during lowpop.