### PR TITLE
Vampire rejuvenation blood cost is now 0 instead of 1

### DIFF
--- a/code/modules/spells/general/rejuvenate.dm
+++ b/code/modules/spells/general/rejuvenate.dm
@@ -16,7 +16,7 @@
 	override_base = "vamp"
 	hud_state = "vampire_rejuv"
 
-	var/blood_cost = 1
+	var/blood_cost = 0
 
 /spell/rejuvenate/cast_check(var/skipcharge = 0, var/mob/user = usr)
 	. = ..()

--- a/code/modules/spells/general/rejuvenate.dm
+++ b/code/modules/spells/general/rejuvenate.dm
@@ -1,5 +1,5 @@
 /spell/rejuvenate
-	name = "Rejuvenate (1)"
+	name = "Rejuvenate"
 	desc = "Flush your system with spare blood to remove any incapacitating effects."
 	abbreviation = "RJ"
 


### PR DESCRIPTION
It's so close to 0 that it might as well not matter, but this fixes the dilemma of getting fucked out of your ability to hypnotize people as a fledgling vampire because you start with 10 blood (just enough for one hypnotize) and for some reason you use rejuvenate, which leaves you with 9 usable blood, making you unable to use hypnotize. Vampires everywhere rejoice.

:cl:
 * tweak: The vampire's rejuvenation ability is now free and no longer costs 1 blood.