### PR TITLE
Snow turf climate and prints refactoring

### DIFF
--- a/code/datums/climate.dm
+++ b/code/datums/climate.dm
@@ -138,6 +138,7 @@ var/list/weathertracker = list() //associative list, gathers time spent one each
 	weathertracker[name] += SS_WAIT_WEATHER
 
 var/list/global_snowtiles = list()
+var/list/environment_snowtiles = list()
 var/list/snow_state_to_texture = list()
 
 /datum/weather/snow
@@ -157,9 +158,7 @@ var/obj/effect/blizzard_holder/blizzard_image = null
 		E.alarm(!(snow_intensity % SNOW_BLIZZARD))
 		//sends 1 if snow_intensity equals blizzard exactly, otherwise sends 0
 	blizzard_image.UpdateSnowfall(snow_intensity)
-	for(var/turf/unsimulated/floor/snow/tile in global_snowtiles)
-		if(tile.ignore_blizzard_updates)
-			continue
+	for(var/turf/unsimulated/floor/snow/tile in environment_snowtiles)
 		tile.update_environment()
 	force_update_snowfall_sfx()
 

--- a/code/datums/climate.dm
+++ b/code/datums/climate.dm
@@ -110,6 +110,9 @@ var/list/weathertracker = list() //associative list, gathers time spent one each
 
 /datum/climate/arctic/New()
 	current_weather = new /datum/weather/snow/calm(src)
+	if(!blizzard_image)
+		blizzard_image = new
+	blizzard_image.UpdateSnowfall(SNOW_CALM)
 	..()
 
 ///////////////////////////////////  WEATHER DATUMS //////////////////////////////
@@ -148,9 +151,6 @@ var/obj/effect/blizzard_holder/blizzard_image = null
 
 /datum/weather/snow/New(var/datum/climate/C)
 	..()
-	if(!blizzard_image)
-		blizzard_image = new
-	blizzard_image.UpdateSnowfall(snow_intensity)
 
 /datum/weather/snow/execute()
 	for(var/obj/machinery/teleport/hub/emergency/E in machines)

--- a/code/datums/climate.dm
+++ b/code/datums/climate.dm
@@ -150,6 +150,7 @@ var/obj/effect/blizzard_holder/blizzard_image = null
 	..()
 	if(!blizzard_image)
 		blizzard_image = new
+	blizzard_image.UpdateSnowfall(snow_intensity)
 
 /datum/weather/snow/execute()
 	for(var/obj/machinery/teleport/hub/emergency/E in machines)

--- a/code/datums/climate.dm
+++ b/code/datums/climate.dm
@@ -136,7 +136,6 @@ var/list/weathertracker = list() //associative list, gathers time spent one each
 
 var/list/global_snowtiles = list()
 var/list/snow_state_to_texture = list()
-var/snowtiles_setup = 0 //has the blizzard parent been initialized?
 
 /datum/weather/snow
 	var/snow_intensity = SNOW_CALM
@@ -144,6 +143,11 @@ var/snowtiles_setup = 0 //has the blizzard parent been initialized?
 	var/snowfall_prob = 0
 	var/snowfall_rate = list(0,0)
 	var/snow_fluff_estimate = "snowing"
+	var/obj/effect/blizzard_holder/blizzard_image = null
+
+/datum/weather/snow/New(var/datum/climate/C)
+	..()
+	blizzard_image = new
 
 /datum/weather/snow/execute()
 	for(var/obj/machinery/teleport/hub/emergency/E in machines)
@@ -152,7 +156,7 @@ var/snowtiles_setup = 0 //has the blizzard parent been initialized?
 	for(var/turf/unsimulated/floor/snow/tile in global_snowtiles)
 		if(tile.ignore_blizzard_updates)
 			continue
-		tile.snow_state = snow_intensity
+		blizzard_image.UpdateSnowfall(snow_intensity)
 		tile.update_environment()
 	force_update_snowfall_sfx()
 

--- a/code/datums/climate.dm
+++ b/code/datums/climate.dm
@@ -143,20 +143,22 @@ var/list/snow_state_to_texture = list()
 	var/snowfall_prob = 0
 	var/snowfall_rate = list(0,0)
 	var/snow_fluff_estimate = "snowing"
-	var/obj/effect/blizzard_holder/blizzard_image = null
+
+var/obj/effect/blizzard_holder/blizzard_image = null
 
 /datum/weather/snow/New(var/datum/climate/C)
 	..()
-	blizzard_image = new
+	if(!blizzard_image)
+		blizzard_image = new
 
 /datum/weather/snow/execute()
 	for(var/obj/machinery/teleport/hub/emergency/E in machines)
 		E.alarm(!(snow_intensity % SNOW_BLIZZARD))
 		//sends 1 if snow_intensity equals blizzard exactly, otherwise sends 0
+	blizzard_image.UpdateSnowfall(snow_intensity)
 	for(var/turf/unsimulated/floor/snow/tile in global_snowtiles)
 		if(tile.ignore_blizzard_updates)
 			continue
-		blizzard_image.UpdateSnowfall(snow_intensity)
 		tile.update_environment()
 	force_update_snowfall_sfx()
 

--- a/code/datums/climate.dm
+++ b/code/datums/climate.dm
@@ -171,7 +171,8 @@ var/obj/effect/blizzard_holder/blizzard_image = null
 		if(i == tile_interval)
 			tile.change_snowballs(snowfall_rate[1],snowfall_rate[2])
 			if(tile.snowprint_parent)
-				tile.snowprint_parent.ClearSnowprints()
+				qdel(tile.snowprint_parent)
+				tile.snowprint_parent = null
 			i = 1
 		else
 			i++

--- a/code/game/turfs/unsimulated/snow.dm
+++ b/code/game/turfs/unsimulated/snow.dm
@@ -51,8 +51,9 @@
 
 /turf/unsimulated/floor/snow/initialize()
 	..()
-	vis_contents.Cut()
-	vis_contents += blizzard_image
+	if(!snow_intensity_override)
+		vis_contents.Cut()
+		vis_contents += blizzard_image
 
 /turf/unsimulated/floor/snow/proc/update_environment()
 	if(real_snow_tile)

--- a/code/game/turfs/unsimulated/snow.dm
+++ b/code/game/turfs/unsimulated/snow.dm
@@ -29,7 +29,7 @@
 
 /turf/unsimulated/floor/snow/New()
 	..()
-	if((!map || !map.climate || !istype(map.climate.current_weather,/datum/weather/snow)) && !blizzard_image)
+	if(!blizzard_image)
 		blizzard_image = new
 	vis_contents += blizzard_image
 	if(real_snow_tile)
@@ -49,12 +49,6 @@
 		qdel(snowprint_parent)
 	..()
 
-/turf/unsimulated/floor/snow/initialize()
-	..()
-	if(!snow_intensity_override)
-		vis_contents.Cut()
-		vis_contents += blizzard_image
-
 /turf/unsimulated/floor/snow/proc/update_environment()
 	if(real_snow_tile)
 		if(snowballs)
@@ -70,8 +64,8 @@
 			snow_state = S.snow_intensity
 	if(!snow_state)
 		snow_state = SNOW_CALM
-	temperature = T_ARCTIC-(5*round(2**(snow_state-1))) //0 = 0, 1 = 5, 2 = 10, 3 = 20
-	turf_speed_multiplier = max(1,1.4*(snow_state-1)) /*0 = 1, 1 = 1, 2 = 1.4, 3 = 2.8*/ * (1+(snowballs/10)) //higher numbers mean slower
+	temperature = T_ARCTIC-(5*round(2**(snow_state-1))) //CALM -= 0, AVERAGE -= 5, HARD -= 10, BLIZZARD -= 20
+	turf_speed_multiplier = max(1,1.4*(snow_state-1)) /*CALM = 1, AVERAGE = 1, HARD = 1.4, BLIZZARD = 2.8*/ * (1+(snowballs/10)) //higher numbers mean slower
 
 /turf/unsimulated/floor/snow/Exited(atom/A, atom/newloc)
 	..()

--- a/code/game/turfs/unsimulated/snow.dm
+++ b/code/game/turfs/unsimulated/snow.dm
@@ -43,8 +43,6 @@
 		else
 			snowballs = initial_snowballs
 		icon_state = "snow[rand(0, 6)]"
-		if(snowprints)
-			snowprint_parent = new /obj/effect/snowprint_holder(src)
 	update_environment()
 	global_snowtiles += src
 	if(real_snow_tile && !ignore_blizzard_updates)
@@ -65,7 +63,8 @@
 		else
 			icon_state = "permafrost_full"
 			if(snowprint_parent)
-				snowprint_parent.ClearSnowprints()
+				qdel(snowprint_parent)
+				snowprint_parent = null
 
 /turf/unsimulated/floor/snow/proc/get_snow_state()
 	. = snow_intensity_override
@@ -90,7 +89,9 @@
 	..()
 	if(istype(A,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = A
-		if(snowprint_parent && snowballs && !H.flying)
+		if(snowprints && snowballs && !H.flying)
+			if(!snowprint_parent)
+				snowprint_parent = new /obj/effect/snowprint_holder(src)
 			if(!H.locked_to && !H.lying) //Our human is walking or at least standing upright, create footprints
 				snowprint_parent.AddSnowprint(H.get_footprint_type(), H.dir, SNOWPRINT_GOING)
 			else //Our human is down on his ass or in a vehicle, create tracks
@@ -107,7 +108,9 @@
 	..()
 	if(istype(A,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = A
-		if(snowprint_parent && snowballs && !H.flying)
+		if(snowprints && snowballs && !H.flying)
+			if(!snowprint_parent)
+				snowprint_parent = new /obj/effect/snowprint_holder(src)
 			if(!H.locked_to && !H.lying) //Our human is walking or at least standing upright, create footprints
 				snowprint_parent.AddSnowprint(H.get_footprint_type(), H.dir, SNOWPRINT_COMING)
 			else //Our human is down on his ass or in a vehicle, create tracks
@@ -180,7 +183,7 @@
 	anchored = 1
 	plane = ABOVE_TURF_PLANE
 	mouse_opacity = 0 //Unclickable
-	var/list/icon/existing_prints = list()
+	var/list/existing_prints = list()
 
 /obj/effect/snowprint_holder/proc/AddSnowprint(var/obj/effect/decal/cleanable/blood/tracks/footprints/footprint_type, var/dir, var/comeorgo = SNOWPRINT_COMING)
 	var/state2check = comeorgo == SNOWPRINT_COMING ? initial(footprint_type.coming_state) : initial(footprint_type.going_state)
@@ -190,10 +193,6 @@
 	footprint.SwapColor("#FFFFFF","#BEBEBE")
 	overlays += footprint
 	existing_prints["[state2check]-[dir]"] = footprint
-
-/obj/effect/snowprint_holder/proc/ClearSnowprints()
-	overlays.Cut()
-	existing_prints.Cut()
 
 /turf/unsimulated/floor/snow/attackby(obj/item/weapon/W as obj, mob/user as mob)
 

--- a/code/game/turfs/unsimulated/snow.dm
+++ b/code/game/turfs/unsimulated/snow.dm
@@ -385,6 +385,7 @@
 	..() //forces this to always be blizzarding regardless of blizzard rules
 	if(!heavy_blizzard_image)
 		heavy_blizzard_image = new
+	vis_contents.Cut()
 	vis_contents += heavy_blizzard_image
 
 var/obj/effect/blizzard_holder/heavy/heavy_blizzard_image = null

--- a/code/game/turfs/unsimulated/snow.dm
+++ b/code/game/turfs/unsimulated/snow.dm
@@ -68,7 +68,7 @@
 		. = SNOW_CALM
 
 /turf/unsimulated/floor/snow/adjust_slowdown(mob/living/L, current_slowdown)
-	current_slowdown *= max(1,1.4*(get_snow_state()-1)) /*CALM = 1, AVERAGE = 1, HARD = 1.4, BLIZZARD = 2.8*/ * (1+(snowballs/10)) //higher numbers mean slower
+	current_slowdown *= (max(1,1.4*(get_snow_state()-1)) /*CALM = 1, AVERAGE = 1, HARD = 1.4, BLIZZARD = 2.8*/ * (1+(snowballs/10))) //higher numbers mean slower
 	return ..()
 
 /turf/unsimulated/floor/snow/return_air()

--- a/code/game/turfs/unsimulated/snow.dm
+++ b/code/game/turfs/unsimulated/snow.dm
@@ -70,20 +70,8 @@
 			snow_state = S.snow_intensity
 	if(!snow_state)
 		snow_state = SNOW_CALM
-	switch(snow_state)
-		if(SNOW_CALM)
-			temperature = T_ARCTIC
-			turf_speed_multiplier = 1 //higher numbers mean slower
-		if(SNOW_AVERAGE)
-			temperature = T_ARCTIC-5
-			turf_speed_multiplier = 1
-		if(SNOW_HARD)
-			temperature = T_ARCTIC-10
-			turf_speed_multiplier = 1.4
-		if(SNOW_BLIZZARD)
-			temperature = T_ARCTIC-20
-			turf_speed_multiplier = 2.8
-	turf_speed_multiplier *= 1+(snowballs/10)
+	temperature = T_ARCTIC-(5*round(2**(snow_state-1))) //0 = 0, 1 = 5, 2 = 10, 3 = 20
+	turf_speed_multiplier = max(1,1.4*(snow_state-1)) /*0 = 1, 1 = 1, 2 = 1.4, 3 = 2.8*/ * (1+(snowballs/10)) //higher numbers mean slower
 
 /turf/unsimulated/floor/snow/Exited(atom/A, atom/newloc)
 	..()

--- a/code/game/turfs/unsimulated/snow.dm
+++ b/code/game/turfs/unsimulated/snow.dm
@@ -28,9 +28,9 @@
 
 /turf/unsimulated/floor/snow/New()
 	..()
+	vis_contents += blizzard_image
 	if(map && map.climate && istype(map.climate.current_weather,/datum/weather/snow))
 		var/datum/weather/snow/S = map.climate.current_weather
-		vis_contents += S.blizzard_image
 	if(real_snow_tile)
 		if(initial_snowballs == -1)
 			snowballs = rand(5, 10)
@@ -49,6 +49,7 @@
 	..()
 
 /turf/unsimulated/floor/snow/proc/update_environment()
+	vis_contents.Cut()
 	if(real_snow_tile)
 		if(snowballs)
 			icon_state = "snow[rand(0,6)]"
@@ -75,6 +76,7 @@
 		temperature = T_ARCTIC
 		turf_speed_multiplier = 1 //higher numbers mean slower
 	turf_speed_multiplier *= 1+(snowballs/10)
+	vis_contents += blizzard_image
 
 /turf/unsimulated/floor/snow/Exited(atom/A, atom/newloc)
 	..()

--- a/code/game/turfs/unsimulated/snow.dm
+++ b/code/game/turfs/unsimulated/snow.dm
@@ -29,6 +29,8 @@
 
 /turf/unsimulated/floor/snow/New()
 	..()
+	if((!map || !map.climate || !istype(map.climate.current_weather,/datum/weather/snow)) && !blizzard_image)
+		blizzard_image = new
 	vis_contents += blizzard_image
 	if(real_snow_tile)
 		if(initial_snowballs == -1)
@@ -149,6 +151,14 @@
 	anchored = 1
 	plane = ABOVE_TURF_PLANE
 	mouse_opacity = 0
+
+/obj/effect/blizzard_holder/New()
+	..()
+	if(map && map.climate && istype(map.climate.current_weather,/datum/weather/snow))
+		var/datum/weather/snow/S = map.climate.current_weather
+		UpdateSnowfall(S.snow_intensity)
+	else
+		UpdateSnowfall(SNOW_CALM)
 
 /obj/effect/blizzard_holder/proc/UpdateSnowfall(var/snow_state)
 	if(!snow_state_to_texture["[snow_state]"])

--- a/code/game/turfs/unsimulated/snow.dm
+++ b/code/game/turfs/unsimulated/snow.dm
@@ -381,11 +381,10 @@
 	holomap_draw_override = HOLOMAP_DRAW_EMPTY
 	snow_intensity_override = SNOW_BLIZZARD
 
-/turf/unsimulated/floor/snow/heavy_blizzard/update_environment()
+/turf/unsimulated/floor/snow/heavy_blizzard/New()
 	..() //forces this to always be blizzarding regardless of blizzard rules
 	if(!heavy_blizzard_image)
 		heavy_blizzard_image = new
-	vis_contents.Cut()
 	vis_contents += heavy_blizzard_image
 
 var/obj/effect/blizzard_holder/heavy/heavy_blizzard_image = null

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2850,7 +2850,7 @@
 #include "maprendering\maprendering.dm"
 #include "maps\_map.dm"
 #include "maps\_map_override.dm"
-#include "maps\snaxi.dm"
+#include "maps\tgstation.dm"
 #include "maps\defficiency\areas.dm"
 #include "maps\lampreystation\lamprey.dm"
 #include "maps\packedstation\telecomms.dm"

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2850,7 +2850,7 @@
 #include "maprendering\maprendering.dm"
 #include "maps\_map.dm"
 #include "maps\_map_override.dm"
-#include "maps\tgstation.dm"
+#include "maps\snaxi.dm"
 #include "maps\defficiency\areas.dm"
 #include "maps\lampreystation\lamprey.dm"
 #include "maps\packedstation\telecomms.dm"


### PR DESCRIPTION
[performance]

## What this does
makes the snowy overlay on all snow turfs a vis_contents'd image with properties tied to the current climate instead of a new object on each turf so they work more like how gas overlays do, only makes a snowprint parent object exist on a snow turf if there are actually snowprints, and cuts down on some switch blocks and makes them into equivalent math formulas, all tested working

seems like there's sadly no way around snowprints being objects on the turf though because you can't change the plane of an icon but can't colorswap on an image, THANKS BYOND

## Why it's good
should aid performance and cause tens of thousands less objects to exist on snowmaps