### PR TITLE
Genetic degradation from repeated clonings

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1855,3 +1855,7 @@ var/list/weekend_days = list("Friday", "Saturday", "Sunday")
 //Cooking-related temperatures
 #define COOKTEMP_DEFAULT (T0C + 316) //Default cooking temperature, around 600 F
 #define COOKTEMP_HUMANSAFE (BODYTEMP_HEAT_DAMAGE_LIMIT - 1) //Human-safe temperature for cooked food, 1 degree less than the threshold for burning a human.
+
+//Genetic degredation from repeated clonings
+#define GENDEG_SAFECLONINGS 1 //How many times someone can be cloned before genetic degredation begins to affect their ability to recover from clone damage.
+#define GENDEG_DAMAGE 7 //How much sticky clone damage is accrued per cloning beyond GENDEG_SAFECLONINGS.

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1856,6 +1856,6 @@ var/list/weekend_days = list("Friday", "Saturday", "Sunday")
 #define COOKTEMP_DEFAULT (T0C + 316) //Default cooking temperature, around 600 F
 #define COOKTEMP_HUMANSAFE (BODYTEMP_HEAT_DAMAGE_LIMIT - 1) //Human-safe temperature for cooked food, 1 degree less than the threshold for burning a human.
 
-//Genetic degredation from repeated clonings
-#define GENDEG_SAFECLONINGS 1 //How many times someone can be cloned before genetic degredation begins to affect their ability to recover from clone damage.
+//Genetic degradation from repeated clonings
+#define GENDEG_SAFECLONINGS 1 //How many times someone can be cloned before genetic degradation begins to affect their ability to recover from clone damage.
 #define GENDEG_DAMAGE 7 //How much sticky clone damage is accrued per cloning beyond GENDEG_SAFECLONINGS.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -315,7 +315,7 @@
 			amount = min(amount, 0)
 	cloneloss = min(max(cloneloss + (amount * clone_damage_modifier), 0),(maxHealth*2))
 
-/mob/living/proc/getGeneDegredation() //more persistent clone damage that's harder to heal from due to repeated clonings
+/mob/living/proc/getGeneDegradation() //more persistent clone damage that's harder to heal from due to repeated clonings
 	return max(0, (times_cloned - GENDEG_SAFECLONINGS) * GENDEG_DAMAGE)
 
 /mob/living/proc/setCloneLoss(var/amount)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -313,8 +313,10 @@
 		var/mob/living/carbon/human/H = src
 		if(isslimeperson(H))
 			amount = min(amount, 0)
-
 	cloneloss = min(max(cloneloss + (amount * clone_damage_modifier), 0),(maxHealth*2))
+
+/mob/living/proc/getGeneDegredation() //more persistent clone damage that's harder to heal from due to repeated clonings
+	return max(0, (times_cloned - GENDEG_SAFECLONINGS) * GENDEG_DAMAGE)
 
 /mob/living/proc/setCloneLoss(var/amount)
 	if(status_flags & GODMODE)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3722,7 +3722,7 @@ var/procizine_tolerance = 0
 		if(M.bodytemperature < 50)
 			M.adjustCloneLoss(-1)
 		else
-			var/clone_to_heal = M.getGeneDegredation() - M.getCloneLoss()
+			var/clone_to_heal = M.getGeneDegradation() - M.getCloneLoss()
 			if(clone_to_heal < 0)
 				M.adjustCloneLoss(max(-1, clone_to_heal))
 
@@ -3751,7 +3751,7 @@ var/procizine_tolerance = 0
 		if(M.bodytemperature < 50)
 			M.adjustCloneLoss(-3)
 		else
-			var/clone_to_heal = M.getGeneDegredation() - M.getCloneLoss()
+			var/clone_to_heal = M.getGeneDegradation() - M.getCloneLoss()
 			if(clone_to_heal < 0)
 				M.adjustCloneLoss(max(-3, clone_to_heal))
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3716,10 +3716,15 @@ var/procizine_tolerance = 0
 		return 1
 
 	if(M.bodytemperature < 170)
-		M.adjustCloneLoss(-1)
 		M.adjustOxyLoss(-1)
 		M.heal_organ_damage(1,1)
 		M.adjustToxLoss(-1)
+		if(M.bodytemperature < 50)
+			M.adjustCloneLoss(-1)
+		else
+			var/clone_to_heal = M.getGeneDegredation() - M.getCloneLoss()
+			if(clone_to_heal < 0)
+				M.adjustCloneLoss(max(-1, clone_to_heal))
 
 /datum/reagent/cryoxadone/on_plant_life(obj/machinery/portable_atmospherics/hydroponics/T)
 	..()
@@ -3740,10 +3745,15 @@ var/procizine_tolerance = 0
 		return 1
 
 	if(M.bodytemperature < 170)
-		M.adjustCloneLoss(-3)
 		M.adjustOxyLoss(-3)
 		M.heal_organ_damage(3,3)
 		M.adjustToxLoss(-3)
+		if(M.bodytemperature < 50)
+			M.adjustCloneLoss(-3)
+		else
+			var/clone_to_heal = M.getGeneDegredation() - M.getCloneLoss()
+			if(clone_to_heal < 0)
+				M.adjustCloneLoss(max(-3, clone_to_heal))
 
 /datum/reagent/clonexadone/on_plant_life(obj/machinery/portable_atmospherics/hydroponics/T)
 	..()
@@ -5498,7 +5508,7 @@ var/procizine_tolerance = 0
 	nutriment_factor = 20 * REAGENTS_METABOLISM
 	color = "#302000" //rgb: 48, 32, 0
 	density = 0.9185
-	specheatcap = 2.402	
+	specheatcap = 2.402
 	var/has_had_heart_explode = 0
 
 /datum/reagent/cornoil/on_mob_life(var/mob/living/M)


### PR DESCRIPTION
## What this does
Currently, when someone has been cloned, you can tell what clone number they are by using a penlight on their eyes and counting the dots on their sclera. This makes it so that after a certain number of "safe" clonings (tentatively set to 1), one's genome begins to degrade, making it somewhat harder to completely heal below a certain amount of clone damage (tentatively set to 7 "sticky" clone damage per cloning beyond the safe limit). I'd like to hear what people think about these values.
So, with the tentative values above:

- 0 clonings: can fully heal to 0 clone damage as normal
- 1 cloning: can fully heal to 0 clone damage as normal
- 2 clonings: can heal down to 7 clone damage using standard methods
- 3 clonings: can heal down to 14 clone damage using standard methods
- 4 clonings: 21 "sticky" clone damage
- 5 clonings: 28 "sticky" clone damage
- etc. 

However, there are still numerous ways to heal such genetically degraded clones down to 0 clone damage;
there are four chems that heal clone damage, and I modified (or kept) their function as follows:

- rezadone  (no change): fully heals clone damage regardless of temperature
- medical nanobots (no change): fully heals clone damage regardless of temperature
- cryoxadone*: heals to the degraded limit under normal conditions (body temperature sub 170 degrees K), and heals fully under 50 degrees K 
- clonexadone*: heals to the degraded limit under normal conditions (body temperature sub 170 degrees K), and heals fully under 50 degrees K 

So basically the only methods that are affected by this "soft" limit on clone healing are cryoxadone and clonexadone, and they both can still fully heal clone damage if the person's body temperature is sub 50 degrees K, but not at the operating temperature of a roundstart cryo tube setup.

If people think these values are too severe or too mild, or that maybe this should be added into hardcore mode alongside starvation, please let me know. We could set the limit to 2 "safe" clonings and 5 degradation damage every time beyond that, for example.

## Why it's good
I think this amps up the consequences of death a little bit without it being too intense. Also adds a mild incentive to try to keep people alive via surgery and other means rather than simply cloning them without issue. And finally adds a bit of potential for situations like having the atmos tech install a better cooling system in medbay, or a reason to grow koibeans or hunt carp, and possibly other interesting situations involving achieving low body temperatures in makeshift ways to heal such clone damage. A relatively mild change but hopefully adds a little bit of spice.

## Changelog
:cl:
 * rscadd: Repeated clonings will gradually degrade one's genome, requiring lower temperatures for cryoxadone and clonexadone to fully rejuvenate a degraded clone. Medical nanobots and rezadone function as normal.
