### PR TITLE
Hobo shack piping fixes

### DIFF
--- a/maps/misc/hoboshack.dmm
+++ b/maps/misc/hoboshack.dmm
@@ -22,6 +22,14 @@
 /obj/item/stack/sheet/wood/bigstack,
 /turf/simulated/floor/wood,
 /area/shack)
+"cE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	req_access_txt = 1
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidfloor"
+	},
+/area/shack)
 "gK" = (
 /obj/structure/toilet{
 	dir = 8
@@ -136,9 +144,9 @@
 /area/shack)
 "rN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1;
-	initialize_directions = 14
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4;
+	initialize_directions = 12
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidfloor"
@@ -172,9 +180,6 @@
 	},
 /area/shack)
 "vp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	req_access_txt = 1
 	},
@@ -272,6 +277,9 @@
 /obj/item/weapon/reagent_containers/food/drinks/beer,
 /obj/item/weapon/reagent_containers/food/drinks/beer,
 /obj/item/toy/cards,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	req_access_txt = 1
+	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidfloor"
 	},
@@ -282,9 +290,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/hobostart,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = 1
-	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidfloor"
 	},
@@ -320,9 +325,9 @@
 	},
 /area/shack)
 "Kr" = (
-/obj/machinery/atmospherics/unary/vent_pump{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1;
-	on = 1
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidfloor"
@@ -356,6 +361,10 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1;
+	on = 1
+	},
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
@@ -420,9 +429,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4;
 	initialize_directions = 12
-	},
-/obj/machinery/door/mineral/wood{
-	name = "Wooden Door"
 	},
 /obj/machinery/door/mineral/wood{
 	name = "Wooden Door"
@@ -498,7 +504,7 @@ lF
 Tw
 rN
 Fy
-Kr
+Cp
 Od
 ZK
 "}
@@ -508,9 +514,9 @@ Lo
 mM
 lF
 WD
-uX
+Kr
 EH
-Cp
+cE
 QD
 ZK
 "}


### PR DESCRIPTION
[general]

## What this does
removes some duplicate doors and pipes, makes the log door entrance area ventilated.

## Why it's good
whoever mapped the log doors forgot to do this too, stops air from draining in them.

## Changelog
:cl:
 * rscadd: The log door entrance to hobo shacks is now properly ventilated.
 * tweak: Some duplicate pipes and doors have been removed from hobo shacks.