### PR TITLE
enable jecties by default for new accounts

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -165,7 +165,7 @@ var/const/MAX_SAVE_SLOTS = 16
 	var/ambience_volume = 25
 	var/credits_volume = 75
 	var/window_flashing = 1
-	var/antag_objectives = 0 //If set to 1, solo antag roles will get the standard objectives. If set to 0, will give them a freeform objective instead.
+	var/antag_objectives = 1 //If set to 1, solo antag roles will get the standard objectives. If set to 0, will give them a freeform objective instead.
 	var/typing_indicator = 1
 
 		//Mob preview


### PR DESCRIPTION
this PR enables antagonist objectives by default for new accounts.
fixes #35269
:cl:
* tweak: Antag objectives are now enabled by default for new accounts.