### PR TITLE
New contraband crate drug: Skeet

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -395,6 +395,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	num_contained = 5
 	contains = list(/obj/item/seeds/bloodtomatoseed,
 					/obj/item/weapon/storage/pill_bottle/zoom,
+					/obj/item/weapon/storage/pill_bottle/skeet,
 					/obj/item/weapon/storage/pill_bottle/happy,
 					/obj/item/weapon/reagent_containers/glass/bottle/pcp,
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe,

--- a/code/game/objects/items/contraband.dm
+++ b/code/game/objects/items/contraband.dm
@@ -28,3 +28,17 @@
 	new /obj/item/weapon/reagent_containers/pill/zoom( src )
 	new /obj/item/weapon/reagent_containers/pill/zoom( src )
 	new /obj/item/weapon/reagent_containers/pill/zoom( src )
+
+/obj/item/weapon/storage/pill_bottle/skeet
+	name = "Elderly Thyroid Medication"
+	desc = "An old pill bottle with it's label partially scratched off and written over. It reads 'Take new pill each time vison clears'."
+
+/obj/item/weapon/storage/pill_bottle/skeet/New()
+	. = ..()
+	new /obj/item/weapon/reagent_containers/pill/skeet( src )
+	new /obj/item/weapon/reagent_containers/pill/skeet( src )
+	new /obj/item/weapon/reagent_containers/pill/skeet( src )
+	new /obj/item/weapon/reagent_containers/pill/skeet( src )
+	new /obj/item/weapon/reagent_containers/pill/skeet( src )
+	new /obj/item/weapon/reagent_containers/pill/skeet( src )
+	new /obj/item/weapon/reagent_containers/pill/skeet( src )

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -255,15 +255,15 @@
 	reagents.add_reagent(SUGAR, 15)
 
 /obj/item/weapon/reagent_containers/pill/zoom
-	name = "Zoom pill"
-	desc = "Zoooom!"
-	icon_state = "pill7" //grey oblong
+	name = "Cryptosporidium pill"
+	desc = "Straight from the mothership drug labs; a party pill designed for ravers and addicts alike!"
+	icon_state = "pill37" //darkblue tablet
 
 /obj/item/weapon/reagent_containers/pill/zoom/New()
 	..()
-	reagents.add_reagent(IMPEDREZENE, 10)
-	reagents.add_reagent(SYNAPTIZINE, 1)
-	reagents.add_reagent(HYPERZINE, 10)
+	reagents.add_reagent(STOXIN, 1)
+	reagents.add_reagent(CRYPTOBIOLIN, 3)
+	reagents.add_reagent(HYPERZINE, 1)
 
 /obj/item/weapon/reagent_containers/pill/hyperzine
 	name = "Hyperzine pill"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -255,11 +255,22 @@
 	reagents.add_reagent(SUGAR, 15)
 
 /obj/item/weapon/reagent_containers/pill/zoom
-	name = "Cryptosporidium pill"
+	name = "Zoom pill"
+	desc = "Zoooom!"
+	icon_state = "pill7" //grey oblong
+
+/obj/item/weapon/reagent_containers/pill/zoom/New()
+	..()
+	reagents.add_reagent(IMPEDREZENE, 10)
+	reagents.add_reagent(SYNAPTIZINE, 1)
+	reagents.add_reagent(HYPERZINE, 10)
+
+/obj/item/weapon/reagent_containers/pill/skeet
+	name = "Skeet pill"
 	desc = "Straight from the mothership drug labs; a party pill designed for ravers and addicts alike!"
 	icon_state = "pill37" //darkblue tablet
 
-/obj/item/weapon/reagent_containers/pill/zoom/New()
+/obj/item/weapon/reagent_containers/pill/skeet/New()
 	..()
 	reagents.add_reagent(STOXIN, 1)
 	reagents.add_reagent(CRYPTOBIOLIN, 3)


### PR DESCRIPTION
epic name, I know

## What this does
Adds a new pill bottle to the cargo contraband crate with a new concoction: Skeet, one part sleep toxin, one part hyperzine, three parts cryptobiolin, all parts fun.

[Warning, somehow even MORE low quality showcasing video]

[droggas.webm](https://user-images.githubusercontent.com/89323872/190092637-829b7cee-df17-4429-b49f-1e76a6299e0e.webm)


## Elaboration
Skeet is described as a raver party drug, with a visual effect of foggy vision from the sleep toxin, a high heartrate and speed from hyperzine, and sporadic movement from cryptobiolin, leave what I believe to be a fun and unique drug combination. 
This PR was spurred on from a past of toying with recreational drug combinations, and with my recent purchasings of contraband crates to take copious amounts of PCP and Space Drugs, I wished to throw my hat in the ring with a new drug combination for people to check out without needing me to make and distribute it.

If I can think up anymore good recreational drugs to add to the contraband crate, i'll certainly make up another PR, although the options are all very limited when you factor in things like redundancies and the injection of new ghetto chems out into the wild.

:cl:
 * rscadd: Adds a new pill concoction to the contraband crate: Skeet, Ravers drug of choice to become the life of any party.
