### PR TITLE
roboticists now get access to ringer with rnd deskbell frequency

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -287,6 +287,13 @@
 	default_cartridge = /obj/item/weapon/cartridge/robotics
 	icon_state = "pda-robot"
 
+/obj/item/device/pda/roboticist/New()
+	starting_apps += /datum/pda_app/ringer
+	..()
+	var/datum/pda_app/ringer/app = locate(/datum/pda_app/ringer) in applications
+	if(app)
+		app.frequency = deskbell_freq_rnd
+
 /obj/item/device/pda/librarian
 	name = "Librarian PDA"
 	icon_state = "pda-libb"


### PR DESCRIPTION
Brings them in line with the rest of science. Useful for when you're the lone member of research.

[qol]

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Roboticists now have access to PDA ringer app, set to RnD's deskbell frequency.