### PR TITLE
Fixed plasma reagent runtime

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2671,7 +2671,7 @@
 		return 1
 
 	var/mob/living/carbon/human/H = M
-	if(isplasmaman(H) || H.species.flags & PLASMA_IMMUNE)
+	if(istype(H) && H.species.flags & PLASMA_IMMUNE)
 		return 1
 	else
 		M.adjustToxLoss(3 * REM)


### PR DESCRIPTION
```
[16:00:31] Runtime in Chemistry-Reagents.dm, line 2674: undefined variable /mob/living/carbon/monkey/punpun/var/species
proc name: on mob life (/datum/reagent/plasma/on_mob_life)
src: Plasma (/datum/reagent/plasma)
call stack:
Plasma (/datum/reagent/plasma): on mob life(Pun Pun (/mob/living/carbon/monkey/punpun), 0)
/datum/reagents (/datum/reagents): metabolize(Pun Pun (/mob/living/carbon/monkey/punpun), 0)
Pun Pun (/mob/living/carbon/monkey/punpun): handle chemicals in body()
Pun Pun (/mob/living/carbon/monkey/punpun): Life()
Mob (/datum/subsystem/mob): fire(1)
Mob (/datum/subsystem/mob): ignite(1)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing()
(This error will now be silenced for 10 minutes)
```