### PR TITLE
Reverts the unused addiction system

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -18,12 +18,6 @@
 
 	immune_system = new (src)
 
-/mob/living/create_reagents(const/max_vol)
-	..(max_vol)
-	addicted_chems = new /datum/reagents(max_vol)
-	addicted_chems.my_atom = src
-	tolerated_chems = list()
-
 /mob/living/Destroy()
 	for(var/mob/living/silicon/robot/mommi/MoMMI in player_list)
 		for(var/image/I in static_overlays)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -356,7 +356,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	return total_transfered
 */
 
-/datum/reagents/proc/metabolize(var/mob/living/M, var/alien)
+/datum/reagents/proc/metabolize(var/mob/M, var/alien)
 	if(M && chem_temp != M.bodytemperature)
 		chem_temp = M.bodytemperature
 		handle_reactions()
@@ -366,25 +366,6 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 			R.on_mob_life(M, alien)
 			if(R)
 				R.metabolize(M)
-	if(M.addicted_chems)
-		for(var/B in M.addicted_chems.reagent_list)
-			var/datum/reagent/R2 = B
-			if(M && R2 && !has_reagent_type(R2.type))
-				R2.on_withdrawal(M)
-	for(var/reagent_id in M.tolerated_chems)
-		if(!has_reagent(reagent_id))
-			var/datum/reagent/R3 = chemical_reagents_list[reagent_id]
-			if(ishuman(M))
-				var/mob/living/carbon/human/H = M
-				var/datum/organ/internal/liver/L = H.internal_organs_by_name["liver"]
-				if(L)
-					var/reagent_efficiency = 1
-					if(reagent_id in L.reagent_efficiencies)
-						reagent_efficiency = L.reagent_efficiencies[reagent_id]
-					M.tolerated_chems[reagent_id] = max(0, M.tolerated_chems[reagent_id] - (L.efficiency * reagent_efficiency * R3.tolerance_increase))
-					return
-			// If we aren't human, we don't have a liver, so just remove tolerance the old fashioned way.
-			M.tolerated_chems[reagent_id] = max(0, M.tolerated_chems[reagent_id] - R3.tolerance_increase)
 	update_total()
 
 /datum/reagents/proc/update_aerosol(var/mob/M)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -49,8 +49,6 @@
 	var/mug_icon_state = null
 	var/mug_name = null
 	var/mug_desc = null
-	var/addictive = FALSE
-	var/tolerance_increase = null  //for tolerance, if set above 0, will increase each by that amount on tick.
 
 /datum/reagent/proc/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume)
 	set waitfor = 0
@@ -58,8 +56,6 @@
 	if(!holder)
 		return 1
 	if(!istype(M))
-		return 1
-	if((src.id in M.tolerated_chems) && M.tolerated_chems[src.id] && M.tolerated_chems[src.id] >= volume)
 		return 1
 
 	var/datum/reagent/self = src //Note : You need to declare self again (before the parent call) to use it in your chemical, see blood
@@ -98,13 +94,14 @@
 		for (var/role in M.mind.antag_roles)
 			var/datum/role/R = M.mind.antag_roles[role]
 			R.handle_splashed_reagent(self.id)
+<<<<<<< HEAD
 	
 	if(self.tolerance_increase)
 		M.tolerated_chems[self.id] += self.tolerance_increase
+=======
+>>>>>>> parent of 41b85b444d (Reagent addiction/tolerance system, take two (#31994))
 
 /datum/reagent/proc/reaction_dropper_mob(var/mob/living/M, var/method = TOUCH, var/volume)
-	if((src.id in M.tolerated_chems) && M.tolerated_chems[src.id] && M.tolerated_chems[src.id] >= volume)
-		return 1
 	var/datum/reagent/self = src //Note : You need to declare self again (before the parent call) to use it in your chemical, see blood
 	src = null
 	if(M.reagents)
@@ -114,9 +111,12 @@
 		for (var/role in M.mind.antag_roles)
 			var/datum/role/R = M.mind.antag_roles[role]
 			R.handle_splashed_reagent(self.id)
+<<<<<<< HEAD
 	
 	if(self.tolerance_increase)
 		M.tolerated_chems[self.id] += self.tolerance_increase
+=======
+>>>>>>> parent of 41b85b444d (Reagent addiction/tolerance system, take two (#31994))
 
 /datum/reagent/proc/reaction_dropper_obj(var/obj/O, var/volume)
 	reaction_obj(O, volume)
@@ -185,8 +185,6 @@
 				C.absorbed_chems.Add(id)
 				to_chat(M, "<span class = 'notice'>We have learned [src].</span>")
 
-	if((src.id in M.tolerated_chems) && M.tolerated_chems[src.id] && M.tolerated_chems[src.id] >= volume)
-		return 1
 	if(is_overdosing())
 		on_overdose(M)
 
@@ -194,11 +192,6 @@
 		for (var/role in M.mind.antag_roles)
 			var/datum/role/R = M.mind.antag_roles[role]
 			R.handle_reagent(id)
-	
-	if(addictive && M.addicted_chems)
-		M.addicted_chems.add_reagent(src.id, custom_metabolism)
-	if(tolerance_increase)
-		M.tolerated_chems[src.id] += tolerance_increase
 
 /datum/reagent/proc/is_overdosing() //Too much chems, or been in your system too long
 	return (overdose_am && volume >= overdose_am) || (overdose_tick && tick >= overdose_tick)
@@ -217,26 +210,8 @@
 /datum/reagent/proc/on_introduced(var/data)
 	return
 
-/datum/reagent/proc/on_removal(var/amount)
+/datum/reagent/proc/on_removal(var/data)
 	return 1
-
-//Called every tick when listed as an addicted chemical
-/datum/reagent/proc/on_withdrawal(var/mob/living/M)
-	if(!holder)
-		return 1
-	if(!M)
-		M = holder.my_atom //Try to find the mob through the holder
-	if(!istype(M)) //Still can't find it, abort
-		return 1
-	if(M.addicted_chems)
-		M.addicted_chems.remove_reagent(src.id, custom_metabolism)
-	tick++
-	real_tick++
-
-//Has to be a reagents datum for on_withdrawal()
-/mob/living/var/datum/reagents/addicted_chems
-//Associative lists for tolerance formatted like (REAGENT_ID = amount)
-/mob/living/var/list/tolerated_chems
 
 //Completely unimplemented as of 2021, commenting out
 ///datum/reagent/proc/on_move(var/mob/M)
@@ -1146,7 +1121,6 @@
 	overdose_am = REAGENTS_OVERDOSE
 	density = 5.23
 	specheatcap = 0.62
-
 
 /datum/reagent/space_drugs/on_mob_life(var/mob/living/M)
 
@@ -2064,7 +2038,6 @@
 	custom_metabolism = 0.05
 	density = 1.26
 	specheatcap = 24.59
-
 
 /datum/reagent/oxycodone/on_mob_life(var/mob/living/M)
 
@@ -3241,14 +3214,13 @@
 	density = 1.79
 	specheatcap = 0.70
 
-
 /datum/reagent/hyperzine/on_mob_life(var/mob/living/M)
 
 	if(..())
 		return 1
 
 	if(prob(5) && M.stat == CONSCIOUS)
-		M.emote(pick("twitch","blink_r","shiver")) //See movement_tally_multiplier for the rest
+		M.emote(pick("twitch","blink_r","shiver"))
 
 /datum/reagent/hyperzine/on_overdose(var/mob/living/M)
 	if(ishuman(M) && M.get_heart()) // Got a heart?

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -94,12 +94,7 @@
 		for (var/role in M.mind.antag_roles)
 			var/datum/role/R = M.mind.antag_roles[role]
 			R.handle_splashed_reagent(self.id)
-<<<<<<< HEAD
-	
-	if(self.tolerance_increase)
-		M.tolerated_chems[self.id] += self.tolerance_increase
-=======
->>>>>>> parent of 41b85b444d (Reagent addiction/tolerance system, take two (#31994))
+
 
 /datum/reagent/proc/reaction_dropper_mob(var/mob/living/M, var/method = TOUCH, var/volume)
 	var/datum/reagent/self = src //Note : You need to declare self again (before the parent call) to use it in your chemical, see blood
@@ -111,12 +106,7 @@
 		for (var/role in M.mind.antag_roles)
 			var/datum/role/R = M.mind.antag_roles[role]
 			R.handle_splashed_reagent(self.id)
-<<<<<<< HEAD
-	
-	if(self.tolerance_increase)
-		M.tolerated_chems[self.id] += self.tolerance_increase
-=======
->>>>>>> parent of 41b85b444d (Reagent addiction/tolerance system, take two (#31994))
+
 
 /datum/reagent/proc/reaction_dropper_obj(var/obj/O, var/volume)
 	reaction_obj(O, volume)


### PR DESCRIPTION
Reverts the addiction system introduced in #31994. Feedback both in that PR, #31942, and #32359 has made it clear that the playerbase is simply not interested in this system at all, so it is best to remove it now before any sneaky coders reference it in future PRs.

:cl:
 * rscdel: removed the unused drug tolerance and addiction system
