### PR TITLE
Add fake xeno-creep spray bottle to Autodrobe

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -468,6 +468,7 @@
 #define DSYRUP			"dsyrup"
 #define GRUE_BILE		"grue_bile"
 #define PINKLADY		"pinklady"
+#define FAKE_CREEP		"fake_creep"
 
 #define TUNGSTEN 			"tungsten"
 #define LITHIUMSODIUMTUNGSTATE 			"lithiumsodiumtungstate"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -322,8 +322,8 @@ var/global/num_vending_terminals = 1
 	for (var/datum/data/vending_product/D in voucher_records)
 		D.amount = D.original_amount
 	for (var/datum/data/vending_product/D in holiday_records)
-		D.amount = D.original_amount	
-		
+		D.amount = D.original_amount
+
 	new /obj/item/stack/sheet/cardboard(P.loc, 4)
 	qdel(P)
 	if(user.machine==src)
@@ -2681,6 +2681,7 @@ var/global/num_vending_terminals = 1
 		/obj/item/clothing/head/syndie_football_helmet = 5,
 		/obj/item/clothing/suit/syndie_football = 5,
 		/obj/item/toy/gun = 3,
+		/obj/item/weapon/reagent_containers/spray/creepspray = 2,
 		/obj/item/weapon/glue/temp_glue = 1
 		)
 	premium = list(

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -10146,3 +10146,19 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	specheatcap = 0.45
 	density = 7.874
 	var/mute_duration = 300 //30 seconds
+
+/datum/reagent/fake_creep // Used to spread xenomorph creep. Why? Well, why not?
+	name = "Dan's Grape Drank"
+	id = FAKE_CREEP
+	description = "Discount Dan's award-winning grape drink. Limited production run! Now with added peanuts!"
+	reagent_state = REAGENT_STATE_LIQUID
+	color = "#6F2DA8" // 111, 45, 168
+
+/datum/reagent/fake_creep/reaction_turf(var/turf/simulated/T, var/volume)
+
+	if(..())
+		return 1
+
+	if(volume >= 1)
+		if(!locate(/obj/effect/alien/weeds) in T)
+			new /obj/effect/alien/weeds(T)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -181,6 +181,16 @@
 	..()
 	reagents.add_reagent(INSECTICIDE, 250)
 
+//Fake Xeno Creep Sprayer
+/obj/item/weapon/reagent_containers/spray/creepspray
+	name = "Creep Spray"
+	desc = "Filled with a mysterious purple liquid."
+	volume = 250
+
+/obj/item/weapon/reagent_containers/spray/creepspray/New()
+	..()
+	reagents.add_reagent(FAKE_CREEP, 250)
+
 //chemsprayer
 /obj/item/weapon/reagent_containers/spray/chemsprayer
 	name = "chem sprayer"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
-Creates a new reagent called "fake_creep" that spawns Xenomorph creep (aka. weeds) when sprayed/splashed on a turf. 
-Creates a new spray bottle called "Creep Sprayer" that comes with 250 of this reagent in it.
-Adds the "Creep Sprayer" to the hacked AutoDrobe.

## Why it's good
<!-- Explain why you think these changes are good. -->
This gives the clown more tools to fake a Xenomorph infestation, along with the Xenomorph suit. Sharp eyes will note the lack of a creep node would give this away as fake. Calls the legitimate xeno weeds, however their behaviour is manipulated by weed nodes so they won't propagate (or do anything else) in this state.

## Testing
-Spawned an empty spray bottle. Added reagent. Generates one (1) creep per spray.
-Spawned a creep sprayer. Generates one (1) creep per spray.
-Spawned an empty beaker. Added reagent. Generates one (1) creep when splashed.

## Untested
-Reagent has no vars or functions related to being splashed on clothes or ingested. I don't believe this breaks anything when drank or added to anything else. Open to correction.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added one new reagent, one new spray bottle, and added this to the AutoDrobe's contraband section
 * rscdel: Apparently I deleted two lines somewhere. And then added two lines. I'm an idiot and I don't believe this breaks anything?

