### PR TITLE
allow full-tile windows to be alt clicked just like everything else

### DIFF
--- a/code/game/objects/structures/fullwindow.dm
+++ b/code/game/objects/structures/fullwindow.dm
@@ -32,6 +32,14 @@
 /obj/structure/window/full/setup_border_dummy()
 	return
 
+/obj/structure/window/full/AltClick(mob/user)
+	var/turf/T = get_turf(src)
+	if(T && (T in range(1, user.loc)) && (T in view(1, user.virtualhearer))) //If next to user's location (to allow locker and mech alt-clicks) and if the user can actually view it
+		if(user.listed_turf == T)
+			user.listed_turf = null
+		else
+			user.listed_turf = T
+			user.client.statpanel = T.name
 
 /obj/structure/window/full/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 	if(istype(mover) && mover.checkpass(pass_flags_self))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -90,9 +90,6 @@ var/list/one_way_windows
 	examine_health(user)
 
 /obj/structure/window/AltClick(mob/user)
-	if(isfullwindow(src)) //We want these to be alt-clickable as it's very useful for building and they can't be rotated anyway
-		..()
-		return
 	if(user.incapacitated() || !Adjacent(user))
 		return
 	rotate()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -92,6 +92,7 @@ var/list/one_way_windows
 /obj/structure/window/AltClick(mob/user)
 	if(isfullwindow(src)) //We want these to be alt-clickable as it's very useful for building and they can't be rotated anyway
 		..()
+		return
 	if(user.incapacitated() || !Adjacent(user))
 		return
 	rotate()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -90,6 +90,8 @@ var/list/one_way_windows
 	examine_health(user)
 
 /obj/structure/window/AltClick(mob/user)
+	if(isfullwindow(src)) //We want these to be alt-clickable as it's very useful for building and they can't be rotated anyway
+		..()
 	if(user.incapacitated() || !Adjacent(user))
 		return
 	rotate()


### PR DESCRIPTION
~~Kind of a stupid way to do this, but I don't know if `call()` on /obj/structure/window/full would be any better? (Or if it even works that way...)~~ Just copied the proc from `/atom/proc/AltClick()` onto full windows.
Fixes #34180
## What this does
You can now alt-click full windows, useful for getting that last directional window in when building.
Thanks to Inorien for pointing out that `isfullwindow()` is an actual macro that exists (lol)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Full windows can now be alt-clicked to see the contents of the tile, just like all other stuff.
