### PR TITLE
Conveyor belt metal cost tweaks

### DIFF
--- a/code/modules/recycling/conveyor_assembly.dm
+++ b/code/modules/recycling/conveyor_assembly.dm
@@ -78,6 +78,7 @@
 		var/obj/item/tool/weldingtool/WT = W
 		if(WT.remove_fuel(0,user))
 			var/obj/item/stack/sheet/metal/M = new /obj/item/stack/sheet/metal
+			M.amount = 2
 			user.visible_message("<span class='warning'>[src] is shaped into metal by [user.name] with the welding tool.</span>", \
 			"<span class='warning'>You shape the [src] into metal with the welding tool.</span>", \
 			"<span class='warning'>You hear welding.</span>")
@@ -114,10 +115,10 @@
 			return
 	else if(istype(P, /obj/item/stack/sheet/metal))
 		var/obj/item/stack/S = P
-		if(S.amount > 4)
+		if(S.amount > 2)
 			playsound(src, 'sound/items/Ratchet.ogg', 75, 1)
-			if(do_after(user, src, 30) && S.amount > 4)
-				S.use(4)
+			if(do_after(user, src, 30) && S.amount > 2)
+				S.use(2)
 				to_chat(user, "<span class='notice'>You add the plates to \the [src].</span>")
 				new /obj/machinery/conveyor(src.loc, src.dir)
 				qdel(src)


### PR DESCRIPTION
[tweak][bugfix]

## What this does
makes a full conveyor belt cost 2 less metal to complete, down to 4 from 6 (2 in first stage and 2 in last down from 4)

## Why it's good
6 is a bit much

## Changelog
:cl:
 * bugfix: Conveyor belt assembly pieces now return the 2 sheets of metal needed to build one instead of just 1.
 * tweak: Conveyor belts now only cost 4 total metal to make.