### PR TITLE
Can live after being nuked

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -310,6 +310,9 @@ var/datum/controller/gameticker/ticker
 	for(var/mob/M in player_list)
 		if(M.client)
 			M.client.screen += cinematic	//show every client the cinematic
+		if (istype(M,/mob/living/carbon/human))
+			var/mob/living/carbon/human/C = M
+			C.apply_radiation(rand(50, 250),RAD_EXTERNAL)
 
 	//Now animate the cinematic
 	switch(station_missed)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -307,25 +307,9 @@ var/datum/controller/gameticker/ticker
 	cinematic.mouse_opacity = 0
 	cinematic.screen_loc = "1,0"
 
-	var/obj/structure/bed/temp_buckle = new(src)
-	//Incredibly hackish. It creates a bed within the gameticker (lol) to stop mobs running around
-	if(station_missed)
-		for(var/mob/living/M in living_mob_list)
-			M.locked_to = temp_buckle				//buckles the mob so it can't do anything
-			if(M.client)
-				M.client.screen += cinematic	//show every client the cinematic
-	else	//nuke kills everyone on the station to prevent "hurr-durr I survived"
-		for(var/mob/living/M in living_mob_list)
-			M.locked_to = temp_buckle
-			if(M.client)
-				M.client.screen += cinematic
-
-			if(!(M.z))	//inside a crate or something
-				var/turf/T = get_turf(M)
-				if(T && T.z==map.zMainStation)	//we don't use M.death(0) because it calls a for(/mob) loop and
-					M.nuke_act()
-			else if(M.z == map.zMainStation) //on the station.
-				M.nuke_act()
+	for(var/mob/M in player_list)
+		if(M.client)
+			M.client.screen += cinematic	//show every client the cinematic
 
 	//Now animate the cinematic
 	switch(station_missed)
@@ -347,10 +331,7 @@ var/datum/controller/gameticker/ticker
 
 
 		if(2)	//nuke was nowhere nearby	//TODO: a really distant explosion animation
-			sleep(50)
 			world << sound('sound/effects/explosionfar.ogg')
-
-
 		else	//station was destroyed
 			if( mode && !override )
 				override = mode.name
@@ -374,15 +355,8 @@ var/datum/controller/gameticker/ticker
 					world << sound('sound/effects/explosionfar.ogg')
 					cinematic.icon_state = "summary_selfdes"
 
-	//If its actually the end of the round, wait for it to end.
-	//Otherwise if its a verb it will continue on afterwards.
-	sleep(300)
-
 	if(cinematic)
 		qdel(cinematic)		//end the cinematic
-	if(temp_buckle)
-		qdel(temp_buckle)	//release everybody
-	return
 
 /datum/controller/gameticker/proc/station_nolife_cinematic(var/override = null)
 	if( cinematic )

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -372,7 +372,7 @@ var/list/nuclear_bombs = list()
 
 /obj/item/weapon/disk/nuclear/process()
 	var/turf/T = get_turf(src)
-	if(!T)
+	if(!T && !ticker.station_was_nuked)
 		var/atom/A
 		for(A=src, A && A.loc && !isturf(A.loc), A=A.loc);  // semicolon is for the empty statement
 		message_admins("\The [src] ended up in nullspace somehow, and has been replaced.[loc ? " It was contained in [A] when it was nullspaced." : ""]")

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -372,7 +372,7 @@ var/list/nuclear_bombs = list()
 
 /obj/item/weapon/disk/nuclear/process()
 	var/turf/T = get_turf(src)
-	if(!T && !ticker.station_was_nuked)
+	if(!T)
 		var/atom/A
 		for(A=src, A && A.loc && !isturf(A.loc), A=A.loc);  // semicolon is for the empty statement
 		message_admins("\The [src] ended up in nullspace somehow, and has been replaced.[loc ? " It was contained in [A] when it was nullspaced." : ""]")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1430,8 +1430,7 @@ Thanks.
 	return 0
 
 /mob/living/nuke_act() //Called when caught in a nuclear blast
-	health = 0
-	stat = DEAD
+	return
 
 /mob/living/proc/turn_into_statue(forever = 0, force)
 	if(!force)


### PR DESCRIPTION
[tweak]
After the station gets nuked, you're no longer buckled in place and die instantaneously but instead get radded. Also, the cinematic ends faster. Removes some weird old code. The round ends as normal

:cl:
 * rscadd: You can potentially live through nuclear explosions
