### PR TITLE
Fixed Blob "Jump to Core" button at the top not working, and Cerebrate button consuming points when disabled

### DIFF
--- a/code/_onclick/mindUI/blob.dm
+++ b/code/_onclick/mindUI/blob.dm
@@ -70,7 +70,7 @@
 		return
 	var/i = 1
 	for (var/obj/abstract/mind_ui_element/hoverable/blob_thumbnail_shortcut/smallblob in elements)
-		smallblob.Hide()
+		smallblob.invisibility = 101
 		var/obj/effect/blob/B = null
 		if(i<=M.special_blobs.len)
 			B = M.special_blobs[i]

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -144,6 +144,7 @@
 
 	if(antag_madness != ANTAG_MADNESS_OFF)
 		to_chat(src, "<span class='danger'>Something is amiss, maybe some genetic defect, but regardless you find yourself unable to create a new blob core. You'll have to endure on your own.</span>")
+		add_points(cost)
 		return
 
 	B.change_to(/obj/effect/blob/core, src, TRUE)


### PR DESCRIPTION
:cl:
* bugfix: Fixed the "Jump to Blob Core" button at the top left of the screen of Blob players not working properly.
* bugfix: Fixed the "Create Core Blob" button consuming points for nothing when attempting to use it during Antag Madness.