### PR TITLE
Returns clatter to plasmamen

### DIFF
--- a/code/modules/mob/living/carbon/human/plasmaman/species.dm
+++ b/code/modules/mob/living/carbon/human/plasmaman/species.dm
@@ -2,7 +2,7 @@
 	name = "Plasmaman"
 	icobase = 'icons/mob/human_races/r_plasmaman_sb.dmi'
 	deform = 'icons/mob/human_races/r_plasmaman_pb.dmi'  // TODO: Need deform.
-	known_languages = list(LANGUAGE_HUMAN)
+	known_languages = list(LANGUAGE_HUMAN, LANGUAGE_CLATTER)
 	attack_verb = "punches"
 
 	flags = WHITELISTED | PLAYABLE | PLASMA_IMMUNE


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Gives plasmamen back the clatter language.
## Why it's good
<!-- Explain why you think these changes are good. -->
While I agree with giving them solcom for lore reasons, I see no reasons they shouldn't have this in addition, they have the exposed skull to clatter with after all.
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added Clatter language back to plasmamen
