### PR TITLE
fixes damocles not exploding when thrown (and also makes it so it doesnt explode if you catch it)

### DIFF
--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -325,9 +325,9 @@
 	explosion(target, 0, 0, 1, whodunnit = user)
 
 /obj/item/weapon/damocles/throw_impact(atom/hit_atom, speed, mob/user)
-	if(..())
-		explosion(get_turf(src), 0, 2, 3, whodunnit = user)
-		qdel(src)
+	..()
+	explosion(get_turf(src), 0, 2, 3, whodunnit = user)
+	qdel(src)
 
 /obj/item/weapon/caber
 	name = "Ullapool Caber"

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -326,8 +326,9 @@
 
 /obj/item/weapon/damocles/throw_impact(atom/hit_atom, speed, mob/user)
 	..()
-	explosion(get_turf(src), 0, 2, 3, whodunnit = user)
-	qdel(src)
+	if(!ismob(loc)) /* So long as someone didn't catch it, it'll explode. */
+		explosion(get_turf(src), 0, 2, 3, whodunnit = user)
+		qdel(src)
 
 /obj/item/weapon/caber
 	name = "Ullapool Caber"


### PR DESCRIPTION
I'll give you one (1) guess as to who broke it.
fixes #34648
fixes #34228

I unatomically have also made it so if you manage to catch it, it doesn't explode, mostly because I think that'd be cool.
However, if people don't like that, I'll just remove it since that sort of change doesn't belong in a bugfix anyway.

[bugfix][tweak]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Damocles now explodes properly when thrown, as intended.
 * rscadd: Damocles won't explode if you can catch it. Good luck!