### PR TITLE
Fixes rune drawing offset

### DIFF
--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -41,7 +41,7 @@
 					switch(direction)
 						if(WEST)
 							src.pixel_x = max(src.pixel_x, 0)
-						if(SOUTH || SOUTHEAST || SOUTHWEST)
+						if(SOUTH, SOUTHEAST, SOUTHWEST)
 							src.pixel_y = max(src.pixel_y, 0)
 						if(EAST)
 							if(istype(src,/obj/effect/decal/cleanable/crayon/text))
@@ -50,7 +50,7 @@
 								src.maptext_width = 32
 								src.update_icon()
 							src.pixel_x = min(src.pixel_x, 0)
-						if(NORTH || NORTHEAST || NORTHWEST)
+						if(NORTH, NORTHEAST, NORTHWEST)
 							if(istype(src,/obj/effect/decal/cleanable/crayon/text))
 								var/obj/effect/decal/cleanable/crayon/text/CT2 = src
 								src.pixel_y = min(src.pixel_y, max(0,src.maptext_height - (CT2.fontsize*1.5)))

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -142,8 +142,8 @@ var/global/list/all_graffitis = list(
 				to_chat(user, "You start drawing graffiti on \the [target].")
 			if("rune")
 				to_chat(user, "You start drawing a rune on \the [target].")
-				pix_x = -16
-				pix_y = -16
+				pix_x = 0
+				pix_y = 0
 			if("text")
 				fontsize = input("How big should the text be, in pts?", "Crayon scribbles", "[CRAYON_MIN_FONTSIZE]") as num
 				if(!fontsize)


### PR DESCRIPTION
[bugfix]

## What this does
Closes #33653.

## Changelog
:cl:
 * bugfix: Crayon drawn runes are now in the center of turfs again.