### PR TITLE
smartfridges start with mini icons (for pills, bottles, etc.) enabled

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -18,7 +18,7 @@
 	var/icon_off = "smartfridge-off"
 	var/list/datum/fridge_pile/piles = list()
 	var/opened = 0.0
-	var/display_miniicons = FALSE
+	var/display_miniicons = MINIICONS_ON
 
 	var/list/accepted_types = list(	/obj/item/weapon/reagent_containers/food/snacks/grown,
 									/obj/item/weapon/grown,


### PR DESCRIPTION
## Why it's good
No good reason for them to be off. You still have the option to disable them, if you so choose.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Smartfridges now start with mini-icons (for pills, bottles, etc.) enabled
