### PR TITLE
Horizon will now compile (and a bit of clean-up)

### DIFF
--- a/maps/horizon.dm
+++ b/maps/horizon.dm
@@ -46,15 +46,4 @@
 
 ////////////////////////////////////////////////////////////////
 #include "horizon.dmm"
-
-#if !defined(MAP_OVERRIDE_FILES)
-	#define MAP_OVERRIDE_FILES
-	#include "packedstation\misc.dm"
-	/* This is gonna stay just in case - Prometh
-	#include "packedstation\uplink_item.dm"
-	#include "packedstation\job\jobs.dm" //Job changes removed for now
-	#include "packedstation\job\removed.dm"
-#elif !defined(MAP_OVERRIDE)
-	#warn a map has already been included, ignoring packedstation. */
-#endif
 #endif


### PR DESCRIPTION
What happened was that the toys that were replaced in [this pull request](https://github.com/vgstation-coders/vgstation13/pull/35336) were not actually replaced on the Horizon map. This fixes it.
Removes unnecessary code from Horizon.dm

:cl:
 * bugfix: Horizon will now run properly.
