### PR TITLE
Acidic Banana Peel Sanity: Grayy Edition

### DIFF
--- a/code/game/objects/items/weapons/grenades/clowngrenade.dm
+++ b/code/game/objects/items/weapons/grenades/clowngrenade.dm
@@ -70,24 +70,38 @@
 	if(isliving(AM))
 		var/burned = rand(2,5)
 		var/mob/living/M = AM
-		if(M.lying)
-			M.take_overall_damage(0, max(0, (burned - 2)))
-			M.simple_message("<span class='danger'>Something burns your back!</span>",\
-				"<span class='userdanger'>They're eating your back!</span>")
-			return 0
+		if(ishuman(M))
+			if(isgrey(M))
+				if(M.lying)
+					M.simple_message("<span class='notice'>You feel a slight tingling sensation on your back, but it quickly subsides.</span>",\
+						"<span class='notice'>You're quite certain that's acid on your back.</span>")
+			else
+				if(M.lying)
+					M.take_overall_damage(0, max(0, (burned - 2)))
+					M.simple_message("<span class='danger'>Something burns your back!</span>",\
+						"<span class='userdanger'>They're eating your back!</span>")
+					return 0
 
 		if(ishuman(M))
 			if(M.CheckSlip())
-				M.simple_message("<span class='warning'>Your feet feel like they're on fire!</span>",\
-					"<span class='userdanger'>Egads! They bite your feet!</span>")
-				M.take_overall_damage(0, max(0, (burned - 2)))
+				if(isgrey(M))
+					M.simple_message("<span class='notice'>You feel a slight tingling sensation in your feet, but it quickly subsides.</span>",\
+						"<span class='notice'>You're quite certain that's acid on your feet.</span>")
+				else
+					M.simple_message("<span class='warning'>Your feet feel like they're on fire!</span>",\
+						"<span class='userdanger'>Egads! They bite your feet!</span>")
+					M.take_overall_damage(0, max(0, (burned - 2)))
 			else
 				return 0
 
 		if(!istype(M, /mob/living/carbon/slime) && !isrobot(M))
-			slip_n_slide(M, 10, 10, "<span class='userdanger[iscarbon(M) ? " notice" : ""]'>Please, just end the pain!</span>")
-			M.take_organ_damage(2) // Was 5 -- TLE
-			M.take_overall_damage(0, burned)
+			if(ishuman(M))
+				if(isgrey(M))
+					slip_n_slide(M, 10, 10)
+				else
+					slip_n_slide(M, 10, 10, "<span class='userdanger[iscarbon(M) ? " notice" : ""]'>Please, just end the pain!</span>")
+					M.take_organ_damage(2) // Was 5 -- TLE
+					M.take_overall_damage(0, burned)
 		return 1
 	return ..()
 
@@ -95,5 +109,7 @@
 	var/burned = rand(1,3)
 	if(istype(hit_atom ,/mob/living))
 		var/mob/living/M = hit_atom
-		M.take_organ_damage(0, burned)
+		if(ishuman(M) && !isgrey(M))
+			M.take_organ_damage(0, burned)
 	return ..()
+


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->

## Wait a minute... I LIKE ACID ##
![clown_grenade](https://user-images.githubusercontent.com/81007356/188263863-e11659f1-87f7-494e-b4a3-fba3dd96b607.png)

- This consistency issue has bothered me for a while. Despite it clearly saying in the clown grenade's description that the banana peels it releases are acidic, greys are burned by them when slipping on them or crawling over them.

## Vidya Example ##
https://user-images.githubusercontent.com/81007356/188263869-1b7589b8-3c89-4917-a5bb-5e18c0193940.mp4

- Greys are no longer burned by acidic banana peels, though they still slip on them.

## Closing Thoughts ##
- This is obviously a buff to ayys, even if it's consistent. I'm willing to take suggestions and feedback on how it should be implemented.
- One suggested alternative is that they could have a high resistance, but not immunity to the burn damage.

[bugfix] [consistency]

:cl:
 * bugfix: Grayys no longer take burn damage from slipping on or crawling over acidic banana peels.