### PR TITLE
Swaps gunk kabob and roaches on a stick recipes.

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -3541,6 +3541,7 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/popcorn/cricket
 
 /datum/recipe/gunkkabobroach
+	reagents = list(GUNKS = 5)
 	items = list(
 		/obj/item/stack/rods,
 		/obj/item/weapon/reagent_containers/food/snacks/meat/roach,
@@ -3549,6 +3550,7 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/gunkkabob
 
 /datum/recipe/gunkkabobcricket
+	reagents = list(GUNKS = 5)
 	items = list(
 		/obj/item/stack/rods,
 		/obj/item/weapon/reagent_containers/food/snacks/meat/cricket,
@@ -3628,7 +3630,6 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/gunkcake
 	
 /datum/recipe/roachesonastick
-	reagents = list(GUNKS = 5)
 	items = list(
 		/obj/item/stack/rods,
 		/obj/item/weapon/reagent_containers/food/snacks/meat/roach,


### PR DESCRIPTION
Pushes further into the "it's literally 2 cockroaches on a stick" deal since you only need to use 2 cockroach meat and 1 stick.
:cl:
 * tweak: Gunk kabob now needs 5u Gunk to be cooked. Roaches on a stick no longer needs Gunk to be cooked.