### PR TITLE
fix instruments breaking when a song has a space (comma) at the end of a line

### DIFF
--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -114,13 +114,15 @@
 
 		var/lineCount = 1;
 		for(var/line in lines)
-			//world << line
+			//to_chat(world, "line: [line]")
 			var/chordCount = 1;
 			for(var/beat in splittext(lowertext(line), ","))
-				//world << "beat: [beat]"
+				//to_chat(world, "beat: [beat] / beat length: [length(beat)]")
+				if(!length(beat)) //This occurs when a comma is at the end of a line
+					beat = " " //It's intended to be a space so here we make it a space
 				var/list/notes = splittext(beat, "/")
 				for(var/note in splittext(notes[1], "-"))
-					//world << "note: [note]"
+					//to_chat(world, "note: [note]")
 					if(!playing || shouldStopPlaying(user))//If the instrument is playing, or special case
 						playing = 0
 						return


### PR DESCRIPTION
## What this does
Songs with spaces at the ends of their lines runtime here in musician.dm:
`for(var/note in splittext(notes[1], "-"))` 
(because it tries to access an index of 1 in a blank variable)
It's blank because it uses `,` to split up the beats:
`for(var/beat in splittext(lowertext(line), ","))`
...and the comma is at the end of a line, so it finds nothing.

fixes #32917
[runtime][tested]
```[17:10:10] Runtime in musician.dm,122: list index out of bounds
  proc name: playsong (/datum/song/proc/playsong)
  usr: Joshua Kemerer (nervere) (/mob/living/carbon/human)
  usr.loc: The floor (153, 259, 1) (/turf/simulated/floor/shuttle)
  src: Untitled (/datum/song/handheld)
  call stack:
  Untitled (/datum/song/handheld): playsong(Joshua Kemerer (/mob/living/carbon/human))
  Untitled (/datum/song/handheld): Topic("src=\[0x2102d3a5];play=1", /list (/list))
```
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed instruments breaking when a song has a space (comma) at the end of a line
