### PR TITLE
Fixed flesh-to-stone permanently rendering people mute

### DIFF
--- a/code/game/objects/structures/mannequin.dm
+++ b/code/game/objects/structures/mannequin.dm
@@ -455,6 +455,7 @@
 /obj/structure/mannequin/proc/freeCaptive()
 	if (!captured)
 		return
+	captured.sdisabilities &= ~MUTE
 	captured.timestopped = 0
 	captured.forceMove(loc)
 	for(var/cloth in clothing)
@@ -501,7 +502,6 @@
 			continue
 		captured.put_in_hands(tool)
 	held_items.len = 0
-
 	captured.dir = dir
 	captured.apply_damage(additional_damage)
 


### PR DESCRIPTION
Closes #31864

:cl:
 \* bugfix: The Flesh\-to\-Stone spell no longer renders its victims permanently mute.