### PR TITLE
Changeling: Monkeyform duplicate icons

### DIFF
--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -47,7 +47,7 @@
 
 // Toggles several features, explained in their respective comments.
 // You can turn those on and off manually if you prefer, instead of setting this
-#define DEVELOPER_MODE 1
+#define DEVELOPER_MODE 0
 
 // If 1, unit tests will be compiled
 #define UNIT_TESTS_ENABLED 0

--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -47,7 +47,7 @@
 
 // Toggles several features, explained in their respective comments.
 // You can turn those on and off manually if you prefer, instead of setting this
-#define DEVELOPER_MODE 0
+#define DEVELOPER_MODE 1
 
 // If 1, unit tests will be compiled
 #define UNIT_TESTS_ENABLED 0

--- a/code/datums/gamemode/powers/changeling.dm
+++ b/code/datums/gamemode/powers/changeling.dm
@@ -165,7 +165,7 @@
 /datum/power/changeling/Epinephrine
 	name = "Epinephrine sacs"
 	desc = "We evolve additional sacs of adrenaline throughout our body."
-	helptext = "Gives the ability to instantly recover from stuns.  High chemical cost."
+	helptext = "Gives the ability to instantly recover from stuns."
 	cost = 3
 	spellpath = /spell/changeling/unstun
 

--- a/code/game/gamemodes/changeling/changeling_procs.dm
+++ b/code/game/gamemodes/changeling/changeling_procs.dm
@@ -2,7 +2,6 @@
 /mob/proc/make_changeling()
 	if(!mind)
 		return
-
 	var/datum/role/changeling/C = mind.GetRole(CHANGELING)
 	if(!C)
 		return
@@ -14,7 +13,6 @@
 		C.antag.current.add_spell(new /spell/changeling/higherform, "changeling_spell_base", /obj/abstract/screen/movable/spell_master/changeling)
 
 	C.refreshpowers()
-
 
 	var/mob/living/carbon/human/H = src
 	if(istype(H))

--- a/code/modules/spells/changeling/changeling_spell.dm
+++ b/code/modules/spells/changeling/changeling_spell.dm
@@ -55,6 +55,3 @@
 
 /spell/changeling/choose_targets(var/mob/user = usr)
 	return list(user) // Self-cast
-
-
-	

--- a/code/modules/spells/changeling/lesser_form.dm
+++ b/code/modules/spells/changeling/lesser_form.dm
@@ -38,8 +38,7 @@
 	to_chat(user, "<span class='warning'>Our genes cry out!</span>")
 	
 	var/mob/living/carbon/monkey/O = user.monkeyize(ignore_primitive = 1) // stops us from becoming the monkey version of whoever we were pretending to be
-	O.add_spell(new /spell/changeling/higherform, "changeling_spell_base", master_type = /obj/abstract/screen/movable/spell_master/changeling)
-	O.make_changeling(1)
+	O.make_changeling()
 	var/datum/role/changeling/Ochangeling = O.mind.GetRole(CHANGELING)
 	O.changeling_update_languages(Ochangeling.absorbed_languages)
 	feedback_add_details("changeling_powers","LF")

--- a/code/modules/spells/changeling/unstun.dm
+++ b/code/modules/spells/changeling/unstun.dm
@@ -1,10 +1,10 @@
 /spell/changeling/unstun
-	name = "Epinephrine Sacs"
+	name = "Epinephrine Sacs (45)"
 	desc = "We extract extra adrenaline from epinephrine sacs within our body, instantly recovering us from stuns."
 	abbreviation = "ES"
 	hud_state = "unstun"
-	max_genedamage = 0
 	spell_flags = NEEDSHUMAN
+	chemcost = 45
 
 //Recover from stuns.
 /spell/changeling/unstun/cast(var/list/targets, var/mob/living/carbon/human/user)
@@ -17,8 +17,6 @@
 	C.SetKnockdown(0)
 	C.lying = 0
 	C.update_canmove()
-	var/datum/role/changeling/changeling = user.mind.GetRole(CHANGELING)
-	changeling.geneticdamage = 30
 
 	feedback_add_details("changeling_powers","UNS")
 

--- a/code/modules/spells/changeling/unstun.dm
+++ b/code/modules/spells/changeling/unstun.dm
@@ -1,12 +1,13 @@
 /spell/changeling/unstun
-	name = "Epinephrine Sacs (45)"
+	name = "Epinephrine Sacs"
 	desc = "We extract extra adrenaline from epinephrine sacs within our body, instantly recovering us from stuns."
 	abbreviation = "ES"
 	hud_state = "unstun"
 
 	spell_flags = NEEDSHUMAN
 
-	chemcost = 45
+	charge_max = 1 MINUTES
+	cooldown_min = 1 MINUTES
 
 //Recover from stuns.
 /spell/changeling/unstun/cast(var/list/targets, var/mob/living/carbon/human/user)

--- a/code/modules/spells/changeling/unstun.dm
+++ b/code/modules/spells/changeling/unstun.dm
@@ -3,11 +3,8 @@
 	desc = "We extract extra adrenaline from epinephrine sacs within our body, instantly recovering us from stuns."
 	abbreviation = "ES"
 	hud_state = "unstun"
-
+	max_genedamage = 0
 	spell_flags = NEEDSHUMAN
-
-	charge_max = 1 MINUTES
-	cooldown_min = 1 MINUTES
 
 //Recover from stuns.
 /spell/changeling/unstun/cast(var/list/targets, var/mob/living/carbon/human/user)
@@ -20,6 +17,8 @@
 	C.SetKnockdown(0)
 	C.lying = 0
 	C.update_canmove()
+	var/datum/role/changeling/changeling = user.mind.GetRole(CHANGELING)
+	changeling.geneticdamage = 30
 
 	feedback_add_details("changeling_powers","UNS")
 


### PR DESCRIPTION
[bugfix]

Monkeyform for whatever reason gives two spell icons for higher form.

## What this does
- One monkeyform icon
## Why it's good
- Bugfix
