### PR TITLE
Add stop pulling and body zone targeting buttons to grues (WIP)

### DIFF
--- a/code/_onclick/hud/other_mobs.dm
+++ b/code/_onclick/hud/other_mobs.dm
@@ -316,17 +316,17 @@
 	mymob.healths2.name= "darkness"
 	mymob.healths2.screen_loc=ui_under_health
 
-+	mymob.pullin = new /obj/abstract/screen
-+	mymob.pullin.icon = 'icons/mob/screen1_construct.dmi'
-+	mymob.pullin.icon_state = "pull0"
-+	mymob.pullin.name = "pull"
-+	mymob.pullin.screen_loc = ui_construct_pull
-+
-+	mymob.zone_sel = new /obj/abstract/screen/zone_sel
-+	mymob.zone_sel.icon = 'icons/mob/screen1_construct.dmi'
-+	mymob.zone_sel.overlays.len = 0
-+	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
-+
-+	mymob.client.reset_screen()
-+
-+	mymob.client.screen += list(mymob.healths, mymob.healths2, mymob.pullin, mymob.zone_sel)
+	mymob.pullin = new /obj/abstract/screen
+	mymob.pullin.icon = 'icons/mob/screen1_construct.dmi'
+	mymob.pullin.icon_state = "pull0"
+	mymob.pullin.name = "pull"
+	mymob.pullin.screen_loc = ui_construct_pull
+
+	mymob.zone_sel = new /obj/abstract/screen/zone_sel
+	mymob.zone_sel.icon = 'icons/mob/screen1_construct.dmi'
+	mymob.zone_sel.overlays.len = 0
+	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
+
+	mymob.client.reset_screen()
+
+	mymob.client.screen += list(mymob.healths, mymob.healths2, mymob.pullin, mymob.zone_sel)

--- a/code/_onclick/hud/other_mobs.dm
+++ b/code/_onclick/hud/other_mobs.dm
@@ -316,4 +316,17 @@
 	mymob.healths2.name= "darkness"
 	mymob.healths2.screen_loc=ui_under_health
 
-	mymob.client.screen += list(mymob.healths,mymob.healths2)
++	mymob.pullin = new /obj/abstract/screen
++	mymob.pullin.icon = 'icons/mob/screen1_construct.dmi'
++	mymob.pullin.icon_state = "pull0"
++	mymob.pullin.name = "pull"
++	mymob.pullin.screen_loc = ui_construct_pull
++
++	mymob.zone_sel = new /obj/abstract/screen/zone_sel
++	mymob.zone_sel.icon = 'icons/mob/screen1_construct.dmi'
++	mymob.zone_sel.overlays.len = 0
++	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
++
++	mymob.client.reset_screen()
++
++	mymob.client.screen += list(mymob.healths, mymob.healths2, mymob.pullin, mymob.zone_sel)

--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -136,6 +136,7 @@
 	..()
 	if(client && hud_used)
 		hud_used.grue_hud()
+		update_pull_icon()
 
 //health indicator
 		if (health >= maxHealth)


### PR DESCRIPTION
This is a draft for adding a "stop pulling" button to grues as well as body zone targeting (not yet complete) I'm posting it as a draft for now because I have a question/am stuck on something. To get the buttons to work properly I have to add `mymob.client.reset_screen()` to `grue_hud()`. However, doing so seems to break the visuals and make everything blurry. I thought maybe it was related to the custom grue-vision colors and such so I commented that out to test but the same blurriness bug still occurred. So I'm wondering if anyone knows how to fix that or what could be causing that bug.

The blurriness seems like only the lighting layer is being rendered and not the actual atoms beneath it.

I also need to update the icons.

[wip][help]

Closes #32313
:cl:
 * rscadd: Stop pulling and zone targeting buttons for grues.