### PR TITLE
Probably fixes the persistence misc subsystem sometimes failing

### DIFF
--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -122,22 +122,23 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 
 /datum/persistence_task/forwards_fulfilled/on_init()
 	data = read_file()
-	var/list/previous_forwards_formatted = data["fulfilled_forwards"]
-	for(var/list/formatted_vars in previous_forwards_formatted)
-		var/ourtype = null
-		if(formatted_vars["type"])
-			ourtype = text2path(formatted_vars["type"])
-		var/ourname = null
-		if(formatted_vars["sender"])
-			ourname = formatted_vars["sender"]
-		var/ourstation = null
-		if(formatted_vars["station"])
-			ourstation = formatted_vars["station"]
-		var/oursubtype = null
-		if(formatted_vars["subtype"])
-			oursubtype = text2path(formatted_vars["subtype"])
-		if(ispath(ourtype,/datum/cargo_forwarding))
-			SSsupply_shuttle.previous_forwards += new ourtype(ourname, ourstation, oursubtype, TRUE)
+	if ("fulfilled_forwards" in data)
+		var/list/previous_forwards_formatted = data["fulfilled_forwards"]
+		for(var/list/formatted_vars in previous_forwards_formatted)
+			var/ourtype = null
+			if(formatted_vars["type"])
+				ourtype = text2path(formatted_vars["type"])
+			var/ourname = null
+			if(formatted_vars["sender"])
+				ourname = formatted_vars["sender"]
+			var/ourstation = null
+			if(formatted_vars["station"])
+				ourstation = formatted_vars["station"]
+			var/oursubtype = null
+			if(formatted_vars["subtype"])
+				oursubtype = text2path(formatted_vars["subtype"])
+			if(ispath(ourtype,/datum/cargo_forwarding))
+				SSsupply_shuttle.previous_forwards += new ourtype(ourname, ourstation, oursubtype, TRUE)
 
 /datum/persistence_task/forwards_fulfilled/on_shutdown()
 	var/list/all_forwards = SSsupply_shuttle.previous_forwards.Copy() + SSsupply_shuttle.fulfilled_forwards.Copy()

--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -21,7 +21,7 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 			continue
 		task = new task_type()
 		task.on_init()
-		tasks[task.type] = task
+		tasks["[task.type]"] = task
 	..()
 
 /datum/subsystem/persistence_misc/Shutdown()
@@ -177,6 +177,7 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 /datum/persistence_task/latest_dynamic_rulesets/on_shutdown()
 	var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
 	if (!istype(dynamic_mode))
+		stack_trace("we shut down the persistence - Misc subsystem and ticker.mode is not Dynamic.")
 		return
 	data = list(
 		"one_round_ago" = list(),
@@ -202,6 +203,7 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 /datum/persistence_task/dynamic_ruleset_weights/on_shutdown()
 	var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
 	if (!istype(dynamic_mode))
+		stack_trace("we shut down the persistence - Misc subsystem and ticker.mode is not Dynamic.")
 		return
 
 	data = list()

--- a/code/datums/statistics/stat_helpers.dm
+++ b/code/datums/statistics/stat_helpers.dm
@@ -43,9 +43,11 @@
 	d.time_of_death = M.timeofdeath
 
 	var/turf/spot = get_turf(M)
-	d.death_x = spot.x
-	d.death_y = spot.y
-	d.death_z = spot.z
+
+	if (spot)
+		d.death_x = spot.x
+		d.death_y = spot.y
+		d.death_z = spot.z
 
 	d.mob_typepath = M.type
 	d.mind_name = M.name

--- a/code/datums/statistics/stat_helpers.dm
+++ b/code/datums/statistics/stat_helpers.dm
@@ -43,11 +43,9 @@
 	d.time_of_death = M.timeofdeath
 
 	var/turf/spot = get_turf(M)
-
-	if (spot)
-		d.death_x = spot.x
-		d.death_y = spot.y
-		d.death_z = spot.z
+	d.death_x = spot.x
+	d.death_y = spot.y
+	d.death_z = spot.z
 
 	d.mob_typepath = M.type
 	d.mind_name = M.name

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -22,6 +22,7 @@
 		"an eclipse","a sandwich so tall that it pierces the heavens","things you people wouldn't believe","attack ships on fire off the shoulder of Orion","C-beams glittering in the dark near the Tannhäuser Gate",
 		"the xenoarchaeologist", "the xenobiologist", "getting reincarnated in another world","a hat pile so tall that it pierces the heavens","a wheelchair ride pile so tall that it pierces the heavens",
 		"bees","a cryptographic sequencer","the singularity","mr. clean","a dual sword made of pure energy","a welding tool being held to a fuel tank","a cascading supermatter sea",
+		"a rat of incredible muscular mass",
 		)
 	spawn(0)
 		for(var/i = rand(1,4),i > 0, i--)

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -22,7 +22,7 @@
 		"an eclipse","a sandwich so tall that it pierces the heavens","things you people wouldn't believe","attack ships on fire off the shoulder of Orion","C-beams glittering in the dark near the Tannhäuser Gate",
 		"the xenoarchaeologist", "the xenobiologist", "getting reincarnated in another world","a hat pile so tall that it pierces the heavens","a wheelchair ride pile so tall that it pierces the heavens",
 		"bees","a cryptographic sequencer","the singularity","mr. clean","a dual sword made of pure energy","a welding tool being held to a fuel tank","a cascading supermatter sea",
-		"a rat of incredible muscular mass","a cuban mariachi wearing a green mask"
+		"a rat of incredible muscular mass","a cuban mariachi wearing a green mask",
 		)
 	spawn(0)
 		for(var/i = rand(1,4),i > 0, i--)

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -22,7 +22,7 @@
 		"an eclipse","a sandwich so tall that it pierces the heavens","things you people wouldn't believe","attack ships on fire off the shoulder of Orion","C-beams glittering in the dark near the Tannhäuser Gate",
 		"the xenoarchaeologist", "the xenobiologist", "getting reincarnated in another world","a hat pile so tall that it pierces the heavens","a wheelchair ride pile so tall that it pierces the heavens",
 		"bees","a cryptographic sequencer","the singularity","mr. clean","a dual sword made of pure energy","a welding tool being held to a fuel tank","a cascading supermatter sea",
-		"a rat of incredible muscular mass",
+		"a rat of incredible muscular mass","a cuban mariachi wearing a green mask"
 		)
 	spawn(0)
 		for(var/i = rand(1,4),i > 0, i--)

--- a/code/modules/unit_tests/highscores.dm
+++ b/code/modules/unit_tests/highscores.dm
@@ -1,5 +1,5 @@
 /datum/unit_test/highscores/start()
-    var/datum/persistence_task/highscores/task = SSpersistence_misc.tasks[/datum/persistence_task/highscores]
+    var/datum/persistence_task/highscores/task = SSpersistence_misc.tasks["/datum/persistence_task/highscores"]
     task.file_path = "data/persistence/money_highscores_test.json"
     task.clear_records()
 


### PR DESCRIPTION
and if not it adds stack traces to potential points of failure, so the debugging may continue. More importantly this will make the persistence task datums actually VV'able as the tasks lists will no longer just contain a list of types.

still back-end I guess, though this might fix Dynamic+ not working at times.

the Dreaming.dm edits were to force the unit tests to re-run until I could align my neurons to figure out why they failed, as is tradition.