### PR TITLE
Instant-runoff voting option

### DIFF
--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -376,7 +376,8 @@ var/global/datum/controller/vote/vote = new()
 /datum/controller/vote/proc/cancel_vote(var/mob/user, var/vote)
 	var/mob_ckey = user.ckey
 	if ((vote && (choices[vote] in voters[mob_ckey])) || (!vote && voters[mob_ckey]))
-		tally[voters[mob_ckey]]--
+		var/list/choicevotes = choices[vote]
+		tally[voters[mob_ckey]][choicevotes.Find(voters[mob_ckey])]--
 		if(vote)
 			voters[mob_ckey] -= list(choices[vote])
 		else
@@ -518,7 +519,7 @@ var/global/datum/controller/vote/vote = new()
 	interface.callJavaScript("update_mode", status_data, hclient_or_mob)
 	if(tally.len)
 		for (var/i = 1; i <= tally.len; i++)
-			var/list/L = list(i, tally[i], tally[tally[i][1]])
+			var/list/L = list(i, tally[i], tally[tally[i]][1])
 			interface.callJavaScript("update_choices", L, hclient_or_mob)
 
 /datum/controller/vote/proc/interact(client/user)

--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -223,8 +223,9 @@ var/global/datum/controller/vote/vote = new()
 		var/maxvotes = 0
 		var/greatest_votes = 0
 		for(var/a in tally)
-			if(tally[a].len > maxvotes)
-				maxvotes = tally[a].len
+			var/list/talnums = tally[a]
+			if(talnums.len > maxvotes)
+				maxvotes = talnums.len
 		for(var/i in 1 to maxvotes)
 			for(var/c in tally)
 				if(!(c in discarded_choices))
@@ -354,7 +355,11 @@ var/global/datum/controller/vote/vote = new()
 	if(mob_ckey)
 		if(voters[mob_ckey])
 			if(num)
-				return choices.Find(voters[mob_ckey])
+				var/list/nums = list()
+				var/list/ourchoices = voters[mob_ckey]
+				for(var/item in ourchoices)
+					nums.Add(list(choices.Find(item)))
+				return json_encode(nums)
 			else
 				return voters[mob_ckey]
 	return 0
@@ -365,7 +370,8 @@ var/global/datum/controller/vote/vote = new()
 	if(choices[vote] in voters[mob_ckey])
 		cancel_vote(user,vote)
 	voters[mob_ckey] += list(choices[vote])
-	tally[choices[vote]][voters[mob_ckey].Find(choices[vote])]++
+	var/list/mobvotes = voters[mob_ckey]
+	tally[choices[vote]][mobvotes.Find(choices[vote])]++
 
 /datum/controller/vote/proc/cancel_vote(var/mob/user, var/vote)
 	var/mob_ckey = user.ckey

--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -518,7 +518,7 @@ var/global/datum/controller/vote/vote = new()
 	interface.callJavaScript("update_mode", status_data, hclient_or_mob)
 	if(tally.len)
 		for (var/i = 1; i <= tally.len; i++)
-			var/list/L = list(i, tally[i], tally[tally[i]])
+			var/list/L = list(i, tally[i], tally[tally[i][1]])
 			interface.callJavaScript("update_choices", L, hclient_or_mob)
 
 /datum/controller/vote/proc/interact(client/user)

--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -461,14 +461,14 @@ var/global/datum/controller/vote/vote = new()
 			for(var/i = 1; i <= choices.len; i++)
 				if(isnull(task.data[choices[i]]))
 					tally += choices[i]
-					tally[choices[i]] = 0
+					tally[choices[i]] = list(0)
 				else
 					tally += choices[i]
 					tally[choices[i]] = task.data[choices[i]]
 		else
 			for (var/c in choices)
 				tally += c
-				tally[c] = 0
+				tally[c] = list(0)
 		if(mode == "custom")
 			text += "<br>[question]"
 

--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -633,7 +633,7 @@ var/global/datum/controller/vote/vote = new()
 				update()
 		if("toggle_vote_method")
 			if(user.client.holder)
-				config.toggle_vote_method = config.toggle_vote_method % 4 + 1
+				config.toggle_vote_method = config.toggle_vote_method % 5 + 1
 
 				update()
 		else

--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -458,7 +458,7 @@ var/global/datum/controller/vote/vote = new()
 		if(config.toggle_vote_method == INSTANTRUNOFF)
 			multiples = TRUE
 		var/list/blankslist = list()
-		for(var/n in 1 to choices)
+		for(var/n in 1 to choices.len)
 			blankslist.Add(list(0))
 		if(config.toggle_vote_method == PERSISTENT && mode == "map")
 			var/datum/persistence_task/vote/task = SSpersistence_misc.tasks[/datum/persistence_task/vote]

--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -457,19 +457,22 @@ var/global/datum/controller/vote/vote = new()
 		//initialize tally
 		if(config.toggle_vote_method == INSTANTRUNOFF)
 			multiples = TRUE
+		var/list/blankslist = list()
+		for(var/n in 1 to choices)
+			blankslist.Add(list(0))
 		if(config.toggle_vote_method == PERSISTENT && mode == "map")
 			var/datum/persistence_task/vote/task = SSpersistence_misc.tasks[/datum/persistence_task/vote]
 			for(var/i = 1; i <= choices.len; i++)
 				if(isnull(task.data[choices[i]]))
 					tally += choices[i]
-					tally[choices[i]] = list(0)
+					tally[choices[i]] = blankslist.Copy()
 				else
 					tally += choices[i]
 					tally[choices[i]] = task.data[choices[i]]
 		else
 			for (var/c in choices)
 				tally += c
-				tally[c] = list(0)
+				tally[c] = blankslist.Copy()
 		if(mode == "custom")
 			text += "<br>[question]"
 

--- a/code/modules/html_interface/voting/voting.js
+++ b/code/modules/html_interface/voting/voting.js
@@ -60,7 +60,7 @@ function update_mode(newMode, newQuestion, newTimeleft, vrestart, vmode, vmap, v
 		$("#vote_main").append($("<div  class='item'></div>").append($("<div class='itemContent'></div>").html("<a href='?src=" + hSrc + ";vote=map'>Map</a>" + (admin == 2 ? "(<a href='?src=" + hSrc + ";vote=toggle_map'>" + (toggle_map?"All Compiled":"Votable") + "</a>)" : ""))));
 	}
 	if(admin > 0){
-		var a = ((toggle_vote_method == 1) ? "Weighted" : (toggle_vote_method == 2) ? "Majority" : (toggle_vote_method == 3) ? "Persistent" : (toggle_vote_method == 4) ? "Random" : "Null");
+		var a = ((toggle_vote_method == 1) ? "Weighted" : (toggle_vote_method == 2) ? "Majority" : (toggle_vote_method == 3) ? "Persistent" : (toggle_vote_method == 4) ? "Random" : (toggle_vote_method == 5) ? "Instant runoff" : "Null");
 		$("#vote_main").append($("<div  class='item'></div>").append($("<div class='itemContent'></div>").html("<a href='?src=" + hSrc + ";vote=toggle_vote_method'>" + a + "</a>")));
 
 	}

--- a/code/modules/html_interface/voting/voting.js
+++ b/code/modules/html_interface/voting/voting.js
@@ -5,7 +5,7 @@ var allow_restart = 0;
 var allow_mode = 0 ;
 var toggle_map = 0;
 var toggle_vote_method = 1;
-var selected_vote = 0;
+var selected_votes = 0;
 var admin = 0;
 var updates = 0;
 var clearallup = 0;
@@ -25,7 +25,7 @@ function fuck(){
 }
 function client_data(selection, privs){
 	updates += 1;
-	selected_vote = parseInt(selection) || 0;
+	selected_votes = JSON.parse(selection) || 0;
 	admin = parseInt(privs) || 0;
 }
 
@@ -89,7 +89,7 @@ function update_choices(ID, choice, votes){
 	try{ID = parseInt(ID);
 		votes = parseInt(votes);}
 	catch(ex){alert("Failed to parse something " + ID + " " + votes); return;}
-	$("#vote_choices").append($("<div class='item'></div>").append($("<div id='choice_"+ID +"'></div>").html("<a " + (selected_vote == ID ? "class='linkOn' " : "")  +  "href='?src=" + hSrc + ";vote=" + ID + "'>"+choice+" (" + votes + " votes)</a>")));
+	$("#vote_choices").append($("<div class='item'></div>").append($("<div id='choice_"+ID +"'></div>").html("<a " + (selected_votes == ID ? "class='linkOn' " : "")  +  "href='?src=" + hSrc + ";vote=" + ID + "'>"+choice+" (" + votes + " votes)</a>")));
 }
 function displayBar(value, rangeMin, rangeMax, styleClass, showText) {
 

--- a/code/modules/html_interface/voting/voting.js
+++ b/code/modules/html_interface/voting/voting.js
@@ -25,7 +25,7 @@ function fuck(){
 }
 function client_data(selection, privs){
 	updates += 1;
-	selected_votes = JSON.parse(selection) || 0;
+	selected_votes = JSON.parse(selection) || [];
 	admin = parseInt(privs) || 0;
 }
 
@@ -89,7 +89,13 @@ function update_choices(ID, choice, votes){
 	try{ID = parseInt(ID);
 		votes = parseInt(votes);}
 	catch(ex){alert("Failed to parse something " + ID + " " + votes); return;}
-	$("#vote_choices").append($("<div class='item'></div>").append($("<div id='choice_"+ID +"'></div>").html("<a " + (selected_votes == ID ? "class='linkOn' " : "")  +  "href='?src=" + hSrc + ";vote=" + ID + "'>"+choice+" (" + votes + " votes)</a>")));
+	var votetocheck = 0
+	for(var i = 0; i < selected_votes.len; i++) {
+		if(selected_votes[i] == ID)
+			votetocheck = i
+			break
+	}
+	$("#vote_choices").append($("<div class='item'></div>").append($("<div id='choice_"+ID +"'></div>").html("<a " + (votetocheck ? "class='linkOn' " : "")  +  "href='?src=" + hSrc + ";vote=" + ID + "'>"+choice+(votetocheck ? " (#" : "")+(votetocheck || "")+(votetocheck ? ")" : "")+" (" + votes + " votes)</a>")));
 }
 function displayBar(value, rangeMin, rangeMax, styleClass, showText) {
 


### PR DESCRIPTION
[content][administration]

## What this does
Adds a new voting method admins can pick, instant-runoff, where players can rank which options they want from first to last. If no option has no clear >50% majority from first preference voting, the least picked option is eliminated and each preference gets added to each vote until one does. Was originally planned to be single transferable votes, but that only suits multiple options and this is better designed for singular ones.

## Why it's good
More accurate system for deciding a map on which most players want if there's pluralities.

## Changelog
:cl:
 * rscadd: Admins can now use instant-runoff as a voting method, allowing players to rank options by preference. If no first preference has over 50%, the least popular option is eliminated and everything else's second preference is added to the votes, and so on with each preference until a clear majority is found.