### PR TITLE
Stop players from voting prior to round start

### DIFF
--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -325,6 +325,7 @@ var/global/datum/controller/vote/vote = new()
 /datum/controller/vote/proc/initiate_vote(var/vote_type, var/initiator_key, var/popup = 0)
 	var/mob/user = usr
 	if(!world.has_round_started() && !user.client.holder)
+		to_chat(user, "<span class='notice'> You can't do that right now!")
 		return
 	if(currently_voting)
 		message_admins("<span class='info'>[initiator_key] attempted to begin a vote, however a vote is already in progress.</span>")

--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -324,6 +324,8 @@ var/global/datum/controller/vote/vote = new()
 
 /datum/controller/vote/proc/initiate_vote(var/vote_type, var/initiator_key, var/popup = 0)
 	var/mob/user = usr
+	if(!world.has_round_started())
+		return
 	if(currently_voting)
 		message_admins("<span class='info'>[initiator_key] attempted to begin a vote, however a vote is already in progress.</span>")
 		return

--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -324,7 +324,7 @@ var/global/datum/controller/vote/vote = new()
 
 /datum/controller/vote/proc/initiate_vote(var/vote_type, var/initiator_key, var/popup = 0)
 	var/mob/user = usr
-	if(!world.has_round_started())
+	if(!world.has_round_started() && !user.client.holder)
 		return
 	if(currently_voting)
 		message_admins("<span class='info'>[initiator_key] attempted to begin a vote, however a vote is already in progress.</span>")


### PR DESCRIPTION
[hotfix][bugfix]

I decided try to break it and I did

## What this does
- Prevent players from calling a vote prior to round start (does not affect admins)

## Why it's good
- Prevent players from calling a vote prior to round start

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: You can no longer call a vote prior to round start. Does not affect admins