### PR TITLE
Gives Ayy Mobs Mothership Access (Mothership Lab Vault)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/human/grey.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/grey.dm
@@ -150,6 +150,9 @@
 
 	corpse = /obj/effect/landmark/corpse/grey/explorer
 
+/mob/living/simple_animal/hostile/humanoid/grey/explorer/GetAccess()
+	return list(access_mothership_general, access_mothership_military)
+
 ///////////////////////////////////////////////////////////////////SPACEWORTHY EXPLORERS///////////
 /mob/living/simple_animal/hostile/humanoid/grey/explorer/space
 	name = "Grey Explorer"
@@ -277,6 +280,9 @@
 	faction = "mothership"
 
 	corpse = /obj/effect/landmark/corpse/grey/soldier_sentry
+
+/mob/living/simple_animal/hostile/humanoid/grey/soldier/GetAccess()
+	return list(access_mothership_general, access_mothership_military)
 
 ///////////////////////////////////////////////////////////////////GREY GUARD///////////
 //Baseline soldier. Has an additional 25 HP and a disintegrator ranged weapon. They can also change firing modes in combat!
@@ -595,6 +601,9 @@
 	faction = "mothership"
 
 	corpse = /obj/effect/landmark/corpse/grey/researcher
+
+/mob/living/simple_animal/hostile/humanoid/grey/researcher/GetAccess()
+	return list(access_mothership_general, access_mothership_research)
 
 ///////////////////////////////////////////////////////////////////GREY SCIENTIST///////////
 //Grey ranged researcher. Less hit points than a soldier, will shoot their disintegrator at targets and occasionally change firing modes
@@ -933,3 +942,6 @@
 /mob/living/simple_animal/hostile/humanoid/grey/leader/Aggro()
 	..()
 	say(pick("You came this far, even after being warned not to? So be it.","You are clearly too intellectually inferior to understand anything but force.","Attacking a mothership administrator? I almost pity your stupidity.","What do you even hope to accomplish from this?","What a grand and intoxicating insolence.","Once I've disintegrated your body I will keep your brain to study your unnatural behavior."), all_languages[LANGUAGE_GREY])
+
+/mob/living/simple_animal/hostile/humanoid/grey/leader/GetAccess()
+	return list(access_mothership_general, access_mothership_maintenance, access_mothership_military, access_mothership_research, access_mothership_leader)

--- a/code/modules/mob/living/simple_animal/hostile/human/greynurse.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/greynurse.dm
@@ -88,6 +88,9 @@
 	new /mob/living/simple_animal/hostile/humanoid/nurseunit(get_turf(src))
 	..(gibbed)
 
+/mob/living/simple_animal/hostile/humanoid/greynurse/GetAccess()
+	return list(access_mothership_general, access_mothership_maintenance, access_mothership_military, access_mothership_research, access_mothership_leader)
+
 /mob/living/simple_animal/hostile/humanoid/greynurse/New() // she can also speak quack
 	..()
 	languages += all_languages[LANGUAGE_GREY]
@@ -254,6 +257,9 @@
 	new /obj/effect/gibspawner/genericmothership(src.loc)
 	new /obj/effect/gibspawner/robot(src.loc)
 	..(gibbed)
+
+/mob/living/simple_animal/hostile/humanoid/nurseunit/GetAccess()
+	return list(access_mothership_general, access_mothership_maintenance, access_mothership_military, access_mothership_research, access_mothership_leader)
 
 /mob/living/simple_animal/hostile/humanoid/nurseunit/New()
 	..()


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
## Ayy Door Open Get ##
- Ayy humanoid mobs now have mothership access based on their role and rank. If an admeme ever busses a player into one, they should be able to actually open doors in their area without having to force them open
- In practice probably won't have much effect on the vault, as critical chokepoints are divided by bolted doors or other obstacles, but you might see a few ayy mobs wandering into other rooms and doing a little more roaming
- Neat idea suggested by Kurfurst

:cl:
 * rscadd: Ayy simplemobs now have mothership access to open doors based on their role and rank