### PR TITLE
Fixes Scrambler and Microwave Ray Effects Ignoring Shield Blocks

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -475,9 +475,13 @@
 		var/mob/living/M = target
 		if(ishuman(target))
 			var/mob/living/carbon/human/H = M
-			to_chat(M, "<span class='warning'>You are heated by the microwave ray's energy!</span>")
-			H.eye_blurry = max(M.eye_blurry, 5)
-			M.bodytemperature += 120
+			if(!blocked)
+				to_chat(H, "<span class='warning'>You are heated by the microwave ray's energy!</span>")
+				H.eye_blurry = max(H.eye_blurry, 5)
+				H.bodytemperature += 120
+			else
+				return
+	return 1
 
 /obj/item/projectile/energy/scramblerray
 	name = "scrambler ray"
@@ -491,8 +495,12 @@
 		var/mob/living/M = target
 		if(ishuman(target))
 			var/mob/living/carbon/human/H = M
-			to_chat(M, "<span class='warning'>The scrambler ray's energy makes you feel lightheaded and sick!</span>")
-			H.eye_blurry = max(M.eye_blurry, 5)
-			M.adjustBrainLoss(2)
-			H.drop_item()
-			H.vomit(0,1)
+			if(!blocked)
+				to_chat(H, "<span class='warning'>The scrambler ray's energy makes you feel lightheaded and sick!</span>")
+				H.eye_blurry = max(H.eye_blurry, 5)
+				H.adjustBrainLoss(2)
+				H.drop_item()
+				H.vomit(0,1)
+			else
+				return
+	return 1

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -470,18 +470,13 @@
 	flag = "energy"
 	fire_sound = 'sound/weapons/ray2.ogg'
 
-/obj/item/projectile/energy/microwaveray/on_hit(var/atom/target, var/blocked = 0)//These two could likely check temp protection on the mob
-	if(istype(target, /mob/living))
-		var/mob/living/M = target
-		if(ishuman(target))
-			var/mob/living/carbon/human/H = M
-			if(!blocked)
-				to_chat(H, "<span class='warning'>You are heated by the microwave ray's energy!</span>")
-				H.eye_blurry = max(H.eye_blurry, 5)
-				H.bodytemperature += 120
-			else
-				return
-	return 1
+/obj/item/projectile/energy/microwaveray/on_hit(var/atom/target, var/blocked = 0)
+	if (..(target, blocked))
+		var/mob/living/carbon/human/H = target
+		to_chat(H, "<span class='warning'>You are heated by the microwave ray's energy!</span>")
+		H.eye_blurry = max(H.eye_blurry, 5)
+		H.bodytemperature += 120
+	return 0
 
 /obj/item/projectile/energy/scramblerray
 	name = "scrambler ray"
@@ -491,16 +486,11 @@
 	fire_sound = 'sound/weapons/ray2.ogg'
 
 /obj/item/projectile/energy/scramblerray/on_hit(var/atom/target, var/blocked = 0)
-	if(istype(target, /mob/living))
-		var/mob/living/M = target
-		if(ishuman(target))
-			var/mob/living/carbon/human/H = M
-			if(!blocked)
-				to_chat(H, "<span class='warning'>The scrambler ray's energy makes you feel lightheaded and sick!</span>")
-				H.eye_blurry = max(H.eye_blurry, 5)
-				H.adjustBrainLoss(2)
-				H.drop_item()
-				H.vomit(0,1)
-			else
-				return
-	return 1
+	if (..(target, blocked))
+		var/mob/living/carbon/human/H = target
+		to_chat(H, "<span class='warning'>The scrambler ray's energy makes you feel lightheaded and sick!</span>")
+		H.eye_blurry = max(H.eye_blurry, 5)
+		H.adjustBrainLoss(2)
+		H.drop_item()
+		H.vomit(0,1)
+	return 0


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
## Bad Bug, Bad ##
There's a bug with the disintegrator alternate mode rays (microwave and scrambler) where they apply their effects even if blocked by a shield. Only damage is getting blocked.

I'm trying to squish the bug so that ray damage AND effects are blocked properly by shields.

[bugfix]

:cl:
 * bugfix: Microwave and scrambler rays can now be properly blocked by a shield.