### PR TITLE
lung message fix

### DIFF
--- a/code/modules/organs/internal/lungs/lung.dm
+++ b/code/modules/organs/internal/lungs/lung.dm
@@ -57,13 +57,13 @@
 			return 1	//godmode
 		if(breath.temperature < H.species.cold_level_1)
 			if(prob(20))
-				H << "<span class='warning'>You feel your face freezing and an icicle forming in your lungs!</span>"
+				to_chat(H, "<span class='warning'>You feel your face freezing and an icicle forming in your lungs!</span>")
 		else if(breath.temperature > H.species.heat_level_1)
 			if(prob(20))
 				if(isslimeperson(H))
-					H << "<span class='warning'>You feel supercharged by the extreme heat!</span>"
+					to_chat(H, "<span class='warning'>You feel supercharged by the extreme heat!</span>")
 				else
-					H << "<span class='warning'>You feel your face burning and a searing heat in your lungs!</span>"
+					to_chat(H, "<span class='warning'>You feel your face burning and a searing heat in your lungs!</span>")
 
 		if(isslimeperson(H))
 			if(breath.temperature < H.species.cold_level_1)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes it so the `"<span class='warning'>You feel supercharged by the extreme heat!</span>"` messages if you inhale very hot hot air properly display. Closes #35069. Fully tested.

## Why it's good
<!-- Explain why you think these changes are good. -->
It should have been working all this time.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed breathing hot air messages.
