### PR TITLE
Deluxe HoP cartridge and access change app

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1113,6 +1113,14 @@ var/list/uplink_items = list()
 	discounted_cost = 8
 	jobs_with_discount = list("Captain", "Head of Personnel")
 
+/datum/uplink_item/jobspecific/command/remoteidchanger
+	name = "Hacked HumanResources9001 DX cartridge"
+	desc = "Allows remote changing of the details (including name, account number, job title and access) of any ID inside any PDA that can be messaged. The hacked version of this cartridge bypasses any notification to the target of an access change."
+	item = /obj/item/weapon/cartridge/hop/dx/antag
+	cost = 20
+	discounted_cost = 12
+	jobs_with_discount = list("Captain", "Head of Personnel")
+
 /datum/uplink_item/jobspecific/trader
 	category = "Trader Specials"
 

--- a/code/game/objects/items/devices/PDA/cart/heads.dm
+++ b/code/game/objects/items/devices/PDA/cart/heads.dm
@@ -139,8 +139,7 @@
 	if(href_list["select_pda"])
 		var/list/pda_with_id = list()
 		for(var/obj/item/device/pda/pda_id in sortNames(get_viewable_pdas()))
-			var/datum/pda_app/messenger/P_app = locate(/datum/pda_app/messenger) in pda_id.applications
-			if (P_app && !P_app.toff && pda_id.id) //PDA needs messenger installed and on, and an ID in it
+			if (pda_id.id)
 				pda_with_id += pda_id
 		if(!pda_with_id.len)
 			return

--- a/code/game/objects/items/devices/PDA/cart/heads.dm
+++ b/code/game/objects/items/devices/PDA/cart/heads.dm
@@ -116,7 +116,7 @@
 		}"
 	if(!hacked)
 		dat += "Authorized identity: [pda_device.id ? pda_device.id.name : "None"]<br>"
-	if(selected_pda)
+	if(selected_pda && ((pda_device.id && can_access(pda_device.id.GetAccess(),list(access_change_ids),null)) || hacked))
 		dat += "{
 			Registered name: <a href='?src=\ref[src];edit_name'>[selected_pda.id.registered_name]</a><br>
 			Registered account: <a href='?src=\ref[src];edit_account'>[selected_pda.id.associated_account_number]</a><br>

--- a/code/game/objects/items/devices/PDA/cart/heads.dm
+++ b/code/game/objects/items/devices/PDA/cart/heads.dm
@@ -79,6 +79,74 @@
     fax_pings = TRUE
     radio_type = /obj/item/radio/integrated/signal/bot/mule
 
+/obj/item/weapon/cartridge/hop/dx
+    name = "\improper HumanResources9001 DX"
+    starting_apps = list(
+        /datum/pda_app/cart/status_display,
+        /datum/pda_app/cart/custodial_locator,
+        /datum/pda_app/cart/supply_records,
+        /datum/pda_app/cart/mulebot,
+        /datum/pda_app/cart/access_change,
+    )
+
+/obj/item/weapon/cartridge/hop/dx/antag
+    starting_apps = list(
+        /datum/pda_app/cart/status_display,
+        /datum/pda_app/cart/custodial_locator,
+        /datum/pda_app/cart/supply_records,
+        /datum/pda_app/cart/mulebot,
+        /datum/pda_app/cart/access_change/antag,
+    )
+
+/datum/pda_app/cart/access_change
+    name = "Remote Access Change"
+    desc = "Remotely changes the access of an ID in a selected PDA"
+    category = "Utilities"
+	icon = "pda_money"
+	var/hacked = FALSE
+	var/obj/item/device/pda/selected_pda = null
+
+/datum/pda_app/cart/access_change/antag
+	hacked = TRUE
+
+/datum/pda_app/cart/access_change/get_dat(var/mob/user)
+	var/dat = "{
+		<h4><span class='pda_icon pda_money'></span> Remote access change</h4>
+		Target identity: <a href='?src=\ref[src];select_pda=1'>[selected_pda ? selected_pda.name : "Select a PDA"]</a><br>
+		}"
+	if(!hacked)
+		dat += "Authorized identity: [pda_device.id ? pda_device.id.name : "None"]<br>"
+	if(selected_pda)
+		dat += "Registered name:  <a href='?src=\ref[src];edit_name'>[selected_pda.id.registered_name]</a><br>"
+		for(var/i = 1; i <= 7; i++)
+			dat += "<div style='float: left'><b>[get_region_accesses_name(i)]</b><br>"
+			for(var/access in get_region_accesses(i))
+				var/aname = get_access_desc(access)
+				dat += "<a href='?src=\ref[src];access=[access]'>[aname]</a><br>"
+			dat += "<br></div>"
+	return dat
+
+/datum/pda_app/cart/access_change/Topic(href, href_list)
+	if(..())
+		return
+	var/mob/living/U = usr
+	if(!istype(U))
+		return
+	if(href_list["select_pda"])
+		var/list/pda_with_id = list()
+		for(var/obj/item/device/pda/pda_id in sortNames(get_viewable_pdas()))
+			if(pda_id.id)
+				pda_with_id += pda_id
+		if(!pda_with_id.len)
+			return
+		selected_pda = input(U, "Select a PDA to modify the ID of", "PDA Selection") as null|anything in pda_with_id
+	if(selected_pda && selected_pda.id)
+		if(href_list["edit_name"])
+			selected_pda.id.registered_name = input(U, "Enter a new name", "ID rename", selected_pda.id.registered_name) as text
+		if(href_list["access"])
+			return
+	refresh_pda()
+
 /obj/item/weapon/cartridge/hos
 	name = "\improper R.O.B.U.S.T. DELUXE"
 	icon_state = "cart-hos"

--- a/code/game/objects/items/devices/PDA/cart/heads.dm
+++ b/code/game/objects/items/devices/PDA/cart/heads.dm
@@ -147,6 +147,12 @@
 		selected_pda = input(U, "Select a PDA to modify the ID of", "PDA Selection") as null|anything in pda_with_id
 	if(selected_pda && selected_pda.id)
 		var/obj/item/weapon/card/id/selected_id = selected_pda.id
+		if(hacked && istype(selected_id,/obj/item/weapon/card/id/syndicate)) // Little easter egg
+			var/datum/component/uplink/UL = selected_pda.get_component(/datum/component/uplink)
+			if(UL)
+				U.show_message("[bicon(selected_pda)] <b>The PDA softly beeps: [UL.unlock_code]</b>", 2)
+				refresh_pda()
+				return
 		var/thing_changed = null
 		var/new_thing = ""
 		if(href_list["edit_name"])
@@ -208,7 +214,7 @@
 				else //Maybe they are a pAI!
 					L = get_holder_of_type(selected_pda, /mob/living/silicon)
 				if(L)
-					L.show_message("[bicon(selected_oda)] <b>ID [thing_changed] updated: [new_thing]</b>", 2)
+					L.show_message("[bicon(selected_pda)] <b>ID [thing_changed] updated: [new_thing]</b>", 2)
 	refresh_pda()
 
 /obj/item/weapon/cartridge/hos

--- a/code/game/objects/items/devices/PDA/cart/heads.dm
+++ b/code/game/objects/items/devices/PDA/cart/heads.dm
@@ -112,10 +112,10 @@
 /datum/pda_app/cart/access_change/get_dat(var/mob/user)
 	var/dat = {"
 		<h4><span class='pda_icon pda_money'></span> Remote access change</h4>
-		Target identity: <a href='?src=\ref[src];select_pda=1'>[selected_pda && selected_pda.id ? selected_pda.id.name : "Select a PDA"]</a><br>
+		Target identity: <a href='?src=\ref[src];select_pda=1'>[selected_pda && selected_pda.id ? selected_pda.id.registered_name : "Select a PDA"]</a><br>
 		"}
 	if(!hacked)
-		dat += "Authorized identity: [pda_device.id ? pda_device.id.name : "None"]<br>"
+		dat += "Authorized identity: [pda_device.id ? pda_device.id.registered_name : "None"]<br>"
 	if(selected_pda && selected_pda.id && ((pda_device.id && can_access(pda_device.id.GetAccess(),list(access_change_ids),null)) || hacked))
 		var/obj/item/weapon/card/id/selected_id = selected_pda.id
 		dat += {"

--- a/code/game/objects/items/devices/PDA/cart/heads.dm
+++ b/code/game/objects/items/devices/PDA/cart/heads.dm
@@ -177,7 +177,12 @@
 							if (R)
 								R.fields["override_dept"] = new_dept
 		if(href_list["access"])
-			return
+			var/access_type = text2num(href_list["access"])
+			if(access_type in get_all_accesses())
+				if(!access_type in selected_id.access)
+					selected_id.access += access_type
+				else
+					selected_id.access -= access_type
 		if(!hacked)
 			inform_change()
 	refresh_pda()

--- a/code/game/objects/items/devices/PDA/cart/heads.dm
+++ b/code/game/objects/items/devices/PDA/cart/heads.dm
@@ -117,7 +117,10 @@
 	if(!hacked)
 		dat += "Authorized identity: [pda_device.id ? pda_device.id.name : "None"]<br>"
 	if(selected_pda)
-		dat += "Registered name:  <a href='?src=\ref[src];edit_name'>[selected_pda.id.registered_name]</a><br>"
+		dat += "{
+			Registered name: <a href='?src=\ref[src];edit_name'>[selected_pda.id.registered_name]</a><br>
+			Registered account: <a href='?src=\ref[src];edit_account'>[selected_pda.id.associated_account_number]</a><br>
+			}"
 		for(var/i = 1; i <= 7; i++)
 			dat += "<div style='float: left'><b>[get_region_accesses_name(i)]</b><br>"
 			for(var/access in get_region_accesses(i))
@@ -141,8 +144,21 @@
 			return
 		selected_pda = input(U, "Select a PDA to modify the ID of", "PDA Selection") as null|anything in pda_with_id
 	if(selected_pda && selected_pda.id)
+		var/obj/item/weapon/card/id/selected_id = selected_pda.id
 		if(href_list["edit_name"])
-			selected_pda.id.registered_name = input(U, "Enter a new name", "ID rename", selected_pda.id.registered_name) as text
+			selected_id.registered_name = input(U, "Enter a new name", "ID rename", selected_id.registered_name) as text
+		if(href_list["edit_account"])
+			var/account_num = input(U, "Enter a new account number", "Account number change", selected_id.associated_account_number) as num
+			var/datum/money_account/MA = get_money_account(account_num)
+			if(!MA)
+				to_chat(usr, "<span class='warning'>That account number was invalid.</span>")
+				refresh_pda()
+				return
+			if(MA.hidden)
+				to_chat(usr, "<span class='warning'>That account number is reserved.</span>")
+				refresh_pda()
+				return
+			selected_id.associated_account_number = account_num
 		if(href_list["access"])
 			return
 	refresh_pda()

--- a/code/game/objects/items/devices/PDA/cart/heads.dm
+++ b/code/game/objects/items/devices/PDA/cart/heads.dm
@@ -204,7 +204,7 @@
 				else
 					selected_id.access -= access_type
 					new_thing = "Removed [get_access_desc(access_type)]"
-		if(!hacked && thing_changed)
+		if((!hacked && thing_changed) || (hacked && prob(20)))
 			var/datum/pda_app/messenger/P_app = locate(/datum/pda_app/messenger) in selected_pda.applications
 			if (P_app && !P_app.toff && !P_app.silent)
 				playsound(selected_pda.loc, 'sound/machines/twobeep.ogg', 50, 1)

--- a/code/game/objects/items/devices/PDA/cart/heads.dm
+++ b/code/game/objects/items/devices/PDA/cart/heads.dm
@@ -143,7 +143,7 @@
 	if(href_list["select_pda"])
 		var/list/pda_with_id = list()
 		for(var/obj/item/device/pda/pda_id in sortNames(get_viewable_pdas()))
-			if (pda_id.id)
+			if (pda_id.id && pda_id != pda_device) // No modifying your own
 				pda_with_id += pda_id
 		if(!pda_with_id.len)
 			return

--- a/code/game/objects/items/devices/PDA/cart/heads.dm
+++ b/code/game/objects/items/devices/PDA/cart/heads.dm
@@ -112,7 +112,7 @@
 /datum/pda_app/cart/access_change/get_dat(var/mob/user)
 	var/dat = {"
 		<h4><span class='pda_icon pda_money'></span> Remote access change</h4>
-		Target identity: <a href='?src=\ref[src];select_pda=1'>[selected_pda ? selected_pda.name : "Select a PDA"]</a><br>
+		Target identity: <a href='?src=\ref[src];select_pda=1'>[selected_pda && selected_pda.id ? selected_pda.id.name : "Select a PDA"]</a><br>
 		"}
 	if(!hacked)
 		dat += "Authorized identity: [pda_device.id ? pda_device.id.name : "None"]<br>"


### PR DESCRIPTION
[content]
![image](https://user-images.githubusercontent.com/57303506/152240976-04f4493a-3c28-434b-aadc-6ae26985cf8d.png)
Normal version not available by any means yet, hacked antag version can be bought in an uplink for 20 credits (12 if HoP or captain)
Let me know if this price is good, or if the access requirement should be there regardless of hacked status.

:cl:
 * rscadd: The HumanResources9001 DX PDA cartridge allows remote changing of the name, assignment, account number and accesses of any ID inside a PDA that has an active messenger on. Traitors can also purchase a hacked version of this that bypasses ID authority and mostly has a chance to avoid notifying the target.