### PR TITLE
Vampire Shapeshifting changes + Screech breaks light bulbs

### DIFF
--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -47,7 +47,7 @@
 
 // Toggles several features, explained in their respective comments.
 // You can turn those on and off manually if you prefer, instead of setting this
-#define DEVELOPER_MODE 1
+#define DEVELOPER_MODE 0
 
 // If 1, unit tests will be compiled
 #define UNIT_TESTS_ENABLED 0

--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -47,7 +47,7 @@
 
 // Toggles several features, explained in their respective comments.
 // You can turn those on and off manually if you prefer, instead of setting this
-#define DEVELOPER_MODE 0
+#define DEVELOPER_MODE 1
 
 // If 1, unit tests will be compiled
 #define UNIT_TESTS_ENABLED 0

--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -42,7 +42,7 @@
 
 #define ishorrorform(A) (ishuman(A) && istype(A:species, /datum/species/horror))
 
-#define isumbra(A) (ishuman(A) && istype(A:species, /datum/species/umbra))
+#define istruevampire(A)  (ishuman(A) && isvampire(A) && istype(A:species, /datum/species/vampire))
 
 #define ismushroom(A) ((ishuman(A) && istype(A:species, /datum/species/mushroom)) || (istype(A, /mob/living/carbon/monkey/mushroom)))
 

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1359,7 +1359,7 @@ var/proccalls = 1
 #define CHANNEL_WEATHER				1018
 #define CHANNEL_MEDBOTS				1019
 #define CHANNEL_BALLOON				1020
-#define CHANNEL_UMBRA				1021	//only ever used to allow the ambient umbra sound to be made to stop playing
+#define CHANNEL_GRUE				1021	//only ever used to allow the ambient grue sound to be made to stop playing
 #define CHANNEL_LOBBY				1022
 #define CHANNEL_AMBIENCE			1023
 #define CHANNEL_ADMINMUSIC			1024

--- a/code/datums/gamemode/powers/vampire.dm
+++ b/code/datums/gamemode/powers/vampire.dm
@@ -1,15 +1,9 @@
-
-// -- Vampire powers
-
 /datum/power/vampire
 	name = "Vampire Power"
 	desc = "Vampire Power"
 	granttext = "" // Displays the granttext if needed
 
-
-// -- List of all vampire spells
-
-/* Tier 0 : roundstart */
+//List of all vampire spells
 /datum/power/vampire/rejuvenate
 	cost = 0
 	spellpath = /spell/rejuvenate
@@ -23,19 +17,12 @@
 	cost = 0
 	spellpath = /spell/targeted/hypnotise
 
-/* Tier 1 */
-/datum/power/vampire/shape
-	cost = 100
-	spellpath = /spell/shapeshift
-	granttext = "You have gained the shapeshifting ability, at the cost of stored blood you can change your form permanently."
-
 /datum/power/vampire/vision
 	cost = 100
 	spellpath = null // No spell for night vision.
 	granttext = "Your vampiric vision has improved."
 	store_in_memory = TRUE
 
-/* Tier 2 */
 /datum/power/vampire/disease
 	cost = 150
 	spellpath = /spell/targeted/disease
@@ -46,7 +33,6 @@
 	spellpath = /spell/cloak
 	granttext = "You have gained the Cloak of Darkness ability which when toggled makes you near invisible in the shroud of darkness."
 
-/* Tier 3 */
 /datum/power/vampire/bats
 	cost = 200
 	spellpath = /spell/aoe_turf/conjure/bats
@@ -62,13 +48,11 @@
 	granttext = "Your rejuvination abilities have improved and will now heal you over time when used."
 	store_in_memory = TRUE
 
-/* Tier 3.5 (/vg/) */
 /datum/power/vampire/jaunt
 	cost = 250
 	spellpath = /spell/targeted/ethereal_jaunt/vamp
 	granttext = "You have gained the Mist Form ability which allows you to take on the form of mist for a short period and pass over any obstacle in your path."
 
-/* Tier 4 */
 /datum/power/vampire/slave
 	cost = 300
 	spellpath = /spell/targeted/enthrall
@@ -79,25 +63,26 @@
 	spellpath = /spell/aoe_turf/blink/vamp
 	granttext = "You have gained the ability to shadowstep, which makes you disappear into nearby shadows at the cost of blood."
 
-/* Tier 5 (/vg/) */
 /datum/power/vampire/mature
 	cost = 400
 	granttext = "You have reached physical maturity. You are more vulnerable to holy things, and your vision has been improved greatly. You drain blood from people twice as fast and you no longer need to take their masks off."
 	store_in_memory = TRUE
 
-/* Tier 6 (/vg/) */
+/datum/power/vampire/shapeshift
+	cost = 400
+	spellpath = /spell/shapeshift
+	granttext = "You have gained the shapeshifting ability."
+
 /datum/power/vampire/shadow
 	cost = 450
 	spellpath = /spell/menace
 	granttext = "You have gained mastery over the shadows. In the dark, you can mask your identity, instantly terrify non-vampires who approach you, and enter the chapel for a longer period of time."
 
-/* Tier 66 (/vg/) */
 /datum/power/vampire/charisma // Passive
 	cost = 500
 	granttext = "You develop an uncanny charismatic aura that makes you difficult to disobey. Hypnotise and Enthrall take less time to perform, and Enthrall works on implanted targets."
 	store_in_memory = TRUE
 
-/* Tier 666 (/vg/) */
 /datum/power/vampire/undying
 	cost = 666
 	spellpath = /spell/undeath

--- a/code/datums/gamemode/powers/vampire.dm
+++ b/code/datums/gamemode/powers/vampire.dm
@@ -7,7 +7,6 @@
 /datum/power/vampire/rejuvenate
 	cost = 0
 	spellpath = /spell/rejuvenate
-	granttext = "You have gained the ability to rejuvnate your body and clean yourself of all incapacitating effects."
 
 /datum/power/vampire/glare
 	cost = 0
@@ -16,6 +15,10 @@
 /datum/power/vampire/hypnotise
 	cost = 0
 	spellpath = /spell/targeted/hypnotise
+
+/datum/power/vampire/shapeshift
+	cost = 0
+	spellpath = /spell/shapeshift
 
 /datum/power/vampire/vision
 	cost = 100
@@ -67,11 +70,6 @@
 	cost = 400
 	granttext = "You have reached physical maturity. You are more vulnerable to holy things, and your vision has been improved greatly. You drain blood from people twice as fast and you no longer need to take their masks off."
 	store_in_memory = TRUE
-
-/datum/power/vampire/shapeshift
-	cost = 400
-	spellpath = /spell/shapeshift
-	granttext = "You have gained the shapeshifting ability."
 
 /datum/power/vampire/shadow
 	cost = 450

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -23,9 +23,6 @@
 	var/nullified = 0
 	var/smitecounter = 0
 
-	var/list/saved_appearances = list()
-	var/datum/human_appearance/initial_appearance
-
 	var/reviving = FALSE
 	var/draining = FALSE
 	var/blood_usable = STARTING_BLOOD
@@ -81,10 +78,6 @@
 	if(faction && istype(faction, /datum/faction/vampire) && faction.leader == src)
 		var/datum/faction/vampire/V = faction
 		V.name_clan(src)
-
-	var/mob/living/carbon/human/H = antag.current
-	initial_appearance = H.my_appearance.Copy()
-	initial_appearance.name = H.real_name
 
 /datum/role/vampire/RemoveFromRole(var/datum/mind/M)
 	var/list/vamp_spells = getAllVampSpells()
@@ -385,11 +378,6 @@
 		smitetemp = -1
 
 	smitecounter = max(0, (smitecounter + smitetemp))
-
-	// At any rate
-	if (smitecounter && H.real_name != initial_appearance.name)
-		H.switch_appearance(initial_appearance) // Reveal us as who we are
-		H.real_name = initial_appearance.name
 
 	switch(smitecounter)
 		if(1 to 30) //just dizziness

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -249,10 +249,11 @@
 	// Vision-related changes.
 	if (locate(/datum/power/vampire/vision) in current_powers)
 		H.change_sight(adding = SEE_MOBS)
+		H.update_perception()
 
 	if (locate(/datum/power/vampire/mature) in current_powers)
 		H.change_sight(adding = SEE_TURFS|SEE_OBJS)
-		H.see_in_dark = 8
+		H.update_perception()
 
 /datum/role/vampire/proc/is_mature_or_has_vision()
 	return (locate(/datum/power/vampire/vision) in current_powers) || (locate(/datum/power/vampire/mature) in current_powers)

--- a/code/datums/helper_datums/butchering.dm
+++ b/code/datums/helper_datums/butchering.dm
@@ -425,9 +425,6 @@
 				butchSpeed += 0.25
 				if(!toolName)
 					toolName = "claws"
-		if(isumbra(H))
-			toolName = "umbra"
-			butchSpeed += 0.5
 	else
 		butchSpeed = 0.5
 	if(!butchSpeed)

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -165,13 +165,15 @@
 
 	//Hair
 	var/list/species_hair = valid_sprite_accessories(hair_styles_list, null, species.name)
-	var/hair = clamp(dna.GetUIValueRange(DNA_UI_HAIR_STYLE, species_hair.len), 1, species_hair.len)
-	my_appearance.h_style = species_hair[hair]
+	if(length(species_hair))
+		var/hair = clamp(dna.GetUIValueRange(DNA_UI_HAIR_STYLE, species_hair.len), 1, species_hair.len)
+		my_appearance.h_style = species_hair[hair]
 
 	//Facial Hair
 	var/list/species_facial_hair = valid_sprite_accessories(facial_hair_styles_list, null, species.name)
-	var/beard = clamp(dna.GetUIValueRange(DNA_UI_BEARD_STYLE, species_facial_hair.len), 1, species_facial_hair.len)
-	my_appearance.f_style = species_facial_hair[beard]
+	if(length(species_facial_hair))
+		var/beard = clamp(dna.GetUIValueRange(DNA_UI_BEARD_STYLE, species_facial_hair.len), 1, species_facial_hair.len)
+		my_appearance.f_style = species_facial_hair[beard]
 
 	regenerate_icons()
 

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -324,7 +324,7 @@
 			/mob/living/carbon/human/manifested,
 			/mob/living/carbon/human/muton,
 			/mob/living/carbon/human/golem,
-			/mob/living/carbon/human/umbra,
+			/mob/living/carbon/human/vampire,
 			/mob/living/carbon/human/frankenstein,
 			/mob/living/carbon/human/lich,
 			/mob/living/carbon/human/NPC,

--- a/code/modules/medical/autopsy.dm
+++ b/code/modules/medical/autopsy.dm
@@ -47,9 +47,6 @@
 				advanced_butchery = "\The [target_name] seems to have been butchered with"
 				for(var/i = 1, i <= H.advanced_butchery.len, i++)
 					var/tool_name = H.advanced_butchery[i]
-					if(tool_name == "umbra")
-						advanced_butchery = "<span class='warning'>\The [target_name] is likely to have been eaten by an umbra.</span>"
-						break
 					if(H.advanced_butchery.len == 1)
 						advanced_butchery += " \a [tool_name]."
 					else if(i != H.advanced_butchery.len)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -76,9 +76,8 @@
 	my_appearance.h_style = "Bald"
 	regenerate_icons()
 
-/mob/living/carbon/human/umbra/New(var/new_loc, delay_ready_dna = 0)
-	..(new_loc, "Umbra")
-	faction = "grue" //Umbras are friendly with grues
+/mob/living/carbon/human/vampire/New(var/new_loc, delay_ready_dna = 0)
+	..(new_loc, "Vampire")
 	my_appearance.h_style = "Bald"
 	regenerate_icons()
 
@@ -2266,7 +2265,7 @@
 			return list(
 		if ("Golem")
 			return list(
-		if ("Umbra")
+		if ("Vampire")
 			return list(
 		if ("Slime")
 			return list(

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -188,7 +188,7 @@ var/global/list/damage_icon_parts = list()
 
 	var/husk = (M_HUSK in src.mutations)
 	var/fat = (M_FAT in src.mutations) && (species && species.anatomy_flags & CAN_BE_FAT)
-	var/hulk = (M_HULK in src.mutations) && !ishorrorform(src) && !isumbra(src) && mind.special_role != HIGHLANDER // Part of the species.
+	var/hulk = (M_HULK in src.mutations) && !ishorrorform(src) && mind.special_role != HIGHLANDER // Part of the species.
 	var/skeleton = (M_SKELETON in src.mutations)
 
 	var/g = "m"

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1032,7 +1032,7 @@ var/list/has_died_as_golem = list()
 	flags = IS_WHITELISTED | HYPOTHERMIA_IMMUNE
 	anatomy_flags = HAS_LIPS
 	punch_damage = 7
-	default_mutations=list(M_CLAWS,M_TALONS)
+	default_mutations=list(M_CLAWS,M_TALONS, M_JAMSIGNALS)
 	has_mutant_race = 0
 
 	primitive = /mob/living/carbon/monkey //Just to keep them SoC friendly.

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1266,8 +1266,6 @@ var/list/has_died_as_golem = list()
 /datum/species/insectoid/gib(mob/living/carbon/human/H) //changed from Skrell to Insectoid for testing
 	H.default_gib()
 
-
-
 /datum/species/mushroom
 	name = "Mushroom"
 	icobase = 'icons/mob/human_races/r_mushman.dmi'

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1033,8 +1033,6 @@ var/list/has_died_as_golem = list()
 	anatomy_flags = HAS_LIPS
 	punch_damage = 7
 	default_mutations=list(M_CLAWS,M_TALONS)
-	burn_mod = 2
-	brute_mod = 2
 	has_mutant_race = 0
 
 	primitive = /mob/living/carbon/monkey //Just to keep them SoC friendly.

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1024,24 +1024,20 @@ var/list/has_died_as_golem = list()
 		else
 			to_chat(user, "<span class='warning'>The used extract doesn't have any effect on \the [src].</span>")
 
-/datum/species/umbra
-	name = "Umbra"
+/datum/species/vampire
+	name = "Vampire"
 	icobase = 'icons/mob/human_races/r_grue.dmi'		// Normal icon set.
 	deform = 'icons/mob/human_races/r_def_grue.dmi'	// Mutated icon set.
-	eyes = "grue_eyes_s"
 	attack_verb = "claws"
-	flags = NO_PAIN | IS_WHITELISTED | HYPOTHERMIA_IMMUNE
+	flags = IS_WHITELISTED | HYPOTHERMIA_IMMUNE
 	anatomy_flags = HAS_LIPS
 	punch_damage = 7
-	default_mutations=list(M_HULK,M_CLAWS,M_TALONS)
+	default_mutations=list(M_CLAWS,M_TALONS)
 	burn_mod = 2
 	brute_mod = 2
-	move_speed_multiplier = 2
 	has_mutant_race = 0
 
 	primitive = /mob/living/carbon/monkey //Just to keep them SoC friendly.
-
-	spells = list(/spell/swallow_light,/spell/shatter_lights)
 
 	has_organ = list(
 		"heart" =    /datum/organ/internal/heart,
@@ -1050,13 +1046,13 @@ var/list/has_died_as_golem = list()
 		"kidneys" =  /datum/organ/internal/kidney,
 		"brain" =    /datum/organ/internal/brain,
 		"appendix" = /datum/organ/internal/appendix,
-		"eyes" =     /datum/organ/internal/eyes/umbra
+		"eyes" =     /datum/organ/internal/eyes/monstrous
 	)
 
-/datum/species/umbra/makeName()
-	return "umbra"
+/datum/species/vampire/makeName()
+	return "vampire"
 
-/datum/species/umbra/gib(mob/living/carbon/human/H)
+/datum/species/vampire/gib(mob/living/carbon/human/H)
 	..()
 	H.default_gib()
 

--- a/code/modules/mob/living/carbon/species_powers.dm
+++ b/code/modules/mob/living/carbon/species_powers.dm
@@ -23,7 +23,7 @@
 		if(istype(E))
 			E.dark_mode = !E.dark_mode
 
-/spell/swallow_light	//Umbra
+/spell/swallow_light
 	name = "Swallow Light"
 	abbreviation = "SL"
 	desc = "Create a void of darkness around yourself."
@@ -41,11 +41,11 @@
 /spell/swallow_light/cast(list/targets, mob/user)
 	user.set_light(8,-20)
 	playsound(user, cast_sound, 50, 1)
-	playsound(user, 'sound/misc/grue_ambience.ogg', 50, channel = CHANNEL_UMBRA)
+	playsound(user, 'sound/misc/grue_ambience.ogg', 50, channel = CHANNEL_GRUE)
 
 /spell/swallow_light/stop_casting(list/targets, mob/user)
 	user.set_light(0)
-	playsound(user, null, 50, channel = CHANNEL_UMBRA)
+	playsound(user, null, 50, channel = CHANNEL_GRUE)
 
 /spell/swallow_light/choose_targets(mob/user = usr)
 	var/list/targets = list()
@@ -55,7 +55,7 @@
 /spell/swallow_light/is_valid_target(var/target, mob/user, options)
 	return(target == user)
 
-/spell/shatter_lights	//Umbra
+/spell/shatter_lights
 	name = "Shatter Lights"
 	abbreviation = "ST"
 	desc = "Shatter all nearby lights with a shriek."

--- a/code/modules/mob/living/carbon/species_powers.dm
+++ b/code/modules/mob/living/carbon/species_powers.dm
@@ -23,64 +23,6 @@
 		if(istype(E))
 			E.dark_mode = !E.dark_mode
 
-/spell/swallow_light
-	name = "Swallow Light"
-	abbreviation = "SL"
-	desc = "Create a void of darkness around yourself."
-	panel = "Racial Abilities"
-	override_base = "racial"
-	hud_state = "racial_dark"
-	spell_flags = INCLUDEUSER
-	charge_type = Sp_GRADUAL
-	charge_max = 600
-	minimum_charge = 100
-	range = SELFCAST
-	cast_sound = 'sound/misc/grue_growl.ogg'
-	still_recharging_msg = "<span class='notice'>You're still regaining your strength.</span>"
-
-/spell/swallow_light/cast(list/targets, mob/user)
-	user.set_light(8,-20)
-	playsound(user, cast_sound, 50, 1)
-	playsound(user, 'sound/misc/grue_ambience.ogg', 50, channel = CHANNEL_GRUE)
-
-/spell/swallow_light/stop_casting(list/targets, mob/user)
-	user.set_light(0)
-	playsound(user, null, 50, channel = CHANNEL_GRUE)
-
-/spell/swallow_light/choose_targets(mob/user = usr)
-	var/list/targets = list()
-	targets += user
-	return targets
-
-/spell/swallow_light/is_valid_target(var/target, mob/user, options)
-	return(target == user)
-
-/spell/shatter_lights
-	name = "Shatter Lights"
-	abbreviation = "ST"
-	desc = "Shatter all nearby lights with a shriek."
-	panel = "Racial Abilities"
-	override_base = "racial"
-	hud_state = "blackout"
-	charge_max = 1200
-	spell_flags = null
-	range = SELFCAST
-	cast_sound = 'sound/misc/grue_screech.ogg'
-	still_recharging_msg = "<span class='notice'>You're still regaining your strength.</span>"
-
-/spell/shatter_lights/cast(list/targets, mob/user)
-	playsound(user, cast_sound, 100)
-	for(var/obj/machinery/light/L in range(7))
-		L.broken()
-
-/spell/shatter_lights/choose_targets(mob/user = usr)
-	var/list/targets = list()
-	targets += user
-	return targets
-
-/spell/shatter_lights/is_valid_target(var/target, mob/user, options)
-	return(target == user)
-
 /spell/regen_limbs	//Slime people
 	name = "Regenerate Limbs"
 	abbreviation = "RL"

--- a/code/modules/mob/living/simple_animal/hostile/grue_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue_powers.dm
@@ -99,10 +99,10 @@
 /spell/aoe_turf/grue_drainlight/cast(list/targets, mob/living/simple_animal/hostile/grue/user)
 	playsound(user, 'sound/effects/grue_drainlight.ogg', 50, 1)
 	user.drainlight(TRUE)
-	playsound(user, 'sound/misc/grue_ambience.ogg', 50, channel = CHANNEL_UMBRA)
+	playsound(user, 'sound/misc/grue_ambience.ogg', 50, channel = CHANNEL_GRUE)
 
 /spell/aoe_turf/grue_drainlight/stop_casting(list/targets, mob/living/simple_animal/hostile/grue/user, var/mute=FALSE)
 	user.drainlight(FALSE, mute)
-	playsound(user, null, 50, channel = CHANNEL_UMBRA)
+	playsound(user, null, 50, channel = CHANNEL_GRUE)
 	..()
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -2207,6 +2207,8 @@ Use this proc preferably at the end of an equipment loadout
 	if(istype(H))
 		if(H.wear_id && istype(H.wear_id.GetID(), /obj/item/weapon/card/id/syndicate))
 			return null
+	if(istruevampire(H))
+		return null
 	var/datum/role/changeling/C = target.mind.GetRole(CHANGELING)
 	if(istype(C))
 		if(locate(/datum/power/changeling/DigitalCamouflage) in C.current_powers)

--- a/code/modules/organs/internal/eyes/eyes.dm
+++ b/code/modules/organs/internal/eyes/eyes.dm
@@ -10,8 +10,6 @@
 	var/see_in_dark=2
 	var/list/colourmatrix = list()
 
-
-
 /datum/organ/internal/eyes/proc/init_perception(var/mob/living/carbon/human/M)
 	return
 
@@ -55,6 +53,9 @@
 	name = "monstrous eyes"
 	see_in_dark= 9
 	removed_type = /obj/item/organ/internal/eyes/monstrous
+
+/datum/organ/internal/eyes/monstrous/update_perception(var/mob/living/carbon/human/M)
+	M.client.darkness_planemaster.alpha = 100
 
 /datum/organ/internal/eyes/mushroom
 	name = "mushroom eyes"

--- a/code/modules/organs/internal/eyes/eyes.dm
+++ b/code/modules/organs/internal/eyes/eyes.dm
@@ -24,7 +24,6 @@
 	if(is_bruised())
 		owner.eye_blurry = max(2, owner.eye_blurry)
 
-
 /datum/organ/internal/eyes/tajaran
 	name = "feline eyes"
 	see_in_dark=9
@@ -52,14 +51,10 @@
 	name = "bird eyes"
 	removed_type = /obj/item/organ/internal/eyes/vox
 
-/datum/organ/internal/eyes/umbra
+/datum/organ/internal/eyes/monstrous
 	name = "monstrous eyes"
-	see_in_dark=8
-	colourmatrix = list(-1, 0, 0,
-						 0,-1, 0,
-						 0, 0,-1,
-						 1, 1, 1)
-	removed_type = /obj/item/organ/internal/eyes/umbra
+	see_in_dark= 9
+	removed_type = /obj/item/organ/internal/eyes/monstrous
 
 /datum/organ/internal/eyes/mushroom
 	name = "mushroom eyes"

--- a/code/modules/organs/organ_objects.dm
+++ b/code/modules/organs/organ_objects.dm
@@ -288,11 +288,11 @@
 	prosthetic_name = "vox visual prosthesis"
 	organ_type = /datum/organ/internal/eyes/vox
 
-/obj/item/organ/internal/eyes/umbra
-	name = "umbra eyeballs"
+/obj/item/organ/internal/eyes/monstrous
+	name = "monstrous eyeballs"
 //	icon_state = "eyes"
-	prosthetic_name = "umbra visual prosthesis"
-	organ_type = /datum/organ/internal/eyes/umbra
+	prosthetic_name = "monstrous visual prosthesis"
+	organ_type = /datum/organ/internal/eyes/monstrous
 
 /obj/item/organ/internal/eyes/mushroom
 	name = "mushroom eyeballs"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -9796,7 +9796,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/datum/organ/internal/eyes/E= H.internal_organs_by_name["eyes"] //damages the eyes
-		if(E && !istype(E, /datum/organ/internal/eyes/umbra) && !E.robotic) //doesn't harm umbra or robotic eyes
+		if(E && !istype(E, /datum/organ/internal/eyes/monstrous) && !E.robotic) //doesn't harm monstrous or robotic eyes
 			E.damage += 0.5
 
 /datum/reagent/bumcivilian

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -73,13 +73,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/meat/human/after_consume(var/mob/user, var/datum/reagents/reagentreference)
 	if(!user)
 		return
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(isumbra(H))
-			H.adjustOxyLoss(-50)
-			H.heal_organ_damage(50, 0)
-			H.heal_organ_damage(0, 50)
-			H.adjustToxLoss(-50)
 	..()
 
 /obj/item/weapon/reagent_containers/food/snacks/meat/diona

--- a/code/modules/spells/aoe_turf/screech.dm
+++ b/code/modules/spells/aoe_turf/screech.dm
@@ -64,6 +64,8 @@
 		C.Jitter(150)
 	for(var/obj/structure/window/W in view(4))
 		W.shatter()
+	for(var/obj/machinery/light/L in view(7))
+		L.broken()
 
 	playsound(user, 'sound/effects/creepyshriek.ogg', 100, 1)
 

--- a/code/modules/spells/general/shapeshift.dm
+++ b/code/modules/spells/general/shapeshift.dm
@@ -1,56 +1,46 @@
 /spell/shapeshift
-	name = "Shapeshift (1)"
-	desc = "Changes your name and appearance, either to someone in view or randomly. Has a cooldown of 3 minutes."
+	name = "Shapeshift"
+	desc = "You change into your true form."
 	abbreviation = "SS"
-
+	still_recharging_msg = "<span class='warning'>We are not ready to do that!</span>"
 	school = "vampire"
 	user_type = USER_TYPE_VAMPIRE
 
+	charge_max = 300
+	cooldown_min = 30 SECONDS
+	spell_flags = NEEDSHUMAN
+
 	charge_type = Sp_RECHARGE
-	charge_max = 3 MINUTES
 	invocation_type = SpI_NONE
 	range = 0
-	spell_flags = STATALLOWED | NEEDSHUMAN
-	cooldown_min = 3 MINUTES
 
 	override_base = "vamp"
 	hud_state = "vamp_shapeshift"
+	var/datum/dna/identity = null
+	var/datum/human_appearance/appearance = null
+	var/humanform = TRUE
 
-	var/blood_cost = 1
-
-/spell/shapeshift/cast_check(var/skipcharge = 0, var/mob/user = usr)
+/spell/shapeshift/cast_check(skipcharge = 0, mob/user = usr)
 	. = ..()
-	if (!.) // No need to go further.
-		return FALSE
-	if (!user.vampire_power(blood_cost, CONSCIOUS))
+	if (!.) 
 		return FALSE
 
 /spell/shapeshift/choose_targets(var/mob/user = usr)
 	return list(user) // Self-cast
 
 /spell/shapeshift/cast(var/list/targets, var/mob/living/carbon/human/user)
-	if (!istype(user))
-		return FALSE
-	var/list/choices = list()
-	var/datum/role/vampire/V = isvampire(user)
-	choices[V.initial_appearance.name] = V.initial_appearance
-	for (var/mob/living/carbon/human/H in view(user) - user)
-		choices[H.real_name] = H.my_appearance.Copy()
-	for (var/datum/human_appearance/looks in V.saved_appearances)
-		choices[looks.name] = looks
-	choices["Random"] = ""
-
-	var/choice = input(user, "Which appearance shall we adopt?", "Shapeshift", "Random") as null|anything in choices
-
-	if (!choice)
-		return
-	else if (choice == "Random")
-		var/name = user.generate_name() //random_name(M.current.gender)
-		var/datum/human_appearance/new_looks = user.randomise_appearance_for(user.gender)
-		new_looks.name = name
-		V.saved_appearances += new_looks
+	if(humanform)
+		identity = user.dna.Clone()
+		appearance = user.my_appearance.Copy()
+		humanform = FALSE
+		user.name = "Nosferatu"
+		user.real_name = "Nosferatu"
+		user.set_species("Vampire")
+		user.UpdateAppearance()
 	else
-		user.switch_appearance(choices[choice])
-		user.real_name = choice
-
-	V.remove_blood(blood_cost)
+		user.set_species(identity.species, 0)
+		user.dna = identity
+		user.UpdateAppearance()
+		humanform = TRUE
+	
+	..()

--- a/code/modules/spells/general/shapeshift.dm
+++ b/code/modules/spells/general/shapeshift.dm
@@ -6,8 +6,8 @@
 	school = "vampire"
 	user_type = USER_TYPE_VAMPIRE
 
-	charge_max = 300
-	cooldown_min = 30 SECONDS
+	charge_max = 200
+	cooldown_min = 20 SECONDS
 	spell_flags = NEEDSHUMAN
 
 	charge_type = Sp_RECHARGE

--- a/code/modules/spells/general/shapeshift.dm
+++ b/code/modules/spells/general/shapeshift.dm
@@ -41,6 +41,7 @@
 		user.set_species(identity.species, 0)
 		user.dna = identity
 		user.UpdateAppearance()
+		user.update_perception()
 		humanform = TRUE
 	
 	..()

--- a/code/modules/spells/general/shapeshift.dm
+++ b/code/modules/spells/general/shapeshift.dm
@@ -1,6 +1,6 @@
 /spell/shapeshift
 	name = "Shapeshift"
-	desc = "You change into your true form."
+	desc = "You change into your true form, granting you better vision, and obfuscating technology."
 	abbreviation = "SS"
 	still_recharging_msg = "<span class='warning'>We are not ready to do that!</span>"
 	school = "vampire"


### PR DESCRIPTION
Right now I think changeling and vampire are a little too similar, so here's a start of something that differentiates them at least a little more

## What this does
- Instead of shapeshifting being similar to changeling's transform, I've made it so you turn into a vampire in your true form (which I took from umbra, which was formally grue)
- being a true vampire will hide your former jobbie identity and you can rapidly change when necessary
- hides you from cameras and easy identification although it's visually obvious what you are
- nerfed the former umbra (now vampire) and replaced old code
- make vampire vision work in the dark (it currently doesn't)
- the former umbra, former grue code is all still being used. The drainlight is used by grue, and I combined the break lights into the vampire screech

## Why it's good
- Hopefully one small step in the right direction with vampires
- fixes vision issues
- uses sprites that aren't currently being used
-  differentiates vampire from changeling a little

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Reworked vampire's shapeshifting. When using Shapeshift, the vampire transforms into a "true vampire" that has vision in the dark. hides you from cameras, and hides your jobbie name.
 * rscadd: Vampire's Screech now breaks lights in a radius around the vampire.