### PR TITLE
Switch claw machine failure message to to_chat from visible_message

### DIFF
--- a/code/game/machinery/clawmachine.dm
+++ b/code/game/machinery/clawmachine.dm
@@ -314,7 +314,7 @@
 		playsound(src, 'sound/machines/claw_machine_success.ogg', 50, 1)
 	else
 		//dispense disappointment
-		src.visible_message("<span class='notice'>\The [src]'s claw drops the prize it was carrying prematurely. Disappointing!</span>")
+		to_chat(user, "<span class='notice'>\The [src]'s claw drops the prize it was carrying prematurely. Disappointing!</span>")
 		playsound(src, 'sound/machines/claw_machine_fail.ogg', 50, 1)
 	busy = FALSE
 


### PR DESCRIPTION
I forgot to switch one of these messages from visible_message to to_chat. I decided to switch these all to to_chat because visible_message spams everyone nearby, which could be annoying, whereas to_chat only spams the user.

Not gonna make a changelog entry for a change this small.