### PR TITLE
Cleaner World Log at Startup

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -293,7 +293,7 @@
 		if(M.client || istype(M, /mob/living/captive_brain)) //Ignore the mob if it has a client or is a "captive brain" (borer nonsense)
 			continue
 		sorted_output.Add(M)
-		
+
 	return sorted_output
 
 // Finds ALL mobs on turfs in line of sight. Similar to "in dview", but catches mobs that are not on a turf (e.g. inside a locker or such).
@@ -1515,7 +1515,6 @@ Game Mode config tags:
 				continue
 			taken_freqs.Add(chosen_freq)
 			freqs[i] = chosen_freq
-			world.log << "Radio frequency [i] is now [chosen_freq]"
 			freq_found = TRUE
 
 	freqtospan = list(
@@ -1653,7 +1652,7 @@ Game Mode config tags:
 				if(draw_red)
 					T.color = "red"
 					sleep(5)
-		
+
 		y = epicenter.y + c_dist - 1
 		x = epicenter.x + c_dist
 		for(y in y to epicenter.y-c_dist step -1)

--- a/code/controllers/mc/subsystem.dm
+++ b/code/controllers/mc/subsystem.dm
@@ -157,7 +157,6 @@
 	var/time = (world.timeofday - start_timeofday) / 10
 	var/msg = "Initialized [name] subsystem within [time] seconds!"
 	log_debug(msg,FALSE) // Redundant chat output as whole world sees message below anyways
-	world.log << msg
 	to_chat(world, "<span class='danger'>[msg]</span>")
 	initialized = TRUE
 	return time

--- a/code/controllers/subsystem/init/map.dm
+++ b/code/controllers/subsystem/init/map.dm
@@ -34,21 +34,17 @@ var/datum/subsystem/map/SSmap
 	if (rand(1,3) == 3)
 		generate_hoboshack()
 
-	log_startup_progress("Calling post on zLevels, letting them know they can do zlevel specific stuff...")
 	var/watch_prim = start_watch()
 	for(var/datum/zLevel/z in map.zLevels)
-		log_startup_progress("Generating zLevel [z.z].")
 		var/watch = start_watch()
 		z.post_mapload()
-		log_startup_progress("Finished with zLevel [z.z] in [stop_watch(watch)]s.")
-	log_startup_progress("Finished calling post on zLevels in [stop_watch(watch_prim)]s.")
+		log_debug("Finished with zLevel [z.z] in [stop_watch(watch)]s.", FALSE)
+	log_debug("Finished calling post on zLevels in [stop_watch(watch_prim)]s.", FALSE)
 
 	var/watch = start_watch()
-	log_startup_progress("Starting map-specific inits...")
 	map.map_specific_init()
-	log_startup_progress("Finished map-specific inits in [stop_watch(watch)]s.")
+	log_debug("Finished map-specific inits in [stop_watch(watch)]s.", FALSE)
 
-	log_startup_progress("Creating pickspawners...")
 	spawn_map_pickspawners() //this is down here so that it calls after allll the vaults etc are done spawning - if in the future some pickspawners don't fire, it's because this needs moving
 
 	..()

--- a/code/controllers/subsystem/init/more_init_stuff.dm
+++ b/code/controllers/subsystem/init/more_init_stuff.dm
@@ -18,20 +18,17 @@ var/datum/subsystem/more_init/SSmore_init
 	setup_news()
 
 	var/watch=start_watch()
-	log_startup_progress("Caching damage icons...")
 	cachedamageicons()
-	log_startup_progress("  Finished caching damage icons in [stop_watch(watch)]s.")
+	log_debug("  Finished caching damage icons in [stop_watch(watch)]s.", FALSE)
 
 	watch=start_watch()
-	log_startup_progress("Caching space parallax simulation...")
 	create_global_parallax_icons()
-	log_startup_progress("  Finished caching space parallax simulation in [stop_watch(watch)]s.")
+	log_debug("  Finished caching space parallax simulation in [stop_watch(watch)]s.", FALSE)
 
 	if (!config.skip_minimap_generation)
 		watch=start_watch()
-		log_startup_progress("Generating holominimaps...")
 		generateHoloMinimaps()
-		log_startup_progress("  Finished holominimaps in [stop_watch(watch)]s.")
+		log_debug("  Finished holominimaps in [stop_watch(watch)]s.", FALSE)
 	else
 		//holomaps_initialized = 1 //Assume holominimaps were prerendered, the worst thing that happens if they're missing is that the minimap consoles don't show a minimap - NO IT'S NOT YOU DUMBFUCK, THOSE VARS EXIST FOR A REASON
 		log_startup_progress("Not generating holominimaps - SKIP_HOLOMINIMAP_GENERATION found in config/config.txt")
@@ -39,13 +36,11 @@ var/datum/subsystem/more_init/SSmore_init
 
 	if(config.media_base_url)
 		watch = start_watch()
-		log_startup_progress("Caching jukebox playlists...")
 		load_juke_playlists()
-		log_startup_progress("  Finished caching jukebox playlists in [stop_watch(watch)]s.")
+		log_debug("  Finished caching jukebox playlists in [stop_watch(watch)]s.", FALSE)
 	..()
 
 	watch=start_watch()
-	log_startup_progress("Doing the other misc. initializations...")
 	process_teleport_locs()				//Sets up the wizard teleport locations
 	process_ghost_teleport_locs()		//Sets up ghost teleport locations.
 	process_adminbus_teleport_locs()	//Sets up adminbus teleport locations.
@@ -57,7 +52,7 @@ var/datum/subsystem/more_init/SSmore_init
 	CHECK_TICK
 	centcomm_store = new
 	create_randomized_reagents()
-	log_startup_progress("Finished doing the other misc. initializations in [stop_watch(watch)]s.")
+	log_debug("Finished doing the other misc. initializations in [stop_watch(watch)]s.", FALSE)
 
 /proc/cache_machinery_components_rating()
 	var/list/cache = list()

--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -813,10 +813,7 @@
 		AM.map_element_rotate(rotate)
 
 /proc/setup_shuttles()
-	world.log << "Setting up all shuttles..."
 
-	var/all_count = 0
-	var/count = 0
 	for(var/datum/shuttle/S in shuttles)
 		switch(S.initialize())
 			if(INIT_NO_AREA)
@@ -836,19 +833,13 @@
 					warning("[S.name] ([S.type]) couldn't connect to a destination port on init - unless this is intended, there might be problems.")
 				else
 					world.log << "[S.name] ([S.type]) couldn't connect to a destination port on init - unless this is intended, there might be problems."
-			else
-				count++
-		all_count++
 
-	world.log << "[all_count] shuttles initialized, of them [count] were initialized properly."
 
 	//THE MOST IMPORTANT PIECE OF CODE HERE
 	emergency_shuttle.shuttle = escape_shuttle
 
 	if(!emergency_shuttle || !emergency_shuttle.shuttle)
 		warning("Emergency shuttle is broken.")
-	else
-		world.log << "Emergency shuttle has been successfully set up."
 
 //Custom shuttles
 /datum/shuttle/custom

--- a/code/modules/admin/banappearance.dm
+++ b/code/modules/admin/banappearance.dm
@@ -55,7 +55,6 @@ DEBUG
 			log_admin("appearance_keylist was empty")
 	else
 		if(!SSdbcore.Connect())
-			world.log << "Database connection failed. Reverting to the legacy ban system."
 			diary << "Database connection failed. Reverting to the legacy ban system."
 			config.ban_legacy_system = 1
 			appearance_loadbanfile()

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -63,7 +63,6 @@ DEBUG
 			log_admin("jobban_keylist was empty")
 	else
 		if(!SSdbcore.Connect())
-			world.log << "Database connection failed. Reverting to the legacy ban system."
 			diary << "Database connection failed. Reverting to the legacy ban system."
 			config.ban_legacy_system = 1
 			jobban_loadbanfile()

--- a/code/modules/admin/banooc.dm
+++ b/code/modules/admin/banooc.dm
@@ -12,7 +12,6 @@ var/oocban_keylist[0]
 
 /proc/oocban_loadbanfile()
 	if(!SSdbcore.Connect())
-		world.log << "Database connection failed. Skipping ooc ban loading"
 		diary << "Database connection failed. Skipping ooc ban loading"
 		return
 

--- a/code/modules/admin/banpax.dm
+++ b/code/modules/admin/banpax.dm
@@ -12,7 +12,6 @@ var/paxban_keylist[0]
 
 /proc/paxban_loadbanfile()
 	if(!SSdbcore.Connect())
-		world.log << "Database connection failed. Skipping pax ban loading"
 		diary << "Database connection failed. Skipping pax ban loading"
 		return
 

--- a/code/modules/html_interface/map/interactive_map.dm
+++ b/code/modules/html_interface/map/interactive_map.dm
@@ -83,10 +83,6 @@ var/const/ALLOW_CENTCOMM = FALSE
 	var/current_git_hash = trim(return_revision())
 	var/delete_cache = !last_git_hash || !current_git_hash || last_git_hash != current_git_hash
 
-	if(delete_cache)
-		testing("MINIMAP: Deleting outdated cached minimaps")
-	else
-		testing("MINIMAP: Will attempt to use cached minimaps")
 	for (var/z = 1 to world.maxz)
 		if(z == map.zCentcomm && !ALLOW_CENTCOMM)
 			continue
@@ -94,10 +90,8 @@ var/const/ALLOW_CENTCOMM = FALSE
 			fdel("[getMinimapFile(z)].png")
 		generateMiniMap(z)
 
-	testing(fdel(last_git_hash_path))
 	text2file(current_git_hash, last_git_hash_path)
 
-	testing("MINIMAP: All minimaps have been generated.")
 	minimapinit = 1
 	// some idiot put HTML asset sending here.  In a spawn.  After a long wait for minimap generation.
 	// Dear Idiot: don't do that anymore.

--- a/code/modules/migrations/migration_controller.dm
+++ b/code/modules/migrations/migration_controller.dm
@@ -42,7 +42,7 @@
 				pack[M.id] = M
 				//world.log << "\[Migrations] [pkgID]#[M.id] = [M.type] - [M.name]"
 			packages[pkgID]=pack
-			world.log << "\[Migrations] Loaded [pack.len] [id] DB migrations from package [pkgID]."
+			log_debug("\[Migrations] Loaded [pack.len] [id] DB migrations from package [pkgID].", FALSE)
 		//VersionCheck()
 		UpdateAll()
 

--- a/code/modules/mob/living/carbon/human/life/handle_environment.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_environment.dm
@@ -10,7 +10,6 @@
 	//Body temperature is adjusted in two steps. Firstly your body tries to stabilize itself a bit.
 	if(stat != DEAD)
 		handle_body_temperature()
-		//log_debug("Adjusting to atmosphere.")
 
 	//After then, it reacts to the surrounding atmosphere based on your thermal protection
 	if(!on_fire) //If you're on fire, you do not heat up or cool down based on surrounding gases


### PR DESCRIPTION
Just a pet annoyance, there are tons of testing outputs that definitely do not need to be output onto world.log and probably should have been removed before the thing they were testing was merged. This makes things much cleaner when you boot up a local server.