### PR TITLE
Fixes RestrainedClickOn not working

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -127,6 +127,7 @@
 	things considerably
 */
 /mob/living/carbon/monkey/RestrainedClickOn(var/atom/A)
+	..()
 	if(a_intent != I_HURT || !ismob(A))
 		return
 	delayNextAttack(10)
@@ -151,6 +152,7 @@
 
 //Humans being able to bite and kick while restrained, either generally or only when not being pulled or grabbed, according to config.human_captive_kickbite.
 /mob/living/carbon/human/RestrainedClickOn(var/atom/A)
+	..()
 	if(a_intent != I_HURT || !attack_type || A.loc == src || !Adjacent(A))
 		return
 	if(is_pacified())


### PR DESCRIPTION
Humans and monkeys had their RestrainedClickOn overridden. This fixes it.
I might use the effects of this bugfix for a future PR who some likely already know about.
:cl:
 * bugfix: Fixed a bug where clicking people while restrained did not do anything even when it could. This doesn't affect anything currently.