### PR TITLE
Removes Linestation

### DIFF
--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -79,20 +79,6 @@
 	name = "Island Station"
 	path = "Island"
 	min_players = 25
-	
-/datum/next_map/line
-	name = "Frankenline Station"
-	path = "line"
-	min_players = 25
-	
-/datum/next_map/line/is_votable()
-	var/MM = text2num(time2text(world.timeofday, "MM")) // get the current month
-	if (MM != 10)
-		var/msg = "Skipping map [name] as this is no longer the Halloween season."
-		message_admins(msg)
-		warning(msg)
-		return FALSE
-	return ..()
 
 /datum/next_map/lamprey
 	name = "Lamprey Station"

--- a/maps/_map_override.dm
+++ b/maps/_map_override.dm
@@ -66,9 +66,5 @@
 		#undef MAP_OVERRIDE
 		#include "island.dm"
 		#define MAP_OVERRIDE 13
-	#elif MAP_OVERRIDE == 14
-		#undef MAP_OVERRIDE
-		#include "line.dm"
-		#define MAP_OVERRIDE 13
 	#endif
 #endif


### PR DESCRIPTION
Removes Linestation from the list of compiled maps. Previously this was going to appear during October per #31770, but it managed to weasel its way back into the voteable maps list (and therefore playable maps per recent voting PRs). As the in-game poll (http://ss13.moe/index.php/poll/230) showed a desire to remove this map from rotation, this PR fully implements this.

(0% tested)

:cl:
 * rscdel: removed Linestation from the compiled maps list, preventing it from being voted on.
