### PR TITLE
Shift + Scroll To Toggle Switchtool

### DIFF
--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/obj/switchtool.dmi'
 	icon_state = "switchtool"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/switchtool.dmi', "right_hand" = 'icons/mob/in-hand/right/switchtool.dmi')
-	desc = "A multi-deployable, multi-instrument, finely crafted multi-purpose tool. The envy of engineers everywhere.  Use SHIFT+Mousewheel to quickly Swap tools"
+	desc = "A multi-deployable, multi-instrument, finely crafted multi-purpose tool. The envy of engineers everywhere."
 	flags = FPRINT
 	siemens_coefficient = 1
 	force = 3
@@ -74,6 +74,7 @@
 /obj/item/weapon/switchtool/examine(mob/user)
 	..()
 	to_chat(user, "This one is capable of holding [get_formatted_modules()].")
+	to_chat(user, " Use SHIFT+Mousewheel to quickly Swap tools")
 
 /obj/item/weapon/switchtool/attack_self(mob/user)
 	if(!user)
@@ -289,7 +290,7 @@
 	name = "surgeon's switchtool"
 	icon_state = "surg_switchtool"
 	item_state = "surg_switchtool"
-	desc = "A switchtool containing most of the necessary items for impromptu surgery. For the surgeon on the go.  Use SHIFT+Mousewheel to quickly Swap tools"
+	desc = "A switchtool containing most of the necessary items for impromptu surgery. For the surgeon on the go."
 
 	origin_tech = Tc_MATERIALS + "=4;" + Tc_BLUESPACE + "=3;" + Tc_BIOTECH + "=3"
 	stored_modules = list("/obj/item/tool/scalpel:scalpel" = null,
@@ -323,7 +324,7 @@
 	sharpness_flags = 0
 	icon_state = "s_a_k"
 	item_state = "s_a_k"
-	desc = "Crafted by the Space Swiss for everyday use in military campaigns. Nonpareil.  Use SHIFT+Mousewheel to quickly Swap tools"
+	desc = "Crafted by the Space Swiss for everyday use in military campaigns. Nonpareil."
 	origin_tech = Tc_MATERIALS + "=5;" + Tc_BLUESPACE + "=3"
 
 	stored_modules = list("/obj/item/tool/screwdriver:screwdriver" = null,
@@ -594,7 +595,7 @@
 
 /obj/item/weapon/switchtool/engineering
 	name = "\improper Engineering switchtool"
-	desc = "A switchtool designed specifically to be the perfect companion for an Engineer. Use SHIFT+Mousewheel to quickly Swap tools"
+	desc = "A switchtool designed specifically to be the perfect companion for an Engineer."
 	stored_modules = list(
 		"/obj/item/tool/crowbar:crowbar" = null,
 		"/obj/item/tool/screwdriver:screwdriver" = null,

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -201,6 +201,8 @@
 		return FALSE
 	if(!stored_modules[module])
 		return FALSE
+	if(deployed)
+		return FALSE
 	playsound(src, deploy_sound, 10, 1)
 	deployed = stored_modules[module]
 	hmodule = get_module_name(module)

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -18,6 +18,7 @@
 	melt_temperature = MELTPOINT_STEEL
 	origin_tech = Tc_MATERIALS + "=5;" + Tc_BLUESPACE + "=3"
 	var/hmodule = null
+	var/index = 0
 
 	//the colon separates the typepath from the name
 	var/list/obj/item/stored_modules = list("/obj/item/tool/screwdriver:screwdriver" = null,
@@ -103,6 +104,22 @@
 	else
 		return ..()
 
+/obj/item/weapon/switchtool/MouseWheeled(var/mob/user, var/delta_x, var/delta_y, var/params)
+	var/modifiers = params2list(params)
+	if (modifiers["ctrl"])
+		if (delta_y <= 0)
+			index++
+		else
+			index--
+		if (index > stored_modules.len)
+			index = 0
+		if(index < 0)
+			index = stored_modules.len
+		var/moduled = stored_modules[index]
+		undeploy()
+		deploy(moduled, user)
+		edit_deploy(1)
+
 /obj/item/weapon/switchtool/proc/get_module_type(var/module)
 	return copytext(module, 1, findtext(module, ":"))
 
@@ -180,14 +197,10 @@
 	user.update_inv_hands()
 
 /obj/item/weapon/switchtool/proc/deploy(var/module, mob/user)
-
 	if(!(module in stored_modules))
 		return FALSE
 	if(!stored_modules[module])
 		return FALSE
-	if(deployed)
-		return FALSE
-
 	playsound(src, deploy_sound, 10, 1)
 	deployed = stored_modules[module]
 	hmodule = get_module_name(module)

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/obj/switchtool.dmi'
 	icon_state = "switchtool"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/switchtool.dmi', "right_hand" = 'icons/mob/in-hand/right/switchtool.dmi')
-	desc = "A multi-deployable, multi-instrument, finely crafted multi-purpose tool. The envy of engineers everywhere."
+	desc = "A multi-deployable, multi-instrument, finely crafted multi-purpose tool. The envy of engineers everywhere.  Use SHIFT+Mousewheel to quickly Swap tools"
 	flags = FPRINT
 	siemens_coefficient = 1
 	force = 3
@@ -106,7 +106,7 @@
 
 /obj/item/weapon/switchtool/MouseWheeled(var/mob/user, var/delta_x, var/delta_y, var/params)
 	var/modifiers = params2list(params)
-	if (modifiers["ctrl"])
+	if (modifiers["shift"])
 		if (delta_y <= 0)
 			index++
 		else
@@ -289,7 +289,7 @@
 	name = "surgeon's switchtool"
 	icon_state = "surg_switchtool"
 	item_state = "surg_switchtool"
-	desc = "A switchtool containing most of the necessary items for impromptu surgery. For the surgeon on the go."
+	desc = "A switchtool containing most of the necessary items for impromptu surgery. For the surgeon on the go.  Use SHIFT+Mousewheel to quickly Swap tools"
 
 	origin_tech = Tc_MATERIALS + "=4;" + Tc_BLUESPACE + "=3;" + Tc_BIOTECH + "=3"
 	stored_modules = list("/obj/item/tool/scalpel:scalpel" = null,
@@ -323,7 +323,7 @@
 	sharpness_flags = 0
 	icon_state = "s_a_k"
 	item_state = "s_a_k"
-	desc = "Crafted by the Space Swiss for everyday use in military campaigns. Nonpareil."
+	desc = "Crafted by the Space Swiss for everyday use in military campaigns. Nonpareil.  Use SHIFT+Mousewheel to quickly Swap tools"
 	origin_tech = Tc_MATERIALS + "=5;" + Tc_BLUESPACE + "=3"
 
 	stored_modules = list("/obj/item/tool/screwdriver:screwdriver" = null,
@@ -594,7 +594,7 @@
 
 /obj/item/weapon/switchtool/engineering
 	name = "\improper Engineering switchtool"
-	desc = "A switchtool designed specifically to be the perfect companion for an Engineer."
+	desc = "A switchtool designed specifically to be the perfect companion for an Engineer. Use SHIFT+Mousewheel to quickly Swap tools"
 	stored_modules = list(
 		"/obj/item/tool/crowbar:crowbar" = null,
 		"/obj/item/tool/screwdriver:screwdriver" = null,


### PR DESCRIPTION
## What this does
You can now iterate through a switchtool by holding down Shift + MouseWheel. When reaching the bottom, it will wrap around to the start again.

## Why it's good
Makes switchtools a bit more convenient to use.

## Changelog
:cl:
 * rscadd: You can now iterate through a switchtool by holding down Shift + MouseWheel.


