### PR TITLE
Fix some angles

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -148,7 +148,7 @@ var/list/voxlocker = list() //Vox locker spawn points
 //	list/traitors = list()	//traitor list
 var/list/cardinal = list( NORTH, SOUTH, EAST, WEST )
 var/list/diagonal = list(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
-var/list/alldirs = list(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
+var/list/alldirs = list(NORTH, NORTHEAST, EAST, SOUTHEAST, SOUTH, SOUTHWEST, WEST, NORTHWEST)
 
 var/global/universal_cult_chat = 0 //if set to 1, even human cultists can use cultchat
 

--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -148,7 +148,7 @@ var/list/voxlocker = list() //Vox locker spawn points
 //	list/traitors = list()	//traitor list
 var/list/cardinal = list( NORTH, SOUTH, EAST, WEST )
 var/list/diagonal = list(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
-var/list/alldirs = list(NORTH, NORTHEAST, EAST, SOUTHEAST, SOUTH, SOUTHWEST, WEST, NORTHWEST) //WARNING: order is important here
+var/list/alldirs = list(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
 
 var/global/universal_cult_chat = 0 //if set to 1, even human cultists can use cultchat
 

--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -148,7 +148,7 @@ var/list/voxlocker = list() //Vox locker spawn points
 //	list/traitors = list()	//traitor list
 var/list/cardinal = list( NORTH, SOUTH, EAST, WEST )
 var/list/diagonal = list(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
-var/list/alldirs = list(NORTH, NORTHEAST, EAST, SOUTHEAST, SOUTH, SOUTHWEST, WEST, NORTHWEST)
+var/list/alldirs = list(NORTH, NORTHEAST, EAST, SOUTHEAST, SOUTH, SOUTHWEST, WEST, NORTHWEST) //WARNING: order is important here
 
 var/global/universal_cult_chat = 0 //if set to 1, even human cultists can use cultchat
 

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -94,7 +94,7 @@
 			return "east"
 		if(WEST)
 			return "west"
-		if(NORTHWEST)
+		if(NORTHEAST)
 			return "northeast"
 		if(SOUTHEAST)
 			return "southeast"

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -86,21 +86,21 @@
 
 /proc/dir2text(direction)
 	switch(direction)
-		if(1.0)
+		if(NORTH)
 			return "north"
-		if(2.0)
+		if(SOUTH)
 			return "south"
-		if(4.0)
+		if(EAST)
 			return "east"
-		if(8.0)
+		if(WEST)
 			return "west"
-		if(5.0)
+		if(NORTHWEST)
 			return "northeast"
-		if(6.0)
+		if(SOUTHEAST)
 			return "southeast"
-		if(9.0)
+		if(NORTHWEST)
 			return "northwest"
-		if(10.0)
+		if(SOUTHWEST)
 			return "southwest"
 		else
 	return
@@ -109,45 +109,29 @@
 /proc/text2dir(direction)
 	switch(uppertext(direction))
 		if("NORTH")
-			return 1
+			return NORTH
 		if("SOUTH")
-			return 2
+			return SOUTH
 		if("EAST")
-			return 4
+			return EAST
 		if("WEST")
-			return 8
+			return WEST
 		if("NORTHEAST")
-			return 5
+			return NORTHEAST
 		if("NORTHWEST")
-			return 9
+			return NORTHWEST
 		if("SOUTHEAST")
-			return 6
+			return SOUTHEAST
 		if("SOUTHWEST")
-			return 10
+			return SOUTHWEST
 		else
 	return
 
 //Converts an angle (degrees) into an ss13 direction
-/proc/angle2dir(var/degree)
-	degree = ((degree+22.5)%360)
-	if(degree < 45)
-		return NORTH
-	if(degree < 90)
-		return NORTHEAST
-	if(degree < 135)
-		return EAST
-	if(degree < 180)
-		return SOUTHEAST
-	if(degree < 225)
-		return SOUTH
-	if(degree < 270)
-		return SOUTHWEST
-	if(degree < 315)
-		return WEST
-	return NORTH|WEST
+/proc/angle2dir(X)
+	return alldirs[round((((X%360)+382.5)%360)/45)+1]
 
 //returns the north-zero clockwise angle in degrees, given a direction
-
 /proc/dir2angle(var/D)
 	switch(D)
 		if(NORTH)

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -129,6 +129,7 @@
 
 //Converts an angle (degrees) into an ss13 direction
 /proc/angle2dir(var/degree)
+	//shifted 22.5 degrees to account for >337.5
 	degree = ((degree+22.5)%360)
 	if(degree < 45)
 		return NORTH

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -128,8 +128,23 @@
 	return
 
 //Converts an angle (degrees) into an ss13 direction
-/proc/angle2dir(X)
-	return alldirs[round((((X%360)+382.5)%360)/45)+1]
+/proc/angle2dir(var/degree)
+	degree = ((degree+22.5)%360)
+	if(degree < 45)
+		return NORTH
+	if(degree < 90)
+		return NORTHEAST
+	if(degree < 135)
+		return EAST
+	if(degree < 180)
+		return SOUTHEAST
+	if(degree < 225)
+		return SOUTH
+	if(degree < 270)
+		return SOUTHWEST
+	if(degree < 315)
+		return WEST
+	return NORTHWEST
 
 //returns the north-zero clockwise angle in degrees, given a direction
 /proc/dir2angle(var/D)


### PR DESCRIPTION
Had a look at this and implemented it:
https://github.com/tgstation/tgstation/pull/30989
https://github.com/tgstation/tgstation/pull/49486

However, they got the modulus formula wrong, so I just reverted to what it was and fixed it properly.

## What this does
- fixes `return NORTH|WEST `. This has existed since 10+ years ago, and my understanding is that this is before diagonal directions existed, where all diagonals were defined this way.
- replaces numbers with the byond dirs

## Why it's good
Consistency