### PR TITLE
Matsynths don't recycle.

### DIFF
--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -294,7 +294,7 @@ var/global/list/rnd_machines = list()
 		spawn(ANIM_LENGTH)
 			busy = FALSE
 		return 1
-	if(O.materials && (research_flags & FAB_RECYCLER))
+	if(O.materials && (research_flags & FAB_RECYCLER) && !istype(O, /obj/item/device/material_synth))
 		if(O.materials.getVolume() + src.materials.getVolume() > max_material_storage)
 			to_chat(user, "\The [src]'s material bin is too full to recycle \the [O].")
 			return 1


### PR DESCRIPTION
### What this does
Mat synths will not be recycled when used against a fabricator (autolathe, protolathe, etc) and will scan the materials properly.
There's probably a better way to implement this but this is the simplest way to do it.
Didn't break on testing so [tested] I guess.
### Why it's good
[bugfix] good, also [hotfix]
Closes #33176.
:cl:
 * bugfix: Material Synthesizers will properly scan materials from protolathes without being recycled.