### PR TITLE
Wearable emags

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1279,13 +1279,7 @@ About the new airlock wires panel:
 					spawn(0)	close(1)
 		src.busy = 0
 	else if (istype(I, /obj/item/weapon/card/emag))
-		if (!operating)
-			operating = -1
-			if(density)
-				door_animate("spark")
-				sleep(6)
-				open(1)
-			operating = -1
+		emag_act(src)
 	else
 		..(I, user)
 	add_fingerprint(user)
@@ -1299,7 +1293,7 @@ About the new airlock wires panel:
 			sleep(6)
 			open(1)
 		operating = -1
-	
+
 
 /obj/machinery/door/airlock/bashed_in(var/mob/user, var/throw_circuit = TRUE)
 	playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
@@ -1357,6 +1351,16 @@ About the new airlock wires panel:
 	var/heat = C.is_hot()
 	if(heat > 300)
 		ignite(heat)
+	..()
+
+/obj/machinery/door/airlock/emag_act()
+	if (!src.operating)
+		src.operating = -1
+		if(src.density)
+			src.door_animate("spark")
+			sleep(6)
+			src.open(1)
+		src.operating = -1
 	..()
 
 /obj/machinery/door/airlock/open(var/forced=0)
@@ -1508,6 +1512,5 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/enable_AI_control(var/bypass = FALSE)
 	if(bypass)
 		aiControlDisabled = 2
-	else 
+	else
 		aiControlDisabled = 0
-	

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1516,5 +1516,5 @@ About the new airlock wires panel:
 		aiControlDisabled = 0
 
 /obj/machinery/door/airlock/tackled(mob/living/carbon/human/user)
-	if(user.wear_id && istype(user.wear_id, /obj/item/weapon/card/emag))
+	if(ishuman(user) && istype(user.wear_id, /obj/item/weapon/card/emag))
 		emag_act()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1517,5 +1517,4 @@ About the new airlock wires panel:
 
 /obj/machinery/door/airlock/tackled(mob/living/carbon/human/user)
 	if(user.wear_id && istype(user.wear_id, /obj/item/weapon/card/emag))
-		return 1
-	..()
+		emag_act()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1514,3 +1514,8 @@ About the new airlock wires panel:
 		aiControlDisabled = 2
 	else
 		aiControlDisabled = 0
+
+/obj/machinery/door/airlock/tackled(mob/living/carbon/human/user)
+	if(user.wear_id && istype(user.wear_id, /obj/item/weapon/card/emag))
+		return 1
+	..()

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -58,6 +58,7 @@
 	name = "cryptographic sequencer"
 	icon_state = "emag"
 	item_state = "card-id"
+	slot_flags = SLOT_ID
 	origin_tech = Tc_MAGNETS + "=2;" + Tc_SYNDICATE + "=2"
 
 	/**
@@ -217,7 +218,7 @@ var/list/global/id_cards = list()
 		SetOwnerDNAInfo(loc)
 
 /obj/item/weapon/card/id/Destroy()
-	id_cards -= src 
+	id_cards -= src
 	..()
 
 /obj/item/weapon/card/id/examine(mob/user)

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -163,8 +163,7 @@
 			isTackling = FALSE	//Safety from throw_at being a jerk
 		else
 			tackleGetHurt()
-			if(Obstacle.tackled(src))
-				Obstacle.emag_act()
+			Obstacle.tackled(src)
 
 /mob/living/carbon/proc/tackleGetHurt(var/hurtAmount = 0, var/knockAmount = 0, var/hurtSound = "trayhit")
 	if(!hurtAmount)

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -163,7 +163,7 @@
 			isTackling = FALSE	//Safety from throw_at being a jerk
 		else
 			tackleGetHurt()
-			if(airlockEmagTackled(src,Obstacle))
+			if(Obstacle.tackled(src))
 				Obstacle.emag_act()
 
 /mob/living/carbon/proc/tackleGetHurt(var/hurtAmount = 0, var/knockAmount = 0, var/hurtSound = "trayhit")
@@ -243,11 +243,5 @@
 /mob/living/carbon/proc/bonusTackleRange(var/tR = 3)
 	return tR
 
-/atom/proc/airlockEmagTackled(var/mob/living/carbon/C,var/atom/A)
-	if(!istype(A,/obj/machinery/door/airlock))
-		return 0
-	if(!istype(C,/mob/living/carbon/human))
-		return 0
-	var/mob/living/carbon/human/H = C
-	if(H.wear_id && istype(H.wear_id, /obj/item/weapon/card/emag))
-		return 1
+/atom/proc/tackled(mob/living/user)
+	return 0

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -162,18 +162,9 @@
 		if(!throwing)
 			isTackling = FALSE	//Safety from throw_at being a jerk
 		else
-			if(istype(Obstacle,/obj/machinery/door/airlock) && istype(src,/mob/living/carbon/human)) //Tackling doors while wearing an emag hacks them open
-				var/obj/machinery/door/airlock/A = Obstacle
-				var/mob/living/carbon/human/H = src
-				if(H.wear_id && istype(H.wear_id, /obj/item/weapon/card/emag))
-					if (!A.operating)
-						A.operating = -1
-						if(A.density)
-							A.door_animate("spark")
-							sleep(6)
-							A.open(1)
-						A.operating = -1
 			tackleGetHurt()
+			if(airlockEmagTackled(src,Obstacle))
+				Obstacle.emag_act()
 
 /mob/living/carbon/proc/tackleGetHurt(var/hurtAmount = 0, var/knockAmount = 0, var/hurtSound = "trayhit")
 	if(!hurtAmount)
@@ -251,3 +242,12 @@
 
 /mob/living/carbon/proc/bonusTackleRange(var/tR = 3)
 	return tR
+
+/atom/proc/airlockEmagTackled(var/mob/living/carbon/C,var/atom/A)
+	if(!istype(A,/obj/machinery/door/airlock))
+		return 0
+	if(!istype(C,/mob/living/carbon/human))
+		return 0
+	var/mob/living/carbon/human/H = C
+	if(H.wear_id && istype(H.wear_id, /obj/item/weapon/card/emag))
+		return 1

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -162,6 +162,17 @@
 		if(!throwing)
 			isTackling = FALSE	//Safety from throw_at being a jerk
 		else
+			if(istype(Obstacle,/obj/machinery/door/airlock) && istype(src,/mob/living/carbon/human)) //Tackling doors while wearing an emag hacks them open
+				var/obj/machinery/door/airlock/A = Obstacle
+				var/mob/living/carbon/human/H = src
+				if(H.wear_id && istype(H.wear_id, /obj/item/weapon/card/emag))
+					if (!A.operating)
+						A.operating = -1
+						if(A.density)
+							A.door_animate("spark")
+							sleep(6)
+							A.open(1)
+						A.operating = -1
 			tackleGetHurt()
 
 /mob/living/carbon/proc/tackleGetHurt(var/hurtAmount = 0, var/knockAmount = 0, var/hurtSound = "trayhit")


### PR DESCRIPTION
As emags are modified IDs, it didn't make sense that you were unable to wear them - this PR changes that. Additionally, tackling any airlock while wearing a cryptographic sequencer will emag it. Features for only the most bold and confident traitors.

![features](https://user-images.githubusercontent.com/66280799/164512551-41196172-cc45-43c2-9531-6d80954ac31b.PNG)

[tested]

:cl:
 * rscadd: brave traitors can now wear cryptographic sequencers in their ID slot
 * rscadd: tackling a door while wearing an emag will emag it
