### PR TITLE
Surgery fixes v2

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1512,8 +1512,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(E)
 		owner.internal_organs_by_name.Remove("eyes")
 		owner.internal_organs.Remove(E)
-
-	return
+		src.internal_organs.Remove(E)
+	return E
 
 /datum/organ/external/head/explode()
 	owner.remove_internal_organ(owner, owner.internal_organs_by_name["brain"], src)
@@ -1616,7 +1616,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	wounds = source.wounds.Copy()
 	burn_dam = source.burn_dam
 	brute_dam = source.brute_dam
-	internal_organs = source.internal_organs
+	internal_organs = source.internal_organs.Copy()
 
 	//Copy status flags except for ORGAN_CUT_AWAY and ORGAN_DESTROYED
 	status = source.status & ~(ORGAN_CUT_AWAY | ORGAN_DESTROYED)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1618,7 +1618,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	wounds = source.wounds.Copy()
 	burn_dam = source.burn_dam
 	brute_dam = source.brute_dam
-	if(!isnull(source.internal_organs)) //DM throughs an error since Copy() can't run on a null object; some limbs don't have this var currently
+	if(!isnull(source.internal_organs)) //DM throws an error since Copy() can't run on a null object; some limbs don't have this var currently
 		internal_organs = source.internal_organs.Copy()
 
 	//Copy status flags except for ORGAN_CUT_AWAY and ORGAN_DESTROYED

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1065,6 +1065,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 		//Transfer any internal_organs from the organ item to the body
 		for(var/datum/organ/internal/transfer in organ.internal_organs)
+			if(transfer.name == "eyes" || "brain")
+				owner.organs_by_name["head"].internal_organs += transfer
 			owner.internal_organs += transfer
 			owner.internal_organs_by_name[transfer.organ_type] = transfer
 			owner.internal_organs_by_name[transfer.organ_type].owner = owner

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1618,7 +1618,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	wounds = source.wounds.Copy()
 	burn_dam = source.burn_dam
 	brute_dam = source.brute_dam
-	internal_organs = source.internal_organs.Copy()
+	if(!isnull(source.internal_organs)) //DM throughs an error since Copy() can't run on a null object; some limbs don't have this var currently
+		internal_organs = source.internal_organs.Copy()
 
 	//Copy status flags except for ORGAN_CUT_AWAY and ORGAN_DESTROYED
 	status = source.status & ~(ORGAN_CUT_AWAY | ORGAN_DESTROYED)


### PR DESCRIPTION
## What this does
Changes the new() proc for external organ items (ie, the in-hand version of each body part) to copy instead of directly reference the old set of internal organs.

Also fixes a bug that would've caused double sets of eyes!

This also makes my prior code work that puts the brain as an internal organ object in the head - this currently has no use, and the legacy organ_data object still works as the brain data holder.

## Why it's good
This was causing an issue when the body part or body in general was being qdel'd (gibbed or removed, essentially) that it'd remove internal organs after they had been transferred to their new organ item.

Fixes #32875

## Changelog
:cl:
 * bugfix: Eyes will now stay in decapitated heads.