### PR TITLE
fix corpse equipment generation runtime

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -12,7 +12,7 @@
 	var/corpsegender = G_MALE
 	var/list/possible_names
 
-	var/corpseuniform = null //Set this to an object path to have the slot filled with said object on the corpse.
+	var/list/corpseuniform = null //Set this to an object path to have the slot filled with said object on the corpse.
 	var/corpsesuit = null
 	var/corpseshoes = null
 	var/corpsegloves = null
@@ -1302,8 +1302,8 @@
 	corpsehelmet = list(/obj/item/clothing/head/ushanka, /obj/item/clothing/head/squatter_hat) //heh
 
 /obj/effect/landmark/corpse/civilian/New()
-	corpseuniform += existing_typesof(/obj/item/clothing/under/color)
-	corpsehelmet += existing_typesof(/obj/item/clothing/head/soft)
+	corpseuniform = existing_typesof(/obj/item/clothing/under/color)
+	corpsehelmet = existing_typesof(/obj/item/clothing/head/soft)
 
 	return ..()
 
@@ -1312,8 +1312,7 @@
 
 	var/mob/M = .
 	if(M.gender == FEMALE)
-		for(var/Y in existing_typesof(/obj/item/clothing/under/dress))
-			corpseuniform += Y
+		corpseuniform += existing_typesof(/obj/item/clothing/under/dress)
 
 	if(prob(50))
 		corpsemask = null

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -1312,7 +1312,8 @@
 
 	var/mob/M = .
 	if(M.gender == FEMALE)
-		corpseuniform += existing_typesof(/obj/item/clothing/under/dress)
+		for(var/Y in existing_typesof(/obj/item/clothing/under/dress))
+			corpseuniform += Y
 
 	if(prob(50))
 		corpsemask = null


### PR DESCRIPTION
type mismatch
[runtime]
```
[22:38:50] Runtime in code/modules/awaymissions/corpse.dm,1315: type mismatch: /obj/item/clothing/under/color... (/obj/item/clothing/under/color/grey/cadet) += /list (/list)
  proc name: createCorpse (/obj/effect/landmark/corpse/civilian/createCorpse)
  src: Civilian (/obj/effect/landmark/corpse/civilian)
  src.loc: null
  call stack:
  Civilian (/obj/effect/landmark/corpse/civilian): createCorpse()
  Civilian (/obj/effect/landmark/corpse/civilian): initialize()
  Objects (/datum/subsystem/obj): Initialize(95277)
  Master (/datum/controller/master): Setup()
```