### PR TITLE
Roundstart bugfixes

### DIFF
--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -127,11 +127,11 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 	sleep(1 SECONDS)
 	//moving this random bullshit into here, because it didn't belong in world/New()
 	//SetupHooks() // /N3X15 project from 8 years ago (WIP)
+	generate_radio_frequencies()
 	createDatacore()
 	createPaiController()
 	make_datum_references_lists()	//initialises global lists for referencing frequently used datums (so that we only ever do it once)
 	Holiday = Get_Holiday()
-	generate_radio_frequencies()
 	world.update_status()
 	
 	// Initialize subsystems.

--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -126,8 +126,8 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 	set waitfor = FALSE
 	sleep(1 SECONDS)
 	//moving this random bullshit into here, because it didn't belong in world/New()
-	//SetupHooks() // /N3X15 project from 8 years ago (WIP)
 	generate_radio_frequencies()
+	SetupHooks() // /N3X15 project from 8 years ago (WIP). The jukebox seems to be the only thing using this
 	createDatacore()
 	createPaiController()
 	make_datum_references_lists()	//initialises global lists for referencing frequently used datums (so that we only ever do it once)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -199,7 +199,7 @@ var/datum/controller/gameticker/ticker
 			to_chat(world, "<B>Possibilities:</B> [english_list(modes)]")
 
 	equip_characters()
-	var/discrete_areas = areas.Copy()
+	CHECK_TICK
 	for(var/mob/living/carbon/human/player in player_list)
 		switch(player.mind.assigned_role)
 			if("MODE","Mobile MMI","Trader")
@@ -207,25 +207,12 @@ var/datum/controller/gameticker/ticker
 			else
 				player.update_icons()
 				data_core.manifest_inject(player)
-		//Get populated departments
-		var/area/A = get_area(player)
-		if(A in discrete_areas) //We've already added their department
-			discrete_areas -= get_department_areas(player)
-	CHECK_TICK
-	//Toggle lightswitches and lamps on in occupied departments
-	for(var/area/DA in discrete_areas)
-		for(var/obj/machinery/light_switch/LS in DA)
-			LS.toggle_switch(0)
-			break
-		for(var/obj/item/device/flashlight/lamp/L in DA)
-			L.toggle_onoff(0)
-	CHECK_TICK
+
 	current_state = GAME_STATE_PLAYING
 
 	// Update new player panels so they say join instead of ready up.
 	for(var/mob/new_player/player in player_list)
 		player.new_player_panel_proc()
-
 
 #if UNIT_TESTS_AUTORUN
 	run_unit_tests()
@@ -646,6 +633,21 @@ var/datum/controller/gameticker/ticker
 				R.connect_AI(select_active_ai_with_fewest_borgs())
 				to_chat(R, R.connected_ai?"<b>You have synchronized with an AI. Their name will be stated shortly. Other AIs can be ignored.</b>":"<b>You are not synchronized with an AI, and therefore are not required to heed the instructions of any unless you are synced to them.</b>")
 			R.lawsync()
+
+	spawn()
+		var/discrete_areas = areas.Copy()
+		//Get unpopulated departments
+		for(var/mob/living/carbon/human/player in player_list)
+			var/area/A = get_area(player)
+			if(A in discrete_areas) //We've already added their department
+				discrete_areas -= get_department_areas(player)
+		//Toggle lightswitches and lamps on in occupied departments
+		for(var/area/DA in discrete_areas)
+			for(var/obj/machinery/light_switch/LS in DA)
+				LS.toggle_switch(0)
+				break
+			for(var/obj/item/device/flashlight/lamp/L in DA)
+				L.toggle_onoff(0)
 
 // -- Tag mode!
 /datum/controller/gameticker/proc/tag_mode(var/mob/user)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -414,6 +414,7 @@ var/datum/controller/gameticker/ticker
 				job_master.EquipRank(player, player.mind.assigned_role, 0)
 				EquipCustomItems(player)
 			player.apeify()
+		stoplag()
 	if(captainless)
 		for(var/mob/M in player_list)
 			if(!istype(M,/mob/new_player))

--- a/code/modules/customitems/item_spawning.dm
+++ b/code/modules/customitems/item_spawning.dm
@@ -1,96 +1,95 @@
 
 /proc/EquipCustomItems(mob/living/carbon/human/M)
 //	testing("\[CustomItem\] Checking for custom items for [M.ckey] ([M.real_name])...")
-	spawn()
-		if(!SSdbcore.Connect())
-			return
+	if(!SSdbcore.Connect())
+		return
 
-		// SCHEMA
-		/**
-		* customitems
-		*
-		* cuiCKey VARCHAR(36) NOT NULL,
-		* cuiRealName VARCHAR(60) NOT NULL,
-		* cuiPath VARCHAR(255) NOT NULL,
-		* cuiDescription TEXT NOT NULL,
-		* cuiReason TEXT NOT NULL,
-		* cuiPropAdjust TEXT NOT NULL,
-		* cuiJobMask TEXT NOT NULL,
-		* PRIMARY KEY(cuiCkey,cuiRealName,cuiPath)
-		*/
+	// SCHEMA
+	/**
+	* customitems
+	*
+	* cuiCKey VARCHAR(36) NOT NULL,
+	* cuiRealName VARCHAR(60) NOT NULL,
+	* cuiPath VARCHAR(255) NOT NULL,
+	* cuiDescription TEXT NOT NULL,
+	* cuiReason TEXT NOT NULL,
+	* cuiPropAdjust TEXT NOT NULL,
+	* cuiJobMask TEXT NOT NULL,
+	* PRIMARY KEY(cuiCkey,cuiRealName,cuiPath)
+	*/
 
-		// Grab the info we want.
-		var/datum/DBQuery/query = SSdbcore.NewQuery("SELECT cuiPath, cuiPropAdjust, cuiJobMask FROM customitems WHERE cuiCKey=:ckey AND (cuiRealName=:real_name OR cuiRealName='*')",
-			list(
-				"ckey" = "[M.ckey]",
-				"real_name" = "[M.real_name]"
-		))
-		if(!query.Execute())
-			message_admins("Error: [query.ErrorMsg()]")
-			log_sql("Error: [query.ErrorMsg()]")
-			qdel(query)
-			return
-
-		while(query.NextRow())
-			var/path = text2path(query.item[1])
-			var/propadjust = query.item[2]
-			var/jobmask = query.item[3]
-	//		testing("\[CustomItem\] Setting up [path] for [M.ckey] ([M.real_name]).  jobmask=[jobmask];propadjust=[propadjust]")
-			var/ok=0
-			if(jobmask!="*")
-				var/allowed_jobs = splittext(jobmask,",")
-				var/alt_blocked=0
-				if(M.mind.role_alt_title)
-					if(!(M.mind.role_alt_title in allowed_jobs))
-						alt_blocked=1
-				if(!(M.mind.assigned_role in allowed_jobs) || alt_blocked)
-	//				testing("Failed to apply custom item for [M.ckey]: Role(s) [M.mind.assigned_role][M.mind.role_alt_title ? " (nor "+M.mind.role_alt_title+")" : ""] are not in allowed_jobs ([english_list(allowed_jobs)])")
-					continue
-
-
-			var/obj/item/Item = new path()
-	//		testing("Adding new custom item [query.item[1]] to [key_name_admin(M)]...")
-			if(istype(Item,/obj/item/weapon/card/id))
-				var/obj/item/weapon/card/id/I = Item
-				for(var/obj/item/weapon/card/id/C in M)
-					//default settings
-					I.name = "[M.real_name]'s ID Card ([M.mind.role_alt_title ? M.mind.role_alt_title : M.mind.assigned_role])"
-					I.registered_name = M.real_name
-					I.access = C.access
-					I.assignment = C.assignment
-					I.blood_type = C.blood_type
-					I.dna_hash = C.dna_hash
-					I.fingerprint_hash = C.fingerprint_hash
-					//I.pin = C.pin
-					//replace old ID
-					qdel(C)
-					C = null
-					ok = M.equip_if_possible(I, slot_wear_id, 0)	//if 1, last argument deletes on fail
-					break
-	//			testing("Replaced ID!")
-			else if(istype(M.back, /obj/item/weapon/storage)) // Try to place it in something on the mob's back
-				var/obj/item/weapon/storage/backpack = M.back
-				if(backpack.contents.len < backpack.storage_slots)
-					Item.forceMove(M.back)
-					ok = 1
-		//			testing("Added to [M.back.name]!")
-					to_chat(M, "<span class='notice'>Your [Item.name] has been added to your [M.back.name].</span>")
-			else
-				for(var/obj/item/weapon/storage/S in M.contents) // Try to place it in any item that can store stuff, on the mob.
-					if (S.contents.len < S.storage_slots)
-						Item.forceMove(S)
-						ok = 1
-	//					testing("Added to [S]!")
-						to_chat(M, "<span class='notice'>Your [Item.name] has been added to your [S.name].</span>")
-						break
-
-			//skip:
-			if (ok == 0) // Finally, since everything else failed, place it on the ground
-	//			testing("Plopped onto the ground!")
-				Item.forceMove(get_turf(M.loc))
-
-			HackProperties(Item,propadjust)
+	// Grab the info we want.
+	var/datum/DBQuery/query = SSdbcore.NewQuery("SELECT cuiPath, cuiPropAdjust, cuiJobMask FROM customitems WHERE cuiCKey=:ckey AND (cuiRealName=:real_name OR cuiRealName='*')",
+		list(
+			"ckey" = "[M.ckey]",
+			"real_name" = "[M.real_name]"
+	))
+	if(!query.Execute())
+		message_admins("Error: [query.ErrorMsg()]")
+		log_sql("Error: [query.ErrorMsg()]")
 		qdel(query)
+		return
+
+	while(query.NextRow())
+		var/path = text2path(query.item[1])
+		var/propadjust = query.item[2]
+		var/jobmask = query.item[3]
+//		testing("\[CustomItem\] Setting up [path] for [M.ckey] ([M.real_name]).  jobmask=[jobmask];propadjust=[propadjust]")
+		var/ok=0
+		if(jobmask!="*")
+			var/allowed_jobs = splittext(jobmask,",")
+			var/alt_blocked=0
+			if(M.mind.role_alt_title)
+				if(!(M.mind.role_alt_title in allowed_jobs))
+					alt_blocked=1
+			if(!(M.mind.assigned_role in allowed_jobs) || alt_blocked)
+//				testing("Failed to apply custom item for [M.ckey]: Role(s) [M.mind.assigned_role][M.mind.role_alt_title ? " (nor "+M.mind.role_alt_title+")" : ""] are not in allowed_jobs ([english_list(allowed_jobs)])")
+				continue
+
+
+		var/obj/item/Item = new path()
+//		testing("Adding new custom item [query.item[1]] to [key_name_admin(M)]...")
+		if(istype(Item,/obj/item/weapon/card/id))
+			var/obj/item/weapon/card/id/I = Item
+			for(var/obj/item/weapon/card/id/C in M)
+				//default settings
+				I.name = "[M.real_name]'s ID Card ([M.mind.role_alt_title ? M.mind.role_alt_title : M.mind.assigned_role])"
+				I.registered_name = M.real_name
+				I.access = C.access
+				I.assignment = C.assignment
+				I.blood_type = C.blood_type
+				I.dna_hash = C.dna_hash
+				I.fingerprint_hash = C.fingerprint_hash
+				//I.pin = C.pin
+				//replace old ID
+				qdel(C)
+				C = null
+				ok = M.equip_if_possible(I, slot_wear_id, 0)	//if 1, last argument deletes on fail
+				break
+//			testing("Replaced ID!")
+		else if(istype(M.back, /obj/item/weapon/storage)) // Try to place it in something on the mob's back
+			var/obj/item/weapon/storage/backpack = M.back
+			if(backpack.contents.len < backpack.storage_slots)
+				Item.forceMove(M.back)
+				ok = 1
+	//			testing("Added to [M.back.name]!")
+				to_chat(M, "<span class='notice'>Your [Item.name] has been added to your [M.back.name].</span>")
+		else
+			for(var/obj/item/weapon/storage/S in M.contents) // Try to place it in any item that can store stuff, on the mob.
+				if (S.contents.len < S.storage_slots)
+					Item.forceMove(S)
+					ok = 1
+//					testing("Added to [S]!")
+					to_chat(M, "<span class='notice'>Your [Item.name] has been added to your [S.name].</span>")
+					break
+
+		//skip:
+		if (ok == 0) // Finally, since everything else failed, place it on the ground
+//			testing("Plopped onto the ground!")
+			Item.forceMove(get_turf(M.loc))
+
+		HackProperties(Item,propadjust)
+	qdel(query)
 
 	// This is hacky, but since it's difficult as fuck to make a proper parser in BYOND without killing the server, here it is. - N3X
 /proc/HackProperties(var/mob/living/carbon/human/M,var/obj/item/I,var/script)


### PR DESCRIPTION
[hotfix]

Now that the lights start immediately on, turning off empty departments is less of a priority, so this PR moves it to a spot that should affect players less.

## What this does
- Moves some code to a lesser priority function
- Removes `spawn()` from `EquipCustomItems` so everything should be loaded before players are injected
- SetupHooks are actually used to my surprise

## Why it's good
- Closes #33079
- Closes #33076
- Closes #33086
- (maybe, I can't think of any way to fix this right now)