### PR TITLE
Fixes Virtual Wallet Getting Charged When Unable to Afford Vending Merch

### DIFF
--- a/code/modules/Economy/utils.dm
+++ b/code/modules/Economy/utils.dm
@@ -231,6 +231,14 @@ var/global/no_pin_for_debit = TRUE
 			// We'll charge the virtual wallet first.
 			if(primary_money_account.money < transaction_amount)
 				// Not enough funds in the virtual wallet so we'll need the bank account.
+				var/datum/money_account/bank_acc_check = linked_db.get_account(card.associated_account_number)
+				if(!bank_acc_check)
+					to_chat(user, "[bicon(src)] <span class='warning'>Not enough funds to process transaction.</span>")
+					return CARD_CAPTURE_FAILURE_NOT_ENOUGH_FUNDS
+				if((bank_acc_check.money + primary_money_account.money) < transaction_amount)
+					to_chat(user, "[bicon(src)] <span class='warning'>Not enough funds to process transaction.</span>")
+					return CARD_CAPTURE_FAILURE_NOT_ENOUGH_FUNDS
+				// But if they don't have enough money to begin with, even with a bank account, reject the whole thing.
 				if(primary_money_account.money > 0 && alert(user, "Not enough funds in \the [card]'s virtual wallet. Do you want to charge the virtual wallet's remaining balance of $[num2septext(primary_money_account.money)] before charging the rest to your bank account?", "Card Transaction", "Yes", "No") == "Yes")
 					// But lets check if there's an amount on the virtual card and ask if the user would like to apply that balance.
 					if(user_loc != user.loc)


### PR DESCRIPTION
# Miners Keep Their Money When Wanting to Buy More Than They Can Afford!
![image](https://user-images.githubusercontent.com/69739118/194712838-a8e742e8-4d68-43fe-9872-f346475ec656.png)
![image](https://user-images.githubusercontent.com/69739118/194712818-dedf61ab-19d8-4211-b662-e3c6057431bb.png)
(taken during different tests because forgot to screenshot the popup on my last test)


## What this does
So. You're here to understand how some old code works. Here we go.

When you try to buy something from a vending machine, it first looks to see if your ID has a virtual wallet. It usually does. If it can't afford what you're trying to buy, it then asks if you want to put your virtual wallet balance towards the big purchase, with the rest charged to your bank account. The problem is that it doesn't care what your bank account balance is, at all, until after it charges your virtual wallet of everything. Then it doesn't refund you when your bank account can't cover the rest. Miners who try to buy the diamond pickaxe are most familiar with this bug.

This PR adds in a check to see if you can afford your purchase with your virtual wallet and bank account combined. If you can't afford it, it just immediately rejects you. If you CAN afford it, it asks if you want to spend your virtual wallet money or keep it and just try to use only your bank account. (Virtual wallet money can be directly printed into cash, bank account money requires an ATM.)

It also adds a sanity check at the end where if your bank account suddenly can't afford the purchase after your virtual wallet was charged, then your virtual wallet is properly refunded instead of leaving your account emptied.

## Why it's good
Miners no longer lose a lot of money roundstart when trying to buy the diamond pickaxe out of the vending machine. Also, fixes an exploit that lets you have your cake and eat it too. Can't have that!

Also: Fixes #33209, Fixes #27803, Fixes #30316, Fixes #28064, Fixes #25680, Fixes #32253

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: If you can't afford something from a vending machine even if you combine your virtual wallet and bank account balance, your card is quickly rejected before any account security checks or charges are made.
 * bugfix: Fixed virtual wallets losing all their money when trying to buy things you can't afford
 * bugfix: Fixed an exploit letting you buy almost anything from a vending machine for only $1, so long as you had enough money to buy it to begin with
 
 [tested] [bugfix]
