### PR TITLE
fix runtime with AI ion storm event

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -160,7 +160,7 @@
 */
 
 	for(var/mob/living/silicon/ai/target in mob_list)
-		if(target.mind.special_role == "traitor")
+		if(target.mind && target.mind.special_role == "traitor")
 			continue
 		to_chat(target, "<span class='danger'>You have detected a change in your laws information:</span>")
 		to_chat(target, final_law)


### PR DESCRIPTION
[runtime]

```
[22:28:00] Runtime in code/modules/events/ion_storm.dm,163: Cannot read null.special_role
  proc name: generate ion law (/proc/generate_ion_law)
  src: null
  call stack:
  generate ion law()
  /datum/event/ionstorm (/datum/event/ionstorm): announce()
  /datum/event/ionstorm (/datum/event/ionstorm): process()
  Event (/datum/subsystem/event): fire(0)
  Event (/datum/subsystem/event): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```