### PR TITLE
Makes sound synth and ROGANbot more customisable in varedit

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -56,10 +56,6 @@ var/list/diagnostic_hud_users = list() // list of all entities using a diagnosti
 		var/datum/emote/E = new path()
 		E.emote_list[E.key] = E
 
-	for(var/path in subtypesof(/datum/rogan_sound))
-		var/datum/rogan_sound/S = new path()
-		number2rogansound[S.number] = S
-
 /* // Uncomment to debug chemical reaction list.
 /client/verb/debug_chemical_list()
 

--- a/code/game/objects/items/devices/roganbot.dm
+++ b/code/game/objects/items/devices/roganbot.dm
@@ -6,7 +6,6 @@
 	default_volume = 35
 	var/current_phrase = "Rogan?"
 	var/emote_phrase = FALSE
-	var/default_emote = FALSE
 	var/speak_cooldown = 0.6 SECONDS
 	var/tmp/last_speak
 	var/mobsonly = TRUE //Fuck off speaker assemblies
@@ -51,11 +50,6 @@
 		"Build a wonder." = list("say"=37,"selected_sound"='sound/effects/aoe2/37 build a wonder.ogg'),
 		"Give me your extra resources." = list("say"=38,"selected_sound"='sound/effects/aoe2/38 give me your extra resources.ogg'),
 	)
-
-
-/obj/item/device/soundsynth/roganbot/New()
-	..()
-	emote_phrase = default_emote
 
 /obj/item/device/soundsynth/roganbot/Hear(var/datum/speech/speech, var/rendered_speech="")
 	set waitfor = 0 //Should be queued after the original speech completes

--- a/code/game/objects/items/devices/roganbot.dm
+++ b/code/game/objects/items/devices/roganbot.dm
@@ -3,7 +3,6 @@
 	desc = "A sound synthetizer with 38 preset phrases. To activate, say a number from 1 to 38 out loud."
 	flags = HEAR | FPRINT
 	selected_sound = 'sound/effects/aoe2/29 rogan.ogg'
-	default_shiftpitch = FALSE
 	default_volume = 35
 	var/current_phrase = "Rogan?"
 	var/emote_phrase = FALSE
@@ -75,10 +74,7 @@
 	var/list/USA = sound_list[thesoundthatwewant]
 	if(USA && USA["selected_sound"] && USA["say"])
 		current_phrase = thesoundthatwewant
-		if(USA["emote"])
-			emote_phrase = USA["emote"]
-		else
-			emote_phrase = default_emote
+		emote_phrase = USA["emote"] ? TRUE : FALSE
 
 /obj/item/device/soundsynth/roganbot/play()
 	..()

--- a/code/game/objects/items/devices/roganbot.dm
+++ b/code/game/objects/items/devices/roganbot.dm
@@ -1,226 +1,89 @@
-/obj/item/device/roganbot
+/obj/item/device/soundsynth/roganbot
 	name = "ROGANbot"
 	desc = "A sound synthetizer with 38 preset phrases. To activate, say a number from 1 to 38 out loud."
-	icon_state = "soundsynth"
-	item_state = "radio"
-	w_class = W_CLASS_TINY
 	flags = HEAR | FPRINT
+	selected_sound = 'sound/effects/aoe2/29 rogan.ogg'
+	default_shiftpitch = FALSE
+	default_volume = 35
+	var/current_phrase = "Rogan?"
+	var/emote_phrase = FALSE
+	var/default_emote = FALSE
 	var/speak_cooldown = 0.6 SECONDS
 	var/tmp/last_speak
 	var/mobsonly = TRUE //Fuck off speaker assemblies
 
-/obj/item/device/roganbot/Hear(var/datum/speech/speech, var/rendered_speech="")
+	sound_list = list(
+		"Yes." = list("say"=1,"selected_sound"='sound/effects/aoe2/01 yes.ogg'),
+		"No." = list("say"=2,"selected_sound"='sound/effects/aoe2/02 no.ogg'),
+		"Food, please." = list("say"=3,"selected_sound"='sound/effects/aoe2/03 food, please.ogg'),
+		"Wood, please." = list("say"=4,"selected_sound"='sound/effects/aoe2/04 wood, please.ogg'),
+		"Gold, please." = list("say"=5,"selected_sound"='sound/effects/aoe2/05 gold, please.ogg'),
+		"Stone, please." = list("say"=6,"selected_sound"='sound/effects/aoe2/06 stone, please.ogg'),
+		"Ahh!" = list("say"=7,"selected_sound"='sound/effects/aoe2/07 ahh.ogg'),
+		"All hail, king of the losers!" = list("say"=8,"selected_sound"='sound/effects/aoe2/08 all hail.ogg'),
+		"Oooh!" = list("say"=9,"selected_sound"='sound/effects/aoe2/09 oooh.ogg'),
+		"I'll beat you back to Age of Empires." = list("say"=10,"selected_sound"='sound/effects/aoe2/10 back to age 1.ogg'),
+		"laughs raucously." = list("say"=11,"emote"=TRUE,"selected_sound"='sound/effects/aoe2/11 herb laugh.ogg'),
+		"AHH! Being rushed!" = list("say"=12,"selected_sound"='sound/effects/aoe2/12 being rushed.ogg'),
+		"Sure, blame it on your ISP." = list("say"=13,"selected_sound"='sound/effects/aoe2/13 blame your isp.ogg'),
+		"START THE GAME ALREADY!" = list("say"=14,"selected_sound"='sound/effects/aoe2/14 start the game.ogg'),
+		"Don't point that thing at me!" = list("say"=15,"selected_sound"='sound/effects/aoe2/15 dont point that thing.ogg'),
+		"Enemy sighted." = list("say"=16,"selected_sound"='sound/effects/aoe2/16 enemy sighted.ogg'),
+		"It is good to be the King." = list("say"=17,"selected_sound"='sound/effects/aoe2/17 it is good.ogg'),
+		"Monk! I need a monk!" = list("say"=18,"selected_sound"='sound/effects/aoe2/18 i need a monk.ogg'),
+		"Long time, no siege." = list("say"=19,"selected_sound"='sound/effects/aoe2/19 long time no siege.ogg'),
+		"My granny could scrap better than that." = list("say"=20,"selected_sound"='sound/effects/aoe2/20 my granny.ogg'),
+		"Nice town. I'll take it." = list("say"=21,"selected_sound"='sound/effects/aoe2/21 nice town ill take it.ogg'),
+		"Quit touchin' me!" = list("say"=22,"selected_sound"='sound/effects/aoe2/22 quit touchin.ogg'),
+		"Raiding party!" = list("say"=23,"selected_sound"='sound/effects/aoe2/23 raiding party.ogg'),
+		"Dadgum." = list("say"=24,"selected_sound"='sound/effects/aoe2/24 dadgum.ogg'),
+		"Ehh, smite me." = list("say"=25,"selected_sound"='sound/effects/aoe2/25 smite me.ogg'),
+		"The wonder... the wonder... the... no!" = list("say"=26,"selected_sound"='sound/effects/aoe2/26 the wonder.ogg'),
+		"You played 2 hours to die like this?" = list("say"=27,"selected_sound"='sound/effects/aoe2/27 you play 2 hours.ogg'),
+		"Yeah, well, you should see the other guy." = list("say"=28,"selected_sound"='sound/effects/aoe2/28 you should see the other guy.ogg'),
+		"Rogan?" = list("say"=29,"selected_sound"='sound/effects/aoe2/29 rogan.ogg'),
+		"Wololo..." = list("say"=30,"selected_sound"='sound/effects/aoe2/30 wololo.ogg'),
+		"Attack an enemy now." = list("say"=31,"selected_sound"='sound/effects/aoe2/31 attack an enemy now.ogg'),
+		"Cease creating extra villagers." = list("say"=32,"selected_sound"='sound/effects/aoe2/32 cease creating extra villagers.ogg'),
+		"Create extra villagers." = list("say"=33,"selected_sound"='sound/effects/aoe2/33 create extra villagers.ogg'),
+		"Build a navy." = list("say"=34,"selected_sound"='sound/effects/aoe2/34 build a navy.ogg'),
+		"Stop building a navy." = list("say"=35,"selected_sound"='sound/effects/aoe2/35 stop building a navy.ogg'),
+		"Wait for my signal to attack." = list("say"=36,"selected_sound"='sound/effects/aoe2/36 wait for my signal to attack.ogg'),
+		"Build a wonder." = list("say"=37,"selected_sound"='sound/effects/aoe2/37 build a wonder.ogg'),
+		"Give me your extra resources." = list("say"=38,"selected_sound"='sound/effects/aoe2/38 give me your extra resources.ogg'),
+	)
+
+
+/obj/item/device/soundsynth/roganbot/New()
+	..()
+	emote_phrase = default_emote
+
+/obj/item/device/soundsynth/roganbot/Hear(var/datum/speech/speech, var/rendered_speech="")
 	set waitfor = 0 //Should be queued after the original speech completes
 	if(!speech.speaker || (mobsonly && !isliving(speech.speaker)))
 		return
 	if(last_speak + speak_cooldown >= world.timeofday)
 		return
-	for(var/index in number2rogansound)
-		if(speech.message == "[index]" || dd_hasprefix(speech.message, "[index] "))
-			playtaunt(number2rogansound[index])
+	for(var/phrase in sound_list)
+		var/list/USA = sound_list[phrase]
+		if(USA && USA["say"] && (speech.message == "[USA["say"]]" || dd_hasprefix(speech.message, "[USA["say"]] ")))
+			set_sound(phrase)
+			play()
 
-/obj/item/device/roganbot/proc/playtaunt(var/datum/rogan_sound/S)
-	playsound(src, S.soundfile, 35, FALSE)
-	if(S.transcript)
-		say(S.transcript)
-	else if(S.emote)
-		src.visible_message("<b>\The [src]</b> [S.emote]") //simplified from emotes.dm which is only for mobs
+/obj/item/device/soundsynth/roganbot/set_sound(var/thesoundthatwewant)
+	..()
+	var/list/USA = sound_list[thesoundthatwewant]
+	if(USA && USA["selected_sound"] && USA["say"])
+		current_phrase = thesoundthatwewant
+		if(USA["emote"])
+			emote_phrase = USA["emote"]
+		else
+			emote_phrase = default_emote
+
+/obj/item/device/soundsynth/roganbot/play()
+	..()
+	if(emote_phrase)
+		src.visible_message("<b>\The [src]</b> [current_phrase]") //simplified from emotes.dm which is only for mobs
+	else
+		say(current_phrase)
 	last_speak = world.timeofday
-
-var/global/list/number2rogansound = list() //populated by /proc/make_datum_references_lists()
-
-/datum/rogan_sound
-	var/number
-	var/transcript
-	var/emote
-	var/soundfile
-
-/datum/rogan_sound/taunt1
-	number = "1"
-	transcript = "Yes."
-	soundfile = 'sound/effects/aoe2/01 yes.ogg'
-
-/datum/rogan_sound/taunt2
-	number = "2"
-	transcript = "No."
-	soundfile = 'sound/effects/aoe2/02 no.ogg'
-
-/datum/rogan_sound/taunt3
-	number = "3"
-	transcript = "Food, please."
-	soundfile = 'sound/effects/aoe2/03 food, please.ogg'
-
-/datum/rogan_sound/taunt4
-	number = "4"
-	transcript = "Wood, please."
-	soundfile = 'sound/effects/aoe2/04 wood, please.ogg'
-
-/datum/rogan_sound/taunt5
-	number = "5"
-	transcript = "Gold, please."
-	soundfile = 'sound/effects/aoe2/05 gold, please.ogg'
-
-/datum/rogan_sound/taunt6
-	number = "6"
-	transcript = "Stone, please."
-	soundfile = 'sound/effects/aoe2/06 stone, please.ogg'
-
-/datum/rogan_sound/taunt7
-	number = "7"
-	transcript = "Ahh!"
-	soundfile = 'sound/effects/aoe2/07 ahh.ogg'
-
-/datum/rogan_sound/taunt8
-	number = "8"
-	transcript = "All hail, king of the losers!"
-	soundfile = 'sound/effects/aoe2/08 all hail.ogg'
-
-/datum/rogan_sound/taunt9
-	number = "9"
-	transcript = "Oooh!"
-	soundfile = 'sound/effects/aoe2/09 oooh.ogg'
-
-/datum/rogan_sound/taunt10
-	number = "10"
-	transcript = "I'll beat you back to Age of Empires."
-	soundfile = 'sound/effects/aoe2/10 back to age 1.ogg'
-
-/datum/rogan_sound/taunt11
-	number = "11"
-	emote = "laughs raucously."
-	soundfile = 'sound/effects/aoe2/11 herb laugh.ogg'
-
-/datum/rogan_sound/taunt12
-	number = "12"
-	transcript = "AHH! Being rushed!"
-	soundfile = 'sound/effects/aoe2/12 being rushed.ogg'
-
-/datum/rogan_sound/taunt13
-	number = "13"
-	transcript = "Sure, blame it on your ISP."
-	soundfile = 'sound/effects/aoe2/13 blame your isp.ogg'
-
-/datum/rogan_sound/taunt14
-	number = "14"
-	transcript = "START THE GAME ALREADY!"
-	soundfile = 'sound/effects/aoe2/14 start the game.ogg'
-
-/datum/rogan_sound/taunt15
-	number = "15"
-	transcript = "Don't point that thing at me!"
-	soundfile = 'sound/effects/aoe2/15 dont point that thing.ogg'
-
-/datum/rogan_sound/taunt16
-	number = "16"
-	transcript = "Enemy sighted."
-	soundfile = 'sound/effects/aoe2/16 enemy sighted.ogg'
-
-/datum/rogan_sound/taunt17
-	number = "17"
-	transcript = "It is good to be the King."
-	soundfile = 'sound/effects/aoe2/17 it is good.ogg'
-
-/datum/rogan_sound/taunt18
-	number = "18"
-	transcript = "Monk! I need a monk!"
-	soundfile = 'sound/effects/aoe2/18 i need a monk.ogg'
-
-/datum/rogan_sound/taunt19
-	number = "19"
-	transcript = "Long time, no siege."
-	soundfile = 'sound/effects/aoe2/19 long time no siege.ogg'
-
-/datum/rogan_sound/taunt20
-	number = "20"
-	transcript = "My granny could scrap better than that."
-	soundfile = 'sound/effects/aoe2/20 my granny.ogg'
-
-/datum/rogan_sound/taunt21
-	number = "21"
-	transcript = "Nice town. I'll take it."
-	soundfile = 'sound/effects/aoe2/21 nice town ill take it.ogg'
-
-/datum/rogan_sound/taunt22
-	number = "22"
-	transcript = "Quit touchin' me!"
-	soundfile = 'sound/effects/aoe2/22 quit touchin.ogg'
-
-/datum/rogan_sound/taunt23
-	number = "23"
-	transcript = "Raiding party!"
-	soundfile = 'sound/effects/aoe2/23 raiding party.ogg'
-
-/datum/rogan_sound/taunt24
-	number = "24"
-	transcript = "Dadgum."
-	soundfile = 'sound/effects/aoe2/24 dadgum.ogg'
-
-/datum/rogan_sound/taunt25
-	number = "25"
-	transcript = "Ehh, smite me."
-	soundfile = 'sound/effects/aoe2/25 smite me.ogg'
-
-/datum/rogan_sound/taunt26
-	number = "26"
-	transcript = "The wonder... the wonder... the... no!"
-	soundfile = 'sound/effects/aoe2/26 the wonder.ogg'
-
-/datum/rogan_sound/taunt27
-	number = "27"
-	transcript = "You played 2 hours to die like this?"
-	soundfile = 'sound/effects/aoe2/27 you play 2 hours.ogg'
-
-/datum/rogan_sound/taunt28
-	number = "28"
-	transcript = "Yeah, well, you should see the other guy."
-	soundfile = 'sound/effects/aoe2/28 you should see the other guy.ogg'
-
-/datum/rogan_sound/taunt29
-	number = "29"
-	transcript = "Rogan?"
-	soundfile = 'sound/effects/aoe2/29 rogan.ogg'
-
-/datum/rogan_sound/taunt30
-	number = "30"
-	transcript = "Wololo..."
-	soundfile = 'sound/effects/aoe2/30 wololo.ogg'
-
-/datum/rogan_sound/taunt31
-	number = "31"
-	transcript = "Attack an enemy now."
-	soundfile = 'sound/effects/aoe2/31 attack an enemy now.ogg'
-
-/datum/rogan_sound/taunt32
-	number = "32"
-	transcript = "Cease creating extra villagers."
-	soundfile = 'sound/effects/aoe2/32 cease creating extra villagers.ogg'
-
-/datum/rogan_sound/taunt33
-	number = "33"
-	transcript = "Create extra villagers."
-	soundfile = 'sound/effects/aoe2/33 create extra villagers.ogg'
-
-/datum/rogan_sound/taunt34
-	number = "34"
-	transcript = "Build a navy."
-	soundfile = 'sound/effects/aoe2/34 build a navy.ogg'
-
-/datum/rogan_sound/taunt35
-	number = "35"
-	transcript = "Stop building a navy."
-	soundfile = 'sound/effects/aoe2/35 stop building a navy.ogg'
-
-/datum/rogan_sound/taunt36
-	number = "36"
-	transcript = "Wait for my signal to attack."
-	soundfile = 'sound/effects/aoe2/36 wait for my signal to attack.ogg'
-
-/datum/rogan_sound/taunt37
-	number = "37"
-	transcript = "Build a wonder."
-	soundfile = 'sound/effects/aoe2/37 build a wonder.ogg'
-
-/datum/rogan_sound/taunt38
-	number = "38"
-	transcript = "Give me your extra resources."
-	soundfile = 'sound/effects/aoe2/38 give me your extra resources.ogg'

--- a/code/game/objects/items/devices/sound_synth.dm
+++ b/code/game/objects/items/devices/sound_synth.dm
@@ -61,10 +61,7 @@
 	if(assblast && assblast["selected_sound"])
 		selected_sound = assblast["selected_sound"]
 		shiftpitch = assblast["shiftpitch"] ? TRUE : FALSE
-		if(assblast["volume"])
-			volume = assblast["volume"]
-		else
-			volume = default_volume
+		volume = assblast["volume"] ? assblast["volume"] : default_volume
 
 /obj/item/device/soundsynth/attack_self(mob/user as mob)
 	if(spam_flag + 2 SECONDS < world.timeofday)

--- a/code/game/objects/items/devices/sound_synth.dm
+++ b/code/game/objects/items/devices/sound_synth.dm
@@ -8,39 +8,46 @@
 	siemens_coefficient = 1
 
 	var/tmp/spam_flag = 0 //To prevent mashing the button to cause annoyance like a huge idiot.
-	var/selected_sound = "sound/items/bikehorn.ogg"
-	var/shiftpitch = 1
+	var/selected_sound = 'sound/items/bikehorn.ogg'
+	var/shiftpitch = TRUE
+	var/default_shiftpitch = TRUE
 	var/volume = 50
+	var/default_volume = 50
 
-	var/list/sound_list = list( //How I would like to add tabbing to make this not as messy, but BYOND doesn't like that.
-	"Honk" = "selected_sound=sound/items/bikehorn.ogg&shiftpitch=1&volume=50",
-	"Applause" = "selected_sound=sound/effects/applause.ogg&shiftpitch=1&volume=65",
-	"Laughter" = "selected_sound=sound/effects/laughtrack.ogg&shiftpitch=1&volume=65",
-	"Rimshot" = "selected_sound=sound/effects/rimshot.ogg&shiftpitch=1&volume=65",
-	"Trombone" = "selected_sound=sound/misc/sadtrombone.ogg&shiftpitch=1&volume=50",
-	"Airhorn" = "selected_sound=sound/items/AirHorn.ogg&shiftpitch=1&volume=50",
-    "Alert" = "selected_sound=sound/effects/alert.ogg&shiftpitch=1&volume=50",
-    "Awooga" = "selected_sound=sound/effects/awooga.ogg&shiftpitch=1&volume=50",
-    "Boom" = "selected_sound=sound/effects/Explosion1.ogg&shiftpitch=1&volume=50",
-	"Boom from Afar" = "selected_sound=sound/effects/explosionfar.ogg&shiftpitch=1&volume=50",
-    "Bubbles" = "selected_sound=sound/effects/bubbles.ogg&shiftpitch=1&volume=50",
-    "Construction Noises" = "selected_sound=sound/items/Deconstruct.ogg&shiftpitch=1&volume=60",
-	"Countdown" = "selected_sound=sound/ambience/countdown.ogg&shiftpitch=0&volume=55",
-    "Creepy Whisper" = "selected_sound=sound/hallucinations/turn_around1.ogg&shiftpitch=1&volume=50",
-    "Ding" = "selected_sound=sound/machines/ding.ogg&shiftpitch=1&volume=50",
-    "Double Beep" = "selected_sound=sound/machines/twobeep.ogg&shiftpitch=1&volume=50",
-    "Flush" = "selected_sound=sound/machines/disposalflush.ogg&shiftpitch=1&volume=40",
-	"Kawaii" = "selected_sound=sound/AI/animes.ogg&shiftpitch=0&volume=60",
-    "Startup" = "selected_sound=sound/mecha/nominal.ogg&shiftpitch=0&volume=50",
-    "Welding Noises" = "selected_sound=sound/items/Welder.ogg&shiftpitch=1&volume=55",
-	"Quack" = "selected_sound=sound/items/quack.ogg&shiftpitch=1&volume=50",
-	"Short Slide Whistle" = "selected_sound=sound/effects/slide_whistle_short.ogg&shiftpitch=1&volume=50",
-	"Long Slide Whistle" = "selected_sound=sound/effects/slide_whistle_long.ogg&shiftpitch=1&volume=50",
-	"YEET" = "selected_sound=sound/effects/yeet.ogg&shiftpitch=1&volume=50",
-	"Time Stop" = "selected_sound=sound/effects/theworld3.ogg&shiftpitch=0&volume=80",
-	"Click" = "selected_sound=sound/effects/kirakrik.ogg&shiftpitch=0&volume=80",
-	"SPS" = "selected_sound=sound/items/fake_SPS.ogg&shiftpitch=0&volume=100"
+	var/list/sound_list = list(
+		"Honk" = list("selected_sound"='sound/items/bikehorn.ogg'),
+		"Applause" = list("selected_sound"='sound/effects/applause.ogg',"volume"=65),
+		"Laughter" = list("selected_sound"='sound/effects/laughtrack.ogg',"volume"=65),
+		"Rimshot" = list("selected_sound"='sound/effects/rimshot.ogg',"volume"=65),
+		"Trombone" = list("selected_sound"='sound/misc/sadtrombone.ogg'),
+		"Airhorn" = list("selected_sound"='sound/items/AirHorn.ogg'),
+		"Alert" = list("selected_sound"='sound/effects/alert.ogg'),
+		"Awooga" = list("selected_sound"='sound/effects/awooga.ogg'),
+		"Boom" = list("selected_sound"='sound/effects/Explosion1.ogg'),
+		"Boom from Afar" = list("selected_sound"='sound/effects/explosionfar.ogg'),
+		"Bubbles" = list("selected_sound"='sound/effects/bubbles.ogg'),
+		"Construction Noises" = list("selected_sound"='sound/items/Deconstruct.ogg',"volume"=60),
+		"Countdown" = list("selected_sound"='sound/ambience/countdown.ogg',"shiftpitch"=FALSE,"volume"=55),
+		"Creepy Whisper" = list("selected_sound"='sound/hallucinations/turn_around1.ogg'),
+		"Ding" = list("selected_sound"='sound/machines/ding.ogg'),
+		"Double Beep" = list("selected_sound"='sound/machines/twobeep.ogg'),
+		"Flush" = list("selected_sound"='sound/machines/disposalflush.ogg',"volume"=40),
+		"Kawaii" = list("selected_sound"='sound/AI/animes.ogg',"shiftpitch"=FALSE,"volume"=60),
+		"Startup" = list("selected_sound"='sound/mecha/nominal.ogg',"shiftpitch"=FALSE),
+		"Welding Noises" = list("selected_sound"='sound/items/Welder.ogg',"volume"=55),
+		"Quack" = list("selected_sound"='sound/items/quack.ogg'),
+		"Short Slide Whistle" = list("selected_sound"='sound/effects/slide_whistle_short.ogg'),
+		"Long Slide Whistle" = list("selected_sound"='sound/effects/slide_whistle_long.ogg'),
+		"YEET" = list("selected_sound"='sound/effects/yeet.ogg'),
+		"Time Stop" = list("selected_sound"='sound/effects/theworld3.ogg',"shiftpitch"=FALSE,"volume"=80),
+		"Click" = list("selected_sound"='sound/effects/kirakrik.ogg',"shiftpitch"=FALSE,"volume"=80),
+		"SPS" = list("selected_sound"='sound/items/fake_SPS.ogg',"shiftpitch"=FALSE,"volume"=100)
 	)
+
+/obj/item/device/soundsynth/New()
+	..()
+	shiftpitch = default_shiftpitch
+	volume = default_volume
 
 /obj/item/device/soundsynth/verb/pick_sound()
 	set category = "Object"
@@ -49,15 +56,28 @@
 	if(!thesoundthatwewant)
 		return
 	to_chat(usr, "Sound playback set to: [thesoundthatwewant]!")
-	var/list/assblast = params2list(sound_list[thesoundthatwewant])
-	selected_sound = assblast["selected_sound"]
-	shiftpitch = text2num(assblast["shiftpitch"])
-	volume = text2num(assblast["volume"])
+	set_sound(thesoundthatwewant)
+
+/obj/item/device/soundsynth/proc/set_sound(var/thesoundthatwewant)
+	var/list/assblast = sound_list[thesoundthatwewant]
+	if(assblast && assblast["selected_sound"])
+		selected_sound = assblast["selected_sound"]
+		if(assblast["shiftpitch"])
+			shiftpitch = assblast["shiftpitch"]
+		else
+			shiftpitch = default_shiftpitch
+		if(assblast["volume"])
+			volume = assblast["volume"]
+		else
+			volume = default_volume
 
 /obj/item/device/soundsynth/attack_self(mob/user as mob)
 	if(spam_flag + 2 SECONDS < world.timeofday)
-		playsound(src, selected_sound, volume, shiftpitch)
+		play()
 		spam_flag = world.timeofday
+
+/obj/item/device/soundsynth/proc/play()
+	playsound(src, selected_sound, volume, shiftpitch)
 
 /obj/item/device/soundsynth/attack(mob/living/M as mob, mob/living/user as mob, def_zone)
 	if(M == user)

--- a/code/game/objects/items/devices/sound_synth.dm
+++ b/code/game/objects/items/devices/sound_synth.dm
@@ -10,43 +10,41 @@
 	var/tmp/spam_flag = 0 //To prevent mashing the button to cause annoyance like a huge idiot.
 	var/selected_sound = 'sound/items/bikehorn.ogg'
 	var/shiftpitch = TRUE
-	var/default_shiftpitch = TRUE
 	var/volume = 50
 	var/default_volume = 50
 
 	var/list/sound_list = list(
-		"Honk" = list("selected_sound"='sound/items/bikehorn.ogg'),
-		"Applause" = list("selected_sound"='sound/effects/applause.ogg',"volume"=65),
-		"Laughter" = list("selected_sound"='sound/effects/laughtrack.ogg',"volume"=65),
-		"Rimshot" = list("selected_sound"='sound/effects/rimshot.ogg',"volume"=65),
-		"Trombone" = list("selected_sound"='sound/misc/sadtrombone.ogg'),
-		"Airhorn" = list("selected_sound"='sound/items/AirHorn.ogg'),
-		"Alert" = list("selected_sound"='sound/effects/alert.ogg'),
-		"Awooga" = list("selected_sound"='sound/effects/awooga.ogg'),
-		"Boom" = list("selected_sound"='sound/effects/Explosion1.ogg'),
-		"Boom from Afar" = list("selected_sound"='sound/effects/explosionfar.ogg'),
-		"Bubbles" = list("selected_sound"='sound/effects/bubbles.ogg'),
-		"Construction Noises" = list("selected_sound"='sound/items/Deconstruct.ogg',"volume"=60),
-		"Countdown" = list("selected_sound"='sound/ambience/countdown.ogg',"shiftpitch"=FALSE,"volume"=55),
-		"Creepy Whisper" = list("selected_sound"='sound/hallucinations/turn_around1.ogg'),
-		"Ding" = list("selected_sound"='sound/machines/ding.ogg'),
-		"Double Beep" = list("selected_sound"='sound/machines/twobeep.ogg'),
-		"Flush" = list("selected_sound"='sound/machines/disposalflush.ogg',"volume"=40),
-		"Kawaii" = list("selected_sound"='sound/AI/animes.ogg',"shiftpitch"=FALSE,"volume"=60),
-		"Startup" = list("selected_sound"='sound/mecha/nominal.ogg',"shiftpitch"=FALSE),
-		"Welding Noises" = list("selected_sound"='sound/items/Welder.ogg',"volume"=55),
-		"Quack" = list("selected_sound"='sound/items/quack.ogg'),
-		"Short Slide Whistle" = list("selected_sound"='sound/effects/slide_whistle_short.ogg'),
-		"Long Slide Whistle" = list("selected_sound"='sound/effects/slide_whistle_long.ogg'),
-		"YEET" = list("selected_sound"='sound/effects/yeet.ogg'),
-		"Time Stop" = list("selected_sound"='sound/effects/theworld3.ogg',"shiftpitch"=FALSE,"volume"=80),
-		"Click" = list("selected_sound"='sound/effects/kirakrik.ogg',"shiftpitch"=FALSE,"volume"=80),
-		"SPS" = list("selected_sound"='sound/items/fake_SPS.ogg',"shiftpitch"=FALSE,"volume"=100)
+		"Honk" = list("selected_sound"='sound/items/bikehorn.ogg',"shiftpitch"=TRUE),
+		"Applause" = list("selected_sound"='sound/effects/applause.ogg',"shiftpitch"=TRUE,"volume"=65),
+		"Laughter" = list("selected_sound"='sound/effects/laughtrack.ogg',"shiftpitch"=TRUE,"volume"=65),
+		"Rimshot" = list("selected_sound"='sound/effects/rimshot.ogg',"shiftpitch"=TRUE,"volume"=65),
+		"Trombone" = list("selected_sound"='sound/misc/sadtrombone.ogg',"shiftpitch"=TRUE),
+		"Airhorn" = list("selected_sound"='sound/items/AirHorn.ogg',"shiftpitch"=TRUE),
+		"Alert" = list("selected_sound"='sound/effects/alert.ogg',"shiftpitch"=TRUE),
+		"Awooga" = list("selected_sound"='sound/effects/awooga.ogg',"shiftpitch"=TRUE),
+		"Boom" = list("selected_sound"='sound/effects/Explosion1.ogg',"shiftpitch"=TRUE),
+		"Boom from Afar" = list("selected_sound"='sound/effects/explosionfar.ogg',"shiftpitch"=TRUE),
+		"Bubbles" = list("selected_sound"='sound/effects/bubbles.ogg',"shiftpitch"=TRUE),
+		"Construction Noises" = list("selected_sound"='sound/items/Deconstruct.ogg',"shiftpitch"=TRUE,"volume"=60),
+		"Countdown" = list("selected_sound"='sound/ambience/countdown.ogg',"volume"=55),
+		"Creepy Whisper" = list("selected_sound"='sound/hallucinations/turn_around1.ogg',"shiftpitch"=TRUE),
+		"Ding" = list("selected_sound"='sound/machines/ding.ogg',"shiftpitch"=TRUE),
+		"Double Beep" = list("selected_sound"='sound/machines/twobeep.ogg',"shiftpitch"=TRUE),
+		"Flush" = list("selected_sound"='sound/machines/disposalflush.ogg',"shiftpitch"=TRUE,"volume"=40),
+		"Kawaii" = list("selected_sound"='sound/AI/animes.ogg',"volume"=60),
+		"Startup" = list("selected_sound"='sound/mecha/nominal.ogg'),
+		"Welding Noises" = list("selected_sound"='sound/items/Welder.ogg',"shiftpitch"=TRUE,"volume"=55),
+		"Quack" = list("selected_sound"='sound/items/quack.ogg',"shiftpitch"=TRUE),
+		"Short Slide Whistle" = list("selected_sound"='sound/effects/slide_whistle_short.ogg',"shiftpitch"=TRUE),
+		"Long Slide Whistle" = list("selected_sound"='sound/effects/slide_whistle_long.ogg',"shiftpitch"=TRUE),
+		"YEET" = list("selected_sound"='sound/effects/yeet.ogg',"shiftpitch"=TRUE),
+		"Time Stop" = list("selected_sound"='sound/effects/theworld3.ogg',"volume"=80),
+		"Click" = list("selected_sound"='sound/effects/kirakrik.ogg',"volume"=80),
+		"SPS" = list("selected_sound"='sound/items/fake_SPS.ogg',"volume"=100)
 	)
 
 /obj/item/device/soundsynth/New()
 	..()
-	shiftpitch = default_shiftpitch
 	volume = default_volume
 
 /obj/item/device/soundsynth/verb/pick_sound()
@@ -62,10 +60,7 @@
 	var/list/assblast = sound_list[thesoundthatwewant]
 	if(assblast && assblast["selected_sound"])
 		selected_sound = assblast["selected_sound"]
-		if(assblast["shiftpitch"])
-			shiftpitch = assblast["shiftpitch"]
-		else
-			shiftpitch = default_shiftpitch
+		shiftpitch = assblast["shiftpitch"] ? TRUE : FALSE
 		if(assblast["volume"])
 			volume = assblast["volume"]
 		else

--- a/code/game/objects/items/devices/sound_synth.dm
+++ b/code/game/objects/items/devices/sound_synth.dm
@@ -61,7 +61,7 @@
 	if(assblast && assblast["selected_sound"])
 		selected_sound = assblast["selected_sound"]
 		shiftpitch = assblast["shiftpitch"] ? TRUE : FALSE
-		volume = assblast["volume"] ? assblast["volume"] : default_volume
+		volume = assblast["volume"] || default_volume
 
 /obj/item/device/soundsynth/attack_self(mob/user as mob)
 	if(spam_flag + 2 SECONDS < world.timeofday)

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -236,7 +236,7 @@ var/list/forbidden_varedit_object_types = list(
 	var/to_continue = TRUE
 	var/list/things_to_return = list()
 	while (to_continue)
-		things_to_return += variable_set(src, acceptsLists = FALSE)
+		mod_list_add(things_to_return)
 		to_continue = (alert("Do you want to add another item to the list? It has currently [things_to_return.len] items.", "Filling a list", "Yes", "No") == "Yes")
 
 	return things_to_return

--- a/code/modules/store/items.dm
+++ b/code/modules/store/items.dm
@@ -157,7 +157,7 @@
 /datum/storeitem/roganbot
 	name = "ROGANbot"
 	desc = "Your own personalized assistant to speed up your workplace communication skills! Ages 550 and up."
-	typepath = /obj/item/device/roganbot
+	typepath = /obj/item/device/soundsynth/roganbot
 	cost = 100
 	stock = 1
 	category = "Toys"


### PR DESCRIPTION
[tweak][administration]
namely converts the params and datums of the former and latter into a single list association system, where phrase is equal to a list containing associations with params, sound selected being a file, volume a number, and others true/false or etc.
also tweaks varediting to allow for associated lists inside lists instead of just at the highest level to make this all work in the first place.

:cl:
 * rscadd: ROGANbots are now more in common with regular sound synthesizers, inheriting all of their functionality along with its own.