### PR TITLE
Allows merch computer food to be poisoned by does not tip backdoor

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -149,7 +149,7 @@
 				EFFECT_DANGER_DEADLY	= 0,
 				)
 
-			new_virus.origin = "Poisoned Pizza"
+			new_virus.origin = "Poisoned [name]"
 
 			new_virus.makerandom(list(40,60),list(20,90),anti,bad,src)
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -108,8 +108,61 @@
 
 	return
 
-/obj/item/weapon/reagent_containers/food/snacks/proc/make_poisonous()
-	return
+/obj/item/weapon/reagent_containers/food/snacks/proc/make_poisonous(var/list/additional_poisons)
+	var/original_total_volume = reagents.total_volume
+	reagents.clear_reagents()
+	if(prob(50))
+		var/virus_choice = pick(subtypesof(/datum/disease2/disease) - typesof(/datum/disease2/disease/predefined))
+		var/datum/disease2/disease/new_virus = new virus_choice
+
+		var/list/anti = list(
+			ANTIGEN_BLOOD	= 0,
+			ANTIGEN_COMMON	= 1,
+			ANTIGEN_RARE	= 2,
+			ANTIGEN_ALIEN	= 0,
+			)
+		var/list/bad = list(
+			EFFECT_DANGER_HELPFUL	= 0,
+			EFFECT_DANGER_FLAVOR	= 0,
+			EFFECT_DANGER_ANNOYING	= 1,
+			EFFECT_DANGER_HINDRANCE	= 2,
+			EFFECT_DANGER_HARMFUL	= 4,
+			EFFECT_DANGER_DEADLY	= 0,
+			)
+
+		new_virus.origin = "Poisoned Pizza"
+
+		new_virus.makerandom(list(40,60),list(20,90),anti,bad,src)
+
+		var/list/blood_data = list(
+			"viruses" = null,
+			"blood_DNA" = null,
+			"blood_type" = "O-",
+			"resistances" = null,
+			"trace_chem" = null,
+			"virus2" = list()
+		)
+		blood_data["virus2"]["[new_virus.uniqueID]-[new_virus.subID]"] = new_virus
+		reagents.add_reagent(BLOOD, original_total_volume, blood_data)
+	else
+		var/static/list/possible_poisons = list(
+			BLEACH,
+			PLASMA,
+			TOXIN,
+			SOLANINE,
+			PLASTICIDE,
+			RADIUM,
+			CRYPTOBIOLIN,
+			IMPEDREZENE,
+			SOYSAUCE,
+			MINDBREAKER,
+			SPIRITBREAKER,
+			MUTAGEN,
+		)
+		if(additional_poisons && additional_poisons.len)
+			possible_poisons += additional_poisons.Copy()
+		while(reagents.total_volume < original_total_volume)
+			reagents.add_reagent(pick(possible_poisons), rand(5, 10))
 
 /obj/item/weapon/reagent_containers/food/snacks/should_qdel_if_empty()
 	return TRUE
@@ -3626,23 +3679,6 @@
 	reagents.add_reagent(TOMATOJUICE, 6)
 	bitesize = 2
 
-/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/margherita/make_poisonous()
-	var/original_total_volume = reagents.total_volume
-	reagents.clear_reagents()
-	var/static/list/possible_poisons = list(
-		BLEACH,
-		PLASMA,
-		TOXIN,
-		SOLANINE,
-		PLASTICIDE,
-		RADIUM,
-		CRYPTOBIOLIN,
-		IMPEDREZENE,
-		SOYSAUCE
-	)
-	while(reagents.total_volume < original_total_volume)
-		reagents.add_reagent(pick(possible_poisons), rand(5, 10))
-
 /obj/item/weapon/reagent_containers/food/snacks/margheritaslice
 	name = "Margherita slice"
 	desc = "A slice of the most cheesy pizza in galaxy."
@@ -3663,43 +3699,6 @@
 	reagents.add_reagent(NUTRIMENT, 50)
 	reagents.add_reagent(TOMATOJUICE, 6)
 	bitesize = 2
-
-/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/meatpizza/make_poisonous()
-	var/original_total_volume = reagents.total_volume
-	reagents.clear_reagents()
-
-	var/virus_choice = pick(subtypesof(/datum/disease2/disease) - typesof(/datum/disease2/disease/predefined))
-	var/datum/disease2/disease/new_virus = new virus_choice
-
-	var/list/anti = list(
-		ANTIGEN_BLOOD	= 0,
-		ANTIGEN_COMMON	= 1,
-		ANTIGEN_RARE	= 2,
-		ANTIGEN_ALIEN	= 0,
-		)
-	var/list/bad = list(
-		EFFECT_DANGER_HELPFUL	= 0,
-		EFFECT_DANGER_FLAVOR	= 0,
-		EFFECT_DANGER_ANNOYING	= 1,
-		EFFECT_DANGER_HINDRANCE	= 2,
-		EFFECT_DANGER_HARMFUL	= 4,
-		EFFECT_DANGER_DEADLY	= 0,
-		)
-
-	new_virus.origin = "Poisoned Pizza"
-
-	new_virus.makerandom(list(40,60),list(20,90),anti,bad,src)
-
-	var/list/blood_data = list(
-		"viruses" = null,
-		"blood_DNA" = null,
-		"blood_type" = "O-",
-		"resistances" = null,
-		"trace_chem" = null,
-		"virus2" = list()
-	)
-	blood_data["virus2"]["[new_virus.uniqueID]-[new_virus.subID]"] = new_virus
-	reagents.add_reagent(BLOOD, original_total_volume, blood_data)
 
 /obj/item/weapon/reagent_containers/food/snacks/meatpizzaslice
 	name = "Meatpizza slice"
@@ -3740,15 +3739,6 @@
 	reagents.add_reagent(NUTRIMENT, 35)
 	bitesize = 2
 
-/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/mushroompizza/make_poisonous()
-	var/original_total_volume = reagents.total_volume
-	reagents.clear_reagents()
-	var/static/list/possible_poisons = list(
-		MINDBREAKER,
-		SPIRITBREAKER
-	)
-	reagents.add_reagent(pick(possible_poisons), original_total_volume)
-
 /obj/item/weapon/reagent_containers/food/snacks/mushroompizzaslice
 	name = "Mushroompizza slice"
 	desc = "Maybe it's the last slice of pizza in your life."
@@ -3770,11 +3760,6 @@
 	reagents.add_reagent(TOMATOJUICE, 6)
 	reagents.add_reagent(IMIDAZOLINE, 12)
 	bitesize = 2
-
-/obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/vegetablepizza/make_poisonous()
-	var/original_total_volume = reagents.total_volume
-	reagents.clear_reagents()
-	reagents.add_reagent(MUTAGEN, original_total_volume)
 
 /obj/item/weapon/reagent_containers/food/snacks/vegetablepizzaslice
 	name = "Vegetable pizza slice"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -111,58 +111,60 @@
 /obj/item/weapon/reagent_containers/food/snacks/proc/make_poisonous(var/list/additional_poisons)
 	var/original_total_volume = reagents.total_volume
 	reagents.clear_reagents()
-	if(prob(50))
-		var/virus_choice = pick(subtypesof(/datum/disease2/disease) - typesof(/datum/disease2/disease/predefined))
-		var/datum/disease2/disease/new_virus = new virus_choice
+	var/static/list/possible_poisons = list(
+		BLEACH,
+		PLASMA,
+		TOXIN,
+		SOLANINE,
+		PLASTICIDE,
+		RADIUM,
+		CRYPTOBIOLIN,
+		IMPEDREZENE,
+		SOYSAUCE,
+		MINDBREAKER,
+		SPIRITBREAKER,
+		MUTAGEN,
+		BLOOD,
+	)
+	if(additional_poisons && additional_poisons.len)
+		possible_poisons += additional_poisons.Copy()
+	while(reagents.total_volume < original_total_volume)
+		var/ourpoison = pick(possible_poisons)
+		if(ourpoison == BLOOD)
+			var/virus_choice = pick(subtypesof(/datum/disease2/disease) - typesof(/datum/disease2/disease/predefined))
+			var/datum/disease2/disease/new_virus = new virus_choice
 
-		var/list/anti = list(
-			ANTIGEN_BLOOD	= 0,
-			ANTIGEN_COMMON	= 1,
-			ANTIGEN_RARE	= 2,
-			ANTIGEN_ALIEN	= 0,
+			var/list/anti = list(
+				ANTIGEN_BLOOD	= 0,
+				ANTIGEN_COMMON	= 1,
+				ANTIGEN_RARE	= 2,
+				ANTIGEN_ALIEN	= 0,
+				)
+			var/list/bad = list(
+				EFFECT_DANGER_HELPFUL	= 0,
+				EFFECT_DANGER_FLAVOR	= 0,
+				EFFECT_DANGER_ANNOYING	= 1,
+				EFFECT_DANGER_HINDRANCE	= 2,
+				EFFECT_DANGER_HARMFUL	= 4,
+				EFFECT_DANGER_DEADLY	= 0,
+				)
+
+			new_virus.origin = "Poisoned Pizza"
+
+			new_virus.makerandom(list(40,60),list(20,90),anti,bad,src)
+
+			var/list/blood_data = list(
+				"viruses" = null,
+				"blood_DNA" = null,
+				"blood_type" = "O-",
+				"resistances" = null,
+				"trace_chem" = null,
+				"virus2" = list()
 			)
-		var/list/bad = list(
-			EFFECT_DANGER_HELPFUL	= 0,
-			EFFECT_DANGER_FLAVOR	= 0,
-			EFFECT_DANGER_ANNOYING	= 1,
-			EFFECT_DANGER_HINDRANCE	= 2,
-			EFFECT_DANGER_HARMFUL	= 4,
-			EFFECT_DANGER_DEADLY	= 0,
-			)
-
-		new_virus.origin = "Poisoned Pizza"
-
-		new_virus.makerandom(list(40,60),list(20,90),anti,bad,src)
-
-		var/list/blood_data = list(
-			"viruses" = null,
-			"blood_DNA" = null,
-			"blood_type" = "O-",
-			"resistances" = null,
-			"trace_chem" = null,
-			"virus2" = list()
-		)
-		blood_data["virus2"]["[new_virus.uniqueID]-[new_virus.subID]"] = new_virus
-		reagents.add_reagent(BLOOD, original_total_volume, blood_data)
-	else
-		var/static/list/possible_poisons = list(
-			BLEACH,
-			PLASMA,
-			TOXIN,
-			SOLANINE,
-			PLASTICIDE,
-			RADIUM,
-			CRYPTOBIOLIN,
-			IMPEDREZENE,
-			SOYSAUCE,
-			MINDBREAKER,
-			SPIRITBREAKER,
-			MUTAGEN,
-		)
-		if(additional_poisons && additional_poisons.len)
-			possible_poisons += additional_poisons.Copy()
-		while(reagents.total_volume < original_total_volume)
-			reagents.add_reagent(pick(possible_poisons), rand(5, 10))
+			blood_data["virus2"]["[new_virus.uniqueID]-[new_virus.subID]"] = new_virus
+			reagents.add_reagent(ourpoison, rand(5, 10), blood_data)
+		else
+			reagents.add_reagent(ourpoison, rand(5, 10))
 
 /obj/item/weapon/reagent_containers/food/snacks/should_qdel_if_empty()
 	return TRUE

--- a/code/modules/store/items.dm
+++ b/code/modules/store/items.dm
@@ -15,8 +15,20 @@
 		var/obj/item/weapon/storage/S = thing
 		user.put_in_hands(S)
 		if(station_does_not_tip)
+			var/list/additional_types = list(
+				IRRADIATEDBEANS,
+				MUTATEDBEANS,
+				CHEESYGLOOP,
+				DIABEETUSOL,
+				HORSEMEAT,
+				BEFF,
+				TOXICWASTE,
+				MOONROCKS,
+			)
+			if(istype(S,/obj/item/weapon/storage/bag/zam_food/))
+				additional_types.Add(WATER) //Bad for greys
 			for(var/obj/item/weapon/reagent_containers/food/snacks/F in S)
-				F.make_poisonous()
+				F.make_poisonous(additional_types)
 
 //If this returns FALSE, then the button simply will not appear for the user in question.
 /datum/storeitem/proc/available_to_user(mob/user)

--- a/code/modules/store/items.dm
+++ b/code/modules/store/items.dm
@@ -10,11 +10,13 @@
 	var/category = "Misc"
 
 /datum/storeitem/proc/deliver(var/mob/user,var/obj/machinery/computer/merch/merchcomp)
+	var/thing = new typepath(merchcomp.loc)
 	if(istype(typepath,/obj/item/weapon/storage))
-		var/thing = new typepath(merchcomp.loc)
-		user.put_in_hands(thing)
-	else
-		new typepath(merchcomp.loc)
+		var/obj/item/weapon/storage/S = thing
+		user.put_in_hands(S)
+		if(station_does_not_tip)
+			for(var/obj/item/weapon/reagent_containers/food/snacks/F in S)
+				F.make_poisonous()
 
 //If this returns FALSE, then the button simply will not appear for the user in question.
 /datum/storeitem/proc/available_to_user(mob/user)

--- a/code/modules/store/store.dm
+++ b/code/modules/store/store.dm
@@ -73,8 +73,7 @@ var/global/datum/store/centcomm_store
 	if(!charge(user,item.cost,item,merchcomp))
 		return 0
 	// Give them the item.
-	var/atom/movable/ouritem = item.deliver(user,merchcomp)
-	item.post_delivery(ouritem)
+	item.deliver(user,merchcomp)
 	if(item.stock != -1)
 		item.stock--
 	return 1

--- a/code/modules/store/store.dm
+++ b/code/modules/store/store.dm
@@ -73,7 +73,8 @@ var/global/datum/store/centcomm_store
 	if(!charge(user,item.cost,item,merchcomp))
 		return 0
 	// Give them the item.
-	item.deliver(user,merchcomp)
+	var/atom/movable/ouritem = item.deliver(user,merchcomp)
+	item.post_delivery(ouritem)
 	if(item.stock != -1)
 		item.stock--
 	return 1


### PR DESCRIPTION
[content][tweak]
Seemed thematic with cargo.
Also standardised the poisoning of food effects, allowing for more variety with each.

:cl:
 * rscadd: Cargo merch computers are now no longer safe from the "does not tip" backdoor item.