### PR TITLE
Paroles the homeless

### DIFF
--- a/maps/misc/hoboshack.dmm
+++ b/maps/misc/hoboshack.dmm
@@ -433,10 +433,12 @@
 	on = 1
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2
+	dir = 2;
+	req_access = null
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 1
+	dir = 1;
+	req_access = null
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"

--- a/maps/misc/hoboshack.dmm
+++ b/maps/misc/hoboshack.dmm
@@ -432,13 +432,11 @@
 	dir = 1;
 	on = 1
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	req_access = null
+/obj/machinery/door/window{
+	dir = 1
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	req_access = null
+/obj/machinery/door/window{
+	dir = 2
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"


### PR DESCRIPTION
~Removed "access_security" (1) from the recently added brigdoor hobo airlocks.~

Reverts the changed hoboshack airlocks from brigdoors to regular windoors.
 
Closes #33349
:cl:
 * bugfix: Hobos no longer locked in their cabin.

