### PR TITLE
Meteors, Rods, Vines, Powercreeper & Carp do not fire during low pop.

### DIFF
--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -3,8 +3,10 @@
 	endWhen = 450
 	var/list/spawned_carp = list()
 
-/datum/event/carp_migration/can_start()
-	return 40
+/datum/event/carp_migration/can_start(var/list/active_with_role)
+	if(active_with_role.len > 6)
+		return 40
+	return 0
 
 /datum/event/carp_migration/setup()
 	announceWhen = rand(15, 30)

--- a/code/modules/events/immovablerod.dm
+++ b/code/modules/events/immovablerod.dm
@@ -10,12 +10,12 @@ var/list/all_rods = list()
 	announceWhen = 1
 
 /datum/event/immovable_rod/can_start(var/list/active_with_role)
-	if(active_with_role["Engineer"] > 1)
+	if(active_with_role["Engineer"] > 1 && active_with_role.len > 6)
 		return 15
 	return 0
 
 /datum/event/immovable_rod/big/can_start(var/list/active_with_role)
-	if(active_with_role["Engineer"] > 2)
+	if(active_with_role["Engineer"] > 2 && active_with_role.len > 6)
 		return 15
 	return 0
 

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -9,7 +9,7 @@
 	endWhen			= 30
 
 /datum/event/meteor_wave/can_start(var/list/active_with_role)
-	if(active_with_role["Engineer"] > 1)
+	if(active_with_role["Engineer"] > 1 && active_with_role.len > 6)
 		return 15
 	return 0
 
@@ -34,7 +34,7 @@
 	endWhen 		= 30
 
 /datum/event/meteor_shower/can_start(var/list/active_with_role)
-	if(active_with_role["Engineer"] > 1)
+	if(active_with_role["Engineer"] > 1 && active_with_role.len > 6)
 		return 40
 	return 0
 

--- a/code/modules/events/powercreeper.dm
+++ b/code/modules/events/powercreeper.dm
@@ -1,7 +1,9 @@
 /datum/event/powercreeper
 
 /datum/event/powercreeper/can_start()
-	return 15
+	if(active_with_role["Engineer"] > 1)
+		return 15
+	return 0
 
 /datum/event/powercreeper/start()
 	spawn()

--- a/code/modules/events/powercreeper.dm
+++ b/code/modules/events/powercreeper.dm
@@ -1,7 +1,7 @@
 /datum/event/powercreeper
 
-/datum/event/powercreeper/can_start()
-	if(active_with_role["Engineer"] > 1)
+/datum/event/powercreeper/can_start(var/list/active_with_role)
+	if(active_with_role["Engineer"] > 1 && active_with_role.len > 6)
 		return 15
 	return 0
 

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -1,7 +1,9 @@
 /datum/event/spacevine
 
 /datum/event/spacevine/can_start()
-	return 20
+	if(active_with_role.len > 6)
+		return 20
+	return 0
 
 /datum/event/spacevine/start()
 	spacevine_infestation()
@@ -9,7 +11,9 @@
 /datum/event/biomass
 
 /datum/event/biomass/can_start()
-	return 15
+	if(active_with_role.len > 6)
+		return 15
+	return 0
 
 /datum/event/biomass/start()
 	biomass_infestation()

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -1,6 +1,6 @@
 /datum/event/spacevine
 
-/datum/event/spacevine/can_start()
+/datum/event/spacevine/can_start(var/list/active_with_role)
 	if(active_with_role.len > 6)
 		return 20
 	return 0
@@ -10,7 +10,7 @@
 
 /datum/event/biomass
 
-/datum/event/biomass/can_start()
+/datum/event/biomass/can_start(var/list/active_with_role)
 	if(active_with_role.len > 6)
 		return 15
 	return 0


### PR DESCRIPTION
## What this does
The following events no longer fire when the active population is 5 or below players.
Meteors, Powercreeper, Spacevines, Biomass & Space carp migration.
Also adds a requirement for 2 or more Engineers for powercreeper to fire.
## Why it's good
This has been requested by low pop players before,
These events just fire endlessly when the server is empty gunking it up, which often leads to a shuttle call & 20~ minute wait if you are the first player joining, or only active player.
They aren't particularly engaging at lower population levels when there isn't the resources/will to properly fight them.

## Changelog
:cl:
 * tweak: Meteors, Powercreeper, Spacevines, Biomass & Space carp migration no longer fire at 5 pop or below.
 * tweak: Adds a requirement for 2 or more Engineers for powercreeper to fire.