### PR TITLE
Makes cytisine farming viable.

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -588,7 +588,7 @@
 	plant_dmi = 'icons/obj/hydroponics/deathberry.dmi'
 	mutants = null
 	products = list(/obj/item/weapon/reagent_containers/food/snacks/grown/deathberries)
-	chems = list(NUTRIMENT = list(1), SOLANINE = list(3,3), CORIAMYRTIN = list(1,5), CYTISINE = list(1))
+	chems = list(NUTRIMENT = list(1), SOLANINE = list(3,3), CORIAMYRTIN = list(1,5), CYTISINE = list(1,5))
 
 	yield = 3
 	potency = 50


### PR DESCRIPTION
Cytisine has some uses as a strong poison and alternative to synaptizine, issue is that you can't easily farm it since it doesn't scale with potency. 
:cl:
 * tweak: Death Berries' Cytisine now scales with potency and isn't a static 1u per berry.
