### PR TITLE
customizable turrets for admins + button to spawn in Fun Secrets

### DIFF
--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -639,7 +639,7 @@
 				<b>Admin-only mode:</b> <a href='?src=\ref[src];admin_only=1'>[admin_only?"ON":"OFF"]</a><br>
 				<b>Projectile type:</b> <a href='?src=\ref[src];projectile_type=1'>[projectile_type]</a><br>
 				<b>Projectiles per burst:</b> <a href='?src=\ref[src];projectile_burst=1'>[projectiles_per_shot]</a><br>
-				<b>Firing delay:</b> <a href='?src=\ref[src];firing_delay=1'>[cooldown]</a><br>
+				<b>Firing delay:</b> <a href='?src=\ref[src];firing_delay=1'>[cooldown] deci-seconds</a><br>
 				<b>Set ammo #:</b> <a href='?src=\ref[src];force_ammo_amt=1'>[projectiles]</a><br>
 				
 			

--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -598,9 +598,9 @@
 	icon_state = "gun_turret"
 
 /obj/structure/turret/gun_turret/examine(mob/user)
-	if(admin_only)
-		desc += "<br><span class='warning'>This turret's control panel is glowing red and appears to be remotely locked down.</span>"
 	..()
+	if(admin_only)
+		to_chat(user, "<span class='warning'>This turret's control panel is glowing red and appears to be remotely locked down.</span>")
 
 /obj/structure/turret/gun_turret/ex_act()
 	qdel (src)

--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -577,7 +577,8 @@
 		icon_state = "turretid_safe"
 
 /obj/structure/turret/gun_turret
-	name = "Gun Turret"
+	name = "gun turret"
+	desc = "A break-away from traditional design, this turret always has its hulking gun exposed. It looks menacing."
 	density = 1
 	anchored = 1
 	var/cooldown = 20
@@ -587,12 +588,19 @@
 	var/list/exclude = list()
 	var/atom/cur_target
 	var/scan_range = 7
+	var/projectile_type = /obj/item/projectile
+	var/firing_delay = 2
+	var/admin_only = 0 //Can non-admins interface with this turret's controls?
 	health = 40
 	var/list/scan_for = list("human"=0,"cyborg"=0,"mecha"=0,"alien"=1)
 	var/on = 0
 	icon = 'icons/obj/turrets.dmi'
 	icon_state = "gun_turret"
 
+/obj/structure/turret/gun_turret/examine(mob/user)
+	if(admin_only)
+		desc += "<br><span class='warning'>This turret's control panel is glowing red and appears to be remotely locked down.</span>"
+	..()
 
 /obj/structure/turret/gun_turret/ex_act()
 	qdel (src)
@@ -612,9 +620,12 @@
 	return ..()
 
 /obj/structure/turret/gun_turret/attack_hand(mob/user as mob)
+	if(admin_only && !check_rights(R_ADMIN))
+		to_chat(user, "<span class='warning'> The turret's control panel is glowing red and appears to be remotely locked down.</span>")
+		return
 	user.set_machine(src)
 	var/dat = {"<html>
-					<head><title>[src] Control</title></head>
+					<head><title>[src] control</title></head>
 					<body>
 					<b>Power: </b><a href='?src=\ref[src];power=1'>[on?"on":"off"]</a><br>
 					<b>Scan Range: </b><a href='?src=\ref[src];scan_range=-1'>-</a> [scan_range] <a href='?src=\ref[src];scan_range=1'>+</a><br>
@@ -622,7 +633,16 @@
 	for(var/scan in scan_for)
 		dat += "<div style=\"margin-left: 15px;\">[scan] (<a href='?src=\ref[src];scan_for=[scan]'>[scan_for[scan]?"Yes":"No"]</a>)</div>"
 
-	dat += {"<b>Ammo: </b>[max(0, projectiles)]<br>
+	dat += "<b>Ammo: </b>[max(0, projectiles)]<br>"
+	if(check_rights(R_ADMIN))
+		dat += {"<br><b><font color="red">Admin Options:</font></b><br>
+				<b>Admin-only mode:</b> <a href='?src=\ref[src];admin_only=1'>[admin_only?"ON":"OFF"]</a><br>
+				<b>Projectile type:</b> <a href='?src=\ref[src];projectile_type=1'>[projectile_type]</a><br>
+				<b>Projectiles per burst:</b> <a href='?src=\ref[src];projectile_burst=1'>[projectiles_per_shot]</a><br>
+				<b>Firing delay:</b> <a href='?src=\ref[src];firing_delay=1'>[cooldown]</a><br>
+				<b>Set ammo #:</b> <a href='?src=\ref[src];force_ammo_amt=1'>[projectiles]</a><br>
+				
+			
 				</body>
 				</html>"}
 	user << browse(dat, "window=turret")
@@ -652,6 +672,47 @@
 	if(href_list["scan_for"])
 		if(href_list["scan_for"] in scan_for)
 			scan_for[href_list["scan_for"]] = !scan_for[href_list["scan_for"]]
+	if(href_list["admin_only"])
+		if(!check_rights(R_ADMIN))
+			return
+		src.admin_only = !src.admin_only
+	if(href_list["projectile_type"])
+		if(!check_rights(R_ADMIN))
+			return
+		var/list/valid_turret_projectiles = existing_typesof(/obj/item/projectile/bullet) + existing_typesof(/obj/item/projectile/energy)
+		var/userinput = filter_list_input("New projectile typepath", "You can only pick one!", valid_turret_projectiles)
+		if(!userinput)
+			to_chat(usr, "<span class='warning'><b>No projetile typepath entered. The turret's projectile remains unchanged.</b></span>")
+			return
+		projectile_type = userinput
+
+	if(href_list["projectile_burst"])
+		if(!check_rights(R_ADMIN))
+			return
+		var/userinput = input("Enter new # of projectiles in a burst-fire", "RATATATTATATA", 2) as num
+		if(userinput > 5)
+			projectiles_per_shot = 5
+			to_chat(usr, "<span class='warning'><b>Error: Max burst-fire exceeded. Burst-fire set to 5.</b></span>")
+			return
+		projectiles_per_shot = max(1, userinput)
+	if(href_list["firing_delay"])
+		if(!check_rights(R_ADMIN))
+			return
+		var/userinput = input("Enter new firing delay (as tenths of a second)", "RATATATTATATA", 20) as num
+		if(userinput <= 0)
+			cooldown = 1
+			to_chat(usr, "<span class='warning'><b>Error: Firing cooldown floor reached. Cooldown set to 1/10th of a second.</b></span>")
+			return
+		cooldown = userinput
+	if(href_list["force_ammo_amt"])
+		if(!check_rights(R_ADMIN))
+			return
+		var/userinput = input("Enter new # of projectiles left in the turret", "RATATATTATATA", 100) as num
+		if(userinput < 0)
+			projectiles = 0
+			to_chat(usr, "<span class='warning'><b>Error: Setting negative projectiles is a bad idea, okay? <u>Don't do that<u/>. Projectiles reset to 0.</b></span>")
+			return
+		projectiles = userinput
 	src.updateUsrDialog()
 	return
 
@@ -730,7 +791,7 @@
 		if (targloc == curloc)
 			continue
 		playsound(src, 'sound/weapons/Gunshot.ogg', 50, 1)
-		var/obj/item/projectile/A = new /obj/item/projectile(curloc)
+		var/obj/item/projectile/A = new projectile_type(curloc)
 		src.projectiles--
 		A.original = target
 		A.current = curloc
@@ -742,6 +803,9 @@
 		A.process()
 		sleep(2)
 	return
+
+/obj/structure/turret/gun_turret/admin
+	admin_only = 1
 
 /obj/machinery/turret/Destroy()
 	// deletes its own cover with it

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -868,6 +868,7 @@ var/global/floorIsLava = 0
 			<A href='?src=\ref[src];secretsfun=eagles'>Egalitarian Station Mode (removes access on doors except for Command and Security)</A><BR>
 			<A href='?src=\ref[src];secretsfun=RandomizedLawset'>Give the AIs a randomly generated Lawset.</A><BR>
 			<A href='?src=\ref[src];secretsfun=buddha_mode_everyone'>Toggle Buddha Mode on/off for everyone</A><BR>
+			<A href='?src=\ref[src];secretsfun=spawn_custom_turret'>Spawn a customizable turret</A><BR>
 			<BR>
 			<A href='?src=\ref[src];secretsfun=power'>Make all areas powered</A><BR>
 			<A href='?src=\ref[src];secretsfun=unpower'>Make all areas unpowered</A><BR>

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -4323,6 +4323,13 @@
 								if(H.client)
 									to_chat(H, "<span class='warning'>The tranquility that once filled your soul has vanished. You are once again a slave to your worldly desires.</span>")
 
+			if("spawn_custom_turret")
+				if(alert("Are you sure you'd like to spawn a custom turret at your location?", "Confirmation", "Yes", "Cancel") == "Cancel")
+					return
+				new /obj/structure/turret/gun_turret/admin(get_turf(usr))
+				log_admin("[key_name(usr)] has spawned a customizable turret at [get_coordinates_string(usr)].")
+				message_admins("[key_name(usr)] has spawned a customizable turret at [get_coordinates_string(usr)].")
+
 			if("vermin_infestation")
 				var/list/locations = list(
 					"RANDOM" = null,


### PR DESCRIPTION
## What this does
New customizable turret for admins. This already existed, somewhat, but most variables weren't able to be edited and it was a pain to do.
You can customize:
- projectile type (limited to /bullet and /energy to prevent issues, although nothing stops you from manually VV'ing this)
- projectile burst
- firing speed
- ammo remaining
- admin-only mode (players won't be able to approach and edit the NORMAL controls that normally come with the turret, like who's targeted and range. regardless of what admin-only mode is set to, they cannot modify the above variables.
- the turret's description changes when admin-only mode is on so players do not have to endanger themselves by approaching a turret that is normally programmable

There is a button to spawn this in the Fun Secrets part of the Secrets Panel.

Turret panel:
![image](https://github.com/vgstation-coders/vgstation13/assets/26285377/1d5a4979-3646-4368-bcb0-a795c99a5b91)

FULL POWER:
![image](https://github.com/vgstation-coders/vgstation13/assets/26285377/1424296c-2305-4001-8de1-760eda981a85)

## Why it's good
Hopefully this leads to some creative bussing that wasn't quite possible before.

[administration]

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Revamped a programmable turret to be fully customizable by admins for bussing purposes. Find it in the "Fun Secrets" part of the Secrets Panel.
