### PR TITLE
Radio text fix

### DIFF
--- a/code/datums/saycode/speech.dm
+++ b/code/datums/saycode/speech.dm
@@ -89,7 +89,7 @@
 	return rendered
 
 /datum/speech/proc/render_as_name()
-	if(as_name && as_name != name)
+	if(as_name && uppertext(as_name) != uppertext(name))
 		return " (as [as_name])"
 	return ""
 


### PR DESCRIPTION
Comparison of names does not consider capitalization when talking over the radio, but this fixes it

## What this does
For example, "Gimmick the Clown (as Gimmick The Clown):" will now show up as "Gimmick The Clown:"

## Why it's good
Fixes an issue
