### PR TITLE
Allows the powercell in the rapid crate sender to be removed

### DIFF
--- a/code/modules/telesci/rcs.dm
+++ b/code/modules/telesci/rcs.dm
@@ -120,7 +120,8 @@
 	else if(W.is_screwdriver(user))
 		if(cell)
 			cell.updateicon()
-			cell.forceMove(get_turf(src.loc))
+			cell.forceMove(get_turf(loc))
+			user.put_in_hands(cell)
 			cell = null
 			to_chat(user, "<span class='notice'>You remove the cell from the [src].</span>")
 			playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)

--- a/code/modules/telesci/rcs.dm
+++ b/code/modules/telesci/rcs.dm
@@ -94,7 +94,7 @@
 /obj/item/weapon/rcs/examine(mob/user)
 	..()
 	if(send_cost > 0)
-		to_chat(user, "<span class='info'>There are [round(cell.charge / send_cost)] charges left.</span>")
+		to_chat(user, "<span class='info'>There are [round(cell.charge / send_cost)] charges left in the powercell.</span>")
 
 /obj/item/weapon/rcs/Destroy()
 	if (cell)
@@ -116,6 +116,24 @@
 		emagged = 1
 		spark(src, 5)
 		to_chat(user, "<span class = 'caution'>You emag the RCS. Click on it to toggle between modes.</span>")
+
+	else if(W.is_screwdriver(user))
+		if(cell)
+			cell.updateicon()
+			cell.forceMove(get_turf(src.loc))
+			cell = null
+			to_chat(user, "<span class='notice'>You remove the cell from the [src].</span>")
+			playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
+			update_icon()
+	else if(ispowercell(W))
+		if(!cell)
+			if(user.drop_item(W, src))
+				cell = W
+				to_chat(user, "<span class='notice'>You install a cell in [src].</span>")
+				update_icon()
+				playsound(src, 'sound/items/Screwdriver2.ogg', 50, 1)
+		else
+			to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
 
 /obj/item/weapon/rcs/preattack(var/obj/structure/closet/crate/target, var/mob/user, var/proximity_flag, var/click_parameters)
 	if (!istype(target) || target.opened || !proximity_flag || !cell || teleporting)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
Allows the powercell inside an RCS to be removed with a screwdriver

## Why it's good
Currently the rapid crate sender (RCS) can only be charged by the weapon chargers, despite using an internal powercell. This allows you to remove the cell via a screwdriver and charge it on a standard powercell charger, exactly the same as screwdrivering a stun baton to remove its cell

If merged I will update the wiki

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: The powercell of the rapid crate sender (RCS) can now be removed with a screwdriver

