### PR TITLE
Two singularities in the world can link on some occasions

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1235,7 +1235,7 @@ var/global/list/image/blood_overlays = list()
 	return
 
 //handling the pulling of the item for singularity
-/obj/item/singularity_pull(S, current_size)
+/obj/item/singularity_pull(S, current_size, repel = FALSE)
 	if(flags & INVULNERABLE)
 		return
 	spawn(0) //this is needed or multiple items will be thrown sequentially and not simultaneously
@@ -1246,11 +1246,20 @@ var/global/list/image/blood_overlays = list()
 				return
 		if(current_size >= STAGE_FOUR)
 			//throw_at(S, 14, 3)
-			step_towards(src,S)
+			if(!repel)
+				step_towards(src, S)
+			else
+				step_away(src, S)
 			sleep(1)
-			step_towards(src,S)
+			if(!repel)
+				step_towards(src, S)
+			else
+				step_away(src, S)
 		else if(current_size > STAGE_ONE)
-			step_towards(src,S)
+			if(!repel)
+				step_towards(src, S)
+			else
+				step_away(src, S)
 		else
 			..()
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -360,14 +360,20 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 		to_chat(user, "\the [src] already has a slime extract attached.")
 		return FALSE
 
-/obj/singularity_pull(S, current_size)
+/obj/singularity_pull(S, current_size, repel = FALSE)
 	INVOKE_EVENT(src, /event/before_move)
 	if(anchored)
 		if(current_size >= STAGE_FIVE)
 			anchored = 0
-			step_towards(src, S)
+			if(!repel)
+				step_towards(src, S)
+			else
+				step_away(src, S)
 	else
-		step_towards(src, S)
+		if(!repel)
+			step_towards(src, S)
+		else
+			step_away(src, S)
 	INVOKE_EVENT(src, /event/after_move)
 
 /obj/proc/multitool_menu(var/mob/user,var/obj/item/device/multitool/P)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1500,8 +1500,11 @@
 	if(current_size >= STAGE_THREE) //Pull items from hand
 		for(var/obj/item/I in held_items)
 			if(prob(current_size*5) && I.w_class >= ((11-current_size)/2) && u_equip(I,1))
-				step_towards(I, src)
-				to_chat(src, "<span class = 'warning'>\The [S] pulls \the [I] from your grip!</span>")
+				if(!repel)
+					step_towards(I, S)
+				else
+					step_away(I, S)
+				to_chat(src, "<span class = 'warning'>\The [S] [repel ? "pushes" : "pulls"] \the [I] from your grip!</span>")
 	if(radiations)
 		apply_radiation(current_size * radiations, RAD_EXTERNAL)
 	if(shoes)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1494,7 +1494,7 @@
 	investigation_log(I_SINGULO,"has been consumed by a singularity")
 	gib()
 	return gain
-/mob/living/carbon/human/singularity_pull(S, current_size,var/radiations = 3)
+/mob/living/carbon/human/singularity_pull(S, current_size, repel = FALSE, var/radiations = 3)
 	if(src.flags & INVULNERABLE)
 		return 0
 	if(current_size >= STAGE_THREE) //Pull items from hand

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1243,9 +1243,12 @@ Thanks.
 		gib()
 		return(gain)
 
-/mob/living/singularity_pull(S)
+/mob/living/singularity_pull(S, current_size, repel = FALSE)
 	if(!(src.flags & INVULNERABLE))
-		step_towards(src, S)
+		if(!repel)
+			step_towards(src, S)
+		else
+			step_away(src, S)
 
 //shuttle_act is called when a shuttle collides with the mob
 /mob/living/shuttle_act(datum/shuttle/S)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -67,7 +67,7 @@ var/list/obj/machinery/singularity/global_singularity_pool
 /obj/machinery/singularity/proc/link_wormhole(var/obj/machinery/singularity/other)
 	if(other)
 		other.name = "white hole"
-		desc = "Every action has an equal and opposite reaction. A black hole sucks time and matter out of the universe, a white hole returns it."
+		other.desc = "Every action has an equal and opposite reaction. A black hole sucks time and matter out of the universe, a white hole returns it."
 		other.repels = TRUE
 		other.energy = src.energy
 		other.color= list(-1,0,0,

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -56,7 +56,9 @@ var/list/obj/machinery/singularity/global_singularity_pool
 	if(!global_singularity_pool)
 		global_singularity_pool = list()
 	global_singularity_pool += src
-	if(prob(10) && global_singularity_pool.len > 1)
+
+/obj/machinery/singularity/proc/link_a_wormhole()
+	if(global_singularity_pool.len > 1)
 		var/obj/machinery/singularity/other = pick(global_singularity_pool)
 		if(other && other != src)
 			if(prob(50))
@@ -66,6 +68,8 @@ var/list/obj/machinery/singularity/global_singularity_pool
 
 /obj/machinery/singularity/proc/link_wormhole(var/obj/machinery/singularity/other)
 	if(other)
+		visible_message("<span class='notice'>[src] pulsates as a distinctive [get_area(other) ? "[get_area(other)]": "place"] becomes visible.</span>")
+		other.visible_message("<span class='notice'>[other] pulsates as a distinctive [get_area(src) ? "[get_area(src)]": "place"] becomes visible.</span>")
 		other.name = "white hole"
 		other.desc = "Every action has an equal and opposite reaction. A black hole sucks time and matter out of the universe, a white hole returns it."
 		other.repels = TRUE

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -57,18 +57,18 @@ var/list/obj/machinery/singularity/white_hole_candidates
 	if(!global_singularity_pool)
 		global_singularity_pool = list()
 	global_singularity_pool += src
-	if(!repels)
-		if(!white_hole_candidates)
-			white_hole_candidates = list()
-		if(!(src in white_hole_candidates))
-			white_hole_candidates += src
+	if(!white_hole_candidates)
+		white_hole_candidates = list()
+	if(!repels && !(src in white_hole_candidates))
+		white_hole_candidates += src
 	if(prob(1) && white_hole_candidates.len > 1)
 		link_a_wormhole()
 
 /obj/machinery/singularity/proc/link_a_wormhole()
 	var/obj/machinery/singularity/other = null
-	while(white_hole_candidates.len > 1 && other == src)
+	do
 		other = pick(white_hole_candidates)
+	while(white_hole_candidates.len > 1 && other == src)
 	if(other && other != src)
 		if(prob(50))
 			link_wormhole(other)
@@ -94,15 +94,21 @@ var/list/obj/machinery/singularity/white_hole_candidates
 
 /obj/machinery/singularity/proc/unlink_wormholes()
 	if(wormhole_out)
+		visible_message("<span class='warning'>[get_area(wormhole_out) ? "[get_area(wormhole_out)]": "The strange place"] is no longer visible as [src] closes its path to it.</span>")
 		wormhole_out.name = initial(wormhole_out.name)
 		wormhole_out.desc = initial(wormhole_out.desc)
 		wormhole_out.repels = FALSE
 		wormhole_out.color= initial(wormhole_out.color)
+		if(!(wormhole_out in white_hole_candidates))
+			white_hole_candidates += wormhole_out
 		wormhole_out = null
 	if(wormhole_in)
+		visible_message("<span class='warning'>[get_area(wormhole_in) ? "[get_area(wormhole_in)]": "The strange place"] is no longer visible as [src] closes its path to it.</span>")
 		name = initial(name)
 		repels = FALSE
 		color = initial(color)
+		if(!(src in white_hole_candidates))
+			white_hole_candidates += src
 		wormhole_in = null
 
 /obj/machinery/singularity/attack_hand(mob/user as mob)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -155,8 +155,10 @@ var/list/obj/machinery/singularity/global_singularity_pool
 					animate(L, alpha = 255, time = 3 SECONDS)
 
 /obj/machinery/singularity/Hear(var/datum/speech/speech, var/rendered_message="")
-	if(repels && speech.speaker.dna) // Wait a minute... I missed a discussion!
-		speech_messages[speech.speaker.dna] = speech.message // We all did
+	if(repels && ismob(speech.speaker))
+		var/mob/M = speech.speaker
+		if(M.dna) // Wait a minute... I missed a discussion!
+			speech_messages[M.dna] = speech.message // We all did
 
 /obj/machinery/singularity/process()
 	dissipate()
@@ -169,7 +171,7 @@ var/list/obj/machinery/singularity/global_singularity_pool
 			event()
 	eat()
 	if(repels && speech_messages.len) // I've never seen one before, no one has, but I'm guessing it's a white hole.
-		for(var/mob/M in viewers) // A white hole?
+		for(var/mob/M in viewers(src)) // A white hole?
 			if((M.dna in speech_messages) && prob(10))
 				if(prob(90)) // So that thing's spewing time? Back into the universe?
 					M.say(speech_messages[M.dna])

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -58,7 +58,7 @@ var/list/obj/machinery/singularity/global_singularity_pool
 	global_singularity_pool += src
 	if(prob(10) && global_singularity_pool.len > 1)
 		var/obj/machinery/singularity/other = pick(global_singularity_pool)
-		if(other)
+		if(other && other != src)
 			if(prob(50))
 				link_wormhole(other)
 			else

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -60,7 +60,7 @@ var/list/obj/machinery/singularity/global_singularity_pool
 /obj/machinery/singularity/proc/link_a_wormhole()
 	if(global_singularity_pool.len > 1)
 		var/obj/machinery/singularity/other = pick(global_singularity_pool)
-		if(other && other != src)
+		if(other && other != src && !other.repels)
 			if(prob(50))
 				link_wormhole(other)
 			else

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -56,6 +56,8 @@ var/list/obj/machinery/singularity/global_singularity_pool
 	if(!global_singularity_pool)
 		global_singularity_pool = list()
 	global_singularity_pool += src
+	if(prob(1))
+		link_a_wormhole()
 
 /obj/machinery/singularity/proc/link_a_wormhole()
 	if(global_singularity_pool.len > 1)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -67,6 +67,7 @@ var/list/obj/machinery/singularity/global_singularity_pool
 /obj/machinery/singularity/proc/link_wormhole(var/obj/machinery/singularity/other)
 	if(other)
 		other.name = "gravitational soutgularity"
+		desc = "Every action has an equal and opposite reaction. A black hole sucks time and matter out of the universe, a white hole returns it"
 		other.repels = TRUE
 		other.energy = src.energy
 		other.color= list(-1,0,0,
@@ -79,6 +80,7 @@ var/list/obj/machinery/singularity/global_singularity_pool
 /obj/machinery/singularity/proc/unlink_wormholes()
 	if(wormhole_out)
 		wormhole_out.name = initial(wormhole_out.name)
+		wormhole_out.desc = initial(wormhole_out.desc)
 		wormhole_out.repels = FALSE
 		wormhole_out.color= initial(wormhole_out.color)
 		wormhole_out = null
@@ -978,6 +980,7 @@ var/list/obj/machinery/singularity/global_singularity_pool
 
 /obj/machinery/singularity/soutgularity
 	name = "gravitational soutgularity"
+	desc = "Every action has an equal and opposite reaction. A black hole sucks time and space out of the universe, a white hole returns it"
 	repels = TRUE
 	color= list(-1,0,0,
 				0,-1,0,

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -13,6 +13,7 @@ var/list/global_singularity_pool
 	use_power = 0
 
 	var/obj/machinery/singularity/wormhole_out = null
+	var/obj/machinery/singularity/wormhole_in = null
 	var/current_size = 1
 	var/allowed_size = 1
 	var/contained = 1 //Are we going to move around?
@@ -57,13 +58,33 @@ var/list/global_singularity_pool
 	if(prob(10))
 		var/obj/machinery/singularity/other = locate(/obj/machinery/singularity) in power_machines
 		if(other)
-			other.name = "gravitational soutgularity"
-			other.repels = TRUE
-			other.color= list(-1,0,0,
-						0,-1,0,
-						0,0,-1,
-						1,1,1) //Invert it
-			wormhole_out = other
+			if(prob(50))
+				link_wormhole(other)
+			else
+				other.link_wormhole(src)
+
+/obj/machinery/singularity/link_wormhole(var/obj/machinery/singularity/other)
+	if(other)
+		other.name = "gravitational soutgularity"
+		other.repels = TRUE
+		other.color= list(-1,0,0,
+					0,-1,0,
+					0,0,-1,
+					1,1,1) //Invert it
+		wormhole_out = other
+		wormhole_in = src
+
+/obj/machinery/singularity/unlink_wormholes()
+	if(wormhole_out)
+		wormhole_out.name = initial(wormhole_out.name)
+		wormhole_out.repels = FALSE
+		wormhole_out.color= initial(wormhole_out.color)
+		wormhole_out = null
+	if(wormhole_in)
+		name = initial_name()
+		repels = FALSE
+		color = initial(color)
+		wormhole_in = null
 
 /obj/machinery/singularity/attack_hand(mob/user as mob)
 	consume(user)
@@ -659,6 +680,7 @@ var/list/global_singularity_pool
 */ //Fuck you centcomm
 
 /obj/machinery/singularity/Destroy()
+	unlink_wormholes()
 	..()
 	power_machines -= src
 	global_singularity_pool -= src

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -444,9 +444,9 @@ var/list/obj/machinery/singularity/global_singularity_pool
 			newsea.ChangeTurf(/turf/unsimulated/wall/supermatter)
 
 /obj/machinery/singularity/proc/consume(const/atom/A)
-	if(repels)
+	if(repels && !(istype(A,/obj/item/bluespace_crystal)))
 		return
-	if(wormhole_out)
+	if(wormhole_out && !(istype(A,/obj/item/bluespace_crystal)))
 		var/turf/T = get_turf(wormhole_out)
 		do_teleport(A, T)
 	else

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -63,7 +63,7 @@ var/list/global_singularity_pool
 			else
 				other.link_wormhole(src)
 
-/obj/machinery/singularity/link_wormhole(var/obj/machinery/singularity/other)
+/obj/machinery/singularity/proc/link_wormhole(var/obj/machinery/singularity/other)
 	if(other)
 		other.name = "gravitational soutgularity"
 		other.repels = TRUE
@@ -74,14 +74,14 @@ var/list/global_singularity_pool
 		wormhole_out = other
 		wormhole_in = src
 
-/obj/machinery/singularity/unlink_wormholes()
+/obj/machinery/singularity/proc/unlink_wormholes()
 	if(wormhole_out)
 		wormhole_out.name = initial(wormhole_out.name)
 		wormhole_out.repels = FALSE
 		wormhole_out.color= initial(wormhole_out.color)
 		wormhole_out = null
 	if(wormhole_in)
-		name = initial_name()
+		name = initial(name)
 		repels = FALSE
 		color = initial(color)
 		wormhole_in = null
@@ -427,7 +427,7 @@ var/list/global_singularity_pool
 		return
 	if(wormhole_out)
 		var/turf/T = get_turf(wormhole_out)
-		A.forceMove(T)
+		do_teleport(A, T)
 	else
 		var/gain = A.singularity_act(current_size,src)
 		src.energy += gain

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -67,7 +67,7 @@ var/list/obj/machinery/singularity/global_singularity_pool
 /obj/machinery/singularity/proc/link_wormhole(var/obj/machinery/singularity/other)
 	if(other)
 		other.name = "white hole"
-		desc = "Every action has an equal and opposite reaction. A black hole sucks time and matter out of the universe, a white hole returns it"
+		desc = "Every action has an equal and opposite reaction. A black hole sucks time and matter out of the universe, a white hole returns it."
 		other.repels = TRUE
 		other.energy = src.energy
 		other.color= list(-1,0,0,
@@ -980,7 +980,7 @@ var/list/obj/machinery/singularity/global_singularity_pool
 
 /obj/machinery/singularity/soutgularity
 	name = "white hole"
-	desc = "Every action has an equal and opposite reaction. A black hole sucks time and space out of the universe, a white hole returns it"
+	desc = "Every action has an equal and opposite reaction. A black hole sucks time and space out of the universe, a white hole returns it."
 	repels = TRUE
 	color= list(-1,0,0,
 				0,-1,0,

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -66,7 +66,7 @@ var/list/obj/machinery/singularity/global_singularity_pool
 
 /obj/machinery/singularity/proc/link_wormhole(var/obj/machinery/singularity/other)
 	if(other)
-		other.name = "gravitational soutgularity"
+		other.name = "white hole"
 		desc = "Every action has an equal and opposite reaction. A black hole sucks time and matter out of the universe, a white hole returns it"
 		other.repels = TRUE
 		other.energy = src.energy
@@ -979,7 +979,7 @@ var/list/obj/machinery/singularity/global_singularity_pool
 	modifier = "scrung_"
 
 /obj/machinery/singularity/soutgularity
-	name = "gravitational soutgularity"
+	name = "white hole"
 	desc = "Every action has an equal and opposite reaction. A black hole sucks time and space out of the universe, a white hole returns it"
 	repels = TRUE
 	color= list(-1,0,0,

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -60,7 +60,8 @@ var/list/obj/machinery/singularity/white_hole_candidates
 	if(!repels)
 		if(!white_hole_candidates)
 			white_hole_candidates = list()
-		white_hole_candidates += src
+		if(!(src in white_hole_candidates))
+			white_hole_candidates += src
 	if(prob(1) && white_hole_candidates.len > 1)
 		link_a_wormhole()
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -1,4 +1,5 @@
 var/list/obj/machinery/singularity/global_singularity_pool
+var/list/obj/machinery/singularity/white_hole_candidates
 
 /obj/machinery/singularity
 	name = "gravitational singularity" //Lower case
@@ -56,17 +57,22 @@ var/list/obj/machinery/singularity/global_singularity_pool
 	if(!global_singularity_pool)
 		global_singularity_pool = list()
 	global_singularity_pool += src
-	if(prob(1))
+	if(!repels)
+		if(!white_hole_candidates)
+			white_hole_candidates = list()
+		white_hole_candidates += src
+	if(prob(1) && white_hole_candidates.len > 1)
 		link_a_wormhole()
 
 /obj/machinery/singularity/proc/link_a_wormhole()
-	if(global_singularity_pool.len > 1)
-		var/obj/machinery/singularity/other = pick(global_singularity_pool)
-		if(other && other != src && !other.repels)
-			if(prob(50))
-				link_wormhole(other)
-			else
-				other.link_wormhole(src)
+	var/obj/machinery/singularity/other = null
+	while(white_hole_candidates.len > 1 && other == src)
+		other = pick(white_hole_candidates)
+	if(other && other != src)
+		if(prob(50))
+			link_wormhole(other)
+		else
+			other.link_wormhole(src)
 
 /obj/machinery/singularity/proc/link_wormhole(var/obj/machinery/singularity/other)
 	if(other)
@@ -82,6 +88,8 @@ var/list/obj/machinery/singularity/global_singularity_pool
 					1,1,1) //Invert it
 		wormhole_out = other
 		other.wormhole_in = src
+		if(other in white_hole_candidates)
+			white_hole_candidates -= other
 
 /obj/machinery/singularity/proc/unlink_wormholes()
 	if(wormhole_out)
@@ -707,6 +715,7 @@ var/list/obj/machinery/singularity/global_singularity_pool
 	..()
 	power_machines -= src
 	global_singularity_pool -= src
+	white_hole_candidates -= src
 
 /obj/machinery/singularity/bite_act(mob/user)
 	consume(user)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -72,7 +72,7 @@ var/list/global_singularity_pool
 					0,0,-1,
 					1,1,1) //Invert it
 		wormhole_out = other
-		wormhole_in = src
+		other.wormhole_in = src
 
 /obj/machinery/singularity/proc/unlink_wormholes()
 	if(wormhole_out)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -34,6 +34,7 @@ var/list/obj/machinery/singularity/global_singularity_pool
 	var/chained = 0 //Adminbus chain-grab
 	var/modifier = "" //for memes
 	var/repels = FALSE //For pushing stuff out the other end
+	var/list/speech_messages = list() //Time is occuring in random pockets. The laws of causality no longer apply.
 
 /obj/machinery/singularity/New(loc, var/starting_energy = 50, var/temp = 0)
 	//CARN: admin-alert for chuckle-fuckery.
@@ -153,6 +154,10 @@ var/list/obj/machinery/singularity/global_singularity_pool
 					L.forceMove(get_turf(user))
 					animate(L, alpha = 255, time = 3 SECONDS)
 
+/obj/machinery/singularity/Hear(var/datum/speech/speech, var/rendered_message="")
+	if(repels && speech.speaker.dna) // Wait a minute... I missed a discussion!
+		speech_messages[speech.speaker.dna] = speech.message // We all did
+
 /obj/machinery/singularity/process()
 	dissipate()
 	check_energy()
@@ -163,6 +168,13 @@ var/list/obj/machinery/singularity/global_singularity_pool
 		if(prob(event_chance)) //Chance for it to run a special event TODO: Come up with one or two more that fit.
 			event()
 	eat()
+	if(repels && speech_messages.len) // I've never seen one before, no one has, but I'm guessing it's a white hole.
+		for(var/mob/M in viewers) // A white hole?
+			if((M.dna in speech_messages) && prob(10))
+				if(prob(90)) // So that thing's spewing time? Back into the universe?
+					M.say(speech_messages[M.dna])
+				else
+					M.say("So what is it?") //Only joking
 
 /obj/machinery/singularity/attack_ai() //To prevent AIs from gibbing themselves when they click on one.
 	return

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -1,4 +1,4 @@
-var/list/global_singularity_pool
+var/list/obj/machinery/singularity/global_singularity_pool
 
 /obj/machinery/singularity
 	name = "gravitational singularity" //Lower case
@@ -55,8 +55,8 @@ var/list/global_singularity_pool
 	if(!global_singularity_pool)
 		global_singularity_pool = list()
 	global_singularity_pool += src
-	if(prob(10))
-		var/obj/machinery/singularity/other = locate(/obj/machinery/singularity) in power_machines
+	if(prob(10) && global_singularity_pool.len > 1)
+		var/obj/machinery/singularity/other = pick(global_singularity_pool)
 		if(other)
 			if(prob(50))
 				link_wormhole(other)
@@ -67,6 +67,7 @@ var/list/global_singularity_pool
 	if(other)
 		other.name = "gravitational soutgularity"
 		other.repels = TRUE
+		other.energy = src.energy
 		other.color= list(-1,0,0,
 					0,-1,0,
 					0,0,-1,

--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -53,7 +53,7 @@
 		else
 			S.link_a_wormhole()
 		if(istype(src,/obj/item/bluespace_crystal/flawless) && S.wormhole_out)
-			var/turf/T = get_turf(wormhole_out)
+			var/turf/T = get_turf(S.wormhole_out)
 			do_teleport(src, T)
 		else
 			qdel(src)

--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -46,7 +46,9 @@
 	qdel(src)
 
 /obj/item/bluespace_crystal/singularity_act(var/current_size,var/obj/machinery/singularity/S)
-	if(!(istype(src,/obj/item/bluespace_crystal/artificial)) || prob(50))
+	if(istype(src,/obj/item/bluespace_crystal/artificial)
+		return ..()
+	if(istype(src,/obj/item/bluespace_crystal/flawless) || prob(50))
 		if(S.wormhole_out || S.wormhole_in)
 			S.unlink_wormholes()
 		else
@@ -55,7 +57,7 @@
 			var/turf/T = get_turf(S.wormhole_out)
 			do_teleport(src, T)
 		else
-			qdel(src)
+			return ..()
 
 // Artifical bluespace crystal, doesn't give you much research.
 

--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -46,8 +46,7 @@
 	qdel(src)
 
 /obj/item/bluespace_crystal/singularity_act(var/current_size,var/obj/machinery/singularity/S)
-	var/prob = istype(src,/obj/item/bluespace_crystal/artificial) ? 50 : 100
-	if(prob)
+	if(!(istype(src,/obj/item/bluespace_crystal/artificial)) || prob(50))
 		if(S.wormhole_out)
 			S.unlink_wormholes()
 		else

--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -47,7 +47,7 @@
 
 /obj/item/bluespace_crystal/singularity_act(var/current_size,var/obj/machinery/singularity/S)
 	if(!(istype(src,/obj/item/bluespace_crystal/artificial)) || prob(50))
-		if(S.wormhole_out)
+		if(S.wormhole_out || S.wormhole_in)
 			S.unlink_wormholes()
 		else
 			S.link_a_wormhole()

--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -51,7 +51,7 @@
 	if(istype(src,/obj/item/bluespace_crystal/flawless) || prob(10))
 		if(S.wormhole_out || S.wormhole_in)
 			S.unlink_wormholes()
-		else
+		else if(white_hole_candidates.len > 1)
 			S.link_a_wormhole()
 		if(istype(src,/obj/item/bluespace_crystal/flawless) && S.wormhole_out)
 			var/turf/T = get_turf(S.wormhole_out)

--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -56,8 +56,8 @@
 		if(istype(src,/obj/item/bluespace_crystal/flawless) && S.wormhole_out)
 			var/turf/T = get_turf(S.wormhole_out)
 			do_teleport(src, T)
-		else
-			return ..()
+			return 2
+	return ..()
 
 // Artifical bluespace crystal, doesn't give you much research.
 

--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -45,6 +45,19 @@
 
 	qdel(src)
 
+/obj/item/bluespace_crystal/singularity_act(var/current_size,var/obj/machinery/singularity/S)
+	var/prob = istype(src,/obj/item/bluespace_crystal/artificial) ? 50 : 100
+	if(prob)
+		if(S.wormhole_out)
+			S.unlink_wormholes()
+		else
+			S.link_a_wormhole()
+		if(istype(src,/obj/item/bluespace_crystal/flawless) && S.wormhole_out)
+			var/turf/T = get_turf(wormhole_out)
+			do_teleport(src, T)
+		else
+			qdel(src)
+
 // Artifical bluespace crystal, doesn't give you much research.
 
 /obj/item/bluespace_crystal/artificial

--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -46,7 +46,7 @@
 	qdel(src)
 
 /obj/item/bluespace_crystal/singularity_act(var/current_size,var/obj/machinery/singularity/S)
-	if(istype(src,/obj/item/bluespace_crystal/artificial)
+	if(istype(src,/obj/item/bluespace_crystal/artificial))
 		return ..()
 	if(istype(src,/obj/item/bluespace_crystal/flawless) || prob(50))
 		if(S.wormhole_out || S.wormhole_in)

--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -48,7 +48,7 @@
 /obj/item/bluespace_crystal/singularity_act(var/current_size,var/obj/machinery/singularity/S)
 	if(istype(src,/obj/item/bluespace_crystal/artificial))
 		return ..()
-	if(istype(src,/obj/item/bluespace_crystal/flawless) || prob(50))
+	if(istype(src,/obj/item/bluespace_crystal/flawless) || prob(10))
 		if(S.wormhole_out || S.wormhole_in)
 			S.unlink_wormholes()
 		else


### PR DESCRIPTION
[content]
When they're linked, the outwards facing one becomes a "white hole", that repels items from it rather than attracting and eating them, and the old inward one teleports them to the outward one on consumption.

:cl:
 * rscadd: Two singularities existing at once in the world can now "link" with each other on creation (1% chance) or on reaction with bluespace crystals (10% chance if not flawless, artifical ones won't work) as a one directional wormhole, with the outwards facing one repelling items instead of attracting, and teleporting items to it from the inward one instead of them being consumed by that. They may also spew time, back into the universe.