### PR TITLE
Changes map lights to default

### DIFF
--- a/maps/misc/voxshuttle.dmm
+++ b/maps/misc/voxshuttle.dmm
@@ -885,7 +885,6 @@
 "cd" = (
 /obj/machinery/light/small{
 	dir = 4;
-	on = 1
 	},
 /obj/item/clothing/mask/breath,
 /obj/item/stack/medical/bruise_pack/bandaid,

--- a/maps/randomvaults/assistantslair.dmm
+++ b/maps/randomvaults/assistantslair.dmm
@@ -436,7 +436,6 @@
 /obj/item/clothing/mask/gas,
 /obj/machinery/light/small{
 	dir = 4;
-	on = 1
 	},
 /turf/simulated/floor/plating,
 /area/vault/assistantlair)
@@ -676,7 +675,6 @@
 	},
 /obj/machinery/light/small{
 	dir = 4;
-	on = 1
 	},
 /turf/simulated/floor/plating,
 /area/vault/assistantlair)
@@ -859,7 +857,6 @@
 "cL" = (
 /obj/machinery/light/small{
 	dir = 4;
-	on = 1
 	},
 /turf/simulated/floor/plating,
 /area/vault/assistantlair)


### PR DESCRIPTION
While code diving, I came across lights that were mapped on, which was weird. This overrides them being set properly, based on whether there's a lightswitch or if there is someone that spawned in the department round start. While it would be a minor inconsistency, it's just extra unnecessary junk.

Edit: it's only 100 lights and basically I'm a retard and wasted my time

## What this does
- Removes `on = 1` from every light

## Why it's good
- Doesn't override the light setting
- Smaller map size?? Removes redundant lines of code

:cl:
 * bugfix: Made lights a little more consistent with how they are set round start. No shouldn't notice a difference