### PR TITLE
Station atmos issues roundend score

### DIFF
--- a/code/game/gamemodes/endgame/scoreboard/department_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/department_score.dm
@@ -59,9 +59,20 @@
 	if(!score.powerloss) //No APCs with bad power
 		score.powerbonus = 2500
 
+	for(var/obj/machinery/alarm/A2 in air_alarms)
+		if(A2.z != map.zMainStation)
+			continue
+		var/area/this_area = get_area(A2)
+		if(max(A2.local_danger_level, this_area.atmosalm-1) > 0)
+			score.atmoloss++ //Red or yellow light means bad
+	if(!score.atmoloss) //No air alarms with issues
+		score.atmobonus = 2500
+
 	//crewscore
 	score.crewscore -= score.powerloss * 50 //Power issues are BAD, they mean the Engineers aren't doing their job at all
 	score.crewscore += score.powerbonus
+	score.crewscore -= score.atmoloss * 50 //You too, atmos techs
+	score.crewscore += score.atmobonus
 
 /datum/controller/gameticker/scoreboard/proc/service_score()
 	//Janitor

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -10,6 +10,7 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	var/oremined			= 0 //How many chunks of ore were smelted
 	var/eventsendured		= 0 //How many random events did the station endure?
 	var/powerloss			= 0 //How many APCs have alarms (under 30 %)?
+	var/atmoloss			= 0 //How many air alarms are giving issues?
 	var/maxpower			= 0 //Most watts in grid on any of the world's powergrids.
 	var/escapees			= 0 //How many people got out alive?
 	var/deadcrew			= 0 //Humans who died during the round
@@ -30,6 +31,7 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 
 	//These ones are mainly for the stat panel
 	var/powerbonus			= 0 //If all APCs on the station are running optimally, big bonus
+	var/atmobonus			= 0 //If all air alarms on the station are running optimally, big bonus
 	var/messbonus			= 0 //If there are no messes on the station anywhere, huge bonus
 	var/deadaipenalty		= 0 //AIs who died during the round
 	var/foodeaten			= 0 //How much food was consumed
@@ -137,6 +139,7 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	if(score.oremined > 0)
 		dat += "<B>Ore Smelted:</B> [score.oremined] ([score.oremined] Points)<BR>"
 	dat += "<B>Whole Station Powered:</B> [score.powerbonus ? "Yes" : "No"] ([score.powerbonus] Points)<BR>"
+	dat += "<B>Whole Station Airtight:</B> [score.atmobonus ? "Yes" : "No"] ([score.atmobonus] Points)<BR>"
 	if (score.disease_vaccine_score > 0)
 		dat += "<B>Isolated Vaccines:</B> [score.disease_vaccine] ([score.disease_vaccine_score] Points)<BR>"
 	if (score.disease_extracted > 0)
@@ -161,6 +164,8 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 		dat += "<B>Cargo Crates Not Forwarded:</B> [score.stuffnotforwarded] (-[score.stuffnotforwarded * 25] Points)<BR>"
 	if (score.powerloss > 0)
 		dat += "<B>Station Power Issues:</B> [score.powerloss] (-[score.powerloss * 50] Points)<BR>"
+	if (score.atmoloss > 0)
+		dat += "<B>Station Atmospheric Issues:</B> [score.atmoloss] (-[score.atmoloss * 50] Points)<BR>"
 	if(score.turfssingulod > 0)
 		dat += "<B>Tiles destroyed by a singularity:</B> [score.turfssingulod] (-[round(score.turfssingulod/2)] Points)<BR>"
 	if(score.disease_bad > 0)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -186,6 +186,7 @@ var/global/list/airalarm_presets = list(
 	"Plasmaman" = new /datum/airalarm_preset/plasmaman,
 	"Vacuum" = new /datum/airalarm_preset/vacuum,
 )
+var/global/list/air_alarms = list()
 
 /obj/machinery/alarm
 	desc = "An alarm used to control the area's atmospherics systems."
@@ -310,6 +311,7 @@ var/global/list/airalarm_presets = list(
 	var/area/this_area = get_area(src)
 	if(src in this_area.air_alarms)
 		this_area.air_alarms.Remove(src)
+	air_alarms -= src
 	..()
 
 /obj/machinery/alarm/proc/first_run()
@@ -317,6 +319,7 @@ var/global/list/airalarm_presets = list(
 	area_uid = this_area.uid
 	name = "[this_area.name] Air Alarm"
 	this_area.air_alarms.Add(src)
+	air_alarms += src
 
 	// breathable air according to human/Life()
 	/*


### PR DESCRIPTION
## What this does
adds a score system similar to the power one, where a whole station "airtight" (ie no atmos issues) gives a 2500 point bonus, and every atmos issue gives 100 docked. can change these on request.

## Why it's good
encourages good atmos management.

## Changelog
:cl:
 * rscadd: Roundend scores now factor in atmospheric issues, with a bonus for none.