### PR TITLE
Fixes players being unable to pick up items created at a Cult Forge

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -1194,7 +1194,7 @@ var/list/cult_spires = list()
 						QDEL_NULL(forging)
 						var/obj/item/I = new template(L)
 						if (istype(I))
-							I.plane = relative_plane(EFFECTS_PLANE)
+							I.plane = EFFECTS_PLANE
 							I.layer = PROJECTILE_LAYER
 							I.pixel_y = 12
 						else


### PR DESCRIPTION
Caused by #33824

Impressed that this went 5 months without being reported.

:cl:
* bugfix: Fixed players being unable to pick up items created at a Cult Forge.