### PR TITLE
Enables attack animations by default

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -221,7 +221,7 @@ var/const/MAX_SAVE_SLOTS = 16
 	var/list/roles=list() // "role" => ROLEPREF_*
 
 	//attack animation type
-	var/attack_animation = NO_ANIMATION
+	var/attack_animation = ITEM_ANIMATION
 
 	var/usenanoui = 1 //Whether or not this client will use nanoUI, this doesn't do anything other than objects being able to check this.
 


### PR DESCRIPTION
## What this does
Sets the default attack animation setting to be set to Item Animations rather than No Animation.

## Why it's good
Greatly increases the visual information offered by the game for new players. Closer the time they were introduced, attack animations got a lot of flak because they were new and different, but now that it's been a few years maybe the outlook will be different?

[controversial]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Item attack animations are now enabled by default for new players.
