### PR TITLE
adjust light fixture layering to be above humans and potted plants

### DIFF
--- a/__DEFINES/planes+layers.dm
+++ b/__DEFINES/planes+layers.dm
@@ -173,11 +173,10 @@ Why is FLOAT_PLANE added to a bunch of these?
 	#define RAILING_FRONT_LAYER 		0.3
 	#define WINDOOR_LAYER 				1
 	#define OPEN_CURTAIN_LAYER			2
-	// BELOW_OBJ_LAYER					2
-	// OBJ_LAYER 	 					3
-	// ABOVE_OBJ_LAYER					4
-	#define CLOSED_CURTAIN_LAYER		5
-	#define CLOSED_FIREDOOR_LAYER		6
+	#define CLOSED_CURTAIN_LAYER		3
+	#define CLOSED_FIREDOOR_LAYER		4
+	#define POTTED_PLANT_LAYER			5
+	#define LIGHT_FIXTURE_LAYER			6
 	#define CHAT_LAYER					7
 
 #define BLOB_PLANE 				(11 + FLOAT_PLANE)			// For Blobs, which are above humans.

--- a/code/game/objects/structures/flora/flora.dm
+++ b/code/game/objects/structures/flora/flora.dm
@@ -319,8 +319,8 @@
 	desc = "Oh, no. Not again."
 	icon = 'icons/obj/plants.dmi'
 	icon_state = "plant-26"
-	layer = FLY_LAYER
 	plane = ABOVE_HUMAN_PLANE
+	layer = POTTED_PLANT_LAYER
 
 /obj/structure/flora/pottedplant/Destroy()
 	for(var/I in contents)

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -8,8 +8,8 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "tube-construct-stage1"
 	anchored = 1
-	plane = OBJ_PLANE
-	layer = ABOVE_DOOR_LAYER
+	plane = ABOVE_HUMAN_PLANE
+	layer = LIGHT_FIXTURE_LAYER
 	var/stage = 1
 	var/fixture_type = "tube"
 	var/sheets_refunded = 2


### PR DESCRIPTION
## What this does
Layering now follows this order:
Light fixtures layer above potted plants and humans.
Potted plants layer above humans.
![image](https://github.com/vgstation-coders/vgstation13/assets/26285377/bbabc701-39ea-4edb-a3cd-7eae3b97fdac)

## Why it's good
Humans being on the same tile as a light looks like they're stomping on it, which looks very silly.
Also, this fixes #34862
[tweak]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Light fixtures no longer layer under potted plants.
 * tweak: Light fixtures now layer above humans.