### PR TITLE
Fixes some erroneous string macros

### DIFF
--- a/code/modules/games/cards/une/une_cards.dm
+++ b/code/modules/games/cards/une/une_cards.dm
@@ -47,7 +47,7 @@
 
 /obj/item/toy/singlecard/une
 	name = "une card"
-	desc = "\a card."
+	desc = "a card."
 	icon = 'icons/obj/une_cards.dmi'
 	icon_state = "unecard_down"
 	var/image/unecardimg

--- a/code/modules/games/cards/une/une_cards.dm
+++ b/code/modules/games/cards/une/une_cards.dm
@@ -47,7 +47,7 @@
 
 /obj/item/toy/singlecard/une
 	name = "une card"
-	desc = "a card."
+	desc = "A card."
 	icon = 'icons/obj/une_cards.dmi'
 	icon_state = "unecard_down"
 	var/image/unecardimg

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cluwne.dm
@@ -101,7 +101,7 @@
 		return
 	if(ismob(AM))
 		var/mob/M = AM
-		to_chat(src, "<span class='danger'>You are too depressed to push [M] out of \the way.</span>")
+		to_chat(src, "<span class='danger'>You are too depressed to push [M] out of the way.</span>")
 		M.LAssailant = src
 		M.assaulted_by(src)
 		return

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/faguette.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/faguette.dm
@@ -54,7 +54,7 @@
 		return
 	if(ismob(AM))
 		var/mob/M = AM
-		to_chat(src, "<span class='danger'>You are too depressed to push [M] out of \the way.</span>")
+		to_chat(src, "<span class='danger'>You are too depressed to push [M] out of the way.</span>")
 		M.LAssailant = src
 		M.assaulted_by(src)
 		return


### PR DESCRIPTION
This fixes some erroneous uses of `\the` and `\a` that apparently cause silent errors in BYOND. 
See #33542
