### PR TITLE
The credits screen will have a different song if the Malfunctioning AI wins

### DIFF
--- a/code/datums/gamemode/factions/malf.dm
+++ b/code/datums/gamemode/factions/malf.dm
@@ -38,7 +38,7 @@
 	..()
 	if (stage >= FACTION_ENDGAME)
 		var/living_ais = 0
-		var/datum/role/malfAI/M 
+		var/datum/role/malfAI/M
 		for (var/datum/role/R in members)
 			if(!R.antag.current)
 				continue
@@ -84,7 +84,7 @@
 You may now choose to detonate the nuclear device!</span>"})
 		M.takeover = TRUE
 		M.antag.DisplayUI("Malf")
-
+	ticker.malfunctioning_AI_victory = 1
 
 	return
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -43,6 +43,7 @@ var/datum/controller/gameticker/ticker
 	var/station_was_nuked
 	var/no_life_on_station
 	var/revolutionary_victory //If on, Castle can be voted if the conditions are right
+	var/malfunctioning_AI_victory //If on, will play a different credits song
 
 	var/list/datum/role/antag_types = list() // Associative list of all the antag types in the round (List[id] = roleNumber1) //Seems to be totally unused?
 

--- a/code/modules/credits/credits.dm
+++ b/code/modules/credits/credits.dm
@@ -290,7 +290,9 @@ var/global/datum/credits/end_credits = new
 //Currently only hosts one additional song
 /datum/credits/proc/determine_round_end_song()
 	var/list/candidates = list()
-	if(ticker.station_was_nuked)
+	if(ticker.malfunctioning_AI_victory)
+		candidates += "http://ss13.moe/media/source/roundend/credits/System_Shock_Elevator.mp3"
+	else if(ticker.station_was_nuked)
 		candidates += pick("http://ss13.moe/media/source/roundend/credits/RA2_Blow_It_Up.mp3",
 						"http://ss13.moe/media/source/roundend/credits/Castanets_You_Are_The_Blood.mp3",
 						"http://ss13.moe/media/source/roundend/credits/Julee_Cruise_Falling_Instrumental.mp3",


### PR DESCRIPTION
[System Shock's elevator theme](https://www.youtube.com/watch?v=-KdpmJP6W-E).

Requires changes to the media server prior to being merged. I have the audio file.

:cl:
 * rscadd: There is a new round-end credits song that plays when a Malfunctioning AI wins.