### PR TITLE
Removes duplicates in lists in custom food names

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -31,6 +31,8 @@
 
 		return "[output][and_text][input[index]]"
 
+#define unique_english_list(A) english_list(uniquenamelist(A))
+
 //Returns a counted list of atom names in plain english as a string
 /proc/counted_english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
 	var/list/names = uniquenamelist(input) // First, get the items to list

--- a/code/modules/food/customizables.dm
+++ b/code/modules/food/customizables.dm
@@ -432,25 +432,16 @@
 	return I
 
 /obj/item/weapon/reagent_containers/food/snacks/customizable/proc/updateName()
-	var/i = 1
-	var/new_name
-	for(var/obj/item/S in src.ingredients)
-		if(i == 1)
-			new_name += "[S.name]"
-			if (fullyCustom)
-				desc = S.desc
-		else if(i == src.ingredients.len)
-			new_name += " and [S.name]"
-		else
-			new_name += ", [S.name]"
-		i++
+	. = unique_english_list(src.ingredients)
 	if (!fullyCustom)
-		new_name = "[new_name] [initial(src.name)]"
-	if(length(new_name) >= 150)
+		. = "[.] [initial(src.name)]"
+	else if(ingredients.len)
+		var/obj/item/S = ingredients[1]
+		desc = S.desc
+	if(length(.) >= 150)
 		name = "something yummy"
 	else
-		name = new_name
-	return new_name
+		name = .
 
 /obj/item/weapon/reagent_containers/food/snacks/customizable/Destroy()
 	for(. in src.ingredients) qdel(.)


### PR DESCRIPTION
[tweak][grammar]

## What this does
adds the define unique_english_list() which makes an english_list() out of uniquenamelist() for the effect of removing duplicates
uses this function on the names of customizable foods, so "apple, apple, orange, pear, pear and pear burger" would now read "apple, orange and pear burger"

## Why it's good
more concise names

## Changelog
:cl:
 * tweak: Custom food names now have duplicates trimmed, resulting in names like "meat, meat, meat, cheese and egg burger" now being "meat, cheese and egg burger"