### PR TITLE
fix light replacer runtime

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -444,7 +444,7 @@ This used to be handled by attackby() on the light fixtures and bulbs themselves
 		target.explode()
 
 /obj/item/device/lightreplacer/proc/get_best_light(var/obj/machinery/light/target)
-	if(!istype(supply))
+	if(!istype(supply) || !istype(target))
 		return 0
 	var/best_light
 	if(!target.fitting) //no idea how this happens


### PR DESCRIPTION
[runtime]
happens when you click a tile with no light fixture
```
[19:17:34] Runtime in code/game/objects/items/devices/lightreplacer.dm,450: Cannot read null.fitting
  proc name: get best light (/obj/item/device/lightreplacer/proc/get_best_light)
  usr: Cashe Yaka (leon454) (/mob/living/carbon/human)
  usr.loc: The floor (220, 225, 1) (/turf/simulated/floor)
  src: the light replacer (/obj/item/device/lightreplacer/loaded/mixed)
  src.loc: Cashe Yaka (/mob/living/carbon/human)
  call stack:
  the light replacer (/obj/item/device/lightreplacer/loaded/mixed): get best light(null)
  the light replacer (/obj/item/device/lightreplacer/loaded/mixed): preattack(the floor (220,224,1) (/turf/simulated/floor), Cashe Yaka (/mob/living/carbon/human), 1, "icon-x=30;icon-y=4;left=1;butt...")
  Cashe Yaka (/mob/living/carbon/human): ClickOn(the floor (220,224,1) (/turf/simulated/floor), "icon-x=30;icon-y=4;left=1;butt...")
  the floor (220,224,1) (/turf/simulated/floor): Click(the floor (220,224,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=30;icon-y=4;left=1;butt...")
  Leon454 (/client): Click(the floor (220,224,1) (/turf/simulated/floor), the floor (220,224,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=30;icon-y=4;left=1;butt...")
```
