### PR TITLE
Adds two new virus symptoms and adds strength multiplier to three other symptoms

### DIFF
--- a/code/modules/virus2/effect/stage_2.dm
+++ b/code/modules/virus2/effect/stage_2.dm
@@ -210,21 +210,18 @@
 	if(istype(mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = mob
 		if(H.species.name == "Human")
+			var/beard_name = ""
 			spawn(50)
-				if(multiplier >= 1 && multiplier <= 1.9 && !(H.my_appearance.f_style == "Full Beard"))
-					H.my_appearance.f_style = "Full Beard"
-					to_chat(H, "<span class='warning'>Your chin and neck itch!.</span>")
-					H.update_hair()
-				if(multiplier >= 2 && multiplier <= 2.9  && !(H.my_appearance.f_style == "Long Beard"))
-					H.my_appearance.f_style = "Long Beard"
-					to_chat(H, "<span class='warning'>Your chin and neck itch!.</span>")
-					H.update_hair()
-				if(multiplier >= 3 && multiplier <= 3.9 && !(H.my_appearance.f_style == "Very Long Beard"))
-					H.my_appearance.f_style = "Very Long Beard"
-					to_chat(H, "<span class='warning'>Your chin and neck itch!.</span>")
-					H.update_hair()
-				if(multiplier >= 4 && !(H.my_appearance.f_style == "Dwarf Beard"))
-					H.my_appearance.f_style = "Dwarf Beard"
+				if(multiplier >= 1 && multiplier < 2)
+					beard_name = "Full Beard"
+				if(multiplier >= 2 && multiplier < 3)
+					beard_name = "Long Beard"
+				if(multiplier >= 3 && multiplier < 4)
+					beard_name = "Very Long Beard"
+				if(multiplier >= 4)
+					beard_name = "Dwarf Beard"
+				if(beard_name != "" && H.my_appearance.f_style != beard_name)
+					H.my_appearance.f_style = beard_name
 					to_chat(H, "<span class='warning'>Your chin and neck itch!.</span>")
 					H.update_hair()
 

--- a/code/modules/virus2/effect/stage_2.dm
+++ b/code/modules/virus2/effect/stage_2.dm
@@ -203,17 +203,30 @@
 	name = "Bearding"
 	desc = "Causes the infected to spontaneously grow a beard, regardless of gender. Only affects humans."
 	stage = 2
+	max_multiplier = 5
 	badness = EFFECT_DANGER_FLAVOR
 
 /datum/disease2/effect/beard/activate(var/mob/living/mob)
 	if(istype(mob, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = mob
-		if(H.species.name == "Human" && !(H.my_appearance.f_style == "Full Beard"))
-			to_chat(H, "<span class='warning'>Your chin and neck itch!.</span>")
+		if(H.species.name == "Human")
 			spawn(50)
-				H.my_appearance.f_style = "Full Beard"
-				H.update_hair()
-
+				if(multiplier >= 1 && multiplier <= 1.9 && !(H.my_appearance.f_style == "Full Beard"))
+					H.my_appearance.f_style = "Full Beard"
+					to_chat(H, "<span class='warning'>Your chin and neck itch!.</span>")
+					H.update_hair()
+				if(multiplier >= 2 && multiplier <= 2.9  && !(H.my_appearance.f_style == "Long Beard"))
+					H.my_appearance.f_style = "Long Beard"
+					to_chat(H, "<span class='warning'>Your chin and neck itch!.</span>")
+					H.update_hair()
+				if(multiplier >= 3 && multiplier <= 3.9 && !(H.my_appearance.f_style == "Very Long Beard"))
+					H.my_appearance.f_style = "Very Long Beard"
+					to_chat(H, "<span class='warning'>Your chin and neck itch!.</span>")
+					H.update_hair()
+				if(multiplier >= 4 && !(H.my_appearance.f_style == "Dwarf Beard"))
+					H.my_appearance.f_style = "Dwarf Beard"
+					to_chat(H, "<span class='warning'>Your chin and neck itch!.</span>")
+					H.update_hair()
 
 /datum/disease2/effect/bloodynose
 	name = "Intranasal Hemorrhage"

--- a/code/modules/virus2/effect/stage_3.dm
+++ b/code/modules/virus2/effect/stage_3.dm
@@ -194,12 +194,13 @@
 	if(ishuman(mob))
 		var/mob/living/carbon/human/affected = mob
 		if(multiplier >=2) //clown shoes added
-			var/obj/item/clothing/shoes/clown_shoes/virusshoes = new /obj/item/clothing/shoes/clown_shoes
-			virusshoes.canremove = 0
-			if(affected.shoes && !istype(affected.shoes, /obj/item/clothing/shoes/clown_shoes/))
+			if(affected.shoes && !istype(affected.shoes, /obj/item/clothing/shoes/clown_shoes))
+				var/obj/item/clothing/shoes/clown_shoes/virusshoes = new /obj/item/clothing/shoes/clown_shoes
+				virusshoes.canremove = 0
 				affected.u_equip(affected.shoes,1)
 				affected.equip_to_slot(virusshoes, slot_shoes)
 			if(!affected.shoes)
+				var/obj/item/clothing/shoes/clown_shoes/virusshoes = new /obj/item/clothing/shoes/clown_shoes
 				affected.equip_to_slot(virusshoes, slot_shoes)
 		if(multiplier >=3) //clown suit added
 			var/obj/item/clothing/under/rank/clown/virussuit = new /obj/item/clothing/under/rank/clown

--- a/code/modules/virus2/effect/stage_3.dm
+++ b/code/modules/virus2/effect/stage_3.dm
@@ -178,6 +178,7 @@
 	name = "Pierrot's Throat"
 	desc = "Overinduces a sense of humor in the infected, causing them to be overcome by the spirit of a clown."
 	stage = 3
+	max_multiplier = 4
 	badness = EFFECT_DANGER_HINDRANCE
 
 /datum/disease2/effect/pthroat/activate(var/mob/living/mob)
@@ -190,6 +191,30 @@
 		mob.equip_to_slot(virusclown_hat, slot_wear_mask)
 	mob.reagents.add_reagent(PSILOCYBIN, 20)
 	mob.say(pick("HONK!", "Honk!", "Honk.", "Honk?", "Honk!!", "Honk?!", "Honk..."))
+	if(ishuman(mob))
+		var/mob/living/carbon/human/affected = mob
+		if(multiplier >=2) //clown shoes added
+			var/obj/item/clothing/shoes/clown_shoes/virusshoes = new /obj/item/clothing/shoes/clown_shoes
+			virusshoes.canremove = 0
+			if(affected.shoes && !istype(affected.shoes, /obj/item/clothing/shoes/clown_shoes/))
+				affected.u_equip(affected.shoes,1)
+				affected.equip_to_slot(virusshoes, slot_shoes)
+			if(!affected.shoes)
+				affected.equip_to_slot(virusshoes, slot_shoes)
+		if(multiplier >=3) //clown suit added
+			var/obj/item/clothing/under/rank/clown/virussuit = new /obj/item/clothing/under/rank/clown
+			virussuit.canremove = 0
+			if(affected.w_uniform && !istype(affected.w_uniform, /obj/item/clothing/under/rank/clown/))
+				affected.u_equip(affected.w_uniform,1)
+				affected.equip_to_slot(virussuit, slot_w_uniform)
+			if(!affected.w_uniform)
+				affected.equip_to_slot(virussuit, slot_w_uniform)
+		if(multiplier >=3.5) //makes you clumsy
+			affected.dna.SetSEState(CLUMSYBLOCK,1)
+			genemutcheck(affected,CLUMSYBLOCK,null,MUTCHK_FORCED)
+			affected.update_mutations()
+
+
 
 /datum/disease2/effect/horsethroat
 	name = "Horse Throat"
@@ -856,12 +881,12 @@
 	)
 	// Getting sent to one of these areas would probably kill the person, so let's exclude them.
 	var/list/blacklisted_areas = list(
-		/area/engineering/engine_smes,		
+		/area/engineering/engine_smes,
 		/area/engineering/engine,
 		/area/science/xenobiology,
 	)
 	var/list/valid_areas = list()
-	var/active = 0 
+	var/active = 0
 
 /datum/disease2/effect/cult_teleport/activate(mob/living/carbon/mob)
 	if(valid_areas.len == 0)

--- a/code/modules/virus2/effect/stage_4.dm
+++ b/code/modules/virus2/effect/stage_4.dm
@@ -568,6 +568,7 @@
 	badness = EFFECT_DANGER_HARMFUL
 	chance = 10
 	max_chance = 20
+	max_multiplier = 4
 	var/old_r_hair = 0
 	var/old_g_hair = 0
 	var/old_b_hair = 0
@@ -654,15 +655,20 @@
 				var/list/possible_invocations = list(
 					"By Merlins beard!",
 					"Feel the power of the Dark Side!",
-					"NEC CANTIO!",
 					"AULIE OXIN FIERA!",
 					"STI KALY!",
 					"TARCOL MINTI ZHERI!")
 
-				if (count >= 40)
+				if (multiplier >= 1.5)
+					possible_invocations += "NEC CANTIO!"
+
+				if (multiplier >= 2)
+					possible_invocations += "E'MAGI!"
+
+				if (multiplier >= 3)
 					possible_invocations += "SCYAR NILA!"
 
-				if (count >= 60)
+				if (multiplier >= 3.5)
 					possible_invocations += "EI NATH!"//may the gods forgive me
 
 				var/spell_to_cast = pick(possible_invocations)
@@ -737,7 +743,7 @@
 										L+=T
 							if(L?.len)
 								mob.forceMove(pick(L))
-					if ("EI NATH!")//at least it's 1 out of 7, in a 2% chance to happen of an effect with a 10% (max 20%) to proc.
+					if ("EI NATH!")
 						var/list/targets = list()
 						for(var/mob/living/L in range(1, get_turf(mob)))
 							if (L != mob)
@@ -751,6 +757,11 @@
 										var/obj/item/organ/internal/brain/B = new(C.loc)
 										B.transfer_identity(C)
 								target.gib()
+					if ("E'MAGI!")
+						for(var/atom/AM in range (7, get_turf(mob)))
+							AM.arcane_act()
+
+
 
 			if(count >= 60)
 				spawn_wizard_clothes(mob)
@@ -1146,6 +1157,32 @@
 	if(ishuman(mob) && !isunathi(mob))
 		var/mob/living/carbon/human/H = mob
 		H.set_species("Unathi")
+		H.regenerate_icons()
+
+/datum/disease2/effect/insectoid
+	name = "Kafkaesque Syndrome"
+	desc =  "A previously experimental syndrome that found its way into the wild. Causes the infected to mutate into an Insectoid."
+	stage = 4
+	badness = EFFECT_DANGER_DEADLY
+
+/datum/disease2/effect/insectoid/activate(var/mob/living/mob)
+	if(ishuman(mob) && !isinsectoid(mob))
+		var/mob/living/carbon/human/H = mob
+		H.set_species("Insectoid")
+		H.regenerate_icons()
+		if(prob(5))
+			mob.say("How about if I sleep a little bit longer and forget all this nonsense.")
+
+/datum/disease2/effect/grey
+	name = "Grey Anatomy"
+	desc =  "A previously experimental syndrome that found its way into the wild. Causes the infected to mutate into a Grey."
+	stage = 4
+	badness = EFFECT_DANGER_DEADLY
+
+/datum/disease2/effect/grey/activate(var/mob/living/mob)
+	if(ishuman(mob) && !isgrey(mob))
+		var/mob/living/carbon/human/H = mob
+		H.set_species("Grey")
 		H.regenerate_icons()
 
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Just some stuff I wanted to add with the last PR I made, but never got round to doing it until now.

First, new symptoms. Adds an insectoid symptom and grey symptom for stage 4; in line with the other ones. (Kafka Syndrome + Grey Anatomy)

I also tweaked three other symptoms. One thing that has bothered me for a while is the limited extent to which the 'multiplier' effect is used in virology. For those not familiar, you can make a symptom more 'powerful', with the most obvious example being the awful anime symptom which has multiple effects, or the hand growth symptom where the number of hands you grow is linked to the strength of the symptom. 

This adds this effect to three other symptoms that didn't previously have it; Bearding, Pierrot's Throat and Wizarditis

Bearding:
The higher strength the symptom, the bigger the beard you get is, all the way up to a full dwarf beard.

Pierrot's Throat:
You can now increase the symptom strength to make the virus give people clown shoes (not lubed ones, but normal ones), and a clown uniform as well.

Wizarditis:
The spells that you can randomly cast are now linked to the strength of the symptom. At baseline you'll open doors, teleport around and temporarily blind people, but as the strength is increased more possible spells are added, so now you wont accidently disintergrate someone unless the strength has been manipulated. I also added Arcane Tamper as a possible spell that can be cast from this, with upgraded strength. 


## Why it's good
<!-- Explain why you think these changes are good. -->
More virus diversity; expands existing symptom strength mechanic to some new symptoms

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: added two new virus symptoms; Kafka Syndrome and Grey Anatomy.
 * tweak: Wizarditis; Bearding Syndrome and Pierrot's Throat can now have their effects strengthened, in line with other symptoms such as Protagonista.

[tweak]
