### PR TITLE
mobs wearing cardborg helmet now have appropriate speech verbs

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -21,6 +21,8 @@
 		var/speaker_verb_override = speaker.get_spoken_verb(msg)
 		if (speaker_verb_override)
 			return speaker_verb_override
+	if(locate(/obj/item/clothing/head/cardborg) in speaker.get_equipped_items())
+		silicon = 1
 	switch(mode)
 		if(SPEECH_MODE_WHISPER)
 			return "[whisper_verb]"


### PR DESCRIPTION
## What this does
Adds condition to language datum proc `get_spoken_verb` that treats user as having silicon speech verbs if the cardborg helmet is worn. Should work for all mobs that can wear the hat, just tested on humans and monkeys though. The caveat to this change is that if you're stammering or brain-damaged, you'll still say "stutters" or "gibbers" instead, respectively. I don't think that's a bad thing, though.

## Why it's good
Makes it more convincing that you're an AI. If you've invested the resources into doing a silicon impersonation gimmick, now it can't be metagamed.

P.S.
I really didn't want to handle this via `get_spoken_verb`, but the other ways I tried, like handling it via an equip/unequip event were too complicated and didn't work very well, or were too convoluted. I reviewed all of say code and couldn't really find a solution that is as simple as this, even if snowflaking the helmet here is bad.

That said, please give suggestions for implementation if you have any.
[tweak]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Mobs wearing the cardborg helmet now have the appropriate speech verbs. You will "state" speech instead of "saying" it, "query" instead of "ask", and "declare" instead of "exclaim".
