### PR TITLE
Optimize handle_reactions()

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -404,9 +404,13 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 
 	var/reaction_occured = 0
 	do
+		reaction_occured = 0
 		for(var/datum/reagent/R in reagent_list) // Usually a small list
-			for(var/datum/chemical_reaction/C in chemical_reactions_list[R.id]) // Was a big list but now it should be smaller since we filtered it with our reagent id
+			for(var/reaction in chemical_reactions_list[R.id]) // Was a big list but now it should be smaller since we filtered it with our reagent id
+				if(!reaction)
+					continue
 
+				var/datum/chemical_reaction/C = reaction
 				var/reaction_result = handle_reaction(C)
 				if(reaction_result)
 					if(reaction_result == NON_DISCRETE_REACTION)
@@ -754,6 +758,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	var/amount_in_cache = amount_cache[reagent]
 	return amount_in_cache ? amount_in_cache >= max(0, amount) : 0
 
+
 /datum/reagents/proc/has_only_any(list/good_reagents)
     var/found_any_good_reagent = FALSE
     for(var/reagent in amount_cache)
@@ -811,7 +816,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	return 0
 
 /datum/reagents/proc/get_reagent_amount(var/reagent)
-	return amount_cache[reagent]
+	return amount_cache[reagent] + 0 //Convert null to 0.
 
 /datum/reagents/proc/get_reagents()
 	var/res = ""

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -404,13 +404,9 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 
 	var/reaction_occured = 0
 	do
-		reaction_occured = 0
 		for(var/datum/reagent/R in reagent_list) // Usually a small list
-			for(var/reaction in chemical_reactions_list[R.id]) // Was a big list but now it should be smaller since we filtered it with our reagent id
-				if(!reaction)
-					continue
+			for(var/datum/chemical_reaction/C in chemical_reactions_list[R.id]) // Was a big list but now it should be smaller since we filtered it with our reagent id
 
-				var/datum/chemical_reaction/C = reaction
 				var/reaction_result = handle_reaction(C)
 				if(reaction_result)
 					if(reaction_result == NON_DISCRETE_REACTION)
@@ -755,9 +751,8 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 /datum/reagents/proc/has_reagent(var/reagent, var/amount = -1)
 	// N3X: Caching shit.
 	// Only cache if not using get (since we only track bools)
-	if(reagent in amount_cache)
-		return amount_cache[reagent] >= max(0,amount)
-	return 0
+	var/amount_in_cache = amount_cache[reagent]
+	return amount_in_cache ? amount_in_cache >= max(0, amount) : 0
 
 /datum/reagents/proc/has_only_any(list/good_reagents)
     var/found_any_good_reagent = FALSE
@@ -816,12 +811,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	return 0
 
 /datum/reagents/proc/get_reagent_amount(var/reagent)
-	for(var/A in reagent_list)
-		var/datum/reagent/R = A
-		if (R.id == reagent)
-			return R.volume
-
-	return 0
+	return amount_cache[reagent]
 
 /datum/reagents/proc/get_reagents()
 	var/res = ""

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -449,7 +449,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 				multipliers += round(amount_cache[D] / req_reag_amt)
 				break
 		else
-			if(amount_cache[B] < C.required_reagents[B])
+			if(amount_cache[B] < req_reag_amt)
 				break
 			total_matching_reagents++
 			multipliers += round(amount_cache[B] / req_reag_amt)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -407,16 +407,15 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	do
 		reaction_occured = 0
 		for(var/R in amount_cache) // Usually a small list
-			for(var/datum/chemical_reaction/C in chemical_reactions_list[R]) // Was a big list but now it should be smaller since we filtered it with our reagent id
-				if(C)
-					switch(handle_reaction(C))
-						if(DISCRETE_REACTION)
-							any_reactions = 1
-							break
-						if(NON_DISCRETE_REACTION)
-							any_reactions = 1
-							reaction_occured = 1
-							break
+			for(var/datum/chemical_reaction/C as anything in chemical_reactions_list[R]) // Was a big list but now it should be smaller since we filtered it with our reagent id
+				switch(handle_reaction(C))
+					if(DISCRETE_REACTION)
+						any_reactions = 1
+						break
+					if(NON_DISCRETE_REACTION)
+						any_reactions = 1
+						reaction_occured = 1
+						break
 	while(reaction_occured)
 
 	if(any_reactions)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -402,23 +402,25 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	if(my_atom.flags & NOREACT)
 		return //Yup, no reactions here. No siree.
 
-	var/reaction_occured = 0
+	var/any_reactions
+	var/reaction_occured
 	do
 		reaction_occured = 0
-		for(var/datum/reagent/R in reagent_list) // Usually a small list
-			for(var/reaction in chemical_reactions_list[R.id]) // Was a big list but now it should be smaller since we filtered it with our reagent id
-				if(!reaction)
-					continue
-
-				var/datum/chemical_reaction/C = reaction
-				var/reaction_result = handle_reaction(C)
-				if(reaction_result)
-					if(reaction_result == NON_DISCRETE_REACTION)
-						reaction_occured = 1
-					break
-
+		for(var/R in amount_cache) // Usually a small list
+			for(var/datum/chemical_reaction/C in chemical_reactions_list[R]) // Was a big list but now it should be smaller since we filtered it with our reagent id
+				if(C)
+					switch(handle_reaction(C))
+						if(DISCRETE_REACTION)
+							any_reactions = 1
+							break
+						if(NON_DISCRETE_REACTION)
+							any_reactions = 1
+							reaction_occured = 1
+							break
 	while(reaction_occured)
-	update_total()
+
+	if(any_reactions)
+		update_total()
 	return 0
 
 /datum/reagents/proc/handle_reaction(var/datum/chemical_reaction/C, var/requirement_override = FALSE, var/multiplier_override = 1)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -434,7 +434,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 		for(var/B in C.required_catalysts)
 			if(amount_cache[B] >= C.required_catalysts[B])
 				total_required_catalysts--
-		if (total_required_catalysts)
+		if(total_required_catalysts)
 			return NO_REACTION
 
 		if(C.required_container && !istype(my_atom, C.required_container))

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -437,20 +437,22 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	if(C.react_discretely || requirement_override)
 		multipliers += 1 //Only once
 
+	var/req_reag_amt
 	for(var/B in C.required_reagents)
+		req_reag_amt = C.required_reagents[B]
 		if(islist(B))
 			var/list/L = B
 			for(var/D in L)
-				if(amount_cache[D] < C.required_reagents[B])
+				if(amount_cache[D] < req_reag_amt)
 					continue
 				total_matching_reagents++
-				multipliers += round(get_reagent_amount(D) / C.required_reagents[B])
+				multipliers += round(amount_cache[D] / req_reag_amt)
 				break
 		else
 			if(amount_cache[B] < C.required_reagents[B])
 				break
 			total_matching_reagents++
-			multipliers += round(get_reagent_amount(B) / C.required_reagents[B])
+			multipliers += round(amount_cache[B] / req_reag_amt)
 	for(var/B in C.required_catalysts)
 		if(amount_cache[B] < C.required_catalysts[B])
 			break
@@ -473,18 +475,19 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 		var/multiplier = min(multipliers) * multiplier_override
 		var/preserved_data = null
 		for(var/B in C.required_reagents)
+			req_reag_amt = C.required_reagents[B]
 			if(islist(B))
 				var/list/L = B
 				for(var/D in L)
-					if(amount_cache[D] >= C.required_reagents[B])
+					if(amount_cache[D] >= req_reag_amt)
 						if(!preserved_data)
 							preserved_data = get_data(D)
-						remove_reagent(D, (multiplier * C.required_reagents[B]), safety = 1)
+						remove_reagent(D, (multiplier * req_reag_amt), safety = 1)
 						break
 			else
 				if(!preserved_data)
 					preserved_data = get_data(B)
-				remove_reagent(B, (multiplier * C.required_reagents[B]), safety = 1)
+				remove_reagent(B, (multiplier * req_reag_amt), safety = 1)
 
 		chem_temp += C.reaction_temp_change
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -498,20 +498,20 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 			for(var/S in C.secondary_results)
 				add_reagent(S, C.result_amount * C.secondary_results[S] * multiplier, reagtemp = chem_temp)
 
-		var/quiet = C.quiet
-		if	(istype(my_atom, /obj/item/weapon/grenade/chem_grenade) && !quiet)
-			my_atom.visible_message("<span class='caution'>[bicon(my_atom)] Something comes out of \the [my_atom].</span>")
-			//Logging inside chem_grenade.dm, prime()
-		else if	(istype(my_atom, /mob/living/carbon/human) && !quiet)
-			my_atom.visible_message("<span class='notice'>[my_atom] shudders a little.</span>","<span class='notice'>You shudder a little.</span>")
-			//Since the are no fingerprints to be had here, we'll trust the attack logs to log this
-		else
-			if(!quiet)
-				my_atom.visible_message("<span class='notice'>[bicon(my_atom)] The solution begins to bubble.</span>")
+		if(C.quiet)
 			C.log_reaction(src, created_volume)
-
-		if(!quiet && !(my_atom.flags & SILENTCONTAINER))
-			playsound(my_atom, 'sound/effects/bubbles.ogg', 80, 1)
+		else
+			if(istype(my_atom, /mob/living/carbon/human))
+				my_atom.visible_message("<span class='notice'>[my_atom] shudders a little.</span>","<span class='notice'>You shudder a little.</span>")
+				//Since the are no fingerprints to be had here, we'll trust the attack logs to log this
+			else if(istype(my_atom, /obj/item/weapon/grenade/chem_grenade))
+				my_atom.visible_message("<span class='caution'>[bicon(my_atom)] Something comes out of \the [my_atom].</span>")
+				//Logging inside chem_grenade.dm, prime()
+			else
+				my_atom.visible_message("<span class='notice'>[bicon(my_atom)] The solution begins to bubble.</span>")
+				C.log_reaction(src, created_volume)
+			if(!(my_atom.flags & SILENTCONTAINER))
+				playsound(my_atom, 'sound/effects/bubbles.ogg', 80, 1)
 
 		C.on_reaction(src, created_volume)
 		if(C.react_discretely)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -422,6 +422,10 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	return 0
 
 /datum/reagents/proc/handle_reaction(var/datum/chemical_reaction/C, var/requirement_override = FALSE, var/multiplier_override = 1)
+
+	if((C.required_temp && (C.is_cold_recipe ? (chem_temp > C.required_temp) : (chem_temp < C.required_temp))) && !requirement_override)
+		return NO_REACTION
+
 	var/total_required_reagents = C.required_reagents.len
 	var/total_matching_reagents = 0
 	var/total_required_catalysts = C.required_catalysts.len
@@ -429,9 +433,6 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	var/matching_container = 0
 	var/required_conditions = 0
 	var/list/multipliers = new/list()
-	var/required_temp = C.required_temp
-	var/is_cold_recipe = C.is_cold_recipe
-	var/meets_temp_requirement = 0
 	var/quiet = C.quiet
 
 	if(C.react_discretely || requirement_override)
@@ -468,10 +469,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	if(C.required_condition_check(src))
 		required_conditions = 1
 
-	if(required_temp == 0 || (is_cold_recipe && chem_temp <= required_temp) || (!is_cold_recipe && chem_temp >= required_temp))
-		meets_temp_requirement = 1
-
-	if((total_matching_reagents == total_required_reagents && total_matching_catalysts == total_required_catalysts && matching_container && required_conditions && meets_temp_requirement) || requirement_override)
+	if((total_matching_reagents == total_required_reagents && total_matching_catalysts == total_required_catalysts && matching_container && required_conditions) || requirement_override)
 		var/multiplier = min(multipliers) * multiplier_override
 		var/preserved_data = null
 		for(var/B in C.required_reagents)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -441,18 +441,18 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 		if(islist(B))
 			var/list/L = B
 			for(var/D in L)
-				if(!has_reagent(D, C.required_reagents[B]))
+				if(amount_cache[D] < C.required_reagents[B])
 					continue
 				total_matching_reagents++
 				multipliers += round(get_reagent_amount(D) / C.required_reagents[B])
 				break
 		else
-			if(!has_reagent(B, C.required_reagents[B]))
+			if(amount_cache[B] < C.required_reagents[B])
 				break
 			total_matching_reagents++
 			multipliers += round(get_reagent_amount(B) / C.required_reagents[B])
 	for(var/B in C.required_catalysts)
-		if(!has_reagent(B, C.required_catalysts[B]))
+		if(amount_cache[B] < C.required_catalysts[B])
 			break
 		total_matching_catalysts++
 
@@ -476,7 +476,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 			if(islist(B))
 				var/list/L = B
 				for(var/D in L)
-					if(has_reagent(D, C.required_reagents[B]))
+					if(amount_cache[D] >= C.required_reagents[B])
 						if(!preserved_data)
 							preserved_data = get_data(D)
 						remove_reagent(D, (multiplier * C.required_reagents[B]), safety = 1)
@@ -757,7 +757,6 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	// Only cache if not using get (since we only track bools)
 	var/amount_in_cache = amount_cache[reagent]
 	return amount_in_cache ? amount_in_cache >= amount : 0
-
 
 /datum/reagents/proc/has_only_any(list/good_reagents)
     var/found_any_good_reagent = FALSE

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -752,11 +752,11 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 /**************************************
  *  RETURNS A BOOL NOW, USE get_reagent IF YOU NEED TO GET ONE.
  **************************************/
-/datum/reagents/proc/has_reagent(var/reagent, var/amount = -1)
+/datum/reagents/proc/has_reagent(var/reagent, var/amount = 0)
 	// N3X: Caching shit.
 	// Only cache if not using get (since we only track bools)
 	var/amount_in_cache = amount_cache[reagent]
-	return amount_in_cache ? amount_in_cache >= max(0, amount) : 0
+	return amount_in_cache ? amount_in_cache >= amount : 0
 
 
 /datum/reagents/proc/has_only_any(list/good_reagents)


### PR DESCRIPTION
## What this does
This optimizes `handle_reactions()` in a few different ways.
To test, I ran `handle_reactions()` 100000 times on the contents of the following beaker, twice with the current way and twice with the optimizations:

<img width="151" alt="reagents" src="https://github.com/vgstation-coders/vgstation13/assets/7112773/669e4692-5e99-4664-a057-1c670e7cf467">

Average time pre-optimization:
214.326 units

Average time post-optimization:
77.394 units

So we shaved about 63% off the time.

After testing, normal reactions still work, catalyzed reactions still work, container-specific reactions still work, heated reactions still work, and metabolic effects of reagents still work, and there's no runtimes so things seem to check out okay.

## Why it's good
Makes `handle_reactions()` faster to reduce CPU load.