### PR TITLE
Fixes the faction objectives "Fail." and "[faction] has failed" not being red on the scoreboard

### DIFF
--- a/html/browser/common.css
+++ b/html/browser/common.css
@@ -211,6 +211,11 @@ h4
 	color: #272727;
 }
 
+.red
+{
+	color: #FF0000;
+}
+
 .notice
 {
 	position: relative;


### PR DESCRIPTION
![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/9589d13b-83e0-4d30-a74d-4e468d58d618)

Issue caused by #22914, swapping lots of "font color = red" to "span class = red" for some reason.