### PR TITLE
Xenoarch digsite scanner tweaks

### DIFF
--- a/code/modules/research/xenoarchaeology/tools/tools_digsitelocator.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_digsitelocator.dm
@@ -33,16 +33,28 @@
 		playtoolsound(src, 50)
 		for(var/turf/unsimulated/mineral/M in range(7, user))
 			if(M.finds.len)
-				var/datum/find/F = M.finds[1]
-				var/image/I = image('icons/turf/mine_overlays.dmi', loc = M, icon_state = "find_overlay[pick("1","2","3")]", layer = UNDER_HUD_LAYER)
-				I.color = color_from_find_reagent[F.responsive_reagent]
-				I.plane = HUD_PLANE
-				C.images += I
+				var/n = 0
+				var/list/image/IS = list()
+				var/totalfinds = M.finds.len
+				for(var/datum/find/F in M.finds)
+					n++
+					var/image/I = image('icons/turf/mine_overlays.dmi', loc = M, icon_state = "find_overlay[pick("1","2","3")]", layer = UNDER_HUD_LAYER)
+					IS.Add(I)
+					I.color = color_from_find_reagent[F.responsive_reagent]
+					I.plane = HUD_PLANE
+					var/matrix/TR = matrix()
+					TR.Scale(((totalfinds + 1) - n) / totalfinds, ((totalfinds + 1) - n) / totalfinds)
+					I.transform = TR
+					var/list/col = rgb2num(I.color)
+					I.filters = filter(type="outline",color=rgb(255-col[1],255-col[2],255-col[3]))
+					C.images += I
 				spawn(1 SECONDS)
-					animate(I, alpha = 0, time = 4 SECONDS)
+					for(var/image/I in IS)
+						animate(I, alpha = 0, time = 4 SECONDS)
 				spawn(5 SECONDS)
-					if(C)
-						C.images -= I
+					for(var/image/I in IS)
+						if(C)
+							C.images -= I
 			if (adv && M.artifact_find)
 				var/image/I = image('icons/turf/mine_overlays.dmi', loc = M, icon_state = "artifact_overlay", layer = UNDER_HUD_LAYER)
 				I.plane = HUD_PLANE

--- a/code/modules/research/xenoarchaeology/tools/tools_digsitelocator.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_digsitelocator.dm
@@ -42,11 +42,12 @@
 					IS.Add(I)
 					I.color = color_from_find_reagent[F.responsive_reagent]
 					I.plane = HUD_PLANE
-					var/matrix/TR = matrix()
-					TR.Scale(((totalfinds + 1) - n) / totalfinds, ((totalfinds + 1) - n) / totalfinds)
-					I.transform = TR
-					var/list/col = rgb2num(I.color)
-					I.filters = filter(type="outline",color=rgb(255-col[1],255-col[2],255-col[3]))
+					if(n > 1)
+						var/matrix/TR = matrix()
+						TR.Scale(((totalfinds + 1) - n) / totalfinds, ((totalfinds + 1) - n) / totalfinds)
+						I.transform = TR
+						var/list/col = rgb2num(I.color)
+						I.filters = filter(type="outline",color=rgb(255-col[1],255-col[2],255-col[3]))
 					C.images += I
 				spawn(1 SECONDS)
 					for(var/image/I in IS)

--- a/code/modules/research/xenoarchaeology/tools/tools_digsitelocator.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_digsitelocator.dm
@@ -1,6 +1,6 @@
 /obj/item/device/xenoarch_scanner
 	name = "xenoarchaeological digsite locator"
-	desc = "A scanner that checks the surrounding area for potential xenoarch digsites. If it finds any, It will briefly make them visible. Requires mesons for optimal use."
+	desc = "A scanner that scans the surrounding area for potential xenoarch digsites, highlighting them temporarily in a colour associated with their responsive reagent. Requires mesons for optimal use."
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "digsitelocator"
 	item_state  = "analyzer"
@@ -15,10 +15,10 @@
 /obj/item/device/xenoarch_scanner/adv
 	name = "advanced xenoarchaeological digsite locator"
 	icon_state = "digsitelocator_adv"
-	desc = "A scanner that scans the surrounding area for potential xenoarch digsites, highlighting them temporarily in a colour associated with their responsive reagent. Requires mesons for optimal use."
+	desc = "A scanner that scans the surrounding area for potential xenoarch digsites, highlighting them temporarily in a colour associated with their responsive reagent, along with a flashing red circle mark for larger artifacts. Requires mesons for optimal use."
 	adv = TRUE
 
-/obj/item/device/xenoarch_scanner/adv/examine(mob/user)
+/obj/item/device/xenoarch_scanner/examine(mob/user)
 	..()
 	to_chat(user, "<span class = 'notice'>It has a list of colour codes:</span>")
 	for(var/i in color_from_find_reagent)

--- a/code/modules/research/xenoarchaeology/tools/tools_digsitelocator.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_digsitelocator.dm
@@ -38,7 +38,7 @@
 				var/totalfinds = M.finds.len
 				for(var/datum/find/F in M.finds)
 					n++
-					var/image/I = image('icons/turf/mine_overlays.dmi', loc = M, icon_state = "find_overlay[pick("1","2","3")]", layer = UNDER_HUD_LAYER)
+					var/image/I = image('icons/turf/mine_overlays.dmi', loc = M, icon_state = "find_overlay[rand(1,3)]", layer = UNDER_HUD_LAYER)
 					IS.Add(I)
 					I.color = color_from_find_reagent[F.responsive_reagent]
 					I.plane = HUD_PLANE


### PR DESCRIPTION
[tweak]

## What this does
 * moves the advanced one's extra description stuff to all of them since the color stuff applies to them all nowadays.
 * updates the item descriptions to match this and also describe what the advanced one does better. 
![image](https://user-images.githubusercontent.com/87321915/195962520-ccf5154c-8969-45cd-8f02-653e598be420.png)
 * adds any finds hidden behind the main one as a smaller overlay with a luminosity inverted outline to distinguish it, half in size for the 2nd in a pair of two, and 2/3rds and 1/3rd in size for the respective last two in a pair of three. (dunno if i should lock this behind the advanced one at all)

## Why it's good
more visual cue that there's more than one find

## Changelog
:cl:
 * rscadd: Xenoarchaeology digsite locators now show all small finds on a mine turf.
 * tweak: Xenoarchaeology digsite locators no longer need to be advanced to show the color keys on examination.
 * tweak: The descriptions of both basic and advanced xenoarchaeology digsite locators have been updated to match their current usages.