### PR TITLE
Revsquad and Provocateurs no longer considers silicons to be enemy jobs

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -272,7 +272,7 @@
 	name = "Provocateur"
 	role_category = /datum/role/revolutionary
 	restricted_from_jobs = list("Merchant", "Brig Medic", "AI", "Cyborg", "Mobile MMI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Internal Affairs Agent")
-	enemy_jobs = list("AI", "Cyborg", "Security Officer","Detective","Head of Security", "Captain", "Warden")
+	enemy_jobs = list("Security Officer","Detective","Head of Security", "Captain", "Warden")
 	required_pop = list(20,20,15,15,15,15,15,0,0,0)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -455,7 +455,7 @@
 /datum/dynamic_ruleset/midround/from_ghosts/faction_based/revsquad
 	name = "Revolutionary Squad"
 	role_category = /datum/role/revolutionary/leader
-	enemy_jobs = list("AI", "Cyborg", "Security Officer", "Warden","Detective","Head of Security", "Captain")
+	enemy_jobs = list("Security Officer", "Warden","Detective","Head of Security", "Captain")
 	required_pop = list(25,25,25,25,25,20,15,15,10,10)
 	required_candidates = 3
 	weight = BASE_RULESET_WEIGHT


### PR DESCRIPTION
This makes them in-line with normal Revolution. Currently it's entirely possible for revsquad or a latejoin headrev to appear when there is little to no Security but about 2 silicons (a cyborg and an AI).

:cl:
 * tweak: The "Revolutionary Squad" and "Provocateur" dynamic rulesets no longer consider silicon to be enemy jobs, meaning they will need a proper amount of security personnel to appear rather than for them to be possible to fire with just silicons.