### PR TITLE
Printed paintings are no longer blank by default

### DIFF
--- a/code/modules/library/computers/remote_gallery_access.dm
+++ b/code/modules/library/computers/remote_gallery_access.dm
@@ -136,4 +136,5 @@
 	C.name = "[newbook.title] by [newbook.author]"
 	C.desc = newbook.description
 	C.set_painting_data(json2painting(newbook.content, newbook.title, newbook.author, newbook.description))
+	C.update_painting(1)
 	return C

--- a/code/modules/library/computers/remote_gallery_access.dm
+++ b/code/modules/library/computers/remote_gallery_access.dm
@@ -136,5 +136,5 @@
 	C.name = "[newbook.title] by [newbook.author]"
 	C.desc = newbook.description
 	C.set_painting_data(json2painting(newbook.content, newbook.title, newbook.author, newbook.description))
-	C.update_painting(1)
+	C.update_painting(TRUE)
 	return C


### PR DESCRIPTION
Thanks to BoHaynes for helping in nailing the problem down, as this couldn't be done in a personal server due to no database.
The painting is now properly updated when printed.

:cl:
 * bugfix: Printed paintings at the Remote Gallery Computer are no longer blank.