### PR TITLE
admins with +poll no longer see unusable Create Poll verb when de-adminned

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -354,6 +354,7 @@ var/list/admin_verbs_mod = list(
 		admin_verbs_debug,
 		admin_verbs_possess,
 		admin_verbs_permissions,
+		admin_verbs_polling,
 		/client/proc/stealth,
 		admin_verbs_rejuv,
 		admin_verbs_sounds,


### PR DESCRIPTION
## What this does
No more of this:
![image](https://github.com/vgstation-coders/vgstation13/assets/26285377/a9ededac-8c98-4177-9574-0e58271bf6eb)

[tested]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: admins with +poll no longer see unusable Create Poll verb when de-adminned