### PR TITLE
fix advanced medical scanner runtime

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -190,7 +190,7 @@
 			continue
 		x.forceMove(loc)
 
-	if(!occupant.gcDestroyed)
+	if(occupant && !occupant.gcDestroyed)
 		occupant.forceMove(exit)
 		occupant.reset_view()
 		if(istype(ejector) && ejector != occupant)


### PR DESCRIPTION
```
[13:23:57] Runtime in code/game/machinery/adv_med.dm,193: Cannot read null.gcDestroyed
  proc name: go out (/obj/machinery/bodyscanner/proc/go_out)
  usr: Orish O'Bird (jaid777) (/mob/living/carbon/human)
  usr.loc: The floor (254, 228, 1) (/turf/simulated/floor)
  src: the body scanner (/obj/machinery/bodyscanner)
  src.loc: the floor (255,229,1) (/turf/simulated/floor)
  call stack:
  the body scanner (/obj/machinery/bodyscanner): go out(the floor (255,229,1) (/turf/simulated/floor), Orish O\'Bird (/mob/living/carbon/human))
  the body scanner (/obj/machinery/bodyscanner): Eject Body Scanner()
```
[runtime]

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed a runtime occurring when exiting advanced medical scanners.
