### PR TITLE
Tweaks Bound Object

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -507,3 +507,12 @@
     for(var/a in L)
         if(max == null || L[a] > max) max = L[a]
     return max
+
+//Convert a list of paths into a list of object names
+/proc/types_to_english_list(var/list/L)
+	var/list/names = list()
+	for(var/P in L)
+		if(!ispath(P))
+			continue
+		names += "\the [P:name]"
+	return english_list(names)

--- a/code/modules/spells/targeted/recall.dm
+++ b/code/modules/spells/targeted/recall.dm
@@ -7,9 +7,11 @@
 
 	school = "abjuration"
 	charge_max = 100
+	minimum_charge = 10 //1 second delay
 	spell_flags = SELECTABLE | WAIT_FOR_CLICK
 	hud_state = "wiz_bound"
-	level_max = list(Sp_TOTAL = 3, Sp_SPEED = 2, Sp_POWER = 1)
+	level_max = list(Sp_TOTAL = 4, Sp_SPEED = 2, Sp_POWER = 2)
+	price = 0.5 * Sp_BASE_PRICE
 
 	var/has_object = 0
 	var/obj/bound
@@ -46,7 +48,18 @@
 		/obj/machinery/media/receiver/boombox/wallmount,		//sound systems
 		/obj/machinery/keycard_auth,							//keycard authentication devices
 		)
+	//Generally extremely dangerous things that could spell doom and devastation for anyone nearby, possibly the wizard too
+	var/list/empower_limited = list(
+		/obj/machinery/singularity,
+		/obj/machinery/power/supermatter,
+	)
 
+/spell/targeted/bound_object/get_upgrade_price(upgrade_type)
+	switch(upgrade_type)
+		if(Sp_SPEED)
+			return 5
+		if(Sp_POWER)
+			return 20
 
 /spell/targeted/bound_object/is_valid_target(obj/target, mob/user, options, bypass_range = 0)
 	if(!istype(target))
@@ -59,7 +72,6 @@
 	for(var/J in prohibited)
 		if(istype(target, J))
 			return 0
-
 	return target
 
 /spell/targeted/bound_object/before_channel(mob/user)
@@ -93,6 +105,11 @@
 /spell/targeted/bound_object/cast(list/targets, mob/user = user)
 	for(var/obj/target in targets)
 		if(!has_object)
+			if(spell_levels[Sp_POWER] < 2) //Moving this check here because if it returned 0 on is_valid_target it would force the character to touch it if in range. Ouch.
+				for(var/E in empower_limited)
+					if(istype(target, E))
+						to_chat(user, "<span class='warning'>This is too powerful to bind to yourself. Empower your spell sufficiently enough first!</span>")
+						return 0
 			has_object = 1
 			bound = target
 			bound_icon = image(target.icon, target.icon_state, layer = HUD_ITEM_LAYER)
@@ -102,16 +119,24 @@
 	return 1
 
 /spell/targeted/bound_object/empower_spell()
-	spell_levels[Sp_POWER]++
-	allow_anchored = 1
-
-	var/upgrade_desc = "You have reduced the restrictions on your binding."
-
+	var/upgrade_desc
+	if(spell_levels[Sp_POWER] == 0)
+		spell_levels[Sp_POWER]++
+		allow_anchored = 1
+		upgrade_desc = "You have reduced the restrictions on your binding."
+	else
+		spell_levels[Sp_POWER]++
+		upgrade_desc = "You can now bind far more destructive objects to yourself."
 	return upgrade_desc
 
 /spell/targeted/bound_object/get_upgrade_info(upgrade_type, level)
 	if(upgrade_type == Sp_POWER)
-		return "Increases your binding skill, allowing otherwise immobile structures and machines to be moved."
+		if(spell_levels[Sp_POWER] == 0)
+			return "Increases your binding skill, allowing otherwise immobile structures and machines to be moved."
+		if(spell_levels[Sp_POWER] == 1)
+			return "Further increases your binding skill, allowing you to bind certain incredibly destructive objects."
+		else
+			return "You can already bind a great amount of things."
 	return ..()
 
 /spell/targeted/bound_object/on_right_click(mob/user)

--- a/code/modules/spells/targeted/recall.dm
+++ b/code/modules/spells/targeted/recall.dm
@@ -134,7 +134,7 @@
 		if(spell_levels[Sp_POWER] == 0)
 			return "Increases your binding skill, allowing otherwise immobile structures and machines to be moved."
 		if(spell_levels[Sp_POWER] == 1)
-			return "Further increases your binding skill, allowing you to bind certain incredibly destructive objects."
+			return "Further increases your binding skill, allowing you to bind [types_to_english_list(empower_limited)]."
 		else
 			return "You can already bind a great amount of things."
 	return ..()


### PR DESCRIPTION
Thanks to @Kurfursten for help!

Halved price cost but it needs a second empowerment to bind the singularity and supermatter.

Now I know what you're thinking, "this is removing fun!" but I assure you that the reason I did this change is because I believe the cost is too high for how much of a generic effect it is. It is just "you don't lose an object you bound to yourself" which is amazing if you want to use a staff or something precious you found, but very few people take it because of its price point. For 20 points you can HAVE some innate, dangerous spell as your weapon instead of binding a specific gun as your weapon. I also believe that if I simply halved the cost everyone would get mad because you can use it on the singularity to summon it instantly to destroy everything and people could believe it could lead to more of that, so this is more of a preemptive tradeoff. If people want it enough I can remove the empowerment limitation while keeping the discount. As it is it requires 50 spell points total to be able to bind the singularity and supermatter (buying the spell which is 10 points and buying two empowerment levels which is 20 each).

Also added a minimum cooldown of 1 second for sanity.



:cl:
 * tweak: The "Bound Object" spell now costs 10 points instead of 20.
 * tweak: The Gravitational Singularity and the Supermatter now require a new second level of "Bound Object" empowerment to be able to be bound
 * tweak: Added a minimum of 1 second cooldown to the "Bound Object" spell.