### PR TITLE
Makes maint access revoke and readding more customisable

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -328,6 +328,11 @@
 		if(7) //supply
 			return "Supply"
 
+/proc/get_access_desc_list(var/list/L)
+	var/list/names = list()
+	for(var/access in L)
+		names.Add(get_access_desc(access))
+	return english_list(names)
 
 /proc/get_access_desc(A)
 	switch(A)

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -43,7 +43,7 @@
 			var/area/ma = get_area(A)
 			ma.radiation_alert()
 
-		make_maint_all_access()
+		make_doors_all_access(list(access_maint_tunnels))
 
 
 		sleep(30 SECONDS)
@@ -106,4 +106,4 @@
 		sleep(600) // Want to give them time to get out of maintenance.
 
 
-		revoke_maint_all_access()
+		revoke_doors_all_access(list(access_maint_tunnels))

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -202,15 +202,17 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 
 var/global/list/all_access_list = list()
 
-/proc/make_doors_all_access(var/list/accesses)
+/proc/make_doors_all_access(var/list/accesses, var/announce = TRUE)
 	all_access_list.Add(accesses)
-	to_chat(world, "<font size=4 color='red'>Attention!</font>")
-	to_chat(world, "<span class='red'>The [get_access_desc_list(accesses)] access requirement has been revoked on all airlocks.</span>")
+	if(announce)
+		to_chat(world, "<font size=4 color='red'>Attention!</font>")
+		to_chat(world, "<span class='red'>The [get_access_desc_list(accesses)] access requirement has been revoked on all airlocks.</span>")
 
-/proc/revoke_doors_all_access(var/list/accesses)
+/proc/revoke_doors_all_access(var/list/accesses, var/announce = TRUE)
 	all_access_list.Remove(accesses)
-	to_chat(world, "<font size=4 color='red'>Attention!</font>")
-	to_chat(world, "<span class='red'>The [get_access_desc_list(accesses)] access requirement has been readded on all airlocks.</span>")
+	if(announce)
+		to_chat(world, "<font size=4 color='red'>Attention!</font>")
+		to_chat(world, "<span class='red'>The [get_access_desc_list(accesses)] access requirement has been readded on all airlocks.</span>")
 
 /obj/machinery/door/airlock/allowed(mob/M)
 	if(check_access_list(all_access_list))

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -182,10 +182,10 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 			set_security_level(SEC_LEVEL_RED)
 			feedback_inc("alert_keycard_auth_red",1)
 		if("Grant Emergency Maintenance Access")
-			make_maint_all_access()
+			make_doors_all_access(list(access_maint_tunnels))
 			feedback_inc("alert_keycard_auth_maintGrant",1)
 		if("Revoke Emergency Maintenance Access")
-			revoke_maint_all_access()
+			revoke_doors_all_access(list(access_maint_tunnels))
 			feedback_inc("alert_keycard_auth_maintRevoke",1)
 		if("Emergency Response Team")
 			var/datum/striketeam/ert/response_team = new()
@@ -200,19 +200,19 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 	for(var/obj/machinery/keycard_auth/KA in authenticators)
 		KA.reset()
 
-var/global/maint_all_access = 0
+var/global/list/all_access_list = list()
 
-/proc/make_maint_all_access()
-	maint_all_access = 1
+/proc/make_doors_all_access(var/list/accesses)
+	all_access_list.Add(accesses)
 	to_chat(world, "<font size=4 color='red'>Attention!</font>")
-	to_chat(world, "<span class='red'>The maintenance access requirement has been revoked on all airlocks.</span>")
+	to_chat(world, "<span class='red'>The [get_access_desc_list(accesses)] access requirement has been revoked on all airlocks.</span>")
 
-/proc/revoke_maint_all_access()
-	maint_all_access = 0
+/proc/revoke_doors_all_access(var/list/accesses)
+	all_access_list.Remove(accesses)
 	to_chat(world, "<font size=4 color='red'>Attention!</font>")
-	to_chat(world, "<span class='red'>The maintenance access requirement has been readded on all maintenance airlocks.</span>")
+	to_chat(world, "<span class='red'>The [get_access_desc_list(accesses)] access requirement has been readded on all airlocks.</span>")
 
 /obj/machinery/door/airlock/allowed(mob/M)
-	if(maint_all_access && src.check_access_list(list(access_maint_tunnels)))
+	if(check_access_list(all_access_list))
 		return 1
 	return ..(M)


### PR DESCRIPTION
[tested]

## What this does
Updates the functions to accept other kinds of access than maint, and if this should be announced or not. Still only currently used for doors. Will probably use this for something in another PR, but it's here for now.

## Why it's good
Should allow for more custom use of this proc.
