### PR TITLE
Fix cluwne ban

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1354,7 +1354,7 @@
 
 		//Other races  (BLUE, because I have no idea what other color to make this)
 		jobs += "<table cellpadding='1' cellspacing='0' width='100%'>"
-		jobs += "<tr bgcolor='ccccff'><th colspan='1'>Other Races</th></tr><tr align='center'>"
+		jobs += "<tr bgcolor='ccccff'><th colspan='10'>Other Races</th></tr><tr align='center'>"
 
 		if(jobban_isbanned(M, "Dionaea"))
 			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Dionaea;jobban4=\ref[M]'><font color=red>Dionaea</font></a></td>"
@@ -1369,6 +1369,15 @@
 
 		jobs += "</tr></table>"
 
+		// Special job bans (Cluwne)
+		jobs += "<table cellpadding='1' cellspacing='0' width='100%'>"
+		jobs += "<tr bgcolor='87ceeb'><th colspan='10'>Special Bans</th></tr><tr align='center'>"
+
+		if(jobban_isbanned(M, "Cluwne"))
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Cluwne;jobban4=\ref[M]'><font color=red>Cluwne</font></a></td>"
+		else
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Cluwne;jobban4=\ref[M]'>Cluwne</a></td>"
+		jobs += "</tr></table>"
 
 		body = "<body>[jobs]</body>"
 		dat = "<tt>[header][body]</tt>"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Adds the cluwne ban to the player panel job ban list so admins can actually cluwne ban people without jumping through hoops (adding the ban manually to the database)
Also fixes a consistency issue in the menu: The row for the bans above special bans wasn't spanning all the way to the right
![grafik](https://github.com/vgstation-coders/vgstation13/assets/132118542/2690b744-982b-40d2-8dcd-19f39a3e2dc2)

![grafik](https://github.com/vgstation-coders/vgstation13/assets/132118542/0cf88c1b-c7bd-4b87-a7a4-7b08e8d778f2)

Closes #35006

## Why it's good
<!-- Explain why you think these changes are good. -->
Manlyo got confused and had to ask papa apo to fix up his ban
Now he can do it himself

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added cluwne bans to job ban panel