### PR TITLE
Fireballs will no longer detonate in proximity of a target, now requires direct collision

### DIFF
--- a/code/modules/spells/targeted/projectile/fireball.dm
+++ b/code/modules/spells/targeted/projectile/fireball.dm
@@ -1,7 +1,7 @@
 /spell/targeted/projectile/dumbfire/fireball
 	name = "Fireball"
 	abbreviation = "FB"
-	desc = "This spell conjures a fireball that will fly in the direction you're facing and explode on collision with anything, or when it gets close to anyone else."
+	desc = "This spell conjures a fireball that will fly in the direction you're facing and explode on collision with anything."
 	user_type = USER_TYPE_WIZARD
 	specialization = SSOFFENSIVE
 
@@ -19,6 +19,7 @@
 	spell_aspect_flags = SPELL_FIRE
 	duration = 20
 	projectile_speed = 1
+	cast_prox_range = 0
 
 	amt_dam_brute = 40
 	amt_dam_fire = 45


### PR DESCRIPTION
Someone talked in deadchat yesterday about how hard it sucks to dodge fireballs because a wizard can just fling it down the middle in a hallway and it's impossible to dodge without outrunning it. Although the user did not know that you can lie down to avoid the fireball but lying down on demand when you see a fireball approaching requires a macro and almost nobody does that.
I agree that fireballs should be easier to dodge. Normally fireballs would detonate when adjacent to a possible target. This makes it so that fireballs will have to collide with a target to detonate.

:cl:
 * tweak: Fireballs will no longer explode when near a victim, but instead require a direct collision with the victim to explode.