### PR TITLE
+20 threat cost to civil war of casters rolling

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -247,7 +247,7 @@
 	required_pop = list(25,25,20,20,20,20,15,15,15,5)
 	required_candidates = 4
 	weight = BASE_RULESET_WEIGHT/2
-	cost = 45
+	cost = 65
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 40
 	flags = HIGHLANDER_RULESET


### PR DESCRIPTION
## Why it's good
<!-- Explain why you think these changes are good. -->
Wizard costs 35 threat, this mode spawns 4 wizards and only costs 45. I have upped the threat cost to 65.
Here is my reasoning:
- The wizard teams do not have sufficient incentive to kill each other. More often than not, this mode is simply 4 wizards terrorizing the station instead of 1.
- To this same end, wizards rarely complete their objectives of eliminating the other faction, instead dying and leaving behind a ruined station that usually takes ages to achieve a shuttle call.
- Even if wizards DID follow their objectives, the logical next step of them winning is a shuttle call. That is to say: the only possible result for this gamemode is a depopulated station with an early shuttle call. This gamemode has the flag `HIGHLANDER_RULESET` which indicates that it is indeed meant to be a round-ender when rolled.
- I do not believe that a mode with such a high likelihood to swiftly end the round should be able to roll so easily. Bear in mind that this is a roundstart ruleset.

[balance]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Civil War of Casters now requires 65 threat to be rolled.
