### PR TITLE
R-UST console circuitry crate

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1655,15 +1655,6 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 200	//10x the fuel, 10x the cost + 50 for convenience
 	containername = "Large antimatter containment jar crate"
 
-/datum/supply_packs/rust_gyrotron
-	contains = list(/obj/machinery/rust/gyrotron)
-	name = "R-UST Mk. 7 gyrotron"
-	cost = 25
-	containertype = /obj/structure/closet/crate/secure/large
-	containername = "\improper R-UST Mk. 7 gyrotron crate"
-	group = "Engineering"
-	access = list(access_engine)
-
 /datum/supply_packs/rust
 	contains = list(/obj/item/weapon/module/rust_fuel_compressor,
 					/obj/item/weapon/module/rust_fuel_port,
@@ -1674,6 +1665,28 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure/engisec
 	containername = "\improper R-UST Mk. 7 fuel compressor circuitry crate"
+	group = "Engineering"
+	access = list(access_engine)
+
+/datum/supply_packs/rust_consoles
+	contains = list(/obj/item/weapon/circuitboard/rust_gyrotron_control,
+					/obj/item/weapon/circuitboard/rust_fuel_control,
+					/obj/item/weapon/circuitboard/rust_core_monitor,
+					/obj/item/weapon/circuitboard/rust_core_control
+					)
+	name = "R-UST Mk. 7 console circuitry kit"
+	cost = 30
+	containertype = /obj/structure/closet/crate/secure/engisec
+	containername = "\improper R-UST Mk. 7 console circuitry crate"
+	group = "Engineering"
+	access = list(access_engine)
+
+/datum/supply_packs/rust_gyrotron
+	contains = list(/obj/machinery/rust/gyrotron)
+	name = "R-UST Mk. 7 gyrotron"
+	cost = 25
+	containertype = /obj/structure/closet/crate/secure/large
+	containername = "\improper R-UST Mk. 7 gyrotron crate"
 	group = "Engineering"
 	access = list(access_engine)
 


### PR DESCRIPTION
One of the main chokepoints on making a R-UST is having to wait for RnD to get the necessary research for the consoles or doing it yourself if nobody's available, which steals valuable time you could've used to make the R-UST and not use it because the round ends in 40 minutes and you're only halfway done.
The crate costs 30 credits and has a copy all 4 R-UST console circuits. It requires engineering access like all other R-UST crates.
Also moved the gyrotron crate to be under the R-UST one since I've accidentally bought 3 cores and 1 gyro way more times than I'd like to admit.
:cl:
 * rscadd: R-UST console circuitry supply crate for 30 credits. It has a Core Monitor, Core Controller, Gyrotron Controller and Fuel Injector Controller circuit.
 * tweak: Moves the gyrotron crate to be under the R-UST core crate.