### PR TITLE
Nerfs grue damage scaling, adds scaling armor penetration

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1428,7 +1428,6 @@ var/proccalls = 1
 #define GRUE_DIM 1	//light level neither heals nor burns
 #define GRUE_LIGHT 2//bright enough to burn
 #define GRUE_DRAINLIGHT 1 //Channeling the drain light ability
-#define GRUE_DAMAGE_LIMIT 50 //Grue damage will stop increasing past this point, instead they will gain extra armor penetration.
 /*
  *
  *

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1428,6 +1428,7 @@ var/proccalls = 1
 #define GRUE_DIM 1	//light level neither heals nor burns
 #define GRUE_LIGHT 2//bright enough to burn
 #define GRUE_DRAINLIGHT 1 //Channeling the drain light ability
+#define GRUE_DAMAGE_LIMIT 50 //Grue damage will stop increasing past this point, instead they will gain extra armor penetration.
 /*
  *
  *

--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -595,9 +595,9 @@
 	//health regen in darkness
 	lightparams.regenbonus = lightparams.base_regenbonus * (1.5 ** eatencount) //increased health regen in darkness
 
-	//melee damage
-	melee_damage_lower = min(GRUE_DAMAGE_LIMIT, base_melee_dam_lw + (5 * eatencount))
-	melee_damage_upper = min(GRUE_DAMAGE_LIMIT, base_melee_dam_up + (5 * eatencount))
+	//melee damage, 50 damage limit
+	melee_damage_lower = min(50, base_melee_dam_lw + (5 * eatencount))
+	melee_damage_upper = min(50, base_melee_dam_up + (5 * eatencount))
 	//How much armor they ignore on hit, +10% armor penetration for every target consumed up to 100% of armor ignored.
 	armor_modifier = max(0, 1 - (0.1 * eatencount))
 

--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -596,8 +596,10 @@
 	lightparams.regenbonus = lightparams.base_regenbonus * (1.5 ** eatencount) //increased health regen in darkness
 
 	//melee damage
-	melee_damage_lower = base_melee_dam_lw + (7 * eatencount)
-	melee_damage_upper = base_melee_dam_up + (7 * eatencount)
+	melee_damage_lower = min(GRUE_DAMAGE_LIMIT, base_melee_dam_lw + (5 * eatencount))
+	melee_damage_upper = min(GRUE_DAMAGE_LIMIT, base_melee_dam_up + (5 * eatencount))
+	//How much armor they ignore on hit, +10% armor penetration for every target consumed up to 100% of armor ignored.
+	armor_modifier = max(0, 1 - (0.1 * eatencount))
 
 	//speed bonus in dark and dim conditions
 	lightparams.speed_m_dark_dim_light[1]=max(1/2,lightparams.base_speed_m_dark_dim_light[1]/(1.2 ** eatencount))//faster in darkness

--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -598,8 +598,8 @@
 	//melee damage, 50 damage limit
 	melee_damage_lower = min(50, base_melee_dam_lw + (5 * eatencount))
 	melee_damage_upper = min(50, base_melee_dam_up + (5 * eatencount))
-	//How much armor they ignore on hit, +10% armor penetration for every target consumed up to 100% of armor ignored.
-	armor_modifier = max(0, 1 - (0.1 * eatencount))
+	//How much armor they ignore on hit, +10% armor penetration for every target consumed up to 50% of armor ignored, meaning 80% damage reduction becomes 40%.
+	armor_modifier = max(0.5, 1 - (0.1 * eatencount))
 
 	//speed bonus in dark and dim conditions
 	lightparams.speed_m_dark_dim_light[1]=max(1/2,lightparams.base_speed_m_dark_dim_light[1]/(1.2 ** eatencount))//faster in darkness


### PR DESCRIPTION
Adds a limit of 50 maximum upper and lower damage. One big problem with grues is that they would scale way too hard off damage, and given the eventual toughness, regeneration in the dark and especially the immense damage an overfed grue could become extremely powerful. A grue that fed on 10 targets would deal 90-100 damage.
Reduced the amount of damage gained per consumed entity from 7 to 5. An adult grue would require to eat a total of 4 times to hit the 50 upper damage limit. Should keep them a little in check before they start hitting the "MIGHT be able to put the target in critical condition" threshold.
Added scaling armor penetration, each consumed entity grants the grue 10% armor penetration up to a maximum of 50%. Helps grues fight better against heavily armored players rather than being rendered helpless against 80% damage reductions from things like riot armor.

:cl:
 * rscadd: Grues will now become increasingly more effective against armored targets the more people they eat. After eating 5 people they will reach the limit of reducing damage reduction by 50%, multiplicatively.
 * tweak: Grues are now limited to a maximum of 50 damage per hit.
 * tweak: Grues will gain slightly less damage out of every consumed player, from 7 to 5.