### PR TITLE
PDA power monitor fixes

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1,4 +1,5 @@
 #define HTMLTAB "&nbsp;&nbsp;&nbsp;&nbsp;"
+#define UTF_LIMIT (1 << 20) + (1 << 16) - 1
 #define string2charlist(string) (splittext(string, regex("(.)")) - splittext(string, ""))
 
 /*
@@ -266,14 +267,14 @@
 //Returns a string with reserved characters and spaces before the first letter removed
 /proc/trim_left(text)
 	for (var/i = 1 to length(text))
-		if (text2ascii(text, i) > 32)
+		if (text2ascii(text, i) > 32 && text2ascii(text, i) <= UTF_LIMIT)
 			return copytext(text, i)
 	return ""
 
 //Returns a string with reserved characters and spaces after the last letter removed
 /proc/trim_right(text)
 	for (var/i = length(text), i > 0, i--)
-		if (text2ascii(text, i) > 32)
+		if (text2ascii(text, i) > 32 && text2ascii(text, i) <= UTF_LIMIT)
 			return copytext(text, 1, i + 1)
 
 	return ""

--- a/code/game/objects/items/devices/PDA/cart/engineering.dm
+++ b/code/game/objects/items/devices/PDA/cart/engineering.dm
@@ -64,7 +64,7 @@
                     for(var/obj/machinery/power/apc/A in L)
                         var/area/APC_area = get_area(A)
                         menu += copytext(add_tspace(trim_left(APC_area.name), 30), 1, 31)
-                        menu += " [S[A.equipment+1]] [S[A.lighting+1]] [S[A.environ+1]] [add_lspace(A.lastused_total, 9)] [A.cell ? "[add_lspace(round(A.cell.percent()), 3)]% [chg[A.charging+1]]" : "  N/C"]<BR>"
+                        menu += " [S[A.equipment+1]] [S[A.lighting+1]] [S[A.environ+1]] [add_lspace(format_watts(A.lastused_total), 9)] [A.cell ? "[add_lspace(round(A.cell.percent()), 3)]% [chg[A.charging+1]]" : "  N/C"]<BR>"
 
                 menu += "</FONT></PRE>"
     return menu

--- a/code/game/objects/items/devices/PDA/cart/engineering.dm
+++ b/code/game/objects/items/devices/PDA/cart/engineering.dm
@@ -55,19 +55,16 @@
                         var/obj/machinery/power/apc/A = term.master
                         L += A
 
-
-                menu += {"<PRE>Total power: [format_watts(connected_powernet.avail)]<BR>Total load:  [format_watts(connected_powernet.viewload)]<BR>
-                    <FONT SIZE=-1>"}
+                menu += "<PRE>Total power: [format_watts(connected_powernet.avail)]<BR>Total load:  [format_watts(connected_powernet.viewload)]<BR><FONT SIZE=-1>"
                 if(L.len > 0)
-                    menu += "Area                           Eqp./Lgt./Env.  Load   Cell<HR>"
-
+                    menu += "             Area              Eqp./Lgt./Env.    Load    Cell<HR>"
                     var/list/S = list(" Off","AOff","  On", " AOn")
                     var/list/chg = list("N","C","F")
 
                     for(var/obj/machinery/power/apc/A in L)
                         var/area/APC_area = get_area(A)
-                        menu += copytext(add_tspace(APC_area.name, 30), 1, 30)
-                        menu += " [S[A.equipment+1]] [S[A.lighting+1]] [S[A.environ+1]] [add_lspace(A.lastused_total, 6)]  [A.cell ? "[add_lspace(round(A.cell.percent()), 3)]% [chg[A.charging+1]]" : "  N/C"]<BR>"
+                        menu += copytext(add_tspace(trim_left(APC_area.name), 30), 1, 31)
+                        menu += " [S[A.equipment+1]] [S[A.lighting+1]] [S[A.environ+1]] [add_lspace(A.lastused_total, 9)] [A.cell ? "[add_lspace(round(A.cell.percent()), 3)]% [chg[A.charging+1]]" : "  N/C"]<BR>"
 
                 menu += "</FONT></PRE>"
     return menu


### PR DESCRIPTION
## What this does
Fixes `trim_left()` and `trim_right()` so macros such as `\improper` are no longer recognized as valid non-blank characters.
Tweaks the UI for the PDA power monitor app (Power-ON cartridge and others) so it's no longer some terrible inconsistent mess:
![beforeandafter](https://user-images.githubusercontent.com/78439377/176757807-e48eab60-acc6-4557-9ad3-67889c31240d.png)

All those area names that were a couple spaces shorter than the rest for no apparent reason? All ` "\improper"` macros that were adding to the name length and fooling `add_tspace()` into adding less spaces than it should. Thanks, BYOND.

[ui][bugfix]
## Changelog
:cl:
 * bugfix: Fixes and updates the PDA's power monitor app UI layout.