### PR TITLE
Traitor Item: Alternate Jobs Database

### DIFF
--- a/code/controllers/subsystem/init/job.dm
+++ b/code/controllers/subsystem/init/job.dm
@@ -14,6 +14,9 @@ var/datum/subsystem/job/SSjob
 	job_master = new /datum/controller/occupations()
 	job_master.SetupOccupations()
 	job_master.LoadJobs("config/jobs.txt")
+	funjob_master = new /datum/controller/occupations()
+	funjob_master.SetupOccupations()
+	funjob_master.LoadJobs("config/funnyjobs.txt")
 	for (var/mob/new_player/player in player_list)
 		player.new_player_panel_proc() // adds the Manifest Prediction button to players who were already connected
 	if(!syndicate_code_phrase)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1120,6 +1120,14 @@ var/list/uplink_items = list()
 	discounted_cost = 8
 	jobs_with_discount = list("Captain", "Head of Personnel")
 
+/datum/uplink_item/jobspecific/command/jobdisk
+	name = "Alternate Jobs Database"
+	desc = "A disk which, when installed in the Labor Management Console, enables mystery jobs to be hired at the station."
+	item = /obj/item/weapon/disk/jobdisk
+	cost = 10
+	discounted_cost = 6
+	jobs_with_discount = list("Captain", "Head of Personnel")
+
 /datum/uplink_item/jobspecific/command/lawgivermk2
 	name = "Lawgiver Demolition Kit"
 	desc = "A container that comes with a Lawgiver modification kit, converting it into a Demolition variant Lawgiver. Also comes with two spare demolition magazines."

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -95,6 +95,10 @@
 	w_type = RECYK_ELECTRONIC
 	starting_materials = list(MAT_IRON = 200, MAT_GLASS = 20)
 
+/obj/item/weapon/disk/jobdisk
+	name = "Alternate Jobs Database"
+	desc = "A disk which, when installed in the Labor Management Console, enables mystery jobs to be hired at the station."
+
 //TODO: Figure out wtf this is and possibly remove it -Nodrak
 /obj/item/weapon/dummy
 	name = "dummy"

--- a/code/game/jobs/job/funny.dm
+++ b/code/game/jobs/job/funny.dm
@@ -1,0 +1,231 @@
+/datum/job/chiropractor
+	title = "Chiropractor"
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "the Head of Personnel"
+	wage_payout = 10
+	selection_color = "#dddddd"
+	access = list(access_maint_tunnels)
+	minimal_access = list(access_maint_tunnels)
+
+	no_random_roll = 1
+
+	outfit_datum = /datum/outfit/assistant
+
+/datum/job/ideasman
+	title = "Ideas Man"
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "the Head of Personnel"
+	wage_payout = 10
+	selection_color = "#dddddd"
+	access = list(access_maint_tunnels)
+	minimal_access = list(access_maint_tunnels)
+
+	no_random_roll = 1
+
+	outfit_datum = /datum/outfit/assistant
+
+/datum/job/dogwalker
+	title = "Dog Walker"
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "the Head of Personnel"
+	wage_payout = 10
+	selection_color = "#dddddd"
+	access = list(access_maint_tunnels)
+	minimal_access = list(access_maint_tunnels)
+
+	no_random_roll = 1
+
+	outfit_datum = /datum/outfit/assistant
+
+/datum/job/psychologist
+	title = "Psychologist"
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "the Head of Personnel"
+	wage_payout = 10
+	selection_color = "#dddddd"
+	access = list(access_maint_tunnels)
+	minimal_access = list(access_maint_tunnels)
+
+	no_random_roll = 1
+
+	outfit_datum = /datum/outfit/assistant
+
+/datum/job/scubadiver
+	title = "Scuba Diver"
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "the Head of Personnel"
+	wage_payout = 10
+	selection_color = "#dddddd"
+	access = list(access_maint_tunnels)
+	minimal_access = list(access_maint_tunnels)
+
+	no_random_roll = 1
+
+	outfit_datum = /datum/outfit/assistant
+
+/datum/job/plumber
+	title = "Plumber"
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "the Head of Personnel"
+	wage_payout = 10
+	selection_color = "#dddddd"
+	access = list(access_maint_tunnels)
+	minimal_access = list(access_maint_tunnels)
+
+	no_random_roll = 1
+
+	outfit_datum = /datum/outfit/assistant
+
+/datum/job/dentist
+	title = "Dentist"
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "the Head of Personnel"
+	wage_payout = 10
+	selection_color = "#dddddd"
+	access = list(access_maint_tunnels)
+	minimal_access = list(access_maint_tunnels)
+
+	no_random_roll = 1
+
+	outfit_datum = /datum/outfit/assistant
+
+/datum/job/managementconsultant
+	title = "Management Consultant"
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "the Head of Personnel"
+	wage_payout = 10
+	selection_color = "#dddddd"
+	access = list(access_maint_tunnels)
+	minimal_access = list(access_maint_tunnels)
+
+	no_random_roll = 1
+
+	outfit_datum = /datum/outfit/assistant
+
+
+/datum/job/weddingplanner
+	title = "Wedding Planner"
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "the Head of Personnel"
+	wage_payout = 10
+	selection_color = "#dddddd"
+	access = list(access_maint_tunnels)
+	minimal_access = list(access_maint_tunnels)
+
+	no_random_roll = 1
+
+	outfit_datum = /datum/outfit/assistant
+
+
+/datum/job/lifeguard
+	title = "Lifeguard"
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "the Head of Personnel"
+	wage_payout = 10
+	selection_color = "#dddddd"
+	access = list(access_maint_tunnels)
+	minimal_access = list(access_maint_tunnels)
+
+	no_random_roll = 1
+
+	outfit_datum = /datum/outfit/assistant
+
+
+/datum/job/insurancesalesman
+	title = "Insurance Salesman"
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "the Head of Personnel"
+	wage_payout = 10
+	selection_color = "#dddddd"
+	access = list(access_maint_tunnels)
+	minimal_access = list(access_maint_tunnels)
+
+	no_random_roll = 1
+
+	outfit_datum = /datum/outfit/assistant
+
+
+/datum/job/cableguy
+	title = "Cable Guy"
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "the Head of Personnel"
+	wage_payout = 10
+	selection_color = "#dddddd"
+	access = list(access_maint_tunnels)
+	minimal_access = list(access_maint_tunnels)
+
+	no_random_roll = 1
+
+	outfit_datum = /datum/outfit/assistant
+
+
+/datum/job/woodidentifier
+	title = "Wood Identifier"
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "the Head of Personnel"
+	wage_payout = 10
+	selection_color = "#dddddd"
+	access = list(access_maint_tunnels)
+	minimal_access = list(access_maint_tunnels)
+
+	no_random_roll = 1
+
+	outfit_datum = /datum/outfit/assistant
+
+
+/datum/job/projectmanager
+	title = "Project Manager"
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "the Head of Personnel"
+	wage_payout = 10
+	selection_color = "#dddddd"
+	access = list(access_maint_tunnels)
+	minimal_access = list(access_maint_tunnels)
+
+	no_random_roll = 1
+
+	outfit_datum = /datum/outfit/assistant
+
+
+/datum/job/interiordesigner
+	title = "Interior Designer"
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "the Head of Personnel"
+	wage_payout = 10
+	selection_color = "#dddddd"
+	access = list(access_maint_tunnels)
+	minimal_access = list(access_maint_tunnels)
+
+	no_random_roll = 1
+
+	outfit_datum = /datum/outfit/assistant

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -1,4 +1,5 @@
 var/global/datum/controller/occupations/job_master
+var/global/datum/controller/occupations/funjob_master
 
 #define FREE_ASSISTANTS 2
 
@@ -136,6 +137,12 @@ var/global/datum/controller/occupations/job_master
 
 /datum/controller/occupations/proc/TogglePriority(var/rank, mob/user)
 	var/datum/job/job = GetJob(rank)
+	if(job in funny_positions)
+		if(user)
+			log_admin("[key_name(user)] has set the priority of the ?!##!#? job to [job.priority].")
+			message_admins("[key_name_admin(user)] has set the priority of the ?!##!#? job to [job.priority].")
+		for(var/mob/new_player/player in player_list)
+			to_chat(player, "<span class='notice'>The ?!##!#? job is [job.priority ? "now highly requested!" : "no longer highly requested."]</span>")
 	if(job)
 		if(job.priority)
 			job.priority = FALSE

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -81,6 +81,24 @@ var/list/misc_positions = list(
 	"Trader",
 )
 
+var/list/funny_positions = list(
+	"Chiropractor",
+	"Ideas Man",
+	"Dog Walker",
+	"Psychologist",
+	"Scuba Diver",
+	"Plumber",
+	"Dentist",
+	"Management Consultant",
+	"Wedding Planner",
+	"Lifeguard",
+	"Insurance Salesman",
+	"Cable Guy",
+	"Wood Identifier",
+	"Project Manager",
+	"Interior Designer",
+)
+
 var/list/all_jobs_txt = list(
 	"Captain",
 	"Head of Personnel",

--- a/code/game/machinery/computer/labor.dm
+++ b/code/game/machinery/computer/labor.dm
@@ -8,6 +8,8 @@ var/list/labor_console_categories = list(
 	"Cargo" = cargo_positions,
 	)
 
+var/global/funjobs = FALSE //Enables the funny jobs
+
 /obj/machinery/computer/labor
 	name = "Labor Administration Console"
 	desc = "According to the manual, you need to take a six-week Labor Administration Associate Training Course before you're qualified to navigate this console's complex interface. Being a Head of Personnel is hard work."
@@ -26,6 +28,7 @@ var/list/labor_console_categories = list(
 
 	var/icon/verified_overlay
 	var/icon/awaiting_overlay
+
 
 /obj/machinery/computer/labor/New()
 	..()
@@ -142,6 +145,20 @@ var/list/labor_console_categories = list(
 		if(isEmag(W))
 			playsound(src, get_sfx("card_swipe"), 60, 1, -5)
 			verified(user)
+	if(istype(W,/obj/item/weapon/disk/jobdisk))
+		to_chat(user, "<span class='notice'>You begin installing the alternate database.</span>")
+		if(!user.drop_item(W))
+			to_chat(user, "<span class='warning'>You can't let go of \the [W].</span>")
+			return
+		W.forceMove(src)
+		if(do_after(user,src,30))
+			playsound(src, 'sound/machines/ping.ogg', 35, 0, -2)
+			to_chat(user, "<span class='notice'>Alternate jobs  database successfully installed.</span>")
+			funjobs = TRUE
+			funjob_master.TogglePriority(toggling_priority, user)
+			W.forceMove(loc)
+		else
+			W.forceMove(loc)
 
 /obj/machinery/computer/labor/kick_act(mob/user)
 	..()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -199,6 +199,8 @@
 			return
 		var/count_pings = 0
 		var/list/priority_jobs = job_master.GetPrioritizedJobs()
+		if(funjobs)
+			priority_jobs = funjob_master.GetPrioritizedJobs()
 		if (priority_jobs.len)
 			to_chat(src, "<span class='warning'>Slots for priority roles are already opened.</span>")
 			return

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -665,6 +665,7 @@
 #include "code\game\jobs\job\captain.dm"
 #include "code\game\jobs\job\civilian.dm"
 #include "code\game\jobs\job\engineering.dm"
+#include "code\game\jobs\job\funny.dm"
 #include "code\game\jobs\job\job.dm"
 #include "code\game\jobs\job\medical.dm"
 #include "code\game\jobs\job\science.dm"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Adds the Alternate Jobs Database for 10 TC (5 if you're the HOP). Installing this into the Labor Administration Console will allow new players to join as the "?!#!#?" role which randomly picks a job from the following list of funny jobs:

- Chiropractor
- Ideas Man
- Dog Walker
- Psychologist
- Scuba Diver*
- Plumber
- Dentist
- Management Consultant
- Wedding Planner
- Lifeguard
- Insurance Salesman
- Cable Guy*
- Wood Identifier
- Project Manager
- Interior Designer

Still very WIP and nonfunctional. I will need outfit sprites for any jobs marked with *; others will use existing clothing. Credit to "Bill Posters" for the idea.

Todo:
- [ ] Allow for a single job "?!#!#?" to be prioritized which will pick from a random list of jobs. Open to suggestions here.
- [ ] Setup outfit datums.
- [ ] Procure sprites for the marked roles.

## Why it's good
<!-- Explain why you think these changes are good. -->
- Adds the first HOP-oriented traitor item.
- Provides for hilarity and RP situations.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added the Alternate Jobs Database, opening employment on vgstation13 to all walks of life.
