### PR TITLE
Buff cannonball recycle material gain to 100%

### DIFF
--- a/code/modules/projectiles/guns/projectile/constructable/siegecannon.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/siegecannon.dm
@@ -209,7 +209,7 @@
 	throw_speed = 1
 	throw_range = 2	//Rather heavy
 	force = 10	//Somehow less than a toolbox but okay
-	starting_materials = list(MAT_IRON = CC_PER_SHEET_METAL*3)
+	starting_materials = list(MAT_IRON = CC_PER_SHEET_METAL*20)
 	w_type = RECYK_METAL
 	flags = FPRINT | TWOHANDABLE | MUSTTWOHAND
 	var/cannonFired = FALSE
@@ -485,7 +485,7 @@
 	desc = "A large sphere of honk."
 	icon = 'icons/obj/siege_cannon.dmi'
 	icon_state = "clownnonball"
-	starting_materials = list(MAT_CLOWN = CC_PER_SHEET_METAL*3)
+	starting_materials = list(MAT_CLOWN = CC_PER_SHEET_CLOWN*20)
 	adjRange = 50
 	adjSpeed = 1
 	adjForce = 0


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
[tweak]
## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Sets cannonball and clownnonball recycle amount to their prize, 20 metal/bananium each

Closes #35174

## Why it's good
<!-- Explain why you think these changes are good. -->
Consistency with other objects, every object I checked recycled into its exact prize. The only exception was the diamond pickaxe for balance reasons (Available at roundstart from vendors for free diamonds)
There's no other way to get clownnonballs but by making them from bananium.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Cannon- and Clownnonballs recycle into 20 sheets of iron/bananium each
