### PR TITLE
fix runtime spam when a changeling's body is destroyed

### DIFF
--- a/code/datums/gamemode/role/changeling.dm
+++ b/code/datums/gamemode/role/changeling.dm
@@ -83,7 +83,7 @@
 		AppendObjective(/datum/objective/hijack)
 
 /datum/role/changeling/proc/changelingRegen()
-	if(antag && antag.current && antag.current.stat == DEAD)
+	if((antag && antag.current && antag.current.stat == DEAD) || isnull(antag.current))
 		return
 	var/changes = FALSE
 	var/changeby = chem_charges

--- a/code/datums/gamemode/role/changeling.dm
+++ b/code/datums/gamemode/role/changeling.dm
@@ -83,7 +83,7 @@
 		AppendObjective(/datum/objective/hijack)
 
 /datum/role/changeling/proc/changelingRegen()
-	if((antag && antag.current && antag.current.stat == DEAD) || isnull(antag.current))
+	if(antag && antag.current && antag.current.stat == DEAD)
 		return
 	var/changes = FALSE
 	var/changeby = chem_charges
@@ -106,7 +106,8 @@
 	return chosen_dna
 
 /datum/role/changeling/process()
-	changelingRegen()
+	if(antag.current)
+		changelingRegen()
 	..()
 
 // READ: Don't use the apostrophe in name or desc. Causes script errors.


### PR DESCRIPTION
[runtime]
```
[01:11:08] Runtime in changeling.dm,98: Cannot execute null.updateChangelingHUD().
  proc name: changelingRegen (/datum/role/changeling/proc/changelingRegen)
  src: Changeling (/datum/role/changeling)
  call stack:
  Changeling (/datum/role/changeling): changelingRegen()
  Changeling (/datum/role/changeling): process()
  Changeling Hivemind (/datum/faction/changeling): process()
  Dynamic Mode (/datum/gamemode/dynamic): process()
  Dynamic Mode (/datum/gamemode/dynamic): process()
  /datum/controller/gameticker (/datum/controller/gameticker): process()
  Ticker (/datum/subsystem/ticker): fire(0)
  Ticker (/datum/subsystem/ticker): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed runtime spam when changeling's body is destroyed.
