### PR TITLE
Zombie/simple mob interaction fixes

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -443,7 +443,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	if(air_contents.total_moles() < 10)
 		return
 	if(istype(occupant, /mob/living/simple_animal/))
-		go_out(ejector = L)
+		go_out()
 		return
 	if(occupant)
 		if(occupant.stat == DEAD)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -442,6 +442,9 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 /obj/machinery/atmospherics/unary/cryo_cell/proc/process_occupant()
 	if(air_contents.total_moles() < 10)
 		return
+	if(istype(occupant, /mob/living/simple_animal/))
+		go_out(ejector = L)
+		return
 	if(occupant)
 		if(occupant.stat == DEAD)
 			return
@@ -545,8 +548,11 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	update_icon()
 	nanomanager.update_uis(src)
 
-
 /obj/machinery/atmospherics/unary/cryo_cell/proc/put_mob(mob/living/M as mob, mob/living/user)
+	if (occupant)
+		if(user)
+			to_chat(user, "<span class='danger'>The cryo cell is already occupied!</span>")
+		return FALSE
 	if(!istype(M))
 		if(user)
 			to_chat(user, "<span class='danger'>The cryo cell cannot handle such a lifeform!</span>")
@@ -573,17 +579,11 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 			if(!HAS_MODULE_QUIRK(robit, MODULE_CAN_HANDLE_MEDICAL))
 				to_chat(user, "<span class='warning'>You do not have the means to do this!</span>")
 				return FALSE
-
 	for(var/mob/living/carbon/slime/S in range(1,M))
 		if(S.Victim == M)
 			if(user)
 				to_chat(user, "<span class='warning'>[M.name] will not fit into the cryo cell because they have a slime latched onto their head.</span>")
 			return FALSE
-
-	if (occupant)
-		if(user)
-			to_chat(user, "<span class='danger'>The cryo cell is already occupied!</span>")
-		return FALSE
 	if(panel_open)
 		if(user)
 			to_chat(user, "<span class='bnotice'>Close the maintenance panel first.</span>")
@@ -630,7 +630,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	set name = "Move inside"
 	set category = "Object"
 	set src in oview(1)
-	if(usr.incapacitated() || usr.lying || usr.locked_to) //are you cuffed, dying, lying, stunned or other
+	if(usr.incapacitated() || usr.locked_to)
 		return
 	for(var/mob/living/carbon/slime/M in range(1,usr))
 		if(M.Victim == usr)

--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -426,7 +426,7 @@
 			user.visible_message("\The [user] begins whacking at [src] repeatedly with a bible for some reason.", "<span class='notice'>You attempt to invoke the power of [bible.my_rel.deity_name] to bring this poor soul back from the brink.</span>")
 
 			var/chaplain = 0 //Are we the Chaplain ? Used for simplification
-			if(user.mind && (user.mind.assigned_role == "Chaplain"))
+			if(user.mind && (isReligiousLeader(user)))
 				chaplain = TRUE //Indeed we are
 			if(do_after(user, src, 25)) //So there's a nice delay
 				if(!chaplain)

--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -426,7 +426,7 @@
 			user.visible_message("\The [user] begins whacking at [src] repeatedly with a bible for some reason.", "<span class='notice'>You attempt to invoke the power of [bible.my_rel.deity_name] to bring this poor soul back from the brink.</span>")
 
 			var/chaplain = 0 //Are we the Chaplain ? Used for simplification
-			if(user.mind && (isReligiousLeader(user)))
+			if(user.mind && isReligiousLeader(user))
 				chaplain = TRUE //Indeed we are
 			if(do_after(user, src, 25)) //So there's a nice delay
 				if(!chaplain)

--- a/code/modules/virus2/effect/stage_4.dm
+++ b/code/modules/virus2/effect/stage_4.dm
@@ -83,8 +83,12 @@
 
 /datum/disease2/effect/zombie/activate(var/mob/living/mob)
 	if(ishuman(mob))
-		var/mob/living/carbon/human/h = mob
-		h.become_zombie_after_death = 2
+		var/mob/living/carbon/human/H = mob
+		H.become_zombie_after_death = 2
+		if(H.isDeadorDying())
+			if(isjusthuman(H))
+				H.make_zombie()
+	to_chat(mob, "<span class = 'notice'>You hunger...</span>")
 
 /datum/disease2/effect/suicide
 	name = "Suicidal Syndrome"


### PR DESCRIPTION
Had some scope creep with this PR... Focussed on fixing some bugs related to zombies, whatever got my attention.
- Fixed religious leader check, Closes #32412
- Cryodunking hostile simple mobs no longer tames them forever. You get the release sequence, then they exit and are able to attack again. If a zombie is dead, it doesn't exit. If it revives, it does exit. Closes #31793
- Adding some feedback so the user knows when they can kill themselves to turn into a zombie, Closes #27855

:cl:
 * bugfix: Zombie fixes
