### PR TITLE
Cruciatus' Spiritbreaker increases with potency

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -788,7 +788,7 @@
 	production = 6
 	yield = 6
 	potency = 5
-	chems = list(NUTRIMENT = list(1), MESCALINE = list(1,8), TANNIC_ACID = list(1,8,1), OPIUM = list(1,10,1), SPIRITBREAKER = list(10))
+	chems = list(NUTRIMENT = list(1), MESCALINE = list(1,8), TANNIC_ACID = list(1,8,1), OPIUM = list(1,10,1), SPIRITBREAKER = list(1,10,1))
 
 
 /datum/seed/ambrosia/deus


### PR DESCRIPTION
For [consistency] since all the other ambrosia chems are affected by potency. Also [qol] since currently you have to make fucktons of cruciatus plants to get high spiritbreaker yields instead of the "buff potency" method used for all other plants.
It also means that unbuffed cruciatus will have less than 10u spiritbreaker.

Closes #9947

:cl:
 * tweak: Spiritbreaker is no longer a flat 10u on an ambrosia cruciatus leaf, the amount now depends on potency.