### PR TITLE
fix being unable to wrench atmos controller

### DIFF
--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -18,7 +18,7 @@ var/global/list/atmos_controllers = list()
 	var/obj/item/weapon/card/id/log_in_id = null //the ID that's currently logged in
 	var/screen = ACA_SCREEN_DETAILSVIEW //the current screen in the UI
 	var/datum/airalarm_preset/selected_preset = null //stores the preset settings while they're being edited
-	machine_flags = EMAGGABLE
+	machine_flags = EMAGGABLE | SCREWTOGGLE | WRENCHMOVE
 
 	light_color = LIGHT_COLOR_CYAN
 


### PR DESCRIPTION
## Changelog
fixes #34499
thanks to @pedr69 
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Central Atmos Controller can now be wrenched/unwrenched, screwed/unscrewed