### PR TITLE
Fixes Welder Targetting Eyes and Mouth vs Human Mobs

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -382,7 +382,9 @@
 		if(can_operate(M, user, src))
 			if(do_surgery(M, user, src))
 				return
-		var/datum/organ/external/S = M:organs_by_name[user.zone_sel.selecting]
+		//hasorgans() literally just calls ishuman(), which is a typecheck for...
+		var/mob/living/carbon/human/H = M
+		var/datum/organ/external/S = H.get_organ(user.zone_sel.selecting)
 		if (!S)
 			return
 		if(!(S.status & ORGAN_ROBOT) || user.a_intent != I_HELP)


### PR DESCRIPTION
# Another Xivvis Special
Imagine you're in a desperate situation. You gobba fight. All you've got is a welding tool. You turn it on and dive upon the innocent assistant, but you click them and nothing happens. You've made the classic blunder.

You've attacked someone with a welding tool while targetting the eyes or mouth.

## What this does
Fixes #18332. Now, if you target the eyes or mouth of a human-like target with a welding tool in a non-surgery situation, you actually attack.
Old:
![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/c186f840-7d0a-4956-90d9-5ac70d2225cf)

New:
![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/0e2171b0-2f49-4fd5-973a-bfd93f3faaf7)

## Why it's good
lmao welding a dude's teeth out

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Welding tools now properly attack the head while targetting the eyes and mouth, instead of doing nothing.

[bugfix][tested]