### PR TITLE
Fixes drooling issue

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -116,7 +116,7 @@
 		"How do I set up the. SHow do I set u p the Singu. how I the scrungularity????", \
 		"OMG I SED LAW 2 U FAG MOMIM LAW 2!!!", \
 		"I AM BASTE"))
-	else if(prob(3))
+	else if(getBrainLoss() >= 60 && prob(3))
 		emote("drool")
 	if(getBrainLoss() > 50 && prob(1.5))
 		if(canmove)


### PR DESCRIPTION
## What this does
Fixes an issue where every player is drooling regularly, every minute or so.

## Why it's good
While it is slightly amusing that NT is sending braindead workers to the station, it gets annoying quickly.

## Changelog
 * bugfix: Fixed bug that caused constant drooling.


