### PR TITLE
Roundstart and Init speed

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -239,9 +239,6 @@ var/global/datum/gas_mixture/space_gas = new
 //Announcement intercom
 var/global/obj/item/device/radio/intercom/universe/announcement_intercom = new
 
-//used by jump-to-area etc. Updated by area/updateName()
-var/list/sortedAreas = list()
-
 var/global/bomberman_mode = 0
 var/global/bomberman_hurt = 0
 var/global/bomberman_destroy = 0

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -895,9 +895,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 //Returns sortedAreas list if populated
 //else populates the list first before returning it
 /proc/SortAreas()
-	for(var/area/A in areas)
-		sortedAreas.Add(A)
-
+	sortedAreas = areas.Copy()
 	sortTim(sortedAreas, /proc/cmp_name_asc)
 
 /area/proc/addSorted()

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -892,16 +892,6 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	sleep(time)
 	return 1
 
-//Returns sortedAreas list if populated
-//else populates the list first before returning it
-/proc/SortAreas()
-	sortedAreas = areas.Copy()
-	sortTim(sortedAreas, /proc/cmp_name_asc)
-
-/area/proc/addSorted()
-	sortedAreas.Add(src)
-	sortTim(sortedAreas, /proc/cmp_name_asc)
-
 //Takes: Area type as text string or as typepath OR an instance of the area.
 //Returns: A list of all areas of that type in the world.
 /proc/get_areas(var/areatype)

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -25,11 +25,12 @@ var/list/processing_objects = list()
 			object.initialize()
 			var/time = (world.timeofday - time_start)
 			if(time > 1) // At this point very few items (such as corpse landmarks) take longer than a tick to init, with the main bulk of items taking around 1 tick being things that use relativewall()
+				CHECK_TICK
 				var/turf/T = get_turf(object)
 				log_debug("Slow object initialize. [object] ([object.type]) at [T?.x],[T?.y],[T?.z] took [time/10] seconds to initialize.")
 		else
 			bad_inits[object.type] = bad_inits[object.type]+1
-		CHECK_TICK
+	CHECK_TICK
 	for(var/area/place in areas)
 		var/obj/machinery/power/apc/place_apc = place.areaapc
 		if(place_apc)

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -27,7 +27,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "unknown"
 	mouse_opacity = 0
 	luminosity = 0
-	var/lightswitch = 1
+	var/haslightswitch = FALSE
 	var/list/ambient_sounds = list(
 		/datum/ambience/generic1,
 		/datum/ambience/generic2,

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -643,18 +643,21 @@ var/datum/controller/gameticker/ticker
 		var/area/A = get_area(H)
 		if(!(A in discrete_areas)) //We've already added their department
 			discrete_areas += get_department_areas(H)
+	CHECK_TICK
 	for(var/area/DA in discrete_areas)
 		for(var/obj/machinery/light_switch/LS in DA)
 			LS.toggle_switch(1)
 			break
 		for(var/obj/item/device/flashlight/lamp/L in DA)
 			L.toggle_onoff(1)
+	CHECK_TICK
 	//Toggle lights without lightswitches
 	//with better area organization, a lot of this headache can be limited
 	for(var/area/A in areas - discrete_areas)
 		if(!A.requires_power || !A.haslightswitch)
 			for(var/obj/machinery/light/L in A)
 				L.seton(1)
+	CHECK_TICK
 
 // -- Tag mode!
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -646,8 +646,15 @@ var/datum/controller/gameticker/ticker
 	for(var/area/DA in discrete_areas)
 		for(var/obj/machinery/light_switch/LS in DA)
 			LS.toggle_switch(1)
+			break
 		for(var/obj/item/device/flashlight/lamp/L in DA)
 			L.toggle_onoff(1)
+	//Toggle lights without lightswitches
+	//with better area organization, a lot of this headache can be limited
+	for(var/area/A in areas - discrete_areas)
+		if(!A.requires_power || !A.haslightswitch)
+			for(var/obj/machinery/light/L in A)
+				L.seton(1)
 
 // -- Tag mode!
 

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -16,19 +16,14 @@
 
 /obj/machinery/light_switch/initialize()
 	add_self_to_holomap()
-	if (!map.lights_always_ok)
-		var/area/A = get_area(src)
-		if (!A.lights_always_start_on)
-			toggle_switch(newstate = 0)
 
 /obj/machinery/light_switch/New(var/loc, var/ndir, var/building = 2)
 	..()
 	var/area/this_area = get_area(src)
 	name = "[this_area.name] light switch"
 	buildstage = building
-	if(buildstage)
-		on = this_area.lightswitch
-	else
+	this_area.haslightswitch = TRUE
+	if(!buildstage)
 		pixel_x = (ndir & 3)? 0 : (ndir == 4 ? 28 * PIXEL_MULTIPLIER: -28 * PIXEL_MULTIPLIER)
 		pixel_y = (ndir & 3)? (ndir ==1 ? 28 * PIXEL_MULTIPLIER: -28 * PIXEL_MULTIPLIER) : 0
 		dir = ndir
@@ -66,8 +61,6 @@
 				if(do_after(user, src,10) && buildstage == 2)
 					to_chat(user, "<span class='notice'>You unscrew the cover blocking the inner wiring of \the [src].</span>")
 					buildstage = 1
-					var/area/this_area = get_area(src)
-					on = this_area.lightswitch
 			return
 		if(1)
 			if(W.is_screwdriver(user))
@@ -131,7 +124,6 @@
 	on = !on
 	playsound(src,'sound/misc/click.ogg',30,0,-1)
 	var/area/this_area = get_area(src)
-	this_area.lightswitch = on
 	this_area.updateicon()
 
 	for(var/obj/machinery/light_switch/L in this_area)

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -14,9 +14,6 @@
 /obj/machinery/light_switch/supports_holomap()
 	return TRUE
 
-/obj/machinery/light_switch/initialize()
-	add_self_to_holomap()
-
 /obj/machinery/light_switch/New(var/loc, var/ndir, var/building = 2)
 	..()
 	var/area/this_area = get_area(src)
@@ -28,6 +25,7 @@
 		pixel_y = (ndir & 3)? (ndir ==1 ? 28 * PIXEL_MULTIPLIER: -28 * PIXEL_MULTIPLIER) : 0
 		dir = ndir
 	updateicon()
+	add_self_to_holomap()
 
 /obj/machinery/light_switch/proc/updateicon()
 	if(!overlay)

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -308,8 +308,6 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 
 		edit_area(user)
 
-	newarea.addSorted()
-
 	ghostteleportlocs[newarea.name] = newarea
 
 	sleep(5)

--- a/code/game/objects/items/devices/beacon_designator.dm
+++ b/code/game/objects/items/devices/beacon_designator.dm
@@ -75,4 +75,3 @@
 		T.change_area(oldarea,newarea)
 		for(var/atom/allthings in T.contents)
 			allthings.change_area(oldarea,newarea)
-	newarea.addSorted()

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -1,12 +1,16 @@
-/client/proc/Jump(var/area/A in sortedAreas)
+/client/proc/Jump()
 	set name = "Jump to Area"
 	set desc = "Area to jump to"
 	set category = "Admin"
+
 	if(!src.holder)
 		to_chat(src, "Only administrators may use this command.")
 		return
 
 	if(config.allow_admin_jump)
+		var/sortedAreas = areas.Copy()
+		sortTim(sortedAreas, /proc/cmp_name_asc)
+		var/area/A = input(usr, "Choose the jump area", "Area") as null|anything in sortedAreas
 		if(!A)
 			return
 
@@ -197,6 +201,8 @@
 	if(!src.holder)
 		to_chat(src, "Only administrators may use this command.")
 		return
+	var/sortedAreas = areas.Copy()
+	sortTim(sortedAreas, /proc/cmp_name_asc)
 	var/area/A = input(usr, "Pick an area.", "Pick an area") in sortedAreas
 	if(A)
 		if(config.allow_admin_jump)

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -320,8 +320,6 @@ var/list/map_dimension_cache = list()
 
 		if(istype(A))
 			areas.Add(instance)
-			A.addSorted()
-
 
 	members.Remove(members[index])
 

--- a/code/modules/bomberman/bomberman.dm
+++ b/code/modules/bomberman/bomberman.dm
@@ -960,7 +960,6 @@ var/global/list/arena_spawnpoints = list()//used by /mob/dead/observer/Logout()
 		A.power_environ = 0
 		A.always_unpowered = 0
 		A.jammed = SUPER_JAMMED	//lol telesci
-		A.addSorted()
 		arena = A
 
 		spawn(0)

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -402,7 +402,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	var/success = FALSE
 	if(!this_area || !this_area.power_light)
 		return FALSE
-	if(!this_area.haslightswitch || !requires_power)
+	if(!this_area.haslightswitch || !this_area.requires_power)
 		return TRUE
 	for(var/obj/machinery/light_switch/L in this_area)
 		if(L.on)

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -137,21 +137,14 @@ var/global/list/obj/machinery/light/alllights = list()
 		update(0)
 	alllights += src
 
-	spawn(2)
-		var/area/A = get_area(src)
-		if(A && !A.requires_power)
-			on = 1
-
-		if (!map.lights_always_ok)
-			switch(fitting)
-				if("tube")
-					if(prob(2))
-						broken(1)
-				if("bulb")
-					if(prob(5))
-						broken(1)
-		spawn(1)
-			update(0)
+	if(map.broken_lights)
+		switch(fitting)
+			if("tube")
+				if(prob(2))
+					broken(1)
+			if("bulb")
+				if(prob(5))
+					broken(1)
 
 /obj/machinery/light/supports_holomap()
 	return TRUE
@@ -406,7 +399,16 @@ var/global/list/obj/machinery/light/alllights = list()
  */
 /obj/machinery/light/proc/has_power()
 	var/area/this_area = get_area(src)
-	return this_area && this_area.lightswitch && this_area.power_light
+	var/success = FALSE
+	if(!this_area || !this_area.power_light)
+		return FALSE
+	if(!this_area.haslightswitch)
+		return TRUE
+	for(var/obj/machinery/light_switch/L in this_area)
+		if(L.on)
+			success = TRUE
+		break
+	return success
 
 /obj/machinery/light/proc/flicker(var/amount = rand(10, 20))
 	if(flickering)

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -402,7 +402,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	var/success = FALSE
 	if(!this_area || !this_area.power_light)
 		return FALSE
-	if(!this_area.haslightswitch)
+	if(!this_area.haslightswitch || !requires_power)
 		return TRUE
 	for(var/obj/machinery/light_switch/L in this_area)
 		if(L.on)

--- a/code/modules/randomMaps/special.dm
+++ b/code/modules/randomMaps/special.dm
@@ -65,7 +65,6 @@
 			if(!area_object)
 				area_object = new area_type
 				area_object.tag = "[area_type]/\ref[src]"
-				area_object.addSorted()
 
 			area_object.contents.Add(T)
 			T.change_area(old_area, area_object)

--- a/code/modules/research/xenoarchaeology/areas.dm
+++ b/code/modules/research/xenoarchaeology/areas.dm
@@ -59,7 +59,6 @@
 /area/research_outpost/spectro
 	name = "Mass Spectrometry Lab"
 	icon_state = "anospectro"
-	lightswitch = FALSE
 	ambient_sounds = list(
 		/datum/ambience/ded2)
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -125,8 +125,6 @@ var/auxtools_path
 
 	Master.Setup()
 
-	SortAreas()							//Build the list of all existing areas and sort it alphabetically
-
 	return ..()
 
 /world/Topic(T, addr, master, key)

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -102,8 +102,7 @@
 	var/can_enlarge = TRUE //can map elements expand this map? turn off for surface maps
 	var/datum/climate/climate = null //use for weather cycle
 	var/has_engines = FALSE // Is the map a space ship with big engines?
-
-	var/lights_always_ok = FALSE //should all lights be on and working at roundstart
+	var/broken_lights = TRUE //broken lights roundstart
 	var/can_have_robots = TRUE
 
 /datum/map/New()

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -37,7 +37,6 @@
 			allthings.change_area(src, new_area)
 
 	new_area.tag = "[new_area.type]/\ref[ME]"
-	new_area.addSorted()
 
 /area/vault/powered
 	requires_power = 1

--- a/maps/test_tiny.dm
+++ b/maps/test_tiny.dm
@@ -12,7 +12,6 @@
 	zLevels = list(/datum/zLevel/station)
 	enabled_jobs = list(/datum/job/trader)
 	zCentcomm = 1
-	lights_always_ok = TRUE
 
 /datum/subsystem/supply_shuttle
 	movetime = 5 SECONDS

--- a/maps/test_very_tiny.dm
+++ b/maps/test_very_tiny.dm
@@ -5,7 +5,6 @@
 	zLevels = list(/datum/zLevel/station)
 	enabled_jobs = list(/datum/job/trader)
 	zCentcomm = 1
-	lights_always_ok = TRUE
 
 ////////////////////////////////////////////////////////////////
 #include "test_very_tiny.dmm"


### PR DESCRIPTION
Typically when roundstart begins, you're met with a big lag spike due to lights flipping on and off (I don't know how many times). Anyway, I crash at roundstart fairly regularly so I hope this PR can prevent that

## What this does
- Adds some `CHECK_TICKS` where they may be necessary
- Initializes lights to be off. This is instead of initialized on, only to have them shut off and turned on again (retarded)
- Reuses a redundant variable defined in `area` to determine if lights are on instead of just checking the light... Juggling lights_power_on, power_light, lightswitch on, etc. is already hard enough to juggle. Instead, it holds if the area has a lightswitch (useful).
- Moved some random barely used sortedArea proc to where it's used

## Why it's good
- Hopefully prevents crashing at roundstart due to lag spikes
- fasta

:cl:
 * tweak: You might experience less lag at roundstart
