### PR TITLE
Adds Lawgiver modkit box to traitor HoS' uplink. Also changes "Command and Security Specials" to "Security Specials"

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -652,7 +652,7 @@ var/list/uplink_items = list()
 		return I
 
 /datum/uplink_item/jobspecific/command_security
-	category = "Command and Security Specials"
+	category = "Security Specials"
 
 /datum/uplink_item/jobspecific/command_security/syndicuffs
 	name = "Syndicate Cuffs"
@@ -709,27 +709,6 @@ var/list/uplink_items = list()
 	cost = 12
 	discounted_cost = 10
 	jobs_with_discount = list("Detective")
-
-/datum/uplink_item/jobspecific/command_security/briefcase_smg
-	name = "Briefcase SMG"
-	desc = "A modified briefcase capable of storing and firing a gun under a false bottom, while still allowing regular storage functions. Starts with a 9mm SMG loaded with 18 rounds that can be fired by holding the briefcase. Use a screwdriver to pry away the false bottom and either retrieve the gun or insert a new one. Distinguishable upon close examination due to the added weight."
-	item = /obj/item/weapon/storage/briefcase/false_bottomed/smg
-	cost = 14
-	discounted_cost = 10
-	jobs_with_discount = list("Internal Affairs Agent")
-
-/datum/uplink_item/jobspecific/command_security/briefcase_smg/on_item_spawned(var/obj/I, var/mob/user)
-	if(gives_discount(user.job) || gives_discount(user.dna.species))
-		I.icon_state = "briefcase-centcomm"
-	return
-
-/datum/uplink_item/jobspecific/command_security/knifeboot
-	name = "Concealed knife shoes"
-	desc = "Lace-up shoes with a knife concealed in the toecap. Tap your heels together to reveal the small knife. Remember to kick the target to stab them. Knife will be visible when pulled out, but kicking with the knife will not be directly obvious to observers."
-	item = /obj/item/clothing/shoes/knifeboot
-	cost = 4
-	discounted_cost = 2
-	jobs_with_discount = list("Internal Affairs Agent")
 
 /datum/uplink_item/jobspecific/medical
 	category = "Medical Specials"
@@ -1132,6 +1111,34 @@ var/list/uplink_items = list()
 	cost = 12
 	discounted_cost = 8
 	jobs_with_discount = list("Captain", "Head of Personnel")
+
+/datum/uplink_item/jobspecific/command/lawgivermk2
+	name = "Lawgiver Demolition Kit"
+	desc = "A container that comes with a Lawgiver modification kit, converting it into a Demolition variant Lawgiver. Also comes with two spare demolition magazines."
+	item = /obj/item/weapon/storage/box/survival/demolition
+	cost = 12
+	jobs_exclusive = list("Head of Security")
+
+/datum/uplink_item/jobspecific/command/briefcase_smg
+	name = "Briefcase SMG"
+	desc = "A modified briefcase capable of storing and firing a gun under a false bottom, while still allowing regular storage functions. Starts with a 9mm SMG loaded with 18 rounds that can be fired by holding the briefcase. Use a screwdriver to pry away the false bottom and either retrieve the gun or insert a new one. Distinguishable upon close examination due to the added weight."
+	item = /obj/item/weapon/storage/briefcase/false_bottomed/smg
+	cost = 14
+	discounted_cost = 10
+	jobs_with_discount = list("Internal Affairs Agent")
+
+/datum/uplink_item/jobspecific/command/briefcase_smg/on_item_spawned(var/obj/I, var/mob/user)
+	if(gives_discount(user.job) || gives_discount(user.dna.species))
+		I.icon_state = "briefcase-centcomm"
+	return
+
+/datum/uplink_item/jobspecific/command/knifeboot
+	name = "Concealed knife shoes"
+	desc = "Lace-up shoes with a knife concealed in the toecap. Tap your heels together to reveal the small knife. Remember to kick the target to stab them. Knife will be visible when pulled out, but kicking with the knife will not be directly obvious to observers."
+	item = /obj/item/clothing/shoes/knifeboot
+	cost = 4
+	discounted_cost = 2
+	jobs_with_discount = list("Internal Affairs Agent")
 
 /datum/uplink_item/jobspecific/trader
 	category = "Trader Specials"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1115,7 +1115,7 @@ var/list/uplink_items = list()
 /datum/uplink_item/jobspecific/command/lawgivermk2
 	name = "Lawgiver Demolition Kit"
 	desc = "A container that comes with a Lawgiver modification kit, converting it into a Demolition variant Lawgiver. Also comes with two spare demolition magazines."
-	item = /obj/item/weapon/storage/box/survival/demolition
+	item = /obj/item/weapon/storage/box/demolition
 	cost = 12
 	jobs_exclusive = list("Head of Security")
 

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -167,3 +167,19 @@
 	else if(proximity_flag && istype(target, /obj/item/weapon/gun/energy/kinetic_accelerator))
 		parts[1] = 1
 		qdel(target)
+
+
+/obj/item/device/modkit/demolition
+	name = "Lawgiver modkit"
+	desc = "A kit containing all the needed tools and parts to modify the Lawgiver into the demolition variant, granting it access to high explosive and double whammy rounds."
+	icon_state = "modkit"
+
+/obj/item/device/modkit/demolition/New()
+	..()
+	parts = new/list(1)
+	original = new/list(1)
+	finished = new/list(1)
+
+	parts[1] =	1
+	original[1] = /obj/item/weapon/gun/lawgiver
+	finished[1] = /obj/item/weapon/gun/lawgiver/demolition

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -1317,3 +1317,10 @@
 	new /obj/item/weapon/reagent_containers/food/snacks/dorfbiscuit(src)
 	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
 	new /obj/item/weapon/grenade/chem_grenade/metalfoam(src)
+
+/obj/item/weapon/storage/box/demolition
+	icon_state = "box_of_doom"
+	items_to_spawn = list(
+		/obj/item/device/modkit/demolition,
+		/obj/item/ammo_storage/magazine/lawgiver/demolition = 2,
+	)


### PR DESCRIPTION
Traitor HoS' can now purchase a box for 12 tc that comes with a modkit that converts his standard lawgiver into the demolition variant. For those unfamiliar this is essentially the same thing but adds high explosive and double whammy rounds to the list of ammos. The box also comes with two spare magazines.

This also reorgazines the "Command and Security Specials" section, moving the smg briefcase and knife shoes to the "Command Specials" category and changing the former to "Security Specials". (Why this wasn't done when command specials section was added is beyond me)


:cl:
 * rscadd: Traitor HoS' uplinks now have a box that contains a kit that allows them to modify their lawgiver to the demolition variant as well as spare magazines.
 * tweak: Reorganizes the uplink's command related items, separating them from the security section.
