### PR TITLE
Grues getting burnt is only heard by those who can see it

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -189,7 +189,8 @@
 					to_chat(src, "<span class='danger'>The burning light sears your flesh!</span>")
 				else
 					to_chat(src, "<span class='warning'>The bright light scalds you!</span>")
-				playsound(src, 'sound/effects/grue_burn.ogg', 50, 1)
+				for(var/mob/M in viewers(world.view, src)) //Only audible to those who can see the grue
+					M.playsound_local(src, 'sound/effects/grue_burn.ogg', 50, 1)
 
 		//update accum_light_expos_mult for light damage
 		lightparams.alem_adjust()


### PR DESCRIPTION
One of the biggest initial hurdles of a grue is finding a good enough spot to lurk in, but you'd also want to remove the sources of light that someone could use for safety, essentially setting up your own ambush zones in which people will be eaten by a grue. Unfortunately if you don't time it right (AKA if you're in the light just as a process() tick happens) you end up getting burnt, which plays a loud, unique sound to everyone who might be around, alerting the crew of a grue far too early and making them avoid the maintenance tunnels.
This change makes it so that grue sizzling will only be heard by those who can see the grue, which both improves the grue's own stealth capability and maintains the audio feedback for the crew that sees it.

:cl:
 * tweak: The sizzling sound effect from grues being exposed to light is quieter; it will only be heard by those who have visual contact with the grue.