### PR TITLE
Sodium and water explosions

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -29,7 +29,8 @@
 #define TOXIN 			"toxin"
 #define PLASTICIDE 			"plasticide"
 #define CYANIDE "cyanide"
-#define POTASSIUM_HYDROXIDE 			"potassium_hydroxide"
+#define POTASH 			"POTASH"
+#define LYE 			"lye"
 #define CHEFSPECIAL 			"chefspecial"
 #define MINTTOXIN 			"minttoxin"
 #define MUTATIONTOXIN 			"mutationtoxin"
@@ -533,6 +534,7 @@ var/list/cheartstopper = list(/*"potassium_chloride",*/ CHEESYGLOOP) //this stop
 #define STOXINS list(STOXIN, STOXIN2, VALERENIC_ACID)
 #define SACIDS list(SACID, FORMIC_ACID)
 #define PACIDS list(PACID, PHENOL)
+#define CAUSTICSODAS list(POTASH, LYE)
 #define NEUROTOXINS list(NEUROTOXIN, CURARE)
 #define TOXINS list(TOXIN, SOLANINE)
 #define CRYPTOBIOLINS list(CRYPTOBIOLIN, PHYSOSTIGMINE)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -747,8 +747,8 @@
 		holder.remove_reagent(PLASMA, REM)
 	if(holder.has_any_reagents(SACIDS))
 		holder.remove_reagents(SACIDS, REM)
-	if(holder.has_reagent(POTASSIUM_HYDROXIDE))
-		holder.remove_reagent(POTASSIUM_HYDROXIDE, 2 * REM)
+	if(holder.has_any_reagents(CAUSTICSODAS))
+		holder.remove_reagents(CAUSTICSODAS, 2 * REM)
 	if(holder.has_reagent(CYANIDE))
 		holder.remove_reagent(CYANIDE, REM)
 	if(holder.has_reagent(AMATOXIN))
@@ -867,9 +867,9 @@
 	M.adjustOxyLoss(4)
 	M.sleeping += 1
 
-/datum/reagent/potassium_hydroxide
-	name = "Potassium Hydroxide"
-	id = POTASSIUM_HYDROXIDE
+/datum/reagent/potash
+	name = "Potash"
+	id = POTASH
 	description = "A corrosive chemical used in making soap and batteries."
 	reagent_state = REAGENT_STATE_SOLID
 	overdose_am = REAGENTS_OVERDOSE
@@ -878,12 +878,17 @@
 	density = 2.12
 	specheatcap = 65.87 //how much energy in joules it takes to heat this thing up by 1 degree (J/g). round to 2dp
 
-/datum/reagent/potassium_hydroxide/on_mob_life(var/mob/living/M)
+/datum/reagent/potash/on_mob_life(var/mob/living/M)
 
 	if(..())
 		return 1
 
 	M.adjustFireLoss(1.5 * REM)
+
+/datum/reagent/potash/lye
+	name = "Lye"
+	id = LYE
+	description = "Also known as caustic soda, a corrosive chemical used in making soap and treating meat."
 
 //Quiet and lethal, needs at least 4 units in the person before they'll die
 /datum/reagent/chefspecial
@@ -3526,8 +3531,8 @@
 		holder.remove_reagent(PLASMA, REM)
 	if(holder.has_any_reagents(SACIDS))
 		holder.remove_reagents(SACIDS, REM)
-	if(holder.has_reagent(POTASSIUM_HYDROXIDE))
-		holder.remove_reagent(POTASSIUM_HYDROXIDE, 2 * REM)
+	if(holder.has_any_reagents(CAUSTICSODAS))
+		holder.remove_reagents(CAUSTICSODAS, 2 * REM)
 	if(holder.has_reagent(CYANIDE))
 		holder.remove_reagent(CYANIDE, REM)
 	if(holder.has_reagent(AMATOXIN))

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -86,7 +86,7 @@
 			e.amount *= 0.5
 	e.start()
 	holder.clear_reagents()
-	holder.add_reagent(POTASSIUM_HYDROXIDE, created_volume)
+	holder.add_reagent(POTASH, created_volume)
 
 /datum/chemical_reaction/explosion_potassium/holy
 	id = "holy_explosion_potassium"
@@ -97,11 +97,30 @@
 	..()
 	playsound(holder.my_atom, 'sound/misc/holyhandgrenade.ogg', 100, 1)
 
+/datum/chemical_reaction/explosion_potassium/sodium
+	name = "Water Sodium Explosion"
+	id = "explosion_sodium"
+	required_reagents = list(SODIUM = 1, WATER = 1)
+
+/datum/chemical_reaction/explosion_potassium/sodium/on_reaction(var/datum/reagents/holder, var/created_volume)
+	..()
+	holder.clear_reagents()
+	holder.add_reagent(LYE, created_volume)
+
+/datum/chemical_reaction/explosion_potassium/holy/sodium
+	id = "holy_explosion_sodium"
+	required_reagents = list(SODIUM = 1, HOLYWATER = 1)
+
+/datum/chemical_reaction/explosion_potassium/holy/sodium/on_reaction(var/datum/reagents/holder, var/created_volume)
+	..()
+	holder.clear_reagents()
+	holder.add_reagent(LYE, created_volume)
+
 /datum/chemical_reaction/soap //Potassium Hydroxide is used in making liquid soap not bar soap but that will not stop me
 	name = "Soap"
 	id = "soap"
 	result = null
-	required_reagents = list(POTASSIUM_HYDROXIDE = 20, NUTRIMENT = 5)
+	required_reagents = list(CAUSTICSODAS = 20, NUTRIMENT = 5)
 	required_temp = T0C + 50
 	result_amount = 1
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -103,8 +103,9 @@
 	required_reagents = list(SODIUM = 1, WATER = 1)
 
 /datum/chemical_reaction/explosion_potassium/sodium/on_reaction(var/datum/reagents/holder, var/created_volume)
-	..()
-	holder.clear_reagents()
+	if(!(holder.has_reagent(CARBON,3) && holder.has_reagent(WATER,1)))
+		..()
+		holder.clear_reagents()
 	holder.add_reagent(LYE, created_volume)
 
 /datum/chemical_reaction/explosion_potassium/holy/sodium
@@ -290,7 +291,7 @@
 	name = "Sodium Polyacrylate"
 	id = SODIUM_POLYACRYLATE
 	result = SODIUM_POLYACRYLATE
-	required_reagents = list(CARBON = 3, LYE = 1, WATER = 1)
+	required_reagents = list(CARBON = 3, LYE = 2, WATER = 1)
 	result_amount = 8
 
 /datum/chemical_reaction/spoly_absorb_water

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -290,7 +290,7 @@
 	name = "Sodium Polyacrylate"
 	id = SODIUM_POLYACRYLATE
 	result = SODIUM_POLYACRYLATE
-	required_reagents = list(CARBON = 3, SODIUM = 1, WATER = 2)
+	required_reagents = list(CARBON = 3, LYE = 1, WATER = 1)
 	result_amount = 8
 
 /datum/chemical_reaction/spoly_absorb_water


### PR DESCRIPTION
[content][tested]
Mainly done for immulsions sake, the reaction from this also creates a chemical similar to potassium hydroxide called lye. The former has also been renamed potash, for consistency.
Tested with chemical reactions, no real hiccups or new risks of explosions with normal recipes, (save sodium polyacrylate) just be extra careful from now on with the order of ingredients of any reaction that uses both sodium and water at any point, making sure they aren't in the beaker together.
:cl:
 * rscadd: Sodium and water are not safe to mix by themselves anymore. Its product is now lye, a potassium hydroxide analogue.
 * tweak: Potassium hydroxide has been renamed potash.