### PR TITLE
Give opium a painkilling effect

### DIFF
--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -53,4 +53,6 @@
 		return TRUE
 	if(reagents.has_reagent(OXYCODONE))
 		return TRUE
+	if(reagents.has_reagent(OPIUM))
+		return TRUE
 	return FALSE

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -46,13 +46,10 @@
 /mob/living/carbon/proc/handle_shock() //Currently only used for humans
 	update_pain_level()
 
+
+/mob/living/carbon/proc/total_painkillers()
+	for(var/datum/reagent/R in reagents.reagent_list)
+		. += R.pain_resistance
+
 /mob/living/carbon/proc/has_painkillers()
-	if(reagents.has_reagent(PARACETAMOL))
-		return TRUE
-	if(reagents.has_reagent(TRAMADOL))
-		return TRUE
-	if(reagents.has_reagent(OXYCODONE))
-		return TRUE
-	if(reagents.has_reagent(OPIUM))
-		return TRUE
-	return FALSE
+	return total_painkillers() > 0 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -9226,6 +9226,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 	name = "Opium"
 	id = OPIUM
 	description = "Opium is an exceptional natural analgesic."
+	pain_resistance = 80
 	color = "#AE9260" //rgb: 174, 146, 96
 
 /datum/reagent/bicaridine/opium/on_plant_life(obj/machinery/portable_atmospherics/hydroponics/T)


### PR DESCRIPTION
## What this does
Currently, opium has the same brute healing effects as bicaridine. This keeps those the same but also adds a painkilling effect.

## Why it's good
Adds a painkiller to botany, and also makes opium match its in-game description:

> Opium is an exceptional natural analgesic.

 as well as its irl effect.


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Opium also works as a painkiller.
 * bugfix: Fixed certain painkillers not counting as painkillers in certain situations.

