### PR TITLE
Fixes manuals being printed as books

### DIFF
--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/library.dmi'
 	due_date = 0 // Game time in 1/10th seconds
 	unique = 1   // 0 - Normal book, 1 - Should not be treated as normal book, unable to be copied, unable to be modified
+	var/id = 0
 
 /obj/item/weapon/book/manual/engineering_construction
 	name = "Station Repairs and Construction"
@@ -13,6 +14,7 @@
 	author = "Engineering Encyclopedia"		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
 	title = "Station Repairs and Construction"
 	wiki_page = "Guide_to_Construction"
+	id = 1
 
 /obj/item/weapon/book/manual/engineering_particle_accelerator
 	name = "Particle Accelerator User's Guide"
@@ -20,6 +22,7 @@
 	author = "Engineering Encyclopedia"		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
 	title = "Particle Accelerator User's Guide"
 //big pile of shit below.
+	id = 2
 
 	dat = {"<html>
 				<head>
@@ -63,6 +66,7 @@
 	author = "Engineering Encyclopedia"		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
 	title = "Hacking"
 	wiki_page = "Hacking"
+	id = 3
 
 /obj/item/weapon/book/manual/engineering_singularity_safety
 	name = "Singularity Safety in Special Circumstances"
@@ -70,7 +74,7 @@
 	author = "Engineering Encyclopedia"		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
 	title = "Singularity Safety in Special Circumstances"
 //big pile of shit below.
-
+	id = 4
 	dat = {"<html>
 				<head>
 				<style>
@@ -118,6 +122,7 @@
 	item_state = "book5"
 	author = "Farmer John"
 	title = "Growing Dionae and YOU! A book on growing your new best friends!"
+	id = 5
 	dat = {"<html>
 				<head>
 				<style>
@@ -152,6 +157,7 @@
 	author = "Medical Journal, volume 3"		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
 	title = "Cloning techniques of the 26th century"
 	wiki_page = "Guide_to_Cloning"
+	id = 6
 
 /obj/item/weapon/book/manual/chemistry_manual
 	name = "Chemistry 101"
@@ -160,13 +166,14 @@
 	author = "SpaceChem Inc."
 	title = "Chemistry 101"
 	wiki_page = "Guide_to_Chemistry"
-
+	id = 7
 
 /obj/item/weapon/book/manual/ripley_build_and_repair
 	name = "APLU \"Ripley\" Construction and Operation Manual"
 	icon_state ="book"
 	author = "Weyland-Yutani Corp"		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
 	title = "APLU \"Ripley\" Construction and Operation Manual"
+	id = 8
 //big pile of shit below.
 
 	/*dat = {"<html>
@@ -243,6 +250,7 @@
 	icon_state = "rdbook"
 	author = "Dr. L. Ight"
 	title = "Research and Development 101"
+	id = 9
 	dat = {"<html>
 				<head>
 				<style>
@@ -293,6 +301,7 @@
 	icon_state = "borgbook"
 	author = "XISC"
 	title = "Cyborgs for Dummies"
+	id = 10
 	dat = {"<html>
 				<head>
 				<style>
@@ -498,6 +507,7 @@
 	author = "Nanotrasen"
 	title = "Space Law"
 	wiki_page = "Space_Law"
+	id = 11
 
 /obj/item/weapon/book/manual/security_antag_guide	//if you wanna edit, just copypaste the dat into https://www.w3schools.com/html/tryit.asp?filename=tryhtml_default
 	name = "Enemies of Nanotrasen: A Quick Overview"
@@ -506,6 +516,7 @@
 	item_state = "bookAntagGuide"
 	author = "Nanotrasen"
 	title = "Enemies of Nanotrasen: A Quick Overview"
+	id = 12
 	book_width = 692
 
 /obj/item/weapon/book/manual/security_antag_guide/New(turf/loc)
@@ -672,6 +683,7 @@
 	author = "Engineering Encyclopedia"
 	title = "Engineering Textbook"
 	wiki_page = "Guide_to_Engineering"
+	id = 13
 
 /obj/item/weapon/book/manual/rust
 	name = "R-UST User Manual"
@@ -679,6 +691,7 @@
 	author = "NanoTrasen"
 	title = "R-UST User Manual"
 	wiki_page = "R-UST"
+	id = 14
 
 /obj/item/weapon/book/manual/chef_recipes
 	name = "Chef Recipes"
@@ -687,6 +700,7 @@
 	author = "Lord Frenrir Cageth"
 	title = "Chef Recipes"
 	wiki_page = "Guide_to_Food_and_Drinks"
+	id = 15
 
 /obj/item/weapon/book/manual/barman_recipes
 	name = "Barman Recipes"
@@ -695,6 +709,7 @@
 	author = "Sir John Rose"
 	title = "Barman Recipes"
 	wiki_page = "Barman_recipes"
+	id = 16
 
 /obj/item/weapon/book/manual/detective
 	name = "The Film Noir: proper Procedures for Investigations"
@@ -703,6 +718,7 @@
 	author = "Nanotrasen"
 	title = "The Film Noir: proper Procedures for Investigations"
 	wiki_page = "Guide_to_Forensics"
+	id = 17
 
 /obj/item/weapon/book/manual/nuclear
 	name = "Fission Mailed: Nuclear Sabotage 101"
@@ -712,6 +728,7 @@
 	title = "Fission Mailed: Nuclear Sabotage 101"
 	wiki_page = "Nuclear_Agent"
 	forbidden = 2 // Only available to emagged terminals.
+	id = 18
 
 /obj/item/weapon/book/manual/ship_building
 	name = "Dummies guide to Interstellar Flight"
@@ -719,12 +736,14 @@
 	icon_state = "bookDummy"
 	author = "David Alcubierre"
 	wiki_page = "Ship_Building"
+	id = 19
 
 /obj/item/weapon/book/manual/mailing_guide
 	name = "Guide to disposal mailing system"
 	icon_state ="book"     // a proper icon would be nice
 	author = "Ulyanovsk Logistics Division"		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
 	title = "Guide to disposal mailing system"
+	id = 20
 	dat = {"<html>
 				<head>
 				<style>
@@ -987,6 +1006,7 @@ var/virology_encyclopedia = ""
 	author = "Frederick Chapman Montagnier"
 	title = "Symptom Encyclopedia"
 	dat = ""
+	id = 21
 	book_width = 819
 	book_height = 516
 
@@ -1094,6 +1114,7 @@ var/virology_encyclopedia = ""
 	item_state ="snow"
 	author = "The Abominable Snowman"
 	title = "Snow Survival Guide"
+	id = 22
 	wiki_page = "Guide_to_Snow_Map"
 	desc = "A guide to surviving on the surface of a snow planet. It even comes with a magnesium strip to ignite for emergency heating when applied to snow!</span>"
 

--- a/code/modules/html_interface/paintTool/custom_painting_datum.dm
+++ b/code/modules/html_interface/paintTool/custom_painting_datum.dm
@@ -241,7 +241,7 @@
 		if(!usr || usr.incapacitated())
 			return
 
-		var /datum/painting_utensil/pu = new /datum/painting_utensil(usr)
+		var/datum/painting_utensil/pu = new /datum/painting_utensil(usr)
 		if(!pu.palette.len)
 			to_chat(usr, "<span class='warning'>You need to be holding a painting utensil in your active hand.</span>")
 			return

--- a/code/modules/library/computers/checkout.dm
+++ b/code/modules/library/computers/checkout.dm
@@ -197,7 +197,7 @@
 					<TT>Category: </TT><A href='?src=\ref[src];uploadcategory=1'>[upload_category]</A><BR>
 					<A href='?src=\ref[src];upload=1'>\[Upload\]</A><BR>"}
 			dat += "<A href='?src=\ref[src];switchscreen=[MAIN_MENU]'>(Return to main menu)</A><BR>"
-		if(PRINT_NEW_BOOK)
+		if(PRINT_MANUAL)
 			dat += "<H3>Print a Manual</H3>"
 			dat += "<table>"
 
@@ -208,14 +208,12 @@
 			if(!emagged)
 				forbidden |= /obj/item/weapon/book/manual/nuclear
 
-			var/manualcount = 0
 			var/obj/item/weapon/book/manual/M = null
 
 			for(var/manual_type in typesof(/obj/item/weapon/book/manual))
 				if (!(manual_type in forbidden))
 					M = manual_type
-					dat += "<tr><td><A href='?src=\ref[src];manual=[manualcount]'>[initial(M.title)]</A></td></tr>"
-				manualcount++
+					dat += "<tr><td><A href='?src=\ref[src];manual=[initial(M.id)]'>[initial(M.title)]</A></td></tr>"
 			dat += "</table>"
 			dat += "<BR><A href='?src=\ref[src];switchscreen=[MAIN_MENU]'>(Return to main menu)</A><BR>"
 
@@ -482,18 +480,16 @@
 	if(href_list["manual"])
 		if(!href_list["manual"])
 			return
-		var/bookid = href_list["manual"]
+		var/manual_id = text2num(href_list["manual"])
+		var/the_manual_type
+		for (var/manual_type in typesof(/obj/item/weapon/book/manual))
+			var/obj/item/weapon/book/manual/M = manual_type
+			if (initial(M.id) == manual_id)
+				the_manual_type = manual_type
+				break
 
-		if(!SSdbcore.IsConnected())
-			alert("Connection to Archive has been severed. Aborting.")
-			return
-
-		var/datum/cachedbook/newbook = getItemByID("[bookid]", library_table)
-		if(!newbook)
-			alert("No book found")
-			return
-		if((newbook.forbidden == 2 && !emagged) || newbook.forbidden == 1)
-			alert("This book is forbidden and cannot be printed.")
+		if (!the_manual_type)
+			visible_message("<b>[src]</b>'s monitor flashes, \"The manual requested cannot be found in the database. Please contact an administrator.\"")
 			return
 
 		if(bibledelay)
@@ -503,7 +499,7 @@
 			bibledelay = 1
 			spawn(60)
 				bibledelay = 0
-			make_external_book(newbook)
+			new the_manual_type(get_turf(src))
 
 	if(href_list["preview"])
 		var/datum/cachedbook/PVB = href_list["preview"]


### PR DESCRIPTION
Closes #34906.
Worth noting that this has nothing to do with the DB/painting rework. I think printing manuals was always broken.

It makes no sense that the manuals were fetched from the DB when they exist in the code.

I've tried to look at other issues, such as #34689 but I could not reproduce them.
The issue in which a painting needs to be interacted with and saved before it is able to be rendered on the surface remains unsolved and warrants further investigation. I'm not really sure what is happening here.

[bugfix]

:cl:
- bugfix: The library checkout computer is now able to print out manuals.