### PR TITLE
Restored Dusky's robotic vocal cords

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -264,7 +264,7 @@ List of hard deletions:"}
 	tag = null
 	for(var/timer in active_timers)
 		qdel(timer)
-	for(var/component in active_components)
+	for(var/component in datum_components)
 		qdel(component)
 	active_timers = null
 


### PR DESCRIPTION
#32102 unintentionally made it so whenever any datum was deleted, the global list of "processing" components was cleared, instead of the components that belonged to the datum that was being deleted. It happened to fix the runtime error just as well, though!