### PR TITLE
Some more lighting optimizations

### DIFF
--- a/__DEFINES/lighting.dm
+++ b/__DEFINES/lighting.dm
@@ -9,7 +9,7 @@
 #define LIGHTING_FALLOFF        1 // type of falloff to use for lighting; 1 for circular, 2 for square
 #define LIGHTING_LAMBERTIAN     0 // use lambertian shading for light sources
 #define LIGHTING_HEIGHT         1 // height off the ground of light sources on the pseudo-z-axis, you should probably leave this alone
-#define LIGHTING_ROUND_VALUE    1 / 64 //Value used to round lumcounts, values smaller than 1/129 don't matter (if they do, thanks sinking points), greater values will make lighting less precise, but in turn increase performance, VERY SLIGHTLY.
+#define LIGHTING_ROUND_VALUE    (1 / 64) //Value used to round lumcounts, values smaller than 1/129 don't matter (if they do, thanks sinking points), greater values will make lighting less precise, but in turn increase performance, VERY SLIGHTLY.
 
 #define LIGHTING_ICON 'icons/effects/lighting_overlay.dmi' // icon used for lighting shading effects
 

--- a/__DEFINES/lighting.dm
+++ b/__DEFINES/lighting.dm
@@ -9,7 +9,7 @@
 #define LIGHTING_FALLOFF        1 // type of falloff to use for lighting; 1 for circular, 2 for square
 #define LIGHTING_LAMBERTIAN     0 // use lambertian shading for light sources
 #define LIGHTING_HEIGHT         1 // height off the ground of light sources on the pseudo-z-axis, you should probably leave this alone
-#define LIGHTING_ROUND_VALUE    1 / 128 //Value used to round lumcounts, values smaller than 1/255 don't matter (if they do, thanks sinking points), greater values will make lighting less precise, but in turn increase performance, VERY SLIGHTLY.
+#define LIGHTING_ROUND_VALUE    1 / 64 //Value used to round lumcounts, values smaller than 1/129 don't matter (if they do, thanks sinking points), greater values will make lighting less precise, but in turn increase performance, VERY SLIGHTLY.
 
 #define LIGHTING_ICON 'icons/effects/lighting_overlay.dmi' // icon used for lighting shading effects
 

--- a/__DEFINES/tick.dm
+++ b/__DEFINES/tick.dm
@@ -1,10 +1,36 @@
-#define MAPTICK_MC_MIN_RESERVE 40 //Percentage of tick to leave for master controller to run
-#define TICK_LIMIT_RUNNING (max(90 - world.map_cpu, MAPTICK_MC_MIN_RESERVE))
-#define TICK_LIMIT_TO_RUN 78
+//Percentage of tick to leave for master controller to run
+#define MAPTICK_MC_MIN_RESERVE 70
+//internal_tick_usage is updated every tick
+#if DM_VERSION > 513
+#define MAPTICK_LAST_INTERNAL_TICK_USAGE world.map_cpu
+#else
+#define MAPTICK_LAST_INTERNAL_TICK_USAGE 50
+#endif
+
+// Tick limit while running normally
+#define TICK_BYOND_RESERVE 2
+#define TICK_LIMIT_RUNNING (max(100 - TICK_BYOND_RESERVE - MAPTICK_LAST_INTERNAL_TICK_USAGE, MAPTICK_MC_MIN_RESERVE))
+// Tick limit used to resume things in stoplag
+#define TICK_LIMIT_TO_RUN 70
+// Tick limit for MC while running
 #define TICK_LIMIT_MC 70
-#define TICK_LIMIT_MC_INIT 98
-#define TICK_CHECK ( world.tick_usage > CURRENT_TICKLIMIT ? stoplag() : 0 )
-#define CHECK_TICK if (world.tick_usage > CURRENT_TICKLIMIT)  stoplag()
+// Tick limit while initializing
+#define TICK_LIMIT_MC_INIT_DEFAULT (100 - TICK_BYOND_RESERVE)
+
+//for general usage
+#define TICK_USAGE world.tick_usage
+//to be used where the result isn't checked
+#define TICK_USAGE_REAL world.tick_usage
+
+// Returns true if tick_usage is above the limit
+#define TICK_CHECK ( TICK_USAGE > CURRENT_TICKLIMIT )
+// runs stoplag if tick_usage is above the limit
+#define CHECK_TICK ( TICK_CHECK ? stoplag() : 0 )
+
+// Returns true if tick usage is above 95, for high priority usage
+#define TICK_CHECK_HIGH_PRIORITY ( TICK_USAGE > 95 )
+// runs stoplag if tick_usage is above 95, for high priority usage
+#define CHECK_TICK_HIGH_PRIORITY ( TICK_CHECK_HIGH_PRIORITY? stoplag() : 0 )
 
 // Do X until it's done, while looking for lag.
 #define UNTIL(X) while(!(X)) stoplag()

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -1,4 +1,3 @@
-// So you can be all 10 SECONDS
 #define SECONDS * 10
 #define MINUTES * 600
 #define HOURS   * 36000
@@ -6,7 +5,10 @@
 #define TimeOfGame (get_game_time())
 #define TimeOfTick (world.tick_usage*0.01*world.tick_lag)
 
-//#define REALTIMEOFDAY (world.timeofday + (MIDNIGHT_ROLLOVER * MIDNIGHT_ROLLOVER_CHECK))
+#define DS2TICKS(DS) ((DS)/world.tick_lag)
+#define TICKS2DS(T) ((T) TICKS)
+#define MS2DS(T) ((T) MILLISECONDS)
+#define DS2MS(T) ((T) * 100)
 
 /proc/get_game_time()
 	var/global/time_offset = 0

--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -132,7 +132,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 
 	var/time_to_init = world.timeofday
 	// Initialize subsystems.
-	CURRENT_TICKLIMIT = TICK_LIMIT_MC_INIT
+	CURRENT_TICKLIMIT = TICK_LIMIT_MC_INIT_DEFAULT
 	for (var/datum/subsystem/SS in subsystems)
 		if (SS.flags & SS_NO_INIT)
 			continue

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -1,13 +1,8 @@
-#define STAGE_SOURCES  1
-#define STAGE_CORNERS  2
-#define STAGE_OVERLAYS 3
-
 var/datum/subsystem/lighting/SSlighting
 
 var/list/lighting_update_lights    = list() // List of lighting sources  queued for update.
 var/list/lighting_update_corners   = list() // List of lighting corners  queued for update.
 var/list/lighting_update_overlays  = list() // List of lighting overlays queued for update.
-
 
 /datum/subsystem/lighting
 	name          = "Lighting"
@@ -17,37 +12,22 @@ var/list/lighting_update_overlays  = list() // List of lighting overlays queued 
 	priority      = SS_PRIORITY_LIGHTING
 	flags         = SS_TICKER
 
-	var/list/currentrun_lights
-	var/list/currentrun_corners
-	var/list/currentrun_overlays
-
-	var/resuming_stage = 0
-
-
 /datum/subsystem/lighting/New()
 	NEW_SS_GLOBAL(SSlighting)
-
 
 /datum/subsystem/lighting/stat_entry()
 	..("L:[lighting_update_lights.len]|C:[lighting_update_corners.len]|O:[lighting_update_overlays.len]")
 
-
 /datum/subsystem/lighting/Initialize(timeofday)
 	create_all_lighting_overlays()
-
 	..()
 
-
 /datum/subsystem/lighting/fire(resumed=FALSE)
-	if (resuming_stage == 0 || !resumed)
-		currentrun_lights   = lighting_update_lights
-		lighting_update_lights   = list()
-
-		resuming_stage = STAGE_SOURCES
-
-	while (currentrun_lights.len)
-		var/datum/light_source/L = currentrun_lights[currentrun_lights.len]
-		currentrun_lights.len--
+	var/real_tick_limit = CURRENT_TICKLIMIT
+	CURRENT_TICKLIMIT = (real_tick_limit - world.tick_usage)/3
+	var/i = 0
+	for (i in 1 to lighting_update_lights.len)
+		var/datum/light_source/L = lighting_update_lights[i]
 
 		if (L.check() || L.destroyed || L.force_update)
 			L.remove_lum()
@@ -61,51 +41,40 @@ var/list/lighting_update_overlays  = list() // List of lighting overlays queued 
 		L.force_update = FALSE
 		L.needs_update = FALSE
 
-		if (MC_TICK_CHECK)
-			return
+		if (TICK_CHECK)
+			break
+	if (i)
+		lighting_update_lights.Cut(1, i+1)
+		i = 0
 
-	if (resuming_stage == STAGE_SOURCES || !resumed)
-		// PJB left this in, was causing crashes.
-		//if (currentrun_corners && currentrun_corners.len)
-		//	to_chat(world, "we still have corners to do, but we're gonna override them?")
+	CURRENT_TICKLIMIT = ((real_tick_limit - world.tick_usage)/2)+world.tick_usage
 
-		currentrun_corners  = lighting_update_corners
-		lighting_update_corners  = list()
-
-		resuming_stage = STAGE_CORNERS
-
-	while (currentrun_corners.len)
-		var/datum/lighting_corner/C = currentrun_corners[currentrun_corners.len]
-		currentrun_corners.len--
+	for (i in 1 to lighting_update_corners.len)
+		var/datum/lighting_corner/C = lighting_update_corners[i]
 
 		C.update_overlays()
 		C.needs_update = FALSE
-		if (MC_TICK_CHECK)
-			return
+		if (TICK_CHECK)
+			break
+	if (i)
+		lighting_update_corners.Cut(1, i+1)
+		i = 0
 
-	if (resuming_stage == STAGE_CORNERS || !resumed)
-		currentrun_overlays = lighting_update_overlays
-		lighting_update_overlays = list()
+	CURRENT_TICKLIMIT = real_tick_limit
 
-		resuming_stage = STAGE_OVERLAYS
+	for (i in 1 to lighting_update_overlays.len)
+		var/atom/movable/lighting_overlay/O = lighting_update_overlays[i]
 
-	while (currentrun_overlays.len)
-		var/atom/movable/lighting_overlay/O = currentrun_overlays[currentrun_overlays.len]
-		currentrun_overlays.len--
+		if (!O || O.gcDestroyed)
+			continue
 
 		O.update_overlay()
 		O.needs_update = FALSE
-		if (MC_TICK_CHECK)
-			return
-
-	resuming_stage = 0
-
+		if (TICK_CHECK)
+			break
+	if (i)
+		lighting_update_overlays.Cut(1, i+1)
 
 /datum/subsystem/lighting/Recover()
 	initialized = SSlighting.initialized
 	..()
-
-
-#undef STAGE_SOURCES
-#undef STAGE_CORNERS
-#undef STAGE_OVERLAYS

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -32,7 +32,6 @@
 
 /atom/movable/lighting_overlay/Destroy()
 	global.lighting_update_overlays     -= src
-	SSlighting.currentrun_overlays -= src
 
 	var/turf/T   = loc
 	if (istype(T))

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -27,19 +27,19 @@
 		return
 
 	var/area/A = loc
-	if (A.dynamic_lighting)
-		if (!lighting_corners_initialised)
-			generate_missing_corners()
+	if (!A.dynamic_lighting)
+		return
+	if (!lighting_corners_initialised)
+		generate_missing_corners()
 
-		new /atom/movable/lighting_overlay(src)
+	new /atom/movable/lighting_overlay(src)
 
-		for (var/datum/lighting_corner/C in corners)
-			if (!C.active) // We would activate the corner, calculate the lighting for it.
-				for (var/L in C.affecting)
-					var/datum/light_source/S = L
-					S.recalc_corner(C)
-
-				C.active = TRUE
+	for (var/datum/lighting_corner/C in corners)
+		if (!C.active) // We would activate the corner, calculate the lighting for it.
+			for (var/L in C.affecting)
+				var/datum/light_source/S = L
+				S.recalc_corner(C)
+			C.active = TRUE
 
 // Used to get a scaled lumcount.
 /turf/proc/get_lumcount(var/minlum = 0, var/maxlum = 1)
@@ -51,17 +51,18 @@
 		totallums += L.lum_r + L.lum_b + L.lum_g
 
 	totallums /= 12 // 4 corners, each with 3 channels, get the average.
-
 	totallums = (totallums - minlum) / (maxlum - minlum)
 
 	return CLAMP01(totallums)
 
 // Can't think of a good name, this proc will recalculate the has_opaque_atom variable.
 /turf/proc/recalc_atom_opacity()
-	has_opaque_atom = FALSE
-	for (var/atom/A in src.contents + src) // Loop through every movable atom on our tile PLUS ourselves (we matter too...)
-		if (A.opacity)
-			has_opaque_atom = TRUE
+	has_opaque_atom = opacity
+	if (!has_opaque_atom)
+		for (var/atom/A in src.contents) // Loop through every movable atom on our tile PLUS ourselves (we matter too...)
+			if (A.opacity)
+				has_opaque_atom = TRUE
+				break
 
 /turf/Exited(var/atom/movable/Obj, var/atom/newloc)
 	. = ..()


### PR DESCRIPTION
[performance]

Made some changes based off:

https://github.com/tgstation/tgstation/pull/25861
https://github.com/tgstation/tgstation/pull/24963

## What this does
- Peaked at 46% with the optimizations, whereas it'd jump to like 86% without the optimizations. Also the lighting subsystem didn't go above 16ms with optimizations, and went above 100ms without. Breaking all lights and fixing them does the something similar too, much lower peak CPU usage.
- Increasing the `LIGHTING_ROUND_VALUE` from 1 / 128 to 1 / 64 "reduces the number of states to 24 bits of entropy"
- This has no impact if the value rounded is above `LIGHTING_SOFT_THRESHOLD`

1 / 8
![image](https://user-images.githubusercontent.com/94659603/177519169-987d2484-f6e3-42e1-88a5-11dfdf4a9242.png)
![image](https://user-images.githubusercontent.com/94659603/177519309-0f9688e0-ebac-4a1c-8d7c-e2360528615b.png)
![image](https://user-images.githubusercontent.com/94659603/177520457-f66b7974-5f2b-44fc-b937-49fe1e471c7a.png)

1 / 64
![image](https://user-images.githubusercontent.com/94659603/177513088-126a1d28-f2a7-4d55-98a7-fa9293c25ed7.png)
![image](https://user-images.githubusercontent.com/94659603/177513434-ce7380f1-ec5e-445e-9101-13e5eec2cf89.png)
![image](https://user-images.githubusercontent.com/94659603/177519950-18f229bd-17a6-4810-9812-b7e6d31d9812.png)

1 / 128
![image](https://user-images.githubusercontent.com/94659603/177522158-e8dfb2b3-0b97-49af-9d12-6414ffd2c444.png)

Bleeding edge (1 / 128)
![image](https://user-images.githubusercontent.com/94659603/177514562-f9d2fbf8-830d-47b0-ba21-abbbdcc80309.png)
![image](https://user-images.githubusercontent.com/94659603/177514815-8313611e-ec06-40ed-8a74-2df519268334.png)
![image](https://user-images.githubusercontent.com/94659603/177514898-0457aca5-6892-4217-b997-3fe615921155.png)


## Why it's good
- Theoretically improves client performance with very slight visual changes that are probably not noticeable