### PR TITLE
Adds status alert you can click to automatically use the "exit active cryo tube" function

### DIFF
--- a/code/_onclick/hud/screen_alarms.dm
+++ b/code/_onclick/hud/screen_alarms.dm
@@ -200,8 +200,11 @@ var/global/list/screen_alarms_locs = list(
 
 /obj/abstract/screen/alert/object/cryo/Click(location, control, params)
 	. = ..()
-	if(master)
-		return master.AltClick(usr)
+	var/obj/machinery/atmospherics/unary/cryo_cell/C = master
+	if(C)
+		if(!C.on)
+			return C.go_out(ejector = usr) //If the cryo tube is off, exit normally.
+		return C.AltClick(usr) //Otherwise, use the 30 second exit method.
 
 /obj/abstract/screen/alert/object/buckled
 	name = "Buckled"

--- a/code/_onclick/hud/screen_alarms.dm
+++ b/code/_onclick/hud/screen_alarms.dm
@@ -84,20 +84,24 @@ var/global/list/screen_alarms_locs = list(
 	5 = ui_alert5
 	)
 
-//Re-render all alerts - also called in /datum/hud/show_hud() because it's needed there
+//Re-render all alerts
 /datum/hud/proc/reorganize_alerts()
-	var/list/alerts = mymob.alerts
+	var/list/mobalerts = mymob.alerts
 	var/icon_pref
-	if(!alerts.len)
+	if(!mobalerts.len)
 		return FALSE
 	if(!hud_shown)
-		for(var/i = 1, i <= alerts.len, i++)
-			mymob.client.screen -= alerts[alerts[i]]
+		for(var/i = 1, i <= mobalerts.len, i++)
+			mymob.client.screen -= mobalerts[mobalerts[i]]
 		return TRUE
-	for(var/i = 1, i <= alerts.len, i++)
+	for(var/obj/abstract/screen/alert/A in mobalerts) 			//Sorting the alerts list before it's passed to the client's screen
+		if(istype(A, /obj/abstract/screen/alert/object/cryo))
+			mobalerts.Swap(A, 1) 								//Cryo alert goes on top because it's taller than all of the other alerts
+			continue 											//Surely you won't ever be in TWO cryopods at once... right?
+	for(var/i = 1, i <= mobalerts.len, i++)
 		if(i > screen_alarms_locs.len)
 			break
-		var/obj/abstract/screen/alert/alert = alerts[alerts[i]]
+		var/obj/abstract/screen/alert/alert = mobalerts[mobalerts[i]]
 		if(alert.icon_state == "template")
 			if(!icon_pref)
 				icon_pref = ui_style2icon(mymob.client.prefs.UI_style)

--- a/code/_onclick/hud/screen_alarms.dm
+++ b/code/_onclick/hud/screen_alarms.dm
@@ -94,10 +94,9 @@ var/global/list/screen_alarms_locs = list(
 		for(var/i = 1, i <= mobalerts.len, i++)
 			mymob.client.screen -= mobalerts[mobalerts[i]]
 		return TRUE
-	for(var/obj/abstract/screen/alert/A in mobalerts) 			//Sorting the alerts list before it's passed to the client's screen
-		if(istype(A, /obj/abstract/screen/alert/object/cryo))
-			mobalerts.Swap(A, 1) 								//Cryo alert goes on top because it's taller than all of the other alerts
-			continue 											//Surely you won't ever be in TWO cryopods at once... right?
+	for(var/i in 1 to mobalerts.len)
+		if(mobalerts[i] == "mob_cryo")
+			mobalerts.Swap(i, 1)
 	for(var/i = 1, i <= mobalerts.len, i++)
 		if(i > screen_alarms_locs.len)
 			break
@@ -124,6 +123,7 @@ var/global/list/screen_alarms_locs = list(
 #define TEMP_ALARM_HEAT_STRONG 4
 
 #define SCREEN_ALARM_BUCKLE "mob_buckle"
+#define SCREEN_ALARM_CRYO "mob_cryo"
 #define SCREEN_ALARM_PRESSURE "mob_pressure"
 #define SCREEN_ALARM_TEMPERATURE "mob_temp"
 #define SCREEN_ALARM_FIRE "mob_fire"

--- a/code/_onclick/hud/screen_alarms.dm
+++ b/code/_onclick/hud/screen_alarms.dm
@@ -194,10 +194,19 @@ var/global/list/screen_alarms_locs = list(
 /obj/abstract/screen/alert/object
 	icon_state = "template" // We'll set the icon to the client's ui pref in reorganize_alerts()
 
+/obj/abstract/screen/alert/object/cryo
+	name = "Cryogenics"
+	desc = "You're frozen inside a cryogenics tube. Click on this alert to engage the release sequence."
+
+/obj/abstract/screen/alert/object/cryo/Click(location, control, params)
+	. = ..()
+	if(master)
+		return master.AltClick(usr)
+
 /obj/abstract/screen/alert/object/buckled
 	name = "Buckled"
 	desc = "You've been buckled to something and can't move. Click on this alert to unbuckle."
-
+	
 /obj/abstract/screen/alert/object/buckled/coffin/Click(location, control, params)
 	if(!usr || !usr.client)
 		return

--- a/code/_onclick/hud/screen_alarms.dm
+++ b/code/_onclick/hud/screen_alarms.dm
@@ -206,7 +206,7 @@ var/global/list/screen_alarms_locs = list(
 /obj/abstract/screen/alert/object/buckled
 	name = "Buckled"
 	desc = "You've been buckled to something and can't move. Click on this alert to unbuckle."
-	
+
 /obj/abstract/screen/alert/object/buckled/coffin/Click(location, control, params)
 	if(!usr || !usr.client)
 		return

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -546,7 +546,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 			if(B)
 				B.buckle_mob(occupant, ejector)
 				ejector.start_pulling(B)
-		occupant.clear_alert(SCREEN_ALARM_BUCKLE)
+		occupant.clear_alert(SCREEN_ALARM_CRYO)
 		occupant = null
 	update_icon()
 	nanomanager.update_uis(src)
@@ -613,7 +613,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	update_icon()
 	nanomanager.update_uis(src)
 	M.ExtinguishMob()
-	M.throw_alert(SCREEN_ALARM_BUCKLE, /obj/abstract/screen/alert/object/cryo, new_master = src)
+	M.throw_alert(SCREEN_ALARM_CRYO, /obj/abstract/screen/alert/object/cryo, new_master = src)
 	if(user)
 		if(M == user)
 			visible_message("[user] climbs into \the [src].")

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -546,7 +546,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 			if(B)
 				B.buckle_mob(occupant, ejector)
 				ejector.start_pulling(B)
-	//	occupant.metabslow = 0
+		occupant.clear_alert(SCREEN_ALARM_BUCKLE)
 		occupant = null
 	update_icon()
 	nanomanager.update_uis(src)
@@ -613,7 +613,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	update_icon()
 	nanomanager.update_uis(src)
 	M.ExtinguishMob()
-
+	M.throw_alert(SCREEN_ALARM_BUCKLE, /obj/abstract/screen/alert/object/cryo, new_master = src)
 	if(user)
 		if(M == user)
 			visible_message("[user] climbs into \the [src].")

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -618,7 +618,6 @@
 		usr.client.perspective = EYE_PERSPECTIVE
 		usr.client.eye = src
 		usr.forceMove(src)
-//		usr.metabslow = 1
 		occupant = usr
 		isopen = 0 //Close the thing after the guy gets inside
 		update_icon()


### PR DESCRIPTION
"Hey anon! You DID know you could alt-click to get out a cryo tube... right? It even works when you're fast asleep!"
Most people don't know this, so I added an alert you can click to get out of cryo.

My appreciation goes out to DamianQ, Rasuo, and Bright who all helped my pea-brain understand and fix what was wrong with how I was trying to prioritize the cryo alert. Thank you for your patience!

## Why it's good
Makes a vital function of the tubes more apparent + convenient.

## To do
- [x] Handle alert addition and removal from occupant
- [x] Add exception for when the cryo tubes are off
- [x] Address issue with overlapping alerts if cryotube entered when an alert is already present
## 

:cl:
 * rscadd: You can now click a status alert (similar to the chair buckle alert) to release yourself from cryo, even when asleep!
