### PR TITLE
New ban type: Observer only

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -336,6 +336,8 @@
 
 #define iscluwnebanned(H) (jobban_isbanned(H, "Cluwne"))
 
+#define isobserverbanned(H) (jobban_isbanned(H, "Observer"))
+
 //Macro for AREAS!
 
 #define isspace(A) (A.type == /area)

--- a/code/datums/gamemode/role/time_agent.dm
+++ b/code/datums/gamemode/role/time_agent.dm
@@ -120,7 +120,7 @@
 					eviltwinrecruiter = new(src)
 					eviltwinrecruiter.display_name = "time agent twin"
 					eviltwinrecruiter.role = TIMEAGENT
-					eviltwinrecruiter.jobban_roles = list("syndicate")
+					eviltwinrecruiter.jobban_roles += list("syndicate")
 					eviltwinrecruiter.logging = TRUE
 
 					// A player has their role set to Yes or Always

--- a/code/datums/gamemode/role/time_agent.dm
+++ b/code/datums/gamemode/role/time_agent.dm
@@ -120,7 +120,7 @@
 					eviltwinrecruiter = new(src)
 					eviltwinrecruiter.display_name = "time agent twin"
 					eviltwinrecruiter.role = TIMEAGENT
-					eviltwinrecruiter.jobban_roles += list("syndicate")
+					eviltwinrecruiter.jobban_roles = list("syndicate")
 					eviltwinrecruiter.logging = TRUE
 
 					// A player has their role set to Yes or Always

--- a/code/datums/recruiter.dm
+++ b/code/datums/recruiter.dm
@@ -6,7 +6,7 @@
 
 	var/display_name
 	var/role // ROLE_*
-	var/list/jobban_roles = list("Observer") // Players who may only observe should not be polled
+	var/list/jobban_roles
 	var/reject_antag_hud = 1
 	var/alien_whitelist_id = null // "Diona"
 	var/recruitment_timeout = 600
@@ -104,6 +104,10 @@
 
 /datum/recruiter/proc/check_observer(var/mob/dead/observer/O)
 	if(reject_antag_hud && O.has_enabled_antagHUD == 1 && config.antag_hud_restricted)
+		return 0
+
+	// "Observer" banned players may not be recruited
+	if(isobserverbanned(O))
 		return 0
 
 	if(jobban_roles.len > 0)

--- a/code/datums/recruiter.dm
+++ b/code/datums/recruiter.dm
@@ -6,7 +6,7 @@
 
 	var/display_name
 	var/role // ROLE_*
-	var/list/jobban_roles
+	var/list/ = list()
 	var/reject_antag_hud = 1
 	var/alien_whitelist_id = null // "Diona"
 	var/recruitment_timeout = 600

--- a/code/datums/recruiter.dm
+++ b/code/datums/recruiter.dm
@@ -6,7 +6,7 @@
 
 	var/display_name
 	var/role // ROLE_*
-	var/list/ = list()
+	var/list/jobban_roles = list()
 	var/reject_antag_hud = 1
 	var/alien_whitelist_id = null // "Diona"
 	var/recruitment_timeout = 600

--- a/code/datums/recruiter.dm
+++ b/code/datums/recruiter.dm
@@ -6,7 +6,7 @@
 
 	var/display_name
 	var/role // ROLE_*
-	var/list/jobban_roles = list()
+	var/list/jobban_roles = list("Observer") // Players who may only observe should not be polled
 	var/reject_antag_hud = 1
 	var/alien_whitelist_id = null // "Diona"
 	var/recruitment_timeout = 600

--- a/code/game/gamemodes/wizard/apprentice_contract.dm
+++ b/code/game/gamemodes/wizard/apprentice_contract.dm
@@ -145,7 +145,7 @@ var/list/wizard_apprentice_setups_by_name = list()
 	if(!recruiter)
 		recruiter = new(src)
 		recruiter.display_name = name
-		recruiter.jobban_roles = list("Syndicate")
+		recruiter.jobban_roles += list("Syndicate")
 		recruiter.recruitment_timeout = 30 SECONDS
 	// Role set to Yes or Always
 	recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))

--- a/code/game/gamemodes/wizard/apprentice_contract.dm
+++ b/code/game/gamemodes/wizard/apprentice_contract.dm
@@ -145,7 +145,7 @@ var/list/wizard_apprentice_setups_by_name = list()
 	if(!recruiter)
 		recruiter = new(src)
 		recruiter.display_name = name
-		recruiter.jobban_roles += list("Syndicate")
+		recruiter.jobban_roles = list("Syndicate")
 		recruiter.recruitment_timeout = 30 SECONDS
 	// Role set to Yes or Always
 	recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))

--- a/code/game/objects/items/devices/hologram_projector.dm
+++ b/code/game/objects/items/devices/hologram_projector.dm
@@ -81,7 +81,7 @@
 	if(!recruiter)
 		recruiter = new(src)
 		recruiter.display_name = "Holoperson"
-		recruiter.jobban_roles += list(ROLE_POSIBRAIN)
+		recruiter.jobban_roles = list(ROLE_POSIBRAIN)
 		recruiter.recruitment_timeout = 30 SECONDS
 	// Role set to Yes or Always
 	recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))

--- a/code/game/objects/items/devices/hologram_projector.dm
+++ b/code/game/objects/items/devices/hologram_projector.dm
@@ -81,7 +81,7 @@
 	if(!recruiter)
 		recruiter = new(src)
 		recruiter.display_name = "Holoperson"
-		recruiter.jobban_roles = list(ROLE_POSIBRAIN)
+		recruiter.jobban_roles += list(ROLE_POSIBRAIN)
 		recruiter.recruitment_timeout = 30 SECONDS
 	// Role set to Yes or Always
 	recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))

--- a/code/game/objects/items/robot/robot_items/robot_spawner.dm
+++ b/code/game/objects/items/robot/robot_items/robot_spawner.dm
@@ -49,7 +49,7 @@
 		recruiter = new(src)
 		recruiter.display_name = name
 		recruiter.role = role
-		recruiter.jobban_roles = jobban_roles
+		recruiter.jobban_roles += jobban_roles
 
 	recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))
 	recruiter.player_not_volunteering = new /callback(src, nameof(src::recruiter_not_recruiting()))

--- a/code/game/objects/items/robot/robot_items/robot_spawner.dm
+++ b/code/game/objects/items/robot/robot_items/robot_spawner.dm
@@ -49,7 +49,7 @@
 		recruiter = new(src)
 		recruiter.display_name = name
 		recruiter.role = role
-		recruiter.jobban_roles += jobban_roles
+		recruiter.jobban_roles = jobban_roles
 
 	recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))
 	recruiter.player_not_volunteering = new /callback(src, nameof(src::recruiter_not_recruiting()))

--- a/code/game/objects/items/weapons/null_rod.dm
+++ b/code/game/objects/items/weapons/null_rod.dm
@@ -364,7 +364,7 @@
 		recruiter = new(src)
 		recruiter.display_name = name
 		recruiter.role = ROLE_BORER //Uses the borer pref because preferences are scary and i don't want to touch them.
-		recruiter.jobban_roles += list("pAI") // pAI/Borers share the same jobban check so here we go too.
+		recruiter.jobban_roles = list("pAI") // pAI/Borers share the same jobban check so here we go too.
 
 	// Role set to Yes or Always
 	recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))

--- a/code/game/objects/items/weapons/null_rod.dm
+++ b/code/game/objects/items/weapons/null_rod.dm
@@ -364,7 +364,7 @@
 		recruiter = new(src)
 		recruiter.display_name = name
 		recruiter.role = ROLE_BORER //Uses the borer pref because preferences are scary and i don't want to touch them.
-		recruiter.jobban_roles = list("pAI") // pAI/Borers share the same jobban check so here we go too.
+		recruiter.jobban_roles += list("pAI") // pAI/Borers share the same jobban check so here we go too.
 
 	// Role set to Yes or Always
 	recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -396,7 +396,7 @@
 		output += "<option value='[j]'>[j]</option>"
 	for(var/j in nonhuman_positions)
 		output += "<option value='[j]'>[j]</option>"
-	for(var/j in list("traitor","changeling","operative","revolutionary","cultist","wizard","cluwne","artist", "observer"))
+	for(var/j in list("traitor","changeling","operative","revolutionary","cultist","wizard","cluwne","artist","observer"))
 		output += "<option value='[j]'>[j]</option>"
 
 	output += {"</select></td></tr></table>

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -396,7 +396,7 @@
 		output += "<option value='[j]'>[j]</option>"
 	for(var/j in nonhuman_positions)
 		output += "<option value='[j]'>[j]</option>"
-	for(var/j in list("traitor","changeling","operative","revolutionary","cultist","wizard","cluwne","artist"))
+	for(var/j in list("traitor","changeling","operative","revolutionary","cultist","wizard","cluwne","artist", "observer"))
 		output += "<option value='[j]'>[j]</option>"
 
 	output += {"</select></td></tr></table>

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1354,7 +1354,7 @@
 
 		//Other races  (BLUE, because I have no idea what other color to make this)
 		jobs += "<table cellpadding='1' cellspacing='0' width='100%'>"
-		jobs += "<tr bgcolor='ccccff'><th colspan='1'>Other Races</th></tr><tr align='center'>"
+		jobs += "<tr bgcolor='ccccff'><th colspan='10'>Other Races</th></tr><tr align='center'>"
 
 		if(jobban_isbanned(M, "Dionaea"))
 			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Dionaea;jobban4=\ref[M]'><font color=red>Dionaea</font></a></td>"
@@ -1369,6 +1369,20 @@
 
 		jobs += "</tr></table>"
 
+		// Special job bans (Cluwne, observer)
+		jobs += "<table cellpadding='1' cellspacing='0' width='100%'>"
+		jobs += "<tr bgcolor='87ceeb'><th colspan='10'>Special Bans</th></tr><tr align='center'>"
+
+		if(jobban_isbanned(M, "Cluwne"))
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Cluwne;jobban4=\ref[M]'><font color=red>Cluwne</font></a></td>"
+		else
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Cluwne;jobban4=\ref[M]'>Cluwne</a></td>"
+
+		if(jobban_isbanned(M, "Observer"))
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Observer;jobban4=\ref[M]'><font color=red>Observe&nbsp;Only</font></a></td>"
+		else
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Observer;jobban4=\ref[M]'>Observe&nbsp;Only</font></a></td>"
+		jobs += "</tr></table>"
 
 		body = "<body>[jobs]</body>"
 		dat = "<tt>[header][body]</tt>"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -54,6 +54,11 @@ var/creating_arena = FALSE
 	see_in_dark = 100
 	verbs += /mob/dead/observer/proc/dead_tele
 
+	if (isobserverbanned(body))
+		verbs -= /mob/dead/observer/verb/become_hobo
+		verbs -= /mob/dead/observer/verb/become_mommi
+		verbs -= /mob/dead/observer/verb/become_mouse
+
 	// Our new boo spell.
 	add_spell(new /spell/aoe_turf/boo, "grey_spell_ready")
 	add_spell(new /spell/targeted/ghost/toggle_medHUD)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -54,11 +54,6 @@ var/creating_arena = FALSE
 	see_in_dark = 100
 	verbs += /mob/dead/observer/proc/dead_tele
 
-	if (isobserverbanned(body))
-		verbs -= /mob/dead/observer/verb/become_hobo
-		verbs -= /mob/dead/observer/verb/become_mommi
-		verbs -= /mob/dead/observer/verb/become_mouse
-
 	// Our new boo spell.
 	add_spell(new /spell/aoe_turf/boo, "grey_spell_ready")
 	add_spell(new /spell/targeted/ghost/toggle_medHUD)

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -38,7 +38,7 @@
 		recruiter = new(src)
 		recruiter.display_name = "posibrain"
 		recruiter.role = ROLE_POSIBRAIN
-		recruiter.jobban_roles += list(ROLE_POSIBRAIN)
+		recruiter.jobban_roles = list(ROLE_POSIBRAIN)
 		recruiter.logging = TRUE
 
 		// A player has their role set to Yes or Always

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -38,7 +38,7 @@
 		recruiter = new(src)
 		recruiter.display_name = "posibrain"
 		recruiter.role = ROLE_POSIBRAIN
-		recruiter.jobban_roles = list(ROLE_POSIBRAIN)
+		recruiter.jobban_roles += list(ROLE_POSIBRAIN)
 		recruiter.logging = TRUE
 
 		// A player has their role set to Yes or Always

--- a/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
@@ -265,7 +265,7 @@
 		recruiter = new(src)
 		recruiter.display_name = "sammi"
 		recruiter.role = ROLE_POSIBRAIN // keep it same for these
-		recruiter.jobban_roles = list(ROLE_POSIBRAIN)
+		recruiter.jobban_roles += list(ROLE_POSIBRAIN)
 		recruiter.logging = TRUE
 
 		// A player has their role set to Yes or Always

--- a/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
@@ -265,7 +265,7 @@
 		recruiter = new(src)
 		recruiter.display_name = "sammi"
 		recruiter.role = ROLE_POSIBRAIN // keep it same for these
-		recruiter.jobban_roles += list(ROLE_POSIBRAIN)
+		recruiter.jobban_roles = list(ROLE_POSIBRAIN)
 		recruiter.logging = TRUE
 
 		// A player has their role set to Yes or Always

--- a/code/modules/mob/living/simple_animal/borer/egg.dm
+++ b/code/modules/mob/living/simple_animal/borer/egg.dm
@@ -37,7 +37,7 @@
 		recruiter = new(src)
 		recruiter.display_name = "borer"
 		recruiter.role = ROLE_BORER
-		recruiter.jobban_roles = list("pAI")
+		recruiter.jobban_roles += list("pAI")
 
 		// A player has their role set to Yes or Always
 		recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))

--- a/code/modules/mob/living/simple_animal/borer/egg.dm
+++ b/code/modules/mob/living/simple_animal/borer/egg.dm
@@ -37,7 +37,7 @@
 		recruiter = new(src)
 		recruiter.display_name = "borer"
 		recruiter.role = ROLE_BORER
-		recruiter.jobban_roles += list("pAI")
+		recruiter.jobban_roles = list("pAI")
 
 		// A player has their role set to Yes or Always
 		recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -330,9 +330,23 @@
 	observer.name = observer.real_name
 	if(!client.holder && !config.antag_hud_allowed)           // For new ghosts we remove the verb from even showing up if it's not allowed.
 		observer.verbs -= /mob/dead/observer/verb/toggle_antagHUD        // Poor guys, don't know what they are missing!
+
+	if (isobserverbanned(src))
+		observer = remove_obs_banned_verbs(observer)
+
 	mind.transfer_to(observer)
 	log_admin("([observer.ckey]/[observer]) started the game as a ghost.")
 	qdel(src)
+
+/mob/new_player/proc/remove_obs_banned_verbs(mob/dead/observer/O)
+	O.verbs -= /mob/dead/observer/verb/become_hobo
+	O.verbs -= /mob/dead/observer/verb/become_mommi
+	O.verbs -= /mob/dead/observer/verb/become_mouse
+	O.verbs -= /mob/dead/observer/verb/pai_signup
+
+	for(var/spell/targeted/ghost/become_mouse/spell in O.spell_list)
+		O.remove_spell(spell)
+	return O
 
 /mob/new_player/proc/create_cluwne()
 	var/mob/living/simple_animal/hostile/retaliate/cluwne/cluwne = new()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -61,12 +61,18 @@
 
 	output += "</div>"
 
-	//dumb but doesn't require rewriting this menu
+	// Special bans get different menus
+	if(isobserverbanned(src))
+		output = "<div align = 'center'<p><a href='byond://?src=\ref[src];show_preferences=1'>Setup Character</A></p>"
+		if(!ticker || ticker.current_state <= GAME_STATE_PREGAME)
+			if(job_master)
+				output += "<a href='byond://?src=\ref[src];predict=1'>Manifest Prediction (Unreliable)</A><br>"
+		else
+			output += "<a href='byond://?src=\ref[src];manifest=1'>View the Crew Manifest</A><br>"
+		output += "<p><a href='byond://?src=\ref[src];observe=1'>Observe</A></p></div>"
+
 	if(iscluwnebanned(src))
 		output = "<div align='center'><p><a href='byond://?src=\ref[src];cluwnebanned=1'>cluwne</a></p></div>"
-
-	if(isobserverbanned(src))
-		output = "<div align='center'><p><a href='byond://?src=\ref[src];observe=1'>Observe</A></p></div>"
 
 	var/datum/browser/popup = new(src, "playersetup", "<div align='center'>New Player Options</div>", 210, 250)
 	popup.set_content(output)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -318,9 +318,7 @@
 	// Has to be done here so we can get our random icon.
 	if(client.prefs.be_random_body)
 		client.prefs.randomize_appearance_for() // No argument means just the prefs are randomized.
-	client.prefs.update_preview_icon(1)
-	if(isobserverbanned(client))
-		client.prefs.preview_icon.Blend(new /icon('icons/mob/head.dmi', "duncecap"), ICON_OVERLAY)
+	client.prefs.update_preview_icon(1, src)
 	observer.icon = client.prefs.preview_icon
 	observer.alpha = 127
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -65,6 +65,9 @@
 	if(iscluwnebanned(src))
 		output = "<div align='center'><p><a href='byond://?src=\ref[src];cluwnebanned=1'>cluwne</a></p></div>"
 
+	if(isobserverbanned(src))
+		output = "<div align='center'><p><a href='byond://?src=\ref[src];observe=1'>Observe</A></p></div>"
+
 	var/datum/browser/popup = new(src, "playersetup", "<div align='center'>New Player Options</div>", 210, 250)
 	popup.set_content(output)
 	popup.set_window_options("focus=0;can_close=0;can_minimize=1;can_maximize=0;can_resize=1;titlebar=1;")
@@ -310,6 +313,8 @@
 	if(client.prefs.be_random_body)
 		client.prefs.randomize_appearance_for() // No argument means just the prefs are randomized.
 	client.prefs.update_preview_icon(1)
+	if(isobserverbanned(client))
+		client.prefs.preview_icon.Blend(new /icon('icons/mob/head.dmi', "duncecap"), ICON_OVERLAY)
 	observer.icon = client.prefs.preview_icon
 	observer.alpha = 127
 

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -158,7 +158,7 @@
 
 		.[key] = from_list[key]
 
-/datum/preferences/proc/update_preview_icon(var/for_observer=0)		//seriously. This is horrendous.
+/datum/preferences/proc/update_preview_icon(var/for_observer=0, var/mob/client=null)		//seriously. This is horrendous.
 	preview_icon_front = null
 	preview_icon_side = null
 	preview_icon = null
@@ -541,6 +541,10 @@
 				var/drink_icon = pick('icons/mob/in-hand/right/drinkingglass.dmi', 'icons/mob/in-hand/left/drinkingglass.dmi')
 				var/drink_icon_state = pick("coffee", "cafe_latte", "beer", "alebottle", "gargleblasterglass", "energy_drink", "sangria", "gintonicglass")
 				clothes_s.Blend(new /icon(drink_icon, drink_icon_state), ICON_OVERLAY)
+
+	// "Observer" banned players get a dunce cap
+	if(client != null && isobserverbanned(client))
+		clothes_s.Blend(new /icon('icons/mob/head.dmi', "duncecap"), ICON_OVERLAY)
 
 	if(disabilities & NEARSIGHTED)
 		preview_icon.Blend(new /icon('icons/mob/eyes.dmi', "glasses"), ICON_OVERLAY)

--- a/code/modules/spells/changeling/split.dm
+++ b/code/modules/spells/changeling/split.dm
@@ -36,7 +36,7 @@
 	if(!recruiter)
 		recruiter = new(owner.current)
 		recruiter.display_name = "Changeling"
-		recruiter.jobban_roles = list("Syndicate")
+		recruiter.jobban_roles += list("Syndicate")
 		recruiter.recruitment_timeout = 30 SECONDS
 	// Role set to Yes or Always
 	recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))

--- a/code/modules/spells/changeling/split.dm
+++ b/code/modules/spells/changeling/split.dm
@@ -36,7 +36,7 @@
 	if(!recruiter)
 		recruiter = new(owner.current)
 		recruiter.display_name = "Changeling"
-		recruiter.jobban_roles += list("Syndicate")
+		recruiter.jobban_roles = list("Syndicate")
 		recruiter.recruitment_timeout = 30 SECONDS
 	// Role set to Yes or Always
 	recruiter.player_volunteering = new /callback(src, nameof(src::recruiter_recruiting()))


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Adds the special type of jobban "observer":
- Can't join the game as anything but observer
- Won't be polled for midround recruitment
- Can't become mouse, mommi, hobo or pAI
- They don a dunce cap

Added to the admin player panel
Added cluwne ban to the panel as well, was missing

## Why it's good
<!-- Explain why you think these changes are good. -->
You just want to give a shitter a timeout but you want to let them observe the game still? Then this ban is for you. They can still use deadchat and OOC. If they start shitting those up, then a regular ban was the right choice after all.

![observer bans](https://github.com/vgstation-coders/vgstation13/assets/132118542/7e50e797-e2d3-44d9-bd99-c359af471a6a)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added "observer" type ban, can only observe. Added alongside cluwne to admin player panel jobban list.
