### PR TITLE
Examine messages

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -230,6 +230,7 @@ var/const/MAX_SAVE_SLOTS = 16
 
 	var/tgui_fancy = TRUE
 	var/fps = 0
+	var/examine_messages = TRUE
 
 	var/client/client
 	var/saveloaded = 0
@@ -437,6 +438,8 @@ var/const/MAX_SAVE_SLOTS = 16
 	<a href='?_src_=prefs;preference=window_flashing'><b>[(window_flashing) ? "Yes":"No"]</b></a><br>
 	<b>Fancy tgui:</b>
 	<a href='?_src_=prefs;preference=tgui_fancy'>[tgui_fancy ? "Enabled" : "Disabled"]</a><br>
+	<b>Examine messages:</b>
+	<a href='?_src_=prefs;preference=examine_messages'>[examine_messages ? "Enabled" : "Disabled"]</a><br>
 	<b>
 	<center>Runechat prefererences</center>
 	<b>Chat on map for mobs:</b>
@@ -1380,6 +1383,9 @@ Values up to 1000 are allowed.", "FPS", fps) as null|num
 
 				if("tgui_fancy")
 					tgui_fancy = !tgui_fancy
+
+				if("examine_messages")
+					examine_messages = !examine_messages
 
 				if ("mob_chat_on_map")
 					mob_chat_on_map = !mob_chat_on_map

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -72,6 +72,7 @@
 	obj_chat_on_map 	 =  text2num(preference_list_client["obj_chat_on_map"])
 	no_goonchat_for_obj  =  text2num(preference_list_client["no_goonchat_for_obj"])
 	tgui_fancy           =  text2num(preference_list_client["tgui_fancy"])
+	examine_messages	 =  text2num(preference_list_client["examine_messages"])
 	show_warning_next_time = text2num(preference_list_client["show_warning_next_time"])
 	last_warned_message = preference_list_client["last_warned_message"]
 	warning_admin = preference_list_client["warning_admin"]
@@ -111,6 +112,7 @@
 	obj_chat_on_map 	 =  sanitize_integer(obj_chat_on_map, 0, 1, initial(obj_chat_on_map))
 	no_goonchat_for_obj  =  sanitize_integer(no_goonchat_for_obj, 0, 1, initial(no_goonchat_for_obj))
 	tgui_fancy           =  sanitize_integer(tgui_fancy, 0, 1, initial(tgui_fancy))
+	examine_messages     =  sanitize_integer(examine_messages, 0, 1, initial(examine_messages))
 	show_warning_next_time = sanitize_integer(show_warning_next_time, 0, 1, initial(show_warning_next_time))
 	fps = sanitize_integer(fps, -1, 1000, initial(fps))
 	initialize_preferences()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1165,19 +1165,18 @@ Use this proc preferably at the end of an equipment loadout
 		var/mob/living/L = src
 		if(!isobserver(L) && !L.eyecheck() && !L.invisibility && L.alpha >= 1)
 			if(A.loc != L || A == L.get_active_hand() || A == L.get_inactive_hand())
-				var/look_target = "at \the [A]"
-				if(isobj(A.loc))
-					look_target = "inside \the [A.loc]"
-				if(A == L)
-					look_target = "at [A]"
 				for(var/mob/M in viewers(4, L))
 					if(M == L)
 						continue
 					if(M.client && M.client.prefs.examine_messages)
 						if(M.is_blind())
 							continue
-						to_chat(M, "<span class='info'><b>\The [L]</b> looks [look_target].</span>")
-
+						if(isobj(A.loc))
+							to_chat(M, "<span class='info'><b>\The [L]</b> looks inside \the [A.loc].</span>")
+						else if(A == L)
+							to_chat(M, "<span class='info'><b>\The [L]</b> looks at \the [A.loc].</span>")
+						else
+							to_chat(M, "<span class='info'><b>\The [L]</b> looks at [A.loc].</span>")
 
 /mob/living/verb/verb_pickup(obj/I in acquirable_objects_in_view(usr, 1))
 	set name = "Pick up"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1161,6 +1161,23 @@ Use this proc preferably at the end of an equipment loadout
 	face_atom(A)
 	A.examine(src)
 
+	if(istype(src,/mob/living))
+		var/mob/living/L = src
+		if(!isobserver(L) && !L.eyecheck() && !L.invisibility && L.alpha >= 1)
+			if(A.loc != L || A == L.get_active_hand() || A == L.get_inactive_hand())
+				var/look_target = "at \the [A]"
+				if(isobj(A.loc))
+					look_target = "inside \the [A.loc]"
+				if(A == L)
+					look_target = "at [A]"
+				for(var/mob/M in viewers(4, L))
+					if(M == L)
+						continue
+					if(M.client && M.client.prefs.examine_messages)
+						if(M.is_blind())
+							continue
+						to_chat(M, "<span class='info'><b>\The [L]</b> looks [look_target].</span>")
+
 
 /mob/living/verb/verb_pickup(obj/I in acquirable_objects_in_view(usr, 1))
 	set name = "Pick up"


### PR DESCRIPTION
Adds a setting (defaulted to TRUE) to enable examine messages to be displayed when someone within 4 tiles examines something (ie you will get a message when the HOP examines an ID near you). Wearing sunglasses prevents others from seeing what you are looking at.

![1](https://user-images.githubusercontent.com/66280799/163579456-bf380470-52f1-4502-9c29-38942f9d4f1c.PNG)

[gameplay]

:cl:
 * rscadd: messages are now displayed when someone near you examines something.
