### PR TITLE
Adds beekeeping attire to hydroponics lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -22,6 +22,7 @@
 		pick(
 			/obj/item/clothing/under/rank/hydroponics,
 			/obj/item/clothing/under/rank/botany,
+			/obj/item/clothing/under/rank/beekeeper,
 		),
 		/obj/item/device/analyzer/plant_analyzer,
 		/obj/item/clothing/head/greenbandana,
@@ -29,4 +30,6 @@
 		/obj/item/weapon/hatchet,
 		/obj/item/weapon/bee_net,
 		/obj/item/weapon/storage/belt/botanist,
+		/obj/item/clothing/suit/bio_suit/beekeeping,
+		/obj/item/clothing/head/bio_hood/beekeeping,
 	)


### PR DESCRIPTION
Hydroponics lockers now have a chance of spawning the beekeeper's jumpsuit, and will always spawn with a beekeeping suit.

Inspired by watching a poor botanist who had no idea beekeeper suits existed die repeatedly to his bees.

[qol]
:cl:
 * rscadd: Hydroponics lockers now contain beekeeping gear
