### PR TITLE
Fixes trade and wage subsystem runtimes on maps without accounts for either

### DIFF
--- a/code/modules/Economy/Wages.dm
+++ b/code/modules/Economy/Wages.dm
@@ -65,12 +65,18 @@ If all wages are decreased bellow 100%, for example due to the AI spending all t
 	..()
 
 /proc/stationAllowance()//grants the station the allowance it'll need to pay the next salary
+	if(!station_account)
+		message_admins("Station allowance skipped, no station account found.")
+		return
 	station_account.money += station_allowance + WageBonuses()
 
 	new /datum/transaction(station_account,"Nanotrasen station allowance","[station_allowance]","Nanotrasen Payroll Server",send2PDAs=FALSE)
 
 
 /proc/wagePayout()
+	if(!station_account)
+		message_admins("Wage payout skipped, no station account found.")
+		return
 	//adding extra allowance due to latejoiners
 	if (latejoiner_allowance > 0)
 		station_allowance += latejoiner_allowance
@@ -124,7 +130,7 @@ If all wages are decreased bellow 100%, for example due to the AI spending all t
 	var/bonus = 0
 
 	//1000 bonus per prisoner
-	for(var/mob/living/carbon/human/H in current_prisoners) 
+	for(var/mob/living/carbon/human/H in current_prisoners)
 		if(H.z == map.zMainStation && !isspace(get_area(H)) && !H.isDead())
 			bonus += 1000
 

--- a/code/modules/trader/trade_system.dm
+++ b/code/modules/trader/trade_system.dm
@@ -25,12 +25,24 @@ var/datum/subsystem/trade_system/SStrade
 	..()
 
 /datum/subsystem/trade_system/fire(resumed = FALSE)
-	if(prob(FLUX_CHANCE))
-		market_flux()
-	restock_chance()
-	flash_sale()
-	for(var/obj/structure/trade_window/TW in all_twindows)
-		nanomanager.update_uis(TW)
+	if(flags & SS_NO_FIRE)
+		if(trader_account)
+			message_admins("Trade subsystem resumed, trader account found.")
+			flags &= ~SS_NO_FIRE
+			//if(state == SS_PAUSED)
+				//state = SS_RUNNING
+		return
+	if(trader_account)
+		if(prob(FLUX_CHANCE))
+			market_flux()
+		restock_chance()
+		flash_sale()
+		for(var/obj/structure/trade_window/TW in all_twindows)
+			nanomanager.update_uis(TW)
+	else
+		flags |= SS_NO_FIRE
+		//pause()
+		message_admins("Trade subsystem was paused due to lack of a trader account.")
 
 /datum/subsystem/trade_system/proc/market_flux(var/update_windows = TRUE)
 	for(var/datum/trade_product/TP in all_trade_merch)


### PR DESCRIPTION
[bugfix][runtime]

## What this does
Stops null.money runtime spam on small test maps that don't provide either of these.

## Why it's good
Less chat spam during them. (Especially the trade subsystem one)