### PR TITLE
Killer Tomato and Giant Mushroom Cuts for cooking

### DIFF
--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -503,7 +503,7 @@
 	icon_state = "mushroom"
 	greaterform = "Mushroom"
 	species_type = /mob/living/carbon/monkey/mushroom
-	meat_type = /obj/item/weapon/reagent_containers/food/snacks/hugemushroomslice/mushroom_man
+	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/hugemushroomslice/mushroom_man
 	canWearClothes = 0
 	canWearHats = 0
 	canWearGlasses = 0

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1275,7 +1275,7 @@ var/list/has_died_as_golem = list()
 	deform = 'icons/mob/human_races/r_mushman.dmi'
 	eyes = "mushroom_eyes"
 	known_languages = list(LANGUAGE_VOX)
-	meat_type = /obj/item/weapon/reagent_containers/food/snacks/hugemushroomslice/mushroom_man
+	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/hugemushroomslice/mushroom_man
 
 	flags = WHITELISTED | PLAYABLE | NO_BREATHE | IS_PLANT | SPECIES_NO_MOUTH
 	anatomy_flags = NO_BALD

--- a/code/modules/mob/living/simple_animal/friendly/tomato.dm
+++ b/code/modules/mob/living/simple_animal/friendly/tomato.dm
@@ -8,7 +8,7 @@
 	turns_per_move = 5
 	maxHealth = 15
 	health = 15
-	meat_type = /obj/item/weapon/reagent_containers/food/snacks/tomatomeat
+	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/tomatomeat
 	response_help  = "prods the"
 	response_disarm = "pushes aside the"
 	response_harm   = "smacks the"

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -9,7 +9,7 @@
 	maxHealth = 10
 	health = 10
 
-	meat_type = /obj/item/weapon/reagent_containers/food/snacks/hugemushroomslice
+	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/hugemushroomslice
 	size = SIZE_SMALL
 
 	response_help  = "pets"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1114,13 +1114,14 @@
 	..()
 	reagents.add_reagent(TRICORDRAZINE, rand(1,5))
 
-/obj/item/weapon/reagent_containers/food/snacks/tomatomeat
+/obj/item/weapon/reagent_containers/food/snacks/meat/tomatomeat
 	name = "tomato slice"
 	desc = "A slice from a huge tomato."
 	icon_state = "tomatomeat"
+	food_flags = FOOD_MEAT
 	base_crumb_chance = 0
 
-/obj/item/weapon/reagent_containers/food/snacks/tomatomeat/New()
+/obj/item/weapon/reagent_containers/food/snacks/meat/tomatomeat/New()
 	..()
 	reagents.add_reagent(NUTRIMENT, 3)
 	src.bitesize = 6

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1098,19 +1098,20 @@
 	reagents.add_reagent(CARPPHEROMONES, 3)
 	bitesize = 3
 
-/obj/item/weapon/reagent_containers/food/snacks/hugemushroomslice
+/obj/item/weapon/reagent_containers/food/snacks/meat/hugemushroomslice
 	name = "huge mushroom slice"
 	desc = "A slice from a huge mushroom."
 	icon_state = "hugemushroomslice"
+	food_flags = FOOD_MEAT
 	base_crumb_chance = 0
 
-/obj/item/weapon/reagent_containers/food/snacks/hugemushroomslice/New()
+/obj/item/weapon/reagent_containers/food/snacks/meat/hugemushroomslice/New()
 	..()
 	reagents.add_reagent(NUTRIMENT, 3)
 	reagents.add_reagent(PSILOCYBIN, 3)
 	src.bitesize = 6
 
-/obj/item/weapon/reagent_containers/food/snacks/hugemushroomslice/mushroom_man/New()
+/obj/item/weapon/reagent_containers/food/snacks/meat/hugemushroomslice/mushroom_man/New()
 	..()
 	reagents.add_reagent(TRICORDRAZINE, rand(1,5))
 


### PR DESCRIPTION
Mo' meat for ya foods.

## What this does
Allows Killer Tomato meat and Giant Mushroom/Mushman meat to be used as a meat substitute for cooking

## Elaboration
One thing I never realized as I never really interacted with the killer tomatos up until recently was that their meat is fairly useless. That's of course not to say it cannot be grilled or eaten raw, it's still quite nutritious, however lacking the ability to actually use it for recipes makes it undesirable to say the least. So, after some snooping around I figured out the problem and decided to rectify the issue. 
In doing so I remembered that the cuts from the giant mushroom too suffer the same problem of it's inability to be used in recipes, so I used the same trick on the giant mushrooms/mushmen, administered the meat pie test and got everything working hunky dory. I think at least in regards to the quite bare bone killer tomatos, this will make them as a viable meat substitute for growing in hydroponics, as for the giant mushrooms, I think it'll be good for any trader looking to sell some food with a bit of kick to it. 

## Changelog

:cl:
 * tweak: Lets you use Killer Tomato meat and Giant Mushroom meat as a meat substitute in recipes
