### PR TITLE
Shut up games vending machine

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3537,12 +3537,6 @@ var/global/num_vending_terminals = 1
 /obj/machinery/vending/games
 	name = "\improper Al's Fun And Games"
 	desc = "A vending machine that sells various games and toys."
-	product_slogans = list(
-		"It's all fun and games at Al's Fun And Games!",
-		"Roll for initiative!",
-		"It's a full house of fun!",
-		"Caves and Wyverns 3rd edition available now!"
-	)
 	product_ads = list(
 		"Sponsored by Warlocks of the Shore.",
 		"Al's Fun And Games Co. is not liable for friendships damaged by use of the Product."


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Removes the cheesy spoken-out-loud slogans from the games vending machine.

## Why it's good
<!-- Explain why you think these changes are good. -->

This thing is usually next to the library D&D table and can be annoying if you're actually playing D&D there.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: The games vending machine no longer speaks