### PR TITLE
Shuttle automatically called if round lasts 8 hours

### DIFF
--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -350,7 +350,7 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 
 				if(collision_imminent)
 					playsound(shuttle.linked_port, 'sound/misc/weather_warning.ogg', 80, 0, 7, 0, 0)
-				
+
 				if(timeleft>0)
 					return 0
 
@@ -423,7 +423,7 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 		else
 			return 1
 
-/proc/shuttle_autocall()
+/proc/shuttle_autocall(var/reason = "None")
 	if (emergency_shuttle.departed)
 		return
 
@@ -431,7 +431,7 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 		return
 
 	emergency_shuttle.incall(2)
-	log_game("All the AIs, comm consoles and boards are destroyed. Shuttle called.")
-	message_admins("All the AIs, comm consoles and boards are destroyed. Shuttle called.", 1)
-	captain_announce("The emergency shuttle has been called. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.")
+	log_game("[reason]. Shuttle called.")
+	message_admins("[reason]. Shuttle called.", 1)
+	captain_announce("The emergency shuttle has been called. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes. Justification: [reason]")
 	world << sound('sound/AI/shuttlecalled.ogg')

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -47,6 +47,7 @@ var/stacking_limit = 90
 	var/list/dead_players = list()
 	var/list/list_observers = list()
 	var/last_time_of_population = 0
+	var/last_time_of_late_shuttle_call = 0
 
 	var/latejoin_injection_cooldown = 0
 	var/midround_injection_cooldown = 0
@@ -500,7 +501,7 @@ var/stacking_limit = 90
 			if (latejoin_rule.persistent)
 				current_rules += latejoin_rule
 			. = TRUE
-	for (var/datum/dynamic_ruleset/latejoin/non_executed in drafted_rules) 
+	for (var/datum/dynamic_ruleset/latejoin/non_executed in drafted_rules)
 		non_executed.assigned.Cut()
 
 
@@ -658,11 +659,14 @@ var/stacking_limit = 90
 					living_players.Add(M)//yes we're adding a ghost to "living_players", so make sure to properly check for type when testing midround rules
 					continue
 			dead_players.Add(M)//Players who actually died (and admins who ghosted, would be nice to avoid counting them somehow)
-	
+
 	if(living_players.len) //if anybody is around and alive in the current round
 		last_time_of_population = world.time
 	else if(last_time_of_population && world.time - last_time_of_population > 5 MINUTES && world.time > 15 MINUTES) //if enough time has passed without it
 		ticker.station_nolife_cinematic()
+	if(world.time > (7 HOURS + 40 MINUTES) && world.time - last_time_of_late_shuttle_call > 1 HOUR && emergency_shuttle.direction == 0) // 8 hour work shift, with time for shuttle to arrive and leave. If recalled, do every hour
+		shuttle_autocall("Shift due to end")
+		last_time_of_late_shuttle_call = world.time
 
 /datum/gamemode/dynamic/proc/GetInjectionChance()
 	var/chance = 0

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -664,7 +664,7 @@ var/stacking_limit = 90
 		last_time_of_population = world.time
 	else if(last_time_of_population && world.time - last_time_of_population > 5 MINUTES && world.time > 15 MINUTES) //if enough time has passed without it
 		ticker.station_nolife_cinematic()
-	if(world.time > (7 HOURS + 40 MINUTES) && world.time - last_time_of_late_shuttle_call > 1 HOUR && emergency_shuttle.direction == 0) // 8 hour work shift, with time for shuttle to arrive and leave. If recalled, do every hour
+	if(world.time > (7 HOURS + 40 MINUTES) && world.time - last_time_of_late_shuttle_call > 1 HOURS && emergency_shuttle.direction == 0) // 8 hour work shift, with time for shuttle to arrive and leave. If recalled, do every hour
 		shuttle_autocall("Shift due to end")
 		last_time_of_late_shuttle_call = world.time
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -729,7 +729,7 @@ var/list/shuttle_log = list()
 	if(ticker.mode.name == "revolution" || ticker.mode.name == "AI malfunction")
 		return ..()
 
-	shuttle_autocall()
+	shuttle_autocall("All the AIs, comm consoles and boards are destroyed")
 	..()
 
 // -- Blob defcon 1 things
@@ -831,6 +831,6 @@ var/list/shuttle_log = list()
 	if(ticker.mode.name == "revolution" || ticker.mode.name == "AI malfunction")
 		return ..()
 
-	shuttle_autocall()
+	shuttle_autocall("All the AIs, comm consoles and boards are destroyed")
 
 	..()

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -42,7 +42,7 @@
 		callshuttle = 0
 
 	if(callshuttle == 3) //if all three conditions are met
-		shuttle_autocall()
+		shuttle_autocall("All the AIs, comm consoles and boards are destroyed")
 
 	if(explosive && !gibbed && !istype(loc, /obj/machinery/power/apc))
 		visible_message("<span class='danger'>[name] begins to spark violently!</span>")


### PR DESCRIPTION
[content]

## What this does
Adds an actual shift time limit before the shuttle comes. Is recallable, but if recalled, will automatically keep calling every hour after that.

## Why it's good
Stops server crashing due to "resource leakage" which usually happens 12 hours into a round, most rounds that manage to last this long are also usually deadpop.

## Changelog
:cl:
 * rscadd: Shifts now automatically call a shuttle after 8 hours. Recalling this will send it again an hour later each time it's recalled.