### PR TITLE
Biogenerators can make butter.

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -40,6 +40,13 @@
 	other_amounts=list(5)
 	result=/obj/item/weapon/reagent_containers/food/snacks/sliceable/cheesewheel
 
+/datum/biogen_recipe/food/butter
+	id="butter"
+	name="Butter"
+	cost=150 //The 40u milk for 20u cream costs 80, so this is about 87% more expensive
+	other_amounts=list(5)
+	result=/obj/item/weapon/reagent_containers/food/snacks/butter
+
 /datum/biogen_recipe/food/meat
 	id="meat"
 	name="Slab of meat"


### PR DESCRIPTION
### What this does
Lets biogenerators make butter for 150 biomass each, about 1.8x the cost needed to make the required milk (to then turn into cream).
### Why it's good
Gives more uses to the biogenerator and encourages the chef to ask the botanist for butter, which makes butter recipes more common.
:cl:
 * rscadd: Biogenerators can make butter for 150 biomass.