### PR TITLE
The red crowbar's unique noise now also works on reinforced walls.

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -717,7 +717,7 @@
 		force = 1.0 // To compensate
 
 /obj/item/tool/crowbar/red/suicide_act(var/mob/living/user)
-	to_chat(viewers(user), "<span class='danger'>[user] is smashing \his head in with the [src.name]! It looks like \he's done waiting for half life three!</span>")
+	to_chat(viewers(user), "<span class='danger'>[user] is smashing \his head in with the [src.name]! It looks like \he's done waiting for Half-Life 3!</span>")
 	playsound(get_turf(src), 'sound/medbot/Flatline_custom.ogg', 35)
 	return (SUICIDE_ACT_BRUTELOSS)
 

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -317,6 +317,8 @@
 						"<span class='notice'>You mend \the [src]'s external support rods.</span>")
 				else
 					return
+	if(istype(W, /obj/item/tool/crowbar/red))
+		playsound(src, "crowbar_hit", 50, 1, -1)
 
 //This is where we perform actions that aren't deconstructing, constructing or thermiting the reinforced wall
 

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -55,7 +55,7 @@
 	icon_state = "r_wall-[d_state]"  //You can thank me later
 
 /turf/simulated/wall/r_wall/attackby(obj/item/W as obj, mob/user as mob)
-
+	user.delayNextAttack(W.attack_delay)
 	if (!user.dexterity_check())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
@@ -317,8 +317,6 @@
 						"<span class='notice'>You mend \the [src]'s external support rods.</span>")
 				else
 					return
-	if(istype(W, /obj/item/tool/crowbar/red))
-		playsound(src, "crowbar_hit", 50, 1, -1)
 
 //This is where we perform actions that aren't deconstructing, constructing or thermiting the reinforced wall
 
@@ -350,7 +348,10 @@
 	//Finally, CHECKING FOR FALSE WALLS if it isn't damaged
 	//This is obsolete since reinforced false walls were commented out, but gotta slap the wall with my hand anyways !
 	else if(!d_state)
-		return attack_hand(user)
+		if(istype(W, /obj/item/tool/crowbar/red))
+			playsound(src, "crowbar_hit", 50, 1, -1)
+		else
+			return attack_hand(user)
 	return
 
 /turf/simulated/wall/r_wall/attack_construct(mob/user as mob)


### PR DESCRIPTION
Also cleans up the suicide_act() message a bit. Reinforced walls now have a proper item attack delay.

:cl:
 * bugfix: The unique noise that plays when red crowbars hit a reinforced wall now also plays on reinforced walls.
 * bugfix: Reinforced walls are now properly affected by attack delay.
 * spellcheck: Cleaned up the red crowbar's suicide message a bit.
