### PR TITLE
Hyperzine Heartdamage Nerf

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3525,17 +3525,17 @@ var/procizine_tolerance = 0
 		M.emote(pick("twitch","blink_r","shiver")) //See movement_tally_multiplier for the rest
 
 /datum/reagent/hyperzine/on_overdose(var/mob/living/M)
+	..() //calls parent to give everyone toxin damage
 	if(ishuman(M) && M.get_heart()) // Got a heart?
 		var/mob/living/carbon/human/H = M
 		var/datum/organ/internal/heart/damagedheart = H.get_heart()
 		if(H.species.name != "Diona" && damagedheart) // Not on dionae
-			if(prob(5) && M.stat == CONSCIOUS)
+			if(prob(15) && M.stat == CONSCIOUS)
 				to_chat(H, "<span class='danger'>You feel a sharp pain in your chest!</span>")
-			damagedheart.damage += 1
+				damagedheart.damage += 1
 		else
 			M.adjustFireLoss(1) // Burn damage for dionae
-	else
-		M.adjustToxLoss(1) // Toxins for everyone else
+
 
 /datum/reagent/hyperzine/on_plant_life(obj/machinery/portable_atmospherics/hydroponics/T)
 	if(!holder)
@@ -7042,7 +7042,7 @@ var/procizine_tolerance = 0
 	color = "#2043D0"
 	glass_icon_state = "husbando"
 	glass_name = "\improper Husbando"
-	
+
 /datum/reagent/ethanol/husbando/on_mob_life(var/mob/living/M) //it's copypasted from waifu
 	if(..())
 		return 1
@@ -7072,7 +7072,7 @@ var/procizine_tolerance = 0
 	glass_icon_state = "tomboy"
 	glass_name = "\improper Tomboy"
 
-/datum/reagent/ethanol/tomboy/on_mob_life(var/mob/living/M) 
+/datum/reagent/ethanol/tomboy/on_mob_life(var/mob/living/M)
 	if(..())
 		return 1
 	if(M.gender == MALE)


### PR DESCRIPTION
## What this does
This change makes hyperzine have a 15% chance to deal heart damage, down from a 100% chance per #29261
it also adds back the toxin damage on overdose to all humanoids which was previously moved to only non-diona carbons without hearts.

## Why it's good
When doing the math pomf informed me that a 16 unit overdose would be a death sentence, which seems extreme to me. This change keeps the heart damage while moving it to a chance so it isn't as lethal while also reintroducing the toxin damage to humans so that hyperzine is still more deadly to overdose on than other reagents. Locally compiled and tested.

## Changelog
:cl:
 * rscadd: hyperzine now also does toxin damage on overdose no matter what
 * rscdel: hyperzine now only has a chance to deal heart damage instead of a guarantee

