### PR TITLE
Dynamic+ now resets Extended's incremental weight if a round ended with not a single ruleset executed (aka, "de-facto Extended")

### DIFF
--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -212,8 +212,11 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 	for (var/category in dynamic_mode.ruleset_category_weights)
 		data[category] = dynamic_mode.ruleset_category_weights[category]
 
-	for (var/datum/dynamic_ruleset/DR in dynamic_mode.executed_rules)
-		data[DR.weight_category] = 0
+	if (dynamic_mode.executed_rules.len <= 0)
+		data["Extended"] = 0
+	else
+		for (var/datum/dynamic_ruleset/DR in dynamic_mode.executed_rules)
+			data[DR.weight_category] = 0
 
 	write_file(data)
 


### PR DESCRIPTION
This was clearly an oversight on my part, and it'll make more sense too since the round-end scoreboard already calls such rounds "extended".

:cl:
* tweak: Dynamic mode now resets Extended's incremental weight if a round ended with not a single ruleset executed (aka, de-facto Extended). These types of round would occur naturally on low threat, and since they wouldn't reset Extended's threat level it would instead increase and have even more chance to occur on the next round even if it had a higher threat level.