### PR TITLE
Allows land-based vaults to overwrite

### DIFF
--- a/code/modules/randomMaps/special.dm
+++ b/code/modules/randomMaps/special.dm
@@ -161,6 +161,8 @@
 	width  = 0
 	height = 0
 
+	var/overwriting = FALSE
+
 /datum/map_element/customizable/vault_placement/pre_load()
 	if(usr && (!width || !height))
 		width  = input(usr, "Enter the area's width (4-400). The starting point is the lower left corner. Enter an invalid value to cancel.", "Vault Generator", 100) as num
@@ -173,10 +175,12 @@
 			height = 0
 			return
 
+		overwriting = input(usr, "Do you want these vaults to overwrite their area?", "Vault Overwriting", "Yes", "No") == "Yes"
+
 /datum/map_element/customizable/vault_placement/initialize()
 	if(!location)
 		return
 	if(!width || !height)
 		return
 
-	populate_area_with_vaults(block(location, locate(location.x + width, location.y + height, location.z)))
+	populate_area_with_vaults(block(location, locate(location.x + width, location.y + height, location.z, overwrites=overwriting)))

--- a/code/modules/randomMaps/special.dm
+++ b/code/modules/randomMaps/special.dm
@@ -183,4 +183,4 @@
 	if(!width || !height)
 		return
 
-	populate_area_with_vaults(block(location, locate(location.x + width, location.y + height, location.z, overwrites=overwriting)))
+	populate_area_with_vaults(block(location, locate(location.x + width, location.y + height, location.z)), overwrites=overwriting)

--- a/code/modules/randomMaps/vaults.dm
+++ b/code/modules/randomMaps/vaults.dm
@@ -91,14 +91,14 @@
 
 	var/surprise_number = rand(1, min(list_of_surprises.len, max_secret_rooms))
 
-	var/result = populate_area_with_vaults(/area/mine/unexplored, list_of_surprises, surprise_number, filter_function=/proc/asteroid_can_be_placed)
+	var/result = populate_area_with_vaults(/area/mine/unexplored, list_of_surprises, surprise_number, filter_function=/proc/asteroid_can_be_placed, TRUE)
 
 	message_admins("<span class='info'>Loaded [result] out of [surprise_number] mining surprises.</span>")
 
 /proc/generate_hoboshack()
 	var/list/list_of_shacks = get_map_element_objects(/datum/map_element/hoboshack)
 
-	var/result = populate_area_with_vaults(/area/mine/unexplored, list_of_shacks, 1, filter_function=/proc/asteroid_can_be_placed)
+	var/result = populate_area_with_vaults(/area/mine/unexplored, list_of_shacks, 1, filter_function=/proc/asteroid_can_be_placed, TRUE)
 
 	message_admins("<span class='info'>Loaded space hobo shack [result ? "" : "un"]successfully.</span>")
 
@@ -118,7 +118,7 @@
 //POPULATION_SCARCE is cheaper but may not do the job as well
 //NOTE: Vaults may be placed partially outside of the area. Only the lower left corner is guaranteed to be in the area
 
-/proc/populate_area_with_vaults(area/A, list/map_element_objects, var/amount = -1, population_density = POPULATION_DENSE, filter_function)
+/proc/populate_area_with_vaults(area/A, list/map_element_objects, var/amount = -1, population_density = POPULATION_DENSE, filter_function, var/overwrites = FALSE)
 	var/list/area_turfs
 
 	if(ispath(A, /area))
@@ -209,7 +209,7 @@
 			var/turf/t2 = locate(vault_x + new_width, vault_y + new_height, vault_z)
 			valid_spawn_points.Remove(block(t1, t2))
 
-		if(ME.load(vault_x, vault_y, vault_z, vault_rotate))
+		if(ME.load(vault_x, vault_y, vault_z, vault_rotate, overwrites))
 			spawned.Add(ME)
 			message_admins("<span class='info'>Loaded [ME.file_path]: [formatJumpTo(locate(vault_x, vault_y, vault_z))] [(config.disable_vault_rotation || !ME.can_rotate) ? "" : ", rotated by [vault_rotate] degrees"].")
 			if(!ME.can_rotate)

--- a/code/modules/randomMaps/vaults.dm
+++ b/code/modules/randomMaps/vaults.dm
@@ -91,14 +91,14 @@
 
 	var/surprise_number = rand(1, min(list_of_surprises.len, max_secret_rooms))
 
-	var/result = populate_area_with_vaults(/area/mine/unexplored, list_of_surprises, surprise_number, filter_function=/proc/asteroid_can_be_placed, TRUE)
+	var/result = populate_area_with_vaults(/area/mine/unexplored, list_of_surprises, surprise_number, filter_function=/proc/asteroid_can_be_placed, overwrites=TRUE)
 
 	message_admins("<span class='info'>Loaded [result] out of [surprise_number] mining surprises.</span>")
 
 /proc/generate_hoboshack()
 	var/list/list_of_shacks = get_map_element_objects(/datum/map_element/hoboshack)
 
-	var/result = populate_area_with_vaults(/area/mine/unexplored, list_of_shacks, 1, filter_function=/proc/asteroid_can_be_placed, TRUE)
+	var/result = populate_area_with_vaults(/area/mine/unexplored, list_of_shacks, 1, filter_function=/proc/asteroid_can_be_placed, overwrites=TRUE)
 
 	message_admins("<span class='info'>Loaded space hobo shack [result ? "" : "un"]successfully.</span>")
 

--- a/maps/snaxi.dm
+++ b/maps/snaxi.dm
@@ -148,7 +148,7 @@
 	var/result
 	for(var/area/A in areas_to_vault)
 		var/amount = rand(MIN_REGIONAL_VAULTS,MAX_REGIONAL_VAULTS)
-		result = populate_area_with_vaults(A, list_of_vaults, amount, 1, filter_function=/proc/just_snow, TRUE)
+		result = populate_area_with_vaults(A, list_of_vaults, amount, 1, filter_function=/proc/just_snow, overwrites=TRUE)
 		message_admins("<span class='info'>Loaded [result] vaults in [A].</span>")
 	return TRUE
 

--- a/maps/snaxi.dm
+++ b/maps/snaxi.dm
@@ -148,7 +148,7 @@
 	var/result
 	for(var/area/A in areas_to_vault)
 		var/amount = rand(MIN_REGIONAL_VAULTS,MAX_REGIONAL_VAULTS)
-		result = populate_area_with_vaults(A, list_of_vaults, amount, 1, filter_function=/proc/just_snow)
+		result = populate_area_with_vaults(A, list_of_vaults, amount, 1, filter_function=/proc/just_snow, TRUE)
 		message_admins("<span class='info'>Loaded [result] vaults in [A].</span>")
 	return TRUE
 


### PR DESCRIPTION
[vault][tweak]
Closes #29903.
Working implementation in-game of overwriting.
Also applies to all mining and snow vaults too, for good measure.
Can also now be set in the custom vault area map element.

:cl:
 * tweak: Space hobo shacks can no longer be filled with goliaths or other foreign objects from nearby mine features.