### PR TITLE
Fixes Switchtool + RND Fab Runtimes.

### DIFF
--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -114,11 +114,11 @@
 		else
 			index--
 		if (index > stored_modules.len)
-			index = 0
-		if(index < 0)
+			index = 1
+		if(index < 1)
 			index = stored_modules.len
 		var/moduled = stored_modules[index]
-		undeploy()
+		undeploy(user)
 		deploy(moduled, user)
 		edit_deploy(1)
 

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -203,6 +203,9 @@ var/global/list/rnd_machines = list()
 		icon_state = "[base_state]"
 
 		var/datum/material/material = materials.getMaterial(found)
+		if(material == 0)
+			busy = FALSE
+			return 1
 		materials.addAmount(found, amount * material.cc_per_sheet)
 		spawn(ANIM_LENGTH)
 			busy = FALSE
@@ -290,6 +293,9 @@ var/global/list/rnd_machines = list()
 		icon_state = "[base_state]"
 
 		var/datum/material/material = materials.getMaterial(found)
+		if(material == 0)
+			busy = FALSE
+			return 1
 		materials.addAmount(found, amount * material.cc_per_sheet)
 		spawn(ANIM_LENGTH)
 			busy = FALSE


### PR DESCRIPTION
## What this does
Fixes two runtimes that occur when using the Shift + Scroll on a switchtool. They had no ingame impact but spammed the runtime logs.

Also probably fixes a bug that locks RND machines in the busy state, rendering them inoperable without admin intervention.
I couldn't replicate what exact situation causes this runtime, so I couldn't test but this should fix the issue I think.
Probably something to do with, trying to insert sheets with both ALT + Click and the normal input method at the same time.

Fixes: #33624

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixes a bug that gets RND machines stuck in the busy state.

