### PR TITLE
Haunting people as a ghost now displays a list that prioritizes players first

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -254,7 +254,7 @@
 
 //Orders mobs by type then by name
 /proc/sortmobs()
-	var/list/moblist = list()
+	var/list/sorted_output = list()
 	var/list/sortedplayers = list()
 	var/list/sortedmobs = list()
 	for(var/mob/M in mob_list) //divide every mob into either players (has a mind) or non-players (no mind). braindead/catatonic/etc. mobs included in players
@@ -265,35 +265,35 @@
 	sortNames(sortedplayers) //sort both lists in preparation for what we'll do below
 	sortNames(sortedmobs)
 	for(var/mob/living/silicon/ai/M in sortedplayers)
-		moblist.Add(M)
+		sorted_output.Add(M)
 	for(var/mob/camera/M in sortedplayers)
-		moblist.Add(M)
+		sorted_output.Add(M)
 	for(var/mob/living/silicon/pai/M in sortedplayers)
-		moblist.Add(M)
+		sorted_output.Add(M)
 	for(var/mob/living/silicon/robot/M in sortedplayers)
-		moblist.Add(M)
+		sorted_output.Add(M)
 	for(var/mob/living/carbon/human/M in sortedplayers)
-		moblist.Add(M)
+		sorted_output.Add(M)
 	for(var/mob/living/carbon/brain/M in sortedplayers)
-		moblist.Add(M)
+		sorted_output.Add(M)
 	for(var/mob/living/carbon/alien/M in sortedplayers)
-		moblist.Add(M)
+		sorted_output.Add(M)
 	for(var/mob/dead/observer/M in sortedplayers)
-		moblist.Add(M)
+		sorted_output.Add(M)
 	for(var/mob/new_player/M in sortedplayers)
-		moblist.Add(M)
+		sorted_output.Add(M)
 	for(var/mob/living/carbon/monkey/M in sortedplayers)
-		moblist.Add(M)
+		sorted_output.Add(M)
 	for(var/mob/living/carbon/slime/M in sortedplayers)
-		moblist.Add(M)
+		sorted_output.Add(M)
 	for(var/mob/living/simple_animal/M in sortedplayers)
-		moblist.Add(M)
+		sorted_output.Add(M)
 	for(var/mob/living/M in sortedmobs) //mobs that have never been controlled by a player go last in the list. /mob/living to filter unwanted non-player non-world mobs (i.e. you'll nullspace if you observe them)
 		if(M.client)
 			continue
-		moblist.Add(M)
+		sorted_output.Add(M)
 		
-	return moblist
+	return sorted_output
 
 // Finds ALL mobs on turfs in line of sight. Similar to "in dview", but catches mobs that are not on a turf (e.g. inside a locker or such).
 /proc/get_all_mobs_in_dview(var/turf/T, var/range = world.view, var/list/ignore_types = list())

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -255,35 +255,44 @@
 //Orders mobs by type then by name
 /proc/sortmobs()
 	var/list/moblist = list()
-	var/list/sortmob = sortNames(mob_list)
-	for(var/mob/living/silicon/ai/M in sortmob)
+	var/list/sortedplayers = list()
+	var/list/sortedmobs = list()
+	for(var/mob/M in mob_list) //divide every mob into either players (has a mind) or non-players (no mind). braindead/catatonic/etc. mobs included in players
+		if(!M.mind)
+			sortedmobs |= M
+			continue
+		sortedplayers |= M
+	sortNames(sortedplayers) //sort both lists in preparation for what we'll do below
+	sortNames(sortedmobs)
+	for(var/mob/living/silicon/ai/M in sortedplayers)
 		moblist.Add(M)
-	for(var/mob/camera/M in sortmob)
+	for(var/mob/camera/M in sortedplayers)
 		moblist.Add(M)
-	for(var/mob/living/silicon/pai/M in sortmob)
+	for(var/mob/living/silicon/pai/M in sortedplayers)
 		moblist.Add(M)
-	for(var/mob/living/silicon/robot/M in sortmob)
+	for(var/mob/living/silicon/robot/M in sortedplayers)
 		moblist.Add(M)
-	for(var/mob/living/carbon/human/M in sortmob)
+	for(var/mob/living/carbon/human/M in sortedplayers)
 		moblist.Add(M)
-	for(var/mob/living/carbon/brain/M in sortmob)
+	for(var/mob/living/carbon/brain/M in sortedplayers)
 		moblist.Add(M)
-	for(var/mob/living/carbon/alien/M in sortmob)
+	for(var/mob/living/carbon/alien/M in sortedplayers)
 		moblist.Add(M)
-	for(var/mob/dead/observer/M in sortmob)
+	for(var/mob/dead/observer/M in sortedplayers)
 		moblist.Add(M)
-	for(var/mob/new_player/M in sortmob)
+	for(var/mob/new_player/M in sortedplayers)
 		moblist.Add(M)
-	for(var/mob/living/carbon/monkey/M in sortmob)
+	for(var/mob/living/carbon/monkey/M in sortedplayers)
 		moblist.Add(M)
-	for(var/mob/living/carbon/slime/M in sortmob)
+	for(var/mob/living/carbon/slime/M in sortedplayers)
 		moblist.Add(M)
-	for(var/mob/living/simple_animal/M in sortmob)
+	for(var/mob/living/simple_animal/M in sortedplayers)
 		moblist.Add(M)
-//	for(var/mob/living/silicon/hivebot/M in world)
-//		mob_list.Add(M)
-//	for(var/mob/living/silicon/hive_mainframe/M in world)
-//		mob_list.Add(M)
+	for(var/mob/living/M in sortedmobs) //mobs that have never been controlled by a player go last in the list. /mob/living to filter unwanted non-player non-world mobs (i.e. you'll nullspace if you observe them)
+		if(M.client)
+			continue
+		moblist.Add(M)
+		
 	return moblist
 
 // Finds ALL mobs on turfs in line of sight. Similar to "in dview", but catches mobs that are not on a turf (e.g. inside a locker or such).


### PR DESCRIPTION
## What it does/Why it's good
Haunting people tends to be annoying because a list of AI mobs/corpses/etc. from ruins populates the list of human mobs.
This PR makes the `sortmob()` proc create two lists: players (anything that has a mind, including braindead/catatonic/dead players), and non-players, such as mobs from space ruins that are almost never relevant to what you want to see.

The list of players is prioritized and put at the top, so you no longer have to sort through the garbage.
The big global list of mobs is still only sorted through a single time, so this isn't any more or less performant.

Closes #18260
[qol]
## Changelog
:cl:
 * rscadd: Observers' Haunt verb now prioritizes actual players when presenting a list of people to spectate.