### PR TITLE
Fixed component datums not being deleted with the parent

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -264,6 +264,8 @@ List of hard deletions:"}
 	tag = null
 	for(var/timer in active_timers)
 		qdel(timer)
+	for(var/component in active_components)
+		qdel(component)
 	active_timers = null
 
 /datum/var/gcDestroyed


### PR DESCRIPTION
This fixes some runtime errors related to Dusky.
