### PR TITLE
Re-enables lamprey and OG bagel

### DIFF
--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -30,7 +30,6 @@
 	name = "Bagelstation"
 	path = "Bagelstation"
 	var/bagel_requirement = 17
-	is_enabled = FALSE
 
 /datum/next_map/bagel/is_votable()
 	if(score.bagelscooked < bagel_requirement)
@@ -97,7 +96,6 @@
 /datum/next_map/lamprey
 	name = "Lamprey Station"
 	path = "Lamprey"
-	is_enabled = FALSE
 
 /datum/next_map/lamprey/is_votable()
 	if(score.crewscore > -20000)


### PR DESCRIPTION
You still need the -20000 score and 17 bagels requirement (respectively) to be reached and for people to vote for the map.
This change is to allow for voting, it can still be manually forced by an admin if this doesn't pass.
### What this does
Enables Lamprey and OG Bagel if you get the requirements.
### Why it's good
We were promised the cursed map (lamprey) if we got -20000 score. I've been in at least 3 rounds where we've reached that score and have not gotten lamprey.
We were promised the donut map (OG Bagel) if 17 bagels got cooked, I've done it and others have too (see #32222) but still no bagelstation.
:cl:
 * rscadd: Re-enables lamprey and bagel to be voted if the requirements are met.