### PR TITLE
Adds scrying orbs and magic mirrors to wizard dens for all maps

### DIFF
--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -23125,6 +23125,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
+"boo" = (
+/obj/structure/wizard/scrying,
+/turf/unsimulated/floor{
+	dir = 8;
+	icon_state = "wood"
+	},
+/area/wizard_station)
 "bop" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/plating,
@@ -363885,7 +363892,7 @@ dty
 dty
 dty
 dzN
-dBd
+boo
 dBd
 dBd
 dBd


### PR DESCRIPTION
## Why it's good
Some maps have them, some don't. Fixes this consistency issue so you're not disadvantaged on some maps.
Requested by @PrimeDSS13 
Closes #33505
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Wizard dens on all maps now have access to a magic mirror and a scrying orb.
