### PR TITLE
Allows amauri noreact property to interact with xenobotany genes

### DIFF
--- a/code/modules/hydroponics/prehistoric_plants.dm
+++ b/code/modules/hydroponics/prehistoric_plants.dm
@@ -93,6 +93,7 @@
 	plant_dmi = 'icons/obj/hydroponics/amauri.dmi'
 	products = list(/obj/item/weapon/reagent_containers/food/snacks/grown/amauri)
 	mutants = null
+	noreact = 1
 	chems = list(POTASSIUM = list(0,10),SUGAR = list(0,10),PHOSPHORUS = list(0,10))
 
 	lifespan = 25
@@ -115,7 +116,6 @@
 	name = "amauri fruit"
 	desc = "It is small, round and hard. Its skin is a thick dark purple."
 	plantname = "amauri"
-	flags = NOREACT
 	hydroflags = HYDRO_PREHISTORIC
 
 /datum/seed/gelthi

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -56,6 +56,7 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 	var/ligneous = 0				// If 1, requires sharp instrument to harvest. Kudzu with this trait resists sharp items better.
 	var/teleporting = 0				// If 1, causes teleportation when thrown.
 	var/juicy = 0					// 0 = no, 1 = splatters when thrown, 2 = slips
+	var/noreact = 0					// If 1, chems do not react inside the plant.
 
 	// Cosmetics.
 	var/plant_dmi = 'icons/obj/hydroponics/apple.dmi'// DMI  to use for the plant growing in the tray.
@@ -172,6 +173,9 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 		juicy = 2
 	else if(juicy_prob < 10)
 		juicy = 1
+
+	if(prob(5))
+		noreact = 1
 
 	endurance = rand(60,100)
 	yield = rand(2,15)
@@ -309,6 +313,7 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 					stinging 			= max(gene.values[3], stinging)
 					ligneous 			= max(gene.values[4], ligneous)
 					juicy 				= max(gene.values[5], juicy)
+					noreact 			= max(gene.values[6], noreact)
 
 		if(GENE_BIOLUMINESCENCE)
 			switch(mode)
@@ -428,7 +433,8 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 				(thorny           	 	? thorny           		: 0),
 				(stinging            	? stinging            	: 0),
 				(ligneous             	? ligneous            	: 0),
-				(juicy             		? juicy             	: 0)
+				(juicy             		? juicy             	: 0),
+				(noreact             	? noreact             	: 0)
 			)
 		if(GENE_BIOLUMINESCENCE)
 			P.values = list(
@@ -660,6 +666,7 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 	new_seed.ligneous =             ligneous
 	new_seed.teleporting =          teleporting
 	new_seed.juicy =        	    juicy
+	new_seed.noreact =        	    noreact
 	new_seed.plant_icon_state =     plant_icon_state
 	new_seed.splat_type =           splat_type
 	new_seed.packet_icon =          packet_icon

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -46,6 +46,8 @@ var/list/special_fruits = list()
 		potency = round(seed.potency)
 		force = seed.thorny ? 5+seed.carnivorous*3 : 0
 		throwforce = seed.thorny ? 5+seed.carnivorous*3 : 0
+		if(seed.noreact)
+			flags |= NOREACT
 
 		if(seed.teleporting)
 			name = "blue-space [name]"


### PR DESCRIPTION
[content][tested]

## What this does
Takes the NOREACT flag of amauri fruits and makes them a seed datum variable, listed under the morphology category for splicing or purging with other plant genes.

## Why it's good
Should allow some more variety with morphology splicing, such as putting EMPs into amauri fruits without the non-amauris activating it.

## Changelog
:cl:
 * rscadd: The no-reaction hard shells of amauri fruits can now be spliced into other plants via xenobotany.
 * tweak: Amauri fruits now register fingerprints on them.