### PR TITLE
fix runtime with health analyzer

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -177,6 +177,8 @@ Damage Specifics: <span class='notice'>0</span> - <font color='green'>0</font> -
 Blood Level Unknown: ???% ???cl
 Subject's pulse: ??? BPM"})
 			return
+	if(!istype(M))
+		return
 	if(!silent)
 		user.visible_message("<span class='notice'>[user] analyzes [M]'s vitals.</span>", ignore_self = TRUE)
 		playsound(user, 'sound/items/healthanalyzer.ogg', 50, 1)


### PR DESCRIPTION
scanning non-mobs no longer runtimes (lol)
[runtime]

```
[22:25:45] Runtime in code/game/objects/items/devices/scanners.dm,183: undefined proc or verb /obj/item/device/pda/medical/getOxyLoss().

  proc name: healthanalyze (/proc/healthanalyze)
  usr: X68000 (resynthesis) (/mob/living/silicon/pai)
  usr.loc: The floor (208, 229, 1) (/turf/simulated/floor)
  src: null
  call stack:
  healthanalyze(PDA-Eric Baum (Brig Medic) (/obj/item/device/pda/medical), X68000 (/mob/living/silicon/pai), 1, 0, 0)
  X68000 (/mob/living/silicon/pai): softwareMedicalRecord()
  X68000 (/mob/living/silicon/pai): Software Interface()
  X68000 (/mob/living/silicon/pai): Topic("src=\[0x30001e1];software=medi...", /list (/list))
  Resynthesis (/client): Topic("src=\[0x30001e1];software=medi...", /list (/list), X68000 (/mob/living/silicon/pai))
```