### PR TITLE
Meat Fridge Bugfixes

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -4018,9 +4018,10 @@ var/global/list/obj/item/weapon/paper/lotto_numbers/lotto_papers = list()
 /obj/machinery/vending/meat/vend(datum/data/vending_product/R, mob/user, by_voucher = 0)
 	..()
 	if(hasmouse && prob(chanceofejectingmouse))
-		dispensemouse(vend_delay)
+		spawn(vend_delay)
+			dispensemouse(vend_delay)
 
-/obj/machinery/vending/meat/crowbarDestroy(mob/user, obj/item/tool/crowbar/C)
+/obj/machinery/vending/meat/spillContents(var/destroy_chance = 0)
 	..()
 	if(hasmouse)
 		dispensemouse()
@@ -4037,12 +4038,11 @@ var/global/list/obj/item/weapon/paper/lotto_numbers/lotto_papers = list()
 			else
 				to_chat(user, "<SPAN CLASS='notice'>You can only hear the hum of the motor.</SPAN>")
 
-/obj/machinery/vending/meat/proc/dispensemouse(var/delay = 0)
+/obj/machinery/vending/meat/proc/dispensemouse()
 	hasmouse = FALSE
-	spawn(delay)
-		visible_message("\The [src.name] makes an unusual sound as some sort of [initial(hiddenmouse.name)] pops out of the slot!", "You hear a squeak.")
-		if(hiddenmousesound)
-			playsound(loc, hiddenmousesound, 50, 1)
-		new hiddenmouse(get_turf(src))
+	visible_message("\The [src.name] makes an unusual sound as some sort of [initial(hiddenmouse.name)] pops out of the slot!", "You hear a squeak.")
+	if(hiddenmousesound)
+		playsound(loc, hiddenmousesound, 50, 1)
+	new hiddenmouse(get_turf(src))
 
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -4019,7 +4019,7 @@ var/global/list/obj/item/weapon/paper/lotto_numbers/lotto_papers = list()
 	..()
 	if(hasmouse && prob(chanceofejectingmouse))
 		spawn(vend_delay)
-			dispensemouse(vend_delay)
+			dispensemouse()
 
 /obj/machinery/vending/meat/spillContents(var/destroy_chance = 0)
 	..()


### PR DESCRIPTION
# Meat Fridge Bugfixes
![image](https://user-images.githubusercontent.com/69739118/179317818-20fdb72a-42f3-4da6-89dc-8dc6d1ca180a.png)

## What this does
Fixes #32919. While the ``crowbarDestroy()`` function was overridden, it wasn't set to return anything, so the vendor was never qdel'd. This PR, instead of adding returns, replaces the child ``crowbarDestroy()`` with a child ``spillContents()``, covering more destruction cases than just crowbar removal.

Also, ``dispenseMouse()`` no longer uses a built-in delay. Only vending was intended to use the spawn delay, so it was moved there. Leaving the delay in the general function had the potential to cause runtimes, especially with destroyed vending machines!

## Why it's good
No infinite components. No runtimes. The mouse can possibly come out if a monster smashes the vending machine.

## Changelog
:cl:
 * bugfix: Meat Fridge no longer gives infinite components when disassembled.
 * tweak: Mobs hidden in a Meat Fridge can come out in more situations, without causing runtimes.

[bugfix][tested]
