### PR TITLE
Dropping an item from generic body pain now produces a user message

### DIFF
--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -15,7 +15,7 @@
 	if(world.time < next_pain_time && !force)
 		return
 	if(amount > 50 && prob(amount / 5) && get_active_hand())
-		to_chat(src, "<span class='danger'>The pain in your [partname] causes you to drop [get_active_hand()]</span>")
+		to_chat(src, "<span class='danger'>The pain in your [partname] causes you to wince and drop [get_active_hand()]!</span>")
 		src.drop_item()
 	var/msg
 	if(burning)

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -14,7 +14,8 @@
 		return
 	if(world.time < next_pain_time && !force)
 		return
-	if(amount > 50 && prob(amount / 5))
+	if(amount > 50 && prob(amount / 5) && get_active_hand())
+		to_chat(src, "<span class='danger'>The pain in your [partname] causes you to drop [get_active_hand()]</span>")
 		src.drop_item()
 	var/msg
 	if(burning)


### PR DESCRIPTION
[tweak]

## What this does
previously this just did it with no user message, now it does.

## Why it's good
makes it easier to notice.

## Changelog
:cl:
 * rscadd: Players dropping an item from body pain now gives them a chat message showing it.