### PR TITLE
Reverts limb targeting requirements for pepperspray

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -4925,7 +4925,7 @@ var/procizine_tolerance = 0
 	if(..())
 		return 1
 
-	if(method == TOUCH && ishuman(M)
+	if(method == TOUCH && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/mouth_covered = H.get_body_part_coverage(MOUTH)
 		var/obj/item/eyes_covered = H.get_body_part_coverage(EYES)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -4925,7 +4925,7 @@ var/procizine_tolerance = 0
 	if(..())
 		return 1
 
-	if(method == TOUCH && ishuman(M) && ((TARGET_MOUTH in zone_sels) || (LIMB_HEAD in zone_sels)))
+	if(method == TOUCH && ishuman(M)
 		var/mob/living/carbon/human/H = M
 		var/obj/item/mouth_covered = H.get_body_part_coverage(MOUTH)
 		var/obj/item/eyes_covered = H.get_body_part_coverage(EYES)


### PR DESCRIPTION
## What this does
Pepper spray has been semi-broken for a while because targeting eyes no longer works. Currently, you have to target the head or mouth because Kanef's reagent targeting PR forgot to add the eyes as a valid thing to target. (#32424)

I was going to fix the bug, but then I decided that the way it was before (no limb targeting required) was far better, and that Kanef's change was completely unnecessary.

## Why it's good
I don't think anyone likes having to target a limb before pepper spraying some assistant.
If people feel as if the limb requirement should remain a feature, I'll change this PR to just fix the bug instead.

[balance]
## Changelog
:cl:
 * tweak: Pepper spray no longer requires a bodypart to be targeted to work.