### PR TITLE
Catbeast fixes

### DIFF
--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -140,7 +140,7 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 	if(!A)
 		return // offstation
 	ticks_survived++
-	if(!(ticks_survived % 10) && ticks_survived < 150) //every 20 seconds, for 5 minutes
+	if(!(ticks_survived % 10) && !(ticks_survived > 150)) //every 20 seconds, for 5 minutes
 		increment_threat(SURVIVAL_THREAT)
 	if(!(A in areas_defiled))
 		increment_threat(DEFILE_THREAT)
@@ -163,7 +163,8 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 
 
 /datum/role/catbeast/proc/OnStation()
-	if(antag.current.z != map.zMainStation)
+	var/turf/T = get_turf(antag.current)
+	if(T.z != map.zMainStation)
 		return FALSE
 	var/area/A = get_area(antag.current)
 	if (isspace(A))

--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -32,7 +32,7 @@
 		D.threat_log += "[worldtime2text()]: Loose catbeast created."
 		D.threat_log += src //The actual reporting on threat it made comes from this entry
 	spawn(1.5 MINUTES)
-		if(antag.current.stat!=DEAD && OnStation())
+		if(antag.current.stat!=DEAD && OnStation() == -1)
 			command_alert("An escaped disease-ridden catbeast has been detected aboard your station. Crew should cooperate with security staff in its extermination or removal from the main station. Remember to get a medical checkup afterward in case of infection.", "Catbeast Detected",1)
 	return TRUE
 
@@ -136,9 +136,10 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 	..()
 	if(!iscatbeast(antag.current) || antag.current.gcDestroyed || antag.current.stat == DEAD)
 		return // dead or destroyed
-	var/area/A = OnStation()
-	if(!A)
-		return // offstation
+	var/on_station = OnStation()
+	if(!on_station || on_station == -1)
+		return // offstation or hiding
+	var/area/A = on_station
 	ticks_survived++
 	if(!(ticks_survived % 10) && !(ticks_survived > 150)) //every 20 seconds, for 5 minutes
 		increment_threat(SURVIVAL_THREAT)
@@ -164,8 +165,10 @@ var/list/catbeast_names = list("Meowth","Fluffy","Subject 246","Experiment 35a",
 
 /datum/role/catbeast/proc/OnStation()
 	var/turf/T = get_turf(antag.current)
-	if(T.z != map.zMainStation)
+	if(T.z != map.zMainStation) //Antag not on station's z-level
 		return FALSE
+	if(antag.current.z != map.zMainStation) //Antag is hiding in an object, but do not count them out of the station
+		return -1
 	var/area/A = get_area(antag.current)
 	if (isspace(A))
 		return FALSE


### PR DESCRIPTION
- Will properly generate a maximum of 15 threat points rather than 14.
- Fixes the ability to "dodge" an announcement.


:cl:
 * bugfix: Catbeasts will now properly generate a maximum of 15 threat points out of surviving rather than 14 threat points.
 * bugfix: Fixed a bug where catbeasts could prevent the announcement that announced them by hiding in a locker, which previously considered them "not on the station" for the purpose of whether the announcement should run.