### PR TITLE
Removes metal autoignition

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1124,7 +1124,6 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define AUTOIGNITION_WOOD  573.15
 #define AUTOIGNITION_PAPER 519.15
 #define AUTOIGNITION_PLASTIC 689.15 //autoignition temperature of ABS plastic
-#define AUTOIGNITION_METAL null //1033.15 is the autoignition temperature of steel under high pressure pure oxgen
 #define AUTOIGNITION_FABRIC 523.15
 #define AUTOIGNITION_PROTECTIVE 573.15 //autoignition temperature of protective clothing like firesuits or kevlar vests
 #define AUTOIGNITION_ORGANIC 633.15 //autoignition temperature of animal fats

--- a/code/game/objects/items/ashtray.dm
+++ b/code/game/objects/items/ashtray.dm
@@ -3,7 +3,6 @@
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/cigs_lighters.dmi', "right_hand" = 'icons/mob/in-hand/right/cigs_lighters.dmi')
 	item_state = "ashtray"
 	w_class = W_CLASS_TINY
-	autoignition_temperature = AUTOIGNITION_METAL
 
 	var/max_butts 	= 0
 	var/empty_desc 	= ""

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -18,7 +18,6 @@ var/global/msg_id = 0
 	w_class = W_CLASS_TINY
 	flags = FPRINT
 	slot_flags = SLOT_ID | SLOT_BELT
-	autoignition_temperature = AUTOIGNITION_METAL
 
 	//Main variables
 	var/owner = null

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -7,7 +7,6 @@
 	w_class = W_CLASS_SMALL
 	flags = FPRINT
 	slot_flags = SLOT_BELT
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/flush = null
 	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_MATERIALS + "=4"
 

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -8,7 +8,6 @@
 	throw_speed = 4
 	throw_range = 20
 	flags = FPRINT | NO_ATTACK_MSG
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/c_tag = ""
 	var/active = FALSE
 	var/network = ""

--- a/code/game/objects/items/devices/deskbell.dm
+++ b/code/game/objects/items/devices/deskbell.dm
@@ -17,7 +17,6 @@
 	starting_materials = list(MAT_IRON = 3750)
 	w_type = RECYK_METAL
 	melt_temperature=MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	anchored = 1
 	origin_tech = Tc_MATERIALS + "=1"
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -12,7 +12,6 @@
 	starting_materials = list(MAT_IRON = 50, MAT_GLASS = 20)
 	w_type = RECYK_ELECTRONIC
 	melt_temperature = MELTPOINT_STEEL // Assuming big beefy fucking maglite.
-	autoignition_temperature = AUTOIGNITION_METAL //see above
 	actions_types = list(/datum/action/item_action/toggle_light)
 	var/on = 0
 	var/brightness_on = 4 //luminosity when on

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -7,7 +7,6 @@
 	icon_state = "geiger_counter"
 	w_class = W_CLASS_SMALL
 	origin_tech = Tc_ENGINEERING + "=3;" + Tc_MATERIALS + "=4"
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/on = 0
 	var/last_call = 0
 	var/last_sound = 0

--- a/code/game/objects/items/devices/handtv.dm
+++ b/code/game/objects/items/devices/handtv.dm
@@ -4,7 +4,6 @@ var/global/list/camera_bugs = list()
 	desc = "A handheld tv meant for remote viewing."
 	icon_state = "handtv"
 	w_class = W_CLASS_TINY
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/obj/item/device/camera_bug/current
 	var/network
 

--- a/code/game/objects/items/devices/holomap.dm
+++ b/code/game/objects/items/devices/holomap.dm
@@ -6,7 +6,6 @@
 
 	icon = 'icons/obj/device.dmi'
 	icon_state = "holomap"
-	autoignition_temperature = AUTOIGNITION_METAL
 
 	var/list/image/showing = list()
 	var/client/viewing // Client that is using the device right now, also determines whether it's on or off.

--- a/code/game/objects/items/devices/instruments.dm
+++ b/code/game/objects/items/devices/instruments.dm
@@ -8,7 +8,6 @@
 	icon = 'icons/obj/musician.dmi'
 	force = 10
 	var/requires_mouth = FALSE
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/device/instrument/New()
 	..()

--- a/code/game/objects/items/devices/ioncannon_remote.dm
+++ b/code/game/objects/items/devices/ioncannon_remote.dm
@@ -9,7 +9,6 @@
 	flags = FPRINT
 	var/cooldown = 0
 	mech_flags = MECH_SCAN_FAIL
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/device/loic_remote/New()
 	processing_objects.Add(src)

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -28,7 +28,6 @@ var/static/list/mat2type = list(
 	flags = FPRINT
 	siemens_coefficient = 1
 	w_class = W_CLASS_MEDIUM
-	autoignition_temperature = AUTOIGNITION_METAL
 	origin_tech = Tc_ENGINEERING + "=4;" + Tc_MATERIALS + "=5;" + Tc_POWERSTORAGE + "=3"
 
 	var/mode = 1 //0 is material selection, 1 is material production

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -9,7 +9,6 @@
 	var/list/original = list()	//the starting parts
 	var/list/finished = list()	//the finished products
 	toolsounds = list('sound/items/Screwdriver.ogg')
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/device/modkit/New()
 	..()

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -23,7 +23,6 @@
 	starting_materials		= list(MAT_IRON = 50, MAT_GLASS = 20)
 	w_type					= RECYK_ELECTRONIC
 	melt_temperature		= MELTPOINT_SILICON
-	autoignition_temperature = AUTOIGNITION_METAL
 	origin_tech				= Tc_MAGNETS + "=1;" + Tc_ENGINEERING + "=1"
 	// VG: We dun changed dis so we can link simple machines. - N3X
 	var/datum/weakref/buffer // simple machine buffer for device linkage

--- a/code/game/objects/items/devices/pipe_painter.dm
+++ b/code/game/objects/items/devices/pipe_painter.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "labeler1"
 	item_state = "flight"
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/list/modes = list(
 		"grey",
 		"red",

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -14,7 +14,6 @@
 	starting_materials = list(MAT_IRON = 750)
 	w_type = RECYK_ELECTRONIC
 	melt_temperature = MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	origin_tech = Tc_POWERSTORAGE + "=3;" + Tc_SYNDICATE + "=5"
 	var/drain_rate = 600000		// amount of power to drain per tick
 	var/last_drain = 0			// amount we tried to drain last tick

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -11,7 +11,6 @@
 	w_class = W_CLASS_HUGE
 	starting_materials = list(MAT_IRON = 10000, MAT_GLASS = 2500)
 	w_type = RECYK_ELECTRONIC
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/code = 2
 	var/datum/radio_frequency/radio_connection
 

--- a/code/game/objects/items/devices/reportintercom.dm
+++ b/code/game/objects/items/devices/reportintercom.dm
@@ -7,7 +7,6 @@
 	w_class = W_CLASS_TINY
 	flags = FPRINT
 	siemens_coefficient = 1
-	autoignition_temperature = AUTOIGNITION_METAL
 
 	var/used = 0
 

--- a/code/game/objects/items/devices/rigbuilding.dm
+++ b/code/game/objects/items/devices/rigbuilding.dm
@@ -5,7 +5,6 @@
 	item_state = null
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/spacesuits.dmi', "right_hand" = 'icons/mob/in-hand/right/spacesuits.dmi')
 	w_class = W_CLASS_LARGE
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/buildstate = RIG_EMPTY
 	var/obj/item/weapon/cell/cell = null
 	var/obj/item/clothing/suit/space/rig/result = null //changes based on which kit you use

--- a/code/game/objects/items/devices/silicate sprayer.dm
+++ b/code/game/objects/items/devices/silicate sprayer.dm
@@ -21,7 +21,6 @@
 
 	origin_tech = Tc_ENGINEERING + "=2"
 
-	autoignition_temperature = AUTOIGNITION_METAL
 
 	var/start_filled = TRUE
 	var/max_silicate = 50

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -5,7 +5,6 @@
 	item_state = "ttv"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/tanks.dmi', "right_hand" = 'icons/mob/in-hand/right/tanks.dmi')
 	desc = "Regulates the transfer of air between two tanks."
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/obj/item/weapon/tank/tank_one
 	var/obj/item/weapon/tank/tank_two
 	var/obj/item/device/attached_device

--- a/code/game/objects/items/mountable_frames/frames.dm
+++ b/code/game/objects/items/mountable_frames/frames.dm
@@ -3,7 +3,6 @@
 	desc = "Place it on a wall."
 	flags = FPRINT
 	w_type=RECYK_METAL
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/sheets_refunded = 2
 	var/list/mount_reqs = list() //can contain simfloor, nospace. Used in try_build to see if conditions are needed, then met
 	var/frame_material = /obj/item/stack/sheet/metal

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -7,7 +7,6 @@
 	siemens_coefficient = 1
 	slot_flags = SLOT_BELT
 	w_type=RECYK_ELECTRONIC
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/list/part = null
 	var/sabotaged = 0 //Emagging limbs can have repercussions when installed as prosthetics.
 	var/brute_dam = 0

--- a/code/game/objects/items/stacks/misc.dm
+++ b/code/game/objects/items/stacks/misc.dm
@@ -15,7 +15,6 @@
 	attack_verb = list("hits", "bludgeons", "whacks")
 	w_type=RECYK_METAL
 	melt_temperature = MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/active = 0
 
 /obj/item/stack/rods/Destroy()
@@ -154,7 +153,6 @@
 	irregular_plural = "chains"
 	max_amount = 20
 	w_type = RECYK_METAL
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/stack/chains/can_stack_with(var/obj/item/other_stack)
 	if(!ispath(other_stack) && istype(other_stack) && other_stack.material_type == material_type)

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -7,7 +7,6 @@
 	origin_tech = Tc_MATERIALS + "=4;" + Tc_ENGINEERING + "=3"
 	amount = 10
 	surgerysound = 'sound/items/bonegel.ogg'
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/stack/nanopaste/attack(mob/living/M as mob, mob/user as mob)
 	if(!istype(M) || !istype(user))

--- a/code/game/objects/items/stacks/sheets/light.dm
+++ b/code/game/objects/items/stacks/sheets/light.dm
@@ -12,7 +12,6 @@
 	flags = FPRINT
 	siemens_coefficient = 1
 	max_amount = 60
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/stack/light_w/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(istype(O,/obj/item/tool/wirecutters))

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -23,7 +23,6 @@
 	siemens_coefficient = 1
 	origin_tech = Tc_MATERIALS + "=1"
 	melt_temperature = MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	mat_type = MAT_IRON
 	perunit = CC_PER_SHEET_METAL
 

--- a/code/game/objects/items/stacks/tiles/mineral.dm
+++ b/code/game/objects/items/stacks/tiles/mineral.dm
@@ -15,7 +15,6 @@
 	material = "plasma"
 	starting_materials = list(MAT_PLASMA = CC_PER_SHEET_PLASMA / 4) // Recipe requires 1 sheet for 4 tiles
 	w_type = RECYK_METAL
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/stack/tile/mineral/uranium
 	name = "uranium tile"

--- a/code/game/objects/items/stacks/tiles/tiles.dm
+++ b/code/game/objects/items/stacks/tiles/tiles.dm
@@ -8,7 +8,6 @@
 	starting_materials = list(MAT_IRON = 937.5)
 	w_type = RECYK_METAL
 	melt_temperature = MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	throwforce = 10
 	throw_speed = 4
 	throw_range = 20
@@ -136,7 +135,6 @@
 	desc = "A relatively clear reinforced glass tile."
 	icon_state = "tile_rglass"
 	max_amount = 60
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/stack/glass_tile/rglass/proc/build(turf/S as turf)
 	var/obj/structure/lattice/L = S.canBuildCatwalk(src)

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -67,7 +67,6 @@
 	siemens_coefficient = 0
 	w_class = W_CLASS_SMALL
 	var/working = FALSE
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/weapon/mech_expansion_kit/preattack(atom/target, mob/user , proximity)
 	if(!proximity)

--- a/code/game/objects/items/weapons/airlock_painter.dm
+++ b/code/game/objects/items/weapons/airlock_painter.dm
@@ -14,7 +14,6 @@
 	flags = FPRINT
 	siemens_coefficient = 1
 	slot_flags = SLOT_BELT
-	autoignition_temperature = AUTOIGNITION_METAL
 
 	var/obj/item/device/toner/ink = null
 

--- a/code/game/objects/items/weapons/butterfly.dm
+++ b/code/game/objects/items/weapons/butterfly.dm
@@ -17,7 +17,6 @@
 	throw_range = 6
 	w_type = RECYK_METAL
 	melt_temperature = MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	origin_tech = Tc_MATERIALS + "=3"
 	attack_verb = list("slashes", "stabs", "slices", "tears", "rips", "cuts")
 	var/open = FALSE

--- a/code/game/objects/items/weapons/chisel.dm
+++ b/code/game/objects/items/weapons/chisel.dm
@@ -11,7 +11,6 @@
 	starting_materials = list(MAT_IRON = 120)
 
 	flags = FPRINT
-	autoignition_temperature = AUTOIGNITION_METAL
 	siemens_coefficient = 1
 
 	var/use_name

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -59,7 +59,6 @@
 	throw_range = 15
 	attack_verb = list("HONKS")
 	hitsound = 'sound/items/bikehorn.ogg'
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/honk_delay = 20
 	var/last_honk_time = 0
 	var/vary_pitch = 1

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -17,7 +17,6 @@
 	starting_materials = list(MAT_IRON = 90) // TODO: Check against autolathe.
 	w_type = RECYK_METAL
 	melt_temperature = MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	attack_verb = list("slams", "whacks", "bashes", "thunks", "batters", "bludgeons", "thrashes")
 	var/max_water = 50
 	var/last_use = 1.0

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -14,7 +14,6 @@
 	var/det_time = 5 SECONDS
 	var/armsound = 'sound/weapons/armbomb.ogg'
 	mech_flags = MECH_SCAN_ILLEGAL
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/weapon/grenade/proc/clown_check(var/mob/living/user)
 	if(clumsy_check(user) && prob(50))

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -17,7 +17,6 @@
 	starting_materials = list(MAT_IRON = 500)
 	w_type = RECYK_METAL
 	melt_temperature = MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	origin_tech = Tc_MATERIALS + "=1"
 	toolsounds = list('sound/weapons/handcuffs.ogg')
 	restraint_resist_time = 2 MINUTES

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -9,7 +9,6 @@
 	var/datum/organ/external/part
 	var/allow_reagents = FALSE
 	var/malfunction = NONE
-	autoignition_temperature = AUTOIGNITION_METAL
 
 // return FALSE if the implant fails. In this case the implant is NOT consumed.
 // If you wish to consume the implant, delete it inside `implanted()` instead.

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -7,7 +7,6 @@
 	throw_speed = 1
 	throw_range = 5
 	w_class = W_CLASS_TINY
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/obj/item/weapon/implant/imp
 
 /obj/item/weapon/implantcase/proc/update()

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -29,7 +29,6 @@
 	shrapnel_amount = 1
 	shrapnel_size = 2
 	shrapnel_type = /obj/item/projectile/bullet/shrapnel
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/loaded_food = ""
 	var/image/food_overlay
 	var/food_type
@@ -516,7 +515,6 @@
 	starting_materials = list(MAT_IRON = 3000)
 	w_type = RECYK_METAL
 	melt_temperature = MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/list/carrying = list() // List of things on the tray. - Doohl
 	var/max_carry = 10 // w_class = W_CLASS_TINY -- takes up 1
 					   // w_class = W_CLASS_SMALL -- takes up 3

--- a/code/game/objects/items/weapons/lance.dm
+++ b/code/game/objects/items/weapons/lance.dm
@@ -21,7 +21,6 @@
 
 	slowdown = 3.0 //Very heavy
 	flags = SLOWDOWN_WHEN_CARRIED
-	autoignition_temperature = AUTOIGNITION_METAL
 
 	var/obj/effect/lance_trigger/trigger
 	var/last_used = 0

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -6,7 +6,6 @@
 	heat_production = 3500
 	source_temperature = TEMPERATURE_PLASMA
 	sterility = 0
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/weapon/melee/energy/is_hot()
 	if(active)

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -10,7 +10,6 @@
 	force = 10
 	throwforce = 7
 	w_class = W_CLASS_MEDIUM
-	autoignition_temperature = AUTOIGNITION_METAL
 	origin_tech = Tc_COMBAT + "=4"
 	attack_verb = list("flogs", "whips", "lashes", "disciplines")
 

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -16,7 +16,6 @@
 	starting_materials = list(MAT_IRON = 700, MAT_GLASS = 50)
 	w_type = RECYK_ELECTRONIC
 	melt_temperature = MELTPOINT_STEEL // Rugged
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/rigged = 0		// true if rigged to explode
 	var/minor_fault = 0 //If not 100% reliable, it will build up faults.
 	var/brute_damage = 0 //Used by cyborgs

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -41,7 +41,6 @@
 	desc = "A small wooden shield. Its surface area is small, but it's still somewhat effective."
 	icon_state = "buckler"
 	w_class = W_CLASS_MEDIUM
-	autoignition_temperature = AUTOIGNITION_METAL
 	slot_flags = 0
 	starting_materials = list()
 
@@ -67,7 +66,6 @@
 	name = "roman shield"
 	desc = "Bears an inscription on the inside: <i>\"Romanes venio domus\"</i>."
 	icon_state = "roman_shield"
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/weapon/shield/riot/roman/IsShield()
 	return 1
@@ -96,7 +94,6 @@
 	throw_speed = 1
 	throw_range = 4
 	w_class = W_CLASS_TINY
-	autoignition_temperature = AUTOIGNITION_METAL
 	origin_tech = Tc_MATERIALS + "=4;" + Tc_MAGNETS + "=3;" + Tc_SYNDICATE + "=4"
 	attack_verb = list("shoves", "bashes")
 	var/active = 0
@@ -146,7 +143,6 @@
 	throw_speed = 2
 	throw_range = 10
 	w_class = W_CLASS_SMALL
-	autoignition_temperature = AUTOIGNITION_METAL
 	origin_tech = Tc_MAGNETS + "=3;" + Tc_SYNDICATE + "=4"
 
 
@@ -263,7 +259,6 @@
 	flags = FPRINT | SLOWDOWN_WHEN_CARRIED
 	slowdown = 4
 	w_type = RECYK_METAL
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/weapon/shield/riot/rune
 	name = "rune kiteshield"
@@ -278,7 +273,6 @@
 	throw_speed = 1
 	throw_range = 6
 	w_class = W_CLASS_LARGE
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/weapon/shield/riot/tower/IsShield()
 	return 2 //Considering its size, twice as effective as a normal shield, but difficult to lug around

--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -5,7 +5,6 @@
 	w_class = W_CLASS_SMALL
 	var/rating = 1
 	melt_temperature = MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/weapon/stock_parts/New()
 	. = ..()

--- a/code/game/objects/items/weapons/storage/RPED.dm
+++ b/code/game/objects/items/weapons/storage/RPED.dm
@@ -10,7 +10,6 @@
 	storage_slots = 100
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/misc_tools.dmi', "right_hand" = 'icons/mob/in-hand/right/misc_tools.dmi')
 	display_contents_with_number = TRUE
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/bluespace = FALSE
 
 /obj/item/weapon/storage/bag/gadgets/part_replacer/bluespace

--- a/code/game/objects/items/weapons/storage/bluespace.dm
+++ b/code/game/objects/items/weapons/storage/bluespace.dm
@@ -11,7 +11,6 @@
 	icon_state = "holdingpack"
 	fits_max_w_class = W_CLASS_LARGE
 	max_combined_w_class = 28
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/weapon/storage/backpack/holding/miniblackhole
 	name = "miniature black hole"

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -8,7 +8,6 @@
 	max_combined_w_class = 14 //The sum of the w_classes of all the items in this storage item.
 	storage_slots = 4
 	req_one_access = list(access_armory)
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/locked = 1
 	var/broken = 0
 	var/icon_locked = "lockbox+l"

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -26,7 +26,6 @@
 	w_class = W_CLASS_MEDIUM
 	fits_max_w_class = W_CLASS_SMALL
 	max_combined_w_class = 14
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/weapon/storage/secure/examine(mob/user)
 	..()

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -16,7 +16,6 @@
 	w_type = RECYK_METAL
 	w_class = W_CLASS_LARGE
 	melt_temperature = MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	origin_tech = Tc_COMBAT + "=1"
 	attack_verb = list("robusts", "batters", "staves in")
 	fits_max_w_class = W_CLASS_MEDIUM

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -11,7 +11,6 @@
 	w_class = W_CLASS_MEDIUM
 	origin_tech = Tc_COMBAT + "=2"
 	attack_verb = list("beats")
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/stunforce = 10
 	var/status = 0
 	var/obj/item/weapon/cell/bcell = null

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -7,7 +7,6 @@
 	item_state = "retractor"
 	starting_materials = list(MAT_IRON = 10000, MAT_GLASS = 5000)
 	melt_temperature = MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	w_type = RECYK_METAL
 	flags = FPRINT
 	siemens_coefficient = 1
@@ -43,7 +42,6 @@
 	item_state = "hemostat"
 	starting_materials = list(MAT_IRON = 5000, MAT_GLASS = 2500)
 	w_type = RECYK_METAL
-	autoignition_temperature = AUTOIGNITION_METAL
 	flags = FPRINT
 	siemens_coefficient = 1
 	w_class = W_CLASS_TINY
@@ -75,7 +73,6 @@
 	item_state = "cautery"
 	starting_materials = list(MAT_IRON = 5000, MAT_GLASS = 2500)
 	w_type = RECYK_ELECTRONIC
-	autoignition_temperature = AUTOIGNITION_METAL
 	flags = FPRINT
 	siemens_coefficient = 1
 	w_class = W_CLASS_TINY
@@ -104,7 +101,6 @@
 	toolspeed = 0.6
 	heat_production = 1500
 	source_temperature = TEMPERATURE_PLASMA
-	autoignition_temperature = AUTOIGNITION_METAL
 	sterility = 100
 
 /*
@@ -135,7 +131,6 @@
 	hitsound = 'sound/weapons/circsawhit.ogg'
 	starting_materials = list(MAT_IRON = 15000, MAT_GLASS = 10000)
 	w_type = RECYK_ELECTRONIC
-	autoignition_temperature = AUTOIGNITION_METAL
 	flags = FPRINT
 	siemens_coefficient = 1
 	force = 15.0
@@ -176,7 +171,6 @@
 	throw_range = 5
 	starting_materials = list(MAT_IRON = 10000, MAT_GLASS = 5000)
 	w_type = RECYK_METAL
-	autoignition_temperature = AUTOIGNITION_METAL
 	origin_tech = Tc_MATERIALS + "=1;" + Tc_BIOTECH + "=1"
 	attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "rips", "dices", "cuts")
 	surgerysound = 'sound/items/scalpel.ogg'
@@ -189,7 +183,6 @@
 	item_state = "laserscalpel1"
 	heat_production = 0
 	source_temperature = TEMPERATURE_PLASMA //Even if it's laser based, it depends on plasma
-	autoignition_temperature = AUTOIGNITION_METAL
 	damtype = "fire"
 	sharpness_flags = SHARP_TIP | SHARP_BLADE | HOT_EDGE
 	toolspeed = 0.6
@@ -295,7 +288,6 @@
 	throw_range = 5
 	starting_materials = list(MAT_IRON = 20000, MAT_GLASS = 10000)
 	w_type = RECYK_ELECTRONIC
-	autoignition_temperature = AUTOIGNITION_METAL
 	origin_tech = Tc_MATERIALS + "=1;" + Tc_BIOTECH + "=1"
 	attack_verb = list("attacks", "slashes", "saws", "cuts")
 	surgerysound = 'sound/items/circularsaw.ogg'
@@ -415,7 +407,6 @@
 	attack_verb = list("attacks", "hits", "bludgeons")
 	starting_materials = list(MAT_IRON = 10000, MAT_GLASS = 5000)
 	w_type = RECYK_METAL
-	autoignition_temperature = AUTOIGNITION_METAL
 	origin_tech = Tc_MATERIALS + "=1;" + Tc_BIOTECH + "=1"
 	surgerysound = 'sound/items/bonesetter.ogg'
 
@@ -438,7 +429,6 @@
 	//icon = 'icons/obj/surgery.dmi'
 	icon_state = "stun baton"
 	force = 0
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/weapon/revivalprod/attack(mob/target,mob/user)
 	if(target.lying)

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -16,7 +16,6 @@
 	starting_materials = list(MAT_IRON = 15000)
 	w_type = RECYK_METAL
 	melt_temperature = MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	origin_tech = Tc_MATERIALS + "=5;" + Tc_BLUESPACE + "=3"
 	var/hmodule = null
 	var/index = 0
@@ -219,7 +218,7 @@
 	return TRUE
 
 /obj/item/weapon/switchtool/proc/edit_deploy(var/doedit)
-	if(!deployed) 
+	if(!deployed)
 		return
 	if(doedit) //Makes the deployed item take on the features of the switchtool for attack animations and text. Other bandaid fixes for snowflake issues can go here.
 		sharpness = deployed.sharpness
@@ -229,7 +228,7 @@
 		deployed.overlays = overlays
 		deployed.cant_drop = TRUE
 	//Revert the changes to the deployed item.
-	else 
+	else
 		sharpness = initial(sharpness)
 		deployed.name = initial(deployed.name)
 		deployed.icon = initial(deployed.icon)

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -30,7 +30,6 @@
 	mech_flags = MECH_SCAN_FAIL
 	flags = FPRINT
 	slot_flags = SLOT_BELT
-	autoignition_temperature = AUTOIGNITION_METAL
 	force = 10
 	var/hurt_intent_stun_duration = 0.8 SECONDS
 	var/normal_stun_duration = 0.5 SECONDS
@@ -99,7 +98,6 @@
 	flags = FPRINT
 	slot_flags = SLOT_BELT
 	w_class = W_CLASS_SMALL
-	autoignition_temperature = AUTOIGNITION_METAL
 	force = 3
 	var/on = 0
 
@@ -299,7 +297,6 @@
 	item_state = "grey_sword"
 	force = 4
 	w_type = RECYK_METAL
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/weapon/rsscimmy
 	name = "rune scimitar"
@@ -313,7 +310,6 @@
 	sharpness_flags = SHARP_TIP | SHARP_BLADE
 	force = 25.0
 	w_class = W_CLASS_MEDIUM
-	autoignition_temperature = AUTOIGNITION_METAL
 	throwforce = 15.0
 	throw_speed = 3
 	throw_range = 9
@@ -328,7 +324,6 @@
 	sharpness = 1
 	flags = FPRINT
 	sharpness_flags = SHARP_TIP | SHARP_BLADE
-	autoignition_temperature = AUTOIGNITION_METAL
 	force = 25 //A solid weapon by itself
 	w_class = W_CLASS_LARGE
 	attack_verb = list("slashes", "rips", "dices", "cuts", "attacks", "slices", "tears")

--- a/code/game/objects/items/weapons/table_rack_parts.dm
+++ b/code/game/objects/items/weapons/table_rack_parts.dm
@@ -17,7 +17,6 @@
 	starting_materials = list(MAT_IRON = 3750)
 	w_type = RECYK_METAL
 	melt_temperature=MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	flags = FPRINT
 	siemens_coefficient = 1
 	attack_verb = list("slams", "bashes", "batters", "bludgeons", "thrashes", "whacks")
@@ -181,7 +180,6 @@
 	desc = "Parts of a slightly beveled brass table."
 	icon_state = "brass_tableparts"
 	starting_materials = list(MAT_BRASS = 15000)
-	autoignition_temperature = AUTOIGNITION_METAL
 	table_type = /obj/structure/table/reinforced/clockwork
 	sheet_type = /obj/item/stack/sheet/brass
 	sheet_amount = 4
@@ -213,7 +211,6 @@
 	starting_materials = list(MAT_IRON = 3750)
 	w_type = RECYK_METAL
 	melt_temperature=MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/sheet_amount = 1
 
 /obj/item/weapon/rack_parts/attackby(obj/item/weapon/W, mob/user)

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -7,7 +7,6 @@
 	w_class = W_CLASS_MEDIUM
 	item_state = "jetpack"
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/datum/effect/system/trail/ion_trail
 	var/on = 0.0
 	var/stabilization_on = 0

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -7,7 +7,6 @@
 	flags = FPRINT
 	siemens_coefficient = 1
 	slot_flags = SLOT_BACK
-	autoignition_temperature = AUTOIGNITION_METAL
 
 	pressure_resistance = ONE_ATMOSPHERE*5
 

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -50,7 +50,6 @@
 	starting_materials = list(MAT_IRON = 150)
 	w_type = RECYK_METAL
 	melt_temperature = MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	origin_tech = Tc_MATERIALS + "=1;" + Tc_ENGINEERING + "=1"
 	attack_verb = list("bashes", "batters", "bludgeons", "whacks")
 	toolsounds = list('sound/items/Ratchet.ogg')
@@ -116,7 +115,6 @@
 	starting_materials = list(MAT_IRON = 75)
 	w_type = RECYK_METAL
 	melt_temperature = MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	attack_verb = list("stabs")
 	toolsounds = list('sound/items/Screwdriver.ogg', 'sound/items/Screwdriver2.ogg')
 	surgerysound = 'sound/items/Screwdriver.ogg'
@@ -212,7 +210,6 @@
 	starting_materials = list(MAT_IRON = 80)
 	w_type = RECYK_METAL
 	melt_temperature = MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	origin_tech = Tc_MATERIALS + "=1;" + Tc_ENGINEERING + "=1"
 	attack_verb = list("pinches", "nips at")
 	toolsounds = list('sound/items/Wirecutter.ogg')
@@ -697,7 +694,6 @@
 	starting_materials = list(MAT_IRON = 50)
 	w_type = RECYK_METAL
 	melt_temperature = MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	origin_tech = Tc_ENGINEERING + "=1"
 	attack_verb = list("attacks", "bashes", "batters", "bludgeons", "whacks")
 	toolsounds = list('sound/items/Crowbar.ogg')
@@ -788,7 +784,6 @@
 	w_class = W_CLASS_SMALL
 	w_type = RECYK_MISC
 	origin_tech = Tc_COMBAT + "=2"
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/open = 0
 
 /obj/item/weapon/conversion_kit/New()
@@ -824,7 +819,6 @@
 	starting_materials = list(MAT_IRON = 70, MAT_GLASS = 30)
 	w_type = RECYK_MISC
 	melt_temperature = MELTPOINT_STEEL
-	autoignition_temperature = AUTOIGNITION_METAL
 	origin_tech = Tc_ENGINEERING + "=1"
 	var/max_fuel = 20 	//The max amount of acid stored
 	var/work_speed = 1 //multiplier

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -27,7 +27,6 @@
 	var/has_lockless_type = null //The type this closet should be converted to if made no longer ID secured
 	var/is_wooden = null //used in dismantling cabinet-type closets
 	var/obj/item/weapon/circuitboard/airlock/electronics
-	autoignition_temperature = AUTOIGNITION_METAL
 
 	starting_materials = list(MAT_IRON = 2*CC_PER_SHEET_METAL)
 	w_type = RECYK_METAL

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -11,7 +11,6 @@
 	req_access = null
 	opened = 0
 	flags = FPRINT
-	autoignition_temperature = AUTOIGNITION_METAL
 //	mouse_drag_pointer = MOUSE_ACTIVE_POINTER	//???
 	var/rigged = 0
 	var/sound_effect_open = 'sound/machines/click.ogg'

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -5,7 +5,6 @@
 	icon_state = "densecrate"
 	density = 1
 	flags = FPRINT
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/structure/largecrate/attack_hand(mob/user as mob)
 	to_chat(user, "<span class='notice'>You need a crowbar to pry this open!</span>")

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -69,7 +69,6 @@
 	flags = FPRINT
 	body_parts_covered = HEAD|EYES
 	light_power = 0.5
-	autoignition_temperature = AUTOIGNITION_METAL
 	var/onfire = 0.0
 	var/status = 0
 	var/fire_resist = T0C+1300	//this is the max temp it can stand before you start to cook. although it might not burn away, you take damage

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -8,7 +8,6 @@
 	species_fit = list(VOX_SHAPED, INSECT_SHAPED)
 	footprint_type = /obj/effect/decal/cleanable/blood/tracks/footprints/magboots
 	w_class = W_CLASS_LARGE
-	autoignition_temperature = AUTOIGNITION_METAL
 
 	var/stomp_attack_power = 45
 	var/stomp_delay = 3 SECONDS

--- a/code/modules/trader/crates/alcatrazfour.dm
+++ b/code/modules/trader/crates/alcatrazfour.dm
@@ -329,7 +329,6 @@ var/global/list/alcatraz_stuff = list(
 	name = "warden's spare secway key"
 	desc = "It has a tag that reads:"
 	var/home_map
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/key/security/spare/New()
 	..()
@@ -348,7 +347,6 @@ var/global/list/alcatraz_stuff = list(
 	icon_state = "telebaton_1"
 	item_state = "telebaton_1"
 	w_class = W_CLASS_SMALL
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/weapon/depocket_wand/attack(mob/living/M, mob/living/user)
 
@@ -450,7 +448,7 @@ var/global/list/alcatraz_stuff = list(
 										"Try again when you can relate to the intoxicating taste of blood.",
 										"What is a man? A miserable little pile of soft drinks.",
 										"You mortals all look underage to me. Pray tell, can you even manage a bottle?",
-										"Bah. You mock Le Confrérie des Chevaliers du Tastevin with your plebian visage.",
+										"Bah. You mock Le Confrï¿½rie des Chevaliers du Tastevin with your plebian visage.",
 										"I will not associate with any less than an iron liver.",
 										"You dare ask my service when you cannot even hold your liquor?")
 			to_chat(user,"<B>[src]</B> [pick("murmurs","insults","mocks","groans","complains")], \"<span class='sinister'>[pick(reject_phrases)]</span>\"")

--- a/code/modules/trader/crates/cloudnine.dm
+++ b/code/modules/trader/crates/cloudnine.dm
@@ -162,7 +162,6 @@ var/list/decelerators = list()
 /obj/item/weapon/am_containment/decelerator
 	name = "antimatter decelerator"
 	desc = "Acts as a 'filter' to trap antiparticles emitted by radiation. In function, it can be used to power an antimatter engine and refuel itself with nearby radiation."
-	autoignition_temperature = AUTOIGNITION_METAL
 
 /obj/item/weapon/am_containment/decelerator/New()
 	..()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Removes the autoignition_temperature var from all items which previously had AUTOIGNITION_METAL assigned to it. Additionally, removes the null AUTOIGNITION_METAL constant.

## Why it's good
<!-- Explain why you think these changes are good. -->
As mentioned in a previous PR, metal only ignites under very specific conditions of which I don't plan to ever simulate. These are just useless lines of code causing clutter.
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscdel: Removed unused autoignition vars.
