### PR TITLE
Blood-stain-related examine fixes

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -443,7 +443,7 @@ its easier to just keep the beam vertical.
 /atom/proc/examine(mob/user, var/size = "", var/show_name = TRUE, var/show_icon = TRUE)
 	//This reformat names to get a/an properly working on item descriptions when they are bloody
 	var/f_name = "\a [src]."
-	if(blood_DNA && blood_DNA.len)
+	if(is_blood_stained())
 		var/stain_text = get_stain_text(FALSE)
 		f_name = "[get_indefinite_article(stain_text, gender)] <span class='danger'><span style='color: [get_stain_text_color()]'>[stain_text]</span></span> [name]!"
 
@@ -1006,7 +1006,9 @@ its easier to just keep the beam vertical.
 		var/stains[0]
 		for (var/this_blood_DNA in blood_DNA)
 			if (this_blood_DNA)
-				stains[get_stain_name(blood_DNA[this_blood_DNA])]++
+				var/stain_name = get_stain_name(blood_DNA[this_blood_DNA])
+				if (stain_name)
+					stains[stain_name]++
 		if (stains.len)
 			for (var/thisstain in stains)
 				. += "[. ? "and-" : ""][thisstain]-"
@@ -1018,7 +1020,7 @@ its easier to just keep the beam vertical.
 	if (findtextEx("A+A-B+B-AB+AB-O+O-", stain_type))
 		return "blood"
 	else if (stain_type == "N/A")
-		return "blood" //call everything unspecified "blood" just in case
+		return
 	else
 		return stain_type
 
@@ -1031,3 +1033,8 @@ its easier to just keep the beam vertical.
 	if (colored_text && blood_color)
 		stain_text = "<span style='color: [get_stain_text_color()]'>[stain_text]</span>"
 	return indef_art + " " + stain_text
+
+/atom/proc/is_blood_stained()
+	if (blood_color && blood_DNA && blood_DNA.len)
+		return TRUE
+	return FALSE

--- a/code/game/objects/structures/mannequin.dm
+++ b/code/game/objects/structures/mannequin.dm
@@ -292,7 +292,7 @@
 	var/msg = ""
 
 	for(var/obj/item/I in held_items)
-		if(I.blood_DNA && I.blood_DNA.len)
+		if(I.is_blood_stained())
 			msg += "<span class='warning'>It's holding [bicon(I)] [I.a_stained()] [I.name] in its [get_index_limb_name(is_holding_item(I))]!</span>\n"
 		else
 			msg += "It's holding [bicon(I)] \a [I] in its [get_index_limb_name(is_holding_item(I))].\n"
@@ -320,7 +320,7 @@
 				if(SLOT_MANNEQUIN_EARS)
 					slot_examine = " on its ears"
 
-			if(clothToExamine.blood_DNA && clothToExamine.blood_DNA.len)
+			if(clothToExamine.is_blood_stained())
 				msg += "<span class='warning'>It's wearing [bicon(clothToExamine)] [clothToExamine.a_stained()] [clothToExamine][slot_examine]![clothToExamine.description_accessories()]</span>\n"
 			else
 				msg += "It's wearing [bicon(clothToExamine)] \a [clothToExamine][slot_examine].[clothToExamine.description_accessories()] \n"

--- a/code/modules/mob/living/carbon/complex/examine.dm
+++ b/code/modules/mob/living/carbon/complex/examine.dm
@@ -10,7 +10,7 @@
 
 	for(var/obj/item/I in held_items)
 		if(I.is_visible())
-			if(I.blood_DNA && I.blood_DNA.len)
+			if(I.is_blood_stained())
 				msg += "<span class='warning'>It has [bicon(I)] [I.a_stained()] [I.name] in its [get_index_limb_name(is_holding_item(I))]!</span>\n"
 			else
 				msg += "It has [bicon(I)] \a [I] in its [get_index_limb_name(is_holding_item(I))].\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -57,35 +57,35 @@
 
 	//uniform
 	if(w_uniform && !(slot_w_uniform in obscured) && w_uniform.is_visible())
-		if(w_uniform.blood_DNA && w_uniform.blood_DNA.len)
+		if(w_uniform.is_blood_stained())
 			msg += "<span class='warning'>[t_He] [t_is] wearing [bicon(w_uniform)] [w_uniform.a_stained()] [w_uniform.name]! [format_examine(w_uniform, "Examine")][w_uniform.description_accessories()]</span>\n"
 		else
 			msg += "[t_He] [t_is] wearing [bicon(w_uniform)] \a [w_uniform]. [format_examine(w_uniform, "Examine")][w_uniform.description_accessories()]\n"
 
 	//head
 	if(head && head.is_visible())
-		if(head.blood_DNA && head.blood_DNA.len)
+		if(head.is_blood_stained())
 			msg += "<span class='warning'>[t_He] [t_is] wearing [bicon(head)] [head.a_stained()] [head.name] on [t_his] head! [format_examine(head, "Examine")][head.description_accessories()]</span>\n"
 		else
 			msg += "[t_He] [t_is] wearing [bicon(head)] \a [head] on [t_his] head. [format_examine(head, "Examine")][head.description_accessories()][head.description_hats()]\n"
 
 	//suit/armour
 	if(wear_suit && wear_suit.is_visible())
-		if(wear_suit.blood_DNA && wear_suit.blood_DNA.len)
+		if(wear_suit.is_blood_stained())
 			msg += "<span class='warning'>[t_He] [t_is] wearing [bicon(wear_suit)] [wear_suit.a_stained()] [wear_suit.name]!  [format_examine(wear_suit, "Examine")][wear_suit.description_accessories()]</span>\n"
 		else
 			msg += "[t_He] [t_is] wearing [bicon(wear_suit)] \a [wear_suit]. [format_examine(wear_suit, "Examine")][wear_suit.description_accessories()]\n"
 
 		//suit/armour storage
 		if(s_store)
-			if(s_store.blood_DNA && s_store.blood_DNA.len)
+			if(s_store.is_blood_stained())
 				msg += "<span class='warning'>[t_He] [t_is] carrying [bicon(s_store)] [s_store.a_stained()] [s_store.name] on [t_his] [wear_suit.name]!  [format_examine(s_store, "Examine")]</span>\n"
 			else
 				msg += "[t_He] [t_is] carrying [bicon(s_store)] \a [s_store] on [t_his] [wear_suit.name].\n"
 
 	//back
 	if(back && back.is_visible())
-		if(back.blood_DNA && back.blood_DNA.len)
+		if(back.is_blood_stained())
 			msg += "<span class='warning'>[t_He] [t_has] [bicon(back)] [back.a_stained()] [back.name] on [t_his] back! [format_examine(back, "Examine")][back.description_accessories()]</span>\n"
 		else
 			msg += "[t_He] [t_has] [bicon(back)] \a [back] on [t_his] back. [format_examine(back, "Examine")][back.description_accessories()]\n"
@@ -93,14 +93,14 @@
 	//hands
 	for(var/obj/item/I in held_items)
 		if(I.is_visible())
-			if(I.blood_DNA && I.blood_DNA.len)
+			if(I.is_blood_stained())
 				msg += "<span class='warning'>[t_He] [t_is] holding [bicon(I)] [I.a_stained()] [I.name] in [t_his] [get_index_limb_name(is_holding_item(I))]!  [format_examine(I, "Examine")]</span>\n"
 			else
 				msg += "[t_He] [t_is] holding [bicon(I)] \a [I] in [t_his] [get_index_limb_name(is_holding_item(I))]. [format_examine(I, "Examine")]\n"
 
 	//gloves
 	if(gloves && !(slot_gloves in obscured) && gloves.is_visible())
-		if(gloves.blood_DNA && gloves.blood_DNA.len)
+		if(gloves.is_blood_stained())
 			msg += "<span class='warning'>[t_He] [t_has] [bicon(gloves)] [gloves.a_stained()] [gloves.name] on [t_his] hands! [format_examine(gloves, "Examine")][gloves.description_accessories()]</span>\n"
 		else
 			msg += "[t_He] [t_has] [bicon(gloves)] \a [gloves] on [t_his] hands. [format_examine(gloves, "Examine")][gloves.description_accessories()]\n"
@@ -116,35 +116,35 @@
 
 	//belt
 	if(belt && belt.is_visible())
-		if(belt.blood_DNA && belt.blood_DNA.len)
+		if(belt.is_blood_stained())
 			msg += "<span class='warning'>[t_He] [t_has] [bicon(belt)] [belt.a_stained()] [belt.name] about [t_his] waist! [format_examine(belt, "Examine")][belt.description_accessories()]</span>\n"
 		else
 			msg += "[t_He] [t_has] [bicon(belt)] \a [belt] about [t_his] waist. [format_examine(belt, "Examine")][belt.description_accessories()]\n"
 
 	//shoes
 	if(shoes && !(slot_shoes in obscured) && shoes.is_visible())
-		if(shoes.blood_DNA && shoes.blood_DNA.len)
+		if(shoes.is_blood_stained())
 			msg += "<span class='warning'>[t_He] [t_is] wearing [bicon(shoes)] [shoes.a_stained()] [shoes.name] on [t_his] feet! [format_examine(shoes, "Examine")][shoes.description_accessories()]</span>\n"
 		else
 			msg += "[t_He] [t_is] wearing [bicon(shoes)] \a [shoes] on [t_his] feet. [format_examine(shoes, "Examine")][shoes.description_accessories()]\n"
 
 	//mask
 	if(wear_mask && !(slot_wear_mask in obscured) && wear_mask.is_visible())
-		if(wear_mask.blood_DNA && wear_mask.blood_DNA.len)
+		if(wear_mask.is_blood_stained())
 			msg += "<span class='warning'>[t_He] [t_has] [bicon(wear_mask)] [wear_mask.a_stained()] [wear_mask.name] [wear_mask.goes_in_mouth ? "in" : "on"] [t_his] [wear_mask.goes_in_mouth ? "mouth" : "face"]! [format_examine(wear_mask, "Examine")][wear_mask.description_accessories()]</span>\n"
 		else
 			msg += "[t_He] [t_has] [bicon(wear_mask)] \a [wear_mask] [wear_mask.goes_in_mouth ? "in" : "on"] [t_his] [wear_mask.goes_in_mouth ? "mouth" : "face"]. [format_examine(wear_mask, "Examine")][wear_mask.description_accessories()]\n"
 
 	//eyes
 	if(glasses && !(slot_glasses in obscured) && glasses.is_visible())
-		if(glasses.blood_DNA && glasses.blood_DNA.len)
+		if(glasses.is_blood_stained())
 			msg += "<span class='warning'>[t_He] [t_has] [bicon(glasses)] [glasses.a_stained()] [glasses.name] covering [t_his] eyes! [format_examine(glasses, "Examine")][glasses.description_accessories()]</span>\n"
 		else
 			msg += "[t_He] [t_has] [bicon(glasses)] \a [glasses] covering [t_his] eyes. [format_examine(glasses, "Examine")][glasses.description_accessories()]\n"
 
 	//ears
 	if(ears && !(slot_ears in obscured) && ears.is_visible())
-		if(ears.blood_DNA && ears.blood_DNA.len)
+		if(ears.is_blood_stained())
 			msg += "<span class='warning'>[t_He] [t_has] [bicon(ears)] [ears.a_stained()] [ears.name] on [t_his] ears! [format_examine(ears, "Examine")][ears.description_accessories()]</span>\n"
 		else
 			msg += "[t_He] [t_has] [bicon(ears)] \a [ears] on [t_his] ears. [format_examine(ears, "Examine")][ears.description_accessories()]\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -147,7 +147,7 @@
 		if(ears.blood_DNA && ears.blood_DNA.len)
 			msg += "<span class='warning'>[t_He] [t_has] [bicon(ears)] [ears.a_stained()] [ears.name] on [t_his] ears! [format_examine(ears, "Examine")][ears.description_accessories()]</span>\n"
 		else
-			msg += "[t_He] [t_has] [bicon(ears)] \a [ears.name] on [t_his] ears. [format_examine(ears, "Examine")][ears.description_accessories()]\n"
+			msg += "[t_He] [t_has] [bicon(ears)] \a [ears] on [t_his] ears. [format_examine(ears, "Examine")][ears.description_accessories()]\n"
 
 	//ID
 	if(wear_id)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -86,7 +86,7 @@
 	//back
 	if(back && back.is_visible())
 		if(back.blood_DNA && back.blood_DNA.len)
-			msg += "<span class='warning'>[t_He] [t_has] [bicon(back)] [back.a_stained()] [back] on [t_his] back! [format_examine(back, "Examine")][back.description_accessories()]</span>\n"
+			msg += "<span class='warning'>[t_He] [t_has] [bicon(back)] [back.a_stained()] [back.name] on [t_his] back! [format_examine(back, "Examine")][back.description_accessories()]</span>\n"
 		else
 			msg += "[t_He] [t_has] [bicon(back)] \a [back] on [t_his] back. [format_examine(back, "Examine")][back.description_accessories()]\n"
 
@@ -138,13 +138,16 @@
 	//eyes
 	if(glasses && !(slot_glasses in obscured) && glasses.is_visible())
 		if(glasses.blood_DNA && glasses.blood_DNA.len)
-			msg += "<span class='warning'>[t_He] [t_has] [bicon(glasses)] [glasses.a_stained()] [glasses] covering [t_his] eyes! [format_examine(glasses, "Examine")][glasses.description_accessories()]</span>\n"
+			msg += "<span class='warning'>[t_He] [t_has] [bicon(glasses)] [glasses.a_stained()] [glasses.name] covering [t_his] eyes! [format_examine(glasses, "Examine")][glasses.description_accessories()]</span>\n"
 		else
 			msg += "[t_He] [t_has] [bicon(glasses)] \a [glasses] covering [t_his] eyes. [format_examine(glasses, "Examine")][glasses.description_accessories()]\n"
 
 	//ears
 	if(ears && !(slot_ears in obscured) && ears.is_visible())
-		msg += "[t_He] [t_has] [bicon(ears)] \a [ears] on [t_his] ears. [format_examine(ears, "Examine")][ears.description_accessories()]\n"
+		if(ears.blood_DNA && ears.blood_DNA.len)
+			msg += "<span class='warning'>[t_He] [t_has] [bicon(ears)] [ears.a_stained()] [ears.name] on [t_his] ears! [format_examine(ears, "Examine")][ears.description_accessories()]</span>\n"
+		else
+			msg += "[t_He] [t_has] [bicon(ears)] \a [ears.name] on [t_his] ears. [format_examine(ears, "Examine")][ears.description_accessories()]\n"
 
 	//ID
 	if(wear_id)

--- a/code/modules/mob/living/carbon/monkey/examine.dm
+++ b/code/modules/mob/living/carbon/monkey/examine.dm
@@ -14,7 +14,7 @@
 
 	for(var/obj/item/I in held_items)
 		if(I.is_visible())
-			if(I.blood_DNA && I.blood_DNA.len)
+			if(I.is_blood_stained())
 				msg += "<span class='warning'>It has [bicon(I)] [I.a_stained()] [I.name] in its [get_index_limb_name(is_holding_item(I))]!</span>\n"
 			else
 				msg += "It has [bicon(I)] \a [I] in its [get_index_limb_name(is_holding_item(I))].\n"


### PR DESCRIPTION
This fixes an issue where blood-stained items worn in certain slots by humans are described as
"a blood-stained **the** science goggles".
Also fixes an issue where where phantom blood of a grey could appear in blood-stain description text.
Also adds a bloody examine message to items in the ear slot.

:cl:
 * rscadd: Blood-stained headsets are described as such in human examine descriptions.
 * bugfix: Fixed issues with phantom blood appearing on certain things like surgically removed heads and dead bees.