### PR TITLE
Chemical Healing with Damaged Robolimbs Bugfix (The Second Mystery of Xivvis)

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -171,18 +171,10 @@
 ////////////////////////////////////////////
 
 //Returns a list of damaged organs
-/mob/living/carbon/human/proc/get_damaged_organs(var/brute, var/burn)
+/mob/living/carbon/human/proc/get_damaged_organs(var/brute, var/burn, var/ignore_inorganic = FALSE)
 	var/list/datum/organ/external/parts = list()
 	for(var/datum/organ/external/O in organs)
-		if((brute && O.brute_dam) || (burn && O.burn_dam))
-			parts += O
-	return parts
-
-//Returns a list of damaged organic organs!
-/mob/living/carbon/human/proc/get_damaged_organic_organs(var/brute, var/burn)
-	var/list/datum/organ/external/parts = list()
-	for(var/datum/organ/external/O in organs)
-		if(((brute && O.brute_dam) || (burn && O.burn_dam)) && O.is_organic())
+		if(((brute && O.brute_dam) || (burn && O.burn_dam)) && !(ignore_inorganic && !O.is_organic()))
 			parts += O
 	return parts
 
@@ -202,7 +194,7 @@
 //It automatically updates damage overlays if necesary
 //It automatically updates health status
 /mob/living/carbon/human/heal_organ_damage(var/brute, var/burn)
-	var/list/datum/organ/external/parts = get_damaged_organic_organs(brute,burn)
+	var/list/datum/organ/external/parts = get_damaged_organs(brute,burn,TRUE)
 	if(!parts.len)
 		return
 	var/datum/organ/external/picked = pick(parts)
@@ -232,7 +224,7 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 
 //Heal MANY external organs, in random order
 /mob/living/carbon/human/heal_overall_damage(var/brute, var/burn)
-	var/list/datum/organ/external/parts = get_damaged_organic_organs(brute,burn)
+	var/list/datum/organ/external/parts = get_damaged_organs(brute,burn,TRUE)
 	var/datum/organ/internal/heart/hivelord/H = get_heart()
 	if(istype(H)) // hivelord hearts just heal better
 		brute *= 2

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -178,6 +178,14 @@
 			parts += O
 	return parts
 
+//Returns a list of damaged organic organs!
+/mob/living/carbon/human/proc/get_damaged_organic_organs(var/brute, var/burn)
+	var/list/datum/organ/external/parts = list()
+	for(var/datum/organ/external/O in organs)
+		if(((brute && O.brute_dam) || (burn && O.burn_dam)) && O.is_organic())
+			parts += O
+	return parts
+
 //Returns a list of damageable organs
 /mob/living/carbon/human/proc/get_damageable_organs(var/ignore_inorganics = FALSE)
 	var/list/datum/organ/external/parts = list()
@@ -194,7 +202,7 @@
 //It automatically updates damage overlays if necesary
 //It automatically updates health status
 /mob/living/carbon/human/heal_organ_damage(var/brute, var/burn)
-	var/list/datum/organ/external/parts = get_damaged_organs(brute,burn)
+	var/list/datum/organ/external/parts = get_damaged_organic_organs(brute,burn)
 	if(!parts.len)
 		return
 	var/datum/organ/external/picked = pick(parts)
@@ -224,7 +232,7 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 
 //Heal MANY external organs, in random order
 /mob/living/carbon/human/heal_overall_damage(var/brute, var/burn)
-	var/list/datum/organ/external/parts = get_damaged_organs(brute,burn)
+	var/list/datum/organ/external/parts = get_damaged_organic_organs(brute,burn)
 	var/datum/organ/internal/heart/hivelord/H = get_heart()
 	if(istype(H)) // hivelord hearts just heal better
 		brute *= 2


### PR DESCRIPTION
The second of three medical mysteries presented to me by Dacendeth:
## If you have both damaged metal limbs and regular limbs, why are chemicals less effective at healing?
Let's say you had a robotic left arm, and a normal right arm. If they were both burned and you drank kelotane, it'd heal your biolimb every OTHER tick on average, evening out to half the maximum possible heal from the chemical, at half the usual rate.

## What this does
Chemical healing, before this PR, would grab a list of all of your damaged external organs, including robotic ones. It would then either pick one at random to attempt to heal (or spread evenly for certain healing methods). Robotic/peg limbs can't be healed this way, so it would waste the healing amount assigned to the non-organic limb. This PR makes it so that chemical healing will now only spread healing across valid injuries.

## Why it's good
Chemicals no longer flow to the limbs that don't even have blood. How was kelotane going to fix your flaming peg leg? Makes healing more consistent, and... Fixes #25640

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Healing chemicals only target valid, non-peg/robot limbs
 
[bugfix] [balance]