### PR TITLE
Executioner swords have some armor piercing.

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -36,6 +36,7 @@
 	minimal_access = list(access_hydroponics, access_morgue) // Removed tox and chem access because STOP PISSING OFF THE CHEMIST GUYS // //Removed medical access because WHAT THE FUCK YOU AREN'T A DOCTOR YOU GROW WHEAT //Given Morgue access because they have a viable means of cloning.
 	alt_titles = list("Hydroponicist", "Beekeeper", "Gardener")
 	outfit_datum = /datum/outfit/hydro
+	species_blacklist = list()
 
 //Cargo
 /datum/job/qm
@@ -168,6 +169,7 @@
 	access = list(access_janitor, access_maint_tunnels)
 	minimal_access = list(access_janitor, access_maint_tunnels)
 	outfit_datum = /datum/outfit/janitor
+	species_blacklist = list()//Mop it up, shroomie.
 
 /datum/job/janitor/get_wage()
 	if(Holiday == APRIL_FOOLS_DAY)

--- a/code/modules/projectiles/guns/projectile/constructable/swords.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/swords.dm
@@ -277,6 +277,7 @@
 			force = 25
 			sharpness = 2.0
 			sharpness_flags = SHARP_TIP | SHARP_BLADE
+			armor_penetration = 33
 			slot_flags = SLOT_BACK
 			attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "rips", "dices", "cleaves")
 			complete = 1


### PR DESCRIPTION
You know those executioner swords, the makeshift ones you can make that can attack once every 2 years? They don't pierce armor at all for some reason. I tried stabbing the HOS with a dermal patch in the head with one and did about 2 damage.

## Why it's good
This rare and mostly still useless sword will have a mild niche against heavily armored opponents. It still won't pierce as much as just a kitchen knife, but it does much more damage than one.

## Changelog

:cl:

 * tweak: Makeshift Executioner Swords aren't completely cucked by armor. That's it.
