### PR TITLE
add server byond build info to show-server-revision verb

### DIFF
--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -7,6 +7,7 @@
 	var/output = return_revision() || "Unable to load revision info from HEAD"
 
 	output += {"Current Infomational Settings: <br>
+		BYOND version of server: [world.byond_version].[world.byond_build]<br>
 		Protect Authority Roles From Tratior: [config.protect_roles_from_antagonist]<br>"}
 	usr << browse(output,"window=revdata");
 	return


### PR DESCRIPTION
## Why it's good
Better bug reports when people follow the format. Less ambiguity about what the server is running at any given moment.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Show-Server-Revision now also gives info on the server's current BYOND version.
