### PR TITLE
fix plaguemouse memory spam

### DIFF
--- a/code/datums/gamemode/factions/plague_mice.dm
+++ b/code/datums/gamemode/factions/plague_mice.dm
@@ -27,9 +27,13 @@
 	. = ..()
 	if (!plague)
 		SetupDisease()
-
 	var/mob/living/simple_animal/mouse/plague/M = R.antag.current
 	M.infect_disease2(plague,1, "Plague Mice")
+
+	/* With the disease set-up, store the detials of the disease in the mouse's memory */
+	var/datum/mind/mouse_mind = R.antag
+	mouse_mind.store_memory(plague.get_info(TRUE), forced = 1)
+	mouse_mind.store_memory("<hr>")
 
 /datum/faction/plague_mice/OnPostSetup()
 	if (!plague || !invasion)

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -198,10 +198,6 @@ var/list/infected_contact_mobs = list()
 			if (O && !istype(src, /mob/living/simple_animal/mouse/plague))
 				O.total_infections++
 			plague.update_hud_icons()
-			for(var/datum/role/plague_mouse/M in plague.members)
-				var/datum/mind/mouse_mind = M.antag
-				mouse_mind.store_memory(D.get_info(TRUE), forced = 1)
-				mouse_mind.store_memory("<hr>")
 		//----------------
 
 		for (var/obj/item/device/pda/p in contents)


### PR DESCRIPTION
Fixes completely untested Kanef feature from #29857 
If he tested it even once, he would've found that the disease info updates every single time anyone infects someone.
Fixes #33128

[bugfix]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Plague mice no longer get their memory spammed every time someone new is infected with their disease.