### PR TITLE
Fixes silicons not having access to malfunctiong AI stats

### DIFF
--- a/code/datums/gamemode/role/malf/malf.dm
+++ b/code/datums/gamemode/role/malf/malf.dm
@@ -101,7 +101,7 @@ Once done, you will be able to interface with all systems, notably the onboard n
 /datum/role/malfAI/StatPanel()
 	stat(null, text("APCs hacked: [apcs.len]"))
 	stat(null, text("APC hack limit: [currently_hacking_apcs.len]/[apc_hacklimit]"))
-	stat(null, text("Machine hack limit: [currently_hacking_machines.len]/[apcs.len]")) //Machine limit is equal to APCs hacked
+	stat(null, text("Machine hack limit: [currently_hacking_machines.len]/[apcs.len + 1]")) //Machine limit is equal to APCs hacked, and +1 from innate malf AI hacking slot
 	stat(null, text("Processing power per minute: [apcs.len * apc_process_power * 30]")) // 0.03 * 30 (process ticks, a tick is ~2 seconds)
 
 ////////////////////////////////////////////////

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -284,11 +284,6 @@
 			if(R.activated)
 				stat("\The [R.name]", "Modules: [english_list(R.modules)]")
 
-		if (mind)
-			for (var/role in mind.antag_roles)
-				var/datum/role/R = mind.antag_roles[role]
-				stat(R.StatPanel())
-
 /mob/living/carbon/human/attack_slime(mob/living/carbon/slime/M as mob)
 	M.unarmed_attack_mob(src)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1919,3 +1919,11 @@ Thanks.
 	if(B.host_brain.ckey)
 		to_chat(src, "<span class='danger'>You send a punishing spike of psychic agony lancing into your host's brain.</span>")
 		to_chat(B.host_brain, "<span class='danger'><FONT size=3>Horrific, burning agony lances through you, ripping a soundless scream from your trapped mind!</FONT></span>")
+
+/mob/living/Stat()
+	..()
+	if(statpanel("Status"))
+		if(mind)
+			for(var/role in mind.antag_roles)
+				var/datum/role/R = mind.antag_roles[role]
+				stat(R.StatPanel())

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -227,10 +227,6 @@
 			var/F_stat = F.get_statpanel_addition()
 			if(F_stat)
 				stat(null, "[F_stat]")
-		if(mind)
-			for(var/role in mind.antag_roles)
-				var/datum/role/R = mind.antag_roles[role]
-				stat(R.StatPanel())
 
 // this function displays the stations manifest in a separate window
 /mob/living/silicon/proc/show_station_manifest()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -227,6 +227,10 @@
 			var/F_stat = F.get_statpanel_addition()
 			if(F_stat)
 				stat(null, "[F_stat]")
+		if(mind)
+			for(var/role in mind.antag_roles)
+				var/datum/role/R = mind.antag_roles[role]
+				stat(R.StatPanel())
 
 // this function displays the stations manifest in a separate window
 /mob/living/silicon/proc/show_station_manifest()


### PR DESCRIPTION
Only humans had a check for StatPanel(). Now all living mobs have them, including silicons.
Also changed a bit of the description of the machine hack limit

:cl:
 * bugfix: Malfunctioning AIs should now properly see their stats. The issue was that the code that added the stats was not being called, and the code that called it was instead human-exclusive. Now the code checks at all living mobs rather than just humans, which includes silicons.
 * bugfix: "Machine hack limit" status in the Malfunctioning AI's status bar will now properly reflect on the AI's innate hacking limit of 1, rather than starting off as "0/0".