### PR TITLE
Attempt at fixing arcane door nerve gas

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -274,7 +274,8 @@ var/list/all_doors = list()
 		if (O.blocks_doors())
 			return 0
 	if(arcane_linked_door && arcane_linked_door.density)
-		arcane_linked_door.open()
+		spawn(1)
+			arcane_linked_door.open()
 	if(!operating)
 		operating = 1
 
@@ -319,7 +320,8 @@ var/list/all_doors = list()
 			return 0
 
 	if(arcane_linked_door && !arcane_linked_door.density)
-		arcane_linked_door.close()
+		spawn(1)
+			arcane_linked_door.close()
 
 	operating = 1
 
@@ -427,7 +429,7 @@ var/list/all_doors = list()
 	if(arcane_linked_door && !density && istype(AM,/atom/movable))
 		var/atom/movable/A = AM
 		var/turf/T = get_turf(arcane_linked_door)
-		if(T & T.Cross())
+		if(T && T.Cross())
 			for(var/dir in cardinal)
 				var/turf/T2 = get_step(T,dir)
 				if(T2 && T2.Cross())

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -273,7 +273,7 @@ var/list/all_doors = list()
 	for (var/obj/O in src.loc)
 		if (O.blocks_doors())
 			return 0
-	if(arcane_linked_door)
+	if(arcane_linked_door && arcane_linked_door.density)
 		arcane_linked_door.open()
 	if(!operating)
 		operating = 1
@@ -318,7 +318,7 @@ var/list/all_doors = list()
 		if (O.blocks_doors())
 			return 0
 
-	if(arcane_linked_door)
+	if(arcane_linked_door && !arcane_linked_door.density)
 		arcane_linked_door.close()
 
 	operating = 1
@@ -426,18 +426,13 @@ var/list/all_doors = list()
 	if(arcane_linked_door && !density && istype(AM,/atom/movable))
 		var/atom/movable/A = AM
 		var/turf/T = get_turf(arcane_linked_door)
-		if(T)
-			T = get_step(T,A.dir)
-			if(T && T.Cross())
-				A.forceMove(T)
-				return ..()
+		if(T & T.Cross())
 			for(var/dir in cardinal)
-				T = get_step(T,dir)
-				if(T && T.Cross())
-					A.forceMove(T)
-					return ..()
-			A.forceMove(T)
-			return ..()
+				var/turf/T2 = get_step(T,dir)
+				if(T2 && T2.Cross())
+					A.forceMove(T2)
+					if(A.dir != dir)
+						A.change_dir(dir)
 
 /obj/machinery/door/CanAStarPass(var/obj/item/weapon/card/id/ID)
 	return !density || check_access(ID)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -391,11 +391,12 @@ var/list/all_doors = list()
 
 /obj/machinery/door/arcane_act(mob/user)
 	..()
-	while(!arcane_linked_door || arcane_linked_door == src || arcane_linked_door.flow_flags & ON_BORDER || arcane_linked_door.z == map.zCentcomm) // no windoors or centcomm pls
-		arcane_linked_door = pick(all_doors)
-	arcane_linked_door.arcanetampered = arcanetampered
-	arcane_linked_door.arcane_linked_door = src
-	return "D'R ST'K!"
+	if(!(flow_flags & ON_BORDER))
+		while(!arcane_linked_door || arcane_linked_door == src || arcane_linked_door.flow_flags & ON_BORDER || arcane_linked_door.z == map.zCentcomm) // no windoors or centcomm pls
+			arcane_linked_door = pick(all_doors)
+		arcane_linked_door.arcanetampered = arcanetampered
+		arcane_linked_door.arcane_linked_door = src
+		return "D'R ST'K!"
 
 /obj/machinery/door/bless()
 	..()


### PR DESCRIPTION
[bugfix][performance]

## What this does
my best guess is in worst case scenarios you keep getting forcemove'd back and forth between the two doors causing things to hang, i got that in testing once but thought i fixed it.
also the sound spam was fixed with spawn()s, as many things would be.
Closes #33655.
Closes #33566.

## Changelog
:cl:
 * bugfix: Arcane tampered doors no longer break the universe.
