### PR TITLE
SCP-294 tweaks and improvements

### DIFF
--- a/code/game/machinery/scp_294.dm
+++ b/code/game/machinery/scp_294.dm
@@ -96,7 +96,7 @@
 			if(findtext(input_reagent,"'s blood"))
 				bloodonly = 1
 				input_reagent = replacetext(input_reagent,"'s blood","")
-			if(input_reagent == L.name || input_reagent in mob_name_parts)
+			if(input_reagent == L.name || (input_reagent in mob_name_parts))
 				mobfound = L
 				break
 		// Then searches through the list of all reagents and ignores case, plus converts spaces into either nothing or underscores for IDs

--- a/code/game/machinery/scp_294.dm
+++ b/code/game/machinery/scp_294.dm
@@ -68,29 +68,56 @@
 			detach()
 
 	if(href_list["input"])
-		if(container)
-			var/input_reagent = input("Enter the name of any liquid", "Input") as text
-			if ((input_reagent in prohibited_reagents) || ((input_reagent in emagged_only_reagents) && !emagged))
-				say("OUT OF RANGE")
-				return
+		var/input_reagent = input("Enter the name of any liquid", "Input") as text
+		input_reagent = lowertext(input_reagent) // Lowercase for easier parsing
+		if(findtext(input_reagent,"a cup of ")) // These appear at the start of a lot of requests in the SCP so parse these properly too
+			input_reagent = replacetext(input_reagent,"a cup of ","")
+		else if(findtext(input_reagent,"cup of ",0,7))
+			input_reagent = replacetext(input_reagent,"cup of ","")
+		if(!container) // Spawn a paper cup like in SCP if no container is inserted
+			container = new/obj/item/weapon/reagent_containers/food/drinks/sillycup(src)
+		var/obj/item/weapon/reagent_containers/X = src.container
+		var/datum/reagents/U = X.reagents
+		if(!U)
+			if(!X.gcDestroyed)
+				X.create_reagents(X.volume)
 			else
-				var/obj/item/weapon/reagent_containers/glass/X = src.container
-				var/datum/reagents/U = X.reagents
-				if(!U)
-					if(!X.gcDestroyed)
-						X.create_reagents(X.volume)
-					else
-						qdel(X)
-						X = null
-						return
-				var/space = U.maximum_volume - U.total_volume
+				qdel(X)
+				X = null
+				return
+		var/space = U.maximum_volume - U.total_volume
 
-				// so we get no runtimes
-				try
-					U.add_reagent(input_reagent, min(amount, energy * 10, space))
-					energy = max(energy - min(amount, energy * 10, space) / 10, 0)
-				catch
-					say("OUT OF RANGE")
+		var/chemfound = FALSE
+		var/mob/living/mobfound = null
+		var/bloodonly = 0 // This is a number for subtraction purposes, see below
+		// First checks for all living mobs to see if input matches their name to take stuff from, like the cup of joe in the original SCP
+		for(var/mob/living/L in mob_list)
+			var/list/mob_name_parts = splittext(L.name," ")
+			if(findtext(input_reagent,"'s blood"))
+				bloodonly = 1
+				input_reagent = replacetext(input_reagent,"'s blood","")
+			if(input_reagent == L.name || input_reagent in mob_name_parts)
+				mobfound = L
+				break
+		// Then searches through the list of all reagents and ignores case, plus converts spaces into either nothing or underscores for IDs
+		// (due to no consistent alternating between either)
+		for(var/reagent_id in chemical_reagents_list)
+			var/datum/reagent/R = chemical_reagents_list[reagent_id]
+			if(input_reagent == lowertext(R.name) || input_reagent == lowertext(reagent_id) || lowertext(reagent_id) == replacetext(input_reagent," ","") || lowertext(reagent_id) == replacetext(input_reagent," ","_"))
+				input_reagent = reagent_id
+				chemfound = TRUE
+				break
+		if(mobfound && mobfound.reagents && !mobfound.status_flags & GODMODE && !mobfound.flags & INVULNERABLE)
+			// Take half from each unless only taking blood, then take all from blood instead
+			mobfound.take_blood(X, (min(amount, energy * 10, space)) / (2 - bloodonly))
+			if(!bloodonly)
+				mobfound.reagents.trans_to(U, (min(amount, energy * 10, space)) / 2)
+			energy = max(energy - min(amount, energy * 10, space) / 10, 0)
+		else if(chemfound && !(input_reagent in prohibited_reagents) && !((input_reagent in emagged_only_reagents) && !emagged))
+			U.add_reagent(input_reagent, min(amount, energy * 10, space))
+			energy = max(energy - min(amount, energy * 10, space) / 10, 0)
+		else
+			say("OUT OF RANGE")
 
 	add_fingerprint(usr)
 	return 1 // update UIs attached to this object

--- a/code/game/machinery/scp_294.dm
+++ b/code/game/machinery/scp_294.dm
@@ -108,6 +108,8 @@
 				chemfound = TRUE
 				break
 		if(mobfound && mobfound.reagents && !(mobfound.status_flags & GODMODE) && !(mobfound.flags & INVULNERABLE))
+			if(!mobfound.reagents.total_volume) // Stops division by zero runtime
+				bloodonly = TRUE
 			// Take half from each unless only taking blood, then take all from blood instead
 			mobfound.take_blood(X, (min(amount, energy * 10, space)) / (2 - bloodonly))
 			if(!bloodonly)

--- a/code/game/machinery/scp_294.dm
+++ b/code/game/machinery/scp_294.dm
@@ -107,7 +107,7 @@
 				input_reagent = reagent_id
 				chemfound = TRUE
 				break
-		if(mobfound && mobfound.reagents && !mobfound.status_flags & GODMODE && !mobfound.flags & INVULNERABLE)
+		if(mobfound && mobfound.reagents && !(mobfound.status_flags & GODMODE) && !(mobfound.flags & INVULNERABLE))
 			// Take half from each unless only taking blood, then take all from blood instead
 			mobfound.take_blood(X, (min(amount, energy * 10, space)) / (2 - bloodonly))
 			if(!bloodonly)

--- a/nano/templates/scp_294.tmpl
+++ b/nano/templates/scp_294.tmpl
@@ -8,7 +8,7 @@ Used In File(s): /obj/machinery/chem_dispenser/scp_294
 	</div>
 	<div class="itemContent">
 		{{:helper.link(data.glass ? 'Eject Glass' : 'Eject Recipient', 'eject', {'ejectBeaker' : 1}, data.isBeakerLoaded ? null : 'disabled', 'floatRight')}}
-		{{:helper.link('Input', 'circle-arrow-s', {'input' : 1}, 'floatRight')}}
+		{{:helper.link('Input', 'circle-arrow-s', {'input' : 1}, null, 'floatRight')}}
 	</div>
 </div>
 

--- a/nano/templates/scp_294.tmpl
+++ b/nano/templates/scp_294.tmpl
@@ -8,7 +8,7 @@ Used In File(s): /obj/machinery/chem_dispenser/scp_294
 	</div>
 	<div class="itemContent">
 		{{:helper.link(data.glass ? 'Eject Glass' : 'Eject Recipient', 'eject', {'ejectBeaker' : 1}, data.isBeakerLoaded ? null : 'disabled', 'floatRight')}}
-		{{:helper.link('Input', 'circle-arrow-s', {'input' : 1}, data.isBeakerLoaded ? null : 'disabled', 'floatRight')}}
+		{{:helper.link('Input', 'circle-arrow-s', {'input' : 1}, 'floatRight')}}
 	</div>
 </div>
 


### PR DESCRIPTION
[tweak][content]
Makes looking up names of chemicals to spawn not case sensitive anymore in checks, plus truncates spaces and/or converts them to underscores and also checks actual reagent names along with their ID.
As a bonus, these now support entering a mob's name to grab some reagents and blood out of them to make them more faithful to the original, as well as spawning a paper cup for the reagents if none is entered. (and allowing input with none inside to follow on this)

:cl:
 * rscadd: Strange coffee machines have improved their chemical seeking capabilities, being able to retrieve them from mobs and being less specific with names.