### PR TITLE
Change scaling for explosions to previous

### DIFF
--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -185,8 +185,6 @@
 	pressure = temp_first.return_pressure()/2
 
 	var/range = (pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE
-	if(range > 14)
-		range = (pressure-TANK_FRAGMENT_PRESSURE+14000)/(2*TANK_FRAGMENT_SCALE)
 	var/dev = round(range*0.25)
 
 	return dev

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -260,8 +260,6 @@
 		air_contents.react()
 		pressure = air_contents.return_pressure()
 		var/range = (pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE
-		if(range > 14)
-			range = (pressure-TANK_FRAGMENT_PRESSURE+14000)/(2*TANK_FRAGMENT_SCALE)
 		if(range > MAX_EXPLOSION_RANGE)
 			cap = 1
 			uncapped = range

--- a/code/modules/projectiles/guns/projectile/constructable/blastcannon.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/blastcannon.dm
@@ -139,8 +139,6 @@
 			bomb_air_contents_2.react()
 			pressure = bomb_air_contents_2.return_pressure()
 			var/range = (pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE
-			if(range > 14)
-				range = (pressure-TANK_FRAGMENT_PRESSURE+14000)/(2*TANK_FRAGMENT_SCALE)
 			uncapped = range
 			if(!ignorecap)
 				if(range > MAX_EXPLOSION_RANGE)


### PR DESCRIPTION
See #32957. Since the secret repo defines the size of the explosion, scaling with the cap in that previous PR didn't make much sense. @jwhitak

## What this does
- removes the scaling after range 14

## Why it's good
- Since the secret repo defines how big explosions are, it was pointless to scale it like this in the first place

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: TTVs scale much better with high pressure again.