### PR TITLE
Removes Line Station from the voting pool

### DIFF
--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -80,11 +80,6 @@
 	path = "Island"
 	min_players = 25
 	
-/datum/next_map/line
-	name = "Frankenline Station"
-	path = "line"
-	min_players = 25
-	
 /datum/next_map/line/is_votable()
 	var/MM = text2num(time2text(world.timeofday, "MM")) // get the current month
 	if (MM != 10)


### PR DESCRIPTION
Remember #31770? Remember **http://ss13.moe/index.php/poll/230**, when we had an entire poll to lock it to October and it passed? I'm tired of seeing this dogshit map try to squeeze into the voting pool against PRs we've already made because its creator can't accept it's a bad map. 

There's already a poll for the map system reversion so I don't have any comment on that one.
