### PR TITLE
advanced lung toxin/sleep immunity

### DIFF
--- a/code/modules/organs/internal/lungs/filter.dm
+++ b/code/modules/organs/internal/lungs/filter.dm
@@ -10,22 +10,16 @@
 	gasses = list()
 	var/list/intake_settings=list(
 		GAS_OXYGEN = list(
-			new /datum/lung_gas/metabolizable(GAS_OXYGEN,            min_pp=16, max_pp=280),
+			new /datum/lung_gas/metabolizable(GAS_OXYGEN,            min_pp=8, max_pp=280),
 			new /datum/lung_gas/waste(GAS_CARBON,            max_pp=10),
-			new /datum/lung_gas/toxic(GAS_PLASMA,                    max_pp=5, max_pp_mask=0, reagent_id="plasma", reagent_mult=0.1),
-			new /datum/lung_gas/sleep_agent(GAS_SLEEPING, min_giggle_pp=1, min_para_pp=5, min_sleep_pp=10),
 		),
 		GAS_NITROGEN = list(
-			new /datum/lung_gas/metabolizable(GAS_NITROGEN,          min_pp=16, max_pp=280),
+			new /datum/lung_gas/metabolizable(GAS_NITROGEN,          min_pp=8, max_pp=280),
 			new /datum/lung_gas/waste(GAS_CARBON,            	max_pp=10), // I guess? Ideally it'd be some sort of nitrogen compound.  Maybe N2O?
-			new /datum/lung_gas/toxic(GAS_OXYGEN,                    max_pp=0.5, max_pp_mask=0, reagent_id=GAS_OXYGEN, reagent_mult=0.1),
-			new /datum/lung_gas/toxic(GAS_PLASMA,                    max_pp=5, max_pp_mask=0, reagent_id="plasma", reagent_mult=0.1),
-			new /datum/lung_gas/sleep_agent(GAS_SLEEPING, min_giggle_pp=1, min_para_pp=5, min_sleep_pp=10),
 		),
 		GAS_PLASMA = list(
-			new /datum/lung_gas/metabolizable(GAS_PLASMA, min_pp=16, max_pp=280),
+			new /datum/lung_gas/metabolizable(GAS_PLASMA, min_pp=8, max_pp=280),
 			new /datum/lung_gas/waste(GAS_OXYGEN,         max_pp=10),
-			new /datum/lung_gas/sleep_agent(GAS_SLEEPING, min_giggle_pp=1, min_para_pp=5, min_sleep_pp=10),
 		)
 	)
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
This buffs advanced lungs to totally filter out toxins and sleep chems. It also makes it so that those with advanced lungs need less of whatever chemical they need to breathe, to not suffocate. Closes #35046.

![image](https://github.com/vgstation-coders/vgstation13/assets/145183032/57fb5f75-335b-4fe3-a4d2-db315cedb85c)
![image](https://github.com/vgstation-coders/vgstation13/assets/145183032/ec3572db-f4fb-42e7-a949-e85298a176ea)



## Why it's good
<!-- Explain why you think these changes are good. -->
In #35046 consensus seemed to be that advanced lungs should be more powerful.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Advanced lung buffs.
