### PR TITLE
Makes candles last longer.

### DIFF
--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -10,7 +10,7 @@
 	light_color = LIGHT_COLOR_FIRE
 	autoignition_temperature = AUTOIGNITION_FABRIC //idk the wick lmao
 
-	var/wax = 200
+	var/wax = 900
 	var/lit = 0
 	var/flavor_text
 	var/trashtype = /obj/item/trash/candle


### PR DESCRIPTION
Did you know that there are several types of candles? Beeswax, paraffin, soy, etc. The longest burning one is beeswax, shortest is soy, paraffin somewhere in the middle.
Since you can make extra candles on the biogenerator, I'm inclined to think they are closer to soy candles than beeswax or paraffin. Apparently soy candles take between 20 to 40 minutes to burn through a 2.5cm diameter of wax, for an average of 30m. 
The candles currently last around 7 minutes, this ups that to 30 minutes (I'm guessing spess candles are really thin so the 30m is spread out through the entire length).
Your candles will still eventually run dry, so use holocandles if you want moodlights that don't burn out.
Closes #34910.
:cl:
 * tweak: Candles now last 30 minutes instead 7 minutes.