### PR TITLE
Makes shifts start at exactly 12:00

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -26,7 +26,10 @@
 
 //Returns the world time in english
 /proc/worldtime2text(timestamp = world.time, give_seconds = FALSE)
-	return "[(round(timestamp / 36000) + 12) % 24]:[(timestamp / 600 % 60) < 10 ? add_zero(timestamp / 600 % 60, 1) : timestamp / 600 % 60]\
+	if(timestamp == world.time)
+		timestamp -= Master.time_taken_to_init
+	return "[(round(((timestamp / 600) + 55) / 60) + 11) % 24]:\
+	[(((timestamp / 600) + 55) % 60) < 10 ? add_zero(((timestamp / 600) + 55) % 60, 1) : ((timestamp / 600) + 55) % 60]\
 	[give_seconds ? ":[(timestamp / 10 % 60) < 10 ? add_zero(timestamp / 10 % 60, 1) : timestamp / 10 % 60]" : ""]"
 
 

--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -35,6 +35,8 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 	var/init_time
 	var/tickdrift = 0
 
+	var/time_taken_to_init = 0
+
 	var/sleep_delta
 
 	var/make_runtime = 0
@@ -128,6 +130,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 	// Sort subsystems by init_order, so they initialize in the correct order.
 	sortTim(subsystems, /proc/cmp_subsystem_init)
 
+	var/time_to_init = world.time
 	// Initialize subsystems.
 	CURRENT_TICKLIMIT = TICK_LIMIT_MC_INIT
 	for (var/datum/subsystem/SS in subsystems)
@@ -136,9 +139,10 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		SS.Initialize(world.timeofday)
 		CHECK_TICK
 	CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
+	time_taken_to_init = world.time - time_to_init
 
-	to_chat(world, "<span class='boldannounce'>Initializations complete!</span>")
-	world.log << "Initializations complete."
+	to_chat(world, "<span class='boldannounce'>Initializations complete in [time_taken_to_init / 10] seconds!</span>")
+	world.log << "Initializations complete. Took [time_taken_to_init / 10] seconds."
 
 	// Sort subsystems by display setting for easy access.
 	sortTim(subsystems, /proc/cmp_subsystem_display)


### PR DESCRIPTION
[tweak][tested][consistency]

## What this does
Offsets worldtime2text back by about 5 minutes overall, plus the amount of time it took the server to boot up. (without this rounds would not start as soon as it hits 12:00)

## Why it's good
The AI announcement at roundstart says the time is 12 noon but it's actually 12:05, so this makes it consistent.

## Changelog
:cl:
 * tweak: Shifts no longer start 5 minutes late.