### PR TITLE
Blood splatters are only created when the limb is bleeding.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -260,7 +260,7 @@ emp_act
 				knock_out_teeth(user)
 
 	var/bloody = FALSE
-	if(final_force && ((I.damtype == BRUTE) || (I.damtype == HALLOSS)) && prob(25 + (final_force * 2)))
+	if(final_force && ((I.damtype == BRUTE) || (I.damtype == HALLOSS)) && (affecting.status & ORGAN_BLEEDING))
 		if(!(src.species.anatomy_flags & NO_BLOOD))
 			I.add_blood(src)	//Make the weapon bloody, not the person.
 			if(prob(33))

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -285,9 +285,10 @@
 		target.take_organ_damage(3)// 7 is the same as crowbar punch
 
 	// Break the syringe and transfer some of the reagents to the target
-	var/syringestab_amount_transferred = max(rand(min(reagents.total_volume, 2), (reagents.total_volume - 5)), 0) //nerfed by popular demand.
-	src.reagents.reaction(target, INGEST, amount_override = min(reagents.total_volume,syringestab_amount_transferred)/(reagents.reagent_list.len))
-	src.reagents.trans_to(target, syringestab_amount_transferred)
+	if(reagents.reagent_list.len)
+		var/syringestab_amount_transferred = max(rand(min(reagents.total_volume, 2), (reagents.total_volume - 5)), 0) //nerfed by popular demand.
+		src.reagents.reaction(target, INGEST, amount_override = min(reagents.total_volume,syringestab_amount_transferred)/(reagents.reagent_list.len))
+		src.reagents.trans_to(target, syringestab_amount_transferred)
 	src.desc += " It is broken."
 	src.mode = SYRINGE_BROKEN
 	src.add_blood(target)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
When attacking someone, there was a chance that your weapon would get bloodied that varied with the force of your weapon. This PR guarantees that your weapon will be bloodied when attacking someone, but only if the limb you hit caused bleeding (or was bleeding).

## Why it's good
It doesn't make sense to create a blood mess when the victim isn't actually bleeding. 
Sometimes accidental, low-force attacks look like murder scenes, which I think is part of why many people aren't alarmed by blood that they see lying around (mapped in blood is also to blame). Hopefully this will make blood messes more significant and a sign of something bad.

## Changelog

:cl:
 * tweak: When attacking somebody, your weapon will only be bloodied if the attacked limb is bleeding.
 * tweak: Weapons will always become bloody when causing bleeding or attacking a bleeding limb.

