### PR TITLE
Ghosts can now look at malf-locked APCs

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -923,9 +923,10 @@
 		if(usr.machine == src)
 			usr.unset_machine()
 		return 1
-	if((!aidisabled) && malflocked && (usr != malfai && usr.loc != src)) //exclusive control enabled
-		to_chat(usr, "Access refused.")
-		return 0
+	if(!isobserver(usr))
+		if((!aidisabled) && malflocked && (usr != malfai && usr.loc != src)) //exclusive control enabled
+			to_chat(usr, "Access refused.")
+			return 0
 	if(!can_use(usr, 1))
 		return 0
 	if(!(istype(usr, /mob/living/silicon) || isAdminGhost(usr) || OMNI_LINK(usr, src)) && locked)


### PR DESCRIPTION
If an AI has full control over an APC ghosts can't even look at the screen because of the malf AI's exclusive control. This fixes it.

:cl:
 * bugfix: Fixed ghosts being unable to access an APC that a Malfunctioning AI has exclusive control over.