### PR TITLE
Enables puddle reacting/spreading

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -176,7 +176,7 @@
 	var/emag_recharge_ticks = 0
 
 	var/puddle_spreading = 0 //If puddles can spread
-	var/puddle_reactions = 0 //If puddles can react chemicals in them
+	var/puddle_reactions = 1 //If puddles can react chemicals in them
 
 	var/map_voting = 0
 	var/renders_url = ""
@@ -590,8 +590,8 @@
 					multiz_bottom_cap = text2num(value)
 				if("enable_puddle_spread")
 					config.puddle_spreading = 1
-				if("enable_puddle_react")
-					config.puddle_reactions = 1
+				if("disable_puddle_react")
+					config.puddle_reactions = 0
 
 				if("media_base_url")
 					media_base_url = value

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -175,7 +175,7 @@
 	var/emag_recharge_rate = 0
 	var/emag_recharge_ticks = 0
 
-	var/puddle_spreading = 0 //If puddles can spread
+	var/puddle_spreading = 1 //If puddles can spread
 	var/puddle_reactions = 1 //If puddles can react chemicals in them
 
 	var/map_voting = 0
@@ -588,8 +588,8 @@
 					multiz_render_cap = text2num(value)
 				if("multiz_bottom_cap")
 					multiz_bottom_cap = text2num(value)
-				if("enable_puddle_spread")
-					config.puddle_spreading = 1
+				if("disable_puddle_spread")
+					config.puddle_spreading = 0
 				if("disable_puddle_react")
 					config.puddle_reactions = 0
 

--- a/code/modules/liquid/splash_simulation.dm
+++ b/code/modules/liquid/splash_simulation.dm
@@ -45,7 +45,7 @@ var/static/list/burnable_reagents = list(FUEL) //TODO: More types later
 
 /obj/effect/overlay/puddle/proc/spread()
 	var/excess_volume = turf_on.reagents.total_volume - MAX_PUDDLE_VOLUME
-	var/list/spread_directions = cardinal
+	var/list/spread_directions = cardinal.Copy()
 	for(var/direction in spread_directions)
 		var/turf/T = get_step(src,direction)
 		if(!T)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -29,11 +29,12 @@
 	var/datum/log_controller/I = investigations[I_CHEMS]
 	var/atom/A = holder.my_atom
 	var/turf/T = get_turf(holder.my_atom)
-	var/mob/M = get_holder_of_type(A, /mob) //if held by a mob (not necessarily true)
+	var/mob/M = T != A ? get_holder_of_type(A, /mob) : null //if held by a mob (not necessarily true, and turfs cannot be "held" by mobs)
 
-	var/obj/machinery/O = get_holder_of_type(A, /obj/machinery) //rather than showing "in a large beaker" let's show the name of the machine if it's inside one
-	if(istype(O))
-		A = O
+	if(T != A) //machinery cannot "hold" turfs
+		var/obj/machinery/O = get_holder_of_type(A, /obj/machinery) //rather than showing "in a large beaker" let's show the name of the machine if it's inside one
+		if(istype(O))
+			A = O
 
 	var/investigate_text = "<small>[time_stamp()] \ref[A] ([formatJumpTo(T)])</small> || "
 
@@ -3676,7 +3677,7 @@
 	result = BLACKCOLOR
 	required_reagents = list(COLORFUL_REAGENT = 1, CARBON = 1)
 	result_amount = 2
-	
+
 /datum/chemical_reaction/degeneratecalcium
 	name = "Degenerate Calcium"
 	id = DEGENERATECALCIUM

--- a/config-example/config.txt
+++ b/config-example/config.txt
@@ -376,5 +376,5 @@ MULTIZ_BOTTOM_CAP 16
 ## Comment to disable puddles spreading
 ENABLE_PUDDLE_SPREAD
 
-## Comment to disable puddles reacting
-ENABLE_PUDDLE_REACT
+## Uncomment to disable puddles reacting
+#DISABLE_PUDDLE_REACT

--- a/config-example/config.txt
+++ b/config-example/config.txt
@@ -373,8 +373,8 @@ MULTIZ_RENDER_CAP 8
 ## The maximum number of z-levels checked below in multi-z
 MULTIZ_BOTTOM_CAP 16
 
-## Comment to disable puddles spreading
-ENABLE_PUDDLE_SPREAD
+## Uncomment to disable puddles spreading
+#DISABLE_PUDDLE_SPREAD
 
 ## Uncomment to disable puddles reacting
 #DISABLE_PUDDLE_REACT


### PR DESCRIPTION
[bugfix]
Closes #32197.
Closes #32198.
Closes #32202.

Also fixes issues with puddle reaction log runtimes and spreading removing cardinal directions from the entire game.