### PR TITLE
Fixes xeno thermals

### DIFF
--- a/code/modules/mob/hearing/virtualhearer.dm
+++ b/code/modules/mob/hearing/virtualhearer.dm
@@ -77,13 +77,14 @@ var/list/stationary_hearers = list(	/obj/item/device/radio/intercom,
 		sight = copying
 	if(removing)
 		sight &= ~removing
-		if((sight != oldsight) && (removing & (SEE_TURFS | SEE_MOBS | SEE_OBJS)))
-			sight |= SEE_BLACKNESS
 	if(adding)
 		sight |= adding
-		if((sight != oldsight) && (adding & (SEE_TURFS | SEE_MOBS | SEE_OBJS)))
-			sight &= ~SEE_BLACKNESS
 	if(sight != oldsight)
+		if(sight & (SEE_TURFS | SEE_MOBS | SEE_OBJS))
+			sight &= ~SEE_BLACKNESS
+		else
+			sight |= SEE_BLACKNESS
+
 		var/mob/virtualhearer/VH = mob_hearers[src]
 		if(VH)
 			VH.sight = sight


### PR DESCRIPTION
Fixes #33938 and also maybe other thermals. I didn't check whether or not other thermals were broken.
I'm not sure why this wasn't written like this to begin with. Maybe to allow `change_sight()` to also change `SEE_BLACKNESS`, but this would have been very unintuitive since it could only do so when not also applying/removing certain other flags. I also don't think there's any particular reason to allow for manual application of `SEE_BLACKNESS`.

I wonder if xeno thermals were also broken for exactly this reason before multiZ