### PR TITLE
Vampire text typo fix

### DIFF
--- a/code/datums/gamemode/objectives/freeform/vampire.dm
+++ b/code/datums/gamemode/objectives/freeform/vampire.dm
@@ -1,2 +1,2 @@
 /datum/objective/freeform/vampire
-	explanation_text = "The Masquerade has officially ended. After years of tedium, the time to embrance wild abandon and create chaos is upon you."
+	explanation_text = "The Masquerade has officially ended. After years of tedium, the time to embrace wild abandon and create chaos is upon you."


### PR DESCRIPTION
Fixes a typo in vampire scoreboard text:
"embrance" -> "embrace"
