### PR TITLE
Fixes latejoin Time Agent Anomaly not appearing on scoreboard or getting properly logged

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -345,6 +345,7 @@
 	newagent.AssignToRole(M.mind,1)
 	agency.HandleRecruitedRole(newagent)
 	newagent.Greet(GREET_DEFAULT)
+	return 1
 
 //////////////////////////////////////////////
 //                                          //


### PR DESCRIPTION
Really a miracle I spotted that one.

:cl:
* bugfix: Latejoin Time Agent Anomaly now appears properly in the scoreboard and gets properly logged.