### PR TITLE
Fix brass windows disappearing when anchored (workaround)

### DIFF
--- a/code/game/objects/structures/fullwindow.dm
+++ b/code/game/objects/structures/fullwindow.dm
@@ -181,6 +181,11 @@
 	sheetamount = 4
 	health = 80
 
+/obj/structure/window/full/reinforced/clockwork/relativewall()
+	// Ignores adjacent anchored window tiles for "merging", since there's only a single brass window sprite
+	// Remove this whenever someone sprites all the required icon states
+	return
+
 /obj/structure/window/full/reinforced/clockwork/loose
 	anchored = 0
 	d_state = 0

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -752,6 +752,11 @@ var/list/one_way_windows
 	sheetamount = 2
 	health = 80
 
+/obj/structure/window/reinforced/clockwork/relativewall()
+	// Ignores adjacent anchored window tiles for "merging", since there's only a single brass window sprite
+	// Remove this whenever someone sprites all the required icon states
+	return
+
 /obj/structure/window/reinforced/clockwork/cultify()
 	return
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
[needspritework][bugfix]
## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Brass windows no longer try to "merge" their icon with nearby windows like walls or other windows do.
Closes #35166

![grafik](https://github.com/vgstation-coders/vgstation13/assets/132118542/b2139525-7c3f-4972-9537-2b371d425524)

For the actual fix - letting brass windows behave like other windows - a line of sprites is required like for other windows, for example:
![grafik](https://github.com/vgstation-coders/vgstation13/assets/132118542/397bb30e-40dc-4036-9a02-77c7141ec3a9)
There's only a single brass window sprite.

If anyone wants to sprite brass windows feel free

## Why it's good
<!-- Explain why you think these changes are good. -->
I can't sprite so I can't do the actual fixing, but now the windows at least don't disappear when next to another

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Clockwork windows no longer disappear when anchored next to each other
