### PR TITLE
Palette crayon fix

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -33,74 +33,74 @@ var/global/list/all_graffitis = list(
 
 /obj/item/toy/crayon/red
 	icon_state = "crayonred"
-	colour = "#DA0000"
+	mainColour = "#DA0000"
 	shadeColour = "#810C0C"
 	colourName = "red"
 
 /obj/item/toy/crayon/orange
 	icon_state = "crayonorange"
-	colour = "#FF9300"
+	mainColour = "#FF9300"
 	shadeColour = "#A55403"
 	colourName = "orange"
 
 /obj/item/toy/crayon/yellow
 	icon_state = "crayonyellow"
-	colour = "#FFF200"
+	mainColour = "#FFF200"
 	shadeColour = "#886422"
 	colourName = "yellow"
 
 /obj/item/toy/crayon/green
 	icon_state = "crayongreen"
-	colour = "#A8E61D"
+	mainColour = "#A8E61D"
 	shadeColour = "#61840F"
 	colourName = "green"
 
 /obj/item/toy/crayon/blue
 	icon_state = "crayonblue"
-	colour = "#00B7EF"
+	mainColour = "#00B7EF"
 	shadeColour = "#0082A8"
 	colourName = "blue"
 
 /obj/item/toy/crayon/purple
 	icon_state = "crayonpurple"
-	colour = "#DA00FF"
+	mainColour = "#DA00FF"
 	shadeColour = "#810CFF"
 	colourName = "purple"
 
 /obj/item/toy/crayon/black
 	icon_state = "crayonblack"
-	colour = "#222222"
+	mainColour = "#222222"
 	shadeColour = "#000000"
 	colourName = "black"
 
 /obj/item/toy/crayon/mime
 	icon_state = "crayonmime"
 	desc = "A very sad-looking crayon."
-	colour = "#FFFFFF"
+	mainColour = "#FFFFFF"
 	shadeColour = "#000000"
 	colourName = "mime"
 	uses = 0
 
 /obj/item/toy/crayon/mime/attack_self(mob/living/user as mob) //inversion
-	if(colour != "#FFFFFF" && shadeColour != "#000000")
-		colour = "#FFFFFF"
+	if(mainColour != "#FFFFFF" && shadeColour != "#000000")
+		mainColour = "#FFFFFF"
 		shadeColour = "#000000"
 		to_chat(user, "You will now draw in white and black with this crayon.")
 	else
-		colour = "#000000"
+		mainColour = "#000000"
 		shadeColour = "#FFFFFF"
 		to_chat(user, "You will now draw in black and white with this crayon.")
 	return
 
 /obj/item/toy/crayon/rainbow
 	icon_state = "crayonrainbow"
-	colour = "#FFF000"
+	mainColour = "#FFF000"
 	shadeColour = "#000FFF"
 	colourName = "rainbow"
 	uses = 0
 
 /obj/item/toy/crayon/rainbow/attack_self(mob/living/user as mob)
-	colour = input(user, "Please select the main colour.", "Crayon colour") as color
+	mainColour = input(user, "Please select the main colour.", "Crayon colour") as color
 	shadeColour = input(user, "Please select the shade colour.", "Crayon colour") as color
 	return
 
@@ -159,7 +159,7 @@ var/global/list/all_graffitis = list(
 
 				if(user.client)
 					var/image/I = image(icon = null) //Create an empty image. You can't just do "image()" for some reason, at least one argument is needed
-					I.maptext = {"<span style="color:[colour];font-size:[FONT_SIZE];font-family:'[FONT_NAME]';" valign="[alignment]">[preference]</span>"}
+					I.maptext = {"<span style="color:[mainColour];font-size:[FONT_SIZE];font-family:'[FONT_NAME]';" valign="[alignment]">[preference]</span>"}
 					I.loc = get_turf(target)
 					animate(I, alpha = 100, 10, -1)
 					animate(alpha = 255, 10, -1)
@@ -190,12 +190,12 @@ var/global/list/all_graffitis = list(
 				C.name = "written text"
 				C.desc = "\"[preference]\", written in crayon."
 
-				var/maptext_start = {"<span style="color:[colour];font-size:[FONT_SIZE];font-family:'[FONT_NAME]';" valign="[alignment]">"}
+				var/maptext_start = {"<span style="color:[mainColour];font-size:[FONT_SIZE];font-family:'[FONT_NAME]';" valign="[alignment]">"}
 				var/maptext_end = "</span>"
 				C.maptext = "[maptext_start][preference][maptext_end]"
 
 			else
-				C = new /obj/effect/decal/cleanable/crayon(target, main = colour, shade = shadeColour, type = drawtype)
+				C = new /obj/effect/decal/cleanable/crayon(target, main = mainColour, shade = shadeColour, type = drawtype)
 
 			if(target.density && (C.loc != get_turf(user))) //Drawn on a wall (while standing on a floor)
 				C.forceMove(get_turf(user))

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -537,7 +537,7 @@
 	icon_state = "crayonred"
 	w_class = W_CLASS_TINY
 	attack_verb = list("attacks", "colours", "colors")//teehee
-	var/colour = DEFAULT_BLOOD //RGB
+	var/mainColour = DEFAULT_BLOOD //RGB
 	var/shadeColour = "#220000" //RGB
 	var/uses = 30 //0 for unlimited uses
 	var/instant = 0

--- a/code/modules/html_interface/paintTool/custom_painting_datum.dm
+++ b/code/modules/html_interface/paintTool/custom_painting_datum.dm
@@ -34,9 +34,9 @@
 		var/obj/item/toy/crayon/c = held_item
 		max_strength = PENCIL_STRENGTH_MAX
 		min_strength = PENCIL_STRENGTH_MIN
-		palette += c.colour
+		palette += c.mainColour
 		palette += c.shadeColour
-		base_color = c.color
+		base_color = c.mainColour
 
 	// Painting with hair dye sprays
 	if (istype(held_item, /obj/item/weapon/hair_dye))

--- a/code/modules/html_interface/paintTool/custom_painting_datum.dm
+++ b/code/modules/html_interface/paintTool/custom_painting_datum.dm
@@ -63,6 +63,16 @@
 				palette += b.paint_color
 			base_color = b.paint_color
 
+	// Normalize palette colors
+	for (var/i = 1; i < palette.len; i++)
+		palette[i] = lowertext(palette[i])
+		if (length(palette[i]) < 9) //If missing alpha channel assume opaque
+			palette[i] += "ff"
+	// Normalize base color
+	base_color = lowertext(base_color)
+	if (length(base_color) < 9) //If missing alpha channel assume opaque
+		base_color += "ff"
+
 
 /datum/painting_utensil/proc/duplicate()
 	var/datum/painting_utensil/dupe = new(null, null)

--- a/code/modules/paperwork/paper_folded.dm
+++ b/code/modules/paperwork/paper_folded.dm
@@ -43,8 +43,8 @@
 			src.name = N
 	else if(istype(I, /obj/item/toy/crayon))
 		var/obj/item/toy/crayon/C = I
-		src.color = C.colour //doesn't work with paper hats but I haven't found a way to fix it, who will even notice anyways
-		src.unfolded.color = C.colour
+		src.color = C.mainColour //doesn't work with paper hats but I haven't found a way to fix it, who will even notice anyways
+		src.unfolded.color = C.mainColour
 	else if(I.is_hot())
 		src.ashify_item(user)
 		return

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -111,7 +111,7 @@
 		text_color = P.colour
 	else if(istype(P, /obj/item/toy/crayon))
 		var/obj/item/toy/crayon/C = P
-		text_color = C.colour
+		text_color = C.mainColour
 
 	return "<span style=\"[style];color:[text_color]\">[t]</span>"
 

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -13,16 +13,16 @@
 /obj/item/ammo_storage/magazine/attackby(var/atom/A, var/mob/user)
 	if(istype(A,/obj/item/toy/crayon))
 		var/obj/item/toy/crayon/grayon = A
-		if(colored_marking) 
+		if(colored_marking)
 			overlays -= colored_marking
 		var/image/magazine_mark = image('icons/obj/ammo.dmi', src, "[initial(icon_state)]-overlay")
 		if(has_icon(magazine_mark.icon, "[initial(icon_state)]-overlay"))
-			magazine_mark.icon += grayon.colour
-			markingcolor = grayon.colour
+			magazine_mark.icon += grayon.mainColour
+			markingcolor = grayon.mainColour
 			overlays += magazine_mark
 			colored_marking = magazine_mark
 			to_chat(user, "<span class='notice'>You add a [grayon.colourName] marking on \the [src] with \the [grayon]. </span>")
-	
+
 	if(istype(A,/obj/item/weapon/soap))
 		if(colored_marking)
 			overlays -= colored_marking


### PR DESCRIPTION
Fixes #31661, hopefully for good. 
Crayons should no longer brick palettes and prevent their window from opening due to providing a null color. Also, some colors such as those from pens (and now crayons after fixing that) were refusing to mix, fixes that too.

[bugfix]
:cl:
 * bugfix: Crayons no longer break palettes and prevent their UI from opening.