### PR TITLE
The "Centre of mass doctrine" PR

### DIFF
--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -38,15 +38,15 @@
 		else
 			var/idle_time = world.time - last_moved
 			switch (idle_time)
-			if (-9999 to 2 SECONDS)
-				target_zone = get_zone_with_miss_chance(def_zone, src)
-			if (2 SECONDS to 5 SECONDS)
-				if (prob(50))
+				if (-9999 to 2 SECONDS)
 					target_zone = get_zone_with_miss_chance(def_zone, src)
+				if (2 SECONDS to 5 SECONDS)
+					if (prob(50))
+						target_zone = get_zone_with_miss_chance(def_zone, src)
+					else
+						target_zone = def_zone
 				else
 					target_zone = def_zone
-			else
-				target_zone = def_zone
 	else if(originator)
 		if(ismob(originator))
 			var/mob/M = originator

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -33,7 +33,20 @@
 	if (crit)
 		power *= CRIT_MULTIPLIER
 	if(def_zone)
-		target_zone = get_zone_with_miss_chance(def_zone, src)
+		if (crit || restrained())
+			target_zone = def_zone
+		else
+			var/idle_time = world.time - last_moved
+			switch (idle_time)
+			if (-9999 to 2 SECONDS)
+				target_zone = get_zone_with_miss_chance(def_zone, src)
+			if (2 SECONDS to 5 SECONDS)
+				if (prob(50))
+					target_zone = get_zone_with_miss_chance(def_zone, src)
+				else
+					target_zone = def_zone
+			else
+				target_zone = def_zone
 	else if(originator)
 		if(ismob(originator))
 			var/mob/M = originator

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -194,21 +194,21 @@
 			if(LIMB_HEAD)
 				miss_chance = 40
 			if(LIMB_LEFT_LEG, LIMB_RIGHT_LEG, LIMB_RIGHT_ARM, LIMB_LEFT_ARM)
-				miss_chance = 40
+				miss_chance = 60
 				if (miss_chance_mod < 0)
 					miss_chance_mod *= 0.5
 			if(LIMB_LEFT_HAND, LIMB_RIGHT_HAND, LIMB_LEFT_FOOT, LIMB_RIGHT_FOOT)
-				miss_chance = 60
+				miss_chance = 90
 				if (miss_chance_mod < 0)
 					miss_chance_mod *= 0.2
 		miss_chance = max(miss_chance + miss_chance_mod, 0)
 		if(prob(miss_chance))
 			var/fully_miss = 70
 			switch(zone)
-				if(LIMB_HEAD)
+				if(LIMB_HEAD, LIMB_LEFT_LEG, LIMB_RIGHT_LEG, LIMB_RIGHT_ARM, LIMB_LEFT_ARM)
 					fully_miss = 70
 				else
-					fully_miss = 95
+					fully_miss = 50
 			if(prob(fully_miss))
 				return null
 			else

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -184,31 +184,32 @@
 /proc/get_zone_with_miss_chance(zone, var/mob/target, var/miss_chance_mod = 0)
 	zone = check_zone(zone)
 
+	if (!isnum(miss_chance_mod))
+		miss_chance_mod = 0
+
 	// you can only miss if your target is standing and not restrained
 	if(!target.locked_to && !target.lying)
 		var/miss_chance = 10
 		switch(zone)
 			if(LIMB_HEAD)
 				miss_chance = 40
-			if(LIMB_LEFT_LEG)
-				miss_chance = 20
-			if(LIMB_RIGHT_LEG)
-				miss_chance = 20
-			if(LIMB_LEFT_ARM)
-				miss_chance = 20
-			if(LIMB_RIGHT_ARM)
-				miss_chance = 20
-			if(LIMB_LEFT_HAND)
-				miss_chance = 50
-			if(LIMB_RIGHT_HAND)
-				miss_chance = 50
-			if(LIMB_LEFT_FOOT)
-				miss_chance = 50
-			if(LIMB_RIGHT_FOOT)
-				miss_chance = 50
+			if(LIMB_LEFT_LEG, LIMB_RIGHT_LEG, LIMB_RIGHT_ARM, LIMB_LEFT_ARM)
+				miss_chance = 40
+				if (miss_chance_mod < 0)
+					miss_chance_mod *= 0.5
+			if(LIMB_LEFT_HAND, LIMB_RIGHT_HAND, LIMB_LEFT_FOOT, LIMB_RIGHT_FOOT)
+				miss_chance = 60
+				if (miss_chance_mod < 0)
+					miss_chance_mod *= 0.2
 		miss_chance = max(miss_chance + miss_chance_mod, 0)
 		if(prob(miss_chance))
-			if(prob(70))
+			var/fully_miss = 70
+			switch(zone)
+				if(LIMB_HEAD)
+					fully_miss = 70
+				else
+					fully_miss = 95
+			if(prob(fully_miss))
 				return null
 			else
 				var/t = rand(1, 10)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -282,7 +282,7 @@ var/list/impact_master = list()
 			var/mob/living/carbon/shot_at = A
 			if (istype(A))
 				if(target_zone)
-					if (shot_at.stat || target_zone.restrained())
+					if (shot_at.stat || shot_at.restrained())
 						def_zone = target_zone
 					else
 						var/idle_time = world.time - shot_at.last_moved

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -278,7 +278,24 @@ var/list/impact_master = list()
 				miss_modifier += 8*distance
 				miss_modifier += (abs(miss_modifier))
 
-			def_zone = get_zone_with_miss_chance(def_zone, M, miss_modifier)
+			var/target_zone = def_zone
+			var/mob/living/carbon/shot_at = A
+			if (istype(A))
+				if(target_zone)
+					if (shot_at.stat || target_zone.restrained())
+						def_zone = target_zone
+					else
+						var/idle_time = world.time - shot_at.last_moved
+						switch (idle_time)
+							if (-9999 to 2 SECONDS)
+								def_zone = get_zone_with_miss_chance(target_zone, src)
+							if (2 SECONDS to 5 SECONDS)
+								if (prob(50))
+									def_zone = get_zone_with_miss_chance(target_zone, src)
+								else
+									def_zone = target_zone
+							else
+								def_zone = target_zone
 
 		if(!def_zone)
 			visible_message("<span class='notice'>\The [src] misses [M] narrowly!</span>")


### PR DESCRIPTION
## Background

I got told on discord that #32779 was more or less intended to discourage or at least, mitigate evil POWERGAMERS targetting unarmoured outer limbs (such as hands or feet) as they were unarmoured and as such would be more likely to give you the full damage output.

This is especially true in melee fight when you're fighting, say, the HoS with an absurdly high armour score on the head, but nothing on the feet and hands.

I actually know at least **3** (three!) people who knew about this and, at times, "abused" it (especially for melee combat) and as such it's not as theoretical as it might sound in the first place.

To fix this *properly* this PR raises the chances to miss when aiming to the limbs by quite a bit.

## Numbers changed

Format : Ballistic+Melee/Laser (intended target% + other limb%)

Head : untouched

Legs, arms :
- Before : 86/110% chance to hit the target (!!!!) (80% intended target + 6% other limb/80% + 30% laser rifle bonus, so always intended target)
- Now : 58%/68% (40% + 18% / 55% + 13%, laser bonus included)

Hands, feet :
- Before : 65%/86% (50% + 15% / 80% + 6%)
- Now : 55%/58% (10% + 45% / 16% + 42%, so lots of chance to hit something else)

In short you will be more likely to miss, but you will only occasionally not hit anything at all. Most likely, you will not hit what you intend to when not targetting the centre of mass.

## Discussion

I realised, however, that it would make a lot of execution less funny if the HoS tried to shot at the guy in the feet for an example but failed again and again to do so. (I mean it *would* be funny but a bit unexpected and get old after a while). Which is why you will *always* hit the target if the mob has been idle for more than 5 seconds, and will have a 50% chance of landing a perfect shot if they have been idle more than 2 seconds and less than 5.

This might make the Nicholas Blaine type even more jumpy and try to keep that sweet less-than-two-seconds advantage, but frankly : 

a) it's funny
b) they are getting more targetted by this PR removing a less-than-known powergaming tactic to maximise DPS
c) it's very noticeable to refuse to stay idle for more than 2 seconds at a time so, in the end, they get more attention from admins and that's probably something they should avoid.

It is very much a small combat rework, particularly the part about the "shooting first" bonus, so feel free to give your thoughts.

## Recap

:cl:
- tweak: Aiming at the hands, legs, arms or feet is now more likely to miss or hit another body limb.
- tweak: You will always hit the limb you are targetting against a target that has been idle for the last 5 seconds.