### PR TITLE
Removes Splashing Chemicals on Vending Machines

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -191,6 +191,9 @@ var/global/num_vending_terminals = 1
 		qdel(coinbox)
 		coinbox = null
 	..()
+	
+/obj/machinery/vending/splashable()
+	return FALSE
 
 /obj/machinery/vending/proc/dump_vendpack_and_coinbox()
 	if(product_records.len && cardboard) //Only spit out if we have slotted cardboard


### PR DESCRIPTION
This is grudgecode not gonna lie.
![image](https://user-images.githubusercontent.com/69739118/198051989-7e43844b-e77a-4305-a3fa-a17affe3c7f3.png)

## What this does
When you load a custom vending machine, if you try to load a beaker or container without a lid that is able to splash, you will splash the custom vending machine before loading the item.

This PR fixes it so that you can't splash custom vending machines, similar to most other machines that regularly accept and use liquid containers such as the various reagent dispensers, virology machines, etc.

## Why it's good
![image](https://user-images.githubusercontent.com/69739118/198053518-38246b9f-adfd-4001-9472-32c9971390b4.png)
Now I can just mindlessly dump my cargo ordered gallon jugs of PCP which apparently come shipped to you with lids, but the containers are open somehow, into the custom vending machine, without them emptying themselves.

Also, Fixes #33570.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: You can no longer splash vending machines with reagent containers.

[bugfix] [tested]