### PR TITLE
Adds some cave clothing in xeno wardrobes

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
@@ -95,6 +95,8 @@
 		/obj/item/clothing/suit/unathi/mantle,
 		/obj/item/clothing/suit/unathi/robe,
 		/obj/item/clothing/shoes/sandal = 3,
+		/obj/item/clothing/under/rags = 2,
+		/obj/item/clothing/under/shorts/black,
 	)
 
 


### PR DESCRIPTION
# Unga!
![image](https://user-images.githubusercontent.com/69739118/182080465-a3a45113-b2f2-4ca6-b874-753379f57166.png)

## What this does
Adds two sets of rags and a pair of black athletic shorts to the xeno wardrobe that spawns in arrivals. This is intended for use by the "alien" cavemen who join the station, or by catbeasts who want to actually wear fitting clothes (opposed to trying to pretend that they're greyshirt assistants). The black athletic shorts are to match with the current primitivism chaplain outfit.

## Why it's good
Makes looking like a caveman a little bit easier and faster for those who seek to bring a little unga bunga to the station.

## Changelog
:cl:
 * rscadd: Some caveman style outfits have been added to the arrivals xeno wardrobe closet.

[tested]