### PR TITLE
Fixes inability to put items into containers with unset health.

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -370,7 +370,7 @@
 	if(usr) //WHYYYYY
 
 		//Allow smashing of storage items on harm intent without also putting the weapon into the container.
-		if(valid_item_attack(W, usr) || health <= 0)
+		if(valid_item_attack(W, usr) || (health && health <= 0))
 			return 0
 
 		usr.u_equip(W,0)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -370,7 +370,7 @@
 	if(usr) //WHYYYYY
 
 		//Allow smashing of storage items on harm intent without also putting the weapon into the container.
-		if(valid_item_attack(W, usr) || (health && health <= 0))
+		if(valid_item_attack(W, usr) || (!isnull(health) && health <= 0))
 			return 0
 
 		usr.u_equip(W,0)


### PR DESCRIPTION
[bugfix]
Fixes bug where items with null `health` var can't have items inserted into them.
:cl:
 * bugfix: Items can be inserted into healthless items again.
