### PR TITLE
Fixes camera bug ventcrawling.

### DIFF
--- a/code/_onclick/ventcrawl.dm
+++ b/code/_onclick/ventcrawl.dm
@@ -21,6 +21,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 		/obj/transmog_body_container,
 		/obj/item/verbs,
 		/obj/item/weapon/gun/hookshot/flesh,
+		/obj/item/device/camera_bug,
 	)
 	return allowed_items
 


### PR DESCRIPTION
[bugfix]
Closes: #32702 
## What this does
Lets you ventcrawl if there's a camera bug attached to you.

## Why it's good
It fixes a bug.

## Changelog
:cl:
 * bugfix: You are now able to ventcrawl if there's a camera bug attached to you. This mainly applies to slimes.

