### PR TITLE
CWC remove and replaced with multiple wizards

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -302,12 +302,12 @@
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/raginmages/acceptable(var/population=0,var/threat=0)
-	if(locate(/datum/dynamic_ruleset/roundstart/cwc) in mode.executed_rules)
-		message_admins("Rejected Ragin' Mages as there was a Civil War.")
-		return 0 //This is elegantly skipped by specific ruleset.
-		//This means that all ragin mages in CWC will be called only by that ruleset.
-	else
-		return ..()
+//	if(locate(/datum/dynamic_ruleset/roundstart/cwc) in mode.executed_rules)
+//		message_admins("Rejected Ragin' Mages as there was a Civil War.")
+//		return 0 //This is elegantly skipped by specific ruleset.
+//		//This means that all ragin mages in CWC will be called only by that ruleset.
+//	else
+//		return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/raginmages/ready(var/forced = 0)
 	if(wizardstart.len == 0)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -222,7 +222,7 @@
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 40
 	var/list/roundstart_wizards = list()
-	var/wizard_threshold = 2
+	var/wizard_threshold = 1
 
 /datum/dynamic_ruleset/roundstart/wizard/choose_candidates()
 	var/num_wizards = min(round(mode.roundstart_pop_ready / 10) + 1, candidates.len)
@@ -230,7 +230,7 @@
 		var/mob/M = pick(candidates)
 		assigned += M
 		candidates -= M
-		// Above 2 wizards, we start to cost a bit more.
+		// Above 1 wizard, we start to cost a bit more.
 		if (i > wizard_threshold)
 			if ((mode.threat > cost))
 				mode.spend_threat(cost)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -217,7 +217,7 @@
 	enemy_jobs = list("Security Officer","Detective","Head of Security", "Captain")
 	required_pop = list(15,15,15,10,10,10,10,5,5,0)
 	required_candidates = 1
-	weight = BASE_RULESET_WEIGHT/2
+	weight = BASE_RULESET_WEIGHT
 	cost = 30
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 40
@@ -246,8 +246,7 @@
 	return ..()
 
 /datum/dynamic_ruleset/roundstart/wizard/execute()
-	var/mob/M = pick(assigned)
-	if (M)
+	for (var/mob/M in assigned)
 		var/datum/role/wizard/newWizard = new
 		M.forceMove(pick(wizardstart))
 		if(!isjusthuman(M))

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -222,6 +222,21 @@
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 40
 	var/list/roundstart_wizards = list()
+	var/wizard_threshold = 2
+
+/datum/dynamic_ruleset/roundstart/wizard/choose_candidates()
+	var/num_wizards = min(round(mode.roundstart_pop_ready / 10) + 1, candidates.len)
+	for (var/i = 1 to num_wizards)
+		var/mob/M = pick(candidates)
+		assigned += M
+		candidates -= M
+		// Above 2 wizards, we start to cost a bit more.
+		if (i > wizard_threshold)
+			if ((mode.threat > cost))
+				mode.spend_threat(cost)
+			else
+				break
+	return (assigned.len > 0)
 
 /datum/dynamic_ruleset/roundstart/wizard/acceptable(var/population=0,var/threat=0)
 	if(wizardstart.len == 0)
@@ -251,7 +266,7 @@
 //         CIVIL WAR OF CASTERS             ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //                                          //
 //////////////////////////////////////////////
-
+/*
 /datum/dynamic_ruleset/roundstart/cwc
 	name = "Civil War of Casters"
 	role_category = /datum/role/wizard
@@ -268,7 +283,7 @@
 //	var/wizard_cd = 210 //7 minutes
 	var/total_wizards = 4
 
-/*
+
 /datum/dynamic_ruleset/roundstart/cwc/process()
 	..()
 	if (wizard_cd)
@@ -286,7 +301,7 @@
 		message_admins("Dynamic Mode: Civil War rages on. Trying to send mage [sent_wizards+1] for [initial(RM.my_fac.name)].")
 		RM.cost = 0
 		mode.picking_specific_rule(RM,TRUE) //forced
-*/
+
 
 /datum/dynamic_ruleset/roundstart/cwc/choose_candidates()
 	for(var/wizards_number = 1 to total_wizards)
@@ -314,7 +329,7 @@
 		newWizard.AssignToRole(M.mind,1)
 		newWizard.Greet(GREET_MIDROUND)
 	return 1
-
+*/
 //////////////////////////////////////////////
 //                                          //
 //                BLOOD CULT                ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I think everyone is aware that Civil War of Casters never really worked, and it ended up with the crew against four (4) wizards killing them. Instead, I've updated Wizard mode to have 1 to 3 wizards by costing 30 threat each (so 90 threat can be used).

Just seems like CWC results in rounds ending immediately

:cl:
 * rscadd: Wizards are no longer having a civil war.
