### PR TITLE
fix speech runtime for non-mob speakers

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -21,8 +21,8 @@
 		var/speaker_verb_override = speaker.get_spoken_verb(msg)
 		if (speaker_verb_override)
 			return speaker_verb_override
-			if(locate(/obj/item/clothing/head/cardborg) in speaker.get_equipped_items())
-				silicon = 1
+		if(locate(/obj/item/clothing/head/cardborg) in speaker.get_equipped_items())
+			silicon = 1
 	switch(mode)
 		if(SPEECH_MODE_WHISPER)
 			return "[whisper_verb]"

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -21,8 +21,8 @@
 		var/speaker_verb_override = speaker.get_spoken_verb(msg)
 		if (speaker_verb_override)
 			return speaker_verb_override
-	if(locate(/obj/item/clothing/head/cardborg) in speaker.get_equipped_items())
-		silicon = 1
+			if(locate(/obj/item/clothing/head/cardborg) in speaker.get_equipped_items())
+				silicon = 1
 	switch(mode)
 		if(SPEECH_MODE_WHISPER)
 			return "[whisper_verb]"


### PR DESCRIPTION
Fixes runtime I caused with #34360
~~I actually can't re-create this runtime locally but this will probably fix it.~~
Turns out I just messed up my config.txt recently so runtimes didn't log properly. This is tested and it works.

```[01:34:19] Runtime in language.dm,24: undefined proc or verb /obj/structure/trade_window/get equipped items().

  proc name: get spoken verb (/datum/language/proc/get_spoken_verb)
  src: Vox-pidgin (/datum/language/vox)
  call stack:
  Vox-pidgin (/datum/language/vox): get spoken verb("Market forces shifting...", 0, 1, Trade Window (/obj/structure/trade_window))
  Vox-pidgin (/datum/language/vox): render speech(Chaka the Gentle (/datum/speech), "<span class=\'message vox\'>\"...")
  Chaka the Gentle (/datum/speech): render message()
  Trade Window (/obj/structure/trade_window): render speech(Chaka the Gentle (/datum/speech))
  Trade Window (/obj/structure/trade_window): send speech(Chaka the Gentle (/datum/speech), 7, null)
  Trade Window (/obj/structure/trade_window): say("Market forces shifting...", Vox-pidgin (/datum/language/vox), Trade Window (/obj/structure/trade_window), null)
  Trade Window (/obj/structure/trade_window): say("Market forces shifting...")
  Trade Window (/obj/structure/trade_window): market flux()
  Trade System (/datum/subsystem/trade_system): market flux(1)
  Trade System (/datum/subsystem/trade_system): fire(0)
  Trade System (/datum/subsystem/trade_system): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```
[runtime]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed runtime when non-mob objects speak.
