### PR TITLE
add secret alienwhitelist.txt code back

### DIFF
--- a/code/game/jobs/alien_whitelist.dm
+++ b/code/game/jobs/alien_whitelist.dm
@@ -28,5 +28,5 @@ var/global/list/alien_whitelist[] = list()
 	if(!(alien_whitelist && alien_whitelist[ckey]))
 		return 0
 	var/list/species = alien_whitelist[ckey]
-	if(chosen_species in species || "All" in species)
+	if(chosen_species in species)
 		return 1 

--- a/code/game/jobs/alien_whitelist.dm
+++ b/code/game/jobs/alien_whitelist.dm
@@ -1,0 +1,32 @@
+// ckey = list("species", "species")
+var/global/list/alien_whitelist[] = list()
+
+/proc/load_alienwhitelist()
+	alien_whitelist = list()
+	var/text = file2text("config/alienwhitelist.txt")
+	if (!text)
+		diary << "Failed to load config/alienwhitelist.txt\n"
+	else
+		for(var/line in splittext(text, "\n"))
+			if(dd_hasprefix(line,"#"))
+				continue
+			if(!findtext(line,"-"))
+				continue
+			var/list/parts=splittext(line,"-")
+			var/ckey=trim(lowertext(parts[1]))
+			var/specieslist=splittext(parts[2],",")
+			for(var/species in specieslist)
+				species = trim(species)
+				alien_whitelist[ckey] += list(species)
+
+/proc/get_player_whitelist(var/ckey)
+	return alien_whitelist[ckey]
+
+/proc/check_player_whitelist(var/ckey, var/chosen_species)
+	if(!config.usealienwhitelist)
+		return
+	if(!(alien_whitelist && alien_whitelist[ckey]))
+		return 0
+	var/list/species = alien_whitelist[ckey]
+	if(chosen_species in species || "All" in species)
+		return 1 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -953,10 +953,16 @@ var/const/MAX_SAVE_SLOTS = 16
 						age = max(min( round(text2num(new_age)), AGE_MAX),AGE_MIN)
 				if("species")
 					var/prev_species = species
-					if(check_rights(R_ADMIN,0))
-						species = input("Please select a species", "Character Generation", null) in whitelisted_species
+					if(config.usealienwhitelist)	
+						if(check_rights(R_ADMIN,0))
+							species = input("Please select a species", "Character Generation", null) in whitelisted_species + get_player_whitelist(user.ckey)
+						else
+							species = input("Please select a species", "Character Generation", null) in playable_species + get_player_whitelist(user.ckey)
 					else
-						species = input("Please select a species", "Character Generation", null) in playable_species
+						if(check_rights(R_ADMIN,0))
+							species = input("Please select a species", "Character Generation", null) in whitelisted_species
+						else
+							species = input("Please select a species", "Character Generation", null) in playable_species
 
 					if(prev_species != species)
 						//grab one of the valid hair styles for the newly chosen species

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -661,10 +661,10 @@
 
 	if(prefs.species)
 		chosen_species = all_species[prefs.species]
-	if(chosen_species && (check_rights(R_ADMIN, 0) || chosen_species.flags & PLAYABLE || chosen_species.conditional_playable()))
+	if(chosen_species && (check_rights(R_ADMIN, 0) || chosen_species.flags & PLAYABLE || chosen_species.conditional_playable() || check_player_whitelist(prefs.client.ckey, chosen_species.name)))
 		new_character.set_species(prefs.species)
 	else
-		to_chat(usr, "Your preferences had a non-playable species, so you were reverted to the default species.")
+		to_chat(src, "Your preferences had a non-playable species, so you were reverted to the default species.")
 
 	var/datum/language/chosen_language
 	if(prefs.language)

--- a/code/world.dm
+++ b/code/world.dm
@@ -89,6 +89,8 @@ var/auxtools_path
 	jobban_updatelegacybans()
 	appearance_loadbanfile()
 	LoadBans()
+	if(config.usealienwhitelist)
+		load_alienwhitelist()
 
 	spawn() copy_logs() // Just copy the logs.
 	if(config && config.log_runtimes)

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -662,6 +662,7 @@
 #include "code\game\jobs\access.dm"
 #include "code\game\jobs\job_controller.dm"
 #include "code\game\jobs\jobs.dm"
+#include "code\game\jobs\alien_whitelist.dm"
 #include "code\game\jobs\job\assistant.dm"
 #include "code\game\jobs\job\captain.dm"
 #include "code\game\jobs\job\civilian.dm"


### PR DESCRIPTION
So one of my previous PRs removed some code because it didn't work with what I was doing (and it didn't work period). So I made a new PR that re-adds it back, but it does work but with some more limited functionality, as the other system works extremely well for whitelisting/blacklisting jobs and species. "All" does not work though.

## What this does
![image](https://user-images.githubusercontent.com/94659603/204664922-900f63b0-9965-4834-9c3b-572d40f1bf17.png)

## Why it's good
- anyone who can edit alienwhitelist.txt can play as any species they choose as long as it actually exists