### PR TITLE
Allow paramedic hardsuits to carry regular sized tanks.

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -16,7 +16,7 @@
 	desc = "A paramedic space suit. Used in the recovery of bodies from space."
 	species_fit = list(INSECT_SHAPED, GREY_SHAPED)
 	species_restricted = list("exclude",VOX_SHAPED)
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/tank/emergency_nitrogen,/obj/item/roller,/obj/item/device/pcmc)
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/roller,/obj/item/device/pcmc)
 	slowdown = HARDSUIT_SLOWDOWN_LOW
 
 //Space santa outfit suit


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
[bugfix]
## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
closes #33962
Allows paramedic hardsuits to hold regular-sized tanks, not just emergency oxygen/nitrogen tanks.

## Why it's good
Lets paramedic hardsuits do what every other type of hardsuit can do.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Fixed paramedic hardsuits not allowing you to carry normal-sized tanks in suit storage.
