### PR TITLE
Project mind messages' font is now bold

### DIFF
--- a/__DEFINES/stylesheet.dm
+++ b/__DEFINES/stylesheet.dm
@@ -95,7 +95,7 @@ h1.alert, h2.alert		{color: #000000;}
 .good					{color: green;}
 .average				{color: #FF8000;}
 .bad					{color: #FF0000;}
-.mushroom				{color: #4B0082;}
+.mushroom				{color: #4B0082; font-weight: bold;}
 /* /vg/ Saycode Rewrite */
 .italics, .talkinto		{font-style:italic;}
 .whisper				{font-style:italic;color:#333333;}

--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -165,9 +165,9 @@
 			return
 
 		if(M_REMOTE_TALK in target.mutations)
-			target.show_message("<span class='notice'>You hear [user.real_name]'s voice: [say]</span>")
+			target.show_message("<span class='notice'>You hear [user.real_name]'s voice: </span><span class='bold'>[say]</span>")
 		else
-			target.show_message("<span class='notice'>You hear a voice that seems to echo around the room: [say]</span>")
+			target.show_message("<span class='notice'>You hear a voice that seems to echo around the room: </span><span class='bold'>[say]</span>")
 		user.show_message("<span class='notice'>You project your mind towards [believed_name]: [say]</span>")
 		log_admin("[key_name(user)] projects his mind towards (believed:[believed_name]/actual:[key_name(target)]: [say]</span>")
 		message_admins("[key_name(user)] projects his mind towards (believed:[believed_name]/actual:[key_name(target)]: [say]</span>")

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1350,7 +1350,7 @@ var/list/has_died_as_golem = list()
 		if(telepathic_target == M) //Talking to ourselves
 			to_chat(M,"<span class='mushroom'>Projected to self: [message]</span>")
 			return
-		to_chat(telepathic_target,"<span class='mushroom'>You feel <b>[M]</b>'s thoughts: [message]</span>.")
+		to_chat(telepathic_target,"<span class='notice'>You feel <b>[M]</b>'s thoughts: </span><span class='mushroom'>[message]</span>")
 		to_chat(M,"<span class='mushroom'>Projected to <b>[telepathic_target]</b>: [message]</span>")
 
 

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -120,7 +120,7 @@ h1.alert, h2.alert		{color: #000000;}
 .red					{color: #FF0000;}
 .grey					{color: #585858; font-family: Dotum, sans-serif;}
 .skeleton				{color: #585858; font-weight: bold; font-style: italic;}
-.mushroom				{color: #4B0082;}
+.mushroom				{color: #4B0082; font-weight: bold;}
 .gutter					{color: #61380B; font-style: italic;}
 .golem					{color: #B4DBCB; font-weight: bold;}
 .slime					{color: #34A7Af;}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6307265/159169800-002eaa65-fddc-4a1b-88a0-5c9e562332de.png)
Fixes #31857

:cl:
 * tweak: The font for telepathic messages is now bold.