### PR TITLE
Adds a delay to holy water/potassium reactions

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -95,8 +95,8 @@
 
 /datum/chemical_reaction/explosion_potassium/holy/on_reaction(var/datum/reagents/holder, var/created_volume)
 	set waitfor = FALSE //makes sleep() work like spawn()
-	playsound(holder.my_atom, 'sound/misc/holyhandgrenade.ogg', 100, 1)
-	sleep(1 SECONDS) //wait for the song to finish
+	playsound(holder.my_atom, 'sound/misc/holyhandgrenade.ogg', 100, 0)
+	sleep(2 SECONDS) //wait for the song to finish
 	..() //boom
 
 /datum/chemical_reaction/soap //Potassium Hydroxide is used in making liquid soap not bar soap but that will not stop me

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -94,8 +94,10 @@
 	result_amount = 2.4
 
 /datum/chemical_reaction/explosion_potassium/holy/on_reaction(var/datum/reagents/holder, var/created_volume)
-	..()
+	set waitfor = FALSE //makes sleep() work like spawn()
 	playsound(holder.my_atom, 'sound/misc/holyhandgrenade.ogg', 100, 1)
+	sleep(1 SECONDS) //wait for the song to finish
+	..() //boom
 
 /datum/chemical_reaction/soap //Potassium Hydroxide is used in making liquid soap not bar soap but that will not stop me
 	name = "Soap"


### PR DESCRIPTION
Anyone remember the old Worms series? When you used the Holy Hand Grenade, there was a small delay between the sacred sound playing and the earth shattering kaboom. This PR adds this delay to the game for holy water and potassium reactions. Behold, the preview below, as the poor Chaplain is given a brief moment to contemplate his actions before the explosion.

Also fixing a small sound issue while we're here (unatomic, I'm gonna be repo banned for this one).

EDIT: This would allow for easier ghetto grenades. If you can secure access to holy water and potassium, these would be effectively 2 second timer grenades. While it's still easy to get actual grenades together assuming you can get into tool storage or cargo, this removes that step and allows for a Chaplain to go full bomberman if they can get their hands on beakers and potassium in large enough quantities. Emoji the PR with that in mind...

https://user-images.githubusercontent.com/69739118/163483100-31fb7b65-3bb8-4132-8e1e-a64573f6b7bc.mp4

[bugfix] [sound] [tweak]

:cl:
 * tweak: Added a small delay to the holy water/potass reaction, so you can hear the sound effect before dying!
 * bugfix: Fixed holy water/potass explosion sound playing too quickly/slowly.


