### PR TITLE
Makes bee buzzing messages less ambiguous looking

### DIFF
--- a/code/modules/mob/living/simple_animal/bees/bees_mob.dm
+++ b/code/modules/mob/living/simple_animal/bees/bees_mob.dm
@@ -290,7 +290,7 @@ var/bee_mobs_count = 0
 	//Making noise
 	if(prob(1))
 		if(prob(50))
-			src.visible_message("<span class='notice'>[pick("Buzzzz.","Hmmmmm.","Bzzz.")]</span>")
+			src.emote("me",1,pick("Buzzzz.","Hmmmmm.","Bzzz."))
 		playsound(src, 'sound/effects/bees.ogg', min(20 * bees.len, 100), 1)
 
 

--- a/code/modules/mob/living/simple_animal/bees/bees_mob.dm
+++ b/code/modules/mob/living/simple_animal/bees/bees_mob.dm
@@ -290,7 +290,7 @@ var/bee_mobs_count = 0
 	//Making noise
 	if(prob(1))
 		if(prob(50))
-			src.emote("me",1,pick("buzzzz","hmmmmm","bzzz"))
+			src.emote("me",1,pick("buzzzz[bees.len <= 1 ? "es" : ""]","hmmmmm[bees.len <= 1 ? "s" : ""]","bzzz[bees.len <= 1 ? "es" : ""]"))
 		playsound(src, 'sound/effects/bees.ogg', min(20 * bees.len, 100), 1)
 
 

--- a/code/modules/mob/living/simple_animal/bees/bees_mob.dm
+++ b/code/modules/mob/living/simple_animal/bees/bees_mob.dm
@@ -290,7 +290,7 @@ var/bee_mobs_count = 0
 	//Making noise
 	if(prob(1))
 		if(prob(50))
-			src.emote("me",1,pick("Buzzzz.","Hmmmmm.","Bzzz."))
+			src.emote("me",1,pick("buzzzz","hmmmmm","bzzz"))
 		playsound(src, 'sound/effects/bees.ogg', min(20 * bees.len, 100), 1)
 
 


### PR DESCRIPTION
[tweak][consistency]

## What this does
changes them to emotes like "**the swarm of bees** buzzzzz" and etc.
## Why it's good
less ambiguous onomatopoeia, more in line with other mobs.

## Changelog
:cl:
 * tweak: Bees now emote their buzzing instead of just making the user read "Bzzzzz" or "Hmmmm"