### PR TITLE
Vox and trader only co-operative cell item: Vox shoal raid pacts

### DIFF
--- a/code/datums/gamemode/factions/vox_shoal.dm
+++ b/code/datums/gamemode/factions/vox_shoal.dm
@@ -252,7 +252,7 @@ var/list/potential_bonus_items = list(
 			results = "The vox raiders didn't beat the previous record of [score_to_beat]."
 
 		for (var/datum/role/R in members)
-			to_chat(R.antag.current, "<span class='notice'>The raid is over. The shoal contract has seized. Enjoy your spoils!</span>")
+			to_chat(R.antag.current, "<span class='notice'>The raid is over. The shoal contract has seized and all collected items and personnel have been converted to shoal funds at the trade window. Enjoy your spoils!</span>")
 		trader_account.money += total_points
 
 	else if (vox_shuttle.returned_home)

--- a/code/datums/gamemode/factions/vox_shoal.dm
+++ b/code/datums/gamemode/factions/vox_shoal.dm
@@ -254,6 +254,8 @@ var/list/potential_bonus_items = list(
 		for (var/datum/role/R in members)
 			to_chat(R.antag.current, "<span class='notice'>The raid is over. The shoal contract has seized and all collected items and personnel have been converted to shoal funds at the trade window. Enjoy your spoils!</span>")
 		trader_account.money += total_points
+		var/datum/trade_product/voxraid/VR = new
+		SStrade.all_trade_merch.Add(VR)
 
 	else if (vox_shuttle.returned_home)
 		completed =  TRUE
@@ -422,6 +424,17 @@ var/list/potential_bonus_items = list(
 	new /obj/item/clothing/glasses/hud/health(src)
 	new /obj/item/tool/circular_saw(src)
 	new /obj/item/weapon/gun/dartgun/vox/medical(src)
+
+/obj/item/weapon/storage/box/large/vox_equipment/random/New()
+	..()
+	var/boxtype = pick(
+		/obj/item/weapon/storage/box/large/vox_equipment/raider,
+		/obj/item/weapon/storage/box/large/vox_equipment/engineer,
+		/obj/item/weapon/storage/box/large/vox_equipment/saboteur,
+		/obj/item/weapon/storage/box/large/vox_equipment/medic,
+	)
+	new boxtype(loc)
+	qdel(src)
 
 /obj/machinery/vending/raider
 	name = "\improper Raider Surplus"

--- a/code/datums/gamemode/factions/vox_shoal.dm
+++ b/code/datums/gamemode/factions/vox_shoal.dm
@@ -203,8 +203,34 @@ var/list/potential_bonus_items = list(
 			total_points -= RULE_OF_THREE(-60, 100, time_left)
 			completed = TRUE
 			return
-		/*
-		// -- Secondly, add points if everyone is alive and well, and send back our prisonners to the mainstation in a shelter.
+
+		// -- Secondly, are all our raiders in the end area?
+		for (var/datum/role/R in members)
+			if(!(get_area(R.antag.current) == end_area))
+				return
+
+		// -- Thirdly, add points if everyone is alive and well, but reset and break out if goal is not met.
+		for (var/mob/living/H in end_area)
+			if (!isvoxraider(H))
+				count_score(H)
+
+		var/datum/objective/abduct/A = locate(/datum/objective/abduct) in objective_holder.GetObjectives()
+		if(!A || got_personnel < A.num)
+			got_personnel = 0
+			score = 0
+			return
+
+		for (var/obj/O in end_area)
+			count_score(O)
+
+		var/datum/objective/steal_priority/SP = locate(/datum/objective/steal_priority) in objective_holder.GetObjectives()
+		if(!SP || got_items < SP.num)
+			got_items = 0
+			score = 0
+			return
+
+		completed = TRUE
+
 		for (var/mob/living/H in end_area)
 			if (isvoxraider(H))
 				if (H.stat)
@@ -213,13 +239,8 @@ var/list/potential_bonus_items = list(
 				else
 					to_chat(H, "<span class='notice'>The raid has been concluded, and you returned safe. This will greatly helps us.</span>")
 					total_points += 500
-			else
-				count_score(H)
 
-		for (var/obj/O in end_area)
-			count_score(O)
-
-		// -- Thirdly, let's compare the score.
+		// -- Fourthly, let's compare the score.
 		var/vox_raider_data = SSpersistence_misc.read_data(/datum/persistence_task/vox_raiders)
 		var/score_to_beat = text2num(vox_raider_data["best_score"])
 
@@ -232,7 +253,6 @@ var/list/potential_bonus_items = list(
 
 		for (var/datum/role/R in members)
 			to_chat(R.antag.current, "<span class='notice'>The raid is over. The shoal contract has seized. Enjoy your spoils!</span>")
-			*/
 
 	else if (vox_shuttle.returned_home)
 		completed =  TRUE

--- a/code/datums/gamemode/factions/vox_shoal.dm
+++ b/code/datums/gamemode/factions/vox_shoal.dm
@@ -253,6 +253,7 @@ var/list/potential_bonus_items = list(
 
 		for (var/datum/role/R in members)
 			to_chat(R.antag.current, "<span class='notice'>The raid is over. The shoal contract has seized. Enjoy your spoils!</span>")
+		trader_account.money += total_points
 
 	else if (vox_shuttle.returned_home)
 		completed =  TRUE

--- a/code/datums/gamemode/factions/vox_shoal.dm
+++ b/code/datums/gamemode/factions/vox_shoal.dm
@@ -145,49 +145,57 @@ var/list/potential_bonus_items = list(
 				A = null
 				continue
 
-		var/spawn_count = 1
+	var/spawn_count = 1
 
-		for(var/datum/role/vox_raider/V in members)
-			var/datum/mind/synd_mind = V.antag
-			equip_raider(synd_mind.current, spawn_count)
+	for(var/datum/role/vox_raider/V in members)
+		var/datum/mind/synd_mind = V.antag
+		equip_raider(synd_mind.current, spawn_count)
 
 /datum/faction/vox_shoal/proc/equip_raider(var/mob/living/carbon/human/vox, var/index)
-	vox.age = rand(12,20)
-	if(vox.overeatduration) //We need to do this here and now, otherwise a lot of gear will fail to spawn
-		vox.overeatduration = 0 //Fat-B-Gone
-		if(vox.nutrition > 400) //We are also overeating nutriment-wise
-			vox.nutrition = 400 //Fix that
-		vox.mutations.Remove(M_FAT)
-		vox.update_mutantrace(0)
-		vox.update_mutations(0)
-		vox.update_inv_w_uniform(0)
-		vox.update_inv_wear_suit()
+	if(!tradepost_shoal)
+		vox.age = rand(12,20)
+		if(vox.overeatduration) //We need to do this here and now, otherwise a lot of gear will fail to spawn
+			vox.overeatduration = 0 //Fat-B-Gone
+			if(vox.nutrition > 400) //We are also overeating nutriment-wise
+				vox.nutrition = 400 //Fix that
+			vox.mutations.Remove(M_FAT)
+			vox.update_mutantrace(0)
+			vox.update_mutations(0)
+			vox.update_inv_w_uniform(0)
+			vox.update_inv_wear_suit()
 
-	vox.my_appearance.s_tone = random_skin_tone("Vox")
-	vox.dna.mutantrace = "vox"
-	vox.set_species("Vox")
-	vox.fully_replace_character_name(vox.real_name, vox.generate_name())
-	vox.mind.name = vox.name
-	//vox.languages = HUMAN // Removing language from chargen.
-	vox.default_language = all_languages[LANGUAGE_VOX]
-	vox.flavor_text = ""
-	vox.species.default_language = LANGUAGE_VOX
-	vox.remove_language(LANGUAGE_GALACTIC_COMMON)
-	vox.my_appearance.h_style = "Short Vox Quills"
-	vox.my_appearance.f_style = "Shaved"
-	for(var/datum/organ/external/limb in vox.organs)
-		limb.status &= ~(ORGAN_DESTROYED | ORGAN_ROBOT | ORGAN_PEG)
-	var/datum/outfit/striketeam/voxraider/concrete_outfit = new
-	concrete_outfit.equip(vox)
-	vox.regenerate_icons()
+		vox.my_appearance.s_tone = random_skin_tone("Vox")
+		vox.dna.mutantrace = "vox"
+		vox.set_species("Vox")
+		vox.fully_replace_character_name(vox.real_name, vox.generate_name())
+		vox.mind.name = vox.name
+		//vox.languages = HUMAN // Removing language from chargen.
+		vox.default_language = all_languages[LANGUAGE_VOX]
+		vox.flavor_text = ""
+		vox.species.default_language = LANGUAGE_VOX
+		vox.remove_language(LANGUAGE_GALACTIC_COMMON)
+		vox.my_appearance.h_style = "Short Vox Quills"
+		vox.my_appearance.f_style = "Shaved"
+		for(var/datum/organ/external/limb in vox.organs)
+			limb.status &= ~(ORGAN_DESTROYED | ORGAN_ROBOT | ORGAN_PEG)
+		var/datum/outfit/striketeam/voxraider/concrete_outfit = new
+		concrete_outfit.equip(vox)
+		vox.regenerate_icons()
+		/*
+		spawn()
+			var/chosen_loadout = input(vox, "The raid is about to begin. What kind of operations would you like to specialize into ?") in list("Raider", "Engineer", "Saboteur", "Medic")
+			concrete_outfit.chosen_spec = chosen_loadout
+			concrete_outfit.equip_special_items(vox)
+		*/
+	else
+		var/obj/item/weapon/card/id/card = vox.get_id_card()
+		if(card)
+			if(!(access_trade in card.access))
+				card.access.Add(access_trade)
+			if(!(access_trade in card.base_access))
+				card.base_access.Add(access_trade)
+
 	vox.store_memory("The priority items for the day are: [english_list(bonus_items_of_the_day)]")
-
-	/*
-	spawn()
-		var/chosen_loadout = input(vox, "The raid is about to begin. What kind of operations would you like to specialize into ?") in list("Raider", "Engineer", "Saboteur", "Medic")
-		concrete_outfit.chosen_spec = chosen_loadout
-		concrete_outfit.equip_special_items(vox)
-	*/
 
 /datum/faction/vox_shoal/process()
 	if (completed)

--- a/code/datums/gamemode/factions/vox_shoal.dm
+++ b/code/datums/gamemode/factions/vox_shoal.dm
@@ -252,13 +252,13 @@ var/list/potential_bonus_items = list(
 			results = "The vox raiders didn't beat the previous record of [score_to_beat]."
 
 		for (var/datum/role/R in members)
-			to_chat(R.antag.current, "<span class='notice'>The raid is over. The shoal contract has seized and all collected items and personnel have been converted to shoal funds at the trade window. Enjoy your spoils!</span>")
+			to_chat(R.antag.current, "<span class='notice'>The raid is over. The shoal contract has ceased and all collected items and personnel have been converted to shoal funds at the trade window. Enjoy your spoils!</span>")
 		trader_account.money += total_points
 		for(var/path in subtypesof(/datum/trade_product))
 			var/datum/trade_product/TP = path
 			if(!(initial(TP.raid_required)))
 				continue
-			all_trade_merch += new path
+			SStrade.all_trade_merch += new path
 
 	else if (vox_shuttle.returned_home)
 		completed =  TRUE

--- a/code/datums/gamemode/factions/vox_shoal.dm
+++ b/code/datums/gamemode/factions/vox_shoal.dm
@@ -136,17 +136,17 @@ var/list/potential_bonus_items = list(
 /datum/faction/vox_shoal/OnPostSetup()
 	..()
 
-	for(var/obj/effect/landmark/A in landmarks_list)
-		if (A.name == "vox_locker")
-			var/obj/structure/closet/loot/L = new(get_turf(A))
-			our_bounty_lockers += L
-			qdel(A)
-			A = null
-			continue
-
-	var/spawn_count = 1
-
 	if(!tradepost_shoal)
+		for(var/obj/effect/landmark/A in landmarks_list)
+			if (A.name == "vox_locker")
+				var/obj/structure/closet/loot/L = new(get_turf(A))
+				our_bounty_lockers += L
+				qdel(A)
+				A = null
+				continue
+
+		var/spawn_count = 1
+
 		for(var/datum/role/vox_raider/V in members)
 			var/datum/mind/synd_mind = V.antag
 			equip_raider(synd_mind.current, spawn_count)
@@ -195,7 +195,7 @@ var/list/potential_bonus_items = list(
 	. = ..()
 	time_left -= 2
 	if (tradepost_shoal)
-		var/area/end_area = locate(/area/trade_floor)
+		var/area/end_area = locate(/area/vox_trading_post/docking)
 		// -- First, are we late ? -100 points for every minute over the clock.
 		if (time_left < 0)
 			for (var/datum/role/R in members)

--- a/code/datums/gamemode/factions/vox_shoal.dm
+++ b/code/datums/gamemode/factions/vox_shoal.dm
@@ -254,8 +254,11 @@ var/list/potential_bonus_items = list(
 		for (var/datum/role/R in members)
 			to_chat(R.antag.current, "<span class='notice'>The raid is over. The shoal contract has seized and all collected items and personnel have been converted to shoal funds at the trade window. Enjoy your spoils!</span>")
 		trader_account.money += total_points
-		var/datum/trade_product/voxraid/VR = new
-		SStrade.all_trade_merch.Add(VR)
+		for(var/path in subtypesof(/datum/trade_product))
+			var/datum/trade_product/TP = path
+			if(!(initial(TP.raid_required)))
+				continue
+			all_trade_merch += new path
 
 	else if (vox_shuttle.returned_home)
 		completed =  TRUE

--- a/code/datums/gamemode/role/vox_raider.dm
+++ b/code/datums/gamemode/role/vox_raider.dm
@@ -38,6 +38,10 @@
 	icon_state = "contract0"
 	var/uses = 1
 
+/obj/item/vox_charter/Destroy()
+	new /datum/artifact_postmortem_data(src)
+	..()
+
 /obj/item/vox_charter/examine(mob/user, size, show_name)
 	..()
 	var/speaksvox = FALSE

--- a/code/datums/gamemode/role/vox_raider.dm
+++ b/code/datums/gamemode/role/vox_raider.dm
@@ -7,14 +7,16 @@
 	logo_state = "vox-logo"
 	default_admin_voice = "Vox Shoal"
 	admin_voice_style = "vox"
+	var/tradepost_shoal = FALSE
 
 /datum/role/vox_raider/OnPostSetup()
 	.=..()
 	if(!.)
 		return
-	antag.current.forceMove(pick(voxstart))
-	equip_raider(antag.current)
-	equip_vox_raider(antag.current)
+	if(!tradepost_shoal)
+		antag.current.forceMove(pick(voxstart))
+		equip_raider(antag.current)
+		equip_vox_raider(antag.current)
 
 /datum/role/vox_raider/chief_vox
 	logo_state = "vox-logo"
@@ -26,3 +28,56 @@
 	var/minutes = round(vox.time_left / (2*60), 1)
 	var/seconds = add_zero("[vox.time_left / 2 % 60]", 2)
 	return "Raid time left: [minutes]:[seconds] minutes."
+
+/obj/item/vox_charter
+	name = "vox pidgin pamphlet"
+	desc = "A mysterious parchment written in vox pidgin."
+	w_class = W_CLASS_TINY
+	mech_flags = MECH_SCAN_FAIL
+	icon = 'icons/obj/wizard.dmi'
+	icon_state = "contract0"
+	var/uses = 1
+
+/obj/item/vox_charter/examine(mob/user, size, show_name)
+	..()
+	var/speaksvox = FALSE
+	for(var/datum/language/L in user.languages)
+		if(istype(L,/datum/language/vox))
+			speaksvox = TRUE
+			break
+	to_chat(user, "<span class='vox'>[speaksvox ? "It is specifically call for cousins forming a shoal creed, to raid wares for credit and fortune." : "You can't make out the contents of the text, but from its general structure it seems alarmist and instructional in nature."]</span>")
+
+/obj/item/vox_charter/attack_self(mob/user as mob)
+	var/speaksvox = FALSE
+	for(var/datum/language/L in user.languages)
+		if(istype(L,/datum/language/vox))
+			speaksvox = TRUE
+			break
+	if(!speaksvox)
+		to_chat(user, "<span class='vox'>You try to make out the words on the parchment and stumble with the awkward, caw-like vocalisations.</span>")
+	else if(!isvox(user))
+		to_chat(user, "<span class='vox'>You seem to actually understand this call for a raid, but the vox do not accept non-vox into their ranks.</span>")
+	else if(isantagbanned(user) || jobban_isbanned(user, VOXRAIDER))
+		to_chat(user, "<span class='vox'>You seem eager to sign your name, but remember that the vox have specifically excluded you from raiding parties in the past.</span>")
+	else if(!isvoxraider(user))
+		to_chat(user, "<span class='vox'>You sign a name on the line at the end, it seems cousins accept new friend into plunder of many goods and wares. Bring coin, bring captive, all you can find! For glory of voxkind.</span>")
+		var/datum/faction/vox_shoal/shoal = find_active_faction_by_type(/datum/faction/vox_shoal)
+		if (!shoal)
+			shoal = ticker.mode.CreateFaction(/datum/faction/vox_shoal, null, 1)
+			shoal.OnPostSetup()
+		shoal.tradepost_shoal = TRUE
+		var/datum/role/vox_raider/newRaider = new /datum/role/vox_raider()
+		newRaider.tradepost_shoal = TRUE
+		newRaider.AssignToRole(user.mind,1)
+		shoal.HandleRecruitedRole(newRaider)
+		newRaider.OnPostSetup()
+		newRaider.Greet(GREET_DEFAULT)
+		uses--
+	else
+		to_chat(user, "<span class='vox'>You seem to already have pact active with raiding. Maybe ask again some other time?</span>")
+
+	if(!uses)
+		qdel(src)
+
+/obj/item/vox_charter/acidable()
+	return 0

--- a/code/datums/gamemode/role/vox_raider.dm
+++ b/code/datums/gamemode/role/vox_raider.dm
@@ -69,12 +69,14 @@
 		if (!shoal)
 			shoal = ticker.mode.CreateFaction(/datum/faction/vox_shoal, null, 1)
 			shoal.OnPostSetup()
+			shoal.forgeObjectives()
 		shoal.tradepost_shoal = TRUE
 		var/datum/role/vox_raider/newRaider = new /datum/role/vox_raider()
 		newRaider.tradepost_shoal = TRUE
 		newRaider.AssignToRole(user.mind,1)
 		shoal.HandleRecruitedRole(newRaider)
 		newRaider.OnPostSetup()
+		newRaider.AnnounceObjectives()
 		newRaider.Greet(GREET_DEFAULT)
 		uses--
 	else

--- a/code/datums/gamemode/role/vox_raider.dm
+++ b/code/datums/gamemode/role/vox_raider.dm
@@ -76,8 +76,8 @@
 		newRaider.AssignToRole(user.mind,1)
 		shoal.HandleRecruitedRole(newRaider)
 		newRaider.OnPostSetup()
-		newRaider.AnnounceObjectives()
 		newRaider.Greet(GREET_DEFAULT)
+		newRaider.AnnounceObjectives()
 		uses--
 	else
 		to_chat(user, "<span class='vox'>You seem to already have pact active with raiding. Maybe ask again some other time?</span>")

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1209,6 +1209,20 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/bloodcult_pamphlet/oneuse
 	cost = 60
 
+/datum/uplink_item/syndie_coop/voxraid_charter
+	name = "Vox Raid Charter"
+	desc = "A charter for cousins decreeing the beginning of a raiding on Nanotrasen-held spaces, forming a shoal creed for bringing back wares for many goods! For fluent vox eyes only."
+	item = /obj/item/vox_charter
+	cost = 60
+	discounted_cost = 40
+	jobs_exclusive = list("Trader","Vox","Skeletal Vox")
+	jobs_with_discount = list("Trader")
+
+/datum/uplink_item/syndie_coop/voxraid_charter/on_item_spawned(var/obj/I, var/mob/user)
+	if(istype(I,/obj/item/vox_charter))
+		var/obj/item/vox_charter/VC = I
+		VC.uses = gives_discount(user.job) || gives_discount(user.dna.species) ? 2 : 3 // Cap it at 20 per head
+
 /datum/uplink_item/syndie_coop/codebreaker
 	name = "Codebreaker"
 	desc = "The be-all-end-all solution to halting Nanotrasen's expansion into free space.  This piece of Gorlex tech will allow a cell that is sufficiently large enough to decrypt the authentication key for their target station's failsafe thermonuclear warhead.  Good luck, operatives."

--- a/code/modules/research/xenoarchaeology/artifact/artifact.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact.dm
@@ -18,6 +18,7 @@
 	5;/obj/machinery/syndicate_beacon,
 	5;/obj/item/clothing/mask/stone,
 	5;/obj/item/changeling_vial,
+	5;/obj/item/vox_charter,
 	5;/obj/item/weapon/bloodcult_pamphlet/oneuse,
 	25;/obj/item/clothing/gloves/warping_claws,
 	25;/obj/machinery/singularity_beacon,

--- a/code/modules/trader/trade_datums.dm
+++ b/code/modules/trader/trade_datums.dm
@@ -12,6 +12,7 @@
 	var/totalsold = 0
 	var/flux_rate = 1
 	var/sales_category = TRADE_SINGLE
+	var/raid_required = FALSE
 
 /datum/trade_product/proc/current_price(mob/user)
 	var/loyalty_multiplier = 1
@@ -160,3 +161,11 @@
 	restocks_left = 3
 	sales_category = TRADE_VARIETY
 
+/datum/trade_product/voxraid
+	name = "vox raiding kit"
+	path = /obj/item/weapon/storage/box/large/vox_equipment/random
+	baseprice = 100
+	maxunits = 3
+	restocks_left = 3
+	sales_category = TRADE_VARIETY
+	raid_required = TRUE

--- a/code/modules/trader/trade_system.dm
+++ b/code/modules/trader/trade_system.dm
@@ -20,6 +20,9 @@ var/datum/subsystem/trade_system/SStrade
 
 /datum/subsystem/trade_system/Initialize(timeofday)
 	for(var/path in subtypesof(/datum/trade_product))
+		var/datum/trade_product/TP = path
+		if(initial(TP.raid_required))
+			continue
 		all_trade_merch += new path
 	market_flux(FALSE)
 	..()


### PR DESCRIPTION
[content]

## What this does
Adds a vox and trader exclusive co-operative cell item to traitor uplinks, costing 60 TC but discounted to 40 TC for traders, activating it as a vox that can speak vox pidgin sets up a vox raider faction modified to use the trade outpost as a base, with the reward being points converted into shoal funds and some raider items being unlocked at trade windows. Also adds the charter as a very rare xenoarchaeology artifact, like the other antag items with the same chance.

## Why it's good
Adds more vox and trader specific items, and is thematic with them while opening up the trade window to some antag-exclusive items.

## Changelog
:cl:
 * rscadd: Trader and vox syndicate members can now purchase a charter declaring a shoal creed for a vox raid, the completion of which promises many coin for shoal funds at trader windows, and some new gifts.