### PR TITLE
Staff of Necromancy tweaks

### DIFF
--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -47,7 +47,7 @@
 
 // Toggles several features, explained in their respective comments.
 // You can turn those on and off manually if you prefer, instead of setting this
-#define DEVELOPER_MODE 1
+#define DEVELOPER_MODE 0
 
 // If 1, unit tests will be compiled
 #define UNIT_TESTS_ENABLED 0

--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -47,7 +47,7 @@
 
 // Toggles several features, explained in their respective comments.
 // You can turn those on and off manually if you prefer, instead of setting this
-#define DEVELOPER_MODE 0
+#define DEVELOPER_MODE 1
 
 // If 1, unit tests will be compiled
 #define UNIT_TESTS_ENABLED 0

--- a/code/game/objects/items/potions.dm
+++ b/code/game/objects/items/potions.dm
@@ -247,7 +247,7 @@
 	return ishuman(user)
 
 /obj/item/potion/zombie/imbibe_effect(mob/living/carbon/human/user)
-	user.become_zombie = TRUE
+	user.zombify()
 
 /obj/item/potion/zombie/impact_atom(atom/target)
 	var/mob/M = get_last_player_touched()

--- a/code/game/objects/items/potions.dm
+++ b/code/game/objects/items/potions.dm
@@ -253,10 +253,7 @@
 	var/mob/M = get_last_player_touched()
 	var/list/L = get_all_mobs_in_dview(get_turf(src))
 	for(var/mob/living/carbon/human/H in L)
-		if(H.isDeadorDying())
-			H.zombify(M)
-		else
-			H.become_zombie = TRUE
+		H.zombify(M)
 
 /obj/item/potion/fullness
 	name = "potion of fullness"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1936,7 +1936,7 @@
 		dropBorers()
 		var/mob/living/simple_animal/hostile/necro/zombie/turned/T = new(get_turf(src), master, (retain_mind ? src : null))
 		if(master && master.faction)
-			T.faction = "\ref[user]"
+			T.faction = "\ref[master]"
 		T.add_spell(/spell/aoe_turf/necro/zombie/evolve)
 		if(isgrey(src))
 			T.icon_state = "mauled_laborer"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1935,6 +1935,8 @@
 	else if(stat == DEAD || InCritical())
 		dropBorers()
 		var/mob/living/simple_animal/hostile/necro/zombie/turned/T = new(get_turf(src), master, (retain_mind ? src : null))
+		if(master && master.faction)
+			T.faction = "\ref[user]"
 		T.add_spell(/spell/aoe_turf/necro/zombie/evolve)
 		if(isgrey(src))
 			T.icon_state = "mauled_laborer"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1923,8 +1923,8 @@
 	return TRUE
 
 /mob/living/carbon/human/proc/zombify(mob/master, var/retain_mind = TRUE, var/crabzombie = FALSE)
-	dropBorers()
 	if(crabzombie)
+		dropBorers()
 		var/mob/living/simple_animal/hostile/necro/zombie/headcrab/T = new(get_turf(src), master, (retain_mind ? src : null))
 		T.virus2 = virus_copylist(virus2)
 		T.get_clothes(src, T)
@@ -1932,7 +1932,8 @@
 		T.host = src
 		forceMove(null)
 		return T
-	else
+	else if(stat == DEAD || InCritical())
+		dropBorers()
 		var/mob/living/simple_animal/hostile/necro/zombie/turned/T = new(get_turf(src), master, (retain_mind ? src : null))
 		T.add_spell(/spell/aoe_turf/necro/zombie/evolve)
 		if(isgrey(src))
@@ -1953,6 +1954,8 @@
 		T.host = src
 		forceMove(null)
 		return T
+	else
+		become_zombie = TRUE
 
 /mob/living/carbon/human/throw_item(var/atom/target,var/atom/movable/what=null)
 	var/atom/movable/item = get_active_hand()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -253,8 +253,8 @@
 	to_chat(user, "<span class='notice'>You will now raise [raisetype ? "skeletal" : "zombified"] minions from corpses.</span>")
 	next_change = world.timeofday + 30
 
-/obj/item/weapon/gun/energy/staff/necro/afterattack(atom/target, mob/living/user, flag, params, struggle = 0)
-	if(!charges || istype(target, /mob/living/simple_animal/hostile/necro) || get_dist(target, user) > 7)
+/obj/item/weapon/gun/energy/staff/necro/afterattack(atom/target, mob/living/user = usr, flag, params, struggle = 0)
+	if(!charges || get_dist(target, user) > 7)
 		return 0
 	var/success = FALSE
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -270,7 +270,7 @@
 			H.zombify(user)
 	else if(istype(target, /mob/living/simple_animal/hostile/necro/zombie/))
 		success = TRUE
-		var/living/simple_animal/S = target
+		var/mob/living/simple_animal/S = target
 		S.faction = "\ref[user]"
 	else if(isanimal(target) || ismonkey(target))
 		var/mob/living/L = target

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -268,7 +268,7 @@
 			spooky.faction = "\ref[user]"
 		else
 			H.zombify(user)
-	else if(istype(target, /mob/living/simple_animal/hostile/necro/zombie/)
+	else if(istype(target, /mob/living/simple_animal/hostile/necro/zombie/))
 		success = TRUE
 		var/living/simple_animal/S = target
 		S.faction = "\ref[user]"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -269,8 +269,8 @@
 			H.zombify(user)
 	else if(isanimal(target) || ismonkey(target))
 		var/mob/living/L = target
-		success = TRUE
 		if(L.stat == DEAD)
+			success = TRUE
 			var/mob/living/simple_animal/hostile/necro/meat_ghoul/mG = new /mob/living/simple_animal/hostile/necro/meat_ghoul(get_turf(L), user)
 			mG.ghoulifyMeat(L)
 			mG.faction = "\ref[user]"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -213,9 +213,6 @@
 		P.status=setting
 	return 1
 
-#define RAISE_TYPE_ZOMBIE 0
-#define RAISE_TYPE_SKELETON 1
-
 /obj/item/weapon/gun/energy/staff/necro
 	name = "staff of necromancy"
 	desc = "A wicked looking staff that pulses with evil energy."
@@ -253,7 +250,7 @@
 		return
 	raisetype = !raisetype
 
-	to_chat(user, "<span class='notice'>You will now raise [raisetype < 2 ? (raisetype ? "skeletal" : "zombified") : "unknown"] minions from corpses.</span>")
+	to_chat(user, "<span class='notice'>You will now raise [raisetype ? "skeletal" : "zombified"] minions from corpses.</span>")
 	next_change = world.timeofday + 30
 
 /obj/item/weapon/gun/energy/staff/necro/afterattack(atom/target, mob/living/user, flag, params, struggle = 0)
@@ -262,14 +259,14 @@
 	var/success = FALSE
 	if(ishuman(target))
 		success = TRUE
-		switch(raisetype)
-			if(RAISE_TYPE_ZOMBIE)
-				H.zombify(user)
-			if(RAISE_TYPE_SKELETON)
-				H.dropBorers()
-				var/mob/living/simple_animal/hostile/necro/skeleton/spooky = new /mob/living/simple_animal/hostile/necro/skeleton(get_turf(H), user, H)
-				H.gib()
-				spooky.faction = "\ref[user]"
+		if(raisetype)
+			H.dropBorers()
+			var/mob/living/simple_animal/hostile/necro/skeleton/spooky = new /mob/living/simple_animal/hostile/necro/skeleton(get_turf(H), user, H)
+			H.gib()
+			spooky.faction = "\ref[user]"
+		else
+			var/mob/living/carbon/human/H = target
+			H.zombify(user)
 	else if(isanimal(target) || ismonkey(target))
 		var/mob/living/L = target
 		success = TRUE
@@ -288,7 +285,6 @@
 		S.gib()
 	if(success)
 		make_tracker_effects(get_turf(S), user)
-		charges--
 		if(iswizard(user) || isapprentice(user))
 			user.say(pick("ARISE, [pick("MY CREATION","MY MINION","CH'KUN")].",\
 			"BOW BEFORE [pick("MY POWER","ME, [uppertext(H.real_name)]")].",\
@@ -300,12 +296,10 @@
 			"YOUR TIME HAS NOT COME, YET.",\
 			"YOUR SOUL MAY BELONG TO [uppertext(ticker.Bible_deity_name)] BUT YOU BELONG TO ME."))
 		playsound(src, get_sfx("soulstone"), 50,1)
+		charges--
 
 /obj/item/weapon/gun/energy/staff/necro/attack(mob/living/target as mob, mob/living/user as mob)
 	afterattack(target,user,1)
-
-#undef RAISE_TYPE_ZOMBIE
-#undef RAISE_TYPE_SKELETON
 
 /obj/item/weapon/gun/energy/staff/destruction_wand
 	name = "wand of destruction"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -257,6 +257,7 @@
 	if(!charges || istype(target, /mob/living/simple_animal/hostile/necro) || get_dist(target, user) > 7)
 		return 0
 	var/success = FALSE
+
 	if(ishuman(target))
 		success = TRUE
 		var/mob/living/carbon/human/H = target
@@ -267,6 +268,10 @@
 			spooky.faction = "\ref[user]"
 		else
 			H.zombify(user)
+	else if(istype(target, /mob/living/simple_animal/hostile/necro/zombie/)
+		success = TRUE
+		var/living/simple_animal/S = target
+		S.faction = "\ref[user]"
 	else if(isanimal(target) || ismonkey(target))
 		var/mob/living/L = target
 		if(L.stat == DEAD)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -259,35 +259,36 @@
 	var/success = FALSE
 	if(ishuman(target))
 		success = TRUE
+		var/mob/living/carbon/human/H = target
 		if(raisetype)
 			H.dropBorers()
 			var/mob/living/simple_animal/hostile/necro/skeleton/spooky = new /mob/living/simple_animal/hostile/necro/skeleton(get_turf(H), user, H)
 			H.gib()
 			spooky.faction = "\ref[user]"
 		else
-			var/mob/living/carbon/human/H = target
 			H.zombify(user)
 	else if(isanimal(target) || ismonkey(target))
 		var/mob/living/L = target
 		success = TRUE
 		if(L.stat == DEAD)
-			var/mob/living/simple_animal/hostile/necro/meat_ghoul/mG = new /mob/living/simple_animal/hostile/necro/meat_ghoul(get_turf(M), user)
-			mG.ghoulifyMeat(M)
+			var/mob/living/simple_animal/hostile/necro/meat_ghoul/mG = new /mob/living/simple_animal/hostile/necro/meat_ghoul(get_turf(L), user)
+			mG.ghoulifyMeat(L)
 			mG.faction = "\ref[user]"
-			qdel(M)
+			L.gib()
 		else
 			to_chat(user,"<span class = 'warning'>The creature must be dead before it can be undead.</span>")
 	else if(istype(target, /obj/item/weapon/reagent_containers/food/snacks/meat))
-		var/mob/living/simple_animal/hostile/necro/animal_ghoul/aG = new /mob/living/simple_animal/hostile/necro/animal_ghoul(get_turf(S), user, S)
+		var/mob/living/simple_animal/hostile/necro/animal_ghoul/aG = new /mob/living/simple_animal/hostile/necro/animal_ghoul(get_turf(target), user, target)
 		success = TRUE
-		aG.ghoulifyAnimal(S)
+		aG.ghoulifyAnimal(target)
 		aG.faction = "\ref[user]"
-		S.gib()
+		qdel(target)
+
 	if(success)
-		make_tracker_effects(get_turf(S), user)
+		make_tracker_effects(get_turf(target), user)
 		if(iswizard(user) || isapprentice(user))
 			user.say(pick("ARISE, [pick("MY CREATION","MY MINION","CH'KUN")].",\
-			"BOW BEFORE [pick("MY POWER","ME, [uppertext(H.real_name)]")].",\
+			"BOW BEFORE [pick("MY POWER","ME, [uppertext(target.name)]")].",\
 			"G'T T'FUK UP.",\
 			"IF YOU DIE, YOU DIE FOR ME.",\
 			"EVEN IN DEATH YOU MAY SERVE.",\

--- a/code/modules/virus2/effect/stage_4.dm
+++ b/code/modules/virus2/effect/stage_4.dm
@@ -84,9 +84,7 @@
 /datum/disease2/effect/zombie/activate(var/mob/living/mob)
 	if(ishuman(mob))
 		var/mob/living/carbon/human/H = mob
-		H.become_zombie = TRUE
-		if(H.isDeadorDying())
-			H.zombify()
+		H.zombify()
 	to_chat(mob, "<span class = 'notice'>You hunger...</span>")
 
 /datum/disease2/effect/suicide


### PR DESCRIPTION
[tweak][bugfix]

Staff of Necromancy has it's own special snowflake zombie code.

## What this does
- Replaces staff of necromancy zombie code with the proper zombify code
- Adjusts some zombify things to make it a better fit
- redo some confusing code
- using the staff on zombies makes them join your faction

## Why it's good
Staff of Necromancy zombies can now evolve

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Staff of Necromancy zombies can now evolve again
