### PR TITLE
Fixes issue with harvesting non-edible plants

### DIFF
--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -517,8 +517,10 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 
 		if(ispath(product_type, /obj/item/stack))
 			product = drop_stack(product_type, T, 1, null)
-		else if(ispath(product_type, /obj/item/weapon/reagent_containers/food/snacks/grown) || ispath(product_type, /obj/item/weapon/grown))
+		else if(ispath(product_type, /obj/item/weapon/reagent_containers/food/snacks/grown))
 			product = new product_type(T, custom_plantname = name, harvester = harvester)
+		else if(ispath(product_type, /obj/item/weapon/grown)
+			product = new product_type(T, custom_plantname = name)
 		else
 			product = new product_type(T)
 

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -519,7 +519,7 @@ var/global/list/gene_tag_masks = list()   // Gene obfuscation for delicious tria
 			product = drop_stack(product_type, T, 1, null)
 		else if(ispath(product_type, /obj/item/weapon/reagent_containers/food/snacks/grown))
 			product = new product_type(T, custom_plantname = name, harvester = harvester)
-		else if(ispath(product_type, /obj/item/weapon/grown)
+		else if(ispath(product_type, /obj/item/weapon/grown))
 			product = new product_type(T, custom_plantname = name)
 		else
 			product = new product_type(T)


### PR DESCRIPTION
This fixes an issue where non-edible plants were being passed `harvester` into `New()` when it was only defined as an arg for edible plants.

Fixes #32714

:cl:
 * bugfix: Fixed non-edible plants not being generated properly.