### PR TITLE
Robustharvest weed rate too high

### DIFF
--- a/code/modules/hydroponics/hydro_tray_process.dm
+++ b/code/modules/hydroponics/hydro_tray_process.dm
@@ -24,7 +24,7 @@
 
 	// There's a chance for a weed explosion to happen if the weeds take over.
 	// Plants that are themselves weeds (weed_tolerance > 80) are unaffected.
-	if (get_weedlevel() > WEEDLEVEL_MAX/5 && prob(10))
+	if (get_weedlevel() == WEEDLEVEL_MAX && prob(10))
 		if(!seed || get_weedlevel() >= seed.weed_tolerance + 20)
 			weed_invasion()
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2502,9 +2502,9 @@
 	..()
 	T.add_nutrientlevel(1)
 	if(prob(25*custom_plant_metabolism))
-		T.add_weedlevel(3)
+		T.add_weedlevel(10)
 	if(T.seed && !T.dead && prob(25*custom_plant_metabolism))
-		T.add_pestlevel(3)
+		T.add_pestlevel(10)
 	if(T.seed && !T.dead && !T.seed.immutable)
 		var/chance
 		chance = unmix(T.seed.potency, 15, 150)*350*custom_plant_metabolism


### PR DESCRIPTION
[hotfix][bugfix][tweak][balance]
Accidentally made the weed rate too high
## What this does
- Weed overtaking doesn't happen so soon

## Why it's good
Maintains the same rate prior to my hydroponics PRs

:cl:
 * bugfix: Weeds shouldn't overtake as fast

