### PR TITLE
Fixed a bug that prevented adminbus-created shuttles from moving

### DIFF
--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -542,7 +542,7 @@
 	return occupants
 
 /proc/get_refill_area(var/obj/docking_port/destination/D)
-	if(ispath(D.refill_area))
+	if(ispath(D?.refill_area))
 		return locate(D.refill_area)
 	else
 		return get_space_area()


### PR DESCRIPTION
This thing assumed all shuttles were docked at a docking port at any given time, which is always true except for when an admin turns an area into a shuttle.