### PR TITLE
Remove redundant ticker.minds

### DIFF
--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -482,15 +482,13 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 
 /datum/subsystem/supply_shuttle/proc/forbidden_atoms_check(atom/A)
 	var/contents = get_contents_in_object(A)
-	for(var/mob/living/simple_animal/hostile/mimic/M in contents)
-		M.angry = 0
-		M.apply_disguise()
 	for(var/mob/living/M in contents)
-		if(M.key || M.ckey) //only mobs that were never player controlled
+		if(istype(M, /mob/living/simple_animal/hostile/mimic))
+			var/mob/living/simple_animal/hostile/mimic/mimic = M
+			mimic.angry = 0
+			mimic.apply_disguise()
+		if(M.key || M.ckey || M.mind) //only mobs that were never player controlled
 			return TRUE
-		for(var/datum/mind/M2 in ticker.minds) //see above, but for ghosts
-			if(M2.current == M)
-				return TRUE
 
 	if (locate(/obj/item/weapon/disk/nuclear) in contents)
 		return TRUE

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -180,7 +180,6 @@ var/datum/controller/gameticker/ticker
 	for(var/mob/M in player_list)
 		if(!istype(M, /mob/new_player/))
 			var/mob/living/L = M
-			ticker.minds += L.mind
 			L.store_position()
 			M.close_spawn_windows()
 			continue
@@ -196,7 +195,6 @@ var/datum/controller/gameticker/ticker
 		switch(np.mind.assigned_role)
 			if("Cyborg", "Mobile MMI", "AI")
 				var/mob/living/silicon/S = np.create_roundstart_silicon(prefs)
-				ticker.minds += S.mind
 				S.store_position()
 				log_admin("([key]) started the game as a [S.mind.assigned_role].")
 				new_characters[key] = S
@@ -204,7 +202,6 @@ var/datum/controller/gameticker/ticker
 				//antags aren't new players
 			else
 				var/mob/living/carbon/human/H = np.create_human(prefs)
-				ticker.minds += H.mind
 				H.store_position()
 				EquipCustomItems(H)
 				H.update_icons()

--- a/code/game/striketeams/emergency_response_team.dm
+++ b/code/game/striketeams/emergency_response_team.dm
@@ -66,8 +66,6 @@ var/list/response_team_members = list()
 	M.mind.current = M
 	M.mind.assigned_role = "MODE"
 	M.mind.special_role = "Response Team"
-	if(!(M.mind in ticker.minds))
-		ticker.minds += M.mind//Adds them to regular mind list.
 
 	var/datum/faction/ert = find_active_faction_by_type(/datum/faction/strike_team/ert)
 	if(ert)

--- a/code/game/striketeams/striketeam_datums.dm
+++ b/code/game/striketeams/striketeam_datums.dm
@@ -347,9 +347,7 @@ var/list/sent_strike_teams = list()
 	new_commando.mind = new
 	new_commando.mind.current = new_commando
 	new_commando.mind.assigned_role = "MODE"
-	new_commando.mind.special_role = "Custom Team"
-	if(!(new_commando.mind in ticker.minds))
-		ticker.minds += new_commando.mind//Adds them to regular mind list.
+	new_commando.mind.special_role = "Custom Team".
 
 	var/datum/faction/customsquad = find_active_faction_by_type(/datum/faction/strike_team/custom)
 	if(customsquad)

--- a/code/game/striketeams/striketeam_datums.dm
+++ b/code/game/striketeams/striketeam_datums.dm
@@ -347,7 +347,7 @@ var/list/sent_strike_teams = list()
 	new_commando.mind = new
 	new_commando.mind.current = new_commando
 	new_commando.mind.assigned_role = "MODE"
-	new_commando.mind.special_role = "Custom Team".
+	new_commando.mind.special_role = "Custom Team"
 
 	var/datum/faction/customsquad = find_active_faction_by_type(/datum/faction/strike_team/custom)
 	if(customsquad)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -437,7 +437,6 @@
 	if(character.mind.assigned_role != "MODE")
 		if(character.mind.assigned_role != "Cyborg")
 			data_core.manifest_inject(character)
-			ticker.minds += character.mind//Cyborgs and AIs handle this in the transform proc.	//TODO!!!!! ~Carn
 			if(character.mind.assigned_role == "Trader")
 				//If we're a trader, instead send a message to PDAs with the trader cartridge
 				for (var/obj/item/device/pda/P in PDAs)


### PR DESCRIPTION
Nervere said he would be doing stuff with `ticker.minds` in the future, so it will indeed serve a purpose. **Tested** **it** and everything is indeed redundant because of `mob/living/Login()` containing `mind_initialize()`. All living/mobs call Login() when keys are assigned to mobs. Wish someone about mind_initialize in living/Login earlier... Here I was thinking `ticker.minds += L.mind` was actually important

## Why it's good
- Less clutter and redundant code