### PR TITLE
fix spider huds and overlays not working

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/base_spider.dm
@@ -162,8 +162,6 @@
 /mob/living/simple_animal/hostile/giant_spider/Life()
 	if(timestopped)
 		return 0 //under effects of time magick
-	if (health == maxHealth)
-		return ..()
 	if (health > 0)
 		health = min(maxHealth, health_regen_rate + health)
 	. = ..()


### PR DESCRIPTION
## What this does
Spiders at max health did not call hud and damage overlay updates properly.
Caused by #32520 adding unnecessary sanity that returned where it shouldn't have.

fixes #34331
[bugfix][tested]

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: HUD and damage overlays now work properly for spiders.