### PR TITLE
Vampire's hypnotise ability works instantly even when the target is not incapacitated, previously 1 second.

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -675,7 +675,3 @@
 				to_chat(M.current, "<span class='warning'>An holy artifact protects [src]!</span>")
 				success = FALSE
 	return success
-
-// If the target is weakened, the spells take less time to complete.
-/mob/living/carbon/proc/get_vamp_enhancements()
-	return ((knockdown ? 2 : 0) + (stunned ? 1 : 0) + (sleeping || paralysis ? 3 : 0))

--- a/code/modules/spells/targeted/hypnotise.dm
+++ b/code/modules/spells/targeted/hypnotise.dm
@@ -1,6 +1,6 @@
 /spell/targeted/hypnotise
 	name = "Hypnotise (10)"
-	desc = "A piercing stare that incapacitates your victim for a good length of time."
+	desc = "A piercing stare that paralyzes your victim for a good length of time."
 	abbreviation = "HN"
 
 	school = "vampire"
@@ -60,13 +60,9 @@
 		if ((C.sdisabilities & BLIND) || (C.sight & BLIND))
 			to_chat(user, "<span class='warning'>\the [C] is blind!</span>")
 			return FALSE
-		if(do_mob(user, C, 10 - C.get_vamp_enhancements()))
-			to_chat(user, "<span class='warning'>Your piercing gaze knocks out \the [C].</span>")
-			to_chat(C, "<span class='sinister'>You find yourself unable to move and barely able to speak.</span>")
-			apply_spell_damage(target)
-		else
-			to_chat(user, "<span class='warning'>You broke your gaze.</span>")
-			return FALSE
+		to_chat(user, "<span class='warning'>Your piercing gaze paralyzes \the [C].</span>")
+		to_chat(C, "<span class='sinister'>You find yourself unable to move and barely able to speak.</span>")
+		apply_spell_damage(target)
 	var/datum/role/vampire/V = isvampire(user)
 	if (V)
 		V.remove_blood(blood_cost)


### PR DESCRIPTION
It takes 1 second without the target being incapacitated for the hypnosis to work. It's basically unnecessary.
Arguably a quality of life change.

PS. The target was not made aware that there was an attempt to use the ability on them if it failed.

:cl:
 * tweak: The vampire's hypnotise ability works instantly even when the target is not incapacitated. If the target was not incapacitated in any way it would have taken 1 second which is a negligible difference.
 * spellcheck: Changed the hypnotise ability descriptions to better emphasize that the target is paralyzed.
