### PR TITLE
convert ALL maps to TGM format, remove dirty variables

### DIFF
--- a/maps/RandomZLevels/Academy.dmm
+++ b/maps/RandomZLevels/Academy.dmm
@@ -82,7 +82,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	environ = 0;
-	equipment = 3;
 	locked = 0;
 	req_access = ""
 	},
@@ -125,8 +124,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet,
@@ -135,8 +133,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/headmaster)
@@ -152,8 +149,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/headmaster)
@@ -189,8 +185,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/headmaster)
@@ -203,8 +198,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/headmaster)
@@ -280,8 +274,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -423,8 +416,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/item/weapon/pen/red,
 /turf/simulated/floor/carpet,
@@ -464,8 +456,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/item/weapon/dice/d20,
 /turf/simulated/floor/carpet,
@@ -487,8 +478,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/headmaster)
@@ -520,8 +510,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/headmaster)
@@ -656,8 +645,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -669,8 +657,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -681,8 +668,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -752,8 +738,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -786,8 +771,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -812,8 +796,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -842,8 +825,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/item/weapon/pen/red,
 /obj/machinery/light{
@@ -879,14 +861,11 @@
 /turf/simulated/floor/plating,
 /area/awaymission/academy/headmaster)
 "cF" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/academy/headmaster)
@@ -901,8 +880,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/item/stack/cable_coil/random,
 /turf/simulated/floor,
@@ -941,8 +919,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -970,8 +947,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/awaymission/academy/classrooms)
@@ -1007,8 +983,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/awaymission/academy/classrooms)
@@ -1083,8 +1058,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/academy/classrooms)
@@ -1092,8 +1066,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -1261,8 +1234,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/greengrid,
@@ -1271,8 +1243,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -1296,8 +1267,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/awaymission/academy/classrooms)
@@ -1389,8 +1359,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -1402,8 +1371,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -1413,8 +1381,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -1445,8 +1412,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/awaymission/academy/classrooms)
@@ -1472,8 +1438,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -1517,8 +1482,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -1567,8 +1531,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	environ = 3;
-	equipment = 3;
 	locked = 0;
 	req_access = ""
 	},
@@ -1583,8 +1545,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/classrooms)
@@ -1670,8 +1631,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -1686,8 +1646,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -1754,8 +1713,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -1804,8 +1762,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -1858,8 +1815,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -1923,8 +1879,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/classrooms)
@@ -1932,8 +1887,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1946,8 +1900,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -1958,8 +1911,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "bar"
@@ -1969,8 +1921,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -1982,8 +1933,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -1995,8 +1945,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -2007,8 +1956,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -2132,8 +2080,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/noticeboard{
 	pixel_y = -32
@@ -2174,8 +2121,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /turf/simulated/floor{
@@ -2191,8 +2137,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/classrooms)
@@ -2225,8 +2170,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/academy/classrooms)
@@ -2250,8 +2194,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/academyaft)
@@ -2280,8 +2223,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -2295,8 +2237,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -2362,8 +2303,7 @@
 "gl" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/awaymission/academy/classrooms)
 "gm" = (
@@ -2405,8 +2345,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/academy/classrooms)
@@ -2446,8 +2385,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -2472,8 +2410,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/recharger,
 /obj/structure/table/reinforced,
@@ -2501,9 +2438,7 @@
 	},
 /area/awaymission/academy/classrooms)
 "gE" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "warning"
@@ -2514,17 +2449,14 @@
 /turf/simulated/floor/plating,
 /area/awaymission/academy/classrooms)
 "gG" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window,
 /obj/machinery/door/window{
 	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/academy/classrooms)
@@ -2542,8 +2474,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -2608,9 +2539,7 @@
 	},
 /area/awaymission/academy/classrooms)
 "gS" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window,
 /obj/item/ammo_casing,
 /turf/simulated/floor{
 	dir = 4;
@@ -2627,8 +2556,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/academyaft)
@@ -2678,8 +2606,7 @@
 /obj/structure/window/reinforced,
 /obj/item/ammo_casing,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/awaymission/academy/classrooms)
 "ha" = (
@@ -2736,8 +2663,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -2753,8 +2679,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/classrooms)
@@ -2762,8 +2687,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -2816,21 +2740,18 @@
 /area/awaymission/academy/classrooms)
 "hp" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaymission/academy/classrooms)
 "hq" = (
 /obj/item/weapon/stool,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaymission/academy/classrooms)
 "hr" = (
 /obj/machinery/light,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaymission/academy/classrooms)
@@ -2846,8 +2767,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/academyaft)
@@ -2870,8 +2790,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/academy/academyaft)
@@ -2879,24 +2798,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/turf/simulated/floor{
-	icon_state = "hydrofloor"
-	},
-/area/awaymission/academy/academyaft)
-"hA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
 	},
 /turf/simulated/floor{
 	icon_state = "hydrofloor"
@@ -2919,8 +2826,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	environ = 3;
-	equipment = 3;
 	locked = 0;
 	req_access = ""
 	},
@@ -2988,30 +2893,11 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "hydrofloor"
 	},
-/area/awaymission/academy/academyaft)
-"hN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor,
-/area/awaymission/academy/academyaft)
-"hO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/plating,
 /area/awaymission/academy/academyaft)
 "hP" = (
 /obj/structure/cable{
@@ -3031,8 +2917,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/academy/academyaft)
@@ -3055,8 +2940,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "hydrofloor"
@@ -3076,8 +2960,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3092,8 +2975,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/plating,
@@ -3102,8 +2984,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3121,8 +3002,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -3133,8 +3013,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/academy/academyaft)
@@ -3142,8 +3021,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -3155,8 +3033,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3169,8 +3046,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -3183,8 +3059,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/item/weapon/caution,
 /turf/simulated/floor{
@@ -3197,8 +3072,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3236,8 +3110,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/academy/academyaft)
@@ -3245,8 +3118,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "hydrofloor"
@@ -3352,8 +3224,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/power/battery/smes/infinite,
 /turf/simulated/floor/plating,
@@ -3362,8 +3233,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3400,14 +3270,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/awaymission/academy/academyaft)
 "iG" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
@@ -3416,14 +3284,12 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
 "iI" = (
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
@@ -3450,7 +3316,6 @@
 "iM" = (
 /obj/machinery/door/mineral/iron,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
@@ -3476,12 +3341,10 @@
 "iQ" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
@@ -3491,7 +3354,6 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
@@ -3515,19 +3377,15 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
 "iV" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
@@ -3550,7 +3408,6 @@
 	name = "awaystart"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
@@ -3562,7 +3419,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
@@ -3601,7 +3457,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
@@ -3639,7 +3494,6 @@
 	},
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
@@ -3662,7 +3516,6 @@
 	name = "awaystart"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/academy/academyaft)
@@ -3720,8 +3573,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/academyaft)
@@ -3802,8 +3654,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3820,8 +3671,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless{
 	dir = 4;
@@ -3841,8 +3691,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -3865,8 +3714,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless{
 	dir = 4;
@@ -4005,8 +3853,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -4037,8 +3884,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -4099,15 +3945,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/awaymission/academy/academygate)
-"kk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/carpet,
-/area/awaymission/academy/academygate)
 "kl" = (
 /turf/simulated/floor/grass,
 /area/awaymission/academy/academygate)
@@ -4159,8 +3996,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/window{
 	dir = 2
@@ -4177,8 +4013,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4191,8 +4026,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/academy/academygate)
@@ -4222,8 +4056,6 @@
 "kz" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	environ = 3;
-	equipment = 3;
 	locked = 0;
 	req_access = ""
 	},
@@ -4303,7 +4135,6 @@
 	id_tag = "AcademyGate"
 	},
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/awaymission/academy/academygate)
@@ -10625,7 +10456,7 @@ ht
 hy
 hy
 hw
-hO
+hy
 hw
 hy
 hw
@@ -10882,7 +10713,7 @@ bI
 bI
 hp
 ht
-hA
+hM
 hF
 hK
 hK
@@ -12856,9 +12687,9 @@ gV
 fX
 fX
 kg
-kk
-kk
-kk
+ky
+ky
+ky
 kr
 kt
 kw
@@ -14913,7 +14744,7 @@ aW
 aa
 ht
 hK
-hA
+hM
 ix
 iD
 iJ
@@ -15302,7 +15133,7 @@ aa
 aa
 aa
 ht
-hN
+hZ
 hF
 hK
 hK
@@ -15432,7 +15263,7 @@ aa
 aa
 aa
 ht
-hO
+hy
 hw
 hw
 hw

--- a/maps/RandomZLevels/arcticwaste.dmm
+++ b/maps/RandomZLevels/arcticwaste.dmm
@@ -158,7 +158,6 @@
 /area/awaymission/articwasteland/gateway)
 "aI" = (
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/awaymission/articwasteland/gateway)
@@ -179,7 +178,6 @@
 "aM" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/awaymission/articwasteland/gateway)

--- a/maps/RandomZLevels/beach.dmm
+++ b/maps/RandomZLevels/beach.dmm
@@ -62,8 +62,6 @@
 /area/awaymission/beach)
 "t" = (
 /obj/structure/closet/gmcloset{
-	icon_closed = "black";
-	icon_state = "black";
 	name = "formal wardrobe"
 	},
 /turf/unsimulated/floor{

--- a/maps/RandomZLevels/blackmarketpackers.dmm
+++ b/maps/RandomZLevels/blackmarketpackers.dmm
@@ -2730,14 +2730,6 @@
 	},
 /turf/simulated/floor,
 /area/awaymission/BMPship1)
-"hQ" = (
-/obj/mecha/working/ripley/mk2/firefighter,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "carpet15-7";
-	tag = "icon-carpet15-7 (EAST)"
-	},
-/area/awaymission/BMPship3)
 "hR" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9974,7 +9966,7 @@ cY
 dt
 dN
 el
-hQ
+cX
 ds
 fy
 ds

--- a/maps/RandomZLevels/blackmarketpackers.dmm
+++ b/maps/RandomZLevels/blackmarketpackers.dmm
@@ -615,8 +615,8 @@
 "cu" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/weapon/reagent_containers/food/snacks/meat,
-/obj/item/organ/internal/appendix,
 /obj/item/weapon/reagent_containers/food/snacks/meat/hugemushroomslice,
+/obj/item/organ/internal/appendix,
 /turf/simulated/floor/plating{
 	icon_state = "warnplate"
 	},
@@ -849,6 +849,12 @@
 	tag = "icon-carpet15-7 (EAST)"
 	},
 /area/awaymission/BMPship3)
+"cZ" = (
+/obj/item/weapon/reagent_containers/food/snacks/meat/hugemushroomslice,
+/turf/simulated/floor{
+	icon_state = "bar"
+	},
+/area/awaymission/BMPship2)
 "da" = (
 /turf/simulated/floor,
 /area/awaymission/BMPship2)
@@ -968,12 +974,8 @@
 /area/awaymission/BMPship3)
 "dv" = (
 /obj/item/weapon/reagent_containers/food/snacks/meat/hugemushroomslice,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "carpet15-15";
-	tag = "icon-carpet15-15 (EAST)"
-	},
-/area/awaymission/BMPship3)
+/turf/simulated/floor,
+/area/awaymission/BMPship2)
 "dw" = (
 /obj/machinery/door/unpowered/shuttle,
 /turf/simulated/floor{
@@ -1852,12 +1854,6 @@
 	icon_state = "warning"
 	},
 /area/awaymission/BMPship1)
-"fu" = (
-/obj/item/weapon/reagent_containers/food/snacks/meat/hugemushroomslice,
-/turf/simulated/floor{
-	icon_state = "bar"
-	},
-/area/awaymission/BMPship2)
 "fv" = (
 /obj/structure/shuttle/diag_wall/smooth{
 	dir = 1
@@ -2085,6 +2081,16 @@
 	},
 /turf/simulated/floor{
 	icon_state = "bar"
+	},
+/area/awaymission/BMPship1)
+"fT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
 	},
 /area/awaymission/BMPship1)
 "fU" = (
@@ -2391,16 +2397,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/awaymission/BMPship1)
-"gK" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -9449,7 +9445,7 @@ eh
 eh
 eh
 eh
-dv
+eh
 eh
 ip
 gB
@@ -10482,7 +10478,7 @@ aq
 bR
 hr
 cE
-cK
+cZ
 cK
 cK
 eo
@@ -10873,7 +10869,7 @@ bS
 hr
 cH
 da
-da
+dv
 dQ
 dV
 es
@@ -12823,7 +12819,7 @@ bX
 ha
 cQ
 df
-fu
+cK
 dV
 es
 eK
@@ -13609,7 +13605,7 @@ di
 di
 fm
 di
-gK
+fT
 fm
 di
 di
@@ -13872,7 +13868,7 @@ fF
 fF
 fo
 gv
-gK
+fT
 di
 hg
 dp
@@ -14002,7 +13998,7 @@ fp
 fV
 gh
 gw
-gK
+fT
 di
 ha
 dp
@@ -14132,7 +14128,7 @@ fp
 fp
 fp
 gw
-gK
+fT
 di
 ha
 hs

--- a/maps/RandomZLevels/blackmarketpackers.dmm
+++ b/maps/RandomZLevels/blackmarketpackers.dmm
@@ -150,8 +150,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/BMPship1)
@@ -371,8 +370,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/BMPship1)
@@ -381,8 +379,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated,
 /area/awaymission/BMPship1)
@@ -390,8 +387,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
 	dir = 8;
@@ -480,14 +476,12 @@
 /area/awaymission/BMPship3)
 "bQ" = (
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/awaymission/BMPship3)
 "bR" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/awaymission/BMPship3)
@@ -525,8 +519,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/item/weapon/hand_labeler,
 /turf/simulated/floor/plating,
@@ -535,8 +528,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship1)
@@ -544,8 +536,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/item/weapon/storage/box,
 /turf/simulated/floor/plating,
@@ -589,21 +580,18 @@
 /area/awaymission/BMPship1)
 "cp" = (
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/awaymission/BMPship1)
 "cq" = (
 /obj/machinery/light,
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/awaymission/BMPship1)
 "cr" = (
 /obj/structure/kitchenspike,
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/awaymission/BMPship1)
@@ -612,7 +600,6 @@
 /obj/item/device/analyzer,
 /obj/item/weapon/spacecash/c10,
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/awaymission/BMPship1)
@@ -622,17 +609,15 @@
 /obj/item/weapon/spacecash/c100,
 /obj/item/weapon/spacecash/c100,
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/awaymission/BMPship1)
 "cu" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/weapon/reagent_containers/food/snacks/meat,
-/obj/item/weapon/reagent_containers/food/snacks/hugemushroomslice,
 /obj/item/organ/internal/appendix,
+/obj/item/weapon/reagent_containers/food/snacks/meat/hugemushroomslice,
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/awaymission/BMPship1)
@@ -643,7 +628,6 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/awaymission/BMPship1)
@@ -654,7 +638,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/awaymission/BMPship1)
@@ -725,9 +708,7 @@
 	},
 /area/awaymission/BMPship2)
 "cG" = (
-/obj/structure/sink{
-	dir = 2
-	},
+/obj/structure/sink,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -860,8 +841,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -869,12 +849,6 @@
 	tag = "icon-carpet15-7 (EAST)"
 	},
 /area/awaymission/BMPship3)
-"cZ" = (
-/obj/item/weapon/reagent_containers/food/snacks/hugemushroomslice,
-/turf/simulated/floor{
-	icon_state = "bar"
-	},
-/area/awaymission/BMPship2)
 "da" = (
 /turf/simulated/floor,
 /area/awaymission/BMPship2)
@@ -993,9 +967,13 @@
 	},
 /area/awaymission/BMPship3)
 "dv" = (
-/obj/item/weapon/reagent_containers/food/snacks/hugemushroomslice,
-/turf/simulated/floor,
-/area/awaymission/BMPship2)
+/obj/item/weapon/reagent_containers/food/snacks/meat/hugemushroomslice,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "carpet15-15";
+	tag = "icon-carpet15-15 (EAST)"
+	},
+/area/awaymission/BMPship3)
 "dw" = (
 /obj/machinery/door/unpowered/shuttle,
 /turf/simulated/floor{
@@ -1102,7 +1080,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	environ = 0;
-	equipment = 3;
 	locked = 0;
 	req_access = ""
 	},
@@ -1212,8 +1189,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "bar"
@@ -1257,8 +1233,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "hydrofloor"
@@ -1268,8 +1243,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -1282,8 +1256,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1308,7 +1281,6 @@
 "ee" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "heater";
 	tag = "icon-heater (EAST)"
 	},
 /obj/structure/window/reinforced{
@@ -1322,7 +1294,6 @@
 "ef" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
-	icon_state = "propulsion";
 	tag = "icon-propulsion (WEST)"
 	},
 /turf/space,
@@ -1409,17 +1380,6 @@
 	icon_state = "bar"
 	},
 /area/awaymission/BMPship2)
-"ep" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/simulated/floor{
-	icon_state = "bar"
-	},
-/area/awaymission/BMPship2)
 "eq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1467,15 +1427,6 @@
 	dir = 8;
 	icon_state = "warning"
 	},
-/area/awaymission/BMPship1)
-"ew" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor,
 /area/awaymission/BMPship1)
 "ex" = (
 /obj/structure/cable{
@@ -1547,8 +1498,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -1698,8 +1648,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "hydrofloor"
@@ -1713,8 +1662,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship1)
@@ -1737,8 +1685,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -1905,27 +1852,12 @@
 	icon_state = "warning"
 	},
 /area/awaymission/BMPship1)
-"ft" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/awaymission/BMPship1)
 "fu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
+/obj/item/weapon/reagent_containers/food/snacks/meat/hugemushroomslice,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "warning"
+	icon_state = "bar"
 	},
-/area/awaymission/BMPship1)
+/area/awaymission/BMPship2)
 "fv" = (
 /obj/structure/shuttle/diag_wall/smooth{
 	dir = 1
@@ -1948,8 +1880,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -1961,8 +1892,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -2001,8 +1931,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2050,7 +1979,6 @@
 "fG" = (
 /obj/machinery/door/window{
 	base_state = "right";
-	dir = 4;
 	icon_state = "right"
 	},
 /turf/simulated/floor/shuttle/plating,
@@ -2092,8 +2020,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -2119,7 +2046,6 @@
 "fO" = (
 /obj/machinery/door/window{
 	base_state = "right";
-	dir = 4;
 	icon_state = "right"
 	},
 /turf/simulated/floor/plating,
@@ -2155,22 +2081,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "bar"
-	},
-/area/awaymission/BMPship1)
-"fT" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
 	},
 /area/awaymission/BMPship1)
 "fU" = (
@@ -2224,19 +2138,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaymission/BMPship1)
-"ga" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "carpet15-15";
-	tag = "icon-carpet15-15 (EAST)"
-	},
-/area/awaymission/BMPship3)
 "gb" = (
 /obj/structure/closet,
 /turf/simulated/floor{
@@ -2298,8 +2199,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/item/weapon/cell/high,
 /turf/simulated/floor,
@@ -2319,8 +2219,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/unpowered/shuttle,
 /turf/simulated/floor{
@@ -2442,8 +2341,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/BMPship3)
@@ -2451,8 +2349,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless{
 	icon_state = "panelscorched";
@@ -2503,8 +2400,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -2566,8 +2462,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/BMPship3)
@@ -2610,8 +2505,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/awaymission/BMPship1)
@@ -2676,8 +2570,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/awaymission/BMPship1)
@@ -2838,14 +2731,13 @@
 /turf/simulated/floor,
 /area/awaymission/BMPship1)
 "hQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+/obj/mecha/working/ripley/mk2/firefighter,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "carpet15-7";
+	tag = "icon-carpet15-7 (EAST)"
 	},
-/turf/simulated/floor,
-/area/awaymission/BMPship1)
+/area/awaymission/BMPship3)
 "hR" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2972,8 +2864,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission)
@@ -2982,8 +2873,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/BMPship1)
@@ -2991,8 +2881,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/BMPship1)
@@ -3031,7 +2920,6 @@
 "it" = (
 /obj/machinery/door/unpowered/shuttle,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/BMPship1)
@@ -3040,7 +2928,6 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/BMPship1)
@@ -3052,7 +2939,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/BMPship1)
@@ -3076,11 +2962,8 @@
 /turf/simulated/floor,
 /area/awaymission/BMPship1)
 "iA" = (
-/obj/structure/sink{
-	dir = 2
-	},
+/obj/structure/sink,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/BMPship1)
@@ -3089,7 +2972,6 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/awaymission/BMPship1)
@@ -9575,7 +9457,7 @@ eh
 eh
 eh
 eh
-eh
+dv
 eh
 ip
 gB
@@ -9836,7 +9718,7 @@ cX
 ds
 fw
 fL
-ga
+fd
 gm
 gD
 gB
@@ -10092,7 +9974,7 @@ cY
 dt
 dN
 el
-cX
+hQ
 ds
 fy
 ds
@@ -10482,7 +10364,7 @@ cK
 cK
 cK
 en
-ep
+dV
 cK
 cK
 cK
@@ -10608,7 +10490,7 @@ aq
 bR
 hr
 cE
-cZ
+cK
 cK
 cK
 eo
@@ -10741,7 +10623,7 @@ cF
 cF
 cF
 dP
-ep
+dV
 es
 es
 es
@@ -10871,7 +10753,7 @@ cG
 da
 da
 dQ
-ep
+dV
 es
 fe
 fe
@@ -10999,9 +10881,9 @@ bS
 hr
 cH
 da
-dv
+da
 dQ
-ep
+dV
 es
 ff
 fe
@@ -11131,7 +11013,7 @@ cI
 da
 da
 dR
-ep
+dV
 es
 fe
 fh
@@ -11261,7 +11143,7 @@ cG
 db
 da
 dQ
-ep
+dV
 es
 fg
 fg
@@ -11391,7 +11273,7 @@ cJ
 cJ
 cJ
 dS
-ep
+dV
 eG
 fh
 fh
@@ -11654,7 +11536,7 @@ cK
 cK
 cK
 fi
-ep
+dV
 cK
 cK
 gp
@@ -11914,7 +11796,7 @@ cK
 cK
 cK
 cK
-ep
+dV
 cK
 cK
 cK
@@ -12179,7 +12061,7 @@ cK
 cK
 gq
 cK
-ep
+dV
 cK
 hr
 hG
@@ -12309,7 +12191,7 @@ cK
 er
 gr
 gI
-ep
+dV
 fP
 hr
 hH
@@ -12439,7 +12321,7 @@ fQ
 es
 gs
 es
-ep
+dV
 cK
 hr
 ac
@@ -12569,7 +12451,7 @@ cK
 es
 gt
 es
-ep
+dV
 cK
 hr
 hI
@@ -12699,7 +12581,7 @@ cK
 es
 gt
 es
-ep
+dV
 cK
 hr
 hG
@@ -12829,7 +12711,7 @@ cK
 es
 gt
 es
-ep
+dV
 cK
 hr
 ac
@@ -12949,7 +12831,7 @@ bX
 ha
 cQ
 df
-cK
+fu
 dV
 es
 eK
@@ -13735,7 +13617,7 @@ di
 di
 fm
 di
-fT
+gK
 fm
 di
 di
@@ -14522,7 +14404,7 @@ di
 gX
 ha
 ht
-hQ
+il
 dp
 dp
 dp
@@ -14652,7 +14534,7 @@ gM
 gY
 ha
 hu
-hQ
+il
 ic
 dp
 ic
@@ -14782,7 +14664,7 @@ ha
 ha
 ha
 hv
-hQ
+il
 dp
 dp
 dp
@@ -14912,7 +14794,7 @@ dH
 dH
 ha
 hs
-hQ
+il
 dp
 ha
 it
@@ -15031,17 +14913,17 @@ cV
 do
 do
 dY
-ew
+do
 eU
 eU
-ew
-ew
+do
+do
 gj
 eU
-ew
+do
 gZ
 hi
-ew
+do
 hR
 dp
 ha
@@ -15293,8 +15175,8 @@ dn
 ea
 bK
 eV
-ft
-ft
+bK
+bK
 fX
 bd
 gy
@@ -15553,8 +15435,8 @@ dJ
 ec
 ex
 eX
-fu
-fu
+ex
+ex
 fY
 dJ
 ec

--- a/maps/RandomZLevels/challenge.dmm
+++ b/maps/RandomZLevels/challenge.dmm
@@ -37,7 +37,6 @@
 "ai" = (
 /obj/item/device/flashlight{
 	icon_state = "flashlight-on";
-	item_state = "flashlight";
 	on = 1
 	},
 /turf/simulated/floor/airless,
@@ -168,13 +167,11 @@
 	active = 1;
 	active_power_usage = 0;
 	anchored = 1;
-	dir = 2;
 	idle_power_usage = 0;
 	locked = 1;
 	name = "Energy Cannon";
 	req_access_txt = "100";
-	state = 2;
-	use_power = 0
+	state = 2
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/challenge/main)
@@ -208,13 +205,11 @@
 	active = 1;
 	active_power_usage = 0;
 	anchored = 1;
-	dir = 2;
 	idle_power_usage = 0;
 	locked = 1;
 	name = "Energy Cannon";
 	req_access_txt = "100";
-	state = 2;
-	use_power = 0
+	state = 2
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/challenge/main)
@@ -242,8 +237,7 @@
 	locked = 1;
 	name = "Energy Cannon";
 	req_access_txt = "100";
-	state = 2;
-	use_power = 0
+	state = 2
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/challenge/main)
@@ -275,8 +269,7 @@
 	locked = 1;
 	name = "Energy Cannon";
 	req_access_txt = "100";
-	state = 2;
-	use_power = 0
+	state = 2
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/challenge/main)
@@ -349,8 +342,7 @@
 	locked = 1;
 	name = "Energy Cannon";
 	req_access_txt = "100";
-	state = 2;
-	use_power = 0
+	state = 2
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -387,8 +379,7 @@
 	locked = 1;
 	name = "Energy Cannon";
 	req_access_txt = "100";
-	state = 2;
-	use_power = 0
+	state = 2
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -413,8 +404,7 @@
 	locked = 1;
 	name = "Energy Cannon";
 	req_access_txt = "100";
-	state = 2;
-	use_power = 0
+	state = 2
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plating,
@@ -432,8 +422,7 @@
 	locked = 1;
 	name = "Energy Cannon";
 	req_access_txt = "100";
-	state = 2;
-	use_power = 0
+	state = 2
 	},
 /turf/simulated/floor/plating{
 	tag = "icon-warnplate (EAST)";
@@ -450,13 +439,11 @@
 	active = 1;
 	active_power_usage = 0;
 	anchored = 1;
-	dir = 2;
 	idle_power_usage = 0;
 	locked = 1;
 	name = "Energy Cannon";
 	req_access_txt = "100";
-	state = 2;
-	use_power = 0
+	state = 2
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -508,7 +495,6 @@
 "bs" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/awaymission/challenge/main)
@@ -533,8 +519,7 @@
 	locked = 1;
 	name = "Energy Cannon";
 	req_access_txt = "100";
-	state = 2;
-	use_power = 0
+	state = 2
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -585,8 +570,7 @@
 	locked = 1;
 	name = "Energy Cannon";
 	req_access_txt = "100";
-	state = 2;
-	use_power = 0
+	state = 2
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/challenge/main)
@@ -603,8 +587,7 @@
 	locked = 1;
 	name = "Energy Cannon";
 	req_access_txt = "100";
-	state = 2;
-	use_power = 0
+	state = 2
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/challenge/main)
@@ -614,14 +597,12 @@
 /area/awaymission/challenge/main)
 "bC" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitecorner"
 	},
 /area/awaymission/challenge/main)
 "bD" = (
 /turf/simulated/floor{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/challenge/main)
 "bE" = (
@@ -664,8 +645,7 @@
 	locked = 1;
 	name = "Energy Cannon";
 	req_access_txt = "100";
-	state = 2;
-	use_power = 0
+	state = 2
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -682,8 +662,7 @@
 	locked = 1;
 	name = "Energy Cannon";
 	req_access_txt = "100";
-	state = 2;
-	use_power = 0
+	state = 2
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/challenge/main)
@@ -697,8 +676,7 @@
 	locked = 1;
 	name = "Energy Cannon";
 	req_access_txt = "100";
-	state = 2;
-	use_power = 0
+	state = 2
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -715,8 +693,7 @@
 	locked = 1;
 	name = "Energy Cannon";
 	req_access_txt = "100";
-	state = 2;
-	use_power = 0
+	state = 2
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -731,8 +708,7 @@
 "bN" = (
 /obj/item/weapon/gun/projectile/russian,
 /turf/simulated/floor{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/challenge/main)
 "bO" = (
@@ -752,7 +728,6 @@
 	desc = "Used for watching evil areas.";
 	name = "Security Monitor";
 	network = "";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/structure/table/reinforced,
@@ -765,7 +740,6 @@
 	desc = "Used for watching evil areas.";
 	name = "Security Monitor";
 	network = "";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/structure/table/reinforced,
@@ -783,7 +757,6 @@
 /area/awaymission/challenge/main)
 "bS" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/awaymission/challenge/main)
@@ -807,7 +780,6 @@
 	desc = "Used for watching evil areas.";
 	name = "Security Monitor";
 	network = "";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor/carpet,
@@ -817,8 +789,7 @@
 	id_tag = "challenge";
 	name = "Gateway Lockdown";
 	pixel_x = -4;
-	pixel_y = 26;
-	req_access_txt = "0"
+	pixel_y = 26
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/challenge/end)
@@ -864,7 +835,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/simulated/floor{
@@ -891,7 +861,6 @@
 /area/awaymission/challenge/end)
 "cf" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Airlock";
 	opacity = 1;
 	req_access_txt = "109"
 	},
@@ -959,9 +928,7 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/paper{
 	info = "Congratulations,<br><br>Your station has been selected to carry out the Gateway Project.<br><br>The equipment will be shipped to you at the start of the next quarter.<br> You are to prepare a secure location to house the equipment as outlined in the attached documents.<br><br>--Nanotrasen Blue Space Research";
-	name = "Confidential Correspondence, Pg 1";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "Confidential Correspondence, Pg 1"
 	},
 /obj/item/weapon/folder/blue,
 /turf/simulated/floor/carpet,
@@ -1165,10 +1132,8 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor{
-	icon_state = "pdoor1";
 	id_tag = "challenge";
-	name = "Gateway Shutters";
-	panel_open = 0
+	name = "Gateway Shutters"
 	},
 /turf/simulated/floor/bluegrid,
 /area/awaymission/challenge/end)
@@ -1191,19 +1156,15 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor{
-	icon_state = "pdoor1";
 	id_tag = "challenge";
-	name = "Gateway Shutters";
-	panel_open = 0
+	name = "Gateway Shutters"
 	},
 /turf/simulated/floor/bluegrid,
 /area/awaymission/challenge/end)
 "cX" = (
 /obj/machinery/door/poddoor{
-	icon_state = "pdoor1";
 	id_tag = "challenge";
-	name = "Gateway Shutters";
-	panel_open = 0
+	name = "Gateway Shutters"
 	},
 /turf/simulated/floor/bluegrid,
 /area/awaymission/challenge/end)
@@ -1231,10 +1192,8 @@
 "de" = (
 /obj/structure/window/reinforced,
 /obj/machinery/door/poddoor{
-	icon_state = "pdoor1";
 	id_tag = "challenge";
-	name = "Gateway Shutters";
-	panel_open = 0
+	name = "Gateway Shutters"
 	},
 /turf/simulated/floor/bluegrid,
 /area/awaymission/challenge/end)
@@ -1242,14 +1201,11 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor{
-	icon_state = "pdoor1";
 	id_tag = "challenge";
-	name = "Gateway Shutters";
-	panel_open = 0
+	name = "Gateway Shutters"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -1291,8 +1247,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -1347,8 +1302,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;

--- a/maps/RandomZLevels/example.dmm
+++ b/maps/RandomZLevels/example.dmm
@@ -40,7 +40,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "area power controller";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -77,8 +76,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/example)
@@ -146,8 +144,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/example)
@@ -155,8 +152,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/example)
@@ -261,7 +257,6 @@
 /area/awaymission/example)
 "aR" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaymission/example)
@@ -563,7 +558,6 @@
 "bD" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -586,8 +580,7 @@
 /area/awaymission/example)
 "bG" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /turf/simulated/floor,
 /area/awaymission/example)
@@ -849,7 +842,6 @@
 	},
 /obj/machinery/light_construct/small{
 	dir = 8;
-	icon_state = "bulb-construct-stage1";
 	tag = "icon-bulb-construct-stage1 (WEST)"
 	},
 /turf/simulated/floor,

--- a/maps/RandomZLevels/hive.dmm
+++ b/maps/RandomZLevels/hive.dmm
@@ -1456,8 +1456,7 @@
 	activate_id = "5";
 	name = "shortcut 5";
 	one_time = 1;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/unsimulated/floor/evil/breathing,
 /area/awaymission/hive)

--- a/maps/RandomZLevels/leviathan.dmm
+++ b/maps/RandomZLevels/leviathan.dmm
@@ -839,8 +839,7 @@
 /area/awaymission/leviathan/mining)
 "cE" = (
 /obj/machinery/door/airlock/glass_medical{
-	name = "Infirmary";
-	req_access_txt = "0"
+	name = "Infirmary"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "asteroidfloor"
@@ -1138,8 +1137,7 @@
 /area/awaymission/leviathan/research/mining)
 "dq" = (
 /obj/machinery/recharger{
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -1158,8 +1156,7 @@
 "ds" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -1169,8 +1166,7 @@
 "dt" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/status_display{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -1179,8 +1175,7 @@
 /area/awaymission/leviathan/research/mining)
 "du" = (
 /obj/machinery/recharger{
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -1193,8 +1188,7 @@
 "dv" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/recharger{
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor,
 /area/awaymission/leviathan/research/mining)
@@ -1232,8 +1226,7 @@
 "dA" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/recharger{
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/simulated/floor,
 /area/awaymission/leviathan/research/mining)
@@ -1266,8 +1259,7 @@
 /obj/structure/table,
 /obj/item/clothing/gloves/latex,
 /obj/machinery/status_display{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -1295,8 +1287,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/status_display{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light{
 	dir = 4
@@ -1600,7 +1591,6 @@
 	},
 /obj/machinery/power/apc{
 	name = "Mining";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor,
@@ -1712,7 +1702,6 @@
 	dir = 1
 	},
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/wood,
@@ -1833,8 +1822,7 @@
 "fa" = (
 /obj/machinery/door/window{
 	dir = 2;
-	name = "Shower";
-	req_access_txt = "0"
+	name = "Shower"
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -1865,8 +1853,7 @@
 /area/awaymission/leviathan/research)
 "fe" = (
 /obj/machinery/door/airlock/glass{
-	name = "Quarters";
-	req_access_txt = "0"
+	name = "Quarters"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1896,8 +1883,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/leviathan/research/mining)
@@ -1909,8 +1895,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/leviathan/research/mining)
@@ -1924,8 +1909,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/leviathan/research/mining)
@@ -1939,8 +1923,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/leviathan/research/mining)
@@ -1955,8 +1938,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/leviathan/research/mining)
@@ -1973,8 +1955,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/leviathan/research/mining)
@@ -1989,8 +1970,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/leviathan/research/mining)
@@ -1999,8 +1979,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2016,8 +1995,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/leviathan/research/mining)
@@ -2032,8 +2010,7 @@
 /area/awaymission/leviathan/research/mining)
 "fq" = (
 /obj/machinery/door/airlock/glass{
-	name = "Hydroponics";
-	req_access_txt = "0"
+	name = "Hydroponics"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2212,9 +2189,7 @@
 /area/awaymission/leviathan/research/mining)
 "fL" = (
 /obj/machinery/door/airlock/glass_medical{
-	id_tag = null;
-	name = "Infirmary";
-	req_access_txt = "0"
+	name = "Infirmary"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
@@ -2234,8 +2209,7 @@
 /area/awaymission/leviathan/research/mining)
 "fN" = (
 /obj/machinery/door/airlock/glass{
-	name = "Crew Area";
-	req_access_txt = "0"
+	name = "Crew Area"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
@@ -2355,7 +2329,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Research";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
@@ -2457,7 +2430,6 @@
 	desc = "Used for watching the isolation room cameras.";
 	name = "Isolation Room Telescreen";
 	network = list("isolation");
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plating,
@@ -2473,14 +2445,12 @@
 "gq" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Storage";
-	req_access_txt = "0";
 	req_one_access_txt = "11;47"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/leviathan/research)
@@ -2488,8 +2458,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -2684,7 +2653,6 @@
 	dir = 8
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor{
@@ -2725,7 +2693,6 @@
 "gT" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Auxiliary Storage";
-	req_access_txt = "0";
 	req_one_access_txt = "11;47"
 	},
 /turf/simulated/floor/plating,
@@ -2794,8 +2761,7 @@
 /obj/structure/sign/examroom{
 	desc = "A guidance sign which reads 'ISOLATION ROOM ONE'";
 	name = "\improper ISOLATION ROOM ONE";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -3012,8 +2978,6 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor{
@@ -3056,8 +3020,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -3073,8 +3036,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -3093,8 +3055,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -3111,8 +3072,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -3128,8 +3088,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -3147,8 +3106,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -3214,8 +3172,7 @@
 /obj/structure/sign/examroom{
 	desc = "A guidance sign which reads 'ISOLATION ROOM TWO'";
 	name = "\improper ISOLATION ROOM TWO";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -3321,8 +3278,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/leviathan/research/mining)
@@ -3333,8 +3289,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/leviathan/research/mining)
@@ -3458,7 +3413,6 @@
 "io" = (
 /obj/machinery/disposal,
 /obj/structure/sign/deathsposal{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/disposalpipe/trunk,
@@ -3673,11 +3627,9 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitegreencorner"
 	},
 /area/awaymission/leviathan/research/gateway)
@@ -3693,7 +3645,6 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitegreen"
 	},
 /area/awaymission/leviathan/research/gateway)
@@ -3707,17 +3658,14 @@
 	dir = 1;
 	name = "Gateway";
 	operating = 0;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitegreen"
 	},
 /area/awaymission/leviathan/research/gateway)
 "iM" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitegreen"
 	},
 /area/awaymission/leviathan/research/gateway)
@@ -3741,8 +3689,6 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor{
@@ -4167,7 +4113,6 @@
 	dir = 9
 	},
 /obj/machinery/door/window{
-	dir = 4;
 	name = "Spectroscopy"
 	},
 /turf/simulated/floor{
@@ -4176,7 +4121,6 @@
 /area/awaymission/leviathan/research)
 "jJ" = (
 /obj/machinery/door/window{
-	dir = 4;
 	name = "Spectroscopy"
 	},
 /turf/simulated/floor{
@@ -4308,8 +4252,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "white"

--- a/maps/RandomZLevels/listeningpost.dmm
+++ b/maps/RandomZLevels/listeningpost.dmm
@@ -236,7 +236,6 @@
 "aK" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
 	tag = "icon-shower (WEST)"
 	},
 /turf/simulated/floor{
@@ -246,7 +245,6 @@
 "aL" = (
 /obj/structure/toilet{
 	dir = 8;
-	icon_state = "toilet00";
 	tag = "icon-toilet00 (WEST)"
 	},
 /turf/simulated/floor{

--- a/maps/RandomZLevels/snowplanet.dmm
+++ b/maps/RandomZLevels/snowplanet.dmm
@@ -104,7 +104,6 @@
 "az" = (
 /obj/machinery/gateway/away,
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "loading_area";
 	tag = "icon-loading_area"
 	},

--- a/maps/RandomZLevels/spacebattle.dmm
+++ b/maps/RandomZLevels/spacebattle.dmm
@@ -3099,13 +3099,6 @@
 	icon_state = "alienvault"
 	},
 /area/awaymission/spacebattle/secret)
-"rK" = (
-/obj/effect/landmark{
-	name = "awaystart"
-	},
-/obj/mecha/working/ripley/mk2/firefighter,
-/turf/simulated/floor,
-/area/awaymission/spacebattle/cruiser)
 
 (1,1,1) = {"
 aa
@@ -25581,7 +25574,7 @@ ce
 ce
 ce
 ce
-rK
+cQ
 cQ
 cQ
 dm
@@ -28414,7 +28407,7 @@ cC
 ce
 dr
 dO
-cM
+dO
 cM
 cM
 cM

--- a/maps/RandomZLevels/spacebattle.dmm
+++ b/maps/RandomZLevels/spacebattle.dmm
@@ -23,7 +23,6 @@
 "ae" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-propulsion (NORTH)";
-	icon_state = "propulsion";
 	dir = 1
 	},
 /turf/space,
@@ -51,7 +50,6 @@
 "ai" = (
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/window/reinforced,
@@ -152,7 +150,6 @@
 "ax" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-propulsion (NORTH)";
-	icon_state = "propulsion";
 	dir = 1
 	},
 /turf/space,
@@ -187,7 +184,6 @@
 "aC" = (
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/window/reinforced,
@@ -294,7 +290,6 @@
 "aR" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-propulsion (NORTH)";
-	icon_state = "propulsion";
 	dir = 1
 	},
 /turf/space,
@@ -332,7 +327,6 @@
 "aX" = (
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/window/reinforced,
@@ -342,7 +336,6 @@
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -354,7 +347,6 @@
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -454,10 +446,8 @@
 /area/awaymission/spacebattle/syndicate2)
 "bn" = (
 /obj/machinery/door/poddoor{
-	icon_state = "pdoor1";
 	id_tag = "spacebattlepod3";
-	name = "Front Hull Door";
-	opacity = 1
+	name = "Front Hull Door"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/awaymission/spacebattle/syndicate2)
@@ -654,7 +644,6 @@
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -671,7 +660,6 @@
 /obj/structure/window/reinforced,
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (NORTH)";
-	icon_state = "heater";
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -712,7 +700,6 @@
 "ca" = (
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (WEST)";
-	icon_state = "heater";
 	dir = 8
 	},
 /obj/structure/window/reinforced{
@@ -752,7 +739,6 @@
 "ch" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-propulsion (EAST)";
-	icon_state = "propulsion";
 	dir = 4
 	},
 /turf/space,
@@ -775,8 +761,7 @@
 	density = 0;
 	icon_state = "pdoor0";
 	id_tag = "spacebattlepod";
-	name = "Front Hull Door";
-	opacity = 1
+	name = "Front Hull Door"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/awaymission/spacebattle/cruiser)
@@ -887,54 +872,47 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/reagent_containers/food/snacks/sausage,
 /turf/simulated/floor{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cF" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cG" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/kitchen/utensil/knife/large,
 /turf/simulated/floor{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cH" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/kitchen/rollingpin,
 /turf/simulated/floor{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cI" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cJ" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
 /turf/simulated/floor{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cL" = (
@@ -967,8 +945,7 @@
 /area/awaymission/spacebattle/cruiser)
 "cR" = (
 /turf/simulated/floor{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cS" = (
@@ -986,31 +963,27 @@
 "cV" = (
 /obj/machinery/door/unpowered/shuttle,
 /turf/simulated/floor{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cW" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/reagent_containers/food/snacks/fries,
 /turf/simulated/floor{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cX" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/reagent_containers/food/snacks/stew,
 /turf/simulated/floor{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cY" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor{
-	icon_state = "cafeteria";
-	dir = 2
+	icon_state = "cafeteria"
 	},
 /area/awaymission/spacebattle/cruiser)
 "cZ" = (
@@ -1135,8 +1108,7 @@
 	density = 0;
 	icon_state = "pdoor0";
 	id_tag = "spacebattlepod2";
-	name = "Front Hull Door";
-	opacity = 1
+	name = "Front Hull Door"
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/awaymission/spacebattle/cruiser)
@@ -1268,7 +1240,7 @@
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "dO" = (
-/obj/mecha/working/ripley/firefighter,
+/obj/mecha/working/ripley/mk2/firefighter,
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "dP" = (
@@ -2153,19 +2125,16 @@
 /area/awaymission/spacebattle/cruiser)
 "gw" = (
 /obj/machinery/door_control{
-	dir = 2;
 	id_tag = "spacebattlestorage";
 	name = "Secure Storage";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "gx" = (
 /obj/machinery/computer/operating,
 /turf/simulated/floor{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/spacebattle/cruiser)
 "gy" = (
@@ -2173,32 +2142,28 @@
 /obj/item/tool/scalpel,
 /obj/item/tool/circular_saw,
 /turf/simulated/floor{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/spacebattle/cruiser)
 "gz" = (
 /obj/structure/table/reinforced,
 /obj/item/tool/retractor,
 /turf/simulated/floor{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/spacebattle/cruiser)
 "gA" = (
 /obj/structure/table/reinforced,
 /obj/item/tool/hemostat,
 /turf/simulated/floor{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/spacebattle/cruiser)
 "gB" = (
 /obj/structure/table/reinforced,
 /obj/item/tool/scalpel,
 /turf/simulated/floor{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "whitehall"
 	},
 /area/awaymission/spacebattle/cruiser)
 "gC" = (
@@ -2451,7 +2416,6 @@
 "hq" = (
 /obj/structure/shuttle/engine/heater{
 	tag = "icon-heater (EAST)";
-	icon_state = "heater";
 	dir = 4
 	},
 /obj/structure/window/reinforced{
@@ -2688,7 +2652,6 @@
 "hZ" = (
 /obj/machinery/shower{
 	tag = "icon-shower (EAST)";
-	icon_state = "shower";
 	dir = 4
 	},
 /obj/item/weapon/bikehorn/rubberducky,
@@ -2704,7 +2667,6 @@
 "ib" = (
 /obj/machinery/shower{
 	tag = "icon-shower (WEST)";
-	icon_state = "shower";
 	dir = 8
 	},
 /turf/simulated/floor{
@@ -2752,7 +2714,6 @@
 "ij" = (
 /obj/machinery/shower{
 	tag = "icon-shower (EAST)";
-	icon_state = "shower";
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -2762,7 +2723,6 @@
 "ik" = (
 /obj/machinery/shower{
 	tag = "icon-shower (WEST)";
-	icon_state = "shower";
 	dir = 8
 	},
 /obj/item/weapon/soap,
@@ -2820,9 +2780,7 @@
 "is" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
@@ -3141,6 +3099,13 @@
 	icon_state = "alienvault"
 	},
 /area/awaymission/spacebattle/secret)
+"rK" = (
+/obj/effect/landmark{
+	name = "awaystart"
+	},
+/obj/mecha/working/ripley/mk2/firefighter,
+/turf/simulated/floor,
+/area/awaymission/spacebattle/cruiser)
 
 (1,1,1) = {"
 aa
@@ -25616,7 +25581,7 @@ ce
 ce
 ce
 ce
-cQ
+rK
 cQ
 cQ
 dm
@@ -28449,7 +28414,7 @@ cC
 ce
 dr
 dO
-dO
+cM
 cM
 cM
 cM

--- a/maps/RandomZLevels/stationCollision.dmm
+++ b/maps/RandomZLevels/stationCollision.dmm
@@ -213,7 +213,6 @@
 "aP" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8;
-	icon_state = "heater";
 	tag = "icon-heater (WEST)"
 	},
 /turf/simulated/floor/plating/airless,
@@ -362,7 +361,6 @@
 "bp" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
-	icon_state = "propulsion";
 	tag = "icon-propulsion (EAST)"
 	},
 /turf/simulated/wall/shuttle/unsmoothed{
@@ -376,7 +374,6 @@
 "br" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8;
-	icon_state = "heater";
 	tag = "icon-heater (WEST)"
 	},
 /turf/simulated/floor/shuttle/plating,
@@ -578,7 +575,6 @@
 "bW" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
-	icon_state = "heater";
 	tag = "icon-heater (NORTH)"
 	},
 /turf/simulated/floor/shuttle/plating,
@@ -659,7 +655,6 @@
 "ci" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4;
-	icon_state = "intact";
 	level = 2
 	},
 /turf/simulated/floor/airless{
@@ -685,7 +680,6 @@
 	stat = 2
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/awaymission/research)
@@ -728,7 +722,6 @@
 "co" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/awaymission/research)
@@ -798,7 +791,6 @@
 "cy" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
-	icon_state = "propulsion";
 	tag = "icon-propulsion (EAST)"
 	},
 /turf/space,
@@ -806,7 +798,6 @@
 "cz" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8;
-	icon_state = "heater";
 	tag = "icon-heater (WEST)"
 	},
 /obj/structure/window/reinforced,
@@ -896,7 +887,6 @@
 "cK" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8;
-	icon_state = "heater";
 	tag = "icon-heater (WEST)"
 	},
 /obj/structure/window/reinforced{
@@ -911,7 +901,6 @@
 "cL" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /obj/item/clothing/suit/storage/labcoat,
@@ -964,7 +953,6 @@
 "cR" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9;
-	icon_state = "intact";
 	level = 2
 	},
 /turf/simulated/floor/airless{
@@ -1039,7 +1027,6 @@
 "da" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /obj/structure/window/reinforced/tinted,
@@ -1181,8 +1168,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/research)
@@ -1190,8 +1176,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "delivery"
@@ -1207,8 +1192,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -1243,7 +1227,6 @@
 /obj/machinery/singularity/narsie/wizard/sc_Narsie{
 	current_size = 5;
 	pixel_x = -240;
-	pixel_y = -256;
 	throw_range = 5
 	},
 /turf/space,
@@ -1291,7 +1274,6 @@
 "dB" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	pixel_y = -10
 	},
 /obj/structure/window/reinforced/tinted{
@@ -1654,8 +1636,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/northblock)
@@ -1663,8 +1644,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "damaged3"
@@ -1674,8 +1654,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/northblock)
@@ -1683,8 +1662,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "floorscorched1"
@@ -1694,8 +1672,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "damaged2"
@@ -1705,8 +1682,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -1717,8 +1693,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "floorscorched2"
@@ -1769,7 +1744,6 @@
 "eH" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4;
-	icon_state = "intact";
 	level = 2
 	},
 /turf/simulated/floor{
@@ -1779,7 +1753,6 @@
 "eI" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9;
-	icon_state = "intact";
 	level = 2
 	},
 /obj/machinery/light/small{
@@ -1792,7 +1765,6 @@
 "eJ" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8;
-	icon_state = "heater";
 	tag = "icon-heater (WEST)"
 	},
 /obj/structure/window/reinforced{
@@ -2238,7 +2210,6 @@
 /obj/item/clothing/head/helmet/space/syndicate,
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /obj/item/clothing/shoes/syndigaloshes,
@@ -2269,8 +2240,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless{
 	icon_state = "damaged5"
@@ -2627,8 +2597,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/midblock)
@@ -2639,8 +2608,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/item/weapon/gun/projectile/shotgun/pump/sc_pump,
@@ -2651,8 +2619,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/midblock)
@@ -2691,7 +2658,6 @@
 "gO" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /obj/effect/landmark/sc_bible_spawner,
@@ -2746,7 +2712,6 @@
 	},
 /obj/effect/decal/remains/human,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/awaymission/arrivalblock)
@@ -3125,7 +3090,6 @@
 "hU" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /obj/item/ammo_casing/a12mm,
@@ -3195,8 +3159,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/arrivalblock)
@@ -3207,8 +3170,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/arrivalblock)
@@ -3217,8 +3179,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -3227,14 +3188,12 @@
 /area/awaymission/arrivalblock)
 "ie" = (
 /obj/machinery/door/airlock/glass_security{
-	name = "Glass Airlock";
-	req_access_txt = "0"
+	name = "Glass Airlock"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/arrivalblock)
@@ -3242,8 +3201,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
 /area/awaymission/midblock)
@@ -3284,7 +3242,6 @@
 "ik" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /obj/item/ammo_casing/a12mm,
@@ -3382,7 +3339,6 @@
 "iA" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /obj/item/ammo_casing/a12mm,
@@ -3405,7 +3361,6 @@
 "iC" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /obj/item/ammo_casing/a12mm,
@@ -3640,8 +3595,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
 /area/awaymission/southblock)
@@ -3652,8 +3606,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
 /area/awaymission/southblock)
@@ -3661,8 +3614,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -3678,8 +3630,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
 /area/awaymission/southblock)
@@ -3729,9 +3680,7 @@
 /area/awaymission/southblock)
 "jv" = (
 /obj/machinery/door/airlock/glass_medical{
-	id_tag = null;
-	name = "Glass Airlock";
-	req_access_txt = "0"
+	name = "Glass Airlock"
 	},
 /turf/simulated/floor,
 /area/awaymission/southblock)
@@ -3792,7 +3741,6 @@
 "jE" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /turf/simulated/floor,
@@ -3962,13 +3910,11 @@
 "kh" = (
 /obj/machinery/light/small,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
 "ki" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
@@ -3976,7 +3922,6 @@
 /obj/structure/table,
 /obj/item/weapon/paper_bin,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
@@ -4171,7 +4116,6 @@
 /obj/item/clothing/under/syndicate,
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /obj/item/weapon/paper/sc_safehint_paper_hydro,
@@ -4647,8 +4591,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/southblock)
@@ -4656,8 +4599,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -4673,8 +4615,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -4685,8 +4626,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -4697,8 +4637,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering,
 /turf/simulated/floor,
@@ -4707,8 +4646,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/awaymission/gateroom)
@@ -4716,8 +4654,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4773,14 +4710,12 @@
 	icon_state = "twindow"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
 "mi" = (
 /obj/machinery/sleeper,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/awaymission/southblock)
@@ -4808,8 +4743,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Gateroom APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable{
 	d2 = 8;

--- a/maps/RandomZLevels/tomb.dmm
+++ b/maps/RandomZLevels/tomb.dmm
@@ -104,7 +104,6 @@
 /obj/structure/button{
 	activate_id = "6";
 	name = "drawbridge (6)";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor,
@@ -718,7 +717,6 @@
 /area/awaymission/tomb/tower_of_madness)
 "cB" = (
 /obj/structure/ladder{
-	height = 0;
 	id = "5-6";
 	name = "Tower of Madness level 6"
 	},
@@ -1063,7 +1061,6 @@
 /area/awaymission/tomb/outside/pyramid_outside)
 "dF" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "ramptop"
 	},
 /area/awaymission/tomb/tomb_of_rafid)
@@ -1222,7 +1219,6 @@
 /area/awaymission/tomb/tower_of_madness)
 "ea" = (
 /obj/structure/ladder{
-	height = 0;
 	id = "4-5";
 	name = "Tower of Madness level 5"
 	},
@@ -1312,8 +1308,7 @@
 "eo" = (
 /turf/unsimulated/floor{
 	dir = 1;
-	icon_state = "ramptop";
-	name = "floor"
+	icon_state = "ramptop"
 	},
 /area/awaymission/tomb/outside/pyramid_outside)
 "ep" = (
@@ -1480,15 +1475,13 @@
 "eP" = (
 /turf/unsimulated/floor{
 	dir = 8;
-	icon_state = "ramptop";
-	name = "floor"
+	icon_state = "ramptop"
 	},
 /area/awaymission/tomb/outside/pyramid_outside)
 "eQ" = (
 /turf/unsimulated/floor{
 	dir = 4;
-	icon_state = "ramptop";
-	name = "floor"
+	icon_state = "ramptop"
 	},
 /area/awaymission/tomb/outside/pyramid_outside)
 "eR" = (
@@ -1836,7 +1829,6 @@
 /area/awaymission/tomb/tower_of_madness)
 "fT" = (
 /obj/structure/ladder{
-	height = 0;
 	id = "3-4";
 	name = "Tower of Madness level 4"
 	},
@@ -2269,7 +2261,6 @@
 /area/awaymission/tomb/tomb_of_rafid)
 "gV" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "ramptop"
 	},
 /area/awaymission/tomb/tower_of_madness)
@@ -2473,7 +2464,6 @@
 /area/awaymission/tomb/tower_of_madness)
 "hB" = (
 /obj/structure/ladder{
-	height = 0;
 	id = "2-3";
 	name = "Tower of Madness level 3"
 	},
@@ -2894,8 +2884,7 @@
 "iO" = (
 /obj/item/weapon/skull/rigged{
 	desc = "It's stuck to the floor!";
-	name = "cursed skull";
-	pixel_y = 0
+	name = "cursed skull"
 	},
 /turf/simulated/floor,
 /area/awaymission/tomb/tomb_of_rafid)
@@ -2937,7 +2926,6 @@
 	dir = 4
 	},
 /obj/structure/ladder{
-	height = 0;
 	id = "1-2";
 	name = "Tower of Madness level 2"
 	},
@@ -2978,7 +2966,6 @@
 /area/awaymission/tomb/tower_of_madness)
 "iZ" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "ramptop"
 	},
 /area/awaymission/tomb/sewers)

--- a/maps/RandomZLevels/wildwest.dmm
+++ b/maps/RandomZLevels/wildwest.dmm
@@ -1369,7 +1369,6 @@
 "dV" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /turf/simulated/floor{
@@ -1381,7 +1380,6 @@
 "dW" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
 	tag = "icon-shower (WEST)"
 	},
 /turf/simulated/floor{

--- a/maps/misc/holodeck.dmm
+++ b/maps/misc/holodeck.dmm
@@ -1899,9 +1899,7 @@
 /area/holodeck/source_thunderdomecourt)
 "fC" = (
 /obj/structure/table/holotable,
-/obj/machinery/readybutton{
-	pixel_y = 0
-	},
+/obj/machinery/readybutton,
 /turf/simulated/floor/holofloor{
 	dir = 1;
 	icon_state = "red"
@@ -2210,9 +2208,7 @@
 	},
 /area/holodeck/source_wildride)
 "gB" = (
-/obj/machinery/conveyor/auto{
-	dir = 2
-	},
+/obj/machinery/conveyor/auto,
 /turf/simulated/floor/holofloor{
 	icon_state = "engine";
 	name = "Holodeck Projector Floor"
@@ -3357,9 +3353,7 @@
 /area/holodeck/source_thunderdomecourt)
 "jN" = (
 /obj/structure/table/holotable,
-/obj/machinery/readybutton{
-	pixel_y = 0
-	},
+/obj/machinery/readybutton,
 /turf/simulated/floor/holofloor{
 	icon_state = "green"
 	},

--- a/maps/misc/voxshuttle.dmm
+++ b/maps/misc/voxshuttle.dmm
@@ -495,7 +495,6 @@
 "bp" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "left";
-	dir = 4;
 	req_access = null
 	},
 /turf/simulated/floor/shuttle/vox{
@@ -884,7 +883,7 @@
 /area/shuttle/vox/station)
 "cd" = (
 /obj/machinery/light/small{
-	dir = 4;
+	dir = 4
 	},
 /obj/item/clothing/mask/breath,
 /obj/item/stack/medical/bruise_pack/bandaid,

--- a/maps/randomvaults/AIsat.dmm
+++ b/maps/randomvaults/AIsat.dmm
@@ -32,8 +32,7 @@
 "ah" = (
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/catwalk,
 /obj/machinery/power/solar/panel/tracker,
@@ -317,9 +316,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/no_alerts/vault_AIsat{
-	pixel_x = 0
-	},
+/obj/machinery/power/apc/no_alerts/vault_AIsat,
 /turf/simulated/floor/greengrid,
 /area/vault/AIsat)
 "aS" = (
@@ -526,8 +523,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/vault/AIsat)

--- a/maps/randomvaults/amelab.dmm
+++ b/maps/randomvaults/amelab.dmm
@@ -569,7 +569,6 @@
 /area/vault/amelab)
 "yK" = (
 /obj/structure/extinguisher_cabinet{
-	dir = 2;
 	pixel_y = 30
 	},
 /obj/machinery/light{

--- a/maps/randomvaults/biodome.dmm
+++ b/maps/randomvaults/biodome.dmm
@@ -505,7 +505,6 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor,
@@ -516,12 +515,6 @@
 /area/vault/biodome)
 "bA" = (
 /obj/structure/flora/ausbushes/palebush,
-/turf/simulated/floor/grass,
-/area/vault/biodome)
-"bB" = (
-/obj/structure/window/reinforced{
-	dir = 2
-	},
 /turf/simulated/floor/grass,
 /area/vault/biodome)
 "bC" = (
@@ -951,7 +944,7 @@ am
 am
 am
 am
-bB
+aJ
 bD
 bH
 ak

--- a/maps/randomvaults/black_site_prism.dmm
+++ b/maps/randomvaults/black_site_prism.dmm
@@ -1058,7 +1058,6 @@
 /obj/item/weapon/bedsheet/purple,
 /obj/structure/window/reinforced,
 /mob/living/simple_animal/hostile/humanoid/wizard{
-	color = null;
 	name = "Garrious the Unpleasant"
 	},
 /turf/unsimulated/floor{

--- a/maps/randomvaults/brokeufo.dmm
+++ b/maps/randomvaults/brokeufo.dmm
@@ -1,118 +1,1180 @@
-"aa" = (/turf/space,/area)
-"ac" = (/obj/effect/decal/warning_stripes{icon_state = "1"},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/engine,/area/shuttle/brokeufo/start)
-"ae" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'EXTERNAL AIRLOCK'"; icon_state = "space"; name = "EXTERNAL AIRLOCK"},/turf/simulated/wall/shuttle,/area/shuttle/brokeufo/start)
-"af" = (/obj/effect/decal/cleanable/blood{icon_state = "floor3"},/turf/simulated/floor/engine,/area/shuttle/brokeufo/start)
-"ag" = (/obj/structure/shuttle/engine/propulsion{dir = 1},/turf/space,/area/shuttle/brokeufo/start)
-"ai" = (/obj/structure/table/reinforced,/obj/item/weapon/storage/toolbox/electrical,/obj/item/device/flashlight/flare/ever_bright,/turf/simulated/floor{dir = 9; icon_state = "yellowfull"},/area/shuttle/brokeufo/start)
-"am" = (/obj/effect/decal/warning_stripes{icon_state = "2"},/turf/simulated/floor/engine,/area/shuttle/brokeufo/start)
-"an" = (/obj/effect/decal/warning_stripes{icon_state = "3"},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/engine,/area/shuttle/brokeufo/start)
-"ap" = (/obj/structure/shuttle/diag_wall/smooth{dir = 8},/turf/space,/area/shuttle/brokeufo/start)
-"aq" = (/obj/item/clothing/gloves/yellow,/turf/simulated/floor{dir = 9; icon_state = "yellowfull"},/area/shuttle/brokeufo/start)
-"ar" = (/obj/structure/shuttle/diag_wall/smooth{dir = 1},/turf/space,/area/shuttle/brokeufo/start)
-"as" = (/turf/simulated/floor/carpet,/area/shuttle/brokeufo/start)
-"au" = (/obj/machinery/light/small{dir = 4},/obj/machinery/vending/medical{emagged = 1; req_access = null; req_access_txt = "162"; req_one_access_txt = "162"},/turf/simulated/floor/engine,/area/shuttle/brokeufo/start)
-"av" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/warning_stripes{icon_state = "bot"},/obj/structure/cage,/obj/effect/landmark/corpse/nazi,/turf/simulated/floor/engine,/area/shuttle/brokeufo/start)
-"aw" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor{dir = 9; icon_state = "yellowfull"},/area/shuttle/brokeufo/start)
-"aB" = (/obj/structure/shuttle/engine/heater{dir = 1},/obj/structure/window/reinforced/plasma,/turf/simulated/floor{icon_state = "old_enginewarn"; tag = "icon-old_enginewarn"},/area/shuttle/brokeufo/start)
-"aC" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/shuttle/brokeufo/start)
-"aE" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/warning_stripes{icon_state = "bot"},/obj/structure/cage,/obj/effect/landmark/corpse/trader,/turf/simulated/floor/engine,/area/shuttle/brokeufo/start)
-"aF" = (/obj/machinery/light{dir = 8},/obj/machinery/vending/engivend,/turf/simulated/floor{dir = 9; icon_state = "yellowfull"},/area/shuttle/brokeufo/start)
-"aG" = (/obj/structure/shuttle/diag_wall/smooth{dir = 8},/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"aH" = (/obj/structure/closet/crate,/obj/item/weapon/reagent_containers/food/snacks/zam_spiderslider/wrapped,/obj/item/weapon/reagent_containers/food/snacks/zamitos_stokjerky,/obj/item/weapon/reagent_containers/food/condiment/zamspices,/turf/simulated/floor/carpet,/area/shuttle/brokeufo/start)
-"aI" = (/obj/effect/decal/warning_stripes{icon_state = "bot"},/obj/structure/cage,/obj/effect/landmark/corpse/clown,/turf/simulated/floor/engine,/area/shuttle/brokeufo/start)
-"aJ" = (/turf/simulated/floor/engine,/area/shuttle/brokeufo/start)
-"aN" = (/obj/structure/bed,/obj/effect/decal/cleanable/dirt,/obj/item/trash/zam_sliderwrapper,/obj/item/weapon/bedsheet/green,/turf/simulated/floor/carpet,/area/shuttle/brokeufo/start)
-"aO" = (/obj/structure/bed,/obj/item/weapon/bedsheet/green,/turf/simulated/floor/carpet,/area/shuttle/brokeufo/start)
-"aP" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/door/airlock/vault{id_tag = "ufocell"; locked = 1; name = "Specimen Containment"; req_access_txt = "162"; req_one_access_txt = "162"},/turf/simulated/floor/engine,/area/shuttle/brokeufo/start)
-"aR" = (/obj/structure/rack,/obj/item/weapon/handcuffs,/obj/item/weapon/handcuffs,/obj/item/weapon/handcuffs,/obj/item/device/flashlight/flare/ever_bright,/obj/effect/decal/warning_stripes{icon_state = "unloading"},/turf/simulated/floor/engine,/area/shuttle/brokeufo/start)
-"aT" = (/obj/effect/decal/cleanable/dirt,/mob/living/simple_animal/hostile/humanoid/grey/explorer/space/ranged{name = "Gort"},/turf/simulated/floor/engine,/area/shuttle/brokeufo/start)
-"aU" = (/obj/machinery/door/airlock/silver{name = "Xenobiology Research Bay"; req_access_txt = "162"; req_one_access_txt = "162"},/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"aW" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/blood/gibs{icon_state = "gibleg"},/obj/item/device/flashlight/flare/ever_bright,/obj/item/organ/external/l_arm,/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"aX" = (/obj/machinery/door/airlock/silver{name = "Engine Access"; req_access_txt = "162"; req_one_access_txt = "162"},/turf/simulated/floor{dir = 9; icon_state = "yellowfull"},/area/shuttle/brokeufo/start)
-"aY" = (/obj/structure/table/reinforced,/obj/machinery/microwave/upgraded{pixel_y = 5},/obj/item/trash/used_tray,/obj/item/weapon/kitchen/utensil/fork/teflon{pixel_x = 6},/turf/simulated/floor/carpet,/area/shuttle/brokeufo/start)
-"aZ" = (/turf/simulated/wall/shuttle,/area/shuttle/brokeufo/start)
-"ba" = (/obj/structure/rack,/obj/item/weapon/storage/box/syringes,/obj/item/weapon/gun/syringe,/obj/effect/decal/warning_stripes{icon_state = "unloading"},/turf/simulated/floor/engine,/area/shuttle/brokeufo/start)
-"bb" = (/obj/effect/decal/cleanable/blood/drip,/mob/living/simple_animal/hostile/humanoid/grey/explorer/space/scalpel{name = "Nikto"},/obj/machinery/vending/wallmed1{pixel_x = 28},/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"bd" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/engine,/area/shuttle/brokeufo/start)
-"be" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/door/airlock/silver{name = "Crew Quarters"; req_access_txt = "162"; req_one_access_txt = "162"},/turf/simulated/floor/carpet,/area/shuttle/brokeufo/start)
-"bf" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/carpet,/area/shuttle/brokeufo/start)
-"bg" = (/obj/item/trash/zam_notraisins,/turf/simulated/floor/carpet,/area/shuttle/brokeufo/start)
-"bh" = (/obj/structure/bed,/obj/effect/decal/cleanable/dirt,/obj/item/weapon/soap,/obj/item/weapon/bedsheet/green,/turf/simulated/floor/carpet,/area/shuttle/brokeufo/start)
-"bi" = (/obj/structure/bed,/obj/machinery/light{dir = 4},/obj/item/weapon/bedsheet/green,/turf/simulated/floor/carpet,/area/shuttle/brokeufo/start)
-"bj" = (/obj/structure/table/reinforced,/obj/item/weapon/storage/bag/zam_food,/obj/item/weapon/reagent_containers/food/snacks/zamdinnerclassic,/obj/item/weapon/reagent_containers/food/snacks/zamdinnerclassic,/obj/item/weapon/reagent_containers/food/drinks/soda_cans/zam_sulphuricsplash,/obj/item/weapon/reagent_containers/food/drinks/soda_cans/zam_sulphuricsplash,/obj/effect/decal/cleanable/dirt,/obj/item/weapon/kitchen/utensil/fork/teflon,/obj/item/weapon/kitchen/utensil/fork/teflon,/turf/simulated/floor/carpet,/area/shuttle/brokeufo/start)
-"by" = (/obj/structure/bed/chair{dir = 4},/turf/simulated/floor/carpet,/area/shuttle/brokeufo/start)
-"bH" = (/turf/simulated/floor{icon_state = "darkredfull"; tag = "icon-darkredfull"},/area/shuttle/brokeufo/start)
-"ca" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor{icon_state = "darkredfull"; tag = "icon-darkredfull"},/area/shuttle/brokeufo/start)
-"cF" = (/obj/structure/shuttle/diag_wall/smooth{dir = 4},/turf/simulated/floor/plating,/area/shuttle/brokeufo/start)
-"cH" = (/obj/structure/table/reinforced,/obj/machinery/door_control{id_tag = "ufostorage"; name = "Storage Bolt Control"; normaldoorcontrol = 1; pixel_x = 25; specialfunctions = 4},/obj/machinery/recharger,/turf/simulated/floor{dir = 6; icon_state = "whitered"},/area/shuttle/brokeufo/start)
-"fd" = (/obj/structure/shuttle/diag_wall/smooth,/turf/simulated/floor/plating,/area/shuttle/brokeufo/start)
-"gw" = (/obj/machinery/light/small,/turf/simulated/floor/carpet,/area/shuttle/brokeufo/start)
-"gS" = (/obj/machinery/light/small,/turf/simulated/floor/plating,/area/shuttle/brokeufo/start)
-"gZ" = (/obj/item/device/flashlight/flare/ever_bright,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plating,/area/shuttle/brokeufo/start)
-"hl" = (/obj/machinery/light/small{dir = 1},/turf/simulated/floor/plating,/area/shuttle/brokeufo/start)
-"hD" = (/obj/structure/shuttle/diag_wall/smooth,/turf/space,/area/shuttle/brokeufo/start)
-"iq" = (/obj/structure/shuttle/engine/propulsion/left{dir = 1},/turf/space,/area/shuttle/brokeufo/start)
-"iH" = (/obj/structure/closet/walllocker/emerglocker{pixel_y = -30},/obj/machinery/light/small{dir = 1},/turf/simulated/floor/plating,/area/shuttle/brokeufo/start)
-"iU" = (/obj/effect/decal/cleanable/dirt,/obj/item/device/flashlight/flare/ever_bright,/obj/machinery/light/small{dir = 1},/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"iW" = (/obj/machinery/door/airlock/external{req_access_txt = "162"; req_one_access_txt = "162"},/turf/simulated/floor/plating,/area/shuttle/brokeufo/start)
-"jP" = (/obj/structure/closet/walllocker/emerglocker{pixel_y = 30},/obj/machinery/light/small/broken,/turf/simulated/floor/plating,/area/shuttle/brokeufo/start)
-"jZ" = (/obj/structure/shuttle/diag_wall/smooth{dir = 1},/turf/simulated/floor/plating,/area/shuttle/brokeufo/start)
-"kc" = (/obj/machinery/computer/shuttle_control/brokeufo{req_access_txt = "162"; req_one_access_txt = "162"},/turf/simulated/floor{icon_state = "whitered"; tag = "icon-whitered"},/area/shuttle/brokeufo/start)
-"kD" = (/obj/docking_port/destination/brokeufo/start,/turf/space,/area)
-"lK" = (/obj/structure/grille,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/full/reinforced,/obj/machinery/door/poddoor{id_tag = "ufobridge"; name = "Blast Shield Shutters"},/obj/docking_port/shuttle{dir = 2},/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"lV" = (/obj/structure/rack,/obj/item/weapon/cell/super,/obj/item/weapon/cell/super,/obj/item/weapon/electrolyzer,/obj/item/tool/solder/pre_fueled,/obj/item/tool/weldingtool/hugetank,/obj/item/weapon/switchtool/swiss_army_knife,/obj/item/tool/crowbar/red,/obj/item/stack/sheet/glass/glass/bigstack,/obj/item/stack/sheet/metal/bigstack,/obj/item/device/radio,/obj/effect/decal/warning_stripes{icon_state = "unloading"},/obj/item/device/multitool,/obj/item/weapon/storage/firstaid/adv,/obj/item/device/flashlight,/turf/simulated/floor{icon_state = "dark"},/area/shuttle/brokeufo/start)
-"mo" = (/obj/structure/shuttle/diag_wall/smooth{dir = 8},/turf/simulated/floor/plating,/area/shuttle/brokeufo/start)
-"nG" = (/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"oL" = (/obj/structure/table/reinforced,/obj/item/tool/bonesetter,/obj/item/tool/bonegel,/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"qo" = (/obj/machinery/door/airlock/vault{id_tag = "ufostorage"; locked = 1; name = "Storage Access"; req_access_txt = "162"; req_one_access_txt = "162"},/turf/simulated/floor{icon_state = "dark"},/area/shuttle/brokeufo/start)
-"rH" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor{dir = 1; icon_state = "darkredcorners"; tag = "icon-darkredcorners (NORTH)"},/area/shuttle/brokeufo/start)
-"tx" = (/obj/effect/decal/cleanable/blood/oil{icon_state = "floor6"},/mob/living/simple_animal/hostile/humanoid/grey/explorer/space/toolbox{name = "Klaatu"},/turf/simulated/floor{dir = 9; icon_state = "yellowfull"},/area/shuttle/brokeufo/start)
-"tS" = (/obj/structure/table/reinforced,/obj/item/stack/sheet/mineral/plastic{amount = 50},/obj/item/stack/sheet/metal{amount = 50},/obj/effect/decal/cleanable/dirt,/obj/item/weapon/storage/box/inflatables,/obj/machinery/power/apc{cell_type = 0; dir = 4; icon_state = "apc1"; opened = 1; pixel_x = 28},/turf/simulated/floor{dir = 9; icon_state = "yellowfull"},/area/shuttle/brokeufo/start)
-"uN" = (/mob/living/simple_animal/hostile/humanoid/grey/explorer/space/ranged{name = "Barada"},/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"ve" = (/obj/effect/decal/cleanable/dirt,/obj/structure/table/reinforced,/obj/machinery/light/small{dir = 8},/obj/item/weapon/storage/firstaid,/obj/item/weapon/storage/box/masks,/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"xP" = (/obj/machinery/door/airlock/silver{name = "Bridge"; req_access_txt = "162"; req_one_access_txt = "162"},/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"xT" = (/obj/structure/grille,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/full/reinforced,/obj/machinery/door/poddoor{id_tag = "ufobridge"; name = "Blast Shield Shutters"},/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"zX" = (/obj/structure/shuttle/diag_wall/smooth{dir = 1},/turf/simulated/floor{icon_state = "darkredcorners"; tag = "icon-darkredcorners"},/area/shuttle/brokeufo/start)
-"Af" = (/obj/structure/dispenser/oxygen,/obj/effect/decal/warning_stripes{icon_state = "unloading"},/turf/simulated/floor{icon_state = "dark"},/area/shuttle/brokeufo/start)
-"Aw" = (/obj/structure/closet/secure_closet/medical2{req_access = null; req_access_txt = "162"; req_one_access_txt = "162"},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"CM" = (/obj/structure/table/reinforced,/obj/item/stack/sheet/mineral/diamond{amount = 10},/turf/simulated/floor{dir = 8; icon_state = "whitered"},/area/shuttle/brokeufo/start)
-"DJ" = (/obj/machinery/light/small{dir = 1},/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"Ek" = (/obj/structure/sign/poster{icon_state = "bsposter10"; pixel_x = -32},/turf/simulated/floor{dir = 1; icon_state = "darkredcorners"; tag = "icon-darkredcorners (NORTH)"},/area/shuttle/brokeufo/start)
-"FC" = (/obj/structure/table/reinforced,/obj/item/weapon/switchtool/surgery,/obj/item/organ/internal/lungs/filter,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"Gm" = (/obj/effect/decal/cleanable/dirt,/obj/item/organ/external/l_hand,/obj/effect/decal/cleanable/blood{icon_state = "gibbl4"},/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"Gt" = (/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"IH" = (/obj/machinery/optable,/obj/machinery/light,/obj/effect/landmark/corpse/tajaran,/obj/effect/decal/cleanable/blood{icon_state = "floor4"},/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"IX" = (/obj/structure/table/reinforced,/obj/effect/decal/cleanable/dirt,/obj/item/weapon/cell/super/empty,/obj/item/weapon/cell/super/empty,/obj/machinery/cell_charger,/turf/simulated/floor{dir = 6; icon_state = "whitered"},/area/shuttle/brokeufo/start)
-"Pb" = (/obj/structure/table/reinforced,/obj/item/weapon/gun/projectile/flare,/turf/simulated/floor{dir = 10; icon_state = "whitered"},/area/shuttle/brokeufo/start)
-"RO" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor{icon_state = "dark"},/area/shuttle/brokeufo/start)
-"SG" = (/obj/structure/shuttle/diag_wall/smooth{dir = 4},/turf/space,/area/shuttle/brokeufo/start)
-"Tp" = (/turf/simulated/floor{icon_state = "dark"},/area/shuttle/brokeufo/start)
-"TL" = (/obj/machinery/light/small{dir = 1},/turf/simulated/floor{icon_state = "darkredcorners"; tag = "icon-darkredcorners"},/area/shuttle/brokeufo/start)
-"Ue" = (/obj/structure/bed/chair/shuttle/red,/obj/item/stack/cable_coil/random,/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"Us" = (/obj/structure/grille,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/obj/structure/window/full/reinforced,/obj/machinery/door/poddoor{id_tag = "ufobridge"; name = "Blast Shield Shutters"},/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"UW" = (/obj/machinery/light,/obj/structure/rack,/obj/item/clothing/shoes/magboots,/obj/item/clothing/head/helmet/space/nasavoid,/obj/item/clothing/suit/space/nasavoid,/obj/item/weapon/tank/jetpack/carbondioxide,/obj/effect/decal/warning_stripes{icon_state = "unloading"},/obj/item/weapon/gun/energy/smalldisintegrator,/turf/simulated/floor{icon_state = "dark"},/area/shuttle/brokeufo/start)
-"WO" = (/obj/structure/table/reinforced,/obj/item/weapon/storage/pill_bottle/zambiscuits,/obj/item/weapon/reagent_containers/food/snacks/zambiscuit_butter,/obj/item/weapon/reagent_containers/food/snacks/zambiscuit,/obj/item/weapon/reagent_containers/food/snacks/zambiscuit,/turf/simulated/floor{dir = 4; icon_state = "whitered"},/area/shuttle/brokeufo/start)
-"XF" = (/turf/simulated/floor/plating,/area/shuttle/brokeufo/start)
-"XU" = (/obj/structure/closet/crate/freezer/surgery,/obj/item/organ/internal/heart/insectoid,/obj/item/organ/internal/heart,/obj/item/organ/internal/heart,/obj/item/organ/internal/lungs,/obj/item/organ/internal/lungs/plasmaman,/obj/item/organ/internal/lungs/vox,/obj/item/organ/internal/lungs,/obj/item/organ/internal/liver,/obj/item/organ/internal/eyes/grey,/obj/item/organ/internal/eyes/tajaran,/obj/item/organ/internal/eyes/tajaran,/obj/item/organ/internal/kidneys,/obj/item/organ/internal/appendix,/obj/item/organ/internal/appendix,/obj/effect/decal/warning_stripes{icon_state = "unloading"},/turf/simulated/floor{icon_state = "dark"},/area/shuttle/brokeufo/start)
-"Zo" = (/obj/structure/table/reinforced,/obj/item/weapon/storage/fancy/flares,/obj/machinery/door_control{id_tag = "ufocell"; name = "Cell Bolt Control"; normaldoorcontrol = 1; pixel_x = -25; pixel_y = 5; specialfunctions = 4},/obj/machinery/door_control{id_tag = "ufobridge"; name = "Blast Shield Control"; pixel_x = -25; pixel_y = -5},/obj/item/weapon/card/id/mothership_soldier,/obj/item/weapon/card/id/mothership_soldier,/turf/simulated/floor{dir = 10; icon_state = "whitered"},/area/shuttle/brokeufo/start)
-"ZA" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor{icon_state = "white"; tag = "icon-white"},/area/shuttle/brokeufo/start)
-"ZR" = (/obj/item/toy/gasha/wizard,/turf/space,/area)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/space,
+/area)
+"ac" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/engine,
+/area/shuttle/brokeufo/start)
+"ae" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	name = "EXTERNAL AIRLOCK"
+	},
+/turf/simulated/wall/shuttle,
+/area/shuttle/brokeufo/start)
+"af" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor3"
+	},
+/turf/simulated/floor/engine,
+/area/shuttle/brokeufo/start)
+"ag" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1
+	},
+/turf/space,
+/area/shuttle/brokeufo/start)
+"ai" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/device/flashlight/flare/ever_bright,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "yellowfull"
+	},
+/area/shuttle/brokeufo/start)
+"am" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "2"
+	},
+/turf/simulated/floor/engine,
+/area/shuttle/brokeufo/start)
+"an" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/engine,
+/area/shuttle/brokeufo/start)
+"ap" = (
+/obj/structure/shuttle/diag_wall/smooth{
+	dir = 8
+	},
+/turf/space,
+/area/shuttle/brokeufo/start)
+"aq" = (
+/obj/item/clothing/gloves/yellow,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "yellowfull"
+	},
+/area/shuttle/brokeufo/start)
+"ar" = (
+/obj/structure/shuttle/diag_wall/smooth{
+	dir = 1
+	},
+/turf/space,
+/area/shuttle/brokeufo/start)
+"as" = (
+/turf/simulated/floor/carpet,
+/area/shuttle/brokeufo/start)
+"au" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/vending/medical{
+	emagged = 1;
+	req_access = null;
+	req_access_txt = "162";
+	req_one_access_txt = "162"
+	},
+/turf/simulated/floor/engine,
+/area/shuttle/brokeufo/start)
+"av" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/obj/structure/cage,
+/obj/effect/landmark/corpse/nazi,
+/turf/simulated/floor/engine,
+/area/shuttle/brokeufo/start)
+"aw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "yellowfull"
+	},
+/area/shuttle/brokeufo/start)
+"aB" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 1
+	},
+/obj/structure/window/reinforced/plasma,
+/turf/simulated/floor{
+	icon_state = "old_enginewarn";
+	tag = "icon-old_enginewarn"
+	},
+/area/shuttle/brokeufo/start)
+"aC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/shuttle/brokeufo/start)
+"aE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/obj/structure/cage,
+/obj/effect/landmark/corpse/trader,
+/turf/simulated/floor/engine,
+/area/shuttle/brokeufo/start)
+"aF" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/vending/engivend,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "yellowfull"
+	},
+/area/shuttle/brokeufo/start)
+"aG" = (
+/obj/structure/shuttle/diag_wall/smooth{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"aH" = (
+/obj/structure/closet/crate,
+/obj/item/weapon/reagent_containers/food/snacks/zam_spiderslider/wrapped,
+/obj/item/weapon/reagent_containers/food/snacks/zamitos_stokjerky,
+/obj/item/weapon/reagent_containers/food/condiment/zamspices,
+/turf/simulated/floor/carpet,
+/area/shuttle/brokeufo/start)
+"aI" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/obj/structure/cage,
+/obj/effect/landmark/corpse/clown,
+/turf/simulated/floor/engine,
+/area/shuttle/brokeufo/start)
+"aJ" = (
+/turf/simulated/floor/engine,
+/area/shuttle/brokeufo/start)
+"aN" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/zam_sliderwrapper,
+/obj/item/weapon/bedsheet/green,
+/turf/simulated/floor/carpet,
+/area/shuttle/brokeufo/start)
+"aO" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet/green,
+/turf/simulated/floor/carpet,
+/area/shuttle/brokeufo/start)
+"aP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/vault{
+	id_tag = "ufocell";
+	locked = 1;
+	name = "Specimen Containment";
+	req_access_txt = "162";
+	req_one_access_txt = "162"
+	},
+/turf/simulated/floor/engine,
+/area/shuttle/brokeufo/start)
+"aR" = (
+/obj/structure/rack,
+/obj/item/weapon/handcuffs,
+/obj/item/weapon/handcuffs,
+/obj/item/weapon/handcuffs,
+/obj/item/device/flashlight/flare/ever_bright,
+/obj/effect/decal/warning_stripes{
+	icon_state = "unloading"
+	},
+/turf/simulated/floor/engine,
+/area/shuttle/brokeufo/start)
+"aT" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/humanoid/grey/explorer/space/ranged{
+	name = "Gort"
+	},
+/turf/simulated/floor/engine,
+/area/shuttle/brokeufo/start)
+"aU" = (
+/obj/machinery/door/airlock/silver{
+	name = "Xenobiology Research Bay";
+	req_access_txt = "162";
+	req_one_access_txt = "162"
+	},
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"aW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibleg"
+	},
+/obj/item/device/flashlight/flare/ever_bright,
+/obj/item/organ/external/l_arm,
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"aX" = (
+/obj/machinery/door/airlock/silver{
+	name = "Engine Access";
+	req_access_txt = "162";
+	req_one_access_txt = "162"
+	},
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "yellowfull"
+	},
+/area/shuttle/brokeufo/start)
+"aY" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave/upgraded{
+	pixel_y = 5
+	},
+/obj/item/trash/used_tray,
+/obj/item/weapon/kitchen/utensil/fork/teflon{
+	pixel_x = 6
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/brokeufo/start)
+"aZ" = (
+/turf/simulated/wall/shuttle,
+/area/shuttle/brokeufo/start)
+"ba" = (
+/obj/structure/rack,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/gun/syringe,
+/obj/effect/decal/warning_stripes{
+	icon_state = "unloading"
+	},
+/turf/simulated/floor/engine,
+/area/shuttle/brokeufo/start)
+"bb" = (
+/obj/effect/decal/cleanable/blood/drip,
+/mob/living/simple_animal/hostile/humanoid/grey/explorer/space/scalpel{
+	name = "Nikto"
+	},
+/obj/machinery/vending/wallmed1{
+	pixel_x = 28
+	},
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"bd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/engine,
+/area/shuttle/brokeufo/start)
+"be" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/silver{
+	name = "Crew Quarters";
+	req_access_txt = "162";
+	req_one_access_txt = "162"
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/brokeufo/start)
+"bf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/shuttle/brokeufo/start)
+"bg" = (
+/obj/item/trash/zam_notraisins,
+/turf/simulated/floor/carpet,
+/area/shuttle/brokeufo/start)
+"bh" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/soap,
+/obj/item/weapon/bedsheet/green,
+/turf/simulated/floor/carpet,
+/area/shuttle/brokeufo/start)
+"bi" = (
+/obj/structure/bed,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/weapon/bedsheet/green,
+/turf/simulated/floor/carpet,
+/area/shuttle/brokeufo/start)
+"bj" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/bag/zam_food,
+/obj/item/weapon/reagent_containers/food/snacks/zamdinnerclassic,
+/obj/item/weapon/reagent_containers/food/snacks/zamdinnerclassic,
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/zam_sulphuricsplash,
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/zam_sulphuricsplash,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/kitchen/utensil/fork/teflon,
+/obj/item/weapon/kitchen/utensil/fork/teflon,
+/turf/simulated/floor/carpet,
+/area/shuttle/brokeufo/start)
+"by" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/brokeufo/start)
+"bH" = (
+/turf/simulated/floor{
+	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
+	},
+/area/shuttle/brokeufo/start)
+"ca" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
+	},
+/area/shuttle/brokeufo/start)
+"cF" = (
+/obj/structure/shuttle/diag_wall/smooth{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/brokeufo/start)
+"cH" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id_tag = "ufostorage";
+	name = "Storage Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
+/obj/machinery/recharger,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "whitered"
+	},
+/area/shuttle/brokeufo/start)
+"fd" = (
+/obj/structure/shuttle/diag_wall/smooth,
+/turf/simulated/floor/plating,
+/area/shuttle/brokeufo/start)
+"gw" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/carpet,
+/area/shuttle/brokeufo/start)
+"gS" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/shuttle/brokeufo/start)
+"gZ" = (
+/obj/item/device/flashlight/flare/ever_bright,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/shuttle/brokeufo/start)
+"hl" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/brokeufo/start)
+"hD" = (
+/obj/structure/shuttle/diag_wall/smooth,
+/turf/space,
+/area/shuttle/brokeufo/start)
+"iq" = (
+/obj/structure/shuttle/engine/propulsion/left{
+	dir = 1
+	},
+/turf/space,
+/area/shuttle/brokeufo/start)
+"iH" = (
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_y = -30
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/brokeufo/start)
+"iU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/flashlight/flare/ever_bright,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"iW" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "162";
+	req_one_access_txt = "162"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/brokeufo/start)
+"jP" = (
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_y = 30
+	},
+/obj/machinery/light/small/broken,
+/turf/simulated/floor/plating,
+/area/shuttle/brokeufo/start)
+"jZ" = (
+/obj/structure/shuttle/diag_wall/smooth{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/brokeufo/start)
+"kc" = (
+/obj/machinery/computer/shuttle_control/brokeufo{
+	req_access_txt = "162";
+	req_one_access_txt = "162"
+	},
+/turf/simulated/floor{
+	icon_state = "whitered";
+	tag = "icon-whitered"
+	},
+/area/shuttle/brokeufo/start)
+"kD" = (
+/obj/docking_port/destination/brokeufo/start,
+/turf/space,
+/area)
+"lK" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/full/reinforced,
+/obj/machinery/door/poddoor{
+	id_tag = "ufobridge";
+	name = "Blast Shield Shutters"
+	},
+/obj/docking_port/shuttle{
+	dir = 2
+	},
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"lV" = (
+/obj/structure/rack,
+/obj/item/weapon/cell/super,
+/obj/item/weapon/cell/super,
+/obj/item/weapon/electrolyzer,
+/obj/item/tool/solder/pre_fueled,
+/obj/item/tool/weldingtool/hugetank,
+/obj/item/weapon/switchtool/swiss_army_knife,
+/obj/item/tool/crowbar/red,
+/obj/item/stack/sheet/glass/glass/bigstack,
+/obj/item/stack/sheet/metal/bigstack,
+/obj/item/device/radio,
+/obj/effect/decal/warning_stripes{
+	icon_state = "unloading"
+	},
+/obj/item/device/multitool,
+/obj/item/weapon/storage/firstaid/adv,
+/obj/item/device/flashlight,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/shuttle/brokeufo/start)
+"mo" = (
+/obj/structure/shuttle/diag_wall/smooth{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/brokeufo/start)
+"nG" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"oL" = (
+/obj/structure/table/reinforced,
+/obj/item/tool/bonesetter,
+/obj/item/tool/bonegel,
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"qo" = (
+/obj/machinery/door/airlock/vault{
+	id_tag = "ufostorage";
+	locked = 1;
+	name = "Storage Access";
+	req_access_txt = "162";
+	req_one_access_txt = "162"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/shuttle/brokeufo/start)
+"rH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "darkredcorners";
+	tag = "icon-darkredcorners (NORTH)"
+	},
+/area/shuttle/brokeufo/start)
+"tx" = (
+/obj/effect/decal/cleanable/blood/oil{
+	icon_state = "floor6"
+	},
+/mob/living/simple_animal/hostile/humanoid/grey/explorer/space/toolbox{
+	name = "Klaatu"
+	},
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "yellowfull"
+	},
+/area/shuttle/brokeufo/start)
+"tS" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/plastic{
+	amount = 50
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/storage/box/inflatables,
+/obj/machinery/power/apc{
+	cell_type = 0;
+	dir = 4;
+	icon_state = "apc1";
+	opened = 1;
+	pixel_x = 28
+	},
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "yellowfull"
+	},
+/area/shuttle/brokeufo/start)
+"uN" = (
+/mob/living/simple_animal/hostile/humanoid/grey/explorer/space/ranged{
+	name = "Barada"
+	},
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"ve" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/weapon/storage/firstaid,
+/obj/item/weapon/storage/box/masks,
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"xP" = (
+/obj/machinery/door/airlock/silver{
+	name = "Bridge";
+	req_access_txt = "162";
+	req_one_access_txt = "162"
+	},
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"xT" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/full/reinforced,
+/obj/machinery/door/poddoor{
+	id_tag = "ufobridge";
+	name = "Blast Shield Shutters"
+	},
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"zX" = (
+/obj/structure/shuttle/diag_wall/smooth{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "darkredcorners";
+	tag = "icon-darkredcorners"
+	},
+/area/shuttle/brokeufo/start)
+"Af" = (
+/obj/structure/dispenser/oxygen,
+/obj/effect/decal/warning_stripes{
+	icon_state = "unloading"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/shuttle/brokeufo/start)
+"Aw" = (
+/obj/structure/closet/secure_closet/medical2{
+	req_access = null;
+	req_access_txt = "162";
+	req_one_access_txt = "162"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"CM" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/diamond{
+	amount = 10
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whitered"
+	},
+/area/shuttle/brokeufo/start)
+"DJ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"Ek" = (
+/obj/structure/sign/poster{
+	icon_state = "bsposter10";
+	pixel_x = -32
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "darkredcorners";
+	tag = "icon-darkredcorners (NORTH)"
+	},
+/area/shuttle/brokeufo/start)
+"FC" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/switchtool/surgery,
+/obj/item/organ/internal/lungs/filter,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"Gm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/organ/external/l_hand,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "gibbl4"
+	},
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"Gt" = (
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"IH" = (
+/obj/machinery/optable,
+/obj/machinery/light,
+/obj/effect/landmark/corpse/tajaran,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor4"
+	},
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"IX" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/cell/super/empty,
+/obj/item/weapon/cell/super/empty,
+/obj/machinery/cell_charger,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "whitered"
+	},
+/area/shuttle/brokeufo/start)
+"Pb" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/gun/projectile/flare,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "whitered"
+	},
+/area/shuttle/brokeufo/start)
+"RO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/shuttle/brokeufo/start)
+"SG" = (
+/obj/structure/shuttle/diag_wall/smooth{
+	dir = 4
+	},
+/turf/space,
+/area/shuttle/brokeufo/start)
+"Tp" = (
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/shuttle/brokeufo/start)
+"TL" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "darkredcorners";
+	tag = "icon-darkredcorners"
+	},
+/area/shuttle/brokeufo/start)
+"Ue" = (
+/obj/structure/bed/chair/shuttle/red,
+/obj/item/stack/cable_coil/random,
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"Us" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/full/reinforced,
+/obj/machinery/door/poddoor{
+	id_tag = "ufobridge";
+	name = "Blast Shield Shutters"
+	},
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"UW" = (
+/obj/machinery/light,
+/obj/structure/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/head/helmet/space/nasavoid,
+/obj/item/clothing/suit/space/nasavoid,
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/obj/effect/decal/warning_stripes{
+	icon_state = "unloading"
+	},
+/obj/item/weapon/gun/energy/smalldisintegrator,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/shuttle/brokeufo/start)
+"WO" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/pill_bottle/zambiscuits,
+/obj/item/weapon/reagent_containers/food/snacks/zambiscuit_butter,
+/obj/item/weapon/reagent_containers/food/snacks/zambiscuit,
+/obj/item/weapon/reagent_containers/food/snacks/zambiscuit,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whitered"
+	},
+/area/shuttle/brokeufo/start)
+"XF" = (
+/turf/simulated/floor/plating,
+/area/shuttle/brokeufo/start)
+"XU" = (
+/obj/structure/closet/crate/freezer/surgery,
+/obj/item/organ/internal/heart/insectoid,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/lungs/plasmaman,
+/obj/item/organ/internal/lungs/vox,
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/eyes/grey,
+/obj/item/organ/internal/eyes/tajaran,
+/obj/item/organ/internal/eyes/tajaran,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/appendix,
+/obj/item/organ/internal/appendix,
+/obj/effect/decal/warning_stripes{
+	icon_state = "unloading"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/shuttle/brokeufo/start)
+"Zo" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/fancy/flares,
+/obj/machinery/door_control{
+	id_tag = "ufocell";
+	name = "Cell Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -25;
+	pixel_y = 5;
+	specialfunctions = 4
+	},
+/obj/machinery/door_control{
+	id_tag = "ufobridge";
+	name = "Blast Shield Control";
+	pixel_x = -25;
+	pixel_y = -5
+	},
+/obj/item/weapon/card/id/mothership_soldier,
+/obj/item/weapon/card/id/mothership_soldier,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "whitered"
+	},
+/area/shuttle/brokeufo/start)
+"ZA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "white";
+	tag = "icon-white"
+	},
+/area/shuttle/brokeufo/start)
+"ZR" = (
+/obj/item/toy/gasha/wizard,
+/turf/space,
+/area)
 
 (1,1,1) = {"
-aaaaaaaaaaapaZagiqagaZaraaaaaaaaaa
-aaaaaaapaZaZaZaBaBaBaZaZaZaraaaaaa
-aaaaapaZavaEaZaFaitSaZaHaNaZaraaaa
-aaapaZaIamanaZawtxaqaZaOasbiaZaraa
-aaaZaRacafauaZaZaXaZaZaYbfbgbhaZaa
-aaaZbaaJaTbdaJaPXFbegwbfasbybjaZaa
-apaeaZaZaZaZaZcFaCfdaZaZaZaZaZaZar
-iWiHiWXFaCgSXFgZXFXFXFhlaCaCiWjPiW
-hDaZaZaZaZaZaZjZaCmoaZaZaZaZaZaeSG
-aaaZoLFCGmGtZAaUXFqoROTpTLbHAfaZaa
-aaaZveaWnGaGaZaZxPaZaZzXcarHXUaZaa
-aahDaZAwbbaZCMiUGtDJWOaZEklVaZSGaa
-aaaahDaZIHaZPbZAUeuNIXaZUWaZSGaaaa
-aaaaaahDaZaZaZZokccHaZaZaZSGaaaaaa
-aaaaaaaaaahDaZUslKxTaZSGaaaaaaZRaa
-aaaaaaaaaaaaaaaakDaaaaaaaaaaaaaaaa
+aa
+aa
+aa
+aa
+aa
+aa
+ap
+iW
+hD
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(2,1,1) = {"
+aa
+aa
+aa
+ap
+aZ
+aZ
+ae
+iH
+aZ
+aZ
+aZ
+hD
+aa
+aa
+aa
+aa
+"}
+(3,1,1) = {"
+aa
+aa
+ap
+aZ
+aR
+ba
+aZ
+iW
+aZ
+oL
+ve
+aZ
+hD
+aa
+aa
+aa
+"}
+(4,1,1) = {"
+aa
+ap
+aZ
+aI
+ac
+aJ
+aZ
+XF
+aZ
+FC
+aW
+Aw
+aZ
+hD
+aa
+aa
+"}
+(5,1,1) = {"
+aa
+aZ
+av
+am
+af
+aT
+aZ
+aC
+aZ
+Gm
+nG
+bb
+IH
+aZ
+aa
+aa
+"}
+(6,1,1) = {"
+ap
+aZ
+aE
+an
+au
+bd
+aZ
+gS
+aZ
+Gt
+aG
+aZ
+aZ
+aZ
+hD
+aa
+"}
+(7,1,1) = {"
+aZ
+aZ
+aZ
+aZ
+aZ
+aJ
+aZ
+XF
+aZ
+ZA
+aZ
+CM
+Pb
+aZ
+aZ
+aa
+"}
+(8,1,1) = {"
+ag
+aB
+aF
+aw
+aZ
+aP
+cF
+gZ
+jZ
+aU
+aZ
+iU
+ZA
+Zo
+Us
+aa
+"}
+(9,1,1) = {"
+iq
+aB
+ai
+tx
+aX
+XF
+aC
+XF
+aC
+XF
+xP
+Gt
+Ue
+kc
+lK
+kD
+"}
+(10,1,1) = {"
+ag
+aB
+tS
+aq
+aZ
+be
+fd
+XF
+mo
+qo
+aZ
+DJ
+uN
+cH
+xT
+aa
+"}
+(11,1,1) = {"
+aZ
+aZ
+aZ
+aZ
+aZ
+gw
+aZ
+XF
+aZ
+RO
+aZ
+WO
+IX
+aZ
+aZ
+aa
+"}
+(12,1,1) = {"
+ar
+aZ
+aH
+aO
+aY
+bf
+aZ
+hl
+aZ
+Tp
+zX
+aZ
+aZ
+aZ
+SG
+aa
+"}
+(13,1,1) = {"
+aa
+aZ
+aN
+as
+bf
+as
+aZ
+aC
+aZ
+TL
+ca
+Ek
+UW
+aZ
+aa
+aa
+"}
+(14,1,1) = {"
+aa
+ar
+aZ
+bi
+bg
+by
+aZ
+aC
+aZ
+bH
+rH
+lV
+aZ
+SG
+aa
+aa
+"}
+(15,1,1) = {"
+aa
+aa
+ar
+aZ
+bh
+bj
+aZ
+iW
+aZ
+Af
+XU
+aZ
+SG
+aa
+aa
+aa
+"}
+(16,1,1) = {"
+aa
+aa
+aa
+ar
+aZ
+aZ
+aZ
+jP
+ae
+aZ
+aZ
+SG
+aa
+aa
+ZR
+aa
+"}
+(17,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+ar
+iW
+SG
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}

--- a/maps/randomvaults/dance_revolution.dmm
+++ b/maps/randomvaults/dance_revolution.dmm
@@ -240,7 +240,6 @@
 /area/vault/dancedance)
 "aW" = (
 /obj/item/weapon/reagent_containers/food/drinks/golden_cup{
-	desc = "A golden cup.";
 	name = "Dance Dance Revolution champion"
 	},
 /turf/simulated/floor/greengrid,

--- a/maps/randomvaults/dungeons/prison.dmm
+++ b/maps/randomvaults/dungeons/prison.dmm
@@ -1,160 +1,2257 @@
-"aa" = (/turf/unsimulated/wall/rock,/area)
-"ab" = (/turf/unsimulated/floor/mars,/area)
-"ac" = (/turf/unsimulated/floor/mars/border,/area)
-"ad" = (/obj/structure/fence/corner{dir = 8},/turf/unsimulated/floor/mars/border,/area)
-"ae" = (/obj/structure/fence{dir = 4},/turf/unsimulated/floor/mars/border,/area)
-"af" = (/obj/structure/fence/post{dir = 4},/turf/unsimulated/floor/mars/border,/area)
-"ag" = (/obj/structure/fence/corner{dir = 4},/turf/unsimulated/floor/mars/border,/area)
-"ah" = (/obj/structure/fence,/turf/unsimulated/floor/mars/border,/area)
-"ai" = (/obj/structure/fence/post,/turf/unsimulated/floor/mars/border,/area)
-"aj" = (/turf/simulated/wall/r_wall,/area/vault/prison)
-"ak" = (/obj/item/weapon/bedsheet,/obj/structure/bed,/turf/simulated/floor{icon_state = "dark vault full"},/area/vault/prison)
-"al" = (/turf/simulated/floor{icon_state = "dark vault full"},/area/vault/prison)
-"am" = (/obj/structure/window/reinforced/tinted,/obj/structure/table/woodentable,/obj/item/toy/cards,/obj/item/toy/cards,/obj/item/weapon/light/tube,/turf/simulated/floor{icon_state = "dark vault full"},/area/vault/prison)
-"an" = (/obj/structure/window/reinforced/tinted,/turf/simulated/floor{icon_state = "dark vault full"},/area/vault/prison)
-"ao" = (/obj/structure/window/reinforced/tinted{dir = 1},/obj/structure/bookcase{name = "bookcase (Adult)"},/turf/simulated/floor{icon_state = "dark vault full"},/area/vault/prison)
-"ap" = (/obj/structure/window/reinforced/tinted{dir = 1},/turf/simulated/floor{icon_state = "dark vault full"},/area/vault/prison)
-"aq" = (/obj/structure/toilet{dir = 4},/obj/machinery/shower{dir = 4},/turf/simulated/floor{icon_state = "cmo"},/area/vault/prison)
-"ar" = (/obj/structure/sink{dir = 4; pixel_x = 11},/obj/structure/mirror{pixel_x = 32},/obj/item/toy/crayon/red,/obj/machinery/light/small{dir = 1},/turf/simulated/floor{icon_state = "cmo"},/area/vault/prison)
-"as" = (/obj/machinery/light_construct,/turf/simulated/floor{icon_state = "dark vault full"},/area/vault/prison)
-"at" = (/obj/structure/disposalpipe/trunk,/obj/machinery/disposal,/turf/simulated/floor{icon_state = "cmo"},/area/vault/prison)
-"au" = (/turf/simulated/floor{icon_state = "cmo"},/area/vault/prison)
-"av" = (/obj/machinery/door/airlock{name = "Dormitory"},/turf/simulated/floor{icon_state = "dark vault full"},/area/vault/prison)
-"aw" = (/obj/machinery/door/airlock/external,/obj/docking_port/destination/vault/prison,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"ax" = (/obj/machinery/door/airlock/external,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"ay" = (/obj/structure/disposalpipe/segment,/turf/simulated/wall,/area/vault/prison)
-"az" = (/obj/machinery/door/airlock{name = "Bathroom"},/turf/simulated/floor{icon_state = "dark vault full"},/area/vault/prison)
-"aA" = (/obj/structure/table/reinforced,/obj/machinery/microwave,/turf/simulated/floor{icon_state = "cafeteria"},/area/vault/prison)
-"aB" = (/obj/machinery/light{dir = 1},/turf/simulated/floor{icon_state = "cafeteria"},/area/vault/prison)
-"aC" = (/turf/simulated/floor{icon_state = "cafeteria"},/area/vault/prison)
-"aD" = (/obj/structure/disposalpipe/trunk,/obj/machinery/disposal,/turf/simulated/floor{icon_state = "hydrofloor"},/area/vault/prison)
-"aE" = (/obj/structure/table,/obj/item/weapon/reagent_containers/food/drinks/mug,/obj/item/weapon/reagent_containers/food/drinks/mug,/obj/item/device/flashlight,/turf/simulated/floor{icon_state = "hydrofloor"},/area/vault/prison)
-"aF" = (/obj/structure/table,/obj/item/weapon/reagent_containers/food/snacks/sosjerky,/turf/simulated/floor{icon_state = "hydrofloor"},/area/vault/prison)
-"aG" = (/obj/structure/table,/obj/machinery/light{dir = 1},/turf/simulated/floor{icon_state = "hydrofloor"},/area/vault/prison)
-"aH" = (/obj/structure/table,/obj/item/toy/crayon/rainbow,/turf/simulated/floor{icon_state = "hydrofloor"},/area/vault/prison)
-"aI" = (/obj/structure/closet/walllocker/emerglocker{pixel_x = -32},/obj/machinery/light/small{dir = 1},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"aJ" = (/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"aK" = (/obj/structure/closet/emcloset,/obj/machinery/light/small{dir = 1},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"aL" = (/obj/machinery/computer/arcade,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"aM" = (/obj/machinery/light{dir = 1},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"aN" = (/obj/structure/disposalpipe/segment,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"aO" = (/obj/machinery/light{dir = 4},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"aP" = (/obj/structure/table/reinforced,/obj/item/weapon/storage/box/donkpockets/random_amount,/turf/simulated/floor{icon_state = "cafeteria"},/area/vault/prison)
-"aQ" = (/obj/structure/disposalpipe/segment,/turf/simulated/floor{icon_state = "hydrofloor"},/area/vault/prison)
-"aR" = (/obj/structure/bed/chair{dir = 1},/turf/simulated/floor{icon_state = "hydrofloor"},/area/vault/prison)
-"aS" = (/obj/item/weapon/stool,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"aT" = (/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"aU" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"aV" = (/obj/structure/disposalpipe/junction,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"aW" = (/obj/item/weapon/storage/box/mugs,/obj/structure/table/reinforced,/turf/simulated/floor{icon_state = "cafeteria"},/area/vault/prison)
-"aX" = (/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/turf/simulated/floor{icon_state = "hydrofloor"},/area/vault/prison)
-"aY" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor{icon_state = "hydrofloor"},/area/vault/prison)
-"aZ" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/door/airlock{name = "Kitchen"},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"ba" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/machinery/light{dir = 1},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bb" = (/obj/structure/disposalpipe/junction{dir = 1; icon_state = "pipe-j2"},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bc" = (/turf/simulated/wall,/area/vault/prison)
-"bd" = (/obj/machinery/door/airlock/maintenance,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"be" = (/obj/structure/reagent_dispensers/watertank,/turf/simulated/floor{icon_state = "cafeteria"},/area/vault/prison)
-"bf" = (/turf/simulated/floor{icon_state = "hydrofloor"},/area/vault/prison)
-"bg" = (/obj/item/toy/crayon/purple,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bh" = (/obj/item/weapon/storage/toolbox/mechanical,/turf/simulated/floor/plating,/area/vault/prison)
-"bi" = (/obj/structure/disposalpipe/segment,/turf/simulated/floor/plating,/area/vault/prison)
-"bj" = (/turf/simulated/floor/plating,/area/vault/prison)
-"bk" = (/obj/structure/reagent_dispensers/watertank,/obj/machinery/light/small{dir = 4},/turf/simulated/floor/plating,/area/vault/prison)
-"bl" = (/obj/machinery/door/airlock/glass_security{name = "Prison Wing"; req_access_txt = ""},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bm" = (/obj/machinery/vending,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bn" = (/obj/structure/disposalpipe/trunk{dir = 1},/obj/machinery/disposal,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bo" = (/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/obj/item/weapon/storage/toolbox/mechanical{pixel_y = 16},/turf/simulated/floor/plating,/area/vault/prison)
-"bp" = (/obj/structure/disposalpipe/junction{icon_state = "pipe-j2"; dir = 4},/turf/simulated/floor/plating,/area/vault/prison)
-"bq" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/simulated/floor/plating,/area/vault/prison)
-"br" = (/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/turf/simulated/floor/plating,/area/vault/prison)
-"bs" = (/obj/structure/reagent_dispensers/fueltank,/turf/simulated/floor/plating,/area/vault/prison)
-"bt" = (/obj/structure/table/reinforced,/obj/effect/decal/cleanable/cobweb,/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bu" = (/obj/structure/table/reinforced,/obj/item/weapon/reagent_containers/food/snacks/plaincakeslice/full,/obj/item/weapon/reagent_containers/food/snacks/plaincakeslice/full,/obj/item/weapon/reagent_containers/food/snacks/plaincakeslice/full,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bv" = (/obj/structure/table/reinforced,/obj/item/trash/plate,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bw" = (/obj/structure/table/reinforced,/obj/machinery/light{dir = 1},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bx" = (/obj/structure/table/reinforced,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"by" = (/obj/machinery/floodlight,/turf/simulated/floor/plating,/area/vault/prison)
-"bz" = (/obj/structure/disposalpipe/segment,/obj/machinery/floodlight,/turf/simulated/floor/plating,/area/vault/prison)
-"bA" = (/obj/item/trash/semki,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bB" = (/obj/structure/reagent_dispensers/watertank,/turf/simulated/floor{icon_state = "showroomfloor"},/area/vault/prison)
-"bC" = (/obj/structure/table,/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cola,/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cola,/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cola,/obj/item/tool/circular_saw,/obj/item/tool/retractor,/obj/machinery/light/small{dir = 1},/turf/simulated/floor{icon_state = "showroomfloor"},/area/vault/prison)
-"bD" = (/obj/structure/table,/obj/item/weapon/reagent_containers/syringe/giant/chloral{pixel_y = 6},/obj/item/weapon/reagent_containers/syringe/giant/chloral,/obj/item/weapon/reagent_containers/syringe/giant{name = "Lethal Injection Syringe"; pixel_y = -6},/obj/item/weapon/lighter{pixel_x = -7},/turf/simulated/floor{icon_state = "showroomfloor"},/area/vault/prison)
-"bE" = (/obj/structure/disposalpipe/trunk{dir = 1},/obj/machinery/disposal/deliveryChute{name = "trash chute"},/turf/simulated/floor{icon_state = "showroomfloor"},/area/vault/prison)
-"bF" = (/obj/structure/disposalpipe/segment,/turf/simulated/wall/r_wall,/area/vault/prison)
-"bG" = (/obj/structure/fence{dir = 4},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bH" = (/obj/structure/fence/door/secure/from_north,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bI" = (/obj/structure/fence/post{dir = 4},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bJ" = (/obj/structure/fence/corner{dir = 4},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bK" = (/obj/item/weapon/mop,/obj/structure/mopbucket,/turf/simulated/floor{icon_state = "showroomfloor"},/area/vault/prison)
-"bL" = (/turf/simulated/floor{icon_state = "showroomfloor"},/area/vault/prison)
-"bM" = (/obj/item/tool/surgicaldrill,/turf/simulated/floor{icon_state = "showroomfloor"},/area/vault/prison)
-"bN" = (/obj/effect/decal/remains/human,/obj/effect/landmark/corpse/civilian{brute_dmg = 200; burn_dmg = 100; oxy_dmg = 0},/turf/unsimulated/floor/mars,/area)
-"bO" = (/obj/structure/disposalpipe/trunk{dir = 1},/obj/structure/disposaloutlet,/turf/unsimulated/floor/mars,/area)
-"bP" = (/obj/effect/landmark/corpse/syndicatesoldier{brute_dmg = 600; burn_dmg = 100},/turf/unsimulated/floor/mars,/area)
-"bQ" = (/obj/structure/fence,/turf/unsimulated/floor/mars,/area)
-"bR" = (/obj/effect/landmark/corpse/civilian,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bS" = (/obj/structure/fence,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bT" = (/obj/effect/decal/cleanable/vomit,/obj/item/weapon/reagent_containers/glass/bucket{pixel_x = 8; pixel_y = 2},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bU" = (/obj/effect/decal/cleanable/blood,/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bV" = (/obj/structure/fence/door/secure/from_east{dir = 4},/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bW" = (/obj/machinery/door/airlock/hatch,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"bX" = (/obj/item/tool/scalpel,/turf/simulated/floor{icon_state = "showroomfloor"},/area/vault/prison)
-"bY" = (/obj/structure/bed/chair{dir = 4},/obj/effect/decal/cleanable/blood,/obj/item/weapon/skull,/turf/simulated/floor{icon_state = "showroomfloor"},/area/vault/prison)
-"bZ" = (/obj/item/weapon/handcuffs,/turf/simulated/floor{icon_state = "showroomfloor"},/area/vault/prison)
-"ca" = (/obj/item/weapon/reagent_containers/food/snacks/donkpocket,/turf/unsimulated/floor/mars,/area)
-"cb" = (/obj/effect/decal/remains/xeno,/turf/unsimulated/floor/mars,/area)
-"cc" = (/obj/effect/decal/remains/human/noskull,/obj/effect/landmark/corpse/civilian{brute_dmg = 200; burn_dmg = 100; oxy_dmg = 0},/turf/unsimulated/floor/mars,/area)
-"cd" = (/obj/item/weapon/reagent_containers/glass/bucket{pixel_x = -6; pixel_y = 2},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"ce" = (/obj/item/stack/sheet/cardboard,/obj/item/stack/sheet/cardboard{pixel_x = -9; pixel_y = 3},/obj/item/stack/sheet/cardboard{pixel_x = 12; pixel_y = 2},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"cf" = (/obj/item/stack/sheet/cardboard,/obj/item/stack/sheet/cardboard{pixel_x = 6; pixel_y = -2},/obj/item/stack/sheet/cardboard{pixel_x = -16; pixel_y = -2},/obj/effect/landmark/corpse/civilian,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"cg" = (/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"ch" = (/obj/structure/fence,/obj/effect/decal/cleanable/blood,/obj/effect/decal/cleanable/blood{pixel_y = -32},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"ci" = (/obj/effect/decal/cleanable/blood,/obj/effect/decal/cleanable/blood/drip,/obj/effect/decal/cleanable/blood{pixel_y = -32},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"cj" = (/obj/effect/landmark/corpse/mutilated{burn_dmg = 50},/obj/effect/decal/cleanable/blood,/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"ck" = (/obj/structure/fence/post,/obj/effect/decal/cleanable/blood{pixel_y = -32},/turf/simulated/floor{icon_state = "pattern_red"},/area/vault/prison)
-"cl" = (/obj/item/tool/wirecutters/clippers,/turf/simulated/floor{icon_state = "showroomfloor"},/area/vault/prison)
-"cm" = (/obj/machinery/light/small,/turf/simulated/floor{icon_state = "showroomfloor"},/area/vault/prison)
-"cn" = (/obj/item/weapon/broken_bottle,/turf/simulated/floor{icon_state = "showroomfloor"},/area/vault/prison)
-"co" = (/obj/structure/sink{dir = 4; pixel_x = 11},/turf/simulated/floor{icon_state = "showroomfloor"},/area/vault/prison)
-"cp" = (/obj/effect/landmark/corpse/mutilated,/turf/unsimulated/floor/mars,/area)
-"cq" = (/obj/effect/landmark/corpse/civilian{brute_dmg = 200; burn_dmg = 100; oxy_dmg = 0},/obj/item/weapon/reagent_containers/food/snacks/donkpocket,/turf/unsimulated/floor/mars,/area)
-"cr" = (/obj/structure/fence/post,/turf/unsimulated/floor/mars,/area)
-"cs" = (/obj/structure/fence{dir = 4},/turf/unsimulated/floor/mars,/area)
-"ct" = (/obj/structure/fence/post{dir = 4},/turf/unsimulated/floor/mars,/area)
-"cu" = (/obj/structure/fence/corner,/turf/unsimulated/floor/mars,/area)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/unsimulated/wall/rock,
+/area)
+"ab" = (
+/turf/unsimulated/floor/mars,
+/area)
+"ac" = (
+/turf/unsimulated/floor/mars/border,
+/area)
+"ad" = (
+/obj/structure/fence/corner{
+	dir = 8
+	},
+/turf/unsimulated/floor/mars/border,
+/area)
+"ae" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/unsimulated/floor/mars/border,
+/area)
+"af" = (
+/obj/structure/fence/post{
+	dir = 4
+	},
+/turf/unsimulated/floor/mars/border,
+/area)
+"ag" = (
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/turf/unsimulated/floor/mars/border,
+/area)
+"ah" = (
+/obj/structure/fence,
+/turf/unsimulated/floor/mars/border,
+/area)
+"ai" = (
+/obj/structure/fence/post,
+/turf/unsimulated/floor/mars/border,
+/area)
+"aj" = (
+/turf/simulated/wall/r_wall,
+/area/vault/prison)
+"ak" = (
+/obj/item/weapon/bedsheet,
+/obj/structure/bed,
+/turf/simulated/floor{
+	icon_state = "dark vault full"
+	},
+/area/vault/prison)
+"al" = (
+/turf/simulated/floor{
+	icon_state = "dark vault full"
+	},
+/area/vault/prison)
+"am" = (
+/obj/structure/window/reinforced/tinted,
+/obj/structure/table/woodentable,
+/obj/item/toy/cards,
+/obj/item/toy/cards,
+/obj/item/weapon/light/tube,
+/turf/simulated/floor{
+	icon_state = "dark vault full"
+	},
+/area/vault/prison)
+"an" = (
+/obj/structure/window/reinforced/tinted,
+/turf/simulated/floor{
+	icon_state = "dark vault full"
+	},
+/area/vault/prison)
+"ao" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/bookcase{
+	name = "bookcase (Adult)"
+	},
+/turf/simulated/floor{
+	icon_state = "dark vault full"
+	},
+/area/vault/prison)
+"ap" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "dark vault full"
+	},
+/area/vault/prison)
+"aq" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "cmo"
+	},
+/area/vault/prison)
+"ar" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/obj/item/toy/crayon/red,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "cmo"
+	},
+/area/vault/prison)
+"as" = (
+/obj/machinery/light_construct,
+/turf/simulated/floor{
+	icon_state = "dark vault full"
+	},
+/area/vault/prison)
+"at" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
+/turf/simulated/floor{
+	icon_state = "cmo"
+	},
+/area/vault/prison)
+"au" = (
+/turf/simulated/floor{
+	icon_state = "cmo"
+	},
+/area/vault/prison)
+"av" = (
+/obj/machinery/door/airlock{
+	name = "Dormitory"
+	},
+/turf/simulated/floor{
+	icon_state = "dark vault full"
+	},
+/area/vault/prison)
+"aw" = (
+/obj/machinery/door/airlock/external,
+/obj/docking_port/destination/vault/prison,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"ax" = (
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"ay" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
+/area/vault/prison)
+"az" = (
+/obj/machinery/door/airlock{
+	name = "Bathroom"
+	},
+/turf/simulated/floor{
+	icon_state = "dark vault full"
+	},
+/area/vault/prison)
+"aA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/vault/prison)
+"aB" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/vault/prison)
+"aC" = (
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/vault/prison)
+"aD" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
+/area/vault/prison)
+"aE" = (
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/drinks/mug,
+/obj/item/weapon/reagent_containers/food/drinks/mug,
+/obj/item/device/flashlight,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
+/area/vault/prison)
+"aF" = (
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
+/area/vault/prison)
+"aG" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
+/area/vault/prison)
+"aH" = (
+/obj/structure/table,
+/obj/item/toy/crayon/rainbow,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
+/area/vault/prison)
+"aI" = (
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = -32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"aJ" = (
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"aK" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"aL" = (
+/obj/machinery/computer/arcade,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"aM" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"aN" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"aO" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"aP" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/box/donkpockets/random_amount,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/vault/prison)
+"aQ" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
+/area/vault/prison)
+"aR" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
+/area/vault/prison)
+"aS" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"aT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"aU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"aV" = (
+/obj/structure/disposalpipe/junction,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"aW" = (
+/obj/item/weapon/storage/box/mugs,
+/obj/structure/table/reinforced,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/vault/prison)
+"aX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
+/area/vault/prison)
+"aY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
+/area/vault/prison)
+"aZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Kitchen"
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"ba" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bb" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bc" = (
+/turf/simulated/wall,
+/area/vault/prison)
+"bd" = (
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"be" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/vault/prison)
+"bf" = (
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
+/area/vault/prison)
+"bg" = (
+/obj/item/toy/crayon/purple,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bh" = (
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/simulated/floor/plating,
+/area/vault/prison)
+"bi" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/vault/prison)
+"bj" = (
+/turf/simulated/floor/plating,
+/area/vault/prison)
+"bk" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/vault/prison)
+"bl" = (
+/obj/machinery/door/airlock/glass_security{
+	name = "Prison Wing";
+	req_access_txt = ""
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bm" = (
+/obj/machinery/vending,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bn" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_y = 16
+	},
+/turf/simulated/floor/plating,
+/area/vault/prison)
+"bp" = (
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/vault/prison)
+"bq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/vault/prison)
+"br" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/vault/prison)
+"bs" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/vault/prison)
+"bt" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bu" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/snacks/plaincakeslice/full,
+/obj/item/weapon/reagent_containers/food/snacks/plaincakeslice/full,
+/obj/item/weapon/reagent_containers/food/snacks/plaincakeslice/full,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bv" = (
+/obj/structure/table/reinforced,
+/obj/item/trash/plate,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bw" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bx" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"by" = (
+/obj/machinery/floodlight,
+/turf/simulated/floor/plating,
+/area/vault/prison)
+"bz" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/floodlight,
+/turf/simulated/floor/plating,
+/area/vault/prison)
+"bA" = (
+/obj/item/trash/semki,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bB" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/prison)
+"bC" = (
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cola,
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cola,
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cola,
+/obj/item/tool/circular_saw,
+/obj/item/tool/retractor,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/prison)
+"bD" = (
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/syringe/giant/chloral{
+	pixel_y = 6
+	},
+/obj/item/weapon/reagent_containers/syringe/giant/chloral,
+/obj/item/weapon/reagent_containers/syringe/giant{
+	name = "Lethal Injection Syringe";
+	pixel_y = -6
+	},
+/obj/item/weapon/lighter{
+	pixel_x = -7
+	},
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/prison)
+"bE" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/deliveryChute{
+	name = "trash chute"
+	},
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/prison)
+"bF" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
+/area/vault/prison)
+"bG" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bH" = (
+/obj/structure/fence/door/secure/from_north,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bI" = (
+/obj/structure/fence/post{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bJ" = (
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bK" = (
+/obj/item/weapon/mop,
+/obj/structure/mopbucket,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/prison)
+"bL" = (
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/prison)
+"bM" = (
+/obj/item/tool/surgicaldrill,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/prison)
+"bN" = (
+/obj/effect/decal/remains/human,
+/obj/effect/landmark/corpse/civilian{
+	brute_dmg = 200;
+	burn_dmg = 100;
+	oxy_dmg = 0
+	},
+/turf/unsimulated/floor/mars,
+/area)
+"bO" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/disposaloutlet,
+/turf/unsimulated/floor/mars,
+/area)
+"bP" = (
+/obj/effect/landmark/corpse/syndicatesoldier{
+	brute_dmg = 600;
+	burn_dmg = 100
+	},
+/turf/unsimulated/floor/mars,
+/area)
+"bQ" = (
+/obj/structure/fence,
+/turf/unsimulated/floor/mars,
+/area)
+"bR" = (
+/obj/effect/landmark/corpse/civilian,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bS" = (
+/obj/structure/fence,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bT" = (
+/obj/effect/decal/cleanable/vomit,
+/obj/item/weapon/reagent_containers/glass/bucket{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bU" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bV" = (
+/obj/structure/fence/door/secure/from_east{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bW" = (
+/obj/machinery/door/airlock/hatch,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"bX" = (
+/obj/item/tool/scalpel,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/prison)
+"bY" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/skull,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/prison)
+"bZ" = (
+/obj/item/weapon/handcuffs,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/prison)
+"ca" = (
+/obj/item/weapon/reagent_containers/food/snacks/donkpocket,
+/turf/unsimulated/floor/mars,
+/area)
+"cb" = (
+/obj/effect/decal/remains/xeno,
+/turf/unsimulated/floor/mars,
+/area)
+"cc" = (
+/obj/effect/decal/remains/human/noskull,
+/obj/effect/landmark/corpse/civilian{
+	brute_dmg = 200;
+	burn_dmg = 100;
+	oxy_dmg = 0
+	},
+/turf/unsimulated/floor/mars,
+/area)
+"cd" = (
+/obj/item/weapon/reagent_containers/glass/bucket{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"ce" = (
+/obj/item/stack/sheet/cardboard,
+/obj/item/stack/sheet/cardboard{
+	pixel_x = -9;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/cardboard{
+	pixel_x = 12;
+	pixel_y = 2
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"cf" = (
+/obj/item/stack/sheet/cardboard,
+/obj/item/stack/sheet/cardboard{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/item/stack/sheet/cardboard{
+	pixel_x = -16;
+	pixel_y = -2
+	},
+/obj/effect/landmark/corpse/civilian,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"cg" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"ch" = (
+/obj/structure/fence,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood{
+	pixel_y = -32
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"ci" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood{
+	pixel_y = -32
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"cj" = (
+/obj/effect/landmark/corpse/mutilated{
+	burn_dmg = 50
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"ck" = (
+/obj/structure/fence/post,
+/obj/effect/decal/cleanable/blood{
+	pixel_y = -32
+	},
+/turf/simulated/floor{
+	icon_state = "pattern_red"
+	},
+/area/vault/prison)
+"cl" = (
+/obj/item/tool/wirecutters/clippers,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/prison)
+"cm" = (
+/obj/machinery/light/small,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/prison)
+"cn" = (
+/obj/item/weapon/broken_bottle,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/prison)
+"co" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/vault/prison)
+"cp" = (
+/obj/effect/landmark/corpse/mutilated,
+/turf/unsimulated/floor/mars,
+/area)
+"cq" = (
+/obj/effect/landmark/corpse/civilian{
+	brute_dmg = 200;
+	burn_dmg = 100;
+	oxy_dmg = 0
+	},
+/obj/item/weapon/reagent_containers/food/snacks/donkpocket,
+/turf/unsimulated/floor/mars,
+/area)
+"cr" = (
+/obj/structure/fence/post,
+/turf/unsimulated/floor/mars,
+/area)
+"cs" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/unsimulated/floor/mars,
+/area)
+"ct" = (
+/obj/structure/fence/post{
+	dir = 4
+	},
+/turf/unsimulated/floor/mars,
+/area)
+"cu" = (
+/obj/structure/fence/corner,
+/turf/unsimulated/floor/mars,
+/area)
 
 (1,1,1) = {"
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaabababababaaaaaaaaaaaaaaaaaaaaaaababababaaaaaaaaaaabaaaaaaaaaaabababababababaa
-aaabababababababaaaaaaaaaaaaaaabababababababaaaaabababaaaaaaaaababababababababaa
-aaabababababababaaaaaaaaaaaaaaabababababababababababababaaababababababababababaa
-aaababababababababaaaaaaacacacacacacacacacacacacacacacacabababababababababababaa
-aaabababababababababababacadaeafaeaeafaeaeafaeaeafaeagacabababababababababababaa
-aaabababababababababababacahababababababababababababahacabababababababababababaa
-aaababababababacacacacacacaiababababababababababababaiacabababababababababababaa
-aaababababababacajajajajajajababababababababababababajacabababababababababababaa
-aaababababababacajakalalakajababababababababababababajacacacacababababababababaa
-aaababababababacajamalalanajababababababababababababajajajajacababababababababaa
-aaababababababacajaoalalapajababababababababababababajaqarajacababababababababaa
-aaababababababacajakasalakajababababababababababababajatauajacacabababababababaa
-aaababababababacajajajavajajajajajajajawaxajajajajajajayazajajacabababababababaa
-aaababababababacajaAaBaCaDaEaFaGaHajaIaJaJaKajaLaJaMaJaNaJaOajacacababababababaa
-aaababababababacajaPaCaCaQaRaRaRaRajajaxaxajajaSaTaUaUaVaJaJajajacababababababaa
-aaababababababacajaWaCaCaXaYaYaYaYaZbaaUaUbaaUaUbbbcbcaybdbcbcajacababababababaa
-aaababababababacajbebebebfbfbfbfbfbcaJaJaJbgaJaJaNbcbhbibjbjbkajacababababababaa
-aaababababababacajbcbcbcbcbcbcbcbcbcblbcbcbcbcbmbnbcbobpbqbrbsajacababababababaa
-aaababababababacajbtbubvbwbxbxbxaMaJaJaJaMaJbcbcbcbcaybcbybzbyajacababababababaa
-aaababababababacajaJaJaJaJbAaJaJaJaJaJaJaJaJbcbBbCbDbEajajbFajajacababababababaa
-aaababababababacajbGbHbGbIbGbHbGbIbGbGbJaJaJbcbKbLbLbMajbNbObPbQacababababababaa
-aaababababababacajbRaJaJbSaJaJbTbSbUaJbVaJaJbWbLbXbYbZajcacbccbQacababababababaa
-aaababababababacajcdaJcebSaJcfcgchcicjckaJaJbcclcmcncoajcpcqcacracababababababaa
-aaababababababacajajajajajajajajajajajajajajajajajajajajcscsctcuacababababababaa
-aaababababababacacacacacacacacacacacacacacacacacacacacacacacacacacababababababaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababababaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(2,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(3,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(4,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(5,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(6,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(7,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(8,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(9,1,1) = {"
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ac
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(10,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ac
+aj
+ak
+am
+ao
+ak
+aj
+aA
+aP
+aW
+be
+bc
+bt
+aJ
+bG
+bR
+cd
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(11,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ac
+aj
+al
+al
+al
+as
+aj
+aB
+aC
+aC
+be
+bc
+bu
+aJ
+bH
+aJ
+aJ
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(12,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ac
+aj
+al
+al
+al
+al
+av
+aC
+aC
+aC
+be
+bc
+bv
+aJ
+bG
+aJ
+ce
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(13,1,1) = {"
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+aj
+ak
+an
+ap
+ak
+aj
+aD
+aQ
+aX
+bf
+bc
+bw
+aJ
+bI
+bS
+bS
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(14,1,1) = {"
+aa
+aa
+aa
+aa
+ac
+ad
+ah
+ai
+aj
+aj
+aj
+aj
+aj
+aj
+aE
+aR
+aY
+bf
+bc
+bx
+bA
+bG
+aJ
+aJ
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(15,1,1) = {"
+aa
+aa
+aa
+aa
+ac
+ae
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aj
+aF
+aR
+aY
+bf
+bc
+bx
+aJ
+bH
+aJ
+cf
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(16,1,1) = {"
+aa
+aa
+ab
+ab
+ac
+af
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aj
+aG
+aR
+aY
+bf
+bc
+bx
+aJ
+bG
+bT
+cg
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(17,1,1) = {"
+aa
+aa
+ab
+ab
+ac
+ae
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aj
+aH
+aR
+aY
+bf
+bc
+aM
+aJ
+bI
+bS
+ch
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(18,1,1) = {"
+aa
+ab
+ab
+ab
+ac
+ae
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aj
+aj
+aj
+aZ
+bc
+bc
+aJ
+aJ
+bG
+bU
+ci
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(19,1,1) = {"
+aa
+ab
+ab
+ab
+ac
+af
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aj
+aI
+aj
+ba
+aJ
+bl
+aJ
+aJ
+bG
+aJ
+cj
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(20,1,1) = {"
+aa
+ab
+ab
+ab
+ac
+ae
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aw
+aJ
+ax
+aU
+aJ
+bc
+aJ
+aJ
+bJ
+bV
+ck
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(21,1,1) = {"
+aa
+ab
+ab
+ab
+ac
+ae
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ax
+aJ
+ax
+aU
+aJ
+bc
+aM
+aJ
+aJ
+aJ
+aJ
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(22,1,1) = {"
+aa
+aa
+ab
+ab
+ac
+af
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aj
+aK
+aj
+ba
+bg
+bc
+aJ
+aJ
+aJ
+aJ
+aJ
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(23,1,1) = {"
+aa
+aa
+aa
+ab
+ac
+ae
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aj
+aj
+aj
+aU
+aJ
+bc
+bc
+bc
+bc
+bW
+bc
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(24,1,1) = {"
+aa
+aa
+aa
+ab
+ac
+ae
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aj
+aL
+aS
+aU
+aJ
+bm
+bc
+bB
+bK
+bL
+cl
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(25,1,1) = {"
+aa
+aa
+ab
+ab
+ac
+af
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aj
+aJ
+aT
+bb
+aN
+bn
+bc
+bC
+bL
+bX
+cm
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(26,1,1) = {"
+aa
+aa
+ab
+ab
+ac
+ae
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aj
+aM
+aU
+bc
+bc
+bc
+bc
+bD
+bL
+bY
+cn
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(27,1,1) = {"
+aa
+ab
+ab
+ab
+ac
+ag
+ah
+ai
+aj
+aj
+aj
+aj
+aj
+aj
+aJ
+aU
+bc
+bh
+bo
+ay
+bE
+bM
+bZ
+co
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(28,1,1) = {"
+aa
+aa
+aa
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+aj
+aq
+at
+ay
+aN
+aV
+ay
+bi
+bp
+bc
+aj
+aj
+aj
+aj
+aj
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(29,1,1) = {"
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ac
+aj
+ar
+au
+az
+aJ
+aJ
+bd
+bj
+bq
+by
+aj
+bN
+ca
+cp
+cs
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(30,1,1) = {"
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+aj
+aj
+aj
+aj
+aO
+aJ
+bc
+bj
+br
+bz
+bF
+bO
+cb
+cq
+cs
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(31,1,1) = {"
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+ac
+ac
+ac
+aj
+aj
+aj
+bc
+bk
+bs
+by
+aj
+bP
+cc
+ca
+ct
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(32,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+ac
+ac
+aj
+aj
+aj
+aj
+aj
+aj
+bQ
+bQ
+cr
+cu
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(33,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(34,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(35,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(36,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(37,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(38,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(39,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(40,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}

--- a/maps/randomvaults/dungeons/satellite_deployment.dmm
+++ b/maps/randomvaults/dungeons/satellite_deployment.dmm
@@ -9,7 +9,6 @@
 "ac" = (
 /obj/effect/step_trigger/thrower{
 	dir = 8;
-	icon_state = "arrows";
 	tag = "icon-arrows (WEST)"
 	},
 /turf/space/transit/east,
@@ -20,7 +19,6 @@
 "ae" = (
 /obj/effect/step_trigger/thrower{
 	dir = 1;
-	icon_state = "arrows";
 	tag = "icon-arrows (NORTH)"
 	},
 /turf/space/transit/east,
@@ -107,7 +105,6 @@
 	},
 /obj/machinery/light/small{
 	dir = 8;
-	icon_state = "lbulb1";
 	tag = "icon-lbulb1 (WEST)"
 	},
 /turf/simulated/floor,
@@ -116,8 +113,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -135,8 +131,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/vault/spy_sat/deployment)
@@ -145,8 +140,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/window/barricade/full/block,
 /turf/simulated/floor,
@@ -297,7 +291,6 @@
 "aQ" = (
 /obj/structure/sign/directions/medical{
 	dir = 1;
-	icon_state = "direction_med";
 	tag = "icon-direction_med (NORTH)"
 	},
 /turf/unsimulated/wall/rock,
@@ -358,7 +351,6 @@
 "aY" = (
 /obj/machinery/light/small{
 	dir = 8;
-	icon_state = "lbulb1";
 	tag = "icon-lbulb1 (WEST)"
 	},
 /turf/simulated/floor,
@@ -402,7 +394,6 @@
 "bg" = (
 /obj/structure/sign/directions/engineering{
 	dir = 4;
-	icon_state = "direction_eng";
 	tag = "icon-direction_eng (EAST)"
 	},
 /turf/unsimulated/wall/rock,
@@ -432,7 +423,6 @@
 "bl" = (
 /obj/effect/step_trigger/thrower{
 	dir = 4;
-	icon_state = "arrows";
 	tag = "icon-arrows (EAST)"
 	},
 /turf/space/transit/east,
@@ -452,7 +442,6 @@
 "bp" = (
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "lbulb1";
 	tag = "icon-lbulb1 (EAST)"
 	},
 /turf/simulated/floor,
@@ -513,7 +502,6 @@
 "by" = (
 /obj/machinery/light/small{
 	dir = 1;
-	icon_state = "lbulb1";
 	tag = "icon-lbulb1 (NORTH)"
 	},
 /turf/simulated/floor,
@@ -704,7 +692,6 @@
 "ce" = (
 /obj/structure/bed/chair{
 	dir = 4;
-	icon_state = "chair";
 	tag = "icon-chair (EAST)"
 	},
 /mob/living/simple_animal/hostile/humanoid/pilot,
@@ -723,7 +710,6 @@
 "ch" = (
 /obj/structure/bed/chair{
 	dir = 8;
-	icon_state = "chair";
 	tag = "icon-chair (WEST)"
 	},
 /turf/simulated/floor/carpet,
@@ -756,7 +742,6 @@
 "cm" = (
 /obj/structure/bed/chair{
 	dir = 4;
-	icon_state = "chair";
 	tag = "icon-chair (EAST)"
 	},
 /turf/simulated/floor/carpet,
@@ -830,7 +815,6 @@
 "cz" = (
 /obj/structure/bed/chair{
 	dir = 8;
-	icon_state = "chair";
 	tag = "icon-chair (WEST)"
 	},
 /mob/living/simple_animal/hostile/humanoid/pilot,
@@ -963,7 +947,6 @@
 /obj/machinery/door/airlock/external,
 /obj/docking_port/destination/vault/satellite_deployment{
 	dir = 2;
-	icon_state = "docking_station";
 	tag = "icon-docking_station"
 	},
 /turf/simulated/floor,

--- a/maps/randomvaults/dungeons/sokoban/E.dmm
+++ b/maps/randomvaults/dungeons/sokoban/E.dmm
@@ -38,8 +38,7 @@
 /area/vault/sokoban/level)
 "h" = (
 /obj/machinery/power/treadmill{
-	dir = 1;
-	icon_state = "treadmill"
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "pattern_blue"
@@ -85,8 +84,7 @@
 /area/vault/sokoban/level)
 "o" = (
 /obj/machinery/power/treadmill{
-	dir = 1;
-	icon_state = "treadmill"
+	dir = 1
 	},
 /obj/structure/mirror{
 	pixel_y = 32
@@ -121,8 +119,7 @@
 /area/vault/sokoban/level)
 "s" = (
 /obj/machinery/power/treadmill{
-	dir = 1;
-	icon_state = "treadmill"
+	dir = 1
 	},
 /obj/abstract/map/spawner/misc/gym,
 /turf/simulated/floor{

--- a/maps/randomvaults/dungeons/wine_cellar.dmm
+++ b/maps/randomvaults/dungeons/wine_cellar.dmm
@@ -275,10 +275,10 @@
 	},
 /area/vault/spacepond/wine_cellar)
 "I" = (
+/obj/item/clothing/mask/gas/grim_reaper/death_commando,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/cobweb2,
-/obj/item/clothing/mask/gas/grim_reaper/death_commando,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},

--- a/maps/randomvaults/dungeons/wine_cellar.dmm
+++ b/maps/randomvaults/dungeons/wine_cellar.dmm
@@ -275,10 +275,10 @@
 	},
 /area/vault/spacepond/wine_cellar)
 "I" = (
-/obj/item/clothing/mask/gas/death_commando,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/cobweb2,
+/obj/item/clothing/mask/gas/grim_reaper/death_commando,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},

--- a/maps/randomvaults/ejectedengine.dmm
+++ b/maps/randomvaults/ejectedengine.dmm
@@ -50,7 +50,6 @@
 "ak" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 6;
-	icon_state = "intact";
 	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/wall/r_wall,
@@ -64,7 +63,6 @@
 "am" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/space,
@@ -90,7 +88,6 @@
 "aq" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/wall/r_wall,
@@ -718,7 +715,6 @@
 "bN" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 9;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor,
@@ -791,7 +787,6 @@
 "bY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
-	on = 0;
 	scrub_CO2 = 0;
 	scrub_Toxins = 0
 	},
@@ -843,7 +838,6 @@
 "cg" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/wall,
@@ -1626,7 +1620,7 @@
 /obj/machinery/computer/general_air_control{
 	frequency = 1553;
 	name = "Engine Monitoring Console";
-	sensors = list("engine_sensor" = "Engine Sensor")
+	sensors = list("engine_sensor"="Engine Sensor")
 	},
 /turf/simulated/floor,
 /area/vault/ejectedengine/monitoring)
@@ -2034,8 +2028,7 @@
 	},
 /obj/machinery/driver_button{
 	id_tag = "engine_gas";
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/machinery/light/burnt{
 	dir = 1
@@ -2209,7 +2202,6 @@
 "fv" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 9;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/wall/r_wall,
@@ -2274,7 +2266,6 @@
 "fH" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/wall/r_wall,

--- a/maps/randomvaults/goonesat.dmm
+++ b/maps/randomvaults/goonesat.dmm
@@ -300,9 +300,7 @@
 /turf/simulated/floor,
 /area/tcommsat/computer)
 "aP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating,
 /area/turret_protected/tcomsat)
 "aQ" = (
@@ -506,8 +504,7 @@
 	dir = 4
 	},
 /mob/living/simple_animal/hostile/humanoid/russian/ranged{
-	dir = 4;
-	icon_state = "russianranged"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/tcommsat/computer)
@@ -525,8 +522,7 @@
 	dir = 8
 	},
 /mob/living/simple_animal/hostile/humanoid/russian/ranged{
-	dir = 8;
-	icon_state = "russianranged"
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/tcommsat/computer)
@@ -535,8 +531,7 @@
 	dir = 1
 	},
 /mob/living/simple_animal/hostile/humanoid/russian/ranged{
-	dir = 1;
-	icon_state = "russianranged"
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/tcommsat/computer)
@@ -799,7 +794,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/hidden/blue,
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -814,7 +808,6 @@
 	on = 1
 	},
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -830,10 +823,9 @@
 	},
 /obj/machinery/computer/general_air_control/large_tank_control{
 	name = "Coldroom Monitoring";
-	sensors = list("satellite_coldroom" = "Server Room")
+	sensors = list("satellite_coldroom"="Server Room")
 	},
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -843,7 +835,6 @@
 /area/tcommsat/computer)
 "bX" = (
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -887,7 +878,6 @@
 	req_access = list(61)
 	},
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -1152,7 +1142,6 @@
 /area/turret_protected/goonroom)
 "cx" = (
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "loading_area";
 	tag = "icon-loading_area"
 	},
@@ -1194,7 +1183,6 @@
 /area/turret_protected/goonroom)
 "cB" = (
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning_corner";
 	tag = "icon-warning_corner"
 	},
@@ -1209,7 +1197,6 @@
 "cC" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/hidden/blue,
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -1223,7 +1210,6 @@
 /area/turret_protected/goonroom)
 "cD" = (
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -1246,7 +1232,6 @@
 	output = 63
 	},
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -1380,7 +1365,6 @@
 	req_access = list(61)
 	},
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "loading_area";
 	tag = "icon-loading_area"
 	},
@@ -1444,7 +1428,6 @@
 "cS" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
 	on = 1
 	},
 /turf/simulated/floor,
@@ -1455,14 +1438,6 @@
 /obj/item/bluespace_crystal/artificial,
 /obj/item/bluespace_crystal/artificial,
 /turf/simulated/floor,
-/area/turret_protected/tcomsat)
-"cU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = "0"
-	},
-/turf/simulated/floor{
-	icon_state = "dark vault full"
-	},
 /area/turret_protected/tcomsat)
 "cV" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/hidden/blue,
@@ -1759,9 +1734,7 @@
 /turf/simulated/floor,
 /area/turret_protected/tcomsat)
 "dx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/corpse/russian,
 /turf/simulated/floor{
 	icon_state = "dark vault full"
@@ -2218,7 +2191,6 @@
 "ej" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
 	on = 1
 	},
 /mob/living/simple_animal/hostile/humanoid/russian,
@@ -2284,9 +2256,7 @@
 /turf/simulated/floor,
 /area/turret_protected/tcomfoyer)
 "eq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor,
 /area/turret_protected/tcomfoyer)
 "er" = (
@@ -2304,7 +2274,6 @@
 "et" = (
 /obj/machinery/light/small,
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning_corner";
 	tag = "icon-warning_corner"
 	},
@@ -2327,9 +2296,7 @@
 /turf/simulated/wall/r_wall,
 /area/tcommsat/entrance)
 "ew" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/wall/r_wall,
 /area/turret_protected/tcomfoyer)
 "ex" = (
@@ -2504,9 +2471,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor,
 /area/tcommsat/entrance)
 "eN" = (
@@ -2545,9 +2510,7 @@
 /area/tcommsat/entrance)
 "eQ" = (
 /obj/structure/sign/securearea,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/wall/r_wall,
 /area/tcommsat/entrance)
 "eR" = (
@@ -2567,9 +2530,7 @@
 /turf/simulated/wall/r_wall,
 /area/tcommsat/entrance)
 "eT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/warning_stripes{
 	dir = 9;
 	icon_state = "warning";
@@ -2605,9 +2566,7 @@
 /turf/simulated/floor,
 /area/tcommsat/entrance)
 "eW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/warning_stripes{
 	dir = 1;
 	icon_state = "warning_corner";
@@ -2750,7 +2709,6 @@
 /area/tcommsat/entrance)
 "fo" = (
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -4964,14 +4922,14 @@ bQ
 co
 cy
 bs
-cU
+bQ
 bQ
 bQ
 dx
 bQ
 bQ
-cU
-cU
+bQ
+bQ
 co
 bT
 ao
@@ -6388,12 +6346,12 @@ cn
 cn
 cZ
 dl
-cU
-cU
-cU
-cU
-cU
-cU
+bQ
+bQ
+bQ
+bQ
+bQ
+bQ
 en
 bT
 ao

--- a/maps/randomvaults/house.dmm
+++ b/maps/randomvaults/house.dmm
@@ -5,7 +5,6 @@
 "ab" = (
 /obj/structure/window/barricade{
 	dir = 1;
-	icon_state = "barricade";
 	tag = "icon-barricade (NORTH)"
 	},
 /turf/simulated/floor/grass{
@@ -41,12 +40,10 @@
 "ak" = (
 /obj/structure/window/barricade{
 	dir = 8;
-	icon_state = "barricade";
 	tag = "icon-barricade (WEST)"
 	},
 /obj/structure/window/barricade{
 	dir = 1;
-	icon_state = "barricade";
 	tag = "icon-barricade (NORTH)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -57,7 +54,6 @@
 "al" = (
 /obj/structure/window/barricade{
 	dir = 1;
-	icon_state = "barricade";
 	tag = "icon-barricade (NORTH)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -68,7 +64,6 @@
 "am" = (
 /obj/structure/window/barricade{
 	dir = 1;
-	icon_state = "barricade";
 	tag = "icon-barricade (NORTH)"
 	},
 /obj/effect/decal/cleanable/soot,
@@ -79,7 +74,6 @@
 "an" = (
 /obj/structure/window/barricade{
 	dir = 1;
-	icon_state = "barricade";
 	tag = "icon-barricade (NORTH)"
 	},
 /turf/simulated/floor/grass{
@@ -89,7 +83,6 @@
 "ao" = (
 /obj/structure/window/barricade{
 	dir = 8;
-	icon_state = "barricade";
 	tag = "icon-barricade (WEST)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -133,7 +126,6 @@
 "au" = (
 /obj/structure/window/barricade{
 	dir = 1;
-	icon_state = "barricade";
 	tag = "icon-barricade (NORTH)"
 	},
 /obj/item/trash/cigbutt,
@@ -144,12 +136,10 @@
 "av" = (
 /obj/structure/window/barricade{
 	dir = 1;
-	icon_state = "barricade";
 	tag = "icon-barricade (NORTH)"
 	},
 /obj/structure/window/barricade{
 	dir = 4;
-	icon_state = "barricade";
 	tag = "icon-barricade (EAST)"
 	},
 /turf/simulated/floor/grass{
@@ -196,18 +186,15 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "rwindow0";
 	tag = "icon-rwindow (EAST)"
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "rwindow0";
 	tag = "icon-rwindow (NORTH)"
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "rwindow0";
 	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
@@ -438,17 +425,14 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "rwindow0";
 	tag = "icon-rwindow (EAST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "rwindow0";
 	tag = "icon-rwindow (NORTH)"
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "rwindow0";
 	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
@@ -489,12 +473,10 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "rwindow0";
 	tag = "icon-rwindow (EAST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "rwindow0";
 	tag = "icon-rwindow (NORTH)"
 	},
 /turf/simulated/floor/plating,
@@ -515,13 +497,11 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 4;
-	icon_state = "rwindow0";
 	tag = "icon-rwindow (EAST)"
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "rwindow0";
 	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
@@ -646,12 +626,10 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1;
-	icon_state = "rwindow0";
 	tag = "icon-rwindow (NORTH)"
 	},
 /obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "rwindow0";
 	tag = "icon-rwindow (WEST)"
 	},
 /turf/simulated/floor/plating,
@@ -705,7 +683,6 @@
 "bY" = (
 /obj/structure/bed/chair/holowood/normal{
 	dir = 4;
-	icon_state = "wooden_chair";
 	tag = "icon-wooden_chair (EAST)"
 	},
 /turf/simulated/floor/wood,
@@ -751,7 +728,6 @@
 	},
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
 /obj/structure/curtain/black,

--- a/maps/randomvaults/iou_fort.dmm
+++ b/maps/randomvaults/iou_fort.dmm
@@ -89,7 +89,6 @@
 /obj/structure/sign/poster{
 	dir = 8;
 	icon_state = "poster6";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor{

--- a/maps/randomvaults/ironchef.dmm
+++ b/maps/randomvaults/ironchef.dmm
@@ -38,7 +38,6 @@
 /obj/machinery/gibber,
 /obj/machinery/light/he,
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -55,7 +54,6 @@
 "ai" = (
 /obj/machinery/cooking/deepfryer,
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -65,7 +63,6 @@
 	},
 /obj/structure/windoor_assembly/secure,
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -249,7 +246,6 @@
 	name = "Iron Chef 1"
 	},
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -260,7 +256,6 @@
 /obj/item/fish_eggs/salmon,
 /obj/item/fish_eggs/salmon,
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -276,7 +271,6 @@
 	name = "Storage"
 	},
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -315,13 +309,11 @@
 	req_access = null
 	},
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "aW" = (
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -359,7 +351,6 @@
 	name = "Iron Chef 2"
 	},
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -383,7 +374,6 @@
 	auto_patrol = 0
 	},
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -405,7 +395,6 @@
 	icon_state = "1"
 	},
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -489,7 +478,6 @@
 "br" = (
 /obj/machinery/processor,
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -499,7 +487,6 @@
 /obj/item/clothing/under/rank/chef,
 /obj/item/clothing/suit/chef,
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -521,14 +508,12 @@
 /obj/machinery/cooking/cerealmaker,
 /obj/machinery/light/he,
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bw" = (
 /obj/machinery/cooking/candy,
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -544,7 +529,6 @@
 	},
 /obj/item/weapon/reagent_containers/dropper/baster,
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -553,7 +537,6 @@
 /obj/item/weapon/kitchen/utensil/knife/large/butch/meatcleaver,
 /obj/structure/table/reinforced,
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -564,7 +547,6 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -575,7 +557,6 @@
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -583,14 +564,12 @@
 /obj/machinery/reagentgrinder,
 /obj/structure/table/reinforced,
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bC" = (
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -599,7 +578,6 @@
 /obj/structure/table/reinforced,
 /obj/item/trash/plate/clean/stack,
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -607,14 +585,12 @@
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
 "bF" = (
 /obj/machinery/bot/chefbot,
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -625,7 +601,6 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -648,7 +623,6 @@
 	icon_state = "2"
 	},
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -676,7 +650,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)
@@ -894,7 +867,6 @@
 "Rr" = (
 /obj/machinery/smartfridge/condiments,
 /turf/simulated/floor{
-	blocks_air = 0;
 	icon_state = "dark"
 	},
 /area/vault/ironchef)

--- a/maps/randomvaults/lightspeedship.dmm
+++ b/maps/randomvaults/lightspeedship.dmm
@@ -211,7 +211,6 @@
 	starting_volume = 3200
 	},
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -284,7 +283,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteyellow"
 	},
 /area/shuttle/lightship/start)
@@ -455,8 +453,7 @@
 /area/shuttle/lightship/start)
 "bN" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "ltube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -547,7 +544,6 @@
 	},
 /obj/machinery/space_heater,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteyellow"
 	},
 /area/shuttle/lightship/start)
@@ -651,16 +647,13 @@
 	},
 /obj/structure/table/glass,
 /obj/item/weapon/storage/firstaid/toxin{
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /obj/item/weapon/storage/firstaid/o2{
-	pixel_x = 3;
-	pixel_y = 0
+	pixel_x = 3
 	},
 /obj/item/weapon/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/item/weapon/storage/firstaid/fire{
 	pixel_x = -7
@@ -773,8 +766,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -919,8 +911,7 @@
 	dir = 1
 	},
 /obj/machinery/r_n_d/fabricator/mech{
-	req_access = list();
-	req_one_access = null
+	req_access = list()
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -1005,7 +996,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteyellow"
 	},
 /area/shuttle/lightship/start)
@@ -1042,7 +1032,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitegreen"
 	},
 /area/shuttle/lightship/start)
@@ -1051,7 +1040,6 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitegreen"
 	},
 /area/shuttle/lightship/start)
@@ -1180,8 +1168,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -1203,9 +1190,7 @@
 /obj/item/ammo_casing/rocket_rpg/nikita{
 	pixel_y = 10
 	},
-/obj/item/ammo_casing/rocket_rpg/nikita{
-	pixel_y = 0
-	},
+/obj/item/ammo_casing/rocket_rpg/nikita,
 /obj/item/ammo_casing/rocket_rpg/nikita{
 	pixel_y = 5
 	},
@@ -1297,9 +1282,7 @@
 /obj/item/ammo_casing/rocket_rpg/nikita{
 	pixel_y = 10
 	},
-/obj/item/ammo_casing/rocket_rpg/nikita{
-	pixel_y = 0
-	},
+/obj/item/ammo_casing/rocket_rpg/nikita,
 /obj/item/ammo_casing/rocket_rpg/nikita{
 	pixel_y = 5
 	},
@@ -1435,13 +1418,11 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteyellow"
 	},
 /area/shuttle/lightship/start)
 "fB" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteyellow"
 	},
 /area/shuttle/lightship/start)
@@ -1456,7 +1437,6 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteyellow"
 	},
 /area/shuttle/lightship/start)
@@ -1498,7 +1478,6 @@
 /area/shuttle/lightship/start)
 "fG" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitered"
 	},
 /area/shuttle/lightship/start)
@@ -1515,7 +1494,6 @@
 /obj/structure/table/reinforced,
 /obj/abstract/map/spawner/security/misc,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitered"
 	},
 /area/shuttle/lightship/start)
@@ -1636,7 +1614,6 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitered"
 	},
 /area/shuttle/lightship/start)
@@ -2022,7 +1999,6 @@
 	pixel_y = 18
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitegreen"
 	},
 /area/shuttle/lightship/start)

--- a/maps/randomvaults/listening.dmm
+++ b/maps/randomvaults/listening.dmm
@@ -158,8 +158,7 @@
 "ar" = (
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/machinery/power/solar/control/vault_listening,
 /obj/machinery/light/small{
@@ -739,7 +738,6 @@
 /area/vault/listening)
 "bH" = (
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning_corner";
 	tag = "icon-warning_corner"
 	},
@@ -750,7 +748,6 @@
 /area/vault/listening)
 "bI" = (
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},

--- a/maps/randomvaults/meteorlogical_station.dmm
+++ b/maps/randomvaults/meteorlogical_station.dmm
@@ -94,20 +94,14 @@
 	pixel_x = -8
 	},
 /obj/item/device/assembly/signaler{
-	pixel_x = -4;
-	pixel_y = 0
+	pixel_x = -4
 	},
 /obj/item/device/assembly/prox_sensor{
-	pixel_x = 0;
 	pixel_y = 6
 	},
+/obj/item/device/assembly/signaler,
 /obj/item/device/assembly/signaler{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/item/device/assembly/signaler{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/shuttle/brig,

--- a/maps/randomvaults/meteorlogical_station.dmm
+++ b/maps/randomvaults/meteorlogical_station.dmm
@@ -139,7 +139,7 @@
 /area/vault/meteorlogical)
 "ax" = (
 /obj/machinery/computer/crew{
-	holomap_filter = HOLOMAP_FILTER_NUKEOPS;
+	holomap_filter = 4;
 	name = "Syndie crew monitoring computer"
 	},
 /turf/simulated/floor/shuttle/brig,

--- a/maps/randomvaults/mini_station.dmm
+++ b/maps/randomvaults/mini_station.dmm
@@ -57,14 +57,12 @@
 /area/vault/powered/mini_station_botany)
 "al" = (
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/vault/powered/mini_station_engineering)
@@ -72,8 +70,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/vault/powered/mini_station_engineering)
@@ -82,14 +79,12 @@
 /area/vault/powered/mini_station)
 "ao" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/vault/powered/mini_station_engineering)
@@ -111,8 +106,7 @@
 /area/vault/powered/mini_station_engineering)
 "ar" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/layered{
-	dir = 8;
-	icon_state = "hoff"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on/layered{
 	dir = 8
@@ -121,8 +115,7 @@
 /area/vault/powered/mini_station)
 "au" = (
 /obj/machinery/atmospherics/pipe/layer_adapter/scrubbers/hidden{
-	dir = 1;
-	icon_state = "adapter_4"
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/vault/powered/mini_station_engineering)
@@ -200,8 +193,7 @@
 /area/vault/powered/mini_station_construction)
 "aF" = (
 /obj/machinery/atmospherics/pipe/layer_adapter/supply/hidden{
-	dir = 1;
-	icon_state = "adapter_2"
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/vault/powered/mini_station_engineering)
@@ -257,8 +249,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/space,
 /area/vault/powered/mini_station_entrance)
@@ -295,8 +286,7 @@
 /area/vault/powered/mini_station_entrance)
 "aR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/layered{
-	dir = 1;
-	icon_state = "hoff"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on/layered{
 	dir = 1
@@ -328,8 +318,7 @@
 /area/vault/powered/mini_station_entrance)
 "aU" = (
 /obj/structure/sign/directions/engineering{
-	dir = 1;
-	icon_state = "direction_eng"
+	dir = 1
 	},
 /turf/simulated/wall,
 /area/vault/powered/mini_station_engineering)
@@ -338,8 +327,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -487,12 +475,10 @@
 /area/vault/powered/mini_station_construction)
 "bk" = (
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -528,18 +514,15 @@
 /area/vault/powered/mini_station_medbay)
 "bu" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/vault/powered/mini_station_medbay)
@@ -566,16 +549,13 @@
 /area/vault/powered/mini_station_engineering)
 "bx" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -645,8 +625,7 @@
 /area/vault/powered/mini_station_entrance)
 "bF" = (
 /obj/structure/bed/chair/wood/normal{
-	dir = 4;
-	icon_state = "wooden_chair"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/vault/powered/mini_station_kitchen)
@@ -727,7 +706,6 @@
 /obj/structure/closet/wardrobe/medic_white,
 /obj/item/stack/sheet/bone,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "blue"
 	},
 /area/vault/powered/mini_station_medbay)
@@ -764,8 +742,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/layered{
-	dir = 8;
-	icon_state = "hoff"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on/layered{
 	dir = 8
@@ -816,7 +793,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on/layered,
 /obj/machinery/atmospherics/unary/vent_scrubber/layered,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "blue"
 	},
 /area/vault/powered/mini_station_medbay)
@@ -824,7 +800,6 @@
 /obj/machinery/vending/tool,
 /obj/machinery/light,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/vault/powered/mini_station_engineering)
@@ -837,8 +812,7 @@
 /area/vault/powered/mini_station_engineering)
 "ci" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
@@ -878,8 +852,7 @@
 /area/vault/powered/mini_station_engineering)
 "co" = (
 /obj/structure/bed/chair/wood/normal{
-	dir = 8;
-	icon_state = "wooden_chair"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layered,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layered,
@@ -914,8 +887,7 @@
 /area/vault/powered/mini_station_botany)
 "ct" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "ltube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layered,
@@ -954,10 +926,7 @@
 "cy" = (
 /obj/item/weapon/switchtool/engineering/mech,
 /obj/item/stack/sheet/mineral/plasma,
-/obj/structure/table{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/structure/table,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -983,16 +952,13 @@
 /area/vault/powered/mini_station)
 "cA" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -1024,10 +990,7 @@
 	pixel_x = 6;
 	pixel_y = 6
 	},
-/obj/structure/table{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/structure/table,
 /turf/simulated/floor,
 /area/vault/powered/mini_station_medbay)
 "cE" = (
@@ -1056,8 +1019,7 @@
 /area/vault/powered/mini_station_entrance)
 "cH" = (
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
@@ -1075,21 +1037,18 @@
 /area/vault/powered/mini_station_kitchen)
 "cJ" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/vault/powered/mini_station_entrance)
 "cK" = (
 /obj/structure/bed/chair/wood/normal{
-	dir = 4;
-	icon_state = "wooden_chair"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
 	dir = 9;
@@ -1114,8 +1073,7 @@
 /area/vault/powered/mini_station_kitchen)
 "cM" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	dir = 2;
-	icon_state = "door_closed"
+	dir = 2
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
@@ -1133,31 +1091,26 @@
 /area/vault/powered/mini_station_entrance)
 "cO" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/vault/powered/mini_station_entrance)
 "cP" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/vault/powered/mini_station)
@@ -1174,12 +1127,10 @@
 /area/vault/powered/mini_station)
 "cR" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
@@ -1238,10 +1189,7 @@
 /obj/item/stack/sheet/metal/bigstack,
 /obj/item/stack/sheet/plasteel/bigstack,
 /obj/item/stack/sheet/glass/glass/bigstack,
-/obj/structure/table{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/structure/table,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
@@ -1285,8 +1233,7 @@
 /area/vault/powered/mini_station_engineering)
 "cY" = (
 /obj/machinery/light/small{
-	dir = 8;
-	icon_state = "lbulb1"
+	dir = 8
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -1329,8 +1276,7 @@
 "dc" = (
 /obj/machinery/door/airlock/external,
 /obj/docking_port/destination/vault/minisat{
-	dir = 4;
-	icon_state = "docking_station"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
@@ -1357,15 +1303,13 @@
 /area/vault/powered/mini_station_botany)
 "dp" = (
 /obj/structure/sign/directions/evac{
-	dir = 4;
-	icon_state = "direction_evac"
+	dir = 4
 	},
 /turf/simulated/wall,
 /area/vault/powered/mini_station_engineering)
 "ee" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/layered{
-	dir = 8;
-	icon_state = "hoff"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on/layered{
 	dir = 8
@@ -1425,26 +1369,22 @@
 /area/vault/powered/mini_station_medbay)
 "fg" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "ltube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/simulated/floor,
 /area/vault/powered/mini_station_engineering)
 "fw" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/vault/powered/mini_station_engineering)
@@ -1475,8 +1415,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1524,12 +1463,10 @@
 /area/vault/powered/mini_station_botany)
 "iQ" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
@@ -1626,8 +1563,7 @@
 	pixel_y = -24
 	},
 /obj/machinery/bodyscanner{
-	dir = 4;
-	icon_state = "body_scanner_0"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/vault/powered/mini_station_kitchen)
@@ -1660,7 +1596,6 @@
 "ot" = (
 /obj/machinery/vending/engivend,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/vault/powered/mini_station_engineering)
@@ -1700,12 +1635,10 @@
 /area/vault/powered/mini_station_kitchen)
 "pY" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
@@ -1713,8 +1646,7 @@
 /area/vault/powered/mini_station_entrance)
 "qk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/layered{
-	dir = 1;
-	icon_state = "hoff"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on/layered{
 	dir = 1
@@ -1728,8 +1660,7 @@
 /area/vault/powered/mini_station_kitchen)
 "qm" = (
 /obj/structure/bed/chair/wood/normal{
-	dir = 4;
-	icon_state = "wooden_chair"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layered{
 	dir = 8;
@@ -1777,10 +1708,7 @@
 /turf/simulated/floor,
 /area/vault/powered/mini_station)
 "so" = (
-/obj/structure/table{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/structure/table,
 /obj/item/weapon/switchtool/surgery,
 /obj/item/weapon/storage/firstaid/toxin,
 /obj/item/stack/sheet/charcoal,
@@ -1831,14 +1759,12 @@
 /area/vault/powered/mini_station_entrance)
 "sT" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/vault/powered/mini_station_medbay)
@@ -2016,10 +1942,7 @@
 "ye" = (
 /obj/item/weapon/storage/toolbox/electrical,
 /obj/item/blueprints/construction_permit,
-/obj/structure/table{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/structure/table,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -2082,10 +2005,7 @@
 /turf/simulated/floor,
 /area/vault/powered/mini_station_construction)
 "Am" = (
-/obj/structure/table{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/structure/table,
 /obj/item/weapon/storage/firstaid,
 /obj/item/weapon/thermometer,
 /obj/item/weapon/storage/box/beakers,
@@ -2147,10 +2067,7 @@
 	},
 /area/vault/powered/mini_station_engineering)
 "Bi" = (
-/obj/structure/table{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/structure/table,
 /obj/item/weapon/storage/firstaid/fire,
 /obj/item/weapon/reagent_containers/glass/beaker,
 /turf/simulated/floor{
@@ -2165,12 +2082,10 @@
 /area/vault/powered/mini_station_kitchen)
 "Bt" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -2234,24 +2149,20 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "blue"
 	},
 /area/vault/powered/mini_station_medbay)
 "ES" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/vault/powered/mini_station_construction)
@@ -2297,18 +2208,15 @@
 /area/vault/powered/mini_station)
 "FM" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/vault/powered/mini_station_medbay)
@@ -2322,12 +2230,10 @@
 /area/vault/powered/mini_station_botany)
 "GH" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
@@ -2335,8 +2241,7 @@
 /area/vault/powered/mini_station)
 "Hu" = (
 /obj/structure/bed/chair/wood/normal{
-	dir = 8;
-	icon_state = "wooden_chair"
+	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -2347,8 +2252,7 @@
 /area/vault/powered/mini_station_kitchen)
 "HX" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	dir = 8;
-	icon_state = "door_closed"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
@@ -2486,8 +2390,7 @@
 /area/vault/powered/mini_station_engineering)
 "Nn" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /obj/structure/table/glass,
 /obj/item/tool/bonesetter/bone_mender{
@@ -2500,23 +2403,19 @@
 	pixel_z = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "blue"
 	},
 /area/vault/powered/mini_station_medbay)
 "NL" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/vault/powered/mini_station)
@@ -2525,8 +2424,7 @@
 /area/vault/powered/mini_station_kitchen)
 "Oc" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/vault/powered/mini_station_medbay)
@@ -2628,8 +2526,7 @@
 /area/vault/powered/mini_station_botany)
 "RR" = (
 /obj/structure/bed/chair/wood/normal{
-	dir = 8;
-	icon_state = "wooden_chair"
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/vault/powered/mini_station_kitchen)
@@ -2681,12 +2578,10 @@
 /area/vault/powered/mini_station)
 "TE" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -2701,18 +2596,15 @@
 /area/vault/powered/mini_station_construction)
 "Uj" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow0"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow0"
+	dir = 8
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow0"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/vault/powered/mini_station_kitchen)
@@ -2867,8 +2759,7 @@
 /area/vault/powered/mini_station)
 "Zs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/layered{
-	dir = 8;
-	icon_state = "hoff"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on/layered{
 	dir = 8

--- a/maps/randomvaults/mining/bar.dmm
+++ b/maps/randomvaults/mining/bar.dmm
@@ -136,7 +136,6 @@
 "au" = (
 /obj/structure/table/woodentable,
 /obj/machinery/chem_dispenser/soda_dispenser{
-	pixel_x = 0;
 	pixel_y = 14
 	},
 /turf/simulated/floor/wood,
@@ -200,7 +199,6 @@
 "aE" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
 	on = 1
 	},
 /turf/simulated/floor/carpet,
@@ -265,7 +263,6 @@
 "aP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
-	on = 0;
 	scrub_CO2 = 0;
 	scrub_Toxins = 0
 	},
@@ -297,7 +294,6 @@
 "aT" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
 	on = 1
 	},
 /turf/simulated/floor{
@@ -308,7 +304,6 @@
 "aU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
-	on = 0;
 	scrub_CO2 = 0;
 	scrub_Toxins = 0
 	},
@@ -396,8 +391,7 @@
 /area/mining_bar)
 "bi" = (
 /obj/structure/bed/chair/comfy/couch/left/teal{
-	dir = 4;
-	icon_state = "couch_left"
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/mining_bar)
@@ -463,7 +457,6 @@
 /area/mining_bar)
 "bs" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	color = "#0000B7";
 	dir = 8;
 	name = "Mix pipe"
 	},
@@ -489,8 +482,7 @@
 /area/mining_bar)
 "bx" = (
 /obj/structure/bed/chair/comfy/couch/right/teal{
-	dir = 4;
-	icon_state = "couch_right"
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/mining_bar)
@@ -522,15 +514,13 @@
 /obj/machinery/atmospherics/trinary/filter/mirrored{
 	dir = 8;
 	filter_type = 1;
-	icon_state = "hintactm_off";
 	on = 1
 	},
 /turf/simulated/floor/engine,
 /area/mining_bar)
 "bE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/engine,
 /area/mining_bar)
@@ -545,7 +535,6 @@
 /obj/machinery/atmospherics/trinary/filter/mirrored{
 	dir = 1;
 	filter_type = 2;
-	icon_state = "hintactm_off";
 	on = 1
 	},
 /turf/simulated/floor/engine,
@@ -568,15 +557,13 @@
 /area/mining_bar)
 "bN" = (
 /obj/structure/piano/random{
-	dir = 4;
-	icon_state = "piano"
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/mining_bar)
 "bP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /turf/simulated/floor/engine,
 /area/mining_bar)
@@ -611,8 +598,7 @@
 /area/mine/explored)
 "bY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/mining_bar)
@@ -656,8 +642,7 @@
 /area/mining_bar)
 "qv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 1;
-	icon_state = "intact"
+	dir = 1
 	},
 /turf/simulated/wall/invulnerable/r_wall,
 /area/mining_bar)
@@ -675,7 +660,6 @@
 "tr" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
-	external_pressure_bound = 101.325;
 	on = 1
 	},
 /turf/simulated/floor/plating,
@@ -696,8 +680,7 @@
 /area/mining_bar)
 "KG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 1;
-	icon_state = "intact"
+	dir = 1
 	},
 /turf/simulated/floor/engine,
 /area/mining_bar)

--- a/maps/randomvaults/research_facility.dmm
+++ b/maps/randomvaults/research_facility.dmm
@@ -136,8 +136,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/vault/research)
@@ -182,8 +181,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/vault/research)
@@ -192,8 +190,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/vault/research)
@@ -245,9 +242,7 @@
 /turf/simulated/floor/plating,
 /area/vault/research)
 "aJ" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 0
-	},
+/obj/machinery/vending/wallmed1,
 /turf/simulated/wall/r_wall,
 /area/vault/research)
 "aK" = (
@@ -286,8 +281,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor{
 	id_tag = "madagascar";
@@ -303,8 +297,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -368,9 +361,7 @@
 /obj/item/weapon/switchtool/surgery,
 /obj/item/weapon/reagent_containers/spray/cleaner{
 	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "Surgery Cleaner"
 	},
 /obj/effect/decal/cleanable/cobweb2,
 /obj/item/weapon/barricade_kit,
@@ -393,8 +384,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/poddoor{
 	id_tag = "madagascar";
@@ -455,8 +445,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/vault/research)
@@ -465,8 +454,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/vault/research)
@@ -781,10 +769,7 @@
 /obj/structure/table,
 /obj/item/weapon/storage/box/beakers,
 /obj/item/weapon/storage/box/beakers,
-/obj/item/stack/medical/advanced/bruise_pack{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/stack/medical/advanced/bruise_pack,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -979,8 +964,7 @@
 /obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/structure/sink{
 	dir = 8;
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -1002,7 +986,6 @@
 "cO" = (
 /obj/machinery/door/airlock/security{
 	name = "Armory";
-	req_access = null;
 	req_access_txt = "3"
 	},
 /turf/simulated/floor{
@@ -1257,7 +1240,6 @@
 "dz" = (
 /obj/machinery/door/airlock/security{
 	name = "Armory";
-	req_access = null;
 	req_access_txt = "3"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -1671,7 +1653,6 @@
 "eR" = (
 /obj/structure/toilet{
 	dir = 1;
-	icon_state = "toilet00";
 	tag = "icon-toilet00 (NORTH)"
 	},
 /turf/simulated/floor{

--- a/maps/randomvaults/rust.dmm
+++ b/maps/randomvaults/rust.dmm
@@ -404,8 +404,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless/damaged,
 /area/vault/rust)
@@ -423,8 +422,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/damaged/airless,
 /area/vault/rust)
@@ -433,8 +431,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/damaged/airless,
 /area/vault/rust)
@@ -537,7 +534,6 @@
 /obj/machinery/power/terminal,
 /obj/structure/cable,
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "loading_area";
 	tag = "icon-loading_area"
 	},
@@ -709,7 +705,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "radiation-w"
 	},
 /obj/effect/decal/warning_stripes{

--- a/maps/randomvaults/snaxi/crash.dmm
+++ b/maps/randomvaults/snaxi/crash.dmm
@@ -431,7 +431,7 @@
 /area)
 "X" = (
 /obj/machinery/vending/tool{
-	contraband = list(/obj/item/tool/weldingtool/hugetank = 2, /obj/item/clothing/gloves/yellow/vox = 2);
+	contraband = list(/obj/item/tool/weldingtool/hugetank=2,/obj/item/clothing/gloves/yellow/vox=2);
 	name = "Outpost YouTool"
 	},
 /obj/machinery/alarm/vox{

--- a/maps/randomvaults/snaxi/thermalplant.dmm
+++ b/maps/randomvaults/snaxi/thermalplant.dmm
@@ -4,7 +4,7 @@
 	frequency = 1666;
 	input_tag = "inc_in";
 	output_tag = "inc_out";
-	sensors = list("inc_sensor" = "Tank")
+	sensors = list("inc_sensor"="Tank")
 	},
 /turf/simulated/floor{
 	icon_state = "dark"

--- a/maps/randomvaults/sokoban_entrance.dmm
+++ b/maps/randomvaults/sokoban_entrance.dmm
@@ -16,8 +16,7 @@
 /area/vault/sokoban)
 "ad" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
-	icon_state = "propulsion"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -73,8 +72,7 @@
 /area/vault/sokoban)
 "aj" = (
 /obj/machinery/conveyor/auto{
-	dir = 6;
-	icon_state = "conveyor0"
+	dir = 6
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
@@ -82,8 +80,7 @@
 /area/vault/sokoban)
 "ak" = (
 /obj/machinery/conveyor/auto{
-	dir = 4;
-	icon_state = "conveyor0"
+	dir = 4
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
@@ -91,8 +88,7 @@
 /area/vault/sokoban)
 "al" = (
 /obj/machinery/conveyor/auto{
-	dir = 4;
-	icon_state = "conveyor0"
+	dir = 4
 	},
 /obj/effect/landmark/sokoban_jail,
 /turf/simulated/floor/shuttle{
@@ -101,8 +97,7 @@
 /area/vault/sokoban)
 "am" = (
 /obj/machinery/conveyor/auto{
-	dir = 10;
-	icon_state = "conveyor0"
+	dir = 10
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
@@ -110,8 +105,7 @@
 /area/vault/sokoban)
 "an" = (
 /obj/machinery/conveyor/auto{
-	dir = 5;
-	icon_state = "conveyor0"
+	dir = 5
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
@@ -119,8 +113,7 @@
 /area/vault/sokoban)
 "ao" = (
 /obj/machinery/conveyor/auto{
-	dir = 8;
-	icon_state = "conveyor0"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
@@ -128,8 +121,7 @@
 /area/vault/sokoban)
 "ap" = (
 /obj/machinery/conveyor/auto{
-	dir = 9;
-	icon_state = "conveyor0"
+	dir = 9
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
@@ -167,8 +159,7 @@
 /area/vault/sokoban)
 "at" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
-	icon_state = "propulsion"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -180,8 +171,7 @@
 /area/vault/sokoban)
 "au" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	icon_state = "heater"
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -191,8 +181,7 @@
 /area/vault/sokoban)
 "av" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 1;
-	icon_state = "heater"
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -218,8 +207,7 @@
 /area/vault/sokoban)
 "az" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "ltube1"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor2"
@@ -227,8 +215,7 @@
 /area/vault/sokoban)
 "aA" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "ltube1"
+	dir = 4
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor2"
@@ -278,15 +265,13 @@
 /area/vault/sokoban)
 "aI" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "ltube1"
+	dir = 8
 	},
 /turf/simulated/floor/shuttle,
 /area/vault/sokoban)
 "aJ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "ltube1"
+	dir = 8
 	},
 /obj/item/stack/package_wrap,
 /turf/simulated/floor/shuttle,
@@ -326,8 +311,7 @@
 /area/vault/sokoban)
 "aP" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "ltube1"
+	dir = 4
 	},
 /obj/structure/largecrate/skele_stand,
 /turf/simulated/floor/shuttle,
@@ -366,8 +350,7 @@
 /area/vault/sokoban)
 "aW" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "ltube1"
+	dir = 4
 	},
 /obj/structure/largecrate/cat,
 /turf/simulated/floor/shuttle,

--- a/maps/randomvaults/spessmart.dmm
+++ b/maps/randomvaults/spessmart.dmm
@@ -371,8 +371,7 @@
 	},
 /obj/structure/sign/securearea{
 	name = "DO NOT CROSS THE WARNING STRIPES WITH UNPAID ITEMS";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -654,7 +653,6 @@
 /obj/structure/rack,
 /obj/abstract/map/spawner/supermarket/clothing,
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning_corner";
 	tag = "icon-warning_corner"
 	},
@@ -681,8 +679,7 @@
 	},
 /obj/structure/sign/securearea{
 	name = "DO NOT CROSS THE WARNING STRIPES WITH UNPAID ITEMS";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /mob/living/simple_animal/robot/food_samples{
 	dir = 8
@@ -730,7 +727,6 @@
 	},
 /obj/machinery/light/small,
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -744,7 +740,6 @@
 /area/vault/supermarket/shop)
 "bG" = (
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -775,7 +770,6 @@
 /area/vault/supermarket/shop)
 "bI" = (
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning_corner";
 	tag = "icon-warning_corner"
 	},
@@ -785,7 +779,6 @@
 /area/vault/supermarket/shop)
 "bJ" = (
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -796,7 +789,6 @@
 "bK" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -918,8 +910,7 @@
 	},
 /obj/structure/sign/securearea{
 	name = "DO NOT CROSS THE WARNING STRIPES WITH UNPAID ITEMS";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -963,17 +954,13 @@
 /area/vault/supermarket/restricted)
 "ch" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
 /area/vault/supermarket/restricted)
 "ci" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/door/airlock/vault{
 	desc = "Feed three times a day.";
@@ -984,9 +971,7 @@
 /area/vault/supermarket/restricted)
 "cj" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/item/tool/crowbar,
 /turf/simulated/floor/plating/airless,
@@ -1010,9 +995,7 @@
 /area/vault/supermarket/shop)
 "cm" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -1115,7 +1098,6 @@
 /area/vault/supermarket/restricted)
 "cy" = (
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -1130,14 +1112,11 @@
 "cz" = (
 /obj/machinery/light,
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -1145,14 +1124,11 @@
 /area/vault/supermarket/shop)
 "cA" = (
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -1165,7 +1141,6 @@
 	tag = "icon-warning_corner (WEST)"
 	},
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning_corner";
 	tag = "icon-warning_corner"
 	},
@@ -1178,7 +1153,6 @@
 /area/vault/supermarket/shop)
 "cC" = (
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -1204,9 +1178,7 @@
 /obj/item/device/robotanalyzer,
 /obj/item/stack/nanopaste,
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
 /area/vault/supermarket/restricted)
@@ -1488,7 +1460,6 @@
 /area/vault/supermarket/shop)
 "dk" = (
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -1500,7 +1471,6 @@
 /area/vault/supermarket/shop)
 "dl" = (
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -1748,9 +1718,7 @@
 /area/vault/supermarket/entrance)
 "dX" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/vault/supermarket/entrance)
@@ -1769,8 +1737,7 @@
 /area/vault/supermarket/entrance)
 "ea" = (
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor{
 	icon_state = "bar"
@@ -1898,7 +1865,6 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	desc = "Nothing to worry about, unless your intentions are vile.";
-	dir = 4;
 	name = "Emergency Shutters"
 	},
 /turf/simulated/floor{
@@ -1956,8 +1922,7 @@
 /area/vault/supermarket/entrance)
 "ey" = (
 /obj/structure/mirror{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/sink{
 	dir = 8;

--- a/maps/randomvaults/syndiecargo.dmm
+++ b/maps/randomvaults/syndiecargo.dmm
@@ -25,7 +25,6 @@
 "af" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
-	icon_state = "heater";
 	tag = "icon-heater (NORTH)"
 	},
 /obj/structure/window/reinforced/plasma,
@@ -39,7 +38,6 @@
 "ag" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
-	icon_state = "heater";
 	tag = "icon-heater (NORTH)"
 	},
 /obj/structure/window/reinforced/plasma,
@@ -48,7 +46,6 @@
 "ah" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 1;
-	icon_state = "heater";
 	tag = "icon-heater (NORTH)"
 	},
 /obj/structure/window/reinforced/plasma,
@@ -82,7 +79,6 @@
 "ap" = (
 /obj/machinery/light/small{
 	dir = 1;
-	icon_state = "lbulb1";
 	tag = "icon-lbulb1 (NORTH)"
 	},
 /obj/machinery/nuclearbomb,
@@ -116,7 +112,6 @@
 "au" = (
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "lbulb1";
 	tag = "icon-lbulb1 (EAST)"
 	},
 /obj/item/toy/foamblade,
@@ -150,7 +145,6 @@
 "ay" = (
 /obj/machinery/light/small{
 	dir = 8;
-	icon_state = "lbulb1";
 	tag = "icon-lbulb1 (WEST)"
 	},
 /turf/simulated/floor/shuttle/plating,
@@ -193,7 +187,6 @@
 "aI" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "ltube1";
 	tag = "icon-ltube1 (NORTH)"
 	},
 /turf/simulated/floor/shuttle{
@@ -387,7 +380,6 @@
 "bf" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "ltube1";
 	tag = "icon-ltube1 (WEST)"
 	},
 /mob/living/simple_animal/hostile/humanoid/syndicate/melee,
@@ -408,7 +400,6 @@
 "bh" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "ltube1";
 	tag = "icon-ltube1 (EAST)"
 	},
 /turf/simulated/floor/shuttle{
@@ -507,7 +498,6 @@
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/small{
 	dir = 8;
-	icon_state = "lbulb1";
 	tag = "icon-lbulb1 (WEST)"
 	},
 /turf/simulated/floor/shuttle/plating,
@@ -516,7 +506,6 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small{
 	dir = 4;
-	icon_state = "lbulb1";
 	tag = "icon-lbulb1 (EAST)"
 	},
 /turf/simulated/floor/shuttle/plating,

--- a/maps/randomvaults/taxi_engineering.dmm
+++ b/maps/randomvaults/taxi_engineering.dmm
@@ -374,8 +374,7 @@
 /obj/item/weapon/storage/fancy/cigarettes,
 /obj/item/weapon/stamp/ce,
 /obj/item/device/radio/intercom{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/item/device/rcd/matter/engineering,
 /obj/item/stack/rcd_ammo,
@@ -423,15 +422,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/airless,
-/area/vault/taxi_engi/engine)
-"aT" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
 	},
 /turf/simulated/floor/plating/airless,
 /area/vault/taxi_engi/engine)
@@ -542,7 +532,6 @@
 "bf" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering";
-	req_access_txt = "0";
 	req_one_access_txt = "10;24"
 	},
 /obj/machinery/door/firedoor,
@@ -874,7 +863,6 @@
 /area/vault/taxi_engi/lobby)
 "bS" = (
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning_corner";
 	tag = "icon-warning_corner"
 	},
@@ -985,7 +973,6 @@
 	id_tag = "Singularity";
 	name = "Shutters Control";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "10"
 	},
 /turf/simulated/floor/plating,
@@ -1144,7 +1131,6 @@
 "co" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering Foyer";
-	req_access_txt = "0";
 	req_one_access_txt = "11;24"
 	},
 /obj/machinery/door/firedoor,
@@ -1597,8 +1583,7 @@
 /area/vault/taxi_engi/lobby)
 "dd" = (
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
+	dir = 8
 	},
 /obj/structure/reagent_dispensers/silicate,
 /turf/simulated/floor{
@@ -1648,8 +1633,7 @@
 "dh" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -1737,11 +1721,9 @@
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the singularity chamber.";
-	dir = 2;
 	name = "Singularity Engine Telescreen";
 	network = list("S*&^ngular##");
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plating,
 /area/vault/taxi_engi/engine)
@@ -1908,8 +1890,7 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -2433,7 +2414,6 @@
 	id_tag = "Singularity";
 	name = "Shutters Control";
 	pixel_x = 24;
-	pixel_y = 0;
 	req_access_txt = "10"
 	},
 /turf/simulated/floor/damaged,
@@ -2448,7 +2428,6 @@
 	id_tag = "Singularity";
 	name = "Shutters Control";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "10"
 	},
 /obj/effect/decal/warning_stripes{
@@ -2551,8 +2530,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/vault/taxi_engi/storage)
@@ -2622,9 +2600,7 @@
 /turf/simulated/floor,
 /area/vault/taxi_engi/engine)
 "fj" = (
-/obj/structure/dispenser{
-	pixel_x = 0
-	},
+/obj/structure/dispenser,
 /turf/simulated/floor,
 /area/vault/taxi_engi/engine)
 "fk" = (
@@ -2769,8 +2745,7 @@
 	pixel_y = -1
 	},
 /obj/item/device/radio/intercom{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plating,
 /area/vault/taxi_engi/storage)
@@ -2809,7 +2784,6 @@
 	id_tag = "Singularity";
 	name = "Shutters Control";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "10"
 	},
 /turf/simulated/floor/plating,
@@ -2902,8 +2876,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/vault/taxi_engi/storage)
@@ -2915,8 +2888,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/vault/taxi_engi/storage)
@@ -2951,7 +2923,6 @@
 "fO" = (
 /obj/machinery/power/apc/no_alerts{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -2966,9 +2937,7 @@
 /area/vault/taxi_engi/storage)
 "fQ" = (
 /obj/machinery/power/emitter{
-	anchored = 0;
-	dir = 8;
-	state = 0
+	dir = 8
 	},
 /obj/item/device/radio/intercom{
 	pixel_y = 25
@@ -2977,17 +2946,13 @@
 /area/vault/taxi_engi/storage)
 "fR" = (
 /obj/machinery/power/emitter{
-	anchored = 0;
-	dir = 8;
-	state = 0
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/vault/taxi_engi/storage)
 "fS" = (
 /obj/machinery/power/emitter{
-	anchored = 0;
-	dir = 8;
-	state = 0
+	dir = 8
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -3087,7 +3052,6 @@
 /obj/item/pod_parts/armor/civ,
 /obj/machinery/power/apc/no_alerts{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor{
@@ -3412,8 +3376,7 @@
 /area)
 "gP" = (
 /obj/item/device/radio/intercom{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/blood/tracks/footprints/clown,
@@ -4129,7 +4092,7 @@ aa
 aa
 aa
 aa
-aT
+aS
 aB
 bK
 cb

--- a/maps/randomvaults/zoo_truck.dmm
+++ b/maps/randomvaults/zoo_truck.dmm
@@ -344,8 +344,7 @@
 /obj/effect/decal/warning_stripes{
 	color = "#FF0000";
 	dir = 8;
-	icon_state = "zoo";
-	pixel_x = 0
+	icon_state = "zoo"
 	},
 /turf/simulated/wall/shuttle,
 /area/vault/automap)
@@ -799,7 +798,6 @@
 "cj" = (
 /obj/effect/plantsegment/single,
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -818,7 +816,6 @@
 	name = "Food Delivery"
 	},
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -832,7 +829,6 @@
 /obj/machinery/light_construct,
 /obj/item/weapon/light/tube,
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -841,7 +837,6 @@
 "cm" = (
 /obj/effect/plantsegment/single,
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -851,7 +846,6 @@
 /obj/effect/plantsegment/single,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -861,7 +855,6 @@
 /obj/effect/plantsegment/single,
 /obj/machinery/light_construct,
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},
@@ -871,7 +864,6 @@
 "cp" = (
 /obj/effect/plantsegment/single,
 /obj/effect/decal/warning_stripes{
-	dir = 2;
 	icon_state = "warning";
 	tag = "icon-warning"
 	},

--- a/maps/test_multiz.dmm
+++ b/maps/test_multiz.dmm
@@ -50,16 +50,13 @@
 /area)
 "al" = (
 /obj/machinery/atmospherics/unary/portables_connector{
-	dir = 2;
 	name = "Connector Port (Air Supply)"
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
 /area/crew_quarters/bar)
 "am" = (
-/obj/machinery/atmospherics/unary/cold_sink/freezer{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/cold_sink/freezer,
 /turf/simulated/floor/plating,
 /area/crew_quarters/bar)
 "an" = (

--- a/maps/test_tiny.dmm
+++ b/maps/test_tiny.dmm
@@ -1367,7 +1367,6 @@
 	req_access_txt = "35"
 	},
 /obj/machinery/pos{
-	department = null;
 	name = "Hydroponics Point of Sale"
 	},
 /obj/machinery/door/firedoor/border_only{


### PR DESCRIPTION
## What this does
All maps not previously in TGM format have been converted. All maps with dirty variables have had them removed.
Exceptions:
- Both maps in the "broken" folder, since they're broken and I can't open them without StrongDMM deleting a lot of typepaths that have since been removed. (jungle.dmm and zresearchlabs.dmm)
- Three maps that @Optimism333 is currently working on, as he has converted them in #34459 (habitation.dmm, research.dmm, mothership_lab.dmm)

## Why it's good
Standardizes map formatting, removes useless data.

[system]
