### PR TITLE
Bumcivillian recipe change.

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -4093,7 +4093,7 @@
 /datum/chemical_reaction/bumcivilian/on_reaction(var/datum/reagents/holder, var/created_volume)
 	..()
 	var/atom/A = get_holder_at_turf_level(holder.my_atom)
-	holder.my_atom.visible_message("<span class='warning'>Suddenly, everything around [A ? "\the [A]" : "\the [my_holder.atom] "]becomes perfectly silent...</span>")
+	holder.my_atom.visible_message("<span class='warning'>Suddenly, everything around [A ? "\the [A] " : "\the [holder.my_atom] "]becomes perfectly silent...</span>")
 	var/datum/reagent/bumcivilian/B = locate(/datum/reagent/bumcivilian) in holder.reagent_list
 	for(var/turf/T in view(get_turf(holder.my_atom)))
 		T.mute_time = world.time + B.mute_duration

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -4092,10 +4092,12 @@
 
 /datum/chemical_reaction/bumcivilian/on_reaction(var/datum/reagents/holder, var/created_volume)
 	..()
+	var/atom/A = get_holder_at_turf_level(holder.my_atom)
+	holder.my_atom.visible_message("<span class='warning'>Suddenly, everything around [A ? "\the [A]" : "\the [my_holder.atom] "]becomes perfectly silent...</span>")
 	var/datum/reagent/bumcivilian/B = locate(/datum/reagent/bumcivilian) in holder.reagent_list
 	for(var/turf/T in view(get_turf(holder.my_atom)))
 		T.mute_time = world.time + B.mute_duration
-
+	
 /datum/chemical_reaction/random
 	name = "Random chemical"
 	id = "random"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -4078,17 +4078,17 @@
 	required_reagents = list(PICCOLYN = 1, INACUSIATE = 1, SUGARS = 1)
 	result_amount = 3
 
-/datum/chemical_reaction/bumcivilian
+/datum/chemical_reaction/bumcivilian //same reaction type as midazoline, you must dunk the iron sheet on sacid to get bumcivillian
 	name = "Bumcivilian"
 	id = BUMCIVILIAN
 	result = BUMCIVILIAN
-	required_reagents = list(IRON = 1, SACIDS = 1) //..5.05 Mg
+	required_reagents = list(SACIDS = 1)
 	result_amount = 1
 
 /datum/chemical_reaction/bumcivilian/required_condition_check(datum/reagents/holder)
-	for(var/obj/item/device/deskbell/B in view(3,get_turf(holder.my_atom)))
-		if(world.time - B.last_ring_time <= 30)
-			return 1
+	if(istype(holder.my_atom, /obj/item/weapon/reagent_containers))
+		return (locate(/obj/item/stack/sheet/metal) in holder.my_atom.contents)
+	return 0
 
 /datum/chemical_reaction/bumcivilian/on_reaction(var/datum/reagents/holder, var/created_volume)
 	..()


### PR DESCRIPTION
Bumcivillian is the sound sucking chem added in #32704.
### What this does
Changes the recipe for bumcivillian from Iron + Sacid and ringing a bell near the reaction in the last 3 seconds to dunking a metal sheet on sacid, which requires a comically large Erlenmeyer flask or jar.. It's the same reaction system used in #29331.
### Why it's good
Fits better with the original [source material](https://www.youtube.com/watch?v=GG4qEzPsbo8) (the bell was rung to prove the reaction happened, not to cause it), and makes it a viable compound to use. Does not touch bumcivillian's behaviour itself at all.
Won't be that big a balance change as the sound suppresion is limited to only the 7x7 area centered around the reaction. You can just move a couple tiles and speak again.
:cl:
 * tweak: Changes Bumcivillian (the sound sucking chemical)'s Recipe. To make bumcivillian you must dunk a metal sheet on sulphuric acid, this requires a comically large Erlenmeyer flask or a jar.