### PR TITLE
Silver makes you blue (sometimes).

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2223,6 +2223,13 @@
 	color = "#D0D0D0" //rgb: 208, 208, 208
 	specheatcap = 0.24
 	density = 10.49
+	
+/datum/reagent/silver/on_mob_life(var/mob/living/M)
+	if(..())
+		return 1
+	if(prob(5)) //so you need lots to go blue	
+		M.color = "#12A7C9"
+		return
 
 /datum/reagent/uranium
 	name ="Uranium salt"


### PR DESCRIPTION
>does it turn you blue if you drink enough silver dust

Now it does. Suggested by @WindowsErrors.
### What this does
Consuming raw silver has a 5% chance per tick to trigger [Argyria](https://en.wikipedia.org/wiki/Argyria), making you blue. Spessmen are tough, so it does no damage to the organs, however it does carry into the clothing. 
### Why it's good
Funny in context and semi-realistic.
:cl:
 * rscadd: Silver powder has a 5% chance per tick to make you blue.