### PR TITLE
Assistant Cap Bugfixes

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -337,6 +337,7 @@ var/global/datum/controller/occupations/job_master
 				continue //no, you can't evade the blacklist just by not being picked for your available jobs
 			Debug("AC2 Assistant located, Player: [player]")
 			AssignRole(player, "Assistant")
+			master_assistant = GetJob("Assistant")
 
 	// Those that got assigned a role, but had assistant higher.
 	var/security_jobs = list(
@@ -364,6 +365,7 @@ var/global/datum/controller/occupations/job_master
 				if(secmod)
 					count = GetSecurityCount()
 				AssignRole(player, "Assistant")
+				master_assistant = GetJob("Assistant")
 			else
 				Debug("AC3: [player] failed the second chance assistant lottery.")
 

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -237,6 +237,16 @@ var/global/datum/controller/occupations/job_master
 		AssignRole(candidate, command_position)
 	return
 
+/** Proc GetSecurityCount
+ *  gets the current number of 'security' roles currently assigned to the station
+ **/
+/datum/controller/occupations/proc/GetSecurityCount()
+	var/datum/job/officer = job_master.GetJob("Security Officer")
+	var/datum/job/warden = job_master.GetJob("Warden")
+	var/datum/job/hos = job_master.GetJob("Head of Security")
+	var/datum/job/detective = job_master.GetJob("Detective")
+	return (officer.current_positions + warden.current_positions + hos.current_positions + detective.current_positions)
+
 /** Proc DivideOccupations
  *  fills var "assigned_role" for all ready players.
  *  This proc must not have any side effect besides of modifying "assigned_role".
@@ -306,13 +316,8 @@ var/global/datum/controller/occupations/job_master
 	// Rejoice, for you have been given a second chance to be a greytider.
 	Debug("DO, Running AC2")
 
-	var/count = 0
-	var/datum/job/officer = job_master.GetJob("Security Officer")
-	var/datum/job/warden = job_master.GetJob("Warden")
-	var/datum/job/hos = job_master.GetJob("Head of Security")
-	var/datum/job/detective = job_master.GetJob("Detective")
+	var/count = GetSecurityCount()
 	var/datum/job/master_assistant = GetJob("Assistant")
-	count = (officer.current_positions + warden.current_positions + hos.current_positions + detective.current_positions)
 
 	// For those who wanted to be assistant if their preferences were filled, here you go.
 	for(var/mob/new_player/player in unassigned)
@@ -334,17 +339,33 @@ var/global/datum/controller/occupations/job_master
 			AssignRole(player, "Assistant")
 
 	// Those that got assigned a role, but had assistant higher.
+	var/security_jobs = list(
+		/datum/job/hos,
+		/datum/job/warden,
+		/datum/job/detective,
+		/datum/job/officer)
 	for (var/mob/new_player/player in shuffle(player_list))
 		if (player.ckey in assistant_second_chance)
-			var/assistant_pref = assistant_second_chance[player.ckey]
-			Debug("AC3: [player] running the second chances for priority [assistant_pref]")
-			if(master_assistant.current_positions-FREE_ASSISTANTS_BRUT > (config.assistantratio * count)) // Not enough sec...
-				if(count < 5) // And less than 5 seccies...
-					Debug("AC3: [player] failed the lottery.")
-			if (assistant_pref < player.mind.job_priority)
-				Debug("AC3: got made an assistant as a second chance.")
+			var/secmod = 0
+			Debug("AC3: [player] running the second chance for assistant")
+
+			//if they are already a security officer, add a modifier to the number of secoffs to see if they qualify for assistant
+			var/datum/job/oldjob = GetJob(player.mind.assigned_role)
+			for(var/secjob in security_jobs)
+				if(istype(oldjob, secjob))
+					Debug("AC3: [player] is a security officer of some sort, noting in case of the assistant cap.")
+					secmod = 1
+			//and if there's enough security officers (assuming you lose your current job) to let you be an assistant...
+			if(!(master_assistant.current_positions-FREE_ASSISTANTS_BRUT > (config.assistantratio * (count-secmod))) || ((count-secmod) >= 5))
+				//No need to check assistant prefs, if you're here then they're on the second_chance list
+				Debug("AC3: [player] got made an assistant as a second chance.")
 				UnassignRole(player)
+				//This may change the number of security players, so we have to update the list of secoffs
+				if(secmod)
+					count = GetSecurityCount()
 				AssignRole(player, "Assistant")
+			else
+				Debug("AC3: [player] failed the second chance assistant lottery.")
 
 	//Final pass - first deal with the empty job group, otherwise send any leftovers to the lobby
 	final_pass: //this is a loop label
@@ -385,11 +406,7 @@ var/global/datum/controller/occupations/job_master
 // -- Snowflaked proc which can be adjusted to more jobs than assistants if needed.
 /datum/controller/occupations/proc/CheckAssistantCount(var/mob/new_player/player, var/level)
 	//People who wants to be assistants, sure, go on.
-	var/count = 0
-	var/datum/job/officer = job_master.GetJob("Security Officer")
-	var/datum/job/warden = job_master.GetJob("Warden")
-	var/datum/job/hos = job_master.GetJob("Head of Security")
-	count = (officer.current_positions + warden.current_positions + hos.current_positions)
+	var/count = GetSecurityCount()
 	Debug("DO, Running Assistant Check 1 for [player]")
 	var/datum/job/master_assistant = GetJob("Assistant")
 	var/not_enough_sec = (master_assistant.current_positions - FREE_ASSISTANTS_BRUT) > (config.assistantratio * count)


### PR DESCRIPTION
# **tl;dr detectives count now and you don't have to latejoin assistant at roundstart anymore**

![image](https://user-images.githubusercontent.com/69739118/193432925-3ed18561-0f6f-46ef-9051-4aef4263186b.png)

## What this does


To understand what this PR does, we must first learn how the Assistant Cap works. It's divided into three checks.

**AC1**: The initial check. When the job assignment assigner comes to you, and your preference is assistant, this is the first assistant cap check that is triggered.
![image](https://user-images.githubusercontent.com/69739118/193432963-6bb88fb0-945d-46c9-8a26-e21bed17d98d.png)

**AC2**: This is the second check. If you are unassigned after all of the job assignments have been issued and you have Join as Assistant if Unassigned enabled, this check is triggered.
![image](https://user-images.githubusercontent.com/69739118/193432957-8146e024-dc24-487f-ba7e-867966b5e7e5.png)

**AC3**: This is the third check. If you had Assistant as a higher priority job then the one you were assigned, then this check triggers, giving you a chance to be reassigned to Assistant. This would likely happen if you had assistant set to High, but the assistant cap was already reached at THAT TIME. After you got denied, other players were assigned to security (likely from their Medium or Low preferences), increasing the cap. This is a 'second chance' to get your higher preference.
![image](https://user-images.githubusercontent.com/69739118/193432969-6b4e6eed-44c5-493e-bc53-7e4a0d04f884.png)
(e.g. If there were already 2 assistants and 0 secoffs when your HIGH roll came, you would be rejected normally because of **AC1**. After your rejection, the assignment process would continue and in this example another player would be assigned to security. Then your MEDIUM roll would come and you would get Captain. After all the jobs were assigned, **AC3** would see that you had a chance to be an Assistant but missed it. It would give you a second chance, checking the now-after-everyone-is-assigned cap to see if it made a mistake. In our example, now that there's another security officer, the cap would have increased so you would be reassigned from Captain to Assistant!)

### Now that we know about these three checks...

**AC1** did not check for detectives.

**AC2** works fine. *Edit: But it would not update the number of counted assistants as it added them, so you could, in theory, have like 10 assistants added to a single open slot in this step.

**AC3** did absolutely nothing - it was broken and always failed. *Edit: And the new version had the same problem as AC2.

So with that in mind, this PR:

Fixes #32749. This bugfixes detectives not counting as security officers for the purposes of the assistant cap in **AC1**. Wardens already counted, but likely this player ran into the bug below. #32993 got the **AC2** check fixed, but they missed **AC1**.

Fixes #33422. Fixes #33266. This PR also fixes **AC3**. The function was literally broken. It checked for security officers, discarded that information, and then did a check that was basically if(0). Now it properly works, including factoring in if you've already been assigned to a security role. If you are, it calculates if you should be reassigned based on the cap that would be in effect if you were reassigned.

This PR also adds the Security Officer Count as a standardized proc.

## Why it's good
Now more assistants can spawn without having to latejoin if there's enough security. More assistants means higher chances of a roundstart welderbombing in tool storage. This means that the administration potentially gets to qdel and then ban people more often. Admins qdeling people has a funny sound effect, and that sound effect makes me laugh. So this PR makes more of that sound effect. Therefore, it's good.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: The Assistant Cap correctly checks for Detectives.
 * bugfix: The Assistant Cap now gives a second chance for assistants who missed the cap the first time but had more security players get selected after them.

[bugfix] [roleissue]