### PR TITLE
Standard gym rats can no longer force doors

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
@@ -131,11 +131,9 @@
 	if(maxHealth < 60)
 		melee_damage_lower = 1
 		melee_damage_upper = 5
-		environment_smash_flags &= ~OPEN_DOOR_STRONG
 	else
 		melee_damage_lower = 5
 		melee_damage_upper = 10
-		environment_smash_flags |= OPEN_DOOR_STRONG
 
 /mob/living/simple_animal/hostile/retaliate/gym_rat/Life() // Copied from hammy wheel running code
 	if(timestopped)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request [tweak]-->

## What this does
Standard gym rats can no longer open doors, with pompadour rats and roid rats keeping that ability.
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Why it's good
Gym rats can rather easily form groups, and I don't think something with more health & melee damage than a player should be able to instantly force open any door, because at that point they can go wherever they want - even more places than normal rats, because even though they've lost the ability to ventcrawl, they can now go places that don't even have vents. I left in the ability for pompadour rats to force doors because it can play into the idea of pomp-rats being "leaders", forcing doors and letting their boys move in. Roid rats keep the ability because they're rarer and swole as fuck.
<!-- Explain why you think these changes are good. -->

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Standard gym rats can no longer force any doors.