### PR TITLE
Fixes not being able to access an opened jukebox wire panel using a multi-tool

### DIFF
--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -462,6 +462,10 @@ var/global/list/loopModeNames=list(
 
 /obj/machinery/media/jukebox/attackby(obj/item/W, mob/user)
 	. = ..()
+	if(ismultitool(W)) //The parent has a multi-tool call that prevents opening the wire panel using a multi-tool. This fixes it.
+		if(panel_open)
+			wires.Interact(user)
+			return
 	if(.)
 		return .
 	if(iswiretool(W))


### PR DESCRIPTION
Only a wirecutter worked because the attackby parent of jukebox (which is machinery/attackby()) overrode the multi-tool call with the multi-tool settings menu for the purposes of linking it to other machines. Now if the wire panel is open the multi-tool should now open the wire menu directly instead.
:cl:
 * bugfix: Jukebox wires can now be accessed directly with a multi-tool again once the wire panel is open.
