### PR TITLE
Further Rapid Cable Layer Quality of Life and Tweaks

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -83,7 +83,7 @@
 		ShiftClickOn(A)
 		return
 	if(modifiers["alt"]) // alt and alt-gr (rightalt)
-		if (held_item.AltFrom(A,src))
+		if (held_item.AltFrom(A,src,A.Adjacent(src, MAX_ITEM_DEPTH),params))
 			return
 		AltClickOn(A)
 		return

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -69,6 +69,8 @@
 		build_click(src, client.buildmode, params, A)
 		return
 
+	var/obj/item/held_item = get_active_hand()
+
 	var/list/modifiers = params2list(params)
 	INVOKE_EVENT(src, /event/clickon, "user" = src,	"modifiers" = modifiers, "target" = A)
 	if(modifiers["middle"])
@@ -81,6 +83,8 @@
 		ShiftClickOn(A)
 		return
 	if(modifiers["alt"]) // alt and alt-gr (rightalt)
+		if (held_item.AltFrom(A,src))
+			return
 		AltClickOn(A)
 		return
 	if(modifiers["ctrl"])
@@ -118,7 +122,6 @@
 			throw_item(A)
 		return
 
-	var/obj/item/held_item = get_active_hand()
 	var/item_attack_delay = 0
 
 	if(held_item == A)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -83,7 +83,7 @@
 		ShiftClickOn(A)
 		return
 	if(modifiers["alt"]) // alt and alt-gr (rightalt)
-		if (held_item.AltFrom(A,src,A.Adjacent(src, MAX_ITEM_DEPTH),params))
+		if (held_item && held_item.AltFrom(A,src,A.Adjacent(src, MAX_ITEM_DEPTH),params))
 			return
 		AltClickOn(A)
 		return

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -18,6 +18,8 @@
 	if(incapacitated() || lockdown)
 		return
 
+	var/obj/item/W = get_active_hand()
+
 	var/list/modifiers = params2list(params)
 	if(modifiers["middle"] && modifiers["shift"])
 		MiddleShiftClickOn(A)
@@ -29,6 +31,8 @@
 		ShiftClickOn(A)
 		return
 	if(modifiers["alt"]) // alt and alt-gr (rightalt)
+		if (W && W.AltFrom(A,src,A.Adjacent(src, MAX_ITEM_DEPTH),params))
+			return
 		AltClickOn(A)
 		return
 	if(modifiers["ctrl"])
@@ -49,8 +53,6 @@
 
 	if(INVOKE_EVENT(src, /event/uattack, "atom" = A))
 		return
-
-	var/obj/item/W = get_active_hand()
 
 	// Cyborgs have no range-checking unless there is item use
 	if(!W)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -613,7 +613,7 @@ var/global/objects_thrown_when_explode = FALSE
 					else
 						return CANNOT_EQUIP
 
-				
+
 
 				return CAN_EQUIP
 			if(slot_back)
@@ -1748,6 +1748,9 @@ var/global/list/image/blood_overlays = list()
 		playsound(A, surgerysound, volume, vary = TRUE)
 
 /obj/item/proc/NoiseDampening()	// checked on headwear by flashbangs
+	return FALSE
+
+/obj/item/proc/AltFrom(var/atom/A,var/mob/user)
 	return FALSE
 
 /obj/item/get_heat_conductivity()

--- a/code/game/objects/items/weapons/RCL.dm
+++ b/code/game/objects/items/weapons/RCL.dm
@@ -71,6 +71,7 @@
 	if (!loaded)
 		loaded = cable
 		loaded.max_amount = max_amount //We store a lot.
+		loaded.forceMove(src)
 	else if (loaded.amount >= max_amount)
 		to_chat(user, "\The [src] cannot hold any further length of cable.")
 		return FALSE

--- a/code/game/objects/items/weapons/RCL.dm
+++ b/code/game/objects/items/weapons/RCL.dm
@@ -42,13 +42,9 @@
 	if(istype(W,/obj/item/stack/cable_coil))
 		if(!loaded)
 			if(user.drop_item(W,src))
-				loaded = W
-				loaded.max_amount = max_amount //We store a lot.
+				add_cable(W,user)
 		else
-			loaded.preattack(W,user,1)
-		update_icon()
-		playsound(loc, 'sound/items/zip.ogg', 20, 1)
-		to_chat(user, "<span class='notice'>You add the cables to the [src]. It now contains [loaded.amount].</span>")
+			add_cable(W,user)
 	else if(W.is_screwdriver(user))
 		if(!loaded)
 			to_chat(user, "<span class='warning'>There are no wires to remove.</span>")
@@ -70,6 +66,20 @@
 		update_icon()
 	else
 		..()
+
+/obj/item/weapon/rcl/proc/add_cable(var/obj/item/stack/cable_coil/cable, var/mob/user)
+	if (!loaded)
+		loaded = cable
+		loaded.max_amount = max_amount //We store a lot.
+	else if (loaded.amount >= max_amount)
+		to_chat(user, "\The [src] cannot hold any further length of cable.")
+		return FALSE
+	else
+		loaded.preattack(cable,user,1)
+	update_icon()
+	playsound(loc, 'sound/items/zip.ogg', 20, 1)
+	to_chat(user, "<span class='notice'>You add the cables to the [src]. It now contains [loaded.amount].</span>")
+	return TRUE
 
 /obj/item/weapon/rcl/update_icon()
 	overlays.len = 0
@@ -116,21 +126,30 @@
 	if(!loaded || !loaded.amount)
 		to_chat(user, "<span class='warning'>There isn't any cable left inside.</span>")
 		return
-
-	var/turf/T = get_turf(src)
 	var/turf/U = get_turf(target)
+	var/list/modifiers = params2list(click_parameters)
+	if(modifiers["alt"])
+		collect_loose_cables(U)
+		return
+	var/turf/T = get_turf(src)
 	placed_stub = FALSE
-
 	if (connect_two_floors(user, T, U, TRUE))
 		playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		active = TRUE
 		set_move_event(user)
 		update_icon()
 
+/obj/item/weapon/rcl/proc/collect_loose_cables(var/turf/target_floor,var/mob/user)
+	for (var/obj/item/stack/cable_coil/cable in target_floor)
+		if (!add_cable(cable,user))
+			return
+	to_chat(user, "<span class='warning'>No loose cables to collect on that tile.</span>")
+
+
 /obj/item/weapon/rcl/proc/connect_two_floors(var/mob/user, var/turf/first_floor, var/turf/second_floor, var/clicked = FALSE)
 	if (!first_floor || !second_floor)
 		return
-	if(!first_floor.can_place_cables(TRUE) || !second_floor.can_place_cables(TRUE))
+	if(!first_floor.can_place_cables(TRUE) && !second_floor.can_place_cables(TRUE))
 		if (user)
 			to_chat(user, "<span class='warning'>You can't place cables between here and there.</span>")
 			if (active)
@@ -154,6 +173,8 @@
 	return used
 
 /obj/item/weapon/rcl/proc/connect_toward(var/mob/user, var/turf/start_floor, var/turf/target_floor, var/new_stubs = FALSE)
+	if (!start_floor.can_place_cables(TRUE))
+		return
 	if(!loaded || !loaded.amount)
 		return FALSE
 	//first we search for a node on that tile
@@ -212,6 +233,8 @@
 
 		if(valid_node.d2 & (valid_node.d2 - 1)) //If the cable is layed diagonally, check the others 2 possible directions
 			valid_node.mergeDiagonalsNetworks(valid_node.d2)
+
+		placed_stub = TRUE//we didn't place a stub but we did connect with one, so we don't want the other tile to make a stub toward us if they already have a full wire toward us
 
 		loaded.use(1)
 		return TRUE

--- a/code/game/objects/items/weapons/RCL.dm
+++ b/code/game/objects/items/weapons/RCL.dm
@@ -126,12 +126,8 @@
 	if(!loaded || !loaded.amount)
 		to_chat(user, "<span class='warning'>There isn't any cable left inside.</span>")
 		return
-	var/turf/U = get_turf(target)
-	var/list/modifiers = params2list(click_parameters)
-	if(modifiers["alt"])
-		collect_loose_cables(U)
-		return
 	var/turf/T = get_turf(src)
+	var/turf/U = get_turf(target)
 	placed_stub = FALSE
 	if (connect_two_floors(user, T, U, TRUE))
 		playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
@@ -139,11 +135,12 @@
 		set_move_event(user)
 		update_icon()
 
-/obj/item/weapon/rcl/proc/collect_loose_cables(var/turf/target_floor,var/mob/user)
+/obj/item/weapon/rcl/AltFrom(var/turf/target_floor,var/mob/user)//Returning null so we can also check tile content
 	for (var/obj/item/stack/cable_coil/cable in target_floor)
 		if (!add_cable(cable,user))
 			return
 	to_chat(user, "<span class='warning'>No loose cables to collect on that tile.</span>")
+	return
 
 
 /obj/item/weapon/rcl/proc/connect_two_floors(var/mob/user, var/turf/first_floor, var/turf/second_floor, var/clicked = FALSE)

--- a/code/game/objects/items/weapons/RCL.dm
+++ b/code/game/objects/items/weapons/RCL.dm
@@ -135,7 +135,9 @@
 		set_move_event(user)
 		update_icon()
 
-/obj/item/weapon/rcl/AltFrom(var/turf/target_floor,var/mob/user)//Returning null so we can also check tile content
+/obj/item/weapon/rcl/AltFrom(var/turf/target_floor,var/mob/user, var/proximity_flag, var/click_parameters)//Returning null so we can also check tile content
+	if(proximity_flag == 0) // not adjacent
+		return
 	for (var/obj/item/stack/cable_coil/cable in target_floor)
 		if (!add_cable(cable,user))
 			return


### PR DESCRIPTION
This PR adds the new AltFrom() proc that lets coders give items a different behaviour on Alt Click.

:cl:
* tweak: RCL no longer entirely prevent cable placement between two tiles if at least one of the tiles is valid (cables will still only be placed on the valid tile)
* bugfix: Fixed a specific case where the RCL would place an extra unwanted node on your tile after clicking an adjacent tile that already had a node despite your tile already having a full wire going toward that tile.
* rscadd: AltClicking an adjacent tile with the RCL equipped will cause it to try and absorb all the loose cable pieces on that tile