### PR TITLE
Grues will nuzzle other grues instead of hitting them

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -280,10 +280,14 @@
 				if(!L.current_bulb || L.current_bulb.status == LIGHT_BROKEN)
 					continue
 				UnarmedAttack(B)
-	if(isgrue(A)) //No friendly firing other grues
-		to_chat(src, "<span class='notice'>You stop yourself from hitting a fellow grue.</span>")
-		return
 	..()
+
+/mob/living/simple_animal/hostile/grue/unarmed_attack_mob(target)
+	if(isgrue(target))
+		playsound(src, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+		visible_message("<span class='notice'>[src] nuzzles \the [target].</span>", "<span class='notice'>You nuzzle \the [target].</span>")
+		return
+	return ..()
 
 
 /mob/living/simple_animal/hostile/grue/proc/get_ddl(var/turf/thisturf) //get the dark_dim_light status of a given turf

--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -280,6 +280,8 @@
 				if(!L.current_bulb || L.current_bulb.status == LIGHT_BROKEN)
 					continue
 				UnarmedAttack(B)
+	if(isgrue(A)) //No friendly firing other grues
+		return
 	..()
 
 

--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -281,6 +281,7 @@
 					continue
 				UnarmedAttack(B)
 	if(isgrue(A)) //No friendly firing other grues
+		to_chat(src, "<span class='notice'>You stop yourself from hitting a fellow grue.</span>")
 		return
 	..()
 


### PR DESCRIPTION
After accidentally instantly killing a bunch of juvenile grues as an overfed grue about a month ago I thought "hey I don't think this is ok, it should be like xenomorphs where they don't attack each other" but it turns out that xenomorphs can attack each other but they deal extremely low damage. Oh well.

:cl:
 * tweak: Grues will now nuzzle other grues instead of hitting them.