### PR TITLE
Beepsky can't see you if you're invisible

### DIFF
--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -122,11 +122,13 @@
 			user.visible_message("<span class='danger'>\The [user] throws \the [src] over \himself and disappears!</span>","<span class='notice'>You throw \the [src] over yourself and disappear.</span>")
 			user.register_event(/event/moved, src, .proc/mob_moved)
 			user.alpha = 1	//to cloak immediately instead of on the next Life() tick
+			user.invisibility = INVISIBILITY_MAXIMUM
 			user.alphas[CLOAKINGCLOAK] = 1
 		else
 			user.visible_message("<span class='warning'>\The [user] appears out of thin air!</span>","<span class='notice'>You take \the [src] off and become visible again.</span>")
 			user.unregister_event(/event/moved, src, .proc/mob_moved)
 			user.alpha = initial(user.alpha)
+			user.invisibility = 0
 			user.alphas.Remove(CLOAKINGCLOAK)
 
 

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -243,6 +243,9 @@ Auto Patrol: []"},
 		if (istype(C, /mob/living/carbon/human))
 			threatlevel = assess_perp(C)
 
+		if (C.alpha == 1 || C.invisibility > SEE_INVISIBLE_LEVEL_TWO)
+			continue
+
 		if (!threatlevel)
 			continue
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -651,11 +651,13 @@
 	if(include_clothing)
 		return ..()
 	body_alphas[source_define] = 1
+	invisibility = INVISIBILITY_MAXIMUM
 	regenerate_icons()
 	if(time > 0)
 		spawn(time)
 			if(src)
 				body_alphas.Remove(source_define)
+				invisibility = 0
 				regenerate_icons()
 
 


### PR DESCRIPTION
When you're a wizard trying to use a cloak of cloaking, or jaunting, Beepsky can ruin your day. This PR prevents Beepsky from using high-levels of anti-magic to capture wizards. Also, other methods of invisibility seem to work

## What this does
This checks flags to see if Beepsky considers you a target. If you're invisible enough, he can't target you to arrest you.

## Why it's good
It's gameover for a wizard who accidentally gets too close to Beepsky, and it's no fun

## HELP
Need to figure out how extinguishers make someone visible

:cl:
 * tweak: Beepsky can't find you if you're invisible.


