### PR TITLE
Cable cut logging updates

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -254,21 +254,17 @@ By design, d1 is the smallest direction and d2 is the highest
 	//investigate_log("was cut by [key_name(usr, usr.client)] in [user.loc.loc]","wires")
 
 	var/message = "A wire has been cut "
-	var/atom/A = user
+	var/area/my_area = user ? get_area(user) : get_area(T)
 
-	if(A)
-		var/turf/Z = get_turf(A)
-		var/area/my_area = get_area(Z)
+	if(my_area)
+		message += {"in [my_area.name]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</A>) [user ? "(<A HREF='?_src_=vars;Vars=\ref[user]'>VV</A>)" : ""]"}
 
-		message += {"in [my_area.name]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</A>) (<A HREF='?_src_=vars;Vars=\ref[A]'>VV</A>)"}
+	if(user)
+		message += " - Cut By: [user.real_name] ([user.key]) (<A HREF='?_src_=holder;adminplayeropts=\ref[user]'>PP</A>) (<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>)"
+		log_game("[user.real_name] ([user.key]) cut a wire in [my_area.name] ([T.x],[T.y],[T.z])")
 
-		var/mob/M = get_holder_of_type(A, /mob) //Why is this here? The use already IS a mob...
-
-		if(M)
-			message += " - Cut By: [M.real_name] ([M.key]) (<A HREF='?_src_=holder;adminplayeropts=\ref[M]'>PP</A>) (<A HREF='?_src_=holder;adminmoreinfo=\ref[M]'>?</A>)"
-			log_game("[M.real_name] ([M.key]) cut a wire in [my_area.name] ([T.x],[T.y],[T.z])")
-
-	message_admins(message, 0, 1)
+	if(powernet.load)
+		message_admins(message, 0, 1)
 
 	qdel(src)
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -256,12 +256,15 @@ By design, d1 is the smallest direction and d2 is the highest
 	var/message = "A wire has been cut "
 	var/area/my_area = user ? get_area(user) : get_area(T)
 
+	if(powernet.load)
+		message += "with a load of [powernet.load] and avail of [powernet.avail] spanning [powernet.cables.len] cables "
+
 	if(my_area)
 		message += {"in [my_area.name]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</A>) [user ? "(<A HREF='?_src_=vars;Vars=\ref[user]'>VV</A>)" : ""]"}
 
 	if(user)
 		message += " - Cut By: [user.real_name] ([user.key]) (<A HREF='?_src_=holder;adminplayeropts=\ref[user]'>PP</A>) (<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>)"
-		log_game("[user.real_name] ([user.key]) cut a wire in [my_area.name] ([T.x],[T.y],[T.z])")
+		log_game("[user.real_name] ([user.key]) cut a wire in [my_area.name] with a load of [powernet.load] and avail of [powernet.avail] spanning [powernet.cables.len] cables ([T.x],[T.y],[T.z])")
 
 	if(powernet.load)
 		message_admins(message, 0, 1)


### PR DESCRIPTION
[administration]
Only messages admins if powernet on cable has load, also shows powernet cable size, load and avail on cut.
Also removes the redundant user-to-atom-to-user conversion thing.