### PR TITLE
pAIs can wirejack windoors

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -282,7 +282,7 @@
 		return
 
 	//If it's a weapon, smash windoor. Unless it's an id card, agent card, ect.. then ignore it (Cards really shouldnt damage a door anyway)
-	if(density && istype(I, /obj/item) && !istype(I, /obj/item/weapon/card))
+	if(density && istype(I, /obj/item) && !istype(I, /obj/item/weapon/card) && !istype(I, /obj/item/device/paicard))
 		var/aforce = I.force
 		user.do_attack_animation(src, I)
 		user.delayNextAttack(8)
@@ -369,10 +369,13 @@
 
 /obj/machinery/door/window/wirejack(var/mob/living/silicon/pai/P)
 	if(..())
-		attack_ai(P)
-		return 1
+		if (!density)
+			return close()
+		else
+			return open()
+		return 1	
 	return 0
-
+	
 /obj/machinery/door/window/clockworkify()
 	GENERIC_CLOCKWORK_CONVERSION(src, /obj/machinery/door/window/clockwork, BRASS_WINDOOR_GLOW)
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -17,7 +17,7 @@
 	explosion_resistance = 5
 	air_properties_vary_with_direction = 1
 	ghost_read = 0
-	machine_flags = EMAGGABLE
+	machine_flags = EMAGGABLE|WIREJACK
 	soundeffect = 'sound/machines/windowdoor.ogg'
 	var/shard_type = /obj/item/weapon/shard
 	penetration_dampening = 2

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -367,6 +367,12 @@
 		electronics.forceMove(loc)
 		electronics = null
 
+/obj/machinery/door/window/wirejack(var/mob/living/silicon/pai/P)
+	if(..())
+		attack_ai(P)
+		return 1
+	return 0
+
 /obj/machinery/door/window/clockworkify()
 	GENERIC_CLOCKWORK_CONVERSION(src, /obj/machinery/door/window/clockwork, BRASS_WINDOOR_GLOW)
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -373,9 +373,7 @@
 			return close()
 		else
 			return open()
-		return 1	
-	return 0
-	
+
 /obj/machinery/door/window/clockworkify()
 	GENERIC_CLOCKWORK_CONVERSION(src, /obj/machinery/door/window/clockwork, BRASS_WINDOOR_GLOW)
 


### PR DESCRIPTION
They can already wirejack regular doors, why not the flimsy glass windoors as well?
For [consistency] with regular door wirejacking, since way too many times someone has wanted me to wirejack a windoor, only for me to have to explain that you can't wirejack windoors. Also [tweak].
:cl:
 * tweak: Windoors are wirejackable by pAIs. 