### PR TITLE
pAI medical chems buff

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -84,7 +84,7 @@
 	var/list/synthable_medical_chems = list(
 		"Bicaridine" = BICARIDINE,
 		"Kelotane" = KELOTANE,
-		"Dexalin Plus" = DEXALINP,
+		"Dexalin" = DEXALIN,
 		"Iron" = IRON,
 		"Tramadol" = TRAMADOL,
 		"Alkysine" = ALKYSINE,

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -89,8 +89,9 @@
 		"Tramadol" = TRAMADOL,
 		"Alkysine" = ALKYSINE,
 		"Arithrazine" = ARITHRAZINE,
+		"Ethylredoxrazine" = ETHYLREDOXRAZINE,
 		"Spaceacilin" = SPACEACILLIN,
-		"Sleep Toxin = STOXIN,
+		"Sleep Toxin" = STOXIN,
 	)
 
 /mob/living/silicon/pai/New(var/obj/item/device/paicard)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -86,11 +86,11 @@
 		"Kelotane" = KELOTANE,
 		"Dexalin Plus" = DEXALINP,
 		"Iron" = IRON,
-		"Spaceacilin" = SPACEACILLIN,
 		"Tramadol" = TRAMADOL,
+		"Alkysine" = ALKYSINE,
 		"Arithrazine" = ARITHRAZINE,
 		"Ethylredoxrazine" = ETHYLREDOXRAZINE,
-		"Alkysine" = ALKYSINE,
+		"Spaceacilin" = SPACEACILLIN,
 		"Sleep Toxin = STOXIN,
 	)
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -82,8 +82,12 @@
 	)
 
 	var/list/synthable_medical_chems = list(
+		"Bicaridine" = BICARIDINE,
+		"Kelotane" = KELOTANE,
+		"Dexalin" = DEXALIN,
+		"Dylovene" = DYLOVENE,
 		"Spaceacilin" = SPACEACILLIN,
-		"Albuterol" = ALBUTEROL,
+		"Tramadol" = TRAMADOL,
 	)
 
 /mob/living/silicon/pai/New(var/obj/item/device/paicard)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -84,7 +84,7 @@
 	var/list/synthable_medical_chems = list(
 		"Bicaridine" = BICARIDINE,
 		"Kelotane" = KELOTANE,
-		"Dexalin" = DEXALIN,
+		"Dexalin Plus" = DEXALINP,
 		"Iron" = IRON,
 		"Spaceacilin" = SPACEACILLIN,
 		"Tramadol" = TRAMADOL,

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -85,7 +85,7 @@
 		"Bicaridine" = BICARIDINE,
 		"Kelotane" = KELOTANE,
 		"Dexalin" = DEXALIN,
-		"Dylovene" = DYLOVENE,
+		"Iron" = IRON,
 		"Spaceacilin" = SPACEACILLIN,
 		"Tramadol" = TRAMADOL,
 	)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -89,7 +89,6 @@
 		"Tramadol" = TRAMADOL,
 		"Alkysine" = ALKYSINE,
 		"Arithrazine" = ARITHRAZINE,
-		"Ethylredoxrazine" = ETHYLREDOXRAZINE,
 		"Spaceacilin" = SPACEACILLIN,
 		"Sleep Toxin = STOXIN,
 	)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -88,6 +88,10 @@
 		"Iron" = IRON,
 		"Spaceacilin" = SPACEACILLIN,
 		"Tramadol" = TRAMADOL,
+		"Arithrazine" = ARITHRAZINE,
+		"Ethylredoxrazine" = ETHYLREDOXRAZINE,
+		"Alkysine" = ALKYSINE,
+		"Sleep Toxin = STOXIN,
 	)
 
 /mob/living/silicon/pai/New(var/obj/item/device/paicard)


### PR DESCRIPTION
Currently, pAI chems are kinda lame when compared to a borer, who can give you the best chems in the game and then some. The best you can do is antitox and inaprovaline without the medical module, and installing the medical module only gives you access to spaceacillin and albuterol. 
I think the medical module should give you access to some standard medical chems.
Purchasing both the chem module and the medical module now give you access to spaceacillin, bicaridine, dexalin, kelotane, iron, arithrazine, ethylredoxrazine, alkysine, sleeptoxin and tramadol, losing the albuterol.
With this you can now choose between being a general utility pAI (food, regular pAI chems, wirejack) or specialize as a medical pAI, with all the chems that implies.

Not sure on the tramadol, but since borers can make tramadol and oxycodone, giving it to pAIs feels ok.
:cl:
 * rscadd: pAIs with both the chemical and medical modules now have access to standard medical chems (Bicaridine, Kelotane, Dexalin, Iron, Arithrazine, Ethylredoxrazine, Alkysine, Sleeptoxin and Tramadol).
 * rscdel: pAIs can no longer make albuterol if they purchase both the chemical and medical modules.