### PR TITLE
Suicide act emote and tweaks

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -40,7 +40,13 @@
 /mob/living/proc/handle_suicide_bomb_cause()
 	var/custom_message = input(src, "Enter a cause to dedicate this to, if any.", "For what cause?") as null|text
 	
+	if(custom_message)
+		return "FOR [uppertext(custom_message)]!"
+
 	var/message_say = "FOR NO RAISIN!"
+
+	if(Holiday == APRIL_FOOLS_DAY)
+		return "ALL FOR THE NOOKIE!"
 
 	if(issyndicate(src))
 		message_say = "FOR THE SYNDICATE!"
@@ -52,27 +58,27 @@
 		message_say = "FOR THE CAUSE!"
 	else if(ishuman(src))
 		var/mob/living/carbon/human/H = src
-		// faiths
-		if(H.mind.faith.name == "Islam")
-			message_say = "ALLAHU AKBAR!"
-		else if(H.mind.faith.deity_name)
-			message_say = "FOR [uppertext(H.mind.faith.deity_name)]!"
-		// jobs
-		else
-			switch(H.mind.assigned_role)
-				if("Clown")
-					message_say = "FOR THE HONKMOTHER!"
-				if("Assistant")
-					message_say = "FOR THE GREYTIDE!"
-				if("Janitor")
-					message_say = "I DO IT FOR FREE!"
-				if("Cargo Technician" || "Quartermaster")
-					message_say = "FOR CARGONIA!"
-				if("Trader")
-					message_say = "FOR THE SHOAL!"
+		if(H.mind)
+			// faiths
+			if(H.mind.faith)
+				if(H.mind.faith.name == "Islam")
+					message_say = "ALLAHU AKBAR!"
+				else if(H.mind.faith.deity_name)
+					message_say = "FOR [uppertext(H.mind.faith.deity_name)]!"
+			// jobs
+			else if (H.mind.assigned_role)
+				switch(H.mind.assigned_role)
+					if("Clown")
+						message_say = "FOR THE HONKMOTHER!"
+					if("Assistant")
+						message_say = "FOR THE GREYTIDE!"
+					if("Janitor")
+						message_say = "I DO IT FOR FREE!"
+					if("Cargo Technician" || "Quartermaster")
+						message_say = "FOR CARGONIA!"
+					if("Trader")
+						message_say = "FOR THE SHOAL!"
 
-	if(custom_message)
-		message_say = "FOR [uppertext(custom_message)]!"
 	return message_say
 
 /mob/living/carbon/attempt_suicide(forced = 0, suicide_set = 1)

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -110,31 +110,30 @@
 	if(suicide_set && mind)
 		mind.suiciding = 1
 
-	var/obj/item/held_item = get_active_hand()
+	var/list/obj/nearbystuff = list() //Check stuff in front of us
+	for(var/obj/O in get_step(loc,dir))
+		nearbystuff += O
+	while(nearbystuff.len)
+		var/obj/chosen_item = pick_n_take(nearbystuff)
+		if(attempt_object_suicide(chosen_item)) 
+			if(istype(chosen_item,/obj/item))
+				var/obj/item/I = chosen_item
+				put_in_hands(I)
+			return
+	nearbystuff = list()
+	for(var/obj/O in adjacent_atoms(src)) //Failed that, check anything around us
+		nearbystuff += O
+	while(nearbystuff.len)
+		var/obj/chosen_item = pick_n_take(nearbystuff)
+		if(attempt_object_suicide(chosen_item)) 
+			if(istype(chosen_item,/obj/item))
+				var/obj/item/I = chosen_item
+				put_in_hands(I)
+			return
+	var/obj/item/held_item = get_active_hand() //Failed that too, perform an object in-hand suicide
 	if(!held_item)
 		held_item = get_inactive_hand()
-	if(!attempt_object_suicide(held_item)) //Failed to perform a special item suicide, go for stuff in front of us
-		var/list/obj/nearbystuff = list()
-		for(var/obj/O in get_step(loc,dir))
-			nearbystuff += O
-		while(nearbystuff.len)
-			var/obj/chosen_item = pick_n_take(nearbystuff)
-			if(attempt_object_suicide(chosen_item)) 
-				if(istype(chosen_item,/obj/item))
-					var/obj/item/I = chosen_item
-					put_in_hands(I)
-				return
-		nearbystuff = list()
-		for(var/obj/O in adjacent_atoms(src)) //Failed that too, check anything around us
-			nearbystuff += O
-		while(nearbystuff.len)
-			var/obj/chosen_item = pick_n_take(nearbystuff)
-			if(attempt_object_suicide(chosen_item)) 
-				if(istype(chosen_item,/obj/item))
-					var/obj/item/I = chosen_item
-					put_in_hands(I)
-				return
-		//Failed that too, go for normal stuff
+	if(!attempt_object_suicide(held_item)) //Failed all of that, go for normal stuff
 		if(Holiday == APRIL_FOOLS_DAY)
 			visible_message("<span class='danger'>[src] stares above and sees your ugly face! It looks like \he's trying to commit suicide.</span>")
 		else

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -113,6 +113,7 @@
 	var/list/obj/nearbystuff = list() //Check stuff in front of us
 	for(var/obj/O in get_step(loc,dir))
 		nearbystuff += O
+	log_debug("Nearby stuff in front of [src]: [counted_english_list(nearbystuff)]")
 	while(nearbystuff.len)
 		var/obj/chosen_item = pick_n_take(nearbystuff)
 		if(attempt_object_suicide(chosen_item)) 
@@ -123,6 +124,7 @@
 	nearbystuff = list()
 	for(var/obj/O in adjacent_atoms(src)) //Failed that, check anything around us
 		nearbystuff += O
+	log_debug("Nearby stuff around [src]: [counted_english_list(nearbystuff)]")
 	while(nearbystuff.len)
 		var/obj/chosen_item = pick_n_take(nearbystuff)
 		if(attempt_object_suicide(chosen_item)) 
@@ -133,6 +135,7 @@
 	var/obj/item/held_item = get_active_hand() //Failed that too, perform an object in-hand suicide
 	if(!held_item)
 		held_item = get_inactive_hand()
+	log_debug("Held item by [src]: [held_item]")
 	if(!attempt_object_suicide(held_item)) //Failed all of that, go for normal stuff
 		if(Holiday == APRIL_FOOLS_DAY)
 			visible_message("<span class='danger'>[src] stares above and sees your ugly face! It looks like \he's trying to commit suicide.</span>")

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -98,6 +98,17 @@
 		user.succumb_proc(0, 1)
 	message = initial(message)
 
+/datum/emote/living/suicide
+	key = "suicide"
+	key_third_person = "suicides"
+	mob_type_blacklist_typelist = list(/mob/living/carbon/brain) // Everyone can release themselves from their mortal coil and taste sweet death
+
+/datum/emote/living/suicide/run_emote(mob/living/user, params)
+	. = ..()
+	if (. && user.stat == UNCONSCIOUS && !params)
+		user.succumb_proc(0, 1)
+		return
+	user.attempt_suicide(0, 1)
 
 /datum/emote/living/carbon/drool
 	key = "drool"

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -191,8 +191,9 @@
 	return ..()
 
 /obj/structure/reagent_dispensers/fueltank/suicide_act(var/mob/living/user)
-	var/obj/item/tool/weldingtool/welder = user.find_held_item_by_type(/obj/item/tool/weldingtool)
-	if(welder)
+	var/obj/item/tool/weldingtool/has_welder = user.find_held_item_by_type(/obj/item/tool/weldingtool)
+	if(has_welder)
+		var/obj/item/tool/weldingtool/welder = user.held_items[has_welder]
 		welder.setWelding(1)
 		if(welder.welding)
 			var/message_say = user.handle_suicide_bomb_cause()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -191,12 +191,14 @@
 	return ..()
 
 /obj/structure/reagent_dispensers/fueltank/suicide_act(var/mob/living/user)
-	var/obj/item/tool/weldingtool/has_welder = user.find_held_item_by_type(/obj/item/tool/weldingtool)
+	var/has_welder = user.find_held_item_by_type(/obj/item/tool/weldingtool)
 	if(has_welder)
 		var/obj/item/tool/weldingtool/welder = user.held_items[has_welder]
 		welder.setWelding(1)
 		if(welder.welding)
 			var/message_say = user.handle_suicide_bomb_cause()
+			if(!user.Adjacent(src))
+				return
 			to_chat(viewers(user), "<span class='danger'>[user] presses the warm lit welder against the cold body of a welding fuel tank! It looks like \he's going out with a bang!</span>")
 			user.say(message_say)
 			welder.afterattack(src,user,1)


### PR DESCRIPTION
[bugfix][qol][content]

:cl:
 * rscadd: Players can now commit suicide easier by typing "*suicide" into the chat box.
 * bugfix: Suicide acts while holding things acting on objects in front of the player should now work properly.
 * bugfix: Welderbomb suicides now work properly.
 * bugfix: Faith and job based suicide bomb lines no longer runtime.