### PR TITLE
Breaking out of lockers now has a progress bar + breaking out of lockers now visibly shakes the locker and makes noise

### DIFF
--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -23,7 +23,7 @@
 // roidstation.dm
 //#define MAP_OVERRIDE 4
 // test_tiny.dm:
-#define MAP_OVERRIDE 6
+//#define MAP_OVERRIDE 6
 // tgstation.dm:
 //#define MAP_OVERRIDE 7
 // snaxi.dm

--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -23,7 +23,7 @@
 // roidstation.dm
 //#define MAP_OVERRIDE 4
 // test_tiny.dm:
-//#define MAP_OVERRIDE 6
+#define MAP_OVERRIDE 6
 // tgstation.dm:
 //#define MAP_OVERRIDE 7
 // snaxi.dm

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -636,9 +636,9 @@
 /obj/structure/closet/proc/shake_closet()
 	shake_animation(3, 3, 0.2, 15)
 	playsound(src, 'sound/effects/grillehit.ogg', 50, 1)
-	spawn(3)
+	spawn(2)
 		playsound(src, 'sound/effects/grillehit.ogg', 50, 1)
-		spawn(3)
+		spawn(2)
 			playsound(src, 'sound/effects/grillehit.ogg', 50, 1)
 
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -627,30 +627,14 @@
 		return 0
 	return 1
 
-/obj/structure/closet/container_resist(mob/user)
-	var/breakout_time = 2 //2 minutes by default
+/obj/structure/closet/shake()
+	shake_animation(3, 3, 0.2, 15)
+	playsound(src, 'sound/effects/grillehit.ogg', 50, 1)
+	spawn(5)
+		playsound(src, 'sound/effects/grillehit.ogg', 50, 1)
+		spawn(5)
+			playsound(src, 'sound/effects/grillehit.ogg', 50, 1)
 
-	if(opened || (!welded && !locked))
-		return  //Door's open, not locked or welded, no point in resisting.
-
-	//okay, so the closet is either welded or locked... resist!!!
-	user.delayNext(DELAY_ALL,100)
-
-	to_chat(user, "<span class='notice'>You lean on the back of [src] and start pushing the door open. (this will take about [breakout_time] minutes.)</span>")
-	for(var/mob/O in viewers(src))
-		to_chat(O, "<span class='warning'>[src] begins to shake violently!</span>")
-	var/turf/T = get_turf(src)	//Check for moved locker
-	if(do_after(user, src, (breakout_time*60*10))) //minutes * 60seconds * 10deciseconds
-		if(!user || user.stat != CONSCIOUS || user.loc != src || opened || (!locked && !welded) || T != get_turf(src))
-			return
-		//we check after a while whether there is a point of resisting anymore and whether the user is capable of resisting
-
-		welded = 0 //applies to all lockers lockers
-		locked = 0 //applies to critter crates and secure lockers only
-		broken = 1 //applies to secure lockers only
-		visible_message("<span class='danger'>[user] successfully broke out of [src]!</span>")
-		to_chat(user, "<span class='notice'>You successfully break out of [src]!</span>")
-		open(user)
 
 /obj/structure/closet/send_to_past(var/duration)
 	..()
@@ -672,6 +656,9 @@
 				return
 		to_chat(ghost, "It contains: <span class='info'>[counted_english_list(contents)]</span>.")
 		investigation_log(I_GHOST, "|| had its contents checked by [key_name(ghost)][ghost.locked_to ? ", who was haunting [ghost.locked_to]" : ""]")
+
+
+
 
 // -- Vox raiders.
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -627,12 +627,18 @@
 		return 0
 	return 1
 
-/obj/structure/closet/shake()
+/obj/structure/closet/proc/on_do_after(mob/user, use_user_turf, user_original_location, atom/target, target_original_location, needhand, obj/item/originally_held_item)
+	. = do_after_default_checks(arglist(args))
+	if(.)
+		shake_closet()
+
+
+/obj/structure/closet/proc/shake_closet()
 	shake_animation(3, 3, 0.2, 15)
 	playsound(src, 'sound/effects/grillehit.ogg', 50, 1)
-	spawn(5)
+	spawn(3)
 		playsound(src, 'sound/effects/grillehit.ogg', 50, 1)
-		spawn(5)
+		spawn(3)
 			playsound(src, 'sound/effects/grillehit.ogg', 50, 1)
 
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1024,7 +1024,7 @@ Thanks.
 		L.visible_message("<span class='danger'>The [C] begins to shake violenty!</span>",
 						  "<span class='warning'>You lean on the back of [C] and start pushing the door open (this will take about [breakout_time] minutes).</span>")
 		spawn(0)
-			if(do_after(usr,src,breakout_time * 60 * 10)) //minutes * 60seconds * 10deciseconds
+			if(do_after(usr, C, breakout_time * 60 * 10, 30, custom_checks = new /callback(I, /obj/structure/closet/proc/shake))) 	//minutes * 60seconds * 10deciseconds
 				if(!C || !L || L.stat != CONSCIOUS || L.loc != C || C.opened) //closet/user destroyed OR user dead/unconcious OR user no longer in closet OR closet opened
 					return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1024,7 +1024,7 @@ Thanks.
 		L.visible_message("<span class='danger'>The [C] begins to shake violenty!</span>",
 						  "<span class='warning'>You lean on the back of [C] and start pushing the door open (this will take about [breakout_time] minutes).</span>")
 		spawn(0)
-			if(do_after(usr, C, breakout_time * 60 * 10, 30, custom_checks = new /callback(C, /obj/structure/closet/shake))) 	//minutes * 60seconds * 10deciseconds
+			if(do_after(usr, C, breakout_time * 60 * 10, 30, custom_checks = new /callback(C, /obj/structure/closet/proc/on_do_after))) 	//minutes * 60seconds * 10deciseconds
 				if(!C || !L || L.stat != CONSCIOUS || L.loc != C || C.opened) //closet/user destroyed OR user dead/unconcious OR user no longer in closet OR closet opened
 					return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1024,7 +1024,7 @@ Thanks.
 		L.visible_message("<span class='danger'>The [C] begins to shake violenty!</span>",
 						  "<span class='warning'>You lean on the back of [C] and start pushing the door open (this will take about [breakout_time] minutes).</span>")
 		spawn(0)
-			if(do_after(usr, C, breakout_time * 60 * 10, 30, custom_checks = new /callback(I, /obj/structure/closet/proc/shake))) 	//minutes * 60seconds * 10deciseconds
+			if(do_after(usr, C, breakout_time * 60 * 10, 30, custom_checks = new /callback(C, /obj/structure/closet/shake))) 	//minutes * 60seconds * 10deciseconds
 				if(!C || !L || L.stat != CONSCIOUS || L.loc != C || C.opened) //closet/user destroyed OR user dead/unconcious OR user no longer in closet OR closet opened
 					return
 


### PR DESCRIPTION
## What this does
Adds a progress bar when breaking out of a locker.
Lockers visibly shake when someone is breaking out of them (a message in chat was already shown but nothing happened visually)
Lockers now making banging sounds when someone is breaking out of them. (Uses the grille hit/machine kick sound, let me know if you have a better sound suggestion)

## Why it's good
This makes it clear when someone is trapped in a locker and breaking out. Even though a message saying "The closet begins to shake violently" was printed in chat it was easy to miss sometimes. 
The progress bar lets you know if you are even breaking out at all. 
Also looks good.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added a progress bar to breaking out of lockers.
 * rscadd: Lockers visibly shake and make noise when someone is breaking out of one.
