### PR TITLE
fixes missing period on grand slam centcomm alert

### DIFF
--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -780,7 +780,7 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 
 /datum/command_alert/lotto_announce
 	alert_title = "Central Command Grand Slam -Stellar- Lottery"
-	message = "A lotto number draw is scheduled to happen within the next 5 minutes. All nearby entertainment monitors will be broadcasting the results"
+	message = "A lotto number draw is scheduled to happen within the next 5 minutes. All nearby entertainment monitors will be broadcasting the results."
 
 /datum/command_alert/lotto_winner
 	alert_title = "Grand Slam -Stellar- Lottery Winner!"


### PR DESCRIPTION
## What this does
adds a "."
## Why it's good
i love me some typofixes
## Changelog
[hotfix][grammar]
:cl:
* typofix: Adds a missing period to the grand slam lottery centcomm alert.
