### PR TITLE
(Un)folding a plastic bag or a box keeps it in the hand

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -648,6 +648,8 @@
 
 	to_chat(user, "<span class='notice'>You fold \the [src] flat.</span>")
 	var/folded = new src.foldable(get_turf(src),foldable_amount)
+	user.u_equip(src)
+	user.put_in_hands(folded)
 	transfer_fingerprints_to(folded)
 	qdel(src)
 


### PR DESCRIPTION
[tweak]
This makes it so folding (or unfolding in the case of a box) a storage item like a plastic bag will keep it in your hand instead of dropping it to the ground.

:cl:
 * tweak: Folding a plastic bag keeps it in the hand.
