### PR TITLE
spacesuit modification station telling why a module wasn't installed

### DIFF
--- a/code/game/machinery/suit_modifier.dm
+++ b/code/game/machinery/suit_modifier.dm
@@ -232,7 +232,9 @@
 	var/obj/item/clothing/suit/space/rig/R = H.is_wearing_item(/obj/item/clothing/suit/space/rig, slot_wear_suit)
 	R.deactivate_suit()
 	for(var/obj/item/rig_module/RM in modules_to_install)
-		if(!RM.can_install(R)) //more versatile check, allows for custom install conditions.
+		var/install_result=RM.can_install(R)
+		if(!install_result[1]) //more versatile check, allows for custom install conditions.
+			say(install_result[2], class = "binaryradio")
 			continue
 		if(do_after(H, src, 8 SECONDS / apply_multiplier, needhand = FALSE))
 			say("Installing [RM] into \the [R].", class = "binaryradio")

--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -12,7 +12,11 @@
 	..()
 
 /obj/item/rig_module/proc/can_install(var/obj/item/clothing/suit/space/rig/target)
-   return !(locate(type) in target.modules) //by default only allow one module of a type
+   if ((locate(type) in target.modules)) //by default only allow one module of a type
+      return list(FALSE, "could not install the " + name + ": module already present.") 
+   else
+      return list(TRUE, name +": successfully installed.")  //redundant second string to return, but just in case
+   
 
 /obj/item/rig_module/proc/examine_addition(mob/user)
 	return
@@ -166,11 +170,12 @@
 	..()
 
 /obj/item/rig_module/plasma_proof/can_install(var/obj/item/clothing/suit/space/rig/target)
-   if(!..())
-      return FALSE
+   var/parent_check=..()
+   if(!parent_check[1])
+      return list(FALSE,parent_check[2]) 
    if(target.clothing_flags & PLASMAGUARD)
-      return FALSE
-   return TRUE
+      return list(FALSE,"could not install the " + name +": suit is already plasma sealed.")
+   return list(TRUE, name +": successfully installed.") 
 
 //Muscle tissue/Hulk module
 /obj/item/rig_module/muscle_tissue
@@ -300,11 +305,12 @@
 		deactivate()
 
 /obj/item/rig_module/rad_shield/can_install(var/obj/item/clothing/suit/space/rig/target)
-   if(!..())
-      return FALSE
+   var/parent_check=..()
+   if(!parent_check[1])
+      return list(FALSE,parent_check[2])
    if(locate(/obj/item/rig_module/rad_shield/adv) in target.modules) //don't allow both rad mods at once
-      return FALSE
-   return TRUE
+      return list(FALSE,"could not install the " + name +": a radiation absorption device is already present.")
+   return list(TRUE, name +": successfully installed.") 
 
 
 
@@ -314,8 +320,9 @@
 	max_capacity = 1600 //About 7-8 "item touches" worth based on the same conditions as the above testing.
 
 /obj/item/rig_module/rad_shield/adv/can_install(var/obj/item/clothing/suit/space/rig/target)
-   if(!..())
-      return FALSE
+   var/parent_check=..()
+   if(!parent_check[1])
+      return list(FALSE,parent_check[2])
    if(locate(/obj/item/rig_module/rad_shield) in target.modules) //don't allow both rad mods at once
-      return FALSE
-   return TRUE
+      return list(FALSE,"could not install the " + name +": a radiation absorption device is already present.")
+   return list(TRUE, name +": successfully installed.") 

--- a/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig_modules/rig_modules.dm
@@ -13,7 +13,7 @@
 
 /obj/item/rig_module/proc/can_install(var/obj/item/clothing/suit/space/rig/target)
    if ((locate(type) in target.modules)) //by default only allow one module of a type
-      return list(FALSE, "could not install the " + name + ": module already present.") 
+      return list(FALSE, "Could not install the " + name + ": module already present.") 
    else
       return list(TRUE, name +": successfully installed.")  //redundant second string to return, but just in case
    
@@ -174,7 +174,7 @@
    if(!parent_check[1])
       return list(FALSE,parent_check[2]) 
    if(target.clothing_flags & PLASMAGUARD)
-      return list(FALSE,"could not install the " + name +": suit is already plasma sealed.")
+      return list(FALSE,"Could not install the " + name +": suit is already plasma sealed.")
    return list(TRUE, name +": successfully installed.") 
 
 //Muscle tissue/Hulk module
@@ -309,7 +309,7 @@
    if(!parent_check[1])
       return list(FALSE,parent_check[2])
    if(locate(/obj/item/rig_module/rad_shield/adv) in target.modules) //don't allow both rad mods at once
-      return list(FALSE,"could not install the " + name +": a radiation absorption device is already present.")
+      return list(FALSE,"Could not install the " + name +": a radiation absorption device is already present.")
    return list(TRUE, name +": successfully installed.") 
 
 
@@ -324,5 +324,5 @@
    if(!parent_check[1])
       return list(FALSE,parent_check[2])
    if(locate(/obj/item/rig_module/rad_shield) in target.modules) //don't allow both rad mods at once
-      return list(FALSE,"could not install the " + name +": a radiation absorption device is already present.")
+      return list(FALSE,"Could not install the " + name +": a radiation absorption device is already present.")
    return list(TRUE, name +": successfully installed.") 


### PR DESCRIPTION
[qol]
## What this does
the spacesuit modification station will now say why a module has not been installed.
PLEASE look over my code, i hope there's a better way to do what i did than returning a list

![Uploading Capture.PNG…]()
_sample of what it would look like in game_

## Why it's good
before it would never tell you why, and you'd just sit in the station for a few seconds in silence until you remember why, never made sense to why it didn't. now with the more recent changes to install conditions it's more useful to have this.

## Changelog
:cl:
 * rscadd: The spacesuit modification station will now say why a module was not installed.
