### PR TITLE
Suicide act improvements sans controversy

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -237,8 +237,9 @@ Class Procs:
 	..()
 
 /obj/machinery/suicide_act(var/mob/living/user)
-	to_chat(viewers(user), "<span class='danger'>[user] is placing \his hands into the sockets of the [src] and tries to fry \himself! It looks like \he's trying to commit suicide.</span>")
-	return(SUICIDE_ACT_FIRELOSS)
+	if(!(stat & NOPOWER|BROKEN|FORCEDISABLE) && use_power > 0)
+		to_chat(viewers(user), "<span class='danger'>[user] is placing \his hands into the sockets of the [src] and tries to fry \himself! It looks like \he's trying to commit suicide.</span>")
+		return(SUICIDE_ACT_FIRELOSS)
 
 /obj/machinery/ex_act(severity)
 	switch(severity)

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -263,8 +263,10 @@
 		update_icon()
 		to_chat(viewers(user), "<span class='danger'>[user] is impaling \himself with the [src]! It looks like \he's trying to commit suicide!</span>")
 		return(SUICIDE_ACT_BRUTELOSS)
-	
-	var/message_say = user.handle_suicide_bomb_cause()
+
+	var/message_say = user.handle_suicide_bomb_cause(src)
+	if(!message_say)
+		return
 	to_chat(viewers(user), "<span class='danger'>[user] activates the [src] and holds it above \his head! It looks like \he's going out with a bang!</span>")
 	user.say(message_say)
 	toggle_valve(user)

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -27,7 +27,9 @@
 	..()
 
 /obj/item/weapon/c4/suicide_act(var/mob/living/user)
-	var/message_say = user.handle_suicide_bomb_cause()
+	var/message_say = user.handle_suicide_bomb_cause(src)
+	if(!message_say)
+		return
 	to_chat(viewers(user), "<span class='danger'>[user] activates the [src] and holds it above \his head! It looks like \he's going out with a bang!</span>")
 	user.say(message_say)
 	target = user

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -121,8 +121,10 @@
 /obj/item/weapon/grenade/iedcasing/suicide_act(var/mob/living/user)
 	if (!active) //no explosion with no active ied, dummy
 		return
-	
-	var/message_say = user.handle_suicide_bomb_cause()
+
+	var/message_say = user.handle_suicide_bomb_cause(src)
+	if(!message_say)
+		return
 	to_chat(viewers(user), "<span class='danger'>[user] activates the [src] and holds it above \his head! It looks like \he's going out with a bang!</span>")
 	user.say(message_say)
 	attack_self(user)

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -38,10 +38,7 @@
 			return 1
 
 /mob/living/proc/handle_suicide_bomb_cause()
-	var/old_canmove = canmove
-	canmove = FALSE // Prevent moving away and ruining this
 	var/custom_message = input(src, "Enter a cause to dedicate this to, if any.", "For what cause?") as null|text
-	canmove = old_canmove
 
 	if(custom_message)
 		return "FOR [uppertext(custom_message)]!"

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -39,8 +39,8 @@
 
 /mob/living/proc/handle_suicide_bomb_cause(var/atom/suicide_object)
 	var/custom_message = input(src, "Enter a cause to dedicate this to, if any.", "For what cause?") as null|text
-	if(!Adjacent(suicide_object) || ((!get_active_hand() || get_active_hand() != suicide_object) && (!get_inactive_hand() || get_inactive_hand() != suicide_object)))
-		return // User moved or lost item, abort.
+	if(!Adjacent(suicide_object)) // User moved or lost item, abort.
+		return
 
 	if(custom_message)
 		return "FOR [uppertext(custom_message)]!"

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -39,7 +39,7 @@
 
 /mob/living/proc/handle_suicide_bomb_cause(var/atom/suicide_object)
 	var/custom_message = input(src, "Enter a cause to dedicate this to, if any.", "For what cause?") as null|text
-	if(!Adjacent(suicide_object) || (!get_active_hand() || get_active_hand() != suicide_object) || (!get_inactive_hand() || get_inactive_hand() != suicide_object))
+	if(!Adjacent(suicide_object) || ((!get_active_hand() || get_active_hand() != suicide_object) && (!get_inactive_hand() || get_inactive_hand() != suicide_object)))
 		return // User moved or lost item, abort.
 
 	if(custom_message)

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -37,8 +37,10 @@
 			updatehealth()
 			return 1
 
-/mob/living/proc/handle_suicide_bomb_cause()
+/mob/living/proc/handle_suicide_bomb_cause(var/atom/suicide_object)
 	var/custom_message = input(src, "Enter a cause to dedicate this to, if any.", "For what cause?") as null|text
+	if(!Adjacent(suicide_object) || (!get_active_hand() || get_active_hand() != suicide_object) || (!get_inactive_hand() || get_inactive_hand() != suicide_object))
+		return // User moved or lost item, abort.
 
 	if(custom_message)
 		return "FOR [uppertext(custom_message)]!"

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -13,7 +13,7 @@
 //Attempt to perform suicide with an item nearby or in-hand
 //Return 0 if the suicide failed, return 1 if successful. Returning 1 does not perform the default suicide afterwards
 /mob/living/proc/attempt_object_suicide(var/obj/suicide_object)
-	if(suicide_object) //We need the item to be there to begin, otherwise abort
+	if(suicide_object && suicide_object.mouse_opacity && !suicide_object.invisibility) //We need the item to be there and tangible to begin, otherwise abort
 		var/damagetype = suicide_object.suicide_act(src)
 		if(damagetype)
 			var/damage_mod = count_set_bitflags(damagetype) // How many damage types are to be applied
@@ -38,7 +38,10 @@
 			return 1
 
 /mob/living/proc/handle_suicide_bomb_cause()
+	var/old_canmove = canmove
+	canmove = FALSE // Prevent moving away and ruining this
 	var/custom_message = input(src, "Enter a cause to dedicate this to, if any.", "For what cause?") as null|text
+	canmove = old_canmove
 
 	if(custom_message)
 		return "FOR [uppertext(custom_message)]!"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -369,7 +369,7 @@ var/list/tag_suits_list = list()
 	flags = FPRINT
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/tank/emergency_nitrogen,/obj/item/toy)
 	body_parts_covered = ARMS|LEGS|FULL_TORSO
-	
+
 /obj/item/clothing/suit/sith
 	name = "Sith Robe"
 	desc = "It's treason then."
@@ -1013,7 +1013,9 @@ var/list/tag_suits_list = list()
 	if (!active) //no explosion with no active vest, dummy
 		return
 
-	var/message_say = user.handle_suicide_bomb_cause()
+	var/message_say = user.handle_suicide_bomb_cause(src)
+	if(!message_say)
+		return
 	to_chat(viewers(user), "<span class='danger'>[user] activates the [src]! It looks like \he's going out with a bang!</span>")
 	user.say(message_say)
 	explosion(user, 3, 5, 7, whodunnit = user)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -196,8 +196,8 @@
 		var/obj/item/tool/weldingtool/welder = user.held_items[has_welder]
 		welder.setWelding(1)
 		if(welder.welding)
-			var/message_say = user.handle_suicide_bomb_cause()
-			if(!user.Adjacent(src))
+			var/message_say = user.handle_suicide_bomb_cause(src)
+			if(!message_say)
 				return
 			to_chat(viewers(user), "<span class='danger'>[user] presses the warm lit welder against the cold body of a welding fuel tank! It looks like \he's going out with a bang!</span>")
 			user.say(message_say)


### PR DESCRIPTION
[content][tested]

## What this does
Prevents suicides with unpowered or broken machines or items that aren't tangible. (such as floor obscured ones)

## Why it's good
Adds some much needed sanity for people who keep hitting nearby pipes by mistake even if they're under floors.

## Changelog
:cl:
 * bugfix: Suicides can no longer be done with invisible or non-mouse opaque items, or powered off machinery.