### PR TITLE
Remove an invalid string macro

### DIFF
--- a/code/game/turfs/unsimulated/snow.dm
+++ b/code/game/turfs/unsimulated/snow.dm
@@ -234,7 +234,7 @@
 				break
 			if(!found_on_ground)
 				qdel(W)
-			user.visible_message("<span class='notice'>[user] finishes \the log wall.</span>", \
+			user.visible_message("<span class='notice'>[user] finishes the log wall.</span>", \
 						"<span class='notice'>You finish the log wall.</span>")
 			var/turf/simulated/wall/X = ChangeTurf(/turf/simulated/wall/mineral/wood/log)
 			if(X)


### PR DESCRIPTION
Right now OpenDream errors on a lot of bad DM that BYOND silently ignores. I haven't done a full OpenDream cleanup pass on /vg/ yet to fix all of that bad DM, but this one specifically came up in https://github.com/wixoaGit/OpenDream/issues/847 and I'm tired of dealing with OpenDream bug reports for every imaginable issue in /vg/.