### PR TITLE
Fix speedloaders reloading bullets one by one

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -67,6 +67,7 @@
 	var/list/stored_ammo = list()
 	var/ammo_type = "/obj/item/ammo_casing/a357"
 	var/reloading = FALSE // Flag to stop multi-box loading
+	var/reload_delay = 5 // Delay for do_after() call of reloading
 	var/reload_sound = 'sound/weapons/magazine_load_click.ogg'
 	var/fumble_sound = 'sound/weapons/casing_drop.ogg'
 	var/exact = 1 //whether or not the item only takes ammo_type, or also subtypes. Set to 1 to only take the specified ammo
@@ -163,17 +164,20 @@
 		if (PW.loaded.len + PW.refuse.len >= PW.max_shells)
 			break
 		if (!(PW.caliber && PW.caliber[loading.caliber]))
-			break
-		if (!do_after(usr, target, 5, 5))
+			break;
+		if (!do_after(usr, target, reload_delay, 5))
 			return fumbleLoad(bullets_from, target)
 
 		bullets_from.stored_ammo -= loading
 		PW.loaded += loading
 		loading.forceMove(PW)
 		bullets_loaded++
-		playsound(usr, reload_sound, 100, 1)
 		bullets_from.update_icon()
 		target.update_icon()
+
+		if (reload_delay == 0 && i > 1)	// When reload delay is 0 (speedloaders by default), play the reload sound on first iteration only
+			continue
+		playsound(usr, reload_sound, 100, 1)
 
 	bullets_from.reloading = FALSE
 	return bullets_loaded

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -164,7 +164,7 @@
 		if (PW.loaded.len + PW.refuse.len >= PW.max_shells)
 			break
 		if (!(PW.caliber && PW.caliber[loading.caliber]))
-			break;
+			break
 		if (!do_after(usr, target, reload_delay, 5))
 			return fumbleLoad(bullets_from, target)
 

--- a/code/modules/projectiles/ammunition/speedloaders.dm
+++ b/code/modules/projectiles/ammunition/speedloaders.dm
@@ -6,6 +6,7 @@
 	desc = "A speedloader, used to load a gun without any of that annoying fumbling."
 	exact = 0 //load anything in the class!
 	materials = list(MAT_IRON = 200)
+	reload_delay = 0
 /obj/item/ammo_storage/speedloader/c38
 	name = "speed loader (.38)"
 	icon_state = "38"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
[bugfix]
## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Adds a reload_delay variable governing the delay between single reloads
This is set to 0 for speedloaders, so they instantly load all bullets into guns
Makes sure the reload sound only plays once if delay is 0

## Why it's good
<!-- Explain why you think these changes are good. -->
Fixes a bug, lets speedloaders speedload

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Speedloaders once again speed load
