### PR TITLE
Fixes several botany chemical reactions

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -47,20 +47,22 @@ var/const/INGEST = 2
 			var/list/reaction_ids = list()
 
 			if(D.required_reagents && D.required_reagents.len)
-				for(var/reaction in D.required_reagents)
-					if(islist(reaction))
-						var/list/L = reaction
-						for(var/content in L)
-							reaction_ids += content
-					else
-						reaction_ids += reaction
+				var/reaction = D.required_reagents[1]
+				if(islist(reaction))
+					var/list/L = reaction
+					for(var/content in L)
+						reaction_ids += content
+				else
+					reaction_ids += reaction
 
 			// Create filters based on each reagent id in the required reagents list
 			for(var/id in reaction_ids)
 				if(!chemical_reactions_list[id])
 					chemical_reactions_list[id] = list()
 				chemical_reactions_list[id] += D
-				break // Don't bother adding ourselves to other reagent ids, it is redundant.
+				//previously we broke here, which meant that we were only testing the first reagent - even if the first reagent was a list
+				//now we no longer break because we didn't add all the reagents to reaction_ids - we want to add the reaction to everything in
+				//reaction_ids, which will be over everything in the first reagent in the table
 
 
 /datum/reagents/proc/remove_any(var/amount=1)

--- a/code/modules/unit_tests/reagent_recipe_collisions.dm
+++ b/code/modules/unit_tests/reagent_recipe_collisions.dm
@@ -29,6 +29,11 @@
 			// the warm reaction doesn't require any particular temperature or the range of temperatures does not overlap, so there is no conflict
 			return FALSE
 
+	//test if the recipes are aliases - important if one of the reagents is a list
+	if(r1.result == r2.result)
+		if(r1.required_reagents == r2.required_reagents)
+			return FALSE
+
 	//find the reactions with the shorter and longer required_reagents list
 	var/datum/chemical_reaction/long_req
 	var/datum/chemical_reaction/short_req


### PR DESCRIPTION
[bugfix] [tested]

## What this does
This PR fixes bugs related to botany chemicals. Botany chemicals are defined as part of a list of components that fulfill the same "role," i.e. ```#define CRYPTOBIOLINS list(CRYPTOBIOLIN, PHYSOSTIGMINE)```. The reaction code iterates through all the reaction datums and initializes them into a filtered list based on the first element of the list of reaction components. This allows us to make some shortcuts in handling reactions - we get all the components of the reaction_holder, look in the filtered list for which reactions originate from each of the elements of the holder, and test each of the recipes in those lists. It saves a lot of processing time compared to testing every single reaction.

The issue is in the generation of the filtered list. The filtered list is generated with only the very first element of the chemical reaction, but that means if the first reagent is a list, like CRYPTOBIOLINS above, it will only generate the filtered list recognizing the first element of that list. This leads to many bugs. Reactions with botany ingredients work, but only if the botany ingredient is not part of the first element of the reaction list. This is why reactions with botany ingredients like hyronalin work (ANTI-TOXINS is not in the first slot), but insecticide and plant-b-gone don't (TOXINS is listed first).

With this PR, instead the filtered reaction list is initialized with all the components of the first element of the reaction list. This fixes many issues with pharmacognosy, including the reactions for plant-b-gone, insecticide, spaceacilin, suxameth, polyacid, and more.

As a note, this does amplify the effect of another existing bug where two colliding chemical reactions will use reagents for both but only produce output for one. That issue is not addressed here.

Closes #32624
Closes #27530
Closes #21353

## Why it's good
Fixes many persistent issues with reactions involving botany chemicals.

## Changelog
:cl:
 * bugfix: Fixes issues with initializing reactions where defined lists are the first reacting component.
