### PR TITLE
Updated pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,6 @@
 <!--
-Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
-This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.
-
-Test your changes. PRs that do not compile will not be accepted.
-Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.
-
-Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.
-
-Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.
-
-It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.
+Pull requests must be atomic. Change one set of related things at a time.
+Test your changes. PRs that were not tested will not be accepted.
 
 == SELF LABELLING PRs ==
 You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
@@ -65,29 +56,30 @@ ui = "UI"
 vault = "Mapping (Vault :question:)"
 vote = "⛔ Requires Server Vote ⛔"
 wip = "WiP"
-
-== CHANGELOGS ==
-Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.
-
-For the keys you can use in an in-body changelog, they are the same as described in example.yml
-NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-
-Valid Prefixes:
-bugfix
-wip (For works in progress)
-tweak
-soundadd
-sounddel
-rscdel (general deleting of nice things)
-rscadd (general adding of nice things)
-imageadd
-imagedel
-spellcheck (typo fixes)
-experiment
-tgs (TG-ported fixes?)
-
-An example changelog is attached to this PR for your convenience:
 -->
+
+## What this does
+<!-- Describe here all changes included in the PR. -->
+<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
+
+## Why it's good
+<!-- Explain why you think these changes are good. -->
+
+## Changelog
+<!-- You can use multiple of the same prefix, and delete unneeded ones. Prefixes correspond to specific icons in the generated changelog. -->
+<!-- Changelogs should represent how a player might be affected by the changes, not a summary of the PR's contents. -->
+<!-- If the PR has little or no impact on how players experience the game then the entire Changelog section, including the heading and content, can be left out. -->
+<!-- NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end! -->
 :cl:
- * rscadd: Did stuff!
- * rscdel: did other stuff!
+ * rscadd: Added new thing.
+ * rscdel: Removed old thing.
+ * bugfix: Fixed a bug that caused something bad to happen.
+ * wip: Added new thing but it's not in its final form.
+ * tweak: Changed a 5 to a 6.
+ * soundadd: Added a new sound.
+ * sounddel: Removed an old sound.
+ * imageadd: Added new sprites.
+ * imagedel: Removed new sprites.
+ * spellcheck: Changed the names of things, fixed typos.
+ * experiment: Added an experimental something.
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,61 +2,7 @@
 Pull requests must be atomic. Change one set of related things at a time.
 Test your changes. PRs that were not tested will not be accepted.
 
-== SELF LABELLING PRs ==
-You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
-where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
-just ctrl+f the list or something. I know it's long.
-
-administration = "Logging / Administration"
-away = "Mapping (Away Mission :earth_africa:)"
-bagel = "Mapping (Bagel :o:)"
-box = "Mapping (Box :baby:)"
-bugfix = "Bug / Fix"
-bus = "Mapping (Bus :bus:)"
-byond = "T-Thanks BYOND"
-consistency = "Consistency Issue"
-controversial = "Controversial"
-deff = "Mapping (Deff :wastebasket:)"
-discussion = "Discussion"
-dnm = "✋ Do Not Merge ✋"
-easy = "Easy Fix"
-exploitable = "Exploitable"
-featureloss = "Feature Loss"
-featurerequest = "Feature Request"
-first = "good first issue"
-formatting = "Grammar / Formatting"
-gamemode = "Gameplay / Gamemode"
-gameplay = "Gameplay / Gamemode"
-general = "Mapping (General :world_map:)"
-goonchat = "Goonchat"
-grammar = "Grammar / Formatting"
-help = "help wanted"
-hotfix = "Hotfix"
-logging = "Logging / Administration"
-meta = "Mapping (Meta :no_mobile_phones:)"
-needspritework = "Needs Spritework"
-oversight = "Oversight"
-packed = "Mapping (Packed :package:)"
-parallax = "Parallax"
-qol = "❤️ Quality of Life ❤️"
-roid = "Mapping (Roidstation :pick:)"
-role = "Role Datums"
-roleissue = "Role Datums Issue"
-runtime = "Runtime Log"
-sanity = "Sanity / Ghosthands"
-snowmap = "Mapping (Snowmap ❄)"
-sound = "Sound"
-sprites = "Sprites"
-spriteworkdone = "Spritework Done Needs Coder"
-system = "System"
-taxi = "Mapping (Taxi :taxi:)"
-tested = "100%  tested"
-tweak = "Tweak"
-ui = "UI"
-vault = "Mapping (Vault :question:)"
-vote = "⛔ Requires Server Vote ⛔"
-wip = "WiP"
--->
+You can now self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
 
 ## What this does
 <!-- Describe here all changes included in the PR. -->
@@ -66,20 +12,13 @@ wip = "WiP"
 <!-- Explain why you think these changes are good. -->
 
 ## Changelog
-<!-- You can use multiple of the same prefix, and delete unneeded ones. Prefixes correspond to specific icons in the generated changelog. -->
-<!-- Changelogs should represent how a player might be affected by the changes, not a summary of the PR's contents. -->
-<!-- If the PR has little or no impact on how players experience the game then the entire Changelog section, including the heading and content, can be left out. -->
-<!-- NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end! -->
+<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
 :cl:
  * rscadd: Added new thing.
  * rscdel: Removed old thing.
  * bugfix: Fixed a bug that caused something bad to happen.
- * wip: Added new thing but it's not in its final form.
  * tweak: Changed a 5 to a 6.
- * soundadd: Added a new sound.
- * sounddel: Removed an old sound.
  * imageadd: Added new sprites.
  * imagedel: Removed new sprites.
- * spellcheck: Changed the names of things, fixed typos.
- * experiment: Added an experimental something.
+ * experiment: Added an experimental/work-in-progress something.
 


### PR DESCRIPTION
## What this does
Changed the GitHub pull request template to:
- Remove outdated information
- Reword and improve the explanations in the comments
- Add a section in which the contributor is expected to describe what their PR does
- Add a section in which the contributor is expected to explain why those changes are good in their opinion

## Why it's good
I think explaining where one is coming from when proposing changes to the game is always beneficial and generates healthy discussion, as opposed to presenting a raw statement of what's been changed and leaving the readers to figure out the author's intention for themselves.

These are examples of PRs with no explanation: #32515, #32401, 
