### PR TITLE
Scale miner output with power

### DIFF
--- a/code/game/machinery/atmoalter/gas_mine.dm
+++ b/code/game/machinery/atmoalter/gas_mine.dm
@@ -179,7 +179,7 @@
 	overlay_color = "#007FFF"
 	gases = list(GAS_OXYGEN = 1)
 
-/obj/machinery/atmospherics/miner/plasma
+/obj/machinery/atmospherics/miner/toxins
 	name = "\improper Plasma Gas Miner"
 	overlay_color = "#FF0000"
 	gases = list(GAS_PLASMA = 1)

--- a/code/game/machinery/atmoalter/gas_mine.dm
+++ b/code/game/machinery/atmoalter/gas_mine.dm
@@ -142,7 +142,9 @@
 		power_load += 1000
 	else if (power_surplus < 0.45 && power_load > 0)
 		power_load -= 1000
-		
+	else
+		power_load = 0
+
 	active_power_usage = power_load
 	update_rate(Ceiling(0.1 * power_load))		//scale mol output by arbitrary 10% power load
 

--- a/code/game/machinery/atmoalter/gas_mine.dm
+++ b/code/game/machinery/atmoalter/gas_mine.dm
@@ -140,11 +140,11 @@
 
 	if(power_surplus > 0.55)
 		power_load += 1000
-		active_power_usage = power_load
-		update_rate(Ceiling(0.1 * power_load))		//scale mol output by arbitrary 10% power load
 	else if (power_surplus < 0.45 && power_load > 0)
 		power_load -= 1000
-		update_rate(0)	
+		
+	active_power_usage = power_load
+	update_rate(Ceiling(0.1 * power_load))		//scale mol output by arbitrary 10% power load
 
 	//gas-related
 	var/datum/gas_mixture/environment = loc.return_air()

--- a/code/game/machinery/atmoalter/gas_mine.dm
+++ b/code/game/machinery/atmoalter/gas_mine.dm
@@ -140,7 +140,6 @@
 
 	if(power_surplus > 0.55)
 		power_load += 1000
-		to_chat(world, "Power load: [power_load]")
 		active_power_usage = power_load
 		update_rate(Ceiling(0.1 * power_load))		//scale mol output by arbitrary 10% power load
 	else if (power_surplus < 0.45 && power_load > 0)

--- a/code/game/machinery/atmoalter/gas_mine.dm
+++ b/code/game/machinery/atmoalter/gas_mine.dm
@@ -14,7 +14,7 @@
 
 	var/datum/gas_mixture/air_contents
 	var/datum/gas_mixture/pumping //used in transfering air around
-	var/max_external_pressure=10000 // 10,000kPa ought to do it.
+	//var/max_external_pressure=10000 // 10,000kPa ought to do it.
 	var/list/gases = list()
 
 	var/overlay_color = "#FFFFFF"
@@ -149,11 +149,11 @@
 	update_rate(Ceiling(0.1 * power_load))		//scale mol output by arbitrary 10% power load
 
 	//gas-related
-	var/datum/gas_mixture/environment = loc.return_air()
-	var/environment_pressure = environment.return_pressure()
+	//var/datum/gas_mixture/environment = loc.return_air()
+	//var/environment_pressure = environment.return_pressure()
 
 	pumping.copy_from(air_contents)
-
+/*
 	var/pressure_delta = 10000
 
 	// External pressure bound
@@ -162,7 +162,7 @@
 	if(pressure_delta > 0.1)
 		var/transfer_moles = pressure_delta * CELL_VOLUME / (pumping.temperature * R_IDEAL_GAS_EQUATION)
 		var/datum/gas_mixture/removed = pumping.remove(transfer_moles)
-		loc.assume_air(removed)
+		loc.assume_air(removed)*/
 
 /obj/machinery/atmospherics/miner/sleeping_agent
 	name = "\improper N2O Gas Miner"

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -90103,7 +90103,7 @@
 	},
 /area/derelict/medical/chapel)
 "nEu" = (
-/obj/machinery/atmospherics/miner/plasma,
+/obj/machinery/atmospherics/miner/toxins,
 /obj/effect/decal/warning_stripes{
 	icon_state = "unloading"
 	},
@@ -99708,7 +99708,7 @@
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "qQU" = (
-/obj/machinery/atmospherics/miner/plasma,
+/obj/machinery/atmospherics/miner/toxins,
 /obj/effect/decal/warning_stripes{
 	icon_state = "unloading"
 	},

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -90103,7 +90103,7 @@
 	},
 /area/derelict/medical/chapel)
 "nEu" = (
-/obj/machinery/atmospherics/miner/toxins,
+/obj/machinery/atmospherics/miner/plasma,
 /obj/effect/decal/warning_stripes{
 	icon_state = "unloading"
 	},
@@ -99708,7 +99708,7 @@
 /turf/simulated/floor,
 /area/hallway/primary/port)
 "qQU" = (
-/obj/machinery/atmospherics/miner/toxins,
+/obj/machinery/atmospherics/miner/plasma,
 /obj/effect/decal/warning_stripes{
 	icon_state = "unloading"
 	},


### PR DESCRIPTION
Currently, gas miners are very non-interactive unless you're antagging or building a burn chamber. Also, there's no use for excess power. So two birds one stone and maybe make a horrible mistake causing runaway power generation with TEGs, I'm going to try to scale surplus wattage into more gas mining. Conversely, with no power means no air, just as an atmospheric simulator should be

## What this does
- update shitcode
- use jellyveggie's `power_priority` `POWER_PRIORITY_EXCESS`
- scale gas miner pressure output with power

## Why it's good
- make people stop bitching about engineers generating niggawatts

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rsadd: Gas mining scales with power generation
