### PR TITLE
Grue drain light tweaks

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -658,7 +658,7 @@
 	return FALSE
 
 /mob/living/simple_animal/hostile/grue/proc/drainlight_set()	//Set the strength of light drain.
-	set_light(max(10, 7 + eatencount), max(-15, -3 * eatencount - 3), GRUE_BLOOD)	//Eating sentients makes the drain more powerful.
+	set_light(max(10, 7 + eatencount), -3 * eatencount - 3, GRUE_BLOOD)	//Eating sentients makes the drain more powerful.
 
 //Ventcrawling and hiding, only for gruespawn
 /mob/living/simple_animal/hostile/grue/proc/ventcrawl()

--- a/code/modules/mob/living/simple_animal/hostile/grue_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue_powers.dm
@@ -91,7 +91,7 @@
 	range = 0
 	charge_type = Sp_GRADUAL | Sp_HOLDVAR
 	holder_var_type = "nutrienergy"
-	holder_var_amount = 0.1 //Around 1 nutrienergy per second.
+	holder_var_amount = 0.2 //Around 2 nutrienergy per second.
 	holder_var_name = "nutritive energy"
 	still_recharging_msg = "<span class='notice'>You need to feed more first.</span>"
 


### PR DESCRIPTION
This increases grue nutrienergy use rate for drain light from 1 per second to 2 per second, and also removes the hard cap on drain light intensity introduced in #34989 (but not range which it keeps limited as-is).

With this change, eating one creature provides enough nutritive energy to drain light for 50 seconds rather than 100 seconds.

I think this could be nice in that it makes the use of the drain light ability more tactical and the grue has to be more discerning about when and when not to use it rather than using it more flippantly, while also restoring the intensity scaling by removing the hard cap so it can counteract large amounts of massed lights and there's more that can happen in that regard.
:cl:
 * tweak: Grue drain light drains nutritive energy twice as fast.
 * tweak: Grue drain light intensity is no longer hard-capped after eating 3 sentients (range is still capped).