### PR TITLE
Mannitol causes temporary brain damage.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -5710,6 +5710,22 @@ var/procizine_tolerance = 0
 	name = "Mannitol"
 	id = MANNITOL
 	description = "The only medicine a <B>REAL MAN</B> needs."
+	color = "#5C4033" //rgb: 92, 64, 51
+	var/originalbraindamage = 0
+	var/yourarted = FALSE
+	
+/datum/reagent/discount/mannitol/on_mob_life(var/mob/living/M)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(!yourarted && volume >= 1)
+			originalbraindamage = H.getBrainLoss() //saves your current brain damage so you DON'T heal when the effects run out
+			H.setBrainLoss(200) //you go absolutely rarted here
+			to_chat(M, "<span class='notice'>You feel your mind cloud and your dexterity vanish...</span>")
+			yourarted = TRUE
+		if(yourarted && volume < 1)
+			H.setBrainLoss(originalbraindamage) //restores your original brain damage value
+			to_chat(M, "<span class='notice'>You suddenly feel your previous mental capabilities return to you!</span>")
+			yourarted = FALSE
 
 /datum/reagent/irradiatedbeans
 	name = "Irradiated Beans"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -5721,6 +5721,7 @@ var/procizine_tolerance = 0
 		if(!yourarted)
 			originalbraindamage = H.getBrainLoss() //saves your current brain damage so you DON'T heal when the effects run out
 			H.setBrainLoss(200) //you go absolutely rarted here
+			H.eye_blurry = max(M.eye_blurry, 5)
 			to_chat(M, "<span class='notice'>You feel your mind cloud and your dexterity vanish...</span>")
 			yourarted = TRUE
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -5711,6 +5711,7 @@ var/procizine_tolerance = 0
 	id = MANNITOL
 	description = "The only medicine a <B>REAL MAN</B> needs."
 	color = "#5C4033" //rgb: 92, 64, 51
+	custom_metabolism = 0.4 //5u means 13s rarted
 	var/originalbraindamage = 0
 	var/yourarted = FALSE
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -5715,11 +5715,17 @@ var/procizine_tolerance = 0
 	var/originalbraindamage = 0
 	var/yourarted = FALSE
 
+/datum/reagent/discount/mannitol/on_mob_life(var/mob/living/M)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(holder.has_any_reagents(ALKYSINE,ALKYCOSINE,ADMINORDRAZINE,GREYGOO) && H.getBrainLoss() < originalbraindamage) //chems with brain healing effects
+			originalbraindamage = H.getBrainLoss() //if you have brainmeds and heal enough to be under the original braindamage, set the original to the current, so you end up healed once mannitol runs out
+
 /datum/reagent/discount/mannitol/on_introduced(var/mob/living/M)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(!yourarted)
-			originalbraindamage = H.getBrainLoss() //saves your current brain damage so you DON'T heal when the effects run out
+			originalbraindamage = H.getBrainLoss() //saves your current brain damage so you DON'T heal if your haven't gone under the original value
 			H.setBrainLoss(200) //you go absolutely rarted here
 			H.eye_blurry = max(M.eye_blurry, 5)
 			to_chat(M, "<span class='notice'>You feel your mind cloud and your dexterity vanish...</span>")

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -5713,8 +5713,8 @@ var/procizine_tolerance = 0
 	color = "#5C4033" //rgb: 92, 64, 51
 	var/originalbraindamage = 0
 	var/yourarted = FALSE
-	
-/datum/reagent/discount/mannitol/on_mob_life(var/mob/living/M)
+
+/datum/reagent/discount/mannitol/on_introduced(var/mob/living/M)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(!yourarted)
@@ -5723,7 +5723,7 @@ var/procizine_tolerance = 0
 			to_chat(M, "<span class='notice'>You feel your mind cloud and your dexterity vanish...</span>")
 			yourarted = TRUE
 
-/datum/reagent/discount/mannitol/reagent_deleted()
+/datum/reagent/discount/mannitol/reagent_deleted(var/mob/living/M)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		H.setBrainLoss(originalbraindamage) //go back to your previous brain damage even if the chem is forcefully purged

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -5717,16 +5717,19 @@ var/procizine_tolerance = 0
 /datum/reagent/discount/mannitol/on_mob_life(var/mob/living/M)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(!yourarted && volume >= 1)
+		if(!yourarted)
 			originalbraindamage = H.getBrainLoss() //saves your current brain damage so you DON'T heal when the effects run out
 			H.setBrainLoss(200) //you go absolutely rarted here
 			to_chat(M, "<span class='notice'>You feel your mind cloud and your dexterity vanish...</span>")
 			yourarted = TRUE
-		if(yourarted && volume < 1)
-			H.setBrainLoss(originalbraindamage) //restores your original brain damage value
-			to_chat(M, "<span class='notice'>You suddenly feel your previous mental capabilities return to you!</span>")
-			yourarted = FALSE
 
+/datum/reagent/discount/mannitol/reagent_deleted()
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.setBrainLoss(originalbraindamage) //go back to your previous brain damage even if the chem is forcefully purged
+		to_chat(M, "<span class='notice'>You suddenly feel your previous mental capabilities return to you!</span>")
+		yourarted = FALSE
+		
 /datum/reagent/irradiatedbeans
 	name = "Irradiated Beans"
 	id = IRRADIATEDBEANS


### PR DESCRIPTION
### What this does
Consuming Mannitol causes temporary severe brain damage. Once you run out of Mannitol you go back to the brain damage level you had before consumption. For reference, 5u lasts for 12.5 seconds, 20u lasts 50s.
The reagent remembers what brain damage level you had before consuming it, so you go back to that value once it runs out. However, if you have brain medicine on your body and the brain damage level goes under the stored value, once the mannitol runs out you stay at the reduced value, you don't jump back to the stored value. This means that you can heal any brain damage you might've had beforehand while on mannitol but you'll waste some of the medicine treating the extra damage.
For example: If you had 100 brain damage, drank mannitol then treated the brain damage down to only 40, once mannitol runs out you won't go back to 100, but rather stay at 40, since you healed those 60 from the original damage.
### Why it's good
Gives a use to an otherwise pure fluff chemical, plus it is funny.
[tested]
:cl:
 * rscadd: Mannitol causes temporary brain damage. Mannitol remembers the brain damage value you had before consuming it, so you go back to that value once you run out. If you treat your brain damage while on mannitol and you go under the stored value, you stay at the reduced value upon running out of mannitol. For example: You had 100 brain damage, drank mannitol, then treated your brain damage to 20, you stay at 20 after running out of mannitol, you don't go back to 100.
 * tweak: Mannitol now runs out twice as fast.