### PR TITLE
Hot oil in deep fryers

### DIFF
--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -460,10 +460,16 @@ var/global/ingredientLimit = 10
 	cks_max_volume = 400
 	cooks_in_reagents = 1
 	var/fry_reagent = CORNOIL
+	var/fry_reagent_temp = T0C + 170 //target temperature of the frying reagent
 
 /obj/machinery/cooking/deepfryer/initialize()
 	..()
-	reagents.add_reagent(fry_reagent, 300)
+	reagents.add_reagent(fry_reagent, 300, reagtemp = fry_reagent_temp)
+
+/obj/machinery/cooking/deepfryer/process()
+	if(stat & (FORCEDISABLE | NOPOWER | BROKEN))
+		return
+	reagents.heating(500, fry_reagent_temp) //thermal transfer is half that of fire_act()
 
 /obj/machinery/cooking/deepfryer/proc/empty_icon() //sees if the value is empty, and changes the icon if it is
 	reagents.update_total() //make the values refresh

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -472,7 +472,7 @@ var/global/ingredientLimit = 10
 /obj/machinery/cooking/deepfryer/process()
 	if(stat & (FORCEDISABLE | NOPOWER | BROKEN))
 		return
-	reagents.heating(active_power_usage * 0.9 * SS_WAIT_MACHINERY / 1 SECONDS, fry_reagent_temp) //Assume 90% efficiency. This could be expanded to depend on upgrades.
+	reagents.heating(active_power_usage * 0.9 * SS_WAIT_MACHINERY / (1 SECONDS), fry_reagent_temp) //Assume 90% efficiency. This could be expanded to depend on upgrades.
 
 /obj/machinery/cooking/deepfryer/proc/empty_icon() //sees if the value is empty, and changes the icon if it is
 	reagents.update_total() //make the values refresh

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -472,7 +472,7 @@ var/global/ingredientLimit = 10
 /obj/machinery/cooking/deepfryer/process()
 	if(stat & (FORCEDISABLE | NOPOWER | BROKEN))
 		return
-	reagents.heating(active_power_usage * 0.9 * SS_WAIT_MACHINERY / SECONDS, fry_reagent_temp) //Assume 90% efficiency. This could be expanded to depend on upgrades.
+	reagents.heating(active_power_usage * 0.9 * SS_WAIT_MACHINERY / 1 SECONDS, fry_reagent_temp) //Assume 90% efficiency. This could be expanded to depend on upgrades.
 
 /obj/machinery/cooking/deepfryer/proc/empty_icon() //sees if the value is empty, and changes the icon if it is
 	reagents.update_total() //make the values refresh

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -472,7 +472,7 @@ var/global/ingredientLimit = 10
 /obj/machinery/cooking/deepfryer/process()
 	if(stat & (FORCEDISABLE | NOPOWER | BROKEN))
 		return
-	reagents.heating(500, fry_reagent_temp) //thermal transfer is half that of fire_act()
+	reagents.heating(active_power_usage * 0.9 * SS_WAIT_MACHINERY / SECONDS, fry_reagent_temp) //Assume 90% efficiency. This could be expanded to depend on upgrades.
 
 /obj/machinery/cooking/deepfryer/proc/empty_icon() //sees if the value is empty, and changes the icon if it is
 	reagents.update_total() //make the values refresh

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -464,7 +464,10 @@ var/global/ingredientLimit = 10
 
 /obj/machinery/cooking/deepfryer/initialize()
 	..()
-	reagents.add_reagent(fry_reagent, 300, reagtemp = fry_reagent_temp)
+	if(stat & (FORCEDISABLE | NOPOWER | BROKEN))
+		reagents.add_reagent(fry_reagent, 300)
+	else
+		reagents.add_reagent(fry_reagent, 300, reagtemp = fry_reagent_temp)
 
 /obj/machinery/cooking/deepfryer/process()
 	if(stat & (FORCEDISABLE | NOPOWER | BROKEN))

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -5478,6 +5478,8 @@ var/procizine_tolerance = 0
 	reagent_state = REAGENT_STATE_LIQUID
 	nutriment_factor = 20 * REAGENTS_METABOLISM
 	color = "#302000" //rgb: 48, 32, 0
+	density = 0.9185
+	specheatcap = 2.402	
 	var/has_had_heart_explode = 0
 
 /datum/reagent/cornoil/on_mob_life(var/mob/living/M)


### PR DESCRIPTION
This makes it so the oil in a deep fryer starts out at around 170C. and makes it so that a deepfryer will heat its reagents if their temperature is under this value. This also gives corn oil a proper density and specific heat capacity.
Fixes #33667

:cl:
 * rscadd: Oil in the deep fryer is now hot.
 * rscadd: Added proper density and specific heat capacity values for corn oil.
