### PR TITLE
Items thrown by explosions will no longer instantly kill anyone they hit

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -142,7 +142,7 @@ var/explosion_shake_message_cooldown = 0
 	var/y0 = offcenter.y
 	//var/z0 = offcenter.z
 
-	var/list/affected_turfs = spiral_block(offcenter,max_range)	
+	var/list/affected_turfs = spiral_block(offcenter,max_range)
 	var/list/cached_exp_block = CalculateExplosionBlock(affected_turfs)
 
 	for(var/turf/T in affected_turfs)
@@ -170,7 +170,7 @@ var/explosion_shake_message_cooldown = 0
 		for(var/atom/movable/A in T)
 			if(T != offcenter && !A.anchored && A.last_explosion_push != explosion_time)
 				A.last_explosion_push = explosion_time
-				
+
 				var/max_dist = _dist+(pushback)
 				var/max_count = pushback
 				var/turf/throwT = get_step_away(A,offcenter,max_dist)
@@ -185,7 +185,7 @@ var/explosion_shake_message_cooldown = 0
 				if(ismob(A))
 					to_chat(A, "<span class='warning'>You are blown away by the explosion!</span>")
 
-				A.throw_at(throwT,pushback+2,500)
+				A.throw_at(throwT,pushback+2,10)
 			A.ex_act(dist,null,whodunnit)
 
 		T.ex_act(dist,null,whodunnit)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -185,7 +185,7 @@ var/explosion_shake_message_cooldown = 0
 				if(ismob(A))
 					to_chat(A, "<span class='warning'>You are blown away by the explosion!</span>")
 
-				A.throw_at(throwT,pushback+2,10)
+				A.throw_at(throwT,pushback+2,5 * pushback) //1x damage at light range, 3x damage at heavy range, 5x damage at dev range
 			A.ex_act(dist,null,whodunnit)
 
 		T.ex_act(dist,null,whodunnit)


### PR DESCRIPTION
![Impact](https://user-images.githubusercontent.com/41342767/184088554-046bbf17-b89a-48b1-aef3-6ea7d0dc7b22.png)

The way the current formula works is that it multiplies throwing force by 100, meaning something with as little throwing damage as 2 will instantly kill someone. This reduces it to regular force at light range, 3x force at heavy range and 5x force at devastation range.

:cl:
 * tweak: The formula for items thrown by explosions has been modified. Instead of doing a flat 100x damage from being launched the damage increases significantly depending on the force of the explosion at the tile, up to 5x at the most damaging radius.