### PR TITLE
Inflatable shelter fixes

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -451,7 +451,7 @@
 		exiting -= user
 		to_chat(user,"<span class='warning'>You stop climbing free of \the [src].</span>")
 		return
-	if(!dest.Cross())
+	if(!dest.Cross(user))
 		exiting -= user
 		to_chat(user,"<span class='warning'>You cannot climb out here, the way is blocked.</span>")
 		return

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -451,6 +451,10 @@
 		exiting -= user
 		to_chat(user,"<span class='warning'>You stop climbing free of \the [src].</span>")
 		return
+	if(!dest.Cross())
+		exiting -= user
+		to_chat(user,"<span class='warning'>You cannot climb out here, the way is blocked.</span>")
+		return
 	var/turf/T = get_turf(src)
 	var/x_offset = 0
 	var/y_offset = 0
@@ -464,11 +468,11 @@
 	spawn(6 SECONDS)
 		if(loc && exiting.Find(user)) //If not loc, it was probably deflated
 			var/turf/T2 = get_turf(src)
-			var/turf/T3 = locate(T2.x+x_offset,T2.y+y_offset,T2.z+z_offset)
-			if(T3.Cross(user))
-				user.forceMove(T3)
+			if(user.Move(locate(T2.x+x_offset,T2.y+y_offset,T2.z+z_offset)))
 				update_icon()
 				to_chat(user,"<span class='notice'>You climb free of the shelter.</span>")
+			else
+				to_chat(user,"<span class='warning'>You cannot climb out here, the way is blocked.</span>")
 		exiting -= user
 
 /obj/structure/inflatable/shelter/MouseDropTo(atom/movable/O, mob/user) //copy pasted from cryo code
@@ -510,19 +514,9 @@
 
 
 /obj/structure/inflatable/shelter/MouseDropFrom(over_object, src_location, turf/over_location, src_control, over_control, params)
-	if(!Adjacent(over_location))
+	if(!Adjacent(over_location) || !istype(over_location) || usr.incapacitated())
 		return
-	if(!istype(over_location) || over_location.density)
-		return
-	if(usr.incapacitated())
-		return
-	for(var/atom/movable/A in over_location.contents)
-		if(A.density)
-			if((A == src) || istype(A, /mob))
-				continue
-			return
-	if(istype(over_location))
-		container_resist(usr,over_location)
+	container_resist(usr,over_location)
 
 /obj/structure/inflatable/shelter/Exited(var/atom/movable/mover)
 	update_icon()

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -464,10 +464,12 @@
 	spawn(6 SECONDS)
 		if(loc && exiting.Find(user)) //If not loc, it was probably deflated
 			var/turf/T2 = get_turf(src)
-			user.forceMove(locate(T2.x+x_offset,T2.y+y_offset,T2.z+z_offset))
-			exiting -= user
-			update_icon()
-			to_chat(user,"<span class='notice'>You climb free of the shelter.</span>")
+			var/turf/T3 = locate(T2.x+x_offset,T2.y+y_offset,T2.z+z_offset)
+			if(T3.Cross(user))
+				user.forceMove(T3)
+				update_icon()
+				to_chat(user,"<span class='notice'>You climb free of the shelter.</span>")
+		exiting -= user
 
 /obj/structure/inflatable/shelter/MouseDropTo(atom/movable/O, mob/user) //copy pasted from cryo code
 	if(O.loc == user || !isturf(O.loc) || !isturf(user.loc) || !user.Adjacent(O)) //no you can't pull things out of your ass

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -451,14 +451,20 @@
 		exiting -= user
 		to_chat(user,"<span class='warning'>You stop climbing free of \the [src].</span>")
 		return
+	var/turf/T = get_turf(src)
+	var/x_offset = 0
+	var/y_offset = 0
+	var/z_offset = 0
+	if(dest)
+		x_offset = dest.x-T.x
+		y_offset = dest.y-T.y
+		z_offset = dest.z-T.z
 	visible_message("<span class='warning'>[user] begins to climb free of the \the [src]!</span>")
 	exiting += user
 	spawn(6 SECONDS)
 		if(loc && exiting.Find(user)) //If not loc, it was probably deflated
-			if (dest)
-				user.forceMove(dest)
-			else
-				user.forceMove(loc)
+			var/turf/T2 = get_turf(src)
+			user.forceMove(locate(T2.x+x_offset,T2.y+y_offset,T2.z+z_offset))
 			exiting -= user
 			update_icon()
 			to_chat(user,"<span class='notice'>You climb free of the shelter.</span>")

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -451,7 +451,7 @@
 		exiting -= user
 		to_chat(user,"<span class='warning'>You stop climbing free of \the [src].</span>")
 		return
-	if(!dest.Cross(user))
+	if(!dest.Cross(user,dest))
 		exiting -= user
 		to_chat(user,"<span class='warning'>You cannot climb out here, the way is blocked.</span>")
 		return

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -350,14 +350,14 @@
 	return TRUE
 
 /obj/structure/inflatable/shelter/update_icon()
-	overlays = list()
-	var/mob/living/carbon/human/occupant = locate(/mob/living/carbon/human) in contents
-	if(occupant)
-		var/image/occupant_overlay = occupant.appearance
-		overlays += occupant_overlay
-	var/image/cover_overlay = image('icons/obj/inflatable.dmi', icon_state = "shelter_top", layer = FLY_LAYER)
-	cover_overlay.plane = ABOVE_HUMAN_PLANE
-	overlays += cover_overlay
+	vis_contents.Cut()
+	overlays.Cut()
+	for(var/mob/living/L in contents)
+		vis_contents.Add(L)
+	if(contents.len)
+		var/image/cover_overlay = image('icons/obj/inflatable.dmi', icon_state = "shelter_top", layer = FLY_LAYER)
+		cover_overlay.plane = ABOVE_HUMAN_PLANE
+		overlays += cover_overlay
 
 /obj/structure/inflatable/shelter/attack_hand(mob/user)
 	if(user.loc == src && ishuman(user))
@@ -451,7 +451,7 @@
 		exiting -= user
 		to_chat(user,"<span class='warning'>You stop climbing free of \the [src].</span>")
 		return
-	if(!dest.Cross(user,dest))
+	if(dest && !dest.Cross(user,dest))
 		exiting -= user
 		to_chat(user,"<span class='warning'>You cannot climb out here, the way is blocked.</span>")
 		return
@@ -467,12 +467,17 @@
 	exiting += user
 	spawn(6 SECONDS)
 		if(loc && exiting.Find(user)) //If not loc, it was probably deflated
-			var/turf/T2 = get_turf(src)
-			if(user.Move(locate(T2.x+x_offset,T2.y+y_offset,T2.z+z_offset)))
+			if(dest)
+				var/turf/T2 = get_turf(src)
+				if(user.Move(locate(T2.x+x_offset,T2.y+y_offset,T2.z+z_offset)))
+					update_icon()
+					to_chat(user,"<span class='notice'>You climb free of the shelter.</span>")
+				else
+					to_chat(user,"<span class='warning'>You cannot climb out here, the way is blocked.</span>")
+			else
+				user.forceMove(loc)
 				update_icon()
 				to_chat(user,"<span class='notice'>You climb free of the shelter.</span>")
-			else
-				to_chat(user,"<span class='warning'>You cannot climb out here, the way is blocked.</span>")
 		exiting -= user
 
 /obj/structure/inflatable/shelter/MouseDropTo(atom/movable/O, mob/user) //copy pasted from cryo code


### PR DESCRIPTION
[bugfix][tested]

## What this does
Previously, if a shelter was moved while a user click dragged themselves to a location to exit, they would appear at that old location even if it was moved, this now makes the user appear at the adjacent tile relative to shelter at any position. There was also a lesser known bug that allowed forcemove-ing into otherwise dense spaces if the state changed at any point after the 6 second wait, but I haven't seen anyone do that before.
Also allows more than one person and any non-human mob to be visible inside it, thanks to vis_contents. (Closes #19484, Closes #22025, Closes #24611)

## Why it's good
Stops people exploiting them, better view of insides.

## Changelog
:cl:
 * tweak: Inflatable shelters now give a message to the user if they can't be exited due to something blocking the way.
 * bugfix: Inflatable shelters can now be properly exited next to them when moved.
 * bugfix: Inflatable shelters can no longer push users into dense spaces if they become dense after the exiting process begins.
 * tweak: All living mobs can now be visible inside shelters
 * tweak: The shelter cover no longer appears when no mobs are inside