### PR TITLE
sanity check for briefcase full of bees

### DIFF
--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -238,9 +238,11 @@
 	var/released = FALSE
 
 /obj/item/weapon/storage/briefcase/bees/show_to(mob/user as mob)
+	..()
+	if(!isliving(user) || user.stat)
+		return
 	if(!released)
 		release(user)
-	..()
 
 //You can hit someone with the briefcase, and the bees will swarm at them
 /obj/item/weapon/storage/briefcase/bees/afterattack(var/atom/target, var/mob/user, var/proximity_flag, var/click_parameters)


### PR DESCRIPTION
Dead people and observers were able to trigger the briefcase full of bees. (lol)
Fixes #33396
[bugfix]

## Changelog
:cl:
 * bugfix: Dead people and observers can no longer trigger the briefcase full of bees.