### PR TITLE
Upgraded pathogenic incubators can now narrow their effects to certain stages

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -577,7 +577,7 @@ var/global/list/disease2_list = list()
 	ticks += speed
 
 //This proc is what governs how a disease mutates when it's in a pathogenic incubator (or with a lower chance inside an irradiated individual)
-/datum/disease2/disease/proc/incubate(var/atom/incubator,var/mutatechance=1,var/focused_stage)
+/datum/disease2/disease/proc/incubate(var/atom/incubator,var/mutatechance=1)
 	mutatechance *= mutation_modifier
 
 	var/mob/living/body = null

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -577,12 +577,14 @@ var/global/list/disease2_list = list()
 	ticks += speed
 
 //This proc is what governs how a disease mutates when it's in a pathogenic incubator (or with a lower chance inside an irradiated individual)
-/datum/disease2/disease/proc/incubate(var/atom/incubator,var/mutatechance=1)
+/datum/disease2/disease/proc/incubate(var/atom/incubator,var/mutatechance=1,var/focused_stage)
 	mutatechance *= mutation_modifier
 
 	var/mob/living/body = null
 	var/obj/item/weapon/virusdish/dish = null
 	var/obj/machinery/disease2/incubator/machine = null
+	var/can_focus_effect = 0 //So we do not copypaste the entire check everywhere
+	var/effect_being_focused = 0 //What effect is being focused on
 
 	if (isliving(incubator))
 		body = incubator
@@ -590,6 +592,11 @@ var/global/list/disease2_list = list()
 		dish = incubator
 		if (istype(dish.loc,/obj/machinery/disease2/incubator))
 			machine = dish.loc
+			if(machine.can_focus) //If it can focus
+				can_focus_effect = 1
+				effect_being_focused = clamp(machine.effect_focus, 0, max_stage) //Do not let the machine focus on the wrong things
+				if(effect_being_focused == 0) //Toggle it off
+					can_focus_effect = 0
 
 	if (mutatechance > 0 && (body || dish) && incubator.reagents)
 		//MUTAGEN + CREATINE = Robustness Up, Effect Strength Up, Effect Chance randomized
@@ -599,6 +606,8 @@ var/global/list/disease2_list = list()
 				var/change = rand(1,5)
 				robustness = min(100,robustness + change)
 				for(var/datum/disease2/effect/e in effects)
+					if(can_focus_effect && !e.stage == effect_being_focused)
+						continue
 					e.multiplier_tweak(0.1)//all effects get their strength increased
 					minormutate()// a random effect has a 20% chance of getting its chance re-rolled between its initial value and max chance.
 							// and the disease's infection chance is rerolled to more or less 10% of the base infection chance for that disease type.
@@ -612,6 +621,8 @@ var/global/list/disease2_list = list()
 				var/change = rand(1,5)
 				robustness = max(0,robustness - change)
 				for(var/datum/disease2/effect/e in effects)
+					if(can_focus_effect && !e.stage == effect_being_focused)
+						continue
 					e.multiplier_tweak(-0.1)//all effects get their strength reduced
 					minormutate()// a random effect has a 20% chance of getting its chance re-rolled between its initial value and max chance.
 							// and the disease's infection chance is rerolled to more or less 10% of the base infection chance for that disease type.
@@ -622,7 +633,8 @@ var/global/list/disease2_list = list()
 			//MUTAGEN (with no creatine or spaceacillin) = New Effect
 			if(!incubator.reagents.remove_reagent(MUTAGEN,0.05) && prob(mutatechance))
 				log += "<br />[timestamp()] Effect Mutation (Mutagen in [incubator])"
-				effectmutate(body != null)
+				var/focused_effect = (can_focus_effect && effect_being_focused)
+				effectmutate(body != null, focused_effect)
 				if (dish)
 					if(dish.info && dish.analysed)
 						dish.info = "OUTDATED : [dish.info]"
@@ -734,13 +746,15 @@ var/global/list/disease2_list = list()
 
 
 //Major Mutations
-/datum/disease2/disease/proc/effectmutate(var/inBody=FALSE)
+/datum/disease2/disease/proc/effectmutate(var/inBody=FALSE, var/specific_effect)
 	clean_global_log()
 	subID = rand(0,9999)
 	var/list/randomhexes = list("7","8","9","a","b","c","d","e")
 	var/colormix = "#[pick(randomhexes)][pick(randomhexes)][pick(randomhexes)][pick(randomhexes)][pick(randomhexes)][pick(randomhexes)]"
 	color = BlendRGB(color,colormix,0.25)
 	var/i = rand(1, effects.len)
+	if(specific_effect)
+		i = specific_effect
 	var/datum/disease2/effect/e = effects[i]
 	var/datum/disease2/effect/f
 	if (inBody)//mutations that occur directly in a body don't cause helpful symptoms to become deadly instantly.

--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -26,6 +26,8 @@
 
 	var/mutatechance = 5
 	var/growthrate = 4
+	var/can_focus = 0 //Whether the machine can focus on an effect to mutate it or not
+	var/effect_focus = 0 //What effect of the disease are we focusing on?
 
 
 /obj/machinery/disease2/incubator/New()
@@ -51,6 +53,10 @@
 			scancount += SP.rating-1
 		if(istype(SP, /obj/item/weapon/stock_parts/micro_laser))
 			lasercount += SP.rating-1
+	if(lasercount >= 4)
+		can_focus = 1
+	else
+		can_focus = 0
 	mutatechance = initial(mutatechance) * max(1, scancount)
 	growthrate = initial(growthrate) + lasercount
 
@@ -169,7 +175,20 @@
 
 		dish_datum.dish.reagents.clear_reagents()
 		return TRUE
-
+	if (href_list["changefocus"])
+		var/slot = text2num(href_list["changefocus"])
+		if(slot == null || slot < 1 || slot > dish_data.len)
+			return TRUE
+		var/dish_incubator_dish/dish_datum = dish_data[slot]
+		if (dish_datum == null)
+			return TRUE
+		var/stage_to_focus = input(usr, "Choose a stage to focus on. This will block symptoms from other stages from being mutated. Input 0 to disable effect focusing.", "Choose a stage.") as num
+		if(!stage_to_focus)
+			to_chat(usr, "<span class='notice'>The effect focusing is now turned off.</span>")
+		else
+			to_chat(usr, "span class='notice'>\The [src] will now focus on stage [stage_to_focus].</span>")
+		effect_focus = stage_to_focus
+		return TRUE
 
 /obj/machinery/disease2/incubator/attack_hand(var/mob/user)
 	. = ..()
@@ -203,6 +222,7 @@
 	var/list/data = list()
 
 	data["on"] = on
+	data["can_focus"] = can_focus
 	var/list/dish_ui_data = list()
 	data["dishes"] = dish_ui_data
 

--- a/nano/templates/dish_incubator.tmpl
+++ b/nano/templates/dish_incubator.tmpl
@@ -60,6 +60,11 @@
 				<td>
 					str={{:value.minor_mutations_strength}}|rob={{:value.minor_mutations_robustness}}|eff={{:value.minor_mutations_effects}}
 				</td>
+				{{if data.can_focus}}
+					<td>
+					{{:helper.link('Focus', 'location-arrow', {'changefocus' : index+1}, null, 'wide')}}
+					</td>
+				{{/if}}
 			{{/if}}
 		</tr>
 	{{/for}}


### PR DESCRIPTION
Done by request. Revival of #21863
This means that any sort of mutation that would apply to various stages can be set up so that it only happens to a particular stage's effects, including turning into a different effect altogether.
Partially tested.

:cl:
 * tweak: The Pathogenic Incubator from Virology, when upgraded, can restrict its effect affection to just a particular stage, meaning that for example mutagen can be used to randomize a specific stage's effect.