### PR TITLE
A small attempt at making the Meteors gamemode flow better.

### DIFF
--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -460,9 +460,9 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 /datum/command_alert/meteor_round/announce()
 	meteor_delay = rand(4500, 6000)
 	if(prob(70)) //slightly off-scale
-		message = "A meteor storm has been detected in proximity of [station_name()] and is expected to strike within [round((rand(meteor_delay - 600, meteor_delay + 600))/600)] minutes. A backup emergency shuttle is being dispatched and emergency gear should be teleported into your station's Bar area in [supply_delay/10] seconds."
+		message = "A meteor storm has been detected in proximity of [station_name()] and is expected to strike within [round((rand(meteor_delay - 600, meteor_delay + 600))/600)] minutes. A backup emergency shuttle is being dispatched and emergency gear should be teleported into your station's Bar area in [supply_delay/10] seconds. Access requirements for non-critical areas has been lifted."
 	else
-		message = "A meteor storm has been detected in proximity of [station_name()] and is expected to strike within [round((rand(meteor_delay - 1800, meteor_delay + 1800))/600)] minutes. A backup emergency shuttle is being dispatched and emergency gear should be teleported into your station's Bar area in [supply_delay/10] seconds."
+		message = "A meteor storm has been detected in proximity of [station_name()] and is expected to strike within [round((rand(meteor_delay - 1800, meteor_delay + 1800))/600)] minutes. A backup emergency shuttle is being dispatched and emergency gear should be teleported into your station's Bar area in [supply_delay/10] seconds. Access requirements for non-critical areas has been lifted."
 	..()
 
 ////small meteor storm

--- a/code/game/gamemodes/meteor/meteor_supply.dm
+++ b/code/game/gamemodes/meteor/meteor_supply.dm
@@ -135,13 +135,13 @@
 //Power to run all that fancy shit. Partially at least, evacuating the AME isn't a bad idea
 /obj/structure/closet/crate/secure/large/meteor_power
 	name = "\improper Space Weather Inc. emergency generator"
-	desc = "Uranium-powered SUPERPACMAN emergency generator. Keep away from meteors."
+	desc = "Diamond-powered MRSPACMAN emergency generator. Keep away from meteors."
 
 /obj/structure/closet/crate/secure/large/meteor_power/New()
 
 	..()
-	new /obj/machinery/power/port_gen/pacman/super(src)
-	new /obj/item/stack/sheet/mineral/uranium(src, 50)
+	new /obj/machinery/power/port_gen/pacman/mrs(src)
+	new /obj/item/stack/sheet/mineral/diamond(src, 50)
 
 /obj/structure/closet/crate/engi/meteor_breach
 	name = "\improper Space Weather Inc. anti-breach kit"

--- a/code/game/gamemodes/meteor/meteor_universe.dm
+++ b/code/game/gamemodes/meteor/meteor_universe.dm
@@ -26,6 +26,12 @@
 
 /datum/universal_state/meteor_storm/OnEnter()
 
+// Egalitarian mode A.K.A no access requirements except prison and bridge
+	for(var/obj/machinery/door/airlock/W in all_doors)
+		if(W.z == STATION_Z  && !istype(get_area(W), /area/bridge) && !istype(get_area(W), /area/crew_quarters) && !istype(get_area(W), /area/security/prison))
+			W.backup_access = W.req_access
+			W.req_access = list()
+
 	sleep(meteor_extra_announce_delay) //Pause everything as according to the extra delay
 
 	world << sound('sound/machines/warning.ogg') //The same chime as the Delta countdown, just twice
@@ -40,7 +46,7 @@
 	CA.supply_delay = supply_delay
 	command_alert(CA)
 
-	message_admins("Meteor Storm announcement given. Meteors will arrive in approximately [round(meteor_delay/600)] minutes. Shuttle will take [10*meteor_shuttle_multiplier] minutes to arrive and supplies are about to be dispatched in the Bar.")
+	message_admins("Meteor Storm announcement given. Meteors will arrive in approximately [round(meteor_delay/600)] minutes. Shuttle will take [10*meteor_shuttle_multiplier] minutes to arrive and supplies are about to be dispatched in the Bar. Egalitarian mode enabled.")
 
 	spawn(100) //Time for the announcement to spell out)
 

--- a/code/game/gamemodes/meteor/meteor_universe.dm
+++ b/code/game/gamemodes/meteor/meteor_universe.dm
@@ -28,7 +28,7 @@
 
 // Egalitarian mode A.K.A no access requirements except prison and bridge
 	for(var/obj/machinery/door/airlock/W in all_doors)
-		if(W.z == STATION_Z  && !istype(get_area(W), /area/bridge) && !istype(get_area(W), /area/crew_quarters) && !istype(get_area(W), /area/security/prison))
+		if(W.z == 1  && !istype(get_area(W), /area/bridge) && !istype(get_area(W), /area/crew_quarters) && !istype(get_area(W), /area/security/prison))
 			W.backup_access = W.req_access
 			W.req_access = list()
 


### PR DESCRIPTION
## What this does
Replaces the meteors gamemode SUPERPACMAN emergency engine with a MRSPACMAN engine.
Enables Egalitarian mode (no access requirements except in brig and bridge) during a meteors round.
## Why it's good
The biggest bottlenecks (in my opinion) with meteors survival are access and power. The SUPERPACMAN is not strong enough to power the station and shielding machinery, you can't depend on engineering or cargo for power, as they're some of the first places to go, and the desperate reinforcements everywhere demands less restrictive access.
[gamemode]
:cl:
 * rscadd: Access requirements during a Meteor storm (Meteors Gamemode) are lifted for all airlocks except brig and bridge.
 * tweak: Changes the Meteors Gamemode 'Space Weather Inc. emergency generator' crate to have a MRSPACMAN and Diamond instead of a SUPERPACMAN and Uranium.