### PR TITLE
Adds an emergency shuttle inbound announcement

### DIFF
--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -218,7 +218,6 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 /datum/emergency_shuttle/proc/shuttle_phase(var/phase, var/casual = 1)
 	switch (phase)
 		if ("inbound")
-			can_recall = 0
 			send2mainirc("The Emergency Shuttle is inbound to the station.")
 			send2maindiscord("The **Emergency Shuttle** is inbound to the station.")
 			send2ickdiscord("The **Emergency Shuttle** is inbound to the station.")
@@ -386,7 +385,7 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 				fake_recall = 0
 				return 0
 
-			else if(timeleft <= 300 && can_recall)
+			else if(timeleft == 300)
 				shuttle_phase("inbound")
 
 			/* --- Shuttle has docked with the station - begin countdown to transit --- */

--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -218,6 +218,7 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 /datum/emergency_shuttle/proc/shuttle_phase(var/phase, var/casual = 1)
 	switch (phase)
 		if ("inbound")
+			can_recall = 0
 			send2mainirc("The Emergency Shuttle is inbound to the station.")
 			send2maindiscord("The **Emergency Shuttle** is inbound to the station.")
 			send2ickdiscord("The **Emergency Shuttle** is inbound to the station.")

--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -217,6 +217,12 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 
 /datum/emergency_shuttle/proc/shuttle_phase(var/phase, var/casual = 1)
 	switch (phase)
+		if ("inbound")
+			send2mainirc("The Emergency Shuttle is inbound to the station.")
+			send2maindiscord("The **Emergency Shuttle** is inbound to the station.")
+			send2ickdiscord("The **Emergency Shuttle** is inbound to the station.")
+			command_alert(/datum/command_alert/emergency_shuttle_norecall)
+
 		if ("station")
 			location = 1
 
@@ -230,9 +236,6 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 
 			if (!casual)
 				settimeleft(SHUTTLELEAVETIME)
-				send2mainirc("The Emergency Shuttle has docked with the station.")
-				send2maindiscord("The **Emergency Shuttle** has docked with the station.")
-				send2ickdiscord("The **Emergency Shuttle** has docked with the station.")
 				command_alert(/datum/command_alert/emergency_shuttle_docked)
 				world << sound('sound/AI/shuttledock.ogg')
 			if(ticker)
@@ -381,6 +384,9 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 				recall()
 				fake_recall = 0
 				return 0
+
+			else if(timeleft <= 300 && can_recall)
+				shuttle_phase("inbound")
 
 			/* --- Shuttle has docked with the station - begin countdown to transit --- */
 			else if(timeleft <= 0)

--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -30,6 +30,7 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 	var/always_fake_recall = 0
 	var/deny_shuttle = 0 //for admins not allowing it to be called.
 	var/departed = 0
+	var/departed_centcomm = 0
 
 	var/shutdown = 0 // Completely shut down.
 
@@ -218,6 +219,7 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 /datum/emergency_shuttle/proc/shuttle_phase(var/phase, var/casual = 1)
 	switch (phase)
 		if ("inbound")
+			departed_centcomm = 1
 			send2mainirc("The Emergency Shuttle is inbound to the station.")
 			send2maindiscord("The **Emergency Shuttle** is inbound to the station.")
 			send2ickdiscord("The **Emergency Shuttle** is inbound to the station.")
@@ -385,7 +387,7 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 				fake_recall = 0
 				return 0
 
-			else if(timeleft == 300)
+			else if(timeleft <= 300 && !departed_centcomm)
 				shuttle_phase("inbound")
 
 			/* --- Shuttle has docked with the station - begin countdown to transit --- */

--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -168,7 +168,7 @@
 	force_report = 1
 
 /datum/command_alert/emergency_shuttle_norecall/announce()
-	message = "The Emergency Shuttle is now inbound and can no longer be recalled. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes."
+	message = "The Emergency Shuttle has now left for the station and can no longer be recalled. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes."
 	..()
 
 /datum/command_alert/emergency_shuttle_docked

--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -162,6 +162,15 @@
 	message = "The emergency shuttle has been recalled."
 	..()
 
+/datum/command_alert/emergency_shuttle_norecall
+	name = "Emergency Shuttle Inbound"
+	alert_title = "Priority Announcement"
+	force_report = 1
+
+/datum/command_alert/emergency_shuttle_norecall/announce()
+	message = "The Emergency Shuttle is now inbound and can no longer be recalled. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes."
+	..()
+
 /datum/command_alert/emergency_shuttle_docked
 	name = "Emergency Shuttle Docked"
 	alert_title = "Priority Announcement"


### PR DESCRIPTION
## What this does
Sends a command report to the crew informing the shuttle can no longer be recalled within 5 minutes of its docking to the station, also moves docking announcements in chat to notify the inbound period instead.

## Why it's good
Makes this more obvious to people not aware of it, more fine threshold of confirmed round end is sent out.

## Changelog
:cl:
 * rscadd: Centcomm now informs crew when the shuttle has left centcomm for their station and can no longer be recalled.