### PR TITLE
Fixes prolonged energetic interactions (electricity trigger) on artifacts

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_electricity.dm
+++ b/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_electricity.dm
@@ -6,7 +6,7 @@
 
 /datum/artifact_trigger/electricity/New()
 	. = ..()
-	power_connection = new(src)
+	power_connection = new(my_artifact)
 	power_connection.power_priority = POWER_PRIORITY_BYPASS
 
 /datum/artifact_trigger/electricity/Destroy()
@@ -17,12 +17,16 @@
 
 /datum/artifact_trigger/electricity/CheckTrigger()
 
-	if(!power_connection.connected && !power_connection.connect())
+	var/turf/T = get_turf(my_artifact)
+	var/obj/structure/cable/cable = locate() in T
+	if(!cable || !istype(cable))
 		if(my_effect.activated)
 			Triggered(0, "NOCABLE", 0)
 		return
-
+	
+	power_connection.connect(cable)
 	var/datum/powernet/PN = power_connection.get_powernet()
+	
 	if(!PN) //Powernet is dead
 		if(my_effect.activated)
 			Triggered(0, "NOPOWERNET", 0)

--- a/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_electricity.dm
+++ b/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_electricity.dm
@@ -2,6 +2,7 @@
 	triggertype = TRIGGER_ELECTRIC
 	scanned_trigger = SCAN_CONSTANT_ENERGETIC
 	var/power_load = 7500
+	var/power_requested = FALSE
 	var/datum/power_connection/consumer/cable/power_connection = null
 
 /datum/artifact_trigger/electricity/New()
@@ -20,6 +21,7 @@
 	var/turf/T = get_turf(my_artifact)
 	var/obj/structure/cable/cable = locate() in T
 	if(!cable || !istype(cable))
+		power_requested = FALSE
 		if(my_effect.activated)
 			Triggered(0, "NOCABLE", 0)
 		return
@@ -28,16 +30,19 @@
 	var/datum/powernet/PN = power_connection.get_powernet()
 	
 	if(!PN) //Powernet is dead
+		power_requested = FALSE
 		if(my_effect.activated)
 			Triggered(0, "NOPOWERNET", 0)
 		return
-	else if(power_connection.get_satisfaction() < 1.0) //Cannot drain enough power
-		if(my_effect.activated)
-			Triggered(0, "NOTENOUGHELECTRICITY", 0)
-		return
-	else if(!my_effect.activated)
+	else
 		power_connection.add_load(power_load)
-		Triggered(0, "ELECTRICITY", 0)
-		return
-	else //makes sure the powernet stays under load if the artifact is moving
-		power_connection.add_load(power_load)
+		if (!power_requested)        // Skip the first power check to make sure satisfaction includes our load, instead of being the satisfaction from before our load
+			power_requested = TRUE   // This ensures artifacts stay off when on a net with less than 7500W, instead of first turning on once and then staying off
+		else
+			if(power_connection.get_satisfaction() < 1.0) //Cannot drain enough power
+				if(my_effect.activated)
+					Triggered(0, "NOTENOUGHELECTRICITY", 0)
+				return
+			else if(!my_effect.activated)
+				Triggered(0, "ELECTRICITY", 0)
+				return


### PR DESCRIPTION
[bugfix]
## What this does
Fixes #33411
Artifacts with the appropiate trigger will now activate properly when placed on top of a powered cable (doesn't neeed to be a wire knot) with at least 7500W.

## Changelog
:cl:
 * bugfix: Artifacts with a "prolonged energetic interaction" trigger should work properly now