### PR TITLE
New custodial crate entry for the supply console

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -610,6 +610,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/janny_gear
 	contains = list(/obj/item/clothing/suit/apron/overalls,
 					/obj/item/clothing/gloves/black,
+					/obj/item/weapon/storage/belt/janitor,
 					/obj/item/clothing/shoes/galoshes)
 	name = "Custodial gear"
 	cost = 100

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -607,6 +607,17 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contraband = 1
 	group = "Clothing"
 
+/datum/supply_packs/janny_gear
+	contains = list(/obj/item/clothing/suit/apron/overalls,
+					/obj/item/clothing/gloves/black,
+					/obj/item/clothing/shoes/galoshes)
+	name = "Custodial gear"
+	cost = 100
+	containertype = /obj/structure/closet/crate/secure/basic
+	containername = "custodial gear crate"
+	access = list(access_janitor)
+	group = "Clothing"
+
 /datum/supply_packs/waifu
 	name = "Feminine formalwear"
 	contains = list(/obj/item/clothing/under/dress/dress_fire,


### PR DESCRIPTION
[controversial] 

- Adds new cargo entry: Custodial gear, has one pair of black gloves, one pair of galoshes, some coveralls and a janny belt for 100 credits, locked behind janitor access.

Tagging this as controversial due to the nature of this PR. Gonna give a couple of my reasons for making this as well as a couple of refutes for some points that might be brought up against it.

For starters, galoshes are irreplaceable, meaning if they're destroyed, lost, or spaced it's not something you'll be getting back unless on the very rare occasion someone brings back a pair from deep space. Now, you can say the reason for this is because galoshes are noslips, and some power gamer is going to buy them and run around being unable to fall for the old sneaky water beaker. To that I say it's misplaced worry. You see, I believe it's more likely our hypothetical straw man powergamer would opt to steal a pair of magboots then spend 100 credits for shoes that not only slow you down, but are NOT immune to zas. That and I believe if a traitor really wanted noslips, he would be better off buying the shoes that wouldn't impair movement, AND can change it's look.
But putting aside all that a moment, another point i'd like to make in avocation for this custodial gear crate is, on the off chance a HOP frees up the slot for a second janitor, said second janitor will be missing half his gear, including a second belt and galoshes. This makes duel janitor play with both jannys being active more viable on a station that isn't Deff.
Finally, as an added safeguard, this crate is locked requiring janitor access, which also helps give QM's and Cargo Techs good reason to deny it to anyone attempting to purchase this that is NOT a janitor, or may have less then good intentions for the purchase.

:cl:
 * rscadd: Adds new custodial gear crate with galoshes in them!
