### PR TITLE
MDF Heavy Armor Uplink Changes, MDF Gear Belt split into its own uplink entry

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -552,10 +552,18 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/ayylmao/harmor
 	name = "MDF Heavy Armor"
-	desc = "A set of cumbersome but sturdy alien armor that excels at protecting the wearer from energy weapons and melee attacks. The armor plates were measured for a grey, but can be adjusted to fit a human as well. Not guaranteed to fit any other species. A partially loaded gear belt is included with the kit."
+	desc = "A set of cumbersome but sturdy alien armor that excels at protecting the wearer from energy weapons and melee attacks. The armor plates were measured for a grey, but can be adjusted to fit a human as well. Not guaranteed to fit any other species. A soldier's uniform and boots are included with the kit."
 	item = /obj/item/weapon/storage/box/syndie_kit/ayylmao_harmor
 	cost = 4
 	discounted_cost = 3
+	jobs_with_discount = list("Grey")
+
+/datum/uplink_item/ayylmao/mdfbelt
+	name = "MDF Gear Belt"
+	desc = "A mothership soldier's belt. Loaded with first aid supplies, binoculars, and an extended oxygen supply tank for operating in breached areas. Keep away from water."
+	item = /obj/item/weapon/storage/belt/mothership/partial_gear
+	cost = 5
+	discounted_cost = 4
 	jobs_with_discount = list("Grey")
 
 /datum/uplink_item/ayylmao/sdrone_grenade

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -560,7 +560,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/ayylmao/mdfbelt
 	name = "MDF Gear Belt"
-	desc = "A mothership soldier's belt. Loaded with first aid supplies, binoculars, and an extended oxygen supply tank for operating in breached areas. Keep away from water."
+	desc = "A mothership soldier's belt. Loaded with an ion pistol, first aid supplies, binoculars, and an extended oxygen supply tank for operating in breached areas. Keep away from water."
 	item = /obj/item/weapon/storage/belt/mothership/partial_gear
 	cost = 5
 	discounted_cost = 4

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -362,7 +362,8 @@
 	items_to_spawn = list(
 		/obj/item/clothing/suit/armor/mothership_heavy,
 		/obj/item/clothing/head/helmet/mothership_visor_heavy,
-		/obj/item/weapon/storage/belt/mothership/partial_gear
+		/obj/item/clothing/under/grey/grey_soldier,
+		/obj/item/clothing/shoes/jackboots/mothership
 	)
 
 //Syndicate Experimental Gear

--- a/maps/randomvaults/mothership_lab.dm
+++ b/maps/randomvaults/mothership_lab.dm
@@ -348,9 +348,12 @@
 /obj/item/weapon/storage/belt/mothership/partial_gear/New()
 	..()
 	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
+	new /obj/item/stack/medical/advanced/bruise_pack(src)
+	new /obj/item/stack/medical/advanced/ointment(src)
 	new /obj/item/weapon/reagent_containers/food/snacks/zambiscuit(src)
 	new /obj/item/weapon/storage/fancy/cigarettes/redsuits(src)
 	new /obj/item/weapon/lighter/zippo(src)
+	new /obj/item/binoculars(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/weapon/tank/emergency_oxygen/engi(src)
 

--- a/maps/randomvaults/mothership_lab.dm
+++ b/maps/randomvaults/mothership_lab.dm
@@ -347,13 +347,14 @@
 
 /obj/item/weapon/storage/belt/mothership/partial_gear/New()
 	..()
+	new /obj/item/weapon/gun/energy/ionrifle/ioncarbine/ionpistol(src)
+	new /obj/item/binoculars(src)
 	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
 	new /obj/item/stack/medical/advanced/bruise_pack(src)
 	new /obj/item/stack/medical/advanced/ointment(src)
 	new /obj/item/weapon/reagent_containers/food/snacks/zambiscuit(src)
 	new /obj/item/weapon/storage/fancy/cigarettes/redsuits(src)
 	new /obj/item/weapon/lighter/zippo(src)
-	new /obj/item/binoculars(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/weapon/tank/emergency_oxygen/engi(src)
 


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->

## What the pr does and why ##
After a while thinking about a suggestion provided in #33133 , I decided to apply it. The MDF Heavy Armor and MDF Gear Belt are now separate purchases from the uplink, and the quality of gear in the belt has been buffed a bit to justify the extra TC spent.

![ayyuplinkscreen](https://user-images.githubusercontent.com/81007356/188251065-61714009-2a3a-470e-b540-c7b0db2181af.png)

## MDF Heavy Armor Changes ##
- The MDF Heavy Armor kit no longer includes a gear belt, instead it comes with an ayy soldier's uniform and boots to complete the look.

![mdfheavy_kit](https://user-images.githubusercontent.com/81007356/188227389-881e8d45-d616-4987-80f0-73f8b49f29fa.png)

- Pictured here with black gloves and a security backpack

![mothershipheavy_gear](https://user-images.githubusercontent.com/81007356/188227651-f8a3d688-7898-4e13-94f1-45eb9aaa11af.png)

## MDF Gear Belt Changes ##
- The MDF gear belt is now its own separate entry under the Extraterrestrial Black Market. It currently costs 5 TC, 4 TC for ayys. It includes an ion pistol, binoculars, first aid autoinjector, two stacks of trauma kits (one for brute, one for burn), extended oxygen tank, and a few other misc items (gas mask, zam biscuit, red suit cigarettes and lighter). This makes it a more useful addition to any traitor's kit, without having to worry about buying a set of armor along with it that you might not be able to wear.

![mdf_belt](https://user-images.githubusercontent.com/81007356/188250969-5aa4ec6b-4207-4272-9a00-8c923733fbd5.png)

- Looks very similar to a normal sec belt at a glance, so unlikely to attract unwanted attention on its own.

![mdfbelt](https://user-images.githubusercontent.com/81007356/188228114-d875847c-194b-4272-9148-0ee377cd5abe.png)

## Closing Thoughts ##
Please do share thoughts and feedback. I did my best to balance the belt's TC price, but I might have under or overshot it.

:cl:
 * rscadd: MDF Heavy Armor purchased from an uplink no longer includes a gear belt, instead it comes with a uniform and boots
 * rscadd: The MDF Gear Belt has been moved into its own entry, contains better gear, and costs 5 TC undiscounted, 4 discounted