### PR TITLE
Makes /obj/machinery/initialize() supercall

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -179,6 +179,7 @@ Class Procs:
 	return ..()
 
 /obj/machinery/initialize()
+	..()
 	if(machine_flags & PURCHASER)
 		reconnect_database()
 		linked_account = vendor_account


### PR DESCRIPTION
Technically fixes #35016, but that bug is really a manifestation of something more fucked up going on, which is much harder to fix.
Tested, in that:
1. It didn't happen (though it was random and fairly rare anyway)
2. Nothing else broke as far as I could tell

I cannot imagine how this could break anything, but it's possible shitcode will find a way