### PR TITLE
Spare Bear pelts count as all access even when worn as hats

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1373,7 +1373,7 @@
 		ACL |= I.GetAccess()
 	if(wear_id)
 		ACL |= wear_id.GetAccess()
-	if(head && istype(head, /obj/item/clothing/head/bearpelt/real/spare))
+	if(head)
 		ACL |= head.GetAccess()
 	return ACL
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1373,6 +1373,8 @@
 		ACL |= I.GetAccess()
 	if(wear_id)
 		ACL |= wear_id.GetAccess()
+	if(head && istype(head, /obj/item/clothing/head/bearpelt/real/spare))
+		ACL |= head.GetAccess()
 	return ACL
 
 /mob/living/carbon/human/get_visible_id()


### PR DESCRIPTION
Currently they only work as any other item AKA only when in the active hand or in the ID slot. This adds an exception in the human code's GetAccess() code where if the hat being worn is a spare bear pelt it will get its accesses. Why? For fun!

:cl:
 * rscadd: Spare Bear pelts now give their all access even when worn on the head.