### PR TITLE
Adds "spellcheck" to the PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,5 +21,4 @@ You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing
  * imageadd: Added new sprites.
  * imagedel: Removed old sprites.
  * experiment: Added an experimental/work-in-progress something.
- * spellcheck: Fixed missing punctuation or restructured a sentence.
-
+ * spellcheck: Fixed missing punctuation, typos or restructured a sentence.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,4 +21,5 @@ You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing
  * imageadd: Added new sprites.
  * imagedel: Removed old sprites.
  * experiment: Added an experimental/work-in-progress something.
+ * spellcheck: Fixed missing punctuation or restructured a sentence.
 


### PR DESCRIPTION
It's a valid and used changelog tag but was not added to the template for some reason.