### PR TITLE
Malf Overloaded Machines print a chat message before exploding agian.

### DIFF
--- a/code/datums/gamemode/role/malf/hackabilities.dm
+++ b/code/datums/gamemode/role/malf/hackabilities.dm
@@ -255,6 +255,7 @@
 /datum/malfhack_ability/oneuse/overload_quiet/activate(var/mob/living/silicon/A)
 	if(!..())
 		return
+	machine.visible_message("<span class='warning'>You hear a [pick("loud", "violent", "unsettling")], [pick("electrical","mechanical")] [pick("buzzing","rumbling","shaking")] sound!</span>")
 	playsound(machine, 'sound/effects/electricity_short_disruption.ogg', 80)
 	spawn(4 SECONDS)
 		if(machine)

--- a/code/datums/gamemode/role/malf/hackabilities.dm
+++ b/code/datums/gamemode/role/malf/hackabilities.dm
@@ -233,7 +233,7 @@
 /datum/malfhack_ability/oneuse/overload_loud/activate(var/mob/living/silicon/A)
 	if(!..())
 		return
-	machine.visible_message("<span class='warning'>You hear a [pick("loud", "violent", "unsettling")], [pick("electrical","mechanical")] [pick("buzzing","rumbling","shaking")] sound!</span>") //highlight this, motherfucker
+	machine.visible_message("<span class='warning'>[machine] makes a [pick("loud", "violent", "unsettling")], [pick("electrical","mechanical")] [pick("buzzing","rumbling","shaking")] sound!</span>") //highlight this, motherfucker
 	if(istype(machine, /obj/machinery/turret))
 		var/obj/machinery/turret/T = machine
 		if(T.cover)
@@ -255,7 +255,7 @@
 /datum/malfhack_ability/oneuse/overload_quiet/activate(var/mob/living/silicon/A)
 	if(!..())
 		return
-	machine.visible_message("<span class='warning'>You hear a [pick("loud", "violent", "unsettling")], [pick("electrical","mechanical")] [pick("buzzing","rumbling","shaking")] sound!</span>")
+	machine.visible_message("<span class='warning'>[machine] makes a [pick("loud", "violent", "unsettling")], [pick("electrical","mechanical")] [pick("buzzing","rumbling","shaking")] sound!</span>")
 	playsound(machine, 'sound/effects/electricity_short_disruption.ogg', 80)
 	spawn(4 SECONDS)
 		if(machine)


### PR DESCRIPTION
in addition to playing noise

## What this does
title

## Why it's good
Allows people to react to machine overloads.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Malf overloads print a message to the chat before exploding again.
