### PR TITLE
Do not prevent dragging a thing onto a table if it's already on the table

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -115,7 +115,7 @@
 
 /obj/machinery/optable/proc/TryToThrowOnTable(var/mob/user,var/mob/victim)
 	for (var/atom/A in loc)
-		if (A == src)
+		if (A == src || A == victim || A == user)
 			continue
 		if (!A.Cross(victim,get_turf(victim)))
 			to_chat(user, "<span class='warning'>\The [A] prevents you from dragging \the [victim] on top of \the [src]</span>")

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -363,7 +363,7 @@
 
 /obj/structure/table/proc/TryToThrowOnTable(var/mob/user,var/mob/victim)
 	for (var/atom/A in loc)
-		if (A == src)
+		if (A == src || A == victim || A == user)
 			continue
 		if (!A.Cross(victim,get_turf(victim)))
 			to_chat(user, "<span class='warning'>\The [A] prevents you from dragging \the [victim] on top of \the [src]</span>")


### PR DESCRIPTION
Currently, `John Patient prevents you from dragging John Patient on top of the operating table` can happen. This fixes that.