### PR TITLE
typofix and (minor) bugfix

### DIFF
--- a/code/game/machinery/kitchen/snackbarmachine.dm
+++ b/code/game/machinery/kitchen/snackbarmachine.dm
@@ -1,6 +1,6 @@
 /obj/machinery/chem_master/snackbar_machine
 	name = "\improper SnackBar Machine"
-	desc = "An explosion of flavour in every bite"
+	desc = "An explosion of flavour in every bite."
 	condi = 1
 	icon_state = "snackbar"
 	chem_board = /obj/item/weapon/circuitboard/snackbar_machine

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -17,7 +17,7 @@
 		if(src && user && genes && choice && choice == "Yes" && user.get_active_hand() == src)
 			to_chat(user, "You wipe the disk data.")
 			name = initial(name)
-			desc = initial(name)
+			desc = initial(desc)
 			genes = list()
 			genesource = "unknown"
 


### PR DESCRIPTION
Turns out the floral data disks called initial(name) instead of initial(desc) on the description when resetting them, so their description turned into "floral data disk".
[grammar][bugfix]
:cl:
 * bugfix: Floral Data Disks that have been reset no longer say "floral data disk" in their description but rather the original description again.
 * spellcheck: Adds missing period on snackbar machine description.