### PR TITLE
AI mentions now accept ALL cases of, "AI, Ai, ai", etc. using a vastly improved regex search

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -311,12 +311,11 @@ var/list/headset_modes = list(
 			/* We use a raw string (@"...") to avoid escaping all of the backslashes used in the pattern, as well as for readability.		*/
 			/* The first pattern is meant to help find "AI" all on its own, WITHOUT including "AI" when surrounded by letters, i.e. (rain) 	*/
 			/* It's also necessary to ensure "AI" is found when surrounded by, say, quotation marks in rendered_message, which is HTML.		*/
-			var/regex/pattern = regex(@"(?<!\l)AI(?!\l)|\Aai\Z|\Aai(?=\s)|(?<=\s)ai(?=\s)", "gi")
+			var/static/regex/pattern = regex(@"(?<!\l)AI(?!\l)|\Aai\Z|\Aai(?=\s)|(?<=\s)ai(?=\s)", "gi")
 			if(pattern.Find(speech.message) || findtext(speech.message, ai.real_name))
 				ai << 'sound/machines/twobeep.ogg'
 				rendered_message = pattern.Replace(rendered_message, "<i style='color: blue;'>AI</i>")
 				rendered_message = replacetext(rendered_message, ai.real_name, "<i style='color: blue;'>[ai.real_name]</i>")
-			qdel(pattern)
 
 	// Runechat messages
 	if (ismob(speech.speaker) && client?.prefs.mob_chat_on_map && stat != UNCONSCIOUS && !is_deaf())

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -307,10 +307,16 @@ var/list/headset_modes = list(
 	if(isAI(src) && speech.frequency && !findtextEx(speech.job,"AI") && (speech.name != name))
 		var/mob/living/silicon/ai/ai = src
 		if(ai.mentions_on)
-			if(findtextEx(speech.message, "AI") || findtext(speech.message, ai.real_name))
+			/* Find "AI", "AI...", or "... AI ...", case-insensitive. Global flag set so regex.Replace() hits all matches. 					*/
+			/* We use a raw string (@"...") to avoid escaping all of the backslashes used in the pattern, as well as for readability.		*/
+			/* The first pattern is meant to help find "AI" all on its own, WITHOUT including "AI" when surrounded by letters, i.e. (rain) 	*/
+			/* It's also necessary to ensure "AI" is found when surrounded by, say, quotation marks in rendered_message, which is HTML.		*/
+			var/regex/pattern = regex(@"(?<!\l)AI(?!\l)|\Aai\Z|\Aai(?=\s)|(?<=\s)ai(?=\s)", "gi")
+			if(pattern.Find(speech.message) || findtext(speech.message, ai.real_name))
 				ai << 'sound/machines/twobeep.ogg'
-				rendered_message = replacetextEx(rendered_message, "AI", "<i style='color: blue;'>AI</i>")
+				rendered_message = pattern.Replace(rendered_message, "<i style='color: blue;'>AI</i>")
 				rendered_message = replacetext(rendered_message, ai.real_name, "<i style='color: blue;'>[ai.real_name]</i>")
+			qdel(pattern)
 
 	// Runechat messages
 	if (ismob(speech.speaker) && client?.prefs.mob_chat_on_map && stat != UNCONSCIOUS && !is_deaf())


### PR DESCRIPTION
## What this does
Title says it all. I'd include screenshots, but no matter how someone types it in chat, it'll say, "AI" in all caps for the AI. This is intentional. (It'll still show normally for everyone else!)

All possible cases were accounted for with this regex. I wasn't able to find any exceptions or ways to break this version in my testing. Finding the correct way to do this was a bigger challenge than I would've imagined!

[qol]

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Toggle-AI-Mentions has been vastly improved, now accounting for when someone says "AI" regardless of caps lock.