### PR TITLE
Exempted ghosts from from getting teleported to a random area at the edges of shuttle areas

### DIFF
--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -130,7 +130,7 @@
 	var/teleport_z_offset = 0
 
 /obj/effect/step_trigger/teleporter/random/Trigger(var/atom/movable/A)
-	if(!istype(A))
+	if(!istype(A) || isobserver(A))
 		return
 	if(istype(A,/obj/item/projectile/fire_breath/shuttle_exhaust))
 		qdel(A)


### PR DESCRIPTION
## What this does
The edges of shuttle areas have these teleporters to throw you out into random space if you touch them. This exempts ghosts from that behavior so you can observe to your heart's content.

## Why it's good
I want to be able to move between observing the shuttle and the pods easily without having to zoom out a ton.
![PBjiwmdRub](https://github.com/vgstation-coders/vgstation13/assets/26285377/90936a93-323f-4bb3-944b-956620a90b6e)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Exempted ghosts from from getting teleported to a random area at the edges of shuttle areas
