### PR TITLE
Fix photos again

### DIFF
--- a/code/libs/Get Flat Icon/Get Flat Icon Deluxe.dm
+++ b/code/libs/Get Flat Icon/Get Flat Icon Deluxe.dm
@@ -81,8 +81,8 @@ cons:
 			var/dir = data[GFI_DX_DIR]
 			if (dir != SOUTH) // south-facing atoms shouldn't pose any problem
 				var/icon_directions = get_icon_dir_count(data[GFI_DX_ICON],data[3])
-				if ((icon_directions == 0) || (icon_directions == 1))
-					data[GFI_DX_DIR] = SOUTH // if the icon has only one direction we HAVE to face south. if we're not sure (something animated?), have it face south anyway.
+				if (icon_directions == 1)
+					data[GFI_DX_DIR] = SOUTH // if the icon has only one direction we HAVE to face south
 				else if (icon_directions == 4)
 					if (dir != NORTH && dir != EAST && dir != WEST)
 						data[GFI_DX_DIR] = SOUTH

--- a/code/modules/mob/living/simple_animal/bees/bees_mob.dm
+++ b/code/modules/mob/living/simple_animal/bees/bees_mob.dm
@@ -61,6 +61,13 @@ var/bee_mobs_count = 0
 
 	blooded = FALSE // certainly not enough blood there to matter
 
+	var/single_direction = TRUE
+
+/mob/living/simple_animal/bee/Move()
+	..()
+	if (single_direction)
+		dir = SOUTH
+
 ///////////////////////////////Basic Procs//////////////////////////////////
 
 /mob/living/simple_animal/bee/New(loc, var/obj/machinery/apiary/new_home)


### PR DESCRIPTION
Reverts the changes from #33309 and forces bees to face South after moving.

Fixes #33363

:cl:
* bugfix: Fixed newly arisen photography issues with objects not facing the right way.