### PR TITLE
Hand tele's "None (Dangerous)" setting will automatically scramble its destination with every activation

### DIFF
--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -193,18 +193,7 @@ Frequency:
 
 	T = destination_id
 
-	//No stacking portals
-	if(locate(/obj/effect/portal) in get_turf(T))
-		user.show_message("<span class='notice'>\The [src] buzzes, there already is a portal there!</span>")
-		return
-	if(locate(/obj/effect/portal) in get_turf(src))
-		user.show_message("<span class='notice'>\The [src] buzzes, there already is a portal here!</span>")
-		return
-
 	var/turf/U = get_turf(src)
-	if(U == get_turf(T))
-		user.show_message("<span class='notice'>\The [src] buzzes, both destinations are the same!</span>")
-		return
 	U.visible_message("<span class='notice'>Locked In.</span>")
 	var/obj/effect/portal/P1 = new (U)
 	var/obj/effect/portal/P2 = new (get_turf(T))

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -179,13 +179,17 @@ Frequency:
 		user.show_message("<span class='notice'>\The [src] is recharging!</span>")
 		return
 
+	var/T
+
+	if((destination_name == "None (Dangerous)"))
+		if(prob(5))
+			T = locate(rand(7, world.maxx - 7), rand(7, world.maxy -7), map.zTCommSat)
+
 	if(!destination_id)
 		if(!choose_destination(user))
 			return
-	var/T = destination_id
 
-	if((destination_name == "None (Dangerous)") && prob(5))
-		T = locate(rand(7, world.maxx - 7), rand(7, world.maxy -7), map.zTCommSat)
+	T = destination_id
 
 	var/turf/U = get_turf(src)
 	U.visible_message("<span class='notice'>Locked In.</span>")
@@ -245,6 +249,16 @@ Frequency:
 		src.destination_name = destination_name
 		src.destination_id = destination_id
 		return 1
+
+/obj/item/weapon/hand_tele/proc/scramble_destination(var/mob/user)
+	var/list/turfs = list()
+	for(var/turf/T in trange(10, user))
+		if (T.x > world.maxx - 8 || T.x < 8)
+			continue
+		if (T.y > world.maxy - 8 || T.y < 8)
+			continue
+		turfs += T
+	return pick(turfs)
 
 /obj/item/weapon/hand_tele/AltClick(var/mob/usr)
 	if((usr.incapacitated() || !Adjacent(usr)))

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -193,7 +193,18 @@ Frequency:
 
 	T = destination_id
 
+	//No stacking portals
+	if(locate(/obj/effect/portal) in get_turf(T))
+		user.show_message("<span class='notice'>\The [src] buzzes, there already is a portal there!</span>")
+		return
+	if(locate(/obj/effect/portal) in get_turf(src))
+		user.show_message("<span class='notice'>\The [src] buzzes, there already is a portal here!</span>")
+		return
+
 	var/turf/U = get_turf(src)
+	if(U == get_turf(T))
+		user.show_message("<span class='notice'>\The [src] buzzes, both destinations are the same!</span>")
+		return
 	U.visible_message("<span class='notice'>Locked In.</span>")
 	var/obj/effect/portal/P1 = new (U)
 	var/obj/effect/portal/P2 = new (get_turf(T))

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -159,7 +159,7 @@ Frequency:
 	autoignition_temperature = AUTOIGNITION_PLASTIC
 	origin_tech = Tc_MAGNETS + "=1;" + Tc_BLUESPACE + "=3"
 	var/list/portals = list()
-	var/charge = HANDTELE_MAX_CHARGE//how many pairs of portal can the hand-tele sustain at once. a new charge is added every 30 seconds until the maximum is reached..
+	var/charge = HANDTELE_MAX_CHARGE//how many pairs of portal can the hand-tele sustain at once. a new charge is added every 30 seconds until the maximum is reached.
 	var/recharging = 0
 	var/destination_id
 	var/destination_name
@@ -184,8 +184,10 @@ Frequency:
 	if((destination_name == "None (Dangerous)"))
 		if(prob(5))
 			T = locate(rand(7, world.maxx - 7), rand(7, world.maxy -7), map.zTCommSat)
+		else
+			destination_id = scramble_destination(user)
 
-	if(!destination_id)
+	else if(!destination_id)
 		if(!choose_destination(user))
 			return
 


### PR DESCRIPTION
Selecting the "None (Dangerous)" setting will now create a portal in a random location rather than set a fixed random location, meaning that each portal will be in a different destination, still has a 5% chance of throwing you into zlevel 3 but only when initially setting it for "None (Dangerous)" because then the hand tele wouldn't really be used by anyone except antags if it could literally space you and everyone nearby on a 1/20 chance


:cl:
 * rscadd: The hand tele will now automatically scramble its destination when its destination is "None (Dangerous)".