### PR TITLE
Fix hydroponics seeds never being able to lose some traits through mutations

### DIFF
--- a/code/modules/hydroponics/hydroponics_mutations.dm
+++ b/code/modules/hydroponics/hydroponics_mutations.dm
@@ -170,7 +170,7 @@
 					generic_mutation_message("rustles!")
 				if(PLANT_VORACIOUS)
 					//clever way of going from 0 to 1 to 2.
-					seed.voracious = (seed.juicy + 1) % 3
+					seed.voracious = (seed.voracious + 1) % 3
 					generic_mutation_message("shudders hungrily.")
 				if(PLANT_HEMATOPHAGE)
 					seed.hematophage = !seed.hematophage
@@ -200,7 +200,7 @@
 					seed.maturation -= round(min(hardcap - hardcap/2*round(log(10,hardcap/seed.maturation*100),0.01),max_change*seed.maturation),0.1)
 					generic_mutation_message("wriggles!")
 				if(PLANT_SPREAD)
-					seed.spread = (seed.juicy + 1) % 3
+					seed.spread = (seed.spread + 1) % 3
 					if(src && seed && seed.spread == 1)
 						visible_message("<span class='notice'>\The [seed.display_name] shifts in the tray!</span>")
 						spawn(20)

--- a/code/modules/hydroponics/hydroponics_mutations.dm
+++ b/code/modules/hydroponics/hydroponics_mutations.dm
@@ -58,8 +58,8 @@
 					else
 						visible_message("<span class='notice'>\The [seed.display_name] sheds its thorns away...</span>")
 				if(PLANT_JUICY)
-					//clever way of going from 0 to 1 to 2. Flips between 1 and 2.
-					seed.juicy = seed.juicy % 2 + 1
+					//clever way of going from 0 to 1 to 2. 
+					seed.juicy = (seed.juicy + 1) % 3
 					generic_mutation_message("wobbles!")
 				if(PLANT_LIGNEOUS)
 					seed.ligneous = !seed.ligneous
@@ -169,8 +169,8 @@
 						seed.fluid_consumption -= change*seed.fluid_consumption
 					generic_mutation_message("rustles!")
 				if(PLANT_VORACIOUS)
-					//clever way of going from 0 to 1 to 2. Flips between 1 and 2.
-					seed.voracious = seed.voracious % 2 + 1
+					//clever way of going from 0 to 1 to 2.
+					seed.voracious = (seed.juicy + 1) % 3
 					generic_mutation_message("shudders hungrily.")
 				if(PLANT_HEMATOPHAGE)
 					seed.hematophage = !seed.hematophage
@@ -200,7 +200,7 @@
 					seed.maturation -= round(min(hardcap - hardcap/2*round(log(10,hardcap/seed.maturation*100),0.01),max_change*seed.maturation),0.1)
 					generic_mutation_message("wriggles!")
 				if(PLANT_SPREAD)
-					seed.spread = seed.spread % 2 + 1
+					seed.spread = (seed.juicy + 1) % 3
 					if(src && seed && seed.spread == 1)
 						visible_message("<span class='notice'>\The [seed.display_name] shifts in the tray!</span>")
 						spawn(20)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
fixes seeds never being able to lose some mutations like vine spreading

## Why it's good
k

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed hydroponics seeds never being able to lose some traits through random mutations.
