### PR TITLE
Improved dynamic armory manifest paper

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -14,6 +14,7 @@
 	pass_flags_self = PASSTABLE
 	health = 140
 	maxHealth = 140
+	on_armory_manifest = TRUE
 
 	machine_flags = EMAGGABLE
 

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -37,6 +37,7 @@ var/list/obj/machinery/flasher/flashers = list()
 	base_state = "pflash"
 	density = 1
 	min_harm_label = 35 //A lot. Has to wrap around the bulb, after all.
+	on_armory_manifest = TRUE
 
 /obj/machinery/flasher/power_change()
 	if ( powered() )

--- a/code/game/machinery/metaldetector.dm
+++ b/code/game/machinery/metaldetector.dm
@@ -22,6 +22,7 @@
 
 	flags = FPRINT | PROXMOVE
 	machine_flags = WRENCHMOVE | FIXED2WORK | EMAGGABLE
+	on_armory_manifest = TRUE
 
 	//List of weapons that metaldetector will not flash for, also copypasted in secbot.dm and ed209bot.dm
 	var/safe_weapons = list(

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -115,6 +115,7 @@
 	mask_type = /obj/item/clothing/mask/breath
 	boot_type = /obj/item/clothing/shoes/magboots
 	req_access = list(access_security)
+	holds_armory_items = TRUE
 
 /obj/machinery/suit_storage_unit/captain
 	name = "Command Suit Storage Unit"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -20,7 +20,6 @@
 	var/obj/item/offhand/wielded = null
 	pass_flags = PASSTABLE
 	pressure_resistance = 5
-	on_armory_manifest = TRUE
 //	causeerrorheresoifixthis
 	var/obj/item/master = null//apparently used by device assemblies to track the object they are attached to.
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -20,6 +20,7 @@
 	var/obj/item/offhand/wielded = null
 	pass_flags = PASSTABLE
 	pressure_resistance = 5
+	on_armory_manifest = TRUE
 //	causeerrorheresoifixthis
 	var/obj/item/master = null//apparently used by device assemblies to track the object they are attached to.
 

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -1,3 +1,6 @@
+/obj/item/weapon/melee
+	on_armory_manifest = TRUE
+
 /obj/item/weapon/melee/energy
 	var/active = 0
 	sharpness = 1.5 //very very sharp

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -1,5 +1,6 @@
 /obj/item/weapon/shield
 	name = "shield"
+	on_armory_manifest = TRUE
 
 /obj/item/weapon/shield/riot
 	name = "riot shield"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -33,6 +33,7 @@
 	autoignition_temperature = 522 // Kelvin
 	fire_fuel = 2
 	autoignition_temperature = AUTOIGNITION_PAPER
+	on_armory_manifest = TRUE
 
 /obj/item/weapon/storage/box/large
 	name = "large box"

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -50,8 +50,8 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 	//Does this item have a slime installed?
 	var/has_slime = 0
 
-	var/on_armory_manifest = FALSE
-	var/holds_armory_items = FALSE
+	var/on_armory_manifest = FALSE // Does this get included in the armory manifest paper?
+	var/holds_armory_items = FALSE // Does this check inside the object for stuff to include?
 
 	//Cooking stuff:
 	var/is_cooktop //If true, the object can be used in conjunction with a cooking vessel, eg. a frying pan, to cook food.

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -50,6 +50,9 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 	//Does this item have a slime installed?
 	var/has_slime = 0
 
+	var/on_armory_manifest = FALSE
+	var/holds_armory_items = FALSE
+
 	//Cooking stuff:
 	var/is_cooktop //If true, the object can be used in conjunction with a cooking vessel, eg. a frying pan, to cook food.
 	var/obj/item/weapon/reagent_containers/pan/cookvessel //The vessel being used to cook food in. If generalized out to other types of vessels, make sure to also generalize the frying pan's cook_start(), etc. as well.

--- a/code/game/objects/structures/crates_lockers/closets/secure/vault.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/vault.dm
@@ -29,7 +29,8 @@
 /obj/structure/closet/secure_closet/vault/armory
 	name = "\improper Armory vault locker"
 	req_access = list(access_armory)
-	
+	holds_armory_items = TRUE
+
 /obj/structure/closet/secure_closet/vault/armory/atoms_to_spawn()
 	if(Holiday == APRIL_FOOLS_DAY)
 		return list(

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -170,6 +170,7 @@
 	icon_state = "bombsuit"
 	icon_closed = "bombsuit"
 	icon_opened = "bombsuitopen"
+	holds_armory_items = TRUE
 
 /obj/structure/closet/bombcloset/atoms_to_spawn()
 	return list(

--- a/code/modules/clothing/accessories/holster.dm
+++ b/code/modules/clothing/accessories/holster.dm
@@ -6,6 +6,7 @@
 	var/obj/item/holstered = null
 	accessory_exclusion = HOLSTER
 	autoignition_temperature = AUTOIGNITION_ORGANIC //leather
+	on_armory_manifest = TRUE
 	var/holster_verb_name = "Holster"
 
 /obj/item/clothing/accessory/holster/proc/can_holster(obj/item/weapon/gun/W)

--- a/code/modules/clothing/accessories/storage.dm
+++ b/code/modules/clothing/accessories/storage.dm
@@ -89,14 +89,14 @@
 	icon_state = "vest_brown"
 	_color = "vest_brown"
 	storage_slots = 5
-	
+
 /obj/item/clothing/accessory/storage/fannypack
 	name = "fanny pack"
 	desc = "Extremely lame, but it's nice to have an extra pocket."
 	icon_state = "fannypack"
 	_color = "fannypack"
 	storage_slots = 1
-	
+
 /obj/item/clothing/accessory/storage/fannypack/preloaded/assistant/New()
 	..()
 	new /obj/item/clothing/accessory/assistantcard(hold)
@@ -108,6 +108,7 @@
 	_color = "bandolier"
 	storage_slots = 8
 	can_only_hold = list("/obj/item/ammo_casing", "/obj/item/projectile/bullet", "/obj/item/ammo_storage/magazine", "/obj/item/ammo_storage/speedloader", "/obj/item/stack/rcd_ammo", "/obj/item/weapon/grenade")
+	on_armory_manifest = TRUE
 
 /obj/item/clothing/accessory/storage/knifeharness
 	name = "decorated harness"

--- a/code/modules/clothing/head/tactical.dm
+++ b/code/modules/clothing/head/tactical.dm
@@ -3,6 +3,7 @@
 	body_parts_covered = HEAD|EARS|EYES|MASKHEADHAIR
 	species_fit = list()
 	autoignition_temperature = AUTOIGNITION_PROTECTIVE
+	on_armory_manifest = TRUE
 
 /obj/item/clothing/head/helmet/tactical/New()
 	..()

--- a/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
+++ b/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
@@ -306,6 +306,7 @@
 	siemens_coefficient = 0.7
 	pressure_resistance = 40 * ONE_ATMOSPHERE
 	head_type = /obj/item/clothing/head/helmet/space/rig/security
+	on_armory_manifest = TRUE
 
 /obj/item/clothing/suit/space/rig/security/fat
 	name = "expanded security hardsuit"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -22,6 +22,7 @@
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.6
 	autoignition_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
+	on_armory_manifest = TRUE
 
 
 /obj/item/clothing/suit/armor/vest

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -70,6 +70,7 @@
 	siemens_coefficient = 0
 	species_fit = list(VOX_SHAPED, INSECT_SHAPED)
 	autoignition_temperature = AUTOIGNITION_PROTECTIVE
+	on_armory_manifest = TRUE
 
 /obj/item/clothing/suit/bomb_suit
 	name = "bomb suit"
@@ -86,6 +87,7 @@
 	siemens_coefficient = 0
 	species_fit = list(VOX_SHAPED, INSECT_SHAPED)
 	autoignition_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
+	on_armory_manifest = TRUE
 
 /obj/item/clothing/head/bomb_hood/security
 	icon_state = "bombsuitsec"

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -761,10 +761,12 @@ var/global/list/paper_folding_results = list ( \
 /obj/item/weapon/paper/armory/initialize()
 	..()
 	var/area/armoryarea = locate(/area/security/armory) in areas
-	if(armoryarea)
+	var/area/wardenarea = locate(/area/security/warden) in areas
+	if(armoryarea || wardenarea)
 		info = "<h1> Secure Armory Item List </h1><br>"
 		var/list/obj/manifest_stuff = list()
-		for(var/obj/O in armoryarea)
+		var/list/stufftocheck = armoryarea.contents + wardenarea.contents
+		for(var/obj/O in stufftocheck)
 			if(isitem(O) || is_type_in_list(O,list(/obj/machinery/flasher/portable,/obj/machinery/detector,/obj/machinery/deployable/barrier)))
 				manifest_stuff += O
 			else if(is_type_in_list(O,list(/obj/structure/closet,/obj/machinery/suit_storage_unit)))

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -762,24 +762,19 @@ var/global/list/paper_folding_results = list ( \
 
 /obj/item/weapon/paper/inventory/initialize()
 	..()
-	var/list/stufftocheck = list()
-	var/areafound = FALSE
 	for(var/areatype in areastocheck)
 		var/area/A = locate(areatype) in areas
 		if(A)
-			areafound = TRUE
-			stufftocheck += A.contents
-	if(areafound)
-		info = "<h1> Secure Armory Item List </h1><br>"
-		var/list/obj/manifest_stuff = list()
-		for(var/obj/O in stufftocheck)
-			if(O.on_armory_manifest)
-				manifest_stuff += O
-			if(O.holds_armory_items)
-				for(var/obj/item/I in O.contents)
-					if(O.on_armory_manifest)
-						manifest_stuff += O
-		info += counted_english_list(manifest_stuff,"No items found.","","<br>","<br>")
+			info = "<h1>[A.name] Item List</h1><br>"
+			var/list/obj/manifest_stuff = list()
+			for(var/obj/O in A.contents)
+				if(O.on_armory_manifest)
+					manifest_stuff += O
+				if(O.holds_armory_items)
+					for(var/obj/item/I in O.contents)
+						if(O.on_armory_manifest)
+							manifest_stuff += O
+			info += "[counted_english_list(manifest_stuff,"No items found.","","<br>","<br>")]<br>"
 	else
 		info = "This station has been inspected by Nanotrasen Officers and has been found to not have any kind of [english_list(areastocheck,and_text = "or")]. If you believe to have received this manifest by mistake, contact Central Command."
 	update_icon()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -775,7 +775,8 @@ var/global/list/paper_folding_results = list ( \
 				manifest_stuff += O
 			if(O.holds_armory_items)
 				for(var/obj/item/I in O.contents)
-					manifest_stuff += O
+					if(O.on_armory_manifest)
+						manifest_stuff += O
 		info += counted_english_list(manifest_stuff,"No items found.","","<br>","<br>")
 	else
 		info = "This station has been inspected by Nanotrasen Officers and has been found to not have any kind of secure armory. If you believe to have received this manifest by mistake, contact Central Command."

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -756,7 +756,7 @@ var/global/list/paper_folding_results = list ( \
                          </h2> <BR></body></html>"}
 
 /obj/item/weapon/paper/inventory
-	name = "\improper Iventory Manifest"
+	name = "\improper Inventory Manifest"
 	desc = "A list of objects in an area to check against the current inventory for misplacement."
 	var/list/areastocheck = list()
 
@@ -782,5 +782,5 @@ var/global/list/paper_folding_results = list ( \
 	update_icon()
 
 /obj/item/weapon/paper/inventory/armory
-	name = "\improper Armory Iventory Manifest"
+	name = "\improper Armory Inventory Manifest"
 	areastocheck = list(/area/security/armory,/area/security/warden)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -771,9 +771,9 @@ var/global/list/paper_folding_results = list ( \
 		if(wardenarea)
 			stufftocheck += wardenarea.contents
 		for(var/obj/O in stufftocheck)
-			if(isitem(O) || is_type_in_list(O,list(/obj/machinery/flasher/portable,/obj/machinery/detector,/obj/machinery/deployable/barrier)))
+			if(O.on_armory_manifest)
 				manifest_stuff += O
-			else if(is_type_in_list(O,list(/obj/structure/closet,/obj/machinery/suit_storage_unit)))
+			if(O.holds_armory_items)
 				for(var/obj/item/I in O.contents)
 					manifest_stuff += O
 		info += counted_english_list(manifest_stuff,"No items found.","","<br>","<br>")

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -754,3 +754,23 @@ var/global/list/paper_folding_results = list ( \
                           <B>NOTICE.</B> Notice of intent to dissolve relationship must be given by fax with at least one day advance notice.<BR>
                           <B>FORCE MAJEURE.</B> This contract may be voided if the trade outpost is destroyed.
                          </h2> <BR></body></html>"}
+
+/obj/item/weapon/paper/armory
+	name = "\improper Armory Iventory Manifest"
+
+/obj/item/weapon/paper/armory/initialize()
+	..()
+	var/area/armoryarea = locate(/area/security/armory) in areas
+	if(armoryarea)
+		info = "<h1> Secure Armory Item List </h1><br>"
+		var/list/obj/manifest_stuff = list()
+		for(var/obj/O in armoryarea)
+			if(isitem(O) || is_type_in_list(O,list(/obj/machinery/flasher/portable,/obj/machinery/detector,/obj/machinery/deployable/barrier)))
+				manifest_stuff += O
+			else if(is_type_in_list(O,list(/obj/structure/closet,/obj/machinery/suit_storage_unit)))
+				for(var/obj/item/I in O.contents)
+					manifest_stuff += O
+		info += counted_english_list(manifest_stuff,"No items found.","","<br>","<br>")
+	else
+		info = "This station has been inspected by Nanotrasen Officers and has been found to not have any kind of secure armory. If you believe to have received this manifest by mistake, contact Central Command."
+	update_icon()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -755,21 +755,23 @@ var/global/list/paper_folding_results = list ( \
                           <B>FORCE MAJEURE.</B> This contract may be voided if the trade outpost is destroyed.
                          </h2> <BR></body></html>"}
 
-/obj/item/weapon/paper/armory
-	name = "\improper Armory Iventory Manifest"
+/obj/item/weapon/paper/inventory
+	name = "\improper Iventory Manifest"
+	desc = "A list of objects in an area to check against the current inventory for misplacement."
+	var/list/areastocheck = list()
 
-/obj/item/weapon/paper/armory/initialize()
+/obj/item/weapon/paper/inventory/initialize()
 	..()
-	var/area/armoryarea = locate(/area/security/armory) in areas
-	var/area/wardenarea = locate(/area/security/warden) in areas
-	if(armoryarea || wardenarea)
+	var/list/stufftocheck = list()
+	var/areafound = FALSE
+	for(var/areatype in areastocheck)
+		var/area/A = locate(areatype) in areas
+		if(A)
+			areafound = TRUE
+			stufftocheck += A.contents
+	if(areafound)
 		info = "<h1> Secure Armory Item List </h1><br>"
 		var/list/obj/manifest_stuff = list()
-		var/list/stufftocheck = list()
-		if(armoryarea)
-			stufftocheck += armoryarea.contents
-		if(wardenarea)
-			stufftocheck += wardenarea.contents
 		for(var/obj/O in stufftocheck)
 			if(O.on_armory_manifest)
 				manifest_stuff += O
@@ -779,5 +781,9 @@ var/global/list/paper_folding_results = list ( \
 						manifest_stuff += O
 		info += counted_english_list(manifest_stuff,"No items found.","","<br>","<br>")
 	else
-		info = "This station has been inspected by Nanotrasen Officers and has been found to not have any kind of secure armory. If you believe to have received this manifest by mistake, contact Central Command."
+		info = "This station has been inspected by Nanotrasen Officers and has been found to not have any kind of [english_list(areastocheck,and_text = "or")]. If you believe to have received this manifest by mistake, contact Central Command."
 	update_icon()
+
+/obj/item/weapon/paper/inventory/armory
+	name = "\improper Armory Iventory Manifest"
+	areastocheck = list(/area/security/armory,/area/security/warden)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -765,7 +765,11 @@ var/global/list/paper_folding_results = list ( \
 	if(armoryarea || wardenarea)
 		info = "<h1> Secure Armory Item List </h1><br>"
 		var/list/obj/manifest_stuff = list()
-		var/list/stufftocheck = armoryarea.contents + wardenarea.contents
+		var/list/stufftocheck = list()
+		if(armoryarea)
+			stufftocheck += armoryarea.contents
+		if(wardenarea)
+			stufftocheck += wardenarea.contents
 		for(var/obj/O in stufftocheck)
 			if(isitem(O) || is_type_in_list(O,list(/obj/machinery/flasher/portable,/obj/machinery/detector,/obj/machinery/deployable/barrier)))
 				manifest_stuff += O

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -762,9 +762,11 @@ var/global/list/paper_folding_results = list ( \
 
 /obj/item/weapon/paper/inventory/initialize()
 	..()
+	var/areafound = FALSE
 	for(var/areatype in areastocheck)
 		var/area/A = locate(areatype) in areas
 		if(A)
+			areafound = TRUE
 			info = "<h1>[A.name] Item List</h1><br>"
 			var/list/obj/manifest_stuff = list()
 			for(var/obj/O in A.contents)
@@ -774,8 +776,8 @@ var/global/list/paper_folding_results = list ( \
 					for(var/obj/item/I in O.contents)
 						if(O.on_armory_manifest)
 							manifest_stuff += O
-			info += counted_english_list(manifest_stuff,"No items found.","","<br>","<br>")
-	else
+			info += "[counted_english_list(manifest_stuff,"No items found.","","<br>","<br>")]<br>"
+	if(!areafound)
 		info = "This station has been inspected by Nanotrasen Officers and has been found to not have any kind of [english_list(areastocheck,and_text = "or")]. If you believe to have received this manifest by mistake, contact Central Command."
 	update_icon()
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -774,7 +774,7 @@ var/global/list/paper_folding_results = list ( \
 					for(var/obj/item/I in O.contents)
 						if(O.on_armory_manifest)
 							manifest_stuff += O
-			info += "[counted_english_list(manifest_stuff,"No items found.","","<br>","<br>")]<br>"
+			info += counted_english_list(manifest_stuff,"No items found.","","<br>","<br>")
 	else
 		info = "This station has been inspected by Nanotrasen Officers and has been found to not have any kind of [english_list(areastocheck,and_text = "or")]. If you believe to have received this manifest by mistake, contact Central Command."
 	update_icon()

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -63,6 +63,7 @@
 	w_class = W_CLASS_TINY
 	throw_speed = 4
 	throw_range = 5
+	on_armory_manifest = TRUE
 	var/list/stored_ammo = list()
 	var/ammo_type = "/obj/item/ammo_casing/a357"
 	var/exact = 1 //whether or not the item only takes ammo_type, or also subtypes. Set to 1 to only take the specified ammo

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -28,6 +28,7 @@
 	harm_label_examine = list("<span class='info'>A label is stuck to the trigger, but it is too small to get in the way.</span>", "<span class='warning'>A label firmly sticks the trigger to the guard!</span>")
 	ghost_read = 0
 	hitsound = 'sound/weapons/smash.ogg'
+	on_armory_manifest = TRUE
 	var/fire_sound = 'sound/weapons/Gunshot.ogg'
 	var/fire_action = "fire"
 	var/empty_sound = 'sound/weapons/empty.ogg'

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -57889,10 +57889,7 @@
 "ege" = (
 /obj/structure/table,
 /obj/item/weapon/storage/bag/clipboard,
-/obj/item/weapon/paper{
-	info = "<h1> Secure Armory </h1> <br>1 Laser Rifle <br>1 Mysterious Armor Suit<br>2 Mr. V.A.L.I.D. Portable Threat Detectors <br>2 Portable Flashers <br>4 Nanotrasen Universal Self-loading Pistols <br>4 .45 magazines (lethal) <br>3 sets of Security Hardsuits <br>3 sets of Riot Armor <br>3 Shotguns <br>3 Stun Batons <br>3 Riot Shields <br>3 Bandoliers <br>3 Energy Guns <br>3 Laser Guns <br>3 Ion Rifles <br>3 Bulletproof Vests <br>3 Armor Vests <br>1 Ablative Vest <br>4 Portable Barriers <br><h1> Armory </h1> <br>1 Box of spare Handcuffs <br>1 Box of spare R.O.B.U.S.T. cartridges <br>1 Box of Flashbangs <br>1 Box of Smoke Bombs <br>3 Gas Masks <br>1 Box of Shotgun Buckshot Shells <br>1 Box of Shotgun Slug Shells <br>1 Box of Shotgun Beanbag Shells <br>1 Box of Shotgun Dart Shells <br>1 Box of Shotgun Stun Shells <br>1 EOD Suit <br>1 Biohazard Suit <br>1 Lockbox with Loyalty Implants <br>1 Chemical Implant Kit <br>1 Tracking Implant Kit";
-	name = "Armory Inventory"
-	},
+/obj/item/weapon/paper/armory,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -57889,7 +57889,7 @@
 "ege" = (
 /obj/structure/table,
 /obj/item/weapon/storage/bag/clipboard,
-/obj/item/weapon/paper/armory,
+/obj/item/weapon/paper/inventory/armory,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;


### PR DESCRIPTION
[general][tweak]

## What this does
changes the static armory inventory paper found in some maps to a list of relevant objects inside the armory that gets built in initialisation, roughly to the same types it documents. doesn't even take long to init like this, <0.1 seconds.
Closes #34064.

## Why it's good
saves mappers hassle.

## Changelog
:cl:
 * tweak: Armory inventory papers are now much more consistently accurate at the start of shifts.