### PR TITLE
Skeet Fluff Changes

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -394,7 +394,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 /datum/supply_packs/randomised/contraband
 	num_contained = 5
 	contains = list(/obj/item/weapon/storage/pill_bottle/zoom,
-					/obj/item/weapon/storage/pill_bottle/skeet,
+					/obj/item/weapon/storage/pill_bottle/speedcrank,
 					/obj/item/weapon/storage/pill_bottle/happy,
 					/obj/item/weapon/reagent_containers/glass/bottle/pcp,
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe,

--- a/code/game/objects/items/contraband.dm
+++ b/code/game/objects/items/contraband.dm
@@ -29,16 +29,16 @@
 	new /obj/item/weapon/reagent_containers/pill/zoom( src )
 	new /obj/item/weapon/reagent_containers/pill/zoom( src )
 
-/obj/item/weapon/storage/pill_bottle/skeet
+/obj/item/weapon/storage/pill_bottle/speedcrank
 	name = "Elderly Thyroid Medication"
 	desc = "An old pill bottle with it's label partially scratched off and written over. It reads 'Take new pill each time vison clears'."
 
-/obj/item/weapon/storage/pill_bottle/skeet/New()
+/obj/item/weapon/storage/pill_bottle/speedcrank/New()
 	. = ..()
-	new /obj/item/weapon/reagent_containers/pill/skeet( src )
-	new /obj/item/weapon/reagent_containers/pill/skeet( src )
-	new /obj/item/weapon/reagent_containers/pill/skeet( src )
-	new /obj/item/weapon/reagent_containers/pill/skeet( src )
-	new /obj/item/weapon/reagent_containers/pill/skeet( src )
-	new /obj/item/weapon/reagent_containers/pill/skeet( src )
-	new /obj/item/weapon/reagent_containers/pill/skeet( src )
+	new /obj/item/weapon/reagent_containers/pill/speedcrank( src )
+	new /obj/item/weapon/reagent_containers/pill/speedcrank( src )
+	new /obj/item/weapon/reagent_containers/pill/speedcrank( src )
+	new /obj/item/weapon/reagent_containers/pill/speedcrank( src )
+	new /obj/item/weapon/reagent_containers/pill/speedcrank( src )
+	new /obj/item/weapon/reagent_containers/pill/speedcrank( src )
+	new /obj/item/weapon/reagent_containers/pill/speedcrank( src )

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -275,16 +275,16 @@
 	reagents.add_reagent(SYNAPTIZINE, 1)
 	reagents.add_reagent(HYPERZINE, 10)
 
-/obj/item/weapon/reagent_containers/pill/skeet
-	name = "Skeet pill"
-	desc = "Straight from the mothership drug labs; a party pill designed for ravers and addicts alike!"
+/obj/item/weapon/reagent_containers/pill/speedcrank
+	name = "Speedcrank pill"
+	desc = "Be up a hello!"
 	icon_state = "pill37" //darkblue tablet
 
-/obj/item/weapon/reagent_containers/pill/skeet/New()
+/obj/item/weapon/reagent_containers/pill/speedcrank/New()
 	..()
-	reagents.add_reagent(STOXIN, 1)
-	reagents.add_reagent(CRYPTOBIOLIN, 3)
-	reagents.add_reagent(HYPERZINE, 1)
+	reagents.add_reagent(VALERENIC_ACID, 1)
+	reagents.add_reagent(PHYSOSTIGMINE, 3)
+	reagents.add_reagent(COCAINE, 1)
 
 /obj/item/weapon/reagent_containers/pill/hyperzine
 	name = "Hyperzine pill"


### PR DESCRIPTION
Mothership cease and desist made me change the pills description.

## What this does
Changes the name of Skeet to Speedcrank, changes the chems to their plant based variant (Hyperzine to Cocaine, Sleeptoxin to Valerenic Acid, Cryptobiolin to Physostigmine), changes the description of the pill.

## Elaboration
This is something I wanted to do for a long time when I found out the chemicals in skeet all had their own plant chem variants (particularly surprised that cryptobiolin had phsostigmine), however only just recently got around to actually changing it. This may be considered a nerf to our contraband pills, as plant chems cannot be electrolized into base chemicals (so I had tested) however I doubt this a great loss to anyone. I am also particularly pleased with the name change from Skeet to Speedcrank, mostly because I think it sounds cooler, but also because the song the name is based off of is extremely well fitting with the functionality of the drug (fast moving, sporadic, raver party drug).

https://www.youtube.com/watch?v=RQC6HbW6TXU

## Changelog

:cl:
 * tweak: Skeet is now Speedcrank! Made with all natural chemicals.