### PR TITLE
fix plasma mod oversight, overhaul to rigsuit mod functions

### DIFF
--- a/code/game/machinery/suit_modifier.dm
+++ b/code/game/machinery/suit_modifier.dm
@@ -232,7 +232,7 @@
 	var/obj/item/clothing/suit/space/rig/R = H.is_wearing_item(/obj/item/clothing/suit/space/rig, slot_wear_suit)
 	R.deactivate_suit()
 	for(var/obj/item/rig_module/RM in modules_to_install)
-		if(locate(RM.type) in R.modules) //One already installed
+		if(!RM.can_install(R)) //more versatile check, allows for custom install conditions.
 			continue
 		if(do_after(H, src, 8 SECONDS / apply_multiplier, needhand = FALSE))
 			say("Installing [RM] into \the [R].", class = "binaryradio")

--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -11,6 +11,9 @@
 	rig = null
 	..()
 
+/obj/item/rig_module/proc/can_install(var/obj/item/clothing/suit/space/rig/target)
+   return !(locate(type) in target.modules) //by default only allow one module of a type
+
 /obj/item/rig_module/proc/examine_addition(mob/user)
 	return
 
@@ -162,6 +165,12 @@
 		rig.H.clothing_flags &= ~PLASMAGUARD
 	..()
 
+/obj/item/rig_module/plasma_proof/can_install(var/obj/item/clothing/suit/space/rig/target)
+   if(!..())
+      return FALSE
+   if(target.clothing_flags & PLASMAGUARD)
+      return FALSE
+   return TRUE
 
 //Muscle tissue/Hulk module
 /obj/item/rig_module/muscle_tissue


### PR DESCRIPTION
[bugfix]

## What this does
FROG MAN DID CODE (see:  #33648)

## Why it's good
Fixes an oversight with the plasma seal mod which overwrites suits which are already plasma sealed
extends the functionality of rigsuit mod checks

## Changelog
:cl:
 * bugfix: Fixed the plasma suit mod being able to be applied to suits that are already sealed
 * rscadd: rigsuit mods can now use custom install conditions
