### PR TITLE
Adds more info to grue Drain Light ability description.  

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/grue_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue_powers.dm
@@ -83,7 +83,7 @@
 
 /spell/aoe_turf/grue_drainlight
 	name = "Drain Light"
-	desc = "Drain the light from the surrounding area. Darkness will not heal you while you do this."
+	desc = "Drain the light from the surrounding area. Darkness will not heal you while you do this, though you can stop at will."
 	hud_state = "grue_drainlight"
 	user_type = USER_TYPE_GRUE
 	panel = "Grue"

--- a/code/modules/mob/living/simple_animal/hostile/grue_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue_powers.dm
@@ -83,7 +83,7 @@
 
 /spell/aoe_turf/grue_drainlight
 	name = "Drain Light"
-	desc = "Drain the light from the surrounding area."
+	desc = "Drain the light from the surrounding area. Darkness will not heal you while you do this."
 	hud_state = "grue_drainlight"
 	user_type = USER_TYPE_GRUE
 	panel = "Grue"


### PR DESCRIPTION
The grue Drain Light ability stops healing-in-darkness while it is active, however this isn't mentioned anywhere in-game. This adds a message to the ability description explaining this.

Also I'm not sure how clear it is that the ability is toggle-able. If this should be added to the description please let me know. It might be the case that people assume it only shuts off once you run out of nutritive energy, similar to a borer, but you can actually turn it on and off, with a slight cooldown. 

:cl:
 * rscadd: Added more info to grue Drain Light ability description.
