### PR TITLE
Catwalks now prevent space slipping

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -549,7 +549,8 @@
 
 	if(..())
 		//Check to see if we slipped
-		if(!ignore_slip && on_foot() && prob(Process_Spaceslipping(5)))
+		var/obj/structure/catwalk/support = locate() in loc
+		if(!support && !ignore_slip && on_foot() && prob(Process_Spaceslipping(5)))
 			to_chat(src, "<span class='notice'><B>You slipped!</B></span>")
 			src.inertia_dir = src.last_move
 			step(src, src.inertia_dir)


### PR DESCRIPTION
Catwalks were added a decade ago by N3X15 who sampled them from Paradise. Then dylan turned them from a turf into an object. Today, they finally do what catwalks are supposed to do in real life: provide adequate footing.

:cl:
* tweak: You no longer have a chance to slip when walking on catwalks.