### PR TITLE
More cargo crate forwarding fixes

### DIFF
--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -419,6 +419,7 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 				var/previous_index = rand(1,previous_forwards.len)
 				var/datum/cargo_forwarding/CF = previous_forwards[previous_index]
 				cargo_forwards.Add(CF) // Blocked it in the creation of a previous forward, now do it here
+				CF.set_time_limit()
 				new_forwards.Add(CF)
 				previous_forwards.Remove(previous_forwards[previous_index]) // Must be the index to remove a specific one
 				log_debug("CARGO FORWARDING: Persistence crate [CF.type] loaded, from [CF.origin_sender_name] of [CF.origin_station_name].")

--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -184,7 +184,7 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 
 		if(isobj(MA))
 			var/obj/O = MA
-			if(O.associated_forward)
+			if(O.associated_forward && (O.associated_forward in cargo_forwards))
 				if(O.associated_forward.associated_crate == O)
 					O.associated_forward.delete_crate = TRUE
 					continue
@@ -418,6 +418,7 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 					break
 				var/previous_index = rand(1,previous_forwards.len)
 				var/datum/cargo_forwarding/CF = previous_forwards[previous_index]
+				cargo_forwards.Add(CF) // Blocked it in the creation of a previous forward, now do it here
 				new_forwards.Add(CF)
 				previous_forwards.Remove(previous_forwards[previous_index]) // Must be the index to remove a specific one
 				log_debug("CARGO FORWARDING: Persistence crate [CF.type] loaded, from [CF.origin_sender_name] of [CF.origin_station_name].")

--- a/code/game/cargo_forwarding.dm
+++ b/code/game/cargo_forwarding.dm
@@ -18,7 +18,7 @@
 	var/obj/item/weapon/paper/manifest/associated_manifest = null // Same here
 	var/origin_station_name = "" // Some fluff
 	var/origin_sender_name = ""
-	var/time_limit = 5 // In minutes
+	var/time_limit = 0 // In minutes
 	var/time_created = 0 // To check time left
 	var/weighed = FALSE // Crate weighed?
 	var/list/atom/initial_contents = list() // For easier atom checking
@@ -46,9 +46,6 @@
 	else // Sometimes they're just from centcomm directly, lorewise
 		origin_station_name = "Central Command"
 
-	time_created = world.time
-	time_limit = rand(7,17) //2 minutes is spent transiting it and it gets created at the start of that, so really 5-15
-
 	if(sender && sender != "")
 		origin_sender_name = sender
 	else
@@ -69,13 +66,15 @@
 			origin_sender_name = origin_station_name == "Central Command" ? pick(male_name,female_name) : pick(male_name,female_name,vox_name,insect_name)
 		while(origin_sender_name in player_names)
 
-	if(!do_not_add)
+	if(!do_not_add) //Remember to do these lines elsewhere if not here!
 		SSsupply_shuttle.cargo_forwards.Add(src)
 		set_time_limit()
 
 /datum/cargo_forwarding/proc/set_time_limit()
+	time_created = world.time
+	time_limit = rand(7,17) //2 minutes is spent transiting it and it gets created at the start of that, so really 5-15
 	spawn(time_limit MINUTES) //Still an order after the time limit?
-		if(src)
+		if(src && !delete_crate && !delete_manifest)
 			log_debug("CARGO FORWARDING: [src] denied: Time ran out")
 			Pay("Time ran out")
 

--- a/code/game/cargo_forwarding.dm
+++ b/code/game/cargo_forwarding.dm
@@ -74,7 +74,7 @@
 	time_created = world.time
 	time_limit = rand(7,17) //2 minutes is spent transiting it and it gets created at the start of that, so really 5-15
 	spawn(time_limit MINUTES) //Still an order after the time limit?
-		if(src && !delete_crate && !delete_manifest)
+		if(src && !delete_crate && !delete_manifest && SSsupply_shuttle && (src in SSsupply_shuttle.cargo_forwards))
 			log_debug("CARGO FORWARDING: [src] denied: Time ran out")
 			Pay("Time ran out")
 
@@ -94,6 +94,9 @@
 	..()
 
 /datum/cargo_forwarding/proc/Pay(var/reason) //Reason for crate denial
+	if(!SSsupply_shuttle || !(src in SSsupply_shuttle.cargo_forwards))
+		return // Only do this if in actual forwards to process
+
 	if(reason)
 		worth *= -0.5 //Deduct a penalty instead
 

--- a/code/game/cargo_forwarding.dm
+++ b/code/game/cargo_forwarding.dm
@@ -71,7 +71,9 @@
 
 	if(!do_not_add)
 		SSsupply_shuttle.cargo_forwards.Add(src)
+		set_time_limit()
 
+/datum/cargo_forwarding/proc/set_time_limit()
 	spawn(time_limit MINUTES) //Still an order after the time limit?
 		if(src)
 			log_debug("CARGO FORWARDING: [src] denied: Time ran out")

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -299,7 +299,7 @@ For vending packs, see vending_packs.dm*/
 		var/displayworth = CF.worth
 		if (isnum(CF.worth))
 			displayworth = "[CF.worth]$"
-		var/timeleft = ((CF.time_created + (CF.time_limit MINUTES)) - world.time)
+		var/timeleft = CF.time_created && CF.time_limit ? ((CF.time_created + (CF.time_limit MINUTES)) - world.time) : 0 // Should never see 0 but just in case
 		var/mm = text2num(time2text(timeleft, "mm")) // Set the minute
 		var/ss = text2num(time2text(timeleft, "ss")) // Set the second
 		var/weighedtext = CF.weighed ? "Yes" : "No"


### PR DESCRIPTION
[bugfix][consistency]

:cl:
 * bugfix: Cargo no longer gets un-notified forwards with it enabled.
 * bugfix: Forward-linked crates not in the list of notified crates can now be sent properly.
 * bugfix: Cargo forwards no longer dock from pay with time running out if already successfully shipped.
 * bugfix: Forwards persisted from other rounds no longer run out of time before they're even shipped.