### PR TITLE
melt pill bottles with swiss army knife

### DIFF
--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -34,7 +34,7 @@
 	var/removing_item = /obj/item/tool/screwdriver //the type of item that lets you take tools out
 
 /obj/item/weapon/switchtool/preattack(atom/target, mob/user, proximity_flag, click_parameters)
-	if(istype(target, /obj/item/weapon/storage)) //we place automatically
+	if(istype(target, /obj/item/weapon/storage) && !istype(target, /obj/item/weapon/storage/pill_bottle)) //we place automatically, but want pill bottles to be meltable
 		return
 	if(deployed)
 		if(!deployed.preattack(target, user))


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Makes pill bottles meltable by swiss army knife. Closes #35082.

## Why it's good
<!-- Explain why you think these changes are good. -->
Should be able to melt pill bottles if you're holding a swiss army knife in zippo mode.

## Caveat
This introduces an inconsistent behavior. When you light a pill bottle with a cheap lighter or a zippo, after it melts, you get a message like: "_The pill bottle cannot hold the lit cheap lighter._". After my change, for the switchtool in lit zippo mode, the message after melting is "_You can't let go of the swiss army knife!_". This seems to be because of the code in the [/obj/item/weapon/storage/can_be_inserted](https://github.com/vgstation-coders/vgstation13/blob/f40bd5f75074f0e6b9d2631a138a9d7ba6fc1884/code/game/objects/items/weapons/storage/storage.dm#L272) proc, and how the code in the [/obj/item/weapon/switchtool/proc/edit_deploy](https://github.com/vgstation-coders/vgstation13/blob/f40bd5f75074f0e6b9d2631a138a9d7ba6fc1884/code/game/objects/items/weapons/switchtool.dm#L243C5-L243C5) proc sets the cant_drop property to TRUE.

Whether or not this consistency issue should be fixed before merging is up to you.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:

 * bugfix: Lets pill bottles be melted by swiss army knives in lighter mode.
