### PR TITLE
Fixes shooting adjacent windows causing the shooter to get shot

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -315,8 +315,6 @@ var/list/impact_master = list()
 
 	if (special_collision != PROJECTILE_COLLISION_MISS)
 		special_collision = A.bullet_act(src, def_zone) // searches for return value
-		if (A.gcDestroyed) // We killed the poor thing
-			A = A_turf
 	if(special_collision != PROJECTILE_COLLISION_DEFAULT && special_collision != PROJECTILE_COLLISION_BLOCKED) // the bullet is still flying, either from missing its target, bouncing off it, or going through a portal
 		bumped = 0 // reset bumped variable!
 


### PR DESCRIPTION
Basically a 2 year old bug #28891
The most observable way this happened in the game was by shooting a directional window (or a barricade) when you're on the same tile as it. If the projectile smashed the window it would also hit you.
What happens is that since the window gets destroyed by a projectile the target is switched to the turf where the target was, and as part of the code if the target is a tile (not exactly sure why) it hits everything and everyone on that turf. This also made things like shotgun shells utterly obliterate windows as a side effect, rather than wrecking the windows but leaving the grille be. Now it no longer switches to the turf if the target is destroyed.
Tested with rockets, rockets explode as normal. This is because #28891 already fixed it by just having the explosion happen regardless of the outcome of the projectile impact, at the target's turf.
Fixes #34661
Fixes #35084
Also it's not a vampire nerf, it's a vampire change!

:cl:
 * bugfix: Fixed a 2 year old bug where shooting a window (and breaking that window) while you were standing on the same tile as it would hit you with the projectile you fired.
