### PR TITLE
Reverts resisting out of straitjackets

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1172,16 +1172,6 @@ Thanks.
 		cuffs = mutual_handcuffs
 		resist_time = cuffs.restraint_resist_time/2 //it's only one cuff
 		var_to_check = "mutual_handcuffs"
-	else if(is_wearing_item(/obj/item/clothing/suit/strait_jacket, slot_wear_suit))
-		cuffs = get_item_by_slot(slot_wear_suit)
-		if(!is_hulk)
-			do_after_callback = new /callback(GLOBAL_PROC, /proc/strait_jacket_resist_do_after)
-			var/left_arm = get_organ(LIMB_LEFT_ARM)
-			var/right_arm = get_organ(LIMB_RIGHT_ARM)
-			for(var/datum/organ/external/arm in list(left_arm, right_arm))
-				if(!arm.is_existing() || arm.is_broken())
-					resist_time = max(0, resist_time - 30 SECONDS)
-		var_to_check = "wear_suit"
 	else
 		return
 	if(is_hulk)
@@ -1207,20 +1197,6 @@ Thanks.
 		else
 			simple_message("<span class='warning'>Your attempt at [is_hulk ? "breaking" : "removing"] \the [cuffs] was interrupted.</span>",
 							"<span class='warning'>Your attempt to regain control of your hands was interrupted. Damn it!</span>")
-
-/proc/strait_jacket_resist_do_after(mob/living/carbon/user)
-	var/left_arm = user.get_organ(LIMB_LEFT_ARM)
-	var/right_arm = user.get_organ(LIMB_RIGHT_ARM)
-	for(var/datum/organ/external/arm in list(left_arm, right_arm))
-		if(!arm)
-			// Not a humanoid or something
-			continue
-		if(!arm.is_existing() || arm.is_broken() || !arm.is_organic())
-			continue
-		if(prob(5))
-			arm.fracture()
-			return FALSE
-	return TRUE
 
 /mob/living/verb/lay_down()
 	set name = "Rest"


### PR DESCRIPTION
## What this does
reverts #31195 

Me and the boys had a chat last night and it led to this

## Why it's good
C'mon man, it really does just spoil the point of the whole thing, you can't get more of them for a reason

But really, it's just not a special item anymore, [I told you guys it would just become handcuffs+](https://i.imgur.com/UTDofRt.png) and gee willickers look at how it's being used now
I thought about just increasing it to something longer than the time it takes to cook a Hot Pocket in a 1,100 watt microwave (even TGstation has it at 5 minutes) but I realized that it wouldn't really fix the underlying principle

Still, I think you can tackle windoors in it anyways

## Changelog
:cl:
 * tweak: you can no longer resist out of straitjackets
