### PR TITLE
Allow the AI to alt-click objects to view turf contents

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -336,7 +336,7 @@
 	var/valid = FALSE
 	if(isAI(user))
 		var/mob/living/silicon/ai/ai = user
-		if(T && (T in range(8, ai.eyeobj.loc)))
+		if(T && (T in range(7, ai.eyeobj.loc)))
 			valid = TRUE
 	else if(T && (T in range(1, user.loc)) && (T in view(1, user.virtualhearer))) //If next to user's location (to allow locker and mech alt-clicks) and if the user can actually view it
 		valid = TRUE

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -333,7 +333,14 @@
 
 /atom/proc/AltClick(var/mob/user)
 	var/turf/T = get_turf(src)
-	if(T && (T in range(1, user.loc)) && (T in view(1, user.virtualhearer))) //If next to user's location (to allow locker and mech alt-clicks) and if the user can actually view it
+	var/valid = FALSE
+	if(isAI(user))
+		var/mob/living/silicon/ai/ai = user
+		if(T && (T in range(8, ai.eyeobj.loc)))
+			valid = TRUE
+	else if(T && (T in range(1, user.loc)) && (T in view(1, user.virtualhearer))) //If next to user's location (to allow locker and mech alt-clicks) and if the user can actually view it
+		valid = TRUE
+	if(valid)
 		if(user.listed_turf == T)
 			user.listed_turf = null
 		else

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -647,11 +647,6 @@ About the new airlock wires panel:
 			// disable/6 is not in Topic; disable/5 disables both temporary and permenant shock
 			Topic("aiDisable=5", list("aiDisable"="5"), 1)
 
-/turf/AIAltClick()
-	for(var/obj/machinery/door/airlock/A in contents)
-		A.AIAltClick()
-		break
-
 /obj/machinery/door/airlock/AICtrlClick() // Bolts doors
 	if(allowed(usr))
 		if(locked)

--- a/code/game/objects/structures/fullwindow.dm
+++ b/code/game/objects/structures/fullwindow.dm
@@ -32,15 +32,6 @@
 /obj/structure/window/full/setup_border_dummy()
 	return
 
-/obj/structure/window/full/AltClick(mob/user)
-	var/turf/T = get_turf(src)
-	if(T && (T in range(1, user.loc)) && (T in view(1, user.virtualhearer))) //If next to user's location (to allow locker and mech alt-clicks) and if the user can actually view it
-		if(user.listed_turf == T)
-			user.listed_turf = null
-		else
-			user.listed_turf = T
-			user.client.statpanel = T.name
-
 /obj/structure/window/full/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
 	if(istype(mover) && mover.checkpass(pass_flags_self))
 		dim_beam(mover)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -90,9 +90,12 @@ var/list/one_way_windows
 	examine_health(user)
 
 /obj/structure/window/AltClick(mob/user)
-	if(user.incapacitated() || !Adjacent(user))
-		return
-	rotate()
+	if(is_fulltile)
+		. = ..()
+	else
+		if(user.incapacitated() || !Adjacent(user))
+			return
+		rotate()
 
 /obj/structure/window/proc/examine_health(mob/user)
 	if(!anchored)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1486,7 +1486,15 @@ Use this proc preferably at the end of an equipment loadout
 
 	if(client && client.inactivity < (1200))
 		if(listed_turf)
-			if(get_dist(listed_turf,src) > 1)
+			var/inrange = TRUE
+			if(isAI(src))
+				var/mob/living/silicon/ai/ai = src
+				if(get_dist(listed_turf, ai.eyeobj) > 7)
+					inrange = FALSE
+			else if(get_dist(listed_turf,src) > 1)
+				inrange = FALSE
+
+			if(!inrange)
 				listed_turf = null
 			else if(statpanel(listed_turf.name))
 				statpanel(listed_turf.name, null, listed_turf)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does

Most mobs can alt-click objects with no special alt-click interactions to display the contents of the turf the object is on in the right-hand panel. This was effectively broken for the AI, as it only worked within 1 tile of the AI core mob.

This enables this behaviour for anything the AI eye can see.

I disabled a feature that allows the AI to alt-click on the turf under an open airlock to electrify the airlock when implementing this. The alternative would've been to enable this feature for all turfs except ones with (open) airlocks on them. I weighed the risk of accidental doorshocks caused by that slightly unintuitive UX against the frequency that I personally, as someone who plays a lot of AI, ever electrify open airlocks by clicking on the turf (never), and figured this was the better option. I hold no strong feelings on the matter and will change it if people disagree though.

<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Why it's good
<!-- Explain why you think these changes are good. -->

This prevents occasions where the AI cannot interact with objects that are obscured by other sprites. For example, the chaplain rebuilding the AI chamber out of glass and covering the flasher with a full window.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: The AI can now alt-click things with no special alt-click interactions to bring up the list of the turf's contents, like other mobs can.
 * tweak: Alt-clicking under an open airlock as the AI no longer electrifies the airlock.