### PR TITLE
Changes Cargo and Medical Job Preference Colors

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -6,7 +6,7 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	wage_payout = 65
-	selection_color = "#B27B30"
+	selection_color = "#CC9D5F"
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
 	minimal_access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
 	outfit_datum = /datum/outfit/qm
@@ -18,7 +18,7 @@
 	spawn_positions = 2
 	supervisors = "the quartermaster and the head of personnel"
 	wage_payout = 20
-	selection_color = "#B27B30"
+	selection_color = "#CEA773"
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
 	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
 	alt_titles = list("Mailman")
@@ -31,7 +31,7 @@
 	spawn_positions = 3
 	supervisors = "the quartermaster and the head of personnel"
 	wage_payout = 30
-	selection_color = "#B27B30"
+	selection_color = "#CEA773"
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
 	minimal_access = list(access_mining, access_mint, access_mining_station, access_mailsorting)
 	outfit_datum = /datum/outfit/mining

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -1,41 +1,3 @@
-//Cargo
-/datum/job/qm
-	title = "Quartermaster"
-	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
-	supervisors = "the head of personnel"
-	wage_payout = 65
-	selection_color = "#CC9D5F"
-	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
-	minimal_access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
-	outfit_datum = /datum/outfit/qm
-
-/datum/job/cargo_tech
-	title = "Cargo Technician"
-	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
-	supervisors = "the quartermaster and the head of personnel"
-	wage_payout = 20
-	selection_color = "#CEA773"
-	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
-	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
-	alt_titles = list("Mailman")
-	outfit_datum = /datum/outfit/cargo_tech
-
-/datum/job/mining
-	title = "Shaft Miner"
-	faction = "Station"
-	total_positions = 3
-	spawn_positions = 3
-	supervisors = "the quartermaster and the head of personnel"
-	wage_payout = 30
-	selection_color = "#CEA773"
-	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
-	minimal_access = list(access_mining, access_mint, access_mining_station, access_mailsorting)
-	outfit_datum = /datum/outfit/mining
-
 //Food
 /datum/job/bartender
 	title = "Bartender"
@@ -74,6 +36,44 @@
 	minimal_access = list(access_hydroponics, access_morgue) // Removed tox and chem access because STOP PISSING OFF THE CHEMIST GUYS // //Removed medical access because WHAT THE FUCK YOU AREN'T A DOCTOR YOU GROW WHEAT //Given Morgue access because they have a viable means of cloning.
 	alt_titles = list("Hydroponicist", "Beekeeper", "Gardener")
 	outfit_datum = /datum/outfit/hydro
+
+//Cargo
+/datum/job/qm
+	title = "Quartermaster"
+	faction = "Station"
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the head of personnel"
+	wage_payout = 65
+	selection_color = "#E9D9BC"
+	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
+	minimal_access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
+	outfit_datum = /datum/outfit/qm
+
+/datum/job/cargo_tech
+	title = "Cargo Technician"
+	faction = "Station"
+	total_positions = 2
+	spawn_positions = 2
+	supervisors = "the quartermaster and the head of personnel"
+	wage_payout = 20
+	selection_color = "#F9EAD5"
+	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
+	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
+	alt_titles = list("Mailman")
+	outfit_datum = /datum/outfit/cargo_tech
+
+/datum/job/mining
+	title = "Shaft Miner"
+	faction = "Station"
+	total_positions = 3
+	spawn_positions = 3
+	supervisors = "the quartermaster and the head of personnel"
+	wage_payout = 30
+	selection_color = "#F9EAD5"
+	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
+	minimal_access = list(access_mining, access_mint, access_mining_station, access_mailsorting)
+	outfit_datum = /datum/outfit/mining
 
 /datum/job/clown
 	title = "Clown"

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -1,3 +1,41 @@
+//Cargo
+/datum/job/qm
+	title = "Quartermaster"
+	faction = "Station"
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the head of personnel"
+	wage_payout = 65
+	selection_color = "#B27B30"
+	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
+	minimal_access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
+	outfit_datum = /datum/outfit/qm
+
+/datum/job/cargo_tech
+	title = "Cargo Technician"
+	faction = "Station"
+	total_positions = 2
+	spawn_positions = 2
+	supervisors = "the quartermaster and the head of personnel"
+	wage_payout = 20
+	selection_color = "#B27B30"
+	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
+	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
+	alt_titles = list("Mailman")
+	outfit_datum = /datum/outfit/cargo_tech
+
+/datum/job/mining
+	title = "Shaft Miner"
+	faction = "Station"
+	total_positions = 3
+	spawn_positions = 3
+	supervisors = "the quartermaster and the head of personnel"
+	wage_payout = 30
+	selection_color = "#B27B30"
+	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
+	minimal_access = list(access_mining, access_mint, access_mining_station, access_mailsorting)
+	outfit_datum = /datum/outfit/mining
+
 //Food
 /datum/job/bartender
 	title = "Bartender"
@@ -36,44 +74,6 @@
 	minimal_access = list(access_hydroponics, access_morgue) // Removed tox and chem access because STOP PISSING OFF THE CHEMIST GUYS // //Removed medical access because WHAT THE FUCK YOU AREN'T A DOCTOR YOU GROW WHEAT //Given Morgue access because they have a viable means of cloning.
 	alt_titles = list("Hydroponicist", "Beekeeper", "Gardener")
 	outfit_datum = /datum/outfit/hydro
-
-//Cargo
-/datum/job/qm
-	title = "Quartermaster"
-	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
-	supervisors = "the head of personnel"
-	wage_payout = 65
-	selection_color = "#dddddd"
-	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
-	minimal_access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
-	outfit_datum = /datum/outfit/qm
-
-/datum/job/cargo_tech
-	title = "Cargo Technician"
-	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
-	supervisors = "the quartermaster and the head of personnel"
-	wage_payout = 20
-	selection_color = "#dddddd"
-	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
-	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
-	alt_titles = list("Mailman")
-	outfit_datum = /datum/outfit/cargo_tech
-
-/datum/job/mining
-	title = "Shaft Miner"
-	faction = "Station"
-	total_positions = 3
-	spawn_positions = 3
-	supervisors = "the quartermaster and the head of personnel"
-	wage_payout = 30
-	selection_color = "#dddddd"
-	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mint, access_mining, access_mining_station)
-	minimal_access = list(access_mining, access_mint, access_mining_station, access_mailsorting)
-	outfit_datum = /datum/outfit/mining
 
 /datum/job/clown
 	title = "Clown"

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -5,7 +5,7 @@
 	spawn_positions = 1
 	supervisors = "the captain"
 	wage_payout = 80
-	selection_color = "#ffddf0"
+	selection_color = "#DFEDFD"
 	req_admin_notify = 1
 	access = list(access_medical, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_biohazard, access_cmo, access_surgery, access_RC_announce,
@@ -25,7 +25,7 @@
 	spawn_positions = 3
 	supervisors = "the chief medical officer"
 	wage_payout = 65
-	selection_color = "#ffeef0"
+	selection_color = "#EFFDFE"
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_eva)
 	minimal_access = list(access_medical, access_morgue, access_surgery, access_virology)
 	alt_titles = list("Emergency Physician", "Surgeon")
@@ -39,7 +39,7 @@
 	spawn_positions = 2
 	supervisors = "the chief medical officer"
 	wage_payout = 65
-	selection_color = "#ffeef0"
+	selection_color = "#EFFDFE"
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_eva)
 	minimal_access = list(access_medical, access_chemistry)
 	alt_titles = list("Pharmacist")
@@ -52,7 +52,7 @@
 	spawn_positions = 2
 	supervisors = "the chief medical officer and research director"
 	wage_payout = 55
-	selection_color = "#ffeef0"
+	selection_color = "#EFFDFE"
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_science, access_eva)
 	minimal_access = list(access_medical, access_morgue, access_genetics, access_science)
 	outfit_datum = /datum/outfit/geneticist
@@ -64,7 +64,7 @@
 	spawn_positions = 1
 	supervisors = "the chief medical officer"
 	wage_payout = 55
-	selection_color = "#ffeef0"
+	selection_color = "#EFFDFE"
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_biohazard, access_genetics, access_eva)
 	minimal_access = list(access_medical, access_virology, access_biohazard)
 	alt_titles = list("Pathologist", "Microbiologist")
@@ -77,7 +77,7 @@
 	spawn_positions = 2
 	supervisors = "the chief medical officer"
 	wage_payout = 55
-	selection_color = "#ffeef0"
+	selection_color = "#EFFDFE"
 	access = list(access_paramedic, access_medical, access_sec_doors, access_maint_tunnels, access_external_airlocks, access_eva, access_morgue, access_surgery)
 	minimal_access=list(access_paramedic, access_medical, access_sec_doors, access_maint_tunnels, access_external_airlocks, access_eva, access_morgue, access_surgery)
 	alt_titles = list("Brig Medic")
@@ -90,7 +90,7 @@
 	spawn_positions = 1
 	supervisors = "the chief medical officer"
 	wage_payout = 55
-	selection_color = "#ffeef0"
+	selection_color = "#EFFDFE"
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry)
 	minimal_access = list(access_medical, access_morgue, access_surgery)
 	alt_titles = list("Nurse")


### PR DESCRIPTION
After trying to find my job preferences for Cargo for the 200 millionth time, I have gotten fed up! I have changed their color so that I can find them a little easier. Also changed Medical while I was here. Clown can get colors in a new PR. 

![image](https://user-images.githubusercontent.com/69739118/166584746-7e6aa382-9471-4365-9047-e8c585a568be.png)


[tweak]
[ui]

-->
:cl:
 * tweak: Changes Cargo's and Medical's colors in the job preference window.
