### PR TITLE
Allows monkey recyclers to recycle all non-sapient animals

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -914,8 +914,8 @@ to destroy them and players will be able to make replacements.
 							/obj/item/weapon/stock_parts/capacitor = 2)
 
 /obj/item/weapon/circuitboard/monkey_recycler
-	name = "Circuit Board (Monkey Recycler)"
-	desc = "A circuit board used to run a machine that turns dead monkeys into monkey cubes."
+	name = "Circuit Board (Animal Recycler)"
+	desc = "A circuit board used to run a machine that turns dead animals into animal cubes."
 	build_path = /obj/machinery/monkey_recycler
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=2;" + Tc_BIOTECH + "=3;" + Tc_POWERSTORAGE + "=2"

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -57,7 +57,7 @@
 		else
 			var/ourtype = target.type
 			for(var/datum/body_archive/archive in body_archives)
-				if(archive.key = target.key)
+				if(archive.key == target.key)
 					ref_body_archives.Add(archive)
 			qdel(target)
 			playsound(src, 'sound/machines/juicer.ogg', 50, 1)

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -1,6 +1,6 @@
 /obj/machinery/monkey_recycler
-	name = "Monkey Recycler"
-	desc = "A machine used for recycling dead monkeys into monkey cubes."
+	name = "Animal Recycler"
+	desc = "A machine used for recycling dead animals into animal cubes."
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "grinder"
 	density = 1
@@ -9,10 +9,10 @@
 	ghost_read = 0
 	idle_power_usage = 5
 	active_power_usage = 50
-	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK
-	var/grinded = 0
-	var/minimum_monkeys = 3 //How many do we need to grind?
-	var/can_recycle_live = FALSE //Can we recycle a live monkey?
+	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK | EMAGGABLE
+	var/minimum_animals = 3 //How many do we need to grind?
+	var/list/grinded = list(/mob/living/carbon/monkey = 0) //How many of each type are grinded?
+	var/can_recycle_live = FALSE //Can we recycle a live mob?
 
 /obj/machinery/monkey_recycler/New()
 	. = ..()
@@ -35,7 +35,7 @@
 			manipcount += SP.rating
 		if(istype(SP, /obj/item/weapon/stock_parts/micro_laser))
 			lasercount += SP.rating
-	minimum_monkeys = max(1,4 - (manipcount/2)) //Tier 1 = 3, Tier 2 = 2, Tier 3 = 1
+	minimum_animals = max(1,4 - (manipcount/2)) //Tier 1 = 3, Tier 2 = 2, Tier 3 = 1
 	if(lasercount >= 3)
 		can_recycle_live = TRUE
 
@@ -45,18 +45,21 @@
 	process_monkey(O, user)
 
 /obj/machinery/monkey_recycler/conveyor_act(var/atom/movable/AM, var/obj/machinery/conveyor/CB)
-	if(ismonkey(AM))
-		var/mob/living/carbon/monkey/target = AM
+	if(isliving(AM))
+		var/mob/living/target = AM
 		if(target.stat == CONSCIOUS && !can_recycle_live)
+			return FALSE
+		if(ishuman(target) && !emagged)
 			return FALSE
 		if(target.abiotic())
 			return FALSE
 		else
+			var/ourtype = target.type
 			qdel(target)
 			playsound(src, 'sound/machines/juicer.ogg', 50, 1)
 			use_power(500)
-			src.grinded++
-			visible_message("<span class='notice'>The machine now has [grinded] monkeys worth of material stored.</span>")
+			src.grinded[ourtype]++
+			visible_message("<span class='notice'>The machine now has [grinded[ourtype]] worth of material stored for this animal.</span>")
 			return TRUE
 	return FALSE
 
@@ -64,52 +67,68 @@
 	if(istype(O, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/G = O
 		var/grabbed = G.affecting
-		if(ismonkey(grabbed))
-			var/mob/living/carbon/monkey/target = grabbed
+		if(isliving(grabbed))
+			var/mob/living/target = grabbed
+			if(ishuman(target) && !emagged)
+				to_chat(user, "<span class='warning'>\the [target] is too sapient for the recycler.</span>")
+				return
 			if(target.stat == CONSCIOUS && !can_recycle_live)
-				to_chat(user, "<span class='warning'>The monkey is struggling far too much to put it in the recycler.</span>")
+				to_chat(user, "<span class='warning'>\the [target] is struggling far too much to put it in the recycler.</span>")
 				return
 			if(target.abiotic())
-				to_chat(user, "<span class='warning'>The monkey may not have abiotic items on.</span>")
+				to_chat(user, "<span class='warning'>\the [target] may not have abiotic items on.</span>")
 				return
 			else
 				user.drop_item(G, force_drop = 1)
+				var/ourtype = target.type
 				qdel(target)
 				target = null
-				to_chat(user, "<span class='notice'>You stuff the monkey in the machine.")
+				to_chat(user, "<span class='notice'>You stuff \the [target] in the machine.")
 				playsound(src, 'sound/machines/juicer.ogg', 50, 1)
 				use_power(500)
-				src.grinded++
-				to_chat(user, "<span class='notice'>The machine now has [grinded] monkeys worth of material stored.</span>")
+				src.grinded[ourtype]++
+				to_chat(user, "<span class='notice'>The machine now has [grinded[ourtype]] worth of material stored for this animal.</span>")
 		else
-			to_chat(user, "<span class='warning'>The machine only accepts monkeys!</span>")
-	else if(ismonkey(O))
-		var/mob/living/carbon/monkey/target = O
+			to_chat(user, "<span class='warning'>The machine only accepts animals!</span>")
+	else if(isliving(O))
+		var/mob/living/target = O
+		if(ishuman(target) && !emagged)
+			to_chat(user, "<span class='warning'>\the [target] is too sapient for the recycler.</span>")
+			return
 		if(target.stat == CONSCIOUS && !can_recycle_live)
-			to_chat(user, "<span class='warning'>The monkey is struggling far too much to put it in the recycler.</span>")
+			to_chat(user, "<span class='warning'>\the [target] is struggling far too much to put it in the recycler.</span>")
 			return
 		if(target.abiotic())
-			to_chat(user, "<span class='warning'>The monkey may not have abiotic items on.</span>")
+			to_chat(user, "<span class='warning'>\the [target] may not have abiotic items on.</span>")
 			return
 		else
+			var/ourtype = target.type
 			qdel(target)
-			to_chat(user, "<span class='notice'>You stuff the monkey in the machine.</span>")
+			to_chat(user, "<span class='notice'>You stuff \the [target] in the machine.</span>")
 			playsound(src, 'sound/machines/juicer.ogg', 50, 1)
 			use_power(500)
-			src.grinded++
-			to_chat(user, "<span class='notice'>The machine now has [grinded] monkeys worth of material stored.</span>")
+			src.grinded[ourtype]++
+			to_chat(user, "<span class='notice'>The machine now has [grinded[ourtype]] worth of material stored for this animal.</span>")
 
 /obj/machinery/monkey_recycler/attack_hand(var/mob/user as mob)
 	if(..())
 		return 1
-	if(grinded >= minimum_monkeys)
-		to_chat(user, "<span class='notice'>The machine hisses loudly as it condenses the grinded monkey meat. After a moment, it dispenses a brand new monkey cube.</span>")
+	var/list/enough_of_types = list()
+	for(var/grindtype in grinded)
+		if(grinded[grindtype] >= minimum_animals)
+			enough_of_types += grindtype
+			enough_of_types[grindtype] = grinded[grindtype]
+	if(enough_of_types.len)
+		var/pickedtype = pick(enough_of_types)
+		to_chat(user, "<span class='notice'>The machine hisses loudly as it condenses the grinded animal meat. After a moment, it dispenses a brand new animal cube.</span>")
 		playsound(src, 'sound/machines/hiss.ogg', 50, 1)
-		grinded -= minimum_monkeys
-		new /obj/item/weapon/reagent_containers/food/snacks/monkeycube/wrapped(src.loc)
-		to_chat(user, "<span class='notice'>The machine's display flashes that it has [grinded] monkeys worth of material left.</span>")
+		grinded[pickedtype] -= minimum_animals
+		var/obj/item/weapon/reagent_containers/food/snacks/monkeycube/wrapped/MW = new(src.loc)
+		MW.contained_mob = pickedtype
+		MW.name = "processed cube"
+		to_chat(user, "<span class='notice'>The machine's display flashes that it has [grinded[pickedtype]] animals worth of material left.</span>")
 	else
-		to_chat(user, "<span class='warning'>The machine needs at least [minimum_monkeys] monkey\s worth of material to produce a monkey cube. It only has [grinded].</span>")
+		to_chat(user, "<span class='warning'>The machine needs at least [minimum_animals] same type animal\s worth of material to produce an animal cube.</span>")
 	return
 
 /obj/machinery/monkey_recycler/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob) //copypasted from sleepers

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -132,7 +132,7 @@
 		if(ref_body_archives.len)
 			for(var/datum/body_archive/BA in ref_body_archives)
 				if(BA.mob_type == pickedtype)
-					var/mob/living/temp_M = new
+					var/mob/living/temp_M = new pickedtype
 					var/mob/living/M = temp_M.actually_reset_body(archive = BA, our_mind = get_mind_by_key(BA.key))
 					M.forceMove(MW)
 					MW.contained_mob = M
@@ -141,8 +141,9 @@
 					qdel(temp_M)
 					break
 		else
-			MW.contained_mob = pickedtype
-			MW.name = "processed cube"
+			var/mob/living/MW_mob = new pickedtype(MW)
+			MW.contained_mob = MW_mob
+			MW.name = "[MW_mob] cube"
 		to_chat(user, "<span class='notice'>The machine's display flashes that it has [grinded[pickedtype]] animals worth of material of this type left.</span>")
 	else
 		to_chat(user, "<span class='warning'>The machine needs at least [minimum_animals] same type animal\s worth of material to produce an animal cube.</span>")

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -132,12 +132,13 @@
 		if(ref_body_archives.len)
 			for(var/datum/body_archive/BA in ref_body_archives)
 				if(BA.mob_type == pickedtype)
-					var/mob/living/M = new(MW)
-					M = M.actually_reset_body(archive = BA, our_mind = get_mind_by_key(BA.key))
+					var/mob/living/temp_M = new
+					var/mob/living/M = temp_M.actually_reset_body(archive = BA, our_mind = get_mind_by_key(BA.key))
 					M.forceMove(MW)
 					MW.contained_mob = M
 					MW.name = "[MW] cube"
 					ref_body_archives.Remove(BA)
+					qdel(temp_M)
 					break
 		else
 			MW.contained_mob = pickedtype

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -132,8 +132,8 @@
 		if(ref_body_archives.len)
 			for(var/datum/body_archive/BA in ref_body_archives)
 				if(BA.mob_type == pickedtype)
-					var/mob/living/M = new
-					M = M.reset_body(BA)
+					var/mob/living/M = new(MW)
+					M = M.actually_reset_body(archive = BA, our_mind = get_mind_by_key(BA.key))
 					M.forceMove(MW)
 					MW.contained_mob = M
 					MW.name = "[MW] cube"

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -69,7 +69,7 @@
 		var/grabbed = G.affecting
 		if(isliving(grabbed))
 			var/mob/living/target = grabbed
-			if(ishuman(target) && !emagged)
+			if((ishuman(target) || issilicon(target)) && !emagged)
 				to_chat(user, "<span class='warning'>\the [target] is too sapient for the recycler.</span>")
 				return
 			if(target.stat == CONSCIOUS && !can_recycle_live)
@@ -87,12 +87,12 @@
 				playsound(src, 'sound/machines/juicer.ogg', 50, 1)
 				use_power(500)
 				src.grinded[ourtype]++
-				to_chat(user, "<span class='notice'>The machine now has [grinded[ourtype]] worth of material stored for this animal.</span>")
+				to_chat(user, "<span class='notice'>The machine now has [grinded[ourtype]] animals worth of material of this type stored.</span>")
 		else
 			to_chat(user, "<span class='warning'>The machine only accepts animals!</span>")
 	else if(isliving(O))
 		var/mob/living/target = O
-		if(ishuman(target) && !emagged)
+		if((ishuman(target) || issilicon(target)) && !emagged)
 			to_chat(user, "<span class='warning'>\the [target] is too sapient for the recycler.</span>")
 			return
 		if(target.stat == CONSCIOUS && !can_recycle_live)
@@ -104,11 +104,12 @@
 		else
 			var/ourtype = target.type
 			qdel(target)
+			target = null
 			to_chat(user, "<span class='notice'>You stuff \the [target] in the machine.</span>")
 			playsound(src, 'sound/machines/juicer.ogg', 50, 1)
 			use_power(500)
 			src.grinded[ourtype]++
-			to_chat(user, "<span class='notice'>The machine now has [grinded[ourtype]] worth of material stored for this animal.</span>")
+			to_chat(user, "<span class='notice'>The machine now has [grinded[ourtype]] animals worth of material of this type stored.</span>")
 
 /obj/machinery/monkey_recycler/attack_hand(var/mob/user as mob)
 	if(..())
@@ -126,7 +127,7 @@
 		var/obj/item/weapon/reagent_containers/food/snacks/monkeycube/wrapped/MW = new(src.loc)
 		MW.contained_mob = pickedtype
 		MW.name = "processed cube"
-		to_chat(user, "<span class='notice'>The machine's display flashes that it has [grinded[pickedtype]] animals worth of material left.</span>")
+		to_chat(user, "<span class='notice'>The machine's display flashes that it has [grinded[pickedtype]] animals worth of material of this type left.</span>")
 	else
 		to_chat(user, "<span class='warning'>The machine needs at least [minimum_animals] same type animal\s worth of material to produce an animal cube.</span>")
 	return

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -49,7 +49,7 @@
 		var/mob/living/target = AM
 		if(target.stat == CONSCIOUS && !can_recycle_live)
 			return FALSE
-		if(ishuman(target) && !emagged)
+		if((target.key || target.ckey) && !emagged)
 			return FALSE
 		if(target.abiotic())
 			return FALSE
@@ -69,7 +69,7 @@
 		var/grabbed = G.affecting
 		if(isliving(grabbed))
 			var/mob/living/target = grabbed
-			if((ishuman(target) || issilicon(target)) && !emagged)
+			if((target.key || target.ckey) && !emagged)
 				to_chat(user, "<span class='warning'>\the [target] is too sapient for the recycler.</span>")
 				return
 			if(target.stat == CONSCIOUS && !can_recycle_live)
@@ -92,7 +92,7 @@
 			to_chat(user, "<span class='warning'>The machine only accepts animals!</span>")
 	else if(isliving(O))
 		var/mob/living/target = O
-		if((ishuman(target) || issilicon(target)) && !emagged)
+		if((target.key || target.ckey) && !emagged)
 			to_chat(user, "<span class='warning'>\the [target] is too sapient for the recycler.</span>")
 			return
 		if(target.stat == CONSCIOUS && !can_recycle_live)

--- a/code/modules/research/designs/boards/machine_science.dm
+++ b/code/modules/research/designs/boards/machine_science.dm
@@ -59,8 +59,8 @@
 	build_path = /obj/item/weapon/circuitboard/mechfab
 
 /datum/design/monkey_recycler
-	name = "Circuit Design (Monkey Recycler)"
-	desc = "Allows for the construction of circuit boards used to build a Monkey Recycler."
+	name = "Circuit Design (Animal Recycler)"
+	desc = "Allows for the construction of circuit boards used to build a Animal Recycler."
 	id = "monkey"
 	req_tech = list(Tc_PROGRAMMING = 3, Tc_ENGINEERING = 2, Tc_BIOTECH = 3, Tc_POWERSTORAGE = 2)
 	build_type = IMPRINTER


### PR DESCRIPTION
[content][qol]
Also renames the machine to the animal recycler to make it more broad.
Should allow for the making of animal cubes out of most things (dead things with no biotic items like before) from carps to mice, except for player controlled mobs (unless emagged)

:cl:
 * rscadd: Monkey recyclers have been reformatted into being general purpose animal recyclers, now allowing the cubing of all non-sapient life... in most cases.