### PR TITLE
Fixing the vox nuggets and drumsticks II: Electric Boogaloo. Adds a priority system for recipes.

### DIFF
--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -77,3 +77,6 @@ var/atom/cmp_dist_origin=null
 
 /proc/cmp_microwave_recipe_asc(datum/recipe/a, datum/recipe/b)
     return b.priority - a.priority
+
+ /proc/cmp_food_processor_asc(datum/food_processor_process/a, datum/food_processor_process/b)
+    return b.priority - a.priority

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -76,7 +76,7 @@ var/atom/cmp_dist_origin=null
 	return b_when - a_when
 
 /proc/cmp_microwave_recipe_dsc(datum/recipe/a, datum/recipe/b)
-	return a.priority - b.priority
+	return b.priority - a.priority
 
 /proc/cmp_food_processor_dsc(datum/food_processor_process/a, datum/food_processor_process/b)
-	return a.priority - b.priority
+	return b.priority - a.priority

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -77,6 +77,3 @@ var/atom/cmp_dist_origin=null
 
 /proc/cmp_microwave_recipe_dsc(datum/recipe/a, datum/recipe/b)
 	return b.priority - a.priority
-
-/proc/cmp_food_processor_dsc(datum/food_processor_process/a, datum/food_processor_process/b)
-	return b.priority - a.priority

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -76,7 +76,7 @@ var/atom/cmp_dist_origin=null
 	return b_when - a_when
 
 /proc/cmp_microwave_recipe_asc(datum/recipe/a, datum/recipe/b)
-    return b.priority - a.priority
+	return b.priority - a.priority
 
  /proc/cmp_food_processor_asc(datum/food_processor_process/a, datum/food_processor_process/b)
-    return b.priority - a.priority
+	return b.priority - a.priority

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -75,8 +75,8 @@ var/atom/cmp_dist_origin=null
 		return b.id - a.id
 	return b_when - a_when
 
-/proc/cmp_microwave_recipe_asc(datum/recipe/a, datum/recipe/b)
-	return b.priority - a.priority
+/proc/cmp_microwave_recipe_dsc(datum/recipe/a, datum/recipe/b)
+	return a.priority - b.priority
 
- /proc/cmp_food_processor_asc(datum/food_processor_process/a, datum/food_processor_process/b)
-	return b.priority - a.priority
+/proc/cmp_food_processor_dsc(datum/food_processor_process/a, datum/food_processor_process/b)
+	return a.priority - b.priority

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -74,3 +74,6 @@ var/atom/cmp_dist_origin=null
 	if(a_when == b_when)
 		return b.id - a.id
 	return b_when - a_when
+
+/proc/cmp_microwave_recipe_asc(datum/recipe/a, datum/recipe/b)
+    return b.priority - a.priority

--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -38,7 +38,7 @@
 	var/list/items //List of items needed, items = list(/obj/item/tool/crowbar, /obj/item/weapon/welder)
 	var/result //Result of a complete recipe. result = /obj/item/weapon/reagent_containers/food/snacks/donut/normal
 	var/time = 10 SECONDS //Length of time it takes to complete the recipe. In 10ths of a second
-
+	var/priority = 0 //To check which recipe takes priority if they share ingredients
 /*
 	check_reagents function
 	Looks for reagents in the reagent container passed to it, and if this matches what we require.

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -74,7 +74,7 @@
 				acceptable_items |= item
 			for (var/reagent in recipe.reagents)
 				acceptable_reagents |= reagent
-        sortTim(available_recipes, /proc/cmp_microwave_recipe_dsc)   
+		sortTim(available_recipes, /proc/cmp_microwave_recipe_dsc)   
 /*******************
 *   Part Upgrades
 ********************/

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -74,7 +74,7 @@
 				acceptable_items |= item
 			for (var/reagent in recipe.reagents)
 				acceptable_reagents |= reagent
-
+        sortTim(available_recipes, /proc/cmp_microwave_recipe_dsc)   
 /*******************
 *   Part Upgrades
 ********************/

--- a/code/game/machinery/kitchen/processor.dm
+++ b/code/game/machinery/kitchen/processor.dm
@@ -47,7 +47,6 @@
 	var/input
 	var/output
 	var/time = 40
-	var/priority = 0
 
 /datum/food_processor_process/proc/process(loc, what)
 	if (src.output && loc)
@@ -117,6 +116,10 @@
 		feedback_add_details("slime_core_harvested","[replacetext(S.colour," ","_")]")
 	..()
 
+/datum/food_processor_process/mob/voxchicken //Do not relocate please I will cry; I tried sorting all fancylike with some help, but it seems the file is scuffed beyond my mortal means
+	input = /mob/living/carbon/monkey/vox
+	output = /obj/item/weapon/reagent_containers/food/snacks/vox_nuggets
+
 /datum/food_processor_process/mob/monkey
 	input = /mob/living/carbon/monkey
 	output = null
@@ -140,11 +143,6 @@
 /datum/food_processor_process/mob/chicken/process(loc, what)
 	playsound(loc, 'sound/machines/ya_dun_clucked.ogg', 50, 1)
 	..()
-
-/datum/food_processor_process/mob/voxchicken
-	input = /mob/living/carbon/monkey/vox
-	output = /obj/item/weapon/reagent_containers/food/snacks/vox_nuggets
-	priority = 1
 
 /datum/food_processor_process/mob/voxchicken/process(loc, what)
 	playsound(loc, 'sound/machines/ya_dun_clucked.ogg', 50, 1)

--- a/code/game/machinery/kitchen/processor.dm
+++ b/code/game/machinery/kitchen/processor.dm
@@ -47,6 +47,7 @@
 	var/input
 	var/output
 	var/time = 40
+	var/priority = 0
 
 /datum/food_processor_process/proc/process(loc, what)
 	if (src.output && loc)
@@ -143,6 +144,7 @@
 /datum/food_processor_process/mob/voxchicken
 	input = /mob/living/carbon/monkey/vox
 	output = /obj/item/weapon/reagent_containers/food/snacks/vox_nuggets
+	priority = 1
 
 /datum/food_processor_process/mob/voxchicken/process(loc, what)
 	playsound(loc, 'sound/machines/ya_dun_clucked.ogg', 50, 1)

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -2261,6 +2261,7 @@
 
 /datum/recipe/vox_nuggets
 	reagents = list(KETCHUP = 5)
+	priority = 1
 	items = list(
 		/obj/item/stack/sheet/cardboard,
 		/obj/item/weapon/reagent_containers/food/snacks/meat/rawchicken/raw_vox_chicken,
@@ -2268,6 +2269,7 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/vox_nuggets
 
 /datum/recipe/vox_chicken_drumstick
+	priority = 1
 	items = list(
 		/obj/item/stack/sheet/cardboard,
 		/obj/item/weapon/reagent_containers/food/snacks/meat/rawchicken/raw_vox_chicken,

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4409,7 +4409,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/vox_chicken_drumstick
 	name = "Vox drumstick"
 	desc = "I can't stand cold food. Unlike you, I ain't never ate from a trash can."
-	icon_state = "chicken_drumstick"
+	icon_state = "vox_drumstick"
 	food_flags = FOOD_MEAT
 	filling_color = "#4A75F4"
 	base_crumb_chance = 0


### PR DESCRIPTION
60% less spaghetti edition. Thanks to PrimeD and Exxion for the help.
It also adds a priority system for recipes that share ingredients.
Fixes #32056. Fixes #32057.
[bugfix]
:cl:
 * bugfix: Fixes vox chicken processing and vox nuggets/vox drumstick recipes.