### PR TITLE
remove ticker.minds

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -191,9 +191,9 @@
 	return null
 
 /proc/get_mind_by_key(var/key)
-	for(var/datum/mind/M in ticker.minds)
-		if(lowertext(M.key) == lowertext(key))
-			return M
+	for(var/mob/M in mob_list)
+		if(lowertext(M.ckey) == lowertext(key))
+			return M.mind
 	return null
 
 // Comment out when done testing shit.

--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -485,7 +485,7 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 	for(var/mob/living/simple_animal/hostile/mimic/M in contents)
 		M.angry = 0
 		M.apply_disguise()
-	for(var/mob/M in contents)
+	for(var/mob/living/M in contents)
 		if(M.key || M.ckey) //only mobs that were never player controlled
 			return TRUE
 

--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -486,7 +486,7 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 		M.angry = 0
 		M.apply_disguise()
 	for(var/mob/living/M in contents)
-		if(M.key || M.ckey) //only mobs that were never player controlled
+		if(M.key || M.ckey || M.mind) //only mobs that were never player controlled
 			return TRUE
 
 	if (locate(/obj/item/weapon/disk/nuclear) in contents)

--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -485,12 +485,9 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 	for(var/mob/living/simple_animal/hostile/mimic/M in contents)
 		M.angry = 0
 		M.apply_disguise()
-	for(var/mob/living/M in contents)
+	for(var/mob/M in contents)
 		if(M.key || M.ckey) //only mobs that were never player controlled
 			return TRUE
-		for(var/datum/mind/M2 in ticker.minds) //see above, but for ghosts
-			if(M2.current == M)
-				return TRUE
 
 	if (locate(/obj/item/weapon/disk/nuclear) in contents)
 		return TRUE

--- a/code/datums/gamemode/objectives/target/target.dm
+++ b/code/datums/gamemode/objectives/target/target.dm
@@ -46,15 +46,15 @@
 
 /datum/objective/target/proc/get_targets()
 	var/list/targets = list()
-	for(var/datum/mind/possible_target in ticker.minds)
-		if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.z != map.zCentcomm) && (possible_target.current.stat != DEAD) && !(possible_target.assigned_role in bad_assassinate_targets))
-			targets += possible_target
+	for(var/mob/living/carbon/human/H in player_list)
+		if(H.ckey != owner.ckey && (H.z != map.zCentcomm) && (!isDead(H)) && !(H.mind.assigned_role in bad_assassinate_targets))
+			targets += H.mind
 	return targets
 
 /datum/objective/target/proc/find_target_by_role(role, role_type = 0)//Option sets either to check assigned role or special role. Default to assigned.
-	for(var/datum/mind/possible_target in ticker.minds)
-		if((possible_target != owner) && ishuman(possible_target.current) && (possible_target.current.z != map.zCentcomm) && ((role_type ? possible_target.special_role : possible_target.assigned_role) == role) && !(possible_target.assigned_role in bad_assassinate_targets))
-			target = possible_target
+	for(var/mob/living/carbon/human/H in player_list)
+		if(H.ckey != owner.ckey && (H.z != map.zCentcomm) && (!isDead(H)) && ((role_type ? H.mind.special_role : H.mind.assigned_role) == role) && !(H.mind.assigned_role in bad_assassinate_targets))
+			target = H.mind
 			return TRUE
 	return FALSE
 

--- a/code/datums/gamemode/objectives/target/target.dm
+++ b/code/datums/gamemode/objectives/target/target.dm
@@ -46,13 +46,13 @@
 
 /datum/objective/target/proc/get_targets()
 	var/list/targets = list()
-	for(var/mob/living/carbon/human/H in player_list)
+	for(var/mob/living/carbon/human/H in mob_list)
 		if(H.mind && (H.mind.key != owner.key) && (H.z != map.zCentcomm) && !H.isDead() && !(H.mind.assigned_role in bad_assassinate_targets))
 			targets += H.mind
 	return targets
 
 /datum/objective/target/proc/find_target_by_role(role, role_type = 0)//Option sets either to check assigned role or special role. Default to assigned.
-	for(var/mob/living/carbon/human/H in player_list)
+	for(var/mob/living/carbon/human/H in mob_list)
 		if(H.mind && (H.mind.key != owner.key) && (H.z != map.zCentcomm) && !H.isDead() && ((role_type ? H.mind.special_role : H.mind.assigned_role) == role) && !(H.mind.assigned_role in bad_assassinate_targets))
 			target = H.mind
 			return TRUE

--- a/code/datums/gamemode/objectives/target/target.dm
+++ b/code/datums/gamemode/objectives/target/target.dm
@@ -47,13 +47,13 @@
 /datum/objective/target/proc/get_targets()
 	var/list/targets = list()
 	for(var/mob/living/carbon/human/H in player_list)
-		if(H.ckey != owner.ckey && (H.z != map.zCentcomm) && (!isDead(H)) && !(H.mind.assigned_role in bad_assassinate_targets))
+		if(H.ckey != owner.key && (H.z != map.zCentcomm) && !H.isDead() && !(H.mind.assigned_role in bad_assassinate_targets))
 			targets += H.mind
 	return targets
 
 /datum/objective/target/proc/find_target_by_role(role, role_type = 0)//Option sets either to check assigned role or special role. Default to assigned.
 	for(var/mob/living/carbon/human/H in player_list)
-		if(H.ckey != owner.ckey && (H.z != map.zCentcomm) && (!isDead(H)) && ((role_type ? H.mind.special_role : H.mind.assigned_role) == role) && !(H.mind.assigned_role in bad_assassinate_targets))
+		if(H.ckey != owner.key && (H.z != map.zCentcomm) && !H.isDead() && ((role_type ? H.mind.special_role : H.mind.assigned_role) == role) && !(H.mind.assigned_role in bad_assassinate_targets))
 			target = H.mind
 			return TRUE
 	return FALSE

--- a/code/datums/gamemode/objectives/target/target.dm
+++ b/code/datums/gamemode/objectives/target/target.dm
@@ -47,13 +47,13 @@
 /datum/objective/target/proc/get_targets()
 	var/list/targets = list()
 	for(var/mob/living/carbon/human/H in player_list)
-		if(H.ckey != owner.key && (H.z != map.zCentcomm) && !H.isDead() && !(H.mind.assigned_role in bad_assassinate_targets))
+		if(H.mind && (H.mind.key != owner.key) && (H.z != map.zCentcomm) && !H.isDead() && !(H.mind.assigned_role in bad_assassinate_targets))
 			targets += H.mind
 	return targets
 
 /datum/objective/target/proc/find_target_by_role(role, role_type = 0)//Option sets either to check assigned role or special role. Default to assigned.
 	for(var/mob/living/carbon/human/H in player_list)
-		if(H.ckey != owner.key && (H.z != map.zCentcomm) && !H.isDead() && ((role_type ? H.mind.special_role : H.mind.assigned_role) == role) && !(H.mind.assigned_role in bad_assassinate_targets))
+		if(H.mind && (H.mind.key != owner.key) && (H.z != map.zCentcomm) && !H.isDead() && ((role_type ? H.mind.special_role : H.mind.assigned_role) == role) && !(H.mind.assigned_role in bad_assassinate_targets))
 			target = H.mind
 			return TRUE
 	return FALSE

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -564,10 +564,6 @@
 		mind.key = key
 	else
 		mind = new /datum/mind(key)
-		if(ticker)
-			ticker.minds += mind
-		else
-			world.log << "## DEBUG: mind_initialize(): No ticker ready yet! Please inform Carn"
 	if(!mind.name)
 		mind.name = real_name
 	if (!mind.body_archive)

--- a/code/datums/statistics/stat_helpers.dm
+++ b/code/datums/statistics/stat_helpers.dm
@@ -155,15 +155,10 @@
 	station_name = station_name()
 
 	// check for survivors
-	for(var/datum/mind/M in ticker.minds)
-		// i'd like manifest stats, eventually, to be something that doesn't depend on
-		// all data being 'pristine' at round end; for instance, an ayy'd player
-		// will probably have a different entry than what they were at roundstart
-		// and that's gross
-		manifest_entries.Add(new /datum/stat/manifest_entry(M))
-		if(istype(M.current, /mob/living) && !M.current.isDead())
-			add_survivor_stat(M.current)
-
+	for(var/mob/living/M in player_list)
+		manifest_entries.Add(new /datum/stat/manifest_entry(M.mind))
+		if(!M.isDead())
+			add_survivor_stat(M)
 
 /proc/stats_server_alert_new_file()
 	world.Export("http://stats.ss13.moe/alert_new_file")

--- a/code/datums/statistics/stat_helpers.dm
+++ b/code/datums/statistics/stat_helpers.dm
@@ -155,9 +155,9 @@
 	station_name = station_name()
 
 	// check for survivors
-	for(var/mob/living/M in player_list)
+	for(var/mob/living/M in mob_list)
 		manifest_entries.Add(new /datum/stat/manifest_entry(M.mind))
-		if(!M.isDead())
+		if(M.mind && !M.isDead())
 			add_survivor_stat(M)
 
 /proc/stats_server_alert_new_file()

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -20,8 +20,6 @@ var/datum/controller/gameticker/ticker
 
 	var/login_music			// music played in pregame lobby
 
-	var/list/datum/mind/minds = list()//The people in the game. Used for objective tracking.
-
 	var/Bible_icon_state	// icon_state the OFFICIAL chaplain has chosen for his bible
 	var/Bible_item_state	// item_state the OFFICIAL chaplain has chosen for his bible
 	var/Bible_name			// name of the bible
@@ -183,7 +181,6 @@ var/datum/controller/gameticker/ticker
 	for(var/mob/M in player_list)
 		if(!istype(M, /mob/new_player/))
 			var/mob/living/L = M
-			ticker.minds += L.mind
 			L.store_position()
 			M.close_spawn_windows()
 			continue
@@ -199,7 +196,6 @@ var/datum/controller/gameticker/ticker
 		switch(np.mind.assigned_role)
 			if("Cyborg", "Mobile MMI", "AI")
 				var/mob/living/silicon/S = np.create_roundstart_silicon(prefs)
-				ticker.minds += S.mind
 				S.store_position()
 				log_admin("([key]) started the game as a [S.mind.assigned_role].")
 				new_characters[key] = S
@@ -207,7 +203,6 @@ var/datum/controller/gameticker/ticker
 				//antags aren't new players
 			else
 				var/mob/living/carbon/human/H = np.create_human(prefs)
-				ticker.minds += H.mind
 				H.store_position()
 				EquipCustomItems(H)
 				H.update_icons()

--- a/code/game/striketeams/emergency_response_team.dm
+++ b/code/game/striketeams/emergency_response_team.dm
@@ -66,8 +66,6 @@ var/list/response_team_members = list()
 	M.mind.current = M
 	M.mind.assigned_role = "MODE"
 	M.mind.special_role = "Response Team"
-	if(!(M.mind in ticker.minds))
-		ticker.minds += M.mind//Adds them to regular mind list.
 
 	var/datum/faction/ert = find_active_faction_by_type(/datum/faction/strike_team/ert)
 	if(ert)

--- a/code/game/striketeams/striketeam_datums.dm
+++ b/code/game/striketeams/striketeam_datums.dm
@@ -348,8 +348,6 @@ var/list/sent_strike_teams = list()
 	new_commando.mind.current = new_commando
 	new_commando.mind.assigned_role = "MODE"
 	new_commando.mind.special_role = "Custom Team"
-	if(!(new_commando.mind in ticker.minds))
-		ticker.minds += new_commando.mind//Adds them to regular mind list.
 
 	var/datum/faction/customsquad = find_active_faction_by_type(/datum/faction/strike_team/custom)
 	if(customsquad)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -434,7 +434,6 @@
 	if(character.mind.assigned_role != "MODE")
 		if(character.mind.assigned_role != "Cyborg")
 			data_core.manifest_inject(character)
-			ticker.minds += character.mind//Cyborgs and AIs handle this in the transform proc.	//TODO!!!!! ~Carn
 			if(character.mind.assigned_role == "Trader")
 				//If we're a trader, instead send a message to PDAs with the trader cartridge
 				for (var/obj/item/device/pda/P in PDAs)


### PR DESCRIPTION
Noticed this when doing the roundstart stuff, I couldn't think of a reason why it would be necessary, since it's relatively easy to access the mind through a mob. While trivial, it does not need to exist, just adds to confusion, and by removing it, it's one less thing to worry about. It's used in three things: body archives (which I repurposed and works), scoreboard stats for survivors (it referenced mobs anyway, so rather than looping through minds, it loops through mobs), and targets (used `H.mind` to maintain its intent, where H is a human mob, which lessens the amount of checks).

It's just a not-well maintained list, and targets for objectives aren't even held in this list. This list just contains a list of minds, but why not just use mob_list? You can just access mind just as readily.

## What this does
- removes the existence of ticker.minds

## Why it's good
- Less junk that isn't futureproofed