### PR TITLE
Fixes wooden buckler block chance

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -45,7 +45,10 @@
 	starting_materials = list()
 
 /obj/item/weapon/shield/riot/buckler/IsShield()
-	return prob(33) //Only attempt to block 1/3 of attacks
+	if(prob(33)) //Only attempt to block 1/3 of attacks
+		return 1
+	else
+		..()
 
 /obj/item/weapon/shield/riot/buckler/on_block(damage, atom/blocked)
 	if(damage > 10)


### PR DESCRIPTION
Wooden bucklers didn't block any attacks whatsoever before, now they block the intended 33%. Mahalo!
[bugfix]

:cl:
 * bugfix: Wooden bucklers should now properly block attacks.