### PR TITLE
Makes the station alert computer not take a goddamn eon to initialize

### DIFF
--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -27,14 +27,14 @@
 		general_area_name = A.general_area_name
 
 		for(var/areatype in typesof(A.general_area))
-			var/area/B = locate(areatype)
+			var/area/B = locate(areatype) in areas
 
 			covered_areas += B
 
 	else//very ugly fix until all the main station's areas inherit from /area/station/
 		var/blockedtypes = typesof(/area/research_outpost,/area/mine,/area/derelict,/area/djstation,/area/vox_trading_post,/area/tcommsat)
 		for(var/atype in (typesof(/area) - blockedtypes))
-			var/area/B = locate(atype)
+			var/area/B = locate(atype) in areas
 
 			covered_areas += B
 


### PR DESCRIPTION
This One Simple Trick shaves over 95% off the time for the station alert computer to initialize, and thus almost 10% off the total combined init time of all objects in the world!