### PR TITLE
fix pda pinpointer displaying negative values for next pda scan

### DIFF
--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -265,7 +265,8 @@ var/list/pinpointerpinpointer_list = list()
 
 /obj/item/weapon/pinpointer/pdapinpointer/examine(mob/user)
 	..()
-	to_chat(user, "<span class='notice'>[src] can select a target again in [altFormatTimeDuration(nextuse-world.time)].</span>") 
+	var/timeuntil = altFormatTimeDuration(max(0, nextuse-world.time))
+	to_chat(user, "<span class='notice'>[src] [timeuntil ? "can select a target again in [timeuntil]." : "is ready to select a new target!"]</span>") 
 	
 
 /obj/item/weapon/pinpointer/pdapinpointer/attack_self()


### PR DESCRIPTION
[bugfix]

example of behavior before: "The pda pinpointer can select a target again in -56.2s."

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: The PDA pinpointer will no longer display negative values when showing the time until its next scan.

