### PR TITLE
Multi-Z falling velocity update

### DIFF
--- a/code/modules/multiz/fall_hit.dm
+++ b/code/modules/multiz/fall_hit.dm
@@ -27,7 +27,7 @@
 	for(var/atom/movable/AM in hit_atom.contents)
 		if(!AM.fall_act(src)) // FALSE breaks out of the normal actions
 			return FALSE
-	if(z_velocity > 2.5)
+	if(z_velocity > 2)
 		visible_message("<span class='warning'>\The [src] falls from above and slams into \the [hit_atom]!</span>", \
 			"<span class='danger'>You fall off and hit \the [hit_atom]!</span>", \
 			"You hear something slam into \the [hit_atom].")
@@ -49,8 +49,8 @@
 	var/obj/item/airbag/airbag = null
 	if(!mind || !mind.suiciding)
 		airbag = locate() in contents
-	if(old_z_velocity > 2.5 && !airbag)
-		if(old_z_velocity > 3.333)
+	if(old_z_velocity > 2 && !airbag)
+		if(old_z_velocity > 3)
 			playsound(loc, "sound/effects/pl_fallpain.ogg", 25, 1, -1)
 			// Bases at ten and scales with the number of Z levels fallen
 			// Because wounds heal rather quickly, 10 should be enough to discourage jumping off 1 ledge but not be enough to ruin you, at least for the first time.
@@ -69,7 +69,7 @@
 			log_debug("[src] has taken [total_brute_loss] damage after falling with a speed of [old_z_velocity] z-levels per second!")
 		AdjustKnockdown(3 * min(old_z_velocity,10))
 	else
-		if(airbag && old_z_velocity > 2.5)
+		if(airbag && old_z_velocity > 2)
 			airbag.deploy(src)
 	return TRUE
 
@@ -88,14 +88,13 @@
 	var/old_z_velocity = z_velocity
 	if(!..())
 		return FALSE
-	var/gravity = get_gravity()
-	if(old_z_velocity > 1.25)
+	if(old_z_velocity > 1)
 		// Tell the pilot that they just dropped down with a superheavy mecha.
 		if(occupant)
 			to_chat(occupant, "<span class='warning'>\The [src] crashed down onto \the [hit_atom]!</span>")
 
-		if(old_z_velocity > 2.5)
-			var/damage = ((10 * min(old_z_velocity,5)) * gravity)
+		if(old_z_velocity > 2)
+			var/damage = 10 * min(old_z_velocity,5)
 			// Anything on the same tile as the landing tile is gonna have a bad day.
 			for(var/mob/living/L in hit_atom.contents)
 				visible_message("<span class='danger'>\The [src] crushes \the [L] as it lands on them!</span>")
@@ -125,9 +124,8 @@ var/global/list/non_items = list(/obj/machinery,/obj/structure)
 	return TRUE
 
 /mob/living/fall_act(var/atom/hitting_atom)
-	var/gravity = get_gravity()
 	if(ismecha(hitting_atom))
-		var/damage = ((10 * min(hitting_atom.z_velocity,5)) * gravity)
+		var/damage = 10 * min(hitting_atom.z_velocity,5)
 		adjustBruteLoss(rand(3*damage, 5*damage))
 		AdjustKnockdown(damage / 2)
 	else if(isitem(hitting_atom))
@@ -139,7 +137,7 @@ var/global/list/non_items = list(/obj/machinery,/obj/structure)
 			gib()
 			return TRUE
 	else if(is_type_in_list(hitting_atom,non_items))
-		var/damage = ((3 * min(hitting_atom.z_velocity,5)) * gravity)
+		var/damage = 3 * min(hitting_atom.z_velocity,5)
 		if(hitting_atom.density)
 			damage *= 3
 		adjustBruteLoss(rand(damage, 2*damage))

--- a/code/modules/multiz/fall_hit.dm
+++ b/code/modules/multiz/fall_hit.dm
@@ -130,9 +130,9 @@ var/global/list/non_items = list(/obj/machinery,/obj/structure)
 		AdjustKnockdown(damage / 2)
 	else if(isitem(hitting_atom))
 		var/obj/item/I = hitting_atom
-		var/damage = (((I.throwforce * min(hitting_atom.z_velocity,5)) * gravity) * I.w_class)
+		var/damage = ((I.throwforce * min(hitting_atom.z_velocity,5)) * I.w_class)
 		adjustBruteLoss(rand(damage, 2*damage))
-		AdjustKnockdown(((2 * min(hitting_atom.z_velocity,5)) * gravity) * I.w_class)
+		AdjustKnockdown((2 * min(hitting_atom.z_velocity,5)) * I.w_class)
 		if(I.w_class == W_CLASS_GIANT)
 			gib()
 			return TRUE

--- a/code/modules/multiz/fall_hit.dm
+++ b/code/modules/multiz/fall_hit.dm
@@ -95,10 +95,6 @@
 
 		if(old_z_velocity > 2)
 			var/damage = 10 * min(old_z_velocity,5)
-			// Anything on the same tile as the landing tile is gonna have a bad day.
-			for(var/mob/living/L in hit_atom.contents)
-				visible_message("<span class='danger'>\The [src] crushes \the [L] as it lands on them!</span>")
-				L.fall_act(src)
 
 			// Now to hurt the mech.
 			take_damage(rand(damage, 3*damage))
@@ -107,10 +103,6 @@
 			if(istype(hit_atom, /turf/simulated/floor))
 				var/turf/simulated/floor/ground = hit_atom
 				ground.break_tile()
-	else
-		// Tell the pilot that they just plopped lightly onto the low-gravity ground with a superheavy mecha.
-		if(occupant)
-			to_chat(occupant, "<span class='warning'>\The [src] softly drops down onto \the [hit_atom]!</span>")
 	return TRUE
 
 /obj/machinery/power/supermatter/fall_impact(var/atom/hit_atom)

--- a/code/modules/multiz/fall_hit.dm
+++ b/code/modules/multiz/fall_hit.dm
@@ -27,7 +27,7 @@
 	for(var/atom/movable/AM in hit_atom.contents)
 		if(!AM.fall_act(src)) // FALSE breaks out of the normal actions
 			return FALSE
-	if(z_velocity > 1)
+	if(z_velocity > 2.5)
 		visible_message("<span class='warning'>\The [src] falls from above and slams into \the [hit_atom]!</span>", \
 			"<span class='danger'>You fall off and hit \the [hit_atom]!</span>", \
 			"You hear something slam into \the [hit_atom].")
@@ -49,8 +49,8 @@
 	var/obj/item/airbag/airbag = null
 	if(!mind || !mind.suiciding)
 		airbag = locate() in contents
-	if(old_z_velocity > 1 && !airbag)
-		if(old_z_velocity > 1.333)
+	if(old_z_velocity > 2.5 && !airbag)
+		if(old_z_velocity > 3.333)
 			playsound(loc, "sound/effects/pl_fallpain.ogg", 25, 1, -1)
 			// Bases at ten and scales with the number of Z levels fallen
 			// Because wounds heal rather quickly, 10 should be enough to discourage jumping off 1 ledge but not be enough to ruin you, at least for the first time.
@@ -69,7 +69,7 @@
 			log_debug("[src] has taken [total_brute_loss] damage after falling with a speed of [old_z_velocity] z-levels per second!")
 		AdjustKnockdown(3 * min(old_z_velocity,10))
 	else
-		if(airbag && old_z_velocity > 1)
+		if(airbag && old_z_velocity > 2.5)
 			airbag.deploy(src)
 	return TRUE
 
@@ -89,12 +89,12 @@
 	if(!..())
 		return FALSE
 	var/gravity = get_gravity()
-	if(old_z_velocity > 0.5)
+	if(old_z_velocity > 1.25)
 		// Tell the pilot that they just dropped down with a superheavy mecha.
 		if(occupant)
 			to_chat(occupant, "<span class='warning'>\The [src] crashed down onto \the [hit_atom]!</span>")
 
-		if(old_z_velocity > 1)
+		if(old_z_velocity > 2.5)
 			var/damage = ((10 * min(old_z_velocity,5)) * gravity)
 			// Anything on the same tile as the landing tile is gonna have a bad day.
 			for(var/mob/living/L in hit_atom.contents)

--- a/code/modules/multiz/fall_hit.dm
+++ b/code/modules/multiz/fall_hit.dm
@@ -24,32 +24,35 @@
 
 // Called by CheckFall when we actually hit something.  Oof
 /atom/movable/proc/fall_impact(var/atom/hit_atom)
-	if(get_gravity() > 0.5)
-		visible_message("\The [src] falls from above and slams into \the [hit_atom]!", "You hear something slam into \the [hit_atom].")
-	else
-		visible_message("\The [src] drops from above onto \the [hit_atom]!", "You hear something drop onto \the [hit_atom].")
 	for(var/atom/movable/AM in hit_atom.contents)
-		AM.fall_act(src)
-	zs_fallen = 0
+		if(!AM.fall_act(src)) // FALSE breaks out of the normal actions
+			return FALSE
+	if(get_gravity() > 0.5)
+		visible_message("<span class='warning'>\The [src] falls from above and slams into \the [hit_atom]!</span>", \
+			"<span class='danger'>You fall off and hit \the [hit_atom]!</span>", \
+			"You hear something slam into \the [hit_atom].")
+	else
+		visible_message("\The [src] drops from above and onto \the [hit_atom].", \
+			"You fall off and land on the \the [hit_atom].", \
+			"You hear something drop onto \the [hit_atom].")
+	z_velocity = 0
+	return TRUE
 
 // Take damage from falling and hitting the ground
-/mob/living/fall_impact(var/turf/landing)
+/mob/living/fall_impact(var/atom/hit_atom)
+	if(!..())
+		return FALSE
 	var/gravity = get_gravity()
 	var/total_brute_loss = 0
 	var/obj/item/airbag/airbag = null
 	if(!mind || !mind.suiciding)
 		airbag = locate() in contents
 	if(gravity > 0.5 && !airbag)
-		visible_message("<span class='warning'>\The [src] falls from above and slams into \the [landing]!</span>", \
-			"<span class='danger'>You fall off and hit \the [landing]!</span>", \
-			"You hear something slam into \the [landing].")
 		if(gravity > 0.667)
-			for(var/atom/movable/AM in landing.contents)
-				AM.fall_act(src)
 			playsound(loc, "sound/effects/pl_fallpain.ogg", 25, 1, -1)
 			// Bases at ten and scales with the number of Z levels fallen
 			// Because wounds heal rather quickly, 10 should be enough to discourage jumping off 1 ledge but not be enough to ruin you, at least for the first time.
-			var/damage = ((10 * min(zs_fallen,5)) * gravity)
+			var/damage = ((10 * min(z_velocity,5)) * gravity)
 			var/old_brute_loss = getBruteLoss()
 			apply_damage(rand(0, damage), BRUTE, LIMB_HEAD)
 			apply_damage(rand(0, damage), BRUTE, LIMB_CHEST)
@@ -61,15 +64,12 @@
 			if(mind && mind.suiciding)
 				adjustBruteLoss(max(0,175 - total_brute_loss)) // Makes the act look real
 				total_brute_loss = getBruteLoss() - old_brute_loss
-			log_debug("[src] has taken [total_brute_loss] damage after falling [zs_fallen] z levels with a gravity of [gravity] Gs!")
-		AdjustKnockdown((3 * min(zs_fallen,10)) * gravity)
+			log_debug("[src] has taken [total_brute_loss] damage after falling [z_velocity] z levels with a gravity of [gravity] Gs!")
+		AdjustKnockdown((3 * min(z_velocity,10)) * gravity)
 	else
 		if(airbag && gravity > 0.5)
 			airbag.deploy(src)
-		visible_message("\The [src] drops from above and onto \the [landing].", \
-			"You fall off and land on the \the [landing].", \
-			"You hear something drop onto \the [landing].")
-	zs_fallen = 0
+	return TRUE
 
 /obj/mecha/handle_fall(var/turf/landing)
 	// First things first, break any lattice
@@ -83,6 +83,8 @@
 	return ..()
 
 /obj/mecha/fall_impact(var/atom/hit_atom)
+	if(!..())
+		return FALSE
 	var/gravity = get_gravity()
 	if(gravity > 0.25)
 		// Tell the pilot that they just dropped down with a superheavy mecha.
@@ -90,7 +92,7 @@
 			to_chat(occupant, "<span class='warning'>\The [src] crashed down onto \the [hit_atom]!</span>")
 
 		if(gravity > 0.5)
-			var/damage = ((10 * min(zs_fallen,5)) * gravity)
+			var/damage = ((10 * min(z_velocity,5)) * gravity)
 			// Anything on the same tile as the landing tile is gonna have a bad day.
 			for(var/mob/living/L in hit_atom.contents)
 				visible_message("<span class='danger'>\The [src] crushes \the [L] as it lands on them!</span>")
@@ -107,7 +109,8 @@
 		// Tell the pilot that they just plopped lightly onto the low-gravity ground with a superheavy mecha.
 		if(occupant)
 			to_chat(occupant, "<span class='warning'>\The [src] softly drops down onto \the [hit_atom]!</span>")
-	zs_fallen = 0
+	z_velocity = 0
+	return TRUE
 
 /obj/machinery/power/supermatter/fall_impact(var/atom/hit_atom)
 	..()
@@ -117,24 +120,34 @@ var/global/list/non_items = list(/obj/machinery,/obj/structure)
 
 // Opposite of fall_impact, called when something is dropped on someone
 /atom/movable/proc/fall_act(var/atom/hitting_atom)
-	return
+	return TRUE
 
 /mob/living/fall_act(var/atom/hitting_atom)
 	var/gravity = get_gravity()
 	if(ismecha(hitting_atom))
-		var/damage = ((10 * min(hitting_atom.zs_fallen,5)) * gravity)
+		var/damage = ((10 * min(hitting_atom.z_velocity,5)) * gravity)
 		adjustBruteLoss(rand(3*damage, 5*damage))
 		AdjustKnockdown(damage / 2)
 	else if(isitem(hitting_atom))
 		var/obj/item/I = hitting_atom
-		var/damage = (((I.throwforce * min(hitting_atom.zs_fallen,5)) * gravity) * I.w_class)
+		var/damage = (((I.throwforce * min(hitting_atom.z_velocity,5)) * gravity) * I.w_class)
 		adjustBruteLoss(rand(damage, 2*damage))
-		AdjustKnockdown(((2 * min(hitting_atom.zs_fallen,5)) * gravity) * I.w_class)
+		AdjustKnockdown(((2 * min(hitting_atom.z_velocity,5)) * gravity) * I.w_class)
 		if(I.w_class == W_CLASS_GIANT)
 			gib()
+			return TRUE
 	else if(is_type_in_list(hitting_atom,non_items))
-		var/damage = ((3 * min(hitting_atom.zs_fallen,5)) * gravity)
+		var/damage = ((3 * min(hitting_atom.z_velocity,5)) * gravity)
 		if(hitting_atom.density)
 			damage *= 3
 		adjustBruteLoss(rand(damage, 2*damage))
 		AdjustKnockdown(damage / 2)
+	return TRUE
+
+/obj/effect/portal/fall_act(var/atom/hitting_atom)
+	if(ismovable(hitting_atom) && target)
+		var/atom/movable/AM = hitting_atom
+		teleport(hitting_atom)
+		AM.z_velocity *= -1 // reverse the momentum here
+		return FALSE
+	return TRUE

--- a/code/modules/multiz/falling.dm
+++ b/code/modules/multiz/falling.dm
@@ -35,7 +35,7 @@
 		return
 
 	fall_lock = TRUE
-	spawn(abs(10/(max(z_velocity,gravity)))) // Now we use a delay of 1 second divided by z velocity, with no possible zero
+	spawn(abs(10/(max(z_velocity,gravity*2.5)))) // Now we use a delay of 1 second divided by z velocity, with no possible zero
 		fall_lock = FALSE
 
 		var/turf/target = z_velocity < 0 ? check_above() : check_below()

--- a/code/modules/multiz/falling.dm
+++ b/code/modules/multiz/falling.dm
@@ -35,7 +35,7 @@
 		return
 
 	fall_lock = TRUE
-	spawn(abs(4/(max(z_velocity,gravity)))) // Now we use a delay of 8 ticks divided by z velocity, with no possible zero
+	spawn(abs(4/(max(z_velocity,gravity)))) // Now we use a delay of 4 ticks divided by z velocity, with no possible zero
 		fall_lock = FALSE
 
 		var/turf/target = z_velocity < 0 ? check_above() : check_below()

--- a/code/modules/multiz/falling.dm
+++ b/code/modules/multiz/falling.dm
@@ -35,13 +35,19 @@
 		return
 
 	fall_lock = TRUE
-	spawn((4 / gravity) / (min(z_velocity,1) / 4)) // Now we use a delay of 4 ticks divided by the gravity, affected by z velocity divided by 4
+	spawn(abs(4/(max(z_velocity,gravity)))) // Now we use a delay 4 divided by z velocity, with no possible zero
 		fall_lock = FALSE
 
 		var/turf/target = z_velocity < 0 ? check_above() : check_below()
 		// We're in a new loc most likely, so check all this again
 		if(!target)
-			return
+			if(z_velocity < 0)
+				z_velocity *= -1 // ceiling hit, no funni actions for this that seem workable yet
+				target = check_below()
+				if(!target)
+					return
+			else
+				return
 
 		if(!get_gravity())
 			return
@@ -159,7 +165,7 @@
 		return
 
 	if(z_velocity < 0)
-		z_velocity -= gravity
+		z_velocity += gravity
 	else if(z_velocity < (4/gravity))
 		z_velocity += (((gravity*4)-z_velocity)/2)
 

--- a/code/modules/multiz/falling.dm
+++ b/code/modules/multiz/falling.dm
@@ -35,7 +35,7 @@
 		return
 
 	fall_lock = TRUE
-	spawn(abs(4/(max(z_velocity,gravity)))) // Now we use a delay of 4 ticks divided by z velocity, with no possible zero
+	spawn(abs(10/(max(z_velocity,gravity)))) // Now we use a delay of 1 second divided by z velocity, with no possible zero
 		fall_lock = FALSE
 
 		var/turf/target = z_velocity < 0 ? check_above() : check_below()
@@ -167,8 +167,8 @@
 	// Velocity adjustment part goes here. TODO: Factor in air drag etc. eventually, maybe (or a more physics accurate formula)
 	if(z_velocity < 0) // Going upwards? Add gravity to the negative value until zero is reached
 		z_velocity += gravity
-	else if(z_velocity < (2/gravity)) // Down? Tend it towards a max of 2*gravity, halfway to the remainder each step
-		z_velocity += (((gravity*2)-z_velocity)/2)
+	else if(z_velocity < (5/gravity)) // Down? Tend it towards a max of 5*gravity, halfway to the remainder each step
+		z_velocity += (((gravity*5)-z_velocity)/2)
 
 	// If the turf has density, we give it first dibs
 	if (landing.density && landing.CheckFall(src))

--- a/code/modules/multiz/falling.dm
+++ b/code/modules/multiz/falling.dm
@@ -167,7 +167,7 @@
 	// Velocity adjustment part goes here. TODO: Factor in air drag etc. eventually, maybe (or a more physics accurate formula)
 	if(z_velocity < 0) // Going upwards? Add gravity to the negative value until zero is reached
 		z_velocity += gravity
-	else if(z_velocity < (5/gravity)) // Down? Tend it towards a max of 5*gravity, halfway to the remainder each step
+	else if(z_velocity < (5*gravity)) // Down? Tend it towards a max of 5*gravity, halfway to the remainder each step
 		z_velocity += (((gravity*5)-z_velocity)/2)
 
 	// If the turf has density, we give it first dibs

--- a/code/modules/multiz/falling.dm
+++ b/code/modules/multiz/falling.dm
@@ -35,7 +35,7 @@
 		return
 
 	fall_lock = TRUE
-	spawn(abs(4/(max(z_velocity,gravity)))) // Now we use a delay 4 divided by z velocity, with no possible zero
+	spawn(abs(8/(max(z_velocity,gravity)))) // Now we use a delay of 8 ticks divided by z velocity, with no possible zero
 		fall_lock = FALSE
 
 		var/turf/target = z_velocity < 0 ? check_above() : check_below()
@@ -164,10 +164,11 @@
 	if(!gravity) //Polaris uses a proc, has_gravity(), for this
 		return
 
-	if(z_velocity < 0)
+	// Velocity adjustment part goes here. TODO: Factor in air drag etc. eventually, maybe (or a more physics accurate formula)
+	if(z_velocity < 0) // Going upwards? Add gravity to the negative value until zero is reached
 		z_velocity += gravity
-	else if(z_velocity < (4/gravity))
-		z_velocity += (((gravity*4)-z_velocity)/2)
+	else if(z_velocity < (2/gravity)) // Down? Tend it towards a max of 2*gravity, halfway to the remainder each step
+		z_velocity += (((gravity*2)-z_velocity)/2)
 
 	// If the turf has density, we give it first dibs
 	if (landing.density && landing.CheckFall(src))

--- a/code/modules/multiz/falling.dm
+++ b/code/modules/multiz/falling.dm
@@ -35,7 +35,7 @@
 		return
 
 	fall_lock = TRUE
-	spawn(abs(8/(max(z_velocity,gravity)))) // Now we use a delay of 8 ticks divided by z velocity, with no possible zero
+	spawn(abs(4/(max(z_velocity,gravity)))) // Now we use a delay of 8 ticks divided by z velocity, with no possible zero
 		fall_lock = FALSE
 
 		var/turf/target = z_velocity < 0 ? check_above() : check_below()


### PR DESCRIPTION
[content][tweak]

## What this does
removes the "zs_fallen" var and replaces it with a velocity checker, affects the gravity calculations (caps at this times two)
enables upwards movement too, and adjusts collision with any portal to transfer downwards velocity into upwards

## Why it's good
portal momentum is fun, plus a cleaner situation

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Portals now invert vertical velocity if collided with, if there is room above. Otherwise, keep it downwards if there is room below.
 * tweak: All movable atoms now have vertical velocity, which eventually reaches a maximum allowed by gravity if downwards. Damage calculations have been adjusted to suit this better.