### PR TITLE
You trip when you run over someone lying down

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -318,6 +318,11 @@
 			R.annoy(src)
 	if(blood)
 		blood_splatter(loc,src,1)
+	if(lying && istype(AM, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = AM
+		if(H.m_intent == "run")
+			H.Knockdown(1)
+		
 
 //gets assignment from ID or ID inside PDA or PDA itself
 //Useful when player do something with computers

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -320,7 +320,7 @@
 		blood_splatter(loc,src,1)
 	if(prob(15) && lying && istype(AM, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = AM
-		if(H.m_intent == "run")
+		if(H.m_intent == "run" && !H.locked_to)
 			H.Knockdown(1)
 		
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -320,7 +320,7 @@
 		blood_splatter(loc,src,1)
 	if(prob(15) && lying && istype(AM, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = AM
-		if(H.m_intent == "run" && !H.locked_to)
+		if(H.m_intent == "run" && !H.locked_to && H.CheckSlip())
 			H.Knockdown(1)
 		
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -318,7 +318,7 @@
 			R.annoy(src)
 	if(blood)
 		blood_splatter(loc,src,1)
-	if(lying && istype(AM, /mob/living/carbon/human))
+	if(prob(15) && lying && istype(AM, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = AM
 		if(H.m_intent == "run")
 			H.Knockdown(1)


### PR DESCRIPTION
Yvvel calls it " table topping", I got the idea from him (this is his fault)

## What this does
When you cross over a lying human mob (dead or simply relaxing) while running, you get knocked down for one tick. (15% chance)

## Why it's good
- it's funny
- Imagine a murderboner with double e-swords tripping over a corpse and instantly dying -- poetic justice

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: You now trip over humans lying down while running (15% chance)