### PR TITLE
Executioner swords have some armor piercing

### DIFF
--- a/code/modules/projectiles/guns/projectile/constructable/swords.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/swords.dm
@@ -274,10 +274,11 @@
 			icon_state = "executioners_sword"
 			hitsound = "sound/weapons/bloodyslice.ogg"
 			w_class = W_CLASS_LARGE
-			force = 25
+			force = 28
 			sharpness = 2.0
 			sharpness_flags = SHARP_TIP | SHARP_BLADE
 			slot_flags = SLOT_BACK
+			armor_penetration = 33
 			attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "rips", "dices", "cleaves")
 			complete = 1
 			if (istype(loc,/mob/living/carbon/human))


### PR DESCRIPTION
Yes, I did just purge my branch, change the same one line and re-pr it.

You know those executioner swords, the makeshift ones you can make that can attack once every 2 years? They don't pierce armor at all for some reason. I tried stabbing the HOS with a dermal patch in the head with one and did about 2 damage.

## Why it's good
This rare and mostly still useless sword will have a mild niche against heavily armored opponents. It still won't pierce as much as just a kitchen knife, but it does much more damage than one.

## Changelog

:cl:

 * tweak: Makeshift Executioner Swords aren't completely cucked by armor. That's it.
