### PR TITLE
Disable thermal dissipation subsystem

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -203,7 +203,7 @@
 	// Dynamic Mode
 	var/high_population_override = 1//If 1, what rulesets can or cannot be called depend on the threat level only
 
-	var/thermal_dissipation = 1 //Whether or not thermal dissipation occurs.
+	var/thermal_dissipation = 0 //Whether or not thermal dissipation occurs.
 	var/reagents_heat_air = 0 //Whether or not reagents exchanging heat with the surrounding air actually heat or the cool air. If off, the energy change only applies to the reagents.
 
 /datum/configuration/New()


### PR DESCRIPTION
This turns thermal dissipation calculations for reagent containers off by default. I'm proposing this as an alternative to #35189, that should allow us to investigate if it has anything to do with the recent stutters (#35194) while also retaining the flexibility for admins to toggle it on and off at will (akin to the current status of recursive food), and also allowing us to take a step back and gather information on what people noticed and did or didn't like about the subsystem, so maybe we can more easily revisit it in the future with improvements and other considerations.
Also, disabling it in this manner would make gradually incorporating feedback and adding new interactions and features more straightforward.

:cl:
 * tweak: Disabled thermal dissipation subsystem by default.