### PR TITLE
Cricket dead icon hotfix

### DIFF
--- a/code/modules/mob/living/simple_animal/cricket.dm
+++ b/code/modules/mob/living/simple_animal/cricket.dm
@@ -6,7 +6,7 @@
 
 	icon_state = "cricket"
 	icon_living = "cricket"
-	icon_dead = "cricket-dead"
+	icon_dead = "cricket_dead"
 
 	emote_hear = list("chirps")
 	emote_sound = list("sound/effects/cricket_chirp.ogg")


### PR DESCRIPTION
It used "cricket-dead" instead of "cricket_dead"
[hotfix][sprites]
:cl:
 * bugfix: Fixed broken icon for dead (not crushed) crickets.