### PR TITLE
christmas in july sucks, removes snaxi from being rolled in july

### DIFF
--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -134,7 +134,7 @@
 
 /datum/next_map/snaxi/is_votable()
 	var/MM = text2num(time2text(world.timeofday, "MM")) // get the current month
-	var/allowed_months = list(1, 2, 7, 12)
+	var/allowed_months = list(1, 2, 12)
 	if (!(MM in allowed_months))
 		var/msg = "Skipping map [name] as this is no longer the Christmas season."
 		message_admins(msg)


### PR DESCRIPTION
## Why it's good
We are four (4) days into "Christmas in July" and this map is already cutting pop to 40% of the previous round when it gets voted. I am not really interested in debating the merits of the map, but I do know that this snow map should not be escaping its confines of winter. 99% of our players are in the northern hemisphere anyway, this "feature" doesn't make much sense.
[tweak]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: SnowStation is no longer part of July's map selection..