### PR TITLE
Fixes Maria's Hive not spawning on the asteroid.

### DIFF
--- a/code/modules/mining/surprises/vg.dm
+++ b/code/modules/mining/surprises/vg.dm
@@ -119,6 +119,13 @@
 	file_path = "maps/randomvaults/mining/angie_lair.dmm"
 	can_rotate = TRUE
 
+/datum/map_element/mining_surprise/maria
+	name = "Maria's hive"
+	desc = "Writhing ground, twisted veins, the feeling of utter helplessness is normal. Do not look away."
+
+	file_path = "maps/randomvaults/mining/mariahive.dmm"
+	can_rotate = TRUE
+
 /datum/map_element/mining_surprise/mine_bar
 	name = "The Buried Bar"
 	desc = "A miner walks into a bar, Dusky says \"Sorry, you're too young to be served\"."


### PR DESCRIPTION
After playing miner for a good while, and asking players if they had seen it, it seemed nobody had seen Maria's Hive spawn in-game ever. Looking into Angie's Lair, it seems I had forgotten to add the mining_surprise define for it.
[hotfix][oversight][bugfix]
:cl:
 * bugfix: Maria's Hive (The Hivelord Queen) can now properly spawn in the asteroid.