### PR TITLE
Grue's "Drain Light" ability affects the red color more

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -654,9 +654,11 @@
 			if(!mute)
 				to_chat(src, "<span class='warning'>You are too hungry to keep draining light...")
 	return FALSE
-
+ // Light drain color is meant to compensate for grue vision being attuned too much to red,
+ // which would make the red color visually extremely bright when affected by shadow drain.
+ // As a consequence, it drains the red color from its surroundings. Spooky.
 /mob/living/simple_animal/hostile/grue/proc/drainlight_set()	//Set the strength of light drain.
-	set_light(7 + eatencount, -3 * eatencount - 3, GRUE_BLOOD)	//Eating sentients makes the drain more powerful.
+	set_light(7 + eatencount, -3 * eatencount - 3, "#872728")	//Eating sentients makes the drain more powerful.
 
 //Ventcrawling and hiding, only for gruespawn
 /mob/living/simple_animal/hostile/grue/proc/ventcrawl()


### PR DESCRIPTION
This also fixes a bug related to grue vision where the "drain light" ability would drain light but wouldn't drain all the red properly, causing it to become extremely bright and basically hard to see in unless the ability was sufficiently strong enough to reduce it enough.

Fixes #32940

:cl:
 * bugfix: Fixed a bug where grues would see an extremely bright red color in areas with intense red light (such as flares) that were being affected by the "drain light" ability, which was caused by the fact that grues see red far better but the ability would drain all other colors far faster, leaving nothing but the red color.
 * tweak: The grue's "drain light" ability now drains the red color from a larger area, and more intensely.