### PR TITLE
Fix biting attack logs

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -86,7 +86,7 @@
 	else
 		LAssailant = M
 		assaulted_by(M)
-	log_attack("[M.name] ([M.ckey]) bitten by [src.name] ([src.ckey])")
+	log_attack("[src.name] ([src.ckey]) bitten by [M.name] ([M.ckey])")
 
 	return
 


### PR DESCRIPTION
This fixes the biter and bitee having their roles reversed in biting attack logs.
Fixes #33904.