### PR TITLE
515 browser pane fix

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1206,7 +1206,6 @@ window "browserwindow"
 		size = 640x480
 		anchor1 = none
 		anchor2 = none
-		is-visible = true
 		saved-params = "pos;size;is-minimized;is-maximized"
 		title = "Browser"
 		is-pane = true

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1206,6 +1206,7 @@ window "browserwindow"
 		size = 640x480
 		anchor1 = none
 		anchor2 = none
+		is-visible = true
 		saved-params = "pos;size;is-minimized;is-maximized"
 		title = "Browser"
 		is-pane = true
@@ -1216,7 +1217,6 @@ window "browserwindow"
 		anchor1 = 0,0
 		anchor2 = 100,100
 		background-color = #ffffff
-		is-default = true
 		saved-params = ""
 		on-show = ".winset\"rpane.infob.is-visible=true?rpane.infob.pos=130,0;rpane.textb.is-visible=true;rpane.browseb.is-visible=true;rpane.browseb.is-checked=true;rpane.rpanewindow.pos=0,30;rpane.rpanewindow.size=0x0;rpane.rpanewindow.left=browserwindow\""
 		on-hide = ".winset\"rpane.infob.is-visible=true?rpane.infob.is-checked=true rpane.infob.pos=65,0 rpane.rpanewindow.left=infowindow:rpane.rpanewindow.left=textwindow rpane.textb.is-visible=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0\""


### PR DESCRIPTION
## What this does
Fixes browser pane in top right popping up and overriding "info" pane whenever a window is closed.
Only became an issue after this fix/version:
https://www.byond.com/forum/post/2844473

I haven't tested this on 514 because the code doesn't compile on 514. Also, running a 515-compiled server on a 514 client doesn't work. Tested on 515 with no issues.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed the "Browser" pane overriding the "Info" pane whenever a window is closed.