### PR TITLE
Disables the thermal dissipation subsystem

### DIFF
--- a/code/controllers/subsystem/thermal_dissipation.dm
+++ b/code/controllers/subsystem/thermal_dissipation.dm
@@ -6,7 +6,7 @@ var/list/datum/reagents/thermal_dissipation_reagents = list()
 	wait          = SS_WAIT_THERM_DISS
 	//flags         = SS_KEEP_TIMING
 	flags 	 = SS_NO_FIRE
-	can_fire = FALSE
+	can_fire = FALSE //Turning thermal dissipation OFF until the matter of its CPU usage has been sorted out, and ideally thermal energy transfer has been fleshed out more as a game mechanic
 	priority      = SS_PRIORITY_THERM_DISS
 	display_order = SS_DISPLAY_THERM_DISS
 

--- a/code/controllers/subsystem/thermal_dissipation.dm
+++ b/code/controllers/subsystem/thermal_dissipation.dm
@@ -4,7 +4,9 @@ var/list/datum/reagents/thermal_dissipation_reagents = list()
 /datum/subsystem/thermal_dissipation
 	name          = "Thermal Dissipation"
 	wait          = SS_WAIT_THERM_DISS
-	flags         = SS_KEEP_TIMING
+	//flags         = SS_KEEP_TIMING
+	flags 	 = SS_NO_FIRE
+	can_fire = FALSE
 	priority      = SS_PRIORITY_THERM_DISS
 	display_order = SS_DISPLAY_THERM_DISS
 


### PR DESCRIPTION
![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/8c2bdeff-506b-4f20-ad6c-92c25ae7be05)
 
This is way too much CPU usage **at rest** for a feature that offers players so little actual gameplay in exchange. People have started discussing how to remove the feature entirely. Whether this ends up happening or not, this quick change in the meantime will ease the performance strain on the server.

:cl:
* experiment: The thermal dissipation subsystem has been disabled