### PR TITLE
Simple mobs can toggle light floor tiles 

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -218,6 +218,9 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 
 /turf/simulated/floor/attack_paw(mob/user as mob)
 	return src.attack_hand(user)
+	
+/turf/simulated/floor/attack_animal(mob/user as mob)
+	return src.attack_hand(user)
 
 /turf/simulated/floor/attack_hand(mob/user as mob)
 	if (is_light_floor())


### PR DESCRIPTION
[tweak]
This makes it so that simple mobs can toggle light floor tiles on and off. This should help light floors not be as hard of a counter to grues.

:cl:
bugfix: Animals can now interact with floor tiles.
