### PR TITLE
Personal airbags now prevent fall damage

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -240,12 +240,10 @@ atom/movable/GotoAirflowDest(n)
 /mob/living/carbon/human/airflow_hit(atom/A)
 	var/b_loss = airflow_speed * zas_settings.Get(/datum/ZAS_Setting/airflow_damage)
 
-	for(var/i in contents)
-		if(istype(i, /obj/item/airbag))
-			var/obj/item/airbag/airbag = i
-			airbag.deploy(src)
-			b_loss = 0
-			break
+	var/obj/item/airbag/airbag = locate() in contents
+	if(airbag)
+		airbag.deploy(src)
+		b_loss = 0
 
 	var/head_damage = ((b_loss/3)/100) * (100 - getarmor(LIMB_HEAD,"melee"))
 	apply_damage(head_damage, BRUTE, LIMB_HEAD, 0, 0, used_weapon = "Airflow")

--- a/code/modules/multiz/fall_hit.dm
+++ b/code/modules/multiz/fall_hit.dm
@@ -37,6 +37,8 @@
 	var/gravity = get_gravity()
 	var/total_brute_loss = 0
 	var/obj/item/airbag/airbag = locate() in contents
+	if(mind && mind.suiciding)
+		airbag = null
 	if(gravity > 0.5 && !airbag)
 		visible_message("<span class='warning'>\The [src] falls from above and slams into \the [landing]!</span>", \
 			"<span class='danger'>You fall off and hit \the [landing]!</span>", \
@@ -62,7 +64,7 @@
 			log_debug("[src] has taken [total_brute_loss] damage after falling [zs_fallen] z levels with a gravity of [gravity] Gs!")
 		AdjustKnockdown((3 * min(zs_fallen,10)) * gravity)
 	else
-		if(airbag && gravity > 0.667)
+		if(airbag && gravity > 0.5)
 			airbag.deploy(src)
 		visible_message("\The [src] drops from above and onto \the [landing].", \
 			"You fall off and land on the \the [landing].", \

--- a/code/modules/multiz/fall_hit.dm
+++ b/code/modules/multiz/fall_hit.dm
@@ -36,9 +36,9 @@
 /mob/living/fall_impact(var/turf/landing)
 	var/gravity = get_gravity()
 	var/total_brute_loss = 0
-	var/obj/item/airbag/airbag = locate() in contents
-	if(mind && mind.suiciding)
-		airbag = null
+	var/obj/item/airbag/airbag = null
+	if(!mind || !mind.suiciding)
+		airbag = locate() in contents
 	if(gravity > 0.5 && !airbag)
 		visible_message("<span class='warning'>\The [src] falls from above and slams into \the [landing]!</span>", \
 			"<span class='danger'>You fall off and hit \the [landing]!</span>", \

--- a/code/modules/multiz/fall_hit.dm
+++ b/code/modules/multiz/fall_hit.dm
@@ -62,7 +62,7 @@
 			log_debug("[src] has taken [total_brute_loss] damage after falling [zs_fallen] z levels with a gravity of [gravity] Gs!")
 		AdjustKnockdown((3 * min(zs_fallen,10)) * gravity)
 	else
-		if(airbag)
+		if(airbag && gravity > 0.667)
 			airbag.deploy(src)
 		visible_message("\The [src] drops from above and onto \the [landing].", \
 			"You fall off and land on the \the [landing].", \

--- a/code/modules/multiz/fall_hit.dm
+++ b/code/modules/multiz/fall_hit.dm
@@ -36,7 +36,8 @@
 /mob/living/fall_impact(var/turf/landing)
 	var/gravity = get_gravity()
 	var/total_brute_loss = 0
-	if(gravity > 0.5)
+	var/obj/item/airbag/airbag = locate() in contents
+	if(gravity > 0.5 && !airbag)
 		visible_message("<span class='warning'>\The [src] falls from above and slams into \the [landing]!</span>", \
 			"<span class='danger'>You fall off and hit \the [landing]!</span>", \
 			"You hear something slam into \the [landing].")
@@ -61,6 +62,8 @@
 			log_debug("[src] has taken [total_brute_loss] damage after falling [zs_fallen] z levels with a gravity of [gravity] Gs!")
 		AdjustKnockdown((3 * min(zs_fallen,10)) * gravity)
 	else
+		if(airbag)
+			airbag.deploy(src)
 		visible_message("\The [src] drops from above and onto \the [landing].", \
 			"You fall off and land on the \the [landing].", \
 			"You hear something drop onto \the [landing].")

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2859,7 +2859,7 @@
 #include "maprendering\maprendering.dm"
 #include "maps\_map.dm"
 #include "maps\_map_override.dm"
-#include "maps\tgstation.dm"
+#include "maps\test_multiz.dm"
 #include "maps\defficiency\areas.dm"
 #include "maps\lampreystation\lamprey.dm"
 #include "maps\packedstation\telecomms.dm"

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2859,7 +2859,7 @@
 #include "maprendering\maprendering.dm"
 #include "maps\_map.dm"
 #include "maps\_map_override.dm"
-#include "maps\test_multiz.dm"
+#include "maps\tgstation.dm"
 #include "maps\defficiency\areas.dm"
 #include "maps\lampreystation\lamprey.dm"
 #include "maps\packedstation\telecomms.dm"


### PR DESCRIPTION
[content]

## What this does
makes the airbags open up on landing if the gravity that causes fall damage is greater than 0.5 gs (suicide jumps are exempt)

## Why it's good
additional use for this item that should've made sense

## Changelog
:cl:
 * rscadd: Personal airbags now prevent fall damage, if possible.