### PR TITLE
Space hobos can now choose their species

### DIFF
--- a/code/modules/mob/dead/observer/verbs.dm
+++ b/code/modules/mob/dead/observer/verbs.dm
@@ -562,8 +562,12 @@
 		return  //Hit the wrong key...again.
 
 	var/mob/living/carbon/human/hobo = new(pick(hobostart))
+	
+	var/list/species_choices = list("Human", "Vox", "Insectoid", "Grey", "Skrell", "Unathi", "Diona", "Mushroom")
+	var/chosen_species = input(src, "Choose a species", "Species") in species_choices
+	hobo.set_species(chosen_species)
+	
 	hobo.key = src.key
-	hobo.set_species(pick(200;"Human",50;"Vox",50;"Insectoid",25;"Diona",25;"Grey",1;"Tajaran",10;"Unathi"))
 	hobo.generate_name()
 	var/datum/outfit/special/with_id/hobo/hobo_outfit = new
 	hobo_outfit.equip(hobo)


### PR DESCRIPTION
## What this does
Currently, space hobos have a random race with the following weights:
- 55% human
- 14% vox
- 14% insect
- 7% diona
- 7% gray
- 0.2% tajaran
- 2.7% unathi

I think this is kind of arbitrary / random, so I changed it to let players choose their species from any on that list, minus tajaran, but including mushroom men.

## Why it's good
Space hobos are the downtrodden / outcasts in Nanotrasen space, so it makes sense for them to be non-human more often than not. Instead of assigning arbitrary values for this, though, I think it's best to leave it to player choice.

[tested]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Space Hobos can now choose their species (from a limited list) before they spawn.
