### PR TITLE
Uncomments the Wiz Wars button

### DIFF
--- a/code/modules/admin/verbs/onlyone.dm
+++ b/code/modules/admin/verbs/onlyone.dm
@@ -96,7 +96,7 @@
 	return H
 
 
-/*MAGIC MISSILE
+//MAGIC MISSILE
 /datum/only_one/wizardwars
 	name = "Wizard Wars"
 
@@ -163,4 +163,3 @@
 		if(M.mind)
 			M.mind.nospells = 0
 		to_chat(M, "<span class='warning'>Invincibility period over. Let the battle begin!</span>")
-*/


### PR DESCRIPTION
A: Why was this ever even commented out this is just an adminbus button that never gets pushed, it was removed by robo in a role datums pr because it wasnt role datums but who GIVES a fuck
B: Needed for a bus on Saturday by Luzzy