### PR TITLE
Bruise Scaling Bugfix (The Third Mystery of Xivvis)

### DIFF
--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -216,8 +216,6 @@
 	needs_treatment = 1 // this only heals when bandaged
 	damage_type = BRUISE
 
-/datum/wound/bruise/monumental
-
 // implement sub-paths by starting at a later stage
 
 /datum/wound/bruise/tiny
@@ -237,6 +235,8 @@
 
 /datum/wound/bruise/huge
 	current_stage = 1
+
+/datum/wound/bruise/monumental
 
 /** BURNS **/
 /datum/wound/burn/moderate


### PR DESCRIPTION
The third of three medical mysteries presented to me by Dacendeth:
## Why do you not heal when you take exactly 15 damage?
14 or less, you naturally heal. 16 or more, you naturally heal. Why not 15? Magic toolbox number funny?

## What this does
![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/9c1b9214-1bb2-424b-943c-6cda9622b53a)
So, turns out, due to a bug, BRUISE wounds between 0 and 15 damage were *monumental* instead of tiny. Those require treatment to heal normally. Yet... 14 damage and under would fall under natural healing, which ignores needs_treatment! This bugfix restores the proper order of BRUISE type wounds, which were apparently off-by-one this whole time for years.
![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/9bfe916f-76d8-4fad-b567-cb8a3bb02314)
This will be the outcome of the changes. Orange highlighed wounds require treatment to fix. And as described above, natural healing would work on anything below 14.

Additional hits to the same area have a good chance to worsen an existing wound, so the 'weirdness' described in the issue below would be explained by the damage being assigned to the way-too-light monumental wound.

## Why it's good
Toolbox wounds can heal, as intended? Fixes #16576 

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed 15 damage bruises not healing (this affects toolboxes!), and 36-45 damage bruises healing without treatment.
 
[bugfix] [balance]