### PR TITLE
Blob and Blobstorm Stricter Requirements

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -400,7 +400,7 @@
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
 	weekday_rule_boost = list("Tue")
-	cost = 50
+	cost = 45
 	requirements = list(90,90,80,40,40,40,30,20,20,10)
 	high_population_requirement = 70
 	logo = "blob-logo"

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -394,12 +394,13 @@
 	name = "Blob Overmind Storm"
 	role_category = /datum/role/blob_overmind/
 	my_fac = /datum/faction/blob_conglomerate/
-	enemy_jobs = list("AI", "Cyborg", "Security Officer", "Station Engineer","Chief Engineer", "Roboticist","Head of Security", "Captain")
-	required_pop = list(25,20,20,15,15,15,10,10,10,10)
+	enemy_jobs = list("AI", "Cyborg", "Warden", "Head of Security", "Captain", "Quartermaster", "Head of Personnel", "Station Engineer", "Chief Engineer", "Atmospheric Technician")
+	required_pop = list(30,25,25,20,20,20,15,15,15,15)
+	required_enemies = list(5,5,4,4,3,3,2,2,1,1)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
 	weekday_rule_boost = list("Tue")
-	cost = 45
+	cost = 50
 	requirements = list(90,90,80,40,40,40,30,20,20,10)
 	high_population_requirement = 70
 	logo = "blob-logo"

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -396,7 +396,7 @@
 	my_fac = /datum/faction/blob_conglomerate/
 	enemy_jobs = list("AI", "Cyborg", "Warden", "Head of Security", "Captain", "Quartermaster", "Head of Personnel", "Station Engineer", "Chief Engineer", "Atmospheric Technician")
 	required_pop = list(30,25,25,20,20,20,15,15,15,15)
-	required_enemies = list(5,5,4,4,3,3,2,2,1,1)
+	required_enemies = list(4,4,4,4,4,4,4,3,2,1)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
 	weekday_rule_boost = list("Tue")

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -575,13 +575,14 @@ Assign your candidates in choose_candidates() instead.
 /datum/dynamic_ruleset/roundstart/blob
 	name = "Blob Conglomerate"
 	role_category = /datum/role/blob_overmind/
-	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden","Detective","Head of Security", "Captain", "Head of Personnel")
-	enemy_jobs = list("AI", "Cyborg", "Security Officer", "Warden","Detective","Head of Security", "Captain")
+	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
+	enemy_jobs = list("AI", "Cyborg", "Warden", "Head of Security", "Captain", "Quartermaster", "Head of Personnel", "Station Engineer", "Chief Engineer", "Atmospheric Technician")
 	required_pop = list(30,25,25,20,20,20,15,15,15,15)
+	required_enemies = list(5,5,4,4,3,3,3,2,2,2)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
 	weekday_rule_boost = list("Tue")
-	cost = 45
+	cost = 50
 	requirements = list(90,90,90,80,60,40,30,20,10,10)
 	high_population_requirement = 70
 	flags = HIGHLANDER_RULESET

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -582,7 +582,7 @@ Assign your candidates in choose_candidates() instead.
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
 	weekday_rule_boost = list("Tue")
-	cost = 50
+	cost = 45
 	requirements = list(90,90,90,80,60,40,30,20,10,10)
 	high_population_requirement = 70
 	flags = HIGHLANDER_RULESET

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -578,7 +578,7 @@ Assign your candidates in choose_candidates() instead.
 	restricted_from_jobs = list("AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
 	enemy_jobs = list("AI", "Cyborg", "Warden", "Head of Security", "Captain", "Quartermaster", "Head of Personnel", "Station Engineer", "Chief Engineer", "Atmospheric Technician")
 	required_pop = list(30,25,25,20,20,20,15,15,15,15)
-	required_enemies = list(5,5,4,4,3,3,3,2,2,2)
+	required_enemies = list(4,4,4,4,4,4,4,3,2,1)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
 	weekday_rule_boost = list("Tue")

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -209,6 +209,18 @@ var/global/list/thing_storm_types = list(
 	var/list/candidates = list()
 	var/started = FALSE
 
+/datum/event/thing_storm/blob_storm/can_start(var/list/active_with_role)
+	if(active_with_role["Engineer"] <= 1)
+		return 0
+	
+	var/list/popl = list()	//list of living players
+	for(var/mob/living/carbon/human/G in player_list)
+		if(G.mind && G.mind.current && G.mind.current.stat != DEAD)
+			popl += G
+	if(popl.len >= 25)
+		return 15
+	return 0
+
 /datum/event/thing_storm/blob_storm/setup()
 	endWhen = rand(60, 90) + 10
 	storm_name="blob storm"

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -210,16 +210,7 @@ var/global/list/thing_storm_types = list(
 	var/started = FALSE
 
 /datum/event/thing_storm/blob_storm/can_start(var/list/active_with_role)
-	if(active_with_role["Engineer"] <= 1)
-		return 0
-	
-	var/list/popl = list()	//list of living players
-	for(var/mob/living/carbon/human/G in player_list)
-		if(G.mind && G.mind.current && G.mind.current.stat != DEAD)
-			popl += G
-	if(popl.len >= 25)
-		return 15
-	return 0
+	return 0 //disabled
 
 /datum/event/thing_storm/blob_storm/setup()
 	endWhen = rand(60, 90) + 10


### PR DESCRIPTION
Highly requested.

## What this does
Blob has been firing a little too much too hard so these are some gentle adjustments to get things done. It hasn't actually, but people still complain about 3 blobs in 30 days.

I've removed two security officer types (secoffs and detectives) from the enemy jobs list, since they are unable to get into the laser gun armory to assist in helping fight the blob. They are fancy assistants when the blob strikes. Sorry, but it's true. Instead, I've added the entire engineering department, as they are vital to maintain power and repairs during a blob. Additionally, I've added the Head of Personnel, who can grant access to the guns/cargo, and the QM, who can use the cargo budget to order literally all the guns at a moment's notice.

I've also put a scaling-on-threat enemy jobs requirement on blob. Now if you don't have at least a certain number of enemies for the blob, the blob will not come. This scales on threat level, starting at 4 enemy jobs, and getting reduced to just 1 at 90+ threat. This way, at least some of the crew will be well-equipped for the fight ahead.

Blobstorms have been complained about as well, so I've updated the requirements to match the above. Also why was Roboticist an enemy of blobstorm specifically?

Blob Enemies: Removed Security Officer, Detective, and Roboticist from the enemies list. 
Blob Enemies: Added CE, Atmos Tech, Engineer, QM, and HoP to the enemies list.
Blobstorm (Midround) Pop Requirements: Changed to match roundstart Blob requirements.
Blobstorm (Overmind Random Event): Remains disabled

## Why it's good
Blob won't fire as often on unprepared crew. Or as often, in general.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Blob requires specific enemies to trigger now, and more population for a midround blobstorm.

[gamemode] [balance]