### PR TITLE
Blobs can no longer be picked up by subspace tunnelers

### DIFF
--- a/code/modules/projectiles/guns/projectile/constructable/subspacetunneler.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/subspacetunneler.dm
@@ -60,6 +60,7 @@
 		/obj/machinery/am_shielding,							//the AME
 		/obj/machinery/gateway,									//the gateway
 		/obj/structure/catwalk,									//catwalks
+		/obj/effect/blob,                                       //blobs
 		)
 
 /obj/item/weapon/subspacetunneler/Destroy()


### PR DESCRIPTION
I witnessed a round where some guy with a tunneler and a camera yoinked the skeleton blob core and did something with it that led to its destruction and I thought "man that sucks".
Drop a TTV instead!

:cl:
 * tweak: Subspace tunnelers can no longer pick up blob tiles.
