### PR TITLE
Fixes blank roles often appearing in the admin antag panel and on the round end scoreboard when Summon Survivors is used

### DIFF
--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -39,15 +39,7 @@
 
 
 
-/mob/living/carbon/human/proc/equip_survivor(var/R)
-	var/summon_type
-	if(istype(R,/datum/role))
-		var/datum/role/surv = R
-		summon_type = surv.type
-	else if(ispath(R))
-		summon_type = R
-	else
-		return
+/mob/living/carbon/human/proc/equip_survivor(var/summon_type)
 	switch (summon_type)
 		if (/datum/role/survivor/crusader)
 			return equip_swords(R)

--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -22,14 +22,15 @@
 		if(H.stat == DEAD || !(H.client) || iswizard(H))
 			continue
 
+		H.equip_survivor(survivor_type)
+
 		if (prob(65))
-			H.equip_survivor(survivor_type)
 			continue
 
-		var/datum/role/R = new survivor_type()
-		H.equip_survivor(R)
+		var/datum/role/R = survivor_type
 
-		if (!(isrole(R.id, H)))
+		if (!(isrole(initial(R.id), H)))
+			R = new survivor_type()
 			R.AssignToRole(H.mind)
 			R.Greet(GREET_RIGHTANDWRONG)
 			R.OnPostSetup()

--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -22,15 +22,15 @@
 		if(H.stat == DEAD || !(H.client) || iswizard(H))
 			continue
 
-		H.equip_survivor(survivor_type)
-
 		if (prob(65))
+			H.equip_survivor(survivor_type)
 			continue
 
 		var/datum/role/R = survivor_type
 
 		if (!(isrole(initial(R.id), H)))
 			R = new survivor_type()
+			H.equip_survivor(R)
 			R.AssignToRole(H.mind)
 			R.Greet(GREET_RIGHTANDWRONG)
 			R.OnPostSetup()
@@ -39,7 +39,15 @@
 
 
 
-/mob/living/carbon/human/proc/equip_survivor(var/summon_type)
+/mob/living/carbon/human/proc/equip_survivor(var/R)
+	var/summon_type
+	if(istype(R,/datum/role))
+		var/datum/role/surv = R
+		summon_type = surv.type
+	else if(ispath(R))
+		summon_type = R
+	else
+		return
 	switch (summon_type)
 		if (/datum/role/survivor/crusader)
 			return equip_swords(R)


### PR DESCRIPTION

![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/b21dbd97-ae6a-4c81-a287-48cb45944c51)


:cl:
* bugfix: Fixed blank roles often appearing in the admin antag panel and on the round end scoreboard when Summon Survivors is used