### PR TITLE
Sound called stored in variable for adminbus: Desk bells and Ian

### DIFF
--- a/code/game/objects/items/devices/deskbell.dm
+++ b/code/game/objects/items/devices/deskbell.dm
@@ -92,7 +92,7 @@
 	if(world.time - last_ring_time >= ring_delay)
 		last_ring_time = world.time
 		flick("[icon_state]-push", src)
-		playsound(src, 'sound/machines/ding2.ogg', 50, 1)
+		playsound(src, hitsound, 50, 1)
 		return 1
 	return 0
 

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -48,6 +48,8 @@
 	var/mob/pointer_caller
 	var/mob/master //Obtained randomly when petting him. Can be overriden.
 
+	var/growl_sound = 'sound/voice/corgigrowl.ogg' // Sound played when hurt
+
 	held_items = list()
 	var/time_between_directed_steps = 6
 
@@ -107,7 +109,7 @@
 						corg_her = "his"
 					if(movement_target)
 						step_towards(src,movement_target,1)
-						playsound(loc, 'sound/voice/corgibark.ogg', 80, 1)
+						playsound(loc, "[pick(emote_sound)]", 80, 1)
 						if(istype(movement_target,/obj/item/weapon/reagent_containers/food/snacks))
 							emote("me", 1, "barks at [movement_target], as if begging it to go into [corg_her] mouth.")
 							corgi_status = BEGIN_FOOD_HUNTING
@@ -549,7 +551,7 @@
 					master = M
 					to_chat(M, "[src] seems closer to you now. At least until somebody else gives \him attention, anyway.")
 			if(I_HURT)
-				playsound(loc, 'sound/voice/corgigrowl.ogg', 80, 1)
+				playsound(loc, growl_sound, 80, 1)
 				emote("me", EMOTE_AUDIBLE, "growls.")
 
 //Sasha isn't even a corgi you dummy!

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -20,6 +20,7 @@
 	speak_emote = list("squeeks","squeeks","squiks")
 	emote_hear = list("squeeks","squeaks","squiks")
 	emote_see = list("runs in a circle", "shakes", "scritches at something")
+	emote_sound = list('sound/effects/mousesqueek.ogg')
 	pass_flags = PASSTABLE
 	flags = HEAR_ALWAYS | PROXMOVE
 	speak_chance = 1
@@ -71,7 +72,7 @@
 	..()
 	standard_damage_overlay_updates()
 	if(!stat && prob(speak_chance))
-		playsound(src, 'sound/effects/mousesqueek.ogg', 100, 1)
+		playsound(src, "[pick(emote_sound)]", 100, 1)
 
 	if(!ckey && stat == CONSCIOUS && prob(0.5) && !(status_flags & BUDDHAMODE))
 		stat = UNCONSCIOUS
@@ -357,7 +358,7 @@
 		if (M.on_foot())
 			if(!stat)
 				to_chat(M, "<span class='notice'>[bicon(src)] Squeek!</span>")
-				playsound(src, 'sound/effects/mousesqueek.ogg', 100, 1)
+				playsound(src, "[pick(emote_sound)]", 100, 1)
 			if (can_be_infected())
 				var/block = 0
 				var/bleeding = 0


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

[easy][content]

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Makes sure Ian and desk bells use the sounds stored in variables instead of in-code. This allows admins to change these to bus in some extra sounds. There MAY BE tons of other things that need this change, if you can think of some, add them in the comments, I'll add them

Some background on Ian: He's of type simplemob, which already have a list of emote sounds to pick at random when speaking. Whoever coded Ian even used the ian bark for this list (single element). But still added the bark's path statically into the code! So the list was NEVER even used! 

-Mice added

## Why it's good
<!-- Explain why you think these changes are good. -->
Lets admins bus in custom sounds for Ian barks, desk bells and mice

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Let admins change the sound of desk bells, Ian barks and mice squeeks
