### PR TITLE
Reagent addiction/tolerance system

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -65,7 +65,7 @@
 			. *= NO_SHOES_SLOWDOWN
 		if(addicted_chems.has_any_reagents(HYPERZINES))
 			var/datum/reagent/R = addicted_chems.get_reagent_by_type(/datum/reagent/hyperzine)
-			. *= min(2,R.volume/5)
+			. *= min(2,(R.volume/50)+1)
 	if(M_FAT in mutations) // hyperzine can't save you, fatty!
 		. *= 1.5
 	if(M_RUN in mutations)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -65,7 +65,7 @@
 			. *= NO_SHOES_SLOWDOWN
 		if(addicted_chems.has_any_reagents(HYPERZINES))
 			var/datum/reagent/R = addicted_chems.get_reagent_by_type(/datum/reagent/hyperzine)
-			. *= max(2,R.tick/10)
+			. *= min(2,R.volume/5)
 	if(M_FAT in mutations) // hyperzine can't save you, fatty!
 		. *= 1.5
 	if(M_RUN in mutations)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -63,6 +63,9 @@
 	if(!reagents.has_any_reagents(HYPERZINES))
 		if(!shoes)
 			. *= NO_SHOES_SLOWDOWN
+		if(addicted_chems.has_any_reagents(HYPERZINES))
+			var/datum/reagent/R = addicted_chems.get_reagent_by_type(/datum/reagent/hyperzine)
+			. *= max(2,R.tick/10)
 	if(M_FAT in mutations) // hyperzine can't save you, fatty!
 		. *= 1.5
 	if(M_RUN in mutations)

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -37,6 +37,10 @@
 				if(organ.status & ORGAN_SPLINTED)
 					pain_level -= 25
 
+	if(addicted_chems.has_any_reagents(OXYCODONE))
+		var/datum/reagent/R = addicted_chems.get_reagent_by_type(/datum/reagent/oxycodone)
+		pain_level += min(50,R.volume*5)
+
 	if(pain_level < 0)
 		pain_level = 0
 

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -39,7 +39,7 @@
 
 	if(addicted_chems.has_any_reagents(OXYCODONE))
 		var/datum/reagent/R = addicted_chems.get_reagent_by_type(/datum/reagent/oxycodone)
-		pain_level += min(50,R.volume*5)
+		pain_level += min(50,R.volume/2)
 
 	if(pain_level < 0)
 		pain_level = 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -18,9 +18,9 @@
 
 	immune_system = new (src)
 
-/mob/living/create_reagents()
-	..()
-	addicted_chems = new /datum/reagents(1000)
+/mob/living/create_reagents(const/max_vol)
+	..(max_vol)
+	addicted_chems = new /datum/reagents(max_vol)
 	addicted_chems.my_atom = src
 	tolerated_chems = list()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -18,6 +18,7 @@
 
 	immune_system = new (src)
 	addicted_chems = new /datum/reagents(1000)
+	addicted_chems.my_atom = src
 
 /mob/living/Destroy()
 	for(var/mob/living/silicon/robot/mommi/MoMMI in player_list)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -17,8 +17,12 @@
 		meat_amount = size
 
 	immune_system = new (src)
+
+/mob/living/create_reagents()
+	..()
 	addicted_chems = new /datum/reagents(1000)
 	addicted_chems.my_atom = src
+	tolerated_chems = list()
 
 /mob/living/Destroy()
 	for(var/mob/living/silicon/robot/mommi/MoMMI in player_list)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -17,6 +17,7 @@
 		meat_amount = size
 
 	immune_system = new (src)
+	addicted_chems = new /datum/reagents(1000)
 
 /mob/living/Destroy()
 	for(var/mob/living/silicon/robot/mommi/MoMMI in player_list)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -356,7 +356,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	return total_transfered
 */
 
-/datum/reagents/proc/metabolize(var/mob/M, var/alien)
+/datum/reagents/proc/metabolize(var/mob/living/M, var/alien)
 	if(M && chem_temp != M.bodytemperature)
 		chem_temp = M.bodytemperature
 		handle_reactions()
@@ -366,6 +366,25 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 			R.on_mob_life(M, alien)
 			if(R)
 				R.metabolize(M)
+	if(M.addicted_chems)
+		for(var/B in M.addicted_chems.reagent_list)
+			var/datum/reagent/R2 = B
+			if(M && R2 && !has_reagent(R2))
+				R2.on_withdrawal(M)
+	for(var/reagent_id in M.tolerated_chems)
+		if(!has_reagent(reagent_id))
+			var/datum/reagent/R3 = chemical_reagents_list[reagent_id]
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				var/datum/organ/internal/liver/L = H.internal_organs_by_name["liver"]
+				if(L)
+					var/reagent_efficiency = 1
+					if(reagent_id in L.reagent_efficiencies)
+						reagent_efficiency = L.reagent_efficiencies[reagent_id]
+					M.tolerated_chems[reagent_id] = max(0, M.tolerated_chems[reagent_id] - (R3.custom_metabolism * L.efficiency * reagent_efficiency * R3.tolerance_increase))
+					return
+			// If we aren't human, we don't have a liver, so just remove tolerance the old fashioned way.
+			M.tolerated_chems[reagent_id] = max(0, M.tolerated_chems[reagent_id] - (R3.custom_metabolism * R3.tolerance_increase))
 	update_total()
 
 /datum/reagents/proc/update_aerosol(var/mob/M)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -381,10 +381,10 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 					var/reagent_efficiency = 1
 					if(reagent_id in L.reagent_efficiencies)
 						reagent_efficiency = L.reagent_efficiencies[reagent_id]
-					M.tolerated_chems[reagent_id] = max(0, M.tolerated_chems[reagent_id] - (R3.custom_metabolism * L.efficiency * reagent_efficiency * R3.tolerance_increase))
+					M.tolerated_chems[reagent_id] = max(0, M.tolerated_chems[reagent_id] - (L.efficiency * reagent_efficiency * R3.tolerance_increase))
 					return
 			// If we aren't human, we don't have a liver, so just remove tolerance the old fashioned way.
-			M.tolerated_chems[reagent_id] = max(0, M.tolerated_chems[reagent_id] - (R3.custom_metabolism * R3.tolerance_increase))
+			M.tolerated_chems[reagent_id] = max(0, M.tolerated_chems[reagent_id] - R3.tolerance_increase)
 	update_total()
 
 /datum/reagents/proc/update_aerosol(var/mob/M)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -369,7 +369,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	if(M.addicted_chems)
 		for(var/B in M.addicted_chems.reagent_list)
 			var/datum/reagent/R2 = B
-			if(M && R2 && !has_reagent(R2))
+			if(M && R2 && !has_reagent_type(R2.type))
 				R2.on_withdrawal(M)
 	for(var/reagent_id in M.tolerated_chems)
 		if(!has_reagent(reagent_id))

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -50,7 +50,7 @@
 	var/mug_name = null
 	var/mug_desc = null
 	var/addiction_increase = 0 //for addiction and tolerance, if set above 0, will increase each by that amount on tick.
-	var/tolerance_increase = 0
+	var/tolerance_increase = REAGENTS_METABOLISM/10
 
 /datum/reagent/proc/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)
 	set waitfor = 0
@@ -3228,8 +3228,8 @@
 	overdose_am = REAGENTS_OVERDOSE/2
 	density = 1.79
 	specheatcap = 0.70
-	addiction_increase = 0.001 // Low metabolism so low values for both
-	tolerance_increase = 0.001
+	addiction_increase = 0.005 // Low metabolism so low values for both
+	tolerance_increase = 0.003
 
 /datum/reagent/hyperzine/on_mob_life(var/mob/living/M)
 
@@ -5127,6 +5127,8 @@
 	nutriment_factor = 20 * REAGENTS_METABOLISM
 	color = "#302000" //rgb: 48, 32, 0
 	var/has_had_heart_explode = 0
+	addiction_increase = REAGENTS_METABOLISM/5
+	tolerance_increase = REAGENTS_METABOLISM/10
 
 /datum/reagent/cornoil/on_mob_life(var/mob/living/M)
 
@@ -5158,6 +5160,11 @@
 					qdel(H.remove_internal_organ(H,heart,H.get_organ(LIMB_CHEST)))
 					H.adjustOxyLoss(60)
 					H.adjustBruteLoss(30)
+
+/datum/reagent/cornoil/on_withdrawal(var/mob/living/M)
+	if(..())
+		return 1
+	M.nutrition = max(0, M.nutrition - max(8,(nutriment_factor*tick)/50))
 
 /datum/reagent/cornoil/reaction_turf(var/turf/simulated/T, var/volume)
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -49,8 +49,8 @@
 	var/mug_icon_state = null
 	var/mug_name = null
 	var/mug_desc = null
-	var/addiction_increase = 0 //for addiction and tolerance, if set above 0, will increase each by that amount on tick.
-	var/tolerance_increase = REAGENTS_METABOLISM/10
+	var/addictive = FALSE
+	var/tolerance_increase = REAGENTS_METABOLISM/10  //for tolerance, if set above 0, will increase each by that amount on tick.
 
 /datum/reagent/proc/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)
 	set waitfor = 0
@@ -185,8 +185,8 @@
 			var/datum/role/R = M.mind.antag_roles[role]
 			R.handle_reagent(id)
 	
-	if(addiction_increase && M.addicted_chems)
-		M.addicted_chems.add_reagent(src.id, addiction_increase)
+	if(addictive && M.addicted_chems)
+		M.addicted_chems.add_reagent(src.id, custom_metabolism)
 	if(tolerance_increase)
 		M.tolerated_chems[src.id] += tolerance_increase
 
@@ -1136,7 +1136,7 @@
 	overdose_am = REAGENTS_OVERDOSE
 	density = 5.23
 	specheatcap = 0.62
-	addiction_increase = 0.1
+	addictive = TRUE
 	tolerance_increase = 0.05
 
 /datum/reagent/space_drugs/on_mob_life(var/mob/living/M)
@@ -1156,7 +1156,7 @@
 /datum/reagent/space_drugs/on_withdrawal(var/mob/living/M)
 	if(..())
 		return 1
-	if(ishuman(M) && prob(min(100,volume)))
+	if(ishuman(M) && prob(min(100,volume/10)))
 		var/mob/living/carbon/human/H = M
 		H.vomit()
 
@@ -2062,7 +2062,7 @@
 	custom_metabolism = 0.05
 	density = 1.26
 	specheatcap = 24.59
-	addiction_increase = 0.01
+	addictive = TRUE
 	tolerance_increase = 0.005
 
 /datum/reagent/oxycodone/on_mob_life(var/mob/living/M)
@@ -3242,7 +3242,7 @@
 	overdose_am = REAGENTS_OVERDOSE/2
 	density = 1.79
 	specheatcap = 0.70
-	addiction_increase = 0.005 // Low metabolism so low values for both
+	addictive = TRUE
 	tolerance_increase = 0.003
 
 /datum/reagent/hyperzine/on_mob_life(var/mob/living/M)
@@ -3256,8 +3256,8 @@
 /datum/reagent/hyperzine/on_withdrawal(var/mob/living/M)
 	if(..())
 		return 1
-	if(prob(50))
-		M.drowsyness = max(M.drowsyness, volume/2) //See movement_tally_multiplier for the rest
+	if(prob(min(100,volume/5)))
+		M.drowsyness = max(M.drowsyness, min(10,volume/10)) //See movement_tally_multiplier for the rest
 
 /datum/reagent/hyperzine/on_overdose(var/mob/living/M)
 	if(ishuman(M) && M.get_heart()) // Got a heart?
@@ -5141,8 +5141,8 @@
 	reagent_state = REAGENT_STATE_LIQUID
 	nutriment_factor = 20 * REAGENTS_METABOLISM
 	color = "#302000" //rgb: 48, 32, 0
+	addictive = TRUE
 	var/has_had_heart_explode = 0
-	addiction_increase = REAGENTS_METABOLISM/5
 
 /datum/reagent/cornoil/on_mob_life(var/mob/living/M)
 
@@ -5178,7 +5178,7 @@
 /datum/reagent/cornoil/on_withdrawal(var/mob/living/M)
 	if(..())
 		return 1
-	M.nutrition = max(0, M.nutrition - max(8,nutriment_factor*volume))
+	M.nutrition = max(0, M.nutrition - max(8,nutriment_factor*volume/10))
 
 /datum/reagent/cornoil/reaction_turf(var/turf/simulated/T, var/volume)
 
@@ -6305,7 +6305,7 @@
 	custom_metabolism = FOOD_METABOLISM
 	density = 0.79
 	specheatcap = 2.46
-	addiction_increase = FOOD_METABOLISM/5
+	addictive = TRUE
 	tolerance_increase = FOOD_METABOLISM/10
 	var/dizzy_adj = 3
 	var/slurr_adj = 3

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -226,7 +226,7 @@
 //Has to be a reagents datum for on_withdrawal()
 /mob/living/var/datum/reagents/addicted_chems
 //Associative lists for tolerance formatted like (REAGENT_ID = amount)
-/mob/living/var/list/tolerated_chems = list()
+/mob/living/var/list/tolerated_chems
 
 //Completely unimplemented as of 2021, commenting out
 ///datum/reagent/proc/on_move(var/mob/M)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1136,6 +1136,8 @@
 	overdose_am = REAGENTS_OVERDOSE
 	density = 5.23
 	specheatcap = 0.62
+	addiction_increase = 0.1
+	tolerance_increase = 0.05
 
 /datum/reagent/space_drugs/on_mob_life(var/mob/living/M)
 
@@ -1150,6 +1152,13 @@
 
 	if(prob(7))
 		M.emote(pick("twitch", "drool", "moan", "giggle"), null, null, TRUE)
+
+/datum/reagent/space_drugs/on_withdrawal(var/mob/living/M)
+	if(..())
+		return 1
+	if(ishuman(M) && prob(min(100,volume)))
+		var/mob/living/carbon/human/H = M
+		H.vomit()
 
 /datum/reagent/holywater
 	name = "Holy Water"
@@ -2053,6 +2062,8 @@
 	custom_metabolism = 0.05
 	density = 1.26
 	specheatcap = 24.59
+	addiction_increase = 0.01
+	tolerance_increase = 0.005
 
 /datum/reagent/oxycodone/on_mob_life(var/mob/living/M)
 
@@ -2072,6 +2083,9 @@
 							"<span class='numb'>You nod to yourself... it's nothing, it just feels good to nod a little...</span>", \
 							"<span class='numb'>Hello?... Is there anybody in there?...</span>", \
 							"<span class='numb'>You feel... comfortably numb.</span>"))
+
+
+//Withdrawal effects in update_pain_level()
 
 /datum/reagent/virus_food
 	name = "Virus Food"
@@ -3242,7 +3256,8 @@
 /datum/reagent/hyperzine/on_withdrawal(var/mob/living/M)
 	if(..())
 		return 1
-	M.drowsyness += 1 //See movement_tally_multiplier for the rest
+	if(prob(50))
+		M.drowsyness = max(M.drowsyness, volume/2) //See movement_tally_multiplier for the rest
 
 /datum/reagent/hyperzine/on_overdose(var/mob/living/M)
 	if(ishuman(M) && M.get_heart()) // Got a heart?
@@ -5128,7 +5143,6 @@
 	color = "#302000" //rgb: 48, 32, 0
 	var/has_had_heart_explode = 0
 	addiction_increase = REAGENTS_METABOLISM/5
-	tolerance_increase = REAGENTS_METABOLISM/10
 
 /datum/reagent/cornoil/on_mob_life(var/mob/living/M)
 
@@ -5164,7 +5178,7 @@
 /datum/reagent/cornoil/on_withdrawal(var/mob/living/M)
 	if(..())
 		return 1
-	M.nutrition = max(0, M.nutrition - max(8,(nutriment_factor*tick)/50))
+	M.nutrition = max(0, M.nutrition - max(8,nutriment_factor*volume))
 
 /datum/reagent/cornoil/reaction_turf(var/turf/simulated/T, var/volume)
 
@@ -6291,6 +6305,8 @@
 	custom_metabolism = FOOD_METABOLISM
 	density = 0.79
 	specheatcap = 2.46
+	addiction_increase = FOOD_METABOLISM/5
+	tolerance_increase = FOOD_METABOLISM/10
 	var/dizzy_adj = 3
 	var/slurr_adj = 3
 	var/confused_adj = 2
@@ -6344,6 +6360,15 @@
 			else if(istype(L))
 				L.take_damage(0.05, 0.5)
 			H.adjustToxLoss(0.5)
+
+/datum/reagent/ethanol/on_withdrawal(var/mob/living/M)
+	if(..())
+		return 1
+	if(prob(2))
+		M.eye_blurry = 5
+		to_chat(M,"<span class='warning'>Your head hurts</span>")
+		if(prob(50))
+			M.drowsyness++
 
 /datum/reagent/ethanol/reaction_obj(var/obj/O, var/volume)
 


### PR DESCRIPTION
[content][system]
Adds support for these.
Ideally withdrawal symptoms should be much less serious than overdose, or just mild annoyance, and should not affect short term use. Actual effects WIP and open for discussion.

:cl:
 * rscadd: Certain reagents can now become addicting or build up a tolerance when consumed. Addiction causes withdrawal affects while tracked when the reagent is not in system and tolerance increases the minimum amount needed to affect a mob, without changing the overdose threshold.
 * rscadd: Hyperzine causes slowdown on withdrawal, tied to severity of addiction.
 * rscadd: Corn oil causes hunger on withdrawal, tied to severity of addiction.
 * rscadd: Oxycodone causes pain on withdrawal, tied to severity of addiction.