### PR TITLE
Revert "Print chat message when emote is unusable due to false mob ty…

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -8,8 +8,10 @@
 
 	var/datum/emote/E
 	E = E.emote_list[lowertext(act)]
-	if(!E || !E.run_emote(src, param, m_type, ignore_status, arguments))
+	if(!E)
 		to_chat(src, "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>")
+		return
+	E.run_emote(src, param, m_type, ignore_status, arguments)
 
 /datum/emote/flip
 	key = "flip"
@@ -46,7 +48,7 @@
 	restraint_check = FALSE
 
 /datum/emote/me/run_emote(mob/user, params, m_type)
-	. = TRUE
+
 	if (user.stat)
 		return
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -333,13 +333,12 @@ var/list/animals_with_wings = list(
 		. = FALSE
 
 /datum/emote/living/custom/run_emote(mob/user, params, type_override = null)
-	. = TRUE
 	if(jobban_isbanned(user, "emote"))
 		to_chat(user, "You cannot send custom emotes (banned).")
-		return
+		return FALSE
 	else if(user.client && user.client.prefs.muted & MUTE_IC)
 		to_chat(user, "You cannot send IC messages (muted).")
-		return
+		return FALSE
 	else if(!params)
 		var/custom_emote = copytext(sanitize(input("Choose an emote to display.") as text|null), 1, MAX_MESSAGE_LEN)
 		if(custom_emote && !check_invalid(user, custom_emote))
@@ -393,4 +392,3 @@ var/list/animals_with_wings = list(
 	message = jointext(message, "")
 
 	to_chat(user, message)
-	return TRUE


### PR DESCRIPTION
This reverts commit 54c899b66ca7544f7997dfcb4f2a78d9b3dab1f4.

<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Reverts some "you cant use this emote!" prints. They worked fine if you were a borg trying to *scream or such, but this spams you with messages if you have diseases that make you emote while unconscious or similar. Not fixing this anytime soon, so let's revert it

Closes #35278
Closes #35370
I know I'm missing one that I commented in

## Why it's good
<!-- Explain why you think these changes are good. -->
No more "YOU CANT USE THIS EMOTE" spam when unconscious/buckled in some situations, particularly when diseases make you emote

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: You should no longer get "You cant use this emote" spam in certain situations