### PR TITLE
Fixes armor calculation runtime with non-clothing items

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -108,10 +108,11 @@ emp_act
 			var/obj/item/C = bp
 			if(C.body_parts_covered & def_zone.body_part)
 				protection += C.get_armor(type)
-			var/obj/item/clothing/CC = C
-			for(var/obj/item/clothing/accessory/A in CC.accessories)
-				if(A.body_parts_covered & def_zone.body_part)
-					protection += A.get_armor(type)
+			if(istype(C, /obj/item/clothing))
+				var/obj/item/clothing/CC = C
+				for(var/obj/item/clothing/accessory/A in CC.accessories)
+					if(A.body_parts_covered & def_zone.body_part)
+						protection += A.get_armor(type)
 	if(istype(loc, /obj/mecha))
 		var/obj/mecha/M = loc
 		protection += M.rad_protection
@@ -127,10 +128,11 @@ emp_act
 			var/obj/item/C = bp
 			if(C.body_parts_covered & def_zone.body_part)
 				protection += C.get_armor_absorb(type)
-			var/obj/item/clothing/CC = C
-			for(var/obj/item/clothing/accessory/A in CC.accessories)
-				if(A.body_parts_covered & def_zone.body_part)
-					protection += A.get_armor_absorb(type)
+			if(istype(C, /obj/item/clothing))
+				var/obj/item/clothing/CC = C
+				for(var/obj/item/clothing/accessory/A in CC.accessories)
+					if(A.body_parts_covered & def_zone.body_part)
+						protection += A.get_armor_absorb(type)
 	return protection
 
 


### PR DESCRIPTION
This fixes a runtime where worn non-clothing items were being checked for accessories during armor calculations, despite not having `accessories` defined as a var. Now it will only check for accessories if it is an `obj/item/clothing`.

:cl:
 * bugfix: Fixed issue with armor calculation for worn non-clothing items.