### PR TITLE
Fixed a PDA runtime

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -386,7 +386,7 @@ var/global/msg_id = 0
 /obj/item/device/pda/proc/id_check(mob/user as mob, choice as num)//To check for IDs; 1 for in-pda use, 2 for out of pda use.
 	if(choice == 1)
 		if (id)
-			remove_id()
+			remove_id(user)
 		else
 			var/obj/item/I = user.get_active_hand()
 			if (istype(I, /obj/item/weapon/card/id))


### PR DESCRIPTION
```
[14:14:50] Runtime in PDA.dm, line 324: Cannot execute null.incapacitated().
verb name: remove id (/obj/item/device/pda/verb/remove_id)
usr: Unknown (mumpsimus) (/mob/living/carbon/human)
usr.loc: The floor (286, 168, 5) (/turf/simulated/floor)
src: PDA-Thyra Trygve (Shaft Miner) (/obj/item/device/pda/shaftminer)
src.loc: Unknown (/mob/living/carbon/human)
call stack:
PDA-Thyra Trygve (Shaft Miner) (/obj/item/device/pda/shaftminer): remove id(null)
PDA-Thyra Trygve (Shaft Miner) (/obj/item/device/pda/shaftminer): id check(Unknown (/mob/living/carbon/human), 1)
PDA-Thyra Trygve (Shaft Miner) (/obj/item/device/pda/shaftminer): Topic("src=\[0x2028583];choice=Authen...", /list (/list))
Mumpsimus (/client): Topic("src=\[0x2028583];choice=Authen...", /list (/list), PDA-Thyra Trygve (Shaft Miner) (/obj/item/device/pda/shaftminer))
```