### PR TITLE
Disallow wormholes from spawning within grilles.

### DIFF
--- a/code/game/gamemodes/events/wormholes.dm
+++ b/code/game/gamemodes/events/wormholes.dm
@@ -4,7 +4,7 @@
 		for(var/turf/simulated/floor/T in world)
 			if(T.z == map.zMainStation)
 				//Check for and avoid grilles.
-				if(var/obj/structure/grille/G in T.contents)
+				if(/obj/structure/grille in T.contents)
 					continue
 				pick_turfs += T
 

--- a/code/game/gamemodes/events/wormholes.dm
+++ b/code/game/gamemodes/events/wormholes.dm
@@ -3,12 +3,9 @@
 		var/list/pick_turfs = list()
 		for(var/turf/simulated/floor/T in world)
 			if(T.z == map.zMainStation)
-				//Check for and avoid grilles and closed doors.
+				//Check for and avoid grilles.
 				if(var/obj/structure/grille/G in T.contents)
 					continue
-				else if(var/obj/machinery/door/D in T.contents)
-					if(D.density)
-						continue
 				pick_turfs += T
 
 		if(pick_turfs.len)

--- a/code/game/gamemodes/events/wormholes.dm
+++ b/code/game/gamemodes/events/wormholes.dm
@@ -3,6 +3,12 @@
 		var/list/pick_turfs = list()
 		for(var/turf/simulated/floor/T in world)
 			if(T.z == map.zMainStation)
+				//Check for and avoid grilles and closed doors.
+				if(var/obj/structure/grille/G in T.contents)
+					continue
+				else if(var/obj/machinery/door/D in T.contents)
+					if(D.density)
+						continue
 				pick_turfs += T
 
 		if(pick_turfs.len)


### PR DESCRIPTION
[bugfix]
## What this does
This makes it so wormholes generated during the Time Agent event don't spawn under a grille.

## Why it's good
Help avoid people getting stuck inside of windows. It currently doesn't allow spawning wormholes inside of wall turfs and since windows with grilles are essentially functionally walls it makes sense. 

If there's a nicer way to do this, or you'd prefer it to exclude other forms of objects as well, please let me know.

:cl:
 * bugfix: Time-agent-related wormholes can no longer appear inside grilles. 

