### PR TITLE
Trader shoal fund score and monthly leaderboard

### DIFF
--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -239,6 +239,21 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 	data = list()
 	fdel(file(file_path))
 
+/datum/persistence_task/highscores/trader
+	execute = TRUE
+	name = "Trader shoal highscores"
+	file_path = "data/persistence/trader_highscores.json"
+
+/datum/persistence_task/highscores/trader/announce_new_highest_record(var/datum/record/money/record)
+	var/name = "Richest shoal haul ever"
+	var/desc = "You broke the record of the richest shoal haul! $[record.cash] chips accumulated."
+	give_award(record.ckey, /obj/item/weapon/reagent_containers/food/drinks/golden_cup, name, desc)
+
+/datum/persistence_task/highscores/trader/announce_new_record(var/datum/record/money/record)
+	var/name = "Good rich shoal haul"
+	var/desc = "You made it to the top 5! You accumulated $[record.cash]."
+	give_award(record.ckey, /obj/item/clothing/accessory/medal/gold, name, desc, FALSE)
+
 //stores map votes for code/modules/html_interface/voting/voting.dm
 /datum/persistence_task/vote
 	execute = TRUE

--- a/code/game/gamemodes/endgame/scoreboard/misc_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/misc_score.dm
@@ -94,8 +94,8 @@
 			rich_shoals += record
 			if(shoal_amount > score.biggestshoalcash)
 				score.biggestshoalcash = shoal_amount
-				score.biggestshoalname = "[player]"
-				score.biggestshoalkey = "[player.key]"
+				score.biggestshoalname = player.real_name
+				score.biggestshoalkey = player.key
 		if(player.hangman_score > score.hangmanrecord)
 			score.hangmanrecord = player.hangman_score
 			score.hangmanname = player.real_name

--- a/code/game/gamemodes/endgame/scoreboard/misc_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/misc_score.dm
@@ -87,9 +87,9 @@
 				score.dmgestkey = player.key
 		if(trader_account)
 			var/shoal_amount = 0
-			for(var/datum/transaction/T in trader_account.transaction_log)
+			for(var/datum/transaction/TR in trader_account.transaction_log)
 				if(T.source_terminal == "[player]")
-					shoal_amount += T.amount
+					shoal_amount += TR.amount
 			if(shoal_amount > 0)
 				var/datum/record/money/record = new(player.key, player.job, shoal_amount)
 				rich_shoals += record

--- a/code/game/gamemodes/endgame/scoreboard/misc_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/misc_score.dm
@@ -85,17 +85,18 @@
 				score.dmgestname = player.real_name
 				score.dmgestjob = player.job
 				score.dmgestkey = player.key
-		var/shoal_amount = 0
-		for(var/datum/transaction/T in trader_account.transaction_log)
-			if(T.source_terminal == "[player]")
-				shoal_amount += T.amount
-		if(shoal_amount > 0)
-			var/datum/record/money/record = new(player.key, player.job, shoal_amount)
-			rich_shoals += record
-			if(shoal_amount > score.biggestshoalcash)
-				score.biggestshoalcash = shoal_amount
-				score.biggestshoalname = player.real_name
-				score.biggestshoalkey = player.key
+		if(trader_account)
+			var/shoal_amount = 0
+			for(var/datum/transaction/T in trader_account.transaction_log)
+				if(T.source_terminal == "[player]")
+					shoal_amount += T.amount
+			if(shoal_amount > 0)
+				var/datum/record/money/record = new(player.key, player.job, shoal_amount)
+				rich_shoals += record
+				if(shoal_amount > score.biggestshoalcash)
+					score.biggestshoalcash = shoal_amount
+					score.biggestshoalname = player.real_name
+					score.biggestshoalkey = player.key
 		if(player.hangman_score > score.hangmanrecord)
 			score.hangmanrecord = player.hangman_score
 			score.hangmanname = player.real_name

--- a/code/game/gamemodes/endgame/scoreboard/misc_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/misc_score.dm
@@ -91,7 +91,7 @@
 				shoal_amount += T.amount
 		if(shoal_amount > 0)
 			var/datum/record/money/record = new(player.key, player.job, shoal_amount)
-				rich_shoals += record
+			rich_shoals += record
 			if(shoal_amount > score.biggestshoalfunder)
 				score.biggestshoalcash = shoal_amount
 				score.biggestshoalname = "[user]"

--- a/code/game/gamemodes/endgame/scoreboard/misc_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/misc_score.dm
@@ -89,7 +89,7 @@
 			var/shoal_amount = 0
 			for(var/datum/transaction/TR in trader_account.transaction_log)
 				if(TR.source_terminal == player.real_name)
-					shoal_amount += TR.amount
+					shoal_amount += text2num(TR.amount)
 			if(shoal_amount > 0)
 				var/datum/record/money/record = new(player.key, player.job, shoal_amount)
 				rich_shoals += record

--- a/code/game/gamemodes/endgame/scoreboard/misc_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/misc_score.dm
@@ -30,13 +30,13 @@
 				var/icon/flat = getFlatIcon(painting)
 				row1 += {"<td><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'></td>"}
 				row2 += {"<td>"[title]"</td>"}
-			
+
 			tooble += {"<tr>[row1]</tr><tr>[row2]</tr>"}
 			if(artistsandworks != currentartist)
 				currentartist = artistsandworks
 				painting_completions += {"<h3>[artistsandworks]</h3>"}
 				painting_completions += {"<table>[tooble]</table>"}
-	
+
 		completions += "<h2>Artisans and their artworks</h2>"
 		completions += painting_completions
 		completions += "<HR>"
@@ -48,7 +48,9 @@
 		completions += "<br>[achievement_declare_completion()]"
 
 	score.money_leaderboard = SSpersistence_misc.tasks[/datum/persistence_task/highscores]
+	score.shoal_leaderboard = SSpersistence_misc.tasks[/datum/persistence_task/highscores/trader]
 	var/list/rich_escapes = list()
+	var/list/rich_shoals = list()
 
 	for(var/mob/living/player in player_list)
 		if(player.stat == DEAD)
@@ -83,6 +85,17 @@
 				score.dmgestname = player.real_name
 				score.dmgestjob = player.job
 				score.dmgestkey = player.key
+		var/shoal_amount = 0
+		for(var/datum/transaction/T in trader_account.transaction_log)
+			if(T.source_terminal == "[player]")
+				shoal_amount += T.amount
+		if(shoal_amount > 0)
+			var/datum/record/money/record = new(player.key, player.job, shoal_amount)
+				rich_shoals += record
+			if(shoal_amount > score.biggestshoalfunder)
+				score.biggestshoalcash = shoal_amount
+				score.biggestshoalname = "[user]"
+				score.biggestshoalkey = "[user.key]"
 		if(player.hangman_score > score.hangmanrecord)
 			score.hangmanrecord = player.hangman_score
 			score.hangmanname = player.real_name
@@ -95,6 +108,8 @@
 	//Money
 	var/datum/persistence_task/highscores/leaderboard = score.money_leaderboard
 	leaderboard.insert_records(rich_escapes)
+	var/datum/persistence_task/highscores/trader/leaderboard2 = score.shoal_leaderboard
+	leaderboard2.insert_records(rich_shoals)
 
 	var/transfer_total = 0
 	for(var/datum/money_account/A in all_money_accounts)

--- a/code/game/gamemodes/endgame/scoreboard/misc_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/misc_score.dm
@@ -88,7 +88,7 @@
 		if(trader_account)
 			var/shoal_amount = 0
 			for(var/datum/transaction/TR in trader_account.transaction_log)
-				if(TR.source_terminal == "[player]")
+				if(TR.source_terminal == player.real_name)
 					shoal_amount += TR.amount
 			if(shoal_amount > 0)
 				var/datum/record/money/record = new(player.key, player.job, shoal_amount)

--- a/code/game/gamemodes/endgame/scoreboard/misc_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/misc_score.dm
@@ -88,7 +88,7 @@
 		if(trader_account)
 			var/shoal_amount = 0
 			for(var/datum/transaction/TR in trader_account.transaction_log)
-				if(TR.source_terminal == player.real_name)
+				if(TR.source_name == player.real_name)
 					shoal_amount += text2num(TR.amount)
 			if(shoal_amount > 0)
 				var/datum/record/money/record = new(player.key, player.job, shoal_amount)

--- a/code/game/gamemodes/endgame/scoreboard/misc_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/misc_score.dm
@@ -92,10 +92,10 @@
 		if(shoal_amount > 0)
 			var/datum/record/money/record = new(player.key, player.job, shoal_amount)
 			rich_shoals += record
-			if(shoal_amount > score.biggestshoalfunder)
+			if(shoal_amount > score.biggestshoalcash)
 				score.biggestshoalcash = shoal_amount
-				score.biggestshoalname = "[user]"
-				score.biggestshoalkey = "[user.key]"
+				score.biggestshoalname = "[player]"
+				score.biggestshoalkey = "[player.key]"
 		if(player.hangman_score > score.hangmanrecord)
 			score.hangmanrecord = player.hangman_score
 			score.hangmanname = player.real_name

--- a/code/game/gamemodes/endgame/scoreboard/misc_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/misc_score.dm
@@ -88,7 +88,7 @@
 		if(trader_account)
 			var/shoal_amount = 0
 			for(var/datum/transaction/TR in trader_account.transaction_log)
-				if(T.source_terminal == "[player]")
+				if(TR.source_terminal == "[player]")
 					shoal_amount += TR.amount
 			if(shoal_amount > 0)
 				var/datum/record/money/record = new(player.key, player.job, shoal_amount)

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -245,10 +245,10 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 			dat += "<B>Most Battered Escapee:</B> [score.dmgestname], [score.dmgestjob]: [score.dmgestdamage] damage ([score.dmgestkey])<BR>"
 		if(score.richestcash)
 			dat += "<B>Richest Escapee:</B> [score.richestname], [score.richestjob]: $[score.richestcash] ([score.richestkey])<BR>"
-		if(score.biggestshoalcash)
-			dat += "<B>Most Generous Shoal Funder:</B> [score.biggestshoalname]: $[score.biggestshoalcash] ([score.biggestshoalkey])<BR>"
 	else
 		dat += "The station wasn't evacuated or there were no survivors!<BR>"
+	if(score.biggestshoalcash)
+		dat += "<B>Most Generous Shoal Funder:</B> [score.biggestshoalname]: $[score.biggestshoalcash] ([score.biggestshoalkey])<BR>"
 	dat += "<B>Department Leaderboard:</B><BR>"
 	var/list/dept_leaderboard = get_dept_leaderboard()
 	for (var/i = 1 to dept_leaderboard.len)

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -311,7 +311,7 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 			dat += "[i++]) <b>$[cash]</b> by <b>[entry.ckey]</b> ([entry.role]). That shift lasted [entry.shift_duration]. Date: [entry.date]<br>"
 	var/datum/persistence_task/highscores/trader/leaderboard2 = score.shoal_leaderboard
 	dat += "<br><b>MONTHLY TOP 5 RICHEST TRADERS:</b><br>"
-	var/i = 1
+	i = 1
 	for(var/datum/record/money/entry in leaderboard2.data)
 		var/cash = num2text(entry.cash, 12)
 		var/list/split_date = splittext(entry.date, "-")

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -51,6 +51,9 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	var/richestjob			= null  //Kinda pointless if you dont have a money system i guess
 	var/richestcash			= 0
 	var/richestkey			= null
+	var/biggestshoalname	= null
+	var/biggestshoalcash	= 0
+	var/biggestshoalkey		= null
 	var/dmgestname			= null //Who had the most damage on the shuttle (but was still alive)
 	var/dmgestjob			= null
 	var/dmgestdamage		= 0
@@ -77,6 +80,7 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	var/bagelscooked		= 0
 	var/disease				= 0
 	var/list/money_leaderboard = list()
+	var/list/shoal_leaderboard = list()
 	var/list/implant_phrases = list()
 	var/list/global_paintings = list()
 
@@ -241,6 +245,8 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 			dat += "<B>Most Battered Escapee:</B> [score.dmgestname], [score.dmgestjob]: [score.dmgestdamage] damage ([score.dmgestkey])<BR>"
 		if(score.richestcash)
 			dat += "<B>Richest Escapee:</B> [score.richestname], [score.richestjob]: $[score.richestcash] ([score.richestkey])<BR>"
+		if(score.biggestshoalcash)
+			dat += "<B>Most Generous Shoal Funder:</B> [score.biggestshoalname]: $[score.biggestshoalcash] ([score.biggestshoalkey])<BR>"
 	else
 		dat += "The station wasn't evacuated or there were no survivors!<BR>"
 	dat += "<B>Department Leaderboard:</B><BR>"
@@ -303,6 +309,18 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 			break
 		else
 			dat += "[i++]) <b>$[cash]</b> by <b>[entry.ckey]</b> ([entry.role]). That shift lasted [entry.shift_duration]. Date: [entry.date]<br>"
+	var/datum/persistence_task/highscores/trader/leaderboard2 = score.shoal_leaderboard
+	dat += "<br><b>MONTHLY TOP 5 RICHEST TRADERS:</b><br>"
+	var/i = 1
+	for(var/datum/record/money/entry in leaderboard2.data)
+		var/cash = num2text(entry.cash, 12)
+		var/list/split_date = splittext(entry.date, "-")
+		if(text2num(split_date[2]) != text2num(time2text(world.timeofday, "MM")))
+			leaderboard2.clear_records()
+			dat += "No rich traders yet!"
+			break
+		else
+			dat += "[i++]) <b>$[cash]</b> by <b>[entry.ckey]</b>. That shift lasted [entry.shift_duration]. Date: [entry.date]<br>"
 	return dat
 
 /mob/proc/display_round_end_scoreboard()

--- a/code/game/machinery/ATM.dm
+++ b/code/game/machinery/ATM.dm
@@ -299,7 +299,7 @@ log transactions
 					else if(transfer_amount <= authenticated_account.money)
 						var/target_account_number = text2num(href_list["target_acc_number"])
 						var/transfer_purpose = copytext(sanitize(href_list["purpose"]),1,MAX_MESSAGE_LEN)
-						if(linked_db.charge_to_account(target_account_number, authenticated_account.owner_name, transfer_purpose, machine_id, transfer_amount))
+						if(linked_db.charge_to_account(target_account_number, authenticated_account.owner_name, transfer_purpose, machine_id, transfer_amount, usr.real_name))
 							to_chat(usr, "[bicon(src)]<span class='info'>Funds transfer successful.</span>")
 							authenticated_account.money -= transfer_amount
 

--- a/code/game/machinery/ATM.dm
+++ b/code/game/machinery/ATM.dm
@@ -106,7 +106,7 @@ log transactions
 				playsound(loc, 'sound/items/polaroid2.ogg', 50, 1)
 
 			//create a transaction log entry
-			new /datum/transaction(authenticated_account, "Credit deposit", round(dosh.worth * dosh.amount * (multiplier/100)), machine_id)
+			new /datum/transaction(authenticated_account, "Credit deposit", round(dosh.worth * dosh.amount * (multiplier/100)), machine_id, source_name = user.real_name)
 
 			to_chat(user, "<span class='info'>You insert [round(dosh.worth * dosh.amount * (multiplier/100))] credit\s into \the [src].</span>")
 			src.attack_hand(user)
@@ -305,7 +305,7 @@ log transactions
 
 							//create an entry in the account transaction log
 							new /datum/transaction(authenticated_account, transfer_purpose, "-[transfer_amount]",\
-													machine_id, "Account #[target_account_number]")
+													machine_id, "Account #[target_account_number]", source_name = usr.real_name)
 						else
 							to_chat(usr, "[bicon(src)]<span class='warning'>Funds transfer failed.</span>")
 
@@ -373,7 +373,7 @@ log transactions
 							withdraw_arbitrary_sum(usr,amount)
 
 							//create an entry in the account transaction log
-							new /datum/transaction(authenticated_account, "Credit withdrawal", "-[amount]", machine_id)
+							new /datum/transaction(authenticated_account, "Credit withdrawal", "-[amount]", machine_id, source_name = usr.real_name)
 						else
 							to_chat(usr, "[bicon(src)]<span class='warning'>You don't have enough funds to do that!</span>")
 			if("withdraw_to_wallet")
@@ -393,7 +393,7 @@ log transactions
 
 							//create an entry in the account transaction log
 							new /datum/transaction(authenticated_account, "Credit transfer to wallet", "-[amount]",\
-													machine_id, card_id.virtual_wallet.owner_name)
+													machine_id, card_id.virtual_wallet.owner_name, source_name = usr.real_name)
 
 							new /datum/transaction(card_id.virtual_wallet, "Credit transfer to wallet", "[amount]",\
 													machine_id, authenticated_account.owner_name)
@@ -416,7 +416,7 @@ log transactions
 
 							//create an entry in the account transaction log
 							new /datum/transaction(authenticated_account, "Credit transfer from wallet", "[amount]",\
-													machine_id, card_id.virtual_wallet.owner_name)
+													machine_id, card_id.virtual_wallet.owner_name, source_name = usr.real_name)
 
 							new /datum/transaction(card_id.virtual_wallet, "Credit transfer from wallet", "-[amount]",\
 													machine_id, authenticated_account.owner_name)

--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -421,7 +421,7 @@ var/latejoiner_allowance = 0//Added to station_allowance and reset before every 
 
 	src.attack_hand(usr)
 
-/obj/machinery/account_database/proc/charge_to_account(var/attempt_account_number, var/source_name, var/purpose, var/terminal_id, var/amount)
+/obj/machinery/account_database/proc/charge_to_account(var/attempt_account_number, var/source_name, var/purpose, var/terminal_id, var/amount, var/target_name)
 	if(!activated || !attempt_account_number)
 		return 0
 	for(var/datum/money_account/D in all_money_accounts)
@@ -429,7 +429,7 @@ var/latejoiner_allowance = 0//Added to station_allowance and reset before every 
 			D.money += amount
 
 			//create a transaction log entry
-			new /datum/transaction(D, purpose, "[abs(amount)]", terminal_id, source_name)
+			new /datum/transaction(D, purpose, "[abs(amount)]", terminal_id, source_name, source_name = target_name)
 
 			return 1
 

--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -147,9 +147,11 @@ var/latejoiner_allowance = 0//Added to station_allowance and reset before every 
 	var/time = ""
 	var/source_terminal = ""
 
-/datum/transaction/New(var/datum/money_account/account=null, var/purpose="", var/amount = 0, var/source_terminal="", var/target_name="", var/date="", var/time = "", var/send2PDAs = TRUE)
+/datum/transaction/New(var/datum/money_account/account=null, var/purpose="", var/amount = 0, var/source_terminal="", var/target_name="", var/date="", var/time = "", var/send2PDAs = TRUE, var/source_name="")
 	// Default to account name if not specified
 	src.target_name = target_name == "" && account ? account.owner_name : target_name
+	// Default to source terminal if not specified
+	src.source_name = source_name == "" ? source_terminal : source_name
 	src.purpose = purpose
 	src.amount = amount
 	// Get current date and time if not specified

--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -146,6 +146,7 @@ var/latejoiner_allowance = 0//Added to station_allowance and reset before every 
 	var/date = ""
 	var/time = ""
 	var/source_terminal = ""
+	var/source_name = ""
 
 /datum/transaction/New(var/datum/money_account/account=null, var/purpose="", var/amount = 0, var/source_terminal="", var/target_name="", var/date="", var/time = "", var/send2PDAs = TRUE, var/source_name="")
 	// Default to account name if not specified

--- a/code/modules/credits/episode_name.dm
+++ b/code/modules/credits/episode_name.dm
@@ -127,7 +127,7 @@
 	if(score.richestcash > 30000)
 		episode_names += new /datum/episode_name/rare("[pick("WAY OF THE WALLET", "THE IRRESISTIBLE RISE OF [uppertext(score.richestname)]", "PRETTY PENNY", "IT'S THE ECONOMY, STUPID")]", "Scrooge Mc[score.richestkey] racked up [score.richestcash] credits this round.", min(450, score.richestcash/500))
 	if(score.biggestshoalcash > 30000)
-		episode_names += new /datum/episode_name/rare("[pick("WAY OF WALLET", "IRRESISTING RISE OF [uppertext(score.richestname)]", "PRETTY PENNY", "IS ECONOMY, STUPID")]", "Scrooge Mc[score.biggestshoalkey] racked up [score.biggestshoalcash] credits this round.", min(450, score.biggestshoalcash/500))
+		episode_names += new /datum/episode_name/rare("[pick("WAY OF WALLET", "IRRESISTING RISE OF [uppertext(score.richestname)]", "PRETTY COIN", "IS ECONOMY, STUPID")]", "Scrooge Mc[score.biggestshoalkey] racked up [score.biggestshoalcash] credits this round.", min(450, score.biggestshoalcash/500))
 	if(score.deadaipenalty > 3)
 		episode_names += new /datum/episode_name/rare("THE ONE WHERE [score.deadaipenalty] AIS DIE", "That's a lot of dead AIs.", min(1500, score.deadaipenalty*300))
 	if(score.lawchanges > 12)

--- a/code/modules/credits/episode_name.dm
+++ b/code/modules/credits/episode_name.dm
@@ -126,6 +126,8 @@
 		episode_names += new /datum/episode_name/rare("MY HEART WILL GO ON", "[score.heartattacks] hearts were reanimated and burst out of someone's chest this round.", min(1500, score.heartattacks*250))
 	if(score.richestcash > 30000)
 		episode_names += new /datum/episode_name/rare("[pick("WAY OF THE WALLET", "THE IRRESISTIBLE RISE OF [uppertext(score.richestname)]", "PRETTY PENNY", "IT'S THE ECONOMY, STUPID")]", "Scrooge Mc[score.richestkey] racked up [score.richestcash] credits this round.", min(450, score.richestcash/500))
+	if(score.biggestshoalcash > 30000)
+		episode_names += new /datum/episode_name/rare("[pick("WAY OF WALLET", "IRRESISTING RISE OF [uppertext(score.richestname)]", "PRETTY PENNY", "IS ECONOMY, STUPID")]", "Scrooge Mc[score.biggestshoalkey] racked up [score.biggestshoalcash] credits this round.", min(450, score.biggestshoalcash/500))
 	if(score.deadaipenalty > 3)
 		episode_names += new /datum/episode_name/rare("THE ONE WHERE [score.deadaipenalty] AIS DIE", "That's a lot of dead AIs.", min(1500, score.deadaipenalty*300))
 	if(score.lawchanges > 12)

--- a/code/modules/trader/trade_window.dm
+++ b/code/modules/trader/trade_window.dm
@@ -277,6 +277,7 @@
 		return
 	comment_deposit(user,value)
 	trader_account.money += value
+	new /datum/transaction(trader_account, "Shoal fund addition", "[value]", "[user]", send2PDAs = FALSE)
 	for(var/obj/item/weapon/spacecash/C in loc.contents)
 		qdel(C)
 

--- a/code/modules/trader/trade_window.dm
+++ b/code/modules/trader/trade_window.dm
@@ -277,7 +277,7 @@
 		return
 	comment_deposit(user,value)
 	trader_account.money += value
-	new /datum/transaction(trader_account, "Shoal fund addition", "[value]", user.real_name, send2PDAs = FALSE)
+	new /datum/transaction(trader_account, "Shoal fund addition", "[value]", user.real_name, send2PDAs = FALSE, source_name = user.real_name)
 	for(var/obj/item/weapon/spacecash/C in loc.contents)
 		qdel(C)
 

--- a/code/modules/trader/trade_window.dm
+++ b/code/modules/trader/trade_window.dm
@@ -277,7 +277,7 @@
 		return
 	comment_deposit(user,value)
 	trader_account.money += value
-	new /datum/transaction(trader_account, "Shoal fund addition", "[value]", "[user]", send2PDAs = FALSE)
+	new /datum/transaction(trader_account, "Shoal fund addition", "[value]", user.real_name, send2PDAs = FALSE)
 	for(var/obj/item/weapon/spacecash/C in loc.contents)
 		qdel(C)
 


### PR DESCRIPTION
[content]

## What this does
adds a line to the end of round scoreboard under "THE WEIRD:", specifically under "richest escapee:" for the richest trader in that round, specifically by counting how much money they deposited into the shoal via trade windows. also adds a top 5 monthly leaderboard for these. debating making stuff purchased at windows count towards this score in price too.

## Why it's good
should be a good showoff of good trader rounds, irregardless of if they decide to escape on the shuttle.

## Changelog
:cl:
 * rscadd: The richest trader is now shown on the end of round scoreboard.
 * rscadd: There is now a top 5 monthly leaderboard of richest traders.