### PR TITLE
Draft: Horizon Dodge

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -121,6 +121,7 @@ var/shuttle_z = map.zCentcomm	//default
 var/airtunnel_start = 68 // default
 var/airtunnel_stop = 68 // default
 var/airtunnel_bottom = 72 // default
+var/dodge = FALSE // Whether the station has dodged the ROD / RADSTORM or not
 var/list/monkeystart = list()
 var/list/wizardstart = list()
 var/list/grinchstart = list()

--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -322,6 +322,11 @@
 	alert = null
 	message = "The station has entered the radiation belt. Please remain in a sheltered area until we have passed the radiation belt."
 
+/datum/command_alert/radiation_storm/dodge
+	name = "Radiation Storm - Start"
+	alert = null
+	message = "The ship has dodged the radiation belt.  Maintenance will lose all access again shortly."
+
 /datum/command_alert/radiation_storm/end
 	name = "Radiation Storm - End"
 	alert = null
@@ -709,6 +714,11 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 	name = "Immovable Rod (\"What The Fuck Was That?\")"
 	alert_title = "Local Bluespace Sensor Report"
 	message = "Alert: The station appears to be on a collision course with an anomalous object perfectly suspended in space. Heavy structural damage may result."
+
+/datum/command_alert/immovable_rod_engines
+	name = "Immovable Rod Inbound"
+	alert_title = "Local Bluespace Sensor Report"
+	message = "Alert: The ship appears to be on a collision course with an anomalous object perfectly suspended in space. Please use ship controls in bridge to evade within 30 seconds or Heavy structural damage may result."
 
 /datum/command_alert/rogue_drone
 	name = "Rogue Drones - Alert"

--- a/code/game/machinery/computer/ship_control.dm
+++ b/code/game/machinery/computer/ship_control.dm
@@ -1,0 +1,12 @@
+/obj/machinery/computer/ship_controls
+	name = "Ship Controls"
+	icon = 'icons/obj/computer.dmi'
+	icon_state = "shuttle"
+	light_color = LIGHT_COLOR_CYAN
+
+/obj/machinery/computer/ship_controls/attack_hand(var/mob/user)
+	if(map.has_engines)
+		if (!ship_has_power)
+			return FALSE
+	dodge = TRUE
+	return

--- a/code/modules/events/immovablerod.dm
+++ b/code/modules/events/immovablerod.dm
@@ -23,6 +23,9 @@ var/list/all_rods = list()
 	return 0
 
 /datum/event/immovable_rod/announce()
+	if(map.has_engines)
+		command_alert(/datum/command_alert/immovable_rod_engines)
+		return
 	command_alert(/datum/command_alert/immovable_rod)
 
 /datum/event/immovable_rod/start()
@@ -33,7 +36,19 @@ var/list/all_rods = list()
 	immovablerod(2)
 
 /proc/immovablerod(var/rodlevel = 0)
+	if(map.has_engines)
+		sleep(30 SECONDS)
 	var/obj/item/projectile/immovablerod/myrod
+	if (dodge):
+		switch(rodlevel)
+			// Pass just alongside station
+			if(0)
+				myrod = new /obj/item/projectile/immovablerod(locate(180,230,1))
+			if(1)
+				myrod = new /obj/item/projectile/immovablerod/big(locate(180,230,1))
+			if(2)
+				myrod = new /obj/item/projectile/immovablerod/hyper(locate(180,230,1))
+
 	switch(rodlevel)
 		if(0)
 			myrod = new /obj/item/projectile/immovablerod(locate(1,1,1))

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -50,6 +50,19 @@
 
 		sleep(30 SECONDS)
 
+		if (dodge):
+			command_alert(/datum/command_alert/radiation_storm/dodge)
+			for(var/area/A in areas)
+				if(A.z != map.zMainStation || is_safe_zone(A))
+					continue
+				var/area/ma = get_area(A)
+				ma.reset_radiation_alert()
+
+			sleep(600) // Want to give them time to get out of maintenance.
+
+
+			revoke_doors_all_access(list(access_maint_tunnels))
+			return
 
 		command_alert(/datum/command_alert/radiation_storm/start)
 

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -809,6 +809,7 @@
 #include "code\game\machinery\computer\robot.dm"
 #include "code\game\machinery\computer\security.dm"
 #include "code\game\machinery\computer\security_alert.dm"
+#include "code\game\machinery\computer\ship_control.dm"
 #include "code\game\machinery\computer\shuttle.dm"
 #include "code\game\machinery\computer\shuttle_computers.dm"
 #include "code\game\machinery\computer\slot_machine.dm"


### PR DESCRIPTION
Needs more testing and a few safety checks to avoid abuse.
I want to gather opinions.

## What this does
You will be able to dodge, rods & radstorms on the horizon map.

Any random rods or radstorm events that are triiggered, will activate a thirty second timer. If the crew can get to the bridge in that time and use the ship controls computer, the ship will dodge and a command announcement will be sent announcing that.

In the case of a radstorm, dodging means the event doesn't end.

In the case of a rod, the rod will be fired down the right side about 10 tiles left of edge of station.

## Why it's good
A few people mentioned this would be a good idea and I like the idea of playing into the ship theme.
If people are keen on this there's a few other things that could be done, like a custom hyperspace event which brings back old motion tiles preventing access to station for a short period.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Horizon can now dodge radstorms and rods with the ship controls console in bridge.
