### PR TITLE
Combustible items that get too hot start burning

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -78,6 +78,9 @@ Attach to transfer valve and open. BOOM.
 	spawn()
 		burnItselfUp()
 
+/atom/proc/try_spontaneous_combustion()
+	return
+
 /atom/proc/melt()
 	return //lolidk
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -1223,9 +1223,15 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 		the_air.temperature = chem_temp
 
 		reactions_check
-		if(skip_flags & SKIP_RXN_CHECK_ON_HEATING)
-			return
-		handle_reactions()
+		if(!(skip_flags & SKIP_RXN_CHECK_ON_HEATING))
+			handle_reactions()
+
+		//Since the temperature of the reagents changed, check if the atom should spontaneously combust.
+		my_atom?.try_spontaneous_combustion()
+
+		//A check for melting could also occur here, but since it wouldn't really do anything for now, we'll skip it for now.
+
+
 
 #undef NO_REACTION_UNMET_TEMP_COND
 #undef NO_REACTION

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -999,6 +999,7 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 	if(skip_flags & SKIP_RXN_CHECK_ON_HEATING)
 		return
 	handle_reactions()
+	my_atom?.try_spontaneous_combustion()
 
 /datum/reagents/proc/get_examine(var/mob/user, var/vis_override, var/blood_type)
 	if(obscured && !vis_override)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -996,9 +996,8 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 		chem_temp = min(chem_temp + temp_change, received_temperature)
 	else
 		chem_temp = max(chem_temp + temp_change, received_temperature, TCMB)
-	if(skip_flags & SKIP_RXN_CHECK_ON_HEATING)
-		return
-	handle_reactions()
+	if(!(skip_flags & SKIP_RXN_CHECK_ON_HEATING))
+		handle_reactions()
 	my_atom?.try_spontaneous_combustion()
 
 /datum/reagents/proc/get_examine(var/mob/user, var/vis_override, var/blood_type)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -406,3 +406,9 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 	. = ..()
 	//Reagent containers can exchange heat with the surrounding air.
 	heat_dissipation_updates() //Every reagent_containers that should be added to the heat dissipation subsystem should call this on_reagent_change(). If you add something that breaks the supercall chain, be sure to call this.
+
+/obj/item/weapon/reagent_containers/try_spontaneous_combustion()
+	if (gcDestroyed || timestopped)
+		return
+	if (reagents && reagents.total_volume && autoignition_temperature && reagents.chem_temp >= autoignition_temperature)
+		ignite()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -46,6 +46,9 @@
 	var/timer = 0 //currently only used on skittering food
 	var/datum/reagents/dip
 
+	autoignition_temperature = AUTOIGNITION_ORGANIC
+	fire_fuel = 10
+
 /obj/item/weapon/reagent_containers/food/snacks/Destroy()
 	var/turf/T = get_turf(src)
 	if(contents.len)
@@ -5897,7 +5900,7 @@
 	slot_flags = SLOT_MASK
 	goes_in_mouth = TRUE
 	throwforce = 1
-	autoignition_temperature = 0
+	autoignition_temperature = AUTOIGNITION_PLASTIC
 	w_type = RECYK_PLASTIC
 	starting_materials = list(MAT_PLASTIC = 100)
 	species_fit = list(INSECT_SHAPED)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -47,7 +47,7 @@
 	var/datum/reagents/dip
 
 	autoignition_temperature = AUTOIGNITION_ORGANIC
-	fire_fuel = 10
+	fire_fuel = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/Destroy()
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
## What this does
Currently we have the concept of autoignition temperature in the code but it doesn't typically get used outside of already-existing fires touching things on their tile. This PR makes it so that certain things can ignite if they get hot enough. As objects themselves don't have a temperature per se, we can use the reagents temperature; if the nutriment in a carrot is 500K then it makes sense to say the carrot is 500K too. So, if the reagents in something reach that something's autoignition temperature, it will start burning. I made all `food/snacks` autoignite at `AUTOIGNITION_ORGANIC` (633.15 K), and gave them a `fire_fuel` of 5 so they don't immediately turn to ash.

This can happen both by the thermal dissipation system and also manual heating by eg. a laser scalpel, So you can laser scalpel a donut to light it on fire.

Also gave lollipop sticks an autoignition temperature of `AUTOIGNITION_PLASTIC`.

## Why it's good
Seems nice expansion to thermal mechanics and makes intuitive sense that if you had a pizza heated to 1000K it would start burning.

## Feedback
For some reason this is much more controversial than I expected. Please explicate any objections below so I can try to assuage them and incorporate feedback.

## Changelog
:cl:
 * rscadd: Combustible items, including food, will ignite if they get too hot (based on their reagent temperature).