### PR TITLE
Fixed a runtime in panel.dm

### DIFF
--- a/code/modules/power/solars/panel.dm
+++ b/code/modules/power/solars/panel.dm
@@ -246,7 +246,7 @@
 		icon_state = "tracker"
 		if(stat & BROKEN)
 			icon_state += "-b"
-		else if(obscured)
+		else if(obscured || !sun)
 			icon_state += "-dark"
 		else
 			glow.transform = turn(matrix(), (sun.angle + 180) % 360)


### PR DESCRIPTION
Solar Trackers would runtime during server init/roundstart until the sun subsystem was initialized.
