### PR TITLE
Fixes the Occult Blood Test reaction not working

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -652,9 +652,11 @@
 	id = "occult_blood_test"
 	required_reagents = list(HOLYSALTS = 5)
 	required_catalysts = list(BLOOD = 5)
+	result = SODIUMCHLORIDE
+	result_amount = 5
 	quiet = TRUE
 
-/datum/chemical_reaction/cultcheck/on_reaction(var/datum/reagents/holder, var/created_volume)
+/datum/chemical_reaction/occult_blood_test/on_reaction(var/datum/reagents/holder, var/created_volume)
 	for(var/datum/reagent/blood/B in holder.reagent_list)
 		var/turf/T = get_turf(holder.my_atom)
 		if ("occult" in B.data)


### PR DESCRIPTION
![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/bbe633a4-f500-461d-a4b0-0fe7979dcd02)


:cl:
* bugfix: The Occult Blood Test chemical reaction finally works properly, after at least 2 years. Adding 5u of holy salts to 5u of the blood of a living cultist will give you an idea of how many cultists are in the world, and on the current Z level. The reaction turns the holy salts back into regular table salt.