### PR TITLE
Tesla Cannon Buff

### DIFF
--- a/code/modules/projectiles/projectile/tesla.dm
+++ b/code/modules/projectiles/projectile/tesla.dm
@@ -1,7 +1,7 @@
 #define MAX_LIGHTNING_PER_PULSE 3
 #define LIGHTNING_RANGE 3
 #define PULSE_SHOCK_CHANCE 50
-#define MIN_LIGHTNING_DAMAGE 10
+#define MIN_LIGHTNING_DAMAGE 30
 
 /obj/item/projectile/teslaball
 	name = "tesla ball"
@@ -20,8 +20,7 @@
 
 /obj/item/projectile/teslaball/New()
 	..()
-	spawn(1 SECONDS)  
-		Pulse()
+	Pulse()
 
 /obj/item/projectile/teslaball/to_bump(atom/A)
 	..()
@@ -39,7 +38,8 @@
 	var/list/possible_turfs = list()
 
 	for(var/mob/living/M in view(LIGHTNING_RANGE,src))
-		victims += M
+		if(!firer || M != firer)
+			victims += M
 
 	while(victims.len > 0)
 		var/mob/living/victim = pick(victims)
@@ -101,7 +101,7 @@
 
 /obj/item/projectile/teslaball/proc/Zap(var/atom/target, var/bolt = TRUE)
 	var/energy_force = CalculateDamage()
-	var/knockdown_time = min(energy_force / 2, 15)
+	var/knockdown_time = min(energy_force / 3, 15)
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		H.electrocute_act(shock_damage = energy_force, source = src, incapacitation_duration = knockdown_time SECONDS, def_zone = LIMB_CHEST)


### PR DESCRIPTION
## What this does
Increases minimum lightning damage to 30 (this is still affected by shock resistance)
Increases minimum knockdown to 10 seconds (15 seconds maximum)
Tesla ball immediately starts shooting out lightning instead of waiting one second, but it wont target the firer.

## Why it's good
The tesla cannon feels like an underwhelming weapon. The projectile is extremely slow which makes it easy to avoid, and the delay before it starts firing lightning makes the weapon a poor escape tool. These changes make getting hit by the projectile more punishing and should make the tesla cannon better at catching pursuers off-guard.

## Changelog
:cl:
 * tweak: The syndicate has improved their tesla technology. Lightning balls now shock people harder and faster than before.

