### PR TITLE
Declassifies old exploit

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -3,7 +3,9 @@
 	~Sayu
 */
 
-//A workaround for a BYOND bug (or at least weird behavior). It's classified.
+//BYOND has a quirk (maybe bug?) where, if you initiate a clickdrag with one mouse button, any clicks with another button during the drag hit the object being dragged.
+//This allowed you to, for example, start a middle-click drag on someone and then have an aimbot that allows you to effortlessly hit them in melee or ranged combat as long as you held MMB.
+//This code discards clicks performed during a drag to prevent this.
 /client/Click(object, location, control, params)
 	var/list/p = params2list(params)
 	if(p["drag"])


### PR DESCRIPTION
#19887
This exploit hasn't actually been exploitable for a long time now. It was kept secret at the time
1. To give other servers a chance to fix it
2. Because, at the time, it was actually possible to circumvent the fix by using older client versions from before the `drag` parameter was added. Those versions are now too outdated to even connect to the server (and probably have been for years).

I'm declassifying it because it can definitely no longer be exploited here (without a hacked client, which wouldn't need this exploit to have an aimbot), and if any other server has somehow not yet fixed it, they've had almost five years to do so.