### PR TITLE
reorganize mech go_out() to fix runtimes

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1409,24 +1409,27 @@
 		return
 
 	var/obj/structure/deathsquad_gravpult/G = locate() in get_turf(src)
-	if(mob_container.forceMove(exit))//ejecting mob container
+	if(mob_container)
 		log_message("[mob_container] moved out.")
 		occupant.reset_view()
 		empty_bad_contents()
 		occupant << browse(null, "window=exosuit")
 		remove_mech_spells()
-		if(istype(mob_container, /obj/item/device/mmi) || istype(mob_container, /obj/item/device/mmi/posibrain))
-			var/obj/item/device/mmi/mmi = mob_container
-			if(mmi.brainmob)
-				occupant.forceMove(mmi)
-				mech_parts.Remove(mmi)
-			occupant.canmove = FALSE
-			mmi.mecha = null
-			verbs += /obj/mecha/verb/eject
 
 		//change the cursor
 		if(occupant && occupant.client)
 			occupant.client.mouse_pointer_icon = initial(occupant.client.mouse_pointer_icon)
+
+		mob_container.forceMove(exit)
+
+		if(istype(mob_container, /obj/item/device/mmi) || istype(mob_container, /obj/item/device/mmi/posibrain))
+			var/obj/item/device/mmi/mmi = mob_container
+			if(mmi.brainmob)
+				mmi.brainmob.forceMove(mmi)
+				mmi.brainmob.canmove = FALSE
+				mech_parts.Remove(mmi)
+			mmi.mecha = null
+			verbs += /obj/mecha/verb/eject
 
 		occupant = null
 		icon_state = initial_icon+"-open"


### PR DESCRIPTION
[runtime][tested]

```[09:25:41] Runtime in code/game/mecha/mecha.dm,1414: Cannot execute null.reset view().
  proc name: go out (/obj/mecha/proc/go_out)
  usr: Mecha Engineer (salmonistasty) (/mob/living/carbon/human/dummy)
  usr.loc: The floor (246, 250, 1) (/turf/simulated/floor)
  src: Marauder (/obj/mecha/combat/marauder/series)
  src.loc: the floor (246,251,1) (/turf/simulated/floor)
  call stack:
  Marauder (/obj/mecha/combat/marauder/series): go out(the floor (246,250,1) (/turf/simulated/floor), 0)
  Marauder (/obj/mecha/combat/marauder/series): go out()
  Marauder (/obj/mecha/combat/marauder/series): Topic("src=\[0x201daf8];eject=1", /list (/list))
  Marauder (/obj/mecha/combat/marauder/series): Topic("src=\[0x201daf8];eject=1", /list (/list))
  SalmonIsTasty (/client): Topic("src=\[0x201daf8];eject=1", /list (/list), Marauder (/obj/mecha/combat/marauder/series))
```