### PR TITLE
AI units are now properly dense

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -16,9 +16,9 @@ var/list/ai_list = list()
 	name = "AI"
 	icon = 'icons/mob/AI.dmi'
 	icon_state = "ai"
-	anchored = TRUE // -- TLE
+	anchored = TRUE
 	density = TRUE
-	status_flags = CANSTUN|CANPARALYSE|CANPUSH
+	status_flags = CANSTUN | CANPARALYSE | CANPUSH
 	force_compose = TRUE
 	size = SIZE_BIG
 
@@ -180,6 +180,9 @@ var/list/ai_list = list()
 		anchored = !anchored
 		to_chat(src, "You are now <b>[anchored ? "" : "un"]anchored</b>.")
 	busy = FALSE
+
+/mob/living/silicon/ai/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+	return (!density || !height || air_group)
 
 /mob/living/silicon/ai/verb/toggle_holopadoverlays()
 	set category = "AI Commands"


### PR DESCRIPTION
## What this does
See changelog.

## Why it's good
Allowing crawling under AI's let's them be killed rather easily with no easy way to save them without being directly adjacent to the AI and alt-clicking to see who's under it. This is incredibly lame, somewhat of an exploit, and should've been fixed ages ago.

A side-effect of this is that you will now take damage and lose teeth when tackling an AI, which is funny.
[tweak]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Tackling an AI is now equivalent to tackling a wall: you'll bounce off and hurt yourself!
 * tweak: Can no longer crawl under AI's.
