### PR TITLE
Fixed only one Hobo Shack having an APC when 2 of those spawn

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -2836,13 +2836,32 @@ var/list/the_station_areas = list (
 /area/maintenance/engine
 	name = "Engine"
 
+var/list/shack_names = list("abandoned","deserted","forsaken","stranded","isolated")
+
 /area/shack
-	name = "abandoned shack"
+	name = "shack"
 	requires_power = 0
 	icon_state = "firingrange"
 	dynamic_lighting = 1
 
 	holomap_draw_override = HOLOMAP_DRAW_FULL
+
+/area/shack/spawned_by_map_element(datum/map_element/ME, list/objects)//So each shack is its own area. Copied from /area/vault/automap.
+	var/area/shack/new_area = new src.type
+
+	for(var/turf/T in src.contents)
+		new_area.contents.Add(T)
+
+		T.change_area(src, new_area)
+		for(var/atom/allthings in T.contents)
+			allthings.change_area(src, new_area)
+
+	new_area.tag = "[new_area.type]/\ref[ME]"
+
+	var/pick_name = pick(shack_names)
+	shack_names -= pick_name
+	new_area.name = "[pick_name] shack"//having a different name for every shack so they are separate entries in the Jump to Area list
+	ghostteleportlocs[new_area.name] = new_area
 
 // BEGIN Horizon
 /area/hallway/primary/foreport

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -133,12 +133,6 @@
 
 /obj/machinery/power/apc/New(loc, var/ndir, var/building=0)
 	..(loc)
-	var/area/this_area = get_area(src)
-	if(this_area.areaapc || this_area.forbid_apc)
-		var/turf/T = get_turf(src)
-		world.log << "[this_area.forbid_apc ? "Forbidden" : "Second"] APC detected in area: [this_area.name] [T.x], [T.y], [T.z]. Deleting the second APC."
-		qdel(src)
-		return
 
 	wires = new(src)
 	// offset 24 pixels in direction of dir
@@ -147,8 +141,6 @@
 		dir = ndir
 	src.tdir = dir		// to fix Vars bug
 	dir = SOUTH
-
-	this_area.set_apc(src)
 
 	if(src.tdir & 3)
 		pixel_x = 0
@@ -189,8 +181,15 @@
 /obj/machinery/power/apc/initialize()
 	..()
 	var/area/this_area = get_area(src)
-	if(this_area)
-		name = "[this_area.name] APC"
+	if(this_area.areaapc || this_area.forbid_apc)
+		var/turf/T = get_turf(src)
+		world.log << "[this_area.forbid_apc ? "Forbidden" : "Second"] APC detected in area: [this_area.name] [T.x], [T.y], [T.z]. Deleting the second APC."
+		qdel(src)
+		return
+
+	name = "[this_area.name] APC"
+
+	this_area.set_apc(src)
 
 	update_icon()
 	add_self_to_holomap()


### PR DESCRIPTION
Brought to my attention by MushroomMan01

Each shack is now its own area should multiple of them spawn. Also mapped APCs now eliminate duplicates on initialize() instead of New() so we have time to fix the areas.

:cl:
* bugfix: Fixed the issue where hobo shacks could lack an APC if two of them spawned. Each shack is now properly its own area.