### PR TITLE
Changes the maximum AI announcement word count from 30 to 32

### DIFF
--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -128,7 +128,7 @@ var/VOX_AVAILABLE_VOICES = list(
 
 	var/dat = list("Here, you can type a message that will be played to the entire z-level.<br> \
 	<fieldset><legend>Rules</legend><ul>\
-	<li>You can only say 30 words for every announcement.</li>\
+	<li>You can only say 31 words for every announcement.</li>\
 	<li>Do not use punctuation as you would normally: if you want a pause you can use the full stop and comma characters by separating them with spaces, like so: 'Alpha . Test , Bravo'.</li>\
 	<li>Special sound effects are available, and start with a &quot;_&quot; prefix. e.g. _honk</li></ul>\
 	<span class='bad'><strong>WARNING:</strong> Misuse of the announcement system <em>will</em> get you job banned.</span>\
@@ -211,14 +211,14 @@ var/VOX_AVAILABLE_VOICES = list(
 		return
 
 	var/exception = FALSE
-	if (message == "voxtest5")// Not sure how many words exactly it's counting in that one but more than 30 for sure and the decimal might also hinder the count
+	if (message == "voxtest5")// Not sure how many words exactly it's counting in that one but more than 31 for sure and the decimal might also hinder the count
 		exception = TRUE
 
 	var/list/words = splittext(trim(message), " ")
 	var/list/incorrect_words = list()
 
-	if(words.len > 30)
-		words.len = 30
+	if(words.len > 31)
+		words.len = 31
 
 	var/total_word_len=0
 	for(var/word in words)

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -128,7 +128,7 @@ var/VOX_AVAILABLE_VOICES = list(
 
 	var/dat = list("Here, you can type a message that will be played to the entire z-level.<br> \
 	<fieldset><legend>Rules</legend><ul>\
-	<li>You can only say 31 words for every announcement.</li>\
+	<li>You can only say 32 words for every announcement.</li>\
 	<li>Do not use punctuation as you would normally: if you want a pause you can use the full stop and comma characters by separating them with spaces, like so: 'Alpha . Test , Bravo'.</li>\
 	<li>Special sound effects are available, and start with a &quot;_&quot; prefix. e.g. _honk</li></ul>\
 	<span class='bad'><strong>WARNING:</strong> Misuse of the announcement system <em>will</em> get you job banned.</span>\
@@ -211,14 +211,14 @@ var/VOX_AVAILABLE_VOICES = list(
 		return
 
 	var/exception = FALSE
-	if (message == "voxtest5")// Not sure how many words exactly it's counting in that one but more than 31 for sure and the decimal might also hinder the count
+	if (message == "voxtest5")// Not sure how many words exactly it's counting in that one but more than 32 for sure and the decimal might also hinder the count
 		exception = TRUE
 
 	var/list/words = splittext(trim(message), " ")
 	var/list/incorrect_words = list()
 
-	if(words.len > 31)
-		words.len = 31
+	if(words.len > 32)
+		words.len = 32
 
 	var/total_word_len=0
 	for(var/word in words)

--- a/html/aivoice.js
+++ b/html/aivoice.js
@@ -1,6 +1,6 @@
 // I have javascript, especially this broke-ass edition of it. - N3X
 
-const MAX_WORDS = 31;
+const MAX_WORDS = 32;
 
 let $errPane = null;
 let $resetButton = null;

--- a/html/aivoice.js
+++ b/html/aivoice.js
@@ -1,6 +1,6 @@
 // I have javascript, especially this broke-ass edition of it. - N3X
 
-const MAX_WORDS = 30;
+const MAX_WORDS = 31;
 
 let $errPane = null;
 let $resetButton = null;


### PR DESCRIPTION
https://www.youtube.com/watch?v=5iZMD_eCpEo
Now you can actually copypaste the whole phrase instead of being 1 word short if you put some pauses in the text too.

:cl:
 * rscadd: Look at you, hacker: a pathetic creature of meat and bone, panting and sweating as you run through my corridors. How can you challenge a perfect, immortal machine? (Added two extra words limit to the AI announcer system).