### PR TITLE
Makes DNA SE length define the right value

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1700,7 +1700,7 @@ var/proccalls = 1
 #define ESPORTS_CULTISTS "Team Geometer"
 #define ESPORTS_SECURITY "Team Security"
 
-#define DNA_SE_LENGTH 58
+#define DNA_SE_LENGTH 59
 
 #define VOX_SHAPED "Vox","Skeletal Vox"
 #define GREY_SHAPED "Grey"


### PR DESCRIPTION
[bugfix]
#31611 added a new thing to it but forgot to update this, might as well salvage this fix from that reverted PR before I rework it in a new way. Before this it would print:
```## WARNING: LACTOSE: No more blocks left to assign!```