### PR TITLE
Sleeper Tweaks including Sleep Chem Purging

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -8,6 +8,7 @@
 	icon_state = "sleeper_0"
 	density = TRUE
 	anchored = TRUE
+	sleeptime = 6 SECONDS
 	var/base_icon = "sleeper"
 	var/mob/living/occupant = null
 	var/available_options = list(INAPROVALINE = "Inaprovaline", STOXIN2 = "Soporific Rejuvenant", DERMALINE = "Dermaline", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin")
@@ -69,10 +70,13 @@
 	switch(T)
 		if(0 to 5)
 			available_options = list(INAPROVALINE = "Inaprovaline", STOXIN2 = "Soporific Rejuvenant", KELOTANE = "Kelotane", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin")
+			sleeptime = 6 SECONDS
 		if(6 to 8)
 			available_options = list(INAPROVALINE = "Inaprovaline", STOXIN2 = "Soporific Rejuvenant", DERMALINE = "Dermaline", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin", IMIDAZOLINE = "Imidazoline" , INACUSIATE = "Inacusiate" ,  TRICORDRAZINE = "Tricordrazine")
+			sleeptime = 4 SECONDS
 		else
 			available_options = list(INAPROVALINE = "Inaprovaline", STOXIN2 = "Soporific Rejuvenant", DERMALINE = "Dermaline", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin", IMIDAZOLINE = "Imidazoline" , INACUSIATE = "Inacusiate" ,  TRICORDRAZINE = "Tricordrazine" , ALKYSINE = "Alkysine" , TRAMADOL = "Tramadol" , PEPTOBISMOL  = "Peptobismol")
+			sleeptime = 2 SECONDS
 
 /obj/machinery/sleeper/emag(mob/user)
 	if(!emagged)
@@ -85,6 +89,7 @@
 	var/dat = list()
 	if(on)
 		dat += "<B>Performing anaesthesic emergence...</B>" //Best I could come up with
+		dat += "<B>Purging sleep-inducing chemicals...</B>" //Same
 		dat += "<HR><A href='?src=\ref[src];toggle_autoeject=1'>Auto-eject occupant: [auto_eject_after ? "Yes" : "No"]</A><BR>"
 	else
 		dat += "<b>Occupant statistics:</b><BR>"
@@ -110,8 +115,8 @@
 			var/fireloss = occupant.getFireLoss()
 			dat += "<span class='[fireloss < 60 ? "" : "average"]'>\t-Burn severity: [round(fireloss, 0.1)]</span><br>"
 
-			var/sleepytime = max(occupant.paralysis, occupant.sleeping)
-			dat += "<hr>Paralysis summary: [sleepytime] ([round(sleepytime * 2)] seconds left!)<br>"
+			var/paralysissum = max(occupant.paralysis, occupant.sleeping)
+			dat += "<hr>Paralysis summary: [paralysissum] ([round(paralysissum * 2)] seconds left!)<br>"
 			dat += "<a href='?src=\ref[src];wakeup=1'>Begin wake-up cycle</a><br>"
 			if(occupant.reagents)
 				for(var/chemical in available_options)
@@ -397,7 +402,7 @@
 	. = TRUE //Returning TRUE means we successfully began the wake-up cycle. We will return immediately as the spawn() begins, not at the end.
 	on = TRUE
 	process()
-	var/sleeptime = min(5 SECONDS, 4*max(occupant.sleeping, occupant.paralysis))
+
 	spawn(sleeptime)
 		if(!src || !on) //the !src check is redundant from the nature of spawn() if I understand correctly, but better be safe than sorry
 			return
@@ -436,6 +441,7 @@
 				B.buckle_mob(old_occupant, ejector)
 				ejector.start_pulling(B)
 	update_icon()
+	playsound(src, 'sound/machines/pressurehiss.ogg', 40, 1)
 	return TRUE
 
 /obj/machinery/sleeper/proc/inject_chemical(mob/living/user as mob, chemical, amount)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -8,7 +8,7 @@
 	icon_state = "sleeper_0"
 	density = TRUE
 	anchored = TRUE
-	sleeptime = 6 SECONDS
+	var/sleeptime = 6 SECONDS
 	var/base_icon = "sleeper"
 	var/mob/living/occupant = null
 	var/available_options = list(INAPROVALINE = "Inaprovaline", STOXIN2 = "Soporific Rejuvenant", DERMALINE = "Dermaline", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin")

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -407,8 +407,7 @@
 		if(!src || !on) //the !src check is redundant from the nature of spawn() if I understand correctly, but better be safe than sorry
 			return
 		if(occupant)
-			if(occupant.reagents.has_any_reagents(list(STOXIN, STOXIN2, VALERENIC_ACID, CHLORALHYDRATE)))
-				occupant.reagents.remove_reagents(list(STOXIN, STOXIN2, VALERENIC_ACID, CHLORALHYDRATE),1000)
+			occupant.reagents.remove_reagents(list(STOXIN, STOXIN2, VALERENIC_ACID, CHLORALHYDRATE),1000)
 			occupant.sleeping = 0
 			occupant.paralysis = 0
 			occupant.resting = 0

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -88,7 +88,7 @@
 /obj/machinery/sleeper/interact(var/mob/user)
 	var/dat = list()
 	if(on)
-		dat += "<B>Performing anaesthesic emergence...</B>" //Best I could come up with
+		dat += "<B>Performing anaesthesic emergence...</B><BR>" //Best I could come up with
 		dat += "<B>Purging sleep-inducing chemicals...</B>" //Same
 		dat += "<HR><A href='?src=\ref[src];toggle_autoeject=1'>Auto-eject occupant: [auto_eject_after ? "Yes" : "No"]</A><BR>"
 	else
@@ -407,10 +407,8 @@
 		if(!src || !on) //the !src check is redundant from the nature of spawn() if I understand correctly, but better be safe than sorry
 			return
 		if(occupant)
-			occupant.reagents.del_reagent(CHLORALHYDRATE)
-			occupant.reagents.del_reagent(STOXIN)
-			occupant.reagents.del_reagent(STOXIN2)
-			occupant.reagents.del_reagent(VALERENIC_ACID)
+			if(occupant.reagents.has_any_reagents(list(STOXIN, STOXIN2, VALERENIC_ACID, CHLORALHYDRATE)))
+				occupant.reagents.remove_reagents(list(STOXIN, STOXIN2, VALERENIC_ACID, CHLORALHYDRATE),1000)
 			occupant.sleeping = 0
 			occupant.paralysis = 0
 			occupant.resting = 0

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -402,6 +402,10 @@
 		if(!src || !on) //the !src check is redundant from the nature of spawn() if I understand correctly, but better be safe than sorry
 			return
 		if(occupant)
+			occupant.reagents.del_reagent(CHLORALHYDRATE)
+			occupant.reagents.del_reagent(STOXIN)
+			occupant.reagents.del_reagent(STOXIN2)
+			occupant.reagents.del_reagent(VALERENIC_ACID)
 			occupant.sleeping = 0
 			occupant.paralysis = 0
 			occupant.resting = 0


### PR DESCRIPTION
A while back I saw a doctor dragging a sleeping patient from surgery right past a sleeper and into the mancrowave in order to wake them up. I mean, chad move, but this made me wonder what unused portion of sleepers could become relevant in the modern speese game. You know, like that wake-up button. This PR touches something involving GHLORAL though so I better put the balance tag.

- Using the wake-up button on the sleeper now purges any sleep chemicals (Sleep Toxin, Sopho Rejuv, Botany Sleep Toxin, and CHLORAL HYDRATE) in the occupant's body. It only works when the occupant is asleep. Damn safeties!
- The time it takes to wake someone up now scales on upgrades, starting at 6 SECONDS and going to 2 SECONDS for a fully upgraded sleeper. Previously, it was a time between 0, 4, and 5 SECONDS depending on how paralyzed/sleepy the occupant was.
- Sleepers and all children (like the mancrowave) now make a cryo hissing noise when ejecting someone. This stacks with existing sounds, so the mancrowave still dings on ejection.

https://user-images.githubusercontent.com/69739118/163703298-89a689ef-9b1d-4af1-85f4-67efd2d85d06.mp4

[balance] [qol]

:cl:
 * rscadd: Sleepers can now purge sleeping chems on a wake-up cycle.
 * tweak: Sleeper wake-up cycle time now scales on upgrades.
 * soundadd: Sleepers and Mancrowaves now hiss when ejecting someone.
