### PR TITLE
Makes ANFO explode at the right power

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -628,6 +628,7 @@
 	id = ANFOBOMB
 	required_reagents = list(AMMONIUMNITRATE = 16, FUEL = 1)  // rough approximation of the 94%-6% mix
 	required_temp = AUTOIGNITION_WELDERFUEL-1 // just for priority and to stop recipe conflicts
+	result_amount = 17
 	fire_temp = AUTOIGNITION_WELDERFUEL
 	power = 1
 


### PR DESCRIPTION
[bugfix]

## What this does
Closes #34257.
turns out they were making a very underwhelming result amount, treated like below 100 units even at stuff like 170


## Changelog
:cl:
 * bugfix: ANFO now explodes as much as it's supposed to.