### PR TITLE
Makes it so the Autodrobe Contraband creep spray makes cleanable decals, rather than actual beno weeds.

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -485,7 +485,7 @@ var/list/salts_particle_emitters = list(
 
 /obj/effect/decal/cleanable/purpledrank
 	name = "weeds?"
-	desc = "Someone spilled some purple drank here."
+	desc = "Someone spilled some grape juice? here."
 	gender = PLURAL
 	density = 0
 	anchored = 1

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -482,3 +482,12 @@ var/list/salts_particle_emitters = list(
 	icon_state = "holysalt"
 	anchored = 1
 	act_delay = 20 SECONDS
+
+/obj/effect/decal/cleanable/purpledrank
+	name = "weeds?"
+	desc = "Someone spilled some purple drank here."
+	gender = PLURAL
+	density = 0
+	anchored = 1
+	icon = 'icons/mob/alien.dmi'
+	icon_state = "weeds"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -10203,5 +10203,5 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 		return 1
 
 	if(volume >= 1)
-		if(!locate(/obj/effect/alien/weeds) in T)
-			new /obj/effect/alien/weeds(T)
+		if(!locate(/obj/effect/decal/cleanable/purpledrank) in T)
+			new /obj/effect/decal/cleanable/purpledrank(T)


### PR DESCRIPTION
Not a good idea for the fake creep to actually be real creep (what in god's name is on that grape drink).

:cl:
 * bugfix: The Autodrobe contraband creep spray now makes cleanable creep decals instead of actual weeds.