### PR TITLE
artifact analyzer ghosthands

### DIFF
--- a/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
+++ b/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
@@ -56,6 +56,8 @@ var/anomaly_report_num = 0
 /obj/machinery/artifact_analyser/attack_hand(var/mob/user as mob)
 	if(..())
 		return
+	if(!isliving(user) || user.stat)
+		return
 	src.add_fingerprint(user)
 
 	if(stat & (NOPOWER|BROKEN|FORCEDISABLE))

--- a/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
+++ b/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
@@ -56,7 +56,7 @@ var/anomaly_report_num = 0
 /obj/machinery/artifact_analyser/attack_hand(var/mob/user as mob)
 	if(..())
 		return
-	if(!isliving(user) || user.stat)
+	if(!isliving(user))
 		return
 	src.add_fingerprint(user)
 


### PR DESCRIPTION
Ghosts can endlessly troll xenoarchaeologists by cancelling the scan on their artifacts.
@dinnerwoerror I know it was you.
[bugfix]

Fixes #32770
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Ghosts can no longer toggle scanning with the xenoarchaeology artifact scanner.