### PR TITLE
logging and debug for lighting source runtime

### DIFF
--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -59,12 +59,21 @@
 
 // Kill ourselves.
 /datum/light_source/proc/destroy()
+	if(destroyed)
+		log_debug("[src] had destroy() called after already being destroyed! coords: [get_coordinates_string(src)], area: [get_area(src)]")
+		return
 	destroyed = TRUE
 	force_update()
-	if (source_atom)
+	if(source_atom)
+		if(!source_atom.light_sources)
+			log_debug("[src] was not in its source atom's light_sources when destroy() was called! coords: [get_coordinates_string(src)], area: [get_area(src)]")
+			return
 		source_atom.light_sources -= src
 
-	if (top_atom)
+	if(top_atom)
+		if(!top_atom.light_sources)
+			log_debug("[src] was not in its top atom's light_sources when destroy() was called! coords: [get_coordinates_string(src)], area: [get_area(src)]")
+			return
 		top_atom.light_sources    -= src
 
 #ifdef LIGHTING_INSTANT_UPDATES


### PR DESCRIPTION
[runtime]
```
[23:16:52] Runtime in code/modules/lighting/lighting_source.dm,65: type mismatch: null -= /datum/light_source (/datum/light_source)
  proc name: destroy (/datum/light_source/proc/destroy)
  src: /datum/light_source (/datum/light_source)
  call stack:
  /datum/light_source (/datum/light_source): destroy()
  /datum/light_source (/datum/light_source): check()
  Lighting (/datum/subsystem/lighting): fire(0)
  Lighting (/datum/subsystem/lighting): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
  (This error will now be silenced for 10 minutes)
```
