### PR TITLE
Walking over people who are lying down with mechs hurts them

### DIFF
--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -11,6 +11,7 @@
 	//operation_req_access = list(access_hos)
 	damage_absorption = list("brute"=0.7,"fire"=1,"bullet"=0.7,"laser"=0.85,"energy"=1,"bomb"=0.8)
 	var/am = "d3c2fbcadca903a41161ccc9df9cf948"
+	step_damage = 15
 
 /*
 /obj/mecha/combat/range_action(target as obj|mob|turf)

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -22,6 +22,7 @@
 		"darkgygax_old",
 		"pobeda"
 	)
+	step_damage = 10
 
 /obj/mecha/combat/gygax/dark
 	desc = "A lightweight exosuit used by Nanotrasen Death Squads. A significantly upgraded Gygax security mech."

--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -15,6 +15,7 @@
 	add_req_access = 0
 	max_equip = 3
 	var/squeak = 0
+	step_damage = 0
 
 /*
 /obj/mecha/combat/honker/New()

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -26,6 +26,7 @@
 	max_equip = 4
 	starts_with_tracking_beacon = FALSE
 	paintable = 0
+	step_damage = 20
 
 /obj/mecha/combat/marauder/seraph
 	desc = "Heavy-duty, command-type exosuit. This is a custom model, utilized only by high-ranking military personnel."

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -95,7 +95,7 @@
 	var/list/mech_sprites = list() //sprites alternatives for a given mech. Only have to enter the name of the paint scheme
 	var/paintable = 0
 
-	var/step_damage = 15 //For stepping on mobs
+	var/step_damage = 10 //For stepping on mobs
 	var/step_coolingdown = FALSE
 	var/step_over_cooldown = 3 SECONDS //Similar to mulebot
 
@@ -418,13 +418,13 @@
 	return result
 
 /obj/mecha/proc/StepOnCreature(var/mob/living/H)
-	if(step_over_cooldown && !H.lying) // Has to be on floor for this, mechs can't knock people over as easily.
+	if(step_coolingdown && !H.lying) // Has to be on floor for this, mechs can't knock people over as easily.
 		return
 	src.visible_message("<span class='warning'>[src] steps on [H]!</span>")
 	playsound(src, 'sound/effects/splat.ogg', 50, 1)
 	var/damage = rand(step_damage/3,step_damage) // Even higher than mulebots since big and heavy.
-	H.apply_damage(2*damage, BRUTE, LIMB_HEAD)
-	H.apply_damage(2*damage, BRUTE, LIMB_CHEST)
+	H.apply_damage(damage, BRUTE, LIMB_HEAD)
+	H.apply_damage(damage, BRUTE, LIMB_CHEST)
 	H.apply_damage(0.5*damage, BRUTE, LIMB_LEFT_LEG)
 	H.apply_damage(0.5*damage, BRUTE, LIMB_RIGHT_LEG)
 	H.apply_damage(0.5*damage, BRUTE, LIMB_LEFT_ARM)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -95,6 +95,10 @@
 	var/list/mech_sprites = list() //sprites alternatives for a given mech. Only have to enter the name of the paint scheme
 	var/paintable = 0
 
+	var/step_damage = 15 //For stepping on mobs
+	var/step_coolingdown = FALSE
+	var/step_over_cooldown = 3 SECONDS //Similar to mulebot
+
 /obj/mecha/get_cell()
 	return cell
 
@@ -412,6 +416,26 @@
 	if(result)
 	 playsound(src, get_sfx("mechstep"),40,1)
 	return result
+
+/obj/mecha/proc/StepOnCreature(var/mob/living/H)
+	if(step_over_cooldown && !H.lying) // Has to be on floor for this, mechs can't knock people over as easily.
+		return
+	src.visible_message("<span class='warning'>[src] steps on [H]!</span>")
+	playsound(src, 'sound/effects/splat.ogg', 50, 1)
+	var/damage = rand(step_damage/3,step_damage) // Even higher than mulebots since big and heavy.
+	H.apply_damage(2*damage, BRUTE, LIMB_HEAD)
+	H.apply_damage(2*damage, BRUTE, LIMB_CHEST)
+	H.apply_damage(0.5*damage, BRUTE, LIMB_LEFT_LEG)
+	H.apply_damage(0.5*damage, BRUTE, LIMB_RIGHT_LEG)
+	H.apply_damage(0.5*damage, BRUTE, LIMB_LEFT_ARM)
+	H.apply_damage(0.5*damage, BRUTE, LIMB_RIGHT_ARM)
+	if(step_over_cooldown)
+		step_over_coolingdown()
+
+/obj/mecha/proc/step_over_coolingdown()
+	step_coolingdown = TRUE
+	spawn(step_over_cooldown)
+		step_coolingdown = FALSE
 
 /obj/mecha/to_bump(atom/obstacle)
 	.=..()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -97,7 +97,7 @@
 
 	var/step_damage = 10 //For stepping on mobs
 	var/step_coolingdown = FALSE
-	var/step_over_cooldown = 3 SECONDS //Similar to mulebot
+	var/step_over_cooldown = 5 SECONDS //Higher than average
 
 /obj/mecha/get_cell()
 	return cell

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -418,7 +418,7 @@
 	return result
 
 /obj/mecha/proc/StepOnCreature(var/mob/living/H)
-	if(step_coolingdown && !H.lying) // Has to be on floor for this, mechs can't knock people over as easily.
+	if(step_coolingdown || !H.lying) // Has to be on floor for this, mechs can't knock people over as easily.
 		return
 	src.visible_message("<span class='warning'>[src] steps on [H]!</span>")
 	playsound(src, 'sound/effects/splat.ogg', 50, 1)

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -18,6 +18,7 @@
 		"paramed",
 		"urinetrouble"
 	)
+	step_damage = 0
 
 /obj/mecha/medical/odysseus/New()
 	..()

--- a/code/game/mecha/working/clarke.dm
+++ b/code/game/mecha/working/clarke.dm
@@ -23,6 +23,7 @@
 		"veteranclarke"
 	)
 	paintable = 1
+	step_damage = 0
 
 /obj/mecha/working/clarke/New()
 	..()

--- a/code/game/objects/structures/vehicles/wheelchair.dm
+++ b/code/game/objects/structures/vehicles/wheelchair.dm
@@ -283,7 +283,7 @@
 			L.update_icons()
 	..()
 
-/obj/structure/bed/chair/vehicle/wheelchair/motorized/syndicate/proc/crush(var/mob/living/H,var/bloodcolor) //Basically identical to the MULE, see mulebot.dm
+/obj/structure/bed/chair/vehicle/wheelchair/motorized/syndicate/proc/crush(var/mob/living/H) //Basically identical to the MULE, see mulebot.dm
 	src.visible_message("<span class='warning'>[src] drives over [H]!</span>")
 	playsound(src, 'sound/effects/splat.ogg', 50, 1)
 	var/damage = rand(5,10) //We're not as heavy as a MULE. Where it does 30-90 damage, we do 15-30 damage

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -330,8 +330,12 @@
 	var/obj/structure/bed/chair/vehicle/wheelchair/motorized/syndicate/WC = AM
 	if(istype(WC))
 		if(!WC.attack_cooldown)
-			WC.crush(src,species.blood_color)
+			WC.crush(src)
 			blood = 1
+	var/obj/mecha/MC = AM
+	if(istype(MC))
+		MC.StepOnCreature(src)
+		blood = 1
 	var/obj/machinery/bot/cleanbot/roomba/R = AM
 	if(istype(R))
 		if(R.armed)


### PR DESCRIPTION
[content]
Another idea by @drawsstuff 
Base damage is roughly 20-40 per treading, with a 5 second delay. Combat mechs do slightly higher damage at 30-60, (except for gygax and HONK, latter doing none at all) and with odysseus and clarkes doing none at all and marauders doing the highest at 40-80.

:cl:
 * rscadd: Mechs now do damage to mobs it treads over if they're lying down.