### PR TITLE
Makes the Firefighter Buildable Again

### DIFF
--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -1597,24 +1597,19 @@
 
 /obj/item/mecha_parts/mecha_equipment/tool/ripleyupgrade
 	name = "Ripley MK-II Conversion Kit"
-	desc = "A pressurized canopy attachment kit for an Autonomous Power Loader Unit \"Ripley\" MK-I mecha, to convert it to the slower, but space-worthy MK-II design. This kit cannot be removed, once applied."
+	desc = "A pressurized canopy attachment kit for an Autonomous Power Loader Unit \"Ripley\" MK-I mecha, to convert it to the slower, but space-worthy MK-II design. Requires access to the internal compartments, and that the mech has a power source, is unoccupied and the cargo compartment is empty."
 	icon_state = "ripleyupgrade"
 
 /obj/item/mecha_parts/mecha_equipment/tool/ripleyupgrade/can_attach(obj/mecha/working/ripley/M)
 	if(M.enclosed) // i'm dumb and missed why istype wasn't working :c
-		to_chat(src, "<span class='warning'>This conversion kit can only be applied to APLU MK-I models.</span>")
 		return 0
 	if(M.cargo.len)
-		to_chat(src, "<span class='warning'>[M]'s cargo hold must be empty before this conversion kit can be applied.</span>")
 		return 0
 	if(!M.mech_maints_ready) //non-removable upgrade, so lets make sure the pilot or owner has their say.
-		to_chat(src, "<span class='warning'>[M] must have maintenance protocols active in order to allow this conversion kit.</span>")
 		return 0
 	if(M.occupant) //We're actualy making a new mech and swapping things over, it might get weird if players are involved
-		to_chat(src, "<span class='warning'>[M] must be unoccupied before this conversion kit can be applied.</span>")
 		return 0
 	if(!M.cell) //Turns out things break if the cell is missing
-		to_chat(src, "<span class='warning'>The conversion process requires a cell installed.</span>")
 		return 0
 	return 1
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -135,7 +135,7 @@
 				W.cargo -= O
 				T.Entered(O, src)
 
-	if(prob(30 || src.enclosed)) // no enclosed space no explosion :)
+	if(prob(30) && src.enclosed) // no enclosed space no explosion :)
 		explosion(T, 0, 0, 1, 3)
 	if(wreckage)
 		var/obj/effect/decal/mecha_wreckage/WR = new wreckage(T)

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -14,7 +14,7 @@
 
 	steps = list(
 					//1
-					list(Co_DESC="Cockpit wire mesh is installed.",
+					list(Co_DESC="Cockpit wire mesh is installed. It requires welding into place.",
 					 	Co_NEXTSTEP = list(Co_KEY=/obj/item/tool/weldingtool,
 					 		Co_AMOUNT = 3,
 					 		Co_VIS_MSG = "{USER} weld{s} external armor layer to {HOLDER}."),
@@ -22,7 +22,7 @@
 					 		Co_VIS_MSG = "{USER} unfasten{s} the cockpit wire screen.")
 					 	),
 					//2
-					 list(Co_DESC="Cockpit wire mesh is installed.",
+					 list(Co_DESC="Cockpit wire mesh is installed. It requires securing with a screwdriver.",
 					 	Co_NEXTSTEP = list(Co_KEY=/obj/item/tool/wrench,
 					 		Co_VIS_MSG = "{USER} secure{s} external armor layer."),
 					 	Co_BACKSTEP = list(Co_KEY=/obj/item/tool/crowbar,

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -31,7 +31,7 @@
 					 		Co_DELAY = 30,)
 					 	),
 					 //3
-					 list(Co_DESC="Internal armor is welded.",
+					 list(Co_DESC="Internal armor is welded. The unsealed cabin requires metal rods, for a screen. ",
 					 	Co_NEXTSTEP = list(Co_KEY=/obj/item/stack/rods,
 					 		Co_AMOUNT = 10,
 					 		Co_VIS_MSG = "{USER} install{s} a steel wire mesh to {HOLDER}'s cabin.",
@@ -157,7 +157,7 @@
 	result = "/obj/mecha/working/ripley"
 
 /datum/construction/reversible/mecha/firefighter
-	result = "/obj/mecha/working/ripley/firefighter"
+	result = "/obj/mecha/working/ripley/mk2/firefighter"
 	steps = list(
 					//1
 					list(Co_DESC="External armor is wrenched.",

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -23,7 +23,7 @@
 					 	),
 					//2
 					 list(Co_DESC="Cockpit wire mesh is installed. It requires securing with a screwdriver.",
-					 	Co_NEXTSTEP = list(Co_KEY=/obj/item/tool/wrench,
+					 	Co_NEXTSTEP = list(Co_KEY=/obj/item/tool/screwdriver,
 					 		Co_VIS_MSG = "{USER} secure{s} external armor layer."),
 					 	Co_BACKSTEP = list(Co_KEY=/obj/item/tool/crowbar,
 					 		Co_VIS_MSG = "{USER} prie{s} external armor layer from {HOLDER}.",


### PR DESCRIPTION
## What this does

You can now build the APLU "Firefighter MK-III Ripley" Mech Exosuit Mecha

Also improves MK1 construction feedback because I saw a MK1 ripley in an unfinished state probably because it's owner didn't know the next step/thought it was bugged out.

## Why it's good

Fixes an oversight.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Firefighter is buildable again, fixed lack of feedback for the MK1 Ripley.
