### PR TITLE
fix silicon interactions with autogibber, allow silicons to be gibbed (ONLY in admin-spawned autogibber)

### DIFF
--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -8,7 +8,7 @@
 	anchored = 1
 	var/operating = 0 //Is it on?
 	var/dirty = 0 // Does it need cleaning?
-	var/gibtime = 20 // Time from starting until meat appears
+	var/gibtime = 40 // Time from starting until meat appears
 	var/mob/living/occupant // Mob who has been put inside
 	var/opened = 0.0
 	var/auto = FALSE
@@ -314,6 +314,7 @@
 	name = "autogibber"
 	desc = "Keep far, far away."
 	icon_state = "autogibber"
+	gibtime = 20
 	auto = TRUE
 
 /obj/machinery/gibber/autogibber/New()

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -138,13 +138,10 @@
 		update_icon()
 
 /obj/machinery/gibber/MouseDropTo(mob/target, mob/user)
-	if(target != user && !issilicon(target) || !istype(user, /mob/living/carbon/human) || user.incapacitated() || get_dist(user, src) > 1)
-		return 		/* We only want silicons and the people dragging themselves into the gibber to get this far. */
+	if(target != user || !istype(user, /mob/living/carbon/human) || user.incapacitated() || get_dist(user, src) > 1)
+		return
 	if(!anchored)
 		to_chat(user, "<span class='warning'>[src] must be anchored first!</span>")
-		return
-	if(target.anchored)
-		to_chat(user, "<span class='warning'>\The [target] must be anchored first!</span>")
 		return
 	if(src.occupant)
 		to_chat(user, "<span class='warning'>[src] is full! Empty it first.</span>")
@@ -154,30 +151,22 @@
 		return
 
 	src.add_fingerprint(user)
-	if(target == user)
-		user.visible_message("<span class='warning'>[user] starts climbing into \the [src].</span>", \
-			"<span class='warning'>You start climbing into \the [src].</span>", \
-			drugged_message = "<span class='warning'>[user] starts dancing like a ballerina!</span>")
-	else 
-		user.visible_message("<span class='warning'>[user] starts shoving \the [target] into the [src]!</span>", \
-			"<span class='warning'>You start shoving \the [target] into \the [src]!</span>", \
-			drugged_message = "<span class='warning'>[user] starts doing the tango with \the [target]!</span>")
-	var/drag_delay = issilicon(target) ? 120 : 30
-	if(do_after(user, src, drag_delay) && user && !occupant && !isnull(src.loc))
-		if(target == user)
-			user.visible_message("<span class='warning'>[user] climbs into \the [src]</span>", \
-				"<span class='warning'>You climb into \the [src].</span>", \
-				drugged_message = "<span class='warning'>\The [src] consumes [user]!</span>")
-		else
-			user.visible_message("<span class='warning'>[user] has crammed \the [target] into \the [src]</span>", \
-				"<span class='warning'>You cram \the [target] into \the [src].</span>", \
-				drugged_message = "<span class='warning'>\The [src] consumes \the [target]!</span>")
 
-		if(target.client)
-			target.client.perspective = EYE_PERSPECTIVE
-			target.client.eye = src
-		target.forceMove(src)
-		src.occupant = target
+	user.visible_message("<span class='warning'>[user] starts climbing into the [src].</span>", \
+		"<span class='warning'>You start climbing into the [src].</span>", \
+		drugged_message = "<span class='warning'>[user] starts dancing like a ballerina!</span>")
+
+	if(do_after(user, src, 30) && user && !occupant && !isnull(src.loc))
+
+		user.visible_message("<span class='warning'>[user] climbs into the [src]</span>", \
+			"<span class='warning'>You climb into the [src].</span>", \
+			drugged_message = "<span class='warning'>[src] consumes [user]!</span>")
+
+		if(user.client)
+			user.client.perspective = EYE_PERSPECTIVE
+			user.client.eye = src
+		user.forceMove(src)
+		src.occupant = user
 		update_icon()
 
 /obj/machinery/gibber/verb/eject()

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -306,8 +306,7 @@
 
 		src.occupant.death(1)
 		src.occupant.ghostize(0)
-		spawn(10)
-			QDEL_NULL(src.occupant)
+		QDEL_NULL(src.occupant)
 
 //auto-gibs anything that bumps into it
 /obj/machinery/gibber/autogibber

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -138,10 +138,13 @@
 		update_icon()
 
 /obj/machinery/gibber/MouseDropTo(mob/target, mob/user)
-	if(target != user || !istype(user, /mob/living/carbon/human) || user.incapacitated() || get_dist(user, src) > 1)
-		return
+	if(target != user && !issilicon(target) || !istype(user, /mob/living/carbon/human) || user.incapacitated() || get_dist(user, src) > 1)
+		return 		/* We only want silicons and the people dragging themselves into the gibber to get this far. */
 	if(!anchored)
 		to_chat(user, "<span class='warning'>[src] must be anchored first!</span>")
+		return
+	if(target.anchored)
+		to_chat(user, "<span class='warning'>\The [target] must be anchored first!</span>")
 		return
 	if(src.occupant)
 		to_chat(user, "<span class='warning'>[src] is full! Empty it first.</span>")
@@ -151,22 +154,30 @@
 		return
 
 	src.add_fingerprint(user)
+	if(target == user)
+		user.visible_message("<span class='warning'>[user] starts climbing into \the [src].</span>", \
+			"<span class='warning'>You start climbing into \the [src].</span>", \
+			drugged_message = "<span class='warning'>[user] starts dancing like a ballerina!</span>")
+	else 
+		user.visible_message("<span class='warning'>[user] starts shoving \the [target] into the [src]!</span>", \
+			"<span class='warning'>You start shoving \the [target] into \the [src]!</span>", \
+			drugged_message = "<span class='warning'>[user] starts doing the tango with \the [target]!</span>")
+	var/drag_delay = issilicon(target) ? 120 : 30
+	if(do_after(user, src, drag_delay) && user && !occupant && !isnull(src.loc))
+		if(target == user)
+			user.visible_message("<span class='warning'>[user] climbs into \the [src]</span>", \
+				"<span class='warning'>You climb into \the [src].</span>", \
+				drugged_message = "<span class='warning'>\The [src] consumes [user]!</span>")
+		else
+			user.visible_message("<span class='warning'>[user] has crammed \the [target] into \the [src]</span>", \
+				"<span class='warning'>You cram \the [target] into \the [src].</span>", \
+				drugged_message = "<span class='warning'>\The [src] consumes \the [target]!</span>")
 
-	user.visible_message("<span class='warning'>[user] starts climbing into the [src].</span>", \
-		"<span class='warning'>You start climbing into the [src].</span>", \
-		drugged_message = "<span class='warning'>[user] starts dancing like a ballerina!</span>")
-
-	if(do_after(user, src, 30) && user && !occupant && !isnull(src.loc))
-
-		user.visible_message("<span class='warning'>[user] climbs into the [src]</span>", \
-			"<span class='warning'>You climb into the [src].</span>", \
-			drugged_message = "<span class='warning'>[src] consumes [user]!</span>")
-
-		if(user.client)
-			user.client.perspective = EYE_PERSPECTIVE
-			user.client.eye = src
-		user.forceMove(src)
-		src.occupant = user
+		if(target.client)
+			target.client.perspective = EYE_PERSPECTIVE
+			target.client.eye = src
+		target.forceMove(src)
+		src.occupant = target
 		update_icon()
 
 /obj/machinery/gibber/verb/eject()

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -11,6 +11,7 @@
 	var/gibtime = 40 // Time from starting until meat appears
 	var/mob/living/occupant // Mob who has been put inside
 	var/opened = 0.0
+	var/auto = FALSE
 	use_power = MACHINE_POWER_USE_IDLE
 	idle_power_usage = 20
 	active_power_usage = 500
@@ -102,6 +103,9 @@
 		return
 	else
 		src.startgibbing(user)
+
+/obj/machinery/gibber/attack_ai(mob/user as mob)
+	return
 
 // OLD /obj/machinery/gibber/attackby(obj/item/weapon/grab/G as obj, mob/user as mob)
 /obj/machinery/gibber/proc/handleGrab(obj/item/weapon/grab/G as obj, mob/user as mob)
@@ -221,6 +225,7 @@
 	var/obj/item/weapon/reagent_containers/food/snacks/meat/allmeat[totalslabs]
 	var/obj/effect/decal/cleanable/blood/gibs/allgibs[totalslabs]
 	playsound(src, 'sound/machines/blender.ogg', 50, 1)
+	var/list/unused_components = direct_subtypesof(/obj/item/robot_parts/robot_component)
 	for (var/i=1 to totalslabs)
 		//first we spawn the meat
 		var/obj/item/weapon/newmeat
@@ -229,8 +234,15 @@
 		else if(ispath(occupant.meat_type, /obj/item/weapon/reagent_containers))
 			newmeat = new occupant.meat_type(src, occupant)
 			newmeat.reagents.add_reagent (NUTRIMENT, sourcenutriment / totalslabs) // Thehehe. Fat guys go first
+		else if(issilicon(occupant))
+			if(unused_components.len)
+				var/part_chosen = pick(unused_components)
+				unused_components -= part_chosen
+				newmeat = new part_chosen
+			else
+				log_debug("Error: No unused components left in \the [src]'s gib loop for the following silicon: [occupant.real_name]!")
 		else
-			newmeat = new occupant.meat_type()
+			newmeat = new occupant.meat_type
 
 		if(src.occupant.reagents)
 			src.occupant.reagents.trans_to (newmeat, round (sourcetotalreagents / totalslabs, 1)) // Transfer all the reagents from the
@@ -245,16 +257,18 @@
 
 		//then we spawn the gib splatter
 		var/obj/effect/decal/cleanable/blood/gibs/newgib
-		if (isalien(occupant)||istype(occupant, /mob/living/simple_animal/hostile/alien))//alien get their own custom gibs
+		if(isalien(occupant)||istype(occupant, /mob/living/simple_animal/hostile/alien))//alien get their own custom gibs
 			newgib = spawngib(/obj/effect/decal/cleanable/blood/gibs/xeno,src,ALIEN_FLESH,ALIEN_BLOOD,occupant.virus2,null)
-		else if (ishuman(occupant))
+		else if(ishuman(occupant))
 			var/mob/living/carbon/human/H = occupant
 			newgib = spawngib(/obj/effect/decal/cleanable/blood/gibs,src,H.species.flesh_color,H.species.blood_color,H.virus2,H.dna)
+		else if(issilicon(occupant))
+			newgib = spawngib(/obj/effect/decal/cleanable/blood/gibs/robot,src,ROBOT_OIL,ROBOT_OIL,occupant.virus2,occupant.dna)
 		else
 			newgib = spawngib(/obj/effect/decal/cleanable/blood/gibs,src,DEFAULT_FLESH,DEFAULT_BLOOD,occupant.virus2,occupant.dna)
 		allgibs[i] = newgib
 
-	src.occupant.attack_log += "\[[time_stamp()]\] Was gibbed by <B>[key_name(user)]</B>" //One shall not simply gib a mob unnoticed!
+	src.occupant.attack_log += "\[[time_stamp()]\] Was [auto ? "auto-" : ""]gibbed by <B>[key_name(user)]</B>" //One shall not simply gib a mob unnoticed!
 	user.attack_log += "\[[time_stamp()]\] Gibbed <B>[key_name(src.occupant)]</B>"
 	log_attack("<B>[key_name(user)]</B> gibbed <B>[key_name(src.occupant)]</B>")
 
@@ -284,13 +298,12 @@
 		src.operating = 0
 		update_icon()
 
-
-
 //auto-gibs anything that bumps into it
 /obj/machinery/gibber/autogibber
 	name = "autogibber"
 	desc = "Keep far, far away."
 	icon_state = "autogibber"
+	auto = TRUE
 
 /obj/machinery/gibber/autogibber/New()
 	..()
@@ -311,73 +324,12 @@
 		M.visible_message("<span class='warning'>[M] is forcefully sucked into \the [src]!</span>", \
 			drugged_message = "<span class='warning'>[M] suddenly vanishes! How did \he do that?</span>")
 		M.forceMove(src)
-		startautogibbing(M)
+		startgibbing(M)
 
-/obj/machinery/gibber/autogibber/proc/startautogibbing(mob/living/victim as mob)
-	if(!victim)
-		visible_message("<span class='warning'>You hear a loud metallic grinding sound.</span>", \
-			drugged_message = "<span class='warning'>You faintly hear a guitar solo.</span>")
-		return
-	use_power(1000)
-	visible_message("<span class='warning'>You hear a loud squelchy grinding sound.</span>", \
-		drugged_message = "<span class='warning'>You hear a band performance.</span>")
-	var/sourcenutriment = victim.nutrition / 15
-	var/sourcetotalreagents
-	if(victim.reagents)
-		sourcetotalreagents = victim.reagents.total_volume
-
-	var/totalslabs = victim.size
-
-	var/obj/item/weapon/reagent_containers/food/snacks/allmeat[totalslabs]
-	for (var/i=1 to totalslabs)
-		var/obj/item/weapon/reagent_containers/food/snacks/newmeat = null
-		if(victim.arcanetampered || src.arcanetampered)
-			newmeat = new /obj/item/weapon/reagent_containers/food/snacks/tofu(src)
-		else if(istype(victim, /mob/living/carbon/human))
-			newmeat = new victim.meat_type(src, victim)
-		else
-			newmeat = victim.drop_meat(src)
-
-		if(newmeat==null)
-			return
-
-		if (newmeat.reagents)//don't want to try and transfer reagents to bones, diamonds, and other non-meat meats
-			newmeat.reagents.add_reagent (NUTRIMENT, sourcenutriment / totalslabs) // Thehehe. Fat guys go first
-
-			if(victim.reagents)
-				victim.reagents.trans_to (newmeat, round (sourcetotalreagents / totalslabs, 1)) // Transfer all the reagents from them
-
-		allmeat[i] = newmeat
-
-	victim.attack_log += "\[[time_stamp()]\] Was auto-gibbed by <B>[src]</B>" //One shall not simply gib a mob unnoticed!
-	log_attack("<B>[src]</B> auto-gibbed <B>[key_name(victim)]</B>")
-	victim.death(1)
-	if(victim.client && (ishuman(victim) || ismonkey(victim) || isalien(victim)))
-		var/obj/item/organ/internal/brain/B = new(src.loc)
-		B.transfer_identity(victim)
-		var/turf/Tx = locate(src.x - 2, src.y, src.z)
-		B.forceMove(src.loc)
-		B.throw_at(Tx,2,1)
-	else
-		victim.ghostize(0)
-	playsound(src, 'sound/effects/gib2.ogg', 50, 1)
-	for (var/i=1 to totalslabs)
-		var/obj/item/meatslab = allmeat[i]
-		var/turf/Tx = locate(src.x - i, src.y, src.z)
-		meatslab.forceMove(src.loc)
-		meatslab.throw_at(Tx,i,1)
-		var/obj/effect/decal/cleanable/blood/gibs/newgib
-		if (!Tx.density)
-			if (isalien(victim)||istype(occupant, /mob/living/simple_animal/hostile/alien))//alien get their own custom gibs
-				newgib = spawngib(/obj/effect/decal/cleanable/blood/gibs/xeno,get_turf(src),ALIEN_FLESH,ALIEN_BLOOD,victim.virus2,null)
-			else if (ishuman(victim))
-				var/mob/living/carbon/human/H = victim
-				newgib = spawngib(/obj/effect/decal/cleanable/blood/gibs,get_turf(src),H.species.flesh_color,H.species.blood_color,H.virus2,H.dna)
-			else
-				newgib = spawngib(/obj/effect/decal/cleanable/blood/gibs,get_turf(src),DEFAULT_FLESH,DEFAULT_BLOOD,victim.virus2,victim.dna)
-			newgib.anchored = FALSE
-			newgib.throw_at(Tx,2,1)//will cover hit humans in blood
-	qdel(victim)
+/obj/machinery/gibber/autogibber/startgibbing(mob/living/victim as mob)
+	if(victim)
+		occupant = victim
+		..()
 
 /obj/machinery/gibber/npc_tamper_act(mob/living/L)
 	attack_hand(L)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -3,6 +3,7 @@
 	voice_name = "synthesized voice"
 	can_butcher = 0
 	mob_property_flags = MOB_ROBOTIC
+	meat_type = null
 
 	var/flashed = 0
 	var/syndicate = 0


### PR DESCRIPTION
## What this does
- Fixes #34805 - Silicons clicking the autogibber will no longer be teleported to it and instantly gibbed.
- Fixes silicons in an autogibber not dying/having anything happen to them.
- Silicons being gibbed will spew out oil and random robot parts. This applies to the kitchen gibber, too!
- Silicons destroyed via gibber will still have their MMI's pop out like normal.
- Yes, AI's can be gibbed. Because that sounds funny.
![vkmoLyArYC](https://github.com/vgstation-coders/vgstation13/assets/26285377/5e9e6d04-9355-4fe7-af6a-d7014ca6e611)
- Fixes silicons having a meat type assigned... for some reason...

~~I will seperate this into two PR's (one for bugfix and one for allowing silicon gibbing) if these changes prove to be controversial.
Yes, I got overzealous again and committed them to the same branch again like a dummie.~~

*__I'm gonna separate this into two PR's when I'm home from work since this will probably be contentious. This PR will not have silicon gibbing in the kitchen gibber.__*

Update 7/28 - Okay, this PR is purely a fix now. Silicons can be gibbed in the autogibber since it's an admin-spawned machine, but not the normal gibber.
See this comment for additional details on specifics: https://github.com/vgstation-coders/vgstation13/pull/34808#issuecomment-1656555418

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed bug with silicons that click an autogibber (no matter how far away) being teleported straight into it and stuck forever.
 * tweak: Once auto-gibbing has started, it now takes 3 seconds instead of 4 to complete. (normal gibber remains untouched)