### PR TITLE
Refactors Reagent Nutrition, Bugfixes (buffs) Dan Snacks and Condiments

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -206,6 +206,10 @@
 	if(tolerance_increase)
 		M.tolerated_chems[src.id] += tolerance_increase
 
+	M.nutrition += nutriment_factor	//Centralized nutritional values
+	if(M.nutrition < 0) //Prevent from going into negatives
+		M.nutrition = 0
+
 /datum/reagent/proc/is_overdosing() //Too much chems, or been in your system too long
 	return (overdose_am && volume >= overdose_am) || (overdose_tick && tick >= overdose_tick)
 
@@ -1590,15 +1594,10 @@
 	description = "The organic compound commonly known as table sugar and sometimes called saccharose. This white, odorless, crystalline powder has a pleasing, sweet taste."
 	reagent_state = REAGENT_STATE_SOLID
 	color = "#FFFFFF" //rgb: 255, 255, 255
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 	sport = SPORTINESS_SUGAR
 	density = 1.59
 	specheatcap = 1.244
-
-/datum/reagent/sugar/on_mob_life(var/mob/living/M)
-	if(..())
-		return 1
-
-	M.nutrition += REM
 
 /datum/reagent/sugar/on_plant_life(var/obj/machinery/portable_atmospherics/hydroponics/T)
 	..()
@@ -1617,15 +1616,9 @@
 	description = "Created from the removal of water from sugar."
 	reagent_state = REAGENT_STATE_SOLID
 	color = "#844b06" //rgb: 132, 75, 6
+	nutriment_factor = 5 * REAGENTS_METABOLISM
 	specheatcap = 1.244
 	density = 1.59
-
-/datum/reagent/caramel/on_mob_life(var/mob/living/M)
-
-	if(..())
-		return 1
-
-	M.nutrition += (2 * REM)
 
 /datum/reagent/honey
 	name = "Honey"
@@ -1643,7 +1636,6 @@
 		var/mob/living/carbon/human/H = M
 		if(!holder)
 			return
-		H.nutrition += nutriment_factor
 		if(H.getBruteLoss() && prob(60))
 			H.heal_organ_damage(quality, 0)
 		if(H.getFireLoss() && prob(50))
@@ -2123,17 +2115,10 @@
 	id = VIRUSFOOD
 	description = "A mixture of water, milk, and oxygen. Virus cells can use this mixture to reproduce."
 	reagent_state = REAGENT_STATE_LIQUID
-	nutriment_factor = 2 * REAGENTS_METABOLISM
+	nutriment_factor = 1 * REAGENTS_METABOLISM
 	color = "#899613" //rgb: 137, 150, 19
 	density = 0.67
 	specheatcap = 4.18
-
-/datum/reagent/virus_food/on_mob_life(var/mob/living/M)
-
-	if(..())
-		return 1
-
-	M.nutrition += nutriment_factor*REM
 
 /datum/reagent/sterilizine
 	name = "Sterilizine"
@@ -3698,7 +3683,6 @@ var/procizine_tolerance = 0
 
 	..()
 
-	M.nutrition += nutriment_factor
 	if(M.bodytemperature < 310) //310 is the normal bodytemp. 310.055
 		M.bodytemperature = min(310, M.bodytemperature + (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 
@@ -4426,8 +4410,6 @@ var/procizine_tolerance = 0
 	if(prob(50))
 		M.heal_organ_damage(1, 0)
 
-	M.nutrition += nutriment_factor	//For hunger and fatness
-
 /datum/reagent/nutriment/on_plant_life(obj/machinery/portable_atmospherics/hydroponics/T)
 	..()
 	T.adjust_nutrient(1)
@@ -4440,7 +4422,7 @@ var/procizine_tolerance = 0
 	id = LIPOZINE
 	description = "A chemical compound that causes a powerful fat-burning reaction."
 	reagent_state = REAGENT_STATE_LIQUID
-	nutriment_factor = 10 * REAGENTS_METABOLISM
+	nutriment_factor = -10 * REAGENTS_METABOLISM
 	color = "#BBEDA4" //rgb: 187, 237, 164
 	density = 2.63
 	specheatcap = 381.13
@@ -4450,10 +4432,7 @@ var/procizine_tolerance = 0
 	if(..())
 		return 1
 
-	M.nutrition -= nutriment_factor
 	M.overeatduration = 0
-	if(M.nutrition < 0) //Prevent from going into negatives
-		M.nutrition = 0
 
 /datum/reagent/dietine
 	name = "Dietine"
@@ -4703,7 +4682,7 @@ var/procizine_tolerance = 0
 	name = "Gator Mix"
 	id = GATORMIX
 	description = "A vile sludge of mixed carbohydrates. Makes people more alert. May cause kidney damage in large doses."
-	nutriment_factor = 8 * REAGENTS_METABOLISM //get fat, son
+	nutriment_factor = 4 * REAGENTS_METABOLISM //get fat, son
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#A41D77"
 	adj_dizzy = -5
@@ -5115,19 +5094,12 @@ var/procizine_tolerance = 0
 	nutriment_factor = 5 * REAGENTS_METABOLISM
 	color = "#302000" //rgb: 48, 32, 0
 
-/datum/reagent/coco/on_mob_life(var/mob/living/M)
-
-	if(..())
-		return 1
-
-	M.nutrition += nutriment_factor
-
 /datum/reagent/drink/hot_coco
 	name = "Hot Chocolate"
 	id = HOT_COCO
 	description = "Made with love! And cocoa beans."
 	reagent_state = REAGENT_STATE_LIQUID
-	nutriment_factor = 2 * FOOD_METABOLISM
+	nutriment_factor = 6 * REAGENTS_METABOLISM
 	color = "#403010" //rgb: 64, 48, 16
 	adj_temp = 5
 	density = 1.2
@@ -5140,8 +5112,6 @@ var/procizine_tolerance = 0
 
 	if(M.bodytemperature < 310) //310 is the normal bodytemp. 310.055
 		M.bodytemperature = min(310, M.bodytemperature + (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
-
-	M.nutrition += nutriment_factor
 
 /datum/reagent/drink/hot_coco/subhuman
 	id = HOT_COCO_SUBHUMAN
@@ -5157,7 +5127,7 @@ var/procizine_tolerance = 0
 	id = CREAMY_HOT_COCO
 	description = "Never ever let it cool."
 	reagent_state = REAGENT_STATE_LIQUID
-	nutriment_factor = 2 * FOOD_METABOLISM
+	nutriment_factor = 2 * REAGENTS_METABOLISM
 	color = "#403010" //rgb: 64, 48, 16
 	glass_icon_state = "creamyhotchocolate"
 	glass_name = "\improper Creamy Hot Chocolate"
@@ -5270,7 +5240,7 @@ var/procizine_tolerance = 0
 	name = "Sprinkles"
 	id = SPRINKLES
 	description = "Multi-colored little bits of sugar, commonly found on donuts. Loved by cops."
-	nutriment_factor = REAGENTS_METABOLISM
+	nutriment_factor = 0.5 * REAGENTS_METABOLISM
 	color = "#FF00FF" //rgb: 255, 0, 255
 	density = 1.59
 	specheatcap = 1.24
@@ -5280,12 +5250,11 @@ var/procizine_tolerance = 0
 	if(..())
 		return 1
 
-	M.nutrition += REM * nutriment_factor
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.job in list("Security Officer", "Head of Security", "Detective", "Warden"))
 			H.heal_organ_damage(1, 1)
-			H.nutrition += REM * nutriment_factor //Double nutrition
+			H.nutrition += nutriment_factor //Double nutrition
 
 /*
 //Removed because of meta bullshit. this is why we can't have nice things.
@@ -5321,8 +5290,6 @@ var/procizine_tolerance = 0
 
 	if(..())
 		return 1
-
-	M.nutrition += nutriment_factor
 
 //Now handle corn oil interactions
 	if(!has_had_heart_explode && ishuman(M))
@@ -5385,8 +5352,6 @@ var/procizine_tolerance = 0
 	if(..())
 		return 1
 
-	M.nutrition += nutriment_factor
-
 /datum/reagent/hot_ramen
 	name = "Hot Ramen"
 	id = HOT_RAMEN
@@ -5402,7 +5367,6 @@ var/procizine_tolerance = 0
 	if(..())
 		return 1
 
-	M.nutrition += nutriment_factor
 	if(M.bodytemperature < 310) //310 is the normal bodytemp. 310.055
 		M.bodytemperature = min(310, M.bodytemperature + (10 * TEMPERATURE_DAMAGE_COEFFICIENT))
 
@@ -5421,7 +5385,6 @@ var/procizine_tolerance = 0
 	if(..())
 		return 1
 
-	M.nutrition += nutriment_factor
 	M.bodytemperature += 10 * TEMPERATURE_DAMAGE_COEFFICIENT
 
 /datum/reagent/flour
@@ -5436,7 +5399,6 @@ var/procizine_tolerance = 0
 
 	if(..())
 		return 1
-	M.nutrition += nutriment_factor
 
 /datum/reagent/flour/reaction_turf(var/turf/simulated/T, var/volume)
 
@@ -5469,7 +5431,6 @@ var/procizine_tolerance = 0
 
 	if(..())
 		return 1
-	M.nutrition += nutriment_factor
 
 /datum/reagent/pancake_mix/reaction_turf(var/turf/simulated/T, var/volume)
 
@@ -5493,8 +5454,6 @@ var/procizine_tolerance = 0
 	if(..())
 		return 1
 
-	M.nutrition += nutriment_factor
-
 /datum/reagent/cherryjelly
 	name = "Cherry Jelly"
 	id = CHERRYJELLY
@@ -5507,8 +5466,6 @@ var/procizine_tolerance = 0
 
 	if(..())
 		return 1
-
-	M.nutrition += nutriment_factor
 
 /datum/reagent/discount
 	name = "Discount Dan's Special Sauce"
@@ -5652,7 +5609,7 @@ var/procizine_tolerance = 0
 	description = "American Cheese."
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#6F884F" //rgb: 255,255,255 //to-do
-	nutriment_factor = REAGENTS_METABOLISM
+	nutriment_factor = 1 * REAGENTS_METABOLISM
 
 /datum/reagent/bonemarrow
 	name = "Bone Marrow"
@@ -5660,7 +5617,7 @@ var/procizine_tolerance = 0
 	description = "Looks like a skeleton got stuck in the production line."
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#6F884F" //rgb: 255,255,255 //to-do
-	nutriment_factor = REAGENTS_METABOLISM
+	nutriment_factor = 1 * REAGENTS_METABOLISM
 
 /datum/reagent/greenramen
 	name = "Greenish Ramen Noodles"
@@ -5747,6 +5704,8 @@ var/procizine_tolerance = 0
 	id = CAFFEINE
 	description = "Caffeine is a common stimulant. It works by making your metabolism faster so it also increases your appetite."
 	color = "#E8E8E8" //rgb: 232, 232, 232
+	// it also makes you hungry because it speeds up your metabolism
+	nutriment_factor = -5 * REAGENTS_METABOLISM
 	density = 1.23
 	specheatcap = 0.89
 	custom_metabolism = 0.1
@@ -5756,14 +5715,12 @@ var/procizine_tolerance = 0
 		return 1
 	// you just ingested pure caffeine so you're gonna get the BIG shakes
 	M.Jitter(10)
-	// it also makes you hungry because it speeds up your metabolism
-	M.nutrition--
 
 /datum/reagent/tendies
 	name = "Tendies"
 	id = TENDIES
 	description = "Gimme gimme chicken tendies, be they crispy or from Wendys."
-	nutriment_factor = REAGENTS_METABOLISM
+	nutriment_factor = 0.5 * REAGENTS_METABOLISM
 	color = "#AB6F0E" //rgb: 171, 111, 14
 	density = 5
 	specheatcap = 1
@@ -5773,12 +5730,11 @@ var/procizine_tolerance = 0
 	if(..())
 		return 1
 
-	M.nutrition += REM * nutriment_factor
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.mind.assigned_role == "Janitor")
 			H.heal_organ_damage(1, 1)
-			H.nutrition += REM * nutriment_factor //Double nutrition
+			H.nutrition += nutriment_factor //Double nutrition
 
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -5790,7 +5746,7 @@ var/procizine_tolerance = 0
 	id = DRINK
 	description = "Uh, some kind of drink."
 	reagent_state = REAGENT_STATE_LIQUID
-	nutriment_factor = REAGENTS_METABOLISM
+	nutriment_factor = 0.5 * REAGENTS_METABOLISM
 	color = "#E78108" //rgb: 231, 129, 8
 	custom_metabolism = FOOD_METABOLISM
 	var/adj_dizzy = 0
@@ -5802,8 +5758,6 @@ var/procizine_tolerance = 0
 
 	if(..())
 		return 1
-
-	M.nutrition += nutriment_factor * REM
 
 	if(adj_dizzy)
 		M.dizziness = max(0,M.dizziness + adj_dizzy)
@@ -5821,7 +5775,7 @@ var/procizine_tolerance = 0
 	id = ORANGEJUICE
 	description = "Both delicious AND rich in Vitamin C. What more do you need?"
 	color = "#E78108" //rgb: 231, 129, 8
-	nutriment_factor = 5 * REAGENTS_METABOLISM
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 	glass_desc = "Vitamins! Yay!"
 
 /datum/reagent/drink/orangejuice/on_mob_life(var/mob/living/M)
@@ -5837,7 +5791,7 @@ var/procizine_tolerance = 0
 	id = OPOKJUICE
 	description = "A fruit from the mothership pulped into bitter juice, with a very slight undertone of sweetness."
 	color = "#FF9191" //rgb: 255, 145, 145
-	nutriment_factor = 5 * REAGENTS_METABOLISM
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 	glass_desc = "Vitamins from the mothership!"
 
 /datum/reagent/drink/opokjuice/on_mob_life(var/mob/living/M)
@@ -5853,7 +5807,7 @@ var/procizine_tolerance = 0
 	id = TOMATOJUICE
 	description = "Tomatoes made into juice. What a waste of good tomatoes, huh?"
 	color = "#731008" //rgb: 115, 16, 8
-	nutriment_factor = 5 * REAGENTS_METABOLISM
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 	glass_desc = "Are you sure this is tomato juice?"
 	mug_desc = "Are you sure this is tomato juice?"
 
@@ -5871,7 +5825,7 @@ var/procizine_tolerance = 0
 	description = "The sweet-sour juice of limes."
 	color = "#99bb43" //rgb: 153, 187, 67
 	alpha = 170
-	nutriment_factor = 5 * REAGENTS_METABOLISM
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 	glass_desc = "A glass of sweet-sour lime juice."
 
 /datum/reagent/drink/limejuice/on_mob_life(var/mob/living/M)
@@ -5887,7 +5841,7 @@ var/procizine_tolerance = 0
 	id = CARROTJUICE
 	description = "It's like a carrot, but less crunchy."
 	color = "#FF8820" //rgb: 255, 136, 32
-	nutriment_factor = 5 * REAGENTS_METABOLISM
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 	glass_desc = "It's like a carrot, but less crunchy."
 
 /datum/reagent/drink/carrotjuice/on_mob_life(var/mob/living/M)
@@ -5907,21 +5861,21 @@ var/procizine_tolerance = 0
 	id = GRAPEJUICE
 	description = "Freshly squeezed juice from red grapes. Quite sweet."
 	color = "#512284" //rgb: 81, 34, 132
-	nutriment_factor = 5 * REAGENTS_METABOLISM
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 
 /datum/reagent/drink/ggrapejuice
 	name = "Green Grape Juice"
 	id = GGRAPEJUICE
 	description = "Freshly squeezed juice from green grapes. Smoothly sweet."
 	color = "#B79E42" //rgb: 183, 158, 66
-	nutriment_factor = 5 * REAGENTS_METABOLISM
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 
 /datum/reagent/drink/berryjuice
 	name = "Berry Juice"
 	id = BERRYJUICE
 	description = "A delicious blend of several different kinds of berries."
 	color = "#660099" //rgb: 102, 0, 153
-	nutriment_factor = 5 * REAGENTS_METABOLISM
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 	glass_desc = "Berry juice. Or maybe it's jam. Who cares?"
 
 /datum/reagent/drink/poisonberryjuice
@@ -5944,7 +5898,7 @@ var/procizine_tolerance = 0
 	description = "The delicious juice of a watermelon."
 	color = "#EF3520" //rgb: 239, 53, 32
 	alpha = 240
-	nutriment_factor = 5 * REAGENTS_METABOLISM
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 
 /datum/reagent/drink/applejuice
 	name = "Apple Juice"
@@ -5952,7 +5906,7 @@ var/procizine_tolerance = 0
 	description = "Tastes of New York."
 	color = "#FDAD01" //rgb: 253, 173, 1
 	alpha = 150
-	nutriment_factor = 5 * REAGENTS_METABOLISM
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 
 /datum/reagent/drink/lemonjuice
 	name = "Lemon Juice"
@@ -5960,7 +5914,7 @@ var/procizine_tolerance = 0
 	description = "This juice is VERY sour."
 	color = "#fff690" //rgb: 255, 246, 144
 	alpha = 170
-	nutriment_factor = 5 * REAGENTS_METABOLISM
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 	glass_desc = "Sour..."
 
 /datum/reagent/drink/banana
@@ -5969,7 +5923,7 @@ var/procizine_tolerance = 0
 	description = "The raw essence of a banana. HONK"
 	color = "#FFE777" //rgb: 255, 230, 119
 	alpha = 255
-	nutriment_factor = 5 * REAGENTS_METABOLISM
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 
 /datum/reagent/drink/nothing
 	name = "Nothing"
@@ -5997,14 +5951,14 @@ var/procizine_tolerance = 0
 	name = "Potato Juice"
 	id = POTATO
 	description = "Juice of the potato. Bleh."
-	nutriment_factor = 5 * FOOD_METABOLISM
+	nutriment_factor = 5 * REAGENTS_METABOLISM
 	color = "#302000" //rgb: 48, 32, 0
 
 /datum/reagent/drink/plumphjuice
 	name = "Plump Helmet Juice"
 	id = PLUMPHJUICE
 	description = "Eeeewwwww."
-	nutriment_factor = 5 * FOOD_METABOLISM
+	nutriment_factor = 5 * REAGENTS_METABOLISM
 	color = "#A28691" //rgb: 162, 134, 145
 	glass_name = "glass of plump helmet wine"
 	glass_desc = "An absolute staple to get through a day's work."
@@ -6016,7 +5970,7 @@ var/procizine_tolerance = 0
 	description = "An opaque white liquid produced by the mammary glands of mammals."
 	color = "#DFDFDF" //rgb: 223, 223, 223
 	alpha = 240
-	nutriment_factor = 5 * REAGENTS_METABOLISM
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 	glass_desc = "White and nutritious goodness!"
 
 /datum/reagent/drink/milk/on_mob_life(var/mob/living/M)
@@ -6044,7 +5998,7 @@ var/procizine_tolerance = 0
 	id = MOMMIMILK
 	description = "Milk from a MoMMI, but how is it produced?"
 	color = "#eaeaea" //rgb(234, 234, 234)
-	nutriment_factor = 5 * REAGENTS_METABOLISM
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 	glass_desc = "Artificially white nutrition!"
 
 
@@ -6063,7 +6017,7 @@ var/procizine_tolerance = 0
 	id = SOYMILK
 	description = "An opaque white liquid made from soybeans."
 	color = "#e8e8d8" //rgb: 232, 232, 216
-	nutriment_factor = 5 * REAGENTS_METABOLISM
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 	glass_desc = "White and nutritious soy goodness!"
 
 /datum/reagent/drink/milk/cream
@@ -6071,7 +6025,7 @@ var/procizine_tolerance = 0
 	id = CREAM
 	description = "The fatty, still liquid part of milk. Why don't you mix this with sum scotch, eh?"
 	color = "#DFD7AF" //rgb: 223, 215, 175
-	nutriment_factor = 5 * REAGENTS_METABOLISM
+	nutriment_factor = 2.5 * REAGENTS_METABOLISM
 	density = 2.37
 	specheatcap = 1.38
 	glass_desc = "Like milk, but thicker."
@@ -6491,8 +6445,6 @@ var/procizine_tolerance = 0
 	//Sober block makes it more difficult to get drunk
 	var/sober_str =! (M_SOBER in M.mutations) ? 1 : 2
 
-	M.nutrition += REM*nutriment_factor
-
 	tick /= sober_str
 
 	//Make all the ethanol-based beverages work together
@@ -6550,7 +6502,7 @@ var/procizine_tolerance = 0
 	name = "Beer"
 	id = BEER
 	description = "An alcoholic beverage made from malted grains, hops, yeast, and water."
-	nutriment_factor = 2 * FOOD_METABOLISM
+	nutriment_factor = 2 * REAGENTS_METABOLISM
 	color = "#664300" //rgb: 102, 67, 0
 	glass_icon_state = "beerglass"
 	glass_desc = "A cold pint of pale lager."
@@ -7170,7 +7122,7 @@ var/procizine_tolerance = 0
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.mind.GetRole(NINJA))
-			M.nutrition += nutriment_factor
+			M.nutrition += nutriment_factor //double of nothing is still... nothing. Change in future PR.
 			if(M.getOxyLoss() && prob(50))
 				M.adjustOxyLoss(-2)
 			if(M.getBruteLoss() && prob(60))
@@ -7303,7 +7255,6 @@ var/procizine_tolerance = 0
 	if(..())
 		return 1
 
-	M.nutrition += nutriment_factor
 	M.drowsyness = max(0, M.drowsyness - 7)
 	M.Jitter(1)
 
@@ -7519,7 +7470,7 @@ var/procizine_tolerance = 0
 	id = DOCTORSDELIGHT
 	description = "A gulp a day keeps the MediBot away. That's what they say, at least."
 	reagent_state = REAGENT_STATE_LIQUID
-	nutriment_factor = FOOD_METABOLISM
+	nutriment_factor = 3 * REAGENTS_METABOLISM
 	color = "#BA7DBA" //rgb: 73, 49, 73
 	glass_icon_state = "doctorsdelightglass"
 	glass_name = "\improper Doctor's Delight"
@@ -7530,7 +7481,6 @@ var/procizine_tolerance = 0
 	if(..())
 		return 1
 
-	M.nutrition += nutriment_factor
 	if(M.getOxyLoss())
 		M.adjustOxyLoss(-2)
 	if(M.getBruteLoss())
@@ -8149,7 +8099,7 @@ var/procizine_tolerance = 0
 	name = "Banana Honk"
 	id = BANANAHONK
 	description = "A non-alcoholic drink of banana juice, milk cream and sugar."
-	nutriment_factor = FOOD_METABOLISM
+	nutriment_factor = 1 * REAGENTS_METABOLISM
 	color = "#664300" //rgb: 102, 67, 0
 	glass_icon_state = "bananahonkglass"
 	glass_name = "\improper Banana Honk"
@@ -8159,7 +8109,7 @@ var/procizine_tolerance = 0
 	name = "Silencer"
 	id = SILENCER
 	description = "Some say this is the diluted blood of the mime."
-	nutriment_factor = FOOD_METABOLISM
+	nutriment_factor = 1 * REAGENTS_METABOLISM
 	color = "#664300" //rgb: 102, 67, 0
 	glass_icon_state = "silencerglass"
 	glass_name = "\improper Silencer"
@@ -8242,7 +8192,7 @@ var/procizine_tolerance = 0
 	name = "Driest Martini"
 	id = DRIESTMARTINI
 	description = "Only for the experienced. You think you see sand floating in the glass."
-	nutriment_factor = FOOD_METABOLISM
+	nutriment_factor = 1 * REAGENTS_METABOLISM
 	color = "#2E6671" //rgb: 46, 102, 113
 	glass_icon_state = "driestmartiniglass"
 	glass_name = "\improper Driest Martini"
@@ -8589,7 +8539,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 /datum/reagent/drink/coffee/tonio
 	name = "Tonio"
 	id = TONIO
-	nutriment_factor = FOOD_METABOLISM
+	nutriment_factor = 3 * REAGENTS_METABOLISM
 	description = "This coffee seems uncannily good."
 	mug_icon_state = "tonio"
 	mug_name = "\improper Tonio"
@@ -8610,7 +8560,6 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 		holder.remove_reagent(reagent.id, 3 * REM)
 
 	M.adjustToxLoss(-2 * REM)
-	M.nutrition += nutriment_factor
 
 	if(M.getBruteLoss() && prob(20))
 		M.heal_organ_damage(1, 0)
@@ -8639,7 +8588,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	name = "Passione"
 	id = PASSIONE
 	description = "Rejuvenating!"
-	nutriment_factor = 3 * REAGENTS_METABOLISM //because honey
+	nutriment_factor = 4.5 * REAGENTS_METABOLISM //because honey
 	mug_icon_state = "passione"
 	mug_name = "\improper Passione"
 	mug_desc = "Sometimes referred to as a 'Vento Aureo'."
@@ -8652,7 +8601,6 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 		if(!holder)
 			return
 		H.sleeping = 0
-		H.nutrition += nutriment_factor //honey doing it's work
 		if(H.getBruteLoss() && prob(60))
 			H.heal_organ_damage(1, 0)
 		if(H.getFireLoss() && prob(50))
@@ -8679,6 +8627,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	name = "Lifeline"
 	id = MEDCOFFEE
 	description = "Tastes like it's got iron in it or something."
+	nutriment_factor = 1.5 * REAGENTS_METABOLISM //because medical healing?
 	mug_icon_state = "medcoffee"
 	mug_name = "\improper Lifeline"
 	mug_desc = "Some days, the only thing that keeps you going is cryo and caffeine."
@@ -8688,7 +8637,6 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	if(..())
 		return 1
 
-	M.nutrition += nutriment_factor
 	if(M.getOxyLoss() && prob(25))
 		M.adjustOxyLoss(-1)
 	if(M.getBruteLoss() && prob(30))
@@ -8870,7 +8818,6 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	if(..())
 		return 1
 
-	M.nutrition += nutriment_factor
 	M.adjustOxyLoss(-2 * REM)
 	M.adjustToxLoss(-2 * REM)
 	M.adjustBruteLoss(-3 * REM)
@@ -9289,10 +9236,6 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	if(holder.has_reagent(LIPOZINE))
 		holder.remove_reagent(LIPOZINE, 50)
 
-	M.nutrition += nutriment_factor
-
-
-
 /datum/reagent/saltwater
 	name = "Salt Water"
 	id = SALTWATER
@@ -9561,7 +9504,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	description = "The mistaken byproduct of confectionery science. Targets the beta pancreatic cells, or equivalent, in carbon based life to not only cease insulin production but begin producing what medical science can only describe as 'the concept of obesity given tangible form'."
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#FFFFFF" //rgb: 255, 255, 255
-	nutriment_factor = 45 * REAGENTS_METABOLISM //This is maybe a little much
+	nutriment_factor = 0 //Custom nutrition effect on_mob_life, scales on volume
 	sport = 0 //This will never come up but adding it made me smile
 	density = 3 //He DENSE
 	specheatcap = 0.55536
@@ -9587,7 +9530,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 		else
 			playsound(H, pick(chubbysound), 100, 1)
 			H.overeatduration += 10 * volume
-			H.nutrition += 10 * volume
+			H.nutrition += 10 * volume //to compare, the holy liquid butter would be 5 here
 		if(H.nutrition > 750)
 			if(prob(volume) && heart && !heart.robotic)
 				to_chat(H, "<span class='danger'>Your heart just can't take it anymore!</span>")
@@ -9761,6 +9704,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	name = "Hyperactivity Incense"
 	id = INCENSE_NOVAFLOWERS
 	description = "This fragrance helps you focus and pull into your energy reserves to move quickly."
+	nutriment_factor = -5 * REAGENTS_METABOLISM
 	custom_metabolism = 0.15
 
 /datum/reagent/incense/novaflowers/on_mob_life(var/mob/living/M)
@@ -9768,7 +9712,6 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 		return 1
 	if(holder.get_reagent_amount(HYPERZINE) < 2)
 		holder.add_reagent(HYPERZINE, 0.5)
-	M.nutrition--
 
 /datum/reagent/incense/banana
 	name = "Banana Incense"


### PR DESCRIPTION
# But why though?
![image](https://user-images.githubusercontent.com/69739118/171978533-22f75849-6fa4-439a-ac64-fad85f475dd6.png)
(picture: theoretical beff dispenser)
### **Beff**.
A mysterious meat that literally does nothing. Until it did something in #29814... Except it never actually worked. Testing revealed that consuming vast quantities of beff did nothing. You gained no nutrition and could not get fat, even if you drank an entire cauldron of the stuff. But why? Then I opened the code.

Oh lord.

Many hours later... 

## What this does
### Code readability:
This PR refactors the nutrition code for our reagent system. This makes new chemicals easier to write in, modify, and directly compare. It also buffs certain chemicals that had a ``nutriment_factor`` that was otherwise unused.

Old system:
- A ``nutriment_factor`` didn't mean that a chemical gave nutrition. Only ``/drink/`` and ``/ethanol/`` reagents did by default (at half value). Every other chem had to have an individual ``on_mob_life()`` proc added, which lead to oversights.
- Most chemicals that worked from ``on_mob_life()`` gave either ``+= nutriment_factor`` OR ``+= nutriment_factor * REM`` at random, further increasing comparison difficulty.

New system:
- See a ``nutriment_factor``? You are done. It adds that value to a mob's nutrition each tick. Some special cases exist (such as sprinkles and tendies), but not a lot.

### Buffs the following chemicals:
These are the chemicals that had a ``nutriment_factor`` but did not use it before this PR. The visual value field is used to compare to Nutriment's 15 (per 10 seconds) in terms of how much nutrition it provides. These are values that were already implemented in the code but didn't actually do anything because nutrition had to be coded per-chem.

![image](https://user-images.githubusercontent.com/69739118/171980666-4ee8fbbe-e240-467a-9e25-e34f6cf31ff1.png)

```egg yolk, gravy, polypgelatin, spaghetti, zamspicytoxin, cinnamon, ketchup, discount dan sauce, mayo, relish, zammild, dipping_sauce, horsemeat, mustard, mustard_powder, beff, deepfriedramen, glowingramen, greenramen, soysauce, bonemarrow, irradiatedbeans, mutatedbeans, offcolorcheese, refriedbeans, zamspices```

### The other chemicals:

This PR doesn't buff or nerf the other chemicals. Any other chems with working nutrition were tweaked to match their current in-game values in the refactor. So, most ``/drink/`` reagents had their ``nutriment_factor`` cut in half to match the now-standard of adding the entire ``nutriment_factor`` to nutrition. Some chemicals had hardcoded values that gave nutrition that wasn't based on the ``nutriment_factor`` such as sugar and caramel. They were also modified to match the standard.

## Why it's good
buffs beff, makes the code a little easier to understand, consuming nothing but gravy for the whole shift is now viable, reminds us that the spaghetti reagent is real.

## Post change nutrition tier list
![image](https://user-images.githubusercontent.com/69739118/171983770-1d0a702b-451a-48dd-abd5-e01fdc432325.png)
(not including the wizard-made diabeetusol for linearly scaling reasons)

## Changelog
[bugfix] [consistency]
:cl:
 * bugfix: Fixed a bug that didn't give nutrition for certain chemicals such as gravy and most condiments.
 * tweak: Dan's Snacks give a little bit more nutrition as a result.
