### PR TITLE
Strike teams will now also flash the windows screen orange when looking for candidates

### DIFF
--- a/code/game/striketeams/striketeam_datums.dm
+++ b/code/game/striketeams/striketeam_datums.dm
@@ -83,6 +83,7 @@ var/list/sent_strike_teams = list()
 
 		to_chat(O, "[bicon(team_logo)]<span class='recruit'>[faction_name] needs YOU to become part of its upcoming [striketeam_name]. (<a href='?src=\ref[src];signup=\ref[O]'>Apply now!</a>)</span>[bicon(team_logo)]")
 		to_chat(O, "[bicon(team_logo)]<span class='recruit'>Their mission: [mission]</span>[bicon(team_logo)]")
+		window_flash(O)
 
 	spawn(1 MINUTES)
 		searching = FALSE


### PR DESCRIPTION
Bringing the "midrounds should notify the user when they happen" standard to another midround group.

:cl:
 * rscadd: Strike teams (such as ERTs and deathsquads) looking for candidates among ghosts will also flash the game's window orange in the taskbar, just like antagonist role searches do.
