### PR TITLE
Mice can no longer nibble silicon's non-existent toes

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -264,11 +264,9 @@
 
 /mob/living/simple_animal/mouse/unarmed_attack_mob(var/mob/living/target)
 	..()
-	if(isUnconscious())
+	if(isUnconscious() || !can_be_infected() || issilicon(target))
 		return
-
-	if(!can_be_infected())
-		return
+	
 	var/block = 0
 	var/bleeding = 0
 


### PR DESCRIPTION
Mice can no longer nibble silicon's non-existent toes. Also condensed some needless extra if statements. The unconscious and infectivity check don't actually seem to check anything because they don't pass a target through, but I left them as they were in case it's a weird byond thing. I don't see why a mouse would be disqualified from nibbling someone for either of these check types anyway.

Closes #32137 

[bugfix] [sanity]
:cl:
 * rscdel: Mice can no longer nibble silicon toes
