### PR TITLE
Removes a recommended extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
     "recommendations": [
-        "gbasood.byond-dm-language-support",
         "platymuus.dm-langclient",
         "EditorConfig.EditorConfig"
     ]


### PR DESCRIPTION
My editor keeps complaining about this and it's getting annoying.
This extension is no longer necessary since dm-langclient provides better syntax highlighting, which overrode this extension anyway.