### PR TITLE
Fixes initialised dir issues with HE pipes

### DIFF
--- a/code/ATMOSPHERICS/he_pipes.dm
+++ b/code/ATMOSPHERICS/he_pipes.dm
@@ -231,6 +231,7 @@
 	radiation_capacity = 24000
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold/update_dir()
+	..()
 	switch(dir)
 		if(NORTH)
 			initialize_directions_he = EAST|SOUTH|WEST

--- a/code/ATMOSPHERICS/he_pipes.dm
+++ b/code/ATMOSPHERICS/he_pipes.dm
@@ -31,7 +31,7 @@
 				node.update_icon(1)
 
 	// BubbleWrap
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/New()
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/update_dir()
 	..()
 	initialize_directions_he = initialize_directions	// The auto-detection from /pipe is good enough for a simple HE pipe
 	// BubbleWrap END
@@ -164,11 +164,8 @@
 	thermal_conductivity = WALL_HEAT_TRANSFER_COEFFICIENT
 
 	// BubbleWrap
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/New()
-	..()
-	update_dir()
-
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/update_dir()
+	..()
 	switch (dir)
 		if (SOUTH)
 			initialize_directions = NORTH
@@ -182,7 +179,6 @@
 		if (WEST)
 			initialize_directions = EAST
 			initialize_directions_he = WEST
-	..()
 	// BubbleWrap END
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
@@ -234,8 +230,7 @@
 	var/obj/machinery/atmospherics/node3
 	radiation_capacity = 24000
 
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold/New()
-	.. ()
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold/update_dir()
 	switch(dir)
 		if(NORTH)
 			initialize_directions_he = EAST|SOUTH|WEST
@@ -312,8 +307,8 @@
 	var/obj/machinery/atmospherics/node4
 	radiation_capacity = 24000
 
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold4w/New()
-	.. ()
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold4w/update_dir()
+	..()
 	initialize_directions_he = NORTH|SOUTH|EAST|WEST
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold4w/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)


### PR DESCRIPTION
[bugfix]
Closes #32155.
Should also allow more kind of HE pipes to rotate in map elements too.

:cl:
 * bugfix: HE pipes are no longer found broken until unwrenched and wrenched again.
