### PR TITLE
Makes powercreep packets cheaper

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -817,7 +817,7 @@ var/list/uplink_items = list()
 	desc = "A packet that creates a dangerous mutated version of kudzu vines. The vines will repeatedly shock people and connect themselves to any cables near them, rapidly growing and spreading out of control if left unchecked."
 	item = /obj/item/deployable_packet/powercreeper
 	cost = 10
-	discounted_cost = 6
+	discounted_cost = 5
 	jobs_with_discount = list("Botanist", "Station Engineer", "Chief Engineer")
 
 /datum/uplink_item/jobspecific/engineering/syndietape_engineering

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -816,8 +816,8 @@ var/list/uplink_items = list()
 	name = "Powercreep Packet"
 	desc = "A packet that creates a dangerous mutated version of kudzu vines. The vines will repeatedly shock people and connect themselves to any cables near them, rapidly growing and spreading out of control if left unchecked."
 	item = /obj/item/deployable_packet/powercreeper
-	cost = 16
-	discounted_cost = 10
+	cost = 10
+	discounted_cost = 6
 	jobs_with_discount = list("Botanist", "Station Engineer", "Chief Engineer")
 
 /datum/uplink_item/jobspecific/engineering/syndietape_engineering


### PR DESCRIPTION
## What this does
Reduces the TC cost of Powercreeper packets from 16 (10 if job) to 10 (5 if job).
## Why it's good
16TC for a tool that can be completely negated by cargo or engineering distributing insulos is too expensive. If everyone is protected powercreep is actually beneficial to the station, giving power back into the grid. Having them cheaper would also allow some exotic syndie clowngineering without consuming all TC.

## Changelog
:cl:
 * tweak: Powercreeper packets now cost 10TC (5TC if job) instead of 16TC (10TC if job)