### PR TITLE
Buffs phylactery

### DIFF
--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -201,7 +201,7 @@
 	if(iswizard(user)) //Wizards are scholars
 		to_chat(user, "<span class='notice'>This is a phylactery! Whoever is bound to it will come back as a lich wherever the phylactery may be, as long as it is charged.</span>")
 		to_chat(user, "<span class='notice'>You can charge it using filled soulstones. The more charges you have, the faster you will revive.</span>")
-		to_chat(user, "<span class='notice'>The phylactery will revive you about ten times faster if you are close to it when perishing.</span>")
+		to_chat(user, "<span class='notice'>The phylactery will revive you faster the closer you are to it when perishing, up to ten times faster if you are 3 tiles away from it.</span>")
 
 /obj/item/phylactery/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/soulstone))
@@ -271,8 +271,8 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/lightpurple(H), slot_w_uniform)
 		original.mind.transfer_to(H) // rebinding on transfer now handled by mind
 		var/release_time = round(rand(60 SECONDS, 120 SECONDS)/charges, 10) //In deciseconds
-		if(original in range(3, src))
-			release_time = round(release_time/10, 10) //Make revival 10x faster if the lich is close to the phylactery
+		var/distance = get_dist(get_turf(src), get_turf(original)) //Make the revival faster the closer the user is to the phylactery
+		release_time = round(release_time/clamp(16-distance*2,1,10), 10) //In increments of 2, starting at 2x when 7 tiles away and ending at 10x when 3 tiles away
 		if(!body_destroyed)
 			original.dust(TRUE)
 		H.Paralyse(release_time/20) //Divide by 20 because Paralyse goes down by 1 every Life() tick (roughly every 2 secs)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -198,9 +198,10 @@
 	..()
 	if(user.mind == bound_mind)
 		to_chat(user, "<span class='notice'>It has [charges ? "[charges]" : "no"] charges left!</span>")
-		if(iswizard(user)) //Wizards are scholars
-			to_chat(user, "<span class='notice'>You can charge it using filled soulstones. The more charges you have, the faster you will revive.</span>")
-			to_chat(user, "<span class='notice'>The phylactery will revive you about ten times faster if you are close to it when perishing.</span>")
+	if(iswizard(user)) //Wizards are scholars
+		to_chat(user, "<span class='notice'>This is a phylactery! Whoever is bound to it will come back as a lich wherever the phylactery may be, as long as it is charged.</span>")
+		to_chat(user, "<span class='notice'>You can charge it using filled soulstones. The more charges you have, the faster you will revive.</span>")
+		to_chat(user, "<span class='notice'>The phylactery will revive you about ten times faster if you are close to it when perishing.</span>")
 
 /obj/item/phylactery/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/soulstone))

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -196,8 +196,11 @@
 
 /obj/item/phylactery/examine(mob/user, size, show_name)
 	..()
-	if(iswizard(user))
-		to_chat(user, "<span class='sinister'>You can use charged soulstones to refill it. The more charges you have, the faster you will revive.</span>")
+	if(user.mind == bound_mind)
+		to_chat(user, "<span class='notice'>It has [charges ? "[charges]" : "no"] charges left!</span>")
+		if(iswizard(user)) //Wizards are scholars
+			to_chat(user, "<span class='notice'>You can charge it using filled soulstones. The more charges you have, the faster you will revive.</span>")
+			to_chat(user, "<span class='notice'>The phylactery will revive you about ten times faster if you are close to it when perishing.</span>")
 
 /obj/item/phylactery/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/soulstone))
@@ -266,11 +269,15 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H), slot_shoes)
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/lightpurple(H), slot_w_uniform)
 		original.mind.transfer_to(H) // rebinding on transfer now handled by mind
-		if(!body_destroyed)
-			original.dust()
 		var/release_time = round(rand(60 SECONDS, 120 SECONDS)/charges, 10) //In deciseconds
+		if(original in range(3, src))
+			release_time = round(release_time/10, 10) //Make revival 10x faster if the lich is close to the phylactery
+		if(!body_destroyed)
+			original.dust(TRUE)
 		H.Paralyse(release_time/20) //Divide by 20 because Paralyse goes down by 1 every Life() tick (roughly every 2 secs)
 		to_chat(H, "<span class = 'notice'>\The [src] will permit you exit in [release_time/10] seconds.</span>")
+		if(charges < 2) //It will get reduced from 1 to 0 further in the code, and it is instead done here because H is not defined a layer above and the original is gone
+			to_chat(H, "<span class='warning'>\The [src] is devoid of any power and will fail to revive you if it not recharged with souls.</span>")
 		spawn(release_time)
 			to_chat(H, "<span class = 'notice'>\The [src] permits you exit from it.</span>")
 			H.forceMove(get_turf(src))

--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -320,7 +320,7 @@
 /datum/spellbook_artifact/phylactery
 	name = "phylactery"
 	desc = "Creates a soulbinding artifact that, upon the death of the user, resurrects them as best it can. You must bind yourself to this through making an incision on your palm, holding the phylactery in that hand, and squeezing it."
-	spawned_items = list(/obj/item/phylactery, /obj/item/clothing/head/wizard/lich, /obj/item/clothing/suit/wizrobe/lich)
+	spawned_items = list(/obj/item/phylactery, /obj/item/clothing/head/wizard/lich, /obj/item/clothing/suit/wizrobe/lich, /obj/item/soulstone)
 
 
 /datum/spellbook_artifact/darkness


### PR DESCRIPTION
- Now comes with a soulstone when purchased.

I intended to have the phylactery be used directly to harvest souls but it's actually pretty elaborate to a degree, the whole "check to see if the body has a mind tied to it", "check to see if you can do it to heads", the sounds made when harvesting and all that. It's easier to just leave the soulstone as a middle man.

- The user will revive progressively faster the closer the phylactery is to them, up to 10x faster if the phylactery is within 3 tiles of them.

This will give aspiring liches the encouragement to keep the phylactery on their person. Normally it would be borderline suicidal, especially because the user's ashing would also automatically destroy the phylactery, but this should make things more interesting, and riskier.
The limit of how fast the phylactery will revive is 2x at up to 7 tiles away.

- The old body will now drop all of its items instead of being ashed into nothingness.

I intended to have the body brought directly to the phylactery without ashing it but after some deliberation such as with time shenanigans (what happens if someone dies and then rewinds?) I decided it would be more feasible to simply allow the items to be preserved rather than have the code go through all these hoops. That also means all those fancy artifacts you can buy, especially as an aspiring necromancer, won't go up in smokes all of a sudden.

- Improved feedback

The wizard-only info has been expanded and is also only available to wizards if they are bound to it. Regular people who are bound to it can see how many charges it has. It also has a warning message when reviving about how it has no charges left and must be recharged in order to continue functioning.


:cl:
 * rscadd: The phylactery purchase in the wizard's spellbook now comes with a complementary soulstone.
 * rscadd: The phylactery will revive its user faster the closer the user is to it, up to 10x faster if the user is within a 3 tile distance of it and 2x faster if the user is within a 7 tile distance of it.
 * tweak: The old body that is destroyed in the process of reforming in a phylactery will now drop all of its contents instead of being obliterated.
 * tweak: Phylacteries now provide some additional information to both their recipients and wizards.
