### PR TITLE
Fixes tape recorder showing true identity behind voice changers

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -25,7 +25,7 @@
 /obj/item/device/taperecorder/Hear(var/datum/speech/speech, var/rendered_speech="")
 	if(recording && speech.speaker != src)
 		timestamp += timerecorded
-		storedinfo += "\[[time2text(timerecorded*10,"mm:ss")]\] [speech.speaker]:  \"[html_encode(speech.message)]\""
+		storedinfo += "\[[time2text(timerecorded*10,"mm:ss")]\] [speech.name]:  \"[html_encode(speech.message)]\""
 
 /obj/item/device/taperecorder/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()


### PR DESCRIPTION
Fixes #32027

:cl:
 * bugfix: Tape recorders will no longer reveal the identity of someone using a voice changer.