### PR TITLE
Lotto ticket adjustments

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3737,13 +3737,13 @@ var/global/num_vending_terminals = 1
 		/obj/item/toy/lotto_ticket/phazon_fortune = 20
 		)
 	contraband = list(
-		/obj/item/toy/lotto_ticket/supermatter_surprise = 1
+		/obj/item/toy/lotto_ticket/supermatter_surprise = 5
 		)
 	prices = list(
 		/obj/item/toy/lotto_ticket/gold_rush = 5,
-		/obj/item/toy/lotto_ticket/diamond_hands = 20,
-		/obj/item/toy/lotto_ticket/phazon_fortune = 50,
-		/obj/item/toy/lotto_ticket/supermatter_surprise = 100
+		/obj/item/toy/lotto_ticket/diamond_hands = 10,
+		/obj/item/toy/lotto_ticket/phazon_fortune = 20,
+		/obj/item/toy/lotto_ticket/supermatter_surprise = 50
 		)
 
 	pack = /obj/structure/vendomatpack/lotto
@@ -3761,7 +3761,7 @@ var/global/num_vending_terminals = 1
 		Broadcast_Message(speech, vmask=null, data=0, compression=0, level=list(0,1))
 		qdel(speech)
 
-/obj/machinery/vending/lotto/attackby(obj/item/I, user)
+/obj/machinery/vending/lotto/attackby(obj/item/I, var/mob/living/user)
 	add_fingerprint(user)
 	if(istype(I, /obj/item/toy/lotto_ticket))
 		var/obj/item/toy/lotto_ticket/T = I
@@ -3774,6 +3774,7 @@ var/global/num_vending_terminals = 1
 			playsound(src, "polaroid", 50, 1)
 			if(T.winnings >= 10000)
 				AnnounceWinner(src,user,T.winnings)
+				log_admin("([user.ckey]/[user]) won a large lottery prize of [T.winnings] credits.")
 			qdel(T)
 	else
 		..()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3765,6 +3765,10 @@ var/global/num_vending_terminals = 1
 	add_fingerprint(user)
 	if(istype(I, /obj/item/toy/lotto_ticket))
 		var/obj/item/toy/lotto_ticket/T = I
+		if(!T.revealed)
+			playsound(src, "buzz-sigh", 50, 1)
+			visible_message("<b>[src]</b>'s monitor flashes, \"This ticket cannot be read until the film is scratched off.\"")
+			return
 		if(!T.iswinner)
 			playsound(src, "buzz-sigh", 50, 1)
 			visible_message("<b>[src]</b>'s monitor flashes, \"This ticket is not a winning ticket.\"")

--- a/code/modules/games/cards/lotto.dm
+++ b/code/modules/games/cards/lotto.dm
@@ -5,7 +5,7 @@
 	w_class = W_CLASS_TINY
 	var/revealed = FALSE
 	var/iswinner = FALSE
-	var/prize_multiplyer
+	var/prize_multiplier
 	var/winnings = 0
 	var/list/prizelist = list(100000,50000,10000,5000,1000,500,250,100,50,20,10,5,4,3,2,1)
 	var/list/problist = list(0.0001, 0.0002, 0.001, 0.002, 0.01, 0.02, 0.04, 0.2, 1, 2.5, 5, 10, 12.5, 17, 20, 25)
@@ -15,12 +15,12 @@
 	pixel_y = rand(-8, 8) * PIXEL_MULTIPLIER
 	pixel_x = rand(-9, 9) * PIXEL_MULTIPLIER
 
-/obj/item/toy/lotto_ticket/proc/scratch(var/input_prize_multiplyer)
+/obj/item/toy/lotto_ticket/proc/scratch(var/input_prize_multiplier)
 	var/tuning_value = 1/5 //Used to adjust expected values.
 	var/profit = 0
 	for(var/prize = 1 to problist.len)
 		if(prob(problist[prize]))
-			profit = prizelist[prize]*input_prize_multiplyer*tuning_value
+			profit = prizelist[prize]*input_prize_multiplier*tuning_value
 			return profit
 
 //Flash code taken from Blinder
@@ -54,7 +54,7 @@
 				src.revealed = TRUE
 				src.update_icon()
 				to_chat(user, "<span class='notice'>You scratch off the film covering the prizes.</span>")
-				winnings = scratch(prize_multiplyer)
+				winnings = scratch(prize_multiplier)
 				if(winnings)
 					src.iswinner = TRUE
 		else
@@ -84,21 +84,21 @@
 	name = "Gold Rush lottery ticket"
 	desc = "A cheap scratch-off lottery ticket. Win up to 100,000 credits!"
 	icon_state = "lotto_1"
-	prize_multiplyer = 5 //EV 4.55, ER -0.45
+	prize_multiplier = 5 //EV 4.55, ER -0.45
 
 //Tier 2 card
 /obj/item/toy/lotto_ticket/diamond_hands
 	name = "Diamond Hands lottery ticket"
 	desc = "A mid-price scratch-off lottery ticket. Win up to 400,000 credits!"
 	icon_state = "lotto_2"
-	prize_multiplyer = 20 //EV 18.20, ER -1.80
+	prize_multiplier = 20 //EV 18.20, ER -1.80
 
 //Tier 3 card
 /obj/item/toy/lotto_ticket/phazon_fortune
 	name = "Phazon Fortune lottery ticket"
 	desc = "An expensive scratch-off lottery ticket. Win up to 1,000,000 credits!"
 	icon_state = "lotto_3"
-	prize_multiplyer = 50 //EV 45.50, ER -4.50
+	prize_multiplier = 50 //EV 45.50, ER -4.50
 
 
 //Emag card
@@ -109,12 +109,12 @@
 	var/flashed = FALSE
 
 /obj/item/toy/lotto_ticket/supermatter_surprise/scratch()
-	var/input_prize_multiplyer = 50
+	var/input_prize_multiplier = 50
 	var/profit = 0
 	while(!profit)
 		for(var/prize = 1 to problist.len)
 			if(prob(problist[prize]))
-				profit = prizelist[prize]*input_prize_multiplyer
+				profit = prizelist[prize]*input_prize_multiplier
 				return profit
 
 /obj/item/toy/lotto_ticket/supermatter_surprise/attackby(obj/item/weapon/S, mob/user)

--- a/code/modules/games/cards/lotto.dm
+++ b/code/modules/games/cards/lotto.dm
@@ -46,8 +46,8 @@
 
 /obj/item/toy/lotto_ticket/attackby(obj/item/weapon/S, mob/user)
 	if(!revealed)
-		if(!user.is_holding_item(src))
-			to_chat(user, "<span class='notice'>The film is too tough to scratch without holding the ticket in your hand!</span>")
+		if(!user.is_holding_item(src) && istype(src,/obj/item/toy/lotto_ticket/supermatter_surprise))
+			to_chat(user, "<span class='notice'>The special film is too tough to scratch without holding the ticket in your hand!</span>")
 			return 1
 		if(S.is_sharp() || istype(S, /obj/item/weapon/coin))
 			if(do_after(user, src, 1 SECONDS))


### PR DESCRIPTION
Per feedback:
- Increases the amount of contraband tickets per vendor from 1 to 5.
- Lowers ticket prices all around.
- Adds admin logging for large prize (>10,000 credits) winners.
- Supermatter tickets now blow off the user's hand but have a guaranteed win using the same prize table as Phazon Fortune. These are NOT supermatter splinters and can be cashed in just fine. They also respect anti-supermatter-effect items such as the Golden Gloves and SASS Sphere.

Closes #32146.

:cl:
 * tweak: lowers lotto ticket prices and changes Supermatter Surprise behavior
