### PR TITLE
Removed logging from the new OpenPort workaround

### DIFF
--- a/code/controllers/subsystem/openport.dm
+++ b/code/controllers/subsystem/openport.dm
@@ -21,10 +21,6 @@ var/datum/subsystem/thanksbyond/SSthanksbyond
 
 /datum/subsystem/thanksbyond/fire(resumed = FALSE)
 	if(!port)
-		log_debug("[name]: skipping because port is not set")
 		return
-	var/old_port = world.port
-	var/result = world.OpenPort("none")
-	log_debug("[name]: closing port [old_port]: [result]")
-	result = world.OpenPort(port)
-	log_debug("[name]: opening port [port]: [result]")
+	world.OpenPort("none")
+	world.OpenPort(port)


### PR DESCRIPTION
A quick look at the logs indicates the proc never failed, and it's quite spammy, firing every 30 seconds. Shoutout to [the BYOND docs](https://www.byond.com/docs/ref/#/world/proc/OpenPort) for being wrong:
>Returns:
    1 on success; 0 on failure 

It actually returns the new port on success, and 0 if `"none"` is passed.