### PR TITLE
Tackle Update Part 1

### DIFF
--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -356,6 +356,12 @@
 		spawn(5 SECONDS)	//But they fought with expert timing
 			blinding = TRUE
 
+/obj/item/clothing/shoes/blindingspeed/rangeTackleBonus()
+	return 2
+
+/obj/item/clothing/shoes/blindingspeed/offenseTackleBonus()
+	return 30
+
 /obj/item/clothing/shoes/blindingspeed/unequipped(mob/living/carbon/human/H, var/from_slot = null)
 	..()
 	if(from_slot == slot_shoes && istype(H))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -290,6 +290,9 @@
 /obj/item/clothing/proc/defenseTackleBonus()
 	return
 
+/obj/item/clothing/proc/rangeTackleBonus()
+	return
+
 //Ears: headsets, earmuffs and tiny objects
 /obj/item/clothing/ears
 	name = "ears"

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -110,7 +110,7 @@
 		return
 	var/tRange = calcTackleRange()
 	isTackling = TRUE
-	knockdown = max(knockdown, 3)	//Not using the Knockdown() proc as it created odd behaviour with hulks and another knockdown immune
+	knockdown = max(knockdown, 2)	//Not using the Knockdown() proc as it created odd behaviour with hulks or other knockdown immune mobs
 	update_canmove()
 	throw_at(A, tRange, 1)
 
@@ -124,26 +124,32 @@
 				add_attacklogs(src, hit_atom, "tackled")
 				var/mob/living/L = hit_atom
 				visible_message("<span class='warning'>[src] tackles [L]!</span>")
-
 				var/tackleDefense = L.calcTackleDefense(src)
 				var/rngForce = rand(tackleForce/2, tackleForce)	//RNG or else most people would just bounce off each other.
 				var/rngDefense = rand(tackleDefense/2, tackleDefense)
 				var/tKnock = max(0, rngDefense - rngForce)
-				tKnock /= 10	//Numbers were inflated a digit to allow flexibility, now they need to be smaller
-				Knockdown(min(4, tKnock)) //To prevent eternity knockdown from tackling an 8 riot shield martian or something
-				tKnock = max(0, rngForce - rngDefense)	//Calculating their knockdown, they might not get knocked down at all
-				if(tKnock)
-					tKnock /= 10
-					L.Knockdown(min(3, tKnock))
-					if(M_HORNS in mutations)
-						tKnock += 5
-					L.adjustBruteLoss(tKnock)
-					for (var/obj/held in L.held_items)
-						var/dir = pick(alldirs)
-						var/turf/target = get_turf(src)
-						for(var/i in 1 to 3)
-							target = get_step(target, dir)
-						L.throw_item(target, held)
+				if(isrobot(L))
+					var/mob/living/silicon/robot/R = L
+					R.tip(get_dir(src, R))
+					visible_message("<span class='warning'>[src] collides with [R], tipping it over!</span>")
+					tackleGetHurt(0, 3)
+					AdjustStunned(3)	//Mostly a mercy to borgs but something something metal casing + skull
+				else
+					tKnock /= 10	//Numbers were inflated a digit to allow flexibility, now they need to be smaller
+					Knockdown(min(4, tKnock)) //To prevent eternity knockdown from tackling an 8 riot shield martian or something
+					tKnock = max(0, rngForce - rngDefense)	//Calculating their knockdown, they might not get knocked down at all
+					if(tKnock)
+						tKnock /= 10
+						L.Knockdown(min(3, tKnock))
+						if(M_HORNS in mutations)
+							tKnock += 5
+						L.adjustBruteLoss(tKnock)
+						for (var/obj/held in L.held_items)
+							var/dir = pick(alldirs)
+							var/turf/target = get_turf(src)
+							for(var/i in 1 to 3)
+								target = get_step(target, dir)
+							L.throw_item(target, held)
 			spawn(3)	//Just to let throw_impact stop throwing a tantrum
 				isTackling = FALSE
 	..()
@@ -154,10 +160,17 @@
 		if(!throwing)
 			isTackling = FALSE	//Safety from throw_at being a jerk
 		else
-			playsound(src, "trayhit", 75, 1)
-			var/tPain = rand(5,15)
-			adjustBruteLoss(tPain)
-			Knockdown(tPain/2)
+			tackleGetHurt()
+
+/mob/living/carbon/proc/tackleGetHurt(var/hurtAmount = 0, var/knockAmount = 0, var/hurtSound = "trayhit")
+	if(!hurtAmount)
+		hurtAmount = rand(5,15)
+	if(!knockAmount)
+		knockAmount = hurtAmount/2
+	playsound(src, hurtSound, 75, 1)
+	adjustBruteLoss(hurtAmount)
+	Knockdown(knockAmount)
+
 
 /mob/living/carbon/calcTackleRange(var/tR = 0)
 	tR += bonusTackleRange()
@@ -165,6 +178,11 @@
 		tR += 1	//Avoiding tR++ for readability and ease of editing later
 	if(M_RUN in mutations)
 		tR += 1
+	if(spell_list.len)
+		var/spell/targeted/leap/leapTackle = locate(/spell/targeted/leap) in spell_list
+		if(leapTackle && leapTackle.charge_counter >= leapTackle.charge_max)
+			tR += 2
+			leapTackle.take_charge()
 	return tR
 
 /mob/living/carbon/calcTackleForce(var/tForce = 50)

--- a/code/modules/mob/living/carbon/human/combat.dm
+++ b/code/modules/mob/living/carbon/human/combat.dm
@@ -285,10 +285,25 @@
 	return tD
 
 /mob/living/carbon/human/bonusTackleRange(var/tR = 0)
+	for(var/obj/item/clothing/C in get_all_slots())
+		if(istype(C))
+			tR += C.rangeTackleBonus()
 	if(species)
 		tR += species.tackleRange
 	if(wear_suit)
 		var/obj/item/slowSuit = wear_suit
 		if(slowSuit.slowdown > NO_SLOWDOWN)
 			tR -= 1
+	if(reagents.get_sportiness()>=10)	//Not as easy as just a swig of sport drink
+		tR += 1
 	return max(0, tR)
+
+/mob/living/carbon/human/tackleGetHurt(var/hurtAmount = 0, var/knockAmount = 0, var/hurtSound = "trayhit")
+	if(!hurtAmount)
+		hurtAmount = rand(5,15)
+	if(!knockAmount)
+		knockAmount = hurtAmount/2
+	if(hurtAmount >= 10)
+		knock_out_teeth()
+	..(hurtAmount, knockAmount, hurtSound)
+

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1847,6 +1847,11 @@
 		species.anatomy_flags = rand(0,65535)
 	if(prob(5))
 		species.chem_flags = rand(0,65535)
+	if(prob(15))
+		species.tackleRange = max(0, rand(species.tackleRange-2, species.tackleRange+2))	//Leaving this with no upper limit is a choice I'm making today. God help us tomorrow.
+	if(prob(15))
+		species.tacklePower = max(0, rand(species.tacklePower*0.5, species.tacklePower*1.5))
+
 
 	if(!can_be_fat)
 		species.anatomy_flags &= ~CAN_BE_FAT


### PR DESCRIPTION
Some tweaks/additions to tackles, now that the playerbase has had time to get used to them and give feedback.

**Tweaks**

- Reduced the guaranteed knockdown duration while performing a tackle by 1/3rd.
- Colliding with something that damages you now knocks some teeth out if the damage is high enough
- Tackling a borg now does the same damage as tackling a wall, with the same chance of knocking your teeth out. Tackling borgs also stuns you rather than just knocking you over

**Additions**

- Phazon salt can now change tackle stats, both range and strength. Phazon has a chance to either add or subtract from the current value of range/strength, **there is no upper limit on either but both are subject to RNG**, god help us all.
- The leap mutation now increases tackle range by 2, but only if it is off cooldown. Receiving this bonus to a tackle puts leap on cooldown.
- Having enough sportiness (multiple sources, not just 1) increases tackle range by 1
- Boots of blinding speed increase tackle range by 2, and power by a moderate amount. You still go blind while tackling.
- **Tackling borgs tips them over**

![hulksmash](https://user-images.githubusercontent.com/64218965/151878307-66085fb2-12d0-4121-b3fc-6209199e3190.png)


I had more ideas but I can't remember what they are. Part 2 when that changes.

-->
:cl:
 * bugfix: Borgs are no longer able to be stunlocked by a single tackle-happy assistant
 * rscadd: Phazon, boots of blinding speed, as well as more mutations and chems now have interactions with tackling
 * rscadd: Tackling borgs can now tip them over and knock out your teeth