### PR TITLE
IV Drip Tweaks

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -190,10 +190,6 @@
 		to_chat(usr, "<span class='warning'>You can't do that.</span>")
 		return
 
-	if(locked_to) //attached to rollerbed? probably?
-		to_chat(usr, "<span class='warning'>You can't do that while \the [src] is fastened to something.</span>")
-		return
-
 	mode = !mode
 	to_chat(usr, "<span class='info'>The [src] is now [mode ? "injecting" : "taking blood"].</span>")
 	update_icon()

--- a/code/game/objects/structures/stool_bed_chair_nest/rollerbed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/rollerbed.dm
@@ -88,7 +88,6 @@
 			"You attach \the [IV] from \the [src].",
 			"You hear a small metal latch.")
 
-		IV.mode = IVDRIP_INJECTING
 		IV.update_icon()
 
 		if(IV.pulledby)


### PR DESCRIPTION
[tweak][bugfix][qol]
This stops an IV drip's injecting/taking blood mode from resetting to injecting when attached to a roller bed, so you can draw blood while the IV drip is attached to the bed. And also, allows you to toggle an IV drip's mode while it's attached to a roller bed.

:cl:
 * tweak: An IV drip's mode can now be toggled while it is attached to a roller bed. 
 * bugfix: Blood-taking IV drips will stay blood-taking when attached to a roller bed.