### PR TITLE
AI's are no longer forced to attach images to a PDA message

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -427,6 +427,10 @@
 		for(var/datum/picture/t in aicamera.aipictures)
 			nametemp += t.fields["name"]
 		var/find = input("Select image") as null|anything in nametemp
+		if(!find)
+			message_app.create_message(src, selected)
+			aiPDA.photo = null
+			return
 		for(var/datum/picture/q in aicamera.aipictures)
 			if(q.fields["name"] == find)
 				aiPDA.photo = new /obj/item/weapon/photo(aiPDA)

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -419,10 +419,14 @@
 	var/selected = plist[c]
 
 	if(aicamera.aipictures.len)
+		if(alert("Would you like to attach photo to this message?", "Add Photo Attachment?", "Yes", "No") == "No")
+			message_app.create_message(src, selected)
+			aiPDA.photo = null
+			return
 		var/list/nametemp = list()
 		for(var/datum/picture/t in aicamera.aipictures)
 			nametemp += t.fields["name"]
-		var/find = input("Select image") in nametemp
+		var/find = input("Select image") as null|anything in nametemp
 		for(var/datum/picture/q in aicamera.aipictures)
 			if(q.fields["name"] == find)
 				aiPDA.photo = new /obj/item/weapon/photo(aiPDA)


### PR DESCRIPTION
## What this does
Currently, AI's that possess photos MUST attach them to a PDA message. This sucks! I fixed it.
Fixes #31736
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: AI's are no longer forced to attach images to a PDA message