### PR TITLE
Xenomorph tweaks (Updated)

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -405,7 +405,7 @@
 					if(W_CLASS_LARGE)
 						melting_speed = 2 //8-10 seconds between ticks
 					else
-						melting_speed = 1
+						melting_speed = 1 //15-20 seconds between ticks
 	tick()
 
 /obj/effect/alien/acid/proc/tick()

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -395,17 +395,7 @@
 		if(isobj(target))
 			var/obj/O = target
 			if(O.w_class && O.w_class < W_CLASS_HUGE)
-				switch(O.w_class) //There has to be a math function for this
-					if(W_CLASS_TINY)
-						melting_speed = 5 //3-4 seconds between ticks
-					if(W_CLASS_SMALL)
-						melting_speed = 4 //4-5 seconds between ticks
-					if(W_CLASS_MEDIUM)
-						melting_speed = 3 //5-7 seconds between ticks
-					if(W_CLASS_LARGE)
-						melting_speed = 2 //8-10 seconds between ticks
-					else
-						melting_speed = 1 //15-20 seconds between ticks
+				melting_speed = 6 - O.w_class //Tiny w_class will melt 5x faster
 	tick()
 
 /obj/effect/alien/acid/proc/tick()

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -370,6 +370,7 @@
 	var/atom/target
 	var/ticks = 0
 	var/target_strength = 0
+	var/melting_speed = 1 //A multiplier, divides the time between acid ticks by the number.
 
 /obj/effect/alien/acid/hyper
 	name = "hyper acid"
@@ -391,6 +392,20 @@
 		target_strength = 8
 	else
 		target_strength = 4
+		if(isobj(target))
+			var/obj/O = target
+			if(O.w_class && O.w_class < W_CLASS_HUGE)
+				switch(O.w_class) //There has to be a math function for this
+					if(W_CLASS_TINY)
+						melting_speed = 5 //3-4 seconds between ticks
+					if(W_CLASS_SMALL)
+						melting_speed = 4 //4-5 seconds between ticks
+					if(W_CLASS_MEDIUM)
+						melting_speed = 3 //5-7 seconds between ticks
+					if(W_CLASS_LARGE)
+						melting_speed = 2 //8-10 seconds between ticks
+					else
+						melting_speed = 1
 	tick()
 
 /obj/effect/alien/acid/proc/tick()
@@ -416,7 +431,8 @@
 			visible_message("<span class='good'><B>[src.target] is struggling to withstand the acid!</B></span>")
 		if(0 to 1)
 			visible_message("<span class='good'><B>[src.target] begins to crumble under the acid!</B></span>")
-	spawn(rand(150, 200)) tick()
+	spawn(round(rand(150, 200)/melting_speed, 1))
+		tick()
 
 /atom/proc/acid_act()
 

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -227,7 +227,7 @@ Doesn't work on other aliens/AI.*/
 
 /spell/corrosive_acid/cast(list/targets, mob/user)
 	var/target = targets[1]
-	user.visible_message("<span class='alien'>\The [user] vomits globs of vile stuff all over [target]! It begins to sizzle and melt under the bubbling mess of acid!</span>")
+	user.visible_message("<span class='alien'>\The [user] vomits globs of vile stuff all over \the [target]! It begins to sizzle and melt under the bubbling mess of acid!</span>")
 	if(isobj(target))
 		var/obj/T = target
 		if(T.w_class && T.w_class <= W_CLASS_HUGE)

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -196,9 +196,11 @@ Doesn't work on other aliens/AI.*/
 	spell_flags = IGNORESPACE|IGNOREDENSE|NODUPLICATE
 	full_list = list("Resin Door" = /obj/machinery/door/mineral/resin,"Resin Wall" = /obj/effect/alien/resin/wall,"Resin Membrane" = /obj/effect/alien/resin/membrane,"Resin Nest" = /obj/structure/bed/nest)
 
+#define ACID_COST 40
+
 /spell/corrosive_acid
 	name = "Corrosive Acid"
-	desc = "Drench an object in acid, destroying it over time."
+	desc = "Drench an object in acid, destroying it over time. It acts faster the smaller the object is and will also refund some plasma depending on the size of it, up to 160 plasma for tiny objects."
 	user_type = USER_TYPE_XENOMORPH
 	panel = "Alien"
 	hud_state = "alien_acid"
@@ -224,8 +226,17 @@ Doesn't work on other aliens/AI.*/
 	return FALSE
 
 /spell/corrosive_acid/cast(list/targets, mob/user)
-	user.visible_message("<span class='alien'>\The [user] vomits globs of vile stuff all over [targets[1]]! It begins to sizzle and melt under the bubbling mess of acid!</span>")
-	new /obj/effect/alien/acid(get_turf(targets[1]), targets[1])
+	var/target = targets[1]
+	user.visible_message("<span class='alien'>\The [user] vomits globs of vile stuff all over [target]! It begins to sizzle and melt under the bubbling mess of acid!</span>")
+	if(isobj(target))
+		var/obj/T = target
+		if(T.w_class && T.w_class <= W_CLASS_HUGE)
+			var/mob/living/carbon/alien/A = user
+			if(istype(A))
+				var/cost = ACID_COST * T.w_class
+				to_chat(user, "<span class='good'>You regain <b>[holder_var_amount - cost]</b> plasma.</span>")
+				A.plasma += holder_var_amount - cost
+	new /obj/effect/alien/acid(get_turf(target), target)
 
 /spell/aoe_turf/alienregurgitate
 	name = "Regurgitate"

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -9,7 +9,7 @@
 	health = 25
 	plasma = 50
 	max_plasma = 50
-	size = SIZE_TINY
+	size = SIZE_SMALL
 
 	var/growth = 0
 	var/time_of_birth

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -252,7 +252,7 @@
 			can_eat = TRUE
 			just_gib = TRUE //by order of Chicken
 			nutriadd = 100 //TODO: Adjust to fit what they'd get via the old handle_stomach proc
-		else if(isalien(user) && iscarbon(affecting) && !isalien(affecting))
+		else if(isalien(user) && iscarbon(affecting))
 			can_eat = TRUE
 		if(can_eat)
 			var/mob/living/carbon/attacker = user

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -252,7 +252,7 @@
 			can_eat = TRUE
 			just_gib = TRUE //by order of Chicken
 			nutriadd = 100 //TODO: Adjust to fit what they'd get via the old handle_stomach proc
-		else if(isalien(user) && iscarbon(affecting))
+		else if(isalien(user) && iscarbon(affecting) && !isalien(affecting))
 			can_eat = TRUE
 		if(can_eat)
 			var/mob/living/carbon/attacker = user


### PR DESCRIPTION
- The alien larva is no longer tiny, but instead small, allowing them to activate doors and airlocks.

Putting the most significant change up at the front. Initially the intent was to allow xeno larvae to walk through a nest by being able to open all the resin doors laying around without needing help, but then I thought about the actual size of the xeno larvae or "chestburster", which is according to [Xenopedia](https://avp.fandom.com/wiki/Chestburster) "1 foot tall and 2 feet long", they're significantly larger than mice. Wirecutters in the game are a small (larger than tiny) item. Thus the intent changed to just categorizing the larvae as small rather than tiny.

- The xenomorph acid now acts faster the smaller the object is, and also refunds some of its cost depending on the size.

The acid is a powerful structure buster to allow xeno containments to fail but when it comes to actually getting rid of any garbage laying around it does a terrible job. It takes too long and it consumes too much plasma. Despite having an initially high plasma cost it will immediately get refunded depending on how small the object is. Consoles and airlocks and walls and such are unaffected, and so are "huge" items (bulky items are one step below huge).
Tiny items will melt 5x faster and refund 160 plasma. Small items will melt 4x faster and refund 120 plasma. Normal-sized items will melt 3x faster and refund 80 plasma. Bulky items will melt 2x faster and refund 40 plasma.

:cl:
 * tweak: Xenomorph larvae are a bit larger, allowing them to open doors including airlocks and resin doors.
 * tweak: The xenomorph's corrosive acid has been significantly improved against smaller objects, not only melting faster the smaller the object is but also refunding some of the plasma cost the smaller the item is (but it still initially costs 200 plasma).
