### PR TITLE
Victims of a changeling sting will no longer hear a hypospray sound

### DIFF
--- a/code/modules/spells/changeling/stings/sting.dm
+++ b/code/modules/spells/changeling/stings/sting.dm
@@ -36,7 +36,6 @@
 		to_chat(user, "<span class='warning'>We sting [L.name].</span>")
 		to_chat(L, "<span class='warning'>You feel a tiny prick!</span>")
 		user << 'sound/items/hypospray.ogg'
-		//L << 'sound/items/hypospray.ogg'
 
 
 

--- a/code/modules/spells/changeling/stings/sting.dm
+++ b/code/modules/spells/changeling/stings/sting.dm
@@ -21,7 +21,7 @@
 
 	if(!istype(L))
 		return FALSE
-	if(user == L && !allowself) 
+	if(user == L && !allowself)
 		to_chat(user, "<span class='warning'>We cannot target ourselves.</span>")
 		return FALSE
 
@@ -32,11 +32,11 @@
 		user.visible_message("<span class='danger'>[user.name] shoots out a stinger from their body!</span>")
 		to_chat(L, "<span class='warning'>You feel a tiny prick!</span>")
 		playsound(user, 'sound/items/syringeproj.ogg', 50, 1)
-	else 
+	else
 		to_chat(user, "<span class='warning'>We sting [L.name].</span>")
 		to_chat(L, "<span class='warning'>You feel a tiny prick!</span>")
 		user << 'sound/items/hypospray.ogg'
-		L << 'sound/items/hypospray.ogg'
+		//L << 'sound/items/hypospray.ogg'
 
 
 
@@ -44,7 +44,7 @@
 
 	spawn(delay)
 		lingsting(user, L)
-		
+
 
 /spell/changeling/sting/proc/lingsting(var/mob/user, var/mob/living/target) //override this with the sting effects
 	return


### PR DESCRIPTION
I think it's too overt, the "You feel a tiny prick" message is subtle and can also mean being stung with a pen by a jokester or a traitor about to do really bad things using a parapen, but when it plays the hypospray sound it just essentially confirms that it was a changeling sting that attacked them and also provides an unmistakable alerting audio cue.
:cl:
 * rscdel: Victims who have been targeted by a changeling sting will no longer hear the sound of a hypospray.
