### PR TITLE
Dan Sauce condiment bottle for 25 credits and a coin.

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3043,6 +3043,9 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/reagent_containers/food/snacks/cheap_raisins = 6,
 		/obj/item/weapon/reagent_containers/food/condiment/small/discount = 12
 		)
+	premium = list(
+		/obj/item/weapon/reagent_containers/food/condiment/discount = 2,
+		)
 	contraband = list(
 		/obj/item/weapon/reagent_containers/pill/antitox = 10
 		)
@@ -3055,7 +3058,8 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/reagent_containers/food/snacks/pie/discount = 6,
 		/obj/item/weapon/reagent_containers/food/snacks/cheap_raisins = 3,
 		/obj/item/weapon/reagent_containers/pill/antitox = 10,
-		/obj/item/weapon/reagent_containers/food/condiment/small/discount = 1
+		/obj/item/weapon/reagent_containers/food/condiment/small/discount = 1,
+		/obj/item/weapon/reagent_containers/food/condiment/discount = 25
 		)
 
 	pack = /obj/structure/vendomatpack/discount


### PR DESCRIPTION
### What this does
You can now buy Dan Sauce condiment bottles on Discount Dan vendors for the low low price of a coin and 25 credits.
### Why it's good
Gives easier access to large quanities of dan sauce for ghetto or gunk cooking.
:cl:
 * rscadd: You can buy dan sauce bottles for 25 credits and a coin in your nearest Discount Dan's vending machine.