### PR TITLE
Clowncart will not lay bananas on tiles that already have one.

### DIFF
--- a/code/game/objects/structures/vehicles/clowncart.dm
+++ b/code/game/objects/structures/vehicles/clowncart.dm
@@ -298,7 +298,7 @@
 
 		if(mode == MODE_DRAWING)
 			draw_graffiti(old_pos)
-		else if(mode == MODE_PEELS)
+		else if(mode == MODE_PEELS && !(locate(/obj/item/weapon/bananapeel) in src.loc.contents))
 			if(!emagged)
 				new /obj/item/weapon/bananapeel/(old_pos)
 				reagents.remove_reagent(BANANA,BANANA_FOR_NORMAL_PEEL)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Clowncarts set to banana mode will only lay banana peels on tiles that don't already have one, now.

## Why it's good
<!-- Explain why you think these changes are good. -->
Clowncarts set to banana mode can spawn a stupid amount of annoying peels. Having every tile in the main hallway be home to 4-5 banana peels is not only annoying for the crew, it causes a massive amount of server lag due to the amount of new objects being instantiated, and more often than not just necessitates the admins purging them all to make the game playable again. This will, hopefully, ameliorate that issue by preventing the clown from creating banana death stacks.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Clowncart will no longer lay banana peels on tiles that already have a banana peel on them.
