### PR TITLE
pinpointers pointing at shunted AI during malf no longer circumventable

### DIFF
--- a/code/datums/gamemode/role/malf/hackabilities.dm
+++ b/code/datums/gamemode/role/malf/hackabilities.dm
@@ -134,9 +134,10 @@
 	S.name = "[A.name] APC Copy"
 	S.add_spell(new /spell/aoe_turf/corereturn, "malf_spell_ready",/obj/abstract/screen/movable/spell_master/malf)
 
-	if (seclevel2num(get_security_level()) == SEC_LEVEL_DELTA)
+	var/datum/faction/malf/malf_faction = find_active_faction_by_member(S.mind.GetRole(MALF), S.mind)
+	if(malf_faction && malf_faction.stage >= FACTION_ENDGAME) /* If the shunting, malfunctioning AI is currently taking over the station... */
 		for(var/obj/item/weapon/pinpointer/point in pinpointer_list)
-			point.target = machine //the pinpointer will detect the shunted AI
+			point.target = machine /* ...then override all pinpointer targets to point at the APC in which the AI is shunted. */
 	S.update_perception()
 	A.mind.transfer_to(S)
 	S.cancel_camera()


### PR DESCRIPTION
## Why it's good
If an AI changes the alert level during station takeover, then shunting wouldn't update any pinpointers to point at the shunted APC. This is because the check to determine whether or not pinpointer targets should be forced was handled poorly.
Fixes #34654

[exploitable]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed an exploit that allowed malfunctioning AI's to prevent pinpointers from showing their location while shunting during station takeover.
