### PR TITLE
Fixed remote view cancel button

### DIFF
--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -49,6 +49,14 @@
 	hud_state = "gen_rmind"
 	mind_affecting = 1
 
+
+/// Resets the view when the Cancel button is pressed or there are no suitable targets.
+/spell/targeted/remoteobserve/choose_targets(mob/living/carbon/human/user)
+	. = ..()
+	if(!length(.))
+		user.remoteview_target = null
+		user.reset_view(0)
+
 /spell/targeted/remoteobserve/cast(var/list/targets, mob/living/carbon/human/user)
 	if(!targets || !targets.len || !user || !istype(user))
 		return


### PR DESCRIPTION
In #32267 I added a cancel button to some spells, but in the case of remote view, `cast` doesn't get called if there are no targets for the spell, so pressing the cancel button doesn't reset the view like one might expect. This fixes that.