### PR TITLE
Vampires changes

### DIFF
--- a/code/datums/gamemode/powers/vampire.dm
+++ b/code/datums/gamemode/powers/vampire.dm
@@ -30,10 +30,10 @@
 	granttext = "Your vampiric vision has improved."
 	store_in_memory = TRUE
 
-/datum/power/vampire/disease
-	cost = 150
-	spellpath = /spell/targeted/disease
-	granttext = "You have gained the Diseased Touch ability which causes those you touch to die shortly after unless treated medically."
+///datum/power/vampire/disease
+//	cost = 150
+//	spellpath = /spell/targeted/disease
+//	granttext = "You have gained the Diseased Touch ability which causes those you touch to die shortly after unless treated medically."
 
 /datum/power/vampire/cloak
 	cost = 150

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -331,19 +331,13 @@
 		H.color = "#FFFFFF"
 		return FALSE
 
-	if((T.get_lumcount() * 10) <= 2)
+	if((T.get_lumcount()) <= 0.4) //Lumcount goes from a value of 0 to 1 and 0.4 is moderately dark
 		if(locate(/datum/power/vampire/mature) in current_powers)
-			H.make_invisible(VAMPIRECLOAK, 0, TRUE, round(255 * 0.3), INVISIBILITY_LEVEL_TWO)
+			H.make_invisible(VAMPIRECLOAK, 0, TRUE, round(255 * 0.2), INVISIBILITY_LEVEL_TWO)
 		else
-			H.make_invisible(VAMPIRECLOAK, 0, TRUE, round(255 * 0.3))
-		return TRUE
+			H.make_invisible(VAMPIRECLOAK, 0, TRUE, round(255 * 0.5))
 	else
-		if(H.invisibility > 0)
-			H.make_visible(VAMPIRECLOAK)
-		if(locate(/datum/power/vampire/mature) in current_powers)
-			H.make_invisible(VAMPIRECLOAK, 0, TRUE, round(255 * 0.3))
-		else
-			H.make_invisible(VAMPIRECLOAK, 0, TRUE, round(255 * 0.8))
+		H.make_visible(VAMPIRECLOAK)
 
 /datum/role/vampire/proc/handle_menace(var/mob/living/carbon/human/H)
 	if(!istruevampire(H))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -464,6 +464,12 @@
 	if(flavor_text && can_show_flavor_text())
 		msg += "[print_flavor_text()]\n"
 
+	if(isvampire(user) && !(src == user))
+		if(ishuman(user)) //Silicons shouldn't get this
+			var/datum/role/vampire/V = isvampire(user)
+			msg += V.examine_can_suck(src)
+			msg += "<br>"
+
 	msg += "*---------*</span>"
 
 	return msg

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -27,8 +27,7 @@
 				src.visible_message("<span class='danger'>\The [M] has bitten \the [src]!</span>", "<span class='userdanger'>You were bitten by \the [M]!</span>")
 			else
 				to_chat(M, "<span class='danger'>You start to slowly reach for [src]'s neck to bite it!.</span>")
-			if(!V.silentbite || do_mob(M, src, (5 SECONDS)))
-				V.handle_bloodsucking(src)
+			V.handle_bloodsucking(src)
 			return
 	//end vampire code
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -27,8 +27,7 @@
 				src.visible_message("<span class='danger'>\The [M] has bitten \the [src]!</span>", "<span class='userdanger'>You were bitten by \the [M]!</span>")
 			else
 				to_chat(M, "<span class='danger'>You start to slowly reach for [src]'s neck to bite it!.</span>")
-			var/mature = (locate(/datum/power/vampire/mature) in V.current_powers) ? 2 : 1
-			if(!V.silentbite || do_mob(M, src, (30 SECONDS) / mature))
+			if(!V.silentbite || do_mob(M, src, (5 SECONDS)))
 				V.handle_bloodsucking(src)
 			return
 	//end vampire code

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -205,7 +205,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 	var/blood_factor = 1
 	if(species && species.anatomy_flags & NO_BLOOD) //Things that do not bleed do not bleed
 		return 0
-		
+
 	if(lying) //Lying down slows blood loss
 		blood_factor -= 0.3
 
@@ -214,16 +214,16 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 
 	if(reagents.has_reagent(INAPROVALINE)) //Inaprov and Bicard slow bleeding, and stack
 		blood_factor -= 0.3
-		
+
 	if(reagents.has_reagent(BICARIDINE))
 		blood_factor -= 0.3
-		
+
 	if(reagents.has_reagent(CLOTTING_AGENT) || reagents.has_reagent(BIOFOAM)) //Clotting agent and biofoam stop bleeding entirely
 		blood_factor = 0
-	
+
 	if(bodytemperature < 170) //Cryo stops bleeding entirely
 		blood_factor = 0
-		
+
 	return max(0, blood_factor) //Do not return a negative percent, we don't want free blood healing!
 
 //Makes a blood drop, leaking amt units of blood from the mob
@@ -232,10 +232,10 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 		return 0
 
 	amt = max(0, amt * calcbloodloss()) //determines how much blood to lose based on human's situation
-	
+
 	if(!amt)
 		return 0
-	
+
 	vessel.remove_reagent(BLOOD,amt)
 	blood_splatter(src,src)
 	stat_collection.blood_spilled += amt
@@ -416,7 +416,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 
 	container.reagents.remove_reagent(BLOOD, amount)
 
-//Transfers blood from container ot vessels, respecting blood types compatability.
+//Transfers blood from container to vessels, respecting blood types compatability.
 /mob/living/carbon/human/inject_blood(obj/item/weapon/reagent_containers/container, var/amount)
 
 	var/datum/reagent/blood/injected = get_blood(container.reagents)
@@ -436,7 +436,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 	if (istype(container,/obj/item/weapon/reagent_containers/food/drinks/cult))//drinking from this cup is always toxic to non cultists, and safe to cultists
 		if (!iscultist(src))
 			toxic = 2
-	else if (blood_incompatible(injected.data["blood_type"],our.data["blood_type"]))
+	else if (blood_incompatible(injected.data["blood_type"],our.data["blood_type"]) && !isvampire(src)) //Vampires are universal receivers
 		toxic = 1
 
 	switch (toxic)

--- a/code/modules/spells/aoe_turf/glare.dm
+++ b/code/modules/spells/aoe_turf/glare.dm
@@ -26,6 +26,7 @@
 		return FALSE
 	if (istype(user.get_item_by_slot(slot_glasses), /obj/item/clothing/glasses/sunglasses/blindfold))
 		to_chat(user, "<span class='warning'>You're blindfolded!</span>")
+		return FALSE
 	if (!user.vampire_power(blood_cost, CONSCIOUS))
 		return FALSE
 

--- a/code/modules/spells/aoe_turf/screech.dm
+++ b/code/modules/spells/aoe_turf/screech.dm
@@ -42,7 +42,7 @@
 				if (FALSE)
 					continue
 				if (VAMP_FAILURE)
-					critfail(targets, user)
+					return critfail(targets, user)
 	return targets
 
 /spell/aoe_turf/screech/cast(var/list/targets, var/mob/user)

--- a/code/modules/spells/general/shapeshift.dm
+++ b/code/modules/spells/general/shapeshift.dm
@@ -22,7 +22,7 @@
 
 /spell/shapeshift/cast_check(skipcharge = 0, mob/user = usr)
 	. = ..()
-	if (!.) 
+	if (!.)
 		return FALSE
 
 /spell/shapeshift/choose_targets(var/mob/user = usr)
@@ -35,8 +35,6 @@
 		user.set_species("Vampire")
 		user.name = "Nosferatu"
 		user.real_name = "Nosferatu"
-		user.UpdateAppearance()
-		user.update_perception()
 		humanform = FALSE
 	else
 		user.set_species(identity.species, 0)
@@ -44,8 +42,8 @@
 		user.name = identity.real_name
 		user.real_name = identity.real_name
 		user.dna = identity
-		user.UpdateAppearance()
-		user.update_perception()
 		humanform = TRUE
-	
+	user.UpdateAppearance()
+	user.update_perception()
+	user.update_name()
 	..()

--- a/code/modules/spells/targeted/disease.dm
+++ b/code/modules/spells/targeted/disease.dm
@@ -1,3 +1,6 @@
+/*
+//A vampire spell that causes deadly infection in targets.
+//Removed from the game because it was just plain unfun to fight against
 /spell/targeted/disease
 	name = "Diseased Touch (50)"
 	desc = "Touches your victim with infected blood giving them the Shutdown Syndrome which quickly shuts down their major organs resulting in a quick painful death."
@@ -92,3 +95,4 @@
 	var/datum/role/vampire/V = isvampire(user)
 	if(V)
 		V.remove_blood(3*blood_cost)
+*/

--- a/code/modules/virus2/effect/stage_special.dm
+++ b/code/modules/virus2/effect/stage_special.dm
@@ -1,9 +1,9 @@
 ////////////////////////SPECIAL/////////////////////////////////
 
 //Vampire Diseased Touch
-/datum/disease2/effect/organs/vampire
-	stage = 1
-	restricted = 2//symptoms won't randomly mutate into this one & won't appear in the symptom encyclopedia
+///datum/disease2/effect/organs/vampire
+//	stage = 1
+//	restricted = 2//symptoms won't randomly mutate into this one & won't appear in the symptom encyclopedia
 
 /datum/disease2/effect/wizarditis/single
 	stage = 1


### PR DESCRIPTION
What initially started off as me looking into the discrepancies of blood sucking eventually rolled into a larger vampire change, aimed at tweaking vampires.

**The important stuff**
- Diseased Touch is removed. It's not fun.
- Vampires suck twice as much blood out of a target but still receive the same amount of blood. This means both that the vampire can't get about 500 usable blood out of someone and also that victims of a vampire suck will collapse significantly sooner from blood loss.
- Vampires can now examine a target to see whether they are eligible for having their blood sucked, and how much blood they carry. It won't tell them if the other is a vampire though.
- Silent biting is now silent. No longer has a wind-up time of 30 seconds, no longer alerts people that the vampire started chowing down on someone. It sucks at a rate of about 25%, people!
- Vampire darkness cloaking now only works in darkness, meaning vampires won't be transparent in the brightest places in existence, but the amount of visibility reduction has been intensified to compensate.
- If a null rod is carried by anyone that isn't a chaplain it will no longer backfire the mature vampire's abilities against the vampire but they will still be protected by the null rod.

**The less important but still good bits**
- Vampires will no longer suffer blood poisoning from having mismatched blood. They're universal receivers!
- Fixed a bug where Glare could work through blindfolds.
- Fixed a bug where Screech could still work on some targets even if it was nullified by a chaplain's null rod.
- Vampires revealing their true forms will now properly update their names.
- Vampires can't switch their bite types when sucking someone, if it started off silently it's going to remain silently until they take their teeth off their target.

:cl:
 * rscdel: The vampire's "Diseased Touch" ability has been removed.
 * rscadd: Vampires can now see from a distance whether a victim is eligible to be sucked and how much blood they are carrying. This will NOT reveal other vampires!
 * tweak: Vampires will now suck blood at a ratio of 1:2, meaning that for every unit of blood the vampire drains the victim will lose 2.
 * tweak: The vampire's "sleight of teeth" ability has been improved significantly; it no longer has an initial delay of 30 seconds and it no longer alerts anyone in the vicinity.
 * tweak: The vampire's "Cloak of Darkness" ability has been changed; it no longer works in bright light at all but in sufficiently dark areas it is even more potent.
 * tweak: Null rods carried by players that are not chaplains will no longer cause vampiric powers to backfire against mature vampires, instead it will only protect the wielder.
 * tweak: Vampires will now properly consume blood from beakers and other containers without getting blood poisoning from mismatching blood types.
 * bugfix: Fixed a bug where the vampire's "Glare" ability merely informed the vampire whether they were blindfolded or not, rather than actually stopping the ability from being done due to being blindfolded.
 * bugfix: Fixed a bug where the vampire's "Screech" ability would affect nearby victims even if it was nullified by a nearby chaplain with a null rod.
 * bugfix: Fixed a bug where vampires revealing their true forms would appear as "Nosferatu" right away rather than as "Unknown", not just because they are meant to be Unknown for as long as they are in their true forms but also because their identities would be visible even when there would be no way to discern their identities.