### PR TITLE
Progressive fade-in at roundstart

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -19,7 +19,7 @@
 		if(screen.anim_state)
 			flick("[screen.anim_state][severity]",screen)
 		client.screen += screen
-		if (screen.screen_loc == "CENTER-7,CENTER-7" && screen.view != client.view)
+		if (screen.screen_loc == "CENTER-7,CENTER-7" && screen.view != client.view && screen.scaling)
 			var/scale = (1 + 2 * client.view) / 15
 			screen.view = client.view
 			screen.transform = matrix(scale, 0, 0, 0, scale, 0)
@@ -88,6 +88,7 @@
 	var/severity = 0
 	var/anim_state
 	var/clear_after_length // also doubles as the length of the animation
+	var/scaling = 1
 
 /obj/abstract/screen/fullscreen/Destroy()
 	severity = 0
@@ -121,7 +122,7 @@
 	icon = 'icons/mob/screen1.dmi'
 	screen_loc = "WEST,SOUTH to EAST,NORTH"
 	icon_state = "blurry"
-	
+
 /obj/abstract/screen/fullscreen/nearsighted
 	icon = 'icons/mob/screen1_blindness.dmi'
 	icon_state = "eye"
@@ -210,3 +211,11 @@
 /obj/abstract/screen/fullscreen/snowfall_average
 	icon_state = "oxydamageoverlay2"
 	layer = DAMAGE_HUD_LAYER
+
+/obj/abstract/screen/fullscreen/client_fadein
+	layer = BLIND_LAYER
+	scaling = 0
+
+/obj/abstract/screen/fullscreen/client_fadein/New()
+	. = ..()
+	icon = current_round_splashscreen

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -185,6 +185,7 @@ var/datum/controller/gameticker/ticker
 			var/mob/living/L = M
 			L.store_position()
 			M.close_spawn_windows()
+
 			continue
 		var/mob/new_player/np = M
 		if(!(np.ready && np.mind && np.mind.assigned_role))
@@ -246,6 +247,10 @@ var/datum/controller/gameticker/ticker
 		M.key = key
 		if(istype(M, /mob/living/carbon/human/))
 			var/mob/living/carbon/human/H = M
+			if (H.client)
+				message_admins("[H.key]")
+				H.overlay_fullscreen("client_fadein", /obj/abstract/screen/fullscreen/client_fadein)
+				H.clear_fullscreen("client_fadein", 3 SECONDS)
 			job_master.PostJobSetup(H)
 		//minds are linked to accounts... And accounts are linked to jobs.
 		var/rank = M.mind.assigned_role

--- a/code/game/turfs/unsimulated/walls.dm
+++ b/code/game/turfs/unsimulated/walls.dm
@@ -72,6 +72,9 @@
 /turf/unsimulated/wall/splashscreen/canSmoothWith()
 	return null
 
+// Global var for fade-in
+var/icon/current_round_splashscreen
+
 /turf/unsimulated/wall/splashscreen/New()
 	if(SNOW_THEME)
 		icon = 'icons/splashworks_alt/snowstation.gif' // uses splashworks_alt folder instead of splashworks so it only appears when we want it to
@@ -85,6 +88,7 @@
 		if(copytext(filename, length(filename)) == "/")
 			filenames -= filename
 	icon = file("[path][pick(filenames)]")
+	current_round_splashscreen = icon
 
 /turf/unsimulated/wall/other
 	icon_state = "r_wall"


### PR DESCRIPTION
[fadein2.webm](https://github.com/vgstation-coders/vgstation13/assets/31417754/494f9e17-7021-423c-b662-0b617976a9fc)

Here's how it looks like. The idea is to make any roundstart lag or other hiccup less noticeable by giving players' eyes something else to focus on.
ATM the fade-in time is 3 seconds but it's trivial to adjust.