### PR TITLE
Another consciousness is in your body

### DIFF
--- a/code/modules/mob/dead/observer/verbs.dm
+++ b/code/modules/mob/dead/observer/verbs.dm
@@ -9,7 +9,6 @@
 		to_chat(src, "<span class='warning'>You have no body.</span>")
 		return
 	if(mind.current.key && copytext(mind.current.key,1,2)!="@")	//makes sure we don't accidentally kick any clients
-		to_chat(usr, "<span class='warning'>Another consciousness is in your body...It is resisting you.</span>")
 		return
 	if(mind.current.ajourn && istype(mind.current.ajourn,/obj/effect/rune_legacy) && mind.current.stat != DEAD) 	//check if the corpse is astral-journeying (it's client ghosted using a cultist rune).
 		var/obj/effect/rune_legacy/R = mind.current.ajourn	//whilst corpse is alive, we can only reenter the body if it's on the rune


### PR DESCRIPTION
Double-clicking yourself as a ghost spams this message

## What this does
Removes the feedback `to_chat` whenever you fail to return to your ghostly body (which doesn't exist).

## Why it's good
Don't get spammed as much
Closes #24631

:cl:
 * tweak: Removes the consciousness text when double-clicking yourself as a ghost