### PR TITLE
Spider QoL

### DIFF
--- a/code/game/objects/effects/rooting_trap.dm
+++ b/code/game/objects/effects/rooting_trap.dm
@@ -33,8 +33,12 @@
 
 /obj/effect/rooting_trap/proc/stick_to(var/atom/A, var/side = null)
 	var/turf/T = get_turf(A)
-
-	if(isliving(A) && !isspace(T))//can't nail people down unless there's a turf to nail them to.
+	if(isspace(T)) //can't nail people down unless there's a turf to nail them to.
+		return FALSE
+	if(!isliving(A))
+		return FALSE
+	var/mob/living/M = A
+	if(M.stat < 2)
 		stuck_to = A
 		lock_atom(A, /datum/locking_category/buckle)
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -50,6 +50,7 @@
 	var/poison_per_bite = 5
 	var/poison_type = TOXIN
 	var/delimbable_icon = TRUE
+	var/health_regen_rate = 2
 	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_STRONG
 
 	//Spider aren't affected by atmos.
@@ -157,6 +158,8 @@
 /mob/living/simple_animal/hostile/giant_spider/Life()
 	if(timestopped)
 		return 0 //under effects of time magick
+	if(health > 0)
+		health = min(maxHealth, health_regen_rate + health)
 	. = ..()
 
 	regular_hud_updates()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -102,7 +102,7 @@
 
 // Checks pressure here vs. around us. Intended to make sure the spider doesn't breach to space while comfortable, or breach into a high pressure area
 /mob/living/simple_animal/hostile/giant_spider/proc/performPressureCheck(var/turf/curturf)
-	if(usr.client)
+	if(client)
 		return
 	if(!istype(curturf))
 		return 0

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -43,7 +43,6 @@
 	wander = 1
 	ranged = 0
 	//minimum_distance = 1
-	status_flags = CANPUSH
 	size = SIZE_SMALL //dog-sized spiders are still big!
 
 	var/icon_aggro = null // for swapping to when we get aggressive

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -158,7 +158,7 @@
 	if(timestopped)
 		return 0 //under effects of time magick
 	if (health == maxHealth)
-		return
+		return ..()
 	if (health > 0)
 		health = min(maxHealth, health_regen_rate + health)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -22,7 +22,7 @@
 	response_disarm = "gently pushes aside"
 	response_harm   = "stomps"
 	stop_automated_movement_when_pulled = 0
-	maxHealth = 200 // Was 75
+	maxHealth = 200
 	health = 200
 	melee_damage_lower = 15
 	melee_damage_upper = 20
@@ -43,6 +43,7 @@
 	wander = 1
 	ranged = 0
 	//minimum_distance = 1
+	status_flags = CANPUSH
 	size = SIZE_SMALL //dog-sized spiders are still big!
 
 	var/icon_aggro = null // for swapping to when we get aggressive
@@ -101,6 +102,8 @@
 
 // Checks pressure here vs. around us. Intended to make sure the spider doesn't breach to space while comfortable, or breach into a high pressure area
 /mob/living/simple_animal/hostile/giant_spider/proc/performPressureCheck(var/turf/curturf)
+	if(usr.client)
+		return
 	if(!istype(curturf))
 		return 0
 	var/datum/gas_mixture/myenv=curturf.return_air()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -157,7 +157,9 @@
 /mob/living/simple_animal/hostile/giant_spider/Life()
 	if(timestopped)
 		return 0 //under effects of time magick
-	if(health > 0)
+	if (health == maxHealth)
+		return
+	if (health > 0)
 		health = min(maxHealth, health_regen_rate + health)
 	. = ..()
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/spiderling.dm
@@ -31,7 +31,7 @@
 	a_intent = I_HELP
 	size = SIZE_TINY
 	//throw_message = "sinks in slowly, before being pushed out of "
-	//status_flags = CANPUSH
+	
 	search_objects = 0
 	wanted_objects = list(/obj/machinery/atmospherics/unary/vent_pump)
 	can_ventcrawl = TRUE


### PR DESCRIPTION
[qol][tweak][bugfix]

I made spider changes with this PR:
- Player controlled spiders can break glass from space and now no longer need to enter/exit through airlocks
- Added slight regen
- Potentially fixes the sticky ball. The issue was that it was using `isliving(A)` which refers to the mob type, rather than the status (`.stat`) which is `CONSCIOUS`, `UNCONSCIOUS`, or `DEAD`

Closes #32084, Closes #32170, Closes #31040, Closes #12364 as #29429 fixed it
:cl:
 * tweak: Human-controlled spiders can break windows from space and have minor regen
