### PR TITLE
Towercap Log doors.

### DIFF
--- a/code/game/machinery/doors/mineral.dm
+++ b/code/game/machinery/doors/mineral.dm
@@ -243,14 +243,12 @@
 /obj/machinery/door/mineral/wood/log/Dismantle(devastated = 0)
 	if(!devastated)
 		new /obj/item/weapon/grown/log/tree(src)
-		new /obj/item/weapon/grown/log/tree(src)
 	qdel(src)
 
 /obj/machinery/door/mineral/wood/log/towercap
 
 /obj/machinery/door/mineral/wood/log/towercap/Dismantle(devastated = 0)
 	if(!devastated)
-		new /obj/item/weapon/grown/log(src)
 		new /obj/item/weapon/grown/log(src)
 	qdel(src)
 

--- a/code/game/machinery/doors/mineral.dm
+++ b/code/game/machinery/doors/mineral.dm
@@ -240,10 +240,18 @@
 		close()
 		visible_message("\The [src] slams shut!", "You hear a slamming of wood.")
 
-/obj/machinery/door/mineral/wood/log/Dismantle(devestated = 0)
-	if(!devestated)
+/obj/machinery/door/mineral/wood/log/Dismantle(devastated = 0)
+	if(!devastated)
 		new /obj/item/weapon/grown/log/tree(src)
 		new /obj/item/weapon/grown/log/tree(src)
+	qdel(src)
+
+/obj/machinery/door/mineral/wood/log/towercap
+
+/obj/machinery/door/mineral/wood/log/towercap/Dismantle(devastated = 0)
+	if(!devastated)
+		new /obj/item/weapon/grown/log(src)
+		new /obj/item/weapon/grown/log(src)
 	qdel(src)
 
 /obj/machinery/door/mineral/resin

--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -73,6 +73,14 @@
 
 		qdel(src)
 		return
+	if(istype(W,/obj/item/weapon/grown/log) && isturf(loc))
+		to_chat(user,"<span class='notice'>You begin building a storm door out of the heavy tree logs.</span>")
+		if(do_after(user,src,4 SECONDS))
+			to_chat(user,"<span class='notice'>You finish the door.</span>")
+			new /obj/machinery/door/mineral/wood/log/towercap(loc)
+			qdel(src)
+	else
+		..()
 
 /obj/item/weapon/grown/log/tree
 	name = "log"

--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -74,7 +74,7 @@
 		qdel(src)
 		return
 	if(istype(W,/obj/item/weapon/grown/log) && isturf(loc))
-		to_chat(user,"<span class='notice'>You begin building a storm door out of the heavy tree logs.</span>")
+		to_chat(user,"<span class='notice'>You begin building a storm door out of the tower-cap logs.</span>")
 		if(do_after(user,src,4 SECONDS))
 			to_chat(user,"<span class='notice'>You finish the door.</span>")
 			new /obj/machinery/door/mineral/wood/log/towercap(loc)


### PR DESCRIPTION
A companion PR to #33357. Merge before #33357.
You can now make log doors (#28432) with tower cap logs as well.
These doors:
![image](https://user-images.githubusercontent.com/67024428/192061146-c2d0e036-c648-43ea-9798-df4cc8b0ab45.png)
[tested]
:cl:
 * rscadd: Log doors can also be made using towercap logs.
 * bugfix: Log doors no longer give 2x the logs you used to make it when disassembled.