### PR TITLE
Slot machines influenced by luck, scratch cards less influenced by luck, & made luckier clovers rarer.

### DIFF
--- a/code/game/machinery/computer/slot_machine.dm
+++ b/code/game/machinery/computer/slot_machine.dm
@@ -97,7 +97,8 @@
 
 		icon_state = initial_icon
 
-/obj/machinery/computer/slot_machine/proc/spin_wheels(win = -1) //If win=-1, the result is pure randomness. If win=0, you NEVER win. If win is 1 to 10, you win.
+/obj/machinery/computer/slot_machine/proc/spin_wheels(win = -1, var/mob/spinner) //If win=-1, the result is pure randomness. If win=0, you NEVER win. If win is 1 to 10, you win.
+
 	while(1)
 		value_1 = rand(1,10)
 		value_2 = rand(1,10)
@@ -105,6 +106,15 @@
 
 		switch(win)
 			if(-1)
+				//Take luck into account.
+				if(spinner)
+					var/spinnerluck = spinner.luck()
+					var/jostlepower = rand(25,325)
+					var/jostles = min(round(abs(spinnerluck), jostlepower) / jostlepower, 1000)
+					while(jostles)
+						if(jostle(spinnerluck > 0))
+							break
+						jostles -= 1
 				return //Pure randomness!
 			if(0)
 				if(!(value_1 == value_2 && value_2 == value_3)) //If we're NOT winning
@@ -116,6 +126,32 @@
 				return
 			else
 				return
+
+/obj/machinery/computer/slot_machine/proc/jostle(towin = TRUE)
+	if(!(value_1 == value_2 && value_2 == value_3) && towin)		//Lucky people get jostles if they were going to lose.
+		switch(rand(1,3))
+			if(1)
+				if(value_1 != value_2 && value_1 != value_3)
+					value_1 = rand(1,10)
+			if(2)
+				if(value_1 != value_2 && value_2 != value_3)
+					value_2 = rand(1,10)
+			if(3)
+				if(value_1 != value_3 && value_2 != value_3)
+					value_3 = rand(1,10)
+	else if((value_1 == value_2 && value_2 == value_3) && !towin)	//Unlucky people get jostles if they were going to win.
+		switch(rand(1,3))
+			if(1)
+				if(value_1 == value_2 || value_1 == value_3)
+					value_1 = rand(1,10)
+			if(2)
+				if(value_1 == value_2 || value_2 == value_3)
+					value_2 = rand(1,10)
+			if(3)
+				if(value_1 == value_3 || value_2 == value_3)
+					value_3 = rand(1,10)
+	else
+		return TRUE
 
 /obj/machinery/computer/slot_machine/proc/spin(mob/user)
 	if(spinning)
@@ -150,9 +186,9 @@
 
 		switch(victory)
 			if(1) //1 in 10 for a guaranteed small reward
-				spin_wheels(win = pick(BELL, MUSHROOM, TREE))
+				spin_wheels(win = pick(BELL, MUSHROOM, TREE), spinner = user)
 			if(2 to 10) //Otherwise, a fully random spin (1/1000 to get jackpot, 1/100 to get other reward)
-				spin_wheels(win = -1)
+				spin_wheels(win = -1, spinner = user)
 
 	//If there's only one icon_state for spinning, everything looks weird
 	var/list/spin_states = list("spin1","spin2","spin3")

--- a/code/game/machinery/computer/slot_machine.dm
+++ b/code/game/machinery/computer/slot_machine.dm
@@ -109,7 +109,7 @@
 				//Take luck into account.
 				if(spinner)
 					var/spinnerluck = spinner.luck()
-					var/jostlepower = rand(25,500)
+					var/jostlepower = rand(25,1000)
 					var/jostles = min(round(abs(spinnerluck), jostlepower) / jostlepower, 1000)
 					while(jostles)
 						if(jostle(spinnerluck > 0))

--- a/code/game/machinery/computer/slot_machine.dm
+++ b/code/game/machinery/computer/slot_machine.dm
@@ -109,7 +109,7 @@
 				//Take luck into account.
 				if(spinner)
 					var/spinnerluck = spinner.luck()
-					var/jostlepower = rand(25,1000)
+					var/jostlepower = rand(25,3000)
 					var/jostles = min(round(abs(spinnerluck), jostlepower) / jostlepower, 1000)
 					while(jostles)
 						if(jostle(spinnerluck > 0))

--- a/code/game/machinery/computer/slot_machine.dm
+++ b/code/game/machinery/computer/slot_machine.dm
@@ -109,7 +109,7 @@
 				//Take luck into account.
 				if(spinner)
 					var/spinnerluck = spinner.luck()
-					var/jostlepower = rand(25,325)
+					var/jostlepower = rand(25,500)
 					var/jostles = min(round(abs(spinnerluck), jostlepower) / jostlepower, 1000)
 					while(jostles)
 						if(jostle(spinnerluck > 0))

--- a/code/game/machinery/computer/slot_machine.dm
+++ b/code/game/machinery/computer/slot_machine.dm
@@ -128,7 +128,7 @@
 				return
 
 /obj/machinery/computer/slot_machine/proc/jostle(towin = TRUE)
-	if(!(value_1 == value_2 && value_2 == value_3) && towin)		//Lucky people get jostles if they were going to lose.
+	if((value_1 != value_2 || value_2 != value_3 || value_1 != value_3) && towin)		//Lucky people get jostles on unaligned wheels.
 		switch(rand(1,3))
 			if(1)
 				if(value_1 != value_2 && value_1 != value_3)
@@ -139,14 +139,17 @@
 			if(3)
 				if(value_1 != value_3 && value_2 != value_3)
 					value_3 = rand(1,10)
-	else if((value_1 == value_2 && value_2 == value_3) && !towin)	//Unlucky people get jostles if they were going to win.
+	else if((value_1 == value_2 || value_2 == value_3 || value_1 == value_3) && !towin)	//Unlucky people get jostles on aligned wheels.
 		switch(rand(1,3))
 			if(1)
-				value_1 = rand(1,10)
+				if(value_1 == value_2 || value_1 == value_3)
+					value_1 = rand(1,10)
 			if(2)
-				value_2 = rand(1,10)
+				if(value_1 == value_2 || value_2 == value_3)
+					value_2 = rand(1,10)
 			if(3)
-				value_3 = rand(1,10)
+				if(value_1 == value_3 || value_2 == value_3)
+					value_3 = rand(1,10)
 	else
 		return TRUE
 

--- a/code/game/machinery/computer/slot_machine.dm
+++ b/code/game/machinery/computer/slot_machine.dm
@@ -142,14 +142,11 @@
 	else if((value_1 == value_2 && value_2 == value_3) && !towin)	//Unlucky people get jostles if they were going to win.
 		switch(rand(1,3))
 			if(1)
-				if(value_1 == value_2 || value_1 == value_3)
-					value_1 = rand(1,10)
+				value_1 = rand(1,10)
 			if(2)
-				if(value_1 == value_2 || value_2 == value_3)
-					value_2 = rand(1,10)
+				value_2 = rand(1,10)
 			if(3)
-				if(value_1 == value_3 || value_2 == value_3)
-					value_3 = rand(1,10)
+				value_3 = rand(1,10)
 	else
 		return TRUE
 

--- a/code/modules/games/cards/lotto.dm
+++ b/code/modules/games/cards/lotto.dm
@@ -22,7 +22,7 @@
 	for(var/prize = 1 to problist.len)
 		var/thisprob = problist[prize]
 		//Take luck into account.
-		if(user ? user.lucky_prob(thisprob, luckfactor = 1/500, ourluck = luck) : prob(thisprob))
+		if(user ? user.lucky_prob(thisprob, luckfactor = 1/1500, ourluck = luck) : prob(thisprob))
 			profit = prizelist[prize]*input_prize_multiplier*tuning_value
 			return profit
 

--- a/code/modules/games/cards/lotto.dm
+++ b/code/modules/games/cards/lotto.dm
@@ -22,7 +22,7 @@
 	for(var/prize = 1 to problist.len)
 		var/thisprob = problist[prize]
 		//Take luck into account.
-		if(user ? user.lucky_prob(thisprob, luckfactor = 1/1500, ourluck = luck) : prob(thisprob))
+		if(user ? user.lucky_prob(thisprob, luckfactor = 1/1000, ourluck = luck) : prob(thisprob))
 			profit = prizelist[prize]*input_prize_multiplier*tuning_value
 			return profit
 

--- a/code/modules/games/cards/lotto.dm
+++ b/code/modules/games/cards/lotto.dm
@@ -22,7 +22,7 @@
 	for(var/prize = 1 to problist.len)
 		var/thisprob = problist[prize]
 		//Take luck into account.
-		if(user ? user.lucky_prob(thisprob, luckfactor = 1/1500, maxskew = 25, ourluck = luck) : prob(thisprob))
+		if(user ? user.lucky_prob(thisprob, luckfactor = 1/5000, maxskew = 25, ourluck = luck) : prob(thisprob))
 			profit = prizelist[prize]*input_prize_multiplier*tuning_value
 			return profit
 

--- a/code/modules/games/cards/lotto.dm
+++ b/code/modules/games/cards/lotto.dm
@@ -22,7 +22,7 @@
 	for(var/prize = 1 to problist.len)
 		var/thisprob = problist[prize]
 		//Take luck into account.
-		if(user ? user.lucky_prob(thisprob, luckfactor = 1/1000, maxskew = 25, ourluck = luck) : prob(thisprob))
+		if(user ? user.lucky_prob(thisprob, luckfactor = 1/1500, maxskew = 25, ourluck = luck) : prob(thisprob))
 			profit = prizelist[prize]*input_prize_multiplier*tuning_value
 			return profit
 

--- a/code/modules/games/cards/lotto.dm
+++ b/code/modules/games/cards/lotto.dm
@@ -22,7 +22,7 @@
 	for(var/prize = 1 to problist.len)
 		var/thisprob = problist[prize]
 		//Take luck into account.
-		if(user ? user.lucky_prob(thisprob, luckfactor = 1/1000, ourluck = luck) : prob(thisprob))
+		if(user ? user.lucky_prob(thisprob, luckfactor = 1/1000, maxskew = 25, ourluck = luck) : prob(thisprob))
 			profit = prizelist[prize]*input_prize_multiplier*tuning_value
 			return profit
 

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -1148,12 +1148,12 @@ var/list/special_fruits = list()
 	if(shifter ? shifter.lucky_prob(prob1, 1/100, 25, ourluck = luck) : prob(prob1))
 		var/ls = 1
 		var/prob2 = max(clamp(mut, 0, 21) / 21, 0.1)
-		prob2 = shifter ? shifter.lucky_probability(prob2, 1/100 , 33, ourluck = luck) : prob2
+		prob2 = shifter ? shifter.lucky_probability(prob2, 1/333 , 33, ourluck = luck) : prob2
 		for(var/i in 1 to 7)
 			if(prob(prob2))
 				ls += 1
 		leaves += ls * pick(-1,1)
-		if(shifter ? shifter.lucky_prob(3, 1/100, 50, ourluck = luck) : prob(3))
+		if(shifter ? shifter.lucky_prob(3, 1/333, 50, ourluck = luck) : prob(3))
 			leaves = clamp(leaves, 0, 7)
 		else if(leaves < 0 || leaves > 7)
 			leaves = 3


### PR DESCRIPTION
## What this does
This makes slot machines affected by luck. Also makes it so getting clovers beyond two-leaf and four-leaf requires a bit more luck to do, so it's a little harder to get your hands on them. I didn't realize how straightforward it was to get a plant with 100+ potency originally.

## Why it's good
Since scratchcards are affected by luck it seems natural to have slot machines affected as well. And this is less of a "money glut" risk than scratchcards because each slot machine has way less cash in it than the scratch card jackpots. And observing and messing around a bit yesterday it seemed rather easy to get the higher tier clovers so hopefully this makes it a bit nicer.

:cl:
 * rscadd: Slot machines are now affected by luck.
 * tweak: Made lucky clovers a bit more rare.
 * tweak: Scaled down scratchcard luck influence.

