### PR TITLE
Adds the ayy tiles to the tile painter

### DIFF
--- a/code/modules/RCD/schematics/tile.dm
+++ b/code/modules/RCD/schematics/tile.dm
@@ -320,6 +320,9 @@
 /datum/rcd_schematic/tile/tatami
 	name = "Tatami"
 
+/datum/rcd_schematic/tile/mothership
+	name = "Mothership"
+
 /datum/rcd_schematic/tile/ss13_logo
 	name = "SS13 logo"
 
@@ -627,6 +630,12 @@ var/global/list/paint_variants = list(
 		new /datum/paint_info(DIR_ONE,		"tatami-yellow-2mat-verti"),
 		new /datum/paint_info(DIR_ORTHO,	"tatami-yellow-3mat"),
 		new /datum/paint_info(DIR_ONE,		"tatami-yellow-spiral"),
+	),
+
+	"Mothership" = list(
+		new /datum/paint_info(DIR_ONE,		"alien_tile1"),
+		new /datum/paint_info(DIR_ONE,		"alien_tile_worn"),
+		new /datum/paint_info(DIR_ONE,		"alien_tile_fancy")
 	),
 
 	"SS13 logo" = list(


### PR DESCRIPTION
## What this does
Adds the mothership tiles to the tile painter, cause I think they look cool and would like to make an ayy themed bar one of these days.
## Why it's good
The aforementioned ayy themes for any building project.
## Changelog
:cl:
 * rscadd: The tile painter can now paint tiles into the mothership designs.