### PR TITLE
Nerf Emagged Pod Explosion

### DIFF
--- a/code/game/shuttles/emergency.dm
+++ b/code/game/shuttles/emergency.dm
@@ -98,7 +98,7 @@ var/global/datum/shuttle/escape/escape_shuttle = new(starting_area=/area/shuttle
 		if(!move_to_dock(dock_shuttle, 0, 180))
 			message_admins("Warning: [src] failed to crash into shuttle.")
 		else
-			explosion(get_turf(dock_shuttle), 2, 4, 5, 6)
+			explosion(get_turf(dock_shuttle), 2, 2, 3, 6)
 
 			for(var/mob/living/M in emergency_shuttle.shuttle.linked_area)
 				shake_camera(M, 10, 1) 

--- a/code/game/shuttles/emergency.dm
+++ b/code/game/shuttles/emergency.dm
@@ -98,7 +98,7 @@ var/global/datum/shuttle/escape/escape_shuttle = new(starting_area=/area/shuttle
 		if(!move_to_dock(dock_shuttle, 0, 180))
 			message_admins("Warning: [src] failed to crash into shuttle.")
 		else
-			explosion(get_turf(dock_shuttle), 2, 2, 3, 6)
+			explosion(get_turf(dock_shuttle), 2, 3, 4, 6)
 
 			for(var/mob/living/M in emergency_shuttle.shuttle.linked_area)
 				shake_camera(M, 10, 1) 


### PR DESCRIPTION
## What this does
Reduces the explosive power of emagged shuttles. Extremely based addition but they are just a tiny bit too strong at the moment.

## Why it's good
At the moment, when someone emagged multiple pods, it's pretty much impossible to survive. 
With an explosive range of 4 for heavy explosions, and 5 for light explosions(Two of which will put you in crit), there's nowhere safe.
This reduces the range for heavy explosion down to 3 tiles and light explosions down to 4. This makes it powerful but not insta death for nearly everybody,

:cl:
 * tweak: Slight nerf of emagged escape pods explosive power


