### PR TITLE
Disables auto signups for roles while adminned

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -225,6 +225,10 @@
 				roleselect_debug("get_active_candidates(role_id=[role_id], buffer=[buffer], poll=[poll]): Skipping [G]  - Inactive.")
 				continue
 
+			if(isAdminGhost(G)) // don't do this to admins
+				roleselect_debug("get_active_candidates(role_id=[role_id], buffer=[buffer], poll=[poll]): Skipping [G]  - Is adminned.")
+				continue
+
 			roleselect_debug("get_active_candidates(role_id=[role_id], buffer=[buffer], poll=[poll]): Selected [G] as candidate.")
 			candidates += G
 		i++


### PR DESCRIPTION
[administration][qol]

## What this does
Makes recruiters skip any ghosts that are admins from automatic signup pollings.


## Why it's good
Allows admins to keep observing rounds without worry of this.

## Changelog
:cl:
 * tweak: Admins are no longer automatically signed up for ghost roles.