### PR TITLE
fix handcuffs disappearing when shot by a damaging projectile

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1262,11 +1262,12 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define BACK_LAYER				17		//Back should be above head so that headgear doesn't hides backpack when facing north
 #define ID_LAYER				18		//IDs should be visible above suits and backpacks
 #define HANDCUFF_LAYER			19
-#define LEGCUFF_LAYER			20
-#define HAND_LAYER				21
-#define TAIL_LAYER				22		//bs12 specific. this hack is probably gonna come back to haunt me
-#define TARGETED_LAYER			23		//BS12: Layer for the target overlay from weapon targeting system
-#define TOTAL_LAYERS			23
+#define MUTUALCUFF_LAYER		20
+#define LEGCUFF_LAYER			21
+#define HAND_LAYER				22
+#define TAIL_LAYER				23		//bs12 specific. this hack is probably gonna come back to haunt me
+#define TARGETED_LAYER			24		//BS12: Layer for the target overlay from weapon targeting system
+#define TOTAL_LAYERS			24
 //////////////////////////////////
 
 //Snake stuff so leaderboard can see it too

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -182,7 +182,9 @@
 	obj_overlays[FACEMASK_LAYER]	= new /obj/abstract/Overlays/facemask_layer
 	obj_overlays[HEAD_LAYER]		= new /obj/abstract/Overlays/head_layer
 	obj_overlays[HANDCUFF_LAYER]	= new /obj/abstract/Overlays/handcuff_layer
+	obj_overlays[MUTUALCUFF_LAYER]	= new /obj/abstract/Overlays/mutualcuff_layer
 	obj_overlays[LEGCUFF_LAYER]		= new /obj/abstract/Overlays/legcuff_layer
+	
 	//obj_overlays[HAND_LAYER]		= new /obj/abstract/Overlays/hand_layer
 	obj_overlays[TAIL_LAYER]		= new /obj/abstract/Overlays/tail_layer
 	obj_overlays[TARGETED_LAYER]	= new /obj/abstract/Overlays/targeted_layer

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -184,7 +184,6 @@
 	obj_overlays[HANDCUFF_LAYER]	= new /obj/abstract/Overlays/handcuff_layer
 	obj_overlays[MUTUALCUFF_LAYER]	= new /obj/abstract/Overlays/mutualcuff_layer
 	obj_overlays[LEGCUFF_LAYER]		= new /obj/abstract/Overlays/legcuff_layer
-	
 	//obj_overlays[HAND_LAYER]		= new /obj/abstract/Overlays/hand_layer
 	obj_overlays[TAIL_LAYER]		= new /obj/abstract/Overlays/tail_layer
 	obj_overlays[TARGETED_LAYER]	= new /obj/abstract/Overlays/targeted_layer

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1302,15 +1302,15 @@ var/global/list/damage_icon_parts = list()
 /mob/living/carbon/human/update_inv_mutual_handcuffed(var/update_icons = TRUE)
 	if(monkeyizing)
 		return
-	overlays -= obj_overlays[HANDCUFF_LAYER]
+	overlays -= obj_overlays[MUTUALCUFF_LAYER]
 	if (mutual_handcuffs && mutual_handcuffs.is_visible())
 		stop_pulling()	//TODO: should be handled elsewhere
-		var/obj/abstract/Overlays/O = obj_overlays[HANDCUFF_LAYER]
+		var/obj/abstract/Overlays/O = obj_overlays[MUTUALCUFF_LAYER]
 		O.icon = 'icons/obj/cuffs.dmi'
 		O.icon_state = "singlecuff1"//TODO: procedurally generated single-cuffs
 		O.pixel_x = species.inventory_offsets["[slot_handcuffed]"]["pixel_x"] * PIXEL_MULTIPLIER
 		O.pixel_y = species.inventory_offsets["[slot_handcuffed]"]["pixel_y"] * PIXEL_MULTIPLIER
-		obj_to_plane_overlay(O,HANDCUFF_LAYER)
+		obj_to_plane_overlay(O,MUTUALCUFF_LAYER)
 
 	if(update_icons)
 		update_icons()

--- a/code/modules/overlays/mobs.dm
+++ b/code/modules/overlays/mobs.dm
@@ -60,6 +60,9 @@
 /obj/abstract/Overlays/handcuff_layer
 	layer = FLOAT_LAYER - (TOTAL_LAYERS - HANDCUFF_LAYER)
 
+/obj/abstract/Overlays/mutualcuff_layer
+	layer = FLOAT_LAYER - (TOTAL_LAYERS - MUTUALCUFF_LAYER)
+
 /obj/abstract/Overlays/legcuff_layer
 	layer = FLOAT_LAYER - (TOTAL_LAYERS - LEGCUFF_LAYER)
 


### PR DESCRIPTION
Broken for 4 years.
Mutual handcuffs were deleting handcuffs every time `regenerate_icons` was called because it used the same layering as actual handcuffs. `regenerate_icons` is called when you're shot by a damaging projectile. It's probably called in other cases too, but this is just what I noticed earlier today and will fix all instances of this bug happening.
[bugfix]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Handcuff overlays will no longer disappear when shot by a damaging projectile. This bug has also been fixed for the other niche instances in which it would happen.
