### PR TITLE
Removes NO_CLONE genetics flag from ghoulification process.

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
@@ -167,11 +167,6 @@
 						adjustBrainLoss(rand(1,3))
 					else
 						victim.take_damage(rand(1,5)*rad_multiplier,silent = 0)
-			if(prob(0.5*major_rad_multiplier))
-				//Become uncloneable
-				if(!(M_NOCLONE in mutations))
-					to_chat(src, "<span class = 'blob'>You feel something twist and break.</span>")
-					mutations |= M_NOCLONE
 		if(rad_tick > RADDOSECRITICAL)
 			if(prob(2*major_rad_multiplier))
 				//Minor limb mutation


### PR DESCRIPTION
Remake of #32033 after finding out some stuff:
I had tried ghoulification 2 months ago and rye flat out refused to work, prompting me to make that PR when I remembered I had it on the backlog. Upon testing, it turns out it now works somehow? It masks the gene defects now but it didn't before.

Why am I reopening this then? Ghouls having no-clone causes some issues with genetics either way. If your NO_CLONE flag ghoul tries to get injected with a gene syringe, it will do all the "injecting" process (the injecting delay, etc) but refuse to inject and drop the syringe on the floor with no effect on you nor any feedback whatsoever. Example in this poor quality gif (test ghoul is missing a leg btw):
![ghoul bug example](https://user-images.githubusercontent.com/67024428/153708709-11721e8f-0c51-4ec8-b9cc-a29ef3d1f368.gif)
This is not related to any opt out of cloning kinda deal. NO_CLONE blocks genetics via DNA machines, gene injectors and cloning. I feel that if you manage to get a working ghoul, you earned the right to use genetics if you want, since you so very rarely get to see a player ghoul.

:cl:
 * rscdel: Removes the NO_CLONE genetics flag from the ghoulification process, allowing ghouls to be cloned and gene edited. Does not add any new way to become a ghoul and is not related to any opt out of cloning thing.