### PR TITLE
Deathsquad changes

### DIFF
--- a/code/datums/outfit/striketeams/nt_deathsquad.dm
+++ b/code/datums/outfit/striketeams/nt_deathsquad.dm
@@ -12,8 +12,8 @@
 			slot_w_uniform_str = /obj/item/clothing/under/deathsquad,
 			slot_shoes_str = /obj/item/clothing/shoes/magboots/deathsquad,
 			slot_gloves_str = /obj/item/clothing/gloves/combat,
-			slot_glasses_str = /obj/item/clothing/glasses/thermal,
-			slot_wear_mask_str = /obj/item/clothing/mask/gas/swat,
+			slot_glasses_str = /obj/item/clothing/glasses/thermal/deathsquad,
+			slot_wear_mask_str = /obj/item/clothing/mask/gas/hecu/deathsquad,
 			slot_wear_suit_str = /obj/item/clothing/suit/space/rig/deathsquad,
 			slot_s_store_str = /obj/item/weapon/tank/emergency_oxygen/double,
 			slot_belt_str = /obj/item/weapon/gun/energy/pulse_rifle,
@@ -39,8 +39,8 @@
 
 	id_type = /obj/item/weapon/card/id/death_commando
 	id_type_leader = /obj/item/weapon/card/id/death_commando_leader
-	assignment_leader = "Death Commando"
-	assignment_member = "Death Commander"
+	assignment_leader = "Death Commander"
+	assignment_member = "Death Commando"
 
 /datum/outfit/striketeam/nt_deathsquad/pre_equip(var/mob/living/carbon/human/H)
 	if (is_leader)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -238,6 +238,10 @@
 	freerange = 1
 	init_keyslot2_type = /obj/item/device/encryptionkey/deathsquad
 
+/obj/item/device/radio/headset/deathsquad/initialize()
+	. = ..()
+	set_frequency(DEATHSQUAD_COMM)
+
 /obj/item/device/radio/headset/ert
 	name = "CentCom Response Team headset"
 	desc = "The headset of the boss's boss. Channels are as follows: ':-' - Response Team :c - command, :s - security, :e - engineering, :d - mining, :q - cargo, :m - medical, :n - science."

--- a/code/game/striketeams/nanotrasen_deathsquad.dm
+++ b/code/game/striketeams/nanotrasen_deathsquad.dm
@@ -17,7 +17,7 @@
 	var/commando_leader_rank = pick("Major", "Rescue Leader", "Commander")
 	var/commando_rank = pick("Corporal", "Sergeant", "Staff Sergeant", "Sergeant 1st Class", "Master Sergeant", "Sergeant Major")
 	var/commando_name = pick(last_names)
-	var/commando_leader_name = pick("Creed", "Dahl")
+	var/commando_leader_name = pick("Creed", "Dahl", "Shephard")
 
 	new_commando.gender = pick(MALE, FEMALE)
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -592,6 +592,18 @@ var/list/science_goggles_wearers = list()
 	item_state = "syringe_kit"
 	species_fit = list(VOX_SHAPED, GREY_SHAPED)
 
+/obj/item/clothing/glasses/thermal/deathsquad
+	name = "Deathsquad Thermal Glasses"
+	desc = "Featuring state-of-the-art combat technology, these thermals not only permit the user to see through walls but also automatically protect the user from blinding flashes of light and are immune to EMPs."
+	vision_flags = SEE_MOBS | SEE_TURFS | SEE_OBJS
+	seedarkness = TRUE
+	see_invisible = SEE_INVISIBLE_LIVING //So the darkness overlay gets rendered
+	eyeprot = 1
+	my_dark_plane_alpha_override_value = 100
+
+/obj/item/clothing/glasses/thermal/deathsquad/emp_act(severity)
+	return
+
 /obj/item/clothing/glasses/simonglasses
 	name = "Simon's Glasses"
 	desc = "Just who the hell do you think I am?"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -443,3 +443,7 @@
 	if(slot == slot_wear_mask)
 		on_face = 0
 	..()
+
+/obj/item/clothing/mask/gas/hecu/deathsquad
+	desc = "An ancient gas mask with the letters HECU stamped on the side. Its circuitry seems to have been upgraded, permitting constant voice modulation."
+	word_cost = 0

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -379,7 +379,7 @@
 /obj/item/clothing/mask/gas/hecu/examine(var/mob/user)
 	..()
 	to_chat(user, "<span class='notice'>Alt-Click the mask to see the list of available words.</span>")
-	to_chat(user, "<span class='notice'>Charge: [mask_charge]/[max_charge] </span>")
+	to_chat(user, "<span class='notice'>Charge: [word_cost ? "[mask_charge]/[max_charge]" : "ENDLESS"] </span>")
 
 /obj/item/clothing/mask/gas/hecu/AltClick(var/mob/user)
 	var/message = "Known words: "

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -172,12 +172,11 @@
 
 //Death squad
 /obj/item/clothing/shoes/magboots/deathsquad
-	desc = "Very expensive and advanced magnetic boots, these incorporate an extremely rare technology that essentially breaks down the extremely slippery space lube wherever the user treads, granting immunity to it."
+	desc = "Very expensive and advanced magnetic boots, used only by the elite during extravehicular activity to ensure the user remains safely attached to the vehicle."
 	name = "deathsquad magboots"
 	icon_state = "DS-magboots0"
 	base_state = "DS-magboots"
 	mag_slow = NO_SLOWDOWN
-	clothing_flags = IGNORE_LUBE //The pain is on
 
 //Syndicate
 /obj/item/clothing/shoes/magboots/syndie

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -172,11 +172,12 @@
 
 //Death squad
 /obj/item/clothing/shoes/magboots/deathsquad
-	desc = "Very expensive and advanced magnetic boots, used only by the elite during extravehicular activity to ensure the user remains safely attached to the vehicle."
+	desc = "Very expensive and advanced magnetic boots, these incorporate an extremely rare technology that essentially breaks down the extremely slippery space lube wherever the user treads, granting immunity to it."
 	name = "deathsquad magboots"
 	icon_state = "DS-magboots0"
 	base_state = "DS-magboots"
 	mag_slow = NO_SLOWDOWN
+	clothing_flags = IGNORE_LUBE //The pain is on
 
 //Syndicate
 /obj/item/clothing/shoes/magboots/syndie

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -6,7 +6,7 @@
 	force = 10
 	fire_sound = 'sound/weapons/pulse.ogg'
 	charge_cost = 200
-	projectile_type = "/obj/item/projectile/beam/pulse/deathsquad"
+	projectile_type = "/obj/item/projectile/beam/pulse"
 	cell_type = "/obj/item/weapon/cell/super"
 	var/mode = 2
 	fire_delay = 2
@@ -30,7 +30,7 @@
 			charge_cost = 200
 			fire_sound = 'sound/weapons/pulse.ogg'
 			to_chat(user, "<span class='warning'>\The [src] is now set to DESTROY.</span>")
-			projectile_type = "/obj/item/projectile/beam/pulse/deathsquad"
+			projectile_type = "/obj/item/projectile/beam/pulse"
 
 /obj/item/weapon/gun/energy/pulse_rifle/cyborg/process_chambered()
 	if(in_chamber)

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -6,7 +6,7 @@
 	force = 10
 	fire_sound = 'sound/weapons/pulse.ogg'
 	charge_cost = 200
-	projectile_type = "/obj/item/projectile/beam/pulse"
+	projectile_type = "/obj/item/projectile/beam/pulse/deathsquad"
 	cell_type = "/obj/item/weapon/cell/super"
 	var/mode = 2
 	fire_delay = 2
@@ -30,7 +30,7 @@
 			charge_cost = 200
 			fire_sound = 'sound/weapons/pulse.ogg'
 			to_chat(user, "<span class='warning'>\The [src] is now set to DESTROY.</span>")
-			projectile_type = "/obj/item/projectile/beam/pulse"
+			projectile_type = "/obj/item/projectile/beam/pulse/deathsquad"
 
 /obj/item/weapon/gun/energy/pulse_rifle/cyborg/process_chambered()
 	if(in_chamber)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -793,6 +793,10 @@ var/list/beam_master = list()
 	destroy = 1
 	fire_sound = 'sound/weapons/pulse.ogg'
 
+/obj/item/projectile/beam/pulse/deathsquad/on_hit(atom/atarget, blocked)
+	target.emp_act(2)
+	..()
+
 /obj/item/projectile/beam/deathlaser
 	name = "death laser"
 	icon_state = "heavylaser"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -793,10 +793,6 @@ var/list/beam_master = list()
 	destroy = 1
 	fire_sound = 'sound/weapons/pulse.ogg'
 
-/obj/item/projectile/beam/pulse/deathsquad/on_hit(atom/atarget, blocked)
-	target.emp_act(2)
-	..()
-
 /obj/item/projectile/beam/deathlaser
 	name = "death laser"
 	icon_state = "heavylaser"

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -34244,6 +34244,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/solar/fport)
+"chd" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera{
+	name = "Assault Armor North";
+	network = list("CREED")
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/specops)
 "chf" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -50428,11 +50440,12 @@
 	},
 /area/centcom/striketeam)
 "doO" = (
-/obj/structure/lattice,
-/turf/space,
-/area)
+/obj/machinery/mech_bay_recharge_port,
+/turf/simulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/specops/centcom)
 "doP" = (
-/obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -50444,6 +50457,7 @@
 	dir = 8
 	},
 /obj/structure/window/full/reinforced,
+/obj/structure/grille/invulnerable,
 /turf/unsimulated/floor{
 	name = "plating"
 	},
@@ -50630,14 +50644,10 @@
 	},
 /area/centcom/specops)
 "dpp" = (
-/obj/machinery/camera{
-	name = "Assault Armor North";
-	network = list("CREED")
-	},
-/obj/mecha/combat/marauder/seraph,
 /obj/machinery/mech_bay_recharge_floor{
 	icon_state = "recharge_floor_dark"
 	},
+/obj/mecha/medical/odysseus/murdysseus,
 /turf/unsimulated/floor{
 	dir = 8;
 	icon_state = "dark-markings"
@@ -51085,10 +51095,10 @@
 /turf/space,
 /area/centcom/specops)
 "dqr" = (
-/obj/mecha/combat/marauder,
 /obj/machinery/mech_bay_recharge_floor{
 	icon_state = "recharge_floor_dark"
 	},
+/obj/mecha/working/ripley/deathripley,
 /turf/unsimulated/floor{
 	dir = 8;
 	icon_state = "dark-markings"
@@ -51428,23 +51438,19 @@
 	},
 /area/centcom/specops)
 "drd" = (
-/obj/machinery/door/airlock/external{
-	name = "Mech Bay"
+/obj/machinery/door/poddoor/admin{
+	id_tag = "Deathsquad Mecha";
+	desc = "These blast doors will only unlock if your superiors deemed it necessary for the mission.";
+	name = "Deathsquad Mecha Access"
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/centcom/specops)
 "dre" = (
-/obj/effect/decal{
-	alpha = 150;
-	icon = 'icons/logos.dmi';
-	icon_state = "death-logo";
-	pixel_x = 16;
-	pixel_y = -16
-	},
+/obj/structure/bed/chair/comfy/couch/mid/black,
 /turf/unsimulated/floor{
-	icon_state = "dark"
+	icon_state = "darkred"
 	},
 /area/centcom/specops)
 "drf" = (
@@ -51639,19 +51645,30 @@
 /turf/space,
 /area/centcom/specops)
 "drA" = (
+/obj/structure/bed/chair/comfy/couch/mid/black{
+	dir = 1
+	},
 /turf/unsimulated/floor{
-	icon_state = "darkredcorners"
+	dir = 1;
+	icon_state = "darkred"
 	},
 /area/centcom/specops)
 "drB" = (
+/obj/structure/bed/chair/comfy/couch/mid/black{
+	dir = 4
+	},
 /turf/unsimulated/floor{
+	dir = 4;
 	icon_state = "darkred"
 	},
 /area/centcom/specops)
 "drC" = (
+/obj/structure/bed/chair/comfy/couch/mid/black{
+	dir = 8
+	},
 /turf/unsimulated/floor{
 	dir = 8;
-	icon_state = "darkredcorners"
+	icon_state = "darkred"
 	},
 /area/centcom/specops)
 "drD" = (
@@ -51890,19 +51907,9 @@
 	},
 /area/centcom/specops)
 "dsc" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/structure/window/full/reinforced,
-/turf/unsimulated/floor{
-	name = "plating"
+/turf/unsimulated/wall/fakeglass{
+	dir = 1
 	},
 /area/centcom/specops)
 "dsd" = (
@@ -52112,36 +52119,28 @@
 	},
 /area)
 "dsC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/structure/window/full/reinforced,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/wall/fakeglass,
 /area/centcom/specops)
 "dsD" = (
+/obj/structure/bed/chair/comfy/couch/turn/inward/black,
 /turf/unsimulated/floor{
-	dir = 4;
+	dir = 8;
 	icon_state = "darkredcorners"
 	},
 /area/centcom/specops)
 "dsE" = (
-/turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "darkred"
+/obj/structure/bed/chair/comfy/couch/turn/inward/black{
+	dir = 8
 	},
-/area/centcom/specops)
-"dsF" = (
 /turf/unsimulated/floor{
 	dir = 1;
 	icon_state = "darkredcorners"
 	},
+/area/centcom/specops)
+"dsF" = (
+/obj/structure/lattice,
+/turf/space,
 /area/centcom/specops)
 "dsG" = (
 /obj/structure/table,
@@ -52306,14 +52305,13 @@
 	},
 /area/centcom/specops)
 "dsW" = (
-/obj/machinery/camera{
-	dir = 1;
-	name = "Assault Armor South";
-	network = list("CREED")
+/obj/machinery/mech_bay_recharge_floor{
+	icon_state = "recharge_floor_dark"
 	},
+/obj/mecha/combat/marauder,
 /turf/unsimulated/floor{
 	dir = 8;
-	icon_state = "dark loading"
+	icon_state = "dark-markings"
 	},
 /area/centcom/specops)
 "dsX" = (
@@ -52781,6 +52779,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/mech_bay_recharge_floor{
+	icon_state = "recharge_floor_dark"
+	},
+/obj/mecha/combat/marauder/seraph,
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
 	},
@@ -52790,6 +52792,7 @@
 	name = "Spec. Ops. Shuttle";
 	network = list("CREED")
 	},
+/obj/machinery/computer/mech_bay_power_console,
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
 	},
@@ -71871,6 +71874,14 @@
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/escape_pod2)
+"hji" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/specops)
 "hjl" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -97867,6 +97878,17 @@
 "qkA" = (
 /turf/simulated/wall/r_wall,
 /area/derelict/research)
+"qkC" = (
+/obj/machinery/light,
+/obj/machinery/camera{
+	dir = 1;
+	name = "Assault Armor South";
+	network = list("CREED")
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/specops)
 "qkN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
@@ -98485,6 +98507,19 @@
 	icon_state = "floor3"
 	},
 /area/centcom/evac)
+"qvA" = (
+/obj/effect/decal{
+	alpha = 150;
+	icon = 'icons/logos.dmi';
+	icon_state = "death-logo";
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/turf/unsimulated/floor{
+	icon_state = "engine";
+	name = "reinforced floor"
+	},
+/area/centcom/specops)
 "qvY" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -102744,6 +102779,22 @@
 	icon_state = "L14"
 	},
 /area/hallway/primary/central)
+"scd" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/full/reinforced,
+/turf/unsimulated/floor{
+	name = "plating"
+	},
+/area/centcom/specops)
 "scf" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -110906,6 +110957,15 @@
 	tag = "icon-caution (WEST)"
 	},
 /area/hallway/primary/aft)
+"uYC" = (
+/obj/structure/bed/chair/comfy/couch/turn/inward/black{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	dir = 4;
+	icon_state = "darkredcorners"
+	},
+/area/centcom/specops)
 "uYG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -113692,6 +113752,14 @@
 	},
 /turf/simulated/floor,
 /area/crew_quarters/locker)
+"vZM" = (
+/obj/structure/bed/chair/comfy/couch/turn/inward/black{
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "darkredcorners"
+	},
+/area/centcom/specops)
 "waa" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -313435,15 +313503,15 @@ cTl
 cTl
 cTl
 cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
+dpk
+dpk
+dpl
+dpk
+dpl
+dpk
+dpl
+dpk
+dpk
 cTl
 cTl
 cTl
@@ -313737,15 +313805,15 @@ cTl
 cTl
 cTl
 cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
+dpl
+dpM
+dpl
+dpM
+dpl
+dpM
+dpl
+dpM
+dpl
 cTl
 cTl
 cTl
@@ -314039,15 +314107,15 @@ cTl
 cTl
 cTl
 cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
+dpk
+dpN
+dpl
+dpN
+dpl
+dpN
+dpl
+dpN
+dpk
 cTl
 cTl
 cTl
@@ -314341,15 +314409,15 @@ cTl
 cTl
 cTl
 cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
+dpk
+dpN
+dpk
+dpN
+dpl
+dpN
+dpk
+dpN
+dpk
 cTl
 cTl
 cTl
@@ -314643,15 +314711,15 @@ cTl
 cTl
 cTl
 cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
+dpk
+dpN
+dpk
+dpN
+dpl
+dpN
+dpk
+dpN
+dpk
 cTl
 cTl
 cTl
@@ -314945,15 +315013,15 @@ cTl
 cTl
 cTl
 cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
-cTl
+dpk
+dpN
+dpk
+dpN
+dpl
+dpN
+dpk
+dpN
+dpk
 cTl
 cTl
 cTl
@@ -315247,15 +315315,15 @@ cTl
 cTl
 cTl
 cTl
-cTl
-cTl
-cTl
-cTl
-doO
-cTl
-cTl
-cTl
-cTl
+dpk
+dpN
+dpk
+dpN
+dpl
+dpN
+dpk
+dpN
+dpk
 cTl
 cTl
 cTl
@@ -315549,15 +315617,15 @@ cTl
 cTl
 cTl
 cTl
-cTl
-cTl
-cTl
-cTl
-doO
-cTl
-cTl
-cTl
-cTl
+dpk
+dpO
+dpk
+dpO
+dpl
+dpO
+dpk
+dpO
+dpk
 cTl
 cTl
 cTl
@@ -315852,13 +315920,13 @@ cTl
 cTl
 cTl
 dpk
+dpP
 dpk
+dqZ
 dpl
+dpP
 dpk
-dpl
-dpk
-dpl
-dpk
+dqZ
 dpk
 cTl
 cTl
@@ -316152,16 +316220,16 @@ cTl
 cTl
 cTl
 cTl
-cTl
+dsF
 dpl
-dpM
+dpP
+dpk
+dpP
 dpl
-dpM
-dpl
-dpM
-dpl
-dpM
-dpl
+dpP
+dpk
+dqZ
+dpk
 cTl
 cTl
 cTl
@@ -316456,13 +316524,13 @@ cTl
 cTl
 cTl
 dpk
-dpN
+dpP
+dpk
+dpP
 dpl
-dpN
-dpl
-dpN
-dpl
-dpN
+dpP
+dpk
+dpP
 dpk
 cTl
 cTl
@@ -316758,13 +316826,13 @@ cTl
 cTl
 cTl
 dpk
-dpN
+dpP
 dpk
-dpN
+dpP
 dpl
-dpN
+dpP
 dpk
-dpN
+dpP
 dpk
 cTl
 cTl
@@ -317058,16 +317126,16 @@ cTl
 cTl
 cTl
 cTl
-cTl
-dpk
-dpN
-dpk
-dpN
-dpl
-dpN
-dpk
-dpN
-dpk
+doq
+dpm
+dpP
+dpm
+dpP
+dpm
+dpP
+dpm
+dpP
+dpm
 cTl
 cTl
 cTl
@@ -317361,15 +317429,15 @@ cTl
 cTl
 don
 cTl
-dpk
-dpN
-dpk
-dpN
-dpl
-dpN
-dpk
-dpN
-dpk
+dpn
+dpQ
+dqq
+dpQ
+drz
+dpQ
+dqq
+dpQ
+dtl
 cTl
 cTl
 cTl
@@ -317663,15 +317731,15 @@ cTl
 cTl
 dcc
 cTl
-dpk
-dpN
-dpk
-dpN
-dpl
-dpN
-dpk
-dpN
-dpk
+dpn
+dpQ
+dqq
+dpQ
+drz
+dpQ
+dqq
+dpQ
+dtl
 cTl
 cTl
 cTl
@@ -317965,15 +318033,15 @@ cTl
 cTl
 dcc
 cTl
-dpk
-dpO
-dpk
-dpO
-dpl
-dpO
-dpk
-dpO
-dpk
+dpn
+dpQ
+dqq
+dpQ
+drz
+dpQ
+dqq
+dpQ
+dtl
 cTl
 cTl
 cTl
@@ -318267,15 +318335,15 @@ dki
 dki
 dcc
 cTl
-dpk
-dpP
-dpk
-dqZ
-dpl
-dpP
-dpk
-dqZ
-dpk
+dpn
+dpQ
+dqq
+dpQ
+drz
+dpQ
+dqq
+dpQ
+dtl
 cTl
 cTl
 cTl
@@ -318568,16 +318636,16 @@ dkj
 dkj
 dkj
 dcc
-doO
-dpl
-dpP
-dpk
-dpP
-dpl
-dpP
-dpk
-dqZ
-dpk
+cTl
+dpn
+dpQ
+dqq
+dpQ
+drz
+dpQ
+dqq
+dpQ
+dtl
 cTl
 cTl
 cTl
@@ -318871,15 +318939,15 @@ cTl
 cTl
 dcc
 cTl
-dpk
-dpP
-dpk
-dpP
-dpl
-dpP
-dpk
-dpP
-dpk
+dpn
+dpQ
+dqq
+dpQ
+drz
+dpQ
+dqq
+dpQ
+dtl
 cTl
 cTl
 cTl
@@ -319173,15 +319241,15 @@ dkI
 cTl
 dcc
 cTl
-dpk
-dpP
-dpk
-dpP
-dpl
-dpP
-dpk
-dpP
-dpk
+dpn
+dpQ
+dqq
+dpQ
+drz
+dpQ
+dqq
+dpQ
+dtl
 cTl
 cTl
 cTl
@@ -319474,16 +319542,16 @@ dmK
 dnu
 cTl
 dcc
-doq
-dpm
-dpP
-dpm
-dpP
-dpm
-dpP
-dpm
-dpP
-dpm
+cTl
+dpn
+dpR
+dqq
+dpR
+drz
+dpR
+dqq
+dpR
+dtl
 cTl
 cTl
 cTl
@@ -319776,16 +319844,16 @@ dln
 dnu
 cTl
 dcc
-cTl
-dpn
-dpQ
-dqq
-dpQ
-drz
-dpQ
-dqq
-dpQ
-dtl
+scd
+doq
+dpS
+doq
+dra
+doq
+dsa
+doq
+dsU
+doq
 cTl
 cTl
 cTl
@@ -320078,16 +320146,16 @@ dnu
 dnu
 cTl
 dcc
-cTl
-dpn
-dpQ
-dqq
-dpQ
-drz
-dpQ
-dqq
-dpQ
-dtl
+doQ
+dpo
+dpT
+dpo
+drb
+dpo
+dsb
+dpo
+dsV
+doq
 cTl
 cTl
 cTl
@@ -320380,16 +320448,16 @@ dmM
 dnu
 cTl
 dcc
-cTl
-dpn
-dpQ
-dqq
-dpQ
-drz
-dpQ
-dqq
-dpQ
-dtl
+doQ
+dsW
+dpU
+dsW
+dpU
+dsW
+dpU
+dsW
+dpU
+doq
 cTl
 cTl
 cTl
@@ -320682,16 +320750,16 @@ dmN
 dnu
 cTl
 dcc
-cTl
-dpn
-dpQ
-dqq
-dpQ
-drz
-dpQ
-dqq
-dpQ
-dtl
+doR
+dpq
+dpV
+dpq
+drc
+dpq
+drc
+dpq
+dsX
+doq
 cTl
 cTl
 cTl
@@ -320984,16 +321052,16 @@ dmO
 dnu
 cTl
 dcc
-cTl
-dpn
-dpQ
-dqq
-dpQ
-drz
-dpQ
-dqq
-dpQ
-dtl
+doS
+doS
+doS
+doS
+doS
+doS
+doS
+doS
+doS
+doq
 cTl
 cTl
 cTl
@@ -321286,16 +321354,16 @@ dmP
 dkJ
 cTl
 dcc
-cTl
-dpn
-dpQ
-dqq
-dpQ
-drz
-dpQ
-dqq
-dpQ
-dtl
+doS
+dpo
+doS
+dpo
+doS
+dpo
+doS
+dpo
+doS
+doq
 cTl
 cTl
 cTl
@@ -321588,16 +321656,16 @@ dmQ
 dnu
 cTl
 dcc
-cTl
-dpn
-dpQ
-dqq
-dpQ
-drz
-dpQ
-dqq
-dpQ
-dtl
+doS
+dpp
+doS
+dpp
+doS
+dpp
+doS
+dpp
+doS
+doq
 cTl
 cTl
 cTl
@@ -321890,16 +321958,16 @@ dmR
 dnu
 cTl
 dcc
-cTl
-dpn
-dpR
-dqq
-dpR
-drz
-dpR
-dqq
-dpR
-dtl
+chd
+dpq
+doS
+dpq
+doS
+dpq
+doS
+dpq
+qkC
+doq
 cTl
 cTl
 cTl
@@ -322192,15 +322260,15 @@ dmS
 dnu
 cTl
 dcc
-doP
-doq
-dpS
-doq
-dra
-doq
-dsa
-doq
-dsU
+doS
+doS
+doS
+doS
+doS
+doS
+doS
+doS
+doS
 doq
 cTl
 cTl
@@ -322494,15 +322562,15 @@ dmT
 dnv
 cTl
 dcc
-doQ
+doS
 dpo
-dpT
+doS
 dpo
-drb
+doS
 dpo
-dsb
+doS
 dpo
-dsV
+doS
 doq
 dtu
 dtu
@@ -322796,15 +322864,15 @@ dcc
 cTl
 cTl
 dcc
-doQ
-dpp
-dpU
+doS
 dqr
-dpU
+doS
 dqr
-dpU
+doS
 dqr
-dsW
+doS
+dqr
+doS
 doP
 cTl
 cTl
@@ -323098,15 +323166,15 @@ dkk
 dkL
 dlw
 dcc
-doR
+hji
 dpq
-dpV
+doS
 dpq
-drc
+doS
 dpq
-drc
+doS
 dpq
-dsX
+dtb
 doq
 cTl
 dtC
@@ -323714,7 +323782,7 @@ doq
 doq
 cTl
 dvl
-duk
+doO
 duk
 duk
 dvl
@@ -324009,9 +324077,9 @@ doq
 doq
 dqt
 dpU
-drA
-dpY
-dsD
+doS
+doS
+doS
 dsY
 doP
 cTl
@@ -324310,10 +324378,10 @@ doT
 dps
 doq
 dqu
-doS
+vZM
 drB
-dsd
-dsE
+uYC
+doS
 dsZ
 dqs
 doP
@@ -324613,9 +324681,9 @@ doS
 dpX
 doS
 dre
-drC
-dpV
-dsF
+dsd
+drA
+doS
 dta
 dtm
 dta
@@ -324914,9 +324982,9 @@ doS
 doS
 dpY
 doS
-doS
-doS
-doS
+dsD
+drC
+dsE
 doS
 dta
 dtm
@@ -327028,7 +327096,7 @@ doV
 dpu
 dpu
 dpu
-dpu
+qvA
 dpu
 dpu
 dpu


### PR DESCRIPTION
![deathsquad zone](https://i.imgur.com/fb3KqrQ.png)
(this is the first time I mapped something this significant please tell me if something is bad)

- Locked mechas behind a blast door that is closed by default, except for the Seraph which is accessible to the Commander and available in the shuttle.

The deathsquad had a lot of personality and fun sucked out of it by the rampant use of mechas. With the locking of mechas behind a blast door that can only be opened by an admin (and a bunch of impenetrable windows) it should allow deathsquaddies to get up close and personal with their prey.

- Added 1 more Marauder, 4 Murderysseus and 4 Death Ripleys. For variety.
- Added a snazzy couch around the holomap, moved decal closer to deathsquad spawns.
- Stealthily replaced the breakable window grilles with invulnerable grilles. No you cannot use the portal gun on Z2.


So what does the deathsquad get to make up for the initial loss of the mechas?
- Deathsquad thermals now also confer x-ray vision, the ability to see in the dark to a degree and protect against flashes. They also cannot be EMP'd to blind the deathsquaddie, because this was a sort of glaring vulnerability that most people, not even the deathsquad, knew about.

And a few miscellaneous changes:
- Deathsquad members will automatically talk into the deathsquad frequency rather than Commons.
- Replaced the deathsquad SWAT masks with HECU masks that can be used indefinitely.
- Fixed a typo where Commando and Commander were swapped. Commander is the leader.
- Added a new possible leader name.

Closes #27000

:cl:
 * tweak: The Nanotrasen Deathsquad no longer has access to mechas by default, but the Commander still gets the Seraph which is now available in the shuttle.
 * rscadd: The Deathsquad mecha bay now has 8 more mecha with more variety.
 * tweak: Changed the Deathsquad lounge a little.
 * rscadd: The thermal glasses worn by the Deathsquad have been significantly improved, and provide protection against flashes, is immune to EMPs and can see through walls.
 * rscadd: Deathsquad commandos now spawn with improved HECU masks.
 * spellcheck: Fixed a typo where Death Commandos were called Death Commanders and vice versa.
 * rscadd: Added a new possible Deathsquad Leader name.
 * tweak: Deathsquad members will now automatically talk in their radio rather than the Common channel.
