### PR TITLE
Increase Max Explosion Radius

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -123,8 +123,7 @@ var/global/disable_vents     = 0
 var/turf/space/Space_Tile = locate(/turf/space) // A space tile to reference when atmos wants to remove excess heat.
 
 //This was a define, but I changed it to a variable so it can be changed in-game.(kept the all-caps definition because... code...) -Errorage
-var/MAX_EXPLOSION_RANGE = 14
-//#define MAX_EXPLOSION_RANGE		14					// Defaults to 12 (was 8) -- TLE
+var/MAX_EXPLOSION_RANGE = 50
 
 #define HUMAN_STRIP_DELAY 40 //takes 40ds = 4s to strip someone.
 #define HUMAN_REVERSESTRIP_DELAY 20

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -123,7 +123,7 @@ var/global/disable_vents     = 0
 var/turf/space/Space_Tile = locate(/turf/space) // A space tile to reference when atmos wants to remove excess heat.
 
 //This was a define, but I changed it to a variable so it can be changed in-game.(kept the all-caps definition because... code...) -Errorage
-var/MAX_EXPLOSION_RANGE = 24
+var/MAX_EXPLOSION_RANGE = 30
 
 #define HUMAN_STRIP_DELAY 40 //takes 40ds = 4s to strip someone.
 #define HUMAN_REVERSESTRIP_DELAY 20

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -123,7 +123,7 @@ var/global/disable_vents     = 0
 var/turf/space/Space_Tile = locate(/turf/space) // A space tile to reference when atmos wants to remove excess heat.
 
 //This was a define, but I changed it to a variable so it can be changed in-game.(kept the all-caps definition because... code...) -Errorage
-var/MAX_EXPLOSION_RANGE = 50
+var/MAX_EXPLOSION_RANGE = 24
 
 #define HUMAN_STRIP_DELAY 40 //takes 40ds = 4s to strip someone.
 #define HUMAN_REVERSESTRIP_DELAY 20

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -123,7 +123,7 @@ var/global/disable_vents     = 0
 var/turf/space/Space_Tile = locate(/turf/space) // A space tile to reference when atmos wants to remove excess heat.
 
 //This was a define, but I changed it to a variable so it can be changed in-game.(kept the all-caps definition because... code...) -Errorage
-var/MAX_EXPLOSION_RANGE = 30
+var/MAX_EXPLOSION_RANGE = 32
 
 #define HUMAN_STRIP_DELAY 40 //takes 40ds = 4s to strip someone.
 #define HUMAN_REVERSESTRIP_DELAY 20

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -284,7 +284,7 @@ var/list/nuclear_bombs = list()
 /obj/machinery/nuclearbomb/blob_act()
 	return
 
-#define NUKERANGE 80
+#define NUKERANGE 120
 /obj/machinery/nuclearbomb/proc/explode()
 	if (src.safety)
 		src.timing = 0

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -185,7 +185,8 @@
 	pressure = temp_first.return_pressure()/2
 
 	var/range = (pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE
-
+	if(range > 14)
+		range = (pressure-TANK_FRAGMENT_PRESSURE+14000)/(2*TANK_FRAGMENT_SCALE)
 	var/dev = round(range*0.25)
 
 	return dev

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -133,12 +133,11 @@
 		spawn(40)
 			var/cap = 0
 			var/uncapped = result
-			if(result > 19) //Roll a nat 20, screw the bombcap
+			if(result > 19) //Roll a nat 20
 				result = 24
 				sleep(40)
 			else
 				cap = 1
-				result = min(result, MAX_EXPLOSION_RANGE) //Apply the bombcap
 				if(result > 14)
 					sleep(20)
 

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -133,14 +133,15 @@
 		spawn(40)
 			var/cap = 0
 			var/uncapped = result
-			if(result > MAX_EXPLOSION_RANGE && result != 20)
+			if(result > 19) //Roll a nat 20, screw the bombcap
+				result = 24
+				sleep(40)
+			else
 				cap = 1
 				result = min(result, MAX_EXPLOSION_RANGE) //Apply the bombcap
 				if(result > 14)
 					sleep(20)
-			else if(result == 20) //Roll a nat 20, screw the bombcap
-				result = 24
-				sleep(40)
+
 			var/turf/epicenter = get_turf(src)
 			explosion(epicenter, round(result*0.25), round(result*0.5), round(result), round(result*1.5), 1, cap, whodunnit = user)
 			if(cap)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -260,6 +260,8 @@
 		air_contents.react()
 		pressure = air_contents.return_pressure()
 		var/range = (pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE
+		if(range > 14)
+			range = (pressure-TANK_FRAGMENT_PRESSURE+14000)/(2*TANK_FRAGMENT_SCALE)
 		if(range > MAX_EXPLOSION_RANGE)
 			cap = 1
 			uncapped = range

--- a/code/modules/projectiles/guns/projectile/constructable/blastcannon.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/blastcannon.dm
@@ -139,6 +139,8 @@
 			bomb_air_contents_2.react()
 			pressure = bomb_air_contents_2.return_pressure()
 			var/range = (pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE
+			if(range > 14)
+				range = (pressure-TANK_FRAGMENT_PRESSURE+14000)/(2*TANK_FRAGMENT_SCALE)
 			uncapped = range
 			if(!ignorecap)
 				if(range > MAX_EXPLOSION_RANGE)

--- a/config-example/game_options.txt
+++ b/config-example/game_options.txt
@@ -57,8 +57,8 @@ METROID_DELAY 0
 ANIMAL_DELAY 0
 
 # Define how large an explosion can be.
-## DEFAULT: 50
-MAX_EXPLOSION_RANGE 50
+## DEFAULT: 24
+MAX_EXPLOSION_RANGE 24
 
 #################
 ### EMAG SHIT ###

--- a/config-example/game_options.txt
+++ b/config-example/game_options.txt
@@ -58,7 +58,7 @@ ANIMAL_DELAY 0
 
 # Define how large an explosion can be.
 ## DEFAULT: 14
-MAX_EXPLOSION_RANGE 14
+MAX_EXPLOSION_RANGE 50
 
 #################
 ### EMAG SHIT ###

--- a/config-example/game_options.txt
+++ b/config-example/game_options.txt
@@ -57,8 +57,8 @@ METROID_DELAY 0
 ANIMAL_DELAY 0
 
 # Define how large an explosion can be.
-## DEFAULT: 30
-MAX_EXPLOSION_RANGE 30
+## DEFAULT: 32
+MAX_EXPLOSION_RANGE 32
 
 #################
 ### EMAG SHIT ###

--- a/config-example/game_options.txt
+++ b/config-example/game_options.txt
@@ -57,7 +57,7 @@ METROID_DELAY 0
 ANIMAL_DELAY 0
 
 # Define how large an explosion can be.
-## DEFAULT: 14
+## DEFAULT: 50
 MAX_EXPLOSION_RANGE 50
 
 #################

--- a/config-example/game_options.txt
+++ b/config-example/game_options.txt
@@ -57,8 +57,8 @@ METROID_DELAY 0
 ANIMAL_DELAY 0
 
 # Define how large an explosion can be.
-## DEFAULT: 24
-MAX_EXPLOSION_RANGE 24
+## DEFAULT: 30
+MAX_EXPLOSION_RANGE 30
 
 #################
 ### EMAG SHIT ###


### PR DESCRIPTION
Now with nicer explosions, we can have bigger ones.

## What this does
- MAX_EXPLOSION_RANGE from 14 to 32 (actually from 28 to 32 based on secret black magic trickery)
- NUKERANGE from 80 to 120
- TTVs have a soft cap after range 14 (previous max)
![image](https://user-images.githubusercontent.com/94659603/180488654-973ed011-9a32-46b1-b38e-c89887a5e987.png)

## Why it's good
Bigger is better

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Added soft cap for TTVs from 14 to 32. Nuke explosion cap from 80 to 120