### PR TITLE
Inflatable shelters no longer spawn inside of fire alarms, and no longer inject you with medicine upon entering

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1186,13 +1186,10 @@ FIRE ALARM
 	var/last_process = 0
 	var/wiresexposed = 0
 	var/buildstage = 2 // 2 = complete, 1 = no wires,  0 = circuit gone
-	var/shelter = 1
+	var/shelter = 0
 	var/alarm = 0
 	var/last_alarm_time = 0
 	var/alarm_delay = 10 SECONDS
-
-/obj/machinery/firealarm/empty
-	shelter = 0
 
 /obj/machinery/firealarm/supports_holomap()
 	return TRUE
@@ -1391,7 +1388,7 @@ FIRE ALARM
 	if(shelter)
 		dat += "An emergency shelter is mounted within. <A href='?src=\ref[src];shelter=1'>Retrieve</A>"
 	else
-		dat += "The shelter has been removed. <A href='?src=\ref[src];shelter=1'>Insert</A>"
+		dat += "There's an empty slot for storing an emergency shelter. <A href='?src=\ref[src];shelter=1'>Insert</A>"
 	user << browse(dat, "window=firealarm")
 	onclose(user, "firealarm")
 

--- a/code/game/objects/items/mountable_frames/fire_alarm.dm
+++ b/code/game/objects/items/mountable_frames/fire_alarm.dm
@@ -10,5 +10,5 @@
 	mount_reqs = list("simfloor", "nospace")
 
 /obj/item/mounted/frame/firealarm/do_build(turf/on_wall, mob/user)
-	new /obj/machinery/firealarm/empty(get_turf(src), get_dir(on_wall, user), 1)
+	new /obj/machinery/firealarm(get_turf(src), get_dir(on_wall, user), 1)
 	qdel(src)

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -398,12 +398,7 @@
 	user.forceMove(src)
 	update_icon()
 	user.reset_view()
-	if(user.reagents && !user.reagents.has_reagent(PRESLOMITE))
-		user.reagents.add_reagent(PRESLOMITE,3)
-		user.reagents.add_reagent(LEPORAZINE,1)
-		to_chat(user,"<span class='warning'>You feel a prick upon entering \the [src].</span>")
-	else
-		to_chat(user,"<span class='notice'>You enter \the [src].</span>")
+	to_chat(user,"<span class='notice'>You enter \the [src].</span>")
 
 /obj/structure/inflatable/shelter/proc/laundry(var/mob/living/carbon/human/user)
 	if(user.loc != src)


### PR DESCRIPTION
## What this does
This makes it so that inflatable shelters no longer spawn inside of fire alarms, though they can still be stocked into fire alarms if obtained another way, such as the cyborg inflatable dispenser module. Also, this makes it so that inflatable shelters don't inject you with preslomite and leporazine upon entering.

## Why it's good
To me, and some others I've talked with this a bit about, inflatable shelters are the epitome of anticlimax, bathos, eye-rolling cheesiness, TG-ness, whatever you want to call it. There's plenty of times when I'd rather my character die in a fiery plasma inferno than climb into the bouncy castle, but I begrudgingly do the latter because in terms of RP my character wouldn't kill themselves when there was a viable escape right there. But I feel like I'm riding the preschool bus sitting there flouride staring out into the inferno, while one man in a hardsuit pulls a bouncy house full of people piled on top of each other through the fire and flames. The injection thing is just the cherry on top of this.

## Other considerations
If this doesn't pass I can take a look at the following changes (or maybe I can also do these in this PR if people want):

- making them melt in high temperatures (they're made of a plastic-rubber type material, shouldn't be able to survive arc furnace temperatures of a plasma fire)
- making them only work in low-pressure environments (they're inflatable so it seems like they shouldn't be able to inflate at 101.3 kPa if the surrounding air is say 500 kPa)

This would make them into more of a "survive breaches and pressure loss by sheltering in a balloon" thing which I think is a bit more sensible.

However from messing with this a bit it seems like they "eat" the atmos underneath them and put out fires on their tile and I'm not sure of the exact mechanism for this but I can take a look if people want.

Let me know what you think.

## Changelog
:cl:
 * tweak: Fire alarms are no longer stocked with inflatable shelters at roundstart.
 * tweak: Inflatable shelters no longer inject preslomite and leporazine into those entering them.