### PR TITLE
Autodrobe Fake Creep Minor Updates

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -4098,7 +4098,7 @@
 	var/datum/reagent/bumcivilian/B = locate(/datum/reagent/bumcivilian) in holder.reagent_list
 	for(var/turf/T in view(get_turf(holder.my_atom)))
 		T.mute_time = world.time + B.mute_duration
-	
+
 /datum/chemical_reaction/random
 	name = "Random chemical"
 	id = "random"
@@ -4106,6 +4106,13 @@
 	required_reagents = list(NOTHING = 10, PHAZON = 10)
 	required_catalysts = list(MUTAGEN = 10, ENZYME = 10)
 	result_amount = 1
+
+/datum/chemical_reaction/fake_creep // Xenomorph weeds aka creep.
+	name = "Dan's Purple Drank"
+	id = FAKE_CREEP
+	result = FAKE_CREEP
+	required_reagents = list(MUTAGEN = 1, PLASMA = 1, DISCOUNT = 1)
+	result_amount = 3
 
 /datum/chemical_reaction/random/on_reaction(var/datum/reagents/holder, var/created_volume)
 	..()

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -183,8 +183,8 @@
 
 //Fake Xeno Creep Sprayer
 /obj/item/weapon/reagent_containers/spray/creepspray
-	name = "Creep Spray"
-	desc = "Filled with a mysterious purple liquid."
+	name = "Alien Weed Spray"
+	desc = "You're unsure if this is meant to cull or create weeds. The Discount Dan logo is haphazardly slapped on top of a faded yellow 'W' and gray 'Y'"
 	volume = 250
 
 /obj/item/weapon/reagent_containers/spray/creepspray/New()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
Minor adjustments as per feedback given in #34364:
-Added a Dan's recipe for xeno creep. Recipe is 1 mutagen, 1 dansauce, 1 plasma (because Alien resource is plasma)
-Updated the description and name of the spraying bottle found in the contraband section of the Autodrobe to hint more at what it does

## Testing
-Acquired a new drinking glass
-Added 1u of each reagent into a glass using the admin "add reagent command" and confirming the recipe executes
-Confirmed that I can throw the glass on the floor and generate creep as intended

## Why it's good
-Utilizes dansauce as someone requested
-Clarification on the spray bottle to be a bit more clear on what it is/does

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Adds a recipe to create the fake_creep reagent utilizing dansauce
 * tweak: Small changes to description of the creep spraying bottle in the contraband section of the Autodrobe

