### PR TITLE
Removes Frankenline Station From Map Vote

### DIFF
--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -80,10 +80,10 @@
 	path = "Island"
 	min_players = 25
 	
-/datum/next_map/line
-	name = "Frankenline Station"
-	path = "line"
-	min_players = 20
+#/datum/next_map/line
+#	name = "Frankenline Station"
+#	path = "line"
+#	min_players = 20
 
 /datum/next_map/lamprey
 	name = "Lamprey Station"


### PR DESCRIPTION
Frankenline Station was a meme map built around a meme premise and added to the voting list as a regular map. This PR (0% tested) comments out the votability without removing the map. If the map maker would like to reimplement this map as votable on Halloween or something like that, it is possible to do so in the future.