### PR TITLE
Tile replacing shortcut

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -529,6 +529,12 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 					make_tiled_floor(T)
 			else
 				to_chat(user, "<span class='warning'>This section is too damaged to support a tile. Use a welder to fix the damage.</span>")
+		else if(iscrowbar(user.get_inactive_hand()))
+			var/obj/item/stack/tile/T = C
+			if(T.material == floor_tile.material)
+				return
+			if(T.use(1))
+				make_tiled_floor(T)
 	else if(isshovel(C))
 		if(is_grass_floor())
 			playsound(src, 'sound/items/shovel.ogg', 50, 1)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -529,12 +529,6 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 					make_tiled_floor(T)
 			else
 				to_chat(user, "<span class='warning'>This section is too damaged to support a tile. Use a welder to fix the damage.</span>")
-		else if(iscrowbar(user.get_inactive_hand()))
-			var/obj/item/stack/tile/T = C
-			if(T.material == floor_tile.material)
-				return
-			if(T.use(1))
-				make_tiled_floor(T)
 	else if(isshovel(C))
 		if(is_grass_floor())
 			playsound(src, 'sound/items/shovel.ogg', 50, 1)


### PR DESCRIPTION
## What this does
You can now replace tiles quickly by holding the stack of tiles in your main hand & a crowbar in your off hand. 
This will consume both tiles. See Gif for example
![tiles gif](https://github.com/vgstation-coders/vgstation13/assets/102815299/2da4df44-005d-41d6-b7f9-89fac95cf2a9)


## Why it's good
There's no good way to replace a lot of tiles on station, which can make bar building & other forms of construction tedious. 
This makes the process a bit quicker.

## Changelog
:cl:
 * rscadd: You can now replace tiles quickly by holding the stack of tiles in your main hand & a crowbar in your off hand. (This will consume the tile on the floor as well)
