### PR TITLE
Tool Belt can now Hold Station bounced Radios, Construction Permits & GPS's

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -46,7 +46,10 @@
 		"/obj/item/device/device_analyser",
 		"/obj/item/device/silicate_sprayer",
 		"/obj/item/device/geiger_counter",
-		"/obj/item/airshield_projector"
+		"/obj/item/airshield_projector",
+		"/obj/item/device/radio",
+		"/obj/item/device/gps",
+		"/obj/item/blueprints/construction_permit"
 		)
 
 /obj/item/weapon/storage/belt/utility/complete/New()
@@ -114,7 +117,10 @@
 		"/obj/item/device/silicate_sprayer",
 		"/obj/item/device/geiger_counter",
 		"/obj/item/weapon/inflatable_dispenser",
-		"/obj/item/airshield_projector"
+		"/obj/item/airshield_projector",
+		"/obj/item/tool/irons",
+		"/obj/item/device/radio",
+		"/obj/item/device/gps"
 		)
 
 /obj/item/weapon/storage/belt/utility/chief/full/New() //This is mostly for testing I guess


### PR DESCRIPTION


## What this does
Engineering Toolbelt can now hold Station bounced Radios, Construction Permits & GPS
Chief Engineer Toolbelt can hold the above + set of irons.

## Why it's good
This is all commonly used Engineering equipment and I can't think of a good reason to not carry them on the belt.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Engineering Toolbelt can now hold Station bounced Radios, Construction Permits & GPS
 * tweak: Chief Engineer Toolbelt an now hold Station bounced Radios, Construction Permits, Set of Irons & GPS
