### PR TITLE
New cargo console entries

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1928,7 +1928,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	contains = list(/obj/item/stack/package_wrap,
                     /obj/item/stack/package_wrap,
                     /obj/item/stack/package_wrap,
-                    /obj/item/stack/package_wrap,)
+                    /obj/item/stack/package_wrap)
 	cost = 10
 	containertype = /obj/structure/closet/crate/basic
 	containername = "package wrap crate"
@@ -1941,7 +1941,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
                     /obj/item/mounted/poster/cargo,
                     /obj/item/mounted/poster/cargo,
                     /obj/item/mounted/poster/cargo,
-                    /obj/item/mounted/poster/cargo,)
+                    /obj/item/mounted/poster/cargo)
 	cost = 50
 	containertype = /obj/structure/closet/crate/basic
 	containername = "cargonia poster crate"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -183,8 +183,9 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/pen/blue,
 					/obj/item/weapon/pen/red,
 					/obj/item/weapon/pen/fountain,
-					/obj/item/weapon/storage/bag/clipboard)
-	cost = 10
+					/obj/item/device/flashlight/lamp,
+					/obj/item/device/flashlight/lamp)
+	cost = 15
 	containertype = /obj/structure/closet/crate/basic
 	containername = "office supply crate"
 	group = "Supplies"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -189,13 +189,22 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containername = "office supply crate"
 	group = "Supplies"
 
-/datum/supply_packs/heaterscoolers
-	name = "Heater and AC"
+/datum/supply_packs/space_heaters
+	name = "Space Heaters"
 	contains = list(/obj/machinery/space_heater,
+					/obj/machinery/space_heater)
+	cost = 20
+	containertype = /obj/structure/largecrate
+	containername = "space heater crate"
+	group = "Supplies"
+
+/datum/supply_packs/air_conditioners
+	name = "Air Conditioners"
+	contains = list(/obj/machinery/space_heater/air_conditioner,
 					/obj/machinery/space_heater/air_conditioner)
 	cost = 20
 	containertype = /obj/structure/largecrate
-	containername = "temperature control crate"
+	containername = "air conditioner crate"
 	group = "Supplies"
 
 /datum/supply_packs/porcelain
@@ -1515,7 +1524,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	name = "Portable Scrubber and Pump"
 	contains = list(/obj/machinery/portable_atmospherics/pump,
 					/obj/machinery/portable_atmospherics/scrubber)
-	cost = 20
+	cost = 25
 	containertype = /obj/structure/largecrate
 	containername = "portable atmospherics crate"
 	group = "Engineering"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -171,6 +171,33 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containername = "newscaster crate"
 	group = "Supplies"
 
+/datum/supply_packs/office_supplies
+	name = "Office supplies"
+	contains = list(/obj/item/weapon/paper_pack,
+					/obj/item/weapon/folder/black,
+					/obj/item/weapon/folder/white,
+					/obj/item/weapon/folder/blue,
+					/obj/item/weapon/folder/red,
+					/obj/item/weapon/folder/orange,
+					/obj/item/weapon/pen,
+					/obj/item/weapon/pen/blue,
+					/obj/item/weapon/pen/red,
+					/obj/item/weapon/pen/fountain,
+					/obj/item/weapon/storage/bag/clipboard)
+	cost = 10
+	containertype = /obj/structure/closet/crate/basic
+	containername = "office supply crate"
+	group = "Supplies"
+
+/datum/supply_packs/heaterscoolers
+	name = "Heater and AC"
+	contains = list(/obj/machinery/space_heater,
+					/obj/machinery/space_heater/air_conditioner)
+	cost = 20
+	containertype = /obj/structure/largecrate
+	containername = "temperature control crate"
+	group = "Supplies"
+
 /datum/supply_packs/porcelain
 	name = "Porcelain furniture"
 	contains = list()
@@ -1484,6 +1511,15 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containername = "mechanical maintenance crate"
 	group = "Engineering"
 
+/datum/supply_packs/scrubberpump
+	name = "Portable Scrubber and Pump"
+	contains = list(/obj/machinery/portable_atmospherics/pump,
+					/obj/machinery/portable_atmospherics/scrubber)
+	cost = 20
+	containertype = /obj/structure/largecrate
+	containername = "portable atmospherics crate"
+	group = "Engineering"
+
 /datum/supply_packs/solar
 	name = "Solar panels kit"
 	contains  = list(/obj/machinery/power/solar_assembly,
@@ -1885,6 +1921,30 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 25
 	containertype = /obj/structure/closet/crate/engi
 	containername = "automation supplies crate"
+	group = "Cargo"
+
+/datum/supply_packs/package_wrap
+	name = "Package wrap"
+	contains = list(/obj/item/stack/package_wrap,
+                    /obj/item/stack/package_wrap,
+                    /obj/item/stack/package_wrap,
+                    /obj/item/stack/package_wrap,)
+	cost = 10
+	containertype = /obj/structure/closet/crate/basic
+	containername = "package wrap crate"
+	group = "Cargo"
+
+/datum/supply_packs/cargonia_propaganda
+	name = "Cargo posters"
+	contains = list(/obj/item/mounted/poster/cargo,
+                    /obj/item/mounted/poster/cargo,
+                    /obj/item/mounted/poster/cargo,
+                    /obj/item/mounted/poster/cargo,
+                    /obj/item/mounted/poster/cargo,
+                    /obj/item/mounted/poster/cargo,)
+	cost = 50
+	containertype = /obj/structure/closet/crate/basic
+	containername = "cargonia poster crate"
 	group = "Cargo"
 
 
@@ -2621,15 +2681,23 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 
 /datum/supply_packs/sovietmachines
 	name = "Old and Forgotten stack of packs"
-	contains = list(/obj/structure/vendomatpack/sovietsoda,
-					/obj/structure/vendomatpack/sovietsoda,
-					/obj/structure/vendomatpack/nazivend,
+	contains = list(/obj/structure/vendomatpack/nazivend,
 					/obj/structure/vendomatpack/sovietvend)
 	cost = 20
 	containertype = /obj/structure/stackopacks
 	containername = "Old and Forgotten stack of packs"
 	group = "Vending Machine packs"
 	hidden = 1
+
+/datum/supply_packs/sovietsodamachines
+	name = "Russian Beverage stack of packs"
+	contains = list(/obj/structure/vendomatpack/sovietsoda,
+					/obj/structure/vendomatpack/sovietsoda)
+	cost = 10
+	containertype = /obj/structure/stackopacks
+	containername = "Russian Beverage stack of packs"
+	group = "Vending Machine packs"
+	contraband = 1
 
 /datum/supply_packs/magimachines
 	name = "Strange and Bright stack of packs"


### PR DESCRIPTION
## Changes

- Adds office supply crate for 15 credits under the supply group; has folders, pens, paper and two office lamps (grey ones)
- Adds portable scrubber and air pump crate for 25 credits under the engineering group; has one each
- Adds space heater crate for 20 credits under supply group; has two heaters per crate
- Adds air conditioner crate for 20 credits under supply group; has two ac's per crate
- Adds package wrap crate for 10 credits under cargo group; has four rolls of package wrap which is roughly 94 uses
- Adds cargo poster crate for 50 credits under cargo group; has six posters which can either be a seal or flag
- Adds russian beverage stack of packs for 10 credits under vending machine group; has two recharge packs of soviet soda machines and can be purchased from a contraband hacked cargo console (soldering iron)
- Removes soviet soda recharge packs from old and forgotten stack of packs

## Elaboration
In the unlikely event some of these "irreplaceable items" were to go missing, or somehow get destroyed, there are now cargo entries to help you replace or get more of them. The paper in the office supply crate is specifically the paper pack with the red ribbon on it, originally I wanted to also add some nano-paper packs with it, but seeing the librarians nano-paper dispenser that couldn't even use the nano-paper packs to replenish it due to requiring plasteel to recharge it, I thought it best to just leave it out for the time being until someone changes it. Another thing to note in the office supply crate are the specifics of the goods, such as the red, blue, black and fountain pens, as well as the folders being red, blue, black, med white, and cargo orange. Soviet soda recharge packs were removed from the old and forgotten stack of packs due to getting their own entries and being frankly out of place with the commie and nazi vend.

## Changelog
closes #31535

:cl:
 * rscadd: Adds several new entries to the cargo console