### PR TITLE
Head Fixes

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -800,7 +800,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 		for(var/implant in implants)
 			qdel(implant)
 
-		//Remove damage statuses from limb
 		src.status &= ~ORGAN_BROKEN
 		src.status &= ~ORGAN_BLEEDING
 		src.status &= ~ORGAN_SPLINTED

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -800,6 +800,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		for(var/implant in implants)
 			qdel(implant)
 
+		//Remove damage statuses from limb
 		src.status &= ~ORGAN_BROKEN
 		src.status &= ~ORGAN_BLEEDING
 		src.status &= ~ORGAN_SPLINTED
@@ -1067,9 +1068,15 @@ Note that amputating the affected organ does in fact remove the infection from t
 		src.status = organ.status
 		src.brute_dam = organ.brute_dam
 		src.burn_dam = organ.burn_dam
-		owner.internal_organs += organ.internal_organs
+
+		//Transfer any internal_organs from the organ item to the body
 		for(var/datum/organ/internal/transfer in organ.internal_organs)
-			owner.internal_organs_by_name[transfer.organ_type] += transfer
+			if(transfer) //Don't transfer null organs
+				owner.internal_organs += transfer
+		//Transfer any internal_organs (by name) from the organ item to the body
+		for(var/datum/organ/internal/transfer_by_name in organ.internal_organs)
+			if(transfer_by_name)
+				owner.internal_organs_by_name[transfer_by_name.organ_type] += transfer_by_name
 
 
 		//Process attached parts (i.e. if attaching an arm with a hand, this will process the hand)
@@ -1080,12 +1087,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 			var/datum/organ/external/OE = owner.get_organ(attached.part)
 
 			OE.attach(attached)
-
-		if(organ.organ_data && !owner.internal_organs_by_name[organ.organ_data.organ_type]) //run if the limb has organ_data, and the patient doesn't have that internal organ yet
-			owner.internal_organs_by_name[organ.organ_data.organ_type] = organ.organ_data.Copy() //patient's interal organ (of the same name) is assigned the organ_data's properties from the limb
-			owner.internal_organs += owner.internal_organs_by_name[organ.organ_data.organ_type] //patient's internal organ list has organ_data added to it
+		//If the limb we're attaching has organ_data, convert and transfer it to internal_organs (this is for the brain only)
+		if(organ.organ_data && !owner.internal_organs_by_name[organ.organ_data.organ_type]) //If the limb has organ_data, and the patient doesn't have that internal organ yet:
+			owner.internal_organs_by_name[organ.organ_data.organ_type] = organ.organ_data.Copy() //Patient's interal organ (of the same name) is assigned the organ_data's properties from the limb
+			owner.internal_organs += owner.internal_organs_by_name[organ.organ_data.organ_type] //Patient's internal organ list has organ_data added to it
 			internal_organs += owner.internal_organs_by_name[organ.organ_data.organ_type] //the limb's internal organ list has organ_data added to it
-			owner.internal_organs_by_name[organ.organ_data.organ_type].owner = owner //the patient's new organ's owner is now the patient
+			owner.internal_organs_by_name[organ.organ_data.organ_type].owner = owner //the patient's new organ has its owner set to the patient
 
 
 	else if(istype(I, /obj/item/weapon/peglimb)) //Attaching a peg limb

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1075,7 +1075,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 		//Transfer any internal_organs (by name) from the organ item to the body
 		for(var/datum/organ/internal/transfer_by_name in organ.internal_organs)
 			if(transfer_by_name)
-				owner.internal_organs_by_name[transfer_by_name.organ_type] += transfer_by_name
+				owner.internal_organs_by_name[transfer_by_name.organ_type] = transfer_by_name
+				owner.internal_organs_by_name[transfer_by_name.organ_type].owner = owner
 
 
 		//Process attached parts (i.e. if attaching an arm with a hand, this will process the hand)
@@ -1512,6 +1513,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 /datum/organ/external/head/explode()
 	owner.remove_internal_organ(owner, owner.internal_organs_by_name["brain"], src)
+	eject_eyes()
 	.=..()
 	owner.update_hair()
 

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -371,7 +371,7 @@
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] cuts off [target]'s [affected.display_name] with \the [tool].</span>", \
 	"<span class='notice'>You cut off [target]'s [affected.display_name] with \the [tool].</span>")
-	affected.open = 0
+	affected.open = 0 //Resets surgery status on limb, should prevent conflicting/phantom surgery
 	affected.droplimb(1,0)
 
 /datum/surgery_step/generic/cut_limb/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -371,6 +371,7 @@
 	var/datum/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] cuts off [target]'s [affected.display_name] with \the [tool].</span>", \
 	"<span class='notice'>You cut off [target]'s [affected.display_name] with \the [tool].</span>")
+	affected.open = 0
 	affected.droplimb(1,0)
 
 /datum/surgery_step/generic/cut_limb/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
[bugfix]
Fixes the rest of the jank I added by accident, and retains previous fixes. Also added some comments to explain what half this shit does, and some sanity so we're not passing null organs from limbs to the body. 
Lastly, fixes an issue where you would get stuck in 'Cavity/Implant surgery' if you cut off a head you're doing "normal" surgery on, and could no longer do the head reattachment surgery.

Closes #31680

:cl:
 * bugfix: Fixes dupe issue when using monkeyman heads in lieu of the original corpse's head during head reattachment surgery
 * bugfix: Exploded heads will delete eyes from the body too 
 * bugfix: You will no longer be stuck in implant/cavity surgery if the head is cut off after you've opened it surgically.