### PR TITLE
Fix network_expansion() for pressure valves

### DIFF
--- a/code/ATMOSPHERICS/components/trinary_devices/pressure_valve.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/pressure_valve.dm
@@ -134,6 +134,20 @@
 /obj/machinery/atmospherics/trinary/pressure_valve/proc/toggle_enabled()
 	enabled = !enabled
 	if (!enabled) close()
+	
+
+/obj/machinery/atmospherics/trinary/pressure_valve/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
+	..()
+
+	if(open)
+		if(reference == node1)
+			if(node3)
+				return node3.network_expand(new_network, src)
+		else if(reference == node3)
+			if(node1)
+				return node1.network_expand(new_network, src)
+
+	return null
 
 // --- Graphics ---
 
@@ -175,19 +189,6 @@
 	if(isMoMMI(user) && (user in (viewers(1, src) + loc))) // MoMMIs must be next to the valve to view and manipulate it
 		attack_hand(user)
 	return
-
-/obj/machinery/atmospherics/trinary/pressure_valve/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
-	..()
-
-	if(open)
-		if(reference == node1)
-			if(node3)
-				return node3.network_expand(new_network, src)
-		else if(reference == node3)
-			if(node1)
-				return node1.network_expand(new_network, src)
-
-	return null
 
 //-------------------------
 // Digital pressure valves

--- a/code/ATMOSPHERICS/components/trinary_devices/pressure_valve.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/pressure_valve.dm
@@ -176,11 +176,23 @@
 		attack_hand(user)
 	return
 
+/obj/machinery/atmospherics/trinary/pressure_valve/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
+	..()
+
+	if(open)
+		if(reference == node1)
+			if(node3)
+				return node3.network_expand(new_network, src)
+		else if(reference == node3)
+			if(node1)
+				return node1.network_expand(new_network, src)
+
+	return null
+
 //-------------------------
 // Digital pressure valves
 //-------------------------
 // Radio enabled, aka: can be multitooled and connected to consoles
-// TODO !JLVG Radio stuff
 /obj/machinery/atmospherics/trinary/pressure_valve/digital
 	icon_state = "pvalve_d"
 	icon_state_overlay_enabled = "pvalve_d_enabled"


### PR DESCRIPTION
[bugfix]
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
I was revisiting atmos code because reasons, and found out that:
1. `network_expansion()` is a thing I may have forgotten about back when I did pressure vavles.
2. The behavior inherited from trinary atmos devices wouldn't cut it for pressure valves.

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes an issue where closing a valve or removing a pipe could cause other pressure valves connected to the same network to behave as if closed regardless of that pressure valve's state.

Been testing this out a bit , first while trying to confirm what a lack `network_expansion()` (as compared to normal valves) might do, then after the changes to confirm it's working now - It's particularly noticeable in contraptions involving multiple pressure valves, as one valve closing could affect others, an issue I had been attributing to poor pipe spaghetti on my part.


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed a bug where changes to a pipeline's structure (eg: closing a valve) would cause other pressure valves to act as closed despite meeting the conditions to be open.
