### PR TITLE
Sorts R&D designs by name

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -610,6 +610,15 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				screen = 1.6
 				updateUsrDialog()
 
+	else if(href_list["alphatoggle"]) //Reset the R&D console's database.
+		griefProtection()
+		if(files)
+			screen = 0.0
+			files.alphabetsort = !files.alphabetsort
+			spawn(20)
+				screen = 1.6
+				updateUsrDialog()
+
 	else if(href_list["toggleCategory"]) //Filter or unfilter a category
 		var/cat = href_list["toggleCategory"]
 		var/machine = href_list["machine"]
@@ -814,6 +823,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 			dat += {"<A href='?src=\ref[src];menu=1.7'>Device Linkage Menu</A><BR>
 				<A href='?src=\ref[src];lock=0.2'>Lock Console</A><BR>
+				<A href='?src=\ref[src];alphatoggle=1'>[files?.alphabetsort ? "Dis" : "En"]able alphabetical sorting.</A><BR>
 				<A href='?src=\ref[src];reset=1'>Reset R&D Database.</A><BR>"}
 		if(1.7) //R&D device linkage
 

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -144,6 +144,7 @@ var/global/list/hidden_tech = list(
 		T.level = clamp(T.level, 1, 20)
 	for(var/datum/design/D in known_designs)
 		D.CalcReliability(known_tech)
+	sortTim(known_designs, /proc/cmp_name_asc)
 	return
 
 //Refreshes the levels of a given tech.

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -55,6 +55,7 @@ var/global/list/hidden_tech = list(
 /datum/research								//Holder for all the existing, archived, and known tech. Individual to console.
 	var/list/known_tech = list()			//List of locally known tech.
 	var/list/known_designs = list()			//List of available designs (at base reliability).
+	var/alphabetsort = FALSE				//Is it sorted alphabetically?
 
 /datum/research/New()		//Insert techs into possible_tech here. Known_tech automatically updated.
 	if(!tech_list.len)
@@ -144,7 +145,8 @@ var/global/list/hidden_tech = list(
 		T.level = clamp(T.level, 1, 20)
 	for(var/datum/design/D in known_designs)
 		D.CalcReliability(known_tech)
-	sortTim(known_designs, /proc/cmp_name_asc)
+	if(alphabetsort)
+		sortTim(known_designs, /proc/cmp_name_asc)
 	return
 
 //Refreshes the levels of a given tech.


### PR DESCRIPTION
[tweak][qol]

## What this does
Makes the names of designs as displayed on R&D consoles be sorted by name under each category every time they get refreshed when enabled as a setting in the R&D console settings. (such as adding levels and deconstructing things)

## Why it's good
More consistency with the order they're displayed in, more muscle memory to it.

## Changelog
:cl:
 * tweak: R&D designs now show up in alphabetical order under their categories, when toggled on in the settings menu. Is off by default.