### PR TITLE
Small Vault Update (Pod Station, Broke UFO)

### DIFF
--- a/code/datums/shuttle.dm
+++ b/code/datums/shuttle.dm
@@ -99,7 +99,7 @@
 			linked_area = starting_area
 			warning("Unable to find area [starting_area] in world - [src.type] ([src.name]) won't be able to function properly.")
 
-	if(istype(linked_area) && linked_area.contents.len) //Only add the shuttle to the list if its area exists and it has something in it
+	if(istype(linked_area)) //Only add the shuttle to the list if its area exists and it has something in it
 		shuttles |= src
 	if(password)
 		password = rand(10000,99999)

--- a/code/game/shuttles/brokeufo.dm
+++ b/code/game/shuttles/brokeufo.dm
@@ -45,6 +45,11 @@
 	var/global/datum/shuttle/brokeufo/brokeufo_shuttle = new(starting_area=/area/shuttle/brokeufo/start)
 	brokeufo_shuttle.initialize()
 	link_to(brokeufo_shuttle)
+
+	var/obj/item/weapon/paper/manual_ufo = new(get_turf(src))
+
+	manual_ufo.name = "GDR Scout Passcode"
+	manual_ufo.info = "Keep this document in a secure location. Your craft's passcode is: \"<b>[brokeufo_shuttle.password]</b>\"."
 	.=..()
 
 //code/game/objects/structures/docking_port.dm

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -627,6 +627,12 @@ var/list/icon_state_to_appearance = list()
 	..()
 	icon_state = pick("cavefl_1","cavefl_2","cavefl_3","cavefl_4")
 
+/turf/unsimulated/floor/asteroid/underground/airless // Used by the pod station vault
+	name = "paved asteroid"
+	oxygen = 0.01
+	nitrogen = 0.01
+	temperature = TCMB
+
 /turf/unsimulated/floor/asteroid/New()
 	..()
 	if(prob(20) && icon_state == "asteroid")

--- a/maps/randomvaults/brokeufo.dmm
+++ b/maps/randomvaults/brokeufo.dmm
@@ -144,10 +144,9 @@
 	},
 /area/shuttle/brokeufo/start)
 "aH" = (
-/obj/structure/closet/crate,
-/obj/item/weapon/reagent_containers/food/snacks/zam_spiderslider/wrapped,
-/obj/item/weapon/reagent_containers/food/snacks/zamitos_stokjerky,
-/obj/item/weapon/reagent_containers/food/condiment/zamspices,
+/obj/structure/bed/ayy1,
+/obj/item/trash/zam_sliderwrapper,
+/obj/structure/curtain/open/bed,
 /turf/simulated/floor/carpet,
 /area/shuttle/brokeufo/start)
 "aI" = (
@@ -161,16 +160,9 @@
 "aJ" = (
 /turf/simulated/floor/engine,
 /area/shuttle/brokeufo/start)
-"aN" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/zam_sliderwrapper,
-/obj/item/weapon/bedsheet/green,
-/turf/simulated/floor/carpet,
-/area/shuttle/brokeufo/start)
 "aO" = (
-/obj/structure/bed,
-/obj/item/weapon/bedsheet/green,
+/obj/structure/bed/ayy1,
+/obj/structure/curtain/open/bed,
 /turf/simulated/floor/carpet,
 /area/shuttle/brokeufo/start)
 "aP" = (
@@ -236,17 +228,6 @@
 	icon_state = "yellowfull"
 	},
 /area/shuttle/brokeufo/start)
-"aY" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave/upgraded{
-	pixel_y = 5
-	},
-/obj/item/trash/used_tray,
-/obj/item/weapon/kitchen/utensil/fork/teflon{
-	pixel_x = 6
-	},
-/turf/simulated/floor/carpet,
-/area/shuttle/brokeufo/start)
 "aZ" = (
 /turf/simulated/wall/shuttle,
 /area/shuttle/brokeufo/start)
@@ -290,22 +271,28 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/brokeufo/start)
 "bg" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/item/trash/zam_notraisins,
 /turf/simulated/floor/carpet,
 /area/shuttle/brokeufo/start)
 "bh" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/weapon/soap,
-/obj/item/weapon/bedsheet/green,
-/turf/simulated/floor/carpet,
-/area/shuttle/brokeufo/start)
-"bi" = (
-/obj/structure/bed,
+/obj/item/weapon/reagent_containers/food/snacks/zam_spiderslider/wrapped,
+/obj/item/weapon/reagent_containers/food/snacks/zamitos_stokjerky,
+/obj/item/weapon/reagent_containers/food/condiment/zamspices,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/weapon/bedsheet/green,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/carpet,
+/area/shuttle/brokeufo/start)
+"bi" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave/upgraded{
+	pixel_y = 5
+	},
+/obj/item/weapon/kitchen/utensil/fork/teflon{
+	pixel_x = 6
+	},
 /turf/simulated/floor/carpet,
 /area/shuttle/brokeufo/start)
 "bj" = (
@@ -321,7 +308,7 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/brokeufo/start)
 "by" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/comfy/ayy1{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
@@ -1075,7 +1062,7 @@ ar
 aZ
 aH
 aO
-aY
+aO
 bf
 aZ
 hl
@@ -1091,9 +1078,9 @@ aa
 (13,1,1) = {"
 aa
 aZ
-aN
-as
 bf
+as
+bg
 as
 aZ
 aC
@@ -1111,7 +1098,7 @@ aa
 ar
 aZ
 bi
-bg
+by
 by
 aZ
 aC

--- a/maps/randomvaults/brokeufo.dmm
+++ b/maps/randomvaults/brokeufo.dmm
@@ -823,6 +823,13 @@
 	icon_state = "dark"
 	},
 /area/shuttle/brokeufo/start)
+"YX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/acidsink{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/brokeufo/start)
 "Zo" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/fancy/flares,
@@ -1078,7 +1085,7 @@ aa
 (13,1,1) = {"
 aa
 aZ
-bf
+YX
 as
 bg
 as

--- a/maps/randomvaults/brokeufo.dmm
+++ b/maps/randomvaults/brokeufo.dmm
@@ -492,6 +492,7 @@
 /obj/structure/table/reinforced,
 /obj/item/tool/bonesetter,
 /obj/item/tool/bonegel,
+/obj/item/tool/FixOVein,
 /turf/simulated/floor{
 	icon_state = "white";
 	tag = "icon-white"
@@ -568,6 +569,7 @@
 	},
 /obj/item/weapon/storage/firstaid,
 /obj/item/weapon/storage/box/masks,
+/obj/item/tool/cautery,
 /turf/simulated/floor{
 	icon_state = "white";
 	tag = "icon-white"

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -46,6 +46,14 @@
 /area/vault/podstation
 	requires_power = 1
 
+/area/vault/podstation/interior
+	name = "\improper Pod Station"
+	icon_state = "kitchen"
+
+/area/vault/podstation/exterior
+	name = "\improper Pod Station Asteroid"
+	icon_state = "pod"
+
 /area/vault/fastfood
 
 /area/vault/fastfood/dining

--- a/maps/randomvaults/podstation.dmm
+++ b/maps/randomvaults/podstation.dmm
@@ -223,6 +223,9 @@
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/cannedcoffee,
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/cannedcoffee,
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/cannedcoffee,
+/obj/item/weapon/reagent_containers/food/drinks/tomatosoup,
+/obj/item/weapon/reagent_containers/food/drinks/tomatosoup,
+/obj/item/weapon/reagent_containers/food/drinks/tomatosoup,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -259,7 +262,9 @@
 /area/vault/podstation/interior)
 "dU" = (
 /obj/structure/fence/door,
-/turf/unsimulated/floor/asteroid,
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
 /area/vault/podstation/exterior)
 "ev" = (
 /mob/living/simple_animal/hostile/bigroach,
@@ -900,6 +905,22 @@
 	},
 /turf/simulated/floor,
 /area/vault/podstation/interior)
+"pL" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
+/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
+/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
+/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
+/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
+/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
+/obj/item/weapon/reagent_containers/food/snacks/sundae,
+/obj/item/weapon/reagent_containers/food/snacks/sundae,
+/obj/item/weapon/reagent_containers/food/snacks/sundae,
+/obj/item/weapon/reagent_containers/food/snacks/sundae,
+/turf/simulated/floor{
+	icon_state = "freezerfloor"
+	},
+/area/vault/podstation/interior)
 "pU" = (
 /turf/space,
 /area)
@@ -1010,7 +1031,9 @@
 /obj/structure/fence/corner{
 	dir = 1
 	},
-/turf/unsimulated/floor/asteroid,
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
 /area/vault/podstation/exterior)
 "rF" = (
 /mob/living/simple_animal/cockroach,
@@ -1174,7 +1197,9 @@
 "wh" = (
 /obj/item/trash/tray,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/asteroid,
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
 /area/vault/podstation/exterior)
 "wi" = (
 /obj/machinery/camera{
@@ -1435,13 +1460,17 @@
 	},
 /turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation/exterior)
+"DW" = (
+/obj/structure/lattice,
+/turf/space,
+/area)
 "Ee" = (
 /obj/machinery/light/small,
 /turf/space,
 /area/vault/podstation/exterior)
 "En" = (
 /obj/structure/reagent_dispensers/cauldron/barrel{
-	name = "Dan's Sauce Barrel"
+	name = "Discount Dan's Sauce Barrel"
 	},
 /obj/effect/decal/cleanable/greenglow,
 /turf/unsimulated/floor/airless{
@@ -1562,7 +1591,9 @@
 /obj/structure/fence/corner{
 	dir = 8
 	},
-/turf/unsimulated/floor/asteroid,
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
 /area/vault/podstation/exterior)
 "HV" = (
 /obj/structure/fence/door/opened,
@@ -1667,6 +1698,8 @@
 /obj/item/weapon/reagent_containers/food/snacks/loadedbakedpotato,
 /obj/item/weapon/reagent_containers/food/snacks/loadedbakedpotato,
 /obj/item/weapon/reagent_containers/food/snacks/loadedbakedpotato,
+/obj/item/weapon/reagent_containers/food/snacks/chilaquiles,
+/obj/item/weapon/reagent_containers/food/snacks/chilaquiles,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -1755,7 +1788,9 @@
 /area/vault/podstation/exterior)
 "Np" = (
 /obj/structure/fence,
-/turf/unsimulated/floor/asteroid,
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
 /area/vault/podstation/exterior)
 "NA" = (
 /obj/effect/decal/warning_stripes{
@@ -1987,9 +2022,8 @@
 /obj/item/weapon/reagent_containers/food/snacks/grilledcheese,
 /obj/item/weapon/reagent_containers/food/snacks/corndog,
 /obj/item/weapon/reagent_containers/food/snacks/corndog,
-/obj/item/weapon/reagent_containers/food/snacks/bagel,
-/obj/item/weapon/reagent_containers/food/snacks/bagel,
-/obj/item/weapon/reagent_containers/food/snacks/bagel,
+/obj/item/weapon/reagent_containers/food/snacks/margheritaslice,
+/obj/item/weapon/reagent_containers/food/snacks/margheritaslice,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -2065,6 +2099,11 @@
 	},
 /turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation/exterior)
+"UL" = (
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
+/area)
 "UN" = (
 /obj/structure/window/barricade/full/block,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -2075,6 +2114,9 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/vault/podstation/interior)
+"UO" = (
+/turf/unsimulated/floor/asteroid,
+/area)
 "Vb" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
@@ -2088,7 +2130,9 @@
 /obj/structure/fence/corner{
 	dir = 10
 	},
-/turf/unsimulated/floor/asteroid,
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
 /area/vault/podstation/exterior)
 "VP" = (
 /turf/unsimulated/floor/airless{
@@ -2110,13 +2154,17 @@
 /obj/structure/fence{
 	dir = 4
 	},
-/turf/unsimulated/floor/asteroid,
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
 /area/vault/podstation/exterior)
 "VW" = (
 /obj/structure/fence/corner{
 	dir = 5
 	},
-/turf/unsimulated/floor/asteroid,
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
 /area/vault/podstation/exterior)
 "VX" = (
 /obj/machinery/camera{
@@ -2132,7 +2180,9 @@
 "VY" = (
 /obj/item/trash/cigbutt,
 /obj/item/weapon/storage/bag/trash,
-/turf/unsimulated/floor/asteroid,
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
 /area/vault/podstation/exterior)
 "Wu" = (
 /obj/machinery/cryopod,
@@ -2238,16 +2288,7 @@
 	},
 /area/vault/podstation/interior)
 "XB" = (
-/obj/item/weapon/reagent_containers/food/snacks/sundae,
-/obj/item/weapon/reagent_containers/food/snacks/sundae,
-/obj/item/weapon/reagent_containers/food/snacks/sundae,
 /obj/structure/closet/crate/freezer,
-/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
-/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
-/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
-/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
-/obj/item/weapon/reagent_containers/food/snacks/candiedapple,
-/obj/item/weapon/reagent_containers/food/snacks/candiedapple,
 /obj/item/weapon/reagent_containers/food/snacks/cinnamonroll,
 /obj/item/weapon/reagent_containers/food/snacks/cinnamonroll,
 /obj/item/weapon/reagent_containers/food/snacks/chococherrycakeslice,
@@ -2255,6 +2296,15 @@
 /obj/item/weapon/reagent_containers/food/snacks/chococherrycakeslice,
 /obj/item/weapon/reagent_containers/food/snacks/muffin/berry,
 /obj/item/weapon/reagent_containers/food/snacks/muffin/berry,
+/obj/item/weapon/reagent_containers/food/snacks/poppypretzel,
+/obj/item/weapon/reagent_containers/food/snacks/poppypretzel,
+/obj/item/weapon/reagent_containers/food/snacks/poppypretzel,
+/obj/item/weapon/reagent_containers/food/snacks/bagel,
+/obj/item/weapon/reagent_containers/food/snacks/bagel,
+/obj/item/weapon/reagent_containers/food/snacks/bagel,
+/obj/item/weapon/reagent_containers/food/snacks/bagel,
+/obj/item/weapon/reagent_containers/food/snacks/croissant,
+/obj/item/weapon/reagent_containers/food/snacks/croissant,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -2405,7 +2455,7 @@ ES
 HJ
 Np
 VJ
-VS
+ES
 VS
 aI
 pU
@@ -2444,14 +2494,14 @@ ES
 ES
 ES
 ES
-pU
+DW
 ES
 Yx
 HV
 Yx
 VU
 ES
-VS
+ES
 VS
 pU
 pU
@@ -2497,7 +2547,7 @@ Yx
 VW
 Np
 rx
-VS
+ES
 pU
 pU
 pU
@@ -2633,8 +2683,8 @@ XS
 Kk
 Kk
 Yx
-VS
-pU
+ES
+DW
 pU
 pU
 pU
@@ -2679,8 +2729,8 @@ vM
 af
 wi
 Yx
-pU
-pU
+UL
+DW
 pU
 pU
 "}
@@ -2724,8 +2774,8 @@ ol
 bB
 QW
 Nl
-VS
-pU
+eZ
+UO
 pU
 pU
 "}
@@ -2768,9 +2818,9 @@ Kk
 Kk
 Kk
 Kk
+Kk
 zr
-VS
-pU
+UO
 pU
 pU
 "}
@@ -2812,10 +2862,10 @@ RX
 Zo
 ai
 cJ
+pL
 Kk
 Yx
-ES
-pU
+UO
 pU
 pU
 "}
@@ -2856,11 +2906,11 @@ Kg
 yE
 Xr
 Xr
+Xr
 FJ
 Kk
 Yx
-ES
-pU
+UO
 pU
 pU
 "}
@@ -2901,11 +2951,11 @@ Kv
 Sc
 XB
 Qx
+Xr
 Wu
 Kk
 Yx
-ES
-pU
+UO
 pU
 pU
 "}
@@ -2948,9 +2998,9 @@ Kk
 Kk
 Kk
 Kk
+Kk
 Yx
-ES
-pU
+UO
 pU
 pU
 "}
@@ -2994,8 +3044,8 @@ hD
 iv
 Kk
 aM
-ES
-pU
+Yx
+UO
 pU
 pU
 "}
@@ -3040,7 +3090,7 @@ sK
 Kk
 Yx
 ES
-pU
+UO
 pU
 pU
 "}
@@ -3085,7 +3135,7 @@ CD
 Kk
 Yx
 ES
-pU
+DW
 pU
 pU
 "}
@@ -3130,7 +3180,7 @@ px
 Kk
 Yx
 ES
-pU
+DW
 pU
 pU
 "}

--- a/maps/randomvaults/podstation.dmm
+++ b/maps/randomvaults/podstation.dmm
@@ -714,6 +714,13 @@
 /obj/item/weapon/storage/backpack/satchel,
 /turf/simulated/floor/dark,
 /area/vault/podstation)
+"mh" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/unsimulated/floor/asteroid/underground/airless,
+/area/vault/podstation)
 "mj" = (
 /obj/machinery/processor,
 /obj/item/trash/fries_cone,
@@ -809,12 +816,14 @@
 /turf/simulated/floor,
 /area/vault/podstation)
 "ol" = (
-/obj/machinery/atmospherics/miner/oxygen,
 /obj/effect/decal/warning_stripes{
 	icon_state = "unloading"
 	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/machinery/atmospherics/miner/air{
+	desc = "Gasses mined from the gas giant below (above?) flow out through this massive vent."
 	},
 /turf/simulated/floor/engine{
 	name = "vacuum floor";
@@ -1107,7 +1116,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	canSpawnMice = 0;
-	dir = 8;
+	dir = 1;
 	external_pressure_bound = 0;
 	frequency = 1443;
 	icon_state = "in";
@@ -1760,11 +1769,12 @@
 	},
 /area/vault/podstation)
 "Ov" = (
-/obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/unary/tank/air{
+	starting_volume = 3200
+	},
 /turf/simulated/floor/plating,
 /area/vault/podstation)
 "OX" = (
@@ -3855,7 +3865,7 @@ bX
 hQ
 YT
 Zy
-Si
+mh
 Zy
 Zy
 Dz

--- a/maps/randomvaults/podstation.dmm
+++ b/maps/randomvaults/podstation.dmm
@@ -823,7 +823,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/miner/air{
-	desc = "Gasses mined from the gas giant below (above?) flow out through this massive vent."
+	desc = "Gasses mined from the gas giant below (above?) flow out through this massive vent.";
+	on = 1
 	},
 /turf/simulated/floor/engine{
 	name = "vacuum floor";
@@ -1605,6 +1606,11 @@
 	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "air"
+	},
+/obj/machinery/door_control{
+	pixel_y = 25;
+	name = "Gas Miner Control";
+	id_tag = "podstation_air"
 	},
 /turf/simulated/floor/plating,
 /area/vault/podstation)

--- a/maps/randomvaults/podstation.dmm
+++ b/maps/randomvaults/podstation.dmm
@@ -7,21 +7,69 @@
 /turf/simulated/wall,
 /area/vault/podstation)
 "ai" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/weapon/reagent_containers/food/condiment/ketchup,
-/obj/item/weapon/reagent_containers/food/condiment/vinegar,
-/obj/item/weapon/reagent_containers/food/condiment/small/mayo,
-/obj/item/weapon/reagent_containers/food/condiment/small/mayo,
-/obj/item/weapon/reagent_containers/food/condiment/small/vinegar,
-/obj/item/weapon/reagent_containers/food/condiment/small/ketchup,
-/obj/item/weapon/reagent_containers/food/condiment/small/ketchup,
-/obj/item/weapon/reagent_containers/food/condiment/small/ketchup,
-/obj/item/weapon/reagent_containers/food/condiment/flour,
-/obj/item/weapon/reagent_containers/food/condiment/flour,
-/obj/item/weapon/reagent_containers/food/condiment/hotsauce,
-/obj/item/weapon/reagent_containers/food/condiment/relish,
-/obj/item/weapon/storage/fancy/egg_box/empty,
-/obj/item/weapon/reagent_containers/food/condiment/spacemilk,
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	one_way = 1
+	},
+/obj/machinery/door/window{
+	base_state = "right";
+	icon_state = "right"
+	},
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/bear{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/bear{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/bear{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/bear{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/blebweiser{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/blebweiser{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/blebweiser{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/blebweiser{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/gibness,
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/gibness,
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/gibness,
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/gibness,
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/bluespaceribbon{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/bluespaceribbon{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/bluespaceribbon{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/bluespaceribbon{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "unloading"
+	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -46,7 +94,7 @@
 /obj/effect/decal/cleanable/blood/oil{
 	icon_state = "floor2"
 	},
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "aW" = (
 /obj/machinery/floodlight/on/infinite,
@@ -96,9 +144,6 @@
 "bJ" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp,
-/obj/item/weapon/spacecash/c100,
-/obj/item/weapon/spacecash/c100,
-/obj/item/weapon/coin/gold,
 /obj/machinery/door_control{
 	id_tag = "podstationclosing";
 	name = "Closing Time";
@@ -107,27 +152,38 @@
 	range = 20;
 	specialfunctions = 4
 	},
+/obj/item/weapon/storage/wallet,
+/obj/item/weapon/coin/gold,
+/obj/item/clothing/accessory/holster/handgun,
+/obj/item/weapon/spacecash/c100,
+/obj/item/weapon/spacecash/c100,
+/obj/item/weapon/spacecash/c100,
+/obj/item/weapon/spacecash/c100,
 /turf/simulated/floor/dark,
 /area/vault/podstation)
 "bP" = (
-/obj/window_grille_spawner/reinforced,
 /obj/structure/window/barricade/full/block,
-/turf/simulated/floor{
-	icon_state = "bluefull"
+/obj/structure/grille,
+/obj/structure/window/full/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id_tag = "podstationkitchen";
+	name = "Kitchen Shutters";
+	dir = 2
 	},
+/turf/simulated/floor/plating,
 /area/vault/podstation)
 "bX" = (
 /obj/structure/spacepod_frame/unarmored{
 	dir = 1
 	},
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "cd" = (
 /obj/item/weapon/tank/oxygen/red,
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "cq" = (
 /mob/living/simple_animal/cockroach,
@@ -161,6 +217,9 @@
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/nuka,
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/sportdrink,
 /obj/structure/closet/secure_closet/freezer,
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cannedcoffee,
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cannedcoffee,
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cannedcoffee,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -172,20 +231,27 @@
 	},
 /turf/space,
 /area/vault/podstation)
+"df" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "blue"
+	},
+/area/vault/podstation)
 "dp" = (
-/obj/window_grille_spawner/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
 	id_tag = "podstationoffice";
 	name = "Office Shutters"
 	},
-/turf/simulated/floor/dark,
+/obj/structure/grille,
+/obj/structure/window/full/reinforced,
+/turf/simulated/floor/plating,
 /area/vault/podstation)
 "dK" = (
 /obj/structure/bed/chair/office,
-/obj/item/weapon/reagent_containers/food/snacks/roach_eggs,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
+/obj/item/weapon/reagent_containers/food/snacks/roach_eggs,
 /turf/simulated/floor/carpet,
 /area/vault/podstation)
 "dU" = (
@@ -194,15 +260,10 @@
 /area/vault/podstation)
 "ev" = (
 /mob/living/simple_animal/hostile/bigroach,
-/obj/structure/mirror{
-	pixel_y = 33
-	},
-/obj/structure/sink{
-	pixel_y = 28
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on/layered{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor,
 /area/vault/podstation)
 "eH" = (
@@ -231,6 +292,12 @@
 	icon_state = "whiteblue"
 	},
 /area/vault/podstation)
+"eZ" = (
+/obj/structure/lattice,
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
+/area/vault/podstation)
 "fx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave{
@@ -247,6 +314,7 @@
 	external_pressure_bound = 101;
 	on = 1
 	},
+/obj/item/weapon/reagent_containers/pan,
 /obj/item/trash/egg,
 /turf/simulated/floor{
 	dir = 1;
@@ -266,6 +334,12 @@
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whiteblue"
+	},
+/area/vault/podstation)
+"gm" = (
+/obj/structure/hanging_lantern,
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
 	},
 /area/vault/podstation)
 "gp" = (
@@ -296,14 +370,24 @@
 /turf/simulated/floor,
 /area/vault/podstation)
 "gM" = (
+/obj/structure/closet{
+	anchored = 1
+	},
+/obj/item/stack/sheet/cardboard,
+/obj/item/stack/sheet/cardboard,
+/obj/item/weapon/storage/backpack/satchel_norm,
+/obj/item/weapon/storage/backpack/satchel_norm,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/media/receiver/boombox,
+/obj/item/stack/package_wrap,
+/obj/item/stack/package_wrap,
 /obj/effect/decal/cleanable/cobweb2,
-/obj/structure/closet,
-/obj/item/clothing/under/waiter,
-/obj/item/clothing/under/waiter,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/shoes/laceup,
-/obj/item/stack/sheet/cardboard,
-/obj/item/stack/sheet/cardboard,
+/obj/item/clothing/under/overalls,
+/obj/item/clothing/under/overalls,
+/obj/item/clothing/shoes/workboots,
+/obj/item/clothing/shoes/workboots,
+/obj/item/clothing/head/beanie/black,
+/obj/item/clothing/head/beanie/black,
 /turf/simulated/floor,
 /area/vault/podstation)
 "gS" = (
@@ -351,7 +435,7 @@
 	},
 /obj/item/weapon/reagent_containers/food/condiment/spacemilk,
 /obj/item/weapon/reagent_containers/food/condiment/spacemilk,
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "hw" = (
 /obj/item/weapon/reagent_containers/glass/bottle/insecticide,
@@ -363,14 +447,17 @@
 	icon_state = "bot"
 	},
 /obj/item/weapon/reagent_containers/glass/bottle/insecticide,
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "hD" = (
 /mob/living/simple_animal/cockroach,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/urinal{
-	dir = 4;
-	pixel_x = -30
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/mirror{
+	pixel_x = -26
 	},
 /turf/simulated/floor,
 /area/vault/podstation)
@@ -383,12 +470,12 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "hL" = (
 /obj/effect/decal/warning_stripes/pathmarkers,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "hQ" = (
 /obj/structure/closet/crate/freezer,
@@ -405,7 +492,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "if" = (
 /mob/living/simple_animal/hostile/bigroach,
@@ -420,11 +507,18 @@
 /turf/simulated/floor/carpet,
 /area/vault/podstation)
 "iv" = (
-/mob/living/simple_animal/cockroach,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/urinal{
 	dir = 4;
 	pixel_x = -30
+	},
+/obj/structure/mopbucket,
+/turf/simulated/floor,
+/area/vault/podstation)
+"iH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/vault/podstation)
@@ -468,9 +562,27 @@
 	icon_state = "whiteblue"
 	},
 /area/vault/podstation)
+"jU" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/unsimulated/floor/asteroid/underground/airless,
+/area/vault/podstation)
 "kb" = (
 /obj/machinery/floodlight/on/infinite,
 /turf/unsimulated/floor/asteroid,
+/area/vault/podstation)
+"kp" = (
+/obj/structure/rack,
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/obj/item/weapon/cell/high/empty,
+/obj/item/weapon/cell/high/empty,
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
 /area/vault/podstation)
 "kq" = (
 /mob/living/simple_animal/cockroach,
@@ -499,6 +611,12 @@
 	icon_state = "white"
 	},
 /area/vault/podstation)
+"kD" = (
+/obj/structure/hanging_lantern{
+	dir = 8
+	},
+/turf/unsimulated/floor/asteroid,
+/area/vault/podstation)
 "kQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
@@ -509,6 +627,17 @@
 	},
 /area/vault/podstation)
 "kS" = (
+/obj/machinery/door_control{
+	id_tag = "podstationregister";
+	name = "Register Shutters";
+	pixel_x = -25
+	},
+/obj/machinery/camera{
+	id_tag = "podstationcameras";
+	name = "Pod Station Register";
+	network = list("PODSTATION");
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "blue"
 	},
@@ -525,9 +654,14 @@
 /turf/simulated/floor,
 /area/vault/podstation)
 "lj" = (
-/obj/window_grille_spawner/reinforced,
 /obj/structure/window/barricade/full/block,
-/turf/simulated/floor,
+/obj/structure/grille,
+/obj/structure/window/full/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "podstationregister";
+	name = "Register Shutters"
+	},
+/turf/simulated/floor/plating,
 /area/vault/podstation)
 "lt" = (
 /obj/item/weapon/barricade_kit,
@@ -538,9 +672,15 @@
 	},
 /area/vault/podstation)
 "lu" = (
-/obj/item/trash/cigbutt/cigarbutt,
-/obj/effect/decal/cleanable/ash,
-/turf/unsimulated/floor/asteroid,
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/obj/structure/rack,
+/obj/item/device/crank_charger,
+/obj/item/device/crank_charger,
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
 /area/vault/podstation)
 "lz" = (
 /obj/structure/table/woodentable,
@@ -564,9 +704,14 @@
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/black,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/weapon/spacecash/c100,
-/obj/item/weapon/spacecash/c100,
 /obj/item/weapon/storage/belt/leather,
+/obj/item/clothing/shoes/laceup,
+/obj/item/ammo_storage/magazine/lr22,
+/obj/item/ammo_storage/magazine/lr22,
+/obj/item/weapon/gun/projectile/pistol/NT22,
+/obj/item/clothing/under/det/noir,
+/obj/item/clothing/head/soft/black,
+/obj/item/weapon/storage/backpack/satchel,
 /turf/simulated/floor/dark,
 /area/vault/podstation)
 "mj" = (
@@ -598,10 +743,11 @@
 "mO" = (
 /obj/item/weapon/reagent_containers/food/snacks/roach_eggs,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
-	dir = 9
-	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/soap,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/device/flashlight,
+/obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor,
 /area/vault/podstation)
 "mW" = (
@@ -647,9 +793,6 @@
 /area/vault/podstation)
 "oj" = (
 /obj/structure/table/reinforced,
-/obj/item/weapon/spacecash/c10,
-/obj/item/weapon/spacecash/c10,
-/obj/item/weapon/spacecash/c10,
 /obj/machinery/atmospherics/unary/vent_pump{
 	external_pressure_bound = 101;
 	on = 1
@@ -662,6 +805,7 @@
 	id_tag = "podstationregister";
 	name = "Register Shutters"
 	},
+/obj/machinery/cell_charger,
 /turf/simulated/floor,
 /area/vault/podstation)
 "ol" = (
@@ -692,6 +836,8 @@
 	id_tag = "podstationregister";
 	name = "Register Shutters"
 	},
+/obj/item/weapon/spacecash/c10,
+/obj/item/weapon/spacecash/c10,
 /turf/simulated/floor,
 /area/vault/podstation)
 "op" = (
@@ -703,18 +849,17 @@
 	id_tag = "podstationregister";
 	name = "Register Shutters"
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "blue"
-	},
+/turf/simulated/floor,
 /area/vault/podstation)
 "or" = (
 /obj/structure/signpost,
-/turf/unsimulated/floor/asteroid,
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
 /area/vault/podstation)
 "oZ" = (
 /obj/effect/decal/cleanable/blood/oil,
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "pn" = (
 /obj/structure/bed/chair{
@@ -835,6 +980,15 @@
 	icon_state = "asteroidfloor"
 	},
 /area/vault/podstation)
+"ru" = (
+/obj/structure/reagent_dispensers/silicate,
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
+/area/vault/podstation)
 "rx" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -851,6 +1005,9 @@
 "sb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/mayo_packet,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/vault/podstation)
 "sg" = (
@@ -864,7 +1021,13 @@
 /turf/simulated/wall,
 /area/vault/podstation)
 "sK" = (
-/obj/structure/mopbucket,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1;
+	external_pressure_bound = 101;
+	on = 1
+	},
+/mob/living/simple_animal/cockroach,
+/obj/machinery/light/small/broken,
 /turf/simulated/floor,
 /area/vault/podstation)
 "sN" = (
@@ -941,6 +1104,7 @@
 /turf/simulated/floor,
 /area/vault/podstation)
 "vM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	canSpawnMice = 0;
 	dir = 8;
@@ -953,7 +1117,6 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
 /turf/simulated/floor/engine{
 	name = "vacuum floor";
 	nitrogen = 0.01;
@@ -1067,6 +1230,16 @@
 "yU" = (
 /obj/item/trash/candy,
 /turf/unsimulated/floor/asteroid,
+/area/vault/podstation)
+"zr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/hanging_lantern{
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
 /area/vault/podstation)
 "zs" = (
 /mob/living/simple_animal/cockroach,
@@ -1236,14 +1409,14 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "DR" = (
 /obj/item/weapon/storage/toolbox/emergency,
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "Ee" = (
 /obj/machinery/light/small,
@@ -1257,6 +1430,7 @@
 /area/vault/podstation)
 "Eu" = (
 /obj/effect/decal/cleanable/greenglow,
+/obj/structure/hanging_lantern,
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
@@ -1294,6 +1468,12 @@
 	icon_state = "cafeteria"
 	},
 /area/vault/podstation)
+"FJ" = (
+/obj/machinery/light,
+/turf/simulated/floor{
+	icon_state = "freezerfloor"
+	},
+/area/vault/podstation)
 "FL" = (
 /obj/machinery/light/small/broken,
 /turf/space,
@@ -1325,8 +1505,14 @@
 /area/vault/podstation)
 "Gz" = (
 /obj/structure/rack,
-/obj/item/stack/sheet/metal/bigstack,
+/obj/item/weapon/storage/belt/utility/full,
 /obj/item/tool/solder,
+/obj/item/tool/solder,
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/obj/item/weapon/reagent_containers/glass/bottle/sacid,
+/obj/item/weapon/reagent_containers/glass/bottle/sacid,
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
@@ -1337,24 +1523,21 @@
 /area/vault/podstation)
 "Hg" = (
 /obj/structure/rack,
-/obj/item/stack/sheet/glass/glass/bigstack,
+/obj/item/stack/sheet/glass/glass/bigstack{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/obj/item/stack/sheet/metal/bigstack{
+	pixel_x = 1;
+	pixel_y = 1
+	},
 /obj/item/device/spacepod_equipment/locking/lock,
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
-"HH" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/soap,
-/obj/machinery/light/small/broken,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1;
-	external_pressure_bound = 101;
-	on = 1
-	},
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/device/flashlight,
-/turf/simulated/floor,
 /area/vault/podstation)
 "HJ" = (
 /obj/structure/fence/corner{
@@ -1368,6 +1551,14 @@
 	icon_state = "asteroidfloor"
 	},
 /area/vault/podstation)
+"HW" = (
+/obj/effect/decal/cleanable/ash,
+/obj/item/trash/cigbutt/cigarbutt,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "asteroidwarning"
+	},
+/area/vault/podstation)
 "If" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1375,8 +1566,23 @@
 /turf/space,
 /area/vault/podstation)
 "IC" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/unary/portables_connector,
+/obj/structure/rack,
+/obj/item/clothing/head/tinfoil,
+/obj/item/pod_parts/core,
+/obj/item/weapon/circuitboard/mecha/pod,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/device/multitool,
+/obj/item/clothing/suit/space/ghettorig,
+/obj/item/clothing/suit/space/ghettorig,
+/obj/item/clothing/head/helmet/space/ghetto,
+/obj/item/clothing/head/helmet/space/ghetto,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/weapon/storage/belt/utility/full,
+/obj/item/weapon/storage/belt/utility/full,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plating,
 /area/vault/podstation)
 "IJ" = (
@@ -1433,13 +1639,36 @@
 /obj/item/weapon/reagent_containers/food/snacks/fries/cone,
 /obj/effect/decal/cleanable/cobweb2,
 /obj/item/weapon/reagent_containers/food/snacks/fries/cone,
+/obj/item/weapon/chipbasket,
+/obj/item/weapon/chipbasket,
+/obj/item/weapon/chipbasket,
+/obj/item/weapon/chipbasket,
+/obj/item/weapon/reagent_containers/food/snacks/potatosalad,
+/obj/item/weapon/reagent_containers/food/snacks/potatosalad,
+/obj/item/weapon/reagent_containers/food/snacks/loadedbakedpotato,
+/obj/item/weapon/reagent_containers/food/snacks/loadedbakedpotato,
+/obj/item/weapon/reagent_containers/food/snacks/loadedbakedpotato,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
 /area/vault/podstation)
 "KC" = (
 /obj/effect/decal/warning_stripes/pathmarkers,
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
+/area/vault/podstation)
+"Li" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/unsimulated/floor/airless{
+	dir = 4;
+	icon_state = "asteroidwarning"
+	},
+/area/vault/podstation)
+"Lv" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/obj/item/device/silicate_sprayer,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "LD" = (
 /obj/structure/table,
@@ -1496,7 +1725,7 @@
 	icon_state = "bot"
 	},
 /obj/machinery/cryopod,
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "Nl" = (
 /obj/structure/catwalk,
@@ -1508,14 +1737,6 @@
 "Np" = (
 /obj/structure/fence,
 /turf/unsimulated/floor/asteroid,
-/area/vault/podstation)
-"NA" = (
-/obj/structure/hanging_lantern{
-	dir = 1
-	},
-/turf/unsimulated/floor/airless{
-	icon_state = "asteroidfloor"
-	},
 /area/vault/podstation)
 "NF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1533,47 +1754,130 @@
 /obj/item/weapon/storage/fancy/cigarettes/shoalsticks,
 /obj/item/trash/zam_notraisins,
 /obj/item/weapon/newspaper,
+/obj/item/weapon/storage/fancy/cigarettes/ntstandard,
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
 /area/vault/podstation)
 "Ov" = (
-/obj/structure/rack,
+/obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/item/clothing/head/tinfoil,
-/obj/item/pod_parts/core,
-/obj/item/weapon/circuitboard/mecha/pod,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/device/multitool,
-/obj/item/clothing/suit/space/ghettorig,
-/obj/item/clothing/suit/space/ghettorig,
-/obj/item/clothing/head/helmet/space/ghetto,
-/obj/item/clothing/head/helmet/space/ghetto,
-/obj/item/weapon/storage/toolbox/electrical,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
 /area/vault/podstation)
 "OX" = (
 /obj/structure/spacepod_frame,
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "Qp" = (
-/obj/structure/table,
-/obj/item/weapon/tray,
-/obj/item/weapon/storage/box/condimentbottles,
-/obj/machinery/light/broken{
-	dir = 1
+/obj/structure/rack,
+/obj/item/weapon/storage/fancy/cigarettes/spaceports{
+	pixel_x = -2;
+	pixel_y = 2
 	},
-/obj/machinery/door_control{
-	id_tag = "podstationregister";
-	name = "Register Shutters";
-	pixel_y = 25
+/obj/item/weapon/storage/fancy/cigarettes/spaceports{
+	pixel_x = -2;
+	pixel_y = 2
 	},
-/turf/simulated/floor,
+/obj/item/weapon/storage/fancy/cigarettes/spaceports{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/fancy/cigarettes/spaceports{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/fancy/cigarettes/starlights,
+/obj/item/weapon/storage/fancy/cigarettes/starlights,
+/obj/item/weapon/storage/fancy/cigarettes/starlights,
+/obj/item/weapon/storage/fancy/cigarettes/starlights,
+/obj/item/weapon/storage/fancy/cigarettes/shoalsticks{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/weapon/storage/fancy/cigarettes/shoalsticks{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/weapon/storage/fancy/cigarettes/shoalsticks{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/weapon/storage/fancy/cigarettes/shoalsticks{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/weapon/storage/fancy/cigarettes/dromedaryco{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/weapon/storage/fancy/cigarettes/dromedaryco{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/weapon/storage/fancy/cigarettes/dromedaryco{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/weapon/storage/fancy/cigarettes/dromedaryco{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window{
+	dir = 2
+	},
+/obj/item/weapon/storage/fancy/cigarettes/luckystrike{
+	pixel_x = 7;
+	pixel_y = -7
+	},
+/obj/item/weapon/storage/fancy/cigarettes/luckystrike{
+	pixel_x = 7;
+	pixel_y = -7
+	},
+/obj/item/weapon/storage/fancy/cigarettes/luckystrike{
+	pixel_x = 7;
+	pixel_y = -7
+	},
+/obj/item/weapon/storage/fancy/cigarettes/luckystrike{
+	pixel_x = 7;
+	pixel_y = -7
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "unloading"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/vault/podstation)
+"Qx" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/reagent_containers/food/condiment/ketchup,
+/obj/item/weapon/reagent_containers/food/condiment/vinegar,
+/obj/item/weapon/reagent_containers/food/condiment/small/mayo,
+/obj/item/weapon/reagent_containers/food/condiment/small/mayo,
+/obj/item/weapon/reagent_containers/food/condiment/small/vinegar,
+/obj/item/weapon/reagent_containers/food/condiment/small/ketchup,
+/obj/item/weapon/reagent_containers/food/condiment/small/ketchup,
+/obj/item/weapon/reagent_containers/food/condiment/small/ketchup,
+/obj/item/weapon/reagent_containers/food/condiment/flour,
+/obj/item/weapon/reagent_containers/food/condiment/flour,
+/obj/item/weapon/reagent_containers/food/condiment/hotsauce,
+/obj/item/weapon/reagent_containers/food/condiment/relish,
+/obj/item/weapon/storage/fancy/egg_box/empty,
+/obj/item/weapon/reagent_containers/food/condiment/spacemilk,
+/obj/item/weapon/reagent_containers/food/dipping_sauce/queso,
+/obj/item/weapon/reagent_containers/food/dipping_sauce/queso,
+/obj/item/weapon/reagent_containers/food/dipping_sauce/guacamole,
+/obj/item/weapon/reagent_containers/food/dipping_sauce/salsa,
+/turf/simulated/floor{
+	icon_state = "freezerfloor"
+	},
 /area/vault/podstation)
 "QK" = (
 /obj/structure/catwalk{
@@ -1587,14 +1891,13 @@
 /turf/space,
 /area/vault/podstation)
 "RG" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/blood/oil{
 	icon_state = "floor6"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /turf/simulated/floor/plating,
@@ -1645,6 +1948,22 @@
 	},
 /obj/item/weapon/reagent_containers/food/snacks/meatpizzaslice,
 /obj/item/weapon/reagent_containers/food/snacks/chicken_nuggets,
+/obj/item/weapon/reagent_containers/food/snacks/fishtacosupreme,
+/obj/item/weapon/reagent_containers/food/snacks/fishtacosupreme,
+/obj/item/weapon/reagent_containers/food/snacks/chiliconcarne,
+/obj/item/weapon/reagent_containers/food/snacks/chiliconcarne,
+/obj/item/weapon/reagent_containers/food/snacks/chiliconcarne,
+/obj/item/weapon/reagent_containers/food/snacks/threebeanburrito,
+/obj/item/weapon/reagent_containers/food/snacks/threebeanburrito,
+/obj/item/weapon/reagent_containers/food/snacks/fishfingers,
+/obj/item/weapon/reagent_containers/food/snacks/fishfingers,
+/obj/item/weapon/reagent_containers/food/snacks/grilledcheese,
+/obj/item/weapon/reagent_containers/food/snacks/grilledcheese,
+/obj/item/weapon/reagent_containers/food/snacks/corndog,
+/obj/item/weapon/reagent_containers/food/snacks/corndog,
+/obj/item/weapon/reagent_containers/food/snacks/bagel,
+/obj/item/weapon/reagent_containers/food/snacks/bagel,
+/obj/item/weapon/reagent_containers/food/snacks/bagel,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -1653,7 +1972,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "Sn" = (
 /obj/structure/bed/chair{
@@ -1665,8 +1984,13 @@
 	},
 /area/vault/podstation)
 "SS" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/unsimulated/floor/asteroid,
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/obj/structure/dispenser/oxygen,
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
 /area/vault/podstation)
 "Ti" = (
 /obj/structure/bed/chair{
@@ -1682,7 +2006,7 @@
 "Ts" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "TC" = (
 /obj/structure/catwalk{
@@ -1699,7 +2023,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "TV" = (
 /turf/unsimulated/floor/airless{
@@ -1712,7 +2036,26 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
+/area/vault/podstation)
+"UN" = (
+/obj/structure/window/barricade/full/block,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "podstationregister";
+	name = "Register Shutters"
+	},
+/obj/structure/grille,
+/obj/structure/window/full/reinforced,
+/turf/simulated/floor/plating,
+/area/vault/podstation)
+"Vb" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/unsimulated/floor/airless{
+	icon_state = "asteroidfloor"
+	},
 /area/vault/podstation)
 "VJ" = (
 /obj/structure/fence/corner{
@@ -1784,25 +2127,107 @@
 /obj/item/trash/ketchup_packet,
 /obj/item/trash/vinegar_packet,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/hanging_lantern{
+	dir = 4
+	},
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
 /area/vault/podstation)
 "Xi" = (
-/obj/structure/table,
-/obj/item/stack/package_wrap,
-/obj/item/stack/package_wrap,
-/obj/item/weapon/reagent_containers/food/snacks/roach_eggs,
-/obj/item/weapon/lighter/zippo,
-/obj/machinery/media/receiver/boombox,
-/obj/machinery/camera{
-	id_tag = "podstationcameras";
-	name = "Pod Station Register";
-	network = list("PODSTATION")
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor,
+/obj/machinery/door/window{
+	dir = 2
+	},
+/obj/item/weapon/storage/fancy/matchbox{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/fancy/matchbox{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/fancy/matchbox{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/fancy/matchbox{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/weapon/lighter/zippo{
+	pixel_x = 1
+	},
+/obj/item/weapon/lighter/zippo{
+	pixel_x = 1
+	},
+/obj/item/weapon/lighter/red{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/weapon/lighter/red{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/weapon/lighter/red{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/weapon/lighter/red{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/weapon/lighter/green{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/weapon/lighter/green{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/weapon/lighter/green{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/weapon/lighter/green{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "unloading"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blue"
+	},
 /area/vault/podstation)
 "Xr" = (
+/turf/simulated/floor{
+	icon_state = "freezerfloor"
+	},
+/area/vault/podstation)
+"XB" = (
+/obj/item/weapon/reagent_containers/food/snacks/sundae,
+/obj/item/weapon/reagent_containers/food/snacks/sundae,
+/obj/item/weapon/reagent_containers/food/snacks/sundae,
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
+/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
+/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
+/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
+/obj/item/weapon/reagent_containers/food/snacks/candiedapple,
+/obj/item/weapon/reagent_containers/food/snacks/candiedapple,
+/obj/item/weapon/reagent_containers/food/snacks/cinnamonroll,
+/obj/item/weapon/reagent_containers/food/snacks/cinnamonroll,
+/obj/item/weapon/reagent_containers/food/snacks/chococherrycakeslice,
+/obj/item/weapon/reagent_containers/food/snacks/chococherrycakeslice,
+/obj/item/weapon/reagent_containers/food/snacks/chococherrycakeslice,
+/obj/item/weapon/reagent_containers/food/snacks/muffin/berry,
+/obj/item/weapon/reagent_containers/food/snacks/muffin/berry,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -1821,7 +2246,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/rack,
 /obj/item/device/crank_charger,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
@@ -1829,7 +2253,6 @@
 	},
 /obj/item/pod_parts/armor/civ,
 /obj/item/pod_parts/armor/civ,
-/obj/item/weapon/storage/box/lights/mixed,
 /obj/item/weapon/circuitboard/mecha/pod,
 /obj/item/weapon/cell/high/empty,
 /obj/item/device/pod_key,
@@ -1837,6 +2260,14 @@
 /obj/item/weapon/tank/oxygen/red,
 /obj/item/weapon/cell/high/empty,
 /obj/item/inflatable/shelter,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 20
+	},
 /turf/simulated/floor/plating,
 /area/vault/podstation)
 "Yx" = (
@@ -1860,27 +2291,38 @@
 	dir = 9
 	},
 /obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/vault/podstation)
 "YT" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "Zo" = (
-/obj/item/weapon/reagent_containers/food/snacks/sundae,
-/obj/item/weapon/reagent_containers/food/snacks/sundae,
-/obj/item/weapon/reagent_containers/food/snacks/sundae,
-/obj/structure/closet/crate/freezer,
-/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
-/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
-/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
-/obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich,
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window{
+	base_state = "right";
+	icon_state = "right"
+	},
+/obj/item/weapon/storage/fancy/beer_box,
+/obj/item/weapon/storage/fancy/beer_box,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/schnapps,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/schnapps,
+/obj/effect/decal/warning_stripes{
+	icon_state = "unloading"
+	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
 /area/vault/podstation)
 "Zy" = (
-/turf/unsimulated/floor/asteroid/underground,
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "ZI" = (
 /turf/unsimulated/floor/airless{
@@ -2017,14 +2459,14 @@ Yx
 gS
 aM
 Yx
-Yx
+Fe
 Yx
 ES
 ES
 ES
 En
 Kk
-NA
+Yx
 VW
 Np
 rx
@@ -2073,8 +2515,8 @@ NF
 VY
 wh
 dU
+eZ
 VS
-pU
 pU
 pU
 pU
@@ -2112,14 +2554,14 @@ IJ
 uy
 aM
 Yx
-Fe
+Yx
 Kk
 NS
 WT
 ba
 rh
 Yx
-pU
+VS
 pU
 pU
 pU
@@ -2163,8 +2605,8 @@ Kk
 XS
 Kk
 Kk
-wi
-pU
+Yx
+VS
 pU
 pU
 pU
@@ -2208,8 +2650,8 @@ Ov
 Yt
 vM
 af
+wi
 Yx
-pU
 pU
 pU
 pU
@@ -2238,7 +2680,7 @@ pU
 pU
 ES
 ES
-VX
+Yx
 Kk
 eS
 jn
@@ -2255,7 +2697,7 @@ ol
 bB
 QW
 Nl
-pU
+VS
 pU
 pU
 pU
@@ -2298,9 +2740,9 @@ RO
 Kk
 Kk
 Kk
-aM
+Kk
+zr
 VS
-pU
 pU
 pU
 pU
@@ -2342,10 +2784,10 @@ JY
 RX
 Zo
 ai
+cJ
 Kk
 Yx
 ES
-pU
 pU
 pU
 pU
@@ -2386,11 +2828,11 @@ Kk
 Kg
 yE
 Xr
-cJ
+Xr
+FJ
 Kk
 Yx
 ES
-pU
 pU
 pU
 pU
@@ -2418,7 +2860,7 @@ pU
 pU
 VS
 ES
-Yx
+gm
 GO
 gB
 cq
@@ -2430,12 +2872,12 @@ BN
 Kk
 Kv
 Sc
-Xr
+XB
+Qx
 Wu
 Kk
 Yx
 ES
-pU
 pU
 pU
 pU
@@ -2463,7 +2905,7 @@ pU
 pU
 VS
 ES
-Yx
+VX
 Kk
 gC
 Kk
@@ -2480,7 +2922,7 @@ Kk
 Kk
 Kk
 Yx
-pU
+ES
 pU
 pU
 pU
@@ -2510,7 +2952,7 @@ VS
 ES
 Yx
 Kk
-CD
+iH
 kS
 nY
 qT
@@ -2525,7 +2967,7 @@ hD
 iv
 Kk
 aM
-pU
+ES
 pU
 pU
 pU
@@ -2556,7 +2998,7 @@ ES
 Yx
 Kk
 Qp
-kS
+df
 oj
 qY
 wB
@@ -2565,12 +3007,12 @@ Cd
 FQ
 LL
 FQ
-Kk
+vG
 ev
 sK
 Kk
 Yx
-pU
+ES
 pU
 pU
 pU
@@ -2610,12 +3052,12 @@ Cf
 FZ
 Mb
 pn
-vG
+Kk
 mO
-HH
+CD
 Kk
 Yx
-pU
+ES
 pU
 pU
 pU
@@ -2656,11 +3098,11 @@ FF
 Mx
 Ti
 Kk
+Kk
 px
 Kk
-Kk
 Yx
-pU
+ES
 pU
 pU
 pU
@@ -2691,7 +3133,7 @@ ES
 Yx
 Kk
 Kk
-lj
+UN
 Kk
 Kk
 xq
@@ -2700,12 +3142,12 @@ Kk
 lj
 lj
 lj
+Kk
 Kk
 ZP
 Kk
-Kk
-Yx
-pU
+aM
+ES
 pU
 pU
 pU
@@ -2745,12 +3187,12 @@ Kk
 Yx
 Yx
 Yx
+aM
 Kk
 Kk
 Kk
 aM
 VS
-pU
 pU
 pU
 pU
@@ -2790,10 +3232,10 @@ sF
 Yx
 ES
 ES
+ES
+ES
+kD
 AH
-ES
-ES
-ES
 ES
 pU
 pU
@@ -2837,7 +3279,7 @@ TV
 TV
 TV
 TV
-TV
+Li
 TV
 TV
 QK
@@ -3141,14 +3583,14 @@ ES
 ES
 ES
 ES
-ES
+kp
 or
 ZI
 Zy
 YT
 Db
 Gz
-ES
+ru
 TM
 ES
 kb
@@ -3193,7 +3635,7 @@ Zy
 Zy
 Db
 Hg
-ES
+Vb
 ES
 ES
 ES
@@ -3232,7 +3674,7 @@ bq
 fJ
 fJ
 fJ
-fJ
+HW
 tc
 Zy
 Zy
@@ -3281,7 +3723,7 @@ Zy
 Si
 YT
 Zy
-Si
+Lv
 Zy
 Zy
 TO
@@ -3458,7 +3900,7 @@ Zy
 hs
 Zy
 Zy
-Si
+jU
 Zy
 Zy
 DR

--- a/maps/randomvaults/podstation.dmm
+++ b/maps/randomvaults/podstation.dmm
@@ -714,13 +714,6 @@
 /obj/item/weapon/storage/backpack/satchel,
 /turf/simulated/floor/dark,
 /area/vault/podstation)
-"mh" = (
-/obj/effect/decal/warning_stripes{
-	icon_state = "bot"
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
 "mj" = (
 /obj/machinery/processor,
 /obj/item/trash/fries_cone,
@@ -1607,11 +1600,6 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "air"
 	},
-/obj/machinery/door_control{
-	pixel_y = 25;
-	name = "Gas Miner Control";
-	id_tag = "podstation_air"
-	},
 /turf/simulated/floor/plating,
 /area/vault/podstation)
 "IZ" = (
@@ -1752,6 +1740,12 @@
 "Np" = (
 /obj/structure/fence,
 /turf/unsimulated/floor/asteroid,
+/area/vault/podstation)
+"NA" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "NF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1988,6 +1982,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation)
 "Sn" = (
@@ -3736,7 +3731,7 @@ Zy
 hw
 Zy
 Zy
-Si
+NA
 YT
 Zy
 Lv
@@ -3784,7 +3779,7 @@ oZ
 cd
 Zy
 Zy
-Si
+NA
 Zy
 Zy
 Uk
@@ -3871,7 +3866,7 @@ bX
 hQ
 YT
 Zy
-mh
+Si
 Zy
 Zy
 Dz
@@ -3922,7 +3917,7 @@ Zy
 DR
 YT
 Zy
-Si
+NA
 aO
 Zy
 Db

--- a/maps/randomvaults/podstation.dmm
+++ b/maps/randomvaults/podstation.dmm
@@ -5,7 +5,7 @@
 	tag = ""
 	},
 /turf/simulated/wall,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "ai" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced{
@@ -73,57 +73,57 @@
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "aI" = (
 /obj/structure/catwalk,
 /turf/space,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "aM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "aN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "aO" = (
 /obj/effect/decal/cleanable/blood/oil{
 	icon_state = "floor2"
 	},
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "aW" = (
 /obj/machinery/floodlight/on/infinite,
 /turf/unsimulated/floor/airless{
 	dir = 8;
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "ba" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/port_gen/pacman,
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "bq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "bB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
 	dir = 10;
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/wall,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "bE" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/paper_bin/black,
@@ -140,7 +140,7 @@
 	pixel_x = -25
 	},
 /turf/simulated/floor/dark,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "bJ" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp,
@@ -160,7 +160,7 @@
 /obj/item/weapon/spacecash/c100,
 /obj/item/weapon/spacecash/c100,
 /turf/simulated/floor/dark,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "bP" = (
 /obj/structure/window/barricade/full/block,
 /obj/structure/grille,
@@ -171,20 +171,20 @@
 	dir = 2
 	},
 /turf/simulated/floor/plating,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "bX" = (
 /obj/structure/spacepod_frame/unarmored{
 	dir = 1
 	},
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "cd" = (
 /obj/item/weapon/tank/oxygen/red,
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "cq" = (
 /mob/living/simple_animal/cockroach,
 /obj/effect/decal/cleanable/flour,
@@ -192,14 +192,17 @@
 	dir = 4;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "cx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/floor/airless{
 	dir = 8;
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
+"cE" = (
+/turf/simulated/wall,
+/area/vault/podstation/exterior)
 "cJ" = (
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/dr_gibb,
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/dr_gibb,
@@ -223,20 +226,20 @@
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "cK" = (
 /obj/machinery/light/small{
 	dir = 1;
 	invisibility = 1
 	},
 /turf/space,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "df" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	icon_state = "blue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "dp" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
@@ -246,18 +249,18 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "dK" = (
 /obj/structure/bed/chair/office,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
 /obj/item/weapon/reagent_containers/food/snacks/roach_eggs,
 /turf/simulated/floor/carpet,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "dU" = (
 /obj/structure/fence/door,
 /turf/unsimulated/floor/asteroid,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "ev" = (
 /mob/living/simple_animal/hostile/bigroach,
 /obj/machinery/atmospherics/unary/vent_scrubber/on/layered{
@@ -265,7 +268,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "eH" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/bigroach/queen,
@@ -277,27 +280,27 @@
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "eS" = (
 /obj/machinery/chem_master/condimaster,
 /obj/effect/decal/cleanable/cobweb,
-/obj/machinery/light/broken{
-	dir = 1
-	},
 /obj/machinery/alarm{
 	pixel_y = 24
+	},
+/obj/machinery/light/broken{
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "eZ" = (
 /obj/structure/lattice,
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "fx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave{
@@ -307,7 +310,7 @@
 	dir = 1;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "fI" = (
 /obj/machinery/cooking/grill,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -320,13 +323,13 @@
 	dir = 1;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "fJ" = (
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "fZ" = (
 /obj/machinery/cooking/grill,
 /obj/item/weapon/reagent_containers/food/snacks/roach_eggs,
@@ -335,13 +338,13 @@
 	dir = 1;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "gm" = (
 /obj/structure/hanging_lantern,
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "gp" = (
 /mob/living/simple_animal/cockroach,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -354,13 +357,13 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "gB" = (
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "gC" = (
 /obj/structure/window/barricade/full,
 /obj/effect/decal/cleanable/dirt,
@@ -368,7 +371,7 @@
 	icon_state = "unloading"
 	},
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "gM" = (
 /obj/structure/closet{
 	anchored = 1
@@ -389,7 +392,7 @@
 /obj/item/clothing/head/beanie/black,
 /obj/item/clothing/head/beanie/black,
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "gS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
@@ -401,7 +404,7 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "hd" = (
 /obj/item/trash/lollipopstick,
 /obj/effect/decal/cleanable/dirt,
@@ -414,7 +417,7 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "hs" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/weapon/reagent_containers/food/snacks/meat,
@@ -436,7 +439,7 @@
 /obj/item/weapon/reagent_containers/food/condiment/spacemilk,
 /obj/item/weapon/reagent_containers/food/condiment/spacemilk,
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "hw" = (
 /obj/item/weapon/reagent_containers/glass/bottle/insecticide,
 /obj/structure/closet/crate,
@@ -448,7 +451,7 @@
 	},
 /obj/item/weapon/reagent_containers/glass/bottle/insecticide,
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "hD" = (
 /mob/living/simple_animal/cockroach,
 /obj/structure/sink{
@@ -460,7 +463,7 @@
 	pixel_x = -26
 	},
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "hE" = (
 /obj/structure/closet/crate,
 /obj/item/weapon/reagent_containers/spray/cleaner,
@@ -471,12 +474,12 @@
 	icon_state = "bot"
 	},
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "hL" = (
 /obj/effect/decal/warning_stripes/pathmarkers,
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "hQ" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/weapon/reagent_containers/food/snacks/grown/potato,
@@ -493,7 +496,7 @@
 	icon_state = "bot"
 	},
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "if" = (
 /mob/living/simple_animal/hostile/bigroach,
 /obj/effect/decal/cleanable/dirt,
@@ -505,7 +508,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/carpet,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "iv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/urinal{
@@ -513,15 +516,16 @@
 	pixel_x = -30
 	},
 /obj/structure/mopbucket,
+/obj/item/weapon/mop,
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "iH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "iS" = (
 /mob/living/simple_animal/hostile/bigroach,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -532,7 +536,7 @@
 	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/carpet,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "jd" = (
 /obj/machinery/door/airlock/highsecurity{
 	id_tag = "PodStationOffice";
@@ -547,7 +551,7 @@
 	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/dark,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "jn" = (
 /obj/effect/decal/cleanable/cockroach_remains,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -561,18 +565,18 @@
 	dir = 8;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "jU" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "kb" = (
 /obj/machinery/floodlight/on/infinite,
 /turf/unsimulated/floor/asteroid,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "kp" = (
 /obj/structure/rack,
 /obj/effect/decal/warning_stripes{
@@ -583,7 +587,7 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "kq" = (
 /mob/living/simple_animal/cockroach,
 /obj/effect/decal/cleanable/dirt,
@@ -597,7 +601,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "kC" = (
 /mob/living/simple_animal/cockroach,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -610,13 +614,13 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "kD" = (
 /obj/structure/hanging_lantern{
 	dir = 8
 	},
 /turf/unsimulated/floor/asteroid,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "kQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered{
@@ -625,7 +629,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "kS" = (
 /obj/machinery/door_control{
 	id_tag = "podstationregister";
@@ -641,18 +645,18 @@
 /turf/simulated/floor{
 	icon_state = "blue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "kU" = (
 /mob/living/simple_animal/hostile/bigroach,
 /turf/simulated/floor{
 	icon_state = "blue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "kW" = (
 /obj/effect/decal/cleanable/cockroach_remains,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "lj" = (
 /obj/structure/window/barricade/full/block,
 /obj/structure/grille,
@@ -662,7 +666,7 @@
 	name = "Register Shutters"
 	},
 /turf/simulated/floor/plating,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "lt" = (
 /obj/item/weapon/barricade_kit,
 /obj/effect/decal/cleanable/dirt,
@@ -670,7 +674,7 @@
 	dir = 4;
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "lu" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
@@ -681,7 +685,7 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "lz" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light/small/broken{
@@ -698,7 +702,7 @@
 	network = list("PODSTATION")
 	},
 /turf/simulated/floor/dark,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "lR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
@@ -713,7 +717,7 @@
 /obj/item/clothing/head/soft/black,
 /obj/item/weapon/storage/backpack/satchel,
 /turf/simulated/floor/dark,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "mj" = (
 /obj/machinery/processor,
 /obj/item/trash/fries_cone,
@@ -721,13 +725,13 @@
 	dir = 8;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "mK" = (
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
 /turf/space,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "mM" = (
 /obj/structure/table,
 /obj/item/weapon/kitchen/rollingpin,
@@ -739,7 +743,7 @@
 	dir = 9;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "mO" = (
 /obj/item/weapon/reagent_containers/food/snacks/roach_eggs,
 /obj/effect/decal/cleanable/dirt,
@@ -749,7 +753,7 @@
 /obj/item/device/flashlight,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "mW" = (
 /obj/structure/table,
 /obj/item/trash/waffles,
@@ -759,7 +763,7 @@
 	dir = 5;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "nO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
@@ -776,7 +780,7 @@
 	dir = 4;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "nY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/pos{
@@ -790,7 +794,7 @@
 	name = "Register Shutters"
 	},
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "oj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -806,8 +810,18 @@
 	name = "Register Shutters"
 	},
 /obj/machinery/cell_charger,
+/obj/item/weapon/paper{
+	info = "I'm done with the slack, so here it is. Neither of you are getting another paycheck until the following are finished:<BR><BR> 1. Get rid of the roach problem. I ordered you a shipment of insecticide, get it done already.<BR> 2. Clean up the floors. The mop's in the restroom.<BR> 3. Take out any trash left after the roaches are gone and the floor is clean. <BR> 4. Take the new shipment of meat in and cook up some fresh burgers. Check if any in the freezer are going stale, and toss them if they are.<BR> 5. Clean up my office. Don't touch any of my shit.<BR> 6. Finish fixing up the pods in our lot.<BR><BR> If all of that isn't done by the time I get back from vacation, you're both fired. Get it done. <i>Big Boss</i>";
+	name = "note from the boss";
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/weapon/paper{
+	name = "note from an employee";
+	info = "Hi boss, you haven't seen these roaches. You have no idea how bad it is in the station these days. After they got into that barrel of Dan's Sauce last week they've been getting bigger and nastier. One nearly took Rick's hand off the last time we came in to work. So fuck you and fuck your to-do list. Find two new schmucks who'll wipe your ass for minimum wage. We quit."
+	},
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "ol" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "unloading"
@@ -824,7 +838,7 @@
 	nitrogen = 0.01;
 	oxygen = 0.01
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "on" = (
 /obj/structure/table/reinforced,
 /obj/machinery/pos{
@@ -842,7 +856,7 @@
 /obj/item/weapon/spacecash/c10,
 /obj/item/weapon/spacecash/c10,
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "op" = (
 /obj/machinery/door/window{
 	dir = 2
@@ -853,17 +867,17 @@
 	name = "Register Shutters"
 	},
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "or" = (
 /obj/structure/signpost,
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "oZ" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "pn" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -878,14 +892,14 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "px" = (
 /obj/structure/window/barricade/full/block,
 /obj/machinery/door/airlock{
 	name = "Toilet"
 	},
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "pU" = (
 /turf/space,
 /area)
@@ -903,14 +917,14 @@
 	dir = 10;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "qj" = (
 /mob/living/simple_animal/hostile/bigroach,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitebluecorner"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "qr" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/condiment/ketchup{
@@ -927,7 +941,7 @@
 	dir = 10;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "qs" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/glass/beaker{
@@ -942,7 +956,7 @@
 	dir = 6;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "qL" = (
 /obj/effect/decal/cleanable/cockroach_remains,
 /obj/machinery/door_control{
@@ -957,7 +971,7 @@
 	dir = 4;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "qT" = (
 /obj/effect/decal/cleanable/cockroach_remains,
 /obj/effect/decal/cleanable/dirt,
@@ -965,7 +979,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "qY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
@@ -973,7 +987,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "rh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fence{
@@ -982,7 +996,7 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "ru" = (
 /obj/structure/reagent_dispensers/silicate,
 /obj/effect/decal/warning_stripes{
@@ -991,20 +1005,20 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "rx" = (
 /obj/structure/fence/corner{
 	dir = 1
 	},
 /turf/unsimulated/floor/asteroid,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "rF" = (
 /mob/living/simple_animal/cockroach,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "sb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/mayo_packet,
@@ -1012,17 +1026,17 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "sg" = (
 /obj/structure/catwalk{
 	icon_state = "catwalk1"
 	},
 /turf/simulated/wall,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "sF" = (
 /obj/structure/sign/nosmoking_2,
 /turf/simulated/wall,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "sK" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -1032,7 +1046,7 @@
 /mob/living/simple_animal/cockroach,
 /obj/machinery/light/small/broken,
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "sN" = (
 /obj/structure/hanging_lantern{
 	dir = 8
@@ -1041,19 +1055,19 @@
 	dir = 4;
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "sX" = (
 /turf/unsimulated/floor/airless{
 	dir = 10;
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "tc" = (
 /turf/unsimulated/floor/airless{
 	dir = 6;
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "ui" = (
 /obj/structure/bed/chair,
 /obj/item/trash/cigbutt,
@@ -1061,18 +1075,18 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "uy" = (
 /obj/structure/bed/chair,
 /obj/item/weapon/storage/fancy/cigarettes/spaceports,
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "uF" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "uJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
@@ -1082,7 +1096,7 @@
 	dir = 8;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "uR" = (
 /mob/living/simple_animal/cockroach,
 /obj/effect/decal/cleanable/flour,
@@ -1095,7 +1109,7 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "vG" = (
 /obj/structure/window/barricade/full/block,
 /obj/machinery/door/airlock{
@@ -1105,7 +1119,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "vM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -1125,7 +1139,7 @@
 	nitrogen = 0.01;
 	oxygen = 0.01
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "vW" = (
 /mob/living/simple_animal/hostile/bigroach,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1139,7 +1153,7 @@
 	dir = 4;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "we" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -1156,12 +1170,12 @@
 /turf/simulated/floor{
 	icon_state = "bluefull"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "wh" = (
 /obj/item/trash/tray,
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/floor/asteroid,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "wi" = (
 /obj/machinery/camera{
 	id_tag = "podstationcameras";
@@ -1171,7 +1185,7 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "wu" = (
 /obj/item/trash/plate,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1184,7 +1198,7 @@
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "wB" = (
 /obj/item/weapon/reagent_containers/food/snacks/roach_eggs,
 /obj/effect/decal/cleanable/dirt,
@@ -1197,17 +1211,17 @@
 	},
 /obj/item/trash/sosjerky,
 /turf/simulated/floor/damaged,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "xb" = (
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "xk" = (
 /obj/item/trash/candy,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "xq" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "podstationclosing";
@@ -1215,11 +1229,11 @@
 	},
 /obj/structure/window/barricade/full/block,
 /turf/simulated/floor/plating,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "xt" = (
 /obj/structure/closet/walllocker/emerglocker/north,
 /turf/simulated/floor/plating,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "yE" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
@@ -1229,11 +1243,11 @@
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "yU" = (
 /obj/item/trash/candy,
 /turf/unsimulated/floor/asteroid,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "zr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/hanging_lantern{
@@ -1243,7 +1257,7 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "zs" = (
 /mob/living/simple_animal/cockroach,
 /obj/effect/decal/cleanable/egg_smudge{
@@ -1253,7 +1267,7 @@
 	dir = 8;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "zu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
@@ -1262,13 +1276,13 @@
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "zz" = (
 /mob/living/simple_animal/hostile/bigroach,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "zB" = (
 /obj/item/weapon/reagent_containers/food/snacks/roach_eggs,
 /obj/effect/decal/cleanable/dirt,
@@ -1276,26 +1290,26 @@
 	dir = 4;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "zL" = (
 /mob/living/simple_animal/cockroach,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "zU" = (
 /obj/effect/decal/cleanable/cockroach_remains,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Ah" = (
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "AD" = (
 /obj/machinery/light/small/broken,
 /turf/simulated/floor/plating,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "AF" = (
 /obj/effect/decal/cleanable/cockroach_remains,
 /obj/machinery/light_switch{
@@ -1305,7 +1319,7 @@
 	dir = 10;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "AH" = (
 /obj/machinery/camera{
 	dir = 4;
@@ -1314,7 +1328,7 @@
 	network = list("PODSTATION")
 	},
 /turf/unsimulated/floor/asteroid,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "AI" = (
 /mob/living/simple_animal/cockroach,
 /obj/effect/decal/cleanable/dirt,
@@ -1323,28 +1337,28 @@
 /turf/simulated/floor{
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "AK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/brewer,
 /turf/simulated/floor{
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "BN" = (
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "whiteblue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "BO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	icon_state = "rampbottom";
 	tag = "icon-rampbottom"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Cb" = (
 /obj/docking_port/destination/salvage/pod_station{
 	dir = 2
@@ -1360,13 +1374,13 @@
 	icon_state = "rampbottom";
 	tag = "icon-rampbottom"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Cf" = (
 /turf/simulated/floor{
 	icon_state = "rampbottom";
 	tag = "icon-rampbottom"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Cz" = (
 /mob/living/simple_animal/cockroach,
 /obj/machinery/light/small/broken{
@@ -1376,29 +1390,29 @@
 	icon_state = "rampbottom";
 	tag = "icon-rampbottom"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "CD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "CY" = (
 /turf/unsimulated/floor/airless{
 	dir = 9;
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Db" = (
 /turf/unsimulated/floor/airless{
 	dir = 1;
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Dq" = (
 /mob/living/simple_animal/cockroach,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Dx" = (
 /obj/item/trash/bustanuts,
 /obj/effect/decal/cleanable/dirt,
@@ -1406,47 +1420,49 @@
 	dir = 5;
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Dz" = (
 /obj/structure/door_assembly,
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "DR" = (
 /obj/item/weapon/storage/toolbox/emergency,
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Ee" = (
 /obj/machinery/light/small,
 /turf/space,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "En" = (
-/obj/structure/reagent_dispensers/cauldron/barrel,
+/obj/structure/reagent_dispensers/cauldron/barrel{
+	name = "Dan's Sauce Barrel"
+	},
+/obj/effect/decal/cleanable/greenglow,
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Eu" = (
 /obj/effect/decal/cleanable/greenglow,
-/obj/structure/hanging_lantern,
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "ED" = (
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
 /turf/space,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "ES" = (
 /turf/unsimulated/floor/asteroid,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Fe" = (
 /obj/structure/hanging_lantern{
 	dir = 4
@@ -1454,7 +1470,7 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "FB" = (
 /obj/machinery/door/airlock/freezer,
 /obj/structure/window/barricade/full/block,
@@ -1463,24 +1479,24 @@
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "FF" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "FJ" = (
 /obj/machinery/light,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "FL" = (
 /obj/machinery/light/small/broken,
 /turf/space,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "FQ" = (
 /mob/living/simple_animal/cockroach,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1489,7 +1505,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "FZ" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/vomit/pre_dry,
@@ -1497,7 +1513,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Ga" = (
 /obj/item/trash/chicken_bucket,
 /obj/effect/decal/cleanable/dirt,
@@ -1505,7 +1521,7 @@
 	dir = 4;
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Gz" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/belt/utility/full,
@@ -1519,11 +1535,11 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "GO" = (
 /obj/structure/sink/kitchen,
 /turf/simulated/wall,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Hg" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/glass/bigstack{
@@ -1541,19 +1557,19 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "HJ" = (
 /obj/structure/fence/corner{
 	dir = 8
 	},
 /turf/unsimulated/floor/asteroid,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "HV" = (
 /obj/structure/fence/door/opened,
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "HW" = (
 /obj/effect/decal/cleanable/ash,
 /obj/item/trash/cigbutt/cigarbutt,
@@ -1561,13 +1577,13 @@
 	dir = 4;
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "If" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/space,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "IC" = (
 /obj/structure/rack,
 /obj/item/clothing/head/tinfoil,
@@ -1587,10 +1603,10 @@
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plating,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "IJ" = (
 /turf/simulated/wall/r_wall,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "IQ" = (
 /obj/machinery/camera{
 	id_tag = "podstationcameras";
@@ -1601,12 +1617,12 @@
 	icon_state = "air"
 	},
 /turf/simulated/floor/plating,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "IZ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/window/barricade/full/block,
 /turf/simulated/floor/plating,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "JY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layered{
@@ -1616,7 +1632,7 @@
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Kg" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -1628,10 +1644,10 @@
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Kk" = (
 /turf/simulated/wall,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Kv" = (
 /obj/item/weapon/reagent_containers/food/snacks/fries/cone,
 /obj/item/weapon/reagent_containers/food/snacks/fries/cone,
@@ -1654,25 +1670,25 @@
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "KC" = (
 /obj/effect/decal/warning_stripes/pathmarkers,
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Li" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/floor/airless{
 	dir = 4;
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Lv" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
 /obj/item/device/silicate_sprayer,
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "LD" = (
 /obj/structure/table,
 /obj/machinery/light/broken{
@@ -1689,7 +1705,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "LL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layered{
@@ -1703,7 +1719,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Mb" = (
 /obj/structure/table,
 /obj/item/trash/fries_cone,
@@ -1714,7 +1730,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Mx" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/sportdrink,
@@ -1722,38 +1738,38 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "MP" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
 /obj/machinery/cryopod,
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Nl" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/unary/vent{
 	dir = 1
 	},
 /turf/space,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Np" = (
 /obj/structure/fence,
 /turf/unsimulated/floor/asteroid,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "NA" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "NF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/mayo_packet,
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "NS" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/trash/chips,
@@ -1767,7 +1783,7 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Ov" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1776,11 +1792,11 @@
 	starting_volume = 3200
 	},
 /turf/simulated/floor/plating,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "OX" = (
 /obj/structure/spacepod_frame,
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Qp" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/fancy/cigarettes/spaceports{
@@ -1864,7 +1880,7 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Qx" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/weapon/reagent_containers/food/condiment/ketchup,
@@ -1888,18 +1904,18 @@
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "QK" = (
 /obj/structure/catwalk{
 	icon_state = "catwalk3"
 	},
 /turf/space,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "QW" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/layer_adapter/scrubbers/hidden,
 /turf/space,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "RG" = (
 /obj/effect/decal/cleanable/blood/oil{
 	icon_state = "floor6"
@@ -1911,7 +1927,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "RO" = (
 /obj/structure/sign/electricshock,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1922,7 +1938,7 @@
 	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/wall,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "RX" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood{
@@ -1935,7 +1951,7 @@
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Sc" = (
 /obj/item/weapon/reagent_containers/food/snacks/fishburger,
 /obj/item/weapon/reagent_containers/food/snacks/xenoburger,
@@ -1977,14 +1993,14 @@
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Si" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Sn" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -1993,7 +2009,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "SS" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
@@ -2002,7 +2018,7 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Ti" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -2013,42 +2029,42 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Ts" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "TC" = (
 /obj/structure/catwalk{
 	icon_state = "catwalk2"
 	},
 /turf/simulated/wall,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "TM" = (
 /obj/item/weapon/shard,
 /turf/unsimulated/floor/asteroid,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "TO" = (
 /obj/item/inflatable/shelter,
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "TV" = (
 /turf/unsimulated/floor/airless{
 	dir = 4;
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Uk" = (
 /obj/item/tool/wrench,
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "UN" = (
 /obj/structure/window/barricade/full/block,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -2058,7 +2074,7 @@
 /obj/structure/grille,
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Vb" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
@@ -2067,41 +2083,41 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "VJ" = (
 /obj/structure/fence/corner{
 	dir = 10
 	},
 /turf/unsimulated/floor/asteroid,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "VP" = (
 /turf/unsimulated/floor/airless{
 	dir = 8;
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "VS" = (
 /obj/structure/lattice,
 /turf/space,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "VT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layered,
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "VU" = (
 /obj/structure/fence{
 	dir = 4
 	},
 /turf/unsimulated/floor/asteroid,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "VW" = (
 /obj/structure/fence/corner{
 	dir = 5
 	},
 /turf/unsimulated/floor/asteroid,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "VX" = (
 /obj/machinery/camera{
 	dir = 10;
@@ -2112,18 +2128,18 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "VY" = (
 /obj/item/trash/cigbutt,
 /obj/item/weapon/storage/bag/trash,
 /turf/unsimulated/floor/asteroid,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Wu" = (
 /obj/machinery/cryopod,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "WT" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -2144,7 +2160,7 @@
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Xi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -2215,12 +2231,12 @@
 	dir = 1;
 	icon_state = "blue"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Xr" = (
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "XB" = (
 /obj/item/weapon/reagent_containers/food/snacks/sundae,
 /obj/item/weapon/reagent_containers/food/snacks/sundae,
@@ -2242,7 +2258,7 @@
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "XS" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -2250,7 +2266,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/wall,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Yt" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -2280,12 +2296,12 @@
 	amount = 20
 	},
 /turf/simulated/floor/plating,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Yx" = (
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "YD" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -2307,11 +2323,11 @@
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "YT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "Zo" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced{
@@ -2331,15 +2347,15 @@
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
-/area/vault/podstation)
+/area/vault/podstation/interior)
 "Zy" = (
 /turf/unsimulated/floor/asteroid/underground/airless,
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "ZI" = (
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidwarning"
 	},
-/area/vault/podstation)
+/area/vault/podstation/exterior)
 "ZP" = (
 /obj/structure/toilet{
 	dir = 8
@@ -2351,7 +2367,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/vault/podstation)
+/area/vault/podstation/interior)
 
 (1,1,1) = {"
 pU
@@ -2476,7 +2492,7 @@ ES
 ES
 ES
 En
-Kk
+cE
 Yx
 VW
 Np
@@ -2520,8 +2536,8 @@ IJ
 ui
 yU
 ES
-Eu
-Kk
+gm
+cE
 NF
 VY
 wh
@@ -2564,9 +2580,9 @@ lz
 IJ
 uy
 aM
+Eu
 Yx
-Yx
-Kk
+cE
 NS
 WT
 ba

--- a/maps/randomvaults/podstation.dmm
+++ b/maps/randomvaults/podstation.dmm
@@ -2099,11 +2099,6 @@
 	},
 /turf/unsimulated/floor/asteroid/underground/airless,
 /area/vault/podstation/exterior)
-"UL" = (
-/turf/unsimulated/floor/airless{
-	icon_state = "asteroidfloor"
-	},
-/area)
 "UN" = (
 /obj/structure/window/barricade/full/block,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -2114,9 +2109,6 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/plating,
 /area/vault/podstation/interior)
-"UO" = (
-/turf/unsimulated/floor/asteroid,
-/area)
 "Vb" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
@@ -2684,7 +2676,7 @@ Kk
 Kk
 Yx
 ES
-DW
+VS
 pU
 pU
 pU
@@ -2729,8 +2721,8 @@ vM
 af
 wi
 Yx
-UL
-DW
+Yx
+VS
 pU
 pU
 "}
@@ -2775,7 +2767,7 @@ bB
 QW
 Nl
 eZ
-UO
+ES
 pU
 pU
 "}
@@ -2820,7 +2812,7 @@ Kk
 Kk
 Kk
 zr
-UO
+ES
 pU
 pU
 "}
@@ -2865,7 +2857,7 @@ cJ
 pL
 Kk
 Yx
-UO
+ES
 pU
 pU
 "}
@@ -2910,7 +2902,7 @@ Xr
 FJ
 Kk
 Yx
-UO
+ES
 pU
 pU
 "}
@@ -2955,7 +2947,7 @@ Xr
 Wu
 Kk
 Yx
-UO
+ES
 pU
 pU
 "}
@@ -3000,7 +2992,7 @@ Kk
 Kk
 Kk
 Yx
-UO
+ES
 pU
 pU
 "}
@@ -3045,7 +3037,7 @@ iv
 Kk
 aM
 Yx
-UO
+ES
 pU
 pU
 "}
@@ -3090,7 +3082,7 @@ sK
 Kk
 Yx
 ES
-UO
+ES
 pU
 pU
 "}
@@ -3135,7 +3127,7 @@ CD
 Kk
 Yx
 ES
-DW
+VS
 pU
 pU
 "}
@@ -3180,7 +3172,7 @@ px
 Kk
 Yx
 ES
-DW
+VS
 pU
 pU
 "}


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
## Revisiting the Podstation ##
![image](https://github.com/vgstation-coders/vgstation13/assets/81007356/89807f6d-e055-44fd-b67b-c9a8ebfd7dc1)

### Misc Changes ###
- Adds various tools that were missing: gas masks, satchels, welding goggles, toolbelts, some plasma for the pacman outside
- Adds a bit more food and variety to the freezer: burritos, bagels, potato salad (foodstuffs that fit the theme of spess convenience store fare)
- Adds a rack of cigarettes and lighters near the register. Carries most brands except NT Standard, Golden Carp, and Red Suits.
- Adds a rack of alcoholic beverages to the freezer, mostly canned beers. Two boxes of generic space beers, and schnapps.
- Fixes the asteroid cave (the road) turfs outside having partial atmos.
- Adds a bit more reward for clearing out the boss' office. There's a NT-22 pocket pistol and a holster. You can now stop shop lifters! Maybe.
- Fixed the piping so that the atmos of the structure actually refills.
- Tweaked the bathroom door entrance so you don't need to jump over a chair.
- Added two notes to the counter that give some context as to why the pod station is in such disrepair.
- Added proper areas to the vault.

## Revisiting the Broken UFO ##
![2023-08-16 01 31 25](https://github.com/vgstation-coders/vgstation13/assets/81007356/e82c50c9-e650-4d4b-9fe6-687b680faff7)

### Misc Changes ###
- Slightly improved the layout of the ayy crew bedroom. Replaced furniture with new ayy furniture.
- The problem that caused the craft to not be able to be linked to by a shuttle control console has been solved.
- A paper with the password has been added to the craft.

[vault]

:cl:
 * tweak: Touches up the pod station vault
 * tweak: Touches up the broke ufo vault
 * bugfix: Shuttle consoles can now be linked to the broken ufo again