### PR TITLE
Adds airshields to the solder blank circuitboard list.

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -291,6 +291,7 @@ to destroy them and players will be able to make replacements.
 	"air alarm"=/obj/item/weapon/circuitboard/air_alarm,
 	"fire alarm"=/obj/item/weapon/circuitboard/fire_alarm,
 	"airlock"=/obj/item/weapon/circuitboard/airlock,
+	"airshield"=/obj/item/weapon/circuitboard/airshield,
 	"APC"=/obj/item/weapon/circuitboard/power_control,
 	"vendomat"=/obj/item/weapon/circuitboard/vendomat,
 	"microwave"=/obj/item/weapon/circuitboard/microwave,


### PR DESCRIPTION
### What this does
Adds the airshield circuitboard to the blank circuitboard's solder options. This makes them slightly more accessible to engineering staff and not as dependent on RnD for more circuits.
### Why it's good
Lets you manufacture the airshield circuits without needing to depend on RnD or the neverworking mechanic.
:cl:
 * rscadd: Airshield circuitboards on the blank circuitboard's solder options.