### PR TITLE
Fix vox/plasmaman librarians not starting with a bookbag.

### DIFF
--- a/code/datums/outfit/civilian.dm
+++ b/code/datums/outfit/civilian.dm
@@ -552,6 +552,7 @@
 			slot_shoes_str = /obj/item/clothing/shoes/black,
 			slot_wear_suit_str = /obj/item/clothing/suit/space/plasmaman/librarian,
 			slot_head_str = /obj/item/clothing/head/helmet/space/plasmaman/librarian,
+			slot_l_store_str = /obj/item/weapon/storage/bag/bookbag,
 			slot_wear_mask_str = /obj/item/clothing/mask/breath,
 		),
 		/datum/species/vox/ = list(
@@ -560,6 +561,7 @@
 			slot_shoes_str = /obj/item/clothing/shoes/black,
 			slot_wear_suit_str = /obj/item/clothing/suit/space/vox/civ/librarian,
 			slot_head_str = /obj/item/clothing/head/helmet/space/vox/civ/librarian,
+			slot_l_store_str = /obj/item/weapon/storage/bag/bookbag,
 			slot_wear_mask_str = /obj/item/clothing/mask/breath/vox,
 		),
 	)


### PR DESCRIPTION

## What this does
Title
## Why it's good
Lets these librarians make use of the new book bag.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Vox/Plasmaman librarians now start with a bookbag.

