### PR TITLE
Remove scaling miner with power

### DIFF
--- a/code/game/machinery/atmoalter/gas_mine.dm
+++ b/code/game/machinery/atmoalter/gas_mine.dm
@@ -110,11 +110,6 @@
 		return
 
 	PN = area_apc.terminal.powernet
-	if(PN)
-		PN.add_connection(src)
-		return TRUE
-	else
-		return FALSE
 
 /obj/machinery/atmospherics/miner/attack_ghost(var/mob/user)
 	return


### PR DESCRIPTION
Couldn't get it to work the way I wanted it to work, so reverting to a state that keeps original gas miner functionality
- Closes #33717

:cl:
 * rscdel: No scaling miners with power. Returns miners to prior functionality
