### PR TITLE
Ghosts can sometimes shatter lights by spooking them.

### DIFF
--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -432,8 +432,12 @@ var/global/list/obj/machinery/light/alllights = list()
 	if(!can_spook())
 		return
 	src.add_hiddenprint(user)
-	src.flicker(1)
-	investigation_log(I_GHOST, "|| was made to flicker by [key_name(user)][user.locked_to ? ", who was haunting [user.locked_to]" : ""]")
+	if(prob(99)
+		src.flicker(1)
+		investigation_log(I_GHOST, "|| was made to flicker by [key_name(user)][user.locked_to ? ", who was haunting [user.locked_to]" : ""]")
+	else //1% chance for lights to break when manually haunted
+		src.broken()
+		investigation_log(I_GHOST, "|| was made to break by [key_name(user)][user.locked_to ? ", who was haunting [user.locked_to]" : ""]")
 	return
 
 // ai attack - make lights flicker, because why not

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -432,7 +432,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	if(!can_spook())
 		return
 	src.add_hiddenprint(user)
-	if(prob(99)
+	if(prob(99))
 		src.flicker(1)
 		investigation_log(I_GHOST, "|| was made to flicker by [key_name(user)][user.locked_to ? ", who was haunting [user.locked_to]" : ""]")
 	else //1% chance for lights to break when manually haunted


### PR DESCRIPTION
## What this does
Whenever a ghost blinks a light manually (clicking on the light itself), there's a 1% chance the light shatters.
When testing, it took an average of 30 manual blinks for a light to break.
This breaks them like they would break when smashing a lightbulb unlike the "burnt-out" breaking that sometimes can happen.
## Why it's good
Gives ghosts better ways to haunt people with marginal effects on normal rounds.

:cl:
 * rscadd: Lights being blinked manually by ghosts have a 1% chance of breaking.