### PR TITLE
Fix *whistle emote for humans by changing the brain emote that overwrites it

### DIFF
--- a/code/modules/mob/living/carbon/brain/emote.dm
+++ b/code/modules/mob/living/carbon/brain/emote.dm
@@ -34,8 +34,8 @@
 	message = "plays a loud tone."
 	emote_type = EMOTE_AUDIBLE
 
-/datum/emote/brain/whistle
-	key = "whistle"
-	key_third_person = "whistles"
-	message = "whistles."
+/datum/emote/brain/whine
+	key = "whine"
+	key_third_person = "whines"
+	message = "whines."
 	emote_type = EMOTE_AUDIBLE


### PR DESCRIPTION
[bugfix]
![grafik](https://github.com/vgstation-coders/vgstation13/assets/132118542/76b76f38-a8f7-4010-8ed0-230db33c030b)

## What this does
Enables humans to use the *whistle emote as defined in /datum/emote/living/carbon/whistle
Removed the *whistle emote from brains as it overwrites the human emote and added *whine, something similar enough

The culprit is /proc/make_datum_references_lists(), where every type of emote is added to a list as such:
- E.emote_list[E.key] = E
since /emote/living/carbon/ and /emote/living/carbon/brain use the same key for whistle, the latter one overwrites the former
Could maybe have rewritten half the code to enable the use of both, but seemed overkill for my first contrib :3

Closes #34219

## Why it's good
Lets you use *whistle as expected

## Changelog
:cl:
 * rscadd: Added *whine emote to brains
 * rscdel: Removed *whistle emote from brains
 * bugfix: *whistle emote now works for living mob types

