### PR TITLE
Grues no longer see the red circle harm overlay when damaged

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -211,6 +211,10 @@
 	if((stat==CONSCIOUS) && !busy && !ismoulting && !client && !mind && !ckey) //Checks for AI
 		grue_ai()
 
+//Grues already have a way to check their own health and the damage indicator doesn't mesh well with the vision.
+/mob/living/simple_animal/hostile/grue/standard_damage_overlay_updates()
+	return
+
 //AI stuff:
 /mob/living/simple_animal/hostile/grue/proc/grue_ai()
 


### PR DESCRIPTION
Because it sucks! Seriously!
Comparison between full health grue vision and damaged grue vision.
![healthy](https://github.com/vgstation-coders/vgstation13/assets/41342767/2be0e54b-41d2-47ca-84ee-12377d79ceb0)
![damaged](https://github.com/vgstation-coders/vgstation13/assets/41342767/e97d3501-48c2-4df8-8f2f-e319e9812960)

It outright doesn't show you which tile is properly safe anymore!

:cl:
 * tweak: Grues will no longer see the red damage overlay as they get more damaged.