### PR TITLE
Fixed salvage-crate-sender runtime error

### DIFF
--- a/code/modules/telesci/rcs.dm
+++ b/code/modules/telesci/rcs.dm
@@ -93,7 +93,8 @@
 
 /obj/item/weapon/rcs/examine(mob/user)
 	..()
-	to_chat(user, "<span class='info'>There are [round(cell.charge / send_cost)] charges left.</span>")
+	if(send_cost > 0)
+		to_chat(user, "<span class='info'>There are [round(cell.charge / send_cost)] charges left.</span>")
 
 /obj/item/weapon/rcs/Destroy()
 	if (cell)


### PR DESCRIPTION
```
[20:09:54] Runtime in rcs.dm, line 96: Division by zero
proc name: examine (/obj/item/weapon/rcs/examine)
usr: Nugget (xeroxemnas) (/mob/living/carbon/human)
usr.loc: The floor (176, 280, 5) (/turf/simulated/floor/vox)
src: the salvage-crate-sender (SCS) (/obj/item/weapon/rcs/salvage)
src.loc: the satchel (/obj/item/weapon/storage/backpack/satchel_norm)
call stack:
the salvage-crate-sender (SCS) (/obj/item/weapon/rcs/salvage): examine(Nugget (/mob/living/carbon/human))
Nugget (/mob/living/carbon/human): Examine(the salvage-crate-sender (SCS) (/obj/item/weapon/rcs/salvage))
the salvage-crate-sender (SCS) (/obj/item/weapon/rcs/salvage): ShiftClick(Nugget (/mob/living/carbon/human))
Nugget (/mob/living/carbon/human): ShiftClickOn(the salvage-crate-sender (SCS) (/obj/item/weapon/rcs/salvage))
Nugget (/mob/living/carbon/human): ClickOn(the salvage-crate-sender (SCS) (/obj/item/weapon/rcs/salvage), "icon-x=19;icon-y=21;left=1;shi...")
the salvage-crate-sender (SCS) (/obj/item/weapon/rcs/salvage): Click(null, "mapwindow.map", "icon-x=19;icon-y=21;left=1;shi...")
Xeroxemnas (/client): Click(the salvage-crate-sender (SCS) (/obj/item/weapon/rcs/salvage), null, "mapwindow.map", "icon-x=19;icon-y=21;left=1;shi...")
```