### PR TITLE
No longer get ruptured lung with no lung damage

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_breath.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_breath.dm
@@ -60,7 +60,7 @@
 				if(!breath || breath.total_moles < BREATH_MOLES / 5 || breath.total_moles > BREATH_MOLES * 5)
 					if(prob(15)) // 15% chance for lung damage if air intake is less of a fifth, or more than five times the threshold
 						L.damage += 1
-					if(!is_lung_ruptured())
+					if(!is_lung_ruptured() && L.damage > 2)
 						var/chance_break = (L.damage / L.min_bruised_damage)*50 // Chance to rupture: 1/15 = 3%, 2/15 = 7%, etc...
 						if(prob(chance_break))
 							rupture_lung()

--- a/code/modules/mob/living/carbon/human/life/handle_breath.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_breath.dm
@@ -58,10 +58,10 @@
 				breath = environment.remove_volume(CELL_VOLUME * BREATH_PERCENTAGE)
 
 				if(!breath || breath.total_moles < BREATH_MOLES / 5 || breath.total_moles > BREATH_MOLES * 5)
-					if(prob(15)) // 15% chance for lung damage if air intake is less of a fifth, or more than five times the threshold
+					if(prob(20))
 						L.damage += 1
 					if(!is_lung_ruptured() && L.damage > 2)
-						var/chance_break = (L.damage / L.min_bruised_damage)*50 // Chance to rupture: 1/15 = 3%, 2/15 = 7%, etc...
+						var/chance_break = (L.damage / L.min_broken_damage)*100
 						if(prob(chance_break))
 							rupture_lung()
 


### PR DESCRIPTION
Tweaked the code so you can't instantly get a ruptured lung when exposed to vacuum, but increased the chances over longer exposure (very minor increase). The percentages in the comments weren't even correct.

:cl:
 * tweak: You will not get a ruptured lung instantly when in a vacuum
