### PR TITLE
Fixes autolathes needing wood to make spades.

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -418,7 +418,7 @@ proc/move_mining_shuttle()
 	sharpness = 0.8
 	throwforce = 7.0
 	w_class = W_CLASS_SMALL
-
+	starting_materials = list(MAT_IRON = CC_PER_SHEET_METAL * 2.5) // costs less than a full pick, come on man it's a tiny ass shovel
 	toolspeed = 0.6 //slower than the large shovel
 
 


### PR DESCRIPTION
Closes #32118.
It was just an inheritance issue, it called the same materials a pickaxe would give, which include wood.
[bugfix]
:cl:
 * bugfix: Spades can now be properly printed in autolathes.