### PR TITLE
Remove vampire deadchat

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -15,8 +15,6 @@
 
 	var/iscloaking = FALSE
 	var/silentbite = FALSE
-	var/deadchat_timer = 0
-	var/deadchat = FALSE
 	var/nullified = 0
 	var/smitecounter = 0
 
@@ -273,7 +271,6 @@
 	handle_cloak(H)
 	handle_menace(H)
 	handle_smite(H)
-	handle_deadspeak(H)
 	if(istype(H.loc, /turf/space))
 		H.check_sun()
 	if(istype(H.loc, /obj/structure/closet/coffin))
@@ -340,19 +337,6 @@
 		C.Jitter(20)
 		C.Dizzy(20)
 		to_chat(C, "<span class='sinister'>Your heart is filled with dread, and you shake uncontrollably.</span>")
-
-/datum/role/vampire/proc/handle_deadspeak(var/mob/living/carbon/human/H)
-	if(deadchat)
-		return
-	if(H.stat == DEAD)
-		return
-	if((locate(/datum/power/vampire/charisma) in current_powers) && world.time > deadchat_timer)
-		deadchat = TRUE
-		//have deadchat for 30 seconds every five minutes
-		spawn(rand(200, 400))
-			if(H.stat != DEAD)
-				deadchat_timer = world.time + 1800 + rand(300, 1200)
-				deadchat = FALSE
 
 /datum/role/vampire/proc/handle_smite(var/mob/living/carbon/human/H)
 	var/smitetemp = 0

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -76,14 +76,9 @@ var/list/global_deadchat_listeners = list()
 	var/list/hearers = get_deadchat_hearers()
 	if(hearers)
 		for(var/mob/M in hearers)
-			if(isvampire(M))
-				var/rendered = "<span class='game deadsay'><span class='name'> [name]</span>[alt_name] <span class='message'>[message]</span></span>"
-				to_chat(M, rendered)
-				continue
-			else
-				var/rendered = "<span class='game deadsay'><a href='byond://?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>(Follow)</a>"
-				rendered += "<span class='name'> [name]</span>[alt_name] <span class='message'>[message]</span></span>"
-				to_chat(M, rendered)
+			var/rendered = "<span class='game deadsay'><a href='byond://?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>(Follow)</a>"
+			rendered += "<span class='name'> [name]</span>[alt_name] <span class='message'>[message]</span></span>"
+			to_chat(M, rendered)
 
 /mob/proc/get_ear()
 	// returns an atom representing a location on the map from which this

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -344,10 +344,6 @@ For the main html chat area
 		if(istype(M, /mob/new_player))
 			continue
 
-		var/datum/role/vampire/V = isvampire(M)
-		if(V && V.deadchat)
-			hearers += M
-			continue
 		else if(M.client.prefs.toggles & CHAT_DEAD)
 			if(M.client.holder && M.client.holder.rights & R_ADMIN) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only give to Administrators and above
 				hearers += M


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
Vampires no longer hear deadchat at random intervals.

## Why it's good
Adam's only justification for this being good was "it's a new feature!" (he actually said this)
I contend that it's actively harmful for a roleplaying game for the following reasons:
- Being bombarded with OOC information just for being powerful breaks immersion.
- Deadchat is explicitly a mix of IC and OOC, mostly OOC. Free access to deadchat as a player in the round is detrimental to the separation between IC and OOC.
- This is much different from wizard scrying orbs, as those are an investment a wizard must make, unlike vampires which gain this naturally and indefinitely after gaining enough blood.
- Having passive and constant access to deadchat is a huge buff that is really not needed for an already extremely powerful antag.
- On the flip side of things, getting killed/exposed/etc. because someone happened to have deadchat access is NOT a fun way to lose the game, and has zero recourse for the affected.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscdel: Vampires no longer have deadchat access.