### PR TITLE
Hobo shack, no windoors edition.

### DIFF
--- a/maps/misc/hoboshack.dmm
+++ b/maps/misc/hoboshack.dmm
@@ -339,24 +339,23 @@
 	},
 /area/shack)
 "Od" = (
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/grille/broken,
+/obj/structure/window/reinforced,
+/obj/machinery/door/mineral/wood{
+	name = "Wooden Door";
+	opacity = 0
+	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
 /area/shack)
 "QD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
@@ -425,18 +424,21 @@
 /obj/machinery/door/mineral/wood{
 	name = "Wooden Door"
 	},
+/obj/machinery/door/mineral/wood{
+	name = "Wooden Door"
+	},
 /turf/simulated/floor/wood,
 /area/shack)
 "Yn" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1;
-	on = 1
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/door/window{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/door/window{
-	dir = 2
+/obj/machinery/door/mineral/wood{
+	name = "Wooden Door";
+	opacity = 0
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -521,7 +523,7 @@ Zu
 uX
 Hg
 Cp
-lF
+Yn
 ZK
 "}
 (6,1,1) = {"
@@ -532,8 +534,8 @@ lF
 wK
 pC
 Rz
-lQ
-Yn
+mM
+lF
 ZK
 "}
 (7,1,1) = {"

--- a/maps/misc/hoboshack.dmm
+++ b/maps/misc/hoboshack.dmm
@@ -218,6 +218,9 @@
 	icon_state = "asteroidplating"
 	},
 /area/shack)
+"xn" = (
+/turf/space,
+/area/shack)
 "zr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5;
@@ -343,8 +346,8 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/door/mineral/wood{
-	name = "Wooden Door";
+/obj/machinery/door/mineral/wood/log/towercap{
+	name = "towercap log door";
 	opacity = 0
 	},
 /turf/simulated/floor/plating{
@@ -436,8 +439,8 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/door/mineral/wood{
-	name = "Wooden Door";
+/obj/machinery/door/mineral/wood/log/towercap{
+	name = "towercap log door";
 	opacity = 0
 	},
 /turf/simulated/floor/plating{
@@ -582,7 +585,7 @@ lF
 lF
 lF
 lF
-lF
+xn
 ZK
 ZK
 "}

--- a/maps/misc/hoboshack.dmm
+++ b/maps/misc/hoboshack.dmm
@@ -218,9 +218,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/shack)
-"xn" = (
-/turf/space,
-/area/shack)
 "zr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5;
@@ -585,7 +582,7 @@ lF
 lF
 lF
 lF
-xn
+lF
 ZK
 ZK
 "}


### PR DESCRIPTION
Do not merge before #33364.
### What this does
Removes the windoors on the hobo shack, replacing them with a wooden door ghetto airlock.
![image](https://user-images.githubusercontent.com/67024428/192030502-a41d47b4-91e8-42e2-bea7-150ead7c49c3.png)
### Why it's good
Solves the windoor delay issue depressurizing the hobo shack and gives the place a more ghetto feel.
:cl:
 * rscadd: Replaced the windoors on the hobo shack with a ghetto airlock made with towercap log doors.