### PR TITLE
fix russian revolver runtime

### DIFF
--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -244,6 +244,10 @@
 	..()
 
 /obj/item/weapon/gun/projectile/russian/Fire(atom/target, mob/living/user, params, reflex = 0, struggle = 0, var/use_shooter_turf = FALSE)
+	if(!getAmmo()) /* Check to ensure that russian revolvers that start empty don't runtime. */
+		user.visible_message("<span class='warning'>*click*</span>")
+		playsound(user, 'sound/weapons/empty.ogg', 100, 1)
+		return
 	var/obj/item/ammo_casing/AC = loaded[1]
 	if(!AC || !AC.BB)
 		user.visible_message("<span class='warning'>*click*</span>")


### PR DESCRIPTION
caused by the subtype of russian revolvers that start empty
[runtime]

```[23:16:09] Runtime in code/modules/projectiles/guns/projectile/revolver.dm,247: list index out of bounds
  proc name: Fire (/obj/item/weapon/gun/projectile/russian/Fire)
  usr: Madelynn Edelfelt (chaklet) (/mob/living/carbon/human)
  usr.loc: The floor (145, 112, 1) (/turf/simulated/floor)
  src: the russian revolver (/obj/item/weapon/gun/projectile/russian/empty)
  src.loc: Madelynn Edelfelt (/mob/living/carbon/human)
  call stack:
  the russian revolver (/obj/item/weapon/gun/projectile/russian/empty): Fire(the Interrogation Room Vent Pu... (/obj/machinery/atmospherics/unary/vent_pump), Madelynn Edelfelt (/mob/living/carbon/human), "icon-x=25;icon-y=21;left=1;but...", 0, 0, 0)
  the russian revolver (/obj/item/weapon/gun/projectile/russian/empty): afterattack(the Interrogation Room Vent Pu... (/obj/machinery/atmospherics/unary/vent_pump), Madelynn Edelfelt (/mob/living/carbon/human), 0, "icon-x=25;icon-y=21;left=1;but...", 0)
  the russian revolver (/obj/item/weapon/gun/projectile/russian/empty): afterattack(the Interrogation Room Vent Pu... (/obj/machinery/atmospherics/unary/vent_pump), Madelynn Edelfelt (/mob/living/carbon/human), 0, "icon-x=25;icon-y=21;left=1;but...", 0)
  Madelynn Edelfelt (/mob/living/carbon/human): RangedClickOn(the Interrogation Room Vent Pu... (/obj/machinery/atmospherics/unary/vent_pump), "icon-x=25;icon-y=21;left=1;but...", the russian revolver (/obj/item/weapon/gun/projectile/russian/empty))
  Madelynn Edelfelt (/mob/living/carbon/human): ClickOn(the Interrogation Room Vent Pu... (/obj/machinery/atmospherics/unary/vent_pump), "icon-x=25;icon-y=21;left=1;but...")
  the Interrogation Room Vent Pu... (/obj/machinery/atmospherics/unary/vent_pump): Click(the floor (145,109,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=25;icon-y=21;left=1;but...")
  Chaklet (/client): Click(the Interrogation Room Vent Pu... (/obj/machinery/atmospherics/unary/vent_pump), the floor (145,109,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=25;icon-y=21;left=1;but...")```