### PR TITLE
Moves the football uniforms to the autodrobe.

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -848,21 +848,6 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/security_formal_wear/New()
 	selection_from = list(Blue, Navy, Tan)
 
-/datum/supply_packs/nfl_suits
-	name = "NFL Suit and training dummy"
-	contains = list(/obj/structure/mannequin,
-					/obj/item/clothing/head/syndie_football_helmet,
-					/obj/item/clothing/head/syndie_football_helmet,
-					/obj/item/clothing/head/syndie_football_helmet,
-					/obj/item/clothing/suit/syndie_football,
-					/obj/item/clothing/suit/syndie_football,
-					/obj/item/clothing/suit/syndie_football,)
-	cost = 100
-	containertype = /obj/structure/largecrate/
-	containername = "NFL dummy crate"
-	group = "Clothing"
-
-
 //Winter Coats//
 
 /datum/supply_packs/engwinter

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2631,7 +2631,9 @@ var/global/num_vending_terminals = 1
 		/obj/item/clothing/head/cowboy = 3,
 		/obj/item/clothing/suit/kimono/sakura = 3,
 		/obj/item/clothing/head/widehat_red = 3,
-		/obj/item/clothing/suit/red_suit = 3
+		/obj/item/clothing/suit/red_suit = 3,
+		/obj/item/clothing/head/nt_football_helmet = 5,
+		/obj/item/clothing/suit/nt_football = 5,
 		) //Pretty much everything that had a chance to spawn.
 	contraband = list(
 		/obj/item/weapon/storage/box/smartbox/clothing_box/clownpsyche = AUTO_DROBE_DEFAULT_STOCK,
@@ -2639,6 +2641,8 @@ var/global/num_vending_terminals = 1
 		/obj/item/clothing/head/cardborg = 3,
 		/obj/item/clothing/suit/judgerobe = 3,
 		/obj/item/clothing/head/powdered_wig = 3,
+		/obj/item/clothing/head/syndie_football_helmet = 5,
+		/obj/item/clothing/suit/syndie_football = 5,
 		/obj/item/toy/gun = 3,
 		/obj/item/weapon/glue/temp_glue = 1
 		)
@@ -2714,14 +2718,12 @@ var/global/num_vending_terminals = 1
 		/obj/item/clothing/head/beanie/stripedred = 10,
 		/obj/item/clothing/head/beanie/stripedblue = 10,
 		/obj/item/clothing/head/beanie/stripedgreen = 10,
-		/obj/item/clothing/head/nt_football_helmet = 5,
 		)
 	contraband = list(
 		/obj/item/clothing/mask/balaclava = 5,
 		/obj/item/clothing/head/bearpelt = 5,
 		/obj/item/clothing/head/bearpelt/brown = 5,
 		/obj/item/clothing/head/energy_dome = 5,
-		/obj/item/clothing/head/syndie_football_helmet = 5,
 		)
 	premium = list(
 		/obj/item/clothing/head/soft/rainbow = 1,
@@ -2786,13 +2788,11 @@ var/global/num_vending_terminals = 1
 		/obj/item/clothing/suit/storage/wintercoat/hoodie/yellow = 10,
 		/obj/item/clothing/suit/storage/wintercoat/hoodie/orange = 10,
 		/obj/item/clothing/suit/storage/wintercoat/hoodie/cyan = 10,
-		/obj/item/clothing/suit/nt_football = 5,
 		)
 	contraband = list(
 		/obj/item/clothing/under/syndicate/tacticool = 5,
 		/obj/item/clothing/under/color/orange = 5,
 		/obj/item/clothing/under/psyche = 5,
-		/obj/item/clothing/suit/syndie_football = 5,
 		)
 	premium = list(
 		/obj/item/clothing/under/rainbow = 1,

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2667,7 +2667,6 @@ var/global/num_vending_terminals = 1
 		/obj/item/clothing/head/helmet/samurai = 3,
 		/obj/item/clothing/suit/armor/samurai = 3,
 		/obj/item/toy/syndicateballoon/green = 1,
-		/obj/item/clothing/head/nt_football_helmet = 5,
 		)
 
 	pack = /obj/structure/vendomatpack/autodrobe
@@ -2714,13 +2713,15 @@ var/global/num_vending_terminals = 1
 		/obj/item/clothing/head/beanie/striped = 10,
 		/obj/item/clothing/head/beanie/stripedred = 10,
 		/obj/item/clothing/head/beanie/stripedblue = 10,
-		/obj/item/clothing/head/beanie/stripedgreen = 10
+		/obj/item/clothing/head/beanie/stripedgreen = 10,
+		/obj/item/clothing/head/nt_football_helmet = 5,
 		)
 	contraband = list(
 		/obj/item/clothing/mask/balaclava = 5,
 		/obj/item/clothing/head/bearpelt = 5,
 		/obj/item/clothing/head/bearpelt/brown = 5,
 		/obj/item/clothing/head/energy_dome = 5,
+		/obj/item/clothing/head/syndie_football_helmet = 5,
 		)
 	premium = list(
 		/obj/item/clothing/head/soft/rainbow = 1,
@@ -2791,6 +2792,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/clothing/under/syndicate/tacticool = 5,
 		/obj/item/clothing/under/color/orange = 5,
 		/obj/item/clothing/under/psyche = 5,
+		/obj/item/clothing/suit/syndie_football = 5,
 		)
 	premium = list(
 		/obj/item/clothing/under/rainbow = 1,


### PR DESCRIPTION
Really weird that the NT football helmet is on the autodrobe under premium, the NT football uniform under normal on the suitlord and the syndie uniform+helmet on the supply shuttle.
:cl:
* tweak: Moves the NT football helmet and uniform to the autodrobe.
* tweak: Moves the Syndie football helmet and uniform to the autodrobe under contraband.
* rscdel: Removes the syndie football clothing supply crate.