### PR TITLE
Puddle code cleanup and performance

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -20,6 +20,8 @@
 /turf/simulated/on_reagent_change()
 	if(config.puddle_reactions)
 		reagents.reaction(src, volume_multiplier = 0)
+	if(current_puddle)
+		current_puddle.update_icon()
 
 /turf/simulated/proc/AddTracks(var/typepath,var/bloodDNA,var/comingdir,var/goingdir,var/bloodcolor=DEFAULT_BLOOD)
 	var/obj/effect/decal/cleanable/blood/tracks/tracks = locate(typepath) in src

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -20,8 +20,6 @@
 /turf/simulated/on_reagent_change()
 	if(config.puddle_reactions)
 		reagents.reaction(src, volume_multiplier = 0)
-	if(current_puddle)
-		current_puddle.update_icon()
 
 /turf/simulated/proc/AddTracks(var/typepath,var/bloodDNA,var/comingdir,var/goingdir,var/bloodcolor=DEFAULT_BLOOD)
 	var/obj/effect/decal/cleanable/blood/tracks/tracks = locate(typepath) in src

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -377,6 +377,7 @@ var/list/admin_verbs_mod = list(
 		/client/proc/ticklag,
 		/client/proc/cmd_admin_grantfullaccess,
 		/client/proc/kaboom,
+		/client/proc/toggle_puddle_values,
 		/client/proc/cmd_admin_areatest,
 		/client/proc/readmin,
 		/proc/generateMiniMaps,

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -145,6 +145,7 @@ var/intercom_range_display_status = 0
 	src.verbs += /client/proc/ticklag	//allows you to set the ticklag.
 	src.verbs += /client/proc/cmd_admin_grantfullaccess
 	src.verbs += /client/proc/kaboom
+	src.verbs += /client/proc/toggle_puddle_values
 	src.verbs += /client/proc/cmd_admin_areatest
 	src.verbs += /client/proc/cmd_admin_rejuvenate
 	src.verbs += /datum/admins/proc/show_role_panel

--- a/code/modules/liquid/splash_simulation.dm
+++ b/code/modules/liquid/splash_simulation.dm
@@ -135,6 +135,8 @@ var/puddle_text = FALSE
 				return ..()
 
 /obj/effect/overlay/puddle/Destroy()
+	for(var/client/C in admins)
+		C.images -= debug_text
 	if(turf_on && turf_on.reagents)
 		turf_on.reagents.clear_reagents()
 	processing_objects.Remove(src)
@@ -143,9 +145,8 @@ var/puddle_text = FALSE
 	..()
 
 /obj/effect/overlay/puddle/update_icon()
-	if(puddle_text)
-		for(var/client/C in admins)
-			C.images -= debug_text
+	for(var/client/C in admins)
+		C.images -= debug_text
 	if(turf_on && turf_on.reagents && turf_on.reagents.reagent_list.len)
 		color = mix_color_from_reagents(turf_on.reagents.reagent_list,TRUE)
 		alpha = mix_alpha_from_reagents(turf_on.reagents.reagent_list,TRUE)
@@ -153,15 +154,15 @@ var/puddle_text = FALSE
 		// Absolute scaling with volume, Scale() would give relative.
 		transform = matrix(min(1, puddle_volume / CIRCLE_PUDDLE_VOLUME), 0, 0, 0, min(1, puddle_volume / CIRCLE_PUDDLE_VOLUME), 0)
 		if(puddle_text)
+			var/round = 1
+			if(puddle_volume < 1000)
+				round = 0.1
+			if(puddle_volume < 100)
+				round = 0.01
+			if(puddle_volume < 10)
+				round = 0.001
+			debug_text.maptext = "<span class = 'center maptext black_outline'>[round(puddle_volume, round)]</span>"
 			for(var/client/C in admins)
-				var/round = 1
-				if(puddle_volume < 1000)
-					round = 0.1
-				if(puddle_volume < 100)
-					round = 0.01
-				if(puddle_volume < 10)
-					round = 0.001
-				debug_text.maptext = "<span class = 'center maptext black_outline'>[round(puddle_volume, round)]</span>"
 				C.images += debug_text
 		relativewall()
 	else // Sanity

--- a/code/modules/liquid/splash_simulation.dm
+++ b/code/modules/liquid/splash_simulation.dm
@@ -48,10 +48,7 @@ var/puddle_text = FALSE
 	if(turf_on.reagents)
 		for(var/datum/reagent/R in turf_on.reagents.reagent_list)
 			if(R.evaporation_rate)
-				if(R.evaporation_rate < R.volume)
-					turf_on.reagents.remove_reagent(R.id, R.evaporation_rate)
-				else
-					turf_on.reagents.del_reagent(R.id,update_totals=0)
+				turf_on.reagents.remove_reagent(R.id, R.evaporation_rate)
 		if(config.puddle_spreading && turf_on.reagents.total_volume > MAX_PUDDLE_VOLUME)
 			spread()
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -163,7 +163,9 @@
 	if(T.reagents && T.can_accept_liquid(0) && self.reagent_state == REAGENT_STATE_LIQUID && self.creates_puddle)
 		if(volume)
 			T.reagents.add_reagent(self.id, volume)
-		if(!T.current_puddle)
+		if(T.current_puddle)
+			T.current_puddle.update_icon()
+		else
 			new /obj/effect/overlay/puddle(T)
 
 /datum/reagent/proc/metabolize(var/mob/living/M)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -163,9 +163,7 @@
 	if(T.reagents && T.can_accept_liquid(0) && self.reagent_state == REAGENT_STATE_LIQUID && self.creates_puddle)
 		if(volume)
 			T.reagents.add_reagent(self.id, volume)
-		if(T.current_puddle)
-			T.current_puddle.update_icon()
-		else
+		if(!T.current_puddle)
 			new /obj/effect/overlay/puddle(T)
 
 /datum/reagent/proc/metabolize(var/mob/living/M)


### PR DESCRIPTION
[performance][tweak][tested]
Removing a bunch of redundant update_icon() calls, rewrites spread proc a bit and removes a redundant reaction() call, also adds an admin debug verb for showing total volume of puddles.
