### PR TITLE
The "Telepathy" power can now be middle-clicked to make it a "point & click" spell

### DIFF
--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -135,6 +135,8 @@
 	hud_state = "gen_project"
 	compatible_mobs = list(/mob/living/carbon/human, /datum/mind)
 	mind_affecting = 1
+	var/targeted = 0
+
 /spell/targeted/telepathy/cast_check(var/skipcharge = 0, var/mob/user = usr)
 	. = ..()
 	if (!.)
@@ -144,8 +146,9 @@
 	if(user.mind.miming)
 		to_chat(user, "<span class = 'warning'>You find yourself unable to convey your thoughts outside of gestures.</span>")
 		return
+
 /spell/targeted/telepathy/cast(var/list/targets, mob/living/carbon/human/user)
-	var/datum/species/mushroom/M = user.species
+	var/datum/species/mushroom/M = user.species //Mushmen will set their target for regular speech instead
 	var/message
 	if(!istype(M))
 		message = stripped_input(user, "What do you wish to say?", "Telepathy")
@@ -177,6 +180,18 @@
 			for(var/mob/dead/observer/G in dead_mob_list)
 				G.show_message("<i>Telepathy, <b>[user]</b> to [english_list(targets)]</b>:<b> \"[message]\"</b></i>")
 			log_admin("[key_name(user)] projects his mind towards to [english_list(targets)]: [message]")
+
+/spell/targeted/telepathy/on_right_click(mob/user)
+	..()
+	if(!targeted)
+		targeted = TRUE
+		to_chat(user, "<span class='notice'>You will now target the spell to immediately communicate to someone in view.</span>")
+		spell_flags |=  WAIT_FOR_CLICK
+	else
+		targeted = FALSE
+		to_chat(user, "<span class='notice'>You will now select from a list of people to communicate to.</span>")
+		spell_flags &= ~WAIT_FOR_CLICK
+	return 1 //So that the spellmaster does not try to perform it
 
 /datum/dna/gene/basic/morph
 	name = "Morph"


### PR DESCRIPTION

:cl:
 * rscadd: The "Telepathy" power can be middle-clicked to toggle between its current method of selecting recipients and "channeling" or clicking a recipient directly to communicate with them.