### PR TITLE
sanity check on cargo carts to fix runtime

### DIFF
--- a/code/game/objects/structures/vehicles/carts/cargo.dm
+++ b/code/game/objects/structures/vehicles/carts/cargo.dm
@@ -67,6 +67,8 @@
 
 /obj/machinery/cart/cargo/MouseDropTo(var/atom/movable/C, mob/user)
 	..()
+	if(!istype(C))
+		return
 	if(C.anchored)
 		to_chat(user, "\The [C] is fastened to the floor!")
 		return


### PR DESCRIPTION
[runtime]
```[18:45:29] Runtime in code/game/objects/structures/vehicles/carts/cargo.dm,70: undefined variable /turf/unsimulated/floor/snow/var/anchored
  proc name: MouseDropTo (/obj/machinery/cart/cargo/MouseDropTo)
  usr: John Beckett (ltcmdr) (/mob/living/carbon/human)
  usr.loc: The asphalt (151, 140, 1) (/turf/unsimulated/floor/snow/asphalt)
  src: the toboggan (/obj/machinery/cart/cargo/toboggan)
  src.loc: the snow (152,141,1) (/turf/unsimulated/floor/snow)
  call stack:
  the toboggan (/obj/machinery/cart/cargo/toboggan): MouseDropTo(the snow (152,141,1) (/turf/unsimulated/floor/snow), John Beckett (/mob/living/carbon/human), the snow (152,141,1) (/turf/unsimulated/floor/snow), the snow (152,141,1) (/turf/unsimulated/floor/snow), "mapwindow.map", "mapwindow.map", "icon-x=21;icon-y=5;left=1;butt...")
  the snow (152,141,1) (/turf/unsimulated/floor/snow): MouseDrop(the toboggan (/obj/machinery/cart/cargo/toboggan), the snow (152,141,1) (/turf/unsimulated/floor/snow), the snow (152,141,1) (/turf/unsimulated/floor/snow), "mapwindow.map", "mapwindow.map", "icon-x=21;icon-y=5;left=1;butt...")```