### PR TITLE
fix arcane tampered atoms not being cleared on wiz death

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -403,7 +403,6 @@ var/list/all_doors = list()
 /obj/machinery/door/bless()
 	..()
 	if(arcane_linked_door)
-		arcane_linked_door.bless()
 		arcane_linked_door = null
 		if(!density)
 			set_opacity(0)


### PR DESCRIPTION
Fixes #34422
Credit to Kanef for the fix.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Arcane Tampering is now properly cleared from all objects when a wizard dies.
