### PR TITLE
Implements strange seed and no-fruit product blacklist and fixes related inconsistencies with clovers

### DIFF
--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -524,9 +524,7 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 
 		score.stuffharvested += 1 //One point per product unit
 
-		if(mysterious)
-			product.name += "?"
-			product.desc += " On second thought, something about this one looks strange."
+		mysterious_append(product)
 
 		if(biolum)
 			if(biolum_colour)
@@ -539,6 +537,11 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 
 			product.visible_message("<span class='notice'>The pod disgorges [product]!</span>")
 			handle_living_product(product)
+
+/datum/seed/proc/mysterious_append(product)
+	if(mysterious)
+		product.name += "?"
+		product.desc += " On second thought, something about this one looks strange."
 
 //Harvest without concern for the user
 /datum/seed/proc/autoharvest(var/turf/T, var/yield_mod = 1)

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -538,7 +538,7 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 			product.visible_message("<span class='notice'>The pod disgorges [product]!</span>")
 			handle_living_product(product)
 
-/datum/seed/proc/mysterious_append(product)
+/datum/seed/proc/mysterious_append(atom/product)
 	if(mysterious)
 		product.name += "?"
 		product.desc += " On second thought, something about this one looks strange."

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -524,7 +524,9 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 
 		score.stuffharvested += 1 //One point per product unit
 
-		mysterious_append(product)
+		if(mysterious)
+			product.name += "?"
+			product.desc += " On second thought, something about this one looks strange."
 
 		if(biolum)
 			if(biolum_colour)
@@ -537,11 +539,6 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 
 			product.visible_message("<span class='notice'>The pod disgorges [product]!</span>")
 			handle_living_product(product)
-
-/datum/seed/proc/mysterious_append(atom/product)
-	if(mysterious)
-		product.name += "?"
-		product.desc += " On second thought, something about this one looks strange."
 
 //Harvest without concern for the user
 /datum/seed/proc/autoharvest(var/turf/T, var/yield_mod = 1)

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -83,7 +83,7 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 	mysterious = 1
 
 	seed_noun = pick("spores","nodes","cuttings","seeds")
-	products = list(pick(subtypesof(/obj/item/weapon/reagent_containers/food/snacks/grown)))
+	products = list(pick(subtypesof(/obj/item/weapon/reagent_containers/food/snacks/grown/) - strange_seed_product_blacklist)) //The product can be any subtype of /food/snacks/grown, except those in strange_seed_product_blacklist.
 	potency = rand(5,30)
 
 	randomize_icon()

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -934,7 +934,7 @@ var/list/strange_seed_product_blacklist = list(subtypesof(/obj/item/weapon/reage
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/nofruit/New(atom/loc, custom_plantname, mob/harvester)
 	..()
-	available_fruits = existing_typesof(/obj/item/weapon/reagent_containers/food/snacks/grown) - get_special_fruits()
+	available_fruits = existing_typesof(/obj/item/weapon/reagent_containers/food/snacks/grown) - get_special_fruits() - strange_seed_product_blacklist
 	available_fruits = shuffle(available_fruits)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/nofruit/verb/pick_leaf()

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -1141,8 +1141,7 @@ var/list/special_fruits = list()
 			luckiness = 10000
 	icon = 'icons/obj/hydroponics/clover.dmi'
 	icon_state = "clover[leaves]"
-	if(seed?.mysterious)
-		seed.mysterious_append(src)
+	seed?.mysterious_append(src)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/clover/proc/shift_leaves(var/mut = 0, var/mob/shifter)
 	leaves = 3

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -1140,7 +1140,7 @@ var/list/special_fruits = list()
 			desc = "The fates themselves are said to shower their adoration on the one who bears this legendary lucky charm."
 			luckiness = 10000
 	icon = 'icons/obj/hydroponics/clover.dmi'
-	icon_state = "clover[leaves]
+	icon_state = "clover[leaves]"
 	if(seed?.mysterious)
 		seed.mysterious_append(src)
 

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -1143,7 +1143,6 @@ var/list/strange_seed_product_blacklist = list(subtypesof(/obj/item/weapon/reage
 			luckiness = 10000
 	icon = 'icons/obj/hydroponics/clover.dmi'
 	icon_state = "clover[leaves]"
-	seed?.mysterious_append(src)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/clover/proc/shift_leaves(var/mut = 0, var/mob/shifter)
 	leaves = 3
@@ -1167,6 +1166,6 @@ var/list/strange_seed_product_blacklist = list(subtypesof(/obj/item/weapon/reage
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/clover/initialize(mob/harvester)
 	. = ..()
-	if(isnull(leaves) || seed?.mysterious)
+	if(isnull(leaves))
 		shift_leaves(seed?.potency, harvester)
 	update_leaves()

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -262,7 +262,7 @@ var/list/special_fruits = list()
 	return 1
 
 //Types blacklisted from appearing as products of strange seeds and no-fruit.
-var/list/strange_seed_product_blacklist = list(subtypesof(/obj/item/weapon/reagent_containers/food/snacks/grown/clover/)) //Otherwise the selection would be biased by the relatively large number of multiple leaf-number-specific subtypes - the base type with randomized leaves is still valid.
+var/list/strange_seed_product_blacklist = subtypesof(/obj/item/weapon/reagent_containers/food/snacks/grown/clover/) //Otherwise the selection would be biased by the relatively large number of multiple leaf-number-specific subtypes - the base type with randomized leaves is still valid.
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/corn
 	name = "ear of corn"

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -1133,7 +1133,7 @@ var/list/special_fruits = list()
 			luckiness = 100
 		if(6)
 			name = "six-leaf clover"
-			desc = "A closely-guarded secret of the leperchauns."
+			desc = "A closely-guarded secret of the leprechauns."
 			luckiness = 1000
 		if(7)
 			name = "seven-leaf clover"

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -1133,16 +1133,16 @@ var/list/special_fruits = list()
 			luckiness = 100
 		if(6)
 			name = "six-leaf clover"
-			desc = "A closely-guarded secret of the leprechauns."
+			desc = "A closely-guarded secret of the leperchauns."
 			luckiness = 1000
 		if(7)
 			name = "seven-leaf clover"
 			desc = "The fates themselves are said to shower their adoration on the one who bears this legendary lucky charm."
 			luckiness = 10000
 	icon = 'icons/obj/hydroponics/clover.dmi'
-	icon_state = "clover[leaves]"
+	icon_state = "clover[leaves]
 	if(seed?.mysterious)
-		name += "?"
+		seed.mysterious_append(src)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/clover/proc/shift_leaves(var/mut = 0, var/mob/shifter)
 	leaves = 3

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -262,7 +262,7 @@ var/list/special_fruits = list()
 	return 1
 
 //Types blacklisted from appearing as products of strange seeds.
-var/list/strange_seed_product_blacklist = list(subtypesof(/obj/item/weapon/reagent_containers/food/snacks/grown/clover/)) //Otherwise the selection would be biased by the multiple neaf-number subtypes - the base type is still valid.
+var/list/strange_seed_product_blacklist = list(subtypesof(/obj/item/weapon/reagent_containers/food/snacks/grown/clover/)) //Otherwise the selection would be biased by the relatively large number of multiple leaf-number-specific subtypes - the base type with randomized leaves is still valid.
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/corn
 	name = "ear of corn"

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -261,6 +261,8 @@ var/list/special_fruits = list()
 			spark(M) //Two set of sparks, one before the teleport and one after. //Sure then ?
 	return 1
 
+//Types blacklisted from appearing as products of strange seeds.
+var/list/strange_seed_product_blacklist = list(subtypesof(/obj/item/weapon/reagent_containers/food/snacks/grown/clover/)) //Otherwise the selection would be biased by the multiple neaf-number subtypes - the base type is still valid.
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/corn
 	name = "ear of corn"

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -1141,6 +1141,8 @@ var/list/special_fruits = list()
 			luckiness = 10000
 	icon = 'icons/obj/hydroponics/clover.dmi'
 	icon_state = "clover[leaves]"
+	if(seed?.mysterious)
+		name += "?"
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/clover/proc/shift_leaves(var/mut = 0, var/mob/shifter)
 	leaves = 3
@@ -1164,6 +1166,6 @@ var/list/special_fruits = list()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/clover/initialize(mob/harvester)
 	. = ..()
-	if(isnull(leaves))
+	if(isnull(leaves) || seed?.mysterious)
 		shift_leaves(seed?.potency, harvester)
 	update_leaves()

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -261,7 +261,7 @@ var/list/special_fruits = list()
 			spark(M) //Two set of sparks, one before the teleport and one after. //Sure then ?
 	return 1
 
-//Types blacklisted from appearing as products of strange seeds.
+//Types blacklisted from appearing as products of strange seeds and no-fruit.
 var/list/strange_seed_product_blacklist = list(subtypesof(/obj/item/weapon/reagent_containers/food/snacks/grown/clover/)) //Otherwise the selection would be biased by the relatively large number of multiple leaf-number-specific subtypes - the base type with randomized leaves is still valid.
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/corn


### PR DESCRIPTION
This implements a strange seed product and no-fruit product blacklist, and adds the specific leaf-numbered clover subtypes to it, fixing the following two issues:
- Makes it so clovers generated by strange seeds and no-fruit will have a random number of leaves instead of having the possibility of always being four-leaf, etc.
- Prevents a bias towards clovers in strange seed and no-fruit product selection, based on the relatively large number of subtypes.