### PR TITLE
Reduces explosion throw damage

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -197,7 +197,7 @@ var/explosion_shake_message_cooldown = 0
 				if(ismob(A))
 					to_chat(A, "<span class='warning'>You are blown away by the explosion!</span>")
 
-				A.throw_at(throwT,pushback+2,500)
+				A.throw_at(throwT,pushback+2,pushback)
 			A.ex_act(dist,null,whodunnit)
 			atomtime = world.time - atomtime
 			if(atomtime > 0)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -197,7 +197,7 @@ var/explosion_shake_message_cooldown = 0
 				if(ismob(A))
 					to_chat(A, "<span class='warning'>You are blown away by the explosion!</span>")
 
-				A.throw_at(throwT,pushback+2,pushback)
+				A.throw_at(throwT,pushback+2,pushback*5) //1x at light range, 3x at heavy range, 5x at dev range
 			A.ex_act(dist,null,whodunnit)
 			atomtime = world.time - atomtime
 			if(atomtime > 0)


### PR DESCRIPTION
Now that the dust has settled and that far more players have (likely) experienced being on the receiving end of shrapnel with 100x throwing force damage hopefully people will reconsider the idea of reducing the damage so that the shrapnel isn't infinitely worse than the explosion itself. Fireballing wizards should die because they cast the spell too close to the target like the fools they are rather than because the target just so happened to be next to a floor tile that got launched into the wizard.

Currently this changes it so that it does 1x damage at light range, 3x damage at heavy range and 5x damage at devastation range, which is the same as the [previous PR](https://github.com/vgstation-coders/vgstation13/pull/33041).


:cl:
 * tweak: Explosion shrapnel will no longer instantly kill players, but instead do damage based on which explosion severity the object has been in.