### PR TITLE
Have a client when updating perception

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -44,6 +44,8 @@
 	change_sight(adding = SEE_MOBS)
 
 /mob/living/carbon/alien/update_perception()
+	if(!client)
+		return
 	if(dark_plane)
 		dark_plane.alphas["alien"] = 200
 		dark_plane.colours = "#8C5E2F"

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -67,6 +67,8 @@
 		src.add_spell(new spell, "cult_spell_ready", /obj/abstract/screen/movable/spell_master/bloodcult)
 
 /mob/living/simple_animal/construct/update_perception()
+	if(!client)
+		return
 	if(dark_plane)
 		dark_plane.alphas["construct"] = 75
 		client.color = list(

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -184,6 +184,8 @@
 	standard_damage_overlay_updates()
 
 /mob/living/simple_animal/hostile/giant_spider/update_perception()
+	if(!client)
+		return
 	if(a_matrix_testing_override)	// setting to 1 lets you use spiders as a perception-testing mob
 		client.color = list(a_11,a_12,a_13,a_14,
 							a_21,a_22,a_23,a_24,

--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -382,6 +382,8 @@
 
 //Grue vision
 /mob/living/simple_animal/hostile/grue/update_perception()
+	if(!client)
+		return
 	if(dark_plane)
 		if (master_plane)
 			master_plane.blend_mode = BLEND_ADD

--- a/code/modules/mob/living/simple_animal/hostile/necro.dm
+++ b/code/modules/mob/living/simple_animal/hostile/necro.dm
@@ -191,6 +191,8 @@
 	var/list/clothing = list() //If the previous corpse had clothing, it 'wears' it
 
 /mob/living/simple_animal/hostile/necro/zombie/update_perception()
+	if(!client)
+		return
 	if(dark_plane)
 		dark_plane.alphas["zombie"] = 90
 		see_in_dark = 8


### PR DESCRIPTION
NPCs don't need their vision updated, and this eliminates runtimes

## What this does
- checks for clients before updating perception

## Why it's good
- no more runtimes in update_perception()