### PR TITLE
Roundstart Blood Supply Nerf

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1952,6 +1952,8 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/blood/BMinus,
 					/obj/item/weapon/reagent_containers/blood/OPlus,
 					/obj/item/weapon/reagent_containers/blood/OMinus,
+					/obj/item/weapon/reagent_containers/blood/empty,
+					/obj/item/weapon/reagent_containers/blood/empty,
 					/obj/item/weapon/reagent_containers/blood/empty)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/medsec

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -295,7 +295,7 @@
 /obj/machinery/smartfridge/bloodbank/filled/New()
 	. = ..()
 
-	for(var/i = 0 to 4)
+	for(var/i = 0 to 2)
 		insert_item(new /obj/item/weapon/reagent_containers/blood/APlus(src))
 		insert_item(new /obj/item/weapon/reagent_containers/blood/AMinus(src))
 		insert_item(new /obj/item/weapon/reagent_containers/blood/BPlus(src))

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -300,6 +300,8 @@
 		insert_item(new /obj/item/weapon/reagent_containers/blood/AMinus(src))
 		insert_item(new /obj/item/weapon/reagent_containers/blood/BPlus(src))
 		insert_item(new /obj/item/weapon/reagent_containers/blood/BMinus(src))
+		insert_item(new /obj/item/weapon/reagent_containers/blood/ABPlus(src))
+		insert_item(new /obj/item/weapon/reagent_containers/blood/ABMinus(src))
 		insert_item(new /obj/item/weapon/reagent_containers/blood/OPlus(src))
 		insert_item(new /obj/item/weapon/reagent_containers/blood/OMinus(src))
 		insert_item(new /obj/item/weapon/reagent_containers/blood/empty(src))

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -300,10 +300,9 @@
 		insert_item(new /obj/item/weapon/reagent_containers/blood/AMinus(src))
 		insert_item(new /obj/item/weapon/reagent_containers/blood/BPlus(src))
 		insert_item(new /obj/item/weapon/reagent_containers/blood/BMinus(src))
-		insert_item(new /obj/item/weapon/reagent_containers/blood/ABPlus(src))
-		insert_item(new /obj/item/weapon/reagent_containers/blood/ABMinus(src))
 		insert_item(new /obj/item/weapon/reagent_containers/blood/OPlus(src))
 		insert_item(new /obj/item/weapon/reagent_containers/blood/OMinus(src))
+	for(var/i = 0 to 5)
 		insert_item(new /obj/item/weapon/reagent_containers/blood/empty(src))
 
 /obj/machinery/smartfridge/bloodbank/power_change()

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -110,6 +110,12 @@
 /obj/item/weapon/reagent_containers/blood/BMinus
 	blood_type = "B-"
 
+/obj/item/weapon/reagent_containers/blood/ABPlus
+	blood_type = "AB+"
+
+/obj/item/weapon/reagent_containers/blood/ABMinus
+	blood_type = "AB-"
+
 /obj/item/weapon/reagent_containers/blood/OPlus
 	blood_type = "O+"
 


### PR DESCRIPTION
Currently, there is already more than enough blood at roundstart in the refrigerated blood bank for most rounds, so much so that you can usually get away with using the O packs regardless of the patient's blood type. This reduces the quantity of packs of each type of blood from 5 to 3. That way doctors will be more incentivized to consider which type of blood to use rather than liberally using the O packs, and have blood drives and use Dr. Acula bots. This also increases the number of empty packs in the refrigerated blood bank from 5 to 6, and in the bloodbag supply crate from 1 to 3.

~~This adds AB+ and AB- blood packs to the Refrigerated Blood Banks. Indeed it is the least useful type of blood for transfusions but it seems like it was missing. Since this would increase the total amount of roundstart filled blood packs from 30 to 40, I also decreased the amount of each type of blood pack. There is already more than enough blood for most rounds though, so I figured to make the blood supply more relevant I nerfed it somewhat to have 3 packs per type, rather than the current 5. That way doctors will be more incentivized to have blood drives and use Dr. Acula bots and consider which type of blood to use rather than liberally using the O packs.~~

[tweak]

:cl:
 * tweak: Refrigerated blood banks are now stocked with fewer full blood packs in total.
 * tweak: Empty blood packs are easier to come by.
