### PR TITLE
Makes clothing items not cause slowdown when not explicitly worn

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -651,7 +651,7 @@
 		for(var/obj/item/I in get_all_slots())
 			if(I == src.back)
 				. *= max(1,I.slowdown / 2) // heavy items worn on the back. those shouldn't slow you down as much.
-			else
+			else if(!isclothing(I) || (isclothing(I) && (I in get_clothing_items())))
 				. *= I.slowdown
 
 		for(var/obj/item/I in held_items)


### PR DESCRIPTION
[bugfix]

## What this does
in particular, stops space blankets doing this when in your pocket and not worn
doesn't affect non clothing type objects like trash bags.
Closes #25590.

## Changelog
:cl:
 * bugfix: Space blanket and other things that are worn to cause slowdown no longer cause it from being in your pocket.