### PR TITLE
Reenables events when few players

### DIFF
--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -20,7 +20,7 @@ var/list/event_last_fired = list()
 	if(universe.name != "Normal")
 		message_admins("Universe isn't normal, aborting random event spawn.")
 		return
-	if(player_list.len < 6) //minimum pop of 5 to trigger events
+	if(player_list.len < 1) //minimum pop of 1 to trigger events
 		message_admins("Too few players to trigger random event, aborting.")
 		return
 	var/list/active_with_role = number_active_with_role()

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -20,7 +20,7 @@ var/list/event_last_fired = list()
 	if(universe.name != "Normal")
 		message_admins("Universe isn't normal, aborting random event spawn.")
 		return
-	if(player_list.len < 1) //minimum pop of 1 to trigger events
+	if(player_list.len =< 1) //minimum pop of 1 to trigger events
 		message_admins("Too few players to trigger random event, aborting.")
 		return
 	var/list/active_with_role = number_active_with_role()

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -20,7 +20,7 @@ var/list/event_last_fired = list()
 	if(universe.name != "Normal")
 		message_admins("Universe isn't normal, aborting random event spawn.")
 		return
-	if(player_list.len <= 1) //minimum pop of 1 to trigger events
+	if(player_list.len < 1) //minimum pop of 1 to trigger events
 		message_admins("Too few players to trigger random event, aborting.")
 		return
 	var/list/active_with_role = number_active_with_role()

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -20,7 +20,7 @@ var/list/event_last_fired = list()
 	if(universe.name != "Normal")
 		message_admins("Universe isn't normal, aborting random event spawn.")
 		return
-	if(player_list.len =< 1) //minimum pop of 1 to trigger events
+	if(player_list.len <= 1) //minimum pop of 1 to trigger events
 		message_admins("Too few players to trigger random event, aborting.")
 		return
 	var/list/active_with_role = number_active_with_role()


### PR DESCRIPTION
After playing and observing rounds with #32285 in effect, I think it's better to have the events turned back on.

### **What is being done?**
This PR decreases the minimum population requirement of random events back to 1 player online, whether in the lobby, observing or playing.
This means that kudzu, carp, old vendotrons, whatever else event that has minimum job requirements active will be back in deadpop.

### **Why is this being done?**
I believe it can get very boring for solo players especially if they have nothing to do on an empty station with nothing happening. I understand that not everyone has the initiative to perform projects all on their own and may need problems to solve laid before them by the game itself.

Now, you may think to yourself, "_I do not want to be this guy_"
![deadpopper going to work](https://user-images.githubusercontent.com/55976761/166077060-844a679c-cd59-49f7-b8b6-6f57992c75d1.png)

I will tell you, **do not worry**, due to this PR #32291 it is very much less likely for situations where people would be trapped in the arrivals shuttle to happen, since vines and such are limited to certain areas only and no longer in the main halls.

But honestly I really just want the vendotrons back, give me the loot.
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
:cl:
 * rscadd: Random events are now enabled on less than 6 players again
