### PR TITLE
Faster init

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -134,6 +134,7 @@ Class Procs:
 	#endif
 
 	log_startup_progress("Processing Geometry...")
+	sleep(-1)
 	var/simulated_turf_count = 0
 	for(var/turf/simulated/S in world)
 		simulated_turf_count++

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -133,11 +133,8 @@ Class Procs:
 	set background = 1 //The for loop later is sufficiently long to trip BYOND's infinite loop detection.
 	#endif
 
-	to_chat(world, "<span class='danger'>Processing Geometry...</span>")
-	sleep(-1)
-
+	log_startup_progress("Processing Geometry...")
 	var/simulated_turf_count = 0
-
 	for(var/turf/simulated/S in world)
 		simulated_turf_count++
 		S.update_air_properties()

--- a/code/controllers/subsystem/init/map.dm
+++ b/code/controllers/subsystem/init/map.dm
@@ -33,7 +33,9 @@ var/datum/subsystem/map/SSmap
 		generate_hoboshack()
 		
 	var/watch_prim = start_watch()
+	log_startup_progress("Calling post on zLevels...)
 	for(var/datum/zLevel/z in map.zLevels)
+		log_startup_progress("Generating zLevel [z.z].")
 		z.post_mapload()
 	log_startup_progress("Finished calling post on [map.zLevels.len] zLevels in [stop_watch(watch_prim)]s.")
 

--- a/code/controllers/subsystem/init/map.dm
+++ b/code/controllers/subsystem/init/map.dm
@@ -33,7 +33,7 @@ var/datum/subsystem/map/SSmap
 		generate_hoboshack()
 		
 	var/watch_prim = start_watch()
-	log_startup_progress("Calling post on zLevels..."")
+	log_startup_progress("Calling post on zLevels...")
 	for(var/datum/zLevel/z in map.zLevels)
 		log_startup_progress("Generating zLevel [z.z].")
 		z.post_mapload()

--- a/code/controllers/subsystem/init/map.dm
+++ b/code/controllers/subsystem/init/map.dm
@@ -17,7 +17,7 @@ var/datum/subsystem/map/SSmap
 
 	if (!config.skip_vault_generation)
 		var/watch = start_watch()
-		log_startup_progress("Placing vaults and secrets...")"
+		log_startup_progress("Placing vaults and secrets...")
 		generate_vaults()
 		generate_asteroid_secrets()
 		log_startup_progress("Placed vaults and secrets in [stop_watch(watch)]s.")
@@ -33,7 +33,7 @@ var/datum/subsystem/map/SSmap
 		generate_hoboshack()
 		
 	var/watch_prim = start_watch()
-	log_startup_progress("Calling post on zLevels...)
+	log_startup_progress("Calling post on zLevels..."")
 	for(var/datum/zLevel/z in map.zLevels)
 		log_startup_progress("Generating zLevel [z.z].")
 		z.post_mapload()

--- a/code/controllers/subsystem/init/map.dm
+++ b/code/controllers/subsystem/init/map.dm
@@ -2,16 +2,13 @@
 
 var/datum/subsystem/map/SSmap
 
-
 /datum/subsystem/map
 	name       = "Map"
 	init_order = SS_INIT_MAP
 	flags      = SS_NO_FIRE
 
-
 /datum/subsystem/map/New()
 	NEW_SS_GLOBAL(SSmap)
-
 
 /datum/subsystem/map/Initialize(timeofday)
 	if (config.enable_roundstart_away_missions)
@@ -20,10 +17,9 @@ var/datum/subsystem/map/SSmap
 
 	if (!config.skip_vault_generation)
 		var/watch = start_watch()
-		log_startup_progress("Placing random space structures...")
 		generate_vaults()
 		generate_asteroid_secrets()
-		log_startup_progress("  Finished placing structures in [stop_watch(watch)]s.")
+		log_startup_progress("Placed vaults and secrets in [stop_watch(watch)]s.")
 	else
 		log_startup_progress("Not generating vaults - SKIP_VAULT_GENERATION found in config/config.txt")
 
@@ -32,20 +28,15 @@ var/datum/subsystem/map/SSmap
 	
 	//hobo shack generation, one shack will spawn, 1/3 chance of two shacks
 	generate_hoboshack()
-	if (rand(1,3) == 3)
+	if (prob(33))
 		generate_hoboshack()
 		
-	log_startup_progress("Calling post on zLevels, letting them know they can do zlevel specific stuff...")
 	var/watch_prim = start_watch()
 	for(var/datum/zLevel/z in map.zLevels)
-		log_startup_progress("Generating zLevel [z.z].")
-		var/watch = start_watch()
 		z.post_mapload()
-		log_startup_progress("Finished with zLevel [z.z] in [stop_watch(watch)]s.")
-	log_startup_progress("Finished calling post on zLevels in [stop_watch(watch_prim)]s.")
+	log_startup_progress("Finished calling post on [map.zLevels.len] zLevels in [stop_watch(watch_prim)]s.")
 
 	var/watch = start_watch()
-	log_startup_progress("Starting map-specific inits...")
 	map.map_specific_init()
 	log_startup_progress("Finished map-specific inits in [stop_watch(watch)]s.")
 

--- a/code/controllers/subsystem/init/map.dm
+++ b/code/controllers/subsystem/init/map.dm
@@ -17,6 +17,7 @@ var/datum/subsystem/map/SSmap
 
 	if (!config.skip_vault_generation)
 		var/watch = start_watch()
+		log_startup_progress("Placing vaults and secrets...")"
 		generate_vaults()
 		generate_asteroid_secrets()
 		log_startup_progress("Placed vaults and secrets in [stop_watch(watch)]s.")

--- a/code/controllers/subsystem/init/more_init_stuff.dm
+++ b/code/controllers/subsystem/init/more_init_stuff.dm
@@ -11,15 +11,18 @@ var/datum/subsystem/more_init/SSmore_init
 /datum/subsystem/more_init/Initialize(timeofday)
 	setup_news()
 	var/watch=start_watch()
+	log_startup_progress("Caching damage icons...")
 	cachedamageicons()
 	log_startup_progress("Finished caching damage icons in [stop_watch(watch)]s.")
 
 	watch=start_watch()
+	log_startup_progress("Caching space parallax simulation...")
 	create_global_parallax_icons()
 	log_startup_progress("  Finished caching space parallax simulation in [stop_watch(watch)]s.")
 
 	if (!config.skip_minimap_generation)
 		watch=start_watch()
+		log_startup_progress("Generating holominimaps...")
 		generateHoloMinimaps()
 		log_startup_progress("Finished holominimaps in [stop_watch(watch)]s.")
 	else
@@ -29,11 +32,13 @@ var/datum/subsystem/more_init/SSmore_init
 
 	if(config.media_base_url)
 		watch = start_watch()
+		log_startup_progress("Caching jukebox playlists...")
 		load_juke_playlists()
 		log_startup_progress("  Finished caching jukebox playlists in [stop_watch(watch)]s.")
 	..()
 
 	watch=start_watch()
+	log_startup_progress("Doing the other misc. initializations...")
 	process_teleport_locs()				//Sets up the wizard teleport locations
 	process_ghost_teleport_locs()		//Sets up ghost teleport locations.
 	process_adminbus_teleport_locs()	//Sets up adminbus teleport locations.

--- a/code/controllers/subsystem/init/more_init_stuff.dm
+++ b/code/controllers/subsystem/init/more_init_stuff.dm
@@ -11,20 +11,17 @@ var/datum/subsystem/more_init/SSmore_init
 /datum/subsystem/more_init/Initialize(timeofday)
 	setup_news()
 	var/watch=start_watch()
-	log_startup_progress("Caching damage icons...")
 	cachedamageicons()
-	log_startup_progress("  Finished caching damage icons in [stop_watch(watch)]s.")
+	log_startup_progress("Finished caching damage icons in [stop_watch(watch)]s.")
 
 	watch=start_watch()
-	log_startup_progress("Caching space parallax simulation...")
 	create_global_parallax_icons()
 	log_startup_progress("  Finished caching space parallax simulation in [stop_watch(watch)]s.")
 
 	if (!config.skip_minimap_generation)
 		watch=start_watch()
-		log_startup_progress("Generating holominimaps...")
 		generateHoloMinimaps()
-		log_startup_progress("  Finished holominimaps in [stop_watch(watch)]s.")
+		log_startup_progress("Finished holominimaps in [stop_watch(watch)]s.")
 	else
 		//holomaps_initialized = 1 //Assume holominimaps were prerendered, the worst thing that happens if they're missing is that the minimap consoles don't show a minimap - NO IT'S NOT YOU DUMBFUCK, THOSE VARS EXIST FOR A REASON
 		log_startup_progress("Not generating holominimaps - SKIP_HOLOMINIMAP_GENERATION found in config/config.txt")
@@ -32,13 +29,11 @@ var/datum/subsystem/more_init/SSmore_init
 
 	if(config.media_base_url)
 		watch = start_watch()
-		log_startup_progress("Caching jukebox playlists...")
 		load_juke_playlists()
 		log_startup_progress("  Finished caching jukebox playlists in [stop_watch(watch)]s.")
 	..()
 
 	watch=start_watch()
-	log_startup_progress("Doing the other misc. initializations...")
 	process_teleport_locs()				//Sets up the wizard teleport locations
 	process_ghost_teleport_locs()		//Sets up ghost teleport locations.
 	process_adminbus_teleport_locs()	//Sets up adminbus teleport locations.

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -19,18 +19,20 @@ var/list/processing_objects = list()
 
 
 /datum/subsystem/obj/Initialize()
-	for(var/atom/object in world)
-		if(!(object.flags & ATOM_INITIALIZED))
-			var/time_start = world.timeofday
-			object.initialize()
-			var/time = (world.timeofday - time_start)
-			if(time > 1)
-				var/turf/T = get_turf(object)
-				log_debug("Slow object initialize. [object] ([object.type]) at [T?.x],[T?.y],[T?.z] took [time/10] seconds to initialize.")
-				log_startup_progress("Initialized [object] in [time/10] seconds")
-		else
-			bad_inits[object.type] = bad_inits[object.type]+1
-		CHECK_TICK
+	spawn()
+		sleep(-1)
+		for(var/atom/object in world)
+			if(!(object.flags & ATOM_INITIALIZED))
+				var/time_start = world.timeofday
+				object.initialize()
+				var/time = (world.timeofday - time_start)
+				if(time > 1)
+					var/turf/T = get_turf(object)
+					log_debug("Slow object initialize. [object] ([object.type]) at [T?.x],[T?.y],[T?.z] took [time/10] seconds to initialize.")
+					log_startup_progress("Initialized [object] in [time/10] seconds")
+			else
+				bad_inits[object.type] = bad_inits[object.type]+1
+			CHECK_TICK
 	for(var/area/place in areas)
 		var/obj/machinery/power/apc/place_apc = place.areaapc
 		if(place_apc)

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -28,6 +28,7 @@ var/list/processing_objects = list()
 				var/turf/T = get_turf(object)
 				log_debug("Slow object initialize. [object] ([object.type]) at [T?.x],[T?.y],[T?.z] took [time/10] seconds to initialize.")
 				log_startup_progress("Initialized [object] in [time/10] seconds")
+				TICK_CHECK
 		else
 			bad_inits[object.type] = bad_inits[object.type]+1
 	TICK_CHECK

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -24,9 +24,10 @@ var/list/processing_objects = list()
 			var/time_start = world.timeofday
 			object.initialize()
 			var/time = (world.timeofday - time_start)
-			if(time > 1) // At this point very few items (such as corpse landmarks) take longer than a tick to init, with the main bulk of items taking around 1 tick being things that use relativewall()
+			if(time > 1)
 				var/turf/T = get_turf(object)
 				log_debug("Slow object initialize. [object] ([object.type]) at [T?.x],[T?.y],[T?.z] took [time/10] seconds to initialize.")
+				log_startup_progress("Initialized [object] in [time/10] seconds")
 		else
 			bad_inits[object.type] = bad_inits[object.type]+1
 		CHECK_TICK

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -35,9 +35,7 @@ var/list/processing_objects = list()
 		var/obj/machinery/power/apc/place_apc = place.areaapc
 		if(place_apc)
 			place_apc.update()
-	
 	..()
-
 
 /datum/subsystem/obj/stat_entry()
 	..("P:[processing_objects.len]")

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -24,7 +24,7 @@ var/list/processing_objects = list()
 			var/time_start = world.timeofday
 			object.initialize()
 			var/time = (world.timeofday - time_start)
-			if(time > 1)
+			if(time > 2) //0.2 seconds
 				var/turf/T = get_turf(object)
 				log_debug("Slow object initialize. [object] ([object.type]) at [T?.x],[T?.y],[T?.z] took [time/10] seconds to initialize.")
 				log_startup_progress("Initialized [object] in [time/10] seconds")

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -19,24 +19,23 @@ var/list/processing_objects = list()
 
 
 /datum/subsystem/obj/Initialize()
-	spawn()
-		sleep(-1)
-		for(var/atom/object in world)
-			if(!(object.flags & ATOM_INITIALIZED))
-				var/time_start = world.timeofday
-				object.initialize()
-				var/time = (world.timeofday - time_start)
-				if(time > 1)
-					var/turf/T = get_turf(object)
-					log_debug("Slow object initialize. [object] ([object.type]) at [T?.x],[T?.y],[T?.z] took [time/10] seconds to initialize.")
-					log_startup_progress("Initialized [object] in [time/10] seconds")
-			else
-				bad_inits[object.type] = bad_inits[object.type]+1
-			CHECK_TICK
+	for(var/atom/object in world)
+		if(!(object.flags & ATOM_INITIALIZED))
+			var/time_start = world.timeofday
+			object.initialize()
+			var/time = (world.timeofday - time_start)
+			if(time > 1)
+				var/turf/T = get_turf(object)
+				log_debug("Slow object initialize. [object] ([object.type]) at [T?.x],[T?.y],[T?.z] took [time/10] seconds to initialize.")
+				log_startup_progress("Initialized [object] in [time/10] seconds")
+		else
+			bad_inits[object.type] = bad_inits[object.type]+1
+	TICK_CHECK
 	for(var/area/place in areas)
 		var/obj/machinery/power/apc/place_apc = place.areaapc
 		if(place_apc)
 			place_apc.update()
+	
 	..()
 
 

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -24,7 +24,7 @@ var/list/processing_objects = list()
 			var/time_start = world.timeofday
 			object.initialize()
 			var/time = (world.timeofday - time_start)
-			if(time > 2) //0.2 seconds
+			if(time > 1) //0.1 seconds
 				var/turf/T = get_turf(object)
 				log_debug("Slow object initialize. [object] ([object.type]) at [T?.x],[T?.y],[T?.z] took [time/10] seconds to initialize.")
 				log_startup_progress("Initialized [object] in [time/10] seconds")

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -18,27 +18,28 @@
 
 /obj/machinery/computer/station_alert/initialize()
 	..()
-	if(src.z != map.zMainStation)
-		var/area/A = get_area(src)
-		if(!A)
-			return
-		name = "[A.general_area_name] Alert Computer"
-		general_area_name = A.general_area_name
+	spawn(30 SECONDS) //defer init
+		if(src.z != map.zMainStation)
+			var/area/A = get_area(src)
+			if(!A)
+				return
+			name = "[A.general_area_name] Alert Computer"
+			general_area_name = A.general_area_name
 
-		for(var/areatype in typesof(A.general_area))
-			var/area/B = locate(areatype)
-			covered_areas += B
+			for(var/areatype in typesof(A.general_area))
+				var/area/B = locate(areatype)
+				covered_areas += B
 
-	else//very ugly fix until all the main station's areas inherit from /area/station/
-		var/blockedtypes = typesof(/area/research_outpost,/area/mine,/area/derelict,/area/djstation,/area/vox_trading_post,/area/tcommsat)
-		for(var/atype in (typesof(/area) - blockedtypes))
-			var/area/B = locate(atype)
-			covered_areas += B
+		else//very ugly fix until all the main station's areas inherit from /area/station/
+			var/blockedtypes = typesof(/area/research_outpost,/area/mine,/area/derelict,/area/djstation,/area/vox_trading_post,/area/tcommsat)
+			for(var/atype in (typesof(/area) - blockedtypes))
+				var/area/B = locate(atype)
+				covered_areas += B
 
-	for(var/area/A in covered_areas)
-		A.sendDangerLevel(src)
-		A.send_firealert(src)
-		A.send_poweralert(src)
+		for(var/area/A in covered_areas)
+			A.sendDangerLevel(src)
+			A.send_firealert(src)
+			A.send_poweralert(src)
 
 /obj/machinery/computer/station_alert/attack_hand(mob/user)
 	add_fingerprint(user)

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -1,4 +1,3 @@
-
 /obj/machinery/computer/station_alert
 	name = "Station Alert Computer"
 	desc = "Used to access the station's automated alert system."
@@ -28,20 +27,18 @@
 
 		for(var/areatype in typesof(A.general_area))
 			var/area/B = locate(areatype)
-
 			covered_areas += B
 
 	else//very ugly fix until all the main station's areas inherit from /area/station/
 		var/blockedtypes = typesof(/area/research_outpost,/area/mine,/area/derelict,/area/djstation,/area/vox_trading_post,/area/tcommsat)
 		for(var/atype in (typesof(/area) - blockedtypes))
 			var/area/B = locate(atype)
-
 			covered_areas += B
 
-	for(var/area/A in covered_areas)
-		A.sendDangerLevel(src)
-		A.send_firealert(src)
-		A.send_poweralert(src)
+		for(var/area/A in covered_areas)
+			A.sendDangerLevel(src)
+			A.send_firealert(src)
+			A.send_poweralert(src)
 
 /obj/machinery/computer/station_alert/attack_hand(mob/user)
 	add_fingerprint(user)

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -18,7 +18,7 @@
 
 /obj/machinery/computer/station_alert/initialize()
 	..()
-	spawn(30 SECONDS) //defer init
+	spawn(30 SECONDS) //defer init because of slowness
 		if(src.z != map.zMainStation)
 			var/area/A = get_area(src)
 			if(!A)

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -35,10 +35,10 @@
 			var/area/B = locate(atype)
 			covered_areas += B
 
-		for(var/area/A in covered_areas)
-			A.sendDangerLevel(src)
-			A.send_firealert(src)
-			A.send_poweralert(src)
+	for(var/area/A in covered_areas)
+		A.sendDangerLevel(src)
+		A.send_firealert(src)
+		A.send_poweralert(src)
 
 /obj/machinery/computer/station_alert/attack_hand(mob/user)
 	add_fingerprint(user)

--- a/code/modules/randomMaps/vaults.dm
+++ b/code/modules/randomMaps/vaults.dm
@@ -211,7 +211,7 @@
 				continue
 			break
 		while(sanity < 100)
-		message_admins("TESTING: Filtered [filter_counter] turfs.")
+		//message_admins("TESTING: Filtered [filter_counter] turfs.")
 		if(!new_spawn_point)
 			continue
 		var/vault_x = new_spawn_point.x

--- a/code/modules/randomMaps/vaults.dm
+++ b/code/modules/randomMaps/vaults.dm
@@ -194,7 +194,7 @@
 			continue
 		var/sanity = 0
 		var/turf/new_spawn_point
-		var/filter_counter = 0
+		//var/filter_counter = 0
 		do
 			sanity++
 			new_spawn_point = pick(valid_spawn_points)
@@ -207,7 +207,7 @@
 					break
 			if(inbounds || (filter_function && !call(filter_function)(ME, new_spawn_point)))
 				new_spawn_point = null
-				filter_counter++
+				//filter_counter++
 				continue
 			break
 		while(sanity < 100)


### PR DESCRIPTION
## What this does
- Added a startup log to show certain objects that take more than 1 second to load (typically all of them load in less than 0.1 seconds)
- Better placement of `TICK_CHECK` in obj subsystem, which reduces init time by a couple seconds
- added a spawn() to the station alert computer as it takes several seconds extra due to a weird fix to a problem (that should be fixed properly eventually)

Readded the stupid useless messages that no one will use

## Why it's good
- added a little more information for obj
- Deferred Station Alert Computer to initialize 30 seconds later as it takes a long time. This could probably be fixed by referring to the comment in the station_alert.dm

:cl:
* tweak: Messed around with initialization a little so that you can talk to your chums in SS13 a few seconds earlier