### PR TITLE
Fixes pre-mapped lit candles having a bugged icon featuring only the flame

### DIFF
--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -15,6 +15,17 @@
 	var/flavor_text
 	var/trashtype = /obj/item/trash/candle
 
+/obj/item/candle/New(turf/loc)
+	..()
+	if(world.has_round_started())
+		initialize()
+
+/obj/item/candle/initialize()
+	..()
+	if (lit)//pre-mapped lit candles
+		lit = 0
+		light("",TRUE)
+
 /obj/item/candle/update_icon()
 	overlays.len = 0
 	var/i


### PR DESCRIPTION
Fixes #32346

:cl:
* bugfix: Fixed pre-mapped lit candles having a bugged icon featuring only the flame.