### PR TITLE
combat borgs now unlock on code delta too

### DIFF
--- a/__DEFINES/silicon.dm
+++ b/__DEFINES/silicon.dm
@@ -52,7 +52,7 @@ var/global/list/all_robot_modules = default_nanotrasen_robot_modules + emergency
 
 /proc/getAvailableRobotModules()
 	var/list/pickable_modules = default_nanotrasen_robot_modules.Copy()
-	if(security_level == SEC_LEVEL_RED)
+	if(security_level >= SEC_LEVEL_RED)
 		pickable_modules += emergency_nanotrasen_robot_modules
 	return pickable_modules
 


### PR DESCRIPTION
## What this does
Currently combat borgs unlock on code red but then lock back up on the highest alert level (delta).
Closes #35292

Changing this will fix an inconsistency but will probably buff Malfunctioning AI's pretty hard. 
Looking for opinions so please be vocal in the comments, I'll just close this if it's disliked.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Cyborgs are no longer disallowed from choosing the combat module on code delta.