### PR TITLE
Hiding tiny items under floortiles

### DIFF
--- a/__DEFINES/planes+layers.dm
+++ b/__DEFINES/planes+layers.dm
@@ -87,6 +87,7 @@ Why is FLOAT_PLANE added to a bunch of these?
 	#define VENT_BEZEL_LAYER			7
 	#define WIRE_TERMINAL_LAYER			8
 	#define PULSEDEMON_LAYER			9
+	#define FLOORBOARD_ITEM_LAYER		10
 
 #define FLOOR_PLANE 			(-3 + FLOAT_PLANE)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -120,6 +120,7 @@
 		invisibility = i ? 101 : 0
 		plane = i ? ABOVE_PLATING_PLANE : initial(plane)
 		layer = i ? FLOORBOARD_ITEM_LAYER : initial(layer)
+		anchored = i
 
 /obj/item/t_scanner_expose()
 	if (level != LEVEL_BELOW_FLOOR)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -122,6 +122,11 @@
 		layer = i ? FLOORBOARD_ITEM_LAYER : initial(layer)
 		anchored = i
 
+/obj/item/Crossed(atom/movable/AM)
+	if(level < LEVEL_ABOVE_FLOOR)
+		return 1
+	return 0
+
 /obj/item/t_scanner_expose()
 	if (level != LEVEL_BELOW_FLOOR)
 		return

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -114,6 +114,31 @@
 		I.desc = "Looks like this was \a [src] some time ago."
 		qdel(src)
 
+/obj/item/hide(i)
+	if(isturf(loc))
+		level = i ? LEVEL_BELOW_FLOOR : LEVEL_ABOVE_FLOOR
+		invisibility = i ? 101 : 0
+		plane = i ? ABOVE_PLATING_PLANE : initial(plane)
+		layer = i ? FLOORBOARD_ITEM_LAYER : initial(layer)
+
+/obj/item/t_scanner_expose()
+	if (level != LEVEL_BELOW_FLOOR)
+		return
+
+	var/oldalpha = alpha
+	invisibility = 0
+	alpha = 127
+	plane = initial(plane)
+	layer = initial(layer)
+
+	spawn(1 SECONDS)
+		var/turf/U = loc
+		if(istype(U) && U.intact)
+			invisibility = 101
+			plane = ABOVE_PLATING_PLANE
+			layer = FLOORBOARD_ITEM_LAYER
+		alpha = oldalpha
+
 /obj/item/device
 	icon = 'icons/obj/device.dmi'
 
@@ -1284,16 +1309,16 @@ var/global/list/image/blood_overlays = list()
 	//Attempt to damage the item if it's breakable here.
 	var/glanced = TRUE
 	var/broken = FALSE
-	
+
 	if(breakable_flags & BREAKABLE_UNARMED)
 		glanced=!take_damage(get_obj_kick_damage(H, kickingfoot), skip_break = TRUE, mute = TRUE)
-		
+
 	H.visible_message("<span class='danger'>[H] kicks \the [src][generate_break_text(glanced, TRUE)]</span>", "<span class='danger'>You kick \the [src][generate_break_text(glanced, TRUE)]</span>")
-	
+
 	if(breakable_flags & BREAKABLE_UNARMED)
 		var/thispropel = new /datum/throwparams(T, kick_power, 1)
 		broken = try_break(propelparams = thispropel)
-		
+
 	if(kick_power >= 6 && !broken) //Fly in an arc!
 		spawn()
 			var/original_pixel_y = pixel_y

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -96,7 +96,7 @@
 	return 0
 
 /obj/item/candle/Crossed(var/obj/Proj)
-	if(isbeam(Proj))
+	if(isbeam(Proj) && level == LEVEL_ABOVE_FLOOR)
 		var/obj/item/projectile/beam/P = Proj//could be a laser beam or an emitter beam, both feature the get_damage() proc, for now...
 		if(P.get_damage() != 0)
 			light("", 1)

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -96,7 +96,9 @@
 	return 0
 
 /obj/item/candle/Crossed(var/obj/Proj)
-	if(isbeam(Proj) && level == LEVEL_ABOVE_FLOOR)
+	if(..())
+		return 1
+	if(isbeam(Proj))
 		var/obj/item/projectile/beam/P = Proj//could be a laser beam or an emitter beam, both feature the get_damage() proc, for now...
 		if(P.get_damage() != 0)
 			light("", 1)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -551,7 +551,9 @@ var/global/msg_id = 0
 		map_app.holomap.stopWatching()
 
 /obj/item/device/pda/clown/Crossed(AM as mob|obj) //Clown PDA is slippery.
-	if (istype(AM, /mob/living/carbon) && level == LEVEL_ABOVE_FLOOR)
+	if(..())
+		return 1
+	if (iscarbon(AM))
 		var/mob/living/carbon/M = AM
 		if (M.Slip(8, 5, 1))
 			to_chat(M, "<span class='notice'>You slipped on the PDA!</span>")

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -551,7 +551,7 @@ var/global/msg_id = 0
 		map_app.holomap.stopWatching()
 
 /obj/item/device/pda/clown/Crossed(AM as mob|obj) //Clown PDA is slippery.
-	if (istype(AM, /mob/living/carbon))
+	if (istype(AM, /mob/living/carbon) && level == LEVEL_ABOVE_FLOOR)
 		var/mob/living/carbon/M = AM
 		if (M.Slip(8, 5, 1))
 			to_chat(M, "<span class='notice'>You slipped on the PDA!</span>")

--- a/code/game/objects/items/gum.dm
+++ b/code/game/objects/items/gum.dm
@@ -198,7 +198,9 @@
 	update_icon()
 
 /obj/item/gum/Crossed(mob/living/carbon/human/AM)
-	if(chewed && !locked_to && level == LEVEL_ABOVE_FLOOR)
+	if(..())
+		return 1
+	if(chewed && !locked_to)
 		if(istype(AM) && AM.on_foot())
 			gum_shoes(AM)
 

--- a/code/game/objects/items/gum.dm
+++ b/code/game/objects/items/gum.dm
@@ -198,10 +198,9 @@
 	update_icon()
 
 /obj/item/gum/Crossed(mob/living/carbon/human/AM)
-	if(chewed && !locked_to)
+	if(chewed && !locked_to && level == LEVEL_ABOVE_FLOOR)
 		if(istype(AM) && AM.on_foot())
 			gum_shoes(AM)
-	..()
 
 /obj/item/gum/proc/gum_shoes(mob/living/carbon/human/H)	//make this explode
 	if(!istype(H))

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -8,22 +8,23 @@
  * Banana Peels
  */
 /obj/item/weapon/bananapeel/Crossed(AM as mob|obj)
-	if(level == LEVEL_ABOVE_FLOOR) // Slipping if these are below a floor tile is nonsensical
-		if (istype(AM, /mob/living/carbon))
-			var/mob/living/carbon/M = AM
-			if(slip_n_slide(M))
-				M.simple_message("<span class='notice'>You slipped on the [name]!</span>",
-					"<span class='userdanger'>Something is scratching at your feet! Oh god!</span>")
-		if(istype(AM, /obj/structure/bed/chair/vehicle/gokart))
-			var/obj/structure/bed/chair/vehicle/gokart/kart = AM
-			var/left_or_right = prob(50) ? turn(kart.dir, 90) : turn(kart.dir, -90)
-			var/tiles_to_slip = rand(round(potency/20, 1), round(potency/10, 1))
-			kart.speen()
-			playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
-			spawn()
-				for(var/i in 1 to tiles_to_slip)
-					step(kart, left_or_right)
-					sleep(1)
+	if(..())  // Slipping if these are below a floor tile is nonsensical
+		return 1
+	if (iscarbon(AM))
+		var/mob/living/carbon/M = AM
+		if(slip_n_slide(M))
+			M.simple_message("<span class='notice'>You slipped on the [name]!</span>",
+				"<span class='userdanger'>Something is scratching at your feet! Oh god!</span>")
+	if(istype(AM, /obj/structure/bed/chair/vehicle/gokart))
+		var/obj/structure/bed/chair/vehicle/gokart/kart = AM
+		var/left_or_right = prob(50) ? turn(kart.dir, 90) : turn(kart.dir, -90)
+		var/tiles_to_slip = rand(round(potency/20, 1), round(potency/10, 1))
+		kart.speen()
+		playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
+		spawn()
+			for(var/i in 1 to tiles_to_slip)
+				step(kart, left_or_right)
+				sleep(1)
 
 /datum/locking_category/banana_peel
 

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -10,6 +10,11 @@
 /obj/item/weapon/bananapeel/Crossed(AM as mob|obj)
 	if(..())  // Slipping if these are below a floor tile is nonsensical
 		return 1
+	handle_slip(AM)
+
+/datum/locking_category/banana_peel
+
+/obj/item/weapon/bananapeel/proc/handle_slip(atom/movable/AM)
 	if (iscarbon(AM))
 		var/mob/living/carbon/M = AM
 		if(slip_n_slide(M))
@@ -25,8 +30,6 @@
 			for(var/i in 1 to tiles_to_slip)
 				step(kart, left_or_right)
 				sleep(1)
-
-/datum/locking_category/banana_peel
 
 /obj/item/weapon/bananapeel/proc/slip_n_slide(var/mob/living/carbon/M)
 	if(!M.Slip(2,2,1))

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -8,21 +8,22 @@
  * Banana Peels
  */
 /obj/item/weapon/bananapeel/Crossed(AM as mob|obj)
-	if (istype(AM, /mob/living/carbon))
-		var/mob/living/carbon/M = AM
-		if(slip_n_slide(M))
-			M.simple_message("<span class='notice'>You slipped on the [name]!</span>",
-				"<span class='userdanger'>Something is scratching at your feet! Oh god!</span>")
-	if(istype(AM, /obj/structure/bed/chair/vehicle/gokart))
-		var/obj/structure/bed/chair/vehicle/gokart/kart = AM
-		var/left_or_right = prob(50) ? turn(kart.dir, 90) : turn(kart.dir, -90)
-		var/tiles_to_slip = rand(round(potency/20, 1), round(potency/10, 1))
-		kart.speen()
-		playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
-		spawn()
-			for(var/i in 1 to tiles_to_slip)
-				step(kart, left_or_right)
-				sleep(1)
+	if(level == LEVEL_ABOVE_FLOOR) // Slipping if these are below a floor tile is nonsensical
+		if (istype(AM, /mob/living/carbon))
+			var/mob/living/carbon/M = AM
+			if(slip_n_slide(M))
+				M.simple_message("<span class='notice'>You slipped on the [name]!</span>",
+					"<span class='userdanger'>Something is scratching at your feet! Oh god!</span>")
+		if(istype(AM, /obj/structure/bed/chair/vehicle/gokart))
+			var/obj/structure/bed/chair/vehicle/gokart/kart = AM
+			var/left_or_right = prob(50) ? turn(kart.dir, 90) : turn(kart.dir, -90)
+			var/tiles_to_slip = rand(round(potency/20, 1), round(potency/10, 1))
+			kart.speen()
+			playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
+			spawn()
+				for(var/i in 1 to tiles_to_slip)
+					step(kart, left_or_right)
+					sleep(1)
 
 /datum/locking_category/banana_peel
 
@@ -71,7 +72,7 @@
 		add_fingerprint(user)
 
 /obj/item/weapon/bikehorn/Crossed(var/mob/living/AM)
-	if (isliving(AM) && world.time > next_honk)
+	if (isliving(AM) && world.time > next_honk) // Honking these while under floortiles is fine though
 		honk(AM)
 		next_honk = world.time + honk_delay
 

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -103,7 +103,7 @@
 	show_roll(user, thrown, result)
 
 /obj/item/weapon/dice/d4/Crossed(var/mob/living/carbon/human/H)
-	if(istype(H) && !H.shoes)
+	if(istype(H) && !H.shoes && level == LEVEL_ABOVE_FLOOR)
 		to_chat(H, "<span class='danger'>You step on the D4!</span>")
 		H.apply_damage(4,BRUTE,(pick(LIMB_LEFT_LEG, LIMB_RIGHT_LEG)))
 		H.Knockdown(3)

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -103,7 +103,9 @@
 	show_roll(user, thrown, result)
 
 /obj/item/weapon/dice/d4/Crossed(var/mob/living/carbon/human/H)
-	if(istype(H) && !H.shoes && level == LEVEL_ABOVE_FLOOR)
+	if(..())
+		return 1
+	if(istype(H) && !H.shoes)
 		to_chat(H, "<span class='danger'>You step on the D4!</span>")
 		H.apply_damage(4,BRUTE,(pick(LIMB_LEFT_LEG, LIMB_RIGHT_LEG)))
 		H.Knockdown(3)

--- a/code/game/objects/items/weapons/grenades/clowngrenade.dm
+++ b/code/game/objects/items/weapons/grenades/clowngrenade.dm
@@ -67,7 +67,9 @@
 	var/slip_power = 4
 
 /obj/item/weapon/bananapeel/traitorpeel/Crossed(AM as mob|obj)
-	if(isliving(AM) && level == LEVEL_ABOVE_FLOOR)
+	if(..())
+		return 1
+	if(isliving(AM))
 		var/burned = rand(2,5)
 		var/mob/living/M = AM
 		if(M.lying)
@@ -84,18 +86,6 @@
 				M.take_overall_damage(0, max(0, (burned - 2)))
 
 		if(!istype(M, /mob/living/carbon/slime) && !isrobot(M))
-			M.stop_pulling()
-			step(M, M.dir)
-			spawn(1)
-				for(var/i = 1 to slip_power)
-					step(M, M.dir)
-					sleep(1)
-			M.take_organ_damage(2) // Was 5 -- TLE
-			M.simple_message("<span class='notice'>You slipped on \the [name]!</span>",\
-				"<span class='userdanger'>Please, just end the pain!</span>")
-			playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
-			M.Knockdown(10)
-			M.Stun(10)
 			M.take_overall_damage(0, burned)
 
 /obj/item/weapon/bananapeel/traitorpeel/throw_impact(atom/hit_atom)

--- a/code/game/objects/items/weapons/grenades/clowngrenade.dm
+++ b/code/game/objects/items/weapons/grenades/clowngrenade.dm
@@ -67,8 +67,8 @@
 	var/slip_power = 4
 
 /obj/item/weapon/bananapeel/traitorpeel/Crossed(AM as mob|obj)
-	var/burned = rand(2,5)
-	if(istype(AM, /mob/living))
+	if(isliving(AM) && level == LEVEL_ABOVE_FLOOR)
+		var/burned = rand(2,5)
 		var/mob/living/M = AM
 		if(M.lying)
 			M.take_overall_damage(0, max(0, (burned - 2)))

--- a/code/game/objects/items/weapons/grenades/clowngrenade.dm
+++ b/code/game/objects/items/weapons/grenades/clowngrenade.dm
@@ -66,9 +66,7 @@
 
 	var/slip_power = 4
 
-/obj/item/weapon/bananapeel/traitorpeel/Crossed(AM as mob|obj)
-	if(..())
-		return 1
+/obj/item/weapon/bananapeel/traitorpeel/handle_slip(atom/movable/AM)
 	if(isliving(AM))
 		var/burned = rand(2,5)
 		var/mob/living/M = AM
@@ -86,6 +84,18 @@
 				M.take_overall_damage(0, max(0, (burned - 2)))
 
 		if(!istype(M, /mob/living/carbon/slime) && !isrobot(M))
+			M.stop_pulling()
+			step(M, M.dir)
+			spawn(1)
+				for(var/i = 1 to slip_power)
+					step(M, M.dir)
+					sleep(1)
+			M.take_organ_damage(2) // Was 5 -- TLE
+			M.simple_message("<span class='notice'>You slipped on \the [name]!</span>",\
+				"<span class='userdanger'>Please, just end the pain!</span>")
+			playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
+			M.Knockdown(10)
+			M.Stun(10)
 			M.take_overall_damage(0, burned)
 
 /obj/item/weapon/bananapeel/traitorpeel/throw_impact(atom/hit_atom)

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -316,7 +316,9 @@
 			sleep(1)
 
 /obj/item/weapon/melee/energy/sword/dualsaber/bananabunch/Crossed(AM as mob|obj)
-	if (iscarbon(AM) && level == LEVEL_ABOVE_FLOOR)
+	if(..())
+		return 1
+	if (iscarbon(AM))
 		var/mob/living/carbon/M = AM
 		if (M.Slip(2, 2, 1))
 			M.simple_message("<span class='notice'>You slipped on [src]!</span>",

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -316,7 +316,7 @@
 			sleep(1)
 
 /obj/item/weapon/melee/energy/sword/dualsaber/bananabunch/Crossed(AM as mob|obj)
-	if (istype(AM, /mob/living/carbon))
+	if (iscarbon(AM) && level == LEVEL_ABOVE_FLOOR)
 		var/mob/living/carbon/M = AM
 		if (M.Slip(2, 2, 1))
 			M.simple_message("<span class='notice'>You slipped on [src]!</span>",

--- a/code/game/objects/items/weapons/shard.dm
+++ b/code/game/objects/items/weapons/shard.dm
@@ -99,6 +99,6 @@
 	return ..()
 
 /obj/item/weapon/shard/Crossed(var/mob/living/AM)
-	if(level == LEVEL_ABOVE_FLOOR)
-		FeetStab(AM)
-	..()
+	if(..())
+		return 1
+	FeetStab(AM)

--- a/code/game/objects/items/weapons/shard.dm
+++ b/code/game/objects/items/weapons/shard.dm
@@ -99,5 +99,6 @@
 	return ..()
 
 /obj/item/weapon/shard/Crossed(var/mob/living/AM)
-	FeetStab(AM)
+	if(level == LEVEL_ABOVE_FLOOR)
+		FeetStab(AM)
 	..()

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -47,7 +47,9 @@
 
 
 /obj/item/weapon/soap/Crossed(var/atom/movable/AM)
-	if (istype(AM, /mob/living/carbon) && level == LEVEL_ABOVE_FLOOR)
+	if(..())
+		return 1
+	if (iscarbon(AM))
 		var/mob/living/carbon/M = AM
 		if (M.Slip(3, 2, 1))
 			M.simple_message("<span class='notice'>You slipped on the [name]!</span>",

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -47,7 +47,7 @@
 
 
 /obj/item/weapon/soap/Crossed(var/atom/movable/AM)
-	if (istype(AM, /mob/living/carbon))
+	if (istype(AM, /mob/living/carbon) && level == LEVEL_ABOVE_FLOOR)
 		var/mob/living/carbon/M = AM
 		if (M.Slip(3, 2, 1))
 			M.simple_message("<span class='notice'>You slipped on the [name]!</span>",

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -128,7 +128,7 @@ Frequency:
 	item_state = "bluespacebanana_peel"
 
 /obj/item/weapon/bananapeel/bluespace/Crossed(AM as mob|obj)
-	if (istype(AM, /mob/living/carbon))
+	if (istype(AM, /mob/living/carbon) && level == LEVEL_ABOVE_FLOOR)
 		var/mob/living/carbon/M = AM
 		if (M.Slip(2, 2, 1))
 			M.simple_message("<span class='notice'>You slipped on the [name]!</span>",

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -127,17 +127,20 @@ Frequency:
 	icon_state = "peel"
 	item_state = "bluespacebanana_peel"
 
-/obj/item/weapon/bananapeel/bluespace/Crossed(AM as mob|obj)
-	if(..())
-		return 1
-	if(ishuman(AM))
-		var/mob/living/carbon/human/H = AM
-		var/obj/teleported_shoes = H.get_item_by_slot(slot_shoes)
-		var/tele_destination = pick_rand_tele_turf(H, src.potency/15, src.potency/10)
-		if(teleported_shoes && tele_destination)
-			H.drop_from_inventory(teleported_shoes)
-			teleported_shoes.forceMove(tele_destination)
-			spark(H.loc)
+/obj/item/weapon/bananapeel/bluespace/handle_slip(atom/movable/AM)
+	if (iscarbon(AM))
+		var/mob/living/carbon/M = AM
+		if (M.Slip(2, 2, 1))
+			M.simple_message("<span class='notice'>You slipped on the [name]!</span>",
+				"<span class='userdanger'>Something is scratching at your feet! Oh god!</span>")
+			if(ishuman(AM))
+				var/mob/living/carbon/human/H = AM
+				var/obj/teleported_shoes = H.get_item_by_slot(slot_shoes)
+				var/tele_destination = pick_rand_tele_turf(H, src.potency/15, src.potency/10)
+				if(teleported_shoes && tele_destination)
+					H.drop_from_inventory(teleported_shoes)
+					teleported_shoes.forceMove(tele_destination)
+					spark(H.loc)
 
 /*
  * Hand-tele

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -128,19 +128,16 @@ Frequency:
 	item_state = "bluespacebanana_peel"
 
 /obj/item/weapon/bananapeel/bluespace/Crossed(AM as mob|obj)
-	if (istype(AM, /mob/living/carbon) && level == LEVEL_ABOVE_FLOOR)
-		var/mob/living/carbon/M = AM
-		if (M.Slip(2, 2, 1))
-			M.simple_message("<span class='notice'>You slipped on the [name]!</span>",
-				"<span class='userdanger'>Something is scratching at your feet! Oh god!</span>")
-			if(istype(AM,/mob/living/carbon/human))
-				var/mob/living/carbon/human/H = AM
-				var/obj/teleported_shoes = H.get_item_by_slot(slot_shoes)
-				var/tele_destination = pick_rand_tele_turf(H, src.potency/15, src.potency/10)
-				if(teleported_shoes && tele_destination)
-					H.drop_from_inventory(teleported_shoes)
-					teleported_shoes.forceMove(tele_destination)
-					spark(H.loc)
+	if(..())
+		return 1
+	if(ishuman(AM))
+		var/mob/living/carbon/human/H = AM
+		var/obj/teleported_shoes = H.get_item_by_slot(slot_shoes)
+		var/tele_destination = pick_rand_tele_turf(H, src.potency/15, src.potency/10)
+		if(teleported_shoes && tele_destination)
+			H.drop_from_inventory(teleported_shoes)
+			teleported_shoes.forceMove(tele_destination)
+			spark(H.loc)
 
 /*
  * Hand-tele

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -218,7 +218,7 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 
 /turf/simulated/floor/attack_paw(mob/user as mob)
 	return src.attack_hand(user)
-	
+
 /turf/simulated/floor/attack_animal(mob/user as mob)
 	return src.attack_hand(user)
 
@@ -400,6 +400,12 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 	material = "metal"
 	plane = PLATING_PLANE
 
+	for(var/obj/item/I in contents)
+		// Sorry about magic number but this is what the value actually gets set to in make_metal_floor, rather than what the define becomes.
+		if(I.layer == FLOORBOARD_ITEM_LAYER && I.plane == 32765 && I.invisibility == 101 && !istype(I,/obj/item/projectile))
+			I.plane = initial(I.plane)
+			I.layer = initial(I.layer)
+			I.invisibility = initial(I.invisibility)
 	update_icon()
 	levelupdate()
 
@@ -434,6 +440,11 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 			if(istype(get_step(src,direction),/turf/simulated/floor))
 				var/turf/simulated/floor/FF = get_step(src,direction)
 				FF.update_icon() //so siding gets updated properly
+	for(var/obj/item/I in contents)
+		if(I.w_class == W_CLASS_TINY && !istype(I,/obj/item/projectile))
+			I.plane = ABOVE_PLATING_PLANE
+			I.layer = FLOORBOARD_ITEM_LAYER
+			I.invisibility = 101
 	update_icon()
 	levelupdate()
 	playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -402,10 +402,7 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 
 	for(var/obj/item/I in contents)
 		if(I.level == LEVEL_BELOW_FLOOR && !istype(I,/obj/item/projectile))
-			I.plane = initial(I.plane)
-			I.layer = initial(I.layer)
-			I.invisibility = initial(I.invisibility)
-			I.level = initial(I.level)
+			I.hide(intact)
 	update_icon()
 	levelupdate()
 
@@ -445,10 +442,7 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 		for(var/obj/item/I in contents)
 			// Hiding things under the tiles!
 			if(I.w_class == W_CLASS_TINY && !istype(I,/obj/item/projectile))
-				I.plane = ABOVE_PLATING_PLANE
-				I.layer = FLOORBOARD_ITEM_LAYER
-				I.level = LEVEL_BELOW_FLOOR
-				I.invisibility = 101
+				I.hide(intact)
 	update_icon()
 	levelupdate()
 	playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -401,11 +401,11 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 	plane = PLATING_PLANE
 
 	for(var/obj/item/I in contents)
-		// Sorry about magic number but this is what the value actually gets set to in make_metal_floor, rather than what the define becomes.
-		if(I.layer == FLOORBOARD_ITEM_LAYER && I.plane == 32765 && I.invisibility == 101 && !istype(I,/obj/item/projectile))
+		if(I.level == LEVEL_BELOW_FLOOR && !istype(I,/obj/item/projectile))
 			I.plane = initial(I.plane)
 			I.layer = initial(I.layer)
 			I.invisibility = initial(I.invisibility)
+			I.level = initial(I.level)
 	update_icon()
 	levelupdate()
 
@@ -444,6 +444,7 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 		if(I.w_class == W_CLASS_TINY && !istype(I,/obj/item/projectile))
 			I.plane = ABOVE_PLATING_PLANE
 			I.layer = FLOORBOARD_ITEM_LAYER
+			I.level = LEVEL_BELOW_FLOOR
 			I.invisibility = 101
 	update_icon()
 	levelupdate()

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -440,12 +440,15 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 			if(istype(get_step(src,direction),/turf/simulated/floor))
 				var/turf/simulated/floor/FF = get_step(src,direction)
 				FF.update_icon() //so siding gets updated properly
-	for(var/obj/item/I in contents)
-		if(I.w_class == W_CLASS_TINY && !istype(I,/obj/item/projectile))
-			I.plane = ABOVE_PLATING_PLANE
-			I.layer = FLOORBOARD_ITEM_LAYER
-			I.level = LEVEL_BELOW_FLOOR
-			I.invisibility = 101
+	// Placement sanity
+	if(!(locate(/obj/structure/table) in contents) && !(locate(/obj/structure/rack) in contents) && !(locate(/obj/structure/closet) in contents))
+		for(var/obj/item/I in contents)
+			// Hiding things under the tiles!
+			if(I.w_class == W_CLASS_TINY && !istype(I,/obj/item/projectile))
+				I.plane = ABOVE_PLATING_PLANE
+				I.layer = FLOORBOARD_ITEM_LAYER
+				I.level = LEVEL_BELOW_FLOOR
+				I.invisibility = 101
 	update_icon()
 	levelupdate()
 	playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -82,7 +82,9 @@
 
 
 /obj/item/device/assembly/mousetrap/Crossed(AM as mob|obj)
-	if(armed && level == LEVEL_ABOVE_FLOOR)
+	if(..())
+		return 1
+	if(armed)
 		if(ishuman(AM))
 			var/mob/living/carbon/H = AM
 			if(H.m_intent == "run")
@@ -91,7 +93,6 @@
 								  "<span class='warning'>You accidentally step on [src]</span>")
 		if(ismouse(AM))
 			triggered(AM)
-	..()
 
 
 /obj/item/device/assembly/mousetrap/on_found(mob/wearer, mob/finder as mob)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -82,7 +82,7 @@
 
 
 /obj/item/device/assembly/mousetrap/Crossed(AM as mob|obj)
-	if(armed)
+	if(armed && level == LEVEL_ABOVE_FLOOR)
 		if(ishuman(AM))
 			var/mob/living/carbon/H = AM
 			if(H.m_intent == "run")

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -192,8 +192,9 @@
 	Attach(M)
 
 /obj/item/clothing/mask/facehugger/Crossed(atom/target) // Instead of HasEntered. Probably the right proc, probably.
-	if(level == LEVEL_ABOVE_FLOOR)
-		HasProximity(target)
+	if(..())
+		return 1
+	HasProximity(target)
 
 /obj/item/clothing/mask/facehugger/on_found(wearer, mob/finder as mob)
 	if(stat == CONSCIOUS)

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -192,8 +192,8 @@
 	Attach(M)
 
 /obj/item/clothing/mask/facehugger/Crossed(atom/target) // Instead of HasEntered. Probably the right proc, probably.
-	HasProximity(target)
-	return
+	if(level == LEVEL_ABOVE_FLOOR)
+		HasProximity(target)
 
 /obj/item/clothing/mask/facehugger/on_found(wearer, mob/finder as mob)
 	if(stat == CONSCIOUS)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -2058,7 +2058,7 @@
 	bitesize = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/butter/Crossed(atom/movable/O)
-	if (istype(O, /mob/living/carbon/human))
+	if (ishuman(O) && level == LEVEL_ABOVE_FLOOR)
 		var/mob/living/carbon/human/H = O
 		if (H.CheckSlip() != TRUE)
 			return
@@ -2297,7 +2297,7 @@
 	crumb_icon = "dribbles"
 	random_filling_colors = list("#5A01EF", "#4B2A7F", "#826BA7", "#573D80")
 	valid_utensils = UTENSILE_SPOON
-	
+
 /obj/item/weapon/reagent_containers/food/snacks/roboticiststears/New()
 	..()
 	reagents.add_reagent(NUTRIMENT, 60) //You're using phazon here, that's the good shit.
@@ -4957,7 +4957,7 @@
 	icon_state = "slider_slippery"
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/slippery/Crossed(atom/movable/O) //exactly the same as soap
-	if (istype(O, /mob/living/carbon/human))
+	if (ishuman(O) && level == LEVEL_ABOVE_FLOOR)
 		var/mob/living/carbon/human/H = O
 		if (H.CheckSlip() != TRUE)
 			return
@@ -6654,7 +6654,7 @@ var/global/list/bomb_like_items = list(/obj/item/device/transfer_valve, /obj/ite
 	base_crumb_chance = 0
 
 /obj/item/weapon/reagent_containers/food/snacks/butterstick/Crossed(atom/movable/O)
-	if (istype(O, /mob/living/carbon/human))
+	if (ishuman(O) && level == LEVEL_ABOVE_FLOOR)
 		var/mob/living/carbon/human/H = O
 		if (H.CheckSlip() != TRUE)
 			return

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -2058,7 +2058,9 @@
 	bitesize = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/butter/Crossed(atom/movable/O)
-	if (ishuman(O) && level == LEVEL_ABOVE_FLOOR)
+	if(..())
+		return 1
+	if (ishuman(O))
 		var/mob/living/carbon/human/H = O
 		if (H.CheckSlip() != TRUE)
 			return
@@ -4957,7 +4959,9 @@
 	icon_state = "slider_slippery"
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/slippery/Crossed(atom/movable/O) //exactly the same as soap
-	if (ishuman(O) && level == LEVEL_ABOVE_FLOOR)
+	if(..())
+		return 1
+	if (ishuman(O))
 		var/mob/living/carbon/human/H = O
 		if (H.CheckSlip() != TRUE)
 			return
@@ -6654,7 +6658,9 @@ var/global/list/bomb_like_items = list(/obj/item/device/transfer_valve, /obj/ite
 	base_crumb_chance = 0
 
 /obj/item/weapon/reagent_containers/food/snacks/butterstick/Crossed(atom/movable/O)
-	if (ishuman(O) && level == LEVEL_ABOVE_FLOOR)
+	if(..())
+		return 1
+	if (ishuman(O))
 		var/mob/living/carbon/human/H = O
 		if (H.CheckSlip() != TRUE)
 			return

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -127,11 +127,7 @@ var/list/special_fruits = list()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/Crossed(var/mob/living/carbon/M)
 	..()
-	if(!seed)
-		return
-	if(!istype(M))
-		return
-	if(!M.on_foot())
+	if(!seed || level != LEVEL_ABOVE_FLOOR || !istype(M) || !M.on_foot())
 		return
 	if(seed.thorny || seed.stinging)
 		if(istype(M, /mob/living/carbon/human))

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -126,8 +126,7 @@ var/list/special_fruits = list()
 	return ..()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/Crossed(var/mob/living/carbon/M)
-	..()
-	if(!seed || level != LEVEL_ABOVE_FLOOR || !istype(M) || !M.on_foot())
+	if(!seed || ..() || !istype(M) || !M.on_foot())
 		return
 	if(seed.thorny || seed.stinging)
 		if(istype(M, /mob/living/carbon/human))


### PR DESCRIPTION
[content]
![hiding](https://user-images.githubusercontent.com/57303506/167490347-ebb01266-3135-45f0-8d38-9165d6252b80.gif)
![image](https://user-images.githubusercontent.com/57303506/167629929-f3d7a67d-9876-43b7-a130-10f87272e4b0.png)

## What this does
Allows any item with w_class of tiny to be hidden under any kind of floor tile on a bare plating.

## Why it's good
Another way to hide items, and another method to check for them, while being balanced enough as to not hide huge things like guns.

## Changelog
:cl:
 * rscadd: Tiled floors can now be used to store very small items. A t-ray scanner will still expose them like anything else underneath.
