### PR TITLE
Sanitizes Github, So we can get public access again.

### DIFF
--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -38,7 +38,7 @@
 
 var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a","Nyanners","Thing From Below","Airlock Scratcher","Flees-Like-Fleas",
 						"Lurks-In-Shadows","Eartha Kitt","Target Practice","Fresh Meat","Ca'thulu","Furry Fury","Vore-Strikes-Back","Killing Machine","Uncle Tom",
-						"Nine Lives", "Bad Luck", "Siamese Sam", "Tom Tabby", "Hairball", "Throws-Dice-Poorly", "Wizard Apprentice", "Lynch Lynx", "Felix", "Niggerman")
+						"Nine Lives", "Bad Luck", "Siamese Sam", "Tom Tabby", "Hairball", "Throws-Dice-Poorly", "Wizard Apprentice", "Lynch Lynx", "Felix")
 
 /datum/role/catbeast/proc/infect_catbeast(mob/living/carbon/human/H, str, rob, list/anti, list/bad)
 	var/virus_choice = pick(subtypesof(/datum/disease2/disease) - typesof(/datum/disease2/disease/predefined))

--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -38,7 +38,7 @@
 
 var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a","Nyanners","Thing From Below","Airlock Scratcher","Flees-Like-Fleas",
 						"Lurks-In-Shadows","Eartha Kitt","Target Practice","Fresh Meat","Ca'thulu","Furry Fury","Vore-Strikes-Back","Killing Machine","Uncle Tom",
-						"Nine Lives", "Bad Luck", "Siamese Sam", "Tom Tabby", "Hairball", "Throws-Dice-Poorly", "Wizard Apprentice", "Lynch Lynx", "Felix")
+						"Nine Lives", "Bad Luck", "Siamese Sam", "Tom Tabby", "Hairball", "Throws-Dice-Poorly", "Wizard Apprentice", "Lynch Lynx", "Felix", "Lovecraft's Cat")
 
 /datum/role/catbeast/proc/infect_catbeast(mob/living/carbon/human/H, str, rob, list/anti, list/bad)
 	var/virus_choice = pick(subtypesof(/datum/disease2/disease) - typesof(/datum/disease2/disease/predefined))

--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -702,7 +702,7 @@ var/list/all_bible_styles = list(
 	bible_type = /obj/item/weapon/storage/bible/booze
 	male_adept = "LGBT Advocate"
 	female_adept = "LGBT Advocate"
-	keys = list("homosexuality", , "gayness", "gay", "penis", "cock", "cocks", "dick", "dicks")
+	keys = list("homosexuality", "gayness", "gay", "penis", "cock", "cocks", "dick", "dicks")
 	preferred_incense = /obj/item/weapon/storage/fancy/incensebox/banana
 
 /datum/religion/homosexuality/equip_chaplain(var/mob/living/carbon/human/H)

--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -702,7 +702,7 @@ var/list/all_bible_styles = list(
 	bible_type = /obj/item/weapon/storage/bible/booze
 	male_adept = "LGBT Advocate"
 	female_adept = "LGBT Advocate"
-	keys = list("homosexuality", "faggotry", "gayness", "gay", "penis", "faggot", "cock", "cocks", "dick", "dicks")
+	keys = list("homosexuality", , "gayness", "gay", "penis", "cock", "cocks", "dick", "dicks")
 	preferred_incense = /obj/item/weapon/storage/fancy/incensebox/banana
 
 /datum/religion/homosexuality/equip_chaplain(var/mob/living/carbon/human/H)

--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -715,7 +715,7 @@ var/list/all_bible_styles = list(
 	bible_type = /obj/item/weapon/storage/bible/booze
 	male_adept = "Retard"
 	female_adept = "Retard"
-	keys = list("lol", "wtf", "badmin", "shitmin", "deadmin", "nigger", "dickbutt", ":^)", "XD", "le", "meme", "memes", "ayy", "ayy lmao", "lmao", "reddit", "4chan", "tumblr", "9gag", "brian damag")
+	keys = list("lol", "wtf", "badmin", "shitmin", "deadmin", "dickbutt", ":^)", "XD", "le", "meme", "memes", "ayy", "ayy lmao", "lmao", "reddit", "4chan", "tumblr", "9gag", "brian damag")
 	convert_method = "standing both next to a table."
 	preferred_incense = /obj/item/weapon/storage/fancy/incensebox/banana
 
@@ -1558,7 +1558,7 @@ var/list/all_bible_styles = list(
 	female_adept = "Looper"
 	keys = list("loop", "ouroboros")
 	bookstyle = "The Loop"
-	
+
 /datum/religion/loop/equip_chaplain(var/mob/living/carbon/human/H)
 	H.equip_or_collect(new /obj/item/clothing/suit/timefake(H), slot_wear_suit)
 	H.equip_or_collect(new /obj/item/clothing/head/timefake(H), slot_head)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -809,7 +809,7 @@ its easier to just keep the beam vertical.
 
 /datum/proc/setGender(gend = FEMALE)
 	if(!("gender" in vars))
-		CRASH("Oh shit you stupid nigger the [src] doesn't have a gender variable.")
+		CRASH("The [src] doesn't have a gender variable.")
 	if(ishuman(src))
 		ASSERT(gend != PLURAL && gend != NEUTER)
 	src:gender = gend

--- a/code/game/dna/genes/speech.dm
+++ b/code/game/dna/genes/speech.dm
@@ -1,6 +1,6 @@
 #define ACT_REPLACE      /datum/speech_filter_action/replace
 #define ACT_PICK_REPLACE /datum/speech_filter_action/pick_replace
-#define GENERIC_INSULT_WORDS "\\b(asshole|comdom|shitter|shitler|retard|dipshit|dipshit|greyshirt|faggot|security|shitcurity)"
+#define GENERIC_INSULT_WORDS "\\b(asshole|comdom|shitter|shitler|retard|dipshit|dipshit|greyshirt|security|shitcurity)"
 
 /datum/speech_filter
 	// REGEX OH BOY
@@ -233,7 +233,6 @@
 	addWordReplacement("beer","water with ice")
 	addWordReplacement("drink","water")
 	addWordReplacement("\\b(feminist|feminazi|SJW|social justice warrior)","empowered woman")
-	addWordReplacement("faggot","effeminate male")
 	addPickReplacement("fag", list("fig", "friend"))
 	addWordReplacement("tranny","felinid")
 	addWordReplacement("trannies","felinids")

--- a/code/game/dna/genes/speech.dm
+++ b/code/game/dna/genes/speech.dm
@@ -1,6 +1,6 @@
 #define ACT_REPLACE      /datum/speech_filter_action/replace
 #define ACT_PICK_REPLACE /datum/speech_filter_action/pick_replace
-#define GENERIC_INSULT_WORDS "\\b(asshole|comdom|shitter|shitler|retard|dipshit|dipshit|greyshirt|nigger|faggot|security|shitcurity)"
+#define GENERIC_INSULT_WORDS "\\b(asshole|comdom|shitter|shitler|retard|dipshit|dipshit|greyshirt|faggot|security|shitcurity)"
 
 /datum/speech_filter
 	// REGEX OH BOY
@@ -233,7 +233,6 @@
 	addWordReplacement("beer","water with ice")
 	addWordReplacement("drink","water")
 	addWordReplacement("\\b(feminist|feminazi|SJW|social justice warrior)","empowered woman")
-	addWordReplacement("nigger","african american")
 	addWordReplacement("faggot","effeminate male")
 	addPickReplacement("fag", list("fig", "friend"))
 	addWordReplacement("tranny","felinid")

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -114,7 +114,7 @@
 
 /obj/machinery/cell_charger/attack_hand(mob/user)
 	if(charging)
-		if(emagged) //Oh shit nigger what are you doing
+		if(emagged)
 			spark(src, 5)
 			spawn(15)
 				explosion(src.loc, -1, 1, 3, adminlog = 0, whodunnit = user) //Overload

--- a/code/game/objects/items/devices/PDA/apps/general.dm
+++ b/code/game/objects/items/devices/PDA/apps/general.dm
@@ -142,7 +142,7 @@ var/global/list/currentevents3 = list("Border patrol around Space America has ti
 	"Renowned mime scientist Free Shrugs has discovered a new element today. He has named it '  ', he also says that it has the properties of '   '.",
 	"Archaeologists have discovered god's final message to his creation today. The message reads, 'bawk'.",
 	"Scientists have discovered a new type of elementary particle today. Our sources say it has a bad atitude, and enjoys the color blue.",
-	"Today, a man was discovered to be living with a 20 year old ghost in his house. When the ghost was questioned who killed him, he responded 'A FAGGOT!'. More at four.",
+	"Today, a man was discovered to be living with a 20 year old ghost in his house. When the ghost was questioned who killed him, he responded 'A Tarjan!'. More at four.",
 	"Scientists report that ghosts do in fact exist, however, they are huge assholes.",
 	"Supermatter researchers today have reported that the substance is highly volatile and could possibly rip apart the universe in large quantities. Discount Dan has been reported as ordering over 1000 pounds of supermatter shards.",
 	"Scientists working at the BPRF have discovered a pocket universe comprised fully of dead clown souls today. 40 scientists are being treated for madness."

--- a/code/game/objects/items/devices/PDA/apps/general.dm
+++ b/code/game/objects/items/devices/PDA/apps/general.dm
@@ -142,7 +142,7 @@ var/global/list/currentevents3 = list("Border patrol around Space America has ti
 	"Renowned mime scientist Free Shrugs has discovered a new element today. He has named it '  ', he also says that it has the properties of '   '.",
 	"Archaeologists have discovered god's final message to his creation today. The message reads, 'bawk'.",
 	"Scientists have discovered a new type of elementary particle today. Our sources say it has a bad atitude, and enjoys the color blue.",
-	"Today, a man was discovered to be living with a 20 year old ghost in his house. When the ghost was questioned who killed him, he responded 'A Tarjan!'. More at four.",
+	"Today, a man was discovered to be living with a 20 year old ghost in his house. When the ghost was questioned who killed him, he responded 'A Tajaran!'. More at four.",
 	"Scientists report that ghosts do in fact exist, however, they are huge assholes.",
 	"Supermatter researchers today have reported that the substance is highly volatile and could possibly rip apart the universe in large quantities. Discount Dan has been reported as ordering over 1000 pounds of supermatter shards.",
 	"Scientists working at the BPRF have discovered a pocket universe comprised fully of dead clown souls today. 40 scientists are being treated for madness."

--- a/code/game/objects/items/devices/PDA/apps/general.dm
+++ b/code/game/objects/items/devices/PDA/apps/general.dm
@@ -142,7 +142,7 @@ var/global/list/currentevents3 = list("Border patrol around Space America has ti
 	"Renowned mime scientist Free Shrugs has discovered a new element today. He has named it '  ', he also says that it has the properties of '   '.",
 	"Archaeologists have discovered god's final message to his creation today. The message reads, 'bawk'.",
 	"Scientists have discovered a new type of elementary particle today. Our sources say it has a bad atitude, and enjoys the color blue.",
-	"Today, a man was discovered to be living with a 20 year old ghost in his house. When the ghost was questioned who killed him, he responded 'A Tajaran!'. More at four.",
+	"Today, a man was discovered to be living with a 20 year old ghost in his house. When the ghost was questioned who killed him, he responded 'A BASTARD!'. More at four.",
 	"Scientists report that ghosts do in fact exist, however, they are huge assholes.",
 	"Supermatter researchers today have reported that the substance is highly volatile and could possibly rip apart the universe in large quantities. Discount Dan has been reported as ordering over 1000 pounds of supermatter shards.",
 	"Scientists working at the BPRF have discovered a pocket universe comprised fully of dead clown souls today. 40 scientists are being treated for madness."

--- a/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
+++ b/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
@@ -65,7 +65,7 @@
 	desc = "Releases a harmless blast that confuses most organics. For when the crime is JUST TOO MUCH"
 	alarm = "HALT! SECURITY!"
 	alarm_sound = 'sound/voice/halt.ogg'
-	emagged_alarm = "FUCK YOU SHIT EATING Bastard. EAT A DICK AND SHIT OUT ABORTIONS OF FUCK AND DO A SHIT IN YOUR ASS. FUCK SHIT MONKEY FUCK ASS WANKER FROM THE DEPTHS OF SHIT."
+	emagged_alarm = "FUCK YOU SHIT EATING BASTARD. EAT A DICK AND SHIT OUT ABORTIONS OF FUCK AND DO A SHIT IN YOUR ASS. FUCK SHIT MONKEY FUCK ASS WANKER FROM THE DEPTHS OF SHIT."
 	emagged_alarm_sound = 'sound/voice/binsult.ogg'
 	vary = FALSE
 

--- a/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
+++ b/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
@@ -65,7 +65,7 @@
 	desc = "Releases a harmless blast that confuses most organics. For when the crime is JUST TOO MUCH"
 	alarm = "HALT! SECURITY!"
 	alarm_sound = 'sound/voice/halt.ogg'
-	emagged_alarm = "FUCK YOU SHIT EATING Bastard. EAT A DICK AND SHIT OUT ABORTIONS OF FUCK AND DO A SHIT IN YOUR ASS. FUCK SHIT MONKEY FUCK ASS WANKER FROM THE DEPTHS OF SHIT.
+	emagged_alarm = "FUCK YOU SHIT EATING Bastard. EAT A DICK AND SHIT OUT ABORTIONS OF FUCK AND DO A SHIT IN YOUR ASS. FUCK SHIT MONKEY FUCK ASS WANKER FROM THE DEPTHS OF SHIT."
 	emagged_alarm_sound = 'sound/voice/binsult.ogg'
 	vary = FALSE
 

--- a/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
+++ b/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
@@ -65,7 +65,7 @@
 	desc = "Releases a harmless blast that confuses most organics. For when the crime is JUST TOO MUCH"
 	alarm = "HALT! SECURITY!"
 	alarm_sound = 'sound/voice/halt.ogg'
-	emagged_alarm = "FUCK YOUR CUNT YOU SHIT EATING COCKSUCKER MAN EAT A DONG FUCKING ASS RAMMING SHITFUCK. EAT PENISES IN YOUR FUCKFACE AND SHIT OUT ABORTIONS OF FUCK AND DO A SHIT IN YOUR ASS YOU COCK FUCK SHIT MONKEY FUCK ASS WANKER FROM THE DEPTHS OF SHIT."
+	emagged_alarm = "FUCK YOU Shitcurity,."
 	emagged_alarm_sound = 'sound/voice/binsult.ogg'
 	vary = FALSE
 

--- a/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
+++ b/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
@@ -65,7 +65,7 @@
 	desc = "Releases a harmless blast that confuses most organics. For when the crime is JUST TOO MUCH"
 	alarm = "HALT! SECURITY!"
 	alarm_sound = 'sound/voice/halt.ogg'
-	emagged_alarm = "FUCK YOU Shitcurity,."
+	emagged_alarm = "FUCK YOU SHIT EATING Bastard. EAT A DICK. FUCK SHIT MONKEY FUCK ASS WANKER FROM THE DEPTHS OF SHIT.
 	emagged_alarm_sound = 'sound/voice/binsult.ogg'
 	vary = FALSE
 

--- a/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
+++ b/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
@@ -65,7 +65,7 @@
 	desc = "Releases a harmless blast that confuses most organics. For when the crime is JUST TOO MUCH"
 	alarm = "HALT! SECURITY!"
 	alarm_sound = 'sound/voice/halt.ogg'
-	emagged_alarm = "FUCK YOU SHIT EATING Bastard. EAT A DICK. FUCK SHIT MONKEY FUCK ASS WANKER FROM THE DEPTHS OF SHIT.
+	emagged_alarm = "FUCK YOU SHIT EATING Bastard. EAT A DICK AND SHIT OUT ABORTIONS OF FUCK AND DO A SHIT IN YOUR ASS. FUCK SHIT MONKEY FUCK ASS WANKER FROM THE DEPTHS OF SHIT.
 	emagged_alarm_sound = 'sound/voice/binsult.ogg'
 	vary = FALSE
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1049,7 +1049,7 @@
 
 /obj/item/toy/gasha/snowflake
 	name = "toy snowflake"
-	desc = "What a faggot."
+	desc = "What a snowflake."
 	icon_state = "fag"
 
 /obj/item/toy/gasha/shade

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -177,7 +177,7 @@
 							h.equip_to_slot(kneesock,slot_shoes)
 							h.equip_to_slot(apron,slot_wear_suit)
 							h.equip_to_slot(kitty_ears,slot_head)
-							to_chat(user, "<span class=danger><B>You have been turned into a disgusting faggot! </span></B>")
+							to_chat(user, "<span class=danger><B>You have been turned into a disgusting furry! </span></B>")
 						if(3)
 							if(h.species.name != "Tajaran") // Catbeasts don't get to roll the dice and turn into monsters.
 								var/list/valid_species = (all_species - list("Krampus", "Horror"))

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -324,7 +324,7 @@
 		var/obj/item/weapon/pickaxe/PK = W
 		if(!(PK.diggables & DIG_WALLS))
 			return
-		if(mineral == "diamond") //Nigger it's a one meter thick wall made out of diamonds
+		if(mineral == "diamond")
 			return
 
 		user.visible_message("<span class='warning'>[user] begins [PK.drill_verb] straight into \the [src].</span>", \

--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -71,7 +71,7 @@
 		say(pick("IM A PONY NEEEEEEIIIIIIIIIGH", \
 		"without oxigen blob don't evoluate?", \
 		"CAPTAINS A COMDOM", \
-		"[pick("", "that faggot traitor")] [pick("joerge", "george", "gorge", "gdoruge")] [pick("mellens", "melons", "mwrlins")] is grifing me HAL;P!!!", \
+		"[pick("", "that traitor")] [pick("joerge", "george", "gorge", "gdoruge")] [pick("mellens", "melons", "mwrlins")] is grifing me HAL;P!!!", \
 		"can u give me [pick("telikesis","halk","eppilapse")]?", \
 		"THe saiyans screwed", \
 		"Bi is THE BEST OF BOTH WORLDS>", \

--- a/code/modules/research/xenoarchaeology/artifact/artifact_communication.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_communication.dm
@@ -3,7 +3,7 @@
 	desc = "There seems to be six slots capable of holding small crystals placed along its side."
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "communication"
-	stat = NOPOWER //Niggers you will wrench this shit down or else
+	stat = NOPOWER
 	density = 1
 	use_power = MACHINE_POWER_USE_IDLE
 	active_power_usage = 4000

--- a/maps/misc/riftbeach2.dmm
+++ b/maps/misc/riftbeach2.dmm
@@ -56,7 +56,7 @@
 /area/beach)
 "n" = (
 /mob/living/simple_animal/crab{
-	desc = "ARE YOU READY FOR THAT SLEEPOVER NIGGER? FUCK YEAH YOU ARE!";
+	desc = "ARE YOU READY FOR THAT SLEEPOVER? FUCK YEAH YOU ARE!";
 	icon_living = "Nicholson";
 	icon_state = "Nicholson";
 	name = "Crab Nicholson"

--- a/maps/misc/riftbeach3.dmm
+++ b/maps/misc/riftbeach3.dmm
@@ -123,7 +123,7 @@
 /area/beach)
 "L" = (
 /mob/living/simple_animal/crab{
-	desc = "ARE YOU READY FOR THAT SLEEPOVER NIGGER? FUCK YEAH YOU ARE!";
+	desc = "ARE YOU READY FOR THAT SLEEPOVER? FUCK YEAH YOU ARE!";
 	icon_living = "Nicholson";
 	icon_state = "Nicholson";
 	name = "Crab Nicholson"


### PR DESCRIPTION
## What this does
This removes/replaces all the words, that github flagged as being why our repository is tagged as objectionable content & one or two instances that would definitely get flagged if checked again,
See following list https://docs.google.com/document/d/1IGHR_zjGl_rtitNXuSGkY-TxOudgf9kPpKBAeAUOZps/edit

I did not remove the "Faggot" food, as I think this can be explained in an appeal as it's a real dish.

## Why it's good
The Github being private is terrible for community engagement with the codebase. People should not be forced to create an account just to see the changes being made. 
Anonymity is an important aspect of 4chan culture & should be maintained where possible.
This has virtually no impact whatsoever on the gameplay of the server, you can still say whatever you like in PR's, Comments & on server. 

There is no guarantee Github will accept any appeal based on these changes but TGstation was in a similar position a few years ago and once they removed what was requested they were promptly freed.
