### PR TITLE
deadchat death message uses mob's real name if available

### DIFF
--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -56,9 +56,10 @@
 	if(transmogged_from)
 		transmog_death()
 	if(client || mind)
-		var/mobname = src.real_name ? "[src.real_name]" : "[src]"
+		var/mindname = (src.mind && src.mind.name) ? "[src.mind.name]" : "[real_name]"
+		var/died_as = (mindname == real_name) ? "" : " (died as [real_name])"
 		for(var/mob/M in get_deadchat_hearers())
-			var/rendered = "\proper<a href='?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>(Follow)</a><span class='game deadsay'> \The <span class='name'>[mobname]</span> has died at \the <span class='name'>[get_area(src)]</span>.</span>"
+			var/rendered = "\proper<a href='?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>(Follow)</a><span class='game deadsay'> \The <span class='name'>[mindname][died_as]</span> has died at \the <span class='name'>[get_area(src)]</span>.</span>"
 			to_chat(M, rendered)
 			log_game("[key_name(src)] has died at [get_area(src)]. Coordinates: ([get_coordinates_string(src)])")
 

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -57,7 +57,8 @@
 		transmog_death()
 	if(client || mind)
 		for(var/mob/M in get_deadchat_hearers())
-			var/rendered = "\proper<a href='?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>(Follow)</a><span class='game deadsay'> \The <span class='name'>[src]</span> has died at \the <span class='name'>[get_area(src)]</span>.</span>"
+			var/mobname = src.mind ? "[src.mind.real_name]" : "[src]"
+			var/rendered = "\proper<a href='?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>(Follow)</a><span class='game deadsay'> \The <span class='name'>[mobname]</span> has died at \the <span class='name'>[get_area(src)]</span>.</span>"
 			to_chat(M, rendered)
 			log_game("[key_name(src)] has died at [get_area(src)]. Coordinates: ([get_coordinates_string(src)])")
 

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -56,8 +56,8 @@
 	if(transmogged_from)
 		transmog_death()
 	if(client || mind)
+		var/mobname = src.real_name ? "[src.real_name]" : "[src]"
 		for(var/mob/M in get_deadchat_hearers())
-			var/mobname = src.mind ? "[src.mind.real_name]" : "[src]"
 			var/rendered = "\proper<a href='?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>(Follow)</a><span class='game deadsay'> \The <span class='name'>[mobname]</span> has died at \the <span class='name'>[get_area(src)]</span>.</span>"
 			to_chat(M, rendered)
 			log_game("[key_name(src)] has died at [get_area(src)]. Coordinates: ([get_coordinates_string(src)])")


### PR DESCRIPTION
much better than "Unknown has died at X"

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Deadchat death messages should no longer tell you about "unknown" dying, uses their actual name instead.