### PR TITLE
Fix RTG icon not updating properly

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -279,9 +279,8 @@
 		return 0
 	var/power_used = min(maxcharge-charge,charge_rate)
 	charge += power_used
-//	if(prob(5))
-//		for(var/mob/living/L in view(get_turf(src), max(5,(maxcharge/charge))))
-//			L.apply_radiation(charge_rate/10, RAD_EXTERNAL)
+	updateicon()
+
 	if(charge_rate && charge_rate < (initial(charge_rate)/10))	//turns into a broken cell with no charge rate, 0 max charge, a 5% chance to explode every 2s and 25% chance to leak radiation equal to 1/10th of its charge rate
 		name = "broken cell"
 		icon_state = "cell"


### PR DESCRIPTION
## What this does
Adds a missing call to updateicon() and delets some fuckin bullshit while there

## Why it's good
RTG cell charge display behaviour is bad and doesn't update properly. Expected behaviour would be that leaving the cell idle and untouched would eventually see its icon change from dark->amber->green, but that wasn't happening
This makes it happen

## Changelog
:cl:
 * bugfix: RTG cell icon updates properly
