### PR TITLE
Make "Lurk and Eat" grue objective succeed as intended

### DIFF
--- a/code/datums/gamemode/objectives/grue.dm
+++ b/code/datums/gamemode/objectives/grue.dm
@@ -3,8 +3,7 @@
 	name = "Lurk and Eat"
 
 /datum/objective/grue/grue_basic/IsFulfilled()
-	if (..())
-		return TRUE
+	return TRUE
 
 /datum/objective/grue/eat_sentients
 	explanation_text = "Eat sentient beings."

--- a/code/datums/gamemode/objectives/grue.dm
+++ b/code/datums/gamemode/objectives/grue.dm
@@ -3,7 +3,10 @@
 	name = "Lurk and Eat"
 
 /datum/objective/grue/grue_basic/IsFulfilled()
-	return TRUE
+	if (..())
+		return TRUE
+	var/datum/role/grue/G = owner.GetRole(ROLE_GRUE)
+	return (G.stat != DEAD)
 
 /datum/objective/grue/eat_sentients
 	explanation_text = "Eat sentient beings."

--- a/code/datums/gamemode/objectives/grue.dm
+++ b/code/datums/gamemode/objectives/grue.dm
@@ -6,7 +6,7 @@
 	if (..())
 		return TRUE
 	var/datum/role/grue/G = owner.GetRole(ROLE_GRUE)
-	return !(PD.antag.current.isDead())
+	return !(G.antag.current.isDead())
 
 /datum/objective/grue/eat_sentients
 	explanation_text = "Eat sentient beings."

--- a/code/datums/gamemode/objectives/grue.dm
+++ b/code/datums/gamemode/objectives/grue.dm
@@ -6,7 +6,7 @@
 	if (..())
 		return TRUE
 	var/datum/role/grue/G = owner.GetRole(ROLE_GRUE)
-	return (G.stat != DEAD)
+	return !(PD.antag.current.isDead())
 
 /datum/objective/grue/eat_sentients
 	explanation_text = "Eat sentient beings."

--- a/code/datums/gamemode/objectives/grue.dm
+++ b/code/datums/gamemode/objectives/grue.dm
@@ -6,7 +6,7 @@
 	if (..())
 		return TRUE
 	var/datum/role/grue/G = owner.GetRole(ROLE_GRUE)
-	return !(G.antag.current.isDead())
+	return !(G.antag.current?.isDead())
 
 /datum/objective/grue/eat_sentients
 	explanation_text = "Eat sentient beings."


### PR DESCRIPTION
[bugfix]
This makes the objectives for egg-hatched grues, "Lurk in the darkness and eat as many sentient beings as you can." succeed by default, as originally intended. Heretofore, it's been failing by default.

As far as I know.. someone still has to be alive at the end of the round to get the "[name] was successful!" message even when their objectives are fulfilled, but if someone could please confirm that it'd be appreciated.

:cl:
 * bugfix: Fixed fulfilling of objectives for hatched grues 
