### PR TITLE
Reduce amount of pain from scalding reagents

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -645,7 +645,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 			else
 				custom_pain_msg = "Pain sears [which_organ ? " your " + which_organ.display_name : ""]!"
 			H.custom_pain(custom_pain_msg, post_mod_predicted_dmg >= SCALD_AGONIZING, post_mod_predicted_dmg >= SCALD_PAINFUL)
-		L.apply_effect(burn_dmg * 5, AGONY) //pain
+		L.apply_effect(burn_dmg, AGONY) //pain
 		L.apply_damage(burn_dmg, BURN, which_organ)
 
 #undef SCALD_PAINFUL


### PR DESCRIPTION
## What this does
This makes it so far less pain is applied when you get scalded with hot reagents. Currently, it does 5 times the burn damage, as temporary pain-damage. This reduces it to 1x, so greatly lessens the pain effect of being splashed with hot oil or scarfing down a large amount of hot food.

## Why it's good
Make eating scalding hot ramen or caramel less of a problem in terms of temporarily passing out from pain.

This is one option which can be considered an alternative to #35191

Fixes  #34975

## Changelog
:cl:
 * tweak: Reduced pain damage from being splashed by or consuming scalding hot reagents.
