### PR TITLE
Mutated cockroach meat name

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -229,6 +229,7 @@
 	bitesize = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/meat/roach/big
+	name = "mutated cockroach meat"
 	desc = "A chunk of meat from an above-average sized cockroach."
 	icon_state = "bigroachmeat"
 


### PR DESCRIPTION
Now that there are specific uses for both regular cockroach meat and mutated cockroach meat, I think it's better to have them properly differentiated.
:cl:
 * tweak: Mutated cockroach meat no longer shares the exact same name as regular cockroach meat.
