### PR TITLE
Scoreboard Tweak

### DIFF
--- a/code/datums/gamemode/factions/faction.dm
+++ b/code/datums/gamemode/factions/faction.dm
@@ -258,7 +258,7 @@ var/list/factions_with_hud_icons = list()
 
 /datum/faction/proc/GetObjectivesMenuHeader() //Returns what will show when the factions objective completion is summarized
 	var/icon/logo = icon('icons/logos.dmi', logo_state)
-	var/header = {"<img src='data:image/png;base64,[icon2base64(logo)]' style='position:relative; top:10px;'> <FONT size = 2><B>[name]</B></FONT> <img src='data:image/png;base64,[icon2base64(logo)]' style='position:relative; top:10px;'><br>"}
+	var/header = {"<img src='data:image/png;base64,[icon2base64(logo)]' style='position:relative; top:10px;'> <FONT size = 2><B>[name]</B></FONT> <img src='data:image/png;base64,[icon2base64(logo)]' style='position:relative; top:10px;'>"}
 	return header
 
 /datum/faction/proc/AdminPanelEntry(var/datum/admins/A)

--- a/code/datums/gamemode/factions/vampire_faction.dm
+++ b/code/datums/gamemode/factions/vampire_faction.dm
@@ -23,7 +23,7 @@
 	if(newname)
 		if (newname == "Unknown" || newname == "floor" || newname == "wall" || newname == "rwall" || newname == "_")
 			to_chat(V.antag.current, "That name is reserved.")
-		name = "The [newname] Vampire Clan."
+		name = "The [newname] Vampire Clan"
 
 
 /datum/faction/vampire/OnPostSetup()

--- a/code/game/gamemodes/endgame/scoreboard/antag_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/antag_score.dm
@@ -1,4 +1,5 @@
-/datum/controller/gameticker/scoreboard/proc/syndicate_score(var/datum/faction/syndicate/traitor/TR, var/completions)
+/datum/controller/gameticker/scoreboard/proc/syndicate_score(var/datum/faction/syndicate/traitor/TR)
+	var/completions
 	var/list/boombox = score.implant_phrases
 	var/synphra = score.syndiphrases
 	var/synspo = score.syndisponses
@@ -16,6 +17,7 @@
 			completions += "<BR>The following explosive implants were used:<BR>"
 			for(var/entry in score.implant_phrases)
 				completions += "[entry]<BR>"
+	return completions
 
 /datum/controller/gameticker/scoreboard/proc/nuke_op_score(var/datum/faction/syndicate/nuke_op/NO)
 	var/foecount = 0
@@ -38,7 +40,7 @@
 			oparrested++
 		else if(M.current.stat == DEAD)
 			opkilled++
-	for(var/mob/living/C in mob_list)
+	for(var/mob/living/C in player_list)
 		if(!istype(C,/mob/living/carbon/human) || !istype(C,/mob/living/silicon/robot) || !istype(C,/mob/living/silicon/ai))
 			continue
 		if(C.stat == DEAD)
@@ -157,8 +159,8 @@
 			revarrested++
 		else if (M.current.stat == DEAD)
 			revkilled++
-	for(var/mob/living/carbon/human/player in mob_list)
-		if(player.mind)
+	for(var/mob/living/player in player_list)
+		if (istype(player, /mob/living/carbon/human))
 			var/role = player.mind.assigned_role
 			if(role in list("Captain", "Head of Security", "Head of Personnel", "Chief Engineer", "Research Director"))
 				if(player.stat == DEAD)
@@ -169,9 +171,9 @@
 				if(locate(/datum/role/revolutionary) in player.mind.antag_roles)
 					continue
 				loycount++
-	for(var/mob/living/silicon/X in mob_list)
-		if (X.stat != DEAD)
-			loycount++
+		else if(istype(player, /mob/living/silicon))
+			if (player.stat != DEAD)
+				loycount++
 	//if(score.scores["traitorswon"])
 		//score.scores["crewscore"] -= 10000
 	if(foecount == revarrested)

--- a/code/game/gamemodes/endgame/scoreboard/department_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/department_score.dm
@@ -7,21 +7,17 @@
 			disease_score += text2num(E.badness)
 
 		//diseases only count if the mob is still alive
-		if (disease_score <3)
-			for (var/mob/living/L in mob_list)
-				if (ID in L.virus2)
-					disease_spread_count++
-					if (L.stat != DEAD)
-						score.disease_good++
-		else
-			for (var/mob/living/L in mob_list)
-				if(!L.mind) //No ballooning the negative score with infected monkeymen
-					continue
-				if (ID in L.virus2)
-					disease_spread_count++
-					if (L.stat != DEAD)
-						score.disease_bad++
-
+		
+		for (var/mob/living/L in player_list)
+			if (L.stat == DEAD)
+				continue
+			if (!(ID in L.virus2))
+				continue
+			disease_spread_count++
+			if (disease_score <3)
+				score.disease_good++
+			else
+				score.disease_bad++
 		if (disease_spread_count > score.disease_most_count)
 			score.disease_most_count = disease_spread_count
 			score.disease_most = ID
@@ -123,39 +119,40 @@
 
 /datum/controller/gameticker/scoreboard/proc/silicon_score()
 	var/ai_completions = ""
-	var/completions
-	for(var/mob/living/silicon/ai/ai in mob_list)
-		var/icon/flat = getFlatIcon(ai)
-		if(ai.stat != 2)
-			ai_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [ai.name] (Played by: [get_key(ai)])'s laws at the end of the game were:</b>"}
-		else
-			ai_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [ai.name] (Played by: [get_key(ai)])'s laws when it was deactivated were:</b>"}
-		ai_completions += "<br>[ai.write_laws()]"
-
-		if (ai.connected_robots.len)
-			var/robolist = "<br><b>The AI's loyal minions were:</b> "
-			for(var/mob/living/silicon/robot/robo in ai.connected_robots)
-				if (!robo.connected_ai || !isMoMMI(robo)) // Don't report MoMMIs or unslaved robutts
-					continue
-				robolist += "[robo.name][robo.stat?" (Deactivated) (Played by: [get_key(robo)]), ":" (Played by: [get_key(robo)]), "]"
-			ai_completions += "[robolist]"
-
-	for (var/mob/living/silicon/robot/robo in mob_list)
-		if(!robo)
-			continue
-		var/icon/flat = getFlatIcon(robo)
-		if (!robo.connected_ai)
-			if (robo.stat != 2)
-				ai_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [robo.name] (Played by: [get_key(robo)]) survived as an AI-less [isMoMMI(robo)?"MoMMI":"borg"]! Its laws were:</b>"}
+	var/robot_completions = ""
+	var/pai_completions = ""
+	var/completions = ""
+	for(var/mob/living/silicon/player in player_list)
+		var/icon/flat = getFlatIcon(player)
+		if(istype(player, /mob/living/silicon/ai))
+			var/mob/living/silicon/ai/ai = player
+			if(ai.stat != DEAD)
+				ai_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [ai.name] (Played by: [get_key(ai)])'s laws at the end of the game were:</b>"}
 			else
-				ai_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [robo.name] (Played by: [get_key(robo)]) was unable to survive the rigors of being a [isMoMMI(robo)?"MoMMI":"cyborg"] without an AI. Its laws were:</b>"}
-		else
-			ai_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [robo.name] (Played by: [get_key(robo)]) [robo.stat!=2?"survived":"perished"] as a [isMoMMI(robo)?"MoMMI":"cyborg"] slaved to [robo.connected_ai]! Its laws were:</b>"}
-		ai_completions += "<br>[robo.write_laws()]"
+				ai_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [ai.name] (Played by: [get_key(ai)])'s laws when it was deactivated were:</b>"}
+			ai_completions += "<br>[ai.write_laws()]"
 
-	for(var/mob/living/silicon/pai/pAI in mob_list)
-		var/icon/flat = getFlatIcon(pAI)
-		ai_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [pAI.name] (Played by: [get_key(pAI)]) [pAI.stat!=2?"survived":"perished"] as a pAI whose master was [pAI.master]! Its directives were:</b><br>[pAI.write_directives()]"}
+			if (ai.connected_robots.len)
+				ai_completions += "<br><b>The AI's loyal minions were:</b> "
+				for(var/mob/living/silicon/robot/robot in ai.connected_robots)
+					if (!robot.connected_ai || !isMoMMI(robot)) // Don't report MoMMIs or unslaved borgs
+						continue
+					ai_completions += "[robot.name][robot.stat?" (Deactivated) (Played by: [get_key(robot)]), ":" (Played by: [get_key(robot)]), "]"
+
+		else if(istype(player, /mob/living/silicon/robot))
+			var/mob/living/silicon/robot/robot = player
+			if (!robot.connected_ai)
+				if (robot.stat != DEAD)
+					robot_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [robot.name] (Played by: [get_key(robot)]) survived as an AI-less [isMoMMI(robot)?"MoMMI":"borg"]! Its laws were:</b>"}
+				else
+					robot_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [robot.name] (Played by: [get_key(robot)]) was unable to survive the rigors of being a [isMoMMI(robot)?"MoMMI":"cyborg"] without an AI. Its laws were:</b>"}
+			else
+				robot_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [robot.name] (Played by: [get_key(robot)]) [robot.stat!=DEAD?"survived":"perished"] as a [isMoMMI(robot)?"MoMMI":"cyborg"] slaved to [robot.connected_ai]! Its laws were:</b>"}
+			robot_completions += "<br>[player.write_laws()]"
+
+		else if(istype(player, /mob/living/silicon/pai))
+			var/mob/living/silicon/pai/pAI = player
+			pai_completions += {"<br><b><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> [pAI.name] (Played by: [get_key(pAI)]) [pAI.stat!=DEAD?"survived":"perished"] as a pAI whose master was [pAI.master]! Its directives were:</b><br>[pAI.write_directives()]"}
 
 	var/siliconpoints = score.deadsilicon * 500 //Silicons certainly aren't either
 	var/multi = find_active_faction_by_type(/datum/faction/malf) ? 1 : -1 //Dead silicons on malf are good
@@ -163,8 +160,11 @@
 	if(score.deadaipenalty)
 		score.crewscore += 1000*multi //Give a harsh punishment for killing the AI
 	
-	if(ai_completions)
+	if(ai_completions || robot_completions || pai_completions)
 		completions += "<h2>Silicons Laws</h2>"
 		completions += ai_completions
+		completions += robot_completions
+		completions += pai_completions
 		completions += "<HR>"
-		return completions
+		
+	return completions

--- a/code/game/gamemodes/endgame/scoreboard/misc_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/misc_score.dm
@@ -1,7 +1,7 @@
 /datum/controller/gameticker/scoreboard/proc/misc_score()
 	var/completions = ""
-	score.crewscore -= round(turfssingulod/2)
 
+	//Painting
 	var/list/gallery = score.global_paintings
 	var/painting_completions = ""
 	if(gallery.len) //the list of all artworks
@@ -51,38 +51,38 @@
 	var/list/rich_escapes = list()
 
 	for(var/mob/living/player in player_list)
-		if(player.stat != DEAD)
-			var/turf/T = get_turf(player)
-			if(!T)
-				continue
+		if(player.stat == DEAD)
+			continue
+		var/turf/T = get_turf(player)
+		if(!T)
+			continue
+		if(istype(T.loc, /area/shuttle/escape/centcom) || istype(T.loc, /area/shuttle/escape_pod1/centcom) || istype(T.loc, /area/shuttle/escape_pod2/centcom) || istype(T.loc, /area/shuttle/escape_pod3/centcom) || istype(T.loc, /area/shuttle/escape_pod5/centcom))
+			score.escapees++
+			var/cashscore = 0
+			var/dmgscore = 0
 
-			if(istype(T.loc, /area/shuttle/escape/centcom) || istype(T.loc, /area/shuttle/escape_pod1/centcom) || istype(T.loc, /area/shuttle/escape_pod2/centcom) || istype(T.loc, /area/shuttle/escape_pod3/centcom) || istype(T.loc, /area/shuttle/escape_pod5/centcom))
-				score.escapees++
-				var/cashscore = 0
-				var/dmgscore = 0
+			for(var/obj/item/weapon/card/id/C1 in get_contents_in_object(player, /obj/item/weapon/card/id))
+				cashscore += C1.GetBalance() //From bank account
+				if(istype(C1.virtual_wallet))
+					cashscore += C1.virtual_wallet.money
 
-				for(var/obj/item/weapon/card/id/C1 in get_contents_in_object(player, /obj/item/weapon/card/id))
-					cashscore += C1.GetBalance() //From bank account
-					if(istype(C1.virtual_wallet))
-						cashscore += C1.virtual_wallet.money
+			for(var/obj/item/weapon/spacecash/C2 in get_contents_in_object(player, /obj/item/weapon/spacecash))
+				cashscore += (C2.amount * C2.worth)
 
-				for(var/obj/item/weapon/spacecash/C2 in get_contents_in_object(player, /obj/item/weapon/spacecash))
-					cashscore += (C2.amount * C2.worth)
+			var/datum/record/money/record = new(player.key, player.job, cashscore)
+			rich_escapes += record
 
-				var/datum/record/money/record = new(player.key, player.job, cashscore)
-				rich_escapes += record
-
-				if(cashscore > score.richestcash)
-					score.richestcash = cashscore
-					score.richestname = player.real_name
-					score.richestjob = player.job
-					score.richestkey = player.key
-				dmgscore = player.bruteloss + player.fireloss + player.toxloss + player.oxyloss
-				if(dmgscore > score.dmgestdamage)
-					score.dmgestdamage = dmgscore
-					score.dmgestname = player.real_name
-					score.dmgestjob = player.job
-					score.dmgestkey = player.key
+			if(cashscore > score.richestcash)
+				score.richestcash = cashscore
+				score.richestname = player.real_name
+				score.richestjob = player.job
+				score.richestkey = player.key
+			dmgscore = player.bruteloss + player.fireloss + player.toxloss + player.oxyloss
+			if(dmgscore > score.dmgestdamage)
+				score.dmgestdamage = dmgscore
+				score.dmgestname = player.real_name
+				score.dmgestjob = player.job
+				score.dmgestkey = player.key
 		if(player.hangman_score > score.hangmanrecord)
 			score.hangmanrecord = player.hangman_score
 			score.hangmanname = player.real_name
@@ -92,20 +92,9 @@
 			for(var/thing in player.attack_log)
 				if(findtext(thing, "<font color='orange'>")) //I just dropped 10 IQ points from seeing this
 					score.clownabuse++
-
+	//Money
 	var/datum/persistence_task/highscores/leaderboard = score.money_leaderboard
 	leaderboard.insert_records(rich_escapes)
-
-	score.time = round(world.time/10) //One point for every five seconds. One minute is 12 points, one hour 720 points
-
-	for(var/mob/living/simple_animal/SA in dead_mob_list)
-		if(SA.is_pet)
-			score.deadpets++
-
-	score.crewscore -= score.deadcrew * 250 //Human beans aren't free
-	score.crewscore += score.eventsendured * 200 //Events fine every 10 to 15 and are uncommon
-	score.crewscore += score.escapees * 100 //Two rescued human beans are worth a dead one
-	score.arenafights = arena_rounds
 
 	var/transfer_total = 0
 	for(var/datum/money_account/A in all_money_accounts)
@@ -113,7 +102,18 @@
 			var/amt = text2num(T.amount)
 			if(amt <= 0) // This way we don't track payouts or starting funds, only money transferred to terminals or between players
 				transfer_total += abs(amt)
+
 	score.totaltransfer = transfer_total
+
+	for(var/mob/living/simple_animal/SA in dead_mob_list)
+		if(SA.is_pet)
+			score.deadpets++
+
+	score.time = round(world.time/10) //One point for every five seconds. One minute is 12 points, one hour 720 points
+	score.crewscore -= score.deadcrew * 250 //Human beans aren't free
+	score.crewscore += score.eventsendured * 200 //Events fine every 10 to 15 and are uncommon
+	score.crewscore += score.escapees * 100 //Two rescued human beans are worth a dead one
+	score.arenafights = arena_rounds
 
 	arena_top_score = 0
 	for(var/x in arena_leaderboard)

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -117,8 +117,8 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	return
 
 /datum/controller/gameticker/scoreboard/proc/display()
-	var/dat = "<BR><h2>Round Statistics and Score</h2>"
-	dat += "<B><U>GENERAL STATS</U></B><BR>
+	var/dat = "<h2>Round Statistics and Score</h2>"
+	dat += "<B><U>GENERAL STATS</U></B><BR>"
 	dat += "<U>THE GOOD:</U><BR>"
 	dat += "<B>Length of Shift:</B> [round(world.time/600)] Minutes ([round(score.time * 0.2)] Points)<BR>"
 	dat += "<B>Shuttle Escapees:</B> [score.escapees] ([score.escapees * 100] Points)<BR>"
@@ -133,9 +133,9 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 		dat += "<B>Plasma Shipped:</B> [score.plasmashipped] ([score.plasmashipped * 0.5] Points)<BR>"
 	if(score.stuffshipped > 0)
 		dat += "<B>Centcom Orders Fulfilled:</B> [score.stuffshipped] ([score.stuffshipped * 100] Points)<BR>"
-	if(score.oresmined > 0)
+	if(score.oremined > 0)
 		dat += "<B>Ore Smelted:</B> [score.oremined] ([score.oremined] Points)<BR>"
-	dat += "<B>Whole Station Powered:</B> [score.powerbonus ? "Yes" : "No"] ([score.powerbonus] Points)<BR>
+	dat += "<B>Whole Station Powered:</B> [score.powerbonus ? "Yes" : "No"] ([score.powerbonus] Points)<BR>"
 	if (score.disease_vaccine_score > 0)
 		dat += "<B>Isolated Vaccines:</B> [score.disease_vaccine] ([score.disease_vaccine_score] Points)<BR>"
 	if (score.disease_extracted > 0)
@@ -161,12 +161,12 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 		"<B>Bad diseases in living mobs:</B> [score.disease_bad] (-[score.disease_bad * 50] Points)<BR><BR>"
 
 	dat += "<U>THE WEIRD</U><BR>"
-/*	<B>Final Station Budget:</B> $[num2text(totalfunds,50)]<BR>"}
+/*	<B>Final Station Budget:</B> $[num2text(totalfunds,50)]<BR>"
 	var/profit = totalfunds - 100000
 	if (profit > 0)
 		dat += "<B>Station Profit:</B> +[num2text(profit,50)]<BR>"
 	else if (profit < 0)
-		dat += "<B>Station Deficit:</B> [num2text(profit,50)]<BR>"}*/
+		dat += "<B>Station Deficit:</B> [num2text(profit,50)]<BR>"*/
 	if(score.foodeaten > 0)
 		dat += "<B>Food Eaten:</b> [score.foodeaten]<BR>"
 	if(score.clownabuse > 0)
@@ -246,8 +246,8 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	for (var/i = 1 to dept_leaderboard.len)
 		dat += "<B>#[i] - </B>[dept_leaderboard[i]] ($[dept_leaderboard[dept_leaderboard[i]]])<BR>"
 
-	dat += {"<HR><BR>
-	<B><U>FINAL SCORE: [score.crewscore]</U></B><BR>"}
+	dat += "<HR><BR>
+	dat += <B><U>FINAL SCORE: [score.crewscore]</U></B><BR>"
 	score.rating = "A Rating"
 
 	switch(score.crewscore)

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -154,7 +154,8 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 		dat += "<B>AIs Destroyed:</B> [score.deadaipenalty] ([find_active_faction_by_type(/datum/faction/malf) ? score.deadaipenalty * 1000 : score.deadaipenalty * -1000] Points)<BR>"
 	dat += "<B>Uncleaned Messes:</B> [score.mess] (-[score.mess] Points)<BR>"
 	dat += "<B>Trash on Station:</B> [score.litter] (-[score.litter] Points)<BR>"
-	dat += "<B>Station Power Issues:</B> [score.powerloss] (-[score.powerloss * 50] Points)<BR>"
+	if (score.station_powerloss > 0)
+		dat += "<B>Station Power Issues:</B> [score.powerloss] (-[score.powerloss * 50] Points)<BR>"
 	if(score.turfssingulod > 0)
 		dat += "<B>Tiles destroyed by a singularity:</B> [score.turfssingulod] (-[round(score.turfssingulod/2)] Points)<BR>"
 	if(score.disease_bad > 0)

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -154,7 +154,7 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 		dat += "<B>AIs Destroyed:</B> [score.deadaipenalty] ([find_active_faction_by_type(/datum/faction/malf) ? score.deadaipenalty * 1000 : score.deadaipenalty * -1000] Points)<BR>"
 	dat += "<B>Uncleaned Messes:</B> [score.mess] (-[score.mess] Points)<BR>"
 	dat += "<B>Trash on Station:</B> [score.litter] (-[score.litter] Points)<BR>"
-	if (score.station_powerloss > 0)
+	if (score.powerloss > 0)
 		dat += "<B>Station Power Issues:</B> [score.powerloss] (-[score.powerloss * 50] Points)<BR>"
 	if(score.turfssingulod > 0)
 		dat += "<B>Tiles destroyed by a singularity:</B> [score.turfssingulod] (-[round(score.turfssingulod/2)] Points)<BR>"

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -84,7 +84,7 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	var/datum/faction/revolution/RV = find_active_faction_by_type(/datum/faction/revolution)
 
 	ticker.mode.declare_completion()
-	dat += "[ticker.mode.dat]<HR>" //figure this out
+	dat += "[ticker.mode.dat]<HR>"
 
 	//populate scores
 	dat += medbay_score()
@@ -117,48 +117,68 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	return
 
 /datum/controller/gameticker/scoreboard/proc/display()
-	var/dat = {"<BR><h2>Round Statistics and Score</h2>"}
-	dat += {"<B><U>GENERAL STATS</U></B><BR>
+	var/dat = "<BR><h2>Round Statistics and Score</h2>"
+	dat += "<B><U>GENERAL STATS</U></B><BR>
+	dat += "<U>THE GOOD:</U><BR>"
+	dat += "<B>Length of Shift:</B> [round(world.time/600)] Minutes ([round(score.time * 0.2)] Points)<BR>"
+	dat += "<B>Shuttle Escapees:</B> [score.escapees] ([score.escapees * 100] Points)<BR>"
+	if(score.eventsendured > 0)
+		dat += "<B>Random Events Endured:</B> [score.eventsendured] ([score.eventsendured * 200] Points)<BR>"
+	if(score.meals > 0)
+		dat += "<B>Meals Prepared:</B> [score.meals] ([score.meals * 5] Points)<BR>"
+	if(score.stuffharvested > 0)
+		dat += "<B>Hydroponics Harvests:</B> [score.stuffharvested] ([score.stuffharvested] Points)<BR>"
+	dat += "<B>Ultra-Clean Station:</B> [score.messbonus ? "Yes" : "No"] ([score.messbonus] Points)<BR>"
+	if(score.plasmashipped > 0)
+		dat += "<B>Plasma Shipped:</B> [score.plasmashipped] ([score.plasmashipped * 0.5] Points)<BR>"
+	if(score.stuffshipped > 0)
+		dat += "<B>Centcom Orders Fulfilled:</B> [score.stuffshipped] ([score.stuffshipped * 100] Points)<BR>"
+	if(score.oresmined > 0)
+		dat += "<B>Ore Smelted:</B> [score.oremined] ([score.oremined] Points)<BR>"
+	dat += "<B>Whole Station Powered:</B> [score.powerbonus ? "Yes" : "No"] ([score.powerbonus] Points)<BR>
+	if (score.disease_vaccine_score > 0)
+		dat += "<B>Isolated Vaccines:</B> [score.disease_vaccine] ([score.disease_vaccine_score] Points)<BR>"
+	if (score.disease_extracted > 0)
+		dat += "<B>Extracted Symptoms:</B> [score.disease_extracted] ([score.disease_effects] Points)<BR>"
+	if (score.slimes > 0)
+		dat += "<B>Harvested Slimes:</B> [score.slimes] ([score.slimes * 20] Points)<BR><BR>"
+	if (score.artifacts > 0)
+		dat += "<B>Analyzed & Activated Large Artifacts:</B> [score.artifacts] ([score.artifacts * 400] Points)<BR><BR>"
 
-	<U>THE GOOD:</U><BR>
-	<B>Length of Shift:</B> [round(world.time/600)] Minutes ([round(score.time * 0.2)] Points)<BR>
-	<B>Shuttle Escapees:</B> [score.escapees] ([score.escapees * 100] Points)<BR>
-	<B>Random Events Endured:</B> [score.eventsendured] ([score.eventsendured * 200] Points)<BR>
-	<B>Meals Prepared:</B> [score.meals] ([score.meals * 5] Points)<BR>
-	<B>Hydroponics Harvests:</B> [score.stuffharvested] ([score.stuffharvested] Points)<BR>
-	<B>Ultra-Clean Station:</B> [score.messbonus ? "Yes" : "No"] ([score.messbonus] Points)<BR>
-	<B>Plasma Shipped:</B> [score.plasmashipped] ([score.plasmashipped * 0.5] Points)<BR>
-	<B>Centcom Orders Fulfilled:</B> [score.stuffshipped] ([score.stuffshipped * 100] Points)<BR>
-	<B>Ore Smelted:</B> [score.oremined] ([score.oremined] Points)<BR>
-	<B>Whole Station Powered:</B> [score.powerbonus ? "Yes" : "No"] ([score.powerbonus] Points)<BR>
-	<B>Isolated Vaccines:</B> [score.disease_vaccine] ([score.disease_vaccine_score] Points)<BR>
-	<B>Extracted Symptoms:</B> [score.disease_extracted] ([score.disease_effects] Points)<BR>
-	<B>Harvested Slimes:</B> [score.slimes] ([score.slimes * 20] Points)<BR><BR>
-	<B>Analyzed & Activated Large Artifacts:</B> [score.artifacts] ([score.artifacts * 400] Points)<BR><BR>
+	dat += "<U>THE BAD:</U><BR>"
+	if (score.deadcrew > 0)
+		dat += "<B>Dead Crewmen:</B> [score.deadcrew] (-[score.deadcrew * 250] Points)<BR>"
+	if (score.deadsilicon > 0)
+		dat += "<B>Destroyed Silicons:</B> [score.deadsilicon] ([find_active_faction_by_type(/datum/faction/malf) ? score.deadsilicon * 500 : score.deadsilicon * -500] Points)<BR>"
+	if (score.deadaipenalty > 0)
+		dat += "<B>AIs Destroyed:</B> [score.deadaipenalty] ([find_active_faction_by_type(/datum/faction/malf) ? score.deadaipenalty * 1000 : score.deadaipenalty * -1000] Points)<BR>"
+	dat += "<B>Uncleaned Messes:</B> [score.mess] (-[score.mess] Points)<BR>"
+	dat += "<B>Trash on Station:</B> [score.litter] (-[score.litter] Points)<BR>"
+	dat += "<B>Station Power Issues:</B> [score.powerloss] (-[score.powerloss * 50] Points)<BR>"
+	if(score.turfssingulod > 0)
+		dat += "<B>Tiles destroyed by a singularity:</B> [score.turfssingulod] (-[round(score.turfssingulod/2)] Points)<BR>"
+	if(score.disease_bad > 0)
+		"<B>Bad diseases in living mobs:</B> [score.disease_bad] (-[score.disease_bad * 50] Points)<BR><BR>"
 
-	<U>THE BAD:</U><BR>
-	<B>Dead Crewmen:</B> [score.deadcrew] (-[score.deadcrew * 250] Points)<BR>
-	<B>Destroyed Silicons:</B> [score.deadsilicon] ([find_active_faction_by_type(/datum/faction/malf) ? score.deadsilicon * 500 : score.deadsilicon * -500] Points)<BR>
-	<B>AIs Destroyed:</B> [score.deadaipenalty] ([find_active_faction_by_type(/datum/faction/malf) ? score.deadaipenalty * 1000 : score.deadaipenalty * -1000] Points)<BR>
-	<B>Uncleaned Messes:</B> [score.mess] (-[score.mess] Points)<BR>
-	<B>Trash on Station:</B> [score.litter] (-[score.litter] Points)<BR>
-	<B>Station Power Issues:</B> [score.powerloss] (-[score.powerloss * 50] Points)<BR>
-	<B>Tiles destroyed by a singularity:</B> [score.turfssingulod] (-[round(score.turfssingulod/2)] Points)<BR>
-	<B>Bad diseases in living mobs:</B> [score.disease_bad] (-[score.disease_bad * 50] Points)<BR><BR>
-
-	<U>THE WEIRD</U><BR>"}
+	dat += "<U>THE WEIRD</U><BR>"
 /*	<B>Final Station Budget:</B> $[num2text(totalfunds,50)]<BR>"}
 	var/profit = totalfunds - 100000
 	if (profit > 0)
 		dat += "<B>Station Profit:</B> +[num2text(profit,50)]<BR>"
 	else if (profit < 0)
 		dat += "<B>Station Deficit:</B> [num2text(profit,50)]<BR>"}*/
-	dat += "<B>Food Eaten:</b> [score.foodeaten]<BR>"
-	dat += "<B>Times a Clown was Abused:</B> [score.clownabuse]<BR>"
-	dat += "<B>Number of Times Someone was Slipped: </B> [score.slips]<BR>"
-	dat += "<B>Number of Explosions This Shift:</B> [score.explosions]<BR>"
-	dat += "<B>Number of Arena Rounds:</B> [score.arenafights]<BR>"
-	dat += "<B>Total money transferred:</B> [score.totaltransfer]<BR>"
+	if(score.foodeaten > 0)
+		dat += "<B>Food Eaten:</b> [score.foodeaten]<BR>"
+	if(score.clownabuse > 0)
+		dat += "<B>Times a Clown was Abused:</B> [score.clownabuse]<BR>"
+	if(score.slips > 0)
+		dat += "<B>Number of Times Someone was Slipped: </B> [score.slips]<BR>"
+	if(score.explosions > 0)
+		dat += "<B>Number of Explosions This Shift:</B> [score.explosions]<BR>"
+	if(score.arenafights > 0)
+		dat += "<B>Number of Arena Rounds:</B> [score.arenafights]<BR>"
+	if(score.totaltransfer > 0)
+		dat += "<B>Total money transferred:</B> [score.totaltransfer]<BR>"
 	if(score.dimensionalpushes > 0)
 		dat += "<B>Dimensional Pushes:</B> [score.dimensionalpushes]<BR>"
 	if(score.assesblasted > 0)
@@ -227,7 +247,6 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 		dat += "<B>#[i] - </B>[dept_leaderboard[i]] ($[dept_leaderboard[dept_leaderboard[i]]])<BR>"
 
 	dat += {"<HR><BR>
-
 	<B><U>FINAL SCORE: [score.crewscore]</U></B><BR>"}
 	score.rating = "A Rating"
 

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -158,7 +158,7 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	if(score.turfssingulod > 0)
 		dat += "<B>Tiles destroyed by a singularity:</B> [score.turfssingulod] (-[round(score.turfssingulod/2)] Points)<BR>"
 	if(score.disease_bad > 0)
-		"<B>Bad diseases in living mobs:</B> [score.disease_bad] (-[score.disease_bad * 50] Points)<BR><BR>"
+		dat += "<B>Bad diseases in living mobs:</B> [score.disease_bad] (-[score.disease_bad * 50] Points)<BR><BR>"
 
 	dat += "<U>THE WEIRD</U><BR>"
 /*	<B>Final Station Budget:</B> $[num2text(totalfunds,50)]<BR>"
@@ -246,8 +246,8 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	for (var/i = 1 to dept_leaderboard.len)
 		dat += "<B>#[i] - </B>[dept_leaderboard[i]] ($[dept_leaderboard[dept_leaderboard[i]]])<BR>"
 
-	dat += "<HR><BR>
-	dat += <B><U>FINAL SCORE: [score.crewscore]</U></B><BR>"
+	dat += "<HR><BR>"
+	dat += "<B><U>FINAL SCORE: [score.crewscore]</U></B><BR>"
 	score.rating = "A Rating"
 
 	switch(score.crewscore)


### PR DESCRIPTION
* Fixed small thing with antag implants (forgot the return for the proc)
* Redid the silicon scoreboard to minimize looping
* Improved readability

Does it make a difference? Probably very minimal. Working on roundend nuke stuff so the rock cooks faster -- as it is currently implemented, it takes 30+ seconds after the nuke goes off for the cooking