### PR TITLE
Adds Screwtoggle to Trade Shuttle Computer

### DIFF
--- a/code/game/shuttles/trade.dm
+++ b/code/game/shuttles/trade.dm
@@ -29,7 +29,7 @@ var/global/datum/shuttle/trade/trade_shuttle = new(starting_area = /area/shuttle
 	icon_state = "syndishuttle"
 
 	light_color = LIGHT_COLOR_RED
-	machine_flags = EMAGGABLE //No screwtoggle because this computer can't be built
+	machine_flags = EMAGGABLE | SCREWTOGGLE
 
 /obj/machinery/computer/shuttle_control/trade/New() //Main shuttle_control code is in code/game/machinery/computer/shuttle_computer.dm
 	link_to(trade_shuttle)


### PR DESCRIPTION
This was originally not included because you can't build the circuitboard, but it's important to fixing the broken glass

If this becomes an issue we can throw a couple replacement circuitboards in the trade gear vendor

🆑 
* bugfix: You can now repair the trade shuttle computer.