### PR TITLE
Tweaks alt-clicking tiles to allow seeing the list of entities when in range instead of adjacent

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -320,7 +320,7 @@
 
 /atom/proc/AltClick(var/mob/user)
 	var/turf/T = get_turf(src)
-	if(T && (T in range(1, user)))
+	if(T && (T in range(1, user.loc)) && (T in view(1, user.virtualhearer))) //If next to user's location (to allow locker and mech alt-clicks) and if the user can actually view it
 		if(user.listed_turf == T)
 			user.listed_turf = null
 		else

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -320,7 +320,7 @@
 
 /atom/proc/AltClick(var/mob/user)
 	var/turf/T = get_turf(src)
-	if(T && T.Adjacent(user))
+	if(T && (T in range(1, user)))
 		if(user.listed_turf == T)
 			user.listed_turf = null
 		else

--- a/code/game/objects/structures/fullwindow.dm
+++ b/code/game/objects/structures/fullwindow.dm
@@ -77,15 +77,6 @@
 				dir = NORTHWEST
 		update_nearby_tiles()
 
-/obj/structure/window/full/AltClick(var/mob/user)
-	. = ..()
-	var/turf/T = loc
-	if (istype(T))
-		if (user.listed_turf == T)
-			user.listed_turf = null
-		else
-			user.listed_turf = T
-			user.client.statpanel = T.name
 
 /obj/structure/window/full/clockworkify()
 	GENERIC_CLOCKWORK_CONVERSION(src, /obj/structure/window/full/reinforced/clockwork, BRASS_FULL_WINDOW_GLOW)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -268,14 +268,6 @@
 
 	reset_vars_after_duration(resettable_vars, duration)
 
-/obj/structure/grille/AltClick(var/mob/user)
-	var/turf/T = loc
-	if (istype(T))
-		if (user.listed_turf == T)
-			user.listed_turf = null
-		else
-			user.listed_turf = T
-			user.client.statpanel = T.name
 
 //Mapping entities and alternatives !
 


### PR DESCRIPTION
Changed the adjacency (can the user click on this tile?) check with a range (is the user within the range of the tile?) check and a view (can the user see the tile [although the user in this case is the "virtual hearer" that has the same sight/hear values as the user, except that it works if the user is in a container]?) check. This means you can alt-click past tiles that would otherwise be blocked by windoors/barricades and with no other functional difference.
Removed window/grille alt-click code that would be redundant with this change.
I wanted to make it look all snazzy by just greying out unreachable objects but I couldn't figure out how to do that. If someone else knows how to do that that would be great.

:cl:
 * tweak: Alt-clicking to reveal a list of things on a tile has been tweaked, and it now allows you to alt-click past windoors and barricades to see all the entities inside the alt-clicked tile.