### PR TITLE
Typo fix and rewording on frame cartridge description

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -302,7 +302,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/stealthy_weapons/framecart
 	name = "F.R.A.M.E PDA Cartridge"
-	desc = "When inserted into a PDA, gives you four charges allowing you to create a fake uplink on a PDAs of crewmembers who have messaging enabled. This will also use the same unlock code as your uplink if applicable, or else generate a new one. TC can also be inserted into the cartridge to send to the PDA"
+	desc = "When inserted into a PDA, gives you four charges allowing you to create a fake uplink on PDAs of crewmembers who have messaging enabled. The fake uplinks will use the same unlock code as your uplink if applicable, or else generate a new one. TC can also be inserted into the cartridge to send to the PDA"
 	item = /obj/item/weapon/cartridge/syndifake
 	cost = 6
 


### PR DESCRIPTION
[grammar]
:cl:
 * spellcheck: fixes a typo and slightly rewords the F.R.A.M.E. PDA Cartridge description.