### PR TITLE
Cargo Supply: Minor name changes and space suit entry tweak

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -693,32 +693,34 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/space_suits
 	name = "Space suit"
 	contains = list(/obj/item/clothing/suit/space,
-					/obj/item/clothing/head/helmet/space)
-	cost = 200
+					/obj/item/clothing/head/helmet/space,
+					/obj/item/weapon/tank/oxygen,
+					/obj/item/clothing/mask/breath)
+	cost = 150
 	containertype = /obj/structure/closet/crate/basic
 	containername = "space suit crate"
 	group = "Clothing"
 
 /datum/supply_packs/vox_supply
-	name = "Vox supplies"
+	name = "Vox pressure suit"
 	contains = list(/obj/item/clothing/suit/space/vox/civ,
 					/obj/item/clothing/head/helmet/space/vox/civ,
 					/obj/item/weapon/tank/nitrogen,
 					/obj/item/clothing/mask/breath/vox)
 	cost = 100
 	containertype = /obj/structure/closet/crate/basic
-	containername = "vox supplies crate"
+	containername = "vox suit crate"
 	group = "Clothing"
 
 /datum/supply_packs/plasmaman_supply
-	name = "Plasmaman supplies"
+	name = "Plasmaman suit"
 	contains = list(/obj/item/clothing/suit/space/plasmaman,
 					/obj/item/clothing/head/helmet/space/plasmaman,
 					/obj/item/weapon/tank/plasma/plasmaman,
 					/obj/item/clothing/mask/breath)
 	cost = 100
 	containertype = /obj/structure/closet/crate/basic
-	containername = "plasmaman supplies crate"
+	containername = "plasmaman suit crate"
 	group = "Clothing"
 
 /datum/supply_packs/grey_supply


### PR DESCRIPTION
- changes names of Vox supplies and Plasmaman supplies in the cargo orders console to Vox pressure suit and Plasmaman suit respectively
- added breath mask and oxygen airtank to space suit crate to be more in line with the pressure suit and plasmaman suit crate
- lowered spacesuits price to 150

200 is steep when considering the space suits lack of magboots and lowered speed, would have preferred to do 100 credits as the plasmaman suit and vox pressure suit crate, but I figured it right to acknowledge the fact that the space suit can be worn by multiple species, where as they can only be worn by their respective. 

Change of name for Vox and Plasmaman supplies may pave the way for a new specific crate that adds internals resupply for all species.

Price should be reverted back to 200 if the consensus is reached to add magboots to the space suit entry.

:cl:
* tweak: space suit priced changed to 150 with slight package alteration, vox supplies and plasmaman supplies renamed
