### PR TITLE
Electro disability fix

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -1,26 +1,35 @@
 //Refer to life.dm for caller
 
 /mob/living/carbon/human/proc/handle_disabilities()
-	if(disabilities & ELECTROSENSE)
-		var/affect_chance = 100
-		var/affect_amount = 0
+	if(disabilities & ELECTROSENSE && !dna.GetSEState(JAMSIGNALSBLOCK))
+		var/affect_chance = 30
+		var/affected = FALSE
 		if(head && istype(head,/obj/item/clothing/head/tinfoil))
-			affect_chance /= 2
+			affect_chance -= 15
 		if(wear_suit && istype(wear_suit,/obj/item/clothing/suit/spaceblanket))
-			affect_chance /= 2
-		for(var/obj/machinery/M in range(3,src))
-			if(!(M.stat & (NOPOWER|BROKEN|FORCEDISABLE)) && M.use_power > 0 && prob(affect_chance))
-				affect_amount++
-		for(var/atom/movable/A in range(rand(1,2),src))
-			var/obj/item/weapon/cell/C = A.get_cell()
-			if(C && C.charge && prob(affect_chance))
-				affect_amount++
-		if(!stat)
-			adjustHalLoss(affect_amount)
-			if(prob(min(affect_amount,100)))
-				Jitter(min(affect_amount,100))
-			if(prob(min(affect_amount,100)))
-				eye_blurry += min(affect_amount,100)
+			affect_chance -= 15
+		if(prob(affect_chance))
+			for(var/atom/movable/A in view(2,src))
+				if(istype(A,/obj/machinery))
+					var/obj/machinery/M = A
+					if(!(M.stat & (NOPOWER|BROKEN|FORCEDISABLE)) && M.use_power > 0)
+						affected = TRUE
+						continue
+				if(istype(A,/obj/item/weapon/cell))
+					var/obj/item/weapon/cell/C = A.get_cell()
+					if(C && C.charge)
+						affected = TRUE
+						continue
+				if(istype(A,/obj/item/device/radio))
+					affected = TRUE
+					continue
+		if(affected)
+			to_chat(src, "<span class='warning'>The electrical devices hum loudly!</span>")
+			Jitter(20)
+			if(eye_blurry <= 1)
+				eye_blurry = 10
+			if(getHalLoss() < 40)
+				adjustHalLoss(20)
 
 	if(disabilities & ASTHMA)
 		if(prob(0.2))


### PR DESCRIPTION
[bugfix]

## What this does
- Limits the amount of halloss a user can receive and also adds radios as a trigger

## Why it's good
- Electro disability now no longer paincrits you almost instantly forever

:cl:
* tweak: Electrosense disability is now completely negated by wearing appropriate clothing or by having the JAMSIGNAL mutation.
* tweak: Lowered the maximum trigger chance on electrosense disability by 70%.
* tweak: The range of the disability has been reduced by 33%.
* tweak: Electrosense disability no longer stacks with multiple sources of electricity.
* tweak: Radios are now included as a trigger of the electrosense disability
* tweak: Players with electrosense disability no longer take any hallucination damage past 59, making it impossible to go into crit.
* tweak: Reduced maximum blurriness from electrosense disability by 90%.
* tweak: Reduced maximum jitteriness from electrosense disability by 80%.