### PR TITLE
RCD/RPD investigation logging

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1219,6 +1219,7 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define I_WIRES    "wires"
 #define I_GHOST    "poltergeist"
 #define I_ARTIFACT "artifacts"
+#define I_RCD      "RCD"
 
 
 // delayNext() flags.

--- a/code/modules/RCD/schematics/engi.dm
+++ b/code/modules/RCD/schematics/engi.dm
@@ -32,6 +32,7 @@
 
 			playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
 			add_gamelogs(user, "deconstructed \the [T] with \the [master]", admin = TRUE, tp_link = TRUE, tp_link_short = FALSE, span_class = "danger")
+			T.investigation_log(I_RCD,"was deconstructed by [user]")
 			T.ChangeTurf(T.get_underlying_turf())
 			return 0
 
@@ -43,6 +44,7 @@
 				return 1
 
 			playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
+			D.investigation_log(I_RCD,"was deconstructed by [user]")
 			qdel(D)
 			return 0
 
@@ -58,12 +60,15 @@
 			playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
 			for(var/obj/structure/grille/G in W.loc)
 				if(!istype(G,/obj/structure/grille/invulnerable)) // No more breaking out in places like lamprey
+					G.investigation_log(I_RCD,"was deconstructed by [user]")
 					qdel(G)
 			for(var/obj/structure/window/WI in W.loc)
 				if(is_type_in_list(W, list(/obj/structure/window/plasma,/obj/structure/window/reinforced/plasma,/obj/structure/window/full/plasma,/obj/structure/window/full/reinforced/plasma)) && !can_r_wall)
 					continue
 				if(WI != W)
+					WI.investigation_log(I_RCD,"was deconstructed by [user]")
 					qdel(WI)
+			W.investigation_log(I_RCD,"was deconstructed by [user]")
 			qdel(W)
 			return 0
 	return 1
@@ -85,6 +90,7 @@
 
 	to_chat(user, "Building floor...")
 	playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
+	S.investigation_log(I_RCD,"was made into a floor by [user]")
 	S.ChangeTurf(/turf/simulated/floor/plating/airless)
 	return 0
 
@@ -115,6 +121,7 @@
 
 
 		playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
+		T.investigation_log(I_RCD,"was made into a reinforced floor by [user]")
 		T.ChangeTurf(/turf/simulated/floor/engine/plated/airless)
 	return 0
 
@@ -137,6 +144,7 @@
 			return 1
 
 		playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
+		T.investigation_log(I_RCD,"had a wall built on it by [user]")
 		T.ChangeTurf(/turf/simulated/wall)
 		return 0
 
@@ -161,6 +169,7 @@
 			return 1
 
 		playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
+		T.investigation_log(I_RCD,"had a reinforced wall built on it by [user]")
 		T.ChangeTurf(/turf/simulated/wall/r_wall)
 		return 0
 
@@ -445,6 +454,7 @@
 			D.req_access = selected_access.Copy()
 
 	D.autoclose	= 1
+	A.investigation_log(I_RCD,"had \a [D] built on it by [user]")
 
 /datum/rcd_schematic/con_window
 	name						= "Build window"
@@ -527,6 +537,7 @@
 	playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
 
 	new selected.build_type(A)
+	A.investigation_log(I_RCD,"had \a [selected.name] built on it by [user]")
 
 /datum/selection_schematic
 	var/name			= "Selection"

--- a/code/modules/RCD/schematics/pipe.dm
+++ b/code/modules/RCD/schematics/pipe.dm
@@ -38,6 +38,8 @@
 	else
 		qdel(AM)
 
+	AM.investigation_log(I_RCD,"was deconstructed by [user]")
+
 /datum/rcd_schematic/paint_pipes
 	name     = "Paint pipes"
 	category = "Utilities"
@@ -148,6 +150,7 @@
 		O.color = selected_color
 		O.update_icon()
 	user.visible_message("<span class='notice'>[user] paints \the [O] [selected_color].</span>","<span class='notice'>You paint \the [O] [selected_color].</span>")
+	// is pipe painting really worth logging? cmon now
 
 /datum/rcd_schematic/paint_pipes/Topic(var/href, var/list/href_list)
 	if(href_list["set_color"])

--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -24,7 +24,8 @@ var/global/list/investigations=list(
 	I_CHEMS   = null, // Set on world.New()
 	I_WIRES   = null, // Set on world.New()
 	I_GHOST   = null, // Set on world.New()
-	I_ARTIFACT= null  // Set on world.New()
+	I_ARTIFACT= null, // Set on world.New()
+	I_RCD     = null  // Set on world.New()
 )
 
 // Handles appending shit to log.

--- a/code/world.dm
+++ b/code/world.dm
@@ -60,6 +60,7 @@ var/auxtools_path
 	investigations[I_WIRES] = new /datum/log_controller(I_WIRES, filename="data/logs/[date_string] wires.htm", persist=TRUE)
 	investigations[I_GHOST] = new /datum/log_controller(I_GHOST, filename="data/logs/[date_string] poltergeist.htm", persist=TRUE)
 	investigations[I_ARTIFACT] = new /datum/log_controller(I_ARTIFACT, filename="data/logs/[date_string] artifact.htm", persist=TRUE)
+	investigations[I_RCD] = new /datum/log_controller(I_RCD, filename="data/logs/[date_string] rcd.htm", persist=TRUE)
 
 	diary = file("data/logs/[date_string].log")
 	panicfile = new/savefile("data/logs/profiling/proclogs/[date_string].sav")


### PR DESCRIPTION
[administration]

## What this does
Closes #34021.
logs building things on RCDs and eating pipes with RPDs so far, creates a new investigation log category for these devices.

## Why it's good
investigation logging isn't as obtrusive but also helps pinpoint cuckcubing.