### PR TITLE
Fixes roundstart silicons keeping form as wizard

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -238,6 +238,8 @@
 	if (M)
 		var/datum/role/wizard/newWizard = new
 		M.forceMove(pick(wizardstart))
+		if(!isjusthuman(M))
+			M = M.Humanize("Human")
 		newWizard.AssignToRole(M.mind,1)
 		roundstart_wizards += newWizard
 		var/datum/faction/wizard/federation = find_active_faction_by_type(/datum/faction/wizard)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -312,6 +312,8 @@
 		else
 			PFW.HandleRecruitedRole(newWizard)
 		M.forceMove(pick(wizardstart))
+		if(!isjusthuman(M))
+			M = M.Humanize("Human")
 		newWizard.AssignToRole(M.mind,1)
 		newWizard.Greet(GREET_MIDROUND)
 	return 1
@@ -472,6 +474,8 @@ Assign your candidates in choose_candidates() instead.
 		if(spawnpos > synd_spawn.len)
 			spawnpos = 1
 		M.forceMove(synd_spawn[spawnpos])
+		if(!isjusthuman(M))
+			M = M.Humanize("Human")
 		if(leader)
 			leader = 0
 			var/datum/role/nuclear_operative/leader/newCop = new


### PR DESCRIPTION
[bugfix][role][gamemode]
Closes #31872.
Should fix civil war and nukeops too.

:cl:
 * bugfix: The Wizard Federation is no longer in possession of "Wizard AIs" or any other form of silicon.