### PR TITLE
Toxin bottles on NutriMax contraband.

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2124,6 +2124,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/storage/bag/plants = 5,
 		)
 	contraband = list(
+		/obj/item/weapon/reagent_containers/glass/bottle/toxin = 10,
 		/obj/item/weapon/reagent_containers/glass/bottle/ammonia = 10,
 		/obj/item/weapon/reagent_containers/glass/bottle/diethylamine = 5,
 		)


### PR DESCRIPTION
Since we can have toxin-dependent plants now adding toxin bottles seemed appropriate, and it would not affect balance much considering botany has access to way stronger poisons than regular toxin.

### Why it's good
Helps you more easily plant and take care of toxin-dependent plants.
:cl:
 * rscadd: Toxin bottles on NutriMax contraband.