### PR TITLE
Human zombies can force open doors

### DIFF
--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -66,5 +66,6 @@
 /mob/proc/resurrect()
 	living_mob_list |= src
 	dead_mob_list -= src
-
+	if(src.client)
+		clear_fullscreens()
 	verbs -= /mob/living/proc/butcher

--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -652,7 +652,7 @@
 	icon_state = "ghoul"
 	icon_dead = "ghoul"
 	icon_living = "ghoul"
-	desc = "Suffering from onset decay from radiation exposure, this one has lost their mind, their soul, but not their hunger."
+	desc = "Suffering from onset decay from radiation exposure. They have lost their mind and soul, but not their hunger."
 	can_evolve = 0
 	canRegenerate = 0
 

--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -391,7 +391,7 @@
 		clothing.Remove(I)
 	..()
 
-/mob/living/simple_animal/hostile/necro/zombie/turned //Not very useful
+/mob/living/simple_animal/hostile/necro/zombie/turned
 	icon_state = "zombie_turned" //Looks almost not unlike just a naked guy to potentially catch others off guard
 	icon_living = "zombie_turned"
 	icon_dead = "zombie_turned"
@@ -399,6 +399,7 @@
 	maxHealth = 50
 	health = 50
 	can_evolve = TRUE
+	environment_smash_flags = OPEN_DOOR_WEAK
 	var/mob/living/carbon/human/host //Whoever the zombie was previously, kept in a reference to potentially bring back
 	var/being_unzombified = FALSE
 

--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -3,7 +3,6 @@
 	var/unique_name = 0
 	faction = "necro"
 	mob_property_flags = MOB_UNDEAD
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
 
 /mob/living/simple_animal/hostile/necro/New(loc, mob/living/Owner, var/mob/living/Victim, datum/mind/Controller)
 	..()
@@ -96,6 +95,7 @@
 	melee_damage_upper = 10
 	attacktext = "bites"
 	speak_emote = list("groans", "moans")
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
 
 /mob/living/simple_animal/hostile/necro/animal_ghoul/proc/ghoulifyAnimal(S)
 	var/mob/living/aGhoul = S
@@ -157,6 +157,7 @@
 	max_n2 = 0
 	minbodytemp = 0
 
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
 	meat_type = null
 /*
 #define EVOLVING 1
@@ -205,6 +206,8 @@
 	min_n2 = 0
 	max_n2 = 0
 	minbodytemp = 0
+
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
 
 	var/times_revived //Tracks how many times the zombie has regenerated from death
 	var/times_eaten //Tracks how many times the zombie has chewed on a human corpse
@@ -396,6 +399,7 @@
 	maxHealth = 50
 	health = 50
 	can_evolve = TRUE
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK
 	var/mob/living/carbon/human/host //Whoever the zombie was previously, kept in a reference to potentially bring back
 	var/being_unzombified = FALSE
 
@@ -476,6 +480,7 @@
 	maxHealth = 100
 	health = 100
 	can_evolve = 1
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
 
 /mob/living/simple_animal/hostile/necro/zombie/rotting/check_evolve()
 	..()
@@ -493,6 +498,7 @@
 	health = 150
 	can_evolve = 0
 	var/zombify_chance = 25 //Down with hardcoding
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
 
 /mob/living/simple_animal/hostile/necro/zombie/putrid/check_edibility(var/mob/living/carbon/human/target)
 	if(busy)
@@ -619,6 +625,7 @@
 
 	attacktext = "claws"
 	attack_sound = 'sound/weapons/slice.ogg'
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
 
 /mob/living/simple_animal/hostile/necro/zombie/raider2
 	name = "rotting raider"
@@ -638,6 +645,7 @@
 
 	attacktext = "claws"
 	attack_sound = 'sound/weapons/slice.ogg'
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
 
 ///////////////// GHOULS ////////////////////
 
@@ -657,6 +665,7 @@
 	melee_damage_upper = 20
 	attacktext = "punches"
 	attack_sound = "sound/weapons/punch1.ogg"
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
 
 /mob/living/simple_animal/hostile/necro/zombie/ghoul/Life()
 	..()
@@ -683,6 +692,7 @@
 
 	melee_damage_lower = 15
 	melee_damage_upper = 25
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
 	var/last_rad_blast = 0
 
 /mob/living/simple_animal/hostile/necro/zombie/ghoul/glowing_one/Life()
@@ -740,6 +750,7 @@
 	canRegenerate = 0
 	var/mob/living/carbon/human/host //Whoever the zombie was previously, kept in a reference to potentially bring back
 	var/obj/item/clothing/mask/facehugger/headcrab/crab //The crab controlling it.
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK
 
 /mob/living/simple_animal/hostile/necro/zombie/headcrab/New(loc, mob/living/Owner, var/mob/living/Victim, datum/mind/Controller)
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -95,6 +95,7 @@
 	melee_damage_upper = 10
 	attacktext = "bites"
 	speak_emote = list("groans", "moans")
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS
 
 /mob/living/simple_animal/hostile/necro/animal_ghoul/proc/ghoulifyAnimal(S)
 	var/mob/living/aGhoul = S

--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -3,6 +3,7 @@
 	var/unique_name = 0
 	faction = "necro"
 	mob_property_flags = MOB_UNDEAD
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
 
 /mob/living/simple_animal/hostile/necro/New(loc, mob/living/Owner, var/mob/living/Victim, datum/mind/Controller)
 	..()
@@ -95,7 +96,6 @@
 	melee_damage_upper = 10
 	attacktext = "bites"
 	speak_emote = list("groans", "moans")
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS
 
 /mob/living/simple_animal/hostile/necro/animal_ghoul/proc/ghoulifyAnimal(S)
 	var/mob/living/aGhoul = S
@@ -157,7 +157,6 @@
 	max_n2 = 0
 	minbodytemp = 0
 
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS
 	meat_type = null
 /*
 #define EVOLVING 1
@@ -206,8 +205,6 @@
 	min_n2 = 0
 	max_n2 = 0
 	minbodytemp = 0
-
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS
 
 	var/times_revived //Tracks how many times the zombie has regenerated from death
 	var/times_eaten //Tracks how many times the zombie has chewed on a human corpse
@@ -399,7 +396,6 @@
 	maxHealth = 50
 	health = 50
 	can_evolve = TRUE
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK
 	var/mob/living/carbon/human/host //Whoever the zombie was previously, kept in a reference to potentially bring back
 	var/being_unzombified = FALSE
 
@@ -480,7 +476,6 @@
 	maxHealth = 100
 	health = 100
 	can_evolve = 1
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK
 
 /mob/living/simple_animal/hostile/necro/zombie/rotting/check_evolve()
 	..()
@@ -498,7 +493,6 @@
 	health = 150
 	can_evolve = 0
 	var/zombify_chance = 25 //Down with hardcoding
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK
 
 /mob/living/simple_animal/hostile/necro/zombie/putrid/check_edibility(var/mob/living/carbon/human/target)
 	if(busy)
@@ -625,7 +619,6 @@
 
 	attacktext = "claws"
 	attack_sound = 'sound/weapons/slice.ogg'
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK
 
 /mob/living/simple_animal/hostile/necro/zombie/raider2
 	name = "rotting raider"
@@ -645,7 +638,6 @@
 
 	attacktext = "claws"
 	attack_sound = 'sound/weapons/slice.ogg'
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK
 
 ///////////////// GHOULS ////////////////////
 
@@ -665,7 +657,6 @@
 	melee_damage_upper = 20
 	attacktext = "punches"
 	attack_sound = "sound/weapons/punch1.ogg"
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK
 
 /mob/living/simple_animal/hostile/necro/zombie/ghoul/Life()
 	..()
@@ -692,7 +683,6 @@
 
 	melee_damage_lower = 15
 	melee_damage_upper = 25
-
 	var/last_rad_blast = 0
 
 /mob/living/simple_animal/hostile/necro/zombie/ghoul/glowing_one/Life()
@@ -750,7 +740,6 @@
 	canRegenerate = 0
 	var/mob/living/carbon/human/host //Whoever the zombie was previously, kept in a reference to potentially bring back
 	var/obj/item/clothing/mask/facehugger/headcrab/crab //The crab controlling it.
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK
 
 /mob/living/simple_animal/hostile/necro/zombie/headcrab/New(loc, mob/living/Owner, var/mob/living/Victim, datum/mind/Controller)
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -399,7 +399,7 @@
 	maxHealth = 50
 	health = 50
 	can_evolve = TRUE
-	environment_smash_flags = OPEN_DOOR_WEAK
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK
 	var/mob/living/carbon/human/host //Whoever the zombie was previously, kept in a reference to potentially bring back
 	var/being_unzombified = FALSE
 
@@ -750,7 +750,7 @@
 	canRegenerate = 0
 	var/mob/living/carbon/human/host //Whoever the zombie was previously, kept in a reference to potentially bring back
 	var/obj/item/clothing/mask/facehugger/headcrab/crab //The crab controlling it.
-	environment_smash_flags = OPEN_DOOR_WEAK
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK
 
 /mob/living/simple_animal/hostile/necro/zombie/headcrab/New(loc, mob/living/Owner, var/mob/living/Victim, datum/mind/Controller)
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -739,7 +739,7 @@
 ///////////////// HEADCRAB ZOMBIES ////////////////////
 ///////////////////////////////////////////////////////
 
-/mob/living/simple_animal/hostile/necro/zombie/headcrab //Not very useful
+/mob/living/simple_animal/hostile/necro/zombie/headcrab
 	icon_state = "zombie_headcrab"
 	icon_living = "zombie_headcrab"
 	icon_dead = "zombie_headcrab"
@@ -750,6 +750,7 @@
 	canRegenerate = 0
 	var/mob/living/carbon/human/host //Whoever the zombie was previously, kept in a reference to potentially bring back
 	var/obj/item/clothing/mask/facehugger/headcrab/crab //The crab controlling it.
+	environment_smash_flags = OPEN_DOOR_WEAK
 
 /mob/living/simple_animal/hostile/necro/zombie/headcrab/New(loc, mob/living/Owner, var/mob/living/Victim, datum/mind/Controller)
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -95,7 +95,6 @@
 	melee_damage_upper = 10
 	attacktext = "bites"
 	speak_emote = list("groans", "moans")
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
 
 /mob/living/simple_animal/hostile/necro/animal_ghoul/proc/ghoulifyAnimal(S)
 	var/mob/living/aGhoul = S
@@ -157,7 +156,7 @@
 	max_n2 = 0
 	minbodytemp = 0
 
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK | OPEN_DOOR_SMART
 	meat_type = null
 /*
 #define EVOLVING 1
@@ -206,8 +205,6 @@
 	min_n2 = 0
 	max_n2 = 0
 	minbodytemp = 0
-
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
 
 	var/times_revived //Tracks how many times the zombie has regenerated from death
 	var/times_eaten //Tracks how many times the zombie has chewed on a human corpse
@@ -399,7 +396,7 @@
 	maxHealth = 50
 	health = 50
 	can_evolve = TRUE
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK | OPEN_DOOR_SMART
 	var/mob/living/carbon/human/host //Whoever the zombie was previously, kept in a reference to potentially bring back
 	var/being_unzombified = FALSE
 
@@ -480,7 +477,7 @@
 	maxHealth = 100
 	health = 100
 	can_evolve = 1
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK | OPEN_DOOR_SMART
 
 /mob/living/simple_animal/hostile/necro/zombie/rotting/check_evolve()
 	..()
@@ -498,7 +495,7 @@
 	health = 150
 	can_evolve = 0
 	var/zombify_chance = 25 //Down with hardcoding
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK
 
 /mob/living/simple_animal/hostile/necro/zombie/putrid/check_edibility(var/mob/living/carbon/human/target)
 	if(busy)
@@ -625,7 +622,7 @@
 
 	attacktext = "claws"
 	attack_sound = 'sound/weapons/slice.ogg'
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK
 
 /mob/living/simple_animal/hostile/necro/zombie/raider2
 	name = "rotting raider"
@@ -645,7 +642,7 @@
 
 	attacktext = "claws"
 	attack_sound = 'sound/weapons/slice.ogg'
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK
 
 ///////////////// GHOULS ////////////////////
 
@@ -665,7 +662,7 @@
 	melee_damage_upper = 20
 	attacktext = "punches"
 	attack_sound = "sound/weapons/punch1.ogg"
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_STRONG
 
 /mob/living/simple_animal/hostile/necro/zombie/ghoul/Life()
 	..()
@@ -692,7 +689,7 @@
 
 	melee_damage_lower = 15
 	melee_damage_upper = 25
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_SMART
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_STRONG | OPEN_DOOR_SMART
 	var/last_rad_blast = 0
 
 /mob/living/simple_animal/hostile/necro/zombie/ghoul/glowing_one/Life()
@@ -750,7 +747,7 @@
 	canRegenerate = 0
 	var/mob/living/carbon/human/host //Whoever the zombie was previously, kept in a reference to potentially bring back
 	var/obj/item/clothing/mask/facehugger/headcrab/crab //The crab controlling it.
-	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK
+	environment_smash_flags = SMASH_LIGHT_STRUCTURES | SMASH_CONTAINERS | OPEN_DOOR_WEAK | OPEN_DOOR_SMART
 
 /mob/living/simple_animal/hostile/necro/zombie/headcrab/New(loc, mob/living/Owner, var/mob/living/Victim, datum/mind/Controller)
 	..()


### PR DESCRIPTION
So I made an attempt at using the host body's access req and spent too long trying to figure it out... The problem lies with `req_access`. Anyway, this overrides any access issues. Seems like a bandaid solution, but it works.

## What this does
- Adds the `OPEN_DOOR_WEAK` flag to human-controlled zombies
- Adds the `OPEN_DOOR_SMART` for less hungry zombies
- Closes #31504
- Removes paincrit halo on revive
- Fixes some grammar

## Why it's good
Easier than breaking through a wall of glass, especially when you already had access on your living/not undead body

:cl:
 * tweak: Human zombies can force open doors and modified some behavior with doors for other zombies


