### PR TITLE
Detectives now count as security for the assistant cap

### DIFF
--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -27,7 +27,8 @@
 	var/datum/job/officer = job_master.GetJob("Security Officer")
 	var/datum/job/warden = job_master.GetJob("Warden")
 	var/datum/job/hos = job_master.GetJob("Head of Security")
-	var/sec_jobs = (officer.current_positions + warden.current_positions + hos.current_positions)
+	var/datum/job/detective = job_master.GetJob("Detective")
+	var/sec_jobs = (officer.current_positions + warden.current_positions + hos.current_positions + detective.current_positions)
 
 	if(sec_jobs > 5)
 		return 99

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -310,8 +310,9 @@ var/global/datum/controller/occupations/job_master
 	var/datum/job/officer = job_master.GetJob("Security Officer")
 	var/datum/job/warden = job_master.GetJob("Warden")
 	var/datum/job/hos = job_master.GetJob("Head of Security")
+	var/datum/job/detective = job_master.GetJob("Detective")
 	var/datum/job/master_assistant = GetJob("Assistant")
-	count = (officer.current_positions + warden.current_positions + hos.current_positions)
+	count = (officer.current_positions + warden.current_positions + hos.current_positions + detective.current_positions)
 
 	// For those who wanted to be assistant if their preferences were filled, here you go.
 	for(var/mob/new_player/player in unassigned)


### PR DESCRIPTION
## What this does
Detectives now count as security toward the assistant cap, just like officers, wardens, and HoSes currently do.

## Why it's good
Doesn't make much sense to me to not count detectives toward the cap since they are security staff and can do their part to keep the tide under control, so more people can play assistant if they want to and there's a detective to increase the cap.

## Changelog
:cl:
 * tweak: Detectives now count as security staff toward the assistant cap.
