### PR TITLE
Antimatter axe modkit consistency

### DIFF
--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -183,3 +183,17 @@
 	parts[1] =	1
 	original[1] = /obj/item/weapon/gun/lawgiver
 	finished[1] = /obj/item/weapon/gun/lawgiver/demolition
+
+/obj/item/device/modkit/antiaxe_kit
+	name = "antimatter axe kit"
+	desc = "A matter inverter from the secret labs of the Cloud IX engineering facility. It will turn your ordinary axe into an antimatter axe."
+
+/obj/item/device/modkit/antiaxe_kit/New()
+	..()
+	parts = new/list(1)
+	original = new/list(1)
+	finished = new/list(1)
+
+	parts[1] =	1
+	original[1] = /obj/item/weapon/fireaxe
+	finished[1] = /obj/item/weapon/fireaxe/antimatter

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -1373,7 +1373,7 @@ var/global/list/cloudnine_stuff = list(
 	/obj/structure/largecrate/secure/magmaw,
 	/obj/item/wasteos,
 	/obj/item/weapon/storage/toolbox/master,
-	/obj/item/weapon/antiaxe_kit,
+	/obj/item/device/modkit/antiaxe_kit,
 	)
 
 /obj/structure/closet/crate/internals/cloudnine/New()
@@ -1636,16 +1636,6 @@ var/list/omnitoolable = list(/obj/machinery/alarm,/obj/machinery/power/apc)
 /obj/item/weapon/storage/toolbox/master/attack_self(mob/user)
 	cant_drop = !cant_drop
 	to_chat(user,"<span class='notice'>You [cant_drop ? "engage" : "disengage"] the safety grip.</span>")
-
-/obj/item/weapon/antiaxe_kit
-	name = "antimatter axe kit"
-	desc = "A matter inverter from the secret labs of the Cloud IX engineering facility. It will turn your ordinary axe into an antimatter axe."
-	icon = 'icons/obj/device.dmi'
-	icon_state = "modkit"
-	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/newsprites_lefthand.dmi', "right_hand" = 'icons/mob/in-hand/right/newsprites_righthand.dmi')
-	flags = FPRINT
-	siemens_coefficient = 0
-	w_class = W_CLASS_SMALL
 
 /obj/item/weapon/fireaxe/antimatter
 	name = "antimatter fireaxe"

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -86,14 +86,6 @@
 	if(user)
 		user.update_inv_hands()
 
-/obj/item/weapon/fireaxe/attackby(obj/item/weapon/W, mob/user)
-	..()
-	if(istype(W,/obj/item/weapon/antiaxe_kit))
-		playsound(src, 'sound/weapons/emitter.ogg', 25, 1)
-		new /obj/item/weapon/fireaxe/antimatter(loc)
-		qdel(W)
-		qdel(src)
-
 /obj/item/weapon/fireaxe/suicide_act(mob/user)
 		to_chat(viewers(user), "<span class='danger'>[user] is smashing \himself in the head with the [src.name]! It looks like \he's commit suicide!</span>")
 		return (SUICIDE_ACT_BRUTELOSS)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Makes the trader Antimatter Axe Modkit consistent with other modkits instead of being snowflaked.

## Why it's good
<!-- Explain why you think these changes are good. -->
Prevents using the modkit improperly while wearing an axe (closes #32654)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Antimatter Axe Modkit is now consistent with other modkits
