### PR TITLE
Kick ATMs to Release ID

### DIFF
--- a/code/game/machinery/ATM.dm
+++ b/code/game/machinery/ATM.dm
@@ -68,6 +68,13 @@ log transactions
 		if(ticks_left_locked_down <= 0)
 			number_incorrect_tries = 0
 
+/obj/machinery/atm/kick_act(mob/living/carbon/human/H)
+	..()
+	if(atm_card && prob(50))
+		atm_card.forceMove(get_turf(src))
+		visible_message("<span class='notice'>\A [atm_card] pops out of \the [src]!</span>")
+		atm_card = null
+
 /obj/machinery/atm/attackby(obj/item/I as obj, mob/user as mob)
 	if(I.is_wrench(user))
 		user.visible_message("<span class='notice'>[user] begins to take apart the [src]!</span>", "<span class='notice'>You start to take apart the [src]</span>")


### PR DESCRIPTION
closes #21402

I have been cleaning up after WhiteHusky's debit cards for THREE YEARS.

Fixed a bug where you could no longer kick an ATM to free your card because it doesn't use the scan var anymore.

🆑 
* bugfix: You can once again kick ATMs to release your ID.