### PR TITLE
Biting and kicking while handcuffed but not being pulled, grabbed, or buckled.

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -151,7 +151,7 @@
 
 //Humans being able to bite and kick while restrained, either generally or only when not being pulled or grabbed, according to config.human_captive_kickbite.
 /mob/living/carbon/human/RestrainedClickOn(var/atom/A)
-	if(a_intent != I_HURT || !attack_type || A.loc == src)
+	if(a_intent != I_HURT || !attack_type || A.loc == src || !Adjacent(A))
 		return
 	if(is_pacified())
 		to_chat(src, "<span class = 'notice'>Violence is not the answer, you remind yourself.</span>")

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -157,14 +157,15 @@
 		to_chat(src, "<span class = 'notice'>Violence is not the answer, you remind yourself.</span>")
 		return
 	if(!config.human_captive_kickbite)
-		if(pulledby || grabbed_by.len)
+		if(pulledby || grabbed_by.len || locked_to)
+			var/restrained_message = "<span class = 'notice'>You're [locked_to ? "buckled to [locked_to]" : "being restrained"]!"
 			switch(attack_type)
 				if(ATTACK_KICK)
-					to_chat(src, "<span class = 'notice'>You're being restrained! Need a leg up?</span>")
+					restrained_message += " Need a leg up?"
 				if(ATTACK_BITE)
-					to_chat(src, "<span class = 'notice'>You're being restrained! Bitten off more than you can chew?</span>")
-				else
-					to_chat(src, "<span class = 'notice'>You're being restrained!</span>")
+					restrained_message += " Bitten off more than you can chew?"
+			restrained_message += "</span>"
+			to_chat(src, restrained_message)
 			return
 	handleSpecialAttack(A)
 

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -19,7 +19,7 @@
 		delayNextAttack(10)
 
 	if(!can_use_hand_or_stump())
-		to_chat(src, "<span class = 'info'>You try to move your arm but nothing happens. Need a hand?</span>")
+		to_chat(src, "<span class = 'notice'>You try to move your arm but nothing happens. Need a hand?</span>")
 		return
 
 	if(src.can_use_hand())
@@ -160,11 +160,11 @@
 		if(pulledby || grabbed_by.len)
 			switch(attack_type)
 				if(ATTACK_KICK)
-					to_chat(src, "<span class = 'info'>Your restraints keep you from kicking properly. Need a leg up?</span>")
+					to_chat(src, "<span class = 'notice'>You're being restrained! Need a leg up?</span>")
 				if(ATTACK_BITE)
-					to_chat(src, "<span class = 'info'>Your restraints keep you from biting properly. Bitten off more than you can chew?</span>")
+					to_chat(src, "<span class = 'notice'>You're being restrained! Bitten off more than you can chew?</span>")
 				else
-					to_chat(src, "<span class = 'info'>Your restraints keep you from doing that properly.</span>")
+					to_chat(src, "<span class = 'notice'>You're being restrained!</span>")
 			return
 	handleSpecialAttack(A)
 

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -6,38 +6,9 @@
 */
 /mob/living/carbon/human/UnarmedAttack(var/atom/A, var/proximity, var/params)
 	var/obj/item/clothing/gloves/G = gloves // not typecast specifically enough in defines
-
 	if(a_intent == "hurt" && !is_pacified() && A.loc != src)
-		var/special_attack_result = SPECIAL_ATTACK_SUCCESS
-		switch(attack_type) //Special attacks - kicks, bites
-			if(ATTACK_KICK)
-				if(can_kick(A))
-
-					delayNextAttack(10)
-
-					special_attack_result = A.kick_act(src)
-					if(special_attack_result != SPECIAL_ATTACK_CANCEL) //kick_act returns that value if there's no interaction specified
-						after_special_attack(A, attack_type, special_attack_result)
-						return
-
-					delayNextAttack(-10) //This is only called when the kick fails
-				else
-					set_attack_type() //Reset attack type
-
-			if(ATTACK_BITE)
-				if(can_bite(A))
-
-					delayNextAttack(10)
-
-					special_attack_result = A.bite_act(src)
-					if(special_attack_result != SPECIAL_ATTACK_CANCEL) //bite_act returns that value if there's no interaction specified
-						after_special_attack(A, attack_type, special_attack_result)
-						return
-
-					delayNextAttack(-10) //This is only called when the bite fails
-				else
-					set_attack_type() //Reset attack type
-
+		if(handleSpecialAttack(A))
+			return
 	// Special glove functions:
 	// If the gloves do anything, have them return 1 to stop
 	// normal attack_hand() here.
@@ -48,8 +19,9 @@
 		delayNextAttack(10)
 
 	if(!can_use_hand_or_stump())
-		to_chat(src, "You try to move your arm but nothing happens. Need a hand?")
+		to_chat(src, "<span class = 'info'>You try to move your arm but nothing happens. Need a hand?</span>")
 		return
+
 	if(src.can_use_hand())
 		A.attack_hand(src, params, proximity)
 	else
@@ -59,6 +31,32 @@
 		var/obj/O = A
 		if(O.material_type)
 			O.material_type.on_use(O, src, null)
+
+/mob/living/carbon/human/proc/handleSpecialAttack(var/atom/A)
+	var/special_attack_result = SPECIAL_ATTACK_SUCCESS
+	switch(attack_type) //Special attacks - kicks, bites
+		if(ATTACK_KICK)
+			if(can_kick(A))
+				delayNextAttack(10)
+				special_attack_result = A.kick_act(src)
+				if(special_attack_result != SPECIAL_ATTACK_CANCEL) //kick_act returns that value if there's no interaction specified
+					after_special_attack(A, attack_type, special_attack_result)
+					return TRUE
+				delayNextAttack(-10) //This is only called when the kick fails
+			else
+				set_attack_type() //Reset attack type
+
+		if(ATTACK_BITE)
+			if(can_bite(A))
+				delayNextAttack(10)
+				special_attack_result = A.bite_act(src)
+				if(special_attack_result != SPECIAL_ATTACK_CANCEL) //bite_act returns that value if there's no interaction specified
+					after_special_attack(A, attack_type, special_attack_result)
+					return TRUE
+				delayNextAttack(-10) //This is only called when the bite fails
+			else
+				set_attack_type() //Reset attack type
+	return FALSE
 
 /atom/proc/attack_hand(mob/user as mob, params, var/proximity)
 	return
@@ -150,6 +148,25 @@
 	else
 		for(var/mob/O in viewers(ML, null))
 			O.show_message("<span class='danger'>[src] has attempted to bite [ML]!</span>", 1)
+
+//Humans being able to bite and kick while restrained, either generally or only when not being pulled or grabbed, according to config.human_captive_kickbite.
+/mob/living/carbon/human/RestrainedClickOn(var/atom/A)
+	if(a_intent != I_HURT || !attack_type || A.loc == src)
+		return
+	if(is_pacified())
+		to_chat(src, "<span class = 'notice'>Violence is not the answer, you remind yourself.</span>")
+		return
+	if(!config.human_captive_kickbite)
+		if(pulledby || grabbed_by.len)
+			switch(attack_type)
+				if(ATTACK_KICK)
+					to_chat(src, "<span class = 'info'>Your restraints keep you from kicking properly. Need a leg up?</span>")
+				if(ATTACK_BITE)
+					to_chat(src, "<span class = 'info'>Your restraints keep you from biting properly. Bitten off more than you can chew?</span>")
+				else
+					to_chat(src, "<span class = 'info'>Your restraints keep you from doing that properly.</span>")
+			return
+	handleSpecialAttack(A)
 
 /*
 	Aliens

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -156,7 +156,7 @@
 	var/gateway_delay = 18000 //How long the gateway takes before it activates. Default is half an hour.
 	var/ghost_interaction = 0
 
-	var/human_captive_kickbite = 0 //Can restrained humans still kick and bite while also being pulled or grabbed?
+	var/human_captive_kickbite = 0 //Can restrained humans still kick and bite while also being pulled, grabbed, or buckled?
 
 	var/comms_password = ""
 	var/paperwork_library = 0 //use the library DLL.

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -156,6 +156,8 @@
 	var/gateway_delay = 18000 //How long the gateway takes before it activates. Default is half an hour.
 	var/ghost_interaction = 0
 
+	var/human_captive_kickbite = 0 //Can restrained humans still kick and bite while also being pulled or grabbed?
+
 	var/comms_password = ""
 	var/paperwork_library = 0 //use the library DLL.
 
@@ -532,6 +534,9 @@
 
 				if("uneducated_mice")
 					config.uneducated_mice = 1
+
+				if("human_captive_kickbite")
+					config.human_captive_kickbite = 1
 
 				if("comms_password")
 					config.comms_password = value


### PR DESCRIPTION
[content]
## What this does
This makes it so you can bite and kick while handcuffed, but not while also being pulled, grabbed, or buckled to something.  That way someone who has their arms tied can still defend themselves, but once their captor gets a good grip on them they can't bite or kick. If somehow they slip out of their captor's grasp again during the transport process back to their intended destination, they can kick and bite again until re-pulled or re-grabbed.

This also adds a config option that allows handcuffed people to bite and kick even when pulled, grabbed, or buckled, which is set to off by default, giving the behavior described above.

## Why it's good
Gives handcuffed people a little more recourse to self-defense, but not so much so that every captive needs to be muzzled and legcuffed or continually stunned.

## Changelog
:cl:
 * rscadd: Handcuffed people can still bite and kick as long as they're not being pulled, grabbed, or buckled.
 * rscadd: Config option allowing handcuffed people to bite and kick even when pulled, grabbed, or buckled (default off).

