### PR TITLE
Staff of Necromancy bugfix

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -261,13 +261,17 @@
 	if(ishuman(target))
 		success = TRUE
 		var/mob/living/carbon/human/H = target
-		if(raisetype)
-			H.dropBorers()
-			var/mob/living/simple_animal/hostile/necro/skeleton/spooky = new /mob/living/simple_animal/hostile/necro/skeleton(get_turf(H), user, H)
-			H.gib()
-			spooky.faction = "\ref[user]"
+		if(H.stat)
+			if(raisetype)
+				H.dropBorers()
+				var/mob/living/simple_animal/hostile/necro/skeleton/spooky = new /mob/living/simple_animal/hostile/necro/skeleton(get_turf(H), user, H)
+				H.gib()
+				spooky.faction = "\ref[user]"
+			else
+				H.zombify(user)
 		else
-			H.zombify(user)
+			success = FALSE
+			
 	else if(istype(target, /mob/living/simple_animal/hostile/necro/zombie/))
 		success = TRUE
 		var/mob/living/simple_animal/S = target


### PR DESCRIPTION
[hotfix]

If targets are alive, this can turn them right into skeleton simplemobs, or make them a zombie upon death. This is extremely overpowered!

## What this does
- Target has to be unconscious or dead

## Why it's good
- fix to my own code that I overlooked

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:

 * bugfix: Staff of necromancy no longer works on conscious humans