### PR TITLE
Restricts RC/captain/centcomm announcements to broadcasting on levels with a telecomms relay

### DIFF
--- a/code/defines/procs/captain_announce.dm
+++ b/code/defines/procs/captain_announce.dm
@@ -2,7 +2,7 @@
 	var/list/send_to_zs = list(map.zCentcomm)
 
 	for(var/obj/machinery/telecomms/relay/R in telecomms_list)
-		if(R.on && !(R.z in send_to_zs)
+		if(R.on && !(R.z in send_to_zs))
 			send_to_zs.Add(R.z)
 
 	for(var/mob/M in player_list)

--- a/code/defines/procs/captain_announce.dm
+++ b/code/defines/procs/captain_announce.dm
@@ -1,7 +1,11 @@
 /proc/captain_announce(var/text)
-	to_chat(world, "<h1 class='alert'>Priority Announcement</h1>")
-	to_chat(world, "<span class='alert'>[html_encode(text)]</span>")
-	to_chat(world, "<br>")
+	var/list/send_to_zs = list(map.zCentcomm)
+
+	for(var/obj/machinery/telecomms/relay/R in telecomms_list)
+		if(R.on && !(R.z in send_to_zs)
+			send_to_zs.Add(R.z)
+
 	for(var/mob/M in player_list)
-		if(!istype(M,/mob/new_player) && M.client)
+		if(!istype(M,/mob/new_player) && M.client && (M.z in send_to_zs))
 			M << sound('sound/vox/_doop.wav')
+			to_chat(M, "<h1 class='alert'>Priority Announcement</h1><span class='alert'>[html_encode(text)]</span><br>")

--- a/code/defines/procs/command_alert.dm
+++ b/code/defines/procs/command_alert.dm
@@ -29,7 +29,7 @@
 	var/list/send_to_zs = list(map.zCentcomm)
 
 	for(var/obj/machinery/telecomms/relay/R in telecomms_list)
-		if(R.on && !(R.z in send_to_zs)
+		if(R.on && !(R.z in send_to_zs))
 			send_to_zs.Add(R.z)
 
 	for(var/mob/M in player_list)

--- a/code/defines/procs/command_alert.dm
+++ b/code/defines/procs/command_alert.dm
@@ -25,8 +25,15 @@
 		command += {"<br><span class='alert'>[gibberish_main ? Gibberish(html_encode(text),70) : html_encode(text)]</span><br>
 			<br>"}
 
+
+	var/list/send_to_zs = list(map.zCentcomm)
+
+	for(var/obj/machinery/telecomms/relay/R in telecomms_list)
+		if(R.on && !(R.z in send_to_zs)
+			send_to_zs.Add(R.z)
+
 	for(var/mob/M in player_list)
-		if(!istype(M,/mob/new_player) && M.client)
+		if(!istype(M,/mob/new_player) && M.client && (M.z in send_to_zs))
 			to_chat(M, command)
 			if(!map.linked_to_centcomm)
 				M << sound(pick(static_list), volume = 60)

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -422,7 +422,7 @@ var/list/obj/machinery/requests_console/requests_consoles = list()
 	var/list/send_to_zs = list(map.zCentcomm)
 
 	for(var/obj/machinery/telecomms/relay/R in telecomms_list)
-		if(R.on && !(R.z in send_to_zs)
+		if(R.on && !(R.z in send_to_zs))
 			send_to_zs.Add(R.z)
 
 	for(var/mob/M in player_list)

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -419,8 +419,14 @@ var/list/obj/machinery/requests_console/requests_consoles = list()
 	if(!announcementConsole)
 		return
 
+	var/list/send_to_zs = list(map.zCentcomm)
+
+	for(var/obj/machinery/telecomms/relay/R in telecomms_list)
+		if(R.on && !(R.z in send_to_zs)
+			send_to_zs.Add(R.z)
+
 	for(var/mob/M in player_list)
-		if(!istype(M,/mob/new_player) && M.client)
+		if(!istype(M,/mob/new_player) && M.client && (M.z in send_to_zs))
 			to_chat(M, "<b><font size = 3><font color = red>[department] announcement:</font color> [msg]</font size></b>")
 			M << sound(announceSound)
 	log_say("[key_name(user)] ([formatJumpTo(get_turf(user))]) has made an announcement from \the [src]: [msg]")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -671,6 +671,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			command_alert(input, customname,1);
 		if("Heads Only")
 			headsonly = TRUE
+			world << sound('sound/AI/commandreport.ogg', volume = 60)
 			to_chat(world, "<span class='warning'>New Nanotrasen Update available at all communication consoles.</span>")
 		else
 			return
@@ -684,7 +685,6 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			C.messagetitle.Add("[command_name()] Update")
 			C.messagetext.Add(P.info)
 
-	world << sound('sound/AI/commandreport.ogg', volume = 60)
 	log_admin("[key_name(src)] has created a [headsonly ? "heads only" : "publicly announced"] command report titled [customname]: [input]")
 	message_admins("[key_name_admin(src)] has created a command report", 1)
 	feedback_add_details("admin_verb","CCR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!


### PR DESCRIPTION
[tweak][bugfix]

## What this does
rudimentary way to make these only heard on the station, centcomm and mining levels by default, may make more elaborate so traders and hobos don't hear them without a radio too.

## Why it's good
makes being lost in deep space feel like it much more.

## Changelog
:cl:
 * bugfix: Lobby players can no longer read captain announcements.
 * tweak: Players can now only hear request console announcements, captain announcements, central command alerts and central command announcements if they are on a level of the map that has telecomms connection.