### PR TITLE
Departmental Request Consoles can now make multi-line announcements too

### DIFF
--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -274,7 +274,7 @@ var/list/obj/machinery/requests_console/requests_consoles = list()
 			priority = -1
 
 	if(href_list["writeAnnouncement"])
-		var/new_message = copytext(reject_bad_text(stripped_message(usr, "Write your message:", "Departmental Announcement", "")),1,MAX_MESSAGE_LEN)
+		var/new_message = copytext(stripped_message(usr, "Write your message:", "Departmental Announcement", ""))
 		if(new_message)
 			message = new_message
 			switch(href_list["priority"])

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -274,7 +274,7 @@ var/list/obj/machinery/requests_console/requests_consoles = list()
 			priority = -1
 
 	if(href_list["writeAnnouncement"])
-		var/new_message = copytext(stripped_message(input(usr, "Write your message:", "Awaiting Input", "")),1,MAX_MESSAGE_LEN)
+		var/new_message = copytext(reject_bad_text(stripped_message(usr, "Write your message:", "Departmental Announcement", "")),1,MAX_MESSAGE_LEN)
 		if(new_message)
 			message = new_message
 			switch(href_list["priority"])

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -274,7 +274,7 @@ var/list/obj/machinery/requests_console/requests_consoles = list()
 			priority = -1
 
 	if(href_list["writeAnnouncement"])
-		var/new_message = copytext(stripped_message(usr, "Write your message:", "Departmental Announcement", ""),1,MAX_MESSAGE_LEN)
+		var/new_message = stripped_message(usr, "Write your message:", "Departmental Announcement", "")
 		if(new_message)
 			message = new_message
 			switch(href_list["priority"])

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -274,7 +274,7 @@ var/list/obj/machinery/requests_console/requests_consoles = list()
 			priority = -1
 
 	if(href_list["writeAnnouncement"])
-		var/new_message = copytext(stripped_message(usr, "Write your message:", "Departmental Announcement", ""))
+		var/new_message = copytext(stripped_message(usr, "Write your message:", "Departmental Announcement", ""),1,MAX_MESSAGE_LEN)
 		if(new_message)
 			message = new_message
 			switch(href_list["priority"])

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -274,7 +274,7 @@ var/list/obj/machinery/requests_console/requests_consoles = list()
 			priority = -1
 
 	if(href_list["writeAnnouncement"])
-		var/new_message = copytext(reject_bad_text(input(usr, "Write your message:", "Awaiting Input", "")),1,MAX_MESSAGE_LEN)
+		var/new_message = copytext(stripped_message(input(usr, "Write your message:", "Awaiting Input", "")),1,MAX_MESSAGE_LEN)
 		if(new_message)
 			message = new_message
 			switch(href_list["priority"])

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -266,7 +266,7 @@ var/list/obj/machinery/requests_console/requests_consoles = list()
 				else
 					priority = -1
 		else
-			to_chat(usr, "<span class='warning'>Invalid characters found in the text.</span>")
+			to_chat(usr, "<span class='warning'>Invalid characters or no text detected.</span>")
 			dpt = "";
 			msgVerified = ""
 			msgStamped = ""
@@ -283,7 +283,7 @@ var/list/obj/machinery/requests_console/requests_consoles = list()
 				else
 					priority = -1
 		else
-			to_chat(usr, "<span class='warning'>Invalid characters found in the text.</span>")
+			to_chat(usr, "<span class='warning'>Invalid characters or no text detected.</span>")
 			message = ""
 			announceAuth = 0
 			screen = 0


### PR DESCRIPTION
Departmental request consoles can now make multi-line announcements, as requested by DJ in #32435
:cl:
 * tweak: Departmental Request Consoles can now also make multi-line announcements
