### PR TITLE
Dynamic+

### DIFF
--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -206,8 +206,11 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 
 	data = list()
 
-	for(var/category in dynamic_mode.ruleset_category_weights)
+	for (var/category in dynamic_mode.ruleset_category_weights)
 		data[category] = dynamic_mode.ruleset_category_weights[category]
+
+	for (var/datum/dynamic_ruleset/DR in dynamic_mode.executed_rules)
+		data[DR.weight_category] = 0
 
 	write_file(data)
 

--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -178,7 +178,7 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 	var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
 	if (!istype(dynamic_mode))
 		return
-	var/list/data = list(
+	data = list(
 		"one_round_ago" = list(),
 		"two_rounds_ago" = dynamic_mode.previously_executed_rules["one_round_ago"],
 		"three_rounds_ago" = dynamic_mode.previously_executed_rules["two_rounds_ago"]
@@ -189,6 +189,49 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 		if(some_ruleset.stillborn)//executed near the end of the round
 			continue
 		data["one_round_ago"] |= "[some_ruleset.type]"
+	write_file(data)
+
+/datum/persistence_task/dynamic_ruleset_weights
+	execute = TRUE
+	name = "Dynamic ruleset weights"
+	file_path = "data/persistence/dynamic_ruleset_weights.json"
+
+/datum/persistence_task/dynamic_ruleset_weights/on_init()
+	data = read_file()
+
+/datum/persistence_task/dynamic_ruleset_weights/on_shutdown()
+	var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
+	if (!istype(dynamic_mode))
+		return
+
+	data = list()
+
+	for(var/category in dynamic_mode.ruleset_category_weights)
+		data[category] = dynamic_mode.ruleset_category_weights[category]
+
+	write_file(data)
+
+/datum/persistence_task/previous_dynamic_intensity
+	execute = TRUE
+	name = "Previous dynamic intensity"
+	file_path = "data/persistence/dynamic_ruleset_weights.json"
+
+/datum/persistence_task/previous_dynamic_intensity/on_init()
+	data = read_file()
+
+/datum/persistence_task/previous_dynamic_intensity/on_shutdown()
+	var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
+	if (!istype(dynamic_mode))
+		return
+
+	data = list(
+		"one_round_ago" = list(),
+		"two_rounds_ago" = dynamic_mode.previously_executed_rules["one_round_ago"],
+		"three_rounds_ago" = dynamic_mode.previously_executed_rules["two_rounds_ago"]
+	)
+
+	data["one_round_ago"] = dynamic_mode.get_intensity()
+
 	write_file(data)
 
 // This task has a unit test on code/modules/unit_tests/highscores.dm

--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -211,29 +211,6 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 
 	write_file(data)
 
-/datum/persistence_task/previous_dynamic_intensity
-	execute = TRUE
-	name = "Previous dynamic intensity"
-	file_path = "data/persistence/dynamic_ruleset_weights.json"
-
-/datum/persistence_task/previous_dynamic_intensity/on_init()
-	data = read_file()
-
-/datum/persistence_task/previous_dynamic_intensity/on_shutdown()
-	var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
-	if (!istype(dynamic_mode))
-		return
-
-	data = list(
-		"one_round_ago" = list(),
-		"two_rounds_ago" = dynamic_mode.previously_executed_rules["one_round_ago"],
-		"three_rounds_ago" = dynamic_mode.previously_executed_rules["two_rounds_ago"]
-	)
-
-	data["one_round_ago"] = dynamic_mode.get_intensity()
-
-	write_file(data)
-
 // This task has a unit test on code/modules/unit_tests/highscores.dm
 /datum/persistence_task/highscores
 	execute = TRUE

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -42,11 +42,8 @@
 
 	var/role_category_override = null // If a role is to be considered another for the purpose of bannig.
 
-	// -- Dynamic Plus --
 	var/dynamic_weight = 0		//Each round that passes without firing, the ruleset's weight increases linearly, allowing rarer rulesets with complicated requirements to fire more often when they meet those
-	var/min_pop_required = 0	//The ruleset needs pop to be above this number to fire
 	var/weight_category = null	//Allows multiple rulesets to share the same weight (like Wizard and CWC, or a Roundstart Ruleset with its Midround/Latejoin variants)
-	var/expected_intensity = 0	//Essentially the ruleset's threat level. If the previous round was too intense, the effective weight will be decreased, and vice versa
 
 /datum/dynamic_ruleset/New()
 	..()
@@ -165,6 +162,9 @@
 			break
 
 	result = previous_rounds_odds_reduction(result)
+
+	if (weight_category in mode.ruleset_category_weights)
+		result *= mode.ruleset_category_weights[weight_category]
 
 	if (mode.highlander_rulesets_favoured && (flags & HIGHLANDER_RULESET))
 		result *= ADDITIONAL_RULESET_WEIGHT

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -42,8 +42,7 @@
 
 	var/role_category_override = null // If a role is to be considered another for the purpose of bannig.
 
-	var/dynamic_weight = 0		//Each round that passes without firing, the ruleset's weight increases linearly, allowing rarer rulesets with complicated requirements to fire more often when they meet those
-	var/weight_category = null	//Allows multiple rulesets to share the same weight (like Wizard and CWC, or a Roundstart Ruleset with its Midround/Latejoin variants)
+	var/weight_category = null	//Allows multiple rulesets to share the same dynamic weight (like Wizard and CWC, or a Roundstart Ruleset with its Midround/Latejoin variants)
 
 /datum/dynamic_ruleset/New()
 	..()

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -1,5 +1,5 @@
 /datum/dynamic_ruleset
-	var/name = ""//For admin logging, and round end scoreboard
+	var/name = ""//For admin logging, and round end scoreboard.
 	var/persistent = 0//if set to 1, the rule won't be discarded after being executed, and /gamemode/dynamic will call process() every MC tick
 	var/repeatable = 0//if set to 1, dynamic mode will be able to draft this ruleset again later on. (doesn't apply for roundstart rules)
 	var/midround = 1//if set to 1, is a midround rule
@@ -41,6 +41,12 @@
 	var/datum/gamemode/dynamic/mode = null
 
 	var/role_category_override = null // If a role is to be considered another for the purpose of bannig.
+
+	// -- Dynamic Plus --
+	var/dynamic_weight = 0		//Each round that passes without firing, the ruleset's weight increases linearly, allowing rarer rulesets with complicated requirements to fire more often when they meet those
+	var/min_pop_required = 0	//The ruleset needs pop to be above this number to fire
+	var/weight_category = null	//Allows multiple rulesets to share the same weight (like Wizard and CWC, or a Roundstart Ruleset with its Midround/Latejoin variants)
+	var/expected_intensity = 0	//Essentially the ruleset's threat level. If the previous round was too intense, the effective weight will be decreased, and vice versa
 
 /datum/dynamic_ruleset/New()
 	..()
@@ -103,8 +109,8 @@
 
 /datum/dynamic_ruleset/proc/ready(var/forced = 0)	//Here you can perform any additional checks you want. (such as checking the map, the amount of certain jobs, etc)
 	if (admin_disable_rulesets && !forced)
-		message_admins("Dynamic Mode: [name] was prevented from firing by admins.")
-		log_admin("Dynamic Mode: [name] was prevented from firing by admins.")
+		message_admins("Dynamic Mode: [name] was prevented from firing because rulesets are disabled.")
+		log_admin("Dynamic Mode: [name] was prevented from firing because rulesets are disabled.")
 		return FALSE
 	if (required_candidates > candidates.len)		//IMPORTANT: If ready() returns 1, that means execute() should never fail!
 		return FALSE

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -59,16 +59,13 @@
 	restricted_from_jobs = list("AI","Cyborg","Mobile MMI")
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Traitor"
 	cost = 5
 	requirements = list(40,30,20,10,10,10,10,10,10,10)
 	high_population_requirement = 10
 	repeatable = TRUE
 	flags = TRAITOR_RULESET
 
-	// -- Dynamic Plus --
-	min_pop_required = 3
-	weight_category = "Traitor"
-	expected_intensity = 5
 
 /datum/dynamic_ruleset/latejoin/infiltrator/execute()
 	var/mob/M = pick(assigned)
@@ -94,15 +91,11 @@
 	required_pop = list(15,15,10,10,10,10,10,0,0,0)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT/2
+	weight_category = "Wizard"
 	cost = 20
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 40
 	repeatable = TRUE
-
-	// -- Dynamic Plus --
-	min_pop_required = 15
-	weight_category = "Wizard"
-	expected_intensity = 20
 
 /datum/dynamic_ruleset/latejoin/raginmages/execute()
 	var/mob/M = pick(assigned)
@@ -133,17 +126,13 @@
 	required_pop = list(15,15,10,10,10,10,10,0,0,0)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Ninja"
 	cost = 20
 	requirements = list(90,90,60,20,10,10,10,10,10,10)
 	high_population_requirement = 20
 	logo = "ninja-logo"
 
 	repeatable = TRUE
-
-	// -- Dynamic Plus --
-	min_pop_required = 15
-	weight_category = "Ninja"
-	expected_intensity = 20
 
 /datum/dynamic_ruleset/latejoin/ninja/execute()
 	var/mob/M = pick(assigned)
@@ -173,6 +162,7 @@
 	required_enemies = list(1,1,1,1,1,1,1,1,1,1)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Pulse"
 	cost = 25
 	requirements = list(70,40,20,20,20,20,15,15,5,5)
 	high_population_requirement = 10
@@ -181,10 +171,6 @@
 	repeatable = TRUE
 	var/list/cables_to_spawn_at = list()
 
-	// -- Dynamic Plus --
-	min_pop_required = 8
-	weight_category = "Pulse"
-	expected_intensity = 15
 
 /datum/dynamic_ruleset/latejoin/pulse_demon/ready(var/forced = 0)
 	for(var/datum/powernet/PN in powernets)
@@ -227,17 +213,13 @@
 	enemy_jobs = list()
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Grue"
 	cost = 20
 	requirements = list(70,60,50,40,30,20,10,10,10,10)
 	high_population_requirement = 10
 	logo = "grue-logo"
 	repeatable = TRUE
 	var/list/grue_spawn_spots=list()
-
-	// -- Dynamic Plus --
-	min_pop_required = 15
-	weight_category = "Grue"
-	expected_intensity = 25
 
 /datum/dynamic_ruleset/latejoin/grue/ready(var/forced = 0)
 	grue_spawn_spots=list()
@@ -294,16 +276,12 @@
 	required_pop = list(20,20,15,15,15,15,15,0,0,0)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Revolution"
 	cost = 20
 	var/required_heads = 3
 	requirements = list(101,101,70,40,30,20,20,20,20,20)
 	high_population_requirement = 50
 	flags = HIGHLANDER_RULESET
-
-	// -- Dynamic Plus --
-	min_pop_required = 20
-	weight_category = "Revolution"
-	expected_intensity = 50
 
 /datum/dynamic_ruleset/latejoin/provocateur/ready(var/forced=FALSE)
 	if (forced)
@@ -344,11 +322,8 @@
 	cost = 10
 	requirements = list(70, 60, 50, 40, 30, 20, 10, 10, 10, 10)
 	logo = "time-logo"
-
-	// -- Dynamic Plus --
-	min_pop_required = 10
 	weight_category = "Time"
-	expected_intensity = 3
+
 
 /datum/dynamic_ruleset/latejoin/time_agent/ready(var/forced=0)
 	var/player_count = mode.living_players.len
@@ -387,15 +362,11 @@
 	required_pop = list(15,15,15,10,10,10,10,5,5,0)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Changeling"
 	cost = 20
 	requirements = list(80,70,60,60,30,20,10,10,10,10)
 	high_population_requirement = 30
 	repeatable = FALSE
-
-	// -- Dynamic Plus --
-	min_pop_required = 10
-	weight_category = "Changeling"
-	expected_intensity = 5
 
 /datum/dynamic_ruleset/latejoin/changeling/execute()
 	var/mob/M = pick(assigned)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -65,6 +65,11 @@
 	repeatable = TRUE
 	flags = TRAITOR_RULESET
 
+	// -- Dynamic Plus --
+	min_pop_required = 3
+	weight_category = "Traitor"
+	expected_intensity = 5
+
 /datum/dynamic_ruleset/latejoin/infiltrator/execute()
 	var/mob/M = pick(assigned)
 	var/datum/role/traitor/newTraitor = new
@@ -93,6 +98,11 @@
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 40
 	repeatable = TRUE
+
+	// -- Dynamic Plus --
+	min_pop_required = 15
+	weight_category = "Wizard"
+	expected_intensity = 20
 
 /datum/dynamic_ruleset/latejoin/raginmages/execute()
 	var/mob/M = pick(assigned)
@@ -130,6 +140,11 @@
 
 	repeatable = TRUE
 
+	// -- Dynamic Plus --
+	min_pop_required = 15
+	weight_category = "Ninja"
+	expected_intensity = 20
+
 /datum/dynamic_ruleset/latejoin/ninja/execute()
 	var/mob/M = pick(assigned)
 	if(!latejoinprompt(M))
@@ -165,6 +180,11 @@
 
 	repeatable = TRUE
 	var/list/cables_to_spawn_at = list()
+
+	// -- Dynamic Plus --
+	min_pop_required = 8
+	weight_category = "Pulse"
+	expected_intensity = 15
 
 /datum/dynamic_ruleset/latejoin/pulse_demon/ready(var/forced = 0)
 	for(var/datum/powernet/PN in powernets)
@@ -213,6 +233,11 @@
 	logo = "grue-logo"
 	repeatable = TRUE
 	var/list/grue_spawn_spots=list()
+
+	// -- Dynamic Plus --
+	min_pop_required = 15
+	weight_category = "Grue"
+	expected_intensity = 25
 
 /datum/dynamic_ruleset/latejoin/grue/ready(var/forced = 0)
 	grue_spawn_spots=list()
@@ -275,6 +300,11 @@
 	high_population_requirement = 50
 	flags = HIGHLANDER_RULESET
 
+	// -- Dynamic Plus --
+	min_pop_required = 20
+	weight_category = "Revolution"
+	expected_intensity = 50
+
 /datum/dynamic_ruleset/latejoin/provocateur/ready(var/forced=FALSE)
 	if (forced)
 		required_heads = 1
@@ -314,6 +344,11 @@
 	cost = 10
 	requirements = list(70, 60, 50, 40, 30, 20, 10, 10, 10, 10)
 	logo = "time-logo"
+
+	// -- Dynamic Plus --
+	min_pop_required = 10
+	weight_category = "Time"
+	expected_intensity = 3
 
 /datum/dynamic_ruleset/latejoin/time_agent/ready(var/forced=0)
 	var/player_count = mode.living_players.len
@@ -356,6 +391,11 @@
 	requirements = list(80,70,60,60,30,20,10,10,10,10)
 	high_population_requirement = 30
 	repeatable = FALSE
+
+	// -- Dynamic Plus --
+	min_pop_required = 10
+	weight_category = "Changeling"
+	expected_intensity = 5
 
 /datum/dynamic_ruleset/latejoin/changeling/execute()
 	var/mob/M = pick(assigned)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -1,3 +1,15 @@
+
+/*
+	* Syndicate Infiltrator
+	* Ragin' Mages
+	* Space Ninja Attack
+	* Pulse Demon Infiltration
+	* Grue Infestation
+	* Provocateur
+	* Time Agent Anomaly
+	* Changelings
+*/
+
 //////////////////////////////////////////////
 //                                          //
 //            LATEJOIN RULESETS             ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -205,6 +205,11 @@
 	high_population_requirement = 10
 	flags = TRAITOR_RULESET
 
+	// -- Dynamic Plus --
+	min_pop_required = 10
+	weight_category = "Traitor"
+	expected_intensity = 5
+
 /datum/dynamic_ruleset/midround/autotraitor/trim_candidates()
 	..()
 	for(var/mob/living/player in living_players)
@@ -271,6 +276,11 @@
 	high_population_requirement = 65
 	flags = HIGHLANDER_RULESET
 
+	// -- Dynamic Plus --
+	min_pop_required = 15
+	weight_category = "Malf"
+	expected_intensity = 30
+
 /datum/dynamic_ruleset/midround/malf/trim_candidates()
 	..()
 	candidates = candidates[CURRENT_LIVING_PLAYERS]
@@ -320,6 +330,11 @@
 	logo = "raginmages-logo"
 	repeatable = TRUE
 
+	// -- Dynamic Plus --
+	min_pop_required = 25
+	weight_category = "Wizard"
+	expected_intensity = 30
+
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/raginmages/ready(var/forced=0)
 	if(locate(/datum/dynamic_ruleset/roundstart/cwc) in mode.executed_rules)
 		message_admins("Rejected Ragin' Mages as there was a Civil War.")
@@ -359,6 +374,11 @@
 	var/operative_cap = list(2, 2, 3, 3, 4, 5, 5, 5, 5, 5)
 	logo = "nuke-logo"
 	flags = HIGHLANDER_RULESET
+
+	// -- Dynamic Plus --
+	min_pop_required = 20
+	weight_category = "Nuke"
+	expected_intensity = 80
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/nuclear/ready(var/forced = 0)
 	if (forced)
@@ -420,6 +440,11 @@
 
 	makeBody = FALSE
 
+	// -- Dynamic Plus --
+	min_pop_required = 20
+	weight_category = "Blob"
+	expected_intensity = 60
+
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/blob_storm/ready(var/forced=0)
 	max_candidates = max(1, round(living_players.len/25))
 	return ..()
@@ -461,6 +486,11 @@
 
 	var/required_heads = 3
 
+	// -- Dynamic Plus --
+	min_pop_required = 20
+	weight_category = "Revolution"
+	expected_intensity = 50
+
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/revsquad/ready(var/forced = 0)
 	if(forced)
 		required_heads = 1
@@ -495,6 +525,11 @@
 	high_population_requirement = 20
 	logo = "ninja-logo"
 	repeatable = TRUE
+
+	// -- Dynamic Plus --
+	min_pop_required = 15
+	weight_category = "Ninja"
+	expected_intensity = 20
 
 /datum/dynamic_ruleset/midround/from_ghosts/ninja/ready(var/forced=0)
 	var/player_count = mode.living_players.len
@@ -535,6 +570,11 @@
 	repeatable = FALSE //Listen, this psyche is not big enough for two metaphysical seekers.
 	flags = MINOR_RULESET
 
+	// -- Dynamic Plus --
+	min_pop_required = 5
+	weight_category = "Rambler"
+	expected_intensity = 2
+
 /datum/dynamic_ruleset/midround/from_ghosts/rambler/ready(var/forced=0)
 	if(!mode.executed_rules)
 		return FALSE
@@ -567,6 +607,11 @@
 	cost = 10
 	requirements = list(70, 60, 50, 40, 30, 20, 10, 10, 10, 10)
 	logo = "time-logo"
+
+	// -- Dynamic Plus --
+	min_pop_required = 10
+	weight_category = "Time"
+	expected_intensity = 3
 
 /datum/dynamic_ruleset/midround/from_ghosts/time_agent/ready(var/forced=0)
 	var/player_count = mode.living_players.len
@@ -606,6 +651,11 @@
 	requirements = list(40,20,10,10,10,10,10,10,10,10) // So that's not possible to roll it naturally
 	high_population_requirement = 10
 	flags = MINOR_RULESET
+
+	// -- Dynamic Plus --
+	min_pop_required = 0
+	weight_category = "Special"//Admin-only
+	expected_intensity = 70
 
 /datum/dynamic_ruleset/midround/from_ghosts/grinch/ready(var/forced=0)
 	if(grinchstart.len == 0)
@@ -647,6 +697,11 @@
 	logo = "catbeast-logo"
 	flags = MINOR_RULESET
 
+	// -- Dynamic Plus --
+	min_pop_required = 5
+	weight_category = "Catbeast"
+	expected_intensity = 10
+
 /datum/dynamic_ruleset/midround/from_ghosts/catbeast/ready(var/forced=0)
 	if(mode.midround_threat>50) //We're threatening enough!
 		message_admins("Rejected catbeast ruleset, [mode.midround_threat] threat was over 50.")
@@ -675,6 +730,11 @@
 	high_population_requirement = 35
 	var/vox_cap = list(2,2,3,3,4,5,5,5,5,5)
 	logo = "vox-logo"
+
+	// -- Dynamic Plus --
+	min_pop_required = 15
+	weight_category = "Vox"
+	expected_intensity = 40
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/heist/ready(var/forced = 0)
 	var/indice_pop = min(10,round(living_players.len/5)+1)
@@ -729,6 +789,11 @@
 	my_fac = /datum/faction/plague_mice
 	logo = "plague-logo"
 
+	// -- Dynamic Plus --
+	min_pop_required = 5
+	weight_category = "Plague"
+	expected_intensity = 10
+
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/plague_mice/generate_ruleset_body(var/mob/applicant)
 	var/datum/faction/plague_mice/active_fac = find_active_faction_by_type(my_fac)
 	var/mob/living/simple_animal/mouse/plague/new_mouse = new (active_fac.invasion)
@@ -760,6 +825,11 @@
 	flags = MINOR_RULESET
 	my_fac = /datum/faction/spider_infestation
 	logo = "spider-logo"
+
+	// -- Dynamic Plus --
+	min_pop_required = 15
+	weight_category = "Spider"
+	expected_intensity = 30
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/spider_infestation/generate_ruleset_body(var/mob/applicant)
 	var/datum/faction/spider_infestation/active_fac = find_active_faction_by_type(my_fac)
@@ -794,6 +864,11 @@
 	logo = "xeno-logo"
 	my_fac = /datum/faction/xenomorph
 	var/list/vents = list()
+
+	// -- Dynamic Plus --
+	min_pop_required = 20
+	weight_category = "Alien"
+	expected_intensity = 60
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/xenomorphs/ready()
 	..()
@@ -841,6 +916,11 @@
 	logo = "pulsedemon-logo"
 	var/list/cables_to_spawn_at = list()
 
+	// -- Dynamic Plus --
+	min_pop_required = 8
+	weight_category = "Pulse"
+	expected_intensity = 15
+
 /datum/dynamic_ruleset/midround/from_ghosts/pulse_demon/ready(var/forced = 0)
 	for(var/datum/powernet/PN in powernets)
 		for(var/obj/structure/cable/C in PN.cables)
@@ -880,6 +960,11 @@
 	logo = "grue-logo"
 	repeatable = TRUE
 	var/list/grue_spawn_spots=list()
+
+	// -- Dynamic Plus --
+	min_pop_required = 15
+	weight_category = "Grue"
+	expected_intensity = 25
 
 /datum/dynamic_ruleset/midround/from_ghosts/grue/ready(var/forced = 0)
 	grue_spawn_spots=list()
@@ -935,6 +1020,11 @@
 	high_population_requirement = 10
 	flags = MINOR_RULESET
 	makeBody = FALSE
+
+	// -- Dynamic Plus --
+	min_pop_required = 5
+	weight_category = "Prisoner"
+	expected_intensity = 2
 
 /datum/dynamic_ruleset/midround/from_ghosts/prisoner/setup_role(var/datum/role/new_role)
 	new_role.OnPostSetup()
@@ -1053,3 +1143,8 @@
 	requirements = list(10,10,10,10,10,10,10,10,10,10)
 	logo = "gun-logo"
 	repeatable = TRUE
+
+	// -- Dynamic Plus --
+	min_pop_required = 0
+	weight_category = "Special"//Admin only
+	expected_intensity = 0

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -1,3 +1,26 @@
+
+/*
+	* Syndicate Sleeper Agent
+	* Malfunctioning AI
+	* Ragin' Mages
+	* Nuclear Assault
+	* Blob Overmind Storm
+	* Revolutionary Squad
+	* Space Ninja Attack
+	* Soul Rambler Migration
+	* Time Agent Anomaly
+	* The Grinch
+	* Loose Catbeast
+	* Vox Heist
+	* Plague Mice Invasion
+	* Spider Infestation
+	* Alien Infestation
+	* Pulse Demon Infiltration
+	* Grue Infestation
+	* Prisoner
+	* Judge
+*/
+
 //////////////////////////////////////////////
 //                                          //
 //            MIDROUND RULESETS             ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -199,16 +199,12 @@
 	restricted_from_jobs = list("AI","Mobile MMI")
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Traitor"
 	cost = 10
 	requirements = list(50,40,30,20,10,10,10,10,10,10)
 	repeatable = TRUE
 	high_population_requirement = 10
 	flags = TRAITOR_RULESET
-
-	// -- Dynamic Plus --
-	min_pop_required = 10
-	weight_category = "Traitor"
-	expected_intensity = 5
 
 /datum/dynamic_ruleset/midround/autotraitor/trim_candidates()
 	..()
@@ -271,15 +267,11 @@
 	required_pop = list(25,25,25,20,20,20,15,15,15,15)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Malf"
 	cost = 35
 	requirements = list(90,80,70,60,50,40,40,30,30,20)
 	high_population_requirement = 65
 	flags = HIGHLANDER_RULESET
-
-	// -- Dynamic Plus --
-	min_pop_required = 15
-	weight_category = "Malf"
-	expected_intensity = 30
 
 /datum/dynamic_ruleset/midround/malf/trim_candidates()
 	..()
@@ -324,16 +316,12 @@
 	required_pop = list(20,20,15,15,15,15,15,10,10,0)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT/2
+	weight_category = "Wizard"
 	cost = 25
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 50
 	logo = "raginmages-logo"
 	repeatable = TRUE
-
-	// -- Dynamic Plus --
-	min_pop_required = 25
-	weight_category = "Wizard"
-	expected_intensity = 30
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/raginmages/ready(var/forced=0)
 	if(locate(/datum/dynamic_ruleset/roundstart/cwc) in mode.executed_rules)
@@ -368,17 +356,13 @@
 	required_candidates = 5 // Placeholder, see op. cap
 	max_candidates = 5
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Nuke"
 	cost = 35
 	requirements = list(90, 90, 80, 40, 40, 40, 30, 20, 20, 10)
 	high_population_requirement = 60
 	var/operative_cap = list(2, 2, 3, 3, 4, 5, 5, 5, 5, 5)
 	logo = "nuke-logo"
 	flags = HIGHLANDER_RULESET
-
-	// -- Dynamic Plus --
-	min_pop_required = 20
-	weight_category = "Nuke"
-	expected_intensity = 80
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/nuclear/ready(var/forced = 0)
 	if (forced)
@@ -431,6 +415,7 @@
 	required_enemies = list(4,4,4,4,4,4,4,3,2,1)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Blob"
 	weekday_rule_boost = list("Tue")
 	cost = 45
 	requirements = list(90,90,80,40,40,40,30,20,20,10)
@@ -439,11 +424,6 @@
 	flags = HIGHLANDER_RULESET
 
 	makeBody = FALSE
-
-	// -- Dynamic Plus --
-	min_pop_required = 20
-	weight_category = "Blob"
-	expected_intensity = 60
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/blob_storm/ready(var/forced=0)
 	max_candidates = max(1, round(living_players.len/25))
@@ -477,6 +457,7 @@
 	required_pop = list(25,25,25,25,25,20,15,15,10,10)
 	required_candidates = 3
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Revolution"
 	cost = 30
 	requirements = list(90, 90, 90, 90, 40, 40, 30, 20, 10, 10)
 	high_population_requirement = 50
@@ -485,11 +466,6 @@
 	flags = HIGHLANDER_RULESET
 
 	var/required_heads = 3
-
-	// -- Dynamic Plus --
-	min_pop_required = 20
-	weight_category = "Revolution"
-	expected_intensity = 50
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/revsquad/ready(var/forced = 0)
 	if(forced)
@@ -520,16 +496,12 @@
 	required_pop = list(15,15,15,15,15,10,10,10,5,5)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Ninja"
 	cost = 20
 	requirements = list(90,90,60,20,10,10,10,10,10,10)
 	high_population_requirement = 20
 	logo = "ninja-logo"
 	repeatable = TRUE
-
-	// -- Dynamic Plus --
-	min_pop_required = 15
-	weight_category = "Ninja"
-	expected_intensity = 20
 
 /datum/dynamic_ruleset/midround/from_ghosts/ninja/ready(var/forced=0)
 	var/player_count = mode.living_players.len
@@ -563,17 +535,13 @@
 	required_pop = list(0,0,10,10,15,15,20,20,20,25)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Rambler"
 	timeslot_rule_boost = list(SLEEPTIME)
 	cost = 5
 	requirements = list(5,5,15,15,25,25,55,55,55,75)
 	logo = "rambler-logo"
 	repeatable = FALSE //Listen, this psyche is not big enough for two metaphysical seekers.
 	flags = MINOR_RULESET
-
-	// -- Dynamic Plus --
-	min_pop_required = 5
-	weight_category = "Rambler"
-	expected_intensity = 2
 
 /datum/dynamic_ruleset/midround/from_ghosts/rambler/ready(var/forced=0)
 	if(!mode.executed_rules)
@@ -604,14 +572,10 @@
 	role_category = /datum/role/time_agent
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT * 0.4
+	weight_category = "Time"
 	cost = 10
 	requirements = list(70, 60, 50, 40, 30, 20, 10, 10, 10, 10)
 	logo = "time-logo"
-
-	// -- Dynamic Plus --
-	min_pop_required = 10
-	weight_category = "Time"
-	expected_intensity = 3
 
 /datum/dynamic_ruleset/midround/from_ghosts/time_agent/ready(var/forced=0)
 	var/player_count = mode.living_players.len
@@ -647,15 +611,11 @@
 	required_pop = list(0,0,0,0,0,0,0,0,0,0)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Special"
 	cost = 10
-	requirements = list(40,20,10,10,10,10,10,10,10,10) // So that's not possible to roll it naturally
+	requirements = list(40,20,10,10,10,10,10,10,10,10)
 	high_population_requirement = 10
 	flags = MINOR_RULESET
-
-	// -- Dynamic Plus --
-	min_pop_required = 0
-	weight_category = "Special"//Admin-only
-	expected_intensity = 70
 
 /datum/dynamic_ruleset/midround/from_ghosts/grinch/ready(var/forced=0)
 	if(grinchstart.len == 0)
@@ -691,16 +651,12 @@
 	role_category = /datum/role/catbeast
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Catbeast"
 	cost = 0
 	requirements = list(0,0,0,0,0,0,0,0,0,0)
 	high_population_requirement = 0
 	logo = "catbeast-logo"
 	flags = MINOR_RULESET
-
-	// -- Dynamic Plus --
-	min_pop_required = 5
-	weight_category = "Catbeast"
-	expected_intensity = 10
 
 /datum/dynamic_ruleset/midround/from_ghosts/catbeast/ready(var/forced=0)
 	if(mode.midround_threat>50) //We're threatening enough!
@@ -725,16 +681,12 @@
 	required_pop = list(20,20,20,15,15,15,15,15,10,10)
 	required_candidates = 5
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Vox"
 	cost = 25
 	requirements = list(50,50,50,30,30,30,30,20,10,10)
 	high_population_requirement = 35
 	var/vox_cap = list(2,2,3,3,4,5,5,5,5,5)
 	logo = "vox-logo"
-
-	// -- Dynamic Plus --
-	min_pop_required = 15
-	weight_category = "Vox"
-	expected_intensity = 40
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/heist/ready(var/forced = 0)
 	var/indice_pop = min(10,round(living_players.len/5)+1)
@@ -782,17 +734,13 @@
 	required_candidates = 1
 	max_candidates = 5
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Plague"
 	cost = 25
 	requirements = list(90,70,50,40,30,20,10,10,10,10)
 	high_population_requirement = 40
 	flags = MINOR_RULESET
 	my_fac = /datum/faction/plague_mice
 	logo = "plague-logo"
-
-	// -- Dynamic Plus --
-	min_pop_required = 5
-	weight_category = "Plague"
-	expected_intensity = 10
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/plague_mice/generate_ruleset_body(var/mob/applicant)
 	var/datum/faction/plague_mice/active_fac = find_active_faction_by_type(my_fac)
@@ -819,17 +767,13 @@
 	required_candidates = 1
 	max_candidates = 12 // max amount of spiderlings spawned by a spider infestation random event
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Spider"
 	cost = 25
 	requirements = list(90,80,60,40,30,20,10,10,10,10)
 	high_population_requirement = 50
 	flags = MINOR_RULESET
 	my_fac = /datum/faction/spider_infestation
 	logo = "spider-logo"
-
-	// -- Dynamic Plus --
-	min_pop_required = 15
-	weight_category = "Spider"
-	expected_intensity = 30
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/spider_infestation/generate_ruleset_body(var/mob/applicant)
 	var/datum/faction/spider_infestation/active_fac = find_active_faction_by_type(my_fac)
@@ -857,18 +801,14 @@
 	required_pop = list(25,20,20,15,15,15,10,10,10,10)
 	required_candidates = 1
 	max_candidates = 3
-	weight = 1
+	weight = BASE_RULESET_WEIGHT
+	weight_category = "Alien"
 	cost = 30
 	requirements = list(90,90,70,60,50,40,20,10,10,10)
 	high_population_requirement = 35
 	logo = "xeno-logo"
 	my_fac = /datum/faction/xenomorph
 	var/list/vents = list()
-
-	// -- Dynamic Plus --
-	min_pop_required = 20
-	weight_category = "Alien"
-	expected_intensity = 60
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/xenomorphs/ready()
 	..()
@@ -910,16 +850,12 @@
 	required_enemies = list(1,1,1,1,1,1,1,1,1,1)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Pulse"
 	cost = 20
 	requirements = list(70,40,20,20,20,20,15,15,5,5)
 	high_population_requirement = 10
 	logo = "pulsedemon-logo"
 	var/list/cables_to_spawn_at = list()
-
-	// -- Dynamic Plus --
-	min_pop_required = 8
-	weight_category = "Pulse"
-	expected_intensity = 15
 
 /datum/dynamic_ruleset/midround/from_ghosts/pulse_demon/ready(var/forced = 0)
 	for(var/datum/powernet/PN in powernets)
@@ -954,17 +890,13 @@
 	enemy_jobs = list()
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Grue"
 	cost = 20
 	requirements = list(70,60,50,40,30,20,10,10,10,10)
 	high_population_requirement = 10
 	logo = "grue-logo"
 	repeatable = TRUE
 	var/list/grue_spawn_spots=list()
-
-	// -- Dynamic Plus --
-	min_pop_required = 15
-	weight_category = "Grue"
-	expected_intensity = 25
 
 /datum/dynamic_ruleset/midround/from_ghosts/grue/ready(var/forced = 0)
 	grue_spawn_spots=list()
@@ -1014,17 +946,13 @@
 	required_enemies = list(1,1,1,1,1,1,1,1,1,1)
 	required_pop = list(25,20,20,20,15,15,10,10,0,0)
 	required_candidates = 1
-	weight = 1
+	weight = BASE_RULESET_WEIGHT
+	weight_category = "Prisoner"
 	cost = 0
 	requirements = list(70,40,20,20,20,20,15,15,5,5)
 	high_population_requirement = 10
 	flags = MINOR_RULESET
 	makeBody = FALSE
-
-	// -- Dynamic Plus --
-	min_pop_required = 5
-	weight_category = "Prisoner"
-	expected_intensity = 2
 
 /datum/dynamic_ruleset/midround/from_ghosts/prisoner/setup_role(var/datum/role/new_role)
 	new_role.OnPostSetup()
@@ -1139,12 +1067,8 @@
 	required_candidates = 1
 	max_candidates = 5
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Special"//Admin only
 	cost = 20
 	requirements = list(10,10,10,10,10,10,10,10,10,10)
 	logo = "gun-logo"
 	repeatable = TRUE
-
-	// -- Dynamic Plus --
-	min_pop_required = 0
-	weight_category = "Special"//Admin only
-	expected_intensity = 0

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -38,6 +38,11 @@
 	requirements = list(10,10,10,10,10,10,10,10,10,10)
 	high_population_requirement = 10
 
+	// -- Dynamic Plus --
+	min_pop_required = 3
+	weight_category = "Traitor"
+	expected_intensity = 5	//each traitor spawned raises the actual intensity by 1
+
 /datum/dynamic_ruleset/roundstart/traitor/choose_candidates()
 	var/traitor_scaling_coeff = 10 - max(0,round(mode.threat_level/10)-5)//above 50 threat level, coeff goes down by 1 for every 10 levels
 	var/num_traitors = min(round(mode.roundstart_pop_ready / traitor_scaling_coeff) + 1, candidates.len)
@@ -57,6 +62,7 @@
 		var/datum/role/traitor/newTraitor = new
 		newTraitor.AssignToRole(M.mind,1)
 		newTraitor.Greet(GREET_ROUNDSTART)
+		DynamicIntensity(3,"NewTraitor")
 		// Above 3 traitors, we start to cost a bit more.
 	return 1
 
@@ -83,6 +89,11 @@
 	var/additional_cost = 5
 	requirements = list(101,101,101,101,10,10,10,10,10,10)
 	high_population_requirement = 15
+
+	// -- Dynamic Plus --
+	min_pop_required = 8
+	weight_category = "Traitor"
+	expected_intensity = 5	//each traitor spawned raises the actual intensity by 1
 
 // -- Currently a copypaste of traitors. Could be fixed to be less copy & paste.
 /datum/dynamic_ruleset/roundstart/challengers/choose_candidates()
@@ -111,6 +122,7 @@
 		double_agents += newTraitor
 		newTraitor.AssignToRole(M.mind,1)
 		newTraitor.Greet(GREET_ROUNDSTART)
+		DynamicIntensity(3,"NewTraitor")
 
 	if (double_agents.len > 1)
 		for (var/i = 1 to (double_agents.len - 1))
@@ -147,6 +159,11 @@
 	cost = 18
 	requirements = list(80,70,60,60,30,20,10,10,10,10)
 	high_population_requirement = 30
+
+	// -- Dynamic Plus --
+	min_pop_required = 10
+	weight_category = "Changeling"
+	expected_intensity = 5
 
 // -- Currently a copypaste of traitors. Could be fixed to be less copy & paste.
 /datum/dynamic_ruleset/roundstart/changeling/choose_candidates()
@@ -192,6 +209,11 @@
 	high_population_requirement = 30
 	var/vampire_threshold = 2
 
+	// -- Dynamic Plus --
+	min_pop_required = 15
+	weight_category = "Vampire"
+	expected_intensity = 15
+
 // -- Currently a copypaste of traitors. Could be fixed to be less copy & paste.
 /datum/dynamic_ruleset/roundstart/vampire/choose_candidates()
 	var/num_vampires = min(round(mode.roundstart_pop_ready / 10) + 1, candidates.len)
@@ -235,6 +257,11 @@
 	high_population_requirement = 40
 	var/list/roundstart_wizards = list()
 
+	// -- Dynamic Plus --
+	min_pop_required = 15
+	weight_category = "Wizard"
+	expected_intensity = 20
+
 /datum/dynamic_ruleset/roundstart/wizard/execute()
 	var/mob/new_player/M = pick(assigned)
 	if (M)
@@ -272,6 +299,11 @@
 	flags = HIGHLANDER_RULESET
 //	var/wizard_cd = 210 //7 minutes
 	var/total_wizards = 4
+
+	// -- Dynamic Plus --
+	min_pop_required = 25
+	weight_category = "Wizard"
+	expected_intensity = 60
 
 
 /datum/dynamic_ruleset/roundstart/cwc/choose_candidates()
@@ -325,6 +357,11 @@
 	var/cultist_cap = list(2,2,3,4,4,4,4,4,4,4)
 	//Readd this once proper round ending rituals are added
 	//flags = HIGHLANDER_RULESET
+
+	// -- Dynamic Plus --
+	min_pop_required = 15
+	weight_category = "Cult"
+	expected_intensity = 15
 
 /datum/dynamic_ruleset/roundstart/bloodcult/ready(var/forced = 0)
 	var/indice_pop = min(10,round(mode.roundstart_pop_ready/5)+1)
@@ -381,6 +418,9 @@ Assign your candidates in choose_candidates() instead.
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 40
 
+	// -- Dynamic Plus --
+	lol
+
 /datum/dynamic_ruleset/roundstart/cult_legacy/execute()
 	//if ready() did its job, candidates should have 4 or more members in it
 	var/datum/faction/cult/narsie/legacy = find_active_faction_by_type(/datum/faction/cult/narsie)
@@ -421,6 +461,11 @@ Assign your candidates in choose_candidates() instead.
 	high_population_requirement = 40
 	var/operative_cap = list(2, 2, 3, 3, 4, 5, 5, 5, 5, 5)
 	flags = HIGHLANDER_RULESET
+
+	// -- Dynamic Plus --
+	min_pop_required = 20
+	weight_category = "Nuke"
+	expected_intensity = 80
 
 /datum/dynamic_ruleset/roundstart/nuclear/ready(var/forced = 0)
 	var/indice_pop = min(10, round(mode.roundstart_pop_ready/5) + 1)
@@ -497,6 +542,11 @@ Assign your candidates in choose_candidates() instead.
 	requirements = list(90,80,70,60,50,40,40,30,30,20)
 	high_population_requirement = 60
 	flags = HIGHLANDER_RULESET
+
+	// -- Dynamic Plus --
+	min_pop_required = 15
+	weight_category = "Malf"
+	expected_intensity = 30
 
 // NB : `M` will never be empty as `ready` made sure we have at least one candidate with malf AI on.
 // This candidate will become an AI upon roundstart, eventually replacing other AIs candidates who do not have the preference.
@@ -583,6 +633,11 @@ Assign your candidates in choose_candidates() instead.
 	high_population_requirement = 70
 	flags = HIGHLANDER_RULESET
 
+	// -- Dynamic Plus --
+	min_pop_required = 20
+	weight_category = "Blob"
+	expected_intensity = 70
+
 /datum/dynamic_ruleset/roundstart/blob/execute()
 	var/datum/faction/blob_conglomerate/blob_fac = find_active_faction_by_type(/datum/faction/blob_conglomerate)
 	if (!blob_fac)
@@ -623,6 +678,11 @@ Assign your candidates in choose_candidates() instead.
 	requirements = list(0,0,0,0,0,0,0,0,0,0)
 	high_population_requirement = 101
 
+	// -- Dynamic Plus --
+	min_pop_required = 0
+	weight_category = "Extended"
+	expected_intensity = 0
+
 // 70% chance of allowing extended at 0-30 threat, then (100-threat)% chance.
 /datum/dynamic_ruleset/roundstart/extended/ready(var/forced=0)
 	var/probability = clamp(mode.threat_level, 30, 100)
@@ -634,7 +694,9 @@ Assign your candidates in choose_candidates() instead.
 /datum/dynamic_ruleset/roundstart/extended/execute()
 	message_admins("Starting a round of extended.")
 	log_admin("Starting a round of extended.")
-	mode.forced_extended = TRUE
+	admin_disable_rulesets = TRUE
+	log_admin("Dynamic rulesets are disabled in Extended.")
+	message_admins("Dynamic rulesets are disabled in Extended.")
 	return TRUE
 
 //////////////////////////////////////////////
@@ -657,6 +719,11 @@ Assign your candidates in choose_candidates() instead.
 	delay = 5 MINUTES
 	var/required_heads = 3
 	flags = HIGHLANDER_RULESET
+
+	// -- Dynamic Plus --
+	min_pop_required = 20
+	weight_category = "Revolution"
+	expected_intensity = 60
 
 /datum/dynamic_ruleset/roundstart/delayed/revs/ready(var/forced = 0)
 	if (forced)
@@ -714,6 +781,11 @@ Assign your candidates in choose_candidates() instead.
 	high_population_requirement = 10
 	flags = MINOR_RULESET
 
+	// -- Dynamic Plus --
+	min_pop_required = 0
+	weight_category = "Special"//Admin only
+	expected_intensity = 70
+
 /datum/dynamic_ruleset/roundstart/grinch/ready(var/forced=0)
 	if(grinchstart.len == 0)
 		log_admin("Cannot accept Grinch ruleset. Couldn't find any grinch spawn points.")
@@ -752,6 +824,11 @@ Assign your candidates in choose_candidates() instead.
 	requirements = list(101,101,101,101,101,101,101,101,101,101) // So that's not possible to roll it naturally
 	high_population_requirement = 101
 	flags = MINOR_RULESET
+
+	// -- Dynamic Plus --
+	min_pop_required = 0
+	weight_category = "Special"//Admin only
+	expected_intensity = 100
 
 /datum/dynamic_ruleset/roundstart/tag_mode/execute()
 
@@ -800,6 +877,11 @@ var/antag_madness = ANTAG_MADNESS_OFF
 	persistent = TRUE//latejoiners will either be heads of staff or traitors (unless traitor is deactivated/antagbanned)
 	var/list/nanotrasen_staff = list("Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Internal Affairs Agent")
 	var/escalation_delay = 18 MINUTES
+
+	// -- Dynamic Plus --
+	min_pop_required = 0
+	weight_category = "Special"//Admin only
+	expected_intensity = 666
 
 /datum/dynamic_ruleset/roundstart/antag_madness/trim_candidates()//All the heads of staff get the role, the rest of the players will get trimmed by the other rulesets
 	for(var/mob/P in candidates)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -388,9 +388,6 @@ Assign your candidates in choose_candidates() instead.
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 40
 
-	// -- Dynamic Plus --
-	lol
-
 /datum/dynamic_ruleset/roundstart/cult_legacy/execute()
 	//if ready() did its job, candidates should have 4 or more members in it
 	var/datum/faction/cult/narsie/legacy = find_active_faction_by_type(/datum/faction/cult/narsie)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -1,4 +1,23 @@
 
+/*
+	* Syndicate Traitors
+	* Syndicate Challengers
+	* Changelings
+	* Vampires
+	* Wizard
+	* Civil War of Casters
+	* Blood Cult
+	* Nuclear Emergency
+	* Malfunctioning AI
+	* Blob Conglomerate
+	* Extended
+	* Revolution
+	* The Grinch
+	* Tag mode
+	* Antag Madness
+*/
+
+
 //////////////////////////////////////////////
 //                                          //
 //           SYNDICATE TRAITORS             ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -32,16 +32,12 @@
 	restricted_from_jobs = list("AI","Mobile MMI")
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Traitor"
 	cost = 10
 	var/traitor_threshold = 3
 	var/additional_cost = 5
 	requirements = list(10,10,10,10,10,10,10,10,10,10)
 	high_population_requirement = 10
-
-	// -- Dynamic Plus --
-	min_pop_required = 3
-	weight_category = "Traitor"
-	expected_intensity = 5	//each traitor spawned raises the actual intensity by 1
 
 /datum/dynamic_ruleset/roundstart/traitor/choose_candidates()
 	var/traitor_scaling_coeff = 10 - max(0,round(mode.threat_level/10)-5)//above 50 threat level, coeff goes down by 1 for every 10 levels
@@ -62,7 +58,6 @@
 		var/datum/role/traitor/newTraitor = new
 		newTraitor.AssignToRole(M.mind,1)
 		newTraitor.Greet(GREET_ROUNDSTART)
-		DynamicIntensity(3,"NewTraitor")
 		// Above 3 traitors, we start to cost a bit more.
 	return 1
 
@@ -84,16 +79,12 @@
 	restricted_from_jobs = list("AI","Cyborg","Mobile MMI")
 	required_candidates = 3
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Traitor"
 	cost = 15
 	var/traitor_threshold = 4
 	var/additional_cost = 5
 	requirements = list(101,101,101,101,10,10,10,10,10,10)
 	high_population_requirement = 15
-
-	// -- Dynamic Plus --
-	min_pop_required = 8
-	weight_category = "Traitor"
-	expected_intensity = 5	//each traitor spawned raises the actual intensity by 1
 
 // -- Currently a copypaste of traitors. Could be fixed to be less copy & paste.
 /datum/dynamic_ruleset/roundstart/challengers/choose_candidates()
@@ -122,7 +113,6 @@
 		double_agents += newTraitor
 		newTraitor.AssignToRole(M.mind,1)
 		newTraitor.Greet(GREET_ROUNDSTART)
-		DynamicIntensity(3,"NewTraitor")
 
 	if (double_agents.len > 1)
 		for (var/i = 1 to (double_agents.len - 1))
@@ -156,14 +146,10 @@
 	required_pop = list(15,15,15,10,10,10,10,5,5,0)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Changeling"
 	cost = 18
 	requirements = list(80,70,60,60,30,20,10,10,10,10)
 	high_population_requirement = 30
-
-	// -- Dynamic Plus --
-	min_pop_required = 10
-	weight_category = "Changeling"
-	expected_intensity = 5
 
 // -- Currently a copypaste of traitors. Could be fixed to be less copy & paste.
 /datum/dynamic_ruleset/roundstart/changeling/choose_candidates()
@@ -204,15 +190,11 @@
 	required_pop = list(15,15,15,10,10,10,10,5,5,0)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Vampire"
 	cost = 15
 	requirements = list(80,70,60,60,30,20,10,10,10,10)
 	high_population_requirement = 30
 	var/vampire_threshold = 2
-
-	// -- Dynamic Plus --
-	min_pop_required = 15
-	weight_category = "Vampire"
-	expected_intensity = 15
 
 // -- Currently a copypaste of traitors. Could be fixed to be less copy & paste.
 /datum/dynamic_ruleset/roundstart/vampire/choose_candidates()
@@ -252,15 +234,11 @@
 	required_pop = list(15,15,15,10,10,10,10,5,5,0)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT/2
+	weight_category = "Wizard"
 	cost = 30
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 40
 	var/list/roundstart_wizards = list()
-
-	// -- Dynamic Plus --
-	min_pop_required = 15
-	weight_category = "Wizard"
-	expected_intensity = 20
 
 /datum/dynamic_ruleset/roundstart/wizard/execute()
 	var/mob/new_player/M = pick(assigned)
@@ -293,17 +271,13 @@
 	required_pop = list(25,25,20,20,20,20,15,15,15,5)
 	required_candidates = 4
 	weight = BASE_RULESET_WEIGHT/2
+	weight_category = "Wizard"
 	cost = 45
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 40
 	flags = HIGHLANDER_RULESET
 //	var/wizard_cd = 210 //7 minutes
 	var/total_wizards = 4
-
-	// -- Dynamic Plus --
-	min_pop_required = 25
-	weight_category = "Wizard"
-	expected_intensity = 60
 
 
 /datum/dynamic_ruleset/roundstart/cwc/choose_candidates()
@@ -351,17 +325,13 @@
 	required_candidates = 4
 	required_enemies = list(2,2,2,2,2,2,2,2,2,2)
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Cult"
 	cost = 30
 	requirements = list(90,80,60,30,20,10,10,10,10,10)
 	high_population_requirement = 40
 	var/cultist_cap = list(2,2,3,4,4,4,4,4,4,4)
 	//Readd this once proper round ending rituals are added
 	//flags = HIGHLANDER_RULESET
-
-	// -- Dynamic Plus --
-	min_pop_required = 15
-	weight_category = "Cult"
-	expected_intensity = 15
 
 /datum/dynamic_ruleset/roundstart/bloodcult/ready(var/forced = 0)
 	var/indice_pop = min(10,round(mode.roundstart_pop_ready/5)+1)
@@ -456,16 +426,12 @@ Assign your candidates in choose_candidates() instead.
 	required_candidates = 5 //This value is useless, see operative_cap
 	required_enemies = list(2,2,2,2,2,2,2,2,2,2)
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Nuke"
 	cost = 30
 	requirements = list(90, 80, 60, 30, 20, 10, 10, 10, 10, 10)
 	high_population_requirement = 40
 	var/operative_cap = list(2, 2, 3, 3, 4, 5, 5, 5, 5, 5)
 	flags = HIGHLANDER_RULESET
-
-	// -- Dynamic Plus --
-	min_pop_required = 20
-	weight_category = "Nuke"
-	expected_intensity = 80
 
 /datum/dynamic_ruleset/roundstart/nuclear/ready(var/forced = 0)
 	var/indice_pop = min(10, round(mode.roundstart_pop_ready/5) + 1)
@@ -538,15 +504,11 @@ Assign your candidates in choose_candidates() instead.
 	required_pop = list(25,25,25,20,20,20,15,15,15,15)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Malf"
 	cost = 40
 	requirements = list(90,80,70,60,50,40,40,30,30,20)
 	high_population_requirement = 60
 	flags = HIGHLANDER_RULESET
-
-	// -- Dynamic Plus --
-	min_pop_required = 15
-	weight_category = "Malf"
-	expected_intensity = 30
 
 // NB : `M` will never be empty as `ready` made sure we have at least one candidate with malf AI on.
 // This candidate will become an AI upon roundstart, eventually replacing other AIs candidates who do not have the preference.
@@ -627,16 +589,12 @@ Assign your candidates in choose_candidates() instead.
 	required_enemies = list(4,4,4,4,4,4,4,3,2,1)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Blob"
 	weekday_rule_boost = list("Tue")
 	cost = 45
 	requirements = list(90,90,90,80,60,40,30,20,10,10)
 	high_population_requirement = 70
 	flags = HIGHLANDER_RULESET
-
-	// -- Dynamic Plus --
-	min_pop_required = 20
-	weight_category = "Blob"
-	expected_intensity = 70
 
 /datum/dynamic_ruleset/roundstart/blob/execute()
 	var/datum/faction/blob_conglomerate/blob_fac = find_active_faction_by_type(/datum/faction/blob_conglomerate)
@@ -673,15 +631,12 @@ Assign your candidates in choose_candidates() instead.
 	enemy_jobs = list()
 	required_pop = list(30,30,30,30,30,30,30,30,30,30)
 	required_candidates = 0
-	weight = 0.5*BASE_RULESET_WEIGHT
+	weight = BASE_RULESET_WEIGHT * 0.5
+	weight_category = "Extended"
 	cost = 0
 	requirements = list(0,0,0,0,0,0,0,0,0,0)
 	high_population_requirement = 101
 
-	// -- Dynamic Plus --
-	min_pop_required = 0
-	weight_category = "Extended"
-	expected_intensity = 0
 
 // 70% chance of allowing extended at 0-30 threat, then (100-threat)% chance.
 /datum/dynamic_ruleset/roundstart/extended/ready(var/forced=0)
@@ -713,17 +668,13 @@ Assign your candidates in choose_candidates() instead.
 	required_pop = list(25,25,25,20,20,20,15,15,15,15)
 	required_candidates = 3
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Revolution"
 	cost = 40
 	requirements = list(101,101,70,40,30,20,10,10,10,10)
 	high_population_requirement = 50
 	delay = 5 MINUTES
 	var/required_heads = 3
 	flags = HIGHLANDER_RULESET
-
-	// -- Dynamic Plus --
-	min_pop_required = 20
-	weight_category = "Revolution"
-	expected_intensity = 60
 
 /datum/dynamic_ruleset/roundstart/delayed/revs/ready(var/forced = 0)
 	if (forced)
@@ -776,15 +727,11 @@ Assign your candidates in choose_candidates() instead.
 	required_pop = list(0,0,0,0,0,0,0,0,0,0)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Special"//Admin only
 	cost = 10
 	requirements = list(101,101,101,101,101,101,101,101,101,101) // So that's not possible to roll it naturally
 	high_population_requirement = 10
 	flags = MINOR_RULESET
-
-	// -- Dynamic Plus --
-	min_pop_required = 0
-	weight_category = "Special"//Admin only
-	expected_intensity = 70
 
 /datum/dynamic_ruleset/roundstart/grinch/ready(var/forced=0)
 	if(grinchstart.len == 0)
@@ -820,15 +767,11 @@ Assign your candidates in choose_candidates() instead.
 	required_pop = list(0,0,0,0,0,0,0,0,0,0)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
+	weight_category = "Special"//Admin only
 	cost = 10
 	requirements = list(101,101,101,101,101,101,101,101,101,101) // So that's not possible to roll it naturally
 	high_population_requirement = 101
 	flags = MINOR_RULESET
-
-	// -- Dynamic Plus --
-	min_pop_required = 0
-	weight_category = "Special"//Admin only
-	expected_intensity = 100
 
 /datum/dynamic_ruleset/roundstart/tag_mode/execute()
 
@@ -872,16 +815,12 @@ var/antag_madness = ANTAG_MADNESS_OFF
 	protected_from_jobs = list()
 	restricted_from_jobs = list()
 	cost = 0
+	weight_category = "Special"//Admin only
 	requirements = list(101,101,101,101,101,101,101,101,101,101) // Adminbus only
 	high_population_requirement = 101
 	persistent = TRUE//latejoiners will either be heads of staff or traitors (unless traitor is deactivated/antagbanned)
 	var/list/nanotrasen_staff = list("Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Internal Affairs Agent")
 	var/escalation_delay = 18 MINUTES
-
-	// -- Dynamic Plus --
-	min_pop_required = 0
-	weight_category = "Special"//Admin only
-	expected_intensity = 666
 
 /datum/dynamic_ruleset/roundstart/antag_madness/trim_candidates()//All the heads of staff get the role, the rest of the players will get trimmed by the other rulesets
 	for(var/mob/P in candidates)

--- a/code/datums/gamemode/factions/blob.dm
+++ b/code/datums/gamemode/factions/blob.dm
@@ -198,6 +198,8 @@
 				to_chat(aiPlayer, "Laws Updated: [law]")
 			..() //Set thematic
 		if (FACTION_DEFEATED) //Cleanup time
+			if (stage <= 1)//Blob lost before even reaching the first Defcon
+				DynamicIntensity(-10,"WizardDiedEarly")
 			command_alert(/datum/command_alert/biohazard_station_unlock)
 			send_intercept(FACTION_DEFEATED)
 			emergency_shuttle_lockdown = null

--- a/code/datums/gamemode/factions/blob.dm
+++ b/code/datums/gamemode/factions/blob.dm
@@ -198,8 +198,6 @@
 				to_chat(aiPlayer, "Laws Updated: [law]")
 			..() //Set thematic
 		if (FACTION_DEFEATED) //Cleanup time
-			if (stage <= 1)//Blob lost before even reaching the first Defcon
-				DynamicIntensity(-10,"WizardDiedEarly")
 			command_alert(/datum/command_alert/biohazard_station_unlock)
 			send_intercept(FACTION_DEFEATED)
 			emergency_shuttle_lockdown = null

--- a/code/datums/gamemode/objectives/escape.dm
+++ b/code/datums/gamemode/objectives/escape.dm
@@ -45,13 +45,6 @@
 		/area/security
 	)
 
-/datum/objective/escape_prisoner/ShuttleDocked(var/state)
-	if (state == 2)
-		if (IsFulfilled())
-			DynamicIntensity(10,"PrisonerEscaped")
-		else
-			DynamicIntensity(-10,"PrisonerKept")
-
 /datum/objective/escape_prisoner/IsFulfilled()
 	if (..())
 		return TRUE
@@ -71,7 +64,7 @@
 
 	if(istype(owner.current, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = owner.current
-		if(H.restrained())
+		if(H.restrained()) 
 			return FALSE
 	else if (istype(owner.current, /mob/living/carbon))
 		var/mob/living/carbon/C = owner.current

--- a/code/datums/gamemode/objectives/escape.dm
+++ b/code/datums/gamemode/objectives/escape.dm
@@ -45,6 +45,13 @@
 		/area/security
 	)
 
+/datum/objective/escape_prisoner/ShuttleDocked(var/state)
+	if (state == 2)
+		if (IsFulfilled())
+			DynamicIntensity(10,"PrisonerEscaped")
+		else
+			DynamicIntensity(-10,"PrisonerKept")
+
 /datum/objective/escape_prisoner/IsFulfilled()
 	if (..())
 		return TRUE
@@ -64,7 +71,7 @@
 
 	if(istype(owner.current, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = owner.current
-		if(H.restrained()) 
+		if(H.restrained())
 			return FALSE
 	else if (istype(owner.current, /mob/living/carbon))
 		var/mob/living/carbon/C = owner.current

--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -142,10 +142,8 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 	ticks_survived++
 	if(!(ticks_survived % 10) && ticks_survived < 150) //every 20 seconds, for 5 minutes
 		increment_threat(SURVIVAL_THREAT)
-		DynamicIntensity(0.5,"CatbeastSurvival")
 	if(!(A in areas_defiled))
 		increment_threat(DEFILE_THREAT)
-		DynamicIntensity(0.5,"CatbeastAreas")
 		areas_defiled.Add(A)
 		to_chat(antag.current,"<span class='notice'>You have defiled [A.name] with your presence.")
 	switch(current_disease_tier)

--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -142,8 +142,10 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 	ticks_survived++
 	if(!(ticks_survived % 10) && ticks_survived < 150) //every 20 seconds, for 5 minutes
 		increment_threat(SURVIVAL_THREAT)
+		DynamicIntensity(0.5,"CatbeastSurvival")
 	if(!(A in areas_defiled))
 		increment_threat(DEFILE_THREAT)
+		DynamicIntensity(0.5,"CatbeastAreas")
 		areas_defiled.Add(A)
 		to_chat(antag.current,"<span class='notice'>You have defiled [A.name] with your presence.")
 	switch(current_disease_tier)

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -564,8 +564,6 @@
 	var/datum/gamemode/dynamic/D = ticker.mode
 	if(!istype(D))
 		return //It's not dynamic!
-	if (D.dynamicplus)
-		return //Not using threat today!
 	threat_generated += amount
 	if(D.midround_threat >= D.midround_threat_level)
 		D.create_midround_threat(amount)
@@ -579,8 +577,6 @@
 	var/datum/gamemode/dynamic/D = ticker.mode
 	if(!istype(D))
 		return
-	if (D.dynamicplus)
-		return //Not using threat today!
 	D.spend_midround_threat(amount)
 	D.threat_log += "[worldtime2text()]: [name] has decreased the threat amount by [amount]."
 

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -564,6 +564,8 @@
 	var/datum/gamemode/dynamic/D = ticker.mode
 	if(!istype(D))
 		return //It's not dynamic!
+	if (D.dynamicplus)
+		return //Not using threat today!
 	threat_generated += amount
 	if(D.midround_threat >= D.midround_threat_level)
 		D.create_midround_threat(amount)
@@ -577,6 +579,8 @@
 	var/datum/gamemode/dynamic/D = ticker.mode
 	if(!istype(D))
 		return
+	if (D.dynamicplus)
+		return //Not using threat today!
 	D.spend_midround_threat(amount)
 	D.threat_log += "[worldtime2text()]: [name] has decreased the threat amount by [amount]."
 

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -14,16 +14,6 @@
 	var/list/artifacts_bought = list()
 	var/list/potions_bought = list()
 
-	var/time_of_join = 0
-	var/time_of_death = 0
-
-
-
-	if(!istype(get_area(user), /area/wizard_station))
-		to_chat(user, "<span class='notice'>No refunds once you leave your den.</span>")
-		return
-
-
 /datum/role/wizard/ForgeObjectives()
 	if(!antag.current.client.prefs.antag_objectives)
 		AppendObjective(/datum/objective/freeform/wizard)
@@ -42,21 +32,6 @@
 		else
 			AppendObjective(/datum/objective/hijack)
 	return
-
-
-/datum/role/wizard/process()
-	var/mob/M = antag.current
-	if (!M)
-		return
-	if (!time_of_join)
-		if(!istype(get_area(user), /area/wizard_station))
-			time_of_join = world.time
-
-	if (M.stat == DEAD)
-		if (!time_of_death)
-			time_of_death = world.time
-			if (!time_of_join || ((time_of_death - time_of_join) < 300 SECONDS))
-				DynamicIntensity(-10,"WizardDiedEarly")
 
 /datum/role/wizard/OnPostSetup()
 	. = ..()

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -14,6 +14,16 @@
 	var/list/artifacts_bought = list()
 	var/list/potions_bought = list()
 
+	var/time_of_join = 0
+	var/time_of_death = 0
+
+
+
+	if(!istype(get_area(user), /area/wizard_station))
+		to_chat(user, "<span class='notice'>No refunds once you leave your den.</span>")
+		return
+
+
 /datum/role/wizard/ForgeObjectives()
 	if(!antag.current.client.prefs.antag_objectives)
 		AppendObjective(/datum/objective/freeform/wizard)
@@ -32,6 +42,21 @@
 		else
 			AppendObjective(/datum/objective/hijack)
 	return
+
+
+/datum/role/wizard/process()
+	var/mob/M = antag.current
+	if (!M)
+		return
+	if (!time_of_join)
+		if(!istype(get_area(user), /area/wizard_station))
+			time_of_join = world.time
+
+	if (M.stat == DEAD)
+		if (!time_of_death)
+			time_of_death = world.time
+			if (!time_of_join || ((time_of_death - time_of_join) < 300 SECONDS))
+				DynamicIntensity(-10,"WizardDiedEarly")
 
 /datum/role/wizard/OnPostSetup()
 	. = ..()

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -743,12 +743,16 @@ var/datum/controller/gameticker/ticker
 	tag_mode.name = "Tag mode"
 	tag_mode.calledBy = "[key_name(user)]"
 	forced_roundstart_ruleset += tag_mode
-	dynamic_forced_extended = TRUE
+	admin_disable_rulesets = TRUE
+	log_admin("Dynamic rulesets are disabled in Tag Mode.")
+	message_admins("Dynamic rulesets are disabled in Tag Mode.")
 
 /datum/controller/gameticker/proc/cancel_tag_mode(var/mob/user)
 	tag_mode_enabled = FALSE
 	to_chat(world, "<h1>Tag mode has been cancelled.<h1>")
-	dynamic_forced_extended = FALSE
+	admin_disable_rulesets = FALSE
+	log_admin("Dynamic rulesets have been re-enabled.")
+	message_admins("Dynamic rulesets have been re-enabled.")
 	forced_roundstart_ruleset = list()
 
 /world/proc/has_round_started()

--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -3,8 +3,6 @@
 	message_admins("[key_name_admin(usr, 1)] summoned [summon_type]!")
 	log_game("[key_name(usr)] summoned [summon_type]!")
 
-	DynamicIntensity(15,"RightAndWrong")
-
 	var/datum/role/survivor_type
 
 	switch (summon_type)

--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -3,6 +3,8 @@
 	message_admins("[key_name_admin(usr, 1)] summoned [summon_type]!")
 	log_game("[key_name(usr)] summoned [summon_type]!")
 
+	DynamicIntensity(15,"RightAndWrong")
+
 	var/datum/role/survivor_type
 
 	switch (summon_type)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -737,9 +737,6 @@ var/global/floorIsLava = 0
 		<h3>Common options</h3>
 		<i>All these options can be changed midround.</i> <br/>
 		<br/>
-		<b>Force extended:</b> - Option is <a href='?src=\ref[src];force_extended=1'> <b>[dynamic_forced_extended ? "ON" : "OFF"]</a></b>.
-		<br/>This will force the round to be extended. No rulesets will be drafted. <br/>
-		<br/>
 		<b>No stacking:</b> - Option is <a href='?src=\ref[src];no_stacking=1'> <b>[dynamic_no_stacking ? "ON" : "OFF"]</b></a>.
 		<br/>Unless the threat goes above [stacking_limit], only one "round-ender" ruleset will be drafted. <br/>
 		<br/>

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -33,11 +33,11 @@
 		for (var/previous_round in dynamic_mode.previously_executed_rules)
 			switch(previous_round)
 				if ("one_round_ago")
-					dat += "<h4><b>Last Round:</b></h4>"
+					dat += "<h4><b>Last Round (Intensity:[dynamic_mode.intensity_previous[previous_round]]):</b></h4>"
 				if ("two_rounds_ago")
-					dat += "<h4><b>Two Rounds ago:</b></h4>"
+					dat += "<h4><b>Two Rounds ago (Intensity:[dynamic_mode.intensity_previous[previous_round]]):</b></h4>"
 				if ("three_rounds_ago")
-					dat += "<h4><b>Three Rounds ago:</b></h4>"
+					dat += "<h4><b>Three Rounds ago (Intensity:[dynamic_mode.intensity_previous[previous_round]]):</b></h4>"
 			for(var/previous_ruleset in dynamic_mode.previously_executed_rules[previous_round])
 				var/datum/dynamic_ruleset/DR = previous_ruleset
 				dat += "- [initial(DR.name)] <br/>"

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -33,11 +33,11 @@
 		for (var/previous_round in dynamic_mode.previously_executed_rules)
 			switch(previous_round)
 				if ("one_round_ago")
-					dat += "<h4><b>Last Round (Intensity:[dynamic_mode.intensity_previous[previous_round]]):</b></h4>"
+					dat += "<h4><b>Last Round:</b></h4>"
 				if ("two_rounds_ago")
-					dat += "<h4><b>Two Rounds ago (Intensity:[dynamic_mode.intensity_previous[previous_round]]):</b></h4>"
+					dat += "<h4><b>Two Rounds ago:</b></h4>"
 				if ("three_rounds_ago")
-					dat += "<h4><b>Three Rounds ago (Intensity:[dynamic_mode.intensity_previous[previous_round]]):</b></h4>"
+					dat += "<h4><b>Three Rounds ago:</b></h4>"
 			for(var/previous_ruleset in dynamic_mode.previously_executed_rules[previous_round])
 				var/datum/dynamic_ruleset/DR = previous_ruleset
 				dat += "- [initial(DR.name)] <br/>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1855,18 +1855,6 @@
 		dynamic_curve_width = new_width
 		dynamic_mode_options(usr)
 
-	else if(href_list["force_extended"])
-		if(!check_rights(R_ADMIN))
-			return
-
-		if(master_mode != "Dynamic Mode")
-			return alert(usr, "The game mode has to be Dynamic Mode!", null, null, null, null)
-
-		dynamic_forced_extended = !dynamic_forced_extended
-		log_admin("[key_name(usr)] set 'forced_extended' to [dynamic_forced_extended].")
-		message_admins("[key_name(usr)] set 'forced_extended' to [dynamic_forced_extended].")
-		dynamic_mode_options(usr)
-
 	else if(href_list["toggle_rulesets"])
 		if(!check_rights(R_ADMIN))
 			return


### PR DESCRIPTION
Way less ambitious than my original proposal as after playing and observing for a few months, I think things aren't as bad as they seemed initially. That being said, I still want to give this a shot.

Also removed the "forced extended" dynamic option as it is redundant with the "Disable Rulesets" button. So both buttons have been basically merged. (The Extended ruleset disables rulesets so no changes on that end from the players' perspective)

:cl:
* experiment: Dynamic rulesets now have their weight increase linearly round after round until they get to proc, upon which it gets reset to 1 (at round end). This experiment should allow rarer rulesets with complicated pre-requirements to be more likely to fire when they finally meet those, while rulesets that have just fired will have dramatically reduced chances to fire again on the next round(s) (unless they are the only valid ruleset for a given threat and pop configuration of course)