### PR TITLE
Removes global map multiZ variable, makes checks more dynamic

### DIFF
--- a/__DEFINES/rcd.dm
+++ b/__DEFINES/rcd.dm
@@ -4,3 +4,5 @@
 #define RCD_RANGE        4  // Use range() instead of adjacency. (old RPD behaviour.) (overriden by RCD_SELF_SANE)
 #define RCD_SELF_COST    8  // Handle energy usage ourselves. (energy availability still checked).
 #define RCD_ALLOW_SWITCH 16 // Allow schematic to be switched even if this one is currently in use.
+#define RCD_Z_UP		 32 // Must have Z level above to use
+#define RCD_Z_DOWN 		 64 // Must have Z level below to use

--- a/code/ATMOSPHERICS/pipe/pipe_dispenser.dm
+++ b/code/ATMOSPHERICS/pipe/pipe_dispenser.dm
@@ -34,11 +34,11 @@
 	interact(user)
 
 /obj/machinery/pipedispenser/interact(mob/user)
-	var/multi_z_dat = map.multiz ? {"
+	var/multi_z_dat = HasAbove(z) || HasBelow(z) ? {"
 <b>Multi-floor pipes:</b>
 <ul>
-	<li><a href='?src=\ref[src];make=[PIPE_Z_UP];dir=1'>Up Pipe</a></li>
-	<li><a href='?src=\ref[src];make=[PIPE_Z_DOWN];dir=1'>Down Pipe</a></li>
+	[HasAbove(z) ? "<li><a href='?src=\ref[src];make=[PIPE_Z_UP];dir=1'>Up Pipe</a></li>" : ""]
+	[HasBelow(z) ? "<li><a href='?src=\ref[src];make=[PIPE_Z_DOWN];dir=1'>Down Pipe</a></li>" : ""]
 </ul>"} : ""
 	var/dat = {"
 <b>Regular pipes:</b>

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -132,11 +132,10 @@
 			condition |= M.x > src.x
 		if(req_access_dir & WEST)
 			condition |= M.x < src.x
-		if(map.multiz)
-			if(req_access_dir & UP)
-				condition |= M.z > src.z
-			if(req_access_dir & DOWN)
-				condition |= M.z < src.z
+		if(HasAbove(z) && (req_access_dir & UP))
+			condition |= M.z > src.z
+		if(HasBelow(z) && (req_access_dir & DOWN))
+			condition |= M.z < src.z
 		if(condition)
 			return can_access(ACL,req_access,req_one_access)
 		else

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -55,8 +55,6 @@
 
 /obj/item/stack/sheet/metal/New(var/loc, var/amount=null)
 	recipes = metal_recipes
-	if(map.multiz)
-		recipes.Add(new/datum/stack_recipe("multi-floor stairs",   /obj/structure/stairs_frame, 4, time = 100, one_per_turf = 1, on_floor = 1))
 	return ..()
 
 /*

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -77,6 +77,8 @@
 
 		if(istype(E, /datum/stack_recipe))
 			var/datum/stack_recipe/R = E
+			if((R.z_up_required && !HasAbove(z)) || (R.z_down_required && !HasBelow(z)))
+				continue
 			var/max_multiplier = round(src.amount / R.req_amount)
 			var/title
 			var/can_build = 1

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -78,7 +78,7 @@
 		if(istype(E, /datum/stack_recipe))
 			var/datum/stack_recipe/R = E
 			var/turf/T = get_turf(src)
-			if((R.z_up_required && !HasAbove(T.z)) || (R.z_down_required && !HasBelow(T.z)))
+			if(!T || (R.z_up_required && !HasAbove(T.z)) || (R.z_down_required && !HasBelow(T.z)))
 				continue
 			var/max_multiplier = round(src.amount / R.req_amount)
 			var/title

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -77,7 +77,8 @@
 
 		if(istype(E, /datum/stack_recipe))
 			var/datum/stack_recipe/R = E
-			if((R.z_up_required && !HasAbove(z)) || (R.z_down_required && !HasBelow(z)))
+			var/turf/T = get_turf(src)
+			if((R.z_up_required && !HasAbove(T.z)) || (R.z_down_required && !HasBelow(T.z)))
 				continue
 			var/max_multiplier = round(src.amount / R.req_amount)
 			var/title

--- a/code/game/objects/items/stacks/stack_recipes.dm
+++ b/code/game/objects/items/stacks/stack_recipes.dm
@@ -12,9 +12,11 @@
 	var/one_per_turf = 0
 	var/on_floor = 0
 	var/start_unanchored = 0
+	var/z_up_required = 0
+	var/z_down_required = 0
 	var/list/other_reqs = list()
 
-/datum/stack_recipe/New(title, result_type, req_amount = 1, res_amount = 1, max_res_amount = 1, time = 0, one_per_turf = 0, on_floor = 0, start_unanchored = 0, other_reqs = list())
+/datum/stack_recipe/New(title, result_type, req_amount = 1, res_amount = 1, max_res_amount = 1, time = 0, one_per_turf = 0, on_floor = 0, start_unanchored = 0, other_reqs = list(), z_up_required = 0, z_down_required = 0)
 	src.title = title
 	src.result_type = result_type
 	src.req_amount = req_amount
@@ -25,6 +27,8 @@
 	src.on_floor = on_floor
 	src.start_unanchored = start_unanchored
 	src.other_reqs = other_reqs
+	src.z_up_required = z_up_required
+	src.z_down_required = z_down_required
 
 /datum/stack_recipe/proc/can_build_here(var/mob/usr, var/turf/T)
 	if(one_per_turf && locate(result_type) in T)
@@ -261,6 +265,7 @@ var/list/datum/stack_recipe/metal_recipes = list (
 	null,
 	new/datum/stack_recipe("computer frame", /obj/structure/computerframe,                      5, time = 25, one_per_turf = 1			    ),
 	new/datum/stack_recipe("wall girders",   /obj/structure/girder,                             2, time = 50, one_per_turf = 1, on_floor = 1),
+	new/datum/stack_recipe("multi-floor stairs",   /obj/structure/stairs_frame, 4, time = 100, one_per_turf = 1, on_floor = 1, z_up_required = 1),
 	new/datum/stack_recipe("railings",   /obj/structure/railing/loose,             				2, time = 25, on_floor = 1),
 	new/datum/stack_recipe("firelock frame", /obj/item/firedoor_frame,                          5, time = 50),
 	new/datum/stack_recipe("machine frame",  /obj/machinery/constructable_frame/machine_frame,  5, time = 25, one_per_turf = 1, on_floor = 1),

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -23,6 +23,7 @@
 	// Make sparks. LOTS OF SPARKS.
 	var/sparky          = TRUE
 
+	var/z_last_checked	= 0
 	// A list schematics can use for storing mutual data.
 	var/list/data
 
@@ -45,6 +46,10 @@
 
 	init_schematics()
 	rebuild_ui()
+
+	var/turf/T = get_turf(src)
+	if(T)
+		z_last_checked = T.z
 
 //create and organize the schematics
 /obj/item/device/rcd/proc/init_schematics()
@@ -78,6 +83,9 @@
 		dropped_by.hud_used.toggle_show_schematics_display(null,1, src)
 
 /obj/item/device/rcd/attack_self(var/mob/user)
+	var/turf/T = get_turf(src)
+	if(T?.z != z_last_checked)
+		rebuild_ui()
 	interface.show(user)
 
 /obj/item/device/rcd/proc/rebuild_ui()
@@ -96,7 +104,7 @@
 		var/list/L = schematics[cat]
 		for(var/datum/rcd_schematic/C in L)
 			var/turf/T = get_turf(src)
-			if(((C.flags & RCD_Z_DOWN) && !HasBelow(T.z)) || ((C.flags & RCD_Z_UP) && !HasAbove(T.z)))
+			if(!T || ((C.flags & RCD_Z_DOWN) && !HasBelow(T.z)) || ((C.flags & RCD_Z_UP) && !HasAbove(T.z)))
 				continue
 			dat += C.schematic_list_line(interface)
 

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -95,7 +95,8 @@
 		dat += "<b>[cat]:</b><ul style='list-style-type:disc'>"
 		var/list/L = schematics[cat]
 		for(var/datum/rcd_schematic/C in L)
-			if(((C.flags & RCD_Z_DOWN) && !HasBelow(z)) || ((C.flags & RCD_Z_UP) && !HasAbove(z)))
+			var/turf/T = get_turf(src)
+			if(((C.flags & RCD_Z_DOWN) && !HasBelow(T.z)) || ((C.flags & RCD_Z_UP) && !HasAbove(T.z)))
 				continue
 			dat += C.schematic_list_line(interface)
 

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -95,6 +95,8 @@
 		dat += "<b>[cat]:</b><ul style='list-style-type:disc'>"
 		var/list/L = schematics[cat]
 		for(var/datum/rcd_schematic/C in L)
+			if(((C.flags & RCD_Z_DOWN) && !HasBelow(z)) || ((C.flags & RCD_Z_UP) && !HasAbove(z)))
+				continue
 			dat += C.schematic_list_line(interface)
 
 		dat += "</ul>"

--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -29,6 +29,8 @@
 		/datum/rcd_schematic/pipe/dtvalve,
 		/datum/rcd_schematic/pipe/layer_manifold,
 		/datum/rcd_schematic/pipe/layer_adapter,
+		/datum/rcd_schematic/pipe/z_up,
+		/datum/rcd_schematic/pipe/z_down,
 
 		/* Devices */
 		/datum/rcd_schematic/pipe/connector,
@@ -65,16 +67,10 @@
 		/datum/rcd_schematic/pipe/disposal/outlet,
 		/datum/rcd_schematic/pipe/disposal/chute,
 		/datum/rcd_schematic/pipe/disposal/sort,
-		/datum/rcd_schematic/pipe/disposal/sort_wrap
+		/datum/rcd_schematic/pipe/disposal/sort_wrap,
+		/datum/rcd_schematic/pipe/disposal/up,
+		/datum/rcd_schematic/pipe/disposal/down,
 	)
-
-/obj/item/device/rcd/rpd/New()
-	if(map.multiz)
-		schematics.Add(/datum/rcd_schematic/pipe/z_up)
-		schematics.Add(/datum/rcd_schematic/pipe/z_down)
-		schematics.Add(/datum/rcd_schematic/pipe/disposal/up)
-		schematics.Add(/datum/rcd_schematic/pipe/disposal/down)
-	..()
 
 /obj/item/device/rcd/rpd/examine(var/mob/user)
 	..()

--- a/code/modules/RCD/schematics/pipe.dm
+++ b/code/modules/RCD/schematics/pipe.dm
@@ -510,12 +510,14 @@ var/global/list/disposalpipeID2State = list(
 
 	pipe_id		= PIPE_Z_UP
 	pipe_type	= PIPE_Z_UP_BINARY
+	flags 		= RCD_RANGE | RCD_GET_TURF | RCD_ALLOW_SWITCH | RCD_Z_UP
 
 /datum/rcd_schematic/pipe/z_down
 	name		= "Down Pipe"
 
 	pipe_id		= PIPE_Z_DOWN
 	pipe_type	= PIPE_Z_DOWN_BINARY
+	flags 		= RCD_RANGE | RCD_GET_TURF | RCD_ALLOW_SWITCH | RCD_Z_DOWN
 
 /datum/rcd_schematic/pipe/manifold
 	name		= "Manifold"
@@ -847,6 +849,7 @@ var/global/list/disposalpipeID2State = list(
 	pipe_id		= DISP_PIPE_UP
 	actual_id	= 13
 	pipe_type	= PIPE_Z_UP_BINARY
+	flags 		= RCD_RANGE | RCD_GET_TURF | RCD_ALLOW_SWITCH | RCD_Z_UP
 
 /datum/rcd_schematic/pipe/disposal/down
 	name		= "Down Pipe"
@@ -854,3 +857,4 @@ var/global/list/disposalpipeID2State = list(
 	pipe_id		= DISP_PIPE_DOWN
 	actual_id	= 14
 	pipe_type	= PIPE_Z_DOWN_BINARY
+	flags 		= RCD_RANGE | RCD_GET_TURF | RCD_ALLOW_SWITCH | RCD_Z_DOWN

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -31,7 +31,6 @@
 	var/zDerelict = 4
 	var/zAsteroid = 5
 	var/zDeepSpace = 6
-	var/multiz = FALSE //Don't even boot up multiz if we don't need it.
 
 	//Center of thunderdome admin room
 	var/tDomeX = 0

--- a/maps/test_euclidean.dm
+++ b/maps/test_euclidean.dm
@@ -34,7 +34,6 @@
 	tDomeX = 50
 	tDomeY = 50
 	tDomeZ = 1
-	multiz = TRUE
 	zLevels = list(
 		/datum/zLevel/centcomm,
 		/datum/zLevel/ground,

--- a/maps/test_multiz.dm
+++ b/maps/test_multiz.dm
@@ -36,7 +36,6 @@
 	tDomeX = 100
 	tDomeY = 100
 	tDomeZ = 1
-	multiz = TRUE
 	zLevels = list(
 		/datum/zLevel/centcomm,
 		/datum/zLevel/subterranean,

--- a/maps/tgstation-snow.dm
+++ b/maps/tgstation-snow.dm
@@ -14,7 +14,6 @@
 	zMainStation = 2
 	zCentcomm = 3
 	zTCommSat = 5
-	multiz = TRUE
 	zLevels = list(
 		/datum/zLevel/snowmine{
 			z_above = 2

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2832,7 +2832,7 @@
 #include "maprendering\maprendering.dm"
 #include "maps\_map.dm"
 #include "maps\_map_override.dm"
-#include "maps\test_multiz.dm"
+#include "maps\tgstation.dm"
 #include "maps\defficiency\areas.dm"
 #include "maps\lampreystation\lamprey.dm"
 #include "maps\packedstation\telecomms.dm"

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2832,7 +2832,7 @@
 #include "maprendering\maprendering.dm"
 #include "maps\_map.dm"
 #include "maps\_map_override.dm"
-#include "maps\tgstation.dm"
+#include "maps\test_multiz.dm"
 #include "maps\defficiency\areas.dm"
 #include "maps\lampreystation\lamprey.dm"
 #include "maps\packedstation\telecomms.dm"


### PR DESCRIPTION
[tweak]

## What this does
Removes the map datum level "multiz" variable and replaces it with suitable hasabove and hasbelow checks in old cases.

## Why it's good
Forbids construction of multi-z pipes and stairs on non suitable layers with no above or below, makes coding or bussing multi-z easier.

## Changelog
:cl:
 * tweak: Stairs can no longer be built on levels with nothing above.
 * tweak: Upwards or downwards pipes can no longer be built if nothing is in their indicated direction.