### PR TITLE
Makes code compile on 1609 and also probably fixes some stuff

### DIFF
--- a/code/_onclick/hud/screen_alarms.dm
+++ b/code/_onclick/hud/screen_alarms.dm
@@ -160,7 +160,7 @@ var/global/list/screen_alarms_locs = list(
 /obj/abstract/screen/alert/New()
 	..()
 	if(timeout)
-		add_timer(new /callback(src, src::qdel_self()), timeout)
+		add_timer(new /callback(src, nameof(src::qdel_self())), timeout)
 	if(emph)
 		overlays.Add(image('icons/mob/screen_alarms.dmi', icon_state = "emph_outline"))
 

--- a/code/controllers/subsystem/pathfinder.dm
+++ b/code/controllers/subsystem/pathfinder.dm
@@ -35,7 +35,7 @@ var/datum/subsystem/pathfinder/SSpathfinder
 		while(flow[free])
 			CHECK_TICK
 			free = (free % lcount) + 1
-		var/t = add_timer(new /callback(src, src::toolong(), free), 15 SECONDS)
+		var/t = add_timer(new /callback(src, nameof(src::toolong()), free), 15 SECONDS)
 		flow[free] = t
 		flow[t] = M
 		return free

--- a/code/datums/alt_control.dm
+++ b/code/datums/alt_control.dm
@@ -8,7 +8,7 @@
 /datum/control/New(var/mob/new_controller, var/atom/new_controlled)
 	..()
 	controller = new_controller
-	controller.register_event(/event/damaged, src, src::user_damaged())
+	controller.register_event(/event/damaged, src, nameof(src::user_damaged()))
 	controlled = new_controlled
 
 /datum/control/Destroy()

--- a/code/datums/chat_message.dm
+++ b/code/datums/chat_message.dm
@@ -61,7 +61,7 @@ var/runechat_icon = null
 	if (owned_by)
 		owned_by.seen_messages.Remove(src)
 		owned_by.images.Remove(message)
-		owned_by.mob.unregister_event(/event/destroyed, src, src::qdel_self())
+		owned_by.mob.unregister_event(/event/destroyed, src, nameof(src::qdel_self()))
 	owned_by = null
 	message_loc = null
 	message = null
@@ -81,7 +81,7 @@ var/runechat_icon = null
 	set waitfor = FALSE
 	// Register client who owns this message
 	owned_by = owner.client
-	owner.register_event(/event/destroyed, src, src::qdel_self())
+	owner.register_event(/event/destroyed, src, nameof(src::qdel_self()))
 
 	// Clip message
 	var/maxlen = owned_by.prefs.max_chat_length
@@ -136,7 +136,7 @@ var/runechat_icon = null
 	if(!TICK_CHECK)
 		return finish_image_generation(mheight, target, owner, complete_text, lifespan)
 
-	var/callback/our_callback = new /callback(src, src::finish_image_generation(), mheight, target, owner, complete_text, lifespan)
+	var/callback/our_callback = new /callback(src, nameof(src::finish_image_generation()), mheight, target, owner, complete_text, lifespan)
 	SSrunechat.message_queue += our_callback
 	return
 

--- a/code/datums/components/coinflip.dm
+++ b/code/datums/components/coinflip.dm
@@ -5,20 +5,20 @@
 	if(!isitem(parent))
 		return FALSE
 
-	parent.register_event(/event/item_attack_self, src, src::on_attack_self())
-	parent.register_event(/event/throw_impact, src, src::on_throw_impact())
-	parent.register_event(/event/equipped, src, src::equipped())
-	parent.register_event(/event/examined, src, src::examined())
+	parent.register_event(/event/item_attack_self, src, nameof(src::on_attack_self()))
+	parent.register_event(/event/throw_impact, src, nameof(src::on_throw_impact()))
+	parent.register_event(/event/equipped, src, nameof(src::equipped()))
+	parent.register_event(/event/examined, src, nameof(src::examined()))
 
 	sideup = pick(COIN_HEADS, COIN_TAILS)
 
 	return TRUE
 
 /datum/component/coinflip/Destroy()
-	parent.unregister_event(/event/item_attack_self, src, src::on_attack_self())
-	parent.unregister_event(/event/throw_impact, src, src::on_throw_impact())
-	parent.unregister_event(/event/equipped, src, src::equipped())
-	parent.unregister_event(/event/examined, src, src::examined())
+	parent.unregister_event(/event/item_attack_self, src, nameof(src::on_attack_self()))
+	parent.unregister_event(/event/throw_impact, src, nameof(src::on_throw_impact()))
+	parent.unregister_event(/event/equipped, src, nameof(src::equipped()))
+	parent.unregister_event(/event/examined, src, nameof(src::examined()))
 	..()
 
 /datum/component/coinflip/proc/on_attack_self(mob/living/user, obj/item/item)

--- a/code/datums/components/cooktop.dm
+++ b/code/datums/components/cooktop.dm
@@ -3,15 +3,15 @@
 /datum/component/cooktop/initialize()
 	if(!isobj(parent))
 		return FALSE
-	parent.register_event(/event/attackhand, src, src::on_attackhand())
-	parent.register_event(/event/attackby, src, src::on_attackby())
-	parent.register_event(/event/examined, src, src::on_examine())
+	parent.register_event(/event/attackhand, src, nameof(src::on_attackhand()))
+	parent.register_event(/event/attackby, src, nameof(src::on_attackby()))
+	parent.register_event(/event/examined, src, nameof(src::on_examine()))
 	return TRUE
 
 /datum/component/cooktop/Destroy()
-	parent.unregister_event(/event/attackhand, src, src::on_attackhand())
-	parent.unregister_event(/event/attackby, src, src::on_attackby())
-	parent.unregister_event(/event/examined, src, src::on_examine())
+	parent.unregister_event(/event/attackhand, src, nameof(src::on_attackhand()))
+	parent.unregister_event(/event/attackby, src, nameof(src::on_attackby()))
+	parent.unregister_event(/event/examined, src, nameof(src::on_examine()))
 	..()
 
 /datum/component/cooktop/proc/on_attackhand(mob/user, atom/target)

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -15,23 +15,23 @@
 	if(!isitem(parent))
 		return FALSE
 
-	parent.register_event(/event/attackby, src, src::on_attackby())
-	parent.register_event(/event/item_attack_self, src, src::on_attack_self())
+	parent.register_event(/event/attackby, src, nameof(src::on_attackby()))
+	parent.register_event(/event/item_attack_self, src, nameof(src::on_attack_self()))
 	if(istype(parent, /obj/item/device/pda))
 		generate_unlock_code()
-		parent.register_event(/event/pda_change_ringtone, src, src::on_pda_change_ringtone())
+		parent.register_event(/event/pda_change_ringtone, src, nameof(src::on_pda_change_ringtone()))
 
 	if(istype(parent, /obj/item/device/radio))
 		generate_frequency()
-		parent.register_event(/event/radio_new_frequency, src, src::on_radio_new_frequency())
+		parent.register_event(/event/radio_new_frequency, src, nameof(src::on_radio_new_frequency()))
 
 	return TRUE
 
 /datum/component/uplink/Destroy()
-	parent.unregister_event(/event/attackby, src, src::on_attackby())
-	parent.unregister_event(/event/item_attack_self, src, src::on_attack_self())
-	parent.unregister_event(/event/pda_change_ringtone, src, src::on_pda_change_ringtone())
-	parent.unregister_event(/event/radio_new_frequency, src, src::on_radio_new_frequency())
+	parent.unregister_event(/event/attackby, src, nameof(src::on_attackby()))
+	parent.unregister_event(/event/item_attack_self, src, nameof(src::on_attack_self()))
+	parent.unregister_event(/event/pda_change_ringtone, src, nameof(src::on_pda_change_ringtone()))
+	parent.unregister_event(/event/radio_new_frequency, src, nameof(src::on_radio_new_frequency()))
 	..()
 
 /datum/component/uplink/ui_host(mob/user)

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -408,7 +408,7 @@ var/list/valid_ninja_suits = list(
 				list("Charge Sword", "radial_zap", "Reset the cooldown on your blade's teleport. Cost: [CHARGE_COST_MULTIPLIER]0 per second."),
 			)
 
-			var/task = show_radial_menu(usr,loc,choices,custom_check = new /callback(src, src::radial_check(), user))
+			var/task = show_radial_menu(usr,loc,choices,custom_check = new /callback(src, nameof(src::radial_check()), user))
 			if(!radial_check(user))
 				return
 			switch(task)

--- a/code/datums/gamemode/role/time_agent.dm
+++ b/code/datums/gamemode/role/time_agent.dm
@@ -124,11 +124,11 @@
 					eviltwinrecruiter.logging = TRUE
 
 					// A player has their role set to Yes or Always
-					eviltwinrecruiter.player_volunteering = new /callback(src, src::recruiter_recruiting())
+					eviltwinrecruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))
 					// ", but No or Never
-					eviltwinrecruiter.player_not_volunteering = new /callback(src, src::recruiter_not_recruiting())
+					eviltwinrecruiter.player_not_volunteering = new /callback(src, nameof(src::recruiter_not_recruiting()))
 
-					eviltwinrecruiter.recruited = new /callback(src, src::recruiter_recruited())
+					eviltwinrecruiter.recruited = new /callback(src, nameof(src::recruiter_recruited()))
 
 					eviltwinrecruiter.request_player()
 			if(5 to INFINITY)

--- a/code/datums/helper_datums/butchering.dm
+++ b/code/datums/helper_datums/butchering.dm
@@ -451,7 +451,7 @@
 
 
 /mob/living/proc/butcherChooseStep(mob/user, var/list/butcherOptions, butcherTool)
-	var/choice = show_radial_menu(user,loc,butcherOptions,custom_check = new /callback(src, src::radial_check(), user))
+	var/choice = show_radial_menu(user,loc,butcherOptions,custom_check = new /callback(src, nameof(src::radial_check()), user))
 	if(!radial_check(user))
 		return
 	if(!butcherCheck(user, butcherTool))

--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -93,7 +93,7 @@ var/list/datum/map_element/map_elements = list()
 	if(!istype(A))
 		return
 
-	A.register_event(/event/destroyed, src, src::clear_references())
+	A.register_event(/event/destroyed, src, nameof(src::clear_references()))
 	return A
 
 

--- a/code/datums/tether.dm
+++ b/code/datums/tether.dm
@@ -16,8 +16,8 @@
 	effective_master = master
 	slave = S
 	effective_slave = slave
-	master.register_event(/event/moved, src, src::master_moved())
-	master.register_event(/event/moved, src, src::slave_moved())
+	master.register_event(/event/moved, src, nameof(src::master_moved()))
+	master.register_event(/event/moved, src, nameof(src::slave_moved()))
 	if(!master.current_tethers)
 		master.current_tethers = list()
 	master.current_tethers.Add(src)
@@ -27,17 +27,17 @@
 
 /datum/tether/Destroy()
 	if(effective_master != master)
-		effective_master.unregister_event(/event/moved, src, src::master_moved())
+		effective_master.unregister_event(/event/moved, src, nameof(src::master_moved()))
 		effective_master.current_tethers.Remove(src)
 		effective_master = null
-	master.unregister_event(/event/moved, src, src::master_moved())
+	master.unregister_event(/event/moved, src, nameof(src::master_moved()))
 	master.current_tethers.Remove(src)
 	master = null
 	if(effective_slave != slave)
-		effective_slave.unregister_event(/event/moved, src, src::slave_moved())
+		effective_slave.unregister_event(/event/moved, src, nameof(src::slave_moved()))
 		effective_slave.current_tethers.Remove(src)
 		effective_slave = null
-	slave.unregister_event(/event/moved, src, src::slave_moved())
+	slave.unregister_event(/event/moved, src, nameof(src::slave_moved()))
 	slave.current_tethers.Remove(src)
 	slave = null
 	..()
@@ -55,12 +55,12 @@
 /datum/tether/proc/master_moved()
 	if(effective_master != master)
 		if(!isturf(effective_master.loc) || isturf(master.loc))
-			effective_master.unregister_event(/event/moved, src, src::master_moved())
+			effective_master.unregister_event(/event/moved, src, nameof(src::master_moved()))
 			effective_master.current_tethers.Remove(src)
 			effective_master = master
 	if(!isturf(master.loc) && effective_master == master)
 		effective_master = get_holder_at_turf_level(master)
-		effective_master.register_event(/event/moved, src, src::master_moved())
+		effective_master.register_event(/event/moved, src, nameof(src::master_moved()))
 		if(!effective_master.current_tethers)
 			effective_master.current_tethers = list()
 		effective_master.current_tethers.Add(src)
@@ -72,12 +72,12 @@
 /datum/tether/proc/slave_moved()
 	if(effective_slave != slave)
 		if(!isturf(effective_slave.loc) || isturf(slave.loc))
-			effective_slave.unregister_event(/event/moved, src, src::slave_moved())
+			effective_slave.unregister_event(/event/moved, src, nameof(src::slave_moved()))
 			effective_slave.current_tethers.Remove(src)
 			effective_slave = slave
 	if(!isturf(slave.loc) && effective_slave == slave)
 		effective_slave = get_holder_at_turf_level(slave)
-		effective_slave.register_event(/event/moved, src, src::slave_moved())
+		effective_slave.register_event(/event/moved, src, nameof(src::slave_moved()))
 		if(!effective_slave.current_tethers)
 			effective_slave.current_tethers = list()
 		effective_slave.current_tethers.Add(src)

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -476,7 +476,7 @@
 					to_chat(trappeduser, "<span class='warning'>With your leg missing, you slip out of the bear trap.</span>")
 					trapped = 0
 					unlock_atom(trappeduser)
-					trappeduser.unregister_event(/event/moved, src, src::forcefully_remove())
+					trappeduser.unregister_event(/event/moved, src, nameof(src::forcefully_remove()))
 					trappeduser = null
 					anchored = FALSE
 					return
@@ -491,7 +491,7 @@
 						playsound(user.loc, 'sound/weapons/handcuffs.ogg', 30, 1, -3)
 						trapped = 0
 						unlock_atom(trappeduser)
-						trappeduser.unregister_event(/event/moved, src, src::forcefully_remove())
+						trappeduser.unregister_event(/event/moved, src, nameof(src::forcefully_remove()))
 						trappeduser = null
 						anchored = FALSE
 						return
@@ -565,7 +565,7 @@
 				trapped = 0
 				anchored = FALSE
 				unlock_atom(trappeduser)
-				trappeduser.unregister_event(/event/moved, src, src::forcefully_remove())
+				trappeduser.unregister_event(/event/moved, src, nameof(src::forcefully_remove()))
 				trappeduser = null
 			else
 				to_chat(user, "<span class='notice'>You begin to pry the bear trap off of [trappeduser.name].</span>")
@@ -574,7 +574,7 @@
 					trapped = 0
 					anchored = FALSE
 					unlock_atom(trappeduser)
-					trappeduser.unregister_event(/event/moved, src, src::forcefully_remove())
+					trappeduser.unregister_event(/event/moved, src, nameof(src::forcefully_remove()))
 					trappeduser = null
 		else if (istype(trappedbear))
 			to_chat(user, "<span class='notice'>You begin to pry the bear trap off of [trappedbear.name].</span>")
@@ -643,7 +643,7 @@
 		playsound(src, 'sound/effects/snap.ogg', 60, 1)
 		H.audible_scream()
 		lock_atom(H, /datum/locking_category/beartrap)
-		H.register_event(/event/moved, src, src::forcefully_remove())
+		H.register_event(/event/moved, src, nameof(src::forcefully_remove()))
 
 		if(trappedorgan.take_damage(15, 0, 25, SERRATED_BLADE & SHARP_BLADE))
 			H.UpdateDamageIcon()
@@ -652,7 +652,7 @@
 		if(!H.pick_usable_organ(trappedorgan)) //check if they lost their leg, and get them out of the trap
 			to_chat(H, "<span class='warning'>With your leg missing, you slip out of the bear trap!</span>")
 			trapped = 0
-			trappeduser.unregister_event(/event/moved, src, src::forcefully_remove())
+			trappeduser.unregister_event(/event/moved, src, nameof(src::forcefully_remove()))
 			trappeduser = null
 			unlock_atom(H)
 			anchored = FALSE
@@ -694,7 +694,7 @@
 			to_chat(trappeduser, "<span class='warning'>With your leg missing, you slip out of the bear trap.</span>")
 			trapped = 0
 			unlock_atom(trappeduser)
-			trappeduser.unregister_event(/event/moved, src, src::forcefully_remove())
+			trappeduser.unregister_event(/event/moved, src, nameof(src::forcefully_remove()))
 			trappeduser = null
 			anchored = FALSE
 
@@ -721,7 +721,7 @@
 		visible_message("<span class='warning'>The wound on [mover]'s leg worsens terribly as the trap let go of them.</span>")
 		trapped = 0
 		unlock_atom(trappeduser)
-		trappeduser.unregister_event(/event/moved, src, src::forcefully_remove())
+		trappeduser.unregister_event(/event/moved, src, nameof(src::forcefully_remove()))
 		anchored = FALSE
 		trappeduser.update_canmove()
 		trappeduser = null

--- a/code/defines/procs/AStar.dm
+++ b/code/defines/procs/AStar.dm
@@ -329,7 +329,7 @@ length to avoid portals or something i guess?? Not that they're counted right no
 
 /////////////////////////////////////////////////////////////////////////
 
-/atom/proc/make_astar_path(var/atom/target, var/callback = new /callback(src, src::get_astar_path()))
+/atom/proc/make_astar_path(var/atom/target, var/callback = new /callback(src, nameof(src::get_astar_path())))
 	AStar(src, callback, get_turf(src), target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 30, 30)
 
 //override when needed to receive your path

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -736,7 +736,7 @@
 		AM.lock_atom(src, /datum/locking_category/overlay)
 	if (istype(master, /atom/movable))
 		var/atom/movable/AM = master
-		AM.register_event(/event/destroyed, src, src::qdel_self())
+		AM.register_event(/event/destroyed, src, nameof(src::qdel_self()))
 	verbs.len = 0
 
 /atom/movable/overlay/proc/qdel_self(datum/thing)
@@ -746,7 +746,7 @@
 	if(istype(master, /atom/movable))
 		var/atom/movable/AM = master
 		AM.unlock_atom(src)
-		AM.unregister_event(/event/destroyed, src, src::qdel_self())
+		AM.unregister_event(/event/destroyed, src, nameof(src::qdel_self()))
 	master = null
 	return ..()
 

--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -51,13 +51,13 @@
 
 /datum/dna/gene/basic/stealth/chameleon/activate(var/mob/M, var/connected, var/flags)
 	..()
-	M.register_event(/event/moved, src, src::mob_moved())
+	M.register_event(/event/moved, src, nameof(src::mob_moved()))
 	return 1
 
 /datum/dna/gene/basic/stealth/chameleon/deactivate(var/mob/M, var/connected, var/flags)
 	if(!..())
 		return 0
-	M.unregister_event(/event/moved, src, src::mob_moved())
+	M.unregister_event(/event/moved, src, nameof(src::mob_moved()))
 	return 1
 
 /datum/dna/gene/basic/stealth/chameleon/proc/mob_moved(var/mob/mover)

--- a/code/game/gamemodes/events/powercreeper.dm
+++ b/code/game/gamemodes/events/powercreeper.dm
@@ -179,9 +179,9 @@
 			else
 				P.growdirs &= ~get_dir(P, src)
 		if(dying)
-			T.unregister_event(/event/density_change, src, src::proxDensityChange())
+			T.unregister_event(/event/density_change, src, nameof(src::proxDensityChange()))
 		else
-			T.register_event(/event/density_change, src, src::proxDensityChange())
+			T.register_event(/event/density_change, src, nameof(src::proxDensityChange()))
 
 /obj/structure/cable/powercreeper/proc/proxDensityChange(atom/atom)
 	var/turf/T = get_turf(atom)

--- a/code/game/gamemodes/wizard/apprentice_contract.dm
+++ b/code/game/gamemodes/wizard/apprentice_contract.dm
@@ -148,11 +148,11 @@ var/list/wizard_apprentice_setups_by_name = list()
 		recruiter.jobban_roles = list("Syndicate")
 		recruiter.recruitment_timeout = 30 SECONDS
 	// Role set to Yes or Always
-	recruiter.player_volunteering = new /callback(src, src::recruiter_recruiting())
+	recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))
 	// Role set to No or Never
-	recruiter.player_not_volunteering = new /callback(src, src::recruiter_not_recruiting())
+	recruiter.player_not_volunteering = new /callback(src, nameof(src::recruiter_not_recruiting()))
 
-	recruiter.recruited = new /callback(src, src::recruiter_recruited())
+	recruiter.recruited = new /callback(src, nameof(src::recruiter_recruited()))
 
 	recruiter.request_player()
 

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -118,11 +118,11 @@
 		user.update_inv_hands()
 		if(wielded)
 			user.visible_message("<span class='danger'>\The [user] throws \the [src] over \himself and disappears!</span>","<span class='notice'>You throw \the [src] over yourself and disappear.</span>")
-			user.register_event(/event/moved, src, src::mob_moved())
+			user.register_event(/event/moved, src, nameof(src::mob_moved()))
 			user.make_invisible(CLOAKINGCLOAK, 0, TRUE, 1, INVISIBILITY_LEVEL_TWO)
 		else
 			user.visible_message("<span class='warning'>\The [user] appears out of thin air!</span>","<span class='notice'>You take \the [src] off and become visible again.</span>")
-			user.unregister_event(/event/moved, src, src::mob_moved())
+			user.unregister_event(/event/moved, src, nameof(src::mob_moved()))
 			user.make_visible(CLOAKINGCLOAK)
 
 /obj/item/weapon/glow_orb
@@ -214,8 +214,8 @@
 
 /obj/item/phylactery/Destroy()
 	if(bound_soul)
-		bound_soul.unregister_event(/event/death, src, src::revive_soul())
-		bound_soul.unregister_event(/event/z_transition, src, src::z_block())
+		bound_soul.unregister_event(/event/death, src, nameof(src::revive_soul()))
+		bound_soul.unregister_event(/event/z_transition, src, nameof(src::z_block()))
 		to_chat(bound_soul, "<span class = 'warning'><b>You feel your form begin to unwind!</b></span>")
 		spawn(rand(5 SECONDS, 15 SECONDS))
 			bound_soul.dust()
@@ -279,23 +279,23 @@
 
 /obj/item/phylactery/proc/unbind()
 	if(bound_soul)
-		bound_soul.unregister_event(/event/z_transition, src, src::z_block())
-		bound_soul.unregister_event(/event/death, src, src::revive_soul())
+		bound_soul.unregister_event(/event/z_transition, src, nameof(src::z_block()))
+		bound_soul.unregister_event(/event/death, src, nameof(src::revive_soul()))
 	bound_soul = null
 	update_icon()
 
 /obj/item/phylactery/proc/bind(var/mob/to_bind)
-	to_bind.register_event(/event/death, src, src::revive_soul())
-	to_bind.register_event(/event/z_transition, src, src::z_block())
+	to_bind.register_event(/event/death, src, nameof(src::revive_soul()))
+	to_bind.register_event(/event/z_transition, src, nameof(src::z_block()))
 	bound_soul = to_bind
 
 /obj/item/phylactery/proc/unbind_mind()
 	if(bound_mind)
-		bound_mind.unregister_event(/event/after_mind_transfer, src, src::follow_mind())
+		bound_mind.unregister_event(/event/after_mind_transfer, src, nameof(src::follow_mind()))
 	bound_mind = null
 
 /obj/item/phylactery/proc/bind_mind(var/datum/mind/to_bind)
-	to_bind.register_event(/event/after_mind_transfer, src, src::follow_mind())
+	to_bind.register_event(/event/after_mind_transfer, src, nameof(src::follow_mind()))
 	bound_mind = to_bind
 
 /obj/item/phylactery/proc/follow_mind(datum/mind/mind)

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -209,7 +209,7 @@
 		if(target)
 			if (waiting_for_path)
 				return 1
-			calc_path(target, new /callback(src, src::get_path()))
+			calc_path(target, new /callback(src, nameof(src::get_path())))
 			if (path && length(path))
 				process_path()
 			return 1
@@ -249,7 +249,7 @@
 	if(frustration > 5)
 		summoned = FALSE // Let's not try again.
 		if (target && !target.gcDestroyed)
-			calc_path(target, new /callback(src, src::get_path()), next)
+			calc_path(target, new /callback(src, nameof(src::get_path())), next)
 		else
 			target = null
 			path = list()
@@ -330,7 +330,7 @@
 
 	if(patrol_target)
 		waiting_for_patrol = TRUE
-		calc_patrol_path(patrol_target, new /callback(src, src::get_patrol_path()))
+		calc_patrol_path(patrol_target, new /callback(src, nameof(src::get_patrol_path())))
 // This proc send out a singal to every beacon listening to the "beacon_freq" variable.
 // The signal says, "i'm a bot looking for a beacon to patrol to."
 // Every beacon with the flag "patrol" responds by trasmitting its location.
@@ -393,7 +393,7 @@
 			return TRUE
 	if(frustration > 5)
 		if (target && !target.gcDestroyed)
-			calc_path(target, new /callback(src, src::get_path()), next)
+			calc_path(target, new /callback(src, nameof(src::get_path())), next)
 		else
 			target = null
 			patrol_path = list()

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -34,13 +34,13 @@
 		detectTime = world.time // start the clock
 	if (!(target in motionTargets))
 		motionTargets += target
-		target.register_event(/event/destroyed, src, src::clearDeletedTarget())
+		target.register_event(/event/destroyed, src, nameof(src::clearDeletedTarget()))
 	return 1
 
 /obj/machinery/camera/proc/lostTarget(var/mob/target)
 	if (target in motionTargets)
 		motionTargets -= target
-		target.unregister_event(/event/destroyed, src, src::clearDeletedTarget())
+		target.unregister_event(/event/destroyed, src, nameof(src::clearDeletedTarget()))
 	if (motionTargets.len == 0)
 		cancelAlarm()
 

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -585,7 +585,7 @@
 			list("Examine", "radial_examine")
 		)
 
-		var/task = show_radial_menu(usr,loc,choices,custom_check = new /callback(src, src::radial_check(), user))
+		var/task = show_radial_menu(usr,loc,choices,custom_check = new /callback(src, nameof(src::radial_check()), user))
 		if(!radial_check(usr))
 			return
 

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -271,14 +271,14 @@
 
 /obj/item/mecha_parts/mecha_equipment/tool/cable_layer/attach()
 	..()
-	chassis.register_event(/event/moved, src, src::layCable())
+	chassis.register_event(/event/moved, src, nameof(src::layCable()))
 
 /obj/item/mecha_parts/mecha_equipment/tool/cable_layer/detach()
-	chassis.unregister_event(/event/moved, src, src::layCable())
+	chassis.unregister_event(/event/moved, src, nameof(src::layCable()))
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/tool/cable_layer/Destroy()
-	chassis.unregister_event(/event/moved, src, src::layCable())
+	chassis.unregister_event(/event/moved, src, nameof(src::layCable()))
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/tool/cable_layer/action(var/obj/item/stack/cable_coil/target)

--- a/code/game/objects/effects/beam.dm
+++ b/code/game/objects/effects/beam.dm
@@ -226,9 +226,9 @@
 	BM.target=AM
 	BM.update_end_icon()
 	if(istype(AM))
-		AM.register_event(/event/moved, BM, src::target_moved())
-		AM.register_event(/event/destroyed, BM, src::target_destroyed())
-	AM.register_event(/event/density_change, BM, src::target_density_change())
+		AM.register_event(/event/moved, BM, nameof(src::target_moved()))
+		AM.register_event(/event/destroyed, BM, nameof(src::target_destroyed()))
+	AM.register_event(/event/density_change, BM, nameof(src::target_density_change()))
 	BM.targetContactLoc = AM.loc
 	beam_testing("\ref[BM] - Connected to [AM]")
 	AM.beam_connect(BM)
@@ -269,8 +269,8 @@
 	var/obj/effect/beam/_master=get_master()
 	if(_master.target)
 		if(ismovable(_master.target))
-			_master.target.unregister_event(/event/moved, _master, src::target_moved())
-			_master.target.unregister_event(/event/destroyed, src, src::target_destroyed())
+			_master.target.unregister_event(/event/moved, _master, nameof(src::target_moved()))
+			_master.target.unregister_event(/event/destroyed, src, nameof(src::target_destroyed()))
 		_master.target.beam_disconnect(_master)
 		_master.target=null
 		//if(_master.next)
@@ -382,7 +382,7 @@
 
 	var/turf/T = get_turf(src)
 	if(T)
-		T.register_event(/event/density_change, src, src::turf_density_change())
+		T.register_event(/event/density_change, src, nameof(src::turf_density_change()))
 
 	next = spawn_child()
 	if(next)
@@ -428,11 +428,11 @@
 /obj/effect/beam/Destroy()
 	var/turf/T = get_turf(src)
 	if(T)
-		T.unregister_event(/event/density_change, src, src::turf_density_change())
+		T.unregister_event(/event/density_change, src, nameof(src::turf_density_change()))
 	var/obj/effect/beam/ourselves = src
 	var/obj/effect/beam/ourmaster = get_master()
 	if(target)
-		target.unregister_event(/event/density_change, src, src::target_density_change())
+		target.unregister_event(/event/density_change, src, nameof(src::target_density_change()))
 		if(target.beams)
 			target.beams -= ourselves
 	for(var/obj/machinery/mirror/M in mirror_list)

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -16,10 +16,10 @@
 	update_icon()
 
 /obj/item/device/geiger_counter/pickup(mob/user)
-	user.register_event(/event/irradiate, src, src::measure_rad())
+	user.register_event(/event/irradiate, src, nameof(src::measure_rad()))
 
 /obj/item/device/geiger_counter/dropped(mob/user)
-	user.unregister_event(/event/irradiate, src, src::measure_rad())
+	user.unregister_event(/event/irradiate, src, nameof(src::measure_rad()))
 
 
 /obj/item/device/geiger_counter/proc/measure_rad(mob/living/carbon/human/user, rads)

--- a/code/game/objects/items/devices/hologram_projector.dm
+++ b/code/game/objects/items/devices/hologram_projector.dm
@@ -84,11 +84,11 @@
 		recruiter.jobban_roles = list(ROLE_POSIBRAIN)
 		recruiter.recruitment_timeout = 30 SECONDS
 	// Role set to Yes or Always
-	recruiter.player_volunteering = new /callback(src, src::recruiter_recruiting())
+	recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))
 	// Role set to No or Never
-	recruiter.player_not_volunteering = new /callback(src, src::recruiter_not_recruiting())
+	recruiter.player_not_volunteering = new /callback(src, nameof(src::recruiter_not_recruiting()))
 
-	recruiter.recruited = new /callback(src, src::recruiter_recruited())
+	recruiter.recruited = new /callback(src, nameof(src::recruiter_recruited()))
 	recruiter.request_player()
 
 /obj/item/device/hologram_projector/proc/recruiter_recruiting(mob/dead/observer/player, controls)

--- a/code/game/objects/items/devices/holomap.dm
+++ b/code/game/objects/items/devices/holomap.dm
@@ -21,7 +21,7 @@
 	//QDEL_NULL(delayer)
 
 	if (viewing)
-		viewing.mob.unregister_event(/event/logout, src, src::mob_logout())
+		viewing.mob.unregister_event(/event/logout, src, nameof(src::mob_logout()))
 
 	..()
 
@@ -35,7 +35,7 @@
 		viewing.images -= showing
 		showing.Cut()
 		to_chat(user, "You turn off \the [src].")
-		viewing.mob.unregister_event(/event/logout, src, src::mob_logout())
+		viewing.mob.unregister_event(/event/logout, src, nameof(src::mob_logout()))
 		viewing = null
 		return
 
@@ -46,14 +46,14 @@
 	showing = get_images(get_turf(user), viewing.view)
 	viewing.images |= showing
 	//delayer.addDelay(2 SECONDS) // Should be enough to prevent lag due to spam.
-	user.register_event(/event/logout, src, src::mob_logout())
+	user.register_event(/event/logout, src, nameof(src::mob_logout()))
 
 /obj/item/device/holomap/proc/mob_logout(mob/user)
 	if (viewing)
 		viewing.images -= showing
 		viewing = null
 
-	user.unregister_event(/event/logout, src, src::mob_logout())
+	user.unregister_event(/event/logout, src, nameof(src::mob_logout()))
 
 	visible_message("\The [src] turns off.")
 	showing.Cut()

--- a/code/game/objects/items/misc_items.dm
+++ b/code/game/objects/items/misc_items.dm
@@ -17,7 +17,7 @@
 		stop_using(mover)
 
 /obj/item/seeing_stone/proc/start_using(mob/user)
-	user.register_event(/event/moved, src, src::mob_moved())
+	user.register_event(/event/moved, src, nameof(src::mob_moved()))
 	user.visible_message("\The [user] holds \the [src] up to \his eye.","You hold \the [src] up to your eye.")
 	user.see_invisible = INVISIBILITY_MAXIMUM
 	user.see_invisible_override = INVISIBILITY_MAXIMUM
@@ -30,7 +30,7 @@
 	using = TRUE
 
 /obj/item/seeing_stone/proc/stop_using(mob/user)
-	user.unregister_event(/event/moved, src, src::mob_moved())
+	user.unregister_event(/event/moved, src, nameof(src::mob_moved()))
 	user.visible_message("\The [user] lowers \the [src].","You lower \the [src].")
 	user.see_invisible = initial(user.see_invisible)
 	user.see_invisible_override = 0

--- a/code/game/objects/items/robot/robot_items/robot_binoculars.dm
+++ b/code/game/objects/items/robot/robot_items/robot_binoculars.dm
@@ -19,11 +19,11 @@
 		if(R.client)
 			var/client/C = R.client
 			if(zoom && R.is_component_functioning("camera"))
-				R.register_event(/event/moved, src, src::mob_moved())
+				R.register_event(/event/moved, src, nameof(src::mob_moved()))
 				R.visible_message("[R]'s camera lens focuses loudly.","Your camera lens focuses loudly.")
 				R.regenerate_icons()
 				C.changeView(C.view + 4)
 			else
-				R.unregister_event(/event/moved, src, src::moved())
+				R.unregister_event(/event/moved, src, nameof(src::moved()))
 				R.regenerate_icons()
 				C.changeView(C.view - 4)

--- a/code/game/objects/items/robot/robot_items/robot_spawner.dm
+++ b/code/game/objects/items/robot/robot_items/robot_spawner.dm
@@ -51,9 +51,9 @@
 		recruiter.role = role
 		recruiter.jobban_roles = jobban_roles
 
-	recruiter.player_volunteering = new /callback(src, src::recruiter_recruiting())
-	recruiter.player_not_volunteering = new /callback(src, src::recruiter_not_recruiting())
-	recruiter.recruited = new /callback(src, src::recruiter_recruited())
+	recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))
+	recruiter.player_not_volunteering = new /callback(src, nameof(src::recruiter_not_recruiting()))
+	recruiter.recruited = new /callback(src, nameof(src::recruiter_recruited()))
 	recruiter.request_player()
 
 /obj/item/weapon/robot_spawner/proc/recruiter_recruiting(mob/dead/observer/player, controls)

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -239,10 +239,10 @@
 
 /obj/item/vachandle/pickup(mob/user)
 	..()
-	user.register_event(/event/moved, src, src::mob_moved())
+	user.register_event(/event/moved, src, nameof(src::mob_moved()))
 
 /obj/item/vachandle/dropped(mob/user)
-	user.unregister_event(/event/moved, src, src::mob_moved())
+	user.unregister_event(/event/moved, src, nameof(src::mob_moved()))
 	if(loc != myvac)
 		retract()
 

--- a/code/game/objects/items/weapons/RCL.dm
+++ b/code/game/objects/items/weapons/RCL.dm
@@ -101,9 +101,9 @@
 	if(user)
 		if(active)
 			trigger(user)
-			user.register_event(/event/moved, src, src::holder_moved())
+			user.register_event(/event/moved, src, nameof(src::holder_moved()))
 			return
-		user.unregister_event(/event/moved, src, src::holder_moved())
+		user.unregister_event(/event/moved, src, nameof(src::holder_moved()))
 
 /obj/item/weapon/rcl/attack_self(mob/user as mob)
 	active = !active

--- a/code/game/objects/items/weapons/implants/types/adrenalin_implant.dm
+++ b/code/game/objects/items/weapons/implants/types/adrenalin_implant.dm
@@ -28,10 +28,10 @@
 		source.SetParalysis(0)
 
 /obj/item/weapon/implant/adrenalin/implanted(mob/implanter)
-	imp_in.register_event(/event/emote, src, src::trigger())
+	imp_in.register_event(/event/emote, src, nameof(src::trigger()))
 	imp_in.mind.store_memory("The freedom implant can be activated by using the pale emote, <B>say *pale</B> to attempt to activate.", 0, 0)
 	to_chat(imp_in, "The implanted freedom implant can be activated by using the pale emote, <B>say *pale</B> to attempt to activate.")
 
 /obj/item/weapon/implant/adrenalin/handle_removal(mob/remover)
-	imp_in?.unregister_event(/event/emote, src, src::trigger())
+	imp_in?.unregister_event(/event/emote, src, nameof(src::trigger()))
 	makeunusable(75)

--- a/code/game/objects/items/weapons/implants/types/chemical_implant.dm
+++ b/code/game/objects/items/weapons/implants/types/chemical_implant.dm
@@ -34,10 +34,10 @@ the implant may become unstable and either pre-maturely inject the subject or si
 		src.activate(src.reagents.total_volume)
 
 /obj/item/weapon/implant/chem/implanted(mob/implanter)
-	imp_in.register_event(/event/emote, src, src::trigger())
+	imp_in.register_event(/event/emote, src, nameof(src::trigger()))
 
 /obj/item/weapon/implant/chem/handle_removal(mob/remover)
-	imp_in?.unregister_event(/event/emote, src, src::trigger())
+	imp_in?.unregister_event(/event/emote, src, nameof(src::trigger()))
 	makeunusable(75)
 
 /obj/item/weapon/implant/chem/activate(var/cause)

--- a/code/game/objects/items/weapons/implants/types/compressed_matter_implant.dm
+++ b/code/game/objects/items/weapons/implants/types/compressed_matter_implant.dm
@@ -37,7 +37,7 @@
 	qdel(src)
 
 /obj/item/weapon/implant/compressed/implanted(mob/implanter)
-	imp_in.register_event(/event/emote, src, src::trigger())
+	imp_in.register_event(/event/emote, src, nameof(src::trigger()))
 	activation_emote = input(implanter, "Choose activation emote:") in list("blink", "blink_r", "eyebrow", "chuckle", "twitch_s", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
 	implanter.mind.store_memory("Compressed matter implant in [implanter == imp_in ? "yourself" : imp_in.name] can be activated by using the [activation_emote] emote, <B>say *[activation_emote]</B> to attempt to activate.", TRUE)
 	to_chat(implanter, "The implanted compressed matter implant can be activated by using the [activation_emote] emote, <B>say *[activation_emote]</B> to attempt to activate.")
@@ -46,5 +46,5 @@
 	return FALSE
 
 /obj/item/weapon/implant/compressed/handle_removal(mob/remover)
-	imp_in?.unregister_event(/event/emote, src, src::trigger())
+	imp_in?.unregister_event(/event/emote, src, nameof(src::trigger()))
 	makeunusable(75)

--- a/code/game/objects/items/weapons/implants/types/exile_implant.dm
+++ b/code/game/objects/items/weapons/implants/types/exile_implant.dm
@@ -35,7 +35,7 @@
 	siteOfImplant = get_turf(imp_in)
 	zlevels -= illegalZ
 	to_chat(imp_in, "<span class='notice'>You shiver as you feel a weak, unsettling film surround you.</span>")
-	imp_in.register_event(/event/moved, src, src::zBan())
+	imp_in.register_event(/event/moved, src, nameof(src::zBan()))
 
 /obj/item/weapon/implant/exile/proc/zBan(atom/movable/mover)
 	var/turf/T = get_turf(src)
@@ -108,7 +108,7 @@
 /obj/item/weapon/implant/exile/proc/freeFromExile()
 	playsound(imp_in, "sound/machines/notify.ogg", 100, 1)
 	to_chat(imp_in, "<span class='notice'>You feel a sudden shooting pain. The film-like sensation fades. Your implant has jaunted out of your body.</span>" )
-	imp_in.unregister_event(/event/moved, src, src::zBan())
+	imp_in.unregister_event(/event/moved, src, nameof(src::zBan()))
 	src.forceMove(siteOfImplant)
 	imp_in = null
 

--- a/code/game/objects/items/weapons/implants/types/explosive_implant.dm
+++ b/code/game/objects/items/weapons/implants/types/explosive_implant.dm
@@ -52,7 +52,7 @@
 	usr.mind.store_memory("Explosive implant in [imp_in] can be activated by saying something containing the phrase ''[src.phrase]'', <B>say [src.phrase]</B> to attempt to activate.", 0, 0)
 	to_chat(usr, "The implanted explosive implant in [imp_in] can be activated by saying something containing the phrase ''[src.phrase]'', <B>say [src.phrase]</B> to attempt to activate.")
 	addHear()
-	source.register_event(/event/emote, src, src::trigger())
+	source.register_event(/event/emote, src, nameof(src::trigger()))
 	score.implant_phrases += "[usr.real_name] ([get_key(usr)]) rigged [imp_in.real_name] to explode on the phrase <font color='red'>\"[phrase]\"</font>!"
 	return 1
 
@@ -81,7 +81,7 @@
 	return 0
 
 /obj/item/weapon/implant/explosive/handle_removal(mob/remover)
-	imp_in?.unregister_event(/event/emote, src, src::trigger())
+	imp_in?.unregister_event(/event/emote, src, nameof(src::trigger()))
 	makeunusable(75)
 
 /obj/item/weapon/implant/explosive/proc/small_boom()
@@ -100,7 +100,7 @@
 			qdel(src)
 
 /obj/item/weapon/implant/explosive/nuclear/implanted(mob/source)
-	imp_in.register_event(/event/emote, src, src::trigger())
+	imp_in.register_event(/event/emote, src, nameof(src::trigger()))
 
 //emp proof implant for nuclear operatives
 /obj/item/weapon/implant/explosive/nuclear/emp_act(severity)

--- a/code/game/objects/items/weapons/implants/types/freedom_implant.dm
+++ b/code/game/objects/items/weapons/implants/types/freedom_implant.dm
@@ -26,12 +26,12 @@
 				source.u_equip(jacket, TRUE)
 
 /obj/item/weapon/implant/freedom/implanted(mob/implanter)
-	imp_in.register_event(/event/emote, src, src::trigger())
+	imp_in.register_event(/event/emote, src, nameof(src::trigger()))
 	imp_in.mind.store_memory("Freedom implant can be activated by using the [activation_emote] emote, <B>say *[activation_emote]</B> to attempt to activate.", 0, 0)
 	to_chat(imp_in, "The implanted freedom implant can be activated by using the [activation_emote] emote, <B>say *[activation_emote]</B> to attempt to activate.")
 
 /obj/item/weapon/implant/freedom/handle_removal(mob/remover)
-	imp_in?.unregister_event(/event/emote, src, src::trigger())
+	imp_in?.unregister_event(/event/emote, src, nameof(src::trigger()))
 	makeunusable(75)
 
 /obj/item/weapon/implant/freedom/get_data()

--- a/code/game/objects/items/weapons/implants/types/uplink_implant.dm
+++ b/code/game/objects/items/weapons/implants/types/uplink_implant.dm
@@ -9,14 +9,14 @@
 	uplink_comp.telecrystals = 10
 
 /obj/item/weapon/implant/uplink/implanted(mob/implanter)
-	imp_in.register_event(/event/emote, src, src::trigger())
+	imp_in.register_event(/event/emote, src, nameof(src::trigger()))
 	activation_emote = input("Choose activation emote:") in list("blink", "blink_r", "eyebrow", "chuckle", "twitch_s", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
 	imp_in.mind.store_memory("Uplink implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate.", 0, 0)
 	to_chat(imp_in, "The implanted uplink implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate.")
 	return 1
 
 /obj/item/weapon/implant/uplink/handle_removal(mob/remover)
-	imp_in?.unregister_event(/event/emote, src, src::trigger())
+	imp_in?.unregister_event(/event/emote, src, nameof(src::trigger()))
 	makeunusable(75)
 
 /obj/item/weapon/implant/uplink/activate()

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -370,13 +370,13 @@
 	to_chat(user, active ? "<span class='warning'> [src] starts vibrating.</span>" : "<span class='notice'> [src] stops vibrating.</span>")
 	playsound(user, active ? 'sound/weapons/hfmachete1.ogg' : 'sound/weapons/hfmachete0.ogg', 40, 0)
 	if(active)
-		user.register_event(/event/moved, src, src::mob_moved())
+		user.register_event(/event/moved, src, nameof(src::mob_moved()))
 	else
-		user.unregister_event(/event/moved, src, src::mob_moved())
+		user.unregister_event(/event/moved, src, nameof(src::mob_moved()))
 	update_icon()
 
 /obj/item/weapon/melee/energy/hfmachete/dropped(mob/user)
-	user.unregister_event(/event/moved, src, src::mob_moved())
+	user.unregister_event(/event/moved, src, nameof(src::mob_moved()))
 
 /obj/item/weapon/melee/energy/hfmachete/throw_at(atom/target, range, speed, override = 1)
 	if(!usr)
@@ -475,9 +475,9 @@
 	to_chat(user, active ? "<span class='warning'> [src] starts vibrating.</span>" : "<span class='notice'> [src] stops vibrating.</span>")
 	playsound(user, active ? 'sound/weapons/hfmachete1.ogg' : 'sound/weapons/hfmachete0.ogg', 40, 0 )
 	if(active)
-		user.register_event(/event/moved, src, src::mob_moved())
+		user.register_event(/event/moved, src, nameof(src::mob_moved()))
 	else
-		user.unregister_event(/event/moved, src, src::mob_moved())
+		user.unregister_event(/event/moved, src, nameof(src::mob_moved()))
 
 /obj/item/weapon/melee/energy/hfmachete/bloodlust/IsShield()
 	if(active)

--- a/code/game/objects/items/weapons/null_rod.dm
+++ b/code/game/objects/items/weapons/null_rod.dm
@@ -367,11 +367,11 @@
 		recruiter.jobban_roles = list("pAI") // pAI/Borers share the same jobban check so here we go too.
 
 	// Role set to Yes or Always
-	recruiter.player_volunteering = new /callback(src, src::recruiter_recruiting())
+	recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))
 	// Role set to No or Never
-	recruiter.player_not_volunteering = new /callback(src, src::recruiter_not_recruiting())
+	recruiter.player_not_volunteering = new /callback(src, nameof(src::recruiter_not_recruiting()))
 
-	recruiter.recruited = new /callback(src, src::recruiter_recruited())
+	recruiter.recruited = new /callback(src, nameof(src::recruiter_recruited()))
 
 	recruiter.request_player()
 

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -192,10 +192,10 @@
 
 /obj/item/weapon/storage/bag/ore/auto/pickup(mob/user)
 	if(handling)
-		user.register_event(/event/moved, src, src::mob_moved())
+		user.register_event(/event/moved, src, nameof(src::mob_moved()))
 
 /obj/item/weapon/storage/bag/ore/auto/dropped(mob/user)
-	user.unregister_event(/event/moved, src, src::mob_moved())
+	user.unregister_event(/event/moved, src, nameof(src::mob_moved()))
 
 // -----------------------------
 //          Plant bag

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -242,7 +242,7 @@
 
 /obj/item/binoculars/update_wield(mob/user)
 	if(wielded)
-		user.register_event(/event/moved, src, src::mob_moved())
+		user.register_event(/event/moved, src, nameof(src::mob_moved()))
 		user.visible_message("\The [user] holds \the [src] up to \his eyes.","You hold \the [src] up to your eyes.")
 		item_state = "binoculars_wielded"
 		user.regenerate_icons()
@@ -251,7 +251,7 @@
 			var/client/C = user.client
 			C.changeView(C.view + 7)
 	else
-		user.unregister_event(/event/moved, src, src::mob_moved())
+		user.unregister_event(/event/moved, src, nameof(src::mob_moved()))
 		user.visible_message("\The [user] lowers \the [src].","You lower \the [src].")
 		item_state = "binoculars"
 		user.regenerate_icons()

--- a/code/game/objects/structures/ancient_cryopod.dm
+++ b/code/game/objects/structures/ancient_cryopod.dm
@@ -36,11 +36,11 @@
 			recruiter.display_name = name
 			recruiter.role = ROLE_MINOR
 		// Role set to Yes or Always
-		recruiter.player_volunteering = new /callback(src, src::recruiter_recruiting())
+		recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))
 		// Role set to No or Never
-		recruiter.player_not_volunteering = new /callback(src, src::recruiter_not_recruiting())
+		recruiter.player_not_volunteering = new /callback(src, nameof(src::recruiter_not_recruiting()))
 
-		recruiter.recruited = new /callback(src, src::recruiter_recruited())
+		recruiter.recruited = new /callback(src, nameof(src::recruiter_recruited()))
 		recruiter.request_player()
 	else
 		visible_message("<span class='notice'>\The [name] flickers to life and displays an error message: 'Unable to revive occupant, enviromental pressure inadequate for sustaining human life.'</span>")

--- a/code/game/objects/structures/flora/flora.dm
+++ b/code/game/objects/structures/flora/flora.dm
@@ -115,15 +115,15 @@
 
 	for(var/turf/T in circlerange(src,2))
 		if(T.y > y)
-			T.register_event(/event/entered, src, src::give_transparency())
-			T.register_event(/event/exited, src, src::remove_transparency())
+			T.register_event(/event/entered, src, nameof(src::give_transparency()))
+			T.register_event(/event/exited, src, nameof(src::remove_transparency()))
 
 
 /obj/structure/flora/tree/Destroy()
 	for(var/turf/T in circlerange(src,2))
 		if(T.y > y)
-			T.unregister_event(/event/entered, src, src::give_transparency())
-			T.unregister_event(/event/exited, src, src::remove_transparency())
+			T.unregister_event(/event/entered, src, nameof(src::give_transparency()))
+			T.unregister_event(/event/exited, src, nameof(src::remove_transparency()))
 	..()
 
 /obj/structure/flora/tree/proc/update_transparency()

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -109,7 +109,7 @@ FLOOR SAFES
 				open = FALSE
 		return
 
-	recursive_dial(user, show_radial_menu(user,src,choices,'icons/obj/safe_radial.dmi',"radial-safe", custom_check = new /callback(src, src::radial_check(), user), recursive = TRUE))
+	recursive_dial(user, show_radial_menu(user,src,choices,'icons/obj/safe_radial.dmi',"radial-safe", custom_check = new /callback(src, nameof(src::radial_check()), user), recursive = TRUE))
 
 
 /obj/structure/safe/proc/recursive_dial(var/mob/user, var/datum/radial_menu/radial)
@@ -201,7 +201,7 @@ FLOOR SAFES
 		user.drop_item(I, T)
 	else
 		if(istype(I, /obj/item/clothing/accessory/stethoscope))
-			recursive_dial(user, show_radial_menu(user,src,choices,'icons/obj/safe_radial.dmi',"radial-safe", custom_check = new /callback(src, src::radial_check(), user), recursive = TRUE))
+			recursive_dial(user, show_radial_menu(user,src,choices,'icons/obj/safe_radial.dmi',"radial-safe", custom_check = new /callback(src, nameof(src::radial_check()), user), recursive = TRUE))
 
 /obj/structure/safe/blob_act()
 	return

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -68,7 +68,7 @@
 				list("Take plasma tank", "radial_ptank[platanks.len ? "" : "empty"]"),
 			)
 
-			var/task = show_radial_menu(user,loc,choices,custom_check = new /callback(src, src::radial_check(), user),starting_angle=90,ending_angle=450)
+			var/task = show_radial_menu(user,loc,choices,custom_check = new /callback(src, nameof(src::radial_check()), user),starting_angle=90,ending_angle=450)
 			if(!radial_check(user))
 				return
 

--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -84,11 +84,11 @@
 
 /obj/item/device/rcd/rpd/pickup(var/mob/living/L)
 	..()
-	L.register_event(/event/clickon, src, src::mob_onclickon())
+	L.register_event(/event/clickon, src, nameof(src::mob_onclickon()))
 
 /obj/item/device/rcd/rpd/dropped(var/mob/living/L)
 	..()
-	L.unregister_event(/event/clickon, src, src::mob_onclickon())
+	L.unregister_event(/event/clickon, src, nameof(src::mob_onclickon()))
 	hook_key = null
 
 // If the RPD is held, some modifiers are removed.

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -440,17 +440,17 @@
 		update_icon()
 		to_chat(user, "<span class = 'warning'>You hear \the [src] tick!</span>")
 
-		user.unregister_event(/event/irradiate, src, src::check_rads())
+		user.unregister_event(/event/irradiate, src, nameof(src::check_rads()))
 
 /obj/item/clothing/accessory/rad_patch/on_attached(obj/item/clothing/C)
 	..()
 	if(ismob(C.loc) && !triggered)
 		var/mob/user = C.loc
-		user.register_event(/event/irradiate, src, src::check_rads())
+		user.register_event(/event/irradiate, src, nameof(src::check_rads()))
 
 /obj/item/clothing/accessory/rad_patch/on_removed(mob/user)
 	..()
-	user?.unregister_event(/event/irradiate, src, src::check_rads())
+	user?.unregister_event(/event/irradiate, src, nameof(src::check_rads()))
 
 /obj/item/clothing/accessory/rad_patch/examine(mob/user)
 	..(user)

--- a/code/modules/clothing/glasses/scanners.dm
+++ b/code/modules/clothing/glasses/scanners.dm
@@ -324,11 +324,11 @@ var/list/meson_images = list()
 	clear()
 
 	if (viewing)
-		viewing.unregister_event(/event/logout, src, src::mob_logout())
+		viewing.unregister_event(/event/logout, src, nameof(src::mob_logout()))
 		viewing = null
 
 	if (new_mob)
-		new_mob.register_event(/event/logout, src, src::mob_logout())
+		new_mob.register_event(/event/logout, src, nameof(src::mob_logout()))
 		viewing = new_mob
 
 /obj/item/clothing/glasses/scanner/material/proc/mob_logout(mob/living/carbon/user)
@@ -336,7 +336,7 @@ var/list/meson_images = list()
 		return
 
 	clear()
-	viewing.unregister_event(/event/logout, src, src::mob_logout())
+	viewing.unregister_event(/event/logout, src, nameof(src::mob_logout()))
 	viewing = null
 
 /obj/item/clothing/glasses/scanner/material/proc/get_images(var/turf/T, var/view)

--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -246,7 +246,7 @@
 	rig.armor["rad"] = 100
 
 	say_to_wearer("[src] enabled.")
-	rig.wearer.register_event(/event/irradiate, src, src::absorb_rads())
+	rig.wearer.register_event(/event/irradiate, src, nameof(src::absorb_rads()))
 	..()
 
 /obj/item/rig_module/rad_shield/deactivate()
@@ -261,7 +261,7 @@
 		say_to_wearer("[src] disabled. Please cleanse it by sterilizing the suit in a suit storage unit.")
 	else
 		say_to_wearer("[src] disabled.")
-	rig.wearer?.unregister_event(/event/irradiate, src, src::absorb_rads())
+	rig.wearer?.unregister_event(/event/irradiate, src, nameof(src::absorb_rads()))
 	..()
 
 /obj/item/rig_module/rad_shield/suit_storage_act()
@@ -270,7 +270,7 @@
 
 /obj/item/rig_module/rad_shield/proc/absorb_rads(mob/living/carbon/human/user, rads)
 	if(rig?.wearer != user) //Well lad.
-		user.unregister_event(/event/irradiate, src, src::absorb_rads())
+		user.unregister_event(/event/irradiate, src, nameof(src::absorb_rads()))
 		return
 
 	if(rig.H)

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -1008,12 +1008,12 @@ var/list/tag_suits_list = list()
 		return
 	active = 1
 	canremove = 0
-	H.register_event(/event/touched, src, src::on_touched())
-	H.register_event(/event/attacked_by, src, src::on_attacked_by())
-	H.register_event(/event/hitby, src, src::on_hitby())
-	H.register_event(/event/unarmed_attack, src, src::on_unarmed_attack())
-	H.register_event(/event/to_bump, src, src::on_to_bump())
-	H.register_event(/event/bumped, src, src::on_bumped())
+	H.register_event(/event/touched, src, nameof(src::on_touched()))
+	H.register_event(/event/attacked_by, src, nameof(src::on_attacked_by()))
+	H.register_event(/event/hitby, src, nameof(src::on_hitby()))
+	H.register_event(/event/unarmed_attack, src, nameof(src::on_unarmed_attack()))
+	H.register_event(/event/to_bump, src, nameof(src::on_to_bump()))
+	H.register_event(/event/bumped, src, nameof(src::on_bumped()))
 
 /obj/item/clothing/suit/bomber_vest/proc/on_touched(mob/toucher, mob/touched)
 	if(toucher == touched) //No bombing ourselves by checking ourselves
@@ -1040,12 +1040,12 @@ var/list/tag_suits_list = list()
 	active = 0
 	var/mob/living/carbon/human/H = loc
 	if(H)
-		H.unregister_event(/event/touched, src, src::on_touched())
-		H.unregister_event(/event/attacked_by, src, src::on_attacked_by())
-		H.unregister_event(/event/hitby, src, src::on_hitby())
-		H.unregister_event(/event/unarmed_attack, src, src::on_unarmed_attack())
-		H.unregister_event(/event/to_bump, src, src::on_to_bump())
-		H.unregister_event(/event/bumped, src, src::on_bumped())
+		H.unregister_event(/event/touched, src, nameof(src::on_touched()))
+		H.unregister_event(/event/attacked_by, src, nameof(src::on_attacked_by()))
+		H.unregister_event(/event/hitby, src, nameof(src::on_hitby()))
+		H.unregister_event(/event/unarmed_attack, src, nameof(src::on_unarmed_attack()))
+		H.unregister_event(/event/to_bump, src, nameof(src::on_to_bump()))
+		H.unregister_event(/event/bumped, src, nameof(src::on_bumped()))
 
 /obj/item/clothing/suit/bomber_vest/examine(mob/user)
 	..()

--- a/code/modules/clothing/suits/plate_carrier.dm
+++ b/code/modules/clothing/suits/plate_carrier.dm
@@ -26,12 +26,12 @@
 /obj/item/clothing/suit/armor/plate_carrier/equipped(var/mob/user, var/slot)
 	..()
 	if(slot == slot_wear_suit)
-		user.register_event(/event/damaged, src, src::handle_user_damage())
+		user.register_event(/event/damaged, src, nameof(src::handle_user_damage()))
 
 
 /obj/item/clothing/suit/armor/plate_carrier/unequipped(mob/user, var/from_slot = null)
 	if(from_slot == slot_wear_suit)
-		user.unregister_event(/event/damaged, src, src::handle_user_damage())
+		user.unregister_event(/event/damaged, src, nameof(src::handle_user_damage()))
 	..()
 
 /obj/item/clothing/suit/armor/plate_carrier/attack_self(mob/user)

--- a/code/modules/components/ai/area_territorial.dm
+++ b/code/modules/components/ai/area_territorial.dm
@@ -9,13 +9,13 @@
 /datum/component/ai/area_territorial/proc/SetArea(var/area/new_area)
 	unset_area()
 	territory = new_area
-	territory.register_event(/event/area_entered, src, src::area_enter())
-	territory.register_event(/event/area_exited, src, src::area_exit())
+	territory.register_event(/event/area_entered, src, nameof(src::area_enter()))
+	territory.register_event(/event/area_exited, src, nameof(src::area_exit()))
 
 /datum/component/ai/area_territorial/proc/unset_area()
 	if(territory)
-		territory.unregister_event(/event/area_entered, src, src::area_enter())
-		territory.unregister_event(/event/area_exited, src, src::area_exit())
+		territory.unregister_event(/event/area_entered, src, nameof(src::area_enter()))
+		territory.unregister_event(/event/area_exited, src, nameof(src::area_exit()))
 
 /datum/component/ai/area_territorial/Destroy()
 	unset_area()

--- a/code/modules/components/ai/controller.dm
+++ b/code/modules/components/ai/controller.dm
@@ -5,26 +5,26 @@
 	var/_state = HOSTILE_STANCE_IDLE
 
 /datum/component/controller/initialize()
-	parent.register_event(/event/comp_ai_cmd_set_busy, src, src::cmd_set_busy())
-	parent.register_event(/event/comp_ai_cmd_get_busy, src, src::cmd_get_busy())
+	parent.register_event(/event/comp_ai_cmd_set_busy, src, nameof(src::cmd_set_busy()))
+	parent.register_event(/event/comp_ai_cmd_get_busy, src, nameof(src::cmd_get_busy()))
 
-	parent.register_event(/event/comp_ai_cmd_set_target, src, src::cmd_set_target())
-	parent.register_event(/event/comp_ai_cmd_get_target, src, src::cmd_get_target())
+	parent.register_event(/event/comp_ai_cmd_set_target, src, nameof(src::cmd_set_target()))
+	parent.register_event(/event/comp_ai_cmd_get_target, src, nameof(src::cmd_get_target()))
 
-	parent.register_event(/event/comp_ai_cmd_set_state, src, src::cmd_set_state())
-	parent.register_event(/event/comp_ai_cmd_get_state, src, src::cmd_get_state())
+	parent.register_event(/event/comp_ai_cmd_set_state, src, nameof(src::cmd_set_state()))
+	parent.register_event(/event/comp_ai_cmd_get_state, src, nameof(src::cmd_get_state()))
 
 	return TRUE
 
 /datum/component/controller/Destroy()
-	parent.unregister_event(/event/comp_ai_cmd_set_busy, src, src::cmd_set_busy())
-	parent.unregister_event(/event/comp_ai_cmd_get_busy, src, src::cmd_get_busy())
+	parent.unregister_event(/event/comp_ai_cmd_set_busy, src, nameof(src::cmd_set_busy()))
+	parent.unregister_event(/event/comp_ai_cmd_get_busy, src, nameof(src::cmd_get_busy()))
 
-	parent.unregister_event(/event/comp_ai_cmd_set_target, src, src::cmd_set_target())
-	parent.unregister_event(/event/comp_ai_cmd_get_target, src, src::cmd_get_target())
+	parent.unregister_event(/event/comp_ai_cmd_set_target, src, nameof(src::cmd_set_target()))
+	parent.unregister_event(/event/comp_ai_cmd_get_target, src, nameof(src::cmd_get_target()))
 
-	parent.unregister_event(/event/comp_ai_cmd_set_state, src, src::cmd_set_state())
-	parent.unregister_event(/event/comp_ai_cmd_get_state, src, src::cmd_get_state())
+	parent.unregister_event(/event/comp_ai_cmd_set_state, src, nameof(src::cmd_set_state()))
+	parent.unregister_event(/event/comp_ai_cmd_get_state, src, nameof(src::cmd_get_state()))
 	return ..()
 
 /datum/component/controller/proc/cmd_set_busy(yes)

--- a/code/modules/components/ai/controllers/movement.dm
+++ b/code/modules/components/ai/controllers/movement.dm
@@ -2,11 +2,11 @@
 	var/walk_delay = 4
 
 /datum/component/controller/movement/initialize()
-	parent.register_event(/event/comp_ai_cmd_move, src, src::cmd_move())
+	parent.register_event(/event/comp_ai_cmd_move, src, nameof(src::cmd_move()))
 	return TRUE
 
 /datum/component/controller/movement/Destroy()
-	parent.unregister_event(/event/comp_ai_cmd_move, src, src::cmd_move())
+	parent.unregister_event(/event/comp_ai_cmd_move, src, nameof(src::cmd_move()))
 	..()
 
 /datum/component/controller/movement/proc/cmd_move(target)

--- a/code/modules/components/ai/controllers/simple_animal.dm
+++ b/code/modules/components/ai/controllers/simple_animal.dm
@@ -2,11 +2,11 @@
 	var/disable_automove_on_busy = TRUE
 
 /datum/component/controller/simple_animal/initialize()
-	parent.register_event(/event/comp_ai_cmd_can_attack, src, src::cmd_can_attack())
+	parent.register_event(/event/comp_ai_cmd_can_attack, src, nameof(src::cmd_can_attack()))
 	return ..()
 
 /datum/component/controller/simple_animal/Destroy()
-	parent.unregister_event(/event/comp_ai_cmd_can_attack, src, src::cmd_can_attack())
+	parent.unregister_event(/event/comp_ai_cmd_can_attack, src, nameof(src::cmd_can_attack()))
 	..()
 
 /datum/component/controller/simple_animal/proc/cmd_can_attack(target)

--- a/code/modules/components/ai/conversation.dm
+++ b/code/modules/components/ai/conversation.dm
@@ -2,13 +2,13 @@
 	var/list/messages = list()
 
 /datum/component/ai/conversation/initialize()
-	parent.register_event(/event/comp_ai_cmd_say, src, src::cmd_say())
-	parent.register_event(/event/comp_ai_cmd_specific_say, src, src::cmd_specific_say())
+	parent.register_event(/event/comp_ai_cmd_say, src, nameof(src::cmd_say()))
+	parent.register_event(/event/comp_ai_cmd_specific_say, src, nameof(src::cmd_specific_say()))
 	return TRUE
 
 /datum/component/ai/conversation/Destroy()
-	parent.unregister_event(/event/comp_ai_cmd_say, src, src::cmd_say())
-	parent.unregister_event(/event/comp_ai_cmd_specific_say, src, src::cmd_specific_say())
+	parent.unregister_event(/event/comp_ai_cmd_say, src, nameof(src::cmd_say()))
+	parent.unregister_event(/event/comp_ai_cmd_specific_say, src, nameof(src::cmd_specific_say()))
 	..()
 
 /datum/component/ai/conversation/proc/cmd_say()

--- a/code/modules/components/ai/def_zone_handler.dm
+++ b/code/modules/components/ai/def_zone_handler.dm
@@ -15,11 +15,11 @@
 	)
 
 /datum/component/ai/targetting_handler/initialize()
-	parent.register_event(/event/comp_ai_cmd_evaluate_target, src, src::evaluate_target())
+	parent.register_event(/event/comp_ai_cmd_evaluate_target, src, nameof(src::evaluate_target()))
 	return TRUE
 
 /datum/component/ai/targetting_handler/Destroy()
-	parent.unregister_event(/event/comp_ai_cmd_evaluate_target, src, src::evaluate_target())
+	parent.unregister_event(/event/comp_ai_cmd_evaluate_target, src, nameof(src::evaluate_target()))
 	..()
 
 //Center mass.

--- a/code/modules/components/ai/door_opener.dm
+++ b/code/modules/components/ai/door_opener.dm
@@ -3,11 +3,11 @@
 	var/max_pressure_diff = -1
 
 /datum/component/ai/door_opener/initialize()
-	parent.register_event(/event/comp_ai_cmd_attack, src, src::cmd_attack())
+	parent.register_event(/event/comp_ai_cmd_attack, src, nameof(src::cmd_attack()))
 	return TRUE
 
 /datum/component/ai/door_opener/Destroy()
-	parent.unregister_event(/event/comp_ai_cmd_attack, src, src::cmd_attack())
+	parent.unregister_event(/event/comp_ai_cmd_attack, src, nameof(src::cmd_attack()))
 	..()
 
 /datum/component/ai/door_opener/proc/cmd_attack(atom/target)

--- a/code/modules/components/ai/hearing.dm
+++ b/code/modules/components/ai/hearing.dm
@@ -9,11 +9,11 @@
 	var/response_delay = 10
 
 /datum/component/ai/hearing/initialize()
-	parent.register_event(/event/hear, src, src::on_hear())
+	parent.register_event(/event/hear, src, nameof(src::on_hear()))
 	return TRUE
 
 /datum/component/ai/hearing/Destroy()
-	parent.unregister_event(/event/hear, src, src::on_hear())
+	parent.unregister_event(/event/hear, src, nameof(src::on_hear()))
 	..()
 
 /datum/component/ai/hearing/proc/on_hear(datum/speech/speech)
@@ -72,7 +72,7 @@
 
 /datum/component/ai/hearing/order/initialize()
 	..()
-	parent.register_event(/event/comp_ai_cmd_order, src, src::on_order())
+	parent.register_event(/event/comp_ai_cmd_order, src, nameof(src::on_order()))
 	if(!notfoundmessages.len)
 		notfoundmessages = list("ERROR-[Gibberish(rand(1000,9999),50)]: Item not found. Please try again.")
 	if(!(src in active_components))
@@ -81,7 +81,7 @@
 	return TRUE
 
 /datum/component/ai/hearing/order/Destroy()
-	parent.unregister_event(/event/comp_ai_cmd_order, src, src::on_order())
+	parent.unregister_event(/event/comp_ai_cmd_order, src, nameof(src::on_order()))
 	active_components -= src
 	..()
 

--- a/code/modules/components/ai/hostile/melee/melee.dm
+++ b/code/modules/components/ai/hostile/melee/melee.dm
@@ -1,11 +1,11 @@
 /datum/component/ai/melee
 
 /datum/component/ai/melee/initialize()
-	parent.register_event(/event/comp_ai_cmd_attack, src, src::cmd_attack())
+	parent.register_event(/event/comp_ai_cmd_attack, src, nameof(src::cmd_attack()))
 	return TRUE
 
 /datum/component/ai/melee/Destroy()
-	parent.unregister_event(/event/comp_ai_cmd_attack, src, src::cmd_attack())
+	parent.unregister_event(/event/comp_ai_cmd_attack, src, nameof(src::cmd_attack()))
 	..()
 
 /datum/component/ai/melee/proc/can_attack(atom/target)

--- a/code/modules/components/ai/human/human_target_finder.dm
+++ b/code/modules/components/ai/human/human_target_finder.dm
@@ -2,13 +2,13 @@
 	range = 7
 
 /datum/component/ai/target_finder/human/initialize()
-	parent.register_event(/event/attackby, src, src::on_attackby())
-	parent.register_event(/event/comp_ai_cmd_find_targets, src, src::cmd_find_targets())
+	parent.register_event(/event/attackby, src, nameof(src::on_attackby()))
+	parent.register_event(/event/comp_ai_cmd_find_targets, src, nameof(src::cmd_find_targets()))
 	return TRUE
 
 /datum/component/ai/target_finder/human/Destroy()
-	parent.unregister_event(/event/attackby, src, src::on_attackby())
-	parent.unregister_event(/event/comp_ai_cmd_find_targets, src, src::cmd_find_targets())
+	parent.unregister_event(/event/attackby, src, nameof(src::on_attackby()))
+	parent.unregister_event(/event/comp_ai_cmd_find_targets, src, nameof(src::cmd_find_targets()))
 	..()
 
 /datum/component/ai/target_finder/human/cmd_find_targets()

--- a/code/modules/components/ai/human/retaliate.dm
+++ b/code/modules/components/ai/human/retaliate.dm
@@ -1,11 +1,11 @@
 /datum/component/ai/crowd_attack
 
 /datum/component/ai/crowd_attack/initialize()
-	parent.register_event(/event/attackby, src, src::on_attackby())
+	parent.register_event(/event/attackby, src, nameof(src::on_attackby()))
 	return TRUE
 
 /datum/component/ai/crowd_attack/Destroy()
-	parent.unregister_event(/event/attackby, src, src::on_attackby())
+	parent.unregister_event(/event/attackby, src, nameof(src::on_attackby()))
 	..()
 
 /datum/component/ai/crowd_attack/proc/on_attackby(mob/attacker, obj/item/item)

--- a/code/modules/components/ai/target_finders/target_finder.dm
+++ b/code/modules/components/ai/target_finders/target_finder.dm
@@ -7,11 +7,11 @@
 	)
 
 /datum/component/ai/target_finder/initialize()
-	parent.register_event(/event/comp_ai_cmd_find_targets, src, src::cmd_find_targets())
+	parent.register_event(/event/comp_ai_cmd_find_targets, src, nameof(src::cmd_find_targets()))
 	return TRUE
 
 /datum/component/ai/target_finder/Destroy()
-	parent.unregister_event(/event/comp_ai_cmd_find_targets, src, src::cmd_find_targets())
+	parent.unregister_event(/event/comp_ai_cmd_find_targets, src, nameof(src::cmd_find_targets()))
 	..()
 
 /datum/component/ai/target_finder/proc/cmd_find_targets()

--- a/code/modules/components/ai/target_holders/target_holder.dm
+++ b/code/modules/components/ai/target_holders/target_holder.dm
@@ -1,9 +1,9 @@
 /datum/component/ai/target_holder
 
 /datum/component/ai/target_holder/initialize()
-	parent.register_event(/event/comp_ai_cmd_add_target, src, src::cmd_add_target())
-	parent.register_event(/event/comp_ai_cmd_remove_target, src, src::cmd_remove_target())
-	parent.register_event(/event/comp_ai_cmd_get_best_target, src, src::cmd_get_best_target())
+	parent.register_event(/event/comp_ai_cmd_add_target, src, nameof(src::cmd_add_target()))
+	parent.register_event(/event/comp_ai_cmd_remove_target, src, nameof(src::cmd_remove_target()))
+	parent.register_event(/event/comp_ai_cmd_get_best_target, src, nameof(src::cmd_get_best_target()))
 	return TRUE
 
 /datum/component/ai/target_holder/proc/cmd_add_target(var/atom/A)

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -50,12 +50,12 @@
 /obj/effect/plantsegment/proc/before_moving()
 	for(var/direc in cardinal)
 		var/turf/T = get_step(src, direc)
-		T.unregister_event(/event/density_change, src, src::proxDensityChange())
+		T.unregister_event(/event/density_change, src, nameof(src::proxDensityChange()))
 
 /obj/effect/plantsegment/proc/after_moving()
 	for(var/direc in cardinal)
 		var/turf/T = get_step(src, direc)
-		T.register_event(/event/density_change, src, src::proxDensityChange())
+		T.register_event(/event/density_change, src, nameof(src::proxDensityChange()))
 
 /obj/effect/plantsegment/New(var/newloc, var/datum/seed/newseed, var/turf/newepicenter, var/start_fully_mature = 0)
 	..()

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -145,7 +145,7 @@
 	if(!istype(M))
 		return
 
-	M.register_event(/event/resist, src, src::manual_unbuckle())
+	M.register_event(/event/resist, src, nameof(src::manual_unbuckle()))
 
 	last_special = world.time
 
@@ -157,7 +157,7 @@
 	if(!istype(M))
 		return
 
-	M.unregister_event(/event/resist, src, src::manual_unbuckle())
+	M.unregister_event(/event/resist, src, nameof(src::manual_unbuckle()))
 
 /obj/effect/plantsegment/proc/entangle_mob(var/mob/living/victim)
 	if(!victim || victim.locked_to || !seed || seed.spread != 2 || is_locking(/datum/locking_category/plantsegment)) //How much of this is actually necessary, I wonder

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -42,11 +42,11 @@
 		recruiter.logging = TRUE
 
 		// A player has their role set to Yes or Always
-		recruiter.player_volunteering = new /callback(src, src::recruiter_recruiting())
+		recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))
 		// ", but No or Never
-		recruiter.player_not_volunteering = new /callback(src, src::recruiter_not_recruiting())
+		recruiter.player_not_volunteering = new /callback(src, nameof(src::recruiter_not_recruiting()))
 
-		recruiter.recruited = new /callback(src, src::recruiter_recruited())
+		recruiter.recruited = new /callback(src, nameof(src::recruiter_recruited()))
 
 	recruiter.request_player()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -218,8 +218,8 @@
 
 	update_mutantrace()
 
-	register_event(/event/equipped, src, src::update_name())
-	register_event(/event/unequipped, src, src::update_name())
+	register_event(/event/equipped, src, nameof(src::update_name()))
+	register_event(/event/unequipped, src, nameof(src::update_name()))
 
 /mob/living/carbon/human/proc/update_name()
 	name = get_visible_name()

--- a/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
@@ -269,11 +269,11 @@
 		recruiter.logging = TRUE
 
 		// A player has their role set to Yes or Always
-		recruiter.player_volunteering = new /callback(src, src::recruiter_recruiting())
+		recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))
 		// ", but No or Never
-		recruiter.player_not_volunteering = new /callback(src, src::recruiter_not_recruiting())
+		recruiter.player_not_volunteering = new /callback(src, nameof(src::recruiter_not_recruiting()))
 
-		recruiter.recruited = new /callback(src, src::recruiter_recruited())
+		recruiter.recruited = new /callback(src, nameof(src::recruiter_recruited()))
 
 	recruiter.request_player()
 

--- a/code/modules/mob/living/simple_animal/borer/egg.dm
+++ b/code/modules/mob/living/simple_animal/borer/egg.dm
@@ -40,11 +40,11 @@
 		recruiter.jobban_roles = list("pAI")
 
 		// A player has their role set to Yes or Always
-		recruiter.player_volunteering = new /callback(src, src::recruiter_recruiting())
+		recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))
 		// ", but No or Never
-		recruiter.player_not_volunteering = new /callback(src, src::recruiter_not_recruiting())
+		recruiter.player_not_volunteering = new /callback(src, nameof(src::recruiter_not_recruiting()))
 
-		recruiter.recruited = new /callback(src, src::recruiter_recruited())
+		recruiter.recruited = new /callback(src, nameof(src::recruiter_recruited()))
 
 /obj/item/weapon/reagent_containers/food/snacks/borer_egg/proc/Hatch()
 	if(hatching)

--- a/code/modules/mob/living/simple_animal/grue_egg.dm
+++ b/code/modules/mob/living/simple_animal/grue_egg.dm
@@ -89,11 +89,11 @@
 //		recruiter.jobban_roles = list("pAI")
 
 		// A player has their role set to Yes or Always
-		recruiter.player_volunteering = new /callback(src, src::recruiter_recruiting())
+		recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))
 		// ", but No or Never
-		recruiter.player_not_volunteering = new /callback(src, src::recruiter_not_recruiting())
+		recruiter.player_not_volunteering = new /callback(src, nameof(src::recruiter_not_recruiting()))
 
-		recruiter.recruited = new /callback(src, src::recruiter_recruited())
+		recruiter.recruited = new /callback(src, nameof(src::recruiter_recruited()))
 
 /mob/living/simple_animal/grue_egg/proc/Hatch()
 	if(hatching)

--- a/code/modules/optics/mirrors/mirror.dm
+++ b/code/modules/optics/mirrors/mirror.dm
@@ -101,7 +101,7 @@ var/global/list/obj/machinery/mirror/mirror_list = list()
 		if(B.HasSource(src))
 			return // Prevent infinite loops.
 		..()
-		B.register_event(/event/beam_power_change, src, src::on_power_change())
+		B.register_event(/event/beam_power_change, src, nameof(src::on_power_change()))
 		update_beams()
 
 /obj/machinery/mirror/beam_disconnect(var/obj/effect/beam/emitter/B)
@@ -109,7 +109,7 @@ var/global/list/obj/machinery/mirror/mirror_list = list()
 		if(B.HasSource(src))
 			return // Prevent infinite loops.
 		..()
-		B.unregister_event(/event/beam_power_change, src, src::on_power_change())
+		B.unregister_event(/event/beam_power_change, src, nameof(src::on_power_change()))
 		update_beams()
 
 // When beam power changes

--- a/code/modules/optics/prism.dm
+++ b/code/modules/optics/prism.dm
@@ -80,7 +80,7 @@ var/list/obj/machinery/prism/prism_list = list()
 		if(B.HasSource(src))
 			return // Prevent infinite loops.
 		..()
-		B.register_event(/event/beam_power_change, src, src::on_power_change())
+		B.register_event(/event/beam_power_change, src, nameof(src::on_power_change()))
 		update_beams(B)
 
 /obj/machinery/prism/beam_disconnect(var/obj/effect/beam/emitter/B)
@@ -88,7 +88,7 @@ var/list/obj/machinery/prism/prism_list = list()
 		if(B.HasSource(src))
 			return // Prevent infinite loops.
 		..()
-		B.unregister_event(/event/beam_power_change, src, src::on_power_change())
+		B.unregister_event(/event/beam_power_change, src, nameof(src::on_power_change()))
 		update_beams(B)
 
 // When beam power changes

--- a/code/modules/power/components.dm
+++ b/code/modules/power/components.dm
@@ -34,7 +34,7 @@
 	power_machines |= src
 
 	// Used for updating turf power_connection lists when moved.
-	parent.register_event(/event/moved, src, src::parent_moved())
+	parent.register_event(/event/moved, src, nameof(src::parent_moved()))
 	addToTurf()
 
 /datum/power_connection/Destroy()
@@ -43,7 +43,7 @@
 
 	// Remember to tell our turf that we're gone.
 	removeFromTurf()
-	parent.unregister_event(/event/moved, src, src::parent_moved())
+	parent.unregister_event(/event/moved, src, nameof(src::parent_moved()))
 	..()
 
 // CALLBACK from /event/moved.

--- a/code/modules/projectiles/guns/projectile/constructable/tomahawk.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/tomahawk.dm
@@ -161,7 +161,7 @@
 
 /obj/item/weapon/hatchet/tomahawk/pipe/Destroy()
 	if(current_blunt)
-		current_blunt.unregister_event(/event/destroyed, src, src::burnout())
+		current_blunt.unregister_event(/event/destroyed, src, nameof(src::burnout()))
 		QDEL_NULL(current_blunt)
 	..()
 
@@ -179,7 +179,7 @@
 			return
 		to_chat(user, "<span class='notice'>You crush \the [W] into \the [src].</span>")
 		var/obj/item/clothing/mask/cigarette/blunt/rolled/B = new/obj/item/clothing/mask/cigarette/blunt/rolled(src)
-		B.register_event(/event/destroyed, src, src::burnout())
+		B.register_event(/event/destroyed, src, nameof(src::burnout()))
 		B.inside_item = 1
 		W.reagents.trans_to(B, (W.reagents.total_volume))
 		B.update_brightness()
@@ -321,7 +321,7 @@
 			return
 		to_chat(user, "<span class='notice'>You crush \the [W] into \the [src].</span>")
 		var/obj/item/clothing/mask/cigarette/blunt/rolled/B = new/obj/item/clothing/mask/cigarette/blunt/rolled(src)
-		B.register_event(/event/destroyed, src, src::burnout())
+		B.register_event(/event/destroyed, src, nameof(src::burnout()))
 		B.inside_item = 1
 		W.reagents.trans_to(B, (W.reagents.total_volume))
 		B.update_brightness()

--- a/code/modules/reagents/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/machinery/reagentgrinder.dm
@@ -347,7 +347,7 @@ var/global/list/juice_items = list (
 			list("Detach Beaker", "radial_detachbeaker")
 		)
 
-		var/task = show_radial_menu(usr,loc,choices,custom_check = new /callback(src, src::radial_check(), user))
+		var/task = show_radial_menu(usr,loc,choices,custom_check = new /callback(src, nameof(src::radial_check()), user))
 		if(!radial_check(user))
 			return
 

--- a/code/modules/research/xenoarchaeology/artifact/artifact_essenceprinter.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_essenceprinter.dm
@@ -14,7 +14,7 @@
 /obj/structure/essence_printer/Destroy()
 	new /datum/artifact_postmortem_data(src)
 	if(bound_soul)
-		bound_soul.unregister_event(/event/death, src, src::print())
+		bound_soul.unregister_event(/event/death, src, nameof(src::print()))
 		bound_soul = null
 	..()
 
@@ -34,9 +34,9 @@
 	R.languages = H.languages.Copy()
 	R.name=R.dna.real_name
 	if(bound_soul)
-		bound_soul.unregister_event(/event/death, src, src::print())
+		bound_soul.unregister_event(/event/death, src, nameof(src::print()))
 	bound_soul = H
-	H.register_event(/event/death, src, src::print())
+	H.register_event(/event/death, src, nameof(src::print()))
 
 /obj/structure/essence_printer/attack_ghost(mob/user)
 	if(!ready)

--- a/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_energy.dm
+++ b/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_energy.dm
@@ -4,9 +4,9 @@
 
 /datum/artifact_trigger/energy/New()
 	..()
-	my_artifact.register_event(/event/attackby, src, src::owner_attackby())
-	my_artifact.register_event(/event/projectile, src, src::owner_projectile())
-	my_artifact.register_event(/event/beam_connect, src, src::owner_beam())
+	my_artifact.register_event(/event/attackby, src, nameof(src::owner_attackby()))
+	my_artifact.register_event(/event/projectile, src, nameof(src::owner_projectile()))
+	my_artifact.register_event(/event/beam_connect, src, nameof(src::owner_beam()))
 
 /datum/artifact_trigger/energy/proc/owner_attackby(mob/living/attacker, obj/item/item)
 	var/static/list/energy_weapons = list(
@@ -38,7 +38,7 @@
 		Triggered(null, "BEAMCONNECT", beam)
 
 /datum/artifact_trigger/energy/Destroy()
-	my_artifact.unregister_event(/event/attackby, src, src::owner_attackby())
-	my_artifact.unregister_event(/event/projectile, src, src::owner_projectile())
-	my_artifact.unregister_event(/event/beam_connect, src, src::owner_beam())
+	my_artifact.unregister_event(/event/attackby, src, nameof(src::owner_attackby()))
+	my_artifact.unregister_event(/event/projectile, src, nameof(src::owner_projectile()))
+	my_artifact.unregister_event(/event/beam_connect, src, nameof(src::owner_beam()))
 	..()

--- a/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_force.dm
+++ b/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_force.dm
@@ -9,10 +9,10 @@
 
 /datum/artifact_trigger/force/New()
 	..()
-	my_artifact.register_event(/event/attackby, src, src::owner_attackby())
-	my_artifact.register_event(/event/explosion, src, src::owner_explode())
-	my_artifact.register_event(/event/projectile, src, src::owner_projectile())
-	my_artifact.register_event(/event/bumped, src, src::owner_bumped())
+	my_artifact.register_event(/event/attackby, src, nameof(src::owner_attackby()))
+	my_artifact.register_event(/event/explosion, src, nameof(src::owner_explode()))
+	my_artifact.register_event(/event/projectile, src, nameof(src::owner_projectile()))
+	my_artifact.register_event(/event/bumped, src, nameof(src::owner_bumped()))
 
 /datum/artifact_trigger/force/proc/owner_attackby(mob/living/attacker, obj/item/item)
 	if(item.force < FORCE_THRESHOLD)
@@ -40,8 +40,8 @@
 	Triggered(usr, "THROW", thrown_item)
 
 /datum/artifact_trigger/force/Destroy()
-	my_artifact.unregister_event(/event/attackby, src, src::owner_attackby())
-	my_artifact.unregister_event(/event/explosion, src, src::owner_explode())
-	my_artifact.unregister_event(/event/projectile, src, src::owner_projectile())
-	my_artifact.unregister_event(/event/bumped, src, src::owner_bumped())
+	my_artifact.unregister_event(/event/attackby, src, nameof(src::owner_attackby()))
+	my_artifact.unregister_event(/event/explosion, src, nameof(src::owner_explode()))
+	my_artifact.unregister_event(/event/projectile, src, nameof(src::owner_projectile()))
+	my_artifact.unregister_event(/event/bumped, src, nameof(src::owner_bumped()))
 	..()

--- a/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_pay2use.dm
+++ b/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_pay2use.dm
@@ -11,8 +11,8 @@
 
 /datum/artifact_trigger/pay2use/New()
 	..()
-	my_artifact.register_event(/event/attackhand, src, src::owner_attackhand())
-	my_artifact.register_event(/event/attackby, src, src::owner_attackby())
+	my_artifact.register_event(/event/attackhand, src, nameof(src::owner_attackhand()))
+	my_artifact.register_event(/event/attackby, src, nameof(src::owner_attackby()))
 	mode = rand(0,2)
 	var/where = pick("on one of its sides","at the top","hidden underneath", "on the front")
 	switch(mode)
@@ -189,7 +189,7 @@
 		payviacard(500, 3600, usr)
 
 /datum/artifact_trigger/pay2use/Destroy()
-	my_artifact.unregister_event(/event/attackhand, src, src::owner_attackhand())
-	my_artifact.unregister_event(/event/attackby, src, src::owner_attackby())
+	my_artifact.unregister_event(/event/attackhand, src, nameof(src::owner_attackhand()))
+	my_artifact.unregister_event(/event/attackby, src, nameof(src::owner_attackby()))
 	linked_db = null
 	..()

--- a/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_pressure.dm
+++ b/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_pressure.dm
@@ -10,7 +10,7 @@
 /datum/artifact_trigger/pressure/New()
 	..()
 	high_triggered = prob(50)
-	my_artifact.register_event(/event/explosion, src, src::owner_explode())
+	my_artifact.register_event(/event/explosion, src, nameof(src::owner_explode()))
 
 /datum/artifact_trigger/pressure/CheckTrigger()
 	var/turf/T = get_turf(my_artifact)
@@ -31,5 +31,5 @@
 	Triggered(0, "EXPLOSION", 0)
 
 /datum/artifact_trigger/pressure/Destroy()
-	my_artifact.register_event(/event/explosion, src, src::owner_explode())
+	my_artifact.register_event(/event/explosion, src, nameof(src::owner_explode()))
 	..()

--- a/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_reagent.dm
+++ b/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_reagent.dm
@@ -6,7 +6,7 @@
 /datum/artifact_trigger/reagent/New()
 	..()
 	reagent_group = pick("WATER", "ACID", "VOLATILE", "TOXIN")
-	my_artifact.register_event(/event/attackby, src, src::owner_attackby())
+	my_artifact.register_event(/event/attackby, src, nameof(src::owner_attackby()))
 
 /datum/artifact_trigger/reagent/proc/owner_attackby(mob/living/attacker, obj/item/item)
 	if (istype(item, /obj/item/weapon/reagent_containers/glass) && item.is_open_container() ||\
@@ -21,5 +21,5 @@
 			Triggered(attacker, reagent_group, item)
 
 /datum/artifact_trigger/reagent/Destroy()
-	my_artifact.unregister_event(/event/attackby, src, src::owner_attackby())
+	my_artifact.unregister_event(/event/attackby, src, nameof(src::owner_attackby()))
 	..()

--- a/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_temperature.dm
+++ b/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_temperature.dm
@@ -10,8 +10,8 @@
 	..()
 	heat_triggered = prob(50)
 
-	my_artifact.register_event(/event/attackby, src, src::owner_attackby())
-	my_artifact.register_event(/event/explosion, src, src::owner_explode())
+	my_artifact.register_event(/event/attackby, src, nameof(src::owner_attackby()))
+	my_artifact.register_event(/event/explosion, src, nameof(src::owner_explode()))
 
 /datum/artifact_trigger/temperature/CheckTrigger()
 	var/turf/T = get_turf(my_artifact)
@@ -36,6 +36,6 @@
 	Triggered(0, "EXPLOSION", 0)
 
 /datum/artifact_trigger/temperature/Destroy()
-	my_artifact.unregister_event(/event/attackby, src, src::owner_attackby())
-	my_artifact.unregister_event(/event/explosion, src, src::owner_explode())
+	my_artifact.unregister_event(/event/attackby, src, nameof(src::owner_attackby()))
+	my_artifact.unregister_event(/event/explosion, src, nameof(src::owner_explode()))
 	..()

--- a/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_touch.dm
+++ b/code/modules/research/xenoarchaeology/artifact/triggers/unknown_trigger_touch.dm
@@ -4,8 +4,8 @@
 
 /datum/artifact_trigger/touch/New()
 	..()
-	my_artifact.register_event(/event/attackhand, src, src::owner_attackhand())
-	my_artifact.register_event(/event/bumped, src, src::owner_bumped())
+	my_artifact.register_event(/event/attackhand, src, nameof(src::owner_attackhand()))
+	my_artifact.register_event(/event/bumped, src, nameof(src::owner_bumped()))
 
 /datum/artifact_trigger/touch/proc/activate(mob/user, context)
 	Triggered(user, "TOUCH", 0)
@@ -26,6 +26,6 @@
 	activate(user, "TOUCH")
 
 /datum/artifact_trigger/touch/Destroy()
-	my_artifact.unregister_event(/event/attackhand, src, src::owner_attackhand())
-	my_artifact.unregister_event(/event/bumped, src, src::owner_bumped())
+	my_artifact.unregister_event(/event/attackhand, src, nameof(src::owner_attackhand()))
+	my_artifact.unregister_event(/event/bumped, src, nameof(src::owner_bumped()))
 	..()

--- a/code/modules/research/xenoarchaeology/tools/bunsen_burner.dm
+++ b/code/modules/research/xenoarchaeology/tools/bunsen_burner.dm
@@ -244,7 +244,7 @@
 		list("Examine", "radial_examine")
 	)
 
-	var/task = show_radial_menu(usr,loc,choices,custom_check = new /callback(src, src::radial_check(), user))
+	var/task = show_radial_menu(usr,loc,choices,custom_check = new /callback(src, nameof(src::radial_check()), user))
 	if(!radial_check(user))
 		return
 

--- a/code/modules/spells/aoe_turf/conjure/arcane_golem.dm
+++ b/code/modules/spells/aoe_turf/conjure/arcane_golem.dm
@@ -33,7 +33,7 @@
 /spell/aoe_turf/conjure/arcane_golem/cast(list/targets, mob/user)
 	//Link the golem to its master
 	newVars = list("master_spell" = src)
-	user.register_event(/event/spellcast, src, src::copy_spellcast())
+	user.register_event(/event/spellcast, src, nameof(src::copy_spellcast()))
 
 	check_golems()
 

--- a/code/modules/spells/changeling/split.dm
+++ b/code/modules/spells/changeling/split.dm
@@ -39,11 +39,11 @@
 		recruiter.jobban_roles = list("Syndicate")
 		recruiter.recruitment_timeout = 30 SECONDS
 	// Role set to Yes or Always
-	recruiter.player_volunteering = new /callback(src, src::recruiter_recruiting())
+	recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))
 	// Role set to No or Never
-	recruiter.player_not_volunteering = new /callback(src, src::recruiter_not_recruiting())
+	recruiter.player_not_volunteering = new /callback(src, nameof(src::recruiter_not_recruiting()))
 
-	recruiter.recruited = new /callback(src, src::recruiter_recruited())
+	recruiter.recruited = new /callback(src, nameof(src::recruiter_recruited()))
 	recruiter.request_player()
 
 /spell/changeling/split/proc/checkSplit(var/success)

--- a/code/modules/spells/general/reflect_pain.dm
+++ b/code/modules/spells/general/reflect_pain.dm
@@ -39,13 +39,13 @@
 		for(var/mob/living/T in view(L))
 			if(!T.isDead() && (T != L))
 				to_chat(T, "<span class='sinister'>An unholy charm binds your life to [L]. While the spell is active, any pain \he receive\s will be redirected to you.</span>")
-		L.register_event(/event/damaged, src, src::reflect())
+		L.register_event(/event/damaged, src, nameof(src::reflect()))
 		L.overlays.Add(user_overlay)
 		playsound(L, 'sound/effects/vampire_intro.ogg', 80, 1, "vary" = 0)
 
 		spawn(duration)
 			to_chat(L, "<span class='sinister'>Your life essence is no longer bound to this plane. You won't reflect received damage to your enemies anymore.</span>")
-			L.unregister_event(/event/damaged, src, src::reflect())
+			L.unregister_event(/event/damaged, src, nameof(src::reflect()))
 			L.overlays.Remove(user_overlay)
 
 /spell/mirror_of_pain/proc/reflect(kind, amount)

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -224,17 +224,17 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 		if(!cast_check(skipcharge, user))
 			return 0
 		user.remove_spell_channeling() //In case we're swapping from an older spell to this new one
-		user.register_event(/event/uattack, src, src::channeled_spell())
+		user.register_event(/event/uattack, src, nameof(src::channeled_spell()))
 		user.spell_channeling = src
 		if(spell_flags & CAN_CHANNEL_RESTRAINED)
-			user.register_event(/event/ruattack, src, src::channeled_spell())
+			user.register_event(/event/ruattack, src, nameof(src::channeled_spell()))
 			user.spell_channeling = src
 		connected_button.name = "(Ready) [name]"
 		currently_channeled = 1
 		connected_button.add_channeling()
 	else
-		user.unregister_event(/event/uattack, src, src::channeled_spell())
-		user.unregister_event(/event/ruattack, src, src::channeled_spell())
+		user.unregister_event(/event/uattack, src, nameof(src::channeled_spell()))
+		user.unregister_event(/event/ruattack, src, nameof(src::channeled_spell()))
 		user.spell_channeling = null
 		currently_channeled = 0
 		connected_button.remove_channeling()

--- a/code/modules/spells/targeted/punch.dm
+++ b/code/modules/spells/targeted/punch.dm
@@ -60,8 +60,8 @@
 					return
 			present_target = target
 //Use two events because each does something the other cannot do, even if they are mostly similar.
-			target.register_event(/event/to_bump, src, src::handle_bump())
-			target.register_event(/event/throw_impact, src, src::handle_throw_impact())
+			target.register_event(/event/to_bump, src, nameof(src::handle_bump()))
+			target.register_event(/event/throw_impact, src, nameof(src::handle_throw_impact()))
 			L.do_attack_animation(target, L, I)
 			target.take_organ_damage(L.get_unarmed_damage(target) * 5) //A PUNCH THAT SHALL PIERCE PROTECTIONS
 			target.throw_at(get_edge_target_turf(L, L.dir), INFINITY, 1)
@@ -76,8 +76,8 @@
 					sleep(1)
 				target.transform = turn(target.transform, -turns)
 				target.Knockdown(2)
-				target.unregister_event(/event/to_bump, src, src::handle_bump()) //Just in case
-				target.unregister_event(/event/throw_impact, src, src::handle_throw_impact())
+				target.unregister_event(/event/to_bump, src, nameof(src::handle_bump())) //Just in case
+				target.unregister_event(/event/throw_impact, src, nameof(src::handle_throw_impact()))
 
 		for(var/obj/mecha/M in targets) //Target is a mecha
 			if(L.is_pacified(1, M))
@@ -88,14 +88,14 @@
 			M.ex_act(1)
 
 /spell/targeted/punch/proc/handle_bump(atom/movable/bumper, atom/bumped)
-	present_target.unregister_event(/event/to_bump, src, src::handle_bump())
-	present_target.unregister_event(/event/throw_impact, src, src::handle_throw_impact())
+	present_target.unregister_event(/event/to_bump, src, nameof(src::handle_bump()))
+	present_target.unregister_event(/event/throw_impact, src, nameof(src::handle_throw_impact()))
 	var/mob/living/L = holder
 	explode_on_impact(bumped, present_target, L)
 
 /spell/targeted/punch/proc/handle_throw_impact(atom/hit_atom, speed, mob/living/user)
-	present_target.unregister_event(/event/to_bump, src, src::handle_bump())
-	present_target.unregister_event(/event/throw_impact, src, src::handle_throw_impact())
+	present_target.unregister_event(/event/to_bump, src, nameof(src::handle_bump()))
+	present_target.unregister_event(/event/throw_impact, src, nameof(src::handle_throw_impact()))
 	var/mob/living/L = holder
 	explode_on_impact(hit_atom, present_target, L)
 

--- a/code/modules/spells/targeted/roidrat_punch.dm
+++ b/code/modules/spells/targeted/roidrat_punch.dm
@@ -35,8 +35,8 @@
 					return
 			present_target = target
 //Use two events because each does something the other cannot do, even if they are mostly similar.
-			target.register_event(/event/to_bump, src, src::handle_bump())
-			target.register_event(/event/throw_impact, src, src::handle_throw_impact())
+			target.register_event(/event/to_bump, src, nameof(src::handle_bump()))
+			target.register_event(/event/throw_impact, src, nameof(src::handle_throw_impact()))
 			L.do_attack_animation(target, L, I)
 			target.take_organ_damage(30) //A PUNCH THAT SHALL PIERCE PROTECTIONS
 			target.throw_at(get_edge_target_turf(L, L.dir), INFINITY, 1)
@@ -51,16 +51,16 @@
 					sleep(1)
 				target.transform = turn(target.transform, -turns)
 				target.Knockdown(2)
-				target.unregister_event(/event/to_bump, src, src::handle_bump()) //Just in case
-				target.unregister_event(/event/throw_impact, src, src::handle_throw_impact())
+				target.unregister_event(/event/to_bump, src, nameof(src::handle_bump())) //Just in case
+				target.unregister_event(/event/throw_impact, src, nameof(src::handle_throw_impact()))
 
 /spell/targeted/punch/roidrat/handle_bump(atom/movable/bumper, atom/bumped)
-	present_target.unregister_event(/event/to_bump, src, src::handle_bump())
-	present_target.unregister_event(/event/throw_impact, src, src::handle_throw_impact())
+	present_target.unregister_event(/event/to_bump, src, nameof(src::handle_bump()))
+	present_target.unregister_event(/event/throw_impact, src, nameof(src::handle_throw_impact()))
 
 /spell/targeted/punch/roidrat/handle_throw_impact(atom/hit_atom, speed, mob/living/user)
-	present_target.unregister_event(/event/to_bump, src, src::handle_bump())
-	present_target.unregister_event(/event/throw_impact, src, src::handle_throw_impact())
+	present_target.unregister_event(/event/to_bump, src, nameof(src::handle_bump()))
+	present_target.unregister_event(/event/throw_impact, src, nameof(src::handle_throw_impact()))
 
 /spell/targeted/punch/roidrat/explode_on_impact(var/atom/bumped, var/mob/living/T, var/mob/living/user) // No explosions wanted on this child of the spell
 	return

--- a/code/modules/trader/crates/alcatrazfour.dm
+++ b/code/modules/trader/crates/alcatrazfour.dm
@@ -581,11 +581,11 @@ var/global/list/alcatraz_stuff = list(
 
 /obj/item/pedometer/pickup(mob/user)
 	..()
-	user.register_event(/event/moved, src, src::mob_moved())
+	user.register_event(/event/moved, src, nameof(src::mob_moved()))
 
 /obj/item/pedometer/dropped(mob/user)
 	..()
-	user.unregister_event(/event/moved, src, src::mob_moved())
+	user.unregister_event(/event/moved, src, nameof(src::mob_moved()))
 
 /obj/item/pedometer/proc/mob_moved(atom/movable/mover)
 	var/turf/T = get_turf(src)

--- a/code/modules/unit_tests/events.dm
+++ b/code/modules/unit_tests/events.dm
@@ -3,7 +3,7 @@
 	var/did_something = FALSE
 /datum/unit_test/event_does_stuff/start()
 	var/datum/demo_datum = new
-	demo_datum.register_event(/event/demo_event, src, src::do_something())
+	demo_datum.register_event(/event/demo_event, src, nameof(src::do_something()))
 	INVOKE_EVENT(demo_datum, /event/demo_event)
 	if(!did_something)
 		fail("lazy event did nothing")
@@ -14,21 +14,21 @@
 	var/datum/demo_datum = new
 	if(!isnull(demo_datum.registered_events))
 		fail("registered_events is not null by default")
-	demo_datum.register_event(/event/demo_event, src, src::do_nothing())
+	demo_datum.register_event(/event/demo_event, src, nameof(src::do_nothing()))
 	assert_eq(demo_datum.registered_events.len, 1)
 	assert_eq(demo_datum.registered_events[/event/demo_event].len, 1)
-	demo_datum.unregister_event(/event/demo_event, src, src::do_nothing())
+	demo_datum.unregister_event(/event/demo_event, src, nameof(src::do_nothing()))
 	if(!isnull(demo_datum.registered_events))
 		fail("registered_events is not null after removing the last handler")
 /datum/unit_test/event_cleanup/proc/do_nothing()
 
 /datum/unit_test/event_arguments/start()
 	var/datum/demo_datum = new
-	demo_datum.register_event(/event/demo_event, src, src::do_stuff_with_args())
+	demo_datum.register_event(/event/demo_event, src, nameof(src::do_stuff_with_args()))
 	INVOKE_EVENT(demo_datum, /event/demo_event, "abc", 123)
-	demo_datum.unregister_event(/event/demo_event, src, src::do_stuff_with_args())
+	demo_datum.unregister_event(/event/demo_event, src, nameof(src::do_stuff_with_args()))
 
-	demo_datum.register_event(/event/demo_event, src, src::do_something_with_named_args())
+	demo_datum.register_event(/event/demo_event, src, nameof(src::do_something_with_named_args()))
 	INVOKE_EVENT(demo_datum, /event/demo_event, "second_parameter"=1)
 /datum/unit_test/event_arguments/proc/do_stuff_with_args(string, number)
 	assert_eq(string, "abc")

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -1056,13 +1056,13 @@
 	AT.id_tag = "vaultkitchen"
 	AT.enter_signal = /event/comp_ai_cmd_retaliate
 	AT.typefilter = /mob/living/carbon/human
-	register_event(/event/comp_ai_cmd_retaliate, src, src::Retaliate())
+	register_event(/event/comp_ai_cmd_retaliate, src, nameof(src::Retaliate()))
 	add_component(/datum/component/ai/conversation)
 	var/datum/component/ai/area_territorial/say/fastfood/intruder/AT2 = add_component(/datum/component/ai/area_territorial/say/fastfood/intruder)
 	AT2.SetArea(locate(/area/vault/fastfood/kitchen))
 
 /mob/living/simple_animal/hostile/retaliate/cookbot/Destroy()
-	unregister_event(/event/comp_ai_cmd_retaliate, src, src::Retaliate())
+	unregister_event(/event/comp_ai_cmd_retaliate, src, nameof(src::Retaliate()))
 	..()
 
 /mob/living/simple_animal/hostile/retaliate/cookbot/death(var/gibbed = FALSE)

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -267,7 +267,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 		for(var/atom/movable/AM in (src.contents + E.contents))
 
 			if(!is_type_in_list(AM, protected_objects)) continue
-			AM.register_event(/event/destroyed, src, src::item_destroyed())
+			AM.register_event(/event/destroyed, src, nameof(src::item_destroyed()))
 
 /area/vault/supermarket/shop/Exited(atom/movable/AM, atom/newloc)
 	..()


### PR DESCRIPTION
It's fucking stupid that this is necessary, but it is. Even though obtaining a proc ref from the current type was possible before, and a syntax was added that you would *think* would let you do it, it's not possible anymore. You can only get the name and call it by name.
I thought about making a macro for this, but it wouldn't really have simplified it meaningfully. Unless the macro expanded into *two* arguments, but that sounds pretty cursed.