### PR TITLE
Fixes biomass packets.

### DIFF
--- a/code/game/gamemodes/events/powercreeper.dm
+++ b/code/game/gamemodes/events/powercreeper.dm
@@ -23,27 +23,27 @@
 	var/growdirs = 0
 	var/zapdirs = 0
 
-/obj/structure/cable/powercreeper/New(loc, growdir, packet_override)
+/obj/structure/cable/powercreeper/New(loc, growdir) //packet_override var removed to fix a runtime
 	//did we get created by a packet?
 	var/anim_length = 0
-	if(packet_override)
-		flick("creation_packet", src)
-		anim_length = 39
-		add_state = ""
-	else
-		//are we growing from another powercreeper?
-		if(growdir)
-			if(prob(LEAVES_CHANCE))
-				add_state = ""
-			icon_state = initial(icon_state) + add_state
-			dir = growdir
-			flick("growing[add_state]", src)
-			anim_length = 18
-		else
-			//we just kinda spawned i guess
-			flick("creation", src)
+//	if(packet_override)
+//		flick("creation_packet", src)
+//		anim_length = 39
+//		add_state = ""
+//	else
+	//are we growing from another powercreeper?
+	if(growdir)
+		if(prob(LEAVES_CHANCE))
 			add_state = ""
-			anim_length = 20
+		icon_state = initial(icon_state) + add_state
+		dir = growdir
+		flick("growing[add_state]", src)
+		anim_length = 18
+	else
+		//we just kinda spawned i guess
+		flick("creation", src)
+		add_state = ""
+		anim_length = 20
 	spawn(anim_length)
 		grown = 1
 

--- a/code/game/objects/items/deployable_packet.dm
+++ b/code/game/objects/items/deployable_packet.dm
@@ -17,7 +17,7 @@
 	activated = 1
 
 	spawn(POWERCREEP_PACKET_ACTIVATION_TIME_IN_SECONDS SECONDS)
-		new deployeditem(get_turf(src), packet_override = 1) //override for powercreep fast spawn 
+		new deployeditem(get_turf(src)) //used to have the [packet_override = 1] var for powercreep fast spawn from packet, but it broke biomass spawning 
 		qdel(src)
 
 /obj/item/deployable_packet/biomass


### PR DESCRIPTION
The packet_override var on the packet was valid for powercreep but runtimed on biomass, which broke the biomass packet.
### What this does
Fixes biomass packets by removing the packet_override var.
Fixes #32958
[hotfix][tested]
:cl:
 * bugfix: Fixes biomass packets not working. As a side effect of this, powercreep spawning from a packet has a slightly shorter animation on creation.