### PR TITLE
Makes false wall closing and opening faster

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -187,7 +187,7 @@ var/list/false_wall_images = list()
 		icon_state = "[mineral]fwall_open"
 		flick("[mineral]fwall_opening", src)
 		loc.mouse_opacity = 1
-		sleep(15)
+		sleep(6)
 		setDensity(FALSE)
 		set_opacity(0)
 		opening = 0
@@ -197,7 +197,7 @@ var/list/false_wall_images = list()
 		flick("[mineral]fwall_closing", src)
 		icon_state = "[mineral]0"
 		setDensity(TRUE)
-		sleep(15)
+		sleep(6)
 		set_opacity(1)
 		src.relativewall()
 		opening = 0
@@ -375,7 +375,7 @@ var/list/false_wall_images = list()
 		icon_state = "frwall_open"
 		flick("frwall_opening", src)
 		loc.mouse_opacity = 1
-		sleep(15)
+		sleep(6)
 		setDensity(FALSE)
 		set_opacity(0)
 		opening = 0
@@ -385,7 +385,7 @@ var/list/false_wall_images = list()
 		icon_state = "r_wall"
 		flick("frwall_closing", src)
 		setDensity(TRUE)
-		sleep(15)
+		sleep(6)
 		set_opacity(1)
 		relativewall()
 		opening = 0

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -187,7 +187,7 @@ var/list/false_wall_images = list()
 		icon_state = "[mineral]fwall_open"
 		flick("[mineral]fwall_opening", src)
 		loc.mouse_opacity = 1
-		sleep(6)
+		sleep(5)
 		setDensity(FALSE)
 		set_opacity(0)
 		opening = 0
@@ -197,7 +197,7 @@ var/list/false_wall_images = list()
 		flick("[mineral]fwall_closing", src)
 		icon_state = "[mineral]0"
 		setDensity(TRUE)
-		sleep(6)
+		sleep(5)
 		set_opacity(1)
 		src.relativewall()
 		opening = 0
@@ -375,7 +375,7 @@ var/list/false_wall_images = list()
 		icon_state = "frwall_open"
 		flick("frwall_opening", src)
 		loc.mouse_opacity = 1
-		sleep(6)
+		sleep(5)
 		setDensity(FALSE)
 		set_opacity(0)
 		opening = 0
@@ -385,7 +385,7 @@ var/list/false_wall_images = list()
 		icon_state = "r_wall"
 		flick("frwall_closing", src)
 		setDensity(TRUE)
-		sleep(6)
+		sleep(5)
 		set_opacity(1)
 		relativewall()
 		opening = 0


### PR DESCRIPTION
While I was testing #32944 I noticed a vast discrepancy between the animation playing that opened the wall and when the wall actually updated, the animation itself lasts 0.5 seconds yet it takes 1.5 seconds to actually update the wall. This PR vastly lowers the difference by making the false wall update in 0.5 seconds, making false walls open and close faster (the animation remains the same).
:cl:
 * tweak: False walls now open/close significantly faster, from 1.5 seconds to 0.5 seconds