### PR TITLE
Sliders use Multispawners instead of boxes.

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -689,70 +689,70 @@
 	return
 
 //SLIDER BOXES
-
-/obj/item/weapon/storage/fancy/food_box/slider_box
-	name = "slider box"
-	desc = "I wonder what's inside."
-	icon_type = "slider"
-	storage_slots = 4
-	can_only_hold = list("/obj/item/weapon/reagent_containers/food/snacks/slider")
-	var/slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider//set this as the spawn path of your slider
-	starting_materials = list(MAT_CARDBOARD = 3750)
-	w_type=RECYK_MISC
-
-/obj/item/weapon/storage/fancy/food_box/slider_box/New()
-	..()
-	for(var/i=1, i <= storage_slots; i++)
-		new slider_type(src)
-
-/obj/item/weapon/storage/fancy/food_box/slider_box/synth
-	name = "synth slider box"
-	icon_type = "synth slider"
-	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/synth
-
-/obj/item/weapon/storage/fancy/food_box/slider_box/xeno
-	name = "xeno slider box"
-	icon_type = "xeno slider"
-	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/xeno
-
-/obj/item/weapon/storage/fancy/food_box/slider_box/chicken
-	name = "chicken slider box"
-	icon_type = "chicken slider"
-	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/chicken
-
-/obj/item/weapon/storage/fancy/food_box/slider_box/toxiccarp
-	name = "carp slider box"
-	icon_type = "carp slider"
-	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/toxiccarp
-	storage_slots = 2
-
-/obj/item/weapon/storage/fancy/food_box/slider_box/carp
-	name = "carp slider box"
-	icon_type = "carp slider"
-	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/carp
-	storage_slots = 2
-
-/obj/item/weapon/storage/fancy/food_box/slider_box/spider
-	name = "spidey slidey box"
-	icon_type = "spider slider"
-	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/carp/spider
-
-/obj/item/weapon/storage/fancy/food_box/slider_box/clown
-	name = "honky slider box"
-	icon_type = "honky slider"
-	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/clown
-
-/obj/item/weapon/storage/fancy/food_box/slider_box/mime
-	name = "quiet slider box"
-	icon_type = "quiet slider"
-	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/mime
-
-/obj/item/weapon/storage/fancy/food_box/slider_box/slippery
-	name = "slippery slider box"
-	icon_type = "slippery slider"
-	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/slippery
-	storage_slots = 2
-
+/*
+ * /obj/item/weapon/storage/fancy/food_box/slider_box
+ * 	name = "slider box"
+ * 	desc = "I wonder what's inside."
+ *	icon_type = "slider"
+ *	storage_slots = 4
+ *	can_only_hold = list("/obj/item/weapon/reagent_containers/food/snacks/slider")
+ *	var/slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider//set this as the spawn path of your slider
+ *	starting_materials = list(MAT_CARDBOARD = 3750)
+ *	w_type=RECYK_MISC
+ *
+ * /obj/item/weapon/storage/fancy/food_box/slider_box/New()
+ *	..()
+ *	for(var/i=1, i <= storage_slots; i++)
+ *		new slider_type(src)
+ *
+ * /obj/item/weapon/storage/fancy/food_box/slider_box/synth
+ *	name = "synth slider box"
+ *	icon_type = "synth slider"
+ *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/synth
+ *
+ * /obj/item/weapon/storage/fancy/food_box/slider_box/xeno
+ *	name = "xeno slider box"
+ *	icon_type = "xeno slider"
+ *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/xeno
+ *
+ * /obj/item/weapon/storage/fancy/food_box/slider_box/chicken
+ *	name = "chicken slider box"
+ *	icon_type = "chicken slider"
+ *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/chicken
+ *
+ * /obj/item/weapon/storage/fancy/food_box/slider_box/toxiccarp
+ *	name = "carp slider box"
+ *	icon_type = "carp slider"
+ *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/toxiccarp
+ *	storage_slots = 2
+ *
+ * /obj/item/weapon/storage/fancy/food_box/slider_box/carp
+ *	name = "carp slider box"
+ *	icon_type = "carp slider"
+ *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/carp
+ *	storage_slots = 2
+ *
+ * /obj/item/weapon/storage/fancy/food_box/slider_box/spider
+ *	name = "spidey slidey box"
+ *	icon_type = "spider slider"
+ *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/carp/spider
+ *
+ * /obj/item/weapon/storage/fancy/food_box/slider_box/clown
+ *	name = "honky slider box"
+ *	icon_type = "honky slider"
+ *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/clown
+ *
+ * /obj/item/weapon/storage/fancy/food_box/slider_box/mime
+ *	name = "quiet slider box"
+ *	icon_type = "quiet slider"
+ *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/mime
+ *
+ * /obj/item/weapon/storage/fancy/food_box/slider_box/slippery
+ *	name = "slippery slider box"
+ *	icon_type = "slippery slider"
+ *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/slippery
+ *	storage_slots = 2
+ */
 //SLIDER BOXES END
 
 ////////////

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -689,70 +689,70 @@
 	return
 
 //SLIDER BOXES
-/*
- * /obj/item/weapon/storage/fancy/food_box/slider_box
- * 	name = "slider box"
- * 	desc = "I wonder what's inside."
- *	icon_type = "slider"
- *	storage_slots = 4
- *	can_only_hold = list("/obj/item/weapon/reagent_containers/food/snacks/slider")
- *	var/slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider//set this as the spawn path of your slider
- *	starting_materials = list(MAT_CARDBOARD = 3750)
- *	w_type=RECYK_MISC
- *
- * /obj/item/weapon/storage/fancy/food_box/slider_box/New()
- *	..()
- *	for(var/i=1, i <= storage_slots; i++)
- *		new slider_type(src)
- *
- * /obj/item/weapon/storage/fancy/food_box/slider_box/synth
- *	name = "synth slider box"
- *	icon_type = "synth slider"
- *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/synth
- *
- * /obj/item/weapon/storage/fancy/food_box/slider_box/xeno
- *	name = "xeno slider box"
- *	icon_type = "xeno slider"
- *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/xeno
- *
- * /obj/item/weapon/storage/fancy/food_box/slider_box/chicken
- *	name = "chicken slider box"
- *	icon_type = "chicken slider"
- *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/chicken
- *
- * /obj/item/weapon/storage/fancy/food_box/slider_box/toxiccarp
- *	name = "carp slider box"
- *	icon_type = "carp slider"
- *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/toxiccarp
- *	storage_slots = 2
- *
- * /obj/item/weapon/storage/fancy/food_box/slider_box/carp
- *	name = "carp slider box"
- *	icon_type = "carp slider"
- *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/carp
- *	storage_slots = 2
- *
- * /obj/item/weapon/storage/fancy/food_box/slider_box/spider
- *	name = "spidey slidey box"
- *	icon_type = "spider slider"
- *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/carp/spider
- *
- * /obj/item/weapon/storage/fancy/food_box/slider_box/clown
- *	name = "honky slider box"
- *	icon_type = "honky slider"
- *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/clown
- *
- * /obj/item/weapon/storage/fancy/food_box/slider_box/mime
- *	name = "quiet slider box"
- *	icon_type = "quiet slider"
- *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/mime
- *
- * /obj/item/weapon/storage/fancy/food_box/slider_box/slippery
- *	name = "slippery slider box"
- *	icon_type = "slippery slider"
- *	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/slippery
- *	storage_slots = 2
- */
+
+/obj/item/weapon/storage/fancy/food_box/slider_box
+	name = "slider box"
+	desc = "I wonder what's inside."
+	icon_type = "slider"
+	storage_slots = 4
+	can_only_hold = list("/obj/item/weapon/reagent_containers/food/snacks/slider")
+	var/slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider//set this as the spawn path of your slider
+	starting_materials = list(MAT_CARDBOARD = 3750)
+	w_type=RECYK_MISC
+
+/obj/item/weapon/storage/fancy/food_box/slider_box/New()
+	..()
+	for(var/i=1, i <= storage_slots; i++)
+		new slider_type(src)
+
+/obj/item/weapon/storage/fancy/food_box/slider_box/synth
+	name = "synth slider box"
+	icon_type = "synth slider"
+	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/synth
+
+/obj/item/weapon/storage/fancy/food_box/slider_box/xeno
+	name = "xeno slider box"
+	icon_type = "xeno slider"
+	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/xeno
+
+/obj/item/weapon/storage/fancy/food_box/slider_box/chicken
+	name = "chicken slider box"
+	icon_type = "chicken slider"
+	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/chicken
+
+/obj/item/weapon/storage/fancy/food_box/slider_box/toxiccarp
+	name = "carp slider box"
+	icon_type = "carp slider"
+	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/toxiccarp
+	storage_slots = 2
+
+/obj/item/weapon/storage/fancy/food_box/slider_box/carp
+	name = "carp slider box"
+	icon_type = "carp slider"
+	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/carp
+	storage_slots = 2
+
+/obj/item/weapon/storage/fancy/food_box/slider_box/spider
+	name = "spidey slidey box"
+	icon_type = "spider slider"
+	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/spider
+
+/obj/item/weapon/storage/fancy/food_box/slider_box/clown
+	name = "honky slider box"
+	icon_type = "honky slider"
+	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/clown
+
+/obj/item/weapon/storage/fancy/food_box/slider_box/mime
+	name = "quiet slider box"
+	icon_type = "quiet slider"
+	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/mime
+
+/obj/item/weapon/storage/fancy/food_box/slider_box/slippery
+	name = "slippery slider box"
+	icon_type = "slippery slider"
+	slider_type = /obj/item/weapon/reagent_containers/food/snacks/slider/slippery
+	storage_slots = 2
+
 //SLIDER BOXES END
 
 ////////////

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -237,35 +237,39 @@
 		/obj/item/weapon/reagent_containers/food/snacks/meat,
 		/obj/item/weapon/reagent_containers/food/snacks/meat
 		)
-	result = /obj/item/weapon/storage/fancy/food_box/slider_box
+	result = /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider
 
 /datum/recipe/sliders/synth
+	priority = 1
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh,
 		/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh
 		)
-	result = /obj/item/weapon/storage/fancy/food_box/slider_box/synth
+	result = /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/synth
 
 /datum/recipe/sliders/xeno
+	priority = 1
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat,
 		/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat
 		)
-	result = /obj/item/weapon/storage/fancy/food_box/slider_box/xeno
+	result = /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/xeno
 
 /datum/recipe/sliders/chicken
+	priority = 1
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/meat/rawchicken,
 		/obj/item/weapon/reagent_containers/food/snacks/meat/rawchicken
 		)
-	result = /obj/item/weapon/storage/fancy/food_box/slider_box/chicken
+	result = /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/chicken
 
 /datum/recipe/sliders/spider
+	priority = 1
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/meat/spidermeat,
 		/obj/item/weapon/reagent_containers/food/snacks/meat/spidermeat
 		)
-	result = /obj/item/weapon/storage/fancy/food_box/slider_box/spider
+	result = /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/spider
 
 /datum/recipe/sliders/clown
 	items = list(
@@ -273,7 +277,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/meat,
 		/obj/item/clothing/mask/gas/clown_hat
 		)
-	result = /obj/item/weapon/storage/fancy/food_box/slider_box/clown
+	result = /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/clown
 
 /datum/recipe/sliders/mime
 	items = list(
@@ -281,7 +285,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/meat,
 		/obj/item/clothing/head/beret
 		)
-	result = /obj/item/weapon/storage/fancy/food_box/slider_box/mime
+	result = /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/mime
 
 /datum/recipe/sliders/slippery
 	reagents = list(FLOUR = 10, LUBE = 5)
@@ -290,7 +294,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/meat,
 		/obj/item/weapon/reagent_containers/food/snacks/grown/banana
 		)
-	result = /obj/item/weapon/storage/fancy/food_box/slider_box/slippery
+	result = /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/slippery
 
 // Eggs ////////////////////////////////////////////////////////
 
@@ -2338,15 +2342,16 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/cubancarp
 
 /datum/recipe/sliders/carp
+	priority = 1
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/meat/carpmeat
 		)
-	result = /obj/item/weapon/storage/fancy/food_box/slider_box/carp
+	result = /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/carp
 
 /datum/recipe/sliders/carp/make_food(var/obj/container, var/mob/user)
 	var/obj/item/weapon/reagent_containers/food/snacks/meat/carpmeat/C = locate() in container
 	if(C.poisonsacs)
-		result = /obj/item/weapon/storage/fancy/food_box/slider_box/toxiccarp
+		result = /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/toxiccarp
 	..()
 
 /datum/recipe/turkey

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -59,7 +59,7 @@
 	hud_list[STATUS_HUD]      = image('icons/mob/hud.dmi', src, "hudhealthy")
 
 	var/turf/T = get_turf(src)
-	if (!client && istype(T.loc,/area/maintenance) && prob(20))
+	if (!client && (T ? istype(T.loc,/area/maintenance) : FALSE) && prob(20))
 		MaintInfection()
 
 /mob/living/simple_animal/mouse/can_be_infected()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -5121,7 +5121,6 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/synth/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 10) //spawns 4
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/synth
 	name = "synth slider"
@@ -5130,10 +5129,11 @@
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/xeno
 	name = "xeno sliders"
 	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider/xeno
-
+	child_volume = 3.5
+	
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/xeno/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 10) //spawns 4
+	reagents.add_reagent(NUTRIMENT, 4) //spawns 4
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/xeno
 	name = "xeno slider"
@@ -5143,10 +5143,11 @@
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/chicken
 	name = "chicken sliders"
 	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider/chicken
-
+	child_volume = 3.5
+	
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/chicken/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 10) //spawns 4
+	reagents.add_reagent(NUTRIMENT, 4) //spawns 4
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/chicken
 	name = "chicken slider"
@@ -5156,10 +5157,11 @@
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/carp
 	name = "carp sliders"
 	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider/carp
+	child_volume = 3.5
 
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/carp/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 10) //spawns 4
+	reagents.add_reagent(NUTRIMENT, 4) //spawns 4
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/carp
 	name = "carp slider"
@@ -5169,11 +5171,11 @@
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/toxiccarp
 	name = "carp sliders"
 	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider/toxiccarp
-	child_volume = 4.5
-	
+	child_volume = 5.5
+
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/toxiccarp/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 10) //spawns 4
+	reagents.add_reagent(NUTRIMENT, 4) //spawns 4
 	reagents.add_reagent(CARPOTOXIN, 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/toxiccarp
@@ -5184,10 +5186,11 @@
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/spider
 	name = "spidey slideys"
 	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider/spider
+	child_volume = 3.5
 
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/spider/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 10) //spawns 4
+	reagents.add_reagent(NUTRIMENT, 4) //spawns 4
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/spider
 	name = "spidey slidey"
@@ -5201,8 +5204,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/clown/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 10) //spawns 4
-	reagents.add_reagent(HONKSERUM, 10)
+	reagents.add_reagent(HONKSERUM, 10) //spawns 4
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/clown
 	name = "honky slider"
@@ -5216,8 +5218,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/mime/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 10) //spawns 4
-	reagents.add_reagent(SILENCER, 10)
+	reagents.add_reagent(SILENCER, 10) //spawns 4
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/mime
 	name = "quiet slider"
@@ -5227,10 +5228,10 @@
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/slippery
 	name = "slippery sliders"
 	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider/slippery
+	child_volume = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/slippery/New()
-	..()
-	reagents.add_reagent(NUTRIMENT, 5) //spawns 2
+	..() //spawns 2
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/slippery
 	name = "slippery slider"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -5197,10 +5197,12 @@
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/clown
 	name = "honky sliders"
 	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider/clown
+	child_volume = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/clown/New()
 	..()
-	reagents.add_reagent(HONKSERUM, 10) //spawns 4
+	reagents.add_reagent(NUTRIMENT, 10) //spawns 4
+	reagents.add_reagent(HONKSERUM, 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/clown
 	name = "honky slider"
@@ -5210,10 +5212,12 @@
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/mime
 	name = "quiet sliders"
 	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider/mime
+	child_volume = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/mime/New()
 	..()
-	reagents.add_reagent(SILENCER, 10) //spawns 4
+	reagents.add_reagent(NUTRIMENT, 10) //spawns 4
+	reagents.add_reagent(SILENCER, 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/mime
 	name = "quiet slider"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -581,6 +581,13 @@
 //	and set your recipe's result to your spawner.
 //	reagents.add_reagent() should take place in your spawner's New() proc, not in its children's.
 //	Consult sushi types below for examples of usage.
+
+// Multispawners take the total amount of reagents, both the ones added by the recipe and the ingredients's ones, divides the number by the child volume and spawns that many of items.
+// For example: If the child volume is 1 and the total reagents, both from the ingredients and the extra upon cooking, add to 10u, then it would spawn 10 items. 
+// This means that "stronger" ingredients spawn more items.
+// If you have child volume 5, the recipe adds 10u reagents and the ingredients' reagents add 10 more, the multispawner would spawn 4 items, since (10+10):5=4.
+// Only the fooditem ingredient reagents get tallied, any "raw" reagents the recipe calls for, such as flour, don't get counted for multispawner purposes.
+
 /obj/item/weapon/reagent_containers/food/snacks/multispawner
 	name = "food spawner"
 	var/child_type = /obj/item/weapon/reagent_containers/food/snacks
@@ -5092,86 +5099,134 @@
 
 ////////////////SLIDERS////////////////
 
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider
+	name = "sliders"
+	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider
+	child_volume = 2.5
+
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/New()
+	..()
+	reagents.add_reagent(NUTRIMENT, 10) //spawns 4
+
 /obj/item/weapon/reagent_containers/food/snacks/slider
 	name = "slider"
 	desc = "It's so tiny!"
 	icon_state = "slider"
 	food_flags = FOOD_MEAT
-
-/obj/item/weapon/reagent_containers/food/snacks/slider/New()
-	..()
-	reagents.add_reagent(NUTRIMENT, 2.5)
 	bitesize = 1.5
+
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/synth
+	name = "synth sliders"
+	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider/synth
+
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/synth/New()
+	..()
+	reagents.add_reagent(NUTRIMENT, 10) //spawns 4
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/synth
 	name = "synth slider"
 	desc = "It's made to be tiny!"
+
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/xeno
+	name = "xeno sliders"
+	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider/xeno
+
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/xeno/New()
+	..()
+	reagents.add_reagent(NUTRIMENT, 10) //spawns 4
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/xeno
 	name = "xeno slider"
 	desc = "It's green!"
 	icon_state = "slider_xeno"
 
-/obj/item/weapon/reagent_containers/food/snacks/slider/xeno/New()
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/chicken
+	name = "chicken sliders"
+	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider/chicken
+
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/chicken/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 1)
-	bitesize = 2
+	reagents.add_reagent(NUTRIMENT, 10) //spawns 4
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/chicken
 	name = "chicken slider"
 	desc = "Chicken sliders? That's new."
 	icon_state = "slider_chicken"
 
-/obj/item/weapon/reagent_containers/food/snacks/slider/chicken/New()
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/carp
+	name = "carp sliders"
+	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider/carp
+
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/carp/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 1)
-	bitesize = 2
+	reagents.add_reagent(NUTRIMENT, 10) //spawns 4
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/carp
 	name = "carp slider"
 	desc = "I wonder how it tastes!"
 	icon_state = "slider_carp"
 
-/obj/item/weapon/reagent_containers/food/snacks/slider/carp/New()
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/toxiccarp
+	name = "carp sliders"
+	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider/toxiccarp
+	child_volume = 4.5
+	
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/toxiccarp/New()
 	..()
-	reagents.add_reagent(NUTRIMENT, 1)
-	bitesize = 2.5
+	reagents.add_reagent(NUTRIMENT, 10) //spawns 4
+	reagents.add_reagent(CARPOTOXIN, 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/toxiccarp
 	name = "carp slider"
 	desc = "I wonder how it tastes!"
 	icon_state = "slider_carp"
 
-/obj/item/weapon/reagent_containers/food/snacks/slider/toxiccarp/New()
-	..()
-	reagents.add_reagent(NUTRIMENT, 1)
-	reagents.add_reagent(CARPOTOXIN, 2)
-	bitesize = 2.5
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/spider
+	name = "spidey slideys"
+	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider/spider
 
-/obj/item/weapon/reagent_containers/food/snacks/slider/carp/spider
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/spider/New()
+	..()
+	reagents.add_reagent(NUTRIMENT, 10) //spawns 4
+
+/obj/item/weapon/reagent_containers/food/snacks/slider/spider
 	name = "spidey slidey"
 	desc = "I think there's still a leg in there!"
 	icon_state = "slider_spider"
+
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/clown
+	name = "honky sliders"
+	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider/clown
+
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/clown/New()
+	..()
+	reagents.add_reagent(HONKSERUM, 10) //spawns 4
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/clown
 	name = "honky slider"
 	desc = "HONK!"
 	icon_state = "slider_clown"
 
-/obj/item/weapon/reagent_containers/food/snacks/slider/clown/New()
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/mime
+	name = "quiet sliders"
+	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider/mime
+
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/mime/New()
 	..()
-	reagents.add_reagent(HONKSERUM, 2.5)
-	bitesize = 2.5
+	reagents.add_reagent(SILENCER, 10) //spawns 4
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/mime
-	name = "quiet Slider"
+	name = "quiet slider"
 	desc = "..."
 	icon_state = "slider_mime"
 
-/obj/item/weapon/reagent_containers/food/snacks/slider/mime/New()
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/slippery
+	name = "slippery sliders"
+	child_type = /obj/item/weapon/reagent_containers/food/snacks/slider/slippery
+
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/slider/slippery/New()
 	..()
-	reagents.add_reagent(SILENCER, 2.5)
-	bitesize = 2.5
+	reagents.add_reagent(NUTRIMENT, 5) //spawns 2
 
 /obj/item/weapon/reagent_containers/food/snacks/slider/slippery
 	name = "slippery slider"


### PR DESCRIPTION
### What this does
Makes the slider recipes use multispawners instead of spawning a box with sliders inside.
### Why it's good
Sushi uses it and it feels less clunky.
Closes #7743 by virtue of them no longer being used (they're still not boxes). They still exist in the code however.
:cl:
 * rscadd: All slider recipes now use multispawners, just like sushi. They'll no longer spawn in boxes. Multispawner food makes more food the stronger the ingredients (more reagents inside).