### PR TITLE
Ninjas, and wizards with No Guns Allowed will no longer have guns explode in their hand

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1579,6 +1579,10 @@ var/proccalls = 1
 
 #define SPELL_ANIMATION_TTL 2 MINUTES
 
+//MERELY_HONORABLE means unable to use guns, VERY_HONORABLE means using a gun will blow up the hand
+#define MERELY_HONORABLE 1
+#define VERY_HONORABLE 2
+
 //Grasp indexes
 #define GRASP_RIGHT_HAND 1
 #define GRASP_LEFT_HAND 2

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -564,13 +564,13 @@ var/list/list/zones = list(list(LIMB_HEAD,LIMB_LEFT_ARM,LIMB_LEFT_HAND,LIMB_LEFT
 	if(istype(user))
 		if(user.mind)
 			if(isbomberman(user) && (honorable & HONORABLE_BOMBERMAN))
-				return TRUE
+				return VERY_HONORABLE
 			if(ishighlander(user) && (honorable & HONORABLE_HIGHLANDER))
-				return TRUE
+				return VERY_HONORABLE
 			if(iscarbon(user) && isninja(user) && (honorable & HONORABLE_NINJA))
-				return TRUE
+				return MERELY_HONORABLE
 			if((iswizard(user) || isapprentice(user) || ismagician(user)) && (user.flags & HONORABLE_NOGUNALLOWED))
-				return TRUE
+				return MERELY_HONORABLE
 	return FALSE
 
 // Called by /mob/living/carbon/human/examine() and /mob/living/carbon/human/Topic()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -192,9 +192,13 @@
 	var/dehand = FALSE
 	if(istype(user, /mob/living))
 		var/mob/living/M = user
+		var/honor = is_honorable(M, honorable)
+		if(honor_check && honor == MERELY_HONORABLE) //Merely honorable people simply cannot use guns
+			to_chat(M, "<span class='notice'>You are too honorable to use such weapons!</span>")
+			return
 		if(clumsy_check && clumsy_check(M) && prob(50))
 			explode = TRUE
-		if(honor_check && is_honorable(M, honorable))
+		if(honor_check && honor == VERY_HONORABLE)
 			explode = TRUE
 			dehand = TRUE
 		if(explode)


### PR DESCRIPTION
They will simply be notified they are too honorable to use such weapons, and cannot fire them.
Mostly because this is a mechanic that was intended for bombermen and highlanders who are an adminbus (or at least out-of-round) thing, and the gun exploding in your hand served more as a noobtrap than anything for the far more common ninjas and wizards. This also caused the practice laser gun in the ninja's space dojo to be able to blow off the ninja's hand.
Guns exploding in bombermen's and highlanders' hands is unaffected.
Made a little background code change to separate the honor types used between MERELY_HONORABLE and VERY_HONORABLE.

:cl:
 * tweak: Ninjas who try to use guns will no longer have the guns explode in their hands, they are simply too honorable to use such weapons. The same applies to wizards who have purchased No Gun Allowed.