### PR TITLE
Telepathy messages are once again bolded

### DIFF
--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -158,17 +158,17 @@
 			M.telepathic_target += T
 			continue
 		if(T == user) //Talking to ourselves
-			to_chat(user,"<span class='notice'>Projected to self: [message]</span>")
+			to_chat(user,"<span class='notice'>Projected to self: \"[message]\"</span>")
 			return
 		if(M_TELEPATHY in T.mutations)
-			to_chat(T, "<span class='notice'>You hear [user.real_name]'s voice: [message]</span>")
+			to_chat(T, "<span class='notice'>You hear [user.real_name]'s voice:</span><span class='bold'> \"[message]\"</span>")
 		else
-			to_chat(T,"<span class='notice'>You hear a voice inside your head: [message] </span>")
+			to_chat(T,"<span class='notice'>You hear a voice inside your head:</span><span class='bold'> \"[message]\"</span>")
 		if(all_switch)
 			all_switch = FALSE
-			to_chat(user,"<span class='notice'>Projected to <b>[english_list(targets)]</b>: [message]</span>")
+			to_chat(user,"<span class='notice'>Projected to <b>[english_list(targets)]</b>:</span><span class='bold'>\"[message]\"</span>")
 			for(var/mob/dead/observer/G in dead_mob_list)
-				G.show_message("<i>Telepathy, <b>[user]</b> to [english_list(targets)]</b>: [message]</i>")
+				G.show_message("<i>Telepathy, <b>[user]</b> to [english_list(targets)]</b>:<b> \"[message]\"</b></i>")
 			log_admin("[key_name(user)] projects his mind towards to [english_list(targets)]: [message]")
 
 /datum/dna/gene/basic/morph

--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -166,7 +166,7 @@
 			to_chat(T,"<span class='notice'>You hear a voice inside your head:</span><span class='bold'> \"[message]\"</span>")
 		if(all_switch)
 			all_switch = FALSE
-			to_chat(user,"<span class='notice'>Projected to <b>[english_list(targets)]</b>:</span><span class='bold'>\"[message]\"</span>")
+			to_chat(user,"<span class='notice'>Projected to <b>[english_list(targets)]</b>:</span><span class='bold'> \"[message]\"</span>")
 			for(var/mob/dead/observer/G in dead_mob_list)
 				G.show_message("<i>Telepathy, <b>[user]</b> to [english_list(targets)]</b>:<b> \"[message]\"</b></i>")
 			log_admin("[key_name(user)] projects his mind towards to [english_list(targets)]: [message]")

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1350,14 +1350,14 @@ var/list/has_died_as_golem = list()
 	var/all_switch = TRUE
 	for(var/mob/living/T in telepathic_target)
 		if(istype(T) && can_mind_interact(T.mind))
-			to_chat(T,"<span class='mushroom'>You feel <b>[M]</b>'s thoughts: [message]</span>")
+			to_chat(T,"<span class='mushroom'>You feel <b>[M]</b>'s thoughts: \"[message]\"</span>")
 		else
 			to_chat(M,"<span class='notice'>[T] cannot sense your telepathy.</span>")
 			continue
 		if(all_switch)
 			all_switch = FALSE
 			if(T != M)
-				to_chat(M,"<span class='mushroom'>Projected to <b>[english_list(telepathic_target)]</b>: [message]</span>")
+				to_chat(M,"<span class='mushroom'>Projected to <b>[english_list(telepathic_target)]</b>: \"[message]\"</span>")
 			for(var/mob/dead/observer/G in dead_mob_list)
 				G.show_message("<i>Telepathy, <b>[M]</b> to <b>[english_list(telepathic_target)]</b>: [message]</i>")
 			log_admin("[key_name(M)] projects his mind towards [english_list(telepathic_target)]: [message]")


### PR DESCRIPTION
## What this does
#32604 accidentally removed the bolding from telepathy messages, making them easy to miss. Bolding was first added in #32263. Also adds quotation marks around the message being telepathically sent.

Requested by: @wotisjanitor

## Changelog
:cl:
 * tweak: Telepathy messages will now appear in bold.
