### PR TITLE
Make all sparks except those from igniter not ignite things on the floor

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -151,10 +151,10 @@ steam.start() -- spawns the effect
 
 	var/move_dir = 0
 	var/energy = 0
-	var/surfaceburn = 1
+	var/surfaceburn = 0
 
-/obj/effect/sparks/nosurfaceburn
-	surfaceburn = 0
+/obj/effect/sparks/surfaceburn
+	surfaceburn = 1
 
 /obj/effect/sparks/New(var/travel_dir)
 	..()
@@ -204,7 +204,7 @@ steam.start() -- spawns the effect
 	else
 		location = get_turf(loca)
 
-/datum/effect/system/spark_spread/start(surfaceburn = TRUE)
+/datum/effect/system/spark_spread/start(surfaceburn = FALSE)
 	if (holder)
 		location = get_turf(holder)
 	if(!location)
@@ -220,13 +220,14 @@ steam.start() -- spawns the effect
 		var/nextdir=pick_n_take(directions)
 		if(nextdir)
 			if(surfaceburn)
-				var/obj/effect/sparks/sparks = new /obj/effect/sparks(location)
+				var/obj/effect/sparks/surfaceburn/sparks = new /obj/effect/sparks/surfaceburn(location)
 				sparks.start(nextdir)
 			else
-				var/obj/effect/sparks/nosurfaceburn/sparks = new /obj/effect/sparks/nosurfaceburn(location)
+				var/obj/effect/sparks/sparks = new /obj/effect/sparks(location)
 				sparks.start(nextdir)
+
 // This sparks.
-/proc/spark(var/atom/loc, var/amount = 3, var/cardinals = TRUE, var/surfaceburn = TRUE) //surfaceburn means the sparks can ignite things on the ground. set it to false to keep eg. portals like in the time agent event from burning down the station
+/proc/spark(var/atom/loc, var/amount = 3, var/cardinals = TRUE, var/surfaceburn = FALSE) //surfaceburn means the sparks can ignite things on the ground. set it to false to keep eg. portals like in the time agent event from burning down the station
 	loc = get_turf(loc)
 	var/datum/effect/system/spark_spread/S = new
 	S.set_up(amount, cardinals, loc)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -130,7 +130,7 @@
 				P.red_portal = null
 				P.sync_portals()
 	if (marke_sparks)
-		spark(loc, 5, surfaceburn=0)
+		spark(loc, 5)
 	..()
 
 /obj/effect/portal/cultify()

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -21,7 +21,7 @@
 		if(location)
 			location.hotspot_expose(1000,1000,surfaces=istype(loc,/turf))
 
-		spark(src)
+		spark(src, surfaceburn = TRUE)
 
 		if (istype(src.loc,/obj/item/device/assembly_holder))
 			if (istype(src.loc.loc, /obj/structure/reagent_dispensers/))


### PR DESCRIPTION
## What this does
it seems like #35306 made it somewhat too chaotic and destructive to have sparks burn things on the ground. sparks are used more visually in a lot of places.
so this makes it so that sparks wont burn anything on the ground, the only exception is the sparks from igniters which you would expect

we can add more if you want just let me know, now it's a whitelist thing instead of a blacklist thing

## Why it's good
less things like hacked vending machines and emags starting fires

closes #35424

another option is:
#35427 
vote on what is preferable

## Changelog
:cl:
 * tweak: Sparks, except igniter sparks, don't start fires on the ground.