### PR TITLE
Fixes a Dice Cup Runtime

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -256,7 +256,7 @@ var/global/list/bottle_colour_choices = list("Blue" = "#0094FF","Dark Blue" = "#
 	name = "dice cup"
 	icon = 'icons/obj/drinks.dmi'
 	icon_state = "sakeglass"
-	items_to_spawn = null
+	items_to_spawn = list()
 
 /obj/item/weapon/storage/pill_bottle/dice/cup/on_attack(atom/attacked, mob/user)
 	..()


### PR DESCRIPTION
Got em before the bug report. 
![image](https://user-images.githubusercontent.com/69739118/203743866-ebead995-da59-4591-9f82-841224b045d9.png)
And no runtime. Blam.

## What this does
When the Fun n Games vendor was hacked to throw items, a runtime was triggered, Thrown dice cups didn't have a properly initialized ``items_to_spawn`` list because of a mistake I made. This has been fixed, runtime solved.

## Why it's good
Fixed a bug before a bug report was posted on Github

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed a Dice Cup runtime involving being thrown from vendors.
 
 [tested] [bugfix]