### PR TITLE
Bridge officer and lawyer don't have the green glow sticks clipped to them at roundstart

### DIFF
--- a/code/datums/outfit/civilian.dm
+++ b/code/datums/outfit/civilian.dm
@@ -719,11 +719,10 @@
 /datum/outfit/iaa/post_equip(var/mob/living/carbon/human/H)
 	..()
 	H.put_in_hands(new /obj/item/weapon/storage/briefcase/centcomm(H))
-	equip_accessory(H, /obj/item/clothing/accessory/glowstick/nanotrasen, /obj/item/clothing/under)
-	if(Holiday == APRIL_FOOLS_DAY)
-		if(H.mind.role_alt_title == "Lawyer" || H.mind.role_alt_title == "Bridge Officer") //Lawyers and bridge officers are exempt
-			return
-		H.set_light(1, 4, "#006400") //Dark green, RGB(0,100,0)
+	if(H.mind.role_alt_title == "Internal Affairs Agent") //Lawyers and bridge officers are exempt
+		equip_accessory(H, /obj/item/clothing/accessory/glowstick/nanotrasen, /obj/item/clothing/under)
+		if(Holiday == APRIL_FOOLS_DAY)
+			H.set_light(1, 4, "#006400") //Dark green, RGB(0,100,0)
 
 // -- Chaplain
 


### PR DESCRIPTION
## What this does
currently: IAAs get green glowsticks clipped to their uniform that make them glow green.
since bridge officers and lawyers are alt titles of IAA, they also get this
this makes it so bridge officer and lawyer don't have the green glow sticks clipped to them at roundstart

## Why it's good
the item only fits the black suit sunglasses agent with the earpeice vibes and meme
when i play a bridge officer i always have to do the chore of removing the glowstick because to me bridge officer and also lawyer seems like totally different RP roles than IAA and the glowing meme, or even MIB neuralizer meme if you think of it like that, doesn't fit at all. even if theyre in the same department technically or codewise, the way theyre played and the vibe is way different

## Changelog
:cl:
 * tweak: Bridge officers and lawyers don't have green-glowing IAA identifiers clipped to their uniforms at roundstart.
