### PR TITLE
space cleaner no longer requires limb targeting to clean held items / clothing

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2445,7 +2445,7 @@
 	if(iscarbon(M))
 		var/mob/living/carbon/H = M
 		for(var/obj/item/I in H.held_items)
-				I.clean_blood()
+			I.clean_blood()
 
 		for(var/obj/item/clothing/C in M.get_equipped_items())
 			for(var/part in zone_sels)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2444,8 +2444,7 @@
 
 	if(iscarbon(M))
 		var/mob/living/carbon/H = M
-		if((LIMB_LEFT_HAND in zone_sels) || (LIMB_RIGHT_HAND in zone_sels))
-			for(var/obj/item/I in H.held_items)
+		for(var/obj/item/I in H.held_items)
 				I.clean_blood()
 
 		for(var/obj/item/clothing/C in M.get_equipped_items())

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2447,11 +2447,10 @@
 		for(var/obj/item/I in H.held_items)
 			I.clean_blood()
 
-		for(var/obj/item/clothing/C in M.get_equipped_items())
-			for(var/part in zone_sels)
-				if(C.body_parts_covered & limb_define_to_part_define(part))
-					if(C.clean_blood())
-						H.update_inv_by_slot(C.slot_flags)
+		for(var/obj/item/clothing/C in M.get_equipped_items())	
+			if(C.clean_blood())
+				H.update_inv_by_slot(C.slot_flags)
+
 		M.clean_blood()
 		M.color = ""
 


### PR DESCRIPTION
## What this does
You can now once again clean your held items and clothes using space cleaner, without having to particular limbs.
## Why it's good
No one does this or would think to do this. It's a solution seeking a problem that was added in kanef's limb targeting PR.
Limb targeting has a time and a place, but not here.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Space cleaner now cleans held items without having to target a specific limb.
 * tweak: Space cleaner now cleans all clothes, regardless of which limb is being targeted.