### PR TITLE
Mushroom Man Spores in Megaseed Servitor

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2228,6 +2228,7 @@ var/global/num_vending_terminals = 1
 		)//,/obj/item/seeds/synthbuttseed = 3)
 	premium = list(
 		/obj/item/toy/waterflower = 1,
+		/obj/item/seeds/mushroommanspore = 3
 		)
 
 	pack = /obj/structure/vendomatpack/hydroseeds


### PR DESCRIPTION
## What this does
Mushroom Man spores are now available on the station-side Megaseed Servitor, under the premium (coin-paid) section.

## Why it's good
Lets botanists grow the other diona-like thing.


:cl:
 * rscadd: Nanotrasen has struck a deal with the Shoal and secured a select amount of Mushman spores for their vendors. All coins go to real vox!
