### PR TITLE
Biogenerators can make cheese.

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -36,7 +36,7 @@
 /datum/biogen_recipe/food/cheese
 	id="cheese"
 	name="Cheese Wheel"
-	cost=100 //Making milk and reacting it with enzyme to make costs 80, so this is 25% more expensive
+	cost=100 //Making milk and reacting it with enzyme costs 80, so this is 25% more expensive
 	other_amounts=list(5)
 	result=/obj/item/weapon/reagent_containers/food/snacks/sliceable/cheesewheel
 

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -33,6 +33,13 @@
 	amount_per_unit=10
 	other_amounts=list(5)
 
+/datum/biogen_recipe/food/cheese
+	id="cheese"
+	name="Cheese Wheel"
+	cost=100 //Making milk and catalyzing it into cheese costs 80, so this is 25% more expensive
+	other_amounts=list(5)
+	result=/obj/item/weapon/reagent_containers/food/snacks/sliceable/cheesewheel
+
 /datum/biogen_recipe/food/meat
 	id="meat"
 	name="Slab of meat"

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -36,7 +36,7 @@
 /datum/biogen_recipe/food/cheese
 	id="cheese"
 	name="Cheese Wheel"
-	cost=100 //Making milk and catalyzing it into cheese costs 80, so this is 25% more expensive
+	cost=100 //Making milk and reacting it with enzyme to make costs 80, so this is 25% more expensive
 	other_amounts=list(5)
 	result=/obj/item/weapon/reagent_containers/food/snacks/sliceable/cheesewheel
 


### PR DESCRIPTION
## What this does
Lets the biogenerator make cheese at a slightly more expensive rate than using Universal Enzyme on synthesized milk.
Cheese wheels need 40u Milk to be reacted with enzyme. Making 40u of Milk costs 80 biomass, while making straight cheese costs 100. Slightly more expensive for convenience.
## Why it's good
Gives more uses to the biogenerator.
## Changelog
:cl:
 * rscadd: Biogenerators can make cheese wheels for 100 biomass, 25% more expensive than making a cheese wheel worth of milk.