### PR TITLE
Mech painter is instant and also sanity checks

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -2206,13 +2206,12 @@
 		to_chat(user, "<span class='warning'>This mech is already painted in that style.</span>")
 		return 1
 	if(icontype)
-		to_chat(user, "<span class='info'>You begin repainting the mech.</span>")
-		if (do_after(user, M , 30))
-			M.initial_icon = icontype
-			M.icon_state = icontype +"-open"
-			for(var/spell/mech/MS in M.intrinsic_spells)
-				MS.update_spell_icon()
-			M.refresh_spells() //I think this does something important
+		to_chat(user, "<span class='info'>You paint the mech.</span>")
+		M.initial_icon = icontype
+		M.icon_state = icontype +"-open"
+		for(var/spell/mech/MS in M.intrinsic_spells)
+			MS.update_spell_icon()
+		M.refresh_spells() //I think this does something important
 	return 1
 
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -2201,7 +2201,9 @@
 		return 1
 
 	var/icontype = input("Select the paint-job!")in M.mech_sprites
-
+//Sanity checks because icontype can be selected at an arbitrary amount of time.
+	if(!user.Adjacent(M) || user.incapacitated() || user.lying)
+		return 1
 	if(icontype == M.initial_icon)
 		to_chat(user, "<span class='warning'>This mech is already painted in that style.</span>")
 		return 1

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -2204,6 +2204,9 @@
 //Sanity checks because icontype can be selected at an arbitrary amount of time.
 	if(!user.Adjacent(M) || user.incapacitated() || user.lying)
 		return 1
+	if(M.occupant)
+		to_chat(user, "<span class='warning'>This mech has an occupant. It must be empty before you can paint it.</span>")
+		return 1
 	if(icontype == M.initial_icon)
 		to_chat(user, "<span class='warning'>This mech is already painted in that style.</span>")
 		return 1


### PR DESCRIPTION
Because why not? Especially when you want to know how each paintjob looks like.

Also added a few obligatory sanity checks that should prevent someone from painting the mech if they're not capable of doing so (such as if they're not near the mech or when they're incapacitated), normally it would be handled by do_after() but since that was removed in order to make it instant it's these checks instead.

:cl:
 * tweak: The mech painter is instant and no longer takes 4 seconds to paint a mech.