### PR TITLE
Janitorial supply crate changes

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -108,23 +108,31 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/janitor
 	name = "Janitorial supplies"
 	contains = list(/obj/item/weapon/reagent_containers/glass/bucket,
-					/obj/item/weapon/reagent_containers/glass/bucket,
-					/obj/item/weapon/reagent_containers/glass/bucket,
-					/obj/item/weapon/mop,
-					/obj/item/weapon/caution,
-					/obj/item/weapon/caution,
-					/obj/item/weapon/caution,
+					/obj/item/weapon/reagent_containers/glass/bottle/bleach,
+					/obj/item/weapon/soap,
+					/obj/item/device/lightreplacer,
 					/obj/item/weapon/storage/bag/trash,
 					/obj/item/weapon/reagent_containers/spray/cleaner,
 					/obj/item/weapon/reagent_containers/glass/rag,
 					/obj/item/weapon/grenade/chem_grenade/cleaner,
 					/obj/item/weapon/grenade/chem_grenade/cleaner,
 					/obj/item/weapon/grenade/chem_grenade/cleaner,
-					/obj/item/weapon/storage/box/mousetraps,
-					/obj/structure/mopbucket)
+					/obj/item/weapon/storage/box/mousetraps)
 	cost = 10
 	containertype = /obj/structure/closet/crate/basic
 	containername = "janitorial supplies crate"
+	group = "Supplies"
+
+/datum/supply_packs/mopbucket
+	name = "Mop and Bucket"
+	contains = list(/obj/item/weapon/mop,
+					/obj/item/weapon/caution,
+					/obj/item/weapon/caution,
+					/obj/item/weapon/caution,
+					/obj/structure/mopbucket)
+	cost = 20
+	containertype = /obj/structure/largecrate
+	containername = "mop and bucket crate"
 	group = "Supplies"
 
 /datum/supply_packs/trashcompactor

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -110,7 +110,6 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/weapon/reagent_containers/glass/bucket,
 					/obj/item/weapon/reagent_containers/glass/bottle/bleach,
 					/obj/item/weapon/soap,
-					/obj/item/device/lightreplacer,
 					/obj/item/weapon/storage/bag/trash,
 					/obj/item/weapon/reagent_containers/spray/cleaner,
 					/obj/item/weapon/reagent_containers/glass/rag,
@@ -118,7 +117,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/grenade/chem_grenade/cleaner,
 					/obj/item/weapon/grenade/chem_grenade/cleaner,
 					/obj/item/weapon/storage/box/mousetraps)
-	cost = 10
+	cost = 15
 	containertype = /obj/structure/closet/crate/basic
 	containername = "janitorial supplies crate"
 	group = "Supplies"


### PR DESCRIPTION
- Adds bleach, soap, and a light replacer to the Janitorial supply crate
- removes two buckets, the mop, the mop bucket, and the three wet floor signs from the Janitorial supply crate
- Adds Mop and bucket crate to the supplies group with a mop, mop bucket, and three wet floor signs

Figured it'd be a good addition to have this separation of mopbucket and janny supplies for those who don't want spare buckets or accidentally opening the crate before delivery and being unable to stick the mopbucket back in. Now you don't have to worry about it, it's in a different entry. Also adds goods I always felt was missing from the old janitorial supply crate.
:cl:
 * rscadd: Added Mop and bucket entry to supply console
 * tweak: Changed contents of Janitorial supply crate
