### PR TITLE
Increases minimum age from 17 to 21

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -905,7 +905,7 @@ SEE_PIXELS	256
 #define ROLE_PRISONER		"prisoner"
 #define ROLE_GRUE			"grue"
 
-#define AGE_MIN 17			//youngest a character can be
+#define AGE_MIN 21			//youngest a character can be
 #define AGE_MAX 85			//oldest a character can be
 
 /*//Languages!


### PR DESCRIPTION
Having faced increasing scrutiny from various governments' oversight committees, Nanotrasen employees now must be a fully matured adult with at least some years of training before they can be employed in the cold depths of space.

## Changelog
:cl:
 * tweak: Changed minimum character age from 17 to 21

