### PR TITLE
Hud/Status updates trigger immediately after taking damage instead of waiting for the next Life() tick

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -398,6 +398,8 @@ This function restores all organs.
 
 	// Will set our damageoverlay icon to the next level, which will then be set back to the normal level the next mob.Life().
 	updatehealth()
+	handle_regular_status_updates()
+	handle_regular_hud_updates()
 	hud_updateflag |= 1 << HEALTH_HUD
 
 	//Embedded projectile code.


### PR DESCRIPTION

## What this does
Your HUD and your status will now update immediately when taking damage instead of waiting for the next Life() tick.

Have you ever noticed how it sometimes takes around a second for the damage you've taken to be reflected in your HUD?
Or how you sometimes you don't fall into critical condition immediately after taking >100 damage.
This PR makes those things happen immediately.
When you get pumped full of shotgun slugs by security you will fall down on the spot instead of waddling for a step or two before falling down. 

I am not sure if waiting for the next life tick is intentional or if this is something people like. Please let me know in the comments how you feel. 

## Why it's good
It makes combat more responsive.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Status/HUD updates now happen immediately after taking damage.

