### PR TITLE
Revert Dynamic Changes

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_maths.dm
+++ b/code/datums/gamemode/dynamic/dynamic_maths.dm
@@ -99,7 +99,7 @@
 	// New equation : https://docs.google.com/spreadsheets/d/1qnQm5hDdwZoyVmBCtf6-jwwHKEaCnYa3ljmYPs7gkSE/edit#gid=0
 		if (LORENTZ)
 			relative_threat = lorentz_distribution(dynamic_curve_centre, dynamic_curve_width)
-			threat_level = lorentz2threat(relative_threat) * 0.85
+			threat_level = lorentz2threat(relative_threat)
 			threat = round(threat, 0.1)
 
 			curve_centre_of_round = dynamic_curve_centre
@@ -111,7 +111,7 @@
 			starting_threat = threat_level
 
 			relative_threat = lorentz_distribution(dynamic_curve_centre, dynamic_curve_width)
-			midround_threat_level = lorentz2threat(relative_threat) * 0.6
+			midround_threat_level = lorentz2threat(relative_threat)
 			midround_threat = midround_threat_level
 			midround_starting_threat = midround_threat_level
 


### PR DESCRIPTION
## What this does
This reverts the dynamic changes introduced by @d3athrow on the 28th of October and puts them back to normal previous state of the past few years.

## Why it's good
It seems like nearly every round is extended these days, the low threat generation means even relatively high pop for the servers produces low threat levels. This results in rounds being extended or a single/double traitor almost without exception. 
Midrounds are even worse affected, with it almost always being a Grue/Catbeast/Demon.

To substantiate my claims, see the following data about round types: (Counted by hand from status channel)

Revolution/Rev Squad: 
Last Rolled: 12/12/2022
Total Rolls Since Change: 4
Preceding 65 days: 11

Nuclear Operatives:
Last Rolled: 12/13/2022
Total Rolls Since Change: 8
Preceding 65 days: 26

Vampire:
Last Rolled: 12/21/2022
Total Rolls Since Change: 9
Preceding 65 days; 38

Wizard
Last Rolled: 12/18/2022
Total Rolls Since Change: 23
Preceding 65 days; 58

Space Ninja:
Last Rolled: 12/20/2022
Total Rolls Since Change: 28
Preceding 65 days;  37

Traitor: (These numbers are a rough approximation, includes admin spawns. Too many to count by hand)
Last Rolled: Today
Total Rolls Since Change: 284
Preceding 65 days;  400~

While some of this could be explained away by pop differences, I don't think the server has declined since then, in fact the opposite but I have no hard data to substantiate this, it's certainly not enough to skew the results to this degree.
I've also noticed we have a lot more head/sec play as of late which should stack the results towards higher threat and more antags.

As for the original reasoning for the changes, I believe they were made due to complaints about there being too many highlander style antags and not enough extended or low threat rounds.
Personally I'd disagree with that sentiment and I think one or two high pop rounds were cherrypicked to try make a problem bigger than it actually is, though ultimately it's all up to opinion on what level of antags is good.

However even with the goal of reducing antags in mind, I think the approach that was taken was an incorrect one.
Instead of reducing overall threat, it's far better to increase the threat/spawning conditions required for these gamemodes, for example this was done with blob here in #33381 & #33587 
(Side note the combination of these changes with the dynamic changes means that blob has not rolled since then and is effectively stealth removed)

By multiplying the curve by an arbitrary value, you invalidate most of the point of using a distribution. Additionally the current threat levels were balanced based on a threat/population ratio that is no longer the case.

Another approach would be to add a dedicated extended mode to dynamic, if this is desired and I'd happily even code it, if that's the consensus because I believe these changes have been an extreme net negative to the server and lead to less interesting gameplay overall. We have gone from rounds were anything can happen, to nearly nothing ever happens.

TLDR: Dramatically less antags since this change, see stats above. This leads to boring rounds and should be reverted/modified. There are better ways to address too many antags.


## Changelog
:cl:
 * tweak: Dynamic has been restored to a normal lorentz distribution 

