### PR TITLE
More mining loot crate items (and updates)

### DIFF
--- a/code/modules/mining/abandoned_crates/vg.dm
+++ b/code/modules/mining/abandoned_crates/vg.dm
@@ -71,9 +71,6 @@
 	for(var/i in 1 to rand(3,9))
 		var/type = pick(possible_spawns)
 		var/obj/item/weapon/stock_parts/SP = new type(src)
-		if(MAT_PHAZON in SP.starting_materials)
-			SP.starting_materials[MAT_PHAZON] = 0
-			SP.starting_materials -= MAT_PHAZON
 
 /obj/structure/closet/crate/secure/loot/vg_stockparts/tier3
 	attempts = 2
@@ -84,16 +81,6 @@
 			/obj/item/weapon/stock_parts/manipulator/nano/pico,
 			/obj/item/weapon/stock_parts/scanning_module/adv/phasic,
 			/obj/item/weapon/stock_parts/matter_bin/adv/super)
-
-/obj/structure/closet/crate/secure/loot/vg_stockparts/tier4
-	attempts = 3
-	possible_spawns = list(
-//			/obj/item/weapon/stock_parts/console_screen/reinforced/plasma/rplasma,
-			/obj/item/weapon/stock_parts/capacitor/adv/super/ultra,
-			/obj/item/weapon/stock_parts/micro_laser/high/ultra/giga,
-			/obj/item/weapon/stock_parts/manipulator/nano/pico/femto,
-			/obj/item/weapon/stock_parts/scanning_module/adv/phasic/bluespace,
-			/obj/item/weapon/stock_parts/matter_bin/adv/super/bluespace)
 
 /obj/structure/closet/crate/secure/loot/vg_lazinjectors/New()
 	..()

--- a/code/modules/mining/abandoned_crates/vg.dm
+++ b/code/modules/mining/abandoned_crates/vg.dm
@@ -25,7 +25,7 @@
 
 /obj/structure/closet/crate/secure/loot/vg_bestdrill/New()
 	..()
-	new/obj/item/weapon/pickaxe/plasmacutter/accelerator(src)
+	new/obj/item/device/modkit/plasmacutter(src)
 
 /obj/structure/closet/crate/secure/loot/vg_hivecores
 	attempts = 2

--- a/code/modules/mining/abandoned_crates/vg.dm
+++ b/code/modules/mining/abandoned_crates/vg.dm
@@ -1,3 +1,192 @@
 /obj/structure/closet/crate/secure/loot/vg_painting/New()
 	..()
 	new/obj/item/mounted/frame/painting(src)
+
+/obj/structure/closet/crate/secure/loot/vg_oreloader
+	attempts = 2
+
+/obj/structure/closet/crate/secure/loot/vg_oreloader/New()
+	..()
+	new/obj/item/weapon/storage/bag/ore/auto(src)
+
+/obj/structure/closet/crate/secure/loot/vg_betterdrill
+	attempts = 2
+
+/obj/structure/closet/crate/secure/loot/vg_betterdrill/New()
+	..()
+	new/obj/item/weapon/pickaxe/drill/diamond(src)
+
+/obj/structure/closet/crate/secure/loot/vg_bestdrill
+	attempts = 1
+
+/obj/structure/closet/crate/secure/loot/vg_bestdrill/New()
+	..()
+	new/obj/item/weapon/pickaxe/plasmacutter/accelerator(src)
+
+/obj/structure/closet/crate/secure/loot/vg_phazbananium
+	attempts = 2
+
+/obj/structure/closet/crate/secure/loot/vg_phazbananium/New()
+	..()
+	attempts = rand(1,2)
+	if(attempts == 2)
+		drop_stack(pick(/obj/item/stack/ore/phazon,/obj/item/stack/ore/clown), src, rand(10,20))
+	else
+		drop_stack(/obj/item/stack/ore/phazon, src, rand(5,10))
+		drop_stack(/obj/item/stack/ore/clown, src, rand(5,10))
+
+/obj/structure/closet/crate/secure/loot/vg_cash/New()
+	..()
+	attempts = pick(1,2,2,3,3,3)
+	dispense_cash((10**attempts)*rand(5,20),src) //50-200, 500-2000, 5000-20000
+
+/obj/structure/closet/crate/secure/loot/vg_hivecores
+	attempts = 2
+
+/obj/structure/closet/crate/secure/loot/vg_hivecores/New()
+	..()
+	for(var/i in 1 to 3)
+		new/obj/item/asteroid/hivelord_core(src)
+
+/obj/structure/closet/crate/secure/loot/vg_hideplates
+	attempts = 2
+
+/obj/structure/closet/crate/secure/loot/vg_hideplates/New()
+	..()
+	var/type = pick(/obj/item/asteroid/basilisk_hide,/obj/item/asteroid/goliath_hide)
+	new type(src)
+	if(prob(25))
+		attempts--
+		type = pick(/obj/item/asteroid/basilisk_hide,/obj/item/asteroid/goliath_hide)
+		new type(src)
+
+/obj/structure/closet/crate/secure/loot/vg_rigstuff
+	attempts = 2
+
+/obj/structure/closet/crate/secure/loot/vg_rigstuff/New()
+	..()
+	for(var/i in 1 to rand(2,3))
+		var/rigtype = pick(subtypesof(/obj/item/rig_module))
+		new rigtype(src)
+
+
+/obj/structure/closet/crate/secure/loot/vg_stockparts
+	var/list/possible_spawns = list(
+		/obj/item/weapon/stock_parts/console_screen/reinforced,
+		/obj/item/weapon/stock_parts/capacitor/adv,
+		/obj/item/weapon/stock_parts/micro_laser/high,
+		/obj/item/weapon/stock_parts/manipulator/nano,
+		/obj/item/weapon/stock_parts/scanning_module/adv,
+		/obj/item/weapon/stock_parts/matter_bin/adv)
+
+/obj/structure/closet/crate/secure/loot/vg_stockparts/New()
+	..()
+	for(var/i in 1 to rand(3,9))
+		var/type = pick(possible_spawns)
+		new type(src)
+
+/obj/structure/closet/crate/secure/loot/vg_stockparts/tier3
+	attempts = 2
+	possible_spawns = list(
+			/obj/item/weapon/stock_parts/console_screen/reinforced/plasma,
+			/obj/item/weapon/stock_parts/capacitor/adv/super,
+			/obj/item/weapon/stock_parts/micro_laser/high/ultra,
+			/obj/item/weapon/stock_parts/manipulator/nano/pico,
+			/obj/item/weapon/stock_parts/scanning_module/adv/phasic,
+			/obj/item/weapon/stock_parts/matter_bin/adv/super)
+
+/obj/structure/closet/crate/secure/loot/vg_stockparts/tier4
+	attempts = 3
+	possible_spawns = list(
+//			/obj/item/weapon/stock_parts/console_screen/reinforced/plasma/rplasma,
+			/obj/item/weapon/stock_parts/capacitor/adv/super/ultra,
+			/obj/item/weapon/stock_parts/micro_laser/high/ultra/giga,
+			/obj/item/weapon/stock_parts/manipulator/nano/pico/femto,
+			/obj/item/weapon/stock_parts/scanning_module/adv/phasic/bluespace,
+			/obj/item/weapon/stock_parts/matter_bin/adv/super/bluespace)
+
+/obj/structure/closet/crate/secure/loot/vg_lazinjectors/New()
+	..()
+	for(var/i in 1 to 3)
+		new/obj/item/weapon/lazarus_injector(src)
+
+/obj/structure/closet/crate/secure/loot/vg_advlazinjectors
+	attempts = 2
+
+/obj/structure/closet/crate/secure/loot/vg_advlazinjectors/New()
+	..()
+	for(var/i in 1 to 3)
+		new/obj/item/weapon/lazarus_injector/advanced(src)
+
+/obj/structure/closet/crate/secure/loot/vg_borgupgrades
+	var/list/tospawn = list(/obj/item/borg/upgrade/hook,/obj/item/borg/upgrade/portosmelter)
+
+/obj/structure/closet/crate/secure/loot/vg_borgupgrades/New()
+	..()
+	for(var/i in 1 to max(1,tospawn.len-1))
+		var/type = pick_n_take(tospawn)
+		new type(src)
+
+/obj/structure/closet/crate/secure/loot/vg_borgupgrades/xenoarch
+	attempts = 2
+	tospawn = list(/obj/item/borg/upgrade/hook,/obj/item/borg/upgrade/portosmelter,/obj/item/borg/upgrade/xenoarch)
+
+/obj/structure/closet/crate/secure/loot/vg_borgupgrades/xenoarch_adv
+	attempts = 1
+	tospawn = list(/obj/item/borg/upgrade/hook,/obj/item/borg/upgrade/portosmelter,/obj/item/borg/upgrade/xenoarch_adv)
+
+/obj/structure/closet/crate/secure/loot/vg_seeds
+	attempts = 2
+
+/obj/structure/closet/crate/secure/loot/vg_seeds/New()
+	..()
+	var/list/types = list(
+		/obj/item/seeds/goldappleseed,
+		/obj/item/seeds/silverpearseed,
+		/obj/item/seeds/diamondcarrotseed,
+		/obj/item/seeds/plasmacabbageseed,
+		/obj/item/seeds/glowberryseed,
+		/obj/item/seeds/telriis,
+		/obj/item/seeds/vale)
+	for(var/i in 1 to 3)
+		var/type = pick(types)
+		new type(src)
+	if(prob(10))
+		new /obj/item/seeds/nofruitseed(src)
+
+/obj/structure/closet/crate/secure/loot/vg_bots/New()
+	..()
+	for(var/i in 1 to 3)
+		switch(rand(1,7))
+			if(1)
+				new /obj/item/weapon/bucket_sensor(src)
+				var/robotarm = pick(/obj/item/robot_parts/l_arm,/obj/item/robot_parts/r_arm)
+				new robotarm(src)
+			if(2)
+				new /obj/item/weapon/toolbox_tiles_sensor(src)
+				var/robotarm = pick(/obj/item/robot_parts/l_arm,/obj/item/robot_parts/r_arm)
+				new robotarm(src)
+			if(3)
+				new /obj/item/weapon/medbot_cube(src)
+			if(4)
+				new /obj/item/weapon/secbot_assembly(src)
+				var/robotarm = pick(/obj/item/robot_parts/l_arm,/obj/item/robot_parts/r_arm)
+				new robotarm(src)
+				new /obj/item/device/assembly/prox_sensor(src)
+				// go find the baton yourself, better yet in another loot crate
+			if(5)
+				new /obj/item/clothing/head/cardborg(src)
+				new /obj/item/device/assembly/signaler(src)
+				new /obj/item/device/assembly/prox_sensor(src)
+			if(6)
+				new /obj/item/weapon/secbot_assembly/britsky(src)
+				var/robotarm = pick(/obj/item/robot_parts/l_arm,/obj/item/robot_parts/r_arm)
+				new robotarm(src)
+				new /obj/item/device/assembly/prox_sensor(src)
+				// good luck finding the classic baton but i'm not including it in a low difficulty crate
+			if(7)
+				new /obj/item/weapon/mining_drone_cube(src)
+
+/obj/structure/closet/crate/secure/loot/vg_boreregg/New()
+	..()
+	new /obj/item/weapon/reagent_containers/food/snacks/borer_egg(src)

--- a/code/modules/mining/abandoned_crates/vg.dm
+++ b/code/modules/mining/abandoned_crates/vg.dm
@@ -28,7 +28,7 @@
 	new/obj/item/device/modkit/plasmacutter(src)
 
 /obj/structure/closet/crate/secure/loot/vg_hivecores
-	attempts = 2
+	attempts = 1
 
 /obj/structure/closet/crate/secure/loot/vg_hivecores/New()
 	..()

--- a/code/modules/mining/abandoned_crates/vg.dm
+++ b/code/modules/mining/abandoned_crates/vg.dm
@@ -2,6 +2,10 @@
 	..()
 	new/obj/item/mounted/frame/painting(src)
 
+/obj/structure/closet/crate/secure/loot/vg_plasmabeaker/New()
+	..()
+	new/obj/item/weapon/reagent_containers/glass/beaker/large/plasma(src)
+
 /obj/structure/closet/crate/secure/loot/vg_oreloader
 	attempts = 2
 

--- a/code/modules/mining/abandoned_crates/vg.dm
+++ b/code/modules/mining/abandoned_crates/vg.dm
@@ -70,7 +70,8 @@
 	..()
 	for(var/i in 1 to rand(3,9))
 		var/type = pick(possible_spawns)
-		new type(src)
+		var/obj/item/weapon/stock_parts/SP = new type(src)
+		SP.starting_materials -= MAT_PHAZON
 
 /obj/structure/closet/crate/secure/loot/vg_stockparts/tier3
 	attempts = 2

--- a/code/modules/mining/abandoned_crates/vg.dm
+++ b/code/modules/mining/abandoned_crates/vg.dm
@@ -71,7 +71,9 @@
 	for(var/i in 1 to rand(3,9))
 		var/type = pick(possible_spawns)
 		var/obj/item/weapon/stock_parts/SP = new type(src)
-		SP.starting_materials -= MAT_PHAZON
+		if(MAT_PHAZON in SP.starting_materials)
+			SP.starting_materials[MAT_PHAZON] = 0
+			SP.starting_materials -= MAT_PHAZON
 
 /obj/structure/closet/crate/secure/loot/vg_stockparts/tier3
 	attempts = 2

--- a/code/modules/mining/abandoned_crates/vg.dm
+++ b/code/modules/mining/abandoned_crates/vg.dm
@@ -28,16 +28,11 @@
 	new/obj/item/weapon/pickaxe/plasmacutter/accelerator(src)
 
 /obj/structure/closet/crate/secure/loot/vg_phazbananium
-	attempts = 2
+	attempts = 1
 
 /obj/structure/closet/crate/secure/loot/vg_phazbananium/New()
 	..()
-	attempts = rand(1,2)
-	if(attempts == 2)
-		drop_stack(pick(/obj/item/stack/ore/phazon,/obj/item/stack/ore/clown), src, rand(10,20))
-	else
-		drop_stack(/obj/item/stack/ore/phazon, src, rand(5,10))
-		drop_stack(/obj/item/stack/ore/clown, src, rand(5,10))
+	drop_stack(pick(/obj/item/stack/ore/phazon,/obj/item/stack/ore/clown), src, rand(10,20))
 
 /obj/structure/closet/crate/secure/loot/vg_cash/New()
 	..()

--- a/code/modules/mining/abandoned_crates/vg.dm
+++ b/code/modules/mining/abandoned_crates/vg.dm
@@ -27,18 +27,6 @@
 	..()
 	new/obj/item/weapon/pickaxe/plasmacutter/accelerator(src)
 
-/obj/structure/closet/crate/secure/loot/vg_phazbananium
-	attempts = 1
-
-/obj/structure/closet/crate/secure/loot/vg_phazbananium/New()
-	..()
-	drop_stack(pick(/obj/item/stack/ore/phazon,/obj/item/stack/ore/clown), src, rand(10,20))
-
-/obj/structure/closet/crate/secure/loot/vg_cash/New()
-	..()
-	attempts = pick(1,2,2,3,3,3)
-	dispense_cash((10**attempts)*rand(5,20),src) //50-200, 500-2000, 5000-20000
-
 /obj/structure/closet/crate/secure/loot/vg_hivecores
 	attempts = 2
 

--- a/code/modules/mining/abandoned_crates/vg.dm
+++ b/code/modules/mining/abandoned_crates/vg.dm
@@ -114,14 +114,6 @@
 		var/type = pick_n_take(tospawn)
 		new type(src)
 
-/obj/structure/closet/crate/secure/loot/vg_borgupgrades/xenoarch
-	attempts = 2
-	tospawn = list(/obj/item/borg/upgrade/hook,/obj/item/borg/upgrade/portosmelter,/obj/item/borg/upgrade/xenoarch)
-
-/obj/structure/closet/crate/secure/loot/vg_borgupgrades/xenoarch_adv
-	attempts = 1
-	tospawn = list(/obj/item/borg/upgrade/hook,/obj/item/borg/upgrade/portosmelter,/obj/item/borg/upgrade/xenoarch_adv)
-
 /obj/structure/closet/crate/secure/loot/vg_seeds
 	attempts = 2
 

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -31,12 +31,7 @@
 				lastattempt = input
 				attempts--
 				if (attempts == 0)
-					to_chat(user, "<span class='danger'>The crate's anti-tamper system activates!</span>")
-					var/turf/T = get_turf(src.loc)
-					explosion(T, 0, 0, 0, 1)
-					for(var/item in contents)
-						qdel(item)
-					qdel(src)
+					antitamper()
 					return
 		else
 			to_chat(user, "<span class='notice'>You attempt to interact with the device using a hand gesture, but it appears this crate is from before the DECANECT came out.</span>")
@@ -60,7 +55,24 @@
 				to_chat(user, "<span class='notice'>* Last access attempt lower than expected code.</span>")
 			else
 				to_chat(user, "<span class='notice'>* Last access attempt higher than expected code.</span>")
+		else if ( istype(W, /obj/item/weapon/card/emag) && locked &&!broken)
+			antitamper()
+			return
 		else
 			..()
 	else
 		..()
+
+/obj/structure/closet/crate/secure/loot/emp_act(severity)
+	antitamper()
+
+/obj/structure/closet/crate/secure/loot/ex_act(severity)
+	antitamper()
+
+/obj/structure/closet/crate/secure/loot/proc/antitamper()
+	to_chat(user, "<span class='danger'>The crate's anti-tamper system activates!</span>")
+	var/turf/T = get_turf(src.loc)
+	explosion(T, 0, 0, 0, 1)
+	for(var/item in contents)
+		qdel(item)
+	qdel(src)

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -1,5 +1,3 @@
-var/global/list/valid_abandoned_crate_types = typesof(/obj/structure/closet/crate/secure/loot)-/obj/structure/closet/crate/secure/loot
-
 /obj/structure/closet/crate/secure/loot
 	name = "abandoned crate"
 	desc = "What could be inside?"

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -81,7 +81,7 @@
 		antitamper()
 
 /obj/structure/closet/crate/secure/loot/proc/antitamper()
-	to_chat(user, "<span class='danger'>The crate's anti-tamper system activates!</span>")
+	visible_message("<span class='danger'>The crate's anti-tamper system activates!</span>")
 	var/turf/T = get_turf(src.loc)
 	explosion(T, 0, 0, 0, 1)
 	for(var/item in contents)

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -31,7 +31,12 @@
 				lastattempt = input
 				attempts--
 				if (attempts == 0)
-					antitamper()
+					visible_message("<span class='danger'>The crate's anti-tamper system activates!</span>")
+					var/turf/T = get_turf(src.loc)
+					explosion(T, 0, 0, 0, 1)
+					for(var/item in contents)
+						qdel(item)
+					qdel(src)
 					return
 		else
 			to_chat(user, "<span class='notice'>You attempt to interact with the device using a hand gesture, but it appears this crate is from before the DECANECT came out.</span>")
@@ -55,43 +60,7 @@
 				to_chat(user, "<span class='notice'>* Last access attempt lower than expected code.</span>")
 			else
 				to_chat(user, "<span class='notice'>* Last access attempt higher than expected code.</span>")
-		else if ( istype(W, /obj/item/weapon/card/emag) && locked &&!broken)
-			antitamper()
-			return
 		else
 			..()
 	else
 		..()
-
-/obj/structure/closet/crate/secure/loot/emp_act(severity)
-	antitamper()
-
-/obj/structure/closet/crate/secure/loot/ex_act(severity)
-	switch(severity)
-		if(1)
-			antitamper()
-		if(2)
-			if(prob(50))
-				antitamper()
-		if(3)
-			if(prob(5))
-				antitamper()
-
-/obj/structure/closet/crate/secure/loot/bullet_act(var/obj/item/projectile/Proj)
-	if(Proj.damage)
-		antitamper()
-
-/obj/structure/closet/crate/secure/loot/process()
-	for(var/obj/effect/beam/B in beams)
-		health -= B.get_damage()
-
-	if(health <= 0)
-		antitamper()
-
-/obj/structure/closet/crate/secure/loot/proc/antitamper()
-	visible_message("<span class='danger'>The crate's anti-tamper system activates!</span>")
-	var/turf/T = get_turf(src.loc)
-	explosion(T, 0, 0, 0, 1)
-	for(var/item in contents)
-		qdel(item)
-	qdel(src)

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -71,7 +71,7 @@
 
 /obj/structure/closet/crate/secure/loot/bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.damage)
-	antitamper()
+		antitamper()
 
 /obj/structure/closet/crate/secure/loot/process()
 	for(var/obj/effect/beam/B in beams)

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -69,6 +69,13 @@
 /obj/structure/closet/crate/secure/loot/ex_act(severity)
 	antitamper()
 
+/obj/structure/closet/crate/secure/loot/process()
+	for(var/obj/effect/beam/B in beams)
+		health -= B.get_damage()
+
+	if(health <= 0)
+		antitamper()
+
 /obj/structure/closet/crate/secure/loot/proc/antitamper()
 	to_chat(user, "<span class='danger'>The crate's anti-tamper system activates!</span>")
 	var/turf/T = get_turf(src.loc)

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -48,7 +48,7 @@
 			else
 				to_chat(user, "<span class='notice'>* Anti-Tamper Bomb will activate after [src.attempts] failed access attempts.</span>")
 			if (lastattempt == null)
-				to_chat(user, "<span class='notice'> has been made to open the crate thus far.</span>")
+				to_chat(user, "<span class='notice'>* No attempt has been made to open the crate thus far.</span>")
 				return
 			// hot and cold
 			if (code > lastattempt)

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -69,7 +69,8 @@
 /obj/structure/closet/crate/secure/loot/ex_act(severity)
 	antitamper()
 
-/obj/structure/closet/crate/secure/loot/bullet_act(severity)
+/obj/structure/closet/crate/secure/loot/bullet_act(var/obj/item/projectile/Proj)
+	if(Proj.damage)
 	antitamper()
 
 /obj/structure/closet/crate/secure/loot/process()

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -69,6 +69,9 @@
 /obj/structure/closet/crate/secure/loot/ex_act(severity)
 	antitamper()
 
+/obj/structure/closet/crate/secure/loot/bullet_act(severity)
+	antitamper()
+
 /obj/structure/closet/crate/secure/loot/process()
 	for(var/obj/effect/beam/B in beams)
 		health -= B.get_damage()

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -67,7 +67,15 @@
 	antitamper()
 
 /obj/structure/closet/crate/secure/loot/ex_act(severity)
-	antitamper()
+	switch(severity)
+		if(1)
+			antitamper()
+		if(2)
+			if(prob(50))
+				antitamper()
+		if(3)
+			if(prob(5))
+				antitamper()
 
 /obj/structure/closet/crate/secure/loot/bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.damage)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -522,7 +522,11 @@ var/list/icon_state_to_appearance = list()
 	ChangeTurf(mined_type)
 
 /turf/unsimulated/mineral/proc/DropAbandonedCrate()
-	var/crate_type = pick(valid_abandoned_crate_types)
+	var/list/crate_types = list()
+	for(var/type in subtypesof(/obj/structure/closet/crate/secure/loot))
+		var/obj/structure/closet/crate/secure/loot/L = type
+		crate_types[type] = initial(L.attempts)
+	var/crate_type = pickweight(crate_types)
 	new crate_type(src)
 
 /turf/unsimulated/mineral/proc/GetScanState()


### PR DESCRIPTION
## What this does
adds the following loot crates to the distribution:

 * plasma beaker
 * tier 2 stock parts, any 3 to 9
 * 3 lazarus injectors
 * borg upgrades (picks between the hookshot and autosmelter)
 * assemblies for medbots, cleanbots, cheapsky, floorbots or mining drones. parts for secbots and britsky can be found in these too, but without the batons needed to complete them.
 * borer egg

the following are locked behind crates that spawn with only 2 access attempts:

 * automatic ore loader
 * diamond mining drill
 * a hivelord OR basilisk hide
 * rig suit upgrades (any 2 to 3)
 * tier 3 stock parts, any 3 to 9
 * 3 advanced lazarus injectors
 * 3 random seeds from gold apples, silver pears, diamond carrots, plasma cabbages, glowberries, telriis or vale. also has a 10% chance to spawn a no fruit seed.

the following are locked behind crates that spawn with 1 attempt:

 * plasma cutter conversion kit
 * two hides either hivelord or basilisk
 * 3 hivelord cores

the distribution of these crates has also been weighted to prefer higher attempt (and low difficulty) crates in frequency

## Why it's good
the list of items in these are really barren, plain and not rewarding enough. PLEASE let me know if i didn't increase crate access difficulty in a fair or good way.

## Changelog
:cl:
 * rscadd: The selection of items founded in mine loot crates is now vastly greater, although some more valuable crates have less access attempts now.