### PR TITLE
Electromagnetic Hypersensitivity

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -510,6 +510,7 @@ var/global/list/NOIRMATRIX = list(0.33,0.33,0.33,0,\
 #define ASTHMA		32
 #define LACTOSE		64
 #define ANEMIA		128
+#define ELECTROSENSE	256
 
 //sdisabilities
 #define BLIND			1
@@ -1708,7 +1709,7 @@ var/proccalls = 1
 #define ESPORTS_CULTISTS "Team Geometer"
 #define ESPORTS_SECURITY "Team Security"
 
-#define DNA_SE_LENGTH 59
+#define DNA_SE_LENGTH 60
 
 #define VOX_SHAPED "Vox","Skeletal Vox"
 #define GREY_SHAPED "Grey"

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -415,6 +415,7 @@ var/global/list/BODY_COVER_VALUE_LIST=list("[HEAD]" = COVER_PROTECTION_HEAD,"[EY
 #define DISABILITY_FLAG_LACTOSE		256
 #define DISABILITY_FLAG_LISP		512
 #define DISABILITY_FLAG_ANEMIA		1024
+#define DISABILITY_FLAG_EHS			2048
 
 ///////////////////////////////////////
 // MUTATIONS

--- a/code/game/dna/genes/disabilities.dm
+++ b/code/game/dna/genes/disabilities.dm
@@ -168,3 +168,13 @@
 /datum/dna/gene/disability/anemia/New()
 	..()
 	block = ANEMIABLOCK
+
+/datum/dna/gene/disability/ehs
+	name = "Electromagnetic Hypersensitivity"
+	activation_message = "You feel like electricity burns you."
+	deactivation_message = "Electricity no longer hurts to be around."
+	disability = ELECTROSENSE
+
+/datum/dna/gene/disability/ehs/New()
+	..()
+	block = EHSBLOCK

--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -33,6 +33,7 @@ var/SMALLSIZEBLOCK = 0
 // Goon Stuff
 ///////////////////////////////
 // Disabilities
+var/EHSBLOCK = 0
 var/ANEMIABLOCK = 0
 var/LISPBLOCK = 0
 var/MUTEBLOCK = 0
@@ -142,6 +143,7 @@ var/LACTOSEBLOCK = 0
 	/////////////////////////////////////////////
 
 	// Disabilities
+	EHSBLOCK   	   = getAssignedBlock("ELECTROSENSE",     numsToAssign)
 	ANEMIABLOCK    = getAssignedBlock("ANEMIA",     numsToAssign)
 	LISPBLOCK      = getAssignedBlock("LISP",       numsToAssign)
 	MUTEBLOCK      = getAssignedBlock("MUTE",       numsToAssign)

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -1355,6 +1355,16 @@
 	block = TELEPATHYBLOCK
 	..()
 
+/obj/item/weapon/dnainjector/nofail/ehs
+	name = "DNA-Injector (Electromagnetic Hypersensitivity)"
+	desc = "And he gets to be an IAA? What a sick joke!"
+	datatype = DNA2_BUF_SE
+	value = 0xFFF
+
+/obj/item/weapon/dnainjector/nofail/ehs/initialize()
+	block = EHSBLOCK
+	..()
+
 /obj/item/weapon/dnainjector/nofail/randompower/New(newloc)
     var/type = pick(/obj/item/weapon/dnainjector/nofail/hulkmut,
         /obj/item/weapon/dnainjector/nofail/xraymut,

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -684,6 +684,7 @@ var/const/MAX_SAVE_SLOTS = 16
 	HTML += ShowDisabilityState(user,DISABILITY_FLAG_LACTOSE,     "Lactose Intolerant")
 	HTML += ShowDisabilityState(user,DISABILITY_FLAG_LISP,       "Lisp")
 	HTML += ShowDisabilityState(user,DISABILITY_FLAG_ANEMIA,       "Anemia")
+	HTML += ShowDisabilityState(user,DISABILITY_FLAG_EHS,       "Electromagnetic Hypersensitivity")
 	/*HTML += ShowDisabilityState(user,DISABILITY_FLAG_COUGHING,   "Coughing")
 	HTML += ShowDisabilityState(user,DISABILITY_FLAG_TOURETTES,   "Tourettes") Still working on it! -Angelite*/
 
@@ -1517,6 +1518,8 @@ Values up to 1000 are allowed.", "FPS", fps) as null|num
 		character.disabilities|=NEARSIGHTED
 	if(disabilities & DISABILITY_FLAG_EPILEPTIC)
 		character.disabilities|=EPILEPSY
+	if(disabilities & DISABILITY_FLAG_EHS)
+		character.disabilities|=ELECTROSENSE
 	if(disabilities & DISABILITY_FLAG_DEAF)
 		character.sdisabilities|=DEAF
 	if(disabilities & DISABILITY_FLAG_BLIND)

--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -2,7 +2,6 @@
 
 /mob/living/carbon/human/proc/handle_disabilities()
 	if(disabilities & ELECTROSENSE)
-		var/affected = FALSE
 		var/affect_chance = 100
 		if(head && istype(head,/obj/item/clothing/head/tinfoil))
 			affect_chance /= 2

--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -11,7 +11,7 @@
 		for(var/obj/machinery/M in range(3,src))
 			if(!(M.stat & (NOPOWER|BROKEN|FORCEDISABLE)) && M.use_power > 0 && prob(affect_chance))
 				affect_amount++
-		for(var/atom/movable/A in in range(rand(1,2),src))
+		for(var/atom/movable/A in range(rand(1,2),src))
 			var/obj/item/cell/C = A.get_cell()
 			if(C && C.charge && prob(affect_chance))
 				affect_amount++

--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -14,9 +14,13 @@
 				if(prob(5))
 					Jitter(5)
 				if(prob(5))
-					M.eye_blurry += 5
-		//for(var/obj/item/device/D in search_contents_for(/obj/item/device))
-			//apply_effects(agony = 1, eyeblur = prob(10))
+					eye_blurry += 5
+		/*for(var/obj/item/device/D in search_contents_for(/obj/item/device))
+			adjustHalLoss(1)
+			if(prob(5))
+				Jitter(5)
+			if(prob(5))
+				eye_blurry += 5*/
 
 	if(disabilities & ASTHMA)
 		if(prob(0.2))

--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -3,23 +3,23 @@
 /mob/living/carbon/human/proc/handle_disabilities()
 	if(disabilities & ELECTROSENSE)
 		var/affect_chance = 100
+		var/affect_amount = 0
 		if(head && istype(head,/obj/item/clothing/head/tinfoil))
 			affect_chance /= 2
 		if(wear_suit && istype(wear_suit,/obj/item/clothing/suit/spaceblanket))
 			affect_chance /= 2
 		for(var/obj/machinery/M in range(3,src))
-			if(!(M.stat & NOPOWER) && prob(affect_chance))
-				adjustHalLoss(1)
-				if(prob(5))
-					Jitter(5)
-				if(prob(5))
-					eye_blurry += 5
-		/*for(var/obj/item/device/D in search_contents_for(/obj/item/device))
-			adjustHalLoss(1)
-			if(prob(5))
-				Jitter(5)
-			if(prob(5))
-				eye_blurry += 5*/
+			if(!(M.stat & (NOPOWER|BROKEN|FORCEDISABLE)) && M.use_power > 0 && prob(affect_chance))
+				affect_amount++
+		for(var/atom/movable/A in in range(rand(1,2),src))
+			var/obj/item/cell/C = A.get_cell()
+			if(C && C.charge && prob(affect_chance))
+				affect_amount++
+		adjustHalLoss(affect_amount)
+		if(prob(min(affect_amount,100)))
+			Jitter(min(affect_amount,100))
+		if(prob(min(affect_amount,100)))
+			eye_blurry += min(affect_amount,100)
 
 	if(disabilities & ASTHMA)
 		if(prob(0.2))

--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -1,6 +1,23 @@
 //Refer to life.dm for caller
 
 /mob/living/carbon/human/proc/handle_disabilities()
+	if(disabilities & ELECTROSENSE)
+		var/affected = FALSE
+		var/affect_chance = 100
+		if(head && istype(head,/obj/item/clothing/head/tinfoil))
+			affect_chance /= 2
+		if(wear_suit && istype(wear_suit,/obj/item/clothing/suit/spaceblanket))
+			affect_chance /= 2
+		for(var/obj/machinery/M in range(3,src))
+			if(!(M.stat & NOPOWER) && prob(affect_chance))
+				adjustHalLoss(1)
+				if(prob(5))
+					Jitter(5)
+				if(prob(5))
+					M.eye_blurry += 5
+		//for(var/obj/item/device/D in search_contents_for(/obj/item/device))
+			//apply_effects(agony = 1, eyeblur = prob(10))
+
 	if(disabilities & ASTHMA)
 		if(prob(0.2))
 			asthma_attack()

--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -12,14 +12,15 @@
 			if(!(M.stat & (NOPOWER|BROKEN|FORCEDISABLE)) && M.use_power > 0 && prob(affect_chance))
 				affect_amount++
 		for(var/atom/movable/A in range(rand(1,2),src))
-			var/obj/item/cell/C = A.get_cell()
+			var/obj/item/weapon/cell/C = A.get_cell()
 			if(C && C.charge && prob(affect_chance))
 				affect_amount++
-		adjustHalLoss(affect_amount)
-		if(prob(min(affect_amount,100)))
-			Jitter(min(affect_amount,100))
-		if(prob(min(affect_amount,100)))
-			eye_blurry += min(affect_amount,100)
+		if(!stat)
+			adjustHalLoss(affect_amount)
+			if(prob(min(affect_amount,100)))
+				Jitter(min(affect_amount,100))
+			if(prob(min(affect_amount,100)))
+				eye_blurry += min(affect_amount,100)
 
 	if(disabilities & ASTHMA)
 		if(prob(0.2))


### PR DESCRIPTION
[content]

## What this does
Adds this as a disability, when within 3 tiles of any powered on machinery causes 1 amount of pain for each machine, can be somewhat but not fully negated with a space blanket and tinfoil hat.

## Why it's good
Should allow for something to be mitigated in a unique way (cutting power and wearing aforementioned items) while also allowing people to detect machinery through walls as a silver lining.

## Changelog
:cl:
 * rscadd: Genetics and player preferences can now cause people to be afflicted with electromagnetic hypersensitivity, causing pain in the presence of any active powered machinery.