### PR TITLE
random names for the mmis of mommi/cyborg with pref enabled

### DIFF
--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -241,9 +241,12 @@
 	brainmob.dna = new()
 	brainmob.dna.ResetUI()
 	brainmob.dna.ResetSE()
+	if(P.be_random_name)
+		P.real_name = random_name(P.gender, P.species)
 	brainmob.name = P.real_name
 	brainmob.real_name = P.real_name
 	brainmob.container = src
+
 	name = "Man-Machine Interface: [brainmob.real_name]"
 	icon_state = "mmi_full"
 	locked = 1


### PR DESCRIPTION
## What this does
If a cyborg or mommi has random names enabled in prefs, their MMI will now start with a random name as well.
To be clear, this has no effect on the robot name you choose, just the name of your internal MMI that pops out when you get destroyed.

## Why it's good
No more getting your static / last round's name recognized.

Requested by @kacurasuo 
[qol]

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: MoMMI's/cyborgs with random names enabled in prefs now have randomized MMI names.
