### PR TITLE
You may now glue belts.

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -479,7 +479,10 @@
 		return
 
 	if(!can_be_inserted(W))
-		return TRUE
+		if(istype(W, /obj/item/weapon/glue))
+			return
+		else
+			return TRUE
 
 	if(istype(W, /obj/item/weapon/tray))
 		var/obj/item/weapon/tray/T = W


### PR DESCRIPTION
[bugfix]

## What this does
Long ago, there was a bug where attempting to insert bolas into a full storage object would throw the bolas. This was fixed by returning from the attackby proc in such a way that prevented afterattack from being called. However, this also prevents gluing full storage objects, such as belts, toolboxes, internals boxes, and so on.

I have added a check that allows you to glue full storage objects, returning us to the behavior of yesteryear.

Closes #33432

## Why it's good
bug bad

## Changelog
:cl:
 * bugfix: You may now glue toolboxes again.
