### PR TITLE
Adds a limit to how much damage can be dealt by low pressure

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_environment.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_environment.dm
@@ -57,10 +57,11 @@
 		pressure_alert = -1
 	else
 		if(!(M_RESIST_COLD in mutations))
-			adjustBruteLoss(LOW_PRESSURE_DAMAGE)
-			if(istype(src.loc, /turf/space))
-				adjustBruteLoss(LOW_PRESSURE_DAMAGE) //Space doubles damage (for some reason space vacuum is not station vacuum, nice snowflake)
-			pressure_alert = -2
+			if(getBruteLoss() < (maxHealth - config.health_threshold_dead)) //Stop damaging the body if the brute damage is equal to the difference between max health and dead health. As of 2022 this is 100 and -100 respectively, which means 200 damage.
+				adjustBruteLoss(LOW_PRESSURE_DAMAGE) //Spread across 7 limbs (arms, legs, upper/lower torso, head) this means ~28.5 brute damage to each limb. Should prevent gibbing from low pressure.
+				if(istype(src.loc, /turf/space))
+					adjustBruteLoss(LOW_PRESSURE_DAMAGE) //Space doubles damage (for some reason space vacuum is not station vacuum, nice snowflake)
+				pressure_alert = -2
 		else
 			pressure_alert = -1
 


### PR DESCRIPTION
The limit is 200 brute damage and changes depending on the human's max health and the threshold at which a human is considered dead. Prevents limbs from exploding.
Tested.
Fixes #33791 

:cl:
 * tweak: Added an upper limit to the damage low pressure can deal to humans, which should make bodies exposed to space a bit more recoverable, and a lot more intact limb-wise.
