### PR TITLE
Renames c20r ammo to be distinct from standard 12mm ammo

### DIFF
--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -100,12 +100,13 @@
 	icon_state = "p22-casing"
 
 /obj/item/ammo_casing/a12mm
-	desc = "A 12mm bullet casing."
+	desc = "A 12mm SPECIAL bullet casing."
 	caliber = MM12
 	projectile_type = /obj/item/projectile/bullet/midbullet
 	w_type = RECYK_METAL
 
 /obj/item/ammo_casing/a12mm/assault
+	desc = "A standard 12mm bullet casing."
 	projectile_type = /obj/item/projectile/bullet/midbullet/assault
 
 /obj/item/ammo_casing/a12mm/bounce

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -99,7 +99,7 @@
 	sprite_modulo = 2
 
 /obj/item/ammo_storage/magazine/a12mm/ops
-	name = "C-20r magazine (12mm)"
+	name = "C-20r magazine (12mm SPECIAL)"
 	desc = "A magazine designed for the C-20r. Has 'SA' engraved on the side. Holds 20 rounds."
 	icon_state = "12mm"
 	origin_tech = Tc_COMBAT + "=2"

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -133,7 +133,7 @@
 
 /obj/item/weapon/gun/projectile/automatic/c20r
 	name = "\improper C-20r SMG"
-	desc = "A lightweight, fast firing gun for when you REALLY want someone dead. Uses 12mm rounds. Has a \"Scarborough Arms - Per falcis, per pravitas\" buttstamp."
+	desc = "A lightweight, fast firing gun for when you REALLY want someone dead. Uses 12mm SPECIAL rounds. Has a \"Scarborough Arms - Per falcis, per pravitas\" buttstamp."
 	icon_state = "c20r"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guns.dmi', "right_hand" = 'icons/mob/in-hand/right/guns.dmi')
 	item_state = "c20r"

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -667,8 +667,8 @@
 //Hidden
 
 /datum/design/magazine_12mm/ops
-	name = "C-20r magazine (12mm)"
-	desc = "A magazine for the Syndicate C-20r assault rifle. Holds 12mm ammunition."
+	name = "C-20r magazine (12mm SPECIAL)"
+	desc = "A magazine for the Syndicate C-20r assault rifle. Holds 12mm SPECIAL ammunition."
 	id = "magazine_12mm"
 	build_type = AMMOLATHE
 	materials = list(MAT_IRON = 400)


### PR DESCRIPTION
Clears up past confusion with the difference between Assault Rifle ammo and c20r ammo.

Closes #31636 

[grammar] [consistency]
:cl:
 * rscadd: Renames c20r ammo to 12mm SPECIAL to make it distinct from standard 12mm ammo
