### PR TITLE
Allows clone backups from destroyed bodies (but for real)

### DIFF
--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -193,7 +193,7 @@
 		if(clonemind.current.stat != DEAD)	//mind is associated with a non-dead body
 			return FALSE
 	if(clonemind.active) //somebody is using that mind
-		if( ckey(clonemind.key)!=R.ckey )
+		if(ckey(clonemind.key)!=R.ckey )
 			return FALSE
 	else
 		for(var/mob/G in player_list)
@@ -201,6 +201,10 @@
 				if(isobserver(G))
 					if(G:can_reenter_corpse)
 						break
+					if((!G.mind.current) && G.mind.body_archive) //If the mind's body was destroyed and that mind has a body archive
+						var/datum/dna2/record/D = G.mind.body_archive.data["dna_records"] //Retrieve the DNA records from the mind's body archive
+						if((D.id == R.id) || D.ckey == R.ckey) //If the MD5 hash of the mind's real_name matches the record's real_name (stored as the id variable), or if the ckeys match
+							break //Proceed with cloning. This set of checks is to allow cloning players with completely destroyed bodies, that nevertheless had cloning data stored
 					else
 						return FALSE
 				else if(G)

--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -338,35 +338,31 @@
 			//Can't clone without someone to clone.  Or a pod.  Or if the pod is busy. Or full of gibs.
 			if(!pod1 || !canLink(pod1)) //If the pod exists BUT it's too far away from the console
 				temp = "Error: No Clonepod detected."
+				return
 			else if(pod1.occupant)
 				temp = "Error: Clonepod is currently occupied."
+				return
 			else if(pod1.biomass < CLONE_BIOMASS)
 				temp = "Error: Not enough biomass."
+				return
 			else if(pod1.mess)
 				temp = "Error: Clonepod malfunction."
+				return
 			else if(!config.revival_cloning)
 				temp = "Error: Unable to initiate cloning cycle."
+				return
+
+			if(pod1.growclone(C))
+				temp = "Initiating cloning cycle..."
+				records.Remove(C)
+				QDEL_NULL(C)
+				menu = 1
+
 			else
-				if(pod1.growclone(C))
-					temp = "Initiating cloning cycle..."
-					records.Remove(C)
-					QDEL_NULL(C)
-					menu = 1
-				else
-					//if growclone() failed, we can't clone the guy, so what is this even DOING here?
-					var/mob/selected = find_dead_player("[C.ckey]")
-					if(!selected)
-						temp = "Initiating cloning cycle...<br>Error: Post-initialisation failed. Cloning cycle aborted."
-						src.updateUsrDialog()
-						return
-					selected << 'sound/effects/adminhelp.ogg'
-					if(alert(selected,"Your DNA has been selected for cloning. Do you want to return to life?","Cloning","Yes","No") == "Yes" && pod1.growclone(C))
-						temp = "Initiating cloning cycle..."
-						records.Remove(C)
-						QDEL_NULL(C)
-						menu = 1
-					else
-						temp = "Initiating cloning cycle...<br>Error: Post-initialisation failed. Cloning cycle aborted."
+				temp = "Initiating cloning cycle...<br>Error: Post-initialisation failed. Cloning cycle aborted."
+				src.updateUsrDialog()
+				return
+
 		else
 			temp = "Error: Data corruption."
 

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -131,7 +131,7 @@
 		dorfpod.scan_body(src)
 	if(ticker && ticker.mode)
 		sql_report_death(src)
-	species.handle_death(src)
+	species.handle_death(src, gibbed)
 	if(become_zombie)
 		spawn(20 SECONDS)
 			if(!gcDestroyed)

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -282,7 +282,7 @@ var/global/list/playable_species = list("Human")
 	else
 		return capitalize(pick(first_names_male)) + " " + capitalize(pick(last_names))
 
-/datum/species/proc/handle_death(var/mob/living/carbon/human/H) //Handles any species-specific death events (such as dionaea nymph spawns).
+/datum/species/proc/handle_death(var/mob/living/carbon/human/H, var/gibbed = 0) //Handles any species-specific death events (such as dionaea nymph spawns).
 	return
 
 /datum/species/proc/can_artifact_revive()
@@ -1111,11 +1111,35 @@ var/list/has_died_as_golem = list()
 		"brain" =    /datum/organ/internal/brain/slime_core,
 		)
 
-/datum/species/slime/handle_death(var/mob/living/carbon/human/H) //Handles any species-specific death events (such as dionaea nymph spawns).
-	H.dropBorers()
+/datum/species/slime/handle_death(var/mob/living/carbon/human/H, gibbed) //Handles any species-specific death events (such as dionaea nymph spawns).
+	H.dropBorers(gibbed)
 	for(var/atom/movable/I in H.contents)
 		I.forceMove(H.loc)
 	anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "liquify", sleeptime = 15)
+	if(!gibbed)
+		handle_slime_puddle(H)
+
+/datum/species/slime/gib(mob/living/carbon/human/H)
+	handle_slime_puddle(H)
+	..()
+	H.monkeyizing = TRUE
+	for(var/datum/organ/external/E in H.organs)
+		if(istype(E, /datum/organ/external/chest) || istype(E, /datum/organ/external/groin) || istype(E, /datum/organ/external/head))
+			continue
+		//Only make the limb drop if it's not too damaged
+		if(prob(100 - E.get_damage()))
+			//Override the current limb status and don't cause an explosion
+			E.droplimb(1, 1)
+	var/gib_radius = 0
+	if(H.reagents.has_reagent(LUBE))
+		gib_radius = 6
+
+	anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "gibbed-h", sleeptime = 15)
+	hgibs(H.loc, H.virus2, H.dna, flesh_color, blood_color, gib_radius)
+
+/datum/species/slime/proc/handle_slime_puddle(var/mob/living/carbon/human/H)
+	if(!H)
+		return
 	var/mob/living/slime_pile/S = new(H.loc)
 	if(H.real_name)
 		S.real_name = H.real_name
@@ -1126,10 +1150,6 @@ var/list/has_died_as_golem = list()
 	//Transfer the DNA and mind into the slime puddle.
 	S.dna=H.dna
 	S.mind=H.mind
-
-/datum/species/slime/gib(mob/living/carbon/human/H)
-	..()
-	H.default_gib()
 
 /mob/living/slime_pile //serves as the corpse of slime people
 	name = "puddle of slime"


### PR DESCRIPTION
#34185 doesn't work and, as far as I can tell, never did.
Fixes #34458
Fixes #34462
Fixes #24015
## What this does
This PR ensures that people who got scanned at genetics can still have their DNA record used for a clone, even if their body was gibbed/dusted/etc. after the scan happened.

## Why it's good
It doesn't make sense that your clone backup magically doesn't work because you ran into the SM shard.

[bugfix]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Non-existent bodies can once again be cloned, assuming you got yourself a DNA scan beforehand.
 * bugfix: Slimepeople that are dusted no longer generate slime puddles.
 * bugfix: Slimepeople that are gibbed are now cloneable, provided you have their slime puddle.
