### PR TITLE
Auto-clothing items

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -2008,6 +2008,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/automation
 	name = "Automation supplies"
 	contains = list(/obj/item/weapon/circuitboard/autoprocessor/wrapping,
+					/obj/item/weapon/circuitboard/autoprocessor/clothing,
 					/obj/item/weapon/circuitboard/sorting_machine/item,
 					/obj/item/weapon/circuitboard/crate_opener,
 					/obj/item/weapon/circuitboard/crate_closer)

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1411,7 +1411,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
 					/obj/item/weapon/reagent_containers/food/snacks/meat/cricket,
 					/obj/item/weapon/reagent_containers/food/snacks/meat/roach,
-					/obj/item/weapon/reagent_containers/food/snacks/meat/roach/big			
+					/obj/item/weapon/reagent_containers/food/snacks/meat/roach/big
 					)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure/basic
@@ -2007,7 +2007,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 
 /datum/supply_packs/automation
 	name = "Automation supplies"
-	contains = list(/obj/item/weapon/circuitboard/wrapping_machine,
+	contains = list(/obj/item/weapon/circuitboard/autoprocessor/wrapping,
 					/obj/item/weapon/circuitboard/sorting_machine/item,
 					/obj/item/weapon/circuitboard/crate_opener,
 					/obj/item/weapon/circuitboard/crate_closer)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -1297,9 +1297,9 @@ to destroy them and players will be able to make replacements.
 	desc = "A circuit board used to run a machine that sorts input into two outputs from pre-programmed settings. This one is programmed for items."
 	build_path = /obj/machinery/sorting_machine/item
 
-/obj/item/weapon/circuitboard/autoprocessor/wrapping
-	name = "Circuit Board (Wrapping Machine)"
-	desc = "A circuit board used to run a machine that wraps packages."
+/obj/item/weapon/circuitboard/autoprocessor
+	name = "Circuit Board (Autoprocessor)"
+	desc = "A circuit board used to run a machine that processes things."
 	build_path = /obj/machinery/autoprocessor/wrapping
 	board_type = MACHINE
 	origin_tech = Tc_ENGINEERING + "=2"
@@ -1308,6 +1308,16 @@ to destroy them and players will be able to make replacements.
 		/obj/item/weapon/stock_parts/manipulator = 1,
 		/obj/item/weapon/stock_parts/matter_bin = 2,
 	)
+
+/obj/item/weapon/circuitboard/autoprocessor/wrapping
+	name = "Circuit Board (Wrapping Machine)"
+	desc = "A circuit board used to run a machine that wraps packages."
+	build_path = /obj/machinery/autoprocessor/wrapping
+
+/obj/item/weapon/circuitboard/autoprocessor/clothing
+	name = "Circuit Board (Wrapping Machine)"
+	desc = "A circuit board used to run a machine that clothes living things."
+	build_path = /obj/machinery/autoprocessor/clothing
 
 /obj/item/weapon/circuitboard/processing_unit
 	name = "Circuit Board (Ore Processor)"

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -1297,10 +1297,10 @@ to destroy them and players will be able to make replacements.
 	desc = "A circuit board used to run a machine that sorts input into two outputs from pre-programmed settings. This one is programmed for items."
 	build_path = /obj/machinery/sorting_machine/item
 
-/obj/item/weapon/circuitboard/wrapping_machine
+/obj/item/weapon/circuitboard/autoprocessor/wrapping
 	name = "Circuit Board (Wrapping Machine)"
 	desc = "A circuit board used to run a machine that wraps packages."
-	build_path = /obj/machinery/wrapping_machine
+	build_path = /obj/machinery/autoprocessor/wrapping
 	board_type = MACHINE
 	origin_tech = Tc_ENGINEERING + "=2"
 	req_components = list(

--- a/code/game/objects/items/stacks/packagewrap.dm
+++ b/code/game/objects/items/stacks/packagewrap.dm
@@ -37,7 +37,7 @@
 /obj/item/stack/package_wrap/preattack(var/obj/target, var/mob/user, var/proximity_flag)
 	if(!istype(target, /atom/movable) || !proximity_flag)
 		return
-	if(istype(target,/obj/machinery/wrapping_machine))
+	if(istype(target,/obj/machinery/autoprocessor/wrapping))
 		return
 	if(!is_type_in_list(target, cannot_wrap))
 		if(istype(target, /obj/item/weapon/storage))
@@ -54,7 +54,7 @@
 	var/atom/movable/target = attacked
 	if(!istype(target))
 		return
-	if(istype(target,/obj/machinery/wrapping_machine))
+	if(istype(target,/obj/machinery/autoprocessor/wrapping))
 		return
 	if(is_type_in_list(target, cannot_wrap))
 		to_chat(user, "<span class='notice'>You can't wrap that.</span>")

--- a/code/modules/research/mechanic/flatpack.dm
+++ b/code/modules/research/mechanic/flatpack.dm
@@ -329,3 +329,13 @@
 	..()
 	name = "ancient flatpack (electrolytic chemmaster)"
 	machine = new /obj/machinery/chem_master/electrolytic(src)
+
+/obj/structure/closet/crate/flatpack/ancient/autoclother/New()
+	..()
+	name = "ancient flatpack (autoclother)"
+	machine = new /obj/machinery/autoprocessor/clothing(src)
+
+/obj/structure/closet/crate/flatpack/ancient/prisoner_autoclother/New()
+	..()
+	name = "ancient flatpack (prisoner autoclother)"
+	machine = new /obj/machinery/autoprocessor/clothing/outfit/prisoner(src)

--- a/code/modules/research/mechanic/flatpack.dm
+++ b/code/modules/research/mechanic/flatpack.dm
@@ -330,12 +330,7 @@
 	name = "ancient flatpack (electrolytic chemmaster)"
 	machine = new /obj/machinery/chem_master/electrolytic(src)
 
-/obj/structure/closet/crate/flatpack/ancient/autoclother/New()
-	..()
-	name = "ancient flatpack (autoclother)"
-	machine = new /obj/machinery/autoprocessor/clothing(src)
-
 /obj/structure/closet/crate/flatpack/ancient/prisoner_autoclother/New()
 	..()
 	name = "ancient flatpack (prisoner autoclother)"
-	machine = new /obj/machinery/autoprocessor/clothing/outfit/prisoner(src)
+	machine = new /obj/machinery/autoprocessor/outfit/prisoner(src)

--- a/code/modules/trader/crates/alcatrazfour.dm
+++ b/code/modules/trader/crates/alcatrazfour.dm
@@ -22,6 +22,7 @@ var/global/list/alcatraz_stuff = list(
 	/obj/item/weapon/secway_kit,
 	/obj/structure/largecrate/secure,
 	/obj/item/weapon/storage/lockbox/advanced/ricochettaser,
+	/obj/structure/closet/crate/flatpack/ancient/prisoner_autoclother,
 	/obj/item/weapon/storage/lockbox/advanced/energyshotgun
 	)
 

--- a/code/modules/trader/crates/yantar.dm
+++ b/code/modules/trader/crates/yantar.dm
@@ -9,7 +9,6 @@ var/global/list/yantar_stuff = list(
 	//1 of a kind
 	/obj/item/weapon/storage/trader_chemistry,
 	/obj/structure/closet/crate/flatpack/ancient/chemmaster_electrolyzer,
-	/obj/structure/closet/crate/flatpack/ancient/autoclother,
 	/obj/structure/largecrate/secure/frankenstein,
 	)
 

--- a/code/modules/trader/crates/yantar.dm
+++ b/code/modules/trader/crates/yantar.dm
@@ -9,6 +9,7 @@ var/global/list/yantar_stuff = list(
 	//1 of a kind
 	/obj/item/weapon/storage/trader_chemistry,
 	/obj/structure/closet/crate/flatpack/ancient/chemmaster_electrolyzer,
+	/obj/structure/closet/crate/flatpack/ancient/autoclother,
 	/obj/structure/largecrate/secure/frankenstein,
 	)
 


### PR DESCRIPTION
[content]

## What this does
* adds the autoclother, an item that applies any clothing item stored inside it to anyone who passes through, emagging it will cause items to be stripped and swapped out if possible, and allow items to be inserted into storage. available from cargo under the automation machines supply pack.
* adds a version that builds the insides from outfit datums, including a prisoner one, found in the alcatraz security crates for traders.
* makes both of these inherit the wrapping machine, with a common path for each thing refactored into it all.

## Why it's good
QoL for medbay and permabrig.

## Changelog
:cl:
 * rscadd: Players can now purchase auto clothing devices from cargo and a prisoner variant from traders. Any items inserted into the former will be applied to the person passing through, where as prisoner ones cannot have items applied to them and regenerate their items with each use.
 * tweak: Auto processing items like the wrapping machine now have a smoother in/out animation.