### PR TITLE
Airshield machinery.

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -966,9 +966,6 @@ to destroy them and players will be able to make replacements.
 							/obj/item/weapon/stock_parts/scanning_module = 2,
 							/obj/item/weapon/stock_parts/manipulator = 2)
 
-
-
-
 //Teleporter
 /obj/item/weapon/circuitboard/telehub
 	name = "Circuit Board (Teleporter Generator)"
@@ -1604,4 +1601,15 @@ to destroy them and players will be able to make replacements.
 		/obj/item/weapon/stock_parts/manipulator = 1,
 		/obj/item/weapon/stock_parts/scanning_module = 1,
 		/obj/item/weapon/stock_parts/capacitor = 1,
-		)
+	)
+
+/obj/item/weapon/circuitboard/airshield
+	name = "Circuit Board (Airshield)"
+	desc = "A circuit board for a structural airshield."
+	board_type = MACHINE
+	build_path = /obj/machinery/airshield
+	origin_tech = c_ENGINEERING + "=6;"+ Tc_PROGRAMMING + "=4" + Tc_MATERIALS + "=3"
+	req_components = list(
+		/obj/item/weapon/stock_parts/manipulator = 3,
+		/obj/item/weapon/stock_parts/micro_laser = 1
+	)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -1608,7 +1608,7 @@ to destroy them and players will be able to make replacements.
 	desc = "A circuit board for a structural airshield."
 	board_type = MACHINE
 	build_path = /obj/machinery/airshield
-	origin_tech = c_ENGINEERING + "=6;"+ Tc_PROGRAMMING + "=4" + Tc_MATERIALS + "=3"
+	origin_tech = Tc_ENGINEERING + "=6;"+ Tc_PROGRAMMING + "=4" + Tc_MATERIALS + "=3"
 	req_components = list(
 		/obj/item/weapon/stock_parts/manipulator = 3,
 		/obj/item/weapon/stock_parts/micro_laser = 1

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2413,6 +2413,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/clothing/glasses/scanner/material = 2,
 		/obj/item/device/multitool = 4,
 		/obj/item/weapon/circuitboard/airlock = 10,
+		/obj/item/weapon/circuitboard/airshield = 10,
 		/obj/item/weapon/circuitboard/power_control = 10,
 		/obj/item/weapon/circuitboard/air_alarm = 10,
 		/obj/item/weapon/circuitboard/fire_alarm = 10,

--- a/code/game/objects/structures/airshield.dm
+++ b/code/game/objects/structures/airshield.dm
@@ -49,3 +49,20 @@
 			qdel(src)
 	else
 		..()
+		
+/obj/machinery/airshield //machinery duplicate so it inherits the simple craftable behaviour of machines
+	name = "airshield"
+	desc = "A shield that allows only non-gasses to pass through."
+	icon = 'icons/obj/stationobjs.dmi'
+	icon_state = "emancipation_grill_on"
+	opacity = 0
+	density = 0
+	anchored = 1
+	plane = ABOVE_HUMAN_PLANE
+	idle_power_usage = 100
+	active_power_usage = 100 //always uses 100w
+	
+/obj/machinery/airshield/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+	if(istype(mover))
+		return ..()
+	return FALSE

--- a/code/modules/research/designs/boards/machine_engie.dm
+++ b/code/modules/research/designs/boards/machine_engie.dm
@@ -5,7 +5,7 @@
 //
 
 /datum/design/smes
-	name = "Circuit Design (SMES) "
+	name = "Circuit Design (SMES)"
 	desc = "Allows for the construction of circuit boards used to build Superconducting Magnetic Energy Storage Units."
 	id="smes"
 	req_tech = list(Tc_POWERSTORAGE = 4, Tc_ENGINEERING = 4, Tc_PROGRAMMING = 4)
@@ -15,7 +15,7 @@
 	build_path = /obj/item/weapon/circuitboard/smes
 
 /datum/design/portable_smes
-	name = "Circuit Design (Portable SMES) "
+	name = "Circuit Design (Portable SMES)"
 	desc = "Allows for the construction of circuit boards used to build portable Superconducting Magnetic Energy Storage Units."
 	id="portable_smes"
 	req_tech = list(Tc_POWERSTORAGE = 5, Tc_ENGINEERING = 4, Tc_PROGRAMMING = 4)
@@ -25,7 +25,7 @@
 	build_path = /obj/item/weapon/circuitboard/port_smes
 
 /datum/design/portable_smes_port //Needed to connect the portable SMES.
-	name = "Circuit Design (Portable SMES Port) "
+	name = "Circuit Design (Portable SMES Port)"
 	desc = "Allows for the construction of circuit boards used to build the connector to a portable SMES."
 	id="portable_smes_port"
 	req_tech = list(Tc_POWERSTORAGE = 5, Tc_ENGINEERING = 4, Tc_PROGRAMMING = 4)
@@ -144,6 +144,16 @@
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Machine Boards"
 	build_path = /obj/item/weapon/circuitboard/pipedispenser/disposal
+
+/datum/design/airshield
+	name = "Circuit Design (Airshield)"
+	desc = "Allows for the construction of circuit boards to build airshields."
+	id ="airshield"
+	req_tech = list(Tc_MATERIALS = 3, Tc_ENGINEERING = 5, Tc_PROGRAMMING = 4)
+	build_type = IMPRINTER
+	materials = list (MAT_GLASS = 2000, SACID = 20)
+	category = "Misc"
+	build_path = /obj/item/weapon/circuitboard/airshield
 
 //
 //MECHANICS MACHINES.


### PR DESCRIPTION
Remember those fancy airshields used in the pocket satellite and literally nowhere else? Those that block airflow but not mobs or items. You can make those now.
### What this does
Adds airshield machinery, the circuitboard and design for said circuitboard.
You need 5 Engineering, 4 Data and 3 Materials to be able to print the circuitboard. The machine needs 3 manipulators and 1 microlaser to be assembled.
The circuitboards can also be purchased from EngiVends.
### Why it's good
Atmospherically dangerous setups or gimmicks can now be performed slightly safer without making it harder to work on, if you take the time to build each individual airshield.
:cl:
 * rscadd: Airshields (those on the pocket satellite) machinery. 5 Engineering, 4 Data and 3 Materials for the circuitboard, 3 manipulators and 1 microlaser for the machine assembly.
 * rscadd: Airshield circuits on the engivend.