### PR TITLE
Ghosts and mice can't put people on morgue/crematorium trays anymore

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -222,7 +222,7 @@
 		return
 	if (!ismob(O) && !istype(O, /obj/structure/closet/body_bag))
 		return
-	if (!(ishuman(user) || ismartian(user) || ismonkey(user)) && !isrobot(user))
+	if (!iscarbon(user) && !isrobot(user))
 		return
 
 	O.forceMove(src.loc)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -443,6 +443,9 @@
 		return
 	if (!ismob(O) && !istype(O, /obj/structure/closet/body_bag))
 		return
+	if (!iscarbon(user) && !isrobot(user))
+		return
+
 	O.forceMove(src.loc)
 	if (user != O)
 		for(var/mob/B in viewers(user, 3))

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -222,6 +222,9 @@
 		return
 	if (!ismob(O) && !istype(O, /obj/structure/closet/body_bag))
 		return
+	if (!(ishuman(user) || ismartian(user) || ismonkey(user)) && !isrobot(user))
+		return
+
 	O.forceMove(src.loc)
 	if (user != O)
 		visible_message("<span class='warning'>[user] stuffs [O] into [src]!</span>")


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
[bugfix]

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Makes sure ghosts and mice can't put people onto morgue trays anymore. Will also stop a ton of other weird mobs from doing that, like pitbulls, probably, but I didn't check all of them. Follows the same logic as surgery tables, sleepers... except that monkeys are still allowed to drag people into them without the dexterity drug.

## Why it's good
<!-- Explain why you think these changes are good. -->
Ghastly hands will no longer reach into the mortal realm to dunk you onto a morgue tray
And tiny mice won't heave you onto them anymore either

There were no issues for this, just a random comment in a bug report for something else that I can't find anymore

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Ghosts & mice can no longer drag things onto morgue/crematorium trays