### PR TITLE
Removing corn oil from deep fryer with beakers

### DIFF
--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -84,6 +84,7 @@ var/global/ingredientLimit = 10
 
 	var/cooks_in_reagents = 0 //are we able to add stuff to the machine so that reagents are added to food?
 	var/cks_max_volume = 50
+	var/can_transfer = FALSE
 
 /obj/machinery/cooking/cultify()
 	new /obj/structure/cult_legacy/talisman(loc)
@@ -307,7 +308,7 @@ var/global/ingredientLimit = 10
 	cookSound = 'sound/machines/juicer.ogg'
 	machine_flags = WRENCHMOVE | FIXED2WORK | SCREWTOGGLE | CROWDESTROY
 
-/obj/machinery/cooking/candy/RefreshParts()						
+/obj/machinery/cooking/candy/RefreshParts()
 	var/T = 0
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
 		T += M.rating-1
@@ -359,7 +360,7 @@ var/global/ingredientLimit = 10
 	icon_state_on = "cereal_on"
 	foodChoices = null
 	machine_flags = WRENCHMOVE | FIXED2WORK | SCREWTOGGLE | CROWDESTROY
-	
+
 /obj/machinery/cooking/cerealmaker/RefreshParts()
 	var/T = 0
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
@@ -376,7 +377,7 @@ var/global/ingredientLimit = 10
 /obj/machinery/cooking/cerealmaker/makeFood()
 	makeCereal()
 
-/obj/machinery/cooking/proc/makeCereal()	
+/obj/machinery/cooking/proc/makeCereal()
 	var/obj/item/weapon/reagent_containers/food/snacks/cereal/C = new(src.loc)
 	for(var/obj/item/embedded in src.ingredient.contents)
 		embedded.forceMove(src.loc)
@@ -416,10 +417,12 @@ var/global/ingredientLimit = 10
 	recursive_ingredients = 1
 	cks_max_volume = 400
 	cooks_in_reagents = 1
+	can_transfer = TRUE
+	var/fry_reagent = CORNOIL
 
 /obj/machinery/cooking/deepfryer/initialize()
 	..()
-	reagents.add_reagent(CORNOIL, 300)
+	reagents.add_reagent(fry_reagent, 300)
 
 /obj/machinery/cooking/deepfryer/proc/empty_icon() //sees if the value is empty, and changes the icon if it is
 	reagents.update_total() //make the values refresh
@@ -524,6 +527,7 @@ var/global/ingredientLimit = 10
 	cks_max_volume = 400
 	cooks_in_reagents = 1
 	machine_flags = WRENCHMOVE | CROWDESTROY | SCREWTOGGLE | FIXED2WORK | SHUTTLEWRENCH
+	fry_reagent = SUGAR
 
 /obj/machinery/cooking/deepfryer/confectionator/New()
 	. = ..()
@@ -545,12 +549,6 @@ var/global/ingredientLimit = 10
 	if((. == "valid") && (!foodNesting))
 		if(findtext(I.name,"sugar"))
 			. = "It's already a sugar copy."
-
-/obj/machinery/cooking/deepfryer/confectionator/initialize()
-	..()
-	reagents.clear_reagents()
-	reagents.add_reagent(SUGAR, 300)
-
 
 /obj/machinery/cooking/deepfryer/confectionator/empty_icon() //sees if the value is empty, and changes the icon if it is
 	reagents.update_total() //make the values refresh

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -84,7 +84,6 @@ var/global/ingredientLimit = 10
 
 	var/cooks_in_reagents = 0 //are we able to add stuff to the machine so that reagents are added to food?
 	var/cks_max_volume = 50
-	var/can_transfer = FALSE
 
 /obj/machinery/cooking/cultify()
 	new /obj/structure/cult_legacy/talisman(loc)
@@ -417,7 +416,6 @@ var/global/ingredientLimit = 10
 	recursive_ingredients = 1
 	cks_max_volume = 400
 	cooks_in_reagents = 1
-	can_transfer = TRUE
 	var/fry_reagent = CORNOIL
 
 /obj/machinery/cooking/deepfryer/initialize()

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -244,12 +244,10 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 					to_chat(user, "<span class='notice'>You fill \the [src][src.is_full() ? " to the brim" : ""] with [tx_amount] units of the contents of \the [target].</span>")
 				return tx_amount
 		if(reagents && reagents.is_empty() && istype(target, /obj/machinery/cooking))
-			var/obj/machinery/cooking/C = target
-			if(C.can_transfer)
-				var/tx_amount = transfer_sub(target, src, reagents.maximum_volume, user)
-				if (tx_amount > 0)
-					to_chat(user, "<span class='notice'>You fill \the [src] to the brim with [tx_amount] units of the contents of \the [target].</span>")
-				return tx_amount
+			var/tx_amount = transfer_sub(target, src, reagents.maximum_volume, user)
+			if (tx_amount > 0)
+				to_chat(user, "<span class='notice'>You fill \the [src] to the brim with [tx_amount] units of the contents of \the [target].</span>")
+			return tx_amount
 	// Transfer to container
 	if (can_send /*&& target.reagents**/)
 		var/obj/container = target

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -243,7 +243,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 				if (tx_amount > 0)
 					to_chat(user, "<span class='notice'>You fill \the [src][src.is_full() ? " to the brim" : ""] with [tx_amount] units of the contents of \the [target].</span>")
 				return tx_amount
-		if(reagents && reagents.is_empty() && istype(target, /obj/machinery/cooking))
+		if(reagents && reagents.is_empty() && istype(target, /obj/machinery/cooking/deepfryer))
 			var/tx_amount = transfer_sub(target, src, reagents.maximum_volume, user)
 			if (tx_amount > 0)
 				to_chat(user, "<span class='notice'>You fill \the [src] to the brim with [tx_amount] units of the contents of \the [target].</span>")

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -234,14 +234,22 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 		return -1
 
 	var/success
-	// Transfer from dispenser
-	if (can_receive && istype(target, /obj/structure/reagent_dispensers))
-		var/obj/structure/reagent_dispensers/S = target
-		if(S.can_transfer(src, user))
-			var/tx_amount = transfer_sub(target, src, S.amount_per_transfer_from_this, user)
-			if (tx_amount > 0)
-				to_chat(user, "<span class='notice'>You fill \the [src][src.is_full() ? " to the brim" : ""] with [tx_amount] units of the contents of \the [target].</span>")
-			return tx_amount
+	// Transfer from dispenser or cooking machine
+	if (can_receive)
+		if(istype(target, /obj/structure/reagent_dispensers))
+			var/obj/structure/reagent_dispensers/S = target
+			if(S.can_transfer(src, user))
+				var/tx_amount = transfer_sub(target, src, S.amount_per_transfer_from_this, user)
+				if (tx_amount > 0)
+					to_chat(user, "<span class='notice'>You fill \the [src][src.is_full() ? " to the brim" : ""] with [tx_amount] units of the contents of \the [target].</span>")
+				return tx_amount
+		if(reagents && reagents.is_empty() && istype(target, /obj/machinery/cooking))
+			var/obj/machinery/cooking/C = target
+			if(C.can_transfer)
+				var/tx_amount = transfer_sub(target, src, reagents.maximum_volume, user)
+				if (tx_amount > 0)
+					to_chat(user, "<span class='notice'>You fill \the [src] to the brim with [tx_amount] units of the contents of \the [target].</span>")
+				return tx_amount
 	// Transfer to container
 	if (can_send /*&& target.reagents**/)
 		var/obj/container = target

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -246,7 +246,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 		if(reagents && reagents.is_empty() && istype(target, /obj/machinery/cooking/deepfryer))
 			var/tx_amount = transfer_sub(target, src, reagents.maximum_volume, user)
 			if (tx_amount > 0)
-				to_chat(user, "<span class='notice'>You fill \the [src] to the brim with [tx_amount] units of the contents of \the [target].</span>")
+				to_chat(user, "<span class='notice'>You fill \the [src][src.is_full() ? " to the brim" : ""] with [tx_amount] units of the contents of \the [target].</span>")
 			return tx_amount
 	// Transfer to container
 	if (can_send /*&& target.reagents**/)


### PR DESCRIPTION
[tweak][tested]

## What this does
Allows scooping up corn oil from deep fryers and similar machinery, current code only allows filling with reagents.

## Why it's good
Source of corn oil, consistency.

## Changelog
:cl:
 * rscadd: Corn oil and similar reagents can now be scooped up with a beaker from deep fryers.