### PR TITLE
Catwalks tedium reduction

### DIFF
--- a/code/game/objects/items/stacks/misc.dm
+++ b/code/game/objects/items/stacks/misc.dm
@@ -49,24 +49,18 @@
 			var/turf/T = get_turf(Target)
 			var/obj/structure/lattice/L = T.canBuildCatwalk(src)
 			if(istype(L))
-				if(amount < 2)
-					to_chat(user, "<span class='warning'>You need atleast 2 rods to build a catwalk!</span>")
-					return
 				if(busy) //We are already building a catwalk, avoids stacking catwalks
 					return
 				to_chat(user, "<span class='notice'>You begin to build a catwalk.</span>")
 				busy = 1
-				if(do_after(user, Target, 30))
+				if(do_after(user, Target, 15))
 					busy = 0
-					if(amount < 2)
-						to_chat(user, "<span class='warning'>You ran out of rods!</span>")
-						return
 					if(!istype(L) || L.loc != T)
 						to_chat(user, "<span class='warning'>You need a lattice first!</span>")
 						return
 					playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 					to_chat(user, "<span class='notice'>You build a catwalk!</span>")
-					use(2)
+					use(1)
 					new /obj/structure/catwalk(T)
 					qdel(L)
 					return


### PR DESCRIPTION

![cat-walks](https://github.com/vgstation-coders/vgstation13/assets/7573912/2606dfd5-f357-4dff-9dec-0722fe4a8a27)

It's always bothered me how quickly I seem to run out of metal when building catwalks compared to everything else. Catwalks bring unnecessary tedium by having construction time on top of not even letting build as many of them as you could build tiled floors with the same amount of metal. This PR addresses that, and alleviates the construction time as well.

![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/78660d0b-88a5-447b-af5e-cd5e143983d4)

:cl:
* tweak: Catwalks have had their cost reduced from 3 metal rods to just 2 (both including the 1 rod lattice cost). Their construction time has also been halved.