### PR TITLE
Frankensteins prevented from being Manifested Ghosts

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -98,7 +98,7 @@
 	initialize_basic_NPC_components()
 
 /mob/living/carbon/human/frankenstein/New(var/new_loc, delay_ready_dna = 0) //Just fuck my shit up: the mob
-	var/list/valid_species = (all_species - list("Krampus", "Horror"))
+	var/list/valid_species = (all_species - list("Krampus", "Horror", "Manifested"))
 
 	var/datum/species/new_species = all_species[pick(valid_species)]
 	..(new_loc, new_species.name)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
Frankensteins should no longer be manifested ghosts

## Why it's good
When a frankenstein is created either via the SoC, or via the medical livestock crate, their species is picked at random. Currently this can included 'manifested ghosts' which causes all sorts of issues. If someone is turned into a frankenstein that is also a manifested ghost they cannot be turned back, if you try and perform surgery such as brain removal on one then it will crumble to dust. This should prevent that.

See #34300 for previous discussion on this. 

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed a bug where frankensteins could generated with manifested ghost as their species. 
