### PR TITLE
Fixes the switchtool's zippo not burning/cauterizing stuff as it should

### DIFF
--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -363,6 +363,7 @@
 	if(doedit)
 		if(istype(deployed, /obj/item/weapon/lighter/zippo))
 			var/obj/item/weapon/lighter/lighter = deployed
+			lighter.lit = 1
 			processing_objects.Add(deployed)
 			light_color = LIGHT_COLOR_FIRE
 			set_light(lighter.brightness_on)
@@ -370,6 +371,8 @@
 			undeploy_sound = 'sound/items/zippo_close.ogg'
 	else
 		if(istype(deployed, /obj/item/weapon/lighter/zippo))
+			var/obj/item/weapon/lighter/lighter = deployed
+			lighter.lit = 0
 			processing_objects.Remove(deployed)
 			set_light(0)
 			light_color = initial(light_color)


### PR DESCRIPTION
Fixes #34321

Tested that it both burns paper and cauterizes wounds.
![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/e83ca8a4-a351-489f-8ca0-b9fe568b089c)


:cl:
* bugfix: Fixed the switchtool's zippo not burning and cauterizing stuff as it should.