### PR TITLE
Slow explosion effect debug logging + a fix

### DIFF
--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -351,11 +351,11 @@
 	src.stat |= BROKEN // enables the BROKEN bit
 	src.icon_state = "destroyed_target_prism"
 	invisibility = 0
-	sleep(3)
-	flick("explosion", src)
-	src.setDensity(TRUE)
-	if (cover!=null) // deletes the cover - no need on keeping it there!
-		QDEL_NULL(cover)
+	spawn(3)
+		flick("explosion", src)
+		src.setDensity(TRUE)
+		if (cover!=null) // deletes the cover - no need on keeping it there!
+			QDEL_NULL(cover)
 
 
 /obj/machinery/turret/proc/malf_take_control(mob/living/silicon/ai/A)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -169,7 +169,10 @@ var/explosion_shake_message_cooldown = 0
 			//invulnerable therefore no further explosion
 			continue
 
+
+		var/turftime = world.time
 		for(var/atom/movable/A in T)
+			var/atomtime = world.time
 			if(whitelist && (A in whitelist))
 				continue
 			if(T != offcenter && !A.anchored && A.last_explosion_push != explosion_time)
@@ -191,6 +194,12 @@ var/explosion_shake_message_cooldown = 0
 
 				A.throw_at(throwT,pushback+2,500)
 			A.ex_act(dist,null,whodunnit)
+			atomtime = world.time - atomtime
+			if(atomtime > 0)
+				log_debug("Slow explosion effect on [A]: Took [atomtime/10] seconds.")
+		turftime = world.time - turftime
+		if(turftime > 0)
+			log_debug("Slow turf explosion processing at [formatJumpTo(T)]: Took [turftime/10] seconds.")
 
 		T.ex_act(dist,null,whodunnit)
 


### PR DESCRIPTION
[logging][performance]

## What this does
shows which atoms and containing turfs take longer than normal to be affected by explosions, and also fixes this delay with turrets.

## Why it's good
slightly faster explosions near anything with turrets.

## Changelog
:cl:
 * tweak: Turrets slow down explosions a lot less now.