### PR TITLE
Increases assistant limit per security officer from 2 to 4.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -166,7 +166,7 @@
 	var/python_path = "" //Path to the python executable.  Defaults to "python" on windows and "/usr/bin/env python2" on unix
 
 	var/assistantlimit = 0 //enables assistant limiting
-	var/assistantratio = 2 //how many assistants to security members
+	var/assistantratio = 4 //how many assistants to security members
 
 	var/emag_energy = -1
 	var/emag_starts_charged = 1


### PR DESCRIPTION
## What this does
Increases the assistant cap per security officer from 2 to 4.

## Why it's good
Honestly, I don't actually know that it is.  However, I was peer pressured into making the PR after joking about doing it, and also I'm curious what the emojiocracy thinks of this. In general player freedom is a good thing, if I were to choose an overarching idea driving this thought.

## Changelog
:cl:
 * tweak: Changed assistant cap per security staff from 2 to 4.

