### PR TITLE
blacklist rabid slimes from being chosen to be playable by amorphous mask

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -317,7 +317,8 @@ var/list/blacklisted_mobs = list(
 		/mob/living/simple_animal/hostile/asteroid/goliath/david/dave,	// Isn't supposed to be spawnable by xenobio
 		/mob/living/simple_animal/hostile/bunnybot,						// See viscerator
 		/mob/living/carbon/human/NPC,									// Unfinished, with its own AI that conflicts with player movements.
-		/mob/living/simple_animal/hostile/pulse_demon/					// Your motherfucking life ends in 0 seconds.
+		/mob/living/simple_animal/hostile/pulse_demon/,					// Your motherfucking life ends in 0 seconds.
+		/mob/living/simple_animal/hostile/slime,						// Instantly kills player and destroys the MC.
 		)
 
 //Boss monster list


### PR DESCRIPTION
## Why it's good
It instantly kills the player and also breaks the MC.

fixes #34926 
fixes #33231 
[bugfix]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Rabid slimes can no longer be selected as a valid mob for the amorphous mask. (it breaks everything)