### PR TITLE
Glubbs can now be worn in the ID slot and grant all access

### DIFF
--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -8,6 +8,10 @@
 	max_heat_protection_temperature = GLOVES_MAX_HEAT_PROTECTION_TEMPERATURE
 	_color = "yellow"
 	species_fit = list(VOX_SHAPED, INSECT_SHAPED)
+	slot_flags = SLOT_GLOVES | SLOT_ID
+
+/obj/item/clothing/gloves/yellow/GetAccess()
+	return get_all_accesses()
 
 /obj/item/clothing/gloves/yellow/power //fuck you don't relative path this
 	var/next_shock = 0


### PR DESCRIPTION
Fixes the bug where you couldn't wear your insulated gloves as an all access ID. This finally lets some jobs do what they were meant to this whole time.

[bugfix]

:cl:
 * rscadd: Glubbs can now be worn in ID slots and grant all access