### PR TITLE
Lotto Ticket Updates

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -2622,3 +2622,12 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containertype = /obj/structure/stackopacks
 	containername = "\improper Zam Snax stack of packs"
 	group = "Vending Machine packs"
+
+/datum/supply_packs/lotto
+	name = "Lotto Ticket stack of packs"
+	contains = list(/obj/structure/vendomatpack/lotto,
+					/obj/structure/vendomatpack/lotto)
+	cost = 20
+	containertype = /obj/structure/stackopacks
+	containername = "\improper Lotto Ticket stack of packs"
+	group = "Vending Machine packs"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3748,6 +3748,19 @@ var/global/num_vending_terminals = 1
 
 	pack = /obj/structure/vendomatpack/lotto
 
+
+/proc/obj/machinery/vending/lotto/AnnounceWinner(var/mob/living/carbon/human/character, var/winnings)
+		var/rank = character.mind.role_alt_title
+		var/datum/speech/speech = announcement_intercom.create_speech("[character.real_name],[rank ? " [rank]," : " visitor," ] has won [winnings] credits in the lottery!", transmitter=announcement_intercom)
+		speech.speaker = src
+		speech.name = "Lottery Tickets Vendor"
+		speech.job = "Automated Announcement"
+		speech.as_name = "Lottery Tickets Vendor"
+		speech.frequency = COMMON_FREQ
+
+		Broadcast_Message(speech, vmask=null, data=0, compression=0, level=list(0,1))
+		qdel(speech)
+
 /obj/machinery/vending/lotto/attackby(obj/item/I, user)
 	add_fingerprint(user)
 	if(istype(I, /obj/item/toy/lotto_ticket))
@@ -3759,6 +3772,17 @@ var/global/num_vending_terminals = 1
 			visible_message("<b>[src]</b>'s monitor flashes, \"Withdrawing [T.winnings] credits from the Central Command Lottery Fund!\"")
 			dispense_cash(T.winnings, get_turf(src))
 			playsound(src, "polaroid", 50, 1)
+			if(T.winnings >= 10000)
+				AnnounceWinner(user,T.winnings)
 			qdel(T)
 	else
 		..()
+
+/obj/machinery/vending/lotto/throw_item()
+	var/mob/living/target = locate() in view(7, src)
+
+	if (!target)
+		return 0
+	for(var/i = 0 to rand(3,12))
+		var/obj/I = new /obj/item/weapon/paper(get_turf(src))
+		I.throw_at(target, 16, 3)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3716,7 +3716,7 @@ var/global/num_vending_terminals = 1
 
 /obj/machinery/vending/lotto
 	name = "\improper Lotto Tickets"
-	desc = "Wall-mounted vending machine which dispenses scratch-off lottery tickets. Winners can be cashed at Cargo."
+	desc = "Table-mounted vending machine which dispenses scratch-off lottery tickets. Winners can be cashed at Cargo."
 	product_slogans = list(
 		"Feeling lucky?",
 		"Money won is twice as sweet as money earned.",

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3716,7 +3716,7 @@ var/global/num_vending_terminals = 1
 
 /obj/machinery/vending/lotto
 	name = "\improper Lotto Tickets"
-	desc = "Table-mounted vending machine which dispenses scratch-off lottery tickets. Winners can be cashed at Cargo."
+	desc = "Table-mounted vending machine which dispenses scratch-off lottery tickets. Winners can be cashed here."
 	product_slogans = list(
 		"Feeling lucky?",
 		"Money won is twice as sweet as money earned.",

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3749,7 +3749,7 @@ var/global/num_vending_terminals = 1
 	pack = /obj/structure/vendomatpack/lotto
 
 
-/proc/obj/machinery/vending/lotto/AnnounceWinner(var/obj/machinery/vending/lotto/lottovend, var/mob/living/carbon/human/character, var/winnings)
+/proc/obj/machinery/vending/lotto/AnnounceWinner(var/obj/machinery/vending/lotto/lottovend,var/mob/living/carbon/human/character, var/winnings)
 		var/rank = character.mind.role_alt_title
 		var/datum/speech/speech = announcement_intercom.create_speech("[character.real_name],[rank ? " [rank]," : " visitor," ] has won [winnings] credits in the lottery!", transmitter=announcement_intercom)
 		speech.speaker = lottovend

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3749,7 +3749,7 @@ var/global/num_vending_terminals = 1
 	pack = /obj/structure/vendomatpack/lotto
 
 
-/proc/obj/machinery/vending/lotto/AnnounceWinner(var/obj/machinery/vending/lotto/lottovend,var/mob/living/carbon/human/character, var/winnings)
+/proc/obj/machinery/vending/lotto/AnnounceWinner(var/obj/machinery/vending/lotto/lottovend, var/mob/living/carbon/human/character, var/winnings)
 		var/rank = character.mind.role_alt_title
 		var/datum/speech/speech = announcement_intercom.create_speech("[character.real_name],[rank ? " [rank]," : " visitor," ] has won [winnings] credits in the lottery!", transmitter=announcement_intercom)
 		speech.speaker = lottovend

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3749,10 +3749,10 @@ var/global/num_vending_terminals = 1
 	pack = /obj/structure/vendomatpack/lotto
 
 
-/proc/obj/machinery/vending/lotto/AnnounceWinner(var/mob/living/carbon/human/character, var/winnings)
+/proc/obj/machinery/vending/lotto/AnnounceWinner(var/obj/machinery/vending/lotto/lottovend,var/mob/living/carbon/human/character, var/winnings)
 		var/rank = character.mind.role_alt_title
 		var/datum/speech/speech = announcement_intercom.create_speech("[character.real_name],[rank ? " [rank]," : " visitor," ] has won [winnings] credits in the lottery!", transmitter=announcement_intercom)
-		speech.speaker = src
+		speech.speaker = lottovend
 		speech.name = "Lottery Tickets Vendor"
 		speech.job = "Automated Announcement"
 		speech.as_name = "Lottery Tickets Vendor"
@@ -3773,7 +3773,7 @@ var/global/num_vending_terminals = 1
 			dispense_cash(T.winnings, get_turf(src))
 			playsound(src, "polaroid", 50, 1)
 			if(T.winnings >= 10000)
-				AnnounceWinner(user,T.winnings)
+				AnnounceWinner(src,user,T.winnings)
 			qdel(T)
 	else
 		..()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3749,7 +3749,7 @@ var/global/num_vending_terminals = 1
 	pack = /obj/structure/vendomatpack/lotto
 
 
-/proc/obj/machinery/vending/lotto/AnnounceWinner(var/obj/machinery/vending/lotto/lottovend,var/mob/living/carbon/human/character, var/winnings)
+/obj/machinery/vending/lotto/proc/AnnounceWinner(var/obj/machinery/vending/lotto/lottovend, var/mob/living/carbon/human/character, var/winnings)
 		var/rank = character.mind.role_alt_title
 		var/datum/speech/speech = announcement_intercom.create_speech("[character.real_name],[rank ? " [rank]," : " visitor," ] has won [winnings] credits in the lottery!", transmitter=announcement_intercom)
 		speech.speaker = lottovend


### PR DESCRIPTION
List of changes:
- Lotto vendors now announce winners of >10,000 credits to the crew via common chat.
- Hacked vendors will now only shoot paper (unprinted tickets heh) instead of free lotto tickets.
- Adds cargo resupply pack.

:cl:
 * rscadd: lotto vendors now announce winners to the entire station.
 * rscdel: removed ability to hack the lotto vendor to shoot free tickets.
