### PR TITLE
Removes unreadied requirement for slot editing

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -217,11 +217,9 @@
 		message_admins("[src] ([src.key]) requested high priority jobs. [count_pings ? "[count_pings]" : "<span class='danger'>No</span>"] players heard the request.")
 		return
 
-	if(!ready && href_list["preference"])
+	if(href_list["preference"])
 		if(client)
 			client.prefs.process_link(src, href_list)
-	else if(!href_list["late_join"])
-		new_player_panel()
 
 	if(href_list["showpoll"])
 


### PR DESCRIPTION
[qol][tested][tweak]

## What this does
Allows loading, saving and reloading character slots if declared ready in preround.

## Why it's good
Less fumbling with the ready state during this.

## Changelog
:cl:
 * tweak: Players no longer need to undeclare ready in pre-round to change and edit character slots.