### PR TITLE
Changes Circus of Values vending machine description.

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3294,7 +3294,7 @@ var/global/num_vending_terminals = 1
 
 /obj/machinery/vending/circus
 	name = "\improper Circus of Values"
-	desc = "Would you kindly?"
+	desc = "The Circus of Values vending machine offers a variety of items for sale. Would you kindly?"
 	//Desc text is a direct quote from the Bioshock description
 	product_slogans = list(
 		"Hahahahahahaha!",

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3294,7 +3294,7 @@ var/global/num_vending_terminals = 1
 
 /obj/machinery/vending/circus
 	name = "\improper Circus of Values"
-	desc = "The Circus of Values Vending Machine offers a variety of items for sale."
+	desc = "Welcome to the Circus of Values!"
 	//Desc text is a direct quote from the Bioshock description
 	product_slogans = list(
 		"Hahahahahahaha!",

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3294,7 +3294,7 @@ var/global/num_vending_terminals = 1
 
 /obj/machinery/vending/circus
 	name = "\improper Circus of Values"
-	desc = "The Circus of Values Vending Machine offers a variety of items for sale. Most Vending Machines have items at the bottom that will only become available if you successfully hack the machine."
+	desc = "The Circus of Values Vending Machine offers a variety of items for sale."
 	//Desc text is a direct quote from the Bioshock description
 	product_slogans = list(
 		"Hahahahahahaha!",

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3294,7 +3294,7 @@ var/global/num_vending_terminals = 1
 
 /obj/machinery/vending/circus
 	name = "\improper Circus of Values"
-	desc = "Welcome to the Circus of Values!"
+	desc = "Would you kindly?"
 	//Desc text is a direct quote from the Bioshock description
 	product_slogans = list(
 		"Hahahahahahaha!",

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3294,7 +3294,7 @@ var/global/num_vending_terminals = 1
 
 /obj/machinery/vending/circus
 	name = "\improper Circus of Values"
-	desc = "The Circus of Values vending machine offers a variety of toys and trinkets for sale. Would you kindly?"
+	desc = "The Circus of Values Vending Machine offers a variety of items for sale. Would you kindly?"
 	//Desc text is a direct quote from the Bioshock description
 	product_slogans = list(
 		"Hahahahahahaha!",

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3294,7 +3294,7 @@ var/global/num_vending_terminals = 1
 
 /obj/machinery/vending/circus
 	name = "\improper Circus of Values"
-	desc = "The Circus of Values Vending Machine offers a variety of items for sale. Would you kindly?"
+	desc = "The Circus of Values offers a variety of toys and trinkets for sale. Would you kindly?"
 	//Desc text is a direct quote from the Bioshock description
 	product_slogans = list(
 		"Hahahahahahaha!",

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3294,7 +3294,7 @@ var/global/num_vending_terminals = 1
 
 /obj/machinery/vending/circus
 	name = "\improper Circus of Values"
-	desc = "The Circus of Values vending machine offers a variety of items for sale. Would you kindly?"
+	desc = "The Circus of Values vending machine offers a variety of toys and trinkets for sale. Would you kindly?"
 	//Desc text is a direct quote from the Bioshock description
 	product_slogans = list(
 		"Hahahahahahaha!",


### PR DESCRIPTION
This changes the Circus of Values vending machine description to:
`The Circus of Values offers a variety of toys and trinkets for sale. Would you kindly?`
from
`The Circus of Values Vending Machine offers a variety of items for sale. Most Vending Machines have items at the bottom that will only become available if you successfully hack the machine.`

The reason for this is that currently it seems very dry and "tooltippy" in contrast to other object descriptions. I think this change improves it in terms of immersion and also consistency with most other objects, which don't have anything like the current description, notable exception being the inflatable shelter "did you mean to resist free?" but that's more forgivable in my opinion.

:cl:
 * tweak: Changed Circus of Value vending machine description.