### PR TITLE
Fire alarm sound fixes

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1186,6 +1186,8 @@ FIRE ALARM
 	var/buildstage = 2 // 2 = complete, 1 = no wires,  0 = circuit gone
 	var/shelter = 1
 	var/alarm = 0
+	var/last_alarm_time = 0
+	var/alarm_delay = 10 SECONDS
 
 /obj/machinery/firealarm/empty
 	shelter = 0
@@ -1444,16 +1446,19 @@ FIRE ALARM
 	alarm = 0
 
 /obj/machinery/firealarm/proc/alarm()
-	if (!( src.working ))
+	if (!( src.working ) || alarm || (stat & (NOPOWER|BROKEN|FORCEDISABLE)))
 		return
 	var/area/this_area = get_area(src)
 	this_area.firealert()
 	update_icon()
 	alarm = 1
+	if(world.time - last_alarm_time < alarm_delay)
+		return
 	if(emagged)
 		playsound(src, 'sound/misc/imperial_alert.ogg', 75, 0, 5)
 	else
 		playsound(src, 'sound/misc/fire_alarm.ogg', 75, 0, 5)
+	last_alarm_time = world.time
 
 var/global/list/firealarms = list() //shrug
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- Fixes unpowered fire alarms from making sounds
- Adds a 10 second cooldown between sounds firing so basketball players can no longer spam it

## Why it's good
<!-- Explain why you think these changes are good. -->
Feels better on the ears

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fire alarm sounds can no longer be spammed.
 * bugfix: Fire alarm sounds will no longer fire if unpowered.
 
[bugfix]
