### PR TITLE
fix jukeboxes + smaller bugs/nitpicks

### DIFF
--- a/code/datums/gamemode/role/apes.dm
+++ b/code/datums/gamemode/role/apes.dm
@@ -3,11 +3,12 @@
 	id = THE_APES
 	special_role = THE_APES
 	logo_state = "monkey-logo"
-	greets = null
+	greets = list(GREET_DEFAULT)
 	default_admin_voice = "Ape King"
 	admin_voice_style = "rough"
 
 /datum/role/apes/OnPostSetup(var/laterole = TRUE)
+	src.Greet(GREET_DEFAULT) /* Handling it here since this role is special and doesn't ever get chosen by dynamic. */
 	if(faction)
 		return
 	var/datum/faction/F = find_active_faction_by_type(/datum/faction/apes)
@@ -24,4 +25,4 @@
 		if(GREET_CUSTOM)
 			to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='danger'>[custom]</span>")
 		else
-			to_chat(antag.current, "<span class='bold'>You are not an antagonist. In fact, you're just an ordinary ape/monkey. Ook!</span>")
+			to_chat(antag.current, "<span class='bold'>You have been transformed into an ape!<br>You are not an antagonist. In fact, you're just an ordinary ape. Ook!</span>")

--- a/code/datums/gamemode/role/apes.dm
+++ b/code/datums/gamemode/role/apes.dm
@@ -14,3 +14,14 @@
 	if(!F)
 		F = ticker.mode.CreateFaction(/datum/faction/apes, null, 1)
 	F.HandleRecruitedRole(src)
+
+/datum/role/apes/Greet(greeting, custom)
+	if(!greeting)
+		return
+
+	var/icon/logo = icon('icons/logos.dmi', logo_state)
+	switch(greeting)
+		if(GREET_CUSTOM)
+			to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='danger'>[custom]</span>")
+		else
+			to_chat(antag.current, "<span class='bold'>You are not an antagonist. In fact, you're just an ordinary ape/monkey. Ook!</span>")

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -447,12 +447,13 @@ var/area/space_area
 		thing.area_entered(src)
 
 	for(var/mob/mob_in_obj in Obj.contents)
-		INVOKE_EVENT(src, /event/mob_area_changed, "mob" = mob_in_obj, "newarea" = src, "oldarea" = oldArea)
+		if(istype(mob_in_obj))
+			INVOKE_EVENT(mob_in_obj, /event/mob_area_changed, "mob" = mob_in_obj, "newarea" = src, "oldarea" = oldArea)
 
 	INVOKE_EVENT(src, /event/area_entered, "enterer" = Obj)
 	var/mob/M = Obj
 	if(istype(M))
-		INVOKE_EVENT(src, /event/mob_area_changed, "mob" = M, "newarea" = src, "oldarea" = oldArea)
+		INVOKE_EVENT(M, /event/mob_area_changed, "mob" = M, "newarea" = src, "oldarea" = oldArea)
 		if(narrator)
 			narrator.Crossed(M)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -2269,7 +2269,7 @@ Use this proc preferably at the end of an equipment loadout
 /mob/proc/isBloodedAnimal()
 	return FALSE
 
-/mob/proc/OnMobAreaChanged()
+/mob/proc/OnMobAreaChanged(var/mob, var/newarea, var/oldarea)
 	if(src.client && src.client.media && !src.client.media.forced)
 		spawn()
 			src.update_music()


### PR DESCRIPTION
## What this does
Fixed jukeboxes not working. Caused by my hook deprecation PR: #34504 
The event to check for movement was invoked incorrectly, and the proc that handled it also didn't properly take arguments.
My apologies if this ruined anyone's comfy bar.
Fixes #35447

Fixes the Apes role/faction not being able to be manually assigned. This literally doesn't matter because it does nothing, but it made me realize that this role needs a greeting for Ape Mode so I added that too. This was another thing I changed around in the hooks PR.

[bugfix]

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed jukeboxes not properly starting/stopping.
 * bugfix: Fixed the Ape Mode admin button having some flaws/inconsistencies when the Ape faction/role was assigned to players.