### PR TITLE
message in deadchat when player dies, handle deadchat slightly better

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -26,6 +26,11 @@
 		return null
 	return format_text ? format_text(A.name) : A.name
 
+/proc/get_coordinates_string(var/atom/A)
+	var/turf/T = get_turf(A)
+	return A.loc ? "[T.x],[T.y],[T.z]" : "nullspace"
+
+
 /proc/in_range(atom/source, mob/user)
 	if(source.Adjacent(user))
 		return 1

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -28,7 +28,7 @@
 
 /proc/get_coordinates_string(var/atom/A)
 	var/turf/T = get_turf(A)
-	return A.loc ? "[T.x],[T.y],[T.z]" : "nullspace"
+	return T ? "[T.x],[T.y],[T.z]" : "nullspace"
 
 
 /proc/in_range(atom/source, mob/user)

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -39,7 +39,7 @@
 	living_mob_list -= src
 	dead_mob_list += src
 	stat_collection.add_death_stat(src)
-	if (runescape_skull_display && ticker)//we died, begone skull
+	if(runescape_skull_display && ticker)//we died, begone skull
 		if ("\ref[src]" in ticker.runescape_skulls)
 			var/datum/runescape_skull_data/the_data = ticker.runescape_skulls["\ref[src]"]
 			ticker.runescape_skulls -= "\ref[src]"
@@ -55,6 +55,11 @@
 			spell_master.on_holder_death(src)
 	if(transmogged_from)
 		transmog_death()
+	if(client || mind)
+		for(var/mob/M in get_deadchat_hearers())
+			var/rendered = "\proper<a href='?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>(Follow)</a><span class='game deadsay'> \The <span class='name'>[src]</span> has died at \the <span class='name'>[get_area(src)]</span>.</span>"
+			to_chat(M, rendered)
+			log_game("[key_name(src)], played by has died at [get_area(src)]. Coordinates: ([get_coordinates_string(src)])")
 
 /mob/proc/transmog_death()
 	var/obj/transmog_body_container/C = transmogged_from

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -59,7 +59,7 @@
 		for(var/mob/M in get_deadchat_hearers())
 			var/rendered = "\proper<a href='?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>(Follow)</a><span class='game deadsay'> \The <span class='name'>[src]</span> has died at \the <span class='name'>[get_area(src)]</span>.</span>"
 			to_chat(M, rendered)
-			log_game("[key_name(src)], played by has died at [get_area(src)]. Coordinates: ([get_coordinates_string(src)])")
+			log_game("[key_name(src)] has died at [get_area(src)]. Coordinates: ([get_coordinates_string(src)])")
 
 /mob/proc/transmog_death()
 	var/obj/transmog_body_container/C = transmogged_from

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -66,36 +66,24 @@ var/list/global_deadchat_listeners = list()
 	if(name != real_name)
 		alt_name = " (died as [real_name])"
 
-
-	var/turf/T = get_turf(src)
 	var/ckey = "[key_name(src)]"
 	for(var/datum/deadchat_listener/listener in global_deadchat_listeners)
 		listener.deadchat_event(ckey,message)
 	message = src.say_quote("\"[html_encode(message)]\"")
-	var/location_text = loc ? "[T.x],[T.y],[T.z]" : "nullspace"
+	var/location_text = get_coordinates_string(src)
 	log_say("[name]/[key_name(src)] (@[location_text]) Deadsay: [message]")
 
-	for(var/mob/M in player_list)
-		if(!M.client)
-			continue
-		if(istype(M, /mob/new_player))
-			continue
-			
-		var/datum/role/vampire/V = isvampire(M)
-		if(V && V.deadchat)
-			var/rendered = "<span class='game deadsay'><span class='name'> [name]</span>[alt_name] <span class='message'>[message]</span></span>"
-			to_chat(M, rendered)
-		else if(M.client.prefs.toggles & CHAT_DEAD)
-			var/rendered = "<span class='game deadsay'><a href='byond://?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>(Follow)</a>"
-			rendered += "<span class='name'> [name]</span>[alt_name] <span class='message'>[message]</span></span>"
-			if(M.client.holder && M.client.holder.rights & R_ADMIN) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only give to Administrators and above
-				to_chat(M, rendered)//Admins can hear deadchat, if they choose to, no matter if they're blind/deaf or not.
-			else if(M.stat == DEAD && !istype(M, /mob/dead/observer/deafmute))
+	var/list/hearers = get_deadchat_hearers()
+	if(hearers)
+		for(var/mob/M in hearers)
+			if(isvampire(M))
+				var/rendered = "<span class='game deadsay'><span class='name'> [name]</span>[alt_name] <span class='message'>[message]</span></span>"
 				to_chat(M, rendered)
-			else if(istype(M,/mob/living/carbon/brain))
-				var/mob/living/carbon/brain/B = M
-				if(B.brain_dead_chat())
-					to_chat(M, rendered)
+				continue
+			else
+				var/rendered = "<span class='game deadsay'><a href='byond://?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>(Follow)</a>"
+				rendered += "<span class='name'> [name]</span>[alt_name] <span class='message'>[message]</span></span>"
+				to_chat(M, rendered)
 
 /mob/proc/get_ear()
 	// returns an atom representing a location on the map from which this

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -291,7 +291,6 @@ For the main html chat area
 				continue
 			to_chat(M, message)
 		return
-
 	if (istype(message, /image) || istype(message, /sound) || istype(target, /savefile) || !(ismob(target) || islist(target) || isclient(target) || istype(target, /datum/log) || target == world))
 
 		target << message
@@ -337,5 +336,43 @@ For the main html chat area
 
 		target << output(url_encode(message), "browseroutput:output")
 
+/proc/get_deadchat_hearers()
+	var/list/hearers = list()
+	for(var/mob/M in player_list)
+		if(!M.client)
+			continue
+		if(istype(M, /mob/new_player))
+			continue
+
+		var/datum/role/vampire/V = isvampire(M)
+		if(V && V.deadchat)
+			hearers += M
+			continue
+		else if(M.client.prefs.toggles & CHAT_DEAD)
+			if(M.client.holder && M.client.holder.rights & R_ADMIN) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only give to Administrators and above
+				hearers += M
+				continue
+			else if(M.stat == DEAD && !istype(M, /mob/dead/observer/deafmute))
+				hearers += M
+				continue
+			else if(istype(M,/mob/living/carbon/brain))
+				var/mob/living/carbon/brain/B = M
+				if(B.brain_dead_chat())
+					hearers += M
+					continue
+	. = hearers
+	return .
+
+/* This proc only handles sending the message to everyone who can hear deadchat. Formatting that message is up to you! Consider using <span class='game deadsay'></span> on your message! */
+/* Kinda useless if your message needs to include an href, though... */
+/proc/to_deadchat(message)
+	var/list/hearers = get_deadchat_hearers()
+	if(!hearers || !message)
+		return
+	for(var/mob/M in hearers)
+		to_chat(M, message)
+	log_game("DEADCHAT: [message]")
+	return 1
+		
 /datum/log	//exists purely to capture to_chat() output
 	var/log = ""


### PR DESCRIPTION
Oyasumi, Valentyn-tan.

## What this does
Players (or mobs that have minds, having been formerly controlled by a player), now give a message in chat when they die.
Looks like this:
![image](https://github.com/vgstation-coders/vgstation13/assets/26285377/2071ce77-7e8e-4be9-bf9a-7510ef240ac1)

I also improved how deadsay works, and added a proc to message deadchat only. This proc is currently unused as it doesn't ever quite make sense to use it if your message has an href... but hey, it's there. Also added a helper proc for getting coordinates.

Finally, I added logging for [administration] to see when exactly someone died, which is probably a lot more clear to admins than what we had before, which is just logging for when a mob calls `Logout()`.
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Deadchat is now notified when and where a player dies, with an option to jump to that player's location.