### PR TITLE
Weekend Primetime NO HOLDS BARRED

### DIFF
--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -365,6 +365,8 @@ var/global/datum/controller/vote/vote = new()
 				question = "What should the next map be?"
 				if (config.toggle_maps)
 					maps = get_all_maps()
+				else if(IS_WEEKEND && getTimeslot() == PRIMETIME)
+					maps = get_all_maps()
 				else
 					maps = get_votable_maps()
 				for (var/map in maps)


### PR DESCRIPTION
[emojicracy]

NO POP? NO PROBLEM

## What this does
- regardless of date and pop, people can vote on ALL COMPILED MAPS AVAILABLE regardless of population, date, and whether it's votable (or not).
- `#define PRIMETIME_HOURS 19 to 22`
- If this is merged i'll make another PR to try out persistent voting during primetime as well so that there aren't upset victories

## Why it's good
- something a little different for primetime weekend hours

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Choose from any of your favorite maps during weekend primetime!