### PR TITLE
Fixes fireballs not causing any station damage

### DIFF
--- a/code/modules/spells/targeted/projectile/fireball.dm
+++ b/code/modules/spells/targeted/projectile/fireball.dm
@@ -35,7 +35,7 @@
 /spell/targeted/projectile/dumbfire/fireball/prox_cast(var/list/targets, spell_holder)
 	for(var/mob/living/M in targets)
 		apply_spell_damage(M)
-	explosion(get_turf(spell_holder), ex_severe, ex_heavy, ex_light, ex_flash, whodunnit = spell_holder)
+	explosion(get_turf(spell_holder), ex_severe, ex_heavy, ex_light, ex_flash, whodunnit = holder)
 	return targets
 
 /spell/targeted/projectile/dumbfire/fireball/choose_prox_targets(mob/user = usr, var/atom/movable/spell_holder)


### PR DESCRIPTION
Fireballs were broken for almost a year because spell_holder which is the projectile was passed off as the one who caused the explosion instead of holder which is the user, which made the explosion code runtime. The bug existed since #31070.
Fixes #33259 
:cl:
 * bugfix: Fixed an 11-months-old bug where fireballs didn't cause any explosion at all because the explosion code checked the fireball's ckey instead of the user's ckey. This likely resulted in the fireball dealing far less damage than it should.
