### PR TITLE
Gadget bag buff

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -555,10 +555,10 @@ var/global/list/plantbag_colour_choices = list("plantbag", "green red stripe", "
 	slot_flags = SLOT_BELT
 	name = "gadget bag"
 	desc = "This bag can be used to store many machine components."
-	storage_slots = 25;
+	storage_slots = 50;
 	max_combined_w_class = 200
 	w_class = W_CLASS_TINY
-	can_only_hold = list("/obj/item/weapon/stock_parts", "/obj/item/weapon/reagent_containers/glass/beaker", "/obj/item/weapon/cell")
+	can_only_hold = list("/obj/item/weapon/stock_parts", "/obj/item/weapon/reagent_containers/glass/beaker", "/obj/item/weapon/cell", "/obj/item/weapon/circuitboard")
 	display_contents_with_number = TRUE
 
 /obj/item/weapon/storage/bag/gadgets/mass_remove(atom/A)


### PR DESCRIPTION
I've only ever seen these used twice since even the lowest tier part replacer vastly outranks them.
### What this does
Gadget bags can now hold 50 machine parts instead of only 25 and can hold circuitboards as well.
### Why it's good
Mass production of machinery is kinda slow since you only have so much space in your bag, this should help streamline the process and give an actual use to the bags that is not just recyclefodder.

:cl:
 * rscadd: Gadget bags can now hold circuitboards.
 * tweak: Gadget bags can hold 50 machine parts instead of only 25.