### PR TITLE
Temperature Guns now also set the temperature of the reagents inside hit objects

### DIFF
--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -6,7 +6,7 @@
 	slot_flags = SLOT_BACK
 	w_class = W_CLASS_LARGE
 	fire_sound = 'sound/weapons/pulse3.ogg'
-	desc = "A gun that changes the body temperature of its targets."
+	desc = "A gun that changes the temperature of its targets."
 	var/temperature = 300
 	var/target_temperature = 300
 	charge_cost = 90
@@ -43,7 +43,7 @@
 /obj/item/weapon/gun/energy/temperature/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/card/emag) && !emagged)
 		emagged = 1
-		to_chat(user, "<span class='caution'>You double the gun's temperature cap! Targets hit by now searing beams will burst into flames!</span>")
+		to_chat(user, "<span class='caution'>You double the gun's temperature cap! Individuals hit by now searing beams will burst into flames!</span>")
 		desc = "A gun that changes the body temperature of its targets. Its temperature cap has been hacked."
 
 /obj/item/weapon/gun/energy/temperature/Topic(href, href_list)

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -48,7 +48,7 @@
 
 	var/obj/item/weapon/gun/energy/temperature/T = shot_from
 	if(istype(T))
-		src.temperature = T.temperature
+		temperature = T.temperature
 	else
 		temperature = rand(100,600) //give it a random temp value if it's not fired from a temp gun
 
@@ -84,6 +84,12 @@
 			name = "temperature beam"//failsafe
 			icon_state = "temp_4"
 
+/obj/item/projectile/temp/to_bump(var/atom/A)
+	if (!ismob(A) && A.reagents && A.reagents.total_volume)
+		A.reagents.chem_temp = temperature
+		if(!(A.reagents.skip_flags & SKIP_RXN_CHECK_ON_HEATING))
+			A.reagents.handle_reactions()
+	..()
 
 /obj/item/projectile/temp/on_hit(var/atom/target, var/blocked = 0)//These two could likely check temp protection on the mob
 	if(istype(target, /mob/living))


### PR DESCRIPTION
I can't believe this wasn't a thing

:cl:
* rscadd: Temperature Guns now can now also be used to instantly set the temperature of food, or the reagents contained in beakers and other containers.