### PR TITLE
Make dionae slightly faster than a wheelchair

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -902,7 +902,7 @@ var/global/list/playable_species = list("Human")
 	has_mutant_race = 0
 	burn_mod = 2.5 //treeeeees
 
-	move_speed_mod = 7
+	move_speed_mod = 4
 
 	species_intro = "You are a Diona.<br>\
 					You are a plant, so light is incredibly helpful for you, in both photosynthesis, and regenerating damage you have received.<br>\


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

[controversial] [qol] [tweak]

Makes dionae three units faster.  They're still really slow, but at least now they're slightly faster than using a wheelchair.

Measured some speeds on this scientific test track (marked in red): 

![2023-10-20T07:40:02](https://github.com/vgstation-coders/vgstation13/assets/5822375/a40926f5-9957-489f-b5b0-449c0a45c9be)

- Current diona (move_speed_mod 7): Just shy of 30 seconds.
- Diona in a wheelchair: 22 seconds.
- This PR (move_speed_mod 4): Just shy of 19 seconds.
- Human walking: 15 seconds.
- Human running: 5 seconds.

So they're still slower than a human walking, and by a fair margin.

## Why it's good
<!-- Explain why you think these changes are good. -->

Dionas are funny. I like playing them and I like seeing them around. They're a nice change of pace from the other races that zoom out of earshot and vision in like less than a second. I like them being slow.

However, their current move speed is absolutely meme tier; the other day I was playing diona warden and clocked a trip from the warden's office to the cargo orders console on Roidstation taking 2 minutes and 10 seconds *in one direction*, and only barely caught up to a patrolling Beepsky on my way there. As a consequence, people used to (understandably) constantly dose hyperzine to get around. The changes to hyperzine that remove all punctuation from your speech have seemingly decreased diona popularity by a lot.

Speeding them up a little bit, but not much, seems to me like the right move. At first I considered making them as fast as using a wheelchair (another popular coping mechanism), but then I settled on one notch faster than that because if you're as slow as a wheelchair, why not just be in a wheelchair and be slip immune to boot?

## Why I think it's not OP

We had hyperzine-doped dionae running around at human (or faster-than-human) speeds for years and they weren't OP then. We still have hyperzine-doped dionae and they aren't OP, but people don't like using them for flavour reasons.

## Alternatives considered

- making them as fast as a wheelchair (why not just use a wheelchair?)
- making them slightly slower than a wheelchair (why not just use a wheelchair?)
- giving them some other kind of buff like being harder to push around when on hostile intent due to their roots (balance nightmare)
- not doing anything (they remain a barely used meme race)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Dionae are now about 33% faster, making them slightly faster than using a wheelchair.
