### PR TITLE
Toggle darkness tweak

### DIFF
--- a/code/modules/mob/dead/observer/verbs.dm
+++ b/code/modules/mob/dead/observer/verbs.dm
@@ -248,8 +248,8 @@
 	if (client && client.darkness_planemaster)
 		switch(client.darkness_planemaster.alpha)
 			if(255)
-				client.darkness_planemaster.alpha = 90
-			if(90)
+				client.darkness_planemaster.alpha = 180
+			if(180)
 				client.darkness_planemaster.alpha = 0
 			else
 				client.darkness_planemaster.alpha = 255

--- a/code/modules/mob/dead/observer/verbs.dm
+++ b/code/modules/mob/dead/observer/verbs.dm
@@ -248,10 +248,8 @@
 	if (client && client.darkness_planemaster)
 		switch(client.darkness_planemaster.alpha)
 			if(255)
-				client.darkness_planemaster.alpha = 230
-			if(230)
-				client.darkness_planemaster.alpha = 180
-			if(180)
+				client.darkness_planemaster.alpha = 90
+			if(90)
 				client.darkness_planemaster.alpha = 0
 			else
 				client.darkness_planemaster.alpha = 255


### PR DESCRIPTION
### What this does
Removes the barely brighter darkness toggle like Dacendeth suggested.
### Why it's good
The barely brighter darkness toggle is unnecessary. Closes #33200.
:cl:
 * rscdel: Removes one of the darkness toggles.