### PR TITLE
revert chemmaster to old behavior on beaker detach

### DIFF
--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -516,14 +516,11 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 
 /obj/machinery/chem_master/proc/detach()
 	if(container)
-		if(mode)
-			reagents.trans_to(container, reagents.total_volume)
-		else
-			reagents.clear_reagents()
 		container.forceMove(src.loc)
 		container.pixel_x = 0 //We fucked with the beaker for overlays, so reset that
 		container.pixel_y = 0
 		container = null
+		reagents.clear_reagents()
 		update_icon()
 		updateUsrDialog()
 


### PR DESCRIPTION
Sonix told me he hallucinated this feature and shouldn't have added it in his recent PR, so I fixed it for him.
Fixes #34840 
[tested]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed chemmasters not properly clearing reagent buffer.