### PR TITLE
Vampire bug fixes and some tweaks

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -652,7 +652,7 @@
 		H.visible_message("<span class='warning'>[H] seems to resist the takeover!</span>", "<span class='notice'>Your faith of [ticker.Bible_deity_name] has kept your mind clear of all evil!</span>")
 	return TRUE
 
-/mob/proc/vampire_affected(var/datum/mind/M) // M is the attacker, src is the target.
+/mob/proc/vampire_affected(var/datum/mind/M, var/send_message = TRUE) // M is the attacker, src is the target.
 	//Other vampires aren't affected
 	var/success = TRUE
 	if(mind && mind.GetRole(VAMPIRE))
@@ -662,17 +662,20 @@
 	if(M)
 		//Chaplains are ALWAYS resistant to vampire powers
 		if(isReligiousLeader(src))
-			to_chat(M.current, "<span class='warning'>[src] resists our powers!</span>")
+			if(send_message)
+				to_chat(M.current, "<span class='warning'>[src] resists our powers!</span>")
 			success = FALSE
 		// Null rod nullifies vampire powers, unless we're a young vamp.
 		var/datum/role/vampire/V = M.GetRole(VAMPIRE)
 		var/obj/item/weapon/nullrod/N = locate(/obj/item/weapon/nullrod) in get_contents_in_object(src)
 		if (N)
 			if (locate(/datum/power/vampire/undying) in V.current_powers)
-				to_chat(M.current, "<span class='warning'>A holy artifact has turned our powers against us!</span>")
+				if(send_message)
+					to_chat(M.current, "<span class='warning'>A holy artifact has turned our powers against us!</span>")
 				success = VAMP_FAILURE
 			else if (locate(/datum/power/vampire/jaunt) in V.current_powers)
-				to_chat(M.current, "<span class='warning'>An holy artifact protects [src]!</span>")
+				if(send_message)
+					to_chat(M.current, "<span class='warning'>A holy artifact protects [src]!</span>")
 				success = FALSE
 	return success
 

--- a/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
@@ -275,7 +275,7 @@
 	for(var/mob/living/carbon/human/H in view(7, src))
 		if((H.vampire_affected() <= 0) || H.earprot())
 			continue
-		to_chat(H, "<span class='danger'><font size='3'>You hear a ear piercing shriek and your senses dull!</font></span>")
+		to_chat(H, "<span class='danger'><font size='3'>You hear an ear piercing shriek and your senses dull!</font></span>")
 		H.Knockdown(8)
 		H.ear_deaf = 20
 		H.stuttering = 20

--- a/code/modules/spells/aoe_turf/glare.dm
+++ b/code/modules/spells/aoe_turf/glare.dm
@@ -32,15 +32,9 @@
 
 /spell/aoe_turf/glare/choose_targets(var/mob/user = usr)
 	var/list/targets = list()
-	for(var/mob/living/carbon/C in oview(inner_radius))
-		var/success = C.vampire_affected(user.mind)
-		switch (success)
-			if (TRUE)
-				targets += C
-			if (FALSE)
-				continue
-			if (VAMP_FAILURE)
-				return critfail(targets, user)
+	for(var/mob/living/carbon/C in oview(inner_radius)) //Silicons are excluded
+		if(istype(C))
+			targets += C
 
 	if (!targets.len)
 		to_chat(user, "<span class='warning'>There are no targets.</span>")
@@ -52,12 +46,28 @@
 	var/datum/role/vampire/V = isvampire(user) // Shouldn't ever be null, as cast_check checks if we're a vamp.
 	if (!V)
 		return FALSE
+	var/critical_fail = FALSE
+	var/list/immune_targets = list() //Helps keep things tidy by telling the vampire everyone who is divinely-shielded
+	for(var/mob/living/carbon/affected in targets) //Check for whether the spell should fail, then proceed
+		var/success = affected.vampire_affected(user.mind, FALSE) //We are just checking, don't send messages
+		switch (success)
+			if (FALSE)
+				immune_targets += affected
+			if (VAMP_FAILURE)
+				affected.vampire_affected(user.mind)
+				critical_fail = TRUE
+				break
+	if(critical_fail) //Cancel the spell because a null rod caused a backlash against the vampire
+		critfail(targets, user)
+		return
 	user.visible_message("<span class='danger'>\The [user]'s eyes emit a blinding flash!</span>")
-	for (var/T in targets)
-		var/mob/living/carbon/C = T
-		var/dist = get_dist(user, C)
-		if (C.is_blind())
+	for (var/mob/living/carbon/C in targets)
+		if(C.is_blind())
 			continue
+		if(C in immune_targets)
+			C.vampire_affected(user.mind) //Send the message related to whether they are resistant or being shielded by a null rod
+			continue
+		var/dist = get_dist(user, C)
 		switch (dist)
 			if (0 to 1) // Close mobs
 				C.Stun(8)
@@ -81,6 +91,3 @@
 	user.Stun(4)
 	user.Knockdown(4)
 	user.stuttering += 15
-	var/datum/role/vampire/V = isvampire(user)
-	if (V)
-		V.remove_blood(3*blood_cost)

--- a/code/modules/spells/aoe_turf/glare.dm
+++ b/code/modules/spells/aoe_turf/glare.dm
@@ -26,6 +26,7 @@
 		return FALSE
 	if (istype(user.get_item_by_slot(slot_glasses), /obj/item/clothing/glasses/sunglasses/blindfold))
 		to_chat(user, "<span class='warning'>You're blindfolded!</span>")
+		return FALSE
 	if (!user.vampire_power(blood_cost, CONSCIOUS))
 		return FALSE
 

--- a/code/modules/spells/aoe_turf/screech.dm
+++ b/code/modules/spells/aoe_turf/screech.dm
@@ -42,7 +42,7 @@
 				if (FALSE)
 					continue
 				if (VAMP_FAILURE)
-					critfail(targets, user)
+					return critfail(targets, user)
 	return targets
 
 /spell/aoe_turf/screech/cast(var/list/targets, var/mob/user)

--- a/code/modules/spells/aoe_turf/screech.dm
+++ b/code/modules/spells/aoe_turf/screech.dm
@@ -25,41 +25,35 @@
 	if (!user.vampire_power(blood_cost, 0, FALSE))
 		return FALSE
 
-/spell/aoe_turf/screech/choose_targets(var/mob/user = usr)
-	var/list/targets = list()
-
-	for(var/mob/living/carbon/C in hearers(user, 4))
-		if(C == user)
-			continue
-		if(ishuman(C))
-			var/mob/living/carbon/human/H = C
-			var/success = C.vampire_affected(user.mind)
-			switch (success)
-				if (VAMP_FAILURE)
-					critfail(targets, user)
-					return FALSE //Does not cast
-				if (TRUE)
-					if(H.earprot())
-						continue
-					targets += C
-				if (FALSE)
-					continue
-			if(H.earprot())
-				continue
-	return targets
-
 /spell/aoe_turf/screech/cast(var/list/targets, var/mob/user)
-	for (var/T in targets)
-		var/mob/living/carbon/C = T
-		if(C.is_deaf())
+	var/critical_fail = FALSE
+	var/list/mob_targets = hearers(user, 4)
+	var/list/immune_targets = list() //Helps keep things tidy by telling the vampire everyone who is divinely-shielded
+	for(var/mob/living/carbon/affected in mob_targets) //First we see the status of each target
+		var/success = affected.vampire_affected(user.mind, FALSE) //Don't send any messages
+		switch (success)
+			if (FALSE)
+				immune_targets += affected
+			if (VAMP_FAILURE)
+				affected.vampire_affected(user.mind)
+				critical_fail = TRUE
+				break
+	if(critical_fail) //Cancel the spell because a null rod caused a backlash against the vampire
+		critfail(targets, user)
+		return
+	playsound(user, 'sound/effects/creepyshriek.ogg', 100, 1)
+	for (var/mob/living/carbon/C in mob_targets)
+		if(C.is_deaf() || C.earprot())
 			continue
-		playsound(user, 'sound/effects/creepyshriek.ogg', 100, 1)
+		if(C in immune_targets)
+			C.vampire_affected(user.mind)
+			continue
 		to_chat(C, "<span class='danger'><font size='3'>You hear a ear piercing shriek and your senses dull!</font></span>")
 		C.Knockdown(8)
 		C.ear_deaf = 20
 		C.stuttering = 20
 		C.Stun(8)
-		C.Jitter(150)
+		C.Jitter(20)
 	for(var/obj/structure/window/W in view(4))
 		W.shatter()
 	for(var/obj/machinery/light/L in view(7))

--- a/code/modules/spells/aoe_turf/screech.dm
+++ b/code/modules/spells/aoe_turf/screech.dm
@@ -48,7 +48,7 @@
 		if(C in immune_targets)
 			C.vampire_affected(user.mind)
 			continue
-		to_chat(C, "<span class='danger'><font size='3'>You hear a ear piercing shriek and your senses dull!</font></span>")
+		to_chat(C, "<span class='danger'><font size='3'>You hear an ear piercing shriek and your senses dull!</font></span>")
 		C.Knockdown(8)
 		C.ear_deaf = 20
 		C.stuttering = 20

--- a/code/modules/spells/aoe_turf/screech.dm
+++ b/code/modules/spells/aoe_turf/screech.dm
@@ -33,16 +33,19 @@
 			continue
 		if(ishuman(C))
 			var/mob/living/carbon/human/H = C
-			if(H.earprot())
-				continue
 			var/success = C.vampire_affected(user.mind)
 			switch (success)
+				if (VAMP_FAILURE)
+					critfail(targets, user)
+					return FALSE //Does not cast
 				if (TRUE)
+					if(H.earprot())
+						continue
 					targets += C
 				if (FALSE)
 					continue
-				if (VAMP_FAILURE)
-					return critfail(targets, user)
+			if(H.earprot())
+				continue
 	return targets
 
 /spell/aoe_turf/screech/cast(var/list/targets, var/mob/user)

--- a/code/modules/spells/general/shapeshift.dm
+++ b/code/modules/spells/general/shapeshift.dm
@@ -22,7 +22,7 @@
 
 /spell/shapeshift/cast_check(skipcharge = 0, mob/user = usr)
 	. = ..()
-	if (!.) 
+	if (!.)
 		return FALSE
 
 /spell/shapeshift/choose_targets(var/mob/user = usr)
@@ -35,8 +35,6 @@
 		user.set_species("Vampire")
 		user.name = "Nosferatu"
 		user.real_name = "Nosferatu"
-		user.UpdateAppearance()
-		user.update_perception()
 		humanform = FALSE
 	else
 		user.set_species(identity.species, 0)
@@ -44,8 +42,8 @@
 		user.name = identity.real_name
 		user.real_name = identity.real_name
 		user.dna = identity
-		user.UpdateAppearance()
-		user.update_perception()
 		humanform = TRUE
-	
+	user.UpdateAppearance()
+	user.update_perception()
+	user.update_name()
 	..()

--- a/code/modules/spells/targeted/disease.dm
+++ b/code/modules/spells/targeted/disease.dm
@@ -25,21 +25,10 @@
 	if (!user.vampire_power(blood_cost, CONSCIOUS))
 		return FALSE
 
-/spell/targeted/disease/is_valid_target(atom/target, mob/user, options, bypass_range = 0)
-	if (!ismob(target))
+/spell/targeted/disease/is_valid_target(atom/target, mob/user, options, bypass_range = 0, before_cast)
+	if(!istype(target, /mob/living/carbon))
 		return FALSE
-
-	var/mob/M = target
-
-	var/success = M.vampire_affected(user.mind)
-	switch (success)
-		if (TRUE)
-			return ..()
-		if (FALSE)
-			return FALSE
-		if (VAMP_FAILURE)
-			critfail(target, user)
-			return FALSE
+	return ..()
 
 /spell/targeted/disease/cast(var/list/targets, var/mob/user)
 	if (targets.len > 1)
@@ -51,6 +40,13 @@
 
 	var/mob/living/carbon/target = targets[1]
 
+	var/success = target.vampire_affected(user.mind)
+	switch(success)
+		if(FALSE)
+			return TRUE
+		if(VAMP_FAILURE)
+			critfail(targets, user)
+			return
 	log_admin("[key_name(user)] has death-touched [key_name(target)]. The latter will die in moments.")
 	message_admins("[key_name(user)] has death-touched [key_name(target)] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[target.x];Y=[target.y];Z=[target.z]'>JMP</A>). The latter will die in moments.")
 	var/datum/disease2/disease/S = new ()

--- a/code/modules/spells/targeted/disease.dm
+++ b/code/modules/spells/targeted/disease.dm
@@ -25,7 +25,7 @@
 	if (!user.vampire_power(blood_cost, CONSCIOUS))
 		return FALSE
 
-/spell/targeted/disease/is_valid_target(atom/target, mob/user, options, bypass_range = 0, before_cast)
+/spell/targeted/disease/is_valid_target(atom/target, mob/user, options, bypass_range = 0)
 	if(!istype(target, /mob/living/carbon))
 		return FALSE
 	return ..()

--- a/code/modules/spells/targeted/enthrall.dm
+++ b/code/modules/spells/targeted/enthrall.dm
@@ -25,7 +25,7 @@
 	if (!user.vampire_power(blood_cost, CONSCIOUS))
 		return FALSE
 
-/spell/targeted/enthrall/is_valid_target(atom/target, mob/user, options, bypass_range = 0, before_cast)
+/spell/targeted/enthrall/is_valid_target(atom/target, mob/user, options, bypass_range = 0)
 	if (!ishuman(target)) // Can only enthrall humans
 		return FALSE
 	return ..()

--- a/code/modules/spells/targeted/enthrall.dm
+++ b/code/modules/spells/targeted/enthrall.dm
@@ -25,23 +25,10 @@
 	if (!user.vampire_power(blood_cost, CONSCIOUS))
 		return FALSE
 
-/spell/targeted/enthrall/is_valid_target(atom/target, mob/user, options, bypass_range = 0)
-	if (!ismob(target)) // Can only enthrall humans
+/spell/targeted/enthrall/is_valid_target(atom/target, mob/user, options, bypass_range = 0, before_cast)
+	if (!ishuman(target)) // Can only enthrall humans
 		return FALSE
-
-	var/mob/M = target
-
-	var/success = M.vampire_affected(user.mind)
-	switch (success)
-		if (TRUE)
-			if (!user.can_enthrall(target))
-				return FALSE
-			return ..()
-		if (FALSE)
-			return FALSE
-		if (VAMP_FAILURE)
-			critfail(target, user)
-			return FALSE
+	return ..()
 
 
 /spell/targeted/enthrall/cast(var/list/targets, var/mob/user)
@@ -54,7 +41,13 @@
 
 	if (!V)
 		return FALSE
-
+	var/success = target.vampire_affected(user.mind)
+	switch(success)
+		if(FALSE)
+			return TRUE
+		if(VAMP_FAILURE)
+			critfail(targets, user)
+			return
 	user.visible_message("<span class='warning'>[user] bites \the [target]'s neck!</span>", "<span class='warning'>You bite \the [target]'s neck and begin the flow of power.</span>")
 	to_chat(target, "<span class='sinister'>You feel the tendrils of evil [(locate(/datum/power/vampire/charisma) in V.current_powers) ? "aggressively" : "slowly"] invade your mind.</span>")
 
@@ -63,7 +56,7 @@
 			V.handle_enthrall(target.mind)
 	else
 		to_chat(user, "<span class='warning'>Either you or your target moved, and you couldn't finish enthralling them!</span>")
-		return FALSE
+		return TRUE
 
 	if(!target.client) //There is not a player "in control" of this corpse, so there is no one to inform.
 		var/mob/dead/observer/ghost = mind_can_reenter(target.mind)

--- a/code/modules/spells/targeted/hypnotise.dm
+++ b/code/modules/spells/targeted/hypnotise.dm
@@ -22,6 +22,7 @@
 	hud_state = "vampire_hypno"
 
 	var/blood_cost = 10
+	compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 
 /spell/targeted/hypnotise/cast_check(skipcharge = 0, mob/user = usr)
 	. = ..()
@@ -33,40 +34,30 @@
 	if (!user.vampire_power(blood_cost, CONSCIOUS))
 		return FALSE
 
-/spell/targeted/hypnotise/is_valid_target(atom/target, mob/user, options, bypass_range = 0)
-	if (!ismob(target))
-		return FALSE
-
-	var/mob/M = target
-
-	var/success = M.vampire_affected(user.mind)
-	switch (success)
-		if (TRUE)
-			return ..()
-		if (FALSE)
-			return FALSE
-		if (VAMP_FAILURE)
-			critfail(target, user)
-			return FALSE
-
 /spell/targeted/hypnotise/cast(var/list/targets, var/mob/user)
 	if (targets.len > 1)
 		return FALSE
 
 	var/target = targets[1]
 
-	if(ishuman(target) || ismonkey(target))
-		var/mob/living/carbon/C = target
-		if ((C.sdisabilities & BLIND) || (C.sight & BLIND))
-			to_chat(user, "<span class='warning'>\the [C] is blind!</span>")
-			return FALSE
-		if(do_mob(user, C, 10 - C.get_vamp_enhancements()))
-			to_chat(user, "<span class='warning'>Your piercing gaze knocks out \the [C].</span>")
-			to_chat(C, "<span class='sinister'>You find yourself unable to move and barely able to speak.</span>")
-			apply_spell_damage(target)
-		else
-			to_chat(user, "<span class='warning'>You broke your gaze.</span>")
-			return FALSE
+	var/mob/living/carbon/C = target
+	if ((C.sdisabilities & BLIND) || (C.sight & BLIND))
+		to_chat(user, "<span class='warning'>\the [C] is blind!</span>")
+		return TRUE
+	var/success = C.vampire_affected(user.mind)
+	switch(success)
+		if(FALSE)
+			return TRUE //Refunds the spell cooldown if it failed
+		if(VAMP_FAILURE)
+			critfail(targets, user)
+			return
+	if(do_mob(user, C, 10 - C.get_vamp_enhancements()))
+		to_chat(user, "<span class='warning'>Your piercing gaze knocks out \the [C].</span>")
+		to_chat(C, "<span class='sinister'>You find yourself unable to move and barely able to speak.</span>")
+		apply_spell_damage(target)
+	else
+		to_chat(user, "<span class='warning'>You broke your gaze.</span>")
+		return TRUE
 	var/datum/role/vampire/V = isvampire(user)
 	if (V)
 		V.remove_blood(blood_cost)


### PR DESCRIPTION
:cl:
 * bugfix: Fixed a bug where the vampire's Glare ability worked while blindfolded.
 * bugfix: Fixed a bug where shapeshifted vampires didn't initially update their visible name when shapeshifting with no ID.
 * bugfix: Fixed a bug where a max-power vampire using the Screech ability would get a backlash from every single nearby null rod wearer rather than just one. This also means the Screech ability will be properly stopped and blocked rather than still affecting everyone in the vicinity.
 * bugfix: Null rods carried by people with ear protection will now properly cause a backlash against max-power vampires using the Screech ability instead of doing nothing.
 * bugfix: Fixed a bug where the vampire's Screech ability would play its sound for every single target. It will now only play once per Screech.
 * tweak: Reduced the amount of jittering caused by the vampire's Screech ability from 5 minutes to 40 seconds.
 * tweak: The vampire's Screech ability can be used at any time, rather than only when there are living targets nearby.
 * tweak: Failing to Enthrall someone as a vampire will no longer put the ability on cooldown.
 * tweak: Failing to Hypnotise someone as a vampire, whether because they are blind or for other reasons, will no longer put the ability on cooldown.
 * tweak: Vampire abilities that get backlashed by null rods will now go on cooldown. This also fixed a bug where the max-power vampire's Glare ability could be spammed non-stop.
 * spellcheck: Fixed a tiny typo regarding the message that a vampire receives when a null rod causes a backlash.
 * spellcheck: Fixed a tiny typo regarding the message that a victim of a vampire's Screech receives. This also extends to the NPC vampire creature.