### PR TITLE
Blocks movement out of delivery chutes if way is not clear

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -24,6 +24,7 @@
 	var/last_sound = 0
 	var/template_path = "disposalsbin.tmpl"
 	var/deconstructable = TRUE	//Set to FALSE for disposal machinery that can be used for transporting players or things, but not tinkered with by players.
+	var/out_at_dir = FALSE // Goes out at the direction this faces if true
 
 /obj/machinery/disposal/splashable()
 	return FALSE
@@ -200,7 +201,7 @@
 // leave the disposal
 /obj/machinery/disposal/proc/go_out(mob/user)
 	var/turf/outturf = get_step(src,src.dir)
-	if(!outturf)
+	if(!out_at_dir || !outturf)
 		user.forceMove(src.loc)
 	else if(!user.Move(outturf))
 		return // needs no density

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -199,15 +199,15 @@
 
 // leave the disposal
 /obj/machinery/disposal/proc/go_out(mob/user)
-
-
+	var/turf/outturf = get_step(src,src.dir)
+	if(!outturf)
+		user.forceMove(src.loc)
+	else if(!user.Move(outturf))
+		return // needs no density
 	if (user.client)
 		user.client.eye = user.client.mob
 		user.client.perspective = MOB_PERSPECTIVE
-	user.forceMove(src.loc)
 	update_icon()
-	return
-
 
 // monkeys can only pull the flush lever
 /obj/machinery/disposal/attack_paw(mob/user as mob)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -115,6 +115,7 @@
 	desc = "A chute for big and small packages alike!"
 	density = 1
 	icon_state = "intake"
+	out_at_dir = TRUE
 	var/c_mode = 0
 	var/doFlushIn=0
 	var/num_contents=0


### PR DESCRIPTION
[tweak]

## What this does/Why it's good
stops people being stuck on the same tile as a chute

## Changelog
:cl:
 * tweak: Delivery chutes now put people out at the turf in front of them if people try to get out. If there is none, they remain inside and get flushed.
