### PR TITLE
Building and upgrading artifact scanners and harvesters

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -1421,6 +1421,24 @@ to destroy them and players will be able to make replacements.
 	desc = "A circuit board used to run a machine used in xenoarcheology."
 	build_path = /obj/machinery/anomaly/hyperspectral
 
+/obj/item/weapon/circuitboard/anom/analyser
+	name = "Circuit Board (Anomaly Analyzer)"
+	desc = "A circuit board used to run a machine used in xenoarcheology."
+	build_path = /obj/machinery/artifact_analyser
+
+/obj/item/weapon/circuitboard/anom/analyser/scanpad
+	name = "Circuit Board (Anomaly Scanner Pad)"
+	desc = "A circuit board used to run a machine used in xenoarcheology."
+	build_path = /obj/machinery/artifact_scanpad
+
+/obj/item/weapon/circuitboard/anom/harvester
+	name = "Circuit Board (Exotic Particle Harvester)"
+	desc = "A circuit board used to run a machine used in xenoarcheology."
+	build_path = /obj/machinery/artifact_harvester
+	req_components = list (
+							/obj/item/weapon/stock_parts/scanning_module = 1,
+							/obj/item/weapon/stock_parts/capacitor = 2)
+
 /obj/item/weapon/circuitboard/confectionator
 	name = "circuit board (confectionator)"
 	desc = "A circuit board used to run a kitchen appliance."

--- a/code/modules/research/designs/boards/machine_science.dm
+++ b/code/modules/research/designs/boards/machine_science.dm
@@ -103,6 +103,27 @@
 	id = "hyperspectral"
 	build_path = /obj/item/weapon/circuitboard/anom/hyper
 
+/datum/design/anom/analyser
+	name = "Circuit Design (Anomaly Analyzer)"
+	desc = "Allows for the construction of circuit boards used in Xenoarcheology."
+	id = "artifact"
+	req_tech = list(Tc_PROGRAMMING = 4)
+	build_path = /obj/item/weapon/circuitboard/anom/analyser
+
+/datum/design/anom/scanpad
+	name = "Circuit Design (Anomaly Scanner Pad)"
+	desc = "Allows for the construction of circuit boards used in Xenoarcheology."
+	id = "scanner"
+	req_tech = list(Tc_PROGRAMMING = 4)
+	build_path = /obj/item/weapon/circuitboard/anom/analyser/scanpad
+
+/datum/design/anom/harvester
+	name = "Circuit Design (Exotic Particle Harvester)"
+	desc = "Allows for the construction of circuit boards used in Xenoarcheology."
+	id = "harvester"
+	req_tech = list(Tc_PROGRAMMING = 4, Tc_ANOMALY = 4)
+	build_path = /obj/item/weapon/circuitboard/anom/harvester
+
 /datum/design/suspensionfieldgen
 	name = "Circuit Design (Suspension Field Generator)"
 	desc = "The circuit board for a suspension field generator."

--- a/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
+++ b/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
@@ -17,6 +17,7 @@ var/anomaly_report_num = 0
 	icon_state = "xenoarch_console"
 	anchored = TRUE
 	density = TRUE
+	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK
 	var/scan_in_progress = FALSE
 	var/scan_num = 0
 	var/obj/machinery/artifact_scanpad/owned_scanner = null
@@ -28,6 +29,22 @@ var/anomaly_report_num = 0
 	..()
 	reconnect_scanner()
 	update_icon()
+
+	component_parts = newlist(
+		/obj/item/weapon/circuitboard/anom/analyser,
+		/obj/item/weapon/stock_parts/scanning_module,
+		/obj/item/weapon/stock_parts/scanning_module,
+		/obj/item/weapon/stock_parts/scanning_module
+	)
+
+	RefreshParts()
+
+/obj/machinery/artifact_analyser/RefreshParts()
+	var/scancount = 0
+	for(var/obj/item/weapon/stock_parts/scanning_module/SP in component_parts)
+		scancount += SP.rating-1
+
+	scan_duration = initial(scan_duration) - scancount*10
 
 /obj/machinery/artifact_harvester/Destroy()
 	if (owned_scanner)

--- a/code/modules/research/xenoarchaeology/machinery/artifact_harvester.dm
+++ b/code/modules/research/xenoarchaeology/machinery/artifact_harvester.dm
@@ -9,6 +9,7 @@
 	idle_power_usage = 50
 	active_power_usage = 750
 	use_power = MACHINE_POWER_USE_IDLE
+	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK
 	var/harvesting = 0
 	var/obj/item/weapon/anobattery/inserted_battery
 	var/obj/machinery/artifact/cur_artifact
@@ -16,6 +17,7 @@
 	var/datum/artifact_effect/isolated_secondary
 	var/obj/machinery/artifact_scanpad/owned_scanner = null
 	var/chargerate = 0
+	var/chargemult = 1
 	var/harvester = "" // Logs who started a harvest.
 	var/obj/effect/artifact_field/artifact_field
 	light_color = "#E1C400"
@@ -24,6 +26,24 @@
 /obj/machinery/artifact_harvester/New()
 	..()
 	reconnect_scanner()
+	component_parts = newlist(
+		/obj/item/weapon/circuitboard/anom/harvester,
+		/obj/item/weapon/stock_parts/scanning_module,
+		/obj/item/weapon/stock_parts/capacitor,
+		/obj/item/weapon/stock_parts/capacitor
+	)
+
+	RefreshParts()
+
+/obj/machinery/artifact_harvester/RefreshParts()
+	var/scancount = 0
+	var/scanamount = 0
+	for(var/obj/item/weapon/stock_parts/SP in component_parts)
+		scancount += SP.rating
+		scanamount++
+
+	chargemult = scancount/scanamount
+
 
 /obj/machinery/artifact_harvester/Destroy()
 	if (inserted_battery)
@@ -194,7 +214,7 @@
 				if(inserted_battery.battery_effect)
 					matching_effecttype = (inserted_battery.battery_effect.type == isolated_primary.type)
 				if(!inserted_battery.battery_effect || (matching_id && matching_effecttype))
-					chargerate = isolated_primary.chargelevelmax / isolated_primary.effectrange
+					chargerate = (isolated_primary.chargelevelmax / isolated_primary.effectrange) * chargemult
 					harvesting = 1
 					use_power = MACHINE_POWER_USE_ACTIVE
 					update_icon()
@@ -243,7 +263,7 @@
 				if(inserted_battery.battery_effect)
 					matching_effecttype = (inserted_battery.battery_effect.type == isolated_secondary.type)
 				if(!inserted_battery.battery_effect || (matching_id && matching_effecttype))
-					chargerate = isolated_secondary.chargelevelmax / isolated_secondary.effectrange
+					chargerate = (isolated_secondary.chargelevelmax / isolated_secondary.effectrange) * chargemult
 					harvesting = 1
 					use_power = MACHINE_POWER_USE_ACTIVE
 					update_icon()

--- a/code/modules/research/xenoarchaeology/machinery/artifact_scanner.dm
+++ b/code/modules/research/xenoarchaeology/machinery/artifact_scanner.dm
@@ -7,18 +7,27 @@
 	anchored = TRUE
 	density = FALSE
 	plane = ABOVE_OBJ_PLANE
+	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK
 	var/obj/machinery/artifact_analyser/analyser_console = null
 	var/obj/machinery/artifact_harvester/harvester_console = null
 
 /obj/machinery/artifact_scanpad/New()
 	..()
 	update_icon()
+	component_parts = newlist(
+		/obj/item/weapon/circuitboard/anom/analyser/scanpad,
+		/obj/item/weapon/stock_parts/scanning_module,
+		/obj/item/weapon/stock_parts/scanning_module,
+		/obj/item/weapon/stock_parts/scanning_module
+	)
 
 /obj/machinery/artifact_scanpad/Destroy()
-	analyser_console.owned_scanner = null
-	analyser_console = null
-	harvester_console.owned_scanner = null
-	harvester_console = null
+	if(analyser_console)
+		analyser_console.owned_scanner = null
+		analyser_console = null
+	if(harvester_console)
+		harvester_console.owned_scanner = null
+		harvester_console = null
 	..()
 
 /obj/machinery/artifact_scanpad/power_change()


### PR DESCRIPTION
[content][tested]

## What this does
allows anomaly analyzers, scanpads and harvesters to be built from circuitboards and deconstructed down to them. first 2 require three scanning modules, last one requires one scanning module and two capacitors. all cirtcuitboards require data 4 to build in circuit imprinters, except harvesters which also require anomaly 4. (to match their batteries)
gives them upgrades that increase the speed of scanning (analysers) and harvesting. (harvesters)
former reduces seconds by 1 per level of scanning module, latter increases charge multiplication by 1/3rd for each stock part level.

## Why it's good
R&D should really be able to replace their own machines.

## Changelog
:cl:
 * rscadd: Anomaly scanners, scanpads and harvesters can now be built, deconstructed and upgraded. Upgrades increase scanning speed and battery harvesting speed.
 * bugfix: Scanpads now delete themselves properly if their associated device goes missing.