### PR TITLE
pAIs with the chem module can also make Cola and Beer

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -77,8 +77,8 @@
 		"Inaprovaline" = INAPROVALINE,
 		"Coffee" = COFFEE,
 		"Tea" = TEA,
-		"Cola" = COLA
-		"Beer" = BEER
+		"Cola" = COLA,
+		"Beer" = BEER,
 		"Salt" = SODIUMCHLORIDE,
 		"Smoke" = PAISMOKE,
 	)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -77,6 +77,8 @@
 		"Inaprovaline" = INAPROVALINE,
 		"Coffee" = COFFEE,
 		"Tea" = TEA,
+		"Cola" = COLA
+		"Beer" = BEER
 		"Salt" = SODIUMCHLORIDE,
 		"Smoke" = PAISMOKE,
 	)


### PR DESCRIPTION
## What this does
If you have the chem module, you can dispense some cola or beer to your master.
You can already make coffee and tea with the chem module so this isn't out of place.
## Why it's good
You can fulfill the party pAI experience, become the drinks dispenser.

:cl:
 * rscadd: pAIs with the chem module can now make cola and beer as well.