### PR TITLE
Allows syndicate chems to convert their normal equivalents

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -771,7 +771,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/jobspecific/medical/antisocial
 	name = "Explosive Hug Chemical"
-	desc = "30 units of Bicarodyne, a special chemical that causes a devastating explosion when exposed to endorphins released in the body by a hug. Metabolizes quite slowly."
+	desc = "30 units of Bicarodyne, a special chemical that causes a devastating explosion when exposed to endorphins released in the body by a hug. Metabolizes quite slowly. Converts Bicaridine into more of this substance."
 	item = /obj/item/weapon/storage/box/syndie_kit/explosive_hug //Had to be put in a box because it didn't play well with reagent creation
 	cost = 9
 	discounted_cost = 8
@@ -779,7 +779,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/jobspecific/medical/hypozinebottle
 	name = "Lethal Speed Chemical"
-	desc = "30 units of Hypozine, a special chemical that causes the body to seamlessly synthesize Hyperzine, but also causes increases in muscle activity to levels that rapidly tear the user's body apart, causing catastrophic ligament failure. Metabolizes quite slowly."
+	desc = "30 units of Hypozine, a special chemical that causes the body to seamlessly synthesize Hyperzine, but also causes increases in muscle activity to levels that rapidly tear the user's body apart, causing catastrophic ligament failure. Metabolizes quite slowly. Converts Hyperzine into more of this substance."
 	item = /obj/item/weapon/storage/box/syndie_kit/lethal_hyperzine
 	cost = 5
 	discounted_cost = 4

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1013,6 +1013,22 @@
 	else
 		holder.clear_reagents()
 
+/datum/chemical_reaction/more_bicarodyne
+	name = "Bicarodyne"
+	id = BICARODYNE
+	result = BICARODYNE
+	required_reagents = list(BICARIDINES = 1)
+	required_catalysts = list(BICARODYNE = 1)
+	result_amount = 1
+
+/datum/chemical_reaction/more_hypozine
+	name = "Hypozine"
+	id = HYPOZINE
+	result = HYPOZINE
+	required_reagents = list(HYPERZINES = 1)
+	required_catalysts = list(HYPOZINE = 1)
+	result_amount = 1
+
 /datum/chemical_reaction/nanobots
 	name = "Nanobots"
 	id = NANOBOTS
@@ -3631,7 +3647,7 @@
 	result = HUSBANDO
 	required_reagents = list(MANLYDORF = 1, KARMOTRINE = 4)
 	result_amount = 5
-	
+
 /datum/chemical_reaction/tomboy
 	name = "Tomboy"
 	id = TOMBOY


### PR DESCRIPTION
[tweak][content]

## What this does
makes bicarodyne convert any bicaridine like substance into more bicarodyne.
hypozine does the same with hyperzines.

## Why it's good
gives more usage to these syndicate chems. (let me know if i should change the uplink item prices or conversion rates, this PR makes it normal 1:1 for both)

## Changelog
:cl:
 * rscadd: Bicarodyne now converts bicaridine into itself, and hypozine now converts hyperzine