### PR TITLE
Emags and Glue bundle tweak.

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -351,8 +351,8 @@
 /obj/item/weapon/storage/box/syndie_kit/emags_and_glue/ //Exactly what it sounds like.
 	name = "box (E&G)"
 	items_to_spawn = list(
-		/obj/item/weapon/glue = 4,
-		/obj/item/weapon/card/emag = 4,
+		/obj/item/weapon/glue = 3,
+		/obj/item/weapon/card/emag = 3,
 	)
 
 //Syndicate Ayy Lmao Gear

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -352,7 +352,7 @@
 	name = "box (E&G)"
 	items_to_spawn = list(
 		/obj/item/weapon/glue = 4,
-		/obj/item/weapon/card/emag = 3,
+		/obj/item/weapon/card/emag = 4,
 	)
 
 //Syndicate Ayy Lmao Gear


### PR DESCRIPTION
Kinda weird that you get 4 glues but only 3 emags.
## What this does
You now get equal amounts of glue and emags (3 and 3)
## Why it's good
Consistency good

:cl:
 * tweak: Emags and Glue syndicate bundle now has equal amounts of emags and glue (3 of each).