### PR TITLE
Allows vaults with previous disposals issues to rotate

### DIFF
--- a/code/modules/randomMaps/vault_definitions.dm
+++ b/code/modules/randomMaps/vault_definitions.dm
@@ -66,6 +66,7 @@ var/list/existing_vaults = list()
 
 /datum/map_element/vault/hivebot_factory
 	file_path = "maps/randomvaults/hivebot_factory.dmm"
+	can_rotate = TRUE
 
 /datum/map_element/vault/pretty_rad_clubhouse
 	file_path = "maps/randomvaults/pretty_rad_clubhouse.dmm"
@@ -186,6 +187,7 @@ var/list/existing_vaults = list()
 
 /datum/map_element/vault/zoo_truck
 	file_path = "maps/randomvaults/zoo_truck.dmm"
+	can_rotate = TRUE
 
 /datum/map_element/vault/syndiecargo
 	file_path = "maps/randomvaults/syndiecargo.dmm"

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1408,12 +1408,16 @@
 
 /obj/structure/disposalpipe/trunk/New()
 	. = ..()
-	dpdir = dir
+	update_dir()
 
 	spawn(1)
 		getlinked()
 
 	update()
+
+/obj/structure/disposalpipe/trunk/update_dir()
+	dpdir = dir
+	..()
 
 /obj/structure/disposalpipe/trunk/proc/getlinked()
 	disposal = locate() in loc


### PR DESCRIPTION
[bugfix][vault]
Also fixes map element rotation of trunks, which wasn't being set.

:cl:
 * tweak: Zoo trucks and hivebot factories can now be found in rotated positions in space.