### PR TITLE
Fixes duplicate args

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -298,7 +298,7 @@
 	to_chat(viewers(user), "<span class='danger'>[user] is smashing his face with \the [src.name]! It looks like \he's trying to commit suicide.</span>")
 	return(SUICIDE_ACT_BRUTELOSS)
 
-/obj/item/weapon/melee/bone_hammer/afterattack(null, mob/living/user as mob|obj, null, null, null)
+/obj/item/weapon/melee/bone_hammer/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	user.delayNextAttack(50) //five times the regular attack delay
 
 /obj/item/weapon/melee/bone_hammer/New(atom/A, var/p_borer = null)

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -97,7 +97,7 @@
 	to_chat(user, "<span class = 'warning'>There is no engine within range of \the [src] it can connect to.</span>")
 	return FALSE
 
-/obj/structure/shuttle/engine/heater/DIY/wrenchAnchor(var/mob/user, var/obj/item/I, var/obj/item/I, var/time_to_wrench = 3 SECONDS)
+/obj/structure/shuttle/engine/heater/DIY/wrenchAnchor(var/mob/user, var/obj/item/I, var/time_to_wrench = 3 SECONDS)
 	.=..()
 	if(.)
 		if(!anchored)
@@ -150,7 +150,7 @@
 		return wrenchAnchor(user, I, 5 SECONDS)
 	return ..()
 
-/obj/structure/shuttle/engine/propulsion/DIY/wrenchAnchor(var/mob/user, var/obj/item/I, var/obj/item/I, var/time_to_wrench = 3 SECONDS)
+/obj/structure/shuttle/engine/propulsion/DIY/wrenchAnchor(var/mob/user, var/obj/item/I, var/time_to_wrench = 3 SECONDS)
 	.=..()
 	if(.)
 		if(!anchored)

--- a/code/modules/projectiles/guns/projectile/constructable/swords.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/swords.dm
@@ -249,7 +249,7 @@
 	hitsound = "sound/weapons/smash.ogg"
 	var/complete = 0
 
-/obj/item/weapon/sword/executioner/afterattack(null, mob/living/user as mob|obj, null, null, null)
+/obj/item/weapon/sword/executioner/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(complete)
 		user.delayNextAttack(30) //thrice the regular attack delay
 

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -370,14 +370,14 @@
 /obj/item/projectile/fire_breath/straight
 	fire_blast_type = /obj/effect/fire_blast/no_spread
 
-/obj/item/projectile/fire_breath/New(turf/T, var/direction, var/F_Dam, var/P, var/T, var/F_Dur)
+/obj/item/projectile/fire_breath/New(turf/T, var/direction, var/F_Dam, var/P, var/Temp, var/F_Dur)
 	..(T,direction)
 	if(F_Dam)
 		fire_damage = F_Dam
 	if(P)
 		pressure = P
-	if(T)
-		temperature = T
+	if(Temp)
+		temperature = Temp
 	if(F_Dur)
 		fire_duration = F_Dur
 


### PR DESCRIPTION
It [seems](http://www.byond.com/forum/post/2637941) that BYOND doesn't error properly when you have two args of the same name in a proc definition. This fixes the cases of duplicate proc args that I could find.

This also occured in a few places where multiple args named `null` were being passed into proc overrides, seemingly with the intention of having the args being null.