### PR TITLE
Fixes "has died at." and death stats tending to runtime as well.

### DIFF
--- a/code/datums/statistics/stat_helpers.dm
+++ b/code/datums/statistics/stat_helpers.dm
@@ -34,7 +34,7 @@
 	e.light_impact_range = li_range
 	explosions.Add(e)
 
-/datum/stat_collector/proc/add_death_stat(var/mob/living/M)
+/datum/stat_collector/proc/add_death_stat(var/mob/living/M, var/turf/spot)
 	if(M.iscorpse) return 0 // only ever 1 if they are a corpse landmark spawned mob
 	if(!ticker || ticker.current_state != GAME_STATE_PLAYING) return 0 // We don't care about pre-round or post-round deaths.
 	if(!istype(M, /mob/living) || istype(M, /mob/living/carbon/human/manifested)) return 0
@@ -42,7 +42,8 @@
 	var/datum/stat/death_stat/d = new
 	d.time_of_death = M.timeofdeath
 
-	var/turf/spot = get_turf(M)
+	if (!spot)
+		spot = get_turf(M)
 	d.death_x = spot.x
 	d.death_y = spot.y
 	d.death_z = spot.z

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -46,7 +46,7 @@
 		INVOKE_EVENT(src, /event/death, "user" = src, "body_destroyed" = gibbed)
 		living_mob_list -= src
 		dead_mob_list += src
-		stat_collection.add_death_stat(src)
+		stat_collection.add_death_stat(src,place_of_death)
 		if(runescape_skull_display && ticker)//we died, begone skull
 			if ("\ref[src]" in ticker.runescape_skulls)
 				var/datum/runescape_skull_data/the_data = ticker.runescape_skulls["\ref[src]"]

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -34,6 +34,7 @@
 
 
 /mob/proc/death(gibbed)
+	var/turf/place_of_death = get_turf(src)
 	spawn()
 		if(is_dying)
 			var/deathstring = "[src] at ([get_coordinates_string(src)]) had death() called (with var/gibbed = [gibbed]) while already dying!"
@@ -66,9 +67,9 @@
 			var/mindname = (src.mind && src.mind.name) ? "[src.mind.name]" : "[real_name]"
 			var/died_as = (mindname == real_name) ? "" : " (died as [real_name])"
 			for(var/mob/M in get_deadchat_hearers())
-				var/rendered = "\proper<a href='?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>(Follow)</a><span class='game deadsay'> \The <span class='name'>[mindname][died_as]</span> has died at \the <span class='name'>[get_area(src)]</span>.</span>"
+				var/rendered = "\proper<a href='?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>(Follow)</a><span class='game deadsay'> \The <span class='name'>[mindname][died_as]</span> has died at \the <span class='name'>[get_area(place_of_death)]</span>.</span>"
 				to_chat(M, rendered)
-			log_game("[key_name(src)] has died at [get_area(src)]. Coordinates: ([get_coordinates_string(src)])")
+			log_game("[key_name(src)] has died at [get_area(place_of_death)]. Coordinates: ([get_coordinates_string(src)])")
 		is_dying = FALSE
 
 /mob/proc/transmog_death()


### PR DESCRIPTION
![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/09e05a78-c607-4773-9348-4fb893d330a0)

:cl:
* bugfix: Fixed players dying from getting their body destroyed having their place of death in deadchat/logs being missing.