### PR TITLE
Prioritizes in-hand suicide methods over location-based ones

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -39,7 +39,7 @@
 
 /mob/living/proc/handle_suicide_bomb_cause()
 	var/custom_message = input(src, "Enter a cause to dedicate this to, if any.", "For what cause?") as null|text
-	
+
 	if(custom_message)
 		return "FOR [uppertext(custom_message)]!"
 
@@ -116,33 +116,34 @@
 	if(suicide_set && mind)
 		mind.suiciding = 1
 
-	var/list/obj/nearbystuff = list() //Check stuff in front of us
-	for(var/obj/O in get_step(loc,dir))
-		nearbystuff += O
-	log_debug("Nearby stuff in front of [src]: [counted_english_list(nearbystuff)]")
-	while(nearbystuff.len)
-		var/obj/chosen_item = pick_n_take(nearbystuff)
-		if(attempt_object_suicide(chosen_item)) 
-			if(istype(chosen_item,/obj/item))
-				var/obj/item/I = chosen_item
-				put_in_hands(I)
-			return
-	nearbystuff = list()
-	for(var/obj/O in adjacent_atoms(src)) //Failed that, check anything around us
-		nearbystuff += O
-	log_debug("Nearby stuff around [src]: [counted_english_list(nearbystuff)]")
-	while(nearbystuff.len)
-		var/obj/chosen_item = pick_n_take(nearbystuff)
-		if(attempt_object_suicide(chosen_item)) 
-			if(istype(chosen_item,/obj/item))
-				var/obj/item/I = chosen_item
-				put_in_hands(I)
-			return
-	var/obj/item/held_item = get_active_hand() //Failed that too, perform an object in-hand suicide
+	var/obj/item/held_item = get_active_hand() //First, attempt to perform an object in-hand suicide
 	if(!held_item)
 		held_item = get_inactive_hand()
-	log_debug("Held item by [src]: [held_item]")
-	if(!attempt_object_suicide(held_item)) //Failed all of that, go for normal stuff
+
+	if(!attempt_object_suicide(held_item)) //Failed that, attempt alternate methods
+		var/list/obj/nearbystuff = list() //Check stuff in front of us
+		for(var/obj/O in get_step(loc,dir))
+			nearbystuff += O
+		log_debug("Nearby stuff in front of [src]: [counted_english_list(nearbystuff)]")
+		while(nearbystuff.len)
+			var/obj/chosen_item = pick_n_take(nearbystuff)
+			if(attempt_object_suicide(chosen_item))
+				if(istype(chosen_item,/obj/item))
+					var/obj/item/I = chosen_item
+					put_in_hands(I)
+				return
+		nearbystuff = list()
+		for(var/obj/O in adjacent_atoms(src)) //Failed that, check anything around us
+			nearbystuff += O
+		log_debug("Nearby stuff around [src]: [counted_english_list(nearbystuff)]")
+		while(nearbystuff.len)
+			var/obj/chosen_item = pick_n_take(nearbystuff)
+			if(attempt_object_suicide(chosen_item))
+				if(istype(chosen_item,/obj/item))
+					var/obj/item/I = chosen_item
+					put_in_hands(I)
+				return
+		log_debug("Held item by [src]: [held_item]")
 		if(Holiday == APRIL_FOOLS_DAY)
 			visible_message("<span class='danger'>[src] stares above and sees your ugly face! It looks like \he's trying to commit suicide.</span>")
 		else


### PR DESCRIPTION
Fixing what was likely an unintended outcome from #31690. Closes #31917 and closes #31750. 100% tested.

[bugfix]
[tested]

:cl:
 * rscadd: suicide verb now prioritizes held-item suicides over location-based ones.
