### PR TITLE
borer chat darkmode fix

### DIFF
--- a/goon/browserassets/css/browserOutput_dark.css
+++ b/goon/browserassets/css/browserOutput_dark.css
@@ -37,6 +37,7 @@ a:visited {color: #b76ff5;}
 .alien {color: #b162a9;}
 .solcom	{color: #256194;}
 .clown {color: #FBFF35; font-family: Comic Sans MS, Comic Sans, cursive;}
+.borer {color: #B300B3; font-weight: bold;}
 
 .radio {color: #1ecc43;}
 .comradio {color: #5177ff;}


### PR DESCRIPTION
-->
:cl:
 * tweak: Borer chat darkmode colour change from #800080 to #B300B3. Should be fairly more readable while keeping the purple theme.