### PR TITLE
Lower spark temperature to 500 K to prevent igniting burning via sparks

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -143,6 +143,8 @@ steam.start() -- spawns the effect
 // will always spawn at the items location.
 /////////////////////////////////////////////
 
+#define SPARK_TEMP 500
+
 /obj/effect/sparks
 	name = "sparks"
 	desc = "it's a spark what do you need to know?"
@@ -160,7 +162,7 @@ steam.start() -- spawns the effect
 	..()
 	var/turf/T = loc
 	if(istype(T))
-		T.hotspot_expose(1000, 100, surfaces = surfaceburn)
+		T.hotspot_expose(SPARK_TEMP, 100, surfaces = surfaceburn)
 
 /obj/effect/sparks/proc/start(var/travel_dir, var/max_energy=3)
 	move_dir=travel_dir
@@ -168,14 +170,14 @@ steam.start() -- spawns the effect
 	processing_objects.Add(src)
 	var/turf/T = loc
 	if (istype(T, /turf))
-		T.hotspot_expose(1000, 100, surfaces = surfaceburn)
+		T.hotspot_expose(SPARK_TEMP, 100, surfaces = surfaceburn)
 
 /obj/effect/sparks/Destroy()
 	processing_objects.Remove(src)
 	var/turf/T = src.loc
 
 	if (istype(T, /turf))
-		T.hotspot_expose(1000, 100, surfaces = surfaceburn)
+		T.hotspot_expose(SPARK_TEMP, 100, surfaces = surfaceburn)
 
 	..()
 
@@ -183,7 +185,7 @@ steam.start() -- spawns the effect
 	..()
 	var/turf/T = src.loc
 	if (istype(T, /turf))
-		T.hotspot_expose(1000,100, surfaces = surfaceburn)
+		T.hotspot_expose(SPARK_TEMP, 100, surfaces = surfaceburn)
 	return
 
 /obj/effect/sparks/process()
@@ -231,6 +233,8 @@ steam.start() -- spawns the effect
 	var/datum/effect/system/spark_spread/S = new
 	S.set_up(amount, cardinals, loc)
 	S.start(surfaceburn)
+
+#undef SPARK_TEMP
 
 /////////////////////////////////////////////
 //// SMOKE SYSTEMS

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -130,7 +130,7 @@
 				P.red_portal = null
 				P.sync_portals()
 	if (marke_sparks)
-		spark(loc, 5, surfaceburn=0)
+		spark(loc, 5)
 	..()
 
 /obj/effect/portal/cultify()


### PR DESCRIPTION
## What this does
it seems like https://github.com/vgstation-coders/vgstation13/pull/35306 made it somewhat too chaotic and destructive to have sparks burn things on the ground. sparks are used more visually in a lot of places.
so this makes it so that sparks are 500 K, lower than AUTOIGNITION_PAPER, AUTOIGNITION_WOOD, etc. so these things won't light on fire

## Why it's good
less things like hacked vending machines and emags starting fires

closes https://github.com/vgstation-coders/vgstation13/pull/35424

another option is:
#35426
vote on what is preferable

## Changelog
:cl:
 * tweak: Sparks aren't hot enough to burn items and objects on the ground in most cases.

