### PR TITLE
Stoplag Update

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -1,14 +1,12 @@
+#define MILLISECONDS * 0.01
 #define SECONDS * 10
 #define MINUTES * 600
 #define HOURS   * 36000
+#define MIDNIGHT_ROLLOVER_CHECK (rollovercheck_last_timeofday != world.timeofday ? update_midnight_rollover() : midnight_rollovers)
+#define MIDNIGHT_ROLLOVER		864000	//number of deciseconds in a day
+#define REALTIMEOFDAY (world.timeofday + (MIDNIGHT_ROLLOVER * MIDNIGHT_ROLLOVER_CHECK))
 
 #define TimeOfGame (get_game_time())
-#define TimeOfTick (world.tick_usage*0.01*world.tick_lag)
-
-#define DS2TICKS(DS) ((DS)/world.tick_lag)
-#define TICKS2DS(T) ((T) TICKS)
-#define MS2DS(T) ((T) MILLISECONDS)
-#define DS2MS(T) ((T) * 100)
 
 /proc/get_game_time()
 	var/global/time_offset = 0
@@ -121,13 +119,11 @@
 			return LATETIME
 	CRASH("getTimeslot: Hour not found.")
 
-
 var/global/obj/effect/statclick/time/time_statclick
 /proc/timeStatEntry()
 	if(!time_statclick)
 		time_statclick = new /obj/effect/statclick/time("loading...")
 	stat("Station Time:", time_statclick.update("[worldtime2text()]"))
-
 
 var/midnight_rollovers = 0
 var/rollovercheck_last_timeofday = 0
@@ -136,7 +132,3 @@ var/rollovercheck_last_timeofday = 0
 		midnight_rollovers++
 	rollovercheck_last_timeofday = world.timeofday
 	return midnight_rollovers
-
-#define MIDNIGHT_ROLLOVER_CHECK (rollovercheck_last_timeofday != world.timeofday ? update_midnight_rollover() : midnight_rollovers)
-#define MIDNIGHT_ROLLOVER		864000	//number of deciseconds in a day
-#define REALTIMEOFDAY (world.timeofday + (MIDNIGHT_ROLLOVER * MIDNIGHT_ROLLOVER_CHECK))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1604,23 +1604,6 @@ Game Mode config tags:
 		projectile.OnFired()
 		projectile.process()
 
-
-//Increases delay as the server gets more overloaded,
-//as sleeps aren't cheap and sleeping only to wake up and sleep again is wasteful
-#define DELTA_CALC max(((max(world.tick_usage, world.cpu) / 100) * max(Master.sleep_delta,1)), 1)
-
-/proc/stoplag()
-	. = 0
-	var/i = 1
-	do
-		. += round(i*DELTA_CALC)
-		sleep(i*world.tick_lag*DELTA_CALC)
-		i *= 2
-	while (world.tick_usage > min(TICK_LIMIT_TO_RUN, CURRENT_TICKLIMIT))
-
-#undef DELTA_CALC
-
-
 /proc/stack_trace(message = "Getting a stack trace.")
 	CRASH(message)
 

--- a/code/_onclick/hud/draggable.dm
+++ b/code/_onclick/hud/draggable.dm
@@ -84,7 +84,7 @@
 				if(attachedobject.drag_use(attachedmob, T)) //cancel our continuous use
 					qdel(src)
 					break
-		sleep(world.tick_lag)
+		stoplag()
 
 /obj/abstract/screen/draggable/MouseDrag(over_object,src_location,turf/over_location,src_control,over_control,params)
 	if(istype(over_location) && attachedmob) //null when over black space

--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -236,7 +236,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		tickdrift = max(0, MC_AVERAGE_FAST(tickdrift, (((world.timeofday - init_timeofday) - (world.time - init_time)) / world.tick_lag)))
 		var/starting_tick_usage = world.tick_usage
 		if (processing <= 0)
-			current_ticklimit = TICK_LIMIT_RUNNING
+			CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 			sleep(10)
 			continue
 
@@ -245,7 +245,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		//	(because sleeps are processed in the order received, longer sleeps are more likely to run first)
 		if (starting_tick_usage > TICK_LIMIT_MC) //if there isn't enough time to bother doing anything this tick, sleep a bit.
 			sleep_delta *= 2
-			current_ticklimit = TICK_LIMIT_RUNNING * 0.5
+			CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING * 0.5
 			sleep(world.tick_lag * (processing * sleep_delta))
 			continue
 
@@ -299,7 +299,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		src.sleep_delta = MC_AVERAGE_FAST(src.sleep_delta, sleep_delta)
 		CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		if (processing * sleep_delta <= world.tick_lag)
-			current_ticklimit -= (TICK_LIMIT_RUNNING * 0.25) //reserve the tail 1/4 of the next tick for the mc if we plan on running next tick
+			CURRENT_TICKLIMIT -= (TICK_LIMIT_RUNNING * 0.25) //reserve the tail 1/4 of the next tick for the mc if we plan on running next tick
 		sleep(world.tick_lag * (processing * sleep_delta))
 
 // This is what decides if something should run.

--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -236,6 +236,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		tickdrift = max(0, MC_AVERAGE_FAST(tickdrift, (((world.timeofday - init_timeofday) - (world.time - init_time)) / world.tick_lag)))
 		var/starting_tick_usage = world.tick_usage
 		if (processing <= 0)
+			current_ticklimit = TICK_LIMIT_RUNNING
 			sleep(10)
 			continue
 
@@ -244,6 +245,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		//	(because sleeps are processed in the order received, longer sleeps are more likely to run first)
 		if (starting_tick_usage > TICK_LIMIT_MC) //if there isn't enough time to bother doing anything this tick, sleep a bit.
 			sleep_delta *= 2
+			current_ticklimit = TICK_LIMIT_RUNNING * 0.5
 			sleep(world.tick_lag * (processing * sleep_delta))
 			continue
 
@@ -296,6 +298,8 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		last_run = world.time
 		src.sleep_delta = MC_AVERAGE_FAST(src.sleep_delta, sleep_delta)
 		CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
+		if (processing * sleep_delta <= world.tick_lag)
+			current_ticklimit -= (TICK_LIMIT_RUNNING * 0.25) //reserve the tail 1/4 of the next tick for the mc if we plan on running next tick
 		sleep(world.tick_lag * (processing * sleep_delta))
 
 // This is what decides if something should run.

--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -242,7 +242,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 
 		//if there are mutiple sleeping procs running before us hogging the cpu, we have to run later.
 		//	(because sleeps are processed in the order received, longer sleeps are more likely to run first)
-		if (starting_tick_usage > TICK_LIMIT_MC) //if there isn't enough time to bother doing anything this tick, sleep a bit.
+		if (starting_tick_usage > TICK_LIMIT_MC)
 			sleep_delta *= 2
 			CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING * 0.5
 			sleep(world.tick_lag * (processing * sleep_delta))
@@ -298,7 +298,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		src.sleep_delta = MC_AVERAGE_FAST(src.sleep_delta, sleep_delta)
 		CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		if (processing * sleep_delta <= world.tick_lag)
-			CURRENT_TICKLIMIT -= (TICK_LIMIT_RUNNING * 0.25) //reserve the tail 1/4 of the next tick for the mc if we plan on running next tick
+			CURRENT_TICKLIMIT -= (TICK_LIMIT_RUNNING * 0.25)
 		sleep(world.tick_lag * (processing * sleep_delta))
 
 // This is what decides if something should run.

--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -240,7 +240,6 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 			sleep(10)
 			continue
 
-		//Anti-tick-contention heuristics:
 		//if there are mutiple sleeping procs running before us hogging the cpu, we have to run later.
 		//	(because sleeps are processed in the order received, longer sleeps are more likely to run first)
 		if (starting_tick_usage > TICK_LIMIT_MC) //if there isn't enough time to bother doing anything this tick, sleep a bit.

--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -234,21 +234,25 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 	//the actual loop.
 	while (1)
 		tickdrift = max(0, MC_AVERAGE_FAST(tickdrift, (((world.timeofday - init_timeofday) - (world.time - init_time)) / world.tick_lag)))
+		var/starting_tick_usage = world.tick_usage
 		if (processing <= 0)
 			sleep(10)
 			continue
 
-		//if there are mutiple sleeping procs running before us hogging the cpu, we have to run later
-		//	because sleeps are processed in the order received, so longer sleeps are more likely to run first
-		if (world.tick_usage > TICK_LIMIT_MC)
-			sleep_delta += 2
-			sleep(world.tick_lag * (processing + sleep_delta))
+		//Anti-tick-contention heuristics:
+		//if there are mutiple sleeping procs running before us hogging the cpu, we have to run later.
+		//	(because sleeps are processed in the order received, longer sleeps are more likely to run first)
+		if (starting_tick_usage > TICK_LIMIT_MC) //if there isn't enough time to bother doing anything this tick, sleep a bit.
+			sleep_delta *= 2
+			sleep(world.tick_lag * (processing * sleep_delta))
 			continue
 
-		sleep_delta = MC_AVERAGE_FAST(sleep_delta, 0)
-		if (last_run + (world.tick_lag * processing) > world.time)
+		//Byond resumed us late. assume it might have to do the same next tick
+		if (last_run + Ceiling(world.tick_lag * (processing * sleep_delta), world.tick_lag) < world.time)
 			sleep_delta += 1
-		if (world.tick_usage > (TICK_LIMIT_MC*0.5))
+		sleep_delta = MC_AVERAGE_FAST(sleep_delta, 1) //decay sleep_delta
+
+		if (starting_tick_usage > (TICK_LIMIT_MC*0.75)) //we ran 3/4 of the way into the tick
 			sleep_delta += 1
 
 		if (make_runtime)
@@ -291,10 +295,8 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 		iteration++
 		last_run = world.time
 		src.sleep_delta = MC_AVERAGE_FAST(src.sleep_delta, sleep_delta)
-		sleep(world.tick_lag * (processing + sleep_delta))
-
-
-
+		CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
+		sleep(world.tick_lag * (processing * sleep_delta))
 
 // This is what decides if something should run.
 /datum/controller/master/proc/CheckQueue(list/subsystemstocheck)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3701,7 +3701,7 @@
 				for(var/turf/simulated/floor/F in world)
 					count++
 					if(!(count % 50000))
-						sleep(world.tick_lag)
+						stoplag()
 					if(F.z == map.zMainStation)
 						F.name = "lava"
 						F.desc = "The floor is LAVA!"

--- a/code/modules/client/edge_sliding/move_loop.dm
+++ b/code/modules/client/edge_sliding/move_loop.dm
@@ -63,7 +63,7 @@
 	mloop = 1
 	src.Move(mob.loc,true_dir)
 	while(src.true_dir)
-		sleep(world.tick_lag)
+		stoplag()
 		if(src.true_dir)
 			src.Move(mob.loc,true_dir)
 	mloop = 0

--- a/code/modules/power/meteor_battery.dm
+++ b/code/modules/power/meteor_battery.dm
@@ -18,7 +18,7 @@
 	spawn()
 		while(loc)
 			if(timestopped)
-				sleep(world.tick_lag)
+				stoplag()
 				continue
 			step_towards(src,target)
 			sleep(MISSILE_SPEED)

--- a/code/modules/spells/general/lightning.dm
+++ b/code/modules/spells/general/lightning.dm
@@ -143,7 +143,7 @@
 	L.xo = U.x - T.x
 	L.process()
 	while(!src.lastbumped)
-		sleep(world.tick_lag)
+		stoplag()
 	target = lastbumped
 	if(!istype(target)) //hit something
 //		to_chat(world, "we hit a [formatJumpTo(target)] (<a href='?_src_=vars;Vars=\ref[target]'>VV</a>) instead of a mob")


### PR DESCRIPTION
inspired by https://github.com/yogstation13/yogstation-2017-/pull/3010

## What this does
- Replaces a `round` with `ceiling`
- Sets a delay of at least one tick in stoplag
- parameter determines delay, can replace sleeps where they're used for high workload
- moved stoplag to tick, along with other tick-related macros
- changed some sleeps into stoplag that shouldn't make any impact
- will test and compare different things

## Why it's good
- Less lag

:cl:
 * tweak: Made an attempt to reduce some lag