### PR TITLE
The radiation gene emits less radiation by default but multiplies with user radiation

### DIFF
--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -43,7 +43,7 @@
 		emitted_harvestable_radiation(get_turf(owner), radiation * 100, range = 3) //1 power = ~70W, are you ready for radiation engines?
 		for(var/mob/living/L in orange(1, owner)) //Everyone nearby except the user
 			to_chat(L, "<span class='warning'>You are enveloped by a soft green glow emanating from [owner].</span>")
-			L.apply_radiation(5, RAD_EXTERNAL)
+			L.apply_radiation(3 * radiation/10, RAD_EXTERNAL)
 
 /datum/dna/gene/disability/radioactive/OnDrawUnderlays(var/mob/M,var/g,var/fat)
 	return "rads[fat]_s"

--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -22,7 +22,7 @@
 	speech.message = ""
 
 ////////////////////////////////////////
-// Harmful to others as well as self
+// Harmful to others
 ////////////////////////////////////////
 
 /datum/dna/gene/disability/radioactive
@@ -38,12 +38,13 @@
 
 /datum/dna/gene/disability/radioactive/OnMobLife(var/mob/living/owner)
 	var/radiation = owner.radiation
+	var/living_radiation = round(3 * (radiation >= 10 ? radiation/10 : 1), 1) //+3 radiation for every 10 radiation above 10.
 	owner.radiation = max(radiation - 30, 0)
 	if(owner.getarmor(null, "rad") < 100)
 		emitted_harvestable_radiation(get_turf(owner), radiation * 100, range = 3) //1 power = ~70W, are you ready for radiation engines?
 		for(var/mob/living/L in orange(1, owner)) //Everyone nearby except the user
 			to_chat(L, "<span class='warning'>You are enveloped by a soft green glow emanating from [owner].</span>")
-			L.apply_radiation(3 * radiation/10, RAD_EXTERNAL)
+			L.apply_radiation(living_radiation, RAD_EXTERNAL)
 
 /datum/dna/gene/disability/radioactive/OnDrawUnderlays(var/mob/M,var/g,var/fat)
 	return "rads[fat]_s"


### PR DESCRIPTION
I got owned as a vampire after trying to suck a radioactive insectoid, so I thought "isn't it supposed NOT to do radiation if the user doesn't have any?" but no they still emit radiation, that's by design. While at it I looked at the code and thought "man the radioactive people can brutalize just about anyone with this" so I looked into nerfing it to 3 rads per tick instead of 5, but I also decided to give something back to it: The more radiation the user has the more radiation they emit, at a rate of about +3 extra radiation for every 10 radiation the user has above 10.
Also go make a radioactive monkeyman engine already, come on it's been almost A YEAR since I added it!
:cl:
 * tweak: The radiation gene now emits weaker radiation to living beings by default (from 5 to 3) but increases in strength the more radiation the radioactive person has (+3 radiation for every 10 rads above 10).
