### PR TITLE
Removes the old discord kill phrase system

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -199,7 +199,6 @@
 	// Discord crap.
 	var/discord_url
 	var/discord_password
-	var/kill_phrase = "All your bases are belong to us."
 
 	// Dynamic Mode
 	var/high_population_override = 1//If 1, what rulesets can or cannot be called depend on the threat level only
@@ -635,9 +634,6 @@
 					discord_url = value
 				if("discord_password")
 					discord_password = value
-
-				if ("kill_phrase")
-					kill_phrase = value
 
 				else
 					diary << "Unknown setting in configuration: '[name]'"

--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -376,7 +376,7 @@ var/global/datum/controller/vote/vote = new()
 				var/msg = "A map vote was initiated with these options: [english_list(get_list_of_keys(maps))]."
 				send2maindiscord(msg)
 				send2mainirc(msg)
-				send2ickdiscord(config.kill_phrase) // This the magic kill phrase
+				send2ickdiscord("**A round has ended.** You can discuss it at https://boards.4chan.org/vg/catalog#s=ss13g. A new round will begin soon.")
 			else
 				return 0
 


### PR DESCRIPTION
Back when the Discord channel lock system was in place, the normal round end message from the bot was replaced with a specific "kill phrase" which would make it lock the channel before then sending a set message defined within the bot's code. Seeing as the channel lock was scrapped a long time ago now, it doesn't make much sense to continue relying on the kill phrase system for simply posting about the round ending, so this just makes it work like every other Discord nudge now.

## Why it's good
- Removes an unused system
- Round End message is now defined within the game code once more rather than on an external bot
- Anyone who forks our codebase won't be befuddled by what the fuck the kill phrase is supposed to mean

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscdel: Removed the Discord killphrase seeing as the function is was implemented for was scrapped.