### PR TITLE
The wizard's "Projectile Pastry" spell happens from the wizard rather than the point of cast

### DIFF
--- a/code/modules/spells/targeted/projectile/pie_throw.dm
+++ b/code/modules/spells/targeted/projectile/pie_throw.dm
@@ -30,8 +30,8 @@
 		if (user.is_pacified(VIOLENCE_DEFAULT,target))
 			return
 	spawn()
-		var/turf/T = get_turf(user)
 		for(var/i = 0 to spell_levels[Sp_POWER])
+			var/turf/T = get_turf(user)
 			var/atom/target = pick(targets)
 			var/pie_to_spawn = pick(existing_typesof(/obj/item/weapon/reagent_containers/food/snacks/pie))
 			var/obj/pie = new pie_to_spawn(T)


### PR DESCRIPTION
This means the origin will move along with the wizard.
This also fixes a bug where the wizard could get pied by his own spell.

:cl:
 * tweak: The wizard's "Projectile Pastry" spell now happens from the wizard's location, rather than from the initial location where the spell was cast.