### PR TITLE
fix decals not appearing properly on glass tiles

### DIFF
--- a/code/game/turfs/simulated/floor_glass.dm
+++ b/code/game/turfs/simulated/floor_glass.dm
@@ -5,10 +5,7 @@
 	// Oldspace for people who don't have parallax.
 	icon = 'icons/turf/space.dmi'
 	icon_state = "0"
-
-	plane = SPACE_BACKGROUND_PLANE
-	dynamic_lighting = 0
-	luminosity = 1
+	plane = TURF_PLANE
 	intact = 0 // make pipes appear above space
 
 	var/health=80 // 2x that of an rwindow
@@ -29,9 +26,9 @@
 	if(!floor_overlays[glass_state])
 		var/image/floor_overlay = image('icons/turf/overlays.dmi', glass_state)
 		floor_overlay.plane = GLASSTILE_PLANE
-		floor_overlay.layer = TURF_LAYER
 		floor_overlays[glass_state] = floor_overlay
 	overlays += floor_overlays[glass_state]
+	set_light(0.5, 0.5, "#ffffff")
 	update_icon()
 
 /turf/simulated/floor/glass/update_icon()

--- a/code/game/turfs/simulated/floor_glass.dm
+++ b/code/game/turfs/simulated/floor_glass.dm
@@ -28,7 +28,7 @@
 		floor_overlay.plane = GLASSTILE_PLANE
 		floor_overlays[glass_state] = floor_overlay
 	overlays += floor_overlays[glass_state]
-	set_light(0.5, 0.5, "#ffffff")
+	set_light(1, 0.5, "#ffffff")
 	update_icon()
 
 /turf/simulated/floor/glass/update_icon()

--- a/code/game/turfs/simulated/floor_glass.dm
+++ b/code/game/turfs/simulated/floor_glass.dm
@@ -42,9 +42,8 @@
 	var/damage_fraction = clamp(round((max_health - current_health) / max_health * 5) + 1, 1, 5) //gives a number, 1-5, based on damagedness
 	var/icon_state = "[cracked_base][damage_fraction]"
 	if(!damage_overlays[icon_state])
-		var/image/_damage_overlay = image('icons/obj/structures.dmi', icon_state)
+		var/image/_damage_overlay = image('icons/obj/structures/window.dmi', icon_state)
 		_damage_overlay.plane = GLASSTILE_PLANE
-		_damage_overlay.layer = TURF_LAYER
 		damage_overlays[icon_state] = _damage_overlay
 	var/damage_overlay = damage_overlays[icon_state]
 	if(current_damage_overlay == damage_overlay)


### PR DESCRIPTION
## What this does
Fixed decals being completely invisible due to being layered under some elements of glass floor tiles.
Broken for 2+ years.
Fixed damage icons not appearing on glass tiles.
Broken by: #33574

Additionally, I have changed how lighting works on these tiles. Instead of having dynamic lighting disabled, which looks absolutely awful, these tiles use dynamic lighting and gain a very dim `/datum/light_source` upon being created to simulate the light from space.

These glass tiles are mostly used on Roid, but are also featured on Synergy, which now also properly displays its decals.
Demonstration of the fixed appearances + faint glow (the light tile in the center makes the edges a little bit brighter):
![VGPPvle1MH](https://github.com/vgstation-coders/vgstation13/assets/26285377/5a768196-0552-4874-9853-4f78d273ca60)

[bugfix]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Floor decals of all types now render properly on glass tiles.
