### PR TITLE
Fixes tolerance system runtimes

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -99,8 +99,8 @@
 			var/datum/role/R = M.mind.antag_roles[role]
 			R.handle_splashed_reagent(self.id)
 	
-	if(tolerance_increase)
-		M.tolerated_chems[src.id] += tolerance_increase
+	if(self.tolerance_increase)
+		M.tolerated_chems[self.id] += self.tolerance_increase
 
 /datum/reagent/proc/reaction_dropper_mob(var/mob/living/M, var/method = TOUCH, var/volume)
 	if((src.id in M.tolerated_chems) && M.tolerated_chems[src.id] && M.tolerated_chems[src.id] >= volume)
@@ -115,8 +115,8 @@
 			var/datum/role/R = M.mind.antag_roles[role]
 			R.handle_splashed_reagent(self.id)
 	
-	if(tolerance_increase)
-		M.tolerated_chems[src.id] += tolerance_increase
+	if(self.tolerance_increase)
+		M.tolerated_chems[self.id] += self.tolerance_increase
 
 /datum/reagent/proc/reaction_dropper_obj(var/obj/O, var/volume)
 	reaction_obj(O, volume)


### PR DESCRIPTION
[runtime][bugfix]
```
[09:50:28] Runtime in Chemistry-Reagents.dm, line 102: Cannot read null.tolerance_increase
proc name: reaction mob (/datum/reagent/proc/reaction_mob)
usr: Alejandro Olphert (ondrej008) (/mob/living/carbon/human)
usr.loc: The floor (235, 198, 1) (/turf/simulated/floor)
src: null
call stack:
reaction mob(Alejandro Olphert (/mob/living/carbon/human), 2, 50)
/datum/reagents (/datum/reagents): reaction(Alejandro Olphert (/mob/living/carbon/human), 2, 0, 0)
Kiririn FIRE (/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cannedcoffee): imbibe(Alejandro Olphert (/mob/living/carbon/human))
Kiririn FIRE (/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cannedcoffee): imbibe(Alejandro Olphert (/mob/living/carbon/human))
Kiririn FIRE (/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cannedcoffee): attack(Alejandro Olphert (/mob/living/carbon/human), Alejandro Olphert (/mob/living/carbon/human), null)
Alejandro Olphert (/mob/living/carbon/human): attackby(Kiririn FIRE (/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cannedcoffee), Alejandro Olphert (/mob/living/carbon/human), "icon-x=21;icon-y=14;left=1;scr...", null, null)
Alejandro Olphert (/mob/living/carbon/human): ClickOn(Alejandro Olphert (/mob/living/carbon/human), "icon-x=21;icon-y=14;left=1;scr...")
Alejandro Olphert (/mob/living/carbon/human): Click(the floor (235,198,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=21;icon-y=14;left=1;scr...")
Ondrej008 (/client): Click(Alejandro Olphert (/mob/living/carbon/human), the floor (235,198,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=21;icon-y=14;left=1;scr...")```