### PR TITLE
Fix banana cream pies permanently blinding simple mobs

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -218,10 +218,12 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 	if(sdisabilities & BLIND)	//disabled-blind, doesn't get better on its own
 		blinded = 1
 	else if(eye_blind)			//blindness, heals slowly over time
-		eye_blind = max(eye_blind-1,0)
+		eye_blind = max(eye_blind - 1, 0)
 		blinded = 1
-	else if(eye_blurry)	//blurry eyes heal slowly
-		eye_blurry = max(eye_blurry-1, 0)
+	else
+		if(eye_blurry)	//blurry eyes heal slowly
+			eye_blurry = max(eye_blurry - 1, 0)
+		blinded = null
 
 	//Ears
 	if(sdisabilities & DEAF)	//disabled-deaf, doesn't get better on its own


### PR DESCRIPTION
[bugfix]
This fixes banana cream pies permanently blinding simple mobs, by adding a reset to `blindness` when not under blinding circumstances.

:cl:
 * bugfix: Banana cream pie-induced blindness is now temporary in animals.

