### PR TITLE
Juggernaut's dash should now properly show the range is 4 and not 7

### DIFF
--- a/code/modules/spells/construct_spells.dm
+++ b/code/modules/spells/construct_spells.dm
@@ -22,7 +22,6 @@
 	charge_max = 150
 	spell_flags = 0
 	range = 4
-	var/dash_range = 4
 
 /spell/juggerdash/choose_targets(var/mob/user = usr)
 	return list(user)
@@ -37,8 +36,8 @@
 	playsound(user, 'sound/effects/juggerdash.ogg', 100, 1)
 	var/mob/living/simple_animal/construct/armoured/perfect/jugg = user
 	jugg.crashing = null
-	var/landing = get_distant_turf(get_turf(user), jugg.dir, dash_range)
-	jugg.throw_at(landing, dash_range , 2)
+	var/landing = get_distant_turf(get_turf(user), jugg.dir, range)
+	jugg.throw_at(landing, range , 2)
 
 ///////////////////////////////////WRAITH///////////////////////////////////////
 

--- a/code/modules/spells/construct_spells.dm
+++ b/code/modules/spells/construct_spells.dm
@@ -21,6 +21,7 @@
 	override_base = "cult"
 	charge_max = 150
 	spell_flags = 0
+	range = 4
 	var/dash_range = 4
 
 /spell/juggerdash/choose_targets(var/mob/user = usr)


### PR DESCRIPTION
 * bugfix: Fixed a bug where the range that was mentioned in the cult Juggernaut's dash ability was mistakenly noted down as having a range of 7 tiles rather than 4. Also cleaned up the code a little to avoid redundancy.