### PR TITLE
Fix long range AI upload origin_tech string

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -72,7 +72,7 @@
 	name = "Circuit board (Long Range AI Upload)"
 	desc = "A circuit board for running a computer used for modifying AI laws."
 	build_path = /obj/machinery/computer/aiupload/longrange
-	origin_tech = Tc_PROGRAMMING + "=4" + Tc_MATERIALS + "=9" + Tc_BLUESPACE + "=3" + Tc_MAGNETS + "=5"
+	origin_tech = Tc_PROGRAMMING + "=4;" + Tc_MATERIALS + "=9;" + Tc_BLUESPACE + "=3;" + Tc_MAGNETS + "=5"
 /obj/item/weapon/circuitboard/borgupload
 	name = "Circuit board (Cyborg Upload)"
 	desc = "A circuit board for running a computer used for modifying cyborg laws."


### PR DESCRIPTION
[bugfix]

## What this does
Fixes the corrupted origin_tech string, allowing the upload board to go into the Destructive Analyzer.
Closes #21981

## Why it's good
The long range AI upload can finally go into the Destructive Analyzer.

## Changelog
:cl:
 * bugfix: The long range AI upload board can now be scanned in the Destructive Analyzer.