### PR TITLE
fix energy shotguns firing one projectile

### DIFF
--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -270,6 +270,8 @@
 			P.starting = starting
 			P.shot_from = shot_from
 			P.current = current
+			P.target = target
+			P.original = original
 			var/turf/T = get_step(proj_target, pick_n_take(vdirs))
 			P.OnFired(T)
 			P.process()


### PR DESCRIPTION
## What this does
Fixes unintended consequence of #34250 
Fixes #34273

If there's any other scatter projectiles in the game, they're probably broken too so let me know.
I tested shotgun buckshot, bulletstorm gun, etc. and they work fine.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed energy shotgun's SWEEPER mode only firing one projectile.