### PR TITLE
re-enable stat collection

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -510,7 +510,7 @@ var/datum/controller/gameticker/ticker
 				else
 					blackbox.save_all_data_to_sql()
 
-			//stat_collection.Process()
+			stat_collection.Process()
 
 			if (watchdog.waiting)
 				to_chat(world, "<span class='notice'><B>Server will shut down for an automatic update in [player_list.len ? "[(restart_timeout/10)] seconds." : "a few seconds."]</B></span>")


### PR DESCRIPTION
DNM until server is on 515.1610 or later.
Tested and working on 515.1620
Stat collection was disabled here: https://github.com/vgstation-coders/vgstation13/commit/110eeb7446d0ebb14a7a50fdf8b5c4a635c34170

This was only disabled since it was causing server to hang on restart due to a BYOND bug.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Stat collection has been re-enabled.
