### PR TITLE
Removes darkmode message

### DIFF
--- a/code/modules/client/darkmode.dm
+++ b/code/modules/client/darkmode.dm
@@ -59,6 +59,3 @@
 	winset(src, "mebutton", 			"background-color = [COLOR_DARKMODE_BACKGROUND];text-color = [COLOR_DARKMODE_TEXT]")
 	winset(src, "saybutton", 			"background-color = [COLOR_DARKMODE_BACKGROUND];text-color = [COLOR_DARKMODE_TEXT]")
 	winset(src, "hotkey_toggle", 	"background-color = [COLOR_DARKMODE_BACKGROUND];text-color = [COLOR_DARKMODE_TEXT]")
-
-	to_chat(src, "<span class='bnotice'>Thank you for helping to test the darkmode color preset. There will probably be bugs. \
-		Do not hesitate to GITHUB REPORT any black/purple colored messages that are unreadable in the darkmode background, or to give feedback on the half-assed color pallete. Nothing here is final.</span>")

--- a/goon/browserassets/css/browserOutput_dark.css
+++ b/goon/browserassets/css/browserOutput_dark.css
@@ -29,8 +29,9 @@ a:visited {color: #b76ff5;}
 .sinister {color: #9662b1;}
 .grey, .skeleton {color: #817e7e;}
 .mushroom {color: #ab62b1;}
+.gutter	{color: #ab62b1; font-style: italic;}
 .alien {color: #b162a9;}
-.solcom	{color: #256194;}
+.solcom	{color: #257c94;}
 .clown {color: #FBFF35; font-family: Comic Sans MS, Comic Sans, cursive;}
 .borer {color: #B300B3; font-weight: bold;}
 .grue {color: #D8D8D7; font-weight: bold;}

--- a/goon/browserassets/css/browserOutput_dark.css
+++ b/goon/browserassets/css/browserOutput_dark.css
@@ -22,11 +22,6 @@ a:visited {color: #b76ff5;}
 .motd h1, .motd h2, .motd h3, .motd h4, .motd h5, .motd h6 {color: #98971a;}
 .motd a, .motd a:link, .motd a:visited, .motd a:active, .motd a:hover {color: #98971a;}
 
-.ooc {color: #cca300;}
-.adminooc {color: #3d5bc3;}
-.admin {color: #5975da;}
-.adminmod {color: #8f5e2e;}
-.modooc {color: #ffffff;}
 .maroon {color: #c52943;}
 
 .deadsay {color: #e2c1ff;}


### PR DESCRIPTION
Removes darkmode message telling you to go to Github if you have an issue. I've been using darkmode for like two years without any issues.

Closes #30877

1. If you don't report the issue when it says to report the issue, what's the point?
2. If there is an issue, you can still report the issue without the message
3. Nothing else has a message saying "report the issue"