### PR TITLE
raging mages now costs 25*

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -291,7 +291,7 @@
 	required_pop = list(20,20,15,15,15,15,15,10,10,0)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT/2
-	cost = 40
+	cost = 25
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 50
 	logo = "raginmages-logo"

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -291,7 +291,7 @@
 	required_pop = list(20,20,15,15,15,15,15,10,10,0)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT/2
-	cost = 20
+	cost = 40
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 50
 	logo = "raginmages-logo"


### PR DESCRIPTION
crazy that ragin mages currently costs 5 points less than vox raiders even though it's a total round ender 90% of the time

:cl:
 - tweak: made raging mages midround cost 25 points instead of 20 points