### PR TITLE
mass-buddha mode toggle for admins (found in secrets menu)

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -274,6 +274,10 @@ var/datum/stat_collector/stat_collection = new
 //When enabled, starvation kills
 var/global/hardcore_mode = 0
 
+//Mass Buddha Mode
+//When enabled, all current mobs and all new carbon mobs will be in buddha mode (no crit/death)
+var/global/buddha_mode_everyone = 0
+
 //Global list of all unsimulated mineral turfs for xenoarch
 var/global/list/mineral_turfs = list()
 var/global/list/static_list = list('sound/effects/static/static1.ogg','sound/effects/static/static2.ogg','sound/effects/static/static3.ogg','sound/effects/static/static4.ogg','sound/effects/static/static5.ogg',)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -870,6 +870,7 @@ var/global/floorIsLava = 0
 			<A href='?src=\ref[src];secretsfun=tripleAI'>Triple AI mode (needs to be used in the lobby)</A><BR>
 			<A href='?src=\ref[src];secretsfun=eagles'>Egalitarian Station Mode (removes access on doors except for Command and Security)</A><BR>
 			<A href='?src=\ref[src];secretsfun=RandomizedLawset'>Give the AIs a randomly generated Lawset.</A><BR>
+			<A href='?src=\ref[src];secretsfun=buddha_mode_everyone'>Toggle Buddha Mode on/off for everyone</A><BR>
 			<BR>
 			<A href='?src=\ref[src];secretsfun=power'>Make all areas powered</A><BR>
 			<A href='?src=\ref[src];secretsfun=unpower'>Make all areas unpowered</A><BR>

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -4332,7 +4332,8 @@
 						if(H.mind || H.client)
 							if(!(H.status_flags & BUDDHAMODE))
 								H.status_flags ^= BUDDHAMODE
-								to_chat(H, "<span class='notice'>An incredible sense of tranquility overtakes you. You have let go of your worldly desires.</span>")
+								if(H.client)
+									to_chat(H, "<span class='notice'>An incredible sense of tranquility overtakes you. You have let go of your worldly desires.</span>")
 				else
 					if(alert("This will disable buddha mode for everyone. Are you sure?", "Warning", "Yes", "Cancel") == "Cancel")
 						return
@@ -4343,7 +4344,8 @@
 						if((H.mind || H.client) || (H.attack_log.len)) //attack_log included in case someone got beheaded and the mob lost its client/mind (to unset the flag for corpses, basically)
 							if(H.status_flags & BUDDHAMODE)
 								H.status_flags ^= BUDDHAMODE
-								to_chat(H, "<span class='warning'>The tranquility that once filled your soul has vanished. You are once again a slave to your worldly desires.</span>")
+								if(H.client)
+									to_chat(H, "<span class='warning'>The tranquility that once filled your soul has vanished. You are once again a slave to your worldly desires.</span>")
 
 			if("vermin_infestation")
 				var/list/locations = list(

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -4338,7 +4338,7 @@
 						return
 					buddha_mode_everyone = !buddha_mode_everyone
 					log_admin("[key_name(usr)] has DISABLED buddha mode for everyone!")
-					message_admins("[key_name(usr)] has DISABLED budda mode for everyone!")
+					message_admins("[key_name(usr)] has DISABLED buddha mode for everyone!")
 					for(var/mob/living/carbon/human/H in mob_list)
 						if((H.mind || H.client) || (H.attack_log.len)) //attack_log included in case someone got beheaded and the mob lost its client/mind (to unset the flag for corpses, basically)
 							if(H.status_flags & BUDDHAMODE)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -4320,6 +4320,31 @@
 						hardcore_mode = 0
 						to_chat(world, "<h5><span class='danger'>Hardcore mode has been disabled</span></h5>")
 						to_chat(world, "<span class='info'>Starvation will no longer kill player-controlled characters.</span>")
+
+			if("buddha_mode_everyone")
+				if(!buddha_mode_everyone)
+					if(alert("This will prevent every carbon mob from ever entering crit / dying. Are you sure?", "Warning", "Yes", "Cancel") == "Cancel")
+						return
+					buddha_mode_everyone = !buddha_mode_everyone
+					log_admin("[key_name(usr)] has ENABLED buddha mode for everyone!")
+					message_admins("[key_name(usr)] has ENABLED buddha mode for everyone!")
+					for(var/mob/living/carbon/human/H in mob_list)
+						if(H.mind || H.client)
+							if(!(H.status_flags & BUDDHAMODE))
+								H.status_flags ^= BUDDHAMODE
+								to_chat(H, "<span class='notice'>An incredible sense of tranquility overtakes you. You have let go of your worldly desires.</span>")
+				else
+					if(alert("This will disable buddha mode for everyone. Are you sure?", "Warning", "Yes", "Cancel") == "Cancel")
+						return
+					buddha_mode_everyone = !buddha_mode_everyone
+					log_admin("[key_name(usr)] has DISABLED buddha mode for everyone!")
+					message_admins("[key_name(usr)] has DISABLED budda mode for everyone!")
+					for(var/mob/living/carbon/human/H in mob_list)
+						if((H.mind || H.client) || (H.attack_log.len)) //attack_log included in case someone got beheaded and the mob lost its client/mind (to unset the flag for corpses, basically)
+							if(H.status_flags & BUDDHAMODE)
+								H.status_flags ^= BUDDHAMODE
+								to_chat(H, "<span class='warning'>The tranquility that once filled your soul has vanished. You are once again a slave to your worldly desires.</span>")
+
 			if("vermin_infestation")
 				var/list/locations = list(
 					"RANDOM" = null,

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -210,6 +210,9 @@
 				to_chat(src, "<b>You must eat to survive. Starvation for extended periods of time will kill you!</b>")
 				to_chat(src, "<b>Keep an eye out on the hunger indicator on the right of your screen; it will start flashing red and black when you're close to starvation.</b>")
 
+	if(buddha_mode_everyone)
+		status_flags ^= BUDDHAMODE
+
 	update_colour(0)
 
 	update_mutantrace()


### PR DESCRIPTION
Requested by AngryTurnip. Toggles mass buddha mode on/off. All latejoins, cloned people, etc. will also have buddha mode toggled on while this is enabled. Toggle off to remove it from everyone.

[administration]

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added mass-buddha mode admin button, found in the Secrets panel.
