### PR TITLE
Connection bullshit logging

### DIFF
--- a/code/ZZZ/ZZZ_stupid_logging.dm
+++ b/code/ZZZ/ZZZ_stupid_logging.dm
@@ -1,0 +1,22 @@
+/client/var/client_initialized = FALSE
+
+/client/New()
+	world.log << "/client/New(): [src] (\ref[src])"
+	client_initialized = TRUE
+	..()
+
+/client/Del()
+	world.log << "/client/Del(): [src] (\ref[src])[client_initialized ? "" : " UNINITIALIZED"]"
+	..()
+
+/mob/new_player/New()
+	world.log << "/mob/new_player/New(): [src] (\ref[src]) client [client] (\ref[client])"
+	..()
+
+/mob/new_player/Del()
+	world.log << "/mob/new_player/Del(): [src] (\ref[src]) client [client] (\ref[client])"
+	..()
+
+/mob/new_player/Login()
+	world.log << "/mob/new_player/Login(): [src] (\ref[src]) client [client] (\ref[client])"
+	..()

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2851,6 +2851,7 @@
 #include "code\ZAS\XGM.dm"
 #include "code\ZAS\XGM_gases.dm"
 #include "code\ZAS\Zone.dm"
+#include "code\ZZZ\ZZZ_stupid_logging.dm"
 #include "goon\code\datums\browserOutput.dm"
 #include "goon\code\obj\machinery\bot\chefbot.dm"
 #include "interface\interface.dm"


### PR DESCRIPTION
Some temporary logging stuff to try to diagnose some weird connection issue, at Pomf's request. Folder and file name are because it must come late in compile order to work properly. I did all this in one place instead of in each of these procs separately partially to avoid unnecessarily disrupting history, but mostly so it wouldn't conflict with the secret repo for the `client` ones