### PR TITLE
Uses body archives to find more crew that died for credits "not making it" section

### DIFF
--- a/code/modules/credits/credits.dm
+++ b/code/modules/credits/credits.dm
@@ -282,7 +282,7 @@ var/global/datum/credits/end_credits = new
 			archive_keys_check += H.key
 			corpses += H.real_name
 	for(var/datum/body_archive/B in body_archives)
-		if(B.mob_type && (!ishuman(B.mob_type) && !issilicon(B.mob_type)) || (B.key && (B.key in archive_keys_check)))
+		if((B.mob_type && !ishuman(B.mob_type) && !issilicon(B.mob_type)) || (B.key && (B.key in archive_keys_check)))
 			continue
 		else if(B.name)
 			corpses += B.name

--- a/code/modules/credits/credits.dm
+++ b/code/modules/credits/credits.dm
@@ -282,7 +282,7 @@ var/global/datum/credits/end_credits = new
 			archive_keys_check += H.key
 			corpses += H.real_name
 	for(var/datum/body_archive/B in body_archives)
-		if(B.key && !ishuman(mob_type) && !issilicon(mob_type) && (B.key in archive_keys_check))
+		if(B.key && !ishuman(B.mob_type) && !issilicon(B.mob_type) && (B.key in archive_keys_check))
 			continue
 		else if(B.name)
 			corpses += B.name

--- a/code/modules/credits/credits.dm
+++ b/code/modules/credits/credits.dm
@@ -269,7 +269,7 @@ var/global/datum/credits/end_credits = new
 	for(var/mob/living/silicon/S in mob_list)
 		if(!S.key)
 			continue
-		archive_keys_check += H.key
+		archive_keys_check += S.key
 		cast_string += "[silicon_credits(S)]"
 
 	cast_string += "</table><br>"
@@ -282,7 +282,7 @@ var/global/datum/credits/end_credits = new
 			archive_keys_check += H.key
 			corpses += H.real_name
 	for(var/datum/body_archive/B in body_archives)
-		if(B.key && (B.key in archive_keys_check))
+		if(B.key && !ishuman(mob_type) && !issilicon(mob_type) && (B.key in archive_keys_check))
 			continue
 		else if(B.name)
 			corpses += B.name

--- a/code/modules/credits/credits.dm
+++ b/code/modules/credits/credits.dm
@@ -282,7 +282,7 @@ var/global/datum/credits/end_credits = new
 			archive_keys_check += H.key
 			corpses += H.real_name
 	for(var/datum/body_archive/B in body_archives)
-		if((!ishuman(B.mob_type) && !issilicon(B.mob_type)) || (B.key && (B.key in archive_keys_check)))
+		if(B.mob_type && (!ishuman(B.mob_type) && !issilicon(B.mob_type)) || (B.key && (B.key in archive_keys_check)))
 			continue
 		else if(B.name)
 			corpses += B.name

--- a/code/modules/credits/credits.dm
+++ b/code/modules/credits/credits.dm
@@ -282,7 +282,7 @@ var/global/datum/credits/end_credits = new
 			archive_keys_check += H.key
 			corpses += H.real_name
 	for(var/datum/body_archive/B in body_archives)
-		if(B.key && B.key in archive_keys_check)
+		if(B.key && (B.key in archive_keys_check))
 			continue
 		else if(B.name)
 			corpses += B.name

--- a/code/modules/credits/credits.dm
+++ b/code/modules/credits/credits.dm
@@ -282,7 +282,7 @@ var/global/datum/credits/end_credits = new
 			archive_keys_check += H.key
 			corpses += H.real_name
 	for(var/datum/body_archive/B in body_archives)
-		if(B.key && !ishuman(B.mob_type) && !issilicon(B.mob_type) && (B.key in archive_keys_check))
+		if((!ishuman(B.mob_type) && !issilicon(B.mob_type)) || (B.key && (B.key in archive_keys_check)))
 			continue
 		else if(B.name)
 			corpses += B.name

--- a/code/modules/credits/credits.dm
+++ b/code/modules/credits/credits.dm
@@ -259,14 +259,17 @@ var/global/datum/credits/end_credits = new
 /datum/credits/proc/draft_caststring()
 	cast_string = "<h1>CAST:</h1><br><h2>(in order of appearance)</h2><br>"
 	cast_string += "<table class='crewtable'>"
+	var/list/archive_keys_check = list()
 	for(var/mob/living/carbon/human/H in mob_list)
 		if(!H.key || H.iscorpse)
 			continue
+		archive_keys_check += H.key
 		cast_string += "[gender_credits(H)]"
 
 	for(var/mob/living/silicon/S in mob_list)
 		if(!S.key)
 			continue
+		archive_keys_check += H.key
 		cast_string += "[silicon_credits(S)]"
 
 	cast_string += "</table><br>"
@@ -276,7 +279,13 @@ var/global/datum/credits/end_credits = new
 		if(!H.key || H.iscorpse)
 			continue
 		else if(H.real_name)
+			archive_keys_check += H.key
 			corpses += H.real_name
+	for(var/datum/body_archive/B in body_archives)
+		if(B.key && B.key in archive_keys_check)
+			continue
+		else if(B.name)
+			corpses += B.name
 	if(corpses.len)
 		var/true_story_bro = "<br>[pick("BASED ON","INSPIRED BY","A RE-ENACTMENT OF")] [pick("A TRUE STORY","REAL EVENTS","THE EVENTS ABOARD [uppertext(station_name())]")]"
 		cast_string += "<h3>[true_story_bro]</h3><br>In memory of those that did not make it.<br>[english_list(corpses)].<br>"


### PR DESCRIPTION
## What this does
Uses the newer body archives system to find additional non-counted crewmembers for the credits, putting them in the "Those who did not make it" section.

## Why it's good
Sometimes this sections fails to find many dead crew if any at all, including mobs that had their bodies destroyed and/or logged out.

## Changelog
:cl:
 * rscadd: Episode credits now remember more crew that did not make it.