### PR TITLE
Changelings can now revive after suiciding

### DIFF
--- a/code/modules/spells/changeling/rapidregen.dm
+++ b/code/modules/spells/changeling/rapidregen.dm
@@ -15,9 +15,9 @@
 	. = ..()
 	if (!.)
 		return FALSE
-	if(user.mind && user.mind.suiciding)			//no reviving from suicides
-		to_chat(user, "<span class='warning'>Why would we wish to regenerate if we have already committed suicide?</span>")
-		return FALSE
+//	if(user.mind && user.mind.suiciding)			//no reviving from suicides
+//		to_chat(user, "<span class='warning'>Why would we wish to regenerate if we have already committed suicide?</span>")
+//		return FALSE
 	if(M_HUSK in user.mutations)
 		to_chat(user, "<span class='warning'>We can not regenerate from this. There is not enough left to regenerate.</span>")
 		return FALSE
@@ -34,8 +34,9 @@
 			C.adjustOxyLoss(-5)
 			C.adjustFireLoss(-5)
 			sleep(10)
+	C.mind.suiciding = 0
 	C.rejuvenate(0)
 	feedback_add_details("changeling_powers","RR")
 	..()
 
-	
+

--- a/code/modules/spells/changeling/regenerative_stasis.dm
+++ b/code/modules/spells/changeling/regenerative_stasis.dm
@@ -14,9 +14,9 @@
 	. = ..()
 	if (!.)
 		return FALSE
-	if(user.mind && user.mind.suiciding)			//no reviving from suicides
-		to_chat(user, "<span class='warning'>Why would we wish to regenerate if we have already committed suicide?</span>")
-		return FALSE
+//	if(user.mind && user.mind.suiciding)			//no reviving from suicides
+//		to_chat(user, "<span class='warning'>Why would we wish to regenerate if we have already committed suicide?</span>")
+//		return FALSE
 	if(M_HUSK in user.mutations)
 		to_chat(user, "<span class='warning'>We can not regenerate from this. There is not enough left to regenerate.</span>")
 		return FALSE
@@ -27,7 +27,7 @@
 	var/mob/living/carbon/C = user
 	var/delay = 0 SECONDS
 	inuse = TRUE
-	
+
 	if(C.stat != DEAD)
 		C.status_flags |= FAKEDEATH		//play dead
 		C.update_canmove()
@@ -44,7 +44,7 @@
 		to_chat(C, "<span class = 'notice'>Click the action button to revive.</span>")
 		var/datum/action/lingrevive/revive_action = new()
 		revive_action.Grant(C)
-		
+
 	feedback_add_details("changeling_powers","FD")
 
 	..()
@@ -59,6 +59,7 @@
 	var/datum/role/changeling/changeling = owner.mind.GetRole(CHANGELING)
 	var/mob/living/carbon/C = owner
 
+	C.mind.suiciding = 0
 	C.rejuvenate(0)
 	C.visible_message("<span class='warning'>[owner] appears to wake from the dead, having healed all wounds.</span>")
 	if(M_HUSK in C.mutations) //Yes you can regenerate from being husked if you played dead beforehand, but unless you find a new body, you can not regenerate again.


### PR DESCRIPTION
It doesn't make much sense for a changeling to not be able to revive since reviving is a pretty intentional action. This should also hopefully rescue the occasional new changeling player from suiciding for some reason only to find out afterwards that they can't revive because they suicided.
:cl:
 * rscadd: Changelings can now revive themselves as normal after suiciding.