### PR TITLE
[input wanted!] Slightly lower some map vote thresholds, pop cap on synergy

### DIFF
--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -59,7 +59,7 @@
 /datum/next_map/deff
 	name = "Defficiency"
 	path = "Defficiency"
-	min_players = 30
+	min_players = 25
 
 /datum/next_map/dorf
 	name = "DorfStation"
@@ -115,7 +115,7 @@
 /datum/next_map/metaclub
 	name = "Meta Club"
 	path = "Metaclub"
-	min_players = 24
+	min_players = 20
 
 /datum/next_map/packed
 	name = "Packed Station"
@@ -145,6 +145,7 @@
 /datum/next_map/synergy
 	name = "Synergy Station"
 	path = "Synergy"
+	max_players = 30
 
 /datum/next_map/waystation
 	name = "Waystation"


### PR DESCRIPTION
## Why it's good
I am so tired of having ~20 players online and the only options being Box and the lowpop maps.
This lowers the population requirement for Deff to be voteable by 5, and Meta to be voteable by 4.

Synergy also is no longer voteable if there are more than 30 players online. This isn't for any reason other than that previously it had no limits and over 30 seems like a reasonable one. If the Synergysisters do not like this, I will remove it.

**Please view the full file of map vote thresholds here and give your input on what else, if anything, needs review:**
https://github.com/vgstation-coders/vgstation13/blob/Bleeding-Edge/code/datums/next_map.dm
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Defficiency can now be voted starting at 25 players instead of 30.
 * tweak: Metaclub can now be voted starting at 20 players instead of 24.
 * tweak: Synergy can no longer be voted when there are more than 30 players online.