### PR TITLE
Fixes vox gassing alert

### DIFF
--- a/code/modules/organs/internal/lungs/lung.dm
+++ b/code/modules/organs/internal/lungs/lung.dm
@@ -42,15 +42,22 @@
 	breath.volume = inhale_volume
 	breath.update_values()
 
+	// Instantiate a variable to determine if we should show the player a toxins_alert
+	var/toxic_gas_detected = FALSE
+
 	// First, we consume air.
 	for(var/datum/lung_gas/G in gasses)
 		G.set_context(src,breath,H)
-		G.handle_inhale()
+		toxic_gas_detected |= G.handle_inhale()
 
 	// Next, we exhale. At the moment, only /datum/lung_gas/waste uses this.
 	for(var/datum/lung_gas/G in gasses)
 		G.set_context(src,breath,H)
 		G.handle_exhale()
+
+	// If no toxic gas detected, ensure toxins_alert is disabled
+	if(!toxic_gas_detected)
+		H.toxins_alert = 0
 
 	if( (abs(310.15 - breath.temperature) > 50) && !(M_RESIST_HEAT in H.mutations)) // Hot air hurts :(
 		if(H.status_flags & GODMODE)

--- a/code/modules/organs/internal/lungs/lung_gasses.dm
+++ b/code/modules/organs/internal/lungs/lung_gasses.dm
@@ -163,8 +163,10 @@
 				// no this is bad n3x pls no
 				H.adjustToxLoss(clamp(ratio, MIN_PLASMA_DAMAGE, MAX_PLASMA_DAMAGE))
 			H.toxins_alert = max(H.toxins_alert, 1)
+			return TRUE
+		return FALSE
 	else
-		H.toxins_alert = 0
+		return FALSE
 
 
 ////////////////////////


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Recent vox lung nerf broke the vox gassing alert. This fixes that. Closes #35078.
![image](https://github.com/vgstation-coders/vgstation13/assets/145183032/7d1df81f-989d-4fe9-98e7-ce73581ef658)


## Why it's good
<!-- Explain why you think these changes are good. -->
Vox should know when they are being gassed.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed vox gassing alert.
