### PR TITLE
The Revolution will no longer end if the revolutionaries are unconscious, only if they are dead (or deconverted)

### DIFF
--- a/code/datums/gamemode/factions/syndicate/rev.dm
+++ b/code/datums/gamemode/factions/syndicate/rev.dm
@@ -157,8 +157,8 @@
 	if(stage >= FACTION_ENDGAME)
 		var/anyone = FALSE
 		for(var/datum/role/R in members)
-			if(R.antag.current && !R.antag.current.stat)
-				anyone = TRUE //If one rev is still not incapacitated
+			if(R.antag.current && !(R.antag.current.stat == DEAD))
+				anyone = TRUE //If one rev is still not killed
 		if(!anyone)
 			stage(FACTION_DEFEATED)
 			command_alert(/datum/command_alert/revolutiontoppled)


### PR DESCRIPTION
A PR that I wanted to make for several days now.
Now even the victory requirements between the heads of staff and the revolution are equal!

:cl:
 * tweak: The revolution will no longer lose if its members are unconscious, only if they are dead (or there are none left).