### PR TITLE
Add licensing information to readme (and specify that sprites and sound are CC BY-SA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,15 @@ The database is automatically installed during server startup, but you need to e
 ### IRC Bot Setup
 
 Included in the repo is an IRC bot capable of relaying adminhelps to a specified IRC channel/server (replaces the older one by Skibiliano).  Instructions for bot setup are included in the /bot/ folder along with the bot/relay script itself.
+
+---
+
+### LICENSE
+
+All code is licensed under the [GNU GPL v3.0](https://www.gnu.org/licenses/gpl-3.0.html) unless specified otherwise.
+
+TGUI is licensed under the MIT license.
+
+Goonchat is licensed under [CC BY-NC-SA 3.0](http://creativecommons.org/licenses/by-nc-sa/3.0/us/).
+
+Assets, including icons and sounds, are licensed under [CC BY-SA 3.0](http://creativecommons.org/licenses/by-sa/3.0/us/) unless specified otherwise.


### PR DESCRIPTION
This is something that should have always been here, but wasn't because the reality is that nobody cares about licensing for a silly free spessmen game. Anyway, better late than never.

The big implication here is clarifying that our assets (sprites/sound) are under CC BY-SA 3.0 rather than GPLv3. This has always been sort of implied and assumed: we have ported many sprites from other servers that are CC, other servers have ported many of our sprites assuming they are CC, and licensing sprites under the GPL makes absolutely no sense because the GPL exists for code, not art.

Some ported sprites (e.g. some in the plushie PR) are actually CC BY-NC-SA 3.0. This makes no real difference: the "specified otherwise" part is fulfilled by mentioning this in the commit that adds those sprites (as there is no reasonable way of specifying a license for every single sprite individually), and Creative Commons is not infectious and can exist side-by-side with other licenses, and we aren't monetizing any sprites or the server.

There's also a couple of things in the repo that explicitly have their own license, notably TGUI and Goonchat, so I mentioned those here too.