### PR TITLE
Machinery subsystem optimization

### DIFF
--- a/code/ZAS/_gas_mixture.dm
+++ b/code/ZAS/_gas_mixture.dm
@@ -154,7 +154,7 @@
 	if(thermal_energy < 0)
 		if(temperature <= min_temp)
 			return 0
-		thermal_energy = max(thermal_energy, (min_temp - temperature) * heat_capacity) //ensure temperature does not go below min_temp thermal_energy is negative here.
+		thermal_energy = max(thermal_energy, (min_temp - temperature) * heat_capacity) //ensure temperature does not go below min_temp. thermal_energy is negative here.
 	temperature += thermal_energy / heat_capacity
 	return thermal_energy
 

--- a/code/ZAS/_gas_mixture.dm
+++ b/code/ZAS/_gas_mixture.dm
@@ -154,9 +154,8 @@
 	if(thermal_energy < 0)
 		if(temperature <= min_temp)
 			return 0
-		var/thermal_energy_limit = -(temperature - min_temp) * heat_capacity	//ensure temperature does not go below min_temp
-		thermal_energy = max(thermal_energy, thermal_energy_limit)	//thermal_energy and thermal_energy_limit are negative here.
-	temperature += thermal_energy/heat_capacity
+		thermal_energy = max(thermal_energy, (min_temp - temperature) * heat_capacity) //ensure temperature does not go below min_temp thermal_energy is negative here.
+	temperature += thermal_energy / heat_capacity
 	return thermal_energy
 
 
@@ -209,8 +208,7 @@
 /datum/gas_mixture/proc/update_values()
 	total_moles = 0
 	for(var/g in gas)
-		var/moles = gas[g]
-		if(moles)
+		if(gas[g])
 			total_moles += gas[g]
 		else
 			gas -= g

--- a/code/ZAS/_gas_mixture.dm
+++ b/code/ZAS/_gas_mixture.dm
@@ -208,8 +208,9 @@
 /datum/gas_mixture/proc/update_values()
 	total_moles = 0
 	for(var/g in gas)
-		if(gas[g])
-			total_moles += gas[g]
+		var/moles = gas[g]
+		if(moles)
+			total_moles += moles
 		else
 			gas -= g
 

--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -23,8 +23,6 @@ var/list/machines = list()
 
 	..("M:[global.machines.len]")
 
-
-// This is to allow the near identical fast machinery process to use it.
 /datum/subsystem/machinery/proc/get_currenrun()
 	currentrun_index = machines.len
 	return machines.Copy()

--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -27,13 +27,7 @@ var/list/machines = list()
 // This is to allow the near identical fast machinery process to use it.
 /datum/subsystem/machinery/proc/get_currenrun()
 	currentrun_index = machines.len
-	currentrun.len = currentrun_index
-	if (currentrun_index)
-		for(var/c in 1 to currentrun_index)
-			currentrun[c] = machines[c]
-
-	return currentrun
-
+	return machines.Copy()
 
 /datum/subsystem/machinery/fire(resumed = FALSE)
 	if (!resumed)

--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -40,9 +40,10 @@ var/list/machines = list()
 		currentrun = get_currenrun()
 
 	var/obj/machinery/M
-	while (currentrun_index)
-		M = currentrun[currentrun_index]
-		currentrun_index--
+	var/c = currentrun_index
+	while (c)
+		M = currentrun[c]
+		c--
 
 		if (!M || M.gcDestroyed || M.timestopped)
 			continue
@@ -56,4 +57,6 @@ var/list/machines = list()
 			M.auto_use_power()
 
 		if (MC_TICK_CHECK)
-			return
+			break
+
+	currentrun_index = c

--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -14,10 +14,11 @@ var/list/machines = list()
 	var/currentrun_index
 
 	var/obj/machinery/M //Machine currently being processed.
+	var/c
 
 /datum/subsystem/machinery/New()
 	NEW_SS_GLOBAL(SSmachinery)
-
+	currentrun = list()
 
 /datum/subsystem/machinery/stat_entry(var/msg)
 	if (msg)
@@ -28,13 +29,18 @@ var/list/machines = list()
 
 // This is to allow the near identical fast machinery process to use it.
 /datum/subsystem/machinery/proc/get_currenrun()
-	return machines.Copy()
+	currentrun_index = machines.len
+	currentrun.len = currentrun_index
+	if (currentrun_index)
+		for(c in 1 to currentrun_index)
+		currentrun[c] = machines[c]
+
+	return currentrun
 
 
 /datum/subsystem/machinery/fire(resumed = FALSE)
 	if (!resumed)
 		currentrun = get_currenrun()
-		currentrun_index = currentrun.len
 
 	while (currentrun_index)
 		M = currentrun[currentrun_index]

--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -11,7 +11,9 @@ var/list/machines = list()
 	display_order = SS_DISPLAY_MACHINERY
 
 	var/list/currentrun
+	var/currentrun_index
 
+	var/obj/machinery/M //Machine currently being processed.
 
 /datum/subsystem/machinery/New()
 	NEW_SS_GLOBAL(SSmachinery)
@@ -32,10 +34,11 @@ var/list/machines = list()
 /datum/subsystem/machinery/fire(resumed = FALSE)
 	if (!resumed)
 		currentrun = get_currenrun()
+		currentrun_index = currentrun.len
 
-	while (currentrun.len)
-		var/obj/machinery/M = currentrun[currentrun.len]
-		currentrun.len--
+	while (currentrun_index)
+		M = currentrun[currentrun_index]
+		currentrun_index--
 
 		if (!M || M.gcDestroyed || M.timestopped)
 			continue

--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -13,9 +13,6 @@ var/list/machines = list()
 	var/list/currentrun
 	var/currentrun_index
 
-	var/obj/machinery/M //Machine currently being processed.
-	var/c
-
 /datum/subsystem/machinery/New()
 	NEW_SS_GLOBAL(SSmachinery)
 	currentrun = list()
@@ -32,8 +29,8 @@ var/list/machines = list()
 	currentrun_index = machines.len
 	currentrun.len = currentrun_index
 	if (currentrun_index)
-		for(c in 1 to currentrun_index)
-		currentrun[c] = machines[c]
+		for(var/c in 1 to currentrun_index)
+			currentrun[c] = machines[c]
 
 	return currentrun
 
@@ -42,6 +39,7 @@ var/list/machines = list()
 	if (!resumed)
 		currentrun = get_currenrun()
 
+	var/obj/machinery/M
 	while (currentrun_index)
 		M = currentrun[currentrun_index]
 		currentrun_index--

--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -23,6 +23,7 @@ var/list/machines = list()
 
 	..("M:[global.machines.len]")
 
+// This is to allow the near identical fast machinery process to use it.
 /datum/subsystem/machinery/proc/get_currenrun()
 	currentrun_index = machines.len
 	return machines.Copy()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -330,9 +330,7 @@ Class Procs:
 	if(this_area)
 		return this_area.powered(chan)
 	else
-		var/area/power_area = get_area(src)
-		return power_area ? power_area.powered(chan) : FALSE
-
+		return (get_area(src))?.powered(chan)
 
 /obj/machinery/proc/multitool_topic(var/mob/user,var/list/href_list,var/obj/O)
 	if("set_id" in href_list)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -161,8 +161,6 @@ Class Procs:
 	var/obj/item/weapon/card/id/scan = null	//ID inserted for identification, if applicable
 	var/id_tag = null // Identify the machine
 
-	var/area/power_area //The area the machine is drawing power from.
-
 /obj/machinery/cultify()
 	var/list/random_structure = list(
 		/obj/structure/cult_legacy/talisman,
@@ -282,7 +280,7 @@ Class Procs:
 			connected_cell.use(amount*0.75)
 	else
 
-		power_area = get_area(src)
+		var/area/power_area = get_area(src)
 		if(power_area && powered(chan, null, power_area)) //no point in trying if we don't have power
 			power_area.use_power(amount, chan)
 		else
@@ -332,7 +330,7 @@ Class Procs:
 	if(this_area)
 		return this_area.powered(chan)
 	else
-		power_area = get_area(src)
+		var/area/power_area = get_area(src)
 		return power_area ? power_area.powered(chan) : FALSE
 
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -329,7 +329,7 @@ Class Procs:
 	if((machine_flags & FIXED2WORK) && !anchored)
 		return FALSE
 
-	if	(this_area)
+	if(this_area)
 		return this_area.powered(chan)
 	else
 		power_area = get_area(src)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -161,6 +161,8 @@ Class Procs:
 	var/obj/item/weapon/card/id/scan = null	//ID inserted for identification, if applicable
 	var/id_tag = null // Identify the machine
 
+	var/area/power_area //The area the machine is drawing power from.
+
 /obj/machinery/cultify()
 	var/list/random_structure = list(
 		/obj/structure/cult_legacy/talisman,
@@ -273,19 +275,17 @@ Class Procs:
 // increment the power usage stats for an area
 // defaults to power_channel
 /obj/machinery/proc/use_power(amount, chan = power_channel)
-	var/area/this_area = get_area(src)
 	if(connected_cell && connected_cell.charge > 0)   //If theres a cell directly providing power use it, only for cargo carts at the moment
 		if(connected_cell.charge < amount*0.75)	//Let them squeeze the last bit of power out.
 			connected_cell.charge = 0
 		else
 			connected_cell.use(amount*0.75)
 	else
-		if(!this_area)
-			return 0						// if not, then not powered.
-		if(!powered(chan)) //no point in trying if we don't have power
-			return 0
 
-		this_area.use_power(amount, chan)
+		power_area = get_area(src)
+		if(power_area && powered(chan, null, power_area)) //no point in trying if we don't have power
+			power_area.use_power(amount, chan)
+		return 0
 
 // called whenever the power settings of the containing area change
 // by default, check equipment channel & set flag
@@ -309,7 +309,7 @@ Class Procs:
 
 // returns true if the machine is powered (or doesn't require power).
 // performs basic checks every machine should do, then
-/obj/machinery/proc/powered(chan = power_channel, power_check_anyways = FALSE)
+/obj/machinery/proc/powered(chan = power_channel, power_check_anyways = FALSE, area/this_area)
 	if(!src.loc)
 		return FALSE
 
@@ -328,11 +328,12 @@ Class Procs:
 	if((machine_flags & FIXED2WORK) && !anchored)
 		return FALSE
 
-	var/area/this_area = get_area(src)
-	if(!this_area)
-		return FALSE
+	if	(this_area)
+		return this_area.powered(chan)
+	else
+		power_area = get_area(src)
+		return power_area ? power_area.powered(chan) : FALSE
 
-	return this_area.powered(chan)
 
 /obj/machinery/proc/multitool_topic(var/mob/user,var/list/href_list,var/obj/O)
 	if("set_id" in href_list)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -285,7 +285,8 @@ Class Procs:
 		power_area = get_area(src)
 		if(power_area && powered(chan, null, power_area)) //no point in trying if we don't have power
 			power_area.use_power(amount, chan)
-		return 0
+		else
+			return 0
 
 // called whenever the power settings of the containing area change
 // by default, check equipment channel & set flag


### PR DESCRIPTION
## What this does
Currently, the machinery subsystem is the most resource intensive subsystem under idle conditions.

Overall it seems like this makes it about ~25% faster, so that should translate to about ~7% less "idle" CPU usage (if no player is actively doing anything).

Also I think in general the method of iteratively modifying a list's `len` to erase its values seems slower than just iterating through the list. Let me know if that affects some sort of diagnostic/debugging system that I don't know about, but from what I can tell it seems to work fine.

Also optimizes few other procs. 

## Why it's good
Reduce CPU usage.
