### PR TITLE
Fixes pre-mapped chill bug packets such as those on Vox Trading Posts spawning regular bees

### DIFF
--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -132,7 +132,8 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 	make_datum_references_lists()	//initialises global lists for referencing frequently used datums (so that we only ever do it once)
 	Holiday = Get_Holiday()
 	world.update_status()
-	
+	initialize_beespecies()	//must be init before objects or pre-mapped bee packets will be borked
+
 	// Initialize subsystems.
 	// Sort subsystems by init_order, so they initialize in the correct order.
 	CURRENT_TICKLIMIT = TICK_LIMIT_MC_INIT_DEFAULT

--- a/code/controllers/subsystem/init/more_init_stuff.dm
+++ b/code/controllers/subsystem/init/more_init_stuff.dm
@@ -11,13 +11,12 @@ var/datum/subsystem/more_init/SSmore_init
 /datum/subsystem/more_init/Initialize(timeofday)
 	initialize_rune_words()
 	library_catalog.initialize()
-	initialize_beespecies()
 	init_mind_ui()
 	createPaiController()
 	ticker.init_snake_leaderboard()
 	ticker.init_minesweeper_leaderboard()
 	setup_news()
-	
+
 	var/watch=start_watch()
 	log_startup_progress("Caching damage icons...")
 	cachedamageicons()


### PR DESCRIPTION
Fixes #34044

:cl:
* bugfix: Pre-mapped Chill Bug packets now properly spawn chill bugs from apiaries instead of regular bees.