### PR TITLE
Removes reagent targeting from thrown drinks

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -1802,7 +1802,7 @@
 				message_admins("[lit ? "Lit" : "Unlit"] molotov shattered at [formatJumpTo(get_turf(hit_atom))], thrown by [key_name_admin(user)] and containing [reagents.get_reagent_ids()]")
 			reagents.reaction(get_turf(src), TOUCH) //splat the floor AND the thing we hit, otherwise fuel wouldn't ignite when hitting anything that wasn't a floor
 			if(hit_atom != get_turf(src)) //prevent spilling on the floor twice though
-				reagents.reaction(hit_atom, TOUCH, zone_sels = list(user.zone_sel.selecting))  //maybe this could be improved?
+				reagents.reaction(hit_atom, TOUCH)  //maybe this could be improved?
 		invisibility = INVISIBILITY_MAXIMUM  //so it stays a while to ignite any fuel
 
 		if(molotov == 1) //for molotovs


### PR DESCRIPTION
[bugfix]

## What this does
Closes #32538.

## Why it's good
Passing usr as the throw_impact user in to_bump() fixes this, but I'd rather code limb targeting for throwing separately some other time instead.

## Changelog
:cl:
 * bugfix: Drinking glasses with reagents now shatter on impact again.