### PR TITLE
Makes emote keys less case sensitive

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -7,7 +7,7 @@
 		act = copytext(act, 1, custom_param)
 
 	var/datum/emote/E
-	E = E.emote_list[act]
+	E = E.emote_list[lowertext(act)]
 	if(!E)
 		to_chat(src, "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>")
 		return


### PR DESCRIPTION
[tweak][qol]

## What this does
automatically makes the typed key lowertext in the check

## Why it's good
makes less worries about capitalisation, since they're all lowercase keys anyways

## Changelog
:cl:
 * tweak: Emote keys are no longer case sensitive.