### PR TITLE
Slime extract grenade fixes

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -27,7 +27,6 @@
 	var/obj/item/slime_extract/firstExtract = null	//for large and Ex grenades
 	var/obj/item/slime_extract/secondExtract = null	//for Ex grenades
 	var/obj/item/weapon/reagent_containers/glass/beaker/noreactgrenade/reservoir = null
-	var/extract_uses = 0
 	var/mob/primed_by = "N/A" //"name (ckey)". For logging purposes
 	mech_flags = null
 	det_time =0 //recycling this variable to be used by the grenade launcher's timer override function since chemnades use their assembly's timer instead.
@@ -265,30 +264,28 @@
 	for(var/obj/item/slime_extract/S in beakers)		//checking for reagents inside the slime extracts
 		S.reagents.trans_to(reservoir, S.reagents.total_volume)
 	if (firstExtract != null)
-		extract_uses = firstExtract.Uses
-		for(var/i=1,i<=extract_uses,i++)//<-------//exception for slime extracts injected with steroids. The grenade will repeat its checks untill all its remaining uses are gone
-			if (reservoir.reagents.has_reagent(PLASMA, 5))
-				reservoir.reagents.trans_id_to(firstExtract, PLASMA, 5)		//If the grenade contains a slime extract, the grenade will check in this order
-			else if (reservoir.reagents.has_reagent(BLOOD, 5))	//for any Plasma -> Blood ->or Water among the reagents of the other containers
-				reservoir.reagents.trans_id_to(firstExtract, BLOOD, 5)		//and inject 5u of it into the slime extract.
-			else if (reservoir.reagents.has_reagent(WATER, 5))
-				reservoir.reagents.trans_id_to(firstExtract, WATER, 5)
-			else if (reservoir.reagents.has_reagent(SUGAR, 5))
-				reservoir.reagents.trans_id_to(firstExtract, SUGAR, 5)
-		if(firstExtract.reagents.total_volume)						  //<-------//exception for slime reactions that produce new reagents. The grenade checks if any
+		while(firstExtract && firstExtract.Uses)//<-------//exception for slime extracts injected with steroids. The grenade will repeat its checks untill all its remaining uses are gone
+			var/init_uses = firstExtract.Uses
+			for(var/reagent in firstExtract.reactive_reagents) //If the grenade contains a slime extract, the grenade will check in this order
+				if (reservoir.reagents.has_reagent(reagent, 5))
+					reservoir.reagents.trans_id_to(firstExtract, reagent, 5) //and inject 5u of it into the slime extract.
+				if (!firstExtract)
+					break
+			if(!firstExtract || init_uses == firstExtract.Uses) //Nothing happened, get outta here
+				break
+		if(firstExtract && firstExtract.reagents && firstExtract.reagents.total_volume)	//<-------//exception for slime reactions that produce new reagents. The grenade checks if any
 			firstExtract.reagents.trans_to(reservoir, firstExtract.reagents.total_volume)	//reagents are left in the slime extracts after the slime reactions occured
 		if (secondExtract != null)
-			extract_uses = secondExtract.Uses
-			for(var/j=1,j<=extract_uses,j++)	//why don't anyone ever uses "while" directives anyway?
-				if (reservoir.reagents.has_reagent(PLASMA, 5))
-					reservoir.reagents.trans_id_to(secondExtract, PLASMA, 5)	//since the order in which slime extracts are inserted matters (in the case of an Ex grenade)
-				else if (reservoir.reagents.has_reagent(BLOOD, 5))//this allow users to plannify which reagent will get into which extract.
-					reservoir.reagents.trans_id_to(secondExtract, BLOOD, 5)
-				else if (reservoir.reagents.has_reagent(WATER, 5))
-					reservoir.reagents.trans_id_to(secondExtract, WATER, 5)
-				else if (reservoir.reagents.has_reagent(SUGAR, 5))
-					reservoir.reagents.trans_id_to(secondExtract, SUGAR, 5)
-			if(secondExtract.reagents.total_volume)
+			while(secondExtract && secondExtract.Uses)	//why don't anyone ever uses "while" directives anyway? //we do now
+				var/init_uses = secondExtract.Uses
+				for(var/reagent2 in secondExtract.reactive_reagents)
+					if (reservoir.reagents.has_reagent(reagent2, 5))
+						reservoir.reagents.trans_id_to(secondExtract, reagent2, 5)
+					if (!secondExtract)
+						break
+				if(!secondExtract || init_uses == secondExtract.Uses)
+					break
+			if(secondExtract && secondExtract.reagents && secondExtract.reagents.total_volume)
 				secondExtract.reagents.trans_to(reservoir, secondExtract.reagents.total_volume)
 
 		reservoir.reagents.update_total()
@@ -563,7 +560,7 @@
 	desc = "Used for training and crowd control operations. Contents under pressure. Do not directly inhale contents."
 	stage = GRENADE_STAGE_COMPLETE
 	path = PATH_STAGE_CONTAINER_INSERTED
-	
+
 /obj/item/weapon/grenade/chem_grenade/teargas/New()
 	..()
 	var/obj/item/weapon/reagent_containers/glass/beaker/large/B1 = new(src)
@@ -573,10 +570,10 @@
 	B1.reagents.add_reagent(POTASSIUM, 40)
 	B2.reagents.add_reagent(PHOSPHORUS, 40)
 	B2.reagents.add_reagent(SUGAR, 40)
-	
+
 	detonator = new/obj/item/device/assembly_holder/timer_igniter(src)
 
 	beakers += B1
 	beakers += B2
 	icon_state = initial(icon_state) +"_locked"
-	
+

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -499,6 +499,7 @@
 	var/Uses = 1 // uses before it goes inert
 	var/enhanced = 0 //has it been enhanced before?
 	var/primarytype = /mob/living/carbon/slime
+	var/list/reactive_reagents = list() //easier lookup for reaction checks in grenades
 
 /obj/item/slime_extract/attackby(obj/item/O as obj, mob/user as mob)
 	if(istype(O, /obj/item/weapon/slimesteroid2))
@@ -540,106 +541,127 @@
 	name = "grey slime extract"
 	icon_state = "grey slime extract"
 	primarytype = /mob/living/carbon/slime
+	reactive_reagents = list(PLASMA,BLOOD)
 
 /obj/item/slime_extract/gold
 	name = "gold slime extract"
 	icon_state = "gold slime extract"
 	primarytype = /mob/living/carbon/slime/gold
+	reactive_reagents = list(PLASMA,BLOOD,WATER)
 
 /obj/item/slime_extract/silver
 	name = "silver slime extract"
 	icon_state = "silver slime extract"
 	primarytype = /mob/living/carbon/slime/silver
+	reactive_reagents = list(PLASMA,WATER,CARBON)
 
 /obj/item/slime_extract/metal
 	name = "metal slime extract"
 	icon_state = "metal slime extract"
 	primarytype = /mob/living/carbon/slime/metal
+	reactive_reagents = list(PLASMA,COPPER,TUNGSTEN,RADIUM,CARBON)
 
 /obj/item/slime_extract/purple
 	name = "purple slime extract"
 	icon_state = "purple slime extract"
 	primarytype = /mob/living/carbon/slime/purple
+	reactive_reagents = list(PLASMA,SUGAR)
 
 /obj/item/slime_extract/darkpurple
 	name = "dark purple slime extract"
 	icon_state = "dark purple slime extract"
 	primarytype = /mob/living/carbon/slime/darkpurple
+	reactive_reagents = list(PLASMA)
 
 /obj/item/slime_extract/orange
 	name = "orange slime extract"
 	icon_state = "orange slime extract"
-	primarytype = /mob/living/carbon/slime/orange
+	primarytype = /mob/living/carbon/slime/
+	reactive_reagents = list(PLASMA,BLOOD)
 
 /obj/item/slime_extract/yellow
 	name = "yellow slime extract"
 	icon_state = "yellow slime extract"
 	primarytype = /mob/living/carbon/slime/yellow
+	reactive_reagents = list(PLASMA,BLOOD,WATER)
 
 /obj/item/slime_extract/red
 	name = "red slime extract"
 	icon_state = "red slime extract"
 	primarytype = /mob/living/carbon/slime/red
+	reactive_reagents = list(PLASMA,BLOOD)
 
 /obj/item/slime_extract/blue
 	name = "blue slime extract"
 	icon_state = "blue slime extract"
 	primarytype = /mob/living/carbon/slime/blue
+	reactive_reagents = list(PLASMA)
 
 /obj/item/slime_extract/darkblue
 	name = "dark blue slime extract"
 	icon_state = "dark blue slime extract"
 	primarytype = /mob/living/carbon/slime/darkblue
+	reactive_reagents = list(PLASMA,BLOOD)
 
 /obj/item/slime_extract/pink
 	name = "pink slime extract"
 	icon_state = "pink slime extract"
 	primarytype = /mob/living/carbon/slime/pink
+	reactive_reagents = list(PLASMA)
 
 /obj/item/slime_extract/green
 	name = "green slime extract"
 	icon_state = "green slime extract"
 	primarytype = /mob/living/carbon/slime/green
+	reactive_reagents = list(PLASMA,IRON,BLOOD,WATER)
 
 /obj/item/slime_extract/lightpink
 	name = "light pink slime extract"
 	icon_state = "light pink slime extract"
 	primarytype = /mob/living/carbon/slime/lightpink
+	reactive_reagents = list(PLASMA,BLOOD)
 
 /obj/item/slime_extract/black
 	name = "black slime extract"
 	icon_state = "black slime extract"
 	primarytype = /mob/living/carbon/slime/black
+	reactive_reagents = list(PLASMA,GOLD,WATER,SUGAR,BLOOD)
 
 /obj/item/slime_extract/oil
 	name = "oil slime extract"
 	icon_state = "oil slime extract"
 	primarytype = /mob/living/carbon/slime/oil
+	reactive_reagents = list(PLASMA,BLOOD)
 
 /obj/item/slime_extract/adamantine
 	name = "adamantine slime extract"
 	icon_state = "adamantine slime extract"
 	primarytype = /mob/living/carbon/slime/adamantine
+	reactive_reagents = list(PLASMA,CARBON,GOLD,SILVER)
 
 /obj/item/slime_extract/bluespace
 	name = "bluespace slime extract"
 	icon_state = "bluespace slime extract"
 	primarytype = /mob/living/carbon/slime/bluespace
+	reactive_reagents = list(PLASMA,BLOOD)
 
 /obj/item/slime_extract/pyrite
 	name = "pyrite slime extract"
 	icon_state = "pyrite slime extract"
 	primarytype = /mob/living/carbon/slime/pyrite
+	reactive_reagents = list(PLASMA,BLOOD)
 
 /obj/item/slime_extract/cerulean
 	name = "cerulean slime extract"
 	icon_state = "cerulean slime extract"
 	primarytype = /mob/living/carbon/slime/cerulean
+	reactive_reagents = list(PLASMA,BLOOD)
 
 /obj/item/slime_extract/sepia
 	name = "sepia slime extract"
 	icon_state = "sepia slime extract"
 	primarytype = /mob/living/carbon/slime/sepia
+	reactive_reagents = list(PLASMA,BLOOD,PHAZON)
 
 
 ////Pet Slime Creation///

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -576,7 +576,7 @@
 /obj/item/slime_extract/orange
 	name = "orange slime extract"
 	icon_state = "orange slime extract"
-	primarytype = /mob/living/carbon/slime/
+	primarytype = /mob/living/carbon/slime/orange
 	reactive_reagents = list(PLASMA,BLOOD)
 
 /obj/item/slime_extract/yellow


### PR DESCRIPTION
[bugfix][tweak]
:cl:
 * bugfix: Slime extract grenades no longer fail to use the second extract after consuming the first.
 * tweak: Slime extract grenades will now make extracts consume any reagent they can possibly react with, rather than only plasma, blood, water or sugar.