### PR TITLE
Stoplag Update 2

### DIFF
--- a/__DEFINES/tick.dm
+++ b/__DEFINES/tick.dm
@@ -48,7 +48,7 @@
 
 /proc/stoplag(initial_delay)
 	. = 0
-	var/i = 1var/i = 1
+    var/i = 1
 	if(!initial_delay)
 		initial_delay = world.tick_lag
 	do

--- a/__DEFINES/tick.dm
+++ b/__DEFINES/tick.dm
@@ -49,7 +49,7 @@
 /proc/stoplag(initial_delay)
 	. = 0
 	var/i = 1
-    if (!initial_delay)
+    if(!initial_delay)
 		initial_delay = world.tick_lag
 	do
 		. += Ceiling(i*DELTA_CALC)

--- a/__DEFINES/tick.dm
+++ b/__DEFINES/tick.dm
@@ -48,7 +48,7 @@
 
 /proc/stoplag(initial_delay)
 	. = 0
-    var/i = 1
+	var/i = 1
 	if(!initial_delay)
 		initial_delay = world.tick_lag
 	do

--- a/__DEFINES/tick.dm
+++ b/__DEFINES/tick.dm
@@ -46,11 +46,13 @@
 //as sleeps aren't cheap and sleeping only to wake up and sleep again is wasteful
 #define DELTA_CALC max(((max(world.tick_usage, world.cpu) / 100) * max(Master.sleep_delta,1)), 1)
 
-/proc/stoplag()
+/proc/stoplag(initial_delay)
 	. = 0
 	var/i = 1
+    if (!initial_delay)
+		initial_delay = world.tick_lag
 	do
-		. += round(i*DELTA_CALC)
+		. += Ceiling(i*DELTA_CALC)
 		sleep(i*world.tick_lag*DELTA_CALC)
 		i *= 2
 	while (world.tick_usage > min(TICK_LIMIT_TO_RUN, CURRENT_TICKLIMIT))

--- a/__DEFINES/tick.dm
+++ b/__DEFINES/tick.dm
@@ -48,8 +48,8 @@
 
 /proc/stoplag(initial_delay)
 	. = 0
-	var/i = 1
-    if(!initial_delay)
+	var/i = 1var/i = 1
+	if(!initial_delay)
 		initial_delay = world.tick_lag
 	do
 		. += Ceiling(i*DELTA_CALC)

--- a/__DEFINES/tick.dm
+++ b/__DEFINES/tick.dm
@@ -7,6 +7,13 @@
 #define MAPTICK_LAST_INTERNAL_TICK_USAGE 50
 #endif
 
+#define TimeOfTick (world.tick_usage*0.01*world.tick_lag)
+
+#define DS2TICKS(DS) ((DS)/world.tick_lag)
+#define TICKS2DS(T) ((T) TICKS)
+#define MS2DS(T) ((T) MILLISECONDS)
+#define DS2MS(T) ((T) * 100)
+
 // Tick limit while running normally
 #define TICK_BYOND_RESERVE 2
 #define TICK_LIMIT_RUNNING (max(100 - TICK_BYOND_RESERVE - MAPTICK_LAST_INTERNAL_TICK_USAGE, MAPTICK_MC_MIN_RESERVE))
@@ -34,3 +41,18 @@
 
 // Do X until it's done, while looking for lag.
 #define UNTIL(X) while(!(X)) stoplag()
+
+//Increases delay as the server gets more overloaded,
+//as sleeps aren't cheap and sleeping only to wake up and sleep again is wasteful
+#define DELTA_CALC max(((max(world.tick_usage, world.cpu) / 100) * max(Master.sleep_delta,1)), 1)
+
+/proc/stoplag()
+	. = 0
+	var/i = 1
+	do
+		. += round(i*DELTA_CALC)
+		sleep(i*world.tick_lag*DELTA_CALC)
+		i *= 2
+	while (world.tick_usage > min(TICK_LIMIT_TO_RUN, CURRENT_TICKLIMIT))
+
+#undef DELTA_CALC

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -1,14 +1,14 @@
+#define MILLISECONDS * 0.01
 #define SECONDS * 10
 #define MINUTES * 600
 #define HOURS   * 36000
 
-#define TimeOfGame (get_game_time())
-#define TimeOfTick (world.tick_usage*0.01*world.tick_lag)
+#define MIDNIGHT_ROLLOVER_CHECK (rollovercheck_last_timeofday != world.timeofday ? update_midnight_rollover() : midnight_rollovers)
+#define MIDNIGHT_ROLLOVER		864000	//number of deciseconds in a day
+#define REALTIMEOFDAY (world.timeofday + (MIDNIGHT_ROLLOVER * MIDNIGHT_ROLLOVER_CHECK))
 
-#define DS2TICKS(DS) ((DS)/world.tick_lag)
-#define TICKS2DS(T) ((T) TICKS)
-#define MS2DS(T) ((T) MILLISECONDS)
-#define DS2MS(T) ((T) * 100)
+
+#define TimeOfGame (get_game_time())
 
 /proc/get_game_time()
 	var/global/time_offset = 0
@@ -33,7 +33,6 @@
 	return "[(round(((timestamp / 600) + 55) / 60) + 11) % 24]:\
 	[(((timestamp / 600) + 55) % 60) < 10 ? add_zero(((timestamp / 600) + 55) % 60, 1) : ((timestamp / 600) + 55) % 60]\
 	[give_seconds ? ":[(timestamp / 10 % 60) < 10 ? add_zero(timestamp / 10 % 60, 1) : timestamp / 10 % 60]" : ""]"
-
 
 /proc/formatTimeDuration(var/deciseconds)
 	var/m = round(deciseconds / 600)
@@ -121,13 +120,11 @@
 			return LATETIME
 	CRASH("getTimeslot: Hour not found.")
 
-
 var/global/obj/effect/statclick/time/time_statclick
 /proc/timeStatEntry()
 	if(!time_statclick)
 		time_statclick = new /obj/effect/statclick/time("loading...")
 	stat("Station Time:", time_statclick.update("[worldtime2text()]"))
-
 
 var/midnight_rollovers = 0
 var/rollovercheck_last_timeofday = 0
@@ -136,7 +133,3 @@ var/rollovercheck_last_timeofday = 0
 		midnight_rollovers++
 	rollovercheck_last_timeofday = world.timeofday
 	return midnight_rollovers
-
-#define MIDNIGHT_ROLLOVER_CHECK (rollovercheck_last_timeofday != world.timeofday ? update_midnight_rollover() : midnight_rollovers)
-#define MIDNIGHT_ROLLOVER		864000	//number of deciseconds in a day
-#define REALTIMEOFDAY (world.timeofday + (MIDNIGHT_ROLLOVER * MIDNIGHT_ROLLOVER_CHECK))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1355,23 +1355,6 @@ Game Mode config tags:
 		projectile.OnFired()
 		projectile.process()
 
-
-//Increases delay as the server gets more overloaded,
-//as sleeps aren't cheap and sleeping only to wake up and sleep again is wasteful
-#define DELTA_CALC max(((max(world.tick_usage, world.cpu) / 100) * max(Master.sleep_delta,1)), 1)
-
-/proc/stoplag()
-	. = 0
-	var/i = 1
-	do
-		. += round(i*DELTA_CALC)
-		sleep(i*world.tick_lag*DELTA_CALC)
-		i *= 2
-	while (world.tick_usage > min(TICK_LIMIT_TO_RUN, CURRENT_TICKLIMIT))
-
-#undef DELTA_CALC
-
-
 /proc/stack_trace(message = "Getting a stack trace.")
 	CRASH(message)
 

--- a/code/_onclick/hud/draggable.dm
+++ b/code/_onclick/hud/draggable.dm
@@ -84,7 +84,7 @@
 				if(attachedobject.drag_use(attachedmob, T)) //cancel our continuous use
 					qdel(src)
 					break
-		sleep(world.tick_lag)
+		stoplag()
 
 /obj/abstract/screen/draggable/MouseDrag(over_object,src_location,turf/over_location,src_control,over_control,params)
 	if(istype(over_location) && attachedmob) //null when over black space

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3701,7 +3701,7 @@
 				for(var/turf/simulated/floor/F in world)
 					count++
 					if(!(count % 50000))
-						sleep(world.tick_lag)
+						stoplag()
 					if(F.z == map.zMainStation)
 						F.name = "lava"
 						F.desc = "The floor is LAVA!"


### PR DESCRIPTION
Based on my previous PR but without the licensing issues #32914

## What this does
- Replaces a `round` with `ceiling` in stoplag
- Switches some `sleep(world.tick_lag)` to `stoplag()`
- moved stoplag to `tick.dm` along with some tick-related defines
- adds a parameter to stoplag so that code that has a parameter for stoplag actually gets used... This is likely stuff ported from tg in times of yore

## Why it's good
- organization
- less invasive and copypasta than my other PR but should still have some benefit