### PR TITLE
Cargo forwarding fixes

### DIFF
--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -185,11 +185,12 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 		if(isobj(MA))
 			var/obj/O = MA
 			if(O.associated_forward)
-				if(O.associated_forward.associated_crate == src)
+				if(O.associated_forward.associated_crate == O)
 					O.associated_forward.delete_crate = TRUE
-				if(O.associated_forward.associated_manifest == src)
+					continue
+				if(O.associated_forward.associated_manifest == O)
 					O.associated_forward.delete_manifest = TRUE
-				continue
+					continue
 
 		if(istype(MA,/obj/structure/closet/crate))
 			recycled_crates++

--- a/code/game/cargo_forwarding.dm
+++ b/code/game/cargo_forwarding.dm
@@ -80,6 +80,16 @@
 /datum/cargo_forwarding/Destroy()
 	SSsupply_shuttle.cargo_forwards.Remove(src)
 	acct = null
+	if(associated_crate)
+		associated_crate.associated_forward = null
+		if(delete_crate)
+			qdel(associated_crate)
+		associated_crate = null
+	if(associated_manifest)
+		associated_manifest.associated_forward = null
+		if(delete_manifest)
+			qdel(associated_manifest)
+		associated_manifest = null
 	..()
 
 /datum/cargo_forwarding/proc/Pay(var/reason) //Reason for crate denial
@@ -96,41 +106,44 @@
 		S.say("[name] forwarded [reason ? "unsuccessfully! [reason]. Reward docked." : "successfully!"]")
 		playsound(S, 'sound/machines/info.ogg', 50, 1)
 
-	if(!reason && prob(50)) // Only make this forward move on properly to another station with a chance if fulfilled (persistence)
-		var/list/positions_to_check = list()
-		switch(src.acct_by_string)
-			if("Cargo")
-				positions_to_check = CARGO_POSITIONS
-			if("Engineering")
-				positions_to_check = ENGINEERING_POSITIONS
-			if("Medical")
-				positions_to_check = MEDICAL_POSITIONS
-			if("Science")
-				positions_to_check = SCIENCE_POSITIONS
-			if("Civilian")
-				positions_to_check = CIVILIAN_POSITIONS
-		var/list/possible_position_names = list()
-		var/list/possible_names = list()
-		for(var/mob/living/M in player_list)
-			if(positions_to_check && positions_to_check.len && (M.mind.assigned_role in positions_to_check))
-				possible_position_names += M.name
-			possible_names += M.name
-		if(possible_position_names && possible_position_names.len)
-			origin_sender_name = pick(possible_position_names)
-		else if(possible_names && possible_names.len)
-			origin_sender_name = pick(possible_names)
-		origin_station_name = station_name()
-		SSsupply_shuttle.fulfilled_forwards += src
+	if(!reason)
+		if(prob(50)) // Only make this forward move on properly to another station with a chance if fulfilled (persistence)
+			var/list/positions_to_check = list()
+			switch(src.acct_by_string)
+				if("Cargo")
+					positions_to_check = CARGO_POSITIONS
+				if("Engineering")
+					positions_to_check = ENGINEERING_POSITIONS
+				if("Medical")
+					positions_to_check = MEDICAL_POSITIONS
+				if("Science")
+					positions_to_check = SCIENCE_POSITIONS
+				if("Civilian")
+					positions_to_check = CIVILIAN_POSITIONS
+			var/list/possible_position_names = list()
+			var/list/possible_names = list()
+			for(var/mob/living/M in player_list)
+				if(positions_to_check && positions_to_check.len && (M.mind.assigned_role in positions_to_check))
+					possible_position_names += M.name
+				possible_names += M.name
+			if(possible_position_names && possible_position_names.len)
+				origin_sender_name = pick(possible_position_names)
+			else if(possible_names && possible_names.len)
+				origin_sender_name = pick(possible_names)
+			origin_station_name = station_name()
+			SSsupply_shuttle.fulfilled_forwards += src
 		score.stuffforwarded++
 	else if(reason)
 		score.stuffnotforwarded++
-	if(delete_crate && associated_crate)
+	if(associated_crate)
 		associated_crate.associated_forward = null
-		qdel(associated_crate)
+		if(delete_crate)
+			qdel(associated_crate)
 		associated_crate = null
-	if(delete_manifest && associated_manifest)
+	if(associated_manifest)
 		associated_manifest.associated_forward = null
-		qdel(associated_manifest)
+		if(delete_manifest)
+			qdel(associated_manifest)
 		associated_manifest = null
 	SSsupply_shuttle.cargo_forwards.Remove(src)
 


### PR DESCRIPTION
[bugfix]
Closes #32275.

:cl:
 * bugfix: Cargo crates forwarded now disappear from the shuttle when sent.
 * bugfix: Fulfilled forwards now always count towards the score, rather than half the time.