### PR TITLE
Lamps in unoccupied departments off at roundstart and lamp flickering by ghosts.

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -637,7 +637,7 @@ var/datum/controller/gameticker/ticker
 				to_chat(R, R.connected_ai?"<b>You have synchronized with an AI. Their name will be stated shortly. Other AIs can be ignored.</b>":"<b>You are not synchronized with an AI, and therefore are not required to heed the instructions of any unless you are synced to them.</b>")
 			R.lawsync()
 
-	//Toggle lightswitches on in occupied departments
+	//Toggle lightswitches and lamps on in occupied departments
 	var/discrete_areas = list()
 	for(var/mob/living/carbon/human/H in player_list)
 		var/area/A = get_area(H)
@@ -646,6 +646,8 @@ var/datum/controller/gameticker/ticker
 	for(var/area/DA in discrete_areas)
 		for(var/obj/machinery/light_switch/LS in DA)
 			LS.toggle_switch(1)
+		for(var/obj/item/device/flashlight/lamp/L in DA)
+			L.toggle_onoff(1)
 
 // -- Tag mode!
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -18,6 +18,7 @@
 	var/has_sound = 1 //The CLICK sound when turning on/off
 	var/sound_on = 'sound/items/flashlight_on.ogg'
 	var/sound_off = 'sound/items/flashlight_off.ogg'
+	var/flickering = FALSE
 
 	health = 30
 	breakable_flags = BREAKABLE_ALL
@@ -63,6 +64,12 @@
 	update_brightness(user)
 	return 1
 
+/obj/item/device/flashlight/proc/toggle_onoff(var/onoff = null)
+	if(isnull(onoff))
+		on = !on
+	else
+		on = onoff
+	update_brightness()
 
 /obj/item/device/flashlight/attack(mob/living/M as mob, mob/living/user as mob)
 	add_fingerprint(user)
@@ -109,6 +116,23 @@
 				to_chat(user, "<span class='notice'>[src] highlights [M.times_cloned] dot[M.times_cloned != 1 ? "s" : ""] on [M]'s sclerae!</span>")
 	else
 		return ..()
+
+/obj/item/device/flashlight/proc/flicker()
+	if(flickering)
+		return
+	if(on)
+		flickering = 1
+		spawn(0)
+			on = FALSE
+			update_brightness()
+			sleep(rand(5, 15))
+			flickering = 0
+			on = TRUE
+			update_brightness()
+
+/obj/item/device/flashlight/attack_ghost(var/mob/dead/observer/ghost)
+	flicker()
+	. = ..()
 
 /obj/item/device/flashlight/torch
 	name = "torch"
@@ -168,7 +192,6 @@
 		to_chat(user, "<span class='notice'>\The [src] cannot be attached to that.</span>")
 	return ..()
 
-
 // the desk lamps are a bit special
 /obj/item/device/flashlight/lamp
 	name = "desk lamp"
@@ -180,7 +203,7 @@
 	flags = FPRINT
 	siemens_coefficient = 1
 	starting_materials = null
-	on = 1
+	on = 0	//Lamps start out off unless someone spawns in the same room as them at roundstart.
 
 /obj/item/device/flashlight/lamp/cultify()
 	new /obj/structure/cult/pylon(loc)
@@ -258,6 +281,9 @@
 		update_brightness(U)
 	else
 		update_brightness()
+
+/obj/item/device/flashlight/flare/flicker()
+	return
 
 /obj/item/device/flashlight/flare/attack_self(mob/user)
 

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -249,7 +249,6 @@ var/global/list/obj/machinery/light/alllights = list()
 // update the icon_state and luminosity of the light depending on its state
 /obj/machinery/light/proc/update(var/trigger = 1)
 
-
 	update_icon()
 	if(on)
 		if(light_range != current_bulb.brightness_range || light_power != current_bulb.brightness_power || light_color != current_bulb.brightness_color)


### PR DESCRIPTION
This makes lamps in unstaffed departments start turned-off at roundstart.
Also, it makes it so ghosts can flicker lamps and flashlights like they can with wall-mounted lights.
Hopefully this will allow for more spooky vibes and situations at times, like arriving on a empty station during minpop rounds and seeing more rooms dark and unoccupied, as well as ghost antics.

:cl:
 * rscadd: Lamps in unstaffed departments start out turned-off.
 * rscadd: Ghosts can now flicker lamps and flashlights.