### PR TITLE
Fix abandoned crate ez opening on alt click

### DIFF
--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -20,6 +20,8 @@ var/global/list/valid_abandoned_crate_types = typesof(/obj/structure/closet/crat
 
 /obj/structure/closet/crate/secure/loot/attack_hand(mob/user as mob)
 	if(locked)
+		if (src.allowed(usr))
+			return ..()
 		to_chat(user, "<span class='notice'>The crate is locked with a Deca-code lock.</span>")
 		var/input = input(usr, "Enter digit from [min] to [max].", "Deca-Code Lock", "") as num
 		if(in_range(src, user))

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -6,6 +6,7 @@ var/global/list/valid_abandoned_crate_types = typesof(/obj/structure/closet/crat
 	icon_state = "rustysecurecrate"
 	icon_opened = "rustysecurecrateopen"
 	icon_closed = "rustysecurecrate"
+	req_access = list(access_salvage_captain)
 	var/code = null
 	var/lastattempt = null
 	var/attempts = 3

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -29,6 +29,7 @@ var/global/list/valid_abandoned_crate_types = typesof(/obj/structure/closet/crat
 			if (input == code)
 				to_chat(user, "<span class='notice'>The crate unlocks!</span>")
 				locked = 0
+				update_icon()
 			else if (input == null || input > max || input < min)
 				to_chat(user, "<span class='notice'>You leave the crate alone.</span>")
 			else


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
[bugfix]
## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Adds salvage captain access to the abandoned crates. 
The pirate that flew the salvage ship ages ago must have hidden his riches among the rocks on the asteroid.
Closes #34550
Closes #21333

## Why it's good
<!-- Explain why you think these changes are good. -->
Fixes ez opening of abandoned crates via alt click and also adds a nice bonus to having the salvage captain ID.
Not overpowered either!!

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: You can't open abandoned crates by alt clicking anymore
 * tweak: The salvage ship's captain buried his riches among the rocks of the asteroid. Find his ID to easily open his abandoned crates.