### PR TITLE
Update laundromat_drug_lab.dmm to use the already existing stair floor sprites

### DIFF
--- a/maps/randomvaults/dungeons/laundromat_drug_lab.dmm
+++ b/maps/randomvaults/dungeons/laundromat_drug_lab.dmm
@@ -250,7 +250,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine{
-	icon_state = "leftfacingstairs2"
+	dir = 8;
+	icon_state = "ramptop"
 	},
 /area/vault/laundromat/drug_lab)
 "nN" = (
@@ -613,7 +614,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine{
-	icon_state = "leftfacingstairs1"
+	dir = 8;
+	icon_state = "rampbottom"
 	},
 /area/vault/laundromat/drug_lab)
 "PJ" = (


### PR DESCRIPTION
#35324 added two new stair sprites to floors.dmi

![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/fe4310df-9b55-4bef-9c5b-2470de7f8423)


both of which are single dir, "left facing" stairs. Even though we already 3 "4-direction" stairs icon_states, including two that would perfectly fit the role of the stairs in that vault.

![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/8897375a-c535-4043-aa2d-0002334d4323)
![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/f09bf78e-4b96-46ed-acb2-85e8ec26fbc9)

This PR replaces the vault's floors with these pre-existing stair icons so we don't clog up floors.dmi and the extra stairs can be removed later.