### PR TITLE
Dynamic will now consider up to 5 non-ready players for roundstart ruleset severity

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -67,6 +67,8 @@ var/stacking_limit = 90
 	var/no_stacking = 1
 	var/classic_secret = 0
 	var/high_pop_limit = 45
+	var/count_non_ready = 1 //If on, non-ready players will still count towards ruleset eligibility
+	var/real_ready_players = 0 //Gets incremented in most cases as roundstart_pop_ready
 
 	var/list/ruleset_category_weights = list()
 	var/dynamic_weight_increment = 1
@@ -182,12 +184,16 @@ var/stacking_limit = 90
 		if (initial(DR.weight))
 			midround_rules += new rule()
 	for(var/mob/new_player/player in player_list)
-		if(player.mind && player.ready)
-			roundstart_pop_ready++
-			candidates.Add(player)
+		if(player.mind)
+			if(player.ready)
+				candidates.Add(player)
+				roundstart_pop_ready++
+				real_ready_players++
+			else if(count_non_ready) //Non-ready players will also count
+				roundstart_pop_ready++
 
-	message_admins("DYNAMIC MODE: Listing [roundstart_rules.len] round start rulesets, and [roundstart_pop_ready] players ready.")
-	log_admin("DYNAMIC MODE: Listing [roundstart_rules.len] round start rulesets, and [roundstart_pop_ready] players ready.")
+	message_admins("DYNAMIC MODE: Listing [roundstart_rules.len] round start rulesets, and [real_ready_players] players ready.")
+	log_admin("DYNAMIC MODE: Listing [roundstart_rules.len] round start rulesets, and [real_ready_players] players ready.")
 
 	distribution_mode = dynamic_chosen_mode
 	message_admins("Distribution mode is : [dynamic_chosen_mode].")
@@ -268,7 +274,7 @@ var/stacking_limit = 90
 	if (roundstart_pop_ready >= high_pop_limit)
 		message_admins("DYNAMIC MODE: Mode: High Population Override is in effect! ([roundstart_pop_ready]/[high_pop_limit]) Threat Level will have more impact on which roles will appear, and player population less.")
 		log_admin("DYNAMIC MODE: High Population Override is in effect! ([roundstart_pop_ready]/[high_pop_limit]) Threat Level will have more impact on which roles will appear, and player population less.")
-	if (roundstart_pop_ready <= 0)
+	if (real_ready_players <= 0)
 		message_admins("DYNAMIC MODE: Not a single player readied-up. The round will begin without any roles assigned.")
 		log_admin("DYNAMIC MODE: Not a single player readied-up. The round will begin without any roles assigned.")
 		return 1

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -69,6 +69,7 @@ var/stacking_limit = 90
 	var/high_pop_limit = 45
 	var/count_non_ready = 1 //If on, non-ready players will still count towards ruleset eligibility
 	var/real_ready_players = 0 //Gets incremented in most cases as roundstart_pop_ready
+	var/non_ready_count_limit = 5 //Limits the amount of non-ready players that will be counted for increasing roundstart Dynamic severity, by default 5.
 
 	var/list/ruleset_category_weights = list()
 	var/dynamic_weight_increment = 1
@@ -183,14 +184,16 @@ var/stacking_limit = 90
 		var/datum/dynamic_ruleset/midround/DR = rule
 		if (initial(DR.weight))
 			midround_rules += new rule()
+	var/non_ready_count = 0 //Keeps track and is used in limiting how many non-ready players are counted for roundstart_pop_ready
 	for(var/mob/new_player/player in player_list)
 		if(player.mind)
 			if(player.ready)
 				candidates.Add(player)
 				roundstart_pop_ready++
 				real_ready_players++
-			else if(count_non_ready) //Non-ready players will also count
+			else if(count_non_ready && !(non_ready_count >= non_ready_count_limit)) //Non-ready players will also count up to a limit
 				roundstart_pop_ready++
+				non_ready_count++
 
 	message_admins("DYNAMIC MODE: Listing [roundstart_rules.len] round start rulesets, and [real_ready_players] players ready.")
 	log_admin("DYNAMIC MODE: Listing [roundstart_rules.len] round start rulesets, and [real_ready_players] players ready.")

--- a/code/modules/unit_tests/dynamic_mode.dm
+++ b/code/modules/unit_tests/dynamic_mode.dm
@@ -30,7 +30,7 @@
 		player_list += N
 	..()
 	assert_eq(player_list.len, 5)
-	assert_eq(dynamic_mode.roundstart_pop_ready, 3)
+	assert_eq(dynamic_mode.real_ready_players, 3)
 	for(var/mob/M in player_list)
 		qdel(M)
 


### PR DESCRIPTION
**Your honor,**

![1](https://github.com/vgstation-coders/vgstation13/assets/41342767/d7adcb47-8342-44d8-b768-30c1061ef3db)
-
![2](https://github.com/vgstation-coders/vgstation13/assets/41342767/136634c0-a0f9-4e28-8465-fdb9195f9f1f)
-
![3](https://github.com/vgstation-coders/vgstation13/assets/41342767/249136ee-9c29-4b5c-ac5e-e7440ac07347)
-
![4](https://github.com/vgstation-coders/vgstation13/assets/41342767/97691d7e-0bdc-4eb6-a0c9-ec7d37fa19e6)
-
![5](https://github.com/vgstation-coders/vgstation13/assets/41342767/752722b6-879d-4f52-8fb9-a40050cae1b4)
-
![6](https://github.com/vgstation-coders/vgstation13/assets/41342767/287f205c-bd74-4428-8770-b7ec7c126584)
-
![7](https://github.com/vgstation-coders/vgstation13/assets/41342767/9046668a-6dfb-4198-99c0-fcaf159e823a)
-
![8](https://github.com/vgstation-coders/vgstation13/assets/41342767/69360553-e05c-455f-8b51-26c23196b7d9)
-
![9](https://github.com/vgstation-coders/vgstation13/assets/41342767/aaacf464-100b-4d1a-b0a0-af388c727305)
-
![10](https://github.com/vgstation-coders/vgstation13/assets/41342767/0aebd098-8a2c-4665-a78a-8c83a5ec0332)
-
![11](https://github.com/vgstation-coders/vgstation13/assets/41342767/20c2c7e9-74ae-4dc8-8402-8e7dea30c6a3)
-
![12](https://github.com/vgstation-coders/vgstation13/assets/41342767/e63260ff-0c32-4eaa-a2b3-1af4befb7202)
-
![13](https://github.com/vgstation-coders/vgstation13/assets/41342767/4fd5ea98-d0b0-4047-b7b6-bb8c45125dfd)
-

Dynamic has been slightly gamed by causing it to roll significantly less dangerous antagonists than it should as players will not arrive at roundstart but instead arrive shortly after.
This change will make it so that Dynamic will (by default) consider up to 5 non-ready players for roundstart ruleset severity. More non-ready players beyond that number will not be considered for roundstart rulesets, which means you cannot have a team of nukies on an empty station because there are 26 non-ready players.

The reason it is 5 players is because Dynamic's thresholds work on a scale of every 5 (0 to 4 players, 5 to 9 players, 10 to 14 players and so on), thus on average it should up Dynamic's severity by one "stage".

If people start disconnecting from the game purely to avoid this element then they probably earned it, but adding a hoop should discourage this in any case, much like how moving Toxins to the Research Outpost has drastically reduced the amount of bombs being made because there is extra inconvenience in getting there.

Shouldn't cause any issues, but it may make it slightly more likely for antagonists to overlap, in theory causing a player to be two different antagonists. Maybe.

Some instances of roundstart_pop_ready that relied on real number of players (such as reporting how many players there are or whether there are any players in-game) will now rely on a new variable called "real_ready_players" that gets incremented by the amount of ready players there are.

:cl:
 * experiment: Dynamic will now consider up to 5 players that are not readied up for the purpose of determining roundstart rulesets and their severity.