### PR TITLE
Should fix seeing naked players at roundstart

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -243,8 +243,9 @@ var/datum/controller/gameticker/ticker
 	//Keep track of the spawn landmark so that we can reset player views to it
 	var/obj/effect/landmark/start/S
 	for(var/obj/effect/landmark/start/searching in landmarks_list)
-		S = searching
-		break
+		if(searching.name == "start")
+			S = searching
+			break
 
 	//Transfer characters to players
 	for(var/i = 1, i <= new_characters.len, i++)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -240,17 +240,20 @@ var/datum/controller/gameticker/ticker
 	var/list/clowns = list()
 	var/already_an_ai = FALSE
 
+	//Keep track of the spawn landmark so that we can reset player views to it
+	var/obj/effect/landmark/start/S
+	for(var/obj/effect/landmark/start/searching in landmarks_list)
+		S = searching
+		break
+
 	//Transfer characters to players
 	for(var/i = 1, i <= new_characters.len, i++)
 		var/mob/M = new_characters[new_characters[i]]
 		var/key = new_characters[i]
 		M.key = key
+		M.reset_view(S) //Reset the view back to the starting screen until we finish all this setup, to prevent players from seeing things they shouldn't see, like naked players
 		if(istype(M, /mob/living/carbon/human/))
 			var/mob/living/carbon/human/H = M
-			if (H.client)
-				message_admins("[H.key]")
-				H.overlay_fullscreen("client_fadein", /obj/abstract/screen/fullscreen/client_fadein)
-				H.clear_fullscreen("client_fadein", 3 SECONDS)
 			job_master.PostJobSetup(H)
 		//minds are linked to accounts... And accounts are linked to jobs.
 		var/rank = M.mind.assigned_role
@@ -262,7 +265,13 @@ var/datum/controller/gameticker/ticker
 		if(job)
 			job.equip(M, job.priority) // Outfit datum.
 
-
+	//Reset views back to the players
+	for(var/i = 1, i <= new_characters.len, i++)
+		var/mob/M = new_characters[new_characters[i]]
+		M.reset_view()
+		if(M.client)
+			M.overlay_fullscreen("client_fadein", /obj/abstract/screen/fullscreen/client_fadein)
+			M.clear_fullscreen("client_fadein", 3 SECONDS)
 
 	//delete the new_player mob for those who readied
 	for(var/mob/np in new_players_ready)


### PR DESCRIPTION
Does not fix naked nukies.

Basically after moving the player's key to a new character it sets their vision back to the roundstart screen immediately, and after everyone is set up it resets the view back to the player characters.

Also fixes some splashscreen fade-out related stuff, silicons can now see it and it won't send extra messages to the admins.

:cl:
 * experiment: Players should no longer see other naked players during roundstart aboard the station itself.
 * bugfix: Silicons should now see the splashscreen fade out when joining the game.