### PR TITLE
RCL can pickup cable on ground

### DIFF
--- a/code/game/objects/items/stacks/cable.dm
+++ b/code/game/objects/items/stacks/cable.dm
@@ -148,6 +148,10 @@ var/global/list/datum/stack_recipe/cable_recipes = list ( \
 		to_chat(user, "<span class='notice'>You cut a piece off the cable coil.</span>")
 		update_icon()
 		return
+	if(istype(W, /obj/item/weapon/rcl/))
+		var/obj/item/weapon/rcl/O = W
+		O.attackby(src, usr)
+		return
 	return ..()
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
## What this does
Exactly what it says, RCL can now pickup cable on ground instead of having to pick it up and put it in manually.

## Why it's good
Makes fixing cut wires and stuff easier with an RCL. Should hopefully see actual use with this change.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Rapid Cable Layers can now pickup cables on the ground

