### PR TITLE
Diamond dust works as Doctor's Delight if consumed by a golem.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2278,9 +2278,23 @@
 	if(..())
 		return 1
 
-	M.adjustBruteLoss(5 * REM) //Not a good idea to eat crystal powder
-	if(prob(30))
-		M.audible_scream()
+	if(isgolem(M)) //golems metabolize the diamond into very expensive doctor's delight
+		if(M.getOxyLoss())
+			M.adjustOxyLoss(-2)
+		if(M.getBruteLoss())
+			M.heal_organ_damage(2, 0)
+		if(M.getFireLoss())
+			M.heal_organ_damage(0, 2)
+		if(M.getToxLoss())
+			M.adjustToxLoss(-2)
+		if(M.dizziness != 0)
+			M.dizziness = max(0, M.dizziness - 15)
+		if(M.confused != 0)
+			M.remove_confused(5)
+	else
+		M.adjustBruteLoss(5 * REM) //Not a good idea to eat crystal powder
+		if(prob(30))
+			M.audible_scream()
 
 /datum/reagent/phazon
 	name = "Phazon Salt"


### PR DESCRIPTION
### What this does
By now most know that eating diamond dust is not a good idea, unless you fancy tons of brute damage and screaming, that is, if you're not a golem. Golems have recently discovered they have a particular affinity with powdered diamond, which reinforces and restores the damaged adamantite.
### Why it's good
Fluff and gives a non-manufacturing non-lethal use for diamond dust.
:cl:
 * rscadd: Diamond dust now works as Doctor's Delight if consumed by a golem. It still hurts if consumed by any other species.