### PR TITLE
Fixes dices not rolling on throws

### DIFF
--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -94,7 +94,7 @@
 	diceroll(user, 0)
 
 /obj/item/weapon/dice/throw_impact(atom/hit_atom, speed, user)
-	if(..())
+	if(!..())
 		diceroll(user, 1)
 
 /obj/item/weapon/dice/proc/show_roll(mob/user as mob, thrown, result)


### PR DESCRIPTION
[bugfix]

## What this does
Closes #34175.

## Changelog
:cl:
 * bugfix: Dices roll on being thrown again.