### PR TITLE
Removes Summon Server Crash

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -379,7 +379,7 @@ This function restores all organs.
 		damage = (damage/100)*(100-blocked)
 
 	if(!ignore_events && INVOKE_EVENT(src, /event/damaged, "kind" = damagetype, "amount" = damage))
-		return 0
+		return 0 //This event code is also in the mob/living parent which this proc mostly overrides.
 
 	switch(damagetype)
 		if(BRUTE)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -12,6 +12,8 @@
 	if(!damage)
 		return 0
 	var/damage_done = (damage/100)*(100-blocked)
+	if(!ignore_events && INVOKE_EVENT(src, /event/damaged, "kind" = damagetype, "amount" = damage))
+		return 0
 	switch(damagetype)
 		if(BRUTE)
 			adjustBruteLoss(damage_done)


### PR DESCRIPTION
After much deliberation I think Summon Server Crash is bad for the server and isn't fun to play with. It's impossible to counter, it's extremely dangerous to nearby victims (and the server) and it overshadows even the other powerful abilities such as Summon Pastry and Summon Snacks. I know people would largely hate the removal of Summon Server Crash but I think it's probably for the best that we remove it now before people get too used to it and they start believing that this is a good thing.

Fixes #34279
Fixes #29366

Adds the "damaged" event to mob/living but still leaves one in /mob/living/carbon/human because in most cases it gets overridden. This also means that if a human receives damage that isn't burn or brute (such as cloning damage or oxygen damage) it should properly call the event in the parent, since it moves to the parent in that line of code.

:cl:
 * bugfix: Fixed a bug that caused Pain Mirror to be able to indefinitely ping-pong between different Pain Mirror users, provided that they were not human. This was, most notably, possible with the wizard's Arcane Golems.