### PR TITLE
Robust Harvest balance

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2502,9 +2502,9 @@
 	..()
 	T.add_nutrientlevel(1)
 	if(prob(25*custom_plant_metabolism))
-		T.add_weedlevel(10)
+		T.add_weedlevel(3)
 	if(T.seed && !T.dead && prob(25*custom_plant_metabolism))
-		T.add_pestlevel(10)
+		T.add_pestlevel(3)
 	if(T.seed && !T.dead && !T.seed.immutable)
 		var/chance
 		chance = unmix(T.seed.potency, 15, 150)*350*custom_plant_metabolism


### PR DESCRIPTION
[balance][tweak][qol]

Apparently weeds still grow too fast and there's really no reason to ruin a botanists round for using robust harvest

## What this does
- changes two numbers so the weed rate and pest rate are lower

## Why it's good
- Botanists still complaining about robust harvest being too aggressively weedy although it should be consistent with previous use
- no reason not to reduce it if it allows for higher QoL

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: lowered robust harvest weed rates again
