### PR TITLE
Wild West QOL

### DIFF
--- a/code/game/machinery/doors/mineral.dm
+++ b/code/game/machinery/doors/mineral.dm
@@ -18,7 +18,8 @@
 /obj/machinery/door/mineral/New(location)
 	..()
 	icon_state = "[prefix]door_closed"
-	name = "[prefix] door"
+	if(name == "mineral door") //preserve mapped names
+		name = "[prefix] door"
 
 /obj/machinery/door/mineral/Bumped(atom/user)
 	if(operating)

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -141,7 +141,7 @@
 			secured = !secured
 			C.playtoolsound(src, 80)
 			update_icon()
-			
+
 /turf/simulated/floor/engine/proc/explode_layers(var/layers = 1)
 	if(secured)		//plasteel tile, screwed in
 		secured = FALSE
@@ -163,11 +163,11 @@
 	var/turf/simulated/floor/F = src
 	F.make_plating()
 	layers -= 1
-	
+
 	//normal plating
 	if(!layers)
 		return
-		
+
 	var/severity = 2
 	if(layers > 1)
 		severity = 1
@@ -276,6 +276,7 @@
 
 /turf/simulated/floor/plating/deck
 	name = "deck"
+	icon_state = "deck"
 	icon_plating = "deck"
 	desc = "Children love to play on this deck."
 

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -38,6 +38,7 @@
 	walltype = "log"
 	mineral = "log"
 	icon_state = "log0"
+	var/deconstruct_type = /turf/unsimulated/floor/snow/empty
 
 /turf/simulated/wall/mineral/wood/log/dismantle_wall()
 	new /obj/item/weapon/grown/log/tree(src)
@@ -47,8 +48,11 @@
 		if(istype(O,/obj/structure/sign/poster))
 			var/obj/structure/sign/poster/P = O
 			P.roll_and_drop(src)
-	ChangeTurf(/turf/unsimulated/floor/snow/empty)
+	ChangeTurf(deconstruct_type)
 	update_near_walls()
+
+/turf/simulated/wall/mineral/wood/log/desert
+	deconstruct_type = /turf/simulated/floor/plating/ironsand
 
 /turf/simulated/wall/mineral/brick
 	name = "brick wall"

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -36,4 +36,5 @@
 
 /turf/simulated/wall/syndicate
 	icon = 'icons/turf/shuttle.dmi'
+	icon_state = "satwall0"
 	walltype = "satwall"

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -420,7 +420,7 @@
 /obj/item/clothing/accessory/rad_patch
 	name = "radiation detection patch"
 	desc = "A paper patch that you can attach to your clothing. Changes color to black when it absorbs over a certain amount of radiation."
-	icon_state = "rad_patch"
+	icon_state = "patch_0"
 	var/rad_absorbed = 0
 	var/rad_threshold = 45
 	var/triggered = FALSE


### PR DESCRIPTION
A bunch of minor non-player-facing changes that don't need a CL

* mapped mineral doors can keep names
* deck looks correct when mapping
* syndicate wall looks correct when mapping
* log walls can be deconstructed to different floors depending on mapping, added a desert subtype
* radiation patch looks correct when mapping