### PR TITLE
Fixes cannonball and clownnonball recycling.

### DIFF
--- a/code/modules/projectiles/guns/projectile/constructable/siegecannon.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/siegecannon.dm
@@ -209,7 +209,7 @@
 	throw_speed = 1
 	throw_range = 2	//Rather heavy
 	force = 10	//Somehow less than a toolbox but okay
-	starting_materials = list(MAT_IRON = CC_PER_SHEET_METAL*3)
+	starting_materials = list(MAT_IRON = CC_PER_SHEET_METAL*20)
 	w_type = RECYK_METAL
 	flags = FPRINT | TWOHANDABLE | MUSTTWOHAND
 	var/cannonFired = FALSE
@@ -487,7 +487,7 @@
 	desc = "A large sphere of honk."
 	icon = 'icons/obj/siege_cannon.dmi'
 	icon_state = "clownnonball"
-	starting_materials = list(MAT_CLOWN = CC_PER_SHEET_METAL*3)
+	starting_materials = list(MAT_CLOWN = CC_PER_SHEET_METAL*10.7) //20.006 bananium sheets
 	adjRange = 50
 	adjSpeed = 1
 	adjForce = 0

--- a/code/modules/projectiles/guns/projectile/constructable/siegecannon.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/siegecannon.dm
@@ -487,7 +487,7 @@
 	desc = "A large sphere of honk."
 	icon = 'icons/obj/siege_cannon.dmi'
 	icon_state = "clownnonball"
-	starting_materials = list(MAT_CLOWN = CC_PER_SHEET_METAL*10.7) //20.006 bananium sheets
+	starting_materials = list(MAT_CLOWN = CC_PER_SHEET_CLOWN*20)
 	adjRange = 50
 	adjSpeed = 1
 	adjForce = 0


### PR DESCRIPTION
### What this does
For some reason the regular cannonball recycled into 3 sheets and the clownnonball recycled into 5.625, despite both of them costing 20 sheets to make.
### Why it's good
bugfix good and consistency with literally every other item recycling giving you back the exact cost of the material.
:cl:
 * bugfix: Cannonball and Clownnonball recycling now gives you the proper amount of materials.