### PR TITLE
grue darkmode fix

### DIFF
--- a/goon/browserassets/css/browserOutput_dark.css
+++ b/goon/browserassets/css/browserOutput_dark.css
@@ -38,6 +38,7 @@ a:visited {color: #b76ff5;}
 .solcom	{color: #256194;}
 .clown {color: #FBFF35; font-family: Comic Sans MS, Comic Sans, cursive;}
 .borer {color: #B300B3; font-weight: bold;}
+.grue {color: #D8D8D7; font-weight: bold;}
 
 .radio {color: #1ecc43;}
 .comradio {color: #5177ff;}


### PR DESCRIPTION
Grue speech colour is #272728, this is very close to the #171717 that darkmode uses as it's background colour. Changed the grue speech darkmode colour to its opposite, #D8D8D7, a grayish white.
![image](https://user-images.githubusercontent.com/67024428/150598811-af3770f8-ce87-4850-94fd-eacb9c456fef.png)

[hotfix]
:cl:
 * tweak: Darkmode grue-speech is no longer unreadable.