### PR TITLE
Midround threat will now also appear on the threat report

### DIFF
--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -111,6 +111,8 @@
 						<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"><BR>"}
 
 	var/list/threat_detected = round(starting_threat)
+	var/midround_threat = round(midround_starting_threat)
+	var/likelihood
 
 	switch(threat_detected)
 		if(0 to 19)
@@ -137,6 +139,21 @@
 			intercepttext += "<b>Impending Doom</b></center><BR>"
 			intercepttext += "Your station is somehow in the middle of hostile territory, in clear view of any enemy of the corporation. Your likelihood to survive is low, and station destruction is expected and almost inevitable. Secure any sensitive material and neutralize any enemy you will come across. It is important that you at least try to maintain the station.<BR>"
 			intercepttext += "Good luck."
+
+	switch(midround_threat)
+		if(0 to 9)
+			likelihood = "very low"
+		if(10 to 19)
+			likelihood = "low"
+		if(20 to 39)
+			likelihood = "average"
+		if(40 to 59)
+			likelihood = "high"
+		if(60 to 100)
+			likelihood = "very high"
+
+	intercepttext += "<BR><BR>In addition, the risks of additional enemies of the corporation assaulting the station are <b>[likelihood]</b>."
+
 
 	intercepttext += "</body></html>"
 


### PR DESCRIPTION
Suggested.
- Very Low = 0-9 threat
- Low = 10-19 threat
- Average = 20-39 threat
- High = 40-59 threat
- Very High = 60-100 threat.

These rankings are mostly regarding the severity of what sort of antags can spawn. At around 35 threat nuke ops can start spawning if the round conditions allow for it, blob at 45.

![paper](https://github.com/vgstation-coders/vgstation13/assets/41342767/5137d291-fb60-4785-bfda-3c6aebfcb554)



:cl:
 * rscadd:  The threat report paper at the communication consoles will now also show a rough estimate of how likely it is for additional enemies of the station to appear.