### PR TITLE
Adjusts Pulse Demon and Prisoner Threat/Pop Requirements

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -155,7 +155,7 @@
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
 	cost = 25
-	requirements = list(5,5,15,15,20,20,20,20,40,70)
+	requirements = list(70,40,20,20,20,20,15,15,5,5)
 	high_population_requirement = 10
 	logo = "pulsedemon-logo"
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -823,7 +823,7 @@
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
 	cost = 20
-	requirements = list(5,5,15,15,20,20,20,20,40,70)
+	requirements = list(70,40,20,20,20,20,15,15,5,5)
 	high_population_requirement = 10
 	logo = "pulsedemon-logo"
 	var/list/cables_to_spawn_at = list()
@@ -914,11 +914,11 @@
 	restricted_from_jobs = list()
 	enemy_jobs = list("Warden","Head of Security")
 	required_enemies = list(1,1,1,1,1,1,1,1,1,1)
-	required_pop = list(0,0,10,10,15,15,20,20,20,25)
+	required_pop = list(25,20,20,20,15,15,10,10,0,0)
 	required_candidates = 1
-	weight = 3
+	weight = 1
 	cost = 0
-	requirements = list(5,5,15,15,20,20,20,20,40,70)
+	requirements = list(70,40,20,20,20,20,15,15,5,5)
 	high_population_requirement = 10
 	flags = MINOR_RULESET
 	makeBody = FALSE


### PR DESCRIPTION
this is a curse that remains from kanef code

## What this does
Tl;dr math, this is why these antags are kinda rare and only spawn at unusual pops/threats, even with prisoner having triple weight on being triggered.

Flips the population and threat requirement lists for Pulse Demon and Prisoner midrounds/latejoins. Antag datums use a crazy number of confusing lists and variables to try and balance what pops and what threat antags can spawn on. Looking over thing, three outliers existed: Ramblers, Pulse Demons, and Prisoners. After running numbers, it seems that certain lists were put in backwards, messing with when they can spawn. This PR effectively makes them follow the standard rules for spawning in. Low pop needs very high threat now to have Pulse Demons and Prisoners, and not so much threat at high pop. In the worst case, the lists would collide, making certain 'windows' of threat that had to be observed for the antag to spawn in.

For example, during 0-5 player lowpop, Pulse Demons would only spawn in on 5-20 threat exactly, instead of the likely intended 70 threat. Whereas on a packed station of 100 players, a pulse demon would need 70 threat, opposed to the likely intended 5 threat. Note that very specific and unusual 5-20 threat window.

I'm dropping prisoner spawn rate back to standard, since the tripling was implemented because nobody ever saw prisoners. It's likely because of the lists being backwards and needing very specific threat ranges to spawn in.

Ramblers are not changed because their requirements being backwards is a cool niche thing and was likely intended.

Pulse Demon: Threat Requiements (entries by standard pop scaling) from ``5,5,15,15,20,20,20,20,40,70`` to  ``70,40,20,20,20,20,15,15,5,5``.
Prisoners: Reduced triggering weight from triple weight to standard weight.
Prisoners: Population Requirements (entries by standard threat scaling) from ``0,0,10,10,15,15,20,20,20,25`` to ``25,20,20,20,15,15,10,10,0,0``.
Prisoners: Threat Requirements (entries by standard pop scaling) from ``5,5,15,15,20,20,20,20,40,70`` to ``70,40,20,20,20,20,15,15,5,5``.

## Why it's good
Pulse Demons and Prisoners spawn in when they 'should' now.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Changed the pop/threat that Prisoners and Pulse Demons can spawn in at.
 
 [gameplay] [gamemode] [balance]