### PR TITLE
makes spoons more horribly inefficient at murder

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -95,6 +95,7 @@
 	name = "spoon"
 	desc = "SPOON!"
 	icon_state = "spoon"
+	force = 3
 	attack_verb = list("attacks", "pokes", "hits")
 	melt_temperature = MELTPOINT_STEEL
 	var/bendable = TRUE
@@ -182,6 +183,7 @@
 	name = "plastic spoon"
 	desc = "Super dull action!"
 	icon_state = "pspoon"
+	force = 1
 	melt_temperature = MELTPOINT_PLASTIC
 	autoignition_temperature = AUTOIGNITION_PLASTIC
 	bendable = FALSE

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -95,7 +95,7 @@
 	name = "spoon"
 	desc = "SPOON!"
 	icon_state = "spoon"
-	force = 3
+	force = 4
 	attack_verb = list("attacks", "pokes", "hits")
 	melt_temperature = MELTPOINT_STEEL
 	var/bendable = TRUE


### PR DESCRIPTION
not that the hyperbole in (fixes #34446) is correct, as it's just 5 damage. however, i do think it'd be funny to have easily obtainable "weapons" with very low damage

metal spoon is now 4 force
plastic spoon is now 1 force

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Spoons are now even less effective at hurting people.
