### PR TITLE
fix optical thermal eyepatch sprite

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -597,8 +597,8 @@ var/list/science_goggles_wearers = list()
 /obj/item/clothing/glasses/thermal/eyepatch
 	name = "Optical Thermal Eyepatch"
 	desc = "An eyepatch with built-in thermal optics."
-	icon_state = "eyepatch"
-	item_state = "eyepatch"
+	icon_state = "eyepatch0"
+	item_state = "eyepatch0"
 	species_fit = list(GREY_SHAPED)
 	min_harm_label = 3
 	harm_label_examine = list("<span class='info'>A tiny label is on the lens.</span>","<span class='warning'>A label covers the lens!</span>")


### PR DESCRIPTION
fix optical thermal eyepatch sprite
[bugfix]

closes #34211
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: The Optical Thermal Eyepatch now has the proper spriting.
