### PR TITLE
Optimize handle_reactions()

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -404,13 +404,9 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 
 	var/reaction_occured = 0
 	do
-		reaction_occured = 0
 		for(var/datum/reagent/R in reagent_list) // Usually a small list
-			for(var/reaction in chemical_reactions_list[R.id]) // Was a big list but now it should be smaller since we filtered it with our reagent id
-				if(!reaction)
-					continue
+			for(var/datum/chemical_reaction/C in chemical_reactions_list[R.id]) // Was a big list but now it should be smaller since we filtered it with our reagent id
 
-				var/datum/chemical_reaction/C = reaction
 				var/reaction_result = handle_reaction(C)
 				if(reaction_result)
 					if(reaction_result == NON_DISCRETE_REACTION)
@@ -755,9 +751,8 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 /datum/reagents/proc/has_reagent(var/reagent, var/amount = -1)
 	// N3X: Caching shit.
 	// Only cache if not using get (since we only track bools)
-	if(reagent in amount_cache)
-		return amount_cache[reagent] >= max(0,amount)
-	return 0
+	var/amount_in_cache = amount_cache[reagent]
+	return amount_in_cache ? amount_in_cache >= max(0, amount) : 0
 
 /datum/reagents/proc/has_only_any(list/good_reagents)
     var/found_any_good_reagent = FALSE
@@ -816,12 +811,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	return 0
 
 /datum/reagents/proc/get_reagent_amount(var/reagent)
-	for(var/A in reagent_list)
-		var/datum/reagent/R = A
-		if (R.id == reagent)
-			return R.volume
-
-	return 0
+	return amount_cache[reagent]
 
 /datum/reagents/proc/get_reagents()
 	var/res = ""


### PR DESCRIPTION
## What this does
This optimizes `handle reactions()`, by making additional use of `amount_cache` instead of `reagent_list`.
To test, I ran `handle_reactions()` 100000 times on the contents of the following beaker, twice with the current way and twice with these optimizations:

<img width="151" alt="reagents" src="https://github.com/vgstation-coders/vgstation13/assets/7112773/efe7a60d-c50e-43ff-ae4a-6904b3a9d9ac">

Average time pre-optimization:
214.326 units

Average time post-optimization:
169.580 units

So we shaved about 21% off the time.

After testing, normal reactions still work, heated reactions still work, and metabolic effects of reagents still work, and there's no runtimes so things seem to check out okay.

## Why it's good
Makes `handle_reactions()` faster to reduce CPU load.
