### PR TITLE
Adding the ability to paint on floors with brushes, and also the ability to use multiple crayons from a box while floorpainting

### DIFF
--- a/code/modules/html_interface/paintTool/custom_painting_datum.dm
+++ b/code/modules/html_interface/paintTool/custom_painting_datum.dm
@@ -33,7 +33,7 @@
 	if (istype(held_item, /obj/item/toy/crayon))
 		for (var/obj/item/weapon/storage/fancy/crayons/box in user.held_items)
 			for (var/crayon in box)
-				var/obj/item/toy/crayon/c = held_item
+				var/obj/item/toy/crayon/c = crayon
 				max_strength = PENCIL_STRENGTH_MAX
 				min_strength = PENCIL_STRENGTH_MIN
 				palette += c.mainColour

--- a/code/modules/html_interface/paintTool/custom_painting_datum.dm
+++ b/code/modules/html_interface/paintTool/custom_painting_datum.dm
@@ -31,6 +31,15 @@
 
 	// Painting with a crayon
 	if (istype(held_item, /obj/item/toy/crayon))
+		for (var/obj/item/weapon/storage/fancy/crayons/box in user.held_items)
+			for (var/crayon in box)
+				var/obj/item/toy/crayon/c = held_item
+				max_strength = PENCIL_STRENGTH_MAX
+				min_strength = PENCIL_STRENGTH_MIN
+				palette += c.mainColour
+				palette += c.shadeColour
+				base_color = c.mainColour
+
 		var/obj/item/toy/crayon/c = held_item
 		max_strength = PENCIL_STRENGTH_MAX
 		min_strength = PENCIL_STRENGTH_MIN

--- a/code/modules/painting/painting_brush.dm
+++ b/code/modules/painting/painting_brush.dm
@@ -55,3 +55,13 @@
 			paint_color = rgb(paint_color_rgb[1], paint_color_rgb[2], paint_color_rgb[3], mix_alpha_from_reagents(target.reagents.reagent_list))
 			to_chat(user, "<span class='notice'>You dip \the [name] in \the [target.name].</span>")
 		update_icon()
+
+//presumably this will allow painting on the floor, credit to Anonymous user No.453861032
+	if(istype(target, /turf/simulated)) 
+		var/turf/simulated/the_turf = target
+		var/datum/painting_utensil/p = new(user, src)
+		if (!the_turf.advanced_graffiti)
+			var/datum/custom_painting/advanced_graffiti = new(the_turf, 32, 32, base_color = "#00000000")
+			the_turf.advanced_graffiti = advanced_graffiti
+		the_turf.advanced_graffiti.interact(user, p)
+		return


### PR DESCRIPTION
closes #35300
Credit to Anonymous user No.453861032 from the thread for the coding
The purpose of this pull request is the ability to paint on floors with a brush, as well as the ability to use all the crayons in a box of crayons to draw on the floor in the advanced graffiti.

Why it's good: this is a logical extension of the painting and floor graffiti systems, so there shouldn't be any issues.

This is my first time doing any sort of pull request, so lemme know if I goofed a bit on this
Edit: added changelog

 :cl:
  - rscadd: Thanks to >>453861032, you can now paint on floors with a paintbrush.