### PR TITLE
Limits challengers to only appear at a minimum of about 20 players

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -30,7 +30,7 @@
 
 	var/list/requirements = list(40,30,20,10,10,10,10,10,10,10)
 	//requirements are the threat level requirements per pop range. The ranges are as follow:
-	//0-4, 5-9, 10-14, 15-19, 20-24, 25-29, 30-34, 35-39, 40-54, 45+
+	//0-4, 5-9, 10-14, 15-19, 20-24, 25-29, 30-34, 35-39, 40-44, 45+
 	//so with the above default values, The rule will never get drafted below 10 threat level (aka: "peaceful extended"), and it requires a higher threat level at lower pops.
 	//for reminder: the threat level is rolled at roundstart and tends to hover around 50 https://docs.google.com/spreadsheets/d/1QLN_OBHqeL4cm9zTLEtxlnaJHHUu0IUPzPbsI-DFFmc/edit#gid=499381388
 	var/high_population_requirement = 10

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -62,6 +62,7 @@
 	cost = 15
 	var/traitor_threshold = 4
 	var/additional_cost = 5
+	required_pop = list(100,100,100,100,0,0,0,0,0,0)
 	high_population_requirement = 15
 
 // -- Currently a copypaste of traitors. Could be fixed to be less copy & paste.
@@ -531,7 +532,7 @@ Assign your candidates in choose_candidates() instead.
 	return 1
 
 /datum/dynamic_ruleset/roundstart/malf/proc/displace_AI(var/mob/displaced)
-	var/mob/new_player/old_AI = new 
+	var/mob/new_player/old_AI = new
 	old_AI.ckey = displaced.ckey
 	old_AI.name = displaced.ckey
 	qdel(displaced)
@@ -553,7 +554,7 @@ Assign your candidates in choose_candidates() instead.
 		log_admin("([old_AI.ckey]) was displaced by a malf AI and sent back to lobby.")
 		message_admins("([old_AI.ckey]) was displaced by a malf AI and started the game as a [old_AI.mind.assigned_role].")
 		old_AI.ready = 0
-		return 
+		return
 
 	if(old_AI.mind.assigned_role=="AI" || old_AI.mind.assigned_role=="Cyborg" || old_AI.mind.assigned_role=="Mobile MMI")
 		old_AI.create_roundstart_silicon(old_AI.mind.assigned_role)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -62,7 +62,7 @@
 	cost = 15
 	var/traitor_threshold = 4
 	var/additional_cost = 5
-	required_pop = list(100,100,100,100,0,0,0,0,0,0)
+	requirements = list(101,101,101,101,10,10,10,10,10,10)
 	high_population_requirement = 15
 
 // -- Currently a copypaste of traitors. Could be fixed to be less copy & paste.


### PR DESCRIPTION
Requested. Challengers are rather disastrous for lowpop rounds as they can fire at any time and force a minimum of 3 traitors on the station, which is also bad because there are little to no Security personnel to deal with them. This PR forces them to appear when there are at least a minimum of 20 players in the game.
Closes #32872
:cl:
 * rscdel: Syndicate Challengers no longer appear when there are less than 20 in-game players.
