### PR TITLE
Mecha Scythe Powercreeper fix

### DIFF
--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -309,7 +309,8 @@
 			for(var/obj/structure/cable/powercreeper/C in range(chassis,i == 4 ? 2 : 1))
 				if(get_dir(chassis,C)&chassis.dir || C.loc == get_turf(chassis))
 					if(istype(C, /obj/structure/cable/powercreeper))
-						C.die()
+						spawn(0)
+							C.die()
 						eradicated++
 			sleep(3)
 		if(eradicated)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Makes it so mech scything creeper isnt awfully slow waiting for the animation of the creeper to die before it cuts the next one.

## Why it's good
<!-- Explain why you think these changes are good. -->
Fixes #33533
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:

 * bugfix: Mechscything powercreeper isn't painfully slow anymore.

