### PR TITLE
Food with ectoplasm inside can be eaten by ghosts.

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -607,6 +607,14 @@
 
 	reset_vars_after_duration(resettable_vars, duration)
 
+/obj/item/weapon/reagent_containers/food/snacks/spook()
+	if(reagents.has_reagent(ECTOPLASM))
+		visible_message("<span class='warning'>A specter takes a bite of \the [src] from beyond the grave!</span>")
+		playsound(src,'sound/items/eatfood.ogg', rand(10,50), 1)
+		bitecount++
+		reagents.remove_any(bitesize)
+		if(!reagents.total_volume)
+			qdel(src)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// FOOD END


### PR DESCRIPTION
Ghosts can Boo! on top of food that contains ectoplasm to take a bite. You can now go out of your way to feed the eternally suffering, and ghosts as well, if you can source enough ectoplasm for that. Thanks to @Hinaichigo for the idea.
:cl:
 * rscadd: Food that contains Ectoplasm can be eaten by ghosts.