### PR TITLE
Stops lobby players seeing captain announcements

### DIFF
--- a/code/defines/procs/captain_announce.dm
+++ b/code/defines/procs/captain_announce.dm
@@ -1,7 +1,5 @@
 /proc/captain_announce(var/text)
-	to_chat(world, "<h1 class='alert'>Priority Announcement</h1>")
-	to_chat(world, "<span class='alert'>[html_encode(text)]</span>")
-	to_chat(world, "<br>")
 	for(var/mob/M in player_list)
 		if(!istype(M,/mob/new_player) && M.client)
 			M << sound('sound/vox/_doop.wav')
+			to_chat(M, "<h1 class='alert'>Priority Announcement</h1><span class='alert'>[html_encode(text)]</span><br>")


### PR DESCRIPTION
[bugfix]

## Changelog
:cl:
 * bugfix: Lobby players can no longer read captain announcements.
