### PR TITLE
Immovable Pillars (big rods) can no longer randomly hit the station.

### DIFF
--- a/code/modules/events/immovablerod.dm
+++ b/code/modules/events/immovablerod.dm
@@ -15,8 +15,6 @@ var/list/all_rods = list()
 	return 0
 
 /datum/event/immovable_rod/big/can_start(var/list/active_with_role)
-	if(active_with_role["Engineer"] > 2)
-		return 15
 	return 0
 
 /datum/event/immovable_rod/hyper/can_start(var/list/active_with_role)


### PR DESCRIPTION
rods come in three flavors of intensity - rod, pillar, monolith
monoliths are already bus only but pillars aren't, despite them being very destructive

frankly I think this event is terrible and I would rather remove it but its a classic I guess.

:cl:

* rscdel: Immovable Pillars can no longer hit the station. 
