### PR TITLE
Nazicurity

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -130,6 +130,11 @@
 		/obj/item/weapon/card/debit/preferred/department/security,
 		/obj/item/weapon/pinpointer,
 		/obj/item/weapon/storage/box/large/securitygear,
+		/obj/item/clothing/head/naziofficer,
+		/obj/item/clothing/suit/officercoat,
+		/obj/item/clothing/under/officeruniform,
+		/obj/item/clothing/suit/space/rig/nazi,
+		/obj/item/weapon/kitchen/utensil/knife/nazi,
 	)
 
 /obj/structure/closet/secure_closet/warden
@@ -161,6 +166,10 @@
 		/obj/item/weapon/storage/box/bolas,
 		/obj/item/weapon/batteringram,
 		/obj/item/weapon/storage/box/large/securitygear,
+		/obj/item/clothing/head/naziofficer,
+		/obj/item/clothing/suit/officercoat,
+		/obj/item/clothing/under/officeruniform,
+		/obj/item/weapon/kitchen/utensil/knife/nazi,
 	)
 
 /obj/structure/closet/secure_closet/security
@@ -183,6 +192,10 @@
 		/obj/item/clothing/suit/armor/vest/security,
 		/obj/item/clothing/head/helmet/tactical/sec/preattached,
 		/obj/item/weapon/storage/box/large/securitygear,
+		/obj/item/clothing/head/stalhelm,
+		/obj/item/clothing/suit/soldiercoat,
+		/obj/item/clothing/under/soldieruniform,
+		/obj/item/weapon/kitchen/utensil/knife/nazi,
 	)
 
 
@@ -256,6 +269,11 @@
 		/obj/item/clothing/accessory/holster/handgun/wornout,
 		/obj/item/weapon/gun/projectile/detective,
 		/obj/item/weapon/storage/box/large/detectivegear,
+		/obj/item/clothing/suit/soldiercoat,
+		/obj/item/clothing/under/soldieruniform,
+		/obj/item/weapon/kitchen/utensil/knife/nazi,
+		/obj/item/clothing/head/panzer,
+		/obj/item/clothing/shoes/jackboots,
 	)
 
 /obj/structure/closet/secure_closet/detective/update_icon()

--- a/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
@@ -27,6 +27,8 @@
 		/obj/item/clothing/head/peaked = 3,
 		/obj/item/clothing/head/garrison = 2,
 		/obj/item/clothing/head/cowboy/sec = 3,
+		/obj/item/clothing/under/soldieruniform = 2,
+		/obj/item/clothing/head/panzer = 2,
 	)
 
 /obj/structure/closet/wardrobe/pink


### PR DESCRIPTION
[content]

## What this does
Adds some Nazi-themed equipment to security lockers including the wardrobe

## Why it's good
Bro, have you seen these fucking security players this year? There have probably been more uploads of NT Default and Robocop in the past two months than there were in the preceding two years...
They deserve the Nazi clothes roundstart in security with the way these wanna-be Gestapo nu-sec's act, they might as well start owning up to the reputation by now... in fact I'm thinking this addition might genuinely lead to interesting security roleplay at this rate (security roleplay, can you believe that?)

## Changelog
:cl:
 * rscadd: Adds basic Nazi clothes to the security wardrobe
 * rscadd: Adds Nazi soldier uniform, soldier coat, stalhelm, and Nazi knife to security officer lockers
 * rscadd: Adds Nazi soldier uniform, soldier coat, panzer cap, and Nazi knife to detective locker
 * rscadd: Adds Nazi officer uniform, officer coat, officer hat, and Nazi knife to warden locker
 * rscadd: Adds Nazi hardsuit, officer uniform, officer coat, officer hat, and Nazi knife to head of security locker
