### PR TITLE
Plasmaman and vox helmets no longer prevent determining the wearer's gender

### DIFF
--- a/__DEFINES/clothing.dm
+++ b/__DEFINES/clothing.dm
@@ -1,6 +1,6 @@
 #define HIDES_IDENTITY_DEFAULT 0
 #define HIDES_IDENTITY_ALWAYS 1
-
+#define HIDES_IDENTITY_NEVER -1
 
 //clothing flags
 #define MASKINTERNALS		1 // mask allows internals

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -118,6 +118,7 @@
 	species_restricted = list(VOX_SHAPED)
 	species_fit = list(VOX_SHAPED)
 	body_parts_visible_override = 0
+	hides_identity = HIDES_IDENTITY_NEVER
 
 /obj/item/clothing/head/helmet/space/vox/pressure
 	name = "alien helmet"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -42,7 +42,7 @@
 	species_restricted = list(PLASMAMAN_SHAPED)
 	species_fit = list(PLASMAMAN_SHAPED)
 	eyeprot = 0
-
+	hides_identity = HIDES_IDENTITY_NEVER
 	icon_state = "plasmaman_helmet0"
 	item_state = "plasmaman_helmet0"
 	var/base_state = "plasmaman_helmet"


### PR DESCRIPTION
It used to work like this before a series of bugfixes changed it. I don't think it was intentional, either way.

:cl:
 * tweak: Plasmaman and vox helmets no longer prevent determining the wearer's gender.