### PR TITLE
Some mech fixes

### DIFF
--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -22,11 +22,10 @@
 	return
 
 /obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp/detach()
-	..()
 	if(istype(chassis, /obj/mecha/working))
 		var/obj/mecha/working/W = chassis
 		W.hydraulic_clamp = null
-	return
+	..()
 
 /obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp/action(atom/target)
 	if(!action_checks(target))
@@ -437,9 +436,8 @@
 		return ..()
 
 /obj/item/mecha_parts/mecha_equipment/jetpack/detach()
-	..()
 	chassis.proc_res["dyndomove"] = null
-	return
+	..()
 
 /obj/item/mecha_parts/mecha_equipment/jetpack/attach(obj/mecha/M as obj)
 	..()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1210,7 +1210,7 @@
 	for (var/datum/faction/F in factions_with_hud_icons)
 		F.update_hud_icons()
 
-/obj/mecha/proc/moved_inside(var/mob/living/carbon/H as mob)
+/obj/mecha/proc/moved_inside(var/mob/living/carbon/human/H as mob)
 	if(!isnull(src.loc) && H && H.client && (H in range(1)))
 		H.reset_view(src)
 		H.stop_pulling()
@@ -1291,6 +1291,8 @@
 		src.silicon_pilot = TRUE
 		if(src.silicon_icon_state)
 			src.icon_state = src.silicon_icon_state
+		else
+			icon_state = initial_icon
 		if(!lights) //if the main lights are off, turn on cabin lights
 			light_power = light_brightness_off
 			set_light(light_range_off)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1210,7 +1210,7 @@
 	for (var/datum/faction/F in factions_with_hud_icons)
 		F.update_hud_icons()
 
-/obj/mecha/proc/moved_inside(var/mob/living/carbon/human/H as mob)
+/obj/mecha/proc/moved_inside(var/mob/living/carbon/H as mob)
 	if(!isnull(src.loc) && H && H.client && (H in range(1)))
 		H.reset_view(src)
 		H.stop_pulling()
@@ -1261,8 +1261,6 @@
 
 	if(do_after(user, src, 40))
 		if(!occupant)
-			log_admin("[key_name(usr)] has inserted [mmi_as_oc] (played by: [mmi_as_oc.brainmob.ckey]) into the [src] at X=[src.x];Y=[src.y];Z=[src.z]")
-			message_admins("[key_name(usr)] has inserted [mmi_as_oc] (played by: [mmi_as_oc.brainmob.ckey]) into the [src]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
 			return mmi_moved_inside(mmi_as_oc,user)
 		else
 			to_chat(user, "Occupant detected.")
@@ -1300,11 +1298,14 @@
 		src.log_message("[mmi_as_oc] moved in as pilot.")
 		if(!hasInternalDamage())
 			src.occupant << sound('sound/mecha/nominalsyndi.ogg',volume=50)
+		refresh_spells()
 
 		//change the cursor
 		if(occupant.client && cursor_enabled)
 			occupant.client.mouse_pointer_icon = file("icons/mouse/mecha_mouse.dmi")
 
+		log_admin("[key_name(user)] has inserted [mmi_as_oc] (played by: [mmi_as_oc.brainmob.ckey]) into the [src] at X=[src.x];Y=[src.y];Z=[src.z]")
+		message_admins("[key_name(user)] has inserted [mmi_as_oc] (played by: [mmi_as_oc.brainmob.ckey]) into the [src]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
 		return 1
 	else
 		return 0
@@ -1429,7 +1430,6 @@
 		occupant.reset_view()
 		empty_bad_contents()
 		occupant << browse(null, "window=exosuit")
-		remove_mech_spells()
 
 		//change the cursor
 		if(occupant && occupant.client)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1247,9 +1247,13 @@
 	else if(occupant)
 		to_chat(user, "Occupant detected.")
 		return 0
-	else if(dna && dna!=mmi_as_oc.brainmob.dna.unique_enzymes)
-		to_chat(user, "Stop it!")
-		return 0
+	else if(dna)
+		if(!mmi_as_oc.brainmob.dna)
+			to_chat(user, "Remove the DNA-lock before proceeding.</span>") //Avoids a posibrain runtime since posibrains don't have DNA
+			return 0
+		if(mmi_as_oc.brainmob.dna && dna!=mmi_as_oc.brainmob.dna.unique_enzymes)
+			to_chat(user, "The DNA-lock rejects \the [mmi_as_oc], the DNAs do not match.") //Gives a clue that the MMI could be inserted if it was the original DNA lock holder.
+			return 0
 	//Added a message here since people assume their first click failed or something./N
 //	to_chat(user, "Installing MMI, please stand by.")
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1249,7 +1249,7 @@
 		return 0
 	else if(dna)
 		if(!mmi_as_oc.brainmob.dna)
-			to_chat(user, "Remove the DNA-lock before proceeding.</span>") //Avoids a posibrain runtime since posibrains don't have DNA
+			to_chat(user, "Remove the DNA-lock before proceeding.") //Avoids a posibrain runtime since posibrains don't have DNA
 			return 0
 		if(mmi_as_oc.brainmob.dna && dna!=mmi_as_oc.brainmob.dna.unique_enzymes)
 			to_chat(user, "The DNA-lock rejects \the [mmi_as_oc], the DNAs do not match.") //Gives a clue that the MMI could be inserted if it was the original DNA lock holder.


### PR DESCRIPTION
Thanks a lot to BoHaynes for all the help with testing!
Also fixes a runtime related to spell removal. Turns out spell removal was getting called twice because both Exited() (a wider-purpose proc that happens every time something gets out of an object) and go_out() (a mech code proc that handled the occupant going out) were getting called every time an occupant left the mech, because go_out() includes forceMove() which includes Exited().
Also fixes an oversight similar to the jetpack problem for hydraulic clamps, in that it would try to call the occupant after the occupant has been rendered null. It didn't have any significant gameplay impact as far as I can tell, other than that drilling for ore would automatically collect the ore without having the clamp to do so.
Also admins should no longer be told that an MMI or posibrain has been inserted into a mech if it failed to do so.

:cl:
 * bugfix: Fixed a bug where detaching a mech's jetpack while the jetpack was active would render the mech permanently immobile.
 * bugfix: Fixed a bug where MMIs and posibrains getting inserted into a mech would not update its sprite, making it appear as if it was not occupied until they moved.
 * bugfix: Fixed a bug where MMIs and posibrains getting inserted into a mech would not have their spell menu appear until their equipment changed.
 * bugfix: Fixed a bug where users did not receive any message when failing to insert a posibrain into a mech with a DNA-lock active, because the posibrain does not have a DNA.
 * bugfix: Fixed a bug where a mech that had its hydraulic clamp removed could still automatically collect ore when digging.
 * spellcheck: Added more descriptive messages for when trying to insert an MMI or posibrain into a mech with a DNA-lock active.