### PR TITLE
More suicide_act() improvements

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -237,8 +237,9 @@ Class Procs:
 	..()
 
 /obj/machinery/suicide_act(var/mob/living/user)
-	to_chat(viewers(user), "<span class='danger'>[user] is placing \his hands into the sockets of the [src] and tries to fry \himself! It looks like \he's trying to commit suicide.</span>")
-	return(SUICIDE_ACT_FIRELOSS)
+	if(idle_power_usage || (active_power_usage && use_power))
+		to_chat(viewers(user), "<span class='danger'>[user] is placing \his hands into the sockets of the [src] and tries to fry \himself! It looks like \he's trying to commit suicide.</span>")
+		return(SUICIDE_ACT_FIRELOSS)
 
 /obj/machinery/ex_act(severity)
 	switch(severity)


### PR DESCRIPTION
[content][tested]

## What this does
Allows suicides with all reachable objects in view by walking up to them, not just adjacent; and also prevents suicides with powered off machines or items that aren't tangible. (such as floor obscured ones)

## Why it's good
Adds some much needed sanity for people who keep hitting nearby pipes by mistake even if they're under floors, plus should make the "all else fails" suicides appear way less often.

## Changelog
:cl:
 * rscadd: Players can now end up committing suicide with anything they can see and get to, not just immediately nearby items.
 * bugfix: Suicides can no longer be done with invisible or non-mouse opaque items.
 * tweak: Suicides can no longer be done with powered off machinery.