### PR TITLE
Fix Runtimes When Mech Punching Objects

### DIFF
--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -102,7 +102,7 @@
 					src.occupant_message("You hit [target].")
 					src.visible_message("<span class='red'><b>[src.name] hits [target]</b></span>")
 					if(!istype(target, /turf/simulated/wall))
-						target:attackby(src,src.occupant)
+						target:attackby(src.fist,src.occupant)
 					else if(prob(5))
 						target:dismantle_wall(1)
 						src.occupant_message("<span class='notice'>You smash through the wall.</span>")

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -86,6 +86,8 @@
 	var/obj/item/mecha_parts/mecha_equipment/selected
 	var/max_equip = 3 //The maximum amount of equipment this mecha an hold at one time.
 
+	var/obj/item/weapon/mecha_fist/fist = null
+
 	var/turf/crashing = null
 	var/list/mech_parts = list()
 
@@ -113,6 +115,7 @@
 		removeVerb(/obj/mecha/verb/connect_to_port)
 		removeVerb(/obj/mecha/verb/toggle_internal_tank)
 	add_cell()
+	add_fist()
 	if(starts_with_tracking_beacon)
 		add_tracking_beacon()
 	add_iterators()
@@ -174,6 +177,8 @@
 	connected_port = null
 	if(radio)
 		QDEL_NULL(radio)
+	if(fist)
+		QDEL_NULL(fist)
 	if(electropack)
 		QDEL_NULL(electropack)
 	if(tracking)
@@ -224,6 +229,11 @@
 		GAS_NITROGEN, N2STANDARD*cabin_air.volume/(R_IDEAL_GAS_EQUATION*cabin_air.temperature))
 	mech_parts.Add(cabin_air)
 	return cabin_air
+
+/obj/mecha/proc/add_fist()
+	fist = new
+	fist.name = "[src]'s fist"
+	fist.force = src.force
 
 /obj/mecha/proc/add_radio()
 	radio = new(src)
@@ -2294,6 +2304,11 @@
 			mecha.cell.charge -= min(20,mecha.cell.charge)
 			mecha.cell.maxcharge -= min(20,mecha.cell.maxcharge)
 
+/////////////
+/obj/item/weapon/mecha_fist/ // An invisible weapon representing the mech's punching force. Used for melee attacks.
+	name = "mecha fist"
+	desc = "The fist of a powerful mech. You probably shouldn't be seeing this."
+	abstract = TRUE
 
 /////////////
 


### PR DESCRIPTION
[bugfix][consistency]

## What this does
Gives mechs an invisible "fist" weapon passed to objects' attackby() when mech punching with melee_action(), fixing the runtime error when attempting to damage windows, grilles, and other mechs.

Only combat mechs (obj/mecha/combat) can punch (excluding the H.O.N.K, which has its own proc).

To enable other mechs in the future, the melee_action() logic will either need to be brought down to obj/mecha, or defined for that mech type.

Closes #28913

## Why it's good
Fixes the runtimes that would fire when attempting to punch grilles, windows, and other mechs while piloting a mech.
Also allows a combat mech to bust through windows and grilles and fistfight other mechs for great glory (even if unarmed!).

## Changelog
:cl:
* bugfix: Fixed a set of runtime errors preventing mechs from punching grilles, windows, and other mechs.