### PR TITLE
Fixed a bunch of hard dels

### DIFF
--- a/code/__HELPERS/math/ray/ray.dm
+++ b/code/__HELPERS/math/ray/ray.dm
@@ -72,7 +72,8 @@
 /ray/proc/getReboundOnAtom(var/rayCastHit/hit)
 	//calc where we hit the atom
 	var/vector/hit_point = hit.point_raw
-	var/vector/hit_atom_loc = atom2vector(hit.hit_atom) + new /vector(0.5, 0.5)
+	var/atom/movable/resolved_hit_atom = hit.hit_atom?.get()
+	var/vector/hit_atom_loc = atom2vector(resolved_hit_atom) + new /vector(0.5, 0.5)
 
 	var/vector/hit_vector = hit_point - hit_atom_loc
 
@@ -136,7 +137,7 @@
 		var/turf/T = vector2turf(new_position, z)
 
 		//trying hit at turf
-		var/rayCastHitInfo/info = new /rayCastHitInfo(src, T, new_position, new_position_unfloored, distance)
+		var/rayCastHitInfo/info = new /rayCastHitInfo(src, makeweakref(T), new_position, new_position_unfloored, distance)
 		var/rayCastHit/hit = raycast_hit_check(info)
 		switch(hit.hit_code())
 			if(RAY_CAST_NO_HIT_EXIT)
@@ -154,7 +155,7 @@
 
 		//trying hit on every atom inside the turf
 		for(var/atom/movable/A in T)
-			info = new /rayCastHitInfo(src, A, new_position, new_position_unfloored, distance)
+			info = new /rayCastHitInfo(src, makeweakref(A), new_position, new_position_unfloored, distance)
 			hit = raycast_hit_check(info)
 			switch(hit.hit_code())
 				if(RAY_CAST_NO_HIT_EXIT)

--- a/code/__HELPERS/math/ray/rayCastHit.dm
+++ b/code/__HELPERS/math/ray/rayCastHit.dm
@@ -1,6 +1,6 @@
 /rayCastHit
 	var/ray/used_ray
-	var/atom/movable/hit_atom
+	var/datum/weakref/hit_atom
 	var/vector/point
 	var/vector/point_raw
 	var/distance

--- a/code/__HELPERS/math/ray/rayCastHitInfo.dm
+++ b/code/__HELPERS/math/ray/rayCastHitInfo.dm
@@ -1,11 +1,11 @@
 /rayCastHitInfo
 	var/ray/used_ray
-	var/atom/movable/hit_atom
+	var/datum/weakref/hit_atom
 	var/vector/point
 	var/vector/point_raw
 	var/distance
 
-/rayCastHitInfo/New(var/ray/used_ray, var/atom/movable/hit_atom, var/vector/point, var/vector/point_raw, var/distance)
+/rayCastHitInfo/New(var/ray/used_ray, var/datum/weakref/hit_atom, var/vector/point, var/vector/point_raw, var/distance)
 	src.used_ray = used_ray
 	src.hit_atom = hit_atom
 	src.point = point

--- a/code/__HELPERS/math/ray/ray_test_procs.dm
+++ b/code/__HELPERS/math/ray/ray_test_procs.dm
@@ -7,9 +7,11 @@
 	var/list/res = our_ray.cast(dist)
 	for(var/rayCastHit/rCH in res)
 		var/image/I = image('icons/Testing/Zone.dmi',"fullblock",10)
-		rCH.hit_atom.overlays += I
-		var/ref = "\ref[rCH.hit_atom]"
+		var/datum/weakref/ref = rCH.hit_atom
+		var/atom/movable/R = ref.get()
+		R.overlays += I
+		R = null
 		spawn(30)
-			var/atom/movable/R = locate(ref)
+			R = ref.get()
 			R.overlays -= I
 	return res

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -264,9 +264,10 @@ List of hard deletions:"}
 	tag = null
 	for(var/timer in active_timers)
 		qdel(timer)
-	for(var/component in datum_components)
-		qdel(component)
 	active_timers = null
+	for(var/component_type in datum_components)
+		qdel(datum_components[component_type])
+	datum_components = null
 
 /datum/var/gcDestroyed
 

--- a/code/modules/components/ai/area_territorial.dm
+++ b/code/modules/components/ai/area_territorial.dm
@@ -6,12 +6,19 @@
 	var/area/territory = null
 
 /datum/component/ai/area_territorial/proc/SetArea(var/area/new_area)
-	if(territory)
-		territory.unregister_event(/event/area_entered, src, .proc/area_enter)
-		territory.unregister_event(/event/area_exited, src, .proc/area_exit)
+	unset_area()
 	territory = new_area
 	territory.register_event(/event/area_entered, src, .proc/area_enter)
 	territory.register_event(/event/area_exited, src, .proc/area_exit)
+
+/datum/component/ai/area_territorial/proc/unset_area()
+	if(territory)
+		territory.unregister_event(/event/area_entered, src, .proc/area_enter)
+		territory.unregister_event(/event/area_exited, src, .proc/area_exit)
+
+/datum/component/ai/area_territorial/Destroy()
+	unset_area()
+	..()
 
 /datum/component/ai/area_territorial/proc/area_enter(atom/movable/enterer)
 	if(isliving(enterer)) // No ghosts

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -44,6 +44,9 @@
 		qdel(immune_system)
 		immune_system = null
 
+	if(addicted_chems)
+		qdel(addicted_chems)
+		addicted_chems = null
 	. = ..()
 
 /mob/living/examine(var/mob/user, var/size = "", var/show_name = TRUE, var/show_icon = TRUE) //Show the mob's size and whether it's been butchered

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -41,12 +41,12 @@ var/list/beam_master = list()
 	hit_cache = .
 
 /ray/beam_ray/raycast_hit_check(var/rayCastHitInfo/info)
-	var/atom/movable/A = info.hit_atom
-	var/turf/T = vector2turf(info.point, z)
+	var/atom/movable/A = info.hit_atom.get()
 
 	if(isnull(A))
 		return new /rayCastHit(info, RAY_CAST_NO_HIT_CONTINUE)
 
+	var/turf/T = vector2turf(info.point, z)
 	T.last_beam_damage = fired_beam.damage
 
 	if(!A.Cross(fired_beam, T) || (!isturf(fired_beam.original) && A == fired_beam.original))
@@ -236,7 +236,7 @@ var/list/beam_master = list()
 			log_attack("<font color='red'>[key_name(firer_mob)] shot himself with a [type].</font>")
 			M.attack_log += "\[[time_stamp()]\] <b>[key_name(firer_mob)]</b> shot himself with a <b>[type]</b>"
 			firer_mob.attack_log += "\[[time_stamp()]\] <b>[key_name(firer_mob)]</b> shot himself with a <b>[type]</b>"
-			if(firer_mob.key || firer_mob.ckey)		
+			if(firer_mob.key || firer_mob.ckey)
 				msg_admin_attack("[key_name(firer_mob)] shot himself with a [type], [pick("top kek!","for shame.","he definitely meant to do that","probably not the last time either.")] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[firer_mob.x];Y=[firer_mob.y];Z=[firer_mob.z]'>JMP</a>)")
 			if(!iscarbon(firer_mob))
 				M.LAssailant = null


### PR DESCRIPTION
- Made `/rayCastHit` and `/rayCastHitInfo` hold weak references to the hit atoms
- Fixed component datums deletion, this time for real
- Made `/datum/component/ai/area_territorial` unregister its events from the area when it's deleted
- Made `mob/living` delete their `addicted_chems` reagent datum, which was holding a reference to the mob itself