### PR TITLE
Fixes Swiss Tool tech values

### DIFF
--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -309,6 +309,7 @@
 	icon_state = "s_a_k"
 	item_state = "s_a_k"
 	desc = "Crafted by the Space Swiss for everyday use in military campaigns. Nonpareil."
+	origin_tech = Tc_MATERIALS + "=5;" + Tc_BLUESPACE + "=3"
 
 	stored_modules = list("/obj/item/tool/screwdriver:screwdriver" = null,
 						"/obj/item/tool/wrench:wrench" = null,

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -16,7 +16,7 @@
 	starting_materials = list(MAT_IRON = 15000)
 	w_type = RECYK_METAL
 	melt_temperature = MELTPOINT_STEEL
-	origin_tech = Tc_MATERIALS + "=9;" + Tc_BLUESPACE + "=5"
+	origin_tech = Tc_MATERIALS + "=5;" + Tc_BLUESPACE + "=3"
 	var/hmodule = null
 
 	//the colon separates the typepath from the name


### PR DESCRIPTION
Forgive me for what I must do.

Sets the tech value of Swiss Tools to what it takes to make them (Materials 5, Bluespace 3) rather than the incredibly high values of the base switchtool.

Closes #32422 

[sanity] [balance] [bugfix]
:cl:
 * rscadd: Sets Swiss Tool tech values to a more reasonable value
