### PR TITLE
More time agent fixes

### DIFF
--- a/code/datums/gamemode/objectives/target/erase.dm
+++ b/code/datums/gamemode/objectives/target/erase.dm
@@ -11,7 +11,7 @@
 	if(target_erased)
 		return "Target erased."
 	else
-		return "Remove [target.current.real_name][target.assigned_role!="MODE" ? ", the [target.assigned_role]," : ""] from the timeline with your timeline eraser. Dead or alive counts, but the process takes time and is very noticeable to anyone in the vicinity."
+		return "Remove [target.current.real_name][target.assigned_role && target.assigned_role != "MODE" ? ", the [target.assigned_role]," : ""] from the timeline with your timeline eraser. Dead or alive counts, but the process takes time and is very noticeable to anyone in the vicinity."
 
 /datum/objective/target/assassinate/erase/proc/check(var/atom/eraser_target)
 	if(istype(eraser_target, /mob))

--- a/code/datums/gamemode/objectives/target/erase.dm
+++ b/code/datums/gamemode/objectives/target/erase.dm
@@ -11,7 +11,7 @@
 	if(target_erased)
 		return "Target erased."
 	else
-		return "Remove [target.current.real_name], the [target.assigned_role=="MODE" ? (target.special_role) : (target.assigned_role)] from the timeline with your timeline eraser. Dead or alive counts, but the process takes time and is very noticeable to anyone in the vicinity."
+		return "Remove [target.current.real_name][target.assigned_role!="MODE" ? ", the [target.assigned_role]," : ""] from the timeline with your timeline eraser. Dead or alive counts, but the process takes time and is very noticeable to anyone in the vicinity."
 
 /datum/objective/target/assassinate/erase/proc/check(var/atom/eraser_target)
 	if(istype(eraser_target, /mob))

--- a/code/datums/gamemode/objectives/target/erase.dm
+++ b/code/datums/gamemode/objectives/target/erase.dm
@@ -8,10 +8,7 @@
 	return target_erased
 
 /datum/objective/target/assassinate/erase/format_explanation()
-	if(target_erased)
-		return "Target erased."
-	else
-		return "Remove [target.current.real_name][target.assigned_role && target.assigned_role != "MODE" ? ", the [target.assigned_role]," : ""] from the timeline with your timeline eraser. Dead or alive counts, but the process takes time and is very noticeable to anyone in the vicinity."
+	return "Remove [target.current.real_name][target.assigned_role && target.assigned_role != "MODE" ? ", the [target.assigned_role]," : ""] from the timeline with your timeline eraser. Dead or alive counts, but the process takes time and is very noticeable to anyone in the vicinity."
 
 /datum/objective/target/assassinate/erase/proc/check(var/atom/eraser_target)
 	if(istype(eraser_target, /mob))

--- a/code/datums/gamemode/objectives/target/locate.dm
+++ b/code/datums/gamemode/objectives/target/locate.dm
@@ -10,19 +10,20 @@
 		return FALSE
 	return TRUE
 
+var/list/potential_locate_objects = list(/obj/item/weapon/bikehorn/rubberducky,
+	/obj/item/weapon/hand_tele,
+	/obj/item/weapon/gun/energy/laser/captain,
+	/obj/item/weapon/aiModule/freeform/core,
+	/obj/item/weapon/gun/lawgiver,
+	/obj/item/weapon/circuitboard/aiupload,
+	/obj/item/clothing/gloves/yellow,
+	/obj/item/weapon/reagent_containers/hypospray,
+	/obj/item/weapon/disk/nuclear,
+	/obj/item/weapon/reagent_containers/glass/bucket,
+)
+
 /datum/objective/target/locate/find_target()
-	var/list/potential_objects = list(/obj/item/weapon/bikehorn/rubberducky,
-			/obj/item/weapon/hand_tele,
-			/obj/item/weapon/gun/energy/laser/captain,
-			/obj/item/weapon/aiModule/freeform/core,
-			/obj/item/weapon/gun/lawgiver,
-			/obj/item/weapon/circuitboard/aiupload,
-			/obj/item/clothing/gloves/yellow,
-			/obj/item/weapon/reagent_containers/hypospray,
-			/obj/item/weapon/disk/nuclear,
-			/obj/item/weapon/reagent_containers/glass/bucket,
-			)
-	potential_objects = shuffle(potential_objects)
+	var/list/potential_objects = shuffle(potential_locate_objects)
 	var/min = object_min - 1
 	var/max = (object_max >= object_min) ? object_max : (potential_objects.len-1)
 	for(var/i = 0 to rand(min,max))

--- a/code/datums/gamemode/objectives/target/rearrange.dm
+++ b/code/datums/gamemode/objectives/target/rearrange.dm
@@ -12,7 +12,8 @@
 		return "No items to move."
 
 /datum/objective/target/locate/rearrange/find_target()
-	destination = new pick(the_station_areas - /area/solar)
+	var/dtype = pick(the_station_areas - /area/solar)
+	destination = new dtype
 	..()
 	return TRUE
 

--- a/code/datums/gamemode/objectives/target/rearrange.dm
+++ b/code/datums/gamemode/objectives/target/rearrange.dm
@@ -12,7 +12,7 @@
 		return "No items to move."
 
 /datum/objective/target/locate/rearrange/find_target()
-	destination = pick(the_station_areas - /area/solar)
+	destination = new pick(the_station_areas - /area/solar)
 	..()
 	return TRUE
 
@@ -22,7 +22,7 @@
 			objects_in_area.Remove(A)
 	for(var/atom/A in objects_to_locate)
 		if(locate(A) in objects)
-			if(istype(get_area(A), destination) && !(locate(A) in objects_in_area)) // Second, to add anything new
+			if(istype(get_area(A), destination.type) && !(locate(A) in objects_in_area)) // Second, to add anything new
 				objects_in_area.Add(A)
 		if(!(locate(A) in objects_in_area)) // Third, once this is all done, check all objects we need in the area, if one isn't there, break out, we aren't done.
 			return

--- a/code/datums/gamemode/objectives/time_agent_extract.dm
+++ b/code/datums/gamemode/objectives/time_agent_extract.dm
@@ -19,6 +19,9 @@
 					break
 	else
 		anomaly = time_anomaly_list[1]
+	for(var/obj/item/weapon/pinpointer/advpinpointer/time_agent/TAP in pinpointer_list)
+		if(anomaly)
+			TAP.target = anomaly
 	explanation_text = format_explanation()
 	return TRUE
 

--- a/code/datums/gamemode/role/time_agent.dm
+++ b/code/datums/gamemode/role/time_agent.dm
@@ -235,12 +235,12 @@
 
 /obj/item/device/jump_charge/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(istimeagent(user) && istype(target, /obj/effect/time_anomaly))
-		var/datum/faction/time_agent/F = user.mind.GetFactionFromRole(TIMEAGENT)
+		var/datum/faction/time_agent/F = user.mind.GetFactionFromRole(TIMEAGENT) || user.mind.GetFactionFromRole(TIMEAGENTTWIN)
 		if(F)
 			var/datum/objective/time_agent_extract/TAE = locate() in F.objective_holder.GetObjectives()
 			if(TAE && target == TAE.anomaly)
 				to_chat(user, "<span class = 'notice'>New anomaly discovered. Welcome back, [user.real_name]. Moving to new co-ordinates.</span>")
-				var/datum/role/time_agent/R = user.mind.GetRole(TIMEAGENT)
+				var/datum/role/time_agent/R = user.mind.GetRole(TIMEAGENT) || user.mind.GetRole(TIMEAGENTTWIN)
 				R.extract()
 				TAE.extracted = TRUE
 				TAE.anomaly = null
@@ -336,4 +336,4 @@
 /obj/item/weapon/pinpointer/advpinpointer/time_agent/New()
 	item_paths["Jump Charge"] = /obj/item/device/jump_charge
 	item_paths["Time Anomaly"] = /obj/effect/time_anomaly
-	target = locate(item_paths["Jump Charge"])
+	target = locate(/obj/item/device/jump_charge)

--- a/code/datums/gamemode/role/time_agent.dm
+++ b/code/datums/gamemode/role/time_agent.dm
@@ -338,4 +338,5 @@
 	item_paths["Time Anomaly"] = /obj/effect/time_anomaly
 	target = locate(/obj/item/device/jump_charge)
 	for(var/path in potential_locate_objectives)
-			item_paths[initial(path.name)] = path
+			var/obj/dpath = initial(path)
+			item_paths[initial(dpath.name)] = path

--- a/code/datums/gamemode/role/time_agent.dm
+++ b/code/datums/gamemode/role/time_agent.dm
@@ -337,3 +337,5 @@
 	item_paths["Jump Charge"] = /obj/item/device/jump_charge
 	item_paths["Time Anomaly"] = /obj/effect/time_anomaly
 	target = locate(/obj/item/device/jump_charge)
+	for(var/path in potential_locate_objectives)
+			item_paths[initial(path.name)] = path

--- a/code/datums/gamemode/role/time_agent.dm
+++ b/code/datums/gamemode/role/time_agent.dm
@@ -330,5 +330,10 @@
 					P = null
 	qdel(target)
 
+/obj/item/weapon/pinpointer/advpinpointer/time_agent
+	mode = 2
+
 /obj/item/weapon/pinpointer/advpinpointer/time_agent/New()
 	item_paths["Jump Charge"] = /obj/item/device/jump_charge
+	item_paths["Time Anomaly"] = /obj/effect/time_anomaly
+	target = locate(item_paths["Jump Charge"])

--- a/code/datums/gamemode/role/time_agent.dm
+++ b/code/datums/gamemode/role/time_agent.dm
@@ -69,68 +69,71 @@
 
 /datum/role/time_agent/process()
 
-	time_elapsed++
-	if(time_elapsed % action_timer == 0)
-		timer_action(time_elapsed / action_timer)
-	if (antag && antag.current && antag.current.hud_used)
-		if(antag.current.hud_used.countdown_display)
-			antag.current.hud_used.countdown_display.overlays.len = 0
-			var/time_until_next_action = action_timer - (time_elapsed % action_timer)
-			var/first = round(time_until_next_action/10)
-			var/second = time_until_next_action % 10
-			var/image/I1 = new('icons/obj/centcomm_stuff.dmi',src,"[first]",30)
-			var/image/I2 = new('icons/obj/centcomm_stuff.dmi',src,"[second]",30)
-			I1.pixel_x += 10 * PIXEL_MULTIPLIER
-			I2.pixel_x += 17 * PIXEL_MULTIPLIER
-			I1.pixel_y -= 11 * PIXEL_MULTIPLIER
-			I2.pixel_y -= 11 * PIXEL_MULTIPLIER
-			antag.current.hud_used.countdown_display.overlays += I1
-			antag.current.hud_used.countdown_display.overlays += I2
-		else
-			antag.current.hud_used.countdown_time_agent()
+	if (antag && antag.current)
+		time_elapsed++
+		if(time_elapsed % action_timer == 0)
+			timer_action(time_elapsed / action_timer)
+		if (antag.current.hud_used)
+			if(antag.current.hud_used.countdown_display)
+				antag.current.hud_used.countdown_display.overlays.len = 0
+				var/time_until_next_action = action_timer - (time_elapsed % action_timer)
+				var/first = round(time_until_next_action/10)
+				var/second = time_until_next_action % 10
+				var/image/I1 = new('icons/obj/centcomm_stuff.dmi',src,"[first]",30)
+				var/image/I2 = new('icons/obj/centcomm_stuff.dmi',src,"[second]",30)
+				I1.pixel_x += 10 * PIXEL_MULTIPLIER
+				I2.pixel_x += 17 * PIXEL_MULTIPLIER
+				I1.pixel_y -= 11 * PIXEL_MULTIPLIER
+				I2.pixel_y -= 11 * PIXEL_MULTIPLIER
+				antag.current.hud_used.countdown_display.overlays += I1
+				antag.current.hud_used.countdown_display.overlays += I2
+			else
+				antag.current.hud_used.countdown_time_agent()
 
 /datum/role/time_agent/proc/timer_action(severity)
-	var/mob/living/carbon/human/H = antag.current
-	switch(severity)
-		if(1)
-			spawn_rand_maintenance(H)
-			spawn()
-				showrift(H,1)
-		if(2)
-			// send the time agent specifically to the past, future, and stop time on him for 30 sec or so
-			H.timeslip += 30
-		if(3)
-			switch(pick(list(1,2)))
-				if(1)
-					wormhole_event()
-					H.teleportitis += 30
-				if(2)
-					// what could possibly go wrong
-					generate_ion_law()
-					generate_ion_law()
-					generate_ion_law()
-					command_alert(/datum/command_alert/ion_storm)
-					empulse(H.loc, 4, 10)
-					// also maybe make the AI actively malicious to time travellers
-		if(4)
-			eviltwinrecruiter = new(src)
-			eviltwinrecruiter.display_name = "time agent twin"
-			eviltwinrecruiter.role = TIMEAGENT
-			eviltwinrecruiter.jobban_roles = list("syndicate")
-			eviltwinrecruiter.logging = TRUE
+	if(antag && antag.current)
+		var/mob/living/carbon/human/H = antag.current
+		switch(severity)
+			if(1)
+				spawn_rand_maintenance(H)
+				spawn()
+					showrift(H,1)
+			if(2)
+				// send the time agent specifically to the past, future, and stop time on him for 30 sec or so
+				H.timeslip += 30
+			if(3)
+				switch(pick(list(1,2)))
+					if(1)
+						wormhole_event()
+						H.teleportitis += 30
+					if(2)
+						// what could possibly go wrong
+						generate_ion_law()
+						generate_ion_law()
+						generate_ion_law()
+						command_alert(/datum/command_alert/ion_storm)
+						empulse(H.loc, 4, 10)
+						// also maybe make the AI actively malicious to time travellers
+			if(4)
+				if(!H.stat)
+					eviltwinrecruiter = new(src)
+					eviltwinrecruiter.display_name = "time agent twin"
+					eviltwinrecruiter.role = TIMEAGENT
+					eviltwinrecruiter.jobban_roles = list("syndicate")
+					eviltwinrecruiter.logging = TRUE
 
-			// A player has their role set to Yes or Always
-			eviltwinrecruiter.player_volunteering = new /callback(src, .proc/recruiter_recruiting)
-			// ", but No or Never
-			eviltwinrecruiter.player_not_volunteering = new /callback(src, .proc/recruiter_not_recruiting)
+					// A player has their role set to Yes or Always
+					eviltwinrecruiter.player_volunteering = new /callback(src, .proc/recruiter_recruiting)
+					// ", but No or Never
+					eviltwinrecruiter.player_not_volunteering = new /callback(src, .proc/recruiter_not_recruiting)
 
-			eviltwinrecruiter.recruited = new /callback(src, .proc/recruiter_recruited)
+					eviltwinrecruiter.recruited = new /callback(src, .proc/recruiter_recruited)
 
-			eviltwinrecruiter.request_player()
-		if(5 to INFINITY)
-			// time_elapsed += 30
-			// var/datum/organ/internal/teleorgan = pick(H.internal_organs)
-			return
+					eviltwinrecruiter.request_player()
+			if(5 to INFINITY)
+				// time_elapsed += 30
+				// var/datum/organ/internal/teleorgan = pick(H.internal_organs)
+				return
 
 /datum/role/time_agent/proc/recruiter_recruiting(mob/dead/observer/player, controls)
 	to_chat(player, "<span class=\"recruit\">You are a possible candidate for \a [src]'s evil twin. Get ready. ([controls])</span>")
@@ -144,20 +147,21 @@
 	antag.current.investigation_log(subject,message)
 
 /datum/role/time_agent/proc/recruiter_recruited(mob/dead/observer/player)
-	if(player)
-		qdel(eviltwinrecruiter)
-		eviltwinrecruiter = null
-		var/mob/living/carbon/human/H = new /mob/living/carbon/human(pick(timeagentstart))
-		H.ckey = player.ckey
-		H.client.changeView()
-		var/datum/role/time_agent/eviltwin/twin = new /datum/role/time_agent/eviltwin(H.mind, fac = src.faction)
-		twin.erase_target = src
-		twin.Greet(GREET_DEFAULT)
-		twin.ForgeObjectives()
-		twin.OnPostSetup()
-		twin.AnnounceObjectives()
-	else
-		eviltwinrecruiter.request_player()
+	if(antag && antag.current && !antag.current.stat)
+		if(player)
+			qdel(eviltwinrecruiter)
+			eviltwinrecruiter = null
+			var/mob/living/carbon/human/H = new /mob/living/carbon/human(pick(timeagentstart))
+			H.ckey = player.ckey
+			H.client.changeView()
+			var/datum/role/time_agent/eviltwin/twin = new /datum/role/time_agent/eviltwin(H.mind, fac = src.faction)
+			twin.erase_target = src
+			twin.Greet(GREET_DEFAULT)
+			twin.ForgeObjectives()
+			twin.OnPostSetup()
+			twin.AnnounceObjectives()
+		else
+			eviltwinrecruiter.request_player()
 
 /datum/role/time_agent/OnPostSetup()
 	.=..()

--- a/code/datums/gamemode/role/time_agent.dm
+++ b/code/datums/gamemode/role/time_agent.dm
@@ -337,7 +337,7 @@
 	item_paths["Jump Charge"] = /obj/item/device/jump_charge
 	item_paths["Time Anomaly"] = /obj/effect/time_anomaly
 	target = locate(/obj/item/device/jump_charge)
-	for(var/path in potential_locate_objectives)
+	for(var/path in potential_locate_objects)
 		var/obj/dpath = new path
 		item_paths[dpath.name] = path
 		qdel(dpath)

--- a/code/datums/gamemode/role/time_agent.dm
+++ b/code/datums/gamemode/role/time_agent.dm
@@ -338,5 +338,6 @@
 	item_paths["Time Anomaly"] = /obj/effect/time_anomaly
 	target = locate(/obj/item/device/jump_charge)
 	for(var/path in potential_locate_objectives)
-			var/obj/dpath = initial(path)
-			item_paths[initial(dpath.name)] = path
+			var/obj/dpath = new path
+			item_paths[dpath.name] = path
+			qdel(dpath)

--- a/code/datums/gamemode/role/time_agent.dm
+++ b/code/datums/gamemode/role/time_agent.dm
@@ -338,6 +338,6 @@
 	item_paths["Time Anomaly"] = /obj/effect/time_anomaly
 	target = locate(/obj/item/device/jump_charge)
 	for(var/path in potential_locate_objectives)
-			var/obj/dpath = new path
-			item_paths[dpath.name] = path
-			qdel(dpath)
+		var/obj/dpath = new path
+		item_paths[dpath.name] = path
+		qdel(dpath)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -137,6 +137,7 @@
 	return TRUE
 
 /obj/item/weapon/gun/energy/laser/captain
+	name ="captain's laser gun"
 	icon_state = "caplaser"
 	item_state = null
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guninhands_left.dmi', "right_hand" = 'icons/mob/in-hand/right/guninhands_right.dmi')


### PR DESCRIPTION
[bugfix][tweak][gamemode][role]
Closes #31779.

:cl:
 * bugfix: Time agent pinpointers can now target the jump charge and anomaly.
 * bugfix: Rearrange objective now actually checks area right.
 * bugfix: Time agent twins can now enter the anomaly to leave and increase threat.
 * spellcheck: Fixes bad formatting on the time agent erase objective.
 * tweak: Time agent twins now only spawn if their target is alive.
 * tweak: Time agent pinpointers now also target their possible locate objectives.