### PR TITLE
fix dippable foods runtime

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -537,7 +537,7 @@
 	if (food_flags & FOOD_DIPPABLE)
 		if (target.is_open_container() && user.Adjacent(target))
 			var/obj/item/weapon/reagent_containers/container = target
-			if(!istype(container)
+			if(!istype(container))
 				return
 			if (dip && dip.total_volume)
 				to_chat(user, "<span class='warning'>\The [src] is already dipped in [dip.get_master_reagent_name()]. Take a bite before you can dip it further.</span>")

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -537,6 +537,8 @@
 	if (food_flags & FOOD_DIPPABLE)
 		if (target.is_open_container() && user.Adjacent(target))
 			var/obj/item/weapon/reagent_containers/container = target
+			if(!istype(container)
+				return
 			if (dip && dip.total_volume)
 				to_chat(user, "<span class='warning'>\The [src] is already dipped in [dip.get_master_reagent_name()]. Take a bite before you can dip it further.</span>")
 				return


### PR DESCRIPTION
`is_open_container()` returns true on mobs, so this code was causing runtimes
[runtime]

caused by #34290
```[16:12:14] Runtime in code/modules/reagents/reagent_containers/food/snacks.dm,543: undefined proc or verb /mob/living/carbon/human/is empty().

  proc name: afterattack (/obj/item/weapon/reagent_containers/food/snacks/afterattack)
  usr: Algot Gudakuk (racismismysuperpower) (/mob/living/carbon/human)
  usr.loc: The floor (210, 225, 1) (/turf/simulated/floor)
  src: the donut (/obj/item/weapon/reagent_containers/food/snacks/donut/normal)
  src.loc: Algot Gudakuk (/mob/living/carbon/human)
  call stack:
  the donut (/obj/item/weapon/reagent_containers/food/snacks/donut/normal): afterattack(Algot Gudakuk (/mob/living/carbon/human), Algot Gudakuk (/mob/living/carbon/human), 1, "icon-x=17;icon-y=19;left=1;but...")
  Algot Gudakuk (/mob/living/carbon/human): ClickOn(Algot Gudakuk (/mob/living/carbon/human), "icon-x=17;icon-y=19;left=1;but...")
  Algot Gudakuk (/mob/living/carbon/human): Click(the floor (210,226,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=17;icon-y=19;left=1;but...")
  Racism is my superpower (/client): Click(Algot Gudakuk (/mob/living/carbon/human), the floor (210,226,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=17;icon-y=19;left=1;but...")
  (This error will now be silenced for 10 minutes)```