### PR TITLE
banishes greytide to highpop where it belongs

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -166,7 +166,7 @@
 	var/python_path = "" //Path to the python executable.  Defaults to "python" on windows and "/usr/bin/env python2" on unix
 
 	var/assistantlimit = 0 //enables assistant limiting
-	var/assistantratio = 2 //how many assistants to security members
+	var/assistantratio = 1 //how many assistants to security members
 
 	var/emag_energy = -1
 	var/emag_starts_charged = 1


### PR DESCRIPTION
one assistant per sec instead of two.
Begone from this place, unwanted colorless mass.

🆑
tweak: Changed assistant cap per security staff from 2 to 1 (+1 default)