### PR TITLE
Space Drugs and Mescaline mutate biomolecules

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1240,7 +1240,6 @@
 	density = 5.23
 	specheatcap = 0.62
 
-
 /datum/reagent/space_drugs/on_mob_life(var/mob/living/M)
 
 	if(..())
@@ -1254,7 +1253,24 @@
 
 	if(prob(7))
 		M.emote(pick("twitch", "drool", "moan", "giggle"), null, null, TRUE)
-
+		
+/datum/reagent/space_drugs/on_plant_life(obj/machinery/portable_atmospherics/hydroponics/T)
+	if(!holder)
+		return
+	if(!T)
+		T = holder.my_atom //Try to find the mob through the holder
+	if(!istype(T)) //Still can't find it, abort
+		return
+	var/amount = T.reagents.get_reagent_amount(id)
+	if(amount >= 1)
+		if(prob(15))
+			T.mutate(GENE_BIOMOLECULES)
+			T.reagents.remove_reagent(id, 1)
+		if(prob(15))
+			T.mutate(GENE_BIOMOLECULES)
+	else if(amount > 0)
+		T.reagents.remove_reagent(id, amount)
+		
 /datum/reagent/holywater
 	name = "Holy Water"
 	id = HOLYWATER
@@ -2569,6 +2585,8 @@
 	if(T.reagents.get_reagent_amount(id) >= 1)
 		if(prob(1))
 			T.mutate(GENE_PHYTOCHEMISTRY)
+		if(prob(1))
+			T.mutate(GENE_BIOMOLECULES)
 		if(prob(1))
 			T.mutate(GENE_MORPHOLOGY)
 		if(prob(1))


### PR DESCRIPTION
## What this does
The [Biomolecules PR](https://github.com/vgstation-coders/vgstation13/pull/33985) didn't add a chem that can mutate biomolecules. This fixes that by making it so space drugs and mescaline can mutate it.
It also makes it so Left 4 Zed can mutate biomolecules as well, since L4Z can mutate ALL gene groups.
## Why it's good
Consistency with all other gene groups, adds a way to mutate biomolecules that doesn't require the botanic gene gun.
[consistency][oversight]
:cl:
 * rscadd: You can mutate the botanic Biomolecules gene with space drugs or mescaline.
 * bugfix: Left-4-Zed can mutate biomolecules as it should.