### PR TITLE
Suit Storage Units can be moved and created

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -1670,3 +1670,18 @@ to destroy them and players will be able to make replacements.
 		/obj/item/weapon/stock_parts/manipulator = 3,
 		/obj/item/weapon/stock_parts/micro_laser = 1
 	)
+
+/obj/item/weapon/circuitboard/suit_storage_unit
+	name = "Circuit board (Suit Storage Unit)"
+	desc = "A circuit board used to clean, charge, and store a hardsuit"
+	build_path = /obj/machinery/suit_storage_unit
+	board_type = MACHINE
+	origin_tech = Tc_ENGINEERING + "=2;" + Tc_PROGRAMMING + "=2" + Tc_POWERSTORAGE + "=2"
+	req_components = list(
+		/obj/item/weapon/stock_parts/micro_laser = 2,
+		/obj/item/weapon/stock_parts/manipulator = 1,
+		/obj/item/weapon/stock_parts/scanning_module = 1,	
+		/obj/item/weapon/stock_parts/capacitor = 1,	
+		/obj/item/weapon/stock_parts/console_screen = 1
+	)
+	

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -71,7 +71,7 @@
 					new /obj/machinery/fishtank/bowl(get_turf(src))
 					qdel(src)
 				return
-			if (2)m
+			if (2)
 				if(iscrowbar(P))
 					if (C != null)
 						C.forceMove(get_turf(src))

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -71,7 +71,7 @@
 					new /obj/machinery/fishtank/bowl(get_turf(src))
 					qdel(src)
 				return
-			if (2)
+			if (2)m
 				if(iscrowbar(P))
 					if (C != null)
 						C.forceMove(get_turf(src))
@@ -1676,7 +1676,7 @@ to destroy them and players will be able to make replacements.
 	desc = "A circuit board used to clean, charge, and store a hardsuit"
 	build_path = /obj/machinery/suit_storage_unit
 	board_type = MACHINE
-	origin_tech = Tc_ENGINEERING + "=2;" + Tc_PROGRAMMING + "=2" + Tc_POWERSTORAGE + "=2"
+	origin_tech = Tc_ENGINEERING + "=2;" + Tc_PROGRAMMING + "=2;" + Tc_POWERSTORAGE + "=2"
 	req_components = list(
 		/obj/item/weapon/stock_parts/micro_laser = 2,
 		/obj/item/weapon/stock_parts/manipulator = 1,

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -780,13 +780,6 @@
 //////////////////////////////REMINDER: Make it lock once you place some fucker inside.
 
 
-//obj/machinery/suit_storage_unit/wrenchAnchor(var/mob/user, var/obj/item/I)
-//	if(isUV | issuperUV) 
-//		to_chat(user, "<span class='warning'>Wait for the [src] to finish cauterising.</span>")
-//		return FALSE
-//	. = ..()
-//	update_icon()	
-
 obj/machinery/suit_storage_unit/New()
 	. = ..()
 	component_parts = newlist(

--- a/code/modules/research/designs/boards/machine_science.dm
+++ b/code/modules/research/designs/boards/machine_science.dm
@@ -143,3 +143,14 @@
 	materials = list(MAT_GLASS = 2000, SACID = 20)
 	category = "Console Boards"
 	build_path = /obj/item/weapon/circuitboard/weathercontrol
+
+/datum/design/suitstorageunit
+	name = "Circuit Design(Suit Storage Unit)"
+	desc = "The circuit board for a Suit Storage Unit."
+	id = "suitstorageunit"
+	req_tech = list(Tc_PROGRAMMING = 2, Tc_ENGINEERING = 2, Tc_POWERSTORAGE = 2)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 2000, SACID = 15)
+	category = "Machine Boards"
+	build_path = /obj/item/weapon/circuitboard/suit_storage_unit
+	


### PR DESCRIPTION
## What this does
Allows Suit Storage Units to be unanchored with a wrench and welder so you can move them, and you can also make new ones. (how unatomic of me).
This also allows you to deconstruct SSUs, too

code was tested in a controlled environment, so hopefully the odd features that the SSU has won't be in conflict. already added a check so you can't wrench it if it's disinfecting, and another check to deconstruction to make sure there's nothing inside of it so that no items will be deleted.

## Why it's good
I always found it weird that you couldn't move them.
Also found it weird that you couldn't make another unit, as you can make the suits that go inside of them, so this solves that.

## Changelog
:cl:
 * rscadd: Suit Storage Units can now be (un)secured from the floor by unwelding and unwrenching them
 * rscadd: Suit Storage Units can now be created with a machine frame and their respective board (requires 2 Programming, 2 Engineering, 2 Powerstorage research)
 * rscadd: Suit Storage Units can now be deconstructed if they are empty
