### PR TITLE
Magical Wardrobe can now be cast in the Wizard Den

### DIFF
--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -13,6 +13,7 @@
 
 	var/list/artifacts_bought = list()
 	var/list/potions_bought = list()
+	var/left_den = 0
 
 /datum/role/wizard/ForgeObjectives()
 	if(!antag.current.client.prefs.antag_objectives)
@@ -73,6 +74,11 @@
 	for (var/spell/S in old_character.spell_list)
 		if (S.user_type == USER_TYPE_WIZARD && !(S.spell_flags & LOSE_IN_TRANSFER))
 			new_character.add_spell(S)
+
+/datum/role/wizard/process()
+	..()
+	if(!istype(get_area(antag.current), /area/wizard_station))
+		left_den = 1
 
 /datum/role/wizard/GetScoreboard()
 	. = ..()

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -77,7 +77,7 @@
 
 /datum/role/wizard/process()
 	..()
-	if(!istype(get_area(antag.current), /area/wizard_station))
+	if(!left_den && !istype(get_area(antag.current), /area/wizard_station))
 		left_den = 1
 
 /datum/role/wizard/GetScoreboard()

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -271,10 +271,11 @@
 
 /obj/item/weapon/spellbook/proc/refund(mob/user)
 	var/datum/role/wizard/W = iswizard(user)
-	if(istype(W) && W.left_den)
-		to_chat(user, "<span class='notice'>No refunds once you leave your den.</span>")
-		return
-	else
+	if(istype(W))
+		if(W.left_den)
+			to_chat(user, "<span class='notice'>No refunds once you leave your den.</span>")
+			return
+	else if(!W)
 		to_chat(user, "<span class='warning'>You are not properly trained by the Wizard Federation to forget spells!</span>")
 		return
 

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -275,7 +275,7 @@
 		if(W.left_den)
 			to_chat(user, "<span class='notice'>No refunds once you leave your den.</span>")
 			return
-	else if(!W)
+	else
 		to_chat(user, "<span class='warning'>You are not properly trained by the Wizard Federation to forget spells!</span>")
 		return
 

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -270,9 +270,14 @@
 
 
 /obj/item/weapon/spellbook/proc/refund(mob/user)
-	if(!istype(get_area(user), /area/wizard_station))
+	var/datum/role/wizard/W = iswizard(user)
+	if(istype(W) && W.left_den)
 		to_chat(user, "<span class='notice'>No refunds once you leave your den.</span>")
 		return
+	else
+		to_chat(user, "<span class='warning'>You are not properly trained by the Wizard Federation to forget spells!</span>")
+		return
+
 
 	for(var/spell/S in user.spell_list)
 		if(S.refund_price <= 0)
@@ -284,7 +289,6 @@
 		uses += S.refund_price
 
 		//stat collection: spellbook purchases
-		var/datum/role/wizard/W = user.mind.GetRole(WIZARD)
 		if(istype(W) && istype(W.stat_datum, /datum/stat/role/wizard))
 			var/datum/stat/role/wizard/WD = W.stat_datum
 			WD.spellbook_purchases.Add("REFUND-" + S.name)

--- a/code/modules/spells/aoe_turf/magic_wardrobe.dm
+++ b/code/modules/spells/aoe_turf/magic_wardrobe.dm
@@ -7,7 +7,7 @@
 	hud_state = "wardrobe_main"
 	charge_max = 300 SECONDS
 	cooldown_min = 150 SECONDS
-	spell_flags = NEEDSCLOTHES | Z2NOCAST
+	spell_flags = NEEDSCLOTHES
 	invocation_type = SpI_SHOUT
 	invocation = "NAR'NI'AH"
 	summon_type = list(/obj/structure/closet/magical_wardrobe)


### PR DESCRIPTION
Also adds a variable that tracks if the wizard left the den, to prevent the wizard from recalling just to refund his spells. Prevents non-wizards people from refunding their spells on the spellbook, not like it actually ever kicked in since the only check was to check if the user is in the wizard's den, and there's pretty much zero chance the user would be in the wizard den if he's not a wizard.

:cl:
 * tweak: Magical Wardrobe can now be used in the Wizard Den. Plan your nefarious attacks against the station from your space lair of doom today!