### PR TITLE
Fish Engine Power Define Change

### DIFF
--- a/code/modules/fish/fish_tank.dm
+++ b/code/modules/fish/fish_tank.dm
@@ -804,7 +804,7 @@
 	if(check_tank())
 		for(var/fish in attached_tank.fish_list)
 			if(fish == "electric eel")
-				power += ARBITRARILY_LARGE_NUMBER * multiplier //10000
+				power += 10000 * multiplier //10000
 		add_avail(power)
 		return
 	for(var/mob/living/carbon/human/H in loc)


### PR DESCRIPTION
# Fixes an Improperly Used Define

## What this does
Changes the power generated by the electric eels to be a hard coded ``10000`` vs a define used for something entirely different (``ARBITRARILY_LARGE_NUMBER``, used for limits on delays/vehicles, also ``10000`` at this time but could change for Reasons).

This will have no change in gameplay, power will remain the same. This will also make sure power will remain the same even if the ``ARBITARILY_LARGE_NUMBER`` is changed in the future.

Also this is untested.

## Why it's good
Deity told me to change it or else. I don't want to find out what else is.

