### PR TITLE
Revert "Puddle slipping tweaks"

### DIFF
--- a/code/modules/liquid/splash_simulation.dm
+++ b/code/modules/liquid/splash_simulation.dm
@@ -107,9 +107,9 @@ var/static/list/burnable_reagents = list(FUEL) //TODO: More types later
 		if(isliving(AM))
 			var/mob/living/L = AM
 			if(turf_on.reagents.has_reagent(LUBE))
-				L.ApplySlip(TURF_WET_LUBE, turf_on.reagents.get_reagent_amount(LUBE))
+				L.ApplySlip(TURF_WET_LUBE)
 			else if(turf_on.reagents.has_any_reagents(MILDSLIPPABLES))
-				L.ApplySlip(TURF_WET_WATER, turf_on.reagents.get_reagent_amounts(MILDSLIPPABLES))
+				L.ApplySlip(TURF_WET_WATER)
 
 	else
 		return ..()
@@ -141,7 +141,7 @@ var/static/list/burnable_reagents = list(FUEL) //TODO: More types later
 		color = mix_color_from_reagents(turf_on.reagents.reagent_list,TRUE)
 		alpha = mix_alpha_from_reagents(turf_on.reagents.reagent_list,TRUE)
 		// Absolute scaling with volume, Scale() would give relative.
-		transform = matrix(clamp(turf_on.reagents.total_volume / CIRCLE_PUDDLE_VOLUME, 0.1, 1), 0, 0, 0, clamp(turf_on.reagents.total_volume / CIRCLE_PUDDLE_VOLUME, 0.1, 1), 0)
+		transform = matrix(min(1, turf_on.reagents.total_volume / CIRCLE_PUDDLE_VOLUME), 0, 0, 0, min(1, turf_on.reagents.total_volume / CIRCLE_PUDDLE_VOLUME), 0)
 	else // Sanity
 		qdel(src)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -656,19 +656,16 @@
 				regenerate_icons()
 
 
-/mob/living/carbon/ApplySlip(var/wet, var/intensity)
+/mob/living/carbon/ApplySlip(var/wet)
 	if (!..())
 		return FALSE
 
 	if (unslippable) //if unslippable, don't even bother making checks
 		return FALSE
 
-	if(intensity < 10)
-		return FALSE
-
 	switch(wet)
 		if(TURF_WET_WATER)
-			if (!Slip(stun_amount = min(5, intensity / 10), weaken_amount = min(3, intensity / 16), slip_on_walking = FALSE, overlay_type = TURF_WET_WATER))
+			if (!Slip(stun_amount = 5, weaken_amount = 3, slip_on_walking = FALSE, overlay_type = TURF_WET_WATER))
 				return FALSE
 			step(src, dir)
 			visible_message("<span class='warning'>[src] slips on the wet floor!</span>", \
@@ -676,9 +673,9 @@
 
 		if(TURF_WET_LUBE)
 			step(src, dir)
-			if (!Slip(stun_amount = min(5, intensity / 10), weaken_amount = min(3, intensity / 16), slip_on_walking = TRUE, overlay_type = TURF_WET_LUBE, slip_on_magbooties = TRUE))
+			if (!Slip(stun_amount = 5, weaken_amount = 3, slip_on_walking = TRUE, overlay_type = TURF_WET_LUBE, slip_on_magbooties = TRUE))
 				return FALSE
-			for (var/i = 1 to max(1,intensity / 12))
+			for (var/i = 1 to 4)
 				spawn(i)
 					if(!locked_to)
 						step(src, dir)
@@ -687,7 +684,7 @@
 			"<span class='warning'>You slip on the floor!</span>")
 
 		if(TURF_WET_ICE)
-			if(prob(30) && Slip(stun_amount = min(4, intensity / 12), weaken_amount = min(3, intensity / 16),  overlay_type = TURF_WET_ICE))
+			if(prob(30) && Slip(stun_amount = 4, weaken_amount = 3,  overlay_type = TURF_WET_ICE))
 				step(src, dir)
 				visible_message("<span class='warning'>[src] slips on the icy floor!</span>", \
 				"<span class='warning'>You slip on the icy floor!</span>")

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -998,7 +998,7 @@
 /mob/living/carbon/slime/IgniteMob()
 	return 0
 
-/mob/living/carbon/slime/ApplySlip(var/wet, var/intensity)
+/mob/living/carbon/slime/ApplySlip(var/wet)
 	return FALSE
 
 //////////////////////////////Old shit from metroids/RoRos, and the old cores, would not take much work to re-add them////////////////////////

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1728,7 +1728,7 @@ Thanks.
 	tool.reagents.reaction(src, INGEST)
 	return ..()
 
-/mob/living/proc/ApplySlip(var/wet, var/intensity)
+/mob/living/proc/ApplySlip(var/wet)
 	return on_foot() // Check if we have legs, gravity, etc. Checked by the children.
 
 /mob/living/proc/Slip(stun_amount, weaken_amount, slip_on_walking = 0, overlay_type, slip_with_magbooties = 0)

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -6,12 +6,12 @@
 /mob/living/silicon/robot/CheckSlip(slip_on_walking = FALSE, overlay_type = TURF_WET_WATER, slip_on_magbooties = FALSE)
 	return ((HAS_MODULE_QUIRK(src, MODULE_HAS_MAGPULSE))? SLIP_HAS_MAGBOOTS : FALSE)
 
-/mob/living/silicon/robot/ApplySlip(var/wet, var/intensity)
+/mob/living/silicon/robot/ApplySlip(var/wet)
 
 	if (wet != TURF_WET_WATER)
 		return FALSE
 
-	if(Slip(min(5, intensity / 10), min(3, intensity / 16)))
+	if(Slip(5,3))
 		//Don't step forward as a robot, we're not slipping just glitching.
 		visible_message("<span class='warning'>[src] short circuits on the water!</span>", \
 					"<span class='warning'>You short circuit on the water!</span>")

--- a/code/modules/mob/living/simple_animal/friendly/slime.dm
+++ b/code/modules/mob/living/simple_animal/friendly/slime.dm
@@ -131,5 +131,5 @@
 		clear_fullscreen("brute")
 	return TRUE
 
-/mob/living/simple_animal/slime/ApplySlip(var/wet, var/intensity)
+/mob/living/simple_animal/slime/ApplySlip(var/wet)
 	return FALSE

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -802,10 +802,6 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 
 	return 0
 
-/datum/reagents/proc/get_reagent_amounts(var/list/reagents)
-	for(var/R in reagents)
-		. += get_reagent_amount(R)
-
 /datum/reagents/proc/get_reagents()
 	var/res = ""
 	for(var/datum/reagent/A in reagent_list)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -739,7 +739,6 @@
 	id = LUBE
 	description = "Lubricant is a substance introduced between two moving surfaces to reduce the friction and wear between them. giggity."
 	viscosity = 25
-	evaporation_rate = 1
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#009CA8" //rgb: 0, 156, 168
 	overdose_am = REAGENTS_OVERDOSE
@@ -5144,7 +5143,6 @@
 	name = "Corn Oil"
 	id = CORNOIL
 	description = "An oil derived from various types of corn."
-	evaporation_rate = 1
 	reagent_state = REAGENT_STATE_LIQUID
 	nutriment_factor = 20 * REAGENTS_METABOLISM
 	color = "#302000" //rgb: 48, 32, 0


### PR DESCRIPTION
Reverts #32231.
Lube and water are now almost unusable. They evaporate way too quick. You can't even use the 5u sprays anymore since they can't make puddles at 5u. Clown Water Flowers can't make puddles (thus can't slip anyone) anymore since they spray 1u. Water is barely slippable. See #32243 for a list of issues with this "fix".