### PR TITLE
Windoor opening time method change

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -72,19 +72,20 @@
 		to_chat(user, "It is a secure windoor. It's stronger and closes more quickly.")
 
 /obj/machinery/door/window/Bumped(atom/movable/AM)
+	var/sleeptime = normalspeed ? 50 : 20 // secure doors close faster
 	if(!ismob(AM))
 		var/obj/machinery/bot/bot = AM
 		if(istype(bot))
 			if(density && check_access(bot.botcard))
 				open()
-				sleep(50)
+				sleep(sleeptime)
 				close()
 		else if(istype(AM, /obj/mecha))
 			var/obj/mecha/mecha = AM
 			if(density)
 				if(mecha.occupant && allowed(mecha.occupant))
 					open()
-					sleep(50)
+					sleep(sleeptime)
 					close()
 		else if(istype(AM, /obj/structure/bed/chair/vehicle))
 			var/obj/structure/bed/chair/vehicle/vehicle = AM
@@ -93,7 +94,7 @@
 					if(istype(vehicle, /obj/structure/bed/chair/vehicle/firebird))
 						vehicle.forceMove(get_step(vehicle,vehicle.dir))//Firebird doesn't wait for no slowpoke door to fully open before dashing through!
 					open()
-					sleep(50)
+					sleep(sleeptime)
 					close()
 				else if(!operating)
 					denied()
@@ -104,11 +105,7 @@
 		return
 	if(density && allowed(AM))
 		open()
-		// What.
-		if(check_access(null))
-			sleep(50)
-		else //secure doors close faster
-			sleep(20)
+		sleep(sleeptime)
 		close()
 
 /obj/machinery/door/window/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
@@ -385,6 +382,7 @@
 	health = 100
 	assembly_type = /obj/structure/windoor_assembly/secure
 	penetration_dampening = 4
+	normalspeed = 0
 
 /obj/machinery/door/window/plasma
 	name = "plasma window door"
@@ -403,6 +401,7 @@
 	secure = TRUE
 	assembly_type = /obj/structure/windoor_assembly/plasma
 	penetration_dampening = 8
+	normalspeed = 0
 
 // Used on Packed ; smartglassified roundstart
 // TODO: Remove this snowflake stuff.


### PR DESCRIPTION
[tweak][consistency]

## What this does
changes the factor that makes windoors close again in 2 seconds rather than 5 to being the secure types, rather than if it has access.
also actually applies this shorter time to bots, mechas and vehicles it uses too.

## Why it's good
seems more intuitive and flexible

## Changelog
:cl:
 * tweak: Secure windoors now always close faster.
 * tweak: Normal windoors with access no longer close faster.
 * tweak: Bots, mechas and vehicles are now more consistent with these times instead of always closing them slowly. 