### PR TITLE
Resting/dying human mobs can hide in crates, much like lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -459,20 +459,21 @@
 	src.setDensity(TRUE)
 	return 1
 
-/obj/structure/closet/crate/insert(var/atom/movable/AM, var/include_mobs = 0)
+/obj/structure/closet/crate/insert(var/atom/movable/AM)
 
 	if(contents.len >= storage_capacity)
 		return -1
 
-	if(include_mobs && isliving(AM))
-		var/mob/living/L = AM
-		if(L.locked_to)
+	if(ishuman(AM))
+		var/mob/living/carbon/human/H = AM
+		if(!istype(H) || H.locked_to)
 			return 0
+		if(!(H.resting || H.stat)) /* We only want mobs that are human and are resting/dying to be able to get inside. */
+			return 0
+
 	else if(isobj(AM))
 		if(AM.density || AM.anchored || istype(AM,/obj/structure/closet))
 			return 0
-	else
-		return 0
 
 	if(istype(AM, /obj/structure/bed)) //This is only necessary because of rollerbeds and swivel chairs.
 		var/obj/structure/bed/B = AM

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1228,10 +1228,10 @@ Thanks.
 
 	if(client.move_delayer.blocked())
 		return
-
-	if(istype(loc, /obj/structure/closet/crate))
-		to_chat(src, "<span class='warning'>There isn't enough room to get up. Open the [loc.name] first!</span>")
-		return
+	if(resting) /* If you're somehow already standing up while inside a crate (shouldn't happen), you can still rest. */
+		if(istype(loc, /obj/structure/closet/crate))
+			to_chat(src, "<span class='warning'>There isn't enough room to get up. Open the [loc.name] first!</span>")
+			return
 
 	rest_action()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1229,6 +1229,10 @@ Thanks.
 	if(client.move_delayer.blocked())
 		return
 
+	if(istype(loc, /obj/structure/closet/crate))
+		to_chat(src, "<span class='warning'>There isn't enough room to get up. Open the [loc.name] first!</span>")
+		return
+
 	rest_action()
 
 /mob/living/proc/rest_action()


### PR DESCRIPTION
## What this does
Any resting or dying (crit or already dead) human mob can now be enclosed into a crate. This is essentially the same thing as hiding in lockers, but with more restrictions and slightly harder to do as you have to rest first.

## Why it's good
More paranoia in spess, consistency, etc. Knowing that lockers can contain people but that crates never will is lame!

## Points of discussion
- Should all living mobs be able to do this instead of just humans? Personally I think that'd be very unbalanced.
- Are there any ways to exploit this that I haven't thought of? Currently, I've restricted un-resting while you're in a crate.
- Should any other restrictions be applied?

## To-Do:
- [ ] Resisting out of a crate needs its own visible message ("door" implies locker)
- [ ] Resisting out of a wrapped crate will give you a "success" message but not actually unwrap it or open the crate.
- [ ] Trying to put a mutualcuffed person in a crate just runtimes and doesn't let them in (not letting them in is good but I need to fix the runtime)
- [ ] Test locked crates

[balance]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Resting/dying human mobs can now hide in crates, much like they can lockers.
