### PR TITLE
Fix cryotube cooling at ultra-low temperatures

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -475,8 +475,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	if(!occupant)
 		return
 	if(!ejecting)
-		occupant.bodytemperature += (air_contents.temperature - occupant.bodytemperature) * (current_heat_capacity + air_contents.heat_capacity()) / current_heat_capacity
-		occupant.bodytemperature = max(occupant.bodytemperature, air_contents.temperature) // this is so ugly i'm sorry for doing it i'll fix it later i promise
+		occupant.bodytemperature += (air_contents.temperature - occupant.bodytemperature) * (1 - current_heat_capacity / (current_heat_capacity + air_contents.heat_capacity()))
 	else
 		occupant.bodytemperature = mix(occupant.bodytemperature, T0C + 37, 0.6)
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -475,7 +475,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 	if(!occupant)
 		return
 	if(!ejecting)
-		occupant.bodytemperature += 20*(air_contents.temperature - occupant.bodytemperature)*current_heat_capacity/(current_heat_capacity + air_contents.heat_capacity())
+		occupant.bodytemperature += (air_contents.temperature - occupant.bodytemperature) * (current_heat_capacity + air_contents.heat_capacity()) / current_heat_capacity
 		occupant.bodytemperature = max(occupant.bodytemperature, air_contents.temperature) // this is so ugly i'm sorry for doing it i'll fix it later i promise
 	else
 		occupant.bodytemperature = mix(occupant.bodytemperature, T0C + 37, 0.6)


### PR DESCRIPTION
## What this does
This fixes an issue where cryotubes cool people at a slower rate at ultra-low temperatures.
This was caused by the body temperature change per tick scaling negatively with the heat capacity of the cryotube gas. At very low temperatures, all of the moles in the tube would cause the the body cooling to slow down significantly. However this doesn't make sense, as the more moles there are, the more thermal mass there is to absorb the body heat. Since we don't currently have notions of thermal conductivity (aside from things like needing gloves to unscrew lit lightbulbs), or thermal mass of mobs, I guess the intent was to have this serve this function, but maybe it was implemented in an inverted way. Or maybe heat capacity was mistaken to mean the amount of heat energy in the gas.
Either way, I changed it so that the higher the heat capacity of the cryotube gas, the more "effective" the cooling is, which seems to make more sense.
See here:
http://ss13.moe/forum/viewtopic.php?f=4&t=6279

## Why it's good
More intuitive cryotube cooling behavior, facilitating ultra-low body temperatures.

## Changelog
:cl:
 * bugfix: Cryotube occupant body cooling no longer slows down significantly at ultra-low temperatures.