### PR TITLE
Wizard's spellbook describes stuff better and some fixes

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -120,8 +120,9 @@
 
 			var/spell_name = spell.name
 			var/spell_cooldown = get_spell_cooldown_string(spell.charge_max, spell.charge_type)
+			var/spell_range = get_spell_range_string(spell.range)
 
-			dat += "<strong>[spell_name]</strong>[spell_cooldown]<br>"
+			dat += "<strong>[spell_name]</strong>[spell_cooldown]<br>Range: [spell_range]<br>"
 
 			//Get spell properties
 			var/list/properties = get_spell_properties(spell.spell_flags, user)
@@ -148,7 +149,7 @@
 				upgrade_data += "<a href='?src=\ref[src];spell=\ref[spell];upgrade_type=[upgrade];upgrade_info=1'>[upgrade]</a>: [lvl]/[max] ([upgrade_button])</a>  "
 
 			if(upgrade_data)
-				dat += "[upgrade_data]<br><br>"
+				dat += "[upgrade_data]<br>"
 			dat+= "<br>"
 
 //FORMATTING
@@ -259,6 +260,13 @@
 			return " - [charges] charge\s"
 		if(Sp_RECHARGE)
 			return " - cooldown: [(charges/10)]s"
+
+/obj/item/weapon/spellbook/proc/get_spell_range_string(var/range)
+	if(range == 1)
+		return "Adjacent"
+	if((range == SELFCAST) || (range == 0))
+		return "Self"
+	return range
 
 /obj/item/weapon/spellbook/proc/get_spell_price(spell/spell_type)
 	if(ispath(spell_type, /spell))

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -127,23 +127,25 @@
 			var/list/properties = get_spell_properties(spell.spell_flags, user)
 			var/property_data
 			for(var/P in properties)
-				property_data += "[P] "
+				property_data += "[P]<br>"
 
 			if(property_data)
-				dat += "<span style=\"color:blue\">[property_data]</span><br>"
+				dat += "[property_data]"
 
 			//Get the upgrades
 			var/upgrade_data = ""
 
 			for(var/upgrade in spell.spell_levels)
+				var/upgrade_button = "<a href='?src=\ref[src];spell=\ref[spell];upgrade_type=[upgrade];upgrade=1'>upgrade ([spell.get_upgrade_price(upgrade)] points)</a>"
 				var/lvl = spell.spell_levels[upgrade]
 				var/max = spell.level_max[upgrade]
 
 				//If maximum upgrade level is 0, skip
 				if(!max)
 					continue
-
-				upgrade_data += "<a href='?src=\ref[src];spell=\ref[spell];upgrade_type=[upgrade];upgrade_info=1'>[upgrade]</a>: [lvl]/[max] (<a href='?src=\ref[src];spell=\ref[spell];upgrade_type=[upgrade];upgrade=1'>upgrade ([spell.get_upgrade_price(upgrade)] points)</a>)  "
+				if(lvl >= max)
+					upgrade_button = "<strong>MAXED</strong>"
+				upgrade_data += "<a href='?src=\ref[src];spell=\ref[spell];upgrade_type=[upgrade];upgrade_info=1'>[upgrade]</a>: [lvl]/[max] ([upgrade_button])</a>  "
 
 			if(upgrade_data)
 				dat += "[upgrade_data]<br><br>"
@@ -153,6 +155,7 @@
 //<b>Fireball</b> - 10 seconds (buy for 1 spell point)
 //<i>(Description)</i>
 //Requires robes to cast
+//Lost on mind transfer
 
 	if(shown_offensive_spells.len)
 		dat += "<span style=\"color:red\"><strong>OFFENSIVE SPELLS:</strong></span><br><br>"
@@ -219,9 +222,9 @@
 	var/list/properties = get_spell_properties(flags, user)
 	var/property_data
 	for(var/P in properties)
-		property_data += "[P] "
+		property_data += "[P]<br>"
 	if(property_data)
-		dat += "<span style=\"color:blue\">[property_data]</span><br>"
+		dat += "[property_data]"
 	dat += "<br>"
 	return dat
 
@@ -229,7 +232,7 @@
 	var/list/properties = list()
 
 	if(flags & NEEDSCLOTHES)
-		var/new_prop = "Requires wizard robes to cast."
+		var/new_prop = "<span style=\"color:blue\">Requires wizard robes to cast.</span>"
 
 		//If user has the robeless spell, strike the text out
 		if(user)
@@ -239,8 +242,11 @@
 
 		properties.Add(new_prop)
 
+	if(flags & LOSE_IN_TRANSFER)
+		properties.Add("<span style=\"color:red\">Lost on mind transfer.</span>")
+
 	if(flags & STATALLOWED)
-		properties.Add("Can be cast while unconscious.")
+		properties.Add("<span style=\"color:green\">Can be cast while unconscious.</span>")
 
 	return properties
 

--- a/code/game/gamemodes/wizard/spellbook_oneuse.dm
+++ b/code/game/gamemodes/wizard/spellbook_oneuse.dm
@@ -570,7 +570,7 @@
 ///// ANCIENT SPELLBOOK /////
 
 /obj/item/weapon/spellbook/oneuse/ancient //the ancient spellbook contains weird and dangerous spells that aren't otherwise available to purchase, only available via the spellbook bundle
-	var/list/possible_spells = list(/spell/targeted/disintegrate, /spell/targeted/parrotmorph, /spell/aoe_turf/conjure/spares, /spell/targeted/balefulmutate, /spell/targeted/card)
+	var/list/possible_spells = list(/spell/targeted/disintegrate, /spell/targeted/parrotmorph, /spell/aoe_turf/conjure/spares, /spell/targeted/balefulmutate)
 	spell = null
 	icon_state = "book"
 	desc = "A book of lost and forgotten knowledge."

--- a/code/modules/spells/aoe_turf/conjure/arcane_golem.dm
+++ b/code/modules/spells/aoe_turf/conjure/arcane_golem.dm
@@ -116,6 +116,8 @@
 /spell/aoe_turf/conjure/arcane_golem/get_upgrade_info(upgrade_type)
 	switch(upgrade_type)
 		if(Sp_AMOUNT)
+			if(spell_levels[Sp_AMOUNT] >= level_max[Sp_AMOUNT])
+				return "You can already sustain the maximum about of golems!"
 			return "Gain the ability to sustain [golem_limit + ADDITIONAL_GOLEMS_PER_UPGRADE_LEVEL] golems at once."
 
 	return ..()

--- a/code/modules/spells/aoe_turf/conjure/pontiac.dm
+++ b/code/modules/spells/aoe_turf/conjure/pontiac.dm
@@ -13,6 +13,7 @@
 	spell_flags = Z2NOCAST
 	invocation = "NO F'AT C'HX"
 	invocation_type = SpI_SHOUT
+	level_max = list(Sp_TOTAL = 0)
 	range = 0
 
 	summon_type = list(/obj/structure/bed/chair/vehicle/firebird)

--- a/code/modules/spells/aoe_turf/fall.dm
+++ b/code/modules/spells/aoe_turf/fall.dm
@@ -42,6 +42,8 @@ var/global/list/falltempoverlays = list()
 
 /spell/aoe_turf/fall/get_upgrade_info(upgrade_type, level)
 	if(upgrade_type == Sp_POWER)
+		if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
+			return "This spell can't be made any more powerful than this!"
 		return "Increase the spell's duration by [duration_increase_per_level/10] second\s and radius by 2 meters."
 	return ..()
 

--- a/code/modules/spells/aoe_turf/fall.dm
+++ b/code/modules/spells/aoe_turf/fall.dm
@@ -43,7 +43,7 @@ var/global/list/falltempoverlays = list()
 /spell/aoe_turf/fall/get_upgrade_info(upgrade_type, level)
 	if(upgrade_type == Sp_POWER)
 		if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
-			return "This spell can't be made any more powerful than this!"
+			return "The spell can't be made any more powerful than this!"
 		return "Increase the spell's duration by [duration_increase_per_level/10] second\s and radius by 2 meters."
 	return ..()
 

--- a/code/modules/spells/aoe_turf/hangcurse.dm
+++ b/code/modules/spells/aoe_turf/hangcurse.dm
@@ -27,7 +27,11 @@ Removes letters in the afflicted's sentences like the virology symptom, others m
 
 /spell/aoe_turf/hangman/get_upgrade_info(upgrade_type, level)
 	if(upgrade_type == Sp_POWER)
-		return "Remove more letters from the affecteds' sentences"
+		if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
+			if(prob(10))
+				return "Th__ _p_ll _lr__dy r_mov__ __ m_ny l_tt_r_ __ _t c_n!"
+			return "This spell already removes as many letters as it can!"
+		return "Remove more letters from the sentences of those who are affected."
 	return ..()
 
 /spell/aoe_turf/hangman/empower_spell()
@@ -45,7 +49,7 @@ Removes letters in the afflicted's sentences like the virology symptom, others m
 		if(2)
 			name = "C__s_ __ _h_ H__g___"
 			invocation = "V_R'_ R_'_G_"
-	
+
 	return "The curse will now retain less letters"
 
 /spell/aoe_turf/hangman/choose_targets(var/mob/user = usr)

--- a/code/modules/spells/aoe_turf/magic_wardrobe.dm
+++ b/code/modules/spells/aoe_turf/magic_wardrobe.dm
@@ -75,7 +75,7 @@
 /spell/aoe_turf/conjure/magical_wardrobe/get_upgrade_info(upgrade_type, level)
 	if(upgrade_type == Sp_SPEED)
 		if(spell_levels[Sp_SPEED] >= level_max[Sp_SPEED])
-			return "This spell can't be made any quicker than this!"
+			return "The spell can't be made any quicker than this!"
 		var/formula = round((initial_charge_max - cooldown_min)/level_max[Sp_SPEED])
 		return "Decreases the cooldown on summoning a new wardrobe by [formula/10]. Does not affect the recall or summon spells. Also increases its durability."
 	if(upgrade_type == Sp_MOVE)

--- a/code/modules/spells/aoe_turf/magic_wardrobe.dm
+++ b/code/modules/spells/aoe_turf/magic_wardrobe.dm
@@ -74,12 +74,21 @@
 
 /spell/aoe_turf/conjure/magical_wardrobe/get_upgrade_info(upgrade_type, level)
 	if(upgrade_type == Sp_SPEED)
-		return "Decreases the cooldown on summoning a new wardrobe. Does not effect the recall or summon spells. Also increases its durability."
+		if(spell_levels[Sp_SPEED] >= level_max[Sp_SPEED])
+			return "This spell can't be made any quicker than this!"
+		var/formula = round((initial_charge_max - cooldown_min)/level_max[Sp_SPEED])
+		return "Decreases the cooldown on summoning a new wardrobe by [formula/10]. Does not affect the recall or summon spells. Also increases its durability."
 	if(upgrade_type == Sp_MOVE)
+		if(spell_levels[Sp_MOVE] >= level_max[Sp_MOVE])
+			return "You can already summon the wardrobe to your location!"
 		return "Allows you to summon your wardrobe to your location. Also increases its durability."
 	if(upgrade_type == Sp_POWER)
+		if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
+			return "You are already immune to the magical backlash of your wardrobe getting destroyed!"
 		return "Prevents magical backlash from affecting you when your wardrobe is destroyed. Also increases its durability."
 	if(upgrade_type == Sp_AMOUNT)
+		if(spell_levels[Sp_AMOUNT] >= level_max[Sp_AMOUNT])
+			return "You have already made the wardrobe as durable as it can be through this upgrade! You may try buying a different upgrade."
 		return "Significantly increases durability. Only wizards completely devoted to fashion should choose this."
 	return ..()
 

--- a/code/modules/spells/general/lightning.dm
+++ b/code/modules/spells/general/lightning.dm
@@ -204,13 +204,15 @@
 		if(Sp_POWER)
 			switch(level)
 				if(1)
-					return "Allow the spell to arc to one additional target."
+					return "Allow the spell to arc to one additional target and slightly increases its damage."
 				if(2)
-					return "Allow the spell to arc up to 3 targets."
+					return "Allow the spell to arc up to 3 targets and slightly increases its damage."
 				if(3)
-					return "Allow the spell to arc up to 5 targets."
-		else
-			return ..()
+					return "Allow the spell to arc up to 5 targets and slightly increases its damage."
+		if(Sp_SPEED)
+			if(spell_levels[Sp_SPEED] == 2)
+				return "Allows you to multi-cast the spell, being able to fire up to two bolts of lightning before having to re-cast."
+	return ..()
 
 /spell/lightning/sith
 	basedamage = 25

--- a/code/modules/spells/general/ring_of_fire.dm
+++ b/code/modules/spells/general/ring_of_fire.dm
@@ -76,8 +76,12 @@
 /spell/aoe_turf/ring_of_fire/get_upgrade_info(upgrade_type)
 	switch(upgrade_type)
 		if(Sp_MOVE)
+			if(spell_levels[Sp_MOVE] >= level_max[Sp_MOVE])
+				return "The ring already moves together with you!"
 			return "Make the ring move together with you."
 		if(Sp_POWER)
+			if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
+				return "The ring already casts living flames when it is over!"
 			return "Make the ring cast living flames when it is over."
 
 	return ..()

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -632,8 +632,17 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 /spell/proc/get_upgrade_info(upgrade_type)
 	switch(upgrade_type)
 		if(Sp_SPEED)
-			return "Reduce this spell's cooldown."
+			if(spell_levels[Sp_SPEED] >= level_max[Sp_SPEED])
+				return "This spell can't be made any quicker than this!"
+			var/formula
+			if(cooldown_reduc)
+				formula = min(charge_max - cooldown_min, cooldown_reduc)
+			else
+				formula = round((initial_charge_max - cooldown_min)/level_max[Sp_SPEED], 1)
+			return "Reduce this spell's cooldown by [formula/10] seconds."
 		if(Sp_POWER)
+			if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
+				return "This spell can't be made any more powerful than this!"
 			return "Increase this spell's power."
 
 //Return a string that gets appended to the spell on the scoreboard

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -633,7 +633,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	switch(upgrade_type)
 		if(Sp_SPEED)
 			if(spell_levels[Sp_SPEED] >= level_max[Sp_SPEED])
-				return "This spell can't be made any quicker than this!"
+				return "The spell can't be made any quicker than this!"
 			var/formula
 			if(cooldown_reduc)
 				formula = min(charge_max - cooldown_min, cooldown_reduc)
@@ -642,7 +642,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 			return "Reduce this spell's cooldown by [formula/10] seconds."
 		if(Sp_POWER)
 			if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
-				return "This spell can't be made any more powerful than this!"
+				return "The spell can't be made any more powerful than this!"
 			return "Increase this spell's power."
 
 //Return a string that gets appended to the spell on the scoreboard

--- a/code/modules/spells/targeted/arcanetamper.dm
+++ b/code/modules/spells/targeted/arcanetamper.dm
@@ -32,11 +32,11 @@
 			description = "It will now make nearby items anomalous."
 		if(1)
 			name = "Ranged Arcane Tamper"
-			description = "It will now make all items in normal view anomalous."
+			description = "It can now affect any item in view."
 			range = 7
 		if(2)
-			name = "Ranged Recurisve Arcane Tamper"
-			description = "It will now make all items in normal view anomalous along with their contents."
+			name = "Ranged Recursive Arcane Tamper"
+			description = "It will now make any item in normal view anomalous along with their contents."
 			recursive = TRUE
 		else
 			return
@@ -52,10 +52,12 @@
 
 /spell/targeted/arcane_tamper/get_upgrade_info(upgrade_type)
 	switch(upgrade_type)
-		if(Sp_SPEED)
-			return "Lowers the cooldown of the spell."
 		if(Sp_POWER)
-			return "Upgrades the range, then recursiveness, of the spell"
+			if(spell_levels[Sp_POWER] == 0)
+				return "Upgrades the range of the spell. At the second upgrade, improves the recursiveness of the spell, allowing it to affect the target's contents."
+			if(spell_levels[Sp_POWER] == 1)
+				return "Improves the recursiveness of the spell, allowing it to affect the target's contents."
+	return ..()
 
 /spell/targeted/arcane_tamper/cast(list/targets, mob/user)
 	..()

--- a/code/modules/spells/targeted/equip/robesummon.dm
+++ b/code/modules/spells/targeted/equip/robesummon.dm
@@ -87,6 +87,8 @@
 
 /spell/targeted/equip_item/robesummon/get_upgrade_info(upgrade_type, level)
 	if(upgrade_type == Sp_POWER)
+		if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
+			return "It already summons a gem-encrusted hardsuit and internals!"
 		return "Make the spell summon a gem-encrusted hardsuit and internals."
 	return ..()
 

--- a/code/modules/spells/targeted/grease.dm
+++ b/code/modules/spells/targeted/grease.dm
@@ -14,6 +14,14 @@
 	level_max = list(Sp_TOTAL = 5, Sp_SPEED = 4, Sp_POWER = 1)
 	hud_state = "bucket"
 
+/spell/targeted/grease/get_upgrade_info(upgrade_type)
+	switch(upgrade_type)
+		if(Sp_POWER)
+			if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
+				return "You can already emit grease at the targeted location!"
+			return "Allows you to target a different location within 4 tiles of you to cover it with grease."
+	return ..()
+
 
 /spell/targeted/grease/empower_spell()
 	spell_levels[Sp_POWER]++

--- a/code/modules/spells/targeted/grease.dm
+++ b/code/modules/spells/targeted/grease.dm
@@ -9,7 +9,7 @@
 	charge_max = 300
 	invocation = "GR'ESE LIT'NING"
 	invocation_type = SpI_SHOUT
-	range = 1
+	range = 0
 	spell_flags = NEEDSCLOTHES | INCLUDEUSER
 	level_max = list(Sp_TOTAL = 5, Sp_SPEED = 4, Sp_POWER = 1)
 	hud_state = "bucket"
@@ -33,7 +33,7 @@
 		if(1)
 			name = "Slick Grease"
 			range = 4
-			explosion_description = "You can now point to a location within [range] to become a grease slick. Has spell congruency with fire-based spells."
+			explosion_description = "You can now point to a location up to [range] tiles away to become slick greased. Has spell congruency with fire-based spells."
 			spell_flags |= WAIT_FOR_CLICK
 		else
 			return

--- a/code/modules/spells/targeted/heal.dm
+++ b/code/modules/spells/targeted/heal.dm
@@ -58,7 +58,7 @@
 	switch(upgrade_type)
 		if(Sp_SPEED)
 			if(spell_levels[Sp_SPEED] >= level_max[Sp_SPEED])
-				return "This spell can't be made any quicker than this!"
+				return "The spell can't be made any quicker than this!"
 			return "Reduce this spell's cooldown by [cooldown_reduc/10] seconds."
 		if(Sp_POWER)
 			if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])

--- a/code/modules/spells/targeted/heal.dm
+++ b/code/modules/spells/targeted/heal.dm
@@ -57,10 +57,16 @@
 /spell/targeted/heal/get_upgrade_info(upgrade_type, level)
 	switch(upgrade_type)
 		if(Sp_SPEED)
-			return "Reduce this spell's cooldown."
+			if(spell_levels[Sp_SPEED] >= level_max[Sp_SPEED])
+				return "This spell can't be made any quicker than this!"
+			return "Reduce this spell's cooldown by [cooldown_reduc/10] seconds."
 		if(Sp_POWER)
+			if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
+				return "This spell already has a chance of mending internal injuries!"
 			return "Grants the spell a chance of mending internal injuries in the primary target."
 		if(Sp_RANGE)
+			if(spell_levels[Sp_RANGE] >= level_max[Sp_RANGE])
+				return "This spell already affects a small area around the target!"
 			return "Expands the spell's effects to a small area around the target."
 
 

--- a/code/modules/spells/targeted/invoke_emotion.dm
+++ b/code/modules/spells/targeted/invoke_emotion.dm
@@ -60,12 +60,15 @@ var/global/list/invoked_emotions = list()
 
 /spell/targeted/invoke_emotion/get_upgrade_info(upgrade_type)
 	switch(upgrade_type)
-		if(Sp_SPEED)
-			return "Nearly removes the cooldown of the spell."
 		if(Sp_POWER)
+			if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
+				return "The invoked paper annoys the target as much as it can!"
 			return "Invoked paper is more likely to cut, or otherwise curse, the target."
 		if(Sp_MOVE)
+			if(spell_levels[Sp_MOVE] >= level_max[Sp_MOVE])
+				return "The invoked emotions can already place themselves in their target's hand!"
 			return "Invoked emotions have a chance to place themselves in their target's hand."
+	return ..()
 
 /obj/item/weapon/pen/invoked_quill
 	name = "invoked quill"

--- a/code/modules/spells/targeted/pacify.dm
+++ b/code/modules/spells/targeted/pacify.dm
@@ -44,7 +44,7 @@
 			if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
 				return "This spell can't be made any more powerful than this!"
 			var/duration = 2/REAGENTS_METABOLISM*2 //2 extra units of Chillwax per rank, multiplied by 2 due to Life() happening every 2 seconds
-			return "Increases how long targets are pacified for by around [duration/10] seconds."
+			return "Increases how long targets are pacified for by around [duration] seconds."
 		if(Sp_RANGE)
 			if(spell_levels[Sp_RANGE] >= level_max[Sp_RANGE])
 				return "This spell's area of effect is at its maximum!"

--- a/code/modules/spells/targeted/pacify.dm
+++ b/code/modules/spells/targeted/pacify.dm
@@ -42,7 +42,7 @@
 	switch(upgrade_type)
 		if(Sp_POWER)
 			if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
-				return "This spell can't be made any more powerful than this!"
+				return "The spell can't be made any more powerful than this!"
 			var/duration = 2/REAGENTS_METABOLISM*2 //2 extra units of Chillwax per rank, multiplied by 2 due to Life() happening every 2 seconds
 			return "Increases how long targets are pacified for by around [duration] seconds."
 		if(Sp_RANGE)

--- a/code/modules/spells/targeted/pacify.dm
+++ b/code/modules/spells/targeted/pacify.dm
@@ -40,12 +40,16 @@
 
 /spell/targeted/pacify/get_upgrade_info(upgrade_type)
 	switch(upgrade_type)
-		if(Sp_SPEED)
-			return "Reduce this spell's cooldown."
 		if(Sp_POWER)
-			return "Increases how long targets are pacified for."
+			if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
+				return "This spell can't be made any more powerful than this!"
+			var/duration = 2/REAGENTS_METABOLISM*2 //2 extra units of Chillwax per rank, multiplied by 2 due to Life() happening every 2 seconds
+			return "Increases how long targets are pacified for by around [duration/10] seconds."
 		if(Sp_RANGE)
-			return "Increases the area of the spell's impact."
+			if(spell_levels[Sp_RANGE] >= level_max[Sp_RANGE])
+				return "This spell's area of effect is at its maximum!"
+			return "Increases the area of the spell's impact by 1 tile."
+	return ..()
 
 /spell/targeted/pacify/is_valid_target(atom/target, mob/user, options, bypass_range = 0)
 	if(!istype(target))

--- a/code/modules/spells/targeted/projectile/pie_throw.dm
+++ b/code/modules/spells/targeted/projectile/pie_throw.dm
@@ -25,7 +25,7 @@
 	switch(upgrade_type)
 		if(Sp_POWER)
 			if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
-				return "This spell can't be made any more powerful than this!"
+				return "The spell can't be made any more powerful than this!"
 			return "Allows you to throw an extra pie, and increases the throwing damage of each pie by 4."
 	return ..()
 

--- a/code/modules/spells/targeted/projectile/pie_throw.dm
+++ b/code/modules/spells/targeted/projectile/pie_throw.dm
@@ -21,6 +21,14 @@
 
 	hud_state = "pie"
 
+/spell/targeted/projectile/pie/get_upgrade_info(upgrade_type)
+	switch(upgrade_type)
+		if(Sp_POWER)
+			if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
+				return "This spell can't be made any more powerful than this!"
+			return "Allows you to throw an extra pie, and increases the throwing damage of each pie by 4."
+	return ..()
+
 /spell/targeted/projectile/pie/empower_spell()
 	spell_levels[Sp_POWER]++
 	return "Your spell now throws [spell_levels[Sp_POWER]+1] pies at once!"

--- a/code/modules/spells/targeted/pumpkinhead.dm
+++ b/code/modules/spells/targeted/pumpkinhead.dm
@@ -1,6 +1,6 @@
 /spell/targeted/pumpkin_head
 	name = "pass the pumpkin"
-	desc = "whomever you select with this spell is given a carnivorous pumpkin that will eat the head of whomever is holding it after 60 seconds."
+	desc = "Whomever you select with this spell is given a carnivorous pumpkin that will eat the head of whomever is holding it after 60 seconds."
 	abbreviation = "PTP"
 	user_type = USER_TYPE_WIZARD
 	specialization = SSOFFENSIVE

--- a/code/modules/spells/targeted/punch.dm
+++ b/code/modules/spells/targeted/punch.dm
@@ -25,10 +25,9 @@
 
 /spell/targeted/punch/get_upgrade_info(upgrade_type)
 	switch(upgrade_type)
-		if(Sp_SPEED)
-			return "Reduce this spell's cooldown."
 		if(Sp_POWER)
-			return "Make the explosion more devastating."
+			return "Make the explosion more devastating, allowing it to cause more damage and even breach the ground."
+	return ..()
 
 /spell/targeted/punch/empower_spell()
 	..()

--- a/code/modules/spells/targeted/street_alchemy.dm
+++ b/code/modules/spells/targeted/street_alchemy.dm
@@ -57,16 +57,21 @@
 
 /spell/targeted/alchemy/get_upgrade_info(upgrade_type)
 	switch(upgrade_type)
-		if(Sp_SPEED)
-			return
 		if(Sp_POWER)
+			if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
+				return "Thrown elixirs can already transfer their contents into living targets!"
 			return "Thrown elixirs transfer their contents into living targets."
 		if(Sp_RANGE)
+			if(spell_levels[Sp_RANGE] >= level_max[Sp_RANGE])
+				return "This spell already steals as many reagents as it can from an area!"
 			if(spell_levels[Sp_RANGE] >= 21)
 				return "You will now steal all reagents in an area."
 			return "Pilfers from one more target per cast."
 		if(Sp_AMOUNT)
+			if(spell_levels[Sp_AMOUNT] >= level_max[Sp_AMOUNT])
+				return "You have already reached the limit of how many elixirs can exist at a time!"
 			return "The amount of alchemic elixirs that can exist at a time."
+	return ..()
 
 /spell/targeted/alchemy/cast(list/targets, mob/user)
 	for(var/target in targets)

--- a/code/modules/spells/targeted/summon_snacks.dm
+++ b/code/modules/spells/targeted/summon_snacks.dm
@@ -111,14 +111,17 @@
 
 /spell/targeted/summon_snacks/get_upgrade_info(upgrade_type)
 	switch(upgrade_type)
-		if(Sp_SPEED)
-			return "Lowers the cooldown of the spell."
 		if(Sp_POWER)
+			if(spell_levels[Sp_POWER] >= level_max[Sp_POWER])
+				return "Your snacks already carry a small amount of disabeetusol!"
 			return "Your snacks will now contain a small amount of diabeetusol. Full of flavor and calories!"
 		if(Sp_AMOUNT)
+			if(spell_levels[Sp_AMOUNT] >= level_max[Sp_AMOUNT])
+				return "Your snacks have reached the limit of how many bites are needed to finish eating them!"
 			return "Increases how many bites it takes to finish eating."
 		if(Sp_MOVE)
-			return "Changes the type of snack and drink. Resets at max level to allow cycling through the menu. Level 0: Filling, Level 1: Discount, Level 2: Horrible, Level 3: Pub, Level 4: Patrol, Level 5: Spicy."
+			return "Changes the type of snack and drink. Resets at max level to allow cycling through the menu. Level 0: Filling, Level 1: Discount, Level 2: Horrible, Level 3: Pub, Level 4: Patrol, Level 5: Spicy, Level 6: Dwarven."
+	return ..()
 
 /obj/item/weapon/reagent_containers/food/snacks/summoned
 	name = "wizard snack"


### PR DESCRIPTION
![image](https://github.com/vgstation-coders/vgstation13/assets/41342767/0620f2f8-a38b-4244-beaf-8e78cb42fb93)
![image](https://github.com/vgstation-coders/vgstation13/assets/41342767/a909231c-bc63-4150-928c-130cf74be11d)


:cl:
 * rscadd: The wizard's spellbook will now tell you which spell is lost upon transferring minds with spells such as Mind Swap.
 * rscadd: The wizard's spellbook will now tell you a spell's range once purchased.
 * rscadd: Many spells in the wizard's spellbook will be more descriptive when their attribute buttons (such as cooldown and power) are pressed. Most notably, the cooldown button will tell you by how many seconds the cooldown is reduced.
 * bugfix: Fixed a bug where the "Card Trick" spell could be acquired from the spellbook bundle's ancient spellbook.
 * bugfix: Fixed a bug where the "Chariot" spell could have its cooldown reduced despite being a one-time-use spell that summons a Firebird vehicle.
 * spellcheck: The wizard's spellbook will now display "MAXED!" for a maxed spell level rather than the upgrade cost.
 * spellcheck: Slightly reformatted the wizard's spellbook: multiple elements such as "requires wizard robes" and "lost on mind transfer" will stack on top of each other rather than one next to another, and the text for a spell that is capable of being used while unconscious is now green instead of blue.
 * spellcheck: The "Summon Snacks" swapping description will now mention Dwarven snacks.
 * spellcheck: Fixed up the "Grease" wizard spell's empowerment message.