### PR TITLE
Creeping vine spread distance depends on maturation

### DIFF
--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -1,5 +1,5 @@
 #define DEFAULT_SEED "glowshroom"
-#define CREEPER_GROWTH_DISTANCE 4
+#define CREEPER_GROWTH_DISTANCE_LIMIT 4
 
 /obj/effect/plantsegment
 	name = "space vines"
@@ -84,7 +84,10 @@
 		plane = ABOVE_TURF_PLANE
 	mature_time = Ceiling(seed.maturation/2)
 	spread_chance = round(40 + triangular_seq(seed.potency*2, 30)) // Diminishing returns formula, see maths.dm
-	spread_distance_limit = limited_growth ? (CREEPER_GROWTH_DISTANCE) : 0
+	if (limited_growth)
+		spread_distance_limit = clamp(ceil((25 - seed.maturation) / 6), 1, CREEPER_GROWTH_DISTANCE_LIMIT)
+	else
+		spread_distance_limit = 0
 	update_icon()
 
 	if(start_fully_mature)


### PR DESCRIPTION
## What this does
Currently, creeping plants spread to a maximum distance of 4 tiles away from the germination site. This makes it so the creeping distance limit depends on maturation, and can range from 1 to 4 as follows:
<img width="178" alt="seedcreepdistance" src="https://github.com/vgstation-coders/vgstation13/assets/7112773/354cbc4a-c69d-414d-bf72-34a767b6e21a">


## Why it's good
I think it's nice to allow you to fine tune your creeping vine spreads, for example if you want a beneficial vine in a small room. You can make small areas with different types of vines instead of each vine necessarily taking up a relatively large 9x9 area.

## Changelog
:cl:
 * rscadd: Creeping vine spread distance depends on development genes; plants with longer maturation periods creep to a shorter distance.
