### PR TITLE
Revert "limit ricochet bounces"

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -131,7 +131,7 @@
 
 /obj/item/projectile/bullet/midbullet/bouncebullet
 	bounce_type = PROJREACT_WALLS|PROJREACT_WINDOWS
-	bounces = 200
+	bounces = -1
 
 /obj/item/projectile/bullet/midbullet/bouncebullet/lawgiver
 	damage = 30

--- a/code/modules/projectiles/projectile/ricochet.dm
+++ b/code/modules/projectiles/projectile/ricochet.dm
@@ -185,10 +185,7 @@
 				dir = SOUTHWEST
 
 /obj/item/projectile/ricochet/proc/bounce()
-	bouncin += 1
-	if(bouncin > 200)
-		bulletdies()
-		return
+	bouncin = 1
 	var/obj/structure/ricochet_bump/bump = new(loc)
 	if(nodamage)
 		bump.icon_state += "_t"


### PR DESCRIPTION
Reverts vgstation-coders/vgstation13#33780

5 updoots to 13 downvotes for something that didn't feel critically needed.
Infinite bouncies are fun, allow some clever (and hilarious play), and can sometimes make the Lawgiver more dangerous to use (and that's a good thing).

Maybe for another, more common gun, it would make sense, but the Lawgiver is supposed to be fun and unique.