### PR TITLE
Fix Malf AI Displacement + Possibly (?) Fix roundstart revs not being able to fire?

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -205,7 +205,7 @@ var/stacking_limit = 90
 	log_admin("Parameters were: centre = [curve_centre_of_round], width = [curve_width_of_round].")
 
 	var/rst_pop = 0
-	for(var/mob/living/carbon/human/player in player_list)
+	for(var/mob/living/player in player_list)
 		if(player.mind)
 			rst_pop++
 	if (rst_pop >= high_pop_limit)
@@ -253,7 +253,7 @@ var/stacking_limit = 90
 		var/datum/dynamic_ruleset/midround/DR = rule
 		if (initial(DR.weight))
 			midround_rules += new rule()
-	for(var/mob/living/carbon/human/player in player_list)
+	for(var/mob/living/player in player_list)
 		if(player.mind)
 			roundstart_pop_ready++
 			candidates.Add(player)
@@ -338,7 +338,7 @@ var/stacking_limit = 90
 		extra_rulesets_amount = 0
 	else
 		var/rst_pop = 0
-		for(var/mob/living/carbon/human/player in player_list)
+		for(var/mob/living/player in player_list)
 			if(player.mind)
 				rst_pop++
 		if (rst_pop > high_pop_limit)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -513,10 +513,9 @@ Assign your candidates in choose_candidates() instead.
 	var/mob/M = progressive_job_search() //dynamic_rulesets.dm. Handles adding the guy to assigned.
 	if(M.mind.assigned_role != "AI")
 		for(var/mob/living/silicon/ai/player in player_list) //mode.candidates is everyone readied up, not to be confused with candidates
-			//if(player.mind.assigned_role == "AI")
-			//We have located an AI to replace
-			displace_AI(player)
-			break
+			if(player != M)	// This should always be true but in case something goes terribly terribly wrong we definitely do not want to end up displacing the malf AI
+				displace_AI(player)
+				break		// There will only be one roundstart AI normally. In case of a triple-AI round we only need to displace one AI anyway.
 
 	//Now that we've replaced the eventual other AIs, we make sure this chosen candidate has the proper roles.
 	M.mind.assigned_role = "AI"

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -517,8 +517,8 @@ Assign your candidates in choose_candidates() instead.
 		for(var/mob/living/silicon/ai/player in player_list) //mode.candidates is everyone readied up, not to be confused with candidates
 			//if(player.mind.assigned_role == "AI")
 			//We have located an AI to replace
-			displace_AI(player)
 			message_admins("Displacing AI played by: [key_name(player)].")
+			displace_AI(player)
 			break
 
 	//Now that we've replaced the eventual other AIs, we make sure this chosen candidate has the proper roles.

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -515,7 +515,6 @@ Assign your candidates in choose_candidates() instead.
 		for(var/mob/living/silicon/ai/player in player_list) //mode.candidates is everyone readied up, not to be confused with candidates
 			//if(player.mind.assigned_role == "AI")
 			//We have located an AI to replace
-			message_admins("Displacing AI played by: [key_name(player)].")
 			displace_AI(player)
 			break
 
@@ -557,17 +556,20 @@ Assign your candidates in choose_candidates() instead.
 			job_master.AssignRole(old_AI, "Assistant")
 	if(!old_AI.mind.assigned_role)
 		to_chat(old_AI, "<span class='danger'>You have been returned to lobby due to your job preferences being filled.")
+		log_admin("([old_AI.ckey]) was displaced by a malf AI and sent back to lobby.")
+		message_admins("([old_AI.ckey]) was displaced by a malf AI and started the game as a [old_AI.mind.assigned_role].")
 		old_AI.ready = 0
 		return 
 
 	if(old_AI.mind.assigned_role=="AI" || old_AI.mind.assigned_role=="Cyborg" || old_AI.mind.assigned_role=="Mobile MMI")
-		log_admin("([old_AI.ckey]) was displaced by a malf AI and started the game as a [old_AI.mind.assigned_role].")
 		old_AI.create_roundstart_silicon(old_AI.mind.assigned_role)
 	else
 		var/mob/living/carbon/human/new_character = old_AI.create_character(0)
 		new_character.DormantGenes(20,10,0,0) // 20% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
 		job_master.EquipRank(new_character, new_character.mind.assigned_role, 0)
 		EquipCustomItems(new_character)
+	log_admin("([old_AI.ckey]) was displaced by a malf AI and started the game as a [old_AI.mind.assigned_role].")
+	message_admins("([old_AI.ckey]) was displaced by a malf AI and started the game as a [old_AI.mind.assigned_role].")
 	qdel(old_AI)
 
 //////////////////////////////////////////////

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -548,18 +548,15 @@ Assign your candidates in choose_candidates() instead.
 		for(var/datum/job/job in shuffledoccupations)
 			if(job_master.TryAssignJob(old_AI,level,job))
 				break
-	if(old_AI.mind.assigned_role)
-		return
 	if(old_AI.client.prefs.alternate_option == GET_RANDOM_JOB)
 		job_master.GiveRandomJob(old_AI)
-		return
 	else if(old_AI.client.prefs.alternate_option == BE_ASSISTANT)
 		job_master.AssignRole(old_AI, "Assistant")
 	else
 		to_chat(old_AI, "<span class='danger'>You have been returned to lobby due to your job preferences being filled.")
 		old_AI.ready = 0
 		job_master.AssignRole(old_AI, "Assistant")
-
+	qdel(displaced)
 //////////////////////////////////////////////
 //                                          //
 //         BLOB					            ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -511,12 +511,15 @@ Assign your candidates in choose_candidates() instead.
 // You should `not` perform any null checks on M. M being null is a sign of a problem and should runtime.
 /datum/dynamic_ruleset/roundstart/malf/choose_candidates()
 	var/mob/M = progressive_job_search() //dynamic_rulesets.dm. Handles adding the guy to assigned.
+	to_chat(world, "found an AI candidate")
 	if(M.mind.assigned_role != "AI")
-		for(var/mob/player in mode.candidates) //mode.candidates is everyone readied up, not to be confused with candidates
-			if(player.mind.assigned_role == "AI")
-				//We have located an AI to replace
-				displace_AI(player)
-				message_admins("Displacing AI played by: [key_name(player)].")
+		to_chat(world, "selected candidate not roundstart AI")
+		for(var/mob/living/silicon/ai/player in player_list) //mode.candidates is everyone readied up, not to be confused with candidates
+			//if(player.mind.assigned_role == "AI")
+			//We have located an AI to replace
+			displace_AI(player)
+			message_admins("Displacing AI played by: [key_name(player)].")
+			break
 
 	//Now that we've replaced the eventual other AIs, we make sure this chosen candidate has the proper roles.
 	M.mind.assigned_role = "AI"
@@ -536,12 +539,12 @@ Assign your candidates in choose_candidates() instead.
 	MAI.Greet()
 	return 1
 
-/datum/dynamic_ruleset/roundstart/malf/proc/displace_AI(var/mob/new_player/old_AI)
+/datum/dynamic_ruleset/roundstart/malf/proc/displace_AI(var/mob/displaced)
+	var/mob/new_player/old_AI = new 
+	old_AI.ckey = displaced.ckey
 	old_AI.mind.assigned_role = null
 	var/list/shuffledoccupations = shuffle(job_master.occupations)
 	for(var/level = 3 to 1 step -1)
-		if(old_AI.mind.assigned_role)
-			break
 		for(var/datum/job/job in shuffledoccupations)
 			if(job_master.TryAssignJob(old_AI,level,job))
 				break
@@ -555,6 +558,7 @@ Assign your candidates in choose_candidates() instead.
 	else
 		to_chat(old_AI, "<span class='danger'>You have been returned to lobby due to your job preferences being filled.")
 		old_AI.ready = 0
+		job_master.AssignRole(old_AI, "Assistant")
 
 //////////////////////////////////////////////
 //                                          //
@@ -656,7 +660,7 @@ Assign your candidates in choose_candidates() instead.
 	if (!..())
 		return FALSE
 	var/head_check = 0
-	for (var/mob/new_player/player in player_list)
+	for (var/mob/player in player_list)
 		if (player.mind.assigned_role in command_positions)
 			head_check++
 	return (head_check >= required_heads)

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -3,6 +3,8 @@
 	if(join_motd)
 		to_chat(src, "<div class=\"motd\">[join_motd]</div>")
 
+	client.reset_screen()
+	
 	if(!mind)
 		mind = new /datum/mind(key)
 		mind.active = 1
@@ -12,7 +14,7 @@
 		loc = pick(newplayer_start)
 	else
 		loc = locate(1,1,1)
-
+	
 	change_sight(adding = SEE_TURFS)
 	player_list |= src
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -153,6 +153,7 @@
 	O.verbs += /mob/living/silicon/ai/proc/show_laws_verb
 	O.verbs += /mob/living/silicon/ai/proc/ai_statuschange
 	O.job = "AI"
+	O.mind.assigned_role = "AI"
 	mob_rename_self(O,"ai", null, 1)
 	. = O
 	if(del_mob)
@@ -184,6 +185,7 @@
 	if(!skipnaming)
 		spawn()
 			O.Namepick()
+	O.mind.assigned_role = "Cyborg"
 	qdel(src)
 	return O
 
@@ -211,6 +213,7 @@
 	if(!skipnaming)
 		spawn()
 			O.Namepick()
+	O.mind.assigned_role = "Mobile MMI"
 	qdel(src)
 	return O
 


### PR DESCRIPTION
Alternative to #31733
Closes #31439 and #31346, Reopens #31786 only to close it immediately
While making this I noticed that the ready() proc in revs looks for new_player mobs to see if they were assigned head roles. Since #31104 was merged back in NOVEMBER roundstart revolution hasn't rolled, and I think that might have been causing it.
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
:cl:
 * bugfix: Fixed two AIs sometimes appearing when Malfunctioning AI is rolled.
 * bugfix: Possibly fix roundstart revolution never being able to fire.
 * bugfix: Silicons can roll for other rulesets (that they are supposed to be eligible for) again.