### PR TITLE
Autoprocessor fixes

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -1306,7 +1306,8 @@ to destroy them and players will be able to make replacements.
 	req_components = list(
 		/obj/item/weapon/stock_parts/scanning_module = 1,
 		/obj/item/weapon/stock_parts/manipulator = 1,
-		/obj/item/weapon/stock_parts/matter_bin = 2,
+		/obj/item/weapon/stock_parts/matter_bin = 1,
+		/obj/item/weapon/stock_parts/capacitor = 1
 	)
 
 /obj/item/weapon/circuitboard/autoprocessor/wrapping
@@ -1315,9 +1316,19 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/autoprocessor/wrapping
 
 /obj/item/weapon/circuitboard/autoprocessor/clothing
-	name = "Circuit Board (Wrapping Machine)"
+	name = "Circuit Board (Clothing Machine)"
 	desc = "A circuit board used to run a machine that clothes living things."
 	build_path = /obj/machinery/autoprocessor/clothing
+
+/obj/item/weapon/circuitboard/autoprocessor/outfit
+	name = "Circuit Board (Auto Outfitter)"
+	desc = "A circuit board used to run a machine that automatically applies an outfit to people inside."
+	build_path = /obj/machinery/autoprocessor/outfit
+
+/obj/item/weapon/circuitboard/autoprocessor/outfit/prisoner
+	name = "Circuit Board (Prisoner Outfitter)"
+	desc = "A circuit board used to run a machine that automatically applies prisoner clothes to people inside."
+	build_path = /obj/machinery/autoprocessor/outfit/prisoner
 
 /obj/item/weapon/circuitboard/processing_unit
 	name = "Circuit Board (Ore Processor)"

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -762,7 +762,8 @@
 	anchored = 1
 	idle_power_usage = 100 //No active power usage because this thing passively uses 100, always. Don't ask me why N3X15 coded it like this.
 	plane = ABOVE_HUMAN_PLANE
-
+	var/circuitpath = /obj/item/weapon/circuitboard/autoprocessor
+	
 	var/atom/movable/mover //Virtual atom used to check passing ability on the out turf.
 
 	var/next_sound = 0
@@ -775,7 +776,13 @@
 
 /obj/machinery/autoprocessor/New()
 	. = ..()
-
+	component_parts = newlist(
+		circuitpath,
+		/obj/item/weapon/stock_parts/scanning_module,
+		/obj/item/weapon/stock_parts/manipulator,
+		/obj/item/weapon/stock_parts/matter_bin,
+		/obj/item/weapon/stock_parts/capacitor
+	)
 	mover = new
 
 /obj/machinery/autoprocessor/Destroy()
@@ -853,6 +860,7 @@
 	desc = "Wraps and tags items."
 	machine_flags = SCREWTOGGLE | CROWDESTROY
 	idle_power_usage = 100 //No active power usage because this thing passively uses 100, always. Don't ask me why N3X15 coded it like this.
+	circuitpath = /obj/item/weapon/circuitboard/autoprocessor/wrapping
 
 	var/packagewrap = 0
 	var/syndiewrap = 0
@@ -1030,6 +1038,8 @@
 	desc = "Automatically swaps clothes of people inside. Use machine with an empty hand to retrieve clothing, or with held clothing to place it inside."
 	machine_flags = SCREWTOGGLE | CROWDESTROY | EMAGGABLE
 	idle_power_usage = 100 //No active power usage because this thing passively uses 100, always. Don't ask me why N3X15 coded it like this.
+	circuitpath = /obj/item/weapon/circuitboard/autoprocessor/clothing
+
 	var/list/obj/item/held_clothing = list()
 	var/strip_items = FALSE
 
@@ -1085,8 +1095,10 @@
 		visible_message("<span class='notice'>[src] beeps: [items_equipped] article\s of clothing applied successfully.</span>")
 
 /obj/machinery/autoprocessor/outfit
-	name = "autoclother"
+	name = "auto outfitter"
 	desc = "Automatically applies an outfit to people inside."
+	circuitpath = /obj/item/weapon/circuitboard/autoprocessor/outfit
+
 	var/outfit_type = /datum/outfit/assistant
 	var/datum/outfit/outfit_datum
 
@@ -1114,6 +1126,7 @@
 		visible_message("<span class='notice'>[src] beeps: [outfit_datum.outfit_name] outfit applied successfully.</span>")
 
 /obj/machinery/autoprocessor/outfit/prisoner
-	name = "prisoner clother"
+	name = "prisoner outfitter"
 	desc = "Automatically applies prisoner clothes to people inside."
+	circuitpath = /obj/item/weapon/circuitboard/autoprocessor/outfit/prisoner
 	outfit_type = /datum/outfit/special/prisoner

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -798,7 +798,8 @@
 /obj/machinery/autoprocessor/process()
 	if(stat & (BROKEN | NOPOWER | FORCEDISABLE))
 		return
-
+	if(!isturf(loc)) //If it's inside a flatpack, for instance
+		return
 	var/turf/in_T = get_step(src, input_dir)
 	var/turf/out_T = get_step(src, output_dir)
 

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -800,6 +800,7 @@
 		return
 	if(!isturf(loc)) //If it's inside a flatpack, for instance
 		return
+
 	var/turf/in_T = get_step(src, input_dir)
 	var/turf/out_T = get_step(src, output_dir)
 


### PR DESCRIPTION
Closes #33851

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Autoprocessors and their subtypes now have their own circuitboards.
 * rscadd: Autoprocessors and their subtypes now have upgradeable stock parts.
 * bugfix: The prisoner auto-outfitter no longer processes prisoners from inside its flatpack.
