### PR TITLE
Adds a failsafe to the Blast Cannon loop preventing endless lag should the projectile end up on another Z level + fixed teleportation interaction

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -141,6 +141,7 @@
 		P.override_target_X += Xchange
 		P.override_target_Y += Ychange
 		P.reflected = TRUE//you can now get hit by the projectile you just fired. Careful with portals!
+		P.teleport_act()
 
 	if(curturf.z != destturf.z)
 		INVOKE_EVENT(teleatom, /event/z_transition, "user" = teleatom, "from_z" = curturf.z, "to_z" = destturf.z)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -857,3 +857,6 @@ var/list/impact_master = list()
 
 /obj/item/projectile/proc/apply_projectile_color_shift(var/proj_color_shift)
 	return
+
+/obj/item/projectile/proc/teleport_act()
+	return

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -461,7 +461,7 @@
 	icon_state = "hornetgun"
 	projectile_speed = 0.5
 	bee_type = /mob/living/simple_animal/bee/hornetgun
-	
+
 /obj/item/projectile/bullet/beegun/ss_viscerator
 	name = "viscerator"
 	icon_state = "ss_visceratorgun"
@@ -472,7 +472,7 @@
 	..()
 	if(isbee(bee_type)	)
 		playsound(starting, 'sound/effects/bees.ogg', 75, 1)
-	
+
 /obj/item/projectile/bullet/beegun/to_bump(atom/A as mob|obj|turf|area)
 	if (!A)
 		return 0
@@ -653,6 +653,9 @@
 
 /obj/item/projectile/bullet/blastwave/process_step()
 	..()
+	if (!loc)
+		return
+
 	distance_traveled++
 
 	if (distance_traveled > light_damage_range)
@@ -661,17 +664,19 @@
 
 	radius = round(distance_traveled/widening_rate)
 
+	var/max_steps = distance_traveled + radius + 1
+
 	var/turf/T = loc
 	for (var/turf/U in range(radius,T))
 		if (!(U in affected_turfs))
 			affected_turfs |= U
-
+			var/steps = 0
 			var/turf/Trajectory = U
 			var/dist = cheap_pythag(U.x - starting.x, U.y - starting.y)
-			while(Trajectory != starting)
+			while((Trajectory != starting) && (steps <= max_steps))
 				Trajectory = get_step_towards(Trajectory,starting)
 				dist += CalculateExplosionSingleBlock(Trajectory)
-
+				steps++//failsafe in case of fuckery such as the projectile finding itself on a different Z level
 			if (dist <= heavy_damage_range)
 				heavy_turfs += U
 			else if (dist <= medium_damage_range)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -666,15 +666,17 @@
 
 	var/max_steps = distance_traveled + radius + 1
 
+	var/turf/relative_epicenter = locate(override_starting_X,override_starting_Y,z)
+
 	var/turf/T = loc
 	for (var/turf/U in range(radius,T))
 		if (!(U in affected_turfs))
 			affected_turfs |= U
 			var/steps = 0
 			var/turf/Trajectory = U
-			var/dist = cheap_pythag(U.x - starting.x, U.y - starting.y)
+			var/dist = cheap_pythag(U.x - override_starting_X, U.y - override_starting_Y)
 			while((Trajectory != starting) && (steps <= max_steps))
-				Trajectory = get_step_towards(Trajectory,starting)
+				Trajectory = get_step_towards(Trajectory,relative_epicenter)
 				dist += CalculateExplosionSingleBlock(Trajectory)
 				steps++//failsafe in case of fuckery such as the projectile finding itself on a different Z level
 			if (dist <= heavy_damage_range)
@@ -683,6 +685,10 @@
 				medium_turfs += U
 			else if (dist <= light_damage_range)
 				light_turfs += U
+
+/obj/item/projectile/bullet/blastwave/teleport_act()
+	override_starting_X = clamp(override_starting_X,1,world.maxx)
+	override_starting_Y = clamp(override_starting_Y,1,world.maxy)
 
 /obj/item/projectile/bullet/blastwave/bullet_die()
 	//the bullet moved all the way, now to explode dem turfs


### PR DESCRIPTION
:cl:
* bugfix: Patched an issue where if a Blast Cannon projectile found itself on a different Z Level (or was moved in some unconventional way) it would loop some of its code forever, resulting in server performance slowing down to a crawl.
* bugfix: Blast Cannon projectiles now interact as one would expect with portals (they now update their relative distance to the epicenter upon teleportation. Previously they would fizzle out if the destination was too far away)