### PR TITLE
Sets Reasonable Max Values on Grue Light Drain

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -656,7 +656,7 @@
 	return FALSE
 
 /mob/living/simple_animal/hostile/grue/proc/drainlight_set()	//Set the strength of light drain.
-	set_light(7 + eatencount, max(-15, -3 * eatencount - 3), GRUE_BLOOD)	//Eating sentients makes the drain more powerful.
+	set_light(max(10, 7 + eatencount), max(-15, -3 * eatencount - 3), GRUE_BLOOD)	//Eating sentients makes the drain more powerful.
 
 //Ventcrawling and hiding, only for gruespawn
 /mob/living/simple_animal/hostile/grue/proc/ventcrawl()

--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -656,7 +656,7 @@
 	return FALSE
 
 /mob/living/simple_animal/hostile/grue/proc/drainlight_set()	//Set the strength of light drain.
-	set_light(7 + eatencount, -3 * eatencount - 3, GRUE_BLOOD)	//Eating sentients makes the drain more powerful.
+	set_light(7 + eatencount, max(-15, -3 * eatencount - 3), GRUE_BLOOD)	//Eating sentients makes the drain more powerful.
 
 //Ventcrawling and hiding, only for gruespawn
 /mob/living/simple_animal/hostile/grue/proc/ventcrawl()


### PR DESCRIPTION
## What this does
Caps the max range on Light drain to 10 tiles for Grue's regardless of how many bodies they have eaten.
Caps the max strength of light drain to -21 regardless of body count (This still requires you to have over 7 flashlights or more powerful light sources to deal damage to the Grue at max strength)

## Why it's good
Grue is a snowballing Antag, that's why it can be fun however once they reached high body counts it became near impossible to even see them due to drain light. This combined with their uncapped damage and speed made it exceptionally busted, this PR keeps them strong but gives the station a chance to fight back if they are well prepared.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Grue light drain range & power no has a hard limit of 10 tiles

