### PR TITLE
Power monitor demand fixes

### DIFF
--- a/code/game/machinery/antiquemattersynth.dm
+++ b/code/game/machinery/antiquemattersynth.dm
@@ -73,7 +73,7 @@ list("category" = "machinery", "name" = "MSGS", "path" = /obj/machinery/atmosphe
 	template["charge"] = round(100 * charge/max_charge)
 	if (charged_last_tick)
 		template["charging"] = MONITOR_STATUS_BATTERY_CHARGING
-	return list("\ref[src]" = get_monitor_status_template())
+	return list("\ref[src]" = template)
 
 /obj/machinery/power/antiquesynth/update_icon()
 	return

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -355,6 +355,7 @@
 		// Request power for next tick
 		shieldload = rand(storedpower_consumption, storedpower_consumption * 4)
 		power_connection.add_load(shieldload)
+		power_connection.monitor_demand = shieldload
 
 	// Attemp to consume stored power. If enough, we're powered,
 	if (storedpower >= storedpower_consumption)

--- a/code/modules/power/components.dm
+++ b/code/modules/power/components.dm
@@ -296,9 +296,17 @@
 			use_power(idle_usage, channel)
 		if (MACHINE_POWER_USE_ACTIVE)
 			use_power(active_usage, channel)
-
 	return 1
 
+/datum/power_connection/consumer/get_monitor_status_template()
+	var/template = ..()
+	if (template)
+		switch (use_power)
+			if (MACHINE_POWER_USE_IDLE)
+				template["demand"] = idle_usage
+			if (MACHINE_POWER_USE_ACTIVE)
+				template["demand"] = active_usage
+	return template
 
 //////////////////////
 /// TERMINAL RECEIVER


### PR DESCRIPTION
[bugfix]
## What this does
Fix #33729

Radio broadcasters put draw on the grid through switching the `use_power` var to active/idle and letting the cable power component's `auto_use_power()` do the rest, so this also makes the component take `use_power` in consideration to automatically set the draw sent to the monitor.
Matter synth and wall shield generators were just dumb mistakes on my part, one line fix.

## Changelog
:cl:
 * bugfix: Radio broadcasters, wall shield generators and antique matter synths now report their power draw properly on the power monitor.