### PR TITLE
Latejoin rulesets will now actually refund their threat cost properly if the candidate refused to be a role

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -503,6 +503,10 @@ var/stacking_limit = 90
 			if (latejoin_rule.persistent)
 				current_rules += latejoin_rule
 			. = TRUE
+		else //Actually it can fail here because latejoin prompts are optional and often called in the execute(), returns 0 if candidate refused
+			threat_log += "[worldtime2text()]: Rule [latejoin_rule.name] refunded [latejoin_rule.cost] (selected applicant refused)"
+			message_admins("DYNAMIC MODE: [latejoin_rule.name] failed to start due to the candidate refusing to play the role.")
+			refund_midround_threat(latejoin_rule.cost)
 	for (var/datum/dynamic_ruleset/latejoin/non_executed in drafted_rules)
 		non_executed.assigned.Cut()
 


### PR DESCRIPTION
The latejoin candidacy happens in the ruleset's execute(), but nothing in the code actually refunded the midround threat points properly if the latejoiner refused to become the role, meaning that it would basically vanish with the midround threat points and no antagonist. I picked this up after noticing an anomaly in a round where a "grue infestation" ruleset was played in the threat log but did not refund its 20 point cost.
This fixes it.

:cl:
 * bugfix: Fixed a bug where late-join rulesets (the prompt you may get to become an antagonist if you spawn in the game during the round) did not refund their Dynamic threat cost if the candidate refused to become an antagonist.
