### PR TITLE
Reduces Boo! cooldown from 60s to 30s.

### DIFF
--- a/code/modules/mob/dead/observer/spells.dm
+++ b/code/modules/mob/dead/observer/spells.dm
@@ -45,7 +45,7 @@ var/global/list/boo_phrases_silicon=list(
 	spell_flags = STATALLOWED | GHOSTCAST
 
 	school = "transmutation"
-	charge_max = 60 SECONDS
+	charge_max = 30 SECONDS
 	invocation = ""
 	invocation_type = SpI_NONE
 	range = 1 // Or maybe 3?


### PR DESCRIPTION
### What this does
The observer/ghost Boo! spell now needs only 30s to recharge.
### Why it's good
Boo! takes too long to recharge for the effect it has on a round (next to none), the obsgang deserves some love.
:cl:
 * tweak: The ghost Boo! spell takes 30s to recharge (from 60s).