### PR TITLE
Power Monitor fixes

### DIFF
--- a/code/game/objects/items/devices/PDA/cart/engineering.dm
+++ b/code/game/objects/items/devices/PDA/cart/engineering.dm
@@ -25,17 +25,20 @@
             var/powercount = 0
             var/found = 0
 
-            for(var/obj/machinery/computer/powermonitor/pMon in power_machines)
-                if(!(pMon.stat & (NOPOWER|BROKEN)))
-                    var/turf/T = get_turf(pda_device)
-                    if(T.z == pMon.z)//the application may only detect power monitoring computers on its Z-level.
-                        if(!found)
-                            menu = "<h4><span class='pda_icon pda_power'></span> Please select a Power Monitoring Computer</h4><BR>"
-                            found = 1
-                            menu += "<FONT SIZE=-1>"
-                        powercount++
-                        menu += "<a href='byond://?src=\ref[src];choice=Power Select;target=[powercount]'> [pMon] </a><BR>"
-                        powermonitors += "\ref[pMon]"
+            for(var/datum/power_connection/C in power_machines)
+                if(istype(C.parent, /obj/machinery/computer/powermonitor))
+                    var/obj/machinery/computer/powermonitor/pMon = C.parent
+
+                    if(!(pMon.stat & (NOPOWER|BROKEN)))
+                        var/turf/T = get_turf(pda_device)
+                        if(T.z == pMon.z)//the application may only detect power monitoring computers on its Z-level.
+                            if(!found)
+                                menu = "<h4><span class='pda_icon pda_power'></span> Please select a Power Monitoring Computer</h4><BR>"
+                                found = 1
+                                menu += "<FONT SIZE=-1>"
+                            powercount++
+                            menu += "<a href='byond://?src=\ref[src];target=[powercount]'> [pMon] </a><BR>"
+                            powermonitors += "\ref[pMon]"
             if(found)
                 menu += "</FONT>"
 
@@ -44,15 +47,16 @@
                 menu = "<h4><span class='pda_icon pda_power'></span> Power Monitor </h4><BR>"
                 menu += "No connection<BR>"
             else
+                var/datum/powernet/connected_powernet = powmonitor.power_connection.get_powernet()
                 menu = "<h4><span class='pda_icon pda_power'></span> [powmonitor] </h4><BR>"
                 var/list/L = list()
-                for(var/obj/machinery/power/terminal/term in powmonitor.connected_powernet.nodes)
+                for(var/obj/machinery/power/terminal/term in connected_powernet.nodes)
                     if(istype(term.master, /obj/machinery/power/apc))
                         var/obj/machinery/power/apc/A = term.master
                         L += A
 
 
-                menu += {"<PRE>Total power: [powmonitor.connected_powernet.avail] W<BR>Total load:  [num2text(powmonitor.connected_powernet.viewload,10)] W<BR>
+                menu += {"<PRE>Total power: [format_watts(connected_powernet.avail)]<BR>Total load:  [format_watts(connected_powernet.viewload)]<BR>
                     <FONT SIZE=-1>"}
                 if(L.len > 0)
                     menu += "Area                           Eqp./Lgt./Env.  Load   Cell<HR>"
@@ -71,8 +75,8 @@
 /datum/pda_app/cart/power_monitor/Topic(href, href_list)
     if(..())
         return
-    if(href_list["Power Select"])
-        var/pnum = text2num(href_list["Power Select"])
+    if(href_list["target"])
+        var/pnum = text2num(href_list["target"])
         powmonitor = locate(powermonitors[pnum])
         if(istype(powmonitor))
             mode = 1


### PR DESCRIPTION
## What this does
Should hopefully fix the bug detected by Kurfurst on #32613; going by today's runtimes it seems to be caused by me being dumb and not having the monitor consider the possibility APCs may have no battery to send info of.

Fixes #32531, and also fixes power monitors not showing up on the PDA power monitoring app.
Also finishes off power monitor documentation, I had apparently left some leftover ideas like `"icon": ???` still in.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixes an oversight causing power monitors to crash if an APC is shorted or has no battery in it.
 * bugfix: Fixes power monitors often becoming unresponsive if someone cuts/adds wires to the grid, which used to require that you unscrew and re-screw the monitor's screen to fix it.
 * bugfix: Fixes power monitors not showing up on the PDA power monitoring app.

[bugfix]

