### PR TITLE
Vox pirate sword and also Vox pirate pirate sword

### DIFF
--- a/code/datums/gamemode/factions/vox_shoal.dm
+++ b/code/datums/gamemode/factions/vox_shoal.dm
@@ -321,7 +321,7 @@ var/list/potential_bonus_items = list(
 	..()
 	new /obj/item/clothing/suit/space/vox/carapace(src)
 	new /obj/item/clothing/head/helmet/space/vox/carapace(src)
-	new /obj/item/weapon/melee/telebaton(src)
+	new /obj/item/weapon/melee/energy/sword/pirate(src)
 	new /obj/item/clothing/glasses/thermal/monocle(src)
 	new /obj/item/device/chameleon(src)
 	var/obj/item/weapon/crossbow/W = new(src)
@@ -354,6 +354,7 @@ var/list/potential_bonus_items = list(
 	new /obj/item/weapon/storage/belt/utility/full(src)
 	new /obj/item/clothing/glasses/thermal/monocle(src)
 	new /obj/item/weapon/card/emag(src)
+	new /obj/item/weapon/melee/telebaton(src)
 	new /obj/item/weapon/gun/dartgun/vox/raider(src)
 	new /obj/item/device/multitool(src)
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -582,6 +582,14 @@ var/list/uplink_items = list()
 	cost = 6
 	discounted_cost = 4
 	jobs_with_discount = list("Grey")
+	
+/datum/uplink_item/ayylmao/pirate_cutlass
+	name = "Energy Cutlass"
+	desc = "An energy sword with a broader blade at a slight curve, making it simpler to use when cutting, but the rather conspicuous hand guard means it can't be attached to a second sword at the handles like a typical straight-bladed energy sword."
+	item = /obj/item/weapon/melee/energy/sword/pirate
+	cost = 8
+	discounted_cost = 6
+	jobs_with_discount = list("Vox")
 
 // IMPLANTS
 // Any Syndicate item that gets implanted into the body goes here


### PR DESCRIPTION
## What this does
Energy cutlass traitor item for vox

Also while I was making this I thought we already had a vox pirate so I gave the energy cutlass to the vox raider and moved the vox raider's telescopic baton to the vox sabetour as exchange since the saboteur doesn't really have a melee weapon 

## Why it's good
While I'm still waiting patiently for both the third Sid Meier's Pirates game and [the nuke update](https://github.com/vgstation-coders/vgstation13/commit/be044b18c88950cc805f146309e6528d0e99c1b8), I figured this unused asset could be used somewhere, and that somewhere is here

### But why for vox?
Get it? Because vox sailors? They live on ships instead of on planets like everybody else? The high seas and all that?
Y'all are acting like this _isn't_ the most flavored non-human species in the game

## Changelog
:cl:
 * rscadd: Energy cutlass traitor item for vox
 * tweak: The Vox Raider gets an energy cutlass but their telescopic baton was taken and given to the Vox Saboteur in exchange