### PR TITLE
Safes are now once again silent except to those who are interacting with it

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -134,7 +134,8 @@ FLOOR SAFES
 
 	switch (task)
 		if ("Rotate Clockwise")
-			playsound(loc, 'sound/machines/dial_tick.ogg', 25, 1)
+			if(canhear)
+				user.playsound_local(loc, 'sound/machines/dial_tick.ogg', 25, 1)
 			dial = increment(dial)
 			feedback = "<span class='notice'>You turn the dial up to [dial * 5].</span>"
 			if(dial == tumbler_1_pos)
@@ -157,7 +158,8 @@ FLOOR SAFES
 			to_chat(user, feedback)
 
 		if ("Rotate Counter-Clockwise")
-			playsound(loc, 'sound/machines/dial_tick.ogg', 25, 1)
+			if(canhear)
+				user.playsound_local(loc, 'sound/machines/dial_tick.ogg', 25, 1)
 			dial = decrement(dial)
 			feedback = "<span class='notice'>You turn the dial down to [dial * 5].</span>"
 			if(dial == tumbler_1_pos)

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -134,8 +134,7 @@ FLOOR SAFES
 
 	switch (task)
 		if ("Rotate Clockwise")
-			if(canhear)
-				user.playsound_local(loc, 'sound/machines/dial_tick.ogg', 25, 1)
+			user.playsound_local(loc, 'sound/machines/dial_tick.ogg', 25, 1)
 			dial = increment(dial)
 			feedback = "<span class='notice'>You turn the dial up to [dial * 5].</span>"
 			if(dial == tumbler_1_pos)
@@ -158,8 +157,7 @@ FLOOR SAFES
 			to_chat(user, feedback)
 
 		if ("Rotate Counter-Clockwise")
-			if(canhear)
-				user.playsound_local(loc, 'sound/machines/dial_tick.ogg', 25, 1)
+			user.playsound_local(loc, 'sound/machines/dial_tick.ogg', 25, 1)
 			dial = decrement(dial)
 			feedback = "<span class='notice'>You turn the dial down to [dial * 5].</span>"
 			if(dial == tumbler_1_pos)


### PR DESCRIPTION
I kinda noticed something suspicious during my vault-breaking shenanigans that people would end up circling the vault looking for false walls, and if that failed they'd wait outside or try to hack in. Then I realized that #29621 made the dial sound a very audible thing, something so loud that others can hear through the walls.
This PR changes it so that the noise for turning the dial only plays out to the user.

:cl:
 * tweak: Vault safes now only play a dial-turning noise to those who interact with it, instead of being audible through walls.

