### PR TITLE
Improved Admin Logging on Field Generator Failure

### DIFF
--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -304,6 +304,6 @@ var/global/list/obj/machinery/field_generator/field_gen_list = list()
 			if(O.last_warning && temp)
 				if((world.time - O.last_warning) > 50) //to stop message-spam
 					temp = 0
-					message_admins("A singulo exists and a containment field has failed.",1)
+					message_admins("A singulo exists and a containment field has failed. ([O.x],[O.y],[O.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[O.x];Y=[O.y];Z=[O.z]'>JMP</a>)",1)
 					investigation_log(I_SINGULO,"has <font color='red'>failed</font> whilst a singulo exists.")
 			O.last_warning = world.time


### PR DESCRIPTION
[administration]
## What this does
Whenever a field generator fails with any existing singulo(s), the admin message generated now contains a hyperlink to jump to that singulo's coordinates.

Closes #25120

## Why it's good
May help protect the sanity of admins when responding to looses in real-time. Previously, they could only teleport to nearby emitters that got deleted.