### PR TITLE
Admin custom bomb warnings and logs

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -668,11 +668,13 @@ var/list/admin_verbs_mod = list(
 			if(devastation_range > 299 || heavy_impact_range > 299 || light_impact_range > 299)
 				if(alert(usr, "THIS EXPLOSION MAY CRASH THE SERVER, ARE YOU REALLY SURE?", "DANGER ZONE", "Yes", "No") == "No")
 					return 0;
-				log_admin("[key_name(usr)] decided to set off a potentially server-crashing bomb despite the warning.")
+				log_admin("[key_name_admin(src)] decided to set off a potentially server-crashing bomb despite the warning.")
+				message_admins("<span class='warning'>[key_name_admin(src)] decided to set off a potentially server-crashing bomb despite the warning.</span>")
 			else if (devastation_range > 149 || heavy_impact_range > 149 || light_impact_range > 149)
 				if(alert(usr, "This explosion is likely to cause significant server lag, continue anyway?", "Lag Warning", "Yes", "No") == "No")
 					return 0;
-				log_admin("[key_name(usr)] decided to set off a potentially server-lagging bomb despite the warning.")
+				log_admin("[key_name_admin(src)] decided to set off a potentially server-lagging bomb despite the warning.")
+				message_admins("<span class='warning'>[key_name_admin(src)] decided to set off a potentially server-lagging bomb despite the warning.</span>")
 			explosion(epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, whodunnit = usr)
 
 	log_admin("[key_name(usr)] creating an admin explosion at [epicenter.loc] ([epicenter.x],[epicenter.y],[epicenter.z]).")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -665,6 +665,14 @@ var/list/admin_verbs_mod = list(
 			var/heavy_impact_range = input("Heavy impact range (in tiles):") as num
 			var/light_impact_range = input("Light impact range (in tiles):") as num
 			var/flash_range = input("Flash range (in tiles):") as num
+			if(var/devastation_range > 299 || var/heavy_impact_range > 299 || var/light_impact_range > 299)
+				if(alert(usr, "THIS EXPLOSION MAY CRASH THE SERVER, ARE YOU REALLY SURE?", "DANGER ZONE", "Yes", "No") == "No")
+					return 0;
+				log_admin("[key_name(usr)] decided to set off a potentially server-crashing bomb despite the warning.")
+			else if (var/devastation_range > 149 || var/heavy_impact_range > 149 || var/light_impact_range > 149)
+				if(alert(usr, "This explosion is likely to cause significant server lag, continue anyway?", "Lag Warning", "Yes", "No") == "No")
+					return 0;
+				log_admin("[key_name(usr)] decided to set off a potentially server-lagging bomb despite the warning.")
 			explosion(epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, whodunnit = usr)
 
 	log_admin("[key_name(usr)] creating an admin explosion at [epicenter.loc] ([epicenter.x],[epicenter.y],[epicenter.z]).")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -665,11 +665,11 @@ var/list/admin_verbs_mod = list(
 			var/heavy_impact_range = input("Heavy impact range (in tiles):") as num
 			var/light_impact_range = input("Light impact range (in tiles):") as num
 			var/flash_range = input("Flash range (in tiles):") as num
-			if(var/devastation_range > 299 || var/heavy_impact_range > 299 || var/light_impact_range > 299)
+			if(devastation_range > 299 || heavy_impact_range > 299 || light_impact_range > 299)
 				if(alert(usr, "THIS EXPLOSION MAY CRASH THE SERVER, ARE YOU REALLY SURE?", "DANGER ZONE", "Yes", "No") == "No")
 					return 0;
 				log_admin("[key_name(usr)] decided to set off a potentially server-crashing bomb despite the warning.")
-			else if (var/devastation_range > 149 || var/heavy_impact_range > 149 || var/light_impact_range > 149)
+			else if (devastation_range > 149 || heavy_impact_range > 149 || light_impact_range > 149)
 				if(alert(usr, "This explosion is likely to cause significant server lag, continue anyway?", "Lag Warning", "Yes", "No") == "No")
 					return 0;
 				log_admin("[key_name(usr)] decided to set off a potentially server-lagging bomb despite the warning.")


### PR DESCRIPTION
![adminlog](https://github.com/vgstation-coders/vgstation13/assets/19687076/957e24eb-d6fc-4803-b3e0-62f69867c2ae)
![adminwarn](https://github.com/vgstation-coders/vgstation13/assets/19687076/13013508-d6d7-43d3-b18a-014d7010485e)
## What this does
Adds warning messages and additional admin logging messages for dangerously large custom bombs.

## Why it's good
Admins might think twice before detonating 20000dev bombs.

[administration]
## Changelog
 * rscadd: Added warnings and additional logging to bombs above a certain threshold.