### PR TITLE
Random mob cargo forward fixes

### DIFF
--- a/code/game/objects/structures/cage.dm
+++ b/code/game/objects/structures/cage.dm
@@ -74,10 +74,9 @@
 			toggle_door(user)
 
 /obj/structure/cage/ex_act(var/severity)
-	if(severity < 3)
-		var/list/affected_mobs = remove_mobs()
-		for(var/atom/movable/M in affected_mobs)
-			M.ex_act(severity)
+	var/list/affected_mobs = severity < 3 ? remove_mobs() : get_mobs()
+	for(var/atom/movable/M in affected_mobs)
+		M.ex_act(severity)
 	..()
 
 /obj/structure/cage/shuttle_act(var/datum/shuttle/S)
@@ -271,6 +270,13 @@
 		return TRUE
 
 	return checked in get_locked(/datum/locking_category/cage)
+
+/obj/structure/cage/proc/get_mobs()
+	switch(cover_state)
+		if(C_OPENED)
+			. = get_locked(/datum/locking_category/cage)
+		if(C_CLOSED)
+			. = contents
 
 /obj/structure/cage/proc/remove_mobs()
 	. = list()

--- a/code/game/objects/structures/cage.dm
+++ b/code/game/objects/structures/cage.dm
@@ -74,9 +74,10 @@
 			toggle_door(user)
 
 /obj/structure/cage/ex_act(var/severity)
-	var/list/affected_mobs = remove_mobs()
-	for(var/atom/movable/M in affected_mobs)
-		M.ex_act(severity)
+	if(severity < 3)
+		var/list/affected_mobs = remove_mobs()
+		for(var/atom/movable/M in affected_mobs)
+			M.ex_act(severity)
 	..()
 
 /obj/structure/cage/shuttle_act(var/datum/shuttle/S)

--- a/code/game/objects/structures/cage.dm
+++ b/code/game/objects/structures/cage.dm
@@ -41,9 +41,13 @@
 		toggle_cover()
 
 /obj/structure/cage/Destroy()
-	for(var/atom/movable/M in contents)
-		M.forceMove(src.loc)
-
+	switch(cover_state)
+		if(C_OPENED)
+			for(var/mob/living/L in get_locked(/datum/locking_category/cage))
+				qdel(L)
+		if(C_CLOSED)
+			for(var/atom/movable/M in contents)
+				qdel(M)
 	..()
 
 /obj/structure/cage/update_icon()
@@ -69,6 +73,17 @@
 		else
 			toggle_door(user)
 
+/obj/structure/cage/ex_act(var/severity)
+	var/list/affected_mobs = remove_mobs()
+	for(var/atom/movable/M in affected_mobs)
+		M.ex_act(severity)
+	..()
+
+/obj/structure/cage/shuttle_act(var/datum/shuttle/S)
+	var/list/affected_mobs = remove_mobs()
+	for(var/atom/movable/M in affected_mobs)
+		M.shuttle_act(S)
+	..()
 
 /obj/structure/cage/bullet_act(var/obj/item/projectile/Proj)
 	if (!locked_atoms?.len)
@@ -256,11 +271,25 @@
 
 	return checked in get_locked(/datum/locking_category/cage)
 
+/obj/structure/cage/proc/remove_mobs()
+	. = list()
+	switch(cover_state)
+		if(C_OPENED) //Cover is opened - mob is atom unlocked from the cage
+			for(var/mob/living/L in get_locked(/datum/locking_category/cage))
+				unlock_atom(L)
+				. |= L
+		if(C_CLOSED) //Cover is closed - mob is removed from the cage
+			for(var/atom/movable/M in contents)
+				M.forceMove(src.loc)
+				. |= M
+
 /obj/structure/cage/random_mob/New()
 	..()
-	var/mobtype = pick(existing_typesof(/mob/living/simple_animal) - (existing_typesof_list(blacklisted_mobs) + existing_typesof_list(boss_mobs)))
-	var/mob/living/simple_animal/ourmob = new mobtype
-	add_mob(ourmob)
+	spawn()
+		toggle_cover() // Spawn closed for cargo forwards
+		var/mobtype = pick(existing_typesof(/mob/living/simple_animal) - (existing_typesof_list(blacklisted_mobs) + existing_typesof_list(boss_mobs)))
+		var/mob/living/simple_animal/ourmob = new mobtype
+		add_mob(ourmob)
 
 #undef C_OPENED
 #undef C_CLOSED


### PR DESCRIPTION
[bugfix]
Changes how the cage is deleted, will now delete the mobs inside normally, except if affected by an explosion or shuttle, in which case the mob inside will also be affected in turn after being taken out. (Will not be removed from cages in light explosions as they cannot be deleted at all from them)
Also spawns random mob cages closed so the contents checks works during forwarding.
Closes #32479.

:cl:
 * bugfix: Random mob cages now have their mobs in content checks during cargo forwards.
 * bugfix: Random mob cages now delete the mob inside when sent as a cargo forward.
 * tweak: Mobs no longer survive explosions or shuttle crushes if inside cages.