### PR TITLE
Makes time anomalies immune to the timeline eraser.

### DIFF
--- a/code/datums/gamemode/objectives/time_agent_extract.dm
+++ b/code/datums/gamemode/objectives/time_agent_extract.dm
@@ -40,6 +40,7 @@
 	icon_state = "time_anomaly"
 	anchored = 1
 	mouse_opacity = 1
+	flags = TIMELESS
 	var/last_effect
 
 /obj/effect/time_anomaly/New()


### PR DESCRIPTION
[bugfix] ?
Fixes #32052 
I hope this wasn't intentional, for the sake of all future time agent players. Thanks to DamianQ for helping me out.
🆑
- bugfix: You can no longer erase the time anomaly with a timeline eraser.