### PR TITLE
Fixed monitor on/off animations playing on things that shouldn't have them.

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1162,6 +1162,8 @@ var/default_colour_matrix = list(1,0,0,0,\
 
 #define MAX_N_OF_ITEMS 999 // Used for certain storage machinery, BYOND infinite loop detector doesn't look things over 1000.
 
+//flags for computer behavior
+#define NO_ONOFF_ANIMS 1
 
 ///////////////////////
 ///////RESEARCH////////

--- a/code/game/machinery/computer/arcade/arcade.dm
+++ b/code/game/machinery/computer/arcade/arcade.dm
@@ -7,6 +7,7 @@
 	var/datum/arcade_game/game
 	machine_flags = EMAGGABLE | SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK
 	emag_cost = 0 // because fun
+	computer_flags = NO_ONOFF_ANIMS
 	light_color = LIGHT_COLOR_GREEN
 	var/haunted = 0
 	var/mob/playerone

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -9,6 +9,7 @@
 	var/obj/item/weapon/circuitboard/circuit = null //if circuit==null, computer can't disassembly
 	var/processing = 0
 	var/empproof = FALSE // For plasma glass builds
+	var/computer_flags = 0
 	machine_flags = EMAGGABLE | SCREWTOGGLE | WRENCHMOVE | FIXED2WORK | MULTITOOL_MENU | SHUTTLEWRENCH
 	pass_flags_self = PASSMACHINE
 	use_auto_lights = 1
@@ -22,7 +23,8 @@
 /obj/machinery/computer/New()
 	..()
 	if(world.has_round_started())
-		anim(target = src, a_icon = 'icons/obj/computer.dmi', flick_anim = "on")
+		if(!(computer_flags & NO_ONOFF_ANIMS))
+			anim(target = src, a_icon = 'icons/obj/computer.dmi', flick_anim = "on")
 		initialize()
 
 /obj/machinery/computer/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
@@ -100,20 +102,20 @@
 
 	// Unpowered/Disabled
 	else if(stat & (FORCEDISABLE|NOPOWER))
-		if(icon_state != "[initial(icon_state)]0")
+		if(icon_state != "[initial(icon_state)]0" && !(computer_flags & NO_ONOFF_ANIMS))
 			anim(target = src, a_icon = 'icons/obj/computer.dmi', flick_anim = "off")
 		icon_state = "[initial(icon_state)]0"
 
 	// Functional
 	else
-		if(icon_state == "[initial(icon_state)]0")
+		if(icon_state == "[initial(icon_state)]0" && !(computer_flags & NO_ONOFF_ANIMS))
 			anim(target = src, a_icon = 'icons/obj/computer.dmi', flick_anim = "on")
 		icon_state = initial(icon_state)
 
 
 /obj/machinery/computer/power_change(var/nodelay = 0)
-	
-	if(nodelay)		
+
+	if(nodelay)
 		..()
 		update_icon()
 	else
@@ -122,7 +124,7 @@
 			update_icon()
 
 // This is a wierd workaround.
-// power_change(TRUE) should be called on wrench move but I want to avoid overriding /obj/machinery/attackby() 
+// power_change(TRUE) should be called on wrench move but I want to avoid overriding /obj/machinery/attackby()
 /obj/machinery/computer/wrenchAnchor()
 	. = ..()
 	if(. == TRUE)
@@ -152,7 +154,8 @@
 							"You begin to unscrew the monitor...")
 	if (do_after(user, src, 20) && (circuit || CC))
 		var/obj/structure/computerframe/A = new /obj/structure/computerframe( src.loc )
-		anim(target = A, a_icon = 'icons/obj/computer.dmi', flick_anim = "off")
+		if(!(computer_flags & NO_ONOFF_ANIMS))
+			anim(target = A, a_icon = 'icons/obj/computer.dmi', flick_anim = "off")
 		src.transfer_fingerprints_to(A)
 		if(!CC)
 			CC = new circuit( A )

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -605,3 +605,5 @@
 	density = 0
 
 	light_color = LIGHT_COLOR_GREEN
+
+	computer_flags = NO_ONOFF_ANIMS

--- a/code/game/machinery/computer/pda_terminal.dm
+++ b/code/game/machinery/computer/pda_terminal.dm
@@ -9,6 +9,7 @@
 	var/machine_id = ""
 
 	machine_flags = EMAGGABLE | SCREWTOGGLE | WRENCHMOVE | FIXED2WORK | MULTITOOL_MENU | PURCHASER
+	computer_flags = NO_ONOFF_ANIMS
 
 /obj/machinery/computer/pda_terminal/New()
 	..()

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -590,3 +590,4 @@ What a mess.*/
 	icon_state = "messyfiles"
 
 	light_color = null
+	computer_flags = NO_ONOFF_ANIMS

--- a/code/game/machinery/computer/slot_machine.dm
+++ b/code/game/machinery/computer/slot_machine.dm
@@ -24,6 +24,7 @@
 	icon_state = "slot"
 
 	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK
+	computer_flags = NO_ONOFF_ANIMS
 
 	var/show_name
 

--- a/code/modules/library/computers/base.dm
+++ b/code/modules/library/computers/base.dm
@@ -7,6 +7,7 @@
 	var/num_pages = 0
 	var/num_results = 0
 	var/datum/library_query/query = new()
+	computer_flags = NO_ONOFF_ANIMS
 	pass_flags = PASSTABLE
 	icon = 'icons/obj/library.dmi'
 	icon_state = "computer"


### PR DESCRIPTION
fixes library computer, arcade machine, laptops, filing cabinet computer

## What this does
Adds a new category of flags for computers. Adds NO_ONOFF_ANIMS flag to that category. Give computers that flag and they will skip the animation.

## Why it's good
Looks good.

## Changelog
:cl:
 * bugfix: Fix certain machines having monitor animations when they shouldn't have them.

