### PR TITLE
canister consistent eject behaviour with tank dispenser

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -373,7 +373,7 @@
 
 			if(istype(holding, /obj/item/weapon/tank))
 				holding.manipulated_by = usr.real_name
-			holding.forceMove(loc)
+			usr.put_in_hands(holding)
 			holding = null
 
 	if (href_list["pressure_adj"])


### PR DESCRIPTION
## What this does
before: tank dispenser puts the tank in your hand, gas canister puts the tank on the floor where the can is
after: both go to your hand

## Why it's good
ux consistency

## Changelog
:cl:
 * tweak: Gas tanks eject the same way on tank dispensers and gas canisters (to hand)
