### PR TITLE
Changes and Additions to cargo orders

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -5,7 +5,7 @@
 //BIG NOTE: Don't add living things to crates, that's bad, it will break the shuttle.
 //NEW NOTE: Do NOT set the price of any crates below 7 points. Doing so allows infinite points.
 
-var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality","Engineering","Medical","Science","Hydroponics","Vending Machine packs")
+var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality","Engineering","Cargo","Medical","Science","Hydroponics","Vending Machine packs")
 
 /datum/supply_packs
 	var/name = null
@@ -64,35 +64,22 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containername = "label rolls crate"
 	group = "Supplies"
 
-/datum/supply_packs/internals
-	name = "Internals resupply"
-	contains = list(/obj/item/clothing/mask/gas,
-					/obj/item/clothing/mask/gas,
-					/obj/item/clothing/mask/gas,
-					/obj/item/weapon/tank/air,
-					/obj/item/weapon/tank/air,
-					/obj/item/weapon/tank/air)
-	cost = 10
-	containertype = /obj/structure/closet/crate/internals
-	containername = "internals crate"
-	group = "Supplies"
-
 /datum/supply_packs/evacuation
 	name = "Emergency equipment"
 	contains = list(/obj/item/weapon/storage/toolbox/emergency,
 					/obj/item/weapon/storage/toolbox/emergency,
-					/obj/item/clothing/suit/storage/hazardvest,
-					/obj/item/clothing/suit/storage/hazardvest,
+					/obj/item/inflatable/shelter,
+					/obj/item/inflatable/shelter,
 					/obj/item/weapon/tank/emergency_oxygen,
 					/obj/item/weapon/tank/emergency_oxygen,
 					/obj/item/weapon/tank/emergency_oxygen,
-					/obj/item/weapon/tank/emergency_oxygen,
-					/obj/item/weapon/tank/emergency_oxygen,
-					/obj/item/clothing/mask/gas,
-					/obj/item/clothing/mask/gas,
-					/obj/item/clothing/mask/gas,
-					/obj/item/clothing/mask/gas,
-					/obj/item/clothing/mask/gas,
+					/obj/item/weapon/tank/emergency_oxygen/engi,
+					/obj/item/weapon/tank/emergency_oxygen/engi,
+					/obj/item/clothing/mask/breath,
+					/obj/item/clothing/mask/breath,
+					/obj/item/clothing/mask/breath,
+					/obj/item/clothing/mask/breath,
+					/obj/item/clothing/mask/breath,
 					/obj/machinery/bot/floorbot,
 					/obj/machinery/bot/floorbot,
 					/obj/machinery/bot/medbot,
@@ -108,21 +95,20 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/janitor
 	name = "Janitorial supplies"
 	contains = list(/obj/item/weapon/reagent_containers/glass/bucket,
-					/obj/item/weapon/reagent_containers/glass/bucket,
-					/obj/item/weapon/reagent_containers/glass/bucket,
+					/obj/item/weapon/reagent_containers/glass/bottle/bleach,
+					/obj/item/weapon/soap,
 					/obj/item/weapon/mop,
 					/obj/item/weapon/caution,
 					/obj/item/weapon/caution,
 					/obj/item/weapon/caution,
 					/obj/item/weapon/storage/bag/trash,
 					/obj/item/weapon/reagent_containers/spray/cleaner,
-					/obj/item/weapon/reagent_containers/glass/rag,
 					/obj/item/weapon/grenade/chem_grenade/cleaner,
 					/obj/item/weapon/grenade/chem_grenade/cleaner,
 					/obj/item/weapon/grenade/chem_grenade/cleaner,
 					/obj/item/weapon/storage/box/mousetraps,
 					/obj/structure/mopbucket)
-	cost = 10
+	cost = 20
 	containertype = /obj/structure/closet/crate/basic
 	containername = "janitorial supplies crate"
 	group = "Supplies"
@@ -162,32 +148,6 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 10
 	containertype = /obj/structure/closet/crate/basic
 	containername = "newscaster crate"
-	group = "Supplies"
-
-/datum/supply_packs/mule
-	name = "MULEbot"
-	contains = list(/obj/machinery/bot/mulebot)
-	cost = 20
-	containertype = /obj/structure/largecrate/mule
-	containername = "\improper MULEbot crate"
-	group = "Supplies"
-
-/datum/supply_packs/tractor
-	name = "Tractor"
-	contains = list(/obj/structure/bed/chair/vehicle/tractor,
-					/obj/machinery/cart/cargo)
-	cost = 40
-	containertype = /obj/structure/largecrate
-	containername = "tractor crate"
-	group = "Supplies"
-
-/datum/supply_packs/carts
-	name = "Carts"
-	contains = list(/obj/machinery/cart/cargo,
-                    /obj/machinery/cart/cargo)
-	cost = 15
-	containertype = /obj/structure/largecrate
-	containername = "carts crate"
 	group = "Supplies"
 
 /datum/supply_packs/porcelain
@@ -318,26 +278,6 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Supplies"
 	one_access = list(access_engine_minor, access_science)
 
-/datum/supply_packs/mining
-	name = "Mining equipment"
-	contains = list(/obj/item/weapon/pickaxe/drill,
-					/obj/item/weapon/pickaxe,
-					/obj/item/weapon/pickaxe,
-					/obj/item/device/flashlight/lantern,
-					/obj/item/device/flashlight/lantern,
-					/obj/item/device/flashlight/lantern,
-					/obj/item/device/mining_scanner,
-					/obj/item/weapon/storage/bag/ore,
-					/obj/item/weapon/storage/bag/ore,
-					/obj/item/weapon/storage/bag/ore,
-					/obj/item/weapon/storage/bag/money,
-					/obj/item/weapon/storage/bag/money)
-	cost = 20
-	containertype = /obj/structure/closet/crate/basic
-	containername = "mining equipment crate"
-	access = list(access_mining)
-	group = "Supplies"
-
 /datum/supply_packs/firefighting
 	name = "Firefighting equipment"
 	contains = list(/obj/item/clothing/suit/fire/firefighter,
@@ -360,7 +300,6 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	/obj/item/device/camera_film,
 	/obj/item/device/camera_film,
 	/obj/item/weapon/storage/photo_album,
-	/obj/item/stack/package_wrap,
 	/obj/item/weapon/reagent_containers/glass/paint/red,
 	/obj/item/weapon/reagent_containers/glass/paint/green,
 	/obj/item/weapon/reagent_containers/glass/paint/blue,
@@ -693,32 +632,34 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/space_suits
 	name = "Space suit"
 	contains = list(/obj/item/clothing/suit/space,
-					/obj/item/clothing/head/helmet/space)
-	cost = 200
+					/obj/item/clothing/head/helmet/space,
+					/obj/item/weapon/tank/oxygen,
+					/obj/item/clothing/mask/breath)
+	cost = 100
 	containertype = /obj/structure/closet/crate/basic
 	containername = "space suit crate"
 	group = "Clothing"
 
 /datum/supply_packs/vox_supply
-	name = "Vox supplies"
+	name = "Vox pressure suit"
 	contains = list(/obj/item/clothing/suit/space/vox/civ,
 					/obj/item/clothing/head/helmet/space/vox/civ,
 					/obj/item/weapon/tank/nitrogen,
 					/obj/item/clothing/mask/breath/vox)
 	cost = 100
 	containertype = /obj/structure/closet/crate/basic
-	containername = "vox supplies crate"
+	containername = "vox suit crate"
 	group = "Clothing"
 
 /datum/supply_packs/plasmaman_supply
-	name = "Plasmaman supplies"
+	name = "Plasmaman suit"
 	contains = list(/obj/item/clothing/suit/space/plasmaman,
 					/obj/item/clothing/head/helmet/space/plasmaman,
 					/obj/item/weapon/tank/plasma/plasmaman,
 					/obj/item/clothing/mask/breath)
 	cost = 100
 	containertype = /obj/structure/closet/crate/basic
-	containername = "plasmaman supplies crate"
+	containername = "plasmaman suit crate"
 	group = "Clothing"
 
 /datum/supply_packs/grey_supply
@@ -1049,9 +990,9 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/shield/riot,
 					/obj/item/weapon/shield/riot,
 					/obj/item/weapon/shield/riot,
-					/obj/item/weapon/storage/box/flashbangs,
-					/obj/item/weapon/storage/box/flashbangs,
-					/obj/item/weapon/storage/box/flashbangs,
+					/obj/item/weapon/grenade/chem_grenade/teargas,
+					/obj/item/weapon/grenade/chem_grenade/teargas,
+					/obj/item/weapon/grenade/chem_grenade/teargas,
 					/obj/item/weapon/handcuffs,
 					/obj/item/weapon/handcuffs,
 					/obj/item/weapon/handcuffs,
@@ -1777,24 +1718,6 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Engineering"
 	access = list(access_engine_minor)
 
-/datum/supply_packs/rcs_device
-	name = "Rapid-Crate-Sender"
-	contains = list (/obj/item/weapon/rcs)
-	cost = 80
-	containertype = /obj/structure/closet/crate/engi
-	containername = "\improper RCS crate"
-	group = "Engineering"
-
-/datum/supply_packs/rcs_telepad
-	name = "Cargo telepads"
-	contains = list (/obj/item/device/telepad_beacon,
-					 /obj/item/device/telepad_beacon,
-					 /obj/item/device/telepad_beacon)
-	cost = 80
-	containertype = /obj/structure/closet/crate/engi
-	containername = "\improper RCS telepad crate"
-	group = "Engineering"
-
 /datum/supply_packs/inflatables
 	name = "Inflatable structures pack"
 	contains = list (/obj/item/weapon/storage/box/inflatables,
@@ -1843,24 +1766,6 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containername = "secure shuttle permit crate"
 	group = "Engineering"
 
-/datum/supply_packs/suit_modification_station
-	name = "Suit modification station"
-	contains = list()
-	cost = 200
-	containertype = /obj/structure/closet/crate/flatpack/suit_modifier
-	group = "Engineering"
-
-/datum/supply_packs/hardsuit_frames
-	name = "Hardsuit frames"
-	contains = list(/obj/item/device/rigframe,
-					/obj/item/device/rigframe,
-					/obj/item/device/rigframe)
-	cost = 200
-	containertype = /obj/structure/closet/crate/secure/scisec
-	access = list(access_robotics)
-	containername = "hardsuit frame crate"
-	group = "Engineering"
-
 /datum/supply_packs/gourmonger
 	name = "Dehydrated gourmonger"
 	contains = list(/obj/item/weapon/reagent_containers/food/snacks/monkeycube/gourmonger)
@@ -1870,6 +1775,77 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	access = list(access_engine_minor)
 	group = "Engineering"
 
+
+//////CARGO//////
+
+/datum/supply_packs/mule
+	name = "MULEbot"
+	contains = list(/obj/machinery/bot/mulebot)
+	cost = 20
+	containertype = /obj/structure/largecrate/mule
+	containername = "\improper MULEbot crate"
+	group = "Cargo"
+
+/datum/supply_packs/tractor
+	name = "Tractor"
+	contains = list(/obj/structure/bed/chair/vehicle/tractor,
+					/obj/machinery/cart/cargo)
+	cost = 40
+	containertype = /obj/structure/largecrate
+	containername = "tractor crate"
+	group = "Cargo"
+
+/datum/supply_packs/carts
+	name = "Carts"
+	contains = list(/obj/machinery/cart/cargo,
+                    /obj/machinery/cart/cargo)
+	cost = 15
+	containertype = /obj/structure/largecrate
+	containername = "carts crate"
+	group = "Cargo"
+
+/datum/supply_packs/mining
+	name = "Mining equipment"
+	contains = list(/obj/item/weapon/pickaxe/drill,
+					/obj/item/weapon/pickaxe,
+					/obj/item/weapon/pickaxe/shovel,
+					/obj/item/weapon/pickaxe/shovel,
+					/obj/item/device/flashlight/lantern,
+					/obj/item/device/flashlight/lantern,
+					/obj/item/device/flashlight/lantern,
+					/obj/item/weapon/storage/belt/mining,
+					/obj/item/weapon/storage/belt/mining,
+					/obj/item/device/mining_scanner,
+					/obj/item/device/mining_scanner,
+					/obj/item/weapon/storage/bag/ore,
+					/obj/item/weapon/storage/bag/ore,
+					/obj/item/clothing/glasses/scanner/meson,
+					/obj/item/clothing/glasses/scanner/meson,
+					/obj/item/weapon/storage/bag/money)
+	cost = 30
+	containertype = /obj/structure/closet/crate/basic
+	containername = "mining equipment crate"
+	access = list(access_mining)
+	group = "Cargo"
+
+/datum/supply_packs/rcs_device
+	name = "Rapid-Crate-Sender"
+	contains = list (/obj/item/weapon/rcs)
+	cost = 80
+	containertype = /obj/structure/closet/crate/engi
+	containername = "\improper RCS crate"
+	group = "Cargo"
+
+/datum/supply_packs/rcs_telepad
+	name = "Cargo telepads"
+	contains = list (/obj/item/device/telepad_beacon,
+					 /obj/item/device/telepad_beacon,
+					 /obj/item/device/telepad_beacon)
+	cost = 80
+	containertype = /obj/structure/closet/crate/engi
+	containername = "\improper RCS telepad crate"
+	group = "Cargo"
+
 /datum/supply_packs/automation
 	name = "Automation supplies"
 	contains = list(/obj/item/weapon/circuitboard/wrapping_machine,
@@ -1878,8 +1854,20 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/circuitboard/crate_closer)
 	cost = 25
 	containertype = /obj/structure/closet/crate/engi
-	containername = "Automation Supplies Crate"
-	group = "Engineering"
+	containername = "automation supplies crate"
+	group = "Cargo"
+
+/datum/supply_packs/package_wrap
+	name = "Package Wrap"
+	contains = list(/obj/item/stack/package_wrap,
+                    /obj/item/stack/package_wrap,
+                    /obj/item/stack/package_wrap,
+                    /obj/item/stack/package_wrap,)
+	cost = 10
+	containertype = /obj/structure/closet/crate/basic
+	containername = "package wrap crate"
+	group = "Cargo"
+
 
 //////MEDICAL//////
 
@@ -2187,6 +2175,24 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 50
 	containertype = /obj/structure/largecrate/anomaly_container
 	containername = "anomaly container crate"
+	group = "Science"
+
+/datum/supply_packs/suit_modification_station
+	name = "Suit modification station"
+	contains = list()
+	cost = 200
+	containertype = /obj/structure/closet/crate/flatpack/suit_modifier
+	group = "Science"
+
+/datum/supply_packs/hardsuit_frames
+	name = "Hardsuit frames"
+	contains = list(/obj/item/device/rigframe,
+					/obj/item/device/rigframe,
+					/obj/item/device/rigframe)
+	cost = 200
+	containertype = /obj/structure/closet/crate/secure/scisec
+	access = list(access_robotics)
+	containername = "hardsuit frame crate"
 	group = "Science"
 
 
@@ -2594,15 +2600,23 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 
 /datum/supply_packs/sovietmachines
 	name = "Old and Forgotten stack of packs"
-	contains = list(/obj/structure/vendomatpack/sovietsoda,
-					/obj/structure/vendomatpack/sovietsoda,
-					/obj/structure/vendomatpack/nazivend,
+	contains = list(/obj/structure/vendomatpack/nazivend,
 					/obj/structure/vendomatpack/sovietvend)
 	cost = 20
 	containertype = /obj/structure/stackopacks
 	containername = "Old and Forgotten stack of packs"
 	group = "Vending Machine packs"
 	hidden = 1
+
+/datum/supply_packs/sovietsoadas
+	name = "Russian Beverage stack of packs"
+	contains = list(/obj/structure/vendomatpack/sovietsoda,
+					/obj/structure/vendomatpack/sovietsoda,)
+	cost = 10
+	containertype = /obj/structure/stackopacks
+	containername = "Russian Beverage stack of packs"
+	group = "Vending Machine packs"
+	contraband = 1
 
 /datum/supply_packs/magimachines
 	name = "Strange and Bright stack of packs"


### PR DESCRIPTION
Greetings, welcome to my first PR. For someone who's played a lot of Quartermaster I've familiarized myself with many of the cargo entries, and over time I've felt that it would be best to see some things changed, or new things implemented. However it was only until recently did I finally decide to figure out how all this works to try my hands at making some of these changes happen. 
To those inclined I present **Changes and Additions to cargo orders**

The first major change in this PR is the addition of a new category simply labeled _"Cargo"_. 

![cargo](https://user-images.githubusercontent.com/89323872/166511795-22f86dd1-a116-4c4b-a6d5-d6c103c3b0d9.PNG)

The cargo category was put in place to help thin out the ever bloated engineering category and better organize entries for ease of finding what you're looking for (which may ironically do the opposite for people used to the old layout).

Two entries; Suit modification station and Hardsuit frames were moved to the science category where I felt they were better suited (considering you get all your suit mods printed from science, and it's robotics that puts together your hardsuit frames, not engineering)

Several entries have had their contents changed, those entries being: Emergency equipment, Janitorial supplies, Riot gear, Mining equipment, Space suit, as well as name changes for the Vox supplies and Plasmaman supplies (named Vox pressure suit and Plasmaman suit respectively).

To elaborate into each of the changes, the Emergency Equipment Crate got two extended emergency airtanks (yellows) to replace a couple of the five emergency airtanks (small blues), the gasmasks were replaced with breath masks to restock any missing from lockers in an unlikely case, and had it's two hazard vests replaced with the currently irreplaceable emergency shelters. 
Janitorial supplies cut down on two buckets to make way for a bottle of bleach and a bar of soap, however with this change the rag was removed and the price was raised up to 20 credits. 
Riot gear has replaced the flashbangs with teargas grenades, because who's gonna be throwing flashbangs at rioters? 
Space suit crate now comes with an oxygen tank (big blue), a breath mask and has it's priced reduced down to 100 credits. This change was to match the now renamed Vox supplies and Plasmaman supplies that are both 100 credits, and come with a single breath mask and relevant air tank. Always thought it was weird a space suit crate is 200 and doesn't even come with magboots.
The mining equipment crate I didn't even realize we had until I added it to the cargo category, I changed it to be a two man supply crate with more of the miners essentials (mesrons, belts, shovels) keeping the extra lantern and removing one of the comically large money bags, since I figure you'll probably be buying this crate for the lanterns anyhow.
Finally, to finish the changes to existing cargo entries, I removed the **BODA** vendomat packs from the Old and Forgotten stack of packs, and removed the wrapping paper from the Art supply crate, which leads us perfectly into our _new entries_. 

New entries include wrapping paper supply, as seen in the cargo category and Russian Beverage stack of packs which can be found in the Vending Machine Packs category on a hacked cargo console (soldering iron).
The wrapping paper crate comes with four rolls of wrapping paper, which I think is about 92 uses? Mostly useful if you play on packed and wanna pass things over the desk.
The Russian Beverage stack of packs is to finally fully realize my goal of closing this PR I made ages ago, on behalf of the  ASWDC (Ayy Soda Water Drinker Coalition). #https://github.com/vgstation-coders/vgstation13/issues/31535

The final change was the removal of the internals resupply crate, which I remember audibly laughing at, thinking about how nobody has probably ever ordered that crate besides out of pure curiosity. I originally wanted to change it to have a single oxygen dispenser inside of it, but I couldn't figure how to get it to come out of it's crate unwrenched. A second idea I had for it was for the resupply crate to actually be a resupply for each species air type (Oxygen, Plasma, Nitrogen) but I thought it a better idea to save it for another PR with perhaps a better name for the entry.

So yeah, originally I wanted to add more entries for things you couldn't normally get more of, like an office supply crate you could get pens and folders from, crate full of portable scrubbers and pumps, a crate full of a heaters and coolers, but I figured these changes were already plentiful enough, and I could save it for a brand spanking new PR with some suggestions from other players, so please leave 'em, and also take a look and make sure I didn't fuck anything up for my first PR, thanks.

<tweak> <balance>

:cl:
* tweak: Changes and additions to several of the cargo ordering consoles' stock
* rscadd: Added new category to cargo ordering console as well as a couple new entries
* rscdel: Removed internals resupply crate
