### PR TITLE
Fixes disposal cross runtime

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -456,7 +456,7 @@
 		if(istype(I, /obj/item/weapon/dummy) || istype(I, /obj/item/projectile))
 			return
 		var/mob/mob = get_mob_by_key(mover.fingerprintslast)
-		if(prob(75) || (mob && mob.reagents.get_sportiness()>=5))
+		if(prob(75) || (mob?.reagents?.get_sportiness()>=5))
 			I.forceMove(src)
 			for(var/mob/M in viewers(src))
 				M.show_message("\the [I] lands in \the [src].", 1)


### PR DESCRIPTION
[bugfix][runtime]

## What this does
Makes things land in disposal bins 33% more often when fired out of a vending machine or any other throwing item that isn't a mob.

## Why it's good
Stops them from stopping just short of the bin in those cases.

## Changelog
:cl:
 * bugfix: Vending machines and similar items can now land items in disposal bins more reliably.