### PR TITLE
Fixes trader lockboxes

### DIFF
--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -470,6 +470,7 @@
 	health = 200
 	storage_slots = 1
 	fits_max_w_class = W_CLASS_LARGE
+	req_one_access = null
 
 /obj/item/weapon/storage/lockbox/advanced/ex_act()
 	react()


### PR DESCRIPTION
fixes #35007
🆑 
* bugfix: Fixed an oversight that required you to have warden access to open trader lockboxes (ricochet taser, energy shotgun) - now only requires security.