### PR TITLE
Fix players seeing lights being toggled on or off at roundstart, and make rooms lit on an individual basis

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -22,7 +22,7 @@ var/list/lighting_update_overlays  = list() // List of lighting overlays queued 
 	create_all_lighting_overlays()
 	..()
 
-/datum/subsystem/lighting/fire(resumed=FALSE)
+/datum/subsystem/lighting/fire(resumed=FALSE, allow_breaks=TRUE)
 	var/real_tick_limit = CURRENT_TICKLIMIT
 	CURRENT_TICKLIMIT = (real_tick_limit - world.tick_usage)/3
 	var/i = 0
@@ -41,7 +41,7 @@ var/list/lighting_update_overlays  = list() // List of lighting overlays queued 
 		L.force_update = FALSE
 		L.needs_update = FALSE
 
-		if (TICK_CHECK)
+		if (TICK_CHECK && allow_breaks)
 			break
 	if (i)
 		lighting_update_lights.Cut(1, i+1)
@@ -54,7 +54,7 @@ var/list/lighting_update_overlays  = list() // List of lighting overlays queued 
 
 		C.update_overlays()
 		C.needs_update = FALSE
-		if (TICK_CHECK)
+		if (TICK_CHECK && allow_breaks)
 			break
 	if (i)
 		lighting_update_corners.Cut(1, i+1)
@@ -70,7 +70,7 @@ var/list/lighting_update_overlays  = list() // List of lighting overlays queued 
 
 		O.update_overlay()
 		O.needs_update = FALSE
-		if (TICK_CHECK)
+		if (TICK_CHECK && allow_breaks)
 			break
 	if (i)
 		lighting_update_overlays.Cut(1, i+1)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -52,9 +52,6 @@ var/datum/controller/gameticker/ticker
 	// Tag mode!
 	var/tag_mode_enabled = FALSE
 
-	var/list/roundstart_occupied_areas = list() //List of areas that are occupied at roundstart, used to handle the lights being on or off.
-
-
 #define LOBBY_TICKING 1
 #define LOBBY_TICKING_RESTARTED 2
 /datum/controller/gameticker/proc/pregame()
@@ -179,6 +176,8 @@ var/datum/controller/gameticker/ticker
 	//After antagonists have been removed from new_players in player_list, create crew
 	var/list/new_characters = list()	//list of created crew for transferring
 	var/list/new_players_ready = list() //unique list of people who have readied up, so we can delete mob/new_player later (ready is lost on mind transfer)
+	var/list/roundstart_occupied_areas = list() //List of areas that are occupied at roundstart, used to handle the lights being on or off.
+
 	for(var/mob/M in player_list)
 		if(!istype(M, /mob/new_player/))
 			var/mob/living/L = M
@@ -213,7 +212,7 @@ var/datum/controller/gameticker/ticker
 		CHECK_TICK
 
 	//Now that we have all of the occupied areas, we handle the lights being on or off, before actually putting the players into their bodies.
-	handle_lights()
+	handle_lights(roundstart_occupied_areas)
 	//Force the lighting subsystem to update.
 	SSlighting.fire(FALSE, FALSE)
 	roundstart_occupied_areas = null //Don't need it anymore.
@@ -657,8 +656,8 @@ var/datum/controller/gameticker/ticker
 			roles += player.mind.assigned_role
 	return roles
 
-/datum/controller/gameticker/proc/handle_lights()
-	for(var/area/this_area in roundstart_occupied_areas)
+/datum/controller/gameticker/proc/handle_lights(var/list/areas_to_turn_lights_on)
+	for(var/area/this_area in areas_to_turn_lights_on)
 		for(var/obj/machinery/light_switch/LS in this_area)
 			LS.toggle_switch(1, playsound = FALSE)
 		for(var/obj/machinery/light/lightykun in this_area)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -656,7 +656,7 @@ var/datum/controller/gameticker/ticker
 			roles += player.mind.assigned_role
 	return roles
 
-/datum/controller/gameticker/proc/handle_lights(var/list/areas_to_turn_lights_on)
+/datum/controller/gameticker/proc/handle_lights(list/areas_to_turn_lights_on)
 	for(var/area/this_area in areas_to_turn_lights_on)
 		for(var/obj/machinery/light_switch/LS in this_area)
 			LS.toggle_switch(1, playsound = FALSE)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -215,7 +215,6 @@ var/datum/controller/gameticker/ticker
 	handle_lights(roundstart_occupied_areas)
 	//Force the lighting subsystem to update.
 	SSlighting.fire(FALSE, FALSE)
-	roundstart_occupied_areas = null //Don't need it anymore.
 
 	var/list/clowns = list()
 	var/already_an_ai = FALSE

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -200,7 +200,7 @@ var/datum/controller/gameticker/ticker
 				S.store_position()
 				log_admin("([key]) started the game as a [S.mind.assigned_role].")
 				new_characters[key] = S
-				roundstart_occupied_areas += get_area(S)
+				roundstart_occupied_areas |= get_area(S)
 			if("MODE")
 				//antags aren't new players
 			else
@@ -209,7 +209,7 @@ var/datum/controller/gameticker/ticker
 				EquipCustomItems(H)
 				H.update_icons()
 				new_characters[key] = H
-				roundstart_occupied_areas += get_area(H)
+				roundstart_occupied_areas |= get_area(H)
 		CHECK_TICK
 
 	//Now that we have all of the occupied areas, we handle the lights being on or off, before actually putting the players into their bodies.

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -8,7 +8,7 @@
 	icon_state = "light1"
 	anchored = 1.0
 	var/buildstage = 2
-	var/on = 1
+	var/on = 0
 	var/image/overlay
 
 /obj/machinery/light_switch/supports_holomap()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -384,7 +384,6 @@
 	autoignition_temperature = AUTOIGNITION_ORGANIC
 	var/brightness_max = 6
 	var/brightness_min = 2
-	on = 0
 	drawspower = FALSE //slime lamps don't draw power from the area apc
 
 	breakable_fragments = null

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -196,7 +196,7 @@
 	flags = FPRINT
 	siemens_coefficient = 1
 	starting_materials = null
-	on = 1	//Lamps start on but are turned off unless someone spawns in the same department as them at roundstart.
+	on = 0	//Lamps start off but are turned on if someone spawns in the same department as them at roundstart.
 	var/drawspower = TRUE
 	var/datum/power_connection/consumer/pwrconn //the on var means the lamp switch is turned on but the area also has to be powered for it to produce light
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -17,7 +17,7 @@
 
 	anchored = 1	//  don't get pushed around
 
-	//The locations of where the player's character's body should spawn.
+	//The location where the player's character's body should spawn.
 	var/character_loc
 
 /mob/new_player/verb/new_player_panel()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -755,7 +755,7 @@
 		else
 			// Use the arrivals shuttle spawn point
 			stack_trace("no spawn points for [rank]")
-			character_loc = S.loc
+			character_loc = pick(latejoin)
 		// 20% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
 		new_character.DormantGenes(20,10,0,0)
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -17,6 +17,9 @@
 
 	anchored = 1	//  don't get pushed around
 
+	//The locations of where the player's character's body should spawn.
+	var/character_loc
+
 /mob/new_player/verb/new_player_panel()
 	set src = usr
 	new_player_panel_proc()
@@ -748,11 +751,11 @@
 				break
 		if(S)
 			// Use the given spawn point
-			new_character.forceMove(S.loc)
+			character_loc = S.loc
 		else
 			// Use the arrivals shuttle spawn point
 			stack_trace("no spawn points for [rank]")
-			new_character.forceMove(pick(latejoin))
+			character_loc = S.loc
 		// 20% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
 		new_character.DormantGenes(20,10,0,0)
 
@@ -760,6 +763,8 @@
 		if(R.converts_everyone && new_character.mind.assigned_role != "Chaplain")
 			R.convert(new_character,null,TRUE,TRUE)
 			break //Only autoconvert them once, and only if they aren't leading their own faith.
+
+	new_character.forceMove(character_loc)
 
 	if(late_join)
 		new_character.key = key
@@ -796,16 +801,19 @@
 	if(type == "AI")
 		var/mob/living/silicon/new_character
 		new_character = AIize()
+
+		new_character.forceMove(spawn_loc)
 		return new_character
+
 	else
 		var/mob/living/silicon/robot/new_character
-		forceMove(spawn_loc)
 		if(type == "Mobile MMI")
 			new_character = MoMMIfy()
 		else
 			new_character = Robotize()
 		new_character.mmi.create_identity(prefs) //Uses prefs to create a brain mob
 
+		new_character.forceMove(spawn_loc)
 		return new_character
 
 /mob/new_player/proc/ViewPrediction()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -17,9 +17,6 @@
 
 	anchored = 1	//  don't get pushed around
 
-	//The location where the player's character's body should spawn.
-	var/character_loc
-
 /mob/new_player/verb/new_player_panel()
 	set src = usr
 	new_player_panel_proc()
@@ -751,11 +748,11 @@
 				break
 		if(S)
 			// Use the given spawn point
-			character_loc = S.loc
+			new_character.forceMove(S.loc)
 		else
 			// Use the arrivals shuttle spawn point
 			stack_trace("no spawn points for [rank]")
-			character_loc = pick(latejoin)
+			new_character.forceMove(pick(latejoin))
 		// 20% chance of getting a dormant bad gene, in which case they also get 10% chance of getting a dormant good gene
 		new_character.DormantGenes(20,10,0,0)
 
@@ -763,8 +760,6 @@
 		if(R.converts_everyone && new_character.mind.assigned_role != "Chaplain")
 			R.convert(new_character,null,TRUE,TRUE)
 			break //Only autoconvert them once, and only if they aren't leading their own faith.
-
-	new_character.forceMove(character_loc)
 
 	if(late_join)
 		new_character.key = key
@@ -801,19 +796,16 @@
 	if(type == "AI")
 		var/mob/living/silicon/new_character
 		new_character = AIize()
-
-		new_character.forceMove(spawn_loc)
 		return new_character
-
 	else
 		var/mob/living/silicon/robot/new_character
 		if(type == "Mobile MMI")
 			new_character = MoMMIfy()
 		else
 			new_character = Robotize()
+		new_character.forceMove(spawn_loc)
 		new_character.mmi.create_identity(prefs) //Uses prefs to create a brain mob
 
-		new_character.forceMove(spawn_loc)
 		return new_character
 
 /mob/new_player/proc/ViewPrediction()


### PR DESCRIPTION
## What this does
This makes it so all the light, lightswitch, and lamp on-or-off toggling that depends on whether or not the room is occupied at roundstart, occurs before players are transferred into their bodies, so that the player won't see the lights changing right at the start of the round. To get this to work, these things are done before body transfer occurs:
- lightswitches, lamps, and lightbulbs themselves are force-updated 
- a complete tick of the lighting subsystem is forced to fire

Something changed in this also that I think is nice is that only lights in the exact area the player starts in will be toggled. So, if the only player starts in telescience, the lights in the robotics lab will be off. I think that could give a nice lonely vibe in lowpop but let me know if you think otherwise.

## Why it's good
Hopefully fix the longstanding issues relating to lights being on-or-off at roundstart. Also amp up the loneliness vibes a little.

## Changelog
:cl:
 * bugfix: Fixed being able to see lights toggling at roundstart based on crew occupancy.
 * tweak: Only occupied rooms have their lights on at roundstart; other unoccupied rooms in the same department will be dark, assuming they have lightswitches.
