### PR TITLE
Advanced RCD reinforcement cost change

### DIFF
--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -93,7 +93,7 @@
 	icon				= 'icons/turf/floors.dmi'
 	icon_state			= "engine"
 	category			= "Construction"
-	energy_cost			= 2
+	energy_cost			= 1
 
 	flags		= RCD_GET_TURF
 
@@ -147,7 +147,7 @@
 	icon				= 'icons/turf/walls.dmi'
 	icon_state			= "r_wall"
 	category			= "Construction"
-	energy_cost			= 5
+	energy_cost			= 2
 
 /datum/rcd_schematic/con_rwalls/attack(var/atom/A, var/mob/user)
 	if(A?.type != /turf/simulated/wall) // Only one with strict type like this for now


### PR DESCRIPTION
#32795's OP said it would cost 1 unit to reinforce a floor and 2 to reinforce a wall, yet the code says 2 for a floor and 5 for a wall.
[tweak][balance]
:cl:
 * tweak: Reinforcing floors or walls with the Advanced RCD now cost what was originally advertised.