### PR TITLE
Fix Supermatter Surprise scratch card guaranteed win

### DIFF
--- a/code/modules/games/cards/lotto.dm
+++ b/code/modules/games/cards/lotto.dm
@@ -26,6 +26,17 @@
 			profit = prizelist[prize] * prize_multiplier * tuning_value
 			return profit
 
+/obj/item/toy/lotto_ticket/supermatter_surprise/scratch(var/input_prize_multiplier, var/mob/user)
+    var/profit = 0
+    var/luck = user?.luck()
+    while(!profit)
+        for(var/prize = 1 to problist.len)
+            var/thisprob = problist[prize]
+            //Take luck into account.
+            if(user ? user.lucky_prob(thisprob, luckfactor = 1/12000, maxskew = 49.9, ourluck = luck) : prob(thisprob))
+                profit = prizelist[prize] * input_prize_multiplier
+                return profit
+
 //Flash code taken from Blinder
 /obj/item/toy/lotto_ticket/proc/flash(var/turf/T , var/mob/living/M)
 	playsound(src, 'sound/effects/EMPulse.ogg', 100, 1)

--- a/code/modules/games/cards/lotto.dm
+++ b/code/modules/games/cards/lotto.dm
@@ -27,16 +27,16 @@
 			return profit
 
 /obj/item/toy/lotto_ticket/supermatter_surprise/scratch(var/input_prize_multiplier, var/mob/user)
-    var/profit = 0
+	var/profit = 0
 	var/attempt = 0
-    var/luck = user?.luck()
-    while(!profit && attempt < 10000)
-        for(var/prize = 1 to problist.len)
-            var/thisprob = problist[prize]
-            //Take luck into account.
-            if(user ? user.lucky_prob(thisprob, luckfactor = 1/12000, maxskew = 49.9, ourluck = luck) : prob(thisprob))
-                profit = prizelist[prize] * input_prize_multiplier
-                return profit
+	var/luck = user?.luck()
+	while(!profit && attempt < 10000)
+		for(var/prize = 1 to problist.len)
+			var/thisprob = problist[prize]
+			//Take luck into account.
+			if(user ? user.lucky_prob(thisprob, luckfactor = 1/12000, maxskew = 49.9, ourluck = luck) : prob(thisprob))
+				profit = prizelist[prize] * input_prize_multiplier
+				return profit
 		attempt++
 	return prizelist[prizelist.len] * input_prize_multiplier
 

--- a/code/modules/games/cards/lotto.dm
+++ b/code/modules/games/cards/lotto.dm
@@ -28,14 +28,17 @@
 
 /obj/item/toy/lotto_ticket/supermatter_surprise/scratch(var/input_prize_multiplier, var/mob/user)
     var/profit = 0
+	var/attempt = 0
     var/luck = user?.luck()
-    while(!profit)
+    while(!profit && attempt < 10000)
         for(var/prize = 1 to problist.len)
             var/thisprob = problist[prize]
             //Take luck into account.
             if(user ? user.lucky_prob(thisprob, luckfactor = 1/12000, maxskew = 49.9, ourluck = luck) : prob(thisprob))
                 profit = prizelist[prize] * input_prize_multiplier
                 return profit
+		attempt++
+	return prizelist[prizelist.len] * input_prize_multiplier
 
 //Flash code taken from Blinder
 /obj/item/toy/lotto_ticket/proc/flash(var/turf/T , var/mob/living/M)

--- a/code/modules/games/cards/lotto.dm
+++ b/code/modules/games/cards/lotto.dm
@@ -27,16 +27,14 @@
 			return profit
 
 /obj/item/toy/lotto_ticket/supermatter_surprise/scratch(var/input_prize_multiplier, var/mob/user)
-	var/profit = 0
 	var/attempt = 0
 	var/luck = user?.luck()
-	while(!profit && attempt < 10000)
+	while(attempt < 10000)
 		for(var/prize = 1 to problist.len)
 			var/thisprob = problist[prize]
 			//Take luck into account.
 			if(user ? user.lucky_prob(thisprob, luckfactor = 1/12000, maxskew = 49.9, ourluck = luck) : prob(thisprob))
-				profit = prizelist[prize] * input_prize_multiplier
-				return profit
+				return prizelist[prize] * input_prize_multiplier
 		attempt++
 	return prizelist[prizelist.len] * input_prize_multiplier
 


### PR DESCRIPTION
This fixes Supermatter Surprise scratch cards not having a guaranteed win as intended.

Fixes #34745
:cl:
 * bugfix: Supermatter Surprise scratch cards have a guaranteed win as advertised.