### PR TITLE
Mushroom Fixes

### DIFF
--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -130,7 +130,7 @@
 	range = GLOBALCAST //the world
 	max_targets = 1
 	selection_type = "view"
-	spell_flags = SELECTABLE|TALKED_BEFORE|INCLUDEUSER
+	spell_flags = SELECTABLE|TALKED_BEFORE
 	override_base = "genetic"
 	hud_state = "gen_project"
 	compatible_mobs = list(/mob/living/carbon/human, /datum/mind)

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1342,11 +1342,31 @@ var/list/has_died_as_golem = list()
 	H.default_gib()
 
 /datum/species/mushroom/silent_speech(mob/M, message)
+	if(M.stat == DEAD)
+		var/mob/dead/observer/O = M
+		if(istype(M))
+			O.say(message)
+		return
+	if (M.stat == UNCONSCIOUS)
+		to_chat(M, "<span class='warning'>You must be conscious to do this!</span>")
+		return
+	//Need to remove targets, otherwise mushroom can communicate at any distance to everyone
+	var/all_switch = FALSE
+	var/list/too_far = list()
+	for(var/mob/living/T in telepathic_target)
+		if(T in view(10,M))
+			continue
+		all_switch = TRUE
+		telepathic_target -= T
+		too_far += T.name
+	if(all_switch)
+		to_chat(M, "<span class='notice'>[english_list(too_far)] is too far away.</span>")
+
 	if(!telepathic_target.len)
 		var/mob/living/L = M
 		telepathic_target += L
 
-	var/all_switch = TRUE
+	all_switch = TRUE
 	for(var/mob/living/T in telepathic_target)
 		if(istype(T) && M.can_mind_interact(T))
 			to_chat(T,"<span class='mushroom'>You feel <b>[M]</b>'s thoughts: </span><span class='mushroom'>[message]</span>")

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1342,31 +1342,20 @@ var/list/has_died_as_golem = list()
 	H.default_gib()
 
 /datum/species/mushroom/silent_speech(mob/M, message)
+	if(!message)
+		return
 	if(M.stat == DEAD)
-		var/mob/dead/observer/O = M
-		if(istype(M))
-			O.say(message)
+		to_chat(M, "<span class='warning'>You must be alive to do this!</span>")
 		return
 	if (M.stat == UNCONSCIOUS)
 		to_chat(M, "<span class='warning'>You must be conscious to do this!</span>")
 		return
-	//Need to remove targets, otherwise mushroom can communicate at any distance to everyone
-	var/all_switch = FALSE
-	var/list/too_far = list()
-	for(var/mob/living/T in telepathic_target)
-		if(T in view(10,M))
-			continue
-		all_switch = TRUE
-		telepathic_target -= T
-		too_far += T.name
-	if(all_switch)
-		to_chat(M, "<span class='notice'>[english_list(too_far)] is too far away.</span>")
 
 	if(!telepathic_target.len)
 		var/mob/living/L = M
 		telepathic_target += L
 
-	all_switch = TRUE
+	var/all_switch = TRUE
 	for(var/mob/living/T in telepathic_target)
 		if(istype(T) && M.can_mind_interact(T))
 			to_chat(T,"<span class='mushroom'>You feel <b>[M]</b>'s thoughts: </span><span class='mushroom'>[message]</span>")


### PR DESCRIPTION
[bugfix]

## What this does
- Prevents mushrooms from sending fungal emissions while unconscious or dead.
- Need to have a non-null message to send a message

## Why it's good
Bugfixes

:cl:
 * bugfix: Mushrooms can't send messages while unconscious or dead