### PR TITLE
Updates the size of object spawn windows

### DIFF
--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -6,4 +6,4 @@
 		create_mob_html = file2text('html/create_object.html')
 		create_mob_html = replacetext(create_mob_html, "null /* object types */", "\"[mobjs]\"")
 
-	user << browse(replacetext(create_mob_html, "/* ref src */", "\ref[src]"), "window=create_mob;size=425x520")
+	user << browse(replacetext(create_mob_html, "/* ref src */", "\ref[src]"), "window=create_mob;size=700x500")

--- a/code/modules/admin/create_object.dm
+++ b/code/modules/admin/create_object.dm
@@ -7,7 +7,7 @@
 		create_object_html = file2text('html/create_object.html')
 		create_object_html = replacetext(create_object_html, "null /* object types */", "\"[objectjs]\"")
 
-	user << browse(replacetext(create_object_html, "/* ref src */", "\ref[src]"), "window=create_object;size=425x475")
+	user << browse(replacetext(create_object_html, "/* ref src */", "\ref[src]"), "window=create_object;size=700x500")
 
 
 /datum/admins/proc/quick_create_object(var/mob/user)
@@ -26,4 +26,4 @@
 		quick_create_object_html = file2text('html/create_object.html')
 		quick_create_object_html = replacetext(quick_create_object_html, "null /* object types */", "\"[objectjs]\"")
 
-	user << browse(replacetext(quick_create_object_html, "/* ref src */", "\ref[src]"), "window=quick_create_object;size=425x475")
+	user << browse(replacetext(quick_create_object_html, "/* ref src */", "\ref[src]"), "window=quick_create_object;size=700x500")

--- a/code/modules/admin/create_turf.dm
+++ b/code/modules/admin/create_turf.dm
@@ -6,4 +6,4 @@
 		create_turf_html = file2text('html/create_object.html')
 		create_turf_html = replacetext(create_turf_html, "null /* object types */", "\"[turfjs]\"")
 
-	user << browse(replacetext(create_turf_html, "/* ref src */", "\ref[src]"), "window=create_turf;size=425x475")
+	user << browse(replacetext(create_turf_html, "/* ref src */", "\ref[src]"), "window=create_turf;size=700x500")


### PR DESCRIPTION
## What this does
Makes the create object, create mob and create turf windows bigger, so admins can see the full path of what they are trying to spawn.

## Why it's good
It is.

![image](https://user-images.githubusercontent.com/102815299/193148952-de2ef43c-61fa-47af-b65f-ba6b3daa5813.png)

## Changelog

🆑

 - rscadd: Gives the admins more visibility over how likely they are to crash the server when pushing funny buttons
