### PR TITLE
fix tertiary languages not working

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -687,6 +687,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 				sHuman.real_name = real_name
 				concrete_outfit.equip(sHuman, TRUE)
 				client?.prefs.copy_to(sHuman)
+				sHuman.add_language(client?.prefs.language)
 				sHuman.dna.UpdateSE()
 				sHuman.dna.UpdateUI()
 				sHuman.ckey = ckey

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -670,8 +670,7 @@
 	if(prefs.language)
 		chosen_language = all_languages["[prefs.language]"]
 	if(chosen_language)
-		if(chosen_language.flags & WHITELISTED)
-			new_character.add_language("[prefs.language]")
+		new_character.add_language("[prefs.language]")
 	if(ticker.random_players || appearance_isbanned(src)) //disabling ident bans for now
 		new_character.setGender(pick(MALE, FEMALE))
 		prefs.real_name = random_name(new_character.gender, new_character.species.name)


### PR DESCRIPTION
They were not being added because of a change from #33424 that required the `WHITELISTED` flag, which is deprecated, and also has a different use case than how it was being implemented anyway.
Fixes #33534 

I also fixed languages not being added to mobs created by admins alt-clicking a ghost, but that was unrelated.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed tertiary languages not being properly added to characters.