### PR TITLE
Buffs the AC 2's damage

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -47,7 +47,7 @@
 	projectile_speed = 0.5
 
 /obj/item/projectile/bullet/weakbullet/mech
-	damage = 20
+	damage = 18
 	stun = 0
 	weaken = 0
 	embed = 1

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -47,7 +47,7 @@
 	projectile_speed = 0.5
 
 /obj/item/projectile/bullet/weakbullet/mech
-	damage = 18
+	damage = 15
 	stun = 0
 	weaken = 0
 	embed = 1

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -47,8 +47,10 @@
 	projectile_speed = 0.5
 
 /obj/item/projectile/bullet/weakbullet/mech
+	damage = 20
 	stun = 0
 	weaken = 0
+	embed = 1
 
 /obj/item/projectile/bullet/weakbullet/booze/on_hit(var/atom/target, var/blocked = 0)
 	if(..(target, blocked))


### PR DESCRIPTION
## What this does
Simply, buffs the ac 2's damage output to 15, and adds embedding.

## Why it's good
The ac 2's damage of 10 per projectile (30 dam if all projs hit) made it useless when stacked against the other lethal weaponry (heavy-laser;60 damage, scattershot;100 damage at PB).  This buffs it with the intention of it firing less powerful but accurate bursts of wounding shots so it's useful as a hit-and-run weapon rather then straight up damage (45 damage if all projectiles hit).

:cl:
 * tweak: The AC 2's bullets now do 15 damage and can embed.
