### PR TITLE
Attacking simplemobs plays your weapon hitsound.

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -71,6 +71,8 @@
 	M.adjustFireLoss(burn_dmg)
 	M.adjustToxLoss(toxin_dmg)
 
+	updatehealth()
+
 	M.iscorpse = 1
 
 	M.pixel_x = src.pixel_x

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -71,12 +71,15 @@
 	M.adjustFireLoss(burn_dmg)
 	M.adjustToxLoss(toxin_dmg)
 
-	M.updatehealth()
-
 	M.iscorpse = 1
 
 	M.pixel_x = src.pixel_x
 	M.pixel_y = src.pixel_y
+
+	M.lying = 1
+	M.updatehealth()
+	M.regenerate_icons()
+	M.update_transform()
 
 	if(generate_random_appearance)
 		M.dna.ResetSE()

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -71,7 +71,7 @@
 	M.adjustFireLoss(burn_dmg)
 	M.adjustToxLoss(toxin_dmg)
 
-	updatehealth()
+	M.updatehealth()
 
 	M.iscorpse = 1
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -539,6 +539,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 		return
 	if(supernatural && isholyweapon(O))
 		purge = 3
+	playsound(loc, O.hitsound, 50, 1, -1)
 	..()
 
 


### PR DESCRIPTION
one of those things that make you wonder how it went unnoticed for so long.
silicons have the same problem of silent hitsounds but I'm not fixing it here because the "meaty" sounding hitsounds wouldn't really work when attacking a hunk of metal.

not tested
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Hitsounds now work when attacking simple animals.
 * tweak: Killed humanoid simplemobs shouldn't stand around akwardly before dying anymore.

