### PR TITLE
fix runtime causing roundstart lag when blacksite prism ruin spawns

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -452,7 +452,7 @@ var/list/impact_master = list()
 /obj/item/projectile/proc/OnFired(var/proj_target = original)	//if assigned, allows for code when the projectile gets fired
 	target = get_turf(proj_target)
 
-	if(!original && !target)
+	if(isnull(target) || (!original && !target))
 		qdel(src) //If for some reason the target stops existing as the weapon is fired, just delete the projectile
 		return
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -452,7 +452,7 @@ var/list/impact_master = list()
 /obj/item/projectile/proc/OnFired(var/proj_target = original)	//if assigned, allows for code when the projectile gets fired
 	target = get_turf(proj_target)
 
-	if(isnull(target) || (!original && !target))
+	if(!original || !target))
 		qdel(src) //If for some reason the target stops existing as the weapon is fired, just delete the projectile
 		return
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -452,7 +452,7 @@ var/list/impact_master = list()
 /obj/item/projectile/proc/OnFired(var/proj_target = original)	//if assigned, allows for code when the projectile gets fired
 	target = get_turf(proj_target)
 
-	if(!original || !target))
+	if(!original || !target)
 		qdel(src) //If for some reason the target stops existing as the weapon is fired, just delete the projectile
 		return
 


### PR DESCRIPTION
The syndicates were gunning down vox prisoners so fast that it was causing a lot of runtimes when the vox simplemob got qdel'd to turn into a lootable carbon mob body.
closes #34246
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed roundstart lag due to runtime from a space ruin.