### PR TITLE
Gym rats grow in size the stronger they are, up to 2x their original size at max bulk.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
@@ -41,6 +41,7 @@
 	var/static/list/edibles = list(/obj/item/weapon/reagent_containers/food/snacks)
 
 	var/scalerate = 1
+	var/translaterate = 4.5 //it is multiplied by the current scalerate, and we want a final value of 9
 	var/all_fours = TRUE
 
 	var/last_scavenge = 0
@@ -108,6 +109,7 @@
 				scalerate = 2
 			var/matrix/M = matrix()
 			M.Scale(scalerate,scalerate)
+			M.Translate(0, translaterate*scalerate)
 			transform = M
 		else
 			health+=5 // Otherwise we just get a little health back
@@ -252,6 +254,7 @@
 					scalerate = 1
 				var/matrix/M = matrix()
 				M.Scale(scalerate,scalerate)
+			M.Translate(0, -translaterate*scalerate)
 				transform = M
 				adjustBruteLoss(1) // Here so that the mouse aggros. It won't be happy that you're cutting into its gainz!
 			if(maxHealth < 20)
@@ -410,6 +413,7 @@
 				scalerate = 2
 			var/matrix/M = matrix()
 			M.Scale(scalerate,scalerate)
+			M.Translate(0, translaterate*scalerate)
 			transform = M
 		else
 			health+=5 // Otherwise we just get a little health back

--- a/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
@@ -41,7 +41,7 @@
 	var/static/list/edibles = list(/obj/item/weapon/reagent_containers/food/snacks)
 
 	var/SCALERATE = 1
-	var/rattype = regular
+	var/rattype = 1
 	var/all_fours = TRUE
 
 	var/last_scavenge = 0
@@ -101,7 +101,7 @@
 		playsound(src, 'sound/items/eatfood.ogg', rand(10,50), 1)
 		if(maxHealth < health_cap) // Are we below our max gainz level? Add on some max hp!
 			adjust_hp(5)
-			if(rattype = regular) //regular gym rat
+			if(rattype = 1) //regular gym rat
 				SCALERATE += (1/14)
 			else						//pompadour
 				SCALERATE += (1/16)
@@ -243,9 +243,9 @@
 			if(maxHealth >= 20)
 				visible_message("<span class='warning'>[src] seems to shrink as the soymilk washes over them! Its muscles look less visible...</span>")
 				maxHealth-=10
-				if(rattype = regular) //regular gym rat
+				if(rattype = 1) //regular gym rat
 					SCALERATE -= (1/7)
-				else if(rattype = pompadour) //pompadour
+				else if(rattype = 2) //pompadour
 					SCALERATE -= (1/8)
 				else //roidrat
 					SCALERATE -= (1/10)
@@ -281,7 +281,7 @@
 
 	melee_damage_lower = 1
 	melee_damage_upper = 6
-	rattype = pompadour
+	rattype = 2
 	health_cap = 120 // Eating protein can pack on a whopping 200% increase in max health. GAINZ
 	icon_eat = "gymrat_pompadour-eat"
 
@@ -348,7 +348,7 @@
 
 	health_cap = 250 // Eating protein can pack on a 66% increase in max health. Less percentage-wise than gym rats who are working out the "natural" way, but the raw numbers are still pretty scary
 	icon_eat = "roidrat-eat"
-	rattype = roidrat
+	rattype = 3
 	var/punch_throw_chance = 20 // Chance of sending a target flying a short distance with a punch
 	var/punch_throw_speed = 3
 	var/punch_throw_range = 6

--- a/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
@@ -19,7 +19,7 @@
 	speak_emote = list("squeaks loudly")
 	emote_hear = list("squeaks loudly")
 	emote_see = list("flexes", "sweats", "does a rep")
-
+	appearance_flags = PIXEL_SCALE
 	size = SIZE_SMALL // If they're not at least small it doesn't seem like the treadmill works or makes sound
 	pass_flags = PASSTABLE
 	stop_automated_movement_when_pulled = TRUE
@@ -40,6 +40,7 @@
 	var/list/gym_equipments = list(/obj/structure/stacklifter, /obj/structure/punching_bag, /obj/structure/weightlifter, /obj/machinery/power/treadmill)
 	var/static/list/edibles = list(/obj/item/weapon/reagent_containers/food/snacks)
 
+	var/SCALERATE = 1
 	var/all_fours = TRUE
 
 	var/last_scavenge = 0
@@ -99,6 +100,15 @@
 		playsound(src, 'sound/items/eatfood.ogg', rand(10,50), 1)
 		if(maxHealth < health_cap) // Are we below our max gainz level? Add on some max hp!
 			adjust_hp(5)
+			if(initial(maxhealth) = 30) //regular gym rat
+				SCALERATE += (1/14)
+			else						//pompadour
+				SCALERATE += (1/16)
+			if(SCALERATE > 2) //to tame the float point inaccuracies
+				SCALERATE = 2
+			var/matrix/M = matrix()
+			M.Scale(SCALERATE,SCALERATE)
+			transform = M
 		else
 			health+=5 // Otherwise we just get a little health back
 			to_chat(src, text("<span class='warning'>The meat nourishes you, but your muscles don't grow. You've bulked all you can...</span>"))
@@ -232,6 +242,17 @@
 			if(maxHealth >= 20)
 				visible_message("<span class='warning'>[src] seems to shrink as the soymilk washes over them! Its muscles look less visible...</span>")
 				maxHealth-=10
+				if(initial(maxhealth) = 30) //regular gym rat
+					SCALERATE -= (1/7)
+				else if(initial(maxhealth) = 40) //pompadour
+					SCALERATE -= (1/8)
+				else //roidrat
+					SCALERATE -= (1/10)
+				if(SCALERATE < 1) //to tame the float point inaccuracies 
+					SCALERATE = 1
+				var/matrix/M = matrix()
+				M.Scale(SCALERATE,SCALERATE)
+				transform = M
 				adjustBruteLoss(1) // Here so that the mouse aggros. It won't be happy that you're cutting into its gainz!
 			if(maxHealth < 20)
 				visible_message("<span class='warning'>[src] shrinks back into a more appropriate size for a mouse.</span>")
@@ -386,6 +407,12 @@
 		playsound(src, 'sound/items/eatfood.ogg', rand(10,50), 1)
 		if(maxHealth < health_cap) // Are we below our max gainz level? Add on some max hp!
 			adjust_hp(5)
+			SCALERATE += (1/20)
+			if(SCALERATE > 2) //to tame the float point inaccuracies
+				SCALERATE = 2
+			var/matrix/M = matrix()
+			M.Scale(SCALERATE,SCALERATE)
+			transform = M
 		else
 			health+=5 // Otherwise we just get a little health back
 			to_chat(src, text("<span class='warning'>The meat nourishes you, but your muscles don't grow. You've bulked all you can...</span>"))

--- a/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
@@ -41,7 +41,6 @@
 	var/static/list/edibles = list(/obj/item/weapon/reagent_containers/food/snacks)
 
 	var/SCALERATE = 1
-	var/rattype = 1
 	var/all_fours = TRUE
 
 	var/last_scavenge = 0
@@ -101,7 +100,7 @@
 		playsound(src, 'sound/items/eatfood.ogg', rand(10,50), 1)
 		if(maxHealth < health_cap) // Are we below our max gainz level? Add on some max hp!
 			adjust_hp(5)
-			if(rattype == 1) //regular gym rat
+			if(initial(maxHealth) == 30) //regular gym rat
 				SCALERATE += (1/14)
 			else						//pompadour
 				SCALERATE += (1/16)
@@ -243,9 +242,9 @@
 			if(maxHealth >= 20)
 				visible_message("<span class='warning'>[src] seems to shrink as the soymilk washes over them! Its muscles look less visible...</span>")
 				maxHealth-=10
-				if(rattype == 1) //regular gym rat
+				if(initial(maxHealth) == 30) //regular gym rat
 					SCALERATE -= (1/7)
-				else if(rattype == 2) //pompadour
+				else if(initial(maxHealth) == 40) //pompadour
 					SCALERATE -= (1/8)
 				else //roidrat
 					SCALERATE -= (1/10)
@@ -281,7 +280,6 @@
 
 	melee_damage_lower = 1
 	melee_damage_upper = 6
-	rattype = 2
 	health_cap = 120 // Eating protein can pack on a whopping 200% increase in max health. GAINZ
 	icon_eat = "gymrat_pompadour-eat"
 
@@ -348,7 +346,6 @@
 
 	health_cap = 250 // Eating protein can pack on a 66% increase in max health. Less percentage-wise than gym rats who are working out the "natural" way, but the raw numbers are still pretty scary
 	icon_eat = "roidrat-eat"
-	rattype = 3
 	var/punch_throw_chance = 20 // Chance of sending a target flying a short distance with a punch
 	var/punch_throw_speed = 3
 	var/punch_throw_range = 6

--- a/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
@@ -254,7 +254,7 @@
 					scalerate = 1
 				var/matrix/M = matrix()
 				M.Scale(scalerate,scalerate)
-			M.Translate(0, -translaterate*scalerate)
+				M.Translate(0, -translaterate*scalerate)
 				transform = M
 				adjustBruteLoss(1) // Here so that the mouse aggros. It won't be happy that you're cutting into its gainz!
 			if(maxHealth < 20)

--- a/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
@@ -100,7 +100,7 @@
 		playsound(src, 'sound/items/eatfood.ogg', rand(10,50), 1)
 		if(maxHealth < health_cap) // Are we below our max gainz level? Add on some max hp!
 			adjust_hp(5)
-			if(initial(maxhealth) = 30) //regular gym rat
+			if(initial(maxHealth) = 30) //regular gym rat
 				SCALERATE += (1/14)
 			else						//pompadour
 				SCALERATE += (1/16)
@@ -244,7 +244,7 @@
 				maxHealth-=10
 				if(initial(maxhealth) = 30) //regular gym rat
 					SCALERATE -= (1/7)
-				else if(initial(maxhealth) = 40) //pompadour
+				else if(initial(maxHealth) = 40) //pompadour
 					SCALERATE -= (1/8)
 				else //roidrat
 					SCALERATE -= (1/10)

--- a/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
@@ -41,6 +41,7 @@
 	var/static/list/edibles = list(/obj/item/weapon/reagent_containers/food/snacks)
 
 	var/SCALERATE = 1
+	var/rattype = regular
 	var/all_fours = TRUE
 
 	var/last_scavenge = 0
@@ -100,7 +101,7 @@
 		playsound(src, 'sound/items/eatfood.ogg', rand(10,50), 1)
 		if(maxHealth < health_cap) // Are we below our max gainz level? Add on some max hp!
 			adjust_hp(5)
-			if(initial(maxHealth) = 30) //regular gym rat
+			if(rattype = regular) //regular gym rat
 				SCALERATE += (1/14)
 			else						//pompadour
 				SCALERATE += (1/16)
@@ -242,9 +243,9 @@
 			if(maxHealth >= 20)
 				visible_message("<span class='warning'>[src] seems to shrink as the soymilk washes over them! Its muscles look less visible...</span>")
 				maxHealth-=10
-				if(initial(maxhealth) = 30) //regular gym rat
+				if(rattype = regular) //regular gym rat
 					SCALERATE -= (1/7)
-				else if(initial(maxHealth) = 40) //pompadour
+				else if(rattype = pompadour) //pompadour
 					SCALERATE -= (1/8)
 				else //roidrat
 					SCALERATE -= (1/10)
@@ -280,7 +281,7 @@
 
 	melee_damage_lower = 1
 	melee_damage_upper = 6
-
+	rattype = pompadour
 	health_cap = 120 // Eating protein can pack on a whopping 200% increase in max health. GAINZ
 	icon_eat = "gymrat_pompadour-eat"
 
@@ -347,7 +348,7 @@
 
 	health_cap = 250 // Eating protein can pack on a 66% increase in max health. Less percentage-wise than gym rats who are working out the "natural" way, but the raw numbers are still pretty scary
 	icon_eat = "roidrat-eat"
-
+	rattype = roidrat
 	var/punch_throw_chance = 20 // Chance of sending a target flying a short distance with a punch
 	var/punch_throw_speed = 3
 	var/punch_throw_range = 6

--- a/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
@@ -101,7 +101,7 @@
 		playsound(src, 'sound/items/eatfood.ogg', rand(10,50), 1)
 		if(maxHealth < health_cap) // Are we below our max gainz level? Add on some max hp!
 			adjust_hp(5)
-			if(rattype = 1) //regular gym rat
+			if(rattype == 1) //regular gym rat
 				SCALERATE += (1/14)
 			else						//pompadour
 				SCALERATE += (1/16)
@@ -243,9 +243,9 @@
 			if(maxHealth >= 20)
 				visible_message("<span class='warning'>[src] seems to shrink as the soymilk washes over them! Its muscles look less visible...</span>")
 				maxHealth-=10
-				if(rattype = 1) //regular gym rat
+				if(rattype == 1) //regular gym rat
 					SCALERATE -= (1/7)
-				else if(rattype = 2) //pompadour
+				else if(rattype == 2) //pompadour
 					SCALERATE -= (1/8)
 				else //roidrat
 					SCALERATE -= (1/10)

--- a/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
@@ -40,7 +40,7 @@
 	var/list/gym_equipments = list(/obj/structure/stacklifter, /obj/structure/punching_bag, /obj/structure/weightlifter, /obj/machinery/power/treadmill)
 	var/static/list/edibles = list(/obj/item/weapon/reagent_containers/food/snacks)
 
-	var/SCALERATE = 1
+	var/scalerate = 1
 	var/all_fours = TRUE
 
 	var/last_scavenge = 0
@@ -101,13 +101,13 @@
 		if(maxHealth < health_cap) // Are we below our max gainz level? Add on some max hp!
 			adjust_hp(5)
 			if(initial(maxHealth) == 30) //regular gym rat
-				SCALERATE += (1/14)
+				scalerate += (1/14)
 			else						//pompadour
-				SCALERATE += (1/16)
-			if(SCALERATE > 2) //to tame the float point inaccuracies
-				SCALERATE = 2
+				scalerate += (1/16)
+			if(scalerate > 2) //to tame the float point inaccuracies
+				scalerate = 2
 			var/matrix/M = matrix()
-			M.Scale(SCALERATE,SCALERATE)
+			M.Scale(scalerate,scalerate)
 			transform = M
 		else
 			health+=5 // Otherwise we just get a little health back
@@ -243,15 +243,15 @@
 				visible_message("<span class='warning'>[src] seems to shrink as the soymilk washes over them! Its muscles look less visible...</span>")
 				maxHealth-=10
 				if(initial(maxHealth) == 30) //regular gym rat
-					SCALERATE -= (1/7)
+					scalerate -= (1/7)
 				else if(initial(maxHealth) == 40) //pompadour
-					SCALERATE -= (1/8)
+					scalerate -= (1/8)
 				else //roidrat
-					SCALERATE -= (1/10)
-				if(SCALERATE < 1) //to tame the float point inaccuracies 
-					SCALERATE = 1
+					scalerate -= (1/10)
+				if(scalerate < 1) //to tame the float point inaccuracies 
+					scalerate = 1
 				var/matrix/M = matrix()
-				M.Scale(SCALERATE,SCALERATE)
+				M.Scale(scalerate,scalerate)
 				transform = M
 				adjustBruteLoss(1) // Here so that the mouse aggros. It won't be happy that you're cutting into its gainz!
 			if(maxHealth < 20)
@@ -405,11 +405,11 @@
 		playsound(src, 'sound/items/eatfood.ogg', rand(10,50), 1)
 		if(maxHealth < health_cap) // Are we below our max gainz level? Add on some max hp!
 			adjust_hp(5)
-			SCALERATE += (1/20)
-			if(SCALERATE > 2) //to tame the float point inaccuracies
-				SCALERATE = 2
+			scalerate += (1/20)
+			if(scalerate > 2) //to tame the float point inaccuracies
+				scalerate = 2
 			var/matrix/M = matrix()
-			M.Scale(SCALERATE,SCALERATE)
+			M.Scale(scalerate,scalerate)
 			transform = M
 		else
 			health+=5 // Otherwise we just get a little health back


### PR DESCRIPTION
## What this does
Makes it so whenever a gym rat, pompadour rat or ROID RAT eats meat, they grow in size, up to 2x their original size at MAX BULK. When exposed to soymilk, they accordingly become smaller and smaller.
When feeding on meat:
![ezgif-3-f8bb72626e](https://user-images.githubusercontent.com/67024428/212232859-7da5a828-9cb3-435b-a091-4dcfb4753a25.gif)
When sprayed with soymilk:
![ezgif-3-d0bae15303](https://user-images.githubusercontent.com/67024428/212232885-14c92ccf-e780-409e-8216-c966daf37715.gif)
## Why it's good
Gives a way to check just how strong a gym rat is, the bigger they are, the stronger. 
:cl:
 * rscadd: Gym Rats, Pompadour Rats and Roid Rats become bigger when bulking, maxing out at 2x their original size at max bulk. When exposed to soymilk, which reduces their bulk, they go smaller accordingly. They can't go smaller than their original size.