### PR TITLE
Fixes AI/Borg Upload Lockbox Permissons

### DIFF
--- a/code/modules/research/designs/boards/computer_command.dm
+++ b/code/modules/research/designs/boards/computer_command.dm
@@ -10,7 +10,7 @@
 	category = "Console Boards"
 	build_path = /obj/item/weapon/circuitboard/aiupload
 	locked = 1
-	req_lock_access = list(access_rd, access_ce)
+	req_lock_access = list(access_ai_upload)
 
 /datum/design/aiupload/longrange
 	name = "Circuit Design (Long Range AI Upload)"
@@ -30,7 +30,7 @@
 	category = "Console Boards"
 	build_path = /obj/item/weapon/circuitboard/borgupload
 	locked = 1
-	req_lock_access = list(access_rd, access_ce)
+	req_lock_access = list(access_ai_upload)
 
 /datum/design/comconsole
 	name = "Circuit Design (Communications)"

--- a/code/modules/research/designs/boards/computer_command.dm
+++ b/code/modules/research/designs/boards/computer_command.dm
@@ -10,7 +10,7 @@
 	category = "Console Boards"
 	build_path = /obj/item/weapon/circuitboard/aiupload
 	locked = 1
-	req_lock_access = list(access_rnd, access_robotics, access_rd)
+	req_lock_access = list(access_rd, access_ce)
 
 /datum/design/aiupload/longrange
 	name = "Circuit Design (Long Range AI Upload)"
@@ -30,7 +30,7 @@
 	category = "Console Boards"
 	build_path = /obj/item/weapon/circuitboard/borgupload
 	locked = 1
-	req_lock_access = list(access_rnd, access_robotics, access_rd)
+	req_lock_access = list(access_rd, access_ce)
 
 /datum/design/comconsole
 	name = "Circuit Design (Communications)"


### PR DESCRIPTION
## What this does
Changes the permissions on AI/Borg Upload Circuitboard lockboxes to, AI upload access access only.

## Why it's good
Roboticist & Normal scientist have no access to the core or the secure part of storage so this was likely an oversight that has gone unnoticed. If antags want a board they can just drill/emag anyway.

Fixes: #33903

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Changes the permissions on AI/Borg Upload Circuitboard lockboxes to AI upload.

