### PR TITLE
slime person cloning instakill fix

### DIFF
--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -246,7 +246,7 @@
 	if(H.dna.species != "Human")
 		H.set_species(H.dna.species, TRUE)
 
-	isslimeperson(H) ? H.adjustToxLoss(75) : H.adjustCloneLoss(150)
+	isslimeperson(H) ? H.adjustToxLoss(75) : H.adjustCloneLoss(150) // 75 for slime people due to their tox_mod of 2
 	H.adjustBrainLoss(upgraded ? 0 : (heal_level + 50 + rand(10, 30))) // The rand(10, 30) will come out as extra brain damage
 	H.Paralyse(4)
 	H.stat = H.status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS //There was a bug which allowed you to talk for a few seconds after being cloned, because your stat wasn't updated until next Life() tick. This is a fix for this!

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -246,7 +246,7 @@
 	if(H.dna.species != "Human")
 		H.set_species(H.dna.species, TRUE)
 
-	isslimeperson(H) ? H.adjustToxLoss(150) : H.adjustCloneLoss(150)
+	isslimeperson(H) ? H.adjustToxLoss(75) : H.adjustCloneLoss(150)
 	H.adjustBrainLoss(upgraded ? 0 : (heal_level + 50 + rand(10, 30))) // The rand(10, 30) will come out as extra brain damage
 	H.Paralyse(4)
 	H.stat = H.status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS //There was a bug which allowed you to talk for a few seconds after being cloned, because your stat wasn't updated until next Life() tick. This is a fix for this!


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Makes slime people cloneable. Closes #35093.

Due to slime people having a `tox_mod` of 2 ([link](https://github.com/vgstation-coders/vgstation13/blob/f40bd5f75074f0e6b9d2631a138a9d7ba6fc1884/code/modules/mob/living/carbon/species.dm#L1112)) they were being instakilled by the cloner.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixes slime person cloning
