### PR TITLE
Makes the atmos analyzer use XGM instead of hardcoded gasses.

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -392,27 +392,25 @@ Subject's pulse: ??? BPM"})
 		message += "<span class='bnotice'><B>[bicon(container)] Results of [container] scan:</span></B>"
 	if(total_moles)
 		message += "<br>[human_standard && abs(pressure - ONE_ATMOSPHERE) > 10 ? "<span class='bad'>" : "<span class='notice'>"] Pressure: [round(pressure, 0.1)] kPa</span>"
-		var/o2_concentration = scanned[GAS_OXYGEN]/total_moles
-		var/n2_concentration = scanned[GAS_NITROGEN]/total_moles
-		var/co2_concentration = scanned[GAS_CARBON]/total_moles
-		var/plasma_concentration = scanned[GAS_PLASMA]/total_moles
-		var/heat_capacity = scanned.heat_capacity()
+		
+		for (var/id in XGM.gases)
+			var/class = "notice"
+			var/moles = scanned[id]
+			var/concentration = moles / total_moles
+			var/datum/gas/gas = XGM.gases[id]
 
-		var/unknown_concentration =  1 - (o2_concentration + n2_concentration + co2_concentration + plasma_concentration)
+			if (concentration < 0.01)
+				continue
 
-		if(n2_concentration > 0.01)
-			message += "<br>[human_standard && abs(n2_concentration - N2STANDARD) > 20 ? "<span class='bad'>" : "<span class='notice'>"] Nitrogen: [round(scanned[GAS_NITROGEN], 0.1)] mol, [round(n2_concentration*100)]%</span>"
-		if(o2_concentration > 0.01)
-			message += "<br>[human_standard && abs(o2_concentration - O2STANDARD) > 2 ? "<span class='bad'>" : "<span class='notice'>"] Oxygen: [round(scanned[GAS_OXYGEN], 0.1)] mol, [round(o2_concentration*100)]%</span>"
-		if(co2_concentration > 0.01)
-			message += "<br>[human_standard ? "<span class='bad'>" : "<span class='notice'>"] CO2: [round(scanned[GAS_CARBON], 0.1)] mol, [round(co2_concentration*100)]%</span>"
-		if(plasma_concentration > 0.01)
-			message += "<br>[human_standard ? "<span class='bad'>" : "<span class='notice'>"] Plasma: [round(scanned[GAS_PLASMA], 0.1)] mol, [round(plasma_concentration*100)]%</span>"
-		if(unknown_concentration > 0.01)
-			message += "<br><span class='notice'>Unknown: [round(unknown_concentration*100)]%</span>"
+			if (human_standard)
+				switch (id)
+					if (GAS_OXYGEN) class = abs(concentration - O2STANDARD) > 2 ? "bad" : "notice"
+					if (GAS_NITROGEN) class = abs(concentration - N2STANDARD) > 20 ? "bad" : "notice"
+					else class = "bad"
+			message += "<br><span class='[class]'>[gas.name]: [round(moles, 0.1)] mol, [round(concentration*100)]%</span>"
 
 		message += "<br>[human_standard && !IsInRange(scanned.temperature, BODYTEMP_COLD_DAMAGE_LIMIT, BODYTEMP_HEAT_DAMAGE_LIMIT) ? "<span class='bad'>" : "<span class='notice'>"] Temperature: [round(scanned.temperature-T0C)]&deg;C"
-		message += "<br><span class='notice'>Heat capacity: [round(heat_capacity, 0.01)]</span>"
+		message += "<br><span class='notice'>Heat capacity: [round(scanned.heat_capacity(), 0.01)]</span>"
 	else
 		message += "<br><span class='warning'>No gasses detected[container && !istype(container, /turf) ? " in \the [container]." : ""]!</span>"
 	return message

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -393,7 +393,7 @@ Subject's pulse: ??? BPM"})
 	if(total_moles)
 		message += "<br>[human_standard && abs(pressure - ONE_ATMOSPHERE) > 10 ? "<span class='bad'>" : "<span class='notice'>"] Pressure: [round(pressure, 0.1)] kPa</span>"
 		
-		for (var/id in XGM.gases)
+		for (var/id in scanned.gas)
 			var/class = "notice"
 			var/moles = scanned[id]
 			var/concentration = moles / total_moles
@@ -404,9 +404,12 @@ Subject's pulse: ??? BPM"})
 
 			if (human_standard)
 				switch (id)
-					if (GAS_OXYGEN) class = abs(concentration - O2STANDARD) > 2 ? "bad" : "notice"
-					if (GAS_NITROGEN) class = abs(concentration - N2STANDARD) > 20 ? "bad" : "notice"
-					else class = "bad"
+					if (GAS_OXYGEN)
+						class = abs(concentration - O2STANDARD) > 2 ? "bad" : "notice"
+					if (GAS_NITROGEN)
+						class = abs(concentration - N2STANDARD) > 20 ? "bad" : "notice"
+					else
+						class = "bad"
 			message += "<br><span class='[class]'>[gas.name]: [round(moles, 0.1)] mol, [round(concentration*100)]%</span>"
 
 		message += "<br>[human_standard && !IsInRange(scanned.temperature, BODYTEMP_COLD_DAMAGE_LIMIT, BODYTEMP_HEAT_DAMAGE_LIMIT) ? "<span class='bad'>" : "<span class='notice'>"] Temperature: [round(scanned.temperature-T0C)]&deg;C"


### PR DESCRIPTION
[bugfix]

## What this does
Resolves #23115 by letting the atmos analyzer detect all XGM gasses. This doesn't address any of the other issues listed in #20082.

## Why it's good
N2O is detected by atmos analyzers now instead of being shown as "Unknown". Future gasses will also be listed without any additional work.

![Image](https://github.com/vgstation-coders/vgstation13/assets/122755709/821e18a4-7969-421c-b528-f23598cb4e2e)

## Changelog
:cl:
 * tweak: Made the atmos analyzer use XGM instead of hardcoded gasses.
 * bugfix: Fixed N2O showing as "unknown" on the atmos analyzer.
