### PR TITLE
ensure mobs receive hair update upon droplimb() called on head

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -821,6 +821,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 			//Throw organs around
 			var/randomdir = pick(cardinal)
 			step(organ, randomdir)
+			
+		if(istype(src, /datum/organ/external/head))
+			owner.update_hair(1)
 
 		owner.update_body(1)
 		owner.handle_organs(1)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -821,9 +821,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 			//Throw organs around
 			var/randomdir = pick(cardinal)
 			step(organ, randomdir)
-			
-		if(istype(src, /datum/organ/external/head))
-			owner.update_hair(1)
 
 		owner.update_body(1)
 		owner.handle_organs(1)
@@ -1559,6 +1556,11 @@ Note that amputating the affected organ does in fact remove the infection from t
 	disfigured = TRUE
 
 	owner.update_hair()
+
+/datum/organ/external/head/droplimb(override, no_explode, spawn_limb, display_message)
+	. = ..()
+	owner.update_hair(1)
+	return .
 
 /****************************************************
 			   EXTERNAL ORGAN ITEMS


### PR DESCRIPTION
## What this fixes
Getting your head destroyed in wacky ways (like biting a supermatter shard) would create floating ghost hair that follows the headless body around since hair never gets properly updated. Now, whenever droplimb is called on a head, hair will be updated.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed hair not properly updating sometimes when a player's head is destroyed.