### PR TITLE
fix runtime when non-mobs call Crossed() on snails

### DIFF
--- a/code/modules/mob/living/simple_animal/snail.dm
+++ b/code/modules/mob/living/simple_animal/snail.dm
@@ -76,7 +76,9 @@ var/max_snails = 40
 		return
 	return ..()
 
-/mob/living/simple_animal/snail/Crossed(mob/living/M as mob)
+/mob/living/simple_animal/snail/Crossed(mob/living/O)
+	if(!istype(O))
+		return
 	if(M.a_intent == I_HURT && prob(30))
 		adjustBruteLoss(4) // Owie
 	if (!in_shell && !isDead())

--- a/code/modules/mob/living/simple_animal/snail.dm
+++ b/code/modules/mob/living/simple_animal/snail.dm
@@ -76,8 +76,8 @@ var/max_snails = 40
 		return
 	return ..()
 
-/mob/living/simple_animal/snail/Crossed(mob/living/O)
-	if(O.a_intent == I_HURT && prob(30))
+/mob/living/simple_animal/snail/Crossed(mob/living/M as mob)
+	if(M.a_intent == I_HURT && prob(30))
 		adjustBruteLoss(4) // Owie
 	if (!in_shell && !isDead())
 		recoil()

--- a/code/modules/mob/living/simple_animal/snail.dm
+++ b/code/modules/mob/living/simple_animal/snail.dm
@@ -79,7 +79,7 @@ var/max_snails = 40
 /mob/living/simple_animal/snail/Crossed(mob/living/O)
 	if(!istype(O))
 		return
-	if(M.a_intent == I_HURT && prob(30))
+	if(O.a_intent == I_HURT && prob(30))
 		adjustBruteLoss(4) // Owie
 	if (!in_shell && !isDead())
 		recoil()


### PR DESCRIPTION
[runtime]
```[01:14:31] Runtime in snail.dm,80: undefined variable /obj/effect/beam/emitter/eyes/var/a_intent
  proc name: Crossed (/mob/living/simple_animal/snail/Crossed)
  src: the space snail (/mob/living/simple_animal/snail)
  src.loc: the floor (15,240,2) (/turf/simulated/floor/shuttle)
  call stack:
  the space snail (/mob/living/simple_animal/snail): Crossed(the emitter beam (/obj/effect/beam/emitter/eyes))
  the emitter beam (/obj/effect/beam/emitter/eyes): Move(the floor (15,240,2) (/turf/simulated/floor/shuttle), 1, 0, 0, 0)
  the emitter beam (/obj/effect/beam/emitter/eyes): emit(/list (/list), 6, 0)
  the emitter beam (/obj/effect/beam/emitter/eyes): emit(/list (/list), 6, 0)
  the emitter beam (/obj/effect/beam/emitter/eyes): emit(Unknown (/mob/living/carbon/human), 6, 0)
  the emitter beam (/obj/effect/beam/emitter/eyes): emit(Unknown (/mob/living/carbon/human), -1, 0)
  the emitter goggles (/obj/item/clothing/glasses/emitter): update emitter end()
  Unknown (/mob/living/carbon/human): invoke event(/event/after_move (/event/after_move), /list (/list))
  Unknown (/mob/living/carbon/human): change dir(1, null)
  Unknown (/mob/living/carbon/human): speen(4)
```
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed a runtime when objects were moved on top of snails.
