### PR TITLE
Fast macro-based heapsort

### DIFF
--- a/__DEFINES/sort.dm
+++ b/__DEFINES/sort.dm
@@ -1,0 +1,33 @@
+#define SIFT_DOWN(L, comparison, n, i) do { \
+var/SIFT_DOWN_largest = i; \
+var/SIFT_DOWN_i; \
+do { \
+	SIFT_DOWN_i = SIFT_DOWN_largest; \
+	var/SIFT_DOWN_l = 2 * SIFT_DOWN_largest; \
+	var/SIFT_DOWN_r = SIFT_DOWN_l + 1; \
+	if(SIFT_DOWN_l <= n) { \
+		if(comparison(L[SIFT_DOWN_l], L[SIFT_DOWN_largest])) { \
+			SIFT_DOWN_largest = SIFT_DOWN_l; \
+		} \
+		if((SIFT_DOWN_r <= n) && comparison(L[SIFT_DOWN_r], L[SIFT_DOWN_largest])) { \
+			SIFT_DOWN_largest = SIFT_DOWN_r; \
+		} \
+	} \
+	L.Swap(SIFT_DOWN_i, SIFT_DOWN_largest); \
+} while(SIFT_DOWN_largest != SIFT_DOWN_i);} while(FALSE)
+
+#define SORT(L, comparison) do { \
+var/SORT_N = L.len; \
+for(var/SORT_i in round(SORT_N / 2) to 1 step -1) { \
+	SIFT_DOWN(L, comparison, SORT_N, SORT_i); \
+} \
+for(var/SORT_i in SORT_N to 2 step -1) { \
+	L.Swap(1, SORT_i); \
+	SIFT_DOWN(L, comparison, SORT_i - 1, 1); \
+}} while(FALSE)
+
+#define GREATER(a, b) (a > b)
+#define LESS(a, b) (a < b)
+
+#define SORT_ASC(L) SORT(L, GREATER)
+#define SORT_DSC(L) SORT(L, LESS)

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -66,6 +66,7 @@
 #include "__DEFINES\silicon.dm"
 #include "__DEFINES\simple_animal_defines.dm"
 #include "__DEFINES\snow.dm"
+#include "__DEFINES\sort.dm"
 #include "__DEFINES\spell_defines.dm"
 #include "__DEFINES\striketeam_defines.dm"
 #include "__DEFINES\stylesheet.dm"


### PR DESCRIPTION
Far faster than our other sorting methods in typical cases. Not actually used anywhere yet. Damian was interested in potentially using it, so here it is.
The code itself is a clusterfuck due to being potent macro abuse, but its usage is actually pretty nice. Since it's a macro and not a proc, the comparison argument can be *any token*, not just a passable object. Thus it can be a proc as in the existing solutions, or a macro, allowing for zero proc call overhead in the comparisons.

In my testing, on *random* lists, it starts out around three times faster than `sortTim()` on small lists, and increases from there as the list grows. Random lists are not the best case for Timsort, though, so on large lists of certain "shapes", it could potentially outperform this. Timsort notably scales much better on already-sorted and nearly-sorted lists. Timsort is also stable, while heapsort is not, but I don't think there is currently a single thing in the codebase which depends on a stable sort.

Could be further optimized by converting it to bottom-up heapsort, and probably in other ways as well. Though potentially useful, this was made largely as a novelty and/or tech demo.