### PR TITLE
Improved "Perhaps fix the problem with people unable to connect to s13.moe"

### DIFF
--- a/code/controllers/subsystem/openport.dm
+++ b/code/controllers/subsystem/openport.dm
@@ -1,0 +1,30 @@
+var/datum/subsystem/thanksbyond/SSthanksbyond
+
+/// Band-aided attempt to work around a problem that prevents clients from
+/// connecting to the server. Closing and opening the listening port seems
+/// to fix it.
+/datum/subsystem/thanksbyond
+	name	= "OpenPort"
+	wait	= 30 SECONDS
+	flags	= SS_FIRE_IN_LOBBY
+	var/port
+
+/datum/subsystem/thanksbyond/New()
+	NEW_SS_GLOBAL(SSthanksbyond)
+
+/datum/subsystem/thanksbyond/Initialize()
+	port = world.port
+	return ..()
+
+/datum/subsystem/thanksbyond/stat_entry()
+	..("port: [port] | world.port: [world.port]")
+
+/datum/subsystem/thanksbyond/fire(resumed = FALSE)
+	if(!port)
+		log_debug("[name]: skipping because port is not set")
+		return
+	var/old_port = world.port
+	var/result = world.OpenPort("none")
+	log_debug("[name]: closing port [old_port]: [result]")
+	result = world.OpenPort(port)
+	log_debug("[name]: opening port [port]: [result]")

--- a/code/world.dm
+++ b/code/world.dm
@@ -127,13 +127,6 @@ var/auxtools_path
 
 	SortAreas()							//Build the list of all existing areas and sort it alphabetically
 
-	// Baid-aid fix for people who can't connect
-	spawn()
-		while (TRUE)
-			sleep(300)
-			OpenPort("none")
-			OpenPort(7777)
-			
 	return ..()
 
 /world/Topic(T, addr, master, key)

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -244,6 +244,7 @@
 #include "code\controllers\subsystem\mob.dm"
 #include "code\controllers\subsystem\nanoui.dm"
 #include "code\controllers\subsystem\objects.dm"
+#include "code\controllers\subsystem\openport.dm"
 #include "code\controllers\subsystem\pathfinder.dm"
 #include "code\controllers\subsystem\pathing.dm"
 #include "code\controllers\subsystem\pipenet.dm"


### PR DESCRIPTION
Moved the thing to a subsystem, so that admins can turn it off if something goes wrong. It now uses the port that the server was started on, instead of 7777, so that it doesn't mess with local servers. The port can be changed at runtime. Added debug logs.