### PR TITLE
Castle job preference fixes and a tweak

### DIFF
--- a/__DEFINES/__compile_options.dm
+++ b/__DEFINES/__compile_options.dm
@@ -44,6 +44,8 @@
 //#define MAP_OVERRIDE 15
 // wheelstation.dm
 //#define MAP_OVERRIDE 16
+// tgstation-sec.dm
+//#define MAP_OVERRIDE 17
 
 // Toggles several features, explained in their respective comments.
 // You can turn those on and off manually if you prefer, instead of setting this

--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -348,7 +348,7 @@ We don't care about names, DNA, accounts, activity, any of that. We're just gonn
 		var/list/jobs = player.client.prefs.jobs
 
 		for(var/job in jobs)
-			if(jobs[job] == JOB_PREF_HIGH)
+			if((jobs[job] == JOB_PREF_HIGH) && GetJob(job))
 				crystal_ball[job] += 1
 
 /*

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -28,14 +28,15 @@
 	var/datum/job/warden = job_master.GetJob("Warden")
 	var/datum/job/hos = job_master.GetJob("Head of Security")
 	var/datum/job/detective = job_master.GetJob("Detective")
-// Additional check to prevent runtimes in case there's zero Security jobs in the round
-	var/officer_jobs = officer ? officer.current_positions : -1
-	var/warden_jobs = warden ? warden.current_positions : -1
-	var/hos_jobs = hos ? hos.current_positions : -1
-	var/detective_jobs = detective ? detective.current_positions : -1
 // No security roles can be selected, no limit.
-	if((officer_jobs == -1) && (warden_jobs == -1) && (hos_jobs == -1) && (detective_jobs == -1))
+	if((isnull(officer)) && (isnull(warden)) && (isnull(hos)) && (isnull(detective)))
 		return 99
+// Additional check to prevent runtimes in case there's zero Security jobs in the round
+	var/officer_jobs = officer ? officer.current_positions : 0
+	var/warden_jobs = warden ? warden.current_positions : 0
+	var/hos_jobs = hos ? hos.current_positions : 0
+	var/detective_jobs = detective ? detective.current_positions : 0
+
 	var/sec_jobs = (officer_jobs + warden_jobs + hos_jobs + detective_jobs)
 
 	if(sec_jobs > 5)

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -28,7 +28,15 @@
 	var/datum/job/warden = job_master.GetJob("Warden")
 	var/datum/job/hos = job_master.GetJob("Head of Security")
 	var/datum/job/detective = job_master.GetJob("Detective")
-	var/sec_jobs = (officer.current_positions + warden.current_positions + hos.current_positions + detective.current_positions)
+// Additional check to prevent runtimes in case there's zero Security jobs in the round
+	var/officer_jobs = officer ? officer.current_positions : 0
+	var/warden_jobs = warden ? warden.current_positions : 0
+	var/hos_jobs = hos ? hos.current_positions : 0
+	var/detective_jobs = detective ? detective.current_positions : 0
+// No security, no limit.
+	if(!officer_jobs && !warden_jobs && !hos_jobs && !detective_jobs)
+		return 99
+	var/sec_jobs = (officer_jobs + warden_jobs + hos_jobs + detective_jobs)
 
 	if(sec_jobs > 5)
 		return 99

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -29,12 +29,12 @@
 	var/datum/job/hos = job_master.GetJob("Head of Security")
 	var/datum/job/detective = job_master.GetJob("Detective")
 // Additional check to prevent runtimes in case there's zero Security jobs in the round
-	var/officer_jobs = officer ? officer.current_positions : 0
-	var/warden_jobs = warden ? warden.current_positions : 0
-	var/hos_jobs = hos ? hos.current_positions : 0
-	var/detective_jobs = detective ? detective.current_positions : 0
-// No security, no limit.
-	if(!officer_jobs && !warden_jobs && !hos_jobs && !detective_jobs)
+	var/officer_jobs = officer ? officer.current_positions : -1
+	var/warden_jobs = warden ? warden.current_positions : -1
+	var/hos_jobs = hos ? hos.current_positions : -1
+	var/detective_jobs = detective ? detective.current_positions : -1
+// No security roles can be selected, no limit.
+	if((officer_jobs == -1) && (warden_jobs == -1) && (hos_jobs == -1) && (detective_jobs == -1))
 		return 99
 	var/sec_jobs = (officer_jobs + warden_jobs + hos_jobs + detective_jobs)
 

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -29,7 +29,7 @@
 	var/datum/job/hos = job_master.GetJob("Head of Security")
 	var/datum/job/detective = job_master.GetJob("Detective")
 // No security roles can be selected, no limit.
-	if((isnull(officer)) && (isnull(warden)) && (isnull(hos)) && (isnull(detective)))
+	if(isnull(officer) && isnull(warden) && isnull(hos) && isnull(detective))
 		return 99
 // Additional check to prevent runtimes in case there's zero Security jobs in the round
 	var/officer_jobs = officer ? officer.current_positions : 0

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -300,7 +300,7 @@
 				highest_job = job
 
 		var/datum/job/highest_job_datum = job_master.GetJob(highest_job)
-		if(!highest_job_datum) //Fixes a bug where players with a high preference in a job that wasn't in the game couldn't access Setup Character.
+		if(!highest_job_datum) //Fixes a bug where players with a high preference in a job that wasn't in the round couldn't access Setup Character.
 		else switch(highest_job_datum.type)
 			if(/datum/job/hop)
 				clothes_s = new /icon(uniform_dmi, "hop_s")

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -300,8 +300,8 @@
 				highest_job = job
 
 		var/datum/job/highest_job_datum = job_master.GetJob(highest_job)
-
-		switch(highest_job_datum.type)
+		if(!highest_job_datum) //Fixes a bug where players with a high preference in a job that wasn't in the game couldn't access Setup Character.
+		else switch(highest_job_datum.type)
 			if(/datum/job/hop)
 				clothes_s = new /icon(uniform_dmi, "hop_s")
 				clothes_s.Blend(new /icon(feet_dmi, "brown"), ICON_UNDERLAY)

--- a/maps/_map_override.dm
+++ b/maps/_map_override.dm
@@ -74,5 +74,9 @@
 		#undef MAP_OVERRIDE
 		#include "wheelstation.dm"
 		#define MAP_OVERRIDE 16
+	#elif MAP_OVERRIDE == 17
+		#undef MAP_OVERRIDE
+		#include "tgstation-sec.dm"
+		#define MAP_OVERRIDE 17
 	#endif
 #endif


### PR DESCRIPTION
Also adds a MAP_OVERRIDE number for Castle to allow for better testing.

Fixes #35089 
Fixes #33517
Fixes #28145
Fixes #28718

:cl:
 * bugfix: Fixed a bug where players with high preferences in jobs that were not currently in the round could not open the Setup Character menu. This was notable on Castle Station with Security and Silicon jobs.
 * bugfix: Fixed a bug where high preferences for jobs that were not currently in the round would still appear on Manifest Prediction. This was most notable on Castle Station with Security and Silicons.
 * tweak: Assistants will no longer be limited if Security roles are disabled. This notably allows unlimited assistants on Castle Station.