### PR TITLE
Moves Internals packs to be together on cargo console

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -65,7 +65,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Supplies"
 
 /datum/supply_packs/internals
-	name = "O2 Internals resupply"
+	name = "O2 internals resupply"
 	contains = list(/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -65,7 +65,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Supplies"
 
 /datum/supply_packs/internals
-	name = "Internals resupply"
+	name = "O2 Internals resupply"
 	contains = list(/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
@@ -74,7 +74,31 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 					/obj/item/weapon/tank/air)
 	cost = 10
 	containertype = /obj/structure/closet/crate/internals
-	containername = "internals crate"
+	containername = "o2 internals crate"
+	group = "Supplies"
+	
+/datum/supply_packs/vox_supply
+	name = "Vox Internals resupply"
+	contains = list(/obj/item/clothing/suit/space/vox/civ,
+					/obj/item/clothing/head/helmet/space/vox/civ,
+					/obj/item/weapon/tank/nitrogen,
+					/obj/item/weapon/tank/emergency_nitrogen/engi,
+					/obj/item/clothing/mask/breath/vox)
+	cost = 100
+	containertype = /obj/structure/closet/crate/basic
+	containername = "vox suit crate"
+	group = "Supplies"
+	
+/datum/supply_packs/plasmaman_supply
+	name = "Plasmaman Internals resupply"
+	contains = list(/obj/item/clothing/suit/space/plasmaman,
+					/obj/item/clothing/head/helmet/space/plasmaman,
+					/obj/item/weapon/tank/plasma/plasmaman,
+					/obj/item/weapon/tank/emergency_plasma/engi,
+					/obj/item/clothing/mask/breath)
+	cost = 100
+	containertype = /obj/structure/closet/crate/basic
+	containername = "plasmaman suit crate"
 	group = "Supplies"
 
 /datum/supply_packs/evacuation
@@ -734,30 +758,6 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	cost = 150
 	containertype = /obj/structure/closet/crate/basic
 	containername = "space suit crate"
-	group = "Clothing"
-
-/datum/supply_packs/vox_supply
-	name = "Vox pressure suit"
-	contains = list(/obj/item/clothing/suit/space/vox/civ,
-					/obj/item/clothing/head/helmet/space/vox/civ,
-					/obj/item/weapon/tank/nitrogen,
-					/obj/item/weapon/tank/emergency_nitrogen/engi,
-					/obj/item/clothing/mask/breath/vox)
-	cost = 100
-	containertype = /obj/structure/closet/crate/basic
-	containername = "vox suit crate"
-	group = "Clothing"
-
-/datum/supply_packs/plasmaman_supply
-	name = "Plasmaman suit"
-	contains = list(/obj/item/clothing/suit/space/plasmaman,
-					/obj/item/clothing/head/helmet/space/plasmaman,
-					/obj/item/weapon/tank/plasma/plasmaman,
-					/obj/item/weapon/tank/emergency_plasma/engi,
-					/obj/item/clothing/mask/breath)
-	cost = 100
-	containertype = /obj/structure/closet/crate/basic
-	containername = "plasmaman suit crate"
 	group = "Clothing"
 
 /datum/supply_packs/grey_supply

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -78,7 +78,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Supplies"
 	
 /datum/supply_packs/vox_supply
-	name = "Vox Internals resupply"
+	name = "Vox internals set"
 	contains = list(/obj/item/clothing/suit/space/vox/civ,
 					/obj/item/clothing/head/helmet/space/vox/civ,
 					/obj/item/weapon/tank/nitrogen,
@@ -90,7 +90,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Supplies"
 	
 /datum/supply_packs/plasmaman_supply
-	name = "Plasmaman Internals resupply"
+	name = "Plasmaman internals set"
 	contains = list(/obj/item/clothing/suit/space/plasmaman,
 					/obj/item/clothing/head/helmet/space/plasmaman,
 					/obj/item/weapon/tank/plasma/plasmaman,

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -78,7 +78,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Supplies"
 	
 /datum/supply_packs/vox_supply
-	name = "Vox internals set"
+	name = "Vox pressure suit set"
 	contains = list(/obj/item/clothing/suit/space/vox/civ,
 					/obj/item/clothing/head/helmet/space/vox/civ,
 					/obj/item/weapon/tank/nitrogen,
@@ -90,7 +90,7 @@ var/list/all_supply_groups = list("Supplies","Clothing","Security","Hospitality"
 	group = "Supplies"
 	
 /datum/supply_packs/plasmaman_supply
-	name = "Plasmaman internals set"
+	name = "Plasmaman pressure suit set"
 	contains = list(/obj/item/clothing/suit/space/plasmaman,
 					/obj/item/clothing/head/helmet/space/plasmaman,
 					/obj/item/weapon/tank/plasma/plasmaman,


### PR DESCRIPTION
![internals](https://github.com/vgstation-coders/vgstation13/assets/19687076/bcfc2798-f2f4-4894-b659-4290ecc5a06b)

## What this does
Moves the Vox and Plasmamen internals crate from the Clothing category into the Supplies category right below the existing internals resupply crate, also renames the internals resupply to explicitly state that it's O2 internals and not any other type.

## Why it's good
Clothing isn't exactly an intuitive place one might think to look for something to keep someone alive, especially given that the standard human internals crate is in supplies. Now in the off-event that a Vox or (more likely) Plasmaman can't get a hold of the equipment they need to exist, it can be found pretty easily.

[tested] [qol]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Moved Vox & Plasmaman internal supply crates to the Supplies category
