### PR TITLE
Fixes being able to cut down regular walls using a lit-off welder by turning it off mid-welding

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -268,7 +268,7 @@
 			"<span class='warning'>You hear welding noises.</span>")
 			playsound(src, 'sound/items/Welder.ogg', 100, 1)
 
-			if(W.do_weld(user, src, 100, 0))
+			if(WT.do_weld(user, src, 100, 0))
 				if(!istype(src))
 					return
 				playsound(src, 'sound/items/Welder.ogg', 100, 1)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -268,7 +268,7 @@
 			"<span class='warning'>You hear welding noises.</span>")
 			playsound(src, 'sound/items/Welder.ogg', 100, 1)
 
-			if(do_after(user, src, 100))
+			if(W.do_weld(user, src, 100, 0))
 				if(!istype(src))
 					return
 				playsound(src, 'sound/items/Welder.ogg', 100, 1)


### PR DESCRIPTION
This also makes it able for welding tools with a higher speed to actually affect how long it takes.

:cl:
 * bugfix: Fixed a bug where by turning off a welding tool in the middle of cutting down a regular wall with it you could still cut the wall.
 * bugfix: Fixed welding down regular walls not being affected by tool speed.