### PR TITLE
Fixes for Haunt verb

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -258,10 +258,12 @@
 	var/list/sortedplayers = list()
 	var/list/sortedmobs = list()
 	for(var/mob/M in mob_list) //divide every mob into either players (has a mind) or non-players (no mind). braindead/catatonic/etc. mobs included in players
-		if(!M.mind)
-			sortedmobs |= M
+		if(isnull(M))
 			continue
-		sortedplayers |= M
+		if(M.mind || istype(M, /mob/camera))
+			sortedplayers |= M
+			continue
+		sortedmobs |= M
 	sortNames(sortedplayers) //sort both lists in preparation for what we'll do below
 	sortNames(sortedmobs)
 	for(var/mob/living/silicon/ai/M in sortedplayers)


### PR DESCRIPTION
## What this does
-Slightly changes logic of `sortmob()` proc so AI eyes are included (they don't have minds or clients so they weren't)
-Maybe fixes null entries appearing in the list?

The issue with null entries showing up is that sometimes there's nulls in the `mob_list` and I don't know how/why they're there.
To mitigate this, I added an `isnull()` check, but I'm not sure if that'll even do anything. Input here would be highly appreciated.
It's not even a big deal because they just end up pointing to a cyborg when you Haunt them, but nevertheless it's bad.

Closes #33377
[hotfix]
## Changelog
:cl:
 * bugfix: AI eyes should now show up in the observer's Haunt list.