### PR TITLE
Removes Fun

### DIFF
--- a/code/modules/spells/general/lightning.dm
+++ b/code/modules/spells/general/lightning.dm
@@ -100,7 +100,7 @@
 		connected_button.name = name
 		charge_counter = charge_max
 		user.overlays -= chargeoverlay
-		if((zapzap != multicast) && (zapzap != 0)) //partial cast
+		if((zapzap != multicast) && (zapzap > 0)) //partial cast
 			take_charge(holder, 0)
 		zapzap = 0
 	return 1
@@ -111,7 +111,7 @@
 		if (user.is_pacified(VIOLENCE_DEFAULT,L))
 			return
 		zapzap--
-		if(zapzap)
+		if(zapzap > 0)
 			to_chat(user, "<span class='info'>You can throw lightning [zapzap] more time\s</span>")
 			. = 1
 


### PR DESCRIPTION
![alt text](https://arch-img.b4k.co/vg/1639020447819.png)
Closes #31773 and #31568 (double kill!)
I did not test this.