### PR TITLE
Print chat message when emote is unusable due to false mob type

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -46,7 +46,7 @@
 	restraint_check = FALSE
 
 /datum/emote/me/run_emote(mob/user, params, m_type)
-
+	. = TRUE
 	if (user.stat)
 		return
 

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -8,10 +8,8 @@
 
 	var/datum/emote/E
 	E = E.emote_list[lowertext(act)]
-	if(!E)
+	if(!E || !E.run_emote(src, param, m_type, ignore_status, arguments))
 		to_chat(src, "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>")
-		return
-	E.run_emote(src, param, m_type, ignore_status, arguments)
 
 /datum/emote/flip
 	key = "flip"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -386,7 +386,6 @@ var/list/animals_with_wings = list(
 		if(message.len > 1)
 			message += ", [emote]"
 		else
-			to_chat(user, "Adding first elem, curr message: [jointext(message, "")]; key 1.: [keys[1]], all keys: [jointext(keys, ",")]")
 			message += "[emote]"
 
 	message += "."

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -333,12 +333,13 @@ var/list/animals_with_wings = list(
 		. = FALSE
 
 /datum/emote/living/custom/run_emote(mob/user, params, type_override = null)
+	. = TRUE
 	if(jobban_isbanned(user, "emote"))
 		to_chat(user, "You cannot send custom emotes (banned).")
-		return FALSE
+		return
 	else if(user.client && user.client.prefs.muted & MUTE_IC)
 		to_chat(user, "You cannot send IC messages (muted).")
-		return FALSE
+		return
 	else if(!params)
 		var/custom_emote = copytext(sanitize(input("Choose an emote to display.") as text|null), 1, MAX_MESSAGE_LEN)
 		if(custom_emote && !check_invalid(user, custom_emote))
@@ -385,6 +386,7 @@ var/list/animals_with_wings = list(
 		if(message.len > 1)
 			message += ", [emote]"
 		else
+			to_chat(user, "Adding first elem, curr message: [jointext(message, "")]; key 1.: [keys[1]], all keys: [jointext(keys, ",")]")
 			message += "[emote]"
 
 	message += "."
@@ -392,3 +394,4 @@ var/list/animals_with_wings = list(
 	message = jointext(message, "")
 
 	to_chat(user, message)
+	return TRUE


### PR DESCRIPTION
[tested][easy]

![grafik](https://github.com/vgstation-coders/vgstation13/assets/132118542/f4884561-266d-4ae8-8490-503f35917a0f)


## What this does
Prints the same text message you get when you try to use an emote that doesn't exist like *fgrweisgjdsfrg for any emotes that don't work because they are not allowed for your mob type

## Why it's good
Instead of getting silence when trying to emote, get an actual output of what went wrong.

## Changelog

:cl:
 * rscadd: Chat message when trying to use emotes that exist but aren't allowed for your mob type