### PR TITLE
The "Extended" dynamic ruleset will no longer fire at 20 in-game players and above

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -631,7 +631,7 @@ Assign your candidates in choose_candidates() instead.
 	weight = BASE_RULESET_WEIGHT * 0.5
 	weight_category = "Extended"
 	cost = 0
-	requirements = list(0,0,0,0,0,101,101,101,101,101) //Does not fire at 25 pop and above.
+	requirements = list(0,0,0,0,101,101,101,101,101,101) //Does not fire at 20 pop and above.
 	high_population_requirement = 101
 
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -631,7 +631,7 @@ Assign your candidates in choose_candidates() instead.
 	weight = BASE_RULESET_WEIGHT * 0.5
 	weight_category = "Extended"
 	cost = 0
-	requirements = list(0,0,0,0,0,0,0,0,0,0)
+	requirements = list(0,0,0,0,0,101,101,101,101,101) //Does not fire at 25 pop and above.
 	high_population_requirement = 101
 
 


### PR DESCRIPTION
Everyone who has played through multiple Extended rounds can attest to the loss of server population and general player interest after an Extended round, where the round right afterwards has way less players than the round before had but to a degree that is more severe than the usual loss of players between rounds. This causes the period of time where the server is more populated to lose steam, as players beget more players and Extended "exhausted" a number of players by itself, getting worse the longer the Extended round has been.

This PR lowers the threshold at which Extended is unable to roll from 45 (the "high-pop override" mechanic, set at 45 in-game players, disables Extended) to 20, leaving Extended to roll during the lowpop, more peaceful rounds but unable to cripple the pop at 20 or above in-game players. However, this deliberately does not prevent "pseudo-Extended" where the round simply doesn't have enough threat to fire any other gamemode, which makes the rare high-pop Extended round actually special and not a semi-regular occurrence.

:cl:
 * experiment: Dynamic will no longer fire the "Extended" ruleset at 20 or above in-game players.