### PR TITLE
Tweaks luck-related values for slots and lotto tickets 

### DIFF
--- a/code/game/machinery/computer/slot_machine.dm
+++ b/code/game/machinery/computer/slot_machine.dm
@@ -110,7 +110,7 @@
 				if(spinner)
 					var/spinnerluck = spinner.luck()
 					var/jostlepower = 25
-					for(var/i in 1 to 5)
+					for(var/i in 1 to 3)
 						jostlepower = max(jostlepower, rand(25, i * 1000))
 					var/jostles = min(round(abs(spinnerluck), jostlepower) / jostlepower, 1000)
 					while(jostles)

--- a/code/game/machinery/computer/slot_machine.dm
+++ b/code/game/machinery/computer/slot_machine.dm
@@ -109,7 +109,9 @@
 				//Take luck into account.
 				if(spinner)
 					var/spinnerluck = spinner.luck()
-					var/jostlepower = rand(25,5000)
+					var/jostlepower = 25
+					for(var/i in 1 to 3)
+						jostlepower = max(jostlepower, rand(25, i * 1000))
 					var/jostles = min(round(abs(spinnerluck), jostlepower) / jostlepower, 1000)
 					while(jostles)
 						if(jostle(spinnerluck > 0))

--- a/code/game/machinery/computer/slot_machine.dm
+++ b/code/game/machinery/computer/slot_machine.dm
@@ -110,8 +110,8 @@
 				if(spinner)
 					var/spinnerluck = spinner.luck()
 					var/jostlepower = 25
-					for(var/i in 1 to 3)
-						jostlepower = max(jostlepower, rand(25, i * 1000))
+					for(var/i in 1 to 2)
+						jostlepower = max(jostlepower, rand(25, i * 1500))
 					var/jostles = min(round(abs(spinnerluck), jostlepower) / jostlepower, 1000)
 					while(jostles)
 						if(jostle(spinnerluck > 0))

--- a/code/game/machinery/computer/slot_machine.dm
+++ b/code/game/machinery/computer/slot_machine.dm
@@ -110,8 +110,8 @@
 				if(spinner)
 					var/spinnerluck = spinner.luck()
 					var/jostlepower = 25
-					for(var/i in 1 to 2)
-						jostlepower = max(jostlepower, rand(25, i * 1500))
+					for(var/i in 1 to 5)
+						jostlepower = max(jostlepower, rand(25, i * 1000))
 					var/jostles = min(round(abs(spinnerluck), jostlepower) / jostlepower, 1000)
 					while(jostles)
 						if(jostle(spinnerluck > 0))

--- a/code/game/machinery/computer/slot_machine.dm
+++ b/code/game/machinery/computer/slot_machine.dm
@@ -109,7 +109,7 @@
 				//Take luck into account.
 				if(spinner)
 					var/spinnerluck = spinner.luck()
-					var/jostlepower = rand(25,3000)
+					var/jostlepower = rand(25,5000)
 					var/jostles = min(round(abs(spinnerluck), jostlepower) / jostlepower, 1000)
 					while(jostles)
 						if(jostle(spinnerluck > 0))

--- a/code/modules/games/cards/lotto.dm
+++ b/code/modules/games/cards/lotto.dm
@@ -22,7 +22,7 @@
 	for(var/prize = 1 to problist.len)
 		var/thisprob = problist[prize]
 		//Take luck into account.
-		if(user ? user.lucky_prob(thisprob, luckfactor = 1/10000, maxskew = 47.5, ourluck = luck) : prob(thisprob))
+		if(user ? user.lucky_prob(thisprob, luckfactor = 1/12000, maxskew = 49.9, ourluck = luck) : prob(thisprob))
 			profit = prizelist[prize] * prize_multiplier * tuning_value
 			return profit
 

--- a/code/modules/games/cards/lotto.dm
+++ b/code/modules/games/cards/lotto.dm
@@ -22,7 +22,7 @@
 	for(var/prize = 1 to problist.len)
 		var/thisprob = problist[prize]
 		//Take luck into account.
-		if(user ? user.lucky_prob(thisprob, luckfactor = 1/20000, maxskew = 47.5, ourluck = luck) : prob(thisprob))
+		if(user ? user.lucky_prob(thisprob, luckfactor = 1/10000, maxskew = 47.5, ourluck = luck) : prob(thisprob))
 			profit = prizelist[prize] * prize_multiplier * tuning_value
 			return profit
 

--- a/code/modules/games/cards/lotto.dm
+++ b/code/modules/games/cards/lotto.dm
@@ -9,6 +9,7 @@
 	var/winnings = 0
 	var/list/prizelist = list(100000,50000,10000,5000,1000,500,250,100,50,20,10,5,4,3,2,1)
 	var/list/problist = list(0.0001, 0.0002, 0.001, 0.002, 0.01, 0.02, 0.04, 0.2, 1, 2.5, 5, 10, 12.5, 17, 20, 25)
+	var/tuning_value = 1/5 //Used to adjust expected values.
 
 /obj/item/toy/lotto_ticket/New()
 	..()
@@ -16,14 +17,13 @@
 	pixel_x = rand(-9, 9) * PIXEL_MULTIPLIER
 
 /obj/item/toy/lotto_ticket/proc/scratch(var/input_prize_multiplier, var/mob/user)
-	var/tuning_value = 1/5 //Used to adjust expected values.
 	var/profit = 0
 	var/luck = user?.luck()
 	for(var/prize = 1 to problist.len)
 		var/thisprob = problist[prize]
 		//Take luck into account.
-		if(user ? user.lucky_prob(thisprob, luckfactor = 1/5000, maxskew = 25, ourluck = luck) : prob(thisprob))
-			profit = prizelist[prize]*input_prize_multiplier*tuning_value
+		if(user ? user.lucky_prob(thisprob, luckfactor = 1/10000, maxskew = 47.5, ourluck = luck) : prob(thisprob))
+			profit = prizelist[prize] * prize_multiplier * tuning_value
 			return profit
 
 //Flash code taken from Blinder
@@ -102,22 +102,14 @@
 	icon_state = "lotto_3"
 	prize_multiplier = 50 //EV 45.50, ER -4.50
 
-
 //Emag card
 /obj/item/toy/lotto_ticket/supermatter_surprise
 	name = "Supermatter Surprise lottery ticket"
 	desc = "An extremely expensive scratch-off lottery ticket. Guaranteed win of up to 5,000,000 credits! Experimental film material - use at your own risk!"
 	icon_state = "lotto_4"
+	prize_multiplier = 50
+	tuning_value = 1
 	var/flashed = FALSE
-
-/obj/item/toy/lotto_ticket/supermatter_surprise/scratch()
-	var/input_prize_multiplier = 50
-	var/profit = 0
-	while(!profit)
-		for(var/prize = 1 to problist.len)
-			if(prob(problist[prize]))
-				profit = prizelist[prize]*input_prize_multiplier
-				return profit
 
 /obj/item/toy/lotto_ticket/supermatter_surprise/attackby(obj/item/weapon/S, mob/user)
 	..()

--- a/code/modules/games/cards/lotto.dm
+++ b/code/modules/games/cards/lotto.dm
@@ -22,7 +22,7 @@
 	for(var/prize = 1 to problist.len)
 		var/thisprob = problist[prize]
 		//Take luck into account.
-		if(user ? user.lucky_prob(thisprob, luckfactor = 1/10000, maxskew = 47.5, ourluck = luck) : prob(thisprob))
+		if(user ? user.lucky_prob(thisprob, luckfactor = 1/20000, maxskew = 47.5, ourluck = luck) : prob(thisprob))
 			profit = prizelist[prize] * prize_multiplier * tuning_value
 			return profit
 


### PR DESCRIPTION
[tweak][bugfix]
After considering the feedback, I tweaked the influence of luck on slot machines and lotto tickets.
1. Slot machines are less influenced by luck; the expected number of wheel jostles per luck has more of a bias towards lower values.
2. Recalibrated scratchcard parameters so that the base impact of luck is somewhat higher, and raised the luck ceiling so that extremely lucky players won't hit as abrupt of a performance wall. I calibrated it as follows:
- The base "EV" of a Phazon Fortune is 45.5 credits. I don't think it exactly corresponds to the true "expected value" of a play (since once you win a given prize you don't keep rolling on the lower prizes), but it serves as a decent surrogate for our purposes.
- Originally, having a 7-leaf clover in your pocket would raise this to ~1.7 million credits, or essentially winning the jackpot every time.
- Post-nerf (currently), the EV with a 7-leaf is ~130 credits. However, due to the way it was nerfed, having 10 7-leaves only increases this further to ~136 credits, which is essentially the ceiling.
- This PR makes it so the EV with 1 7-leaf is ~230 credits (with getting the jackpot being around 5 or 6 times as likely as usual) and raises the luck ceiling such that the the jackpot probability plateaus at around 1/1000 beyond that.

I think it's nicer to have a wider range AKA having the luck ceiling higher, but not so high that it gives massive payouts too often.

Also fixes a bug where luck wasn't coming into play with Supermatter Surprise tickets. 

Fixes #32692

:cl:
 * tweak: Lowered influence of luck on slot machines.
 * tweak: Tweaked influence of luck on scratchcards to hopefully give more satisfying results.
 * bugfix: Luck influences Supermatter Surprise scratchcards properly.
