### PR TITLE
Machinery Self Sacrifice Bugfix

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -237,8 +237,8 @@ Class Procs:
 	..()
 
 /obj/machinery/suicide_act(var/mob/living/user)
-	if(!(stat & NOPOWER|BROKEN|FORCEDISABLE) && use_power > 0)
-		to_chat(viewers(user), "<span class='danger'>[user] is placing \his hands into the sockets of the [src] and tries to fry \himself! It looks like \he's trying to commit suicide.</span>")
+	if(!(stat & (NOPOWER|BROKEN|FORCEDISABLE)) && use_power > 0)
+		to_chat(viewers(user), "<span class='danger'>[user] is placing \his hands into the sockets of the [src] to try to fry \himself! It looks like \he's trying to commit suicide.</span>")
 		return(SUICIDE_ACT_FIRELOSS)
 
 /obj/machinery/ex_act(severity)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/69739118/190585523-1a75c7fe-e6a6-474b-858e-76c672fe9c9a.png)

## What this does
Makes suicide via generic, stationary machinery actually work. The previous coder did not remember their order of bitwise operations. Also, this fixes the grammar a bit.

## Why it's good
Gives a person the ability to fry themselves using an Airshield.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Suiciding on machines actually works now.
 
 [bugfix] [tested]