### PR TITLE
Change AI's see_invisible from SEE_INVISIBLE_LEVEL_TWO to SEE_INVISIBLE_LEVEL_ONE

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -694,10 +694,10 @@ var/list/liftable_structures = list(\
 #define SEE_INVISIBLE_LIVING 25		//This what players have by default.
 
 #define SEE_INVISIBLE_LEVEL_ONE 35	//Used by mobs under certain conditions.
-#define INVISIBILITY_LEVEL_ONE 35	//Used by infrared beams
+#define INVISIBILITY_LEVEL_ONE 35	//Used by infrared beams and turrets inside their covers
 
 #define SEE_INVISIBLE_LEVEL_TWO 45	//Used by mobs under certain conditions.
-#define INVISIBILITY_LEVEL_TWO 45	//Used by turrets inside their covers and objects/spells
+#define INVISIBILITY_LEVEL_TWO 45	//Used objects/spells
 
 #define INVISIBILITY_OBSERVER 60	//Used by Ghosts.
 #define SEE_INVISIBLE_OBSERVER 60	//Used by Ghosts.

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -230,7 +230,7 @@ Status: []<BR>"},
 			// This code handles moving the turret around. After all, it's a portable turret!
 
 			if(anchored)
-				invisibility = INVISIBILITY_LEVEL_TWO
+				invisibility = INVISIBILITY_LEVEL_ONE
 				icon_state = "[lasercolor]grey_target_prism"
 				cover=new/obj/machinery/turretcover/portable(src.loc) // create a new turret cover. While this is handled in process(), this is to workaround a bug where the turret becomes invisible for a split second
 				cover.host = src // make the cover's parent src

--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -6,7 +6,7 @@
 	var/enabled = 1
 	var/obj/item/weapon/gun/installed = null	// the type of weapon installed
 	anchored = 1
-	invisibility = INVISIBILITY_LEVEL_TWO		// the turret is invisible if it's inside its cover
+	invisibility = INVISIBILITY_LEVEL_ONE		// the turret is invisible if it's inside its cover
 	density = 1
 	var/faction = null 							//No shooting our buddies!
 	var/shootsilicons = 0						//You can make turrets that shoot those robot pricks (except AIs)! You can't toggle this at the control console
@@ -272,7 +272,7 @@
 	raising=0
 	cover.icon_state="turretCover"
 	raised=0
-	invisibility = INVISIBILITY_LEVEL_TWO
+	invisibility = INVISIBILITY_LEVEL_ONE
 
 /obj/machinery/turret/bullet_act(var/obj/item/projectile/Proj)
 	src.health -= Proj.damage

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -898,14 +898,6 @@ var/list/ai_list = list()
 			user.visible_message("<span class='notice'>\The [user] finishes fastening down \the [src]!</span>")
 			anchored = TRUE
 			return
-<<<<<<< HEAD
-	else if(istype(W, /obj/item/mecha_parts/AI_upgrade) && !upgraded)
-		if(user.drop_item(W))
-			qdel(W)
-			to_chat(user, "<span class='notice'>You upgrade the AI.</span>")
-			upgraded = 1
-=======
->>>>>>> parent of edf6849782 (upgrade vision)
 	else
 		return ..()
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -40,6 +40,7 @@ var/list/ai_list = list()
 	var/datum/intercom_settings/intercom_clipboard = null //Clipboard for copy/pasting intercom settings
 	var/mentions_on = FALSE
 	var/list/holopadoverlays = list()
+	var/upgraded = FALSE
 
 	// See VOX_AVAILABLE_VOICES for available values
 	var/vox_voice = "fem";
@@ -879,8 +880,13 @@ var/list/ai_list = list()
 		C.set_light(AI_CAMERA_LUMINOSITY)
 		lit_cameras |= C
 
+/obj/item/mecha_parts/AI_upgrade
+	name = "AI Upgrade"
+	desc = "This device upgrades the AI to ultra-HD vision."
+	icon = 'icons/obj/module.dmi'
+	icon_state = "cyborg_upgrade"
 
-/mob/living/silicon/ai/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/mob/living/silicon/ai/attackby(obj/item/W as obj, mob/user as mob)
 	if(W.is_wrench(user))
 		if(anchored)
 			user.visible_message("<span class='notice'>\The [user] starts to unbolt \the [src] from the plating...</span>")
@@ -898,6 +904,11 @@ var/list/ai_list = list()
 			user.visible_message("<span class='notice'>\The [user] finishes fastening down \the [src]!</span>")
 			anchored = TRUE
 			return
+	else if(istype(W, /obj/item/mecha_parts/AI_upgrade) && !upgraded)
+		if(user.drop_item(W))
+			qdel(W)
+			to_chat(user, "<span class='notice'>You upgrade \the AI.</span>")
+			upgraded = 1
 	else
 		return ..()
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -40,7 +40,6 @@ var/list/ai_list = list()
 	var/datum/intercom_settings/intercom_clipboard = null //Clipboard for copy/pasting intercom settings
 	var/mentions_on = FALSE
 	var/list/holopadoverlays = list()
-	var/upgraded = FALSE
 
 	// See VOX_AVAILABLE_VOICES for available values
 	var/vox_voice = "fem";
@@ -880,13 +879,8 @@ var/list/ai_list = list()
 		C.set_light(AI_CAMERA_LUMINOSITY)
 		lit_cameras |= C
 
-/obj/item/mecha_parts/AI_upgrade
-	name = "AI Upgrade"
-	desc = "This device upgrades the AI to ultra-HD vision."
-	icon = 'icons/obj/module.dmi'
-	icon_state = "cyborg_upgrade"
 
-/mob/living/silicon/ai/attackby(obj/item/W as obj, mob/user as mob)
+/mob/living/silicon/ai/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(W.is_wrench(user))
 		if(anchored)
 			user.visible_message("<span class='notice'>\The [user] starts to unbolt \the [src] from the plating...</span>")
@@ -904,11 +898,14 @@ var/list/ai_list = list()
 			user.visible_message("<span class='notice'>\The [user] finishes fastening down \the [src]!</span>")
 			anchored = TRUE
 			return
+<<<<<<< HEAD
 	else if(istype(W, /obj/item/mecha_parts/AI_upgrade) && !upgraded)
 		if(user.drop_item(W))
 			qdel(W)
 			to_chat(user, "<span class='notice'>You upgrade the AI.</span>")
 			upgraded = 1
+=======
+>>>>>>> parent of edf6849782 (upgrade vision)
 	else
 		return ..()
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -907,7 +907,7 @@ var/list/ai_list = list()
 	else if(istype(W, /obj/item/mecha_parts/AI_upgrade) && !upgraded)
 		if(user.drop_item(W))
 			qdel(W)
-			to_chat(user, "<span class='notice'>You upgrade \the AI.</span>")
+			to_chat(user, "<span class='notice'>You upgrade the AI.</span>")
 			upgraded = 1
 	else
 		return ..()

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -47,7 +47,7 @@
 			ai.client.eye = src
 			ai.change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 			ai.see_in_dark = 8
-			ai.see_invisible = SEE_INVISIBLE_LEVEL_TWO
+			ai.see_invisible = SEE_INVISIBLE_LEVEL_ONE
 
 		if(istype(H) && !holo_bump)  // move our hologram to our new location (unless our advanced hologram was bumped, in which case we're moving to the hologram)
 			H.move_hologram(harderforce)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -47,7 +47,10 @@
 			ai.client.eye = src
 			ai.change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 			ai.see_in_dark = 8
-			ai.see_invisible = SEE_INVISIBLE_LEVEL_ONE
+			if(ai.upgraded)
+				ai.see_invisible = SEE_INVISIBLE_LEVEL_TWO
+			else
+				ai.see_invisible = SEE_INVISIBLE_LEVEL_ONE
 
 		if(istype(H) && !holo_bump)  // move our hologram to our new location (unless our advanced hologram was bumped, in which case we're moving to the hologram)
 			H.move_hologram(harderforce)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -47,10 +47,7 @@
 			ai.client.eye = src
 			ai.change_sight(adding = SEE_TURFS|SEE_MOBS|SEE_OBJS)
 			ai.see_in_dark = 8
-			if(ai.upgraded)
-				ai.see_invisible = SEE_INVISIBLE_LEVEL_TWO
-			else
-				ai.see_invisible = SEE_INVISIBLE_LEVEL_ONE
+			ai.see_invisible = SEE_INVISIBLE_LEVEL_ONE
 
 		if(istype(H) && !holo_bump)  // move our hologram to our new location (unless our advanced hologram was bumped, in which case we're moving to the hologram)
 			H.move_hologram(harderforce)

--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -25,7 +25,7 @@
 	build_type = PROTOLATHE | MECHFAB
 	build_path = /obj/item/mecha_parts/AI_upgrade
 	req_tech = list(Tc_ENGINEERING = 1, Tc_MATERIALS = 1)
-	materials = list(MAT_PHAZON = 5)
+	materials = list(MAT_DIAMOND = 500)
 	category = "Misc"
 
 /datum/design/chempack

--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -18,19 +18,6 @@
 	materials = list(MAT_IRON=10000)
 	category = "Misc"
 
-<<<<<<< HEAD
-/datum/design/AI_upgrade
-	name = "AI Upgrade Module"
-	desc = "Used to allow the AI ultra-HD vision"
-	id = "AI_upgrade"
-	build_type = PROTOLATHE | MECHFAB
-	build_path = /obj/item/mecha_parts/AI_upgrade
-	req_tech = list(Tc_ENGINEERING = 1, Tc_MATERIALS = 1)
-	materials = list(MAT_DIAMOND = 500)
-	category = "Misc"
-
-=======
->>>>>>> parent of edf6849782 (upgrade vision)
 /datum/design/chempack
 	name = "Chemical Pack"
 	desc = "Useful for the storage and transport of large volumes of chemicals. Can be used in conjunction with a wide range of chemical-dispensing devices."

--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -18,6 +18,7 @@
 	materials = list(MAT_IRON=10000)
 	category = "Misc"
 
+<<<<<<< HEAD
 /datum/design/AI_upgrade
 	name = "AI Upgrade Module"
 	desc = "Used to allow the AI ultra-HD vision"
@@ -28,6 +29,8 @@
 	materials = list(MAT_DIAMOND = 500)
 	category = "Misc"
 
+=======
+>>>>>>> parent of edf6849782 (upgrade vision)
 /datum/design/chempack
 	name = "Chemical Pack"
 	desc = "Useful for the storage and transport of large volumes of chemicals. Can be used in conjunction with a wide range of chemical-dispensing devices."

--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -25,7 +25,7 @@
 	build_type = PROTOLATHE | MECHFAB
 	build_path = /obj/item/mecha_parts/AI_upgrade
 	req_tech = list(Tc_ENGINEERING = 1, Tc_MATERIALS = 1)
-	materials = list(MAT_DIAMOND = 500)
+	materials = list(MAT_PHAZON = 5)
 	category = "Misc"
 
 /datum/design/chempack

--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -25,7 +25,7 @@
 	build_type = PROTOLATHE | MECHFAB
 	build_path = /obj/item/mecha_parts/AI_upgrade
 	req_tech = list(Tc_ENGINEERING = 1, Tc_MATERIALS = 1)
-	materials = list(MAT_IRON=10000)
+	materials = list(MAT_DIAMOND = 500)
 	category = "Misc"
 
 /datum/design/chempack

--- a/code/modules/research/designs/misc.dm
+++ b/code/modules/research/designs/misc.dm
@@ -18,6 +18,16 @@
 	materials = list(MAT_IRON=10000)
 	category = "Misc"
 
+/datum/design/AI_upgrade
+	name = "AI Upgrade Module"
+	desc = "Used to allow the AI ultra-HD vision"
+	id = "AI_upgrade"
+	build_type = PROTOLATHE | MECHFAB
+	build_path = /obj/item/mecha_parts/AI_upgrade
+	req_tech = list(Tc_ENGINEERING = 1, Tc_MATERIALS = 1)
+	materials = list(MAT_IRON=10000)
+	category = "Misc"
+
 /datum/design/chempack
 	name = "Chemical Pack"
 	desc = "Useful for the storage and transport of large volumes of chemicals. Can be used in conjunction with a wide range of chemical-dispensing devices."


### PR DESCRIPTION
AIs can see everyone that uses invisibility potions, vampires who are hidden by shadows, wizards who jaunt, and cultists who astral journey, and I have no idea why it's set so high. This PR reduces it to level_one so they can at least see infrared

## What this does
- changes turret invisibility to level_one
- changes see_invisibility for AIEye to level_one

## Why it's good
- Unintended that they can see such mobs
- Closes #33029

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Changes some invisibility values for AIs