### PR TITLE
Fixes emag issues

### DIFF
--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -708,6 +708,8 @@
 				to_chat(user, "<span class='notice'>Unable to repair with the maintenance panel closed.</span>")
 		else
 			to_chat(user, "<span class='notice'>[src] does not need a repair.</span>")
+	else if (istype(W, /obj/item/weapon/card/emag) && emagged < 2)
+		emag_act(user)
 	else
 		if(isobj(W))
 			W.on_attack(src, user)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -600,6 +600,12 @@ Class Procs:
 
 	add_fingerprint(user)
 
+	if(isEmag(O) && machine_flags & EMAGGABLE)
+		var/obj/item/weapon/card/emag/E = O
+		if(E.canUse(user,src))
+			emag_act(user)
+			return 1
+
 	if(O.is_wrench(user) && wrenchable()) //make sure this is BEFORE the fixed2work check
 		if(!panel_open)
 			if(state == 2 && src.machine_flags & WELD_FIXED) //prevent unanchoring welded machinery

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -29,7 +29,7 @@
 	var/image/openimage
 	var/image/closeimage
 
-	machine_flags = SCREWTOGGLE
+	machine_flags = SCREWTOGGLE | EMAGGABLE
 
 	hack_abilities = list(
 		/datum/malfhack_ability/toggle/disable,

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -180,9 +180,7 @@
 		target_living.emag_act(user, organ, src)
 		return
 	if(istype(target,/obj/machinery))
-		var/obj/machinery/M = target
-		if(!(M.machine_flags & EMAGGABLE) || !canUse(user,M) || (istype(M,/obj/machinery/bot) && M.emagged < 2))
-			return
+		return // Handled in machine attackby()
 	target.emag_act(user)
 
 

--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -187,7 +187,7 @@
 	icon_state = "floor4"
 
 
-/obj/machinery/podcomputer 
+/obj/machinery/podcomputer
 	name = "pod computer"
 	desc = "A computer for piloting escape pods. The software hasn't been updated since the autopilot system was installed and is mostly non-functional."
 	use_power = 0
@@ -196,7 +196,7 @@
 	icon_state_open = "podcomputer_maint"
 
 	var/datum/shuttle/escape/pod/linked_pod
-	machine_flags = SCREWTOGGLE
+	machine_flags = SCREWTOGGLE | EMAGGABLE
 
 	hack_abilities = list(
 		/datum/malfhack_ability/oneuse/emag,
@@ -207,7 +207,7 @@
 /obj/machinery/podcomputer/Destroy()
 	linked_pod?.podcomputer = null
 	..()
-	
+
 /obj/machinery/podcomputer/process()
 	..()
 	update_icon()
@@ -228,7 +228,7 @@
 	..()
 	if(panel_open && emagged)
 		to_chat(user, "<span class='danger'>Some of the wires have been shorted out!</span>")
-	
+
 /obj/machinery/podcomputer/attackby(obj/item/O, mob/user)
 	..()
 	if(issolder(O) && emagged && panel_open)
@@ -248,7 +248,7 @@
 		icon_state = "podcomputer_shuttle"
 	else if(emagged)
 		icon_state = "podcomputer_error"
-	else 
+	else
 		icon_state = "podcomputer"
 
 

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -8,7 +8,7 @@
 	anchored = 0
 	use_power = 0
 
-	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK
+	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK | EMAGGABLE
 
 	var/active = 0
 	var/power_gen = 5000
@@ -53,7 +53,6 @@
 
 /obj/machinery/power/port_gen/pacman
 	name = "P.A.C.M.A.N.-type Portable Generator"
-	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK | EMAGGABLE
 	var/sheets = 0
 	var/max_sheets = 100
 	var/sheet_name = ""

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -53,6 +53,7 @@
 
 /obj/machinery/power/port_gen/pacman
 	name = "P.A.C.M.A.N.-type Portable Generator"
+	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK | EMAGGABLE
 	var/sheets = 0
 	var/max_sheets = 100
 	var/sheet_name = ""

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -640,6 +640,7 @@
 	desc = "Magnetically opens crates provided the proper access has been swiped on the machine."
 	icon = 'icons/obj/machines/logistics.dmi'
 	icon_state = "inactive"
+	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | EMAGGABLE
 	var/list/access = list()
 
 /obj/machinery/logistics_machine/crate_opener/New()


### PR DESCRIPTION
Fallout from #32501, moves these checks back into machinery attackby() and blocks any checks on machinery in the emag afterattack()
Closes #32541.
[hotfix][bugfix]

:cl:
 * bugfix: Emags should work on some machinery again.