### PR TITLE
Salmonistasty addition of fartCooldown variable 

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -144,7 +144,7 @@
 			H.visible_message("<span class = 'warning'><b>[H]</b> unleashes a [pick("tremendous","gigantic","colossal")] fart!</span>","<span class = 'warning'>You hear a [pick("tremendous","gigantic","colossal")] fart.</span>")
 			playsound(location, 'sound/effects/superfart.ogg', 50, 0)
 			for(var/mob/living/V in oviewers(aoe_range, get_turf(H)))
-				if(!airborne_can_reach(location,get_turf(V),aoe_range))
+				if(world.time - H.lastFart <= (H.disabilities & LACTOSE ? fartCooldown : fartCooldown  * 2))
 					continue
 				shake_camera(V,10,5)
 				if (V == H)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -3,7 +3,7 @@
 	name = "unknown"
 	real_name = "unknown"
 	voice_name = "unknown"
-	fartCooldown = 20 SECONDS
+	var/fartCooldown = 20 SECONDS
 	icon = 'icons/mob/human.dmi'
 	icon_state = "body_m_s"
 	can_butcher = 1

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -3,6 +3,7 @@
 	name = "unknown"
 	real_name = "unknown"
 	voice_name = "unknown"
+	fartCooldown = 20 SECONDS
 	icon = 'icons/mob/human.dmi'
 	icon_state = "body_m_s"
 	can_butcher = 1

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -3,7 +3,7 @@
 	name = "unknown"
 	real_name = "unknown"
 	voice_name = "unknown"
-	var/fartCooldown = 20 SECONDS
+	var/fartCooldown = 20 SECONDS	//To finally be able to make the clown fart 
 	icon = 'icons/mob/human.dmi'
 	icon_state = "body_m_s"
 	can_butcher = 1


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
[administration] [qol] [help] [dnm]

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Adds a variable "var/fartCooldown " to human.dm to line 6
Changes line 147 in emote.dm to " if(world.time - H.lastFart <= (H.disabilities & LACTOSE ? fartCooldown : fartCooldown  * 2)) "

## Why it's good
<!-- Explain why you think these changes are good. -->
Lets admins to ~abuse~ bus players more. (Clown farting constantly)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * experiment: Added an experimental variable.

