### PR TITLE
Refactoring of slime baby/adult differentiation

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -78,8 +78,6 @@
 
 #define isgrue(A) (istype(A, /mob/living/simple_animal/hostile/grue))
 
-#define isslimeadult(A) istype(A, /mob/living/carbon/slime/adult)
-
 #define isrobot(A) istype(A, /mob/living/silicon/robot)
 
 #define isanimal(A) istype(A, /mob/living/simple_animal)

--- a/__DEFINES/mobs.dm
+++ b/__DEFINES/mobs.dm
@@ -44,3 +44,6 @@
 #define CATBEASTBLACK 2
 
 #define CONFUSED_MAGIC 1
+
+#define SLIME_BABY 1
+#define SLIME_ADULT 2

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -111,7 +111,7 @@
 				slime.Discipline = 0
 
 			if(power >= 3)
-				if(istype(slime, /mob/living/carbon/slime/adult))
+				if(slime.slime_lifestage == SLIME_ADULT)
 					if(prob(5 + round(power/2)))
 
 						if(slime.Victim)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -215,7 +215,7 @@
 		..()
 
 /obj/machinery/door/window/attack_paw(mob/living/user)
-	if(istype(user, /mob/living/carbon/alien/humanoid) || istype(user, /mob/living/carbon/slime/adult))
+	if(istype(user, /mob/living/carbon/alien/humanoid) || isslimeadult(user))
 		if(operating)
 			return
 		user.delayNextAttack(8)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -131,7 +131,7 @@
 	shock(user, 75) //Ditto above
 
 /obj/structure/grille/attack_slime(mob/user as mob)
-	if(!istype(user, /mob/living/carbon/slime/adult))
+	if(!isslimeadult(user))
 		return
 	user.do_attack_animation(src, user)
 	user.delayNextAttack(8)

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -69,7 +69,10 @@
 			spawn_types = list(/mob/living/simple_animal/hostile/giant_spider/spiderling)
 			vermstring = "spiderlings"
 		if(VERM_SLIMES)
-			spawn_types = typesof(/mob/living/carbon/slime) - /mob/living/carbon/slime - typesof(/mob/living/carbon/slime/adult)
+			spawn_types = typesof(/mob/living/carbon/slime)
+			for (var/this_spawn_type in spawn_types.Copy())
+				if (findtext("[this_spawn_type]", "/adult")) //Only baby slimes.
+					spawn_types -= this_spawn_type
 			vermstring = "slimes"
 		if(VERM_BATS)
 			spawn_types = /mob/living/simple_animal/hostile/scarybat

--- a/code/modules/mob/living/carbon/slime/combat.dm
+++ b/code/modules/mob/living/carbon/slime/combat.dm
@@ -8,16 +8,15 @@
 	return "glomps on"
 
 /mob/living/carbon/slime/get_unarmed_damage(var/atom/target)
-	if(isslime(target))
-		return rand(1,3)
-
-	return rand(5, 35)
-
-/mob/living/carbon/slime/adult/get_unarmed_damage(mob/living/target)
-	if(isslime(target))
-		return rand(1,6)
-
-	return rand(15, 40)
+	switch (slime_lifestage)
+		if (SLIME_BABY)
+			if(isslime(target))
+				return rand(1,3)
+			return rand(5, 35)
+		if (SLIME_ADULT)
+			if(isslime(target))
+				return rand(1,6)
+			return rand(15, 40)
 
 /mob/living/carbon/slime/get_unarmed_hit_sound()
 	return 'sound/weapons/welderattack.ogg'
@@ -51,7 +50,6 @@
 	add_attacklogs(src, target, "attacked")
 
 	.=..()
-
 
 	if(powerlevel > 0)
 		if(isalien(target) || ismonkey(target) || ishigherbeing(target))

--- a/code/modules/mob/living/carbon/slime/death.dm
+++ b/code/modules/mob/living/carbon/slime/death.dm
@@ -5,7 +5,7 @@
 	icon_state = "[colour] baby slime dead"
 
 	if(!gibbed)
-		if(istype(src, /mob/living/carbon/slime/adult))
+		if(slime_lifestage == SLIME_ADULT)
 			//ghostize() - Messes up making momma slime a baby
 			var/mob/living/carbon/slime/M1 = new primarytype(loc)
 			if(src.mind)

--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -5,8 +5,6 @@
 	var/Discipline = 0 // if a slime has been hit with a freeze gun, or wrestled/attacked off a human, they become disciplined and don't attack anymore for a while
 	var/SStun = 0 // stun variable
 
-
-
 /mob/living/carbon/slime/Life()
 	//set background = 1
 	if(timestopped)
@@ -26,11 +24,9 @@
 
 		handle_targets()
 
-
 	var/datum/gas_mixture/environment // Added to prevent null location errors-- TLE
 	if(src.loc)
 		environment = loc.return_air()
-
 
 	//Apparently, the person who wrote this code designed it so that
 	//blinded get reset each cycle and then get activated later in the
@@ -49,10 +45,7 @@
 	//Status updates, death etc.
 	handle_regular_status_updates()
 
-
-
 /mob/living/carbon/slime/proc/AIprocess()  // the master AI process
-
 
 //	to_chat(world, "AI proc started.")
 	if(AIproc || stat == DEAD || client)
@@ -60,7 +53,7 @@
 
 	var/hungry = 0
 	var/starving = 0
-	if(istype(src, /mob/living/carbon/slime/adult))
+	if(slime_lifestage == SLIME_ADULT)
 		switch(nutrition)
 			if(400 to 1100)
 				hungry = 1
@@ -82,7 +75,6 @@
 		if(!Target || client)
 //			to_chat(world, "break 2")
 			break
-
 
 		if(Target.health <= -70 || Target.isDead())
 			Target = null
@@ -190,8 +182,6 @@
 		// handle_temperature_damage(HEAD, environment.temperature, environment_heat_capacity*transfer_coefficient)
 	*/
 
-
-
 	/*
 	if(stat==2)
 		bodytemperature += 0.1*(environment.temperature - bodytemperature)*environment_heat_capacity/(environment_heat_capacity + 270000)
@@ -217,12 +207,9 @@
 	else // a hot place
 		bodytemperature += adjust_body_temperature(bodytemperature, loc_temp, 1)
 
-
 	updatehealth()
 
-
 	return //TODO: DEFERRED
-
 
 /mob/living/carbon/slime/proc/adjust_body_temperature(current, loc_temp, boost)
 	var/temperature = current
@@ -243,7 +230,6 @@
 
 /mob/living/carbon/slime/proc/handle_chemicals_in_body()
 
-
 	if(reagents)
 		reagents.metabolize(src)
 
@@ -252,17 +238,13 @@
 
 	return //TODO: DEFERRED
 
-
 /mob/living/carbon/slime/proc/handle_regular_status_updates()
 
 
-	if(istype(src, /mob/living/carbon/slime/adult))
+	if(slime_lifestage == SLIME_ADULT)
 		health = 200 - (getOxyLoss() + getToxLoss() + getFireLoss() + getBruteLoss() + getCloneLoss())
 	else
 		health = 150 - (getOxyLoss() + getToxLoss() + getFireLoss() + getBruteLoss() + getCloneLoss())
-
-
-
 
 	if(health < config.health_threshold_dead && stat != 2)
 		death()
@@ -284,7 +266,6 @@
 		adjustFireLoss(-1)
 		adjustCloneLoss(-1)
 		adjustBruteLoss(-1)
-
 
 	if (src.stat == DEAD)
 
@@ -340,12 +321,10 @@
 
 	return 1
 
-
 /mob/living/carbon/slime/proc/handle_nutrition()
 
-
 	if(prob(20))
-		if(istype(src, /mob/living/carbon/slime/adult))
+		if(slime_lifestage == SLIME_ADULT)
 			burn_calories(rand(4,6))
 		else
 			burn_calories(rand(2,3))
@@ -357,7 +336,7 @@
 			adjustToxLoss(rand(0,5))
 
 	else
-		if(istype(src, /mob/living/carbon/slime/adult))
+		if(slime_lifestage == SLIME_ADULT)
 			if(nutrition >= 1000)
 				if(prob(40))
 					amount_grown++
@@ -368,7 +347,7 @@
 					amount_grown++
 
 	if(amount_grown >= 10 && !Victim && !Target)
-		if(istype(src, /mob/living/carbon/slime/adult))
+		if(slime_lifestage == SLIME_ADULT)
 			if(!client)
 				for(var/i = 1 to 4)
 					var/newslime
@@ -395,7 +374,7 @@
 			if(!client)
 				if(adulttype == null)
 					return
-				var/mob/living/carbon/slime/adult/A = new adulttype(src.loc)
+				var/mob/living/carbon/slime/A = new adulttype(src.loc)
 				A.nutrition = nutrition
 //				A.nutrition += 100
 				A.powerlevel = max(0, powerlevel-1)
@@ -404,7 +383,6 @@
 				transferImplantsTo(A)
 				transferBorers(A)
 				qdel(src)
-
 
 /mob/living/carbon/slime/proc/handle_targets()
 	if(Tempstun)
@@ -446,10 +424,9 @@
 		if(AIproc && SStun)
 			return
 
-
 		var/hungry = 0 // determines if the slime is hungry
 		var/starving = 0 // determines if the slime is starving-hungry
-		if(istype(src, /mob/living/carbon/slime/adult)) // 1200 max nutrition
+		if(slime_lifestage == SLIME_ADULT) // 1200 max nutrition
 			switch(nutrition)
 				if(601 to 900)
 					if(prob(25))
@@ -486,7 +463,7 @@
 						continue
 
 					if(issilicon(L))
-						if(!istype(src, /mob/living/carbon/slime/adult)) //Non-starving diciplined adult slimes wont eat things
+						if(slime_lifestage != SLIME_ADULT) //Non-starving disciplined adult slimes wont eat things
 							if(!starving && Discipline > 0)
 								continue
 
@@ -502,7 +479,7 @@
 							if(isslimeperson(H))
 								continue
 
-						if(!istype(src, /mob/living/carbon/slime/adult)) //Non-starving diciplined adult slimes wont eat things
+						if(slime_lifestage != SLIME_ADULT) //Non-starving diciplined adult slimes wont eat things
 							if(!starving && Discipline > 0)
 								continue
 
@@ -523,10 +500,8 @@
 
 						targets += L //Possible target found!
 
-
-
 			if((hungry || starving) && targets.len > 0)
-				if(!istype(src, /mob/living/carbon/slime/adult))
+				if(slime_lifestage != SLIME_ADULT)
 					if(!starving)
 						for(var/mob/living/carbon/C in targets)
 							if(!Discipline && prob(5))
@@ -551,7 +526,6 @@
 			if(targets.len > 0)
 				if(attacked > 0 )
 					Target = targets[1] //closest mob probably attacked it, so override Target and attack the nearest!
-
 
 		if(!Target)
 			if(hungry || starving)

--- a/code/modules/mob/living/carbon/slime/powers.dm
+++ b/code/modules/mob/living/carbon/slime/powers.dm
@@ -54,10 +54,7 @@
 	anchored = 1
 	var/lastnut = nutrition
 //	to_chat(if(M.client) M, "<span class='warning'>You legs become paralyzed!</span>")
-	if(istype(src, /mob/living/carbon/slime/adult))
-		icon_state = "[colour] adult slime eat"
-	else
-		icon_state = "[colour] baby slime eat"
+	icon_state = "[colour] [lifestage_name()] slime eat"
 	add_logs(src, Victim, "fed on", 0)
 	while(Victim && M.health > -70 && stat != 2)
 		// M.canmove = 0
@@ -101,7 +98,7 @@
 						if(powerlevel > 10)
 							powerlevel = 10
 
-				if(istype(src, /mob/living/carbon/slime/adult))
+				if(slime_lifestage == SLIME_ADULT)
 					if(nutrition > 1200)
 						nutrition = 1200
 				else
@@ -124,14 +121,11 @@
 			break
 
 	if(stat == 2)
-		if(!istype(src, /mob/living/carbon/slime/adult))
+		if(slime_lifestage != SLIME_ADULT)
 			icon_state = "[colour] baby slime dead"
 
 	else
-		if(istype(src, /mob/living/carbon/slime/adult))
-			icon_state = "[colour] adult slime"
-		else
-			icon_state = "[colour] baby slime"
+		icon_state = "[colour] [lifestage_name()] slime"
 
 	canmove = 1
 	anchored = 0
@@ -182,7 +176,7 @@
 	if(stat)
 		to_chat(src, "<i>I must be conscious to do this...</i>")
 		return
-	if(!istype(src, /mob/living/carbon/slime/adult))
+	if(slime_lifestage != SLIME_ADULT)
 		if(amount_grown >= 10)
 			if(istype(src, /mob/living/carbon/slime/pygmy))
 				var/mob/living/carbon/human/slime/S = new (loc)
@@ -202,7 +196,7 @@
 						S.real_name = randomname
 						i++
 				return
-			var/mob/living/carbon/slime/adult/new_slime = new adulttype(loc)
+			var/mob/living/carbon/slime/new_slime = new adulttype(loc)
 			new_slime.nutrition = nutrition
 			new_slime.powerlevel = max(0, powerlevel-1)
 			new_slime.a_intent = I_HURT
@@ -233,7 +227,7 @@
 		to_chat(src, "<i>I must be conscious to do this...</i>")
 		return
 
-	if(istype(src, /mob/living/carbon/slime/adult))
+	if(slime_lifestage == SLIME_ADULT)
 		if(amount_grown >= 10)
 			//if(input("Are you absolutely sure you want to reproduce? Your current body will cease to be, but your consciousness will be transferred into a produced slime.") in list("Yes","No")=="Yes")
 			if(stat)
@@ -281,8 +275,6 @@
 			to_chat(src, "<i>I am not ready to reproduce yet...</i>")
 	else
 		to_chat(src, "<i>I am not old enough to reproduce yet...</i>")
-
-
 
 /mob/living/carbon/slime/verb/ventcrawl()
 	set name = "Crawl through Vent"

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -2,22 +2,13 @@
 	name = "baby slime"
 	desc = null
 	icon = 'icons/mob/slimes.dmi'
-	icon_state = "grey baby slime"
 	pass_flags = PASSTABLE
-	speak_emote = list("hums")
 	layer = SLIME_LAYER
-	maxHealth = 150
-	health = 150
 	gender = NEUTER
-
 	update_icon = 0
-	nutrition = 700 // 1000 = max
-
 	see_in_dark = 8
 	update_slimes = 0
-
 	hasmouth = 0
-
 	can_butcher = FALSE
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/slime
 
@@ -25,12 +16,13 @@
 	// for the sake of cleanliness, though, here they are.
 	status_flags = CANPARALYSE|CANPUSH
 
+	var/slime_lifestage = SLIME_BABY
+
 	var/cores = 1 // the number of /obj/item/slime_extract's the slime has left inside
 
 	var/powerlevel = 0 	// 1-10 controls how much electricity they are generating
 	var/amount_grown = 0 // controls how long the slime has been overfed, if 10, grows into an adult
 						 // if adult: if 10: reproduces
-
 
 	var/mob/living/Victim = null // the person the slime is currently feeding on
 	var/mob/living/Target = null // AI variable - tells the slime to hunt this down
@@ -52,7 +44,7 @@
 	var/adulttype = /mob/living/carbon/slime/adult
 	var/coretype = /obj/item/slime_extract/grey
 	var/list/slime_mutation[5]
-	var/maxcolorcount = 5
+	var/maxcolorcount = 5 //Based on how many different colors they can split into.
 
 	var/core_removal_stage = 0 //For removing cores
 	universal_speak = 1
@@ -61,18 +53,7 @@
 
 /mob/living/carbon/slime/adult
 	name = "adult slime"
-	icon = 'icons/mob/slimes.dmi'
-	icon_state = "grey adult slime"
-	speak_emote = list("telepathically chirps")
-
-	maxHealth = 200
-	health = 200
-	gender = NEUTER
-	size = SIZE_BIG
-
-	update_icon = 0
-	nutrition = 800 // 1200 = max
-	maxcolorcount = 5 //Based on how many different colors they can split into.
+	slime_lifestage = SLIME_ADULT
 
 /mob/living/carbon/slime/Destroy()
 	..()
@@ -85,28 +66,57 @@
 	return
 
 /mob/living/carbon/slime/New()
+	lifestage_updates() //Set values according to whether the slime is a baby or an adult.
 	var/datum/reagents/R = new/datum/reagents(100)
 	reagents = R
 	R.my_atom = src
-	name = text("[colour] slime ([rand(1, 1000)])")
-	desc = text("A baby [colour] slime.")
+	name = "[colour] slime ([rand(1, 1000)])"
+	desc = "\An [lifestage_name()] [colour] slime."
+	icon_state = "[iconstate_color()] [lifestage_name()] slime"
 	real_name = name
 	spawn (1)
 		regenerate_icons()
 		to_chat(src, "<span class='notice'>Your icons have been generated!</span>")
 	..()
 
+/mob/living/carbon/slime/proc/lifestage_updates()
+	switch (slime_lifestage)
+		if (SLIME_BABY)
+			maxHealth = 150
+			health = 150
+			nutrition = 700 // 1000 = max
+			speak_emote = list("hums")
+		if (SLIME_ADULT)
+			maxHealth = 200
+			health = 200
+			size = SIZE_BIG
+			nutrition = 800 // 1200 = max
+			speak_emote = list("telepathically chirps")
+
+/mob/living/carbon/slime/proc/lifestage_name()
+	switch (slime_lifestage)
+		if (SLIME_BABY)
+			return "baby"
+		if (SLIME_ADULT)
+			return "adult"
+
+/mob/living/carbon/slime/proc/iconstate_color()
+	return colour
+
+/proc/isslimeadult(var/atom/A)
+	if (istype(A, /mob/living/carbon/slime))
+		var/mob/living/carbon/slime/S = A
+		return S.slime_lifestage == SLIME_ADULT
+	return FALSE
+
 /mob/living/carbon/slime/adult/New()
-	//verbs.Remove(/mob/living/carbon/slime/verb/ventcrawl)
 	..()
-	name = text("[colour] slime ([rand(1,1000)])")
-	desc = text("An adult [colour] slime.")
 	slime_mutation[1] = /mob/living/carbon/slime/orange
 	slime_mutation[2] = /mob/living/carbon/slime/metal
 	slime_mutation[3] = /mob/living/carbon/slime/blue
 	slime_mutation[4] = /mob/living/carbon/slime/purple
 	slime_mutation[5] = /mob/living/carbon/slime
-	//For an explination on how and why this list is what it is go to 'code\modules\mob\living\carbon\slime\subtypes.dm' and see the READ ME at the top.
+	//For an explanation on how and why this list is what it is go to 'code\modules\mob\living\carbon\slime\subtypes.dm' and see the READ ME at the top.
 
 /mob/living/carbon/slime/movement_delay()
 	if (bodytemperature >= 330.23) // 135 F
@@ -152,7 +162,7 @@
 
 
 				if(istype(AM, /obj/structure/window) || istype(AM, /obj/structure/grille))
-					if(istype(src, /mob/living/carbon/slime/adult))
+					if(slime_lifestage == SLIME_ADULT)
 						if(nutrition <= 600 && !Atkcool)
 							AM.attack_slime(src)
 							spawn()
@@ -171,7 +181,7 @@
 	if(ismob(AM))
 		var/mob/tmob = AM
 
-		if(istype(src, /mob/living/carbon/slime/adult))
+		if(slime_lifestage == SLIME_ADULT)
 			if(istype(tmob, /mob/living/carbon/human))
 				if(prob(90))
 					now_pushing = 0
@@ -187,14 +197,13 @@
 /mob/living/carbon/slime/Process_Spacemove()
 	return 2
 
-
 /mob/living/carbon/slime/Stat()
 	..()
 
 	if(statpanel("Status"))
 		stat(null, "Health: [round((health / maxHealth) * 100)]%")
 
-		if(istype(src,/mob/living/carbon/slime/adult))
+		if(slime_lifestage == SLIME_ADULT)
 			stat(null, "Nutrition: [nutrition]/1200")
 			if(amount_grown >= 10)
 				stat(null, "You can reproduce!")
@@ -205,7 +214,6 @@
 
 		stat(null,"Power Level: [powerlevel]")
 
-
 /mob/living/carbon/slime/adjustFireLoss(amount)
 	..(-abs(amount)) // Heals them
 	return
@@ -214,7 +222,6 @@
 	attacked += 10
 	..(Proj)
 	return PROJECTILE_COLLISION_DEFAULT
-
 
 /mob/living/carbon/slime/emp_act(severity)
 	for(var/obj/item/stickybomb/B in src)
@@ -232,7 +239,6 @@
 /mob/living/carbon/slime/ex_act(severity, var/child=null, var/mob/whodunnit)
 	if(flags & INVULNERABLE)
 		return
-
 
 	if (stat == 2 && client)
 		return
@@ -257,7 +263,6 @@
 			f_loss += 60
 			dmg_phrase = "Damage: 120"
 
-
 		if(3.0)
 			b_loss += 30
 			dmg_phrase = "Damage: 30"
@@ -268,7 +273,6 @@
 	adjustFireLoss(f_loss)
 
 	updatehealth()
-
 
 /mob/living/carbon/slime/blob_act()
 	if(flags & INVULNERABLE)
@@ -296,17 +300,14 @@
 	updatehealth()
 	return
 
-
 /mob/living/carbon/slime/u_equip(obj/item/W as obj)
 	return
-
 
 /mob/living/carbon/slime/attack_ui(slot)
 	return
 
 /mob/living/carbon/slime/attack_slime(mob/living/carbon/slime/M)
 	M.unarmed_attack_mob(src)
-
 
 /mob/living/carbon/slime/attack_animal(mob/living/simple_animal/M)
 	M.unarmed_attack_mob(src)
@@ -323,7 +324,6 @@
 			help_shake_act(M)
 		else
 			M.unarmed_attack_mob(src)
-
 
 /mob/living/carbon/slime/attack_hand(mob/living/carbon/human/M as mob)
 	..()
@@ -365,7 +365,7 @@
 				if(prob(80) && !client)
 					Discipline++
 
-					if(!istype(src, /mob/living/carbon/slime/adult))
+					if(slime_lifestage != SLIME_ADULT)
 						if(Discipline == 1)
 							attacked = 0
 
@@ -380,7 +380,6 @@
 				step_away(src,M)
 
 			return
-
 
 	switch(M.a_intent)
 
@@ -410,7 +409,6 @@
 						sleep(3)
 						step_away(src,M,15)
 
-
 				playsound(loc, "punch", 25, 1, -1)
 				visible_message("<span class='danger'>[M] has punched [src]!</span>")
 
@@ -420,8 +418,6 @@
 				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 				visible_message("<span class='danger'>[M] has attempted to punch [src]!</span>")
 	return
-
-
 
 /mob/living/carbon/slime/attack_alien(mob/living/carbon/alien/humanoid/M as mob)
 	switch(M.a_intent)
@@ -460,12 +456,10 @@
 			updatehealth()
 	return
 
-
 /mob/living/carbon/slime/restrained()
 	if(timestopped)
 		return 1 //under effects of time magick
 	return 0
-
 
 /mob/living/carbon/slime/var/co2overloadtime = null
 
@@ -480,7 +474,6 @@
 	else
 		// slimes can't suffocate unless they suicide or they fall into crit. They are also not harmed by fire
 		health = maxHealth - (getOxyLoss() + getToxLoss() + getFireLoss() + getBruteLoss() + getCloneLoss())
-
 
 /obj/item/slime_extract
 	name = "slime extract"
@@ -662,7 +655,6 @@
 	primarytype = /mob/living/carbon/slime/sepia
 	reactive_reagents = list(PLASMA,BLOOD,PHAZON)
 
-
 ////Pet Slime Creation///
 
 /obj/item/weapon/slimepotion
@@ -676,13 +668,13 @@
 	if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
 		to_chat(user, "<span class='warning'>The potion only works on baby slimes!</span>")
 		return ..()
-	if(istype(M, /mob/living/carbon/slime/adult)) //Can't tame adults
+	if(M.slime_lifestage == SLIME_ADULT) //Can't tame adults
 		to_chat(user, "<span class='warning'>Only baby slimes can be tamed!</span>")
 		return..()
 	if(M.stat)
 		to_chat(user, "<span class='warning'>The [M] is dead!</span>")
 		return..()
-	var/mob/living/simple_animal/slime/pet = new /mob/living/simple_animal/slime(M.loc)
+	var/mob/living/simple_animal/slime/pet = new /mob/living/simple_animal/slime(M.loc) //If slimes are given unique behaviors or abilities per subtype, these procs should probably be changed.
 	pet.icon_state = "[M.colour] baby slime"
 	pet.icon_living = "[M.colour] baby slime"
 	pet.icon_dead = "[M.colour] baby slime dead"
@@ -710,8 +702,8 @@
 	icon_state = "bottle19"
 	w_class = W_CLASS_TINY
 
-/obj/item/weapon/slimepotion2/attack(mob/living/carbon/slime/adult/M as mob, mob/user as mob)
-	if(!istype(M, /mob/living/carbon/slime/adult))//If target is not a slime.
+/obj/item/weapon/slimepotion2/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+	if(!M || M.slime_lifestage != SLIME_ADULT) //If target is not an adult slime.
 		to_chat(user, "<span class='warning'>The potion only works on adult slimes!</span>")
 		return ..()
 	if(M.stat)
@@ -749,7 +741,7 @@
 	if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
 		to_chat(user, "<span class='warning'>The steroid only works on baby slimes!</span>")
 		return ..()
-	if(istype(M, /mob/living/carbon/slime/adult)) //Can't tame adults
+	if(M.slime_lifestage != SLIME_BABY) //Can't tame adults
 		to_chat(user, "<span class='warning'>Only baby slimes can use the steroid!</span>")
 		return..()
 	if(M.stat)
@@ -762,7 +754,6 @@
 	to_chat(user, "You feed \the [M] the steroid. It now has triple the amount of extract.")
 	M.cores = 3
 	qdel (src)
-
 
 /obj/item/weapon/slimenutrient
 	name = "slime nutrient"
@@ -809,7 +800,7 @@
 	if(!istype(M, /mob/living/carbon/slime))//target is not a slime
 		to_chat(user, "<span class='warning'>The solution only works on slimes!</span>")
 		return ..()
-	if(istype(M, /mob/living/carbon/slime/adult))//don't allow adults because i'm lazy i don't wanna
+	if(M.slime_lifestage != SLIME_BABY)//don't allow adults because i'm lazy i don't wanna
 		to_chat(user, "<span class='warning'>Only baby slimes can be duplicated!</span>")
 		return ..()
 	if(M.stat)//dunno if this should be allowed but i think it's probably better this way
@@ -886,7 +877,6 @@
 	item_state = null
 	siemens_coefficient = 0
 	canremove = 0
-
 
 /obj/item/clothing/head/space/golem
 	icon_state = "golem"
@@ -987,7 +977,6 @@
 		ghosts.Add(O)
 		to_chat(O, "<span class='notice'>You are signed up to be a golem.</span>")
 
-
 /mob/living/carbon/slime/has_eyes()
 	return 0
 
@@ -1064,8 +1053,6 @@
 				Flush = 30
 */
 
-
-
 /obj/item/weapon/reagent_containers/food/snacks/egg/slime
 	name = "slime egg"
 	desc = "A small, gelatinous egg."
@@ -1096,7 +1083,6 @@
 		src.visible_message("<span class='notice'>The [name] bursts open!</span>")
 		new/mob/living/carbon/slime(T)
 		qdel(src)
-
 
 /obj/item/weapon/reagent_containers/food/snacks/egg/slime/process()
 	var/turf/location = get_turf(src)

--- a/code/modules/mob/living/carbon/slime/subtypes.dm
+++ b/code/modules/mob/living/carbon/slime/subtypes.dm
@@ -11,20 +11,15 @@ This allows two random colors of slimes, one of it's own color for sure, and fin
 
 /mob/living/carbon/slime/purple
 	colour = "purple"
-	icon_state = "purple baby slime"
 	primarytype = /mob/living/carbon/slime/purple
-	adulttype = /mob/living/carbon/slime/adult/purple
+	adulttype = /mob/living/carbon/slime/purple/adult
 	coretype = /obj/item/slime_extract/purple
 
-/mob/living/carbon/slime/adult/purple
-	icon_state = "purple adult slime"
-	colour = "purple"
-	primarytype = /mob/living/carbon/slime/purple
-	adulttype = /mob/living/carbon/slime/adult/purple
-	coretype = /obj/item/slime_extract/purple
+/mob/living/carbon/slime/purple/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 4
 
-/mob/living/carbon/slime/adult/purple/New()
+/mob/living/carbon/slime/purple/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/darkpurple
 	slime_mutation[2] = /mob/living/carbon/slime/darkblue
@@ -34,20 +29,15 @@ This allows two random colors of slimes, one of it's own color for sure, and fin
 
 /mob/living/carbon/slime/metal
 	colour = "metal"
-	icon_state = "metal baby slime"
 	primarytype = /mob/living/carbon/slime/metal
-	adulttype = /mob/living/carbon/slime/adult/metal
+	adulttype = /mob/living/carbon/slime/metal/adult
 	coretype = /obj/item/slime_extract/metal
 
-/mob/living/carbon/slime/adult/metal
-	icon_state = "metal adult slime"
-	colour = "metal"
-	primarytype = /mob/living/carbon/slime/metal
-	adulttype = /mob/living/carbon/slime/adult/metal
-	coretype = /obj/item/slime_extract/metal
+/mob/living/carbon/slime/metal/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 4
 
-/mob/living/carbon/slime/adult/metal/New()
+/mob/living/carbon/slime/metal/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/silver
 	slime_mutation[2] = /mob/living/carbon/slime/yellow
@@ -57,20 +47,15 @@ This allows two random colors of slimes, one of it's own color for sure, and fin
 
 /mob/living/carbon/slime/orange
 	colour = "orange"
-	icon_state = "orange baby slime"
 	primarytype = /mob/living/carbon/slime/orange
-	adulttype = /mob/living/carbon/slime/adult/orange
+	adulttype = /mob/living/carbon/slime/orange/adult
 	coretype = /obj/item/slime_extract/orange
 
-/mob/living/carbon/slime/adult/orange
-	colour = "orange"
-	icon_state = "orange adult slime"
-	primarytype = /mob/living/carbon/slime/orange
-	adulttype = /mob/living/carbon/slime/adult/orange
-	coretype = /obj/item/slime_extract/orange
+/mob/living/carbon/slime/orange/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 4
 
-/mob/living/carbon/slime/adult/orange/New()
+/mob/living/carbon/slime/orange/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/red
 	slime_mutation[2] = /mob/living/carbon/slime/darkpurple
@@ -80,20 +65,15 @@ This allows two random colors of slimes, one of it's own color for sure, and fin
 
 /mob/living/carbon/slime/blue
 	colour = "blue"
-	icon_state = "blue baby slime"
 	primarytype = /mob/living/carbon/slime/blue
-	adulttype = /mob/living/carbon/slime/adult/blue
+	adulttype = /mob/living/carbon/slime/blue/adult
 	coretype = /obj/item/slime_extract/blue
 
-/mob/living/carbon/slime/adult/blue
-	icon_state = "blue adult slime"
-	colour = "blue"
-	primarytype = /mob/living/carbon/slime/blue
-	adulttype = /mob/living/carbon/slime/adult/blue
-	coretype = /obj/item/slime_extract/blue
+/mob/living/carbon/slime/blue/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 4
 
-/mob/living/carbon/slime/adult/blue/New()
+/mob/living/carbon/slime/blue/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/darkblue
 	slime_mutation[2] = /mob/living/carbon/slime/pink
@@ -104,20 +84,15 @@ This allows two random colors of slimes, one of it's own color for sure, and fin
 
 /mob/living/carbon/slime/darkblue
 	colour = "dark blue"
-	icon_state = "dark blue baby slime"
 	primarytype = /mob/living/carbon/slime/darkblue
-	adulttype = /mob/living/carbon/slime/adult/darkblue
+	adulttype = /mob/living/carbon/slime/darkblue/adult
 	coretype = /obj/item/slime_extract/darkblue
 
-/mob/living/carbon/slime/adult/darkblue
-	icon_state = "dark blue adult slime"
-	colour = "dark blue"
-	primarytype = /mob/living/carbon/slime/darkblue
-	adulttype = /mob/living/carbon/slime/adult/darkblue
-	coretype = /obj/item/slime_extract/darkblue
+/mob/living/carbon/slime/darkblue/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 4
 
-/mob/living/carbon/slime/adult/darkblue/New()
+/mob/living/carbon/slime/darkblue/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/purple
 	slime_mutation[2] = /mob/living/carbon/slime/cerulean
@@ -127,20 +102,15 @@ This allows two random colors of slimes, one of it's own color for sure, and fin
 
 /mob/living/carbon/slime/darkpurple
 	colour = "dark purple"
-	icon_state = "dark purple baby slime"
 	primarytype = /mob/living/carbon/slime/darkpurple
-	adulttype = /mob/living/carbon/slime/adult/darkpurple
+	adulttype = /mob/living/carbon/slime/darkpurple/adult
 	coretype = /obj/item/slime_extract/darkpurple
 
-/mob/living/carbon/slime/adult/darkpurple
-	icon_state = "dark purple adult slime"
-	colour = "dark purple"
-	primarytype = /mob/living/carbon/slime/darkpurple
-	adulttype = /mob/living/carbon/slime/adult/darkpurple
-	coretype = /obj/item/slime_extract/darkpurple
+/mob/living/carbon/slime/darkpurple/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 4
 
-/mob/living/carbon/slime/adult/darkpurple/New()
+/mob/living/carbon/slime/darkpurple/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/purple
 	slime_mutation[2] = /mob/living/carbon/slime/sepia
@@ -149,21 +119,16 @@ This allows two random colors of slimes, one of it's own color for sure, and fin
 
 
 /mob/living/carbon/slime/yellow
-	icon_state = "yellow baby slime"
 	colour = "yellow"
 	primarytype = /mob/living/carbon/slime/yellow
-	adulttype = /mob/living/carbon/slime/adult/yellow
+	adulttype = /mob/living/carbon/slime/yellow/adult
 	coretype = /obj/item/slime_extract/yellow
 
-/mob/living/carbon/slime/adult/yellow
-	icon_state = "yellow adult slime"
-	colour = "yellow"
-	primarytype = /mob/living/carbon/slime/yellow
-	adulttype = /mob/living/carbon/slime/adult/yellow
-	coretype = /obj/item/slime_extract/yellow
+/mob/living/carbon/slime/yellow/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 4
 
-/mob/living/carbon/slime/adult/yellow/New()
+/mob/living/carbon/slime/yellow/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/metal
 	slime_mutation[2] = /mob/living/carbon/slime/bluespace
@@ -173,20 +138,15 @@ This allows two random colors of slimes, one of it's own color for sure, and fin
 
 /mob/living/carbon/slime/silver
 	colour = "silver"
-	icon_state = "silver baby slime"
 	primarytype = /mob/living/carbon/slime/silver
-	adulttype = /mob/living/carbon/slime/adult/silver
+	adulttype = /mob/living/carbon/slime/silver/adult
 	coretype = /obj/item/slime_extract/silver
 
-/mob/living/carbon/slime/adult/silver
-	icon_state = "silver adult slime"
-	colour = "silver"
-	primarytype = /mob/living/carbon/slime/silver
-	adulttype = /mob/living/carbon/slime/adult/silver
-	coretype = /obj/item/slime_extract/silver
+/mob/living/carbon/slime/silver/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 4
 
-/mob/living/carbon/slime/adult/silver/New()
+/mob/living/carbon/slime/silver/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/metal
 	slime_mutation[2] = /mob/living/carbon/slime/pyrite
@@ -196,20 +156,15 @@ This allows two random colors of slimes, one of it's own color for sure, and fin
 
 /mob/living/carbon/slime/pink
 	colour = "pink"
-	icon_state = "pink baby slime"
 	primarytype = /mob/living/carbon/slime/pink
-	adulttype = /mob/living/carbon/slime/adult/pink
+	adulttype = /mob/living/carbon/slime/pink/adult
 	coretype = /obj/item/slime_extract/pink
 
-/mob/living/carbon/slime/adult/pink
-	icon_state = "pink adult slime"
-	colour = "pink"
-	primarytype = /mob/living/carbon/slime/pink
-	adulttype = /mob/living/carbon/slime/adult/pink
-	coretype = /obj/item/slime_extract/pink
+/mob/living/carbon/slime/pink/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 2
 
-/mob/living/carbon/slime/adult/pink/New()
+/mob/living/carbon/slime/pink/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/lightpink
 	slime_mutation[2] = /mob/living/carbon/slime/pink
@@ -217,60 +172,45 @@ This allows two random colors of slimes, one of it's own color for sure, and fin
 
 /mob/living/carbon/slime/red
 	colour = "red"
-	icon_state = "red baby slime"
 	primarytype = /mob/living/carbon/slime/red
-	adulttype = /mob/living/carbon/slime/adult/red
+	adulttype = /mob/living/carbon/slime/red/adult
 	coretype = /obj/item/slime_extract/red
 
-/mob/living/carbon/slime/adult/red
-	icon_state = "red adult slime"
-	colour = "red"
-	primarytype = /mob/living/carbon/slime/red
-	adulttype = /mob/living/carbon/slime/adult/red
-	coretype = /obj/item/slime_extract/red
+/mob/living/carbon/slime/red/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 2
 
-/mob/living/carbon/slime/adult/red/New()
+/mob/living/carbon/slime/red/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/oil
 	slime_mutation[2] = /mob/living/carbon/slime/red
 
 /mob/living/carbon/slime/gold
 	colour = "gold"
-	icon_state = "gold baby slime"
 	primarytype = /mob/living/carbon/slime/gold
-	adulttype = /mob/living/carbon/slime/adult/gold
+	adulttype = /mob/living/carbon/slime/gold/adult
 	coretype = /obj/item/slime_extract/gold
 
-/mob/living/carbon/slime/adult/gold
-	icon_state = "gold adult slime"
-	colour = "gold"
-	primarytype = /mob/living/carbon/slime/gold
-	adulttype = /mob/living/carbon/slime/adult/gold
-	coretype = /obj/item/slime_extract/gold
+/mob/living/carbon/slime/gold/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 2
 
-/mob/living/carbon/slime/adult/gold/New()
+/mob/living/carbon/slime/gold/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/adamantine
 	slime_mutation[2] = /mob/living/carbon/slime/gold
 
 /mob/living/carbon/slime/green
 	colour = "green"
-	icon_state = "green baby slime"
 	primarytype = /mob/living/carbon/slime/green
-	adulttype = /mob/living/carbon/slime/adult/green
+	adulttype = /mob/living/carbon/slime/green/adult
 	coretype = /obj/item/slime_extract/green
 
-/mob/living/carbon/slime/adult/green
-	icon_state = "green adult slime"
-	colour = "green"
-	primarytype = /mob/living/carbon/slime/green
-	adulttype = /mob/living/carbon/slime/adult/green
-	coretype = /obj/item/slime_extract/green
+/mob/living/carbon/slime/green/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 2
 
-/mob/living/carbon/slime/adult/green/New()
+/mob/living/carbon/slime/green/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/black
 	slime_mutation[2] = /mob/living/carbon/slime/green
@@ -279,166 +219,126 @@ This allows two random colors of slimes, one of it's own color for sure, and fin
 
 /mob/living/carbon/slime/lightpink
 	colour = "light pink"
-	icon_state = "light pink baby slime"
 	primarytype = /mob/living/carbon/slime/lightpink
-	adulttype = /mob/living/carbon/slime/adult/lightpink
+	adulttype = /mob/living/carbon/slime/lightpink/adult
 	coretype = /obj/item/slime_extract/lightpink
 
-/mob/living/carbon/slime/adult/lightpink
-	icon_state = "light pink adult slime"
-	colour = "light pink"
-	primarytype = /mob/living/carbon/slime/lightpink
-	adulttype = /mob/living/carbon/slime/adult/lightpink
-	coretype = /obj/item/slime_extract/lightpink
+/mob/living/carbon/slime/lightpink/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 2
 
-/mob/living/carbon/slime/adult/lightpink/New()
+/mob/living/carbon/slime/lightpink/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/lightpink
 	slime_mutation[2] = /mob/living/carbon/slime/lightpink
 
 /mob/living/carbon/slime/oil
-	icon_state = "oil baby slime"
 	colour = "oil"
 	primarytype = /mob/living/carbon/slime/oil
-	adulttype = /mob/living/carbon/slime/adult/oil
+	adulttype = /mob/living/carbon/slime/oil/adult
 	coretype = /obj/item/slime_extract/oil
 
-/mob/living/carbon/slime/adult/oil
-	icon_state = "oil adult slime"
-	colour = "oil"
-	primarytype = /mob/living/carbon/slime/oil
-	adulttype = /mob/living/carbon/slime/adult/oil
-	coretype = /obj/item/slime_extract/oil
+/mob/living/carbon/slime/oil/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 2
 
-/mob/living/carbon/slime/adult/oil/New()
+/mob/living/carbon/slime/oil/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/oil
 	slime_mutation[2] = /mob/living/carbon/slime/oil
 
 
 /mob/living/carbon/slime/black
-	icon_state = "black baby slime"
 	colour = "black"
 	primarytype = /mob/living/carbon/slime/black
-	adulttype = /mob/living/carbon/slime/adult/black
+	adulttype = /mob/living/carbon/slime/black/adult
 	coretype = /obj/item/slime_extract/black
 
-/mob/living/carbon/slime/adult/black
-	icon_state = "black adult slime"
-	colour = "black"
-	primarytype = /mob/living/carbon/slime/black
-	adulttype = /mob/living/carbon/slime/adult/black
-	coretype = /obj/item/slime_extract/black
+/mob/living/carbon/slime/black/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 2
 
-/mob/living/carbon/slime/adult/black/New()
+/mob/living/carbon/slime/black/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/black
 	slime_mutation[2] = /mob/living/carbon/slime/black
 
 
 /mob/living/carbon/slime/adamantine
-	icon_state = "adamantine baby slime"
 	colour = "adamantine"
 	primarytype = /mob/living/carbon/slime/adamantine
-	adulttype = /mob/living/carbon/slime/adult/adamantine
+	adulttype = /mob/living/carbon/slime/adamantine/adult
 	coretype = /obj/item/slime_extract/adamantine
 
-/mob/living/carbon/slime/adult/adamantine
-	icon_state = "adamantine adult slime"
-	colour = "adamantine"
-	primarytype = /mob/living/carbon/slime/adamantine
-	adulttype = /mob/living/carbon/slime/adult/adamantine
-	coretype = /obj/item/slime_extract/adamantine
+/mob/living/carbon/slime/adamantine/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 2
 
-/mob/living/carbon/slime/adult/adamantine/New()
+/mob/living/carbon/slime/adamantine/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/adamantine
 	slime_mutation[2] = /mob/living/carbon/slime/adamantine
 
 
 /mob/living/carbon/slime/bluespace
-	icon_state = "bluespace baby slime"
 	colour = "bluespace"
 	primarytype = /mob/living/carbon/slime/bluespace
-	adulttype = /mob/living/carbon/slime/adult/bluespace
+	adulttype = /mob/living/carbon/slime/bluespace/adult
 	coretype = /obj/item/slime_extract/bluespace
 
-/mob/living/carbon/slime/adult/bluespace
-	icon_state = "bluespace adult slime"
-	colour = "bluespace"
-	primarytype = /mob/living/carbon/slime/bluespace
-	adulttype = /mob/living/carbon/slime/adult/bluespace
-	coretype = /obj/item/slime_extract/bluespace
+/mob/living/carbon/slime/bluespace/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 2
 
-/mob/living/carbon/slime/adult/bluespace/New()
+/mob/living/carbon/slime/bluespace/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/bluespace
 	slime_mutation[2] = /mob/living/carbon/slime/bluespace
 
 
 /mob/living/carbon/slime/pyrite
-	icon_state = "pyrite baby slime"
 	colour = "pyrite"
 	primarytype = /mob/living/carbon/slime/pyrite
-	adulttype = /mob/living/carbon/slime/adult/pyrite
+	adulttype = /mob/living/carbon/slime/pyrite/adult
 	coretype = /obj/item/slime_extract/pyrite
 
-/mob/living/carbon/slime/adult/pyrite
-	icon_state = "pyrite adult slime"
-	colour = "pyrite"
-	primarytype = /mob/living/carbon/slime/pyrite
-	adulttype = /mob/living/carbon/slime/adult/pyrite
-	coretype = /obj/item/slime_extract/pyrite
+/mob/living/carbon/slime/pyrite/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 2
 
-/mob/living/carbon/slime/adult/pyrite/New()
+/mob/living/carbon/slime/pyrite/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/pyrite
 	slime_mutation[2] = /mob/living/carbon/slime/pyrite
 
 
 /mob/living/carbon/slime/cerulean
-	icon_state = "cerulean baby slime"
 	colour = "cerulean"
 	primarytype = /mob/living/carbon/slime/cerulean
-	adulttype = /mob/living/carbon/slime/adult/cerulean
+	adulttype = /mob/living/carbon/slime/cerulean/adult
 	coretype = /obj/item/slime_extract/cerulean
 
-/mob/living/carbon/slime/adult/cerulean
-	icon_state = "cerulean adult slime"
-	colour = "cerulean"
-	primarytype = /mob/living/carbon/slime/cerulean
-	adulttype = /mob/living/carbon/slime/adult/cerulean
-	coretype = /obj/item/slime_extract/cerulean
+/mob/living/carbon/slime/cerulean/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 2
 
-/mob/living/carbon/slime/adult/cerulean/New()
+/mob/living/carbon/slime/cerulean/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/cerulean
 	slime_mutation[2] = /mob/living/carbon/slime/cerulean
 
 
 /mob/living/carbon/slime/sepia
-	icon_state = "sepia baby slime"
 	colour = "sepia"
 	primarytype = /mob/living/carbon/slime/sepia
-	adulttype = /mob/living/carbon/slime/adult/sepia
+	adulttype = /mob/living/carbon/slime/sepia/adult
 	coretype = /obj/item/slime_extract/sepia
 
-/mob/living/carbon/slime/adult/sepia
-	icon_state = "sepia adult slime"
-	colour = "sepia"
-	primarytype = /mob/living/carbon/slime/sepia
-	adulttype = /mob/living/carbon/slime/adult/sepia
-	coretype = /obj/item/slime_extract/sepia
+/mob/living/carbon/slime/sepia/adult
+	slime_lifestage = SLIME_ADULT
 	maxcolorcount = 2
 
-/mob/living/carbon/slime/adult/sepia/New()
+/mob/living/carbon/slime/sepia/adult/New()
 	..()
 	slime_mutation[1] = /mob/living/carbon/slime/sepia
 	slime_mutation[2] = /mob/living/carbon/slime/sepia
@@ -447,7 +347,9 @@ This allows two random colors of slimes, one of it's own color for sure, and fin
 
 /mob/living/carbon/slime/pygmy
 	colour = "pygmy"
-	icon_state = "rainbow baby slime"
 	primarytype = /mob/living/carbon/slime/pygmy
 	adulttype = null
 	coretype = /obj/item/slime_extract/grey
+
+/mob/living/carbon/slime/pygmy/iconstate_color()
+	return "rainbow"

--- a/code/modules/mob/living/simple_animal/hostile/slime.dm
+++ b/code/modules/mob/living/simple_animal/hostile/slime.dm
@@ -73,24 +73,11 @@
 	..()
 
 /mob/living/simple_animal/hostile/slime/proc/calm()
-	var/calmed_type = /mob/living/carbon/slime
+	var/is_adult = istype(src, /mob/living/simple_animal/hostile/slime/adult)
+	var/calmed_type = is_adult ? /mob/living/carbon/slime/adult : /mob/living/carbon/slime
 	if(colour != "grey")
-		var/path_end = replacetext(colour, " ", "")
-		calmed_type = text2path("/mob/living/carbon/slime/" + path_end)
-
-	var/mob/living/carbon/slime/calmed = new calmed_type(loc)
-	for(var/datum/weakref/ref in friends)
-		var/mob/M = ref.get()
-		if (istype(M))
-			calmed.Friends = M
-
-	qdel(src)
-
-/mob/living/simple_animal/hostile/slime/adult/calm()
-	var/calmed_type = /mob/living/carbon/slime/adult
-	if(colour != "grey")
-		var/path_end = replacetext(colour, " ", "")
-		calmed_type = text2path("/mob/living/carbon/slime/adult/" + path_end)
+		var/path_color = replacetext(colour, " ", "")
+		calmed_type = text2path("/mob/living/carbon/slime/" + path_color + (is_adult ? "/adult" : ""))
 
 	var/mob/living/carbon/slime/calmed = new calmed_type(loc)
 	for(var/datum/weakref/ref in friends)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -528,7 +528,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 
 	var/damage = rand(1, 3)
 
-	if(istype(M,/mob/living/carbon/slime/adult))
+	if(M.slime_lifestage == SLIME_ADULT)
 		damage = rand(20, 40)
 	else
 		damage = rand(5, 35)


### PR DESCRIPTION
Currently, slimes babies are
`mob/living/carbon/slime/purple`
and slime adults are
`mob/living/carbon/slime/adult/purple`

This separation of slimes of the same color into two distinct inheritance paths works fine currently, but it's somewhat of a hindrance for implementing a few ideas I have for expanding slime and xenobio stuff. So as a first step to making slimes simpler to expand upon and interact with, I'd like to make slime lifestage determined by a variable, which can be either `SLIME_BABY` or `SLIME_ADULT`.

This should make it simpler to do things like add unique abilities and behavior based on a given slime subtype. For example things like yellow slimes shocking people who touch them. Also it should make it a little more convenient to implement new subtypes of slimes. Also as an example of something I've been thinking about for expanding xenobio, this step prepares the way for making slime color and such something like a datum that could allow for things like cross-breeding or fusing slimes with other mobs to give them specific traits. Like breeding or fusing a yellow slime with a grue and getting an electric grue. Some ideas but this is sort of the first step towards that.

If I didn't miss anything, the only visible change this pull should have in-game is also allowing grey baby slimes to appear in vermin infestation events alongside the other colors. I think the exclusion of grey slimes there was probably an oversight caused by assuming they had their own subtype and weren't just the base type.

:cl:
 * tweak: Grey slimes can appear alongside their kin during slime infestations.