### PR TITLE
Malfunctioning AIs can now hack an additional APC at a time for every 5 APCs hacked

### DIFF
--- a/code/datums/gamemode/role/malf/malf.dm
+++ b/code/datums/gamemode/role/malf/malf.dm
@@ -8,6 +8,7 @@
 	var/list/apcs = list()
 	var/list/currently_hacking_apcs = list()		//any apc's currently being hacked
 	var/apc_hacklimit = 1							//how many apc's can be hacked at a time
+	var/list/apc_checkpoints = list() //Sanity, keeps track of the number of APCs the AI once possessed
 	var/list/currently_hacking_machines = list()	//any non-apc machines currently being hacked
 	var/processing_power = 50
 	var/max_processing_power = 200
@@ -64,7 +65,7 @@ Once done, you will be able to interface with all systems, notably the onboard n
 	if(apcs.len != 0)
 		var/count = 0
 		for(var/obj/machinery/power/apc/A in apcs)
-			if(!A.malf_disrupted)	
+			if(!A.malf_disrupted)
 				count++
 		add_power(count * 0.03)
 
@@ -102,7 +103,7 @@ Once done, you will be able to interface with all systems, notably the onboard n
 	if(!ui)
 		ui = new(user, src, "MalfModules")
 		ui.open()
-	
+
 /datum/role/malfAI/ui_state(mob/user)
 	return global.always_state
 

--- a/code/datums/gamemode/role/malf/malf_apcs.dm
+++ b/code/datums/gamemode/role/malf/malf_apcs.dm
@@ -7,7 +7,7 @@
 
 /obj/machinery/power/apc/malfhack_valid(var/mob/living/silicon/malf)
 	var/datum/role/malfAI/M = malf.mind.GetRole(MALF)
-	if(!istype(M) || !istype(malf))		
+	if(!istype(M) || !istype(malf))
 		to_chat(malf, "<span class='warning'>You are not a malfunctioning AI.</span>")
 		return FALSE
 	if(currently_hacking_ai && currently_hacking_ai != malf)
@@ -54,6 +54,13 @@
 	malfai = malf
 	M.apcs += src
 	to_chat(malf, "<span class='notice'>APC Hack Complete. The [name] is now under your exclusive control. You now have [M.apcs.len] APCs under your control.</span>")
+	var/total_APC = 0
+	for(var/obj/machinery/power/apc/A in M.apcs)
+		total_APC++
+	if(total_APC % 5 == 0 && !(total_APC in M.apc_checkpoints)) //Every 5 APCs hacked, increases the limit of APCs that can be hacked by 1
+		M.apc_hacklimit++
+		to_chat(malf, "<span class='good'>You may now hack an additional APC at a time, up to [M.apc_hacklimit].</span>")
+		M.apc_checkpoints += total_APC //Remembers that this many APCs were hacked to avoid exploits
 	malf.handle_regular_hud_updates()
 	malfimage = new /atom/movable/fake_camera_image(loc)
 	malfimage.pixel_y = pixel_y
@@ -85,7 +92,7 @@
 /obj/machinery/power/apc/enable_AI_control(var/bypass)
 	stat &= ~NOAICONTROL
 	malf_undisrupt()
-	
+
 
 /atom/movable/fake_camera_image
 	name          = ""


### PR DESCRIPTION
When I played Malfunctioning AI I was rather discontent with the full 60 seconds per APC because their individual contribution is not very substantial over larger numbers (another APC to 18 hacked APCs is not substantial compared to when a Malfunctioning AI has only 1 hacked APC) and with each APC hacked the risk of premature detection was higher (plausible deniability such as "someone emagged this hallway APC" and hacking remote APCs in corners of the station that nobody goes to can only get you so far, which isn't very far by the way). To compensate for the increased risk of detection, an AI can now hack additional APCs at a time for every 5 APCs hacked (2 at 5 APCs, 3 at 10 APCs etc.) which should allow them to better seize the initiative before the crew strikes back.

:cl:
 * rscadd: Malfunctioning AIs can now hack an additional APC for every 5 APCs hacked.