### PR TITLE
Glass and Plasma Glass solidification

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -921,6 +921,26 @@
 /datum/chemical_reaction/solidification/phazon/product_to_spawn()
 	return /obj/item/stack/sheet/mineral/phazon
 
+/datum/chemical_reaction/solidification/glass
+	name = "Solid Glass"
+	id = "solidglass"
+	result = null
+	required_reagents = list(SILICATE = 20, CAPSAICIN = 10) //You melt the silicate to make glass
+	result_amount = 1 //amount of sheets created per the above reagents 
+
+/datum/chemical_reaction/solidification/glass/product_to_spawn()
+	return /obj/item/stack/sheet/glass/glass
+
+/datum/chemical_reaction/solidification/plasmaglass
+	name = "Solid Plasma Glass"
+	id = "solidplasmaglass"
+	result = null
+	required_reagents = list(SILICATE = 20, CONDENSEDCAPSAICIN = 10, PLASMA = 20) //You need even stronger heat to make plasmaglass
+	result_amount = 1 //amount of sheets created per the above reagents 
+
+/datum/chemical_reaction/solidification/plasmaglass/product_to_spawn()
+	return /obj/item/stack/sheet/glass/plasmaglass
+
 /datum/chemical_reaction/solidification/plasteel
 	name = "Solid Plasteel"
 	id = "solidplasteel"


### PR DESCRIPTION
Adds a solidification recipe to make glass and plasmaglass. Intended as a prim and proper way to non-mining make glass, while #32987 is the quick and dirty way.
### What this does
You can solidify glass by mixing silicate and capsaicin and can solidify plasmaglass by mixing silicate, plasma and condensed capsaicin.
### Why it's good
Gives a way to manually make glass if no recycling or ore processing is available. Enterprising botanists can now make glass and plasmaglass.
:cl:
 * rscadd: Solidification recipe for glass: 20u Silicate, 10u Capsaicin. Solidification recipe for plasmaglass: 20u Silicate, 20u Plasma, 10u Condensed Capsaicin.