### PR TITLE
New Changeling ability: Bioimmunity

### DIFF
--- a/code/datums/gamemode/powers/changeling.dm
+++ b/code/datums/gamemode/powers/changeling.dm
@@ -255,7 +255,7 @@
 // 	spellpath = /obj/item/verbs/changeling/proc/changeling_chemspit
 
 /datum/power/changeling/disease_immunity
-	name = "Immunity to Disease"
+	name = "Bioimmunity"
 	desc = "We become immune to the symptoms of any pathogen at will."
 	helptext = "It does not purge the diseases nor provides antigens, but instead causes the symptoms to never appear."
 	cost = 2

--- a/code/datums/gamemode/powers/changeling.dm
+++ b/code/datums/gamemode/powers/changeling.dm
@@ -1,7 +1,7 @@
 /datum/power/changeling
 	var/allowduringlesserform = 0
 	var/allowduringhorrorform = 1
-	spellmaster = /obj/abstract/screen/movable/spell_master/changeling	
+	spellmaster = /obj/abstract/screen/movable/spell_master/changeling
 
 /datum/power/changeling/can_use(var/mob/user)
 	if(ismonkey(user))
@@ -16,7 +16,7 @@
 			return FALSE
 	return TRUE
 
-/datum/power_holder/changeling 
+/datum/power_holder/changeling
 	menu_name = "Changeling Evolution Menu"
 	menu_desc = {"Hover over a power to see more information<br>
 				Absorb genomes to acquire more evolution points"}
@@ -44,7 +44,7 @@
 	cost = 0
 	allowduringlesserform = 1
 	spellpath = /spell/changeling/regenerate
-	
+
 /datum/power/changeling/split
 	name = "Split"
 	desc = "Split your body into two lifeforms."
@@ -52,7 +52,7 @@
 	cost = 0
 	spellpath = /spell/changeling/split
 	allowduringhorrorform = 0 //this would be terrifying otherwise
-	
+
 /datum/power/changeling/horror_form
 	name = "Horror Form"
 	desc = "This costly evolution allows us to transform into an all-consuming abomination. We are incredibly strong, to the point that we can force open airlocks, and are immune to conventional stuns."
@@ -156,8 +156,8 @@
 
 /datum/power/changeling/boost_range/add_power(var/datum/role/R)
 	. = ..()
-	if (!.) 
-		return 
+	if (!.)
+		return
 	var/datum/role/changeling/changeling = R
 	if(changeling)
 		changeling.sting_range = 2
@@ -177,8 +177,8 @@
 
 /datum/power/changeling/ChemicalSynth/add_power(var/datum/role/R)
 	. = ..()
-	if (!.) 
-		return 
+	if (!.)
+		return
 	var/datum/role/changeling/changeling = R
 	if(changeling)
 		changeling.chem_recharge_rate *= 2
@@ -191,8 +191,8 @@
 
 /datum/power/changeling/AdvChemicalSynth/add_power(var/datum/role/R)
 	. = ..()
-	if (!.) 
-		return 
+	if (!.)
+		return
 	var/datum/role/changeling/changeling = R
 	if(changeling)
 		changeling.chem_recharge_rate *= 2
@@ -205,8 +205,8 @@
 
 /datum/power/changeling/EngorgedGlands/add_power(var/datum/role/R)
 	. = ..()
-	if (!.) 
-		return 
+	if (!.)
+		return
 	var/datum/role/changeling/changeling = R
 	if(changeling)
 		changeling.chem_storage += 25
@@ -220,8 +220,8 @@
 
 /datum/power/changeling/DigitalCamouflage/add_power(var/datum/role/R)
 	. = ..()
-	if (!.) 
-		return 
+	if (!.)
+		return
 	var/mob/living/carbon/human/C = R.antag.current
 	to_chat(C, "<span class='notice'>We distort our form to prevent AI-tracking.</span>")
 
@@ -253,3 +253,10 @@
 // 	cost = 1
 // 	allowduringlesserform = 1
 // 	spellpath = /obj/item/verbs/changeling/proc/changeling_chemspit
+
+/datum/power/changeling/disease_immunity
+	name = "Immunity to Disease"
+	desc = "We become immune to the symptoms of any pathogen at will."
+	helptext = "It does not purge the diseases nor provides antigens, but instead causes the symptoms to never appear."
+	cost = 2
+	spellpath = /spell/changeling/disease_immunity

--- a/code/datums/gamemode/role/changeling.dm
+++ b/code/datums/gamemode/role/changeling.dm
@@ -25,6 +25,7 @@
 	powerpoints = 4	//evolve points
 
 	var/mimicing = ""
+	var/disease_immunity = 0 //If on, the changeling doesn't suffer any symptoms from diseases
 
 /datum/role/changeling/OnPostSetup(var/laterole = FALSE)
 	. = ..()

--- a/code/modules/spells/changeling/disease_immunity.dm
+++ b/code/modules/spells/changeling/disease_immunity.dm
@@ -10,4 +10,4 @@
 	if(!C)
 		return
 	C.disease_immunity = !C.disease_immunity
-	to_chat(user, "<span class='notice'>We [C.disease_immunity ? "make ourselves immune to viral symptoms." : "are now vulnerable to viral symptoms"].</span>")
+	to_chat(user, "<span class='notice'>We [C.disease_immunity ? "make ourselves immune to viral symptoms" : "are now vulnerable to viral symptoms"].</span>")

--- a/code/modules/spells/changeling/disease_immunity.dm
+++ b/code/modules/spells/changeling/disease_immunity.dm
@@ -1,5 +1,5 @@
 /spell/changeling/disease_immunity
-	name = "Immunity to Disease"
+	name = "Bioimmunity"
 	desc = "We become immune to the symptoms of any pathogen at will."
 	abbreviation = "ID"
 	hud_state = "disease_immunity"

--- a/code/modules/spells/changeling/disease_immunity.dm
+++ b/code/modules/spells/changeling/disease_immunity.dm
@@ -1,0 +1,13 @@
+/spell/changeling/disease_immunity
+	name = "Immunity to Disease"
+	desc = "We become immune to the symptoms of any pathogen at will."
+	abbreviation = "ID"
+	hud_state = "disease_immunity"
+
+
+/spell/changeling/disease_immunity/cast(list/targets, mob/living/carbon/human/user)
+	var/datum/role/changeling/C = ischangeling(user)
+	if(!C)
+		return
+	C.disease_immunity = !C.disease_immunity
+	to_chat(user, "<span class='notice'>We [C.disease_immunity ? "make ourselves immune to viral symptoms." : "are now vulnerable to viral symptoms"].</span>")

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -514,6 +514,10 @@ var/global/list/disease2_list = list()
 		ticks += speed
 		return
 
+	var/datum/role/changeling/C = ischangeling(mob)
+	if(C && C.disease_immunity) //Changeling is immune to symptoms
+		return
+
 	// Activating the disease's symptoms
 	for(var/datum/disease2/effect/e in effects)
 		if (e.count > 0)

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2669,6 +2669,7 @@
 #include "code\modules\spells\changeling\absorb_dna.dm"
 #include "code\modules\spells\changeling\armblade.dm"
 #include "code\modules\spells\changeling\changeling_spell.dm"
+#include "code\modules\spells\changeling\disease_immunity.dm"
 #include "code\modules\spells\changeling\evolutionmenu.dm"
 #include "code\modules\spells\changeling\hivemind.dm"
 #include "code\modules\spells\changeling\horrorform.dm"


### PR DESCRIPTION
Start eyeing the people that aren't coughing more closely.
This doesn't actually make the changeling immune to disease, but rather immune to the symptoms of a disease, meaning that you can totally act like some living disease incubator if you want. Eat your heart out Nurgle chaplains (I don't think I've actually seen one in a while though). It's also a toggle so the changeling CAN experience symptoms if they want.
Costs 2 evolution points. I came up with that number because the ability is in all likelihood niche, disease outbreaks are rare and they're often cured, so it's more of an "on-the-moment" "let's not get messed up by the diseases that the crew hasn't dealt with" deal. OR the changeling is the virologist (or wants to spread whatever disease he got from maint mice), in which case it would be cool if he could walk around spreading all that stuff like some sort of fucked up asymptomatic patient zero. Remember that 2 points is 2/3 of the points you get from sucking someone dry in dorms.

Problem 1: I need a sprite for the ability to show up in the HUD. It does show up in the HUD but it's blank.

:cl:
 * rscadd: Added a new Changeling ability: Bioimmunity. For 2 points the changeling gains the ability to no longer be affected by disease symptoms, which can be toggled.