### PR TITLE
The vampire's "Rejuvenate" ability will, if the vampire is sufficiently powerful, also stop any bleeding.

### DIFF
--- a/code/datums/gamemode/powers/powers.dm
+++ b/code/datums/gamemode/powers/powers.dm
@@ -1,4 +1,4 @@
-/datum/power			
+/datum/power
 	var/name = "Power"
 	var/desc = "Placeholder"
 	var/helptext = ""
@@ -6,7 +6,7 @@
 	var/passive = FALSE     //is this a spell or a passive effect?
 	var/spellpath           //Path to a verb that contains the effects.
 	var/cost                //the cost of this power
-	var/datum/role/role 
+	var/datum/role/role
 	var/obj/abstract/screen/movable/spell_master/spellmaster
 
 	var/store_in_memory = FALSE
@@ -29,6 +29,7 @@
 	R.current_powers += src
 	role = R
 	grant_spell()
+	post_upgrade()
 	return TRUE
 
 //gives the user the spells if theres one associated with it, seperated from add_power in instances where spells need to be added/removed repeatedly (changelings)
@@ -58,6 +59,9 @@
 				return TRUE
 		return FALSE
 
+//For when you want to do more things with upgraded spells, such as modify spell text.
+/datum/power/proc/post_upgrade()
+	return
 
 /datum/power_holder
 	var/datum/role/role
@@ -350,7 +354,7 @@
 			break
 
 	if(!thepower)		//ABORT!
-		return 
+		return
 
 	if(thepower in role.current_powers)
 		to_chat(M.current, "<span class='warning'>You have already purchased this power.</span>")
@@ -362,7 +366,7 @@
 
 	role.powerpoints -= thepower.cost
 	thepower.add_power(role)
-	
+
 
 
 

--- a/code/datums/gamemode/powers/vampire.dm
+++ b/code/datums/gamemode/powers/vampire.dm
@@ -52,8 +52,15 @@
 
 /datum/power/vampire/heal
 	cost = 200
-	granttext = "Your rejuvenation abilities have improved and will now heal you over time when used."
+	granttext = "Your rejuvenation abilities have improved and will now heal you over time when used, as well as stop all bleeding, including internal ones."
 	store_in_memory = TRUE
+
+/datum/power/vampire/heal/post_upgrade()
+	var/mob/M = role.antag.current
+	for(var/spell/rejuvenate/R in M.spell_list)
+		if(istype(R))
+			R.desc = "Flush your system with spare blood to remove any incapacitating effects. Now also provides a mild healing effect, and closes any bleeding wounds."
+			break
 
 /datum/power/vampire/jaunt
 	cost = 250

--- a/code/datums/gamemode/powers/vampire.dm
+++ b/code/datums/gamemode/powers/vampire.dm
@@ -58,9 +58,8 @@
 /datum/power/vampire/heal/post_upgrade()
 	var/mob/M = role.antag.current
 	for(var/spell/rejuvenate/R in M.spell_list)
-		if(istype(R))
-			R.desc = "Flush your system with spare blood to remove any incapacitating effects. Now also provides a mild healing effect, and closes any bleeding wounds."
-			break
+		R.desc = "Flush your system with spare blood to remove any incapacitating effects. Now also provides a mild healing effect, and closes any bleeding wounds."
+		break
 
 /datum/power/vampire/jaunt
 	cost = 250

--- a/code/modules/spells/general/rejuvenate.dm
+++ b/code/modules/spells/general/rejuvenate.dm
@@ -31,13 +31,29 @@
 /spell/rejuvenate/cast(var/list/targets, var/mob/user)
 	var/mob/living/carbon/human/H = user
 	var/datum/role/vampire/V = isvampire(user) // Shouldn't ever be null, as cast_check checks if we're a vamp.
+	var/empowered = (V.blood_total >= 200)
 	H.SetKnockdown(0)
 	H.SetStunned(0)
 	H.SetParalysis(0)
 	H.reagents.clear_reagents()
-	to_chat(H, "<span class='notice'>You flush your system with clean blood and remove any incapacitating effects.</span>")
+	if(empowered)
+		to_chat(H, "<span class='notice'>You flush your system with clean blood, removing any incapacitating effects and mildly healing you.</span>")
+	else
+		to_chat(H, "<span class='notice'>You flush your system with clean blood and remove any incapacitating effects.</span>")
 	spawn() // sleep() causes issues with cooldown.
 		if(V.blood_total >= 200)
+			var/wound_count = 0
+			for(var/datum/organ/external/E in H.organs)
+				for(var/datum/wound/W in E.wounds)
+					if(W.internal)
+						W.heal_damage(W.damage) //Completely heal internal wounds.
+						wound_count++
+					else
+						if(W.bleeding()) //Check this purely for fluff
+							W.bleed_timer = 0 //Stop the bleeding completely otherwise. The wounds are still there.
+							wound_count++
+			if(wound_count)
+				to_chat(H, "<span class='notice'>In addition, you stitch [wound_count] wounds shut, preventing any further bleeding.</span>")
 			for(var/i = 0 to 5)
 				H.adjustBruteLoss(-2)
 				H.adjustOxyLoss(-5)

--- a/code/modules/spells/general/rejuvenate.dm
+++ b/code/modules/spells/general/rejuvenate.dm
@@ -41,7 +41,7 @@
 	else
 		to_chat(H, "<span class='notice'>You flush your system with clean blood and remove any incapacitating effects.</span>")
 	spawn() // sleep() causes issues with cooldown.
-		if(V.blood_total >= 200)
+		if(empowered)
 			var/wound_count = 0
 			for(var/datum/organ/external/E in H.organs)
 				for(var/datum/wound/W in E.wounds)


### PR DESCRIPTION
Initially I wanted to add this as one of the functions of a wooden coffin because it already fixes the vampire really good but I decided it's cooler and more dynamic this way.
With a better mastery over blood they can simply stitch their wounds shut. This does NOT heal the wounds themselves, but simply prevents any bleeding. A vampire won't let go of their own blood so easily!

Added a "post-upgrade" proc to vampire power datums, so that you can do more with them other than just giving descriptions and sometimes spells.

The "Rejuvenate" ability will now also have a modified description in the list of spells as well as provide an updated message if the vampire is powerful enough. It also gives you a count of how many wounds were stitched shut by the ability if you have any bleeding wounds, because why not?

:cl:
 * rscadd: The vampire's "Rejuvenate" ability will now, if the vampire is strong enough (at least 200 total blood), also close any bleeding wounds. This includes internal bleeding.
 * rscadd: The vampire's "Rejuvenate" ability now has a different description and activation message when it is empowered.
