### PR TITLE
Convert to Faction nerfs and fixes

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -301,6 +301,8 @@
 
 #define isapprentice(H) (H.mind && H.mind.GetRole(WIZAPP))
 
+#define iswizconvert(H) (H.mind && H.mind.GetRole(WIZARD_CONVERT))
+
 #define isbadmonkey(H) ((/datum/disease/jungle_fever in H.viruses) || (H.mind && H.mind.GetRole(MADMONKEY)))
 
 #define isdeathsquad(H) (H.mind && H.mind.GetRole(DEATHSQUADIE))

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -83,7 +83,11 @@
 			bought_nothing = FALSE
 			. += "<BR>The wizard knew:<BR>"
 			for(var/spell/S in H.spell_list)
-				var/icon/tempimage = icon('icons/mob/screen_spells.dmi', S.hud_state)
+				var/icon/tempimage
+				if(S.override_icon && S.override_icon != S.icon)
+					tempimage = icon(S.override_icon, S.hud_state)
+				else
+					tempimage = icon('icons/mob/screen_spells.dmi', S.hud_state)
 				. += "<img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [S.name]<BR>"
 		if(artifacts_bought || potions_bought)
 			bought_nothing = FALSE

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -84,7 +84,7 @@
 			. += "<BR>The wizard knew:<BR>"
 			for(var/spell/S in H.spell_list)
 				var/icon/tempimage
-				if(S.override_icon && S.override_icon != S.icon)
+				if(S.override_icon != "")
 					tempimage = icon(S.override_icon, S.hud_state)
 				else
 					tempimage = icon('icons/mob/screen_spells.dmi', S.hud_state)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2452,7 +2452,8 @@
 				H.update_inv_by_slot(C.slot_flags)
 
 		M.clean_blood()
-		M.color = ""
+		if(!iswizconvert(M))
+			M.color = ""
 
 /datum/reagent/space_cleaner/bleach
 	name = "Bleach"
@@ -2497,7 +2498,8 @@
 					H.drip(10)
 				else if(prob(5))
 					H.vomit()
-	M.color = ""
+	if(!iswizconvert(M))
+		M.color = ""
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.species.anatomy_flags & MULTICOLOR && !(initial(H.species.anatomy_flags) & MULTICOLOR))
@@ -2510,7 +2512,8 @@
 	if(..())
 		return 1
 
-	M.color = ""
+	if(!iswizconvert(M))
+		M.color = ""
 
 	if(method == TOUCH && ((TARGET_EYES in zone_sels) || (LIMB_HEAD in zone_sels)))
 		if(ishuman(M))
@@ -5498,7 +5501,7 @@ var/procizine_tolerance = 0
 	nutriment_factor = 20 * REAGENTS_METABOLISM
 	color = "#302000" //rgb: 48, 32, 0
 	density = 0.9185
-	specheatcap = 2.402	
+	specheatcap = 2.402
 	var/has_had_heart_explode = 0
 
 /datum/reagent/cornoil/on_mob_life(var/mob/living/M)
@@ -9113,7 +9116,8 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 /datum/reagent/fishbleach/on_mob_life(var/mob/living/carbon/human/H)
 	if(..())
 		return 1
-	H.color = "#12A7C9"
+	if(!iswizconvert(M))
+		H.color = "#12A7C9"
 	return
 
 /datum/reagent/roach_shell
@@ -9615,12 +9619,12 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 
 
 /datum/reagent/colorful_reagent/on_mob_life(mob/living/M)
-	if(M && isliving(M))
+	if(M && isliving(M) && !iswizconvert(M))
 		M.color = pick(random_color_list)
 	..()
 
 /datum/reagent/colorful_reagent/reaction_mob(mob/living/M, reac_volume)
-	if(M && isliving(M))
+	if(M && isliving(M) && !iswizconvert(M))
 		M.color = pick(random_color_list)
 	..()
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -9116,7 +9116,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 /datum/reagent/fishbleach/on_mob_life(var/mob/living/carbon/human/H)
 	if(..())
 		return 1
-	if(!iswizconvert(M))
+	if(!iswizconvert(H))
 		H.color = "#12A7C9"
 	return
 

--- a/code/modules/spells/targeted/convert_faction.dm
+++ b/code/modules/spells/targeted/convert_faction.dm
@@ -54,7 +54,7 @@
 /spell/targeted/civilwarconvert/on_added(mob/user)
 	var/datum/faction/wizard/civilwar/ourfact = find_active_faction_by_typeandmember(/datum/faction/wizard/civilwar, null, user.mind)
 	if(ourfact)
-		var/datum/faction/enemyfaction = ourfact.enemy_faction
+		var/datum/faction/enemyfaction = find_active_faction_by_type(ourfact.enemy_faction)
 		if(enemyfaction)
 			for(var/datum/role/wizard/W in enemyfaction.members)
 				if(W.antag?.current && !(locate(src.type) in W.antag.current.spell_list))

--- a/code/modules/spells/targeted/convert_faction.dm
+++ b/code/modules/spells/targeted/convert_faction.dm
@@ -50,3 +50,9 @@
 			WC.Greet()
 			WC.OnPostSetup()
 			WC.AnnounceObjectives()
+
+/spell/targeted/civilwarconvert/on_added(mob/user)
+	var/datum/faction/ourfact = find_active_faction_by_typeandmember(/datum/faction/wizard/civilwar, null, user.mind)
+	var/datum/faction/enemyfaction = ourfact.enemy_faction
+	for(var/datum/role/wizard/W in enemyfaction)
+		alert(W.antag.current, "A memeber of [ourfact] has just purchased the Conversion spell! They will be able to send converted crew members to attack your team!", "Civil War Converter","Understood")

--- a/code/modules/spells/targeted/convert_faction.dm
+++ b/code/modules/spells/targeted/convert_faction.dm
@@ -57,7 +57,7 @@
 		var/datum/faction/enemyfaction = ourfact.enemy_faction
 		if(enemyfaction)
 			for(var/datum/role/wizard/W in enemyfaction)
-				if(W.antag?.current && (locate(src.type) in W.antag.current.spell_list))
+				if(W.antag?.current && !(locate(src.type) in W.antag.current.spell_list))
 					var/obj/item/weapon/spellbook/S = locate() in get_contents_in_object(W.antag.current)
 					if(S && S.uses >= price && (src.type in S.all_spells))
 						var/confirm = alert(W.antag.current, "A member of [ourfact] has just purchased the Conversion spell! They will be able to send converted crew members to attack your team! Do you wish to purchase it yourself to counter this?", "Civil War Converter","Purchase","Do not") == "Purchase"

--- a/code/modules/spells/targeted/convert_faction.dm
+++ b/code/modules/spells/targeted/convert_faction.dm
@@ -10,7 +10,6 @@
 	invocation = "WOLOLO!"
 	invocation_type = SpI_SHOUT
 	range = 1
-	max_targets = 1
 	spell_flags = WAIT_FOR_CLICK
 	cooldown_min = 10
 	civil_war_only = TRUE

--- a/code/modules/spells/targeted/convert_faction.dm
+++ b/code/modules/spells/targeted/convert_faction.dm
@@ -6,14 +6,13 @@
 	specialization = SSUTILITY
 	price = 40
 	school = "evocation"
-	charge_type = Sp_RECHARGE
 	charge_max = 150
 	invocation = "WOLOLO!"
 	invocation_type = SpI_SHOUT
 	range = 1
 	max_targets = 1
 	spell_flags = WAIT_FOR_CLICK
-	cooldown_min = 20
+	cooldown_min = 10
 	selection_type = "view"
 	civil_war_only = TRUE
 	compatible_mobs = list(/mob/living/carbon/human)

--- a/code/modules/spells/targeted/convert_faction.dm
+++ b/code/modules/spells/targeted/convert_faction.dm
@@ -1,5 +1,5 @@
 /spell/targeted/civilwarconvert
-	name = "Convert to Faction"
+	name = "Conversion"
 	desc = "This spell allows you to convert someone to your side of the civil war."
 	abbreviation = "CF"
 	user_type = USER_TYPE_WIZARD

--- a/code/modules/spells/targeted/convert_faction.dm
+++ b/code/modules/spells/targeted/convert_faction.dm
@@ -52,11 +52,11 @@
 			WC.AnnounceObjectives()
 
 /spell/targeted/civilwarconvert/on_added(mob/user)
-	var/datum/faction/ourfact = find_active_faction_by_typeandmember(/datum/faction/wizard/civilwar, null, user.mind)
+	var/datum/faction/wizard/civilwar/ourfact = find_active_faction_by_typeandmember(/datum/faction/wizard/civilwar, null, user.mind)
 	if(ourfact)
 		var/datum/faction/enemyfaction = ourfact.enemy_faction
 		if(enemyfaction)
-			for(var/datum/role/wizard/W in enemyfaction)
+			for(var/datum/role/wizard/W in enemyfaction.members)
 				if(W.antag?.current && !(locate(src.type) in W.antag.current.spell_list))
 					var/obj/item/weapon/spellbook/S = locate() in get_contents_in_object(W.antag.current)
 					if(S && S.uses >= price && (src.type in S.all_spells))

--- a/code/modules/spells/targeted/convert_faction.dm
+++ b/code/modules/spells/targeted/convert_faction.dm
@@ -13,7 +13,6 @@
 	max_targets = 1
 	spell_flags = WAIT_FOR_CLICK
 	cooldown_min = 10
-	selection_type = "view"
 	civil_war_only = TRUE
 	compatible_mobs = list(/mob/living/carbon/human)
 	cast_sound = 'sound/effects/aoe2/30 wololo.ogg'

--- a/code/modules/spells/targeted/convert_faction.dm
+++ b/code/modules/spells/targeted/convert_faction.dm
@@ -10,25 +10,17 @@
 	charge_max = 150
 	invocation = "WOLOLO!"
 	invocation_type = SpI_SHOUT
-	range = 7
+	range = 1
 	max_targets = 1
 	spell_flags = WAIT_FOR_CLICK
-	cooldown_min = 10
-	selection_type = "range"
+	cooldown_min = 20
+	selection_type = "view"
 	civil_war_only = TRUE
 	compatible_mobs = list(/mob/living/carbon/human)
 	cast_sound = 'sound/effects/aoe2/30 wololo.ogg'
 	hud_state = "apprentice-logo"
 	override_icon = 'icons/logos.dmi'
-	level_max = list(Sp_TOTAL = 5, Sp_SPEED = 4, Sp_POWER = 1)
-	var/bypass_implant = FALSE
-
-/spell/targeted/civilwarconvert/empower_spell()
-	spell_levels[Sp_POWER]++
-	if(spell_levels[Sp_POWER] >= 1)
-		bypass_implant = TRUE
-		name = "Implant-Agnostic Convert to Faction"
-		return "You have improved Convert to Faction into [name]. It will now bypass loyalty implants."
+	level_max = list(Sp_TOTAL = 3, Sp_SPEED = 3, Sp_POWER = 3)
 
 /spell/targeted/civilwarconvert/cast_check(skipcharge = 0,mob/user = usr)
 	return ..() && find_active_faction_by_typeandmember(/datum/faction/wizard/civilwar, null, user.mind)
@@ -38,10 +30,9 @@
 		var/mob/living/carbon/human/H = target
 		if(!istype(H))
 			return FALSE
-		if(!bypass_implant)
-			for(var/obj/item/weapon/implant/loyalty/L in H) // check loyalty implant in the contents
-				if(L.imp_in == H) // a check if it's actually implanted
-					return FALSE
+		for(var/obj/item/weapon/implant/loyalty/L in H) // check loyalty implant in the contents
+			if(L.imp_in == H) // a check if it's actually implanted
+				return FALSE
 		var/datum/faction/ourfact = find_active_faction_by_typeandmember(/datum/faction/wizard/civilwar, null, user.mind)
 		var/datum/faction/theirfact = find_active_faction_by_typeandmember(/datum/faction/wizard/civilwar, null, H.mind)
 		return !iswizard(H) && H.mind && ourfact != theirfact


### PR DESCRIPTION
[balance]

## What this does
removes the implant bypass upgrade and limits the range to 1, putting it in line with rev and thrall limits
the spell is renamed "conversion"
no color change
alerts other team you bought it and gives a quick option to do it themselves if possible
scoreboard icon fix

## Why it's good
suggested balance changes from #34265

## Changelog
:cl:
 * tweak: Convert to Faction is now known as Conversion.
 * tweak: Conversion spell for civil war wizards is no longer ranged, and cannot bypass loyalty implants.
 * tweak: Mobs converted by wizards can no longer have their color washed away or changed.
 * tweak: Purchasing Conversion now alerts the opposing civil war team of this and gives them a quick option to do it themselves.
 * bugfix: Wizard spells with icon overrides show up properly in the scoreboard.