### PR TITLE
Explosions update: More items throwable, general refactoring

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_mobs_and_constructs.dm
@@ -9,7 +9,8 @@
 		/spell/juggerdash,
 		)
 	see_in_dark = 7
-	var/dash_dir = null
+	afterimage = /obj/effect/afterimage/red
+	strongthrow = TRUE
 	var/turf/crashing = null
 	spell_on_use_inhand = /spell/juggerdash //standard jug gets forcewall, but this seems better for perfect
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -590,7 +590,6 @@
 
 	var/dist_travelled = 0
 	var/dist_since_sleep = 0
-	var/area/a = get_area(src.loc)
 
 	. = 1
 
@@ -601,7 +600,7 @@
 	var/error = distcheck ? dist_x/2 - dist_y : dist_y/2 - dist_x
 	var/condition = distcheck ? ((src.x < target.x && dx == EAST) || (src.x > target.x && dx == WEST)) : ((src.y < target.y && dy == NORTH) || (src.y > target.y && dy == SOUTH))
 
-	while(src && target &&((condition && dist_travelled < range) || (a?.gravity == 0)  || istype(src.loc, /turf/space)) && src.throwing && isturf(src.loc))
+	while(src && target && ((condition && dist_travelled < range) || (get_gravity() == 0) || istype(src.loc, /turf/space)) && src.throwing && isturf(src.loc))
 		// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up
 		if(tS && dist_travelled)
 			timestopped = loc.timestopped
@@ -635,7 +634,6 @@
 		if(dist_since_sleep >= fly_speed)
 			dist_since_sleep = 0
 			sleep(1)
-		a = get_area(src.loc)
 
 	//done throwing, either because it hit something or it finished moving
 	src.throwing = 0

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -585,17 +585,9 @@
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)
 
-	var/dx
-	if (target.x > src.x)
-		dx = EAST
-	else
-		dx = WEST
+	var/dx = target.x > src.x ? EAST : WEST
+	var/dy = target.y > src.y ? NORTH : SOUTH
 
-	var/dy
-	if (target.y > src.y)
-		dy = NORTH
-	else
-		dy = SOUTH
 	var/dist_travelled = 0
 	var/dist_since_sleep = 0
 	var/area/a = get_area(src.loc)
@@ -649,8 +641,7 @@
 	src.throwing = 0
 	kinetic_acceleration = 0
 	if(isobj(src))
-		src.throw_impact(get_turf(src), speed, usr)
-
+		throw_impact(get_turf(src), speed, usr)
 //Overlays
 
 /datum/locking_category/overlay

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -594,8 +594,8 @@
 	. = 1
 
 	var/tS = 0
-	var/d1 = 0
-	var/d2 = 0
+	var/d_used = 0
+	var/dist_used = 0
 	var/distcheck = dist_x > dist_y
 	var/error = distcheck ? dist_x/2 - dist_y : dist_y/2 - dist_x
 	var/condition = distcheck ? ((src.x < target.x && dx == EAST) || (src.x > target.x && dx == WEST)) : ((src.y < target.y && dy == NORTH) || (src.y > target.y && dy == SOUTH))
@@ -616,19 +616,19 @@
 		if(afterimage)
 			new afterimage(loc,src)
 		if(error < 0)
-			d1 = distcheck ? dy : dx
-			d2 = distcheck ? dist_x : dist_y
+			d_used = distcheck ? dy : dx
+			dist_used = distcheck ? dist_x : dist_y
 		else
-			d1 = distcheck ? dx : dy
-			d2 = distcheck ? -dist_y : -dist_x
-		var/atom/step = get_step(src, d1)
+			d_used = distcheck ? dx : dy
+			dist_used = distcheck ? -dist_y : -dist_x
+		var/atom/step = get_step(src, d_used)
 		if(!step) // going off the edge of the map makes get_step return null, don't let things go off the edge
 			. = 0
 			break
 
-		src.Move(step, d1, glide_size_override = DELAY2GLIDESIZE(fly_speed))
+		src.Move(step, d_used, glide_size_override = DELAY2GLIDESIZE(fly_speed))
 		. = hit_check(speed, usr)
-		error += d2
+		error += dist_used
 		dist_travelled++
 		dist_since_sleep++
 		if(dist_since_sleep >= fly_speed)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -609,7 +609,7 @@
 	var/error = distcheck ? dist_x/2 - dist_y : dist_y/2 - dist_x
 	var/condition = distcheck ? (src.x < target.x && dx == EAST) || (src.x > target.x && dx == WEST) : (src.y < target.y && dy == NORTH) || (src.y > target.y && dy == SOUTH)
 
-	while(src && target &&((contiditon && dist_travelled < range) || (a?.gravity == 0)  || istype(src.loc, /turf/space)) && src.throwing && isturf(src.loc))
+	while(src && target &&((condition && dist_travelled < range) || (a?.gravity == 0)  || istype(src.loc, /turf/space)) && src.throwing && isturf(src.loc))
 		// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up
 		if(tS && dist_travelled)
 			timestopped = loc.timestopped
@@ -636,7 +636,7 @@
 			break
 
 		src.Move(step, d1, glide_size_override = DELAY2GLIDESIZE(fly_speed))
-		. = hit_check(speed, user)
+		. = hit_check(speed, usr)
 		error += d2
 		dist_travelled++
 		dist_since_sleep++
@@ -649,7 +649,7 @@
 	src.throwing = 0
 	kinetic_acceleration = 0
 	if(isobj(src))
-		src.throw_impact(get_turf(src), speed, user)
+		src.throw_impact(get_turf(src), speed, usr)
 
 //Overlays
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -607,7 +607,7 @@
 	var/d2 = 0
 	var/distcheck = dist_x > dist_y
 	var/error = distcheck ? dist_x/2 - dist_y : dist_y/2 - dist_x
-	var/condition = distcheck ? (src.x < target.x && dx == EAST) || (src.x > target.x && dx == WEST) : (src.y < target.y && dy == NORTH) || (src.y > target.y && dy == SOUTH)
+	var/condition = distcheck ? ((src.x < target.x && dx == EAST) || (src.x > target.x && dx == WEST)) : ((src.y < target.y && dy == NORTH) || (src.y > target.y && dy == SOUTH))
 
 	while(src && target &&((condition && dist_travelled < range) || (a?.gravity == 0)  || istype(src.loc, /turf/space)) && src.throwing && isturf(src.loc))
 		// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -51,7 +51,9 @@
 	var/obj/shadow/shadow
 
 	var/ignore_blocking = 0
-
+	var/dash_dir = null
+	var/afterimage = FALSE
+	var/strongthrow = FALSE
 	var/last_explosion_push = 0
 	var/mob/virtualhearer/virtualhearer
 
@@ -576,24 +578,10 @@
 	if(!fly_speed)
 		fly_speed = speed
 
-	var/mob/user
-	if(usr)
-		user = usr
-		if(M_HULK in usr.mutations)
-			src.throwing = 2 // really strong throw!
+	if(strongthrow)
+		src.throwing = 2// will crash through windows, grilles, tables, people, you name it
 
-	if(istype(src,/obj/mecha))
-		var/obj/mecha/M = src
-		M.dash_dir = dir
-		src.throwing = 2// mechas will crash through windows, grilles, tables, people, you name it
-
-	var/afterimage = 0
-	if(istype(src,/mob/living/simple_animal/construct/armoured/perfect))
-		var/mob/living/simple_animal/construct/armoured/perfect/M = src
-		M.dash_dir = dir
-		src.throwing = 2
-		afterimage = 1
-
+	dash_dir = dir
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)
 
@@ -614,97 +602,53 @@
 
 	. = 1
 
-	if(dist_x > dist_y)
-		var/error = dist_x/2 - dist_y
-
-
-		var/tS = 0
-		while(src && target &&((((src.x < target.x && dx == EAST) || (src.x > target.x && dx == WEST)) && dist_travelled < range) || (a && a.gravity == 0)  || istype(src.loc, /turf/space)) && src.throwing && istype(src.loc, /turf))
-			// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up
-			if(tS && dist_travelled)
-				timestopped = loc.timestopped
-				tS = 0
-			if(timestopped && !dist_travelled)
-				timestopped = 0
-				tS = 1
-			while((loc.timestopped || timestopped) && dist_travelled)
-				sleep(3)
-			if(kinetic_acceleration>kinetic_sum)
-				fly_speed += kinetic_acceleration-kinetic_sum
-				kinetic_sum = kinetic_acceleration
-			if(afterimage)
-				new /obj/effect/afterimage/red(loc,src)
-			if(error < 0)
-				var/atom/step = get_step(src, dy)
-				if(!step) // going off the edge of the map makes get_step return null, don't let things go off the edge
-					. = 0
-					break
-
-				src.Move(step, dy, glide_size_override = DELAY2GLIDESIZE(fly_speed))
-				. = hit_check(speed, user)
-				error += dist_x
-				dist_travelled++
-				dist_since_sleep++
-				if(dist_since_sleep >= fly_speed)
-					dist_since_sleep = 0
-					sleep(1)
-			else
-				var/atom/step = get_step(src, dx)
-				if(!step) // going off the edge of the map makes get_step return null, don't let things go off the edge
-					. = 0
-					break
-
-				src.Move(step, dx, glide_size_override = DELAY2GLIDESIZE(fly_speed))
-				. = hit_check(speed, user)
-				error -= dist_y
-				dist_travelled++
-				dist_since_sleep++
-				if(dist_since_sleep >= fly_speed)
-					dist_since_sleep = 0
-					sleep(1)
-			a = get_area(src.loc)
+	var/tS = 0
+	var/error = 0
+	var/condition = FALSE
+	var/d1 = 0
+	var/d2 = 0
+	var/distcheck = dist_x > dist_y
+	error = distcheck ? dist_x/2 - dist_y : dist_y/2 - dist_x
+	if(distcheck)
+		condition = (src.x < target.x && dx == EAST) || (src.x > target.x && dx == WEST)
 	else
-		var/error = dist_y/2 - dist_x
-		while(src && target &&((((src.y < target.y && dy == NORTH) || (src.y > target.y && dy == SOUTH)) && dist_travelled < range) || (a && a.gravity == 0)  || istype(src.loc, /turf/space)) && src.throwing && istype(src.loc, /turf))
-			// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up
-			if(timestopped)
-				sleep(1)
-				continue
-			if(kinetic_acceleration>0)
-				fly_speed += kinetic_acceleration
-				kinetic_acceleration = 0
-			if(afterimage)
-				new /obj/effect/afterimage/red(loc,src)
-			if(error < 0)
-				var/atom/step = get_step(src, dx)
-				if(!step) // going off the edge of the map makes get_step return null, don't let things go off the edge
-					. = 0
-					break
+		condition = (src.y < target.y && dy == NORTH) || (src.y > target.y && dy == SOUTH)
 
-				src.Move(step, dx, glide_size_override = DELAY2GLIDESIZE(fly_speed))
-				. = hit_check(speed, user)
-				error += dist_y
-				dist_travelled++
-				dist_since_sleep++
-				if(dist_since_sleep >= fly_speed)
-					dist_since_sleep = 0
-					sleep(1)
-			else
-				var/atom/step = get_step(src, dy)
-				if(!step) // going off the edge of the map makes get_step return null, don't let things go off the edge
-					. = 0
-					break
+	while(src && target &&((contiditon && dist_travelled < range) || (a?.gravity == 0)  || istype(src.loc, /turf/space)) && src.throwing && isturf(src.loc))
+		// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up
+		if(tS && dist_travelled)
+			timestopped = loc.timestopped
+			tS = 0
+		if(timestopped && !dist_travelled)
+			timestopped = 0
+			tS = 1
+		while((loc.timestopped || timestopped) && dist_travelled)
+			sleep(3)
+		if(kinetic_acceleration>kinetic_sum)
+			fly_speed += kinetic_acceleration-kinetic_sum
+			kinetic_sum = kinetic_acceleration
+		if(afterimage)
+			new afterimage(loc,src)
+		if(error < 0)
+			d1 = distcheck ? dy : dx
+			d2 = distcheck ? dist_x : dist_y
+		else
+			d1 = distcheck ? dx : dy
+			d2 = distcheck ? -dist_y : -dist_x
+		var/atom/step = get_step(src, d1)
+		if(!step) // going off the edge of the map makes get_step return null, don't let things go off the edge
+			. = 0
+			break
 
-				src.Move(step, dy, glide_size_override = DELAY2GLIDESIZE(fly_speed))
-				. = hit_check(speed, user)
-				error -= dist_x
-				dist_travelled++
-				dist_since_sleep++
-				if(dist_since_sleep >= fly_speed)
-					dist_since_sleep = 0
-					sleep(1)
-
-			a = get_area(src.loc)
+		src.Move(step, d1, glide_size_override = DELAY2GLIDESIZE(fly_speed))
+		. = hit_check(speed, user)
+		error += d2
+		dist_travelled++
+		dist_since_sleep++
+		if(dist_since_sleep >= fly_speed)
+			dist_since_sleep = 0
+			sleep(1)
+		a = get_area(src.loc)
 
 	//done throwing, either because it hit something or it finished moving
 	src.throwing = 0

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -603,16 +603,11 @@
 	. = 1
 
 	var/tS = 0
-	var/error = 0
-	var/condition = FALSE
 	var/d1 = 0
 	var/d2 = 0
 	var/distcheck = dist_x > dist_y
-	error = distcheck ? dist_x/2 - dist_y : dist_y/2 - dist_x
-	if(distcheck)
-		condition = (src.x < target.x && dx == EAST) || (src.x > target.x && dx == WEST)
-	else
-		condition = (src.y < target.y && dy == NORTH) || (src.y > target.y && dy == SOUTH)
+	var/error = distcheck ? dist_x/2 - dist_y : dist_y/2 - dist_x
+	var/condition = distcheck ? (src.x < target.x && dx == EAST) || (src.x > target.x && dx == WEST) : (src.y < target.y && dy == NORTH) || (src.y > target.y && dy == SOUTH)
 
 	while(src && target &&((contiditon && dist_travelled < range) || (a?.gravity == 0)  || istype(src.loc, /turf/space)) && src.throwing && isturf(src.loc))
 		// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -372,7 +372,7 @@
 
 /obj/machinery/dna_scannernew/ex_act(severity)
 	. = list()
-	if (prob(100 / (1<<(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
 		for(var/atom/movable/A as mob|obj in src)
 			A.forceMove(src.loc)
 			A.ex_act(severity)

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -372,7 +372,7 @@
 
 /obj/machinery/dna_scannernew/ex_act(severity)
 	. = list()
-	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+	if (prob(100 / (1<<(severity-1)))) //1 = 100, 2 = 50, 3 = 25
 		for(var/atom/movable/A as mob|obj in src)
 			A.forceMove(src.loc)
 			A.ex_act(severity)

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -371,40 +371,37 @@
 		M.ghost_reenter_alert("Your corpse has been placed into a cloning scanner. Return to your body if you want to be cloned!")
 
 /obj/machinery/dna_scannernew/ex_act(severity)
+	. = list()
+	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+		for(var/atom/movable/A as mob|obj in src)
+			A.forceMove(src.loc)
+			A.ex_act(severity)
+		. += A
+		qdel(src)
 	//This is by far the oldest code I have ever seen, please appreciate how it's preserved in comments for distant posterity. Have some perspective of where we came from.
-	switch(severity)
+	/*switch(severity)
 		if(1.0)
 			for(var/atom/movable/A as mob|obj in src)
-				//A.loc = src.loc
-				A.forceMove(src.loc)
-				//ex_act(severity)
-				A.ex_act(severity)
-				//Foreach goto(35)
-			//SN src = null
-			qdel(src)
-			return
+				A.loc = src.loc
+				ex_act(severity)
+				Foreach goto(35)
+			SN src = null
 		if(2.0)
 			if (prob(50))
 				for(var/atom/movable/A as mob|obj in src)
-					//A.loc = src.loc
-					A.forceMove(src.loc)
-					//ex_act(severity)
-					A.ex_act(severity)
-					//Foreach goto(108)
-				//SN src = null
-				qdel(src)
-				return
+					A.loc = src.loc
+					ex_act(severity)
+					Foreach goto(108)
+				SN src = null
 		if(3.0)
 			if (prob(25))
 				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(src.loc)
+					A.loc = src.loc
 					ex_act(severity)
-					//Foreach goto(181)
-				//SN src = null
-				qdel(src)
-				return
-		//else
-	//return
+					Foreach goto(181)
+				SN src = null
+		else
+	return*/
 
 
 /obj/machinery/dna_scannernew/blob_act()
@@ -489,14 +486,8 @@
 		connected.connected = src
 
 /obj/machinery/computer/scan_consolenew/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			qdel(src)
-			return
-		if(2.0)
-			if (prob(50))
-				qdel(src)
-				return
+	if(prob(100 / (min(2,severity)))) // 1 = 100, 2 = 50
+		qdel(src)
 
 /obj/machinery/computer/scan_consolenew/blob_act()
 	if(prob(75))

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -376,7 +376,7 @@
 		for(var/atom/movable/A as mob|obj in src)
 			A.forceMove(src.loc)
 			A.ex_act(severity)
-		. += A
+			. += A
 		qdel(src)
 	//This is by far the oldest code I have ever seen, please appreciate how it's preserved in comments for distant posterity. Have some perspective of where we came from.
 	/*switch(severity)

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -24,7 +24,13 @@ Obviously, requires DNA2.
 
 	spelltype = /spell/targeted/genetic/hulk
 
+/datum/dna/gene/basic/grant_spell/activate(var/mob/M, var/connected, var/flags)
+	M.strongthrow = TRUE
+	return ..()
+
 /datum/dna/gene/basic/grant_spell/hulk/deactivate(var/mob/M, var/connected, var/flags)
+	if(!initial(M.strongthrow))
+		M.strongthrow = FALSE
 	M.mutations.Remove(M_HULK)
 	M.update_mutations()
 	if (ishuman(M))

--- a/code/game/gamemodes/endgame/xmas/snow.dm
+++ b/code/game/gamemodes/endgame/xmas/snow.dm
@@ -378,20 +378,19 @@ var/global/list/datum/stack_recipe/snow_recipes = list (
 		..()
 
 /obj/structure/window/barricade/snow/ex_act(severity)
+	. = list()
 	switch(severity)
 		if(1.0)
 			visible_message("<span class='danger'>\the [src] is blown apart!</span>")
 			qdel(src)
-			return
 		if(2.0)
 			src.health -= 25
 			if (src.health <= 0)
 				visible_message("<span class='danger'>\the [src] is blown apart!</span>")
-				new /obj/item/stack/sheet/snow(get_turf(src), 1)
-				new /obj/item/stack/sheet/snow(get_turf(src), 1)
-				new /obj/item/stack/sheet/snow(get_turf(src), 1)
+				. += new /obj/item/stack/sheet/snow(get_turf(src), 1)
+				. += new /obj/item/stack/sheet/snow(get_turf(src), 1)
+				. += new /obj/item/stack/sheet/snow(get_turf(src), 1)
 				qdel(src)
-			return
 
 /obj/structure/window/barricade/snow/blob_act()
 	src.health -= 25

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -353,7 +353,7 @@
 
 /obj/machinery/sleeper/ex_act(severity)
 	. = list()
-	if (prob(100 / (1<<(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
 		for(var/atom/movable/A as mob|obj in src)
 			A.forceMove(loc)
 			A.ex_act(severity)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -352,28 +352,13 @@
 	interact(user)
 
 /obj/machinery/sleeper/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			for(var/atom/movable/A as mob|obj in src)
-				A.forceMove(loc)
-				ex_act(severity)
-			qdel(src)
-			return
-		if(2.0)
-			if(prob(50))
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(loc)
-					ex_act(severity)
-				qdel(src)
-				return
-		if(3.0)
-			if(prob(25))
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(loc)
-					ex_act(severity)
-				qdel(src)
-				return
-	return
+	. = list()
+	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+		for(var/atom/movable/A as mob|obj in src)
+			A.forceMove(loc)
+			A.ex_act(severity)
+			. += A
+		qdel(src)
 
 /obj/machinery/sleeper/emp_act(severity)
 	if(stat & (BROKEN|NOPOWER|FORCEDISABLE))

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -353,7 +353,7 @@
 
 /obj/machinery/sleeper/ex_act(severity)
 	. = list()
-	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+	if (prob(100 / (1<<(severity-1)))) //1 = 100, 2 = 50, 3 = 25
 		for(var/atom/movable/A as mob|obj in src)
 			A.forceMove(loc)
 			A.ex_act(severity)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -265,7 +265,7 @@
 
 /obj/machinery/bodyscanner/ex_act(severity)
 	. = list()
-	if (prob(100 / (1<<(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
 		for(var/atom/movable/A as mob|obj in src)
 			A.forceMove(loc)
 			A.ex_act(severity)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -264,29 +264,13 @@
 	return
 
 /obj/machinery/bodyscanner/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			for(var/atom/movable/A as mob|obj in src)
-				A.forceMove(loc)
-				ex_act(severity)
-			qdel(src)
-			return
-		if(2.0)
-			if(prob(50))
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(loc)
-					ex_act(severity)
-				qdel(src)
-				return
-		if(3.0)
-			if(prob(25))
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(loc)
-					ex_act(severity)
-				qdel(src)
-				return
-		else
-	return
+	. = list()
+	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+		for(var/atom/movable/A as mob|obj in src)
+			A.forceMove(loc)
+			A.ex_act(severity)
+			. += A
+		qdel(src)
 
 /obj/machinery/bodyscanner/blob_act()
 	if(prob(50))

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -265,7 +265,7 @@
 
 /obj/machinery/bodyscanner/ex_act(severity)
 	. = list()
-	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+	if (prob(100 / (1<<(severity-1)))) //1 = 100, 2 = 50, 3 = 25
 		for(var/atom/movable/A as mob|obj in src)
 			A.forceMove(loc)
 			A.ex_act(severity)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -23,7 +23,7 @@
 		/datum/malfhack_ability/oneuse/make_autoborger,
 		/datum/malfhack_ability/oneuse/overload_quiet,
 	)
-	
+
 	var/autoborger = FALSE
 	var/make_mommis = FALSE
 	var/is_borging = FALSE
@@ -63,21 +63,18 @@
 	return occupant
 
 /obj/machinery/recharge_station/ex_act(severity)
+	. = list()
 	switch(severity)
 		if(1.0)
 			qdel(src)
-			return
 		if(2.0)
 			if (prob(50))
-				new /obj/item/weapon/circuitboard/recharge_station(src.loc)
+				. += new /obj/item/weapon/circuitboard/recharge_station(src.loc)
 				qdel(src)
-				return
 		if(3.0)
 			if (prob(25))
 				src.anchored = 0
 				src.build_icon()
-		else
-	return
 
 /obj/machinery/recharge_station/process()
 	process_upgrade()
@@ -253,7 +250,7 @@
 	if(!( src.occupant ))
 		return
 	if(ishuman(occupant) && is_borging) // No escaping!
-		return 
+		return
 	if(upgrading)
 		to_chat(occupant, "<span class='notice'>The upgrade hasn't completed yet, interface with \the [src] again to halt the process.</span>")
 		return
@@ -365,9 +362,9 @@
 	var/limbs_to_ignore = list(/datum/organ/external/head, /datum/organ/external/chest, /datum/organ/external/groin)
 	var/list/limbs = list()
 	for(var/datum/organ/external/E in H.organs)
-		if(!E.is_robotic() && !is_type_in_list(E, limbs_to_ignore)) 
+		if(!E.is_robotic() && !is_type_in_list(E, limbs_to_ignore))
 			limbs += E
-	
+
 	build_icon()
 	flick("borgchargerfuckstart", src)
 	H.AdjustKnockdown(10)
@@ -385,16 +382,16 @@
 		E.explode()
 		H.handle_regular_hud_updates()
 		sleep(10)
-	
+
 	if(!src)
 		return
-	
+
 	var/mob/living/silicon/robot/R
 	if(make_mommis)
 		R = H.MoMMIfy(TRUE, TRUE, aiowner)
-	else 
+	else
 		R = H.Robotize(TRUE , TRUE , aiowner)
-	
+
 	occupant = R
 
 	if(!R)
@@ -407,11 +404,11 @@
 		is_borging = FALSE
 		return
 
-	R.cell.maxcharge = 5000	
+	R.cell.maxcharge = 5000
 	R.cell.charge = 5000
 	R.SetKnockdown(3)
 
-	R.custom_name = pick(autoborg_silly_names) 
+	R.custom_name = pick(autoborg_silly_names)
 	R.namepick_uses = 1
 	R.updateicon()
 	R.updatename()
@@ -443,22 +440,22 @@
 				continue
 			return
 	go_out(T)
-	
+
 
 /obj/machinery/recharge_station/MouseDropTo(atom/movable/O as mob|obj, mob/user as mob)
 	if(!isliving(O) || !isliving(user))
 		return
-	if(O.loc == user || !isturf(O.loc) || !isturf(user.loc) || !user.Adjacent(O)) 
+	if(O.loc == user || !isturf(O.loc) || !isturf(user.loc) || !user.Adjacent(O))
 		return
-	if(user.incapacitated() || user.lying) 
+	if(user.incapacitated() || user.lying)
 		return
-	if(!Adjacent(user) || !user.Adjacent(src)) 
+	if(!Adjacent(user) || !user.Adjacent(src))
 		return
 	if(O.locked_to)
 		return
 	if(O.anchored)
 		return
-	if(!isrobot(O) && !ishuman(O)) 
+	if(!isrobot(O) && !ishuman(O))
 		return
 	if(!isrobot(user) && !ishuman(user))
 		return

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -198,19 +198,16 @@
 
 
 /obj/machinery/suit_storage_unit/ex_act(severity)
+	. = list()
 	switch(severity)
 		if(1.0)
 			if(prob(50))
-				dump_everything() //So suits dont survive all the time
+				. += dump_everything() //So suits dont survive all the time
 			qdel(src)
-			return
 		if(2.0)
 			if(prob(50))
-				dump_everything()
+				. += dump_everything()
 				qdel(src)
-			return
-		else
-			return
 
 /obj/machinery/suit_storage_unit/emag_act(var/mob/user)
 	emagged = TRUE
@@ -430,12 +427,14 @@
 
 
 /obj/machinery/suit_storage_unit/proc/dump_everything(var/include_suit=TRUE)
+	. = list()
 	islocked = 0 //locks go free
 	var/list/objects_allowed = list(suit,mask,helmet,boots)
 	for(var/obj/O in contents)
 		if(!include_suit && (O in objects_allowed))
 			continue
 		O.forceMove(get_turf(src))
+		. += O
 	if(include_suit)
 		suit = null
 		helmet = null

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -198,14 +198,18 @@ var/global/num_vending_terminals = 1
 	return FALSE
 
 /obj/machinery/vending/proc/dump_vendpack_and_coinbox()
+	. = list()
 	if(product_records.len && cardboard) //Only spit out if we have slotted cardboard
 		if(is_custom_machine)
 			var/obj/structure/vendomatpack/custom/newpack = new(src.loc)
+			. += newpack
 			for(var/obj/item/I in custom_stock)
 				I.forceMove(newpack)
 				custom_stock.Remove(I)
+				. += I
 		else
 			var/obj/structure/vendomatpack/partial/newpack = new(src.loc)
+			. += newpack
 			newpack.stock = products
 			newpack.secretstock = contraband
 			newpack.preciousstock = premium
@@ -217,6 +221,7 @@ var/global/num_vending_terminals = 1
 
 	if(coinbox)
 		coinbox.forceMove(get_turf(src))
+		. += coinbox
 
 /obj/machinery/vending/examine(var/mob/user)
 	..()
@@ -329,16 +334,15 @@ var/global/num_vending_terminals = 1
 	qdel(P)
 
 /obj/machinery/vending/ex_act(severity)
+	. = list()
 	switch(severity)
 		if(1.0)
-			dump_vendpack_and_coinbox()
+			. += dump_vendpack_and_coinbox()
 			qdel(src)
-			return
 		if(2.0)
 			if (prob(50))
-				dump_vendpack_and_coinbox()
+				. += dump_vendpack_and_coinbox()
 				qdel(src)
-				return
 		if(3.0)
 			if(prob(25))
 				malfunction()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -21,6 +21,7 @@
 	layer = MOB_LAYER //icon draw layer
 	plane = MOB_PLANE
 	infra_luminosity = 15 //byond implementation is bugged. This is supposedly infrared brightness. Lower for combat mechs.
+	strongthrow = TRUE
 	var/list/hud_list = list()
 	var/initial_icon
 	var/can_move = 1
@@ -74,7 +75,6 @@
 	var/datum/global_iterator/pr_give_air //moves air from tank to cabin
 	var/datum/global_iterator/pr_internal_damage //processes internal damage
 
-	var/dash_dir = null
 	var/wreckage
 	var/enclosed = TRUE
 	var/silicon_pilot

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -37,7 +37,7 @@
 					if((dist <= round(heavy_range + world.view - 2, 1)) && (M_turf.z - epicenter.z <= max_range) && (epicenter.z - M_turf.z <= max_range))
 						M << 'sound/effects/EMPulse.ogg'
 
-		for(var/turf/T in multi_z_spiral_block(epicenter,max_range,0,0))
+		for(var/turf/T in multi_z_spiral_block(epicenter,max_range,0,-1))
 			CHECK_TICK
 			var/dist = cheap_pythag(T.x - x0, T.y - y0)
 			if(dist > max_range)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -115,7 +115,7 @@ var/explosion_shake_message_cooldown = 0
 						skip_shake = 1
 
 				if(!explosion_shake_message_cooldown && !skip_shake)
-					to_chat(M, "<span class='danger'>You feel the station's structure shaking all around you.</span>")
+					to_chat(M, "<span class='danger'>You feel everything shaking all around you.</span>")
 					explosion_shake_message_cooldown = 1
 					spawn(50)
 						explosion_shake_message_cooldown = 0

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -169,10 +169,13 @@ var/explosion_shake_message_cooldown = 0
 			//invulnerable therefore no further explosion
 			continue
 
+		// this was previously a loop that got the steps away to the desired position for each atom,
+		// now moved up to the turf level and changed to a slope-ish function that gets it just the same
 		var/divisor = pushback/(max(1,dist))
 		var/rise = round((T.y - y0) * divisor)
 		var/run = round((T.x - x0) * divisor)
 		var/turf/throwT = locate(T.x+run,T.y+rise,T.z) || (get_step_away(T,epicenter,dist+pushback) || T)
+
 		var/turftime = world.time
 		for(var/atom/movable/A in T)
 			var/atomtime = world.time

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -149,7 +149,7 @@ var/explosion_shake_message_cooldown = 0
 	for(var/turf/T in affected_turfs)
 		if(whitelist && (T in whitelist))
 			continue
-		var/dist = cheap_pythag(T.x - x0, T.y - y0) * (2**abs(T.z - z0))
+		var/dist = cheap_pythag(T.x - x0, T.y - y0) * (1<<abs(T.z - z0))
 		var/severity = dist
 		var/pushback = 0
 		for(var/turf/Trajectory = T, Trajectory != epicenter, Trajectory = get_zstep_towards(Trajectory,epicenter))
@@ -204,7 +204,8 @@ var/explosion_shake_message_cooldown = 0
 
 		CHECK_TICK
 	destroytime = world.time - destroytime
-	log_debug("Explosion at [epicenter.x],[epicenter.y],[epicenter.z] took [destroytime/10] seconds.")
+	if(destroytime > 0)
+		log_debug("Explosion at [epicenter.x],[epicenter.y],[epicenter.z] took [destroytime/10] seconds.")
 
 /proc/CalculateExplosionBlock(list/affected_turfs,var/epicenter_z)
 	. = list()

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -32,6 +32,7 @@ var/explosion_shake_message_cooldown = 0
 	var/explosion_time = world.time
 
 	spawn()
+		var/watch = start_watch()
 		epicenter = get_turf(epicenter)
 		if(!epicenter)
 			return
@@ -57,6 +58,8 @@ var/explosion_shake_message_cooldown = 0
 		var/z0 = epicenter.z
 
 		explosion_destroy(epicenter,devastation_range,heavy_impact_range,light_impact_range,flash_range,explosion_time,whodunnit,whitelist)
+
+		var/took = stop_watch(watch)
 
 		//Machines which report explosions.
 		if(!ignored)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -89,7 +89,7 @@ var/explosion_shake_message_cooldown = 0
 
 	for (var/mob/M in player_list)
 		//Double check for client
-		if(M && M.client)
+		if(M?.client)
 			var/turf/M_turf = get_turf(M)
 			if(M_turf && AreConnectedZLevels(M_turf.z,epicenter.z) && abs(M_turf.z - epicenter.z) <= max_range)
 				var/dist = get_dist(M_turf, epicenter)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -153,15 +153,15 @@ var/explosion_shake_message_cooldown = 0
 		var/severity = dist
 		var/pushback = 0
 		for(var/turf/Trajectory = T, Trajectory != epicenter, Trajectory = get_step_towards(Trajectory,epicenter))
-			dist += cached_exp_block[Trajectory]
+			severity += cached_exp_block[Trajectory]
 
-		if(dist < devastation_range)
+		if(severity < devastation_range)
 			severity = 1
 			pushback = 5
-		else if(dist < heavy_impact_range)
+		else if(severity < heavy_impact_range)
 			severity = 2
 			pushback = 3
-		else if(dist < light_impact_range)
+		else if(severity < light_impact_range)
 			severity = 3
 			pushback = 1
 		else

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -149,7 +149,7 @@ var/explosion_shake_message_cooldown = 0
 	for(var/turf/T in affected_turfs)
 		if(whitelist && (T in whitelist))
 			continue
-		var/dist = cheap_pythag(T.x - x0, T.y - y0) * (1<<abs(T.z - z0))
+		var/dist = cheap_pythag(T.x - x0, T.y - y0) * (2**abs(T.z - z0))
 		var/severity = dist
 		var/pushback = 0
 		for(var/turf/Trajectory = T, Trajectory != epicenter, Trajectory = get_zstep_towards(Trajectory,epicenter))

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -51,7 +51,7 @@ var/explosion_shake_message_cooldown = 0
 			log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] [whodunnit ? " caused by [whodunnit] [whodunnit.ckey ? "([whodunnit.ckey])" : "(no key)"]" : ""]")
 
 		SSlighting.postpone(max(round(devastation_range/8),1)) //Pause the lighting updates for a bit.
-		//SSair.postpone(max(round(heavy_impact_range/8),1)) //And air.
+		SSair.postpone(max(round(heavy_impact_range/8),1)) //And air.
 
 		var/x0 = epicenter.x
 		var/y0 = epicenter.y

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -32,7 +32,6 @@ var/explosion_shake_message_cooldown = 0
 	var/explosion_time = world.time
 
 	spawn()
-		var/watch = start_watch()
 		epicenter = get_turf(epicenter)
 		if(!epicenter)
 			return
@@ -57,13 +56,7 @@ var/explosion_shake_message_cooldown = 0
 		var/y0 = epicenter.y
 		var/z0 = epicenter.z
 
-
 		explosion_destroy(epicenter,devastation_range,heavy_impact_range,light_impact_range,flash_range,explosion_time,whodunnit,whitelist)
-
-		var/took = stop_watch(watch)
-		//You need to press the DebugGame verb to see these now....they were getting annoying and we've collected a fair bit of data. Just -test- changes  to explosion code using this please so we can compare
-		if(Debug2)
-			world.log << "## DEBUG: Explosion([x0],[y0],[z0])(d[devastation_range],h[heavy_impact_range],l[light_impact_range]): Took [took] seconds."
 
 		//Machines which report explosions.
 		if(!ignored)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -91,7 +91,7 @@ var/explosion_shake_message_cooldown = 0
 		//Double check for client
 		if(M && M.client)
 			var/turf/M_turf = get_turf(M)
-			if(M_turf && (M_turf.z == epicenter.z || AreConnectedZLevels(M_turf.z,epicenter.z)) && (M_turf.z - epicenter.z <= max_range) && (epicenter.z - M_turf.z <= max_range))
+			if(M_turf && AreConnectedZLevels(M_turf.z,epicenter.z) && abs(M_turf.z - epicenter.z) <= max_range)
 				var/dist = get_dist(M_turf, epicenter)
 				//If inside the blast radius + world.view - 2
 				if((dist <= round(max_range + world.view - 2, 1)) && (M_turf.z == epicenter.z))

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -149,7 +149,7 @@ var/explosion_shake_message_cooldown = 0
 	for(var/turf/T in affected_turfs)
 		if(whitelist && (T in whitelist))
 			continue
-		var/dist = cheap_pythag(T.x - x0, T.y - y0) / (2**(T.z - z0))
+		var/dist = cheap_pythag(T.x - x0, T.y - y0) / (2**abs(T.z - z0))
 		var/severity = dist
 		var/pushback = 0
 		for(var/turf/Trajectory = T, Trajectory != epicenter, Trajectory = get_step_towards(Trajectory,epicenter))

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -50,9 +50,8 @@ var/explosion_shake_message_cooldown = 0
 			message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ([formatJumpTo(epicenter,"JMP")]) [whodunnit ? " caused by [whodunnit] [whodunnit.ckey ? "([whodunnit.ckey])" : "(no key)"] ([formatJumpTo(whodunnit,"JMP")])" : ""]")
 			log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] [whodunnit ? " caused by [whodunnit] [whodunnit.ckey ? "([whodunnit.ckey])" : "(no key)"]" : ""]")
 
-		//Pause the lighting updates for a bit.
-		var/postponeCycles = max(round(devastation_range/8),1)
-		SSlighting.postpone(postponeCycles)
+		SSlighting.postpone(max(round(devastation_range/8),1)) //Pause the lighting updates for a bit.
+		//SSair.postpone(max(round(heavy_impact_range/8),1)) //And air.
 
 		var/x0 = epicenter.x
 		var/y0 = epicenter.y

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -143,8 +143,7 @@ var/explosion_shake_message_cooldown = 0
 	var/z0 = epicenter.z
 
 	var/list/affected_turfs = multi_z_spiral_block(epicenter,max_range,0,0,0.5)
-	// does not actually affect the explosion as severity gets overriden in the dist check, so commented out
-	//var/list/cached_exp_block = CalculateExplosionBlock(affected_turfs)
+	var/list/cached_exp_block = CalculateExplosionBlock(affected_turfs,z0)
 
 	var/destroytime = world.time
 	for(var/turf/T in affected_turfs)
@@ -153,8 +152,8 @@ var/explosion_shake_message_cooldown = 0
 		var/dist = cheap_pythag(T.x - x0, T.y - y0) / (2**(T.z - z0))
 		var/severity = dist
 		var/pushback = 0
-		//for(var/turf/Trajectory = T, Trajectory != epicenter, Trajectory = get_step_towards(Trajectory,epicenter))
-			//severity += cached_exp_block[Trajectory]
+		for(var/turf/Trajectory = T, Trajectory != epicenter, Trajectory = get_step_towards(Trajectory,epicenter))
+			dist += cached_exp_block[Trajectory]
 
 		if(dist < devastation_range)
 			severity = 1
@@ -207,12 +206,12 @@ var/explosion_shake_message_cooldown = 0
 	destroytime = world.time - destroytime
 	log_debug("Explosion at [epicenter.x],[epicenter.y],[epicenter.z] took [destroytime/10] seconds.")
 
-/proc/CalculateExplosionBlock(list/affected_turfs)
+/proc/CalculateExplosionBlock(list/affected_turfs,var/epicenter_z)
 	. = list()
 	// we cache the explosion block rating of every turf in the explosion area
 	//explosion block reduces explosion distance based on path from epicentre
 	for(var/turf/T as anything in affected_turfs)
-		var/current_exp_block = T.density ? T.explosion_block : 0
+		var/current_exp_block = T.density || T.z != epicenter_z ? T.explosion_block : 0
 		for (var/obj/machinery/door/D in T)
 			if(D.density && D.explosion_block)
 				current_exp_block += D.explosion_block

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -60,6 +60,8 @@ var/explosion_shake_message_cooldown = 0
 		explosion_destroy(epicenter,devastation_range,heavy_impact_range,light_impact_range,flash_range,explosion_time,whodunnit,whitelist)
 
 		var/took = stop_watch(watch)
+		if(took > 0.1)
+			log_debug("Explosion at [epicenter.x],[epicenter.y],[epicenter.z] took [took] seconds.")
 
 		//Machines which report explosions.
 		if(!ignored)
@@ -140,7 +142,6 @@ var/explosion_shake_message_cooldown = 0
 	var/list/affected_turfs = multi_z_spiral_block(epicenter,max_range,0,0,0.5)
 	var/list/cached_exp_block = CalculateExplosionBlock(affected_turfs,z0)
 
-	var/destroytime = world.time
 	for(var/turf/T in affected_turfs)
 		if(whitelist && (T in whitelist))
 			continue
@@ -198,9 +199,6 @@ var/explosion_shake_message_cooldown = 0
 		T.ex_act(severity,null,whodunnit)
 
 		CHECK_TICK
-	destroytime = world.time - destroytime
-	if(destroytime > 0)
-		log_debug("Explosion at [epicenter.x],[epicenter.y],[epicenter.z] took [destroytime/10] seconds.")
 
 /proc/CalculateExplosionBlock(list/affected_turfs,var/epicenter_z)
 	. = list()

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -149,7 +149,7 @@ var/explosion_shake_message_cooldown = 0
 	for(var/turf/T in affected_turfs)
 		if(whitelist && (T in whitelist))
 			continue
-		var/dist = cheap_pythag(T.x - x0, T.y - y0) / (2**abs(T.z - z0))
+		var/dist = cheap_pythag(T.x - x0, T.y - y0) * (2**abs(T.z - z0))
 		var/severity = dist
 		var/pushback = 0
 		for(var/turf/Trajectory = T, Trajectory != epicenter, Trajectory = get_zstep_towards(Trajectory,epicenter))

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -152,7 +152,7 @@ var/explosion_shake_message_cooldown = 0
 		var/dist = cheap_pythag(T.x - x0, T.y - y0) / (2**abs(T.z - z0))
 		var/severity = dist
 		var/pushback = 0
-		for(var/turf/Trajectory = T, Trajectory != epicenter, Trajectory = get_step_towards(Trajectory,epicenter))
+		for(var/turf/Trajectory = T, Trajectory != epicenter, Trajectory = get_zstep_towards(Trajectory,epicenter))
 			severity += cached_exp_block[Trajectory]
 
 		if(severity < devastation_range)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -109,6 +109,7 @@
 	return 1
 
 /obj/structure/closet/proc/dump_contents()
+	. = list()
 	if(usr)
 		var/mob/living/L = usr
 		var/obj/machinery/power/supermatter/SM = locate() in contents
@@ -124,12 +125,14 @@
 	for(var/obj/O in src)
 		if(O != src.electronics) //Don't dump your electronics
 			O.forceMove(src.loc)
+			. += O
 
 	for(var/mob/M in src)
 		M.forceMove(src.loc)
 		if(M.client)
 			M.client.eye = M.client.mob
 			M.client.perspective = MOB_PERSPECTIVE
+		. += M
 
 /obj/structure/closet/proc/take_contents()
 	for(var/atom/movable/AM in src.loc)
@@ -333,6 +336,7 @@
 
 // this should probably use dump_contents()
 /obj/structure/closet/ex_act(severity)
+	. = list()
 	var/obj/item/weapon/circuitboard/airlock/E
 	switch(severity)
 		if(1)
@@ -343,7 +347,7 @@
 			for(var/atom/movable/A in src)//pulls everything else out of the locker and hits it with an explosion
 				A.forceMove(src.loc)
 				A.ex_act(severity++)
-			dump_contents()
+			. += dump_contents()
 			qdel(src)
 		if(2)
 			if(prob(50))
@@ -354,7 +358,7 @@
 				for (var/atom/movable/A as mob|obj in src)
 					A.forceMove(src.loc)
 					A.ex_act(severity++)
-				dump_contents()
+				. += dump_contents()
 				qdel(src)
 		if(3)
 			if(prob(5))
@@ -365,7 +369,7 @@
 				for(var/atom/movable/A as mob|obj in src)
 					A.forceMove(src.loc)
 					A.ex_act(severity++)
-				dump_contents()
+				. += dump_contents()
 				qdel(src)
 
 /obj/structure/closet/shuttle_act()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -334,43 +334,22 @@
 	qdel(src)
 	return new_closet
 
-// this should probably use dump_contents()
+// this should probably use dump_contents() // it does now
 /obj/structure/closet/ex_act(severity)
 	. = list()
 	var/obj/item/weapon/circuitboard/airlock/E
-	switch(severity)
-		if(1)
-			broken = 1
-			if(has_electronics)//If it's got electronics, generate them/pull them out
-				E = dump_electronics()
-				E.forceMove(src)
-			for(var/atom/movable/A in src)//pulls everything else out of the locker and hits it with an explosion
-				A.forceMove(src.loc)
-				A.ex_act(severity++)
-			. += dump_contents()
-			qdel(src)
-		if(2)
-			if(prob(50))
-				broken = 1
-				if(has_electronics)
-					E = dump_electronics()
-					E.forceMove(src)
-				for (var/atom/movable/A as mob|obj in src)
-					A.forceMove(src.loc)
-					A.ex_act(severity++)
-				. += dump_contents()
-				qdel(src)
-		if(3)
-			if(prob(5))
-				broken = 1
-				if(has_electronics)
-					E = dump_electronics()
-					E.forceMove(src)
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(src.loc)
-					A.ex_act(severity++)
-				. += dump_contents()
-				qdel(src)
+	var/probdivide = severity == 3 ? 20 : severity
+	if (prob(100/probdivide)) //1 = 100, 2 = 50, 3 = 5
+		broken = 1
+		if(has_electronics)//If it's got electronics, generate them/pull them out
+			E = dump_electronics()
+			. += E
+			E.forceMove(src)
+		for(var/atom/movable/A in src)//pulls everything else out of the locker and hits it with an explosion
+			A.forceMove(src.loc)
+			A.ex_act(severity++)
+		. += dump_contents()
+		qdel(src)
 
 /obj/structure/closet/shuttle_act()
 	for(var/atom/movable/AM in contents)

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -47,25 +47,22 @@
 //However, the door will be blown off its hinges, permanently breaking the fridge
 //And of course, if the bomb is IN the fridge, you're fucked
 /obj/structure/closet/secure_closet/freezer/ex_act(var/severity)
-
+	. = list()
 	//Bomb in here? (using same search as space transits searching for nuke disk)
 	var/list/bombs = search_contents_for(/obj/item/device/transfer_valve)
 	if(!isemptylist(bombs)) // You're fucked.
-		..(severity)
-
-	if(severity == 1)
+		. = ..(severity)
+	else if(severity == 1)
 		//If it's not open, we need to override the normal open proc and set everything ourselves
 		//Otherwise, you can cheese this by simply welding it shut, or if the lock is engaged
 		if(!opened)
 			opened = 1
 			setDensity(FALSE)
-			dump_contents()
+			. += dump_contents()
 
 		//Now, set our special variables
 		exploded = 1
 		update_icon()
-
-	return
 
 /obj/structure/closet/secure_closet/freezer/can_close()
 	if(exploded) //Door blew off, can't close it anymore

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -696,6 +696,7 @@
 
 
 /obj/structure/closet/crate/ex_act(severity)
+	. = list()
 	switch(severity)
 		if(1)
 			qdel(src)
@@ -709,14 +710,14 @@
 			for(var/atom/movable/thing in contents)
 				if(prob(50))
 					qdel(thing)
-			dump_contents()
+			. += dump_contents()
 			qdel(src)
 		if(3)
 			if(prob(50))
 				broken = TRUE
 				if(has_electronics)
 					dump_electronics()
-				dump_contents()
+				. += dump_contents()
 				qdel(src)
 
 /obj/structure/closet/crate/secure/weapon/experimental

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -704,7 +704,7 @@
 			broken = TRUE
 			if(has_electronics)
 				if (prob(50))
-					dump_electronics()
+					. += dump_electronics()
 				else
 					qdel(electronics)
 			for(var/atom/movable/thing in contents)
@@ -716,7 +716,7 @@
 			if(prob(50))
 				broken = TRUE
 				if(has_electronics)
-					dump_electronics()
+					. += dump_electronics()
 				. += dump_contents()
 				qdel(src)
 

--- a/code/game/objects/structures/flora/flora.dm
+++ b/code/game/objects/structures/flora/flora.dm
@@ -177,6 +177,7 @@
 	return 1
 
 /obj/structure/flora/tree/proc/fall_down()
+	. = list()
 	if(!falling_dir)
 		falling_dir = pick(cardinal)
 
@@ -185,8 +186,6 @@
 
 	playsound(loc, 'sound/effects/woodcutting.ogg', 50, 1)
 
-	qdel(src)
-
 	if(!holo)
 		spawn()
 			while(height > 0)
@@ -194,6 +193,7 @@
 					break //If the turf in which to spawn a log doesn't exist, stop the thing
 
 				var/obj/item/I = new log_type(our_turf) //Spawn a log and throw it at the "current_turf"
+				. += I
 				I.throw_at(current_turf, 10, 10)
 
 				current_turf = get_step(current_turf, falling_dir)
@@ -201,6 +201,8 @@
 				height--
 
 				sleep(1)
+
+	qdel(src)
 
 /obj/structure/flora/tree/proc/update_health()
 	if(health < 40 && !falling_dir)
@@ -212,12 +214,13 @@
 		fall_down()
 
 /obj/structure/flora/tree/ex_act(severity)
+	. = list()
 	switch(severity)
 		if(1) //Epicentre
 			return qdel(src)
 		if(2) //Major devastation
 			height -= rand(1,4) //Some logs are lost
-			fall_down()
+			. += fall_down()
 		if(3) //Minor devastation (IED)
 			health -= rand(10,30)
 			update_health()

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -341,42 +341,39 @@
 	return ..()
 
 /obj/structure/girder/ex_act(severity)
+	. = list()
 	switch(severity)
 		if(1.0)
 			if(prob(25) && state == 2) //Strong enough to have a chance to stand if finished, but not in one piece
-				new /obj/item/stack/rods(get_turf(src)) //Lose one ro)
+				. += new /obj/item/stack/rods(get_turf(src)) //Lose one rod
 				state = 0
 				update_icon()
 			else //Not finished or not lucky
 				qdel(src) //No scraps
-			return
 		if(2.0)
 			if(prob(50))
 				if(state == 2)
 					state = 1
 					update_icon()
 				if(state == 1)
-					new /obj/item/stack/rods(get_turf(src))
+					. += new /obj/item/stack/rods(get_turf(src))
 					state = 0
 					update_icon()
 				else
-					new /obj/item/stack/sheet/metal(get_turf(src))
+					. += new /obj/item/stack/sheet/metal(get_turf(src))
 					qdel(src)
-			return
 		if(3.0)
 			if((state == 0) && prob(5))
-				new /obj/item/stack/sheet/metal(get_turf(src))
+				. += new /obj/item/stack/sheet/metal(get_turf(src))
 				qdel(src)
 			else if(prob(15))
 				if(state == 2)
 					state = 1
 					update_icon()
 				if(state == 1)
-					new /obj/item/stack/rods(get_turf(src), 2)
+					. += new /obj/item/stack/rods(get_turf(src), 2)
 					state = 0
 					update_icon()
-			return
-	return
 
 /obj/structure/girder/mech_drill_act(severity)
 	new /obj/item/stack/sheet/metal(get_turf(src))
@@ -476,21 +473,18 @@
 		qdel(src)
 
 /obj/structure/cultgirder/ex_act(severity)
+	. = list()
 	switch(severity)
 		if(1.0)
 			qdel(src)
-			return
 		if(2.0)
 			if (prob(30))
-				new /obj/effect/decal/remains/human(loc)
+				. += new /obj/effect/decal/remains/human(loc)
 				qdel(src)
-			return
 		if(3.0)
 			if (prob(5))
-				new /obj/effect/decal/remains/human(loc)
+				. += new /obj/effect/decal/remains/human(loc)
 				qdel(src)
-			return
-	return
 
 /obj/structure/cultgirder/mech_drill_act(severity)
 	new /obj/effect/decal/remains/human(loc)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -45,13 +45,14 @@
 	qdel(src)
 
 /obj/structure/grille/proc/healthcheck(var/hitsound = 0) //Note : Doubles as the destruction proc()
+	. = list()
 	if(hitsound)
 		playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
 	if(health <= (0.25*initial(health)) && !broken) //Modular, 1/4th of original health. Do make sure the grille isn't broken !
 		broken = 1
 		icon_state = "[initial(icon_state)]-b"
 		setDensity(FALSE) //Not blocking anything anymore
-		new grille_material(get_turf(src)) //One rod set
+		. += new grille_material(get_turf(src)) //One rod set
 		relativewall_neighbours()
 	else if(health > (0.25*initial(health)) && broken) //Repair the damage to this bitch
 		broken = 0
@@ -59,7 +60,7 @@
 		setDensity(TRUE)
 		relativewall_neighbours()
 	if(health <= 0) //Dead
-		new grille_material(get_turf(src)) //Drop the second set of rods
+		. += new grille_material(get_turf(src)) //Drop the second set of rods
 		qdel(src)
 
 /obj/structure/grille/ex_act(severity)
@@ -70,8 +71,7 @@
 			health -= rand(15, 30)
 		if(3)
 			health -= rand(5, 15)
-	healthcheck(hitsound = 1)
-	return
+	. += healthcheck(hitsound = 1)
 
 /obj/structure/grille/blob_act()
 	anim(target = loc, a_icon = 'icons/mob/blob/blob.dmi', flick_anim = "blob_act", sleeptime = 15, lay = 12)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -68,27 +68,14 @@
 			to_chat(user, "<span class='info'>\The [src]'s light display indicates there is a potential clone candidate inside.</span>")
 
 /obj/structure/morgue/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			for(var/atom/movable/A in src)
-				A.forceMove(src.loc)
-				A.ex_act(severity)
-			qdel(src)
-			return
-		if(2.0)
-			if(prob(50))
-				for(var/atom/movable/A in src)
-					A.forceMove(src.loc)
-					A.ex_act(severity)
-				qdel(src)
-				return
-		if(3.0)
-			if(prob(5))
-				for(var/atom/movable/A in src)
-					A.forceMove(src.loc)
-					A.ex_act(severity)
-				qdel(src)
-				return
+	. = list()
+	var/probdivide = severity == 3 ? 20 : severity
+	if (prob(100/probdivide)) //1 = 100, 2 = 50, 3 = 5
+		for(var/atom/movable/A as mob|obj in src)
+			A.forceMove(loc)
+			A.ex_act(severity)
+			. += A
+		qdel(src)
 
 /obj/structure/morgue/alter_health() //???????????????
 	return src.loc
@@ -268,24 +255,14 @@
 		icon_state = "crema1"
 
 /obj/structure/crematorium/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			for(var/atom/movable/A as mob|obj in src)
-				A.forceMove(src.loc)
-				ex_act(severity)
-			qdel(src)
-		if(2.0)
-			if (prob(50))
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(src.loc)
-					ex_act(severity)
-				qdel(src)
-		if(3.0)
-			if (prob(5))
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(src.loc)
-					ex_act(severity)
-				qdel(src)
+	. = list()
+	var/probdivide = severity == 3 ? 20 : severity
+	if (prob(100/probdivide)) //1 = 100, 2 = 50, 3 = 5
+		for(var/atom/movable/A as mob|obj in src)
+			A.forceMove(loc)
+			A.ex_act(severity)
+			. += A
+		qdel(src)
 
 /obj/structure/crematorium/alter_health()
 	return src.loc

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -274,10 +274,12 @@
 	break_glass(damage)
 	if(wired)
 		wired = FALSE
-		. += var/obj/item/stack/cable_coil/CC = new /obj/item/stack/cable_coil(get_turf(src),2)
+		var/obj/item/stack/cable_coil/CC = new /obj/item/stack/cable_coil(get_turf(src),2)
+		. += CC
 		CC._color = wire_color
 		CC.update_icon()
-	. += var/obj/item/stack/sheet/M = new sheettype(loc)
+	var/obj/item/stack/sheet/M = new sheettype(loc)
+	. += M
 	M.amount = 2
 	qdel(src)
 

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -270,35 +270,37 @@
 	return 1
 
 /obj/structure/railing/proc/make_into_sheets(var/damage = FALSE)
+	. = list()
 	break_glass(damage)
 	if(wired)
 		wired = FALSE
-		var/obj/item/stack/cable_coil/CC = new /obj/item/stack/cable_coil(get_turf(src),2)
+		. += var/obj/item/stack/cable_coil/CC = new /obj/item/stack/cable_coil(get_turf(src),2)
 		CC._color = wire_color
 		CC.update_icon()
-	var/obj/item/stack/sheet/M = new sheettype(loc)
+	. += var/obj/item/stack/sheet/M = new sheettype(loc)
 	M.amount = 2
 	qdel(src)
 
 /obj/structure/railing/proc/break_glass(var/damage = FALSE)
+	. = list()
 	if(glasstype)
 		if(damage && railingtype == "plasteel")
 			new /obj/item/stack/rods(get_turf(src),2)
 		switch(glasstype)
 			if(NORMAL_GLASS)
 				if(damage)
-					new /obj/item/weapon/shard(get_turf(src))
-					new /obj/item/weapon/shard(get_turf(src))
+					. += new /obj/item/weapon/shard(get_turf(src))
+					. += new /obj/item/weapon/shard(get_turf(src))
 				else
 					var/glasstospawn = railingtype == "plasteel" ? /obj/item/stack/sheet/glass/rglass : /obj/item/stack/sheet/glass/glass
-					new glasstospawn(get_turf(src),railingtype == "wooden" ? 1 : 2)
+					. += new glasstospawn(get_turf(src),railingtype == "wooden" ? 1 : 2)
 			if(PLASMA_GLASS)
 				if(damage)
-					new /obj/item/weapon/shard/plasma(get_turf(src))
-					new /obj/item/weapon/shard/plasma(get_turf(src))
+					. += new /obj/item/weapon/shard/plasma(get_turf(src))
+					. += new /obj/item/weapon/shard/plasma(get_turf(src))
 				else
 					var/glasstospawn = railingtype == "plasteel" ? /obj/item/stack/sheet/glass/plasmarglass : /obj/item/stack/sheet/glass/plasmaglass
-					new glasstospawn(get_turf(src),railingtype == "wooden" ? 1 : 2)
+					. += new glasstospawn(get_turf(src),railingtype == "wooden" ? 1 : 2)
 		if(damage)
 			playsound(src, "shatter", 70, 1)
 		glasstype = NO_GLASS
@@ -340,6 +342,7 @@
 			make_into_sheets(TRUE)
 
 /obj/structure/railing/ex_act(severity)
+	. = list()
 	switch(severity)
 		if(1)
 			qdel(src)
@@ -347,12 +350,12 @@
 			if(prob(50))
 				qdel(src)
 			else
-				make_into_sheets(TRUE)
+				. += make_into_sheets(TRUE)
 		if(3)
 			if(prob(50))
-				make_into_sheets(TRUE)
+				. += make_into_sheets(TRUE)
 			else
-				break_glass(TRUE)
+				. += break_glass(TRUE)
 
 /obj/structure/railing/suicide_act(mob/living/user)
 	var/turf/T = hurdle(user)
@@ -384,10 +387,11 @@
 	min_damage_force = 15
 
 /obj/structure/railing/plasteel/ex_act(severity)
+	. = list()
 	var/nu_severity = severity + 1
-	..(nu_severity)
+	. += ..(nu_severity)
 	if(nu_severity == 4 && prob(50))
-		break_glass(TRUE)
+		. += break_glass(TRUE)
 
 /obj/structure/railing/plasteel/loose
 	anchored = 0
@@ -411,7 +415,7 @@
 
 /obj/structure/railing/wood/ex_act(severity)
 	var/nu_severity = max(1,severity - 1)
-	..(nu_severity)
+	. = ..(nu_severity)
 
 /obj/structure/railing/wood/loose
 	anchored = 0

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -19,7 +19,9 @@
 
 
 /obj/structure/sign/ex_act(severity)
-	switch(severity)
+	qdel(src)
+	// old code preserved below for fun. just why.
+	/*switch(severity)
 		if(1.0)
 			qdel(src)
 			return
@@ -30,7 +32,7 @@
 			qdel(src)
 			return
 		else
-	return
+	return*/
 
 /obj/structure/sign/blob_act()
 	qdel(src)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -776,7 +776,7 @@
 /obj/structure/rack/ex_act(severity)
 	// previously 3 severity had a higher chance of deleting the parts than 2 severity, made no sense so reversed it. fits in the formula well too.
 	. = list()
-	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+	if (prob(100 / (1<<(severity-1)))) //1 = 100, 2 = 50, 3 = 25
 		. += destroy(FALSE)
 	else
 		. += destroy(TRUE)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -776,7 +776,7 @@
 /obj/structure/rack/ex_act(severity)
 	// previously 3 severity had a higher chance of deleting the parts than 2 severity, made no sense so reversed it. fits in the formula well too.
 	. = list()
-	if (prob(100 / (1<<(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
 		. += destroy(FALSE)
 	else
 		. += destroy(TRUE)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -68,7 +68,7 @@
 
 /obj/structure/table/proc/destroy()
 	if(parts)
-		new parts(loc)
+		. = new parts(loc)
 	setDensity(FALSE)
 	qdel(src)
 
@@ -242,6 +242,7 @@
 			change_dir(SOUTH)
 
 /obj/structure/table/ex_act(severity)
+	. = list()
 	switch(severity)
 		if(1.0)
 			qdel(src)
@@ -252,7 +253,7 @@
 				return
 		if(3.0)
 			if (prob(25))
-				destroy()
+				. += destroy()
 		else
 	return
 
@@ -760,7 +761,7 @@
 
 /obj/structure/rack/proc/destroy(var/dropParts = TRUE)
 	if(parts && dropParts)
-		new parts(loc)
+		. = new parts(loc)
 	setDensity(FALSE)
 	qdel(src)
 
@@ -773,19 +774,12 @@
 	return ..()
 
 /obj/structure/rack/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			destroy(FALSE)
-		if(2.0)
-			if(prob(50))
-				destroy(TRUE)
-			else
-				destroy(FALSE)
-		if(3.0)
-			if(prob(25))
-				destroy(TRUE)
-			else
-				destroy(FALSE)
+	// previously 3 severity had a higher chance of deleting the parts than 2 severity, made no sense so reversed it. fits in the formula well too.
+	. = list()
+	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+		. += destroy(FALSE)
+	else
+		. += destroy(TRUE)
 
 /obj/structure/rack/proc/checkhealth()
 	if(health <= 0)

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -19,29 +19,17 @@
 	for(var/atom/movable/AM in contents)
 		AM.loc = loc
 
-	..()	
+	..()
 
 // When destroyed by explosions, properly handle contents.
 /obj/structure/transit_tube_pod/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			for(var/atom/movable/AM in contents)
-				AM.forceMove(loc)
-				// TODO: What the fuck are you doing
-				AM.ex_act(severity++)
-
-			qdel(src)
-			return
-		if(2.0)
-			if(prob(50))
-				for(var/atom/movable/AM in contents)
-					AM.forceMove(loc)
-					AM.ex_act(severity++)
-
-				qdel(src)
-				return
-		if(3.0)
-			return
+	if(prob(100 - ((severity-1)*50))) // 1 = 100, 2 = 50, 3 = 0
+		for(var/atom/movable/AM in contents)
+			AM.forceMove(loc)
+			// TODO: What the fuck are you doing
+			AM.ex_act(severity++)
+			. += AM
+		qdel(src)
 
 /obj/structure/transit_tube_pod/proc/empty_pod(atom/location)
 	if(!location)
@@ -49,13 +37,13 @@
 	for(var/atom/movable/M in contents)
 		M.forceMove(location)
 	update_icon()
-	
+
 /obj/structure/transit_tube_pod/Process_Spacemove()
 	if(moving) //No drifting while moving in the tubes
 		return TRUE
 	else
 		return ..()
-	
+
 /obj/structure/transit_tube_pod/proc/follow_tube(var/reverse_launch)
 	if(moving)
 		return
@@ -128,8 +116,8 @@
 
 			while(isturf(loc) && Move(get_step(loc, dir)))
 
-		moving = 0	
-	
+		moving = 0
+
 /obj/structure/transit_tube_pod/attackby(obj/item/W as obj, mob/user as mob)
 	if(iswelder(W))
 		var/obj/item/tool/weldingtool/WT = W
@@ -141,7 +129,7 @@
 			TTFP.circuitry = new /obj/item/weapon/circuitboard/mecha/transitpod(TTFP)
 			qdel(src)
 		return 1
-		
+
 /obj/structure/transit_tube_pod/examine(mob/user)
 	..()
 	show_occupants(user)
@@ -157,7 +145,7 @@
 			return
 
 	to_chat(user, "<span class='info'>The tube pod looks empty.</span>")
-	
+
 // Should I return a copy here? If the caller edits or del()s the returned
 //  datum, there might be problems if I don't...
 //	Shut up bitch, let's do it MY way

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -123,7 +123,7 @@ var/list/one_way_windows
 
 //Allows us to quickly check if we should break the window, can handle not having an user
 /obj/structure/window/proc/healthcheck(var/mob/M, var/sound = 1)
-
+	. = list()
 
 	if(health <= 0)
 		if(M) //Did someone pass a mob ? If so, perform a pressure check
@@ -136,7 +136,7 @@ var/list/one_way_windows
 				investigation_log(I_ATMOS, "with a pdiff of [pdiff] has been destroyed by [M.real_name] ([formatPlayerPanel(M, M.ckey)]) at [formatJumpTo(get_turf(src))]!")
 				if(M.ckey) //Only send an admin message if it's an actual players, admins don't need to know what the carps are doing
 					message_admins("\The [src] with a pdiff of [pdiff] has been destroyed by [M.real_name] ([formatPlayerPanel(M, M.ckey)]) at [formatJumpTo(get_turf(src))]!")
-		shatter()
+		. += shatter()
 	else
 		if(sound)
 			playsound(loc, 'sound/effects/Glasshit.ogg', 100, 1)
@@ -172,16 +172,11 @@ var/list/one_way_windows
 	switch(severity)
 		if(1.0)
 			adjustHealthLoss(rand(100, 150))
-			healthcheck()
-			return
 		if(2.0)
 			adjustHealthLoss(rand(20, 50))
-			healthcheck()
-			return
 		if(3.0)
 			adjustHealthLoss(rand(5, 15))
-			healthcheck()
-			return
+	. += healthcheck()
 
 /obj/structure/window/blob_act()
 	anim(target = loc, a_icon = 'icons/mob/blob/blob.dmi', flick_anim = "blob_act", sleeptime = 15, lay = 12)
@@ -606,16 +601,18 @@ var/list/one_way_windows
 	..()
 
 /obj/structure/window/proc/shatter()
+	. = list()
 	if(loc)
 		playsound(src, "shatter", 70, 1)
-	spawnBrokenPieces()
+	. += spawnBrokenPieces()
 	qdel(src)
 
 /obj/structure/window/proc/spawnBrokenPieces()
+	. = list()
 	if(shardtype)
-		new shardtype(loc, sheetamount)
+		. += new shardtype(loc, sheetamount)
 	if(reinforced)
-		new reinforcetype(loc, sheetamount)
+		. += new reinforcetype(loc, sheetamount)
 
 /obj/structure/window/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -83,6 +83,7 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 
 /turf/simulated/floor/ex_act(severity)
 	//set src in oview(1)
+	. = list()
 	switch(severity)
 		if(1.0)
 			src.ChangeTurf(get_underlying_turf())
@@ -93,6 +94,7 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 					if(prob(33))
 						var/obj/item/stack/sheet/metal/M = new /obj/item/stack/sheet/metal(get_turf(src))
 						M.amount = 1
+						. += M
 				if(2)
 					src.ChangeTurf(get_underlying_turf())
 				if(3)
@@ -104,11 +106,11 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 					if(prob(33))
 						var/obj/item/stack/sheet/metal/M = new /obj/item/stack/sheet/metal(get_turf(src))
 						M.amount = 1
+						. += M
 		if(3.0)
 			if (prob(50))
 				src.break_tile()
 				src.hotspot_expose(1000,CELL_VOLUME,surfaces=1)
-	return
 
 /turf/simulated/floor/blob_act()
 	return

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -49,6 +49,7 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 
 	holomap_draw_override = HOLOMAP_DRAW_PATH
 
+	explosion_block = 1
 
 /turf/simulated/floor/New()
 	create_floor_tile()

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -94,6 +94,7 @@
 
 	soot_type = null
 	melt_temperature = 0 // Doesn't melt.
+	explosion_block = 2
 	var/secured = FALSE
 
 /turf/simulated/floor/engine/create_floor_tile()

--- a/code/game/turfs/simulated/invulnerable_wall.dm
+++ b/code/game/turfs/simulated/invulnerable_wall.dm
@@ -40,11 +40,12 @@
 			dismantle_wall()
 
 /turf/simulated/wall/invulnerable/dismantle_wall(devastated = 0, explode = 0)
+	. = list()
 	if(!devastated)
-		new /obj/item/stack/sheet/plasteel(src)//Reinforced girder has deconstruction steps too. If no girder, drop ONE plasteel sheet AND rod)
+		. += new /obj/item/stack/sheet/plasteel(src)//Reinforced girder has deconstruction steps too. If no girder, drop ONE plasteel sheet AND rod)
 	else
-		new /obj/item/stack/rods(src, 2)
-		new /obj/item/stack/sheet/plasteel(src)
+		. += new /obj/item/stack/rods(src, 2)
+		. += new /obj/item/stack/sheet/plasteel(src)
 
 	for(var/obj/O in src.contents) //Eject contents!
 		if(istype(O,/obj/structure/sign/poster))

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -57,20 +57,21 @@
 		to_chat(user, src.engraving)
 
 /turf/simulated/wall/dismantle_wall(devastated = 0, explode = 0)
+	. = list()
 	if(mineral == "metal")
-		new /obj/item/stack/sheet/metal(src, 2)
+		. += new /obj/item/stack/sheet/metal(src, 2)
 	else if(mineral == "wood")
-		new /obj/item/stack/sheet/wood(src, 2)
+		. += new /obj/item/stack/sheet/wood(src, 2)
 	else
 		var/M = text2path("/obj/item/stack/sheet/mineral/[mineral]")
 		if(M)
-			new M(src, 2)
+			. += new M(src, 2)
 
 	if(devastated)
-		new /obj/item/stack/sheet/metal(src)
+		. += new /obj/item/stack/sheet/metal(src)
 	else
 		if(girder_type)
-			new girder_type(src)
+			. += new girder_type(src)
 
 	for(var/obj/O in src.contents) //Eject contents!
 		if(istype(O,/obj/effect/cult_shortcut))
@@ -89,18 +90,14 @@
 	switch(severity)
 		if(1.0)
 			src.ChangeTurf(get_underlying_turf()) //You get NOTHING, you LOSE
-			return
 		if(2.0)
 			if(prob(50))
-				dismantle_wall(0,1)
+				. += dismantle_wall(0,1)
 			else
-				dismantle_wall(1,1)
-			return
+				. += dismantle_wall(1,1)
 		if(3.0)
 			if(prob(40))
-				dismantle_wall(0,1)
-			return
-	return
+				. += dismantle_wall(0,1)
 
 /turf/simulated/wall/mech_drill_act(severity)
 	return dismantle_wall()

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -40,7 +40,8 @@
 	icon_state = "log0"
 
 /turf/simulated/wall/mineral/wood/log/dismantle_wall()
-	new /obj/item/weapon/grown/log/tree(src)
+	. = list()
+	. += new /obj/item/weapon/grown/log/tree(src)
 	for(var/obj/O in src.contents)
 		if(istype(O,/obj/effect/cult_shortcut))
 			qdel(O)

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -12,13 +12,14 @@
 	return
 
 /turf/simulated/wall/cult/dismantle_wall(devastated = 0, explode = 0)
+	. = list()
 	if(!devastated)
-		new /obj/effect/decal/cleanable/blood(src)
-		new girder_type(src)
+		. += new /obj/effect/decal/cleanable/blood(src)
+		. += new girder_type(src)
 	else
 		if(prob(10))
-			new /obj/effect/decal/cleanable/blood(src)
-		//	new /obj/effect/decal/remains/human(src) //Commented out until remains are cleanable
+			. += new /obj/effect/decal/cleanable/blood(src)
+		//	. += new /obj/effect/decal/remains/human(src) //Commented out until remains are cleanable
 
 	for(var/obj/O in src.contents) //Eject contents!
 		if(istype(O,/obj/structure/sign/poster))

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -363,12 +363,13 @@
 			dismantle_wall()
 
 /turf/simulated/wall/r_wall/dismantle_wall(devastated = 0, explode = 0)
+	. = list()
 	if(!devastated)
-		new /obj/item/stack/sheet/plasteel(src)//Reinforced girder has deconstruction steps too. If no girder, drop ONE plasteel sheet AND rod)
-		new girder_type(src)
+		. += new /obj/item/stack/sheet/plasteel(src)//Reinforced girder has deconstruction steps too. If no girder, drop ONE plasteel sheet AND rod)
+		. += new girder_type(src)
 	else
-		new /obj/item/stack/rods(src, 2)
-		new /obj/item/stack/sheet/plasteel(src)
+		. += new /obj/item/stack/rods(src, 2)
+		. += new /obj/item/stack/sheet/plasteel(src)
 
 	for(var/obj/O in src.contents) //Eject contents!
 		if(istype(O,/obj/structure/sign/poster))
@@ -379,28 +380,28 @@
 	update_near_walls()
 
 /turf/simulated/wall/r_wall/ex_act(severity)
+	. = list()
 	if(rotting)
 		severity = 1.0
 	switch(severity)
 		if(1.0)
 			if(prob(66)) //It's "bomb-proof"
-				dismantle_wall(0,1) //So it isn't completely destroyed, nice uh ?
+				. += dismantle_wall(0,1) //So it isn't completely destroyed, nice uh ?
 			else
-				dismantle_wall(1,1) //Fuck it up nicely
+				. += dismantle_wall(1,1) //Fuck it up nicely
 		if(2.0)
 			if(prob(75) && (d_state == WALLCOMPLETED))//No more infinite plasteel generation!
 				src.d_state = WALLCOVERREMOVED
 				update_icon()
-				new /obj/item/stack/sheet/plasteel(get_turf(src)) //Lose the plasteel needed to get ther)
+				. += new /obj/item/stack/sheet/plasteel(get_turf(src)) //Lose the plasteel needed to get ther)
 			else
-				dismantle_wall(0,1)
+				. += dismantle_wall(0,1)
 		if(3.0)
 			if(prob(15))
-				dismantle_wall(0,1)
+				. += dismantle_wall(0,1)
 			else //If prob fails, break the outer safety grille to look like scrap damage
 				src.d_state = WALLCOVEREXPOSED
 				update_icon()
-	return
 
 /turf/simulated/wall/r_wall/dissolvable()
 	return 0

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -646,7 +646,7 @@ var/list/admin_verbs_mod = list(
 	set desc = "Cause an explosion of varying strength at your location."
 
 	var/turf/epicenter = mob.loc
-	var/list/choices = list("Small Bomb (1,3,4)", "Medium Bomb (3,7,14)", "Big Bomb (7,14,28)", "Custom Bomb")
+	var/list/choices = list("Small Bomb (1,3,4)", "Medium Bomb (3,7,14)", "Big Bomb (7,14,28)", "Nuclear Bomb (30,60,120)" "Custom Bomb")
 	var/choice = input("What size explosion would you like to produce?") in choices | null
 	switch(choice)
 		if(null)
@@ -657,6 +657,8 @@ var/list/admin_verbs_mod = list(
 			explosion(epicenter, 3, 7, 14, 14, whodunnit = usr)
 		if("Big Bomb (7,14,28)")
 			explosion(epicenter, 7, 14, 28, 28, whodunnit = usr)
+		if("Nuclear Bomb (30,60,120)")
+			explosion(epicenter, 30, 60, 120, 120, whodunnit = usr)
 		if("Custom Bomb")
 			var/devastation_range = input("Devastation range (in tiles):") as num
 			var/heavy_impact_range = input("Heavy impact range (in tiles):") as num

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -646,7 +646,7 @@ var/list/admin_verbs_mod = list(
 	set desc = "Cause an explosion of varying strength at your location."
 
 	var/turf/epicenter = mob.loc
-	var/list/choices = list("Small Bomb (1,3,4)", "Medium Bomb (3,7,14)", "Big Bomb (7,14,28)", "Nuclear Bomb (30,60,120)" "Custom Bomb")
+	var/list/choices = list("Small Bomb (1,3,4)", "Medium Bomb (3,7,14)", "Big Bomb (7,14,28)", "Nuclear Bomb (30,60,120)", "Custom Bomb")
 	var/choice = input("What size explosion would you like to produce?") in choices | null
 	switch(choice)
 		if(null)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -676,7 +676,7 @@ var/list/admin_verbs_mod = list(
 	set desc = "Cause an EMP of varying strength at your location."
 
 	var/turf/epicenter = mob.loc
-	var/list/choices = list("Small EMP (1,2)", "Medium EMP (2,4)", "Big EMP (4,8)", "Custom EMP")
+	var/list/choices = list("Small EMP (1,2)", "Medium EMP (2,4)", "Big EMP (4,8)", "Supermatter EMP (100,200)", "Custom EMP")
 	var/choice = input("What size EMP would you like to produce?") in choices | null
 	switch(choice)
 		if(null)
@@ -687,6 +687,8 @@ var/list/admin_verbs_mod = list(
 			empulse(epicenter, 2, 4)
 		if("Big EMP (4,8)")
 			empulse(epicenter, 4, 8)
+		if("Supermatter EMP (100,200)")
+			empulse(epicenter, 100, 200)
 		if("Custom EMP")
 			var/heavy_impact_range = input("Heavy impact range (in tiles):") as num
 			var/light_impact_range = input("Light impact range (in tiles):") as num

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -510,7 +510,7 @@
 
 /obj/machinery/cloning/clonepod/ex_act(severity)
 	. = list()
-	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+	if (prob(100 / (1<<(severity-1)))) //1 = 100, 2 = 50, 3 = 25
 		for(var/atom/movable/A as mob|obj in src)
 			A.forceMove(loc)
 			A.ex_act(severity)

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -509,29 +509,13 @@
 	..()
 
 /obj/machinery/cloning/clonepod/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			for(var/atom/movable/A as mob|obj in src)
-				A.forceMove(loc)
-				ex_act(severity)
-			qdel(src)
-			return
-		if(2.0)
-			if (prob(50))
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(loc)
-					ex_act(severity)
-				qdel(src)
-				return
-		if(3.0)
-			if (prob(25))
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(loc)
-					ex_act(severity)
-				qdel(src)
-				return
-		else
-	return
+	. = list()
+	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+		for(var/atom/movable/A as mob|obj in src)
+			A.forceMove(loc)
+			A.ex_act(severity)
+			. += A
+		qdel(src)
 
 /obj/machinery/cloning/clonepod/MouseDropTo(obj/item/weapon/reagent_containers/food/snacks/meat/M, mob/living/user)
 	var/busy = FALSE

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -510,7 +510,7 @@
 
 /obj/machinery/cloning/clonepod/ex_act(severity)
 	. = list()
-	if (prob(100 / (1<<(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
 		for(var/atom/movable/A as mob|obj in src)
 			A.forceMove(loc)
 			A.ex_act(severity)

--- a/code/modules/mining/ore_box.dm
+++ b/code/modules/mining/ore_box.dm
@@ -60,22 +60,18 @@
 	return
 
 /obj/structure/ore_box/proc/dump_everything()
+	. = list()
 	for(var/ore_id in stored_ores)
 		var/amount = stored_ores[ore_id]
 		if(amount > 0)
-			drop_stack(ore_id, get_turf(src), amount)
+			. += drop_stack(ore_id, get_turf(src), amount)
 
 	stored_ores.Cut()
 
 /obj/structure/ore_box/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			dump_everything()
-			qdel(src)
-		if(2.0)
-			if (prob(50))
-				dump_everything()
-				qdel(src)
+	if(prob(100-((severity-1)*50))) // 1= 100, 2 = 50, 3 = 0
+		. += dump_everything()
+		qdel(src)
 
 /obj/structure/ore_box/proc/try_add_ore(var/obj/item/stack/ore/O)
 	if (!O.can_orebox)

--- a/code/modules/multiz/_HELPERS.dm
+++ b/code/modules/multiz/_HELPERS.dm
@@ -120,6 +120,6 @@ var/global/list/visible_spaces = list(/turf/simulated/open, /turf/simulated/floo
 
 	var/turf/epicenter = get_turf(usr)
 	var/max_range = input("Set the max range") as num
-	var/shape_txt = alert("What shape?","Spiral Block", "Cube","Octahedron")
-	var/shape = shape_txt == "Cube" ? 1 : 0
-	multi_z_spiral_block(epicenter,max_range,shape)
+	var/diff = input("What size to increase or decrease by while further away?","Spiral Block") as num
+	var/mult = input("What size to multiply by while further away?","Spiral Block") as num
+	multi_z_spiral_block(epicenter,max_range,1,diff,mult)

--- a/code/modules/multiz/_HELPERS.dm
+++ b/code/modules/multiz/_HELPERS.dm
@@ -97,19 +97,22 @@ var/global/list/visible_spaces = list(/turf/simulated/open, /turf/simulated/floo
 
 	return ((b.x-a.x)**2) + ((b.y-a.y)**2) + ((get_zs_away(a,b))**2)
 
-/proc/multi_z_spiral_block(var/turf/epicenter,var/max_range,var/draw_red=0,var/cube=1)
+/proc/multi_z_spiral_block(var/turf/epicenter,var/max_range,var/draw_red=0,var/difference=0,var/multiple=1)
 	var/turf/upturf = epicenter
 	var/turf/downturf = epicenter
 	. = spiral_block(epicenter,max_range,draw_red)
+	var/current_size = max_range
 	for(var/i = 1, i < max_range, i++)
+		current_size += difference
+		current_size *= multiple
 		if(HasAbove(upturf.z))
 			upturf = GetAbove(upturf)
-			log_debug("Spiralling block of size [cube ? max_range : i + (max_range - i)] in [upturf.loc.name] ([upturf.x],[upturf.y],[upturf.z])")
-			. += spiral_block(upturf, cube ? max_range : max_range - i, draw_red)
+			log_debug("Spiralling block of size [current_size] in [upturf.loc.name] ([upturf.x],[upturf.y],[upturf.z])")
+			. += spiral_block(upturf, current_size, draw_red)
 		if(HasBelow(downturf.z))
 			downturf = GetBelow(downturf)
-			log_debug("Spiralling block of size [cube ? max_range : i + (max_range - i)] in [downturf.loc.name] ([downturf.x],[downturf.y],[downturf.z])")
-			. += spiral_block(downturf, cube ? max_range : max_range - i, draw_red)
+			log_debug("Spiralling block of size [current_size] in [downturf.loc.name] ([downturf.x],[downturf.y],[downturf.z])")
+			. += spiral_block(downturf, current_size, draw_red)
 
 /client/proc/check_multi_z_spiral()
 	set name = "Check Multi-Z Spiral Block"
@@ -120,14 +123,3 @@ var/global/list/visible_spaces = list(/turf/simulated/open, /turf/simulated/floo
 	var/shape_txt = alert("What shape?","Spiral Block", "Cube","Octahedron")
 	var/shape = shape_txt == "Cube" ? 1 : 0
 	multi_z_spiral_block(epicenter,max_range,shape)
-
-// Halves above and below, as per suggestion by deity on how to handle multi-z explosions
-/proc/explosion_destroy_multi_z(turf/epicenter, turf/offcenter, const/devastation_range, const/heavy_impact_range, const/light_impact_range, const/flash_range, var/explosion_time, var/mob/whodunnit)
-	if(HasAbove(offcenter.z) && (devastation_range >= 1 || heavy_impact_range >= 1 || light_impact_range >= 1 || flash_range >= 1))
-		var/turf/upcenter = GetAbove(offcenter)
-		if(upcenter.z > epicenter.z)
-			explosion_destroy(epicenter, upcenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, explosion_time, whodunnit)
-	if(HasBelow(offcenter.z) && (devastation_range >= 1 || heavy_impact_range >= 1 || light_impact_range >= 1 || flash_range >= 1))
-		var/turf/downcenter = GetBelow(offcenter)
-		if(downcenter.z < epicenter.z)
-			explosion_destroy(epicenter, downcenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, explosion_time, whodunnit)

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -60,3 +60,19 @@
 		. = GetBelow(ref)
 	else
 		. = get_step(ref, dir)
+
+/proc/get_zstep_towards(atom/ref, atom/trg)
+	if(trg.z > ref.z)
+		. = GetAbove(ref)
+	else if (trg.z < ref.z)
+		. = GetBelow(ref)
+	else
+		. = get_step_towards(ref, trg)
+
+/proc/get_zstep_away(atom/ref, atom/trg)
+	if(trg.z > ref.z)
+		. = GetAbove(ref)
+	else if (trg.z < ref.z)
+		. = GetBelow(ref)
+	else
+		. = get_step_away(ref, trg)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -284,7 +284,7 @@ By design, d1 is the smallest direction and d2 is the highest
 		if(T.protect_infrastructure)
 			return
 	. = list()
-	if (prob(100 / (1<<(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
 		if(severity > 1)
 			. += new /obj/item/stack/cable_coil(src.loc, src.d1 ? 2 : 1, light_color)
 		qdel(src)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -283,19 +283,11 @@ By design, d1 is the smallest direction and d2 is the highest
 		var/turf/T = loc
 		if(T.protect_infrastructure)
 			return
-	switch(severity)
-		if(1.0)
-			qdel(src)
-		if(2.0)
-			if(prob(50))
-				new /obj/item/stack/cable_coil(src.loc, src.d1 ? 2 : 1, light_color)
-				qdel(src)
-
-		if(3.0)
-			if(prob(25))
-				new /obj/item/stack/cable_coil(src.loc, src.d1 ? 2 : 1, light_color)
-				qdel(src)
-	return
+	. = list()
+	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+		if(severity > 1)
+			. += new /obj/item/stack/cable_coil(src.loc, src.d1 ? 2 : 1, light_color)
+		qdel(src)
 
 /obj/structure/cable/proc/cableColor(var/colorC = "red")
 	light_color = colorC

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -284,7 +284,7 @@ By design, d1 is the smallest direction and d2 is the highest
 		if(T.protect_infrastructure)
 			return
 	. = list()
-	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+	if (prob(100 / (1<<(severity-1)))) //1 = 100, 2 = 50, 3 = 25
 		if(severity > 1)
 			. += new /obj/item/stack/cable_coil(src.loc, src.d1 ? 2 : 1, light_color)
 		qdel(src)

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -112,9 +112,9 @@ var/global/list/rad_collectors = list()
 	return FALSE
 
 /obj/machinery/power/rad_collector/ex_act(severity)
-	switch(severity)
-		if(2, 3)
-			eject()
+	. = list()
+	if(severity > 1)
+		. += eject()
 
 	return ..()
 
@@ -127,6 +127,7 @@ var/global/list/rad_collectors = list()
 
 	P.forceMove(get_turf(src))
 	P.reset_plane_and_layer()
+	. = P
 	P = null
 
 	if(active)

--- a/code/modules/power/solars/panel.dm
+++ b/code/modules/power/solars/panel.dm
@@ -140,16 +140,17 @@
 		health = 1 //Only holding up on shards and scrap
 
 /obj/machinery/power/solar/panel/ex_act(severity)
+	. = list()
 	switch(severity)
 		if(1.0)
 			solar_assembly.glass_type = null //The glass you're looking for is below pal
 			if(prob(15))
-				new /obj/item/weapon/shard(loc)
+				. += new /obj/item/weapon/shard(loc)
 			kill()
 		if(2.0)
 			if(prob(25))
 				solar_assembly.glass_type = null //The glass you're looking for is below pal
-				new /obj/item/weapon/shard(loc)
+				. += new /obj/item/weapon/shard(loc)
 				kill()
 			else
 				broken()

--- a/code/modules/spacepods/spacepods.dm
+++ b/code/modules/spacepods/spacepods.dm
@@ -152,16 +152,17 @@
 	update_icons()
 
 /obj/spacepod/ex_act(severity)
+	. = list()
 	switch(severity)
 		if(1)
 			if(has_passengers())
 				for(var/mob/living/L in get_passengers())
-					move_outside(L, get_turf(src))
+					. += move_outside(L, get_turf(src))
 					L.ex_act(severity + 1)
 					to_chat(L, "<span class='warning'>You are forcefully thrown from \the [src]!</span>")
 			var/mob/living/carbon/human/H = get_pilot()
 			if(H)
-				move_outside(H, get_turf(src))
+				. += move_outside(H, get_turf(src))
 				H.ex_act(severity + 1)
 				to_chat(H, "<span class='warning'>You are forcefully thrown from \the [src]!</span>")
 			QDEL_NULL(ion_trail) // Should be nulled by qdel src in next line but OH WELL
@@ -658,6 +659,7 @@
 		exit_turf = get_turf(src)
 	adjust_occupants(occupant, STATUS_REMOVE)
 	occupant.forceMove(exit_turf)
+	return occupant
 
 /obj/spacepod/proc/adjust_occupants(var/mob/user, var/status)
 	if(status == STATUS_REMOVE)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -176,11 +176,8 @@
 	return TRUE
 
 /obj/machinery/power/supermatter/ex_act(severity,var/mob/whodunnit)
-	switch(severity)
-		if(3.0)
-			return //Should be improved
-		else
-			return explode(whodunnit)
+	if(severity < 3)
+		return explode(whodunnit)
 
 /obj/machinery/power/supermatter/shard/singularity_act(current_size, obj/machinery/singularity/S)
 	var/super = FALSE


### PR DESCRIPTION
[content][tweak][administration]

## What this does
allows ex_act() to optionally return a list, anything returned in this list also gets thrown by the explosion along with any atoms otherwise affected.
also does general code cleanup for explosion_destroy and throw_at, such as variable renaming and gutting the snowflaked multiz destroy function, properly porting it to the multi_z_spiral_block system while upgrading that to also allow specification for what radius to increase or decrease by with each z level away. (preserved in every case it was used in before)
postpones the air subsystem in explosions for somewhat less than the average duration of them (tested with no big effect on it really) that makes them about 10 seconds faster on nuke explosions (negligible below those) but the processing added from extra throwing balances it out to the old values.
finally, adds a timer to the bombs in debug logging, showing how long this took to produce, and an extra "nuclear bomb" option in the admin drop bomb verb for testing really big booms. (and just for fun, the supermatter sized EMP one in the drop EMP verb for consistency)

## Why it's good
more things will get thrown by bombs that really should be.

## Changelog
:cl:
 * tweak: Stuff dropped by exploded objects are now properly thrown by explosions.
 * tweak: Floors now have explosion blocking properties if on a different connected z-level from the epicenter on multi-z maps.
 * tweak: The line about "the station structure shaking" in explosions has been changed to be a more general "everything shaking" since not all explosions happen on the station proper.
 * bugfix: Multi-z explosions no longer hang on infinite loops.
 * bugfix: Exploded body scanners, sleepers, morgue trays and cremators now properly affect mobs inside when destroyed.