### PR TITLE
Applies overdark to everyone and moves some planes

### DIFF
--- a/__DEFINES/planes+layers.dm
+++ b/__DEFINES/planes+layers.dm
@@ -74,11 +74,11 @@ Why is FLOAT_PLANE added to a bunch of these?
 	------
 	FLOAT_PLANE = -32767
 */
-#define BELOW_PLATING_PLANE 			(-6 + FLOAT_PLANE)
+#define BELOW_PLATING_PLANE 			(-5 + FLOAT_PLANE)
 
-#define PLATING_PLANE 			(-5 + FLOAT_PLANE)
+#define PLATING_PLANE 			(-4 + FLOAT_PLANE)
 
-#define ABOVE_PLATING_PLANE		(-4 + FLOAT_PLANE)
+#define ABOVE_PLATING_PLANE		(-3 + FLOAT_PLANE)
 
 	#define CATWALK_LAYER				2
 	#define DISPOSALS_PIPE_LAYER		3
@@ -90,8 +90,6 @@ Why is FLOAT_PLANE added to a bunch of these?
 	#define PULSEDEMON_LAYER			9
 	#define FLOORBOARD_ITEM_LAYER		10
 
-#define FLOOR_PLANE 			(-3 + FLOAT_PLANE)
-
 #define BELOW_TURF_PLANE 		(-2 + FLOAT_PLANE)		// objects that are below turfs and darkness but above platings. Useful for asteroid smoothing or other such magic.
 	#define CORNER_LAYER 				2
 	#define SIDE_LAYER					3
@@ -101,7 +99,7 @@ Why is FLOAT_PLANE added to a bunch of these?
 
 #define GLASSTILE_PLANE			-1						// Another one that won't behave, since it's an overlay
 
-#define ABOVE_TURF_PLANE 		(0 + FLOAT_PLANE)			// For items which should appear above turfs but below other objects and hiding mobs, eg: wires & pipes
+#define ABOVE_TURF_PLANE 		(1 + FLOAT_PLANE)			// For items which should appear above turfs but below other objects and hiding mobs, eg: wires & pipes
 
 	#define HOLOMAP_LAYER				1 //Note: Holomap images are not actually on ABOVE_TURF_PLANE. They are explicitly one plane above the parent turf.
 	#define RUNE_LAYER					2
@@ -124,11 +122,11 @@ Why is FLOAT_PLANE added to a bunch of these?
 	#define CREEPER_LAYER				19
 	#define WEED_LAYER					420
 
-#define NOIR_BLOOD_PLANE 		(1 + FLOAT_PLANE)		 	// Contains BLOOD, (ALSO) will appear to people under the influence of the noir colour matrix. -if changing this, make sure that the blood layer changes too.
+#define NOIR_BLOOD_PLANE 		(2 + FLOAT_PLANE)		 	// Contains BLOOD, (ALSO) will appear to people under the influence of the noir colour matrix. -if changing this, make sure that the blood layer changes too.
 
-#define HIDING_MOB_PLANE 		(2 + FLOAT_PLANE)			// for hiding mobs like MoMMIs or spiders or whatever, under most objects but over pipes & such.
+#define HIDING_MOB_PLANE 		(3 + FLOAT_PLANE)			// for hiding mobs like MoMMIs or spiders or whatever, under most objects but over pipes & such.
 
-#define OBJ_PLANE 				(3 + FLOAT_PLANE)			// For objects which appear below humans.
+#define OBJ_PLANE 				(4 + FLOAT_PLANE)			// For objects which appear below humans.
 
 	#define BELOW_TABLE_LAYER			0
 	#define TABLE_LAYER					0.5
@@ -149,22 +147,22 @@ Why is FLOAT_PLANE added to a bunch of these?
 	#define ABOVE_DOOR_LAYER			12
 	#define CHAIR_LEG_LAYER				13
 
-#define LYING_MOB_PLANE			(4 + FLOAT_PLANE)			// other mobs that are lying down.
+#define LYING_MOB_PLANE			(5 + FLOAT_PLANE)			// other mobs that are lying down.
 
-#define LYING_HUMAN_PLANE 		(5 + FLOAT_PLANE)			// humans that are lying down
+#define LYING_HUMAN_PLANE 		(6 + FLOAT_PLANE)			// humans that are lying down
 
-#define ABOVE_OBJ_PLANE			(6 + FLOAT_PLANE)			// for objects that are below humans when they are standing but above them when they are not. - eg, blankets.
+#define ABOVE_OBJ_PLANE			(7 + FLOAT_PLANE)			// for objects that are below humans when they are standing but above them when they are not. - eg, blankets.
 	#define BLANKIES_LAYER				0
 	#define FACEHUGGER_LAYER			1
 
-#define HUMAN_PLANE 			(7 + FLOAT_PLANE)			// For Humans that are standing up.
+#define HUMAN_PLANE 			(8 + FLOAT_PLANE)			// For Humans that are standing up.
 
-#define MOB_PLANE 				(8 + FLOAT_PLANE)			// For Mobs.
+#define MOB_PLANE 				(9 + FLOAT_PLANE)			// For Mobs.
 
 //	#define MOB_LAYER					4
 	#define SLIME_LAYER					5
 
-#define ABOVE_HUMAN_PLANE 		(9 + FLOAT_PLANE)			// For things that should appear above humans.
+#define ABOVE_HUMAN_PLANE 		(10 + FLOAT_PLANE)			// For things that should appear above humans.
 
 	#define SHADOW_LAYER				0
 	#define VEHICLE_LAYER 				0
@@ -181,7 +179,7 @@ Why is FLOAT_PLANE added to a bunch of these?
 	#define CLOSED_FIREDOOR_LAYER		6
 	#define CHAT_LAYER					7
 
-#define BLOB_PLANE 				(10 + FLOAT_PLANE)			// For Blobs, which are above humans.
+#define BLOB_PLANE 				(11 + FLOAT_PLANE)			// For Blobs, which are above humans.
 
 	#define BLOB_ROOTS_LAYER			-1
 	#define BLOB_BASE_LAYER				0
@@ -192,7 +190,7 @@ Why is FLOAT_PLANE added to a bunch of these?
 	#define BLOB_CORE_LAYER				5
 	#define BLOB_SPORE_LAYER			6
 
-#define EFFECTS_PLANE 			(11 + FLOAT_PLANE)			// For special effects.
+#define EFFECTS_PLANE 			(12 + FLOAT_PLANE)			// For special effects.
 
 	#define BELOW_PROJECTILE_LAYER 		3
 	#define PROJECTILE_LAYER 			4
@@ -204,19 +202,19 @@ Why is FLOAT_PLANE added to a bunch of these?
 	#define HORIZON_EXHAUST_LAYER		10
 	#define POINTER_LAYER 				11
 
-#define GAS_PLANE 				11					// Gas overlays really hate being in anything except vis_contents when FLOAT_PLANE'D, don't ask
+#define GAS_PLANE 				12					// Gas overlays really hate being in anything except vis_contents when FLOAT_PLANE'D, don't ask
 
-#define GHOST_PLANE 			(12 + FLOAT_PLANE)			// Ghosts show up under lighting, HUD etc.
+#define GHOST_PLANE 			(13 + FLOAT_PLANE)			// Ghosts show up under lighting, HUD etc.
 
 	#define GHOST_LAYER 				1
 
-#define FAKE_CAMERA_PLANE		(13)
+#define FAKE_CAMERA_PLANE		(14)
 
-#define LIGHTING_PLANE 			(14)	// Don't put anything other than lighting_overlays in there please
+#define LIGHTING_PLANE 			(15)	// Don't put anything other than lighting_overlays in there please
 	#define SELF_VISION_LAYER 		   -1
 	#define LIGHTING_LAYER 				0
 
-#define ABOVE_LIGHTING_PLANE	(15)
+#define ABOVE_LIGHTING_PLANE	(16)
 	#define ABOVE_LIGHTING_LAYER		0
 	#define SUPERMATTER_WALL_LAYER 		1
 	#define SUPER_PORTAL_LAYER			2
@@ -225,21 +223,21 @@ Why is FLOAT_PLANE added to a bunch of these?
 
 	#define MAPPING_AREA_LAYER			999	// Why isn't this a plane exactly?
 
-#define OPEN_OVERLAY_PLANE	(16 + FLOAT_PLANE) // This one won't behave either
+#define OPEN_OVERLAY_PLANE	(17 + FLOAT_PLANE) // This one won't behave either
 
-#define BASE_PLANE 				(17 + FLOAT_PLANE)		//  this is where darkness is! see "how planes work" - needs SEE_BLACKNESS or SEE_PIXEL (see blackness is better for ss13)
+#define BASE_PLANE 				(18 + FLOAT_PLANE)		//  this is where darkness is! see "how planes work" - needs SEE_BLACKNESS or SEE_PIXEL (see blackness is better for ss13)
 
-#define MISC_HUD_MARKERS_PLANE	18
+#define MISC_HUD_MARKERS_PLANE	19
 
-#define ANTAG_HUD_PLANE		 	19
+#define ANTAG_HUD_PLANE		 	20
 
-#define STATIC_PLANE 			20		// For AI's static.
+#define STATIC_PLANE 			21		// For AI's static.
 
 	#define HACK_LAYER 					1
 	#define STATIC_LAYER				2
 	#define REACTIVATE_CAMERA_LAYER		3
 
-#define FULLSCREEN_PLANE		21		// for fullscreen overlays that do not cover the hud.
+#define FULLSCREEN_PLANE		22		// for fullscreen overlays that do not cover the hud.
 
 	#define FULLSCREEN_LAYER	 		0
 	#define DAMAGE_HUD_LAYER 			1
@@ -248,7 +246,7 @@ Why is FLOAT_PLANE added to a bunch of these?
 	#define CRIT_LAYER 					4
 	#define HALLUCINATION_LAYER 		5
 
-#define HUD_PLANE 				22		// For the Head-Up Display
+#define HUD_PLANE 				23		// For the Head-Up Display
 
 	#define UNDER_HUD_LAYER 			0
 	#define HUD_BASE_LAYER		 		1
@@ -260,7 +258,7 @@ Why is FLOAT_PLANE added to a bunch of these?
 	#define MIND_UI_BUTTON 				11
 	#define MIND_UI_FRONT 				12
 
-#define ABOVE_HUD_PLANE 		23		// For being above the Head-Up Display
+#define ABOVE_HUD_PLANE 		24		// For being above the Head-Up Display
 
 
 /atom/proc/hud_layerise()
@@ -340,16 +338,21 @@ var/noir_master = list(new /obj/abstract/screen/plane_master/noir_master(),new /
 	screen |= ghost_planemaster_dummy
 
 // OVERDARKNESS PLANEMASTER
-// Used to apply darkness over lights that the player isn't supposed to see when the lighting master is set to BLEND_ADD
+// Used to move the BYOND darkness plane from SEE_BLACKNESS to a different plane so it covers things on desired planes above 0
 /obj/abstract/screen/plane_master/overdark_planemaster
 	plane = 0
+	render_target = "*overdark"
+
+var/obj/abstract/screen/plane_master/overdark_planemaster/overdark_planemaster = new()
 
 /obj/abstract/screen/plane_master/overdark_planemaster_target
 	appearance_flags = 0
-	plane = LIGHTING_PLANE
-	blend_mode = BLEND_ADD
+	plane = BASE_PLANE
 	mouse_opacity = 0
 	screen_loc = "CENTER,CENTER"
+	render_source = "*overdark"
+
+var/obj/abstract/screen/plane_master/overdark_planemaster_target/overdark_planemaster_target = new()
 
 // DARKNESS PLANEMASTER
 // One planemaster for each client, which they gain during mob/login()

--- a/code/game/machinery/station_map.dm
+++ b/code/game/machinery/station_map.dm
@@ -85,7 +85,7 @@ var/list/station_holomaps = list()
 
 	floor_markings = image('icons/turf/overlays.dmi', "station_map")
 	floor_markings.dir = dir
-	floor_markings.plane = ABOVE_TURF_PLANE
+	floor_markings.plane = relative_plane(ABOVE_TURF_PLANE)
 	floor_markings.layer = DECAL_LAYER
 	update_icon()
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -45,7 +45,7 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 
 	melt_temperature = 1643.15 // Melting point of steel
 
-	plane = FLOOR_PLANE
+	plane = TURF_PLANE
 
 	holomap_draw_override = HOLOMAP_DRAW_PATH
 

--- a/code/game/turfs/unsimulated/floor.dm
+++ b/code/game/turfs/unsimulated/floor.dm
@@ -2,7 +2,7 @@
 	name = "floor"
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "Floor3"
-	plane = FLOOR_PLANE
+	plane = TURF_PLANE
 
 	holomap_draw_override = HOLOMAP_DRAW_PATH
 

--- a/code/modules/clothing/glasses/scanners.dm
+++ b/code/modules/clothing/glasses/scanners.dm
@@ -74,15 +74,6 @@
 	actions_types = list(/datum/action/item_action/toggle_goggles)
 	species_fit = list(VOX_SHAPED, GREY_SHAPED)
 	eyeprot = -1
-	var/obj/abstract/screen/plane_master/overdark_planemaster/overdark_planemaster
-	var/obj/abstract/screen/plane_master/overdark_planemaster_target/overdark_target
-
-/obj/item/clothing/glasses/scanner/night/New()
-	..()
-	overdark_planemaster = new
-	overdark_planemaster.render_target = "night vision goggles (\ref[src])"
-	overdark_target = new
-	overdark_target.render_source = "night vision goggles (\ref[src])"
 
 /obj/item/clothing/glasses/scanner/night/enable(var/mob/living/carbon/C)
 	see_in_dark = initial(see_in_dark)
@@ -92,12 +83,10 @@
 		var/mob/living/carbon/human/H = C
 		if (H.glasses == src)
 			C.update_perception()
-			add_overdark(C)
 	else if (ismonkey(C))
 		var/mob/living/carbon/monkey/M = C
 		if (M.glasses == src)
 			C.update_perception()
-			add_overdark(C)
 	return ..()
 
 /obj/item/clothing/glasses/scanner/night/disable(var/mob/living/carbon/C)
@@ -105,7 +94,6 @@
 	see_in_dark = 0
 	my_dark_plane_alpha_override = null
 	eyeprot = 0
-	remove_overdark(C)
 	if (ishuman(C))
 		var/mob/living/carbon/human/H = C
 		if (H.glasses == src)
@@ -125,8 +113,6 @@
 			M.master_plane.blend_mode = BLEND_ADD
 		if (M.client)
 			M.client.color = "#33FF33"
-			remove_overdark(M)
-			add_overdark(M)
 	else
 		my_dark_plane_alpha_override = null
 		if (M.master_plane)
@@ -135,21 +121,10 @@
 /obj/item/clothing/glasses/scanner/night/unequipped(mob/living/carbon/user, var/from_slot = null)
 	if(from_slot == slot_glasses)
 		if(on)
-			remove_overdark(user)
 			if (user.client)
 				user.client.color = null
 				user.update_perception()
 	..()
-
-/obj/item/clothing/glasses/scanner/night/proc/add_overdark(var/mob/living/carbon/C)
-	if (istype(C) && C.client)
-		C.client.screen |= overdark_planemaster
-		C.client.screen |= overdark_target
-
-/obj/item/clothing/glasses/scanner/night/proc/remove_overdark(var/mob/living/carbon/C)
-	if (istype(C) && C.client)
-		C.client.screen -= overdark_planemaster
-		C.client.screen -= overdark_target
 
 var/list/meson_wearers = list()
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -87,21 +87,9 @@
 	var/a_53 = 0
 	var/a_54 = 0
 
-	var/obj/abstract/screen/plane_master/overdark_planemaster/overdark_planemaster
-	var/obj/abstract/screen/plane_master/overdark_planemaster_target/overdark_target
-
-/mob/living/simple_animal/hostile/giant_spider/New()
-	..()
-	overdark_planemaster = new
-	overdark_planemaster.render_target = "night vision goggles (\ref[src])"
-	overdark_target = new
-	overdark_target.render_source = "night vision goggles (\ref[src])"
-
 /mob/living/simple_animal/hostile/giant_spider/Login()
 	..()
 	//client.images += light_source_images
-	client.screen |= overdark_planemaster
-	client.screen |= overdark_target
 
 
 /mob/living/simple_animal/hostile/giant_spider/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)

--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -58,9 +58,6 @@
 	stop_automated_movement = TRUE //has custom light-related wander movement
 	wander = FALSE
 
-	var/obj/abstract/screen/plane_master/overdark_planemaster/overdark_planemaster
-	var/obj/abstract/screen/plane_master/overdark_planemaster_target/overdark_target
-
 /datum/grue_calc //used for light-related calculations
 	var/bright_limit_gain = 1											//maximum brightness on tile for health and power regen
 	var/bright_limit_drain = 3											//maximum brightness on tile to not drain health and power
@@ -270,16 +267,9 @@
 	init_language = default_language
 	lifestage_updates() //update the grue's sprite and stats according to the current lifestage
 
-	overdark_planemaster = new
-	overdark_planemaster.render_target = "night vision goggles (\ref[src])"
-	overdark_target = new
-	overdark_target.render_source = "night vision goggles (\ref[src])"
-
 /mob/living/simple_animal/hostile/grue/Login()
 	..()
 	//client.images += light_source_images
-	client.screen |= overdark_planemaster
-	client.screen |= overdark_target
 
 /mob/living/simple_animal/hostile/grue/UnarmedAttack(atom/A)
 	if(isturf(A))

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -68,6 +68,8 @@
 	client.screen += catcher //Catcher of clicks
 	client.screen += clickmaster // click catcher planesmaster on plane 0 with mouse opacity 0 - allows click catcher to work with SEE_BLACKNESS
 	client.screen += clickmaster_dummy // honestly fuck you lummox
+	client.screen += overdark_planemaster
+	client.screen += overdark_planemaster_target
 	client.initialize_ghost_planemaster() //We want to explicitly reset the planemaster's visibility on login() so if you toggle ghosts while dead you can still see cultghosts if revived etc.
 	client.initialize_darkness_planemaster()
 	client.initialize_fakecamera_planemaster()


### PR DESCRIPTION
This overdark thing is something I came up with and Deity implemented to solve a problem with his NVG rework. I also realized at the time that it should probably just be universal rather than only used with NVGs, but we didn't make it universal back then. Now it is. This fixes two main issues:
1. Your own body flickering on and off while walking through darkness while wearing sunglasses
2. Large sprites overlapping with total darkness/obscured turfs rendering above said darkness/turfs

Both of the above were introduced along with MultiZ, due to the requirement to move world object planes above 0 for `FLOAT_PLANE` reasons.

This also properly fixes an issue partially fixed in #33052 with the overdark thing that made certain objects render incorrectly. This was because they were on plane 0, so this moves everything off plane 0.
In doing so, I found a bug where floors were on different planes when mapped vs. when built by applying floor tiles to plating, so I fixed that by just deleting the `FLOOR_PLANE` value used in exactly two places and switching them to `TURF_PLANE` where they were when built and where everything assumed they always were. This might fix some visual piping bugs or something.