### PR TITLE
Emote typecheck refactoring

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -8,16 +8,9 @@
 	var/key_third_person = "" //This will also call the emote
 	var/key_shorthand = "" //This will also call the emote
 	var/message = "" //Message displayed when emote is used
+	var/list/message_mobtype = list() //Message displayed depending on mobtype. Please put subtypes below supertypes so this works right.
 	var/message_mime = "" //Message displayed if the user is a mime
-	var/message_alien = "" //Message displayed if the user is a grown alien
-	var/message_larva = "" //Message displayed if the user is an alien larva
-	var/message_pulsedemon = "" //Message displayed if the user is a pulse demon
-	var/message_robot = "" //Message displayed if the user is a robot
-	var/message_AI = "" //Message displayed if the user is an AI
-	var/message_monkey = "" //Message displayed if the user is a monkey
-	var/message_simple = "" //Message to display if the user is a simple_animal
 	var/message_param = "" //Message to display if a param was given
-	var/message_mommi = "" //Message to display if the user is a mommi. Defaults to message_robot if none specified
 	var/emote_type = EMOTE_VISIBLE //Whether the emote is visible or audible
 	var/restraint_check = FALSE //Checks if the mob is restrained before performing the emote
 	var/muzzle_ignore = FALSE //Will only work if the emote is EMOTE_AUDIBLE
@@ -38,8 +31,6 @@
 		emote_list[key_third_person] = src
 	if(key_shorthand)
 		emote_list[key_shorthand] = src
-	if(!message_mommi)
-		message_mommi = message_robot
 
 /datum/emote/proc/run_emote(mob/user, params, type_override, ignore_status = FALSE, var/arguments)
 	. = TRUE
@@ -132,22 +123,10 @@
 		return "makes a [pick("strong ", "weak ", "")]noise."
 	if(user.mind && ishuman(user) && user.mind.miming && message_mime)
 		. = message_mime
-	if(isalienadult(user) && message_alien)
-		. = message_alien
-	else if(islarva(user) && message_larva)
-		. = message_larva
-	else if(ispulsedemon(user) && message_pulsedemon)
-		. = message_pulsedemon
-	else if(isAI(user) && message_AI)
-		. = message_AI
-	else if(isMoMMI(user) && message_mommi)
-		. = message_mommi
-	else if(issilicon(user) && message_robot)
-		. = message_robot
-	else if(ismonkey(user) && message_monkey)
-		. = message_monkey
-	else if(isanimal(user) && message_simple)
-		. = message_simple
+	if(message_mobtype.len)
+		for(var/mobtype in message_mobtype)
+			if(istype(user,mobtype))
+				. = message_mobtype[mobtype]
 
 /datum/emote/proc/select_param(mob/user, params)
 	return replacetext(message_param, "%t", params)

--- a/code/modules/mob/living/carbon/alien/emote.dm
+++ b/code/modules/mob/living/carbon/alien/emote.dm
@@ -10,8 +10,8 @@
 /datum/emote/living/alien/hiss
 	key = "hiss"
 	key_third_person = "hisses"
-	message_alien = "hisses."
-	message_larva = "hisses softly."
+	message = "hisses."
+	message_mobtype = list(/mob/living/carbon/alien/larva = "hisses softly.")
 
 /datum/emote/living/alien/hiss/run_emote(mob/user, params)
 	. = ..()
@@ -21,8 +21,8 @@
 /datum/emote/living/alien/roar
 	key = "roar"
 	key_third_person = "roars"
-	message_alien = "roars."
-	message_larva = "softly roars."
+	message = "roars."
+	message_mobtype = list(/mob/living/carbon/alien/larva = "softly roars.")
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/alien/roar/run_emote(mob/user, params)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -15,7 +15,7 @@
 	key_third_person = "crosses"
 	key_shorthand = "cro"
 	message = "crosses their arms."
-	message_mommi = "crosses their utility arms."
+	message_mobtype = list(/mob/living/silicon/robot/mommi = "crosses their utility arms.")
 	restraint_check = TRUE
 
 /datum/emote/living/collapse
@@ -30,7 +30,7 @@
 	key_third_person = "glares"
 	key_shorthand = "gla"
 	message = "glares."
-	message_mommi = "glares as best a robot spider can glare."
+	message_mobtype = list(/mob/living/silicon/robot/mommi = "glares as best a robot spider can glare.")
 	message_param = "glares at %t."
 	emote_type = EMOTE_AUDIBLE
 
@@ -75,13 +75,15 @@
 	key = "deathgasp"
 	key_third_person = "deathgasps"
 	message = "seizes up and falls limp, their eyes dead and lifeless..."
-	message_robot = "shudders violently for a moment before falling still, its eyes slowly darkening."
-	message_AI = "lets out a flurry of sparks, its screen flickering as its systems slowly halt."
-	message_alien = "lets out a waning guttural screech, green blood bubbling from its maw..."
-	message_larva = "lets out a sickly hiss of air and falls limply to the floor..."
-	message_pulsedemon = "fizzles out into faint sparks, leaving only a slight trail of smoke..."
-	message_monkey = "lets out a faint chimper as it collapses and stops moving..."
-	message_simple =  "stops moving..."
+	message_mobtype = list(
+		/mob/living/silicon/robot = "shudders violently for a moment before falling still, its eyes slowly darkening.",
+		/mob/living/silicon/ai = "lets out a flurry of sparks, its screen flickering as its systems slowly halt.",
+		/mob/living/carbon/alien = "lets out a waning guttural screech, green blood bubbling from its maw...",
+		/mob/living/carbon/alien/larva = "lets out a sickly hiss of air and falls limply to the floor...",
+		/mob/living/simple_animal =  "stops moving...",
+		/mob/living/simple_animal/hostile/pulse_demon = "fizzles out into faint sparks, leaving only a slight trail of smoke...",
+		/mob/living/carbon/monkey = "lets out a faint chimper as it collapses and stops moving..."
+	)
 	stat_allowed = UNCONSCIOUS
 	mob_type_blacklist_typelist = list(/mob/living/carbon/brain) // Everyone can deathgasp
 
@@ -148,14 +150,14 @@ var/list/animals_with_wings = list(
 	key = "flap"
 	key_third_person = "flaps"
 	message = "flaps their wings."
-	message_mommi = "flaps its utility arms as though they were wings."
+	message_mobtype = list(/mob/living/silicon/robot/mommi = "flaps its utility arms as though they were wings.")
 	restraint_check = TRUE
 
 /datum/emote/living/flap/aflap
 	key = "aflap"
 	key_third_person = "aflaps"
 	message = "flaps their wings ANGRILY!"
-	message_mommi = "flaps its utility arms ANGRILY!"
+	message_mobtype = list(/mob/living/silicon/robot/mommi = "flaps its utility arms ANGRILY!")
 
 /datum/emote/living/flap/can_run_emote(var/mob/user, var/status_check)
 	if (isMoMMI(user))
@@ -214,7 +216,7 @@ var/list/animals_with_wings = list(
 	key = "nod"
 	key_third_person = "nods"
 	message = "nods."
-	message_mommi = "bobs its body in a rough approximation of nodding."
+	message_mobtype = list(/mob/living/silicon/robot/mommi = "bobs its body in a rough approximation of nodding.")
 	message_param = "nods at %t."
 
 /datum/emote/living/point


### PR DESCRIPTION
[tweak]

## What this does
removes all the message type vars for other mobs like message_mommi and etc, compresses them down into an assoc list called message_mobtype, that associates a typecheck with the message to get.

## Why it's good
cuts down on vars, more flexible for coders.