### PR TITLE
Chameleon clothes can no longer turn into clothing items that have no icons, fixes washing machines

### DIFF
--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -127,16 +127,21 @@
 			color = ST._color
 
 		if(color)
+			var/new_jumpsuit_icon = ""
 			var/new_jumpsuit_icon_state = ""
 			var/new_jumpsuit_item_state = ""
 			var/new_jumpsuit_name = ""
+			var/new_glove_icon = ""
 			var/new_glove_icon_state = ""
 			var/new_glove_item_state = ""
 			var/new_glove_name = ""
+			var/new_shoe_icon = ""
 			var/new_shoe_icon_state = ""
 			var/new_shoe_name = ""
+			var/new_sheet_icon = ""
 			var/new_sheet_icon_state = ""
 			var/new_sheet_name = ""
+			var/new_softcap_icon = ""
 			var/new_softcap_icon_state = ""
 			var/new_softcap_name = ""
 			var/ccoil_test = null
@@ -144,6 +149,7 @@
 			for(var/T in typesof(/obj/item/clothing/under))
 				var/obj/item/clothing/under/J = new T
 				if(color == J._color)
+					new_jumpsuit_icon = J.icon //Fixes a bug where assistant suits (which have their own icon file) would make invisible suits
 					new_jumpsuit_icon_state = J.icon_state
 					new_jumpsuit_item_state = J.item_state
 					new_jumpsuit_name = J.name
@@ -155,6 +161,7 @@
 			for(var/T in typesof(/obj/item/clothing/gloves))
 				var/obj/item/clothing/gloves/G = new T
 				if(color == G._color)
+					new_glove_icon = G.icon
 					new_glove_icon_state = G.icon_state
 					new_glove_item_state = G.item_state
 					new_glove_name = G.name
@@ -166,6 +173,7 @@
 			for(var/T in typesof(/obj/item/clothing/shoes))
 				var/obj/item/clothing/shoes/S = new T
 				if(color == S._color)
+					new_shoe_icon = S.icon
 					new_shoe_icon_state = S.icon_state
 					new_shoe_name = S.name
 					qdel(S)
@@ -176,6 +184,7 @@
 			for(var/T in typesof(/obj/item/weapon/bedsheet))
 				var/obj/item/weapon/bedsheet/B = new T
 				if(color == B._color)
+					new_sheet_icon = B.icon
 					new_sheet_icon_state = B.icon_state
 					new_sheet_name = B.name
 					qdel(B)
@@ -186,6 +195,7 @@
 			for(var/T in typesof(/obj/item/clothing/head/soft))
 				var/obj/item/clothing/head/soft/H = new T
 				if(color == H._color)
+					new_softcap_icon = H.icon
 					new_softcap_icon_state = H.icon_state
 					new_softcap_name = H.name
 					qdel(H)
@@ -204,6 +214,7 @@
 				test = null
 			if(new_jumpsuit_icon_state && new_jumpsuit_name)
 				for(var/obj/item/clothing/under/J in contents)
+					J.icon = new_jumpsuit_icon
 					J.item_state = new_jumpsuit_item_state
 					J.icon_state = new_jumpsuit_icon_state
 					J._color = color
@@ -211,6 +222,7 @@
 					J.desc = new_desc
 			if(new_glove_icon_state && new_glove_name)
 				for(var/obj/item/clothing/gloves/G in contents)
+					G.icon = new_glove_icon
 					G.item_state = new_glove_item_state
 					G.icon_state = new_glove_icon_state
 					G._color = color
@@ -224,18 +236,21 @@
 						S.chain.forceMove(src)
 						S.chain = null
 						S.slowdown = NO_SLOWDOWN
+					S.icon = new_shoe_icon
 					S.icon_state = new_shoe_icon_state
 					S._color = color
 					S.name = new_shoe_name
 					S.desc = new_desc
 			if(new_sheet_icon_state && new_sheet_name)
 				for(var/obj/item/weapon/bedsheet/B in contents)
+					B.icon = new_sheet_icon
 					B.icon_state = new_sheet_icon_state
 					B._color = color
 					B.name = new_sheet_name
 					B.desc = new_desc
 			if(new_softcap_icon_state && new_softcap_name)
 				for(var/obj/item/clothing/head/soft/H in contents)
+					H.icon = new_softcap_icon
 					H.icon_state = new_softcap_icon_state
 					H._color = color
 					H.name = new_softcap_name

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -26,7 +26,9 @@
 	..()
 	verbs += /obj/item/clothing/shoes/syndigaloshes/verb/change_appearance_shoes
 	for(var/Type in typesof(/obj/item/clothing/shoes) - list(/obj/item/clothing/shoes, /obj/item/clothing/shoes/syndigaloshes))
-		clothing_choices += new Type
+		var/obj/item/clothing/shoes/S = new Type
+		if(S.icon_state)
+			clothing_choices += S
 	return
 
 /*	// the above 5 lines invalidate any purpose this block once had

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -25,10 +25,8 @@
 /obj/item/clothing/shoes/syndigaloshes/New()
 	..()
 	verbs += /obj/item/clothing/shoes/syndigaloshes/verb/change_appearance_shoes
-	for(var/Type in typesof(/obj/item/clothing/shoes) - list(/obj/item/clothing/shoes, /obj/item/clothing/shoes/syndigaloshes))
-		var/obj/item/clothing/shoes/S = new Type
-		if(S.icon_state)
-			clothing_choices += S
+	for(var/Type in existing_typesof(/obj/item/clothing/shoes) - (/obj/item/clothing/shoes/syndigaloshes))
+		clothing_choices += new Type
 	return
 
 /*	// the above 5 lines invalidate any purpose this block once had

--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -14,15 +14,11 @@
 /obj/item/clothing/under/chameleon/New()
 	..()
 	verbs += /obj/item/clothing/under/chameleon/proc/Change_Color
-	for(var/U in typesof(/obj/item/clothing/under/color)-(/obj/item/clothing/under/color))
-		var/obj/item/clothing/under/V = new U
-		if(V.icon_state)
-			clothing_choices += V
+	for(var/U in existing_typesof(/obj/item/clothing/under/color)-(/obj/item/clothing/under/color))
+		clothing_choices += new U
 
-	for(var/U in typesof(/obj/item/clothing/under/rank)-(/obj/item/clothing/under/rank))
-		var/obj/item/clothing/under/V = new U
-		if(V.icon_state)
-			clothing_choices += V
+	for(var/U in existing_typesof(/obj/item/clothing/under/rank)-(/obj/item/clothing/under/rank))
+		clothing_choices += new U
 	return
 
 
@@ -76,7 +72,7 @@
 	..()
 	var/blocked = list(/obj/item/clothing/under/chameleon, /obj/item/clothing/under/chameleon/all, /obj/item/clothing/under)
 	//to prevent an infinite loop
-	for(var/U in typesof(/obj/item/clothing/under)-blocked)
+	for(var/U in existing_typesof(/obj/item/clothing/under)-blocked)
 		var/obj/item/clothing/under/V = new U
 		clothing_choices += V
 

--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -16,11 +16,13 @@
 	verbs += /obj/item/clothing/under/chameleon/proc/Change_Color
 	for(var/U in typesof(/obj/item/clothing/under/color)-(/obj/item/clothing/under/color))
 		var/obj/item/clothing/under/V = new U
-		clothing_choices += V
+		if(V.icon_state)
+			clothing_choices += V
 
 	for(var/U in typesof(/obj/item/clothing/under/rank)-(/obj/item/clothing/under/rank))
 		var/obj/item/clothing/under/V = new U
-		clothing_choices += V
+		if(V.icon_state)
+			clothing_choices += V
 	return
 
 

--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -14,10 +14,10 @@
 /obj/item/clothing/under/chameleon/New()
 	..()
 	verbs += /obj/item/clothing/under/chameleon/proc/Change_Color
-	for(var/U in existing_typesof(/obj/item/clothing/under/color)-(/obj/item/clothing/under/color))
+	for(var/U in existing_typesof(/obj/item/clothing/under/color))
 		clothing_choices += new U
 
-	for(var/U in existing_typesof(/obj/item/clothing/under/rank)-(/obj/item/clothing/under/rank))
+	for(var/U in existing_typesof(/obj/item/clothing/under/rank))
 		clothing_choices += new U
 	return
 
@@ -70,11 +70,10 @@
 
 /obj/item/clothing/under/chameleon/all/New()
 	..()
-	var/blocked = list(/obj/item/clothing/under/chameleon, /obj/item/clothing/under/chameleon/all, /obj/item/clothing/under)
+	var/blocked = list(/obj/item/clothing/under/chameleon, /obj/item/clothing/under/chameleon/all)
 	//to prevent an infinite loop
 	for(var/U in existing_typesof(/obj/item/clothing/under)-blocked)
-		var/obj/item/clothing/under/V = new U
-		clothing_choices += V
+		clothing_choices += U
 
 /obj/item/clothing/under/chameleon/cold
 	heat_conductivity = 1000


### PR DESCRIPTION
:cl:
 * bugfix: Chameleon clothes (the jumpsuit and no-slip shoes) can no longer turn into clothing items that have no icons.
 * bugfix: Assistant jumpsuits will no longer turn into invisible clothes when re-colored into a washing machine with a stamp. This was due to a bug caused by the assistant jumpsuit having its own icon file compared to other jumpsuits.