### PR TITLE
remove admin immunity to view reset called in Login()

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -116,7 +116,7 @@
 		var/obj/location = loc
 		location.on_login(src)
 
-	if(client && client.haszoomed && !client.holder)
+	if(client && client.haszoomed)
 		client.changeView()
 		client.haszoomed = 0
 


### PR DESCRIPTION
## What this does
When entering a new mob, your view size is reset. This ensures that, if you were a ghost and zoomed out, then became a mid-round antagonist or whatever, your view would be be set back to the normal size. For whatever reason, this does not apply to admins.

I do not think this immunity is actually useful to admins. More often than not, it's an annoyance when I go back and forth between testing stuff in thunderdome and observing with a wider zoom. It also has a potential for abuse, although adding logging if that were a major concern would be trivial.

I find that it's best to remove this immunity altogether.

[administration]