### PR TITLE
Time Stop costs just as much to empower as to quicken

### DIFF
--- a/code/modules/spells/aoe_turf/fall.dm
+++ b/code/modules/spells/aoe_turf/fall.dm
@@ -47,6 +47,9 @@ var/global/list/falltempoverlays = list()
 
 #undef duration_increase_per_level
 
+/spell/aoe_turf/fall/get_upgrade_price()
+	return 10 //Costs 10 points to either empower or quicken
+
 /spell/aoe_turf/fall/New()
 	..()
 	buildimage()


### PR DESCRIPTION
AKA 10 points.
It's important to note that a wizard can only take 3 levels in Time Stop to either quicken it or empower it, when there are a total of 6 levels. This means that if a wizard fully invested in quickening it they wouldn't be able to put any points into empowering it. As both quickening it and empowering it have their own powerful effects (10 second cooldown reduction vs +1 range and second of effect) I believe it is fair (and more fun) to have the empowerment be as cheap as the quickening is. A wizard with 3 Empowerments would have spent 80 spell points for a 6-second time stop with a 50 second cooldown.

:cl:
 * tweak: Empowering Time Stop now costs 10 points instead of 20.