### PR TITLE
Tweak Robust Harvest regarding weed/pests

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2500,9 +2500,9 @@
 	..()
 	T.add_nutrientlevel(1)
 	if(prob(25*custom_plant_metabolism))
-		T.add_weedlevel(10)
+		T.add_weedlevel(3)
 	if(T.seed && !T.dead && prob(25*custom_plant_metabolism))
-		T.add_pestlevel(10)
+		T.add_pestlevel(3)
 	if(T.seed && !T.dead && !T.seed.immutable)
 		var/chance
 		chance = unmix(T.seed.potency, 15, 150)*350*custom_plant_metabolism


### PR DESCRIPTION
According to Fogwick, weed and pests increase 3x faster than usual

## What this does
- Reduces pestlevel from 10 to 3
- Reduces weedlvel from 10 to 3

## Why it's good
Resolve a complaint regarding botany

:cl:
 * tweak: Robust harvest weed and pest rates are reduced 