### PR TITLE
Better fake adminbus explosions

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -48,60 +48,9 @@ var/explosion_shake_message_cooldown = 0
 			score.shuttlebombed += devastation_range //For the scoreboard
 		score.explosions++ //For the scoreboard
 
-		var/max_range = max(devastation_range, heavy_impact_range, light_impact_range)
 		stat_collection.add_explosion_stat(epicenter, devastation_range, heavy_impact_range, light_impact_range)
-//		playsound(epicenter, 'sound/effects/explosionfar.ogg', 100, 1, round(devastation_range*2,1) )
-//		playsound(epicenter, "explosion", 100, 1, round(devastation_range,1) )
 
-
-//Play sounds; we want sounds to be different depending on distance so we will manually do it ourselves.
-//Stereo users will also hear the direction of the explosion!
-//Calculate far explosion sound range. Only allow the sound effect for heavy/devastating explosions.
-//3/7/14 will calculate to 80 + 35
-		var/far_dist = (devastation_range * 20) + (heavy_impact_range * 5)
-		var/frequency = get_rand_frequency()
-		var/skip_shake = 0 //Will not display shaking-related messages
-
-		for (var/mob/M in player_list)
-			//Double check for client
-			if(M && M.client)
-				var/turf/M_turf = get_turf(M)
-				if(M_turf && (M_turf.z == epicenter.z || AreConnectedZLevels(M_turf.z,epicenter.z)) && (M_turf.z - epicenter.z <= max_range) && (epicenter.z - M_turf.z <= max_range))
-					var/dist = get_dist(M_turf, epicenter)
-					//If inside the blast radius + world.view - 2
-					if((dist <= round(max_range + world.view - 2, 1)) && (M_turf.z == epicenter.z))
-						if(devastation_range > 0)
-							M.playsound_local(epicenter, get_sfx("explosion"), 100, 1, frequency, falloff = 5) // get_sfx() is so that everyone gets the same sound
-							shake_camera(M, clamp(devastation_range, 3, 10), 2)
-						else
-							M.playsound_local(epicenter, get_sfx("explosion_small"), 100, 1, frequency, falloff = 5)
-							shake_camera(M, 3, 1)
-
-						//You hear a far explosion if you're outside the blast radius. Small bombs shouldn't be heard all over the station.
-
-					else if(dist <= far_dist)
-						var/far_volume = clamp(far_dist, 30, 50) // Volume is based on explosion size and dist
-						far_volume += (dist <= far_dist * 0.5 ? 50 : 0) // add 50 volume if the mob is pretty close to the explosion
-						if(devastation_range > 0)
-							M.playsound_local(epicenter, 'sound/effects/explosionfar.ogg', far_volume, 1, frequency, falloff = 5)
-							shake_camera(M, 3, 1)
-						else
-							M.playsound_local(epicenter, 'sound/effects/explosionsmallfar.ogg', far_volume, 1, frequency, falloff = 5)
-							skip_shake = 1
-
-					if(!explosion_shake_message_cooldown && !skip_shake)
-						to_chat(M, "<span class='danger'>You feel the station's structure shaking all around you.</span>")
-						explosion_shake_message_cooldown = 1
-						spawn(50)
-							explosion_shake_message_cooldown = 0
-
-		var/close = trange(world.view+round(devastation_range,1), epicenter)
-		//To all distanced mobs play a different sound
-		for(var/mob/M in mob_list) if(M.z == epicenter.z) if(!(M in close))
-			//Check if the mob can hear
-			if(M.ear_deaf <= 0 || !M.ear_deaf)
-				if(!istype(M.loc,/turf/space))
-					M << 'sound/effects/explosionfar.ogg'
+		explosion_effect(epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range)
 		if(adminlog)
 			message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ([formatJumpTo(epicenter,"JMP")]) [whodunnit ? " caused by [whodunnit] [whodunnit.ckey ? "([whodunnit.ckey])" : "(no key)"] ([formatJumpTo(whodunnit,"JMP")])" : ""]")
 			log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] [whodunnit ? " caused by [whodunnit] [whodunnit.ckey ? "([whodunnit.ckey])" : "(no key)"]" : ""]")
@@ -109,13 +58,6 @@ var/explosion_shake_message_cooldown = 0
 		//Pause the lighting updates for a bit.
 		var/postponeCycles = max(round(devastation_range/8),1)
 		SSlighting.postpone(postponeCycles)
-
-		if(heavy_impact_range > 1)
-			var/datum/effect/system/explosion/E = new/datum/effect/system/explosion()
-			E.set_up(epicenter)
-			E.start()
-		else
-			epicenter.turf_animation('icons/effects/96x96.dmi',"explosion_small",-WORLD_ICON_SIZE, -WORLD_ICON_SIZE, 13)
 
 		var/x0 = epicenter.x
 		var/y0 = epicenter.y
@@ -138,6 +80,65 @@ var/explosion_shake_message_cooldown = 0
 		sleep(8)
 
 	return 1
+
+//Play sounds; we want sounds to be different depending on distance so we will manually do it ourselves.
+//Stereo users will also hear the direction of the explosion!
+//Calculate far explosion sound range. Only allow the sound effect for heavy/devastating explosions.
+//3/7/14 will calculate to 80 + 35
+/proc/explosion_effect(turf/epicenter, const/devastation_range, const/heavy_impact_range, const/light_impact_range, const/flash_range)
+	var/max_range = max(devastation_range, heavy_impact_range, light_impact_range)
+
+	var/far_dist = (devastation_range * 20) + (heavy_impact_range * 5)
+	var/frequency = get_rand_frequency()
+	var/skip_shake = 0 //Will not display shaking-related messages
+
+	for (var/mob/M in player_list)
+		//Double check for client
+		if(M && M.client)
+			var/turf/M_turf = get_turf(M)
+			if(M_turf && (M_turf.z == epicenter.z || AreConnectedZLevels(M_turf.z,epicenter.z)) && (M_turf.z - epicenter.z <= max_range) && (epicenter.z - M_turf.z <= max_range))
+				var/dist = get_dist(M_turf, epicenter)
+				//If inside the blast radius + world.view - 2
+				if((dist <= round(max_range + world.view - 2, 1)) && (M_turf.z == epicenter.z))
+					if(devastation_range > 0)
+						M.playsound_local(epicenter, get_sfx("explosion"), 100, 1, frequency, falloff = 5) // get_sfx() is so that everyone gets the same sound
+						shake_camera(M, clamp(devastation_range, 3, 10), 2)
+					else
+						M.playsound_local(epicenter, get_sfx("explosion_small"), 100, 1, frequency, falloff = 5)
+						shake_camera(M, 3, 1)
+
+					//You hear a far explosion if you're outside the blast radius. Small bombs shouldn't be heard all over the station.
+
+				else if(dist <= far_dist)
+					var/far_volume = clamp(far_dist, 30, 50) // Volume is based on explosion size and dist
+					far_volume += (dist <= far_dist * 0.5 ? 50 : 0) // add 50 volume if the mob is pretty close to the explosion
+					if(devastation_range > 0)
+						M.playsound_local(epicenter, 'sound/effects/explosionfar.ogg', far_volume, 1, frequency, falloff = 5)
+						shake_camera(M, 3, 1)
+					else
+						M.playsound_local(epicenter, 'sound/effects/explosionsmallfar.ogg', far_volume, 1, frequency, falloff = 5)
+						skip_shake = 1
+
+				if(!explosion_shake_message_cooldown && !skip_shake)
+					to_chat(M, "<span class='danger'>You feel the station's structure shaking all around you.</span>")
+					explosion_shake_message_cooldown = 1
+					spawn(50)
+						explosion_shake_message_cooldown = 0
+
+	var/close = trange(world.view+round(devastation_range,1), epicenter)
+	//To all distanced mobs play a different sound
+	for(var/mob/M in mob_list) if(M.z == epicenter.z) if(!(M in close))
+		//Check if the mob can hear
+		if(M.ear_deaf <= 0 || !M.ear_deaf)
+			if(!istype(M.loc,/turf/space))
+				M << 'sound/effects/explosionfar.ogg'
+
+	if(heavy_impact_range > 1)
+		var/datum/effect/system/explosion/E = new/datum/effect/system/explosion()
+		E.set_up(epicenter)
+		E.start()
+	else
+		epicenter.turf_animation('icons/effects/96x96.dmi',"explosion_small",-WORLD_ICON_SIZE, -WORLD_ICON_SIZE, 13)
 
 /proc/explosion_destroy(turf/epicenter, turf/offcenter, const/devastation_range, const/heavy_impact_range, const/light_impact_range, const/flash_range, var/explosion_time, var/mob/whodunnit)
 	var/max_range = max(devastation_range, heavy_impact_range, light_impact_range)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -883,7 +883,7 @@ var/global/floorIsLava = 0
 			<A href='?src=\ref[src];secretsfun=togglenarsie'>Toggle Nar-Sie's behaviour</A><BR>
 			<BR>
 			<A href='?src=\ref[src];secretsfun=fakealerts'>Trigger a fake alert</A><BR>
-			<A href='?src=\ref[src];secretsfun=fakebooms'>Adds in some Micheal Bay to the shift without major destruction</A><BR>
+			<A href='?src=\ref[src];secretsfun=fakebooms'>Adds in some Michael Bay to the shift without major destruction</A><BR>
 			<BR>
 			<A href='?src=\ref[src];secretsfun=placeturret'>Create a turret</A><BR>
 			<A href='?src=\ref[src];secretsfun=virusdish'>Create a new virus in a dish</A><BR>

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -883,7 +883,7 @@ var/global/floorIsLava = 0
 			<A href='?src=\ref[src];secretsfun=togglenarsie'>Toggle Nar-Sie's behaviour</A><BR>
 			<BR>
 			<A href='?src=\ref[src];secretsfun=fakealerts'>Trigger a fake alert</A><BR>
-			<A href='?src=\ref[src];secretsfun=fakebooms'>Adds in some Michael Bay to the shift without major destruction</A><BR>
+			<A href='?src=\ref[src];secretsfun=fakebooms'>Create fake explosions around the station</A><BR>
 			<BR>
 			<A href='?src=\ref[src];secretsfun=placeturret'>Create a turret</A><BR>
 			<A href='?src=\ref[src];secretsfun=virusdish'>Create a new virus in a dish</A><BR>

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -4080,13 +4080,13 @@
 			if("fakebooms") //Michael Bay is in the house !
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","FAKEE")
-				var/amount = input("How much high-budget explosions do you want ?", "Michael Bay SFX Systems", 1) as num
+				var/amount = input("How many fake explosions do you want ?", "Fake Explosions", 1) as num
 				if(amount < 1) //No negative or null explosion amounts here math genius
 					to_chat(usr, "<span class='warning'>Invalid input range (null or negative)</span>")
 					return
-				var/realeffect = alert(usr,"Use visible explosions?", "Michael Bay SFX Systems", "Yes", "No") == "Yes"
-				message_admins("[key_name_admin(usr)] improvised himself as Michael Bay and triggered [round(amount)] fake explosions.")
-				log_admin("[key_name_admin(usr)] improvised himself as Michael Bay and triggered [round(amount)] fake explosions.")
+				var/realeffect = alert(usr,"Use visible explosions?", "Fake Explosions", "Yes", "No") == "Yes"
+				message_admins("[key_name_admin(usr)] triggered [round(amount)] fake explosions.")
+				log_admin("[key_name_admin(usr)] triggered [round(amount)] fake explosions.")
 				for(var/i = 1 to amount)
 					if(realeffect)
 						var/turf/epicenter = locate(rand(1,world.maxx),rand(1,world.maxy),map.zMainStation)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -4077,17 +4077,22 @@
 						log_admin("[key_name_admin(usr)] triggered a FAKE revolution alert.")
 						return
 					//TODO (UPHEAVAL PART 2) think of fake alerts too
-			if("fakebooms") //Micheal Bay is in the house !
+			if("fakebooms") //Michael Bay is in the house !
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","FAKEE")
-				var/choice = input("How much high-budget explosions do you want ?", "Micheal Bay SFX Systems", 1) as num
-				if(choice < 1) //No negative or null explosion amounts here math genius
+				var/amount = input("How much high-budget explosions do you want ?", "Michael Bay SFX Systems", 1) as num
+				if(amount < 1) //No negative or null explosion amounts here math genius
 					to_chat(usr, "<span class='warning'>Invalid input range (null or negative)</span>")
 					return
-				message_admins("[key_name_admin(usr)] improvised himself as Micheal Bay and triggered [round(choice)] fake explosions.")
-				log_admin("[key_name_admin(usr)] improvised himself as Micheal Bay and triggered [round(choice)] fake explosions.")
-				for(var/i = 1 to choice)
-					world << sound('sound/effects/explosionfar.ogg')
+				var/realeffect = alert(usr,"Use visible explosions?", "Michael Bay SFX Systems", "Yes", "No") == "Yes"
+				message_admins("[key_name_admin(usr)] improvised himself as Michael Bay and triggered [round(amount)] fake explosions.")
+				log_admin("[key_name_admin(usr)] improvised himself as Michael Bay and triggered [round(amount)] fake explosions.")
+				for(var/i = 1 to amount)
+					if(realeffect)
+						var/turf/epicenter = locate(rand(1,world.maxx),rand(1,world.maxy),map.zMainStation)
+						explosion_effect(epicenter,7,14,28)
+					else
+						world << sound('sound/effects/explosionfar.ogg')
 					sleep(rand(2, 10)) //Sleep 0.2 to 1 second
 			if("togglerunescapepvp")
 				feedback_inc("admin_secrets_fun_used",1)


### PR DESCRIPTION
[content][administration][tested]
Splits off the initial visual part of explosion() into explosion_effect(), as how I already split off explosion_destroy() for multi Z stuff.
Gives an alert prompt for the secret asking if admins want the explosions to be visible, selecting "no" keeps the legacy system.