### PR TITLE
Wall rot event improvements

### DIFF
--- a/code/modules/events/wallrot.dm
+++ b/code/modules/events/wallrot.dm
@@ -1,9 +1,6 @@
 /datum/event/wallrot
 	var/severity = 1
 
-/datum/event/wallrot/can_start()
-	return 30
-
 /datum/event/wallrot/setup()
 	announceWhen = rand(0, 300)
 	endWhen = announceWhen + 1
@@ -15,7 +12,7 @@
 /datum/event/wallrot/can_start()
 	for(var/area/A in the_station_areas)
 		if(locate(/turf/simulated/wall) in A)
-			return 1
+			return 30
 	return 0
 
 /datum/event/wallrot/start()

--- a/code/modules/events/wallrot.dm
+++ b/code/modules/events/wallrot.dm
@@ -30,6 +30,7 @@
 			tries = 0
 			while(!istype(center,/turf/simulated/wall) && tries < 100)
 				center = pick(our_area.get_area_turfs())
+				tries++
 
 			if(center)
 				// Make sure at least one piece of wall rots!

--- a/code/modules/events/wallrot.dm
+++ b/code/modules/events/wallrot.dm
@@ -14,9 +14,8 @@
 
 /datum/event/wallrot/can_start()
 	for(var/area/A in the_station_areas)
-		for(var/turf/T in A.get_area_turfs())
-			if(istype(T,/turf/simulated/wall))
-				return 1
+		if(locate(/turf/simulated/wall) in A)
+			return 1
 	return 0
 
 /datum/event/wallrot/start()

--- a/code/modules/events/wallrot.dm
+++ b/code/modules/events/wallrot.dm
@@ -23,11 +23,11 @@
 		for(var/i in 1 to severity)
 			var/tries = 0
 			var/area/our_area = null
-			while((!our_area || !(locate(/turf/simulated/wall) in our_area.get_area_turfs())) && tries < 100)
+			while((!our_area || !(locate(/turf/simulated/wall) in get_area_turfs(our_area))) && tries < 100)
 				our_area = pick(the_station_areas)
 				tries++
 			var/list/turf/simulated_area_turfs = list()
-			for(var/turf/T in our_area.get_area_turfs())
+			for(var/turf/T in get_area_turfs(our_area))
 				if(istype(T,/turf/simulated/wall))
 					simulated_area_turfs.Add(T)
 			if(simulated_area_turfs.len)

--- a/code/modules/events/wallrot.dm
+++ b/code/modules/events/wallrot.dm
@@ -12,26 +12,36 @@
 /datum/event/wallrot/announce()
 	command_alert(/datum/command_alert/wall_fungi)
 
+/datum/event/wallrot/can_start()
+	for(var/area/A in the_station_areas)
+		for(var/turf/T in A.get_area_turfs())
+			if(istype(T,/turf/simulated/wall))
+				return 1
+	return 0
+
 /datum/event/wallrot/start()
 	spawn()
-		var/turf/center = null
+		for(var/i in 1 to severity)
+			var/tries = 0
+			while((!our_area || !(locate(/turf/simulated/wall) in our_area.get_area_turfs())) && tries < 100)
+				var/area/our_area = pick(the_station_areas)
+				tries++
+			var/turf/center = null
+			tries = 0
+			while(!istype(center,/turf/simulated/wall) && tries < 100)
+				center = pick(our_area.get_area_turfs())
 
-		// 100 attempts
-		for(var/i=0, i<100, i++)
-			var/turf/candidate = locate(rand(1, world.maxx), rand(1, world.maxy), 1)
-			if(istype(candidate, /turf/simulated/wall))
-				center = candidate
+			if(center)
+				// Make sure at least one piece of wall rots!
+				center:rot()
 
-		if(center)
-			// Make sure at least one piece of wall rots!
-			center:rot()
+				// Have a chance to rot lots of other walls.
+				var/rotcount = 0
+				for(var/turf/simulated/wall/W in range(5, center))
+					if(prob(50))
+						W:rot()
+						rotcount++
 
-			// Have a chance to rot lots of other walls.
-			var/rotcount = 0
-			for(var/turf/simulated/wall/W in range(5, center)) if(prob(50))
-				W:rot()
-				rotcount++
-
-				// Only rot up to severity walls
-				if(rotcount >= severity)
-					break
+					// Only rot up to severity walls
+					if(rotcount >= severity)
+						break

--- a/code/modules/events/wallrot.dm
+++ b/code/modules/events/wallrot.dm
@@ -20,12 +20,16 @@
 
 /datum/event/wallrot/start()
 	spawn()
-		for(var/i in 1 to severity)
+		var/list/area/used_areas = list()
+		var/list/turf/used_turfs = list()
+		for(var/i in 1 to round(severity/2))
 			var/tries = 0
 			var/area/our_area = null
-			while((!our_area || !(locate(/turf/simulated/wall) in get_area_turfs(our_area))) && tries < 100)
+			while((!our_area || !(locate(/turf/simulated/wall) in get_area_turfs(our_area)) ||\
+					(our_area in used_areas)) && tries < 100)
 				our_area = pick(the_station_areas)
 				tries++
+			used_areas.Add(our_area)
 			var/list/turf/simulated_area_turfs = list()
 			for(var/turf/T in get_area_turfs(our_area))
 				if(istype(T,/turf/simulated/wall))
@@ -34,15 +38,21 @@
 				var/turf/center = pick(simulated_area_turfs)
 				if(center)
 					// Make sure at least one piece of wall rots!
-					center:rot()
+					if(!(center in used_turfs))
+						center:rot()
+						used_turfs.Add(center)
 
 					// Have a chance to rot lots of other walls.
 					var/rotcount = 0
 					for(var/turf/simulated/wall/W in range(5, center))
-						if(prob(50))
+						if(prob(50) && !(W in used_turfs))
 							W:rot()
+							used_turfs.Add(W)
 							rotcount++
 
 						// Only rot up to severity walls
 						if(rotcount >= severity)
 							break
+
+					log_admin("A wall rot infestation has begun at [center] ([center.x],[center.y],[center.z]) affecting [rotcount] turfs.")
+					message_admins("A wall rot infestation has begun at [formatJumpTo(center)] affecting [rotcount] turfs.")

--- a/code/modules/events/wallrot.dm
+++ b/code/modules/events/wallrot.dm
@@ -22,8 +22,9 @@
 	spawn()
 		for(var/i in 1 to severity)
 			var/tries = 0
+			var/area/our_area = null
 			while((!our_area || !(locate(/turf/simulated/wall) in our_area.get_area_turfs())) && tries < 100)
-				var/area/our_area = pick(the_station_areas)
+				our_area = pick(the_station_areas)
 				tries++
 			var/list/turf/simulated_area_turfs = list()
 			for(var/turf/T in our_area.get_area_turfs())

--- a/code/modules/events/wallrot.dm
+++ b/code/modules/events/wallrot.dm
@@ -26,23 +26,23 @@
 			while((!our_area || !(locate(/turf/simulated/wall) in our_area.get_area_turfs())) && tries < 100)
 				var/area/our_area = pick(the_station_areas)
 				tries++
-			var/turf/center = null
-			tries = 0
-			while(!istype(center,/turf/simulated/wall) && tries < 100)
-				center = pick(our_area.get_area_turfs())
-				tries++
+			var/list/turf/simulated_area_turfs = list()
+			for(var/turf/T in our_area.get_area_turfs())
+				if(istype(T,/turf/simulated/wall))
+					simulated_area_turfs.Add(T)
+			if(simulated_area_turfs.len)
+				var/turf/center = pick(simulated_area_turfs)
+				if(center)
+					// Make sure at least one piece of wall rots!
+					center:rot()
 
-			if(center)
-				// Make sure at least one piece of wall rots!
-				center:rot()
+					// Have a chance to rot lots of other walls.
+					var/rotcount = 0
+					for(var/turf/simulated/wall/W in range(5, center))
+						if(prob(50))
+							W:rot()
+							rotcount++
 
-				// Have a chance to rot lots of other walls.
-				var/rotcount = 0
-				for(var/turf/simulated/wall/W in range(5, center))
-					if(prob(50))
-						W:rot()
-						rotcount++
-
-					// Only rot up to severity walls
-					if(rotcount >= severity)
-						break
+						// Only rot up to severity walls
+						if(rotcount >= severity)
+							break


### PR DESCRIPTION
[tweak]

## What this does
changes the check for this to go through station areas and then turfs in these areas for a place to start the wallrot, instead of any random 100 turfs in the game, wasting a roll.
makes this event actually use can_start() in the event of the entire station's walls dying instead of wasting a roll.
makes more than just one place infected, now anywhere between 3 and 5.

## Why it's good
should make this actually appear to players more, maybe counts as [bugfix] too?

## Changelog
:cl:
 * tweak: Wallrot events are now actually more visible and impacting