### PR TITLE
Makes heavy disintegrator discounted for greys

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -546,7 +546,9 @@ var/list/uplink_items = list()
 	name = "Heavy Disintegrator"
 	desc = "A powerful military issue alien laser weapon. It has a primary firing mode capable of incapacitating most unarmored targets in three shots, and a secondary mode capable of instantaneously inducing nausea and vomiting."
 	item = /obj/item/weapon/gun/energy/heavydisintegrator
-	cost = 16
+	cost = 20
+	discounted_cost = 14
+	jobs_with_discount = list("Grey")
 
 // IMPLANTS
 // Any Syndicate item that gets implanted into the body goes here

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -546,9 +546,8 @@ var/list/uplink_items = list()
 	name = "Heavy Disintegrator"
 	desc = "A powerful military issue alien laser weapon. It has a primary firing mode capable of incapacitating most unarmored targets in three shots, and a secondary mode capable of instantaneously inducing nausea and vomiting."
 	item = /obj/item/weapon/gun/energy/heavydisintegrator
-	cost = 20
-	discounted_cost = 14
-	jobs_with_discount = list("Grey")
+	cost = 16
+	jobs_exclusive = list("Grey")
 
 // IMPLANTS
 // Any Syndicate item that gets implanted into the body goes here

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -546,8 +546,8 @@ var/list/uplink_items = list()
 	name = "Heavy Disintegrator"
 	desc = "A powerful military issue alien laser weapon. It has a primary firing mode capable of incapacitating most unarmored targets in three shots, and a secondary mode capable of instantaneously inducing nausea and vomiting."
 	item = /obj/item/weapon/gun/energy/heavydisintegrator
-	cost = 20
-	discounted_cost = 14
+	cost = 16
+	discounted_cost = 12
 	jobs_with_discount = list("Grey")
 
 // IMPLANTS

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -546,8 +546,9 @@ var/list/uplink_items = list()
 	name = "Heavy Disintegrator"
 	desc = "A powerful military issue alien laser weapon. It has a primary firing mode capable of incapacitating most unarmored targets in three shots, and a secondary mode capable of instantaneously inducing nausea and vomiting."
 	item = /obj/item/weapon/gun/energy/heavydisintegrator
-	cost = 16
-	jobs_exclusive = list("Grey")
+	cost = 20
+	discounted_cost = 14
+	jobs_with_discount = list("Grey")
 
 // IMPLANTS
 // Any Syndicate item that gets implanted into the body goes here


### PR DESCRIPTION
[tweak]
As suggested from #32466, 12 TC for greys.
Let me know if it should be tweaked.

:cl:
 * tweak: The heavy disintegrator traitor item is now cheaper for greys at 12 tc