### PR TITLE
Autoignition tweaks

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1123,7 +1123,7 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define AUTOIGNITION_WOOD  573.15
 #define AUTOIGNITION_PAPER 519.15
 #define AUTOIGNITION_PLASTIC 689.15 //autoignition temperature of ABS plastic
-#define AUTOIGNITION_METAL 1033.15 //autoignition temperature of steel
+#define AUTOIGNITION_METAL null //1033.15 is the autoignition temperature of steel under high pressure pure oxgen
 #define AUTOIGNITION_FABRIC 523.15
 #define AUTOIGNITION_PROTECTIVE 573.15 //autoignition temperature of protective clothing like firesuits or kevlar vests
 #define AUTOIGNITION_ORGANIC 633.15 //autoignition temperature of animal fats

--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -41,7 +41,11 @@ Attach to transfer valve and open. BOOM.
 			in_fire = TRUE
 			break
 		if(!in_fire)
-			var/used_ratio = min(0.2 / getFireFuel(), 1) //To maintain the previous behavior of just using 0.2 fire_fuel
+			var/used_ratio = 0
+			if(!getFireFuel())
+				used_ratio = 0.2 //uses 0.2 fire_fuel if it isn't defined for an object
+			else
+				used_ratio = min(0.2 / getFireFuel(), 1) //To maintain the previous behavior of just using 0.2 fire_fuel
 			burnFireFuel(1, used_ratio) //1 is valid as used_fuel_ratio and the two arguments should multiply to used_ratio, so this is simplest.
 		sleep(2 SECONDS)
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Removes the metal ignition temperature limit. Additionally, removes a runtime for any objects caught on fire that don't have a fuel value assigned to them.

## Why it's good
<!-- Explain why you think these changes are good. -->
Steel (used as the reference here) only ignites at this temperature under high-pressure pure oxygen, not under the normal environments seen in fires. This will leave the autoignition constant tied to all metal items to allow for future rework, but will set the value to null to prevent anything metal from catching on fire.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Removed metal autoignition.
 * bugfix: Removes a fire runtime.