### PR TITLE
Hydroponics weed problem

### DIFF
--- a/code/modules/hydroponics/hydroponics_reagents.dm
+++ b/code/modules/hydroponics/hydroponics_reagents.dm
@@ -33,10 +33,8 @@
 			return
 	if (amount > 0)
 		nutrientlevel = round(min(nutrientlevel + amount, NUTRIENTLEVEL_MAX))
-		weedlevel = round(min(weedlevel + amount, WEEDLEVEL_MAX))
 	else
 		nutrientlevel = round(max(0, nutrientlevel + amount))
-		weedlevel = round(max(0, weedlevel + amount))
 		if(nutrientlevel < 1)
 			add_planthealth(-rand(1,3) * HYDRO_SPEED_MULTIPLIER)
 			affect_growth(-1)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2502,9 +2502,9 @@
 	..()
 	T.add_nutrientlevel(1)
 	if(prob(25*custom_plant_metabolism))
-		T.add_weedlevel(3)
+		T.add_weedlevel(10)
 	if(T.seed && !T.dead && prob(25*custom_plant_metabolism))
-		T.add_pestlevel(3)
+		T.add_pestlevel(10)
 	if(T.seed && !T.dead && !T.seed.immutable)
 		var/chance
 		chance = unmix(T.seed.potency, 15, 150)*350*custom_plant_metabolism

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2452,9 +2452,6 @@
 				H.custom_pain("Your [E] burn horribly!", 1)
 				H.apply_damage(2, BRUTE, LIMB_HEAD)
 
-//Reagents used for plant fertilizers.
-//WHY, just WHY, were fertilizers declared as a child of toxin and later snowflaked to work differently in the hydrotray's process_reagents()?
-
 /datum/reagent/fertilizer
 	name = "fertilizer"
 	id = FERTILIZER


### PR DESCRIPTION
I spotted a problem that I missed with my previous PRs: adding nutrient would increase weeds.

## What this does
- returns robust harvest back to where it was
- eznutrient no longer causes weeds
- This should restore hydroponics to its former glory

## Why it's good
Closes #32845

:cl:
 * tweak: eznutrient no longer causes weed problems