### PR TITLE
Proto-kinetic accelerator modkit uplink item

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -927,7 +927,7 @@ var/list/uplink_items = list()
 /datum/uplink_item/jobspecific/cargo/pkamodifier
 	name = "Proto-Kinetic Accelerator Conversion Kit"
 	desc = "A weapon modkit for proto-kinetic accelerators that removes the pressure checks for them, causing low pressure damage to be done at normal atmospheric conditions. Also increases damage with higher pressure, at a rate of 1 per extra bar."
-	item = /obj/item/weapon/device/modkit/syndi_pka
+	item = /obj/item/device/modkit/syndi_pka
 	cost = 12
 	discounted_cost = 10
 	jobs_with_discount = list("Shaft Miner")

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -924,6 +924,14 @@ var/list/uplink_items = list()
 /datum/uplink_item/jobspecific/cargo/mastertrainer/new_uplink_item(var/new_item, var/turf/location, mob/user)
 	return new new_item(location, user)
 
+/datum/uplink_item/jobspecific/cargo/pkamodifier
+	name = "Proto-Kinetic Accelerator Conversion Kit"
+	desc = "A weapon modkit for proto-kinetic accelerators that removes the pressure checks for them, causing low pressure damage to be done at normal atmospheric conditions. Also increases damage with higher pressure, at a rate of 1 per extra bar."
+	item = /obj/item/weapon/device/modkit/syndi_pka
+	cost = 12
+	discounted_cost = 10
+	jobs_with_discount = list("Shaft Miner")
+
 /datum/uplink_item/jobspecific/service
 	category = "Service Specials"
 

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -197,3 +197,13 @@
 	parts[1] =	1
 	original[1] = /obj/item/weapon/fireaxe
 	finished[1] = /obj/item/weapon/fireaxe/antimatter
+
+/obj/item/device/modkit/syndi_pka/New()
+	..()
+	parts = new/list(1)
+	original = new/list(1)
+	finished = new/list(1)
+
+	parts[1] =	1
+	original[1] = /obj/item/weapon/gun/energy/kinetic_accelerator
+	finished[1] = /obj/item/weapon/gun/energy/kinetic_accelerator/dmod

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -638,6 +638,10 @@
 	icon_charge_multiple = 20
 	var/overheat = 0
 	var/recent_reload = 1
+
+/obj/item/weapon/gun/energy/kinetic_accelerator/dmod
+	projectile_type = "/obj/item/projectile/kinetic/dmod"
+
 /*
 /obj/item/weapon/gun/energy/kinetic_accelerator/shoot_live_shot()
 	overheat = 1

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -143,7 +143,7 @@
 	var/pressure = environment.return_pressure()
 	if(pressure < 50 || damagemodded)
 		name = "full strength kinetic force"
-		damage += (15 + (damagemodded * (max(1,pressure/ONE_ATMOSPHERE) - 1)))
+		damage += (15 + (damagemodded * min(30,max(1,pressure/ONE_ATMOSPHERE) - 1)))
 	..()
 
 /obj/item/projectile/kinetic/on_hit(var/atom/target, var/blocked = 0)

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -129,8 +129,11 @@
 	damage = 15
 	damage_type = BRUTE
 	flag = "energy"
-	var/range = 2
+	var/damagemodded = FALSE
 	fire_sound = 'sound/weapons/Taser.ogg'
+
+/obj/item/projectile/kinetic/dmod
+	damagemodded = TRUE
 
 /obj/item/projectile/kinetic/New()
 	var/turf/proj_turf = get_turf(src)
@@ -138,18 +141,10 @@
 		return
 	var/datum/gas_mixture/environment = proj_turf.return_air()
 	var/pressure = environment.return_pressure()
-	if(pressure < 50)
+	if(pressure < 50 || damagemodded)
 		name = "full strength kinetic force"
-		damage += 15
+		damage += (15 + (damagemodded * (max(1,pressure/ONE_ATMOSPHERE) - 1)))
 	..()
-
-/* wat - N3X
-/obj/item/projectile/kinetic/Range()
-	range--
-	if(range <= 0)
-		new /obj/item/effect/kinetic_blast(src.loc)
-		qdel(src)
-*/
 
 /obj/item/projectile/kinetic/on_hit(var/atom/target, var/blocked = 0)
 	if(!loc)


### PR DESCRIPTION
[content][port]

## What this does
adds a shaft miner uplink item that converts proto-kinetic accelerators into versions that ignore their pressure checks for extra damage, the weapon otherwise looks the exact same. (as found on a few other servers) 12 TC normally, 10 on job discount. also adds a bonus /vg/ exclusive feature where damage actually increases slightly with more air pressure, at a rate of 1 force per extra bar, (average conditions is 1 bar) capped at 30 extra at 31 bars (3.1mpa or ~3,100kpa) for a total of 60, same as revolvers.

## Why it's good
high pressure hijinx.

## Changelog
:cl:
 * rscadd: Syndicate shaft miners can now purchase modkits that convert proto kinetic accelerators into versions that ignore pressure checks, and even increase damage slightly with each additional bar of pressure, capped at 30 extra at 31 bars (3,100kpa).