### PR TITLE
Vampire bugfix

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -314,11 +314,12 @@
 	if((T.get_lumcount() * 10) <= 2)
 		if(locate(/datum/power/vampire/shadow) in current_powers)
 			H.make_invisible(VAMPIRECLOAK, 0, TRUE, round(255 * 0.15), INVISIBILITY_LEVEL_TWO)
-			H.color = "#000000"
 		else
 			H.make_invisible(VAMPIRECLOAK, 0, TRUE, round(255 * 0.15))
 		return TRUE
 	else
+		if(H.invisibility > 0)
+			H.make_visible(VAMPIRECLOAK, TRUE)
 		if(locate(/datum/power/vampire/shadow) in current_powers)
 			H.make_invisible(VAMPIRECLOAK, 0, TRUE, round(255 * 0.15))
 		else


### PR DESCRIPTION
[hotfix][bugfix]

Vampires remain invisible when leaving a dark turf

## What this does
Checks to see if vampires are invisible on a light turf, and consequently makes them visible again.

## Why it's good
Closes #32767

:cl:
 * bugfix: Vampires no longer remain invisible when leaving a dark turf
