### PR TITLE
Adding posibrains to cameras to control things in line of sight.

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -278,6 +278,19 @@ var/list/camera_messages = list()
 
 			return
 
+	// ID swiping for adding access to MMIs put in the camera
+	else if (istype(W, /obj/item/weapon/card) && assembly && assembly.upgrades.len)
+		var/obj/item/device/mmi/MMI = locate(/obj/item/device/mmi) in assembly.upgrades
+		if(MMI)
+			if(isEmag(W))
+				to_chat(user, "You short out [MMI]'s access requirements, overriding them.")
+				spark(src,5)
+				MMI.camera_access = get_all_accesses()
+			else if(isID(W))
+				var/obj/item/weapon/card/id/ID = W
+				to_chat(user, "You add the access on [ID] to [MMI].")
+				MMI.camera_access |= ID.
+
 	// OTHER
 	else if ((istype(W, /obj/item/weapon/paper) || istype(W, /obj/item/device/pda)) && isliving(user))
 		user.delayNextAttack(5)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -289,7 +289,7 @@ var/list/camera_messages = list()
 			else if(isID(W))
 				var/obj/item/weapon/card/id/ID = W
 				to_chat(user, "You add the access on [ID] to [MMI].")
-				MMI.camera_access |= ID.
+				MMI.camera_access |= ID.access
 
 	// OTHER
 	else if ((istype(W, /obj/item/weapon/paper) || istype(W, /obj/item/device/pda)) && isliving(user))

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -16,6 +16,7 @@
 		/obj/item/stack/sheet/mineral/plasma,
 		/obj/item/weapon/reagent_containers/food/snacks/grown/carrot,
 		/obj/item/device/assembly/voice,
+		/obj/item/device/mmi/posibrain,
 		)
 
 	var/list/upgrades = list()

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -30,6 +30,7 @@
 	var/mob/living/carbon/brain/brainmob = null//The current occupant.
 	var/mob/living/silicon/robot = null//Appears unused.
 	var/obj/mecha = null//This does not appear to be used outside of reference in mecha.dm.
+	var/list/camera_access = list()
 
 /obj/item/device/mmi/Destroy()
 	if(brainmob)

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -119,5 +119,5 @@
 	else
 		return ..()
 
-//mob/living/simple_animal/hostile/pulse_demon/GetAccess()
-	//return can_ai_click() ? get_all_accesses() : ..()
+/mob/living/carbon/brain/GetAccess()
+	return can_ai_click() ? camera_access : ..()

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -120,4 +120,7 @@
 		return ..()
 
 /mob/living/carbon/brain/GetAccess()
-	return can_ai_click() ? container.camera_access : ..()
+	if(can_ai_click() && istype(container,/obj/item/device/mmi))
+		var/obj/item/device/mmi/MMI = container
+		return MMI.camera_access
+	return ..()

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -120,4 +120,4 @@
 		return ..()
 
 /mob/living/carbon/brain/GetAccess()
-	return can_ai_click() ? camera_access : ..()
+	return can_ai_click() ? container.camera_access : ..()

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -78,3 +78,46 @@
 
 /mob/living/carbon/brain/dexterity_check()
 	return 1 //This is so certain mech tools work for MMIs and posibrains.
+
+/mob/living/carbon/brain/proc/can_ai_click()
+	if(container && istype(container.loc,/obj/machinery/camera))
+		var/obj/machinery/camera/C = container.loc
+		if(container in C.assembly.upgrades)
+			return TRUE
+	return FALSE
+
+/mob/living/carbon/brain/ClickOn(var/atom/A, params)
+	if(can_ai_click())
+		A.add_hiddenprint(src)
+		A.attack_ai(src)
+	else
+		return ..()
+
+/mob/living/carbon/brain/ShiftClickOn(var/atom/A)
+	if(can_ai_click())
+		A.AIShiftClick(src)
+	else
+		return ..()
+/mob/living/carbon/brain/CtrlClickOn(var/atom/A)
+	if(can_ai_click())
+		A.AICtrlClick(src)
+	else
+		return ..()
+/mob/living/carbon/brain/AltClickOn(var/atom/A)
+	if(can_ai_click())
+		A.AIAltClick(src)
+	else
+		return ..()
+/mob/living/carbon/brain/MiddleShiftClickOn(var/atom/A)
+	if(can_ai_click())
+		A.AIMiddleShiftClick(src)
+	else
+		return ..()
+/mob/living/carbon/brain/RightClickOn(var/atom/A)
+	if(can_ai_click())
+		A.AIRightClick(src)
+	else
+		return ..()
+
+//mob/living/simple_animal/hostile/pulse_demon/GetAccess()
+	//return can_ai_click() ? get_all_accesses() : ..()


### PR DESCRIPTION
## What this does
adds these to the acceptable upgrade types for security cameras.
when a posibrain (not MMIs for now since it doesn't make as much sense on how they'd fit in there, plus i guess it absolutely stops antagonists or anything harmful to the crew going in them) is added to a camera they can control all machinery in the camera's vision range like an AI would, but without any access. swiping the camera with a posibrain inside with your ID will add that access to its controlling, an emag will make it all-access. should probably also be stated but obviously these posibrains cannot move from this position, and they're added and removed just like any kind of upgrade.

## Why it's good
more robutticist gimmicks

## Changelog
:cl:
 * rscadd: Active positronic brains now work as upgrades for cameras, allowing ones placed inside to control all machinery in view like an AI would from a static point. These do not have any access and are only granted it with ID swipes copying their access to them.