### PR TITLE
Ninjas now PROPERLY see in the dark.

### DIFF
--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -921,6 +921,7 @@ Suit and assorted
 		spaceninja.internals.icon_state = "internal1"
 
 	spaceninja.see_in_dark_override = 8
+	spaceninja.dark_plane_alpha_override = 155
 
 /proc/equip_weeaboo(var/mob/living/carbon/human/H)
 	if(!istype(H))
@@ -945,6 +946,7 @@ Suit and assorted
 	H.equip_to_slot_or_del(new /obj/item/stack/shuriken/pizza(H,10), slot_l_store)
 
 	H.see_in_dark_override = 8
+	H.dark_plane_alpha_override = 155
 
 	var/datum/role/R = H.mind.GetRole(NINJA)
 	if(R)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1406,6 +1406,8 @@
 				if (catvision.count)
 					dark_plane.alphas["cattulism"] = clamp(15 + (catvision.count * 20),15,155) // The more it activates, the better we see, until we see as well as a tajaran would.
 					break
+		if(dark_plane_alpha_override)
+			dark_plane.alphas["override"] = dark_plane_alpha_override
 
 	if (istype(glasses))
 		glasses.update_perception(src)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -278,11 +278,12 @@
 	var/list/languages[0]
 
 	var/list/alphas = list()
-	var/alpha_override = FALSE	
+	var/alpha_override = FALSE
 	var/spell/spell_channeling // The spell that's currently being channeled
 
 	var/see_in_dark_override = 0	//for general guaranteed modification of these variables
 	var/see_invisible_override = 0
+	var/dark_plane_alpha_override = 0
 
 	var/obj/transmog_body_container/transmogged_from	//holds a reference to the container holding the mob that this mob used to be before being transmogrified
 	var/mob/transmogged_to		//holds a reference to the mob which holds a reference to this mob in its transmogged_from var


### PR DESCRIPTION
Same shadow vision as catbeasts. They actually are supposed to see in the dark (they have a value of about 8 tiles of dark vision where they can see the contents of tiles) but they couldn't see shit in it because of the shadow layer.

:cl:
 * rscadd: Ninjas now see better in the dark.