### PR TITLE
Changelings can now sting while restrained

### DIFF
--- a/code/modules/spells/changeling/stings/sting.dm
+++ b/code/modules/spells/changeling/stings/sting.dm
@@ -3,7 +3,7 @@
 	desc = "We string our target."
 	abbreviation = "ST"
 
-	spell_flags = WAIT_FOR_CLICK
+	spell_flags = WAIT_FOR_CLICK|CAN_CHANNEL_RESTRAINED
 	range = 1
 
 	var/silent = 0      //dont show the "tiny prick!" message, takes priority if visible is also set to 1
@@ -21,7 +21,7 @@
 
 	if(!istype(L))
 		return FALSE
-	if(user == L && !allowself) 
+	if(user == L && !allowself)
 		to_chat(user, "<span class='warning'>We cannot target ourselves.</span>")
 		return FALSE
 
@@ -32,7 +32,7 @@
 		user.visible_message("<span class='danger'>[user.name] shoots out a stinger from their body!</span>")
 		to_chat(L, "<span class='warning'>You feel a tiny prick!</span>")
 		playsound(user, 'sound/items/syringeproj.ogg', 50, 1)
-	else 
+	else
 		to_chat(user, "<span class='warning'>We sting [L.name].</span>")
 		to_chat(L, "<span class='warning'>You feel a tiny prick!</span>")
 		user << 'sound/items/hypospray.ogg'
@@ -44,7 +44,7 @@
 
 	spawn(delay)
 		lingsting(user, L)
-		
+
 
 /spell/changeling/sting/proc/lingsting(var/mob/user, var/mob/living/target) //override this with the sting effects
 	return


### PR DESCRIPTION
I strongly believe that changelings used to be able to sting while cuffed, but this functionality was lost about 2 years ago when 
#28017 was merged, which turned the sting verbs into spells that could not be used while restrained, and until #33950 was merged that couldn't even work either. This restores the functionality.
I'm not going to pretend it's a bugfix but I'm going to highlight that changelings were meant to do this in the first place. I will also push for a bugfix shortly after involving stings reaching where they shouldn't.
Edit: Bugfix #33954 
:cl:
 * rscadd: Changelings can now once again use their stings while restrained. Be careful who you're subjecting to the flame test!