### PR TITLE
fixes vox skipjak/nukeops shuttle computer being unfixable and unwrenchable

### DIFF
--- a/code/game/shuttles/syndicate.dm
+++ b/code/game/shuttles/syndicate.dm
@@ -50,7 +50,6 @@ var/global/datum/shuttle/syndicate/syndicate_shuttle = new(starting_area = /area
 	icon_state = "syndishuttle"
 
 	light_color = LIGHT_COLOR_RED
-	machine_flags = 0 //No screwtoggle because this computer can't be built
 	allow_silicons = 0 //no NT robots allowed
 
 /obj/machinery/computer/shuttle_control/syndicate/emag_act()

--- a/code/game/shuttles/vox.dm
+++ b/code/game/shuttles/vox.dm
@@ -88,7 +88,6 @@ var/global/datum/shuttle/vox/vox_shuttle = new(starting_area=/area/shuttle/vox/s
 	req_access = list(access_syndicate)
 
 	light_color = LIGHT_COLOR_RED
-	machine_flags = EMAGGABLE //No screwtoggle because this computer can't be built
 
 /obj/machinery/computer/shuttle_control/vox/New() //Main shuttle_control code is in code/game/machinery/computer/shuttle_computer.dm
 	link_to(vox_shuttle)


### PR DESCRIPTION
## What this does
title

## Why it's good
Prevents the shuttle from becoming fucking unusable just by shooting the glass.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed the vox skipjack and the nukeop shuttle computer being unfixable and unwrenchable.
 