### PR TITLE
remove scuffed "good enough condition" requirement for sleepers

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -169,8 +169,6 @@
 						"<span class='warning'>Sorry pal, safety procedures.</span>", \
 						"<span class='warning'>But it's not bedtime yet!</span>")]")
 					sedativeblock++
-				else if((!works_in_crit && occupant.health < 0) && (href_list["chemical"] != INAPROVALINE))
-					to_chat(usr, "<span class='danger'>This person is not in good enough condition for sleepers to be effective! Use another means of treatment, such as cryogenics!</span>")
 				else
 					if(!(href_list["chemical"] in available_options)) //href exploitu go home
 						to_chat(usr,"<span class='warning'>That's odd. You could've sworn the [href_list["chemical"]] button was there just a second ago!")


### PR DESCRIPTION
[tweak][qol]
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does

removes a requirement in the sleepers that states the occupant has to be above 0 health to accept meds, regardless if the meds in question would save them from crit

## Why it's good

1. makes the wild ride a little easier
2. the restriction doesnt even make sense, imagine a doctor refusing to give you life saving medicine because you're "too fucked up" (lol)
3. pictured: me using my new unrestricted sleepers to heal this guy that got his shit kicked in by a toolbox (previously i would get told to just "put him in cryogenics!!!" by the machine)
![image](https://user-images.githubusercontent.com/114632295/197904728-b6bdaabf-d57b-4f08-be66-625438a22caf.png)

cryo is great but sometimes it's overkill / you don't have cryoxadone / the two cryopods are full

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscdel: removed requirement for occupant health to be above 0