### PR TITLE
Fixes emergency lights in space

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -594,6 +594,7 @@
 			if(O.invisibility == 101)
 				O.singularity_act()
 	ChangeTurf(get_underlying_turf())
+	get_area(src).icon_state = null
 	score.turfssingulod++
 	return(2)
 


### PR DESCRIPTION
:cl:
 * tweak: Removes emergency flashing lights in an area when singulo eats a tile in the area
