### PR TITLE
adds logging to admins accessing logs; better log access handling

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -720,8 +720,7 @@ Pressure: [env.pressure]"}
 	if(!holder)
 		return
 	message_admins("[src] used find broken blood tracks")
-	var/date_string = time2text(world.realtime, "YYYY-MM-DD")
-	var/F =file("data/logs/profiling/[date_string]_broken_blood.log")
+	var/F = file("data/logs/profiling/[date_string]_broken_blood.log")
 	fdel(F)
 	for(var/obj/effect/decal/cleanable/blood/tracks/T in blood_list)
 		if(!T.loc)
@@ -748,8 +747,7 @@ Pressure: [env.pressure]"}
 	if(!machines.len && !power_machines.len)
 		to_chat(usr, "Machines has no length!")
 		return
-	var/date_string = time2text(world.realtime, "YYYY-MM-DD")
-	var/F =file("data/logs/profiling/[date_string]_machine_instances.csv")
+	var/F = file("data/logs/profiling/[date_string]_machine_instances.csv")
 	fdel(F)
 	F << "type,count"
 	var/list/machineinstances = list()
@@ -762,7 +760,7 @@ Pressure: [env.pressure]"}
 		F << "[T],[count]"
 
 	to_chat(usr, "<span class='notice'>Dumped to [F].</span>")
-	F =file("data/logs/profiling/[date_string]_power_machine_instances.csv")
+	F = file("data/logs/profiling/[date_string]_power_machine_instances.csv")
 	fdel(F)
 	F << "type,count"
 	machineinstances.len = 0
@@ -781,8 +779,7 @@ Pressure: [env.pressure]"}
 	set category = "Debug"
 	set name = "Dump Del Profiling"
 
-	var/date_string = time2text(world.realtime, "YYYY-MM-DD")
-	var/F =file("data/logs/profiling/[date_string]_del_profiling.csv")
+	var/F = file("data/logs/profiling/[date_string]_del_profiling.csv")
 	fdel(F)
 	F << "type,deletes"
 	for(var/typepath in del_profiling)
@@ -790,7 +787,7 @@ Pressure: [env.pressure]"}
 		F << "[typepath],[ns]"
 
 	to_chat(usr, "<span class='notice'>Dumped to [F].</span>")
-	F =file("data/logs/profiling/[date_string]_gdel_profiling.csv")
+	F = file("data/logs/profiling/[date_string]_gdel_profiling.csv")
 	fdel(F)
 	F << "type,soft deletes"
 	for(var/typepath in gdel_profiling)
@@ -799,7 +796,7 @@ Pressure: [env.pressure]"}
 
 	to_chat(usr, "<span class='notice'>Dumped to [F].</span>")
 
-	F =file("data/logs/profiling/[date_string]_ghdel_profiling.csv")
+	F = file("data/logs/profiling/[date_string]_ghdel_profiling.csv")
 	fdel(F)
 	F << "type,hard deletes"
 	for(var/typepath in ghdel_profiling)

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -34,6 +34,8 @@
 
 	target.verbs |= /client/proc/getruntimelog
 	to_chat(target, "<span class='red'>You have been granted access to runtime logs. Please use them responsibly or risk being banned.</span>")
+	message_admins("[key_name_admin(src)] gave runtime log access to: [key_name(target)]")
+	log_admin("key_name(src) gave runtime log access to: [key_name(target)]")
 	return
 
 
@@ -51,7 +53,6 @@
 	if(file_spam_check())
 		return
 
-	message_admins("[key_name_admin(src)] accessed file: [path]")
 	obtain_log(path, src)
 	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
 
@@ -69,7 +70,6 @@
 	if(file_spam_check())
 		return
 
-	message_admins("[key_name_admin(src)] accessed file: [path]")
 	obtain_log(path, src)
 	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
 	return
@@ -83,8 +83,8 @@
 	set name = "Show Server Log"
 	set desc = "Shows today's server log."
 
-	var/path = "data/logs/[time2text(world.realtime,"YYYY/MM-Month/DD-Day")].log"
-	if( fexists(path) )
+	var/path = "data/logs/[date_string].log"
+	if(fexists(path))
 		obtain_log(path, src)
 	else
 		to_chat(src, "<span class='red'>Error: view_txt_log(): File not found/Invalid path([path]).</span>")
@@ -98,8 +98,8 @@
 	set name = "Show Server Attack Log"
 	set desc = "Shows today's server attack log."
 
-	var/path = "data/logs/[time2text(world.realtime,"YYYY/MM-Month/DD-Day")] Attack.log"
-	if( fexists(path) )
+	var/path = "data/logs/[date_string] Attack.log"
+	if(fexists(path))
 		obtain_log(path, src)
 	else
 		to_chat(src, "<span class='red'>Error: view_atk_log(): File not found/Invalid path([path]).</span>")
@@ -110,7 +110,7 @@
 /datum/admins/proc/view_mob_attack_log(var/mob/M as mob)
 	set category	= "Admin"
 	set name		= "Show mob's attack logs"
-	set desc			= "Shows the (formatted) attack log of a mob in a HTML window."
+	set desc		= "Shows the (formatted) attack log of a mob in a HTML window."
 
 	if(!istype(M))
 		to_chat(usr, "That's not a valid mob!")
@@ -119,12 +119,13 @@
 	var/datum/browser/clean/popup = new (usr, "\ref[M]_admin_log_viewer", "Attack logs of [M]", 300, 300)
 	popup.set_content(jointext(M.attack_log, "<br/>"))
 	popup.open()
-
 	feedback_add_details("admin_verb","VMAL")
 
 //Used by the other procs to actually send the selected logs to the user
 /proc/obtain_log(var/path = null, src)
 	if(path && src)
+		message_admins("[key_name_admin(src)] accessed file: [path]")
+		log_admin("key_name(src) accessed file: [path]")
 		#ifdef RUNWARNING
 		#if DM_VERSION > 506 && DM_VERSION < 508
 			#warn Run is deprecated and disabled for some fucking reason in 507.1275/6, if you have a version that doesn't have run() disabled then comment out #define RUNWARNING in setup.dm

--- a/code/world.dm
+++ b/code/world.dm
@@ -2,6 +2,7 @@
 #define PIXEL_MULTIPLIER WORLD_ICON_SIZE/32
 
 var/world_startup_time
+var/date_string
 
 /world
 	mob = /mob/new_player
@@ -51,7 +52,7 @@ var/auxtools_path
 		WORLD_Y_OFFSET += rand(-50,50)
 
 	// logs
-	var/date_string = time2text(world.realtime, "YYYY/MM-Month/DD-Day")
+	date_string = time2text(world.realtime, "YYYY/MM-Month/DD-Day")
 
 	investigations[I_HREFS] = new /datum/log_controller(I_HREFS, filename="data/logs/[date_string] hrefs.htm", persist=TRUE)
 	investigations[I_ATMOS] = new /datum/log_controller(I_ATMOS, filename="data/logs/[date_string] atmos.htm", persist=TRUE)


### PR DESCRIPTION
## What this does
When a shift rolls over to the next IRL day, the logs do not magically switch to a new file. Therefore, all log access verbs should try and access the log for the IRL day that the shift started.

I also added logging to whenever an admin accesses logs, as well as a message printed to chat for admins (but not special tab).

## Why it's good
Functionality, accountability, less repetitive code.
