### PR TITLE
Fixed assistantslair.dmm causing runtimes

### DIFF
--- a/maps/randomvaults/assistantslair.dmm
+++ b/maps/randomvaults/assistantslair.dmm
@@ -435,7 +435,7 @@
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
 /obj/machinery/light/small{
-	dir = 4;
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/vault/assistantlair)
@@ -674,7 +674,7 @@
 	pixel_y = 8
 	},
 /obj/machinery/light/small{
-	dir = 4;
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/vault/assistantlair)
@@ -856,7 +856,7 @@
 /area/vault/assistantlair)
 "cL" = (
 /obj/machinery/light/small{
-	dir = 4;
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/vault/assistantlair)


### PR DESCRIPTION
[untested]

Thanks to all our big brains on the fix in #33920

## What this does
Preloader doesn't like semicolons in three spots, so this removes them

## Why it's good
- no more runtime