### PR TITLE
Adds a system to examines to show messages exclusively to admins

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -23,6 +23,7 @@ var/global/list/ghdel_profiling = list()
 	var/germ_level = 0 // The higher the germ level, the more germ on the atom.
 	var/penetration_dampening = 5 //drains some of a projectile's penetration power whenever it goes through the atom
 	var/throw_impact_sound = 'sound/weapons/genhit2.ogg'
+	var/admin_desc//Allows admins to see admin-exclusive examines, such as notifications for custom variables
 
 	///Chemistry.
 	var/datum/reagents/reagents = null
@@ -454,6 +455,9 @@ its easier to just keep the beam vertical.
 		to_chat(user, "[show_icon ? bicon(src) : ""] That's [f_name]" + size)
 	if(desc)
 		to_chat(user, desc)
+	if(admin_desc && user.client.holder?.admin_examine)
+		spawn(1) //Adding this so that it ends up at the end of any examine because some things add their own examine text
+			to_chat(user, "<span class='rough'>Admin-only: [admin_desc]</span>")
 
 	if(reagents && is_open_container() && !ismob(src) && !hide_own_reagents()) //is_open_container() isn't really the right proc for this, but w/e
 		if(get_dist(user,src) > 3)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -455,9 +455,6 @@ its easier to just keep the beam vertical.
 		to_chat(user, "[show_icon ? bicon(src) : ""] That's [f_name]" + size)
 	if(desc)
 		to_chat(user, desc)
-	if(admin_desc && user.client.holder?.admin_examine)
-		spawn(1) //Adding this so that it ends up at the end of any examine because some things add their own examine text
-			to_chat(user, "<span class='rough'>Admin-only: [admin_desc]</span>")
 
 	if(reagents && is_open_container() && !ismob(src) && !hide_own_reagents()) //is_open_container() isn't really the right proc for this, but w/e
 		if(get_dist(user,src) > 3)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -23,7 +23,7 @@ var/global/list/ghdel_profiling = list()
 	var/germ_level = 0 // The higher the germ level, the more germ on the atom.
 	var/penetration_dampening = 5 //drains some of a projectile's penetration power whenever it goes through the atom
 	var/throw_impact_sound = 'sound/weapons/genhit2.ogg'
-	var/admin_desc//Allows admins to see admin-exclusive examines, such as notifications for custom variables
+	var/admin_desc //Allows admins to see admin-exclusive examines, such as notifications for custom variables
 
 	///Chemistry.
 	var/datum/reagents/reagents = null

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1384,7 +1384,7 @@ var/global/floorIsLava = 0
 /datum/admins/proc/toggletintedweldhelmets()
 	set category = "Debug"
 	set desc="Reduces view range when wearing welding helmets"
-	set name="Toggle tinted welding helmes"
+	set name="Toggle tinted welding helmets"
 
 	tinted_weldhelh = !( tinted_weldhelh )
 	if (tinted_weldhelh)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -88,7 +88,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/artifacts_panel,
 	/client/proc/body_archive_panel,
 	/client/proc/climate_panel,
-	/datum/admins/proc/ashInvokedEmotions	/*Ashes all paper from the invoke emotion spell. An emergency purge.*/
+	/datum/admins/proc/ashInvokedEmotions,	/*Ashes all paper from the invoke emotion spell. An emergency purge.*/
+	/client/proc/toggle_admin_examine
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -1360,4 +1361,14 @@ var/list/admin_verbs_mod = list(
 	if(holder)
 		holder.ViewAllRods()
 	feedback_add_details("admin_verb","V-ROD") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	return
+
+/client/proc/toggle_admin_examine()
+	set name = "Toggle Admin-only Descriptions"
+	set category = "Admin"
+	set desc = "See admin-only text for certain objects."
+	if(holder)
+		holder.admin_examine = !(holder.admin_examine)
+		to_chat(usr, "<span class='notice'>You toggle [holder.admin_examine ? "on" : "off"] admin examining.")
+	feedback_add_details("admin_verb","admin_examine")
 	return

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -5,6 +5,7 @@ var/list/admin_datums = list()
 	var/client/owner	= null
 	var/rights = 0
 	var/fakekey			= null
+	var/admin_examine   = 1 //If on, allows the admin to see additional examine messages.
 
 	var/datum/marked_datum
 	var/atom/marked_appearance //Reference to an atom or an image

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -7,6 +7,7 @@ var/creating_arena = FALSE
 /mob/dead/observer
 	name = "ghost"
 	desc = "It's a g-g-g-g-ghooooost!" //jinkies!
+	admin_desc = "The 'manual_poltergeist_cooldown' variable allows the cooldown of the ghost's poltergeist activities (such as flicking lightswitches) to be modified in a decisecond format (10 is 1 second). Set it to null to restore the cooldown to the global poltergeist variable (by default 30 seconds)."
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "ghost1"
 	stat = DEAD

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1,3 +1,6 @@
+/mob/living/carbon
+	admin_desc = "The 'manual_emote_sound_override' variable can be set to 1 to enable a character to scream audibly whenever they want."
+
 /mob/living/carbon/Login()
 	..()
 	update_hud()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -4,9 +4,6 @@
 /mob/living/carbon/human/examine(mob/user)
 	var/msg = get_examine_text(user)
 	to_chat(user, msg)
-	if(admin_desc && user.client.holder?.admin_examine)
-		spawn(1) //To make sure it appears at the end of the examine
-			to_chat(user, "<span class='rough'>Admin-only: [admin_desc]</span>")
 	if(istype(user))
 		user.heard(src)
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -4,6 +4,9 @@
 /mob/living/carbon/human/examine(mob/user)
 	var/msg = get_examine_text(user)
 	to_chat(user, msg)
+	if(admin_desc && user.client.holder?.admin_examine)
+		spawn(1) //To make sure it appears at the end of the examine
+			to_chat(user, "<span class='rough'>Admin-only: [admin_desc]</span>")
 	if(istype(user))
 		user.heard(src)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1175,6 +1175,8 @@ Use this proc preferably at the end of an equipment loadout
 
 	face_atom(A)
 	A.examine(src)
+	if(A.admin_desc && src.client?.holder?.admin_examine)
+		to_chat(src, "<span class='rough'>Admin-only: [A.admin_desc]</span>")
 
 	if(istype(src,/mob/living))
 		var/mob/living/L = src


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41342767/210091967-37f955e4-db03-473d-acfc-726d85c1a356.png)

Now you (assuming you're a coder) can leave useful tips for admins. I started off the system by including a bunch of my personal additions (#25714 and #25790) for ghosts and carbons because what would the point be without any entries? And I don't know too much about other features. You can just write things into the new admin_desc variable and the admins will see it when they examine it.
The message itself is in a font called "rough" and is prefixed with "Admin-only:".
If an admin doesn't want to be shown the admin-only messages there is now a toggle for that under the Admin tab called "Toggle Admin-only Descriptions". Frankly I don't know what the difference is between /datum/admins/proc and /client/proc because it's used pretty interchangeably in the code.
I tested it.
Fixes a typo for toggling welding helmet vision dimming, it's "helmets" not "helmes".

I should probably turn this system into a proc rather than a description variable for more flexibility.

:cl:
 * rscadd: Admins now have access to admin-exclusive descriptions.
