### PR TITLE
Adds blue helmets to the Security Vendor's premium section

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2057,7 +2057,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/clothing/head/helmet/tactical/antichrist = 2,
 		/obj/item/clothing/under/police = 2,
 		/obj/item/clothing/under/casualsec = 2,
-		/obj/item/device/modkit/fatsec_rig = 2,
+		/obj/item/device/modkit/fatsec_rig = 2
 		)
 	vouched = list(
 		/obj/item/ammo_storage/magazine/m380auto = 10,

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2054,9 +2054,10 @@ var/global/num_vending_terminals = 1
 	premium = list(
 		/obj/item/clothing/head/helmet/siren = 2,
 		/obj/item/clothing/head/helmet/police = 2,
+		/obj/item/clothing/head/helmet/tactical/antichrist = 2,
 		/obj/item/clothing/under/police = 2,
 		/obj/item/clothing/under/casualsec = 2,
-		/obj/item/device/modkit/fatsec_rig = 2
+		/obj/item/device/modkit/fatsec_rig = 2,
 		)
 	vouched = list(
 		/obj/item/ammo_storage/magazine/m380auto = 10,


### PR DESCRIPTION
Now you can barge into R&D with style!

:cl:
 * rscadd: Added blue helmets to the Security Vendor's premium section, which can be accessed by using coins.