### PR TITLE
RTG cells will no longer irradiate by default, but if they are broken they will irradiate.

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -273,9 +273,9 @@
 		for(var/mob/living/L in view(get_turf(src), 7)) //Oh, and irradiate everyone nearby in a bigger burst of radiation.
 			L.apply_radiation(initial(charge_rate)/5, RAD_EXTERNAL)
 		if(!isturf(loc))
-			visible_message("<span class='warning'>\The [loc] starts sparking and sizzling, emitting a foul faint smoke!")
+			loc.visible_message("<span class='warning'>\The [loc] starts sparking and sizzling, emitting a foul faint smoke!")
 		else
-			visible_message("<span class='warning'>\The [src] breaks, and has started leaking radioactive material!</span>")
+			visible_message("<span class='warning'>\The [src] breaks and starts leaking radioactive material!</span>")
 		if(prob(25))
 			spark(get_turf(src), 1)
 

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -246,9 +246,14 @@
 	return
 
 /obj/item/weapon/cell/rad/process()
-	if(!maxcharge && prob(5)) //5% chance to explode every 2 seconds if the cell is broken
-		explosion(loc, 0, 1, 2, 2)
-		qdel(src)
+	if(!maxcharge) //Cell is broken, make it dangerous
+		if(prob(5)) //5% chance to explode every 2 seconds
+			explosion(loc, 0, 1, 2, 2)
+			qdel(src)
+		if(prob(25)) //25% chance to leak radiation every 2 seconds
+			for(var/mob/living/L in view(get_turf(src), 5))
+				L.apply_radiation(initial(charge_rate)/10, RAD_EXTERNAL)
+
 	if(maxcharge <= charge)
 		return 0
 	var/power_used = min(maxcharge-charge,charge_rate)
@@ -256,7 +261,7 @@
 //	if(prob(5))
 //		for(var/mob/living/L in view(get_turf(src), max(5,(maxcharge/charge))))
 //			L.apply_radiation(charge_rate/10, RAD_EXTERNAL)
-	if(charge_rate < (initial(charge_rate)/10))	//turns into a broken cell with no charge rate, 0 max charge and a 5% chance to explode every 2s
+	if(charge_rate < (initial(charge_rate)/10))	//turns into a broken cell with no charge rate, 0 max charge, a 5% chance to explode every 2s and 25% chance to leak radiation equal to 1/10th of its charge rate
 		name = "broken cell"
 		icon_state = "cell"
 		starting_materials = list(MAT_IRON = 200, MAT_GLASS = 30)
@@ -265,6 +270,9 @@
 		charge_rate = 0
 		damaged = FALSE //so you don't get the damaged examine if the cell is broken
 		desc = "The inner circuitry melted and the paint flaked off. It bulges slightly at the sides. <span class='warning'>It's going to explode any moment now.</span>"
+		for(var/mob/living/L in view(get_turf(src), 7)) //Oh, and irradiate everyone nearby in a bigger burst of radiation.
+			L.apply_radiation(initial(charge_rate)/5, RAD_EXTERNAL)
+		visible_message("<span class='warning'>\The [src] breaks, and has started leaking radioactive material!</span>")
 
 
 /obj/item/weapon/cell/rad/emp_act(severity)

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -253,9 +253,9 @@
 		return 0
 	var/power_used = min(maxcharge-charge,charge_rate)
 	charge += power_used
-	if(prob(5))
-		for(var/mob/living/L in view(get_turf(src), max(5,(maxcharge/charge))))
-			L.apply_radiation(charge_rate/10, RAD_EXTERNAL)
+//	if(prob(5))
+//		for(var/mob/living/L in view(get_turf(src), max(5,(maxcharge/charge))))
+//			L.apply_radiation(charge_rate/10, RAD_EXTERNAL)
 	if(charge_rate < (initial(charge_rate)/10))	//turns into a broken cell with no charge rate, 0 max charge and a 5% chance to explode every 2s
 		name = "broken cell"
 		icon_state = "cell"

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -261,7 +261,7 @@
 //	if(prob(5))
 //		for(var/mob/living/L in view(get_turf(src), max(5,(maxcharge/charge))))
 //			L.apply_radiation(charge_rate/10, RAD_EXTERNAL)
-	if(charge_rate < (initial(charge_rate)/10))	//turns into a broken cell with no charge rate, 0 max charge, a 5% chance to explode every 2s and 25% chance to leak radiation equal to 1/10th of its charge rate
+	if(charge_rate && charge_rate < (initial(charge_rate)/10))	//turns into a broken cell with no charge rate, 0 max charge, a 5% chance to explode every 2s and 25% chance to leak radiation equal to 1/10th of its charge rate
 		name = "broken cell"
 		icon_state = "cell"
 		starting_materials = list(MAT_IRON = 200, MAT_GLASS = 30)
@@ -272,7 +272,12 @@
 		desc = "The inner circuitry melted and the paint flaked off. It bulges slightly at the sides. <span class='warning'>It's going to explode any moment now.</span>"
 		for(var/mob/living/L in view(get_turf(src), 7)) //Oh, and irradiate everyone nearby in a bigger burst of radiation.
 			L.apply_radiation(initial(charge_rate)/5, RAD_EXTERNAL)
-		visible_message("<span class='warning'>\The [src] breaks, and has started leaking radioactive material!</span>")
+		if(!isturf(loc))
+			visible_message("<span class='warning'>\The [loc] starts sparking and sizzling, emitting a foul faint smoke!")
+		else
+			visible_message("<span class='warning'>\The [src] breaks, and has started leaking radioactive material!</span>")
+		if(prob(25))
+			spark(get_turf(src), 1)
 
 
 /obj/item/weapon/cell/rad/emp_act(severity)


### PR DESCRIPTION
I never see RTG cells get used as a result of the radiation, radiation is pretty tough to deal with and if it harms others it's also a good way to get bwoinked as a non-antagonist. This removes the pretty nasty limitation in exchange of the batteries being significantly more dangerous when broken.
One initial burst of radiation when breaking equal to 20% of the charge rate (30 radiation on RTG and 50 radiation on PDTG) and then a 25% chance every tick to irradiate for 1/10th of the charge rate (15 radiation on RTG and 25 radiation on PDTG). This is on top of the already-existing 5% chance per tick for the battery to just explode.
Also added a visible message when the battery breaks to warn people about it. Items containing an RTG cell will get a specific message if their RTG cell breaks involving "foul smoke". Batteries also have a 25% chance to throw sparks when broken.
This is a mostly experimental change that will also gauge what people will do with RTG cells now that they no longer irradiate, but still have a low capacity that cannot withstand big power demand. Depending on the outcome there might be PRs in the future to further tweak it.

:cl:
 * rscadd: RTG cells will now alarm everyone nearby when they break, including if they are in an item.
 * experimental: RTG and PRTG cells no longer emit radiation by default, but they will emit a significant amount of radiation when broken.
