### PR TITLE
limit ricochet bounces

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -131,7 +131,7 @@
 
 /obj/item/projectile/bullet/midbullet/bouncebullet
 	bounce_type = PROJREACT_WALLS|PROJREACT_WINDOWS
-	bounces = 100
+	bounces = 200
 
 /obj/item/projectile/bullet/midbullet/bouncebullet/lawgiver
 	damage = 30

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -131,7 +131,7 @@
 
 /obj/item/projectile/bullet/midbullet/bouncebullet
 	bounce_type = PROJREACT_WALLS|PROJREACT_WINDOWS
-	bounces = -1
+	bounces = 100
 
 /obj/item/projectile/bullet/midbullet/bouncebullet/lawgiver
 	damage = 30

--- a/code/modules/projectiles/projectile/ricochet.dm
+++ b/code/modules/projectiles/projectile/ricochet.dm
@@ -185,7 +185,10 @@
 				dir = SOUTHWEST
 
 /obj/item/projectile/ricochet/proc/bounce()
-	bouncin = 1
+	bouncin += 1
+	if(bouncin > 100)
+		bulletdies()
+		return
 	var/obj/structure/ricochet_bump/bump = new(loc)
 	if(nodamage)
 		bump.icon_state += "_t"

--- a/code/modules/projectiles/projectile/ricochet.dm
+++ b/code/modules/projectiles/projectile/ricochet.dm
@@ -186,7 +186,7 @@
 
 /obj/item/projectile/ricochet/proc/bounce()
 	bouncin += 1
-	if(bouncin > 100)
+	if(bouncin > 200)
 		bulletdies()
 		return
 	var/obj/structure/ricochet_bump/bump = new(loc)


### PR DESCRIPTION
While I don't think it's been an issue recently with bounces, I imagine these projectiles can cause the server to crash in the right conditions

## What this does
- Limits ricochet projectiles to 200 bounces, instead of infinite. At this amount, if it hasn't hit anything, it is likely enclosed in a small space and unlikely to hit anything.

## Why it's good
- prevent possible server crashes

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Limit ricochet bounces from infinity to 100.
