### PR TITLE
Loose catbeasts now get announced regardless of whether they are on station

### DIFF
--- a/code/datums/gamemode/role/catbeast.dm
+++ b/code/datums/gamemode/role/catbeast.dm
@@ -32,7 +32,7 @@
 		D.threat_log += "[worldtime2text()]: Loose catbeast created."
 		D.threat_log += src //The actual reporting on threat it made comes from this entry
 	spawn(1.5 MINUTES)
-		if(antag.current.stat!=DEAD && OnStation() == -1)
+		if(antag.current.stat!=DEAD)
 			command_alert("An escaped disease-ridden catbeast has been detected aboard your station. Crew should cooperate with security staff in its extermination or removal from the main station. Remember to get a medical checkup afterward in case of infection.", "Catbeast Detected",1)
 	return TRUE
 


### PR DESCRIPTION
This started off as a bugfix after I played catbeast and didn't get outed out and then realized I fucked up and made it only announce when the catbeast is hiding in an object. Then I thought "why even have all this get counted in the first place, just announce the catbeast, what's the likelihood that the catbeast is somehow not on the station within the first 90 seconds after spawning?". Now the announcement system no longer checks if the catbeast is on the station, only whether it's dead.
:cl:
 * tweak: Loose catbeasts now get announced regardless of whether they are considered to be aboard the station or not. The announcement will still not play if the catbeast dies within 90 seconds.