### PR TITLE
Fix Sammi accepting infinite power cells when unanchored.

### DIFF
--- a/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
@@ -123,7 +123,7 @@
 	if (istype(W, /obj/item/weapon/cell) && opened)	// trying to put a cell inside
 		if(wiresexposed)
 			to_chat(user, "Close the wiring panel first.")
-		else if(cell)
+		else if(cell || cellhold)
 			to_chat(user, "There is a power cell already installed.")
 		else
 			user.drop_item(W, src)


### PR DESCRIPTION
closes #33800

## What this does
Keeps SAMMIs from accepting an infinite amount of power cells when not anchored.

## Why it's good
Greedy little boys only get one power cell

## Changelog
:cl:
 * bugfix: Fixed SAMMIs accepting infinite power cells when unanchored.
