### PR TITLE
Hostile mobs transfer their friend lists when they "grow up" into an adult

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -366,13 +366,12 @@
 	var/mob/living/simple_animal/hostile/H = from
 	if(istype(H))
 		for (var/datum/weakref/ref in H.friends)
-			var/not_a_friend_yet = TRUE
+			var/already_friend = FALSE
 			var/mob/M = ref.get()
-			for (var/datum/weakref/reff in H.friends)
+			for (var/datum/weakref/reff in friends)
 				if (M == reff.get())
-					not_a_friend_yet = FALSE
-					break
-			if (not_a_friend_yet)
+					already_friend = TRUE
+			if (!already_friend)
 				friends += makeweakref(M)
 
 /mob/living/simple_animal/hostile/proc/OpenFire(var/atom/ttarget)
@@ -530,8 +529,3 @@
 
 /mob/living/simple_animal/hostile/get_armor_modifier(mob/living/target)
 	return armor_modifier
-
-/mob/living/simple_animal/hostile/friend_list_transfer(var/mob/living/simple_animal/hostile/new_animal)
-	//add contents of friends to our new type
-	new_animal.friends += friends
-	return

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -530,3 +530,8 @@
 
 /mob/living/simple_animal/hostile/get_armor_modifier(mob/living/target)
 	return armor_modifier
+
+/mob/living/simple_animal/hostile/friend_list_transfer(var/mob/living/simple_animal/hostile/new_animal)
+	//add contents of friends to our new type
+	new_animal.friends += friends
+	return

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -785,9 +785,6 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 
 	return new_animal
 
-/mob/living/simple_animal/proc/friend_list_transfer(var/mob/living/simple_animal/new_animal)
-	return
-
 /mob/living/simple_animal/proc/inherit_mind(mob/living/simple_animal/from)
 	src.faction = from.faction
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -780,10 +780,16 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 		new_animal.colour = colour
 		new_animal.update_icon()
 
+	//used by hostile mobs when growing up to transfer their list of friends.
+	friend_list_transfer(new_animal)
+
 	forceMove(get_turf(src))
 	qdel(src)
 
 	return new_animal
+
+/mob/living/simple_animal/proc/friend_list_transfer(var/mob/living/simple_animal/new_animal)
+	return
 
 /mob/living/simple_animal/proc/inherit_mind(mob/living/simple_animal/from)
 	src.faction = from.faction

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -780,9 +780,6 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 		new_animal.colour = colour
 		new_animal.update_icon()
 
-	//used by hostile mobs when growing up to transfer their list of friends.
-	friend_list_transfer(new_animal)
-
 	forceMove(get_turf(src))
 	qdel(src)
 


### PR DESCRIPTION
edited:
Fixed an issue with inherit mind proc on simple mobs to properly transfer its friend list were it to grow up.

resolve #34570  and any other issues related to baby carp reverting to hostile when they become adults.

[bugfix]

:cl:
 * bugfix: Baby carps will no longer turn on their friends when they grow up into adults. This rule should also apply to any hostile mob that "grows up" into some kind of adult form.
