### PR TITLE
Makes syndicate wheelchair and mulebot knockdown less annoying

### DIFF
--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -75,7 +75,7 @@ var/global/mulebot_count = 0
 
 	var/bloodiness = 0		// count of bloodiness
 	var/currentBloodColor = DEFAULT_BLOOD
-	var/run_over_cooldown = 3 SECONDS	//how often a pAI-controlled MULEbot can damage a mob by running over them
+	var/run_over_cooldown = 4 SECONDS	//how often a pAI-controlled MULEbot can damage a mob by running over them
 	var/coolingdown = FALSE
 
 	commanding_radio = /obj/item/radio/integrated/signal/bot/mule
@@ -709,8 +709,8 @@ var/global/mulebot_count = 0
 					M.Stun(1)
 					M.Knockdown(1)
 				else
-					M.Stun(8)
-					M.Knockdown(5)
+					M.Stun(2)
+					M.Knockdown(2)
 				M.lying = 1
 	..()
 

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -699,7 +699,7 @@ var/global/mulebot_count = 0
 /obj/machinery/bot/mulebot/to_bump(var/atom/obs)
 	if(!wires.MobAvoid())		//usually just bumps, but if avoidance disabled knock over mobs
 		var/mob/M = obs
-		if(ismob(M))
+		if(ismob(M) && !istype(M.locked_to,/obj/structure/bed))
 			if(istype(M,/mob/living/silicon/robot))
 				src.visible_message("<span class='warning'>[src] bumps into [M]!</span>")
 			else

--- a/code/game/objects/structures/vehicles/wheelchair.dm
+++ b/code/game/objects/structures/vehicles/wheelchair.dm
@@ -269,18 +269,19 @@
 /obj/structure/bed/chair/vehicle/wheelchair/motorized/syndicate/to_bump(var/atom/A)
 	if(isliving(A) && !attack_cooldown)
 		var/mob/living/L = A
-		if(isrobot(L))
-			src.visible_message("<span class='warning'>[src] slams into [L]!</span>")
-			L.Stun(2)
-			L.Knockdown(2)
-			L.adjustBruteLoss(rand(4,6))
-		else
-			src.visible_message("<span class='warning'>[src] knocks over [L]!</span>")
-			L.stop_pulling()
-			L.Stun(8)
-			L.Knockdown(5)
-			L.lying = 1
-			L.update_icons()
+		if(!istype(L.locked_to,/obj/structure/bed))
+			if(isrobot(L))
+				src.visible_message("<span class='warning'>[src] slams into [L]!</span>")
+				L.Stun(2)
+				L.Knockdown(2)
+				L.adjustBruteLoss(rand(4,6))
+			else
+				src.visible_message("<span class='warning'>[src] knocks over [L]!</span>")
+				L.stop_pulling()
+				L.Stun(2)
+				L.Knockdown(2)
+				L.lying = 1
+				L.update_icons()
 	..()
 
 /obj/structure/bed/chair/vehicle/wheelchair/motorized/syndicate/proc/crush(var/mob/living/H,var/bloodcolor) //Basically identical to the MULE, see mulebot.dm
@@ -291,7 +292,7 @@
 	H.apply_damage(damage, BRUTE, LIMB_LEFT_LEG)
 	H.apply_damage(damage, BRUTE, LIMB_RIGHT_LEG)
 	attack_cooldown = 1
-	spawn(10)
+	spawn(40)
 		attack_cooldown = 0
 
 /obj/item/syndicate_wheelchair_kit


### PR DESCRIPTION
[tweak][bugfix]

## What this does
increases mulebot knockdown cooldown to 4 seconds from 3, reduces stun/knockdown time to 4 seconds from 16(!)
inceases syndie wheelchair's one to 4 seconds from 1, reduces stun/knockdown to 4 seconds from 16
stops both knocking over people buckled to things

## Why it's good
common complain about how broken the wheelchair is
mulebots get it too since laser pointers got introduced making non-PAI ones do it much easier

## Changelog
:cl:
 * tweak: Syndicate wheelchairs and mulebots now have a 4 times as long knockdown cooldown, and reduced stun/knockdown time.
 * bugfix: Syndicate wheelchairs and mulebots no longer knock over buckled people.
