### PR TITLE
Fixes Rare NanoUI Bug

### DIFF
--- a/nano/js/nano_template.js
+++ b/nano/js/nano_template.js
@@ -43,7 +43,7 @@ var NanoTemplate = function () {
 					// Disabling caching using jQuery's hack seems to break Nano in some obscure cases on BYOND 512.
 					// Oh well.
 					//cache: false,
-					dataType: 'text',
+					dataType: 'html',
 					timeout: 1000
 				}))
 				.done(function(templateMarkup) {


### PR DESCRIPTION
# One Line Change
Before:
![image](https://user-images.githubusercontent.com/69739118/182942308-9ac779ba-82e9-403e-85b7-d0fb958094a8.png)
After:
![image](https://user-images.githubusercontent.com/69739118/182942556-9c0a95c3-4839-46d2-9541-8a71ad27a195.png)

## What this does
Changes a single line in nano_template.js. For some reason, on my PC (insert works on my PC meme here), the NanoUI template processing fails for the isolation centrifuge, and JUST for that machine. A rare few others mentioned having the same issue happen intermittently. After some testing, I isolated the cause to a single line:
``dataType: 'text',``
Changing this type to html fixes the issue. I chatted briefly with Damian about it. There is no reason this should affect anything. This shouldn't BE a fix for the issue. Yet, here we are. I change this one line of code, and the above two pictures happen respectively. Pre-fix, post-fix. Undoing the fix restores the bug. Redoing the fix removes the bug.

I can also perform this bugfix locally, as a temporary fix. I just have to change one line in the cached .js file. If this PR doesn't get merged, then I can simply rely on this to fix my issue until a more proper fix is (probably never) made.

I have tested most NanoUI machines throughout the station with this fix. They work no problem. But they were working beforehand as well. For me, it was just this one singular machine that my PC didn't like.

What I CAN'T test is how this affects other players' NanoUIs. There's no reason to believe this would break things, but there wasn't a reason to believe this would fix anything. Please test this before merging.

## Why it's good
I can cure viruses again. Fixes #32529, Fixes #26957, Fixes #32953, Fixes #22339, Fixes #26636, Fixes #22339, Fixes #26957, Fixes #28159, and Fixes #33020

## Changelog
:cl:
 * bugfix: Fixes rare nanoUI issue where nothing loads in a NanoUI popup window. Please continue to bug report any UI issues.

[bugfix] [ui]