### PR TITLE
The "my legs are OK" status message will also show up during April Fools

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -215,7 +215,7 @@
 					num_injuries++
 
 			if(num_injuries == 0)
-				if(hallucinating())
+				if(hallucinating() || Holiday == APRIL_FOOLS_DAY)
 					to_chat(src, "<span class = 'orange'>My legs are OK.</span>")
 				else
 					to_chat(src, "My limbs are [pick("okay","OK")].")
@@ -688,7 +688,7 @@
 		spawn(time)
 			make_visible(source_define)
 
-/mob/living/carbon/make_visible(var/source_define)	
+/mob/living/carbon/make_visible(var/source_define)
 	if(!source_define)
 		return
 	if(src && body_alphas[source_define])


### PR DESCRIPTION
Just a small tweak

:cl:
 * tweak: The "my legs are OK" status message will also show up during April Fools when self-examining, not just when hallucinating.