### PR TITLE
fix e-swords with pre-determined colors

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -95,7 +95,8 @@
 
 /obj/item/weapon/melee/energy/sword/New()
 	..()
-	_color = pick("red","blue","green","purple")
+	if(!_color)
+		_color = pick("red","blue","green","purple")
 	if(!active_state)
 		active_state = base_state + _color
 	update_icon()

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -203,12 +203,12 @@
 //Most of the other special functions are handled in their own files.
 
 /obj/item/weapon/melee/energy/sword/green/New()
-	..()
 	_color = "green"
+	..()
 
 /obj/item/weapon/melee/energy/sword/red/New()
-	..()
 	_color = "red"
+	..()
 
 /*
  * Energy Axe


### PR DESCRIPTION
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Energy swords meant to have a pre-determined color now work correctly.
