### PR TITLE
Adds a percentage-based chance to tableclimb

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -355,20 +355,20 @@
 		if(!ishigherbeing(user) || !Adjacent(user) || user.incapacitated() || user.lying) // Doesn't work if you're not dragging yourself, not a human, not in range or incapacitated
 			return
 		var/mob/living/carbon/M = user
-		M.apply_damage(2, BRUTE, LIMB_HEAD, used_weapon = name)
+		if(M.brainloss < 150)
+			M.apply_damage(2, BRUTE, LIMB_HEAD, used_weapon = name)
+		else
+			//unable to hold back the strength
+			M.apply_damage(10, BRUTE, LIMB_HEAD, used_weapon = name)
 		M.adjustBrainLoss(5)
 		playsound(M, "trayhit", 50, 1)
-		if(prob(table_climb_chance))
-			M.visible_message("<span class='danger'>[user] bangs \his head on \the [src]. But, \he refuses to give up, reaching up for \the [src]!</span>", "<span class='danger'>You bang your head on \the [src], but you refuse to give up! You reach for \the [src]...</span>", "You hear a bang.")
-			if(do_after(user, src, 50))
-				M.forceMove(get_turf(src))
-				M.visible_message("<span class='danger'>[user] manages to climb \the [src]!</span>", "<span class='danger'>You successfully climb \the [src]!</span>")
-			else
-				M.visible_message("<span class='danger'>[user] fails to climb \the [src].</span>", "<span class='danger'>You fail to climb \the [src], losing your burst of motivation.</span>")
+		M.Stun(1)
+		M.Knockdown(1)
+		if(prob(table_climb_chance) && !M.locked_to && M.brainloss < 100)
+			M.visible_message("<span class='danger'>[user] bangs \his head on \the [src]. But, \he refuses to give up! Reaching for \the [src], \he manages to pull \himself on top of it!</span>", "<span class='danger'>You bang your head on \the [src], but you refuse to give up! You reach for \the [src]... and pull yourself up!</span>", "You hear a bang.")
+			M.forceMove(get_turf(src))
 		else
 			M.visible_message("<span class='danger'>[user] bangs \his head on \the [src].</span>", "<span class='danger'>You bang your head on \the [src].</span>", "You hear a bang.")
-			M.Stun(1)
-			M.Knockdown(1)
 		return
 	return ..()
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -11,6 +11,9 @@
 /*
  * Tables
  */
+
+/var/global/table_climb_chance = 1
+
 /obj/structure/table
 	name = "table"
 	desc = "A square piece of metal standing on four metal legs. It cannot move."
@@ -354,10 +357,18 @@
 		var/mob/living/carbon/M = user
 		M.apply_damage(2, BRUTE, LIMB_HEAD, used_weapon = name)
 		M.adjustBrainLoss(5)
-		M.Knockdown(1)
-		M.Stun(1)
 		playsound(M, "trayhit", 50, 1)
-		M.visible_message("<span class='danger'>[user] bangs \his head on \the [src].</span>", "<span class='danger'>You bang your head on \the [src].</span>", "You hear a bang.")
+		if(prob(table_climb_chance))
+			M.visible_message("<span class='danger'>[user] bangs \his head on \the [src]. But, \he refuses to give up, reaching up for \the [src]!</span>", "<span class='danger'>You bang your head on \the [src], but you refuse to give up! You reach for \the [src]...</span>", "You hear a bang.")
+			if(do_after(user, src, 50))
+				M.forceMove(get_turf(src))
+				M.visible_message("<span class='danger'>[user] manages to climb \the [src]!</span>", "<span class='danger'>You successfully climb \the [src]!</span>")
+			else
+				M.visible_message("<span class='danger'>[user] fail to climb \the [src].</span>", "<span class='danger'>You fail to climb \the [src], losing your burst of motivation.</span>")
+		else
+			M.visible_message("<span class='danger'>[user] bangs \his head on \the [src].</span>", "<span class='danger'>You bang your head on \the [src].</span>", "You hear a bang.")
+			M.Stun(1)
+			M.Knockdown(1)
 		return
 	return ..()
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -364,7 +364,7 @@
 				M.forceMove(get_turf(src))
 				M.visible_message("<span class='danger'>[user] manages to climb \the [src]!</span>", "<span class='danger'>You successfully climb \the [src]!</span>")
 			else
-				M.visible_message("<span class='danger'>[user] fail to climb \the [src].</span>", "<span class='danger'>You fail to climb \the [src], losing your burst of motivation.</span>")
+				M.visible_message("<span class='danger'>[user] fails to climb \the [src].</span>", "<span class='danger'>You fail to climb \the [src], losing your burst of motivation.</span>")
 		else
 			M.visible_message("<span class='danger'>[user] bangs \his head on \the [src].</span>", "<span class='danger'>You bang your head on \the [src].</span>", "You hear a bang.")
 			M.Stun(1)


### PR DESCRIPTION
# ONE PERCENT CHANCE
![image](https://user-images.githubusercontent.com/69739118/181172967-92290aed-71e5-47f8-af5e-d6e36bc31e31.png)

> it's a trial admin rite of passage
> to become a fullmin you must tell one (1) tgfugee how to tableclimb

## What this does
Adds a ``1%`` chance to climb a table. The table climb is instant, though you still hit your head, and are stunned. If you are too brain damaged, you cannot successfully climb. If you are even more brain damaged, you take considerably more damage to the head for trying.

On average, an assistant will die at least three times before successfully climbing a table.

Additionally, sets a global variable for admins to play with if they want to do a table climbin' bus. If the PR proves unpopular, it's possible to set this variable to 0 and still merge for future entertainment.

## Why it's good
Having that one in a million chance pop through for the assistants who try to break into departments... We can't let them down.

Also, watching a whole bunch of people start hitting their heads on a table just to go for that 1% would be funny.

## Changelog
[controversial] [tested] [badfaith] [help]
:cl:
 * rscadd: Adds a percentage based chance to table climb.