### PR TITLE
Updates Waystation Path so it can be voted again.

### DIFF
--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -150,7 +150,7 @@
 
 /datum/next_map/waystation
 	name = "Waystation"
-	path = "Waystation"
+	path = "waystation"
 	max_players = 25
 
 /datum/next_map/xoq


### PR DESCRIPTION
## What this does
Waystations path in nextmap DM is "Waystation" with uppercase.
The actual DM file is "waystation.dmm" I suspect this is what is causing the map to not appear compiled and thus not being votable.
It's likely pomf just renamed the file on last server.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed a bug preventing voting of waystation

