### PR TITLE
Transfer eaten creature's stomach reagents to grue.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -190,43 +190,25 @@
 					to_chat(src, "<span class='warning'>The bright light scalds you!</span>")
 				playsound(src, 'sound/effects/grue_burn.ogg', 50, 1)
 
-
 		//update accum_light_expos_mult for light damage
 		lightparams.alem_adjust()
-
 
 		//handle light-based nutrienergy gain or drain
 		lightparams.nutri_adjust(src)
 
-
 		//update speed modifier based on light condition
 		lightparams.speed_adjust(src)
-
 
 		if(ismoulting)
 			moulttimer--
 			if(moulttimer<=0)
 				complete_moult()
 
-/*
-	//stop draining light if the grue runs out of nutrienergy
-	if(channeling_flags & GRUE_DRAINLIGHT)
-		nutrienergy = max(0,nutrienergy) //Just in case it went below 0.
-		if(!nutrienergy)
-			for(var/spell/aoe_turf/grue_drainlight/S in spell_list)
-				S.stop_casting(null, src)
-*/
-
 	regular_hud_updates()
 	standard_damage_overlay_updates()
 
-
 	if((stat==CONSCIOUS) && !busy && !ismoulting && !client && !mind && !ckey) //Checks for AI
 		grue_ai()
-
-
-
-
 
 //AI stuff:
 /mob/living/simple_animal/hostile/grue/proc/grue_ai()
@@ -645,7 +627,6 @@
 	else
 		channeling_flags &= !GRUE_DRAINLIGHT
 		set_light(0)
-//		playsound(src, aawwww, 50, 1)
 		if(nutrienergy)
 			if(!mute)
 				to_chat(src, "<span class='notice'>You stop draining light.</span>")

--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -294,6 +294,7 @@
 		attack_sound = 'sound/weapons/bite.ogg'
 		size = SIZE_SMALL
 		pass_flags = PASSTABLE
+		reagents.maximum_volume = 500
 		//Larval grue spells: moult, ventcrawl, and hide
 		add_spell(new /spell/aoe_turf/grue_hide, "grue_spell_ready", /obj/abstract/screen/movable/spell_master/grue)
 		add_spell(new /spell/aoe_turf/grue_ventcrawl, "grue_spell_ready", /obj/abstract/screen/movable/spell_master/grue)
@@ -317,6 +318,7 @@
 		attack_sound = 'sound/weapons/cbar_hitbod1.ogg'
 		size = SIZE_BIG
 		pass_flags = 0
+		reagents.maximum_volume = 1000
 		//Juvenile grue spells: eat and moult
 		add_spell(new /spell/aoe_turf/grue_moult, "grue_spell_ready", /obj/abstract/screen/movable/spell_master/grue)
 		add_spell(new /spell/targeted/grue_eat, "grue_spell_ready", /obj/abstract/screen/movable/spell_master/grue)
@@ -340,6 +342,7 @@
 		attack_sound = 'sound/weapons/cbar_hitbod1.ogg'
 		size = SIZE_BIG
 		pass_flags = 0
+		reagents.maximum_volume = 1500
 		//Adult grue spells: eat, lay eggs, and drain light
 		if(config.grue_egglaying)
 			add_spell(new /spell/aoe_turf/grue_egg, "grue_spell_ready", /obj/abstract/screen/movable/spell_master/grue)


### PR DESCRIPTION
This makes it so when a grue eats someone, the reagent contents of their stomach also get transferred to the grue. 

:cl:
 * rscadd: Grues also ingest the stomach contents of their victims.
