### PR TITLE
Names of human players on the server avoid language scrambling

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -481,44 +481,48 @@
 	for(var/mob/living/carbon/human/H in player_list)
 		var/list/nameparts = splittext(H.real_name," ")
 		for(var/part in nameparts)
-			if(findtext(scrambled_text_pieces[scrambled_text_pieces.len],part)) // human player name in world?
+			if(findtext(lowertext(scrambled_text_pieces[scrambled_text_pieces.len]),lowertext(part))) // human player name in world?
 				var/oldtext = scrambled_text_pieces[scrambled_text_pieces.len]
 				scrambled_text_pieces.Remove(scrambled_text_pieces[scrambled_text_pieces.len]) // take out last element
-				scrambled_text_pieces += splittext(oldtext,part,include_delimiters=TRUE) // replace with split
-				found_names += part
+				scrambled_text_pieces += splittext(oldtext,part,1,0,TRUE) // replace with split
+				found_names += lowertext(part)
 
-	var/scrambled_text = ""
+	. = ""
+	var/capitalize = 1
 	for(var/piece in scrambled_text_pieces)
-		if(piece in found_names)
-			scrambled_text = piece // human name shows up here unscrambled
+		var/scramble_bit = ""
+		if(lowertext(piece) in found_names)
+			if(!capitalize && prob(95))
+				scramble_bit += " "
+			scramble_bit += piece // human name shows up here unscrambled
+			if(prob(95))
+				scramble_bit += " "
 		else
-			var/capitalize = 1
-
-			while(length(scrambled_text) < length(piece))
+			while(length(scramble_bit) < length(piece))
 				var/next = pick(syllables)
 				if(capitalize)
 					next = capitalize(next)
 					capitalize = 0
-				scrambled_text += next
+				scramble_bit += next
 				var/chance = rand(100)
 				if(chance <= 5)
-					scrambled_text += ". "
+					scramble_bit += ". "
 					capitalize = 1
 				else if(chance > 5 && chance <= space_chance)
-					scrambled_text += " "
+					scramble_bit += " "
+		. += scramble_bit
 
-	scrambled_text = trim(scrambled_text)
-	var/ending = copytext(scrambled_text, length(scrambled_text))
+	. = trim(.)
+	var/ending = copytext(., length(.))
 	if(ending == ".")
-		scrambled_text = copytext(scrambled_text,1,length(scrambled_text)-1)
+		. = copytext(.,1,length(.)-1)
 	var/input_ending = copytext(input, length(input))
 	if(input_ending in list("!","?","."))
-		scrambled_text += input_ending
+		. += input_ending
 
 	// Add it to cache, cutting old entries if the list is too long
-	scramble_cache[input] = scrambled_text
+	scramble_cache[input] = .
 	if(scramble_cache.len > SCRAMBLE_CACHE_LEN)
 		scramble_cache.Cut(1, scramble_cache.len-SCRAMBLE_CACHE_LEN-1)
 
-	return scrambled_text
 #undef SCRAMBLE_CACHE_LEN

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -476,28 +476,39 @@
 		scramble_cache[input] = n
 		return n
 
-	var/input_size = length(input)
-	var/scrambled_text = ""
-	var/capitalize = 1
+	var/list/scrambled_text_pieces = list(input)
+	for(var/mob/living/carbon/human/H in player_list)
+		if(findtext(scrambled_text_pieces[scrambled_text_pieces.len],H.real_name)) // human player name in world?
+			scrambled_text_pieces.Remove(scrambled_text_pieces[scrambled_text_pieces.len]) // take out last element
+			scrambled_text_pieces += splittext(scrambled_text_pieces[scrambled_text_pieces.len],H.real_name) // replace with split
 
-	while(length(scrambled_text) < input_size)
-		var/next = pick(syllables)
-		if(capitalize)
-			next = capitalize(next)
-			capitalize = 0
-		scrambled_text += next
-		var/chance = rand(100)
-		if(chance <= 5)
-			scrambled_text += ". "
-			capitalize = 1
-		else if(chance > 5 && chance <= space_chance)
-			scrambled_text += " "
+	var/scrambled_text = ""
+	var/i = 0
+	for(var/piece in scrambled_text_pieces)
+		i++
+		if(!i%2)
+			scrambled_text = piece // human name shows up here unscrambled
+		else
+			var/capitalize = 1
+
+			while(length(scrambled_text) < length(piece))
+				var/next = pick(syllables)
+				if(capitalize)
+					next = capitalize(next)
+					capitalize = 0
+				scrambled_text += next
+				var/chance = rand(100)
+				if(chance <= 5)
+					scrambled_text += ". "
+					capitalize = 1
+				else if(chance > 5 && chance <= space_chance)
+					scrambled_text += " "
 
 	scrambled_text = trim(scrambled_text)
 	var/ending = copytext(scrambled_text, length(scrambled_text))
 	if(ending == ".")
 		scrambled_text = copytext(scrambled_text,1,length(scrambled_text)-1)
-	var/input_ending = copytext(input, input_size)
+	var/input_ending = copytext(input, length(input))
 	if(input_ending in list("!","?","."))
 		scrambled_text += input_ending
 

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -477,16 +477,19 @@
 		return n
 
 	var/list/scrambled_text_pieces = list(input)
+	var/list/found_names = list()
 	for(var/mob/living/carbon/human/H in player_list)
-		if(findtext(scrambled_text_pieces[scrambled_text_pieces.len],H.real_name)) // human player name in world?
-			scrambled_text_pieces.Remove(scrambled_text_pieces[scrambled_text_pieces.len]) // take out last element
-			scrambled_text_pieces += splittext(scrambled_text_pieces[scrambled_text_pieces.len],H.real_name) // replace with split
+		var/list/nameparts = splittext(H.real_name," ")
+		for(var/part in nameparts)
+			if(findtext(scrambled_text_pieces[scrambled_text_pieces.len],part)) // human player name in world?
+				var/oldtext = scrambled_text_pieces[scrambled_text_pieces.len]
+				scrambled_text_pieces.Remove(scrambled_text_pieces[scrambled_text_pieces.len]) // take out last element
+				scrambled_text_pieces += splittext(oldtext,part,include_delimiters=TRUE) // replace with split
+				found_names += part
 
 	var/scrambled_text = ""
-	var/i = 0
 	for(var/piece in scrambled_text_pieces)
-		i++
-		if(!i%2)
+		if(piece in found_names)
 			scrambled_text = piece // human name shows up here unscrambled
 		else
 			var/capitalize = 1

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -480,6 +480,8 @@
 	var/list/found_names = list()
 	for(var/mob/living/carbon/human/H in player_list)
 		var/list/nameparts = splittext(H.real_name," ")
+		if(nameparts.len > 3) // so the clown or borgs can't abuse this to reveal languages with common words
+			continue
 		for(var/part in nameparts)
 			if(findtext(lowertext(scrambled_text_pieces[scrambled_text_pieces.len]),lowertext(part))) // human player name in world?
 				var/oldtext = scrambled_text_pieces[scrambled_text_pieces.len]


### PR DESCRIPTION
[tweak]
![image](https://user-images.githubusercontent.com/87321915/222925699-d6529eb7-8984-4b60-8875-762d991bb043.png)

## What this does
![image](https://user-images.githubusercontent.com/87321915/221456341-b5df5ef9-f333-4e84-bd4b-5dc0a7856339.png)
maybe in a later PR i could make brandnames do this too, like youtool or getmore as an example. (with of course a selective blacklist for zamsnax spoken in grey maybe)
## Why it's good
you probably would recognise your own name or ones familiar to you being said in another language, even if just for comedic effect.

## Changelog
:cl:
 * tweak: Players will now hear other player names in speech regardless of language.