### PR TITLE
explosions now work on shuttles again

### DIFF
--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -42,6 +42,7 @@
 		icon = initial(icon)
 
 /turf/simulated/wall/shuttle/ex_act(severity)
+	..()
 	return
 
 /turf/simulated/wall/shuttle/mech_drill_act(severity)
@@ -152,6 +153,7 @@
 	nitrogen = 0.01
 
 /turf/simulated/floor/shuttle/ex_act(severity)
+	..()
 	switch(severity)
 		if(1.0)
 			if(!(locate(/obj/effect/decal/cleanable/soot) in src))


### PR DESCRIPTION
## Why it's good
year old kanef bug lol https://github.com/vgstation-coders/vgstation13/pull/30963

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Explosions now work on shuttles again.
