### PR TITLE
Reduces suicide damage to 125 (from 175).

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -21,18 +21,18 @@
 			if(damagetype & SUICIDE_ACT_CUSTOM)
 				return 1
 
-			//Do 175 damage divided by the number of damage types applied.
+			//Do 125 amage divided by the number of damage types applied.
 			if(damagetype & SUICIDE_ACT_BRUTELOSS)
-				adjustBruteLoss(175/damage_mod)
+				adjustBruteLoss(125/damage_mod)
 
 			if(damagetype & SUICIDE_ACT_FIRELOSS)
-				adjustFireLoss(175/damage_mod)
+				adjustFireLoss(125/damage_mod)
 
 			if(damagetype & SUICIDE_ACT_TOXLOSS)
-				adjustToxLoss(175/damage_mod)
+				adjustToxLoss(125/damage_mod)
 
 			if(damagetype & SUICIDE_ACT_OXYLOSS)
-				adjustOxyLoss(175/damage_mod)
+				adjustOxyLoss(125/damage_mod)
 
 			updatehealth()
 			return 1
@@ -153,7 +153,7 @@
 								"<span class='danger'>[src] is jamming \his thumbs into \his eye sockets! It looks like \he's trying to commit suicide.</span>", \
 								"<span class='danger'>[src] is twisting \his own neck! It looks like \he's trying to commit suicide.</span>", \
 								"<span class='danger'>[src] is holding \his breath! It looks like \he's trying to commit suicide.</span>"))
-		adjustOxyLoss(max(175 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
+		adjustOxyLoss(max(12 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		updatehealth()
 
 /mob/living/carbon/brain/attempt_suicide(forced = 0, suicide_set = 1)
@@ -251,7 +251,7 @@
 
 	visible_message(pick("<span class='danger'>[src] suddenly starts thrashing around wildly! It looks like \he's trying to commit suicide.</span>", \
 						 "<span class='danger'>[src] suddenly starts mauling \himself! It looks like \he's trying to commit suicide.</span>"))
-	adjustOxyLoss(max(175 - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
+	adjustOxyLoss(max(125 - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 	updatehealth()
 
 /mob/living/carbon/slime/attempt_suicide(forced = 0, suicide_set = 1)


### PR DESCRIPTION
Paroxetine was changed so you could halt a suicide on #29470. Consuming paroxetine before dying removes the "suicided" flag, meaning you no longer get the suicide o2 damage and can get revived again, but you keep all the suicide injuries and they'll need to be treated as normal. 
Problem is that suicide deaths happen way too fast for someone to get paroxetine or drag the body to medical, taking around 25 seconds to kill the mob after falling to crit. 
This change makes it so suiciding does 50 less damage, effectively increasing the time until death from 20s to around 80s, this gives a realistic chance to acquire and give some paroxetine to the suicidal player.
Won't affect balance or gameplay much, since you can always ghost after suiciding, instakilling the mob.
Custom suicides, like bags of holding or bike horns are not affected.
:cl:
 * tweak: Suicides do 50 less damage, effectively increasing the time to death from 25ish seconds to 80ish seconds. This does not affect custom suicides like bags of holding or bike horns.