### PR TITLE
Fix for preview function of library computer

### DIFF
--- a/code/modules/library/computers/checkout.dm
+++ b/code/modules/library/computers/checkout.dm
@@ -158,7 +158,7 @@
 
 				for(var/datum/cachedbook/CB in get_page(page_num))
 					var/author = CB.author
-					var/controls =  "<A href='?src=\ref[src];preview=[CB]'>\[Preview\]</A> <A href='?src=\ref[src];id=[CB.id]'>\[Order\]</A>"
+					var/controls =  "<A href='?src=\ref[src];preview=[CB.id]'>\[Preview\]</A> <A href='?src=\ref[src];id=[CB.id]'>\[Order\]</A>"
 					if(isAdminGhost(user))
 						author += " (<A style='color:red' href='?src=\ref[src];delbyckey=[ckey(CB.ckey)]'>[ckey(CB.ckey)])</A>)"
 					if(isAdminGhost(user) || allowed(user))
@@ -502,7 +502,7 @@
 			new the_manual_type(get_turf(src))
 
 	if(href_list["preview"])
-		var/datum/cachedbook/PVB = href_list["preview"]
+		var/datum/cachedbook/PVB = getItemByID(href_list["preview"], library_table)
 		if(!istype(PVB) || PVB.programmatic)
 			return
 		var/list/_http = world.Export("http://ss13.moe/index.php/book?id=[PVB.id]")


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
Fixes the library preview button. Closes #34682

Can see it here: 
![preview_functionality](https://github.com/vgstation-coders/vgstation13/assets/145183032/1791639b-0959-4694-9e34-ad94df59f7e4)


## Why it's good
We can preview books using the library computer instead of needing to print them out to read them.

## Changelog
:cl:
 * bugfix: Fixed the library preview button.
