### PR TITLE
removes a sneakycoded change that forces all nuclear operatives to be human

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -464,7 +464,7 @@ Assign your candidates in choose_candidates() instead.
 		if(spawnpos > synd_spawn.len)
 			spawnpos = 1
 		M.forceMove(synd_spawn[spawnpos])
-		if(!isjusthuman(M))
+		if(!ishuman(M))
 			M = M.Humanize("Human")
 		if(leader)
 			leader = 0


### PR DESCRIPTION
#31874 at fault

:cl: 
 * bugfix: Operatives can now be nonhumans again.