### PR TITLE
Assorted typofixes.

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_rituals.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_rituals.dm
@@ -299,7 +299,7 @@ var/global/list/cult_altars = list()       // List of cult altars in the world.
 	
 /datum/bloodcult_ritual/curse_blood
 	name = "Spread the Gift"
-	desc = "Spread our gift amongst the crew. Create cursed blood by pouring it into a goblet, then have at least 3 nonbelievers injest that blood."
+	desc = "Spread our gift amongst the crew. Create cursed blood by pouring it into a goblet, then have at least 3 nonbelievers ingest that blood."
 	point_limit = 100
 	var/list/infected = list()
 

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -440,7 +440,7 @@
 				return 1
 			if(iscrowbar(P) && circuit)
 				P.playtoolsound(src, 50)
-				user.visible_message("[user] removes the circuit board.", "You remove the circuit board", "You hear metallic sounds.")
+				user.visible_message("[user] removes the circuit board.", "You remove the circuit board.", "You hear metallic sounds.")
 				src.state = 1
 				src.icon_state = "0"
 				circuit.forceMove(src.loc)

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -635,9 +635,9 @@ var/datum/disease2/disease/wizarditis = null
 	reagents.add_reagent(ROBUSTHARVEST, 30)
 
 /obj/item/weapon/reagent_containers/glass/bottle/insecticide
-	name = "insecticide bottle"
+	name = "Insecticide Bottle"
 	icon = 'icons/obj/chemical.dmi'
-	desc = "A bottle of highly toxic insecticide. There's a small, almost unreadable label warning against consumption."
+	desc = "A bottle of highly toxic Insecticide. There's a small, almost unreadable label warning against consumption."
 
 /obj/item/weapon/reagent_containers/glass/bottle/insecticide/New()
 	..()


### PR DESCRIPTION
### What this does
Fixes the cult cursed blood ritual saying "injest" instead of "ingest".
Adds a missing period to the removing the circuitboard part of computer disassembly.
Changes from "insecticide bottle" to "Insecticide Bottle" for consistency with the other nutrimax (botany chemvend) bottles.
### Why it's good
Typos, missing periods or inconsistencies are bad. Fixing good.
[grammar][hotfix]
:cl: 
 * spellcheck: Adds a missing period to the circuitboard part of computer disassembly, fixes a typo on the cult cursed blood ritual and restores consistency for the insecticide bottles.
