### PR TITLE
Fixes puddles being pulled or put in crates

### DIFF
--- a/code/modules/liquid/splash_simulation.dm
+++ b/code/modules/liquid/splash_simulation.dm
@@ -14,6 +14,7 @@ var/static/list/burnable_reagents = list(FUEL) //TODO: More types later
 	name = "puddle"
 	plane = ABOVE_TURF_PLANE
 	layer = PUDDLE_LAYER
+	anchored = TRUE
 	var/turf/turf_on
 
 /obj/effect/overlay/puddle/New()


### PR DESCRIPTION
[bugfix][tested]
Closes #32199.
Closes #32201.

:cl:
 * bugfix: Puddles can no longer be stored in crates.
 * bugfix: Puddles can no longer be pulled or grabbed with telekinesis.
