### PR TITLE
People thrown by the Punch spell while frozen in time will no longer have funky sprites

### DIFF
--- a/code/modules/spells/targeted/punch.dm
+++ b/code/modules/spells/targeted/punch.dm
@@ -69,9 +69,10 @@
 			var/turns = 0 //Fixes a bug where the transform could occasionally get messed up such as when the target is lying down
 			spawn(0) //Continue spell-code
 				while(target.throwing)
-					target.transform = turn(target.transform, 45) //Spin the target
-					target.SetStunned(2) //We don't want the target to move during this time
-					turns += 45
+					if(!target.timestopped)
+						target.transform = turn(target.transform, 45) //Spin the target
+						target.SetStunned(2) //We don't want the target to move during this time
+						turns += 45
 					sleep(1)
 				target.transform = turn(target.transform, -turns)
 				target.Knockdown(2)


### PR DESCRIPTION
I couldn't replicate anything that would allow a wizard to "instantly kill people while in time-stop" but if it's shrapnel then I warned you already (#33041) and this is where I act all smug.

:cl:
 * bugfix: Targets thrown by the Punch spell while frozen in time will no longer end up with messed up sprites.