### PR TITLE
Add a ~1 second delay between trade window chatter, add a couple new responses

### DIFF
--- a/code/modules/trader/trade_window.dm
+++ b/code/modules/trader/trade_window.dm
@@ -65,7 +65,6 @@
 /obj/structure/trade_window/attackby(obj/item/W, mob/living/carbon/human/user)
 	if(!istype(user))
 		return
-	user.delayNextAttack(8)
 	if(istype(W, /obj/item/weapon/spacecash))
 		var/obj/item/weapon/spacecash/C = W
 		pay_with_cash(C, user)

--- a/code/modules/trader/trade_window.dm
+++ b/code/modules/trader/trade_window.dm
@@ -65,6 +65,7 @@
 /obj/structure/trade_window/attackby(obj/item/W, mob/living/carbon/human/user)
 	if(!istype(user))
 		return
+	user.delayNextAttack(8)
 	if(istype(W, /obj/item/weapon/spacecash))
 		var/obj/item/weapon/spacecash/C = W
 		pay_with_cash(C, user)
@@ -130,6 +131,7 @@
 /obj/structure/trade_window/attack_hand(mob/user)
 	if(!isobserver(user) && (!Adjacent(user) || user.incapacitated()))
 		return
+	user.delayNextAttack(8)
 	ui_interact(user)
 
 /obj/structure/trade_window/ui_interact(mob/living/carbon/human/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open=NANOUI_FOCUS)
@@ -323,8 +325,7 @@
 /obj/structure/trade_window/say(var/message)
 	if(!trader_language)
 		trader_language = all_languages[LANGUAGE_VOX]
-	if(world.time>time_last_speech+2 SECONDS)
-		..(message, trader_language)
+	..(message, trader_language)
 	if(world.time>time_last_speech+5 SECONDS)
 		time_last_speech = world.time
 		playsound(loc, pick(voice_vox_sound), 120, 0)

--- a/code/modules/trader/trade_window.dm
+++ b/code/modules/trader/trade_window.dm
@@ -152,6 +152,8 @@
 
 	var/data[0]
 	if(!aghost)
+		if(closed)
+			say(pick("I'm not opening back up until you fix the air out there!", "Fix the air out there, then we'll talk!"))
 		if(user.get_face_name() == "Unknown")
 			var/datum/organ/external/head/head_organ = user.get_organ(LIMB_HEAD)
 			if(head_organ.disfigured)
@@ -165,7 +167,7 @@
 				return
 
 		else if(!(user.get_face_name() in SStrade.loyal_customers))
-			say("I don't know you. You want to join up? You need someone to vouch for you. Bring a fresh ID and an inkpad to my table when you do.")
+			say(pick("I don't know you. You want to join up? You need someone to vouch for you. Bring a fresh ID and an inkpad to my table when you do.", "You don't look like a member. Bring a fresh ID and an inkpad to my table if you want to do business."))
 			return
 		else
 			greet(user)
@@ -321,7 +323,8 @@
 /obj/structure/trade_window/say(var/message)
 	if(!trader_language)
 		trader_language = all_languages[LANGUAGE_VOX]
-	..(message, trader_language)
+	if(world.time>time_last_speech+2 SECONDS)
+		..(message, trader_language)
 	if(world.time>time_last_speech+5 SECONDS)
 		time_last_speech = world.time
 		playsound(loc, pick(voice_vox_sound), 120, 0)


### PR DESCRIPTION
[fluff]


## What this does
Adds a ~1 second delay before the "bird" behind the trade window speaks again.
Adds a couple responses for when the trade window is closed due to bad atmosphere.
Add an extra response for when a non-trader tries to interact with the trade window.

## Why it's good
The delay is good because people can repeatedly click the trade window to flood the chat with messages. It is very annoying when used with a radio.
The extra responses are good because they increase immersion or something.

## Changelog
nah