### PR TITLE
Fixes internal organ sizes

### DIFF
--- a/code/modules/organs/internal/eyes/eyes.dm
+++ b/code/modules/organs/internal/eyes/eyes.dm
@@ -4,6 +4,7 @@
 	parent_organ = LIMB_HEAD
 	organ_type = "eyes"
 	removed_type = /obj/item/organ/internal/eyes
+	w_class = W_CLASS_TINY
 
 	var/welding_proof=0
 	var/eyeprot=0

--- a/code/modules/organs/internal/eyes/eyes.dm
+++ b/code/modules/organs/internal/eyes/eyes.dm
@@ -4,7 +4,6 @@
 	parent_organ = LIMB_HEAD
 	organ_type = "eyes"
 	removed_type = /obj/item/organ/internal/eyes
-	w_class = W_CLASS_TINY
 
 	var/welding_proof=0
 	var/eyeprot=0

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -54,8 +54,6 @@
 	var/grasp_id = 0 //Does this organ affect other grasping organs?
 	var/can_grasp = 0 //Can this organ actually grasp something?
 
-	var/w_class = W_CLASS_LARGE
-
 
 /datum/organ/external/New(var/datum/organ/external/P)
 	if(P)
@@ -1251,7 +1249,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	has_fat = 1
 	vital = 1
 	encased = "ribcage"
-	w_class = W_CLASS_MEDIUM
 
 /datum/organ/external/groin
 	name = LIMB_GROIN
@@ -1261,7 +1258,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	min_broken_damage = 70
 	body_part = LOWER_TORSO
 	vital = 1
-	w_class = W_CLASS_MEDIUM
 
 //=====Legs======
 
@@ -1273,7 +1269,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	min_broken_damage = 30
 	body_part = LEG_LEFT
 	icon_position = LEFT
-	w_class = W_CLASS_SMALL
 
 /datum/organ/external/l_leg/can_stand()
 	//Peg legs don't require an attached foot
@@ -1310,8 +1305,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	body_part = LEG_RIGHT
 	icon_position = RIGHT
 
-	w_class = W_CLASS_SMALL
-
 //This proc is same as l_leg/can_stand()
 /datum/organ/external/r_leg/can_stand()
 	//Peg legs don't require an attached foot
@@ -1347,7 +1340,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	icon_name = "l_arm"
 	max_damage = 75
 	min_broken_damage = 30
-	w_class = W_CLASS_SMALL
 	body_part = ARM_LEFT
 
 	grasp_id = GRASP_LEFT_HAND
@@ -1368,7 +1360,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	icon_name = "r_arm"
 	max_damage = 75
 	min_broken_damage = 30
-	w_class = W_CLASS_SMALL
 	body_part = ARM_RIGHT
 
 	grasp_id = GRASP_RIGHT_HAND
@@ -1392,7 +1383,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	body_part = FOOT_LEFT
 	icon_position = LEFT
 
-	w_class = W_CLASS_TINY
 	slots_to_drop = list(slot_shoes, slot_legcuffed)
 
 /datum/organ/external/l_foot/generate_dropped_organ(current_organ)
@@ -1412,7 +1402,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	body_part = FOOT_RIGHT
 	icon_position = RIGHT
 
-	w_class = W_CLASS_TINY
 	slots_to_drop = list(slot_shoes, slot_legcuffed)
 
 /datum/organ/external/r_foot/generate_dropped_organ(current_organ)
@@ -1433,7 +1422,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	grasp_id = GRASP_RIGHT_HAND
 	can_grasp = 1
 
-	w_class = W_CLASS_TINY
 	slots_to_drop = list(slot_gloves, slot_handcuffed)
 
 /datum/organ/external/r_hand/generate_dropped_organ(current_organ)
@@ -1454,7 +1442,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	grasp_id = GRASP_LEFT_HAND
 	can_grasp = 1
 
-	w_class = W_CLASS_TINY
 	slots_to_drop = list(slot_gloves, slot_handcuffed)
 
 /datum/organ/external/l_hand/generate_dropped_organ(current_organ)
@@ -1476,7 +1463,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	vital = 1
 	encased = "skull"
 
-	w_class = W_CLASS_SMALL
 	slots_to_drop = list(slot_glasses, slot_wear_mask, slot_head, slot_ears)
 
 /datum/organ/external/head/generate_dropped_organ(current_organ)
@@ -1608,7 +1594,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 		blood_DNA[H.dna.unique_enzymes] = H.dna.b_type
 
 	src.species = source.species || H.species
-	w_class = source.w_class
 	cancer_stage = source.cancer_stage
 	wounds = source.wounds.Copy()
 	burn_dam = source.burn_dam
@@ -1729,6 +1714,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "left arm"
 	icon_state = LIMB_LEFT_ARM
 	part = LIMB_LEFT_ARM
+	w_class = W_CLASS_SMALL
 /obj/item/organ/external/l_arm/New(loc, mob/living/carbon/human/H)
 	..()
 	if(H && istype(H))
@@ -1740,16 +1726,19 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "left foot"
 	icon_state = LIMB_LEFT_FOOT
 	part = LIMB_LEFT_FOOT
+	w_class = W_CLASS_TINY
 
 /obj/item/organ/external/l_hand
 	name = "left hand"
 	icon_state = LIMB_LEFT_HAND
 	part = LIMB_LEFT_HAND
+	w_class = W_CLASS_TINY
 
 /obj/item/organ/external/l_leg
 	name = "left leg"
 	icon_state = LIMB_LEFT_LEG
 	part = LIMB_LEFT_LEG
+	w_class = W_CLASS_SMALL
 /obj/item/organ/external/l_leg/New(loc, mob/living/carbon/human/H)
 	..()
 	if(H && istype(H))
@@ -1761,6 +1750,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "right arm"
 	icon_state = LIMB_RIGHT_ARM
 	part = LIMB_RIGHT_ARM
+	w_class = W_CLASS_SMALL
 /obj/item/organ/external/r_arm/New(loc, mob/living/carbon/human/H)
 	..()
 	if(H && istype(H))
@@ -1772,16 +1762,19 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "right foot"
 	icon_state = LIMB_RIGHT_FOOT
 	part = LIMB_RIGHT_FOOT
+	w_class = W_CLASS_TINY
 
 /obj/item/organ/external/r_hand
 	name = "right hand"
 	icon_state = LIMB_RIGHT_HAND
 	part = LIMB_RIGHT_HAND
+	w_class = W_CLASS_TINY
 
 /obj/item/organ/external/r_leg
 	name = "right leg"
 	icon_state = LIMB_RIGHT_LEG
 	part = LIMB_RIGHT_LEG
+	w_class = W_CLASS_SMALL
 /obj/item/organ/external/r_leg/New(loc, mob/living/carbon/human/H)
 	..()
 	if(H && istype(H))
@@ -1794,6 +1787,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = LIMB_HEAD
 	icon_state = "head_m"
 	part = LIMB_HEAD
+	w_class = W_CLASS_SMALL
 	var/mob/living/carbon/brain/brainmob
 	var/brain_op_stage = 0
 	var/mob/living/carbon/human/origin_body = null

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -16,7 +16,6 @@
 	var/rejecting            // Is this organ already being rejected?
 	var/obj/item/organ/internal/organ_holder
 	var/datum/dna/owner_dna
-	var/w_class = W_CLASS_SMALL
 
 
 /datum/organ/internal/Destroy()
@@ -231,7 +230,6 @@
 	parent_organ = LIMB_GROIN
 	organ_type = "appendix"
 	removed_type = /obj/item/organ/internal/appendix
-	w_class = W_CLASS_TINY
 
 /datum/organ/internal/proc/remove(var/mob/user, var/quiet=0)
 	if(!removed_type)

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -16,6 +16,7 @@
 	var/rejecting            // Is this organ already being rejected?
 	var/obj/item/organ/internal/organ_holder
 	var/datum/dna/owner_dna
+	var/w_class = W_CLASS_SMALL
 
 
 /datum/organ/internal/Destroy()
@@ -230,6 +231,7 @@
 	parent_organ = LIMB_GROIN
 	organ_type = "appendix"
 	removed_type = /obj/item/organ/internal/appendix
+	w_class = W_CLASS_TINY
 
 /datum/organ/internal/proc/remove(var/mob/user, var/quiet=0)
 	if(!removed_type)

--- a/code/modules/organs/organ_objects.dm
+++ b/code/modules/organs/organ_objects.dm
@@ -141,6 +141,8 @@
 	if(!organ_data)
 		organ_data = new organ_type
 
+	w_class = organ_data.w_class
+
 	if(robotic)
 		organ_data.robotic = robotic
 

--- a/code/modules/organs/organ_objects.dm
+++ b/code/modules/organs/organ_objects.dm
@@ -3,6 +3,7 @@
 	desc = "It looks like it probably just plopped out."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "appendix"
+	w_class = W_CLASS_SMALL
 
 	health = 100                              // Process() ticks before death.
 
@@ -141,8 +142,6 @@
 	if(!organ_data)
 		organ_data = new organ_type
 
-	w_class = organ_data.w_class
-
 	if(robotic)
 		organ_data.robotic = robotic
 
@@ -257,6 +256,7 @@
 	prosthetic_icon = "eyes-prosthetic"
 	organ_tag = "eyes"
 	organ_type = /datum/organ/internal/eyes
+	w_class = W_CLASS_TINY
 	var/eye_colour
 	var/emitter = FALSE
 
@@ -329,6 +329,7 @@
 	name = "appendix"
 	icon_state = "appendix"
 	organ_tag = "appendix"
+	w_class = W_CLASS_TINY
 
 //These are here so they can be printed out via the fabricator.
 /obj/item/organ/internal/heart/prosthetic


### PR DESCRIPTION
[tweak]
Closes #32044.
Also makes all internal organs small sized, except for eyeballs and appendices which are tiny. (Torsos are medium, limbs are small sized and hands/feet are tiny currently, for reference)

:cl:
 * rscadd: Internal organs can now fit in storage easier.