### PR TITLE
Skeleton liches can no longer increase debilitating debuffs to sky-high numbers

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
@@ -643,11 +643,11 @@
 				if(!can_mind_interact(H.mind))
 					continue
 				to_chat(H, "<span class = 'warning'>You feel [diceroll>15 ? "incredibly" : ""] disorientated.</span>")
-				H.hallucination = clamp(rand(10,20)*diceroll, hallucination, 60)
+				H.hallucination = clamp(rand(10,20)*diceroll, hallucination, 60) //Maximum of 120 seconds
 				if(diceroll > 15)
-					H.confused = clamp(rand(15,35)*diceroll, confused, 60)
+					H.confused = clamp(rand(15,35)*diceroll, confused, 60) //Maximum of 120 seconds
 				if(diceroll >= 20)
-					H.dizziness = clamp(rand(5,25), dizziness, 30)
+					H.dizziness = clamp(rand(5,25), dizziness, 30) //Maximum of 60 seconds
 		if(2) //Disarm
 			var/number_of_disarmed = min(3, victims.len)
 			for(var/i = 0 to number_of_disarmed)

--- a/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
@@ -643,11 +643,11 @@
 				if(!can_mind_interact(H.mind))
 					continue
 				to_chat(H, "<span class = 'warning'>You feel [diceroll>15 ? "incredibly" : ""] disorientated.</span>")
-				H.hallucination += rand(10,20)*diceroll
+				H.hallucination = clamp(rand(10,20)*diceroll, hallucination, 60)
 				if(diceroll > 15)
-					H.confused += rand(15,35)*diceroll
+					H.confused = clamp(rand(15,35)*diceroll, confused, 60)
 				if(diceroll >= 20)
-					H.dizziness += rand(5,25)
+					H.dizziness = clamp(rand(5,25), dizziness, 30)
 		if(2) //Disarm
 			var/number_of_disarmed = min(3, victims.len)
 			for(var/i = 0 to number_of_disarmed)


### PR DESCRIPTION
I don't like waiting 40 actual minutes before the confused movement wears off.

:cl:
 * tweak: Skeleton liches, such as Azalin, now have a limit on how much of a status effect they can inflict (120 seconds for hallucinations, 120 seconds for confusion and 60 seconds for dizziness).
