### PR TITLE
Prevents godmode allowing organ and bone damage

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -169,6 +169,8 @@
 	droplimb(1, spawn_limb = 0, display_message = FALSE)
 
 /datum/organ/external/proc/take_damage(brute, burn, sharp, edge, used_weapon = null, list/forbidden_limbs = list())
+	if(owner && owner.status_flags & GODMODE)
+		return 0	//godmode
 	if((brute <= 0) && (burn <= 0))
 		return 0
 
@@ -957,6 +959,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return rval
 
 /datum/organ/external/proc/fracture()
+	if(owner && owner.status_flags & GODMODE)
+		return 0	//godmode
 	var/datum/species/species = src.species || owner.species
 	if(species.anatomy_flags & NO_BONES)
 		return

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -169,7 +169,7 @@
 	droplimb(1, spawn_limb = 0, display_message = FALSE)
 
 /datum/organ/external/proc/take_damage(brute, burn, sharp, edge, used_weapon = null, list/forbidden_limbs = list())
-	if(owner && owner.status_flags & GODMODE)
+	if(owner?.status_flags & GODMODE)
 		return 0	//godmode
 	if((brute <= 0) && (burn <= 0))
 		return 0
@@ -959,7 +959,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return rval
 
 /datum/organ/external/proc/fracture()
-	if(owner && owner.status_flags & GODMODE)
+	if(owner?.status_flags & GODMODE)
 		return 0	//godmode
 	var/datum/species/species = src.species || owner.species
 	if(species.anatomy_flags & NO_BONES)

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -152,7 +152,7 @@
 /datum/organ/internal/proc/take_damage(amount, var/silent=0)
 	if(!owner)
 		return
-	if(owner && owner.status_flags & GODMODE)
+	if(owner?.status_flags & GODMODE)
 		return 0	//godmode
 	if(src.robotic == 2)
 		src.damage += (amount * 0.8)

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -152,6 +152,8 @@
 /datum/organ/internal/proc/take_damage(amount, var/silent=0)
 	if(!owner)
 		return
+	if(owner && owner.status_flags & GODMODE)
+		return 0	//godmode
 	if(src.robotic == 2)
 		src.damage += (amount * 0.8)
 	else


### PR DESCRIPTION
[tweak][consistency][tested]

## What this does
See title, applies to admin test dummies too, naturally.

## Why it's good
Allows admins and similar people affected by pacid smoke to reliably pick up items and etc.

## Changelog
:cl:
 * tweak: Godmode no longer allows bones or organs to become damaged.