### PR TITLE
Draw closed firelocks above plastic flaps and curtains

### DIFF
--- a/__DEFINES/planes+layers.dm
+++ b/__DEFINES/planes+layers.dm
@@ -173,7 +173,8 @@ Why is FLOAT_PLANE added to a bunch of these?
 	// OBJ_LAYER 	 					3
 	// ABOVE_OBJ_LAYER					4
 	#define CLOSED_CURTAIN_LAYER		5
-	#define CHAT_LAYER					6
+	#define CLOSED_FIREDOOR_LAYER		6
+	#define CHAT_LAYER					7
 
 #define BLOB_PLANE 				(10 + FLOAT_PLANE)			// For Blobs, which are above humans.
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -15,7 +15,9 @@ var/list/all_doors = list()
 	density = 1
 	layer = OPEN_DOOR_LAYER
 	penetration_dampening = 10
+	var/open_plane = OBJ_PLANE
 	var/open_layer = OPEN_DOOR_LAYER
+	var/closed_plane = OBJ_PLANE
 	var/closed_layer = CLOSED_DOOR_LAYER
 	var/secondsElectrified = 0
 	var/visible = 1
@@ -282,6 +284,7 @@ var/list/all_doors = list()
 		sleep(animation_delay_predensity_opening)
 	else
 		sleep(animation_delay)
+	plane = open_plane
 	layer = open_layer
 	setDensity(FALSE)
 	update_nearby_tiles()
@@ -313,6 +316,7 @@ var/list/all_doors = list()
 
 	operating = 1
 
+	plane = closed_plane
 	layer = closed_layer
 
 	if (makes_noise)
@@ -355,10 +359,11 @@ var/list/all_doors = list()
 
 	if(density)
 		// above most items if closed
+		plane = closed_plane
 		layer = closed_layer
-
 		explosion_resistance = initial(explosion_resistance)
 	else
+		plane = open_plane
 		layer = open_layer
 
 		explosion_resistance = 0

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -65,8 +65,12 @@ var/global/list/alert_overlays_global = list()
 	opacity = 0
 	density = 0
 	layer = BELOW_TABLE_LAYER
+
+	open_plane = OBJ_PLANE
 	open_layer = BELOW_TABLE_LAYER
-	closed_layer = ABOVE_DOOR_LAYER
+
+	closed_plane = ABOVE_HUMAN_PLANE
+	closed_layer = CLOSED_FIREDOOR_LAYER
 
 	dir = 2
 
@@ -464,6 +468,7 @@ var/global/list/alert_overlays_global = list()
 		return
 	..()
 	latetoggle()
+	plane = open_plane
 	layer = open_layer
 	var/area/A = get_area(src)
 	ASSERT(istype(A)) // This worries me.
@@ -507,6 +512,7 @@ var/global/list/alert_overlays_global = list()
 		return
 	..()
 	latetoggle()
+	plane = closed_plane
 	layer = closed_layer
 
 /obj/machinery/door/firedoor/update_icon()

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -51,10 +51,6 @@ var/list/poddoors = list()
 
 /obj/machinery/door/poddoor/New()
 	. = ..()
-	if(density)
-		layer = closed_layer
-	else
-		layer = open_layer
 	poddoors += src
 
 /obj/machinery/door/poddoor/Destroy()
@@ -123,6 +119,7 @@ var/list/poddoors = list()
 		return
 	playsound(loc, 'sound/machines/poddoor.ogg', 60, 1)
 	operating = 1
+	plane = closed_plane
 	layer = closed_layer
 	flick(closingicon, src)
 	icon_state = closedicon

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -23,6 +23,7 @@
 			flick("shutterc0", src)
 			icon_state = "shutter0"
 			sleep(animation_delay)
+			plane = open_plane
 			layer = open_layer
 			setDensity(FALSE)
 			set_opacity(0)
@@ -39,6 +40,7 @@
 	icon_state = "shutter0"
 	playsound(src.loc, sound_open, 100, 1)
 	sleep(animation_delay)
+	plane = open_plane
 	layer = open_layer
 	setDensity(FALSE)
 	set_opacity(0)
@@ -55,6 +57,7 @@
 	if(operating)
 		return
 	operating = 1
+	plane = closed_plane
 	layer = closed_layer
 	flick("shutterc1", src)
 	icon_state = "shutter1"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6307265/157044877-be56506f-2fc8-40ed-9de9-400bd39f77bd.png)
Makes it so a setup as shown in the above no longer makes it impossible to open the firelock.
Fixes #17949
:cl:
 * tweak: Closed firelocks are now rendered above other objects that block clicks/movement like plastic flaps and curtains.