### PR TITLE
Grues have normal vision (while obviously seeing in the dark)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -377,16 +377,7 @@
 	if(!client)
 		return
 	if(dark_plane)
-		if(master_plane)
-			master_plane.blend_mode = BLEND_ADD
-		dark_plane.alphas["grue"] = 15 // with the master_plane at BLEND_ADD, shadows appear well lit while actually well lit places appear blinding.
-		client.color = list(
-				1,0,0,0,
-				-1,0.2,0.2,0,
-				-1,0.2,0.2,0,
-				0,0,0,1,
-				0,0,0,0)
-
+		dark_plane.alphas["grue"] = 120
 	check_dark_vision()
 
 /mob/living/simple_animal/hostile/grue/Stat()


### PR DESCRIPTION
This is what you're missing on.
![grue](https://github.com/vgstation-coders/vgstation13/assets/41342767/3cf666be-9603-41c6-af49-00f9145c20be)

1. It's more readable
2. It looks prettier and not a little bit of an eyesore
3. Light code is an awful amalgamation of planes, overlays and other stuff and the less instances of different color vision stuff there are the easier they are to work with
4. Should mostly fix a bug where an excessive amount of red-colored lights, when affected by the Drain Light ability, would create incredibly bright red areas that grues couldn't see through because they saw red better, AKA mostly fixes #32940 
5. Grues are dark. It looks cooler. Look at it!

:cl:
 * tweak: Grues no longer have cyan-colored vision, but instead normal-colored vision. In addition this should also mostly fix a buggy interaction between grue vision, a lot of sources of red light (prominently flares) and the grue's Drain Light ability.