### PR TITLE
Combines internal and external bleeding modifiers

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -225,6 +225,9 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 
 //Makes a blood drop, leaking amt units of blood from the mob
 /mob/living/carbon/human/proc/drip(var/amt as num)
+	if(species && species.anatomy_flags & NO_BLOOD) //TODO: Make drips come from the reagents instead.
+		return 0
+
 	amt = max(0, amt * calcbloodloss()) //determines how much blood to lose based on human's situation
 	
 	if(!amt)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -181,7 +181,6 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 
 		//Bleeding out
 		var/blood_max = 0
-		var/blood_factor = 1
 		for(var/datum/organ/external/temp in organs)
 			if(!(temp.status & ORGAN_BLEEDING) || temp.status & (ORGAN_ROBOT|ORGAN_PEG))
 				continue
@@ -196,29 +195,41 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 			if (temp.open)
 				blood_max += 2 //Yer stomach is cut open
 
-		blood_max = blood_max * BLOODLOSS_SPEED_MULTIPLIER
+		blood_max = blood_max * BLOODLOSS_SPEED_MULTIPLIER //determines the maximum amount of blood to drip
 
-		if(lying)
-			blood_factor -= 0.3
+		drip(blood_max)
 
-		if(reagents.has_reagent(HYPERZINE)) //Hyperzine is an anti-coagulant :^)
-			blood_factor += 0.3
+//Calculates the percentage of blood to lose, 1 being 100%, 0 being 0%
+//Called by both internal and external bleeding factors. Keep common-to-both increases/descreases here.
+/mob/living/carbon/human/proc/calcbloodloss()
+	var/blood_factor = 1
+	if(species && species.anatomy_flags & NO_BLOOD) //Things that do not bleed do not bleed
+		return 0
+		
+	if(lying) //Lying down slows blood loss
+		blood_factor -= 0.3
 
-		if(reagents.has_reagent(INAPROVALINE))
-			blood_factor -= 0.3
+	if(reagents.has_reagent(HYPERZINE)) //Hyperzine is an anti-coagulant :^)
+		blood_factor += 0.3
 
-		drip(blood_max * max(0, blood_factor))
+	if(reagents.has_reagent(INAPROVALINE) || reagents.has_reagent(BICARIDINE)) //Inaprov and Bicard slow bleeding, but do not stack
+		blood_factor -= 0.3
+		
+	if(reagents.has_reagent(CLOTTING_AGENT) || reagents.has_reagent(BIOFOAM)) //Clotting agent and biofoam stop bleeding entirely
+		blood_factor = 0
+	
+	if(bodytemperature < 170) //Cryo stops bleeding entirely
+		blood_factor = 0
+		
+	return max(0, blood_factor) //Do not return a negative percent, we don't want free blood healing!
 
 //Makes a blood drop, leaking amt units of blood from the mob
 /mob/living/carbon/human/proc/drip(var/amt as num)
-
-
-	if(species && species.anatomy_flags & NO_BLOOD) //TODO: Make drips come from the reagents instead.
-		return 0
-
+	amt = max(0, amt * calcbloodloss()) //determines how much blood to lose based on human's situation
+	
 	if(!amt)
 		return 0
-
+	
 	vessel.remove_reagent(BLOOD,amt)
 	blood_splatter(src,src)
 	stat_collection.blood_spilled += amt

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -610,18 +610,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 	var/datum/species/species = src.species || owner.species
 
 	for(var/datum/wound/W in wounds)
-		//Internal wounds get worse over time. Low temperatures (cryo) stop them.
-		if(W.internal && !W.is_treated() && owner.bodytemperature >= 170 && !(species && species.anatomy_flags & NO_BLOOD))
-			var/blood_factor = 1
-
-			if(owner.reagents.has_reagent(INAPROVALINE) || owner.reagents.has_reagent(BICARIDINE)) //Inaprovaline and bicaridine slow bleeding by 30%
-				blood_factor -= 0.3
-
-			if(owner.reagents.has_reagent(HYPERZINE)) //On the other hand, hyperzine speeds up bleeding by 30%
-				blood_factor += 0.3
-
-			if(owner.reagents.has_reagent(CLOTTING_AGENT) || owner.reagents.has_reagent(BIOFOAM)) //Clotting agent and biofoam stop bleeding entirely.
-				blood_factor = 0
+		//Internal wounds get worse over time, and you lose blood
+		if(W.internal && !W.is_treated() && !(species && species.anatomy_flags & NO_BLOOD))
+			var/blood_factor = owner.calcbloodloss() //Calls helper function to determine amount of blood loss.
 
 			owner.vessel.remove_reagent(BLOOD, W.damage * wound_update_accuracy * 0.07 * max(0, blood_factor))
 


### PR DESCRIPTION
This PR combines the internal and external bleeding modifiers into a single helper function in order to simply the effects of blood loss for the medbay crew. It's difficult to remember what modifier affects what type of bleeding, so this simplifies all current effects into one place. This does *not* prevent specific modifiers from being added or changed later (ex, newChem1 that stops only external bleeding can be added safely).

This also affects some alternative effects that cause blood loss (anything that calls drip()) such as ruptured lungs.

Before PR:

> **EXTERNAL** (blood drops on ground, can fix with bandaids)
> lying down slows bleeding 30%
> hyperzine increases bleeding 30%
> inaprovaline slows bleeding 30%
> bicaridine does not affect external bleeding
> clotting agent/biofoam do not affect external bleeding
> cryo does not affect external bleeding

> **INTERNAL** (no visible blood drops, INTENRAL BLEEDING DETECTED, can fix with surgery)
> lying down does not affect internal bleeding
> hyperzine increases bleeding 30%
> inaprovaline and bicaridine slow bleeding 30% but do not stack with each other
> clotting agent/biofoam stop internal bleeding
> cryo stops internal bleeding

After PR:
> **BOTH EXTERNAL AND INTERNAL** (external still cured only by bandaids, internal still only by surgery)
> lying down slows bleeding 30%
> hyperzine increases bleeding 30%
> inaprov/bicard slow bleeding 30% and do not stack
> clotting agent/biofoam stop bleeding
> cryo slops bleeding

Basic testing is finished on monkeymen on a local server, nothing seems to be broken (famous last words).

[balance]

:cl:
 * rscadd: Combines internal and external bleeding modifiers.
