### PR TITLE
Assistant Cap Latejoin Bugfixes

### DIFF
--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -33,4 +33,4 @@
 	if(sec_jobs > 5)
 		return 99
 
-	return clamp(sec_jobs * config.assistantratio + xtra_positions, total_positions, 99)
+	return clamp(sec_jobs * config.assistantratio + xtra_positions + FREE_ASSISTANTS, total_positions, 99)


### PR DESCRIPTION
# **My own clone... but wait, that number is wrong?**
![image](https://user-images.githubusercontent.com/69739118/193953990-1c2c2000-c5a2-40bc-9f7f-7b8a8b8e5ba7.png)

The assistant cap is currently supposed to be:
* Two free slots for assistants
* Two extra slots for every one member of security.
* Extra slots as added by the HoP/Admemes

```(Sec * 2) + 2Free + Extraslots = Free Slots```

The latejoin assistant cap check uses the following instead (psuedocode, ignoring the 99 clamp if you want to get technical):

```max( 2, (Sec * 2) + Extraslots = Free Slots) )```

Note that this doesn't factor in the two free slots for assistants properly. Instead, It has a minimum value of 2. It appeared to be working in rounds with 0 security, but as soon as you added one security officer, the numbers would be incorrect.

## What this does
This PR fixes the latejoin assistant cap so that it uses the proper formula. Effectively, this means 2 more assistants can join each round so long as there's at least 1 security member.

## Why it's good
Consistency, and more assistants.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: The Assistant Cap now considers the Free Assistant slots for latejoining assistants.

[bugfix] [roleissue]