### PR TITLE
Loading cropped parts of map elements, map reset tool in buildmode

### DIFF
--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -38,7 +38,7 @@ var/list/datum/map_element/map_elements = list()
 		A.spawned_by_map_element(src, objects)
 
 
-/datum/map_element/proc/load(x, y, z, rotate=0, overwrite = FALSE, override_can_rotate = FALSE, clipmin_x=0, clipmax_x=0, clipmin_y=0, clipmax_y=0, clipmin_z=0, clipmax_z=0)
+/datum/map_element/proc/load(x, y, z, rotate=0, overwrite = FALSE, override_can_rotate = FALSE, clipmin_x=0, clipmax_x=INFINITY, clipmin_y=0, clipmax_y=INFINITY, clipmin_z=0, clipmax_z=INFINITY)
 	//Location is always lower left corner.
 	//In some cases, location is set to null (when creating a new z-level, for example)
 	//To account for that, location is set again in maploader's load_map() proc

--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -37,7 +37,8 @@ var/list/datum/map_element/map_elements = list()
 	for(var/atom/A in objects)
 		A.spawned_by_map_element(src, objects)
 
-/datum/map_element/proc/load(x, y, z, rotate=0, overwrite = FALSE, override_can_rotate = FALSE)
+
+/datum/map_element/proc/load(x, y, z, rotate=0, overwrite = FALSE, override_can_rotate = FALSE, clipmin_x=0, clipmax_x=0, clipmin_y=0, clipmax_y=0, clipmin_z=0, clipmax_z=0)
 	//Location is always lower left corner.
 	//In some cases, location is set to null (when creating a new z-level, for example)
 	//To account for that, location is set again in maploader's load_map() proc
@@ -53,7 +54,7 @@ var/list/datum/map_element/map_elements = list()
 	if(file_path)
 		var/file = file(file_path)
 		if(isfile(file))
-			var/list/L = maploader.load_map(file, z, x, y, src, rotation, overwrite)
+			var/list/L = maploader.load_map(file, z, x, y, src, rotation, overwrite, clipmin_x, clipmax_x, clipmin_y, clipmax_y, clipmin_z, clipmax_z)
 			initialize(L)
 			return L
 	else //No file specified - empty map element

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1128,6 +1128,7 @@ var/list/admin_verbs_mod = list(
 	ML_INPUT_COORDS,
 	ML_LOAD_TO_Z2
 	)
+	var/dungeoning = FALSE
 
 	switch(input(usr, "Select a location for the new map element", "Map element loading") as null|anything in choices)
 		if(ML_CURRENT_LOC)
@@ -1160,28 +1161,46 @@ var/list/admin_verbs_mod = list(
 				to_chat(src, "<span class='warning'>Dungeon area not defined! This map is missing the /obj/effect/landmark/dungeon_area object.</span>")
 				return
 
-			var/rotate = input(usr, "Set the rotation offset: (0, 90, 180 or 270) ", "Map element loading", "0") as null|num
-			if(rotate == null)
-				return
-
-			var/rotatetext = rotate ? " rotated by [rotate] degrees" : ""
-			log_admin("[key_name(src)] is loading [ME.file_path] at z-level 2 (location chosen automatically)[rotatetext].")
-			message_admins("[key_name_admin(src)] is loading [ME.file_path] at z-level 2 (location chosen automatically)[rotatetext].")
-			load_dungeon(ME, rotate, TRUE)
-			message_admins("[ME.file_path] loaded at [ME.location ? formatJumpTo(ME.location) : "[x_coord], [y_coord], [z_coord]"][rotatetext].")
-			return
-
+			dungeoning = TRUE
 
 	var/rotate = input(usr, "Set the rotation offset: (0, 90, 180 or 270) ", "Map element loading", "0") as null|num
 	if(rotate == null)
 		return
 	var/overwrite = alert("Overwrite original objects in area?","Map element loading","Yes","No") == "Yes"
+	var/clipmin_x = 0
+	var/clipmax_x = INFINITY
+	var/clipmin_y = 0
+	var/clipmax_y = INFINITY
+	var/clipmin_z = 0
+	var/clipmax_z = INFINITY
+	if(alert("Clip map to bounds?","Map element loading","Yes","No") == "Yes")
+		clipmin_x = input(usr, "Minimum X to clip at", "Map element loading", "0") as null|num
+		if(clipmin_x == null)
+			return
+		clipmax_x = input(usr, "Maximum X to clip at", "Map element loading", "0") as null|num
+		if(clipmax_x == null)
+			return
+		clipmin_y = input(usr, "Minimum Y to clip at", "Map element loading", "0") as null|num
+		if(clipmin_y == null)
+			return
+		clipmax_y = input(usr, "Maximum Y to clip at", "Map element loading", "0") as null|num
+		if(clipmax_y == null)
+			return
+		clipmin_z = input(usr, "Minimum Z to clip at", "Map element loading", "0") as null|num
+		if(clipmin_z == null)
+			return
+		clipmax_z = input(usr, "Maximum Z to clip at", "Map element loading", "0") as null|num
+		if(clipmax_z == null)
+			return
 
 	var/rotatetext = rotate ? " rotated by [rotate] degrees" : ""
 	log_admin("[key_name(src)] is loading [ME.file_path] at [x_coord], [y_coord], [z_coord][rotatetext].")
 	message_admins("[key_name_admin(src)] is loading [ME.file_path] at [x_coord], [y_coord], [z_coord][rotatetext].")
-	//Reduce X and Y by 1 because these arguments are actually offsets, and they're added to 1;1 in the map loader. Without this, spawning something at 1;1 would result in it getting spawned at 2;2
-	ME.load(x_coord - 1, y_coord - 1, z_coord, rotate, overwrite, TRUE)
+	if(dungeoning)
+		load_dungeon(ME, rotate, TRUE, clipmin_x, clipmax_x, clipmin_y, clipmax_y, clipmin_z, clipmax_z)
+	else
+		//Reduce X and Y by 1 because these arguments are actually offsets, and they're added to 1;1 in the map loader. Without this, spawning something at 1;1 would result in it getting spawned at 2;2
+		ME.load(x_coord - 1, y_coord - 1, z_coord, rotate, overwrite, TRUE, clipmin_x, clipmax_x, clipmin_y, clipmax_y, clipmin_z, clipmax_z)
 	message_admins("[ME.file_path] loaded at [ME.location ? formatJumpTo(ME.location) : "[x_coord], [y_coord], [z_coord]"][rotatetext].")
 
 /client/proc/create_awaymission()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1166,7 +1166,9 @@ var/list/admin_verbs_mod = list(
 	var/rotate = input(usr, "Set the rotation offset: (0, 90, 180 or 270) ", "Map element loading", "0") as null|num
 	if(rotate == null)
 		return
-	var/overwrite = alert("Overwrite original objects in area?","Map element loading","Yes","No") == "Yes"
+	var/overwrite = FALSE
+	if(!dungeoning)
+		overwrite = alert("Overwrite original objects in area?","Map element loading","Yes","No") == "Yes"
 	var/clipmin_x = 0
 	var/clipmax_x = INFINITY
 	var/clipmin_y = 0

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1179,19 +1179,19 @@ var/list/admin_verbs_mod = list(
 		clipmin_x = input(usr, "Minimum X to clip at", "Map element loading", "0") as null|num
 		if(clipmin_x == null)
 			return
-		clipmax_x = input(usr, "Maximum X to clip at", "Map element loading", "0") as null|num
+		clipmax_x = input(usr, "Maximum X to clip at", "Map element loading", "[world.maxx]") as null|num
 		if(clipmax_x == null)
 			return
 		clipmin_y = input(usr, "Minimum Y to clip at", "Map element loading", "0") as null|num
 		if(clipmin_y == null)
 			return
-		clipmax_y = input(usr, "Maximum Y to clip at", "Map element loading", "0") as null|num
+		clipmax_y = input(usr, "Maximum Y to clip at", "Map element loading", "[world.maxy]") as null|num
 		if(clipmax_y == null)
 			return
 		clipmin_z = input(usr, "Minimum Z to clip at", "Map element loading", "0") as null|num
 		if(clipmin_z == null)
 			return
-		clipmax_z = input(usr, "Maximum Z to clip at", "Map element loading", "0") as null|num
+		clipmax_z = input(usr, "Maximum Z to clip at", "Map element loading", "[world.maxz]") as null|num
 		if(clipmax_z == null)
 			return
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1176,19 +1176,19 @@ var/list/admin_verbs_mod = list(
 	var/clipmin_z = 0
 	var/clipmax_z = INFINITY
 	if(alert("Clip map to bounds?","Map element loading","Yes","No") == "Yes")
-		clipmin_x = input(usr, "Minimum X to clip at", "Map element loading", "0") as null|num
+		clipmin_x = input(usr, "Minimum X to clip at", "Map element loading", "1") as null|num
 		if(clipmin_x == null)
 			return
 		clipmax_x = input(usr, "Maximum X to clip at", "Map element loading", "[world.maxx]") as null|num
 		if(clipmax_x == null)
 			return
-		clipmin_y = input(usr, "Minimum Y to clip at", "Map element loading", "0") as null|num
+		clipmin_y = input(usr, "Minimum Y to clip at", "Map element loading", "1") as null|num
 		if(clipmin_y == null)
 			return
 		clipmax_y = input(usr, "Maximum Y to clip at", "Map element loading", "[world.maxy]") as null|num
 		if(clipmax_y == null)
 			return
-		clipmin_z = input(usr, "Minimum Z to clip at", "Map element loading", "0") as null|num
+		clipmin_z = input(usr, "Minimum Z to clip at", "Map element loading", "1") as null|num
 		if(clipmin_z == null)
 			return
 		clipmax_z = input(usr, "Maximum Z to clip at", "Map element loading", "[world.maxz]") as null|num

--- a/code/modules/admin/buildmode.dm
+++ b/code/modules/admin/buildmode.dm
@@ -366,7 +366,7 @@ var/global/list/obj/effect/bmode/buildholder/buildmodeholders = list()
 							ME.file_path = "maps/[map.file_dir].dmm"
 						if(!fexists(file(ME.file_path)))
 							CRASH("Map file path for current map ([ME.file_path]) not found somehow! Cannot reset map segment.")
-					ME.load(0, 0, 1, 0, 0, 0, lowest_x, highest_x, lowest_y, highest_y, lowest_z, highest_z)
+					ME.load(0, 0, 1, 0, 1, 0, lowest_x, highest_x, lowest_y, highest_y, lowest_z, highest_z)
 				else
 					if(ispath(whatfill, /area) || istype(holder.buildmode.copycat, /area))
 						//In case of a selective fill, make sure the turf fits into the criteria before changing it

--- a/code/modules/admin/buildmode.dm
+++ b/code/modules/admin/buildmode.dm
@@ -355,8 +355,10 @@ var/global/list/obj/effect/bmode/buildholder/buildmodeholders = list()
 				else if(areaAction == MASS_RESET || areaAction == SELECTIVE_RESET)
 					var/lowest_x = min(start.x,end.x)
 					var/lowest_y = min(start.y,end.y)
+					var/lowest_z = min(start.z,end.z)
 					var/highest_x = max(start.x,end.x)
 					var/highest_y = max(start.y,end.y)
+					var/highest_z = max(start.z,end.z)
 					var/datum/map_element/ME = new
 					ME.file_path = "maps/[map.map_dir].dmm"
 					if(!fexists(file(ME.file_path)))
@@ -364,8 +366,7 @@ var/global/list/obj/effect/bmode/buildholder/buildmodeholders = list()
 							ME.file_path = "maps/[map.file_dir].dmm"
 						if(!fexists(file(ME.file_path)))
 							CRASH("Map file path for current map ([ME.file_path]) not found somehow! Cannot reset map segment.")
-							return
-					ME.load(0, 0, 0, 0, 0, 0, lowest_x, highest_x, lowest_y, highest_y, start.z, end.z)
+					ME.load(0, 0, 1, 0, 0, 0, lowest_x, highest_x, lowest_y, highest_y, lowest_z, highest_z)
 				else
 					if(ispath(whatfill, /area) || istype(holder.buildmode.copycat, /area))
 						//In case of a selective fill, make sure the turf fits into the criteria before changing it

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -133,18 +133,12 @@ var/list/map_dimension_cache = list()
 	var/xcrd_flip=y_offset
 	var/ycrd_flip_rotate=y_offset
 	var/xcrd_flip_rotate=x_offset
-	var/z_on = 0
-	var/x_on = 0
-	var/y_on = 0
 
 	for(var/zpos=findtext(tfile,"\n(1,1,",lpos,0);zpos!=0;zpos=findtext(tfile,"\n(1,1,",zpos+1,0))	//in case there's several maps to load
 		zcrd++
-		z_on++
-		if(z_on < clipmin_z)
-			world.log << "skipped [x_on],[y_on],[z_on] on Z"
+		if((zcrd+1) < clipmin_z)
 			continue
-		if(z_on > clipmax_z)
-			world.log << "broke out with [x_on],[y_on],[z_on] on Z"
+		if((zcrd+1) > clipmax_z)
 			break
 		if(zcrd+z_offset > world.maxz)
 			world.maxz = zcrd+z_offset
@@ -186,38 +180,30 @@ var/list/map_dimension_cache = list()
 		ycrd_rotate = x_offset + map_width + 1
 		ycrd_flip = y_offset
 		ycrd_flip_rotate = x_offset
-		y_on = map_height + 1
 
 		for(var/grid_line in xy_grids)
 			ycrd--
 			ycrd_rotate--
 			ycrd_flip++
 			ycrd_flip_rotate++
-			y_on--
-			if(y_on > clipmax_y)
-				world.log << "skipped [x_on],[y_on],[z_on] on Y"
+			if((ycrd-y_offset) > clipmax_y)
 				continue
-			if(y_on < clipmin_y)
-				world.log << "broke out on [x_on],[y_on],[z_on] on Y"
+			if((ycrd-y_offset) < clipmin_y)
 				break
 			//fill the current square using the model map
 			xcrd=x_offset
 			xcrd_rotate=y_offset
 			xcrd_flip=x_offset + map_width + 1
 			xcrd_flip_rotate=y_offset + map_width + 1
-			x_on = 0
 
 			for(var/mpos=1;mpos<=x_depth;mpos+=key_len)
 				xcrd++
 				xcrd_rotate++
 				xcrd_flip--
 				xcrd_flip_rotate--
-				x_on++
-				if(x_on < clipmin_x)
-					world.log << "skipped [x_on],[y_on],[z_on] on X"
+				if((xcrd-x_offset) < clipmin_x)
 					continue
-				if(x_on > clipmax_x)
-					world.log << "broke out with [x_on],[y_on],[z_on] on X"
+				if((xcrd-x_offset) > clipmax_x)
 					break
 				var/parse_key = copytext(grid_line,mpos,mpos+key_len)
 				switch(rotate)

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -146,6 +146,7 @@ var/list/map_dimension_cache = list()
 			world.log << "skipped [x_on],[y_on],[z_on] on Z"
 			continue
 		if(z_on > clipmax_z)
+			world.log << "broke out with [x_on],[y_on],[z_on] on Z"
 			break
 		if(zcrd+z_offset > world.maxz)
 			world.maxz = zcrd+z_offset
@@ -160,18 +161,25 @@ var/list/map_dimension_cache = list()
 				world.log << "skipped [x_on],[y_on],[z_on] on X"
 				continue
 			if(x_on > clipmax_x)
+				world.log << "broke out with [x_on],[y_on],[z_on] on X"
 				break
 			for(var/ypos=findtext(tfile,quote+"\n",xpos,0)+2; ypos != findtext(tfile,"\n"+quote,xpos,0)+1; ypos = findtext(tfile,"\n",ypos+1,0)+1)
 				i++
-				xy_grids.len = i
-				xy_grids[i] = ""
 				y_on++
 				if(y_on < clipmin_y)
 					world.log << "skipped [x_on],[y_on],[z_on] on Y"
+					if(i > xy_grids.len)
+						xy_grids = ""
+					else
+						xy_grids[i] = ""
 					continue
 				if(y_on > clipmax_y)
+					world.log << "broke out with [x_on],[y_on],[z_on] on Y"
 					break
-				xy_grids[i] += copytext(tfile,ypos,findtext(tfile,"\n",ypos,0))
+				if(i > xy_grids.len)
+					xy_grids += y_on < clipmin_y ? copytext(tfile,ypos,findtext(tfile,"\n",ypos,0)) : ""
+				else
+					xy_grids[i] += y_on < clipmin_y ? copytext(tfile,ypos,findtext(tfile,"\n",ypos,0)) : ""
 
 		//if exceeding the world max x or y, increase it
 		var/x_depth = length(xy_grids[1])

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -133,11 +133,17 @@ var/list/map_dimension_cache = list()
 	var/xcrd_flip=y_offset
 	var/ycrd_flip_rotate=y_offset
 	var/xcrd_flip_rotate=x_offset
+	var/z_on = 0
+	var/x_on = 0
+	var/y_on = 0
 
 	for(var/zpos=findtext(tfile,"\n(1,1,",lpos,0);zpos!=0;zpos=findtext(tfile,"\n(1,1,",zpos+1,0))	//in case there's several maps to load
 		zcrd++
-		if(zcrd-z_offset < clipmin_z || zcrd-z_offset > clipmax_z)
+		z_on++
+		if(z_on < clipmin_z)
 			continue
+		if(z_on > clipmax_z)
+			break
 		if(zcrd+z_offset > world.maxz)
 			world.maxz = zcrd+z_offset
 			map.addZLevel(new /datum/zLevel/away, world.maxz) //create a new z_level if needed
@@ -186,14 +192,15 @@ var/list/map_dimension_cache = list()
 			xcrd_flip=x_offset + map_width + 1
 			xcrd_flip_rotate=y_offset + map_width + 1
 			for(var/mpos=1;mpos<=x_depth;mpos+=key_len)
+				x_on++
 				xcrd++
 				xcrd_rotate++
 				xcrd_flip--
 				xcrd_flip_rotate--
-				if(ycrd-y_offset < clipmin_y || ycrd-y_offset > clipmax_y)
-					break
-				if(xcrd-x_offset < clipmin_x || xcrd-x_offset > clipmax_x)
+				if(x_on < clipmin_x || y_on < clipmin_y)
 					continue
+				if(x_on > clipmax_x || y_on > clipmax_y)
+					break
 				var/parse_key = copytext(grid_line,mpos,mpos+key_len)
 				switch(rotate)
 					if(0)
@@ -209,10 +216,13 @@ var/list/map_dimension_cache = list()
 			if(map_element)
 				map_element.width = xcrd - x_offset
 
+			y_on++
 			ycrd--
 			ycrd_rotate--
 			ycrd_flip++
 			ycrd_flip_rotate++
+			if(y_on > clipmax_y)
+				break
 
 			if(remove_lag)
 				CHECK_TICK

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -201,13 +201,11 @@ var/list/map_dimension_cache = list()
 			xcrd_flip=x_offset + map_width + (clipmin_x)
 			xcrd_flip_rotate=y_offset + map_width + (clipmin_x)
 
-			for(var/mpos=1+(key_len*(clipmin_x-1));mpos<=x_depth;mpos+=key_len)
+			for(var/mpos=1+(key_len*(clipmin_x-1));mpos<=x_depth-((map_width-clipmax_x)*key_len);mpos+=key_len)
 				xcrd++
 				xcrd_rotate++
 				xcrd_flip--
 				xcrd_flip_rotate--
-				if((xcrd-x_offset) > clipmax_x)
-					break
 				var/parse_key = copytext(grid_line,mpos,mpos+key_len)
 				switch(rotate)
 					if(0)

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -186,7 +186,7 @@ var/list/map_dimension_cache = list()
 		ycrd_rotate = x_offset + map_width + 1
 		ycrd_flip = y_offset
 		ycrd_flip_rotate = x_offset
-		y_on = map_height
+		y_on = map_height + 1
 
 		for(var/grid_line in xy_grids)
 			ycrd--
@@ -194,10 +194,10 @@ var/list/map_dimension_cache = list()
 			ycrd_flip++
 			ycrd_flip_rotate++
 			y_on--
-			if(y_on >= clipmax_y)
+			if(y_on > clipmax_y)
 				world.log << "skipped [x_on],[y_on],[z_on] on Y"
 				continue
-			if((y_on+1) < clipmin_y)
+			if(y_on < clipmin_y)
 				world.log << "broke out on [x_on],[y_on],[z_on] on Y"
 				break
 			//fill the current square using the model map

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -139,8 +139,11 @@ var/list/map_dimension_cache = list()
 
 	for(var/zpos=findtext(tfile,"\n(1,1,",lpos,0);zpos!=0;zpos=findtext(tfile,"\n(1,1,",zpos+1,0))	//in case there's several maps to load
 		zcrd++
+		x_on = 0
+		y_on = 0
 		z_on++
 		if(z_on < clipmin_z)
+			world.log << "skipped [x_on],[y_on],[z_on] on Z"
 			continue
 		if(z_on > clipmax_z)
 			break
@@ -150,13 +153,25 @@ var/list/map_dimension_cache = list()
 
 		var/list/xy_grids = list()
 		for(var/xpos=zpos; xpos != findtext(tfile,"\n(1,1,",zpos+1,0); xpos = findtext(tfile,"\n(",xpos+1,0))
-			var/i = 1
+			var/i = 0
+			x_on++
+			y_on = 0
+			if(x_on < clipmin_x)
+				world.log << "skipped [x_on],[y_on],[z_on] on X"
+				continue
+			if(x_on > clipmax_x)
+				break
 			for(var/ypos=findtext(tfile,quote+"\n",xpos,0)+2; ypos != findtext(tfile,"\n"+quote,xpos,0)+1; ypos = findtext(tfile,"\n",ypos+1,0)+1)
-				if(i > xy_grids.len)
-					xy_grids += copytext(tfile,ypos,findtext(tfile,"\n",ypos,0))
-				else
-					xy_grids[i] += copytext(tfile,ypos,findtext(tfile,"\n",ypos,0))
 				i++
+				xy_grids.len = i
+				xy_grids[i] = ""
+				y_on++
+				if(y_on < clipmin_y)
+					world.log << "skipped [x_on],[y_on],[z_on] on Y"
+					continue
+				if(y_on > clipmax_y)
+					break
+				xy_grids[i] += copytext(tfile,ypos,findtext(tfile,"\n",ypos,0))
 
 		//if exceeding the world max x or y, increase it
 		var/x_depth = length(xy_grids[1])
@@ -180,27 +195,29 @@ var/list/map_dimension_cache = list()
 			WARNING("Loading [map_element] enlarged the map. New max y = [world.maxy]")
 
 		//then proceed it line by line, starting from top
-		ycrd = y_offset + map_height
-		ycrd_rotate = x_offset + map_width
-		ycrd_flip = y_offset + 1
-		ycrd_flip_rotate = x_offset + 1
+		ycrd = y_offset + map_height + 1
+		ycrd_rotate = x_offset + map_width + 1
+		ycrd_flip = y_offset
+		ycrd_flip_rotate = x_offset
 
 		for(var/grid_line in xy_grids)
+			ycrd--
+			ycrd_rotate--
+			ycrd_flip++
+			ycrd_flip_rotate++
+			if(!grid_line || grid_line == "")
+				world.log << "skipped null map line"
+				continue
 			//fill the current square using the model map
 			xcrd=x_offset
 			xcrd_rotate=y_offset
 			xcrd_flip=x_offset + map_width + 1
 			xcrd_flip_rotate=y_offset + map_width + 1
 			for(var/mpos=1;mpos<=x_depth;mpos+=key_len)
-				x_on++
 				xcrd++
 				xcrd_rotate++
 				xcrd_flip--
 				xcrd_flip_rotate--
-				if(x_on < clipmin_x || y_on < clipmin_y)
-					continue
-				if(x_on > clipmax_x || y_on > clipmax_y)
-					break
 				var/parse_key = copytext(grid_line,mpos,mpos+key_len)
 				switch(rotate)
 					if(0)
@@ -215,14 +232,6 @@ var/list/map_dimension_cache = list()
 					CHECK_TICK
 			if(map_element)
 				map_element.width = xcrd - x_offset
-
-			y_on++
-			ycrd--
-			ycrd_rotate--
-			ycrd_flip++
-			ycrd_flip_rotate++
-			if(y_on > clipmax_y)
-				break
 
 			if(remove_lag)
 				CHECK_TICK

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -189,21 +189,19 @@ var/list/map_dimension_cache = list()
 		ycrd_flip_rotate = x_offset + (map_height - clipmax_y)
 
 		var/grid_line
-		for(var/i in ((map_height - clipmax_y) + 1) to map_height)
+		for(var/i in (map_height - (clipmax_y - 1)) to (map_height - (clipmin_y - 1)))
 			grid_line = xy_grids[i]
 			ycrd--
 			ycrd_rotate--
 			ycrd_flip++
 			ycrd_flip_rotate++
-			if((ycrd-y_offset) < clipmin_y)
-				break
 			//fill the current square using the model map
 			xcrd=x_offset + (clipmin_x - 1)
 			xcrd_rotate=y_offset + (clipmin_x - 1)
 			xcrd_flip=x_offset + map_width + (clipmin_x)
 			xcrd_flip_rotate=y_offset + map_width + (clipmin_x)
 
-			for(var/mpos=1+((key_len*clipmin_x)-2);mpos<=x_depth;mpos+=key_len)
+			for(var/mpos=1+(key_len*(clipmin_x-1));mpos<=x_depth;mpos+=key_len)
 				xcrd++
 				xcrd_rotate++
 				xcrd_flip--

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -194,10 +194,10 @@ var/list/map_dimension_cache = list()
 			ycrd_flip++
 			ycrd_flip_rotate++
 			y_on--
-			if(y_on > clipmax_y)
+			if(y_on >= clipmax_y)
 				world.log << "skipped [x_on],[y_on],[z_on] on Y"
 				continue
-			if(y_on < clipmin_y)
+			if((y_on+1) < clipmin_y)
 				world.log << "broke out on [x_on],[y_on],[z_on] on Y"
 				break
 			//fill the current square using the model map

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -155,9 +155,9 @@ var/list/map_dimension_cache = list()
 			var/i = 1
 			for(var/ypos=findtext(tfile,quote+"\n",xpos,0)+2; ypos != findtext(tfile,"\n"+quote,xpos,0)+1; ypos = findtext(tfile,"\n",ypos+1,0)+1)
 				if(i > xy_grids.len)
-					xy_grids += y_on < clipmin_y ? copytext(tfile,ypos,findtext(tfile,"\n",ypos,0)) : ""
+					xy_grids += copytext(tfile,ypos,findtext(tfile,"\n",ypos,0))
 				else
-					xy_grids[i] += y_on < clipmin_y ? copytext(tfile,ypos,findtext(tfile,"\n",ypos,0)) : ""
+					xy_grids[i] += copytext(tfile,ypos,findtext(tfile,"\n",ypos,0))
 				i++
 
 		//if exceeding the world max x or y, increase it

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -61,7 +61,7 @@ var/list/map_dimension_cache = list()
  * A list of all atoms created
  *
  */
-/dmm_suite/load_map(var/dmm_file as file, var/z_offset as num, var/x_offset as num, var/y_offset as num, var/datum/map_element/map_element as null, var/rotate as num, var/overwrite as num)
+/dmm_suite/load_map(var/dmm_file as file, var/z_offset as num, var/x_offset as num, var/y_offset as num, var/datum/map_element/map_element as null, var/rotate as num, var/overwrite as num, var/clipmin_x as num, var/clipmax_x as num, var/clipmin_y as num, var/clipmax_y as num, var/clipmin_z as num, var/clipmax_z as num)
 
 	if((rotate % 90) != 0) //If not divisible by 90, make it
 		rotate += (rotate % 90)
@@ -71,7 +71,7 @@ var/list/map_dimension_cache = list()
 
 	//If this is true, the lag is reduced at the cost of slower loading speed, and tiny atmos leaks during loading
 	var/remove_lag
-	if(map_element.load_at_once)
+	if(map_element?.load_at_once)
 		remove_lag = FALSE
 	else if(ticker && ticker.current_state > GAME_STATE_PREGAME)
 		//Lag doesn't matter before the game
@@ -136,6 +136,8 @@ var/list/map_dimension_cache = list()
 
 	for(var/zpos=findtext(tfile,"\n(1,1,",lpos,0);zpos!=0;zpos=findtext(tfile,"\n(1,1,",zpos+1,0))	//in case there's several maps to load
 		zcrd++
+		if(zcrd-z_offset < clipmin_z || zcrd-z_offset > clipmax_z)
+			continue
 		if(zcrd+z_offset > world.maxz)
 			world.maxz = zcrd+z_offset
 			map.addZLevel(new /datum/zLevel/away, world.maxz) //create a new z_level if needed
@@ -188,6 +190,10 @@ var/list/map_dimension_cache = list()
 				xcrd_rotate++
 				xcrd_flip--
 				xcrd_flip_rotate--
+				if(ycrd-y_offset < clipmin_y || ycrd-y_offset > clipmax_y)
+					break
+				if(xcrd-x_offset < clipmin_x || xcrd-x_offset > clipmax_x)
+					continue
 				var/parse_key = copytext(grid_line,mpos,mpos+key_len)
 				switch(rotate)
 					if(0)

--- a/code/modules/randomMaps/dungeons.dm
+++ b/code/modules/randomMaps/dungeons.dm
@@ -45,7 +45,7 @@ var/turf/dungeon_area = null
 
 #define MAXIMUM_DUNGEON_WIDTH 80
 
-/proc/load_dungeon(dungeon_type, var/rotate = 0, var/override_can_rotate = FALSE)
+/proc/load_dungeon(dungeon_type, var/rotate = 0, var/override_can_rotate = FALSE, var/clipmin_x=0, var/clipmax_x=INFINITY, var/clipmin_y=0, var/clipmax_y=INFINITY, var/clipmin_z=0, var/clipmax_z=INFINITY)
 	if(!dungeon_area)
 		return 0
 
@@ -96,6 +96,6 @@ var/turf/dungeon_area = null
 	existing_dungeons.Add(ME) //Add it now, to prevent issues occuring when two dungeons are loaded at once
 
 	//Reduce X and Y by 1 because these arguments are actually offsets, and they're added to 1;1 in the map loader. Without this, spawning something at 1;1 would result in it getting spawned at 2;2
-	var/result = ME.load(spawn_x - 1, spawn_y - 1, dungeon_area.z, rotate, FALSE, override_can_rotate)
+	var/result = ME.load(spawn_x - 1, spawn_y - 1, dungeon_area.z, rotate, FALSE, override_can_rotate, clipmin_x, clipmax_x, clipmin_y, clipmax_y, clipmin_z, clipmax_z)
 
 	return result

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -46,6 +46,8 @@
 
 	//nanoui stuff
 	var/map_dir = ""
+	//buildmode reset
+	var/file_dir = ""
 
 	//Fuck the preprocessor
 	var/dorf = 0

--- a/maps/tgstation.dm
+++ b/maps/tgstation.dm
@@ -7,6 +7,7 @@
 	nameShort = "box"
 	nameLong = "Box Station"
 	map_dir = "boxstation"
+	file_dir = "tgstation"
 	tDomeX = 128
 	tDomeY = 58
 	tDomeZ = 2


### PR DESCRIPTION
[content][administration][qol]

## What this does
Adds parameters to map element loading that can crop the map at certain coords. (example loading X 2 to 4, Y 2 to 4 and Z 1 to 1) The "crop" doesn't move to the offset point, and it rotates with the map element if possible
Also adds a buildmode tool to reset a selected portion of the current map to its compile state by reading from the .dmm (accessible by shift click toggling the basic/advanced buildmode button)
May contain bugs caused by attempting to overwrite area-tied things like APCs or etc, so use with caution

## Why it's good
Allows admins to easily restore a huge chunk of the station if they don't like someone's dudebombs or their own mistaken ones.

## Changelog
:cl:
 * rscadd: Admins can now use buildmode to restore a selected portion of the station to its state at the start of the round.
