### PR TITLE
Faster server startup

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -32,45 +32,43 @@
 
 	return null
 
-/obj/machinery/atmospherics/binary/valve/proc/open(var/animate = TRUE)
+/obj/machinery/atmospherics/binary/valve/proc/open()
 	if(open)
 		return 0
 
-	if(animate)
-		update_icon(0,1)
-		sleep(10)
-	open = TRUE
-	update_icon()
+	update_icon(0,1)
+	spawn(10)
+		open = TRUE
+		update_icon()
 
-	if(network1&&network2)
-		network1.merge(network2)
-		network2 = network1
+		if(network1&&network2)
+			network1.merge(network2)
+			network2 = network1
 
-	if(network1)
-		network1.update = 1
-	else if(network2)
-		network2.update = 1
+		if(network1)
+			network1.update = 1
+		else if(network2)
+			network2.update = 1
 
 	return 1
 
-/obj/machinery/atmospherics/binary/valve/proc/close(var/animate = TRUE)
+/obj/machinery/atmospherics/binary/valve/proc/close()
 	if(!open)
 		return 0
 
-	if(animate)
-		update_icon(0,1)
-		sleep(10)
-	open = FALSE
-	update_icon()
+	update_icon(0,1)
+	spawn(10)
+		open = FALSE
+		update_icon()
 
-	if(network1)
 		if(network1)
-			qdel(network1)
-	if(network2)
-		if(network1)
-			qdel(network2)
+			if(network1)
+				qdel(network1)
+		if(network2)
+			if(network1)
+				qdel(network2)
 
-	build_network()
+		build_network()
 
 	return 1
 
@@ -102,8 +100,8 @@
 	build_network()
 
 	if(openDuringInit)
-		close(FALSE)
-		open(FALSE)
+		close()
+		open()
 		openDuringInit = 0
 
 	else

--- a/code/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -32,12 +32,13 @@
 
 	return null
 
-/obj/machinery/atmospherics/binary/valve/proc/open()
+/obj/machinery/atmospherics/binary/valve/proc/open(var/animate = TRUE)
 	if(open)
 		return 0
 
-	update_icon(0,1) //animate
-	sleep(10)
+	if(animate)
+		update_icon(0,1)
+		sleep(10)
 	open = TRUE
 	update_icon()
 
@@ -52,12 +53,13 @@
 
 	return 1
 
-/obj/machinery/atmospherics/binary/valve/proc/close()
+/obj/machinery/atmospherics/binary/valve/proc/close(var/animate = TRUE)
 	if(!open)
 		return 0
 
-	update_icon(0,1) //animate
-	sleep(10)
+	if(animate)
+		update_icon(0,1)
+		sleep(10)
 	open = FALSE
 	update_icon()
 
@@ -100,8 +102,8 @@
 	build_network()
 
 	if(openDuringInit)
-		close()
-		open()
+		close(FALSE)
+		open(FALSE)
 		openDuringInit = 0
 
 	else

--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -46,13 +46,14 @@
 	if(config.log_admin_only)
 		admin_diary << html_decode(text_to_log)
 
-/proc/log_debug(text)
+/proc/log_debug(text, send2chat = TRUE)
 	if (!config || config.log_debug) // Sorry, if config isn't loaded we'll assume you want debug output.
 		diary << html_decode("\[[time_stamp()]]DEBUG: [text]")
 
-	for(var/client/C in admins)
-		if(C.prefs.toggles & CHAT_DEBUGLOGS)
-			to_chat(C, "DEBUG: [text]")
+	if(send2chat)
+		for(var/client/C in admins)
+			if(C.prefs.toggles & CHAT_DEBUGLOGS)
+				to_chat(C, "DEBUG: [text]")
 
 /proc/log_sql(text)
 	if (!config || (config && config.log_sql))

--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -130,7 +130,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 	// Sort subsystems by init_order, so they initialize in the correct order.
 	sortTim(subsystems, /proc/cmp_subsystem_init)
 
-	var/time_to_init = world.time
+	var/time_to_init = world.timeofday
 	// Initialize subsystems.
 	CURRENT_TICKLIMIT = TICK_LIMIT_MC_INIT
 	for (var/datum/subsystem/SS in subsystems)
@@ -139,7 +139,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		SS.Initialize(world.timeofday)
 		CHECK_TICK
 	CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
-	time_taken_to_init = world.time - time_to_init
+	time_taken_to_init = world.timeofday - time_to_init
 
 	to_chat(world, "<span class='boldannounce'>Initializations complete in [time_taken_to_init / 10] seconds!</span>")
 	world.log << "Initializations complete. Took [time_taken_to_init / 10] seconds."

--- a/code/controllers/mc/subsystem.dm
+++ b/code/controllers/mc/subsystem.dm
@@ -156,7 +156,8 @@
 /datum/subsystem/proc/Initialize(start_timeofday)
 	var/time = (world.timeofday - start_timeofday) / 10
 	var/msg = "Initialized [name] subsystem within [time] seconds!"
-	log_debug(msg)
+	log_debug(msg,FALSE) // Redundant chat output as whole world sees message below anyways
+	world.log << msg
 	to_chat(world, "<span class='danger'>[msg]</span>")
 	initialized = TRUE
 	return time

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -24,7 +24,7 @@ var/list/processing_objects = list()
 			var/time_start = world.timeofday
 			object.initialize()
 			var/time = (world.timeofday - time_start)
-			if(time > 1 SECONDS)
+			if(time > 1) // At this point very few items (such as corpse landmarks) take longer than a tick to init, with the main bulk of items taking around 1 tick being things that use relativewall()
 				var/turf/T = get_turf(object)
 				log_debug("Slow object initialize. [object] ([object.type]) at [T?.x],[T?.y],[T?.z] took [time/10] seconds to initialize.")
 		else

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -8,6 +8,7 @@ var/area/space_area
 	var/global/global_uid = 0
 	var/uid
 	var/obj/machinery/power/apc/areaapc = null
+	var/list/obj/machinery/alarm/air_alarms = list()
 	var/list/area_turfs
 	plane = ABOVE_LIGHTING_PLANE
 	layer = MAPPING_AREA_LAYER
@@ -187,7 +188,7 @@ var/area/space_area
 	var/danger_level = 0
 
 	// Determine what the highest DL reported by air alarms is
-	for(var/obj/machinery/alarm/AA in src)
+	for(var/obj/machinery/alarm/AA in air_alarms)
 		if((AA.stat & (FORCEDISABLE|NOPOWER|BROKEN)) || AA.shorted || AA.buildstage != 2)
 			continue
 		var/reported_danger_level=AA.local_danger_level

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -331,9 +331,9 @@ var/global/list/airalarm_presets = list(
 	apply_preset(1, 0) // Don't cycle and don't propagate.
 	apply_mode() //apply mode to scrubbers and vents
 
-/obj/machinery/alarm/Move(NewLoc, Dir, step_x, step_y, glide_size_override)
-	var/area/old_area = get_area(src)
-	var/area/new_area = get_area(NewLoc)
+/obj/machinery/alarm/Entered(atom/movable/Obj, atom/OldLoc)
+	var/area/old_area = get_area(OldLoc)
+	var/area/new_area = get_area(Obj)
 	if(old_area != new_area)
 		old_area.air_alarms.Remove(src)
 		new_area.air_alarms.Add(src)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -307,13 +307,16 @@ var/global/list/airalarm_presets = list(
 		if(AC.current == src)
 			AC.current = null
 			nanomanager.update_uis(src)
-
+	var/area/this_area = get_area(src)
+	if(src in this_area.air_alarms)
+		this_area.air_alarms.Remove(src)
 	..()
 
 /obj/machinery/alarm/proc/first_run()
 	var/area/this_area = get_area(src)
 	area_uid = this_area.uid
 	name = "[this_area.name] Air Alarm"
+	this_area.air_alarms.Add(src)
 
 	// breathable air according to human/Life()
 	/*
@@ -328,6 +331,13 @@ var/global/list/airalarm_presets = list(
 	apply_preset(1, 0) // Don't cycle and don't propagate.
 	apply_mode() //apply mode to scrubbers and vents
 
+/obj/machinery/alarm/Move(NewLoc, Dir, step_x, step_y, glide_size_override)
+	var/area/old_area = get_area(src)
+	var/area/new_area = get_area(NewLoc)
+	if(old_area != new_area)
+		old_area.air_alarms.Remove(src)
+		new_area.air_alarms.Add(src)
+	return ..()
 
 /obj/machinery/alarm/initialize()
 	add_self_to_holomap()

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -41,7 +41,7 @@
 	for(var/obj/machinery/door/window/brigdoor/M in all_doors)
 		if (M.id_tag == src.id_tag)
 			targets += M
-			M.open() //these start the shift open
+			M.open(animate = FALSE) //these start the shift open
 
 	for(var/obj/machinery/flasher/F in flashers)
 		if(F.id_tag == src.id_tag)

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -41,7 +41,7 @@
 	for(var/obj/machinery/door/window/brigdoor/M in all_doors)
 		if (M.id_tag == src.id_tag)
 			targets += M
-			M.open(animate = FALSE) //these start the shift open
+			M.open() //these start the shift open
 
 	for(var/obj/machinery/flasher/F in flashers)
 		if(F.id_tag == src.id_tag)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -129,7 +129,7 @@
 /obj/machinery/door/window/CanAStarPass(var/obj/item/weapon/card/id/ID, var/to_dir)
 	return !density || (dir != to_dir) || check_access(ID)
 
-/obj/machinery/door/window/open()
+/obj/machinery/door/window/open(var/animate = TRUE)
 	if(!density) //it's already open you silly cunt
 		return FALSE
 	if(operating == 1) //doors can still open when emag-disabled
@@ -143,10 +143,12 @@
 	if(smartwindow && window_is_opaque)
 		animate(src, color="#FFFFFF", time=10)
 
-	door_animate("opening")
-	playsound(src, soundeffect, 100, 1)
+	if(animate)
+		door_animate("opening")
+		playsound(src, soundeffect, 100, 1)
 	icon_state = "[base_state]open"
-	sleep(animation_delay)
+	if(animate)
+		sleep(animation_delay)
 
 	explosion_resistance = 0
 	setDensity(FALSE)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -129,7 +129,7 @@
 /obj/machinery/door/window/CanAStarPass(var/obj/item/weapon/card/id/ID, var/to_dir)
 	return !density || (dir != to_dir) || check_access(ID)
 
-/obj/machinery/door/window/open(var/animate = TRUE)
+/obj/machinery/door/window/open()
 	if(!density) //it's already open you silly cunt
 		return FALSE
 	if(operating == 1) //doors can still open when emag-disabled
@@ -143,20 +143,17 @@
 	if(smartwindow && window_is_opaque)
 		animate(src, color="#FFFFFF", time=10)
 
-	if(animate)
-		door_animate("opening")
-		playsound(src, soundeffect, 100, 1)
+	door_animate("opening")
+	playsound(src, soundeffect, 100, 1)
 	icon_state = "[base_state]open"
-	if(animate)
-		sleep(animation_delay)
+	spawn(animation_delay)
+		explosion_resistance = 0
+		setDensity(FALSE)
+		set_opacity(0) //You can see through open windoors even if the glass is opaque
+		update_nearby_tiles()
 
-	explosion_resistance = 0
-	setDensity(FALSE)
-	set_opacity(0) //You can see through open windoors even if the glass is opaque
-	update_nearby_tiles()
-
-	if(operating == 1) //emag again
-		operating = 0
+		if(operating == 1) //emag again
+			operating = 0
 	return TRUE
 
 /obj/machinery/door/window/close()
@@ -176,11 +173,11 @@
 	explosion_resistance = initial(explosion_resistance)
 	update_nearby_tiles()
 
-	sleep(animation_delay)
-	if(window_is_opaque) //you can't see through closed opaque windoors
-		set_opacity(1)
+	spawn(animation_delay)
+		if(window_is_opaque) //you can't see through closed opaque windoors
+			set_opacity(1)
 
-	operating = 0
+		operating = 0
 	return TRUE
 
 /obj/machinery/door/window/try_break()

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -371,15 +371,17 @@ var/list/map_dimension_cache = list()
 /dmm_suite/proc/instance_atom(var/path,var/list/attributes, var/x, var/y, var/z, var/rotate)
 	if(!path)
 		return
+	var/timestart = world.timeofday
 	var/atom/instance
 	_preloader.setup(attributes, path)
 
+	var/turf/T = locate(x,y,z)
 	if(ispath(path, /turf)) //Turfs use ChangeTurf
-		var/turf/oldTurf = locate(x,y,z)
-		if(path != oldTurf.type)
-			instance = oldTurf.ChangeTurf(path, allow = 1)
+		if(path != T.type)
+			instance = T.ChangeTurf(path, allow = 1)
+			T = instance
 	else
-		instance = new path (locate(x,y,z))//first preloader pass
+		instance = new path (T)//first preloader pass
 
 	// Stolen from shuttlecode but very good to reuse here
 	if(rotate && instance)
@@ -388,6 +390,9 @@ var/list/map_dimension_cache = list()
 	if(use_preloader && instance)//second preloader pass, for those atoms that don't ..() in New()
 		_preloader.load(instance)
 
+	var/timetook2instance = world.timeofday - timestart
+	if(timetook2instance > 1)
+		log_debug("Slow atom instance. [instance] ([instance.type]) at [T?.x],[T?.y],[T?.z] took [timetook2instance/10] seconds to instance.")
 	return instance
 
 //text trimming (both directions) helper proc

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -100,16 +100,14 @@
 			if(AMC.add_shielding(src))
 				break
 		if(!mapped) // Prevent suicide if it's part of the map
-			if(!priorscan)
-				sleep(20)
-				controllerscan(1)//Last chance
-				return
-			qdel(src)
-		else
-			if(!priorscan)
-				sleep(20)
+			if(priorscan)
+				qdel(src)
+			else
+				spawn(20)
+					controllerscan(1)//Last chance
+		else if(!priorscan)
+			spawn(20)
 				controllerscan(1)
-				return
 
 // Find surrounding unconnected shielding and add them to our controller
 /obj/machinery/am_shielding/proc/assimilate()

--- a/code/modules/randomMaps/vaults.dm
+++ b/code/modules/randomMaps/vaults.dm
@@ -228,7 +228,7 @@
 		if(ME.load(vault_x, vault_y, vault_z, vault_rotate, overwrites))
 			var/timetook2load = world.timeofday - timestart
 			spawned.Add(ME)
-			log_debug("Loaded [ME.file_path] in [timetook2load / 10] seconds: ([vault_x]) ([vault_y]) ([vault_z]) [(config.disable_vault_rotation || !ME.can_rotate) ? "" : ", rotated by [vault_rotate] degrees"].",FALSE)
+			log_debug("Loaded [ME.file_path] in [timetook2load / 10] seconds at ([vault_x],[vault_y],[vault_z])[(config.disable_vault_rotation || !ME.can_rotate) ? "" : ", rotated by [vault_rotate] degrees"].",FALSE)
 			message_admins("<span class='info'>Loaded [ME.file_path] in [timetook2load / 10] seconds: [formatJumpTo(locate(vault_x, vault_y, vault_z))] [(config.disable_vault_rotation || !ME.can_rotate) ? "" : ", rotated by [vault_rotate] degrees"].</span>")
 			if(!ME.can_rotate)
 				message_admins("<span class='info'>[ME.file_path] was not rotated, can_rotate was set to FALSE.</span>")

--- a/code/modules/randomMaps/vaults.dm
+++ b/code/modules/randomMaps/vaults.dm
@@ -202,7 +202,7 @@
 			var/inbounds = FALSE
 			for(var/turf/start in invalid_bounds) // And begin the invalid bounds checking. Might look like extra work, but is much faster than just removing blocks of spawn points.
 				var/turf/end = invalid_bounds[start]
-				if(new_spawn_point.x >= start.x && new_spawn_point.y >= start.y && new_spawn_point.x <= end?.x && new_spawn_point.y <= end?.y)
+				if(start && end && new_spawn_point.x >= start.x && new_spawn_point.y >= start.y && new_spawn_point.x <= end.x && new_spawn_point.y <= end.y)
 					inbounds = TRUE
 					break
 			if(inbounds || (filter_function && !call(filter_function)(ME, new_spawn_point)))

--- a/code/modules/randomMaps/vaults.dm
+++ b/code/modules/randomMaps/vaults.dm
@@ -152,6 +152,7 @@
 		if(!istype(ME))
 			continue
 
+		var/timestart1 = world.timeofday
 		var/list/dimensions = ME.get_dimensions() //List with the element's width and height
 
 		var/new_width = dimensions[1]
@@ -217,9 +218,14 @@
 			var/turf/t2 = locate(vault_x + new_width, vault_y + new_height, vault_z)
 			valid_spawn_points.Remove(block(t1, t2))
 
+		var/timetook2find = world.timeofday - timestart1
+		log_debug("[ME.file_path] placed in [timetook2find / 10] seconds.")
+		var/timestart2 = world.timeofday
 		if(ME.load(vault_x, vault_y, vault_z, vault_rotate, overwrites))
+			var/timetook2load = world.timeofday - timestart2
+			log_debug("[ME.file_path] loaded in [timetook2load / 10] seconds.")
 			spawned.Add(ME)
-			message_admins("<span class='info'>Loaded [ME.file_path]: [formatJumpTo(locate(vault_x, vault_y, vault_z))] [(config.disable_vault_rotation || !ME.can_rotate) ? "" : ", rotated by [vault_rotate] degrees"].")
+			message_admins("<span class='info'>Loaded [ME.file_path] in [(timetook2find + timetook2load) / 10] seconds: [formatJumpTo(locate(vault_x, vault_y, vault_z))] [(config.disable_vault_rotation || !ME.can_rotate) ? "" : ", rotated by [vault_rotate] degrees"].")
 			if(!ME.can_rotate)
 				message_admins("<span class='info'>[ME.file_path] was not rotated, can_rotate was set to FALSE.</span>")
 			else if(config.disable_vault_rotation)

--- a/code/modules/randomMaps/vaults.dm
+++ b/code/modules/randomMaps/vaults.dm
@@ -144,6 +144,7 @@
 
 	var/list/spawned = list()
 	var/successes = 0
+	var/list/invalid_bounds = list() // Previously we just removed everything in these bounds from valid_spawn_points, which costed about a second or two during placement, now totally eliminated.
 
 	while(map_element_objects.len)
 		var/datum/map_element/ME = pick(map_element_objects)
@@ -152,7 +153,6 @@
 		if(!istype(ME))
 			continue
 
-		var/timestart1 = world.timeofday
 		var/list/dimensions = ME.get_dimensions() //List with the element's width and height
 
 		var/new_width = dimensions[1]
@@ -178,7 +178,7 @@
 					var/turf/t2 = locate(T.x + conflict.width, T.y + conflict.height, T.z) //Corner #2: Old vault's coordinates plus old vault's dimensions
 
 					//A rectangle defined by corners #1 and #2 is marked as invalid spawn area
-					valid_spawn_points.Remove(block(t1, t2))
+					invalid_bounds[t1] = t2
 
 			if(POPULATION_SCARCE)
 				//This method is much cheaper but results in less accuracy. Bad spawn areas will be removed later - when the new vault is created
@@ -199,7 +199,13 @@
 			sanity++
 			new_spawn_point = pick(valid_spawn_points)
 			valid_spawn_points.Remove(new_spawn_point)
-			if(filter_function && !call(filter_function)(ME, new_spawn_point))
+			var/inbounds = FALSE
+			for(var/turf/start in invalid_bounds) // And begin the invalid bounds checking. Might look like extra work, but is much faster than just removing blocks of spawn points.
+				var/turf/end = invalid_bounds[start]
+				if(new_spawn_point.x >= start.x && new_spawn_point.y >= start.y && new_spawn_point.x <= end?.x && new_spawn_point.y <= end?.y)
+					inbounds = TRUE
+					break
+			if(inbounds || (filter_function && !call(filter_function)(ME, new_spawn_point)))
 				new_spawn_point = null
 				filter_counter++
 				continue
@@ -216,16 +222,14 @@
 		if(population_density == POPULATION_SCARCE)
 			var/turf/t1 = locate(max(1, vault_x - MAX_VAULT_WIDTH - 1), max(1, vault_y - MAX_VAULT_HEIGHT - 1), vault_z)
 			var/turf/t2 = locate(vault_x + new_width, vault_y + new_height, vault_z)
-			valid_spawn_points.Remove(block(t1, t2))
+			invalid_bounds[t1] = t2
 
-		var/timetook2find = world.timeofday - timestart1
-		log_debug("[ME.file_path] placed in [timetook2find / 10] seconds.")
-		var/timestart2 = world.timeofday
+		var/timestart = world.timeofday
 		if(ME.load(vault_x, vault_y, vault_z, vault_rotate, overwrites))
-			var/timetook2load = world.timeofday - timestart2
-			log_debug("[ME.file_path] loaded in [timetook2load / 10] seconds.")
+			var/timetook2load = world.timeofday - timestart
 			spawned.Add(ME)
-			message_admins("<span class='info'>Loaded [ME.file_path] in [(timetook2find + timetook2load) / 10] seconds: [formatJumpTo(locate(vault_x, vault_y, vault_z))] [(config.disable_vault_rotation || !ME.can_rotate) ? "" : ", rotated by [vault_rotate] degrees"].")
+			log_debug("Loaded [ME.file_path] in [timetook2load / 10] seconds: ([vault_x]) ([vault_y]) ([vault_z]) [(config.disable_vault_rotation || !ME.can_rotate) ? "" : ", rotated by [vault_rotate] degrees"].",FALSE)
+			message_admins("<span class='info'>Loaded [ME.file_path] in [timetook2load / 10] seconds: [formatJumpTo(locate(vault_x, vault_y, vault_z))] [(config.disable_vault_rotation || !ME.can_rotate) ? "" : ", rotated by [vault_rotate] degrees"].</span>")
 			if(!ME.can_rotate)
 				message_admins("<span class='info'>[ME.file_path] was not rotated, can_rotate was set to FALSE.</span>")
 			else if(config.disable_vault_rotation)


### PR DESCRIPTION
[performance][administration]


## What this does
* Makes brig doors take less than 0.1 seconds to initialise, down from an average of 0.6-0.7
* Makes station alert computers take less than 0.1 seconds to initialise, down from about 1.0-1.3 (except the first one which goes down from ~2 seconds to ~1 second)
* Makes gas valves with openduringinit set to 1 take less than 0.1 seconds to initialise, down from an average of 1
* Changes the "slow init" debug text threshold to above 1 tick instead of 1 second as most of the edge cases are gone now.
* Adds some logging to server setup loading of map elements (as well as slow instances that take more than 1 tick to spawn) for notifying coders of any future worthy optimisations.
* Makes vault area population take less than 0.1 seconds, down from about 1-4
* Adds an argument to log_debug to make it only print to the debug diary and not show to debug users, as to remove the duplicate "Initialised in <time> seconds" lines for them.
* Makes the lightspeed ship vault load in less than 0.1 seconds, down from about 14

## Why it's good
(Map subsystem is shown spawning 15 vaults)
### Before:
![image](https://user-images.githubusercontent.com/57303506/176562501-bb3c7529-9bce-43bb-bc8e-3b5da1f77230.png)
![image](https://user-images.githubusercontent.com/57303506/176562657-e380a9be-7d3a-4b96-907d-99e816ca1abe.png)
![image](https://user-images.githubusercontent.com/57303506/176562878-e00c945d-570f-40e7-ab97-c60cf36833aa.png)
![image](https://user-images.githubusercontent.com/57303506/176761697-7d0d96c9-8b86-4f25-802d-db43a9db5c15.png)
![image](https://user-images.githubusercontent.com/57303506/176762022-fb085dee-0783-47ba-bd30-263702ae48f6.png)
![image](https://user-images.githubusercontent.com/57303506/176762430-304666fb-b0d0-4cc0-8d17-d9209f4529a5.png)

### After:
![image](https://user-images.githubusercontent.com/57303506/176564540-1434cbf1-00db-4e56-9e01-601465e6f250.png)
![image](https://user-images.githubusercontent.com/57303506/176564679-65c20eaf-f174-4d1c-840a-587bed864288.png)
![image](https://user-images.githubusercontent.com/57303506/176564761-eff1064e-2428-4363-a9b0-b8486fdf0822.png)
![image](https://user-images.githubusercontent.com/57303506/176760609-91ccdf6c-9ce1-41ae-8513-f5a335c2087b.png)
![image](https://user-images.githubusercontent.com/57303506/176760932-980d8958-d7db-4cf1-9571-c94d4b8d1496.png)
![image](https://user-images.githubusercontent.com/57303506/176761059-9619f6b0-ae94-4907-bb27-4ed8bbe2009d.png)
Logging also provides clarity about which map elements (and instanced atoms within) take longer to load.

## Changelog
:cl:
 * tweak: Some objects initialise faster in the world, speeding up server setup and cutting object initialisation time down by over a half.
 * tweak: The vault placement process has been reworked, now populating them in space about four times faster.