### PR TITLE
unathi playable as janitors

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -165,7 +165,6 @@
 	supervisors = "the head of personnel"
 	wage_payout = 20
 	selection_color = "#dddddd"
-	
 	species_blacklist = list()
 	access = list(access_janitor, access_maint_tunnels)
 	minimal_access = list(access_janitor, access_maint_tunnels)

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -165,6 +165,7 @@
 	supervisors = "the head of personnel"
 	wage_payout = 20
 	selection_color = "#dddddd"
+	species_blacklist = list()
 	access = list(access_janitor, access_maint_tunnels)
 	minimal_access = list(access_janitor, access_maint_tunnels)
 	outfit_datum = /datum/outfit/janitor

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -165,7 +165,7 @@
 	supervisors = "the head of personnel"
 	wage_payout = 20
 	selection_color = "#dddddd"
-	species_blacklist = list()
+	species_blacklist = list("Mushroom")
 	access = list(access_janitor, access_maint_tunnels)
 	minimal_access = list(access_janitor, access_maint_tunnels)
 	outfit_datum = /datum/outfit/janitor

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -165,6 +165,7 @@
 	supervisors = "the head of personnel"
 	wage_payout = 20
 	selection_color = "#dddddd"
+	
 	species_blacklist = list()
 	access = list(access_janitor, access_maint_tunnels)
 	minimal_access = list(access_janitor, access_maint_tunnels)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -44,7 +44,7 @@
 	var/pdatype=/obj/item/device/pda
 	var/pdaslot=slot_belt
 
-	var/list/species_blacklist = list("Mushroom") //Job not available to species in this list - shrooms can only be traders
+	var/list/species_blacklist = list("Mushroom", "Unathi") //Job not available to species in this list - shrooms can only be traders
 	var/list/species_whitelist = list() //If this list isn't empty, job is only available to species in this list
 
 	var/must_be_map_enabled = 0	//If 1, this job only appears on maps on which it's enabled (its type must be in the map's "enabled_jobs" list)

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -399,7 +399,7 @@ var/global/list/playable_species = list("Human")
 	heat_level_2 = 480 //Default 400
 	heat_level_3 = 1100 //Default 1000
 
-	flags = WHITELISTED
+	flags = WHITELISTED | PLAYABLE
 	anatomy_flags = HAS_LIPS | HAS_UNDERWEAR | HAS_TAIL
 
 	default_mutations=list(M_CLAWS)


### PR DESCRIPTION
[bugfix]

![image](https://user-images.githubusercontent.com/94659603/204063472-c70989ad-1193-47f4-8414-6a255ec1487d.png)

## What this does
- Lizardmen can be jannies roundstart

## Why it's good
- tested
- Lizardmen are actually pretty shit: they can't wear shoes or gloves, and contrary to the wiki, they can be diseased and toxified and have human vision

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Unathi can now be janitors
