### PR TITLE
Trophy Meats crate buff.

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1373,6 +1373,8 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
 					/obj/item/weapon/reagent_containers/food/snacks/meat/diona,
 					/obj/item/weapon/reagent_containers/food/snacks/meat/crabmeat,
+					/obj/item/weapon/reagent_containers/food/snacks/meat/rawchicken/raw_vox_chicken,
+					/obj/item/weapon/reagent_containers/food/snacks/meat/nymphmeat,
 					/obj/item/weapon/reagent_containers/food/snacks/meat/polyp,
 					/obj/item/weapon/reagent_containers/food/snacks/meat/cricket,
 					/obj/item/weapon/reagent_containers/food/snacks/meat/roach,

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1359,8 +1359,8 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	access = list(access_kitchen)
 	group = "Hospitality"
 
-/datum/supply_packs/randomised/trophy_meats
-	name = "Trophy meats"
+/datum/supply_packs/randomised/assorted_meats
+	name = "Assorted meats"
 	num_contained = 8
 	contains = list(/obj/item/weapon/reagent_containers/food/snacks/meat/mimic,
 					/obj/item/weapon/reagent_containers/food/snacks/meat/bearmeat,
@@ -1379,7 +1379,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/food/snacks/meat/roach/big)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/basic
-	containername = "trophy meats crate"
+	containername = "assorted meats crate"
 	access = list(access_kitchen)
 	group = "Hospitality"
 

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1372,7 +1372,11 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg,
 					/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
 					/obj/item/weapon/reagent_containers/food/snacks/meat/diona,
-					/obj/item/weapon/reagent_containers/food/snacks/meat/crabmeat)
+					/obj/item/weapon/reagent_containers/food/snacks/meat/crabmeat,
+					/obj/item/weapon/reagent_containers/food/snacks/meat/polyp,
+					/obj/item/weapon/reagent_containers/food/snacks/meat/cricket,
+					/obj/item/weapon/reagent_containers/food/snacks/meat/roach,
+					/obj/item/weapon/reagent_containers/food/snacks/meat/roach/big)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/basic
 	containername = "trophy meats crate"


### PR DESCRIPTION
## What this does
Adds cockroach, cricket, mutated cockroach, nymph, vox chicken and polyp meat to the trophy meat crates' randomized selection list.
## Why it's good
Easier access to rare meats for dishes is good.
:cl:
 * rscadd: Trophy meats crate can now have cockroach, mutated cockroach, cricket, nymph, vox chicken and polyp meat.
 * tweak: Renames the "Trophy meats" crate to "Assorted meats".