### PR TITLE
Giving mobs the means of punching, hitting, and slashing Blobs

### DIFF
--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -156,7 +156,6 @@ var/list/blob_overminds = list()
 /obj/effect/blob/process()
 	handle_beams()
 	Life()
-	return
 
 /obj/effect/blob/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()
@@ -171,7 +170,6 @@ var/list/blob_overminds = list()
 	health -= ((damage/brute_resist) - (severity * 5))
 	update_health()
 	update_icon()
-	return
 
 /obj/effect/blob/bullet_act(var/obj/item/projectile/Proj, var/def_zone, var/damage_override = null)
 	. = ..()
@@ -184,7 +182,6 @@ var/list/blob_overminds = list()
 
 	update_health()
 	update_icon()
-	return
 
 /obj/effect/blob/attackby(var/obj/item/weapon/W, var/mob/living/user)
 	user.do_attack_animation(src, W)
@@ -203,7 +200,82 @@ var/list/blob_overminds = list()
 	health -= damage
 	update_health()
 	update_icon()
-	return
+
+/obj/effect/blob/bullet_act(var/obj/item/projectile/Proj, var/def_zone, var/damage_override = null)
+	. = ..()
+	var/damage = isnull(damage_override) ? Proj.damage : damage_override
+	switch(Proj.damage_type)
+		if(BRUTE)
+			health -= (damage/brute_resist)
+		if(BURN)
+			health -= (damage/fire_resist)
+
+	update_health()
+	update_icon()
+
+/obj/effect/blob/hitby(var/atom/movable/AM,var/speed = 5)
+	if(isitem(AM))
+		var/obj/item/I = AM
+		var/damage = I.throwforce*speed/5
+		switch(I.damtype)
+			if(BRUTE)
+				health -= (damage/brute_resist)
+				playsound(src, 'sound/effects/attackblob.ogg', 50, 1)
+			if(BURN)
+				health -= (damage/fire_resist)
+				playsound(src, 'sound/effects/blobweld.ogg', 100, 1)
+		update_health()
+		update_icon()
+
+/obj/effect/blob/attack_animal(var/mob/living/simple_animal/user)
+	user.delayNextAttack(8)
+	user.do_attack_animation(src, user)
+	user.visible_message("<span class='danger'>\The [user] [user.attacktext] \the [src].</span>")
+	switch(user.melee_damage_type)
+		if (BRUTE)
+			health -= (user.get_unarmed_damage(src)/brute_resist)
+			playsound(src, 'sound/effects/attackblob.ogg', 50, 1)
+		if (BURN)
+			health -= (user.get_unarmed_damage(src)/fire_resist)
+			playsound(src, 'sound/effects/blobweld.ogg', 100, 1)
+	update_health()
+	update_icon()
+
+/obj/effect/blob/attack_hand(var/mob/living/carbon/human/user)
+	if (user.a_intent == I_HURT)
+		user.delayNextAttack(8)
+		user.do_attack_animation(src, user)
+		var/datum/species/S = user.get_organ_species(user.get_active_hand_organ())
+		user.visible_message("<span class='danger'>\The [user] [S.attack_verb] \the [src].</span>")
+		health -= (user.get_unarmed_damage(src)/brute_resist)
+		playsound(src, 'sound/effects/attackblob.ogg', 50, 1)
+		update_health()
+		update_icon()
+
+/obj/effect/blob/attack_paw(var/mob/living/carbon/monkey/user)
+	if (user.a_intent == I_HURT)
+		if(user.wear_mask?.is_muzzle)
+			to_chat(user, "<span class='notice'>You can't do this with \the [user.wear_mask] on!</span>")
+			return
+		user.delayNextAttack(8)
+		user.do_attack_animation(src, user)
+		user.visible_message("<span class='danger'>\The [user] [user.attacktext] \the [src].</span>")
+		health -= (user.get_unarmed_damage(src)/brute_resist)
+		playsound(src, 'sound/effects/attackblob.ogg', 50, 1)
+		update_health()
+		update_icon()
+
+/obj/effect/blob/attack_alien(var/mob/living/carbon/alien/humanoid/user)
+	if(istype(user, /mob/living/carbon/alien/larva))
+		return
+	user.delayNextAttack(8)
+	user.do_attack_animation(src, user)
+	var/alienverb = pick(list("slam", "rip", "claw"))
+	user.visible_message("<span class='warning'>[user] [alienverb]s \the [src].</span>")
+	health -= (rand(15,30)/brute_resist)
+	playsound(src, 'sound/effects/attackblob.ogg', 50, 1)
+	update_health()
+	update_icon()
 
 /obj/effect/blob/update_icon(var/spawnend = 0)
 	if(icon_size == 64)

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -259,7 +259,7 @@ var/list/blob_overminds = list()
 			return
 		user.delayNextAttack(8)
 		user.do_attack_animation(src, user)
-		user.visible_message("<span class='danger'>\The [user] [user.attacktext] \the [src].</span>")
+		user.visible_message("<span class='danger'>\The [user] [user.attack_text] \the [src].</span>")
 		health -= (user.get_unarmed_damage(src)/brute_resist)
 		playsound(src, 'sound/effects/attackblob.ogg', 50, 1)
 		update_health()


### PR DESCRIPTION
![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/8a54dfea-5904-4ce9-a88a-762cc6dd61bb)

:cl:
* rscadd: Mobs can now attack blob tiles empty handed. Obviously puny humans won't do much damage at all given its inherent resistance to brute damage, but at least this allow mobs like aliums and constructs to do decent damage to the blob. Blob tiles also now take damage from thrown objects.