### PR TITLE
Bloodstain color mixing

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -716,14 +716,13 @@ its easier to just keep the beam vertical.
 /atom/proc/clear_luminol(var/atom/A)
 	return had_blood
 
-
 //returns 1 if made bloody, returns 0 otherwise
 /atom/proc/add_blood(var/mob/living/carbon/human/M)
 	.=TRUE
 	if(!M)//if the blood is of non-human source
 		if(!blood_DNA || !istype(blood_DNA, /list))
 			blood_DNA = list()
-		blood_color = DEFAULT_BLOOD
+		blood_color = blood_DNA.len ? BlendRGB(blood_color, DEFAULT_BLOOD, 0.5) : DEFAULT_BLOOD //mix new color into existing blood_color if applicable
 		had_blood = TRUE
 		return TRUE
 	if (!( istype(M, /mob/living/carbon/human) ))
@@ -732,13 +731,14 @@ its easier to just keep the beam vertical.
 		M.dna = new /datum/dna(null)
 		M.dna.real_name = M.real_name
 	M.check_dna_integrity()
-	if (!( src.flags & FPRINT))
+	if (!(flags & FPRINT))
 		return FALSE
 	if(!blood_DNA || !istype(blood_DNA, /list))	//if our list of DNA doesn't exist yet (or isn't a list) initialise it.
 		blood_DNA = list()
-	blood_color = DEFAULT_BLOOD
 	if (M.species)
-		blood_color = M.species.blood_color
+		blood_color = blood_DNA.len ? BlendRGB(blood_color, M.species.blood_color, 0.5) : M.species.blood_color
+	else
+		blood_color = blood_DNA.len ? BlendRGB(blood_color, DEFAULT_BLOOD, 0.5) : DEFAULT_BLOOD
 	return TRUE
 
 //this proc exists specifically for cases where the mob that originated the blood (aka the "donor") might not exist anymore, leading to bugs galore
@@ -752,8 +752,7 @@ its easier to just keep the beam vertical.
 	if(!istype(blood_DNA, /list))	//if our list of DNA doesn't exist yet (or isn't a list) initialise it.
 		blood_DNA = list()
 
-	blood_color = blood_data["blood_colour"]
-
+	blood_color = blood_DNA.len ? BlendRGB(blood_color, blood_data["blood_colour"], 0.5) : blood_data["blood_colour"] //mix new color into existing blood_color if applicable
 	return TRUE
 
 /atom/proc/add_vomit_floor(mob/living/carbon/M, toxvomit = 0, active = 0, steal_reagents_from_mob = 1)

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -200,12 +200,14 @@ var/list/infected_cleanables = list()
 		else
 			S.blood_overlay = blood_overlays["[S.type][S.icon_state]"]
 
-		S.blood_overlay.color = basecolor
-		S.overlays += S.blood_overlay
-		S.blood_color=basecolor
-
 		if(!S.blood_DNA)
 			S.blood_DNA = list()
+
+		var/newcolor = (S.blood_color && S.blood_DNA.len) ? BlendRGB(S.blood_color, basecolor, 0.5) : basecolor
+		S.blood_overlay.color = newcolor
+		S.overlays += S.blood_overlay
+		S.blood_color = newcolor
+
 		if(blood_DNA)
 			S.blood_DNA |= blood_DNA.Copy()
 		perp.update_inv_shoes(1)
@@ -214,11 +216,13 @@ var/list/infected_cleanables = list()
 		perp.track_blood = max(amount, 0, perp.track_blood)                                //Or feet
 		if(!perp.feet_blood_DNA)
 			perp.feet_blood_DNA = list()
+
 		if(!istype(blood_DNA, /list))
 			blood_DNA = list()
 		else
 			perp.feet_blood_DNA |= blood_DNA.Copy()
-		perp.feet_blood_color=basecolor
+
+		perp.feet_blood_color = (perp.feet_blood_color && perp.feet_blood_DNA.len) ? BlendRGB(perp.feet_blood_color, basecolor, 0.5) : basecolor
 
 	amount--
 


### PR DESCRIPTION
This makes it so that bloodstains on items, and footprints, can have their blood colors mixed. So if you step on human gibs, then vox gibs, then robot gibs, the bloodstains on your shoe will be a mix of the three colors and you'll leave footprints of that mixed color tracked around. As bloody hands don't store more than one blood DNA, I kept those as is for now.
The mixing works by blending half with the previous color, and half with the new color.

![bloody](https://github.com/vgstation-coders/vgstation13/assets/7112773/209bbfb2-351a-4791-ac43-9640c55f72cd)

:cl:
 * rscadd: Bloodstains mixed from multiple species have mixed colors.
