### PR TITLE
This is the second time ghosts can now look at malf-locked APCs, and we have become exceedingly efficient at it

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -883,14 +883,6 @@
 				nanomanager.close_user_uis(user, src)
 
 			return 0
-/*
-	else if(isobserver(user))
-		if(malfhack && istype(malfai) && !isAdminGhost(user))
-			if(!loud)
-				to_chat(user, "<span class='warning'>\The [src] have AI control disabled!</span>")
-				nanomanager.close_user_uis(user, src)
-			return 0
-*/
 	else
 		if ((!is_in_range(user) || !istype(src.loc, /turf)))
 			nanomanager.close_user_uis(user, src)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -883,13 +883,14 @@
 				nanomanager.close_user_uis(user, src)
 
 			return 0
+/*
 	else if(isobserver(user))
 		if(malfhack && istype(malfai) && !isAdminGhost(user))
 			if(!loud)
 				to_chat(user, "<span class='warning'>\The [src] have AI control disabled!</span>")
 				nanomanager.close_user_uis(user, src)
 			return 0
-
+*/
 	else
 		if ((!is_in_range(user) || !istype(src.loc, /turf)))
 			nanomanager.close_user_uis(user, src)


### PR DESCRIPTION
It was a few lines in the code that deliberately prevented observers from observing. Not exactly sure why, but now it's commented out.

:cl:
 * tweak: Ghosts can now actually look at APCs that were locked by a Malfunctioning AI for real.