### PR TITLE
Fixes Vox Nuggets, Vox Drumstick Buckets and vox chicken processing.

### DIFF
--- a/code/game/machinery/kitchen/processor.dm
+++ b/code/game/machinery/kitchen/processor.dm
@@ -116,6 +116,14 @@
 		feedback_add_details("slime_core_harvested","[replacetext(S.colour," ","_")]")
 	..()
 
+/datum/food_processor_process/mob/voxchicken //out of place on purpose, do not relocate, since that will break vox chicken process-nugetting
+	input = /mob/living/carbon/monkey/vox
+	output = /obj/item/weapon/reagent_containers/food/snacks/vox_nuggets
+
+/datum/food_processor_process/mob/voxchicken/process(loc, what)
+	playsound(loc, 'sound/machines/ya_dun_clucked.ogg', 50, 1)
+	..()
+
 /datum/food_processor_process/mob/monkey
 	input = /mob/living/carbon/monkey
 	output = null
@@ -137,14 +145,6 @@
 	output = /obj/item/weapon/reagent_containers/food/snacks/chicken_nuggets
 
 /datum/food_processor_process/mob/chicken/process(loc, what)
-	playsound(loc, 'sound/machines/ya_dun_clucked.ogg', 50, 1)
-	..()
-
-/datum/food_processor_process/mob/voxchicken
-	input = /mob/living/carbon/monkey/vox
-	output = /obj/item/weapon/reagent_containers/food/snacks/vox_nuggets
-
-/datum/food_processor_process/mob/voxchicken/process(loc, what)
 	playsound(loc, 'sound/machines/ya_dun_clucked.ogg', 50, 1)
 	..()
 

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -2238,7 +2238,7 @@
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/turkey
 
-/datum/recipe/vox_nuggets
+/datum/recipe/vox_nuggets //placed before regular nuggets on purpose, do not relocate, that will break the vox nuggets 
 	reagents = list(KETCHUP = 5)
 	items = list(
 		/obj/item/stack/sheet/cardboard,
@@ -2246,7 +2246,7 @@
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/vox_nuggets
 
-/datum/recipe/vox_chicken_drumstick
+/datum/recipe/vox_chicken_drumstick //placed before regular drumsticks on purpose, do not relocate, that will break the vox drumsticks
 	items = list(
 		/obj/item/stack/sheet/cardboard,
 		/obj/item/weapon/reagent_containers/food/snacks/meat/rawchicken/raw_vox_chicken,

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -2238,6 +2238,22 @@
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/turkey
 
+/datum/recipe/vox_nuggets
+	reagents = list(KETCHUP = 5)
+	items = list(
+		/obj/item/stack/sheet/cardboard,
+		/obj/item/weapon/reagent_containers/food/snacks/meat/rawchicken/raw_vox_chicken,
+		)
+	result = /obj/item/weapon/reagent_containers/food/snacks/vox_nuggets
+
+/datum/recipe/vox_chicken_drumstick
+	items = list(
+		/obj/item/stack/sheet/cardboard,
+		/obj/item/weapon/reagent_containers/food/snacks/meat/rawchicken/raw_vox_chicken,
+		/obj/item/weapon/reagent_containers/food/snacks/meat/rawchicken/raw_vox_chicken,
+		)
+	result = /obj/item/weapon/storage/fancy/food_box/vox_chicken_bucket
+
 /datum/recipe/chicken_nuggets
 	reagents = list(KETCHUP = 5)
 	items = list(
@@ -2258,22 +2274,6 @@
 	reagents = list(CORNOIL = 3)
 	items = list(/obj/item/weapon/reagent_containers/food/snacks/meat/rawchicken)
 	result = /obj/item/weapon/reagent_containers/food/snacks/chicken_tenders
-
-/datum/recipe/vox_nuggets
-	reagents = list(KETCHUP = 5)
-	items = list(
-		/obj/item/stack/sheet/cardboard,
-		/obj/item/weapon/reagent_containers/food/snacks/meat/rawchicken/raw_vox_chicken,
-		)
-	result = /obj/item/weapon/reagent_containers/food/snacks/vox_nuggets
-
-/datum/recipe/vox_chicken_drumstick
-	items = list(
-		/obj/item/stack/sheet/cardboard,
-		/obj/item/weapon/reagent_containers/food/snacks/meat/rawchicken/raw_vox_chicken,
-		/obj/item/weapon/reagent_containers/food/snacks/meat/rawchicken/raw_vox_chicken,
-		)
-	result = /obj/item/weapon/storage/fancy/food_box/vox_chicken_bucket
 
 /datum/recipe/crab_sticks
 	reagents = list(SODIUMCHLORIDE = 1, SUGAR = 1)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4409,7 +4409,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/vox_chicken_drumstick
 	name = "Vox drumstick"
 	desc = "I can't stand cold food. Unlike you, I ain't never ate from a trash can."
-	icon_state = "chicken_drumstick"
+	icon_state = "vox_drumstick"
 	food_flags = FOOD_MEAT
 	filling_color = "#4A75F4"
 	base_crumb_chance = 0


### PR DESCRIPTION
I just moved some code around (literally). 100% tested, works as intended and doesn't break regular nuggets/drumsticks or monkey processing. Fixes #32056. Fixes #32057.
[bugfix]
:cl:
 * bugfix: Cooking nuggets/drumsticks with vox chicken now gives the appropriate vox variant instead of the generic chicken one.
 * bugfix: Processing a vox chicken now gives nuggets as intended instead of blood buckets.