### PR TITLE
Body archive mind transfer on spawning option.

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -190,6 +190,12 @@
 			return M
 	return null
 
+/proc/get_mind_by_key(var/key)
+	for(var/datum/mind/M in ticker.minds)
+		if(lowertext(M.key) == lowertext(key))
+			return M
+	return null
+
 // Comment out when done testing shit.
 //#define DEBUG_ROLESELECT
 

--- a/code/datums/body_archive.dm
+++ b/code/datums/body_archive.dm
@@ -28,13 +28,13 @@ var/list/body_archives = list()
 
 /datum/body_archive/proc/spawn_copy(var/turf/T)//admin toy
 	var/mob/temp_mob = new mob_type(T)
-	var/spawn_naked = ishuman(M) && alert("Keep current job equipment again or not?", "Body Resetting", "Keep Outfit", "Spawn Naked") == "Keep Outfit"
+	var/spawn_naked = ishuman(temp_mob) && alert("Keep current job equipment again or not?", "Body Resetting", "Keep Outfit", "Spawn Naked") == "Keep Outfit"
 	temp_mob.actually_reset_body(src, FALSE, spawn_naked, null, null)
 	qdel(temp_mob)
 
 /datum/body_archive/proc/spawn_transfer(var/turf/T)//admin toy
 	var/mob/temp_mob = new mob_type(T)
-	var/spawn_naked = ishuman(M) && alert("Let them get their current job equipment again or not?", "Body Resetting", "Keep Outfit", "Spawn Naked") == "Keep Outfit"
+	var/spawn_naked = ishuman(temp_mob) && alert("Let them get their current job equipment again or not?", "Body Resetting", "Keep Outfit", "Spawn Naked") == "Keep Outfit"
 	temp_mob.actually_reset_body(src, FALSE, spawn_naked, null, get_mind_by_key(src.key))
 	qdel(temp_mob)
 

--- a/code/datums/body_archive.dm
+++ b/code/datums/body_archive.dm
@@ -29,6 +29,11 @@ var/list/body_archives = list()
 	temp_mob.actually_reset_body(src, FALSE, null, null)
 	qdel(temp_mob)
 
+/datum/body_archive/proc/spawn_transfer(var/turf/T)//admin toy
+	var/mob/temp_mob = new mob_type(T)
+	temp_mob.actually_reset_body(src, FALSE, null, get_mind_by_key(src.key))
+	qdel(temp_mob)
+
 ////////////////////////////////////////////////////////////////////
 //																  //
 //							MOB PROCS							  //

--- a/code/datums/body_archive.dm
+++ b/code/datums/body_archive.dm
@@ -8,6 +8,7 @@ var/list/body_archives = list()
 	// those of the source mind
 	var/name
 	var/key
+	var/rank
 
 	// just an empty list where you can store extra data, such as human DNA records
 	var/list/data = list()
@@ -21,17 +22,20 @@ var/list/body_archives = list()
 	mob_type = source.type
 	name = source.mind.name
 	key = source.mind.key
+	rank = source.mind.assigned_role
 	log_debug("[key_name(source)] has has had their body ([mob_type]) archived.")
 	source.archive_body(src)
 
 /datum/body_archive/proc/spawn_copy(var/turf/T)//admin toy
 	var/mob/temp_mob = new mob_type(T)
-	temp_mob.actually_reset_body(src, FALSE, TRUE, null, null)
+	var/spawn_naked = ishuman(M) && alert("Keep current job equipment again or not?", "Body Resetting", "Keep Outfit", "Spawn Naked") == "Keep Outfit"
+	temp_mob.actually_reset_body(src, FALSE, spawn_naked, null, null)
 	qdel(temp_mob)
 
 /datum/body_archive/proc/spawn_transfer(var/turf/T)//admin toy
 	var/mob/temp_mob = new mob_type(T)
-	temp_mob.actually_reset_body(src, FALSE, FALSE, null, get_mind_by_key(src.key))
+	var/spawn_naked = ishuman(M) && alert("Let them get their current job equipment again or not?", "Body Resetting", "Keep Outfit", "Spawn Naked") == "Keep Outfit"
+	temp_mob.actually_reset_body(src, FALSE, spawn_naked, null, get_mind_by_key(src.key))
 	qdel(temp_mob)
 
 ////////////////////////////////////////////////////////////////////
@@ -189,11 +193,11 @@ var/list/body_archives = list()
 			if (transfered_held_item)
 				old_mob.drop_item(transfered_held_item,loc,TRUE)
 				H.put_in_hands(transfered_held_item)
-	else if(our_mind && !spawn_naked)
-		var/datum/job/J = GetJob(our_mind.assigned_role)
+	else if(!spawn_naked)
+		var/datum/job/J = GetJob(archive.rank)
 		if(J)
 			J.equip(H, J.priority)
-		H.job = our_mind.assigned_role
+		H.job = archive.rank
 
 	//Maybe putting some pants on too
 	H.underwear = archive.data["underwear"]

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -891,6 +891,8 @@ function loadPage(list) {
 			return
 		if (ishuman(M) && alert("Since you are resetting a human, do you want them to keep their current inventory equipped or drop it all on the floor?", "Body Resetting", "Keep Inventory", "Drop Everything") == "Keep Inventory")
 			M.reset_body(keep_clothes = TRUE)
+		else if (ishuman(M) && alert("Since you are resetting a human, do you want them to get their current job equipment again or not?", "Body Resetting", "Keep Outfit", "Spawn Naked") == "Keep Outfit")
+			M.reset_body(spawn_naked = FALSE)
 		else
 			M.reset_body()
 		add_gamelogs(usr, " reset [(M == usr) ? "their own" : "[key_name(M)]'s"] body from its archive.", admin = TRUE, tp_link = TRUE)

--- a/code/modules/admin/body_archive_panel.dm
+++ b/code/modules/admin/body_archive_panel.dm
@@ -26,6 +26,7 @@
 		<th style="width:1%">Key</th>
 		<th style="width:1%">Name</th>
 		<th style="width:0.5%">Spawn Copy</th>
+		<th style="width:1%">Spawn and Transfer</th>
 		<th style="width:1%">Mob Type</th>
 		</tr>
 		"}
@@ -35,6 +36,7 @@
 			<td>[archive.key]</td>
 			<td>[archive.name]</td>
 			<td><a href='?src=\ref[src];bodyarchivepanel_spawncopy=\ref[archive]'>\[SPAWN\]</a></td>
+			<td><a href='?src=\ref[src];bodyarchivepanel_spawntransfer=\ref[archive]'>\[SPAWN+TRANSFER\]</a></td>
 			<td><i>[archive.mob_type]</i></td>
 			</tr>
 			"}
@@ -44,4 +46,4 @@
 		</html>
 		"}
 
-	usr << browse(dat, "window=bodyarchivepanel;size=860x500")
+	usr << browse(dat, "window=bodyarchivepanel;size=860x640")

--- a/code/modules/admin/body_archive_panel.dm
+++ b/code/modules/admin/body_archive_panel.dm
@@ -25,6 +25,7 @@
 		<tr>
 		<th style="width:1%">Key</th>
 		<th style="width:1%">Name</th>
+		<th style="width:1%">Rank</th>
 		<th style="width:0.5%">Spawn Copy</th>
 		<th style="width:1%">Spawn and Transfer</th>
 		<th style="width:1%">Mob Type</th>
@@ -35,6 +36,7 @@
 		dat += {"<tr>
 			<td>[archive.key]</td>
 			<td>[archive.name]</td>
+			<td>[archive.rank]</td>
 			<td><a href='?src=\ref[src];bodyarchivepanel_spawncopy=\ref[archive]'>\[SPAWN\]</a></td>
 			<td><a href='?src=\ref[src];bodyarchivepanel_spawntransfer=\ref[archive]'>\[SPAWN+TRANSFER\]</a></td>
 			<td><i>[archive.mob_type]</i></td>

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -634,6 +634,14 @@
 
 		archive.spawn_copy(get_turf(usr))
 
+	else if(href_list["bodyarchivepanel_spawntransfer"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		var/datum/body_archive/archive = locate(href_list["bodyarchivepanel_spawntransfer"])
+
+		archive.spawn_transfer(get_turf(usr))
+
 	else if(href_list["climate_timeleft"])
 		if(!check_rights(R_ADMIN))
 			return


### PR DESCRIPTION
[administration][qol]
Saves having to manually transfer the key to a new body if the old one is lost, when creating a fresh one.
Also lets archived body copies have their starting job outfit again, and tracks their old assigned role.