### PR TITLE
Changeling armblades now have 75 armor penetration

### DIFF
--- a/code/game/objects/items/weapons/armblade.dm
+++ b/code/game/objects/items/weapons/armblade.dm
@@ -5,6 +5,7 @@
 	icon_state = "armblade"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/swords_axes.dmi', "right_hand" = 'icons/mob/in-hand/right/swords_axes.dmi')
 	force = 30
+	armor_penetration = 75
 	sharpness = 1.5
 	sharpness_flags = SHARP_TIP | SHARP_BLADE | CHOPWOOD
 	throwforce = 0


### PR DESCRIPTION
Changeling armblades are an extremely visible weapon that tells everyone nearby that "yes, this is a changeling", even more so than the e-swords which can be acquired in several other ways that don't involve being part of the syndicate. This should allow them to be better used against well-armored targets, plus I am a fan of Prototype and the (arm)Blade is awesome.
Besides, armblades themselves are inferior to just going all "horror form".

:cl:
 * rscadd: Changeling armblades are now a lot better against armored targets.
