### PR TITLE
Avoid interacting with a BYOND bug relating to icon not being passed to a local static var properly

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -121,26 +121,22 @@
 	return
 
 /obj/machinery/portable_atmospherics/canister/proc/pressure_overlays(var/state)
-	var/overlayiconstate
-	switch(state)
-		if(1)
-			overlayiconstate = "can-o0"
-		if(2)
-			overlayiconstate = "can-o1"
-		if(3)
-			overlayiconstate = "can-o2"
-		if(4)
-			overlayiconstate = "can-o3"
-	return image(icon, overlayiconstate)
+	var/static/list/status_overlays_pressure = list(
+		image(null, "can-o0"),
+		image(null, "can-o1"),
+		image(null, "can-o2"),
+		image(null, "can-o3")
+	)
+
+	return status_overlays_pressure[state]
 
 /obj/machinery/portable_atmospherics/canister/proc/other_overlays(var/state)
-	var/overlayiconstate
-	switch(state)
-		if(1)
-			overlayiconstate = "can-open"
-		if(2)
-			overlayiconstate = "can-connector"
-	return image(icon, overlayiconstate)
+	var/static/list/status_overlays_other = list(
+		image(null, "can-open"),
+		image(null, "can-connector")
+	)
+
+	return status_overlays_other[state]
 
 /obj/machinery/portable_atmospherics/canister/proc/check_updates(tank_pressure = 0)
 	if((overlay_status & OVERLAY_HOLDING) != holding)

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -122,18 +122,18 @@
 
 /obj/machinery/portable_atmospherics/canister/proc/pressure_overlays(var/state)
 	var/static/list/status_overlays_pressure = list(
-		image(null, "can-o0"),
-		image(null, "can-o1"),
-		image(null, "can-o2"),
-		image(null, "can-o3")
+		image('icons/obj/atmos.dmi', "can-o0"),
+		image('icons/obj/atmos.dmi', "can-o1"),
+		image('icons/obj/atmos.dmi', "can-o2"),
+		image('icons/obj/atmos.dmi', "can-o3")
 	)
 
 	return status_overlays_pressure[state]
 
 /obj/machinery/portable_atmospherics/canister/proc/other_overlays(var/state)
 	var/static/list/status_overlays_other = list(
-		image(null, "can-open"),
-		image(null, "can-connector")
+		image('icons/obj/atmos.dmi', "can-open"),
+		image('icons/obj/atmos.dmi', "can-connector")
 	)
 
 	return status_overlays_other[state]

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -131,7 +131,7 @@
 			overlayiconstate = "can-o2"
 		if(4)
 			overlayiconstate = "can-o3"
-	return image('icons/obj/atmos.dmi', overlayiconstate)
+	return image(icon, overlayiconstate)
 
 /obj/machinery/portable_atmospherics/canister/proc/other_overlays(var/state)
 	var/overlayiconstate
@@ -140,7 +140,7 @@
 			overlayiconstate = "can-open"
 		if(2)
 			overlayiconstate = "can-connector"
-	return image('icons/obj/atmos.dmi', overlayiconstate)
+	return image(icon, overlayiconstate)
 
 /obj/machinery/portable_atmospherics/canister/proc/check_updates(tank_pressure = 0)
 	if((overlay_status & OVERLAY_HOLDING) != holding)

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -122,7 +122,7 @@
 
 /obj/machinery/portable_atmospherics/canister/proc/pressure_overlays(var/state)
 	var/static/list/status_overlays_pressure = list(
-		image('icons/obj/atmos.dmi', "can-o0"),
+		image('icons/obj/atmos.dmi', "can-o0"), //Should be able to use icon as an arg here, but BYOND makes it null for some reason. null actually works fine here though because it uses src.icon by default. But for the sake of clarity we'll keep the explicit path here for now. Same situation with the vintage canisters randomvaults/objects.dm.
 		image('icons/obj/atmos.dmi', "can-o1"),
 		image('icons/obj/atmos.dmi', "can-o2"),
 		image('icons/obj/atmos.dmi', "can-o3")

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -33,10 +33,7 @@
 	melt_temperature = MELTPOINT_STEEL
 
 	//Icon Update Code
-	var/global/list/status_overlays_pressure = list()
-	var/global/list/status_overlays_other = list()
 	var/overlay_status = 0
-
 	var/log="" // Bad boys, bad boys.
 
 /obj/machinery/portable_atmospherics/canister/New()
@@ -124,22 +121,26 @@
 	return
 
 /obj/machinery/portable_atmospherics/canister/proc/pressure_overlays(var/state)
-	var/static/list/status_overlays_pressure = list(
-		image(icon, "can-o0"),
-		image(icon, "can-o1"),
-		image(icon, "can-o2"),
-		image(icon, "can-o3")
-	)
-
-	return status_overlays_pressure[state]
+	var/overlayiconstate
+	switch(state)
+		if(1)
+			overlayiconstate = "can-o0"
+		if(2)
+			overlayiconstate = "can-o1"
+		if(3)
+			overlayiconstate = "can-o2"
+		if(4)
+			overlayiconstate = "can-o3"
+	return image('icons/obj/atmos.dmi', overlayiconstate)
 
 /obj/machinery/portable_atmospherics/canister/proc/other_overlays(var/state)
-	var/static/list/status_overlays_other = list(
-		image(icon, "can-open"),
-		image(icon, "can-connector")
-	)
-
-	return status_overlays_other[state]
+	var/overlayiconstate
+	switch(state)
+		if(1)
+			overlayiconstate = "can-open"
+		if(2)
+			overlayiconstate = "can-connector"
+	return image('icons/obj/atmos.dmi', overlayiconstate)
 
 /obj/machinery/portable_atmospherics/canister/proc/check_updates(tank_pressure = 0)
 	if((overlay_status & OVERLAY_HOLDING) != holding)

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -122,7 +122,7 @@
 
 /obj/machinery/portable_atmospherics/canister/proc/pressure_overlays(var/state)
 	var/static/list/status_overlays_pressure = list(
-		image('icons/obj/atmos.dmi', "can-o0"), //Should be able to use icon as an arg here, but BYOND makes it null for some reason. null actually works fine here though because it uses src.icon by default. But for the sake of clarity we'll keep the explicit path here for now. Same situation with the vintage canisters randomvaults/objects.dm.
+		image('icons/obj/atmos.dmi', "can-o0"), //Should be able to use icon as an arg here, but BYOND (as of v514) makes it null for some reason. null actually works fine here though because it uses src.icon by default. But for the sake of clarity we'll keep the explicit path here for now. Same situation with the vintage canisters in randomvaults/objects.dm.
 		image('icons/obj/atmos.dmi', "can-o1"),
 		image('icons/obj/atmos.dmi', "can-o2"),
 		image('icons/obj/atmos.dmi', "can-o3")

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -572,7 +572,7 @@
 			overlayiconstate = "old-o2"
 		if(4)
 			overlayiconstate = "old-o3"
-	return image('icons/obj/atmos.dmi', overlayiconstate)
+	return image(icon, overlayiconstate)
 
 /obj/machinery/portable_atmospherics/canister/old/other_overlays(var/state)
 	var/overlayiconstate
@@ -581,7 +581,7 @@
 			overlayiconstate = "old-open"
 		if(2)
 			overlayiconstate = "old-connector"
-	return image('icons/obj/atmos.dmi', overlayiconstate)
+	return image(icon, overlayiconstate)
 
 
 /obj/machinery/portable_atmospherics/canister/old/process()

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -562,22 +562,27 @@
 	volume = 50000
 
 /obj/machinery/portable_atmospherics/canister/old/pressure_overlays(var/state)
-	var/static/list/status_overlays_pressure = list(
-		image(icon, "old-o0"),
-		image(icon, "old-o1"),
-		image(icon, "old-o2"),
-		image(icon, "old-o3")
-	)
-
-	return status_overlays_pressure[state]
+	var/overlayiconstate
+	switch(state)
+		if(1)
+			overlayiconstate = "old-o0"
+		if(2)
+			overlayiconstate = "old-o1"
+		if(3)
+			overlayiconstate = "old-o2"
+		if(4)
+			overlayiconstate = "old-o3"
+	return image('icons/obj/atmos.dmi', overlayiconstate)
 
 /obj/machinery/portable_atmospherics/canister/old/other_overlays(var/state)
-	var/static/list/status_overlays_other = list(
-		image(icon, "old-open"),
-		image(icon, "old-connector")
-	)
+	var/overlayiconstate
+	switch(state)
+		if(1)
+			overlayiconstate = "old-open"
+		if(2)
+			overlayiconstate = "old-connector"
+	return image('icons/obj/atmos.dmi', overlayiconstate)
 
-	return status_overlays_other[state]
 
 /obj/machinery/portable_atmospherics/canister/old/process()
 	..()

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -562,27 +562,22 @@
 	volume = 50000
 
 /obj/machinery/portable_atmospherics/canister/old/pressure_overlays(var/state)
-	var/overlayiconstate
-	switch(state)
-		if(1)
-			overlayiconstate = "old-o0"
-		if(2)
-			overlayiconstate = "old-o1"
-		if(3)
-			overlayiconstate = "old-o2"
-		if(4)
-			overlayiconstate = "old-o3"
-	return image(icon, overlayiconstate)
+	var/static/list/status_overlays_pressure = list(
+		image(null, "old-o0"),
+		image(null, "old-o1"),
+		image(null, "old-o2"),
+		image(null, "old-o3")
+	)
+
+	return status_overlays_pressure[state]
 
 /obj/machinery/portable_atmospherics/canister/old/other_overlays(var/state)
-	var/overlayiconstate
-	switch(state)
-		if(1)
-			overlayiconstate = "old-open"
-		if(2)
-			overlayiconstate = "old-connector"
-	return image(icon, overlayiconstate)
+	var/static/list/status_overlays_other = list(
+		image(null, "old-open"),
+		image(null, "old-connector")
+	)
 
+	return status_overlays_other[state]
 
 /obj/machinery/portable_atmospherics/canister/old/process()
 	..()

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -563,18 +563,18 @@
 
 /obj/machinery/portable_atmospherics/canister/old/pressure_overlays(var/state)
 	var/static/list/status_overlays_pressure = list(
-		image(null, "old-o0"),
-		image(null, "old-o1"),
-		image(null, "old-o2"),
-		image(null, "old-o3")
+		image('icons/obj/atmos.dmi', "old-o0"),
+		image('icons/obj/atmos.dmi', "old-o1"),
+		image('icons/obj/atmos.dmi', "old-o2"),
+		image('icons/obj/atmos.dmi', "old-o3")
 	)
 
 	return status_overlays_pressure[state]
 
 /obj/machinery/portable_atmospherics/canister/old/other_overlays(var/state)
 	var/static/list/status_overlays_other = list(
-		image(null, "old-open"),
-		image(null, "old-connector")
+		image('icons/obj/atmos.dmi', "old-open"),
+		image('icons/obj/atmos.dmi', "old-connector")
 	)
 
 	return status_overlays_other[state]


### PR DESCRIPTION
This fixes the canister pressure indicator and connector overlays trying to pass their `icon` into the definitions of static/global vars, but failing to because of a bug in BYOND. This results in `icon` being treated as `null`, causing `image()` to inherit the icon from the canisters (atmos.dmi) by default, masking the bug. This PR avoids interacting with this bug by using explicit paths.