### PR TITLE
Allows newscaster censors to hide channel titles

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -43,6 +43,7 @@
 
 /datum/feed_channel
 	var/channel_name=""
+	var/backup_name = ""
 	var/list/datum/feed_message/messages = list()
 	var/locked = FALSE
 	var/author = ""
@@ -83,6 +84,7 @@
 
 /datum/feed_channel/proc/clear()
 	channel_name = ""
+	backup_name = ""
 	messages = list()
 	locked = 0
 	author = ""
@@ -445,7 +447,8 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			if(NEWSCASTER_CENSORSHIP_CHANNEL)
 
 				dat += {"<B>[viewing_channel.channel_name]: </B><FONT SIZE=1>\[ created by: <FONT COLOR='maroon'>[viewing_channel.author]</FONT> \]</FONT><BR>
-					<FONT SIZE=2><A href='?src=\ref[src];censor_channel_author=\ref[viewing_channel]'>[(viewing_channel.author=="\[REDACTED\]") ? ("Undo Author censorship") : ("Censor channel Author")]</A></FONT><HR>"}
+					<FONT SIZE=2><A href='?src=\ref[src];censor_channel_name=\ref[viewing_channel]'>[(viewing_channel.channel_name=="\[REDACTED\]") ? ("Undo Title censorship") : ("Censor channel Title")]</A>
+					<A href='?src=\ref[src];censor_channel_author=\ref[viewing_channel]'>[(viewing_channel.author=="\[REDACTED\]") ? ("Undo Author censorship") : ("Censor channel Author")]</A></FONT><HR>"}
 				if( isemptylist(viewing_channel.messages) )
 					dat+="<I>No feed messages found in channel...</I><BR>"
 				else
@@ -874,6 +877,22 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		else if(href_list["view_wanted"])
 			screen=NEWSCASTER_WANTED_SHOW
 			updateUsrDialog()
+
+		else if(href_list["censor_channel_name"])
+			if(isobserver(usr) && !canGhostWrite(usr,src,"tried to censor a channel title"))
+				to_chat(usr, "<span class='warning'>You can't do that.</span>")
+				return
+			var/datum/feed_channel/FC = locate(href_list["censor_channel_name"])
+			if(FC.is_admin_channel)
+				alert("This channel was created by a Nanotrasen Officer. You cannot censor it.","Ok")
+				return
+			if(FC.channel_name != "<B>\[REDACTED\]</B>")
+				FC.backup_name = FC.channel_name
+				FC.channel_name = "<B>\[REDACTED\]</B>"
+			else
+				FC.channel_name = FC.backup_name
+			updateUsrDialog()
+
 		else if(href_list["censor_channel_author"])
 			if(isobserver(usr) && !canGhostWrite(usr,src,"tried to censor an author"))
 				to_chat(usr, "<span class='warning'>You can't do that.</span>")


### PR DESCRIPTION
[content]
![image](https://user-images.githubusercontent.com/57303506/146651764-2e61e993-fefc-4a3c-968c-3fb7d2de4e0f.png)
![image](https://user-images.githubusercontent.com/57303506/146651804-9ecc3487-3d92-407b-86a8-2e52c86ce570.png)

Because otherwise this allows leaked etc information to be published as feed titles and otherwise unhideable.

:cl:
 * rscadd: Newscaster feed titles can now be censored too, not just their authors.