### PR TITLE
Makes some disease/curse equip only clothes non-acidable

### DIFF
--- a/code/game/objects/items/misc_items.dm
+++ b/code/game/objects/items/misc_items.dm
@@ -48,6 +48,9 @@
 	canremove = 0
 	cant_remove_msg = " is fused to your body!"
 
+/obj/item/red_ribbon_arm/acidable()
+	return 0
+
 /obj/item/red_ribbon_arm/equipped(mob/living/carbon/human/H, equipped_slot)
 	..()
 	if(istype(H) && H.get_item_by_slot(slot_belt) == src && equipped_slot != null && equipped_slot == slot_belt)

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -276,6 +276,9 @@ var/list/science_goggles_wearers = list()
 		canremove = 0
 	..()
 
+/obj/item/clothing/glasses/sunglasses/virus/acidable()
+	return canremove
+
 /obj/item/clothing/glasses/sunglasses/kick_act(mob/living/carbon/human/H)
 	H.visible_message("<span class='danger'>[H] stomps on \the [src], crushing them!</span>", "<span class='danger'>You crush \the [src] under your foot.</span>")
 	playsound(src, "shatter", 50, 1)

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -677,6 +677,9 @@
 /obj/item/clothing/head/elfhat/stickymagic
 	canremove = 0
 
+/obj/item/clothing/head/elfhat/stickymagic/acidable()
+	return 0
+
 /obj/item/clothing/head/rice_hat
 	name = "rice hat"
 	desc = "Welcome to the rice fields, motherfucker."

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -232,6 +232,9 @@
 	canremove = FALSE
 	cringe = TRUE
 
+/obj/item/clothing/head/kitty/anime/cursed/acidable()
+	return 0
+
 /obj/item/clothing/head/butt
 	name = "butt"
 	desc = "So many butts, so little time."

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -187,6 +187,9 @@
 /obj/item/clothing/shoes/clown_shoes/elf/stickymagic
 	canremove = 0
 
+/obj/item/clothing/shoes/clown_shoes/elf/stickymagic/acidable()
+	return 0
+
 #define CLOWNSHOES_RANDOM_SOUND "random sound"
 
 /obj/item/clothing/shoes/clown_shoes/advanced
@@ -310,6 +313,9 @@
 /obj/item/clothing/shoes/clown_shoes/slippy
 	canremove = 0
 	var/lube_chance = 10
+
+/obj/item/clothing/shoes/clown_shoes/slippy/acidable()
+	return 0
 
 /obj/item/clothing/shoes/clown_shoes/slippy/step_action() //The honkpocalypse is here
 	..()

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -780,6 +780,9 @@
 /obj/item/clothing/under/elf/stickymagic
 	canremove = 0
 
+/obj/item/clothing/under/elf/stickymagic/acidable()
+	return 0
+
 /obj/item/clothing/under/onesie
 	name = "green christmas onesie"
 	desc = "Festive pyjamas for the comfy crewman."


### PR DESCRIPTION
[tweak][consistency]

## What this does
Adds some more acid melting exceptions for the specified clothing types.

## Why it's good
Because the change in reagent targeting brought about by #32424 would make these acidable if worn, this prevents that.

## Changelog
:cl:
 * tweak: Various clothing types from diseases and wizard curses are now no longer able to be melted by acid.