### PR TITLE
Increases the capacity of radiation absorption rig modules, adds warnings

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -517,10 +517,8 @@
 						if(rigsuit.MB) //Internal Boots
 							rigsuit.MB.clean_blood()
 							rigsuit.MB.decontaminate()
-						for(var/module in rigsuit.modules)
-							if(istype(module, /obj/item/rig_module/rad_shield))
-								var/obj/item/rig_module/rad_shield/rad = module
-								rad.current_capacity = initial(rad.current_capacity)
+						for(var/obj/item/rig_module/module in rigsuit.modules)
+							module.suit_storage_act()
 				if(mask)
 					mask.clean_blood()
 					mask.decontaminate()

--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -257,7 +257,7 @@
 		rig.H.armor["rad"] = initial_helmet
 	rig?.armor["rad"] = initial_suit
 
-	if(capacity >= max_capacity)
+	if(current_capacity >= max_capacity)
 		say_to_wearer("[src] disabled. Please cleanse it by sterilizing the suit in a suit storage unit.")
 	else
 		say_to_wearer("[src] disabled.")

--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -257,7 +257,10 @@
 		rig.H.armor["rad"] = initial_helmet
 	rig?.armor["rad"] = initial_suit
 
-	say_to_wearer("[src] disabled.")
+	if(capacity >= max_capacity)
+		say_to_wearer("[src] disabled. Please cleanse it by sterilizing the suit in a suit storage unit.")
+	else
+		say_to_wearer("[src] disabled.")
 	rig.wearer?.unregister_event(/event/irradiate, src, .proc/absorb_rads)
 	..()
 


### PR DESCRIPTION
I felt that it absorbed radiation way too fast and wasn't very useful for general engine work and such with the supermatter and the singularity, so I doubled the capacity to make it significantly more worthwhile, with a corresponding increase for the high-capacity variant.
Added various warning messages to better notify the wearers as to how close the module is to capacity, with warnings at 50% capacity, 75% capacity and 90% capacity, as well as a message reminding the user to empty the capacity via a suit storage unit.
Made the suit storage unit code a bit more modular. Instead of being a hardcoded check for the radiation module it now calls a specific proc for all modules.
:cl:
 * rscadd: Radiation absorption rig modules will now warn their users of how close they are to capacity as they absorb radiation, and will now remind users when at full capacity to clear the unit.
 * tweak: Doubled the capacities of radiation absorption rig modules to absorb radiation.
