### PR TITLE
adds variables to instruments that allow them give chems to anyone that hears it

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -363,3 +363,14 @@
 		if("closed","open","closing","opening")
 			return dir
 	return 0
+
+/* Converts a reagent typepath or reagent datum (ex. /datum/reagent/chillwax) into its reagent ID (ex. "chillwax") */
+/proc/reagent_type2id(var/datum/reagent/type)
+	if(!type)
+		return
+	if(istext(type))
+		type = text2path(type)
+	if(type && (istype(type) || ispath(type, /datum/reagent)))
+		type = initial(type.id)
+		. = type
+	return

--- a/code/datums/gamemode/role/rambler.dm
+++ b/code/datums/gamemode/role/rambler.dm
@@ -53,6 +53,7 @@
 	desc = "Similar to other woodwinds, though it can be played only by a true rambler of souls."
 	slot_flags = SLOT_BACK
 	requires_mouth = FALSE //Playing a shakashuri doth art in the mindbrain's heart, anyway
+	bard_reagent_id = CHILLWAX
 
 /obj/item/device/instrument/recorder/shakashuri/attack_self(mob/user)
 	if(!isrambler(user))
@@ -60,10 +61,6 @@
 		return
 	else
 		..()
-
-/obj/item/device/instrument/recorder/shakashuri/OnPlayed(mob/user,mob/M)
-	if(user!=M && M.reagents && !M.reagents.has_reagent(CHILLWAX,1))
-		M.reagents.add_reagent(CHILLWAX,0.3)
 
 /obj/item/weapon/reagent_containers/food/snacks/quiche/frittata/New()
 	..()

--- a/code/game/objects/items/devices/instruments.dm
+++ b/code/game/objects/items/devices/instruments.dm
@@ -51,11 +51,11 @@
 	song.ui_interact(user,ui_key,ui,force_open)
 
 /obj/item/device/instrument/proc/OnPlayed(mob/user, mob/M)
-	var/is_valid_id
 	if(!bard_reagent_id)
 		return
 	if(!user || !M)
 		return
+	var/is_valid_id
 	if(chemical_reagents_list[bard_reagent_id]) /* Check against global list of reagents to see if the ID is already valid */
 		if(!istype(bard_reagent_id)) /* In case someone sets the variable to an existing reagents datum... for some reason... */
 			is_valid_id = 1

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -622,7 +622,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	if(!amount)
 		return 0
 	if(!isnum(amount))
-		return 1
+		return 0
 	update_total()
 	if(total_volume + amount > maximum_volume)
 		amount = (maximum_volume - total_volume) //Doesnt fit in. Make it disappear. Shouldn't happen. Will happen.
@@ -648,7 +648,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 					R.data = data //just in case someone adds a new reagent with a data var
 
 			handle_reactions()
-			return 0
+			return 1
 
 	var/datum/reagent/D = chemical_reagents_list[reagent]
 	if(D)
@@ -681,13 +681,14 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 		update_total()
 		my_atom.on_reagent_change()
 		handle_reactions()
-		return 0
+		return 1
+
 	else
 		warning("[my_atom] attempted to add a reagent called '[reagent]' which doesn't exist. ([usr])")
 
 	handle_reactions()
 
-	return 1
+	return 0
 
 /datum/reagents/proc/remove_reagent(var/reagent, var/amount, var/safety)//Added a safety check for the trans_id_to
 


### PR DESCRIPTION
Admin only in current implementation, but I plan to add a spawnable item.
[content][administration]

## What this does
- `bard_reagent_id` - determines which reagent the instrument will distribute when played
- `bard_reagent_amount` - determines how much reagent will be distributed on each `OnPlayed()` call
- Changes the return values in the `add_reagent` proc to properly reflect whether or not the call was successful

## To-do
- Move this input sanity checking to somewhere else
- Cache valid reagent id so `OnPlayed()` is not constantly checking validity (expensive)
- Add spawn-able item with a reagent already set in `bard_reagent_id`, maybe as loot (artifact with random reagent id?)
- (maybe) An admin button to help them spawn the instrument? I don't know if that'd be even necessary...
- Range variable to limit the effects of the instrument, mostly for balancing the artifact