### PR TITLE
Wood planks crate now has 50 planks instead of 25.

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -267,11 +267,11 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	containername = "plastic sheets crate"
 	group = "Supplies"
 
-/datum/supply_packs/wood25
-	name = "25 wooden planks"
+/datum/supply_packs/wood50
+	name = "50 wooden planks"
 	contains = list(/obj/item/stack/sheet/wood)
-	amount = 25
-	cost = 12
+	amount = 50
+	cost = 20
 	containertype = /obj/structure/closet/crate/engi
 	containername = "wooden planks crate"
 	group = "Supplies"


### PR DESCRIPTION
### What this does
Makes the wood plank crate consistent with the glass, metal and plastic one at a slight cost increase.
### Why it's good
[consistency] good.
:cl:
 * tweak: The wooden planks crate now costs 8 more credits but carries twice as much wood (50 planks).
