### PR TITLE
Banana peel tweaks

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -40,6 +40,7 @@
 	throw_speed = 4
 	throw_range = 20
 	var/potency = 20
+	var/slip_override = 0
 
 /obj/item/weapon/bananapeel/suicide_act(var/mob/living/user)
 	to_chat(viewers(user), "<span class='danger'>[user] drops the [src.name] on the ground and steps on it causing \him to crash to the floor, bashing \his head wide open. </span>")

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -10,11 +10,11 @@
 /obj/item/weapon/bananapeel/Crossed(AM as mob|obj)
 	if(..())  // Slipping if these are below a floor tile is nonsensical
 		return 1
-	handle_slip(AM,0)
+	handle_slip(AM)
 
 /datum/locking_category/banana_peel
 
-/obj/item/weapon/bananapeel/proc/handle_slip(atom/movable/AM,var/slip_override)
+/obj/item/weapon/bananapeel/proc/handle_slip(atom/movable/AM)
 	if(iscarbon(AM) || istype(AM, /obj/structure/bed/chair/vehicle/gokart))
 		return slip_n_slide(AM,2,2,"<span class='userdanger'>Something is scratching at your feet! Oh god!</span>")
 

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -10,38 +10,39 @@
 /obj/item/weapon/bananapeel/Crossed(AM as mob|obj)
 	if(..())  // Slipping if these are below a floor tile is nonsensical
 		return 1
-	handle_slip(AM)
+	handle_slip(AM,0)
 
 /datum/locking_category/banana_peel
 
-/obj/item/weapon/bananapeel/proc/handle_slip(atom/movable/AM)
-	if(iscarbon(AM))
-		var/mob/living/carbon/M = AM
-		slip_n_slide(M)
-	if(istype(AM, /obj/structure/bed/chair/vehicle/gokart))
-		var/obj/structure/bed/chair/vehicle/gokart/kart = AM
-		var/left_or_right = prob(50) ? turn(kart.dir, 90) : turn(kart.dir, -90)
-		var/tiles_to_slip = rand(round(potency/20, 1), round(potency/10, 1))
-		kart.speen()
-		playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
-		spawn()
-			for(var/i in 1 to tiles_to_slip)
-				step(kart, left_or_right)
-				sleep(1)
+/obj/item/weapon/bananapeel/proc/handle_slip(atom/movable/AM,var/slip_override)
+	if(iscarbon(AM) || istype(AM, /obj/structure/bed/chair/vehicle/gokart))
+		return slip_n_slide(AM,2,2,"<span class='userdanger'>Something is scratching at your feet! Oh god!</span>")
 
-/obj/item/weapon/bananapeel/proc/slip_n_slide(var/mob/living/carbon/M)
-	if(!M.Slip(2, 2, 1, slipped_on = src, drugged_message = "<span class='userdanger'>Something is scratching at your feet! Oh god!</span>"))
-		return 0
-	var/tiles_to_slip = rand(round(potency/20, 1),round(potency/10, 1))
-	if(tiles_to_slip && !locked_to) //The banana peel will not be dragged along so stop the ride
-		M.lock_atom(src, /datum/locking_category/banana_peel)
-		for(var/i = 1 to tiles_to_slip)
-			if(!M.locked_to)
-				step(M, M.dir)
-				sleep(1)
-		spawn(1) M.unlock_atom(src)
+/obj/item/weapon/bananapeel/proc/slip_n_slide(var/atom/movable/AM,var/stun_amount,var/weaken_amount,var/drug_message)
+	if(iscarbon(AM) || istype(AM, /obj/structure/bed/chair/vehicle/gokart))
+		var/old_dir = AM.dir // Slipping changes dir, this is consistent
+		if(iscarbon(AM))
+			var/mob/living/carbon/M = AM
+			if(!M.Slip(stun_amount, weaken_amount, 1, slipped_on = src, drugged_message = drug_message))
+				return 0
+		var/tiles_to_slip = slip_override > 0 ? slip_override : rand(round(potency/20, 1),round(potency/10, 1))
+		if(istype(AM, /obj/structure/bed/chair/vehicle/gokart))
+			var/obj/structure/bed/chair/vehicle/gokart/kart = AM
+			var/left_or_right = prob(50) ? turn(AM.dir, 90) : turn(AM.dir, -90)
+			kart.speen()
+			playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
+			spawn()
+				for(var/i in 1 to tiles_to_slip)
+					step(AM, left_or_right)
+					sleep(1)
+		else if(tiles_to_slip && !locked_to) //The banana peel will not be dragged along so stop the ride
+			AM.lock_atom(src, /datum/locking_category/banana_peel)
+			for(var/i = 1 to tiles_to_slip)
+				if(!AM.locked_to)
+					step(AM, old_dir)
+					sleep(1)
+			spawn(1) AM.unlock_atom(src)
 	return 1
-
 
 /*
  * Bike Horns

--- a/code/game/objects/items/weapons/grenades/clowngrenade.dm
+++ b/code/game/objects/items/weapons/grenades/clowngrenade.dm
@@ -64,7 +64,7 @@
 	throw_speed = 4
 	throw_range = 20
 
-	var/slip_power = 4
+	slip_override = 5
 
 /obj/item/weapon/bananapeel/traitorpeel/handle_slip(atom/movable/AM)
 	if(isliving(AM))
@@ -74,7 +74,7 @@
 			M.take_overall_damage(0, max(0, (burned - 2)))
 			M.simple_message("<span class='danger'>Something burns your back!</span>",\
 				"<span class='userdanger'>They're eating your back!</span>")
-			return
+			return 0
 
 		if(ishuman(M))
 			if(M.CheckSlip())
@@ -82,23 +82,14 @@
 					"<span class='userdanger'>Egads! They bite your feet!</span>")
 				M.take_overall_damage(0, max(0, (burned - 2)))
 			else
-				return
+				return 0
 
 		if(!istype(M, /mob/living/carbon/slime) && !isrobot(M))
-			if(iscarbon(M))
-				var/mob/living/carbon/C = M
-				C.Slip(10, 10, slipped_on = src, drugged_message = "<span class='userdanger'>Please, just end the pain!</span>", spanclass = "notice")
-			else //Includes simple animals
-				M.Slip(10, 10)
-				M.simple_message("<span class='notice'>You slipped on \the [name]!</span>",\
-				"<span class='userdanger'>Please, just end the pain!</span>")
-			step(M, M.dir)
-			spawn(1)
-				for(var/i = 1 to slip_power)
-					step(M, M.dir)
-					sleep(1)
+			slip_n_slide(M, 10, 10, "<span class='userdanger[iscarbon(M) ? " notice" : ""]'>Please, just end the pain!</span>")
 			M.take_organ_damage(2) // Was 5 -- TLE
 			M.take_overall_damage(0, burned)
+		return 1
+	return ..()
 
 /obj/item/weapon/bananapeel/traitorpeel/throw_impact(atom/hit_atom)
 	var/burned = rand(1,3)

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -128,17 +128,14 @@ Frequency:
 	item_state = "bluespacebanana_peel"
 
 /obj/item/weapon/bananapeel/bluespace/handle_slip(atom/movable/AM)
-	if(iscarbon(AM))
-		var/mob/living/carbon/M = AM
-		if(M.Slip(2, 2, 1, slipped_on = src, drugged_message = "<span class='userdanger'>Something is scratching at your feet! Oh god!</span>"))
-			if(ishuman(AM))
-				var/mob/living/carbon/human/H = AM
-				var/obj/teleported_shoes = H.get_item_by_slot(slot_shoes)
-				var/tele_destination = pick_rand_tele_turf(H, src.potency/15, src.potency/10)
-				if(teleported_shoes && tele_destination)
-					H.drop_from_inventory(teleported_shoes)
-					teleported_shoes.forceMove(tele_destination)
-					spark(H.loc)
+	if(..() && ishuman(AM))
+		var/mob/living/carbon/human/H = AM
+		var/obj/teleported_shoes = H.get_item_by_slot(slot_shoes)
+		var/tele_destination = pick_rand_tele_turf(H, src.potency/15, src.potency/10)
+		if(teleported_shoes && tele_destination)
+			H.drop_from_inventory(teleported_shoes)
+			teleported_shoes.forceMove(tele_destination)
+			spark(H.loc)
 
 /*
  * Hand-tele

--- a/code/modules/randomMaps/vault_definitions.dm
+++ b/code/modules/randomMaps/vault_definitions.dm
@@ -74,6 +74,7 @@ var/list/existing_vaults = list()
 
 /datum/map_element/vault/clown_base
 	file_path = "maps/randomvaults/clown_base.dmm"
+	can_rotate = TRUE
 
 /datum/map_element/vault/rust
 	file_path = "maps/randomvaults/rust.dmm"

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -371,7 +371,7 @@
 	anchored = 1
 	cant_drop = 1
 
-	slip_power = 10
+	slip_override = 11
 
 /obj/item/weapon/melee/morningstar/catechizer
 	name = "The Catechizer"


### PR DESCRIPTION
[tweak][consistency][bugfix]

## What this does
Makes people slip along bananapeels in the direction they're facing, rather than the one when they fall over.
Allows gokarts to slip on acid peels and bluespace banana peels.
Allows potency to affect bluespace banana peel slipping distance. (but preserves the old distance and stun time for acid ones)
Lets clown base vault rotate as issues with peels not behaving is fixed.

## Why it's good
Allows more consistency with the way people will slip on peels, and botany to slip people with the same distance as normal ones with bluespace so this quality isn't lost on mutation.

## Changelog
:cl:
 * rscadd: Go-karts can now slip on all banana peels.
 * rscadd: Potency now affects bluespace banana peel slippage distance.
 * bugfix: Banana peel slips now make the mob fall in the direction they were facing before they slipped, not after.
 * tweak: Clown base vaults can now be found rotated in space.
