### PR TITLE
fix runtime when untying guillotine blade without victim inside

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/guillotine.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/guillotine.dm
@@ -196,9 +196,10 @@
 	update_icon()
 
 /obj/structure/bed/guillotine/proc/untie_blade(mob/user)
-	user.attack_log += "\[[time_stamp()]\] [key_name(user)] has started to execute [key_name(victim)] with \the [src]."
-	victim.attack_log += "\[[time_stamp()]\] [key_name(user)] has started to execute [key_name(victim)] with \the [src]."
-	message_admins("\[[time_stamp()]\] [key_name(user)] has started to execute [key_name(victim)] with \the [src]. @[formatJumpTo(src)]")
+	if(victim)
+		user.attack_log += "\[[time_stamp()]\] [key_name(user)] has started to execute [key_name(victim)] with \the [src]."
+		src.victim.attack_log += "\[[time_stamp()]\] [key_name(user)] has started to execute [key_name(victim)] with \the [src]."
+		message_admins("\[[time_stamp()]\] [key_name(user)] has started to execute [key_name(victim)] with \the [src]. @[formatJumpTo(src)]")
 	user.visible_message("<span class='danger'>\The [user] begins untying the rope holding \the [src]'s blade!</span>",\
 							"You begin untying the rope holding \the [src]'s blade.")
 	if(do_after(user, src, 100))


### PR DESCRIPTION
## What this does
It was looking to add logging regardless of whether or not there was someone inside the guillotine.

[bugfix][runtime]
```[00:30:14] Runtime in guillotine.dm,200: Cannot read null.attack_log
  proc name: untie blade (/obj/structure/bed/guillotine/proc/untie_blade)
  usr: Joshua Kemerer (nervere) (/mob/living/carbon/human)
  usr.loc: The floor (223, 282, 1) (/turf/simulated/floor)
  src: the guillotine (/obj/structure/bed/guillotine)
  src.loc: the floor (224,282,1) (/turf/simulated/floor)
  call stack:
  the guillotine (/obj/structure/bed/guillotine): untie blade(Joshua Kemerer (/mob/living/carbon/human))
  the guillotine (/obj/structure/bed/guillotine): AltClick(Joshua Kemerer (/mob/living/carbon/human))
  Joshua Kemerer (/mob/living/carbon/human): AltClickOn(the guillotine (/obj/structure/bed/guillotine))
  Joshua Kemerer (/mob/living/carbon/human): AltClickOn(the guillotine (/obj/structure/bed/guillotine))
  Joshua Kemerer (/mob/living/carbon/human): ClickOn(the guillotine (/obj/structure/bed/guillotine), "icon-x=11;icon-y=15;left=1;alt...")
  the guillotine (/obj/structure/bed/guillotine): Click(the floor (224,282,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=11;icon-y=15;left=1;alt...")
  Nervere (/client): Click(the guillotine (/obj/structure/bed/guillotine), the floor (224,282,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=11;icon-y=15;left=1;alt...")
```
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Guillotines can now have their blade released without someone inside.