### PR TITLE
Plastic Flaps Airflow Bugfix

### DIFF
--- a/code/game/objects/structures/flaps.dm
+++ b/code/game/objects/structures/flaps.dm
@@ -19,6 +19,7 @@
 		airtight = !airtight
 		name = "\improper [airtight? "Airtight p" : "P"]lastic flaps"
 		desc = "[airtight? "Heavy duty, airtight, plastic flaps." : "I definitely can't get past those. No way."]"
+		update_nearby_tiles()
 		return 1
 	if(I.is_wrench(user) && airtight != 1)
 		if(anchored == 0)
@@ -33,6 +34,7 @@
 		if(WT.remove_fuel(0, user))
 			new /obj/item/stack/sheet/mineral/plastic (src.loc,10)
 			qdel(src)
+			
 			return
 	return ..()
 

--- a/code/game/objects/structures/flaps.dm
+++ b/code/game/objects/structures/flaps.dm
@@ -56,6 +56,12 @@
 	if(!istype(mover)) // Aircheck!
 		return !airtight
 	return 1
+	
+//Destruction ZAS sanity
+/obj/structure/plasticflaps/Destroy()
+	airtight = 0
+	update_nearby_tiles()
+	..()
 
 /obj/structure/plasticflaps/ex_act(severity)
 	switch(severity)

--- a/code/game/objects/structures/flaps.dm
+++ b/code/game/objects/structures/flaps.dm
@@ -34,7 +34,6 @@
 		if(WT.remove_fuel(0, user))
 			new /obj/item/stack/sheet/mineral/plastic (src.loc,10)
 			qdel(src)
-			
 			return
 	return ..()
 


### PR DESCRIPTION
Razz will be happy to hear this.

## What this does
Fixes a bug involving plastic flaps being permanently airtight (or not airtight). regardless of wrenching, crowbaring, or even deleting. Basically, they now update ZAS when their airtightness changes.

## Why it's good
BUG FIX

Fixes #31861.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Plastic flaps now update ZAS when you crowbar them between airtight states.

[bugfix] [tested]