### PR TITLE
Adds Exclusive Tag to dynamic rulesets & Makes Blob an exclusive ruleset

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -392,6 +392,11 @@ var/stacking_limit = 90
 		// 3. Picking up the CHOSEN ONE.
 		var/datum/dynamic_ruleset/chosen_one = picking_roundstart_rule(drafted_rules, candidate_rules)
 
+		// 4. If Ruleset is exclusive and population is under high_pop_limit, ensure ruleset is only one drafted.
+		if(chosen_one.exclusive && high_pop_limit > rst_pop)
+			drafted_rules = chosen_one	
+			break
+
 		// 4. Adding to the LIST.
 		if (chosen_one)
 			message_admins("DYNAMIC MODE: Picking a [istype(chosen_one, /datum/dynamic_ruleset/roundstart/delayed/) ? " delayed " : ""] ruleset...<font size='3'>[chosen_one.name]</font>!")

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -394,7 +394,7 @@ var/stacking_limit = 90
 
 		// 4. If Ruleset is exclusive and population is under high_pop_limit, ensure ruleset is only one drafted.
 		if(chosen_one.exclusive && high_pop_limit > rst_pop)
-			drafted_rules = chosen_one	
+			drafted_rules = list(chosen_one)	
 			break
 
 		// 4. Adding to the LIST.

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -334,11 +334,11 @@ var/stacking_limit = 90
 
 	var/indice_pop = min(10,round(roundstart_pop_ready/5)+1)
 	var/extra_rulesets_amount = 0
+	var/rst_pop = 0
 
 	if (classic_secret) // Classic secret experience : one & only one roundstart ruleset
 		extra_rulesets_amount = 0
 	else
-		var/rst_pop = 0
 		for(var/mob/living/player in player_list)
 			if(player.mind)
 				rst_pop++

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -17,6 +17,7 @@
 	var/list/weekday_rule_boost = list()
 	var/list/timeslot_rule_boost = list()
 	var/cost = 0//threat cost for this rule.
+	var/exclusive //Rulesets that are exclusive will be drafted at the exclusion of all rulesets unless the population exceeds dynamic_high_pop_limit
 	var/logo = ""//any state from /icons/logos.dmi
 	var/calledBy //who dunnit, for round end scoreboard
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -585,6 +585,7 @@ Assign your candidates in choose_candidates() instead.
 	requirements = list(90,90,90,80,60,40,30,20,10,10)
 	high_population_requirement = 70
 	flags = HIGHLANDER_RULESET
+	exclusive = 1
 
 /datum/dynamic_ruleset/roundstart/blob/execute()
 	var/datum/faction/blob_conglomerate/blob_fac = find_active_faction_by_type(/datum/faction/blob_conglomerate)

--- a/code/modules/optics/prism.dm
+++ b/code/modules/optics/prism.dm
@@ -33,7 +33,6 @@ var/list/obj/machinery/prism/prism_list = list()
 		to_chat(world, "[src] \ref[src] found [get_dir(src, B)] its dir is [dir]")
 		if(get_dir(src, B) != dir)
 			return 1
-
 /obj/machinery/prism/verb/rotate_cw()
 	set name = "Rotate (Clockwise)"
 	set category = "Object"
@@ -61,12 +60,6 @@ var/list/obj/machinery/prism/prism_list = list()
 	beam=null
 	update_beams()
 	return 1
-
-
-/obj/machinery/prism/AltClick(mob/user)
-	if(user.incapacitated() || !Adjacent(user))
-		return
-	rotate_ccw()
 
 /obj/machinery/prism/wrenchAnchor(var/mob/user, var/obj/item/I)
 	. = ..()

--- a/code/modules/optics/prism.dm
+++ b/code/modules/optics/prism.dm
@@ -33,6 +33,7 @@ var/list/obj/machinery/prism/prism_list = list()
 		to_chat(world, "[src] \ref[src] found [get_dir(src, B)] its dir is [dir]")
 		if(get_dir(src, B) != dir)
 			return 1
+
 /obj/machinery/prism/verb/rotate_cw()
 	set name = "Rotate (Clockwise)"
 	set category = "Object"
@@ -60,6 +61,12 @@ var/list/obj/machinery/prism/prism_list = list()
 	beam=null
 	update_beams()
 	return 1
+
+
+/obj/machinery/prism/AltClick(mob/user)
+	if(user.incapacitated() || !Adjacent(user))
+		return
+	rotate_ccw()
 
 /obj/machinery/prism/wrenchAnchor(var/mob/user, var/obj/item/I)
 	. = ..()

--- a/code/modules/power/ShieldGen/shield_capacitor.dm
+++ b/code/modules/power/ShieldGen/shield_capacitor.dm
@@ -161,3 +161,8 @@
 	set src in oview(1)
 
 	rotate(usr, 90)
+
+/obj/machinery/shield_capacitor/AltClick(mob/user)
+	if(user.incapacitated() || !Adjacent(user))
+		return
+	rotate(usr,-90)

--- a/code/modules/power/ShieldGen/shield_capacitor.dm
+++ b/code/modules/power/ShieldGen/shield_capacitor.dm
@@ -161,8 +161,3 @@
 	set src in oview(1)
 
 	rotate(usr, 90)
-
-/obj/machinery/shield_capacitor/AltClick(mob/user)
-	if(user.incapacitated() || !Adjacent(user))
-		return
-	rotate(usr,-90)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -73,6 +73,11 @@
 	src.dir = turn(src.dir, 90)
 	return 1
 
+/obj/machinery/power/emitter/AltClick(mob/user)
+	if(user.incapacitated() || !Adjacent(user))
+		return
+	rotate_cw()
+
 /obj/machinery/power/emitter/initialize()
 	..()
 	if(state == 2 && anchored)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -73,11 +73,6 @@
 	src.dir = turn(src.dir, 90)
 	return 1
 
-/obj/machinery/power/emitter/AltClick(mob/user)
-	if(user.incapacitated() || !Adjacent(user))
-		return
-	rotate_cw()
-
 /obj/machinery/power/emitter/initialize()
 	..()
 	if(state == 2 && anchored)

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -105,6 +105,11 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	src.dir = turn(src.dir, 90)
 	return 1
 
+/obj/structure/particle_accelerator/AltClick(mob/user)
+	if(user.incapacitated() || !Adjacent(user))
+		return
+	rotate()
+
 /obj/structure/particle_accelerator/examine(mob/user)
 	switch(src.construction_state)
 		if(0)
@@ -287,6 +292,11 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 		return 0
 	src.dir = turn(src.dir, 90)
 	return 1
+
+/obj/machinery/particle_accelerator/AltClick(mob/user)
+	if(user.incapacitated() || !Adjacent(user))
+		return
+	rotate()
 
 /obj/machinery/particle_accelerator/update_icon()
 	return

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -105,11 +105,6 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	src.dir = turn(src.dir, 90)
 	return 1
 
-/obj/structure/particle_accelerator/AltClick(mob/user)
-	if(user.incapacitated() || !Adjacent(user))
-		return
-	rotate()
-
 /obj/structure/particle_accelerator/examine(mob/user)
 	switch(src.construction_state)
 		if(0)
@@ -292,11 +287,6 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 		return 0
 	src.dir = turn(src.dir, 90)
 	return 1
-
-/obj/machinery/particle_accelerator/AltClick(mob/user)
-	if(user.incapacitated() || !Adjacent(user))
-		return
-	rotate()
 
 /obj/machinery/particle_accelerator/update_icon()
 	return


### PR DESCRIPTION
[gamemode] [wip]

Very experimental, not entirely sure how to test this or whether this is the best way to do it.

## What this does
Adds Exclusive events to the dynamic ruleset datums, events that are exclusive will be drafted alone and no other rulesets will be injected on roundstart unless the server population is greater than 45. Important to note, this does not affect midround injections or midround blob.

## Why it's good
Blob is primarily a team gamemode, it's also designed to be a standalone roundender. 
Spawning traitors often ruins the gamemode for both the blob and the normal station crew.
 
## Changelog
:cl:
 * rscadd: Added new thing.
 * tweak: Changed a 5 to a 6.

