### PR TITLE
Adds GPS Alt Click + Turret Panel CTRL + Click to Lock

### DIFF
--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -521,6 +521,11 @@
 	return ..()
 
 /obj/machinery/turretid/CtrlClick(mob/user) //Lock the device
+	if(!(user) || !isliving(user)) //BS12 EDIT
+		return FALSE
+	if(user.incapacitated() || !Adjacent(user))
+		return FALSE
+
 	if(stat & (NOPOWER|BROKEN|FORCEDISABLE))
 		return
 	if(allowed(user))

--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -423,6 +423,10 @@
 		return 1
 	return
 
+/obj/machinery/turretid/AltClick(mob/user)
+	src.attackby(user.get_active_hand(), user)
+
+
 /obj/machinery/turretid/attackby(obj/item/weapon/W, mob/user)
 	if(stat & (BROKEN|FORCEDISABLE))
 		return

--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -423,10 +423,6 @@
 		return 1
 	return
 
-/obj/machinery/turretid/AltClick(mob/user)
-	src.attackby(user.get_active_hand(), user)
-
-
 /obj/machinery/turretid/attackby(obj/item/weapon/W, mob/user)
 	if(stat & (BROKEN|FORCEDISABLE))
 		return
@@ -523,6 +519,13 @@
 		updateTurrets()
 		return
 	return ..()
+
+/obj/machinery/turretid/CtrlClick(mob/user) //Lock the device
+	if(stat & (NOPOWER|BROKEN|FORCEDISABLE))
+		return
+	if(allowed(user))
+		locked = !locked
+		to_chat(usr, "<span class='notice'>You [locked ? "lock" : "unlock"] the switchboard panel.</span>")
 
 //All AI shortcuts. Basing this on what airlocks do, so slight clash with user (Alt is dangerous so toggle stun/lethal, Ctrl is bolts so lock, Shift is 'open' so toggle turrets)
 /obj/machinery/turretid/AIAltClick(mob/living/silicon/ai/user) //Stun/lethal toggle

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -72,12 +72,6 @@ var/list/all_GPS_list = list()
 		..()
 
 /obj/item/device/gps/AltClick(mob/user)
-	if(transmitting)
-		transmitting = FALSE
-		update_icon()
-		to_chat(usr, "Hi2")
-		return
-	to_chat(usr, "Hi")
 	transmitting = TRUE
 	update_icon()
 

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -71,6 +71,16 @@ var/list/all_GPS_list = list()
 	else
 		..()
 
+/obj/item/device/gps/AltClick(mob/user)
+	if(transmitting)
+		transmitting = FALSE
+		update_icon()
+		to_chat(usr, "Hi2")
+		return
+	to_chat(usr, "Hi")
+	transmitting = TRUE
+	update_icon()
+
 /obj/item/device/gps/proc/get_location_name()
 	var/turf/device_turf = get_turf(src)
 	var/area/device_area = get_area(src)

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -72,6 +72,10 @@ var/list/all_GPS_list = list()
 		..()
 
 /obj/item/device/gps/AltClick(mob/user)
+	if(!(user) || !isliving(user)) //BS12 EDIT
+		return FALSE
+	if(user.incapacitated() || !Adjacent(user))
+		return FALSE
 	transmitting = TRUE
 	update_icon()
 


### PR DESCRIPTION
## What this does
You can now ALT + Click to toggle a GPS on.

You can now CTRL + Click to Lock/Unlock the turret control panel. For example the one outside the AI core.

## Why it's good
Handy shortcuts which cut click intensity for common tasks.

## Changelog
:cl:
 * rscadd: You can now ALT + Click to toggle a GPS on.
 * rscadd: You can now CTRL + Click to Lock/Unlock the turret control panel

