### PR TITLE
[revive] Fix players seeing lights being toggled on or off at roundstart

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -526,7 +526,7 @@
 	var/areapathtext = "[get_area(AM).type]"
 	var/secondslash = findtext(areapathtext, "/", 2)
 	if(secondslash)
-		var/thirdslash =  findtext(areapathtext, "/", secondslash + 1)
+		var/thirdslash = findtext(areapathtext, "/", secondslash + 1)
 		if(thirdslash)
 			return typesof(text2path(copytext(areapathtext, 1, thirdslash)))
 	return typesof(text2path(areapathtext))

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -537,8 +537,8 @@
 	var/obj/item/device/flashlight/lamp/lampychan
 	for(var/obj/O in A)
 		LS = O
-		lampychan = O
 		lightykun = O
+		lampychan = O
 		if(istype(LS))
 			LS.toggle_switch(1, playsound = FALSE)
 		else if(istype(lightykun))

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -521,3 +521,12 @@
 		if(istype(A,department_type))
 			department_areas += A
 	return department_areas
+
+/proc/get_department_area_typepaths(atom/AM)
+	var/areapathtext = "[get_area(AM).type]"
+	var/secondslash = findtext(areapathtext, "/", 2)
+	if(secondslash)
+		var/thirdslash =  findtext(areapathtext, "/", secondslash + 1)
+		if(thirdslash)
+			return typesof(text2path(copytext(areapathtext, 1, thirdslash)))
+	return typesof(text2path(areapathtext))

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -530,3 +530,19 @@
 		if(thirdslash)
 			return typesof(text2path(copytext(areapathtext, 1, thirdslash)))
 	return typesof(text2path(areapathtext))
+
+/proc/activate_lights_in_area(area/A)
+	var/obj/machinery/light_switch/LS
+	var/obj/machinery/light/lightykun
+	var/obj/item/device/flashlight/lamp/lampychan
+	for(var/obj/O in A)
+		LS = O
+		lampychan = O
+		lightykun = O
+		if(istype(LS))
+			LS.toggle_switch(1, playsound = FALSE)
+		else if(istype(lightykun))
+			lightykun.on = 1
+			lightykun.update()
+		else if(istype(lampychan))
+			lampychan.toggle_onoff(1)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -530,19 +530,3 @@
 		if(thirdslash)
 			return typesof(text2path(copytext(areapathtext, 1, thirdslash)))
 	return typesof(text2path(areapathtext))
-
-/proc/activate_lights_in_area(area/A)
-	var/obj/machinery/light_switch/LS
-	var/obj/machinery/light/lightykun
-	var/obj/item/device/flashlight/lamp/lampychan
-	for(var/obj/O in A)
-		LS = O
-		lightykun = O
-		lampychan = O
-		if(istype(LS))
-			LS.toggle_switch(1, playsound = FALSE)
-		else if(istype(lightykun))
-			lightykun.on = 1
-			lightykun.update()
-		else if(istype(lampychan))
-			lampychan.toggle_onoff(1)

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -22,7 +22,7 @@ var/list/lighting_update_overlays  = list() // List of lighting overlays queued 
 	create_all_lighting_overlays()
 	..()
 
-/datum/subsystem/lighting/fire(resumed=FALSE)
+/datum/subsystem/lighting/fire(resumed=FALSE, allow_breaks=TRUE)
 	var/real_tick_limit = CURRENT_TICKLIMIT
 	CURRENT_TICKLIMIT = (real_tick_limit - world.tick_usage)/3
 	var/i = 0
@@ -41,7 +41,7 @@ var/list/lighting_update_overlays  = list() // List of lighting overlays queued 
 		L.force_update = FALSE
 		L.needs_update = FALSE
 
-		if (TICK_CHECK)
+		if (TICK_CHECK && allow_breaks)
 			break
 	if (i)
 		lighting_update_lights.Cut(1, i+1)
@@ -54,7 +54,7 @@ var/list/lighting_update_overlays  = list() // List of lighting overlays queued 
 
 		C.update_overlays()
 		C.needs_update = FALSE
-		if (TICK_CHECK)
+		if (TICK_CHECK && allow_breaks)
 			break
 	if (i)
 		lighting_update_corners.Cut(1, i+1)
@@ -70,7 +70,7 @@ var/list/lighting_update_overlays  = list() // List of lighting overlays queued 
 
 		O.update_overlay()
 		O.needs_update = FALSE
-		if (TICK_CHECK)
+		if (TICK_CHECK && allow_breaks)
 			break
 	if (i)
 		lighting_update_overlays.Cut(1, i+1)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -216,7 +216,7 @@ var/datum/controller/gameticker/ticker
 		CHECK_TICK
 
 	//Now that we have all of the occupied areas, we handle the lights being on or off, before actually putting the players into their bodies.
-	handle_lights(roundstart_occupied_areas)
+	activate_area_lights(roundstart_occupied_areas)
 	//Force the lighting subsystem to update.
 	SSlighting.fire(FALSE, FALSE)
 
@@ -661,7 +661,7 @@ var/datum/controller/gameticker/ticker
 			roles += player.mind.assigned_role
 	return roles
 
-/datum/controller/gameticker/proc/handle_lights(list/areas_to_turn_lights_on)
+/datum/controller/gameticker/proc/activate_area_lights(list/areas_to_turn_lights_on)
 	for(var/area/this_area in areas_to_turn_lights_on)
 		for(var/obj/machinery/light_switch/LS in this_area)
 			LS.toggle_switch(1, playsound = FALSE)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -662,15 +662,6 @@ var/datum/controller/gameticker/ticker
 			roles += player.mind.assigned_role
 	return roles
 
-/datum/controller/gameticker/proc/activate_lights_in_area(area/A)
-	for(var/obj/machinery/light_switch/LS in A)
-		LS.toggle_switch(1, playsound = FALSE)
-	for(var/obj/machinery/light/lightykun in A)
-		lightykun.on = 1
-		lightykun.update()
-	for(var/obj/item/device/flashlight/lamp/lampychan in A)
-		lampychan.toggle_onoff(1)
-
 /datum/controller/gameticker/proc/post_roundstart()
 	//Handle all the cyborg syncing
 	var/list/active_ais = active_ais()

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -215,6 +215,7 @@ var/datum/controller/gameticker/ticker
 
 	//Now that we have all of the occupied areas, we handle the lights being on or off, before actually putting the players into their bodies.
 	if(roundstart_occupied_area_paths.len)
+		var/tick = get_game_time()
 		var/obj/machinery/light_switch/LS
 		var/obj/machinery/light/lightykun
 		var/obj/item/device/flashlight/lamp/lampychan
@@ -233,6 +234,7 @@ var/datum/controller/gameticker/ticker
 						lampychan.toggle_onoff(1)
 		//Force the lighting subsystem to update.
 		SSlighting.fire(FALSE, FALSE)
+		log_admin("Turned the lights on in [(get_game_time() - tick) / 10] seconds.")
 
 	var/list/clowns = list()
 	var/already_an_ai = FALSE

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -215,9 +215,22 @@ var/datum/controller/gameticker/ticker
 
 	//Now that we have all of the occupied areas, we handle the lights being on or off, before actually putting the players into their bodies.
 	if(roundstart_occupied_area_paths.len)
+		var/obj/machinery/light_switch/LS
+		var/obj/machinery/light/lightykun
+		var/obj/item/device/flashlight/lamp/lampychan
 		for(var/area/A in areas)
 			if(A.type in roundstart_occupied_area_paths)
-				activate_lights_in_area(A)
+				for(var/obj/O in A)
+					LS = O
+					lightykun = O
+					lampychan = O
+					if(istype(LS))
+						LS.toggle_switch(1, playsound = FALSE)
+					else if(istype(lightykun))
+						lightykun.on = 1
+						lightykun.update()
+					else if(istype(lampychan))
+						lampychan.toggle_onoff(1)
 		//Force the lighting subsystem to update.
 		SSlighting.fire(FALSE, FALSE)
 

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -8,7 +8,7 @@
 	icon_state = "light1"
 	anchored = 1.0
 	var/buildstage = 2
-	var/on = 1
+	var/on = 0
 	var/image/overlay
 
 /obj/machinery/light_switch/supports_holomap()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -196,7 +196,7 @@
 	flags = FPRINT
 	siemens_coefficient = 1
 	starting_materials = null
-	on = 1	//Lamps start on but are turned off unless someone spawns in the same department as them at roundstart.
+	on = 0	//Lamps start off but are turned on if someone spawns in the same department as them at roundstart.
 	var/drawspower = TRUE
 	var/datum/power_connection/consumer/pwrconn //the on var means the lamp switch is turned on but the area also has to be powered for it to produce light
 
@@ -384,7 +384,6 @@
 	autoignition_temperature = AUTOIGNITION_ORGANIC
 	var/brightness_max = 6
 	var/brightness_min = 2
-	on = 0
 	drawspower = FALSE //slime lamps don't draw power from the area apc
 
 	breakable_fragments = null

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -799,11 +799,11 @@
 		return new_character
 	else
 		var/mob/living/silicon/robot/new_character
-		forceMove(spawn_loc)
 		if(type == "Mobile MMI")
 			new_character = MoMMIfy()
 		else
 			new_character = Robotize()
+		new_character.forceMove(spawn_loc)
 		new_character.mmi.create_identity(prefs) //Uses prefs to create a brain mob
 
 		return new_character


### PR DESCRIPTION
## What this does
revival of #35150 with some speedups to the overall process
> This makes it so all the light, lightswitch, and lamp on-or-off toggling that depends on whether or not the department is occupied at roundstart, occurs before players are transferred into their bodies, 


https://github.com/vgstation-coders/vgstation13/assets/149450117/de889ed0-d188-476b-87f8-82902376270f



## Why it's good
no more seeing lights flicking on at roundstart, even if you force start round immediatelly on local testing server
:cl:
 * bugfix: Fixed being able to see lights toggling at roundstart based on crew occupancy.

