### PR TITLE
The "Punch" spell no longer shrapnels the wizard nor the victim + a fix

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -148,7 +148,9 @@ var/global/list/ghdel_profiling = list()
 // throw_impact is called multiple times when an item is thrown: see /atom/movable/proc/hit_check at atoms_movable.dm
 // Do NOT delete an item as part of its throw_impact unless you've checked the hit_atom is a turf, as that's effectively the last time throw_impact is called in a single throw.
 // Otherwise, shit will runtime in the subsequent throw_impact calls.
-/atom/proc/throw_impact(atom/hit_atom, var/speed, mob/user)
+/atom/proc/throw_impact(atom/hit_atom, var/speed, mob/user, var/list/impact_whitelist)
+	if(impact_whitelist && (hit_atom in impact_whitelist)) //Return as if it didn't do anything
+		return
 	if(istype(hit_atom,/mob/living))
 		var/mob/living/M = hit_atom
 		playsound(src, src.throw_impact_sound, 80, 1)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -149,12 +149,10 @@ var/global/list/ghdel_profiling = list()
 // Do NOT delete an item as part of its throw_impact unless you've checked the hit_atom is a turf, as that's effectively the last time throw_impact is called in a single throw.
 // Otherwise, shit will runtime in the subsequent throw_impact calls.
 /atom/proc/throw_impact(atom/hit_atom, var/speed, mob/user, var/list/impact_whitelist)
-	if(impact_whitelist && (hit_atom in impact_whitelist)) //Return as if it didn't do anything
-		return
 	if(istype(hit_atom,/mob/living))
 		var/mob/living/M = hit_atom
 		playsound(src, src.throw_impact_sound, 80, 1)
-		M.hitby(src,speed,src.dir)
+		M.hitby(src,speed,src.dir,impact_whitelist)
 		log_attack("<font color='red'>[hit_atom] ([M ? M.ckey : "what"]) was hit by [src] thrown by [user] ([user ? user.ckey : "what"])</font>")
 
 	else if(isobj(hit_atom))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -548,7 +548,7 @@
 /atom/proc/PreImpact(atom/movable/A, speed)
 	return TRUE
 
-/atom/movable/proc/hit_check(var/speed, mob/user)
+/atom/movable/proc/hit_check(var/speed, mob/user, var/list/hit_whitelist)
 	. = 1
 
 	if(throwing)
@@ -557,12 +557,12 @@
 				continue
 
 			if(!A.PreImpact(src,speed))
-				throw_impact(A,speed,user)
+				throw_impact(A,speed,user, hit_whitelist)
 				if(throwing==1)
 					throwing = 0
 					. = 0
 
-/atom/movable/proc/throw_at(atom/target, range, speed, override = TRUE, var/fly_speed = 0) //fly_speed parameter: if 0, does nothing. Otherwise, changes how fast the object flies WITHOUT affecting damage!
+/atom/movable/proc/throw_at(atom/target, range, speed, override = TRUE, var/fly_speed = 0, var/list/whitelist) //fly_speed parameter: if 0, does nothing. Otherwise, changes how fast the object flies WITHOUT affecting damage!
 	set waitfor = FALSE
 	if(!target || !src)
 		return 0
@@ -646,7 +646,7 @@
 					break
 
 				src.Move(step, dy, glide_size_override = DELAY2GLIDESIZE(fly_speed))
-				. = hit_check(speed, user)
+				. = hit_check(speed, user, whitelist)
 				error += dist_x
 				dist_travelled++
 				dist_since_sleep++
@@ -660,7 +660,7 @@
 					break
 
 				src.Move(step, dx, glide_size_override = DELAY2GLIDESIZE(fly_speed))
-				. = hit_check(speed, user)
+				. = hit_check(speed, user, whitelist)
 				error -= dist_y
 				dist_travelled++
 				dist_since_sleep++
@@ -687,7 +687,7 @@
 					break
 
 				src.Move(step, dx, glide_size_override = DELAY2GLIDESIZE(fly_speed))
-				. = hit_check(speed, user)
+				. = hit_check(speed, user, whitelist)
 				error += dist_y
 				dist_travelled++
 				dist_since_sleep++
@@ -701,7 +701,7 @@
 					break
 
 				src.Move(step, dy, glide_size_override = DELAY2GLIDESIZE(fly_speed))
-				. = hit_check(speed, user)
+				. = hit_check(speed, user, whitelist)
 				error -= dist_x
 				dist_travelled++
 				dist_since_sleep++
@@ -715,7 +715,7 @@
 	src.throwing = 0
 	kinetic_acceleration = 0
 	if(isobj(src))
-		src.throw_impact(get_turf(src), speed, user)
+		src.throw_impact(get_turf(src), speed, user, whitelist)
 
 //Overlays
 

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -195,7 +195,7 @@ var/explosion_shake_message_cooldown = 0
 					continue
 				if(ismob(A))
 					to_chat(A, "<span class='warning'>You are blown away by the explosion!</span>")
-				A.throw_at(throwT,pushback+2,500,whitelist = shrapnel_whitelist)
+				A.throw_at(throwT,pushback+2,500,TRUE,0,shrapnel_whitelist)
 			A.ex_act(dist,null,whodunnit)
 			atomtime = world.time - atomtime
 			if(atomtime > 0)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -28,7 +28,7 @@
 
 var/explosion_shake_message_cooldown = 0
 
-/proc/explosion(turf/epicenter, const/devastation_range, const/heavy_impact_range, const/light_impact_range, const/flash_range, adminlog = 1, ignored = 0, verbose = 1, var/mob/whodunnit, var/list/whitelist, var/true_range)
+/proc/explosion(turf/epicenter, const/devastation_range, const/heavy_impact_range, const/light_impact_range, const/flash_range, adminlog = 1, ignored = 0, verbose = 1, var/mob/whodunnit, var/list/whitelist, var/true_range, var/list/shrapnel_whitelist)
 	var/explosion_time = world.time
 
 	spawn()
@@ -61,8 +61,7 @@ var/explosion_shake_message_cooldown = 0
 		var/y0 = epicenter.y
 		var/z0 = epicenter.z
 
-
-		var/datum/sensed_explosion/explosion_datum = explosion_destroy(epicenter,epicenter,devastation_range,heavy_impact_range,light_impact_range,flash_range,explosion_time,whodunnit,whitelist,true_range)
+		var/datum/sensed_explosion/explosion_datum = explosion_destroy(epicenter,epicenter,devastation_range,heavy_impact_range,light_impact_range,flash_range,explosion_time,whodunnit,whitelist,true_range,shrapnel_whitelist)
 
 		var/took = stop_watch(watch)
 
@@ -136,7 +135,7 @@ var/explosion_shake_message_cooldown = 0
 	else
 		epicenter.turf_animation('icons/effects/96x96.dmi',"explosion_small",-WORLD_ICON_SIZE, -WORLD_ICON_SIZE, 13)
 
-/proc/explosion_destroy(turf/epicenter, turf/offcenter, const/devastation_range, const/heavy_impact_range, const/light_impact_range, const/flash_range, var/explosion_time, var/mob/whodunnit, var/list/whitelist, var/cap = 0)
+/proc/explosion_destroy(turf/epicenter, turf/offcenter, const/devastation_range, const/heavy_impact_range, const/light_impact_range, const/flash_range, var/explosion_time, var/mob/whodunnit, var/list/whitelist, var/cap = 0, var/list/shrapnel_whitelist)
 	var/max_range = max(devastation_range, heavy_impact_range, light_impact_range)
 
 	var/x0 = offcenter.x
@@ -196,8 +195,7 @@ var/explosion_shake_message_cooldown = 0
 					continue
 				if(ismob(A))
 					to_chat(A, "<span class='warning'>You are blown away by the explosion!</span>")
-
-				A.throw_at(throwT,pushback+2,500)
+				A.throw_at(throwT,pushback+2,500,whitelist = shrapnel_whitelist)
 			A.ex_act(dist,null,whodunnit)
 			atomtime = world.time - atomtime
 			if(atomtime > 0)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -80,11 +80,13 @@
 /mob/living/proc/thrown_defense(var/obj/O)
 	return 1
 
-/mob/living/hitby(atom/movable/AM as mob|obj,var/speed = 5,var/dir)//Standardization and logging -Sieve
+/mob/living/hitby(atom/movable/AM as mob|obj,var/speed = 5,var/dir,var/list/hit_whitelist)//Standardization and logging -Sieve
 	. = ..()
 	if(.)
 		return
 	if(flags & INVULNERABLE)
+		return
+	if(hit_whitelist && (src in hit_whitelist))
 		return
 	if(istype(AM,/obj/) && !istype(AM,/obj/effect/))
 		var/obj/O = AM

--- a/code/modules/multiz/falling.dm
+++ b/code/modules/multiz/falling.dm
@@ -126,7 +126,7 @@
 	return FALSE
 
 // Function handling going over open spaces, pre-extension to normal throw hit checks
-/atom/movable/hit_check(var/speed, mob/user)
+/atom/movable/hit_check(speed, mob/user, hit_whitelist)
 	if(isopenspace(get_turf(src)))
 		src.fall()
 	. = ..()

--- a/code/modules/spells/targeted/punch.dm
+++ b/code/modules/spells/targeted/punch.dm
@@ -70,7 +70,7 @@
 			spawn(0) //Continue spell-code
 				target.SetStunned(2) //Make sure this kicks in ASAP
 				while(target.throwing)
-					sleep(1) //Fixes a bug where throw_at() briefly cancelled the timestopped variable
+					sleep(1) //Moved it here so that it fixes a bug caused by throw_at() cancelling time stop for a split second
 					if(!target.timestopped)
 						to_chat(world, "SPIN!!")
 						target.transform = turn(target.transform, 45) //Spin the target

--- a/code/modules/spells/targeted/punch.dm
+++ b/code/modules/spells/targeted/punch.dm
@@ -105,11 +105,14 @@
 	if(has_triggered)
 		return
 	var/list/explosion_whitelist = list()
+	var/list/projectile_whitelist = list()
 	explosion_whitelist += user //Wizard is immune to the ensuing explosion, because that's badass
+	projectile_whitelist += user //Wizard shouldn't have to worry too much about the shrapnel from explosions, fight on!
+	projectile_whitelist += T //Shrapnel causes the spell to be overkill on victims and way too unfair
 	if(empowered) //The unfortunate sod being thrown by it won't be that severely harmed compared to what they collide into
-		explosion(get_turf(bumped), 0, 1, 5, whodunnit = user, whitelist = explosion_whitelist, shrapnel_whitelist = explosion_whitelist)
+		explosion(get_turf(bumped), 0, 1, 5, whodunnit = user, whitelist = explosion_whitelist, shrapnel_whitelist = projectile_whitelist)
 	else
-		explosion(get_turf(bumped), 0, 0, 3, whodunnit = user, whitelist = explosion_whitelist, shrapnel_whitelist = explosion_whitelist)
+		explosion(get_turf(bumped), 0, 0, 3, whodunnit = user, whitelist = explosion_whitelist, shrapnel_whitelist = projectile_whitelist)
 	has_triggered = 1
 	spawn(1) //A 0.1 second delay, then we allow the spell to cause explosions again
 		has_triggered = 0
@@ -117,11 +120,14 @@
 //Explosion as a result of the target not flying away, significantly stronger than launching punches
 /spell/targeted/punch/proc/explosive_punch(atom/target)
 	var/list/explosion_whitelist = list()
+	var/list/projectile_whitelist = list()
 	explosion_whitelist += holder
+	projectile_whitelist += holder
+	projectile_whitelist += target
 	if(empowered)
-		explosion(get_turf(target), 0, 3, 7, whodunnit = holder, whitelist = explosion_whitelist, shrapnel_whitelist = explosion_whitelist)
+		explosion(get_turf(target), 0, 3, 7, whodunnit = holder, whitelist = explosion_whitelist, shrapnel_whitelist = projectile_whitelist)
 	else
-		explosion(get_turf(target), 0, 1, 5, whodunnit = holder, whitelist = explosion_whitelist, shrapnel_whitelist = explosion_whitelist)
+		explosion(get_turf(target), 0, 1, 5, whodunnit = holder, whitelist = explosion_whitelist, shrapnel_whitelist = projectile_whitelist)
 
 /spell/targeted/punch/proc/generate_punch_sprite()
 	return image(icon = 'icons/mob/screen_spells.dmi', icon_state = hud_state)

--- a/code/modules/spells/targeted/punch.dm
+++ b/code/modules/spells/targeted/punch.dm
@@ -72,7 +72,6 @@
 				while(target.throwing)
 					sleep(1) //Moved it here so that it fixes a bug caused by throw_at() cancelling time stop for a split second
 					if(!target.timestopped)
-						to_chat(world, "SPIN!!")
 						target.transform = turn(target.transform, 45) //Spin the target
 						target.SetStunned(2) //We don't want the target to move during this time
 						turns += 45

--- a/code/modules/spells/targeted/punch.dm
+++ b/code/modules/spells/targeted/punch.dm
@@ -68,12 +68,14 @@
 			L.visible_message("<span class='danger'>[L] throws a mighty punch that launches \the [target] away!</span>")
 			var/turns = 0 //Fixes a bug where the transform could occasionally get messed up such as when the target is lying down
 			spawn(0) //Continue spell-code
+				target.SetStunned(2) //Make sure this kicks in ASAP
 				while(target.throwing)
+					sleep(1) //Fixes a bug where throw_at() briefly cancelled the timestopped variable
 					if(!target.timestopped)
+						to_chat(world, "SPIN!!")
 						target.transform = turn(target.transform, 45) //Spin the target
 						target.SetStunned(2) //We don't want the target to move during this time
 						turns += 45
-					sleep(1)
 				target.transform = turn(target.transform, -turns)
 				target.Knockdown(2)
 				target.unregister_event(/event/to_bump, src, nameof(src::handle_bump())) //Just in case
@@ -106,9 +108,9 @@
 	var/list/explosion_whitelist = list()
 	explosion_whitelist += user //Wizard is immune to the ensuing explosion, because that's badass
 	if(empowered) //The unfortunate sod being thrown by it won't be that severely harmed compared to what they collide into
-		explosion(get_turf(bumped), 0, 1, 5, whodunnit = user, whitelist = explosion_whitelist)
+		explosion(get_turf(bumped), 0, 1, 5, whodunnit = user, whitelist = explosion_whitelist, shrapnel_whitelist = explosion_whitelist)
 	else
-		explosion(get_turf(bumped), 0, 0, 3, whodunnit = user, whitelist = explosion_whitelist)
+		explosion(get_turf(bumped), 0, 0, 3, whodunnit = user, whitelist = explosion_whitelist, shrapnel_whitelist = explosion_whitelist)
 	has_triggered = 1
 	spawn(1) //A 0.1 second delay, then we allow the spell to cause explosions again
 		has_triggered = 0
@@ -118,9 +120,9 @@
 	var/list/explosion_whitelist = list()
 	explosion_whitelist += holder
 	if(empowered)
-		explosion(get_turf(target), 0, 3, 7, whodunnit = holder, whitelist = explosion_whitelist)
+		explosion(get_turf(target), 0, 3, 7, whodunnit = holder, whitelist = explosion_whitelist, shrapnel_whitelist = explosion_whitelist)
 	else
-		explosion(get_turf(target), 0, 1, 5, whodunnit = holder, whitelist = explosion_whitelist)
+		explosion(get_turf(target), 0, 1, 5, whodunnit = holder, whitelist = explosion_whitelist, shrapnel_whitelist = explosion_whitelist)
 
 /spell/targeted/punch/proc/generate_punch_sprite()
 	return image(icon = 'icons/mob/screen_spells.dmi', icon_state = hud_state)


### PR DESCRIPTION
When I made the Punch spell it also came with an explosion whitelist that allowed explosions to ignore the wizard, so that the wizard won't be basically punching someone with the force of a fireball (kinda) at close range and then get violently destroyed by the ensuing explosion. Unfortunately the shrapnel addition to explosives effectively rendered that point moot, as it was very likely that the debris launched forward by the explosion from the Punch would slam right into the wizard, obliterating them. Frankly it was a significant motivation for attempting to nerf shrapnel damage on two separate occasions.
After the pull request was made I realized that the Punch spell, for the last year, has been ridiculously lethal against its victims; the shrapnel affected them too. They are now immune to the Punch shrapnel too, because that's cool and because it's balanced. Sorry for the Punch-induced instakill grievances for the last year or so.

This PR makes both the wizard and their target immune to the shrapnel caused by the Punch spell, by adding a shrapnel whitelist which gets carried all the way to throw impact code, in which neither the target nor the wizard will get damaged. They will still be hit, it's just that they won't take any damage from being hit, so if a bola happens to be launched by an explosion in will still entangle whoever it hits.

Also fixes a bug where for a brief moment a timestopped target getting Punched would spin.

:cl:
 * rscadd: The Wizard's "Punch" spell will now also make both the wizard and their target immune to the damage caused by any shrapnel launched by the ensuing explosion. It will not, however, cancel any effect that the shrapnel may have, such as bolas entangling their targets.
 * bugfix: Fixed a bug where if a wizard used the "Punch" spell on a target frozen in time it would permanently displace their sprite.