### PR TITLE
Fixes the new NanoUI bug that the last fix caused

### DIFF
--- a/nano/js/nano_template.js
+++ b/nano/js/nano_template.js
@@ -43,7 +43,11 @@ var NanoTemplate = function () {
 					// Disabling caching using jQuery's hack seems to break Nano in some obscure cases on BYOND 512.
 					// Oh well.
 					//cache: false,
-					dataType: 'html',
+					// dataType forces the incoming data to be parsed a certain way and this breaks on certain PCs
+					// or so it seems. Commenting it out may fix the issue since it leaves it up to ajax itself
+					// to determine what the input data is, based on the data itself. Please port everything
+					// TO TGUI ALREADY PLEASE END THIS STUPID BUG AAAAA
+					//dataType: 'html',
 					timeout: 1000
 				}))
 				.done(function(templateMarkup) {


### PR DESCRIPTION
# FIXES NANOUI AGAIN
![image](https://user-images.githubusercontent.com/69739118/185299025-c0e39627-1580-403c-b5d0-fde067e06eb9.png)

## What this does
Comments out the dataType line on the NanoUI template, forcing the ajax to determine on its own what the datatype is, based on the incoming data. It appears to work on my PC. Calling @Eneocho for additional testing.

This should stop the infamous white screen/NT background bug that happens intermittently to random people using nanoUI. The last PR fixed it, but only for people who had it for datatype Text. Changing it to HTML broke it for others who had it working on Text. This should fix it for both. In theory. Can't reproduce the bug myself under datatype = html to confirm for sure, but switching between commented out and datatype = text fixes/breaks it respectively for me, locally.

## Why it's good
STOPS THINGS BREAKING, also this closes an issue that I thought someone opened but I guess they just complained about it to me directly at some point.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed a new rare NanoUI bug caused by fixing a rare NanoUI bug. Report all UI bugs, please... please!

 [help] [hotfix] [bugfix]