### PR TITLE
Nuke Ops no longer end the round

### DIFF
--- a/code/datums/gamemode/gamemode.dm
+++ b/code/datums/gamemode/gamemode.dm
@@ -258,7 +258,7 @@
 	for(var/datum/role/R in orphaned_roles)
 		if (R.check_win())
 			return 1
-	if(emergency_shuttle.location==2 || ticker.station_was_nuked || ticker.no_life_on_station)
+	if(emergency_shuttle.location==2 || ticker.no_life_on_station)
 		return 1
 	return 0
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -313,6 +313,7 @@ var/datum/controller/gameticker/ticker
 		if(M.client)
 			M.client.screen += cinematic	//show every client the cinematic
 
+
 	//Now animate the cinematic
 	switch(station_missed)
 		if(1)	//nuke was nearby but (mostly) missed
@@ -330,8 +331,6 @@ var/datum/controller/gameticker/ticker
 					sleep(35)
 					world << sound('sound/effects/explosionfar.ogg')
 					//flick("end",cinematic)
-
-
 		if(2)	//nuke was nowhere nearby	//TODO: a really distant explosion animation
 			sleep(50)
 			world << sound('sound/effects/explosionfar.ogg')
@@ -359,7 +358,6 @@ var/datum/controller/gameticker/ticker
 					flick("station_explode_fade_red", cinematic)
 					world << sound('sound/effects/explosionfar.ogg')
 					cinematic.icon_state = "summary_selfdes"
-
 	if(cinematic)
 		qdel(cinematic)		//end the cinematic
 	if(temp_buckle)
@@ -467,11 +465,6 @@ var/datum/controller/gameticker/ticker
 				vote.initiate_vote("map","The Server", popup = 1)
 				var/options = jointext(vote.choices, " ")
 				feedback_set("map vote choices", options)
-
-			if (station_was_nuked)
-				feedback_set_details("end_proper","nuke")
-				if(!delay_end && !watchdog.waiting)
-					to_chat(world, "<span class='notice'><B>Rebooting due to destruction of station in [restart_timeout/10] seconds</B></span>")
 			else
 				feedback_set_details("end_proper","\proper completion")
 				if(!delay_end && !watchdog.waiting)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -308,24 +308,10 @@ var/datum/controller/gameticker/ticker
 	cinematic.screen_loc = "1,0"
 
 	var/obj/structure/bed/temp_buckle = new(src)
-	//Incredibly hackish. It creates a bed within the gameticker (lol) to stop mobs running around
-	if(station_missed)
-		for(var/mob/living/M in living_mob_list)
-			M.locked_to = temp_buckle				//buckles the mob so it can't do anything
-			if(M.client)
-				M.client.screen += cinematic	//show every client the cinematic
-	else	//nuke kills everyone on the station to prevent "hurr-durr I survived"
-		for(var/mob/living/M in living_mob_list)
-			M.locked_to = temp_buckle
-			if(M.client)
-				M.client.screen += cinematic
-
-			if(!(M.z))	//inside a crate or something
-				var/turf/T = get_turf(M)
-				if(T && T.z==map.zMainStation)	//we don't use M.death(0) because it calls a for(/mob) loop and
-					M.nuke_act()
-			else if(M.z == map.zMainStation) //on the station.
-				M.nuke_act()
+	for(var/mob/living/M in living_mob_list)
+		M.locked_to = temp_buckle				//buckles the mob so it can't do anything
+		if(M.client)
+			M.client.screen += cinematic	//show every client the cinematic
 
 	//Now animate the cinematic
 	switch(station_missed)
@@ -373,10 +359,6 @@ var/datum/controller/gameticker/ticker
 					flick("station_explode_fade_red", cinematic)
 					world << sound('sound/effects/explosionfar.ogg')
 					cinematic.icon_state = "summary_selfdes"
-
-	//If its actually the end of the round, wait for it to end.
-	//Otherwise if its a verb it will continue on afterwards.
-	sleep(300)
 
 	if(cinematic)
 		qdel(cinematic)		//end the cinematic

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -372,7 +372,7 @@ var/list/nuclear_bombs = list()
 
 /obj/item/weapon/disk/nuclear/process()
 	var/turf/T = get_turf(src)
-	if(!T)
+	if(!T && !ticker.station_was_nuked)
 		var/atom/A
 		for(A=src, A && A.loc && !isturf(A.loc), A=A.loc);  // semicolon is for the empty statement
 		message_admins("\The [src] ended up in nullspace somehow, and has been replaced.[loc ? " It was contained in [A] when it was nullspaced." : ""]")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1429,10 +1429,6 @@ Thanks.
 
 	return 0
 
-/mob/living/nuke_act() //Called when caught in a nuclear blast
-	health = 0
-	stat = DEAD
-
 /mob/living/proc/turn_into_statue(forever = 0, force)
 	if(!force)
 		if(mob_property_flags & (MOB_UNDEAD|MOB_CONSTRUCT|MOB_ROBOTIC|MOB_HOLOGRAPHIC|MOB_SUPERNATURAL))

--- a/code/modules/mob/living/simple_animal/bees/bees_mob.dm
+++ b/code/modules/mob/living/simple_animal/bees/bees_mob.dm
@@ -144,19 +144,6 @@ var/bee_mobs_count = 0
 		if (3)
 			adjustBruteLoss(20)
 
-/mob/living/simple_animal/bee/nuke_act()
-	//first of all, we don't want more bees to come out of a hive that got nuked (for now at least)
-	if (home && home.z == z)
-		home.queen_bees_inside = 0
-		home.worker_bees_inside = 0
-
-	//this may or may not kill them all, but it'll at least spawn a good amount of bee corpses
-	adjustBruteLoss(100)
-
-	//cleanup
-	if (src)
-		qdel(src)
-
 /mob/living/simple_animal/bee/reagent_act(id, method, volume)
 	if(isDead())
 		return

--- a/code/modules/mob/living/simple_animal/hostile/bigroach.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bigroach.dm
@@ -121,9 +121,6 @@
 
 /mob/living/simple_animal/hostile/bigroach/ex_act()
 	return //Survive bombs
-
-/mob/living/simple_animal/hostile/bigroach/nuke_act()
-	return //Survive nuclear blasts
 	
 /mob/living/simple_animal/hostile/bigroach/reagent_act(id, method, volume)
 	if(isDead())

--- a/code/modules/mob/living/simple_animal/roach.dm
+++ b/code/modules/mob/living/simple_animal/roach.dm
@@ -286,9 +286,6 @@
 	spawn(10 SECONDS)
 		stop_flying()
 
-/mob/living/simple_animal/cockroach/nuke_act()
-	return //Survive nuclear blasts
-
 /mob/living/simple_animal/cockroach/reagent_act(id, method, volume)
 	if(isDead())
 		return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1854,9 +1854,6 @@ Use this proc preferably at the end of an equipment loadout
 /mob/proc/teleport_to(var/atom/A)
 	forceMove(get_turf(A))
 
-/mob/proc/nuke_act() //Called when caught in a nuclear blast
-	return
-
 /mob/supermatter_act(atom/source, severity)
 	var/contents = get_contents_in_object(src)
 


### PR DESCRIPTION
[role]
Love me, hate me, I don't care. Rounds no longer end when nuke ops blow up the station. Everyone doesn't instantly die. Everything continues as normal but is in shambles. Nuke still ends the round with blob. Emoji this!

Rationale: we're vg with dynamic, not paradise where the round ends when the antag dies!

:cl:
 * rscadd: Nuke ops no longer end after the nuke goes off
