### PR TITLE
Transit tube construction fixes

### DIFF
--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -64,6 +64,8 @@
 					src.Bumped(GM)
 					qdel(G)
 				break
+		return
+	..()
 
 /obj/structure/transit_tube/station/attack_robot(mob/user)
 	if(Adjacent(user))

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -24,7 +24,7 @@
 /obj/structure/transit_tube/station/Destroy()
 	processing_objects -= src
 	..()
-	
+
 //Attacks
 
 /obj/structure/transit_tube/station/attack_hand(mob/user)
@@ -99,7 +99,7 @@
 					update_icon()
 				return
 		else
-			to_chat(user, "<span class='warning'>Access denied.</span>")			
+			to_chat(user, "<span class='warning'>Access denied.</span>")
 
 //This doesn't work
 /obj/structure/transit_tube/station/Bumped(atom/movable/mover)
@@ -147,7 +147,7 @@
 				pod_moving = 0
 			return 1
 	return 0
-	
+
 /obj/structure/transit_tube/station/process()
 	if(!pod_moving)
 		launch_pod()

--- a/code/game/objects/structures/transit_tubes/transit_tube.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube.dm
@@ -27,12 +27,6 @@
 
 	if (tube_dirs == null)
 		init_dirs()
-	
-/obj/structure/transit_tube/New(loc)
-	..(loc)
-
-	if(tube_dirs == null)
-		init_dirs()
 
 /obj/structure/transit_tube/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 	return TRUE //Otherwise, whatever.
@@ -82,10 +76,10 @@
 
 /obj/structure/transit_tube/proc/enter_delay(pod, to_dir)
 	return enter_delay
-	
+
 // Called when a pod stops in this tube section.
 /obj/structure/transit_tube/proc/pod_stopped(pod, from_dir)
-	return	
+	return
 
 /obj/structure/transit_tube/attackby(obj/item/W as obj, mob/user as mob)
 	if(iswelder(W))
@@ -131,7 +125,7 @@
 	for(var/obj/structure/transit_tube_pod/pod in loc)
 		pod.show_occupants(user)
 
-	
+
 // Parse the icon_state into a list of directions.
 // This means that mappers can use Dream Maker's built in
 //  "Generate Instances from Icon-states" option to get all

--- a/code/game/objects/structures/transit_tubes/transit_tube_assembly.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_assembly.dm
@@ -11,7 +11,7 @@
 
 /obj/structure/transit_tube_frame/New(var/loc, var/dir_override = null)
     ..()
-    
+
     if(dir_override)
         dir = dir_override
 
@@ -74,58 +74,58 @@
     var/obj/item/weapon/circuitboard/airlock/electronics = null
 
 /obj/structure/transit_tube_frame/station/attackby(obj/item/W as obj, mob/user as mob)
-    if(istype(W,/obj/item/stack/sheet/glass/rglass) && anchored && electronics)
-        var/obj/item/stack/sheet/glass/rglass/G = W
-        playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
-        to_chat(user, "<span class='notice'>You begin to add reinforced glass to \the [src]...</span>")
-        if(G.amount < 2)
-            to_chat(user, "<span class='warning'>You need 2 sheets of glass to do this.</span>")
-            return 1
-        if(do_after(user, src, 4 SECONDS))
-            if(G.amount < 2) //User being tricky
-                return 1
-            G.use(2)
-            to_chat(user, "<span class='notice'>You add the reinforced glass to the [src].</span>")
-            var/obj/structure/transit_tube/station/TTS = new /obj/structure/transit_tube/station(loc, dir_icon_states[dir])
+	if(istype(W,/obj/item/stack/sheet/glass/rglass) && anchored && electronics)
+		var/obj/item/stack/sheet/glass/rglass/G = W
+		playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
+		to_chat(user, "<span class='notice'>You begin to add reinforced glass to \the [src]...</span>")
+		if(G.amount < 2)
+			to_chat(user, "<span class='warning'>You need 2 sheets of glass to do this.</span>")
+			return 1
+		if(do_after(user, src, 4 SECONDS))
+			if(G.amount < 2) //User being tricky
+				return 1
+			G.use(2)
+			to_chat(user, "<span class='notice'>You add the reinforced glass to the [src].</span>")
+			var/obj/structure/transit_tube/station/TTS = new /obj/structure/transit_tube/station(loc, null, dir)
 
-            if(src.electronics.one_access)
-                TTS.req_access = null
-                TTS.req_one_access = src.electronics.conf_access
-            else
-                TTS.req_access = src.electronics.conf_access
-            TTS.req_access_dir = src.electronics.dir_access
-            TTS.access_not_dir = src.electronics.access_nodir
+			if(src.electronics.one_access)
+				TTS.req_access = null
+				TTS.req_one_access = src.electronics.conf_access
+			else
+				TTS.req_access = src.electronics.conf_access
+			TTS.req_access_dir = src.electronics.dir_access
+			TTS.access_not_dir = src.electronics.access_nodir
 
-            qdel(src)
-        return 1
-    if(istype(W,/obj/item/weapon/circuitboard/airlock))
-        if(electronics)
-            to_chat(user, "<span class='warning'>There is already a [electronics] in this!</span>")
-        var/obj/item/weapon/circuitboard/airlock/C = W
-        to_chat(user, "You add the [C] to the [src].")
-        C.forceMove(src)
-        electronics = C
-    if(iscrowbar(W) && electronics)
-        to_chat(user, "<span class='notice'>You pry the [electronics] out.</span>")
-        W.playtoolsound(src, 50)
-        electronics.forceMove(get_turf(src))
-        user.put_in_hands(electronics)
-        electronics = null
-    if(W.is_wrench(user))
-        to_chat(user, "<span class='notice'>You [anchored ? "unanchor" : "anchor"] \the [src].</span>")
-        W.playtoolsound(src, 50)
-        anchored = !anchored
-    if(iswelder(W))
-        if(electronics)
-            to_chat(user, "<span class='warning'>Remove the [electronics] first!</span>")
-            return 1
-        var/obj/item/tool/weldingtool/WT = W
-        to_chat(user, "<span class='notice'>You begin to dismantle \the [src]...</span>")
-        if(WT.do_weld(user, src, 4 SECONDS))
-            to_chat(user, "<span class='notice'>You dismantle \the [src].</span>")
-            new /obj/item/stack/sheet/metal(get_turf(src), 5)
-            qdel(src)
-        return 1
+			qdel(src)
+		return 1
+	if(istype(W,/obj/item/weapon/circuitboard/airlock))
+		if(electronics)
+			to_chat(user, "<span class='warning'>There is already a [electronics] in this!</span>")
+		var/obj/item/weapon/circuitboard/airlock/C = W
+		if(user.drop_item(C,src))
+			to_chat(user, "You add the [C] to the [src].")
+			electronics = C
+	if(iscrowbar(W) && electronics)
+		to_chat(user, "<span class='notice'>You pry the [electronics] out.</span>")
+		W.playtoolsound(src, 50)
+		electronics.forceMove(get_turf(src))
+		user.put_in_hands(electronics)
+		electronics = null
+	if(W.is_wrench(user))
+		to_chat(user, "<span class='notice'>You [anchored ? "unanchor" : "anchor"] \the [src].</span>")
+		W.playtoolsound(src, 50)
+		anchored = !anchored
+	if(iswelder(W))
+		if(electronics)
+			to_chat(user, "<span class='warning'>Remove the [electronics] first!</span>")
+			return 1
+		var/obj/item/tool/weldingtool/WT = W
+		to_chat(user, "<span class='notice'>You begin to dismantle \the [src]...</span>")
+		if(WT.do_weld(user, src, 4 SECONDS))
+			to_chat(user, "<span class='notice'>You dismantle \the [src].</span>")
+			new /obj/item/stack/sheet/metal(get_turf(src), 5)
+			qdel(src)
+		return 1
 
 /obj/structure/transit_tube_frame/pod
     name = "transit pod frame"
@@ -133,45 +133,46 @@
     var/obj/item/weapon/circuitboard/mecha/transitpod/circuitry = null
 
 /obj/structure/transit_tube_frame/pod/attackby(obj/item/W as obj, mob/user as mob)
-    if(istype(W,/obj/item/stack/sheet/glass/rglass) && circuitry)
-        var/obj/item/stack/sheet/glass/rglass/G = W
-        playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
-        to_chat(user, "<span class='notice'>You begin to add reinforced glass to \the [src]...</span>")
-        if(G.amount < 2)
-            to_chat(user, "<span class='warning'>You need 2 sheets of glass to do this.</span>")
-            return 1
-        if(do_after(user, src, 4 SECONDS))
-            if(G.amount < 2) //User being tricky
-                return 1
-            G.use(2)
-            to_chat(user, "<span class='notice'>You add the reinforced glass to the [src].</span>")
-            new /obj/structure/transit_tube(loc, dir_icon_states[dir])
-            qdel(src)
-        return 1
-    if(istype(W,/obj/item/weapon/circuitboard/mecha/transitpod))
-        if(circuitry)
-            to_chat(user, "<span class='warning'>There is already a [circuitry] in this!</span>")
-        var/obj/item/weapon/circuitboard/mecha/transitpod/C = W
-        to_chat(user, "You add the [C] to the [src].")
-        C.forceMove(src)
-        circuitry = C
-    if(iscrowbar(W) && circuitry)
-        to_chat(user, "<span class='notice'>You pry the [circuitry] out.</span>")
-        W.playtoolsound(src, 50)
-        circuitry.forceMove(get_turf(src))
-        user.put_in_hands(circuitry)
-        circuitry = null
-    if(iswelder(W))
-        if(circuitry)
-            to_chat(user, "<span class='warning'>Remove the [circuitry] first!</span>")
-            return 1
-        var/obj/item/tool/weldingtool/WT = W
-        to_chat(user, "<span class='notice'>You begin to dismantle \the [src]...</span>")
-        if(WT.do_weld(user, src, 4 SECONDS))
-            to_chat(user, "<span class='notice'>You dismantle \the [src].</span>")
-            new /obj/item/stack/sheet/metal(get_turf(src), 5)
-            qdel(src)
-        return 1
+	if(istype(W,/obj/item/stack/sheet/glass/rglass) && circuitry)
+		var/obj/item/stack/sheet/glass/rglass/G = W
+		playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
+		to_chat(user, "<span class='notice'>You begin to add reinforced glass to \the [src]...</span>")
+		if(G.amount < 2)
+			to_chat(user, "<span class='warning'>You need 2 sheets of glass to do this.</span>")
+			return 1
+		if(do_after(user, src, 4 SECONDS))
+			if(G.amount < 2) //User being tricky
+				return 1
+			G.use(2)
+			to_chat(user, "<span class='notice'>You add the reinforced glass to the [src].</span>")
+			var/obj/structure/transit_tube_pod/TTP = new /obj/structure/transit_tube_pod(loc)
+			TTP.dir = src.dir
+			qdel(src)
+		return 1
+	if(istype(W,/obj/item/weapon/circuitboard/mecha/transitpod))
+		if(circuitry)
+			to_chat(user, "<span class='warning'>There is already a [circuitry] in this!</span>")
+		var/obj/item/weapon/circuitboard/mecha/transitpod/C = W
+		if(user.drop_item(C,src))
+			to_chat(user, "You add the [C] to the [src].")
+			circuitry = C
+	if(iscrowbar(W) && circuitry)
+		to_chat(user, "<span class='notice'>You pry the [circuitry] out.</span>")
+		W.playtoolsound(src, 50)
+		circuitry.forceMove(get_turf(src))
+		user.put_in_hands(circuitry)
+		circuitry = null
+	if(iswelder(W))
+		if(circuitry)
+			to_chat(user, "<span class='warning'>Remove the [circuitry] first!</span>")
+			return 1
+		var/obj/item/tool/weldingtool/WT = W
+		to_chat(user, "<span class='notice'>You begin to dismantle \the [src]...</span>")
+		if(WT.do_weld(user, src, 4 SECONDS))
+			to_chat(user, "<span class='notice'>You dismantle \the [src].</span>")
+			new /obj/item/stack/sheet/metal(get_turf(src), 5)
+			qdel(src)
+		return 1
 
 /obj/item/weapon/circuitboard/mecha/transitpod
 	name = "Circuit board (Transit tube pod)"


### PR DESCRIPTION
[bugfix]
Closes #32378.

:cl:
 * bugfix: Transit tubes can no longer only be constructed in their default position.
 * bugfix: Transit tube stations now have visible icons when constructed.
 * bugfix: Transit tube stations and pods now move the circuitry inside themselves from the user's hand during construction.
 * bugfix: Transit tube pods now retain the direction they were constructed with.
 * bugfix: Transit tube stations can now be deconstructed.