### PR TITLE
Changes "It is a [size] item." to "It is [size]."

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -9,6 +9,7 @@
 	var/hitsound = null
 	var/miss_sound = 'sound/weapons/punchmiss.ogg'
 	var/armor_penetration = 0 // Chance from 0 to 100 to reduce absorb by one, and then rolls the same value. Check living_defense.dm
+	var/uncountable //TRUE means the item will be described as "it" even if its gender is PLURAL.
 
 	w_class = W_CLASS_MEDIUM
 	var/attack_delay = 10 //Delay between attacking with this item, in 1/10s of a second (default = 1 second)
@@ -308,11 +309,11 @@
 
 	//if (clumsy_check(usr) && prob(50)) t = "funny-looking"
 	var/pronoun
-	if (gender == PLURAL)
+	if ((gender == PLURAL) && !uncountable)
 		pronoun = "They are"
 	else
 		pronoun = "It is"
-	size = " [pronoun] a [size] item."
+	size = " [pronoun] [size]."
 	..(user, size, show_name)
 	if(price && price > 0)
 		to_chat(user, "You read '[price] space bucks' on the tag.")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -9,7 +9,7 @@
 	var/hitsound = null
 	var/miss_sound = 'sound/weapons/punchmiss.ogg'
 	var/armor_penetration = 0 // Chance from 0 to 100 to reduce absorb by one, and then rolls the same value. Check living_defense.dm
-	var/uncountable //TRUE means the item will be described as "it" even if its gender is PLURAL.
+	var/uncountable //TRUE means the item's examine description will use "It is" even if the item's gender is PLURAL.
 
 	w_class = W_CLASS_MEDIUM
 	var/attack_delay = 10 //Delay between attacking with this item, in 1/10s of a second (default = 1 second)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -9,8 +9,6 @@
 	var/hitsound = null
 	var/miss_sound = 'sound/weapons/punchmiss.ogg'
 	var/armor_penetration = 0 // Chance from 0 to 100 to reduce absorb by one, and then rolls the same value. Check living_defense.dm
-	var/uncountable //TRUE means the item's examine description will use "It is" even if the item's gender is PLURAL.
-
 	w_class = W_CLASS_MEDIUM
 	var/attack_delay = 10 //Delay between attacking with this item, in 1/10s of a second (default = 1 second)
 
@@ -309,7 +307,7 @@
 
 	//if (clumsy_check(usr) && prob(50)) t = "funny-looking"
 	var/pronoun
-	if ((gender == PLURAL) && !uncountable)
+	if (gender == PLURAL)
 		pronoun = "They are"
 	else
 		pronoun = "It is"

--- a/code/game/objects/items/gum.dm
+++ b/code/game/objects/items/gum.dm
@@ -12,7 +12,6 @@
 	var/atom/target = null
 	var/sprite_shrunk = FALSE //I couldn't think of a satisfactory way to check if our transform matrix is minty fresh, so this is used to track if we're shrunk from being stuck to a vending machine
 	autoignition_temperature = AUTOIGNITION_PAPER
-	uncountable = TRUE
 
 /obj/item/gum/New()
 	..()

--- a/code/game/objects/items/gum.dm
+++ b/code/game/objects/items/gum.dm
@@ -12,6 +12,7 @@
 	var/atom/target = null
 	var/sprite_shrunk = FALSE //I couldn't think of a satisfactory way to check if our transform matrix is minty fresh, so this is used to track if we're shrunk from being stuck to a vending machine
 	autoignition_temperature = AUTOIGNITION_PAPER
+	uncountable = TRUE
 
 /obj/item/gum/New()
 	..()


### PR DESCRIPTION
## What this does
This changes the size class part of the examine description of items to, eg:
`It is tiny.`
from the current
`It is a tiny item.`

## Why it's good
I think it seems more natural. Generally you already know it's an item but you still want the size class information.

## Changelog
:cl:
 * tweak: Changed size class examine description for items.
