### PR TITLE
Sufficiently slow space wind will no longer violently collide things into each other

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -404,7 +404,7 @@
 // Always override this proc instead of BYOND-provided Bump().
 // This gives us better control over what actually gets bumped instead of being stuck with BYOND's decision.
 /atom/movable/proc/to_bump(atom/Obstacle)
-	if(airflow_speed > 0 && airflow_dest)
+	if(airflow_speed > 3 && airflow_dest)
 		airflow_hit(Obstacle)
 	else
 		airflow_speed = 0

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -404,8 +404,8 @@
 // Always override this proc instead of BYOND-provided Bump().
 // This gives us better control over what actually gets bumped instead of being stuck with BYOND's decision.
 /atom/movable/proc/to_bump(atom/Obstacle)
-	if(airflow_speed > 3 && airflow_dest)
-		airflow_hit(Obstacle)
+	if(airflow_speed > 0 && airflow_dest)
+		airflow_hit(Obstacle, airflow_speed)
 	else
 		airflow_speed = 0
 		airflow_time = 0


### PR DESCRIPTION
Ever got into a situation where someone left a hole in the floor in which a locker ended up and your character got repeatedly slammed into that locker until they died, even though the breeze wasn't all that much? You probably have!
Adds a minimum amount of airflow speed required for violent ZAS collision to happen, which prevents people and objects from ZAS-colliding into each other (they will still touch and all that though). Not much sense in being brutalized by air that gently nudges you into a locker.
I'll keep looking at this change until I'm confident I've ironed out any sort of bug from touching paleolithic code.

:cl:
 * tweak: ZAS will no longer violently collide you into objects from any sort of breeze, now it requires a sufficiently strong breeze to do so.