### PR TITLE
Soporific Rejuvenant rework

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1094,25 +1094,36 @@
 	if(..())
 		return 1
 
+	//Always happens, regardless if patient is in the sleeper
+	//Slows down massive suffocation
 	if(M.losebreath >= 10)
 		M.losebreath = max(10, M.losebreath - 10)
+	//Immediate eye blurriness/drowsiness indicate that you may have been drugged
 	switch(tick)
-		if(1 to 15)
-			M.eye_blurry = max(M.eye_blurry, 10)
-		if(15 to 25)
-			M.drowsyness  = max(M.drowsyness, 20)
-		if(25 to INFINITY)
-			M.sleeping += 1
+		if(1 to 5)
+			M.eye_blurry = max(M.eye_blurry, 10) //Eyes get blurry immediately
+		if(5 to INFINITY)
+			M.drowsyness  = max(M.drowsyness, 10) //Drowsiness even outside of the sleeper
+				
+	//This handles sleeper/cryo vs out of sleeper/cryo behaviors
+	if (istype(M.loc,/obj/machinery/sleeper) || M.bodytemperature < 170)
+		//If the patient is in a sleeper/cryo and it's been at least 20 seconds...
+		if(tick >= 10)
+			M.sleeping = max(M.sleeping, 15) //Put to sleep, lasts 30 seconds from exiting the sleeper/running out
 			M.adjustOxyLoss(-M.getOxyLoss())
+			M.heal_organ_damage(REM, REM) //Tricord-level healing
+			M.adjustToxLoss(-REM)
 			M.SetKnockdown(0)
 			M.SetStunned(0)
 			M.SetParalysis(0)
 			M.dizziness = 0
-			M.drowsyness = 0
+			M.drowsyness = 0 //Wake-up function/Natural wearing off inside sleeper prevents drowsiness on waking up
 			M.stuttering = 0
 			M.confused = 0
 			M.remove_jitter()
 			M.hallucination = 0
+	else
+		tick = min(tick, 5) //Getting kicked out of the sleeper requires additional time to restart healing when returned
 
 /datum/reagent/inaprovaline
 	name = "Inaprovaline"


### PR DESCRIPTION
# Soporific Rejuvenant
![image](https://user-images.githubusercontent.com/69739118/163755680-4efadf83-567d-4a56-b678-129cfa1d7ad3.png)
*After* ***John Nanotrasen's*** *secret investigation into reports of mysterious happenings from partner chemical plants, he has discovered that the source of* ***Soporific Rejuvenant*** *for* ***Space Station 13*** *was sabotaged by the* ***Syndicate!*** *The liquid fabricators found in most sleepers were revealed to produce just some regular sleep toxin thinned down with water. It was missing the secret ingredient!*

*Turns out, all of the positive feedback from use of this chemical was attributed to the placebo effect.*

*After sending some of his best and brightest to solve the problem, the trade route for* ***~Discount Dan's Discount Cryo Juice~Soporific Rejuvenant*** *has been restored.*

## **Soporific Rejuvenant New Behavior**
Sleepers are now shitty cryo tubes, thanks to properly sourced, proprietary chemicals.

STOXIN2 has been reworked into a chemical that behaves similarly to a weaker sleep toxin/chloral hydrate at first glance, but has rejuvenating effects if the patient is sleeping in a sleeper or placed into a properly chilly cryo. The only source at this time remains the sleepers themselves. 

**Effects that happen outside of the sleeper/cryo tube:**
- Speeds up recovery from *heavy* suffocation sources, mostly useless.
- Causes immediate eye blurriness (sfx on screen).
- After 10 seconds, causes extreme drowsiness (slowdown, 5% per 2 seconds to pass out for 10 seconds, aka standard drowsyness effects).
- This continues until about 20 seconds after the chemical wears off. 10u takes a little over a minute and a half to wear off.
- The previous healing effects of Soporific Rejuvenant no longer occur outside of sleepers/cryo.
- The previous actually-falling-asleep effects also no longer occur outside of sleepers/cryo.

**Effects that happen inside of the sleeper/cryo tube:**
- After 20 seconds, the patient falls into a restful sleep.
- While sleeping restfully, all previous version healing effects occur (dexalin plus effect, removes knockdowns, stuns, dizziness, drowsyness, stuttering, confusion, jitters, hallucinations).
- While sleeping restfully, an additional tricord-level healing happens (See table of common healing amounts below).
- If the patient is normally removed from the sleeper/cryo, healing immediately stops, and they will remain asleep for at least 30 seconds. They will also wake up very drowsy if any of this chemical is inside of them or has been inside of them for the last 20 seconds.
- If the patient is put back into the sleeper/cryo, it takes about 8-10 seconds for the patient to fall back into a properly restful sleep and for healing to resume.
- If the sleeper wake-up function is used (pending #32407), the patient will wake up without any drowsyness or other side effects.

## Thoughts
**Combat?**
This STOXIN2 rework makes it faster than standard sleep toxin/previous soporific behavior (which is 30 seconds to cause extreme drowsiness), but it lacks the potent heavy sleep effect that sleep toxin has after 50 seconds (the target is guaranteed to sleep for at least the remaining time of the chemical plus 40 seconds). This is overall, a buff. Faster effects are usually better, and drowsyness is a really rough status effect due to slowdown.

That said: Ghloral is Ghloral and remains the best option to immediately remove shitters, easily obtainable round start at any chemical dispenser. Orderly stab sticks exist. Cryo dunking is also superior, since you just have to drag a man into a turned-on tube to put them to rest. STOXIN2 requires a drag into a sleeper, a moment for the injection cooldown to expire, and then a button press.

You can also only get this stuff through a sleeper.

For the above reasons, I don't feel that buffing the drowsyness/sleeping speeds affects medbay combat balance all too much.

**Healing?**
This is straight up a buff to medbay sleepers. They can now heal at tricord speeds, after waiting 20 seconds for a person to fall asleep! Wow... It stacks with bicaridine and the other sleeper chemicals. It's a trashy cryo tube with a built in, sleep-chemical-only mancrowave. After the initial 20 seconds (which takes up 2u of the chemical), STOXIN2 heals brute/burn/tox at a rate of 2.5 per 10 seconds, eating up 1u in that time. Amounts below factor in the 2u required to fall asleep in the sleeper:
> 5u button - 7.5 healing over 50 seconds
> 10u button - 20 healing over 1 minute 40 seconds
> 10+5u buttons - 32.5 healing over 2 minutes 30 seconds
> 10u button x2 - 45 healing over 3 minutes 20 seconds

**Lore?**
I was tempted to make this new STOXIN2 have a chemical formula of STOXIN 20, WATER 5, DISCOUNT (Dan's Sauce) 5. Just going to prove that Discount Dan is our man, giving us the Discount Cryo Juice that we all deserve. But for now, it will remain a secret how these chemicals are put together in just the right way in order to give us the healing we deserve. Of course, the real source of this chemical remains a corporate secret due to trade agreements and licensing.

[balance]

:cl:
 * rscadd: Soporific Rejuvenant has been reworked, and can now heal someone in a sleeper (slowly, over time).
