### PR TITLE
Remove Mussolini

### DIFF
--- a/code/modules/library/computers/remote_gallery_access.dm
+++ b/code/modules/library/computers/remote_gallery_access.dm
@@ -103,7 +103,6 @@
 	return scanner.cached_painting
 
 /obj/machinery/computer/library/checkout/remote_gallery/make_external_book(var/datum/cachedbook/newbook)
-	message_admins("printing [newbook.title]...")
 	if(!newbook)
 		return
 	var/obj/item/mounted/frame/painting/custom/C = new(get_turf(src))


### PR DESCRIPTION
An Hilter is a `to_chat(world` that gives unwanted debug information on live. 

Its cousin, the Mussolini, is about an unwanted `message_admins`.

[bugfix][tested]