### PR TITLE
Cookies and Donuts can now be dipped in liquids

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1409,7 +1409,8 @@ var/proccalls = 1
 #define FOOD_SWEET	4
 #define FOOD_LIQUID	8
 #define FOOD_SKELETON_FRIENDLY 16 //Can be eaten by skeletons
-#define FOOD_LACTOSE 32 //Contains MILK
+#define FOOD_LACTOSE	32 //Contains MILK
+#define FOOD_DIPPABLE	64 //Can be dipped in non-empty open reagent containers
 
 #define UTENSILE_FORK	1
 #define UTENSILE_SPOON	2

--- a/code/game/objects/items/devices/PDA/cart/medical.dm
+++ b/code/game/objects/items/devices/PDA/cart/medical.dm
@@ -86,7 +86,7 @@
 /datum/pda_app/cart/scanner/medical/attack(mob/living/carbon/C, mob/living/user as mob)
     if(istype(C))
         healthanalyze(C,user,1)
-            
+
 /datum/pda_app/cart/medbot
 	name = "Medical Bot Access"
 	desc = "Used to control a medbot."
@@ -129,12 +129,22 @@
 	if(!A.Adjacent(user))
 		return
 	if(!isnull(A.reagents))
+		var/found = 0
 		if(A.reagents.reagent_list.len > 0)
+			found = 1
 			var/reagents_length = A.reagents.reagent_list.len
 			to_chat(user, "<span class='notice'>[reagents_length] chemical agent[reagents_length > 1 ? "s" : ""] found.</span>")
 			for (var/datum/reagent/re in A.reagents.reagent_list)
 				to_chat(user, "<span class='notice'>\t [re]: [re.volume] units</span>")
-		else
+		if (istype (A, /obj/item/weapon/reagent_containers/food/snacks))
+			var/obj/item/weapon/reagent_containers/food/snacks/S = A
+			if(S.dip && S.dip.reagent_list.len > 0)
+				found = 1
+				var/reagents_length = S.dip.reagent_list.len
+				to_chat(user, "<span class='notice'>[reagents_length] additional chemical agent[reagents_length > 1 ? "s" : ""] found in trace amounts.</span>")
+				for (var/datum/reagent/re in S.dip.reagent_list)
+					to_chat(user, "<span class='notice'>\t [re]: [re.volume] units</span>")
+		if (!found)
 			to_chat(user, "<span class='notice'>No active chemical agents found in [A].</span>")
 	else
 		to_chat(user, "<span class='notice'>No significant chemical agents found in [A].</span>")

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -533,6 +533,11 @@ Subject's pulse: ??? BPM"})
 			for(var/datum/reagent/R in O.reagents.reagent_list)
 				var/reagent_percent = (R.volume/O.reagents.total_volume)*100
 				dat += "<br><span class='notice'>[R][details ? " ([R.volume] units, [reagent_percent]%, time in system: [R.real_tick*2] seconds" : ""]</span>"
+		if (istype (O, /obj/item/weapon/reagent_containers/food/snacks))
+			var/obj/item/weapon/reagent_containers/food/snacks/S = O
+			if(S.dip && S.dip.reagent_list.len > 0)
+				for (var/datum/reagent/R in S.dip.reagent_list)
+					dat += "<br><span class='notice'>[R][details ? " (trace amounts, time in system: [R.real_tick*2] seconds" : ""]</span>"
 		if(dat)
 			to_chat(user, "<span class='notice'>Chemicals found in \the [O]:[dat]</span>")
 		else

--- a/code/modules/reagents/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/machinery/reagentgrinder.dm
@@ -537,6 +537,10 @@ var/global/list/juice_items = list (
 			break
 		var/amount = O.reagents.total_volume
 		O.reagents.trans_to(beaker, amount)
+		if (istype (O, /obj/item/weapon/reagent_containers/food/snacks))
+			var/obj/item/weapon/reagent_containers/food/snacks/S = O
+			if (S.dip && S.dip.total_volume)
+				S.dip.trans_to(beaker, S.dip.total_volume)
 		if(!O.reagents.total_volume)
 			remove_object(O)
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -410,6 +410,8 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/examine(mob/user)
 	..()
+	if (dip && dip.total_volume)
+		to_chat(user, "<span class='info'>\The [src] appears to have been dipped in [dip.get_master_reagent_name()].</span>")
 	if (bitecount)
 		if(bitecount == 1)
 			to_chat(user, "<span class='info'>\The [src] was bitten by someone!</span>")

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -14,6 +14,7 @@
 					//FOOD_ANIMAL	- stuff that is made from (or contains) animal products other than meat (eggs, honey, ...). Anything that vegans won't eat!
 					//FOOD_SWEET	- sweet stuff like chocolate and candy
 					//FOOD_LACTOSE  - contains milk
+					//FOOD_DIPPABLE - can be dipped once per bite in an open reagent container, adding 1u of its content to the next bite
 
 					//Example: food_flags = FOOD_SWEET | FOOD_ANIMAL
 					//Unfortunately, food created by cooking doesn't inherit food_flags!
@@ -43,6 +44,7 @@
 	volume = 100 //Double amount snacks can carry, so that food prepared from excellent items can contain all the nutriments it deserves
 
 	var/timer = 0 //currently only used on skittering food
+	var/datum/reagents/dip
 
 /obj/item/weapon/reagent_containers/food/snacks/Destroy()
 	var/turf/T = get_turf(src)
@@ -184,6 +186,8 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/New()
 	..()
+	dip = new/datum/reagents(1)
+	dip.my_atom = src
 	if (random_filling_colors?.len > 0)
 		filling_color = pick(random_filling_colors)
 
@@ -282,6 +286,8 @@
 			"<span class='notice'>You unwillingly [eatverb] some of \the [src].</span>")
 
 	var/datum/reagents/reagentreference = reagents //Even when the object is qdeleted, the reagents exist until this ref gets removed
+	var/datum/reagents/dipreference = dip
+
 	if(reagentreference)	//Handle ingestion of any reagents (Note : Foods always have reagents)
 		if(sounds)
 			playsound(eater, 'sound/items/eatfood.ogg', rand(10,50), 1)
@@ -321,6 +327,9 @@
 			for (var/ID in virus2)
 				var/datum/disease2/disease/D = virus2[ID]
 				eater.infect_disease2(D, 1, notes="(Ate an infected [src])")//eating infected food means 100% chance of infection.
+		if (dipreference && dipreference.total_volume)
+			dipreference.reaction(eater, INGEST, amount_override = 1)
+			dipreference.trans_to(eater, 1)
 		if(reagentreference.total_volume)
 			reagentreference.reaction(eater, INGEST, amount_override = min(reagentreference.total_volume,bitesize*bitesizemod)/(reagentreference.reagent_list.len))
 			spawn() //WHY IS THIS SPAWN() HERE
@@ -510,6 +519,20 @@
 		add_fingerprint(user)
 		contents += W
 		return 1 //No afterattack here
+
+/obj/item/weapon/reagent_containers/food/snacks/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	..()
+	if (food_flags & FOOD_DIPPABLE)
+		if (target.is_open_container() && user.Adjacent(target))
+			var/obj/item/weapon/reagent_containers/container = target
+			if (dip && dip.total_volume)
+				to_chat(user, "<span class='warning'>\The [src] is already dipped in [dip.get_master_reagent_name()]. Take a bite before you can dip it further.</span>")
+				return
+			if (container.is_empty())
+				to_chat(user, "<span class='warning'>\The [container] is empty.</span>")
+				return
+			container.reagents.trans_to(dip, 1)
+			to_chat(user, "<span class='notice'>You dip \the [src] in [dip.get_master_reagent_name()] from \the [container].</span>")
 
 //For slipping solid junk inside food items, like hiding a PDA inside a loaf of bread or something.
 /obj/item/weapon/reagent_containers/food/snacks/proc/can_hold(obj/item/weapon/W)
@@ -717,6 +740,7 @@
 	desc = "COOKIE!!!"
 	icon_state = "COOKIE!!!"
 	base_crumb_chance = 20
+	food_flags = FOOD_DIPPABLE
 
 /obj/item/weapon/reagent_containers/food/snacks/cookie/New()
 	..()
@@ -877,7 +901,7 @@
 	name = "donut"
 	desc = "Goes great with Robust Coffee."
 	icon_state = "donut1"
-	food_flags = FOOD_SWEET | FOOD_ANIMAL //eggs are used
+	food_flags = FOOD_SWEET | FOOD_ANIMAL | FOOD_DIPPABLE //eggs are used
 	var/soggy = 0
 	base_crumb_chance = 30
 
@@ -4310,7 +4334,7 @@
 	name = "sugar cookie"
 	desc = "Just like your little sister used to make."
 	icon_state = "sugarcookie"
-	food_flags = FOOD_SWEET
+	food_flags = FOOD_SWEET | FOOD_DIPPABLE
 
 /obj/item/weapon/reagent_containers/food/snacks/sugarcookie/New()
 	..()
@@ -4322,7 +4346,7 @@
 	name = "caramel cookie"
 	desc = "Just like your little sister used to make."
 	icon_state = "caramelcookie"
-	food_flags = FOOD_SWEET
+	food_flags = FOOD_SWEET | FOOD_DIPPABLE
 
 /obj/item/weapon/reagent_containers/food/snacks/caramelcookie/New()
 	..()
@@ -7287,6 +7311,7 @@ var/global/list/bomb_like_items = list(/obj/item/device/transfer_valve, /obj/ite
 	name = "cookie"
 	desc = "Oh god, it's self-replicating!"
 	icon = 'icons/obj/food2.dmi'
+	food_flags = FOOD_DIPPABLE
 
 /obj/item/weapon/reagent_containers/food/snacks/PAIcookie/New()
 	..()


### PR DESCRIPTION
Quick one hour PR.

If you think other foodstuff than cookies and donuts should be dippable, feel free to make a PR granting those the FOOD_DIPPABLE flag.

![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/945edf63-94bc-45b0-9fe5-5c655574c1d9)
![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/f517aa34-8f25-42f6-ad6d-24705e81fab9)

Fixes #34283

:cl:
* rscadd: You can now dip cookies and donuts in open non-empty reagent containers. Dipping takes 1 unit from the container. The dip covers the snack and doesn't mix with the rest of its reagents until you take a bite. Taking a bite makes you ingest the 1u of dip on top of the reagents from the snack bite itself. You cannot dip an already dipped snack, but since taking a bite makes you ingest the dip, you can take turns dipping and biting.
* rscadd: Examining a snack will tell you if it has been dipped and by which main reagent. Reagent Scanners will give you the detail of all reagents contained in the dip.
* rscadd: Grinding a snack that has been dipped will add the dip to the beaker.