### PR TITLE
Civil War Of Casters is now independent in Dynamic+ from Wizard

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -271,7 +271,7 @@
 	required_pop = list(25,25,20,20,20,20,15,15,15,5)
 	required_candidates = 4
 	weight = BASE_RULESET_WEIGHT/2
-	weight_category = "Wizard"
+	weight_category = "CWC"
 	cost = 45
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 40


### PR DESCRIPTION
#29753 and #34678 have both caused CWC to fire far less often than usual for two reasons:
- Due to role_category, every time wizards spawn (there are 3 rulesets that can spawn them; roundstart wizard, midround and latejoin ragin mages) they give a 3-round penalty to the likelihood of CWC firing, at first at a 0.4x likelihood, then 0.7x, then 0.9x.
- Due to weight_category, every time wizards spawn (the same 3 rulesets) they reset the ruleset weight bonus of everything wizard-related, which includes CWC.

With CWC having a really restrictive ruleset (it's roundstart, it won't roll if any other "Highlander" ruleset such as nukies and blob have rolled, which are far more likely to roll due to Dynamic+), high requirements in both threat points and player count, and the overall likelihood of its bonuses being yoinked away by other, more singular wizard rulesets I think it would be fair to allow it to benefit from Dynamic+, giving it an independent bonus from other wizard rulesets. Yeah that's it, that's the whole pull request.

In the last 2 months Civil War of Casters has fired 3, maybe 4 times. In contrast Nuclear Operatives have happened 22 times, maybe a bit more.

:cl:
 * tweak: Civil War of Casters is slightly more likely to happen.