### PR TITLE
Reverts Malf AIs increasing their APC hack limit for every 5 APCs they own

### DIFF
--- a/code/datums/gamemode/role/malf/malf_apcs.dm
+++ b/code/datums/gamemode/role/malf/malf_apcs.dm
@@ -54,15 +54,6 @@
 	malfai = malf
 	M.apcs += src
 	to_chat(malf, "<span class='notice'>APC Hack Complete. The [name] is now under your exclusive control. You now have [M.apcs.len] APCs under your control.</span>")
-	var/total_APC = 0
-	for(var/obj/machinery/power/apc/A in M.apcs)
-		total_APC++
-	/*
-	if(total_APC % 5 == 0 && !(total_APC in M.apc_checkpoints)) //Every 5 APCs hacked, increases the limit of APCs that can be hacked by 1
-		M.apc_hacklimit++
-		to_chat(malf, "<span class='good'>You may now hack an additional APC at a time, up to [M.apc_hacklimit].</span>")
-		M.apc_checkpoints += total_APC //Remembers that this many APCs were hacked to avoid exploits
-	*/
 	malf.handle_regular_hud_updates()
 	malfimage = new /atom/movable/fake_camera_image(loc)
 	malfimage.pixel_y = pixel_y

--- a/code/datums/gamemode/role/malf/malf_apcs.dm
+++ b/code/datums/gamemode/role/malf/malf_apcs.dm
@@ -57,10 +57,12 @@
 	var/total_APC = 0
 	for(var/obj/machinery/power/apc/A in M.apcs)
 		total_APC++
+	/*
 	if(total_APC % 5 == 0 && !(total_APC in M.apc_checkpoints)) //Every 5 APCs hacked, increases the limit of APCs that can be hacked by 1
 		M.apc_hacklimit++
 		to_chat(malf, "<span class='good'>You may now hack an additional APC at a time, up to [M.apc_hacklimit].</span>")
 		M.apc_checkpoints += total_APC //Remembers that this many APCs were hacked to avoid exploits
+	*/
 	malf.handle_regular_hud_updates()
 	malfimage = new /atom/movable/fake_camera_image(loc)
 	malfimage.pixel_y = pixel_y


### PR DESCRIPTION

## What this does
A long time ago #27669 was merged and let malf AIs end the round in about 20 minutes.
That PR was reverted, but not too long ago #32937 was merged, causing almost the same exact issue.
This PR reverts #32937. APCs take 60 seconds to hack and you cannot hack more than one at a time.

## Why it's good
TLDR: it's too powerful

Increasing the APC limit as you hack more lets malf AIs easily snowball out of control and hack insane numbers of APCs. Don't forget that every time the hack limit is increased, it takes less and less time to reach the next limit increase.
This is made worse by some of the changes to nu-malf, like the fact that APCs generate ability power and increase let the AI hack more non-APCs simultaneously. 


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Malf AIs will no longer be able to hack more APCs simultaneously for every 5 APCs they own.

