### PR TITLE
Say verb puts messages out to OOC for lobby players

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -46,7 +46,7 @@ var/adminbus_ooc_color
 			message_admins("[key_name_admin(src)] has attempted to advertise in OOC: [msg]")
 			return
 		*/
-		if(!isnewplayer(src) && ((copytext(msg, 1, 2) in list(".",";",":","#")) || (findtext(lowertext(copytext(msg, 1, 5)), "say"))))
+		if(!isnewplayer(mob) && ((copytext(msg, 1, 2) in list(".",";",":","#")) || (findtext(lowertext(copytext(msg, 1, 5)), "say"))))
 			if(alert("Your message \"[msg]\" looks like it was meant for in game communication, say it in OOC?", "Meant for OOC?", "No", "Yes") != "Yes")
 				return
 	log_ooc("[mob.name]/[key] (@[mob.x],[mob.y],[mob.z]): [msg]")

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -46,7 +46,7 @@ var/adminbus_ooc_color
 			message_admins("[key_name_admin(src)] has attempted to advertise in OOC: [msg]")
 			return
 		*/
-		if((copytext(msg, 1, 2) in list(".",";",":","#")) || (findtext(lowertext(copytext(msg, 1, 5)), "say")))
+		if(!isnewplayer(src) && ((copytext(msg, 1, 2) in list(".",";",":","#")) || (findtext(lowertext(copytext(msg, 1, 5)), "say"))))
 			if(alert("Your message \"[msg]\" looks like it was meant for in game communication, say it in OOC?", "Meant for OOC?", "No", "Yes") != "Yes")
 				return
 	log_ooc("[mob.name]/[key] (@[mob.x],[mob.y],[mob.z]): [msg]")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -835,4 +835,4 @@
 
 /mob/new_player/say(message, datum/language/speaking, atom/movable/radio, class)
 	if(client)
-		client.OOC(message)
+		client.ooc(message)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -832,3 +832,7 @@
 
 /mob/new_player/cultify()
 	return
+
+/mob/new_player/say(message, datum/language/speaking, atom/movable/radio, class)
+	if(client)
+		client.OOC(message)


### PR DESCRIPTION
[qol]

## What this does
when pressing T or whatever hotkey to speak as a lobby mob, puts it out in OOC chat since this is really the only place they can talk or interact.

## Why it's good
convenient.

## Changelog
:cl:
 * rscadd: Using the "say" command as a lobby player outputs text to OOC now.
 * tweak: The warning about OOC messages sounding like they're meant for IC chat no longer applies to lobby players, who have no means to speak IC anyways.