### PR TITLE
Look, I know that "emag creep" is a concern of many players but hear me out...

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -823,7 +823,7 @@ var/global/num_vending_terminals = 1
 			display_records += src.holiday_records
 		if(src.extended_inventory)
 			display_records += src.hidden_records
-		if(src.coin)
+		if(src.coin || emagged)
 			display_records += src.coin_records
 
 		if(display_records.len > 12)
@@ -870,7 +870,7 @@ var/global/num_vending_terminals = 1
 				dat += GetProductLine(R)
 			dat += "<br>"
 
-		if(src.coin)
+		if(src.coin || emagged)
 			dat += {"<B>&nbsp;&nbsp;premium</B>:<br>"}
 			for (var/datum/data/vending_product/R in coin_records)
 				dat += GetProductLine(R)


### PR DESCRIPTION
Emags unlock the premium section of a vendor's inventory just like coins.
![Think of the GLOVE-RUSH STRATEGIES](https://user-images.githubusercontent.com/41342767/187088497-cad29647-a213-4b37-b494-5792730f2e95.png)

:cl:
 * rscadd: Emags now also unlock a vendor's premium section.