### PR TITLE
Malfunctioning AIs now have access to the "detonate upon destruction" upgrade again

### DIFF
--- a/code/datums/gamemode/role/malf/hackabilities.dm
+++ b/code/datums/gamemode/role/malf/hackabilities.dm
@@ -502,6 +502,19 @@
 
 //--------------------------------------------------------
 
+/datum/malfhack_ability/core/explode
+	name = "Explosive Core"
+	desc = "Rigs your core to explode upon your untimely deactivation."
+	cost = 20
+
+/datum/malfhack_ability/core/explode/activate(mob/living/silicon/ai/A)
+	if(!..())
+		return
+	A.explosive = TRUE
+	to_chat(A, "<span class='warning'>Your core will now detonate if it gets destroyed.</span>")
+
+//--------------------------------------------------------
+
 /datum/malfhack_ability/oneuse/emag
 	name = "Scramble"
 	desc = "Scramble the software on this machine, making it behave as if emagged."

--- a/code/datums/gamemode/role/malf/hackabilities.dm
+++ b/code/datums/gamemode/role/malf/hackabilities.dm
@@ -505,6 +505,7 @@
 /datum/malfhack_ability/core/explode
 	name = "Explosive Core"
 	desc = "Rigs your core to explode upon your untimely deactivation."
+	icon = "radial_alertboom"
 	cost = 20
 
 /datum/malfhack_ability/core/explode/activate(mob/living/silicon/ai/A)

--- a/code/datums/gamemode/role/malf/malf.dm
+++ b/code/datums/gamemode/role/malf/malf.dm
@@ -32,6 +32,7 @@
 		laws.malfunction()
 		malfAI.show_laws()
 		malfAI.DisplayUI("Malf")
+		malfAI.explosive = TRUE
 
 		var/list/abilities = subtypesof(/datum/malfhack_ability) - typesof(/datum/malfhack_ability/core) - /datum/malfhack_ability/toggle - /datum/malfhack_ability/oneuse
 		for(var/A in abilities)

--- a/code/datums/gamemode/role/malf/malf.dm
+++ b/code/datums/gamemode/role/malf/malf.dm
@@ -32,7 +32,6 @@
 		laws.malfunction()
 		malfAI.show_laws()
 		malfAI.DisplayUI("Malf")
-		malfAI.explosive = TRUE
 
 		var/list/abilities = subtypesof(/datum/malfhack_ability) - typesof(/datum/malfhack_ability/core) - /datum/malfhack_ability/toggle - /datum/malfhack_ability/oneuse
 		for(var/A in abilities)


### PR DESCRIPTION
A relatively obscure thing that used to happen before the AI rework was that malfunctioning AIs could buy an ability to explode upon being destroyed. I remembered this because I recalled a random vault in space that contained an NPC malfunctioning AI that I tried once to melee, but then it exploded. The code is still all there, in fact it was changed during the rework in order to play an alarm sound, but nothing actually calls for the AI to be set to explode anymore.
This PR fixes that.

:cl:
 * rscadd: Malfunctioning AIs now once again have access to an upgrade that rigs them to explode if they are deactivated, with a significant blast radius.