### PR TITLE
Ingesting reagent mob reaction rework

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -1053,7 +1053,7 @@ var/list/arcane_tomes = list()
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	mech_flags = MECH_SCAN_FAIL//not that you should be able to drop it in the first place BUT just in case
 	var/mob/originator = null
-	var/obj/abstract/mind_ui_element/hoverable/bloodcult_spell/dagger/linked_ui 
+	var/obj/abstract/mind_ui_element/hoverable/bloodcult_spell/dagger/linked_ui
 	var/stacks = 0
 	var/absorbed = 0
 	surgerysound = 'sound/items/scalpel.ogg'
@@ -1560,7 +1560,7 @@ var/list/arcane_tomes = list()
 		filling.icon += mix_color_from_reagents(reagents.reagent_list)
 		filling.alpha = mix_alpha_from_reagents(reagents.reagent_list)
 		overlays += filling
-	
+
 	for(var/datum/reagent/R in reagents.reagent_list)
 		if(R.id == BLOOD)
 			var/datum/reagent/blood/B = R
@@ -1573,7 +1573,7 @@ var/list/arcane_tomes = list()
 			var/mob/living/carbon/human/H = hit_atom
 			if(!(H.species.chem_flags & NO_DRINK) && !(H.get_body_part_coverage(MOUTH)))
 				H.visible_message("<span class='warning'>Some of \the [src]'s content spills into \the [H]'s mouth.</span>","<span class='danger'>Some of \the [src]'s content spills into your mouth.</span>")
-				reagents.reaction(H, INGEST)
+				reagents.reaction(H, INGEST, amount_override = min(reagents.total_volume,gulp_size)/(reagents.reagent_list.len))
 				reagents.trans_to(H, gulp_size)
 	transfer(get_turf(hit_atom), null, splashable_units = -1)
 

--- a/code/game/objects/items/gum.dm
+++ b/code/game/objects/items/gum.dm
@@ -173,7 +173,8 @@
 			if(M.reagents.has_any_reagents(LEXORINS) || (M_NO_BREATH in M.mutations) || istype(M.loc, /obj/machinery/atmospherics/unary/cryo_cell))
 				reagents.remove_any(REAGENTS_METABOLISM)
 			else
-				reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,1)/(reagents.reagent_list.len))
+				if(prob(25)) //So it's not an instarape in case of acid
+					reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,1)/(reagents.reagent_list.len))
 				reagents.trans_to(M, 1)
 		else //Else just remove some of the reagents
 			reagents.remove_any(REAGENTS_METABOLISM)

--- a/code/game/objects/items/gum.dm
+++ b/code/game/objects/items/gum.dm
@@ -173,8 +173,7 @@
 			if(M.reagents.has_any_reagents(LEXORINS) || (M_NO_BREATH in M.mutations) || istype(M.loc, /obj/machinery/atmospherics/unary/cryo_cell))
 				reagents.remove_any(REAGENTS_METABOLISM)
 			else
-				if(prob(25)) //So it's not an instarape in case of acid
-					reagents.reaction(M, INGEST)
+				reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,1)/(reagents.reagent_list.len))
 				reagents.trans_to(M, 1)
 		else //Else just remove some of the reagents
 			reagents.remove_any(REAGENTS_METABOLISM)

--- a/code/game/objects/items/robot/robot_items/robot_hypospray.dm
+++ b/code/game/objects/items/robot/robot_items/robot_hypospray.dm
@@ -75,7 +75,7 @@
 		"<span class='warning'>[user] injects [M] with [src].</span>",\
 		"<span class='info'>You inject [M] with with [src].<span>")
 	to_chat(M, "<span class='warning'>You feel a tiny prick!</span>")
-	reagents.reaction(M, INGEST)
+	reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,amount_per_transfer_from_this)/(reagents.reagent_list.len))
 
 	if(M.reagents)
 		var/transferred = reagents.trans_to(M, amount_per_transfer_from_this)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -430,8 +430,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 			if(M.reagents.has_any_reagents(LEXORINS) || (M_NO_BREATH in M.mutations) || istype(M.loc, /obj/machinery/atmospherics/unary/cryo_cell))
 				reagents.remove_any(REAGENTS_METABOLISM)
 			else
-				if(prob(25)) //So it's not an instarape in case of acid
-					reagents.reaction(M, INGEST)
+				reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,1)/(reagents.reagent_list.len))
 				reagents.trans_to(M, 1)
 		else //Else just remove some of the reagents
 			reagents.remove_any(REAGENTS_METABOLISM)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -430,7 +430,8 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 			if(M.reagents.has_any_reagents(LEXORINS) || (M_NO_BREATH in M.mutations) || istype(M.loc, /obj/machinery/atmospherics/unary/cryo_cell))
 				reagents.remove_any(REAGENTS_METABOLISM)
 			else
-				reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,1)/(reagents.reagent_list.len))
+				if(prob(25)) //So it's not an instarape in case of acid
+					reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,1)/(reagents.reagent_list.len))
 				reagents.trans_to(M, 1)
 		else //Else just remove some of the reagents
 			reagents.remove_any(REAGENTS_METABOLISM)

--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -113,7 +113,7 @@
 			if(M.reagents.has_any_reagents(LEXORINS) || istype(M.loc, /obj/machinery/atmospherics/unary/cryo_cell))
 				reagents.remove_any(REAGENTS_METABOLISM)
 			else
-				reagents.reaction(M, INGEST)
+				reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,0.5)/(reagents.reagent_list.len))
 				reagents.trans_to(M, 0.5)
 		else
 			processing_objects.Remove(src)

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -127,7 +127,7 @@
 				// Handle chem smoke effect  -- Doohl
 				for(var/obj/effect/smoke/chem/smoke in view(1, src))
 					if(smoke.reagents.total_volume)
-						smoke.reagents.reaction(src, INGEST)
+						smoke.reagents.reaction(src, INGEST, amount_override = min(reagents.total_volume,10)/(reagents.reagent_list.len))
 						spawn(5)
 							if(smoke)
 								smoke.reagents.copy_to(src, 10) // I dunno, maybe the reagents enter the blood stream through the lungs?

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -127,7 +127,7 @@
 				// Handle chem smoke effect  -- Doohl
 				for(var/obj/effect/smoke/chem/smoke in view(1, src))
 					if(smoke.reagents.total_volume)
-						smoke.reagents.reaction(src, INGEST, amount_override = min(reagents.total_volume,10)/(reagents.reagent_list.len))
+						smoke.reagents.reaction(src, INGEST, amount_override = min(smoke.reagents.total_volume,10)/(smoke.reagents.reagent_list.len))
 						spawn(5)
 							if(smoke)
 								smoke.reagents.copy_to(src, 10) // I dunno, maybe the reagents enter the blood stream through the lungs?

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -111,7 +111,7 @@
 				// Handle chem smoke effect  -- Doohl
 				for(var/obj/effect/smoke/chem/smoke in view(1, src))
 					if(smoke.reagents.total_volume)
-						smoke.reagents.reaction(src, INGEST, amount_override = min(reagents.total_volume,10)/(reagents.reagent_list.len))
+						smoke.reagents.reaction(src, INGEST, amount_override = min(smoke.reagents.total_volume,10)/(smoke.reagents.reagent_list.len))
 						spawn(5)
 							if(smoke)
 								smoke.reagents.copy_to(src, 10) // I dunno, maybe the reagents enter the blood stream through the lungs?

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -111,7 +111,7 @@
 				// Handle chem smoke effect  -- Doohl
 				for(var/obj/effect/smoke/chem/smoke in view(1, src))
 					if(smoke.reagents.total_volume)
-						smoke.reagents.reaction(src, INGEST)
+						smoke.reagents.reaction(src, INGEST, amount_override = min(reagents.total_volume,10)/(reagents.reagent_list.len))
 						spawn(5)
 							if(smoke)
 								smoke.reagents.copy_to(src, 10) // I dunno, maybe the reagents enter the blood stream through the lungs?

--- a/code/modules/mob/living/carbon/complex/martian/life.dm
+++ b/code/modules/mob/living/carbon/complex/martian/life.dm
@@ -18,7 +18,7 @@
 	if(!block)
 		for(var/obj/effect/smoke/chem/smoke in view(1, src))
 			if(smoke.reagents.total_volume)
-				smoke.reagents.reaction(src, INGEST, amount_override = min(reagents.total_volume,10)/(reagents.reagent_list.len))
+				smoke.reagents.reaction(src, INGEST, amount_override = min(smoke.reagents.total_volume,10)/(smoke.reagents.reagent_list.len))
 				spawn(5)
 					if(smoke)
 						smoke.reagents.copy_to(src, 10) // I dunno, maybe the reagents enter the blood stream through the lungs?

--- a/code/modules/mob/living/carbon/complex/martian/life.dm
+++ b/code/modules/mob/living/carbon/complex/martian/life.dm
@@ -18,7 +18,7 @@
 	if(!block)
 		for(var/obj/effect/smoke/chem/smoke in view(1, src))
 			if(smoke.reagents.total_volume)
-				smoke.reagents.reaction(src, INGEST)
+				smoke.reagents.reaction(src, INGEST, amount_override = min(reagents.total_volume,10)/(reagents.reagent_list.len))
 				spawn(5)
 					if(smoke)
 						smoke.reagents.copy_to(src, 10) // I dunno, maybe the reagents enter the blood stream through the lungs?

--- a/code/modules/mob/living/carbon/human/life/handle_breath.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_breath.dm
@@ -80,7 +80,7 @@
 				if(!block)
 					for(var/obj/effect/smoke/chem/smoke in view(1, src)) //If there is smoke within one tile
 						if(smoke.reagents.total_volume)
-							smoke.reagents.reaction(src, INGEST)
+							smoke.reagents.reaction(src, INGEST, amount_override = min(smoke.reagents.total_volume,10)/(smoke.reagents.reagent_list.len))
 							spawn(5)
 								if(smoke)
 									smoke.reagents.copy_to(src, 10) //I dunno, maybe the reagents enter the blood stream through the lungs?

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -228,7 +228,7 @@
 				if(!block)
 					for(var/obj/effect/smoke/chem/smoke in view(1, src))
 						if(smoke.reagents.total_volume)
-							smoke.reagents.reaction(src, INGEST)
+							smoke.reagents.reaction(src, INGEST, amount_override = min(reagents.total_volume,10)/(reagents.reagent_list.len))
 							spawn(5)
 								if(smoke)
 									smoke.reagents.copy_to(src, 10) // I dunno, maybe the reagents enter the blood stream through the lungs?

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -228,7 +228,7 @@
 				if(!block)
 					for(var/obj/effect/smoke/chem/smoke in view(1, src))
 						if(smoke.reagents.total_volume)
-							smoke.reagents.reaction(src, INGEST, amount_override = min(reagents.total_volume,10)/(reagents.reagent_list.len))
+							smoke.reagents.reaction(src, INGEST, amount_override = min(smoke.reagents.total_volume,10)/(smoke.reagents.reagent_list.len))
 							spawn(5)
 								if(smoke)
 									smoke.reagents.copy_to(src, 10) // I dunno, maybe the reagents enter the blood stream through the lungs?

--- a/code/modules/projectiles/guns/projectile/constructable/swords.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/swords.dm
@@ -217,7 +217,7 @@
 
 	to_chat(M, "<span class='warning'>The blade's coating seeps into your wound!</span>")
 
-	B.reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,inject_amount)/(reagents.reagent_list.len))
+	B.reagents.reaction(M, INGEST, amount_override = min(B.reagents.total_volume,inject_amount)/(B.reagents.reagent_list.len))
 
 	if(M.reagents)
 		var/list/injected = list()

--- a/code/modules/projectiles/guns/projectile/constructable/swords.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/swords.dm
@@ -217,7 +217,7 @@
 
 	to_chat(M, "<span class='warning'>The blade's coating seeps into your wound!</span>")
 
-	B.reagents.reaction(M, INGEST)
+	B.reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,inject_amount)/(reagents.reagent_list.len))
 
 	if(M.reagents)
 		var/list/injected = list()

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -344,7 +344,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 		reagents.reaction(user, TOUCH)
 		return 1
 	if(reagents.total_volume)
-		reagents.reaction(user, INGEST)
+		reagents.reaction(user, INGEST, amount_override = min(reagents.total_volume,amount_per_imbibe)/(reagents.reagent_list.len))
 		spawn(5)
 			if(reagents)
 				reagents.trans_to(user, amount_per_imbibe)

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -40,7 +40,7 @@
 
 		to_chat(M, "<span class='notice'>You swallow some of the contents of \the [src].</span>")
 		if(reagents.total_volume) //Deal with the reagents in the food
-			reagents.reaction(M, INGEST)
+			reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,amount_per_transfer_from_this)/(reagents.reagent_list.len))
 			spawn(5)
 				reagents.trans_to(M, amount_per_transfer_from_this)
 
@@ -70,7 +70,7 @@
 			M.assaulted_by(user)
 
 		if(reagents.total_volume) //Deal with the reagents in the food
-			reagents.reaction(M, INGEST)
+			reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,amount_per_transfer_from_this)/(reagents.reagent_list.len))
 			spawn(5)
 				reagents.trans_to(M, amount_per_transfer_from_this)
 

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -185,7 +185,7 @@
 					reagents.remove_any(gulp_size)
 					return 0
 
-			reagents.reaction(M, INGEST)
+			reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,gulp_size)/(reagents.reagent_list.len))
 			spawn(5)
 				reagents.trans_to(M, gulp_size)
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -312,14 +312,11 @@
 				var/datum/disease2/disease/D = virus2[ID]
 				eater.infect_disease2(D, 1, notes="(Ate an infected [src])")//eating infected food means 100% chance of infection.
 		if(reagentreference.total_volume)
-			reagentreference.reaction(eater, INGEST)
+			reagentreference.reaction(eater, INGEST, amount_override = min(reagentreference.total_volume,bitesize*bitesizemod)/(reagentreference.reagent_list.len))
 			spawn() //WHY IS THIS SPAWN() HERE
 				if(gcDestroyed)
 					return
-				if(reagentreference.total_volume > bitesize*bitesizemod)
-					reagentreference.trans_to(eater, bitesize*bitesizemod)
-				else
-					reagentreference.trans_to(eater, reagentreference.total_volume)
+				reagentreference.trans_to(eater, min(reagentreference.total_volume,bitesize*bitesizemod))
 				bitecount++
 				after_consume(eater, reagentreference)
 		return 1

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -54,7 +54,7 @@
 		to_chat(M, "<span class='warning'>You feel a tiny prick!</span>")
 		playsound(src, 'sound/items/hypospray.ogg', 50, 1)
 
-		src.reagents.reaction(M, INGEST)
+		src.reagents.reaction(M, INGEST, amount_override = min(reagents.total_volume,amount_per_transfer_from_this)/(reagents.reagent_list.len))
 		if(M.reagents)
 
 			var/list/injected = list()

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -285,8 +285,8 @@
 		target.take_organ_damage(3)// 7 is the same as crowbar punch
 
 	// Break the syringe and transfer some of the reagents to the target
-	src.reagents.reaction(target, INGEST)
 	var/syringestab_amount_transferred = max(rand(min(reagents.total_volume, 2), (reagents.total_volume - 5)), 0) //nerfed by popular demand.
+	src.reagents.reaction(target, INGEST, amount_override = min(reagents.total_volume,syringestab_amount_transferred)/(reagents.reagent_list.len))
 	src.reagents.trans_to(target, syringestab_amount_transferred)
 	src.desc += " It is broken."
 	src.mode = SYRINGE_BROKEN

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -160,7 +160,8 @@
 
 	var/trans = container.reagents.trans_to(target, container.amount_per_transfer_from_this)
 	if (trans > 0)
-		container.reagents.reaction(target, INGEST)	//technically it's contact, but the reagents are being applied to internal tissue
+		//technically it's contact, but the reagents are being applied to internal tissue
+		container.reagents.reaction(target, INGEST, amount_override = min(container.reagents.total_volume,container.amount_per_transfer_from_this)/(container.reagents.reagent_list.len))
 
 		if(container.reagents.has_reagent(PERIDAXON))
 			affected.status &= ~ORGAN_DEAD
@@ -177,7 +178,8 @@
 	var/obj/item/weapon/reagent_containers/container = tool
 
 	var/trans = container.reagents.trans_to(target, container.amount_per_transfer_from_this)
-	container.reagents.reaction(target, INGEST)	//technically it's contact, but the reagents are being applied to internal tissue
+	//technically it's contact, but the reagents are being applied to internal tissue
+	container.reagents.reaction(target, INGEST, amount_override = min(container.reagents.total_volume,container.amount_per_transfer_from_this)/(container.reagents.reagent_list.len))
 
 	user.visible_message("<span class='warning'>[user]'s hand slips, applying [trans] units of the solution to the wrong place in [target]'s [affected.display_name] with the [tool]!</span>" , \
 	"<span class='warning'>Your hand slips, applying [trans] units of the solution to the wrong place in [target]'s [affected.display_name] with the [tool]!</span>")


### PR DESCRIPTION
[tweak]

## What this does
Makes the volume reacting with a mob during ingestion consistent with the amount consumed, rather than the total volume of the reagent holder.

## Why it's good
Allows for more specific situations where something happens as soon as the mob consumes the reagent with relation to the amount consumed.
Necessary for #32884 to behave better.

## Changelog
:cl:
 * tweak: Ingested reagents now properly react with mobs in relation to their amount consumed, rather than their holders' volume.