### PR TITLE
Advanced Clown Shoes can now be emagged to become more spammy

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -535,7 +535,7 @@ its easier to just keep the beam vertical.
 /atom/proc/singularity_pull()
 	return
 
-/atom/proc/emag_act()
+/atom/proc/emag_act(var/mob/user)
 	return
 
 /atom/proc/slime_act()

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -285,7 +285,7 @@
 	..()
 	if(!emagged)
 		if(modulo_steps == 1)
-			to_chat(user, "<span class='warning'Aww shucks! Looks like someone beat you to the punch, for these shoes already play a sound every step! Perhaps it was the result of a very special day, or maybe it was tampered with by a very bored god. Either way, you are a fool!</span>")
+			to_chat(user, "<span class='warning'>Aww shucks! Looks like someone beat you to the punch, for these shoes already play a sound every step! Perhaps it was the result of a very special day, or maybe it was tampered with by a very bored god. Either way, you are a fool!</span>")
 			to_chat(user, "<span class='good'>However, here is a consolation banana.</span>")
 			var/dat = {"<html><div><span style="color:#ff0000;">H</span><span style="color:#99ff00;">O</span><span style="color:#0000ff;">N</span><span style="color:#00ff80;">K</span><span style="color:#0066ff;">!</span></html></div>"}
 			to_chat(user, dat)

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -293,7 +293,7 @@
 			var/obj/item/weapon/reagent_containers/food/snacks/grown/banana/B = new()
 			B.name = "consolation banana"
 			B.desc = "This one seems to be enchanted..."
-			B.potency = 9001 //Honk
+			B.potency = 1337 //Honk
 			user.put_in_hands(B)
 		else
 			to_chat(user, "<span class='warning'>You overload the audio cogitators of \the [src], causing them to play a sound on every step!</span>")

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -228,6 +228,7 @@
 		"Dramatic" = 'sound/effects/dramatic_short.ogg',
 		"Random" = CLOWNSHOES_RANDOM_SOUND)
 	var/random_sound = 0
+	var/emagged = 0
 
 /obj/item/clothing/shoes/clown_shoes/advanced/attack_self(mob/living/user)
 	if(user.mind && !clumsy_check(user))
@@ -279,6 +280,25 @@
 		if(random_sound)
 			step_sound = sound_list[pick(sound_list)]
 	..()
+
+/obj/item/clothing/shoes/clown_shoes/advanced/emag_act(var/mob/user) //Causes the shoes to play a sound every step instead of 2
+	..()
+	if(!emagged)
+		if(modulo_steps == 1)
+			to_chat(user, "<span class='warning'Aww shucks! Looks like someone beat you to the punch, for these shoes already play a sound every step! Perhaps it was the result of a very special day, or maybe it was tampered with by a very bored god. Either way, you are a fool!</span>")
+			to_chat(user, "<span class='good'>However, here is a consolation banana.</span>")
+			var/dat = {"<html><div><span style="color:#ff0000;">H</span><span style="color:#99ff00;">O</span><span style="color:#0000ff;">N</span><span style="color:#00ff80;">K</span><span style="color:#0066ff;">!</span></html></div>"}
+			to_chat(user, dat)
+			playsound(user, 'sound/items/bikehorn.ogg', 100, 0)
+			var/obj/item/weapon/reagent_containers/food/snacks/grown/banana/B = new()
+			B.name = "consolation banana"
+			B.desc = "This one seems to be enchanted..."
+			B.potency = 9001 //Honk
+			user.put_in_hands(B)
+		else
+			to_chat(user, "<span class='warning'>You overload the audio cogitators of \the [src], causing them to play a sound on every step!</span>")
+			modulo_steps = 1
+		emagged = 1
 
 /obj/item/clothing/shoes/clown_shoes/stickymagic
 	canremove = 0

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -405,7 +405,7 @@ var/list/special_fruits = list()
 	filling_color = "#A2B5A1"
 	plantname = "cabbage"
 	fragrance = INCENSE_LEAFY
-	
+
 /obj/item/weapon/reagent_containers/food/snacks/grown/plasmacabbage
 	name = "plasma cabbage"
 	desc = "Not to be confused with red cabbage."
@@ -589,6 +589,12 @@ var/list/special_fruits = list()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/banana/isHandgun()
 	return TRUE
+
+/obj/item/weapon/reagent_containers/food/snacks/grown/banana/after_consume(var/mob/user, var/datum/reagents/reagentreference)
+	var/obj/item/weapon/bananapeel/peel = new
+	peel.potency = potency
+	trash = peel
+	..()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/bluespacebanana
 	name = "bluespace banana"


### PR DESCRIPTION
Done on request.
Plays a sound every step instead of two, causing the clown to become an audio menace upon the station and giving even more reason to lynch them.
The rest is secret. 😉 
Also fixed a bug related to banana peel potency inheritance, meaning that Botany can now grow bananas that slip more.

:cl:
 * tweak: The Advanced Clown Shoes can now be emagged to make the sounds they play more spammy.
 * bugfix: Fixed a bug where banana peels wouldn't inherit the potency of the bananas that produced them and subsequently having more slipping power.