### PR TITLE
Fixes wizard bug/exploit that could allow for far faster spell recharging

### DIFF
--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -140,6 +140,8 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 					charge_counter--
 			else
 				charge_counter++
+		if(charge_counter >= charge_max)
+			return
 		sleep(1)
 	return
 


### PR DESCRIPTION
At some point I visited this bug more than a year ago (not exactly sure when) and couldn't really figure out what was wrong with it. Recently I've decided to pick it up again. Initially I believed the problem had to lie in the ability to perform the spell multiple times somehow, thus the approach was to add a delay to the spell button. It didn't work. Afterwards I realized that the problem lied in how process() does not double-check to see if the process() has already reached the charge limit.
The bug is thus: In the 0.1 second during which process() slept and the spell could be cast it was possible to cast the spell, consume the charge and by the time process() no longer slept it would see that there is no charge and continue charging alongside a new process() that would also charge the spell, causing multiplied recharging. This PR fixes it so that it quits charging the spell if the charge is sufficient enough to cast the spell before sleeping for 0.1 seconds.
I had my own share of fun with this bug in order to perform even more excessive amounts of Blinking but now the PR is here.

:cl:
 * bugfix: Fixed a wizard bug/exploit where wizards could cause a spell to recharge up to several times faster by clicking it at the right time (within 0.1 second of it having a full charge).