### PR TITLE
Game can now only pick prison break event if people are actually in prison

### DIFF
--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -7,14 +7,16 @@
 
 /datum/event/prison_break/can_start()
 	var/foundSomeone = FALSE
-	var/foundBasic = TRUE
+	var/foundBasic = FALSE
 	for(var/area/A in areas)
 		if(istype(A, /area/security/prison) || istype(A, /area/security/brig))
 			prisonAreas += A
-			var/list/areaMobs = mobs_in_area(A)
+			var/list/areaMobs = mobs_in_area(A,1)
 			if(areaMobs && areaMobs.len)
 				foundBasic = TRUE
 			for(var/mob/living/carbon/human/H in areaMobs)
+				if(H.stat)
+					continue
 				var/list/access = H.GetAccess()
 				if(!(access_brig in access))
 					foundSomeone = TRUE

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -6,7 +6,18 @@
 	var/list/area/prisonAreas = list()
 
 /datum/event/prison_break/can_start()
-	return 25
+	var/foundSomeone = FALSE
+	for(var/area/A in areas)
+		if(istype(A, /area/security/prison) || istype(A, /area/security/brig))
+			prisonAreas += A
+			var/list/areaMobs = mobs_in_area(A)
+			if(areaMobs && areaMobs.len)
+				foundSomeone = TRUE
+	if(!prisonAreas || !prisonAreas.len)
+		world.log << "ERROR: Could not initate grey-tide. Unable find prison or brig area."
+	else if(!foundSomeone)
+		world.log << "ERROR: Could not initate grey-tide. Unable find person in prison or brig areas."
+	return 25 * foundSomeone
 
 /datum/event/prison_break/setup()
 	announceWhen = rand(50, 60)
@@ -15,22 +26,21 @@
 	src.endWhen = src.releaseWhen+1
 
 /datum/event/prison_break/announce()
-	if(prisonAreas && prisonAreas.len > 0)
-		command_alert(/datum/command_alert/graytide)
-	else
-		world.log << "ERROR: Could not initate grey-tide. Unable find prison or brig area."
-		kill()
-
+	command_alert(/datum/command_alert/graytide)
 
 /datum/event/prison_break/start()
-	for(var/area/A in areas)
-		if(istype(A, /area/security/prison) || istype(A, /area/security/brig))
-			prisonAreas += A
+	if(!prisonAreas || !prisonAreas.len)
+		for(var/area/A in areas)
+			if(istype(A, /area/security/prison) || istype(A, /area/security/brig))
+				prisonAreas += A
 
 	if(prisonAreas && prisonAreas.len > 0)
 		for(var/area/A in prisonAreas)
 			for(var/obj/machinery/light/L in A)
 				L.flicker(10)
+	else
+		world.log << "ERROR: Could not initate grey-tide. Unable find prison or brig area."
+		kill()
 
 /datum/event/prison_break/tick()
 	if(activeFor == releaseWhen)

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -12,7 +12,7 @@
 		if(istype(A, /area/security/prison) || istype(A, /area/security/brig))
 			prisonAreas += A
 			var/list/areaMobs = mobs_in_area(A)
-			if(areaMobs &&& areaMobs.len)
+			if(areaMobs && areaMobs.len)
 				foundBasic = TRUE
 			for(var/mob/living/carbon/human/H in areaMobs)
 				var/list/access = H.GetAccess()

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -14,7 +14,7 @@
 			var/list/areaMobs = mobs_in_area(A)
 			if(areaMobs &&& areaMobs.len)
 				foundBasic = TRUE
-			for(var/mob/living/carbon/human/H in mobs_in_area)
+			for(var/mob/living/carbon/human/H in areaMobs)
 				var/list/access = H.GetAccess()
 				if(!(access_brig in access))
 					foundSomeone = TRUE

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -7,10 +7,13 @@
 
 /datum/event/prison_break/can_start()
 	var/foundSomeone = FALSE
+	var/foundBasic = TRUE
 	for(var/area/A in areas)
 		if(istype(A, /area/security/prison) || istype(A, /area/security/brig))
 			prisonAreas += A
 			var/list/areaMobs = mobs_in_area(A)
+			if(areaMobs &&& areaMobs.len)
+				foundBasic = TRUE
 			for(var/mob/living/carbon/human/H in mobs_in_area)
 				var/list/access = H.GetAccess()
 				if(!(access_brig in access))
@@ -20,8 +23,10 @@
 			break
 	if(!prisonAreas || !prisonAreas.len)
 		world.log << "ERROR: Could not initate grey-tide. Unable find prison or brig area."
-	else if(!foundSomeone)
+	else if(!foundBasic)
 		world.log << "ERROR: Could not initate grey-tide. Unable find person in prison or brig areas."
+	else if(!foundSomeone)
+		world.log << "ERROR: Could not initate grey-tide. Unable find person in prison or brig areas without access."
 	return 50 * foundSomeone
 
 /datum/event/prison_break/setup()

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -17,7 +17,7 @@
 		world.log << "ERROR: Could not initate grey-tide. Unable find prison or brig area."
 	else if(!foundSomeone)
 		world.log << "ERROR: Could not initate grey-tide. Unable find person in prison or brig areas."
-	return 25 * foundSomeone
+	return 50 * foundSomeone
 
 /datum/event/prison_break/setup()
 	announceWhen = rand(50, 60)

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -11,8 +11,13 @@
 		if(istype(A, /area/security/prison) || istype(A, /area/security/brig))
 			prisonAreas += A
 			var/list/areaMobs = mobs_in_area(A)
-			if(areaMobs && areaMobs.len)
-				foundSomeone = TRUE
+			for(var/mob/living/carbon/human/H in mobs_in_area)
+				var/list/access = H.GetAccess()
+				if(!(access_brig in access))
+					foundSomeone = TRUE
+					break
+		if(foundSomeone)
+			break
 	if(!prisonAreas || !prisonAreas.len)
 		world.log << "ERROR: Could not initate grey-tide. Unable find prison or brig area."
 	else if(!foundSomeone)


### PR DESCRIPTION
[tweak][tested]

## What this does
Does not fire this event if prison areas have no actual mobs in them that can access brig doors, also doubles chance of firing from old value to make it appear in this situation more.

## Why it's good
Frees up an event from an area not in use.

## Changelog
:cl:
 * tweak: Prison breaks will no longer happen if there are no signs of life within cells without access to open them, but are now twice as common when there is.