### PR TITLE
Adjusted quick equip

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -43,6 +43,7 @@ var/global/msg_id = 0
 
 	var/obj/item/device/paicard/pai = null	// A slot for a personal AI device
 	var/obj/item/weapon/photo/photo = null	// A slot for a photo
+	var/obj/item/weapon/pen/pen = null	// A slot for a pen
 
 	var/MM = null
 	var/DD = null
@@ -78,7 +79,7 @@ var/global/msg_id = 0
 		// PDA being given out to people during the cuck cube
 		if(ticker && ticker.current_state >= GAME_STATE_SETTING_UP)
 			cartridge.initialize()
-	new /obj/item/weapon/pen(src)
+	pen = new /obj/item/weapon/pen(src)
 	MM = text2num(time2text(world.timeofday, "MM")) 	// get the current month
 	DD = text2num(time2text(world.timeofday, "DD")) 	// get the day
 
@@ -360,13 +361,13 @@ var/global/msg_id = 0
 		to_chat(user, "<span class='notice'>You are too far away.</span>")
 		return FALSE
 
-	var/obj/item/weapon/pen/O = locate() in src
-	if(!O)
+	if(!pen)
 		to_chat(user, "<span class='notice'>This PDA does not have a pen in it.</span>")
 		return FALSE
 
-	user.put_in_hands(O)
-	to_chat(user, "<span class='notice'>You remove \the [O] from \the [src].</span>")
+	user.put_in_hands(pen)
+	to_chat(user, "<span class='notice'>You remove \the [pen] from \the [src].</span>")
+	pen = null
 	return TRUE
 
 
@@ -452,13 +453,10 @@ var/global/msg_id = 0
 			photo = C
 			to_chat(user, "<span class='notice'>You slot \the [C] into [src].</span>")
 			updateUsrDialog()
-	else if(istype(C, /obj/item/weapon/pen))
-		var/obj/item/weapon/pen/O = locate() in src
-		if(O)
-			to_chat(user, "<span class='notice'>There is already a pen in \the [src].</span>")
-		else
-			if(user.drop_item(C, src))
-				to_chat(user, "<span class='notice'>You slide \the [C] into \the [src].</span>")
+	else if(istype(C, /obj/item/weapon/pen) && !src.pen)
+		if(user.drop_item(C, src))
+			pen = C
+			to_chat(user, "<span class='notice'>You slide \the [C] into \the [src].</span>")
 	else if(istype(C,/obj/item/weapon/spacecash))
 		if(!id)
 			to_chat(user, "[bicon(src)]<span class='warning'>There is no ID in the PDA!</span>")
@@ -469,6 +467,19 @@ var/global/msg_id = 0
 			to_chat(user, "<span class='info'>You insert [round(dosh.worth * dosh.amount * (multiplier/100))] credit\s into the PDA.</span>")
 			qdel(dosh)
 		updateDialog()
+
+/obj/item/device/pda/can_quick_store(var/obj/item/I)
+	if(istype(I,/obj/item/weapon/card/id))
+		var/obj/item/weapon/card/id/idcard = I
+		return !id && idcard.registered_name
+	return (istype(I,/obj/item/weapon/cartridge) && !cartridge) ||\
+			(istype(I,/obj/item/device/paicard) && !pai) ||\
+			(istype(I,/obj/item/weapon/photo) && !photo) ||\
+			(istype(I,/obj/item/weapon/pen) && !pen) ||\
+			(istype(I,/obj/item/weapon/spacecash) && id && id.virtual_wallet)
+
+/obj/item/device/pda/quick_store(var/obj/item/I,mob/user)
+	return !(attackby(I,user))
 
 /obj/item/device/pda/proc/add_to_virtual_wallet(var/amount, var/mob/user, var/atom/giver)
 	if(!id)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -111,12 +111,6 @@
 	starting_materials = list(MAT_PLASTIC = 3*CC_PER_SHEET_MISC) //Recipe calls for 3 sheets
 	w_type = RECYK_PLASTIC
 
-/obj/item/weapon/storage/bag/plasticbag/can_quick_store(var/obj/item/I)
-	return can_be_inserted(I,1)
-
-/obj/item/weapon/storage/bag/plasticbag/quick_store(var/obj/item/I)
-	return handle_item_insertion(I,0)
-
 /obj/item/weapon/storage/bag/plasticbag/suicide_act(var/mob/living/user)
 	user.visible_message("<span class='danger'>[user] puts the [src.name] over \his head and tightens the handles around \his neck! It looks like \he's trying to commit suicide.</span>")
 	return(SUICIDE_ACT_OXYLOSS)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -12,12 +12,6 @@
 	toolsounds = list("rustle")
 	autoignition_temperature = AUTOIGNITION_ORGANIC //leather
 
-/obj/item/weapon/storage/belt/can_quick_store(var/obj/item/I)
-	return can_be_inserted(I,1)
-
-/obj/item/weapon/storage/belt/quick_store(var/obj/item/I)
-	return handle_item_insertion(I,0)
-
 /obj/item/weapon/storage/belt/utility
 	name = "tool-belt" //Carn: utility belt is nicer, but it bamboozles the text parsing.
 	desc = "It has a tag that rates it for compatibility with standard tools, device analyzers, flashlights, cables, engineering tape, small fire extinguishers, compressed matter cartridges, light replacers, and fuel cans."

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -395,6 +395,12 @@
 	refresh_all()
 	return 1
 
+/obj/item/weapon/storage/can_quick_store(var/obj/item/I)
+	return can_be_inserted(I,1)
+
+/obj/item/weapon/storage/quick_store(var/obj/item/I,mob/user)
+	return handle_item_insertion(I,0)
+
 //Call this proc to handle the removal of an item from the storage item. The item will be moved to the atom sent as new_target
 //force needs to be 1 if you want to override the can_be_inserted() if the target's a storage item.
 /obj/item/weapon/storage/proc/remove_from_storage(obj/item/W, atom/new_location, var/force = 0, var/refresh = 1)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -574,7 +574,7 @@ a {
 /obj/proc/can_quick_store(var/obj/item/I) //proc used to check that the current object can store another through quick equip
 	return 0
 
-/obj/proc/quick_store(var/obj/item/I) //proc used to handle quick storing
+/obj/proc/quick_store(var/obj/item/I,mob/user) //proc used to handle quick storing
 	return 0
 
 /**

--- a/code/game/objects/storage/coat.dm
+++ b/code/game/objects/storage/coat.dm
@@ -25,6 +25,12 @@
 		hold = null
 	return ..()
 
+/obj/item/clothing/suit/storage/can_quick_store(var/obj/item/I)
+	return (hold && hold.can_be_inserted(I,1)) || ..()
+
+/obj/item/clothing/suit/storage/quick_store(var/obj/item/I,mob/user)
+	return (hold && hold.handle_item_insertion(I,0)) || ..()
+
 /obj/item/clothing/suit/storage/attack_hand(mob/user)
 	if(user == src.loc)
 		return hold.attack_hand(user)
@@ -54,4 +60,4 @@
 		return hold.attack_hand(user)
 	else
 		return ..()
-	
+

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -33,11 +33,13 @@
 
 /obj/item/clothing/can_quick_store(var/obj/item/I)
 	for(var/obj/item/clothing/accessory/storage/A in accessories)
-		return A.hold && A.hold.can_be_inserted(I,1)
+		if(A.hold && A.hold.can_be_inserted(I,1))
+			return 1
 
 /obj/item/clothing/quick_store(var/obj/item/I,mob/user)
 	for(var/obj/item/clothing/accessory/storage/A in accessories)
-		return A.hold && A.hold.handle_item_insertion(I,0)
+		if(A.hold && A.hold.handle_item_insertion(I,0))
+			return 1
 
 /obj/item/clothing/CtrlClick(var/mob/user)
 	if(isturf(loc))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -31,6 +31,14 @@
 		qdel(A)
 	..()
 
+/obj/item/clothing/can_quick_store(var/obj/item/I)
+	for(var/obj/item/clothing/accessory/storage/A in accessories)
+		return A.hold && A.hold.can_be_inserted(I,1)
+
+/obj/item/clothing/quick_store(var/obj/item/I,mob/user)
+	for(var/obj/item/clothing/accessory/storage/A in accessories)
+		return A.hold && A.hold.handle_item_insertion(I,0)
+
 /obj/item/clothing/CtrlClick(var/mob/user)
 	if(isturf(loc))
 		return ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -612,7 +612,7 @@
 		B.handle_item_insertion(W,1)
 
 //The list of slots by priority. equip_to_appropriate_slot() uses this list. Doesn't matter if a mob type doesn't have a slot.
-var/list/slot_equipment_priority = list( \
+var/static/list/slot_equipment_priority = list( \
 		slot_wear_id,\
 		slot_wear_mask,\
 		slot_head,\

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -613,7 +613,6 @@
 
 //The list of slots by priority. equip_to_appropriate_slot() uses this list. Doesn't matter if a mob type doesn't have a slot.
 var/list/slot_equipment_priority = list( \
-		slot_back,\
 		slot_wear_id,\
 		slot_w_uniform,\
 		slot_wear_suit,\
@@ -626,7 +625,8 @@ var/list/slot_equipment_priority = list( \
 		slot_belt,\
 		slot_s_store,\
 		slot_l_store,\
-		slot_r_store\
+		slot_r_store,\
+		slot_back\
 	)
 
 /*Equips accessories.
@@ -651,12 +651,18 @@ Use this proc preferably at the end of an equipment loadout
 	if(!istype(W))
 		return 0
 
+	var/list/backup_slots = list()
 	for(var/slot in slot_equipment_priority)
 		if(!is_holding_item(W) && !override)
 			return 0
 		var/obj/item/S = get_item_by_slot(slot)
 		if(S && S.can_quick_store(W))
-			return S.quick_store(W)
+			return S.quick_store(W,src)
+		if((slot in list(slot_l_store,slot_r_store)) && W.mob_can_equip(src, slot, 1) == CAN_EQUIP_BUT_SLOT_TAKEN)
+			backup_slots.Add(slot)
+		else if(equip_to_slot_if_possible(W, slot, 0, 1, 1, 0)) //act_on_fail = 0; disable_warning = 0; redraw_mob = 1
+			return 1
+	for(var/slot in backup_slots)
 		if(equip_to_slot_if_possible(W, slot, 0, 1, 1, 0)) //act_on_fail = 0; disable_warning = 0; redraw_mob = 1
 			return 1
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -620,12 +620,12 @@ var/list/slot_equipment_priority = list( \
 		slot_gloves,\
 		slot_ears,\
 		slot_glasses,\
-		slot_w_uniform,\
-		slot_wear_suit,\
 		slot_belt,\
 		slot_s_store,\
 		slot_l_store,\
 		slot_r_store,\
+		slot_w_uniform,\
+		slot_wear_suit,\
 		slot_back\
 	)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -614,14 +614,14 @@
 //The list of slots by priority. equip_to_appropriate_slot() uses this list. Doesn't matter if a mob type doesn't have a slot.
 var/list/slot_equipment_priority = list( \
 		slot_wear_id,\
-		slot_w_uniform,\
-		slot_wear_suit,\
 		slot_wear_mask,\
 		slot_head,\
 		slot_shoes,\
 		slot_gloves,\
 		slot_ears,\
 		slot_glasses,\
+		slot_w_uniform,\
+		slot_wear_suit,\
 		slot_belt,\
 		slot_s_store,\
 		slot_l_store,\

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -651,6 +651,9 @@ Use this proc preferably at the end of an equipment loadout
 	if(!istype(W))
 		return 0
 
+	for(var/obj/item/I in held_items)
+		if(I.can_quick_store(W))
+			return I.quick_store(W,src)
 	var/list/backup_slots = list()
 	for(var/slot in slot_equipment_priority)
 		if(!is_holding_item(W) && !override)


### PR DESCRIPTION
[tweak][qol]

## What this does
allows all storage items to have stuff stored in it with the equip key (e)
moves the backpack, uniform and suits down to the bottom of the quick equip priority to remedy equipping stuff like oxygen tanks to suits (and also so things go into belts and etc before these)
disables the quick swapping of items on pockets only unless they're full and so is the backpack
allows quick storing things into PDAs, coats and accessories with storage like webbing or bandoliers

## Why it's good
makes more use of this hotkey

## Changelog
:cl:
 * rscadd: Backpacks, suits with storage slots, accessories with storage slots and PDAs can now make use of the quick equip hotkey to store items in them.
 * tweak: Backpacks, uniforms and suits have had their storage priority moved to the bottom of the list to facilitate other slots and storage in other items like belts. 
 * rscadd: The quick equip key can now store items inside held objects, with highest priority.