### PR TITLE
Fixes pulse demon weapon nullspacing

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_attack.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_attack.dm
@@ -228,10 +228,11 @@
 	user.loc = src
 	if(charging)
 		to_chat(user,"<span class='notice'>You are now attempting to hijack \the [charging], this will take approximately [user.takeover_time] seconds.</span>")
-		if(do_after(user,src,user.takeover_time*10))
-			to_chat(user,"<span class='notice'>You are now inside \the [charging].</span>")
-			user.loc = charging
-			user.current_weapon = charging
+		if(do_after(user,charging,user.takeover_time*10))
+			if(charging)
+				to_chat(user,"<span class='notice'>You are now inside \the [charging].</span>")
+				user.loc = charging
+				user.current_weapon = charging
 	else
 		to_chat(user,"<span class='warning'>There is no weapon charging.</span>")
 


### PR DESCRIPTION
[bugfix]

## What this does
Closes #33391.

## Changelog
:cl:
 * bugfix: Pulse demons are no longer sent to the shadow realm on attempting to take over a weapon that gets removed before the process finishes.