### PR TITLE
Fix mapped air sensors and pipe meters resetting to default id_tag and frequency

### DIFF
--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -108,11 +108,13 @@
 		return
 	set_frequency(frequency)
 
-/obj/machinery/air_sensor/New(loc, freq = 1439, id = null)
+/obj/machinery/air_sensor/New(loc, freq, id)
 	..()
 
-	frequency = freq
-	id_tag = id
+	if (freq != null)
+		frequency = freq
+	if (id != null)
+		id_tag = id
 	if(ticker && ticker.current_state == GAME_STATE_PLAYING)
 		initialize()
 

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -14,13 +14,15 @@
 	active_power_usage = 4
 	machine_flags = MULTITOOL_MENU
 
-/obj/machinery/meter/New(newloc, new_target, freq = 1439, id = null)
+/obj/machinery/meter/New(newloc, new_target, freq, id)
 	..(newloc)
 	src.target = new_target
 	if(target)
 		setAttachLayer(target.piping_layer)
-	frequency = freq
-	id_tag = id
+	if (freq != null)
+		frequency = freq
+	if (id != null)
+		id_tag = id
 	return 1
 
 /obj/machinery/meter/initialize()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
#35142 introduced a bug where air sensors and pipe meters mapped in with a customized id_tag and frequency have those variables reset upon creation. This fixes that bug.

## Why it's good
<!-- Explain why you think these changes are good. -->
Fixing bugs is good.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Mapped-in air sensors and pipe meters now have the correct id_tag and frequency again.
