### PR TITLE
Adds late-compile secrets file

### DIFF
--- a/code/~secrets/~secrets.dm
+++ b/code/~secrets/~secrets.dm
@@ -1,0 +1,1 @@
+//A file for including things on the secret repo that must come late in compile order. Overrides, most notably.

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2855,6 +2855,7 @@
 #include "code\ZAS\XGM.dm"
 #include "code\ZAS\XGM_gases.dm"
 #include "code\ZAS\Zone.dm"
+#include "code\~secrets\~secrets.dm"
 #include "goon\code\datums\browserOutput.dm"
 #include "goon\code\obj\machinery\bot\chefbot.dm"
 #include "interface\interface.dm"


### PR DESCRIPTION
What it says in the file. This is useful for various secret repo stuff.
The folder is necessary. It wouldn't be late in the compile order without it.