### PR TITLE
Drug Tolerance Updates

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -467,6 +467,7 @@
 #define TRINITRINE		"trinitrine"
 #define MIDAZOLINE		"midazoline"
 #define LOCUTOGEN		"locutogen"
+#define NALOXONE		"naloxone"
 
 //Plant-specific reagents
 #define TANNIC_ACID		"tannic_acid"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -174,7 +174,7 @@ Subject's pulse: ??? BPM"})
 	var/BU = M.getFireLoss() > 50  ? "<b>[M.getFireLoss()]</b>"  : M.getFireLoss()
 	var/BR = M.getBruteLoss() > 50 ? "<b>[M.getBruteLoss()]</b>" : M.getBruteLoss()
 	if(M.status_flags & FAKEDEATH)
-		OX = "<b>200</b>" 
+		OX = "<b>200</b>"
 		message += "<span class='notice'>Analyzing Results for [M]:<br>Overall Status: Dead</span><br>"
 	else
 		message += "<span class='notice'>Analyzing Results for [M]:<br>Overall Status: [M.stat > 1 ? "Dead" : "[(M.health - M.halloss)/M.maxHealth*100]% Healthy"]</span>"
@@ -537,7 +537,12 @@ Subject's pulse: ??? BPM"})
 		if(O.reagents.reagent_list.len)
 			for(var/datum/reagent/R in O.reagents.reagent_list)
 				var/reagent_percent = (R.volume/O.reagents.total_volume)*100
-				dat += "<br><span class='notice'>[R][details ? " ([R.volume] units, [reagent_percent]%, time in system: [R.real_tick*2] seconds" : ""]</span>"
+				var/tolerance_info = null
+				if(istype(O,/mob/living))
+					var/mob/living/M = O
+					if(R.id in M.tolerated_chems)
+						tolerance_info = ", " + "tolerance: " + "[M.tolerated_chems[R.id]]" + " units"
+				dat += "<br><span class='notice'>[R][details ? " ([R.volume] units, [reagent_percent]%, time in system: [R.real_tick*2] seconds[tolerance_info].)" : ""]</span>"
 		if(dat)
 			to_chat(user, "<span class='notice'>Chemicals found in \the [O]:[dat]</span>")
 		else

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -51,7 +51,6 @@
 	var/mug_desc = null
 	var/addictive = FALSE
 	var/tolerance_increase = null  //for tolerance, if set above 0, will increase each by that amount on tick.
-	var/overdose_am_multiplier = null //use this to control if something has an OD threshold
 
 /datum/reagent/proc/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)
 	set waitfor = 0
@@ -9747,8 +9746,8 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 			M.drowsyness  = max(M.drowsyness, 30)
 			M.adjustToxLoss(0.2)
 			for(var/reagent_id in M.tolerated_chems)
-				var/datum/reagent/R = chemical_reagents_list[reagent_id]
-					if(M.tolerated_chems[reagent_id] > 0)
-						M.tolerated_chems[reagent_id] += R.tolerance_increase * -10
-					else
-						M.tolerated_chems[reagent_id] = 0
+				if(M.tolerated_chems[reagent_id] <= 0)
+					M.tolerated_chems[reagent_id] = 0
+				else
+					var/datum/reagent/R = chemical_reagents_list[reagent_id]
+					M.tolerated_chems[reagent_id] += R.tolerance_increase * -10

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3676,7 +3676,7 @@
 	result = BLACKCOLOR
 	required_reagents = list(COLORFUL_REAGENT = 1, CARBON = 1)
 	result_amount = 2
-	
+
 /datum/chemical_reaction/degeneratecalcium
 	name = "Degenerate Calcium"
 	id = DEGENERATECALCIUM
@@ -3922,6 +3922,13 @@
 	id = LOCUTOGEN
 	result = LOCUTOGEN
 	required_reagents = list(PICCOLYN = 1, INACUSIATE = 1, SUGAR = 1)
+	result_amount = 3
+
+/datum/chemical_reaction/naloxone
+	name = "Naloxone"
+	id = NALOXONE
+	result = NALOXONE
+	required_reagents = list(ETHYLREDOXRAZINE = 1, PLASMA = 1, STOXIN = 1)
 	result_amount = 3
 
 /datum/chemical_reaction/random


### PR DESCRIPTION
Expands on the system created by @kane-f in the following ways:
- Overdose levels no longer are stationary and instead follow a parabolic increase as tolerance increases. These levels eventually match the tolerance itself, leading to a loss in effects of a certain drug. 
- Advanced Reagent Scanners now will show drug tolerance levels in terms of units. A tolerance of 5u means any consumption level equal to or less than 5u will not result in any effect but will increase your tolerance and satisfy addictions.
- Adds Naloxone which can be used to reduce drug tolerances. This is meant to be used with a doctor present, as it sedates the patient and causes continual toxin damage, requiring close monitoring and precise dosages.

Following this, I intend to create PRs to implement some drug-specific addictions.

:cl:
 * rscadd: Adds Naloxone, a sedative anti-addiction drug used to reduce drug tolerance at the expense of toxin damage.
 * rscadd: Advanced Reagent Scanners can now identify drug tolerance levels.
 * tweak: Overdose levels now increase with drug tolerance levels to a certain point before falling to the tolerance level.
