### PR TITLE
Item kicking tweaks

### DIFF
--- a/code/game/objects/breakable.dm
+++ b/code/game/objects/breakable.dm
@@ -351,11 +351,7 @@
 		if(try_break(thispropel))
 			recoil_damage = 0 //Don't take recoil damage if the item broke.
 		else if(kick_power && !anchored)
-			if (isitem(src))
-				kicked_item_arc_animation(kick_power)
-				throw_at(T, kick_power, 1)
-			else
-				throw_at(T, kick_power, 1)
+			throw_at(T, kick_power, 1)
 		if(recoil_damage) //Recoil damage to the foot.
 			kicker.foot_impact(src, recoil_damage, ourfoot = foot_organ)
 		Crossed(kicker)

--- a/code/game/objects/breakable.dm
+++ b/code/game/objects/breakable.dm
@@ -343,15 +343,19 @@
 		if(kicker.loc == loc)
 			kick_dir = kicker.dir
 		var/turf/T = get_edge_target_turf(loc, kick_dir)
-		var/kick_power = max((kicker.get_strength() * 10 - (get_total_scaled_w_class(2))), 1) //The range of the kick is (strength)*10. Strength ranges from 1 to 3, depending on the kicker's genes. Range is reduced by w_class^2, and can't be reduced below 1.
+		var/kick_power = get_kick_power(kicker)
 		var/thispropel = new /datum/throwparams(T, kick_power, 1)
-		if(kick_power < 6)
+		if(kick_power < 1)
 			kick_power = 0
 			thispropel = null
 		if(try_break(thispropel))
 			recoil_damage = 0 //Don't take recoil damage if the item broke.
 		else if(kick_power && !anchored)
-			throw_at(T, kick_power, 1)
+			if (isitem(src))
+				kicked_item_arc_animation(kick_power)
+				throw_at(T, kick_power, 1)
+			else
+				throw_at(T, kick_power, 1)
 		if(recoil_damage) //Recoil damage to the foot.
 			kicker.foot_impact(src, recoil_damage, ourfoot = foot_organ)
 		Crossed(kicker)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1390,6 +1390,7 @@ var/global/list/image/blood_overlays = list()
 
 /obj/item/kick_act(mob/living/carbon/human/H) //Kick items around!
 	var/datum/organ/external/kickingfoot = H.pick_usable_organ(LIMB_RIGHT_FOOT, LIMB_LEFT_FOOT)
+	playsound(loc, "punch", 30, 1, -1)
 	if(anchored || w_class > W_CLASS_MEDIUM + H.get_strength())
 		H.visible_message("<span class='danger'>[H] attempts to kick \the [src]!</span>", "<span class='danger'>You attempt to kick \the [src]!</span>")
 		if(prob(70))
@@ -1403,7 +1404,7 @@ var/global/list/image/blood_overlays = list()
 
 	var/turf/T = get_edge_target_turf(loc, kick_dir)
 
-	var/kick_power = max((H.get_strength() * 10 - (get_total_scaled_w_class(2))), 1) //The range of the kick is (strength)*10. Strength ranges from 1 to 3, depending on the kicker's genes. Range is reduced by w_class^2, and can't be reduced below 1.
+	var/kick_power = max((H.get_strength() * 10 - round(get_total_scaled_w_class(3) / 7)), 1) //The range of the kick is (strength)*10. Strength ranges from 1 to 3, depending on the kicker's genes. Range is reduced by w_class^3, and can't be reduced below 1.
 
 	//Attempt to damage the item if it's breakable here.
 	var/glanced = TRUE
@@ -1418,13 +1419,15 @@ var/global/list/image/blood_overlays = list()
 		var/thispropel = new /datum/throwparams(T, kick_power, 1)
 		broken = try_break(propelparams = thispropel)
 
-	if(kick_power >= 6 && !broken) //Fly in an arc!
+	if(kick_power >= 1 && !broken) //Fly in an arc!
 		spawn()
 			var/original_pixel_y = pixel_y
-			animate(src, pixel_y = original_pixel_y + WORLD_ICON_SIZE, time = 10, easing = CUBIC_EASING)
+			animate(src, pixel_y = original_pixel_y + WORLD_ICON_SIZE, time = 5, easing = QUAD_EASING | EASE_OUT)
+			spawn(5)
+				animate(src, pixel_y = original_pixel_y, time = 5, easing = QUAD_EASING | EASE_IN)
 			while(loc)
 				if(!throwing)
-					animate(src, pixel_y = original_pixel_y, time = 5, easing = ELASTIC_EASING)
+					animate(src, pixel_y = original_pixel_y, time = 5, easing = BOUNCE_EASING)
 					break
 				sleep(5)
 		throw_at(T, kick_power, 1)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1425,7 +1425,7 @@ var/global/list/image/blood_overlays = list()
 	Crossed(H) //So you can't kick shards while naked without suffering
 
 /obj/proc/get_kick_power(mob/living/carbon/human/kicker)
-	return max((kicker.get_strength() * 10 - round(get_total_scaled_w_class(3) / 7)), 1) //The range of the kick is (strength)*10. Strength ranges from 1 to 3, depending on the kicker's genes. Range is reduced by w_class^3, and can't be reduced below 1.
+	return max((kicker.get_strength() * 10 - round(get_total_scaled_w_class(3) / 7)), 1) //The range of the kick is affected by the strength of the kicker, depending on the kicker's genes, and the total weight of the object and its contents.
 
 /obj/proc/kicked_item_arc_animation(distance = 5)
 	spawn()


### PR DESCRIPTION
This makes it so you can kick a lot more things around, based on feedback in #34564 and #34615. A toolbox containing a few items can still be kicked a short distance. Also this neatens up the item kick midair animation a bit to give a more gravitational-looking arc, and adds the punch sound to when you kick items to make it a bit more satisfying.

If the kicking distance seems a bit extreme, we can reduce it.


https://github.com/vgstation-coders/vgstation13/assets/7112773/1e48ed9a-75eb-4474-bdac-7a932cdd38a6



Fixes #34564

:cl:
 * rscadd: Kicking an item makes sound.
 * tweak: More items can be kicked around.
 * tweak: Kicked item arc animation should look a bit more gravitational.