### PR TITLE
Fixes loaded rotation of some items

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -22,6 +22,14 @@
 
 /obj/machinery/atmospherics/binary/New()
 	..()
+	update_dir()
+	air1 = new
+	air2 = new
+	update_icon()
+	air1.volume = 200
+	air2.volume = 200
+
+/obj/machinery/atmospherics/binary/update_dir()
 	switch(dir)
 		if(NORTH)
 			initialize_directions = NORTH|SOUTH
@@ -31,12 +39,7 @@
 			initialize_directions = EAST|WEST
 		if(WEST)
 			initialize_directions = EAST|WEST
-	air1 = new
-	air2 = new
-	update_icon()
-	air1.volume = 200
-	air2.volume = 200
-
+	..()
 
 /obj/machinery/atmospherics/binary/get_node(node_id)
 	switch(node_id)

--- a/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
@@ -32,7 +32,7 @@
 
 /obj/machinery/atmospherics/trinary/New()
 	..()
-	initialize_directions()
+	update_dir()
 	air1 = new
 	air2 = new
 	air3 = new
@@ -40,7 +40,7 @@
 	air2.volume = starting_volume
 	air3.volume = starting_volume
 
-/obj/machinery/atmospherics/trinary/proc/initialize_directions()
+/obj/machinery/atmospherics/trinary/update_dir()
 	switch(dir)
 		if(NORTH)
 			initialize_directions = SOUTH|NORTH|EAST
@@ -50,6 +50,7 @@
 			initialize_directions = WEST|EAST|SOUTH
 		if(WEST)
 			initialize_directions = EAST|WEST|NORTH
+	..()
 
 /obj/machinery/atmospherics/trinary/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
 	if(!(pipe.dir in list(NORTH, SOUTH, EAST, WEST)) && src.mirror) //because the dir isn't in the right set, we want to make the mirror kind

--- a/code/ATMOSPHERICS/components/unary/portables_connector.dm
+++ b/code/ATMOSPHERICS/components/unary/portables_connector.dm
@@ -13,7 +13,6 @@
 
 
 /obj/machinery/atmospherics/unary/portables_connector/New()
-	initialize_directions = dir
 	..()
 
 /obj/machinery/atmospherics/unary/portables_connector/hide(var/i) //to make the little pipe section invisible, the icon changes.

--- a/code/ATMOSPHERICS/components/unary/tank.dm
+++ b/code/ATMOSPHERICS/components/unary/tank.dm
@@ -22,7 +22,6 @@
 	..()
 	air_contents.temperature = T20C
 	atmos_machines.Remove(src)
-	initialize_directions = dir
 	if(anchored)
 		verbs -= rotate_verbs
 
@@ -177,7 +176,7 @@
 	if (istype(W, /obj/item/device/analyzer) && get_dist(user, src) <= 1)
 		var/obj/item/device/analyzer/analyzer = W
 		user.show_message(analyzer.output_gas_scan(air_contents, src, 0), 1)
-	
+
 	//deconstruction
 	if(iswelder(W) && !anchored)
 		var/obj/item/tool/weldingtool/WT = W

--- a/code/ATMOSPHERICS/components/unary/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary/unary_base.dm
@@ -9,11 +9,13 @@
 
 /obj/machinery/atmospherics/unary/New()
 	..()
-	initialize_directions = dir
+	update_dir()
 	air_contents = new
 	air_contents.temperature = T0C
 	air_contents.volume = starting_volume
 
+/obj/machinery/atmospherics/unary/update_dir()
+	initialize_directions = dir
 
 /obj/machinery/atmospherics/unary/get_node(node_id)
 	switch(node_id)

--- a/code/ATMOSPHERICS/he_pipes.dm
+++ b/code/ATMOSPHERICS/he_pipes.dm
@@ -165,20 +165,24 @@
 
 	// BubbleWrap
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/New()
-	.. ()
-	switch ( dir )
-		if ( SOUTH )
+	..()
+	update_dir()
+
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/update_dir()
+	switch (dir)
+		if (SOUTH)
 			initialize_directions = NORTH
 			initialize_directions_he = SOUTH
-		if ( NORTH )
+		if (NORTH)
 			initialize_directions = SOUTH
 			initialize_directions_he = NORTH
-		if ( EAST )
+		if (EAST)
 			initialize_directions = WEST
 			initialize_directions_he = EAST
-		if ( WEST )
+		if (WEST)
 			initialize_directions = EAST
 			initialize_directions_he = WEST
+	..()
 	// BubbleWrap END
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -132,6 +132,9 @@
 
 /obj/machinery/atmospherics/pipe/simple/New()
 	..()
+	update_dir()
+
+/obj/machinery/atmospherics/pipe/simple/update_dir()
 	switch(dir)
 		if(SOUTH, NORTH)
 			initialize_directions = SOUTH|NORTH
@@ -145,6 +148,7 @@
 			initialize_directions = SOUTH|EAST
 		if(SOUTHWEST)
 			initialize_directions = SOUTH|WEST
+	..()
 
 /obj/machinery/atmospherics/pipe/simple/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
 	dir = pipe.dir
@@ -477,6 +481,13 @@
 
 /obj/machinery/atmospherics/pipe/manifold/New()
 	icon_state = "manifold"
+	update_dir()
+	centre_overlay = manifold_centre
+	centre_overlay.color = color
+	overlays += centre_overlay
+	..()
+
+/obj/machinery/atmospherics/pipe/manifold/update_dir()
 	switch(dir)
 		if(NORTH)
 			initialize_directions = EAST|SOUTH|WEST
@@ -486,11 +497,7 @@
 			initialize_directions = SOUTH|WEST|NORTH
 		if(WEST)
 			initialize_directions = NORTH|EAST|SOUTH
-	centre_overlay = manifold_centre
-	centre_overlay.color = color
-	overlays += centre_overlay
 	..()
-
 
 /obj/machinery/atmospherics/pipe/manifold/get_node(node_id)
 	switch(node_id)
@@ -982,17 +989,20 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/New()
 	for(var/pipelayer = PIPING_LAYER_MIN; pipelayer <= PIPING_LAYER_MAX; pipelayer += PIPING_LAYER_INCREMENT)
 		layer_nodes.Add(null)
-	switch(dir)
-		if(NORTH,SOUTH)
-			initialize_directions = NORTH|SOUTH
-		if(EAST,WEST)
-			initialize_directions = EAST|WEST
-
+	update_dir()
 	centre_overlay = centre_image
 	centre_overlay.color = color
 	overlays += centre_overlay
 	icon_state = ""
 	..()
+
+/obj/machinery/atmospherics/pipe/layer_manifold/update_dir()
+	..()
+	switch(dir)
+		if(NORTH,SOUTH)
+			initialize_directions = NORTH|SOUTH
+		if(EAST,WEST)
+			initialize_directions = EAST|WEST
 
 /obj/machinery/atmospherics/pipe/layer_manifold/setPipingLayer(var/new_layer = PIPING_LAYER_DEFAULT)
 	piping_layer = PIPING_LAYER_DEFAULT
@@ -1194,11 +1204,15 @@
 
 /obj/machinery/atmospherics/pipe/layer_adapter/New()
 	..()
+	update_dir()
+
+/obj/machinery/atmospherics/pipe/layer_adapter/update_dir()
 	switch(dir)
 		if(NORTH,SOUTH)
 			initialize_directions = NORTH|SOUTH
 		if(EAST,WEST)
 			initialize_directions = EAST|WEST
+	..()
 
 /obj/machinery/atmospherics/pipe/layer_adapter/setPipingLayer(var/new_layer = PIPING_LAYER_DEFAULT)
 	piping_layer = new_layer

--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -717,7 +717,7 @@
 			modern.floor_tile = ancient.floor_tile
 			ancient.floor_tile = null
 		if(rotate)
-			new_turf.shuttle_rotate(rotate)
+			new_turf.map_element_rotate(rotate)
 
 		//*****Move air*****
 
@@ -788,7 +788,7 @@
 		AM.forceMove(new_turf)
 
 	if(rotate)
-		AM.shuttle_rotate(rotate)
+		AM.map_element_rotate(rotate)
 
 /proc/setup_shuttles()
 	world.log << "Setting up all shuttles..."

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -115,8 +115,8 @@ var/global/list/ghdel_profiling = list()
 		if(prob(50))
 			shiftx = -shiftx
 		if(prob(50))
-			shifty = -shifty 
-			
+			shifty = -shifty
+
 		animate(src, pixel_x = pixel_x + shiftx, pixel_y = pixel_y + shifty, time = speed)
 		shakedirections = shakedirections + 1
 		sleep(speed)
@@ -535,7 +535,7 @@ its easier to just keep the beam vertical.
 	return
 
 //Called on every object in a shuttle which rotates
-/atom/proc/shuttle_rotate(var/angle)
+/atom/proc/map_element_rotate(var/angle)
 	change_dir(turn(src.dir, -angle))
 
 	if(canSmoothWith()) //Smooth the smoothable

--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -35,8 +35,6 @@
 	if(anchored)
 		verbs -= rotate_verbs
 
-	initialize_directions = dir
-
 /obj/machinery/atmospherics/unary/cold_sink/freezer/RefreshParts()
 	var/lasercount = 0
 	for(var/obj/item/weapon/stock_parts/SP in component_parts)
@@ -207,8 +205,6 @@
 
 	if(anchored)
 		verbs -= rotate_verbs
-
-	initialize_directions = dir
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/RefreshParts()
 	var/lasercount = 0

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -215,7 +215,7 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 /obj/proc/clockworkify()
 	return
 
-/obj/shuttle_rotate(var/angle)
+/obj/map_element_rotate(var/angle)
 	..()
 	if(req_access_dir)
 		req_access_dir = turn(req_access_dir, -angle)

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -10,7 +10,7 @@
 	opacity = 0
 	anchored = 1
 
-/obj/structure/shuttle/window/shuttle_rotate(angle) //WOW
+/obj/structure/shuttle/window/map_element_rotate(angle) //WOW
 	src.transform = turn(src.transform, angle)
 
 /obj/structure/shuttle/window/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
@@ -46,13 +46,13 @@
 	name = "shuttle engine pre-igniter"
 	var/obj/structure/shuttle/engine/propulsion/DIY/connected_engine
 	anchored = FALSE
-	
+
 /obj/structure/shuttle/engine/heater/DIY/proc/try_connect()
-	if(!anchored) 
+	if(!anchored)
 		desc = initial(desc)
 		return FALSE
 	disconnect()
-	
+
 	for(var/obj/structure/shuttle/engine/propulsion/DIY/D in range(1,src))
 		if(D.anchored && !D.heater && D.dir == dir && D.loc == get_step(src,dir))
 			D.heater = src
@@ -62,17 +62,17 @@
 			return TRUE
 	desc = initial(desc)
 	return FALSE
-	
+
 /obj/structure/shuttle/engine/heater/DIY/proc/disconnect()
 	if(connected_engine)
 		connected_engine.heater = null // prevent infinite recursion and subsequent serb CPU fire
 		connected_engine.disconnect()
 	connected_engine = null
 	src.desc = initial(src.desc)
-			
+
 /obj/structure/shuttle/engine/heater/DIY/attackby(obj/item/I, mob/user)
 	if(I.is_wrench(user) && wrenchAnchor(user, I, 5 SECONDS))
-		return TRUE			
+		return TRUE
 	return ..()
 
 /obj/structure/shuttle/engine/heater/DIY/canAffixHere(var/mob/user)
@@ -83,7 +83,7 @@
 			return ..()
 	to_chat(user, "<span class = 'warning'>There is no engine within range of \the [src] it can connect to.</span>")
 	return FALSE
-	
+
 /obj/structure/shuttle/engine/heater/DIY/wrenchAnchor(var/mob/user, var/obj/item/I, var/obj/item/I, var/time_to_wrench = 3 SECONDS)
 	.=..()
 	if(.)
@@ -98,13 +98,13 @@
 	name = "shuttle engine"
 	var/obj/structure/shuttle/engine/heater/DIY/heater = null
 	anchored = FALSE
-	
+
 /obj/structure/shuttle/engine/propulsion/DIY/proc/disconnect()
 	if(heater)
 		heater.disconnect()
 	heater = null
 	desc = initial(desc)
-	
+
 /obj/structure/shuttle/engine/propulsion/DIY/proc/try_connect()
 	if(!anchored)
 		desc = initial(desc)
@@ -119,7 +119,7 @@
 			return TRUE
 	desc = initial(desc)
 	return FALSE
-	
+
 // find and rectify black-swan type weirdness, i.e. varedit / singuloo unanchoring the engine parts or a push wizard teleporting them away
 // the shuttle should NOT work if one of the heaters has been magicked halfway across the station, so check for it!
 /obj/structure/shuttle/engine/propulsion/DIY/proc/retard_checks()
@@ -131,7 +131,7 @@
 	if(loc != get_step(heater,heater.dir)) // we're not next to the heater anymore
 		disconnect()
 		return
-		
+
 /obj/structure/shuttle/engine/propulsion/DIY/attackby(obj/item/I, mob/user)
 	if(I.is_wrench(user))
 		return wrenchAnchor(user, I, 5 SECONDS)

--- a/code/game/turfs/portal.dm
+++ b/code/game/turfs/portal.dm
@@ -21,8 +21,8 @@
 /turf/portal/initialize()
 	..()
 	update_icon()
-	
-/turf/portal/shuttle_rotate(angle)
+
+/turf/portal/map_element_rotate(angle)
 	..()
 	if(angle == 180 || angle == 270)
 		teleport_x *= -1

--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -59,7 +59,7 @@
 /turf/simulated/wall/shuttle/unsmoothed/relativewall()
 	return
 
-/turf/simulated/shuttle/wall/unsmoothed/shuttle_rotate(angle)
+/turf/simulated/shuttle/wall/unsmoothed/map_element_rotate(angle)
 	src.transform = turn(src.transform, angle)
 
 /turf/simulated/wall/shuttle/unsmoothed/black

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -21,7 +21,7 @@ var/list/gateways = list() //List containing the gateways on away missions
 		return
 	icon_state = "off"
 
-/obj/machinery/gateway/shuttle_rotate()
+/obj/machinery/gateway/map_element_rotate()
 	return
 
 

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -362,11 +362,11 @@ var/list/map_dimension_cache = list()
 
 	// Stolen from shuttlecode but very good to reuse here
 	if(rotate && instance)
-		instance.shuttle_rotate(rotate)
+		instance.map_element_rotate(rotate)
 
 	if(use_preloader && instance)//second preloader pass, for those atoms that don't ..() in New()
 		_preloader.load(instance)
-	
+
 	return instance
 
 //text trimming (both directions) helper proc

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1794,7 +1794,7 @@ Use this proc preferably at the end of an equipment loadout
 /mob/shuttle_act()
 	return
 
-/mob/shuttle_rotate(angle)
+/mob/map_element_rotate(angle)
 	src.dir = turn(src.dir, -angle) //rotating pixel_x and pixel_y is bad
 
 /mob/can_shuttle_move()

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -12,7 +12,7 @@
 
 	dir = SOUTH
 	initialize_directions = SOUTH
-	
+
 	var/obj/machinery/atmospherics/node1
 	var/obj/machinery/atmospherics/node2
 
@@ -28,6 +28,9 @@
 
 /obj/machinery/atmospherics/pipe/zpipe/New()
 	..()
+	update_dir()
+
+/obj/machinery/atmospherics/pipe/zpipe/update_dir()
 	switch(dir)
 		if(SOUTH)
 			initialize_directions = SOUTH
@@ -45,6 +48,7 @@
 			initialize_directions = EAST
 		if(SOUTHWEST)
 			initialize_directions = SOUTH
+	..()
 
 /obj/machinery/atmospherics/pipe/zpipe/hide(var/i)
 	if(istype(loc, /turf/simulated))

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -132,7 +132,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(powernet)
 		powernet.set_to_build() // update the powernets
 
-/obj/structure/cable/shuttle_rotate(angle)
+/obj/structure/cable/map_element_rotate(angle)
 	if(d1)
 		d1 = turn(d1, -angle)
 	if(d2)

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -92,12 +92,12 @@
 	terminal.dir = get_dir(newloc, src)
 	terminal.master = src
 
-/obj/machinery/power/shuttle_rotate(angle)
+/obj/machinery/power/map_element_rotate(angle)
 	..()
 	if(terminal && terminal.dir != get_dir(terminal.loc, src))
 		terminal.dir = get_dir(terminal.loc, src)
 
-/obj/machinery/power/apc/shuttle_rotate(angle)
+/obj/machinery/power/apc/map_element_rotate(angle)
 	..()
 	tdir = dir
 	if(terminal && terminal.dir != tdir)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -786,6 +786,10 @@
 /obj/structure/disposalpipe/proc/nextdir(var/fromdir)
 	return dpdir & (~turn(fromdir, 180))
 
+/obj/structure/disposalpipe/map_element_rotate(var/angle)
+	..()
+	update()
+
 // transfer the holder through this pipe segment
 // overriden for special behaviour
 //
@@ -1027,14 +1031,12 @@
 /obj/structure/disposalpipe/segment/no_deconstruct
 	deconstructable = FALSE
 
-/obj/structure/disposalpipe/segment/New()
+/obj/structure/disposalpipe/segment/update()
 	..()
 	if(icon_state == "pipe-s")
 		dpdir = dir | turn(dir, 180)
 	else
 		dpdir = dir | turn(dir, -90)
-
-	update()
 
 //a three-way junction with dir being the dominant direction
 /obj/structure/disposalpipe/junction
@@ -1043,7 +1045,7 @@
 /obj/structure/disposalpipe/junction/no_deconstruct
 	deconstructable = FALSE
 
-/obj/structure/disposalpipe/junction/New()
+/obj/structure/disposalpipe/junction/update()
 	..()
 	if(icon_state == "pipe-j1")
 		dpdir = dir | turn(dir, -90) | turn(dir,180)
@@ -1051,8 +1053,6 @@
 		dpdir = dir | turn(dir, 90) | turn(dir,180)
 	else // pipe-y
 		dpdir = dir | turn(dir,90) | turn(dir, -90)
-	update()
-	return
 
 // next direction to move
 // if coming in from secondary dirs, then next is primary dir
@@ -1120,6 +1120,10 @@
 	updatedir()
 	updatedesc()
 	update()
+
+/obj/structure/disposalpipe/sortjunction/map_element_rotate(var/angle)
+	..()
+	updatedir()
 
 /obj/structure/disposalpipe/sortjunction/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/device/destTagger))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/57303506/154802651-4948822a-ca09-4c7e-a99b-0da3540de528.png)
Closes #32103.
Closes #32095.
[bugfix][vault]

:cl:
 * rscadd: Pipes in space hobo shacks are now found in working condition much more often.