### PR TITLE
The Biometric Data Update

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -3,7 +3,6 @@
 	var/href
 	href_list = params2list("src=\ref[src]&[target]=1")
 	href = "src=\ref[src];[target]=1"
-	src:temphtml = null
 	src:Topic(href, href_list)
 	return null
 

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -225,7 +225,7 @@
 			to_chat(user, "<span class='warning'>There needs to be an occupant inside the scanner before you can imprint biometric data on an ID card.</span>")
 			return
 		if(!ishuman(occupant))
-			to_chat(user, "<span class='warning'>This lifeform isn't compatible with this machine's biometric measurements.</span>")
+			to_chat(user, "<span class='warning'>This lifeform isn't compatible with this machine's biometric measuring tools.</span>")
 			return
 		var/mob/living/carbon/human/H = occupant
 		var/obj/item/weapon/card/id/ID_card = W

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -232,10 +232,16 @@ var/list/global/id_cards = list()
 	..()
 
 	if(Adjacent(user))
-		user.show_message(text("The current assignment on the card is [src.assignment]."),1)
-		user.show_message("The blood type on the card is [blood_type].",1)
-		user.show_message("The DNA hash on the card is [dna_hash].",1)
-		user.show_message("The fingerprint hash on the card is [fingerprint_hash].",1)
+		if (assignment)
+			user.show_message(text("The current assignment on the card is [assignment]."),1)
+		else
+			user.show_message(text("No assignment has been set. Use an identification computer to edit."),1)
+		if (dna_hash == "\[UNSET\]")
+			user.show_message(text("No biometric data referenced. Use a body scanner at Medbay to imprint."),1)
+		else
+			user.show_message("Blood Type: [blood_type].",1)
+			user.show_message("DNA: [dna_hash].",1)
+			user.show_message("Fingerprint: [fingerprint_hash].",1)
 
 /obj/item/weapon/card/id/attack_self(var/mob/user)
 	if(user.attack_delayer.blocked())


### PR DESCRIPTION
Turns out the only ways to set an ID card's DNA hash, Fingerprint hash, and blood type is to either hold it when it spawns, or use it if it's an Agent ID Card. Until now there was no way to set the biometric data of blank ID cards. Along with photo booths, this is another big step on allowing newly created persons aboard the station to have their papers in order, for the bureaucracy lovers out there.

![image](https://user-images.githubusercontent.com/7573912/214460892-48a8a1b6-2dd6-4a43-953c-063a9b72351d.png)

Took the opportunity to clean up adv_med.dm a bit. I mean, look at this fucking shit:
![image](https://user-images.githubusercontent.com/7573912/214462712-6a1d94c5-2628-42a2-9165-e56f48e0552b.png)

:cl:
* rscadd: Body Scanners now also indicate DNA and fingerprint hashes.
* rscadd: New, non-Agent, ID cards can now have their biometric data set when used on a Body Scanner with a human occupant. Biometric data cannot be modified once imprinted (only Agent ID Cards can do that, as they always did, on their own)