### PR TITLE
Inflatable dispensers can hold more inflatables.

### DIFF
--- a/code/game/objects/items/robot/robot_items/robot_inflatable_dispenser.dm
+++ b/code/game/objects/items/robot/robot_items/robot_inflatable_dispenser.dm
@@ -10,8 +10,8 @@
 
 	var/list/stored_walls = list()
 	var/list/stored_doors = list()
-	var/max_walls = 12
-	var/max_doors = 9
+	var/max_walls = 18
+	var/max_doors = 15
 	var/list/allowed_types = list(/obj/item/inflatable/wall, /obj/item/inflatable/door)
 	var/mode = MODE_WALL
 
@@ -30,8 +30,8 @@
 
 /obj/item/weapon/inflatable_dispenser/robot
 	w_class = W_CLASS_HUGE
-	max_walls = 16
-	max_doors = 12
+	max_walls = 18
+	max_doors = 15
 
 /obj/item/weapon/inflatable_dispenser/examine(mob/user)
 	..()

--- a/code/game/objects/items/robot/robot_items/robot_inflatable_dispenser.dm
+++ b/code/game/objects/items/robot/robot_items/robot_inflatable_dispenser.dm
@@ -10,8 +10,8 @@
 
 	var/list/stored_walls = list()
 	var/list/stored_doors = list()
-	var/max_walls = 4
-	var/max_doors = 3
+	var/max_walls = 8
+	var/max_doors = 6
 	var/list/allowed_types = list(/obj/item/inflatable/wall, /obj/item/inflatable/door)
 	var/mode = MODE_WALL
 
@@ -31,7 +31,7 @@
 /obj/item/weapon/inflatable_dispenser/robot
 	w_class = W_CLASS_HUGE
 	max_walls = 10
-	max_doors = 5
+	max_doors = 6
 
 /obj/item/weapon/inflatable_dispenser/examine(mob/user)
 	..()

--- a/code/game/objects/items/robot/robot_items/robot_inflatable_dispenser.dm
+++ b/code/game/objects/items/robot/robot_items/robot_inflatable_dispenser.dm
@@ -10,8 +10,8 @@
 
 	var/list/stored_walls = list()
 	var/list/stored_doors = list()
-	var/max_walls = 8
-	var/max_doors = 6
+	var/max_walls = 12
+	var/max_doors = 9
 	var/list/allowed_types = list(/obj/item/inflatable/wall, /obj/item/inflatable/door)
 	var/mode = MODE_WALL
 
@@ -30,8 +30,8 @@
 
 /obj/item/weapon/inflatable_dispenser/robot
 	w_class = W_CLASS_HUGE
-	max_walls = 10
-	max_doors = 6
+	max_walls = 16
+	max_doors = 12
 
 /obj/item/weapon/inflatable_dispenser/examine(mob/user)
 	..()

--- a/code/game/objects/items/robot/robot_items/robot_inflatable_dispenser.dm
+++ b/code/game/objects/items/robot/robot_items/robot_inflatable_dispenser.dm
@@ -30,8 +30,6 @@
 
 /obj/item/weapon/inflatable_dispenser/robot
 	w_class = W_CLASS_HUGE
-	max_walls = 18
-	max_doors = 15
 
 /obj/item/weapon/inflatable_dispenser/examine(mob/user)
 	..()


### PR DESCRIPTION
### What this does
Buffs the inflatable dispensers to be able to hold more inflatables.
### Why it's good
Makes dealing with bigger breaches (such as those from nitros or shards) easier and gives a use to an otherwise rarely used item.
Closes #24522.
:cl:
 * tweak: The CE and borg inflatable dispensers can hold 5 boxes worth of inflatables.