### PR TITLE
Changes ore smelted score to reflect ore value

### DIFF
--- a/code/game/gamemodes/endgame/scoreboard/department_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/department_score.dm
@@ -94,7 +94,7 @@
 	score.crewscore += score.plasmashipped * 0.5 //Plasma Sheets shipped
 	score.crewscore += score.stuffforwarded * 50 //Cargo Crates forwarded
 	score.crewscore -= score.stuffnotforwarded * 25 //Cargo Crates not forwarded
-	score.crewscore += score.oremined //Not actually counted at mining, but at processing. One ore smelted is one point
+	score.crewscore += score.oremined //Not actually counted at mining, but at processing. One credit of smelted ore value is one point
 
 /datum/controller/gameticker/scoreboard/proc/science_score()
 	//var/researchpoints = score.scores["researchdone"] * 20 //One discovered design is 20 points. You'll usually find hundreds

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -135,7 +135,7 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	if(score.stuffforwarded > 0)
 		dat += "<B>Cargo Crates Forwarded:</B> [score.stuffforwarded] ([score.stuffforwarded * 50] Points)<BR>"
 	if(score.oremined > 0)
-		dat += "<B>Ore Smelted:</B> [score.oremined] ([score.oremined] Points)<BR>"
+		dat += "<B>Value of Ore Smelted:</B> $[score.oremined] ([score.oremined] Points)<BR>"
 	dat += "<B>Whole Station Powered:</B> [score.powerbonus ? "Yes" : "No"] ([score.powerbonus] Points)<BR>"
 	if (score.disease_vaccine_score > 0)
 		dat += "<B>Isolated Vaccines:</B> [score.disease_vaccine] ([score.disease_vaccine_score] Points)<BR>"

--- a/code/game/objects/items/robot/robot_items/robot_furnace.dm
+++ b/code/game/objects/items/robot/robot_items/robot_furnace.dm
@@ -70,7 +70,7 @@
 			while(R.checkIngredients(ore)) //While we have materials for this
 				for(var/ore_id in R.ingredients)
 					ore.removeAmount(ore_id, R.ingredients[ore_id])
-					score.oremined += 1 //Count this ore piece as processed for the scoreboard
+					score.oremined += ore.getValue() //Count this ore piece as processed for the scoreboard
 
 				new R.yieldtype(get_turf(loc))
 				sheets_this_tick++

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -412,7 +412,7 @@
 		while(R.checkIngredients(ore)) //While we have materials for this
 			for(var/ore_id in R.ingredients)
 				ore.removeAmount(ore_id, R.ingredients[ore_id]) //arg1 = ore name, arg2 = how much per sheet
-				score.oremined += 1 //Count this ore piece as processed for the scoreboard
+				score.oremined += ore.getValue() //Count this ore piece as processed for the scoreboard
 
 			drop_stack(R.yieldtype, out_T)
 

--- a/code/modules/mining/ore_redemption.dm
+++ b/code/modules/mining/ore_redemption.dm
@@ -49,9 +49,7 @@
 			var/obj/structure/ore_box/B = locate() in in_T
 			if(B)
 				for(var/O in B.stored_ores)
-					var/amount = B.stored_ores[O]
-					SmeltOreType(O, amount)
-					score.oremined += amount
+					SmeltOreType(O, B.stored_ores[O])
 		else
 			for(var/i = 0; i < 10; i++)
 				var/obj/item/stack/ore/O = locate() in in_T
@@ -59,7 +57,6 @@
 					continue //Skip slag for now.
 				if(O)
 					SmeltMineral(O)
-					score.oremined += O.amount
 				else
 					break
 
@@ -67,6 +64,7 @@
 	if(O.materials)
 		credits += O.materials.getValue()
 		materials.addFrom(O.materials, TRUE)
+		score.oremined += O.materials.getValue()
 		qdel(O)
 
 /obj/machinery/mineral/ore_redemption/proc/SmeltOreType(var/type, var/amount)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -369,7 +369,7 @@
 			while(R.checkIngredients(materials)) //While we have materials for this
 				for(var/ore_id in R.ingredients)
 					materials.removeAmount(ore_id, R.ingredients[ore_id]) //arg1 = ore name, arg2 = how much per sheet
-					score.oremined += 1 //Count this ore piece as processed for the scoreboard
+					score.oremined += materials.getValue() //Count this ore piece as processed for the scoreboard
 					if(istype(loc,/obj/structure/forge))
 						drop_stack(R.yieldtype,loc.loc)
 					else


### PR DESCRIPTION
[tweak]
Mainly to encourage mining of more rare materials to reach that score. (Multiplied by 50 for diamond, 6 for uranium, gold and silver and 0.2 for glass and iron)

:cl:
 * tweak: Ore smelted contributing to the crew score now reflects its value, increased for gold, silver, uranium and diamond; kept the same for plasma and reduced for glass and iron.