### PR TITLE
Prescription Glasses once again properly transfer their effect to Mesons or similar glasses put over them

### DIFF
--- a/code/datums/outfit/outfit.dm
+++ b/code/datums/outfit/outfit.dm
@@ -322,7 +322,7 @@
 		var/obj/structure/bed/chair/vehicle/wheelchair/W = new(H.loc)
 		W.buckle_mob(H,H)
 
-	if ((H.disabilities & NEARSIGHTED) && H.glasses && !H.glasses.prescription && H.glasses.prescription_type)
+	if ((H.disabilities & NEARSIGHTED) && H.glasses && (H.glasses.nearsighted_modifier >= 0) && H.glasses.prescription_type)
 		var/obj/item/clothing/glasses/prescription = new H.glasses.prescription_type(H)
 		var/obj/prev_glasses = H.glasses
 		H.u_equip(H.glasses,1)

--- a/code/game/objects/structures/vehicles/adminbus_powers.dm
+++ b/code/game/objects/structures/vehicles/adminbus_powers.dm
@@ -601,17 +601,22 @@
 
 		pack.name = "[M.real_name]'s belongings"
 
+		var/might_need_glasses = FALSE
 		for(var/obj/item/I in M)
 			if(istype(I,/obj/item/clothing/glasses))
 				var/obj/item/clothing/glasses/G = I
-				if(G.prescription)
-					continue
+				if(G.nearsighted_modifier != 0)
+					might_need_glasses = TRUE
 			M.u_equip(I)
 			if(I)
 				I.forceMove(M.loc)
 				I.reset_plane_and_layer()
 				I.dropped(M)
 				I.forceMove(pack)
+
+		if (might_need_glasses && ishuman(M))
+			var/mob/living/carbon/human/H = M
+			H.equip_to_slot_or_del(new /obj/item/clothing/glasses/regular(H), slot_glasses)
 
 		var/obj/item/weapon/card/id/thunderdome/ident = null
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2215,17 +2215,22 @@
 
 		pack.name = "[M.real_name]'s belongings"
 
+		var/might_need_glasses = FALSE
 		for(var/obj/item/I in M)
 			if(istype(I,/obj/item/clothing/glasses))
 				var/obj/item/clothing/glasses/G = I
-				if(G.prescription)
-					continue
+				if(G.nearsighted_modifier != 0)
+					might_need_glasses = TRUE
 			M.u_equip(I,1)
 			if(I)
 				I.forceMove(M.loc)
 				I.reset_plane_and_layer()
 				//I.dropped(M)
 				I.forceMove(pack)
+
+		if (might_need_glasses && ishuman(M))
+			var/mob/living/carbon/human/H = M
+			H.equip_to_slot_or_del(new /obj/item/clothing/glasses/regular(H), slot_glasses)
 
 		var/obj/item/weapon/card/id/thunderdome/ident = null
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -15,7 +15,6 @@
 	var/see_invisible = 0
 	var/see_in_dark = 0
 	var/seedarkness = TRUE
-	var/prescription = 0
 	var/prescription_type = null
 	min_harm_label = 12
 	harm_label_examine = list("<span class='info'>A label is covering one lens, but doesn't reach the other.</span>","<span class='warning'>A label covers the lenses!</span>")
@@ -63,7 +62,7 @@ BLIND     // can't see anything
 
 	if(stored_glasses)
 		to_chat(H, "<span class='info'>You place \the [src] on over \the [stored_glasses].</span>")
-		prescription = stored_glasses.prescription
+		nearsighted_modifier = stored_glasses.nearsighted_modifier
 	return CAN_EQUIP
 
 
@@ -84,15 +83,15 @@ BLIND     // can't see anything
 		if (istype(M))
 			if(stored_glasses)
 				if(!M.equip_to_slot_if_possible(stored_glasses, slot_glasses))
+					to_chat(M, "<span class='warning'>\The [stored_glasses] that were stored inside \the [src] drop on the floor.</span>")
 					stored_glasses.forceMove(get_turf(src))
 				stored_glasses = null
-		prescription = initial(prescription)
+		nearsighted_modifier = initial(nearsighted_modifier)
 		M.handle_regular_hud_updates()
 
 /obj/item/clothing/glasses/scanner/meson/prescription
 	name = "prescription mesons"
 	desc = "Optical Meson Scanner with prescription lenses."
-	prescription = 1
 	nearsighted_modifier = -3
 	eyeprot = -1
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
@@ -101,14 +100,12 @@ BLIND     // can't see anything
 	name = "health scanner glasses"
 	desc = "A Health Scanner HUD fitted with prescription lenses."
 	icon_state = "healthglasses"
-	prescription = 1
 	nearsighted_modifier = -3
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
 
 /obj/item/clothing/glasses/sunglasses/sechud/prescription
 	name = "prescription security HUD"
 	desc = "A Security HUD with prescription lenses."
-	prescription = 1
 	nearsighted_modifier = -3
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
 
@@ -132,7 +129,6 @@ var/list/science_goggles_wearers = list()
 
 /obj/item/clothing/glasses/science/prescription
 	name = "prescription science goggles"
-	prescription = 1
 	nearsighted_modifier = -3
 	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
 
@@ -238,7 +234,6 @@ var/list/science_goggles_wearers = list()
 	desc = "Made by Nerd. Co."
 	icon_state = "glasses"
 	item_state = "glasses"
-	prescription = 1
 	nearsighted_modifier = -3
 	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
 	w_class = W_CLASS_TINY
@@ -443,7 +438,6 @@ var/list/science_goggles_wearers = list()
 
 /obj/item/clothing/glasses/sunglasses/prescription
 	name = "prescription sunglasses"
-	prescription = 1
 	nearsighted_modifier = -3
 	species_fit = list(VOX_SHAPED, GREY_SHAPED)
 
@@ -646,7 +640,6 @@ var/list/science_goggles_wearers = list()
 	desc = "Only nerds wear glasses."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "contact"
-	prescription = 1
 	nearsighted_modifier = -3
 	body_parts_covered = null
 
@@ -655,7 +648,6 @@ var/list/science_goggles_wearers = list()
 	desc = "Protects your eyes from bright flashes of light."
 	icon_state = "polarized_contact"
 	darkness_view = -1
-	prescription = 1
 	nearsighted_modifier = -3
 	eyeprot = 1
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -230,7 +230,7 @@ var/list/science_goggles_wearers = list()
 	return //Can't exactly blind someone by covering one eye.
 
 /obj/item/clothing/glasses/regular
-	name = "Prescription Glasses"
+	name = "prescription glasses"
 	desc = "Made by Nerd. Co."
 	icon_state = "glasses"
 	item_state = "glasses"
@@ -249,7 +249,7 @@ var/list/science_goggles_wearers = list()
 	return SPECIAL_ATTACK_FAILED
 
 /obj/item/clothing/glasses/regular/hipster
-	name = "Prescription Glasses"
+	name = "prescription glasses"
 	desc = "Made by Uncool. Co."
 	icon_state = "hipster_glasses"
 	item_state = "hipster_glasses"
@@ -278,15 +278,15 @@ var/list/science_goggles_wearers = list()
 	return
 
 /obj/item/clothing/glasses/gglasses
-	name = "Green Glasses"
+	name = "green glasses"
 	desc = "Forest green glasses, like the kind you'd wear when hatching a nasty scheme."
 	icon_state = "gglasses"
 	item_state = "gglasses"
 	species_fit = list(GREY_SHAPED)
 
 /obj/item/clothing/glasses/sunglasses
-	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes."
 	name = "sunglasses"
+	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes."
 	icon_state = "sun"
 	item_state = "sunglasses"
 	origin_tech = Tc_COMBAT + "=2"
@@ -365,8 +365,8 @@ var/list/science_goggles_wearers = list()
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
 
 /obj/item/clothing/glasses/virussunglasses
-	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes."
 	name = "sunglasses"
+	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes."
 	icon_state = "sun"
 	item_state = "sunglasses"
 	origin_tech = Tc_COMBAT + "=2"
@@ -449,7 +449,7 @@ var/list/science_goggles_wearers = list()
 	min_harm_label = 15
 
 /obj/item/clothing/glasses/sunglasses/sechud
-	name = "HUDSunglasses"
+	name = "\improper HUDSunglasses"
 	desc = "Sunglasses with a HUD."
 	icon_state = "sunhud"
 	var/obj/item/clothing/glasses/hud/security/hud = null
@@ -481,8 +481,8 @@ var/list/science_goggles_wearers = list()
 			qdel(hud)
 
 /obj/item/clothing/glasses/sunglasses/sechud/syndishades
-	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes."
 	name = "sunglasses"
+	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes."
 	icon_state = "sun"
 	item_state = "sunglasses"
 	species_fit = list(VOX_SHAPED, GREY_SHAPED)
@@ -538,7 +538,7 @@ var/list/science_goggles_wearers = list()
 	THERMAL GLASSES
 */
 /obj/item/clothing/glasses/thermal
-	name = "Optical Thermal Scanner"
+	name = "optical thermal scanner"
 	desc = "Thermals in the shape of glasses."
 	icon_state = "thermal"
 	item_state = "glasses"
@@ -573,7 +573,7 @@ var/list/science_goggles_wearers = list()
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
 
 /obj/item/clothing/glasses/thermal/monocle
-	name = "Thermonocle"
+	name = "thermonocle"
 	desc = "A monocle thermal."
 	icon_state = "thermoncle"
 	species_fit = list(VOX_SHAPED, GREY_SHAPED)
@@ -594,7 +594,7 @@ var/list/science_goggles_wearers = list()
 		invisa_view = 0
 
 /obj/item/clothing/glasses/thermal/eyepatch
-	name = "Optical Thermal Eyepatch"
+	name = "optical thermal eyepatch"
 	desc = "An eyepatch with built-in thermal optics."
 	icon_state = "eyepatch0"
 	item_state = "eyepatch0"
@@ -613,14 +613,14 @@ var/list/science_goggles_wearers = list()
 		invisa_view = 0
 
 /obj/item/clothing/glasses/thermal/jensen
-	name = "Optical Thermal Implants"
+	name = "optical thermal implants"
 	desc = "A set of implantable lenses designed to augment your vision."
 	icon_state = "thermalimplants"
 	item_state = "syringe_kit"
 	species_fit = list(VOX_SHAPED, GREY_SHAPED)
 
 /obj/item/clothing/glasses/simonglasses
-	name = "Simon's Glasses"
+	name = "Simon's glasses"
 	desc = "Just who the hell do you think I am?"
 	icon_state = "simonglasses"
 	item_state = "simonglasses"
@@ -628,7 +628,7 @@ var/list/science_goggles_wearers = list()
 	cover_hair = 1
 
 /obj/item/clothing/glasses/kaminaglasses
-	name = "Kamina's Glasses"
+	name = "Kamina's glasses"
 	desc = "I'm going to tell you something important now, so you better dig the wax out of those huge ears of yours and listen! The reputation of Team Gurren echoes far and wide. When they talk about its badass leader - the man of indomitable spirit and masculinity - they're talking about me! The mighty Kamina!"
 	icon_state = "kaminaglasses"
 	item_state = "kaminaglasses"

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -1,5 +1,5 @@
 /obj/item/clothing/glasses/hud
-	name = "HUD"
+	name = "\improper HUD"
 	desc = "A heads-up display that provides important info in (almost) real time."
 	flags = 0 //doesn't protect eyes because it's a monocle, duh
 	origin_tech = Tc_MAGNETS + "=3;" + Tc_BIOTECH + "=2"
@@ -15,7 +15,7 @@
 
 
 /obj/item/clothing/glasses/hud/health
-	name = "Health Scanner HUD"
+	name = "health scanner HUD"
 	desc = "A heads-up display that scans the humanoid carbon lifeforms in view and provides accurate data about their health status."
 	icon_state = "healthhud"
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
@@ -27,7 +27,7 @@
 
 
 /obj/item/clothing/glasses/hud/health/cmo
-	name = "Advanced Health Scanner HUD"
+	name = "advanced health scanner HUD"
 	nearsighted_modifier = -3
 	desc = "A heads-up display that scans the humanoid carbon lifeforms in view and provides accurate data about their health status as well as reveals pathogens in sight. The tinted glass protects the wearer from bright flashes of light."
 	icon_state = "cmohud"
@@ -110,12 +110,12 @@
 
 
 /obj/item/clothing/glasses/hud/security
-	name = "Security HUD"
+	name = "security HUD"
 	desc = "A heads-up display that scans the humanoid carbon lifeforms in view and provides accurate data about their ID status and security records."
 	icon_state = "securityhud"
 
 /obj/item/clothing/glasses/hud/security/jensenshades
-	name = "Augmented shades"
+	name = "augmented shades"
 	desc = "Polarized bioneural eyewear, designed to augment your vision."
 	icon_state = "jensenshades"
 	item_state = "jensenshades"

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -28,7 +28,6 @@
 
 /obj/item/clothing/glasses/hud/health/cmo
 	name = "Advanced Health Scanner HUD"
-	prescription = 1
 	nearsighted_modifier = -3
 	desc = "A heads-up display that scans the humanoid carbon lifeforms in view and provides accurate data about their health status as well as reveals pathogens in sight. The tinted glass protects the wearer from bright flashes of light."
 	icon_state = "cmohud"
@@ -144,7 +143,8 @@
 	prescription_type = /obj/item/clothing/glasses/hud/diagnostic/prescription
 
 /obj/item/clothing/glasses/hud/diagnostic/prescription
-	prescription = TRUE
+	name = "prescription diagnostic HUD"
+	nearsighted_modifier = -3
 
 /obj/item/clothing/glasses/hud/diagnostic/process_hud(var/mob/M)
 	if(harm_labeled < min_harm_label)

--- a/code/modules/trader/crates/zincsaucier.dm
+++ b/code/modules/trader/crates/zincsaucier.dm
@@ -324,10 +324,10 @@ var/global/global_cricket_population = 0
 
 /obj/item/clothing/glasses/hud/hydro
 	name = "hydroHUD"
-	desc = "A heads-up display that displays information on plants and farm animals."
+	desc = "A heads-up display that displays information on plants and farm animals. It appears to feature corrective lenses too."
 	icon_state = "hydrohud"
 	item_state = "rwelding-g"
-	prescription = TRUE
+	nearsighted_modifier = -3
 	var/obj/item/device/analyzer/plant_analyzer/my_analyzer
 
 /obj/item/clothing/glasses/hud/hydro/New()


### PR DESCRIPTION
Fixes #34119

An unintended side-effect of #34035

:cl:
* bugfix: Prescription Glasses once again properly transfer their effect to Mesons or similar glasses put over them.
* bugfix: Fixed some glasses that were meant to have corrective lenses not actually having them (prescription diagnostic HUD and hydroHUD).