### PR TITLE
Ghosts inside dead characters will no longer be affected by speech modifiers

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -217,7 +217,8 @@ var/list/headset_modes = list(
 				score.syndisponses += 1
 
 	var/message_range = SPEECH_RANGE
-	treat_speech(speech)
+	if(!isDead()) //Dead players can still talk from dead bodies and it would be inconvenient to have these.
+		treat_speech(speech)
 	if(!speech.message)
 		qdel(speech)
 		return
@@ -726,7 +727,8 @@ var/list/headset_modes = list(
 	var/critical = InCritical()
 
 	log_whisper("[key_name(src)] ([formatLocation(src)]): [message]")
-	treat_speech(speech)
+	if(!isDead())
+		treat_speech(speech)
 	if(!speech.message)
 		qdel(speech)
 		return
@@ -741,7 +743,8 @@ var/list/headset_modes = list(
 		speech.mode= SPEECH_MODE_FINAL
 		whispers = "whispers with their final breath"
 		said_last_words = src.stat
-	treat_speech(speech)
+	if(!isDead())
+		treat_speech(speech)
 	if(!speech.message)
 		qdel(speech)
 		return


### PR DESCRIPTION
AKA a catbeast won't have whatever they were trying to say in deadchat replaced.

:cl:
 * bugfix: Speech modifiers such as the catbeast's sentence replacements no longer affect deadchat speech.