### PR TITLE
Arcane tamper speed update

### DIFF
--- a/code/modules/spells/targeted/arcanetamper.dm
+++ b/code/modules/spells/targeted/arcanetamper.dm
@@ -10,7 +10,7 @@
 	user_type = USER_TYPE_WIZARD
 	specialization = SSUTILITY
 	school = "transmutation"
-	charge_max = 200
+	charge_max = 150
 	spell_flags = NEEDSCLOTHES // now it's balanced
 	invocation = "E'MAGI!"
 	invocation_type = SpI_NONE // we say it in the arcane_acts

--- a/code/modules/spells/targeted/arcanetamper.dm
+++ b/code/modules/spells/targeted/arcanetamper.dm
@@ -16,7 +16,7 @@
 	invocation_type = SpI_NONE // we say it in the arcane_acts
 	level_max = list(Sp_TOTAL = 4, Sp_SPEED = 2, Sp_POWER = 2)
 	range = 1
-	cooldown_min = 100 // 100 deciseconds reduction per rank
+	cooldown_min = 100 // 50 deciseconds reduction per rank
 	hud_state = "wiz_arctam"
 	spell_flags = WAIT_FOR_CLICK
 	var/recursive = FALSE // does it curse contents too?

--- a/code/modules/spells/targeted/arcanetamper.dm
+++ b/code/modules/spells/targeted/arcanetamper.dm
@@ -10,13 +10,13 @@
 	user_type = USER_TYPE_WIZARD
 	specialization = SSUTILITY
 	school = "transmutation"
-	charge_max = 300
+	charge_max = 200
 	spell_flags = NEEDSCLOTHES // now it's balanced
 	invocation = "E'MAGI!"
 	invocation_type = SpI_NONE // we say it in the arcane_acts
 	level_max = list(Sp_TOTAL = 4, Sp_SPEED = 2, Sp_POWER = 2)
 	range = 1
-	cooldown_min = 200 // 100 deciseconds reduction per rank
+	cooldown_min = 100 // 100 deciseconds reduction per rank
 	hud_state = "wiz_arctam"
 	spell_flags = WAIT_FOR_CLICK
 	var/recursive = FALSE // does it curse contents too?


### PR DESCRIPTION
[tweak]

## What this does
Lowers default spell cooldown to 15 seconds from 30 and upgraded to 10 from 20

## Why it's good
Was suggested as feedback

## Changelog
:cl:
 * tweak: Arcane tamper has had it's normal and upgraded cooldown time halved, from 30 seconds to 15 and 20 seconds to 10 respectively