### PR TITLE
The Thing Before Christmas

### DIFF
--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -118,9 +118,6 @@
 			load_dungeon(T)
 
 /datum/map/proc/map_ruleset(var/datum/dynamic_ruleset/DR)
-	if(ispath(DR.role_category,/datum/role/changeling))
-		return FALSE
-
 	return TRUE //If false, fails Ready()
 
 /datum/map/proc/ruleset_multiplier(var/datum/dynamic_ruleset/DR)


### PR DESCRIPTION
I thought this was a good way to spice up the winter season.
While I know Ling was removed for a reason, I want you to consider that it got removed years ago. It is fair to say that the playerbase and the game changed so much since then than a "tabula rasa" might be justified.

Besides, ling had deathsting removed and its obnoxious chemical stings axxed too. (#23014)
From a QoL standpoint, the stings have been converted to spells and should be as easy to use as the vampire ones.

As a final note, it's painstaingly true that ling is the least worked over of all our antags and is in dire need of some love and new content. However, this content can only come if people experience ling first-hand and get motivated to fix it.

Worse come to worse, we remove it again lole

Merry Christmas everyone.

:cl:
- rscadd: Santa Claus is coming to town. More specifically, he's coming to Antartica. Wait, he was already here all this time? And why does he look so familiar... OH GOD HELP