### PR TITLE
fix lightreplacer usecase and a runtime

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -84,6 +84,10 @@ This used to be handled by attackby() on the light fixtures and bulbs themselves
 	if(lightfixture && lightfixture.current_bulb && is_light_better(best_light, lightfixture.current_bulb))
 		. = ReplaceLight(lightfixture, usr)
 		return .
+	else if(lightfixture && !lightfixture.current_bulb)
+		. = ReplaceLight(lightfixture, usr)
+		if(.)
+			return .
 	else
 		for(var/obj/O in gather_loc.contents)
 			. = insert_if_possible(O)
@@ -443,6 +447,8 @@ This used to be handled by attackby() on the light fixtures and bulbs themselves
 	if(!istype(supply))
 		return 0
 	var/best_light
+	if(!target.fitting) //no idea how this happens
+		target.fitting = initial(target.fitting)
 	switch(target.fitting)
 		if("bulb")
 			best_light = ((locate(/obj/item/weapon/light/bulb/smart) in supply) || (locate(/obj/item/weapon/light/bulb/he) in supply) || (locate(/obj/item/weapon/light/bulb) in supply))


### PR DESCRIPTION
see changelog
[runtime][bugfix]
relevant runtime:
```
[00:14:28] Runtime in lightreplacer.dm,446: Cannot read null.fitting
  proc name: get best light (/obj/item/device/lightreplacer/proc/get_best_light)
  usr: Allad Minsa Recucks (nervere) (/mob/living/carbon/human)
  usr.loc: The floor (225, 282, 1) (/turf/simulated/floor)
  src: the light replacer (/obj/item/device/lightreplacer/loaded/mixed)
  src.loc: Allad Minsa Recucks (/mob/living/carbon/human)
  call stack:
  the light replacer (/obj/item/device/lightreplacer/loaded/mixed): get best light(null)
  the light replacer (/obj/item/device/lightreplacer/loaded/mixed): preattack(the floor (224,282,1) (/turf/simulated/floor), Allad Minsa Recucks (/mob/living/carbon/human), 1, "icon-x=9;icon-y=18;left=1;butt...")
  Allad Minsa Recucks (/mob/living/carbon/human): ClickOn(the floor (224,282,1) (/turf/simulated/floor), "icon-x=9;icon-y=18;left=1;butt...")
  the floor (224,282,1) (/turf/simulated/floor): Click(the floor (224,282,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=9;icon-y=18;left=1;butt...")
  Nervere (/client): Click(the floor (224,282,1) (/turf/simulated/floor), the floor (224,282,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=9;icon-y=18;left=1;butt...")
```

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed light replacers not being able to replace bulb-less light fixtures
 * bugfix: Fixed runtime when a light fixture's fitting var is set to null for some reason (???)
