### PR TITLE
Fixes light replacer boxes

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -41,7 +41,7 @@
 
 	//Quality = switchcount for created bulbs. Higher switchcount = higher chance to burn out on switch.
 	//Efficiency = multiplied by autolathe base glass for lights
-	var/prod_quality = 30 
+	var/prod_quality = 30
 	var/prod_eff = 1.5
 
 	//Options for advanced replacer, put in the base type for sanity purposes
@@ -137,9 +137,9 @@
 		data["waste"]["amount"]++
 
 	data["resources"] = list(
-		"glass" = glass, 
-		"glass_max" = glass_max, 
-		"cardboard" = cardboard, 
+		"glass" = glass,
+		"glass_max" = glass_max,
+		"cardboard" = cardboard,
 		"cardboard_max" = cardboard_max)
 
 	data["settings"] = list(
@@ -200,7 +200,7 @@
 		switch(href_list["fold"])
 			if("supply")
 				if(!supply) //Topic is technically asynchronous, I believe, so this sanity is a good idea
-					supply = new(src)
+					supply = new /obj/item/weapon/storage/box/lights/empty(src)
 					cardboard--
 					if(usr)
 						to_chat(usr, "<span class='notice'>\The [src] constructs a new supply container.</span>")
@@ -208,17 +208,17 @@
 					return 1
 			if("waste")
 				if(!waste) //Topic is technically asynchronous, I believe, so this sanity is a good idea
-					waste = new(src)
+					waste = new /obj/item/weapon/storage/box/lights/empty(src)
 					cardboard--
 					if(usr)
 						to_chat(usr, "<span class='notice'>\The [src] constructs a new waste container.</span>")
 						attack_self(usr)
 					return 1
-		
+
 	if(href_list["recycle"])
 		recycle_waste()
 		return 1
-		
+
 	if(href_list["settings"])
 		switch(href_list["settings"])
 			if("shape")
@@ -244,7 +244,7 @@
 			return 1
 		recharge(usr)
 		return 1
-	
+
 	if(href_list["dump"])
 		if(!istype(src, /obj/item/device/lightreplacer/borg))
 			return 1
@@ -470,21 +470,21 @@
 
 /obj/item/device/lightreplacer/borg/New()
 	..()
-	supply = new /obj/item/weapon/storage/box/lights
-	waste = new /obj/item/weapon/storage/box/lights
+	supply = new /obj/item/weapon/storage/box/lights(src)
+	waste = new /obj/item/weapon/storage/box/lights/empty(src)
 	add_glass(5 * CC_PER_SHEET_GLASS, 2)
 
 /obj/item/device/lightreplacer/loaded/New()
 	..()
-	supply = new /obj/item/weapon/storage/box/lights/tubes
-	waste = new /obj/item/weapon/storage/box/lights
+	supply = new /obj/item/weapon/storage/box/lights/tubes(src)
+	waste = new /obj/item/weapon/storage/box/lights/empty(src)
 
 /obj/item/device/lightreplacer/loaded/he/New()
 	..()
-	supply = new /obj/item/weapon/storage/box/lights/he
-	waste = new /obj/item/weapon/storage/box/lights
+	supply = new /obj/item/weapon/storage/box/lights/he(src)
+	waste = new /obj/item/weapon/storage/box/lights/empty(src)
 
 /obj/item/device/lightreplacer/loaded/mixed/New()
 	..()
-	supply = new /obj/item/weapon/storage/box/lights/mixed
-	waste = new /obj/item/weapon/storage/box/lights
+	supply = new /obj/item/weapon/storage/box/lights/mixed(src)
+	waste = new /obj/item/weapon/storage/box/lights/empty(src)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -247,7 +247,7 @@
 	icon_state = "flashbang"
 	item_state = "flashbang"
 	items_to_spawn = list(/obj/item/weapon/grenade/flashbang = BOX_SPACE)
-		
+
 /obj/item/weapon/storage/box/teargas
 	name = "box of teargas grenades (WARNING)"
 	desc = "<FONT color=red><B>WARNING: Do not use without reading these precautions!</B></FONT>\n<B>WARNING: These devices can expose you to chemicals including Lead Salts and Hexavalent Chromium, which are known to the Republic of New California to cause cancer, and Lead Salts, which are known to the Republic of New California to cause birth defects and other reproductive harm.</B>\nThe Tear-Gas™ Grenade is a high volume, continuous discharge grenade. Tear-Gas™ is discharged through four (4) gas ports located on top of the canister and one (1) located on the bottom. It is similar in size to the typical Flash-Bang™ Grenade.\nThe Tear-Gas™ Grenade was designed for training, but may also be used in operations. The Tear-Gas™ Grenade offers the same approximate stunning time as the Flash-Bang™ Grenade. The similar stunning times may make it the appropriate choice for training or simulation deployment of chemical agent canisters. The Tear-Gas™ formulation is considered to be less toxic than Chloral Hydrate (chloral) smoke. The Tear-Gas™ Grenade emits a very red smoke.\nIn operations, it can be utilized as a carrying agent (multiplier) for Flash-Bang™ Grenades or other stunning munitions, or for concealing the movement of security personnel. It may also be used as a distraction to focus attention away from other activities. The device should be deployed utilizing wind advantage.\nIt should NOT be deployed onto rooftops, in crawl spaces, or indoors due to its fire-producing capability. Hand throw or launch. Launching of grenades will provide deploying officers additional standoff situations.\n<B>WARNING: THIS PRODUCT IS TO BE USED ONLY BY AUTHORIZED AND TRAINED LAW ENFORCEMENT, CORRECTIONS, OR MILITARY PERSONNEL. THIS PRODUCT MAY CAUSE SERIOUS INJURY OR DEATH TO YOU OR OTHERS. THIS PRODUCT MAY CAUSE SERIOUS DAMAGE TO PROPERTY. HANDLE, STORE AND USE WITH EXTREME CARE AND CAUTION. USE ONLY AS INSTRUCTED.</B>"
@@ -658,6 +658,11 @@
 		/obj/item/weapon/light/tube/he = 14,
 		/obj/item/weapon/light/bulb/he = 7,
 	)
+
+/obj/item/weapon/storage/box/lights/empty
+	items_to_spawn = list() //Bro why isn't the default null
+	max_combined_w_class = 21 //In the filled versions, these are set as they're filled.
+	storage_slots = 21
 
 /obj/item/weapon/storage/box/inflatables
 	name = "inflatable barrier box"


### PR DESCRIPTION
Fixes #31853
Fixes #31854
Fixes #31776
This was broken by #31677, which bafflingly changed the base lights box to be what was the bulbs one. I would have reverted that part instead of adding an `/empty` subtype but I didn't want to touch every fucking map for no reason
Also fixes a very small amount of my ancient light replacer shitcode