### PR TITLE
Grues biting power cables

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -237,7 +237,7 @@ By design, d1 is the smallest direction and d2 is the highest
 			G.visible_message("<span class='danger'>[G] [G.attacktext] \the [src]!</span>", "<span class='userdanger'>You [shift_verb_tense(G.attacktext)] \the [src]!</span>")
 			shock(G, 50)
 			var/thisdmg = rand(G.melee_damage_lower, G.melee_damage_upper)
-			if((thisdmg >= 15) || prob(5))
+			if((thisdmg >= 15) || (thisdmg && prob(5)))
 				var/turf/T = src.loc
 				cut(G, T)
 				

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -231,7 +231,16 @@ By design, d1 is the smallest direction and d2 is the highest
 			if(prob(5) && N.can_chew_wires)
 				var/turf/T = src.loc
 				cut(N, T)
-
+		else if(istype(M, /mob/living/simple_animal/hostile/grue))
+			var/mob/living/simple_animal/hostile/grue/G = M
+			G.delayNextAttack(10)
+			G.visible_message("<span class='danger'>[G] [G.attacktext] \the [src]!</span>", "<span class='userdanger'>You [shift_verb_tense(G.attacktext)] \the [src]!</span>")
+			shock(G, 50)
+			var/thisdmg = rand(G.melee_damage_lower, G.melee_damage_upper)
+			if((thisdmg >= 15) || prob(5))
+				var/turf/T = src.loc
+				cut(G, T)
+				
 /obj/structure/cable/bite_act(mob/living/carbon/human/H)
 	H.visible_message("<span class='danger'>[H] bites \the [src]!</span>", "<span class='userdanger'>You bite \the [src]!</span></span>")
 


### PR DESCRIPTION
## What this does
This makes it so grues can bite power cables and break them, similar to a mouse, shocking them in the process if there is power in the cable. If the attack does under 15 damage, it has a 5% chance to break the cable (the same as a mouse), and if it has 15 damage or more, it breaks it without fail. Grue larva fall under this threshold, while juveniles and adults should be able to sever the cable every time.

## Why it's good
I think it gives grues a bit more "pull" in terms of trying to lure crew members into the dark, instead of always having to "push" out into light areas. If power starts failing in particular rooms, this might alert the crew to the possible presence of a grue, so it's also a double-edged sword in that regard in terms of shutting off lights versus revealing oneself. It might be a little spooky having to go fix the power cables in the darkness of maint when you suspect a grue might be lurking around. And also, if engineers crank up the power really high they can fry the grues, but this also increases risks re. assistants trying to hack, malicious door shocking, pulse demon concerns, etc. I think overall this should ramp up the gameplay decisionmaking spectrum a bit for both grues and crewmembers. 

## Changelog
:cl:
 * rscadd: Grues can now chew power cables.

