### PR TITLE
prevent corpse mob from interfering with death stat tracker

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/hunter.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/hunter.dm
@@ -22,4 +22,5 @@
 	speed = 2
 
 /mob/living/simple_animal/hostile/giant_spider/hunter/dead
+	iscorpse = 1
 	health = 0


### PR DESCRIPTION
similar to how corpse landmarks are exempted from being tracked by this