### PR TITLE
Allow RPED to upgrade APC power cells.

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -22,6 +22,7 @@
 	var/electronics_damage = 0 //Used by cyborgs
 	var/starch_cell = 0
 	var/mob/living/simple_animal/hostile/pulse_demon/occupant
+	var/rating = 4
 
 /obj/item/weapon/cell/suicide_act(var/mob/living/user)
 	to_chat(viewers(user), "<span class='danger'>[user] is licking the electrodes of the [src.name]! It looks like \he's trying to commit suicide.</span>")
@@ -38,6 +39,7 @@
 	origin_tech = Tc_POWERSTORAGE + "=0"
 	maxcharge = 500
 	starting_materials = list(MAT_IRON = 700, MAT_GLASS = 40)
+	rating = 1
 
 /obj/item/weapon/cell/crap/empty/New()
 	..()
@@ -46,16 +48,19 @@
 /obj/item/weapon/cell/crap/better
 	name = "\improper Nanotrasen brand rechargeable D battery"
 	maxcharge = 700 //for the ion carbine
+	rating = 3
 
 /obj/item/weapon/cell/crap/worse
 	name = "\improper Nanotrasen brand rechargeable AAA battery"
 	maxcharge = 250
+	rating = 0
 
 /obj/item/weapon/cell/secborg
 	name = "\improper Security borg rechargeable D battery"
 	origin_tech = Tc_POWERSTORAGE + "=0"
 	maxcharge = 600	//600 max charge / 100 charge per shot = six shots
 	starting_materials = list(MAT_IRON = 700, MAT_GLASS = 40)
+	rating = 2
 
 
 /obj/item/weapon/cell/secborg/empty/New()
@@ -67,6 +72,7 @@
 	origin_tech = Tc_POWERSTORAGE + "=0"
 	maxcharge = 600	//600 max charge / 100 charge per shot = six shots
 	starting_materials = list(MAT_IRON = 700, MAT_GLASS = 40)
+	rating = 2
 
 
 /obj/item/weapon/cell/miningborg/empty/New()
@@ -80,14 +86,17 @@
 	icon_state = "hcell"
 	maxcharge = 10000
 	starting_materials = list(MAT_IRON = 700, MAT_GLASS = 60)
+	rating = 6
 
 /obj/item/weapon/cell/high/cyborg
 	name = "cyborg rechargeable power cell"
 	maxcharge = 7500
+	rating = 5
 
 /obj/item/weapon/cell/high/mecha
 	name = "custom high-capacity power cell"
 	maxcharge = 15000
+	rating = 9
 
 /obj/item/weapon/cell/high/empty/New()
 	..()
@@ -99,6 +108,7 @@
 	icon_state = "scell"
 	maxcharge = 20000
 	starting_materials = list(MAT_IRON = 700, MAT_GLASS = 70)
+	rating = 10
 
 /obj/item/weapon/cell/super/empty/New()
 	..()
@@ -110,6 +120,7 @@
 	icon_state = "hpcell"
 	maxcharge = 30000
 	starting_materials = list(MAT_IRON = 700, MAT_GLASS = 80)
+	rating = 11
 
 /obj/item/weapon/cell/hyper/empty/New()
 	..()
@@ -127,11 +138,13 @@
 	w_type = RECYK_BIOLOGICAL
 	minor_fault = 1
 	starch_cell = 1
+	rating = 0
 
 /obj/item/weapon/cell/potato/soviet
 	charge = 15000
 	maxcharge = 15000
 	minor_fault = 0
+	rating = 7
 
 /obj/item/weapon/cell/crepe
 	name = "power crêpe"
@@ -143,11 +156,13 @@
 	w_type = RECYK_BIOLOGICAL
 	minor_fault = 1
 	starch_cell = 1
+	rating = 8
 
 /obj/item/weapon/cell/crepe/mommi
 	maxcharge = 10000
 	charge = 10000
 	minor_fault = 0
+	rating = 6
 
 /obj/item/weapon/cell/crepe/attack_self(var/mob/living/user)
 	if(charge)
@@ -174,6 +189,7 @@
 	maxcharge = 30000
 	starting_materials =  null
 	w_type = RECYK_BIOLOGICAL
+	rating = 11
 
 
 /obj/item/weapon/cell/temperaturegun
@@ -181,6 +197,7 @@
 	desc = "A specially designed power cell for heating and cooling projectiles."
 	icon_state = "icell"
 	maxcharge = 900
+	rating = 3
 
 /obj/item/weapon/cell/send_to_past(var/duration)
 	..()
@@ -200,6 +217,7 @@
 	origin_tech = null
 	maxcharge = 35000
 	starting_materials = list(MAT_IRON = 700, MAT_GLASS = 80)
+	rating = 15
 
 /obj/item/weapon/cell/infinite/New()
 	..()
@@ -216,6 +234,7 @@
 	icon_state = "ucell"
 	maxcharge = 50000
 	starting_materials = list(MAT_IRON = 700, MAT_GLASS = 80)
+	rating = 12
 
 /obj/item/weapon/cell/ultra/empty/New()
 	..()
@@ -229,6 +248,7 @@
 	starting_materials = list(MAT_IRON = 600, MAT_GLASS = 90, MAT_URANIUM = 40)
 	var/charge_rate = 100
 	var/damaged = FALSE
+	rating = 13
 
 /obj/item/weapon/cell/rad/empty/New()
 	..()
@@ -308,6 +328,7 @@
 	maxcharge = 2500
 	starting_materials = list(MAT_IRON = 600, MAT_GLASS = 90, MAT_PHAZON = 100)
 	charge_rate = 250
+	rating = 14
 
 /obj/item/weapon/cell/rad/large/empty/New()
 	..()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -666,7 +666,7 @@
 	if (W.bluespace || wiresexposed || opened)
 		var/obj/item/weapon/cell/max_cell
 		for(var/obj/item/weapon/cell/component in W.contents)
-			if (!max_cell || max_cell.rating < component.rating)
+			if (!max_cell || (max_cell.rating < component.rating))
 				max_cell = component
 
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -633,6 +633,8 @@
 	else if(istype(W, /obj/item/weapon/kitchen/utensil/fork) && opened) // Sticking fork in open APC shocks you
 		to_chat(user, "<span class='warning'>That was really, really dumb of you.</span>") // Why would you even do this
 		shock(user, 75, W.siemens_coefficient)
+	else if (istype(W, /obj/item/weapon/storage/bag/gadgets/part_replacer))
+		exchange_parts(user, W)
 	else
 		// The extra crowbar thing fixes MoMMIs not being able to remove APCs.
 		// They can just pop them off with a crowbar.
@@ -659,6 +661,23 @@
 				"<span class='warning'>You hit the [src.name] with your [W.name]!</span>", \
 				"You hear bang")*/
 			..() //Sanity
+
+/obj/machinery/power/apc/exchange_parts(mob/user, obj/item/weapon/storage/bag/gadgets/part_replacer/W)
+	var/obj/item/weapon/cell/max_cell
+	for(var/obj/item/weapon/cell/component in W.contents)
+		if (!max_cell || max_cell.maxcharge < component.maxcharge)
+			max_cell = component
+
+	if (max_cell && max_cell.maxcharge > cell.maxcharge)
+		W.remove_from_storage(max_cell, src)
+		W.handle_item_insertion(cell, 1)
+		to_chat(user, "<span class='notice'>[cell.name] replaced with [max_cell.name].</span>")
+		cell = max_cell
+		cell_type = max_cell.maxcharge
+		max_cell.forceMove(null)
+		W.play_rped_sound()
+	else
+		to_chat(user, "<span class='notice'>No power cell of higher grade detected.</span>")
 
 // attack with hand - remove cell (if cover open) or interact with the APC
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -663,21 +663,23 @@
 			..() //Sanity
 
 /obj/machinery/power/apc/exchange_parts(mob/user, obj/item/weapon/storage/bag/gadgets/part_replacer/W)
-	var/obj/item/weapon/cell/max_cell
-	for(var/obj/item/weapon/cell/component in W.contents)
-		if (!max_cell || max_cell.maxcharge < component.maxcharge)
-			max_cell = component
+	if (W.bluespace || wiresexposed || opened)
+		var/obj/item/weapon/cell/max_cell
+		for(var/obj/item/weapon/cell/component in W.contents)
+			if (!max_cell || max_cell.rating < component.rating)
+				max_cell = component
 
-	if (max_cell && max_cell.maxcharge > cell.maxcharge)
-		W.remove_from_storage(max_cell, src)
-		W.handle_item_insertion(cell, 1)
-		to_chat(user, "<span class='notice'>[cell.name] replaced with [max_cell.name].</span>")
-		cell = max_cell
-		cell_type = max_cell.maxcharge
-		max_cell.forceMove(null)
-		W.play_rped_sound()
-	else
-		to_chat(user, "<span class='notice'>No power cell of higher grade detected.</span>")
+
+		if (max_cell && max_cell.rating > cell.rating)
+			W.remove_from_storage(max_cell, src)
+			W.handle_item_insertion(cell, 1)
+			to_chat(user, "<span class='notice'>[cell.name] replaced with [max_cell.name].</span>")
+			cell = max_cell
+			cell_type = max_cell.maxcharge
+			max_cell.forceMove(null)
+			W.play_rped_sound()
+		else
+			to_chat(user, "<span class='notice'>No power cell of higher grade detected.</span>")
 
 // attack with hand - remove cell (if cover open) or interact with the APC
 


### PR DESCRIPTION
closes #33804

## What this does
Allows RPEDs to be used on APCs, swapping out the APC power cell for the highest grade power cell in the RPED.

## Why it's good
Makes upgrading the station's APCs a much more streamlined process.

## Changelog
:cl:
 * rscadd: RPEDs can now be used to upgrade APCs.