### PR TITLE
Toned down the screen shake you get from getting shot

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -15,7 +15,7 @@
 /obj/item/projectile/bullet/on_hit(var/atom/target, var/blocked = 0)
 	if (..(target, blocked))
 		var/mob/living/L = target
-		shake_camera(L, 3, 2)
+		shake_camera(L, 2, 1)
 		return 1
 	return 0
 

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -138,7 +138,7 @@
 		L.contaminate()
 		if(prob(knockdown_chance))
 			if(istype(target, /mob/living/carbon/))
-				shake_camera(L, 3, 2)
+				shake_camera(L, 2, 1)
 				L.apply_effect(2, WEAKEN)
 				to_chat(L, "<span class = 'alert'> The force of the bolt knocks you off your feet!")
 		return 1


### PR DESCRIPTION
"Here comes another bullet impact brbrbrbrbrbrbrbrbrbrbr"
Puts the screen shake of bullets and plasma bolts to more manageable levels so that the screen is still somewhat readable during the impact. Duration reduced from 300ms to 200ms and screen shake intensity reduced from 2 to 1, meaning that it will shake adjacently to the player in different directions.

:cl:
 * tweak: The screen shake from bullet and plasma bolt impacts has been toned down.