### PR TITLE
Bartender librarian and cargo tech no longer spawn with plastic bags in their hands

### DIFF
--- a/code/datums/outfit/cargo.dm
+++ b/code/datums/outfit/cargo.dm
@@ -172,7 +172,6 @@
 
 /datum/outfit/cargo_tech/post_equip(var/mob/living/carbon/human/H)
 	..()
-	H.put_in_hands(new /obj/item/weapon/storage/bag/plasticbag(H))
 
 // -- Shaft Miner
 

--- a/code/datums/outfit/civilian.dm
+++ b/code/datums/outfit/civilian.dm
@@ -117,7 +117,6 @@
 
 /datum/outfit/bartender/post_equip(var/mob/living/carbon/human/H)
 	..()
-	H.put_in_hands(new /obj/item/weapon/storage/bag/plasticbag(H))
 	H.dna.SetSEState(SOBERBLOCK,1)
 	H.check_mutations = M_CHECK_JOB
 
@@ -589,8 +588,6 @@
 
 /datum/outfit/librarian/post_equip(var/mob/living/carbon/human/H)
 	..()
-	var/obj/item/weapon/storage/bag/plasticbag/P = new /obj/item/weapon/storage/bag/plasticbag(H)
-	H.put_in_hands(P)
 	var/list/new_languages = list()
 	for(var/L in all_languages)
 		var/datum/language/lang = all_languages[L]


### PR DESCRIPTION
## What this does
Makes it so bartender librarian and cargo tech no longer spawn with plastic bags in their hands
now only assistants start with it

## Why it's good
It feels like trashy to be holding a plastic bag like that as if its part of your job. a suave bartender or a well read librarian holding a crinkly plastic bag as like their uniform just feels unaesthetic and doesn't make sense
i usually throw these out at roundstart and they just feel like garbage and clutter

## Changelog
:cl:
 * tweak: Bartender, librarian, and cargo tech no longer spawn with plastic bags in their hands.
