### PR TITLE
Changes Cargo Requests Reason to Reason/Destination

### DIFF
--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -5,7 +5,7 @@
 #define SUPPLY_DOCKZ 2          //Z-level of the Dock.
 #define SUPPLY_STATIONZ 1       //Z-level of the Station.
 
-#define REASON_LEN 140 // max length for reason message, nanoui appears to not like long strings.
+#define DESTINATION_LEN 140 // max length for destination message, nanoui appears to not like long strings.
 
 #define CENTCOMM_ORDER_DELAY_MIN (20 MINUTES)
 #define CENTCOMM_ORDER_DELAY_MAX (40 MINUTES)

--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -5,7 +5,7 @@
 #define SUPPLY_DOCKZ 2          //Z-level of the Dock.
 #define SUPPLY_STATIONZ 1       //Z-level of the Station.
 
-#define DESTINATION_LEN 140 // max length for destination message, nanoui appears to not like long strings.
+#define REASON_LEN 140 // max length for reason message, nanoui appears to not like long strings.
 
 #define CENTCOMM_ORDER_DELAY_MIN (20 MINUTES)
 #define CENTCOMM_ORDER_DELAY_MAX (40 MINUTES)

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -412,7 +412,7 @@ For vending packs, see vending_packs.dm*/
 			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
 			return
 		var/timeout = world.time + 600
-		var/destination = stripped_input(usr,"Where would you like this item sent/who would you like cargo to call when it arrives?","Destination:","",DESTINATION_LEN)
+		var/reason = stripped_input(usr,"Destination:","Where would you like this item sent/who would you like cargo to call when it arrives?","",REASON_LEN)
 		if(world.time > timeout)
 			return
 		if(!destination)
@@ -650,7 +650,7 @@ For vending packs, see vending_packs.dm*/
 			var/max_crates = round((account.money - total_money_req) / P.cost)
 			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
 			return
-		var/destination = stripped_input(usr,"Where would you like this item sent/who would you like cargo to call when it arrives?","Destination:","",DESTINATION_LEN)
+		var/reason = stripped_input(usr,"Destination:","Where would you like this item sent/who would you like cargo to call when it arrives?","",REASON_LEN)
 		if(world.time > timeout)
 			return
 		if(!destination)

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -412,7 +412,7 @@ For vending packs, see vending_packs.dm*/
 			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
 			return
 		var/timeout = world.time + 600
-		var/reason = stripped_input(usr,"Destination:","Where would you like this item sent/who would you like cargo to call when it arrives?","",REASON_LEN)
+		var/destination = stripped_input(usr,"Where would you like this item sent/who would you like cargo to call when it arrives?","Destination:","",DESTINATION_LEN)
 		if(world.time > timeout)
 			return
 		if(!destination)
@@ -650,7 +650,7 @@ For vending packs, see vending_packs.dm*/
 			var/max_crates = round((account.money - total_money_req) / P.cost)
 			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
 			return
-		var/reason = stripped_input(usr,"Destination:","Where would you like this item sent/who would you like cargo to call when it arrives?","",REASON_LEN)
+		var/destination = stripped_input(usr,"Where would you like this item sent/who would you like cargo to call when it arrives?","Destination:","",DESTINATION_LEN)
 		if(world.time > timeout)
 			return
 		if(!destination)

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -86,7 +86,7 @@ For vending packs, see vending_packs.dm*/
 #undef MENTION_DB_OFFLINE
 #undef USE_ACCOUNT_ON_ID
 
-/obj/item/weapon/paper/request_form/New(var/loc, var/list/account_information, var/datum/supply_packs/pack, var/number_of_crates, var/reason = "No destination provided.")
+/obj/item/weapon/paper/request_form/New(var/loc, var/list/account_information, var/datum/supply_packs/pack, var/number_of_crates, var/destination = "No destination provided.")
 	. = ..(loc)
 	name = "[pack.name] Requisition Form - [account_information["idname"]], [account_information["idrank"]]"
 	info += {"<h3>[station_name] Supply Requisition Form</h3><hr>
@@ -96,7 +96,7 @@ For vending packs, see vending_packs.dm*/
 		info += "USING DEBIT AS: [account_information["authorized_name"]]<br>"
 
 	info+= {"RANK: [account_information["idrank"]]<br>
-		DESTINATION: [reason]<br>
+		DESTINATION: [destination]<br>
 		SUPPLY CRATE TYPE: [pack.name]<br>
 		NUMBER OF CRATES: [number_of_crates]<br>
 		ACCESS RESTRICTION: [get_access_desc(pack.access)]<br>
@@ -412,13 +412,13 @@ For vending packs, see vending_packs.dm*/
 			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
 			return
 		var/timeout = world.time + 600
-		var/reason = stripped_input(usr,"Where would you like this item sent/who would you like cargo to call when it arrives?","Destination:","",REASON_LEN)
+		var/destination = stripped_input(usr,"Where would you like this item sent/who would you like cargo to call when it arrives?","Destination:","",DESTINATION_LEN)
 		if(world.time > timeout)
 			return
-		if(!reason)
+		if(!destination)
 			return
 
-		new /obj/item/weapon/paper/request_form(loc, current_acct, P, crates, reason)
+		new /obj/item/weapon/paper/request_form(loc, current_acct, P, crates, destination)
 		reqtime = (world.time + 5) % 1e5
 		//make our supply_order datum
 		for(var/i = 1; i <= crates; i++)
@@ -429,7 +429,7 @@ For vending packs, see vending_packs.dm*/
 			O.orderedby = idname
 			O.authorized_name = current_acct["authorized_name"]
 			O.account = account
-			O.comment = reason
+			O.comment = destination
 
 			SSsupply_shuttle.requestlist += O
 
@@ -650,13 +650,13 @@ For vending packs, see vending_packs.dm*/
 			var/max_crates = round((account.money - total_money_req) / P.cost)
 			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
 			return
-		var/reason = stripped_input(usr,"Where would you like this item sent/who would you like cargo to call when it arrives?","Destination:","",REASON_LEN)
+		var/destination = stripped_input(usr,"Where would you like this item sent/who would you like cargo to call when it arrives?","Destination:","",DESTINATION_LEN)
 		if(world.time > timeout)
 			return
-		if(!reason)
+		if(!destination)
 			return
 
-		new /obj/item/weapon/paper/request_form(loc, current_acct, P, crates, reason)
+		new /obj/item/weapon/paper/request_form(loc, current_acct, P, crates, destination)
 		reqtime = (world.time + 5) % 1e5
 
 		//make our supply_order datum
@@ -668,7 +668,7 @@ For vending packs, see vending_packs.dm*/
 			O.orderedby = idname
 			O.authorized_name = current_acct["authorized_name"]
 			O.account = account
-			O.comment = reason
+			O.comment = destination
 			SSsupply_shuttle.requestlist += O
 			stat_collection.crates_ordered++
 

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -86,7 +86,7 @@ For vending packs, see vending_packs.dm*/
 #undef MENTION_DB_OFFLINE
 #undef USE_ACCOUNT_ON_ID
 
-/obj/item/weapon/paper/request_form/New(var/loc, var/list/account_information, var/datum/supply_packs/pack, var/number_of_crates, var/reason = "No destination provided.")
+/obj/item/weapon/paper/request_form/New(var/loc, var/list/account_information, var/datum/supply_packs/pack, var/number_of_crates, var/reason = "No reason provided.")
 	. = ..(loc)
 	name = "[pack.name] Requisition Form - [account_information["idname"]], [account_information["idrank"]]"
 	info += {"<h3>[station_name] Supply Requisition Form</h3><hr>
@@ -96,7 +96,7 @@ For vending packs, see vending_packs.dm*/
 		info += "USING DEBIT AS: [account_information["authorized_name"]]<br>"
 
 	info+= {"RANK: [account_information["idrank"]]<br>
-		DESTINATION: [reason]<br>
+		REASON: [reason]<br>
 		SUPPLY CRATE TYPE: [pack.name]<br>
 		NUMBER OF CRATES: [number_of_crates]<br>
 		ACCESS RESTRICTION: [get_access_desc(pack.access)]<br>
@@ -274,7 +274,7 @@ For vending packs, see vending_packs.dm*/
 		var/datum/supply_order/SO = set_name
 		if(SO)
 			if(!SO.comment)
-				SO.comment = "No destination provided."
+				SO.comment = "No reason provided."
 			requests_list.Add(list(list("ordernum" = SO.ordernum, "supply_type" = SO.object.name, "orderedby" = SO.orderedby, "authorized_name" = SO.authorized_name, "comment" = SO.comment, "command1" = list("confirmorder" = SO.ordernum), "command2" = list("rreq" = SO.ordernum))))
 	data["requests"] = requests_list
 

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -412,7 +412,7 @@ For vending packs, see vending_packs.dm*/
 			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
 			return
 		var/timeout = world.time + 600
-		var/reason = stripped_input(usr,"Where would you like this item sent/who would you like cargo to call when it arrives?","Destination:","",REASON_LEN)
+		var/reason = stripped_input(usr,"Why do you want this crate and where/to whom would you like it sent?","Reason/Destination:","",REASON_LEN)
 		if(world.time > timeout)
 			return
 		if(!reason)
@@ -650,7 +650,7 @@ For vending packs, see vending_packs.dm*/
 			var/max_crates = round((account.money - total_money_req) / P.cost)
 			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
 			return
-		var/reason = stripped_input(usr,"Where would you like this item sent/who would you like cargo to call when it arrives?","Destination:","",REASON_LEN)
+		var/reason = stripped_input(usr,"Why do you want this crate and where/to whom would you like it sent?","Reason/Destination:","",REASON_LEN)
 		if(world.time > timeout)
 			return
 		if(!reason)

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -86,7 +86,7 @@ For vending packs, see vending_packs.dm*/
 #undef MENTION_DB_OFFLINE
 #undef USE_ACCOUNT_ON_ID
 
-/obj/item/weapon/paper/request_form/New(var/loc, var/list/account_information, var/datum/supply_packs/pack, var/number_of_crates, var/destination = "No destination provided.")
+/obj/item/weapon/paper/request_form/New(var/loc, var/list/account_information, var/datum/supply_packs/pack, var/number_of_crates, var/reason = "No destination provided.")
 	. = ..(loc)
 	name = "[pack.name] Requisition Form - [account_information["idname"]], [account_information["idrank"]]"
 	info += {"<h3>[station_name] Supply Requisition Form</h3><hr>
@@ -96,7 +96,7 @@ For vending packs, see vending_packs.dm*/
 		info += "USING DEBIT AS: [account_information["authorized_name"]]<br>"
 
 	info+= {"RANK: [account_information["idrank"]]<br>
-		DESTINATION: [destination]<br>
+		DESTINATION: [reason]<br>
 		SUPPLY CRATE TYPE: [pack.name]<br>
 		NUMBER OF CRATES: [number_of_crates]<br>
 		ACCESS RESTRICTION: [get_access_desc(pack.access)]<br>
@@ -412,13 +412,13 @@ For vending packs, see vending_packs.dm*/
 			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
 			return
 		var/timeout = world.time + 600
-		var/destination = stripped_input(usr,"Where would you like this item sent/who would you like cargo to call when it arrives?","Destination:","",DESTINATION_LEN)
+		var/reason = stripped_input(usr,"Where would you like this item sent/who would you like cargo to call when it arrives?","Destination:","",REASON_LEN)
 		if(world.time > timeout)
 			return
-		if(!destination)
+		if(!reason)
 			return
 
-		new /obj/item/weapon/paper/request_form(loc, current_acct, P, crates, destination)
+		new /obj/item/weapon/paper/request_form(loc, current_acct, P, crates, reason)
 		reqtime = (world.time + 5) % 1e5
 		//make our supply_order datum
 		for(var/i = 1; i <= crates; i++)
@@ -429,7 +429,7 @@ For vending packs, see vending_packs.dm*/
 			O.orderedby = idname
 			O.authorized_name = current_acct["authorized_name"]
 			O.account = account
-			O.comment = destination
+			O.comment = reason
 
 			SSsupply_shuttle.requestlist += O
 
@@ -650,13 +650,13 @@ For vending packs, see vending_packs.dm*/
 			var/max_crates = round((account.money - total_money_req) / P.cost)
 			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
 			return
-		var/destination = stripped_input(usr,"Where would you like this item sent/who would you like cargo to call when it arrives?","Destination:","",DESTINATION_LEN)
+		var/reason = stripped_input(usr,"Where would you like this item sent/who would you like cargo to call when it arrives?","Destination:","",REASON_LEN)
 		if(world.time > timeout)
 			return
-		if(!destination)
+		if(!reason)
 			return
 
-		new /obj/item/weapon/paper/request_form(loc, current_acct, P, crates, destination)
+		new /obj/item/weapon/paper/request_form(loc, current_acct, P, crates, reason)
 		reqtime = (world.time + 5) % 1e5
 
 		//make our supply_order datum
@@ -668,7 +668,7 @@ For vending packs, see vending_packs.dm*/
 			O.orderedby = idname
 			O.authorized_name = current_acct["authorized_name"]
 			O.account = account
-			O.comment = destination
+			O.comment = reason
 			SSsupply_shuttle.requestlist += O
 			stat_collection.crates_ordered++
 

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -86,7 +86,7 @@ For vending packs, see vending_packs.dm*/
 #undef MENTION_DB_OFFLINE
 #undef USE_ACCOUNT_ON_ID
 
-/obj/item/weapon/paper/request_form/New(var/loc, var/list/account_information, var/datum/supply_packs/pack, var/number_of_crates, var/reason = "No reason provided.")
+/obj/item/weapon/paper/request_form/New(var/loc, var/list/account_information, var/datum/supply_packs/pack, var/number_of_crates, var/reason = "No destination provided.")
 	. = ..(loc)
 	name = "[pack.name] Requisition Form - [account_information["idname"]], [account_information["idrank"]]"
 	info += {"<h3>[station_name] Supply Requisition Form</h3><hr>
@@ -96,7 +96,7 @@ For vending packs, see vending_packs.dm*/
 		info += "USING DEBIT AS: [account_information["authorized_name"]]<br>"
 
 	info+= {"RANK: [account_information["idrank"]]<br>
-		REASON: [reason]<br>
+		DESTINATION: [reason]<br>
 		SUPPLY CRATE TYPE: [pack.name]<br>
 		NUMBER OF CRATES: [number_of_crates]<br>
 		ACCESS RESTRICTION: [get_access_desc(pack.access)]<br>
@@ -274,7 +274,7 @@ For vending packs, see vending_packs.dm*/
 		var/datum/supply_order/SO = set_name
 		if(SO)
 			if(!SO.comment)
-				SO.comment = "No reason provided."
+				SO.comment = "No destination provided."
 			requests_list.Add(list(list("ordernum" = SO.ordernum, "supply_type" = SO.object.name, "orderedby" = SO.orderedby, "authorized_name" = SO.authorized_name, "comment" = SO.comment, "command1" = list("confirmorder" = SO.ordernum), "command2" = list("rreq" = SO.ordernum))))
 	data["requests"] = requests_list
 
@@ -412,7 +412,7 @@ For vending packs, see vending_packs.dm*/
 			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
 			return
 		var/timeout = world.time + 600
-		var/reason = stripped_input(usr,"Reason:","Why do you require this item?","",REASON_LEN)
+		var/reason = stripped_input(usr,"Destination:","Where would you like this item sent/who would you like cargo to call when it arrives?","",REASON_LEN)
 		if(world.time > timeout)
 			return
 		if(!reason)
@@ -650,7 +650,7 @@ For vending packs, see vending_packs.dm*/
 			var/max_crates = round((account.money - total_money_req) / P.cost)
 			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
 			return
-		var/reason = stripped_input(usr,"Reason:","Why do you require this item?","",REASON_LEN)
+		var/reason = stripped_input(usr,"Destination:","Where would you like this item sent/who would you like cargo to call when it arrives?","",REASON_LEN)
 		if(world.time > timeout)
 			return
 		if(!reason)

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -412,7 +412,7 @@ For vending packs, see vending_packs.dm*/
 			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
 			return
 		var/timeout = world.time + 600
-		var/reason = stripped_input(usr,"Destination:","Where would you like this item sent/who would you like cargo to call when it arrives?","",REASON_LEN)
+		var/reason = stripped_input(usr,"Where would you like this item sent/who would you like cargo to call when it arrives?","Destination:","",REASON_LEN)
 		if(world.time > timeout)
 			return
 		if(!reason)
@@ -650,7 +650,7 @@ For vending packs, see vending_packs.dm*/
 			var/max_crates = round((account.money - total_money_req) / P.cost)
 			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
 			return
-		var/reason = stripped_input(usr,"Destination:","Where would you like this item sent/who would you like cargo to call when it arrives?","",REASON_LEN)
+		var/reason = stripped_input(usr,"Where would you like this item sent/who would you like cargo to call when it arrives?","Destination:","",REASON_LEN)
 		if(world.time > timeout)
 			return
 		if(!reason)


### PR DESCRIPTION
Have you ever made a cargo order, only to be baffled by it asking you WHY you wanted the crate? Who cares WHY you want the crate, you **WANT IT**! The bigger question, and one cargo staff ask frequently, is... _where_ do you want it?

~~This PR will replace the REASON code on crates with a DESTINATION code, helping poor cargo staff from trying to figure out where they need to send the crates labeled (a). It's not like Cargo Technician Billy cares about why you want 3 crates of shotguns, he just needs to know where to send it, because the QM already burned the paperwork.~~

This PR now changes the messaging on the computer to ask for both a REASON and DESTINATION on the same line. This helps fit server culture of putting the destination on the reason field line, but also keeps the culture of actually following the rules and putting a reason in the reason field.

![image](https://user-images.githubusercontent.com/69739118/167227010-674d5544-0ce4-4488-9a9e-cdc2fa65b87f.png)

Notes:
- This will not stop the non-readers from typing random stuff as the reason/destination. It only helps to mitigate it.
- ~~The variable will still be called "reason" because I'm not sure if changing the variable name will break things in other places in the code. A future PR can fix this, especially if folks want their reason codes back.~~ No longer relevant.

[tweak]
[ui]

:cl:
 * tweak: Cargo request computers now ask for a destination in addition to a reason, saving some time for cargo workers trying to send orders out to people who can read.
