### PR TITLE
Fixes power monitor runtiming if an APC is broken or being disassembled

### DIFF
--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -140,23 +140,24 @@
 			var/obj/machinery/power/apc/apc = machine
 			var/list/apc_status = apc.get_monitor_status()
 
-			apc_status["\ref[apc]"]["f_demand"] = format_watts(apc_status["\ref[apc]"]["demand"])
-			data["areas"]["\ref[get_area(apc)]"] = list(
-				"name" = get_area(apc).name,
-				"demand" = apc_status["\ref[apc]"]["demand"],
-				"charging" = MONITOR_STATUS_BATTERY_STEADY,
-				"charge" = 0,
-				"eqp" = apc.equipment,
-				"lgt" = apc.lighting,
-				"env" = apc.environ,
-				"machines" = apc_status
-			)
+			if (apc_status) //broken APCs and APCs being dismantled will return null, don't forget to check for those
+				apc_status["\ref[apc]"]["f_demand"] = format_watts(apc_status["\ref[apc]"]["demand"])
+				data["areas"]["\ref[get_area(apc)]"] = list(
+					"name" = get_area(apc).name,
+					"demand" = apc_status["\ref[apc]"]["demand"],
+					"charging" = MONITOR_STATUS_BATTERY_STEADY,
+					"charge" = 0,
+					"eqp" = apc.equipment,
+					"lgt" = apc.lighting,
+					"env" = apc.environ,
+					"machines" = apc_status
+				)
 
-			if (apc_status["\ref[apc]_b"])
-				apc_status["\ref[apc]_b"]["f_demand"] = format_watts(apc_status["\ref[apc]_b"]["demand"])
-				data["areas"]["\ref[get_area(apc)]"]["demand"] += apc_status["\ref[apc]_b"]["demand"]
-				data["areas"]["\ref[get_area(apc)]"]["charging"] = apc_status["\ref[apc]_b"]["charging"]
-				data["areas"]["\ref[get_area(apc)]"]["charge"] = apc_status["\ref[apc]_b"]["charge"]
+				if (apc_status["\ref[apc]_b"])
+					apc_status["\ref[apc]_b"]["f_demand"] = format_watts(apc_status["\ref[apc]_b"]["demand"])
+					data["areas"]["\ref[get_area(apc)]"]["demand"] += apc_status["\ref[apc]_b"]["demand"]
+					data["areas"]["\ref[get_area(apc)]"]["charging"] = apc_status["\ref[apc]_b"]["charging"]
+					data["areas"]["\ref[get_area(apc)]"]["charge"] = apc_status["\ref[apc]_b"]["charge"]
 
 		else if (machine && !(machine in machines)) //Some machines (eg: SMES) could have an input terminal and output wire knot on
 			machines += machine						// the same grid, counting them twice. This prevents that


### PR DESCRIPTION
[bugfix]
It was literally just missing a null check on the monitor for when `/obj/machinery/power/apc/get_monitor_status()` returns `null` instead of monitor data due to being broken and such (any of `stat & (BROKEN|MAINT|FORCEDISABLE)`)

## What this does
Fixes #33320
For the record, as far as I can tell merely missing a cell was not enough for the bug to happen (despite what was reported on the issue), as neither wiring the ghetto bar on Box to the grid nor removing the cell in the captain's office APC did the trick - They both showed up on the monitor fine, with their charge depleted. 
Keep an eye out for similar crashes in case I missed something.

## Changelog
:cl:
 * bugfix: The power monitor should no longer break whenever an APC breaks or is left half disassembled
