### PR TITLE
Astral Journey Improvements

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
@@ -631,6 +631,7 @@ var/list/astral_projections = list()
 		flags = HEAR | TIMELESS | INVULNERABLE
 		see_invisible = SEE_INVISIBLE_OBSERVER_NOLIGHTING
 		speed = 0.5
+		client.CAN_MOVE_DIAGONALLY = 1
 		overlay_fullscreen("astralborder", /obj/abstract/screen/fullscreen/astral_border)
 		update_fullscreen_alpha("astralborder", 255, 5)
 		var/obj/effect/afterimage/A = new (loc,anchor,10)
@@ -644,6 +645,7 @@ var/list/astral_projections = list()
 		flags = HEAR | PROXMOVE
 		see_invisible = SEE_INVISIBLE_LEVEL_TWO
 		speed = 1
+		client.CAN_MOVE_DIAGONALLY = 0
 		clear_fullscreen("astralborder", animate = 0)
 		alpha = 0
 		animate(src, alpha = 255, time = 10)
@@ -651,6 +653,7 @@ var/list/astral_projections = list()
 			client.images -= propension
 
 	tangibility = !tangibility
+	update_perception()
 
 //saycode
 /mob/living/simple_animal/astral_projection/say(var/message, bubble_type)
@@ -675,3 +678,23 @@ var/list/astral_projections = list()
 		return
 	if(find_active_faction_by_member(iscultist(src)))//can also use cult chat while tangible when using :x
 		return 1
+
+/mob/living/simple_animal/astral_projection/update_perception()
+	if(client)
+		if(client.darkness_planemaster)
+			client.darkness_planemaster.blend_mode = BLEND_MULTIPLY
+			client.darkness_planemaster.alpha = 180
+		if(tangibility)
+			client.color = list(
+						1,0,0,0,
+						0,1.3,0,0,
+						0,0,1.3,0,
+						0,-0.3,-0.3,1,
+						0,0,0,0)
+		else
+			client.color = list(
+				1,0,0,0,
+				0,1,0,0,
+				0,0,1,0,
+				0,0,0,1,
+				0,0,0,0)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
@@ -628,8 +628,7 @@ var/list/astral_projections = list()
 		canmove = 0
 		incorporeal_move = 1
 		flying = 1
-		flags = HEAR | TIMELESS | INVULNERABLE
-		see_invisible = SEE_INVISIBLE_OBSERVER_NOLIGHTING
+		flags = HEAR | TIMELESS | INVULNERABLE	
 		speed = 0.5
 		client.CAN_MOVE_DIAGONALLY = 1
 		overlay_fullscreen("astralborder", /obj/abstract/screen/fullscreen/astral_border)
@@ -646,7 +645,7 @@ var/list/astral_projections = list()
 		see_invisible = SEE_INVISIBLE_LEVEL_TWO
 		speed = 1
 		client.CAN_MOVE_DIAGONALLY = 0
-		clear_fullscreen("astralborder", animate = 0)
+		clear_fullscreen("astralborder", animate = 5)
 		alpha = 0
 		animate(src, alpha = 255, time = 10)
 		if (client)
@@ -684,7 +683,7 @@ var/list/astral_projections = list()
 		if(client.darkness_planemaster)
 			client.darkness_planemaster.blend_mode = BLEND_MULTIPLY
 			client.darkness_planemaster.alpha = 180
-		if(tangibility)
+		if(!tangibility)
 			client.color = list(
 						1,0,0,0,
 						0,1.3,0,0,

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_spells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_spells.dm
@@ -205,6 +205,10 @@
 
 // TODO UPHEAVAL PART 2, make this spell available again as a ritual reward. Though instead of using this code it'll probably be activated through mind UI
 //SPELL III
+
+// DONE!!!
+
+/*
 /spell/cult/blood_dagger
 	name = "Blood Dagger"
 	desc = "(5 BLOOD) Solidify some blood into a sharp weapon. Slash at your enemies to steal their blood. Use the dagger to re-absorb the stolen blood."
@@ -256,7 +260,7 @@
 		H.visible_message("<span class='warning'>\The [user] squeezes the blood in their hand, and it takes the shape of a dagger!</span>",
 			"<span class='warning'>You squeeze the blood in your hand, and it takes the shape of a dagger.</span>")
 		playsound(H, 'sound/weapons/bloodyslice.ogg', 30, 0,-2)
-
+*/
 // TODO UPHEAVAL PART 2, not sure what to do with this spell really, it always kinda sucked and tomes as a whole need an overhaul
 var/list/arcane_pockets = list()
 //SPELL IV

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_tattoos.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_tattoos.dm
@@ -49,7 +49,7 @@ var/list/blood_communion = list()
 	icon_state = "silent"
 	tier = 1
 
-/datum/cult_tattoo/dagger // now available to all cultists by default
+/datum/cult_tattoo/dagger
 	name = TATTOO_DAGGER
 	desc = "Materialize a sharp dagger in your hand for a small cost in blood. Use to retrieve."
 	icon_state = "dagger"
@@ -57,9 +57,10 @@ var/list/blood_communion = list()
 
 /datum/cult_tattoo/dagger/getTattoo(var/mob/M)
 	..()
+	/*
 	if (iscultist(M))
 		M.add_spell(new /spell/cult/blood_dagger, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
-
+	*/
 
 ///////////////////////////
 //                       //


### PR DESCRIPTION

## What this does

- Fullscreen overlay fades out instead of disappearing immediately.
- Prevents diagonal movement while tangible (visible to everyone)
- Gives intangible projections better looking darkvision and and a slight red tint to their vision.

## Why it's good
Looks nicer, improves visibility in dark areas, and prevents yourself from accidentally revealing yourself to be a projection by walking diagonally.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Astral Journey ghosts now have better dark-vision and won't move diagonally while tangible anymore.


