### PR TITLE
Fixes signal spamming

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -129,7 +129,7 @@
 
 	if(href_list["send"])
 		spawn( 0 )
-			signal()
+			activate()
 
 	if(usr)
 		attack_self(usr)
@@ -173,8 +173,6 @@
 		return 0
 	if(!(src.wires & WIRE_RADIO_RECEIVE))
 		return 0
-	if(signal.source == src) //Avoid pinging itself
-		return 0
 	pulse(1)
 
 	if(!holder)
@@ -210,7 +208,7 @@
 
 	if(!M || !ismob(M))
 		if(prob(5))
-			signal()
+			activate()
 		deadman = 0
 		processing_objects.Remove(src)
 	else if(prob(5))

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -50,7 +50,7 @@
 			I.frequency = src.frequency
 			user.u_equip(src,0)
 			qdel(src)
-	
+
 	if(issignaler(W))
 		var/obj/item/device/assembly/signaler/signaler2 = W
 		if(secured && signaler2.secured)
@@ -172,6 +172,8 @@
 	if(signal.encryption != code)
 		return 0
 	if(!(src.wires & WIRE_RADIO_RECEIVE))
+		return 0
+	if(signal.source == src) //Avoid pinging itself
 		return 0
 	pulse(1)
 

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -128,8 +128,11 @@
 		src.code = max(1, src.code)
 
 	if(href_list["send"])
-		spawn( 0 )
-			activate()
+		spawn(0)
+			if(!cooldown)
+				activate()
+			else
+				to_chat(usr, "<span class='warning'>You must wait a little before sending out a signal again!</span>")
 
 	if(usr)
 		attack_self(usr)


### PR DESCRIPTION
Manually signaling signalers would bypass the spam prevention system in place. This PR fixes it.

:cl:
 * bugfix: Signalers can no longer be spam-clicked.