### PR TITLE
Antag and non-antag roles

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -527,7 +527,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		var/counts_as_antag = FALSE
 		for(var/role in M.mind.antag_roles)
 			var/datum/role/R = M.mind.antag_roles[role]
-			if(!R.non_antag)
+			if(R.is_antag)
 				counts_as_antag = TRUE
 				break
 		if(counts_as_antag)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -524,7 +524,14 @@ Turf and target are seperate in case you want to teleport some distance from a t
 			. += "/([M.name])"
 
 	if(showantag && M && isanyantag(M))
-		. += " <span title='[english_list(M.mind.antag_roles)]'>(A)</span>"
+		var/counts_as_antag = FALSE
+		for(var/role in M.mind.antag_roles)
+			var/datum/role/R = M.mind.antag_roles[role]
+			if(!R.non_antag)
+				counts_as_antag = TRUE
+				break
+		if(counts_as_antag)
+			. += " <span title='[english_list(M.mind.antag_roles)]'>(A)</span>"
 
 	if(more_info && M)
 		. += "(<A HREF='?_src_=holder;adminplayeropts=\ref[M]'>PP</A>) (<A HREF='?_src_=holder;adminmoreinfo=\ref[M]'>?</A>)"

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -1,5 +1,5 @@
 /**
-* Used in Mixed Mode, also simplifies equipping antags for other gamemodes and
+* Used in Dynamic Mode, also simplifies equipping antags for other gamemodes and
 * for the role panel.
 
 		###VARS###
@@ -7,17 +7,14 @@
 	@id: String: The unique ID of the role
 	@name: String: The name of the role (Traitor, Changeling)
 	@plural_name: String: The name of a multitude of this role (Traitors, Changelings)
-	@flags: BITFLAGS: Various flags associated with the role. (NEED_HOST means a host is required for the role.)
 	@protection_jobs: list(String): Jobs that can not have this role.
 	@protected_antags: list(String): Antagonists that can not have this role. (Cultists can't be wizards)
-	@protected_host_roles: list(String): Antag IDs that can not be the host of this role (Wizards can have apprentices, but apprentices can't have apprentices)
 	@disallow_job: Boolean: If this role is recruited to at roundstart, the person recruited is not assigned a position on station (Wizard, Nuke Op, Vox Raider)
 	@min_players: int: minimum amount of players that can have this role (4 cultists)
 	@max_players: int: maximum amount of players that can have this role (No more than 5 nuclear operatives)
 	@faction: Faction: What faction this role is associated with.
 	@minds: List(mind): The minds associated with this role (Wizards and their apprentices, Nuclear operatives and their commander)
 	@antag: mind: The actual antag mind.
-	@host: mind: The host, used in such things like cortical borers (Where the antag and host mind can swap at any time)
 	@objectives: Objective Holder: Where the objectives associated with the role will go.
 
 		###PROCS###
@@ -36,11 +33,6 @@
 		Called on Life() to handle the role's additional alphas to the dark plane.
 */
 
-#define ROLE_MIXABLE   			1 // Can be used in mixed mode
-#define ROLE_NEED_HOST 			2 // Antag needs a host/partner
-#define ROLE_ADDITIVE  			4 // Antag can be added on top of another antag.
-#define ROLE_GOOD     			8 // Role is not actually an antag. (Used for GetAllBadMinds() etc)
-
 /datum/role
 	//////////////////////////////
 	// "Static" vars
@@ -52,9 +44,6 @@
 	var/name = null
 
 	var/plural_name = null
-
-	// Various flags and things.
-	var/flags = 0
 
 	// Jobs that cannot be this antag.
 	var/list/restricted_jobs = list()
@@ -68,9 +57,6 @@
 
 	// Antag IDs that cannot be used with this antag type. (cultists can't be wizard, etc)
 	var/list/protected_antags=list()
-
-	// Antags protected from becoming host
-	var/list/protected_host_antags=list()
 
 	// If set, sets special_role to this
 	var/special_role=null
@@ -89,6 +75,8 @@
 
 	var/list/minds = list()
 
+	var/non_antag = FALSE // Role isn't really an antag
+
 	//////////////////////////////
 	// Local
 	//////////////////////////////
@@ -97,9 +85,6 @@
 	var/destroyed = FALSE //Whether or not it has been gibbed
 
 	var/list/uplink_items_bought = list() //migrated from mind, used in GetScoreboard()
-
-	// The host (set if NEED_HOST)
-	var/datum/mind/host=null
 
 	// Objectives
 	var/datum/objective_holder/objectives=new
@@ -215,19 +200,6 @@
 
 	if(is_type_in_list(src, M.antag_roles)) //No double double agent agent
 		return 0
-	return 1
-
-// General sanity checks before assigning host.
-// Return 1 on success, 0 on failure.
-/datum/role/proc/CanBeHost(var/datum/mind/M)
-	if(protected_jobs.len>0)
-		if(M.assigned_role in protected_jobs)
-			return 0
-
-	if(protected_antags.len>0)
-		for(var/forbidden_role in protected_host_antags)
-			if(forbidden_role in M.antag_roles)
-				return 0
 	return 1
 
 // Return 1 on success, 0 on failure.
@@ -635,6 +607,7 @@
 	id = RESPONDER
 	special_role = RESPONDER
 	logo_state = "ERT_empty-logo"
+	non_antag = TRUE
 
 //________________________________________________
 

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -75,7 +75,7 @@
 
 	var/list/minds = list()
 
-	var/non_antag = FALSE // Role isn't really an antag
+	var/is_antag = TRUE // Is role antag or not?
 
 	//////////////////////////////
 	// Local
@@ -607,7 +607,7 @@
 	id = RESPONDER
 	special_role = RESPONDER
 	logo_state = "ERT_empty-logo"
-	non_antag = TRUE
+	is_antag = FALSE
 
 //________________________________________________
 

--- a/code/datums/gamemode/role/streamer.dm
+++ b/code/datums/gamemode/role/streamer.dm
@@ -5,7 +5,7 @@
 	greets = list(GREET_DEFAULT, GREET_CUSTOM)
 	default_admin_voice = "PewDiePie"
 	admin_voice_style = "djradio"
-	non_antag = TRUE
+	is_antag = FALSE
 
 	var/list/followers = list()
 	var/list/subscribers = list()

--- a/code/datums/gamemode/role/streamer.dm
+++ b/code/datums/gamemode/role/streamer.dm
@@ -5,6 +5,7 @@
 	greets = list(GREET_DEFAULT, GREET_CUSTOM)
 	default_admin_voice = "PewDiePie"
 	admin_voice_style = "djradio"
+	non_antag = TRUE
 
 	var/list/followers = list()
 	var/list/subscribers = list()

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -63,9 +63,9 @@
 			var/counts_as_antag = FALSE
 			for(var/role in C.mob.mind.antag_roles)
 				var/datum/role/R = C.mob.mind.antag_roles[role]
-				if(!R.non_antag)
+				if(R.is_antag)
 					counts_as_antag = TRUE
-				var/spanclass = R.non_antag ? "good" : "bad"
+				var/spanclass = R.is_antag ? "bad" : "good"
 				entry += " - <b><span class='[spanclass]'>[uppertext(R.name)]</span></b>"
 			if(counts_as_antag)
 				if(!(C.mob.isDead()))

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -60,13 +60,18 @@
 			else
 				living++
 		if (C.mob.mind && C.mob.mind.antag_roles.len > 0)
+			var/counts_as_antag = FALSE
 			for(var/role in C.mob.mind.antag_roles)
 				var/datum/role/R = C.mob.mind.antag_roles[role]
-				entry += " - <b><span class='red'>[uppertext(R.name)]</span></b>"
-			if(!(C.mob.isDead()))
-				living_antags++
-			else
-				dead_antags++
+				if(!R.non_antag)
+					counts_as_antag = TRUE
+				var/spanclass = R.non_antag ? "good" : "bad"
+				entry += " - <b><span class='[spanclass]'>[uppertext(R.name)]</span></b>"
+			if(counts_as_antag)
+				if(!(C.mob.isDead()))
+					living_antags++
+				else
+					dead_antags++
 		entry += " (<A HREF='?_src_=holder;adminmoreinfo=\ref[C.mob]'>?</A>)"
 		Lines += entry
 


### PR DESCRIPTION
[role][administration]
![image](https://user-images.githubusercontent.com/57303506/167302897-a4911860-ae58-496b-b16c-3a2d21f7b1e0.png)
![image](https://user-images.githubusercontent.com/57303506/167302902-092c7fe9-800c-4b06-9a63-559970c2ce99.png)
Just to disambiguate the who-advanced list and key name pairs in logging.
Not sure what ERT count as but I'm sure they aren't antag.
Also cleans up a bunch of unused code in role datums.