### PR TITLE
Species exclusive and discounted uplink item support

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -8,6 +8,7 @@
 	var/telecrystals = 20
 	var/selected_category
 	var/job
+	var/species
 	var/nuke_ops_inventory = FALSE
 
 /datum/component/uplink/initialize()
@@ -60,13 +61,13 @@
 			"items" = list()
 		)
 		for(var/datum/uplink_item/I in uplink_items[category])
-			if(!I.available_for_job(job) || (!I.available_for_nuke_ops && nuke_ops_inventory))
+			if(!I.available_for_job(job) || !I.available_for_job(species) || (!I.available_for_nuke_ops && nuke_ops_inventory))
 				continue
 			cat["items"] += list(list(
 				"name" = I.name,
-				"cost" = I.get_cost(job),
+				"cost" = I.get_cost(job, species),
 				"desc" = I.desc,
-				"discounted" = I.gives_discount(job) || length(I.jobs_exclusive),
+				"discounted" = I.gives_discount(job) || I.gives_discount(species) || length(I.jobs_exclusive),
 				"refundable" = I.refundable,
 			))
 		if(!length(cat["items"]))

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -61,7 +61,7 @@
 			"items" = list()
 		)
 		for(var/datum/uplink_item/I in uplink_items[category])
-			if(!I.available_for_job(job) || !I.available_for_job(species) || (!I.available_for_nuke_ops && nuke_ops_inventory))
+			if((!I.available_for_job(job) && !I.available_for_job(species)) || (!I.available_for_nuke_ops && nuke_ops_inventory))
 				continue
 			cat["items"] += list(list(
 				"name" = I.name,

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -161,6 +161,7 @@
 	if (new_uplink)
 		uplink = new_uplink
 		new_uplink.job = traitor_mob.mind.assigned_role
+		new_uplink.species = traitor_mob.dna.species
 	else
 		to_chat(traitor_mob, "Unfortunately, the Syndicate wasn't able to get you an uplink.")
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1128,7 +1128,7 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/gun/dartgun/vox/raider
 	cost = 20
 	discounted_cost = 16
-	jobs_exclusive = list("Trader","Vox")
+	jobs_exclusive = list("Trader","Vox","Skeletal Vox")
 	jobs_with_discount = list("Trader")
 
 /datum/uplink_item/jobspecific/trader/dart_cartridge
@@ -1137,7 +1137,7 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/dart_cartridge
 	cost = 6
 	discounted_cost = 2
-	jobs_exclusive = list("Trader","Vox")
+	jobs_exclusive = list("Trader","Vox","Skeletal Vox")
 	jobs_with_discount = list("Trader")
 
 /datum/uplink_item/jobspecific/trader/cratesender
@@ -1146,7 +1146,7 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/storage/box/syndie_kit/cratesender
 	cost = 10
 	discounted_cost = 6
-	jobs_exclusive = list("Trader","Vox")
+	jobs_exclusive = list("Trader","Vox","Skeletal Vox")
 	jobs_with_discount = list("Trader","Cargo Technician","Quartermaster")
 
 // SYNDICATE COOP

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1149,6 +1149,14 @@ var/list/uplink_items = list()
 	jobs_exclusive = list("Trader","Vox","Skeletal Vox")
 	jobs_with_discount = list("Trader","Cargo Technician","Quartermaster")
 
+/datum/uplink_item/jobspecific/cannedmatter
+	category = "Skrell Specials"
+	name = "Canned Compressed Matter"
+	desc = "For once, the syndicate has it."
+	item = /obj/item/weapon/reagent_containers/food/drinks/soda_cans/canned_matter
+	cost = 6
+	jobs_exclusive = list("Skrell")
+
 // SYNDICATE COOP
 // Any high cost items that are intended to only be purchasable when three syndies come together to change the narrative.
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -51,8 +51,8 @@ var/list/uplink_items = list()
 	var/refund_path = null // Alternative path for refunds, in case the item purchased isn't what is actually refunded (Bombs and such).
 	var/refund_amount // specified refund amount in case there needs to be a TC penalty for refunds.
 
-/datum/uplink_item/proc/get_cost(var/user_job, var/cost_modifier = 1)
-	if(gives_discount(user_job))
+/datum/uplink_item/proc/get_cost(var/user_job, var/user_species, var/cost_modifier = 1)
+	if(gives_discount(user_job) || gives_discount(user_species))
 		. = discounted_cost
 	else
 		. = cost
@@ -73,13 +73,13 @@ var/list/uplink_items = list()
 	return new new_item(location)
 
 /datum/uplink_item/proc/spawn_item(var/turf/loc, datum/component/uplink/U, mob/user)
-	if(!available_for_job(U.job))
-		message_admins("[key_name(user)] tried to purchase \the [src.name] from their uplink despite not being available to their job! (Job: [U.job]) ([formatJumpTo(get_turf(U))])")
+	if(!available_for_job(U.job) || !available_for_job(U.species))
+		message_admins("[key_name(user)] tried to purchase \the [src.name] from their uplink despite not being available to them! (Job: [U.job]) (Species: [U.species]) ([formatJumpTo(get_turf(U))])")
 		return
 	if(U.nuke_ops_inventory && !available_for_nuke_ops)
 		message_admins("[key_name(user)] tried to purchase \the [src.name] from their uplink despite being a nuclear operative")
 		return
-	U.telecrystals -= max(get_cost(U.job), 0)
+	U.telecrystals -= max(get_cost(U.job, U.species), 0)
 	feedback_add_details("traitor_uplink_items_bought", name)
 	return new_uplink_item(item, loc, user)
 
@@ -101,7 +101,7 @@ var/list/uplink_items = list()
 	var/obj/item/holder = U.parent
 	if ((holder in user.contents || (in_range(holder, user) && istype(holder.loc, /turf))))
 		user.set_machine(U)
-		if(get_cost(U.job) > U.telecrystals)
+		if(get_cost(U.job, U.species) > U.telecrystals)
 			return 0
 
 		var/O = spawn_item(get_turf(user), U, user)
@@ -132,24 +132,24 @@ var/list/uplink_items = list()
 			if(istype(I, /obj/item))
 				A.put_in_any_hand_if_possible(I)
 
-			U.purchase_log += {"[user] ([user.ckey]) bought <img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [name] for [UI ? UI.get_cost(U.job, 0.5) : get_cost(U.job)]."}
+			U.purchase_log += {"[user] ([user.ckey]) bought <img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [name] for [UI ? UI.get_cost(U.job, U.species, 0.5) : get_cost(U.job, U.species)]."}
 			stat_collection.uplink_purchase(src, I, user)
 			times_bought += 1
 
 			if(user.mind)
-				user.mind.spent_TC += get_cost(U.job)
+				user.mind.spent_TC += get_cost(U.job, U.species)
 				//First, try to add the uplink buys to any operative teams they're on. If none, add to a traitor role they have.
 				var/datum/role/R = user.mind.GetRole(NUKE_OP)
 				if(R)
-					R.faction.faction_scoreboard_data += {"<img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [bundlename] for [UI ? UI.get_cost(U.job, 0.5) : get_cost(U.job)] TC<BR>"}
+					R.faction.faction_scoreboard_data += {"<img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [bundlename] for [UI ? UI.get_cost(U.job, U.species, 0.5) : get_cost(U.job, U.species)] TC<BR>"}
 				else
 					R = user.mind.GetRole(TRAITOR)
 					if(R)
-						R.uplink_items_bought += {"<img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [bundlename] for [UI ? UI.get_cost(U.job, 0.5) : get_cost(U.job)] TC<BR>"}
+						R.uplink_items_bought += {"<img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [bundlename] for [UI ? UI.get_cost(U.job, U.species, 0.5) : get_cost(U.job, U.species)] TC<BR>"}
 					else
 						R = user.mind.GetRole(CHALLENGER)
 						if(R)
-							R.uplink_items_bought += {"<img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [bundlename] for [UI ? UI.get_cost(U.job, 0.5) : get_cost(U.job)] TC<BR>"}
+							R.uplink_items_bought += {"<img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [bundlename] for [UI ? UI.get_cost(U.job, U.species, 0.5) : get_cost(U.job, U.species)] TC<BR>"}
 		return 1
 	return 0
 
@@ -623,17 +623,17 @@ var/list/uplink_items = list()
 		for(var/datum/uplink_item/I in buyable_items[category])
 			if(I == src)
 				continue
-			if(!I.available_for_job(U.job))
+			if(!I.available_for_job(U.job) || !I.available_for_job(U.species))
 				continue
 			if(!I.available_for_nuke_ops && U.nuke_ops_inventory)
 				continue
-			if(I.get_cost(U.job, 0.5) > U.telecrystals)
+			if(I.get_cost(U.job, U.species, 0.5) > U.telecrystals)
 				continue
 			possible_items += I
 
 	if(possible_items.len)
 		var/datum/uplink_item/I = pick(possible_items)
-		U.telecrystals -= max(0, I.get_cost(U.job, 0.5))
+		U.telecrystals -= max(0, I.get_cost(U.job, U.species, 0.5))
 		feedback_add_details("traitor_uplink_items_bought","RN")
 		return I
 
@@ -705,7 +705,7 @@ var/list/uplink_items = list()
 	jobs_with_discount = list("Internal Affairs Agent")
 
 /datum/uplink_item/jobspecific/command_security/briefcase_smg/on_item_spawned(var/obj/I, var/mob/user)
-	if(gives_discount(user.job))
+	if(gives_discount(user.job) || gives_discount(user.dna.species))
 		I.icon_state = "briefcase-centcomm"
 	return
 
@@ -1126,22 +1126,28 @@ var/list/uplink_items = list()
 	name = "Chemical Dart Gun"
 	desc = "A staple in vox weaponry. This dart gun starts loaded with darts containing sleep toxin and chloral hydrate. The beaker inside can be swapped out to create your own deadly mixes."
 	item = /obj/item/weapon/gun/dartgun/vox/raider
-	cost = 16
-	jobs_exclusive = list("Trader")
+	cost = 20
+	discounted_cost = 16
+	jobs_exclusive = list("Trader","Vox")
+	jobs_with_discount = list("Trader")
 
 /datum/uplink_item/jobspecific/trader/dart_cartridge
 	name = "Dart Cartridge"
 	desc = "A spare cartridge to refill your dart gun."
 	item = /obj/item/weapon/dart_cartridge
-	cost = 2
-	jobs_exclusive = list("Trader")
+	cost = 6
+	discounted_cost = 2
+	jobs_exclusive = list("Trader","Vox")
+	jobs_with_discount = list("Trader")
 
 /datum/uplink_item/jobspecific/trader/cratesender
 	name = "Modified Crate Sender"
 	desc = "A modified salvage crate sender that has been modified to bypass the security protocols, allowing it to teleport crates from onboard the station and allowing it to teleport crates to random destinations. Comes with a cargo telepad you can send your stolen goods to."
 	item = /obj/item/weapon/storage/box/syndie_kit/cratesender
-	cost = 6
-	jobs_exclusive = list("Trader")
+	cost = 10
+	discounted_cost = 6
+	jobs_exclusive = list("Trader","Vox")
+	jobs_with_discount = list("Trader","Cargo Technician","Quartermaster")
 
 // SYNDICATE COOP
 // Any high cost items that are intended to only be purchasable when three syndies come together to change the narrative.

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -73,7 +73,7 @@ var/list/uplink_items = list()
 	return new new_item(location)
 
 /datum/uplink_item/proc/spawn_item(var/turf/loc, datum/component/uplink/U, mob/user)
-	if(!available_for_job(U.job) || !available_for_job(U.species))
+	if(!available_for_job(U.job) && !available_for_job(U.species))
 		message_admins("[key_name(user)] tried to purchase \the [src.name] from their uplink despite not being available to them! (Job: [U.job]) (Species: [U.species]) ([formatJumpTo(get_turf(U))])")
 		return
 	if(U.nuke_ops_inventory && !available_for_nuke_ops)
@@ -623,7 +623,7 @@ var/list/uplink_items = list()
 		for(var/datum/uplink_item/I in buyable_items[category])
 			if(I == src)
 				continue
-			if(!I.available_for_job(U.job) || !I.available_for_job(U.species))
+			if(!I.available_for_job(U.job) && !I.available_for_job(U.species))
 				continue
 			if(!I.available_for_nuke_ops && U.nuke_ops_inventory)
 				continue
@@ -1152,7 +1152,7 @@ var/list/uplink_items = list()
 /datum/uplink_item/jobspecific/cannedmatter
 	category = "Skrell Specials"
 	name = "Canned Compressed Matter"
-	desc = "For once, the syndicate has it."
+	desc = "For once, the syndicate has it. When an item is pressed onto the closed can, it can be stored inside regardless of its size, to be released again on the can opening. Does not allow items to be stored anymore once opened."
 	item = /obj/item/weapon/reagent_containers/food/drinks/soda_cans/canned_matter
 	cost = 6
 	jobs_exclusive = list("Skrell")

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -880,8 +880,8 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/canned_matter/attackby(var/obj/item/I, mob/user as mob)
 	if(!(flags & OPENCONTAINER)) // Won't work if already opened
-		user.drop_item(I,src)
-		storeditem = I
+		if(user.drop_item(I,src))
+			storeditem = I
 
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/canned_matter/pop_open(var/mob/user)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -871,6 +871,25 @@
 		var/obj/B = new /obj/item/weapon/reagent_containers/food/snacks/sliceable/bread(get_turf(src))
 		user.put_in_hands(B)
 
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/canned_matter
+	name = "\improper canned bread"
+	desc = "Wow, they have it!"
+	icon_state = "cannedbread"
+	var/obj/item/storeditem = null
+	//no actual chemicals in the can
+
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/canned_matter/attackby(var/obj/item/I, mob/user as mob)
+	if(!(flags & OPENCONTAINER)) // Won't work if already opened
+		user.drop_item(I,src)
+		storeditem = I
+
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/canned_matter/pop_open(var/mob/user)
+	. = ..()
+	spawn(0.5 SECONDS)
+		playsound(src, pick('sound/effects/splat_pie1.ogg','sound/effects/splat_pie2.ogg'), 50)
+		storeditem.forceMove(get_turf(src))
+		storeditem = null
+
 /obj/item/weapon/reagent_containers/food/drinks/coloring
 	name = "\improper vial of food coloring"
 	icon = 'icons/obj/chemical.dmi'


### PR DESCRIPTION
[content]
As suggested in the PR #32466, working example with making the trader exclusive items also available to vox at a higher price.

:cl:
 * rscadd: Species exclusive uplink items are here, with trader items also being able to be purchased by vox in general, albeit at a higher price in most cases.
 * rscadd: The syndicate uplink now has canned compressed matter on extremely rare occasions, if almost never. Not normally obtainable, they say.