### PR TITLE
Bicaridine's and Inaprovaline's bleeding slowdown now stacks.

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -212,7 +212,10 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 	if(reagents.has_reagent(HYPERZINE)) //Hyperzine is an anti-coagulant :^)
 		blood_factor += 0.3
 
-	if(reagents.has_reagent(INAPROVALINE) || reagents.has_reagent(BICARIDINE)) //Inaprov and Bicard slow bleeding, but do not stack
+	if(reagents.has_reagent(INAPROVALINE)) //Inaprov and Bicard slow bleeding, and stack
+		blood_factor -= 0.3
+		
+	if(reagents.has_reagent(BICARIDINE))
 		blood_factor -= 0.3
 		
 	if(reagents.has_reagent(CLOTTING_AGENT) || reagents.has_reagent(BIOFOAM)) //Clotting agent and biofoam stop bleeding entirely


### PR DESCRIPTION
Something I suggested in #32404 that I wanna see.
Consuming both Bicaridine and Inaprovaline now slows down bleeding by 60% (30%+30%) instead of only 30%.
[tweak]
:cl:
 * tweak: Bicaridine and Inaprovaline slower bleeding effect stack with each other.