### PR TITLE
Fixes blob cerebrates being able to reproduce

### DIFF
--- a/code/_onclick/mindUI/_mindUI.dm
+++ b/code/_onclick/mindUI/_mindUI.dm
@@ -160,7 +160,7 @@ var/list/mind_ui_ID2type = list()
 		var/mob/M = mind.current
 		if (!M.client)
 			return
-		
+
 		mind.current.client.screen -= elements
 
 // Makes every element visible
@@ -272,6 +272,10 @@ var/list/mind_ui_ID2type = list()
 /obj/abstract/mind_ui_element/proc/Hide()
 	if (!parent.active) // we check again for it due to potential spawn() use, and inconsistencies caused by quick UI toggling
 		invisibility = 101
+
+//In case we want to make a specific element disappear, and not because the mind UI is inactive.
+/obj/abstract/mind_ui_element/proc/Disappear()
+	invisibility = 101
 
 /obj/abstract/mind_ui_element/proc/GetUser()
 	ASSERT(parent && parent.mind && parent.mind.current)

--- a/code/_onclick/mindUI/blob.dm
+++ b/code/_onclick/mindUI/blob.dm
@@ -329,8 +329,8 @@
 	if(!istype(M) || !M.blob_core)
 		return
 	var/required_points = BLOBCOREBASECOST + (BLOBCORECOSTINC * (blob_cores.len - 1))
-	if (M.max_blob_points < required_points || M.blob_core.creator)
-		Hide()
+	if (M.max_blob_points < required_points || M.blob_core.has_been_created)
+		Disappear()
 		return
 	offset_y = round(-96 + (required_points * 200 / M.max_blob_points))
 	UpdateUIScreenLoc()
@@ -470,8 +470,8 @@
 	var/mob/camera/blob/M = GetUser()
 	if(!istype(M) || !M.blob_core)
 		return
-	if (M.blob_core.creator)
-		Hide()
+	if (M.blob_core.has_been_created)
+		Disappear()
 		return
 	overlays.len = 0
 	if (M.max_blob_points < required_points)

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -232,7 +232,7 @@
 		for(var/mob/camera/blob/O in blob_overminds)
 			if(O != B)
 				to_chat(O,"<span class='notice'>A new blob cerebrate has started thinking inside a blob core! [B] joins the blob! <a href='?src=\ref[O];blobjump=\ref[loc]'>(JUMP)</a></span>")
-
+	B.UpdateAllElementIcons()
 	return 1
 
 /obj/effect/blob/core/update_icon(var/spawnend = 0)

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -15,17 +15,18 @@
 	var/core_warning_delay = 0
 	var/previous_health = 200
 	var/no_ghosts_allowed = FALSE
+	var/has_been_created
 
 	icon_new = "core"
 	icon_classic = "blob_core"
 
 
-/obj/effect/blob/core/New(loc, var/h = 200, var/client/new_overmind = null, var/new_rate = 2, var/mob/camera/blob/C = null,newlook = "new",no_morph = 0)
+/obj/effect/blob/core/New(loc, var/h = 200, var/client/new_overmind = null, var/new_rate = 2, created = null,newlook = "new",no_morph = 0)
 	if (looks == "new")
 		looks = newlook
 	blob_cores += src
 	processing_objects.Add(src)
-	creator = C
+	has_been_created = created
 	if (!asleep && icon_size == 64)
 		if(new_overmind)
 			if (!no_morph)
@@ -205,7 +206,7 @@
 	B.special_blobs += src
 	B.DisplayUI("Blob")
 
-	if(!B.blob_core.creator)//If this core is the first of its lineage (created by game mode/event/admins, instead of another overmind) it gets to choose its looks.
+	if(!B.blob_core.has_been_created)//If this core is the first of its lineage (created by game mode/event/admins, instead of another overmind) it gets to choose its looks.
 		var/new_name = "Blob Overmind ([rand(1, 999)])"
 		B.name = new_name
 		B.real_name = new_name

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -474,7 +474,7 @@ var/list/blob_looks_player = list(//Options available to players
 	if(!ispath(type))
 		error("[type] is an invalid type for the blob.")
 	if(special) //Send additional information to the New()
-		new type(src.loc, 200, null, 1, M, newlook = looks)
+		new type(src.loc, 200, null, 1, 1, newlook = looks)
 	else
 		var/obj/effect/blob/B = new type(src.loc, newlook = looks)
 		B.dir = dir


### PR DESCRIPTION
A [2-year-old bug](https://github.com/vgstation-coders/vgstation13/pull/30672) where MindUI (the screen buttons that show up) was changed during a larger update but it made it so that the button that would render MindUI buttons invisible would only work if the screen button panels were toggled off, AKA it would no longer hide the buttons unless the entire menu was set to be hidden.
Blob cerebrates are not supposed to be allowed to expand and reproduce, that is only reserved for the primary blob core, and it has always been like this because primary blob cores receive the Verb to create more blob cores in their blob panel on the upper right while cerebrates don't, but blob cerebrates have access to the same MindUI buttons. There are lines of code that kept track of whether the cerebrates had a creator (tied to the original blob, more specifically its camera), but that led to two issues:
1. Hiding the "spawn more blob cores" button used that piece of code, aptly named Hide(), which no longer worked properly for the Blob UI, allowing cerebrates to bypass the lack of the Verb and create more cores themselves. This fixes it by calling a new MindUI proc, Disappear() which has the previous functionality of Hide().
2. If the primary blob core is destroyed so is the blob camera, which gets thrown into the garbage processing to be deleted from the game and after a while cerebrates would have no creator, thus they could reproduce. This part of the bug didn't actually kick in because Hide() did not work but it has been changed nonetheless; instead of tracking the blob creator it will now simply track whether the core was created by another blob core with a normal variable.

:cl:
 * bugfix: Fixed a 2-year-old bug where blob cerebrates could create new blob cores.