### PR TITLE
Buff plasmaglass and rplasmaglass when constructing solars

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -120,7 +120,7 @@
 	rglass = /obj/item/stack/sheet/glass/plasmarglass
 	perunit = 2875 //average of plasma and glass
 	melt_temperature = MELTPOINT_STEEL + 500
-	glass_quality = 1.15 //Can you imagine a world in which plasmaglass is worse than rglass
+	glass_quality = 1.5 //Can you imagine a world in which plasmaglass is worse than rglass
 	shealth = 20
 	shard_type = /obj/item/weapon/shard/plasma
 
@@ -143,7 +143,7 @@
 	origin_tech = Tc_MATERIALS + "=4;" + Tc_PLASMATECH + "=2"
 	perunit = 2875
 	reinforced = 1
-	glass_quality = 1.3
+	glass_quality = 1.8
 	shealth = 30
 	shard_type = /obj/item/weapon/shard/plasma
 

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -143,7 +143,7 @@
 	origin_tech = Tc_MATERIALS + "=4;" + Tc_PLASMATECH + "=2"
 	perunit = 2875
 	reinforced = 1
-	glass_quality = 1.8
+	glass_quality = 2
 	shealth = 30
 	shard_type = /obj/item/weapon/shard/plasma
 


### PR DESCRIPTION
[discussion]

## What this does
Buffs the solar power bonus from regular plasma glass from 115% to 150%, and buffs the solar power bonus from reinforced plasma glass from 130% to 200%.

## Why it's good
The amount of times I've seen people actually go to the trouble of replacing the default solar panel glass with reinforced plasma glass is a grand total of one (I did it once, and immediately regretted it upon seeing how marginal the power increase was.) A 30% boost isn't terrible, but for the trouble involved of obtaining and manually replacing the glass on solar panels, there should be a more significant increase in power generation. I'm hoping to incentivize engineers who care about setting up the solars to maybe consider upgrading them once a more conventional engine is set up. Tagging this as discussion to get people's opinions on whether or not this buff should be tweaked (or if it even needs to exist at all.)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Increased power generation for plasma glass and reinforced plasma glass solar panels.
