### PR TITLE
Fixes PDA on clown base vault

### DIFF
--- a/maps/randomvaults/clown_base.dmm
+++ b/maps/randomvaults/clown_base.dmm
@@ -121,11 +121,7 @@
 /turf/simulated/floor/light,
 /area/vault/clownbase)
 "D" = (
-/obj/item/device/pda/clown{
-	desc = "A portable microcomputer by Thinktronic Systems, LTD. The surface is coated with polytetrafluoroethylene and banana drippings. This one has been stepped on for too many times, and appears to be completely unresponsible.";
-	mode = -12345;
-	name = "Antique Clown PDA"
-	},
+/obj/item/device/pda/clown/broken,
 /turf/unsimulated/mineral/random,
 /area/vault/clownbase)
 "E" = (

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -986,8 +986,8 @@
 
 /obj/item/device/pda/clown/broken
 	name = "Antique Clown PDA"
-	desc = "A portable microcomputer by Thinktronic Systems, LTD. The surface is coated with polytetrafluoroethylene and banana drippings. This one has been stepped on for too many times, and appears to be completely unresponsible."
+	desc = "A portable microcomputer by Thinktronic Systems, LTD. The surface is coated with polytetrafluoroethylene and banana drippings. This one has been stepped on for too many times, and appears to be completely unresponsive."
 	starting_apps = list()
 
-/obj/item/device/pda/clown/broken/attack_self()
+/obj/item/device/pda/clown/broken/attack_self(mob/user)
 	INVOKE_EVENT(src, /event/item_attack_self, "user" = user) // Minimalist version of original function

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -983,3 +983,11 @@
 /area/vault/mini_station_construction
 	name = "NT Microstation Construction Room"
 	icon_state = "construction"
+
+/obj/item/device/pda/clown/broken
+	name = "Antique Clown PDA"
+	desc = "A portable microcomputer by Thinktronic Systems, LTD. The surface is coated with polytetrafluoroethylene and banana drippings. This one has been stepped on for too many times, and appears to be completely unresponsible."
+	starting_apps = list()
+
+/obj/item/device/pda/clown/broken/attack_self()
+	INVOKE_EVENT(src, /event/item_attack_self, "user" = user) // Minimalist version of original function


### PR DESCRIPTION
[bugfix][vault]
Was causing a runtime when the vault loads in, probably broke its original non-functionality too, so this should be a fix.

:cl:
 * bugfix: Antique clown PDAs are non functional once again