### PR TITLE
Changeling monkeys no longer require a genome to go back to being human

### DIFF
--- a/code/game/gamemodes/changeling/changeling_procs.dm
+++ b/code/game/gamemodes/changeling/changeling_procs.dm
@@ -9,7 +9,7 @@
 	if(!ishorrorform(C.antag.current) && !(locate(/spell/changeling/evolve) in C.antag.current.spell_list))
 		C.antag.current.add_spell(new /spell/changeling/evolve, "changeling_spell_ready", /obj/abstract/screen/movable/spell_master/changeling	)
 
-	if(ismonkey(C.antag.current) && !(locate(/spell/changeling/higherform) in C.antag.current.spell_list))	//let them un-monkey themself. If they don't have any spare genomes theyre screwed, though
+	if(ismonkey(C.antag.current) && !(locate(/spell/changeling/higherform) in C.antag.current.spell_list))
 		C.antag.current.add_spell(new /spell/changeling/higherform, "changeling_spell_base", /obj/abstract/screen/movable/spell_master/changeling)
 
 	C.refreshpowers()
@@ -19,12 +19,12 @@
 		H.species.fireloss_mult = 2
 		dna.flavor_text = H.flavor_text
 		if(!(M_HUSK in H.mutations))
-			C.absorbed_dna |= dna		
+			C.absorbed_dna |= dna
 			C.absorbed_species |= H.species.name
 
 	for(var/language in languages)
 		C.absorbed_languages |= language
-		
+
 	updateChangelingHUD()
 	return 1
 

--- a/code/modules/spells/changeling/lesser_form.dm
+++ b/code/modules/spells/changeling/lesser_form.dm
@@ -84,6 +84,9 @@
 	for(var/datum/dna/DNA in changeling.absorbed_dna)
 		names += "[DNA.real_name]"
 
+	if(!names.len)
+		to_chat(user, "<span class='warning'>We cannot transform into anyone!</span>")
+		return
 	var/S = input("Select the target DNA: ", "Target DNA", null) as null|anything in names
 	if(!S)
 		return

--- a/code/modules/spells/changeling/lesser_form.dm
+++ b/code/modules/spells/changeling/lesser_form.dm
@@ -11,7 +11,7 @@
 
 /spell/changeling/lesserform/cast_check(var/skipcharge = 0, var/mob/user = usr)
 	. = ..()
-	if (!.) 
+	if (!.)
 		return FALSE
 	if(istype(user.loc, /obj/mecha))
 		to_chat(user, "<span class='warning'>We cannot transform here!</span>")
@@ -27,7 +27,7 @@
 	if(M_HUSK in user.mutations)
 		to_chat(user, "<span class = 'warning'>This hosts genetic code is too scrambled. We can not change form until we have removed this burden.</span>")
 		return FALSE
-		
+
 
 /spell/changeling/lesserform/cast(var/list/targets, var/mob/living/carbon/human/user)
 	..()
@@ -36,7 +36,7 @@
 	user.visible_message("<span class='danger'>[user] transforms!</span>")
 	changeling.geneticdamage = 30
 	to_chat(user, "<span class='warning'>Our genes cry out!</span>")
-	
+
 	var/mob/living/carbon/monkey/O = user.monkeyize(ignore_primitive = 1) // stops us from becoming the monkey version of whoever we were pretending to be
 	O.make_changeling()
 	var/datum/role/changeling/Ochangeling = O.mind.GetRole(CHANGELING)
@@ -57,11 +57,10 @@
 	max_genedamage = 0
 	horrorallowed = 0	//horrors shouldnt even have this spell available to them
 	chemcost = 1
-	required_dna = 1
 
 /spell/changeling/higherform/cast_check(var/skipcharge = 0, var/mob/user = usr)
 	. = ..()
-	if (!.) 
+	if (!.)
 		return FALSE
 	if(istype(user.loc, /obj/mecha))
 		to_chat(user, "<span class='warning'>We cannot transform here!</span>")


### PR DESCRIPTION
I'm not even sure why this is a thing. They can't even absorb anyone in this state, so if a changeling uses it from the start they screw themselves. Maybe they were supposed to absorb before.

:cl:
 * tweak: Changelings who are in a lesser form can now go back to a higher form without needing to have absorbed anyone beforehand.
