### PR TITLE
Alt-click on lamps to turn them on and off.

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -226,10 +226,15 @@
 	set category = "Object"
 	set src in oview(1)
 
-	if(!usr.stat)
+	if(!Adjacent(usr))
+		return
+
+	if(usr.incapacitated() || usr.stat) //Checks for stuns, ghost, restraint, and being awake.
+		return
+
+	if(usr.has_hand_check())
 		attack_self(usr)
 		return TRUE
-	return FALSE
 
 // FLARES
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -205,6 +205,11 @@
 	starting_materials = null
 	on = 0	//Lamps start out off unless someone spawns in the same room as them at roundstart.
 
+/obj/item/device/flashlight/lamp/AltClick()
+	if(toggle_light())
+		return
+	return ..()
+
 /obj/item/device/flashlight/lamp/cultify()
 	new /obj/structure/cult/pylon(loc)
 	qdel(src)
@@ -216,7 +221,6 @@
 	item_state = "lampgreen"
 	brightness_on = 5
 
-
 /obj/item/device/flashlight/lamp/verb/toggle_light()
 	set name = "Toggle light"
 	set category = "Object"
@@ -224,6 +228,8 @@
 
 	if(!usr.stat)
 		attack_self(usr)
+		return TRUE
+	return FALSE
 
 // FLARES
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -229,7 +229,7 @@
 	if(!Adjacent(usr))
 		return
 
-	if(usr.incapacitated() || usr.stat) //Checks for stuns, ghost, restraint, and being awake.
+	if(usr.incapacitated()) //Checks for stuns, ghost, restraint, and being awake.
 		return
 
 	if(usr.has_hand_check())


### PR DESCRIPTION
This makes it so you can turn a lamp on and off via alt-click, so you don't have to use the Object tab verb or pick it up first. Note that this only applies to lamps, and not flashlights. Also makes it so you need a free hand to do so, or something that serves as a hand, like a corgi mouth—the same criteria as for pulling.

:cl:
 * rscadd: Lamps can be turned on or off via alt-click.
 * tweak: Only creatures with a free hand can turn lamps on or off.

