### PR TITLE
Ablative vest deconstructable & mechanic constructable

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -315,6 +315,7 @@
 	desc = "A vest that excels in protecting the wearer against energy projectiles."
 	icon_state = "armor_reflec"
 	item_state = "armor_reflec"
+	origin_tech = Tc_COMBAT + "=3;" + Tc_MATERIALS + "=4;"
 	species_fit = list(VOX_SHAPED, INSECT_SHAPED)
 	clothing_flags = ONESIZEFITSALL
 	blood_overlay_type = "armor"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
[tweak]
## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Gives ablative vest combat 3 and materials 4 research when deconstructed. To construct one you need combat 4 and materials 5.
This also lets you scan them as a mechanic.
![grafik](https://github.com/vgstation-coders/vgstation13/assets/132118542/bdb282da-4fdd-4ac0-bab4-27dbfe5c9a76)
Price is the same as in science except for the plastic tax, so I'm thinking this should be fine

Closes #29701

There's a lot of science-made items that don't have a tech origin... but only this one was reported so here

## Why it's good
<!-- Explain why you think these changes are good. -->
Closes an issue, gives mechanics yet another item to scan and build

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Ablative deconstructable by science for combat 3 and materials 4
 * tweak: Ablative vest can be scanned by mechanics
