### PR TITLE
Fixes mintboxes still having the pill bottle overlay. And tweak.

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -359,9 +359,8 @@ var/global/list/bottle_colour_choices = list("Blue" = "#0094FF","Dark Blue" = "#
 	items_to_spawn = list(/obj/item/weapon/reagent_containers/food/snacks/mint/syndiemint = 50)
 
 /obj/item/weapon/storage/pill_bottle/syndiemints/New()
-
-	overlays -= colour_overlay //no pill bottle overlay
-	colour_overlay = null
+	..()
+	overlays = null //no overlay fuck you
 
 	switch(rand(3))
 		if(0)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1068,7 +1068,8 @@
 				else
 					J.amount = 0
 					H.custom_pain("Your teeth crack and tremble before breaking all of a sudden! THE PAIN!", 100) //you dun fucked up lad
-					H.pain_level = BASE_CARBON_PAIN_RESIST + 25 //pain threshold + 25, so you go into shock from pain
+					H.visible_message("<span class='warning'>[H]'s teeth start cracking and suddenly explode! That must hurt.</span>")
+					H.pain_level = 2 * BASE_CARBON_PAIN_RESIST //so you go into shock from pain
 					playsound(H, 'sound/effects/toothshatter.ogg', 50, 1)
 					H.audible_scream()
 					H.adjustBruteLoss(50) //imagine all your teeth violently exploding, shrapnel and shit

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3270,6 +3270,7 @@
 //the syndie version for muh tators
 /obj/item/weapon/reagent_containers/food/snacks/mint/syndiemint
 	name = "mint candy"
+	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/mint/syndiemint/nano
 	desc = "It's not just a mint!"


### PR DESCRIPTION
Fucking 2 mouse sized bites for per mint jesus fuck.
Muh immulsions.
:cl:
 * bugfix: Mint boxes no longer have pill bottle overlays, this time for real.
 * tweak: Mints are eaten in one bite, not two.
 * tweak: Increased pain given by mint-exploding your teeth so you actually collapse from said pain.

