### PR TITLE
Adds Space Chocolate, a substitute for real chocolate

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -464,6 +464,7 @@
 #define DSYRUP			"dsyrup"
 #define GRUE_BILE		"grue_bile"
 #define PINKLADY		"pinklady"
+#define SPACE_CHOCOLATE "space_chocolate"
 
 #define TUNGSTEN 			"tungsten"
 #define LITHIUMSODIUMTUNGSTATE 			"lithiumsodiumtungstate"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -10153,6 +10153,6 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	if(..())
 		return 1
 	if(ishuman(M))
-		if(!M_FAT in M.mutations)
+		if(!(M_FAT in M.mutations))
 			if(prob(25))
 				M.adjustToxLoss(0.1)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -10139,11 +10139,20 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	density = 7.874
 	var/mute_duration = 300 //30 seconds
 
+//A type of chocolate made from vomit and corn syrup that has significantly less dietary value than corn syrup but is far less toxic than vomit.
 /datum/reagent/space_chocolate
 	name = "Space Chocolate"
 	id = SPACE_CHOCOLATE
-	description = "A liquid mix of chemicals that strongly resembles chocolate in everything but taste. Marketed as real chocolate in Space America."
+	description = "A liquid mix of stomach contents and corn sryup made in Space America that strongly resembles chocolate in everything but taste. Often marketed as real chocolate."
 	color = "#8C5935" // 140, 89, 53
-	nutriment_factor = 2 * REAGENTS_METABOLISM
+	nutriment_factor = 1 * REAGENTS_METABOLISM
 	density = 1.2 //      }
 	specheatcap = 4.18 // } - Similar to Hot Chocolate
+
+/datum/reagent/space_chocolate/on_mob_life(var/mob/living/M)
+	if(..())
+		return 1
+	if(ishuman(M))
+		if(!M_FAT in M.mutations)
+			if(prob(25))
+				M.adjustToxLoss(0.1)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -10154,5 +10154,5 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 		return 1
 	if(ishuman(M))
 		if(!(M_FAT in M.mutations))
-			if(prob(25))
+			if(prob(35))
 				M.adjustToxLoss(0.1)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -5494,7 +5494,7 @@ var/procizine_tolerance = 0
 	nutriment_factor = 20 * REAGENTS_METABOLISM
 	color = "#302000" //rgb: 48, 32, 0
 	density = 0.9185
-	specheatcap = 2.402	
+	specheatcap = 2.402
 	var/has_had_heart_explode = 0
 
 /datum/reagent/cornoil/on_mob_life(var/mob/living/M)
@@ -10138,3 +10138,12 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	specheatcap = 0.45
 	density = 7.874
 	var/mute_duration = 300 //30 seconds
+
+/datum/reagent/space_chocolate
+	name = "Space Chocolate"
+	id = SPACE_CHOCOLATE
+	description = "A liquid mix of chemicals that strongly resembles chocolate in everything but taste. Marketed as real chocolate in Space America."
+	color = "#8C5935" // 140, 89, 53
+	nutriment_factor = 2 * REAGENTS_METABOLISM
+	density = 1.2 //      }
+	specheatcap = 4.18 // } - Similar to Hot Chocolate

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -4035,6 +4035,13 @@
 	for(var/turf/T in view(get_turf(holder.my_atom)))
 		T.mute_time = world.time + B.mute_duration
 
+/datum/chemical_reaction/space_chocolate
+	name = "Space Chocolate"
+	id = SPACE_CHOCOLATE
+	result = SPACE_CHOCOLATE
+	required_reagents = list(VOMIT = 1, CORNSYRUP = 1)
+	result_amount = 2
+
 /datum/chemical_reaction/random
 	name = "Random chemical"
 	id = "random"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -4040,7 +4040,7 @@
 	id = SPACE_CHOCOLATE
 	result = SPACE_CHOCOLATE
 	required_reagents = list(VOMIT = 1, CORNSYRUP = 1)
-	result_amount = 2
+	result_amount = 4
 
 /datum/chemical_reaction/random
 	name = "Random chemical"


### PR DESCRIPTION
4 units can be made with 1 unit of vomit and 1 unit of corn syrup.
Less nutriment than corn syrup but has only a 35% chance to add 0.1 toxin to the character compared to vomit.
If the character is obese it's perfectly safe to consume.

:cl:
 * rscadd: Added Space Chocolate, a not-quite-like-chocolate chocolate substitute that can be made by combining vomit and corn syrup. It is far less toxic than vomit.