### PR TITLE
Bleach recipe tweak

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1145,7 +1145,7 @@
 	id = BLEACH
 	result = BLEACH
 	required_reagents = list(SODIUMCHLORIDE = 2, CLEANER = 2, OXYGEN = 1)
-	result_amount = 1
+	result_amount = 2
 
 //This one isn't even close the the real life reaction but will have to do to avoid conflicts with the above reactions.
 /datum/chemical_reaction/luminol


### PR DESCRIPTION
The recipe's way too expensive. Making 250u of bleach uses all of a chem dispenser's charge, and a bit extra from another. Small tweak so it is cheaper to make in high volumes but not balance changing.
I considered making it 3u instead of 2u but that seemed a bit much.
[tweak]
:cl:
 * tweak: The bleach manufacture reaction now makes 2u instead of 1u.
