### PR TITLE
Fix Engi Coffee Overdose

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -8955,7 +8955,7 @@ var/global/list/tonio_doesnt_remove=list("tonio", "blood")
 /datum/reagent/drink/coffee/engicoffee/on_mob_life(var/mob/living/M)
 	..()
 	M.hallucination = 0
-	M.reagents.add_reagent (HYRONALIN, 0.1)
+	M.reagents.add_reagent (HYRONALIN, 0.05)
 
 /datum/reagent/drink/coffee/medcoffee
 	name = "Lifeline"


### PR DESCRIPTION
## What this does
This prevents large amounts of NT Standard Battery Acid from causing a Hyronalin overdose, bringing it more in line with the other job coffees. Instead of producing .1 units of Hyronalin per tick it now only produces .05, matching Hyronalin's metabolism rate. Previously drinking 60 units of NT Standard Battery Acid would cause an overdose.

## Why it's good
I'm pretty sure being able to OD on coffee was unintentional.

## Changelog
lowered the amount of Hyronalin created by NT Standard Battery Acid metabolizing below overdose thresholds
:cl:
 * tweak: lowered the amount of hyronalin produced by engicoffee.
[bugfix]