### PR TITLE
Station Alert Computer Delay

### DIFF
--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -27,6 +27,7 @@ var/list/processing_objects = list()
 			if(time > 1) // At this point very few items (such as corpse landmarks) take longer than a tick to init, with the main bulk of items taking around 1 tick being things that use relativewall()
 				CHECK_TICK
 				var/turf/T = get_turf(object)
+				log_startup_progress("[object] took [time/10] to initialize.")
 				log_debug("Slow object initialize. [object] ([object.type]) at [T?.x],[T?.y],[T?.z] took [time/10] seconds to initialize.")
 		else
 			bad_inits[object.type] = bad_inits[object.type]+1

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -14,28 +14,35 @@
 
 /obj/machinery/computer/station_alert/New()
 	..()
-	spawn(30 SECONDS) //defer init because of slowness
-		if(src.z != map.zMainStation)
-			var/area/A = get_area(src)
-			if(!A)
-				return
-			name = "[A.general_area_name] Alert Computer"
-			general_area_name = A.general_area_name
+	if(world.has_round_started())
+		initialize()
+	else
+		spawn(30 SECONDS) //defer init because of slowness
+			initialize()
 
-			for(var/areatype in typesof(A.general_area))
-				var/area/B = locate(areatype)
-				covered_areas += B
+/obj/machinery/computer/station_alert/initialize()
+	..()
+	if(src.z != map.zMainStation)
+		var/area/A = get_area(src)
+		if(!A)
+			return
+		name = "[A.general_area_name] Alert Computer"
+		general_area_name = A.general_area_name
 
-		else//very ugly fix until all the main station's areas inherit from /area/station/
-			var/blockedtypes = typesof(/area/research_outpost,/area/mine,/area/derelict,/area/djstation,/area/vox_trading_post,/area/tcommsat)
-			for(var/atype in (typesof(/area) - blockedtypes))
-				var/area/B = locate(atype)
-				covered_areas += B
+		for(var/areatype in typesof(A.general_area))
+			var/area/B = locate(areatype)
+			covered_areas += B
 
-		for(var/area/A in covered_areas)
-			A.sendDangerLevel(src)
-			A.send_firealert(src)
-			A.send_poweralert(src)
+	else//very ugly fix until all the main station's areas inherit from /area/station/
+		var/blockedtypes = typesof(/area/research_outpost,/area/mine,/area/derelict,/area/djstation,/area/vox_trading_post,/area/tcommsat)
+		for(var/atype in (typesof(/area) - blockedtypes))
+			var/area/B = locate(atype)
+			covered_areas += B
+
+	for(var/area/A in covered_areas)
+		A.sendDangerLevel(src)
+		A.send_firealert(src)
+		A.send_poweralert(src)
 
 /obj/machinery/computer/station_alert/attack_hand(mob/user)
 	add_fingerprint(user)

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -19,29 +19,28 @@
 
 /obj/machinery/computer/station_alert/initialize()
 	..()
-	if(src.z != map.zMainStation)
-		var/area/A = get_area(src)
-		if(!A)
-			return
-		name = "[A.general_area_name] Alert Computer"
-		general_area_name = A.general_area_name
+	spawn(30 SECONDS) //defer init because of slowness
+		if(src.z != map.zMainStation)
+			var/area/A = get_area(src)
+			if(!A)
+				return
+			name = "[A.general_area_name] Alert Computer"
+			general_area_name = A.general_area_name
 
-		for(var/areatype in typesof(A.general_area))
-			var/area/B = locate(areatype)
+			for(var/areatype in typesof(A.general_area))
+				var/area/B = locate(areatype)
+				covered_areas += B
 
-			covered_areas += B
+		else//very ugly fix until all the main station's areas inherit from /area/station/
+			var/blockedtypes = typesof(/area/research_outpost,/area/mine,/area/derelict,/area/djstation,/area/vox_trading_post,/area/tcommsat)
+			for(var/atype in (typesof(/area) - blockedtypes))
+				var/area/B = locate(atype)
+				covered_areas += B
 
-	else//very ugly fix until all the main station's areas inherit from /area/station/
-		var/blockedtypes = typesof(/area/research_outpost,/area/mine,/area/derelict,/area/djstation,/area/vox_trading_post,/area/tcommsat)
-		for(var/atype in (typesof(/area) - blockedtypes))
-			var/area/B = locate(atype)
-
-			covered_areas += B
-
-	for(var/area/A in covered_areas)
-		A.sendDangerLevel(src)
-		A.send_firealert(src)
-		A.send_poweralert(src)
+		for(var/area/A in covered_areas)
+			A.sendDangerLevel(src)
+			A.send_firealert(src)
+			A.send_poweralert(src)
 
 /obj/machinery/computer/station_alert/attack_hand(mob/user)
 	add_fingerprint(user)

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -14,11 +14,6 @@
 
 /obj/machinery/computer/station_alert/New()
 	..()
-	if(world.has_round_started())
-		initialize()
-
-/obj/machinery/computer/station_alert/initialize()
-	..()
 	spawn(30 SECONDS) //defer init because of slowness
 		if(src.z != map.zMainStation)
 			var/area/A = get_area(src)

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -136,15 +136,15 @@ var/global/list/obj/machinery/light/alllights = list()
 	else
 		update(0)
 	alllights += src
-
-	if(map.broken_lights)
-		switch(fitting)
-			if("tube")
-				if(prob(2))
-					broken(1)
-			if("bulb")
-				if(prob(5))
-					broken(1)
+	spawn()
+		if(map.broken_lights)
+			switch(fitting)
+				if("tube")
+					if(prob(2))
+						broken(1)
+				if("bulb")
+					if(prob(5))
+						broken(1)
 
 /obj/machinery/light/supports_holomap()
 	return TRUE


### PR DESCRIPTION
Station Alert Computer is the one object that takes longer than one second to initialize. Somehow, it slows down initialization at least on my local

## What this does
- puts a spawn(30 SECONDS) on the Station Alert Computer, to avoid air subsystem issues?
- spawn on broken lights
- Currently it's set to not initialize until after roundstart... But it should only initialize once, so it never actually gets initialized. 

## Why it's good
- Speed up init