### PR TITLE
Changeling tweaks

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -127,6 +127,7 @@
 	things considerably
 */
 /mob/living/carbon/monkey/RestrainedClickOn(var/atom/A)
+	..()
 	if(a_intent != I_HURT || !ismob(A))
 		return
 	delayNextAttack(10)
@@ -151,6 +152,7 @@
 
 //Humans being able to bite and kick while restrained, either generally or only when not being pulled or grabbed, according to config.human_captive_kickbite.
 /mob/living/carbon/human/RestrainedClickOn(var/atom/A)
+	..()
 	if(a_intent != I_HURT || !attack_type || A.loc == src || !Adjacent(A))
 		return
 	if(is_pacified())

--- a/code/datums/gamemode/powers/changeling.dm
+++ b/code/datums/gamemode/powers/changeling.dm
@@ -1,7 +1,7 @@
 /datum/power/changeling
 	var/allowduringlesserform = 0
 	var/allowduringhorrorform = 1
-	spellmaster = /obj/abstract/screen/movable/spell_master/changeling	
+	spellmaster = /obj/abstract/screen/movable/spell_master/changeling
 
 /datum/power/changeling/can_use(var/mob/user)
 	if(ismonkey(user))
@@ -16,7 +16,7 @@
 			return FALSE
 	return TRUE
 
-/datum/power_holder/changeling 
+/datum/power_holder/changeling
 	menu_name = "Changeling Evolution Menu"
 	menu_desc = {"Hover over a power to see more information<br>
 				Absorb genomes to acquire more evolution points"}
@@ -25,7 +25,8 @@
 
 /datum/power/changeling/absorb_dna
 	name = "Absorb DNA"
-	desc = "Permits us to syphon the DNA from a human. They become one with us, and we become stronger."
+	desc = "Permits us to siphon the DNA from a human. They become one with us, and we become stronger."
+	helptext = "You gain 3 evolution points for every absorbed human."
 	cost = 0
 	spellpath = /spell/changeling/absorbdna
 	allowduringhorrorform = 0
@@ -44,15 +45,15 @@
 	cost = 0
 	allowduringlesserform = 1
 	spellpath = /spell/changeling/regenerate
-	
+
 /datum/power/changeling/split
 	name = "Split"
 	desc = "Split your body into two lifeforms."
-	helptext = "Find somewhere safe to split, as you will be vulnerable afterward."
+	helptext = "Find somewhere safe to split, as you will be vulnerable afterward. Your clone will inherit your identity at the time."
 	cost = 0
 	spellpath = /spell/changeling/split
 	allowduringhorrorform = 0 //this would be terrifying otherwise
-	
+
 /datum/power/changeling/horror_form
 	name = "Horror Form"
 	desc = "This costly evolution allows us to transform into an all-consuming abomination. We are incredibly strong, to the point that we can force open airlocks, and are immune to conventional stuns."
@@ -78,14 +79,14 @@
 
 /datum/power/changeling/deaf_sting
 	name = "Deaf Sting"
-	desc = "We silently sting a human, completely deafening them for a short time."
+	desc = "We sting a human, completely deafening them for a short time."
 	cost = 1
 	allowduringlesserform = 1
 	spellpath = /spell/changeling/sting/deaf
 
 /datum/power/changeling/blind_sting
 	name = "Blind Sting"
-	desc = "We silently sting a human, completely blinding them for a short time."
+	desc = "We sting a human, completely blinding them for a short time."
 	cost = 1
 	allowduringlesserform = 1
 	spellpath = /spell/changeling/sting/blind
@@ -101,7 +102,7 @@
 /datum/power/changeling/mimicvoice
 	name = "Mimic Voice"
 	desc = "We shape our vocal glands to sound like a desired voice."
-	helptext = "Will turn your voice into the name that you enter."
+	helptext = "Will turn your voice into the name that you enter. The radio will still use the job of the ID you are wearing."
 	cost = 2
 	spellpath = /spell/changeling/voicechange
 	allowduringhorrorform = 0
@@ -124,6 +125,7 @@
 /datum/power/changeling/paralysis_sting
 	name = "Paralysis Sting"
 	desc = "We silently sting a human, paralyzing them for a short time."
+	helptext = "Paralyzed victims can still talk."
 	cost = 3
 	spellpath = /spell/changeling/sting/paralyse
 
@@ -151,16 +153,16 @@
 /datum/power/changeling/boost_range
 	name = "Boost Range"
 	desc = "We evolve the ability to shoot our stingers at humans, with some preparation."
-	helptext = "Our throat adjusts to launch the stinger."
+	helptext = "Increases the range by 3 tiles."
 	cost = 2
 
 /datum/power/changeling/boost_range/add_power(var/datum/role/R)
 	. = ..()
-	if (!.) 
-		return 
+	if (!.)
+		return
 	var/datum/role/changeling/changeling = R
 	if(changeling)
-		changeling.sting_range = 2
+		changeling.sting_range = 4
 
 /datum/power/changeling/Epinephrine
 	name = "Epinephrine sacs"
@@ -177,8 +179,8 @@
 
 /datum/power/changeling/ChemicalSynth/add_power(var/datum/role/R)
 	. = ..()
-	if (!.) 
-		return 
+	if (!.)
+		return
 	var/datum/role/changeling/changeling = R
 	if(changeling)
 		changeling.chem_recharge_rate *= 2
@@ -191,8 +193,8 @@
 
 /datum/power/changeling/AdvChemicalSynth/add_power(var/datum/role/R)
 	. = ..()
-	if (!.) 
-		return 
+	if (!.)
+		return
 	var/datum/role/changeling/changeling = R
 	if(changeling)
 		changeling.chem_recharge_rate *= 2
@@ -205,8 +207,8 @@
 
 /datum/power/changeling/EngorgedGlands/add_power(var/datum/role/R)
 	. = ..()
-	if (!.) 
-		return 
+	if (!.)
+		return
 	var/datum/role/changeling/changeling = R
 	if(changeling)
 		changeling.chem_storage += 25
@@ -220,8 +222,8 @@
 
 /datum/power/changeling/DigitalCamouflage/add_power(var/datum/role/R)
 	. = ..()
-	if (!.) 
-		return 
+	if (!.)
+		return
 	var/mob/living/carbon/human/C = R.antag.current
 	to_chat(C, "<span class='notice'>We distort our form to prevent AI-tracking.</span>")
 

--- a/code/datums/gamemode/powers/powers.dm
+++ b/code/datums/gamemode/powers/powers.dm
@@ -1,4 +1,4 @@
-/datum/power			
+/datum/power
 	var/name = "Power"
 	var/desc = "Placeholder"
 	var/helptext = ""
@@ -6,7 +6,7 @@
 	var/passive = FALSE     //is this a spell or a passive effect?
 	var/spellpath           //Path to a verb that contains the effects.
 	var/cost                //the cost of this power
-	var/datum/role/role 
+	var/datum/role/role
 	var/obj/abstract/screen/movable/spell_master/spellmaster
 
 	var/store_in_memory = FALSE
@@ -306,7 +306,7 @@
 					<a id='link[i]'
 					onmouseover='expand("item[i]","[P.name]","[P.desc]","[P.helptext]","[P]",[ownsthis])'
 					>
-					<b id='search[i]'>[purchase_word] [P] - Cost: [ownsthis ? "Purchased" : P.cost]</b>
+					<b id='search[i]'>[purchase_word] [P] - Cost: [ownsthis ? P.cost ? "Purchased" : "Innate" : P.cost]</b>
 					</a>
 					<br><span id='item[i]'></span>
 				</td>
@@ -350,7 +350,7 @@
 			break
 
 	if(!thepower)		//ABORT!
-		return 
+		return
 
 	if(thepower in role.current_powers)
 		to_chat(M.current, "<span class='warning'>You have already purchased this power.</span>")
@@ -362,7 +362,7 @@
 
 	role.powerpoints -= thepower.cost
 	thepower.add_power(role)
-	
+
 
 
 

--- a/code/game/objects/items/weapons/armblade.dm
+++ b/code/game/objects/items/weapons/armblade.dm
@@ -5,6 +5,7 @@
 	icon_state = "armblade"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/swords_axes.dmi', "right_hand" = 'icons/mob/in-hand/right/swords_axes.dmi')
 	force = 30
+	armor_penetration = 75
 	sharpness = 1.5
 	sharpness_flags = SHARP_TIP | SHARP_BLADE | CHOPWOOD
 	throwforce = 0

--- a/code/modules/spells/changeling/absorb_dna.dm
+++ b/code/modules/spells/changeling/absorb_dna.dm
@@ -1,6 +1,6 @@
 /spell/changeling/absorbdna
 	name = "Absorb DNA"
-	desc = "Permits us to syphon the DNA from a human. They become one with us, and we become stronger."
+	desc = "Permits us to siphon the DNA from a human. They become one with us, and we become stronger."
 	abbreviation = "AD"
 	hud_state = "absorbdna"
 	spell_flags = NEEDSHUMAN
@@ -25,7 +25,7 @@
 		to_chat(user, "<span class='warning'>[T] is not compatible with our biology.</span>")
 		return FALSE
 	if(M_HUSK in T.mutations)	//No double-absorbing
-		to_chat(user, "<span class='warning'>This creature's DNA is ruined beyond useability!</span>")
+		to_chat(user, "<span class='warning'>This creature's DNA is ruined beyond usability!</span>")
 		return FALSE
 	if(!T.mind)						//No monkeymen
 		to_chat(user, "<span class='warning'>This creature's DNA is useless to us!</span>")
@@ -33,16 +33,18 @@
 	if(G.state != GRAB_KILL)		//Kill-Grabs only
 		to_chat(user, "<span class='warning'>We must have a tighter grip to absorb this creature.</span>")
 		return FALSE
-	if (T.dna == user.dna)
+	if(T.dna == user.dna)
 		to_chat(user, "<span class='warning'>We have already absorbed their DNA.</span>")
 		return FALSE
 	if(inuse)
 		return FALSE
 
 /spell/changeling/absorbdna/cast(var/list/targets, var/mob/living/carbon/human/user)
+	var/datum/role/changeling/changeling = user.mind.GetRole(CHANGELING)
+	if(!changeling) //Not a changeling anymore
+		return
 	var/obj/item/weapon/grab/G = user.get_active_hand() //You need to be grabbing the target
 	var/mob/living/carbon/human/T = G.affecting
-	var/datum/role/changeling/changeling = user.mind.GetRole(CHANGELING)
 	var/absorbtime = 15 SECONDS
 	inuse = TRUE
 	for(var/stage in 1 to 3)
@@ -52,12 +54,14 @@
 			if(2)
 				to_chat(user, "<span class='notice'>We extend a proboscis.</span>")
 				user.visible_message("<span class='warning'>[user] extends a proboscis!</span>")
-				playsound(user, 'sound/effects/lingextends.ogg', 50, 1)
+				for(var/mob/M in range(3, user))
+					M.playsound_local(user, 'sound/effects/lingextends.ogg', 50, 1)
 			if(3)
 				to_chat(user, "<span class='notice'>We stab [T] with the proboscis.</span>")
 				user.visible_message("<span class='danger'>[user] stabs [T] with the proboscis!</span>")
 				to_chat(T, "<span class='danger'>You feel a sharp stabbing pain!</span>")
-				playsound(user, 'sound/effects/lingstabs.ogg', 50, 1)
+				for(var/mob/M in range(3, user))
+					M.playsound_local(user, 'sound/effects/lingstabs.ogg', 50, 1)
 				var/datum/organ/external/affecting = T.get_organ(user.zone_sel.selecting)
 				if(affecting.take_damage(39,0,1, 0,"large organic needle"))
 					T.UpdateDamageIcon(1)
@@ -67,11 +71,13 @@
 			to_chat(user, "<span class='warning'>Our absorption of [T] has been interrupted!</span>")
 			return
 	usr.add_blood(T)
-
+	if(!changeling) //Just in case their ling-ness was removed mid-way, somehow.
+		return
 	to_chat(user, "<span class='notice'>We have absorbed [T]!</span>")
 	user.visible_message("<span class='danger'>[user] sucks the fluids from [T]!</span>")
 	to_chat(T, "<span class='danger'>You have been absorbed by the changeling!</span>")
-	playsound(user, 'sound/effects/lingabsorbs.ogg', 50, 1)
+	for(var/mob/M in range(3, user))
+		M.playsound_local(user, 'sound/effects/lingabsorbs.ogg', 50, 1)
 	add_attacklogs(user, T, "absorbed")
 
 	T.dna.real_name = T.real_name //Set this again, just to be sure that it's properly set.
@@ -126,6 +132,7 @@
 
 	T.death(0)
 	T.ChangeToHusk()
+	T.mutations |= M_NOCLONE
 
 	..()
 

--- a/code/modules/spells/changeling/rapidregen.dm
+++ b/code/modules/spells/changeling/rapidregen.dm
@@ -15,9 +15,9 @@
 	. = ..()
 	if (!.)
 		return FALSE
-	if(user.mind && user.mind.suiciding)			//no reviving from suicides
-		to_chat(user, "<span class='warning'>Why would we wish to regenerate if we have already committed suicide?</span>")
-		return FALSE
+//	if(user.mind && user.mind.suiciding)			//no reviving from suicides
+//		to_chat(user, "<span class='warning'>Why would we wish to regenerate if we have already committed suicide?</span>")
+//		return FALSE
 	if(M_HUSK in user.mutations)
 		to_chat(user, "<span class='warning'>We can not regenerate from this. There is not enough left to regenerate.</span>")
 		return FALSE
@@ -34,8 +34,9 @@
 			C.adjustOxyLoss(-5)
 			C.adjustFireLoss(-5)
 			sleep(10)
+	C.mind.suiciding = 0
 	C.rejuvenate(0)
 	feedback_add_details("changeling_powers","RR")
 	..()
 
-	
+

--- a/code/modules/spells/changeling/regenerative_stasis.dm
+++ b/code/modules/spells/changeling/regenerative_stasis.dm
@@ -1,6 +1,6 @@
 /spell/changeling/regenerate
 	name = "Regenerative Stasis (20)"
-	desc = "We become weakened to a death-like state, where we will rise again from death."
+	desc = "We become weakened to a death-like state, where we will rise again from death. This will take 2 minutes."
 	abbreviation = "RS"
 	hud_state = "regenstasis"
 
@@ -14,9 +14,9 @@
 	. = ..()
 	if (!.)
 		return FALSE
-	if(user.mind && user.mind.suiciding)			//no reviving from suicides
-		to_chat(user, "<span class='warning'>Why would we wish to regenerate if we have already committed suicide?</span>")
-		return FALSE
+//	if(user.mind && user.mind.suiciding)			//no reviving from suicides
+//		to_chat(user, "<span class='warning'>Why would we wish to regenerate if we have already committed suicide?</span>")
+//		return FALSE
 	if(M_HUSK in user.mutations)
 		to_chat(user, "<span class='warning'>We can not regenerate from this. There is not enough left to regenerate.</span>")
 		return FALSE
@@ -27,7 +27,7 @@
 	var/mob/living/carbon/C = user
 	var/delay = 0 SECONDS
 	inuse = TRUE
-	
+
 	if(C.stat != DEAD)
 		C.status_flags |= FAKEDEATH		//play dead
 		C.update_canmove()
@@ -44,7 +44,7 @@
 		to_chat(C, "<span class = 'notice'>Click the action button to revive.</span>")
 		var/datum/action/lingrevive/revive_action = new()
 		revive_action.Grant(C)
-		
+
 	feedback_add_details("changeling_powers","FD")
 
 	..()
@@ -59,6 +59,7 @@
 	var/datum/role/changeling/changeling = owner.mind.GetRole(CHANGELING)
 	var/mob/living/carbon/C = owner
 
+	owner.mind.suiciding = 0 //Just in case the ling wanted to do a funny with the suicide but owned themselves
 	C.rejuvenate(0)
 	C.visible_message("<span class='warning'>[owner] appears to wake from the dead, having healed all wounds.</span>")
 	if(M_HUSK in C.mutations) //Yes you can regenerate from being husked if you played dead beforehand, but unless you find a new body, you can not regenerate again.

--- a/code/modules/spells/changeling/stings/blind.dm
+++ b/code/modules/spells/changeling/stings/blind.dm
@@ -1,6 +1,6 @@
 /spell/changeling/sting/blind
 	name = "Blind Sting (20)"
-	desc = "We quietly sting a human, completely blinding them for a short time."
+	desc = "We sting a human, worsening their vision for half a minute before amplifying its effect for 20 seconds. It is more potent against humans with bad vision."
 	abbreviation = "BS"
 	hud_state = "blindsting"
 

--- a/code/modules/spells/changeling/stings/deaf.dm
+++ b/code/modules/spells/changeling/stings/deaf.dm
@@ -1,6 +1,6 @@
 /spell/changeling/sting/deaf
 	name = "Deaf Sting (5)"
-	desc = "We quietly sting a human, completely deafening them for a short time."
+	desc = "We sting a human, completely deafening them for half a minute."
 	abbreviation = "DS"
 	hud_state = "deafsting"
 

--- a/code/modules/spells/changeling/stings/dnaextract.dm
+++ b/code/modules/spells/changeling/stings/dnaextract.dm
@@ -1,6 +1,6 @@
 /spell/changeling/sting/dnaextract
 	name = "DNA Extraction Sting (40)"
-	desc = "We stealthily sting a target and extract the DNA from them."
+	desc = "We silently sting a target and extract the DNA from them."
 	abbreviation = "NS"
 	hud_state = "extractdna"
 

--- a/code/modules/spells/changeling/stings/fat.dm
+++ b/code/modules/spells/changeling/stings/fat.dm
@@ -1,5 +1,5 @@
 /spell/changeling/sting/fat
-	name = "Fat Sting"
+	name = "Fat Sting (5)"
 	desc = "We silently sting a human or ourselves, forcing them to rapidly accumulate fat."
 	abbreviation = "FS"
 	hud_state = "fatsting"
@@ -20,8 +20,8 @@
 	feedback_add_details("changeling_powers", "FS")
 
 /spell/changeling/sting/unfat
-	name = "Unfat Sting"
-	desc = "We quietly sting a human or ourselves, forcing them to rapidly metabolize their fat."
+	name = "Unfat Sting (5)"
+	desc = "We silently sting a human or ourselves, forcing them to rapidly metabolize their fat."
 	abbreviation = "UF"
 	hud_state = "unfatsting"
 

--- a/code/modules/spells/changeling/stings/hallucinate.dm
+++ b/code/modules/spells/changeling/stings/hallucinate.dm
@@ -1,6 +1,6 @@
 /spell/changeling/sting/hallucinate
 	name = "Hallucination Sting (15)"
-	desc = "We silently sting the victim with powerful hallucinogen, causing them to hallucinate after roughly 45 seconds."
+	desc = "We silently sting the victim with powerful hallucinogen, causing them to hallucinate after roughly 45 seconds for more than 10 minutes."
 	abbreviation = "HS"
 	hud_state = "hallucinatesting"
 

--- a/code/modules/spells/changeling/stings/mute.dm
+++ b/code/modules/spells/changeling/stings/mute.dm
@@ -1,6 +1,6 @@
 /spell/changeling/sting/mute
 	name = "Silence Sting (15)"
-	desc = "We silently sting a human, completely silencing them for a short time."
+	desc = "We silently sting a human, completely silencing them for a minute."
 	abbreviation = "MS"
 	hud_state = "mutesting"
 

--- a/code/modules/spells/changeling/stings/paralyse.dm
+++ b/code/modules/spells/changeling/stings/paralyse.dm
@@ -1,6 +1,6 @@
 /spell/changeling/sting/paralyse
 	name = "Paralysis Sting (30)"
-	desc = "We quietly sting a human, paralyzing them for a short time."
+	desc = "We quietly sting a human, paralyzing them for 40 seconds. They can still communicate in this state."
 	abbreviation = "PS"
 	hud_state = "paralysis"
 

--- a/code/modules/spells/changeling/stings/sting.dm
+++ b/code/modules/spells/changeling/stings/sting.dm
@@ -1,9 +1,9 @@
 /spell/changeling/sting
 	name = "Sting"
-	desc = "We string our target."
+	desc = "We sting our target."
 	abbreviation = "ST"
 
-	spell_flags = WAIT_FOR_CLICK
+	spell_flags = WAIT_FOR_CLICK|CAN_CHANNEL_RESTRAINED
 	range = 1
 
 	var/silent = 0      //dont show the "tiny prick!" message, takes priority if visible is also set to 1
@@ -21,7 +21,7 @@
 
 	if(!istype(L))
 		return FALSE
-	if(user == L && !allowself) 
+	if(user == L && !allowself)
 		to_chat(user, "<span class='warning'>We cannot target ourselves.</span>")
 		return FALSE
 
@@ -32,7 +32,7 @@
 		user.visible_message("<span class='danger'>[user.name] shoots out a stinger from their body!</span>")
 		to_chat(L, "<span class='warning'>You feel a tiny prick!</span>")
 		playsound(user, 'sound/items/syringeproj.ogg', 50, 1)
-	else 
+	else
 		to_chat(user, "<span class='warning'>We sting [L.name].</span>")
 		to_chat(L, "<span class='warning'>You feel a tiny prick!</span>")
 		user << 'sound/items/hypospray.ogg'
@@ -44,7 +44,7 @@
 
 	spawn(delay)
 		lingsting(user, L)
-		
+
 
 /spell/changeling/sting/proc/lingsting(var/mob/user, var/mob/living/target) //override this with the sting effects
 	return

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -225,7 +225,6 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 		user.spell_channeling = src
 		if(spell_flags & CAN_CHANNEL_RESTRAINED)
 			user.register_event(/event/ruattack, src, .proc/channeled_spell)
-			user.spell_channeling = src
 		connected_button.name = "(Ready) [name]"
 		currently_channeled = 1
 		connected_button.add_channeling()


### PR DESCRIPTION
### - Changelings can now sting while restrained.

It didn't make a lot of sense that a shapeshifting creature like the changeling would be rendered impotent by a bunch of cuffs. This should also make them significantly more dangerous when subdued. Start pulling out those lasers or bring some friends. I believe this was part of their normal functionality before the ling verbs were [reworked into spells](#28017).
Actually making this work involved about an annoying hour of two of tracking down a bug where RestrainedClickOn wasn't calling the event that allows clicking while cuffed properly, and because I was a dummy I searched for RestrainedClickOn references instead of RestrainedClickOn defines. It turns out the problem was that the human and monkey RestrainedClickOn procs were redefining the initial RestrainedClickOn proc without also calling the parent that contained the event. That got fixed.

### - Sucking people dry once again renders them uncloneable

I think one of my biggest issues with the [changeling reworks](#31719) were the removal of the DNA-sucked bodies being unable to be cloned, which made the victims too conveniently brought back into the round, so I'm bringing this back. This should also incentivize people to start shoving those brains into borgs again, or put in the extra effort of shoving them into a monkeyman's body.

### - Slurping people is now more quiet.
Much like the [vault safe being too loud](#32972) the slurping noises attract too much attention for what is meant to be a stealth antagonist, when anyone wandering by can hear the telltale sign of a changeling devouring its prey and raise the alarm. This has been changed so that the audible range is only 3 tiles rather than the whole screen.

### - Increased the bonus sting range ability from 1 extra tile to 3 extra tiles.
Ever since the [verb-to-spell rework](#28017) changelings had a bit more trouble blending among the crew because they'd also _turn_ when using the sting, making them really obvious. This should give them some more plausible deniability if they bother taking the upgrade.
On an unrelated note does anyone know how to make it so that something checks for obstacles in the way so that stings can't penetrate walls and windows? This is a bug that's still in the current version of the game (although less noticeable, you can stay in front of an airlock and sting the guy behind it) but I couldn't come up with a solution to fix it in this PR.

### - Added 75 armor penetration to the Armblade.
It's a sure sign that you're a changeling that shouldn't be messed with, might as well act like a proper weapon. And Prototype is great, go play it.

### - Power menu now says "Innate" instead of "Purchased" for spells that are already bought.
0-cost evolutionary powers are already purchased. This is just a nice little change.

### - Tweaked ability descriptions
Many of the so-called "silent stings" aren't actually silent, but instead tell the victim that they've been stung. They also aren't precise enough on their effects, so I've changed that too so they are better at describing it. For example the "paralysis sting" doesn't actually block its victim from talking (like paralysis in the game does), and the mute sting lasts a minute. Fixed fat/unfat stings not having their price in the name (5 chemicals).

### - Changelings that suicide can revive themselves again.
Not much of a reason to prevent that when it's the changeling's choice to do it. Who knows, maybe someone in the future who will suicide as a ling to bait people into thinking it's really, very dead will be grateful for this change when it comes to reviving.

Also slight typo fixes.

:cl:
 * rscadd: Changelings can now sting while restrained. Be careful who you're subjecting to the flame test!
 * rscadd: Changeling armblades now cut through armor with far more ease.
 * rscadd: Victims that have been drained dry by changelings can no longer be cloned. Consider alternatives!
 * rscadd: Changelings who killed themselves can now revive themselves again. Previously they couldn't if they suicided.
 * tweak: The abilities that changelings start with will now say "Innate" instead of "Purchased" in the power menu.
 * tweak: Adjusted the descriptions of various changeling abilities to tell more useful information about their effects and things to look out for.
 * tweak: Changelings have learned some dinner manners and no longer slurp victims so loudly.
 * tweak: The bonus sting range ability for changelings has been increased from +1 tile to +3 tiles.