### PR TITLE
Vampires now gain some nourishment out of sucking people

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -222,7 +222,7 @@
 		target.vessel.remove_reagent(BLOOD,blood)
 		var/mob/living/carbon/V = assailant
 		if(V)
-			var/fatty_chemicals = target.has_reagent_in_blood(CHEESYGLOOP) || target.has_reagent_in_blood(CORNOIL) //If the target has these chemicals in his blood the vampire can get fat from sucking blood.
+			var/fatty_chemicals = target.reagents.has_any_reagents(list(CHEESYGLOOP, CORNOIL)) //If the target has these chemicals in his blood the vampire can get fat from sucking blood.
 			var/eating_threshold = fatty_chemicals ? OVEREAT_THRESHOLD * 2 : OVEREAT_THRESHOLD
 			if(V.nutrition < eating_threshold) //Gives the vampire a little bit of food, at a rate of 1/4 the blood sucked.
 				V.nutrition = round(min(V.nutrition + blood/4, OVEREAT_THRESHOLD), 1)

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -222,7 +222,9 @@
 		target.vessel.remove_reagent(BLOOD,blood)
 		var/mob/living/carbon/V = assailant
 		if(V)
-			if(V.nutrition < OVEREAT_THRESHOLD) //Gives the vampire a little bit of food, at a rate of 1/4 the blood sucked.
+			var/fatty_chemicals = target.has_reagent_in_blood(CHEESYGLOOP) || target.has_reagent_in_blood(CORNOIL) //If the target has these chemicals in his blood the vampire can get fat from sucking blood.
+			var/eating_threshold = fatty_chemicals ? OVEREAT_THRESHOLD * 2 : OVEREAT_THRESHOLD
+			if(V.nutrition < eating_threshold) //Gives the vampire a little bit of food, at a rate of 1/4 the blood sucked.
 				V.nutrition = round(min(V.nutrition + blood/4, OVEREAT_THRESHOLD), 1)
 		update_vamp_hud()
 

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -220,6 +220,10 @@
 			to_chat(assailant, "<span class='notice'>You have accumulated [blood_total] [blood_total > 1 ? "units" : "unit"] of blood[blood_usable_before != blood_usable ?", and have [blood_usable] left to use." : "."]</span>")
 		check_vampire_upgrade()
 		target.vessel.remove_reagent(BLOOD,blood)
+		var/mob/living/carbon/V = assailant
+		if(V)
+			if(V.nutrition < OVEREAT_THRESHOLD) //Gives the vampire a little bit of food, at a rate of 1/4 the blood sucked.
+				V.nutrition = round(min(V.nutrition + blood/4, OVEREAT_THRESHOLD), 1)
 		update_vamp_hud()
 
 	draining = null


### PR DESCRIPTION
This PR makes it so that vampires also feed a little when they suck someone dry at a rate of 1/4th of the blood sucked, meaning that on your average human they'll gain roughly 140 nutriment (in comparison humans spawn at 400 nutriment). They cannot get fat this way unless the target has cheesy gloop or corn oil in their system. Come on, it's been a long time coming.

:cl:
 * rscadd: Vampires now nourish themselves somewhat when feeding, akin to eating food.