### PR TITLE
Unfucks the shield wall generator

### DIFF
--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -406,7 +406,7 @@
 
 /obj/machinery/shieldwallgen/examine(mob/user)
 	..()
-	to_chat(usr, "<span class='info'>[src.get_status_text()]</span>")
+	to_chat(user, "<span class='info'>[src.get_status_text()]</span>")
 
 /obj/machinery/shieldwallgen/process()
 	spawn(100)

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -364,6 +364,19 @@
 	else
 		power = FALSE
 
+/obj/machinery/shieldwallgen/proc/get_status_text()
+	if(!anchored)
+		return "<span class='warning'>It is not secured to the floor.</span>"
+	if(!power_connection.connected)
+		return "<span class='warning'>It is not connected to power.</span>"
+
+	. = "It is <span class='[storedpower>=storedpower_consumption?"info":"warning"]'>"
+	. += "[round((storedpower/maxstoredpower)*100)]%</span> charged. "
+	if(power_connection.get_satisfaction()>0)
+		. += "It is charging at at rate of [round(power_connection.get_satisfaction()*100)]%."
+	else
+		. += "<span class='warning'>It is not charging.</span>"
+
 /obj/machinery/shieldwallgen/attack_hand(mob/user as mob)
 	if(!anchored)
 		to_chat(user, "<span class='warning'>The shield generator needs to be firmly secured to the floor first.</span>")
@@ -371,8 +384,8 @@
 	if(src.locked && !istype(user, /mob/living/silicon))
 		to_chat(user, "<span class='warning'>The controls are locked!</span>")
 		return 1
-	if(power != 1)
-		to_chat(user, "<span class='warning'>The shield generator needs to be powered by wire underneath.</span>")
+	if(!power)
+		to_chat(user, "<span class='warning'>The shield generator's status display flashes: [src.get_status_text()]</span>")
 		return 1
 
 	if(src.active)
@@ -390,6 +403,10 @@
 			"You turn on the shield generator.", \
 			"You hear heavy droning.")
 	src.add_fingerprint(user)
+
+/obj/machinery/shieldwallgen/examine(mob/user)
+	..()
+	to_chat(usr, "<span class='info'>[src.get_status_text()]</span>")
 
 /obj/machinery/shieldwallgen/process()
 	spawn(100)
@@ -473,8 +490,10 @@
 		to_chat(user, "Turn off the field generator first.")
 		return FALSE
 	. = ..()
-	if(!.)
-		return
+	if(anchored)
+		power_connection.connect()
+	else
+		power_connection.disconnect()
 
 /obj/machinery/shieldwallgen/attack_ghost(mob/user)
 	if(isAdminGhost(user))


### PR DESCRIPTION
<!-- [bugfix] [exploitable] [tested] [qol] -->

## What this does
Shield wall generators never disconnect from power, allowing them to be repositioned and powered without a wire knot underneath. This fixes that.

It also adds useful messages when examining and attempting to activate the generator.

## Why it's good
Clarity and a bugfix

## Changelog
:cl:
 * bugfix: Shield wall generators can no longer receive power by magic.
 * tweak: Shield wall generators provide more information when examined.
