### PR TITLE
Log emitter attacks between mobs

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -147,9 +147,10 @@
 	apply_damage(damage, B.damage_type, B.def_zone)
 
 	// Emitter attack logging. Only when source of emitter beam is /mob/living and there's a ckey in either
-	if (B.sources.len >= 1 && (isliving(B.sources[1])) && (B.sources[1].ckey || src.ckey))
+	if (B.sources.len >= 1 && (isliving(B.sources[1])))
 		var/mob/living/assailant = B.sources[1]
-		log_attack("<font color='red'>[assailant.name][assailant.ckey ? "([assailant.ckey])" : "(no key)"] attacked [src.name][src.ckey ? "([src.ckey])" : "(no key)"] with [B.name]</font>")
+		if (assailant.ckey || src.ckey)
+			log_attack("<font color='red'>[assailant.name][assailant.ckey ? "([assailant.ckey])" : "(no key)"] attacked [src.name][src.ckey ? "([src.ckey])" : "(no key)"] with [B.name]</font>")
 
 	// Update check time.
 	last_beamchecks["\ref[B]"]=world.time

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -146,6 +146,11 @@
 	// Actually apply damage
 	apply_damage(damage, B.damage_type, B.def_zone)
 
+	// Emitter attack logging. Only when source of emitter beam is /mob/living and there's a ckey in either
+	if (B.sources.len >= 1 && (isliving(B.sources[1])) && (B.sources[1].ckey || src.ckey))
+		var/mob/living/assailant = B.sources[1]
+		log_attack("<font color='red'>[assailant.name][assailant.ckey ? "([assailant.ckey])" : "(no key)"] attacked [src.name][src.ckey ? "([src.ckey])" : "(no key)"] with [B.name]</font>")
+
 	// Update check time.
 	last_beamchecks["\ref[B]"]=world.time
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
[logging]
![grafik](https://github.com/vgstation-coders/vgstation13/assets/132118542/875f3091-cb31-43ce-b480-118dc06f3588)

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Logs emitter attacks
Closes #32270

Currently only emitter goggles hit this as they add a /mob/living to the emitter beam's sources. Should also work whenever someone adds more mob-used emitters

I made it so either of the two mobs need to have a ckey to avoid at least one source of logspam

## Why it's good
<!-- Explain why you think these changes are good. -->
So you can't use emitter goggles to kill without leaving a trail anymore

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Emitter attacks by players are now logged. (Currently only emitter goggles fall under this)
