### PR TITLE
Fixes barrels not receiving reagents and wooden barrels becoming metallic when getting inside it.

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -564,8 +564,8 @@
 	icon_state = "metalbarrel"
 	desc = "Originally used to store liquids & powder. It is now used as a source of comfort. This one is made of metal."
 	layer = TABLE_LAYER
-	flags = FPRINT | TWOHANDABLE | MUSTTWOHAND // If I end up being coherent enough to make it holdable in-hand
-	var/list/exiting = list() // Manages people leaving the barrel
+	flags = FPRINT | TWOHANDABLE | MUSTTWOHAND | OPENCONTAINER // If I end up being coherent enough to make it holdable in-hand
+	var/list/exiting = list() // Manages people leaving the barrel //Turns out the flags here overwrote the new OPENCONTAINER flag so the barrels were fucked
 	health = 50
 	var/burning = FALSE
 	is_cooktop = TRUE

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -632,7 +632,10 @@
 		icon_state = "flamingmetalbarrel"
 		set_light(3,4,LIGHT_COLOR_FIRE)
 	else
-		icon_state = "metalbarrel"
+		if(is_cooktop) //only metal barrels are cooktops
+			icon_state = "metalbarrel"
+		else
+			icon_state = "woodenbarrel"
 		set_light(0,0,LIGHT_COLOR_FIRE)
 	render_cookvessel()
 


### PR DESCRIPTION
When #34103 reworked how tank explosions work, it changed the is_open_container() proc on the cauldron for an OPENCONTAINER flag, the barrels, being children of the cauldron, also lost the proc in favour of the flag. 
Issue was that the barrels had their own list of flags, which overwrote the inherited OPENCONTAINER one, making them behave as an empty fueltank.
Closes #34931.
Closes #34631.
Closes #34191.
Closes #34004.
[hotfix][bugfix][oversight][tested]
:cl:
 * bugfix: Fixes barrels not being able to receive reagents.
 * bugfix: Wooden barrels no longer become metal barrels when you get inside it.
