### PR TITLE
Female characters can no longer be captains 2: Electric Boogaloo

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -11,6 +11,7 @@
 	minimal_access = list() 	//See get_access()
 	minimal_player_age = 30
 	species_whitelist = list("Human")
+	gender_blacklist = list("female")
 
 	outfit_datum = /datum/outfit/captain
 

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -46,6 +46,7 @@
 
 	var/list/species_blacklist = list("Mushroom") //Job not available to species in this list - shrooms can only be traders
 	var/list/species_whitelist = list() //If this list isn't empty, job is only available to species in this list
+	var/list/gender_blacklist = list() //Characters with specific genders in this list are not allowed to play the job
 
 	var/must_be_map_enabled = 0	//If 1, this job only appears on maps on which it's enabled (its type must be in the map's "enabled_jobs" list)
 								//Example:      enabled_jobs = list(/datum/job/trader) //Enable "trader" job for this map

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -555,6 +555,9 @@ var/const/MAX_SAVE_SLOTS = 16
 		else if(job.species_blacklist.Find(src.species))
 			prefLevelLabel = "Unavailable"
 			prefLevelColor = "gray"
+		else if(job.gender_blacklist.Find(src.gender))
+			prefLevelLabel = "[uppertext(src.gender)]"
+			prefLevelColor = "gray"
 		else
 			switch(jobs[job.title])
 				if(JOB_PREF_HIGH)
@@ -752,6 +755,9 @@ var/const/MAX_SAVE_SLOTS = 16
 
 			to_chat(user, "<span class='notice'>Only the following species can have this job: [allowed_species]. Your species is ([src.species]).</span>")
 			return
+	if(job.gender_blacklist.len)
+		if(job.gender_blacklist.Find(src.gender))
+			to_chat(user, "<span class='notice'>Your gender ([src.gender]) cannot have this job.</span>")
 
 	var/new_value = jobs[job.title]
 	if(increase)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -365,6 +365,10 @@
 		if(job.species_blacklist.Find(client.prefs.species))
 			to_chat(src, alert("[rank] is not available for [client.prefs.species]."))
 			return 0
+	if(job.gender_blacklist.len)
+		if(job.gender_blacklist.Find(client.prefs.gender))
+			to_chat(src, alert("[rank] is not available for [client.prefs.gender]s"))
+			return 0
 
 	job_master.AssignRole(src, rank, 1)
 


### PR DESCRIPTION
As the climate of our server has shifted in the last 2 years and on the insistence of certain players I have felt that it is right to revive #25592. It is tweaked to account for the changes made to the job system since then.
Adds a gender blacklist system.
Tested. It is not possible to set preferences for captaining, nor latejoin.
To-do: Make it possible for this restriction to be ignored during high-priority job listing, signifying the desperation of having a job occupied as soon as possible. Must also test the preference system further. Look into an age-restriction system so that 17yos cannot be captain
:cl:
 * tweak: Female characters can no longer be captains.