### PR TITLE
fix the mining asteroid's secret randomly generated rooms not spawning

### DIFF
--- a/code/controllers/subsystem/init/map.dm
+++ b/code/controllers/subsystem/init/map.dm
@@ -27,8 +27,7 @@ var/datum/subsystem/map/SSmap
 	else
 		log_startup_progress("Not generating vaults - SKIP_VAULT_GENERATION found in config/config.txt")
 
-	for(var/i = 0, i < max_secret_rooms, i++)
-		make_mining_asteroid_secret()
+	make_mining_asteroid_secrets() // loops 3 times
 
 	//hobo shack generation, one shack will spawn, 1/3 chance of two shacks
 	generate_hoboshack()

--- a/code/game/asteroid.dm
+++ b/code/game/asteroid.dm
@@ -46,31 +46,27 @@ proc/admin_spawn_room_at_pos()
 
 	return 1
 
-/proc/make_mining_asteroid_secret()
+/proc/make_mining_asteroid_secrets()
 	var/turf/T = null
 	var/sanity = 0
 	var/list/turfs = null
-
-	turfs = get_area_turfs(/area/mine/unexplored)
+	var/area/A = locate(/area/mine/unexplored)
+	turfs = A.contents.Copy()
 
 	if(!turfs.len)
 		return 0
-
-	while(1)
+	while(spawned_surprises.len < max_secret_rooms)
 		sanity++
 		if(sanity > 100)
-			//testing("Tried to place complex too many times.  Aborting.")
+			log_debug("Tried to place secret asteroid complex too many times. Aborting.")
 			return 0
 
 		T=pick(turfs)
 
 		var/complex_type=pick(mining_surprises)
 		var/mining_surprise/complex = new complex_type
-
 		if(complex.spawn_complex(T))
 			spawned_surprises += complex
-			return 1
+			continue
 
-	return 0
-
-
+	return 1


### PR DESCRIPTION
## What this does
This stopped working because `get_area_turfs` does not work before /turf's are initialized. Turfs are initialized in the Object subsystem, which is initialized after the Map subsystem. Moving the Maps subsystem after the Object subsystem in init order causes a tremendous amount of problems, obviously. Wall smoothing and init is an issue if you move just the mining secrets proc somewhere else.

I changed the way the mining secrets proc gets its list of valid turfs so this won't happen anymore. It's also 3x less expensive to generate these ruins since it's not fetching 20,000+ turfs three times in a row. I didn't include checks for valid complex generation spots when touching `make_mining_asteroid_secrets` as it's already handled in `check_complex_placement`.

Huge thanks to @Inorien for helping me debug this.
[bugfix][tested]

:cl: Nervere & Inorien
 * bugfix: The mining asteroid's secret, randomly-generated rooms now spawn properly again. Don't forget to bring your tools!
