### PR TITLE
Adds an extra ghost warning to defibrilations when pads start setting up

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -308,6 +308,8 @@
 				ghostmob << 'sound/effects/adminhelp.ogg'
 				to_chat(ghostmob, "<span class='interface big'><span class='bold'>[message]</span> \
 					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
+				return TRUE
+	return FALSE
 
 /obj/machinery/dna_scannernew/conveyor_act(var/atom/movable/AM, var/obj/machinery/conveyor/CB)
 	if(isliving(AM))

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -295,17 +295,19 @@
 		if(C)
 			C.update_icon()
 			C.updateUsrDialog()
-			if(!M.client && M.mind)
-				var/mob/dead/observer/ghost = mind_can_reenter(M.mind)
-				if(ghost)
-					var/mob/ghostmob = ghost.get_top_transmogrification()
-					if(ghostmob)
-						ghostmob << 'sound/effects/adminhelp.ogg'
-						to_chat(ghostmob, "<span class='interface big'><span class='bold'>Your corpse has been placed into a cloning scanner. Return to your body if you want to be cloned!</span> \
-							(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
-				break
+			M.ghost_reenter_alert("Your corpse has been placed into a cloning scanner. Return to your body if you want to be cloned!")
 			break
 	return TRUE
+
+/mob/proc/ghost_reenter_alert(var/message) //!M.client = mob has ghosted out of their body
+	if(!client && mind)
+		var/mob/dead/observer/ghost = mind_can_reenter(mind)
+		if(ghost)
+			var/mob/ghostmob = ghost.get_top_transmogrification()
+			if(ghostmob)
+				ghostmob << 'sound/effects/adminhelp.ogg'
+				to_chat(ghostmob, "<span class='interface big'><span class='bold'>[message]</span> \
+					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
 
 /obj/machinery/dna_scannernew/conveyor_act(var/atom/movable/AM, var/obj/machinery/conveyor/CB)
 	if(isliving(AM))
@@ -363,14 +365,8 @@
 	return 0
 
 /obj/machinery/dna_scannernew/on_login(var/mob/M)
-	if(M.mind && !M.client && locate(/obj/machinery/computer/cloning) in range(src, 1)) //!M.client = mob has ghosted out of their body
-		var/mob/dead/observer/ghost = mind_can_reenter(M.mind)
-		if(ghost)
-			var/mob/ghostmob = ghost.get_top_transmogrification()
-			if(ghostmob)
-				ghostmob << 'sound/effects/adminhelp.ogg'
-				to_chat(ghostmob, "<span class='interface big'><span class='bold'>Your corpse has been placed into a cloning scanner. Return to your body if you want to be cloned!</span> \
-					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
+	if(locate(/obj/machinery/computer/cloning) in range(src, 1))
+		M.ghost_reenter_alert("Your corpse has been placed into a cloning scanner. Return to your body if you want to be cloned!")
 
 /obj/machinery/dna_scannernew/ex_act(severity)
 	//This is by far the oldest code I have ever seen, please appreciate how it's preserved in comments for distant posterity. Have some perspective of where we came from.

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -131,13 +131,7 @@
 	user.visible_message("<span class='notice'>[user] starts setting up the paddles on [target]'s chest.</span>", \
 	"<span class='notice'>You start setting up the paddles on [target]'s chest</span>")
 	if(target.mind && !target.client && target.get_heart() && target.get_organ(LIMB_HEAD) && target.has_brain() && !target.mind.suiciding && target.health+target.getOxyLoss() > config.health_threshold_dead)
-		var/mob/dead/observer/ghost = mind_can_reenter(target.mind)
-		if(ghost)
-			var/mob/ghostmob = ghost.get_top_transmogrification()
-			if(ghostmob)
-				ghostmob << 'sound/effects/adminhelp.ogg'
-				to_chat(ghostmob, "<span class='interface big'><span class='bold'>Someone is about to try to defibrilate your body. Return to it if you want to be resurrected!</span> \
-					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
+		target.ghost_reenter_message("Someone is about to try to defibrilate your body. Return to it if you want to be resurrected!")
 	if(do_after(user,target,30))
 		spark(src, 5, FALSE)
 		playsound(src,'sound/items/defib.ogg',50,1)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -131,7 +131,7 @@
 	user.visible_message("<span class='notice'>[user] starts setting up the paddles on [target]'s chest.</span>", \
 	"<span class='notice'>You start setting up the paddles on [target]'s chest</span>")
 	if(target.mind && !target.client && target.get_heart() && target.get_organ(LIMB_HEAD) && target.has_brain() && !target.mind.suiciding && target.health+target.getOxyLoss() > config.health_threshold_dead)
-		target.ghost_reenter_message("Someone is about to try to defibrilate your body. Return to it if you want to be resurrected!")
+		target.ghost_reenter_alert("Someone is about to try to defibrilate your body. Return to it if you want to be resurrected!")
 	if(do_after(user,target,30))
 		spark(src, 5, FALSE)
 		playsound(src,'sound/items/defib.ogg',50,1)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -130,6 +130,14 @@
 /obj/item/weapon/melee/defibrillator/proc/attemptDefib(mob/living/carbon/human/target,mob/user)
 	user.visible_message("<span class='notice'>[user] starts setting up the paddles on [target]'s chest.</span>", \
 	"<span class='notice'>You start setting up the paddles on [target]'s chest</span>")
+	if(target.mind && !target.client && target.get_heart() && target.get_organ(LIMB_HEAD) && target.has_brain() && !target.mind.suiciding && target.health > config.health_threshold_dead)
+		var/mob/dead/observer/ghost = mind_can_reenter(target.mind)
+		if(ghost)
+			var/mob/ghostmob = ghost.get_top_transmogrification()
+			if(ghostmob)
+				ghostmob << 'sound/effects/adminhelp.ogg'
+				to_chat(ghostmob, "<span class='interface big'><span class='bold'>Someone is about to try to defibrilate your body. Return to it if you want to be resurrected!</span> \
+					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
 	if(do_after(user,target,30))
 		spark(src, 5, FALSE)
 		playsound(src,'sound/items/defib.ogg',50,1)
@@ -168,7 +176,7 @@
 				var/mob/ghostmob = ghost.get_top_transmogrification()
 				if(ghostmob)
 					ghostmob << 'sound/effects/adminhelp.ogg'
-					to_chat(ghostmob, "<span class='interface big'><span class='bold'>Someone is trying to revive your body. Return to it if you want to be resurrected!</span> \
+					to_chat(ghostmob, "<span class='interface big'><span class='bold'>Someone has tried to defibrilate your body. Return to it if you want to be resurrected!</span> \
 						(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
 					target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. Vital signs are too weak, please try again in five seconds.</span>")
 					return

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -130,7 +130,7 @@
 /obj/item/weapon/melee/defibrillator/proc/attemptDefib(mob/living/carbon/human/target,mob/user)
 	user.visible_message("<span class='notice'>[user] starts setting up the paddles on [target]'s chest.</span>", \
 	"<span class='notice'>You start setting up the paddles on [target]'s chest</span>")
-	if(target.mind && !target.client && target.get_heart() && target.get_organ(LIMB_HEAD) && target.has_brain() && !target.mind.suiciding && target.health > config.health_threshold_dead)
+	if(target.mind && !target.client && target.get_heart() && target.get_organ(LIMB_HEAD) && target.has_brain() && !target.mind.suiciding && target.health+target.getOxyLoss() > config.health_threshold_dead)
 		var/mob/dead/observer/ghost = mind_can_reenter(target.mind)
 		if(ghost)
 			var/mob/ghostmob = ghost.get_top_transmogrification()

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -165,17 +165,10 @@
 			target.apply_damage(rand(1,5),BURN,LIMB_CHEST)
 			return
 		if(target.mind && !target.client) //Let's call up the ghost! Also, bodies with clients only, thank you.
-			var/mob/dead/observer/ghost = mind_can_reenter(target.mind)
-			if(ghost)
-				var/mob/ghostmob = ghost.get_top_transmogrification()
-				if(ghostmob)
-					ghostmob << 'sound/effects/adminhelp.ogg'
-					to_chat(ghostmob, "<span class='interface big'><span class='bold'>Someone has tried to defibrilate your body. Return to it if you want to be resurrected!</span> \
-						(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
-					target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. Vital signs are too weak, please try again in five seconds.</span>")
-					return
-			//we couldn't find a suitable ghost.
-			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. No brainwaves detected.</span>")
+			if(target.ghost_reenter_alert("Someone has tried to defibrilate your body. Return to it if you want to be resurrected!"))
+				target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. Vital signs are too weak, please try again in five seconds.</span>")
+			else //we couldn't find a suitable ghost.
+				target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. No brainwaves detected.</span>")
 			return
 		target.apply_damage(-target.getOxyLoss(),OXY)
 		target.updatehealth()

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -165,10 +165,7 @@
 			target.apply_damage(rand(1,5),BURN,LIMB_CHEST)
 			return
 		if(target.mind && !target.client) //Let's call up the ghost! Also, bodies with clients only, thank you.
-			if(target.ghost_reenter_alert("Someone has tried to defibrilate your body. Return to it if you want to be resurrected!"))
-				target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. Vital signs are too weak, please try again in five seconds.</span>")
-			else //we couldn't find a suitable ghost.
-				target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. No brainwaves detected.</span>")
+			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. [target.ghost_reenter_alert("Someone has tried to defibrilate your body. Return to it if you want to be resurrected!") ? "Vital signs are too weak, please try again in five seconds" : "No brainwaves detected"].</span>")
 			return
 		target.apply_damage(-target.getOxyLoss(),OXY)
 		target.updatehealth()

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -89,7 +89,7 @@
 
 /obj/item/weapon/melee/defibrillator/attack(mob/M,mob/user)
 	if(!ishuman(M))
-		to_chat(user, "<span class='warning'>You can't defibrilate [M]. You don't even know where to put the paddles!</span>")
+		to_chat(user, "<span class='warning'>You can't defibrillate [M]. You don't even know where to put the paddles!</span>")
 	else if(!charges)
 		to_chat(user, "<span class='warning'>[src] is out of charges.</span>")
 	else if(!ready)
@@ -131,7 +131,7 @@
 	user.visible_message("<span class='notice'>[user] starts setting up the paddles on [target]'s chest.</span>", \
 	"<span class='notice'>You start setting up the paddles on [target]'s chest</span>")
 	if(target.mind && !target.client && target.get_heart() && target.get_organ(LIMB_HEAD) && target.has_brain() && !target.mind.suiciding && target.health+target.getOxyLoss() > config.health_threshold_dead)
-		target.ghost_reenter_alert("Someone is about to try to defibrilate your body. Return to it if you want to be resurrected!")
+		target.ghost_reenter_alert("Someone is about to try to defibrillate your body. Return to it if you want to be resurrected!")
 	if(do_after(user,target,30))
 		spark(src, 5, FALSE)
 		playsound(src,'sound/items/defib.ogg',50,1)
@@ -165,7 +165,7 @@
 			target.apply_damage(rand(1,5),BURN,LIMB_CHEST)
 			return
 		if(target.mind && !target.client) //Let's call up the ghost! Also, bodies with clients only, thank you.
-			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. [target.ghost_reenter_alert("Someone has tried to defibrilate your body. Return to it if you want to be resurrected!") ? "Vital signs are too weak, please try again in five seconds" : "No brainwaves detected"].</span>")
+			target.visible_message("<span class='warning'>[src] buzzes: Defibrillation failed. [target.ghost_reenter_alert("Someone has tried to defibrillate your body. Return to it if you want to be resurrected!") ? "Vital signs are too weak, please try again in five seconds" : "No brainwaves detected"].</span>")
 			return
 		target.apply_damage(-target.getOxyLoss(),OXY)
 		target.updatehealth()

--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -445,10 +445,7 @@
 
 	//There's nothing wrong with the corpse itself past this point
 	if(!subject.client) //There is not a player "in control" of this corpse, maybe they ghosted, maybe they logged out
-		if(subject.ghost_reenter_alert("Someone is trying to clone your corpse. Return to your body if you want to be cloned!"))
-			scantemp = "Error: Subject's brain is not responding to scanning stimuli, subject may be brain dead. Please try again in five seconds."
-		else //No ghost matching this corpse. Guy probably either logged out or was revived by out-of-body means.
-			scantemp = "Error: Mental interface failure."
+		scantemp = "Error: [subject.ghost_reenter_alert("Someone is trying to clone your corpse. Return to your body if you want to be cloned!") ? "Subject's brain is not responding to scanning stimuli, subject may be brain dead. Please try again in five seconds" : "Mental interface failure"]."
 		return
 
 	//Past this point, we know for sure the corpse is cloneable and has a ghost inside.

--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -428,20 +428,9 @@
 			scantemp = "Error: Unable to locate valid genetic data. However, mental interface initialized successfully."
 			to_chat(subject, "<span class='interface'><span class='big bold'>Someone is trying to clone your corpse.</span> \
 				You cannot be cloned as your body has been husked. However, your brain may still be used. Your ghost has been displayed as active and inside your body.</span>")
-			return
 		else
-			var/mob/dead/observer/ghost = mind_can_reenter(subject.mind)
-			if(ghost)
-				var/mob/ghostmob = ghost.get_top_transmogrification()
-				if(ghostmob)
-					scantemp = "Error: Unable to locate valid genetic data. Additionally, subject's brain is not responding to scanning stimuli."
-					ghostmob << 'sound/effects/adminhelp.ogg'
-					to_chat(ghostmob, "<span class='interface'><span class='big bold'>Someone is trying to clone your corpse.</span> \
-						You cannot be cloned as your body has been husked. However, your brain may still be used. To show you're still active, return to your body! (Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
-					return
-			else
-				scantemp = "Error: Unable to locate valid genetic data. Additionally, mental interface failed to initialize."
-				return
+			scantemp = "Error: Unable to locate valid genetic data. Additionally, [subject.ghost_reenter_alert("Someone is trying to clone your corpse. You cannot be cloned as your body has been husked. However, your brain may still be used. To show you're still active, return to your body!") ? "subject's brain is not responding to scanning stimuli" : "mental interface failed to initialize"]."
+		return
 
 	//There's nothing wrong with the corpse itself past this point
 	if(!subject.client) //There is not a player "in control" of this corpse, maybe they ghosted, maybe they logged out

--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -445,18 +445,11 @@
 
 	//There's nothing wrong with the corpse itself past this point
 	if(!subject.client) //There is not a player "in control" of this corpse, maybe they ghosted, maybe they logged out
-		var/mob/dead/observer/ghost = mind_can_reenter(subject.mind)
-		if(ghost)
-			var/mob/ghostmob = ghost.get_top_transmogrification()
-			if(ghostmob) //Found this guy's ghost, and it still belongs to this corpse. There's nothing preventing this guy from being cloned, except them being ghosted
-				scantemp = "Error: Subject's brain is not responding to scanning stimuli, subject may be brain dead. Please try again in five seconds."
-				ghostmob << 'sound/effects/adminhelp.ogg'
-				to_chat(ghostmob, "<span class='interface big'><span class='bold'>Someone is trying to clone your corpse. Return to your body if you want to be cloned!</span> \
-					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
-				return
+		if(subject.ghost_reenter_alert("Someone is trying to clone your corpse. Return to your body if you want to be cloned!"))
+			scantemp = "Error: Subject's brain is not responding to scanning stimuli, subject may be brain dead. Please try again in five seconds."
 		else //No ghost matching this corpse. Guy probably either logged out or was revived by out-of-body means.
 			scantemp = "Error: Mental interface failure."
-			return
+		return
 
 	//Past this point, we know for sure the corpse is cloneable and has a ghost inside.
 	if(!subject.ckey) //ideally would never happen but a check never hurts

--- a/code/modules/medical/patientprocessor.dm
+++ b/code/modules/medical/patientprocessor.dm
@@ -8,16 +8,6 @@
 	var/input_dir = 1
 	output_dir = 2
 
-/obj/machinery/patient_processor/proc/notify_ghost(var/mob/M)
-	if(!M.client)
-		var/mob/dead/observer/ghost = mind_can_reenter(M.mind)
-		if(ghost)
-			var/mob/ghostmob = ghost.get_top_transmogrification()
-			if(ghostmob)
-				ghostmob << 'sound/effects/adminhelp.ogg'
-				to_chat(ghostmob, "<span class='interface big'><span class='bold'>You've been healed by the patient processor! Return to your body to get back into the round like you deserve.</span> \
-					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
-
 /obj/machinery/patient_processor/process()
 	if((!(output_dir in cardinal) || !(input_dir in cardinal)) || output_dir == input_dir || !anchored)
 		return
@@ -25,7 +15,7 @@
 	var/output = get_step(src, output_dir)
 	var/mob/living/M = locate(/mob/living, input)
 	if(M)
-		notify_ghost(M)
+		M.ghost_reenter_alert("You've been healed by the patient processor! Return to your body to get back into the round like you deserve.")
 		M.forceMove(output)
 		M.rejuvenate(animation = TRUE)
 		return
@@ -43,7 +33,7 @@
 		brainmob = brain.brainmob
 	if(!brainmob)
 		return
-	notify_ghost(brainmob)
+	brainmob.ghost_reenter_alert("You've been healed by the patient processor! Return to your body to get back into the round like you deserve.")
 
 	//produce a new body
 	var/datum/dna/new_dna = brainmob.dna.Clone()

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -159,7 +159,7 @@
 		// Checking to see if the ghost has been moused/borer'd/etc since death.
 		var/mob/living/carbon/brain/BM = BO.brainmob
 		if(!BM.client)
-			if(ghost_reenter_alert("Someone is trying to put your brain in a MMI. Return to your body if you want to be resurrected!"))
+			if(BM.ghost_reenter_alert("Someone is trying to put your brain in a MMI. Return to your body if you want to be resurrected!"))
 				to_chat(user, "<span class='warning'>\The [src] indicates that \the [O] seems slow to respond. Try again in a few seconds.</span>")
 				return TRUE
 			to_chat(user, "<span class='warning'>\The [src] indicates that \the [O] is completely unresponsive; there's no point.</span>")

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -159,10 +159,7 @@
 		// Checking to see if the ghost has been moused/borer'd/etc since death.
 		var/mob/living/carbon/brain/BM = BO.brainmob
 		if(!BM.client)
-			if(BM.ghost_reenter_alert("Someone is trying to put your brain in a MMI. Return to your body if you want to be resurrected!"))
-				to_chat(user, "<span class='warning'>\The [src] indicates that \the [O] seems slow to respond. Try again in a few seconds.</span>")
-				return TRUE
-			to_chat(user, "<span class='warning'>\The [src] indicates that \the [O] is completely unresponsive; there's no point.</span>")
+			to_chat(user, "<span class='warning'>\The [src] indicates that \the [O] [BM.ghost_reenter_alert("Someone is trying to put your brain in a MMI. Return to your body if you want to be resurrected!") ? "seems slow to respond. Try again in a few seconds" : "is completely unresponsive; there's no point"].</span>")
 			return TRUE
 		if(!user.drop_item(O))
 			to_chat(user, "<span class='warning'>You can't let go of \the [O]!</span>")

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -159,15 +159,9 @@
 		// Checking to see if the ghost has been moused/borer'd/etc since death.
 		var/mob/living/carbon/brain/BM = BO.brainmob
 		if(!BM.client)
-			var/mob/dead/observer/ghost = mind_can_reenter(BM.mind)
-			if(ghost)
-				var/mob/ghostmob = ghost.get_top_transmogrification()
-				if(ghostmob)
-					to_chat(user, "<span class='warning'>\The [src] indicates that \the [O] seems slow to respond. Try again in a few seconds.</span>")
-					ghostmob << 'sound/effects/adminhelp.ogg'
-					to_chat(ghostmob, "<span class='interface big'><span class='bold'>Someone is trying to put your brain in a MMI. Return to your body if you want to be resurrected!</span> \
-						(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
-					return TRUE
+			if(ghost_reenter_alert("Someone is trying to put your brain in a MMI. Return to your body if you want to be resurrected!"))
+				to_chat(user, "<span class='warning'>\The [src] indicates that \the [O] seems slow to respond. Try again in a few seconds.</span>")
+				return TRUE
 			to_chat(user, "<span class='warning'>\The [src] indicates that \the [O] is completely unresponsive; there's no point.</span>")
 			return TRUE
 		if(!user.drop_item(O))

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1003,13 +1003,7 @@ var/list/has_died_as_golem = list()
 			else
 				if(!client)
 					to_chat(user, "<span class='notice'>As you press \the [A] into \the [src], it shudders briefly, but falls still.</span>")
-					var/mob/dead/observer/ghost = mind_can_reenter(mind)
-					if(ghost)
-						var/mob/ghostmob = ghost.get_top_transmogrification()
-						if(ghostmob)
-							ghostmob << 'sound/effects/adminhelp.ogg'
-							to_chat(ghostmob, "<span class='interface big'><span class='bold'>Someone is trying to resurrect you. Return to your body if you want to live again!</span> \
-								(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
+					ghost_reenter_alert("Someone is trying to resurrect you. Return to your body if you want to live again!")
 				else
 					anim(target = src, a_icon = 'icons/mob/mob.dmi', flick_anim = "reverse-dust-g", sleeptime = 15)
 					var/mob/living/carbon/human/golem/G = new /mob/living/carbon/human/golem

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -2003,16 +2003,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 			if(brainmob.client)
 				mind_found = 1
 				to_chat(user, "<span class='notice'>[pick("The eyes","The jaw","The ears")] of \the [src] twitch ever so slightly.</span>")
-			else
-				var/mob/dead/observer/ghost = mind_can_reenter(brainmob.mind)
-				if(ghost)
-					var/mob/ghostmob = ghost.get_top_transmogrification()
-					if(ghostmob)//Lights are on but no-one's home
-						mind_found = 1
-						to_chat(user, "<span class='notice'>\The [src] stares blankly forward. The pupils dilate but otherwise it does not react to stimuli.</span>")
-						ghostmob << 'sound/effects/adminhelp.ogg'
-						to_chat(ghostmob, "<span class='interface big'><span class='bold'>Someone has found your head. Return to it if you want to be resurrected!</span> \
-							(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
+			else if(brainmob.ghost_reenter_alert("Someone has found your head. Return to it if you want to be resurrected!"))
+				mind_found = 1 //Lights are on but no-one's home
+				to_chat(user, "<span class='notice'>\The [src] stares blankly forward. The pupils dilate but otherwise it does not react to stimuli.</span>")
 			if(!mind_found)
 				to_chat(user, "<span class='danger'>\The [src] seems unresponsive to shock stimuli.</span>")
 		else

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_darkrevive.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_darkrevive.dm
@@ -32,15 +32,8 @@
 		return
 
 	if(target.mind && !target.client)
-		var/mob/dead/observer/ghost = mind_can_reenter(target.mind)
-		if(ghost)
-			var/mob/ghostmob = ghost.get_top_transmogrification()
-			if(ghostmob)
-				ghostmob << 'sound/effects/adminhelp.ogg'
-				to_chat(ghostmob, "<span class='interface big'><span class='bold'>Someone is trying to revive your body. Return to it if you want to be resurrected!</span> \
-					(Verbs -> Ghost -> Re-enter corpse, or <a href='?src=\ref[ghost];reentercorpse=1'>click here!</a>)</span>")
-				target.visible_message("<span class='warning'>[target] seems to shudder a bit.</span>")
-				return
+		if(target.ghost_reenter_alert("Someone is trying to revive your body. Return to it if you want to be resurrected!"))
+			target.visible_message("<span class='warning'>[target] seems to shudder a bit.</span>")
 		return
 
 	target.visible_message("<span class='warning'>[target] shudders, and starts breathing.</span>")


### PR DESCRIPTION
[tweak]

## What this does
adds this if ghosts can be reasonably revived when defibrillator pads are applied, with all the relative checks except the clothing covering ones due to probability.
also some code cleanup with the ghost alert message along the way to cut down on repetition of it.

## Why it's good
notifies observers in more due time that they're about to come back this way.

## Changelog
:cl:
 * tweak: Ghosts are now aware of being revived via defibrillators sooner.
 * tweak: Ghosts now know specifically if defibrillators are bringing them back.