### PR TITLE
Better Library Database

### DIFF
--- a/code/modules/library/computers/checkout.dm
+++ b/code/modules/library/computers/checkout.dm
@@ -266,6 +266,9 @@
 
 		screenstate = 4
 	if(href_list["del"])
+		if(!allowed(usr))
+			to_chat(usr,"<span class='warning'>You do not have access to make deletion requests.</span>")
+			return
 		if(!isAdminGhost(usr)) //old: !usr.check_rights(R_ADMIN)
 			to_chat(usr, "<span class='notice'>Your deletion request has been transmitted to Central Command.</span>")
 			request_delete_book(getBookByID(href_list["del"]),usr)


### PR DESCRIPTION
Thank you to Shifty for testing this

🆑 
* rscadd: The librarian can now request the removal of a book from the library database with a button. Do your civic duty and delete the garbage.
* rscadd: Librarians and admins can now preview a book in the database without ordering it.
* bugfix: Books should not briefly flash a different cover when first ordered from the checkout computer.