### PR TITLE
Shuffle some roundstart procs to init

### DIFF
--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -129,7 +129,6 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 	generate_radio_frequencies()
 	SetupHooks() // /N3X15 project from 8 years ago (WIP). The jukebox seems to be the only thing using this
 	createDatacore()
-	createPaiController()
 	make_datum_references_lists()	//initialises global lists for referencing frequently used datums (so that we only ever do it once)
 	Holiday = Get_Holiday()
 	world.update_status()

--- a/code/controllers/subsystem/init/more_init_stuff.dm
+++ b/code/controllers/subsystem/init/more_init_stuff.dm
@@ -9,17 +9,15 @@ var/datum/subsystem/more_init/SSmore_init
 	NEW_SS_GLOBAL(SSmore_init)
 
 /datum/subsystem/more_init/Initialize(timeofday)
-	var/watch=start_watch()
 	initialize_rune_words()
 	library_catalog.initialize()
 	initialize_beespecies()
-
 	init_mind_ui()
 	createPaiController()
 	ticker.init_snake_leaderboard()
 	ticker.init_minesweeper_leaderboard()
-
 	setup_news()
+	
 	watch=start_watch()
 	log_startup_progress("Caching damage icons...")
 	cachedamageicons()

--- a/code/controllers/subsystem/init/more_init_stuff.dm
+++ b/code/controllers/subsystem/init/more_init_stuff.dm
@@ -10,13 +10,16 @@ var/datum/subsystem/more_init/SSmore_init
 
 /datum/subsystem/more_init/Initialize(timeofday)
 	var/watch=start_watch()
-	log_startup_progress("Initializing stuff formerly left in world/New...")
 	initialize_rune_words()
 	library_catalog.initialize()
 	initialize_beespecies()
 
+	init_mind_ui()
+	createPaiController()
+	ticker.init_snake_leaderboard()
+	ticker.init_minesweeper_leaderboard()
+
 	setup_news()
-	log_startup_progress("  Finished stuff formerly left in world/New in [stop_watch(watch)]s.")
 	watch=start_watch()
 	log_startup_progress("Caching damage icons...")
 	cachedamageicons()

--- a/code/controllers/subsystem/init/more_init_stuff.dm
+++ b/code/controllers/subsystem/init/more_init_stuff.dm
@@ -18,7 +18,7 @@ var/datum/subsystem/more_init/SSmore_init
 	ticker.init_minesweeper_leaderboard()
 	setup_news()
 	
-	watch=start_watch()
+	var/watch=start_watch()
 	log_startup_progress("Caching damage icons...")
 	cachedamageicons()
 	log_startup_progress("  Finished caching damage icons in [stop_watch(watch)]s.")

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -164,8 +164,6 @@ var/datum/controller/gameticker/ticker
 
 	//Configure mode and assign player to special mode stuff
 	job_master.DivideOccupations() //Distribute jobs
-	init_mind_ui()
-	init_PDAgames_leaderboard()
 
 	var/can_continue = mode.Setup()//Setup special modes
 	if(!can_continue)
@@ -451,10 +449,6 @@ var/datum/controller/gameticker/ticker
 				to_chat(world, "<span class='notice'><B>An admin has delayed the round end</B></span>")
 				delay_end = 2
 	return 1
-
-/datum/controller/gameticker/proc/init_PDAgames_leaderboard()
-	init_snake_leaderboard()
-	init_minesweeper_leaderboard()
 
 /datum/controller/gameticker/proc/init_snake_leaderboard()
 	for(var/x=1;x<=PDA_APP_SNAKEII_MAXSPEED;x++)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -126,7 +126,6 @@ var/datum/controller/gameticker/ticker
 	theme.update_music()
 	theme.update_icon()
 
-
 /datum/controller/gameticker/proc/setup()
 	//Create and announce mode
 	if(master_mode=="secret")


### PR DESCRIPTION
Putting some procs where they belong, which is not roundstart

## What this does
- Move some init procs to the general initialization subsystem, which means less clutter and overhead for roundstart.

## Why it's good
- Tested butchering, works fine
- Tested snake and mindsweeper, work fine
- Tested pAis, worked fine
- organization
