### PR TITLE
Using ghost spooking on doors flashes deny animation

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -511,6 +511,10 @@ var/list/all_doors = list()
 /obj/machinery/door/can_overload()
 	return 0
 
+/obj/machinery/door/spook()
+	if(..())
+		denied()
+
 // Flash denied and such.
 /obj/machinery/door/proc/denied()
 	if((Holiday == APRIL_FOOLS_DAY) && prob(10) || (prob(1) && prob(10))) // 1/1000 any time or 1/10 during April Fools to play the Half-Life "Access Denied" voiceover


### PR DESCRIPTION
[content]

## What this does
using the "boo!" spell on doors flashes the access denied stuff, if applicable.

## Why it's good
more things for ghost to mess with with the spell.

## Changelog
:cl:
 * rscadd: Doors can now deny access by themselves sometimes near ghosts... spooky.