### PR TITLE
Changes improper usage of input() to alert()

### DIFF
--- a/code/modules/randomMaps/special.dm
+++ b/code/modules/randomMaps/special.dm
@@ -175,7 +175,7 @@
 			height = 0
 			return
 
-		overwriting = input(usr, "Do you want these vaults to overwrite their area?", "Vault Overwriting", "Yes", "No") == "Yes"
+		overwriting = alert(usr, "Do you want these vaults to overwrite their area?", "Vault Overwriting", "Yes", "No") == "Yes"
 
 /datum/map_element/customizable/vault_placement/initialize()
 	if(!location)


### PR DESCRIPTION
This changes an improper usage (with too many args) of `input()`, which lets the user type in a value,  to `alert()`, which lets the user select from a set of buttons.
