### PR TITLE
Wage payouts to virtual wallets

### DIFF
--- a/SQL/players2.sql
+++ b/SQL/players2.sql
@@ -20,6 +20,7 @@ CREATE TABLE players (
     disabilities        INTEGER,
     nanotrasen_relation TEXT,
     bank_security 		INTEGER,
+    wage_ratio  		INTEGER,
     UNIQUE ( player_ckey, player_slot )
 );
 

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -439,9 +439,10 @@ var/global/datum/controller/occupations/job_master
 		var/balance_wallet = rand(100,250)
 		var/bank_pref_number = H.client.prefs.bank_security
 		var/bank_pref = bank_security_num2text(bank_pref_number)
+		var/pref_wage_ratio = H.client.prefs.wage_ratio
 		if(centcomm_account_db)
 			var/wage = job.get_wage()
-			var/datum/money_account/M = create_account(H.real_name, balance_bank, null, wage_payout = wage, security_pref = bank_pref_number)
+			var/datum/money_account/M = create_account(H.real_name, balance_bank, null, wage_payout = wage, security_pref = bank_pref_number, ratio_pref = pref_wage_ratio)
 
 			if (joined_late)
 				latejoiner_allowance += wage + round(wage/10)

--- a/code/game/machinery/ATM.dm
+++ b/code/game/machinery/ATM.dm
@@ -252,6 +252,7 @@ log transactions
 							<A href='?src=\ref[src];choice=view_screen;view_screen=1'>Change account security level</a><br>
 							<A href='?src=\ref[src];choice=view_screen;view_screen=2'>Make transfer to another bank account</a><br>
 							<A href='?src=\ref[src];choice=view_screen;view_screen=3'>View transaction log</a><br>
+							<A href='?src=\ref[src];choice=wage_percent'>Change virtual wallet wage payout percentage</a><br>
 							<A href='?src=\ref[src];choice=balance_statement'>Print balance statement</a><br>
 							<A href='?src=\ref[src];choice=create_debit_card'>Print new debit card ($5)</a><br>
 							<A href='?src=\ref[src];choice=toggle_account'>Toggle account status</a><br>
@@ -283,6 +284,12 @@ log transactions
 				if(authenticated_account && linked_db && authenticated_account.disabled < 2)
 					authenticated_account.disabled = !authenticated_account.disabled
 					to_chat(usr, "[bicon(src)]<span class='info'>Account [authenticated_account.disabled ? "disabled" : "enabled"].</span>")
+			if("wage_percent")
+				if(authenticated_account && linked_db && authenticated_account.disabled < 2)
+					var/new_wage_ratio = input(usr, "Input what % of wages end up in virtual wallets, from 0-100", "Wage Percentage",authenticated_account.virtual_wallet_wage_ratio) as num
+					if(!isnull(new_wage_ratio))
+						new_wage_ratio = clamp(new_wage_ratio,0,100)
+						authenticated_account.virtual_wallet_wage_ratio = new_wage_ratio
 			if("transfer")
 				if(CAN_INTERACT_WITH_ACCOUNT)
 					var/transfer_amount = text2num(href_list["funds_amount"])

--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -58,7 +58,7 @@ var/latejoiner_allowance = 0//Added to station_allowance and reset before every 
 //the current ingame time (hh:mm) can be obtained by calling:
 //worldtime2text()
 
-/proc/create_account(var/new_owner_name = "Default user", var/starting_funds = 0, var/obj/machinery/account_database/source_db, var/wage_payout = 0, var/security_pref = 1, var/makehidden = FALSE, var/isStationAccount = TRUE)
+/proc/create_account(var/new_owner_name = "Default user", var/starting_funds = 0, var/obj/machinery/account_database/source_db, var/wage_payout = 0, var/security_pref = 1, var/ratio_pref = 0.5, var/makehidden = FALSE, var/isStationAccount = TRUE)
 
 	//create a new account
 	var/datum/money_account/M = new()
@@ -68,6 +68,7 @@ var/latejoiner_allowance = 0//Added to station_allowance and reset before every 
 	M.wage_gain = wage_payout
 	M.security_level = security_pref
 	M.hidden = makehidden
+	M.virtual_wallet_wage_ratio = ratio_pref
 
 	var/ourdate = ""
 	var/ourtime = ""
@@ -130,6 +131,7 @@ var/latejoiner_allowance = 0//Added to station_allowance and reset before every 
 							//1 - require manual login / account number and pin
 							//2 - require card and manual login
 	var/virtual = 0
+	var/virtual_wallet_wage_ratio = 50
 	var/wage_gain = 0 // How much an account gains per 'wage' tick.
 	var/disabled = 0
 	var/hidden = FALSE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -198,6 +198,7 @@ var/const/MAX_SAVE_SLOTS = 16
 
 	var/nanotrasen_relation = "Neutral"
 	var/bank_security = 1			//for bank accounts, 0-2, no-pin,pin,pin&card
+	var/wage_ratio = 50
 
 
 	// 0 = character settings, 1 = game preferences
@@ -321,6 +322,7 @@ var/const/MAX_SAVE_SLOTS = 16
 	<b>Character records:</b>
 	[jobban_isbanned(user, "Records") ? "Banned" : "<a href=\"byond://?src=\ref[user];preference=records;record=1\">Set</a>"]<br>
 	<b>Bank account security preference:</b><a href ='?_src_=prefs;preference=bank_security;task=input'>[bank_security_num2text(bank_security)]</a> <br>
+	<b>Percent of wages sent to ID virtual wallet:</b><a href ='?_src_=prefs;preference=wage_ratio;task=input'>[wage_ratio]</a> <br>
 	</td><td valign='top' width='21%'>
 	<h3>Hair Style</h3>
 	<a href='?_src_=prefs;preference=h_style;task=input'>[h_style]</a><BR>
@@ -1111,6 +1113,12 @@ var/const/MAX_SAVE_SLOTS = 16
 					var/new_bank_security = input(user, BANK_SECURITY_EXPLANATION, "Character Preference")  as null|anything in bank_security_text2num_associative
 					if(!isnull(new_bank_security))
 						bank_security = bank_security_text2num_associative[new_bank_security]
+
+				if("wage_ratio")
+					var/new_wage_ratio = input(user, "Input what % of wages end up in virtual wallets, from 0-100", "Character Preference",wage_ratio) as num
+					if(!isnull(new_wage_ratio))
+						new_wage_ratio = clamp(new_wage_ratio,0,100)
+						wage_ratio = new_wage_ratio
 
 				if("flavor_text")
 					flavor_text = input(user,"Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!","Flavor Text",html_decode(flavor_text)) as message

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -208,6 +208,7 @@ SELECT
     players.disabilities,
     players.nanotrasen_relation,
     players.bank_security,
+    players.wage_ratio,
     jobs.player_ckey,
     jobs.player_slot,
     jobs.alternate_option,
@@ -291,6 +292,7 @@ AND players.player_slot = ? ;"}, ckey, slot)
 	disabilities		= text2num(preference_list["disabilities"])
 	nanotrasen_relation	= preference_list["nanotrasen_relation"]
 	bank_security 		= preference_list["bank_security"]
+	wage_ratio	 		= preference_list["wage_ratio"]
 
 	r_hair				= text2num(preference_list["hair_red"])
 	g_hair				= text2num(preference_list["hair_green"])
@@ -341,8 +343,12 @@ AND players.player_slot = ? ;"}, ckey, slot)
 		nanotrasen_relation = initial(nanotrasen_relation)
 	if(isnull(bank_security))
 		bank_security = initial(bank_security)
+	if(isnull(wage_ratio))
+		wage_ratio = initial(wage_ratio)
 	if(!real_name)
 		real_name = random_name(gender,species)
+	wage_ratio = clamp(wage_ratio,0,100)
+
 	be_random_name	= sanitize_integer(be_random_name, 0, 1, initial(be_random_name))
 	be_random_body	= sanitize_integer(be_random_body, 0, 1, initial(be_random_body))
 	gender			= sanitize_gender(gender)
@@ -432,17 +438,17 @@ AND players.player_slot = ? ;"}, ckey, slot)
 	check.Add("SELECT player_ckey FROM players WHERE player_ckey = ? AND player_slot = ?", ckey, slot)
 	if(check.Execute(db))
 		if(!check.NextRow())
-			q.Add("INSERT INTO players (player_ckey,player_slot,ooc_notes,real_name, random_name,    gender, age, species, language, flavor_text, med_record, sec_record, gen_record, player_alt_titles, disabilities, nanotrasen_relation, bank_security, random_body)\
-			                    VALUES (?,          ?,          ?,        ?,         ?,              ?,      ?,   ?,       ?,        ?,           ?,          ?,          ?,          ?,                 ?,            ?,                   ?,             ?)",
-			                            ckey,       slot,       metadata, real_name, be_random_name, gender, age, species, language, flavor_text, med_record, sec_record, gen_record, altTitles,         disabilities, nanotrasen_relation, bank_security, be_random_body)
+			q.Add("INSERT INTO players (player_ckey,player_slot,ooc_notes,real_name, random_name,    gender, age, species, language, flavor_text, med_record, sec_record, gen_record, player_alt_titles, disabilities, nanotrasen_relation, bank_security, wage_ratio, random_body)\
+			                    VALUES (?,          ?,          ?,        ?,         ?,              ?,      ?,   ?,       ?,        ?,           ?,          ?,          ?,          ?,                 ?,            ?,                   ?,             ?,          ?)",
+			                            ckey,       slot,       metadata, real_name, be_random_name, gender, age, species, language, flavor_text, med_record, sec_record, gen_record, altTitles,         disabilities, nanotrasen_relation, bank_security, wage_ratio, be_random_body)
 			if(!q.Execute(db))
 				message_admins("Error in save_character_sqlite [__FILE__] ln:[__LINE__] #:[q.Error()] - [q.ErrorMsg()]")
 				WARNING("Error in save_character_sqlite [__FILE__] ln:[__LINE__] #:[q.Error()] - [q.ErrorMsg()]")
 				return 0
 			to_chat(user, "Created Character")
 		else
-			q.Add("UPDATE players SET ooc_notes=?,real_name=?,random_name=?,  gender=?,age=?,species=?,language=?,flavor_text=?,med_record=?,sec_record=?,gen_record=?,player_alt_titles=?,disabilities=?,nanotrasen_relation=?,bank_security=?,random_body=?   WHERE player_ckey = ? AND player_slot = ?",\
-									  metadata,   real_name,  be_random_name, gender,  age,  species,  language,  flavor_text,  med_record,  sec_record,  gen_record,  altTitles,          disabilities,  nanotrasen_relation,  bank_security,  be_random_body,       ckey,               slot)
+			q.Add("UPDATE players SET ooc_notes=?,real_name=?,random_name=?,  gender=?,age=?,species=?,language=?,flavor_text=?,med_record=?,sec_record=?,gen_record=?,player_alt_titles=?,disabilities=?,nanotrasen_relation=?,bank_security=?,wage_ratio=?,random_body=?   WHERE player_ckey = ? AND player_slot = ?",\
+									  metadata,   real_name,  be_random_name, gender,  age,  species,  language,  flavor_text,  med_record,  sec_record,  gen_record,  altTitles,          disabilities,  nanotrasen_relation,  bank_security,  wage_ratio,  be_random_body,       ckey,               slot)
 			if(!q.Execute(db))
 				message_admins("Error in save_character_sqlite [__FILE__] ln:[__LINE__] #:[q.Error()] - [q.ErrorMsg()]")
 				WARNING("Error in save_character_sqlite [__FILE__] ln:[__LINE__] #:[q.Error()] - [q.ErrorMsg()]")

--- a/code/modules/migrations/SS13_Prefs/001-create.dm
+++ b/code/modules/migrations/SS13_Prefs/001-create.dm
@@ -24,6 +24,7 @@
 	`disabilities`			INTEGER,
 	`nanotrasen_relation`	TEXT,
 	`bank_security`			INTEGER,
+	`wage_ratio`			INTEGER,
 	UNIQUE(player_ckey, player_slot)
 );"}
 	if(!hasTable("players"))

--- a/code/modules/migrations/SS13_Prefs/029-wage-ratio.dm
+++ b/code/modules/migrations/SS13_Prefs/029-wage-ratio.dm
@@ -1,0 +1,13 @@
+/datum/migration/sqlite/ss13_prefs/_029
+	id = 29
+	name = "Wage Ratio"
+
+/datum/migration/sqlite/ss13_prefs/_029/up()
+	if(!hasColumn("players", "wage_ratio"))
+		return execute("ALTER TABLE `players` ADD COLUMN wage_ratio")
+	return TRUE
+
+/datum/migration/sqlite/ss13_prefs/_029/down()
+	if(hasColumn("players", "wage_ratio"))
+		return execute("ALTER TABLE `players` DROP COLUMN wage_ratio")
+	return TRUE

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1762,6 +1762,7 @@
 #include "code\modules\migrations\SS13_Prefs\026-add-fps.dm"
 #include "code\modules\migrations\SS13_Prefs\027-refactor-jobs.dm"
 #include "code\modules\migrations\SS13_Prefs\028-headset-sounds.dm"
+#include "code\modules\migrations\SS13_Prefs\029-wage-ratio.dm"
 #include "code\modules\migrations\SS13_Prefs\_base.dm"
 #include "code\modules\mining\abandonedcrates.dm"
 #include "code\modules\mining\debug_shit.dm"


### PR DESCRIPTION
[content][tweak]

## What this does
allows players to set how much of their wages they want sent to their ID's virtual wallet on payouts instead of the bank account, in % of wages defaulting to 50, in character setup. can also be changed at ATMs in-game
also adds sanity for cases where players have more than one ID with a virtual wallet tied to their account, any money directed to virtual wallets is equally split between all these IDs

## Why it's good
gives more use for virtual wallets, saves hassle of transferring new wages from ATMs

## Changelog
:cl:
 * rscadd: Nanotrasen wage payouts can now be configured to be sent directly to virtual wallets at ATMs, in percentage of wages.