### PR TITLE
consistency for a crewmember's sex data in records

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -56,7 +56,7 @@
 		G.fields["fingerprint"]	= md5(H.dna.uni_identity)
 		G.fields["p_stat"]		= "Active"
 		G.fields["m_stat"]		= "Stable"
-		G.fields["sex"]			= H.gender
+		G.fields["sex"]			= capitalize(H.gender)
 		G.fields["species"]		= H.get_species()
 
 		if(H.gen_record && !jobban_isbanned(H, "Records"))
@@ -102,7 +102,7 @@
 		L.fields["name"]		= H.real_name
 		L.fields["rank"] 		= H.mind.assigned_role
 		L.fields["age"]			= H.age
-		L.fields["sex"]			= H.gender
+		L.fields["sex"]			= capitalize(H.gender)
 		L.fields["b_type"]		= H.dna.b_type
 		L.fields["b_dna"]		= H.dna.unique_enzymes
 		L.fields["enzymes"]		= H.dna.SE // Used in respawning


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
Currently, if you change someone's gender in the medical/security records, it's very obvious. An untouched record will be uncapitalized, i.e. `male`, while a modified record will be capitalized, i.e. `Male`. This PR makes it consistent: the roundstart record for gender will now be capitalized when generated.

## Why it's good
Less opportunity for metagaming.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Medical and security records now consistently display information on a crewmember's sex.