### PR TITLE
Switch up some init stuff

### DIFF
--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -19,6 +19,7 @@ var/list/processing_objects = list()
 
 
 /datum/subsystem/obj/Initialize()
+	set background = 1
 	for(var/atom/object in world)
 		if(!(object.flags & ATOM_INITIALIZED))
 			var/time_start = world.timeofday

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -30,11 +30,7 @@ var/list/processing_objects = list()
 				log_debug("Slow object initialize. [object] ([object.type]) at [T?.x],[T?.y],[T?.z] took [time/10] seconds to initialize.")
 		else
 			bad_inits[object.type] = bad_inits[object.type]+1
-	CHECK_TICK
-	for(var/area/place in areas)
-		var/obj/machinery/power/apc/place_apc = place.areaapc
-		if(place_apc)
-			place_apc.update()
+
 	..()
 
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -653,11 +653,13 @@ var/datum/controller/gameticker/ticker
 	CHECK_TICK
 	//Toggle lights without lightswitches
 	//with better area organization, a lot of this headache can be limited
-	for(var/area/A in areas - discrete_areas)
+	for(var/area/A in areas)
+		var/obj/machinery/power/apc/place_apc = A.areaapc
+		if(place_apc)
+			place_apc.update()
 		if(!A.requires_power || !A.haslightswitch)
 			for(var/obj/machinery/light/L in A)
 				L.seton(1)
-	CHECK_TICK
 
 // -- Tag mode!
 


### PR DESCRIPTION
## What this does
- move APC updates to a loop that executes roundstart that already exists
- r*move two CHECK_TICKS that seemed unnecessary
- lights out prior to round start

## Why it's good
- instead of two loops doing the same thing at init and roundstart, this just does everything at roundstart
- APCs don't measure power pre-roundstart
- lower obj init time

## Changelog
:cl:
 * tweak: Nanotrasen has implemented cost-cutting measures so stations don't consume power prior to roundstart