### PR TITLE
Allows jetpacks to work from suit storage in hardsuits. Changes which hardsuits can hold jetpacks.

### DIFF
--- a/code/datums/outfit/special_outfits/special.dm
+++ b/code/datums/outfit/special_outfits/special.dm
@@ -50,7 +50,6 @@
 		"Default" = list(
 			slot_wear_suit_str = /obj/item/clothing/suit/space/rig/engineer,
 			slot_wear_mask_str = /obj/item/clothing/mask/breath,
-			slot_s_store_str = /obj/item/weapon/tank/jetpack/oxygen,
 		),
 	)
 
@@ -60,7 +59,6 @@
 		"Default" = list(
 			slot_wear_suit_str = /obj/item/clothing/suit/space/rig/engineer/elite,
 			slot_wear_mask_str = /obj/item/clothing/mask/breath,
-			slot_s_store_str = /obj/item/weapon/tank/jetpack/oxygen,
 		),
 	)
 
@@ -90,7 +88,6 @@
 		"Default" = list(
 			slot_wear_suit_str = /obj/item/clothing/suit/space/rig/medical,
 			slot_wear_mask_str = /obj/item/clothing/mask/breath,
-			slot_s_store_str = /obj/item/weapon/tank/jetpack/oxygen,
 		),
 	)
 
@@ -100,7 +97,6 @@
 		"Default" = list(
 			slot_wear_suit_str = /obj/item/clothing/suit/space/rig/atmos,
 			slot_wear_mask_str = /obj/item/clothing/mask/breath,
-			slot_s_store_str = /obj/item/weapon/tank/jetpack/oxygen,
 		),
 	)
 
@@ -131,7 +127,6 @@
 			slot_head_str = /obj/item/clothing/head/helmet/space,
 			slot_shoes_str = /obj/item/clothing/shoes/black,
 			slot_wear_mask_str = /obj/item/clothing/mask/breath,
-			slot_s_store_str = /obj/item/weapon/tank/jetpack/oxygen,
 		),
 	//Maybe replace with civilian rig whenever that becomes a truely unique rig.
 	)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -664,7 +664,7 @@ var/global/maxStackDepth = 10
 	flags = FPRINT
 	pressure_resistance = 5 * ONE_ATMOSPHERE
 	body_parts_covered = ARMS|LEGS|FULL_TORSO|FEET|HANDS
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/)
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/oxygen,/obj/item/weapon/tank/plasma,/obj/item/weapon/tank/nitrogen,)
 	slowdown = HARDSUIT_SLOWDOWN_BULKY
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 50)
 	siemens_coefficient = 0.9

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -120,7 +120,7 @@ var/list/all_hardsuit_pieces = list(HARDSUIT_HEADGEAR,HARDSUIT_GLOVES,HARDSUIT_B
 	species_fit = list(GREY_SHAPED, TAJARAN_SHAPED, INSECT_SHAPED)
 	species_restricted = list("exclude",VOX_SHAPED)
 	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 10)
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/bag/ore,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/device/rcd, /obj/item/tool/wrench/socket)
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/oxygen,/obj/item/weapon/tank/plasma,/obj/item/weapon/tank/nitrogen,/obj/item/weapon/storage/bag/ore,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/device/rcd, /obj/item/tool/wrench/socket)
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	pressure_resistance = 200 * ONE_ATMOSPHERE
 	actions_types = list(/datum/action/item_action/toggle_rig_suit)

--- a/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
+++ b/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
@@ -16,7 +16,7 @@
 	icon_state = "rig-engineering"
 	item_state = "eng_hardsuit"
 	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 50)
-	allowed = list(/obj/item/device/flashlight, /obj/item/weapon/tank, /obj/item/weapon/storage/bag/ore, /obj/item/device/t_scanner, /obj/item/weapon/pickaxe, /obj/item/device/rcd, /obj/item/tool/wrench/socket)
+	allowed = list(/obj/item/device/flashlight, /obj/item/weapon/tank/oxygen, /obj/item/weapon/tank/plasma, /obj/item/weapon/tank/nitrogen, /obj/item/weapon/storage/bag/ore, /obj/item/device/t_scanner, /obj/item/weapon/pickaxe, /obj/item/device/rcd, /obj/item/tool/wrench/socket)
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	pressure_resistance = 200 * ONE_ATMOSPHERE
 	head_type = /obj/item/clothing/head/helmet/space/rig/engineer
@@ -45,11 +45,13 @@
 	clothing_flags = PLASMAGUARD
 	cell_type = /obj/item/weapon/cell/super
 	head_type = /obj/item/clothing/head/helmet/space/rig/engineer/elite
+	allowed = list(/obj/item/weapon/tank/jetpack)
 
 /obj/item/clothing/head/helmet/space/rig/engineer/elite/test
 	name = "prototype advanced hardsuit helmet"
 	desc = "A bleeding-edge helmet designed to protect its wearer against extreme environments. The armored padding in this helmet was totally removed to give place for its experimental plasmovsky alloy."
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 100, bomb = 100, bio = 100, rad = 100)
+
 
 //Self-charging, auto-refiller high-test suit.
 /obj/item/clothing/suit/space/rig/engineer/elite/test
@@ -89,7 +91,9 @@
 	head_type = /obj/item/clothing/head/helmet/space/rig/mining
 	allowed = list(
 		/obj/item/device/flashlight,
-		/obj/item/weapon/tank,
+		/obj/item/weapon/tank/oxygen,
+		/obj/item/weapon/tank/plasma,
+		/obj/item/weapon/tank/nitrogen,
 		/obj/item/weapon/storage/bag/ore,
 		/obj/item/device/mining_scanner,
 		/obj/item/weapon/pickaxe,
@@ -263,7 +267,7 @@
 	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
 	species_restricted = list("exclude",VOX_SHAPED)
 	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 30)
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/firstaid,/obj/item/device/healthanalyzer,/obj/item/stack/medical, /obj/item/roller)
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/oxygen,/obj/item/weapon/tank/plasma,/obj/item/weapon/tank/nitrogen,/obj/item/weapon/storage/firstaid,/obj/item/device/healthanalyzer,/obj/item/stack/medical, /obj/item/roller)
 	pressure_resistance = 40 * ONE_ATMOSPHERE
 	head_type = /obj/item/clothing/head/helmet/space/rig/medical
 
@@ -292,7 +296,9 @@
 	allowed = list(
 		/obj/item/weapon/gun,
 		/obj/item/device/flashlight,
-		/obj/item/weapon/tank,
+		/obj/item/weapon/tank/oxygen,
+		/obj/item/weapon/tank/plasma,
+		/obj/item/weapon/tank/nitrogen,
 		/obj/item/weapon/melee/baton,
 		/obj/item/weapon/reagent_containers/spray/pepper,
 		/obj/item/ammo_storage,
@@ -389,7 +395,7 @@
 	slowdown = HARDSUIT_SLOWDOWN_HIGH
 	species_fit = list(GREY_SHAPED,INSECT_SHAPED)
 	armor = list(melee = 30, bullet = 5, laser = 40,energy = 5, bomb = 35, bio = 100, rad = 60)
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/backpack/satchel_norm,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/device/rcd, /obj/item/weapon/extinguisher, /obj/item/weapon/extinguisher/foam, /obj/item/weapon/storage/toolbox, /obj/item/tool/wrench/socket)
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/oxygen,/obj/item/weapon/tank/plasma,/obj/item/weapon/tank/nitrogen,/obj/item/weapon/storage/backpack/satchel_norm,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/device/rcd, /obj/item/weapon/extinguisher, /obj/item/weapon/extinguisher/foam, /obj/item/weapon/storage/toolbox, /obj/item/tool/wrench/socket)
 	head_type = /obj/item/clothing/head/helmet/space/rig/atmos/gold
 
 //ADMINBUS RIGS. SOVIET + NAZI
@@ -413,7 +419,7 @@
 	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
 	species_restricted = list("exclude",VOX_SHAPED)//GAS THE VOX
 	armor = list(melee = 40, bullet = 30, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 20)
-	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/melee/)
+	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank/oxygen,/obj/item/weapon/tank/plasma,/obj/item/weapon/tank/nitrogen,/obj/item/weapon/melee/)
 	pressure_resistance = 40 * ONE_ATMOSPHERE
 	head_type = /obj/item/clothing/head/helmet/space/rig/nazi
 
@@ -437,7 +443,7 @@
 	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
 	species_restricted = list("exclude",VOX_SHAPED)//HET
 	armor = list(melee = 40, bullet = 30, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 20)
-	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/melee/)
+	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank/oxygen,/obj/item/weapon/tank/plasma,/obj/item/weapon/tank/nitrogen,/obj/item/weapon/melee/)
 	pressure_resistance = 40 * ONE_ATMOSPHERE
 	head_type = /obj/item/clothing/head/helmet/space/rig/soviet
 
@@ -500,7 +506,7 @@
 	desc = "A heavily armored suit that protects against a lot of things. Used in special operations."
 	icon_state = "rig-deathsquad"
 	item_state = "rig-deathsquad"
-	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_storage,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/tank/emergency_nitrogen,/obj/item/weapon/pinpointer,/obj/item/weapon/shield/energy,/obj/item/weapon/c4,/obj/item/weapon/disk/nuclear)
+	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_storage,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank/jetpack,/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/tank/emergency_nitrogen,/obj/item/weapon/pinpointer,/obj/item/weapon/shield/energy,/obj/item/weapon/c4,/obj/item/weapon/disk/nuclear)
 	armor = list(melee = 80, bullet = 60, laser = 50,energy = 25, bomb = 60, bio = 100, rad = 60)
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.5
@@ -530,7 +536,7 @@
 	desc = "A well polished set of armour belonging to a Space-Knight. Maidens Rescued in Space: 100, Maidens who have slept with me in Space: 0."
 	icon_state = "rig-knight"
 	item_state = "rig-knight"
-	allowed = list(/obj/item/weapon/gun,/obj/item/weapon/melee/baton,/obj/item/weapon/tank,/obj/item/weapon/shield/energy,/obj/item/weapon/claymore)
+	allowed = list(/obj/item/weapon/gun,/obj/item/weapon/melee/baton,/obj/item/weapon/tank/oxygen,/obj/item/weapon/tank/plasma,/obj/item/weapon/tank/nitrogen,/obj/item/weapon/shield/energy,/obj/item/weapon/claymore)
 	armor = list(melee = 60, bullet = 40, laser = 40,energy = 30, bomb = 50, bio = 100, rad = 60)
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.5

--- a/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
+++ b/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
@@ -39,19 +39,18 @@
 	desc = "An advanced suit that protects against hazardous, low pressure environments. Shines with a high polish making it plasma proof."
 	icon_state = "rig-white"
 	item_state = "ce_hardsuit"
+	allowed = list(/obj/item/weapon/tank/jetpack)
 	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
 	species_restricted = list("exclude",VOX_SHAPED)
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	clothing_flags = PLASMAGUARD
 	cell_type = /obj/item/weapon/cell/super
 	head_type = /obj/item/clothing/head/helmet/space/rig/engineer/elite
-	allowed = list(/obj/item/weapon/tank/jetpack)
 
 /obj/item/clothing/head/helmet/space/rig/engineer/elite/test
 	name = "prototype advanced hardsuit helmet"
 	desc = "A bleeding-edge helmet designed to protect its wearer against extreme environments. The armored padding in this helmet was totally removed to give place for its experimental plasmovsky alloy."
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 100, bomb = 100, bio = 100, rad = 100)
-
 
 //Self-charging, auto-refiller high-test suit.
 /obj/item/clothing/suit/space/rig/engineer/elite/test
@@ -506,7 +505,7 @@
 	desc = "A heavily armored suit that protects against a lot of things. Used in special operations."
 	icon_state = "rig-deathsquad"
 	item_state = "rig-deathsquad"
-	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_storage,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank/jetpack,/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/tank/emergency_nitrogen,/obj/item/weapon/pinpointer,/obj/item/weapon/shield/energy,/obj/item/weapon/c4,/obj/item/weapon/disk/nuclear)
+	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_storage,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,obj/item/weapon/tank/jetpack,/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/tank/emergency_nitrogen,/obj/item/weapon/pinpointer,/obj/item/weapon/shield/energy,/obj/item/weapon/c4,/obj/item/weapon/disk/nuclear)
 	armor = list(melee = 80, bullet = 60, laser = 50,energy = 25, bomb = 60, bio = 100, rad = 60)
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.5

--- a/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
+++ b/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
@@ -505,7 +505,7 @@
 	desc = "A heavily armored suit that protects against a lot of things. Used in special operations."
 	icon_state = "rig-deathsquad"
 	item_state = "rig-deathsquad"
-	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_storage,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,obj/item/weapon/tank/jetpack,/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/tank/emergency_nitrogen,/obj/item/weapon/pinpointer,/obj/item/weapon/shield/energy,/obj/item/weapon/c4,/obj/item/weapon/disk/nuclear)
+	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_storage,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,obj/item/weapon/tank,/obj/item/weapon/pinpointer,/obj/item/weapon/shield/energy,/obj/item/weapon/c4,/obj/item/weapon/disk/nuclear)
 	armor = list(melee = 80, bullet = 60, laser = 50,energy = 25, bomb = 60, bio = 100, rad = 60)
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.5

--- a/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
+++ b/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
@@ -505,7 +505,7 @@
 	desc = "A heavily armored suit that protects against a lot of things. Used in special operations."
 	icon_state = "rig-deathsquad"
 	item_state = "rig-deathsquad"
-	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_storage,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,obj/item/weapon/tank,/obj/item/weapon/pinpointer,/obj/item/weapon/shield/energy,/obj/item/weapon/c4,/obj/item/weapon/disk/nuclear)
+	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_storage,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank,/obj/item/weapon/pinpointer,/obj/item/weapon/shield/energy,/obj/item/weapon/c4,/obj/item/weapon/disk/nuclear)
 	armor = list(melee = 80, bullet = 60, laser = 50,energy = 25, bomb = 60, bio = 100, rad = 60)
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.5

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -105,6 +105,14 @@
 //		if(!check_drift && J.allow_thrust(0.01, src))
 //			return 1
 
+//Also allows jetpacks to work from suit storage slots
+	else if(istype(s_store, /obj/item/weapon/tank/jetpack))
+		var/obj/item/weapon/tank/jetpack/J = s_store
+		if(((!check_drift) || (check_drift && J.stabilization_on)) && (!lying) && (J.allow_thrust(0.01, src)))
+			inertia_dir = 0
+			return 1
+			
+
 	//If no working jetpack then use the other checks
 	return ..()
 


### PR DESCRIPTION
#32437 but only the more advanced/unique hardsuits such as the captain's,CE, ERT, nuke ops, syndicate strike team, and deathsquad can hold jetpacks.


:cl:
 * rscadd: Jetpacks now function from suit storage.
 * tweak: Jetpacks can only be stored in more advanced, or unique hardsuits.
