### PR TITLE
Revert 'Nuke Ops Requesting Reinforcements'

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -368,11 +368,6 @@ var/list/corrupt_mobs = list(
 // Set by traitor item, affects cargo supplies
 var/station_does_not_tip = FALSE
 
-// Whether Nuclear Operatives have declared war on station.
-var/war_declared = FALSE
-var/war_declared_time = 0
-var/can_war_be_declared = TRUE
-
 //Malf AI global variables
 var/malf_radio_blackout = FALSE
 var/malf_rcd_disable = FALSE

--- a/__DEFINES/striketeam_defines.dm
+++ b/__DEFINES/striketeam_defines.dm
@@ -3,7 +3,3 @@
 #define TEAM_ERT				"Emergency Response Team"
 #define TEAM_ELITE_SYNDIE		"Elite Syndicate Squad"
 #define TEAM_CUSTOM				ROLE_STRIKE
-
-#define SYNDICATE_SHUTTLE_TRANSIT_DELAY 240
-#define SYNDICATE_SHUTTLE_COOLDOWN 200
-#define CHALLENGE_SYNDIE_SHUTTLE_DELAY 600

--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -742,16 +742,6 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 	message = "Presence of hostile Syndicate operatives has been confirmed in the vicinity of [station_name()]. Command staff is advised to monitor the status of all high-value assets, and security staff should co-operate with all crew members in securing the station from infiltration."
 	..()
 
-/datum/command_alert/nuclear_operatives_war
-	name = "Nuclear Operatives"
-	alert_title = "Imminent Assault"
-	theme = "nukesquad"
-	alertlevel = "red"
-
-/datum/command_alert/nuclear_operatives_war/announce()
-	message = "Syndicate Communications Intercepted: Hostile Syndicate Operatives are preparing to assault [station_name()] ETA 10 minutes. Command staff is advised to monitor the status of all high-value assets, and security staff should co-operate with all crew members in securing the station from infiltration. "
-	..()
-
 /datum/command_alert/blizzard_end
 	alert_title = "Blizzard Status"
 	message = "Automated meteorological warning alert: the blizzard has been confirmed to be no longer active. Thank you for your cooperation with standard safety procedures."

--- a/code/datums/outfit/striketeams/nukeop.dm
+++ b/code/datums/outfit/striketeams/nukeop.dm
@@ -167,7 +167,6 @@
 	R.set_frequency(SYND_FREQ)
 	if(H.mind.GetRole(NUKE_OP_LEADER))
 		H.equip_to_slot_or_del(new /obj/item/device/modkit/syndi_commander(H), slot_in_backpack)
-		H.equip_to_slot_or_del(new /obj/item/device/nuclear_challenge, slot_in_backpack)
 	if (H.active_genes.len > 0)
 		to_chat(H, "The Syndicate has provided you with a ryetalyn pill to cure your genetic defects. Use it at your own discretion.")
 		var/obj/item/weapon/reagent_containers/pill/ryetalyn/pill = new (H)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -218,7 +218,6 @@ var/list/uplink_items = list()
 	item = /obj/effect/spawner/newbomb/timer
 	cost = 25
 	refundable = TRUE
-	num_in_stock = 3
 
 /datum/uplink_item/nukeprice/robot
 	name = "Syndicate-modified Combat Robot Teleporter"

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -360,7 +360,7 @@ For vending packs, see vending_packs.dm*/
 		return 1
 	//Calling the shuttle
 	else if(href_list["send"])
-		if(!map.linked_to_centcomm && !war_declared)
+		if(!map.linked_to_centcomm)
 			to_chat(usr, "<span class='warning'>You aren't able to establish contact with central command, so the shuttle won't move.</span>")
 		else if(!SSsupply_shuttle.can_move())
 			to_chat(usr, "<span class='warning'>For safety reasons the automated supply shuttle cannot transport sapient organisms, classified nuclear weaponry or homing beacons.</span>")

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -988,21 +988,6 @@ to destroy them and players will be able to make replacements.
 							/obj/item/weapon/stock_parts/subspace/crystal = 2,
 							/obj/item/weapon/stock_parts/subspace/transmitter = 4)
 
-/obj/item/weapon/circuitboard/telehub/syndicate
-	name = "Circuit Board (Teleporter Generator)"
-	desc = "A circuit board used to run a machine that generates a teleporter horizon."
-	build_path = /obj/machinery/teleport/hub/syndicate
-	board_type = MACHINE
-	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_ENGINEERING + "=3;" + Tc_BLUESPACE + "=3"
-	req_components = list(
-							/obj/item/weapon/stock_parts/scanning_module/adv/phasic = 2,
-							/obj/item/weapon/stock_parts/capacitor/adv/super = 3,
-							/obj/item/weapon/stock_parts/subspace/ansible = 2,
-							/obj/item/weapon/stock_parts/subspace/filter = 2,
-							/obj/item/weapon/stock_parts/subspace/treatment = 1,
-							/obj/item/weapon/stock_parts/subspace/crystal = 2,
-							/obj/item/weapon/stock_parts/subspace/transmitter = 4)
-
 /obj/item/weapon/circuitboard/telestation
 	name = "Circuit Board (Teleporter Controller)"
 	desc = "A circuit board used to co-ordinate teleporter generators."

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -343,40 +343,6 @@
 		com.one_time_use = 0
 		com.locked = null
 
-/obj/machinery/teleport/hub/syndicate
-	name = "teleporter horizon generator"
-	desc = "This generates the portal through which you step through to teleport elsewhere."
-	icon_state = "tele0"
-	component_parts = newlist(
-		/obj/item/weapon/circuitboard/telehub/syndicate,
-		/obj/item/weapon/stock_parts/scanning_module/adv/phasic,
-		/obj/item/weapon/stock_parts/scanning_module/adv/phasic,
-		/obj/item/weapon/stock_parts/capacitor/adv/super,
-		/obj/item/weapon/stock_parts/capacitor/adv/super,
-		/obj/item/weapon/stock_parts/capacitor/adv/super,
-		/obj/item/weapon/stock_parts/subspace/ansible,
-		/obj/item/weapon/stock_parts/subspace/ansible,
-		/obj/item/weapon/stock_parts/subspace/filter,
-		/obj/item/weapon/stock_parts/subspace/filter,
-		/obj/item/weapon/stock_parts/subspace/treatment,
-		/obj/item/weapon/stock_parts/subspace/crystal,
-		/obj/item/weapon/stock_parts/subspace/crystal,
-		/obj/item/weapon/stock_parts/subspace/transmitter,
-		/obj/item/weapon/stock_parts/subspace/transmitter,
-		/obj/item/weapon/stock_parts/subspace/transmitter,
-		/obj/item/weapon/stock_parts/subspace/transmitter
-	)
-/obj/machinery/teleport/hub/syndicate/get_target_lock()
-	if(war_declared && (world.time / 10 < war_declared_time + CHALLENGE_SYNDIE_SHUTTLE_DELAY))
-		to_chat(usr, "Bluespace Inteference blocking teleportation please wait.")
-		return FALSE
-	return ..()
-
-/obj/machinery/teleport/hub/syndicate/after_teleport()
-	..()
-	can_war_be_declared = FALSE
-
-
 /obj/machinery/teleport/station
 	name = "teleporter controller"
 	desc = "This co-ordinates nearby teleporter horizon generators."

--- a/code/game/shuttles/syndicate.dm
+++ b/code/game/shuttles/syndicate.dm
@@ -1,3 +1,6 @@
+#define SYNDICATE_SHUTTLE_TRANSIT_DELAY 240
+#define SYNDICATE_SHUTTLE_COOLDOWN 200
+
 var/global/datum/shuttle/syndicate/syndicate_shuttle = new(starting_area = /area/shuttle/nuclearops)
 
 /datum/shuttle/syndicate
@@ -14,7 +17,6 @@ var/global/datum/shuttle/syndicate/syndicate_shuttle = new(starting_area = /area
 
 	stable = 1 //Don't stun everyone and don't throw anything when moving
 	can_rotate = 0 //Sleepers, body scanners and multi-tile airlocks aren't rotated properly
-
 
 	req_access = list(access_syndicate)
 
@@ -44,7 +46,6 @@ var/global/datum/shuttle/syndicate/syndicate_shuttle = new(starting_area = /area
 		updateMarker.z = current_port.z
 		updateMarker.offset_y = -5
 
-
 /obj/machinery/computer/shuttle_control/syndicate
 	icon_state = "syndishuttle"
 
@@ -69,32 +70,6 @@ var/global/datum/shuttle/syndicate/syndicate_shuttle = new(starting_area = /area
 	newMarker.offset_y = -25
 
 	holomap_markers[HOLOMAP_MARKER_SYNDISHUTTLE] = newMarker
-
-
-/obj/machinery/computer/shuttle_control/syndicate/try_move(mob/user)
-	if(!shuttle)
-		if(user)
-			to_chat(user, "<span class='warning'>No shuttle detected.</span>")
-		return
-
-	if(!selected_port && shuttle.docking_ports.len >= 2)
-		selected_port = pick(shuttle.docking_ports - shuttle.current_port)
-
-	if(war_declared && (world.time / 10 < war_declared_time + CHALLENGE_SYNDIE_SHUTTLE_DELAY))
-		to_chat(usr, "Shuttle Cannot leave due to bluespace inteference.")
-		return FALSE
-
-	//Send a message to the shuttle to move
-	syndicate_shuttle.travel_to(selected_port, src, user)
-	can_war_be_declared = FALSE
-	selected_port = null
-	updateUsrDialog()
-
-/obj/machinery/computer/shuttle_control/syndicate/emp_act(severity)
-	return
-
-/obj/machinery/computer/shuttle_control/syndicate/kick_act(mob/user)
-	return
 
 //code/game/objects/structures/docking_port.dm
 

--- a/code/modules/events/link_with_centcomm.dm
+++ b/code/modules/events/link_with_centcomm.dm
@@ -12,8 +12,8 @@
 
 /proc/link_to_centcomm()
 	if(!map.linked_to_centcomm)
-		command_alert(/datum/command_alert/command_link_restored)
 		map.linked_to_centcomm = 1
+		command_alert(/datum/command_alert/command_link_restored)
 
 /proc/unlink_from_centcomm()
 	if(map.linked_to_centcomm)

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -98157,7 +98157,7 @@
 /turf/unsimulated/floor/snow/asphalt,
 /area/surface/snow)
 "qII" = (
-/obj/machinery/teleport/hub/syndicate,
+/obj/machinery/teleport/hub,
 /turf/unsimulated/floor{
 	icon_state = "floor4"
 	},

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -959,7 +959,6 @@
 #include "code\game\objects\items\devices\megaphone.dm"
 #include "code\game\objects\items\devices\modkit.dm"
 #include "code\game\objects\items\devices\multitool.dm"
-#include "code\game\objects\items\devices\nuclear_challenge.dm"
 #include "code\game\objects\items\devices\paicard.dm"
 #include "code\game\objects\items\devices\pcmc.dm"
 #include "code\game\objects\items\devices\pipe_painter.dm"


### PR DESCRIPTION
This PR reverts #34245.

The nuke ops PR was merged as a test merge and now we ask the question if it should stay in the game or not.

Made at the request of PrimeD.

🆑 
* rscdel: Nuclear operatives can no longer declare war for additional TC.
