### PR TITLE
People can now walk on one leg.

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -194,6 +194,16 @@
 		var/mob/living/M = hit_atom
 		if(ishuman(M)) //if they're a human species
 			var/mob/living/carbon/human/H = M
+			if(!H.check_stand_ability()) //Target has no legs, how is this going to trip them up?
+				throw_failed()
+				return
+			var/leg_count //If one-legged, will halve the chance of getting caught by bolas
+			for(var/datum/organ/external/leg in H.get_organs(LIMB_LEFT_LEG, LIMB_RIGHT_LEG))
+				leg_count++
+			if(!prob(50*leg_count))
+				H.visible_message("<span class='borange'>The bolas miss [H]!</span>", "<span class='borange'>The bolas miss you!</span>")
+				throw_failed()
+				return
 			if(H.m_intent == "run") //if they're set to run (though not necessarily running at that moment)
 				if(prob(trip_prob)) //this probability is up for change and mostly a placeholder - Comic
 					step(H, H.dir)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -47,13 +47,16 @@
 				E = organ_name
 			else
 				E = get_organ(organ_name)
+			var/is_holding_cane = find_held_item_by_type(/obj/item/weapon/cane)
 			if(!E || (E.status & ORGAN_DESTROYED) || (E.status & ORGAN_PEG))
 				. += 2*multiplier
+				if(is_holding_cane)
+					. -= 1*multiplier //Halve the movement speed penalty
 			if(E.status & ORGAN_SPLINTED)
-				if(!find_held_item_by_type(/obj/item/weapon/cane))
+				if(!is_holding_cane)
 					. += 0.5*multiplier
 			else if(E.status & ORGAN_BROKEN)
-				if(!find_held_item_by_type(/obj/item/weapon/cane))
+				if(!is_holding_cane)
 					. += 1*multiplier
 				. += 0.5*multiplier
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -196,12 +196,12 @@
 	has_limbs = check_crawl_ability()
 
 /mob/living/carbon/human/proc/check_stand_ability()
-	//All legs must be usable in order for a human to stand
+	//At least one leg must be usable in order for a human to stand
 	for(var/datum/organ/external/leg in get_organs(LIMB_LEFT_LEG, LIMB_RIGHT_LEG))
-		if(!leg.can_stand())
-			return FALSE
+		if(leg.can_stand())
+			return TRUE
 
-	return TRUE
+	return FALSE
 
 /mob/living/carbon/human/proc/check_crawl_ability()
 	//At least one limb has to be usable for a human to crawl

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -798,6 +798,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if(body_part & (HAND_LEFT | HAND_RIGHT | ARM_LEFT | ARM_RIGHT))
 			owner.update_hands_icons()
 
+		if(body_part & (LEG_LEFT | LEG_RIGHT))
+			to_chat(owner, "<span class='danger'>The shock of losing your leg knocks you down!</span>")
+			owner.AdjustKnockdown(5)
+
 		if(slots_to_drop && slots_to_drop.len)
 			for(var/slot_id in slots_to_drop)
 				owner.u_equip(owner.get_item_by_slot(slot_id), 1)


### PR DESCRIPTION
Now a player won't be completely incapacitated from losing one leg.
There's also already code that supports walking on one leg and it makes the character 3x slower.
Canes now reduce that penalty to 2x slower.
Getting a leg cut off will knock you down for about 10 seconds.
Losing both your legs or your feet will still knock you down completely though.
Bolas will no longer work on people who cannot stand up AKA legless people.
Bolas will have only a 50% chance of hitting the target if the target has only one leg.

:cl:
 * rscadd: Humans can now walk on one leg, but at a far slower speed. Canes can mitigate this penalty.
 * rscadd: Removing someone's leg will knock them down for about 10 seconds by default.
 * tweak: Throwing bolas no longer work on people with no legs.
 * tweak: People with one leg have a separate 50% chance of avoiding a throwing bola.