### PR TITLE
Make scrubs plural

### DIFF
--- a/code/modules/clothing/under/jobs/medsci.dm
+++ b/code/modules/clothing/under/jobs/medsci.dm
@@ -186,7 +186,7 @@
 
 /obj/item/clothing/under/rank/medical/blue
 	name = "medical scrubs"
-	desc = "They're made of a special fiber that provides minor protection against biohazards. These in are baby blue."
+	desc = "They're made of a special fiber that provides minor protection against biohazards. These are in baby blue."
 	icon_state = "scrubsblue"
 	gender = PLURAL
 	_color = "scrubsblue"

--- a/code/modules/clothing/under/jobs/medsci.dm
+++ b/code/modules/clothing/under/jobs/medsci.dm
@@ -186,16 +186,18 @@
 
 /obj/item/clothing/under/rank/medical/blue
 	name = "medical scrubs"
-	desc = "It's made of a special fiber that provides minor protection against biohazards. This one is in baby blue."
+	desc = "They're made of a special fiber that provides minor protection against biohazards. These in are baby blue."
 	icon_state = "scrubsblue"
+	gender = PLURAL
 	_color = "scrubsblue"
 	clothing_flags = ONESIZEFITSALL
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
 
 /obj/item/clothing/under/rank/medical/green
 	name = "medical scrubs"
-	desc = "It's made of a special fiber that provides minor protection against biohazards. This one is in dark green."
+	desc = "They're made of a special fiber that provides minor protection against biohazards. These are in dark green."
 	icon_state = "scrubsgreen"
+	gender = PLURAL
 	_color = "scrubsgreen"
 	clothing_flags = ONESIZEFITSALL
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
@@ -203,8 +205,9 @@
 
 /obj/item/clothing/under/rank/medical/purple
 	name = "medical scrubs"
-	desc = "It's made of a special fiber that provides minor protection against biohazards. This one is in deep purple."
+	desc = "They're made of a special fiber that provides minor protection against biohazards. These are in deep purple."
 	icon_state = "scrubspurple"
+	gender = PLURAL
 	_color = "scrubspurple"
 	clothing_flags = ONESIZEFITSALL
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)


### PR DESCRIPTION
This makes it so that medical scrubs are plural, so that it says:
>He is wearing some medical scrubs.

instead of
>He is wearing a medical scrubs.

which I think seems to make more sense.

:cl:
 * bugfix: Medical scrubs are referred to in plural.
