### PR TITLE
Anti roundstart-rule-dodging mechanism

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -53,6 +53,7 @@ var/stacking_limit = 90
 	var/midround_injection_cooldown = 0
 
 	var/datum/dynamic_ruleset/latejoin/forced_latejoin_rule = null
+	var/datum/dynamic_ruleset/latejoin/roundstart_latejoin_rule = null
 
 	var/datum/stat/dynamic_mode/dynamic_stats = null
 	var/pop_last_updated = 0
@@ -715,6 +716,14 @@ var/stacking_limit = 90
 			if (forced_latejoin_rule.choose_candidates())
 				picking_latejoin_rule(list(forced_latejoin_rule))
 		forced_latejoin_rule = null
+
+	else if (roundstart_latejoin_rule)
+		roundstart_latejoin_rule.candidates = list(newPlayer)
+		roundstart_latejoin_rule.trim_candidates()
+		if (roundstart_latejoin_rule.ready())
+			if (roundstart_latejoin_rule.choose_candidates())
+				picking_latejoin_rule(list(roundstart_latejoin_rule))
+		roundstart_latejoin_rule = null
 
 	else if (!latejoin_injection_cooldown && injection_attempt())
 		var/list/drafted_rules = list()

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -31,6 +31,8 @@
 				mode.spend_threat(additional_cost)
 			else
 				break
+	if(assigned.len > 0 && num_traitors - assigned.len > 0)
+		mode.roundstart_latejoin_rule = new /datum/dynamic_ruleset/latejoin/infiltrator()
 	return (assigned.len > 0)
 
 /datum/dynamic_ruleset/roundstart/traitor/execute()
@@ -39,10 +41,6 @@
 		newTraitor.AssignToRole(M.mind,1)
 		newTraitor.Greet(GREET_ROUNDSTART)
 		// Above 3 traitors, we start to cost a bit more.
-	var/traitor_scaling_coeff = 10 - max(0,round(mode.threat_level/10)-5)//above 50 threat level, coeff goes down by 1 for every 10 levels
-	var/extra_traitors = assigned - clamp(round((mode.roundstart_pop_ready+1) / traitor_scaling_coeff) + 1, 0, mode.candidates.len+1)
-	if(extra_traitors)
-		mode.roundstart_latejoin_rule = new /datum/dynamic_ruleset/latejoin/infiltrator()
 	return 1
 
 /datum/dynamic_ruleset/roundstart/traitor/previous_rounds_odds_reduction(var/result)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -22,6 +22,7 @@
 /datum/dynamic_ruleset/roundstart/traitor/choose_candidates()
 	var/traitor_scaling_coeff = 10 - max(0,round(mode.threat_level/10)-5)//above 50 threat level, coeff goes down by 1 for every 10 levels
 	var/num_traitors = min(round(mode.roundstart_pop_ready / traitor_scaling_coeff) + 1, candidates.len)
+	var/extra_traitors = min(round(mode.roundstart_pop_ready+1 / traitor_scaling_coeff) + 1, candidates.len+1) - num_traitors
 	for (var/i = 1 to num_traitors)
 		var/mob/M = pick(candidates)
 		assigned += M
@@ -31,7 +32,7 @@
 				mode.spend_threat(additional_cost)
 			else
 				break
-	if(assigned.len > 0 && num_traitors - assigned.len > 0)
+	if(assigned.len > 0 && extra_traitors - assigned.len > 0 && mode.threat > additional_cost)
 		mode.roundstart_latejoin_rule = new /datum/dynamic_ruleset/latejoin/infiltrator()
 	return (assigned.len > 0)
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -39,6 +39,10 @@
 		newTraitor.AssignToRole(M.mind,1)
 		newTraitor.Greet(GREET_ROUNDSTART)
 		// Above 3 traitors, we start to cost a bit more.
+	var/traitor_scaling_coeff = 10 - max(0,round(mode.threat_level/10)-5)//above 50 threat level, coeff goes down by 1 for every 10 levels
+	var/extra_traitors = assigned - clamp(round((mode.roundstart_pop_ready+1) / traitor_scaling_coeff) + 1, 0, mode.candidates.len+1)
+	if(extra_traitors)
+		mode.roundstart_latejoin_rule = new /datum/dynamic_ruleset/latejoin/infiltrator()
 	return 1
 
 /datum/dynamic_ruleset/roundstart/traitor/previous_rounds_odds_reduction(var/result)


### PR DESCRIPTION
[gamemode]

## What this does
using syndicate traitors ruleset as an example, detects that if another traitor slot could've been available with one extra player in similar conditions, it auto assigns the next latejoiner to roll for traitor, with all conditions attached. (such as lowering chance of successful role if they join as sec, eliminating it if prefs are off, etc) 
## Why it's good
stops a way for players to ensure they avoid being antagonist without just turning the pref off.

## Changelog
:cl:
 * tweak: Players who join just after the start of a shift will no longer easily avoid the syndicate's recruitment.