### PR TITLE
removes admin pm overmind verb

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -33,7 +33,6 @@ var/list/admin_verbs_admin = list(
 	/datum/admins/proc/view_txt_log,	/*shows the server log (diary) for today*/
 	/datum/admins/proc/view_atk_log,	/*shows the server combat-log, doesn't do anything presently*/
 	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
-	/client/proc/cmd_admin_pm_context_special, /*Currently only for blobs*/
 	/client/proc/cmd_admin_pm_panel,	/*admin-pm list*/
 	/client/proc/cmd_admin_subtle_message,	/*send an message to somebody as a 'voice in their head'*/
 	/client/proc/cmd_admin_delete,		/*delete an instance/object/mob/etc*/
@@ -294,7 +293,6 @@ var/list/admin_verbs_hideable = list(
 	)
 var/list/admin_verbs_mod = list(
 	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
-	/client/proc/cmd_admin_pm_context_special,
 	/client/proc/cmd_admin_pm_panel,	/*admin-pm list*/
 	/client/proc/debug_variables,		/*allows us to -see- the variables of any instance in the game.*/
 	/datum/admins/proc/PlayerNotes,

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -10,18 +10,6 @@
 	cmd_admin_pm(M.client,null)
 	feedback_add_details("admin_verb","APMM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-//For blobs
-/client/proc/cmd_admin_pm_context_special(var/obj/effect/blob/core/C in blob_cores)
-	set category = null
-	set name = "Admin PM Overmind"
-	if(!holder)
-		to_chat(src, "<span class='red'>Error: Admin-PM-Context: Only administrators may use this command.</span>")
-		return
-	if(!istype(C) || !C.overmind || !C.overmind.client)
-		return
-	cmd_admin_pm(C.overmind.client,null)
-	feedback_add_details("admin_verb","APMCS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
 //shows a list of clients we could send PMs to, then forwards our choice to cmd_admin_pm
 /client/proc/cmd_admin_pm_panel()
 	set category = "Admin"


### PR DESCRIPTION
I asked Kurf about how we could make this not show up on every object in the world, and he said to just remove it.
As Shifty puts it in [#22718](https://github.com/vgstation-coders/vgstation13/issues/22718#issuecomment-488282514), there's only two options and neither are very good.
## What this does
Removes the "Admin PM Overmind" verb which shows up on every single `obj/...`

## Why it's good
It's annoying and has a razor-slim use case. You're better off just viewing the `overmind` variable on a blob core.

Closes #22718
[administration]