### PR TITLE
Roundstart speed

### DIFF
--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -45,7 +45,7 @@
 
 // Toggles several features, explained in their respective comments.
 // You can turn those on and off manually if you prefer, instead of setting this
-#define DEVELOPER_MODE 0
+#define DEVELOPER_MODE 1
 
 // If 1, unit tests will be compiled
 #define UNIT_TESTS_ENABLED 0
@@ -56,7 +56,7 @@
 
 #if DEVELOPER_MODE
 // If defined, overrides the default lobby timer duration
-#define GAMETICKER_LOBBY_DURATION 5 SECONDS
+#define GAMETICKER_LOBBY_DURATION 35 SECONDS
 #endif
 // If 1, mob/Login checks for multiple connections from the same IP on different ckeys and warns the user
 #define WARN_FOR_CLIENTS_SHARING_IP !DEVELOPER_MODE

--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -45,7 +45,7 @@
 
 // Toggles several features, explained in their respective comments.
 // You can turn those on and off manually if you prefer, instead of setting this
-#define DEVELOPER_MODE 1
+#define DEVELOPER_MODE 0
 
 // If 1, unit tests will be compiled
 #define UNIT_TESTS_ENABLED 0
@@ -56,7 +56,7 @@
 
 #if DEVELOPER_MODE
 // If defined, overrides the default lobby timer duration
-#define GAMETICKER_LOBBY_DURATION 35 SECONDS
+#define GAMETICKER_LOBBY_DURATION 5 SECONDS
 #endif
 // If 1, mob/Login checks for multiple connections from the same IP on different ckeys and warns the user
 #define WARN_FOR_CLIENTS_SHARING_IP !DEVELOPER_MODE

--- a/code/datums/gamemode/factions/syndicate/nukeops.dm
+++ b/code/datums/gamemode/factions/syndicate/nukeops.dm
@@ -51,9 +51,7 @@
 /datum/faction/syndicate/nuke_op/OnPostSetup()
 	. = ..()
 
-	var/obj/effect/landmark/uplinklocker = locate("landmark*Syndicate-Uplink") //I will be rewriting this shortly
 	var/obj/effect/landmark/nuke_spawn = locate("landmark*Nuclear-Bomb")
-
 	var/nuke_code = "[rand(10000, 99999)]"
 	var/leader_selected = 0
 	var/agent_number = 1
@@ -84,9 +82,6 @@
 		spawn()
 			concrete_outfit.chosen_spec = equip_nuke_loadout(synd_mind.current)
 			concrete_outfit.equip_special_items(synd_mind.current)
-
-	if(uplinklocker)
-		new /obj/structure/closet/syndicate/nuclear(uplinklocker.loc)
 
 	if(nuke_spawn && synd_spawn.len > 0)
 		var/obj/machinery/nuclearbomb/the_bomb = new /obj/machinery/nuclearbomb(nuke_spawn.loc)

--- a/code/datums/gamemode/gamemode.dm
+++ b/code/datums/gamemode/gamemode.dm
@@ -184,17 +184,6 @@
 		F.HandleRecruitedMind(mob.mind)
 
 /datum/gamemode/proc/PostSetup()
-	spawn (ROUNDSTART_LOGOUT_REPORT_TIME)
-		display_roundstart_logout_report()
-
-	spawn (rand(INTERCEPT_TIME_LOW , INTERCEPT_TIME_HIGH))
-		send_intercept()
-
-	feedback_set_details("round_start","[time2text(world.realtime)]")
-	if(ticker && ticker.mode)
-		feedback_set_details("game_mode","[ticker.mode]")
-	feedback_set_details("server_ip","[world.internet_address]:[world.port]")
-
 	for(var/datum/faction/F in factions)
 		F.forgeObjectives()
 		F.OnPostSetup()
@@ -202,6 +191,10 @@
 		R.ForgeObjectives()
 		R.AnnounceObjectives()
 		R.OnPostSetup()
+	feedback_set_details("round_start","[time2text(world.realtime)]")
+	if(ticker && ticker.mode)
+		feedback_set_details("game_mode","[ticker.mode]")
+	feedback_set_details("server_ip","[world.internet_address]:[world.port]")
 	return 1
 
 /datum/gamemode/proc/TearDown()

--- a/code/datums/gamemode/gamemode.dm
+++ b/code/datums/gamemode/gamemode.dm
@@ -191,10 +191,6 @@
 		R.ForgeObjectives()
 		R.AnnounceObjectives()
 		R.OnPostSetup()
-	feedback_set_details("round_start","[time2text(world.realtime)]")
-	if(ticker && ticker.mode)
-		feedback_set_details("game_mode","[ticker.mode]")
-	feedback_set_details("server_ip","[world.internet_address]:[world.port]")
 	return 1
 
 /datum/gamemode/proc/TearDown()

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -172,19 +172,13 @@ var/datum/controller/gameticker/ticker
 	init_mind_ui()
 	init_PDAgames_leaderboard()
 	for(var/mob/new_player/player in player_list)
-		var/datum/mind/mind = create_characters(player) //Create player characters and transfer them
-		if(!mind)
-			continue
-		switch(mind.assigned_role)
-			if("MODE","Mobile MMI","Trader", "Cyborg", "AI")
-				//silicons already on manifest
-			else
-				player.update_icons()
-				data_core.manifest_inject(player)
+		create_characters(player) //Create player characters and transfer them
 
 	if(ape_mode == APE_MODE_EVERYONE)	//this likely doesn't work properly
 		for(var/mob/living/carbon/human/player in player_list)
 			player.apeify()
+
+	gamestart_time = world.time / 10
 
 	var/can_continue = mode.Setup()//Setup special modes
 	if(!can_continue)
@@ -198,12 +192,6 @@ var/datum/controller/gameticker/ticker
 	
 	mode.PostSetup()
 
-	//antags spawn with PDAs or other crew specific items on the ground, this is a solution (not a good one)
-	for(var/mob/living/carbon/human/player in player_list)
-		var/turf/T = get_turf(player)
-		for(var/obj/item/I in T)
-			qdel(I)
-
 	if(hide_mode)
 		var/list/modes = new
 		for (var/datum/gamemode/M in runnable_modes)
@@ -215,8 +203,15 @@ var/datum/controller/gameticker/ticker
 			to_chat(world, "<B>The current game mode is - Secret!</B>")
 			to_chat(world, "<B>Possibilities:</B> [english_list(modes)]")
 
+	for(var/mob/living/carbon/human/player in player_list)
+		switch(player.mind.assigned_role)
+			if("MODE","Mobile MMI","Trader")
+				//No injection
+			else
+				player.update_icons()
+				data_core.manifest_inject(player)
+
 	current_state = GAME_STATE_PLAYING
-	gamestart_time = world.time / 10
 
 	// Update new player panels so they say join instead of ready up.
 	for(var/mob/new_player/player in player_list)
@@ -364,8 +359,6 @@ var/datum/controller/gameticker/ticker
 		if(new_character.mind.assigned_role != "MODE")
 			job_master.EquipRank(new_character, new_character.mind.assigned_role, 0)
 			EquipCustomItems(new_character)
-
-		return new_character.mind
 
 /datum/controller/gameticker/proc/process()
 	if(current_state != GAME_STATE_PLAYING)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -206,7 +206,9 @@ var/datum/controller/gameticker/ticker
 	for(var/mob/living/carbon/human/player in player_list)
 		switch(player.mind.assigned_role)
 			if("MODE","Mobile MMI","Trader")
-				//No injection
+				var/turf/T = get_turf(player)
+				for(var/obj/item/I in T.contents)
+					qdel(I)
 			else
 				player.update_icons()
 				data_core.manifest_inject(player)
@@ -214,9 +216,7 @@ var/datum/controller/gameticker/ticker
 	current_state = GAME_STATE_PLAYING
 
 	// Update new player panels so they say join instead of ready up.
-	for(var/mob/new_player/player in player_list)
-		if(player.ready)
-			qdel(player)
+	for(var/mob/new_player/player in player_list)	
 		player.new_player_panel_proc()
 
 #if UNIT_TESTS_AUTORUN
@@ -359,6 +359,7 @@ var/datum/controller/gameticker/ticker
 		if(new_character.mind.assigned_role != "MODE")
 			job_master.EquipRank(new_character, new_character.mind.assigned_role, 0)
 			EquipCustomItems(new_character)
+		qdel(player)
 
 /datum/controller/gameticker/proc/process()
 	if(current_state != GAME_STATE_PLAYING)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -413,10 +413,6 @@ var/datum/controller/gameticker/ticker
 			player.apeify()
 		stoplag()
 
-	for(var/mob/M in player_list)
-		if(!istype(M,/mob/new_player))
-			M.store_position()//updates the players' origin_ vars so they retain their location when the round starts.
-
 /datum/controller/gameticker/proc/process()
 	if(current_state != GAME_STATE_PLAYING)
 		return 0

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -184,13 +184,9 @@ var/datum/controller/gameticker/ticker
 				player.create_roundstart_silicon(player.mind.assigned_role)
 				log_admin("([player.ckey]) started the game as a [player.mind.assigned_role].")
 			if("MODE", "Trader")
-				//not on manifest
-				//delete items?? Why are they on this guy? FIX THIS
-				var/turf/T = get_turf(player)
-				for(var/obj/item/I in T.contents)
-					qdel(I)
+				//do nothing
 			else
-				player.create_roundstart_human() //Create player characters and transfer them*/
+				player.create_roundstart_human() //Create player characters and transfer them
 
 	if(ape_mode == APE_MODE_EVERYONE)	//this likely doesn't work properly, why does it only apply to humans?
 		for(var/mob/living/carbon/human/player in player_list)
@@ -568,13 +564,21 @@ var/datum/controller/gameticker/ticker
 	spawn()
 		var/discrete_areas = areas.Copy()
 		var/captain = FALSE
-		//Get unpopulated departments
+
 		for(var/mob/living/carbon/human/player in player_list)
 			var/area/A = get_area(player)
-			if(A in discrete_areas) //We've already added their department
+			//Getting areas where there is a crewmember. This is used to turn off lights in empty departments
+			if(A in discrete_areas)
 				discrete_areas -= get_department_areas(player)
-			if(player && player.mind && player.mind.assigned_role && player.mind.assigned_role == "Captain")
-				captain = TRUE
+			//Used to display a message the captainship message
+			if(player.mind && player.mind.assigned_role)
+				if(player.mind.assigned_role == "Captain")
+					captain = TRUE
+				switch(player.mind.assigned_role)
+					if("MODE","Trader")
+						//No injection
+					else
+						data_core.manifest_inject(player)
 		//Toggle lightswitches and lamps on in occupied departments
 		for(var/area/DA in discrete_areas)
 			for(var/obj/machinery/light_switch/LS in DA)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -217,42 +217,13 @@ var/datum/controller/gameticker/ticker
 	run_unit_tests()
 #endif
 
-//		world << sound('sound/AI/welcome.ogg')// Skie //Out with the old, in with the new. - N3X15
-
-		if(!config.shut_up_automatic_diagnostic_and_announcement_system)
-			var/welcome_sentence=list('sound/AI/vox_login.ogg')
-			welcome_sentence += pick(
-				'sound/AI/vox_reminder1.ogg',
-				'sound/AI/vox_reminder2.ogg',
-				'sound/AI/vox_reminder3.ogg',
-				'sound/AI/vox_reminder4.ogg',
-				'sound/AI/vox_reminder5.ogg',
-				'sound/AI/vox_reminder6.ogg',
-				'sound/AI/vox_reminder7.ogg',
-				'sound/AI/vox_reminder8.ogg',
-				'sound/AI/vox_reminder9.ogg',
-				'sound/AI/vox_reminder10.ogg',
-				'sound/AI/vox_reminder11.ogg',
-				'sound/AI/vox_reminder12.ogg',
-				'sound/AI/vox_reminder13.ogg',
-				'sound/AI/vox_reminder14.ogg',
-				'sound/AI/vox_reminder15.ogg')
-			for(var/sound in welcome_sentence)
-				play_vox_sound(sound,map.zMainStation,null)
-		//Holiday Round-start stuff	~Carn
-		Holiday_Game_Start()
-		//mode.Clean_Antags()
-		create_random_orders(3) //Populate the order system so cargo has something to do
-	//start_events() //handles random events and space dust.
-	//new random event system is handled from the MC.
-
-	if(0 == admins.len)
-		send2adminirc("Round has started with no admins online.")
-		send2admindiscord("**Round has started with no admins online.**", TRUE)
-
 	if(config.sql_enabled)
 		spawn(3000)
 		statistic_cycle() // Polls population totals regularly and stores them in an SQL DB -- TLE
+
+	//mode.Clean_Antags()
+	//start_events() //handles random events and space dust.
+	//new random event system is handled from the MC.
 
 	stat_collection.round_start_time = world.realtime
 	Master.RoundStart()
@@ -647,7 +618,38 @@ var/datum/controller/gameticker/ticker
 					qdel(obj)
 
 		to_chat(world, "<span class='notice'><B>Enjoy the game!</B></span>")
+		//Holiday Round-start stuff	~Carn
+		Holiday_Game_Start()
+		
+		if(0 == admins.len)
+			send2adminirc("Round has started with no admins online.")
+			send2admindiscord("**Round has started with no admins online.**", TRUE)
 		send2maindiscord("**The game has started**")
+
+		//		world << sound('sound/AI/welcome.ogg')// Skie //Out with the old, in with the new. - N3X15
+
+	if(!config.shut_up_automatic_diagnostic_and_announcement_system)
+		var/welcome_sentence=list('sound/AI/vox_login.ogg')
+		welcome_sentence += pick(
+			'sound/AI/vox_reminder1.ogg',
+			'sound/AI/vox_reminder2.ogg',
+			'sound/AI/vox_reminder3.ogg',
+			'sound/AI/vox_reminder4.ogg',
+			'sound/AI/vox_reminder5.ogg',
+			'sound/AI/vox_reminder6.ogg',
+			'sound/AI/vox_reminder7.ogg',
+			'sound/AI/vox_reminder8.ogg',
+			'sound/AI/vox_reminder9.ogg',
+			'sound/AI/vox_reminder10.ogg',
+			'sound/AI/vox_reminder11.ogg',
+			'sound/AI/vox_reminder12.ogg',
+			'sound/AI/vox_reminder13.ogg',
+			'sound/AI/vox_reminder14.ogg',
+			'sound/AI/vox_reminder15.ogg')
+		for(var/sound in welcome_sentence)
+			play_vox_sound(sound,map.zMainStation,null)
+	
+	create_random_orders(3) //Populate the order system so cargo has something to do
 
 // -- Tag mode!
 /datum/controller/gameticker/proc/tag_mode(var/mob/user)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -169,13 +169,16 @@ var/datum/controller/gameticker/ticker
 
 	//Configure mode and assign player to special mode stuff
 	job_master.DivideOccupations() //Distribute jobs
-
-	gamestart_time = world.time / 10
-
 	init_mind_ui()
 	init_PDAgames_leaderboard()
 	create_characters() //Create player characters and transfer them
-	CHECK_TICK
+
+	if(ape_mode == APE_MODE_EVERYONE)	//this likely doesn't work properly
+		for(var/mob/living/carbon/human/player in player_list)
+			player.apeify()
+
+	gamestart_time = world.time / 10
+
 	var/can_continue = mode.Setup()//Setup special modes
 	if(!can_continue)
 		current_state = GAME_STATE_PREGAME
@@ -353,7 +356,6 @@ var/datum/controller/gameticker/ticker
 			if(new_character.mind.assigned_role != "MODE")
 				job_master.EquipRank(new_character, new_character.mind.assigned_role, 0)
 				EquipCustomItems(new_character)
-			new_character.apeify()
 
 /datum/controller/gameticker/proc/process()
 	if(current_state != GAME_STATE_PLAYING)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -336,7 +336,7 @@ var/datum/controller/gameticker/ticker
 
 	no_life_on_station = TRUE
 
-/datum/controller/gameticker/proc/create_characters()
+/datum/controller/gameticker/proc/create_characters(var/mob/new_player/player)
 	for(var/mob/new_player/player in player_list)
 		if(!player.mind)
 			continue

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -174,10 +174,10 @@ var/datum/controller/gameticker/ticker
 
 	for(var/mob/new_player/player in player_list)
 		if(!(player && player.ready && player.mind && player.mind.assigned_role))
-			return
+			continue
 		var/mob/living/L = player
 		if(istype(L))
-			//ticker.minds += L.mind
+			ticker.minds += L.mind
 		
 		switch(player.mind.assigned_role)
 			if("Mobile MMI", "Cyborg", "AI")
@@ -190,7 +190,7 @@ var/datum/controller/gameticker/ticker
 				for(var/obj/item/I in T.contents)
 					qdel(I)
 			else
-				player.create_roundstart_human() //Create player characters and transfer them
+				player.create_roundstart_human() //Create player characters and transfer them*/
 
 	if(ape_mode == APE_MODE_EVERYONE)	//this likely doesn't work properly, why does it only apply to humans?
 		for(var/mob/living/carbon/human/player in player_list)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -768,6 +768,15 @@
 
 	return new_character
 
+/mob/new_player/proc/create_roundstart_human()
+	var/mob/living/carbon/human/new_character = create_character(0)
+	qdel(src)
+	new_character.DormantGenes(20,10,0,0) // 20% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
+	job_master.EquipRank(new_character, new_character.mind.assigned_role, 0)
+	EquipCustomItems(new_character)
+	new_character.update_icons()
+	data_core.manifest_inject(new_character)
+
 //Basically, a stripped down version of create_character(). We don't care about DNA, prefs, species, etc. and we skip some rather lengthy setup for each step.
 /mob/new_player/proc/create_roundstart_silicon(var/type)
 	if(type != "Cyborg" && type != "AI" && type != "Mobile MMI")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -733,7 +733,7 @@
 	domutcheck(new_character, null, MUTCHK_FORCED)
 
 	var/rank = new_character.mind.assigned_role
-	if(ticker.current_state == GAME_STATE_PLAYING)
+	if(!(ticker.current_state == GAME_STATE_PLAYING))
 		var/obj/S = null
 		// Find a spawn point that wasn't given to anyone
 		for(var/obj/effect/landmark/start/sloc in landmarks_list)
@@ -769,12 +769,9 @@
 	return new_character
 
 /mob/new_player/proc/create_roundstart_human()
-	var/mob/living/carbon/human/new_character = create_character(0)
+	var/mob/living/carbon/human/new_character = create_character()
 	qdel(src)
 	new_character.DormantGenes(20,10,0,0) // 20% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
-	job_master.EquipRank(new_character, new_character.mind.assigned_role, 0)
-	EquipCustomItems(new_character)
-	new_character.update_icons()
 
 //Basically, a stripped down version of create_character(). We don't care about DNA, prefs, species, etc. and we skip some rather lengthy setup for each step.
 /mob/new_player/proc/create_roundstart_silicon(var/type)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -751,9 +751,6 @@
 				S = sloc
 				stack_trace("not enough spawn points for [rank]")
 				break
-		if(!S)
-			// Find a spawn point that's using the ancient landmarks. Do we even have these anymore?
-			S = locate("start*[rank]")
 		if(S)
 			// Use the given spawn point
 			new_character.forceMove(S.loc)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -654,7 +654,7 @@
 	src << browse(dat, "window=latechoices;size=360x640;can_close=1")
 
 
-/mob/new_player/proc/create_character(var/joined_late = 0)
+/mob/new_player/proc/create_character()
 	spawning = 1
 	close_spawn_windows()
 
@@ -733,7 +733,7 @@
 	domutcheck(new_character, null, MUTCHK_FORCED)
 
 	var/rank = new_character.mind.assigned_role
-	if(!joined_late)
+	if(ticker.current_state == GAME_STATE_PLAYING)
 		var/obj/S = null
 		// Find a spawn point that wasn't given to anyone
 		for(var/obj/effect/landmark/start/sloc in landmarks_list)
@@ -775,7 +775,6 @@
 	job_master.EquipRank(new_character, new_character.mind.assigned_role, 0)
 	EquipCustomItems(new_character)
 	new_character.update_icons()
-	data_core.manifest_inject(new_character)
 
 //Basically, a stripped down version of create_character(). We don't care about DNA, prefs, species, etc. and we skip some rather lengthy setup for each step.
 /mob/new_player/proc/create_roundstart_silicon(var/type)

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -53843,9 +53843,7 @@
 	},
 /area/shuttle/nuclearops)
 "dxQ" = (
-/obj/effect/landmark{
-	name = "Syndicate-Uplink"
-	},
+/obj/structure/closet/syndicate/nuclear,
 /turf/unsimulated/floor{
 	icon_state = "floor4"
 	},


### PR DESCRIPTION
Still naked at round start for several seconds. There are many `for(var/mob/living/carbon/human/player in player_list)`  that could be combined and prioritized differently.

Since #31796 and #31104, there's no way to deal with how dynamic mode creates antags, as they rely on `human` which are created when crew spawn.

## What this does

The general idea was to reduce the amount of overhead by eliminating loops that could be combined with other loops, so that it goes through each player just once, rather than about 6 times more than is required. I needed to move parts around to do this, but it works... I tested it with AIs, clowns, captains, nuke ops, wizards, etc.

- removes some `src.`
- `mind_collect`, `equip_characters`, and `create_characters` all loop through the same stuff, so I merged them into one
- I moved some stuff, like whether there's a captain and `store_position` (I don't know it's purpose) into another loop that already exists
- moved `apeify` into its own thing so it doesn't loop through every player. It only needs to be checked once
- moved some lower priority stuff to `post_roundstart`

## Why it's good
- This doesn't change the order of things (so it shouldn't mess anything up, see #31796 and #31104)
- fixes some old code that can prevent nuke ops locker from spawning items
- be naked for a shorter amount of time
- Closes #33102

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: you should naked for less time now