### PR TITLE
Several Events Which Shouldn’t Fire During Deadpop Will No Longer Fire During Deadpop

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -365,6 +365,13 @@
 		keys += key
 	return keys
 
+//In an associative list, return a sum of the elements.
+/proc/get_sum_of_elements(var/list/L)
+	var/elements = 0
+	for(var/key in L)
+		elements += L[key]
+	return elements
+
 /proc/count_by_type(var/list/L, type)
 	var/i = 0
 	for(var/T in L)

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -4,7 +4,7 @@
 	var/list/spawned_carp = list()
 
 /datum/event/carp_migration/can_start(var/list/active_with_role)
-	if(active_with_role.len > 6)
+	if(active_with_role["Any"] > 6)
 		return 40
 	return 0
 

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -123,7 +123,7 @@ var/list/event_last_fired = list()
 					if("janitorial robot module")
 						active_with_role["Janitor"]++
 					else
-						active_with_role["Other"]++
+						active_with_role["Minor"]++
 
 		if((M.mind.assigned_role in engineering_positions) && M.mind.assigned_role != "Mechanic")
 			active_with_role["Engineer"]++

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -85,10 +85,11 @@ var/list/event_last_fired = list()
 
 	return 1
 
-// Returns how many characters are currently active(not logged out, not AFK for more than 10 minutes)
-// with a specific role.
+// Returns a list of how many characters are currently active with a specific role
+// see: (not logged out, not AFK for more than 10 minutes)
 // Note that this isn't sorted by department, because e.g. having a roboticist shouldn't make meteors spawn.
-/proc/number_active_with_role(role)
+// Minor roles have lesser influence on events, Any just cares about active players at all
+/proc/number_active_with_role()
 	var/list/active_with_role = list()
 	active_with_role["Engineer"] = 0
 	active_with_role["Medical"] = 0
@@ -98,10 +99,14 @@ var/list/event_last_fired = list()
 	active_with_role["Cyborg"] = 0
 	active_with_role["Janitor"] = 0
 	active_with_role["Botanist"] = 0
+	active_with_role["Minor"] = 0
+	active_with_role["Any"] = 0
 
 	for(var/mob/M in player_list)
 		if(!M.mind || !M.client || M.client.inactivity > 10 * 10 * 60) // longer than 10 minutes AFK counts them as inactive
 			continue
+
+		active_with_role["Any"]++
 
 		if(isrobot(M))
 			var/mob/living/silicon/robot/tincan = M
@@ -113,29 +118,45 @@ var/list/event_last_fired = list()
 						active_with_role["Medical"]++
 					if("security robot module")
 						active_with_role["Security"]++
+					if("combat robot module")
+						active_with_role["Security"]++
+					if("janitorial robot module")
+						active_with_role["Janitor"]++
+					else
+						active_with_role["Other"]++
 
 		if((M.mind.assigned_role in engineering_positions) && M.mind.assigned_role != "Mechanic")
 			active_with_role["Engineer"]++
+			continue
 
 		if(M.mind.assigned_role in medical_positions)
 			active_with_role["Medical"]++
+			continue
 
 		if(M.mind.assigned_role in security_positions)
 			active_with_role["Security"]++
+			continue
 
 		if(M.mind.assigned_role in science_positions)
 			active_with_role["Scientist"]++
+			continue
 
 		if(M.mind.assigned_role == "AI")
 			active_with_role["AI"]++
+			continue
 
 		if(M.mind.assigned_role == "Cyborg")
 			active_with_role["Cyborg"]++
+			continue
 
 		if(M.mind.assigned_role == "Janitor")
 			active_with_role["Janitor"]++
+			continue
 
 		if(M.mind.assigned_role == "Botanist")
 			active_with_role["Botanist"]++
+			continue
+
+		active_with_role["Minor"]++
 
 	return active_with_role

--- a/code/modules/events/immovablerod.dm
+++ b/code/modules/events/immovablerod.dm
@@ -10,12 +10,12 @@ var/list/all_rods = list()
 	announceWhen = 1
 
 /datum/event/immovable_rod/can_start(var/list/active_with_role)
-	if(active_with_role["Engineer"] > 1 && active_with_role.len > 6)
+	if(active_with_role["Engineer"] > 1 && active_with_role["Any"] > 6)
 		return 15
 	return 0
 
 /datum/event/immovable_rod/big/can_start(var/list/active_with_role)
-	if(active_with_role["Engineer"] > 2 && active_with_role.len > 6)
+	if(active_with_role["Engineer"] > 2 && active_with_role["Any"] > 6)
 		return 15
 	return 0
 

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -9,7 +9,7 @@
 	endWhen			= 30
 
 /datum/event/meteor_wave/can_start(var/list/active_with_role)
-	if(active_with_role["Engineer"] > 1 && active_with_role.len > 6)
+	if(active_with_role["Engineer"] > 1 && active_with_role["Any"] > 6)
 		return 15
 	return 0
 
@@ -34,7 +34,7 @@
 	endWhen 		= 30
 
 /datum/event/meteor_shower/can_start(var/list/active_with_role)
-	if(active_with_role["Engineer"] > 1 && active_with_role.len > 6)
+	if(active_with_role["Engineer"] > 1 && active_with_role["Any"] > 6)
 		return 40
 	return 0
 

--- a/code/modules/events/powercreeper.dm
+++ b/code/modules/events/powercreeper.dm
@@ -1,7 +1,7 @@
 /datum/event/powercreeper
 
 /datum/event/powercreeper/can_start(var/list/active_with_role)
-	if(active_with_role["Engineer"] > 1 && active_with_role.len > 6)
+	if(active_with_role["Engineer"] > 1 && active_with_role["Any"] > 6)
 		return 15
 	return 0
 

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -1,7 +1,7 @@
 /datum/event/spacevine
 
 /datum/event/spacevine/can_start(var/list/active_with_role)
-	if(active_with_role.len > 6)
+	if(active_with_role["Any"] > 6)
 		return 20
 	return 0
 
@@ -11,7 +11,7 @@
 /datum/event/biomass
 
 /datum/event/biomass/can_start(var/list/active_with_role)
-	if(active_with_role.len > 6)
+	if(active_with_role["Any"] > 6)
 		return 15
 	return 0
 


### PR DESCRIPTION
It's funny that nobody noticed this. This PR does NOT INCLUDE RADSTORMS (see #35221)

A lone engineering cyborg watching the station fall apart around him except he's spared some of the worst events.

![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/e5665652-22c5-417a-917d-d2c31443ffc5)

## What this does
Fixes #33935 so that it works.

This fixes the active role count on random events so that it actually works on pops less than 8. That means the following events will now no longer fire without their proper minimum active player count of **7**:
* Space Vines
* Biomass
* Powercreeper
* Immovable Rod - Normal
* Immovable Rod - Big
* Meteor - Wave
* Meteor - Shower
* Carp Migration

The other requirements were checked properly (Engineers).

This also formally adds Janitor borgs to the list of Janitors for events (this is unused), adds a Minor role list to event roles (also unused), and adds a helper proc to get the sum of the elements of a helper list (this is super unatomic, but it's a helper proc! it's good!).

## Why it's good
Helepr procs!

I mean, uh, no more vines on deadpop for real this time!

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Low pop events that weren't supposed to fire will no longer fire.
 * bugfix: Vines, Biomass, and Carp need 7 active players.
 * bugfix: Powercreeper, Meteors (Waves/Showers), and Immovable Rods (Small/Large) need 7 active players with at least 1 Engineer.

[bugfix] [tested] [gameplay]