### PR TITLE
Research Archive

### DIFF
--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -332,7 +332,7 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 	if(!research_archive_datum)
 		research_archive_datum = new /datum/research()
 	var/list/techs = read_file()
-	message_admins("DEBUG ARCHIVE: [json_encode(techs)]")
+	log_debug("DEBUG ARCHIVE: [json_encode(techs)]")
 	var/skip_reporting = TRUE
 	for(var/obj/machinery/computer/rdconsole/C in machines)
 		for(var/element in techs)

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -135,3 +135,4 @@
 		else
 			str += "\n|''(Check [R.type]/on_reaction()!)''"
 	text2file(str+"\n|}","chemistry-recipes.wiki")
+z

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -293,27 +293,27 @@ var/global/datum/research/research_archive_datum
 	use_power(200)
 	spawn(3 SECONDS)
 
-	for(var/datum/tech/T in get_list_of_elements(research_archive_datum.known_tech))
-		if(T.id != diskslot.stored.id)
-			continue
-		if(T.level > diskslot.stored.level)
-			if(T.level>=6)
-				visible_message("<span class='warning'>\The [src] rejects the data disk as [T.id] data has already reached its maximum.")
-				break
-			//Pick the lowest: +3 levels, level 6, maximum level of tech, or the maximum level on the disk
-			//Example: increase to level 4 in one pass, then increase to level 6 in second pass
-			T.level = min(T.level+3, 6, T.max_level, diskslot.stored.level)
-			qdel(diskslot)
-			diskslot = null
-			playsound(loc, "sound/machines/paistartup.ogg", 50, 1)
-			visible_message("<span class='good'>\The [src] accepts the data disk, increasing the [T.id] archive to [T.level].</span>")
-		else
-			playsound(loc, "sound/machines/buzz-sigh.ogg", 50, 1)
-			visible_message("<span class='warning'>\The [src] rejects the data disk as it contains no new information.</span>")
-			diskslot.forceMove(loc)
-			diskslot = null
-		break
-	busy = FALSE
+		for(var/datum/tech/T in get_list_of_elements(research_archive_datum.known_tech))
+			if(T.id != diskslot.stored.id)
+				continue
+			if(T.level > diskslot.stored.level)
+				if(T.level>=6)
+					visible_message("<span class='warning'>\The [src] rejects the data disk as [T.id] data has already reached its maximum.")
+					break
+				//Pick the lowest: +3 levels, level 6, maximum level of tech, or the maximum level on the disk
+				//Example: increase to level 4 in one pass, then increase to level 6 in second pass
+				T.level = min(T.level+3, 6, T.max_level, diskslot.stored.level)
+				qdel(diskslot)
+				diskslot = null
+				playsound(loc, "sound/machines/paistartup.ogg", 50, 1)
+				visible_message("<span class='good'>\The [src] accepts the data disk, increasing the [T.id] archive to [T.level].</span>")
+			else
+				playsound(loc, "sound/machines/buzz-sigh.ogg", 50, 1)
+				visible_message("<span class='warning'>\The [src] rejects the data disk as it contains no new information.</span>")
+				diskslot.forceMove(loc)
+				diskslot = null
+			break
+		busy = FALSE
 
 /obj/machinery/researcharchive/kick_act(var/mob/user)
 	..()

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -219,7 +219,7 @@ var/global/datum/research/research_archive_datum
 
 /obj/machinery/researcharchive
 	name = "research archive"
-	desc = "A high-powered data archive device that takes technology disks and persistently backs them up to Central Comamnd servers for future shifts. Usually takes two disks per technology."
+	desc = "A high-powered data archive device that takes technology disks and persistently backs them up to specialized servers for the upcoming shift. Usually takes two disks per technology."
 	icon = 'icons/obj/library.dmi'
 	icon_state = "binder"
 	anchored = TRUE

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -7,6 +7,7 @@
  *		Library Computer
  *		Library Scanner
  *		Book Binder
+ *		Research Archive
  */
 
  #define LIBRARY_BOOKS_PER_PAGE 25
@@ -213,3 +214,109 @@ var/global/list/library_section_names = list("Fiction", "Non-Fiction", "Adult", 
 			QDEL_NULL(O)
 	else
 		return ..()
+
+var/global/datum/research/research_archive_datum
+
+/obj/machinery/researcharchive
+	name = "research archive"
+	desc = "A high-powered data archive device that takes technology disks and persistently backs them up to Central Comamnd servers for future shifts. Usually takes two disks per technology."
+	icon = 'icons/obj/library.dmi'
+	icon_state = "binder"
+	anchored = TRUE
+	density = TRUE
+	machine_flags =  WRENCHMOVE | FIXED2WORK | EJECTNOTDEL // | SCREWTOGGLE | CROWDESTROY
+	pass_flags = PASSTABLE
+	idle_power_usage = 4
+	var/obj/item/weapon/disk/tech_disk/diskslot
+	var/busy = FALSE
+
+/obj/machinery/researcharchive/New()
+	..()
+	if(!research_archive_datum)
+		research_archive_datum = new /datum/research()
+
+/obj/machinery/researcharchive/examine(mob/user)
+	..()
+	if(diskslot)
+		to_chat(user,"<span class='info'>In the slot you can see a disk that contains [diskslot.stored.id] [diskslot.stored.level].</span>")
+		diskslot.examine(user)
+
+/obj/machinery/researcharchive/attackby(var/obj/item/weapon/W, var/mob/user)
+	if(stat & (BROKEN))
+		to_chat(user, "<span class='warning'>\The [src] is broken!</span>")
+		return
+	if(..())
+		return
+
+	if(busy)
+		return
+
+	if (!istype(W,/obj/item/weapon/disk/tech_disk))
+		to_chat(user, "<span class='warning'>\The [src] only accepts technology disks.</span>")
+		return
+
+	if (!user.drop_item(W, src))
+		return
+	if(diskslot)
+		user.put_in_hands(diskslot)
+		visible_message("<span class='notice'>\The [user] swaps the disks in \the [src].</span>","<span class='notice'>You swap the disks in \the [src].</span>")
+	else
+		visible_message("<span class='notice'>\The [user] adds \the [W] to \the [src].</span>","<span class='notice'>You add \the [W] to \the [src].</span>")
+	diskslot = W
+	playsound(loc, 'sound/machines/click.ogg', 50, 1)
+	update_icon()
+
+/obj/machinery/researcharchive/attack_hand(var/mob/user)
+	. = ..()
+	if(stat & (BROKEN))
+		to_chat(user, "<span class='notice'>\The [src] is broken.</span>")
+		return
+
+	if(stat & (NOPOWER))
+		to_chat(user, "<span class='notice'>\The [src] is unpowered.</span>")
+		return
+
+	if(!diskslot)
+		to_chat(user, "<span class='notice'>There is no inserted technology disk.</span>")
+		return
+
+	if(busy)
+		return
+
+	if(diskslot.stored.id in list("syndicate", "Nanotrasen", "anomaly"))
+		to_chat(user, "<span class='notice'>\The [src] cannot process this technology data due to proprietary encoding.</span>")
+		return
+
+	playsound(loc, "sound/machines/heps.ogg", 50, 1)
+
+	busy = TRUE
+	use_power(200)
+	spawn(3 SECONDS)
+
+	for(var/datum/tech/T in get_list_of_elements(research_archive_datum.known_tech))
+		if(T.id != diskslot.stored.id)
+			continue
+		if(T.level > diskslot.stored.level)
+			if(T.level>=6)
+				visible_message("<span class='warning'>\The [src] rejects the data disk as [T.id] data has already reached its maximum.")
+				break
+			//Pick the lowest: +3 levels, level 6, maximum level of tech, or the maximum level on the disk
+			//Example: increase to level 4 in one pass, then increase to level 6 in second pass
+			T.level = min(T.level+3, 6, T.max_level, diskslot.stored.level)
+			qdel(diskslot)
+			diskslot = null
+			playsound(loc, "sound/machines/paistartup.ogg", 50, 1)
+			visible_message("<span class='good'>\The [src] accepts the data disk, increasing the [T.id] archive to [T.level].</span>")
+		else
+			playsound(loc, "sound/machines/buzz-sigh.ogg", 50, 1)
+			visible_message("<span class='warning'>\The [src] rejects the data disk as it contains no new information.</span>")
+			diskslot.forceMove(loc)
+			diskslot = null
+		break
+	busy = FALSE
+
+/obj/machinery/researcharchive/kick_act(var/mob/user)
+	..()
+	if(!busy)
+		diskslot.forceMove(loc)
+		diskslot = null

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -67,8 +67,6 @@ var/global/list/hidden_tech = list(
 			design_list += new D()
 	RefreshResearch()
 
-
-
 //Checks to see if tech has all the required pre-reqs.
 //Input: datum/tech; Output: 0/1 (false/true)
 /datum/research/proc/TechHasReqs(var/datum/tech/T)


### PR DESCRIPTION
Hate doing R&D but love interacting with other people? This new machine for the librarian is for you!
* Research archive spawns in the library
* By using a technology data disk on the archive, you can back up data
  * The backup cannot exceed tech level 6
  * A single data disk can only boost the backed up level by 3 (however, you can use the librarian's disk duplicator to make two copies and upload twice)
* This archive will send the backed up tech levels to the very next shift! If your shift received a boost, there will be a note informing you of this at roundstart.
* Cannot backup anomaly, illegal, or NT tech

Tech level 6 will max out many techs like engineering, power storage, biotech, or programming. However, it will leave room to do a little more research in some areas like materials that go up to 9. Think of this like a big starting boost, the way you might get a starter boost from deconstructing syringe guns from robotics.

Not yet mapped. Nervere said he'd do both librarian devices in the same pass.
Come up with some reward for the librarian providing this service?

:cl:
* rscadd: The research archive can back up tech levels across shifts! Coming soon to a station near you.