### PR TITLE
Gas Miner Hotfix

### DIFF
--- a/code/game/machinery/atmoalter/gas_mine.dm
+++ b/code/game/machinery/atmoalter/gas_mine.dm
@@ -74,7 +74,7 @@
 	if(stat & BROKEN)
 		to_chat(user, "<span class='info'>\The [src]'s status terminal reads: Broken.</span>")
 		return
-	to_chat(user, "<span class='info'>\The [src]'s status terminal reads: Functional and operating at a rate of [Ceiling(KW_TO_KPA_COEFFICIENT * power_load)] kPa per cycle.</span>")
+	to_chat(user, "<span class='info'>\The [src]'s status terminal reads: Functional and operating at a rate of [Ceiling(WATT_TO_KPA_COEFFICIENT * power_load)] kPa per cycle.</span>")
 
 /obj/machinery/atmospherics/miner/wrenchAnchor(var/mob/user, var/obj/item/I)
 	. = ..()

--- a/code/game/machinery/atmoalter/gas_mine.dm
+++ b/code/game/machinery/atmoalter/gas_mine.dm
@@ -1,4 +1,4 @@
-#define KW_TO_KPA_COEFFICIENT 0.5
+#define WATT_TO_KPA_COEFFICIENT 10
 
 /obj/machinery/atmospherics/miner
 	name = "gas miner"
@@ -110,8 +110,11 @@
 		return
 
 	PN = area_apc.terminal.powernet
-	PN.add_connection(src)
-	return TRUE
+	if(PN)
+		PN.add_connection(src)
+		return TRUE
+	else
+		return FALSE
 
 /obj/machinery/atmospherics/miner/attack_ghost(var/mob/user)
 	return
@@ -158,22 +161,17 @@
 	if(stat & BROKEN)
 		return
 
+	update_rate(Ceiling(WATT_TO_KPA_COEFFICIENT * power_load))		//scale mol output by arbitrary power load
 	//scale based on powernet, otherwise constant 4500
 	if(PN)
-		var/power_surplus = PN.get_satisfaction(power_priority)
 		use_power = MACHINE_POWER_USE_ACTIVE
-		update_rate(Ceiling(KW_TO_KPA_COEFFICIENT * power_load))		//scale mol output by arbitrary power load
-		if(power_surplus > 0.55)
-			power_load += 1000
-		else if (power_surplus < 0.45 && power_load > 0)
-			power_load -= 1000
-		else
-			power_load = 0
+		if(power_load < 900)
+			power_load += 100
+			active_power_usage = power_load
 	else
-		power_load = 0
 		use_power = MACHINE_POWER_USE_IDLE
-		update_rate(4500)
-	active_power_usage = power_load
+		power_load = 450
+
 	pumping.copy_from(air_contents)
 /*
 	//gas-related


### PR DESCRIPTION
[hotfix]

Gas miner scaling didn't work as I intended and I don't have time to fix it properly, so here's a quick fix.
- get_satisfaction(excess) doesn't update properly
- the APC takes the load instead of the powernet, so the APC battery gets drained

## What this does
- If there's a powernet, you can get 9000kPa from the miners. No powernet, 4500kPa (standard from before my PR)

## Why it's good
- Doesn't draw all the power from the powernet
- APC doesn't get drained

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Miners don't scale as much with power.