### PR TITLE
Fixed a bug with auto-deadmin

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -291,6 +291,7 @@
 			deadmin()
 			verbs += /client/proc/readmin
 			deadmins += ckey
+			holder = null
 			to_chat(src, "<span class='interface'>You are now de-admined.</span>")
 		else
 			holder.associate(src)


### PR DESCRIPTION
`client.holder` was not being nulled because the admins datum was not yet associated with the client at the time of its destruction, which resulted in auto-deadmined admins being able to see the MC tab and other things despite being de-admined.