### PR TITLE
fix slimeperson cloning

### DIFF
--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -242,7 +242,7 @@
 	if(H.dna.species != "Human")
 		H.set_species(H.dna.species, TRUE)
 
-	H.adjustCloneLoss(150) //new damage var so you can't eject a clone early then stab them to abuse the current damage system --NeoFite
+	isslimeperson(H) ? H.adjustToxLoss(150) : H.adjustCloneLoss(150)
 	H.adjustBrainLoss(upgraded ? 0 : (heal_level + 50 + rand(10, 30))) // The rand(10, 30) will come out as extra brain damage
 	H.Paralyse(4)
 	H.stat = H.status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS //There was a bug which allowed you to talk for a few seconds after being cloned, because your stat wasn't updated until next Life() tick. This is a fix for this!
@@ -306,7 +306,7 @@
 			occupant.Paralyse(4)
 
 			 //Slowly get that clone healed and finished.
-			occupant.adjustCloneLoss(-1*time_coeff) //Very slow, new parts = much faster
+			isslimeperson(occupant) ? occupant.adjustToxLoss(-1*time_coeff) : occupant.adjustCloneLoss(-1*time_coeff) //Very slow, new parts = much faster
 
 			//Premature clones may have brain damage.
 			occupant.adjustBrainLoss(-1*time_coeff) //Ditto above

--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -395,7 +395,7 @@
 		return
 	if(istype(subject, /mob/living/slime_pile))
 		var/mob/living/slime_pile/P = subject
-		if(P.slime_person.has_brain())
+		if(P.slime_person && P.slime_person.has_brain())
 			subject = P.slime_person
 		else
 			scantemp = "Unable to locate genetic base within the slime puddle. Micro-MRI scans indicate its brain is missing."

--- a/code/modules/medical/computer/cloning.dm
+++ b/code/modules/medical/computer/cloning.dm
@@ -393,6 +393,13 @@
 	if((isnull(subject)) || (!ishuman(subject) && !istype(subject, /mob/living/slime_pile)) || (!subject.dna) || (ismanifested(subject)))
 		scantemp = "Error: Unable to locate valid genetic data." //Something went very wrong here
 		return
+	if(istype(subject, /mob/living/slime_pile))
+		var/mob/living/slime_pile/P = subject
+		if(P.slime_person.has_brain())
+			subject = P.slime_person
+		else
+			scantemp = "Unable to locate genetic base within the slime puddle. Micro-MRI scans indicate its brain is missing."
+			return
 	if(!subject.has_brain())
 		scantemp = "Error: No signs of intelligence detected." //Self explainatory
 		return


### PR DESCRIPTION
## What this does
Slimepeople can now be cloned again. Careless reworks of how cloning machines function seems to have unintentionally removed this functionality. Slimepeople also take toxins damage when cloning as opposed to cloneloss for reasons described in the changelog. In my testing, slimepeople clone slightly faster than humans, but I didn't do a whole lot of tests and this may be attributable to RNG.

fixes #32786
fixes #24015
[bugfix][tweak]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Slimepeople can be cloned once more. Simply put the slime puddle inside the cloning machine and scan. Make sure it has its slime core (brain) inside or it won't work!
 * tweak: Slimepeople now take toxins damage when cloning instead of clone damage. This is to prevent them from instantly cloning (as they're immune to cloneloss), while also providing a way for xenobio to ease their cloning process (through giving them a slime heart).
