### PR TITLE
Improves the phazon stock part functionality on certain machinery

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -78,7 +78,7 @@
 			available_options = list(INAPROVALINE = "Inaprovaline", STOXIN2 = "Soporific Rejuvenant", DERMALINE = "Dermaline", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin", IMIDAZOLINE = "Imidazoline" , INACUSIATE = "Inacusiate" ,  TRICORDRAZINE = "Tricordrazine" , ALKYSINE = "Alkysine" , TRAMADOL = "Tramadol" , PEPTOBISMOL  = "Peptobismol")
 			sleeptime = 2 SECONDS
 		if(12 to INFINITY) // Tier 4
-			available_options = list(INAPROVALINE = "Inaprovaline", STOXIN2 = "Soporific Rejuvenant", DERMALINE = "Dermaline", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin", IMIDAZOLINE = "Imidazoline" , INACUSIATE = "Inacusiate" ,  TRICORDRAZINE = "Tricordrazine" , ALKYSINE = "Alkysine" , TRAMADOL = "Tramadol" , PEPTOBISMOL  = "Peptobismol", DOCTORSDELIGHT = "Doctor's Delight", PERIDAXON = "Peridaxon")
+			available_options = list(INAPROVALINE = "Inaprovaline", STOXIN2 = "Soporific Rejuvenant", DERMALINE = "Dermaline", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin", IMIDAZOLINE = "Imidazoline" , INACUSIATE = "Inacusiate" ,  TRICORDRAZINE = "Tricordrazine" , ALKYSINE = "Alkysine" , TRAMADOL = "Tramadol" , PEPTOBISMOL  = "Peptobismol", DOCTORSDELIGHT = "Doctor's Delight", REZADONE = "Rezadone", PERIDAXON = "Peridaxon")
 			sleeptime = 0.1 SECONDS
 
 /obj/machinery/sleeper/emag_act(mob/user)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -68,15 +68,18 @@
 	else
 		works_in_crit = FALSE
 	switch(T)
-		if(0 to 5)
+		if(0 to 5) // Tier 1
 			available_options = list(INAPROVALINE = "Inaprovaline", STOXIN2 = "Soporific Rejuvenant", KELOTANE = "Kelotane", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin")
 			sleeptime = 6 SECONDS
-		if(6 to 8)
+		if(6 to 8) // Tier 2
 			available_options = list(INAPROVALINE = "Inaprovaline", STOXIN2 = "Soporific Rejuvenant", DERMALINE = "Dermaline", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin", IMIDAZOLINE = "Imidazoline" , INACUSIATE = "Inacusiate" ,  TRICORDRAZINE = "Tricordrazine")
 			sleeptime = 4 SECONDS
-		else
+		if(9 to 11) // Tier 3
 			available_options = list(INAPROVALINE = "Inaprovaline", STOXIN2 = "Soporific Rejuvenant", DERMALINE = "Dermaline", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin", IMIDAZOLINE = "Imidazoline" , INACUSIATE = "Inacusiate" ,  TRICORDRAZINE = "Tricordrazine" , ALKYSINE = "Alkysine" , TRAMADOL = "Tramadol" , PEPTOBISMOL  = "Peptobismol")
 			sleeptime = 2 SECONDS
+		if(12 to INFINITY) // Tier 4
+			available_options = list(INAPROVALINE = "Inaprovaline", STOXIN2 = "Soporific Rejuvenant", DERMALINE = "Dermaline", BICARIDINE = "Bicaridine", DEXALIN = "Dexalin", IMIDAZOLINE = "Imidazoline" , INACUSIATE = "Inacusiate" ,  TRICORDRAZINE = "Tricordrazine" , ALKYSINE = "Alkysine" , TRAMADOL = "Tramadol" , PEPTOBISMOL  = "Peptobismol", DOCTORSDELIGHT = "Doctor's Delight", PERIDAXON = "Peridaxon")
+			sleeptime = 0.1 SECONDS
 
 /obj/machinery/sleeper/emag_act(mob/user)
 	if(!emagged)

--- a/code/game/machinery/scp_294.dm
+++ b/code/game/machinery/scp_294.dm
@@ -28,6 +28,9 @@
 		/datum/malfhack_ability/oneuse/emag
 	)
 
+/obj/machinery/chem_dispenser/scp_294/update_chem_list()
+	return
+
 /obj/machinery/chem_dispenser/scp_294/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open=NANOUI_FOCUS)
 	if(stat & (BROKEN|NOPOWER|FORCEDISABLE))
 		return

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -75,8 +75,12 @@
 	T = 0
 	if(total >= 16)
 		upgraded = 1
+		name = "Advanced Cloning Pod"
+		desc = "An electronically-lockable pod for growing organic tissue. This one is extremely advanced, and can output perfectly fine clones that do not need treatment of any kind."
 	else
 		upgraded = 0
+		name = initial(name)
+		desc = initial(desc)
 
 //The return of data disks?? Just for transferring between genetics machine/cloning machine.
 //TO-DO: Make the genetics machine accept them.

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -44,6 +44,7 @@
 		SACID,
 		TUNGSTEN
 		)
+	var/upgraded = 0
 	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK
 /*
 USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
@@ -76,21 +77,37 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 		dispensable_reagents = sortList(dispensable_reagents)
 
 /obj/machinery/chem_dispenser/RefreshParts()
+	var/R = 0
 	var/T = 0
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
 		T += M.rating-1
+		R += M.rating
 	max_energy = initial(max_energy)+(T * 50 / 4)
 
 	T = 0
 	for(var/obj/item/weapon/stock_parts/micro_laser/Ma in component_parts)
 		T += Ma.rating-1
+		R += Ma.rating
 	rechargerate = initial(rechargerate) + (T / 2)
 
-/*
-	for(var/obj/item/weapon/stock_parts/scanning_module/Ml in component_parts)
-		T += Ml.rating
-	//Who even knows what to use the scanning module for
-*/
+	for(var/obj/item/weapon/stock_parts/scanning_module/Ml in component_parts) //Now we know what to use the scanning module for
+		R += Ml.rating
+
+	if(R >= 28) //Tier 4 parts
+		upgraded = 1
+	else
+		upgraded = 0
+	update_chem_list()
+
+/obj/machinery/chem_dispenser/proc/update_chem_list()
+	if(!upgraded)
+		dispensable_reagents = list(HYDROGEN,LITHIUM,CARBON,NITROGEN,OXYGEN,FLUORINE,SODIUM,ALUMINUM,SILICON,PHOSPHORUS,SULFUR,
+									CHLORINE,POTASSIUM,IRON,COPPER,MERCURY,RADIUM,WATER,ETHANOL,SUGAR,SACID,TUNGSTEN)
+	else
+		dispensable_reagents = list(HYDROGEN,LITHIUM,CARBON,NITROGEN,OXYGEN,FLUORINE,SODIUM,ALUMINUM,SILICON,PHOSPHORUS,SULFUR,
+									CHLORINE,POTASSIUM,IRON,COPPER,MERCURY,RADIUM,WATER,ETHANOL,SUGAR,SACID,TUNGSTEN,
+									INAPROVALINE,DEXALIN,ANTI_TOXIN)
+	dispensable_reagents = sortList(dispensable_reagents)
 
 /obj/machinery/chem_dispenser/proc/recharge()
 	if(stat & (BROKEN|NOPOWER|FORCEDISABLE))
@@ -454,6 +471,9 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 	)
 	RefreshParts()
 
+/obj/machinery/chem_dispenser/brewer/update_chem_list()
+	return
+
 /obj/machinery/chem_dispenser/brewer/suicide_act(var/mob/living/user)
 	to_chat(viewers(user), "<span class='danger'>[user] is placing \his mouth under the nozzles of the [src] and filling it! It looks like \he's trying to commit suicide.</span>")
 	playsound(src, 'sound/effects/bubbles.ogg', 80, 1)
@@ -487,6 +507,9 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 		/obj/item/weapon/stock_parts/console_screen
 	)
 	RefreshParts()
+
+/obj/machinery/chem_dispenser/soda_dispenser/update_chem_list()
+	return
 
 /obj/machinery/chem_dispenser/soda_dispenser/suicide_act(var/mob/living/user)
 	to_chat(viewers(user), "<span class='danger'>[user] is placing \his mouth under the nozzles of the [src] and filling it! It looks like \he's trying to commit suicide.</span>")
@@ -547,6 +570,16 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 	)
 	RefreshParts()
 
+/obj/machinery/chem_dispenser/booze_dispenser/update_chem_list()
+	if(!upgraded)
+		dispensable_reagents = list(BEER,WHISKEY,TEQUILA,VODKA,VERMOUTH,RUM,COGNAC,WINE,SAKE,TRIPLESEC,BITTERS,CINNAMONWHISKY,SCHNAPPS,
+									BLUECURACAO,KAHLUA,ALE,ICE = T0C,WATER,GIN,SODAWATER,COLA,CREAM,TOMATOJUICE,ORANGEJUICE,LIMEJUICE,TONIC)
+	else
+		dispensable_reagents = list(BEER,WHISKEY,TEQUILA,VODKA,VERMOUTH,RUM,COGNAC,WINE,SAKE,TRIPLESEC,BITTERS,CINNAMONWHISKY,SCHNAPPS,
+									BLUECURACAO,KAHLUA,ALE,ICE = T0C,WATER,GIN,SODAWATER,COLA,CREAM,TOMATOJUICE,ORANGEJUICE,LIMEJUICE,TONIC,
+									KARMOTRINE)
+
+
 /obj/machinery/chem_dispenser/booze_dispenser/suicide_act(var/mob/living/user)
 	to_chat(viewers(user), "<span class='danger'>[user] is placing \his mouth under the nozzles of the [src] and drowning his sorrows! It looks like \he's trying to commit suicide.</span>")
 	playsound(src, 'sound/effects/bubbles.ogg', 80, 1)
@@ -577,6 +610,9 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 		SPRINKLES
 		)
 	machine_flags = SCREWTOGGLE | WRENCHMOVE | FIXED2WORK
+
+/obj/machinery/chem_dispenser/condiment/update_chem_list()
+	return
 
 /obj/machinery/chem_dispenser/condiment/can_insert(obj/item/I)
 	return istype(I,/obj/item/weapon/reagent_containers/food/snacks) || istype(I,/obj/item/weapon/reagent_containers/food/condiment)

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -45,6 +45,9 @@
 		TUNGSTEN
 		)
 	var/upgraded = 0
+	var/list/upgrade_chems = list(
+		PLASMA
+		)
 	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK
 /*
 USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
@@ -100,14 +103,9 @@ USE THIS CHEMISTRY DISPENSER FOR MAPS SO THEY START AT 100 ENERGY
 	update_chem_list()
 
 /obj/machinery/chem_dispenser/proc/update_chem_list()
-	if(!upgraded)
-		dispensable_reagents = list(HYDROGEN,LITHIUM,CARBON,NITROGEN,OXYGEN,FLUORINE,SODIUM,ALUMINUM,SILICON,PHOSPHORUS,SULFUR,
-									CHLORINE,POTASSIUM,IRON,COPPER,MERCURY,RADIUM,WATER,ETHANOL,SUGAR,SACID,TUNGSTEN)
-	else
-		dispensable_reagents = list(HYDROGEN,LITHIUM,CARBON,NITROGEN,OXYGEN,FLUORINE,SODIUM,ALUMINUM,SILICON,PHOSPHORUS,SULFUR,
-									CHLORINE,POTASSIUM,IRON,COPPER,MERCURY,RADIUM,WATER,ETHANOL,SUGAR,SACID,TUNGSTEN,
-									INAPROVALINE,DEXALIN,ANTI_TOXIN)
-	dispensable_reagents = sortList(dispensable_reagents)
+	dispensable_reagents.Remove(upgrade_chems) //Reset the list
+	if(upgraded)
+		dispensable_reagents.Add(upgrade_chems)
 
 /obj/machinery/chem_dispenser/proc/recharge()
 	if(stat & (BROKEN|NOPOWER|FORCEDISABLE))


### PR DESCRIPTION
It came to my attention that the special stock parts that can only be found via xenoarch had to go through 3 gates:
- The Xenoarch gate - The xenoarchaeologist not only brings them back to the station but also brings all 4 types of them.
- The Mechanics gate - Someone actually bothered to scan them using the Device Analyzer.
- The Phazon gate - Actually having the phazon required to print more of them.

It's for these reasons that I decided "it's fine for the components to do cool stuff, they're really rare and people are lazy at getting them". These machines now have additional functions when fully upgraded with phazon parts:
- Chemistry Dispenser: Unlocks quickly producing Plasma. More suggestions are welcome. No I don't think I can get away with nanobots.
- Booze Dispenser: Unlocks Karmotrine. The components did come from the same place that Karmotrine comes from. Mix those drinks up.
- Sleeper: Unlocks Doctor's Delight, Rezadone and Peridaxon, two more additions to the monstrous healing machine that is the Sleeper.

 Also made the Cloning Pod change its description to better highlight its special function with fully upgraded phazon parts.
:cl:
 * rscadd: The Chemistry Dispenser, Booze Dispenser and Sleeper now unlock extra chemicals when fully upgraded with phazon parts.
 * rscadd: The Cloning Pod will now change its name and description when fully upgraded with phazon parts. This is reversible in case it doesn't have phazon parts anymore.