### PR TITLE
Extended is no longer affected by Dynamic+

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -629,7 +629,7 @@ Assign your candidates in choose_candidates() instead.
 	required_pop = list(30,30,30,30,30,30,30,30,30,30)
 	required_candidates = 0
 	weight = BASE_RULESET_WEIGHT * 0.5
-	weight_category = "Extended"
+//	weight_category = "Extended" //Commented out in order to prevent it from having its weight boosted
 	cost = 0
 	requirements = list(0,0,0,0,0,0,0,0,0,0)
 	high_population_requirement = 101


### PR DESCRIPTION
AKA its weight will not be multiplied several times over the more rounds it doesn't roll.
I've noticed something unusual in the rate at which Extended rounds would appear and it is in my opinion that Extended rolls too often for it to be comfortable, what happens instead is that players go AFK because "oh no, it is _another_ Extended round where few things happen". This PR is aimed more at the general welfare of the player than anything.

:cl:
 * tweak: Extended will no longer be more likely to roll the more rounds there are where Extended hasn't rolled.
