### PR TITLE
Fixes Poutine Oceans and Citadels erasing plates used on them

### DIFF
--- a/code/modules/food/customizables.dm
+++ b/code/modules/food/customizables.dm
@@ -269,37 +269,41 @@
 		return TRUE
 
 	if(istype(I,/obj/item/weapon/reagent_containers/food/snacks))
-		if(istype(I,/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom)) //no platestacking even with recursive food, for now
-			to_chat(user, "<span class='warning'>That's already got a plate!</span>")
-			return
-
-		var/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom/F = new(get_turf(src),I)
-
-		var/obj/item/weapon/reagent_containers/food/snacks/snack = I
-		F.valid_utensils = snack.valid_utensils
-
-		if (virus2?.len)
-			for (var/ID in virus2)
-				var/datum/disease2/disease/D = virus2[ID]
-				F.infect_disease2(D,1, "added on a plate",0)
-		F.attackby(I, user, params)
-		if (istype(F))
-			if (I.item_state)
-				F.item_state = I.item_state
-			else
-				F.item_state = I.icon_state
-		if (plates.len > 0)
-			user.put_in_hands(F)
-			var/obj/item/trash/plate/plate = plates[plates.len]
-			plates -= plate
-			qdel(plate)
-			update_icon()
-		else
-			F.pixel_x = pixel_x
-			F.pixel_y = pixel_y
-			qdel(src)
+		try_to_put_on_plate(user,I,params)
 	else
 		return ..()
+
+/obj/item/trash/plate/proc/try_to_put_on_plate(var/mob/user, var/obj/item/weapon/reagent_containers/food/snacks/snack, params)
+	if(istype(snack,/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom)) //no platestacking even with recursive food, for now
+		to_chat(user, "<span class='warning'>That's already got a plate!</span>")
+		return
+
+	var/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom/F = new(get_turf(src),snack)
+
+	F.valid_utensils = snack.valid_utensils
+
+	if (virus2?.len)
+		for (var/ID in virus2)
+			var/datum/disease2/disease/D = virus2[ID]
+			F.infect_disease2(D,1, "added on a plate",0)
+	F.attackby(snack, user, params)
+	if (istype(F))
+		if (snack.item_state)
+			F.item_state = snack.item_state
+		else
+			F.item_state = snack.icon_state
+	if (plates.len > 0)
+		user.put_in_hands(F)
+		var/obj/item/trash/plate/plate = plates[plates.len]
+		plates -= plate
+		qdel(plate)
+		update_icon()
+	else
+		F.pixel_x = pixel_x
+		F.pixel_y = pixel_y
+		qdel(src)
+	return F
+
 
 /obj/item/trash/bowl
 	name = "bowl"

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -134,12 +134,18 @@
 /obj/structure/poutineocean/attack_hand(mob/user)
 	to_chat(user, "<span class='warning'>You need a plate to get food from \the [src]!</span>")
 
-/obj/structure/poutineocean/attackby(obj/item/W, mob/user)
+/obj/structure/poutineocean/attackby(obj/item/W, mob/user, params)
 	if (istype(W, /obj/item/trash/plate))
-		if(user.drop_item(W))
-			qdel(W)
+		var/obj/item/trash/plate/P = W
+
+		if (P.plates.len > 0)
+			to_chat(user, "<span class='warning'>You're not sure anything good will happen from trying to fill a whole stack of plates at once.</span>")
+			return
+
+		if(user.drop_item(P))
 			var/obj/item/AM = new type_to_dispense(get_turf(src))
-			user.put_in_hands(AM)
+			var/obj/item/poutine_on_plate = P.try_to_put_on_plate(user,AM,params)
+			user.put_in_hands(poutine_on_plate)
 			user.visible_message("<span class='notice'>[user] gathers some [AM.name] from \the [src], and shovels it onto their plate!</span>", "<span class='notice'>You gather some [AM.name] from \the [src], and shovel it onto your plate!</span>")
 			return
 	..()


### PR DESCRIPTION
[bugfix]

Fixes #32375

:cl:
* bugfix: Poutine Oceans and Citadels no longer erase plates used on them, so you can now get multiple servings with a single plate.