### PR TITLE
Allows Comms Console to make multi-line announcements

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -110,6 +110,11 @@
 /proc/stripped_input(var/mob/user, var/message = "", var/title = "", var/default = "", var/max_length=MAX_MESSAGE_LEN)
 	var/name = input(user, message, title, default) as null|text
 	return strip_html_simple(name, max_length)
+	
+//As above, but for full-size paragraph textboxes
+/proc/stripped_message(var/mob/user, var/message = "", var/title = "", var/default = "", var/max_length=MAX_MESSAGE_LEN)
+	var/name = input(user, message, title, default) as null|message
+	return strip_html_simple(name, max_length)
 
 //Filters out undesirable characters from names
 /proc/reject_bad_name(var/t_in, var/allow_numbers=0, var/max_length=MAX_NAME_LEN)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -174,13 +174,13 @@ var/list/shuttle_log = list()
 			if(authenticated==AUTH_CAPT && !(issilicon(usr) && !is_malf_owner(usr)))
 				if(message_cooldown)
 					return
-				var/input = stripped_input(usr, "Please choose a message to announce to the station crew.", "What?")
+				var/input = stripped_message(usr, "Please choose a message to announce to the station crew.", "Priority Announcement")
 				if(message_cooldown || !input || (!usr.Adjacent(src) && !issilicon(usr)))
 					return
 				captain_announce(input)//This should really tell who is, IE HoP, CE, HoS, RD, Captain
 				var/turf/T = get_turf(usr)
-				log_say("[key_name(usr)] (@[T.x],[T.y],[T.z]) has made a captain announcement: [input]")
-				message_admins("[key_name_admin(usr)] has made a captain announcement.", 1)
+				log_say("[key_name(usr)] (@[T.x],[T.y],[T.z]) has made a Comms Console announcement: [input]")
+				message_admins("[key_name_admin(usr)] has made a Comms Console announcement.", 1)
 				message_cooldown = 1
 				spawn(600)//One minute cooldown
 					message_cooldown = 0


### PR DESCRIPTION
NanoTrasen has finally saw fit to install a carriage return key on the Comms Console, command staff and clowns rejoice as they can now post Woody's Got Wood like never before.

Also achieves the above by adding an alternative to the stripped_input proc named stripped_message which is the same proc but with a paragraph sized message box instead.

Also gives priority announcement an actual title for its text box and changes logs to reflect that it's not necessarily a captain announcement all the time.

![annou1](https://user-images.githubusercontent.com/19687076/164952261-cfb5a406-d7cc-4678-bfe8-797f8d958a55.PNG)
![annou2](https://user-images.githubusercontent.com/19687076/164952262-80edd321-0db6-4c3b-b372-42d29ceed1a2.PNG)
![annou3](https://user-images.githubusercontent.com/19687076/164952263-aa2a90b9-8c91-402b-b8f7-d9687a379db1.PNG)
:cl:
 * rscadd: Allows Comms Consoles to make multi-line announcements
 * rscadd: Adds a stripped_message proc for sanitized paragraph input boxes