### PR TITLE
Fixes the effect of space lube on TEG circulators.

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/circulator.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/circulator.dm
@@ -32,7 +32,7 @@
 
 /obj/machinery/atmospherics/binary/circulator/New()
 	. = ..()
-	create_reagents(25)
+	create_reagents(100)
 
 /obj/machinery/atmospherics/binary/circulator/Destroy()
 	. = ..()

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -130,9 +130,9 @@
 
 			//If our circulators are lubed get extra power
 			if(circ1.reagents.get_reagent_amount(LUBE)>=1)
-				last_gen *= 1 + (circ1.volume_capacity_used/16.5) //Up to x3 if flow capacity is 33%
+				last_gen *= 1 + (circ1.volume_capacity_used * 2) //Up to x3 if flow capacity is 33%
 			if(circ2.reagents.get_reagent_amount(LUBE)>=1)
-				last_gen *= 1 + (circ2.volume_capacity_used/16.5)
+				last_gen *= 1 + (circ2.volume_capacity_used * 2)
 
 			if(air2.temperature > air1.temperature)
 				air2.temperature = air2.temperature - energy_transfer/air2_heat_capacity

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -130,9 +130,9 @@
 
 			//If our circulators are lubed get extra power
 			if(circ1.reagents.get_reagent_amount(LUBE)>=1)
-				last_gen *= 1 + (circ1.volume_capacity_used * 2) //Up to x3 if flow capacity is 33%
+				last_gen *= 1 + ((circ1.volume_capacity_used * 100) / 16.5) //Up to x3 if flow capacity is 33%
 			if(circ2.reagents.get_reagent_amount(LUBE)>=1)
-				last_gen *= 1 + (circ2.volume_capacity_used * 2)
+				last_gen *= 1 + ((circ2.volume_capacity_used * 100) / 16.5)
 
 			if(air2.temperature > air1.temperature)
 				air2.temperature = air2.temperature - energy_transfer/air2_heat_capacity


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
Changes the effect of space lube on TEG circulators to actually be significant.

This requires some explanation, so I'll point out some of the things I noticed-- Firstly, when adding space lube to circulators during regular gameplay, I noticed pretty much no difference in power output for the TEG. I initially thought that the code to update the power output just wasn't firing at all, until I looked a little bit further into it. Here's the current code for determining the power bonus from space lube:

https://github.com/vgstation-coders/vgstation13/blob/0471421e9a28d6f362942470054f4b9ac7092462/code/modules/power/generator.dm#L131-L135

This seems fine, if the volume capacity of circulators hit around 33 and max out around there. The comment here would make sense: 33/16.5 = 2. The power output would be tripled.

HOWEVER:

When we look at the actual code for the volume capacity of circulators, we see this:

https://github.com/vgstation-coders/vgstation13/blob/0471421e9a28d6f362942470054f4b9ac7092462/code/ATMOSPHERICS/components/binary_devices/circulator.dm#L60

Flow capacity is represented as a float between 0 and 1. Meaning we have to multiply it by 100 to actually matter.

## Why it's good
<!-- Explain why you think these changes are good. -->
Makes it actually worth banging on chemistry's window and asking for space lube as an engineer.


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed space lube not increasing power output for TEG circulators properly.
 * tweak: TEG circulators now hold 100 units instead of 25.
