### PR TITLE
Fixes observe verb defaulting to cyborg when cancelled

### DIFF
--- a/code/modules/mob/dead/observer/verbs.dm
+++ b/code/modules/mob/dead/observer/verbs.dm
@@ -196,6 +196,8 @@
 
 	var/list/mobs = getmobs()
 	var/input = input("Please, select a mob!", "Haunt", null, null) as null|anything in mobs
+	if(!input)
+		return
 	var/mob/target = mobs[input]
 	manual_follow(target)
 


### PR DESCRIPTION
I really couldn't tell you why it defaults to cyborg. You'd think it'd default to the AI core based on how `sortmob()` works.
Fixes #31482 
:cl:
 * bugfix: Cancelling the Haunt/Observe verb will no longer make you start haunting a cyborg.