### PR TITLE
Cargo Supply security entry changes

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -890,12 +890,10 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/specialops
 	name = "Special Ops supplies"
 	contains = list(/obj/item/weapon/storage/box/emps,
-					/obj/item/weapon/grenade/smokebomb,
-					/obj/item/weapon/grenade/smokebomb,
-					/obj/item/weapon/grenade/smokebomb,
+					/obj/item/weapon/storage/box/smokebombs,
 					/obj/item/weapon/gun/projectile/silenced,
 					/obj/item/ammo_storage/magazine/c45)
-	cost = 20
+	cost = 50
 	containertype = /obj/structure/closet/crate/basic
 	containername = "special ops crate"
 	group = "Security"
@@ -933,23 +931,14 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 
 /datum/supply_packs/beanbagammo
 	name = "Beanbag shells"
-	contains = list(/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag)
+	contains = list(/obj/item/weapon/storage/box/beanbagshells)
 	cost = 10
 	containertype = /obj/structure/closet/crate/basic
 	containername = "beanbag shells crate"
 	group = "Security"
 
 /datum/supply_packs/weapons
-	name = "Weapons"
+	name = "Security weapons"
 	contains = list(/obj/item/weapon/melee/baton/loaded,
 					/obj/item/weapon/melee/baton/loaded,
 					/obj/item/weapon/gun/energy/laser,
@@ -957,11 +946,11 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/gun/energy/taser,
 					/obj/item/weapon/gun/energy/taser,
 					/obj/item/weapon/storage/box/flashbangs,
-					/obj/item/weapon/storage/box/flashbangs,
+					/obj/item/weapon/storage/box/teargas,
 					/obj/item/weapon/storage/box/bolas)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "weapons crate"
+	containername = "security weapons crate"
 	access = list(access_security)
 	group = "Security"
 
@@ -996,9 +985,11 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Armor"
 	contains = list(/obj/item/clothing/head/helmet/tactical/sec,
 					/obj/item/clothing/head/helmet/tactical/sec,
+					/obj/item/clothing/suit/armor/bulletproof,
+					/obj/item/clothing/suit/armor/bulletproof,
 					/obj/item/clothing/suit/armor/vest,
 					/obj/item/clothing/suit/armor/vest)
-	cost = 15
+	cost = 20
 	containertype = /obj/structure/closet/crate/secure/basic
 	containername = "armor crate"
 	access = list(access_security)
@@ -1012,18 +1003,16 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/shield/riot,
 					/obj/item/weapon/shield/riot,
 					/obj/item/weapon/shield/riot,
-					/obj/item/weapon/storage/box/flashbangs,
-					/obj/item/weapon/storage/box/flashbangs,
-					/obj/item/weapon/storage/box/flashbangs,
-					/obj/item/weapon/handcuffs,
-					/obj/item/weapon/handcuffs,
-					/obj/item/weapon/handcuffs,
 					/obj/item/clothing/head/helmet/tactical/riot,
 					/obj/item/clothing/suit/armor/riot,
 					/obj/item/clothing/head/helmet/tactical/riot,
 					/obj/item/clothing/suit/armor/riot,
 					/obj/item/clothing/head/helmet/tactical/riot,
 					/obj/item/clothing/suit/armor/riot,
+					/obj/item/weapon/storage/box/teargas,
+					/obj/item/weapon/storage/box/teargas,
+					/obj/item/weapon/storage/box/teargas,
+					/obj/item/weapon/storage/box/bolas,
 					/obj/item/weapon/storage/box/bolas,
 					/obj/item/weapon/storage/box/bolas)
 	cost = 60
@@ -1101,14 +1090,12 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Security"
 
 /datum/supply_packs/ballistic
-	name = "Ballistic gear"
-	contains = list(/obj/item/clothing/suit/armor/bulletproof,
-					/obj/item/clothing/suit/armor/bulletproof,
-					/obj/item/weapon/gun/projectile/shotgun/pump/combat,
+	name = "Combat shotguns"
+	contains = list(/obj/item/weapon/gun/projectile/shotgun/pump/combat,
 					/obj/item/weapon/gun/projectile/shotgun/pump/combat)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure/basic
-	containername = "ballistic gear crate"
+	containername = "combat shotgun crate"
 	access = list(access_armory)
 	group = "Security"
 
@@ -1116,7 +1103,6 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Shotgun shells"
 	contains = list(/obj/item/weapon/storage/box/lethalshells,
 					/obj/item/weapon/storage/box/buckshotshells,
-					/obj/item/weapon/storage/box/beanbagshells,
 					/obj/item/weapon/storage/box/stunshells,
 					/obj/item/weapon/storage/box/dartshells)
 	cost = 20


### PR DESCRIPTION
Changes various entries in the security group in the cargo supply console

- Gives spec ops supplies crate a box of smoke bombs instead of three loose grenades, raises the price from 20 to 50 credits
- Gives the beanbag shells crate a single box of beanbag shells instead of 10 loose shells
- Changes "Weapons crate" name to "Security weapons crate", changes one of the two boxes of flashbangs with a box of teargas grenades
- Added two bullet proof vests to armor crate, raised price from 15 to 20 credits
- Replaces flashbang boxes with teargas grenade boxes in the Riot crate, added one extra box of bolas and removed the three loose handcuffs
- renamed "Ballistic gear" to "Combat shotguns", removed two bullet proof vests (now in armor crate)
- removed box of beanbag shells from the shotgun shells crate (now in beanbag shells crate)

Originally I just wanted to give the riot crate those teargas grenades, as they felt more appropriate to use during a station riot, however it quickly lead to more changes to things in the security category that I felt warranted it's own PR. I feel the two changes most prevalent besides the price hike to the spec ops crate would be the name change and subsequent removal of bullet proof vests from the Ballistics gear crate, and the reallocation of the beanbag shell box from the shells crate to the beanbag shells crate. 

Starting with the ballistics gear crate, I for starters never liked the name in the first place, always felt it too vague. To that end I know it was named that due to it's inclusion of the bullet proof vests you would use to hold your shotguns, which moves us onto the 15 credit armor crate. The armor crate I always felt was too useless, 15 credits for a couple of vests simple named "armor" and a couple of security helmets nobody would ever care to buy for. To that end in order to help mitigate the ambiguity of the ballistics gear crates name and the uselessness of the armor crate contents, I opted to rename the ballistics gear crate to "Combat shotguns crate" and move it's vests to the armor crate. This way, if you want something to hold your new shotguns, you'd choose to go for the armor crate which gives you two varieties of body armor, or something like the Tactical Assault gear if you're a big spender.

As for the beanbag shell crate, I always thought the loose shells in the crate looked sloppy, and you'd just as well print out beanbags for whoever buying them at the lathe then actually order the damn things. With that said, you might ask why remove the beanbag shells from the normal shotgun shell crate? Simply put, Shotgun Darts. I had for a moment considered changing the beanbag shells crate to the "Civilian shells crate" and adding the darts to the crate, but I came to the conclusion that darts are just beanbags that give slight toxic damage instead of slight brute. To that end I thought 'Why even bother having beanbags and darts in the same crate if they're practically the same thing?' That and the fact that stun shells do the beanbag shells job only 10x more effective in the same crate, would usually mean beanbag boxes would just catch dust. I really think we should either change the functionalities of dart shells to be more useful, or just remove them flat out, but in the meantime, if someone wants to use less then lethals without leaving shrapnel from the shells box, this'll incentive them to use dart shells.

**TLDR: Armor crate too useless, ballistics crate name too vague, so why not give the bullet proof vest to the armor crate to make name better? Beanbag and Darts too similar, so why not give beanbag box to it's own crate?**

:cl:
 * tweak: Changes contents of various security crates from the supply console
