### PR TITLE
Tweaked surgery click delay

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -800,7 +800,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		return FALSE
 	if(user.isStunned())
 		return FALSE
-	var/user_loc_to_check = use_user_turf ? get_turf(user) : user.loc	
+	var/user_loc_to_check = use_user_turf ? get_turf(user) : user.loc
 	if(user_loc_to_check != user_original_location)
 		return FALSE
 	if(target.loc != target_original_location)
@@ -1225,6 +1225,7 @@ var/global/list/common_tools = list(
 
 //check if mob is lying down on something we can operate him on.
 /proc/can_operate(mob/living/carbon/M, mob/U, var/obj/item/tool) // tool arg only needed if you actually intend to perform surgery (and not for instance, just do an autopsy)
+	set waitfor = FALSE
 	if(U == M)
 		return 0
 	var/too_bad = FALSE

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -118,6 +118,7 @@
 		E.germ_level = max(germ_level,E.germ_level) //as funny as scrubbing microbes out with clean gloves is - no.
 
 /proc/do_surgery(mob/living/M, mob/living/user, obj/item/tool, var/success_override = SURGERY_SUCCESS_NORMAL)
+	set waitfor = FALSE
 	if(!ishuman(M) && !isslime(M))
 		return 0
 	if (user.a_intent == I_HURT)	//check for Hippocratic Oath


### PR DESCRIPTION
Currently, performing a surgery step will start a click delay timer when the step finishes. Instead, this PR makes the click delay timer start when the progress bar is *starting*.

This makes it so you have to wait a little bit before you can pick up the next surgery tool after starting the surgery step, *but* you don't have to wait after the step is finished, which means you should be able to finish surgery faster.

It's a subtle difference but I believe it would be nice.