### PR TITLE
Reagent heating fixes

### DIFF
--- a/__DEFINES/materials.dm
+++ b/__DEFINES/materials.dm
@@ -80,3 +80,5 @@
 #define CC_PER_SHEET_MOLITZ      CC_PER_SHEET_METAL
 #define CC_PER_SHEET_GINGERBREAD CC_PER_SHEET_METAL
 
+#define CC_PER_U 10 //How many cc per 1 u of reagent in eg. a glass of water or a human's bloodstream.
+

--- a/__DEFINES/materials.dm
+++ b/__DEFINES/materials.dm
@@ -81,4 +81,3 @@
 #define CC_PER_SHEET_GINGERBREAD CC_PER_SHEET_METAL
 
 #define CC_PER_U 10 //How many cc per 1 u of reagent in eg. a glass of water or a human's bloodstream.
-

--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -522,7 +522,7 @@
 #define TEMPERATURE_WELDER 3480
 #define TEMPERATURE_PLASMA 4500
 #define TEMPERATURE_ETHANOL (T0C+1560)
-#define HEAT_TRANSFER_MULTIPLIER 7 //Multiplies the numbers above when heating a reagent container. A truly magical number.
+#define HEAT_TRANSFER_MULTIPLIER 7 //Multiplies the numbers above when heating a reagent container. A truly magical number. Not currently used anywhere due to a bug with reagent heating being fixed.
 
 // By defining the effect multiplier this way, it'll exactly adjust
 // all effects according to how they originally were with the 0.4 metabolism

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -630,7 +630,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 		if (R.id == reagent)
 
 			//Equalize temperatures
-			chem_temp = get_equalized_temperature(chem_temp, get_thermal_mass(), reagtemp, amount * R.density * R.specheatcap)		
+			chem_temp = get_equalized_temperature(chem_temp, get_thermal_mass(), reagtemp, amount * R.density * R.specheatcap * CC_PER_U)
 
 			R.volume += amount
 			update_total()
@@ -656,7 +656,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 		var/datum/reagent/R = new D.type()
 
 		//Equalize temperatures
-		chem_temp = get_equalized_temperature(chem_temp, get_thermal_mass(), reagtemp, amount * R.density * R.specheatcap)
+		chem_temp = get_equalized_temperature(chem_temp, get_thermal_mass(), reagtemp, amount * R.density * R.specheatcap * CC_PER_U)
 
 		reagent_list += R
 		R.holder = src
@@ -918,18 +918,18 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 /datum/reagents/proc/is_full()
 	return total_volume >= maximum_volume
 
-/datum/reagents/proc/get_overall_mass()
+/datum/reagents/proc/get_overall_mass() //currently unused
 	//M = DV
 	var/overall_mass = 0
 	for(var/datum/reagent/R in reagent_list)
-		overall_mass += R.density*R.volume
+		overall_mass += R.density * R.volume * CC_PER_U
 	return overall_mass
 
 /datum/reagents/proc/get_thermal_mass()
 	var/total_thermal_mass = 0
 	for(var/datum/reagent/R in reagent_list)
 		total_thermal_mass += R.volume * R.density * R.specheatcap
-	return total_thermal_mass * 10 //multiply by 10 because 1 u = 10 mL
+	return total_thermal_mass * CC_PER_U
 
 /datum/reagents/proc/heating(var/power_transfer, var/received_temperature)
 	/*
@@ -942,7 +942,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	if(received_temperature == chem_temp || !total_volume || !reagent_list.len)
 		return
 	var/energy = power_transfer
-	var/temp_change = (energy / (get_thermal_mass())) * HEAT_TRANSFER_MULTIPLIER
+	var/temp_change = (energy / (get_thermal_mass()))
 	if(power_transfer > 0)
 		chem_temp = min(chem_temp + temp_change, received_temperature)
 	else

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -922,8 +922,8 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	//M = DV
 	var/overall_mass = 0
 	for(var/datum/reagent/R in reagent_list)
-		overall_mass += R.density * R.volume * CC_PER_U
-	return overall_mass
+		overall_mass += R.density * R.volume
+	return overall_mass * CC_PER_U
 
 /datum/reagents/proc/get_thermal_mass()
 	var/total_thermal_mass = 0


### PR DESCRIPTION
Currently when reagents are mixed, the impact of each reagent on the resulting mixture's temperature is weighted only by the volume of each reagent, not taking into account the specific heat capacities of the reagents. This fixes this so that reagents with higher specific heat capacities will have a larger impact on the resulting mixture's temperature. This is taken from #33891, but I think this is more atomic to have it separate here.
Also, this fixes an issue where volume was factored into reagent heating twice, making the amount of energy required to heat a reagent by 1 degree scale with the square of its volume, instead of linearly.

:cl:
* bugfix: When reagents are mixed, temperature equalization now takes into account specific heat capacity.
* bugfix: The energy required to heat a reagent now scales linearly with its volume.