### PR TITLE
fix plasma seal suit modification

### DIFF
--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -151,7 +151,6 @@
 	if(rig.clothing_flags & PLASMAGUARD) //i think that's how it's done?
 		say_to_wearer("Existing plasma seal detected. Aborting.")
 		already_has=TRUE
-		deactivate()
 		return
 	say_to_wearer("Plasma seal initialized.")
 	rig.clothing_flags |= PLASMAGUARD

--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -151,6 +151,7 @@
 	if(rig.clothing_flags & PLASMAGUARD) //i think that's how it's done?
 		say_to_wearer("Existing plasma seal detected. Aborting.")
 		already_has=TRUE
+		deactivate()
 		return
 	say_to_wearer("Plasma seal initialized.")
 	rig.clothing_flags |= PLASMAGUARD

--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -143,9 +143,14 @@
 	name = "plasma-proof sealing authority"
 	desc = "Brings the suit it is installed into up to plasma environment standards."
 	active_power_usage = 5
+	var/already_has = FALSE //what kind of shitlang uses all cap booleans?
 
 /obj/item/rig_module/plasma_proof/activate()
 	if(!check_activate())
+		return
+	if(rig.clothing_flags & PLASMAGUARD) //i think that's how it's done?
+		say_to_wearer("Existing plasma seal detected. Aborting.")
+		already_has=TRUE
 		return
 	say_to_wearer("Plasma seal initialized.")
 	rig.clothing_flags |= PLASMAGUARD
@@ -155,6 +160,8 @@
 
 /obj/item/rig_module/plasma_proof/deactivate()
 	if(!check_deactivate())
+		return
+	if(already_has)
 		return
 	say_to_wearer("Plasma seal disengaged.")
 	rig.clothing_flags &= ~PLASMAGUARD


### PR DESCRIPTION
## What this does
makes it so that installing the plasma sealant module no longer will override plasma sealing that a suit already has.

## Why it's good
it fixes a silly quirk of how the module set clothing flags.

## Changelog
:cl:
 * bugfix​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​: plasmaguard flag from module no longer gets removed if a suit already has the flag
 * bugfix: plasma mod disables if there's already plasma protection