### PR TITLE
Adds Socket wrench to Prolathe

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -42,13 +42,13 @@
 		new /obj/item/tool/screwdriver(), \
 		new /obj/item/tool/wirecutters(), \
 		new /obj/item/tool/wrench(), \
+		new /obj/item/tool/wrench/socket(), \
 		new /obj/item/tool/solder(),\
 		new /obj/item/tool/wirecutters/clippers(),\
 		new /obj/item/weapon/minihoe(),\
 		new /obj/item/device/analyzer(), \
 		new /obj/item/weapon/pickaxe/shovel/spade(), \
 		new /obj/item/device/silicate_sprayer/empty(), \
-		new /obj/item/tool/wrench/socket(), \
 		),
 		"Containers"=list(
 		new /obj/item/weapon/reagent_containers/glass/beaker(), \

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -48,6 +48,7 @@
 		new /obj/item/device/analyzer(), \
 		new /obj/item/weapon/pickaxe/shovel/spade(), \
 		new /obj/item/device/silicate_sprayer/empty(), \
+		new /obj/item/tool/wrench/socket(), \
 		),
 		"Containers"=list(
 		new /obj/item/weapon/reagent_containers/glass/beaker(), \

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -42,7 +42,6 @@
 		new /obj/item/tool/screwdriver(), \
 		new /obj/item/tool/wirecutters(), \
 		new /obj/item/tool/wrench(), \
-		new /obj/item/tool/wrench/socket(), \
 		new /obj/item/tool/solder(),\
 		new /obj/item/tool/wirecutters/clippers(),\
 		new /obj/item/weapon/minihoe(),\
@@ -148,6 +147,7 @@
 		new /obj/item/weapon/beartrap(),\
 		new /obj/item/gun_part/scope(),\
 		new /obj/item/weapon/grenade/chem_grenade/timer(), \
+		new /obj/item/tool/wrench/socket(), \
 		)
 	)
 

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -147,7 +147,6 @@
 		new /obj/item/weapon/beartrap(),\
 		new /obj/item/gun_part/scope(),\
 		new /obj/item/weapon/grenade/chem_grenade/timer(), \
-		new /obj/item/tool/wrench/socket(), \
 		)
 	)
 

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -82,7 +82,7 @@
 	icon_state = "socket_wrench"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/newsprites_lefthand.dmi', "right_hand" = 'icons/mob/in-hand/right/newsprites_righthand.dmi')
 	w_class = W_CLASS_LARGE //big shit, to balance its power
-	starting_materials = list(MAT_IRON = 3500)
+	starting_materials = list(MAT_IRON = 75000, MAT_GLASS = 30000)
 	force = 15.0
 	throwforce = 12.0
 

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -82,7 +82,7 @@
 	icon_state = "socket_wrench"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/newsprites_lefthand.dmi', "right_hand" = 'icons/mob/in-hand/right/newsprites_righthand.dmi')
 	w_class = W_CLASS_LARGE //big shit, to balance its power
-	starting_materials = list(MAT_IRON = 250)
+	starting_materials = list(MAT_IRON = 3500)
 	force = 15.0
 	throwforce = 12.0
 

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -82,7 +82,7 @@
 	icon_state = "socket_wrench"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/newsprites_lefthand.dmi', "right_hand" = 'icons/mob/in-hand/right/newsprites_righthand.dmi')
 	w_class = W_CLASS_LARGE //big shit, to balance its power
-	starting_materials = list(MAT_IRON = 75000, MAT_GLASS = 30000)
+	starting_materials = list(MAT_IRON = 150)
 	force = 15.0
 	throwforce = 12.0
 

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -82,6 +82,7 @@
 	icon_state = "socket_wrench"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/newsprites_lefthand.dmi', "right_hand" = 'icons/mob/in-hand/right/newsprites_righthand.dmi')
 	w_class = W_CLASS_LARGE //big shit, to balance its power
+	starting_materials = list(MAT_IRON = 250)
 	force = 15.0
 	throwforce = 12.0
 

--- a/code/modules/research/designs/engineering.dm
+++ b/code/modules/research/designs/engineering.dm
@@ -8,6 +8,16 @@
 	build_path = /obj/item/weapon/cell/empty
 	category = "Engineering"
 
+/datum/design/socket_wrench
+	name = "Socket Wrench"
+	desc = "A wrench intended to be wrenchier than other wrenches. It's the wrenchiest."
+	id = "socket_wrench"
+	req_tech = list(Tc_ENGINEERING = 1)
+	build_type = PROTOLATHE
+	materials = list(MAT_IRON = 10000)
+	build_path = /obj/item/tool/wrench/socket
+	category = "Engineering"
+
 /datum/design/high_cell
 	name = "High-Capacity Power Cell"
 	desc = "A power cell that holds 10000 units of energy."


### PR DESCRIPTION
## What this does
Adds Socket Wrench to the Prolathe, requiring engineering 1. The cost is set at 10000 iron.

## Why it's good
Allows you to effectively deal with plasma floods if the original wrenches have been stolen/destroyed. There's no other way to acquire them other than the atmos tech locker.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added Socket Wrench to prolathe

