### PR TITLE
Welding Goggles coming to an autolathe near you

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -140,6 +140,7 @@
 		new /obj/item/device/rcd/rpd(),\
 		new /obj/item/device/radio/electropack(), \
 		new /obj/item/tool/weldingtool/largetank/empty(), \
+		new /obj/item/clothing/glasses/welding(), \
 		new /obj/item/weapon/handcuffs(), \
 		new /obj/item/ammo_storage/box/a357(), \
 		new /obj/item/ammo_casing/shotgun(), \

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -385,6 +385,7 @@ var/list/science_goggles_wearers = list()
 	item_state = "welding-g"
 	origin_tech = Tc_ENGINEERING + "=1;" + Tc_MATERIALS + "=2"
 	actions_types = list(/datum/action/item_action/toggle_goggles)
+	starting_materials = list(MAT_IRON = 1000, MAT_GLASS = 3000)
 	var/up = 0
 	eyeprot = 3
 	var/visionworsen = 5


### PR DESCRIPTION
me glazzies

## What this does
Adds welding goggles to the contraband section of the autolathe (price is material inverse of the welding helmet 1000 metal 3000 glass)

## Elaboration
I always pull the industrial welding tool from the autolathe when times comes to cut down some walls, but I always thought when I did, how come we have this welding tool as our straight upgrade contraband get, but not the welding goggles that seem so difficult to obtain. So here it is, in all it's glory (or lack there of) the welding goggles for lathe contraband. 
This idea had been one of great uncertainty for me, since I figure it would raise questions about balance, such as why you'd ever take the helmet over this, or perhaps cargo power creep. I don't quite have the answers for it, perhaps I feel it to be trivial at worst, considering things like hardsuits having welding protection, or how easily gotten the advanced welding goggles are if there is an active science department. I figure i'll leave the deep thought to those who wish to vote on it.

![excellent](https://github.com/vgstation-coders/vgstation13/assets/89323872/1f7a90f9-0333-44ee-9d05-b190bea0e4f1)


## Changelog

:cl:
 * rscadd: Adds welding goggles to the autolathe contraband section, protect your glazzies.