### PR TITLE
fix runtime with getting inaccuracy of gun with 0 spread

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -892,8 +892,10 @@ its easier to just keep the beam vertical.
 	return
 
 /atom/proc/get_inaccuracy(var/atom/target, var/spread, var/obj/mecha/chassis)
-	var/turf/curloc = get_turf(src)
 	var/turf/targloc = get_turf(target)
+	if(!spread)
+		return target
+	var/turf/curloc = get_turf(src)
 	var/list/turf/shot_spread = list()
 	for(var/turf/T in trange(min(spread, max(0, get_dist(curloc, targloc)-1)), targloc))
 		if(chassis)


### PR DESCRIPTION
it picks from an empty list if spread is 0, so a special case is added for no spread
[runtime]

```
[19:18:02] Runtime in code/game/atoms.dm,904: pick() from empty list
  proc name: get inaccuracy (/atom/proc/get_inaccuracy)
  usr: Captain (manylo) (/mob/living/carbon/human)
  usr.loc: The floor (16, 234, 2) (/turf/simulated/floor/shuttle)
  src: the NT Glock Custom (/obj/item/weapon/gun/projectile/glock/flame)
  src.loc: Captain (/mob/living/carbon/human)
  call stack:
  the NT Glock Custom (/obj/item/weapon/gun/projectile/glock/flame): get inaccuracy(the reinforced window (/obj/structure/window/reinforced), 1, null)
  the NT Glock Custom (/obj/item/weapon/gun/projectile/glock/flame): Fire(null, Captain (/mob/living/carbon/human), "icon-x=29;icon-y=26;left=1;but...", 0, 0, 0)
  the NT Glock Custom (/obj/item/weapon/gun/projectile/glock/flame): afterattack(the reinforced window (/obj/structure/window/reinforced), Captain (/mob/living/carbon/human), 0, "icon-x=29;icon-y=26;left=1;but...", 0)
  the NT Glock Custom (/obj/item/weapon/gun/projectile/glock/flame): afterattack(the reinforced window (/obj/structure/window/reinforced), Captain (/mob/living/carbon/human), 0, "icon-x=29;icon-y=26;left=1;but...", 0)
  Captain (/mob/living/carbon/human): RangedClickOn(the reinforced window (/obj/structure/window/reinforced), "icon-x=29;icon-y=26;left=1;but...", the NT Glock Custom (/obj/item/weapon/gun/projectile/glock/flame))
  Captain (/mob/living/carbon/human): ClickOn(the reinforced window (/obj/structure/window/reinforced), "icon-x=29;icon-y=26;left=1;but...")
  the reinforced window (/obj/structure/window/reinforced): Click(the plating (19,233,2) (/turf/simulated/floor/shuttle/plating), "mapwindow.map", "icon-x=29;icon-y=26;left=1;but...")
```