### PR TITLE
potential fix for crash+runtime with hookshotting

### DIFF
--- a/code/modules/projectiles/projectile/hookshot.dm
+++ b/code/modules/projectiles/projectile/hookshot.dm
@@ -85,6 +85,8 @@
 	bumped = 1
 
 	var/obj/item/weapon/gun/hookshot/hookshot = shot_from
+	if(!hookshot) /* Can happen with supply cyborg hookshots as they're de-selected/put in inventory/etc. */
+		return
 	spawn()
 		if(!can_tether)
 			..(A)

--- a/code/modules/projectiles/projectile/hookshot.dm
+++ b/code/modules/projectiles/projectile/hookshot.dm
@@ -85,7 +85,7 @@
 	bumped = 1
 
 	var/obj/item/weapon/gun/hookshot/hookshot = shot_from
-	if(!hookshot) /* Can happen with supply cyborg hookshots as they're de-selected/put in inventory/etc. */
+	if(!hookshot) /* Can happen with hookshots if it doesn't have shot_from assigned for one reason or another. Probably something to do with hostage-taking? */
 		return
 	spawn()
 		if(!can_tether)


### PR DESCRIPTION
[runtime][exploitable]

Marking this exploitable because technically anyone can do this but it seems pretty hard to do and the fact that this crashed the server rather than just runtiming is surprising. This indicates there's more going on behind the scenes than what I was able to successfully test, but with any luck this will fix the issue.
Runtime + explanation as follows, bearing in mind this is my second-hand account:
```[02:14:30] Runtime in code/modules/projectiles/projectile/hookshot.dm,97: Cannot execute null.clockwerk chain().
  proc name: to bump (/obj/item/projectile/hookshot/to_bump)
  usr: The big mother fucker 2.0 (jaid777) (/mob/living/silicon/robot)
  usr.loc: The floor (199, 228, 1) (/turf/simulated/floor)
  src: the hook (/obj/item/projectile/hookshot)
  src.loc: the floor (199,228,1) (/turf/simulated/floor)
  call stack:
  the hook (/obj/item/projectile/hookshot): to bump(the wall (199,227,1) (/turf/simulated/wall))
```

It would seem a supply cyborg was messing around with hookshots (specifically, when aiming at people with the hostage-taking feature guns have) and managed to shoot a projectile that didn't have `shot_from` assigned, either because the hookshot was de-selected, stored back in the cyborg's inventory, or something else.

It's hard to say, but I'm willing to bet that the culprit is a hookshot projectile that never had shot_from assigned for some reason related to taking hostages. I could not replicate this and don't know what caused it to happen, but regardless this band-aid should fix it.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed a potential server crash exploit with hookshots.
