### PR TITLE
Add Frequency and ID settings to the RPD

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -3,6 +3,8 @@
 	initialize_directions = SOUTH|NORTH
 	use_power = MACHINE_POWER_USE_IDLE
 
+	var/frequency = -1
+
 	var/datum/gas_mixture/air1
 	var/datum/gas_mixture/air2
 
@@ -92,6 +94,8 @@
 	if(!toggle_status(user)) // Subtypes returning FALSE do not allow alt-clicking to toggle power
 		..()
 
+/obj/machinery/atmospherics/binary/proc/set_frequency(new_frequency)
+
 /obj/machinery/atmospherics/binary/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
 	dir = pipe.dir
 	initialize_directions = pipe.get_pipe_dir()
@@ -108,6 +112,10 @@
 	if (node2)
 		node2.initialize()
 		node2.build_network()
+	if(pipe.frequency)
+		set_frequency(pipe.frequency)
+	if(pipe.id_tag)
+		id_tag = pipe.id_tag
 	return 1
 
 //this is used when a machine_flags = WRENCHMOVE machine gets anchored down

--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -21,7 +21,7 @@
 	//2: Do not pass input_pressure_min
 	//4: Do not pass output_pressure_max
 
-	var/frequency = 0
+	frequency = 0
 	
 	var/datum/radio_frequency/radio_connection
 
@@ -122,7 +122,7 @@
 
 //Radio remote control
 
-/obj/machinery/atmospherics/binary/dp_vent_pump/proc/set_frequency(new_frequency)
+/obj/machinery/atmospherics/binary/dp_vent_pump/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
 	if(frequency)
@@ -150,14 +150,6 @@
 	radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
 
 	return 1
-	
-/obj/machinery/atmospherics/binary/dp_vent_pump/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-	if(pipe.frequency)
-		set_frequency(pipe.frequency)
-	if(pipe.id)
-		src.id_tag = pipe.id
-	return ..()
-
 
 /obj/machinery/atmospherics/binary/dp_vent_pump/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -150,6 +150,12 @@
 	radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
 
 	return 1
+	
+/obj/machinery/atmospherics/binary/dp_vent_pump/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+    if(pipe.frequency)
+        set_frequency(pipe.frequency)
+    return ..()
+
 
 /obj/machinery/atmospherics/binary/dp_vent_pump/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -152,9 +152,11 @@
 	return 1
 	
 /obj/machinery/atmospherics/binary/dp_vent_pump/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-    if(pipe.frequency)
-        set_frequency(pipe.frequency)
-    return ..()
+	if(pipe.frequency)
+		set_frequency(pipe.frequency)
+	if(pipe.id)
+		src.id_tag = pipe.id
+	return ..()
 
 
 /obj/machinery/atmospherics/binary/dp_vent_pump/initialize()

--- a/code/ATMOSPHERICS/components/binary_devices/heat_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/heat_pump.dm
@@ -100,9 +100,11 @@ It also must be positive. Technically it can be 0 without breaking physics, but 
 	..()
 
 /obj/machinery/atmospherics/binary/heat_pump/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-    if(pipe.frequency)
-        set_frequency(pipe.frequency)
-    return ..()
+	if(pipe.frequency)
+		set_frequency(pipe.frequency)
+	if(pipe.id)
+		src.id_tag = pipe.id
+	return ..()
 
 /obj/machinery/atmospherics/binary/heat_pump/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/binary_devices/heat_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/heat_pump.dm
@@ -36,7 +36,7 @@ It also must be positive. Technically it can be 0 without breaking physics, but 
 
 	ghost_read = FALSE
 
-	var/frequency = 0
+	frequency = 0
 	var/datum/radio_frequency/radio_connection
 	machine_flags = MULTITOOL_MENU
 
@@ -99,20 +99,13 @@ It also must be positive. Technically it can be 0 without breaking physics, but 
 		icon_state = "intact_on"
 	..()
 
-/obj/machinery/atmospherics/binary/heat_pump/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-	if(pipe.frequency)
-		set_frequency(pipe.frequency)
-	if(pipe.id)
-		src.id_tag = pipe.id
-	return ..()
-
 /obj/machinery/atmospherics/binary/heat_pump/initialize()
 	..()
 	if(frequency)
 		set_frequency(frequency)
 
 
-/obj/machinery/atmospherics/binary/heat_pump/proc/set_frequency(new_frequency)
+/obj/machinery/atmospherics/binary/heat_pump/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
 	if(frequency)

--- a/code/ATMOSPHERICS/components/binary_devices/heat_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/heat_pump.dm
@@ -99,6 +99,10 @@ It also must be positive. Technically it can be 0 without breaking physics, but 
 		icon_state = "intact_on"
 	..()
 
+/obj/machinery/atmospherics/binary/heat_pump/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+    if(pipe.frequency)
+        set_frequency(pipe.frequency)
+    return ..()
 
 /obj/machinery/atmospherics/binary/heat_pump/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -90,6 +90,11 @@
 	radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
 
 	return 1
+	
+/obj/machinery/atmospherics/binary/passive_gate/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+    if(pipe.frequency)
+        set_frequency(pipe.frequency)
+    return ..()
 
 /obj/machinery/atmospherics/binary/passive_gate/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -9,7 +9,7 @@
 
 	var/open = FALSE
 
-	var/frequency = 0
+	frequency = 0
 
 	var/datum/radio_frequency/radio_connection
 	machine_flags = MULTITOOL_MENU
@@ -66,7 +66,7 @@
 //Radio remote control
 
 
-/obj/machinery/atmospherics/binary/passive_gate/proc/set_frequency(new_frequency)
+/obj/machinery/atmospherics/binary/passive_gate/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
 	if(frequency)
@@ -90,13 +90,6 @@
 	radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
 
 	return 1
-	
-/obj/machinery/atmospherics/binary/passive_gate/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-	if(pipe.frequency)
-		set_frequency(pipe.frequency)
-	if(pipe.id)
-		src.id_tag = pipe.id
-	return ..()
 
 /obj/machinery/atmospherics/binary/passive_gate/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -92,9 +92,11 @@
 	return 1
 	
 /obj/machinery/atmospherics/binary/passive_gate/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-    if(pipe.frequency)
-        set_frequency(pipe.frequency)
-    return ..()
+	if(pipe.frequency)
+		set_frequency(pipe.frequency)
+	if(pipe.id)
+		src.id_tag = pipe.id
+	return ..()
 
 /obj/machinery/atmospherics/binary/passive_gate/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -112,9 +112,11 @@ air2.volume
 	onclose(user, "atmo_pump")
 	
 /obj/machinery/atmospherics/binary/pump/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-    if(pipe.frequency)
-        set_frequency(pipe.frequency)
-    return ..()
+	if(pipe.frequency)
+		set_frequency(pipe.frequency)
+	if(pipe.id)
+		src.id_tag = pipe.id
+	return ..()
 
 /obj/machinery/atmospherics/binary/pump/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -23,7 +23,7 @@ air2.volume
 	desc = "A pump."
 	var/target_pressure = ONE_ATMOSPHERE
 
-	var/frequency = 0
+	frequency = 0
 
 	var/datum/radio_frequency/radio_connection
 
@@ -76,7 +76,7 @@ air2.volume
 //Radio remote control
 
 
-/obj/machinery/atmospherics/binary/pump/proc/set_frequency(new_frequency)
+/obj/machinery/atmospherics/binary/pump/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
 	if(frequency)
@@ -110,13 +110,6 @@ air2.volume
 
 	user << browse("<HEAD><TITLE>[src.name] control</TITLE></HEAD><TT>[dat]</TT>", "window=atmo_pump")
 	onclose(user, "atmo_pump")
-	
-/obj/machinery/atmospherics/binary/pump/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-	if(pipe.frequency)
-		set_frequency(pipe.frequency)
-	if(pipe.id)
-		src.id_tag = pipe.id
-	return ..()
 
 /obj/machinery/atmospherics/binary/pump/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -110,6 +110,11 @@ air2.volume
 
 	user << browse("<HEAD><TITLE>[src.name] control</TITLE></HEAD><TT>[dat]</TT>", "window=atmo_pump")
 	onclose(user, "atmo_pump")
+	
+/obj/machinery/atmospherics/binary/pump/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+    if(pipe.frequency)
+        set_frequency(pipe.frequency)
+    return ..()
 
 /obj/machinery/atmospherics/binary/pump/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -133,6 +133,11 @@
 	..()
 	if(frequency)
 		set_frequency(frequency)
+		
+/obj/machinery/atmospherics/binary/valve/digital/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+	if(pipe.frequency)
+		set_frequency(pipe.frequency)
+	return ..()
 
 /obj/machinery/atmospherics/binary/valve/digital/multitool_menu(var/mob/user,var/obj/item/device/multitool/P)
 	return {"

--- a/code/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -111,7 +111,7 @@
 	name = "digital valve"
 	desc = "A digitally controlled valve."
 	icon = 'icons/obj/atmospherics/digital_valve.dmi'
-	var/frequency = 0
+	frequency = 0
 
 	var/datum/radio_frequency/radio_connection
 
@@ -123,7 +123,7 @@
 
 //Radio remote control
 
-/obj/machinery/atmospherics/binary/valve/digital/proc/set_frequency(new_frequency)
+/obj/machinery/atmospherics/binary/valve/digital/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
 	if(frequency)
@@ -133,13 +133,6 @@
 	..()
 	if(frequency)
 		set_frequency(frequency)
-		
-/obj/machinery/atmospherics/binary/valve/digital/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-	if(pipe.frequency)
-		set_frequency(pipe.frequency)
-	if(pipe.id)
-		src.id_tag = pipe.id
-	return ..()
 
 /obj/machinery/atmospherics/binary/valve/digital/multitool_menu(var/mob/user,var/obj/item/device/multitool/P)
 	return {"

--- a/code/ATMOSPHERICS/components/binary_devices/valve.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/valve.dm
@@ -137,6 +137,8 @@
 /obj/machinery/atmospherics/binary/valve/digital/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
 	if(pipe.frequency)
 		set_frequency(pipe.frequency)
+	if(pipe.id)
+		src.id_tag = pipe.id
 	return ..()
 
 /obj/machinery/atmospherics/binary/valve/digital/multitool_menu(var/mob/user,var/obj/item/device/multitool/P)

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -23,7 +23,7 @@ Thus, the two variables affect pump operation are set in New():
 
 	var/transfer_rate = MAX_TRANSFER_RATE
 
-	var/frequency = 0
+	frequency = 0
 	var/pump_stalled = 0
 
 	var/datum/radio_frequency/radio_connection
@@ -77,7 +77,7 @@ Thus, the two variables affect pump operation are set in New():
 
 	return 1
 
-/obj/machinery/atmospherics/binary/volume_pump/proc/set_frequency(new_frequency)
+/obj/machinery/atmospherics/binary/volume_pump/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
 	if(frequency)
@@ -110,13 +110,6 @@ Thus, the two variables affect pump operation are set in New():
 
 	user << browse("<HEAD><TITLE>[src.name] control</TITLE></HEAD><TT>[dat]</TT>", "window=atmo_pump")
 	onclose(user, "atmo_pump")
-
-/obj/machinery/atmospherics/binary/volume_pump/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-	if(pipe.frequency)
-		set_frequency(pipe.frequency)
-	if(pipe.id)
-		src.id_tag = pipe.id
-	return ..()
 
 /obj/machinery/atmospherics/binary/volume_pump/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -111,7 +111,10 @@ Thus, the two variables affect pump operation are set in New():
 	user << browse("<HEAD><TITLE>[src.name] control</TITLE></HEAD><TT>[dat]</TT>", "window=atmo_pump")
 	onclose(user, "atmo_pump")
 
-
+/obj/machinery/atmospherics/binary/volume_pump/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+    if(pipe.frequency)
+        set_frequency(pipe.frequency)
+    return ..()
 
 /obj/machinery/atmospherics/binary/volume_pump/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -112,9 +112,11 @@ Thus, the two variables affect pump operation are set in New():
 	onclose(user, "atmo_pump")
 
 /obj/machinery/atmospherics/binary/volume_pump/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-    if(pipe.frequency)
-        set_frequency(pipe.frequency)
-    return ..()
+	if(pipe.frequency)
+		set_frequency(pipe.frequency)
+	if(pipe.id)
+		src.id_tag = pipe.id
+	return ..()
 
 /obj/machinery/atmospherics/binary/volume_pump/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -21,12 +21,12 @@ Filter types:
  4: Sleeping Agent (N2O)
 */
 
-	var/frequency = 0
+	frequency = 0
 	var/datum/radio_frequency/radio_connection
 
 	ex_node_offset = 5
 
-/obj/machinery/atmospherics/trinary/filter/proc/set_frequency(new_frequency)
+/obj/machinery/atmospherics/trinary/filter/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
 	if(frequency)

--- a/code/ATMOSPHERICS/components/trinary_devices/pressure_valve.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/pressure_valve.dm
@@ -346,6 +346,11 @@
 	frequency = new_frequency
 	if(frequency)
 		radio_connection = radio_controller.add_object(src, frequency, RADIO_ATMOSIA)
+		
+/obj/machinery/atmospherics/trinary/pressure_valve/digital/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+    if(pipe.frequency)
+        set_frequency(pipe.frequency)
+    return ..()
 
 /obj/machinery/atmospherics/trinary/pressure_valve/digital/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/trinary_devices/pressure_valve.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/pressure_valve.dm
@@ -348,9 +348,11 @@
 		radio_connection = radio_controller.add_object(src, frequency, RADIO_ATMOSIA)
 		
 /obj/machinery/atmospherics/trinary/pressure_valve/digital/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-    if(pipe.frequency)
-        set_frequency(pipe.frequency)
-    return ..()
+	if(pipe.frequency)
+		set_frequency(pipe.frequency)
+	if(pipe.id)
+		src.id_tag = pipe.id
+	return ..()
 
 /obj/machinery/atmospherics/trinary/pressure_valve/digital/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/trinary_devices/pressure_valve.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/pressure_valve.dm
@@ -328,7 +328,7 @@
 	name = "digital conditional valve"
 	desc = "A digitally controlled automatic valve."
 
-	var/frequency = 0
+	frequency = 0
 	var/datum/radio_frequency/radio_connection
 	machine_flags = MULTITOOL_MENU
 
@@ -341,18 +341,11 @@
 	</ul>
 	"}
 
-/obj/machinery/atmospherics/trinary/pressure_valve/digital/proc/set_frequency(new_frequency)
+/obj/machinery/atmospherics/trinary/pressure_valve/digital/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
 	if(frequency)
 		radio_connection = radio_controller.add_object(src, frequency, RADIO_ATMOSIA)
-		
-/obj/machinery/atmospherics/trinary/pressure_valve/digital/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-	if(pipe.frequency)
-		set_frequency(pipe.frequency)
-	if(pipe.id)
-		src.id_tag = pipe.id
-	return ..()
 
 /obj/machinery/atmospherics/trinary/pressure_valve/digital/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/trinary_devices/t_valve.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/t_valve.dm
@@ -232,6 +232,11 @@
 	frequency = new_frequency
 	if(frequency)
 		radio_connection = radio_controller.add_object(src, frequency, RADIO_ATMOSIA)
+		
+/obj/machinery/atmospherics/trinary/tvalve/digital/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+    if(pipe.frequency)
+        set_frequency(pipe.frequency)
+    return ..()		
 
 /obj/machinery/atmospherics/trinary/tvalve/digital/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/trinary_devices/t_valve.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/t_valve.dm
@@ -234,9 +234,11 @@
 		radio_connection = radio_controller.add_object(src, frequency, RADIO_ATMOSIA)
 		
 /obj/machinery/atmospherics/trinary/tvalve/digital/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-    if(pipe.frequency)
-        set_frequency(pipe.frequency)
-    return ..()		
+	if(pipe.frequency)
+		set_frequency(pipe.frequency)
+	if(pipe.id)
+		src.id_tag = pipe.id
+	return ..()
 
 /obj/machinery/atmospherics/trinary/tvalve/digital/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/trinary_devices/t_valve.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/t_valve.dm
@@ -180,7 +180,7 @@
 	desc = "A digitally controlled valve."
 	icon = 'icons/obj/atmospherics/digital_valve.dmi'
 
-	var/frequency = 0
+	frequency = 0
 
 	var/datum/radio_frequency/radio_connection
 
@@ -227,18 +227,11 @@
 
 		//Radio remote control
 
-/obj/machinery/atmospherics/trinary/tvalve/digital/proc/set_frequency(new_frequency)
+/obj/machinery/atmospherics/trinary/tvalve/digital/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
 	if(frequency)
 		radio_connection = radio_controller.add_object(src, frequency, RADIO_ATMOSIA)
-		
-/obj/machinery/atmospherics/trinary/tvalve/digital/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-	if(pipe.frequency)
-		set_frequency(pipe.frequency)
-	if(pipe.id)
-		src.id_tag = pipe.id
-	return ..()
 
 /obj/machinery/atmospherics/trinary/tvalve/digital/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
@@ -3,6 +3,8 @@
 	initialize_directions = SOUTH|NORTH|WEST
 	use_power = MACHINE_POWER_USE_IDLE
 	can_be_coloured = 0
+	
+	var/frequency = -1
 
 	var/datum/gas_mixture/air1
 	var/datum/gas_mixture/air2
@@ -51,6 +53,8 @@
 		if(WEST)
 			initialize_directions = EAST|WEST|NORTH
 	..()
+	
+/obj/machinery/atmospherics/trinary/proc/set_frequency(new_frequency)
 
 /obj/machinery/atmospherics/trinary/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
 	if(!(pipe.dir in list(NORTH, SOUTH, EAST, WEST)) && src.mirror) //because the dir isn't in the right set, we want to make the mirror kind
@@ -77,6 +81,10 @@
 	if (node3)
 		node3.initialize()
 		node3.build_network()
+	if(pipe.frequency)
+		set_frequency(pipe.frequency)
+	if(pipe.id_tag)
+		id_tag = pipe.id_tag
 	return 1
 
 

--- a/code/ATMOSPHERICS/components/unary/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary/outlet_injector.dm
@@ -110,9 +110,11 @@
 	return 1
 	
 /obj/machinery/atmospherics/unary/outlet_injector/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-    if(pipe.frequency)
-        set_frequency(pipe.frequency)
-    return ..()
+	if(pipe.frequency)
+		set_frequency(pipe.frequency)
+	if(pipe.id)
+		src.id_tag = pipe.id
+	return ..()
 
 /obj/machinery/atmospherics/unary/outlet_injector/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/unary/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary/outlet_injector.dm
@@ -108,6 +108,11 @@
 	radio_connection.post_signal(src, signal)
 
 	return 1
+	
+/obj/machinery/atmospherics/unary/outlet_injector/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+    if(pipe.frequency)
+        set_frequency(pipe.frequency)
+    return ..()
 
 /obj/machinery/atmospherics/unary/outlet_injector/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/unary/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary/outlet_injector.dm
@@ -12,7 +12,7 @@
 	var/volume_rate = CELL_VOLUME //1 tile worth of air by default
 	var/max_rate= 4*CELL_VOLUME // 10000L
 
-	var/frequency = 0
+	frequency = 0
 	var/datum/radio_frequency/radio_connection
 
 	level = 1
@@ -82,7 +82,7 @@
 
 	flick("inject", src)
 
-/obj/machinery/atmospherics/unary/outlet_injector/proc/set_frequency(new_frequency)
+/obj/machinery/atmospherics/unary/outlet_injector/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
 	if(frequency)
@@ -108,13 +108,6 @@
 	radio_connection.post_signal(src, signal)
 
 	return 1
-	
-/obj/machinery/atmospherics/unary/outlet_injector/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-	if(pipe.frequency)
-		set_frequency(pipe.frequency)
-	if(pipe.id)
-		src.id_tag = pipe.id
-	return ..()
 
 /obj/machinery/atmospherics/unary/outlet_injector/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/unary/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary/unary_base.dm
@@ -6,6 +6,7 @@
 	var/datum/gas_mixture/air_contents
 	var/obj/machinery/atmospherics/node1
 	var/datum/pipe_network/network
+	var/frequency = -1
 
 /obj/machinery/atmospherics/unary/New()
 	..()
@@ -43,7 +44,8 @@
 /obj/machinery/atmospherics/unary/update_icon(var/adjacent_procd,node_list)
 	node_list = list(node1)
 	..(adjacent_procd,node_list)
-
+	
+/obj/machinery/atmospherics/unary/proc/set_frequency(new_frequency)
 
 /obj/machinery/atmospherics/unary/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
 	dir = pipe.dir
@@ -58,6 +60,10 @@
 	if (node1)
 		node1.initialize()
 		node1.build_network()
+	if(pipe.frequency)
+		set_frequency(pipe.frequency)
+	if(pipe.id_tag)
+		id_tag = pipe.id_tag
 	return 1
 
 //this is used when a machine_flags = WRENCHMOVE machine gets anchored down

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -175,6 +175,10 @@
 
 /obj/machinery/atmospherics/unary/vent_pump/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
 	..()
+	if(pipe.frequency)
+		set_frequency(pipe.frequency)
+	if(pipe.id)
+		src.id_tag = pipe.id
 	src.broadcast_status()
 	return 1
 
@@ -210,11 +214,6 @@
 	radio_connection.post_signal(src, signal, radio_filter_out)
 
 	return 1
-
-/obj/machinery/atmospherics/unary/vent_pump/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-    if(pipe.frequency)
-        set_frequency(pipe.frequency)
-    return ..()
 
 /obj/machinery/atmospherics/unary/vent_pump/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -211,6 +211,10 @@
 
 	return 1
 
+/obj/machinery/atmospherics/unary/vent_pump/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+    if(pipe.frequency)
+        set_frequency(pipe.frequency)
+    return ..()
 
 /obj/machinery/atmospherics/unary/vent_pump/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -24,7 +24,7 @@
 	var/welded = 0 // Added for aliens -- TLE
 	var/canSpawnMice = 1 // Set to 0 to prevent spawning of mice.
 
-	var/frequency = 1439
+	frequency = 1439
 	var/datum/radio_frequency/radio_connection
 
 	var/radio_filter_out
@@ -159,7 +159,7 @@
 
 	return pressure_delta
 
-/obj/machinery/atmospherics/unary/vent_pump/proc/set_frequency(new_frequency)
+/obj/machinery/atmospherics/unary/vent_pump/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
 	if(frequency)
@@ -172,13 +172,9 @@
 		name = "Vent Pump"
 	else
 		broadcast_status()
-
+		
 /obj/machinery/atmospherics/unary/vent_pump/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
 	..()
-	if(pipe.frequency)
-		set_frequency(pipe.frequency)
-	if(pipe.id)
-		src.id_tag = pipe.id
 	src.broadcast_status()
 	return 1
 

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -9,7 +9,7 @@
 
 	level				= 1
 
-	var/frequency		= 1439
+	frequency		= 1439
 	var/datum/radio_frequency/radio_connection
 
 	var/on				= 0
@@ -96,7 +96,7 @@
 
 	..()
 
-/obj/machinery/atmospherics/unary/vent_scrubber/proc/set_frequency(new_frequency)
+/obj/machinery/atmospherics/unary/vent_scrubber/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
 	radio_connection = radio_controller.add_object(src, frequency, radio_filter_in)
@@ -108,13 +108,9 @@
 		name = "Air Scrubber"
 	else
 		broadcast_status()
-
+		
 /obj/machinery/atmospherics/unary/vent_scrubber/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
 	..()
-	if(pipe.frequency)
-		set_frequency(pipe.frequency)
-	if(pipe.id)
-		src.id_tag = pipe.id
 	src.broadcast_status()
 	return 1
 

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -168,6 +168,10 @@
 		else //stalled and too much pressure, do nothing
 			return
 
+/obj/machinery/atmospherics/unary/vent_scrubber/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+    if(pipe.frequency)
+        set_frequency(pipe.frequency)
+    return ..()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/initialize()
 	..()

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -111,6 +111,10 @@
 
 /obj/machinery/atmospherics/unary/vent_scrubber/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
 	..()
+	if(pipe.frequency)
+		set_frequency(pipe.frequency)
+	if(pipe.id)
+		src.id_tag = pipe.id
 	src.broadcast_status()
 	return 1
 
@@ -167,11 +171,6 @@
 			update_icon()
 		else //stalled and too much pressure, do nothing
 			return
-
-/obj/machinery/atmospherics/unary/vent_scrubber/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
-    if(pipe.frequency)
-        set_frequency(pipe.frequency)
-    return ..()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/initialize()
 	..()

--- a/code/ATMOSPHERICS/pipe/construction.dm
+++ b/code/ATMOSPHERICS/pipe/construction.dm
@@ -74,6 +74,7 @@ var/global/list/heat_pipes = list(PIPE_HE_STRAIGHT, PIPE_HE_BENT, PIPE_JUNCTION,
 	flags = FPRINT
 	w_class = W_CLASS_MEDIUM
 	level = 2
+	var/frequency = 0
 
 	var/piping_layer = PIPING_LAYER_DEFAULT
 
@@ -100,8 +101,10 @@ var/global/list/heat_pipes = list(PIPE_HE_STRAIGHT, PIPE_HE_BENT, PIPE_JUNCTION,
 	qdel(src)
 	return 2
 var/list/bent_dirs = list(NORTH|SOUTH, WEST|EAST)
-/obj/item/pipe/New(var/loc, var/pipe_type as num, var/dir as num, var/obj/machinery/atmospherics/make_from = null)
+/obj/item/pipe/New(var/loc, var/pipe_type as num, var/dir as num, var/obj/machinery/atmospherics/make_from = null, frequency = 0)
 	..()
+	if (frequency)
+		src.frequency = frequency
 	if (make_from)
 		src.dir = make_from.dir
 		src.pipename = make_from.name
@@ -581,8 +584,14 @@ var/list/manifold_pipes = list(PIPE_MANIFOLD4W, PIPE_INSUL_MANIFOLD4W, PIPE_HE_M
 	item_state = "buildpipe"
 	flags = FPRINT
 	w_class = W_CLASS_LARGE
+	var/frequency = 1439
 
 	var/layer_to_make = PIPING_LAYER_DEFAULT
+	
+/obj/item/pipe_meter/New(loc, frequency = 0)
+	..()
+	if(frequency)
+		src.frequency = frequency
 
 /obj/item/pipe_meter/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	..()
@@ -597,7 +606,7 @@ var/list/manifold_pipes = list(PIPE_MANIFOLD4W, PIPE_INSUL_MANIFOLD4W, PIPE_HE_M
 	if(!pipe)
 		to_chat(user, "<span class='warning'>You need to fasten it to a pipe.</span>")
 		return 1
-	new/obj/machinery/meter(src.loc, pipe)
+	new/obj/machinery/meter(src.loc, pipe, frequency)
 	W.playtoolsound(src, 50)
 	to_chat(user, "<span class='notice'>You have fastened the meter to the pipe.</span>")
 	qdel(src)
@@ -620,12 +629,18 @@ var/list/manifold_pipes = list(PIPE_MANIFOLD4W, PIPE_INSUL_MANIFOLD4W, PIPE_HE_M
 	item_state = "buildpipe"
 	flags = FPRINT
 	w_class = W_CLASS_LARGE
+	var/frequency = 1439
+	
+/obj/item/pipe_gsensor/New(loc, frequency = 0)
+	..()
+	if(frequency)
+		src.frequency = frequency
 
 /obj/item/pipe_gsensor/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	..()
 	if(!W.is_wrench(user))
 		return ..()
-	new/obj/machinery/air_sensor( src.loc )
+	new/obj/machinery/air_sensor( src.loc, frequency )
 	W.playtoolsound(src, 50)
 	to_chat(user, "<span class='notice'>You have fastened the gas sensor.</span>")
 	qdel(src)

--- a/code/ATMOSPHERICS/pipe/construction.dm
+++ b/code/ATMOSPHERICS/pipe/construction.dm
@@ -75,6 +75,7 @@ var/global/list/heat_pipes = list(PIPE_HE_STRAIGHT, PIPE_HE_BENT, PIPE_JUNCTION,
 	w_class = W_CLASS_MEDIUM
 	level = 2
 	var/frequency = 0
+	var/id = null
 
 	var/piping_layer = PIPING_LAYER_DEFAULT
 
@@ -101,10 +102,12 @@ var/global/list/heat_pipes = list(PIPE_HE_STRAIGHT, PIPE_HE_BENT, PIPE_JUNCTION,
 	qdel(src)
 	return 2
 var/list/bent_dirs = list(NORTH|SOUTH, WEST|EAST)
-/obj/item/pipe/New(var/loc, var/pipe_type as num, var/dir as num, var/obj/machinery/atmospherics/make_from = null, frequency = 0)
+/obj/item/pipe/New(var/loc, var/pipe_type as num, var/dir as num, var/obj/machinery/atmospherics/make_from = null, frequency, id)
 	..()
 	if (frequency)
 		src.frequency = frequency
+	if (id)
+		src.id = id
 	if (make_from)
 		src.dir = make_from.dir
 		src.pipename = make_from.name
@@ -585,13 +588,16 @@ var/list/manifold_pipes = list(PIPE_MANIFOLD4W, PIPE_INSUL_MANIFOLD4W, PIPE_HE_M
 	flags = FPRINT
 	w_class = W_CLASS_LARGE
 	var/frequency = 1439
+	var/id = null
 
 	var/layer_to_make = PIPING_LAYER_DEFAULT
 	
-/obj/item/pipe_meter/New(loc, frequency = 0)
+/obj/item/pipe_meter/New(loc, frequency, id)
 	..()
 	if(frequency)
 		src.frequency = frequency
+	if(id)
+		src.id = id
 
 /obj/item/pipe_meter/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	..()
@@ -606,7 +612,7 @@ var/list/manifold_pipes = list(PIPE_MANIFOLD4W, PIPE_INSUL_MANIFOLD4W, PIPE_HE_M
 	if(!pipe)
 		to_chat(user, "<span class='warning'>You need to fasten it to a pipe.</span>")
 		return 1
-	new/obj/machinery/meter(src.loc, pipe, frequency)
+	new/obj/machinery/meter(src.loc, pipe, frequency, id)
 	W.playtoolsound(src, 50)
 	to_chat(user, "<span class='notice'>You have fastened the meter to the pipe.</span>")
 	qdel(src)
@@ -630,17 +636,20 @@ var/list/manifold_pipes = list(PIPE_MANIFOLD4W, PIPE_INSUL_MANIFOLD4W, PIPE_HE_M
 	flags = FPRINT
 	w_class = W_CLASS_LARGE
 	var/frequency = 1439
+	var/id = null
 	
-/obj/item/pipe_gsensor/New(loc, frequency = 0)
+/obj/item/pipe_gsensor/New(loc, frequency, id)
 	..()
 	if(frequency)
 		src.frequency = frequency
+	if(id)
+		src.id = id
 
 /obj/item/pipe_gsensor/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	..()
 	if(!W.is_wrench(user))
 		return ..()
-	new/obj/machinery/air_sensor( src.loc, frequency )
+	new/obj/machinery/air_sensor( src.loc, frequency, id )
 	W.playtoolsound(src, 50)
 	to_chat(user, "<span class='notice'>You have fastened the gas sensor.</span>")
 	qdel(src)

--- a/code/ATMOSPHERICS/pipe/construction.dm
+++ b/code/ATMOSPHERICS/pipe/construction.dm
@@ -75,7 +75,7 @@ var/global/list/heat_pipes = list(PIPE_HE_STRAIGHT, PIPE_HE_BENT, PIPE_JUNCTION,
 	w_class = W_CLASS_MEDIUM
 	level = 2
 	var/frequency = 0
-	var/id = null
+	var/id_tag = null
 
 	var/piping_layer = PIPING_LAYER_DEFAULT
 
@@ -102,12 +102,12 @@ var/global/list/heat_pipes = list(PIPE_HE_STRAIGHT, PIPE_HE_BENT, PIPE_JUNCTION,
 	qdel(src)
 	return 2
 var/list/bent_dirs = list(NORTH|SOUTH, WEST|EAST)
-/obj/item/pipe/New(var/loc, var/pipe_type as num, var/dir as num, var/obj/machinery/atmospherics/make_from = null, frequency, id)
+/obj/item/pipe/New(var/loc, var/pipe_type as num, var/dir as num, var/obj/machinery/atmospherics/make_from = null, freq, id)
 	..()
-	if (frequency)
-		src.frequency = frequency
+	if (freq)
+		frequency = freq
 	if (id)
-		src.id = id
+		id_tag = id
 	if (make_from)
 		src.dir = make_from.dir
 		src.pipename = make_from.name
@@ -588,16 +588,16 @@ var/list/manifold_pipes = list(PIPE_MANIFOLD4W, PIPE_INSUL_MANIFOLD4W, PIPE_HE_M
 	flags = FPRINT
 	w_class = W_CLASS_LARGE
 	var/frequency = 1439
-	var/id = null
+	var/id_tag = null
 
 	var/layer_to_make = PIPING_LAYER_DEFAULT
 	
-/obj/item/pipe_meter/New(loc, frequency, id)
+/obj/item/pipe_meter/New(loc, freq, id)
 	..()
-	if(frequency)
-		src.frequency = frequency
+	if(freq)
+		frequency = freq
 	if(id)
-		src.id = id
+		id_tag = id
 
 /obj/item/pipe_meter/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	..()
@@ -612,7 +612,7 @@ var/list/manifold_pipes = list(PIPE_MANIFOLD4W, PIPE_INSUL_MANIFOLD4W, PIPE_HE_M
 	if(!pipe)
 		to_chat(user, "<span class='warning'>You need to fasten it to a pipe.</span>")
 		return 1
-	new/obj/machinery/meter(src.loc, pipe, frequency, id)
+	new/obj/machinery/meter(src.loc, pipe, frequency, id_tag)
 	W.playtoolsound(src, 50)
 	to_chat(user, "<span class='notice'>You have fastened the meter to the pipe.</span>")
 	qdel(src)
@@ -636,20 +636,20 @@ var/list/manifold_pipes = list(PIPE_MANIFOLD4W, PIPE_INSUL_MANIFOLD4W, PIPE_HE_M
 	flags = FPRINT
 	w_class = W_CLASS_LARGE
 	var/frequency = 1439
-	var/id = null
+	var/id_tag = null
 	
-/obj/item/pipe_gsensor/New(loc, frequency, id)
+/obj/item/pipe_gsensor/New(loc, freq, id)
 	..()
-	if(frequency)
-		src.frequency = frequency
+	if(freq)
+		frequency = freq
 	if(id)
-		src.id = id
+		id_tag = id
 
 /obj/item/pipe_gsensor/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	..()
 	if(!W.is_wrench(user))
 		return ..()
-	new/obj/machinery/air_sensor( src.loc, frequency, id )
+	new/obj/machinery/air_sensor( src.loc, frequency, id_tag )
 	W.playtoolsound(src, 50)
 	to_chat(user, "<span class='notice'>You have fastened the gas sensor.</span>")
 	qdel(src)

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -108,11 +108,11 @@
 		return
 	set_frequency(frequency)
 
-/obj/machinery/air_sensor/New(loc, frequency = 1439, id = null)
+/obj/machinery/air_sensor/New(loc, freq = 1439, id = null)
 	..()
 
-	src.frequency = frequency
-	src.id_tag = id
+	frequency = freq
+	id_tag = id
 	if(ticker && ticker.current_state == GAME_STATE_PLAYING)
 		initialize()
 

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -108,10 +108,11 @@
 		return
 	set_frequency(frequency)
 
-/obj/machinery/air_sensor/New(loc, frequency = 1439)
+/obj/machinery/air_sensor/New(loc, frequency = 1439, id = null)
 	..()
 
 	src.frequency = frequency
+	src.id_tag = id
 	if(ticker && ticker.current_state == GAME_STATE_PLAYING)
 		initialize()
 

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -108,9 +108,10 @@
 		return
 	set_frequency(frequency)
 
-/obj/machinery/air_sensor/New()
+/obj/machinery/air_sensor/New(loc, frequency = 1439)
 	..()
 
+	src.frequency = frequency
 	if(ticker && ticker.current_state == GAME_STATE_PLAYING)
 		initialize()
 

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -14,13 +14,13 @@
 	active_power_usage = 4
 	machine_flags = MULTITOOL_MENU
 
-/obj/machinery/meter/New(newloc, new_target, frequency = 1439, id = null)
+/obj/machinery/meter/New(newloc, new_target, freq = 1439, id = null)
 	..(newloc)
 	src.target = new_target
 	if(target)
 		setAttachLayer(target.piping_layer)
-	src.frequency = frequency
-	src.id_tag = id
+	frequency = freq
+	id_tag = id
 	return 1
 
 /obj/machinery/meter/initialize()

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -14,12 +14,13 @@
 	active_power_usage = 4
 	machine_flags = MULTITOOL_MENU
 
-/obj/machinery/meter/New(newloc, new_target, frequency = 1439)
+/obj/machinery/meter/New(newloc, new_target, frequency = 1439, id = null)
 	..(newloc)
 	src.target = new_target
 	if(target)
 		setAttachLayer(target.piping_layer)
 	src.frequency = frequency
+	src.id_tag = id
 	return 1
 
 /obj/machinery/meter/initialize()

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -14,11 +14,12 @@
 	active_power_usage = 4
 	machine_flags = MULTITOOL_MENU
 
-/obj/machinery/meter/New(newloc, new_target)
+/obj/machinery/meter/New(newloc, new_target, frequency = 1439)
 	..(newloc)
 	src.target = new_target
 	if(target)
 		setAttachLayer(target.piping_layer)
+	src.frequency = frequency
 	return 1
 
 /obj/machinery/meter/initialize()

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -17,6 +17,8 @@
 	w_type              = RECYK_ELECTRONIC
 	melt_temperature    = MELTPOINT_STEEL // Lots of metal
 	origin_tech         = Tc_ENGINEERING + "=4;" + Tc_MATERIALS + "=2"
+	
+	var/frequency = 0
 
 	//list of schematics, in definitions of RCD subtypes, no organization is needed, in New() these get organized.
 	var/list/schematics = list(/datum/rcd_schematic/test)

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -19,6 +19,7 @@
 	origin_tech         = Tc_ENGINEERING + "=4;" + Tc_MATERIALS + "=2"
 	
 	var/frequency = 0
+	var/id = null
 
 	//list of schematics, in definitions of RCD subtypes, no organization is needed, in New() these get organized.
 	var/list/schematics = list(/datum/rcd_schematic/test)

--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -2,7 +2,8 @@
 	name       = "\improper Rapid-Piping-Device (RPD)"
 	desc       = "A device used to rapidly pipe things."
 	icon_state = "rpd"
-	frequency = 0
+	frequency = 1439
+	id = null
 	var/has_metal_slime = 0
 	var/has_yellow_slime = 0
 	starting_materials = list(MAT_IRON = 75000, MAT_GLASS = 37500)
@@ -196,9 +197,9 @@
 				our_schematic.set_layer(layer)
 				if(layer != 5 )
 					spawn(-1)
-						our_schematic.attack(A, user, frequency)
+						our_schematic.attack(A, user, frequency, id)
 				else
-					var/t = our_schematic.attack(A, user, frequency)
+					var/t = our_schematic.attack(A, user, frequency, id)
 					if(!t) // No errors
 						if(~our_schematic.flags & RCD_SELF_COST) // Handle energy costs unless the schematic does it itself.
 							use_energy(our_schematic.energy_cost, user)
@@ -212,7 +213,7 @@
 			return 1
 
 	busy  = TRUE // Busy to prevent switching schematic while it's in use.
-	var/t = selected.attack(A, user, frequency)
+	var/t = selected.attack(A, user, frequency, id)
 	if(!t) // No errors
 		if(~selected.flags & RCD_SELF_COST) // Handle energy costs unless the schematic does it itself.
 			use_energy(selected.energy_cost, user)

--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -2,6 +2,7 @@
 	name       = "\improper Rapid-Piping-Device (RPD)"
 	desc       = "A device used to rapidly pipe things."
 	icon_state = "rpd"
+	frequency = 0
 	var/has_metal_slime = 0
 	var/has_yellow_slime = 0
 	starting_materials = list(MAT_IRON = 75000, MAT_GLASS = 37500)
@@ -195,9 +196,9 @@
 				our_schematic.set_layer(layer)
 				if(layer != 5 )
 					spawn(-1)
-						our_schematic.attack(A, user)
+						our_schematic.attack(A, user, frequency)
 				else
-					var/t = our_schematic.attack(A, user)
+					var/t = our_schematic.attack(A, user, frequency)
 					if(!t) // No errors
 						if(~our_schematic.flags & RCD_SELF_COST) // Handle energy costs unless the schematic does it itself.
 							use_energy(our_schematic.energy_cost, user)
@@ -211,7 +212,7 @@
 			return 1
 
 	busy  = TRUE // Busy to prevent switching schematic while it's in use.
-	var/t = selected.attack(A, user)
+	var/t = selected.attack(A, user, frequency)
 	if(!t) // No errors
 		if(~selected.flags & RCD_SELF_COST) // Handle energy costs unless the schematic does it itself.
 			use_energy(selected.energy_cost, user)

--- a/code/modules/RCD/schematics/pipe.dm
+++ b/code/modules/RCD/schematics/pipe.dm
@@ -169,7 +169,7 @@
 	category = "Devices"
 	flags    = RCD_RANGE | RCD_GET_TURF | RCD_ALLOW_SWITCH
 
-/datum/rcd_schematic/gsensor/attack(var/atom/A, var/mob/user, frequency = 0)
+/datum/rcd_schematic/gsensor/attack(var/atom/A, var/mob/user, frequency, id)
 	if(!isturf(A))
 		return
 
@@ -179,14 +179,14 @@
 		return 1
 
 	playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
-	new /obj/item/pipe_gsensor(A, frequency)
+	new /obj/item/pipe_gsensor(A, frequency, id)
 
 /datum/rcd_schematic/pmeter
 	name     = "Pipe meter"
 	category = "Devices"
 	flags    = RCD_RANGE | RCD_GET_TURF | RCD_ALLOW_SWITCH
 
-/datum/rcd_schematic/pmeter/attack(var/atom/A, var/mob/user, frequency = 0)
+/datum/rcd_schematic/pmeter/attack(var/atom/A, var/mob/user, frequency, id)
 	if(!isturf(A))
 		return
 
@@ -196,7 +196,7 @@
 		return 1
 
 	playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
-	new /obj/item/pipe_meter(A, frequency)
+	new /obj/item/pipe_meter(A, frequency, id)
 
 //ACTUAL PIPES.
 
@@ -347,7 +347,8 @@
 	
 	. += {"
 		<div>
-			<b>Frequency:</b> <a href="?src=\ref[master.interface];set_freq=-1">[format_frequency(master.frequency)] GHz</a> <a href="?src=\ref[master.interface];set_freq=reset">Reset</a>
+			<b>Frequency:</b> <a href="?src=\ref[master.interface];set_freq=-1">[format_frequency(master.frequency)] GHz</a> <a href="?src=\ref[master.interface];set_freq=[1439]">Reset</a>
+			<b>ID:</b> <a href="?src=\ref[master.interface];set_id=-1">[master.id ? master.id : "-----"] </a> <a href="?src=\ref[master.interface];set_id=null">Reset</a>
 		</div>
 	"}
 
@@ -378,11 +379,6 @@
 		return 1
 		
 	if("set_freq" in href_list)
-		if(href_list["set_freq"]=="reset")
-			master.frequency = 0
-			master.rebuild_ui()
-			return 1
-		
 		var/newfreq=master.frequency
 		if(href_list["set_freq"]!="-1")
 			newfreq=text2num(href_list["set_freq"])
@@ -395,6 +391,18 @@
 				master.frequency = newfreq
 			master.rebuild_ui()
 			
+		return 1
+		
+	if("set_id" in href_list)
+		var/newid=master.id
+		if(href_list["set_id"]!="-1")
+			master.id = null
+		else
+			newid = copytext(reject_bad_text(input(usr, "Specify the new ID tag for this machine", src, master.id) as null|text),1,MAX_MESSAGE_LEN)
+			if(newid)
+				master.id = newid
+		master.rebuild_ui()
+
 		return 1
 
 /datum/rcd_schematic/pipe/proc/set_dir(var/new_dir)
@@ -433,7 +441,7 @@
 
 		set_dir(dirs[index])
 
-/datum/rcd_schematic/pipe/attack(var/atom/A, var/mob/user, frequency = 0)
+/datum/rcd_schematic/pipe/attack(var/atom/A, var/mob/user, frequency, id)
 	to_chat(user, "Building Pipes ...")
 	playsound(user, 'sound/machines/click.ogg', 50, 1)
 	var/thislayer = layer
@@ -443,7 +451,7 @@
 
 	playsound(user, 'sound/items/Deconstruct.ogg', 50, 1)
 
-	var/obj/item/pipe/P = new /obj/item/pipe(A, pipe_id, thisdir, null, frequency)
+	var/obj/item/pipe/P = new /obj/item/pipe(A, pipe_id, thisdir, null, frequency, id)
 	P.setPipingLayer(thislayer)
 	P.update()
 	P.add_fingerprint(user)

--- a/code/modules/RCD/schematics/pipe.dm
+++ b/code/modules/RCD/schematics/pipe.dm
@@ -169,7 +169,7 @@
 	category = "Devices"
 	flags    = RCD_RANGE | RCD_GET_TURF | RCD_ALLOW_SWITCH
 
-/datum/rcd_schematic/gsensor/attack(var/atom/A, var/mob/user)
+/datum/rcd_schematic/gsensor/attack(var/atom/A, var/mob/user, frequency = 0)
 	if(!isturf(A))
 		return
 
@@ -179,14 +179,14 @@
 		return 1
 
 	playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
-	new /obj/item/pipe_gsensor(A)
+	new /obj/item/pipe_gsensor(A, frequency)
 
 /datum/rcd_schematic/pmeter
 	name     = "Pipe meter"
 	category = "Devices"
 	flags    = RCD_RANGE | RCD_GET_TURF | RCD_ALLOW_SWITCH
 
-/datum/rcd_schematic/pmeter/attack(var/atom/A, var/mob/user)
+/datum/rcd_schematic/pmeter/attack(var/atom/A, var/mob/user, frequency = 0)
 	if(!isturf(A))
 		return
 
@@ -196,7 +196,7 @@
 		return 1
 
 	playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
-	new /obj/item/pipe_meter(A)
+	new /obj/item/pipe_meter(A, frequency)
 
 //ACTUAL PIPES.
 
@@ -344,6 +344,12 @@
 			<a class="no_dec" href="?src=\ref[master.interface];set_layer=5"><div class="layer horizontal five  [layer == 5 ? "selected" : ""]"></div></a>
 		</div>
 	"}
+	
+	. += {"
+		<div>
+			<b>Frequency:</b> <a href="?src=\ref[master.interface];set_freq=-1">[format_frequency(master.frequency)] GHz</a> <a href="?src=\ref[master.interface];set_freq=reset">Reset</a>
+		</div>
+	"}
 
 /datum/rcd_schematic/pipe/proc/render_dir_image(var/dir, var/title)
 	var/selected = ""
@@ -369,6 +375,26 @@
 
 		set_layer(n_layer)
 
+		return 1
+		
+	if("set_freq" in href_list)
+		if(href_list["set_freq"]=="reset")
+			master.frequency = 0
+			master.rebuild_ui()
+			return 1
+		
+		var/newfreq=master.frequency
+		if(href_list["set_freq"]!="-1")
+			newfreq=text2num(href_list["set_freq"])
+		else
+			newfreq = input(usr, "Specify a new frequency (GHz). Decimals assigned automatically.", src, master.frequency) as null|num
+		if(newfreq)
+			if(findtext(num2text(newfreq), "."))
+				newfreq *= 10 // shift the decimal one place
+			if(newfreq < 10000)
+				master.frequency = newfreq
+			master.rebuild_ui()
+			
 		return 1
 
 /datum/rcd_schematic/pipe/proc/set_dir(var/new_dir)
@@ -407,7 +433,7 @@
 
 		set_dir(dirs[index])
 
-/datum/rcd_schematic/pipe/attack(var/atom/A, var/mob/user)
+/datum/rcd_schematic/pipe/attack(var/atom/A, var/mob/user, frequency = 0)
 	to_chat(user, "Building Pipes ...")
 	playsound(user, 'sound/machines/click.ogg', 50, 1)
 	var/thislayer = layer
@@ -417,7 +443,7 @@
 
 	playsound(user, 'sound/items/Deconstruct.ogg', 50, 1)
 
-	var/obj/item/pipe/P = new /obj/item/pipe(A, pipe_id, thisdir)
+	var/obj/item/pipe/P = new /obj/item/pipe(A, pipe_id, thisdir, null, frequency)
 	P.setPipingLayer(thislayer)
 	P.update()
 	P.add_fingerprint(user)


### PR DESCRIPTION
## What this does
Implements the idea described in #35123 allowing you to set a frequency and ID in the RPD which will then be applied to all pipes created by it.
- The default frequency is 1439 so it auto links to the APC.
- The default ID is null (-----) so it is auto assigned for vents and scrubbers.

https://github.com/vgstation-coders/vgstation13/assets/34819564/46611d24-fff7-4378-87a1-a0e3874912e3


## Why it's good
Reduces the use of multitool and makes it faster to set up some projects.

## Known issues
The frequency and ID settings only appears after you select a pipe.

## Changelog
:cl:
 * rscadd: Add a frequency setting to the RPD.
