### PR TITLE
Changes minimum population requirement and removes maximum requirement for Synergy Station

### DIFF
--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -140,7 +140,7 @@
 /datum/next_map/synergy
 	name = "Synergy Station"
 	path = "Synergy"
-	max_players = 36
+	max_players = 40
 	min_players = 20
 
 /datum/next_map/waystation

--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -140,7 +140,7 @@
 /datum/next_map/synergy
 	name = "Synergy Station"
 	path = "Synergy"
-	max_players = 30
+	max_players = 36
 	min_players = 20
 
 /datum/next_map/waystation

--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -140,8 +140,7 @@
 /datum/next_map/synergy
 	name = "Synergy Station"
 	path = "Synergy"
-	max_players = 40
-	min_players = 20
+	min_players = 15
 
 /datum/next_map/waystation
 	name = "Waystation"

--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -141,6 +141,7 @@
 	name = "Synergy Station"
 	path = "Synergy"
 	max_players = 30
+	min_players = 20
 
 /datum/next_map/waystation
 	name = "Waystation"


### PR DESCRIPTION
## Why it's good
I think Synergy does not fit very well in the lower pop maps. I think it fits much nicer in the medium pop to low-high pop category. I have noticed a decrease in pop and a lack of latejoiners whenever this map is being played during the mornings and late at night. Feedback is appreciated, as this is my first PR, thanks to @jwhitak for guiding me through the process. Also, I realize that this narrows when synergy could be played, and if people want it, I am open to increasing the maximum pop from 30 to infinity. 

## Changelog
🆑 
 * tweak: Synergy now requires 15 players online to be voteable.
 * tweak: Synergy now has no maximum player limit to be available for voting. 