### PR TITLE
Necrovision

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -191,7 +191,8 @@
 	var/list/clothing = list() //If the previous corpse had clothing, it 'wears' it
 
 /mob/living/simple_animal/hostile/necro/zombie/update_perception()
-	M.dark_plane.alphas["zombie"] = 90
+	dark_plane.alphas["zombie"] = 90
+	see_in_dark = 8
 	check_dark_vision()
 
 /mob/living/simple_animal/hostile/necro/zombie/New() //(mob/living/L)
@@ -412,6 +413,7 @@
 		host.revive()
 		host.become_zombie = FALSE
 		host.update_perception()
+		host.see_in_dark = initial(host.see_in_dark)
 		visible_message("<span class='notice'>\The [src]'s eyes regain focus, and the smell of decay vanishes. [host] has come back to their senses!</span>")
 		host = null
 		qdel(src)

--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -190,6 +190,10 @@
 
 	var/list/clothing = list() //If the previous corpse had clothing, it 'wears' it
 
+/mob/living/simple_animal/hostile/necro/zombie/update_perception()
+	M.dark_plane.alphas["zombie"] = 90
+	check_dark_vision()
+
 /mob/living/simple_animal/hostile/necro/zombie/New() //(mob/living/L)
 	..()
 	hud_list[STATUS_HUD]      = image('icons/mob/hud.dmi', src, "hudundead")
@@ -407,6 +411,7 @@
 		host.resurrect() //It's a miracle!
 		host.revive()
 		host.become_zombie = FALSE
+		host.update_perception()
 		visible_message("<span class='notice'>\The [src]'s eyes regain focus, and the smell of decay vanishes. [host] has come back to their senses!</span>")
 		host = null
 		qdel(src)


### PR DESCRIPTION
Since zombies break lights and are left in the dark without a way to see, it would make sense that their vision was slightly better.

## What this does
- Gives zombies better vision in the dark

## Why it's good
- scarier zombies in the dark, they'll pop out of nowhere and spook ya

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Gives zombies better vision in the dark