### PR TITLE
Gives mechanics Engine access

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -51,7 +51,7 @@
 	supervisors = "the research director and the chief engineer"
 	wage_payout = 45
 	selection_color = "#fff5cc"
-	access = list(access_eva, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_mechanic, access_tcomsat, access_science)
+	access = list(access_engine, access_eva, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_mechanic, access_tcomsat, access_science)
 	minimal_access = list(access_maint_tunnels, access_emergency_storage, access_construction, access_engine_equip, access_external_airlocks, access_mechanic, access_tcomsat, access_science)
 	alt_titles = list("Telecommunications Technician", "Spacepod Mechanic", "Greasemonkey")
 	outfit_datum = /datum/outfit/mechanic


### PR DESCRIPTION
The Mechanic is immunized against all dangers: one may call him a useless role, parasite, assistant with gloves, it all runs off him like water off a raincoat. But tell him to setup an engine and you will be astonished at how he recoils, how injured he is, how he suddenly shrinks back: "I don't have access.”

:cl:
 * rscadd: Mechanics now have engine access.