### PR TITLE
Mouser gun victims can eat their way to freedom.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -48,6 +48,7 @@
 	var/splat = 0
 	var/infectable = 0
 	var/nutrition_loss_mod = 1
+	var/ismouservictim = FALSE
 
 /mob/living/simple_animal/mouse/New()
 	..()
@@ -89,7 +90,7 @@
 			emote("me", EMOTE_AUDIBLE, "snuffles")
 
 	if(nutrition >= MOUSETFAT)
-		if(!maxHealth == 35) //Only mouser rats have 35 max health. Technically there's a very small chance a regular rat gets adminbussed to 35max health, but the code has sanity checks so the transmog death doesn't runtime
+		if(!ismouservictim)
 			visible_message("<span class = 'warning'>\The [src] explodes!</span>")
 			gib()
 		else
@@ -548,6 +549,7 @@
 /mob/living/simple_animal/mouse/transmog
 	maxHealth = 35
 	health = 35
+	ismouservictim = TRUE
 
 /mob/living/simple_animal/mouse/transmog/transmog_death()
 	if(!transmogged_from)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -89,8 +89,11 @@
 			emote("me", EMOTE_AUDIBLE, "snuffles")
 
 	if(nutrition >= MOUSETFAT)
-		visible_message("<span class = 'warning'>\The [src] explodes!</span>")
-		gib()
+		if(!maxHealth == 35) //Only mouser rats have 35 max health. Technically there's a very small chance a regular rat gets adminbussed to 35max health, but the code has sanity checks so the transmog death doesn't runtime
+			visible_message("<span class = 'warning'>\The [src] explodes!</span>")
+			gib()
+		else
+			transmog_death()
 		return
 
 	if(nutrition >= MOUSEFAT && is_fat == 0)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -48,7 +48,6 @@
 	var/splat = 0
 	var/infectable = 0
 	var/nutrition_loss_mod = 1
-	var/ismouservictim = FALSE
 
 /mob/living/simple_animal/mouse/New()
 	..()
@@ -90,11 +89,7 @@
 			emote("me", EMOTE_AUDIBLE, "snuffles")
 
 	if(nutrition >= MOUSETFAT)
-		if(!ismouservictim)
-			visible_message("<span class = 'warning'>\The [src] explodes!</span>")
-			gib()
-		else
-			transmog_death()
+		mouse_overeat()
 		return
 
 	if(nutrition >= MOUSEFAT && is_fat == 0)
@@ -402,6 +397,10 @@
 		M.splat()
 		return PROJECTILE_COLLISION_DEFAULT
 
+/mob/living/simple_animal/mouse/proc/mouse_overeat()
+	visible_message("<span class = 'warning'>\The [src] explodes!</span>")
+	gib()
+
 /*
  * Common mouse types
  */
@@ -549,7 +548,9 @@
 /mob/living/simple_animal/mouse/transmog
 	maxHealth = 35
 	health = 35
-	ismouservictim = TRUE
+
+/mob/living/simple_animal/mouse/transmog/mouse_overeat()
+	transmog_death()
 
 /mob/living/simple_animal/mouse/transmog/transmog_death()
 	if(!transmogged_from)


### PR DESCRIPTION
Closes #34888.
[bugfix]
:cl:
 * bugfix: Mouser gun rats can over eat to return to their real bodies, instead of gibbing.