### PR TITLE
Attempts to make the round start faster by not waiting for the characters' medical/security records' images

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -109,17 +109,17 @@
 		L.fields["identity"]	= H.dna.UI // "
 
 		H.regenerate_icons() // ensuring that we don't end up with bald default-species humans before taking their picture
+		spawn() //This is a heavy proc
+			var/icon/I = icon('icons/effects/32x32.dmi', "blank")
+			var/icon/result = icon(I, "")
+			result.Insert(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(H)), override_dir = SOUTH, ignore_spawn_items = TRUE),  "", dir = SOUTH)
+			result.Insert(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(H)), override_dir = NORTH, ignore_spawn_items = TRUE),  "", dir = NORTH)
+			result.Insert(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(H)), override_dir = EAST, ignore_spawn_items = TRUE),  "", dir = EAST)
+			result.Insert(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(H)), override_dir = WEST, ignore_spawn_items = TRUE),  "", dir = WEST)
+			result.Crop(1,1,32,32)
 
-		var/icon/I = icon('icons/effects/32x32.dmi', "blank")
-		var/icon/result = icon(I, "")
-		result.Insert(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(H)), override_dir = SOUTH, ignore_spawn_items = TRUE),  "", dir = SOUTH)
-		result.Insert(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(H)), override_dir = NORTH, ignore_spawn_items = TRUE),  "", dir = NORTH)
-		result.Insert(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(H)), override_dir = EAST, ignore_spawn_items = TRUE),  "", dir = EAST)
-		result.Insert(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(H)), override_dir = WEST, ignore_spawn_items = TRUE),  "", dir = WEST)
-		result.Crop(1,1,32,32)
-
-		G.fields["photo"]		= result
-		L.fields["image"]		= result
+			G.fields["photo"]		= result
+			L.fields["image"]		= result
 
 		general += G
 		locked += L


### PR DESCRIPTION
I noticed roundstart code being severely delayed, with a significant amount of time between when someone receives an antagonist role and when players have control of their characters. After some further investigation it turns out that the code related to creating medical and security records was very slow, more specifically generating character images to be used in the records.

This PR puts the image-creating code behind a spawn(), which should allow the setup code to go along much faster instead of waiting for the images to be generated before moving along. In theory this means records might not have images available for a brief period of time. **In theory**.

:cl:
 * experiment: Roundstart will now start faster.