### PR TITLE
Fixes being only able to photography bees when they're moving south

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -181,4 +181,4 @@
 		return 4
 	if (findtextEx(haystack, "iVBORw0KGgoAAAANSUhEUgAAACAAAABg"))
 		return 8
-	return 0 //unknown patern, most likely something animated, oh well. be sure to account for that in your proc call.
+	return 0 //unknown pattern, most likely something animated, oh well. be sure to account for that in your proc call.

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -181,4 +181,4 @@
 		return 4
 	if (findtextEx(haystack, "iVBORw0KGgoAAAANSUhEUgAAACAAAABg"))
 		return 8
-	return 0
+	return 0 //unknown patern, most likely something animated, oh well. be sure to account for that in your proc call.

--- a/code/libs/Get Flat Icon/Get Flat Icon Deluxe.dm
+++ b/code/libs/Get Flat Icon/Get Flat Icon Deluxe.dm
@@ -81,8 +81,8 @@ cons:
 			var/dir = data[GFI_DX_DIR]
 			if (dir != SOUTH) // south-facing atoms shouldn't pose any problem
 				var/icon_directions = get_icon_dir_count(data[GFI_DX_ICON],data[3])
-				if (icon_directions == 1)
-					data[GFI_DX_DIR] = SOUTH // if the icon has only one direction we HAVE to face south
+				if ((icon_directions == 0) || (icon_directions == 1))
+					data[GFI_DX_DIR] = SOUTH // if the icon has only one direction we HAVE to face south. if we're not sure (something animated?), have it face south anyway.
 				else if (icon_directions == 4)
 					if (dir != NORTH && dir != EAST && dir != WEST)
 						data[GFI_DX_DIR] = SOUTH


### PR DESCRIPTION
Fixes #31464

Might cause other animated sprites to appear facing south on photos, but it's that or having some of them being outright invisible. Please Lummox add a proc that returns how many directions a given icon_state has so I don't have to hack some base64 hash bullshit.

:cl:
* bugfix: Fixed bees being only able to be photographed when they're moving south.