### PR TITLE
fix humans hearing robot sounds at roundstart

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -802,11 +802,11 @@
 		return new_character
 	else
 		var/mob/living/silicon/robot/new_character
+		forceMove(spawn_loc)
 		if(type == "Mobile MMI")
 			new_character = MoMMIfy()
 		else
 			new_character = Robotize()
-		new_character.forceMove(spawn_loc)
 		new_character.mmi.create_identity(prefs) //Uses prefs to create a brain mob
 
 		return new_character


### PR DESCRIPTION
[hotfix]
fixes humans remotely hearing cyborg sounds at roundstart if a cyborg also spawned