### PR TITLE
Fix issue with Friday the 13th luck malus

### DIFF
--- a/code/modules/luck/luck.dm
+++ b/code/modules/luck/luck.dm
@@ -12,6 +12,8 @@
 		luck += base_luck.base_luck()
 	//adjust based on borne items
 	luck += borne_item_luckiness()
+	if(Holiday == FRIDAY_THE_13TH)
+		luck -= 250
 	return luck
 
 /mob
@@ -32,8 +34,6 @@
 	if(blesscurse.len)
 		for(var/datum/blesscurse/this_blesscurse in blesscurse)
 			base_luck += this_blesscurse.blesscurse_strength
-	if(Holiday == FRIDAY_THE_13TH)
-		base_luck -= 250
 	return base_luck
 
 //Add a blessing or curse to a mob.


### PR DESCRIPTION
This fixes an issue where the unluckiness caused by Friday the 13th may not be applied as intended to mobs in many cases. The issue was due to the Friday the 13th check being a proc of the `base_luck` datum, which is uninitialized until a mob has `luck_adjust()` or `add_blesscurse()` called on them, meaning it would be skipped on most mobs by default.

Fixes #34090