### PR TITLE
Instruments can now be played (and note-recorded) with keyboard input on focused windows

### DIFF
--- a/code/game/objects/items/devices/instruments.dm
+++ b/code/game/objects/items/devices/instruments.dm
@@ -44,7 +44,7 @@
 		return
 
 	user.set_machine(src)
-	song.interact(user,ui_key,ui,force_open)
+	song.ui_interact(user,ui_key,ui,force_open)
 
 /obj/item/device/instrument/proc/OnPlayed(mob/user,mob/M)
 	return

--- a/code/game/objects/items/devices/instruments.dm
+++ b/code/game/objects/items/devices/instruments.dm
@@ -36,7 +36,7 @@
 /obj/item/device/instrument/drum/drum_makeshift/bongos/attack_self(mob/user as mob)
 	interact(user)
 
-/obj/item/device/instrument/interact(mob/user as mob)
+/obj/item/device/instrument/ui_interact(mob/user, ui_key="main", datum/nanoui/ui=null, var/force_open=NANOUI_FOCUS)
 	if(!user)
 		return
 
@@ -44,7 +44,7 @@
 		return
 
 	user.set_machine(src)
-	song.interact(user)
+	song.interact(user,ui_key,ui,force_open)
 
 /obj/item/device/instrument/proc/OnPlayed(mob/user,mob/M)
 	return

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -153,10 +153,9 @@
 		repeat--
 	playing = 0
 	repeat = 0
-	interact(user)
+	ui_interact(user)
 
-//convert this to nanoui
-/datum/song/proc/interact(mob/user)
+/datum/song/ui_interact(mob/user, ui_key="main", datum/nanoui/ui=null, var/force_open=NANOUI_FOCUS)
 	var/data = list(
 		"repeat" = repeat,
 		"ticklag" = world.tick_lag,
@@ -169,14 +168,11 @@
 		"recording" = recording
 	)
 
-	var/datum/nanoui/ui = nanomanager.get_open_ui(user, src, "instrument")
+	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, "instrument", "instrument.tmpl", instrumentObj.name, 800, 600, nstatus_proc = /proc/nanoui_instrument_status_proc)
-		ui.add_stylesheet("instrument.css")
+		ui = new(user, src, ui_key, "pda_terminal.tmpl", src.name, 800, 700)
 		ui.set_initial_data(data)
 		ui.open()
-	else
-		ui.push_data(data)
 
 //copypaste but the src_object is the instrument
 //constants dont work for some reason
@@ -275,7 +271,7 @@
 					lines.Remove(l)
 				else
 					linenum++
-			interact(usr)		// make sure updates when complete
+			ui_interact(usr)		// make sure updates when complete
 	if(href_list["repeat"]) //Changing this from a toggle to a number of repeats to avoid infinite loops.
 		if(playing)
 			return //So that people cant keep adding to repeat. If the do it intentionally, it could result in the server crashing.
@@ -361,7 +357,7 @@
 			return
 
 		lines.Swap(index, index+dir)
-	interact(usr)
+	ui_interact(usr)
 
 	return
 /datum/song/proc/sanitize_tempo(new_tempo)
@@ -418,17 +414,17 @@
 	if(broken)
 		to_chat(user, "<span class='warning'>\The [src] is broken for good.</span>")
 		return 1
-	interact(user)
+	ui_interact(user)
 
 /obj/structure/piano/attack_paw(mob/user)
 	return src.attack_hand(user)
 
-/obj/structure/piano/interact(mob/user)
+/obj/structure/piano/ui_interact(mob/user, ui_key="main", datum/nanoui/ui=null, var/force_open=NANOUI_FOCUS)
 	if(!user || !anchored)
 		return
 
 	user.set_machine(src)
-	song.interact(user)
+	song.ui_interact(user,ui_key,ui,force_open)
 
 /obj/structure/piano/attackby(obj/item/O, mob/user, params)
 	if (O.is_wrench(user))

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -267,6 +267,9 @@
 		spawn()
 			playsong(usr)
 		return //no need to reload the window
+	else if(href_list["play_note"])
+		playnote(5, "n", 3, usr)
+		return //no need to reload the window
 	else if(href_list["newline"])
 		var/newline = input("Enter your line: ", instrumentObj.name) as text|null
 		if(!newline || !in_range(instrumentObj, usr))

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -268,8 +268,8 @@
 			playsong(usr)
 		return //no need to reload the window
 	else if(href_list["play_note"])
-		to_chat(usr,"Note is [href_list["play_note"]][href_list["play_sharpflat"]]-[href_list["play_oct"]]")
-		playnote(text2num(href_list["play_note"]), href_list["play_sharpflat"], text2num(href_list["play_oct"]), usr)
+		to_chat(usr,"Note is [href_list["play_note"]][href_list["play_sharp"]]-[href_list["play_oct"]]")
+		playnote(text2num(href_list["play_note"]), href_list["play_sharp"], text2num(href_list["play_oct"]), usr)
 		return //no need to reload the window
 	else if(href_list["newline"])
 		var/newline = input("Enter your line: ", instrumentObj.name) as text|null

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -81,7 +81,7 @@
 		else if(recorded_line != "")
 			recorded_line += ","
 			if(world.time - time_since_last_note > 5)
-				var/intervals = round(world.time - time_since_last_note/5)
+				var/intervals = round(world.time - time_since_last_note/5) - 1
 				for(var/i in 1 to intervals)
 					recorded_line += ","
 		recorded_line += "[ascii2text(note+64)][acc][oct]"

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -278,11 +278,9 @@
 	else if(href_list["increase_octave"])
 		if(live_octave_base < 8)
 			live_octave_base++
-		return //no need to reload the window
 	else if(href_list["decrease_octave"])
 		if(live_octave_base > 1)
 			live_octave_base--
-		return //no need to reload the window
 	else if(href_list["newline"])
 		var/newline = input("Enter your line: ", instrumentObj.name) as text|null
 		if(!newline || !in_range(instrumentObj, usr))

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -171,7 +171,7 @@
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
 		ui = new(user, src, "instrument", "instrument.tmpl", instrumentObj.name, 800, 600, nstatus_proc = /proc/nanoui_instrument_status_proc)
-		ui.add_stylesheet("instrument.css"
+		ui.add_stylesheet("instrument.css")
 		ui.set_initial_data(data)
 		ui.open()
 

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -268,7 +268,8 @@
 			playsong(usr)
 		return //no need to reload the window
 	else if(href_list["play_note"])
-		playnote(5, "n", 3, usr)
+		to_chat(usr,"Note is [href_list["play_note"]][href_list["play_sharpflat"]]-[href_list["play_oct"]]")
+		playnote(text2num(href_list["play_note"]), href_list["play_sharpflat"], text2num(href_list["play_oct"]), usr)
 		return //no need to reload the window
 	else if(href_list["newline"])
 		var/newline = input("Enter your line: ", instrumentObj.name) as text|null

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -294,8 +294,7 @@
 		if(href_list["play_sharp"] == "s")
 			href_list["play_sharp"] = "#"
 		playnote(text2num(href_list["play_note"]), href_list["play_sharp"], text2num(href_list["play_oct"]), usr, TRUE)
-		if(!recording)
-			return //no need to reload the window
+		return //no need to reload the window
 	else if(href_list["increase_octave"])
 		if(live_octave_base < 8)
 			live_octave_base++

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -14,6 +14,8 @@
 	var/instrumentExt = "ogg"		// the file extension
 	var/obj/instrumentObj = null	// the associated obj playing the sound
 
+	var/show_edithelp = TRUE
+	var/show_playhelp = FALSE
 	var/live_octave_base = 5 // the base octave of playing live with keyboard
 
 /datum/song/New(dir, obj)
@@ -143,7 +145,9 @@
 		"bpm" = round(600 / tempo),
 		"lines" = json_encode(lines),
 		"src" = "\ref[src]", //needed to create buttons in the js
-		"octave" = live_octave_base
+		"octave" = live_octave_base,
+		"show_playhelp" = show_playhelp,
+		"show_edithelp" = show_edithelp
 	)
 
 	var/datum/nanoui/ui = nanomanager.get_open_ui(user, src, "instrument")
@@ -281,6 +285,10 @@
 	else if(href_list["decrease_octave"])
 		if(live_octave_base > 1)
 			live_octave_base--
+	else if(href_list["toggle_playhelp"])
+		show_playhelp = !show_playhelp
+	else if(href_list["toggle_edithelp"])
+		show_edithelp = !show_edithelp
 	else if(href_list["newline"])
 		var/newline = input("Enter your line: ", instrumentObj.name) as text|null
 		if(!newline || !in_range(instrumentObj, usr))

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -170,7 +170,8 @@
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "pda_terminal.tmpl", src.name, 800, 700)
+		ui = new(user, src, "instrument", "instrument.tmpl", instrumentObj.name, 800, 600, nstatus_proc = /proc/nanoui_instrument_status_proc)
+		ui.add_stylesheet("instrument.css"
 		ui.set_initial_data(data)
 		ui.open()
 

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -81,7 +81,7 @@
 		else if(recorded_line != "")
 			recorded_line += ","
 			if(world.time - time_since_last_note > 5)
-				var/intervals = round(world.time - time_since_last_note/5) - 1
+				var/intervals = round((world.time - time_since_last_note)/5) - 1
 				for(var/i in 1 to intervals)
 					recorded_line += ","
 		recorded_line += "[ascii2text(note+64)][acc][oct]"

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -14,6 +14,8 @@
 	var/instrumentExt = "ogg"		// the file extension
 	var/obj/instrumentObj = null	// the associated obj playing the sound
 
+	var/live_octave_base = 5 // the base octave of playing live with keyboard
+
 /datum/song/New(dir, obj)
 	tempo = sanitize_tempo(tempo)
 	instrumentDir = dir
@@ -141,6 +143,7 @@
 		"bpm" = round(600 / tempo),
 		"lines" = json_encode(lines),
 		"src" = "\ref[src]" //needed to create buttons in the js
+		"ocatve" = live_octave_base
 	)
 
 	var/datum/nanoui/ui = nanomanager.get_open_ui(user, src, "instrument")
@@ -271,6 +274,14 @@
 		if(href_list["play_sharp"] == "s")
 			href_list["play_sharp"] = "#"
 		playnote(text2num(href_list["play_note"]), href_list["play_sharp"], text2num(href_list["play_oct"]), usr)
+		return //no need to reload the window
+	else if(href_list["increase_octave"])
+		if(live_octave_base < 8)
+			live_octave_base++
+		return //no need to reload the window
+	else if(href_list["decrease_octave"])
+		if(live_octave_base > 1)
+			live_octave_base--
 		return //no need to reload the window
 	else if(href_list["newline"])
 		var/newline = input("Enter your line: ", instrumentObj.name) as text|null

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -77,10 +77,11 @@
 		M.playsound_local(source, soundfile, 100, falloff = 5)
 	if(recording && live)
 		if(time_since_last_note - world.time <= 0 && last_note != "")
-			last_note += "-[ascii2text(note+64)][acc][oct]"
-		else
-			last_note += ",[ascii2text(note+64)][acc][oct]"
-	time_since_last_note = world.time
+			last_note += "-"
+		else if(last_note != "")
+			last_note += ","
+		last_note += "[ascii2text(note+64)][acc][oct]"
+		time_since_last_note = world.time
 
 /datum/song/proc/shouldStopPlaying(mob/user)
 	if(instrumentObj)

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -82,8 +82,9 @@
 			recorded_line += ","
 			if(world.time - time_since_last_note > 5)
 				var/intervals = round((world.time - time_since_last_note)/5) - 1
-				for(var/i in 1 to intervals)
-					recorded_line += ","
+				if(intervals)
+					for(var/i in 1 to intervals)
+						recorded_line += ","
 		recorded_line += "[ascii2text(note+64)][acc][oct]"
 		if(world.time - time_since_last_note <= 3)
 			recorded_line += "/2"
@@ -311,6 +312,9 @@
 			if(length(recorded_line) > INSTRUMENT_MAX_LINE_LENGTH)
 				recorded_line = html_encode(copytext(recorded_line, 1, INSTRUMENT_MAX_LINE_LENGTH))
 			lines.Add(recorded_line)
+		else if(recording)
+			recorded_line = ""
+			time_since_last_note = world.time
 	else if(href_list["newline"])
 		var/newline = input("Enter your line: ", instrumentObj.name) as text|null
 		if(!newline || !in_range(instrumentObj, usr))

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -270,7 +270,6 @@
 	else if(href_list["play_note"])
 		if(href_list["play_sharp"] == "s")
 			href_list["play_sharp"] = "#"
-		to_chat(usr,"Note is [href_list["play_note"]][href_list["play_sharp"]]-[href_list["play_oct"]]")
 		playnote(text2num(href_list["play_note"]), href_list["play_sharp"], text2num(href_list["play_oct"]), usr)
 		return //no need to reload the window
 	else if(href_list["newline"])

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -142,8 +142,8 @@
 		"ticklag" = world.tick_lag,
 		"bpm" = round(600 / tempo),
 		"lines" = json_encode(lines),
-		"src" = "\ref[src]" //needed to create buttons in the js
-		"ocatve" = live_octave_base
+		"src" = "\ref[src]", //needed to create buttons in the js
+		"octave" = live_octave_base
 	)
 
 	var/datum/nanoui/ui = nanomanager.get_open_ui(user, src, "instrument")

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -268,6 +268,8 @@
 			playsong(usr)
 		return //no need to reload the window
 	else if(href_list["play_note"])
+		if(href_list["play_sharp"] == "s")
+			href_list["play_sharp"] = "#"
 		to_chat(usr,"Note is [href_list["play_note"]][href_list["play_sharp"]]-[href_list["play_oct"]]")
 		playnote(text2num(href_list["play_note"]), href_list["play_sharp"], text2num(href_list["play_oct"]), usr)
 		return //no need to reload the window

--- a/nano/templates/instrument.tmpl
+++ b/nano/templates/instrument.tmpl
@@ -117,12 +117,14 @@ function messageReceived(){
 
 $(function() {
     $(window).keypress(function(e) {
-        if(e.which == "45" || e.which == 45) {
+        var numwhich = e.which;
+        numwhich = +numwhich; // number typecasting
+        if(numwhich == 45) {
             window.location = "byond://?src="+src_ref+"&decrease_octave=1";
-        } else if(e.which == "61" || e.which == 61) {
+        } else if(numwhich == 61) {
             window.location = "byond://?src="+src_ref+"&increase_octave=1";
         } else {
-            window.location = "byond://?src="+src_ref+"&play_note="+keyWhichToNote(e.which)+"&play_sharp="+keyWhichToSharp(e.which)+"&play_oct="+keyWhichToOctave(e.which);
+            window.location = "byond://?src="+src_ref+"&play_note="+keyWhichToNote(numwhich)+"&play_sharp="+keyWhichToSharp(numwhich)+"&play_oct="+keyWhichToOctave(numwhich);
         }
     });
 });
@@ -178,7 +180,6 @@ m = 109
 */
 
 function keyWhichToNote(which) {
-    which = +which;
     switch(which) {
         case 113:
         case 122:
@@ -227,7 +228,6 @@ function keyWhichToNote(which) {
 }
 
 function keyWhichToSharp(which) {
-    which = +which;
     switch(which) {
         case 50:
         case 115:
@@ -248,7 +248,6 @@ function keyWhichToSharp(which) {
 }
 
 function keyWhichToOctave(which) {
-    which = +which;
 	var octave = "{{:data.octave}}";
 	octave = +octave;
     switch(which) {

--- a/nano/templates/instrument.tmpl
+++ b/nano/templates/instrument.tmpl
@@ -12,6 +12,10 @@ Used In File(s): /code/game/objects/structures/musician.dm
 		{{else}}
 			{{:helper.link('Start recording', '', { 'toggle_recording' : 1 })}}
 		{{/if}}
+		0ctave:
+        {{:helper.link('-', '', { 'decrease_octave' : 1 })}}
+		{{:data.octave}}
+        {{:helper.link('+', '', { 'increase_octave' : 1 })}}
     </div>
     <div class="item">
         Repeat Song:
@@ -28,7 +32,7 @@ Used In File(s): /code/game/objects/structures/musician.dm
 <div class="item">
 	{{if data.show_playhelp}}
 		{{:helper.link('Hide Help', '', { 'toggle_playhelp' : 1 })}}
-		<div class="line">Press - to decrease playing octave and = to increase it. (Currently {{:data.octave}})<br>
+		<div class="line">Press - to decrease playing octave and = to increase it.<br>
 		Click "Start recording" to record keyboard inputs. The new line will be added when you click "Stop recording".<br>
 		The following keys represent these notes:<br>
 		<table style="height:50px; background:black">

--- a/nano/templates/instrument.tmpl
+++ b/nano/templates/instrument.tmpl
@@ -60,7 +60,7 @@ var src_ref = "{{:data.src}}";
 
 function renderLines(lines){
     var result = "<table>";
-    for (i = 0; i < lines.length; i++) { 
+    for (i = 0; i < lines.length; i++) {
         var curLine = lines[i].split(",");
         var htmlLine = [];
         for(j = 0; j < curLine.length; j++){
@@ -114,6 +114,13 @@ function messageReceived(){
     $('.buttonActive').stopTime('linkPending');
     $('.buttonActive').removeClass('linkPending');
 }
+
+$(function() {
+    $(window).keypress(function(e) {
+		$("#lines").html(e.which);
+        window.location = "byond://?src="+src_ref+"&play_note=1";
+    });
+});
 
 var lines = $.parseJSON($("#lines").text());
 renderLines(lines);

--- a/nano/templates/instrument.tmpl
+++ b/nano/templates/instrument.tmpl
@@ -23,7 +23,7 @@ Used In File(s): /code/game/objects/structures/musician.dm
 <div class="item">
 	{{if data.show_playhelp}}
 		{{:helper.link('Hide Help', '', { 'toggle_playhelp' : 1 })}}
-		<div class="line">Press - to decrease playing octave and = to increase it.<br>
+		<div class="line">Press - to decrease playing octave and = to increase it. (Currently {{:data.octave}})<br>
 		The following keys represent these notes:<br>
 		<table style="height:50px; background:black">
 			<tr>
@@ -155,7 +155,7 @@ $(function() {
     });
 });
 
-/*
+/* KEYBOARD KEYS TO EVENT.WHICH
 1 = 49
 2 = 50
 3 = 51

--- a/nano/templates/instrument.tmpl
+++ b/nano/templates/instrument.tmpl
@@ -233,7 +233,7 @@ function keyWhichToSharp(which) {
         case 104:
         case 55:
         case 106:
-            return "#";
+            return "s";
             break;
         default:
             return "n";

--- a/nano/templates/instrument.tmpl
+++ b/nano/templates/instrument.tmpl
@@ -21,6 +21,44 @@ Used In File(s): /code/game/objects/structures/musician.dm
     </div>
 </div>
 <div class="item">
+	{{if data.show_playhelp}}
+		{{:helper.link('Hide Help', '', { 'toggle_playhelp' : 1 })}}
+		<div class="line">Press - to decrease playing octave and = to increase it.<br>
+		The following keys represent these notes:<br>
+		<table style="height:50px; background:black">
+			<tr>
+				<td style="background:white; color:black">Z</td>
+				<td style="background:black; color:white">S</td>
+				<td style="background:white; color:black">X</td>
+				<td style="background:black; color:white">D</td>
+				<td style="background:white; color:black">C</td>
+				<td style="background:white; color:black">V</td>
+				<td style="background:black; color:white">G</td>
+				<td style="background:white; color:black">B</td>
+				<td style="background:black; color:white">H</td>
+				<td style="background:white; color:black">N</td>
+				<td style="background:black; color:white">J</td>
+				<td style="background:white; color:black">M</td>
+				<td style="background:white; color:black">,/Q</td>
+				<td style="background:black; color:white">2</td>
+				<td style="background:white; color:black">W</td>
+				<td style="background:black; color:white">3</td>
+				<td style="background:white; color:black">E</td>
+				<td style="background:white; color:black">R</td>
+				<td style="background:black; color:white">5</td>
+				<td style="background:white; color:black">T</td>
+				<td style="background:black; color:white">6</td>
+				<td style="background:white; color:black">Y</td>
+				<td style="background:black; color:white">7</td>
+				<td style="background:white; color:black">U</td>
+				<td style="background:white; color:black">I</td>
+			</tr>
+		</table></div>
+	{{else}}
+		{{:helper.link('Show Help', '', { 'toggle_playhelp' : 1 })}}
+	{{/if}}
+</div>
+<div class="item">
     <H3>Editing</H3>
     <div class="item">
         {{:helper.link('New Song', '', { 'newsong' : 1 })}}
@@ -32,25 +70,27 @@ Used In File(s): /code/game/objects/structures/musician.dm
     {{:helper.link('Add Line', '', { 'newline' : 1 })}}
 </div>
 <div class="item">
-    <B><button id="help_btn" onclick="helpVisibility()">Hide Help</button></B>
-    <span id="help">
-    <BR>
-    Lines are a series of chords, separated by commas (,), each with notes seperated by hyphens (-).<br>
-    Every note in a chord will play together, with chord timed by the tempo.<br>
-    <br>
-    Notes are played by the names of the note, and optionally, the accidental, and/or the octave number.<br>
-    By default, every note is natural and in octave 3. Defining otherwise is remembered for each note.<br>
-    Example: <i>C,D,E,F,G,A,B</i> will play a C major scale.<br>
-    After a note has an accidental placed, it will be remembered: <i>C,C4,C,C3</i> is C3,C4,C4,C3</i><br>
-    Chords can be played simply by seperating each note with a hyphon: <i>A-C#,Cn-E,E-G#,Gn-B</i><br>
-    A pause may be denoted by an empty chord: <i>C,E,,C,G</i><br>
-    To make a chord be a different time, end it with /x, where the chord length will be length<br>
-    defined by tempo / x: <i>C,G/2,E/4</i><br>
-    Combined, an example is: <i>E-E4/4,F#/2,G#/8,B/8,E3-E4/4</i>
-    <br>
-    Lines may be up to 50 characters.<br>
-    A song may only contain up to 50 lines.<br>
-    </span>
+	{{if data.show_edithelp}}
+		{{:helper.link('Hide Help', '', { 'toggle_edithelp' : 1 })}}
+		<div class="line">
+		Lines are a series of chords, separated by commas (,), each with notes seperated by hyphens (-).<br>
+		Every note in a chord will play together, with chord timed by the tempo.<br>
+		<br>
+		Notes are played by the names of the note, and optionally, the accidental, and/or the octave number.<br>
+		By default, every note is natural and in octave 3. Defining otherwise is remembered for each note.<br>
+		Example: <i>C,D,E,F,G,A,B</i> will play a C major scale.<br>
+		After a note has an accidental placed, it will be remembered: <i>C,C4,C,C3</i> is C3,C4,C4,C3</i><br>
+		Chords can be played simply by seperating each note with a hyphon: <i>A-C#,Cn-E,E-G#,Gn-B</i><br>
+		A pause may be denoted by an empty chord: <i>C,E,,C,G</i><br>
+		To make a chord be a different time, end it with /x, where the chord length will be length<br>
+		defined by tempo / x: <i>C,G/2,E/4</i><br>
+		Combined, an example is: <i>E-E4/4,F#/2,G#/8,B/8,E3-E4/4</i>
+		<br>
+		Lines may be up to 50 characters.<br>
+		A song may only contain up to 50 lines.</div>
+	{{else}}
+		{{:helper.link('Show Help', '', { 'toggle_edithelp' : 1 })}}
+	{{/if}}
 </div>
 <script>
 var prevChord = "";
@@ -93,18 +133,6 @@ function activeChord(lineIndex, chordIndex){
         $(prevChord).removeClass(highlightClass);
         $(id).addClass(highlightClass);
         prevChord = id;
-    }
-}
-
-function helpVisibility(){
-    if(helpvis == 1){
-        $("#help").show();
-        $("#help_btn").text("Hide Help");
-        helpvis = 0;
-    }else{
-        $("#help").hide();
-        $("#help_btn").text("Show Help");
-        helpvis = 1;
     }
 }
 

--- a/nano/templates/instrument.tmpl
+++ b/nano/templates/instrument.tmpl
@@ -117,10 +117,125 @@ function messageReceived(){
 
 $(function() {
     $(window).keypress(function(e) {
-		$("#lines").html(e.which);
-        window.location = "byond://?src="+src_ref+"&play_note=1";
+        window.location = "byond://?src="+src_ref+"&play_note="+keyWhichToNote(e.which)+"&play_sharp="+keyWhichToSharpFlat(e.which)+"&play_oct="+keyWhichToOctave(e.which);
     });
 });
+
+/*
+1 = 49
+2 = 50
+3 = 51
+4 = 52
+5 = 53
+6 = 54
+7 = 55
+8 = 56
+9 = 57
+0 = 48
+- = 45
+= = 61
+q = 113
+w = 119
+e = 101
+r = 114
+t = 116
+y = 121
+u = 117
+i = 105
+o = 111
+p = 112
+[ = 91
+] = 93
+a = 97
+s = 115
+d = 100
+f = 102
+g = 103
+h = 104
+j = 106
+k = 107
+l = 108
+; = 59
+' = 39
+# = 35
+\ = 92
+z = 122
+x = 120
+c = 99
+v = 118
+b = 98
+n = 110
+m = 109
+, = 44
+. = 46
+/ = 47
+*/
+
+function keyWhichToNote(which) {
+    switch(which) {
+        case 113:
+        case 122:
+        case 50:
+        case 115:
+		case 105:
+		case 44:
+            return 3;
+        case 119:
+        case 120:
+        case 51:
+        case 110:
+            return 4;
+        case 101:
+        case 99:
+            return 5;
+        case 114:
+        case 118:
+        case 53:
+        case 103:
+            return 6;
+        case 116:
+        case 98:
+        case 54:
+        case 104:
+            return 7;
+        case 121:
+        case 110:
+        case 55:
+        case 106:
+            return 1;
+        case 117:
+        case 109:
+            return 2;
+        default:
+            return 0;
+    }
+}
+
+function keyWhichToSharpFlat(which) {
+    switch(which) {
+        case 50:
+        case 115:
+        case 51:
+        case 110:
+        case 53:
+        case 103:
+        case 54:
+        case 104:
+        case 55:
+        case 106:
+            return "#";
+        default:
+            return "n";
+    }
+}
+
+function keyWhichToOctave(which) {
+    switch(which) {
+        default:
+            return 5;
+    }
+}
+
 
 var lines = $.parseJSON($("#lines").text());
 renderLines(lines);

--- a/nano/templates/instrument.tmpl
+++ b/nano/templates/instrument.tmpl
@@ -117,14 +117,12 @@ function messageReceived(){
 
 $(function() {
     $(window).keypress(function(e) {
-        var numwhich = e.which;
-        numwhich = +numwhich; // number typecasting
-        if(numwhich == 45) {
+        if(e.which == "45" || e.which == 45) {
             window.location = "byond://?src="+src_ref+"&decrease_octave=1";
-        } else if(numwhich == 61) {
+        } else if(e.which == "61" || e.which == 61) {
             window.location = "byond://?src="+src_ref+"&increase_octave=1";
         } else {
-            window.location = "byond://?src="+src_ref+"&play_note="+keyWhichToNote(numwhich)+"&play_sharp="+keyWhichToSharp(numwhich)+"&play_oct="+keyWhichToOctave(numwhich);
+            window.location = "byond://?src="+src_ref+"&play_note="+keyWhichToNote(e.which)+"&play_sharp="+keyWhichToSharp(e.which)+"&play_oct="+keyWhichToOctave(e.which);
         }
     });
 });
@@ -180,6 +178,7 @@ m = 109
 */
 
 function keyWhichToNote(which) {
+    which = +which;
     switch(which) {
         case 113:
         case 122:
@@ -228,6 +227,7 @@ function keyWhichToNote(which) {
 }
 
 function keyWhichToSharp(which) {
+    which = +which;
     switch(which) {
         case 50:
         case 115:
@@ -248,6 +248,7 @@ function keyWhichToSharp(which) {
 }
 
 function keyWhichToOctave(which) {
+    which = +which;
 	var octave = "{{:data.octave}}";
 	octave = +octave;
     switch(which) {

--- a/nano/templates/instrument.tmpl
+++ b/nano/templates/instrument.tmpl
@@ -37,31 +37,31 @@ Used In File(s): /code/game/objects/structures/musician.dm
 		The following keys represent these notes:<br>
 		<table style="height:50px; background:black">
 			<tr>
-				<td style="background:white; color:black">Z</td>
-				<td style="background:black; color:white">S</td>
-				<td style="background:white; color:black">X</td>
-				<td style="background:black; color:white">D</td>
-				<td style="background:white; color:black">C</td>
-				<td style="background:white; color:black">V</td>
-				<td style="background:black; color:white">G</td>
-				<td style="background:white; color:black">B</td>
-				<td style="background:black; color:white">H</td>
-				<td style="background:white; color:black">N</td>
-				<td style="background:black; color:white">J</td>
-				<td style="background:white; color:black">M</td>
-				<td style="background:white; color:black">,/Q</td>
-				<td style="background:black; color:white">2</td>
-				<td style="background:white; color:black">W</td>
-				<td style="background:black; color:white">3</td>
-				<td style="background:white; color:black">E</td>
-				<td style="background:white; color:black">R</td>
-				<td style="background:black; color:white">5</td>
-				<td style="background:white; color:black">T</td>
-				<td style="background:black; color:white">6</td>
-				<td style="background:white; color:black">Y</td>
-				<td style="background:black; color:white">7</td>
-				<td style="background:white; color:black">U</td>
-				<td style="background:white; color:black">I</td>
+				<td style="background:white; color:black">C<br>(Z)</td>
+				<td style="background:black; color:white">C#<br>(S)</td>
+				<td style="background:white; color:black">D<br>(X)</td>
+				<td style="background:black; color:white">D#<br>(D)</td>
+				<td style="background:white; color:black">E<br>(C)</td>
+				<td style="background:white; color:black">F<br>(V)</td>
+				<td style="background:black; color:white">F#<br>(G)</td>
+				<td style="background:white; color:black">G<br>(B)</td>
+				<td style="background:black; color:white">G#<br>(H)</td>
+				<td style="background:white; color:black">A<br>(N)</td>
+				<td style="background:black; color:white">A#<br>(J)</td>
+				<td style="background:white; color:black">B<br>(M)</td>
+				<td style="background:white; color:black">C<br>(,/Q)</td>
+				<td style="background:black; color:white">C#<br>(2)</td>
+				<td style="background:white; color:black">D<br>(W</td>
+				<td style="background:black; color:white">D#<br>(3)</td>
+				<td style="background:white; color:black">E<br>(E)</td>
+				<td style="background:white; color:black">F<br>(R)</td>
+				<td style="background:black; color:white">F#<br>(5)</td>
+				<td style="background:white; color:black">G<br>(T)</td>
+				<td style="background:black; color:white">G#<br>(6)</td>
+				<td style="background:white; color:black">A<br>(Y)</td>
+				<td style="background:black; color:white">A#<br>(7)</td>
+				<td style="background:white; color:black">B<br>(U)</td>
+				<td style="background:white; color:black">C<br>(I)</td>
 			</tr>
 		</table></div>
 	{{else}}

--- a/nano/templates/instrument.tmpl
+++ b/nano/templates/instrument.tmpl
@@ -12,7 +12,7 @@ Used In File(s): /code/game/objects/structures/musician.dm
 		{{else}}
 			{{:helper.link('Start recording', '', { 'toggle_recording' : 1 })}}
 		{{/if}}
-		0ctave:
+		Input octave:
         {{:helper.link('-', '', { 'decrease_octave' : 1 })}}
 		{{:data.octave}}
         {{:helper.link('+', '', { 'increase_octave' : 1 })}}

--- a/nano/templates/instrument.tmpl
+++ b/nano/templates/instrument.tmpl
@@ -7,6 +7,11 @@ Used In File(s): /code/game/objects/structures/musician.dm
     <div class="item">
         {{:helper.link('Play', '', { 'play' : 1 })}}
         {{:helper.link('Stop', '', { 'stop' : 1 })}}
+		{{if data.recording}}
+        	{{:helper.link('Stop recording', '', { 'toggle_recording' : 1 })}}
+		{{else}}
+			{{:helper.link('Start recording', '', { 'toggle_recording' : 1 })}}
+		{{/if}}
     </div>
     <div class="item">
         Repeat Song:

--- a/nano/templates/instrument.tmpl
+++ b/nano/templates/instrument.tmpl
@@ -29,6 +29,7 @@ Used In File(s): /code/game/objects/structures/musician.dm
 	{{if data.show_playhelp}}
 		{{:helper.link('Hide Help', '', { 'toggle_playhelp' : 1 })}}
 		<div class="line">Press - to decrease playing octave and = to increase it. (Currently {{:data.octave}})<br>
+		Click "Start recording" to record keyboard inputs. The new line will be added when you click "Stop recording".<br>
 		The following keys represent these notes:<br>
 		<table style="height:50px; background:black">
 			<tr>

--- a/nano/templates/instrument.tmpl
+++ b/nano/templates/instrument.tmpl
@@ -117,7 +117,7 @@ function messageReceived(){
 
 $(function() {
     $(window).keypress(function(e) {
-        window.location = "byond://?src="+src_ref+"&play_note="+keyWhichToNote(e.which)+"&play_sharp="+keyWhichToSharpFlat(e.which)+"&play_oct="+keyWhichToOctave(e.which);
+        window.location = "byond://?src="+src_ref+"&play_note="+keyWhichToNote(e.which)+"&play_sharp="+keyWhichToSharp(e.which)+"&play_oct="+keyWhichToOctave(e.which);
     });
 });
 
@@ -172,51 +172,61 @@ m = 109
 */
 
 function keyWhichToNote(which) {
+    which = +which;
     switch(which) {
         case 113:
         case 122:
         case 50:
         case 115:
-		case 105:
-		case 44:
+        case 105:
+        case 44:
             return 3;
+            break;
         case 119:
         case 120:
         case 51:
-        case 110:
+        case 100:
             return 4;
+            break;
         case 101:
         case 99:
             return 5;
+            break;
         case 114:
         case 118:
         case 53:
         case 103:
             return 6;
+            break;
         case 116:
         case 98:
         case 54:
         case 104:
             return 7;
+            break;
         case 121:
         case 110:
         case 55:
         case 106:
             return 1;
+            break;
         case 117:
         case 109:
             return 2;
+            break;
         default:
             return 0;
+            break;
     }
 }
 
-function keyWhichToSharpFlat(which) {
+function keyWhichToSharp(which) {
+	which = +which;
     switch(which) {
         case 50:
         case 115:
         case 51:
-        case 110:
+        case 100:
         case 53:
         case 103:
         case 54:
@@ -224,18 +234,53 @@ function keyWhichToSharpFlat(which) {
         case 55:
         case 106:
             return "#";
+            break;
         default:
             return "n";
+            break;
     }
 }
 
 function keyWhichToOctave(which) {
+    which = +which;
     switch(which) {
-        default:
+        case 113:
+        case 119:
+        case 101:
+        case 114:
+        case 116:
+        case 121:
+        case 117:
+        case 50:
+        case 51:
+        case 53:
+        case 54:
+        case 55:
+        case 44:
             return 5;
+            break;
+        case 122:
+        case 120:
+        case 99:
+        case 118:
+        case 98:
+        case 110:
+        case 109:
+        case 115:
+        case 100:
+        case 103:
+        case 104:
+        case 106:
+            return 4;
+            break;
+        case 105:
+            return 6;
+            break;
+        default:
+            return 0;
+            break;
     }
 }
-
 
 var lines = $.parseJSON($("#lines").text());
 renderLines(lines);

--- a/nano/templates/instrument.tmpl
+++ b/nano/templates/instrument.tmpl
@@ -117,7 +117,12 @@ function messageReceived(){
 
 $(function() {
     $(window).keypress(function(e) {
-        window.location = "byond://?src="+src_ref+"&play_note="+keyWhichToNote(e.which)+"&play_sharp="+keyWhichToSharp(e.which)+"&play_oct="+keyWhichToOctave(e.which);
+		if(e.which == "45" || e.which == 45)
+			window.location = "byond://?src="+src_ref+"&decrease_octave=1;
+		else if(e.which == "61" || e.which == 61)
+			window.location = "byond://?src="+src_ref+"&increase_octave=1;
+		else
+        	window.location = "byond://?src="+src_ref+"&play_note="+keyWhichToNote(e.which)+"&play_sharp="+keyWhichToSharp(e.which)+"&play_oct="+keyWhichToOctave(e.which);
     });
 });
 
@@ -243,6 +248,8 @@ function keyWhichToSharp(which) {
 
 function keyWhichToOctave(which) {
     which = +which;
+	var octave = "{{:data.octave}}";
+	octave = +octave;
     switch(which) {
         case 113:
         case 119:
@@ -257,7 +264,7 @@ function keyWhichToOctave(which) {
         case 54:
         case 55:
         case 44:
-            return 5;
+            return octave;
             break;
         case 122:
         case 120:
@@ -271,10 +278,10 @@ function keyWhichToOctave(which) {
         case 103:
         case 104:
         case 106:
-            return 4;
+            return octave-1;
             break;
         case 105:
-            return 6;
+            return octave+1;
             break;
         default:
             return 0;

--- a/nano/templates/instrument.tmpl
+++ b/nano/templates/instrument.tmpl
@@ -117,12 +117,13 @@ function messageReceived(){
 
 $(function() {
     $(window).keypress(function(e) {
-		if(e.which == "45" || e.which == 45)
-			window.location = "byond://?src="+src_ref+"&decrease_octave=1;
-		else if(e.which == "61" || e.which == 61)
-			window.location = "byond://?src="+src_ref+"&increase_octave=1;
-		else
-        	window.location = "byond://?src="+src_ref+"&play_note="+keyWhichToNote(e.which)+"&play_sharp="+keyWhichToSharp(e.which)+"&play_oct="+keyWhichToOctave(e.which);
+        if(e.which == "45" || e.which == 45) {
+            window.location = "byond://?src="+src_ref+"&decrease_octave=1";
+        } else if(e.which == "61" || e.which == 61) {
+            window.location = "byond://?src="+src_ref+"&increase_octave=1";
+        } else {
+            window.location = "byond://?src="+src_ref+"&play_note="+keyWhichToNote(e.which)+"&play_sharp="+keyWhichToSharp(e.which)+"&play_oct="+keyWhichToOctave(e.which);
+        }
     });
 });
 

--- a/nano/templates/instrument.tmpl
+++ b/nano/templates/instrument.tmpl
@@ -221,7 +221,7 @@ function keyWhichToNote(which) {
 }
 
 function keyWhichToSharp(which) {
-	which = +which;
+    which = +which;
     switch(which) {
         case 50:
         case 115:


### PR DESCRIPTION
[content]

## What this does
adds a method for playing instruments live with a keyboard, while the input is focused in the window for it. can also record inputs to lines, but this is probably a janky feature only good for sketching out ideas to edit later.
help screen for it:
![image](https://user-images.githubusercontent.com/87321915/220246277-2966d196-fdb1-4c54-929a-21a1fd1dc6a5.png)

## Why it's good
live playing is now possible, albeit in an awkward yet familiar manner for anyone who's done this in a DAW like FL studio or reaper, also a debatably less awkward way to input songs.

## Changelog
:cl:
 * rscadd: Instruments now accept user keyboard input in their windows while focused for live playing, alongside a mode for recording lines to play back later.