### PR TITLE
Ramen heating tweaks

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -485,7 +485,6 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 
 		chem_temp += C.reaction_temp_change
 		if (C.reaction_heat_released)
-			message_admins("Debug [C.reaction_heat_released] | [multiplier]")
 			heating(multiplier * C.reaction_heat_released, C.reaction_heat_released > 0 ? INFINITY : 0)
 
 		var/created_volume = C.result_amount*multiplier

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -484,6 +484,9 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 				remove_reagent(B, (multiplier * req_reag_amt), safety = 1)
 
 		chem_temp += C.reaction_temp_change
+		if (C.reaction_heat_released)
+			message_admins("Debug [C.reaction_heat_released] | [multiplier]")
+			heating(multiplier * C.reaction_heat_released, C.reaction_heat_released > 0 ? INFINITY : 0)
 
 		var/created_volume = C.result_amount*multiplier
 		if(C.result)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -19,6 +19,7 @@
 	var/required_temp = 0
 	var/react_discretely = FALSE //Handle_reactions() won't find the maximum number of times the chemicals can react. Use only if it shouldn't react more than once at a time.
 	var/reaction_temp_change = 0 //How much to change the temperature of the result chemical after the reaction
+	var/reaction_heat_released = 0 //How much heat energy (J) is released per reaction, scales with amount.
 	var/alert_admins = 0 //1 to alert admins with name and amount, 2 to alert with name and amount of all reagents
 	var/quiet = 0
 
@@ -2507,7 +2508,7 @@
 	result = HOT_RAMEN
 	required_reagents = list(WATER = 1, DRY_RAMEN = 3)
 	result_amount = 3
-	required_temp = 100+T0C
+	required_temp = 98+T0C
 
 /datum/chemical_reaction/hell_ramen
 	name = "Hell Ramen"
@@ -3644,8 +3645,7 @@
 	result = CALCIUMHYDROXIDE
 	required_reagents = list(WATER = 1, CALCIUMOXIDE = 1)
 	result_amount = 1
-	reaction_temp_change = 47
-	react_discretely = TRUE
+	reaction_heat_released = 20000
 
 /datum/chemical_reaction/sodium_silicate
 	name = "Sodium Silicate"


### PR DESCRIPTION
## What this does
Currently, self-heating ramen uses calcium oxide + water -> calcium hydroxide reaction to heat it up enough to cook the ramen (100 C).
This is one of three reactions in the game that affect the temperature of the reagents mixture, the other two being the decomposition of space lube into sludge at extreme temperatures, and water freezing. Those two remain unchanged here.
However this introduces a slightly different mechanism for heat-releasing (or heat-absorbing) reactions and changes calcium oxide to use it. Instead of increasing the temperature of the mixture by a fixed number of degrees (regardless of its specific heat capacity), the reaction will instead release a given amount of heat per volume of the products. Here I set to where filling the ramen in a sink with enough water to boil all the ramen will bring it to ~106 degrees which feels reasonable and cooks it nicely. This also lets us remove the "react discretely" flag from the calcium oxide reaction, which I think was probably added to try to approximate this behavior, but is ultimately somewhat unsuited to this situation.

Also this reduces the ramen cooking temperature from 100 C to 98 C (apparently that's the ideal temperature for cooking ramen). Hopefully that also anticipates any future issues that may arise with regard to water boiling.

## Why it's good
More intuitive behavior and avoid some aberrant edge cases with how it currently works.

## Changelog
:cl:
 * rscadd: Calcium oxide dissolving releases a definite quantity of energy rather than directly shifting temperature by a fixed amount.
