### PR TITLE
Makes syndicate members friendly to syndicate hostile mobs

### DIFF
--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -12,7 +12,6 @@
 /datum/role/traitor/OnPostSetup()
 	..()
 	antag.current.faction = "syndicate"
-	antag.mob_legacy_fac = "syndicate"
 	share_syndicate_codephrase(antag.current)
 	if(istype(antag.current, /mob/living/silicon))
 		can_be_smooth = FALSE //Can't buy anything
@@ -246,7 +245,6 @@
 /datum/role/nuclear_operative/OnPostSetup()
 	..()
 	antag.current.faction = "syndicate"
-	antag.mob_legacy_fac = "syndicate"
 
 /datum/role/nuclear_operative/leader
 	name = NUKE_OP_LEADER

--- a/code/datums/gamemode/role/syndicate.dm
+++ b/code/datums/gamemode/role/syndicate.dm
@@ -11,6 +11,8 @@
 
 /datum/role/traitor/OnPostSetup()
 	..()
+	antag.current.faction = "syndicate"
+	antag.mob_legacy_fac = "syndicate"
 	share_syndicate_codephrase(antag.current)
 	if(istype(antag.current, /mob/living/silicon))
 		can_be_smooth = FALSE //Can't buy anything
@@ -240,6 +242,11 @@
 	logo_state = "nuke-logo"
 	default_admin_voice = "The Syndicate"
 	admin_voice_style = "syndradio"
+
+/datum/role/nuclear_operative/OnPostSetup()
+	..()
+	antag.current.faction = "syndicate"
+	antag.mob_legacy_fac = "syndicate"
 
 /datum/role/nuclear_operative/leader
 	name = NUKE_OP_LEADER


### PR DESCRIPTION
[role]

## What this does
Traitors, challengers and nuclear operatives are now no longer attacked by any simplemob with the "syndicate" faction.

## Why it's good
Wizards already have this with hostile wizard mobs, so why not here.

## Changelog
:cl:
 * rscadd: Syndicate agents and operatives no longer get targeted by their own kind in deep space bases.