### PR TITLE
Fix some anims ending early

### DIFF
--- a/code/game/turfs/turf_flick_animations.dm
+++ b/code/game/turfs/turf_flick_animations.dm
@@ -28,7 +28,7 @@
 //Does not require sleeptime, specifies for how long the animation should be allowed to exist before returning to pool
 //Does not require animation direction, but you can specify
 //Does not require a name
-/proc/anim(turf/location as turf,target as mob|obj,a_icon,a_icon_state as text,flick_anim as text,sleeptime = 0,direction as num, name as text, lay as num, offX as num, offY as num, col as text, alph as num,plane as num, var/trans, var/invis, var/animate_movement)
+/proc/anim(turf/location as turf,target as mob|obj,a_icon,a_icon_state as text,flick_anim as text,sleeptime = 15,direction as num, name as text, lay as num, offX as num, offY as num, col as text, alph as num,plane as num, var/trans, var/invis, var/animate_movement)
 //This proc throws up either an icon or an animation for a specified amount of time.
 //The variables should be apparent enough.
 	if(!location && target)


### PR DESCRIPTION
caused by #34399

:cl:
* bugfix: Fixed some animations (such as the cult teleport animations) ending about a second earlier than they should.