### PR TITLE
Makes coins initialize with random orientation.

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -392,12 +392,13 @@
 	var/string_attached
 	var/material=MAT_IRON // Ore ID, used with coinbags.
 	var/credits = 0 // How many credits is this coin worth?
-	var/sideup = "heads." //heads, tails or on its side?
+	var/sideup = "heads-up." //heads, tails or on its side?
 
 /obj/item/weapon/coin/New()
 	. = ..()
 	pixel_x = rand(-8, 8) * PIXEL_MULTIPLIER
 	pixel_y = rand(-8, 0) * PIXEL_MULTIPLIER
+	sideup = pick("heads-up.","tails-up.")
 
 /obj/item/weapon/coin/recycle(var/datum/materials/rec)
 	if(material==null)


### PR DESCRIPTION
[tweak][consistency]
Currently, all coins start out "heads." When you flip or throw a coin, it becomes either "heads-up.", "tails-up.", or "on the side!" This makes it so that each coin starts out randomly either "heads-up." or "tails-up." Dice are already randomly oriented to start, so this brings coins in line with that.

:cl:
 * tweak: A cosmic imbalance has been rectified with regard to the orientation of coins.
