### PR TITLE
Defib unattached brain nerf

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -159,6 +159,9 @@
 		if(!target.has_brain())
 			defib_message_fail(target, "<span class='warning'>[src] buzzes: Defibrillation failed. No central nervous system detected.</span>")
 			return
+		if(!target.has_attached_brain())
+			defib_message_fail(target, "<span class='warning'>[src] buzzes: Defibrillation failed. Central nervous system detachment detected.</span>")
+			return
 		if(target.mind && target.mind.suiciding)
 			defib_message_fail(target, "<span class='warning'>[src] buzzes: Defibrillation failed. Unrecoverable nerve trauma detected.</span>") // They suicided so they fried their brain. Space Magic.
 			return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1485,6 +1485,13 @@
 		if(brain && istype(brain))
 			return 1
 	return 0
+/mob/living/carbon/human/has_attached_brain()
+	if(internal_organs_by_name["brain"])
+		var/datum/organ/internal/brain = internal_organs_by_name["brain"]
+		if(brain && istype(brain) && !(brain.status & ORGAN_CUT_AWAY))
+			return 1
+		return 0
+	return 0
 /mob/living/carbon/human/has_eyes()
 	if(internal_organs_by_name["eyes"])
 		var/datum/organ/internal/eyes = internal_organs_by_name["eyes"]

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1490,7 +1490,6 @@
 		var/datum/organ/internal/brain = internal_organs_by_name["brain"]
 		if(brain && istype(brain) && !(brain.status & ORGAN_CUT_AWAY))
 			return 1
-		return 0
 	return 0
 /mob/living/carbon/human/has_eyes()
 	if(internal_organs_by_name["eyes"])

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1220,6 +1220,9 @@ Thanks.
 /mob/living/proc/has_brain()
 	return 1
 
+/mob/living/proc/has_attached_brain()
+	return 1
+
 /mob/living/proc/has_eyes()
 	return 1
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
This makes people unrevivable with defib if you neglect to use Fix-O-Vein after inserting a brain during brain replacement. Resolves #35091?
![image](https://github.com/vgstation-coders/vgstation13/assets/145183032/3a84c2b3-dc2e-4313-97bf-eeef5492cbb4)


## Why it's good
<!-- Explain why you think these changes are good. -->
It doesn't make sense for someone to be able to function with a detached brain.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Makes those with detached brains undefibable.
