### PR TITLE
Being smited as a result of farting on a bible now drops your items

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -271,7 +271,7 @@
 						to_chat(H, "<span class='danger'>You were disintegrated by [B.my_rel.deity_name]'s bolt of lightning.</span>")
 						H.attack_log += text("\[[time_stamp()]\] <font color='orange'>Farted on a bible and suffered [B.my_rel.deity_name]'s wrath.</font>")
 						explosion(get_turf(H),-1,-1,1,5, whodunnit = H) //Tiny explosion with flash
-						H.dust()
+						H.dust(TRUE)
 //Ayy lmao
 
 


### PR DESCRIPTION
It's not akin to the supermatter that just annihilates everything.

:cl:
 * tweak: The gods now have enough mercy to leave all the items you carry on the ground when smiting you for farting on a bible.