### PR TITLE
Allow player to control skeleton jack on spook

### DIFF
--- a/code/game/objects/structures/candybucket.dm
+++ b/code/game/objects/structures/candybucket.dm
@@ -89,13 +89,19 @@
 		spooky = TRUE
 
 
-/obj/structure/candybucket/candy_jack/spook()
+/obj/structure/candybucket/candy_jack/spook(mob/dead/observer/ghost)
 	if(..())
-		becomeSpooky()
+		becomeSpooky(ghost)
+	else
+		to_chat(ghost,"<span class='notice'>That jack-o-lantern has spooked its last spook.</span>")
 
-/obj/structure/candybucket/candy_jack/proc/becomeSpooky()
+/obj/structure/candybucket/candy_jack/proc/becomeSpooky(mob/dead/observer/ghost)
 	var/mob/living/simple_animal/hostile/skeletonjack/ourJack = new /mob/living/simple_animal/hostile/skeletonjack(loc)
 	forceMove(ourJack)
 	ourJack.candyEnhance(contents.len)
 	ourJack.ourBucket = src
 	spooky = FALSE //So ghosts can't just infinitely revive the thing. One haunting per bucket.
+	if(ghost)
+		switch(alert(ghost,"Are you sure you wish to become a spooky bucket-boy? You won't be able to re-enter any previous body.","To spook or not to spook","DOKTOR, TURN OFF MY SPOOK INHIBITORS","I just want to animate it"))
+			if("DOKTOR, TURN OFF MY SPOOK INHIBITORS")
+				ghost.mind.transfer_to(ourJack)


### PR DESCRIPTION
> [19:15:46]ADMIN: PM: Manylo/(The god of light switches)->Toomykins/(Gary Gutter): oh yea if you need a coding idea  
> [19:15:55]ADMIN: PM: Manylo/(The god of light switches)->Toomykins/(Gary Gutter): allow the candy_jack to be possed by ghosts instead of being turned on 
> [19:16:02]ADMIN: PM: Manylo/(The god of light switches)->Toomykins/(Gary Gutter): it's spooky / low impact 

>see jack-o-lantern candybucket
>spook it
>animates it
>prompt asks whether you wish to control it
>you get to control it
it's a simplemob 

:cl:
* rscadd: observers/ghosts are now able to possess the jack-o-lantern candy-buckets upon spooking