### PR TITLE
snackbar fix

### DIFF
--- a/code/game/machinery/kitchen/snackbarmachine.dm
+++ b/code/game/machinery/kitchen/snackbarmachine.dm
@@ -16,15 +16,15 @@
 	if(href_list["createpill"] || href_list["createpill_multiple"] || href_list["ejectp"] || href_list["change_pill"])
 		return //No href exploits, fuck off
 
-	if(..())
-		return 1
-
 	usr.set_machine(src)
 
 	if(container && href_list["createbar"])
 		var/obj/item/weapon/reagent_containers/food/snacks/snackbar/SB = new/obj/item/weapon/reagent_containers/food/snacks/snackbar(src.loc)
 		reagents.trans_to(SB, 10)
 		src.updateUsrDialog()
+		return 1
+
+	if(..())
 		return 1
 
 	return


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Snackbar machine did not work before, could not print out your snackbar. This lets it print it out.
![image](https://github.com/vgstation-coders/vgstation13/assets/145183032/6f4e3ef4-8ee4-44e2-8c2b-ea5c0b2732cd)


## Why it's good
<!-- Explain why you think these changes are good. -->
Snacks taste good.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed snackbars being uncreateable.
