### PR TITLE
Allows a bunch of symbols and accents in names.

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -129,7 +129,7 @@ var/list/whitelist_name_diacritics_min = list(
 )
 
 /proc/reject_bad_name(var/t_in, var/allow_numbers=0, var/max_length=MAX_NAME_LEN)
-	if(!t_in || length(t_in) > max_length)
+	if(!t_in || length(t_in) > max_length || length(t_in) < 2)
 		return //Rejects the input if it is null or if it is longer then the max length allowed
 
 	var/current_space = TRUE
@@ -160,7 +160,7 @@ var/list/whitelist_name_diacritics_min = list(
 					current_space = 0
 					t_out += t_in[i]
 				else
-					return
+					continue
 
 			// '  -  .
 			if(39,45,46)			//Common name punctuation
@@ -176,7 +176,7 @@ var/list/whitelist_name_diacritics_min = list(
 					current_space = 0
 					t_out += t_in[i]
 				else
-					return
+					continue
 
 
 			//Space

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -129,7 +129,7 @@ var/list/whitelist_name_diacritics_min = list(
 )
 
 /proc/reject_bad_name(var/t_in, var/allow_numbers=0, var/max_length=MAX_NAME_LEN)
-	if(!t_in || length(t_in) > max_length || length(t_in) < 2)
+	if(!t_in || length(t_in) > max_length)
 		return //Rejects the input if it is null or if it is longer then the max length allowed
 
 	var/current_space = TRUE
@@ -173,6 +173,8 @@ var/list/whitelist_name_diacritics_min = list(
 			// ~   |   @  :  #  $  %  &  *  +
 			if(126,124,64,58,35,36,37,38,42,43)			//Other symbols that we'll allow (mainly for AI)
 				if(allow_numbers)
+					if (i == 1)
+						continue
 					current_space = 0
 					t_out += t_in[i]
 				else
@@ -195,11 +197,11 @@ var/list/whitelist_name_diacritics_min = list(
 					if (current_space)
 						var/index = whitelist_name_diacritics_min.Find(t_in[i])
 						t_out += whitelist_name_diacritics_cap[index]
-						i++
+						i++ // Those are two-bytes letters
 						current_space = 0
 					else
 						t_out += t_in[i]
-						i++
+						i++ // Those are two-bytes letters
 						current_space = 0
 				else
 					return
@@ -207,6 +209,12 @@ var/list/whitelist_name_diacritics_min = list(
 	for(var/bad_name in list("space","floor","wall","r-wall","monkey","unknown","inactive ai","plating"))	//prevents these common metagamey names
 		if(cmptext(t_out,bad_name))
 			return	//(not case sensitive)
+
+	t_out = trim(t_out)
+
+	if (length(t_out) < 2)
+		return
+
 	return t_out
 
 //checks text for html tags

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -134,6 +134,7 @@ var/list/whitelist_name_diacritics_min = list(
 
 	var/current_space = TRUE
 	var/length = 0
+	var/started = FALSE
 
 	t_in = trim(t_in)
 	var/t_out = ""
@@ -142,25 +143,27 @@ var/list/whitelist_name_diacritics_min = list(
 		switch(ascii_char)
 			// A  .. Z
 			if(65 to 90)			//Uppercase Letters
-				current_space = 0
+				started = TRUE
+				current_space = FALSE
 				t_out += t_in[i]
 				length++
 			// a  .. z
 			if(97 to 122)			//Lowercase Letters
+				started = TRUE
 				if (current_space)
-					current_space = 0
+					current_space = FALSE
 					t_out += ascii2text(ascii_char - 32)
 				else
-					current_space = 0
+					current_space = FALSE
 					t_out += t_in[i]
 				length++
 
 			// 0  .. 9
 			if(48 to 57)			//Numbers
 				if(allow_numbers)
-					if (i == 1)
+					if (!started)
 						continue
-					current_space = 0
+					current_space = FALSE
 					t_out += t_in[i]
 					length++
 				else
@@ -168,18 +171,18 @@ var/list/whitelist_name_diacritics_min = list(
 
 			// '  -  .
 			if(39,45,46)			//Common name punctuation
-				if (i == 1)
+				if (!started)
 					continue
-				current_space = 0
+				current_space = FALSE
 				t_out += t_in[i]
 
 
 			// ~   |   @  :  #  $  %  &  *  +
 			if(126,124,64,58,35,36,37,38,42,43)			//Other symbols that we'll allow (mainly for AI)
 				if(allow_numbers)
-					if (i == 1)
+					if (!started)
 						continue
-					current_space = 0
+					current_space = FALSE
 					t_out += t_in[i]
 				else
 					continue
@@ -190,26 +193,28 @@ var/list/whitelist_name_diacritics_min = list(
 				if (current_space)
 					continue
 				else
-					current_space = 1
+					current_space = TRUE
 					t_out += t_in[i]
 			else
 				if (t_in[i] in whitelist_name_diacritics_cap)
+					started = TRUE
 					t_out += t_in[i]
 					i++ // Those are two-bytes letters
 					length++
-					current_space = 0
+					current_space = FALSE
 				else if (t_in[i] in whitelist_name_diacritics_min)
+					started = TRUE
 					if (current_space)
 						var/index = whitelist_name_diacritics_min.Find(t_in[i])
 						t_out += whitelist_name_diacritics_cap[index]
 						i++ // Those are two-bytes letters
 						length++
-						current_space = 0
+						current_space = FALSE
 					else
 						t_out += t_in[i]
 						i++ // Those are two-bytes letters
 						length++
-						current_space = 0
+						current_space = FALSE
 				else
 					return
 

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -132,7 +132,7 @@ var/list/whitelist_name_diacritics_min = list(
 	if(!t_in || length(t_in) > max_length)
 		return //Rejects the input if it is null or if it is longer then the max length allowed
 
-	var/current_space = FALSE
+	var/current_space = TRUE
 
 	t_in = trim(t_in)
 	var/t_out = ""
@@ -155,6 +155,8 @@ var/list/whitelist_name_diacritics_min = list(
 			// 0  .. 9
 			if(48 to 57)			//Numbers
 				if(allow_numbers)
+					if (i == 1)
+						continue
 					current_space = 0
 					t_out += t_in[i]
 				else
@@ -162,11 +164,10 @@ var/list/whitelist_name_diacritics_min = list(
 
 			// '  -  .
 			if(39,45,46)			//Common name punctuation
-				if(allow_numbers)
-					current_space = 0
-					t_out += t_in[i]
-				else
-					return
+				if (i == 1)
+					continue
+				current_space = 0
+				t_out += t_in[i]
 
 
 			// ~   |   @  :  #  $  %  &  *  +
@@ -202,6 +203,10 @@ var/list/whitelist_name_diacritics_min = list(
 						current_space = 0
 				else
 					return
+
+	for(var/bad_name in list("space","floor","wall","r-wall","monkey","unknown","inactive ai","plating"))	//prevents these common metagamey names
+		if(cmptext(t_out,bad_name))
+			return	//(not case sensitive)
 	return t_out
 
 //checks text for html tags

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -133,6 +133,7 @@ var/list/whitelist_name_diacritics_min = list(
 		return //Rejects the input if it is null or if it is longer then the max length allowed
 
 	var/current_space = TRUE
+	var/length = 0
 
 	t_in = trim(t_in)
 	var/t_out = ""
@@ -143,6 +144,7 @@ var/list/whitelist_name_diacritics_min = list(
 			if(65 to 90)			//Uppercase Letters
 				current_space = 0
 				t_out += t_in[i]
+				length++
 			// a  .. z
 			if(97 to 122)			//Lowercase Letters
 				if (current_space)
@@ -151,6 +153,7 @@ var/list/whitelist_name_diacritics_min = list(
 				else
 					current_space = 0
 					t_out += t_in[i]
+				length++
 
 			// 0  .. 9
 			if(48 to 57)			//Numbers
@@ -159,6 +162,7 @@ var/list/whitelist_name_diacritics_min = list(
 						continue
 					current_space = 0
 					t_out += t_in[i]
+					length++
 				else
 					continue
 
@@ -192,16 +196,19 @@ var/list/whitelist_name_diacritics_min = list(
 				if (t_in[i] in whitelist_name_diacritics_cap)
 					t_out += t_in[i]
 					i++ // Those are two-bytes letters
+					length++
 					current_space = 0
 				else if (t_in[i] in whitelist_name_diacritics_min)
 					if (current_space)
 						var/index = whitelist_name_diacritics_min.Find(t_in[i])
 						t_out += whitelist_name_diacritics_cap[index]
 						i++ // Those are two-bytes letters
+						length++
 						current_space = 0
 					else
 						t_out += t_in[i]
 						i++ // Those are two-bytes letters
+						length++
 						current_space = 0
 				else
 					return
@@ -212,7 +219,7 @@ var/list/whitelist_name_diacritics_min = list(
 
 	t_out = trim(t_out)
 
-	if (length(t_out) < 2)
+	if (length < 2)
 		return
 
 	return t_out

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -934,7 +934,7 @@ var/const/MAX_SAVE_SLOTS = 16
 					if(new_name)
 						real_name = new_name
 					else
-						to_chat(user, "<span class='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</span>")
+						to_chat(user, "<span class='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ', some diacritics, and .</span>")
 				if("next_hair_style")
 					h_style = next_list_item(h_style, valid_sprite_accessories(hair_styles_list, null, species)) //gender intentionally left null so speshul snowflakes can cross-hairdress
 				if("previous_hair_style")


### PR DESCRIPTION
Closes #30604. This PR keeps all of the functionality of previous name-checking (automatic whitespace trim, puting capitals after whitespace, etc.)

It currently allows for Latin-1 letters but the system is setup so that any special character can be added (as long as it has both a capital and a small letter). It also relies on the assumption that the letters are encoded with 2 bytes, which I /think/ is the majority of the extended latin table anyway (including slavic letters).

Tested to the best of my ability.