### PR TITLE
Spreadable Spaces

### DIFF
--- a/code/game/gamemodes/events/biomass.dm
+++ b/code/game/gamemodes/events/biomass.dm
@@ -193,9 +193,7 @@
 	// list of all the empty floor turfs in the hallway areas
 	var/list/turf/simulated/floor/Floors = new
 
-	for(var/type in typesof(/area/hallway))
-		if(ispath(type,/area/hallway/secondary/entry)) // no spawn in arrivals, make it less annoying for latejoiners
-			continue
+	for(var/type in typesof(/area/crew_quarters))
 		var/area/Hallway = locate(type)
 
 		for(var/turf/simulated/floor/Floor in Hallway.contents)

--- a/code/game/gamemodes/events/spacevines.dm
+++ b/code/game/gamemodes/events/spacevines.dm
@@ -2,9 +2,7 @@
 /proc/spacevine_infestation(var/potency_min=70, var/potency_max=100, var/maturation_min=2, var/maturation_max=6)
 	spawn() //to stop the secrets panel hanging
 		var/list/turf/simulated/floor/turfs = list() //list of all the empty floor turfs in the hallway areas
-		for(var/areapath in typesof(/area/hallway))
-			if(ispath(areapath,/area/hallway/secondary/entry)) //no spawn in arrivals, make it less annoying for latejoiners
-				continue
+		for(var/areapath in typesof(/area/maintenance))
 			var/area/A = locate(areapath)
 			for(var/turf/simulated/floor/F in A.contents)
 				if(!is_blocked_turf(F) && !(locate(/obj/effect/plantsegment) in F))

--- a/code/modules/events/powercreeper.dm
+++ b/code/modules/events/powercreeper.dm
@@ -6,9 +6,7 @@
 /datum/event/powercreeper/start()
 	spawn()
 		var/list/turf/simulated/floor/turfs = list() //list of all the empty floor turfs in the hallway areas
-		for(var/areapath in typesof(/area/hallway))
-			if(ispath(areapath,/area/hallway/secondary/entry)) //no spawn in arrivals, make it less annoying for latejoiners
-				continue
+		for(var/areapath in subtypesof(/area/engineering))
 			var/area/A = locate(areapath)
 			for(var/turf/simulated/floor/F in A.contents)
 				if(!is_blocked_turf(F))


### PR DESCRIPTION
Gives these plants much needed thematic variety and makes them less likely end up clogging hallways. 100% tested, each one three times.

Space vine seeds get tracked in by EVA workers who bring them in from spacewalks and they are cast off in maintenance.
Biomass is apparently extradimensional space barf. It has a deep connection to barf-filled places in our dimension, like the crew quarters.
Powercreeper has a life cycle that involves laying dormant in seed state for a long time until concentrated ~~autism~~ radiation from engines awakens it.

🆑 
* tweak: Space vines will now only spawn in maintenance, powercreeper only grows out of engineering, and biomass from crew quarters (e.g.: bar, kitchen, toilets).