### PR TITLE
Kicking reverse engines processes queue

### DIFF
--- a/code/modules/research/mechanic/reverse_engine.dm
+++ b/code/modules/research/mechanic/reverse_engine.dm
@@ -135,7 +135,7 @@
 		techdifference = 0
 	return techdifference
 
-/obj/machinery/r_n_d/fabricator/kick_act(mob/living/H)
+/obj/machinery/r_n_d/reverse_engine/kick_act(mob/living/H)
 	..()
 	researchQueue()
 

--- a/code/modules/research/mechanic/reverse_engine.dm
+++ b/code/modules/research/mechanic/reverse_engine.dm
@@ -135,6 +135,10 @@
 		techdifference = 0
 	return techdifference
 
+/obj/machinery/r_n_d/fabricator/kick_act(mob/living/H)
+	..()
+	researchQueue()
+
 /obj/machinery/r_n_d/reverse_engine/proc/researchQueue()
 	if(!research_queue.len)
 		return


### PR DESCRIPTION
[content][consistency][qol]

## What this does
All fabricators and destructive analysers allow it, so this should too.

## Why it's good
Saves a menu interaction.

## Changelog
:cl:
 * rscadd: Kicking reverse engines now processes the design queue.