### PR TITLE
Makes cyber trophy belts hold items they're meant to

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -347,8 +347,8 @@
 	fits_max_w_class = 4
 	max_combined_w_class = 28
 	can_only_hold = list(
- 		/obj/item/device/aicard,
- 		/obj/item/device/mmi,
+ 		"/obj/item/device/aicard",
+ 		"/obj/item/device/mmi",
  	)
 
 /obj/item/weapon/storage/belt/silicon/New()


### PR DESCRIPTION
[bugfix][hotfix]

## What this does
Closes #34012.
i should really not make these be strings someday, maybe associative lists, i'll look at how this var is done some other time.

## Changelog
:cl:
 * bugfix: Cyber trophy belts now hold items they're meant to.