### PR TITLE
Make wooden table parts materials and recycling type into wood

### DIFF
--- a/code/game/objects/items/weapons/table_rack_parts.dm
+++ b/code/game/objects/items/weapons/table_rack_parts.dm
@@ -104,6 +104,7 @@
 	name = "wooden table parts"
 	desc = "Keep away from fire."
 	icon_state = "wood_tableparts"
+	w_type = RECYK_WOOD
 	flags = 0
 	table_type = /obj/structure/table/woodentable
 	sheet_type = /obj/item/stack/sheet/wood

--- a/code/game/objects/items/weapons/table_rack_parts.dm
+++ b/code/game/objects/items/weapons/table_rack_parts.dm
@@ -104,6 +104,7 @@
 	name = "wooden table parts"
 	desc = "Keep away from fire."
 	icon_state = "wood_tableparts"
+	starting_materials = list(MAT_WOOD = 3750)
 	w_type = RECYK_WOOD
 	flags = 0
 	table_type = /obj/structure/table/woodentable


### PR DESCRIPTION
## What this does
This makes wooden table parts be made of wood in terms of materials and recycling category.

## Why it's good
Consistency with wooden table parts' woodenness.

## Changelog
:cl:
 * bugfix: Wooden table parts are made of wood.
