### PR TITLE
Makes R&D stock parts crate contain correct amount of assembly parts

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1411,7 +1411,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/reagent_containers/food/snacks/spidereggs,
 					/obj/item/weapon/reagent_containers/food/snacks/meat/cricket,
 					/obj/item/weapon/reagent_containers/food/snacks/meat/roach,
-					/obj/item/weapon/reagent_containers/food/snacks/meat/roach/big			
+					/obj/item/weapon/reagent_containers/food/snacks/meat/roach/big
 					)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure/basic
@@ -2222,6 +2222,8 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/circuitboard/destructive_analyzer,
 					/obj/item/weapon/stock_parts/matter_bin,
 					/obj/item/weapon/stock_parts/matter_bin,
+					/obj/item/weapon/stock_parts/matter_bin,
+					/obj/item/weapon/stock_parts/manipulator,
 					/obj/item/weapon/stock_parts/manipulator,
 					/obj/item/weapon/stock_parts/manipulator,
 					/obj/item/weapon/stock_parts/manipulator,


### PR DESCRIPTION
[tweak]

## What this does
adds an extra matter bin and micro manipulator.

## Why it's good
saves a trip to the autolathe.

## Changelog
:cl:
 * tweak: R&D stock parts crates from cargo now contain the correct amount of parts to assemble the machines.