### PR TITLE
Roundstart wizards get 120 spellbook points instead of 100

### DIFF
--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -74,6 +74,31 @@
 		if (S.user_type == USER_TYPE_WIZARD && !(S.spell_flags & LOSE_IN_TRANSFER))
 			new_character.add_spell(S)
 
+/datum/proc/is_roundstart_wizard(var/mob/user)
+	if (!ticker || !ticker.mode || !istype(ticker.mode,/datum/gamemode/dynamic))//if mode isn't Dynamic Mode, who cares
+		return TRUE
+
+	if (!user.mind)
+		return FALSE
+
+	var/datum/role/wizard/myWizard = user.mind.GetRole(WIZARD)
+
+	if (!myWizard)//ain't gonna let non-wizards use those.
+		return FALSE
+
+	var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
+
+	var/datum/dynamic_ruleset/roundstart/wizard/wiz_rule = locate() in dynamic_mode.executed_rules
+
+	if (!wiz_rule)
+		return FALSE
+
+	if (myWizard in wiz_rule.roundstart_wizards)
+		return TRUE
+
+	return FALSE
+
+
 /datum/role/wizard/GetScoreboard()
 	. = ..()
 	if(disallow_job) //Not a survivor wizzie

--- a/code/datums/outfit/special_outfits/special.dm
+++ b/code/datums/outfit/special_outfits/special.dm
@@ -649,7 +649,10 @@
 	disable_suit_sensors(H)
 	if(!apprentice)
 		H.put_in_hands(new /obj/item/weapon/teleportation_scroll(H))
-		H.put_in_hands(new /obj/item/weapon/spellbook(H))
+		if(is_roundstart_wizard(H))
+			H.put_in_hands(new /obj/item/weapon/spellbook/better(H))
+		else
+			H.put_in_hands(new /obj/item/weapon/spellbook(H))
 	else
 		H.put_in_hands(new /obj/item/weapon/teleportation_scroll/apprentice(H))
 	H.equip_to_slot_or_del(new /obj/item/weapon/hair_dye/skin_dye(H), slot_in_backpack)

--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -154,30 +154,6 @@
 	spawned_items = list(/obj/item/weapon/cloakingcloak)
 
 //WIZARDS, NO SENSE OF RIGHT OR WRONG
-/datum/spellbook_artifact/proc/is_roundstart_wizard(var/mob/user)
-	if (!ticker || !ticker.mode || !istype(ticker.mode,/datum/gamemode/dynamic))//if mode isn't Dynamic Mode, who cares
-		return TRUE
-
-	if (!user.mind)
-		return FALSE
-
-	var/datum/role/wizard/myWizard = user.mind.GetRole(WIZARD)
-
-	if (!myWizard)//ain't gonna let non-wizards use those.
-		return FALSE
-
-	var/datum/gamemode/dynamic/dynamic_mode = ticker.mode
-
-	var/datum/dynamic_ruleset/roundstart/wizard/wiz_rule = locate() in dynamic_mode.executed_rules
-
-	if (!wiz_rule)
-		return FALSE
-
-	if (myWizard in wiz_rule.roundstart_wizards)
-		return TRUE
-
-	return FALSE
-
 //SUMMON GUNS
 /datum/spellbook_artifact/summon_guns
 	name = "Summon Guns"

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -56,6 +56,9 @@
 	uses = 30 * Sp_BASE_PRICE
 	op = 0
 
+/obj/item/weapon/spellbook/better
+	uses = STARTING_USES * 1.2
+
 /obj/item/weapon/spellbook/New()
 	..()
 


### PR DESCRIPTION
Why? Because it's more fun that way!
I've always kinda envisioned roundstart wizards to be more powerful than their ragin' cousins, but other than a few limitations on what they can buy from the spellbook there was no real difference, until now.
It's basically the value of an extra spell or in most cases empowerment.
Hopefully this should also allow roundstart wizards to have more fun with the diverse amount of spells without sacrificing as much of their practical power.
Also moved the is_roundstart_wizard(user) check to the wizard's role datum file because it is too useful for it to be a mere spellbook check.

:cl:
 * tweak: Roundstart wizards are more powerful! Their spellbooks have 120 points rather than 100 points.