### PR TITLE
Renames the Vendomat vending machine to StockPro

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1351,8 +1351,8 @@ var/global/num_vending_terminals = 1
 	pack = /obj/structure/vendomatpack/boozeomat
 
 /obj/machinery/vending/assist
-	name = "\improper Vendomat"
-	desc = "A vending machine containing generic parts."
+	name = "\improper StockPro"
+	desc = "A vending machine containing generic stock parts and assemblies."
 	icon_state = "generic"
 	products = list(
 		/obj/item/device/assembly/prox_sensor = 5,

--- a/code/game/objects/items/vouchers.dm
+++ b/code/game/objects/items/vouchers.dm
@@ -91,7 +91,7 @@
 
 /obj/item/voucher/free_item/glowing //This one gives you special voucher-only items!
 	name = "glowing voucher"
-	desc = "Don't bother appealing to a Vendomat without this!"
+	desc = "Don't bother appealing to a StockPro without this!"
 	icon_state = "glowingvoucher"
 	freebies = list(
 		/obj/item/weapon/glowstick,


### PR DESCRIPTION
### What this does
Renames the Vendomat vending machine, the one with the stock parts and assemblies, to StockPro. 
### Why it's good
Closes #32750. Less confusion.
:cl:
 * spellcheck: Renamed the Vendomat vending machine (the one with stock parts and assemblies) to StockPro.