### PR TITLE
Frying pan tweaks

### DIFF
--- a/code/game/objects/items/weapons/pan.dm
+++ b/code/game/objects/items/weapons/pan.dm
@@ -29,8 +29,13 @@
 	var/global/list/datum/recipe/available_recipes // List of the recipes you can use
 	var/global/list/acceptable_items = list( // List of the items you can put in
 							/obj/item/weapon/kitchen/utensil,/obj/item/device/pda,/obj/item/device/paicard,
-							/obj/item/weapon/cell,/obj/item/weapon/circuitboard,/obj/item/device/aicard
-							)
+							/obj/item/weapon/cell,/obj/item/weapon/circuitboard,/obj/item/device/aicard)
+	var/global/list/accepts_reagents_from = list(/obj/item/weapon/reagent_containers/glass, //List of items that can be used to transfer reagents to the pan.
+												/obj/item/weapon/reagent_containers/food/drinks,
+												/obj/item/weapon/reagent_containers/food/condiment,
+												/obj/item/weapon/reagent_containers/syringe,
+												/obj/item/weapon/reagent_containers/dropper)
+
 
 /obj/item/weapon/reagent_containers/pan/New()
 	. = ..()
@@ -123,7 +128,7 @@
 	if (!adjacency_flag)
 		return
 
-	//we drop ingredients out of the pan here in three situations:
+	//we drop non-reagent ingredients out of the pan here in three situations:
 		//if we are on disarm intent and use it on a table
 		//if we use it on a non-dense turf
 		//if we use it on a mob
@@ -136,6 +141,8 @@
 			drop_ingredients(target, user)
 	else if(ismob(target))
 		drop_ingredients(target, user)
+	else if(isobj(target))
+		transfer(target, user)
 
 /obj/item/weapon/reagent_containers/pan/attackby(var/obj/item/I, var/mob/user)
 
@@ -179,11 +186,11 @@
 		cook_reboot(user) //Reset the cooking status.
 		update_icon()
 
-	else if(istype(I,/obj/item/weapon/grab))
+	else if(istype(I, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/G = I
 		to_chat(user, "<span class='notice'>The thought of stuffing [G.affecting] into [src] amuses you.</span>")
 
-	else
+	else if(!is_type_in_list(I, accepts_reagents_from))
 		to_chat(user, "<span class='notice'>You have no idea what you can cook with [I].</span>")
 
 /obj/item/weapon/reagent_containers/pan/attack_self(mob/user as mob)
@@ -444,10 +451,9 @@
 	//Getting pans by crafting, cargo crates, and vending machines.
 	//Food being ready making a steam sprite that turns to smoke and fire if left on too long.
 	//Sizzling sound with hot reagents in the pan.
-	//Scooping hot oil out of the deepfryer.
+	//Scooping hot oil out of the deepfryer (can scoop, but the oil isn't hot).
 	//Scalding people with hot reagents (the reagents are already heated on the pan I'm just not sure if there's a way to scald someone with hot reagents).
 	//Body-part specific splash text and also when you dump it onto yourself upon equipping to the head.
-	//Pouring reagents from the pan into other reagent containers (need to consider what to do if it also contains items).
 	//Hot pans with glowing red sprite and extra damage.
 	//Stuff dumping out of the pan when attacking a breakable object, window, camera, etc.
 	//Generalize thermal transfer parameter.

--- a/code/game/objects/items/weapons/pan.dm
+++ b/code/game/objects/items/weapons/pan.dm
@@ -30,7 +30,7 @@
 	var/global/list/acceptable_items = list( // List of the items you can put in
 							/obj/item/weapon/kitchen/utensil,/obj/item/device/pda,/obj/item/device/paicard,
 							/obj/item/weapon/cell,/obj/item/weapon/circuitboard,/obj/item/device/aicard)
-	var/global/list/accepts_reagents_from = list(/obj/item/weapon/reagent_containers/glass, //List of items that can be used to transfer reagents to the pan.
+	var/global/list/accepts_reagents_from = list(/obj/item/weapon/reagent_containers/glass, //Used to suppress message when transferring from these to the pan.
 												/obj/item/weapon/reagent_containers/food/drinks,
 												/obj/item/weapon/reagent_containers/food/condiment,
 												/obj/item/weapon/reagent_containers/syringe,

--- a/code/game/objects/items/weapons/pan.dm
+++ b/code/game/objects/items/weapons/pan.dm
@@ -444,7 +444,7 @@
 	//Food being ready making a steam sprite that turns to smoke and fire if left on too long.
 	//Sizzling sound with hot reagents in the pan.
 	//Scooping hot oil out of the deepfryer.
-	//Scalding people with hot reagents (the reagents are alread heated on the pan I'm just not sure if there's a way to scald someone with hot reagents).
+	//Scalding people with hot reagents (the reagents are already heated on the pan I'm just not sure if there's a way to scald someone with hot reagents).
 	//Body-part specific splash text and also when you dump it onto yourself upon equipping to the head.
 	//Pouring reagents from the pan into other reagent containers (need to consider what to do if it also contains items).
 	//Hot pans with glowing red sprite and extra damage.

--- a/code/game/objects/items/weapons/pan.dm
+++ b/code/game/objects/items/weapons/pan.dm
@@ -250,7 +250,7 @@
 		//otherwise, say that the wielder spills it onto the target
 		else
 			dropper.visible_message( \
-					"<span class='[spanclass]'>[dropper] [splashverb][target ? "" : " out"] the contents of [src][target ? " onto [target == dropper ? get_reflexive_pronoun(dropper) : target]" : ""][spanclass == "warning" ? "!" : "."]</span>", \
+					"<span class='[spanclass]'>[dropper] [splashverb][target ? "" : " out"] the contents of [src][target ? " onto [target == dropper ? get_reflexive_pronoun(dropper.gender) : target]" : ""][spanclass == "warning" ? "!" : "."]</span>", \
 					"<span class='[spanclass]'>You [shift_verb_tense(splashverb)][target ? "" : " out"] the contents of [src][target ? " onto [target == dropper ? "yourself" : target]" : ""].</span>")
 	else
 		visible_message("<span class='warning'>Everything [splashverb] out of [src] [target ? "onto [target]" : ""]!</span>")

--- a/code/game/objects/items/weapons/pan.dm
+++ b/code/game/objects/items/weapons/pan.dm
@@ -195,7 +195,8 @@
 /obj/item/weapon/reagent_containers/pan/proc/take_something_out(mob/user as mob)
 	if(contents.len)
 		var/atom/movable/content = contents[contents.len]
-		if(user.put_in_hands(content))
+		user.put_in_hands(content)
+		if(content.loc != src) //If something was taken out successfully.
 			to_chat(user, "<span class='notice'>You take [content] out of [src].</span>")
 			cook_reboot(user)
 			update_icon()

--- a/code/game/objects/items/weapons/pan.dm
+++ b/code/game/objects/items/weapons/pan.dm
@@ -141,8 +141,10 @@
 			drop_ingredients(target, user)
 	else if(ismob(target))
 		drop_ingredients(target, user)
-	else if(isobj(target))
-		transfer(target, user)
+	else if(isobj(target) && (loc != target))
+		var/obj/O = target
+		if(!O.is_cooktop)
+			transfer(target, user)
 
 /obj/item/weapon/reagent_containers/pan/attackby(var/obj/item/I, var/mob/user)
 

--- a/code/game/objects/items/weapons/pan.dm
+++ b/code/game/objects/items/weapons/pan.dm
@@ -453,7 +453,6 @@
 	//Getting pans by crafting, cargo crates, and vending machines.
 	//Food being ready making a steam sprite that turns to smoke and fire if left on too long.
 	//Sizzling sound with hot reagents in the pan.
-	//Scooping hot oil out of the deepfryer (can scoop, but the oil isn't hot).
 	//Scalding people with hot reagents (the reagents are already heated on the pan I'm just not sure if there's a way to scald someone with hot reagents).
 	//Body-part specific splash text and also when you dump it onto yourself upon equipping to the head.
 	//Hot pans with glowing red sprite and extra damage.

--- a/code/game/objects/items/weapons/pan.dm
+++ b/code/game/objects/items/weapons/pan.dm
@@ -437,24 +437,24 @@
 /////////////////////Areas for to consider for further expansion/////////////////////
 
 	//Plating directly to trays and robot trays.
-	//Grill sprite dynamically responding to power
-	//Setting chef var on_reagents_change as well
-	//Edge cases like recooking the same warm donk pocket over and over
+	//Grill sprite dynamically responding to power.
+	//Setting chef var on_reagents_change as well.
+	//Edge cases like recooking the same warm donk pocket over and over.
 	//Getting pans by crafting, cargo crates, and vending machines.
 	//Food being ready making a steam sprite that turns to smoke and fire if left on too long.
 	//Sizzling sound with hot reagents in the pan.
-	//Scooping hot oil out of the deepfryer
-	//Scalding people with hot reagents (the reagents are alread heated on the pan I'm just not sure if there's a way to scald someone with hot reagents)
+	//Scooping hot oil out of the deepfryer.
+	//Scalding people with hot reagents (the reagents are alread heated on the pan I'm just not sure if there's a way to scald someone with hot reagents).
 	//Body-part specific splash text and also when you dump it onto yourself upon equipping to the head.
-	//Pouring reagents from the pan into other reagent containers (need to consider what to do if it also contains items)
-	//Hot pans with glowing red sprite and extra damage
+	//Pouring reagents from the pan into other reagent containers (need to consider what to do if it also contains items).
+	//Hot pans with glowing red sprite and extra damage.
 	//Stuff dumping out of the pan when attacking a breakable object, window, camera, etc.
 	//Generalize thermal transfer parameter.
-	//Componentize cooking vessels
-	//Spilling (including onto people) when thrown impacting..
+	//Componentize cooking vessels.
+	//Spilling (including onto people) when thrown impacting.
 	//Different cook timings based on heat, or cooking with heat transfer (defined at the recipe level?) rather than a timer.
-	//Frying stuff in oil (could use recipes for this)
+	//Frying stuff in oil (could use recipes for this).
 	//Address cases with large ingredient sprites (see the note in update_icon()).
 	//Consider generating and storing the pan front blood overlay in the same manner as general blood overlays.
 	//Cooking automatically with high ambient heat.
-	//Change order of messages with eg. splashing acid on onesself when equipping the pan to the heat.
+	//Change order of messages with eg. splashing acid on onesself when equipping the pan to the head.

--- a/code/game/objects/items/weapons/pan.dm
+++ b/code/game/objects/items/weapons/pan.dm
@@ -128,7 +128,7 @@
 	if (!adjacency_flag)
 		return
 
-	//we drop non-reagent ingredients out of the pan here in three situations:
+	//we drop ingredients out of the pan here in three situations:
 		//if we are on disarm intent and use it on a table
 		//if we use it on a non-dense turf
 		//if we use it on a mob

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -3458,7 +3458,7 @@
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/greytvdinnerclassic
 
-/datum/recipe/greygreens
+/datum/recipe/salad/greygreens
 	reagents = list(SOYSAUCE = 10)
 	items = list(
 		/obj/item/weapon/grown/nettle,


### PR DESCRIPTION
This does the following:

- makes it so grey greens are a salad and so not pan-cookable.
- fixes it saying "splashes the contents of the frying pan onto itself" to the correct "himself/herself/itself/themselves", when someone splashes the contents of the pan onto themselves.
- fixes #33660 which was caused by it checking that something was successfully put into the hand before updating the icon, missing cases where something was taken out but put onto the floor due to the take-outer having their hands full. 
- makes it so you can transfer reagents in the pan to other reagent containers, while keeping non-reagent ingredients in the pan
- makes it so you can take oil out of the deepfryer with a pan

I'd like to make it so that you can take hot oil out of the deepfryer and then scald people with it, but there are two? issues with this that should probably be addressed in a separate PR:

- Oil in the deep fryer is room temperature.
- I don't think there is a heat-based reagent interaction for scalding mobs.

This PR does handle the frying pan side of this however. 

:cl:
* rscadd: Reagents can be transferred out of frying pans into other reagent containers.
* rscadd: Oil can be taken out of the deepfryer with a frying pan.
* tweak: Grey greens are no longer pan-cookable.