### PR TITLE
Allows banhammer to actually ban, if user can ban people

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -13,7 +13,7 @@
 
 /obj/item/weapon/banhammer/attack_self(var/mob/user)
 	if(user.check_rights(R_BAN))
-		var/obj/item/weapon/banhammer/admin/ABH = new obj/item/weapon/bannhammer/admin(loc)
+		var/obj/item/weapon/banhammer/admin/ABH = new /obj/item/weapon/bannhammer/admin(loc)
 		ABH.attack_self(user)
 		qdel(src)
 
@@ -260,7 +260,7 @@
 			reason = "For no raisin."
 		ipban = alert(usr,"IP ban?",,"Yes","No") == "Yes"
 		if(istemp == "No")
-			sticky = alert(usr,"Sticky Ban [M.ckey]? Use this only if you never intend to unban the player.","Sticky Icky","Yes", "No") == "Yes"
+			sticky = alert(usr,"Sticky Ban with this weapon? Use this only if you never intend to unban players.","Sticky Icky","Yes", "No") == "Yes"
 
 /obj/item/weapon/banhammer/admin/attack(mob/living/M as mob, mob/living/user as mob)
 	. = ..() // Show stuff happen before banning itself.

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -14,6 +14,7 @@
 /obj/item/weapon/banhammer/attack_self(var/mob/user)
 	if(user.check_rights(R_BAN))
 		var/obj/item/weapon/banhammer/admin/ABH = new /obj/item/weapon/banhammer/admin(loc)
+		user.put_in_hands(ABH)
 		ABH.attack_self(user)
 		qdel(src)
 

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -11,6 +11,11 @@
 	throw_range = 15
 	attack_verb = list("bans")
 
+/obj/item/weapon/banhammer/ataack_self(var/mob/user)
+	if(user.check_rights(R_BAN))
+		var/obj/item/weapon/banhammer/admin/ABH = new obj/item/weapon/bannhammer/admin(loc)
+		ABH.attack_self(user)
+		qdel(src)
 
 /obj/item/weapon/banhammer/suicide_act(var/mob/living/user)
 	to_chat(viewers(user), "<span class='danger'>[user] is hitting \himself with the [src.name]! It looks like \he's trying to ban \himself from life.</span>")
@@ -231,6 +236,43 @@
 	desc = "A banhammer specifically reserved for admins. Legends tell of a weapon that destroys the target to the utmost capacity."
 	throwforce = 999
 	force = 999
+	var/istemp = FALSE
+	var/reason = "Griefer"
+	var/mins = 0
+	var/ipban = FALSE
+	var/sticky = FALSE
+	var/bannedby = ""
+
+/obj/item/weapon/banhammer/admin/ataack_self(var/mob/user)
+	if(user.check_rights(R_BAN))
+		bannedby = user.ckey
+		istemp == alert("Temporary Ban?",,"Yes","No") == "Yes"
+		if(istemp)
+			mins = input(usr,"How long (in minutes)?","Ban time",1440) as num|null
+			if(!mins)
+				mins = 1440
+			if(mins >= 525600)
+				mins = 525599
+		else
+			mins = 0
+		reason = input(usr,"Reason?","reason",reason) as text|null
+		if(!reason)
+			reason = "For no raisin."
+		ipban = alert(usr,"IP ban?",,"Yes","No") == "Yes"
+		if(istemp == "No")
+			sticky = alert(usr,"Sticky Ban [M.ckey]? Use this only if you never intend to unban the player.","Sticky Icky","Yes", "No") == "Yes"
+
+/obj/item/weapon/banhammer/admin/attack(mob/living/M as mob, mob/living/user as mob)
+	. = ..() // Show stuff happen before banning itself.
+	if(user.check_rights(R_BAN))
+		M.GetBanned(reason, bannedby, istemp, mins, ipban, sticky)
+	return .
+
+/obj/item/weapon/banhammer/admin/suicide_act(var/mob/living/user)
+	. = ..()
+	if(user.check_rights(R_BAN))
+		user.GetBanned(reason, bannedby, istemp, mins, ipban, sticky)
+	return .
 
 /obj/item/weapon/melee/bone_hammer
 	name = "bone hammer"

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -13,7 +13,7 @@
 
 /obj/item/weapon/banhammer/attack_self(var/mob/user)
 	if(user.check_rights(R_BAN))
-		var/obj/item/weapon/banhammer/admin/ABH = new /obj/item/weapon/bannhammer/admin(loc)
+		var/obj/item/weapon/banhammer/admin/ABH = new /obj/item/weapon/banhammer/admin(loc)
 		ABH.attack_self(user)
 		qdel(src)
 

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -246,7 +246,7 @@
 /obj/item/weapon/banhammer/admin/attack_self(var/mob/user)
 	if(user.check_rights(R_BAN))
 		bannedby = user.ckey
-		istemp == alert("Temporary Ban?",,"Yes","No") == "Yes"
+		istemp = alert("Temporary Ban?",,"Yes","No") == "Yes"
 		if(istemp)
 			mins = input(usr,"How long (in minutes)?","Ban time",1440) as num|null
 			if(!mins)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -13,10 +13,10 @@
 
 /obj/item/weapon/banhammer/attack_self(var/mob/user)
 	if(user.check_rights(R_BAN))
+		qdel(src)
 		var/obj/item/weapon/banhammer/admin/ABH = new /obj/item/weapon/banhammer/admin(loc)
 		user.put_in_hands(ABH)
 		ABH.attack_self(user)
-		qdel(src)
 
 /obj/item/weapon/banhammer/suicide_act(var/mob/living/user)
 	to_chat(viewers(user), "<span class='danger'>[user] is hitting \himself with the [src.name]! It looks like \he's trying to ban \himself from life.</span>")

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -11,7 +11,7 @@
 	throw_range = 15
 	attack_verb = list("bans")
 
-/obj/item/weapon/banhammer/ataack_self(var/mob/user)
+/obj/item/weapon/banhammer/attack_self(var/mob/user)
 	if(user.check_rights(R_BAN))
 		var/obj/item/weapon/banhammer/admin/ABH = new obj/item/weapon/bannhammer/admin(loc)
 		ABH.attack_self(user)
@@ -243,7 +243,7 @@
 	var/sticky = FALSE
 	var/bannedby = ""
 
-/obj/item/weapon/banhammer/admin/ataack_self(var/mob/user)
+/obj/item/weapon/banhammer/admin/attack_self(var/mob/user)
 	if(user.check_rights(R_BAN))
 		bannedby = user.ckey
 		istemp == alert("Temporary Ban?",,"Yes","No") == "Yes"

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -113,7 +113,6 @@ var/savefile/Banlist
 	ban_unban_log_save("[bannedby] has [temp ? "perma" : ""]banned [ckey]. - Reason: [reason] - This [thisinfo].")
 	log_admin("[bannedby] has banned [ckey].\nReason: [reason]\nThis [thisinfo].")
 	message_admins("<span class='warning'>[bannedby] has banned [ckey].\nReason: [reason]\nThis [thisinfo].</span>")
-	feedback_inc(temp ? "ban_tmp_mins" : "ban_perma", temp ? mins : 1)
 	DB_ban_record(temp ? BANTYPE_TEMP : BANTYPE_PERMA, src, temp ? mins : -1, reason)
 
 	del(src.client)

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -98,18 +98,18 @@ var/savefile/Banlist
 
 
 /mob/proc/GetBanned(reason, bannedby, temp, minutes, address, sticky)
-	AddBan(src.ckey, src.computer_id, reason, bannedby, temp, minutess, address ? lastKnownIP : null)
+	AddBan(src.ckey, src.computer_id, reason, bannedby, temp, minutes, address ? lastKnownIP : null)
 	if(sticky)
 		world.SetConfig("SYSTEM/keyban",src.ckey,"type=sticky&reason=[reason]&message=[reason]&admin=[bannedby]")
 		message_admins("[key_name_admin(usr)] has sticky banned [key_name(src)].")
 		log_admin("[key_name(usr)] has sticky banned [key_name(src)].")
 	to_chat(src, "<span class='warning'><BIG><B>You have been banned by [bannedby].\nReason: [reason].</B></BIG></span>")
-	to_chat(src, "<span class='warning'>This is a [temp ? "temporary" : "permanent"] ban[temp ? ", it will be removed in [mins] minutes" : ""].</span>")
+	to_chat(src, "<span class='warning'>This is a [temp ? "temporary" : "permanent"] ban[temp ? ", it will be removed in [minutes] minutes" : ""].</span>")
 	if(config.banappeals)
 		to_chat(src, "<span class='warning'>To try to resolve this matter head to [config.banappeals]</span>")
 	else
 		to_chat(src, "<span class='warning'>No ban appeals URL has been set.</span>")
-	var/thisinfo = temp ? "will be removed in [mins] minutes" : "is a permanent ban"
+	var/thisinfo = temp ? "will be removed in [minutes] minutes" : "is a permanent ban"
 	ban_unban_log_save("[bannedby] has [temp ? "perma" : ""]banned [ckey]. - Reason: [reason] - This [thisinfo].")
 	log_admin("[bannedby] has banned [ckey].\nReason: [reason]\nThis [thisinfo].")
 	message_admins("<span class='warning'>[bannedby] has banned [ckey].\nReason: [reason]\nThis [thisinfo].</span>")

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -116,8 +116,8 @@ var/savefile/Banlist
 		message_admins("<span class='warning'>[bannedby] has banned [ckey].\nReason: [reason]\nThis [thisinfo].</span>")
 		usr.client.holder.DB_ban_record(temp ? BANTYPE_TEMP : BANTYPE_PERMA, src, temp ? minutes : -1, reason)
 
-	del(src.client)
-	//del(src)	// See no reason why to delete mob. Important stuff can be lost. And ban can be lifted before round ends.
+		del(src.client)
+		//del(src)	// See no reason why to delete mob. Important stuff can be lost. And ban can be lifted before round ends.
 
 /proc/AddBan(ckey, computerid, reason, bannedby, temp, minutes, address)
 

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -98,22 +98,23 @@ var/savefile/Banlist
 
 
 /mob/proc/GetBanned(reason, bannedby, temp, minutes, address, sticky)
-	AddBan(src.ckey, src.computer_id, reason, bannedby, temp, minutes, address ? lastKnownIP : null)
-	if(sticky)
-		world.SetConfig("SYSTEM/keyban",src.ckey,"type=sticky&reason=[reason]&message=[reason]&admin=[bannedby]")
-		message_admins("[key_name_admin(usr)] has sticky banned [key_name(src)].")
-		log_admin("[key_name(usr)] has sticky banned [key_name(src)].")
-	to_chat(src, "<span class='warning'><BIG><B>You have been banned by [bannedby].\nReason: [reason].</B></BIG></span>")
-	to_chat(src, "<span class='warning'>This is a [temp ? "temporary" : "permanent"] ban[temp ? ", it will be removed in [minutes] minutes" : ""].</span>")
-	if(config.banappeals)
-		to_chat(src, "<span class='warning'>To try to resolve this matter head to [config.banappeals]</span>")
-	else
-		to_chat(src, "<span class='warning'>No ban appeals URL has been set.</span>")
-	var/thisinfo = temp ? "will be removed in [minutes] minutes" : "is a permanent ban"
-	ban_unban_log_save("[bannedby] has [temp ? "perma" : ""]banned [ckey]. - Reason: [reason] - This [thisinfo].")
-	log_admin("[bannedby] has banned [ckey].\nReason: [reason]\nThis [thisinfo].")
-	message_admins("<span class='warning'>[bannedby] has banned [ckey].\nReason: [reason]\nThis [thisinfo].</span>")
-	usr.client.holder.DB_ban_record(temp ? BANTYPE_TEMP : BANTYPE_PERMA, src, temp ? mins : -1, reason)
+	if(usr && usr.client && usr.client.holder)
+		AddBan(src.ckey, src.computer_id, reason, bannedby, temp, minutes, address ? lastKnownIP : null)
+		if(sticky)
+			world.SetConfig("SYSTEM/keyban",src.ckey,"type=sticky&reason=[reason]&message=[reason]&admin=[bannedby]")
+			message_admins("[key_name_admin(usr)] has sticky banned [key_name(src)].")
+			log_admin("[key_name(usr)] has sticky banned [key_name(src)].")
+		to_chat(src, "<span class='warning'><BIG><B>You have been banned by [bannedby].\nReason: [reason].</B></BIG></span>")
+		to_chat(src, "<span class='warning'>This is a [temp ? "temporary" : "permanent"] ban[temp ? ", it will be removed in [minutes] minutes" : ""].</span>")
+		if(config.banappeals)
+			to_chat(src, "<span class='warning'>To try to resolve this matter head to [config.banappeals]</span>")
+		else
+			to_chat(src, "<span class='warning'>No ban appeals URL has been set.</span>")
+		var/thisinfo = temp ? "will be removed in [minutes] minutes" : "is a permanent ban"
+		ban_unban_log_save("[bannedby] has [temp ? "perma" : ""]banned [ckey]. - Reason: [reason] - This [thisinfo].")
+		log_admin("[bannedby] has banned [ckey].\nReason: [reason]\nThis [thisinfo].")
+		message_admins("<span class='warning'>[bannedby] has banned [ckey].\nReason: [reason]\nThis [thisinfo].</span>")
+		usr.client.holder.DB_ban_record(temp ? BANTYPE_TEMP : BANTYPE_PERMA, src, temp ? mins : -1, reason)
 
 	del(src.client)
 	//del(src)	// See no reason why to delete mob. Important stuff can be lost. And ban can be lifted before round ends.

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -113,7 +113,7 @@ var/savefile/Banlist
 	ban_unban_log_save("[bannedby] has [temp ? "perma" : ""]banned [ckey]. - Reason: [reason] - This [thisinfo].")
 	log_admin("[bannedby] has banned [ckey].\nReason: [reason]\nThis [thisinfo].")
 	message_admins("<span class='warning'>[bannedby] has banned [ckey].\nReason: [reason]\nThis [thisinfo].</span>")
-	DB_ban_record(temp ? BANTYPE_TEMP : BANTYPE_PERMA, src, temp ? mins : -1, reason)
+	usr.client.holder.DB_ban_record(temp ? BANTYPE_TEMP : BANTYPE_PERMA, src, temp ? mins : -1, reason)
 
 	del(src.client)
 	//del(src)	// See no reason why to delete mob. Important stuff can be lost. And ban can be lifted before round ends.

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -97,6 +97,28 @@ var/savefile/Banlist
 	return 1
 
 
+/mob/proc/GetBanned(reason, bannedby, temp, minutes, address, sticky)
+	AddBan(src.ckey, src.computer_id, reason, bannedby, temp, minutess, address ? lastKnownIP : null)
+	if(sticky)
+		world.SetConfig("SYSTEM/keyban",src.ckey,"type=sticky&reason=[reason]&message=[reason]&admin=[bannedby]")
+		message_admins("[key_name_admin(usr)] has sticky banned [key_name(src)].")
+		log_admin("[key_name(usr)] has sticky banned [key_name(src)].")
+	to_chat(src, "<span class='warning'><BIG><B>You have been banned by [bannedby].\nReason: [reason].</B></BIG></span>")
+	to_chat(src, "<span class='warning'>This is a [temp ? "temporary" : "permanent"] ban[temp ? ", it will be removed in [mins] minutes" : ""].</span>")
+	if(config.banappeals)
+		to_chat(src, "<span class='warning'>To try to resolve this matter head to [config.banappeals]</span>")
+	else
+		to_chat(src, "<span class='warning'>No ban appeals URL has been set.</span>")
+	var/thisinfo = temp ? "will be removed in [mins] minutes" : "is a permanent ban"
+	ban_unban_log_save("[bannedby] has [temp ? "perma" : ""]banned [ckey]. - Reason: [reason] - This [thisinfo].")
+	log_admin("[bannedby] has banned [ckey].\nReason: [reason]\nThis [thisinfo].")
+	message_admins("<span class='warning'>[bannedby] has banned [ckey].\nReason: [reason]\nThis [thisinfo].</span>")
+	feedback_inc(temp ? "ban_tmp_mins" : "ban_perma", temp ? mins : 1)
+	DB_ban_record(temp ? BANTYPE_TEMP : BANTYPE_PERMA, src, temp ? mins : -1, reason)
+
+	del(src.client)
+	//del(src)	// See no reason why to delete mob. Important stuff can be lost. And ban can be lifted before round ends.
+
 /proc/AddBan(ckey, computerid, reason, bannedby, temp, minutes, address)
 
 

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -114,7 +114,7 @@ var/savefile/Banlist
 		ban_unban_log_save("[bannedby] has [temp ? "perma" : ""]banned [ckey]. - Reason: [reason] - This [thisinfo].")
 		log_admin("[bannedby] has banned [ckey].\nReason: [reason]\nThis [thisinfo].")
 		message_admins("<span class='warning'>[bannedby] has banned [ckey].\nReason: [reason]\nThis [thisinfo].</span>")
-		usr.client.holder.DB_ban_record(temp ? BANTYPE_TEMP : BANTYPE_PERMA, src, temp ? mins : -1, reason)
+		usr.client.holder.DB_ban_record(temp ? BANTYPE_TEMP : BANTYPE_PERMA, src, temp ? minutes : -1, reason)
 
 	del(src.client)
 	//del(src)	// See no reason why to delete mob. Important stuff can be lost. And ban can be lifted before round ends.

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1545,6 +1545,7 @@
 		if(istemp == "No")
 			sticky = alert(usr,"Sticky Ban [M.ckey]? Use this only if you never intend to unban the player.","Sticky Icky","Yes", "No") == "Yes"
 		M.GetBanned(reason, usr.ckey, istemp == "Yes", mins, ipban == "Yes", sticky)
+		feedback_inc(istemp == "Yes" ? "ban_tmp_mins" : "ban_perma", istemp == "Yes" ? mins : 1)
 
 	else if(href_list["stickyunban"])
 		if(!check_rights(R_BAN))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1524,7 +1524,7 @@
 
 		// now you can! if(M.client && M.client.holder)	return	//admins cannot be banned. Even if they could, the ban doesn't affect them anyway
 
-		var/istemp == alert("Temporary Ban?",,"Yes","No", "Cancel")
+		var/istemp = alert("Temporary Ban?",,"Yes","No", "Cancel")
 		var/mins = 0
 		switch(istemp)
 			if("Yes")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1524,64 +1524,27 @@
 
 		// now you can! if(M.client && M.client.holder)	return	//admins cannot be banned. Even if they could, the ban doesn't affect them anyway
 
-		switch(alert("Temporary Ban?",,"Yes","No", "Cancel"))
+		var/istemp == alert("Temporary Ban?",,"Yes","No", "Cancel")
+		var/mins = 0
+		switch(istemp)
 			if("Yes")
-				var/mins = input(usr,"How long (in minutes)?","Ban time",1440) as num|null
+				mins = input(usr,"How long (in minutes)?","Ban time",1440) as num|null
 				if(!mins)
 					return
 				if(mins >= 525600)
 					mins = 525599
-				var/reason = input(usr,"Reason?","reason","Griefer") as text|null
-				if(!reason)
-					return
-				AddBan(M.ckey, M.computer_id, reason, usr.ckey, 1, mins)
-				ban_unban_log_save("[usr.client.ckey] has banned [M.ckey]. - Reason: [reason] - This will be removed in [mins] minutes.")
-				to_chat(M, "<span class='warning'><BIG><B>You have been banned by [usr.client.ckey].\nReason: [reason].</B></BIG></span>")
-				to_chat(M, "<span class='warning'>This is a temporary ban, it will be removed in [mins] minutes.</span>")
-				feedback_inc("ban_tmp",1)
-				DB_ban_record(BANTYPE_TEMP, M, mins, reason)
-				feedback_inc("ban_tmp_mins",mins)
-				if(config.banappeals)
-					to_chat(M, "<span class='warning'>To try to resolve this matter head to [config.banappeals]</span>")
-				else
-					to_chat(M, "<span class='warning'>No ban appeals URL has been set.</span>")
-				log_admin("[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.")
-				message_admins("<span class='warning'>[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.</span>")
-
-				del(M.client)
-				//del(M)	// See no reason why to delete mob. Important stuff can be lost. And ban can be lifted before round ends.
-			if("No")
-				var/reason = input(usr,"Reason?","reason","Griefer") as text|null
-				if(!reason)
-					return
-				switch(alert(usr,"IP ban?",,"Yes","No","Cancel"))
-					if("Cancel")
-						return
-					if("Yes")
-						AddBan(M.ckey, M.computer_id, reason, usr.ckey, 0, 0, M.lastKnownIP)
-					if("No")
-						AddBan(M.ckey, M.computer_id, reason, usr.ckey, 0, 0)
-				var/sticky = alert(usr,"Sticky Ban [M.ckey]? Use this only if you never intend to unban the player.","Sticky Icky","Yes", "No") == "Yes"
-				if(sticky)
-					world.SetConfig("SYSTEM/keyban",M.ckey,"type=sticky&reason=[reason]&message=[reason]&admin=[ckey(usr.key)]")
-					message_admins("[key_name_admin(usr)] has sticky banned [key_name(M)].")
-					log_admin("[key_name(usr)] has sticky banned [key_name(M)].")
-				to_chat(M, "<span class='warning'><BIG><B>You have been banned by [usr.client.ckey].\nReason: [reason].</B></BIG></span>")
-				to_chat(M, "<span class='warning'>This is a permanent ban.</span>")
-				if(config.banappeals)
-					to_chat(M, "<span class='warning'>To try to resolve this matter head to [config.banappeals]</span>")
-				else
-					to_chat(M, "<span class='warning'>No ban appeals URL has been set.</span>")
-				ban_unban_log_save("[usr.client.ckey] has permabanned [M.ckey]. - Reason: [reason] - This is a permanent ban.")
-				log_admin("[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis is a permanent ban.")
-				message_admins("<span class='warning'>[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis is a permanent ban.</span>")
-				feedback_inc("ban_perma",1)
-				DB_ban_record(BANTYPE_PERMA, M, -1, reason)
-
-				del(M.client)
-				//del(M)
 			if("Cancel")
 				return
+		var/reason = input(usr,"Reason?","reason","Griefer") as text|null
+		if(!reason)
+			return
+		var/ipban = alert(usr,"IP ban?",,"Yes","No","Cancel")
+		if(ipban == "Cancel")
+			return
+		var/sticky = FALSE
+		if(istemp == "No")
+			sticky = alert(usr,"Sticky Ban [M.ckey]? Use this only if you never intend to unban the player.","Sticky Icky","Yes", "No") == "Yes"
+		M.GetBanned(reason, usr.ckey, istemp == "Yes", mins, ipban == "Yes", sticky)
 
 	else if(href_list["stickyunban"])
 		if(!check_rights(R_BAN))


### PR DESCRIPTION
[content][administration]
Works on admin banhammer, using a normal one in hand with +BAN flags turns it into an admin one, and using that in hand allows the wielder to set the details of the ban. Can only ban others if wielder has +BAN flag.