### PR TITLE
fixes bleach bottles

### DIFF
--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -16,10 +16,6 @@
 	melt_temperature = MELTPOINT_GLASS
 	origin_tech = Tc_MATERIALS + "=1"
 
-/obj/item/weapon/reagent_containers/glass/bottle/New(loc,altvol=30)
-	volume = altvol
-	..(loc)
-
 //JUST
 /obj/item/weapon/reagent_containers/glass/bottle/mop_act(obj/item/weapon/mop/M, mob/user)
 	if(..())


### PR DESCRIPTION
### What this does
Fixes bleach bottles spawning with 30u despite both the volume and add_reagent calling for 100u.
Turns out the superior new() call overwrote the bleach bottle's volume on spawn so the bottle only got filled with 30u. After spawning and the reagents added the volume set properly so the bottle got it's 100u capacity but only 30u bleach inside.
I can't quite claim 100% tested, but it didn't seem to break at all on my limited testing.
### Why it's good
Bugfix good.
[hotfix][bugfix]
:cl:
 * bugfix: Fixes bleach bottles spawning with 30u Bleach despite calling for 100u on the code.