### PR TITLE
Hide Shunted AI Copies from OOC Manifest

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -101,6 +101,8 @@
 	// sort mobs
 	if(OOC)
 		for(var/mob/living/silicon/ai/dooropener in mob_list)
+			if(dooropener.parent) //Hide shunted AI APC Copies from view.
+				continue
 			bot[dooropener.name] = "AI"
 			isactive[dooropener.name] = (dooropener.client && dooropener.client.inactivity <= 10 * 60 * 10) ? "Active" : "Inactive"
 		for(var/mob/living/silicon/robot/tincan in mob_list)


### PR DESCRIPTION
[bugfix][exploitable]
_Imagine playing malf._
## What this does
Prevents shunted APC Copies of malfunctioning AIs from appearing in the OOC crew manifest (early/latejoin and observers). 
They are already hidden from normal manifests.

Closes #31071

## Why it's good
Latejoin nerds won't accidentally spoil the gamemode for themselves and irreparably shatter their immulsions simply by opening the crew manifest.

## Changelog
:cl:
 * bugfix: Shunted APC copies of malfunctioning AIs will no longer appear in the crew manifest under certain conditions.

