### PR TITLE
Fixes non-constant expression in switch block.

### DIFF
--- a/code/modules/cmc/crew.dm
+++ b/code/modules/cmc/crew.dm
@@ -273,6 +273,8 @@ GENERAL PROCS
 		health += dam
 	health = round(100 - health)
 	switch (health)
+		if(100)
+			return "0"
 		if(80 to 99)
 			return "1"
 		if(60 to 79)
@@ -281,10 +283,8 @@ GENERAL PROCS
 			return "3"
 		if(20 to 39)
 			return "4"
-		else if(health != 100)
-			return "5"
 		else
-			return "0"
+			return "5"
 
 /*
 HOLOMAP PROCS


### PR DESCRIPTION
This fixes a non-constant expression, and an improper usage of `else if`, in a switch block in the CMC code, errors not caught by the BYOND compiler. 