### PR TITLE
Reduces paincrit stuns

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_shock.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_shock.dm
@@ -28,18 +28,18 @@
 		if(pain_shock_stage == 40)
 			to_chat(src, "<span class='danger'>[pick("The pain is excruciating!", "Please, just end the pain!", "Your whole body is going numb!")]</span>")
 
-		if(pain_shock_stage >= 60)
+		if(pain_shock_stage >= 60 && pain_shock_stage < 80)
 			if(pain_shock_stage == 60)
 				if(!isUnconscious())
 					visible_message("<B>[src]</B>'s body becomes limp.","Your body becomes limp.")
 			if(prob(2))
 				to_chat(src, "<span class='danger'>[pick("The pain is excruciating!", "Please, just end the pain!", "Your whole body is going numb!")]</span>")
-				Knockdown(20)
+				Knockdown(10)
 
 		if(pain_shock_stage >= 80 && pain_shock_stage < 150)
 			if(prob(5))
 				to_chat(src, "<span class='danger'>[pick("The pain is excruciating!", "Please, just end the pain!", "Your whole body is going numb!")]</span>")
-				Knockdown(20)
+				Knockdown(10)
 
 		if(pain_shock_stage >= 120 && pain_shock_stage < 150)
 			if(prob(2))
@@ -49,12 +49,12 @@
 		if(pain_shock_stage == 150)
 			if(!isUnconscious())
 				visible_message("<B>[src]</b> can no longer stand, collapsing!","You can no longer stand, you collapse!")
-			Knockdown(20)
+			Knockdown(10)
 
 		if(pain_shock_stage >= 150)
 			if((life_tick % 8) == 0)
 				if(prob(80))
-					Knockdown(9)
+					Knockdown(4)
 	else//pain goes down
 		//treshold messages
 		if(!isUnconscious())


### PR DESCRIPTION
REJOICE.

- Reduced 40 second knockdowns to 20 seconds.
- Added a limit to stage 60 pain shock where it will not kick in after stage 80, rather than it having a constant 2% chance every tick to knock down randomly, exacerbating stunlock issues
- Reduced stun that happens at stage 150 and above pain shock (it has an 80% chance to be re-applied every 16 seconds) from 18 seconds to 8. 

:cl:
 * tweak: Being in huge amounts of pain will no longer cripple spacemen for excessive amounts of time, in most cases keeping them stunned for minutes on end.