### PR TITLE
Storing Tiny Items in your Mouth - The Cavity Search Update

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -282,6 +282,7 @@ var/MAX_EXPLOSION_RANGE = 14
 #define slot_in_backpack 16
 #define slot_legcuffed 17
 #define slot_legs 18
+#define slot_mouth 19
 
 //slots, but in string format.
 #define slot_back_str "1"
@@ -302,6 +303,7 @@ var/MAX_EXPLOSION_RANGE = 14
 #define slot_in_backpack_str "16"
 #define slot_legcuffed_str "17"
 #define slot_legs_str "18"
+#define slot_mouth_str "19"
 
 #define ACCESSORY_ITEM "accessory item"
 #define SURVIVAL_BOX "Survival Box"

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -287,7 +287,7 @@ Proc for attack log creation, because really why not
 			L = list(LIMB_CHEST, LIMB_GROIN, LIMB_LEFT_ARM, LIMB_RIGHT_ARM, LIMB_LEFT_LEG, LIMB_RIGHT_LEG)
 		if(slot_gloves, slot_handcuffed) //Gloves
 			L = list(LIMB_LEFT_HAND, LIMB_RIGHT_HAND)
-		if(slot_wear_mask, slot_ears, slot_glasses, slot_head)
+		if(slot_wear_mask, slot_ears, slot_glasses, slot_head, slot_mouth)
 			L = list(LIMB_HEAD)
 		if(slot_shoes)
 			L = list(LIMB_LEFT_FOOT, LIMB_RIGHT_FOOT)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -153,7 +153,9 @@
 				delayNextAttack(10)
 			if(INVOKE_EVENT(src, /event/uattack, "atom" = A)) //This returns 1 when doing an action intercept
 				return
-			UnarmedAttack(A, 1, params)
+			if(!biteCheck(A))
+				to_chat(world, "CLICK after bite check")
+				UnarmedAttack(A, 1, params)
 
 	//Clicked on a non-adjacent atom
 	else

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -207,6 +207,11 @@
 /mob/proc/audible_cough()
 	emote("coughs", message = TRUE, ignore_status = TRUE)
 
+/mob/living/carbon/human/audible_cough()
+	..()
+	if(wear_mouth)
+		spitOutItem()
+
 /mob/proc/audible_scream(var/arguments)
 	if(isvox(src) || isskelevox(src))
 		emote("shrieks", message = TRUE, ignore_status = TRUE, arguments = arguments)
@@ -217,4 +222,7 @@
 	else
 		emote("screams", message = TRUE, ignore_status = TRUE, arguments = arguments) // So it's forced
 
-
+/mob/living/carbon/human/audible_scream(var/arguments)
+	..(arguments)
+	if(wear_mouth)
+		spitOutItem()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -268,8 +268,17 @@
 			return
 		//user.next_move = max(user.next_move+2,world.time + 2)
 	add_fingerprint(user)
-	if(can_pickup(user) && !user.put_in_active_hand(src))
-		forceMove(get_turf(user))
+	if(can_pickup(user))
+		if(ishuman(user))
+			to_chat(world, "Is human in pickup")
+			var/mob/living/carbon/human/H = user
+			if(H.attack_type == ATTACK_BITE && H.can_bite(src))
+				to_chat(world, "attack bite and can bite")
+				H.putItemInMouth(src)
+				to_chat(world, "after put in mouth PICKUP")
+				return
+		if(!user.put_in_active_hand(src))
+			forceMove(get_turf(user))
 
 	//transfers diseases between the mob and the item
 	disease_contact(user)
@@ -742,6 +751,13 @@
 					if(B.contents.len < B.storage_slots && w_class <= B.fits_max_w_class)
 						return CAN_EQUIP
 				return CANNOT_EQUIP
+			if(slot_mouth)
+				H.enableSpitting(src)
+				H.hasMouthFull = TRUE
+				return CAN_EQUIP
+			//-->>>>		//RIGHT HERE//	<<<<----//
+
+
 		return CANNOT_EQUIP //Unsupported slot
 		//END HUMAN
 
@@ -1570,3 +1586,4 @@ var/global/list/image/blood_overlays = list()
 
 /obj/item/proc/NoiseDampening()	// checked on headwear by flashbangs
 	return FALSE
+

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -753,7 +753,6 @@
 				return CANNOT_EQUIP
 			if(slot_mouth)
 				H.enableSpitting(src)
-				H.hasMouthFull = TRUE
 				return CAN_EQUIP
 			//-->>>>		//RIGHT HERE//	<<<<----//
 

--- a/code/game/objects/items/weapons/shard.dm
+++ b/code/game/objects/items/weapons/shard.dm
@@ -42,12 +42,14 @@
 	..()
 	return
 
-/obj/item/weapon/shard/mouth_act(mob/user)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		H.adjustBruteLossByPart(rand(25, 50), LIMB_HEAD, src)	//don't eat glass, dummy
-		to_chat(H, "<span class='big warning'>All you can taste is pain!</span>")
-		H.adjustHalLoss(70)
+/obj/item/weapon/shard/mouth_act(mob/user, mInitial = FALSE, mConstant = FALSE)
+	..()
+	if(mInitial)
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			H.adjustBruteLossByPart(rand(20, 40), LIMB_HEAD, src)	//don't eat glass, dummy
+			to_chat(H, "<span class='big warning'>All you can taste is pain!</span>")
+			H.adjustHalLoss(60)
 
 /obj/item/weapon/shard/plasma
 	name = "plasma shard"

--- a/code/game/objects/items/weapons/shard.dm
+++ b/code/game/objects/items/weapons/shard.dm
@@ -42,6 +42,13 @@
 	..()
 	return
 
+/obj/item/weapon/shard/mouth_act(mob/user)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.adjustBruteLossByPart(rand(25, 50), LIMB_HEAD, src)	//don't eat glass, dummy
+		to_chat(H, "<span class='big warning'>All you can taste is pain!</span>")
+		H.adjustHalLoss(70)
+
 /obj/item/weapon/shard/plasma
 	name = "plasma shard"
 	desc = "A shard of plasma glass. Considerably tougher then normal glass shards. Apparently not tough enough to be a window."

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -541,6 +541,10 @@
 				if(B.contents.len < B.storage_slots && W.w_class <= B.fits_max_w_class)
 					W.forceMove(B)
 					equipped = 1
+		if(slot_mouth)
+			if(!src.wear_mouth)
+				src.wear_mouth = W
+				equipped = 1
 
 	if(equipped)
 		W.hud_layerise()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -221,6 +221,11 @@
 			else if(!client)
 				msg += "[t_He] [t_has] a vacant, braindead stare...\n"
 
+	if(wear_mouth)
+		if(distance <= 1 && !skipface)
+			msg += "<span class='info'>[t_He] very clearly [t_has] something in [t_his] mouth.</span>\n"
+
+
 	// Religions
 	if (ismob(user) && user.mind && user.mind.faith && user.mind.faith.leadsThisReligion(user) && mind)
 		if (src.mind.faith == user.mind.faith)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -728,13 +728,15 @@
 
 			if(gcDestroyed)
 				return
-			if(hasMouthFull)
+			if(wear_mouth)
 				if(!spitOutItem())
 					Stun(10)
-					reagents.add_reagent(VOMIT, 10)	//How horrifying
-					adjustToxLoss(10)
+					Knockdown(10)
+					reagents.add_reagent(VOMIT, 15)	//How horrifying
+					adjustToxLoss(20)
+					adjustOxyLoss(25)
 					playsound(loc, 'sound/effects/splat.ogg', 25, 1)
-					visible_message("<span class='warning'>[src] vomits in their own mouth!</span>")
+					visible_message("<span class='big warning'>[src] vomits in their own mouth!</span>")
 			else
 				Stun(5)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -728,54 +728,61 @@
 
 			if(gcDestroyed)
 				return
-
-			Stun(5)
-
-			var/turf/location = loc
-			var/spawn_vomit_on_floor = 0
-
-			if(hairball)
-				src.visible_message("<span class='warning'>[src] hacks up a hairball!</span>","<span class='danger'>You hack up a hairball!</span>")
-
+			if(hasMouthFull)
+				if(!spitOutItem())
+					Stun(10)
+					reagents.add_reagent(VOMIT, 10)	//How horrifying
+					adjustToxLoss(10)
+					playsound(loc, 'sound/effects/splat.ogg', 25, 1)
+					visible_message("<span class='warning'>[src] vomits in their own mouth!</span>")
 			else
-				var/skip_message = 0
+				Stun(5)
 
-				var/obj/structure/toilet/T = locate(/obj/structure/toilet) in location //Look for a toilet
-				if(T && T.open)
-					src.visible_message("<span class='warning'>[src] throws up into \the [T]!</span>", "<span class='danger'>You throw up into \the [T]!</span>")
-					skip_message = 1
-				else //Look for a bucket
+				var/turf/location = loc
+				var/spawn_vomit_on_floor = 0
 
-					for(var/obj/item/weapon/reagent_containers/glass/G in (location.contents + src.get_active_hand() + src.get_inactive_hand()))
-						if(!G.reagents)
-							continue
-						if(!G.is_open_container())
-							continue
+				if(hairball)
+					src.visible_message("<span class='warning'>[src] hacks up a hairball!</span>","<span class='danger'>You hack up a hairball!</span>")
 
-						src.visible_message("<span class='warning'>[src] throws up into \the [G]!</span>", "<span class='danger'>You throw up into \the [G]!</span>")
+				else
+					var/skip_message = 0
 
-						if(G.reagents.total_volume <= G.reagents.maximum_volume-7) //Container can fit 7 more units of chemicals - vomit into it
-							G.reagents.add_reagent(VOMIT, rand(3,10))
-							if(src.reagents)
-								reagents.trans_to(G, 1 + reagents.total_volume * 0.1)
-						else //Container is nearly full - fill it to the brim with vomit and spawn some more on the floor
-							G.reagents.add_reagent(VOMIT, 10)
-							spawn_vomit_on_floor = 1
-							to_chat(src, "<span class='warning'>\The [G] overflows!</span>")
-
+					var/obj/structure/toilet/T = locate(/obj/structure/toilet) in location //Look for a toilet
+					if(T && T.open)
+						src.visible_message("<span class='warning'>[src] throws up into \the [T]!</span>", "<span class='danger'>You throw up into \the [T]!</span>")
 						skip_message = 1
+					else //Look for a bucket
 
-						break
+						for(var/obj/item/weapon/reagent_containers/glass/G in (location.contents + src.get_active_hand() + src.get_inactive_hand()))
+							if(!G.reagents)
+								continue
+							if(!G.is_open_container())
+								continue
 
-				if(!skip_message)
-					src.visible_message("<span class='warning'>[src] throws up!</span>","<span class='danger'>You throw up!</span>")
-					spawn_vomit_on_floor = 1
+							src.visible_message("<span class='warning'>[src] throws up into \the [G]!</span>", "<span class='danger'>You throw up into \the [G]!</span>")
 
-			playsound(loc, 'sound/effects/splat.ogg', 50, 1)
+							if(G.reagents.total_volume <= G.reagents.maximum_volume-7) //Container can fit 7 more units of chemicals - vomit into it
+								G.reagents.add_reagent(VOMIT, rand(3,10))
+								if(src.reagents)
+									reagents.trans_to(G, 1 + reagents.total_volume * 0.1)
+							else //Container is nearly full - fill it to the brim with vomit and spawn some more on the floor
+								G.reagents.add_reagent(VOMIT, 10)
+								spawn_vomit_on_floor = 1
+								to_chat(src, "<span class='warning'>\The [G] overflows!</span>")
 
-			if(spawn_vomit_on_floor)
-				if(istype(location, /turf/simulated))
-					location.add_vomit_floor(src, 1, (hairball ? 0 : 1), 1)
+							skip_message = 1
+
+							break
+
+					if(!skip_message)
+						src.visible_message("<span class='warning'>[src] throws up!</span>","<span class='danger'>You throw up!</span>")
+						spawn_vomit_on_floor = 1
+
+				playsound(loc, 'sound/effects/splat.ogg', 50, 1)
+
+				if(spawn_vomit_on_floor)
+					if(istype(location, /turf/simulated))
+						location.add_vomit_floor(src, 1, (hairball ? 0 : 1), 1)
 
 			if(!hairball)
 				nutrition = max(nutrition-40,0)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -272,7 +272,8 @@ emp_act
 				if(prob((final_force + 10)))
 					apply_effect(5, WEAKEN, armor)
 					visible_message("<span class='danger'>[src] has been knocked down!</span>")
-
+				if(prob(final_force * 10))	//Very high chance
+					spitOutItem()
 				if(bloody)
 					bloody_body(src)
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -312,6 +312,10 @@ emp_act
 
 			drugged_message = "<span class='info'>The tooth fairy takes some of \the [src]'s teeth out!</span>",\
 			self_drugged_message = "<span class='info'>The tooth fairy takes some of your teeth out, and gives you a dollar.</span>")
+	if(wear_mouth)
+		to_chat(src, "<span class='danger'>\The [wear_mouth] falls out of your mouth!</span>")
+		spitOutItem()
+
 
 /mob/living/carbon/human/proc/foot_impact(var/atom/source, var/damage) //When our foot is hurt, for example by kicking something stationary
 	//note: as per can_kick() in human.dm, kicking requires both feet intact

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -43,7 +43,6 @@
 	var/used_skillpoints = 0
 	var/skill_specialization = null
 	var/list/skills = null
-	var/hasMouthFull = FALSE
 
 	var/icon/stand_icon = null
 	var/icon/lying_icon = null

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -35,6 +35,7 @@
 	var/obj/item/s_store = null
 	var/obj/item/l_ear	 = null
 	var/obj/item/r_ear	 = null
+	var/obj/item/wear_mouth	= null
 
 	//Special attacks (bite, kicks, ...)
 	var/attack_type = NORMAL_ATTACK
@@ -42,6 +43,7 @@
 	var/used_skillpoints = 0
 	var/skill_specialization = null
 	var/list/skills = null
+	var/hasMouthFull = FALSE
 
 	var/icon/stand_icon = null
 	var/icon/lying_icon = null

--- a/code/modules/mob/living/carbon/human/human_iteminmouth.dm
+++ b/code/modules/mob/living/carbon/human/human_iteminmouth.dm
@@ -1,0 +1,128 @@
+/datum/action/item_action/itemInMouth
+	name = "Spit Out"
+
+/datum/action/item_action/itemInMouth/proc/adjustForItem()
+	if(!target)
+		return FALSE
+	name = "Spit Out [target]"
+	desc = "Spits out \the [target] you have in your mouth"
+
+/datum/action/item_action/itemInMouth/Trigger()
+	to_chat(world, "Trigger start")
+	if(ishuman(owner))
+		to_chat(world, "Trigger human")
+		var/mob/living/carbon/human/H = owner
+		H.spitItem()
+
+
+/mob/living/carbon/human/verb/spitItem()
+	set name = "Spit Out"
+	set category = "IC"
+
+	if(!hasMouthFull)
+		return FALSE
+	if(a_intent == I_HURT)
+		var/turf/T = get_turf(get_step(src, dir))
+		spitOutItem(TRUE, FALSE, T)
+	else
+		spitOutItem(TRUE, TRUE)
+
+
+
+//Mob procs/////////
+
+/mob/proc/biteCheck(var/atom/A)
+	return FALSE
+
+/mob/living/carbon/human/biteCheck(var/atom/A)
+	to_chat(world, "Start bite check")
+	if(attack_type == ATTACK_BITE)
+		to_chat(world, "ATTACK BITE")
+		if(hasMouthFull)
+			to_chat(world, "has mouth full")
+			spitOutItem(TRUE, FALSE, get_turf(A))
+			to_chat(world, "After spit out")
+			return TRUE
+		if(can_bite(A))
+			to_chat(world, "Can bite")
+			if(a_intent == "hurt")	//So we can still do things like bite pills without change
+				to_chat(world, "hurt")
+				A.bite_act(src)
+			else if(istype(A, /obj/item))
+				to_chat(world, "Biting [A]")
+				var/obj/item/toBite = A
+				putItemInMouth(toBite)
+				to_chat(world, "put in mouth")
+				return TRUE
+	return FALSE
+
+/mob/living/carbon/human/proc/putItemInMouth(var/obj/item/mItem)
+	if(hasMouthFull)
+		to_chat(src, "<span class='warning'>You already have something in your mouth.</span>")
+	else if(mItem.w_class == W_CLASS_TINY)
+		to_chat(world, "It's tiny")
+		if(equip_to_slot_if_possible(mItem, slot_mouth))
+			to_chat(world, "after equip to slot")
+			mItem.mouth_act(src)	//I don't want to hear any giggling in the back of the class
+			visible_message("<span class='warning'>[src] puts \the [mItem] in their mouth!.</span>")
+		else
+			to_chat(src, "<span class='warning'>You couldn't get \the [src] into your mouth!.</span>")
+
+/mob/living/carbon/human/proc/enableSpitting(var/obj/item/mItem)
+	to_chat(world, "begin enable spitting")
+	var/datum/action/A = new /datum/action/item_action/itemInMouth(mItem)
+	to_chat(world, "Action added")
+	A.Grant(src)
+	to_chat(world, "After grant")
+
+/mob/living/carbon/human/proc/spitOutItem(var/message = TRUE, var/spitInHands = FALSE, var/turf/spitAt = null, var/spitStr = 0)
+	to_chat(world, "Begin spit out")
+	var/obj/item/inMouth = get_item_by_slot(slot_mouth)
+	to_chat(world, "in mouth is [inMouth]")
+	if(!inMouth)
+		to_chat(world, "No in mouth")
+		return FALSE
+	if(inMouth.gcDestroyed || inMouth.loc != src)
+		to_chat(world, "in mouth destroyed or not in there")
+		emptyMouth()
+		to_chat(world, "After empty mouth")
+		return TRUE	//Just in case
+	if(inMouth.current_glue_state)
+		to_chat(world, "Glued")
+		return FALSE
+	emptyMouth()
+	to_chat(world, "After second empty mouth")
+	inMouth.forceMove(get_turf(src))
+	to_chat(world, "inmouth was force moved")
+	if(message)
+		visible_message("<span class='warning'>\[src] spits out what was in their mouth!</span>")
+	if(spitInHands)
+		to_chat(world, "spit in hands")
+		put_in_hands(inMouth)
+	if(spitAt)
+		to_chat(world, "spit at turf")
+		spitStr += get_strength(src)	//Will usually be 1
+		inMouth.throw_at(spitAt, spitStr, spitStr)
+	return TRUE
+
+/mob/living/carbon/human/proc/emptyMouth()
+	to_chat(world, "Empty start")
+	var/obj/item/inMouth = get_item_by_slot(slot_mouth)
+	to_chat(world, "in mouth is [inMouth]")
+	u_equip(inMouth, slot_mouth)
+	to_chat(world, "After u_equip")
+	hasMouthFull = FALSE
+
+
+//Item procs/////////////
+
+/obj/item/bite_act(mob/user)
+	to_chat(world, "begin bite act")
+	if(ishuman(user))	//Monkeys aren't smart enough or something. Mostly this is too prone to break things so I'm human restricting it
+		to_chat(world, "after ishuman")
+		var/mob/living/carbon/human/H = user
+		H.putItemInMouth(src)
+
+/obj/item/proc/mouth_act(mob/user)	//If something does something while held in your mouth, like a wad of paper
+	to_chat(world, "mouth act")
+	return

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -489,6 +489,8 @@
 				src.u_equip(W,0)
 			W.forceMove(src.back)
 			return
+		if(slot_mouth)
+			src.wear_mouth = W
 		else
 			to_chat(src, "<span class='warning'>You are trying to equip this item to an unsupported inventory slot. Report this to a coder!</span>")
 			return

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -172,6 +172,8 @@ var/global/list/organ_damage_overlays = list(
 		handle_spaghetti(10)
 	else //Otherwise 5% -kanef
 		handle_spaghetti(5)
+	if(wear_mouth)
+		wear_mouth.mouth_act(src, FALSE, TRUE)
 	if(life_tick > 5 && timeofdeath && (timeofdeath < 5 || world.time - timeofdeath > 6000)) //We are long dead, or we're junk mobs spawned like the clowns on the clown shuttle
 		cycle = "DEAD"
 		return //We go ahead and process them 5 times for HUD images and other stuff though.

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -4,10 +4,17 @@
 	var/list/muteletters_check = list()
 	var/hangman_phrase = ""
 
+
 /mob/living/carbon/human/say(var/message)
 	if(species && (species.flags & SPECIES_NO_MOUTH) && !get_message_mode(message) && !findtext(message, "*", 1, 2))
 		species.silent_speech(src,message)
 	else
+		to_chat(world, "SAY before hasfullmouth")
+		if(hasMouthFull)
+			to_chat(world, "SAY in full mouth")
+			spitOutItem()
+			to_chat(world, "SAY after spit out")
+			message = "MmmmMmmggmm"
 		..()
 
 // This is obsolete if the human is using a language.

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -10,7 +10,7 @@
 		species.silent_speech(src,message)
 	else
 		to_chat(world, "SAY before hasfullmouth")
-		if(hasMouthFull)
+		if(wear_mouth)
 			to_chat(world, "SAY in full mouth")
 			spitOutItem()
 			to_chat(world, "SAY after spit out")

--- a/code/modules/mob/living/combat.dm
+++ b/code/modules/mob/living/combat.dm
@@ -2,6 +2,23 @@
 	if(grab_check(target))
 		return
 
+	if(zone_sel.selecting == "mouth")
+		if(ishuman(target))
+			var/mob/living/carbon/human/H = target
+			if(H.check_body_part_coverage(MOUTH))
+				to_chat(src, "<span class='notice'>Their mouth is blocked!</span>")
+				return
+			var/spitItOutISaidSpitItOut = 10
+			if(H.a_intent != I_HELP)
+				spitItOutISaidSpitItOut = 25
+			visible_message("<span class='danger'>[src] is fishing around in [H]'s mouth!</span>")
+			if(do_after(src, target, spitItOutISaidSpitItOut))
+				if(H.spitOutItem())
+					to_chat(src, "<span class='notice'>You yank something out of [H]'s mouth!</span>")
+				else
+					to_chat(src, "<span class='notice'>You found nothing in [H]'s mouth.</span>")
+			return
+
 	if (is_pacified(VIOLENCE_DEFAULT,target))
 		return
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -263,7 +263,7 @@ var/list/animals_with_wings = list(
 	. = ..()
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(H.hasMouthFull)
+		if(H.wear_mouth)
 			var/turf/T = get_turf(get_step(H, H.dir))
 			H.spitOutItem(TRUE, FALSE, T, 2)
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -259,6 +259,14 @@ var/list/animals_with_wings = list(
 	message = "sneezes."
 	emote_type = EMOTE_AUDIBLE
 
+/datum/emote/living/carbon/sneeze/run_emote(mob/user, params)
+	. = ..()
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.hasMouthFull)
+			var/turf/T = get_turf(get_step(H, H.dir))
+			H.spitOutItem(TRUE, FALSE, T, 2)
+
 /datum/emote/living/smug
 	key = "smug"
 	key_third_person = "smugs"

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1477,7 +1477,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	encased = "skull"
 
 	w_class = W_CLASS_SMALL
-	slots_to_drop = list(slot_glasses, slot_wear_mask, slot_head, slot_ears)
+	slots_to_drop = list(slot_glasses, slot_wear_mask, slot_head, slot_ears, slot_mouth)
 
 /datum/organ/external/head/generate_dropped_organ(current_organ)
 	if(!current_organ)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -195,6 +195,16 @@
 		return
 	if(!eatverb)
 		eatverb = pick("bite", "chew", "nibble", "gnaw", "gobble", "chomp")
+	if(ishuman(eater))
+		var/mob/living/carbon/human/H = eater
+		if(H.wear_mouth)
+			if(H.a_intent == I_HURT && prob(10))
+				to_chat(H, "<span class='danger'>You try to cram more in your mouth and start choking on \the [wear_mouth]!</span>")
+				H.adjustOxyLoss(20)
+				H.Knockdown(2)
+			else
+				to_chat(H, "<span class='notice'>You can't eat \the [src] with \a [wear_mouth] in your mouth!</span>")
+			return
 
 	before_consume(eater)
 

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -283,15 +283,27 @@
 		user.visible_message("<span class='danger'>[user] stabs [target] with \the [src]!</span>", "<span class='danger'>You stab [target] with \the [src]!</span>")
 		target.take_organ_damage(3)// 7 is the same as crowbar punch
 
+	harmSyringeInject(target)
+
+/obj/item/weapon/reagent_containers/syringe/mouth_act(mob/user)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/datum/organ/external/ouchMouth = H.get_organ(LIMB_HEAD)
+		ouchMouth.take_damage(pick(3, 10))	//Tongue or roof of the mouth? Probably the same as a normal harm syringe. Riiiiight between the teeth or back of the throat? Ouch
+		harmSyringeInject(user)
+
+
+/obj/item/weapon/reagent_containers/syringe/proc/harmSyringeInject(var/mob/living/carbon/target)
 	// Break the syringe and transfer some of the reagents to the target
-	src.reagents.reaction(target, INGEST)
+	reagents.reaction(target, INGEST)
 	var/syringestab_amount_transferred = max(rand(min(reagents.total_volume, 2), (reagents.total_volume - 5)), 0) //nerfed by popular demand.
-	src.reagents.trans_to(target, syringestab_amount_transferred)
-	src.desc += " It is broken."
-	src.mode = SYRINGE_BROKEN
-	src.add_blood(target)
-	src.add_fingerprint(usr)
-	src.update_icon()
+	reagents.trans_to(target, syringestab_amount_transferred)
+	desc += " It is broken."
+	mode = SYRINGE_BROKEN
+	add_blood(target)
+	add_fingerprint(usr)
+	update_icon()
+
 
 /obj/item/weapon/reagent_containers/syringe/restock()
 	if(mode == 2) //SYRINGE_BROKEN

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -285,12 +285,14 @@
 
 	harmSyringeInject(target)
 
-/obj/item/weapon/reagent_containers/syringe/mouth_act(mob/user)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		var/datum/organ/external/ouchMouth = H.get_organ(LIMB_HEAD)
-		ouchMouth.take_damage(pick(3, 10))	//Tongue or roof of the mouth? Probably the same as a normal harm syringe. Riiiiight between the teeth or back of the throat? Ouch
-		harmSyringeInject(user)
+/obj/item/weapon/reagent_containers/syringe/mouth_act(mob/user, mInitial = FALSE, mConstant = FALSE)
+	..()
+	if(mInitial)
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			var/datum/organ/external/ouchMouth = H.get_organ(LIMB_HEAD)
+			ouchMouth.take_damage(pick(3, 10))	//Tongue or roof of the mouth? Probably the same as a normal harm syringe. Riiiiight between the teeth or back of the throat? Ouch
+			harmSyringeInject(user)
 
 
 /obj/item/weapon/reagent_containers/syringe/proc/harmSyringeInject(var/mob/living/carbon/target)

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1873,6 +1873,7 @@
 #include "code\modules\mob\living\carbon\human\human_damage.dm"
 #include "code\modules\mob\living\carbon\human\human_defense.dm"
 #include "code\modules\mob\living\carbon\human\human_defines.dm"
+#include "code\modules\mob\living\carbon\human\human_iteminmouth.dm"
 #include "code\modules\mob\living\carbon\human\human_movement.dm"
 #include "code\modules\mob\living\carbon\human\inventory.dm"
 #include "code\modules\mob\living\carbon\human\life.dm"


### PR DESCRIPTION
Now, let's all try to be mature adults. No low hanging fruit. No giggling in the back of the class. No crude humor. We are a respectable, professional server for respectable, professional adults. 

**Shove that little disk right in your mouth / Why**

You are Captain Chokem, you are securing the disk. While normally disks would fit snuggly in a clown's ass, today you're feeling a little greedy. You want that disk yourself. You want that disk right in your mouth. So you go to put that disk in your mouth and- oh no! You can't! You even tried biting it, and disks usually don't really like teeth, but no dice. Thankfully this PR changes that.

**What**

This PR lets you smuggle tiny (and only tiny) items in your mouth. So the disk, the spare, syringes, etc. You can later spit the item into your hands, the floor, or at something in front of you if you're a gross jerk. 

**How to eat**
You can put an item in your mouth by biting an item that does not already have a bite interaction. So no smuggling pills or burgers in your cheeks. Those just get eaten. This also means anything that prevents biting, like most masks, will prevent you from putting disks in your mouth. 

**How to spit**
You can remove an item from your mouth by:
- Using the "spit out" verb
- Clicking the screen icon in the top left (same place as toggling rig helmets)
- Trying to put another item in your mouth when you already have one
- Sneezing
- Vomiting
- Getting punched in the stomach
- Being beheaded
- Speaking

An item being covered in glue prevents you spitting it out until it is unglued. Please make sure not to vomit with a glued item in your mouth.

**Eating glass**
I've also included an easy way to add interactions for specific things being smuggled in your mouth. This PR includes one for both glass shards and syringes, hint: don't. More to come later.

### To Do

- [ ] Actually make it work. I think something with equipping to the mouth slot is busted
- [x] Make it so you can't eat while something is in your mouth
- [ ] Maybe add mutation interactions
- [ ] Maybe add a verb/screen button to put items in your mouth, not just rely on the bite option?
- [ ] Clean up some things. Remove test chat lines.
- [x] Add examine text saying "They very clearly have something in their mouth" similar to examining someone with "a braindead stare"
- [x] Add a method to force someone to spit something out that isn't punching
- [x] Add checks for sharpness flags to add "realism" for putting a screwdriver or knife in your mouth
- [x] Make getting tazed, teeth knocked out, stunned in general, and coughing cause you to spit the item out


**Drafting this because it doesn't work yet. I also feel like this one might be controversial so maybe it can be argued away before I invest more time.**
**Please make suggestions/voice concerns. I'll try to incorporate things while I'm still focused on this**

[wip]


:cl:
 * rscadd: Spessmen can now shove tiny objects in their mouth and spit them up later. 
