### PR TITLE
Malfunctioning AI now prioritises existing AIs

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -205,7 +205,7 @@ var/stacking_limit = 90
 	log_admin("Parameters were: centre = [curve_centre_of_round], width = [curve_width_of_round].")
 
 	var/rst_pop = 0
-	for(var/mob/living/carbon/human/player in player_list)
+	for(var/mob/living/player in player_list)
 		if(player.mind)
 			rst_pop++
 	if (rst_pop >= high_pop_limit)
@@ -253,7 +253,7 @@ var/stacking_limit = 90
 		var/datum/dynamic_ruleset/midround/DR = rule
 		if (initial(DR.weight))
 			midround_rules += new rule()
-	for(var/mob/living/carbon/human/player in player_list)
+	for(var/mob/living/player in player_list)
 		if(player.mind)
 			roundstart_pop_ready++
 			candidates.Add(player)
@@ -338,7 +338,7 @@ var/stacking_limit = 90
 		extra_rulesets_amount = 0
 	else
 		var/rst_pop = 0
-		for(var/mob/living/carbon/human/player in player_list)
+		for(var/mob/living/player in player_list)
 			if(player.mind)
 				rst_pop++
 		if (rst_pop > high_pop_limit)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -8,7 +8,6 @@
 	var/list/protected_from_jobs = list() // if set, and config.protect_roles_from_antagonist = 0, then the rule will have a much lower chance than usual to pick those roles.
 	var/list/restricted_from_jobs = list()//if set, rule will deny candidates from those jobs
 	var/list/exclusive_to_jobs = list()//if set, rule will only accept candidates from those jobs
-	var/list/job_priority = list() //May be used by progressive_job_search for prioritizing some jobs for a role. Order matters.
 	var/list/enemy_jobs = list()//if set, there needs to be a certain amount of players doing those jobs (among the players who won't be drafted) for the rule to be drafted
 	var/list/required_pop = list(10,10,0,0,0,0,0,0,0,0)//if enemy_jobs was set, this is the amount of population required for the ruleset to fire. enemy jobs count double
 	var/required_enemies = list(0,0,0,0,0,0,0,0,0,0)		//If set, the ruleset requires this many enemy jobs to be filled in order to fire (per threat level)
@@ -249,18 +248,6 @@
 		to_chat(M, "<span class='notice'>Added to the [initial(role_category.id)] registration list.</span>")
 		applicants |= M
 		return
-
-/datum/dynamic_ruleset/proc/progressive_job_search()
-	for(var/job in job_priority)
-		for(var/mob/M in candidates)
-			if(M.mind.assigned_role == job)
-				assigned += M
-				candidates -= M
-				return M
-	var/mob/M = pick(candidates)
-	assigned += M
-	candidates -= M
-	return M
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -497,7 +497,6 @@ Assign your candidates in choose_candidates() instead.
 	role_category = /datum/role/malfAI
 	enemy_jobs = list("Security Officer", "Warden","Detective","Head of Security", "Captain", "Scientist", "Chemist", "Research Director", "Chief Engineer")
 	restricted_from_jobs = list("Security Officer", "Warden","Detective","Head of Security", "Captain", "Research Director", "Chief Engineer")
-	job_priority = list("AI","Cyborg")
 	required_pop = list(25,25,25,20,20,20,15,15,15,15)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
@@ -510,19 +509,17 @@ Assign your candidates in choose_candidates() instead.
 	var/ais = 0
 	for(var/mob/living/silicon/ai/AI in player_list)
 		ais++
-	if(ais) // If AIs in the current player list, pick one to be assigned if they're in the candidates
-		for(var/mob/M in candidates)
-			if(M.mind.assigned_role == "AI") // Only AIs readied can become malf
-				assigned.Add(M)
-				candidates.Remove(M)
-	else // If no AIs in the current player list, make someone the AI and give them the proper roles.
-		var/mob/M = progressive_job_search() // dynamic_rulesets.dm. Handles adding the guy to assigned.
-		M.mind.assigned_role = "AI"
-		if(!isAI(M))
-			assigned.Remove(M)
-			M = M.AIize()
-		assigned.Add(M)
-
+	for(var/mob/M in candidates)
+		if(ais && M.mind.assigned_role == "AI") // If AIs in the current player list, pick one to be assigned if they're in the candidates
+			assigned.Add(M)
+			candidates.Remove(M)
+		else if(M.mind.assigned_role == "Cyborg") // If no AIs in the current player list, make a cyborg candidate the AI and give them the proper roles.
+			M.mind.assigned_role = "AI"
+			if(!isAI(M))
+				assigned.Remove(M)
+				M = M.AIize()
+			assigned.Add(M)
+			candidates.Remove(M)
 	return (assigned.len > 0)
 
 /datum/dynamic_ruleset/roundstart/malf/execute()

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -514,14 +514,19 @@ Assign your candidates in choose_candidates() instead.
 			assigned.Add(M)
 			candidates.Remove(M)
 		else if(M.mind.assigned_role == "Cyborg") // If no AIs in the current player list, make a cyborg candidate the AI and give them the proper roles.
-			M.mind.assigned_role = "AI"
-			if(!isAI(M))
-				assigned.Remove(M)
-				M = M.AIize()
-			assigned.Add(M)
-			candidates.Remove(M)
+			make_AI(M)
 			break
+	if(!assigned.len) // If neither, just pick the rest as normal
+		var/mob/M2 = pick(candidates)
+		make_AI(M2)
 	return (assigned.len > 0)
+
+/datum/dynamic_ruleset/roundstart/malf/proc/make_AI(var/mob/M)
+	M.mind.assigned_role = "AI"
+	if(!isAI(M))
+		M = M.AIize()
+	assigned.Add(M)
+	candidates.Remove(M)
 
 /datum/dynamic_ruleset/roundstart/malf/execute()
 	var/datum/faction/malf/unction = find_active_faction_by_type(/datum/faction/malf)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -516,6 +516,15 @@ Assign your candidates in choose_candidates() instead.
 			candidates_to_remove.Add(M)
 	for(var/mob/M in candidates_to_remove)
 		candidates.Remove(M)
+	
+	if(!assigned.len) //If no candidates found before, make someone the AI and give them the proper roles.
+		var/mob/M = progressive_job_search() //dynamic_rulesets.dm. Handles adding the guy to assigned.
+		M.mind.assigned_role = "AI"
+		if(!isAI(M))
+			assigned.Remove(M)
+			M = M.AIize()
+		assigned.Add(M)
+
 	return (assigned.len > 0)
 
 /datum/dynamic_ruleset/roundstart/malf/execute()

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -507,12 +507,15 @@ Assign your candidates in choose_candidates() instead.
 	flags = HIGHLANDER_RULESET
 
 /datum/dynamic_ruleset/roundstart/malf/choose_candidates()
+	var/ais = 0
+	for(var/mob/living/silicon/ai/AI in player_list)
+		ais++
 	for(var/mob/M in candidates)
 		if(M.mind.assigned_role == "AI") // Only AIs readied can become malf
 			assigned.Add(M)
 			candidates.Remove(M)
 	
-	if(!assigned.len) //If no candidates found before, make someone the AI and give them the proper roles.
+	if(!ais) //If no AIs in the game, make someone the AI and give them the proper roles.
 		var/mob/M = progressive_job_search() //dynamic_rulesets.dm. Handles adding the guy to assigned.
 		M.mind.assigned_role = "AI"
 		if(!isAI(M))

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -509,13 +509,9 @@ Assign your candidates in choose_candidates() instead.
 /datum/dynamic_ruleset/roundstart/malf/choose_candidates()
 	var/list/candidates_to_remove = list()
 	for(var/mob/M in candidates)
-		if(candidates.len <= 0)
-			break
 		if(M.mind.assigned_role == "AI") // Only AIs readied can become malf
 			assigned.Add(M)
-			candidates_to_remove.Add(M)
-	for(var/mob/M in candidates_to_remove)
-		candidates.Remove(M)
+			candidates.Remove(M)
 	
 	if(!assigned.len) //If no candidates found before, make someone the AI and give them the proper roles.
 		var/mob/M = progressive_job_search() //dynamic_rulesets.dm. Handles adding the guy to assigned.

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -510,12 +510,12 @@ Assign your candidates in choose_candidates() instead.
 	var/ais = 0
 	for(var/mob/living/silicon/ai/AI in player_list)
 		ais++
-	for(var/mob/M in candidates)
-		if(M.mind.assigned_role == "AI") // Only AIs readied can become malf
-			assigned.Add(M)
-			candidates.Remove(M)
-	
-	if(!ais) //If no AIs in the game, make someone the AI and give them the proper roles.
+	if(ais) // If AIs in the game, pick one to be assigned if they're in the candidates
+		for(var/mob/M in candidates)
+			if(M.mind.assigned_role == "AI") // Only AIs readied can become malf
+				assigned.Add(M)
+				candidates.Remove(M)
+	else //If no AIs in the game, make someone the AI and give them the proper roles.
 		var/mob/M = progressive_job_search() //dynamic_rulesets.dm. Handles adding the guy to assigned.
 		M.mind.assigned_role = "AI"
 		if(!isAI(M))

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -516,7 +516,7 @@ Assign your candidates in choose_candidates() instead.
 		else if(M.mind.assigned_role == "Cyborg") // If no AIs in the current player list, make a cyborg candidate the AI and give them the proper roles.
 			make_AI(M)
 			break
-	if(!assigned.len) // If neither, just pick the rest as normal
+	if(!ais && !assigned.len) // If neither, just pick the rest as normal
 		var/mob/M2 = pick(candidates)
 		make_AI(M2)
 	return (assigned.len > 0)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -507,7 +507,6 @@ Assign your candidates in choose_candidates() instead.
 	flags = HIGHLANDER_RULESET
 
 /datum/dynamic_ruleset/roundstart/malf/choose_candidates()
-	var/list/candidates_to_remove = list()
 	for(var/mob/M in candidates)
 		if(M.mind.assigned_role == "AI") // Only AIs readied can become malf
 			assigned.Add(M)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -520,6 +520,7 @@ Assign your candidates in choose_candidates() instead.
 				M = M.AIize()
 			assigned.Add(M)
 			candidates.Remove(M)
+			break
 	return (assigned.len > 0)
 
 /datum/dynamic_ruleset/roundstart/malf/execute()

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -510,13 +510,13 @@ Assign your candidates in choose_candidates() instead.
 	var/ais = 0
 	for(var/mob/living/silicon/ai/AI in player_list)
 		ais++
-	if(ais) // If AIs in the game, pick one to be assigned if they're in the candidates
+	if(ais) // If AIs in the current player list, pick one to be assigned if they're in the candidates
 		for(var/mob/M in candidates)
 			if(M.mind.assigned_role == "AI") // Only AIs readied can become malf
 				assigned.Add(M)
 				candidates.Remove(M)
-	else //If no AIs in the game, make someone the AI and give them the proper roles.
-		var/mob/M = progressive_job_search() //dynamic_rulesets.dm. Handles adding the guy to assigned.
+	else // If no AIs in the current player list, make someone the AI and give them the proper roles.
+		var/mob/M = progressive_job_search() // dynamic_rulesets.dm. Handles adding the guy to assigned.
 		M.mind.assigned_role = "AI"
 		if(!isAI(M))
 			assigned.Remove(M)


### PR DESCRIPTION
[tweak][bugfix][gamemode]
Instead of displacing an AI.
Seems more logical to no longer displace an AI that wanted to play.
Closes #31346.
Closes #31439.

:cl:
 * bugfix: Malfunctioning AIs no longer spawn next to a regular one if one is ready for the round.
 * bugfix: Silicons can roll dynamic rulesets again.