### PR TITLE
Fixed throw_impact runtime

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -410,7 +410,7 @@
 		airflow_speed = 0
 		airflow_time = 0
 		if(src.throwing)
-			src.throw_impact(Obstacle, user = usr)
+			src.throw_impact(Obstacle, null, usr) // TODO: Find a way to pass the speed. Or remove the speed parameter.
 			src.throwing = 0
 		if(Obstacle)
 			Obstacle.Bumped(src)


### PR DESCRIPTION
Fixes this
```
[01:50:18] Runtime in , line : bad arg name 'user'
proc name: throw impact (/obj/effect/decal/cleanable/throw_impact)
src: the gibs (/obj/effect/decal/cleanable/blood/gibs)
src.loc: the plating (410,82,5) (/turf/simulated/floor/plating)
call stack:
the gibs (/obj/effect/decal/cleanable/blood/gibs): throw impact(the wall (409,82,5) (/turf/simulated/wall), null)
the gibs (/obj/effect/decal/cleanable/blood/gibs): to bump(the wall (409,82,5) (/turf/simulated/wall))
the gibs (/obj/effect/decal/cleanable/blood/gibs): perform bump()
the gibs (/obj/effect/decal/cleanable/blood/gibs): Move(the wall (409,82,5) (/turf/simulated/wall), 8, 0, 0, 32)
the gibs (/obj/effect/decal/cleanable/blood/gibs): throw at(the wall (409,83,5) (/turf/simulated/wall), 1, 1, 1, 1)
the gibs (/obj/effect/decal/cleanable/blood/gibs): streak(/list (/list), 0)
```