### PR TITLE
Wearing the Championship Belt and the Luchador Mask at the same time will double your unarmed damage and tackle power

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -429,3 +429,5 @@
 #define isapperanceeditable(A) (isatom(A))
 
 #define OMNI_LINK(A,B) isliving(A) && A:omnitool_connect(B)
+
+#define is_real_champion(A) ismob(A) && A.is_wearing_item(/obj/item/weapon/storage/belt/champion) && A.is_wearing_item(/obj/item/clothing/mask/luchador)

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -208,8 +208,7 @@
 	tForce += get_strength()*10
 	tForce += offenseMutTackle()
 	tForce += bonusTackleForce()
-	var/is_real_champion = is_wearing_item(/obj/item/weapon/storage/belt/champion) && is_wearing_item(/obj/item/clothing/mask/luchador)
-	if(is_real_champion)
+	if(is_real_champion(src)) //Wearing championship belt and luchador mask
 		tForce *= 2
 	return max(0, tForce)
 
@@ -232,8 +231,7 @@
 		tDef += 35
 	tDef += defenseMutTackle()
 	tDef += bonusTackleDefense()
-	var/is_real_champion = is_wearing_item(/obj/item/weapon/storage/belt/champion) && is_wearing_item(/obj/item/clothing/mask/luchador)
-	if(is_real_champion)
+	if(is_real_champion(src)) //Wearing championship belt and luchador mask
 		tDef *= 2
 	return max(0, tDef)
 

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -208,6 +208,9 @@
 	tForce += get_strength()*10
 	tForce += offenseMutTackle()
 	tForce += bonusTackleForce()
+	var/is_real_champion = is_wearing_item(/obj/item/weapon/storage/belt/champion) && is_wearing_item(/obj/item/clothing/mask/luchador)
+	if(is_real_champion)
+		tForce *= 2
 	return max(0, tForce)
 
 /mob/living/carbon/proc/offenseMutTackle(var/tF = 0)
@@ -229,6 +232,9 @@
 		tDef += 35
 	tDef += defenseMutTackle()
 	tDef += bonusTackleDefense()
+	var/is_real_champion = is_wearing_item(/obj/item/weapon/storage/belt/champion) && is_wearing_item(/obj/item/clothing/mask/luchador)
+	if(is_real_champion)
+		tDef *= 2
 	return max(0, tDef)
 
 /mob/living/carbon/proc/defenseMutTackle(var/tD = 0)

--- a/code/modules/mob/living/carbon/human/combat.dm
+++ b/code/modules/mob/living/carbon/human/combat.dm
@@ -141,7 +141,7 @@
 	var/datum/species/S = get_organ_species(get_active_hand_organ())
 
 	var/damage = rand(0, S.max_hurt_damage)
-	var/is_luchador = is_wearing_item(/obj/item/weapon/storage/belt/champion) && is_wearing_item(/obj/item/clothing/mask/luchador)
+	var/is_real_champion = is_wearing_item(/obj/item/weapon/storage/belt/champion) && is_wearing_item(/obj/item/clothing/mask/luchador)
 	damage += S.punch_damage
 
 	if(mutations.Find(M_HULK))
@@ -153,7 +153,7 @@
 		damage += G.get_damage_added() //Increase damage by the gloves' damage modifier
 
 		G.on_punch(src, victim)
-	if(is_luchador)
+	if(is_real_champion)
 		damage *= 2
 
 	return damage
@@ -288,6 +288,9 @@
 			tF += C.offenseTackleBonus()
 	if(species)
 		tF += species.tacklePower
+	var/is_real_champion = is_wearing_item(/obj/item/weapon/storage/belt/champion) && is_wearing_item(/obj/item/clothing/mask/luchador)
+	if(is_real_champion)
+		tF *= 2
 	return tF
 
 /mob/living/carbon/human/bonusTackleDefense(var/tD = 0)
@@ -296,6 +299,9 @@
 			tD += C.defenseTackleBonus()
 	if(species)
 		tD += species.tacklePower
+	var/is_real_champion = is_wearing_item(/obj/item/weapon/storage/belt/champion) && is_wearing_item(/obj/item/clothing/mask/luchador)
+	if(is_real_champion)
+		tD *= 2
 	return tD
 
 /mob/living/carbon/human/bonusTackleRange(var/tR = 0)

--- a/code/modules/mob/living/carbon/human/combat.dm
+++ b/code/modules/mob/living/carbon/human/combat.dm
@@ -141,6 +141,7 @@
 	var/datum/species/S = get_organ_species(get_active_hand_organ())
 
 	var/damage = rand(0, S.max_hurt_damage)
+	var/is_luchador = is_wearing_item(/obj/item/weapon/storage/belt/champion) && is_wearing_item(/obj/item/clothing/mask/luchador)
 	damage += S.punch_damage
 
 	if(mutations.Find(M_HULK))
@@ -152,6 +153,8 @@
 		damage += G.get_damage_added() //Increase damage by the gloves' damage modifier
 
 		G.on_punch(src, victim)
+	if(is_luchador)
+		damage *= 2
 
 	return damage
 

--- a/code/modules/mob/living/carbon/human/combat.dm
+++ b/code/modules/mob/living/carbon/human/combat.dm
@@ -288,9 +288,6 @@
 			tF += C.offenseTackleBonus()
 	if(species)
 		tF += species.tacklePower
-	var/is_real_champion = is_wearing_item(/obj/item/weapon/storage/belt/champion) && is_wearing_item(/obj/item/clothing/mask/luchador)
-	if(is_real_champion)
-		tF *= 2
 	return tF
 
 /mob/living/carbon/human/bonusTackleDefense(var/tD = 0)
@@ -299,9 +296,6 @@
 			tD += C.defenseTackleBonus()
 	if(species)
 		tD += species.tacklePower
-	var/is_real_champion = is_wearing_item(/obj/item/weapon/storage/belt/champion) && is_wearing_item(/obj/item/clothing/mask/luchador)
-	if(is_real_champion)
-		tD *= 2
 	return tD
 
 /mob/living/carbon/human/bonusTackleRange(var/tR = 0)

--- a/code/modules/mob/living/carbon/human/combat.dm
+++ b/code/modules/mob/living/carbon/human/combat.dm
@@ -141,7 +141,6 @@
 	var/datum/species/S = get_organ_species(get_active_hand_organ())
 
 	var/damage = rand(0, S.max_hurt_damage)
-	var/is_real_champion = is_wearing_item(/obj/item/weapon/storage/belt/champion) && is_wearing_item(/obj/item/clothing/mask/luchador)
 	damage += S.punch_damage
 
 	if(mutations.Find(M_HULK))
@@ -153,7 +152,7 @@
 		damage += G.get_damage_added() //Increase damage by the gloves' damage modifier
 
 		G.on_punch(src, victim)
-	if(is_real_champion)
+	if(is_real_champion(src)) //Wearing championship belt and luchador mask
 		damage *= 2
 
 	return damage


### PR DESCRIPTION
Done by request. There can be only one champion.

:cl:
 * tweak: Wearing the Championship Belt and the Luchador Mask at the same time will now significantly increase your unarmed damage and tackle power.