### PR TITLE
Reverts lights in unoccupied departments shutting down

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -229,8 +229,6 @@ var/datum/controller/gameticker/ticker
 		if(job)
 			job.equip(M, job.priority) // Outfit datum.
 
-	handle_lights()
-
 	//delete the new_player mob for those who readied
 	for(var/mob/np in new_players_ready)
 		qdel(np)
@@ -648,19 +646,6 @@ var/datum/controller/gameticker/ticker
 		if(player.mind && (player.mind.assigned_role in command_positions))
 			roles += player.mind.assigned_role
 	return roles
-
-/datum/controller/gameticker/proc/handle_lights()
-	var/list/discrete_areas = areas.Copy()
-	//Get department areas where there is a crewmember. This is used to turn on lights in occupied departments
-	for(var/mob/living/player in player_list)
-		discrete_areas -= get_department_areas(player)
-	//Toggle lightswitches and lamps on in occupied departments
-	for(var/area/DA in discrete_areas)
-		for(var/obj/machinery/light_switch/LS in DA)
-			LS.toggle_switch(0, playsound = FALSE)
-			break
-		for(var/obj/item/device/flashlight/lamp/L in DA)
-			L.toggle_onoff(0)
 
 /datum/controller/gameticker/proc/post_roundstart()
 	//Handle all the cyborg syncing


### PR DESCRIPTION
I made this because I believe all the lights from unoccupied departments flicking off looks and feels ugly at roundstart, and in some cases you can see the lights getting shut down. The sound of lightswitches being flicked even in occupied departments became ubiquitous.
This is more of a "would people actually want this" PR than anything.

:cl:
 * rscdel: Lights will no longer switch off in unoccupied departments at the start of the game.
