### PR TITLE
Reduces the cost of some pAI software (Redundant Threading, Brightness Enhancer and Remote Signaler) from 15 to 10.

### DIFF
--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -2,9 +2,9 @@
 
 
 /mob/living/silicon/pai/var/list/available_software = list(
-															SOFT_FL = 15,
-															SOFT_RT = 15,
-															SOFT_RS = 15,
+															SOFT_FL = 10,
+															SOFT_RT = 10,
+															SOFT_RS = 10,
 
 															SOFT_WJ = 30,
 															SOFT_CS = 30,


### PR DESCRIPTION
## What this does
Reduces the cost of Redundant Threading (EMP resistance), Brightness Enhancer (Flashlight) and Remote Signaler to 10 RAM.
## Why it's good
Most combinations of pAI software always leave you with 10 points you can't really use, this gives you more options regardless of your pAI build, as those last 10 points can actually be used for something other the pAI GPS or the atmos sensor.
:cl:
 * tweak: The RAM cost for Redundant Threading, Brightness Enhancer and Remote Signaler is now 10 (instead of 15).