### PR TITLE
Makes diagonal shuttle walls show up on mesons

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -2,8 +2,6 @@
  * False Walls
  */
 
-var/list/false_wall_images = list()
-
 // Minimum pressure difference to fail building falsewalls.
 // Also affects admin alerts.
 #define FALSEDOOR_MAX_PRESSURE_DIFF 25.0
@@ -108,7 +106,7 @@ var/list/false_wall_images = list()
 	icon = 'icons/turf/walls.dmi'
 	var/mineral = "metal"
 	var/opening = 0
-	var/image/meson_image
+	is_on_mesons = TRUE
 
 	// WHY DO WE SMOOTH WITH FALSE R-WALLS WHEN WE DON'T SMOOTH WITH REAL R-WALLS.
 /obj/structure/falsewall/canSmoothWith()
@@ -129,15 +127,7 @@ var/list/false_wall_images = list()
 	if(Adjacent(user))
 		to_chat(user, "<span class='rose'>Now that you're standing close to it, that wall appears a bit odd.</span>")
 
-/obj/structure/falsewall/New()
-	..()
-	update_meson_image()
-
 /obj/structure/falsewall/Destroy()
-	for (var/mob/L in meson_wearers)
-		if (L.client)
-			L.client.images -= meson_image
-	false_wall_images -= meson_image
 	var/temploc = src.loc
 	loc.mouse_opacity = 1
 
@@ -191,21 +181,6 @@ var/list/false_wall_images = list()
 		opening = 0
 		loc.mouse_opacity = 0
 		update_meson_image()
-
-
-/obj/structure/falsewall/proc/update_meson_image()
-	for (var/mob/L in meson_wearers)
-		if (L.client)
-			L.client.images -= meson_image
-	false_wall_images -= meson_image
-	meson_image = image('icons/turf/walls.dmi',loc,icon_state)
-	meson_image.plane = plane
-	meson_image.layer = layer
-	false_wall_images |= meson_image
-	for (var/mob/L in meson_wearers)
-		if (L.client)
-			L.client.images |= meson_image
-
 
 /obj/structure/falsewall/update_icon()//Calling icon_update will refresh the smoothwalls if it's closed, otherwise it will make sure the icon is correct if it's open
 	..()
@@ -284,7 +259,7 @@ var/list/false_wall_images = list()
 	anchored = 1
 	var/mineral = "metal"
 	var/opening = 0
-	var/image/meson_image
+	is_on_mesons = TRUE
 
 /obj/structure/falserwall/examine(var/mob/user)
 	..()
@@ -299,17 +274,9 @@ var/list/false_wall_images = list()
 	)
 	return smoothables
 
-/obj/structure/falserwall/New()
-	..()
-	update_meson_image()
-
 /obj/structure/falserwall/Destroy()
 	var/temploc = src.loc
 	loc.mouse_opacity = 1
-	for (var/mob/L in meson_wearers)
-		if (L.client)
-			L.client.images -= meson_image
-	false_wall_images -= meson_image
 
 	spawn(10)
 		for(var/turf/simulated/wall/W in range(temploc,1))
@@ -370,19 +337,6 @@ var/list/false_wall_images = list()
 		opening = 0
 		loc.mouse_opacity = 0
 		update_meson_image()
-
-/obj/structure/falserwall/proc/update_meson_image()
-	for (var/mob/L in meson_wearers)
-		if (L.client)
-			L.client.images -= meson_image
-	false_wall_images -= meson_image
-	meson_image = image('icons/turf/walls.dmi',src,icon_state)
-	meson_image.plane = plane
-	meson_image.layer = layer
-	false_wall_images += meson_image
-	for (var/mob/L in meson_wearers)
-		if (L.client)
-			L.client.images |= meson_image
 
 /obj/structure/falserwall/relativewall()
 

--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -75,8 +75,6 @@
 	desc = "A huge chunk of metal used to separate rooms."
 	icon_state = "diagonalWall"
 	density = 1
-	plane = TURF_PLANE
-	layer = TURF_LAYER
 	anchored = 1
 	opacity = 1
 	is_on_mesons = TRUE

--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -79,6 +79,7 @@
 	layer = TURF_LAYER
 	anchored = 1
 	opacity = 1
+	is_on_mesons = TRUE
 
 /obj/structure/shuttle/diag_wall/initialize()
 	var/turf/T = get_turf(src)

--- a/code/modules/clothing/glasses/scanners.dm
+++ b/code/modules/clothing/glasses/scanners.dm
@@ -271,9 +271,8 @@ var/list/meson_images = list()
 			L.client.images -= meson_image
 	meson_images -= meson_image
 	if(is_on_mesons)
-		meson_image = image(icon,loc,icon_state)
+		meson_image = image(icon,loc,icon_state,layer,dir)
 		meson_image.plane = plane
-		meson_image.layer = layer
 		meson_images += meson_image
 		for (var/mob/L in meson_wearers)
 			if (L.client)

--- a/code/modules/clothing/glasses/scanners.dm
+++ b/code/modules/clothing/glasses/scanners.dm
@@ -271,7 +271,7 @@ var/list/meson_images = list()
 			L.client.images -= meson_image
 	meson_images -= meson_image
 	if(is_on_mesons)
-		meson_image = image(icon,src,icon_state)
+		meson_image = image(icon,loc,icon_state)
 		meson_image.plane = plane
 		meson_image.layer = layer
 		meson_images += meson_image

--- a/code/modules/clothing/glasses/scanners.dm
+++ b/code/modules/clothing/glasses/scanners.dm
@@ -214,14 +214,14 @@ var/list/meson_wearers = list()
 	if (viewing)
 		meson_wearers -= viewing
 		if (viewing.client)
-			viewing.client.images -= false_wall_images
+			viewing.client.images -= meson_images
 
 /obj/item/clothing/glasses/scanner/meson/proc/apply()
 	if (!viewing || !viewing.client || !on)
 		return
 
 	meson_wearers += viewing
-	viewing.client.images += false_wall_images
+	viewing.client.images += meson_images
 
 /obj/item/clothing/glasses/scanner/meson/unequipped(var/mob/living/carbon/M)
 	update_mob()
@@ -245,6 +245,39 @@ var/list/meson_wearers = list()
 			viewing = new_mob
 			apply()
 
+
+var/list/meson_images = list()
+
+/atom/movable
+	var/image/meson_image
+	var/is_on_mesons = FALSE
+
+/atom/movable/New()
+	..()
+	if(is_on_mesons)
+		update_meson_image()
+
+/atom/movable/Destroy()
+	if(meson_image)
+		for (var/mob/L in meson_wearers)
+			if (L.client)
+				L.client.images -= meson_image
+		meson_images -= meson_image
+	..()
+
+/atom/movable/proc/update_meson_image()
+	for (var/mob/L in meson_wearers)
+		if (L.client)
+			L.client.images -= meson_image
+	meson_images -= meson_image
+	if(is_on_mesons)
+		meson_image = image(icon,src,icon_state)
+		meson_image.plane = plane
+		meson_image.layer = layer
+		meson_images += meson_image
+		for (var/mob/L in meson_wearers)
+			if (L.client)
+				L.client.images |= meson_image
 
 /obj/item/clothing/glasses/scanner/material
 	name = "optical material scanner"


### PR DESCRIPTION
[bugfix]

## What this does
fixes this (cannot find the issue for it)
also creates a general system allowing anything to be seen with these if set to be.

## Changelog
:cl:
 * bugfix: Diagonal shuttle walls can now be seen on mesons again.