### PR TITLE
Fixing the Body Archive as well as a whole lot of bullshit

### DIFF
--- a/code/datums/body_archive.dm
+++ b/code/datums/body_archive.dm
@@ -10,7 +10,7 @@ var/list/body_archives = list()
 	var/key
 	var/rank
 
-	var/datum/mind/mind//keeping a pointer to the source mind for tracking purposes
+	var/datum/mind/mind	//keeping a pointer to the source mind for tracking purposes
 
 	// just an empty list where you can store extra data, such as human DNA records
 	var/list/data = list()

--- a/code/datums/body_archive.dm
+++ b/code/datums/body_archive.dm
@@ -10,6 +10,8 @@ var/list/body_archives = list()
 	var/key
 	var/rank
 
+	var/datum/mind/mind//keeping a pointer to the source mind for tracking purposes
+
 	// just an empty list where you can store extra data, such as human DNA records
 	var/list/data = list()
 
@@ -20,23 +22,34 @@ var/list/body_archives = list()
 	..()
 	body_archives += src
 	mob_type = source.type
+	mind = source.mind
 	name = source.mind.name
 	key = source.mind.key
 	rank = source.mind.assigned_role
 	log_debug("[key_name(source)] has has had their body ([mob_type]) archived.")
 	source.archive_body(src)
 
-/datum/body_archive/proc/spawn_copy(var/turf/T)//admin toy
+//Admin toys
+/datum/body_archive/proc/spawn_naked(var/turf/T)
 	var/mob/temp_mob = new mob_type(T)
-	var/spawn_naked = ishuman(temp_mob) && alert("Keep current job equipment again or not?", "Body Resetting", "Keep Outfit", "Spawn Naked") == "Keep Outfit"
-	temp_mob.actually_reset_body(src, FALSE, spawn_naked, null, null)
+	temp_mob.actually_reset_body(src, FALSE, FALSE, null, null)
+	T.turf_animation('icons/effects/96x96.dmi',"beamin",-32,0,MOB_LAYER+1,'sound/weapons/emitter2.ogg',anim_plane = EFFECTS_PLANE)
 	qdel(temp_mob)
 
-/datum/body_archive/proc/spawn_transfer(var/turf/T)//admin toy
+/datum/body_archive/proc/spawn_clothed(var/turf/T)
 	var/mob/temp_mob = new mob_type(T)
-	var/spawn_naked = ishuman(temp_mob) && alert("Let them get their current job equipment again or not?", "Body Resetting", "Keep Outfit", "Spawn Naked") == "Keep Outfit"
-	temp_mob.actually_reset_body(src, FALSE, spawn_naked, null, get_mind_by_key(src.key))
+	temp_mob.actually_reset_body(src, FALSE, TRUE, null, null)
+	T.turf_animation('icons/effects/96x96.dmi',"beamin",-32,0,MOB_LAYER+1,'sound/weapons/emitter2.ogg',anim_plane = EFFECTS_PLANE)
 	qdel(temp_mob)
+
+/datum/body_archive/proc/transfer(var/turf/T)
+	var/mob/living/L = locate(/mob/living/) in T
+	if (!L)
+		return null
+	mind.transfer_to(L)
+	to_chat(L, "<span class='notice'>You blinked and are now seeing the world through a fresh new pair of eyes.</span>")
+	L.playsound_local(T, 'sound/effects/inception.ogg',75,0,0,0,0)
+	return L
 
 ////////////////////////////////////////////////////////////////////
 //																  //
@@ -46,7 +59,7 @@ var/list/body_archives = list()
 
 /mob/proc/archive_body(var/datum/body_archive/archive)
 
-/mob/proc/reset_body(var/datum/body_archive/archive,var/keep_clothes = FALSE, var/spawn_naked = TRUE)
+/mob/proc/reset_body(var/datum/body_archive/archive,var/keep_inventory = FALSE, var/job_outfit = FALSE)
 	if (!archive)
 		if (mind && mind.body_archive)
 			archive = mind.body_archive
@@ -56,10 +69,10 @@ var/list/body_archives = list()
 	var/mob/new_mob
 
 	if (type == archive.mob_type)
-		new_mob = actually_reset_body(archive, keep_clothes, spawn_naked, src, mind)
+		new_mob = actually_reset_body(archive, keep_inventory, job_outfit, src, mind)
 	else
 		var/mob/temp_mob = new archive.mob_type(loc)
-		new_mob = temp_mob.actually_reset_body(archive, keep_clothes, spawn_naked, src, mind)
+		new_mob = temp_mob.actually_reset_body(archive, keep_inventory, job_outfit, src, mind)
 		qdel(temp_mob)
 
 	drop_all()
@@ -67,7 +80,7 @@ var/list/body_archives = list()
 	return new_mob
 
 // With this proc we're guarranted that the mob_type in the archive is the same as src
-/mob/proc/actually_reset_body(var/datum/body_archive/archive,var/keep_clothes = FALSE, var/spawn_naked = TRUE, var/mob/old_mob, var/datum/mind/our_mind)
+/mob/proc/actually_reset_body(var/datum/body_archive/archive,var/keep_inventory = FALSE, var/job_outfit = FALSE, var/mob/old_mob, var/datum/mind/our_mind)
 	var/mob/new_mob = new archive.mob_type(loc)
 	if (our_mind)
 		our_mind.transfer_to(new_mob)
@@ -104,7 +117,7 @@ var/list/body_archives = list()
 
 	//I gave a shot at preserving limb status (destroyed, peg, mechanized) then decided I was too tired and it's too much trouble, so TODO for anyone with the determination
 
-/mob/living/carbon/human/actually_reset_body(var/datum/body_archive/archive, var/keep_clothes = FALSE, var/spawn_naked = TRUE, var/mob/old_mob, var/datum/mind/our_mind)
+/mob/living/carbon/human/actually_reset_body(var/datum/body_archive/archive, var/keep_inventory = FALSE, var/job_outfit = FALSE, var/mob/old_mob, var/datum/mind/our_mind)
 
 	//Creating our new body
 	var/datum/dna2/record/R = archive.data["dna_records"]
@@ -154,7 +167,7 @@ var/list/body_archives = list()
 	domutcheck(H)
 
 	//Optionally transferring items
-	if (ishuman(old_mob) && keep_clothes)
+	if (ishuman(old_mob) && keep_inventory)
 		//taking care of those items separately so they don't fall on the floor
 		var/obj/item/transfered_uniform = old_mob.get_item_by_slot(slot_w_uniform)
 		var/obj/item/transfered_suit = old_mob.get_item_by_slot(slot_wear_suit)
@@ -193,8 +206,9 @@ var/list/body_archives = list()
 			if (transfered_held_item)
 				old_mob.drop_item(transfered_held_item,loc,TRUE)
 				H.put_in_hands(transfered_held_item)
-	else if(!spawn_naked)
-		var/datum/job/J = GetJob(archive.rank)
+
+	if (job_outfit)
+		var/datum/job/J = job_master.GetJob(archive.rank)
 		if(J)
 			J.equip(H, J.priority)
 		H.job = archive.rank

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -903,9 +903,9 @@ function loadPage(list) {
 			to_chat(usr, "Only mobs with a /mind have their original body archived")
 			return
 		if (ishuman(M) && alert("Since you are resetting a human, do you want them to keep their current inventory equipped or drop it all on the floor?", "Body Resetting", "Keep Inventory", "Drop Everything") == "Keep Inventory")
-			M.reset_body(keep_clothes = TRUE)
-		else if (ishuman(M) && alert("Since you are resetting a human, do you want them to get their current job equipment again or not?", "Body Resetting", "Keep Outfit", "Spawn Naked") == "Keep Outfit")
-			M.reset_body(spawn_naked = FALSE)
+			M.reset_body(keep_inventory = TRUE)
+		else if (ishuman(M) && alert("Additionally, do you want them to get a new copy of their job outfit?", "Body Resetting", "New Outfit", "Stay Naked") == "New Outfit")
+			M.reset_body(job_outfit = TRUE)
 		else
 			M.reset_body()
 		add_gamelogs(usr, " reset [(M == usr) ? "their own" : "[key_name(M)]'s"] body from its archive.", admin = TRUE, tp_link = TRUE)

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -145,9 +145,6 @@
 		return 0
 
 	antag = M
-	if(M.current.client)
-		antag.key = M.current.client.ckey
-		antag.active = TRUE
 	M.antag_roles.Add(id)
 	M.antag_roles[id] = src
 	objectives.owner = M

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -91,23 +91,21 @@
 		var/datum/role/R = antag_roles[role]
 		R.PreMindTransfer(current)
 
+	if(current)					//remove ourself from our old body's mind variable NOW THAT THE TRANSFER IS DONE
+		current.old_assigned_role = assigned_role
+		current.mind = null
+
 	if(new_character.mind)		//remove any mind currently in our new body's mind variable
 		new_character.mind.current = null
 
 	nanomanager.user_transferred(current, new_character)
 
-	//find a better way to do this, this is horrible
-	if(active)
-		new_character.key = key	//now transfer the key to link the client to our new body
-
-	if(current)					//remove ourself from our old body's mind variable NOW THAT THE TRANSFER IS DONE
-		current.old_assigned_role = assigned_role
-		current.mind = null
-
 	var/mob/old_character = current
 	current = new_character		//link ourself to our new body
 	new_character.mind = src	//and link our new body to ourself
-	new_character.mind.active = TRUE	//necessary for some reason
+
+	if(active)
+		new_character.key = key	//now transfer the key to link the client to our new body
 
 	for (var/role in antag_roles)
 		var/datum/role/R = antag_roles[role]
@@ -562,6 +560,8 @@
 /mob/proc/mind_initialize() // vgedit: /mob instead of /mob/living
 	if(mind)
 		mind.key = key
+		if(ticker)
+			ticker.minds |= mind
 	else
 		mind = new /datum/mind(key)
 		if(ticker)

--- a/code/modules/admin/body_archive_panel.dm
+++ b/code/modules/admin/body_archive_panel.dm
@@ -26,19 +26,24 @@
 		<th style="width:1%">Key</th>
 		<th style="width:1%">Name</th>
 		<th style="width:1%">Rank</th>
-		<th style="width:0.5%">Spawn Copy</th>
-		<th style="width:1%">Spawn and Transfer</th>
+		<th style="width:0.5%">Naked Copy</th>
+		<th style="width:0.5%">Clothed Copy</th>
+		<th style="width:0.5%">Transfer</th>
 		<th style="width:1%">Mob Type</th>
 		</tr>
 		"}
 
 	for (var/datum/body_archive/archive in body_archives)
+		var/archivename = archive.name
+		if (!archivename)
+			archive.name = "(blank)"
 		dat += {"<tr>
 			<td>[archive.key]</td>
-			<td>[archive.name]</td>
+			<td><a href='?src=\ref[src];bodyarchivepanel_focus=\ref[archive]'>[archivename]</a></td>
 			<td>[archive.rank]</td>
-			<td><a href='?src=\ref[src];bodyarchivepanel_spawncopy=\ref[archive]'>\[SPAWN\]</a></td>
-			<td><a href='?src=\ref[src];bodyarchivepanel_spawntransfer=\ref[archive]'>\[SPAWN+TRANSFER\]</a></td>
+			<td><a href='?src=\ref[src];bodyarchivepanel_spawnnaked=\ref[archive]'>\[SPAWN\]</a></td>
+			<td><a href='?src=\ref[src];bodyarchivepanel_spawnclothed=\ref[archive]'>\[SPAWN\]</a></td>
+			<td><a href='?src=\ref[src];bodyarchivepanel_transfer=\ref[archive]'>\[TRANSFER\]</a></td>
 			<td><i>[archive.mob_type]</i></td>
 			</tr>
 			"}

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -229,10 +229,6 @@
 	new_character.dna.ready_dna(new_character)
 	new_character.key = G_found.key
 
-	// Create a brand new mind for the dude
-	new_character.mind = new
-	new_character.mind.current = new_character
-
 	return new_character
 
 /datum/admins/proc/create_syndicate_death_commando(obj/spawn_location, syndicate_leader_selected = 0)


### PR DESCRIPTION
Fixes #34178
Fixes #34425 (maybe?)

![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/d5eec5bd-51d4-40d7-8f0f-c5b6ef47a7f0)

https://github.com/vgstation-coders/vgstation13/assets/7573912/518cdee2-5489-479d-a5e6-285f3890f87f


Fixes various issues. Some brought by Kanef who didn't test their Body Archive changes, some by Ada who fixed Midround Wizards in the worst way possible (treating the symptoms instead of the cause), and some by older cursed code.

It's almost all backend changes:
* The ticker.minds list now actually properly fills up with all created minds, instead of only a few random ones.
* Reverted ada's changes to mind.transfer_to() which caused a new mind to be created each time and immediately discarded, clogging up the Body Archive with useless crap.
* the one_click_antag.dm's makeBody() proc no longer borks the minds of its mobs, fixing several potential issues notably with midround antags that relied on this proc (aka the real reason why midround Wizards ghosted themselves on self-SoC)
* Fixed (and partially redesigned) Kanef's body archive outfiter. You can now spawn clothed copies with a separate button. Body Archives also now keep track of their origin mind allowing the Body Archive Panel to transfer them to any new mob the admins desire (it's pretty amazing actually, you can transfer a player's mind to a new mob even if they disconnected, and they'll be inside that new mob upon reconnecting).
* A bit of cleanup and copypasta removal