### PR TITLE
Airshield Bugfixes and Power Changes

### DIFF
--- a/code/game/objects/structures/airshield.dm
+++ b/code/game/objects/structures/airshield.dm
@@ -49,7 +49,7 @@
 			qdel(src)
 	else
 		..()
-		
+
 /obj/machinery/airshield //machinery duplicate so it inherits the simple craftable behaviour of machines
 	name = "airshield"
 	desc = "A shield that allows only non-gasses to pass through."
@@ -59,10 +59,76 @@
 	density = 0
 	anchored = 1
 	plane = ABOVE_HUMAN_PLANE
+	power_channel = ENVIRON
 	idle_power_usage = 100
 	active_power_usage = 100 //always uses 100w
-	
+	light_range_on = 1
+	light_power_on = 1
+	use_auto_lights = 1
+	var/construction_step = WIRINGSECURE
+
+/obj/machinery/airshield/New()
+	..()
+	component_parts = newlist(
+		/obj/item/weapon/circuitboard/airshield,\
+		/obj/item/weapon/stock_parts/manipulator,\
+		/obj/item/weapon/stock_parts/manipulator,\
+		/obj/item/weapon/stock_parts/manipulator,\
+		/obj/item/weapon/stock_parts/micro_laser
+	)
+	RefreshParts()
+
 /obj/machinery/airshield/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover))
 		return ..()
-	return FALSE
+	else
+		return (stat & NOPOWER)
+
+/obj/machinery/airshield/attackby(obj/item/weapon/W, mob/user)
+	if(W.is_screwdriver(user))
+		if(user.loc != loc)
+			to_chat(user,"<span class='warning'>You need to be inside \the [src] to do work on it!</span>")
+			return
+		if(construction_step == WIRINGSECURE)
+			visible_message("<span class='warning'>[user] is disassembling the wiring on \the [src]!</span>")
+			W.playtoolsound(src, 80)
+			if(do_after(user, src, 6 SECONDS))
+				W.playtoolsound(src, 80)
+				visible_message("<span class='notice'>[user] finished unsecuring the wires on \the [src].</span>")
+				construction_step = WIRINGUNSECURE
+		else
+			visible_message("<span class='notice'>[user] is resecuring the wires on \the [src].</span>")
+			W.playtoolsound(src, 80)
+			if(do_after(user, src, 1 SECONDS))
+				construction_step = WIRINGSECURE
+	else if(iswelder(W))
+		if(user.loc != loc)
+			to_chat(user,"<span class='warning'>You need to be inside \the [src] to do work on it!</span>")
+			return
+		if(construction_step != WIRINGUNSECURE)
+			to_chat(user,"<span class='warning'>The wires are still secure on that!</span>")
+			return
+		var/obj/item/tool/weldingtool/WT = W
+		user.visible_message("<span class='warning'>[user] starts disassembling \the [src].</span>", \
+			"<span class='notice'>You start disassembling \the [src].</span>")
+		if(WT.do_weld(user, src, 6 SECONDS, 2))
+			user.visible_message("<span class='notice'>[user] finished disassembling \the [src].</span>", \
+			"<span class='notice'>You finish disassembling \the [src].</span>")
+			dropFrame()
+			spillContents()
+			stat |= NOPOWER
+			update_nearby_tiles()
+			qdel(src)
+	else
+		..()
+
+/obj/machinery/airshield/power_change()
+	if (powered(power_channel))
+		stat &= ~NOPOWER
+		set_light(light_range_on, light_power_on)
+		src.icon_state = "emancipation_grill_on"
+	else
+		stat |= NOPOWER
+		set_light(0)
+		src.icon_state = "emancipation_grill"
+	update_nearby_tiles()

--- a/code/game/objects/structures/airshield.dm
+++ b/code/game/objects/structures/airshield.dm
@@ -77,6 +77,7 @@
 		/obj/item/weapon/stock_parts/micro_laser
 	)
 	RefreshParts()
+	power_change()
 
 /obj/machinery/airshield/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	if(istype(mover))
@@ -116,11 +117,14 @@
 			"<span class='notice'>You finish disassembling \the [src].</span>")
 			dropFrame()
 			spillContents()
-			stat |= NOPOWER
-			update_nearby_tiles()
 			qdel(src)
 	else
 		..()
+
+/obj/machinery/airshield/Destroy()
+	stat |= NOPOWER
+	update_nearby_tiles()
+	..()
 
 /obj/machinery/airshield/power_change()
 	if (powered(power_channel))


### PR DESCRIPTION
# Airshields can be TURNED OFF and TAKEN APART!!
![image](https://user-images.githubusercontent.com/69739118/190599949-a0964104-f899-4246-9114-057d04747a94.png)
![image](https://user-images.githubusercontent.com/69739118/190595174-a69b082c-b31a-47ef-b300-c737e4bca250.png)

## What this does
This PR does several very unatomic things in one file, because Machinery Airshields were added in a pretty broken state:
* Allows Machinery Airshields to be properly deconstructed like Structure Airshields (as seen on the Syndie Sat tator tot item). As of current code, they cannot be deconstructed by any normal, non-explosion means, due to missing machine flags and unique deconstruction code. This requires a screwdriver and welder, and must be done from inside the airshield's field.
* Properly requires components in the machine itself. Airshields built by hand with a circuitboard did not have any issues, but those placed by admin spawn or flatpacks did not contain any parts and therefore could not be mechanic scanned or otherwise treated as machines.
* Destroying an airshield now properly updates ZAS. Before, if you had an admin delete it (since you could not deconstruct them), the airshield effect would remain. This also applied to deconstruction.
* Airshields already used power before, but now they properly turn off when they are unpowered. This updates the icon as well as ZAS. Beforehand, if power went out, their effect would remain. Unknown if this was intended, due to discussion on the last PR implying that power outages would turn off the shields.
* Airshields draw power from ENVIRON instead of EQUIP. This means that they are the last things to turn off when power fails, similar to airlocks and vents.
* If an airshield has power, it has a very faint glow and the current emancipation field effect. If it does not have power, the glow turns off and the field vanishes.

## Why it's good
BUGFIX VALIDS. It's arguable if the power changes are a bugfix, but I believe that the power usage was on the initial PR for a reason.

Fixes #33287. Fixes #33344.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Airshields can now be deconstructed with a screwdriver and welder.
 * bugfix: Airshields no longer leave a permanent airshield effect behind when removed.
 * bugfix: Airshields, despite using power, did not turn off when out of power. They turn off now. Beware of random events...
 * tweak: Airshields draw power from the Environment power channel instead of the Equipment channel, turning off only when the APC is completely out of power.
 * tweak: Powered airshields faintly glow, and unpowered airshields no longer have a visible field.

[bugfix] [tested]