### PR TITLE
Fixes Advanced Graffiti spawning additional invisible "rune" decals that show up on photos.

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -191,6 +191,7 @@ var/global/list/all_graffitis = list(
 					var/datum/custom_painting/advanced_graffiti = new(the_turf, 32, 32, base_color = "#00000000")
 					the_turf.advanced_graffiti = advanced_graffiti
 				the_turf.advanced_graffiti.interact(user, p)
+				return
 
 		if(!user.Adjacent(target))
 			return


### PR DESCRIPTION
Fixes #34753

:cl:
* bugfix: Fixes Advanced Graffiti spawning additional invisible "rune" decals that show up on photos.