### PR TITLE
Traitor item: F.R.A.M.E. PDA cartridge

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -168,15 +168,13 @@
 	if(trim(lowertext(new_ringtone)) != trim(lowertext(unlock_code)))
 		return
 	locked = FALSE
-	if(user)
-		tgui_interact(user)
+	tgui_interact(user)
 	return TRUE
 
 /datum/component/uplink/proc/on_radio_new_frequency(mob/user, new_frequency)
 	if(new_frequency != unlock_frequency)
 		return
 	locked = FALSE
-	if(user)
-		tgui_interact(user)
+	tgui_interact(user)
 	return TRUE
 

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -168,13 +168,15 @@
 	if(trim(lowertext(new_ringtone)) != trim(lowertext(unlock_code)))
 		return
 	locked = FALSE
-	tgui_interact(user)
+	if(user)
+		tgui_interact(user)
 	return TRUE
 
 /datum/component/uplink/proc/on_radio_new_frequency(mob/user, new_frequency)
 	if(new_frequency != unlock_frequency)
 		return
 	locked = FALSE
-	tgui_interact(user)
+	if(user)
+		tgui_interact(user)
 	return TRUE
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -300,6 +300,12 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/cartridge/syndicate
 	cost = 6
 
+/datum/uplink_item/stealthy_weapons/framecart
+	name = "F.R.A.M.E PDA Cartridge"
+	desc = "When inserted into a PDA, gives you four charges allowing you to create a fake uplink on a PDAs of crewmembers who have messaging enabled. This will also use the same unlock code as your uplink if applicable, or else generate a new one. TC can also be inserted into the cartridge to send to the PDA"
+	item = /obj/item/weapon/cartridge/syndifake
+	cost = 6
+
 /datum/uplink_item/stealthy_weapons/knuckles
 	name = "Spiked Knuckles"
 	desc = "A pair of spiked metal knuckles that can be worn directly on your hands in place of gloves, dramatically increasing damage done by your punches without giving any obvious signs to observers unless they inspect you more closely."
@@ -523,7 +529,7 @@ var/list/uplink_items = list()
 	cost = 1
 	discounted_cost = 0
 	jobs_with_discount = SCIENCE_POSITIONS
-	
+
 /datum/uplink_item/device_tools/radio_jammer
 	name = "Radio Jammer"
 	desc = "A device that disrupts all radio communication in nearby area. Guaranteed radio silence at point blank range, but effectiveness decreases with range. Requires a power cell for operation. Batteries and screwdriver not included."

--- a/code/game/machinery/telecomms/multicaster.dm
+++ b/code/game/machinery/telecomms/multicaster.dm
@@ -83,7 +83,10 @@ var/list/pda_multicasters = list()
 	name = "Centralized Autonomous Messaging Operator"
 	owner = "CAMO"
 	ownjob = "CAMO"
-	detonate = 0
+	accepted_viruses = list(
+		/datum/pda_app/cart/virus/honk,
+		/datum/pda_app/cart/virus/silent,
+	)
 	hidden = 1
 	starting_apps = list(/datum/pda_app/messenger/camo)
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -29,7 +29,12 @@ var/global/msg_id = 0
 	var/lock_code = "" // Lockcode to unlock uplink
 	var/honkamt = 0 //How many honks left when infected with honk.exe
 	var/mimeamt = 0 //How many silence left when infected with mime.exe
-	var/detonate = 1 // Can the PDA be blown up?
+	var/list/accepted_viruses = list(
+		/datum/pda_app/cart/virus/honk,
+		/datum/pda_app/cart/virus/silent,
+		/datum/pda_app/cart/virus/detonate,
+		/datum/pda_app/cart/virus/fake_uplink,
+	) //What kind of viruses can this PDA be sent?
 	var/hidden = 0 // Is the PDA hidden from the PDA list?
 	var/show_overlays = TRUE
 

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -208,7 +208,11 @@
 	name = "Captain PDA"
 	default_cartridge = /obj/item/weapon/cartridge/captain
 	icon_state = "pda-c"
-	detonate = 0
+	accepted_viruses = list(
+		/datum/pda_app/cart/virus/honk,
+		/datum/pda_app/cart/virus/silent,
+		/datum/pda_app/cart/virus/fake_uplink,
+	)
 
 /obj/item/device/pda/captain/New()
 	starting_apps.Cut()
@@ -355,7 +359,10 @@
 /obj/item/device/pda/ai
 	icon = 'icons/obj/machines/telecomms.dmi'
 	icon_state = "pda_server-on"
-	detonate = 0
+	accepted_viruses = list(
+		/datum/pda_app/cart/virus/honk,
+		/datum/pda_app/cart/virus/silent,
+	)
 
 /obj/item/device/pda/ai/New()
 	starting_apps += /datum/pda_app/spam_filter

--- a/code/game/objects/items/devices/PDA/apps/messenger.dm
+++ b/code/game/objects/items/devices/PDA/apps/messenger.dm
@@ -39,7 +39,7 @@
 						dat += " (<a href='byond://?src=\ref[src];choice=transferFunds;target=\ref[P]'><span class='pda_icon pda_money'></span>*Send Money*</a>)"
 
 					for(var/datum/pda_app/cart/virus/V in pda_device.applications)
-						if (!(istype(V,/datum/pda_app/cart/virus/detonate)) || (istype(V,/datum/pda_app/cart/virus/detonate) && P.detonate))
+						if (P.accepted_viruses && P.accepted_viruses.len && (V.type in P.accepted_viruses))
 							dat += " (<a href='byond://?src=\ref[V];target=\ref[P]'>[V.icon ? "<span class='pda_icon [V.icon]'></span>" : ""]*[V.name]*</a>)"
 					dat += "</li>"
 					count++

--- a/code/game/objects/items/devices/PDA/apps/messenger.dm
+++ b/code/game/objects/items/devices/PDA/apps/messenger.dm
@@ -12,62 +12,52 @@
     var/list/incoming_transactions = list()
 
 /datum/pda_app/messenger/get_dat(var/mob/user)
-    var/dat = ""
-    switch(mode)
-        if (0)
-            dat += {"<h4><span class='pda_icon pda_mail'></span> SpaceMessenger V3.9.4</h4>
-                <a href='byond://?src=\ref[src];choice=Toggle Ringer'><span class='pda_icon pda_bell'></span> Ringer: [silent == 1 ? "Off" : "On"]</a> |
-                <a href='byond://?src=\ref[src];choice=Toggle Messenger'><span class='pda_icon pda_mail'></span> Send / Receive: [toff == 1 ? "Off" : "On"]</a> |
-                <a href='byond://?src=\ref[src];choice=Ringtone'><span class='pda_icon pda_bell'></span> Set Ringtone</a> |
-                <a href='byond://?src=\ref[src];choice=1'><span class='pda_icon pda_mail'></span> Messages</a>"}
-            dat += "<br>"
-            var/datum/pda_app/cart/virus/detonate/DV = locate(/datum/pda_app/cart/virus/detonate) in pda_device.applications
-            if(DV)
-                dat += "<b>[DV.charges] detonation charges left.</b><HR>"
-            var/datum/pda_app/cart/virus/honk/HV = locate(/datum/pda_app/cart/virus/honk) in pda_device.applications
-            if(HV)
-                dat += "<b>[HV.charges] viral files left.</b><HR>"
-            var/datum/pda_app/cart/virus/silent/SV = locate(/datum/pda_app/cart/virus/silent) in pda_device.applications
-            if(SV)
-                dat += "<b>[SV.charges] viral files left.</b><HR>"
+	var/dat = ""
+	switch(mode)
+		if (0)
+			dat += {"<h4><span class='pda_icon pda_mail'></span> SpaceMessenger V3.9.4</h4>
+				<a href='byond://?src=\ref[src];choice=Toggle Ringer'><span class='pda_icon pda_bell'></span> Ringer: [silent == 1 ? "Off" : "On"]</a> |
+				<a href='byond://?src=\ref[src];choice=Toggle Messenger'><span class='pda_icon pda_mail'></span> Send / Receive: [toff == 1 ? "Off" : "On"]</a> |
+				<a href='byond://?src=\ref[src];choice=Ringtone'><span class='pda_icon pda_bell'></span> Set Ringtone</a> |
+				<a href='byond://?src=\ref[src];choice=1'><span class='pda_icon pda_mail'></span> Messages</a>"}
+			dat += "<br>"
+			for(var/datum/pda_app/cart/virus/V in pda_device.applications)
+				dat += "<b>[V.charges] [V.virus_type] left.</b><HR>"
 
+			dat += {"<h4><span class='pda_icon pda_menu'></span> Detected PDAs</h4>
+				<ul>"}
+			var/count = 0
 
-            dat += {"<h4><span class='pda_icon pda_menu'></span> Detected PDAs</h4>
-                <ul>"}
-            var/count = 0
+			if (!toff)
+				for (var/obj/item/device/pda/P in sortNames(get_viewable_pdas()))
+					if (P == src)
+						continue
+					if(P.hidden)
+						continue
+					dat += "<li><a href='byond://?src=\ref[src];choice=Message;target=\ref[P]'>[P]</a>"
+					if (pda_device.id && !istype(P,/obj/item/device/pda/ai))
+						dat += " (<a href='byond://?src=\ref[src];choice=transferFunds;target=\ref[P]'><span class='pda_icon pda_money'></span>*Send Money*</a>)"
 
-            if (!toff)
-                for (var/obj/item/device/pda/P in sortNames(get_viewable_pdas()))
-                    if (P == src)
-                        continue
-                    if(P.hidden)
-                        continue
-                    dat += "<li><a href='byond://?src=\ref[src];choice=Message;target=\ref[P]'>[P]</a>"
-                    if (pda_device.id && !istype(P,/obj/item/device/pda/ai))
-                        dat += " (<a href='byond://?src=\ref[src];choice=transferFunds;target=\ref[P]'><span class='pda_icon pda_money'></span>*Send Money*</a>)"
-                    if (DV && P.detonate)
-                        dat += " (<a href='byond://?src=\ref[DV];target=\ref[P]'><span class='pda_icon pda_boom'></span>*Detonate*</a>)"
-                    if (HV)
-                        dat += " (<a href='byond://?src=\ref[HV];target=\ref[P]'><span class='pda_icon pda_honk'></span>*Send Virus*</a>)"
-                    if (SV)
-                        dat += " (<a href='byond://?src=\ref[SV];target=\ref[P]'>*Send Virus*</a>)"
-                    dat += "</li>"
-                    count++
-            dat += "</ul>"
-            if (count == 0)
-                dat += "None detected.<br>"
-        if(1)
-            dat += {"<h4><span class='pda_icon pda_mail'></span> SpaceMessenger V3.9.4</h4>
-                <a href='byond://?src=\ref[src];choice=Clear'><span class='pda_icon pda_blank'></span> Clear Messages</a>
-                <h4><span class='pda_icon pda_mail'></span> Messages</h4>"}
-            for(var/note in tnote)
-                dat += tnote[note]
-                var/icon/img = imglist[note]
-                if(img)
-                    user << browse_rsc(ImagePDA(img), "tmp_photo_[note].png")
-                    dat += "<img src='tmp_photo_[note].png' width = '192' style='-ms-interpolation-mode:nearest-neighbor'><BR>"
-            dat += "<br>"
-    return dat
+					for(var/datum/pda_app/cart/virus/V in pda_device.applications)
+						if (!(istype(V,/datum/pda_app/cart/virus/detonate)) || (istype(V,/datum/pda_app/cart/virus/detonate) && P.detonate))
+							dat += " (<a href='byond://?src=\ref[V];target=\ref[P]'>[V.icon ? "<span class='pda_icon [V.icon]'></span>" : ""]*[V.name]*</a>)"
+					dat += "</li>"
+					count++
+			dat += "</ul>"
+			if (count == 0)
+				dat += "None detected.<br>"
+		if(1)
+			dat += {"<h4><span class='pda_icon pda_mail'></span> SpaceMessenger V3.9.4</h4>
+				<a href='byond://?src=\ref[src];choice=Clear'><span class='pda_icon pda_blank'></span> Clear Messages</a>
+				<h4><span class='pda_icon pda_mail'></span> Messages</h4>"}
+			for(var/note in tnote)
+				dat += tnote[note]
+				var/icon/img = imglist[note]
+				if(img)
+					user << browse_rsc(ImagePDA(img), "tmp_photo_[note].png")
+					dat += "<img src='tmp_photo_[note].png' width = '192' style='-ms-interpolation-mode:nearest-neighbor'><BR>"
+			dat += "<br>"
+	return dat
 
 /datum/pda_app/messenger/Topic(href, href_list)
     if(..())

--- a/code/game/objects/items/devices/PDA/cart/civilian.dm
+++ b/code/game/objects/items/devices/PDA/cart/civilian.dm
@@ -142,7 +142,6 @@
         last_honk = world.time
 
 /datum/pda_app/cart/virus/honk
-    name = "Honk Virus"
     desc = "HONK!"
     icon = "pda_honk"
 
@@ -157,7 +156,6 @@
     starting_apps = list(/datum/pda_app/cart/virus/silent)
 
 /datum/pda_app/cart/virus/silent
-    name = "Silent Virus"
     desc = "..."
 
 /datum/pda_app/cart/virus/silent/infect(var/obj/item/device/pda/P,var/mob/U)

--- a/code/game/objects/items/devices/PDA/cart/misc.dm
+++ b/code/game/objects/items/devices/PDA/cart/misc.dm
@@ -135,14 +135,12 @@
 		else
 			new_uplink.telecrystals = 0
 		var/datum/component/uplink/our_uplink = pda_device.get_component(/datum/component/uplink)
-		if(!our_uplink && ismob(pda_device.loc))
-			var/mob/M = pda_device.loc
-			if(M.mind)
-				our_uplink = M.mind.find_syndicate_uplink()
+		if(!our_uplink && U.mind)
+			our_uplink = U.mind.find_syndicate_uplink()
 		if(our_uplink)
 			new_uplink.unlock_code = our_uplink.unlock_code
+		new_uplink.locked = FALSE
 		U.show_message("<span class='notice'>Success! Unlock the PDA by entering [new_uplink.unlock_code] into it.</span>", 1)
-		INVOKE_EVENT(P, /event/pda_change_ringtone, "user" = null, "new_ringtone" = new_uplink.unlock_code)
 
 /obj/item/weapon/cartridge/syndicatedoor
 	name = "\improper Doorman Cartridge"

--- a/code/game/objects/items/devices/PDA/cart/misc.dm
+++ b/code/game/objects/items/devices/PDA/cart/misc.dm
@@ -141,6 +141,8 @@
 			new_uplink.unlock_code = our_uplink.unlock_code
 		new_uplink.locked = FALSE
 		U.show_message("<span class='notice'>Success! Unlock the PDA by entering [new_uplink.unlock_code] into it.</span>", 1)
+		if(U.mind)
+			U.mind.store_memory("<B>Uplink Passcode:</B> [new_uplink.unlock_code] ([P.name]).")
 
 /obj/item/weapon/cartridge/syndicatedoor
 	name = "\improper Doorman Cartridge"

--- a/code/game/objects/items/devices/PDA/cart/misc.dm
+++ b/code/game/objects/items/devices/PDA/cart/misc.dm
@@ -66,7 +66,7 @@
         log_admin("[key_name(U)] attempted to blow up syndicate [P] with the Detomatix cartridge but failed")
         message_admins("[key_name_admin(U)] attempted to blow up syndicate [P] with the Detomatix cartridge but failed", 1)
         charges--
-    else if (!P.detonate || prob(difficulty * 2))
+    else if (!(src.type in P.accepted_viruses) || prob(difficulty * 2))
         U.show_message("<span class='warning'>An error flashes on your [src]; [pick("Encryption","Connection","Verification","Handshake","Detonation","Injection")] error!</span>", 1)
         U << browse(null, "window=pda")
         var/list/garble = list()

--- a/code/game/objects/items/devices/PDA/cart/misc.dm
+++ b/code/game/objects/items/devices/PDA/cart/misc.dm
@@ -4,13 +4,13 @@
 	origin_tech = Tc_PROGRAMMING + "=2;" + Tc_SYNDICATE + "=2"
 	mech_flags = MECH_SCAN_ILLEGAL
 	starting_apps = list(/datum/pda_app/cart/virus/detonate)
-	var/shock_charges = 4
 
 /datum/pda_app/cart/virus
-    name = "Virus"
-    desc = "Sends to 5 PDAs"
-    menu = FALSE //Shows up elsewhere
-    var/charges = 5
+	name = "Send Virus"
+	desc = "Sends to 5 PDAs"
+	menu = FALSE //Shows up elsewhere
+	var/charges = 5
+	var/virus_type = "viral files"
 
 /datum/pda_app/cart/virus/Topic(href, href_list)
     if(..())
@@ -37,9 +37,10 @@
     return
 
 /datum/pda_app/cart/virus/detonate
-    name = "Detonate PDA"
-    desc = "And maybe a leg too in the process"
-    icon = "pda_boom"
+	name = "Detonate"
+	desc = "And maybe a leg too in the process"
+	icon = "pda_boom"
+	virus_type = "detonation charges"
 
 /datum/pda_app/cart/virus/detonate/infect(var/obj/item/device/pda/P,var/mob/U)
     var/difficulty = 0
@@ -85,6 +86,63 @@
         message_admins("[key_name_admin(U)] attempted to blow up [P] with the Detomatix cartridge and succeeded", 1)
         charges--
         P.explode(U)
+
+/obj/item/weapon/cartridge/syndifake
+	name = "\improper F.R.A.M.E. PDA Cartridge"
+	icon_state = "cart"
+	origin_tech = Tc_PROGRAMMING + "=2;" + Tc_SYNDICATE + "=2"
+	mech_flags = MECH_SCAN_ILLEGAL
+	starting_apps = list(/datum/pda_app/cart/virus/fake_uplink)
+	var/uses = 0
+
+/obj/item/weapon/cartridge/syndifake/attackby(var/obj/item/W, var/mob/user)
+	if(..())
+		return
+	if(istype(W, /obj/item/stack/telecrystal))
+		var/obj/item/stack/telecrystal/crystals = W
+		uses += crystals.amount
+		to_chat(user, "<span class='notice'>You insert [crystals.amount] telecrystal[crystals.amount > 1 ? "s" : ""] into the cartridge.</span>")
+		crystals.use(crystals.amount)
+
+/obj/item/weapon/cartridge/syndifake/attack_self(var/mob/user)
+	if(..())
+		return
+	if(uses)
+		var/obj/item/stack/telecrystal/crystals = new(user.loc, uses)
+		to_chat(user, "<span class='notice'>You remove [crystals.amount] telecrystal[crystals.amount > 1 ? "s" : ""] from the cartridge.</span>")
+		uses = 0
+		user.put_in_hands(crystals)
+
+/datum/pda_app/cart/virus/fake_uplink
+	name = "Send Uplink"
+	desc = "Frame someone as a tator"
+	icon = "pda_boom"
+	virus_type = "fake uplinks"
+
+/datum/pda_app/cart/virus/fake_uplink/infect(var/obj/item/device/pda/P,var/mob/U)
+	if(P.get_component(/datum/component/uplink))
+		U.show_message("<span class='warning'>An error flashes on your [src]; [pick(syndicate_code_response)]</span>", 1)
+		U << browse(null, "window=pda")
+		var/datum/pda_app/messenger/app = locate(/datum/pda_app/messenger) in P.applications
+		if(app)
+			app.create_message(null, P, null, null, pick(syndicate_code_phrase)) //friendly fire
+		charges--
+	else
+		var/datum/component/uplink/new_uplink = P.add_component(/datum/component/uplink)
+		if(istype(cart_device,/obj/item/weapon/cartridge/syndifake))
+			var/obj/item/weapon/cartridge/syndifake/SF = cart_device
+			new_uplink.telecrystals = SF.uses
+		else
+			new_uplink.telecrystals = 0
+		var/datum/component/uplink/our_uplink = pda_device.get_component(/datum/component/uplink)
+		if(!our_uplink && ismob(pda_device.loc))
+			var/mob/M = pda_device.loc
+			if(M.mind)
+				our_uplink = M.mind.find_syndicate_uplink()
+		if(our_uplink)
+			new_uplink.unlock_code = our_uplink.unlock_code
+		U.show_message("<span class='notice'>Success! Unlock the PDA by entering [new_uplink.unlock_code] into it.</span>", 1)
+		INVOKE_EVENT(P, /event/pda_change_ringtone, "user" = null, "new_ringtone" = new_uplink.unlock_code)
 
 /obj/item/weapon/cartridge/syndicatedoor
 	name = "\improper Doorman Cartridge"
@@ -140,7 +198,7 @@
 /obj/item/weapon/cartridge/camera/New()
 	..()
 	cart_cam = new /obj/item/device/camera/cartridge(src)
-	
+
 /obj/item/weapon/cartridge/camera/Destroy()
 	qdel(cart_cam)
 	cart_cam = null

--- a/code/game/objects/items/devices/PDA/cart/misc.dm
+++ b/code/game/objects/items/devices/PDA/cart/misc.dm
@@ -88,7 +88,7 @@
         P.explode(U)
 
 /obj/item/weapon/cartridge/syndifake
-	name = "\improper F.R.A.M.E. PDA Cartridge"
+	name = "\improper F.R.A.M.E. Cartridge"
 	icon_state = "cart"
 	origin_tech = Tc_PROGRAMMING + "=2;" + Tc_SYNDICATE + "=2"
 	mech_flags = MECH_SCAN_ILLEGAL


### PR DESCRIPTION
[content][port][tested]
Idea ported and implemented from https://tgstation13.org/wiki/Syndicate_Items#Devices_and_Tools

:cl:
 * rscadd: Traitors can now purchase the F.R.A.M.E. PDA cartridge, allowing them to plant an uplink on a targeted PDA, and even send it telecrystals placed inside the cartridge. Unlock code is the same as origin PDA if applicable, otherwise generates new one.