### PR TITLE
Removes NOCLONE from ghoulification.

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
@@ -167,11 +167,6 @@
 						adjustBrainLoss(rand(1,3))
 					else
 						victim.take_damage(rand(1,5)*rad_multiplier,silent = 0)
-			if(prob(0.5*major_rad_multiplier))
-				//Become uncloneable
-				if(!(M_NOCLONE in mutations))
-					to_chat(src, "<span class = 'blob'>You feel something twist and break.</span>")
-					mutations |= M_NOCLONE
 		if(rad_tick > RADDOSECRITICAL)
 			if(prob(2*major_rad_multiplier))
 				//Minor limb mutation


### PR DESCRIPTION
Ghoulification is a roundlong project, needing help from many departments to get the resourcess and chems needed to transform someone, which will take time to set up as well.
Issue is that your ghoul inevitably ends up with a ton of genetic disabilities, which can't be treated via genetics nor masked via ryetalin, meaning that even if you get one or become one yourself, the ghoul is almost unusable due to the gene blindness from regular ghoulifying (which can't be treated with eye transplants) or any of the genetic disabilities they could get if you speed up the irradiating via mutagen.
[tweak]
:cl:
 * rscdel: You no longer get a NOCLONE flag when trying to ghoulify, meaning you'll be able to cure the inevitable genetic disabilities your ghoul will have.
