### PR TITLE
Fixes time agent locate objective attempting to create duplicate nuke disk

### DIFF
--- a/code/datums/gamemode/objectives/target/locate.dm
+++ b/code/datums/gamemode/objectives/target/locate.dm
@@ -28,8 +28,11 @@ var/list/potential_locate_objects = list(/obj/item/weapon/bikehorn/rubberducky,
 	var/max = (object_max >= object_min) ? object_max : (potential_objects.len-1)
 	for(var/i = 0 to rand(min,max))
 		var/type = pick(potential_objects)
-		var/atom/pick = new type
-		objects_to_locate.Add(pick)
+		if(type == /obj/item/weapon/disk/nuclear) // Singleton item, behaves differently.
+			objects_to_locate.Add(nukedisk)
+		else
+			var/atom/pick = new type
+			objects_to_locate.Add(pick)
 		potential_objects.Remove(type)
 	explanation_text = format_explanation()
 	return TRUE


### PR DESCRIPTION
[bugfix]
...and failing to do so, nulling the reference and breaking the objective.

:cl:
 * bugfix: Time agents can now locate the nuclear authentication disk properly.