### PR TITLE
Let players insert/remove IDs/pens from PDAs even if they're not in an inventory slot

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -434,7 +434,6 @@ var/global/msg_id = 0
 			name = "PDA-[owner] ([ownjob])"
 			to_chat(user, "<span class='notice'>Card scanned.</span>")
 		else
-			//Basic safety check. If either both objects are held by user or PDA is on ground and card is in hand.
 			if(in_range(src, user))
 				id_check(user, 2)
 				to_chat(user, "<span class='notice'>You put \the [C] into \the [src]'s slot.</span>")


### PR DESCRIPTION
This always bugged me, especially because it was arbitrary: you could insert pens and scan IDs to register them with the PDA, but not actually insert them or remove them.

:cl:
 * tweak: It is now possible to insert and remove pens and IDs from PDAs even if the PDA is not in an inventory slot (e.g. in a bag or on the ground).