### PR TITLE
APCs now show exact charge and maxcharge for cells.

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -792,6 +792,8 @@
 		"isOperating" = operating,
 		"externalPower" = main_status,
 		"powerCellStatus" = cell ? cell.percent() : null,
+		"powerCellCharge" = cell ? round(cell.charge) : null,
+		"powerCellMaxCharge" = cell ? cell.maxcharge : null,
 		"chargeMode" = chargemode,
 		"chargingStatus" = charging,
 		"totalLoad" = lastused_equip + lastused_light + lastused_environ,

--- a/nano/templates/apc.tmpl
+++ b/nano/templates/apc.tmpl
@@ -57,15 +57,15 @@
 			Power Cell:
 		</div>
 		{{if data.powerCellStatus == null}}
-			<div class="itemContent bad">		
+			<div class="itemContent bad">
 				Power cell removed.
 			</div>
 		{{else}}
-			
-			{{:helper.displayBar(data.powerCellStatus, 0, 100, (data.powerCellStatus >= 50) ? 'good' : (data.powerCellStatus >= 25) ? 'average' : 'bad')}}
-			<div class="itemContent" style="width: 60px">		
+
+			{{:helper.displayBar(data.powerCellStatus, 0, 100, (data.powerCellStatus >= 50) ? 'good' : (data.powerCellStatus >= 25) ? 'average' : 'bad', data.powerCellCharge + '/' + data.powerCellMaxCharge)}}
+			<div class="itemContent" style="width: 60px">
 				{{:helper.round(data.powerCellStatus*10)/10}}%
-			</div>	
+			</div>
 		{{/if}}
 	</div>
 
@@ -80,7 +80,7 @@
 						<span class='good'>Auto</span>
 					{{else}}
 						<span class='bad'>Off</span>
-					{{/if}}				
+					{{/if}}
 				{{else}}
 					{{:helper.link('Auto', 'refresh', {'cmode' : 1}, data.chargeMode ? 'selected' : null)}}{{:helper.link('Off', 'close', {'cmode' : 1}, data.chargeMode ? null : 'selected')}}
 				{{/if}}
@@ -119,7 +119,7 @@
 						&nbsp;&nbsp;Auto
 					{{else}}
 						&nbsp;&nbsp;Manual
-					{{/if}}		
+					{{/if}}
 				{{/if}}
 			</div>
 			{{if !data.locked || data.siliconUser}}
@@ -173,4 +173,3 @@
 	{{/if}}
 
 </div>
-		


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
This is a small edit to the APC UI, that now shows the exact charge and maxcharge within the charging bar for the power cell.

![2022-12-20_19-12-54](https://user-images.githubusercontent.com/7096270/208791398-1f122803-9893-43c7-920f-70282d8d7c36.png)
![2022-12-20_19-13-42](https://user-images.githubusercontent.com/7096270/208791412-ba7e17fe-808e-4cd4-8f47-a676c450fa3f.png)
![2022-12-20_19-14-31](https://user-images.githubusercontent.com/7096270/208791430-50692462-3953-42bf-96ed-ddb81e325304.png)

## Why it's good
Gives engineers a direct insight into how much precise power an APC has, as well as implicitly lets them know what kind of power cell an APC has installed by looking at its max charge number. 

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added precise charge and maxcharge numbers to APC UI.
