### PR TITLE
Fixes the emergency shuttle panel and lets admins crash escape pods into the shuttle

### DIFF
--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -144,6 +144,7 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 			if(!S.move_to_dock(S.transit_port, 0))
 				message_admins("Warning: [S] failed to move to transit.")
 		if("shuttle")
+			S.crashing_this_pod = 1
 			S.crash_into_shuttle()
 			playsound(shuttle.linked_port, 'sound/misc/weather_warning.ogg', 80, 0, 7, 0, 0)
 

--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -143,6 +143,10 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 		if("transit")
 			if(!S.move_to_dock(S.transit_port, 0))
 				message_admins("Warning: [S] failed to move to transit.")
+		if("shuttle")
+			S.crash_into_shuttle()
+			playsound(shuttle.linked_port, 'sound/misc/weather_warning.ogg', 80, 0, 7, 0, 0)
+
 	spawn()
 		for(var/obj/machinery/door/D in S.linked_area)
 			if(destination == "transit" || destination == "shuttle")

--- a/code/game/shuttles/emergency.dm
+++ b/code/game/shuttles/emergency.dm
@@ -60,9 +60,9 @@ var/global/datum/shuttle/escape/escape_shuttle = new(starting_area=/area/shuttle
 	.=..()
 	emergency_shuttle.escape_pods.Add(src)
 	podcomputer = locate(/obj/machinery/podcomputer) in linked_area
-	if(podcomputer)	
+	if(podcomputer)
 		podcomputer.linked_pod = src
-	
+
 	// I fucking hate shuttle wall smoothing it is such an annoying feature that only causes problems
 
 
@@ -74,7 +74,7 @@ var/global/datum/shuttle/escape/escape_shuttle = new(starting_area=/area/shuttle
 /datum/shuttle/escape/pod/proc/crash_into_shuttle()
 	if(!crashing_this_pod)
 		return
-		
+
 	crashing_this_pod = 0
 
 	if(!dock_shuttle)
@@ -94,14 +94,14 @@ var/global/datum/shuttle/escape/escape_shuttle = new(starting_area=/area/shuttle
 		playsound(dock_shuttle, 'sound/machines/hyperspace_begin.ogg', 60, 0, 0, 0, 0)
 
 		spawn(5 SECONDS)
-	
+
 		if(!move_to_dock(dock_shuttle, 0, 180))
 			message_admins("Warning: [src] failed to crash into shuttle.")
 		else
 			explosion(get_turf(dock_shuttle), 2, 3, 4, 6)
 
 			for(var/mob/living/M in emergency_shuttle.shuttle.linked_area)
-				shake_camera(M, 10, 1) 
+				shake_camera(M, 10, 1)
 				if(iscarbon(M) || !M.anchored)
 					M.Knockdown(3)
 
@@ -109,7 +109,7 @@ var/global/datum/shuttle/escape/escape_shuttle = new(starting_area=/area/shuttle
 			// The pod crashed into the shuttle. Make it part of the shuttle
 			// Automatic wall smoothing is gay and causes the pod to 'merge' with the shuttle visually
 			// instead of wasting time solving an issue caused by a worthless feature im going to cheat
-			
+
 			spawn(2 SECONDS)
 				for(var/turf/T in linked_area)
 					T.set_area(emergency_shuttle.shuttle.linked_area)

--- a/code/modules/admin/emergency_shuttle_panel.dm
+++ b/code/modules/admin/emergency_shuttle_panel.dm
@@ -57,11 +57,13 @@
 	dat += "<h2>Escape Pods Control</h2>"
 	for (var/pod in emergency_shuttle.escape_pods)
 		var/datum/shuttle/escape/S = pod
-		var/turf/T = pick(S.linked_area.area_turfs)
-		dat += "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>[S.linked_area.name]</a> : [(emergency_shuttle.escape_pods[pod] == "station") ? "<b>station</b>" : "<a href='?src=\ref[src];move_escape_pod=\ref[pod];move_destination=station'>station</a>"] - [(emergency_shuttle.escape_pods[pod] == "transit") ? "<b>transit</b>" : "<a href='?src=\ref[src];move_escape_pod=\ref[pod];move_destination=transit'>transit</a>"] - [(emergency_shuttle.escape_pods[pod] == "centcom") ? "<b>centcom</b>" : "<a href='?src=\ref[src];move_escape_pod=\ref[pod];move_destination=centcom'>centcom</a>"]<br>"
-
+		if (S.linked_area.area_turfs.len > 0)
+			var/turf/T = pick(S.linked_area.area_turfs)
+			dat += "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>[S.linked_area.name]</a> : [(emergency_shuttle.escape_pods[pod] == "station") ? "<b>station</b>" : "<a href='?src=\ref[src];move_escape_pod=\ref[pod];move_destination=station'>station</a>"] - [(emergency_shuttle.escape_pods[pod] == "transit") ? "<b>transit</b>" : "<a href='?src=\ref[src];move_escape_pod=\ref[pod];move_destination=transit'>transit</a>"] - [(emergency_shuttle.escape_pods[pod] == "centcom") ? "<b>centcom</b>" : "<a href='?src=\ref[src];move_escape_pod=\ref[pod];move_destination=centcom'>centcom</a>"] - <a href='?src=\ref[src];move_escape_pod=\ref[pod];move_destination=shuttle'>crash into shuttle</a><br>"
+		else
+			dat += "<i>[S.linked_area.name] : missing on current map</i><br>"
 	if (emergency_shuttle.escape_pods.len > 1)
-		dat += "Move All Pods : <a href='?src=\ref[src];move_escape_pod=all;move_destination=station'>station</a> - <a href='?src=\ref[src];move_escape_pod=all;move_destination=transit'>transit</a> - <a href='?src=\ref[src];move_escape_pod=all;move_destination=centcom'>centcom</a><br>"
+		dat += "Move All Pods : <a href='?src=\ref[src];move_escape_pod=all;move_destination=station'>station</a> - <a href='?src=\ref[src];move_escape_pod=all;move_destination=transit'>transit</a> - <a href='?src=\ref[src];move_escape_pod=all;move_destination=centcom'>centcom</a> - <a href='?src=\ref[src];move_escape_pod=all;move_destination=shuttle'>crash into shuttle</a><br>"
 
 	dat += "</body></html>"
 	usr << browse(dat, "window=emergencyshuttle;size=440x500")


### PR DESCRIPTION
Fixes #34961

```
[13:38:43] Runtime in code/modules/admin/emergency_shuttle_panel.dm, line 60: pick() from empty list
proc name: emergency shuttle panel (/datum/admins/proc/emergency_shuttle_panel)
usr: Keegan Bynum (sacredatom) (/mob/dead/observer)
usr.loc: The reinforced wall (240, 292, 1) (/turf/simulated/wall/r_wall)
src: /datum/admins (/datum/admins)
call stack:
/datum/admins (/datum/admins): emergency shuttle panel()
SacredAtom (/client): Emergency Shuttle Panel()
```

The issue was that the panel runtimes when you try to open it on a map that doesn't uses all 5 escape pods. When a pod isn't featured on the map the panel now adapts accordingly.

Also since Pods have obtained a brand new possible destination since I last touched the panel I figured I might as well add it there.

![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/f2a6c083-1fed-4d4e-8fb5-68fc39917802)


:cl:
* bugfix: Fixed admins being unable to open the Emergency Shuttle Panel
* rscadd: Admins can now manually crash pods into the emergency shuttle