### PR TITLE
Improved air subsystem initialisation speed

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -136,14 +136,14 @@ Class Procs:
 	to_chat(world, "<span class='danger'>Processing Geometry...</span>")
 	sleep(-1)
 
-	for(var/turf/simulated/S in initial_simturfs)
+	for(var/turf/simulated/S in simturfs)
 		S.update_air_properties()
 
-	to_chat(world, {"<span class='info'>Total Simulated Turfs: [initial_simturfs.len]
+	to_chat(world, {"<span class='info'>Total Simulated Turfs: [simturfs.len]
 Total Zones: [zones.len]
 Total Edges: [edges.len]
 Total Active Edges: [length(processing_parts[SSAIR_EDGES]) ? "<span class='danger'>[length(processing_parts[SSAIR_EDGES])]</span>" : "None"]
-Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - initial_simturfs.len]</span>"})
+Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simturfs.len]</span>"})
 
 	..()
 

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -138,7 +138,7 @@ Class Procs:
 
 	var/simulated_turf_count = 0
 
-	for(var/turf/simulated/S in world)
+	for(var/turf/simulated/S in initial_simturfs)
 		simulated_turf_count++
 		S.update_air_properties()
 

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -136,17 +136,14 @@ Class Procs:
 	to_chat(world, "<span class='danger'>Processing Geometry...</span>")
 	sleep(-1)
 
-	var/simulated_turf_count = 0
-
 	for(var/turf/simulated/S in initial_simturfs)
-		simulated_turf_count++
 		S.update_air_properties()
 
-	to_chat(world, {"<span class='info'>Total Simulated Turfs: [simulated_turf_count]
+	to_chat(world, {"<span class='info'>Total Simulated Turfs: [initial_simturfs.len]
 Total Zones: [zones.len]
 Total Edges: [edges.len]
 Total Active Edges: [length(processing_parts[SSAIR_EDGES]) ? "<span class='danger'>[length(processing_parts[SSAIR_EDGES])]</span>" : "None"]
-Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_count]</span>"})
+Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - initial_simturfs.len]</span>"})
 
 	..()
 

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -1,3 +1,5 @@
+var/global/list/turf/simulated/initial_simturfs = list()
+
 /turf/simulated
 	name = "station"
 
@@ -15,6 +17,7 @@
 	if(istype(loc, /area/chapel))
 		holy = 1
 	levelupdate()
+	initial_simturfs.Add(src)
 
 /turf/simulated/proc/AddTracks(var/typepath,var/bloodDNA,var/comingdir,var/goingdir,var/bloodcolor=DEFAULT_BLOOD)
 	var/obj/effect/decal/cleanable/blood/tracks/tracks = locate(typepath) in src

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -1,4 +1,4 @@
-var/global/list/turf/simulated/initial_simturfs = list()
+var/global/list/turf/simulated/simturfs = list()
 
 /turf/simulated
 	name = "station"
@@ -17,7 +17,11 @@ var/global/list/turf/simulated/initial_simturfs = list()
 	if(istype(loc, /area/chapel))
 		holy = 1
 	levelupdate()
-	initial_simturfs.Add(src)
+	simturfs += src
+
+/turf/simulated/Destroy()
+	simturfs -= src
+	..()
 
 /turf/simulated/proc/AddTracks(var/typepath,var/bloodDNA,var/comingdir,var/goingdir,var/bloodcolor=DEFAULT_BLOOD)
 	var/obj/effect/decal/cleanable/blood/tracks/tracks = locate(typepath) in src

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -341,6 +341,7 @@
 		var/turf/simulated/S = src
 		if(S.zone)
 			S.zone.rebuild()
+		simturfs -= src
 
 	if(istype(src,/turf/simulated/floor))
 		var/turf/simulated/floor/F = src


### PR DESCRIPTION
[performance]

## What this does
changes the "in world" loop only checking simulated turfs to a loop of a list called initial_simturfs, composed only of the list of simulated turfs at roundstart.
removes the total_simulated_turfs variable from the air subsystem initialization and replaces it with the .len of that list.

## Why it's good
![image](https://user-images.githubusercontent.com/87321915/223010914-6ed949c6-9149-47aa-a06e-95069d52620e.png)
![image](https://user-images.githubusercontent.com/87321915/223010450-a5ee119c-40bf-4672-b8d8-01434c13b29b.png)
tested with boxstation
## Changelog
:cl:
 * tweak: The air subsystem starts up 0.2 seconds faster now.
