### PR TITLE
Malfunctioning AIs are now told how long it will take to take over the station

### DIFF
--- a/code/datums/gamemode/role/malf/hackabilities.dm
+++ b/code/datums/gamemode/role/malf/hackabilities.dm
@@ -476,7 +476,7 @@
 	if (M.apcs.len < 3)
 		to_chat(A, "<span class='notice'>You don't have enough hacked APCs to take over the station yet. You need to hack at least 3, however hacking more will make the takeover faster. You have hacked [M.apcs.len] APCs so far.</span>")
 		return
-	if (alert(A, "Are you sure you wish to initiate the takeover? The station hostile runtime detection software is bound to alert everyone. You have hacked [M.apcs.len] APCs.", "Takeover:", "Yes", "No") != "Yes")
+	if (alert(A, "Are you sure you wish to initiate the takeover? The station hostile runtime detection software is bound to alert everyone. You have hacked [M.apcs.len] APCs, and it will take [round(MF.AI_win_timeleft / (M.apcs.len / 6), 1)] seconds to complete.", "Takeover:", "Yes", "No") != "Yes")
 		return
 
 	MF.stage(FACTION_ENDGAME)


### PR DESCRIPTION
It's in the pop-up.
No there is no risk of an AI trying to take over with 0 APCs because there is a minimum of 3 APCs required to do it.
:cl:
 * rscadd: Malfunctioning AIs will now be told how long it will take to take over the station when they plan to do it.
