### PR TITLE
Adds overalls to janitor's closet

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -47,6 +47,7 @@
 		/obj/item/weapon/caution = 6,
 		/obj/item/weapon/storage/bag/trash,
 		/obj/item/device/lightreplacer/loaded/mixed,
+		/obj/item/clothing/suit/apron/overalls,
 		/obj/item/clothing/gloves/black,
 		/obj/item/clothing/head/soft/purple,
 		/obj/item/weapon/storage/box/lights/he = 2,


### PR DESCRIPTION
Because duelling PRs are great and not annoying at all. An alternative option to #32453 that takes advantage of the fact that aprons and overalls can already store janitor items including the trash bag. Janitor closets will now spawn with a set of overalls. Strictly speaking aprons can work too, but I didn't want to make it pick one or the other like botany lockers.

:cl:
 * rscadd: Added overalls to janitor's closets.
