### PR TITLE
fix midround threat not getting properly refunded when a ruleset fails to fire

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -1,4 +1,4 @@
-rvar/list/forced_roundstart_ruleset = list()
+var/list/forced_roundstart_ruleset = list()
 
 // -- Distribution parameters chosen prior to roundstart --
 var/dynamic_curve_centre = 0

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -1,4 +1,4 @@
-var/list/forced_roundstart_ruleset = list()
+rvar/list/forced_roundstart_ruleset = list()
 
 // -- Distribution parameters chosen prior to roundstart --
 var/dynamic_curve_centre = 0
@@ -772,7 +772,7 @@ var/stacking_limit = 90
 
 // Same as above, but for midround
 /datum/gamemode/dynamic/proc/refund_midround_threat(var/regain)
-	threat = min(midround_threat_level,midround_threat+regain)
+	midround_threat = min(midround_threat_level,midround_threat+regain)
 
 /datum/gamemode/dynamic/proc/create_midround_threat(var/gain)
 	midround_threat = min(100, midround_threat+gain)


### PR DESCRIPTION
no cl fuck you

🆑 
* bugfix: Fixed a bug where midround threat would not properly refund after a failed ruleset.