### PR TITLE
Slow down grue proliferation a bit

### DIFF
--- a/code/modules/mob/living/simple_animal/grue_egg.dm
+++ b/code/modules/mob/living/simple_animal/grue_egg.dm
@@ -72,7 +72,7 @@
 /mob/living/simple_animal/grue_egg/New()
 	..()
 	last_ping_time = world.time
-	spawn(rand(30 SECONDS,45 SECONDS))//the egg takes a while to be ready to hatch
+	spawn(rand(90 SECONDS, 150 SECONDS))//the egg takes a while to be ready to hatch
 		Grow()
 
 /mob/living/simple_animal/grue_egg/proc/Grow()

--- a/code/modules/mob/living/simple_animal/grue_egg.dm
+++ b/code/modules/mob/living/simple_animal/grue_egg.dm
@@ -72,7 +72,7 @@
 /mob/living/simple_animal/grue_egg/New()
 	..()
 	last_ping_time = world.time
-	spawn(rand(90 SECONDS, 150 SECONDS))//the egg takes a while to be ready to hatch
+	spawn(rand(150 SECONDS, 180 SECONDS))//the egg takes a while to be ready to hatch
 		Grow()
 
 /mob/living/simple_animal/grue_egg/proc/Grow()


### PR DESCRIPTION
[tweak]
This increases the time it takes for a grue egg to become ready to hatch from 30-45 seconds, to 2.5-3 minutes. The reasons for this are to:
- Give humans more of a chance to go try and hunt down the eggs, adding another "phase" to the gameplay with humans potentially trying to find the eggs and grues trying to keep them hidden and defended, instead of quickly creating new grues shortly after someone gets eaten.
- Slowing down the numbers-based snowball a bit so rounds can continue to go on with grues lurking in the background but not necessarily becoming a huge threat as quickly.

It's one idea but I'm curious if people think this would be a positive or a negative change, so please let me know your thoughts on the matter. And we can bundle some other tweaks into this if people want. 
 
:cl:
 * tweak: Increased grue egg development time.
