### PR TITLE
Paramedic outfit tweak for vox and plasmamen

### DIFF
--- a/code/datums/outfit/medical.dm
+++ b/code/datums/outfit/medical.dm
@@ -319,7 +319,8 @@
 
 	race_items_to_collect = list(
 		/datum/species/vox/ = list(
-			/obj/item/clothing/suit/storage/paramedic,
+			"Paramedic" = list(/obj/item/clothing/suit/storage/paramedic),
+			"Brig Medic" = list(/obj/item/clothing/suit/armor/vest/security/medic),
 			/obj/item/clothing/head/soft/paramedic,
 		),
 		/datum/species/plasmaman/ = list(

--- a/code/datums/outfit/medical.dm
+++ b/code/datums/outfit/medical.dm
@@ -324,7 +324,8 @@
 			/obj/item/clothing/head/soft/paramedic,
 		),
 		/datum/species/plasmaman/ = list(
-			/obj/item/clothing/suit/storage/paramedic,
+			"Paramedic" = list(/obj/item/clothing/suit/storage/paramedic),
+			"Brig Medic" = list(/obj/item/clothing/suit/armor/vest/security/medic),
 			/obj/item/clothing/head/soft/paramedic,
 		)
 	)


### PR DESCRIPTION
[bugfix]


## What this does
Vox and plasmamen paramedics actually spawn with a paramedic vest in their bag so brig medics should get armor like the other races.

## Changelog
:cl:
 * tweak: Vox and plasmamen brig medics now spawn with armor instead of the vest.