### PR TITLE
Fixes admins softlocking via Nar'Sie

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -177,7 +177,6 @@
 	var/emag_recharge_rate = 0
 	var/emag_recharge_ticks = 0
 
-	var/map_voting = 0
 	var/renders_url = ""
 
 	var/mommi_static = 0 //Scrambling mobs for mommis or not
@@ -602,8 +601,6 @@
 					vgws_ip = value
 				if("poll_results_url")
 					poll_results_url = value
-				if("map_voting")
-					map_voting = 1
 				if("renders_url")
 					renders_url = value
 				if("mommi_static")

--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -178,7 +178,7 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 	if (voting_cache)
 		return
 	voting_cache = 1
-	if(config.map_voting && vote)
+	if(vote)
 		for(var/client/C in clients)
 			spawn
 				vote.interface.sendAssets(C)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -482,10 +482,9 @@ var/datum/controller/gameticker/ticker
 			declare_completion()
 
 			gameend_time = world.time / 10
-			if(config.map_voting)
-				vote.initiate_vote("map","The Server", popup = 1)
-				var/options = jointext(vote.choices, " ")
-				feedback_set("map vote choices", options)
+			vote.initiate_vote("map","The Server", popup = 1)
+			var/options = jointext(vote.choices, " ")
+			feedback_set("map vote choices", options)
 
 			if (station_was_nuked)
 				feedback_set_details("end_proper","nuke")
@@ -499,7 +498,7 @@ var/datum/controller/gameticker/ticker
 			end_credits.on_round_end()
 
 			if(blackbox)
-				if(config.map_voting && player_list.len)
+				if(player_list.len)
 					spawn(restart_timeout + 1)
 						blackbox.save_all_data_to_sql()
 				else
@@ -508,8 +507,8 @@ var/datum/controller/gameticker/ticker
 			stat_collection.Process()
 
 			if (watchdog.waiting)
-				to_chat(world, "<span class='notice'><B>Server will shut down for an automatic update in [config.map_voting && player_list.len ? "[(restart_timeout/10)] seconds." : "a few seconds."]</B></span>")
-				if(config.map_voting && player_list.len)
+				to_chat(world, "<span class='notice'><B>Server will shut down for an automatic update in [player_list.len ? "[(restart_timeout/10)] seconds." : "a few seconds."]</B></span>")
+				if(player_list.len)
 					sleep(restart_timeout) //waiting for a mapvote to end
 				if(!delay_end)
 					watchdog.signal_ready()

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -480,11 +480,11 @@ var/datum/controller/gameticker/ticker
 
 		spawn
 			declare_completion()
-
 			gameend_time = world.time / 10
-			vote.initiate_vote("map","The Server", popup = 1)
-			var/options = jointext(vote.choices, " ")
-			feedback_set("map vote choices", options)
+			if(!vote.map_paths)
+				vote.initiate_vote("map","The Server", popup = 1)
+				var/options = jointext(vote.choices, " ")
+				feedback_set("map vote choices", options)
 
 			if (station_was_nuked)
 				feedback_set_details("end_proper","nuke")

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -601,13 +601,23 @@ var/list/shuttle_log = list()
 	return 1
 
 /proc/init_shift_change(var/mob/user, var/force = 0)
-	if ((!( ticker ) || emergency_shuttle.location))
+	if (!ticker)
 		return
-
+	if (emergency_shuttle.direction == -1 && vote.winner ==  "Initiate Crew Transfer")
+		emergency_shuttle.setdirection(1)
+		emergency_shuttle.settimeleft(15)
+		var/reason = pick("is arriving ahead of schedule", "hit the turbo", "has engaged nitro afterburners")
+		captain_announce("The emergency shuttle reversed and [reason]. It will arrive in [emergency_shuttle.timeleft()] seconds.")
+		return
 	if(emergency_shuttle.direction == -1)
 		to_chat(user, "The shuttle may not be called while returning to CentCom.")
 		return
-
+	if (emergency_shuttle.online && vote.winner ==  "Initiate Crew Transfer")
+		if(15 < emergency_shuttle.timeleft())
+			var/reason = pick("is arriving ahead of schedule", "hit the turbo", "has engaged nitro afterburners")
+			emergency_shuttle.settimeleft(15)
+			captain_announce("The emergency shuttle [reason]. It will arrive in [emergency_shuttle.timeleft()] seconds.")
+		return
 	if(emergency_shuttle.online)
 		to_chat(user, "The shuttle is already on its way.")
 		return

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -605,7 +605,7 @@ var/list/shuttle_log = list()
 		return
 	if (emergency_shuttle.direction == -1 && vote.winner ==  "Initiate Crew Transfer")
 		emergency_shuttle.setdirection(1)
-		emergency_shuttle.settimeleft(15)
+		emergency_shuttle.settimeleft(10)
 		var/reason = pick("is arriving ahead of schedule", "hit the turbo", "has engaged nitro afterburners")
 		captain_announce("The emergency shuttle reversed and [reason]. It will arrive in [emergency_shuttle.timeleft()] seconds.")
 		return
@@ -613,9 +613,9 @@ var/list/shuttle_log = list()
 		to_chat(user, "The shuttle may not be called while returning to CentCom.")
 		return
 	if (emergency_shuttle.online && vote.winner ==  "Initiate Crew Transfer")
-		if(15 < emergency_shuttle.timeleft())
+		if(10 < emergency_shuttle.timeleft())
 			var/reason = pick("is arriving ahead of schedule", "hit the turbo", "has engaged nitro afterburners")
-			emergency_shuttle.settimeleft(15)
+			emergency_shuttle.settimeleft(10)
 			captain_announce("The emergency shuttle [reason]. It will arrive in [emergency_shuttle.timeleft()] seconds.")
 		return
 	if(emergency_shuttle.online)

--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -266,7 +266,6 @@ var/global/datum/controller/vote/vote = new()
 		if(config.vote_no_dead && user.stat == DEAD && !user.client.holder)
 			return 0
 		if (isnum(vote) && (1>vote) || (vote > choices.len))
-			to_chat(user, "<span class='warning'>Illegal vote.</span>")
 			return 0
 		if(mode == "map")
 			if(!user.client.holder)

--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -259,7 +259,7 @@ var/global/datum/controller/vote/vote = new()
 		CallHook("Reboot",list())
 		sleep(50)
 		log_game("Rebooting due to restart vote")
-		world.Reboot()
+		world.Reboot(REBOOT_HOST)
 
 /datum/controller/vote/proc/submit_vote(var/mob/user, var/vote)
 	if(mode)

--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -259,7 +259,7 @@ var/global/datum/controller/vote/vote = new()
 		CallHook("Reboot",list())
 		sleep(50)
 		log_game("Rebooting due to restart vote")
-		world.Reboot(REBOOT_HOST)
+		world.Reboot()
 
 /datum/controller/vote/proc/submit_vote(var/mob/user, var/vote)
 	if(mode)

--- a/code/modules/html_interface/voting/voting.js
+++ b/code/modules/html_interface/voting/voting.js
@@ -35,7 +35,7 @@ function update_mode(newMode, newQuestion, newTimeleft, vrestart, vmode, vmap, v
 	allow_mode = parseInt(vmode) || 0;
 	allow_restart = parseInt(vrestart) || 0;
 	toggle_map = parseInt(vmap) || 0;
-	toggle_vote_method = parseInt(vmethod) || 0;
+	toggle_vote_method = parseInt(vmethod) || 1;
 	time_left = parseInt(newTimeleft) || 0;
 	$("#vote_choices").append($("<div class='item'></div>").append($("<div class='itemLabel'></div>").html("Time Left")).append($("<div class='itemContent'></div>").html(displayBar(time_left, 0, 60, (time_left >= 50) ? 'good' : (time_left >= 25) ? 'average' : 'bad', '<center>' + time_left + '</center>'))));
 	$("#vote_choices").append($("<div class='item'></div>").append($("<div class='itemLabel'></div>").html("<br />Question")).append($("<div class='itemContentMedium'></div>").append($("<div class='statusDisplay'></div>").text(question))));

--- a/code/world.dm
+++ b/code/world.dm
@@ -206,7 +206,7 @@ var/auxtools_path
 		..()
 		return
 
-	if(vote.winner && vote.map_paths.len)
+	if(vote.winner && vote.map_paths)
 		//get filename
 		var/filename = "vgstation13.dmb"
 		var/map_path = "maps/voting/" + vote.map_paths[vote.winner] + "/" + filename

--- a/code/world.dm
+++ b/code/world.dm
@@ -190,7 +190,6 @@ var/auxtools_path
 
 
 /world/Reboot(reason)
-	testing("[time_stamp()] - World is rebooting. Reason: [reason]")
 	if(reason == REBOOT_HOST)
 		if(usr)
 			if (!check_rights(R_SERVER))
@@ -207,7 +206,7 @@ var/auxtools_path
 		..()
 		return
 
-	if(config.map_voting && vote.winner && vote.map_paths.len)
+	if(vote.winner && vote.map_paths.len)
 		//get filename
 		var/filename = "vgstation13.dmb"
 		var/map_path = "maps/voting/" + vote.map_paths[vote.winner] + "/" + filename


### PR DESCRIPTION
[hotfix]

Should be harder for poopmins to softlock the server with Nar' Sie, preventing the server from restarting

* This removes the `map_voting` configuration variable that seems obsolete, and that prevents voting sometimes.
* Voting options like crew transfer to make it actually work as intended
* Restart voting option gives admins the option to actually restart the map by voting
* Fixes a runtime