### PR TITLE
Normalizes the charge cost of stun batons from 100 to 1000 charge, tweaks harm batons a little

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -229,10 +229,10 @@
 		else if(istype(charging, /obj/item/weapon/melee/baton)) //25e power loss is so minor that the game shouldn't bother calculating the efficiency of better parts for it
 			var/obj/item/weapon/melee/baton/B = charging
 			if(B.bcell)
-				if(B.bcell.give(175*charging_speed_modifier))
+				if(B.bcell.give(1750*charging_speed_modifier))
 					icon_state = "recharger1"
 					if(!self_powered)
-						use_power(200*charging_speed_modifier)
+						use_power(2000*charging_speed_modifier)
 				else
 					icon_state = "recharger2"
 					if(!has_beeped)
@@ -243,10 +243,10 @@
 		else if(istype(charging, /obj/item/weapon/melee/stunprobe)) //25e power loss is so minor that the game shouldn't bother calculating the efficiency of better parts for it
 			var/obj/item/weapon/melee/stunprobe/B = charging
 			if(B.bcell)
-				if(B.bcell.give(175*charging_speed_modifier))
+				if(B.bcell.give(1750*charging_speed_modifier))
 					icon_state = "recharger1"
 					if(!self_powered)
-						use_power(200*charging_speed_modifier)
+						use_power(2000*charging_speed_modifier)
 				else
 					icon_state = "recharger2"
 					if(!has_beeped)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -317,7 +317,7 @@
 		if(status)
 			force += 10 + 2*(dial-1) //send someone into the shadow realm with 10
 			throwforce += 10 + 2*(dial-1) //it doesn't deal damage on throw, this is just a constistency thing, I guess
-			hitcost = 100 * (dial * dial) // 100 cost on 1, 10000 cost on 10, change power cell
+			hitcost = 1000 * dial * 2 // 1000 cost on 1, 20000 cost on 10, change power cell
 			stunforce = 10 * dial //welcome to the world of pain
 		else
 			depower()
@@ -341,7 +341,7 @@
 		to_chat(user, "<span class = 'notice'>Your lust for inflicting pain is admirable, but 10 is maximum.</span>")
 		new_dial = 10
 	dial = new_dial
-	hitcost = 100 * (dial * dial)
+	hitcost = 1000 * dial * 2
 	to_chat(user, "<span class = 'notice'>The dial is set to [dial].</span>")
 	add_fingerprint(user)
 	return

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -13,8 +13,8 @@
 	attack_verb = list("beats")
 	var/stunforce = 10
 	var/status = 0
-	var/obj/item/weapon/cell/bcell = null
-	var/hitcost = 100 // 10 hits on crap cell
+	var/obj/item/weapon/cell/high/bcell = null
+	var/hitcost = 1000 // 10 hits on crap cell
 	var/stunsound = 'sound/weapons/Egloves.ogg'
 	var/swingsound = "swing_hit"
 

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -14,7 +14,7 @@
 	var/stunforce = 10
 	var/status = 0
 	var/obj/item/weapon/cell/high/bcell = null
-	var/hitcost = 1000 // 10 hits on crap cell
+	var/hitcost = 1000 // 10 hits on high-capacity cell
 	var/stunsound = 'sound/weapons/Egloves.ogg'
 	var/swingsound = "swing_hit"
 

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -276,6 +276,9 @@
 /obj/item/weapon/melee/baton/cattleprod/canbehonkified()
 	return 0
 
+/obj/item/weapon/melee/baton/loaded/borg
+	hitcost = 100 //So the borg doesn't drain most of its battery with just a few hits, in line with other borg-based equipment
+
 // Yes, loaded, this is so attack_self() works.
 // In the unlikely event somebody manages to get a hold of this item, don't allow them to fuck with the nonexistant cell.
 /obj/item/weapon/melee/baton/loaded/borg/attackby(var/obj/item/W, var/mob/user)

--- a/maps/randomvaults/mothership_lab.dm
+++ b/maps/randomvaults/mothership_lab.dm
@@ -551,8 +551,8 @@
 	origin_tech = Tc_COMBAT + "=3" + Tc_POWERSTORAGE + "=2"
 	attack_verb = list("beats")
 	var/status = 0
-	var/obj/item/weapon/cell/bcell = null
-	var/hitcost = 50 // 20 stuns with integrated cell, but can't upgrade or remove it. Doesn't have a normal baton's vulnerability to emp blasts. Compatible with rechargers
+	var/obj/item/weapon/cell/high/bcell = null
+	var/hitcost = 500 // 20 stuns with integrated cell, but can't upgrade or remove it. Doesn't have a normal baton's vulnerability to emp blasts. Compatible with rechargers
 	var/stunsound = 'sound/weapons/electriczap.ogg'
 	var/swingsound = "swing_hit"
 


### PR DESCRIPTION
A high-capacity cell would offer a stun baton **100 hits** before it went dry, an ultra-capacity cell would offer **500**. This PR tweaks it so that stun batons cost 1000 charge (makeshift stun prods consume 2500 charge by comparison), and to compensate they now spawn with high-capacity cells already loaded in, which maintains the "10 hits until they are dry" that they previously spawned with.
Tweaks harm batons to be less affected by the proportional charge costs the higher the dial is due to dial shenanigans because otherwise there would be no cell in the entire game that it could make use of when the dial is maxed (the highest-capacity cell available can store 50000 charge). At maxed dial it consumes 20000 charge instead of the previous 10000.
Multiplies the recharge rate of weapon rechargers accordingly. Tested out so that it doesn't accidentally drain the entire room of power.
Alien batons are also tweaked proportionally.
Cyborg stun batons retain their cost.

:cl:
 * tweak: Stun batons now consume 1000W battery charge instead of 100W. To compensate, they now spawn with high-capacity 10000W charge cells instead of regular 1000W charge cells. This means they will still maintain their 10 hits with the default battery before it runs out of power, but upgrading the battery will no longer have such a drastic effect on how many hits you can deal out.
 * tweak: Harm batons, the Syndicate uplink item, were tweaked as a result of the stun baton power consumption change so that it's still usable at higher dials, but instead of consuming 10000W it consumes 20000W.

