### PR TITLE
Changes lipozine recipe to require capsaicin.

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -765,7 +765,7 @@
 	name = "Lipozine"
 	id = LIPOZINE
 	result = LIPOZINE
-	required_reagents = list(PHOSPHOROUS = 1, ETHANOL = 1, CAPSAICIN = 1)
+	required_reagents = list(SODIUMCHLORIDE = 1, PHOSPHOROUS = 1, CAPSAICIN = 1)
 	result_amount = 3
 
 /datum/chemical_reaction/dietine

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -765,7 +765,7 @@
 	name = "Lipozine"
 	id = LIPOZINE
 	result = LIPOZINE
-	required_reagents = list(SODIUMCHLORIDE = 1, ETHANOL = 1, CAPSAICIN = 1)
+	required_reagents = list(PHOSPHOROUS = 1, ETHANOL = 1, CAPSAICIN = 1)
 	result_amount = 3
 
 /datum/chemical_reaction/dietine

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -765,7 +765,7 @@
 	name = "Lipozine"
 	id = LIPOZINE
 	result = LIPOZINE
-	required_reagents = list(SODIUMCHLORIDE = 1, ETHANOL = 1, RADIUM = 1)
+	required_reagents = list(SODIUMCHLORIDE = 1, ETHANOL = 1, CAPSAICIN = 1)
 	result_amount = 3
 
 /datum/chemical_reaction/dietine


### PR DESCRIPTION
## What this does
This makes it so that lipozine requires capsaicin in its chemistry recipe, changing the recipe to: equal parts sodium-chloride, phosphorous, and capsaicin.

## Why it's good
There are two birds I'm thinking this will stone.
- Becoming skinny again is trivially easy, and so people don't use much of the exercise and gym features that exist. By making lipozine non-trivial to obtain, this might make overeating and fat-related shenanigans more consequential and interesting. For example as obese people can't fit into hardsuits, atmos problems would be more of an issue, and an antag could mess with someone by injecting corn oil into their food and then sabotaging atmos.
- I think chemistry is typically a very self-contained job. Generally, the job consists of pushing buttons on the magic machine and occasionally dealing with breakins. This is masked by the fact that chemistry is situated very close to the hotspot of action known as the medbay, but still I think it could be improved. Lipozine isn't something as vital as bicaridine or clonexadone, but still is fairly often requested by patients, so I think its a good candidate to have it necessitate some outside-of-the-chem-lab interaction, eg. with botany.

## Changelog
:cl:
 * tweak: Lipozine now requires capsaicin to produce.
