### PR TITLE
Jetpacks work on any hardsuit storage slot.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -105,6 +105,13 @@
 //		if(!check_drift && J.allow_thrust(0.01, src))
 //			return 1
 
+//Also allows jetpacks to work from suit storage slots
+	else if(istype(s_store, /obj/item/weapon/tank/jetpack))
+		var/obj/item/weapon/tank/jetpack/J = s_store
+		if(((!check_drift) || (check_drift && J.stabilization_on)) && (!lying) && (J.allow_thrust(0.01, src)))
+			inertia_dir = 0
+			return 1
+
 	//If no working jetpack then use the other checks
 	return ..()
 


### PR DESCRIPTION
Everyone loves competing PRs, right? Alternative to #32530. 
Now any hardsuit can use the jetpacks from the storage slot.
`>BUT MUH BALANCE! THIS WILL BE POWERGAMED!!!!`
It will not. The 3 times people seriously use jetpacks are when OPS/fighting ops, raiders/fighting raiders or space exploring when the pods are unavailable. I seriously see no point in gatekeeping the feature behind expensive suits which we know will be rushed if the alternative gets merged, Spess McExplorer will die in deep space with the fucking CE suit and the crew will be unable to do shit about it. 
:cl:
 * rscadd: Makes jetpacks work from the hardsuit storage slot without hardsuit type restrictions.