### PR TITLE
ALT + Click to insert entire stack into auto/protolathes

### DIFF
--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -148,6 +148,66 @@ var/global/list/rnd_machines = list()
 	if(research_flags &HASOUTPUT)
 		..()
 
+/obj/machinery/r_n_d/AltClick(mob/user)
+	if (shocked)
+		shock(user,50, user.get_active_hand().siemens_coefficient)
+	if (busy)
+		to_chat(user, "<span class='warning'>The [src.name] is busy. Please wait for completion of previous operation.</span>")
+		return 1
+	if(panel_open)
+		return 1
+	if (stat)
+		return 1
+	if (disabled)
+		return 1
+	if (!linked_console && !(istype(src, /obj/machinery/r_n_d/fabricator))) //fabricators get a free pass because they aren't tied to a console
+		to_chat(user, "\The [src] must be linked to an R&D console first!")
+		return 1
+	if(istype(user.get_active_hand(),/obj/item/stack/sheet) && research_flags &TAKESMATIN)
+		var/found = "" //the matID we're compatible with
+		var/obj/item/stack/sheet/stack = user.get_active_hand()
+		for(var/matID in materials.storage)
+			var/datum/material/M = materials.getMaterial(matID)
+			if(M.sheettype==stack.type)
+				found = matID
+		if(!user.Adjacent(src) || !stack || !stack.loc || (stack.loc != user && !isgripper(stack.loc)))
+			return 1
+		/var/amount = 0 
+		amount = min(stack.amount, round((max_material_storage-TotalMaterials())/stack.perunit))
+
+		if (!(amount > 0))
+			to_chat(user, "<span class='warning'>\The [src]'s material bin is full. Please remove material before adding more.</span>")
+			return 1
+
+		if (busy)
+			to_chat(user, "<span class='warning'>\The [src] is busy. Please wait for completion of previous operation.</span>")
+			return 1
+
+		busy = TRUE
+
+		if(research_flags & HASMAT_OVER)
+			update_icon()
+			overlays |= image(icon = icon, icon_state = "[base_state]_[stack.name]")
+			if(default_mat_overlays)
+				overlays |= image(icon = icon, icon_state = "autolathe_[stack.name]")
+			spawn(ANIM_LENGTH)
+				overlays -= image(icon = icon, icon_state = "[base_state]_[stack.name]")
+				if(default_mat_overlays)
+					overlays -= image(icon = icon, icon_state = "autolathe_[stack.name]")
+
+		icon_state = "[base_state]"
+		use_power(max(1000, (3750*amount/10)))
+		stack.use(amount)
+		to_chat(user, "<span class='notice'>You add [amount] sheet[amount > 1 ? "s":""] to the [src].</span>")
+		icon_state = "[base_state]"
+
+		var/datum/material/material = materials.getMaterial(found)
+		materials.addAmount(found, amount * material.cc_per_sheet)
+		spawn(ANIM_LENGTH)
+			busy = FALSE
+		return 1
+	return 0
+
 /obj/machinery/r_n_d/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if (shocked)
 		shock(user,50, O.siemens_coefficient)

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -149,8 +149,9 @@ var/global/list/rnd_machines = list()
 		..()
 
 /obj/machinery/r_n_d/AltClick(mob/user)
+	var/obj/item/O = user.get_active_hand()
 	if (shocked)
-		shock(user,50, user.get_active_hand().siemens_coefficient)
+		shock(user,50, O.siemens_coefficient)
 	if (busy)
 		to_chat(user, "<span class='warning'>The [src.name] is busy. Please wait for completion of previous operation.</span>")
 		return 1
@@ -163,9 +164,9 @@ var/global/list/rnd_machines = list()
 	if (!linked_console && !(istype(src, /obj/machinery/r_n_d/fabricator))) //fabricators get a free pass because they aren't tied to a console
 		to_chat(user, "\The [src] must be linked to an R&D console first!")
 		return 1
-	if(istype(user.get_active_hand(),/obj/item/stack/sheet) && research_flags &TAKESMATIN)
+	if(istype(O,/obj/item/stack/sheet) && research_flags &TAKESMATIN)
 		var/found = "" //the matID we're compatible with
-		var/obj/item/stack/sheet/stack = user.get_active_hand()
+		var/obj/item/stack/sheet/stack = O
 		for(var/matID in materials.storage)
 			var/datum/material/M = materials.getMaterial(matID)
 			if(M.sheettype==stack.type)

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -172,7 +172,7 @@ var/global/list/rnd_machines = list()
 				found = matID
 		if(!user.Adjacent(src) || !stack || !stack.loc || (stack.loc != user && !isgripper(stack.loc)))
 			return 1
-		/var/amount = 0 
+		var/amount = 0 
 		amount = min(stack.amount, round((max_material_storage-TotalMaterials())/stack.perunit))
 
 		if (!(amount > 0))


### PR DESCRIPTION
[qol]
## What this does
You can now hold ALT when inserting materials into a protolathe, autolathe or fabricator to insert the entire stack of materials. If the materials bins would overflow, it'll just take the maximum amount out of the stack. Slightly cursed code, due to the rnd_machines being a mess but testing it worked and didn't break shocking or anything else.

## Why it's good
Most of the time, you just want to stick the entire stack of materials in. Removing the input box just makes it smoother.

## Changelog
 * rscadd: You can now hold ALT+Click to insert entire stack of materials into protolathe, autolathe or fabricator 


