### PR TITLE
The wizard's "No Gun Allowed" spellbook purchase gives 20 points instead of 10

### DIFF
--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -366,7 +366,7 @@
 	name = "No Gun Allowed"
 	abbreviation = "NGA"
 	desc = "Forgo the use of guns in exchange for magical power. Some within the Wizard Federation have lobbied to make this spell a legal obligation."
-	price = -0.5 * Sp_BASE_PRICE
+	price = -1 * Sp_BASE_PRICE
 	one_use = TRUE
 
 /datum/spellbook_artifact/nogunallowed/can_buy(var/mob/user)


### PR DESCRIPTION
Guns are really potent, so much so that they are actually more useful than a good bunch of the wizard's spells when it comes to decent killing power, especially energy guns which can be recharged anywhere and are hitscan. Thus they should have a more significant reward for forgoing the usage of them.
What are you gonna buy with 10 points? Blind? Seriously?

:cl:
 * tweak: The wizard's "No Gun Allowed" purchase will now give 20 points instead of 10.
