### PR TITLE
Fixes power machinery terminals not shuttle rotating (and a runtime)

### DIFF
--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -94,8 +94,14 @@
 
 /obj/machinery/power/shuttle_rotate(angle)
 	..()
-	if(terminal.dir != get_dir(terminal.loc, src))
+	if(terminal && terminal.dir != get_dir(terminal.loc, src))
 		terminal.dir = get_dir(terminal.loc, src)
+
+/obj/machinery/power/apc/shuttle_rotate(angle)
+	..()
+	tdir = dir
+	if(terminal && terminal.dir != tdir)
+		terminal.dir = tdir
 
 /obj/machinery/power/proc/can_attach_terminal(mob/user)
 	return user.loc != src.loc && (get_dir(user, src) in cardinal) && !terminal


### PR DESCRIPTION
[bugfix][runtime]
Was causing this every time the server started up, too.
Should fix how they appear in vaults and etc.

:cl:
 * bugfix: Power terminals are now found connected to their machinery properly in alternate orientations of space structures.