### PR TITLE
Fixed suspension field deleting mobs

### DIFF
--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -370,7 +370,7 @@
 	var/field_type = "chlorine"
 
 /obj/effect/suspension_field/Destroy()
-	for(var/obj/I in src)
+	for(var/atom/movable/I in src)
 		I.forceMove(src.loc)
 	..()
 


### PR DESCRIPTION
Fixes #31274

:cl:
 * bugfix: Suspension field generators no longer delete mobs that are put in inside the fields.