### PR TITLE
Blood Cult is No Longer a Highlander Ruleset

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -329,7 +329,8 @@
 	requirements = list(90,80,60,30,20,10,10,10,10,10)
 	high_population_requirement = 40
 	var/cultist_cap = list(2,2,3,4,4,4,4,4,4,4)
-	flags = HIGHLANDER_RULESET
+	//Readd this once proper round ending rituals are added
+	//flags = HIGHLANDER_RULESET
 
 /datum/dynamic_ruleset/roundstart/bloodcult/ready(var/forced = 0)
 	var/indice_pop = min(10,round(mode.roundstart_pop_ready/5)+1)


### PR DESCRIPTION
i miss deity

## What this does
Removes the HIGHLANDER flag from Blood Cult. They are no longer a round-ending antag, as they have no game-ending ritual. This means that they will no longer prevent other antags that can actually destroy the station, such as nukies, blob, or malf AI, from firing.

REVERT this PR when rituals are properly added AND the rituals let them end the round.

## Why it's good
A boring book club with no plans to summon NARSIE can no longer stop THE WHEEL OPS from coming. ROLL EM FLAT!

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Blood Cult is no longer a Highlander ruleset. This means other round-ending antags such as Nukies can now come if the threat is high enough.

[gameplay] [gamemode] [balance]