### PR TITLE
Fixes powercreeper layering

### DIFF
--- a/code/game/gamemodes/events/powercreeper.dm
+++ b/code/game/gamemodes/events/powercreeper.dm
@@ -13,8 +13,9 @@
 	desc = "A strange alien fruit that passively generates electricity. Best not to touch it."
 	icon = 'icons/obj/structures/powercreeper.dmi'
 	icon_state = "neutral"
+	plane = OBJ_PLANE
+	layer = OBJ_LAYER
 	level = LEVEL_ABOVE_FLOOR
-	plane = ABOVE_TURF_PLANE
 	pass_flags = PASSTABLE | PASSGRILLE | PASSGIRDER | PASSMACHINE
 	slowdown_modifier = 2
 	autoignition_temperature = AUTOIGNITION_PAPER


### PR DESCRIPTION
Powercreepers had weird layering because, unlike kudzu, they're actually considered cables.
Fixes #33359
[bugfix]
:cl:
 * bugfix: The powercreep packet's initial animation now displays properly.
 * bugfix: Powercreepers will now correctly layer above piping devices such as vents/scrubbers, as well as structures such as tables.