### PR TITLE
Fixes seed vendor Plastellium category.

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -76,8 +76,9 @@
 	vending_cat = "vegetables"
 
 /obj/item/seeds/plastiseed
-	name = "packet of plastellium seeds"
+	name = "packet of plastellium spores"
 	seed_type = "plastic"
+	vending_cat = "mushrooms"
 
 /obj/item/seeds/grapeseed
 	name = "packet of grape seeds"


### PR DESCRIPTION
It's a shroom but isn't under the mushroom category. 
[bugfix][hotfix]

:cl:
 * bugfix: moves plastellium location on the seed vendor to be under the mushroom category