### PR TITLE
Leathermaking de-hairing step message for dull blades

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -229,7 +229,7 @@
 			user.visible_message("<span class='notice'>\the [usr] starts cutting hair off \the [src]</span>", "<span class='notice'>You start cutting the hair off \the [src]</span>", "You hear the sound of a knife rubbing against flesh")
 	
 			spawn()
-				if(do_after(user, src, 50))
+				if(do_after(user, src, 5 SECONDS))
 					to_chat(user, "<span class='notice'>You cut the hair from this [src.singular_name]</span>")
 	
 					if(src.use(1))

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -218,20 +218,25 @@
 //Step one - dehairing.
 
 /obj/item/stack/sheet/animalhide/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(W.is_sharp() >= 1.2 && W.sharpness_flags & SHARP_BLADE)
+	if(W.sharpness_flags & SHARP_BLADE)
 
-		//visible message on mobs is defined as visible_message(var/message, var/self_message, var/blind_message)
-		user.visible_message("<span class='notice'>\the [usr] starts cutting hair off \the [src]</span>", "<span class='notice'>You start cutting the hair off \the [src]</span>", "You hear the sound of a knife rubbing against flesh")
+		if(!(W.is_sharp() >= 1.2))
+			to_chat(user, "<span class='notice'>[W]'s edge is too dull.</span>")
+			..()
 
-		spawn()
-			if(do_after(user, src, 50))
-				to_chat(user, "<span class='notice'>You cut the hair from this [src.singular_name]</span>")
-
-				if(src.use(1))
-					var/obj/item/stack/sheet/hairlesshide/H = drop_stack(/obj/item/stack/sheet/hairlesshide, user.loc, 1, user)
-					H.source_string = source_string
-					H.name = source_string ? "hairless [source_string] hide" : "hairless hide"
-		return 1
+		else
+			//visible message on mobs is defined as visible_message(var/message, var/self_message, var/blind_message)
+			user.visible_message("<span class='notice'>\the [usr] starts cutting hair off \the [src]</span>", "<span class='notice'>You start cutting the hair off \the [src]</span>", "You hear the sound of a knife rubbing against flesh")
+	
+			spawn()
+				if(do_after(user, src, 50))
+					to_chat(user, "<span class='notice'>You cut the hair from this [src.singular_name]</span>")
+	
+					if(src.use(1))
+						var/obj/item/stack/sheet/hairlesshide/H = drop_stack(/obj/item/stack/sheet/hairlesshide, user.loc, 1, user)
+						H.source_string = source_string
+						H.name = source_string ? "hairless [source_string] hide" : "hairless hide"
+			return 1
 	else
 		..()
 


### PR DESCRIPTION
When making leather, you have to de-hair the skin. This requires something with `sharpness_flags & SHARP_BLADE` and also the sharpness has to be `>= 1.2`. If you use something that has a sharpness under 1.2, like a glass shard, it won't work, but currently there's no message to indicate why. So this makes the leatherworking de-hairing step give a message when you try to use something with the `SHARP_BLADE` flag but that's too dull to de-hair the skin (closes #35060).

This is part of an atomization of #35063.

[qol]
:cl:
 * rscadd: Added message for using a too-dull blade when trying to de-hair skin for leathermaking.