### PR TITLE
Fixes admins being unable to force rulesets if all of their usual requirements aren't met

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -562,8 +562,8 @@ var/stacking_limit = 90
 					current_rules += new_rule
 				return 1
 		else if (forced)
-			message_admins("DYNAMIC MODE: The ruleset couldn't be executed due to lack of eligible players.")
-			log_admin("DYNAMIC MODE: The ruleset couldn't be executed due to lack of eligible players.")
+			message_admins("DYNAMIC MODE: The ruleset couldn't be executed for the above reason.")	//reason provided in the ruleset's ready()
+			log_admin("DYNAMIC MODE: The ruleset couldn't be executed for the above reason.")		//generally limited to cases where the antag lacks a necessary spawn point
 	return 0
 
 /datum/gamemode/dynamic/process()

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -111,6 +111,8 @@
 		log_admin("Dynamic Mode: [name] was prevented from firing because rulesets are disabled.")
 		return FALSE
 	if (required_candidates > candidates.len)		//IMPORTANT: If ready() returns 1, that means execute() should never fail!
+		log_admin("Cannot accept [name] ruleset, lack of eligible players.")
+		message_admins("Cannot accept [name] ruleset, lack of eligible players.")
 		return FALSE
 	return TRUE
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -294,7 +294,11 @@
 	for(var/mob/player in mode.living_players)
 		if (player.mind.assigned_role in command_positions)
 			head_check++
-	return (head_check >= required_heads)
+	if (head_check < required_heads)
+		log_admin("Cannot accept Provocateur ruleset, not enough heads of staff.")
+		message_admins("Cannot accept Provocateur ruleset, not enough heads of staff.")
+		return FALSE
+	return TRUE
 
 /datum/dynamic_ruleset/latejoin/provocateur/execute()
 	var/mob/M = pick(assigned)
@@ -326,6 +330,8 @@
 
 
 /datum/dynamic_ruleset/latejoin/time_agent/ready(var/forced=0)
+	if (forced)
+		return ..()
 	var/player_count = mode.living_players.len
 	var/antag_count = mode.living_antags.len
 	var/max_traitors = round(player_count / 10) + 1

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -473,7 +473,6 @@
 	if(forced)
 		required_heads = 1
 		required_candidates = 1
-		return ..()
 	if (find_active_faction_by_type(/datum/faction/revolution))
 		return FALSE //Never send 2 rev types
 	if(!..())
@@ -484,7 +483,11 @@
 			continue
 		if(player.mind.assigned_role in command_positions)
 			head_check++
-	return (head_check >= required_heads)
+	if (head_check < required_heads)
+		log_admin("Cannot accept Revolutionary Squad ruleset, not enough heads of staff.")
+		message_admins("Cannot accept Revolutionary Squad ruleset, not enough heads of staff.")
+		return FALSE
+	return TRUE
 
 
 //////////////////////////////////////////////

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -472,6 +472,7 @@
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/revsquad/ready(var/forced = 0)
 	if(forced)
 		required_heads = 1
+		required_candidates = 1
 		return ..()
 	if (find_active_faction_by_type(/datum/faction/revolution))
 		return FALSE //Never send 2 rev types
@@ -669,6 +670,8 @@
 	flags = MINOR_RULESET
 
 /datum/dynamic_ruleset/midround/from_ghosts/catbeast/ready(var/forced=0)
+	if (forced)
+		return ..()
 	if(mode.midround_threat>50) //We're threatening enough!
 		message_admins("Rejected catbeast ruleset, [mode.midround_threat] threat was over 50.")
 		return FALSE
@@ -703,6 +706,7 @@
 	required_candidates = vox_cap[indice_pop]
 	if (forced)
 		required_candidates = 1
+		return ..()
 	if (required_candidates > (dead_players.len + list_observers.len))
 		return 0
 	. = ..()
@@ -821,7 +825,6 @@
 	var/list/vents = list()
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/xenomorphs/ready()
-	..()
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in atmos_machines)
 		if(temp_vent.loc.z == map.zMainStation && !temp_vent.welded && temp_vent.network)
 			if(temp_vent.network.normal_members.len > 50)	//Stops Aliens getting stuck in small networks. See: Security, Virology
@@ -829,9 +832,11 @@
 
 
 	if (vents.len == 0)
+		log_admin("A suitable vent couldn't be found for alien larva. That's bad.")
 		message_admins("A suitable vent couldn't be found for alien larva. That's bad.")
-		return
-	return 1
+		return FALSE
+
+	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/xenomorphs/generate_ruleset_body(var/mob/applicant)
 	var/obj/vent = pick(vents)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -225,6 +225,8 @@
 			living_players -= player//we don't autotator people with roles already
 
 /datum/dynamic_ruleset/midround/autotraitor/ready(var/forced = 0)
+	if (forced)
+		return ..()
 	var/player_count = mode.living_players.len
 	var/antag_count = mode.living_antags.len
 	var/max_traitors = round(player_count / 10) + 1
@@ -324,6 +326,8 @@
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/raginmages/ready(var/forced=0)
+	if (forced)
+		return ..()
 	if(locate(/datum/dynamic_ruleset/roundstart/cwc) in mode.executed_rules)
 		message_admins("Rejected Ragin' Mages as there was a Civil War.")
 		return 0 //This is elegantly skipped by specific ruleset.
@@ -367,9 +371,7 @@
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/nuclear/ready(var/forced = 0)
 	if (forced)
 		required_candidates = 1
-	return ..()
-
-/datum/dynamic_ruleset/midround/from_ghosts/faction_based/nuclear/ready(var/forced = 0)
+		return ..()
 	if(locate(/datum/dynamic_ruleset/roundstart/nuclear) in mode.executed_rules)
 		return 0 //Unavailable if nuke ops were already sent at roundstart
 	var/indice_pop = min(10,round(living_players.len/5) + 1)
@@ -470,6 +472,7 @@
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/revsquad/ready(var/forced = 0)
 	if(forced)
 		required_heads = 1
+		return ..()
 	if (find_active_faction_by_type(/datum/faction/revolution))
 		return FALSE //Never send 2 rev types
 	if(!..())
@@ -504,6 +507,8 @@
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/midround/from_ghosts/ninja/ready(var/forced=0)
+	if (forced)
+		return ..()
 	var/player_count = mode.living_players.len
 	var/antag_count = mode.living_antags.len
 	var/max_traitors = round(player_count / 10) + 1
@@ -544,6 +549,8 @@
 	flags = MINOR_RULESET
 
 /datum/dynamic_ruleset/midround/from_ghosts/rambler/ready(var/forced=0)
+	if (forced)
+		return ..()
 	if(mode.executed_rules.len <= 0)
 		return FALSE
 		//We have nothing to investigate!
@@ -578,6 +585,8 @@
 	logo = "time-logo"
 
 /datum/dynamic_ruleset/midround/from_ghosts/time_agent/ready(var/forced=0)
+	if (forced)
+		return ..()
 	var/player_count = mode.living_players.len
 	var/antag_count = mode.living_antags.len
 	var/max_traitors = round(player_count / 10) + 1


### PR DESCRIPTION
Issue was caused by #34087 essentially merging the acceptable() and ready() procs even though they each had their distinct purpose.

:cl:
* bugfix: Fixed admins being unable to force rulesets if all of their usual requirements weren't met.