### PR TITLE
Reverts Most Targeting-Based Splash Code Changes

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1795,15 +1795,15 @@
 				var/mob/living/carbon/human/H = M
 				var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
 				if(head_organ)
-					if(head_organ.take_damage(0, min(15, volume *2)))
+					if(head_organ.take_damage(min(25, volume * 2), 0))
 						H.UpdateDamageIcon(1)
 					head_organ.disfigure("burn")
 					H.audible_scream()
 			else
-				M.take_organ_damage(0, min(15, volume * 2)) //uses min() and volume to make sure they aren't being sprayed in trace amounts (1 unit != insta rape) -- Doohl
+				M.take_organ_damage(min(15, volume * 2), 0) //uses min() and volume to make sure they aren't being sprayed in trace amounts (1 unit != insta rape) -- Doohl
 	else
 		if(M.dissolvable() == PACID)
-			M.take_organ_damage(0, min(15, volume * 2))
+			M.take_organ_damage(min(15, volume * 2), 0)
 
 /datum/reagent/sacid/reaction_obj(var/obj/O, var/volume)
 	if(..())
@@ -1873,7 +1873,7 @@
 
 			if(H.dissolvable() == PACID)
 				var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
-				if(head_organ.take_damage(0, min(15, volume * 4)))
+				if(head_organ.take_damage(min(15, volume * 4), 0))
 					H.UpdateDamageIcon(1)
 				H.audible_scream()
 
@@ -1890,18 +1890,18 @@
 				return
 
 			if(MK.dissolvable() == PACID)
-				MK.take_organ_damage(0, min(15, volume * 4)) //Same deal as sulphuric acid
+				MK.take_organ_damage(min(15, volume * 4), 0) //Same deal as sulphuric acid
 	else
 		if(M.dissolvable() == PACID) //I think someone doesn't know what this does
 			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
 				var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
-				if(head_organ.take_damage(0, min(15, volume * 4)))
+				if(head_organ.take_damage(min(15, volume * 4), 0))
 					H.UpdateDamageIcon(1)
 				H.audible_scream()
 				head_organ.disfigure("burn")
 			else
-				M.take_organ_damage(0, min(15, volume * 4))
+				M.take_organ_damage(min(15, volume * 4), 0)
 
 /datum/reagent/pacid/reaction_obj(var/obj/O, var/volume)
 	if(..())

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -219,8 +219,8 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 		reagents.clear_reagents()
 	if(user)
 		if(user.Adjacent(target))
-			user.visible_message("<span class='warning'>\The [target][ishuman(target) ? "'s [parse_zone(affecting)]" : ""] has been splashed with something by [user]!</span>",
-								"<span class='notice'>You splash [amount > 0 ? "some of " : ""]the solution onto \the [target][ishuman(target) ? "'s [parse_zone(affecting)]" : ""].</span>")
+			user.visible_message("<span class='warning'>\The [target] has been splashed with something by [user]!</span>",
+			                     "<span class='notice'>You splash the solution onto \the [target].</span>")
 
 //Define this wrapper as well to allow for proc overrides eg. for frying pan
 /obj/item/weapon/reagent_containers/proc/container_splash_sub(var/datum/reagents/reagents, var/atom/target, var/amount, var/mob/user = null)

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -154,7 +154,7 @@
 		//The reagents in the bottle splash all over the target, thanks for the idea Nodrak
 		if(src.reagents)
 			for(var/mob/O in viewers(user, null))
-				O.show_message(text("<span class='bnotice'>The contents of \the [smashtext][src] splashes all over [M][ishuman(M) ? "'s [parse_zone(affecting)]" : ""]!</span>"), 1)
+				O.show_message(text("<span class='bnotice'>The contents of \the [smashtext][src] splashes all over [M]!</span>"), 1)
 			src.reagents.reaction(M, TOUCH, zone_sels = list(user.zone_sel.selecting))
 
 		//Finally, smash the bottle. This kills (del) the bottle.


### PR DESCRIPTION
# Polyacid melts masks again!
[polyacid.webm](https://github.com/vgstation-coders/vgstation13/assets/69739118/154f0900-8681-4525-9ab9-1712b17ee8cb)

## What this does
Reverts a majority of kanef's splash code (limb targetting) changes (#32424) with respect to modern PRs (such as #33591 and  #33371) and adacovsk's dissolvable() changes (#33093). It DOES NOT REVERT the framework for limb targetting, should someone want to code unique effects with it or have a swing at targetted splashes in the future. This PR merely restores the previous behaviors for splashing stuff, ignoring the provided target argument. In gameplay, this is effectively restoring splashing to its pre-kanef 2021 state.

This primarily affects: polyacid, cryo tubes, chemsmoke grenades, getting splashed with stuff (200u water/potass reaction to instantly gib people who forgot to wear a mask). There may be additional unlisted effects! While I did some testing, ss13 is a robust game with plenty of FEATURES that I'm possibly unaware of. Please report any issues you come across.

## Why it's good
people will stop complaining that pacid doesn't remove masks and medical doctors will actually have to take off cryo patient clothes

Fixes #33039, Fixes #32732.

## Future PR Ideas
- Change polyacid/sulfuric acid to burn damage. Highly requested, but unatomic so was not included in this PR.
- Fix smoke effects hitting people 10 times a tick or more, leading to those laggy scream effects/text spams, and making a normal 15-damage-on-splash chemical crush people with 800+ brute damage in seconds.
- Fix adacovsk's dissolvable() change so that instead of returning (FALSE, PACID, WATER)(????) and checking the return value in the calling function, you can instead call dissolvable(reagent) and it will return (TRUE, FALSE) based on the reagent provided. This allows for a more robust list of dissolving chemicals instead of just two (and only one at a time you can't have something that dissolves in both PACID and WATER).

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Restored original pre-2021 splash code.
 * rscdel: Polyacid smoke and splashes no longer affect living creatures that aren't standard human-like mobs or monkies. Silicons are once again immune!
 * bugfix: Polyacid now melts masks again when you splash someone.
 * bugfix: Cryo tubes once again require you to fully strip your patient for maximum effect. Mask and helmet aren't good enough anymore!
 * bugfix: This extends to smoke effects, more clothing will once again provide additional protection from most chemical smokes.

[bugfix][gameplay][tested][balance]