### PR TITLE
Actually fixes multi-z infinite loops

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -77,10 +77,6 @@
 	var/cargo_forwarding_on_roundstart = 0
 	var/cargo_forwarding_amount_override = 0
 
-
-	var/multiz_render_cap = 8			//how far down open spaces will render
-	var/multiz_bottom_cap = 16			//how far down open spaces will detect for a bottom
-
 	// BSQL things
 	var/bsql_debug = 0
 	var/async_query_timeout = 10
@@ -585,11 +581,6 @@
 				if("bsql_thread_limit")
 					bsql_thread_limit = text2num(value)
 
-
-				if("multiz_render_cap")
-					multiz_render_cap = text2num(value)
-				if("multiz_bottom_cap")
-					multiz_bottom_cap = text2num(value)
 
 				if("media_base_url")
 					media_base_url = value

--- a/code/modules/multiz/falling.dm
+++ b/code/modules/multiz/falling.dm
@@ -26,72 +26,27 @@
 	if(!isturf(loc))
 		return
 
-	var/turf/below = GetBelow(src)
-	if(!below)
-		return
-
-	var/turf/bottom = null
-	var/depth = 0
-	for(bottom = GetBelow(src); isopenspace(bottom); bottom = GetBelow(bottom))
-		depth++
-		if(depth > config.multiz_bottom_cap) // To stop getting caught on this in infinite loops
-			break
-
-	if(istype(bottom,/turf/space))
-		return
-
-	var/turf/T = loc
-	if(!T.CanZPass(src, DOWN) || !below.CanZPass(src, DOWN))
-		return
-
-	var/obj/structure/stairs/down_stairs = locate(/obj/structure/stairs) in below
-	// Detect stairs below and traverse down them.
-	if(down_stairs && down_stairs.dir == GetOppositeDir(dir))
-		Move(below)
-		if(isliving(src))
-			var/mob/living/L = src
-			if(L.pulling)
-				L.pulling.Move(below)
+	if(!check_below())
 		return
 
 	var/gravity = get_gravity()
 	// No gravity in space, apparently.
 	if(!gravity) //Polaris uses a proc, has_gravity(), for this
-		return
+		return 0
+
 	fall_lock = TRUE
 	spawn(4 / gravity) // Now we use a delay of 4 ticks divided by the gravity.
 		fall_lock = FALSE
 
+		var/turf/below = check_below()
 		// We're in a new loc most likely, so check all this again
-		below = GetBelow(src)
 		if(!below)
 			return
 
-		bottom = null
-		depth = 0
-		for(bottom = GetBelow(src); isopenspace(bottom); bottom = GetBelow(bottom))
-			depth++
-			if(depth > config.multiz_bottom_cap) // To stop getting caught on this in infinite loops
-				break
-
-		if(istype(bottom,/turf/space))
-			return
-		T = loc
-		if(!T.CanZPass(src, DOWN) || !below.CanZPass(src, DOWN))
-			return
-
-		down_stairs = locate(/obj/structure/stairs) in below
-		if(down_stairs && down_stairs.dir == GetOppositeDir(dir))
-			Move(below)
-			if(isliving(src))
-				var/mob/living/L = src
-				if(L.pulling)
-					L.pulling.Move(below)
-			return
-
 		gravity = get_gravity()
-		if(!gravity)
-			return
+		// No gravity in space, apparently.
+		if(!gravity) //Polaris uses a proc, has_gravity(), for this
+			return 0
 
 		/*if(throwing)  This was causing odd behavior where things wouldn't stop.
 			return*/
@@ -107,6 +62,42 @@
 				handle_fall(below)
 				if(is_client_moving) M.client.moving = 0
 			// TODO - handle fall on damage!
+
+/atom/movable/proc/check_below()
+	var/turf/below = GetBelow(src)
+	if(!below)
+		return 0
+
+	var/turf/bottom = null
+	var/list/turf/checked_belows = list()
+	for(bottom = GetBelow(src); isopenspace(bottom); bottom = GetBelow(bottom))
+		if(bottom in checked_belows) // To stop getting caught on this in infinite loops
+			break
+		checked_belows.Add(bottom)
+
+	if(istype(bottom,/turf/space))
+		return 0
+
+	var/turf/T = loc
+	if(!T.CanZPass(src, DOWN) || !below.CanZPass(src, DOWN))
+		return 0
+
+	var/obj/structure/stairs/down_stairs = locate(/obj/structure/stairs) in below
+	// Detect stairs below and traverse down them.
+	if(down_stairs && down_stairs.dir == GetOppositeDir(dir))
+		Move(below)
+		if(isliving(src))
+			var/mob/living/L = src
+			if(L.pulling)
+				L.pulling.Move(below)
+		return 0
+
+	var/gravity = get_gravity()
+	// No gravity in space, apparently.
+	if(!gravity) //Polaris uses a proc, has_gravity(), for this
+		return 0
+
+	return below
 
 //For children to override
 /atom/movable/proc/can_fall()

--- a/code/modules/multiz/falling.dm
+++ b/code/modules/multiz/falling.dm
@@ -43,9 +43,7 @@
 		if(!below)
 			return
 
-		gravity = get_gravity()
-		// No gravity in space, apparently.
-		if(!gravity) //Polaris uses a proc, has_gravity(), for this
+		if(!get_gravity())
 			return 0
 
 		/*if(throwing)  This was causing odd behavior where things wouldn't stop.

--- a/code/modules/multiz/falling.dm
+++ b/code/modules/multiz/falling.dm
@@ -67,11 +67,11 @@
 		return 0
 
 	var/turf/bottom = null
-	var/list/turf/checked_belows = list()
+	var/list/checked_belows = list()
 	for(bottom = GetBelow(src); isopenspace(bottom); bottom = GetBelow(bottom))
-		if(bottom in checked_belows) // To stop getting caught on this in infinite loops
+		if(bottom.z in checked_belows) // To stop getting caught on this in infinite loops
 			break
-		checked_belows.Add(bottom)
+		checked_belows.Add(bottom.z)
 
 	if(istype(bottom,/turf/space))
 		return 0

--- a/code/modules/multiz/falling.dm
+++ b/code/modules/multiz/falling.dm
@@ -92,11 +92,6 @@
 				L.pulling.Move(below)
 		return 0
 
-	var/gravity = get_gravity()
-	// No gravity in space, apparently.
-	if(!gravity) //Polaris uses a proc, has_gravity(), for this
-		return 0
-
 	return below
 
 //For children to override

--- a/code/modules/multiz/falling.dm
+++ b/code/modules/multiz/falling.dm
@@ -32,7 +32,7 @@
 	var/gravity = get_gravity()
 	// No gravity in space, apparently.
 	if(!gravity) //Polaris uses a proc, has_gravity(), for this
-		return 0
+		return
 
 	fall_lock = TRUE
 	spawn(4 / gravity) // Now we use a delay of 4 ticks divided by the gravity.
@@ -44,7 +44,7 @@
 			return
 
 		if(!get_gravity())
-			return 0
+			return
 
 		/*if(throwing)  This was causing odd behavior where things wouldn't stop.
 			return*/

--- a/code/modules/multiz/turfs.dm
+++ b/code/modules/multiz/turfs.dm
@@ -100,13 +100,13 @@ var/static/list/no_spacemove_turfs = list(/turf/simulated/wall,/turf/unsimulated
 	overlays.Cut()
 	vis_contents.Cut()
 	var/turf/bottom
-	var/list/turf/checked_belows = list()
+	var/list/checked_belows = list()
 	for(bottom = GetBelow(src); isopenspace(bottom); bottom = GetBelow(bottom))
 		alpha_to_subtract /= 2
-		if(bottom in checked_belows) // To stop getting caught on this in infinite loops
+		if(bottom.z in checked_belows) // To stop getting caught on this in infinite loops
 			alpha_to_subtract = 0
 			break
-		checked_belows.Add(bottom)
+		checked_belows.Add(bottom.z)
 
 	if(!bottom || bottom == src)
 		return
@@ -206,13 +206,13 @@ var/static/list/no_spacemove_turfs = list(/turf/simulated/wall,/turf/unsimulated
 		vis_contents.Cut()
 		overlays.Cut()
 		var/turf/bottom
-		var/list/turf/checked_belows = list()
+		var/list/checked_belows = list()
 		for(bottom = GetBelow(src); isopenspace(bottom); bottom = GetBelow(bottom))
 			alpha_to_subtract /= 2
-			if(bottom in checked_belows) // To stop getting caught on this in infinite loops
+			if(bottom.z in checked_belows) // To stop getting caught on this in infinite loops
 				alpha_to_subtract = 0
 				break
-			checked_belows.Add(bottom)
+			checked_belows.Add(bottom.z)
 
 		if(!bottom || bottom == src)
 			return

--- a/code/modules/multiz/turfs.dm
+++ b/code/modules/multiz/turfs.dm
@@ -99,6 +99,9 @@ var/static/list/no_spacemove_turfs = list(/turf/simulated/wall,/turf/unsimulated
 	plane = OPEN_OVERLAY_PLANE
 
 /turf/simulated/open/update_icon()
+	make_openspace_view()
+
+/turf/simulated/proc/make_openspace_view()
 	var/alpha_to_subtract = 127
 	overlays.Cut()
 	vis_contents.Cut()
@@ -118,6 +121,8 @@ var/static/list/no_spacemove_turfs = list(/turf/simulated/wall,/turf/unsimulated
 	vis_contents += bottom
 	if(!istype(bottom,/turf/space)) // Space below us
 		vis_contents.Add(overimage)
+		return 1
+	return 0
 
 /turf/simulated/open/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_lighting_update = 0, var/allow = 1)
 	overlays.Cut()
@@ -204,25 +209,7 @@ var/static/list/no_spacemove_turfs = list(/turf/simulated/wall,/turf/unsimulated
 /turf/simulated/floor/glass/update_icon()
 	..()
 	if(get_base_turf(src.z) == /turf/simulated/open)
-		var/alpha_to_subtract = 127
-		vis_contents.Cut()
-		overlays.Cut()
-		var/turf/bottom
-		var/list/checked_belows = list()
-		for(bottom = GetBelow(src); isopenspace(bottom); bottom = GetBelow(bottom))
-			alpha_to_subtract /= 2
-			if(bottom.z in checked_belows) // To stop getting caught on this in infinite loops
-				return // Again, pointless to render anything
-			checked_belows.Add(bottom.z)
-
-		if(!bottom || bottom == src)
-			return
-		var/obj/effect/open_overlay/overimage = new /obj/effect/open_overlay
-		overimage.alpha = 255 - alpha_to_subtract
-		overimage.color = rgb(0,0,0,overimage.alpha)
-		vis_contents += bottom
-		if(!istype(bottom,/turf/space)) // Space below us
-			vis_contents.Add(overimage)
+		if(make_openspace_view()) // Space below us
 			icon_state = "" // Remove any previous space stuff, if any
 		else
 			// We space background now, forget the vis contentsing of it

--- a/code/modules/multiz/turfs.dm
+++ b/code/modules/multiz/turfs.dm
@@ -27,7 +27,6 @@
 	plane = OPENSPACE_PLANE_START
 	//pathweight = 100000 //For lack of pathweights, mobdropping meta inc
 	dynamic_lighting = 0 // Someday lets do proper lighting z-transfer.  Until then we are leaving this off so it looks nicer.
-
 	var/turf/below
 
 /turf/simulated/open/post_change()
@@ -83,7 +82,11 @@ var/static/list/no_spacemove_turfs = list(/turf/simulated/wall,/turf/unsimulated
 /turf/simulated/open/examine(mob/user, distance, infix, suffix)
 	if(..(user, 2))
 		var/depth = 1
-		for(var/T = GetBelow(src); isopenspace(T); T = GetBelow(T))
+		var/list/checked_belows = list()
+		for(var/turf/T = GetBelow(src); isopenspace(T); T = GetBelow(T))
+			if(T.z in checked_belows) // To stop getting caught on this in infinite loops
+				to_chat(user, "It looks bottomless.")
+				return
 			depth += 1
 		to_chat(user, "It is about [depth] levels deep.")
 
@@ -104,8 +107,7 @@ var/static/list/no_spacemove_turfs = list(/turf/simulated/wall,/turf/unsimulated
 	for(bottom = GetBelow(src); isopenspace(bottom); bottom = GetBelow(bottom))
 		alpha_to_subtract /= 2
 		if(bottom.z in checked_belows) // To stop getting caught on this in infinite loops
-			alpha_to_subtract = 0
-			break
+			return // Don't even render anything
 		checked_belows.Add(bottom.z)
 
 	if(!bottom || bottom == src)
@@ -210,8 +212,7 @@ var/static/list/no_spacemove_turfs = list(/turf/simulated/wall,/turf/unsimulated
 		for(bottom = GetBelow(src); isopenspace(bottom); bottom = GetBelow(bottom))
 			alpha_to_subtract /= 2
 			if(bottom.z in checked_belows) // To stop getting caught on this in infinite loops
-				alpha_to_subtract = 0
-				break
+				return // Again, pointless to render anything
 			checked_belows.Add(bottom.z)
 
 		if(!bottom || bottom == src)

--- a/code/modules/multiz/turfs.dm
+++ b/code/modules/multiz/turfs.dm
@@ -100,12 +100,13 @@ var/static/list/no_spacemove_turfs = list(/turf/simulated/wall,/turf/unsimulated
 	overlays.Cut()
 	vis_contents.Cut()
 	var/turf/bottom
-	var/depth = 0
+	var/list/turf/checked_belows = list()
 	for(bottom = GetBelow(src); isopenspace(bottom); bottom = GetBelow(bottom))
 		alpha_to_subtract /= 2
-		depth++
-		if(depth > config.multiz_render_cap) // To stop getting caught on this in infinite loops
+		if(bottom in checked_belows) // To stop getting caught on this in infinite loops
+			alpha_to_subtract = 0
 			break
+		checked_belows.Add(bottom)
 
 	if(!bottom || bottom == src)
 		return
@@ -205,12 +206,13 @@ var/static/list/no_spacemove_turfs = list(/turf/simulated/wall,/turf/unsimulated
 		vis_contents.Cut()
 		overlays.Cut()
 		var/turf/bottom
-		var/depth = 0
+		var/list/turf/checked_belows = list()
 		for(bottom = GetBelow(src); isopenspace(bottom); bottom = GetBelow(bottom))
 			alpha_to_subtract /= 2
-			depth++
-			if(depth > config.multiz_render_cap) // To stop getting caught on this in infinite loops
+			if(bottom in checked_belows) // To stop getting caught on this in infinite loops
+				alpha_to_subtract = 0
 				break
+			checked_belows.Add(bottom)
 
 		if(!bottom || bottom == src)
 			return

--- a/config-example/config.txt
+++ b/config-example/config.txt
@@ -372,9 +372,3 @@ BSQL_THREAD_LIMIT 50
 
 ## Uncomment to enable verbose BSQL communication logs
 #BSQL_DEBUG
-
-## The maximum number of z-levels rendered above or below in multi-z
-MULTIZ_RENDER_CAP 8
-
-## The maximum number of z-levels checked below in multi-z
-MULTIZ_BOTTOM_CAP 16

--- a/maps/test_euclidean.dm
+++ b/maps/test_euclidean.dm
@@ -13,6 +13,7 @@
 	name = "ground floor"
 	movementJammed = 1
 	z_above = 3
+	z_below = 5
 
 /datum/zLevel/second
 	name = "second floor"
@@ -23,6 +24,7 @@
 /datum/zLevel/third
 	name = "third floor"
 	movementJammed = 1
+	z_above = 2
 	z_below = 4
 
 /datum/map/active

--- a/maps/test_euclidean.dmm
+++ b/maps/test_euclidean.dmm
@@ -90,6 +90,13 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor,
 /area/gateway)
+"fA" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/stairs/west,
+/turf/simulated/floor,
+/area/crew_quarters/bar)
 "fL" = (
 /turf/portal{
 	teleport_x = -1;
@@ -9039,10 +9046,10 @@ aa
 aa
 aa
 ag
-bi
-bi
-bi
-bi
+uv
+uv
+uv
+uv
 ag
 aa
 aa
@@ -9105,10 +9112,10 @@ aa
 aa
 aa
 ag
-bi
-bi
-bi
-bi
+uv
+uv
+uv
+uv
 ag
 aa
 aa
@@ -9171,10 +9178,10 @@ aa
 aa
 aa
 ag
-bi
-bi
-bi
-bi
+uv
+uv
+uv
+uv
 ag
 aa
 aa
@@ -21717,7 +21724,7 @@ ag
 uv
 uv
 uv
-HZ
+fA
 ag
 aa
 aa


### PR DESCRIPTION
[bugfix][tested]
Cleans up some code too, and makes examining them more aware of the fact. Removes the multi-z bottom and render caps since the new method handles it in a much cleaner way and they had no real effect on performance.
Makes the euclidean test map use this infinite loop again for demonstration.

:cl:
 * rscadd: Infinitely deep open spaces can now be examined as such.
