### PR TITLE
Radiation alerts now display in depowered areas

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -337,10 +337,11 @@ var/area/space_area
 		return ambience_list
 
 /area/proc/updateicon()
-	if (!areaapc)
+	if (!areaapc && !radalert)
 		icon_state = null
 		return
-	if ((fire || eject || party || radalert) && ((!requires_power)?(!requires_power):power_environ))//If it doesn't require power, can still activate this proc.
+	//If the area doesn't require power, it can still activate this proc. Radiation alerts don't check for power
+	if (((fire || eject || party) && ((!requires_power)?(!requires_power):power_environ)) || radalert)
 		// Highest priority at the top.
 		if(radalert && !fire)
 			icon_state = "radiation"


### PR DESCRIPTION
## What this does
Radiation storms will now display the radiation alert even in areas without an APC or without power.
This will still only affect areas on the station's z-level.

## Why it's good
Better clarity for what the radiation storm is actually affecting. Players in de-powered areas frequently believe they're safe or their area is shielded when it is not.

Closes #33098

:cl:
 * tweak: Radiation storms will now display the radiation alert even in areas without an APC or without power.
