### PR TITLE
RGB gamer lights

### DIFF
--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -359,6 +359,15 @@ var/global/list/obj/machinery/light/alllights = list()
 		to_chat(user, "You insert \the [W] into \the [src], allowing multitool customization.")
 		return
 	
+	
+	if(rgb_upgrade && iscrowbar(W))
+		W.playtoolsound(src, 75)
+		user.visible_message("[user.name] removes some plastic from \the [src].", \
+			"You remove some plastic from \the [src].", "You hear a noise.")
+		rgb_upgrade = FALSE
+		current_bulb.brightness_color = initial(current_bulb.brightness_color)
+		drop_stack(/obj/item/stack/sheet/mineral/plastic, get_turf(src), 1, user)
+		return
 	user.delayNextAttack(8)
 	
 	// attempt to insert light
@@ -389,16 +398,8 @@ var/global/list/obj/machinery/light/alllights = list()
 				to_chat(user, "This type of light requires a [fitting].")
 				return
 
-	if(rgb_upgrade && iscrowbar(W))
-		W.playtoolsound(src, 75)
-		user.visible_message("[user.name] removes some plastic from \the [src].", \
-			"You remove some plastic from \the [src].", "You hear a noise.")
-		rgb_upgrade = FALSE
-		current_bulb.brightness_color = initial(current_bulb.brightness_color)
-		drop_stack(/obj/item/stack/sheet/mineral/plastic, get_turf(src), 1, user)
-		return
 		// attempt to break the light
-		//If xenos decide they want to smash a light bulb with a toolbox, who am I to stop them? /N
+		//If xenos decide they want to smash a light bulb with a toolbox, who am I to stop them?
 
 	else if(current_bulb && current_bulb.status != LIGHT_BROKEN)
 

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -325,8 +325,8 @@ var/global/list/obj/machinery/light/alllights = list()
 
 /obj/machinery/light/attackby(obj/item/W, mob/living/user)
 	if(ismultitool(W)) //RGB gamer lights
-		if(rgb_upgrade)
-			to_chat(user, "There's nothing to connect \the [W] to on \the [src]")
+		if(!rgb_upgrade)
+			to_chat(user, "There's nothing to connect \the [W] to on \the [src].")
 			return
 		var/which = alert(user, "What would you like to change?", "RGB Gamer lights", "Color", "Power", "Range")
 		var/list/choice_color_list = list("custom") + light_colors
@@ -389,11 +389,18 @@ var/global/list/obj/machinery/light/alllights = list()
 				to_chat(user, "This type of light requires a [fitting].")
 				return
 
+	if(rgb_upgrade && iscrowbar(W))
+		W.playtoolsound(src, 75)
+		user.visible_message("[user.name] removes some plastic from \the [src].", \
+			"You remove some plastic from \the [src].", "You hear a noise.")
+		rgb_upgrade = FALSE
+		current_bulb.brightness_color = initial(current_bulb.brightness_color)
+		drop_stack(/obj/item/stack/sheet/mineral/plastic, get_turf(src), 1, user)
+		return
 		// attempt to break the light
 		//If xenos decide they want to smash a light bulb with a toolbox, who am I to stop them? /N
 
 	else if(current_bulb && current_bulb.status != LIGHT_BROKEN)
-
 
 		user.do_attack_animation(src, W)
 		if(prob(1+W.force * 5))
@@ -413,14 +420,6 @@ var/global/list/obj/machinery/light/alllights = list()
 			to_chat(user, "You hit the light!")
 	// attempt to deconstruct / stick weapon into light socket
 	else if(!current_bulb)
-		if(rgb_upgrade && iscrowbar(W))
-			W.playtoolsound(src, 75)
-			user.visible_message("[user.name] removes some plastic from \the [src].", \
-				"You remove some plastic from \the [src].", "You hear a noise.")
-			rgb_upgrade = FALSE
-			current_bulb.brightness_color = initial(current_bulb.brightness_color)
-			drop_stack(/obj/item/stack/sheet/mineral/plastic, get_turf(src), 1, user)
-			return
 		if(W.is_wirecutter(user)) //If it's a wirecutter take out the wires
 			W.playtoolsound(src, 75)
 			user.visible_message("[user.name] removes \the [src]'s wires.", \

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -328,7 +328,7 @@ var/global/list/obj/machinery/light/alllights = list()
 		if(!rgb_upgrade)
 			to_chat(user, "There's nothing to connect \the [W] to on \the [src].")
 			return
-		var/which = alert(user, "What would you like to change?", "RGB Gamer lights", "Color", "Power", "Range")
+		var/which = alert(user, "What would you like to change?", "Programmable Lights", "Color", "Power", "Range")
 		var/list/choice_color_list = list("custom") + light_colors
 
 		switch(which)

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -349,12 +349,12 @@ var/global/list/obj/machinery/light/alllights = list()
 		update()
 		return
 		
-	if (istype(W,/obj/item/stack/sheet/mineral/plastic))
+	if (istype(W,/obj/item/stack/light_w))
 		if(rgb_upgrade)
 			to_chat(user, "This light is already customizable.")
 			return
-		var/obj/item/stack/sheet/mineral/plastic/plasticsheet = W
-		plasticsheet.use(1)
+		var/obj/item/stack/light_w/lightstack = W
+		lightstack.use(1)
 		rgb_upgrade = TRUE
 		to_chat(user, "You insert \the [W] into \the [src], allowing multitool customization.")
 		return
@@ -366,7 +366,7 @@ var/global/list/obj/machinery/light/alllights = list()
 			"You remove some plastic from \the [src].", "You hear a noise.")
 		rgb_upgrade = FALSE
 		current_bulb.brightness_color = initial(current_bulb.brightness_color)
-		drop_stack(/obj/item/stack/sheet/mineral/plastic, get_turf(src), 1, user)
+		drop_stack(/obj/item/stack/light_w, get_turf(src), 1, user)
 		return
 	user.delayNextAttack(8)
 	

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -2,6 +2,23 @@
 //
 // consists of light fixtures (/obj/machinery/light) and light tube/bulb items (/obj/item/weapon/light)
 
+var/global/list/light_colors = list(
+	"default" = LIGHT_COLOR_TUNGSTEN, \
+	"default (HE)" = LIGHT_COLOR_HALOGEN, \
+	"red" = LIGHT_COLOR_RED, \
+	"green" = LIGHT_COLOR_GREEN, \
+	"blue" = LIGHT_COLOR_BLUE, \
+	"cyan" = LIGHT_COLOR_CYAN, \
+	"pink" = LIGHT_COLOR_PINK, \
+	"yellow" = LIGHT_COLOR_YELLOW, \
+	"brown" = LIGHT_COLOR_BROWN, \
+	"orange" = LIGHT_COLOR_ORANGE, \
+	"purple" = LIGHT_COLOR_PURPLE, \
+	"fire" = LIGHT_COLOR_FIRE, \
+	"flare" = LIGHT_COLOR_FLARE, \
+	"slime" = LIGHT_COLOR_SLIME_LAMP, \
+	)
+
 /obj/machinery/light_construct
 	name = "light fixture frame"
 	desc = "A light fixture under construction."
@@ -121,6 +138,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	var/obj/item/weapon/light/current_bulb = null
 	var/spawn_with_bulb = /obj/item/weapon/light/tube
 	var/fitting = "tube"
+	var/rgb_upgrade = FALSE //add plastic to enable RGB mode
 
 	// No ghost interaction.
 	ghost_read=0
@@ -229,6 +247,8 @@ var/global/list/obj/machinery/light/alllights = list()
 		switch(current_bulb.status)		// set icon_states
 			if(LIGHT_OK)
 				icon_state = "l[current_bulb.base_state][on]"
+				if(on)
+					color = current_bulb.brightness_color
 			if(LIGHT_BURNED)
 				icon_state = "l[current_bulb.base_state]-burned"
 				on = 0
@@ -288,6 +308,8 @@ var/global/list/obj/machinery/light/alllights = list()
 // examine verb
 /obj/machinery/light/examine(mob/user)
 	..()
+	if(rgb_upgrade)
+		to_chat(user, "<span class='info'>it is NT-35322 RGB compliant!</span>")
 	if(current_bulb)
 		switch(current_bulb.status)
 			if(LIGHT_OK)
@@ -302,8 +324,43 @@ var/global/list/obj/machinery/light/alllights = list()
 // attack with item - insert light (if right type), otherwise try to break the light
 
 /obj/machinery/light/attackby(obj/item/W, mob/living/user)
-	user.delayNextAttack(8)
+	if(ismultitool(W)) //RGB gamer lights
+		if(rgb_upgrade)
+			to_chat(user, "There's nothing to connect \the [W] to on \the [src]")
+			return
+		var/which = alert(user, "What would you like to change?", "RGB Gamer lights", "Color", "Power", "Range")
+		var/list/choice_color_list = list("custom") + light_colors
 
+		switch(which)
+			if("Color")
+				var/colorchoice = input(user,"Select a color to set [src] to.","[src]") in choice_color_list
+				if(!Adjacent(user))
+					return
+				if(colorchoice == "custom")
+					current_bulb.brightness_color = input("Please select a color for the tile.", "[src]") as color
+				else
+					current_bulb.brightness_color = choice_color_list[colorchoice]
+			if("Power")
+				var/new_power = input("Desired power (must be below [initial(current_bulb.brightness_power)]): ", "Light bulb power", "") as num
+				current_bulb.brightness_power = clamp(new_power, 0, initial(current_bulb.brightness_power))
+			if("Range")
+				var/new_range = input("Desired range (must be below [initial(current_bulb.brightness_range)]): ", "Light bulb range", "") as num
+				current_bulb.brightness_range = clamp(new_range, 0, initial(current_bulb.brightness_range))
+		update()
+		return
+		
+	if (istype(W,/obj/item/stack/sheet/mineral/plastic))
+		if(rgb_upgrade)
+			to_chat(user, "This light is already customizable.")
+			return
+		var/obj/item/stack/sheet/mineral/plastic/plasticsheet = W
+		plasticsheet.use(1)
+		rgb_upgrade = TRUE
+		to_chat(user, "You insert \the [W] into \the [src], allowing multitool customization.")
+		return
+	
+	user.delayNextAttack(8)
+	
 	// attempt to insert light
 	if(istype(W, /obj/item/weapon/light))
 		if(current_bulb)
@@ -356,6 +413,14 @@ var/global/list/obj/machinery/light/alllights = list()
 			to_chat(user, "You hit the light!")
 	// attempt to deconstruct / stick weapon into light socket
 	else if(!current_bulb)
+		if(rgb_upgrade && iscrowbar(W))
+			W.playtoolsound(src, 75)
+			user.visible_message("[user.name] removes some plastic from \the [src].", \
+				"You remove some plastic from \the [src].", "You hear a noise.")
+			rgb_upgrade = FALSE
+			current_bulb.brightness_color = initial(current_bulb.brightness_color)
+			drop_stack(/obj/item/stack/sheet/mineral/plastic, get_turf(src), 1, user)
+			return
 		if(W.is_wirecutter(user)) //If it's a wirecutter take out the wires
 			W.playtoolsound(src, 75)
 			user.visible_message("[user.name] removes \the [src]'s wires.", \


### PR DESCRIPTION
Allows you to add wired glass tiles to light fixtures to customize the light colors with a multitool.

![prompt](https://github.com/vgstation-coders/vgstation13/assets/8468269/a5bfc8ce-7d22-4586-8e1d-e10b7a17f7f8) 
![lights](https://github.com/vgstation-coders/vgstation13/assets/8468269/f90e0f2f-64ca-4320-8708-80711e0b756b)

if you know of any more relevant issues or feature requests that can be closed, lemme know and I'll add them in here

:cl:
 * experiment: You can now customize lights! Add some wired glass to a light fixture, then use a multitool on it.

