### PR TITLE
Adds engineering and mining cameras to the circuit imprinter

### DIFF
--- a/code/modules/research/designs/boards/computer_engie.dm
+++ b/code/modules/research/designs/boards/computer_engie.dm
@@ -174,3 +174,13 @@
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Console Boards"
 	build_path = /obj/item/weapon/circuitboard/atmoscontrol
+
+/datum/design/engcamera
+	name = "Circuit Design (Engineering Cameras)"
+	desc = "Allows for the construction of circuit boards used to build engineering camera computers."
+	id = "engcamera"
+	req_tech = list(Tc_PROGRAMMING = 2)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 2000, SACID = 20)
+	category = "Console Boards"
+	build_path = /obj/item/weapon/circuitboard/security/engineering

--- a/code/modules/research/designs/boards/computer_misc.dm
+++ b/code/modules/research/designs/boards/computer_misc.dm
@@ -89,3 +89,13 @@
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Console Boards"
 	build_path = /obj/item/weapon/circuitboard/shuttle_control
+
+/datum/design/minecamera
+	name = "Circuit Design (Mining Cameras)"
+	desc = "Allows for the construction of circuit boards used to build mining camera computers."
+	id = "minecamera"
+	req_tech = list(Tc_PROGRAMMING = 2)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 2000, SACID = 20)
+	category = "Console Boards"
+	build_path = /obj/item/weapon/circuitboard/mining


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Allows research computer users to print Engineering and Mining Camera boards from the circuit imprinter. Research level is the same as the Security Camera Console board.

## Why it's good
<!-- Explain why you think these changes are good. -->
Closes #32842.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Engineering and Mining Camera Console boards can now be printed.

