### PR TITLE
Fixes discrepancy between blood drained and blood gained for vampires

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -219,7 +219,7 @@
 		if(blood_total_before != blood_total)
 			to_chat(assailant, "<span class='notice'>You have accumulated [blood_total] [blood_total > 1 ? "units" : "unit"] of blood[blood_usable_before != blood_usable ?", and have [blood_usable] left to use." : "."]</span>")
 		check_vampire_upgrade()
-		target.vessel.remove_reagent(BLOOD,30)
+		target.vessel.remove_reagent(BLOOD,blood)
 		update_vamp_hud()
 
 	draining = null


### PR DESCRIPTION
Regular vampires drained 20 blood while mature vampires drained 40 blood, but the victim lost 30 blood regardless of the blood that was actually absorbed. This fix makes the victim's blood loss actually scale to how much blood vampires consumed.

:cl:
 * bugfix: Fixed a bug where victims of vampire attacks lost a fixed amount of blood regardless of how much blood the vampire actually consumed, making regular vampires drain 380 blood and mature vampires drain 760 blood, when the victim had 560 blood. This did not affect the blood that went into upgrades, but instead blood used for spell-casting.
