### PR TITLE
Optimizes tcomms a little

### DIFF
--- a/code/game/machinery/telecomms/logbrowser.dm
+++ b/code/game/machinery/telecomms/logbrowser.dm
@@ -67,6 +67,9 @@
 			for(var/datum/comm_log_entry/C in SelectedServer.log_entries)
 				i++
 
+				if (i > 75) // No more than 75 entries at the same time
+					break
+
 				// If the log is a speech file
 				if(C.input_type == "Speech File")
 

--- a/code/game/machinery/telecomms/logbrowser.dm
+++ b/code/game/machinery/telecomms/logbrowser.dm
@@ -17,10 +17,24 @@
 
 	var/universal_translate = 0 // set to 1 if it can translate nonhuman speech
 
+	//Used to track what type of mob said a message. Done only once instead of every time someone opens the comm log.
+	var/list/humans = list()
+	var/list/monkeys = list()
+	var/list/silicons = list()
+	var/list/slimes = list()
+	var/list/animals = list()
+
 	circuit = "/obj/item/weapon/circuitboard/comm_server"
 
 	req_access = list(access_tcomsat)
 
+/obj/machinery/computer/telecomms/server/New()
+	..()
+	humans = typesof(/mob/living/carbon/human, /mob/living/carbon/brain)
+	monkeys = typesof(/mob/living/carbon/monkey)
+	silicons = typesof(/mob/living/silicon)
+	slimes = typesof(/mob/living/carbon/slime)
+	animals = typesof(/mob/living/simple_animal)
 
 /obj/machinery/computer/telecomms/server/attack_hand(mob/user as mob)
 	if(stat & (BROKEN|NOPOWER|FORCEDISABLE))
@@ -78,18 +92,18 @@
 					var/language = "Human" // MMIs, pAIs, Cyborgs and humans all speak Human
 					var/mobtype = C.parameters["mobtype"]
 
-					if(ishuman(mobtype))
+					if(mobtype in humans)
 						race = "Human"
 						language = race
 
-					else if(ismonkey(mobtype))
+					else if(mobtype in monkeys)
 						race = "Monkey"
 						language = race
 
-					else if(issilicon(mobtype) || C.parameters["job"] == "AI") // sometimes M gets deleted prematurely for AIs... just check the job
+					else if((mobtype in silicons) || (C.parameters["job"] == "AI")) // sometimes M gets deleted prematurely for AIs... just check the job
 						race = "Artificial Life"
 
-					else if(isslime(mobtype)) // NT knows a lot about slimes, but not aliens. Can identify slimes
+					else if(mobtype in slimes) // NT knows a lot about slimes, but not aliens. Can identify slimes
 						race = "slime"
 						language = race
 
@@ -97,7 +111,7 @@
 						race = "Machinery"
 						language = race
 
-					else if(isanimal(mobtype))
+					else if(mobtype in animals)
 						race = "Domestic Animal"
 						language = race
 

--- a/code/game/machinery/telecomms/logbrowser.dm
+++ b/code/game/machinery/telecomms/logbrowser.dm
@@ -1,3 +1,9 @@
+var/list/static/list_of_human_types = typesof(/mob/living/carbon/human, /mob/living/carbon/brain)
+var/list/static/list_of_monkey_types = typesof(/mob/living/carbon/monkey)
+var/list/static/list_of_silicon_types = typesof(/mob/living/silicon)
+var/list/static/list_of_slime_types = typesof(/mob/living/carbon/slime)
+var/list/static/list_of_animal_types = typesof(/mob/living/simple_animal)
+
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
 /obj/machinery/computer/telecomms
 
@@ -17,24 +23,9 @@
 
 	var/universal_translate = 0 // set to 1 if it can translate nonhuman speech
 
-	//Used to track what type of mob said a message. Done only once instead of every time someone opens the comm log.
-	var/list/humans = list()
-	var/list/monkeys = list()
-	var/list/silicons = list()
-	var/list/slimes = list()
-	var/list/animals = list()
-
 	circuit = "/obj/item/weapon/circuitboard/comm_server"
 
 	req_access = list(access_tcomsat)
-
-/obj/machinery/computer/telecomms/server/New()
-	..()
-	humans = typesof(/mob/living/carbon/human, /mob/living/carbon/brain)
-	monkeys = typesof(/mob/living/carbon/monkey)
-	silicons = typesof(/mob/living/silicon)
-	slimes = typesof(/mob/living/carbon/slime)
-	animals = typesof(/mob/living/simple_animal)
 
 /obj/machinery/computer/telecomms/server/attack_hand(mob/user as mob)
 	if(stat & (BROKEN|NOPOWER|FORCEDISABLE))
@@ -92,18 +83,18 @@
 					var/language = "Human" // MMIs, pAIs, Cyborgs and humans all speak Human
 					var/mobtype = C.parameters["mobtype"]
 
-					if(mobtype in humans)
+					if(mobtype in list_of_human_types)
 						race = "Human"
 						language = race
 
-					else if(mobtype in monkeys)
+					else if(mobtype in list_of_monkey_types)
 						race = "Monkey"
 						language = race
 
-					else if((mobtype in silicons) || (C.parameters["job"] == "AI")) // sometimes M gets deleted prematurely for AIs... just check the job
+					else if((mobtype in list_of_silicon_types) || (C.parameters["job"] == "AI")) // sometimes M gets deleted prematurely for AIs... just check the job
 						race = "Artificial Life"
 
-					else if(mobtype in slimes) // NT knows a lot about slimes, but not aliens. Can identify slimes
+					else if(mobtype in list_of_slime_types) // NT knows a lot about slimes, but not aliens. Can identify slimes
 						race = "slime"
 						language = race
 
@@ -111,7 +102,7 @@
 						race = "Machinery"
 						language = race
 
-					else if(mobtype in animals)
+					else if(mobtype in list_of_animal_types)
 						race = "Domestic Animal"
 						language = race
 

--- a/code/game/machinery/telecomms/logbrowser.dm
+++ b/code/game/machinery/telecomms/logbrowser.dm
@@ -67,9 +67,6 @@
 			for(var/datum/comm_log_entry/C in SelectedServer.log_entries)
 				i++
 
-				if (i > 75) // No more than 75 entries at the same time
-					break
-
 				// If the log is a speech file
 				if(C.input_type == "Speech File")
 

--- a/code/game/machinery/telecomms/logbrowser.dm
+++ b/code/game/machinery/telecomms/logbrowser.dm
@@ -67,9 +67,6 @@
 			for(var/datum/comm_log_entry/C in SelectedServer.log_entries)
 				i++
 
-				if (i > 75) // No more than 75 entries at the same time
-					break
-
 				// If the log is a speech file
 				if(C.input_type == "Speech File")
 
@@ -81,24 +78,18 @@
 					var/language = "Human" // MMIs, pAIs, Cyborgs and humans all speak Human
 					var/mobtype = C.parameters["mobtype"]
 
-					var/list/humans = typesof(/mob/living/carbon/human, /mob/living/carbon/brain)
-					var/list/monkeys = typesof(/mob/living/carbon/monkey)
-					var/list/silicons = typesof(/mob/living/silicon)
-					var/list/slimes = typesof(/mob/living/carbon/slime)
-					var/list/animals = typesof(/mob/living/simple_animal)
-
-					if(mobtype in humans)
+					if(ishuman(mobtype))
 						race = "Human"
 						language = race
 
-					else if(mobtype in monkeys)
+					else if(ismonkey(mobtype))
 						race = "Monkey"
 						language = race
 
-					else if(mobtype in silicons || C.parameters["job"] == "AI") // sometimes M gets deleted prematurely for AIs... just check the job
+					else if(issilicon(mobtype) || C.parameters["job"] == "AI") // sometimes M gets deleted prematurely for AIs... just check the job
 						race = "Artificial Life"
 
-					else if(mobtype in slimes) // NT knows a lot about slimes, but not aliens. Can identify slimes
+					else if(isslime(mobtype)) // NT knows a lot about slimes, but not aliens. Can identify slimes
 						race = "slime"
 						language = race
 
@@ -106,7 +97,7 @@
 						race = "Machinery"
 						language = race
 
-					else if(mobtype in animals)
+					else if(isanimal(mobtype))
 						race = "Domestic Animal"
 						language = race
 


### PR DESCRIPTION
Also removed the 75 log message check, this only affected what was shown clientside which has been optimized. The real fix of #25649 is CHECK_TICK

:cl:
 * bugfix: Checking a telecomm server's message log should lag less.
 * bugfix: The telecomm server message logs are no longer limited to 75 message.
