### PR TITLE
Wizard spell fixes

### DIFF
--- a/code/modules/spells/general/area_teleport.dm
+++ b/code/modules/spells/general/area_teleport.dm
@@ -37,6 +37,9 @@
 		A = pick(teleportlocs)
 
 	var/area/thearea = teleportlocs[A]
+	if(!thearea) //Wizard didn't pick an area
+		to_chat(holder, "<span class='warning'>You cancel the teleportation.</span>")
+		return
 
 	return list(thearea)
 

--- a/code/modules/spells/targeted/buttbots_revenge.dm
+++ b/code/modules/spells/targeted/buttbots_revenge.dm
@@ -15,6 +15,7 @@
 	level_max = list(Sp_TOTAL = 5, Sp_SPEED = 4, Sp_POWER = 1)
 	sparks_spread = 1
 	sparks_amt = 4
+	compatible_mobs = list(/mob/living/carbon/human,/mob/living/carbon/monkey)
 
 	amt_knockdown = 8
 	amt_stunned = 8

--- a/code/modules/spells/targeted/flesh_to_stone.dm
+++ b/code/modules/spells/targeted/flesh_to_stone.dm
@@ -14,6 +14,7 @@
 	invocation_type = SpI_SHOUT
 	amt_stunned = 5//just exists to make sure the statue "catches" them
 	cooldown_min = 200 //100 deciseconds reduction per rank
+	compatible_mobs = list(/mob/living)
 
 	hud_state = "wiz_statue"
 

--- a/code/modules/spells/targeted/genetic.dm
+++ b/code/modules/spells/targeted/genetic.dm
@@ -55,6 +55,7 @@ code\game\\dna\genes\goon_powers.dm
 
 	price = 0.5 * Sp_BASE_PRICE //Half of the normal spell price
 	user_type = USER_TYPE_WIZARD
+	compatible_mobs = list(/mob/living/carbon) //Silicons don't have DNA
 
 /spell/targeted/genetic/mutate
 	name = "Mutate"

--- a/code/modules/spells/targeted/heal.dm
+++ b/code/modules/spells/targeted/heal.dm
@@ -14,6 +14,7 @@
 	invocation_type = SpI_SHOUT
 	message = "<span class='sinister'>You feel refreshed.<span>"
 	level_max = list(Sp_TOTAL = 3, Sp_SPEED = 2, Sp_POWER = 1, Sp_RANGE = 1)
+	compatible_mobs = list(/mob/living)
 
 	max_targets = 1
 

--- a/code/modules/spells/targeted/ice_barrage.dm
+++ b/code/modules/spells/targeted/ice_barrage.dm
@@ -13,6 +13,7 @@
 	cooldown_min = 30
 
 	hud_state = "ice_barrage"
+	compatible_mobs = list(/mob/living)
 
 /spell/targeted/ice_barrage/cast(var/list/targets, mob/user)
 	..()

--- a/code/modules/spells/targeted/wrap.dm
+++ b/code/modules/spells/targeted/wrap.dm
@@ -12,6 +12,7 @@
 	invocation_type = SpI_SHOUT
 	amt_stunned = 5//just exists to make sure the giftwrap "catches" them
 	cooldown_min = 30 //100 deciseconds reduction per rank
+	compatible_mobs = list(/mob/living)
 
 	hud_state = "wrap"
 


### PR DESCRIPTION
- Fixes 6 spells so that targeting the floor with them won't put them on cooldown.
- Cancelling "Teleport" will no longer put it on cooldown.


:cl:
 * bugfix: The following Wizard spells can no longer use the floor as a target (in which case they had no effect and put the spell on cooldown): Buttbot's Revenge/Arse Nath, Flesh to Stone, Blind, Heal, Ice Barrage, Wrap.
 * bugfix: The Wizard's "Teleport" spell will no longer go on cooldown if it is cancelled.