### PR TITLE
Spray bottles now limb target their reagents

### DIFF
--- a/code/game/objects/effects/decals/chemical_puff.dm
+++ b/code/game/objects/effects/decals/chemical_puff.dm
@@ -18,12 +18,12 @@
 	..()
 
 // Reacts with the current turf and its contents
-/obj/effect/decal/chemical_puff/proc/react(var/iteration_delay = 2)
+/obj/effect/decal/chemical_puff/proc/react(var/iteration_delay = 2, var/list/zones)
 	var/turf/cur_turf = get_turf(src)
 	reagents.reaction(cur_turf)
 
 	for (var/atom/A in cur_turf)
-		reagents.reaction(A)
+		reagents.reaction(A, zone_sels = zones && zones.len ? zones : ALL_LIMBS)
 
 		// When spraying against a wall, react with it but not its contents
 		if (get_dist(src, initial_turf) <= 1 && initial_turf.density)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -231,7 +231,7 @@
 
 			for (var/j = 1, j <= rand(6, 8), j++)
 				step_towards(D, my_target)
-				D.react(iteration_delay = 0, zones = user && user.zone_sel ? list(user.zone_sel.selecting) : ALL_LIMBS)
+				D.react(iteration_delay = 0)
 				sleep(2)
 
 			qdel(D)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -104,7 +104,7 @@
 	spawn(0)
 		for (var/i = 0, i < 3, i++)
 			step_towards(D, target)
-			D.react()
+			D.react(zones = user?.zone_sel ? list(user.zone_sel.selecting) : ALL_LIMBS)
 			sleep(3)
 
 		qdel(D)
@@ -231,7 +231,7 @@
 
 			for (var/j = 1, j <= rand(6, 8), j++)
 				step_towards(D, my_target)
-				D.react(iteration_delay = 0)
+				D.react(iteration_delay = 0, zones = user && user.zone_sel ? list(user.zone_sel.selecting) : ALL_LIMBS)
 				sleep(2)
 
 			qdel(D)
@@ -265,7 +265,7 @@
 			step_towards(D, target)
 			if(i > 1)
 				D.flags &= ~NOREACT
-			D.react()
+			D.react(zones = user && user.zone_sel ? list(user.zone_sel.selecting) : ALL_LIMBS)
 			sleep(3)
 
 		qdel(D)


### PR DESCRIPTION
[tweak][bugfix]

## What this does
See title.

## Why it's good
Makes them less broken overall.

## Changelog
:cl:
 * tweak: Spray bottles will now only target the limb the user is selecting for reagent reactions.