### PR TITLE
Slightly reduces Liberator damage against blobs.

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -745,7 +745,7 @@ var/list/beam_master = list()
 	if(ishuman(A))
 		damage = 10
 	if(istype(A,/obj/effect/blob))
-		damage = 40
+		damage = 30
 		var/obj/effect/blob/B = A
 		var/splash_damage = damage/B.fire_resist - B.health
 		if(splash_damage > 0)


### PR DESCRIPTION
At first I have been at the receiving end of it, and I thought "man, this is unbeatable, how are blobs supposed to fight back against a swarm of these weapons? I should probably nerf it", worked a little on a PR like this but then thought "I don't know, maybe it isn't that bad" and didn't push it any further.

**Later on** I have been at the giving end of it. A man with a bag of holding full of Liberators firing directly towards the blob core. Weapon rechargers recharging [10 shots](https://github.com/vgstation-coders/vgstation13/pull/32236) in a matter of seconds (3 ticks in fact, or about 6 seconds at most; gun rechargers recharge at a rate of 100w per second and the battery has a max charge of 250w). The blob would taste about 50 liberator shots during every trip, and I single-handedly managed to destroy the blob core in this constant fire. It had no breathing room to make strong blobs as the lasers would instantly destroy any new blob it would make. That's when I realized that the Liberator was actually too strong against blobs.

This PR slightly reduces its damage (from 40 to 30), which will cause it to destroy a regular blob on hit but only severely damage another regular blob instead of destroying another regular blob outright (and if that damaged blob is hit then it will outright destroy another blob on hit due to splash damage), and it also goes from destroying a strong blob tile in 4 hits to 5 hits. It's a small change but this is also under the consideration of the general attitude players may have against blobs AKA "fuck blobs" and might be opposed to any more significant changes, if not this one.

:cl:
 * tweak: The Liberator is now slightly less effective against blobs.
