### PR TITLE
Fixed Crowbar, Wrench and Wirecutter macros being broken and leading to weird behaviour

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -148,7 +148,7 @@
 
 #define isEmag(A) istype(A, /obj/item/weapon/card/emag)
 
-#define istool(A) iswrench(A) || iswelder(A) || isshovel(A) || ishammer(A) || iscablecoil(A) || iswiretool(A) || iscrowbar(A)
+#define istool(A) (iswrench(A) || iswelder(A) || isshovel(A) || ishammer(A) || iscablecoil(A) || iswiretool(A) || iscrowbar(A))
 
 #define iswelder(A) istype(A, /obj/item/tool/weldingtool)
 
@@ -162,7 +162,7 @@
 
 #define isfood(A) istype(A, /obj/item/weapon/reagent_containers/food)
 
-#define iswirecutter(A) istype(A, /obj/item/tool/wirecutters) || (istype(A, /obj/item/weapon/switchtool) && istype(A:deployed, /obj/item/tool/wirecutters))
+#define iswirecutter(A) (istype(A, /obj/item/tool/wirecutters) || (istype(A, /obj/item/weapon/switchtool) && istype(A:deployed, /obj/item/tool/wirecutters)))
 
 #define iswiretool(A) (iswirecutter(A) || ismultitool(A) || issignaler(A))
 
@@ -176,11 +176,11 @@
 
 #define ismultitool(A) istype(A, /obj/item/device/multitool)
 
-#define iscrowbar(A) istype(A, /obj/item/tool/crowbar) || (istype(A, /obj/item/weapon/switchtool) && istype(A:deployed, /obj/item/tool/crowbar))
+#define iscrowbar(A) (istype(A, /obj/item/tool/crowbar) || (istype(A, /obj/item/weapon/switchtool) && istype(A:deployed, /obj/item/tool/crowbar)))
 
 #define issolder(A) istype(A, /obj/item/tool/solder)
 
-#define iswrench(A) istype(A, /obj/item/tool/wrench) || (istype(A, /obj/item/weapon/switchtool) && istype(A:deployed, /obj/item/tool/wrench))
+#define iswrench(A) (istype(A, /obj/item/tool/wrench) || (istype(A, /obj/item/weapon/switchtool) && istype(A:deployed, /obj/item/tool/wrench)))
 
 #define isswitchtool(A) istype(A, /obj/item/weapon/switchtool)
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -375,6 +375,7 @@ var/list/one_way_windows
 			log_attack("[user.name] ([user.ckey]) window slammed [M.name] ([M.ckey]) ([gstate]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
 			return
 
+    /* One-way windows have serious performance issues - N3X
 	if(iscrowbar(W) && one_way)
 		if(!is_fulltile && get_turf(user) != get_turf(src))
 			to_chat(user, "<span class='warning'>You can't pry the sheet of plastic off from this side of \the [src]!</span>")
@@ -383,7 +384,6 @@ var/list/one_way_windows
 			toggle_one_way()
 			drop_stack(/obj/item/stack/sheet/mineral/plastic, get_turf(user), 1, user)
 			return
-    /* One-way windows have serious performance issues - N3X
 	if(istype(W, /obj/item/stack/sheet/mineral/plastic))
 		if(one_way)
 			to_chat(user, "<span class='notice'>This window already has one-way tint on it.</span>")


### PR DESCRIPTION
Fixes #34308
Fixes #34303

tested and working

:cl:
* bugfix: Fixed macro bugs related to Crowbars, Wrench and Wirecutters, such as no longer being able to open APCs or getting plastic (lmao what) out of windows.