### PR TITLE
Removes janitor requirement on trash compactors

### DIFF
--- a/code/modules/recycling/compactor.dm
+++ b/code/modules/recycling/compactor.dm
@@ -4,7 +4,6 @@
 	icon_state = "compactor_on" //New sprite indicating fullness?
 	machine_flags = WRENCHMOVE | FIXED2WORK
 	flags = FPRINT
-	req_access = list(access_janitor)
 	template_path = "disposalsbincompactor.tmpl"
 
 	hack_abilities = list(


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
Lets anyone use the normal features of a trash compactor.
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Why it's good
<!-- Explain why you think these changes are good. -->
Right now it feels like these never get used as there's no way for a janitor to see if trash needs picking up besides checking the machine, this allows anyone to cube their trash and have a cube the janitor can spot to clean up.
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl: 
* tweak: Trash compactors no longer require janitor access to cube trash
