### PR TITLE
Makes using the vampire "silent bite" actually silent

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -173,7 +173,8 @@
 	log_attack("[key_name(assailant)] bit [key_name(target)] in the neck")
 
 	to_chat(antag.current, "<span class='danger'>You latch on firmly to \the [target]'s neck.</span>")
-	target.show_message("<span class='userdanger'>\The [assailant] latches on to your neck!</span>")
+	if(!silentbite)
+		target.show_message("<span class='userdanger'>\The [assailant] latches on to your neck!</span>")
 
 	if(!iscarbon(assailant))
 		target.LAssailant = null


### PR DESCRIPTION
It's not actually a "silent bite" if it gives a giant red message in chat to the victim.

## Why it's good
This ability is completely worthless otherwise.
If people think this is too powerful then there's several ways to balance it, namely:
- having a percent chance it shows a victim to the message, multiplied by vampire maturity
- halving the benefit of maturity on reducing the silent bite case time (currently 30 seconds divided by maturity tier)

I haven't implemented either of those balance changes as of writing I'd like to see what people think first.

[balance][tweak]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Victims of the vampire's silent bite no longer get a giant red message in chat telling them that they've been bitten.
