### PR TITLE
Allows jetpacks to be used from the suit storage slot

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -105,6 +105,14 @@
 //		if(!check_drift && J.allow_thrust(0.01, src))
 //			return 1
 
+	//Also allows jetpacks to work from suit storage slots
+	else if(istype(s_store, /obj/item/weapon/tank/jetpack))
+		var/obj/item/weapon/tank/jetpack/J = s_store
+		if(((!check_drift) || (check_drift && J.stabilization_on)) && (!lying) && (J.allow_thrust(0.01, src)))
+			inertia_dir = 0
+			return 1
+
+
 	//If no working jetpack then use the other checks
 	return ..()
 


### PR DESCRIPTION
Suits that are advanced enough to hold a jetpack in their suit storage can now actually use said jetpacks from suit storage - engineers and nukies rejoice!

![jetp](https://user-images.githubusercontent.com/19687076/164969668-ad04df38-226b-4785-ac7b-2fce3160b7ef.PNG)
:cl:
 * rscadd: Jetpacks can now be used from the suit storage slot


