### PR TITLE
Fix grue scoreboard text requiring an intact body. 

### DIFF
--- a/code/datums/gamemode/role/grue.dm
+++ b/code/datums/gamemode/role/grue.dm
@@ -27,8 +27,6 @@
 	. = ..()
 	. += "The grue ate [eatencount] sentient being[eatencount==1 ? "" : "s"]"
 	if(config.grue_egglaying)
-		. += " and spawned [spawncount] offspring."
-	else
-		. += "."
-	. += "<BR>"
+		. += " and spawned [spawncount] offspring"
+	. += ".<BR>"
 

--- a/code/datums/gamemode/role/grue.dm
+++ b/code/datums/gamemode/role/grue.dm
@@ -25,11 +25,10 @@
 
 /datum/role/grue/GetScoreboard()
 	. = ..()
-	if(istype(antag.current,/mob/living/simple_animal/hostile/grue))
-		. += "The grue ate [eatencount] sentient being[eatencount==1 ? "" : "s"]"
-		if(config.grue_egglaying)
-			. += " and spawned [spawncount] offspring."
-		else
-			. += "."
-		. += "<BR>"
+	. += "The grue ate [eatencount] sentient being[eatencount==1 ? "" : "s"]"
+	if(config.grue_egglaying)
+		. += " and spawned [spawncount] offspring."
+	else
+		. += "."
+	. += "<BR>"
 


### PR DESCRIPTION
[bugfix]
This fixes the grue scoreboard not displaying `"The grue ate X sentient beings and spawned Y offspring."` if their body was gibbed. There was an unnecessary check.

:cl:
 * bugfix: Fixed grue scoreboard text not appearing if body is gibbed.
