### PR TITLE
Makes round ending with no players PR more true to name

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -46,6 +46,7 @@ var/stacking_limit = 90
 	var/list/living_antags = list()
 	var/list/dead_players = list()
 	var/list/list_observers = list()
+	var/last_time_of_population = 0
 
 	var/latejoin_injection_cooldown = 0
 	var/midround_injection_cooldown = 0
@@ -658,7 +659,9 @@ var/stacking_limit = 90
 					continue
 			dead_players.Add(M)//Players who actually died (and admins who ghosted, would be nice to avoid counting them somehow)
 	
-	if(!living_players.len && world.time > 15 MINUTES) //if nobody is around and alive in the current round and enough time has passed
+	if(living_players.len) //if anybody is around and alive in the current round
+		last_time_of_population = world.time
+	if(last_time_of_population && world.time - last_time_of_population > 5 MINUTES && world.time > 15 MINUTES) //if enough time has passed without it
 		ticker.station_nolife_cinematic()
 
 /datum/gamemode/dynamic/proc/GetInjectionChance()

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -661,7 +661,7 @@ var/stacking_limit = 90
 	
 	if(living_players.len) //if anybody is around and alive in the current round
 		last_time_of_population = world.time
-	if(last_time_of_population && world.time - last_time_of_population > 5 MINUTES && world.time > 15 MINUTES) //if enough time has passed without it
+	else if(last_time_of_population && world.time - last_time_of_population > 5 MINUTES && world.time > 15 MINUTES) //if enough time has passed without it
 		ticker.station_nolife_cinematic()
 
 /datum/gamemode/dynamic/proc/GetInjectionChance()

--- a/code/datums/gamemode/sandbox.dm
+++ b/code/datums/gamemode/sandbox.dm
@@ -1,5 +1,6 @@
 /datum/gamemode/sandbox
 	name = "sandbox"
+	var/last_time_of_players = 0
 
 
 /datum/gamemode/sandbox/Setup()
@@ -18,6 +19,8 @@
 
 /datum/gamemode/sandbox/process()
 	. = ..()
-	if(!player_list.len && world.time > 15 MINUTES) //if nobody is around in the current round and enough time has passed
+	if(player_list.len) //if anybody is in the current round
+		last_time_of_players = world.time
+	if(last_time_of_players && world.time - last_time_of_players > 5 MINUTES && world.time > 15 MINUTES) //if enough time has passed without them
 		CallHook("Reboot",list())
 		world.Reboot()


### PR DESCRIPTION
[tweak]
Apparently I wasn't clear enough in #31962 since I meant 15 minutes after roundstart. This adds an additional check to make the round end if there has been no players after 5 minutes too, instead of instantly.
Closes #32010.

:cl:
 * tweak: Rounds now wait 5 minutes to end if there is no players, due to connectivity issue clauses.
