### PR TITLE
standardize xenos and pj lockers on arrivals shuttles

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
@@ -97,6 +97,7 @@
 		/obj/item/clothing/shoes/sandal = 3,
 		/obj/item/clothing/under/rags = 2,
 		/obj/item/clothing/under/shorts/black,
+		/obj/item/clothing/under/vox/vox_casual = 3,
 	)
 
 
@@ -166,7 +167,7 @@
 
 
 /obj/structure/closet/wardrobe/pjs
-	name = "Pajama wardrobe"
+	name = "pajama wardrobe"
 	icon_state = "white"
 	icon_closed = "white"
 

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -87955,9 +87955,6 @@
 /area/shuttle/arrival/station)
 "nfA" = (
 /obj/structure/closet/wardrobe/xenos,
-/obj/item/clothing/under/vox/vox_casual,
-/obj/item/clothing/under/vox/vox_casual,
-/obj/item/clothing/under/vox/vox_casual,
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "nge" = (
@@ -88020,7 +88017,7 @@
 	},
 /area/shuttle/trade/start)
 "nhh" = (
-/obj/structure/closet/wardrobe/grey,
+/obj/structure/closet/wardrobe/pjs,
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "nhj" = (


### PR DESCRIPTION
## What this does
All arrivals shuttles with a xenos clothes locker have had them added. Most grey clothes lockers on arrivals shuttles have been replaced with pajamas lockers instead, since no one uses/needs the grey ones anyway.

## Why it's good
<!-- Explain why you think these changes are good. -->

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: All station arrivals shuttles now have a xeno clothes locker and pajamas locker.