### PR TITLE
Removes blood tomato seeds from contraband crate.

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -393,8 +393,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 
 /datum/supply_packs/randomised/contraband
 	num_contained = 5
-	contains = list(/obj/item/seeds/bloodtomatoseed,
-					/obj/item/weapon/storage/pill_bottle/zoom,
+	contains = list(/obj/item/weapon/storage/pill_bottle/zoom,
 					/obj/item/weapon/storage/pill_bottle/skeet,
 					/obj/item/weapon/storage/pill_bottle/happy,
 					/obj/item/weapon/reagent_containers/glass/bottle/pcp,


### PR DESCRIPTION
### What this does
Removes the blood tomato seed from the contraband crate. 
It feels way out of place and it isn't really contraband if you can make blood tomatoes in 5 seconds (plant tomato, pour mutagen/radium/uranium/etc, wait 5 seconds).
### Why it's good
Makes the contraband crate thematically consistent.
:cl:
 * rscdel: Contraband cargo crates no longer have blood tomato seeds.