### PR TITLE
Alias chemical reactions no longer collide 

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -476,9 +476,11 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 			if(islist(B))
 				var/list/L = B
 				for(var/D in L)
-					if(!preserved_data)
-						preserved_data = get_data(D)
-					remove_reagent(D, (multiplier * C.required_reagents[B]), safety = 1)
+					if(has_reagent(D, C.required_reagents[B]))
+						if(!preserved_data)
+							preserved_data = get_data(D)
+						remove_reagent(D, (multiplier * C.required_reagents[B]), safety = 1)
+						break
 			else
 				if(!preserved_data)
 					preserved_data = get_data(B)


### PR DESCRIPTION
[bugfix]

## What this does
Chemical reactions involving chemical aliases (such as botany chemicals, or sugar/corn oil, several other examples) collide because they have the same ingredients and the same outputs. The code that handles the reactions is a bit buggy. If you try to perform reactions using a mix of alias chemicals in the same beaker, you will consume all the components simultaneously, while only producing the output for one of them.

The code for handling reactions is divided into a few segments. It first looks through the filtered list of chemical reactions by reagent, and decides which ones are applicable. In this step, there was logic to separately test each chemical alias and determine if there was enough there to perform the reaction. Then, the code would iterate through the reagents list of the chemical reaction, and remove every element from that list from the beaker. However, the alias testing logic of this step wasn't as clean. This caused the collision behavior described above. I have copied the logic from the first step to this step, which forces the reactions to happen one reagent at a time. 

## Why it's good
annoying little bug for botanybros fixt

## Changelog
:cl:
 * bugfix: Colliding chemical reactions no longer consume multiple alias ingredients while only producing the output for one.
