### PR TITLE
Fixes AIs using their Station Holomap on other Z Levels

### DIFF
--- a/code/game/machinery/station_map.dm
+++ b/code/game/machinery/station_map.dm
@@ -324,6 +324,8 @@ var/list/station_holomaps = list()
 	if(user.hud_used && user.hud_used.holomap_obj)
 		watching_mob = user
 		var/turf/T = get_turf(user)
+		if (isAI)
+			T = get_turf(watching_mob.client.eye)
 		bogus = 0
 		if(!((HOLOMAP_EXTRA_STATIONMAP+"_[T.z]") in extraMiniMaps))
 			bogus = 1
@@ -345,12 +347,14 @@ var/list/station_holomaps = list()
 		else
 			to_chat(user, "<span class='notice'>A hologram of the station appears before your eyes.</span>")
 
-/obj/item/device/station_map/proc/update_holomap()
+/obj/item/device/station_map/proc/update_holomap(var/isAI = FALSE)
 	if (!watching_mob || !watching_mob.client || !watching_mob.hud_used)
 		return
 	watching_mob.client.images -= holomap_datum.station_map
 	holomap_datum.station_map.overlays.len = 0
 	var/turf/T = get_turf(src)
+	if (isAI)
+		T = get_turf(watching_mob.client.eye)
 	if (lastZ != T.z)
 		lastZ = T.z
 		bogus = 0

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -56,7 +56,7 @@
 			ai.light_cameras()
 
 		if (ai.station_holomap)
-			ai.station_holomap.update_holomap()
+			ai.station_holomap.update_holomap(TRUE)
 
 /mob/camera/aiEye/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	return 0


### PR DESCRIPTION
Fixes #33119
![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/ccce12d5-cc26-449e-907d-eac4cd9a2e5e)

:cl:
* bugfix: AIs using their Station Holomaps on other Z Level will now see the proper map (and as it is for regular Station/Cyborg Holomaps, only the Station, Asteroid, and Derelict Z levels have detailed maps)