### PR TITLE
Plushies will no longer grant Paracetamol when "hugging"

### DIFF
--- a/code/game/objects/items/plushies.dm
+++ b/code/game/objects/items/plushies.dm
@@ -66,12 +66,6 @@
 		playsound(src, hug_sound, 50, 1, -1)
 	if(stuffed || grenade)
 		src.visible_message("<span class='notice'>\The [src] gives \the [M] a [pick("hug", "warm embrace")].</span>")
-		if(M.reagents)
-			if(M == user)
-				if(!M.has_reagent_in_blood(PARACETAMOL))
-					M.reagents.add_reagent(PARACETAMOL, 1)
-			else
-				M.reagents.add_reagent(PARACETAMOL, 1)
 	else
 		src.visible_message("<span class='notice'>\The [src] gives \the [M] a limp hug.</span>")
 	if(grenade && !grenade.active)


### PR DESCRIPTION
Paracetamol is a painkiller that is normally granted by hugging other players and removes most forms of damage-induced slowdowns, giving plushies a real mechanical advantage in the form of on-demand damage-slowdown removal as long as a player hugs themselves with it.
This PR removes that. The code already limits the amount that can be self-given this way but nothing really prevents it from being reapplied right after it wears off.
Could replace the chemical with Citalopram instead if enough players request it.

:cl:
 * rscdel: Plushies will no longer give paracetamol when "hugging" players.