### PR TITLE
make handle_reactions() faster by reducing redundancy in the reactions lists

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -21,6 +21,7 @@ var/const/INGEST = 2
 	var/obscured = FALSE
 	var/total_thermal_mass = 0
 	var/skip_flags = 0 //Flags for skipping certain calculations where unnecessary. See __DEFINES/reagents.dm.
+
 /datum/reagents/New(maximum=100)
 	maximum_volume = maximum
 
@@ -42,13 +43,14 @@ var/const/INGEST = 2
 		// chemical_reaction_list[PLASMA] is a list of all reactions relating to plasma
 
 		chemical_reactions_list = list()
-		
+
 		//variables that we want to reuse
-		var/list/reaction_ids = list()		
+		var/list/reaction_ids = list()
 		var/smallest_number_of_reactants = INFINITY
 		var/smallest_reactants_list_index = 1
 		var/list/reactant_list
 		var/datum/chemical_reaction/D
+		var/i
 
 		for(var/path in typesof(/datum/chemical_reaction) - /datum/chemical_reaction)
 
@@ -56,13 +58,13 @@ var/const/INGEST = 2
 			reaction_ids.len = 0
 
 			if(D.required_reagents && D.required_reagents.len)
-				
+
 				//to minimize the size of the reactions lists, we ideally want each reaction that requires an individual (non-list) reagent to have that as the "key" reagent of the reaction
 				//if a reaction only requires lists of reagents, then we want to pick the smallest list
 				smallest_number_of_reactants = INFINITY
 				smallest_reactants_list_index = 1
-				
-				var/i = 0
+
+				i = 0
 				for(var/reactant in D.required_reagents)
 					i++
 					if(islist(reactant))
@@ -74,9 +76,9 @@ var/const/INGEST = 2
 						else
 							smallest_reactants_list_index = i
 							smallest_number_of_reactants = reactant_list.len
-							
 					else
 						smallest_number_of_reactants = 1
+						reaction_ids.len = 0
 						reaction_ids += reactant
 						break
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -59,7 +59,7 @@ var/const/INGEST = 2
 
 			if(D.required_reagents && D.required_reagents.len)
 
-				//to minimize the size of the reactions lists, we ideally want each reaction that requires an individual (non-list) reagent to have that as the "key" reagent of the reaction
+				//to minimize the size of the reactions lists, we ideally want each reaction that requires an individual (non-list) reactant to have that as the "key" reactant of the reaction
 				//if a reaction only requires lists of reagents, then we want to pick the smallest list
 				smallest_number_of_reactants = INFINITY
 				smallest_reactants_list_index = 1
@@ -89,7 +89,7 @@ var/const/INGEST = 2
 				chemical_reactions_list[id] += D
 				//previously we broke here, which meant that we were only testing the first reagent - even if the first reagent was a list
 				//now we no longer break because we didn't add all the reagents to reaction_ids - we want to add the reaction to everything in
-				//reaction_ids, which will be everything in the key reagent(s) in the table
+				//reaction_ids, which will be everything in the key reactants(s) in the table
 
 /datum/reagents/proc/remove_any(var/amount=1)
 	var/total_transfered = 0

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -69,11 +69,7 @@ var/const/INGEST = 2
 					i++
 					if(islist(reactant))
 						reactant_list = reactant
-						if(smallest_reactants_list_index)
-							if(reactant_list.len < smallest_number_of_reactants)
-								smallest_reactants_list_index = i
-								smallest_number_of_reactants = reactant_list.len
-						else
+						if(reactant_list.len < smallest_number_of_reactants)
 							smallest_reactants_list_index = i
 							smallest_number_of_reactants = reactant_list.len
 					else


### PR DESCRIPTION
## What this does
the global chemical reactions list is a "list of lists" made of lists of reactions corresponding to a given reactant, let's call it the "key" reactant. this helps avoid checking a long list of all reactions, also by having a "key reactant" for each reaction, that also reduces redundancy in terms of:
eg., a reaction that requires oxygen and water, doesn't need to be checked for oxygen, if it's already checked that it doesn't contain water

reactions can also have lists of interchangable reactants listed as individual reactants. so you can have something that requires any of a given list of interchangable reagents. thats how botany chems can be substituted for chemlab chems, etc.

prior to #33390, when encountering a "list reactant", to avoid redundancy, the reaction would only be added to the reaction list of the first interchangable reactant in the "list reactant", but that caused a bug where botany chems etc. couldnt be used as intended. #33390 fixed this but also added some redundancy again in the case of "list reactants", eg:

`#define ACIDS list(SACID, PACID, FORMIC_ACID, PACID, PHENOL, ACIDSPIT, ACIDTEA)`
if ACIDS were the first required reactant for a reaction, the reaction would be added to 7 different lists
but, if the reaction also required water, we could alternatively add it to the water list once instead

this pr minimizes this redundancy by trying to avoid using "list reactants" as the key reactant where possible, and if a reaction only has "list reactants" then it tries to use the shortest list (this would now be the only source of duplicate reactions in the global list)

testing by running handle_reactions() 100000x on the "add 1u of everything in the chem dispenser but water" solution... it goes from 7.7 sec to 5.0 sec, a 35% reduction.

## Why it's good
faster handle_reactions(), increase performance
