### PR TITLE
Mechanics don't count towards Engineering Staff count for Events

### DIFF
--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -114,7 +114,7 @@ var/list/event_last_fired = list()
 					if("security robot module")
 						active_with_role["Security"]++
 
-		if(M.mind.assigned_role in engineering_positions)
+		if(M.mind.assigned_role in engineering_positions && M.mind.assigned_role != "Mechanic")
 			active_with_role["Engineer"]++
 
 		if(M.mind.assigned_role in medical_positions)


### PR DESCRIPTION
## What this does
Mechanics don't count towards Engineering Staff count for Engineering Events, such as rods & meteors.

## Why it's good
Mechanics are part of both Engineering and Science, it's hard to see why having a spacepod mechanic should result in a greater chance of meteors or rods spawning. Too often, does a large meteor storm hit the station with only one actual Engineer.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Mechanics don't count towards Engineering Staff count for Engineering Events, such as rods & meteors.
 