### PR TITLE
Iron Chef update

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -789,7 +789,7 @@ to destroy them and players will be able to make replacements.
 
 /obj/item/weapon/circuitboard/smartfridge
 	name = "Circuit Board (SmartFridge)"
-	desc = "A circuit board used to run a machine that will hold grown plants, seeds, meat, and eggs."
+	desc = "A circuit board used to run a machine that will hold grown condiments, drinks, plants, seeds, meats, and glasses."
 	build_path = /obj/machinery/smartfridge
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=2"
@@ -808,7 +808,6 @@ to destroy them and players will be able to make replacements.
 		"Chemistry smartfridge" = /obj/item/weapon/circuitboard/smartfridge/chemistry,
 		"Slime extract smartfridge" = /obj/item/weapon/circuitboard/smartfridge/extract,
 		"Seed smartfridge" = /obj/item/weapon/circuitboard/smartfridge/seeds,
-		"Drinks smartfridge" = /obj/item/weapon/circuitboard/smartfridge/drinks,
 		"Refrigerated Blood Bank" = /obj/item/weapon/circuitboard/smartfridge/bloodbank
 	)
 
@@ -846,11 +845,6 @@ to destroy them and players will be able to make replacements.
 	name = "Circuit Board (Megaseed Servitor)"
 	desc = "A circuit board used to run a machine that will hold seed packets."
 	build_path = /obj/machinery/smartfridge/seeds
-
-/obj/item/weapon/circuitboard/smartfridge/drinks
-	name = "Circuit Board (Drinks Showcase)"
-	desc = "A circuit board used to run a machine that will hold glasses, drinks and condiments."
-	build_path = /obj/machinery/smartfridge/drinks
 
 /obj/item/weapon/circuitboard/smartfridge/bloodbank
 	name = "Circuit Board (Refrigerated Blood Bank)"

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -26,7 +26,7 @@
 									/obj/item/weapon/reagent_containers/food/snacks/meat,
 									/obj/item/weapon/reagent_containers/food/snacks/honeycomb,
 									/obj/item/weapon/reagent_containers/food/snacks/egg,
-									/obj/item/weapon/reagent_containers/food/condiment
+									/obj/item/weapon/reagent_containers/food/condiment,
 									/obj/item/weapon/reagent_containers/glass,
 									/obj/item/weapon/reagent_containers/food/drinks,
 									/obj/item/weapon/reagent_containers/food/condiment)

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -230,6 +230,21 @@
 
 	RefreshParts()
 
+/obj/machinery/smartfridge/drinks/filled/New()
+	. = ..()
+
+	for(var/i = 0 to 2)
+		insert_item(new /obj/item/weapon/reagent_containers/food/condiment/honey(src))
+		insert_item(new /obj/item/weapon/reagent_containers/food/condiment/hotsauce(src))
+		insert_item(new /obj/item/weapon/reagent_containers/food/condiment/coldsauce(src))
+		insert_item(new /obj/item/weapon/reagent_containers/food/condiment/ketchup(src))
+		insert_item(new /obj/item/weapon/reagent_containers/food/condiment/gravy/gravybig(src))
+		insert_item(new /obj/item/weapon/reagent_containers/food/condiment/cinnamon(src))
+		insert_item(new /obj/item/weapon/reagent_containers/food/condiment/soysauce(src))
+		insert_item(new /obj/item/weapon/reagent_containers/food/condiment/vinegar(src))
+		insert_item(new /obj/item/weapon/reagent_containers/food/drinks/ice(src))
+		insert_item(new /obj/item/weapon/reagent_containers/food/drinks/discount_sauce(src))
+
 /obj/machinery/smartfridge/extract
 	name = "\improper Slime Extract Storage"
 	desc = "A refrigerated storage unit for slime extracts."
@@ -269,7 +284,7 @@
 	icon_state = "bloodbank"
 	icon_on = "bloodbank"
 
-	accepted_types = list(/obj/item/weapon/reagent_containers/blood)
+	accepted_types = list(/obj/item/weapon/reagent_containers/blood)	
 
 /obj/machinery/smartfridge/bloodbank/New()
 	. = ..()

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -207,7 +207,7 @@
 
 	RefreshParts()
 
-/obj/machinery/smartfridge/filled/New()
+/obj/machinery/smartfridge/condiments/New()
 	. = ..()
 
 	for(var/i = 0 to 2)

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -26,6 +26,9 @@
 									/obj/item/weapon/reagent_containers/food/snacks/meat,
 									/obj/item/weapon/reagent_containers/food/snacks/honeycomb,
 									/obj/item/weapon/reagent_containers/food/snacks/egg,
+									/obj/item/weapon/reagent_containers/food/condiment
+									/obj/item/weapon/reagent_containers/glass,
+									/obj/item/weapon/reagent_containers/food/drinks,
 									/obj/item/weapon/reagent_containers/food/condiment)
 
 	machine_flags = SCREWTOGGLE | CROWDESTROY | EJECTNOTDEL | WRENCHMOVE | FIXED2WORK | EMAGGABLE
@@ -204,33 +207,7 @@
 
 	RefreshParts()
 
-/obj/machinery/smartfridge/drinks
-	name = "\improper Drink Showcase"
-	desc = "A refrigerated storage unit for tasty tasty alcohol."
-
-	accepted_types = list(	/obj/item/weapon/reagent_containers/glass,
-							/obj/item/weapon/reagent_containers/food/drinks,
-							/obj/item/weapon/reagent_containers/food/condiment)
-
-/obj/machinery/smartfridge/drinks/New()
-	. = ..()
-
-	component_parts = newlist(
-		/obj/item/weapon/circuitboard/smartfridge/drinks,
-		/obj/item/weapon/stock_parts/manipulator,
-		/obj/item/weapon/stock_parts/manipulator,
-		/obj/item/weapon/stock_parts/matter_bin,
-		/obj/item/weapon/stock_parts/matter_bin,
-		/obj/item/weapon/stock_parts/matter_bin,
-		/obj/item/weapon/stock_parts/matter_bin,
-		/obj/item/weapon/stock_parts/scanning_module,
-		/obj/item/weapon/stock_parts/console_screen,
-		/obj/item/weapon/stock_parts/console_screen
-	)
-
-	RefreshParts()
-
-/obj/machinery/smartfridge/drinks/filled/New()
+/obj/machinery/smartfridge/filled/New()
 	. = ..()
 
 	for(var/i = 0 to 2)

--- a/maps/randomvaults/ironchef.dmm
+++ b/maps/randomvaults/ironchef.dmm
@@ -15,22 +15,24 @@
 	},
 /area/vault/ironchef)
 "ae" = (
-/obj/machinery/vending/hydroseeds,
+/obj/machinery/vending/old_vendotron,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	dir = 5;
+	icon_state = "checker"
 	},
 /area/vault/ironchef)
 "af" = (
-/obj/machinery/vending/voxseeds,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/windoor_assembly/secure{
+	dir = 2
 	},
+/obj/structure/windoor_assembly/secure,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "ag" = (
-/obj/structure/table/reinforced,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -46,74 +48,49 @@
 	},
 /area/vault/ironchef)
 "ai" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/condiment/honey{
-	pixel_x = -9
+/obj/machinery/cooking/grill,
+/obj/machinery/light/he{
+	dir = 8
 	},
-/obj/item/weapon/reagent_containers/food/condiment/hotsauce{
-	pixel_x = -3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/coldsauce{
-	pixel_x = 3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/ketchup{
-	pixel_x = 9
+/obj/machinery/camera{
+	name = "Iron Chef 1"
 	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "aj" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/condiment/gravy/gravybig{
-	pixel_x = -9
-	},
-/obj/item/weapon/reagent_containers/food/condiment/cornoil{
-	pixel_x = -3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/cinnamon{
-	pixel_x = 3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/soysauce{
-	pixel_x = 9
-	},
+/obj/structure/closet/crate/hydroponics,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/weapon/minihoe,
+/obj/item/weapon/storage/bag/plants,
+/obj/item/tool/wirecutters/clippers,
+/obj/machinery/light/he,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "ak" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/condiment/vinegar{
-	pixel_x = -9
-	},
-/obj/item/weapon/reagent_containers/food/drinks/ice,
-/obj/item/weapon/reagent_containers/food/drinks/discount_sauce{
-	pixel_x = 9
+/obj/machinery/door/airlock/glass{
+	name = "Audience"
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "al" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/dipping_sauce/queso{
-	pixel_y = 18
+/obj/effect/decal/warning_stripes{
+	dir = 4;
+	icon_state = "warning"
 	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/salsa{
-	pixel_y = 13
-	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/hummus{
-	pixel_y = 8
-	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/guacamole,
+/obj/structure/reagent_dispensers/corn_oil_tank,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "am" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/vending/dinnerware,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -161,9 +138,7 @@
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
 "av" = (
-/obj/structure/table/woodentable,
-/obj/item/clothing/gloves/ironchefgauntlets,
-/obj/item/weapon/reagent_containers/glass/beaker/vial/flavor,
+/obj/machinery/light/he,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "checker"
@@ -186,75 +161,58 @@
 	},
 /area/vault/ironchef)
 "ay" = (
-/obj/machinery/apiary,
-/obj/item/queen_bee,
-/obj/item/queen_bee/chill,
-/obj/item/weapon/reagent_containers/food/snacks/beezeez,
+/obj/machinery/vending/voxseeds,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "az" = (
-/obj/structure/rack,
-/obj/item/weapon/fishtools/fish_egg_scoop,
-/obj/item/weapon/fishtools/fish_food,
-/obj/item/weapon/fishtools/fish_net,
-/obj/item/weapon/fishtools/fish_tank_brush,
-/obj/item/tool/crowbar,
-/obj/effect/decal/warning_stripes{
-	dir = 4;
-	icon_state = "warning"
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/drinks/shaker,
+/obj/machinery/chem_dispenser/soda_dispenser/mapping,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
 	},
-/obj/item/weapon/hatchet,
-/obj/item/weapon/extinguisher,
-/turf/simulated/floor/plating,
 /area/vault/ironchef)
 "aA" = (
-/obj/structure/window/reinforced,
-/obj/machinery/egg_incubator,
-/turf/simulated/floor/grass,
+/obj/structure/rack,
+/obj/item/organ/internal/brain,
+/obj/item/clothing/head/butt,
+/obj/item/organ/internal/appendix,
+/obj/item/organ/internal/heart,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
 /area/vault/ironchef)
 "aB" = (
-/obj/structure/window/reinforced,
+/obj/structure/sink/puddle,
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
 "aC" = (
-/obj/structure/window/reinforced,
-/obj/structure/largecrate/goat,
+/mob/living/carbon/monkey,
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
 "aD" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	name = "reinforced one-way window";
-	one_way = 1
-	},
+/obj/machinery/vending/zamsnax,
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "darkblue"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aE" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	name = "reinforced one-way window";
-	one_way = 1
-	},
+/obj/machinery/chem_dispenser,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "darkblue";
-	tag = "icon-darkblue (NORTH)"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aF" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	name = "reinforced one-way window";
-	one_way = 1
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "darkblue"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "aG" = (
@@ -264,21 +222,32 @@
 	},
 /area/vault/ironchef)
 "aH" = (
-/obj/machinery/light,
+/obj/machinery/reagentgrinder,
+/obj/structure/table/reinforced,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aI" = (
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "darkblue"
-	},
+/obj/machinery/egg_incubator,
+/turf/simulated/floor/grass,
 /area/vault/ironchef)
 "aJ" = (
+/obj/structure/rack,
+/obj/item/clothing/head/wizard,
+/obj/item/slime_extract/purple,
+/obj/item/slime_extract/purple,
+/obj/item/weapon/ectoplasm,
+/obj/item/weapon/ectoplasm,
+/obj/item/weapon/ectoplasm,
+/obj/item/clothing/mask/fakemoustache,
+/obj/item/slime_extract/grey,
+/obj/item/slime_extract/grey,
+/obj/item/stack/sheet/snow{
+	amount = 5
+	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkbluecorners"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aK" = (
@@ -294,10 +263,8 @@
 	},
 /area/vault/ironchef)
 "aL" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "darkblue"
-	},
+/obj/structure/largecrate/goat,
+/turf/simulated/floor/grass,
 /area/vault/ironchef)
 "aM" = (
 /turf/simulated/wall,
@@ -322,53 +289,54 @@
 /turf/simulated/wall,
 /area/vault/ironchef)
 "aQ" = (
+/obj/structure/rack,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/customizable/vodka,
+/obj/item/weapon/reagent_containers/food/snacks/pimiento,
+/obj/item/weapon/reagent_containers/food/snacks/grown/kudzupod,
+/obj/item/weapon/reagent_containers/food/snacks/bustanuts,
+/obj/item/weapon/reagent_containers/food/drinks/coloring,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/uranium,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/radium,
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
 /turf/simulated/floor{
-	dir = 2;
-	icon_state = "darkblue"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aR" = (
+/obj/effect/decal/warning_stripes{
+	dir = 4;
+	icon_state = "warning"
+	},
+/obj/machinery/vending/snack,
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "darkblue"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aS" = (
-/obj/structure/rack,
-/obj/item/clothing/head/wizard,
-/obj/item/slime_extract/purple,
-/obj/item/slime_extract/purple,
-/obj/item/weapon/ectoplasm,
-/obj/item/weapon/ectoplasm,
-/obj/item/weapon/ectoplasm,
-/obj/item/clothing/mask/fakemoustache,
-/obj/item/slime_extract/grey,
-/obj/item/slime_extract/grey,
-/obj/item/stack/sheet/snow{
-	amount = 5
+/obj/machinery/light/he{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
 /area/vault/ironchef)
 "aT" = (
-/obj/structure/rack,
-/obj/item/stack/teeth/shark,
-/obj/item/weapon/reagent_containers/food/snacks/monkeycube,
-/obj/item/weapon/reagent_containers/food/snacks/meat/diona,
-/obj/item/weapon/reagent_containers/food/snacks/meat/hive,
-/obj/item/weapon/reagent_containers/food/snacks/meat/bearmeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box/pig,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box/pig,
-/turf/simulated/floor/plating,
-/area/vault/ironchef)
-"aU" = (
-/obj/machinery/cooking,
+/obj/machinery/cooking/deepfryer,
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
+	},
+/area/vault/ironchef)
+"aU" = (
+/obj/machinery/vending/hydroseeds,
+/obj/machinery/light/he{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aV" = (
@@ -420,13 +388,126 @@
 	},
 /area/vault/ironchef)
 "ba" = (
-/obj/structure/kitchenspike,
+/obj/machinery/cooking,
+/obj/machinery/light/he{
+	dir = 4
+	},
+/obj/machinery/camera{
+	name = "Iron Chef 2"
+	},
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bb" = (
+/obj/item/clothing/accessory/armband/cargo,
+/obj/item/clothing/gloves/brown/cargo,
+/obj/item/device/pda/cargo,
+/obj/structure/table,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"bc" = (
+/turf/simulated/floor/plating,
+/area/vault/ironchef)
+"bd" = (
+/obj/machinery/door/airlock/glass{
+	name = "Special Ingredients"
+	},
+/turf/simulated/floor/plating,
+/area/vault/ironchef)
+"be" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/condiment/honey{
+	pixel_x = -9
+	},
+/obj/item/weapon/reagent_containers/food/condiment/hotsauce{
+	pixel_x = -3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/coldsauce{
+	pixel_x = 3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/ketchup{
+	pixel_x = 9
+	},
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
+/area/vault/ironchef)
+"bf" = (
+/obj/machinery/bot/cleanbot{
+	auto_patrol = 0
+	},
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
+/area/vault/ironchef)
+"bg" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "checker"
+	},
+/area/vault/ironchef)
+"bh" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/booze_dispenser/mapping,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"bi" = (
+/obj/machinery/vending/meat,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"bj" = (
+/obj/machinery/apiary,
+/turf/simulated/floor/grass,
+/area/vault/ironchef)
+"bk" = (
+/obj/machinery/chem_master,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"bl" = (
+/obj/machinery/cooking/still,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"bm" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/closet/crate/freezer,
+/turf/simulated/floor/plating,
+/area/vault/ironchef)
+"bn" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -32
+	},
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "checker"
+	},
+/area/vault/ironchef)
+"bo" = (
 /obj/structure/rack,
 /obj/item/robot_parts/head,
 /obj/item/weapon/handcuffs,
@@ -446,120 +527,6 @@
 /obj/item/stack/cable_coil/yellow,
 /obj/item/stack/ore/glass,
 /obj/item/stack/ore/glass,
-/turf/simulated/floor/plating,
-/area/vault/ironchef)
-"bc" = (
-/turf/simulated/floor/plating,
-/area/vault/ironchef)
-"bd" = (
-/obj/machinery/door/airlock/glass{
-	name = "Special Ingredients"
-	},
-/turf/simulated/floor/plating,
-/area/vault/ironchef)
-"be" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
-"bf" = (
-/obj/machinery/bot/cleanbot{
-	auto_patrol = 0
-	},
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
-"bg" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/chef,
-/obj/item/clothing/under/rank/chef,
-/obj/item/clothing/head/chefhat,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
-"bh" = (
-/obj/structure/rack,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/customizable/vodka,
-/obj/item/weapon/reagent_containers/food/snacks/pimiento,
-/obj/item/weapon/reagent_containers/food/snacks/grown/kudzupod,
-/obj/item/weapon/reagent_containers/food/snacks/bustanuts,
-/obj/item/weapon/reagent_containers/food/drinks/coloring,
-/obj/item/weapon/reagent_containers/glass/beaker/vial/uranium,
-/obj/item/weapon/reagent_containers/glass/beaker/vial/radium,
-/turf/simulated/floor/plating,
-/area/vault/ironchef)
-"bi" = (
-/obj/structure/rack,
-/obj/item/organ/internal/brain,
-/obj/item/clothing/head/butt,
-/obj/item/organ/internal/appendix,
-/obj/item/organ/internal/heart,
-/turf/simulated/floor/plating,
-/area/vault/ironchef)
-"bj" = (
-/obj/machinery/cooking/grill,
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
-"bk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
-"bl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
-"bm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
-"bn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
-"bo" = (
-/obj/machinery/door/airlock/mining{
-	name = "Employees Only"
-	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -573,43 +540,41 @@
 	},
 /area/vault/ironchef)
 "bq" = (
-/obj/machinery/cooking/deepfryer,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/reagent_dispensers/sacid,
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "br" = (
-/obj/effect/decal/warning_stripes{
-	dir = 9;
-	icon_state = "warning";
-	tag = "icon-warning (NORTHWEST)"
-	},
+/obj/structure/rack,
+/obj/item/stack/teeth/shark,
+/obj/item/weapon/reagent_containers/food/snacks/monkeycube,
+/obj/item/weapon/reagent_containers/food/snacks/meat/diona,
+/obj/item/weapon/reagent_containers/food/snacks/meat/hive,
+/obj/item/weapon/reagent_containers/food/snacks/meat/bearmeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box/pig,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box/pig,
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bs" = (
-/obj/effect/decal/warning_stripes{
-	dir = 5;
-	icon_state = "warning";
-	tag = "icon-warning (NORTHEAST)"
-	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/chefhat,
+/obj/item/clothing/under/rank/chef,
+/obj/item/clothing/suit/chef,
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bt" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes{
-	dir = 9;
-	icon_state = "warning";
-	tag = "icon-warning (NORTHWEST)"
+	icon_state = "1"
 	},
 /turf/simulated/floor{
 	blocks_air = 0;
@@ -617,18 +582,17 @@
 	},
 /area/vault/ironchef)
 "bu" = (
-/obj/machinery/processor,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/brewer/mapping,
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bv" = (
-/mob/living/simple_animal/mouse/common,
-/turf/simulated/floor/plating,
+/obj/machinery/chem_master/condimaster,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
 /area/vault/ironchef)
 "bw" = (
 /obj/machinery/cooking/candy,
@@ -693,25 +657,40 @@
 	},
 /area/vault/ironchef)
 "bC" = (
-/obj/machinery/door/airlock/mining{
-	name = "Employees Only"
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/condiment/vinegar{
+	pixel_x = -9
 	},
-/turf/simulated/floor/plating,
+/obj/item/weapon/reagent_containers/food/drinks/ice,
+/obj/item/weapon/reagent_containers/food/drinks/discount_sauce{
+	pixel_x = 9
+	},
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
 /area/vault/ironchef)
 "bD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/cooking/cerealmaker,
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/decal/warning_stripes{
-	icon_state = "1"
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/condiment/gravy/gravybig{
+	pixel_x = -9
+	},
+/obj/item/weapon/reagent_containers/food/condiment/cornoil{
+	pixel_x = -3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/cinnamon{
+	pixel_x = 3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/soysauce{
+	pixel_x = 9
 	},
 /turf/simulated/floor{
 	blocks_air = 0;
@@ -726,14 +705,19 @@
 	},
 /area/vault/ironchef)
 "bG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bH" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
@@ -749,18 +733,24 @@
 	},
 /area/vault/ironchef)
 "bJ" = (
-/obj/machinery/gibber,
+/obj/machinery/light/he{
+	dir = 1
+	},
+/obj/machinery/vending/discount,
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bK" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/plating,
+/obj/structure/rack,
+/obj/item/weapon/fishtools/fish_egg_scoop,
+/obj/item/weapon/fishtools/fish_food,
+/obj/item/weapon/fishtools/fish_net,
+/obj/item/weapon/fishtools/fish_tank_brush,
+/obj/item/tool/crowbar,
+/obj/item/weapon/hatchet,
+/obj/item/weapon/extinguisher,
+/turf/simulated/floor/grass,
 /area/vault/ironchef)
 "bL" = (
 /obj/structure/window/full/reinforced,
@@ -792,12 +782,20 @@
 /turf/simulated/floor/carpet,
 /area/vault/ironchef)
 "bQ" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/dipping_sauce/queso{
+	pixel_y = 18
 	},
+/obj/item/weapon/reagent_containers/food/dipping_sauce/salsa{
+	pixel_y = 13
+	},
+/obj/item/weapon/reagent_containers/food/dipping_sauce/hummus{
+	pixel_y = 8
+	},
+/obj/item/weapon/reagent_containers/food/dipping_sauce/guacamole,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "checker"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bR" = (
@@ -810,29 +808,37 @@
 	},
 /area/vault/ironchef)
 "bS" = (
-/obj/item/clothing/accessory/armband/cargo,
-/obj/item/clothing/gloves/brown/cargo,
-/obj/item/device/pda/cargo,
-/obj/structure/table,
+/obj/machinery/door/airlock/glass{
+	name = "Audience"
+	},
 /turf/simulated/floor/plating,
 /area/vault/ironchef)
 "bT" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/weapon/disk/shuttle_coords/vault/ironchef,
-/turf/simulated/floor/plating,
+/obj/structure/table/woodentable,
+/obj/item/clothing/gloves/ironchefgauntlets,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/flavor,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "checker"
+	},
 /area/vault/ironchef)
 "bU" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
+/obj/machinery/gibber,
+/obj/machinery/light/he,
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
 /area/vault/ironchef)
 "bV" = (
-/obj/effect/decal/warning_stripes{
-	dir = 1;
-	icon_state = "loading_area";
-	tag = "icon-loading_area (NORTH)"
+/obj/machinery/processor,
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plating,
 /area/vault/ironchef)
 "bW" = (
 /obj/machinery/light/small{
@@ -855,10 +861,10 @@
 /turf/simulated/floor/carpet,
 /area/vault/ironchef)
 "ca" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/obj/item/weapon/reagent_containers/food/snacks/beezeez,
+/obj/item/queen_bee/chill,
+/obj/item/queen_bee,
+/turf/simulated/floor/grass,
 /area/vault/ironchef)
 "cb" = (
 /obj/effect/decal/warning_stripes{
@@ -884,10 +890,11 @@
 /turf/simulated/floor/engine,
 /area/vault/ironchef)
 "ce" = (
-/obj/machinery/light,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/weapon/disk/shuttle_coords/vault/ironchef,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "checker"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "cf" = (
@@ -895,16 +902,18 @@
 /turf/simulated/floor/plating,
 /area/vault/ironchef)
 "cg" = (
-/obj/structure/closet/crate/freezer,
-/turf/simulated/floor/plating,
+/obj/machinery/cooking/cerealmaker,
+/obj/machinery/light/he,
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
 /area/vault/ironchef)
 "ch" = (
-/obj/effect/decal/warning_stripes{
-	dir = 4;
-	icon_state = "loading_area";
-	tag = "icon-loading_area (EAST)"
+/obj/structure/kitchenspike,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
 	},
-/turf/simulated/floor/plating,
 /area/vault/ironchef)
 "ci" = (
 /obj/effect/decal/warning_stripes{
@@ -956,470 +965,468 @@ aa
 "}
 (2,1,1) = {"
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa
 aa
 "}
 (3,1,1) = {"
+aa
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+ac
+ac
+ac
+ac
 aM
+bo
+aQ
+aA
+br
+aJ
 aM
-aM
-aM
+bN
+bW
+ab
+aa
+aa
 aa
 aa
 "}
 (4,1,1) = {"
+aa
 ab
 ac
+bT
+ae
 ac
-ac
-ac
-ac
-ab
+aM
 aS
-bb
-bh
+as
+as
+as
+as
 aM
-bv
-bv
-ab
-bN
-bW
-bY
-aM
+bO
+bX
+ck
+aa
+aa
 aa
 aa
 "}
 (5,1,1) = {"
-ab
-ac
-ar
-av
-ar
-ac
-ab
-aT
-bc
-bi
-aM
-bv
-bv
-ab
-bO
-bX
-bY
-ck
 aa
-aa
-"}
-(6,1,1) = {"
 ab
 ac
-ar
 ar
 ar
 ac
 aM
 aM
 bd
+bL
+bL
+bL
 aM
-aM
-aM
-aM
-ab
 bP
 bY
-bY
-aM
+ab
+aa
+aa
 aa
 aa
 "}
-(7,1,1) = {"
+(6,1,1) = {"
+aa
 ab
-ac
 ac
 aw
 ac
 ac
 aM
-aU
+ai
 aW
-bj
-bq
+aT
 bw
-bD
-ab
+cg
+aM
 aM
 bZ
-aM
-aM
+ab
+aa
+aa
+aa
+aa
+"}
+(7,1,1) = {"
+aa
+ab
+ad
+as
+ch
+aG
+bL
+aV
+aW
+aW
+aW
+aW
+bD
+bn
+ar
+ab
+aa
+aa
 aa
 aa
 "}
 (8,1,1) = {"
+aa
 ab
-ad
-as
-as
-as
-aG
-aM
+aU
+at
+at
+ag
+bL
 aV
 aW
 aW
+bz
 aW
-aW
-aW
+bH
+bR
+ar
 ab
-bQ
-ar
-ar
-aM
+aa
+aa
 aa
 aa
 "}
 (9,1,1) = {"
+aa
 ab
-ae
+ay
 at
-ax
 at
-as
-aM
+bq
+bL
 aV
 aW
-bk
-br
-bx
 aW
-bL
+bx
+bt
+bH
 bR
 ar
-ar
-aM
+ab
+aa
+aa
 aa
 aa
 "}
 (10,1,1) = {"
-ab
-af
-at
-ay
-at
-aH
-aM
-aV
-aW
-bk
-aW
-by
-bE
-bL
-bR
-ar
-ce
-aM
 aa
-aa
-"}
-(11,1,1) = {"
 ab
-ag
+bu
 at
-as
 at
 as
 aN
 aW
 be
-bl
-bs
-bz
 aW
-bL
+by
+aW
+bH
 bR
 ar
+ab
+aa
+aa
+aa
+aa
+"}
+(11,1,1) = {"
+aa
+ab
+bh
+ax
+as
+as
+aO
+aW
+be
+aW
+bs
+aW
+aF
+bR
 ar
-aM
+ab
+aa
+aa
 aa
 aa
 "}
 (12,1,1) = {"
+aa
 ab
+az
+as
 ah
-as
-as
-as
-as
-aO
+aj
+aP
+aW
+bE
 aW
 aW
 aW
-aW
-aW
-bF
-bL
-bR
+af
 ar
-ar
-aM
+av
+ab
+aa
+aa
 aa
 aa
 "}
 (13,1,1) = {"
+aa
 ab
-ai
-as
-as
+bi
+ax
 as
 as
 aO
+bF
+bC
 aW
-aW
-bm
-aW
+bs
 aW
 bG
-bL
 bR
 ar
-ar
-aM
+ab
+aa
+aa
 aa
 aa
 "}
 (14,1,1) = {"
+aa
 ab
-aj
-as
-as
-as
-as
-aP
-aW
-aW
-bn
-bt
-bx
-bH
+am
+at
+at
+bv
 bL
+aW
+bQ
+aW
+by
+aW
+bH
 bR
 ar
-ce
-aM
+ab
+aa
+aa
 aa
 aa
 "}
 (15,1,1) = {"
+aa
 ab
-ak
-as
-as
-as
-as
-aM
+bl
+at
+at
+aE
+bL
 aX
 aW
 aW
-aW
-by
+bx
 bI
-bL
+bH
 bR
 ar
-ar
-aM
+ab
+aa
+aa
 aa
 aa
 "}
 (16,1,1) = {"
+aa
 ab
-al
-as
-as
-as
-as
-aM
+aD
+at
+at
+bk
+bL
 aY
 aW
 aW
-bs
 bA
 aW
-bL
+bH
 bR
 ar
-ar
-aM
+ab
+aa
+aa
 aa
 aa
 "}
 (17,1,1) = {"
+aa
 ab
-am
-as
+bJ
 as
 as
 aH
-aM
+bL
 aZ
-bf
 aW
-bn
+aW
 aW
 bf
+bD
+bg
+ar
 ab
-ab
-bC
-ab
-ab
+aa
+aa
 aa
 aa
 "}
 (18,1,1) = {"
+aa
 ab
+aR
 an
 an
-az
-an
-an
-aM
+al
+bL
 ba
 aW
-aW
-bu
+bV
 bB
-bJ
-ab
+bU
+aM
+aM
 bS
-bc
-cf
 ab
+aa
+aa
 aa
 aa
 "}
 (19,1,1) = {"
+aa
 ab
 ao
 ao
-aA
-aD
+ao
 aI
+aK
+bL
+ak
+bL
+bL
 aM
 aM
-aM
-bo
-aM
-ab
-ab
-ab
-bT
 bc
-cg
+bc
 ab
+aa
+aa
 aa
 aa
 "}
 (20,1,1) = {"
+aa
 ab
-ap
-ao
+ca
 aB
-aE
-aJ
-aI
-aM
-bg
+aC
+ao
+ao
+bL
 as
-bg
-ab
-bK
+bb
+bL
+bm
 bM
 bc
-ca
-ch
+bc
 ab
+aa
+aa
 aa
 aa
 "}
 (21,1,1) = {"
+aa
 ab
+bj
 ao
+ap
 ao
-aB
-aE
-aK
-aQ
-aM
+aq
+bL
 as
-as
-as
-ab
+ce
+bL
+cf
 bc
-bc
-bU
 cb
 ci
 ab
 aa
 aa
+aa
+aa
 "}
 (22,1,1) = {"
+aa
 ab
-aq
-au
+bK
 aC
-aF
+ao
 aL
-aR
-aM
-as
+au
+bL
 bp
 as
-bC
+bS
 bc
 bc
-bV
 cc
 cj
 ab
 aa
 aa
+aa
+aa
 "}
 (23,1,1) = {"
-ab
-ab
-ab
+aa
 ab
 ab
 ab
@@ -1435,6 +1442,8 @@ ab
 cd
 cd
 ab
+aa
+aa
 aa
 aa
 "}

--- a/maps/randomvaults/ironchef.dmm
+++ b/maps/randomvaults/ironchef.dmm
@@ -160,6 +160,7 @@
 /obj/structure/table,
 /obj/item/device/crank_charger,
 /obj/item/weapon/cell,
+/obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -862,6 +863,14 @@
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
+"Za" = (
+/obj/machinery/vending/wallmed2{
+	pixel_x = 30
+	},
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
 
 (1,1,1) = {"
 aa
@@ -1335,7 +1344,7 @@ aL
 aM
 ax
 bp
-as
+Za
 bl
 aM
 bc

--- a/maps/randomvaults/ironchef.dmm
+++ b/maps/randomvaults/ironchef.dmm
@@ -15,24 +15,10 @@
 	},
 /area/vault/ironchef)
 "ae" = (
-/obj/machinery/vending/old_vendotron,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "checker"
+/obj/machinery/vending/hydroseeds,
+/obj/machinery/light/he{
+	dir = 1
 	},
-/area/vault/ironchef)
-"af" = (
-/obj/structure/windoor_assembly/secure{
-	dir = 2
-	},
-/obj/structure/windoor_assembly/secure,
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
-"ag" = (
-/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -48,49 +34,38 @@
 	},
 /area/vault/ironchef)
 "ai" = (
-/obj/machinery/cooking/grill,
-/obj/machinery/light/he{
-	dir = 8
-	},
-/obj/machinery/camera{
-	name = "Iron Chef 1"
-	},
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
+/obj/structure/rack,
+/obj/item/weapon/fishtools/fish_egg_scoop,
+/obj/item/weapon/fishtools/fish_food,
+/obj/item/weapon/fishtools/fish_net,
+/obj/item/weapon/fishtools/fish_tank_brush,
+/obj/item/tool/crowbar,
+/obj/item/weapon/hatchet,
+/obj/item/weapon/extinguisher,
+/turf/simulated/floor/grass,
 /area/vault/ironchef)
 "aj" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/weapon/reagent_containers/glass/bucket,
-/obj/item/weapon/minihoe,
-/obj/item/weapon/storage/bag/plants,
-/obj/item/tool/wirecutters/clippers,
-/obj/machinery/light/he,
+/obj/structure/safe,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	dir = 5;
+	icon_state = "checker"
 	},
 /area/vault/ironchef)
 "ak" = (
-/obj/machinery/door/airlock/glass{
-	name = "Audience"
-	},
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/brewer/mapping,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "al" = (
-/obj/effect/decal/warning_stripes{
-	dir = 4;
-	icon_state = "warning"
-	},
-/obj/structure/reagent_dispensers/corn_oil_tank,
+/obj/structure/reagent_dispensers/sacid,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "am" = (
-/obj/machinery/vending/dinnerware,
+/obj/machinery/vending/meat,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -138,10 +113,11 @@
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
 "av" = (
-/obj/machinery/light/he,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/weapon/reagent_containers/food/snacks/meat/carpmeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/crabmeat,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "checker"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aw" = (
@@ -161,25 +137,23 @@
 	},
 /area/vault/ironchef)
 "ay" = (
-/obj/machinery/vending/voxseeds,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
+/obj/item/weapon/reagent_containers/food/snacks/beezeez,
+/obj/item/queen_bee/chill,
+/obj/item/queen_bee,
+/turf/simulated/floor/grass,
 /area/vault/ironchef)
 "az" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/drinks/shaker,
-/obj/machinery/chem_dispenser/soda_dispenser/mapping,
+/obj/structure/windoor_assembly/secure{
+	dir = 2
+	},
+/obj/structure/windoor_assembly/secure,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "aA" = (
-/obj/structure/rack,
-/obj/item/organ/internal/brain,
-/obj/item/clothing/head/butt,
-/obj/item/organ/internal/appendix,
-/obj/item/organ/internal/heart,
+/obj/structure/kitchenspike,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -189,26 +163,39 @@
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
 "aC" = (
-/mob/living/carbon/monkey,
-/turf/simulated/floor/grass,
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/condiment/vinegar{
+	pixel_x = -9
+	},
+/obj/item/weapon/reagent_containers/food/drinks/ice,
+/obj/item/weapon/reagent_containers/food/drinks/discount_sauce{
+	pixel_x = 9
+	},
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
 /area/vault/ironchef)
 "aD" = (
-/obj/machinery/vending/zamsnax,
+/obj/machinery/cooking/grill,
+/obj/machinery/light/he{
+	dir = 8
+	},
+/obj/machinery/camera{
+	name = "Iron Chef 1"
+	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "aE" = (
-/obj/machinery/chem_dispenser,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
+/mob/living/carbon/monkey,
+/turf/simulated/floor/grass,
 /area/vault/ironchef)
 "aF" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/decal/warning_stripes{
+	icon_state = "1"
 	},
 /turf/simulated/floor{
 	blocks_air = 0;
@@ -222,8 +209,7 @@
 	},
 /area/vault/ironchef)
 "aH" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -233,19 +219,9 @@
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
 "aJ" = (
-/obj/structure/rack,
-/obj/item/clothing/head/wizard,
-/obj/item/slime_extract/purple,
-/obj/item/slime_extract/purple,
-/obj/item/weapon/ectoplasm,
-/obj/item/weapon/ectoplasm,
-/obj/item/weapon/ectoplasm,
-/obj/item/clothing/mask/fakemoustache,
-/obj/item/slime_extract/grey,
-/obj/item/slime_extract/grey,
-/obj/item/stack/sheet/snow{
-	amount = 5
-	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/weapon/disk/shuttle_coords/vault/ironchef,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -289,30 +265,22 @@
 /turf/simulated/wall,
 /area/vault/ironchef)
 "aQ" = (
-/obj/structure/rack,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/customizable/vodka,
-/obj/item/weapon/reagent_containers/food/snacks/pimiento,
-/obj/item/weapon/reagent_containers/food/snacks/grown/kudzupod,
-/obj/item/weapon/reagent_containers/food/snacks/bustanuts,
-/obj/item/weapon/reagent_containers/food/drinks/coloring,
-/obj/item/weapon/reagent_containers/glass/beaker/vial/uranium,
-/obj/item/weapon/reagent_containers/glass/beaker/vial/radium,
-/obj/item/weapon/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/booze_dispenser/mapping,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aR" = (
-/obj/effect/decal/warning_stripes{
-	dir = 4;
-	icon_state = "warning"
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
 	},
-/obj/machinery/vending/snack,
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
+	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	dir = 5;
+	icon_state = "checker"
 	},
 /area/vault/ironchef)
 "aS" = (
@@ -324,19 +292,21 @@
 	},
 /area/vault/ironchef)
 "aT" = (
-/obj/machinery/cooking/deepfryer,
+/obj/effect/decal/warning_stripes{
+	dir = 4;
+	icon_state = "warning"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aU" = (
-/obj/machinery/vending/hydroseeds,
-/obj/machinery/light/he{
-	dir = 1
-	},
+/obj/machinery/processor,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "aV" = (
@@ -355,24 +325,22 @@
 	},
 /area/vault/ironchef)
 "aX" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/weapon/reagent_containers/food/snacks/meat/carpmeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/crabmeat,
+/obj/machinery/cooking/cerealmaker,
+/obj/machinery/light/he,
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "aY" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,
-/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,
-/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
-/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
-/obj/item/weapon/reagent_containers/food/snacks/meat/roach,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/weapon/minihoe,
+/obj/item/weapon/storage/bag/plants,
+/obj/item/tool/wirecutters/clippers,
+/obj/machinery/light/he,
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aZ" = (
@@ -382,9 +350,11 @@
 /obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
 /obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
 /obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
+/obj/machinery/light/he{
+	dir = 1
+	},
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "ba" = (
@@ -401,10 +371,9 @@
 	},
 /area/vault/ironchef)
 "bb" = (
-/obj/item/clothing/accessory/armband/cargo,
-/obj/item/clothing/gloves/brown/cargo,
-/obj/item/device/pda/cargo,
-/obj/structure/table,
+/obj/machinery/door/airlock/glass{
+	name = "Audience"
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -447,105 +416,79 @@
 	},
 /area/vault/ironchef)
 "bg" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/condiment/gravy/gravybig{
+	pixel_x = -9
 	},
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
+/obj/item/weapon/reagent_containers/food/condiment/cornoil{
+	pixel_x = -3
 	},
+/obj/item/weapon/reagent_containers/food/condiment/cinnamon{
+	pixel_x = 3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/soysauce{
+	pixel_x = 9
+	},
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
+/area/vault/ironchef)
+"bh" = (
+/obj/machinery/light/he,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "checker"
 	},
 /area/vault/ironchef)
-"bh" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/booze_dispenser/mapping,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
 "bi" = (
-/obj/machinery/vending/meat,
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/drinks/shaker,
+/obj/machinery/chem_dispenser/soda_dispenser/mapping,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
-"bj" = (
+"bk" = (
 /obj/machinery/apiary,
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
-"bk" = (
-/obj/machinery/chem_master,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
 "bl" = (
-/obj/machinery/cooking/still,
+/obj/structure/rack,
+/obj/item/clothing/head/wizard,
+/obj/item/slime_extract/purple,
+/obj/item/slime_extract/purple,
+/obj/item/weapon/ectoplasm,
+/obj/item/weapon/ectoplasm,
+/obj/item/weapon/ectoplasm,
+/obj/item/clothing/mask/fakemoustache,
+/obj/item/slime_extract/grey,
+/obj/item/slime_extract/grey,
+/obj/item/stack/sheet/snow{
+	amount = 5
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bm" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/dipping_sauce/queso{
+	pixel_y = 18
 	},
-/obj/structure/closet/crate/freezer,
-/turf/simulated/floor/plating,
-/area/vault/ironchef)
-"bn" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
+/obj/item/weapon/reagent_containers/food/dipping_sauce/salsa{
+	pixel_y = 13
 	},
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
+/obj/item/weapon/reagent_containers/food/dipping_sauce/hummus{
+	pixel_y = 8
 	},
+/obj/item/weapon/reagent_containers/food/dipping_sauce/guacamole,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "checker"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bo" = (
-/obj/structure/rack,
-/obj/item/robot_parts/head,
-/obj/item/weapon/handcuffs,
-/obj/item/weapon/paper,
-/obj/item/stack/rods,
-/obj/item/pipe,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/toy/crayon/blue,
-/obj/item/toy/crayon/blue,
-/obj/item/toy/crayon/blue,
-/obj/item/stack/sheet/cardboard{
-	amount = 10
-	},
-/obj/item/weapon/aiModule/core/asimov,
-/obj/item/stack/sheet/metal,
-/obj/item/weapon/cell,
-/obj/item/stack/cable_coil/yellow,
-/obj/item/stack/ore/glass,
-/obj/item/stack/ore/glass,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
-"bp" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
-"bq" = (
-/obj/structure/reagent_dispensers/sacid,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
-"br" = (
 /obj/structure/rack,
 /obj/item/stack/teeth/shark,
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube,
@@ -562,6 +505,31 @@
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
+"bp" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"bq" = (
+/obj/machinery/cooking/deepfryer,
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
+/area/vault/ironchef)
+"br" = (
+/obj/structure/rack,
+/obj/item/organ/internal/brain,
+/obj/item/clothing/head/butt,
+/obj/item/organ/internal/appendix,
+/obj/item/organ/internal/heart,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
 "bs" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/chefhat,
@@ -573,26 +541,37 @@
 	},
 /area/vault/ironchef)
 "bt" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "1"
-	},
+/obj/machinery/gibber,
+/obj/machinery/light/he,
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bu" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/brewer/mapping,
+/obj/structure/rack,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/customizable/vodka,
+/obj/item/weapon/reagent_containers/food/snacks/pimiento,
+/obj/item/weapon/reagent_containers/food/snacks/grown/kudzupod,
+/obj/item/weapon/reagent_containers/food/snacks/bustanuts,
+/obj/item/weapon/reagent_containers/food/drinks/coloring,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/uranium,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/radium,
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bv" = (
-/obj/machinery/chem_master/condimaster,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
 	},
+/obj/structure/closet/crate/freezer,
+/turf/simulated/floor/plating,
 /area/vault/ironchef)
 "bw" = (
 /obj/machinery/cooking/candy,
@@ -657,17 +636,9 @@
 	},
 /area/vault/ironchef)
 "bC" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/condiment/vinegar{
-	pixel_x = -9
-	},
-/obj/item/weapon/reagent_containers/food/drinks/ice,
-/obj/item/weapon/reagent_containers/food/drinks/discount_sauce{
-	pixel_x = 9
-	},
+/obj/machinery/vending/dinnerware,
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bD" = (
@@ -680,18 +651,7 @@
 /area/vault/ironchef)
 "bE" = (
 /obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/condiment/gravy/gravybig{
-	pixel_x = -9
-	},
-/obj/item/weapon/reagent_containers/food/condiment/cornoil{
-	pixel_x = -3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/cinnamon{
-	pixel_x = 3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/soysauce{
-	pixel_x = 9
-	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
@@ -716,11 +676,18 @@
 	},
 /area/vault/ironchef)
 "bH" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,
+/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,
+/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
+/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
+/obj/item/weapon/reagent_containers/food/snacks/meat/roach,
+/obj/effect/decal/warning_stripes{
+	dir = 4;
+	icon_state = "warning"
+	},
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bI" = (
@@ -733,24 +700,22 @@
 	},
 /area/vault/ironchef)
 "bJ" = (
-/obj/machinery/light/he{
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -32
+	},
+/obj/structure/bed/chair/comfy/brown{
 	dir = 1
 	},
-/obj/machinery/vending/discount,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	dir = 5;
+	icon_state = "checker"
 	},
 /area/vault/ironchef)
 "bK" = (
-/obj/structure/rack,
-/obj/item/weapon/fishtools/fish_egg_scoop,
-/obj/item/weapon/fishtools/fish_food,
-/obj/item/weapon/fishtools/fish_net,
-/obj/item/weapon/fishtools/fish_tank_brush,
-/obj/item/tool/crowbar,
-/obj/item/weapon/hatchet,
-/obj/item/weapon/extinguisher,
-/turf/simulated/floor/grass,
+/obj/machinery/chem_master/condimaster,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
 /area/vault/ironchef)
 "bL" = (
 /obj/structure/window/full/reinforced,
@@ -782,20 +747,9 @@
 /turf/simulated/floor/carpet,
 /area/vault/ironchef)
 "bQ" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/dipping_sauce/queso{
-	pixel_y = 18
-	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/salsa{
-	pixel_y = 13
-	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/hummus{
-	pixel_y = 8
-	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/guacamole,
+/obj/machinery/vending/zamsnax,
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bR" = (
@@ -814,27 +768,26 @@
 /turf/simulated/floor/plating,
 /area/vault/ironchef)
 "bT" = (
-/obj/structure/table/woodentable,
-/obj/item/clothing/gloves/ironchefgauntlets,
-/obj/item/weapon/reagent_containers/glass/beaker/vial/flavor,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/structure/reagent_dispensers/corn_oil_tank,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "checker"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bU" = (
-/obj/machinery/gibber,
-/obj/machinery/light/he,
+/obj/item/clothing/accessory/armband/cargo,
+/obj/item/clothing/gloves/brown/cargo,
+/obj/item/device/pda/cargo,
+/obj/structure/table,
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bV" = (
-/obj/machinery/processor,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
@@ -861,10 +814,28 @@
 /turf/simulated/floor/carpet,
 /area/vault/ironchef)
 "ca" = (
-/obj/item/weapon/reagent_containers/food/snacks/beezeez,
-/obj/item/queen_bee/chill,
-/obj/item/queen_bee,
-/turf/simulated/floor/grass,
+/obj/structure/rack,
+/obj/item/robot_parts/head,
+/obj/item/weapon/handcuffs,
+/obj/item/weapon/paper,
+/obj/item/stack/rods,
+/obj/item/pipe,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/toy/crayon/blue,
+/obj/item/toy/crayon/blue,
+/obj/item/toy/crayon/blue,
+/obj/item/stack/sheet/cardboard{
+	amount = 10
+	},
+/obj/item/weapon/aiModule/core/asimov,
+/obj/item/stack/sheet/metal,
+/obj/item/weapon/cell,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/stack/ore/glass,
+/obj/item/stack/ore/glass,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
 /area/vault/ironchef)
 "cb" = (
 /obj/effect/decal/warning_stripes{
@@ -890,11 +861,15 @@
 /turf/simulated/floor/engine,
 /area/vault/ironchef)
 "ce" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/weapon/disk/shuttle_coords/vault/ironchef,
+/obj/structure/table/woodentable,
+/obj/item/clothing/gloves/ironchefgauntlets,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/flavor,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	dir = 5;
+	icon_state = "checker"
 	},
 /area/vault/ironchef)
 "cf" = (
@@ -902,15 +877,13 @@
 /turf/simulated/floor/plating,
 /area/vault/ironchef)
 "cg" = (
-/obj/machinery/cooking/cerealmaker,
-/obj/machinery/light/he,
+/obj/machinery/chem_master,
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "ch" = (
-/obj/structure/kitchenspike,
+/obj/machinery/vending/voxseeds,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -993,11 +966,11 @@ ac
 ac
 ac
 aM
-bo
-aQ
-aA
+ca
+bu
 br
-aJ
+bo
+bl
 aM
 bN
 bW
@@ -1011,8 +984,8 @@ aa
 aa
 ab
 ac
-bT
-ae
+ce
+aj
 ac
 aM
 aS
@@ -1059,11 +1032,11 @@ aw
 ac
 ac
 aM
-ai
+aD
 aW
-aT
+bq
 bw
-cg
+aX
 aM
 aM
 bZ
@@ -1078,7 +1051,7 @@ aa
 ab
 ad
 as
-ch
+aA
 aG
 bL
 aV
@@ -1087,7 +1060,7 @@ aW
 aW
 aW
 bD
-bn
+bJ
 ar
 ab
 aa
@@ -1098,17 +1071,17 @@ aa
 (8,1,1) = {"
 aa
 ab
-aU
+ae
 at
 at
-ag
+bT
 bL
 aV
 aW
 aW
 bz
 aW
-bH
+bE
 bR
 ar
 ab
@@ -1120,17 +1093,17 @@ aa
 (9,1,1) = {"
 aa
 ab
-ay
+ch
 at
 at
-bq
+al
 bL
-aV
+aW
 aW
 aW
 bx
-bt
-bH
+aF
+bE
 bR
 ar
 ab
@@ -1142,7 +1115,7 @@ aa
 (10,1,1) = {"
 aa
 ab
-bu
+ak
 at
 at
 as
@@ -1152,7 +1125,7 @@ be
 aW
 by
 aW
-bH
+bE
 bR
 ar
 ab
@@ -1164,8 +1137,8 @@ aa
 (11,1,1) = {"
 aa
 ab
-bh
-ax
+aQ
+as
 as
 as
 aO
@@ -1174,7 +1147,7 @@ be
 aW
 bs
 aW
-aF
+bV
 bR
 ar
 ab
@@ -1186,19 +1159,19 @@ aa
 (12,1,1) = {"
 aa
 ab
-az
-as
+bi
+ax
 ah
-aj
+aY
 aP
 aW
-bE
+bg
 aW
 aW
 aW
-af
+az
 ar
-av
+bh
 ab
 aa
 aa
@@ -1208,13 +1181,13 @@ aa
 (13,1,1) = {"
 aa
 ab
-bi
-ax
+am
+as
 as
 as
 aO
 bF
-bC
+aC
 aW
 bs
 aW
@@ -1230,17 +1203,17 @@ aa
 (14,1,1) = {"
 aa
 ab
-am
+bC
 at
 at
-bv
+as
 bL
 aW
-bQ
+bm
 aW
 by
 aW
-bH
+bE
 bR
 ar
 ab
@@ -1252,17 +1225,17 @@ aa
 (15,1,1) = {"
 aa
 ab
-bl
+bQ
 at
 at
-aE
+bK
 bL
-aX
+aW
 aW
 aW
 bx
 bI
-bH
+bE
 bR
 ar
 ab
@@ -1274,17 +1247,17 @@ aa
 (16,1,1) = {"
 aa
 ab
-aD
+av
 at
 at
-bk
+cg
 bL
-aY
+aV
 aW
 aW
 bA
 aW
-bH
+bE
 bR
 ar
 ab
@@ -1296,18 +1269,18 @@ aa
 (17,1,1) = {"
 aa
 ab
-bJ
+aZ
 as
 as
 aH
 bL
-aZ
+aV
 aW
 aW
 aW
 bf
 bD
-bg
+aR
 ar
 ab
 aa
@@ -1318,16 +1291,16 @@ aa
 (18,1,1) = {"
 aa
 ab
-aR
+bH
 an
 an
-al
+aT
 bL
 ba
 aW
-bV
+aU
 bB
-bU
+bt
 aM
 aM
 bS
@@ -1346,9 +1319,9 @@ ao
 aI
 aK
 bL
-ak
-bL
-bL
+bb
+aM
+aM
 aM
 aM
 bc
@@ -1362,16 +1335,16 @@ aa
 (20,1,1) = {"
 aa
 ab
-ca
+ay
 aB
-aC
+aE
 ao
 ao
 bL
 as
-bb
-bL
-bm
+bU
+aM
+bv
 bM
 bc
 bc
@@ -1384,15 +1357,15 @@ aa
 (21,1,1) = {"
 aa
 ab
-bj
+bk
 ao
 ap
 ao
 aq
 bL
 as
-ce
-bL
+aJ
+aM
 cf
 bc
 cb
@@ -1406,8 +1379,8 @@ aa
 (22,1,1) = {"
 aa
 ab
-bK
-aC
+ai
+aE
 ao
 aL
 au

--- a/maps/randomvaults/ironchef.dmm
+++ b/maps/randomvaults/ironchef.dmm
@@ -271,13 +271,6 @@
 "aM" = (
 /turf/simulated/wall,
 /area/vault/ironchef)
-"aN" = (
-/obj/machinery/smartfridge,
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
 "aO" = (
 /obj/machinery/door/airlock/glass{
 	name = "Storage"
@@ -884,7 +877,7 @@
 /turf/simulated/floor/plating,
 /area/vault/ironchef)
 "Rr" = (
-/obj/machinery/smartfridge/drinks/filled,
+/obj/machinery/smartfridge/filled,
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
@@ -1085,7 +1078,7 @@ ay
 at
 at
 cg
-Rr
+bC
 aW
 aW
 aW
@@ -1107,7 +1100,7 @@ bQ
 at
 at
 ah
-aN
+Rr
 aW
 aW
 aW

--- a/maps/randomvaults/ironchef.dmm
+++ b/maps/randomvaults/ironchef.dmm
@@ -877,6 +877,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/vault/ironchef)
+"vi" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/weapon/minihoe,
+/obj/item/weapon/storage/bag/plants,
+/obj/item/tool/wirecutters/clippers,
+/obj/item/weapon/fishtools/fish_egg_scoop,
+/obj/item/weapon/fishtools/fish_food,
+/obj/item/weapon/fishtools/fish_net,
+/obj/item/weapon/fishtools/fishtank_helper,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
 "Rr" = (
 /obj/machinery/smartfridge/condiments,
 /turf/simulated/floor{
@@ -1188,7 +1202,7 @@ ab
 bu
 at
 at
-ah
+vi
 aK
 aW
 aW

--- a/maps/randomvaults/ironchef.dmm
+++ b/maps/randomvaults/ironchef.dmm
@@ -877,7 +877,7 @@
 /turf/simulated/floor/plating,
 /area/vault/ironchef)
 "Rr" = (
-/obj/machinery/smartfridge/filled,
+/obj/machinery/smartfridge/condiments,
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"

--- a/maps/randomvaults/ironchef.dmm
+++ b/maps/randomvaults/ironchef.dmm
@@ -77,20 +77,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
-"al" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/condiment/vinegar{
-	pixel_x = -9
-	},
-/obj/item/weapon/reagent_containers/food/drinks/ice,
-/obj/item/weapon/reagent_containers/food/drinks/discount_sauce{
-	pixel_x = 9
-	},
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
 "am" = (
 /obj/structure/rack,
 /obj/item/stack/teeth/shark,
@@ -273,9 +259,8 @@
 /obj/item/fish_eggs/salmon,
 /obj/item/fish_eggs/salmon,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "vault";
-	tag = "icon-vault (NORTH)"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "aL" = (
@@ -297,7 +282,8 @@
 	name = "Storage"
 	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "aP" = (
@@ -397,25 +383,6 @@
 	name = "Special Ingredients"
 	},
 /turf/simulated/floor/plating,
-/area/vault/ironchef)
-"be" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/condiment/honey{
-	pixel_x = -9
-	},
-/obj/item/weapon/reagent_containers/food/condiment/hotsauce{
-	pixel_x = -3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/coldsauce{
-	pixel_x = 3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/ketchup{
-	pixel_x = 9
-	},
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
 /area/vault/ironchef)
 "bf" = (
 /obj/machinery/bot/cleanbot{
@@ -627,17 +594,7 @@
 	},
 /area/vault/ironchef)
 "bC" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/dipping_sauce/queso{
-	pixel_y = 18
-	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/salsa{
-	pixel_y = 13
-	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/hummus{
-	pixel_y = 8
-	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/guacamole,
+/obj/structure/window/full/reinforced,
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
@@ -791,25 +748,6 @@
 	icon_state = "checker"
 	},
 /area/vault/ironchef)
-"bU" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/condiment/gravy/gravybig{
-	pixel_x = -9
-	},
-/obj/item/weapon/reagent_containers/food/condiment/cornoil{
-	pixel_x = -3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/cinnamon{
-	pixel_x = 3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/soysauce{
-	pixel_x = 9
-	},
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
 "bV" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor{
@@ -916,6 +854,13 @@
 	dir = 2
 	},
 /turf/simulated/floor/carpet,
+/area/vault/ironchef)
+"Rr" = (
+/obj/machinery/smartfridge/drinks/filled,
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
 /area/vault/ironchef)
 
 (1,1,1) = {"
@@ -1057,7 +1002,7 @@ ad
 as
 as
 aG
-bL
+bC
 aV
 aW
 aW
@@ -1079,7 +1024,7 @@ cf
 at
 at
 aQ
-bL
+bC
 aV
 aW
 aW
@@ -1101,7 +1046,7 @@ ay
 at
 at
 cg
-bL
+Rr
 aW
 aW
 aW
@@ -1125,7 +1070,7 @@ at
 ah
 aN
 aW
-be
+aW
 aW
 by
 aW
@@ -1147,7 +1092,7 @@ as
 as
 aO
 aW
-be
+aW
 aW
 bs
 aW
@@ -1169,7 +1114,7 @@ as
 bh
 aP
 aW
-bU
+aW
 aW
 aW
 aW
@@ -1191,7 +1136,7 @@ as
 as
 aO
 bF
-al
+aW
 aW
 bs
 aW
@@ -1213,7 +1158,7 @@ at
 ah
 aK
 aW
-bC
+aW
 aW
 by
 aW
@@ -1233,7 +1178,7 @@ bg
 at
 at
 aF
-bL
+bC
 aW
 aW
 aW
@@ -1255,7 +1200,7 @@ ak
 at
 at
 bV
-bL
+bC
 aV
 aW
 aW
@@ -1277,7 +1222,7 @@ bH
 as
 as
 aH
-bL
+bC
 aV
 aW
 aW
@@ -1299,7 +1244,7 @@ bj
 an
 an
 ae
-bL
+bC
 ba
 aW
 br

--- a/maps/randomvaults/ironchef.dmm
+++ b/maps/randomvaults/ironchef.dmm
@@ -15,35 +15,32 @@
 	},
 /area/vault/ironchef)
 "ae" = (
-/obj/item/clothing/accessory/armband/cargo,
-/obj/item/clothing/gloves/brown/cargo,
-/obj/item/device/pda/cargo,
-/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/snacks/beezeez,
+/obj/item/queen_bee/chill,
+/obj/item/queen_bee,
+/turf/simulated/floor/grass,
+/area/vault/ironchef)
+"af" = (
+/obj/structure/rack,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/customizable/vodka,
+/obj/item/weapon/reagent_containers/food/snacks/pimiento,
+/obj/item/weapon/reagent_containers/food/snacks/grown/kudzupod,
+/obj/item/weapon/reagent_containers/food/snacks/bustanuts,
+/obj/item/weapon/reagent_containers/food/drinks/coloring,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/uranium,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/radium,
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
-"af" = (
-/obj/structure/kitchenspike,
-/turf/simulated/floor/grass,
-/area/vault/ironchef)
 "ag" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/condiment/gravy/gravybig{
-	pixel_x = -9
-	},
-/obj/item/weapon/reagent_containers/food/condiment/cornoil{
-	pixel_x = -3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/cinnamon{
-	pixel_x = 3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/soysauce{
-	pixel_x = 9
-	},
+/obj/machinery/vending/meat,
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "ah" = (
@@ -57,56 +54,61 @@
 	},
 /area/vault/ironchef)
 "ai" = (
-/obj/machinery/vending/voxseeds,
+/obj/structure/rack,
+/obj/item/stack/teeth/shark,
+/obj/item/weapon/reagent_containers/food/snacks/monkeycube,
+/obj/item/weapon/reagent_containers/food/snacks/meat/diona,
+/obj/item/weapon/reagent_containers/food/snacks/meat/hive,
+/obj/item/weapon/reagent_containers/food/snacks/meat/bearmeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box/pig,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box/pig,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aj" = (
-/obj/structure/table/woodentable,
-/obj/item/clothing/gloves/ironchefgauntlets,
-/obj/item/weapon/reagent_containers/glass/beaker/vial/flavor,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/chem_master,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "checker"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "ak" = (
-/obj/structure/rack,
-/obj/item/clothing/head/wizard,
-/obj/item/slime_extract/purple,
-/obj/item/slime_extract/purple,
-/obj/item/weapon/ectoplasm,
-/obj/item/weapon/ectoplasm,
-/obj/item/weapon/ectoplasm,
-/obj/item/clothing/mask/fakemoustache,
-/obj/item/slime_extract/grey,
-/obj/item/slime_extract/grey,
-/obj/item/stack/sheet/snow{
-	amount = 5
-	},
+/obj/structure/table,
+/obj/item/device/crank_charger,
+/obj/item/weapon/cell,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "al" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/drinks/shaker,
-/obj/machinery/chem_dispenser/soda_dispenser/mapping,
+/obj/machinery/vending/hydroseeds,
+/obj/machinery/light/he{
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "am" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/dipping_sauce/queso{
+	pixel_y = 18
 	},
-/obj/structure/closet/crate/freezer,
-/turf/simulated/floor/plating,
+/obj/item/weapon/reagent_containers/food/dipping_sauce/salsa{
+	pixel_y = 13
+	},
+/obj/item/weapon/reagent_containers/food/dipping_sauce/hummus{
+	pixel_y = 8
+	},
+/obj/item/weapon/reagent_containers/food/dipping_sauce/guacamole,
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
 /area/vault/ironchef)
 "an" = (
 /obj/effect/decal/warning_stripes{
@@ -151,15 +153,10 @@
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
 "av" = (
-/obj/structure/rack,
-/obj/item/weapon/fishtools/fish_egg_scoop,
-/obj/item/weapon/fishtools/fish_food,
-/obj/item/weapon/fishtools/fish_net,
-/obj/item/weapon/fishtools/fish_tank_brush,
-/obj/item/tool/crowbar,
-/obj/item/weapon/hatchet,
-/obj/item/weapon/extinguisher,
-/turf/simulated/floor/grass,
+/obj/structure/reagent_dispensers/corn_oil_tank,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
 /area/vault/ironchef)
 "aw" = (
 /obj/machinery/door/airlock/vault{
@@ -172,41 +169,35 @@
 	},
 /area/vault/ironchef)
 "ax" = (
-/obj/machinery/gibber,
 /obj/machinery/light/he,
+/obj/machinery/bot/farmbot,
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "ay" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/condiment/vinegar{
-	pixel_x = -9
-	},
-/obj/item/weapon/reagent_containers/food/drinks/ice,
-/obj/item/weapon/reagent_containers/food/drinks/discount_sauce{
-	pixel_x = 9
-	},
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
-"az" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
-	},
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "checker"
-	},
+/obj/structure/kitchenspike,
+/turf/simulated/floor/grass,
 /area/vault/ironchef)
 "aA" = (
-/obj/machinery/vending/meat,
+/obj/structure/rack,
+/obj/item/robot_parts/head,
+/obj/item/weapon/handcuffs,
+/obj/item/weapon/paper,
+/obj/item/stack/rods,
+/obj/item/pipe,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/toy/crayon/blue,
+/obj/item/toy/crayon/blue,
+/obj/item/toy/crayon/blue,
+/obj/item/stack/sheet/cardboard{
+	amount = 10
+	},
+/obj/item/weapon/aiModule/core/asimov,
+/obj/item/stack/sheet/metal,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/stack/ore/glass,
+/obj/item/stack/ore/glass,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -216,27 +207,25 @@
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
 "aC" = (
-/mob/living/carbon/monkey,
-/turf/simulated/floor/grass,
+/obj/machinery/gibber,
+/obj/machinery/light/he,
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
 /area/vault/ironchef)
 "aD" = (
-/obj/machinery/vending/zamsnax,
+/obj/machinery/vending/voxseeds,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aE" = (
-/obj/machinery/door/airlock/glass{
-	name = "Audience"
-	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
+/mob/living/carbon/monkey,
+/turf/simulated/floor/grass,
 /area/vault/ironchef)
 "aF" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/weapon/disk/shuttle_coords/vault/ironchef,
+/obj/structure/closet/crate/freezer,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -259,13 +248,9 @@
 /area/vault/ironchef)
 "aJ" = (
 /obj/structure/table/reinforced,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/machinery/chem_dispenser/brewer/mapping,
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aK" = (
@@ -307,20 +292,19 @@
 /turf/simulated/wall,
 /area/vault/ironchef)
 "aQ" = (
-/obj/machinery/light/he,
+/obj/structure/safe,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "checker"
 	},
 /area/vault/ironchef)
 "aR" = (
-/obj/structure/rack,
-/obj/item/organ/internal/brain,
-/obj/item/clothing/head/butt,
-/obj/item/organ/internal/appendix,
-/obj/item/organ/internal/heart,
+/obj/effect/decal/warning_stripes{
+	icon_state = "1"
+	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "aS" = (
@@ -332,16 +316,15 @@
 	},
 /area/vault/ironchef)
 "aT" = (
-/obj/machinery/vending/dinnerware,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
 	},
-/area/vault/ironchef)
-"aU" = (
-/obj/machinery/cooking/deepfryer,
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
+	},
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "checker"
 	},
 /area/vault/ironchef)
 "aV" = (
@@ -360,31 +343,21 @@
 	},
 /area/vault/ironchef)
 "aX" = (
-/obj/structure/reagent_dispensers/sacid,
+/obj/machinery/apiary,
+/turf/simulated/floor/grass,
+/area/vault/ironchef)
+"aY" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/weapon/disk/shuttle_coords/vault/ironchef,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
-"aY" = (
-/obj/structure/rack,
-/obj/item/robot_parts/head,
-/obj/item/weapon/handcuffs,
-/obj/item/weapon/paper,
-/obj/item/stack/rods,
-/obj/item/pipe,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/toy/crayon/blue,
-/obj/item/toy/crayon/blue,
-/obj/item/toy/crayon/blue,
-/obj/item/stack/sheet/cardboard{
-	amount = 10
-	},
-/obj/item/weapon/aiModule/core/asimov,
-/obj/item/stack/sheet/metal,
-/obj/item/weapon/cell,
-/obj/item/stack/cable_coil/yellow,
-/obj/item/stack/ore/glass,
-/obj/item/stack/ore/glass,
+"aZ" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/weapon/reagent_containers/food/snacks/meat/carpmeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/crabmeat,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -403,8 +376,13 @@
 	},
 /area/vault/ironchef)
 "bb" = (
-/obj/machinery/cooking/cerealmaker,
-/obj/machinery/light/he,
+/obj/machinery/cooking/grill,
+/obj/machinery/light/he{
+	dir = 8
+	},
+/obj/machinery/camera{
+	name = "Iron Chef 1"
+	},
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
@@ -448,74 +426,71 @@
 	},
 /area/vault/ironchef)
 "bg" = (
-/obj/machinery/vending/hydroseeds,
-/obj/machinery/light/he{
-	dir = 1
+/obj/effect/decal/warning_stripes{
+	dir = 4;
+	icon_state = "warning"
 	},
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bh" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/weapon/reagent_containers/food/snacks/meat/carpmeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/crabmeat,
+/obj/item/clothing/accessory/armband/cargo,
+/obj/item/clothing/gloves/brown/cargo,
+/obj/item/device/pda/cargo,
+/obj/structure/table,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bi" = (
-/obj/machinery/light/he,
-/obj/machinery/bot/farmbot,
+/obj/machinery/cart/cargo,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bj" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
+/obj/machinery/chem_master/condimaster,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
 	},
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
-	},
+/area/vault/ironchef)
+"bk" = (
+/obj/machinery/light/he,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "checker"
 	},
 /area/vault/ironchef)
-"bk" = (
-/obj/machinery/chem_master,
+"bl" = (
+/obj/structure/rack,
+/obj/item/organ/internal/brain,
+/obj/item/clothing/head/butt,
+/obj/item/organ/internal/appendix,
+/obj/item/organ/internal/heart,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bm" = (
-/obj/structure/safe,
+/obj/machinery/processor,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "checker"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bn" = (
-/obj/structure/rack,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/customizable/vodka,
-/obj/item/weapon/reagent_containers/food/snacks/pimiento,
-/obj/item/weapon/reagent_containers/food/snacks/grown/kudzupod,
-/obj/item/weapon/reagent_containers/food/snacks/bustanuts,
-/obj/item/weapon/reagent_containers/food/drinks/coloring,
-/obj/item/weapon/reagent_containers/glass/beaker/vial/uranium,
-/obj/item/weapon/reagent_containers/glass/beaker/vial/radium,
-/obj/item/weapon/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/machinery/cooking/cerealmaker,
+/obj/machinery/light/he,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bo" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/booze_dispenser/mapping,
+/obj/machinery/vending/dinnerware,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -528,8 +503,22 @@
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
+"bq" = (
+/obj/machinery/cooking/deepfryer,
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
+/area/vault/ironchef)
 "br" = (
-/obj/machinery/apiary,
+/obj/structure/rack,
+/obj/item/weapon/fishtools/fish_egg_scoop,
+/obj/item/weapon/fishtools/fish_food,
+/obj/item/weapon/fishtools/fish_net,
+/obj/item/weapon/fishtools/fish_tank_brush,
+/obj/item/tool/crowbar,
+/obj/item/weapon/hatchet,
+/obj/item/weapon/extinguisher,
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
 "bs" = (
@@ -543,37 +532,48 @@
 	},
 /area/vault/ironchef)
 "bt" = (
-/obj/item/weapon/reagent_containers/food/snacks/beezeez,
-/obj/item/queen_bee/chill,
-/obj/item/queen_bee,
-/turf/simulated/floor/grass,
-/area/vault/ironchef)
-"bu" = (
-/obj/machinery/cooking/grill,
-/obj/machinery/light/he{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/condiment/gravy/gravybig{
+	pixel_x = -9
 	},
-/obj/machinery/camera{
-	name = "Iron Chef 1"
+/obj/item/weapon/reagent_containers/food/condiment/cornoil{
+	pixel_x = -3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/cinnamon{
+	pixel_x = 3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/soysauce{
+	pixel_x = 9
 	},
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
-"bv" = (
+"bu" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,
-/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,
-/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
-/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
-/obj/item/weapon/reagent_containers/food/snacks/meat/roach,
-/obj/effect/decal/warning_stripes{
-	dir = 4;
-	icon_state = "warning"
+/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
+/obj/machinery/light/he{
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"bv" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -32
+	},
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "checker"
 	},
 /area/vault/ironchef)
 "bw" = (
@@ -639,8 +639,7 @@
 	},
 /area/vault/ironchef)
 "bC" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/brewer/mapping,
+/obj/machinery/vending/zamsnax,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -680,9 +679,14 @@
 	},
 /area/vault/ironchef)
 "bH" = (
-/obj/structure/reagent_dispensers/corn_oil_tank,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bI" = (
@@ -695,19 +699,21 @@
 	},
 /area/vault/ironchef)
 "bJ" = (
-/obj/machinery/processor,
+/obj/structure/windoor_assembly/secure{
+	dir = 2
+	},
+/obj/structure/windoor_assembly/secure,
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bK" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "1"
+/obj/machinery/door/airlock/glass{
+	name = "Audience"
 	},
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bL" = (
@@ -755,51 +761,34 @@
 /turf/simulated/floor/plating,
 /area/vault/ironchef)
 "bT" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
-/obj/machinery/light/he{
-	dir = 1
-	},
+/obj/structure/reagent_dispensers/sacid,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bU" = (
-/obj/structure/rack,
-/obj/item/stack/teeth/shark,
-/obj/item/weapon/reagent_containers/food/snacks/monkeycube,
-/obj/item/weapon/reagent_containers/food/snacks/meat/diona,
-/obj/item/weapon/reagent_containers/food/snacks/meat/hive,
-/obj/item/weapon/reagent_containers/food/snacks/meat/bearmeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box/pig,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box/pig,
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/booze_dispenser/mapping,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bV" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/dipping_sauce/queso{
-	pixel_y = 18
+/obj/structure/rack,
+/obj/item/clothing/head/wizard,
+/obj/item/slime_extract/purple,
+/obj/item/slime_extract/purple,
+/obj/item/weapon/ectoplasm,
+/obj/item/weapon/ectoplasm,
+/obj/item/weapon/ectoplasm,
+/obj/item/clothing/mask/fakemoustache,
+/obj/item/slime_extract/grey,
+/obj/item/slime_extract/grey,
+/obj/item/stack/sheet/snow{
+	amount = 5
 	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/salsa{
-	pixel_y = 13
-	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/hummus{
-	pixel_y = 8
-	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/guacamole,
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bW" = (
@@ -823,13 +812,12 @@
 /turf/simulated/floor/carpet,
 /area/vault/ironchef)
 "ca" = (
-/obj/structure/windoor_assembly/secure{
-	dir = 2
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/structure/windoor_assembly/secure,
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "cb" = (
@@ -856,22 +844,50 @@
 /turf/simulated/floor/engine,
 /area/vault/ironchef)
 "ce" = (
-/obj/machinery/chem_master/condimaster,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,
+/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,
+/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
+/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
+/obj/item/weapon/reagent_containers/food/snacks/meat/roach,
+/obj/effect/decal/warning_stripes{
+	dir = 4;
+	icon_state = "warning"
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "cf" = (
-/obj/machinery/cart/cargo,
-/turf/simulated/floor/plating,
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/condiment/vinegar{
+	pixel_x = -9
+	},
+/obj/item/weapon/reagent_containers/food/drinks/ice,
+/obj/item/weapon/reagent_containers/food/drinks/discount_sauce{
+	pixel_x = 9
+	},
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
 /area/vault/ironchef)
 "cg" = (
-/obj/effect/decal/warning_stripes{
-	dir = 4;
-	icon_state = "warning"
+/obj/structure/table/woodentable,
+/obj/item/clothing/gloves/ironchefgauntlets,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/flavor,
+/obj/machinery/light/small{
+	dir = 8
 	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "checker"
+	},
+/area/vault/ironchef)
+"ch" = (
 /obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/food/drinks/shaker,
+/obj/machinery/chem_dispenser/soda_dispenser/mapping,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -954,11 +970,11 @@ ac
 ac
 ac
 aM
-aY
-bn
-aR
-bU
-ak
+aA
+af
+bl
+ai
+bV
 aM
 bN
 bW
@@ -972,8 +988,8 @@ aa
 aa
 ab
 ac
-aj
-bm
+cg
+aQ
 ac
 aM
 aS
@@ -1020,11 +1036,11 @@ aw
 ac
 ac
 aM
-bu
-aW
-aU
-bw
 bb
+aW
+bq
+bw
+bn
 aM
 aM
 bZ
@@ -1048,7 +1064,7 @@ aW
 aW
 aW
 bD
-az
+bv
 ar
 ab
 aa
@@ -1059,10 +1075,10 @@ aa
 (8,1,1) = {"
 aa
 ab
-bg
+al
 at
 at
-bH
+av
 bL
 aV
 aW
@@ -1081,16 +1097,16 @@ aa
 (9,1,1) = {"
 aa
 ab
-ai
+aD
 at
 at
-aX
+bT
 bL
 aW
 aW
 aW
 bx
-bK
+aR
 bE
 bR
 ar
@@ -1103,7 +1119,7 @@ aa
 (10,1,1) = {"
 aa
 ab
-bC
+aJ
 at
 at
 ah
@@ -1125,7 +1141,7 @@ aa
 (11,1,1) = {"
 aa
 ab
-bo
+bU
 as
 as
 as
@@ -1135,7 +1151,7 @@ be
 aW
 bs
 aW
-aJ
+bH
 bR
 ar
 ab
@@ -1147,19 +1163,19 @@ aa
 (12,1,1) = {"
 aa
 ab
-al
+ch
 as
 as
-bi
+ax
 aP
 aW
-ag
+bt
 aW
 aW
 aW
-ca
+bJ
 ar
-aQ
+bk
 ab
 aa
 aa
@@ -1169,13 +1185,13 @@ aa
 (13,1,1) = {"
 aa
 ab
-aA
+ag
 as
 as
 as
 aO
 bF
-ay
+cf
 aW
 bs
 aW
@@ -1191,13 +1207,13 @@ aa
 (14,1,1) = {"
 aa
 ab
-aT
+bo
 at
 at
 ah
-bL
+aK
 aW
-bV
+am
 aW
 by
 aW
@@ -1213,10 +1229,10 @@ aa
 (15,1,1) = {"
 aa
 ab
-aD
+bC
 at
 at
-ce
+bj
 bL
 aW
 aW
@@ -1235,10 +1251,10 @@ aa
 (16,1,1) = {"
 aa
 ab
-bh
+aZ
 at
 at
-bk
+aj
 bL
 aV
 aW
@@ -1257,7 +1273,7 @@ aa
 (17,1,1) = {"
 aa
 ab
-bT
+bu
 as
 as
 aH
@@ -1268,7 +1284,7 @@ aW
 aW
 bf
 bD
-bj
+aT
 ar
 ab
 aa
@@ -1279,16 +1295,16 @@ aa
 (18,1,1) = {"
 aa
 ab
-bv
+ce
 an
 an
-cg
+bg
 bL
 ba
 aW
-bJ
+bm
 bB
-ax
+aC
 aM
 aM
 bS
@@ -1301,18 +1317,18 @@ aa
 (19,1,1) = {"
 aa
 ab
-af
+ay
 ao
 ao
 aI
-aK
-bL
-aE
+aM
+aM
+bK
 aM
 aM
 aM
 aM
-bc
+bM
 bc
 ab
 aa
@@ -1323,17 +1339,17 @@ aa
 (20,1,1) = {"
 aa
 ab
-bt
-aB
-aC
-ao
-ao
-bL
-as
 ae
+aB
+aE
+au
 aM
-am
-bM
+bh
+as
+ca
+as
+bS
+bc
 bc
 bc
 ab
@@ -1345,16 +1361,16 @@ aa
 (21,1,1) = {"
 aa
 ab
-br
+aX
 ao
 ap
-ao
 aq
-bL
-as
-aF
 aM
-cf
+aY
+as
+as
+bi
+aM
 bc
 cb
 ci
@@ -1367,16 +1383,16 @@ aa
 (22,1,1) = {"
 aa
 ab
-av
-aC
+br
+aE
 ao
 aL
-au
-bL
+aM
+ak
 bp
 as
-bS
-bc
+aF
+aM
 bc
 cc
 cj

--- a/maps/randomvaults/ironchef.dmm
+++ b/maps/randomvaults/ironchef.dmm
@@ -15,12 +15,35 @@
 	},
 /area/vault/ironchef)
 "ae" = (
-/obj/machinery/vending/hydroseeds,
-/obj/machinery/light/he{
-	dir = 1
-	},
+/obj/item/clothing/accessory/armband/cargo,
+/obj/item/clothing/gloves/brown/cargo,
+/obj/item/device/pda/cargo,
+/obj/structure/table,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"af" = (
+/obj/structure/kitchenspike,
+/turf/simulated/floor/grass,
+/area/vault/ironchef)
+"ag" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/condiment/gravy/gravybig{
+	pixel_x = -9
+	},
+/obj/item/weapon/reagent_containers/food/condiment/cornoil{
+	pixel_x = -3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/cinnamon{
+	pixel_x = 3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/soysauce{
+	pixel_x = 9
+	},
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "ah" = (
@@ -34,41 +57,56 @@
 	},
 /area/vault/ironchef)
 "ai" = (
-/obj/structure/rack,
-/obj/item/weapon/fishtools/fish_egg_scoop,
-/obj/item/weapon/fishtools/fish_food,
-/obj/item/weapon/fishtools/fish_net,
-/obj/item/weapon/fishtools/fish_tank_brush,
-/obj/item/tool/crowbar,
-/obj/item/weapon/hatchet,
-/obj/item/weapon/extinguisher,
-/turf/simulated/floor/grass,
+/obj/machinery/vending/voxseeds,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
 /area/vault/ironchef)
 "aj" = (
-/obj/structure/safe,
+/obj/structure/table/woodentable,
+/obj/item/clothing/gloves/ironchefgauntlets,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/flavor,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "checker"
 	},
 /area/vault/ironchef)
 "ak" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/brewer/mapping,
+/obj/structure/rack,
+/obj/item/clothing/head/wizard,
+/obj/item/slime_extract/purple,
+/obj/item/slime_extract/purple,
+/obj/item/weapon/ectoplasm,
+/obj/item/weapon/ectoplasm,
+/obj/item/weapon/ectoplasm,
+/obj/item/clothing/mask/fakemoustache,
+/obj/item/slime_extract/grey,
+/obj/item/slime_extract/grey,
+/obj/item/stack/sheet/snow{
+	amount = 5
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "al" = (
-/obj/structure/reagent_dispensers/sacid,
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/drinks/shaker,
+/obj/machinery/chem_dispenser/soda_dispenser/mapping,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "am" = (
-/obj/machinery/vending/meat,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
 	},
+/obj/structure/closet/crate/freezer,
+/turf/simulated/floor/plating,
 /area/vault/ironchef)
 "an" = (
 /obj/effect/decal/warning_stripes{
@@ -113,12 +151,15 @@
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
 "av" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/weapon/reagent_containers/food/snacks/meat/carpmeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/crabmeat,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
+/obj/structure/rack,
+/obj/item/weapon/fishtools/fish_egg_scoop,
+/obj/item/weapon/fishtools/fish_food,
+/obj/item/weapon/fishtools/fish_net,
+/obj/item/weapon/fishtools/fish_tank_brush,
+/obj/item/tool/crowbar,
+/obj/item/weapon/hatchet,
+/obj/item/weapon/extinguisher,
+/turf/simulated/floor/grass,
 /area/vault/ironchef)
 "aw" = (
 /obj/machinery/door/airlock/vault{
@@ -131,38 +172,14 @@
 	},
 /area/vault/ironchef)
 "ax" = (
-/obj/machinery/bot/farmbot,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
-"ay" = (
-/obj/item/weapon/reagent_containers/food/snacks/beezeez,
-/obj/item/queen_bee/chill,
-/obj/item/queen_bee,
-/turf/simulated/floor/grass,
-/area/vault/ironchef)
-"az" = (
-/obj/structure/windoor_assembly/secure{
-	dir = 2
-	},
-/obj/structure/windoor_assembly/secure,
+/obj/machinery/gibber,
+/obj/machinery/light/he,
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
-"aA" = (
-/obj/structure/kitchenspike,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
-"aB" = (
-/obj/structure/sink/puddle,
-/turf/simulated/floor/grass,
-/area/vault/ironchef)
-"aC" = (
+"ay" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/reagent_containers/food/condiment/vinegar{
 	pixel_x = -9
@@ -176,30 +193,52 @@
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
-"aD" = (
-/obj/machinery/cooking/grill,
-/obj/machinery/light/he{
-	dir = 8
+"az" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -32
 	},
-/obj/machinery/camera{
-	name = "Iron Chef 1"
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
 	},
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "checker"
 	},
 /area/vault/ironchef)
-"aE" = (
+"aA" = (
+/obj/machinery/vending/meat,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"aB" = (
+/obj/structure/sink/puddle,
+/turf/simulated/floor/grass,
+/area/vault/ironchef)
+"aC" = (
 /mob/living/carbon/monkey,
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
-"aF" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "1"
+"aD" = (
+/obj/machinery/vending/zamsnax,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"aE" = (
+/obj/machinery/door/airlock/glass{
+	name = "Audience"
 	},
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"aF" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/weapon/disk/shuttle_coords/vault/ironchef,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aG" = (
@@ -219,11 +258,14 @@
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
 "aJ" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/weapon/disk/shuttle_coords/vault/ironchef,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "aK" = (
@@ -265,22 +307,20 @@
 /turf/simulated/wall,
 /area/vault/ironchef)
 "aQ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/booze_dispenser/mapping,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
-"aR" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
-	},
+/obj/machinery/light/he,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "checker"
+	},
+/area/vault/ironchef)
+"aR" = (
+/obj/structure/rack,
+/obj/item/organ/internal/brain,
+/obj/item/clothing/head/butt,
+/obj/item/organ/internal/appendix,
+/obj/item/organ/internal/heart,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aS" = (
@@ -292,18 +332,13 @@
 	},
 /area/vault/ironchef)
 "aT" = (
-/obj/effect/decal/warning_stripes{
-	dir = 4;
-	icon_state = "warning"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder,
+/obj/machinery/vending/dinnerware,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aU" = (
-/obj/machinery/processor,
+/obj/machinery/cooking/deepfryer,
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
@@ -325,34 +360,31 @@
 	},
 /area/vault/ironchef)
 "aX" = (
-/obj/machinery/cooking/cerealmaker,
-/obj/machinery/light/he,
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
-"aY" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/weapon/reagent_containers/glass/bucket,
-/obj/item/weapon/minihoe,
-/obj/item/weapon/storage/bag/plants,
-/obj/item/tool/wirecutters/clippers,
-/obj/machinery/light/he,
+/obj/structure/reagent_dispensers/sacid,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
-"aZ" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
-/obj/machinery/light/he{
-	dir = 1
+"aY" = (
+/obj/structure/rack,
+/obj/item/robot_parts/head,
+/obj/item/weapon/handcuffs,
+/obj/item/weapon/paper,
+/obj/item/stack/rods,
+/obj/item/pipe,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/toy/crayon/blue,
+/obj/item/toy/crayon/blue,
+/obj/item/toy/crayon/blue,
+/obj/item/stack/sheet/cardboard{
+	amount = 10
 	},
+/obj/item/weapon/aiModule/core/asimov,
+/obj/item/stack/sheet/metal,
+/obj/item/weapon/cell,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/stack/ore/glass,
+/obj/item/stack/ore/glass,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -371,11 +403,11 @@
 	},
 /area/vault/ironchef)
 "bb" = (
-/obj/machinery/door/airlock/glass{
-	name = "Audience"
-	},
+/obj/machinery/cooking/cerealmaker,
+/obj/machinery/light/he,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bc" = (
@@ -416,139 +448,55 @@
 	},
 /area/vault/ironchef)
 "bg" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/condiment/gravy/gravybig{
-	pixel_x = -9
-	},
-/obj/item/weapon/reagent_containers/food/condiment/cornoil{
-	pixel_x = -3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/cinnamon{
-	pixel_x = 3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/soysauce{
-	pixel_x = 9
+/obj/machinery/vending/hydroseeds,
+/obj/machinery/light/he{
+	dir = 1
 	},
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bh" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/weapon/reagent_containers/food/snacks/meat/carpmeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/crabmeat,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"bi" = (
 /obj/machinery/light/he,
+/obj/machinery/bot/farmbot,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"bj" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "checker"
 	},
 /area/vault/ironchef)
-"bi" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/drinks/shaker,
-/obj/machinery/chem_dispenser/soda_dispenser/mapping,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
 "bk" = (
-/obj/machinery/apiary,
-/turf/simulated/floor/grass,
-/area/vault/ironchef)
-"bl" = (
-/obj/structure/rack,
-/obj/item/clothing/head/wizard,
-/obj/item/slime_extract/purple,
-/obj/item/slime_extract/purple,
-/obj/item/weapon/ectoplasm,
-/obj/item/weapon/ectoplasm,
-/obj/item/weapon/ectoplasm,
-/obj/item/clothing/mask/fakemoustache,
-/obj/item/slime_extract/grey,
-/obj/item/slime_extract/grey,
-/obj/item/stack/sheet/snow{
-	amount = 5
-	},
+/obj/machinery/chem_master,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bm" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/dipping_sauce/queso{
-	pixel_y = 18
-	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/salsa{
-	pixel_y = 13
-	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/hummus{
-	pixel_y = 8
-	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/guacamole,
+/obj/structure/safe,
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "checker"
 	},
 /area/vault/ironchef)
-"bo" = (
-/obj/structure/rack,
-/obj/item/stack/teeth/shark,
-/obj/item/weapon/reagent_containers/food/snacks/monkeycube,
-/obj/item/weapon/reagent_containers/food/snacks/meat/diona,
-/obj/item/weapon/reagent_containers/food/snacks/meat/hive,
-/obj/item/weapon/reagent_containers/food/snacks/meat/bearmeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box/pig,
-/obj/item/weapon/reagent_containers/food/snacks/meat/box/pig,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
-"bp" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
-"bq" = (
-/obj/machinery/cooking/deepfryer,
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
-"br" = (
-/obj/structure/rack,
-/obj/item/organ/internal/brain,
-/obj/item/clothing/head/butt,
-/obj/item/organ/internal/appendix,
-/obj/item/organ/internal/heart,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
-"bs" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/chefhat,
-/obj/item/clothing/under/rank/chef,
-/obj/item/clothing/suit/chef,
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
-"bt" = (
-/obj/machinery/gibber,
-/obj/machinery/light/he,
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
-"bu" = (
+"bn" = (
 /obj/structure/rack,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/customizable/vodka,
 /obj/item/weapon/reagent_containers/food/snacks/pimiento,
@@ -565,13 +513,68 @@
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
-"bv" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
+"bo" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/booze_dispenser/mapping,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
 	},
-/obj/structure/closet/crate/freezer,
-/turf/simulated/floor/plating,
+/area/vault/ironchef)
+"bp" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"br" = (
+/obj/machinery/apiary,
+/turf/simulated/floor/grass,
+/area/vault/ironchef)
+"bs" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/chefhat,
+/obj/item/clothing/under/rank/chef,
+/obj/item/clothing/suit/chef,
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
+/area/vault/ironchef)
+"bt" = (
+/obj/item/weapon/reagent_containers/food/snacks/beezeez,
+/obj/item/queen_bee/chill,
+/obj/item/queen_bee,
+/turf/simulated/floor/grass,
+/area/vault/ironchef)
+"bu" = (
+/obj/machinery/cooking/grill,
+/obj/machinery/light/he{
+	dir = 8
+	},
+/obj/machinery/camera{
+	name = "Iron Chef 1"
+	},
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
+/area/vault/ironchef)
+"bv" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,
+/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,
+/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
+/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
+/obj/item/weapon/reagent_containers/food/snacks/meat/roach,
+/obj/effect/decal/warning_stripes{
+	dir = 4;
+	icon_state = "warning"
+	},
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
 /area/vault/ironchef)
 "bw" = (
 /obj/machinery/cooking/candy,
@@ -636,7 +639,8 @@
 	},
 /area/vault/ironchef)
 "bC" = (
-/obj/machinery/vending/dinnerware,
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/brewer/mapping,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -676,16 +680,7 @@
 	},
 /area/vault/ironchef)
 "bH" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,
-/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,
-/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
-/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
-/obj/item/weapon/reagent_containers/food/snacks/meat/roach,
-/obj/effect/decal/warning_stripes{
-	dir = 4;
-	icon_state = "warning"
-	},
+/obj/structure/reagent_dispensers/corn_oil_tank,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -700,21 +695,19 @@
 	},
 /area/vault/ironchef)
 "bJ" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
-	},
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
-	},
+/obj/machinery/processor,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "checker"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bK" = (
-/obj/machinery/chem_master/condimaster,
+/obj/effect/decal/warning_stripes{
+	icon_state = "1"
+	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bL" = (
@@ -746,12 +739,6 @@
 /obj/item/device/camera,
 /turf/simulated/floor/carpet,
 /area/vault/ironchef)
-"bQ" = (
-/obj/machinery/vending/zamsnax,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
 "bR" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
@@ -768,26 +755,48 @@
 /turf/simulated/floor/plating,
 /area/vault/ironchef)
 "bT" = (
-/obj/structure/reagent_dispensers/corn_oil_tank,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
+/obj/machinery/light/he{
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bU" = (
-/obj/item/clothing/accessory/armband/cargo,
-/obj/item/clothing/gloves/brown/cargo,
-/obj/item/device/pda/cargo,
-/obj/structure/table,
+/obj/structure/rack,
+/obj/item/stack/teeth/shark,
+/obj/item/weapon/reagent_containers/food/snacks/monkeycube,
+/obj/item/weapon/reagent_containers/food/snacks/meat/diona,
+/obj/item/weapon/reagent_containers/food/snacks/meat/hive,
+/obj/item/weapon/reagent_containers/food/snacks/meat/bearmeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box/pig,
+/obj/item/weapon/reagent_containers/food/snacks/meat/box/pig,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bV" = (
 /obj/structure/table/reinforced,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/item/weapon/reagent_containers/food/dipping_sauce/queso{
+	pixel_y = 18
 	},
+/obj/item/weapon/reagent_containers/food/dipping_sauce/salsa{
+	pixel_y = 13
+	},
+/obj/item/weapon/reagent_containers/food/dipping_sauce/hummus{
+	pixel_y = 8
+	},
+/obj/item/weapon/reagent_containers/food/dipping_sauce/guacamole,
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
@@ -814,27 +823,13 @@
 /turf/simulated/floor/carpet,
 /area/vault/ironchef)
 "ca" = (
-/obj/structure/rack,
-/obj/item/robot_parts/head,
-/obj/item/weapon/handcuffs,
-/obj/item/weapon/paper,
-/obj/item/stack/rods,
-/obj/item/pipe,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/toy/crayon/blue,
-/obj/item/toy/crayon/blue,
-/obj/item/toy/crayon/blue,
-/obj/item/stack/sheet/cardboard{
-	amount = 10
+/obj/structure/windoor_assembly/secure{
+	dir = 2
 	},
-/obj/item/weapon/aiModule/core/asimov,
-/obj/item/stack/sheet/metal,
-/obj/item/weapon/cell,
-/obj/item/stack/cable_coil/yellow,
-/obj/item/stack/ore/glass,
-/obj/item/stack/ore/glass,
+/obj/structure/windoor_assembly/secure,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "cb" = (
@@ -861,15 +856,9 @@
 /turf/simulated/floor/engine,
 /area/vault/ironchef)
 "ce" = (
-/obj/structure/table/woodentable,
-/obj/item/clothing/gloves/ironchefgauntlets,
-/obj/item/weapon/reagent_containers/glass/beaker/vial/flavor,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/chem_master/condimaster,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "checker"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "cf" = (
@@ -877,13 +866,12 @@
 /turf/simulated/floor/plating,
 /area/vault/ironchef)
 "cg" = (
-/obj/machinery/chem_master,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
+/obj/effect/decal/warning_stripes{
+	dir = 4;
+	icon_state = "warning"
 	},
-/area/vault/ironchef)
-"ch" = (
-/obj/machinery/vending/voxseeds,
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -966,11 +954,11 @@ ac
 ac
 ac
 aM
-ca
-bu
-br
-bo
-bl
+aY
+bn
+aR
+bU
+ak
 aM
 bN
 bW
@@ -984,8 +972,8 @@ aa
 aa
 ab
 ac
-ce
 aj
+bm
 ac
 aM
 aS
@@ -1032,11 +1020,11 @@ aw
 ac
 ac
 aM
-aD
+bu
 aW
-bq
+aU
 bw
-aX
+bb
 aM
 aM
 bZ
@@ -1051,7 +1039,7 @@ aa
 ab
 ad
 as
-aA
+as
 aG
 bL
 aV
@@ -1060,7 +1048,7 @@ aW
 aW
 aW
 bD
-bJ
+az
 ar
 ab
 aa
@@ -1071,10 +1059,10 @@ aa
 (8,1,1) = {"
 aa
 ab
-ae
+bg
 at
 at
-bT
+bH
 bL
 aV
 aW
@@ -1093,16 +1081,16 @@ aa
 (9,1,1) = {"
 aa
 ab
-ch
+ai
 at
 at
-al
+aX
 bL
 aW
 aW
 aW
 bx
-aF
+bK
 bE
 bR
 ar
@@ -1115,10 +1103,10 @@ aa
 (10,1,1) = {"
 aa
 ab
-ak
+bC
 at
 at
-as
+ah
 aN
 aW
 be
@@ -1137,7 +1125,7 @@ aa
 (11,1,1) = {"
 aa
 ab
-aQ
+bo
 as
 as
 as
@@ -1147,7 +1135,7 @@ be
 aW
 bs
 aW
-bV
+aJ
 bR
 ar
 ab
@@ -1159,19 +1147,19 @@ aa
 (12,1,1) = {"
 aa
 ab
+al
+as
+as
 bi
-ax
-ah
-aY
 aP
 aW
-bg
+ag
 aW
 aW
 aW
-az
+ca
 ar
-bh
+aQ
 ab
 aa
 aa
@@ -1181,13 +1169,13 @@ aa
 (13,1,1) = {"
 aa
 ab
-am
+aA
 as
 as
 as
 aO
 bF
-aC
+ay
 aW
 bs
 aW
@@ -1203,13 +1191,13 @@ aa
 (14,1,1) = {"
 aa
 ab
-bC
+aT
 at
 at
-as
+ah
 bL
 aW
-bm
+bV
 aW
 by
 aW
@@ -1225,10 +1213,10 @@ aa
 (15,1,1) = {"
 aa
 ab
-bQ
+aD
 at
 at
-bK
+ce
 bL
 aW
 aW
@@ -1247,10 +1235,10 @@ aa
 (16,1,1) = {"
 aa
 ab
-av
+bh
 at
 at
-cg
+bk
 bL
 aV
 aW
@@ -1269,7 +1257,7 @@ aa
 (17,1,1) = {"
 aa
 ab
-aZ
+bT
 as
 as
 aH
@@ -1280,7 +1268,7 @@ aW
 aW
 bf
 bD
-aR
+bj
 ar
 ab
 aa
@@ -1291,16 +1279,16 @@ aa
 (18,1,1) = {"
 aa
 ab
-bH
+bv
 an
 an
-aT
+cg
 bL
 ba
 aW
-aU
+bJ
 bB
-bt
+ax
 aM
 aM
 bS
@@ -1313,13 +1301,13 @@ aa
 (19,1,1) = {"
 aa
 ab
-ao
+af
 ao
 ao
 aI
 aK
 bL
-bb
+aE
 aM
 aM
 aM
@@ -1335,16 +1323,16 @@ aa
 (20,1,1) = {"
 aa
 ab
-ay
+bt
 aB
-aE
+aC
 ao
 ao
 bL
 as
-bU
+ae
 aM
-bv
+am
 bM
 bc
 bc
@@ -1357,14 +1345,14 @@ aa
 (21,1,1) = {"
 aa
 ab
-bk
+br
 ao
 ap
 ao
 aq
 bL
 as
-aJ
+aF
 aM
 cf
 bc
@@ -1379,8 +1367,8 @@ aa
 (22,1,1) = {"
 aa
 ab
-ai
-aE
+av
+aC
 ao
 aL
 au

--- a/maps/randomvaults/ironchef.dmm
+++ b/maps/randomvaults/ironchef.dmm
@@ -15,32 +15,31 @@
 	},
 /area/vault/ironchef)
 "ae" = (
-/obj/item/weapon/reagent_containers/food/snacks/beezeez,
-/obj/item/queen_bee/chill,
-/obj/item/queen_bee,
-/turf/simulated/floor/grass,
+/obj/effect/decal/warning_stripes{
+	dir = 4;
+	icon_state = "warning"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
 /area/vault/ironchef)
 "af" = (
-/obj/structure/rack,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/customizable/vodka,
-/obj/item/weapon/reagent_containers/food/snacks/pimiento,
-/obj/item/weapon/reagent_containers/food/snacks/grown/kudzupod,
-/obj/item/weapon/reagent_containers/food/snacks/bustanuts,
-/obj/item/weapon/reagent_containers/food/drinks/coloring,
-/obj/item/weapon/reagent_containers/glass/beaker/vial/uranium,
-/obj/item/weapon/reagent_containers/glass/beaker/vial/radium,
-/obj/item/weapon/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "ag" = (
-/obj/machinery/vending/meat,
+/obj/machinery/gibber,
+/obj/machinery/light/he,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "ah" = (
@@ -54,6 +53,45 @@
 	},
 /area/vault/ironchef)
 "ai" = (
+/obj/machinery/cooking/deepfryer,
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
+/area/vault/ironchef)
+"aj" = (
+/obj/structure/windoor_assembly/secure{
+	dir = 2
+	},
+/obj/structure/windoor_assembly/secure,
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
+/area/vault/ironchef)
+"ak" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/weapon/reagent_containers/food/snacks/meat/carpmeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/crabmeat,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"al" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/condiment/vinegar{
+	pixel_x = -9
+	},
+/obj/item/weapon/reagent_containers/food/drinks/ice,
+/obj/item/weapon/reagent_containers/food/drinks/discount_sauce{
+	pixel_x = 9
+	},
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
+	},
+/area/vault/ironchef)
+"am" = (
 /obj/structure/rack,
 /obj/item/stack/teeth/shark,
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube,
@@ -68,46 +106,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/meat/box/pig,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
-"aj" = (
-/obj/machinery/chem_master,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
-"ak" = (
-/obj/structure/table,
-/obj/item/device/crank_charger,
-/obj/item/weapon/cell,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
-"al" = (
-/obj/machinery/vending/hydroseeds,
-/obj/machinery/light/he{
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
-"am" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/dipping_sauce/queso{
-	pixel_y = 18
-	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/salsa{
-	pixel_y = 13
-	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/hummus{
-	pixel_y = 8
-	},
-/obj/item/weapon/reagent_containers/food/dipping_sauce/guacamole,
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "an" = (
@@ -153,7 +151,11 @@
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
 "av" = (
-/obj/structure/reagent_dispensers/corn_oil_tank,
+/obj/structure/rack,
+/obj/item/organ/internal/brain,
+/obj/item/clothing/head/butt,
+/obj/item/organ/internal/appendix,
+/obj/item/organ/internal/heart,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -169,17 +171,40 @@
 	},
 /area/vault/ironchef)
 "ax" = (
-/obj/machinery/light/he,
-/obj/machinery/bot/farmbot,
+/obj/structure/table,
+/obj/item/device/crank_charger,
+/obj/item/weapon/cell,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "ay" = (
-/obj/structure/kitchenspike,
+/obj/machinery/vending/voxseeds,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"az" = (
+/obj/item/clothing/accessory/armband/cargo,
+/obj/item/clothing/gloves/brown/cargo,
+/obj/item/device/pda/cargo,
+/obj/structure/table,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"aB" = (
+/obj/structure/sink/puddle,
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
-"aA" = (
+"aC" = (
+/obj/structure/safe,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "checker"
+	},
+/area/vault/ironchef)
+"aD" = (
 /obj/structure/rack,
 /obj/item/robot_parts/head,
 /obj/item/weapon/handcuffs,
@@ -202,30 +227,12 @@
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
-"aB" = (
-/obj/structure/sink/puddle,
-/turf/simulated/floor/grass,
-/area/vault/ironchef)
-"aC" = (
-/obj/machinery/gibber,
-/obj/machinery/light/he,
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
-"aD" = (
-/obj/machinery/vending/voxseeds,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/vault/ironchef)
 "aE" = (
 /mob/living/carbon/monkey,
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
 "aF" = (
-/obj/structure/closet/crate/freezer,
+/obj/machinery/chem_master/condimaster,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -247,10 +254,16 @@
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
 "aJ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/brewer/mapping,
+/obj/machinery/cooking/grill,
+/obj/machinery/light/he{
+	dir = 8
+	},
+/obj/machinery/camera{
+	name = "Iron Chef 1"
+	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "aK" = (
@@ -292,19 +305,9 @@
 /turf/simulated/wall,
 /area/vault/ironchef)
 "aQ" = (
-/obj/structure/safe,
+/obj/structure/reagent_dispensers/corn_oil_tank,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "checker"
-	},
-/area/vault/ironchef)
-"aR" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "1"
-	},
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "aS" = (
@@ -316,16 +319,16 @@
 	},
 /area/vault/ironchef)
 "aT" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
-	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/drinks/shaker,
+/obj/machinery/chem_dispenser/soda_dispenser/mapping,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "checker"
+	icon_state = "showroomfloor"
 	},
+/area/vault/ironchef)
+"aU" = (
+/obj/structure/kitchenspike,
+/turf/simulated/floor/grass,
 /area/vault/ironchef)
 "aV" = (
 /obj/structure/closet/secure_closet/freezer/kitchen{
@@ -343,23 +346,28 @@
 	},
 /area/vault/ironchef)
 "aX" = (
-/obj/machinery/apiary,
+/obj/item/weapon/reagent_containers/food/snacks/beezeez,
+/obj/item/queen_bee/chill,
+/obj/item/queen_bee,
 /turf/simulated/floor/grass,
 /area/vault/ironchef)
 "aY" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/weapon/disk/shuttle_coords/vault/ironchef,
+/obj/machinery/light/he,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	dir = 5;
+	icon_state = "checker"
 	},
 /area/vault/ironchef)
 "aZ" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/weapon/reagent_containers/food/snacks/meat/carpmeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/crabmeat,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
+	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	dir = 5;
+	icon_state = "checker"
 	},
 /area/vault/ironchef)
 "ba" = (
@@ -376,16 +384,9 @@
 	},
 /area/vault/ironchef)
 "bb" = (
-/obj/machinery/cooking/grill,
-/obj/machinery/light/he{
-	dir = 8
-	},
-/obj/machinery/camera{
-	name = "Iron Chef 1"
-	},
+/obj/machinery/vending/meat,
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bc" = (
@@ -426,73 +427,94 @@
 	},
 /area/vault/ironchef)
 "bg" = (
-/obj/effect/decal/warning_stripes{
-	dir = 4;
-	icon_state = "warning"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder,
+/obj/machinery/vending/zamsnax,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bh" = (
-/obj/item/clothing/accessory/armband/cargo,
-/obj/item/clothing/gloves/brown/cargo,
-/obj/item/device/pda/cargo,
-/obj/structure/table,
+/obj/machinery/light/he,
+/obj/machinery/bot/farmbot,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bi" = (
-/obj/machinery/cart/cargo,
+/obj/effect/decal/warning_stripes{
+	icon_state = "1"
+	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bj" = (
-/obj/machinery/chem_master/condimaster,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,
+/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,
+/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
+/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
+/obj/item/weapon/reagent_containers/food/snacks/meat/roach,
+/obj/effect/decal/warning_stripes{
+	dir = 4;
+	icon_state = "warning"
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bk" = (
-/obj/machinery/light/he,
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/booze_dispenser/mapping,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "checker"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bl" = (
-/obj/structure/rack,
-/obj/item/organ/internal/brain,
-/obj/item/clothing/head/butt,
-/obj/item/organ/internal/appendix,
-/obj/item/organ/internal/heart,
+/obj/structure/closet/crate/freezer,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bm" = (
-/obj/machinery/processor,
+/obj/structure/rack,
+/obj/item/clothing/head/wizard,
+/obj/item/slime_extract/purple,
+/obj/item/slime_extract/purple,
+/obj/item/weapon/ectoplasm,
+/obj/item/weapon/ectoplasm,
+/obj/item/weapon/ectoplasm,
+/obj/item/clothing/mask/fakemoustache,
+/obj/item/slime_extract/grey,
+/obj/item/slime_extract/grey,
+/obj/item/stack/sheet/snow{
+	amount = 5
+	},
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bn" = (
-/obj/machinery/cooking/cerealmaker,
-/obj/machinery/light/he,
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
+/obj/structure/rack,
+/obj/item/weapon/fishtools/fish_egg_scoop,
+/obj/item/weapon/fishtools/fish_food,
+/obj/item/weapon/fishtools/fish_net,
+/obj/item/weapon/fishtools/fish_tank_brush,
+/obj/item/tool/crowbar,
+/obj/item/weapon/hatchet,
+/obj/item/weapon/extinguisher,
+/turf/simulated/floor/grass,
 /area/vault/ironchef)
 "bo" = (
-/obj/machinery/vending/dinnerware,
+/obj/structure/table/woodentable,
+/obj/item/clothing/gloves/ironchefgauntlets,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/flavor,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	dir = 5;
+	icon_state = "checker"
 	},
 /area/vault/ironchef)
 "bp" = (
@@ -503,23 +525,12 @@
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
-"bq" = (
-/obj/machinery/cooking/deepfryer,
+"br" = (
+/obj/machinery/processor,
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"
 	},
-/area/vault/ironchef)
-"br" = (
-/obj/structure/rack,
-/obj/item/weapon/fishtools/fish_egg_scoop,
-/obj/item/weapon/fishtools/fish_food,
-/obj/item/weapon/fishtools/fish_net,
-/obj/item/weapon/fishtools/fish_tank_brush,
-/obj/item/tool/crowbar,
-/obj/item/weapon/hatchet,
-/obj/item/weapon/extinguisher,
-/turf/simulated/floor/grass,
 /area/vault/ironchef)
 "bs" = (
 /obj/structure/table/reinforced,
@@ -532,48 +543,25 @@
 	},
 /area/vault/ironchef)
 "bt" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/condiment/gravy/gravybig{
-	pixel_x = -9
-	},
-/obj/item/weapon/reagent_containers/food/condiment/cornoil{
-	pixel_x = -3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/cinnamon{
-	pixel_x = 3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/soysauce{
-	pixel_x = 9
-	},
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
-"bu" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
-/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
-/obj/machinery/light/he{
-	dir = 1
+/obj/machinery/door/airlock/glass{
+	name = "Audience"
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
-"bv" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
-	},
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
-	},
+"bu" = (
+/obj/machinery/vending/dinnerware,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "checker"
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"bv" = (
+/obj/machinery/cooking/cerealmaker,
+/obj/machinery/light/he,
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bw" = (
@@ -639,9 +627,20 @@
 	},
 /area/vault/ironchef)
 "bC" = (
-/obj/machinery/vending/zamsnax,
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/dipping_sauce/queso{
+	pixel_y = 18
+	},
+/obj/item/weapon/reagent_containers/food/dipping_sauce/salsa{
+	pixel_y = 13
+	},
+/obj/item/weapon/reagent_containers/food/dipping_sauce/hummus{
+	pixel_y = 8
+	},
+/obj/item/weapon/reagent_containers/food/dipping_sauce/guacamole,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bD" = (
@@ -679,14 +678,17 @@
 	},
 /area/vault/ironchef)
 "bH" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
+/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
+/obj/machinery/light/he{
+	dir = 1
 	},
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "bI" = (
@@ -699,21 +701,31 @@
 	},
 /area/vault/ironchef)
 "bJ" = (
-/obj/structure/windoor_assembly/secure{
-	dir = 2
-	},
-/obj/structure/windoor_assembly/secure,
-/turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
-	},
-/area/vault/ironchef)
-"bK" = (
-/obj/machinery/door/airlock/glass{
-	name = "Audience"
+/obj/structure/rack,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/customizable/vodka,
+/obj/item/weapon/reagent_containers/food/snacks/pimiento,
+/obj/item/weapon/reagent_containers/food/snacks/grown/kudzupod,
+/obj/item/weapon/reagent_containers/food/snacks/bustanuts,
+/obj/item/weapon/reagent_containers/food/drinks/coloring,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/uranium,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/radium,
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"bK" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor{
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bL" = (
@@ -745,6 +757,13 @@
 /obj/item/device/camera,
 /turf/simulated/floor/carpet,
 /area/vault/ironchef)
+"bQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/brewer/mapping,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
 "bR" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
@@ -761,32 +780,38 @@
 /turf/simulated/floor/plating,
 /area/vault/ironchef)
 "bT" = (
-/obj/structure/reagent_dispensers/sacid,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -32
+	},
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
+	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	dir = 5;
+	icon_state = "checker"
 	},
 /area/vault/ironchef)
 "bU" = (
 /obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/booze_dispenser/mapping,
+/obj/item/weapon/reagent_containers/food/condiment/gravy/gravybig{
+	pixel_x = -9
+	},
+/obj/item/weapon/reagent_containers/food/condiment/cornoil{
+	pixel_x = -3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/cinnamon{
+	pixel_x = 3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/soysauce{
+	pixel_x = 9
+	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	blocks_air = 0;
+	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bV" = (
-/obj/structure/rack,
-/obj/item/clothing/head/wizard,
-/obj/item/slime_extract/purple,
-/obj/item/slime_extract/purple,
-/obj/item/weapon/ectoplasm,
-/obj/item/weapon/ectoplasm,
-/obj/item/weapon/ectoplasm,
-/obj/item/clothing/mask/fakemoustache,
-/obj/item/slime_extract/grey,
-/obj/item/slime_extract/grey,
-/obj/item/stack/sheet/snow{
-	amount = 5
-	},
+/obj/machinery/chem_master,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -812,13 +837,8 @@
 /turf/simulated/floor/carpet,
 /area/vault/ironchef)
 "ca" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
+/obj/machinery/apiary,
+/turf/simulated/floor/grass,
 /area/vault/ironchef)
 "cb" = (
 /obj/effect/decal/warning_stripes{
@@ -844,50 +864,30 @@
 /turf/simulated/floor/engine,
 /area/vault/ironchef)
 "ce" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,
-/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,
-/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
-/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
-/obj/item/weapon/reagent_containers/food/snacks/meat/roach,
-/obj/effect/decal/warning_stripes{
-	dir = 4;
-	icon_state = "warning"
-	},
+/obj/machinery/cart/cargo,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "cf" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/condiment/vinegar{
-	pixel_x = -9
-	},
-/obj/item/weapon/reagent_containers/food/drinks/ice,
-/obj/item/weapon/reagent_containers/food/drinks/discount_sauce{
-	pixel_x = 9
+/obj/machinery/vending/hydroseeds,
+/obj/machinery/light/he{
+	dir = 1
 	},
 /turf/simulated/floor{
-	blocks_air = 0;
-	icon_state = "dark"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "cg" = (
-/obj/structure/table/woodentable,
-/obj/item/clothing/gloves/ironchefgauntlets,
-/obj/item/weapon/reagent_containers/glass/beaker/vial/flavor,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/structure/reagent_dispensers/sacid,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "checker"
+	icon_state = "showroomfloor"
 	},
 /area/vault/ironchef)
 "ch" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/drinks/shaker,
-/obj/machinery/chem_dispenser/soda_dispenser/mapping,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/weapon/disk/shuttle_coords/vault/ironchef,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -970,11 +970,11 @@ ac
 ac
 ac
 aM
-aA
-af
-bl
-ai
-bV
+aD
+bJ
+av
+am
+bm
 aM
 bN
 bW
@@ -988,8 +988,8 @@ aa
 aa
 ab
 ac
-cg
-aQ
+bo
+aC
 ac
 aM
 aS
@@ -1036,11 +1036,11 @@ aw
 ac
 ac
 aM
-bb
+aJ
 aW
-bq
+ai
 bw
-bn
+bv
 aM
 aM
 bZ
@@ -1064,7 +1064,7 @@ aW
 aW
 aW
 bD
-bv
+bT
 ar
 ab
 aa
@@ -1075,10 +1075,10 @@ aa
 (8,1,1) = {"
 aa
 ab
-al
+cf
 at
 at
-av
+aQ
 bL
 aV
 aW
@@ -1097,16 +1097,16 @@ aa
 (9,1,1) = {"
 aa
 ab
-aD
+ay
 at
 at
-bT
+cg
 bL
 aW
 aW
 aW
 bx
-aR
+bi
 bE
 bR
 ar
@@ -1119,7 +1119,7 @@ aa
 (10,1,1) = {"
 aa
 ab
-aJ
+bQ
 at
 at
 ah
@@ -1141,7 +1141,7 @@ aa
 (11,1,1) = {"
 aa
 ab
-bU
+bk
 as
 as
 as
@@ -1151,7 +1151,7 @@ be
 aW
 bs
 aW
-bH
+bK
 bR
 ar
 ab
@@ -1163,19 +1163,19 @@ aa
 (12,1,1) = {"
 aa
 ab
-ch
+aT
 as
 as
-ax
+bh
 aP
 aW
-bt
+bU
 aW
 aW
 aW
-bJ
+aj
 ar
-bk
+aY
 ab
 aa
 aa
@@ -1185,13 +1185,13 @@ aa
 (13,1,1) = {"
 aa
 ab
-ag
+bb
 as
 as
 as
 aO
 bF
-cf
+al
 aW
 bs
 aW
@@ -1207,13 +1207,13 @@ aa
 (14,1,1) = {"
 aa
 ab
-bo
+bu
 at
 at
 ah
 aK
 aW
-am
+bC
 aW
 by
 aW
@@ -1229,10 +1229,10 @@ aa
 (15,1,1) = {"
 aa
 ab
-bC
+bg
 at
 at
-bj
+aF
 bL
 aW
 aW
@@ -1251,10 +1251,10 @@ aa
 (16,1,1) = {"
 aa
 ab
-aZ
+ak
 at
 at
-aj
+bV
 bL
 aV
 aW
@@ -1273,7 +1273,7 @@ aa
 (17,1,1) = {"
 aa
 ab
-bu
+bH
 as
 as
 aH
@@ -1284,7 +1284,7 @@ aW
 aW
 bf
 bD
-aT
+aZ
 ar
 ab
 aa
@@ -1295,16 +1295,16 @@ aa
 (18,1,1) = {"
 aa
 ab
-ce
+bj
 an
 an
-bg
+ae
 bL
 ba
 aW
-bm
+br
 bB
-aC
+ag
 aM
 aM
 bS
@@ -1317,13 +1317,13 @@ aa
 (19,1,1) = {"
 aa
 ab
-ay
+aU
 ao
 ao
 aI
 aM
 aM
-bK
+bt
 aM
 aM
 aM
@@ -1339,14 +1339,14 @@ aa
 (20,1,1) = {"
 aa
 ab
-ae
+aX
 aB
 aE
 au
 aM
-bh
+az
 as
-ca
+af
 as
 bS
 bc
@@ -1361,15 +1361,15 @@ aa
 (21,1,1) = {"
 aa
 ab
-aX
+ca
 ao
 ap
 aq
 aM
-aY
+ch
 as
 as
-bi
+ce
 aM
 bc
 cb
@@ -1383,15 +1383,15 @@ aa
 (22,1,1) = {"
 aa
 ab
-br
+bn
 aE
 ao
 aL
 aM
-ak
+ax
 bp
 as
-aF
+bl
 aM
 bc
 cc

--- a/maps/randomvaults/ironchef.dmm
+++ b/maps/randomvaults/ironchef.dmm
@@ -856,6 +856,33 @@
 	},
 /turf/simulated/floor/carpet,
 /area/vault/ironchef)
+"dt" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/vault/ironchef)
+"jl" = (
+/obj/machinery/vending/wallmed2{
+	pixel_x = 30
+	},
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/ironchef)
+"mN" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/vault/ironchef)
 "Rr" = (
 /obj/machinery/smartfridge/drinks/filled,
 /turf/simulated/floor{
@@ -863,13 +890,16 @@
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
-"Za" = (
-/obj/machinery/vending/wallmed2{
-	pixel_x = 30
+"Zp" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
 /area/vault/ironchef)
 
 (1,1,1) = {"
@@ -1020,7 +1050,7 @@ aW
 bD
 bT
 ar
-ab
+Zp
 aa
 aa
 aa
@@ -1042,7 +1072,7 @@ aW
 bE
 bR
 ar
-ab
+dt
 aa
 aa
 aa
@@ -1064,7 +1094,7 @@ bi
 bE
 bR
 ar
-ab
+dt
 aa
 aa
 aa
@@ -1086,7 +1116,7 @@ aW
 bE
 bR
 ar
-ab
+dt
 aa
 aa
 aa
@@ -1108,7 +1138,7 @@ aW
 bK
 bR
 ar
-ab
+mN
 aa
 aa
 aa
@@ -1152,7 +1182,7 @@ aW
 bG
 bR
 ar
-ab
+Zp
 aa
 aa
 aa
@@ -1174,7 +1204,7 @@ aW
 bE
 bR
 ar
-ab
+dt
 aa
 aa
 aa
@@ -1196,7 +1226,7 @@ bI
 bE
 bR
 ar
-ab
+dt
 aa
 aa
 aa
@@ -1218,7 +1248,7 @@ aW
 bE
 bR
 ar
-ab
+dt
 aa
 aa
 aa
@@ -1240,7 +1270,7 @@ bf
 bD
 aZ
 ar
-ab
+mN
 aa
 aa
 aa
@@ -1344,7 +1374,7 @@ aL
 aM
 ax
 bp
-Za
+jl
 bl
 aM
 bc

--- a/maps/randomvaults/ironchef.dmm
+++ b/maps/randomvaults/ironchef.dmm
@@ -597,6 +597,7 @@
 "bD" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
+/obj/item/trash/plate/clean/stack,
 /turf/simulated/floor{
 	blocks_air = 0;
 	icon_state = "dark"

--- a/maps/randomvaults/mining/bar.dmm
+++ b/maps/randomvaults/mining/bar.dmm
@@ -369,7 +369,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/smartfridge/drinks,
+/obj/machinery/smartfridge,
 /turf/simulated/wall/mineral/wood,
 /area/mining_bar)
 "bf" = (


### PR DESCRIPTION
Iron chef is a great vault, but recipes are currently limited. This PR adds equipment so more recipes can be made

## What this does
- redesigns the iron chef vault
- adds some vending machines to make special dishes
- better lighting and more chairs in a more compact area

![image](https://user-images.githubusercontent.com/94659603/184542133-ea3ac3da-e7b1-4aa3-8ab5-90cce7ce2b3e.png)


## Why it's good
- Should be better for both the chefs and the observers

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Improved Iron Chef vault
 * tweak: Smartfridges can now hold drinks, glasses and condiments, making the drink fridge obsolete!