### PR TITLE
Ling balance

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -114,9 +114,6 @@
 //                                          //
 //////////////////////////////////////////////
 
-
-//note: this can only fire on snowmap
-
 /datum/dynamic_ruleset/roundstart/changeling
 	name = "Changelings"
 	role_category = /datum/role/changeling
@@ -130,7 +127,7 @@
 	cost = 18
 	requirements = list(80,60,40,20,20,10,10,10,10,10)
 	high_population_requirement = 30
-	var/changeling_threshold = 2
+	var/changeling_threshold = 1
 
 // -- Currently a copypaste of traitors. Could be fixed to be less copy & paste.
 /datum/dynamic_ruleset/roundstart/changeling/choose_candidates()

--- a/code/datums/gamemode/powers/changeling.dm
+++ b/code/datums/gamemode/powers/changeling.dm
@@ -255,14 +255,14 @@
 	helptext = "The blade can be retracted by using the same spell used to manifest it. It has a chance to deflect projectiles."
 	cost = 3
 	spellpath = /spell/changeling/armblade
-
+/*
 /datum/power/changeling/chemsting
 	name = "Chemical Sting"
 	desc = "We repurpose our internal organs to process and recreate any chemicals we have learned, ready to inject into another lifeform or ourselves if needs be."
 	helptext = "This can be used to hinder others, or help ourselves, through the application of medicines or poisons."
 	cost = 1
 	spellpath = /spell/changeling/changeling_chemsting
-
+*/
 ///datum/power/changeling/chemspit
 //	name = "Chemical Spit"
 // 	desc = "We repurpose our internal organs to process and recreate any chemicals we have learned, ready to fire like projectile venom in our facing direction."

--- a/code/datums/gamemode/powers/changeling.dm
+++ b/code/datums/gamemode/powers/changeling.dm
@@ -1,5 +1,3 @@
-
-
 /datum/power/changeling
 	var/allowduringlesserform = 0
 	var/allowduringhorrorform = 1
@@ -257,14 +255,14 @@
 	helptext = "The blade can be retracted by using the same spell used to manifest it. It has a chance to deflect projectiles."
 	cost = 3
 	spellpath = /spell/changeling/armblade
-/*
+
 /datum/power/changeling/chemsting
 	name = "Chemical Sting"
 	desc = "We repurpose our internal organs to process and recreate any chemicals we have learned, ready to inject into another lifeform or ourselves if needs be."
 	helptext = "This can be used to hinder others, or help ourselves, through the application of medicines or poisons."
 	cost = 1
-	spellpath = /obj/item/verbs/changeling/proc/changeling_chemsting
-*/
+	spellpath = /spell/changeling/changeling_chemsting
+
 ///datum/power/changeling/chemspit
 //	name = "Chemical Spit"
 // 	desc = "We repurpose our internal organs to process and recreate any chemicals we have learned, ready to fire like projectile venom in our facing direction."

--- a/code/datums/gamemode/powers/changeling.dm
+++ b/code/datums/gamemode/powers/changeling.dm
@@ -257,14 +257,14 @@
 	helptext = "The blade can be retracted by using the same spell used to manifest it. It has a chance to deflect projectiles."
 	cost = 3
 	spellpath = /spell/changeling/armblade
-
+/*
 /datum/power/changeling/chemsting
 	name = "Chemical Sting"
 	desc = "We repurpose our internal organs to process and recreate any chemicals we have learned, ready to inject into another lifeform or ourselves if needs be."
 	helptext = "This can be used to hinder others, or help ourselves, through the application of medicines or poisons."
 	cost = 1
 	spellpath = /obj/item/verbs/changeling/proc/changeling_chemsting
-
+*/
 ///datum/power/changeling/chemspit
 //	name = "Chemical Spit"
 // 	desc = "We repurpose our internal organs to process and recreate any chemicals we have learned, ready to fire like projectile venom in our facing direction."

--- a/code/datums/gamemode/powers/changeling.dm
+++ b/code/datums/gamemode/powers/changeling.dm
@@ -65,7 +65,7 @@
 /datum/power/changeling/horror_form
 	name = "Horror Form"
 	desc = "This costly evolution allows us to transform into an all-consuming abomination. We are incredibly strong, to the point that we can force open airlocks, and are immune to conventional stuns."
-	cost = 10
+	cost = 9
 	spellpath = /spell/changeling/horrorform
 	allowduringhorrorform = 0
 
@@ -104,7 +104,7 @@
 /datum/power/changeling/blind_sting
 	name = "Blind Sting"
 	desc = "We silently sting a human, completely blinding them for a short time."
-	cost = 2
+	cost = 1
 	allowduringlesserform = 1
 	spellpath = /spell/changeling/sting/blind
 
@@ -120,7 +120,7 @@
 	name = "Mimic Voice"
 	desc = "We shape our vocal glands to sound like a desired voice."
 	helptext = "Will turn your voice into the name that you enter."
-	cost = 3
+	cost = 2
 	spellpath = /spell/changeling/voicechange
 	allowduringhorrorform = 0
 
@@ -128,7 +128,7 @@
 	name = "Extract DNA"
 	desc = "We stealthily sting a target and extract the DNA from them."
 	helptext = "Will give you the DNA of your target, allowing you to transform into them. Does not count towards absorb objectives."
-	cost = 3
+	cost = 2
 	allowduringlesserform = 1
 	spellpath = /spell/changeling/sting/dnaextract
 
@@ -136,20 +136,20 @@
 	name = "Transformation Sting"
 	desc = "We silently sting a human, injecting a retrovirus that forces them to transform into another."
 	helptext = "Does not provide a warning to others. The victim will transform much like a changeling would."
-	cost = 3
+	cost = 2
 	spellpath = /spell/changeling/sting/transformation
 
 /datum/power/changeling/paralysis_sting
 	name = "Paralysis Sting"
 	desc = "We silently sting a human, paralyzing them for a short time."
-	cost = 4
+	cost = 3
 	spellpath = /spell/changeling/sting/paralyse
 
 /datum/power/changeling/LSDSting
 	name = "Hallucination Sting"
 	desc = "We evolve the ability to sting a target with a powerful hallucinogen."
 	helptext = "The target does not notice they have been stung.  The effect occurs after 30 to 60 seconds."
-	cost = 3
+	cost = 2
 	spellpath = /spell/changeling/sting/hallucinate
 
 /datum/power/changeling/unfat_sting
@@ -168,7 +168,7 @@
 
 /datum/power/changeling/boost_range
 	name = "Boost Range"
-	desc = "We evolve the ability to shoot our stingers at humans, with some preperation."
+	desc = "We evolve the ability to shoot our stingers at humans, with some preparation."
 	helptext = "Our throat adjusts to launch the stinger."
 	cost = 2
 
@@ -184,14 +184,14 @@
 	name = "Epinephrine sacs"
 	desc = "We evolve additional sacs of adrenaline throughout our body."
 	helptext = "Gives the ability to instantly recover from stuns.  High chemical cost."
-	cost = 4
+	cost = 3
 	spellpath = /spell/changeling/unstun
 
 /datum/power/changeling/ChemicalSynth
 	name = "Rapid Chemical-Synthesis"
 	desc = "We evolve new pathways for producing our necessary chemicals, permitting us to naturally create them faster."
 	helptext = "Doubles the rate at which we naturally recharge chemicals."
-	cost = 4
+	cost = 2
 
 /datum/power/changeling/ChemicalSynth/add_power(var/datum/role/R)
 	. = ..()
@@ -205,7 +205,7 @@
 	name = "Advanced Chemical-Synthesis"
 	desc = "We evolve new pathways for producing our necessary chemicals, permitting us to naturally create them faster."
 	helptext = "Doubles the rate at which we naturally recharge chemicals."
-	cost = 8
+	cost = 2
 
 /datum/power/changeling/AdvChemicalSynth/add_power(var/datum/role/R)
 	. = ..()
@@ -219,7 +219,7 @@
 	name = "Engorged Chemical Glands"
 	desc = "Our chemical glands swell, permitting us to store more chemicals inside of them."
 	helptext = "Allows us to store an extra 25 units of chemicals."
-	cost = 4
+	cost = 1
 
 /datum/power/changeling/EngorgedGlands/add_power(var/datum/role/R)
 	. = ..()
@@ -232,7 +232,7 @@
 /datum/power/changeling/DigitalCamoflague
 	name = "Digital Camouflage"
 	desc = "We evolve the ability to distort our form and proportions, defeating common algorithms used to detect lifeforms on cameras."
-	cost = 3
+	cost = 2
 	allowduringlesserform = 1
 	allowduringhorrorform = 0
 
@@ -244,31 +244,29 @@
 	to_chat(C, "<span class='notice'>We distort our form to prevent AI-tracking.</span>")
 	C.digitalcamo = 1
 
-
-
 /datum/power/changeling/rapidregeneration
 	name = "Rapid Regeneration"
 	desc = "We evolve the ability to rapidly regenerate, negating the need for stasis."
 	helptext = "Heals a moderate amount of damage every tick."
-	cost = 8
+	cost = 5
 	spellpath = /spell/changeling/rapidregen
 
 /datum/power/changeling/armblade
 	name = "Arm Blade"
 	desc = "We transform one of our arms into an organic blade that can cut through flesh and bone."
 	helptext = "The blade can be retracted by using the same spell used to manifest it. It has a chance to deflect projectiles."
-	cost = 5
+	cost = 3
 	spellpath = /spell/changeling/armblade
 
-// /datum/power/changeling/chemsting
-// 	name = "Chemical Sting"
-// 	desc = "We repurpose our internal organs to process and recreate any chemicals we have learned, ready to inject into another lifeform or ourselves if needs be."
-// 	helptext = "This can be used to hinder others, or help ourselves, through the application of medicines or poisons."
-// 	cost = 1
-// 	spellpath = /obj/item/verbs/changeling/proc/changeling_chemsting
+/datum/power/changeling/chemsting
+	name = "Chemical Sting"
+	desc = "We repurpose our internal organs to process and recreate any chemicals we have learned, ready to inject into another lifeform or ourselves if needs be."
+	helptext = "This can be used to hinder others, or help ourselves, through the application of medicines or poisons."
+	cost = 1
+	spellpath = /obj/item/verbs/changeling/proc/changeling_chemsting
 
-// /datum/power/changeling/chemspit
-// 	name = "Chemical Spit"
+///datum/power/changeling/chemspit
+//	name = "Chemical Spit"
 // 	desc = "We repurpose our internal organs to process and recreate any chemicals we have learned, ready to fire like projectile venom in our facing direction."
 // 	helptext = "Handy for firing acid at enemies, providing we have learned such chemicals."
 // 	cost = 1

--- a/code/datums/gamemode/role/changeling.dm
+++ b/code/datums/gamemode/role/changeling.dm
@@ -22,7 +22,7 @@
 	var/changelingID = "Changeling"
 	var/geneticdamage = 0
 
-	powerpoints = 5	//evolve points
+	powerpoints = 4	//evolve points
 
 	var/mimicing = ""
 

--- a/code/modules/spells/changeling/absorb_dna.dm
+++ b/code/modules/spells/changeling/absorb_dna.dm
@@ -82,7 +82,7 @@
 	if(user.nutrition < 400)
 		user.nutrition = min((user.nutrition + T.nutrition), 400)
 	user.health = user.maxHealth
-	changeling.powerpoints += 2
+	changeling.powerpoints += 3
 
 	//Steal all of their languages!
 	changeling.absorbed_languages |= T.languages

--- a/code/modules/spells/changeling/changeling_spell.dm
+++ b/code/modules/spells/changeling/changeling_spell.dm
@@ -32,7 +32,7 @@
 	if (!C)     //only changelings allowed
 		message_admins("[user.real_name] has a changeling spell... and they aren't a changeling!")
 		return FALSE
-	if issilicon(user)
+	if (issilicon(user))
 		to_chat(C.antag.current, "<span class='warning'>You must be an organic lifeform.</span>")
 		return FALSE
 	if (C.chem_charges < chemcost)

--- a/code/modules/spells/changeling/changeling_spell.dm
+++ b/code/modules/spells/changeling/changeling_spell.dm
@@ -32,6 +32,9 @@
 	if (!C)     //only changelings allowed
 		message_admins("[user.real_name] has a changeling spell... and they aren't a changeling!")
 		return FALSE
+	if issilicon(user)
+		to_chat(C.antag.current, "<span class='warning'>You must be an organic lifeform.</span>")
+		return FALSE
 	if (C.chem_charges < chemcost)
 		to_chat(C.antag.current, "<span class='warning'>We do not have enough chemicals stored! We require at least [chemcost] units of chemicals.</span>")
 		return FALSE

--- a/code/modules/spells/changeling/horrorform.dm
+++ b/code/modules/spells/changeling/horrorform.dm
@@ -55,7 +55,7 @@
 	sleep(duration)
 	feedback_add_details("changeling_powers","HF")
 	
-/spell/changeling/regenerate/after_cast(list/targets,var/mob/living/carbon/human/user)
+/spell/changeling/horrorform/after_cast(list/targets,var/mob/living/carbon/human/user)
 	var/datum/role/changeling/changeling = user.mind.GetRole(CHANGELING)
 	if(!changeling)
 		return

--- a/code/modules/spells/changeling/horrorform.dm
+++ b/code/modules/spells/changeling/horrorform.dm
@@ -11,21 +11,21 @@
 	duration = 2 MINUTES
 	var/horrorFormMaxHealth = 700
 
+/spell/changeling/horrorform/cast_check(var/skipcharge = 0, var/mob/user = usr)
+	. = ..()
+	if (!.) 
+		return FALSE
+	if(istype(user.loc, /obj/mecha))
+		to_chat(user, "<span class='warning'>We cannot transform here!</span>")
+		return FALSE
+	if(istype(user.loc, /obj/machinery/atmospherics))
+		to_chat(user, "<span class='warning'>We cannot transform here!</span>")
+		return FALSE
+	if(istype(user.loc,/mob))
+		to_chat(user, "<span class='warning'>You can't change right now!</span>")
+		return FALSE
+
 /spell/changeling/horrorform/cast(var/list/targets, var/mob/living/carbon/human/user)
-	..()
-	if (istype(user.loc,/mob))
-		to_chat(usr, "<span class='warning'>You can't change right now!</span>")
-		return 1
-	activate(user)
-	
-	sleep(duration)
-	to_chat(usr, "You are feeling weak. Seek somewhere safe.")
-	sleep(100)	//10 seconds before deactivate
-	deactivate(user)
-
-	return	
-
-/spell/changeling/horrorform/proc/activate(var/mob/living/carbon/human/user)
 	//scale health so they don't get free heals all the time
 	user.maxHealth = horrorFormMaxHealth
 	user.setToxLoss(user.getToxLoss()*horrorFormMaxHealth/100)
@@ -52,22 +52,23 @@
 	user.delayNextAttack(0)
 	user.icon = null
 	user.make_changeling()
+	sleep(duration)
+	feedback_add_details("changeling_powers","HF")
 	
-	return
-
-/spell/changeling/horrorform/proc/deactivate(var/mob/living/carbon/human/user)
+/spell/changeling/regenerate/after_cast(list/targets,var/mob/living/carbon/human/user)
 	var/datum/role/changeling/changeling = user.mind.GetRole(CHANGELING)
 	if(!changeling)
 		return
 	var/list/names = list()
 	for(var/datum/dna/DNA in changeling.absorbed_dna)
 		names += "[DNA.real_name]"
-
 	//take random DNA
 	var/datum/dna/chosen_dna = changeling.GetDNA(pick(names))
 	if(!chosen_dna)
 		return
-
+	
+	to_chat(usr, "You are feeling weak. Seek somewhere safe.")
+	sleep(100)	//10 seconds before deactivate
 	user.visible_message("<span class='danger'>[user] transforms!</span>")
 	user.dna = chosen_dna.Clone()
 
@@ -111,20 +112,5 @@
 	user.mind.transfer_to(O)
 	O.make_changeling()
 	O.changeling_update_languages(changeling.absorbed_languages)
-	feedback_add_details("changeling_powers","HF")
 
 	qdel(user)
-	
-	return
-	
-/spell/changeling/horrorform/cast_check(var/skipcharge = 0, var/mob/user = usr)
-	. = ..()
-	if (!.) 
-		return FALSE
-	if(istype(user.loc, /obj/mecha))
-		to_chat(user, "<span class='warning'>We cannot transform here!</span>")
-		return FALSE
-	if(istype(user.loc, /obj/machinery/atmospherics))
-		to_chat(user, "<span class='warning'>We cannot transform here!</span>")
-		return FALSE
-

--- a/code/modules/spells/changeling/split.dm
+++ b/code/modules/spells/changeling/split.dm
@@ -23,7 +23,7 @@
 /spell/changeling/split/cast(var/list/targets, var/mob/living/carbon/human/user)
 	owner = user.mind
 	var/datum/role/changeling/changeling = owner.GetRole(CHANGELING)
-	if (changeling.splitcount < 2 && !issilicon(user)) //<2 is two splits max
+	if (changeling.splitcount < 2) //<2 is two splits max
 		user.visible_message("[user] is preparing to generate a new form.")
 		Splitting()
 	else

--- a/code/modules/spells/changeling/split.dm
+++ b/code/modules/spells/changeling/split.dm
@@ -7,7 +7,7 @@
 	cooldown_min = 30 SECONDS
 	still_recharging_msg = "<span class='warning'>We are not ready to do that!</span>"
 	chemcost = 50
-	required_dna = 1
+	required_dna = 2
 	max_genedamage = 0
 	horrorallowed = 0
 	var/datum/mind/owner = null // The mind of the user, to be used by the recruiter
@@ -51,7 +51,6 @@
 	var/datum/role/changeling/changeling = owner.GetRole(CHANGELING)
 	if (success)
 		changeling.splitcount += 1
-		changeling.absorbedcount = max(0,changeling.absorbedcount-1)
 		(owner.current).visible_message("<span class='danger'>[(owner.current)] splits!</span>")
 		playsound(owner.current, 'sound/effects/flesh_squelch.ogg', 30, 1)
 	else


### PR DESCRIPTION
[balance]
In addition to the CL, I fixed a bug with horrorform not deactivating

:cl:
 * tweak: Changeling's Split now requires two DNA, but doesn't remove DNA. Only one roundstart ling. Lingborgs can no longer cast Changeling spells. Reduced evolve cost of ling spells.