### PR TITLE
Roach farms can now make up to 100 cockroaches instead of just 50.

### DIFF
--- a/code/modules/mob/living/simple_animal/roach.dm
+++ b/code/modules/mob/living/simple_animal/roach.dm
@@ -248,7 +248,7 @@
 		animate(src, pixel_y = pixel_y - 8 * PIXEL_MULTIPLIER, 5, 1, ELASTIC_EASING)
 
 /mob/living/simple_animal/cockroach/proc/lay_eggs()
-	if((cockroach_egg_amount >= max_unhatchable_eggs_in_world) && (animal_count[src.type] >= ANIMAL_CHILD_CAP)) //If roaches can't breed anymore (too many of them), and there are more than 30 eggs in the world, don't create eggs
+	if((cockroach_egg_amount >= max_unhatchable_eggs_in_world) && (animal_count[src.type] >= ANIMAL_EXTENDED_CHILD_CAP)) //If roaches can't breed anymore (too many of them), and there are more than 30 eggs in the world, don't create eggs
 		last_laid_eggs = world.time
 		return
 
@@ -259,7 +259,7 @@
 	E.pixel_x = src.pixel_x
 	E.pixel_y = src.pixel_y
 
-	if((animal_count[src.type] < ANIMAL_CHILD_CAP))
+	if((animal_count[src.type] < ANIMAL_EXTENDED_CHILD_CAP))
 		last_laid_eggs = world.time //If the eggs can hatch, cooldown is 30 seconds
 		E.fertilize()
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -1,7 +1,7 @@
 var/const/ANIMAL_CHILD_CAP = 50
 var/const/ANIMAL_EXTENDED_CHILD_CAP = 100
 var/global/list/animal_count = list() //Stores types, and amount of animals of that type associated with the type (example: /mob/living/simple_animal/dog = 10)
-//Animals can't breed if amount of children exceeds 50
+//Animals can't breed if amount of children exceeds 50, except cockroaches, who can breed up to 100 children
 
 /mob/living/simple_animal
 	name = "animal"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -1,4 +1,5 @@
 var/const/ANIMAL_CHILD_CAP = 50
+var/const/ANIMAL_EXTENDED_CHILD_CAP = 100
 var/global/list/animal_count = list() //Stores types, and amount of animals of that type associated with the type (example: /mob/living/simple_animal/dog = 10)
 //Animals can't breed if amount of children exceeds 50
 


### PR DESCRIPTION
### What this does
Cockroaches now have an extended child cap of 100, double the previous value.
Closes #34060
### Why it's good
Factory farming cockroaches, gunk burgers eaten across the cosmos.
[tweak]
:cl:
 * tweak: Extends the child cap for cockroaches to 100, from 50.