### PR TITLE
Fix AI control light not working on APC's

### DIFF
--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -19,7 +19,7 @@ var/const/APC_WIRE_AI_CONTROL = 8
 /datum/wires/apc/GetInteractWindow()
 	var/obj/machinery/power/apc/A = holder
 	. += ..()
-	. += text("<br>\n[(A.locked ? "The APC is locked." : "The APC is unlocked.")]<br>\n[(A.shorted ? "The APCs power has been shorted." : "The APC is working properly!")]<br>\n[(A.aidisabled ? "The 'AI control allowed' light is off." : "The 'AI control allowed' light is on.")]")
+	. += text("<br>\n[(A.locked ? "The APC is locked." : "The APC is unlocked.")]<br>\n[(A.shorted ? "The APCs power has been shorted." : "The APC is working properly!")]<br>\n[(A.stat & NOAICONTROL ? "The 'AI control allowed' light is off." : "The 'AI control allowed' light is on.")]")
 
 
 /datum/wires/apc/CanUse(var/mob/living/L)

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -19,7 +19,7 @@
 				reset_view(null)
 
 /mob/living/silicon/ai/proc/life_handle_malf()
-	if(!malfhack || !malfhack.aidisabled)
+	if(!malfhack)
 		return
 	to_chat(src, "<span class='warning'>ERROR: APC access disabled, hack attempt canceled.</span>")
 	malfhacking = 0

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -909,7 +909,7 @@
 			usr.unset_machine()
 		return 1
 	if(!isobserver(usr))
-		if((!stat & NOAICONTROL) && malflocked && (usr != malfai && usr.loc != src)) //exclusive control enabled
+		if(!(stat & NOAICONTROL) && malflocked && (usr != malfai && usr.loc != src)) //exclusive control enabled
 			to_chat(usr, "Access refused.")
 			return 0
 	if(!can_use(usr, 1))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -74,7 +74,6 @@
 	var/chargecount = 0
 	var/locked = 1
 	var/coverlocked = 1
-	var/aidisabled = 0
 	var/tdir = null
 	var/lastused_light = 0
 	var/lastused_equip = 0
@@ -870,14 +869,7 @@
 	if (istype(user, /mob/living/silicon))
 		var/mob/living/silicon/ai/AI = user
 		var/mob/living/silicon/robot/robot = user
-		if (                                                             \
-			src.aidisabled ||                                            \
-			malfhack && istype(malfai) &&                                \
-			(                                                            \
-				(istype(AI) && (malfai!=AI && malfai != AI.parent)) ||   \
-				(istype(robot) && (robot in malfai.connected_robots))    \
-			)                                                            \
-		)
+		if((src.stat & NOAICONTROL) || malfhack && istype(malfai) && ((istype(AI) && (malfai!=AI && malfai != AI.parent)) || (istype(robot) && (robot in malfai.connected_robots))))
 			if(!loud)
 				to_chat(user, "<span class='warning'>\The [src] have AI control disabled!</span>")
 				nanomanager.close_user_uis(user, src)
@@ -917,7 +909,7 @@
 			usr.unset_machine()
 		return 1
 	if(!isobserver(usr))
-		if((!aidisabled) && malflocked && (usr != malfai && usr.loc != src)) //exclusive control enabled
+		if((!stat & NOAICONTROL) && malflocked && (usr != malfai && usr.loc != src)) //exclusive control enabled
 			to_chat(usr, "Access refused.")
 			return 0
 	if(!can_use(usr, 1))


### PR DESCRIPTION
Also removes a variable that no longer does anything which was related to this bug.
Fixes #33182 
[bugfix]
## Changelog
:cl:
 * bugfix: The AI control wire's light on APC's will now properly toggle on and off.