### PR TITLE
fix false alarm debug message for mushroom people

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1502,7 +1502,7 @@ Values up to 1000 are allowed.", "FPS", fps) as null|num
 
 	//Debugging report to track down a bug, which randomly assigned the plural gender to people.
 	if(character.gender in list(PLURAL, NEUTER))
-		if(isliving(character)) //Ghosts get neuter by default
+		if(isliving(character) && !ismushroom(character)) //Ghosts and mushroom people are neuter by default
 			message_admins("[character] ([character.ckey]) has spawned with their gender as plural or neuter. Please notify coders.")
 			character.setGender(MALE)
 


### PR DESCRIPTION
## What this does
yknow

[00:12:44]ADMINWARN: <span class="admin"><span class="prefix">ADMIN LOG:</span> <span class="message">Mugh Shriuem () has spawned with their gender as plural or neuter. Please notify coders.</span></span>