### PR TITLE
Make job ban checking faster (draft)

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -659,7 +659,16 @@ var/global/floorIsLava = 0
 		return
 
 	var/dat = "<B>Job Bans!</B><HR><table>"
-	for(var/t in jobban_keylist)
+	var/list/list_of_bans = list()
+	var/list/these_bans
+	var/reason
+	for(var/ckey in jobban_keylist)
+		these_bans = jobban_keylist[ckey]
+		if(islist(these_bans))
+			for(var/this_rank in these_bans)
+				reason = these_bans[this_rank]
+				list_of_bans += "[ckey] - [this_rank]" + reason ? " ## [reason]" : null
+	for(var/t in list_of_bans)
 		var/r = t
 		if( findtext(r,"##") )
 			r = copytext( r, 1, findtext(r,"##") )//removes the description

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -661,15 +661,13 @@ var/global/floorIsLava = 0
 	var/dat = "<B>Job Bans!</B><HR><table>"
 	var/list/these_bans
 	var/reason
-	var/t
 	var/r
 	for(var/ckey in jobban_keylist)
 		these_bans = jobban_keylist[ckey]
 		for(var/this_rank in these_bans)
 			reason = these_bans[this_rank]
 			r = "[ckey] - [this_rank]"
-			t = reason ? r + " ## [reason]" : r
-			dat += text("<tr><td>[t] (<A href='?src=\ref[src];removejobban=[r]'>unban</A>)</td></tr>")
+			dat += text("<tr><td>[reason ? r + " ## [reason]" : r] (<A href='?src=\ref[src];removejobban=[r]'>unban</A>)</td></tr>")
 	dat += "</table>"
 	usr << browse(dat, "window=ban;size=400x400")
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -659,15 +659,21 @@ var/global/floorIsLava = 0
 		return
 
 	var/dat = "<B>Job Bans!</B><HR><table>"
-	var/list/list_of_bans = list()
 	var/list/these_bans
 	var/reason
+	var/t
+	var/r
 	for(var/ckey in jobban_keylist)
 		these_bans = jobban_keylist[ckey]
-		if(islist(these_bans))
-			for(var/this_rank in these_bans)
-				reason = these_bans[this_rank]
-				list_of_bans += "[ckey] - [this_rank]" + reason ? " ## [reason]" : null
+		for(var/this_rank in these_bans)
+			reason = these_bans[this_rank]
+			r = "[ckey] - [this_rank]"
+			t = reason ? r + " ## [reason]" : r
+			dat += text("<tr><td>[t] (<A href='?src=\ref[src];removejobban=[r]'>unban</A>)</td></tr>")
+	dat += "</table>"
+	usr << browse(dat, "window=ban;size=400x400")
+
+/*
 	for(var/t in list_of_bans)
 		var/r = t
 		if( findtext(r,"##") )
@@ -675,6 +681,7 @@ var/global/floorIsLava = 0
 		dat += text("<tr><td>[t] (<A href='?src=\ref[src];removejobban=[r]'>unban</A>)</td></tr>")
 	dat += "</table>"
 	usr << browse(dat, "window=ban;size=400x400")
+*/
 
 /datum/admins/proc/Game()
 	if(!check_rights(0))

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -2,17 +2,27 @@
 
 var/jobban_runonce			// Updates legacy bans with new info
 var/jobban_keylist[0]		//to store the keys & ranks
+	//is now a list-of-lists:
+		//jobban_keylist["playerckey1"] is an associative list with key: rank, value: reason
 
 /proc/jobban_fullban(mob/M, rank, reason)
 	if (!M || !M.key)
 		return
-	jobban_keylist.Add(text("[M.ckey] - [rank] ## [reason]"))
+	if(islist(jobban_keylist[M.ckey]))
+		jobban_keylist[M.ckey][rank] = reason
+	else
+		jobban_keylist[M.ckey] = list(rank = reason)
+	//jobban_keylist.Add(text("[M.ckey] - [rank] ## [reason]"))
 	jobban_savebanfile()
 
+//unused
 /proc/jobban_client_fullban(ckey, rank)
 	if (!ckey || !rank)
 		return
-	jobban_keylist.Add(text("[ckey] - [rank]"))
+	if(!islist(jobban_keylist[ckey]))
+		jobban_keylist[ckey][rank] = list()
+	jobban_keylist[ckey] = list(rank = null)
+	//jobban_keylist.Add(text("[ckey] - [rank]"))
 	jobban_savebanfile()
 
 //returns a reason if M is banned from rank, returns 0 otherwise
@@ -27,6 +37,13 @@ var/jobban_keylist[0]		//to store the keys & ranks
 			if(config.usewhitelist && !check_whitelist(M))
 				return "Whitelisted Job"
 		*/
+		var/list/s = jobban_keylist[M.ckey]
+		if(s?.len)
+			var/reason = s[rank]
+			if(!reason)
+				reason = "Reason Unspecified"
+			return reason
+/*
 		for (var/s in jobban_keylist)
 			if( findtext(s,"[M.ckey] - [rank]") == 1 )
 				var/startpos = findtext(s, "## ")+3
@@ -35,6 +52,7 @@ var/jobban_keylist[0]		//to store the keys & ranks
 					if(text)
 						return text
 				return "Reason Unspecified"
+*/
 	return 0
 
 /*
@@ -54,13 +72,31 @@ DEBUG
 /proc/jobban_loadbanfile()
 	if(config.ban_legacy_system)
 		var/savefile/S=new("data/job_full.ban")
-		S["keys[0]"] >> jobban_keylist
+		var/list/list_of_bans = list()
+		S["keys[0]"] >> list_of_bans
+//		S["keys[0]"] >> jobban_keylist
 		log_admin("Loading jobban_rank")
 		S["runonce"] >> jobban_runonce
 
-		if (!length(jobban_keylist))
-			jobban_keylist=list()
+		if (!length(list_of_bans))
+			jobban_keylist = list()
 			log_admin("jobban_keylist was empty")
+		else
+			var/first_space
+			var/doublehash
+			var/ckey
+			var/rank
+			var/reason
+			for(var/this_ban in list_of_bans)
+				first_space = findtext(this_ban, " ")
+				ckey = copytext(this_ban, 1, first_space)
+				doublehash = findtext(this_ban, "##")
+				rank = copytext(this_ban, first_space + 3, doublehash ? doublehash - 1 : 0)
+				reason = doublehash ? copytext(this_ban, doublehash + 3, 0) : null
+				if(!jobban_keylist[ckey])
+					jobban_keylist[ckey] = list()
+				jobban_keylist[ckey][rank] = reason
+
 	else
 		if(!SSdbcore.Connect())
 			diary << "Database connection failed. Reverting to the legacy ban system."
@@ -82,8 +118,10 @@ DEBUG
 		while(query.NextRow())
 			var/ckey = query.item[1]
 			var/job = query.item[2]
-
-			jobban_keylist.Add("[ckey] - [job]")
+			if(!jobban_keylist[ckey])
+				jobban_keylist[ckey] = list()
+			jobban_keylist[ckey][job] = null
+			//jobban_keylist.Add("[ckey] - [job]")
 		qdel(query)
 		//Job tempbans
 		var/datum/DBQuery/query1 = SSdbcore.NewQuery("SELECT ckey, job FROM erro_ban WHERE bantype = :bantype AND isnull(unbanned) AND expiration_time > Now()",
@@ -98,12 +136,27 @@ DEBUG
 		while(query1.NextRow())
 			var/ckey = query1.item[1]
 			var/job = query1.item[2]
-			jobban_keylist.Add("[ckey] - [job]")
+			if(!jobban_keylist[ckey])
+				jobban_keylist[ckey] = list()
+			jobban_keylist[ckey][job] = null
+			//jobban_keylist.Add("[ckey] - [job]")
 		qdel(query1)
 
 /proc/jobban_savebanfile()
 	var/savefile/S = new("data/job_full.ban")
-	S["keys[0]"] << jobban_keylist
+
+	var/list/list_of_bans = list()
+	var/list/these_bans
+	var/reason
+	for(var/ckey in jobban_keylist)
+		these_bans = jobban_keylist[ckey]
+		if(islist(these_bans))
+			for(var/this_rank in these_bans)
+				reason = these_bans[this_rank]
+				list_of_bans += "[ckey] - [this_rank]" + reason ? " ## [reason]" : null
+
+	S["keys[0]"] << list_of_bans
+//	S["keys[0]"] << jobban_keylist
 
 /proc/jobban_unban(mob/M, rank)
 	jobban_remove("[M.ckey] - [rank]")
@@ -119,15 +172,42 @@ DEBUG
 		log_admin("Updating jobbanfile!")
 		// Updates bans.. Or fixes them. Either way.
 		for(var/T in jobban_keylist)
-			if(!T)
+			if(!jobban_keylist[T])
+			//if(!T)
 				continue
 		jobban_runonce++	//don't run this update again
 
-
 /proc/jobban_remove(X)
-	for (var/i = 1; i <= length(jobban_keylist); i++)
-		if( findtext(jobban_keylist[i], "[X]") )
-			jobban_keylist.Remove(jobban_keylist[i])
+
+	var/list/list_of_bans = list()
+	var/list/these_bans
+	var/reason
+	for(var/ckey in jobban_keylist)
+		these_bans = jobban_keylist[ckey]
+		if(islist(these_bans))
+			for(var/this_rank in these_bans)
+				reason = these_bans[this_rank]
+				list_of_bans += "[ckey] - [this_rank]" + reason ? " ## [reason]" : null
+	for (var/i = 1; i <= length(list_of_bans); i++)
+		if( findtext(list_of_bans[i], "[X]") )
+			list_of_bans.Remove(list_of_bans[i])
+
+			jobban_keylist = list()
+			var/first_space
+			var/doublehash
+			var/ckey
+			var/rank
+			for(var/this_ban in list_of_bans)
+				first_space = findtext(this_ban, " ")
+				ckey = copytext(this_ban, 1, first_space)
+				doublehash = findtext(this_ban, "##")
+				rank = copytext(this_ban, first_space + 3, doublehash ? doublehash - 1 : 0)
+				reason = doublehash ? copytext(this_ban, doublehash + 3, 0) : null
+				if(!jobban_keylist[ckey])
+					jobban_keylist[ckey] = list()
+				jobban_keylist[ckey][rank] = reason
+
 			jobban_savebanfile()
 			return 1
+
 	return 0

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -183,7 +183,7 @@ DEBUG
 		these_bans = jobban_keylist[ckey]
 		for(var/this_rank in these_bans)
 			reason = these_bans[this_rank]
-			if(findtext("[ckey] - [this_rank]" + reason ? " ## [reason]" : null, "[X]")
+			if(findtext("[ckey] - [this_rank]" + reason ? " ## [reason]" : null, "[X]"))
 				jobban_keylist[ckey].Remove(this_rank)
 				jobban_savebanfile()
 				return 1

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -1,7 +1,7 @@
 
 
 var/jobban_runonce			// Updates legacy bans with new info
-var/jobban_keylist[0]		//to store the keys & ranks
+var/list/jobban_keylist[0]		//to store the keys & ranks
 	//is now a list-of-lists:
 		//jobban_keylist["playerckey1"] is an associative list with key: rank, value: reason
 

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -183,27 +183,8 @@ DEBUG
 		these_bans = jobban_keylist[ckey]
 		for(var/this_rank in these_bans)
 			reason = these_bans[this_rank]
-			list_of_bans += "[ckey] - [this_rank]" + reason ? " ## [reason]" : null
-	for (var/i = 1; i <= length(list_of_bans); i++)
-		if( findtext(list_of_bans[i], "[X]") )
-			list_of_bans.Remove(list_of_bans[i])
-
-			jobban_keylist = list()
-			var/first_space
-			var/doublehash
-			var/ckey
-			var/rank
-			for(var/this_ban in list_of_bans)
-				first_space = findtext(this_ban, " ")
-				ckey = copytext(this_ban, 1, first_space)
-				doublehash = findtext(this_ban, "##")
-				rank = copytext(this_ban, first_space + 3, doublehash ? doublehash - 1 : 0)
-				reason = doublehash ? copytext(this_ban, doublehash + 3, 0) : null
-				if(!jobban_keylist[ckey])
-					jobban_keylist[ckey] = list()
-				jobban_keylist[ckey][rank] = reason
-
-			jobban_savebanfile()
-			return 1
-
+			if(findtext("[ckey] - [this_rank]" + reason ? " ## [reason]" : null, "[X]")
+				jobban_keylist[ckey].Remove(this_rank)
+				jobban_savebanfile()
+				return 1
 	return 0

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -12,7 +12,6 @@ var/jobban_keylist[0]		//to store the keys & ranks
 		jobban_keylist[M.ckey][rank] = reason
 	else
 		jobban_keylist[M.ckey] = list(rank = reason)
-	//jobban_keylist.Add(text("[M.ckey] - [rank] ## [reason]"))
 	jobban_savebanfile()
 
 //unused
@@ -22,7 +21,6 @@ var/jobban_keylist[0]		//to store the keys & ranks
 	if(!islist(jobban_keylist[ckey]))
 		jobban_keylist[ckey][rank] = list()
 	jobban_keylist[ckey] = list(rank = null)
-	//jobban_keylist.Add(text("[ckey] - [rank]"))
 	jobban_savebanfile()
 
 //returns a reason if M is banned from rank, returns 0 otherwise
@@ -150,10 +148,9 @@ DEBUG
 	var/reason
 	for(var/ckey in jobban_keylist)
 		these_bans = jobban_keylist[ckey]
-		if(islist(these_bans))
-			for(var/this_rank in these_bans)
-				reason = these_bans[this_rank]
-				list_of_bans += "[ckey] - [this_rank]" + reason ? " ## [reason]" : null
+		for(var/this_rank in these_bans)
+			reason = these_bans[this_rank]
+			list_of_bans += "[ckey] - [this_rank]" + reason ? " ## [reason]" : null
 
 	S["keys[0]"] << list_of_bans
 //	S["keys[0]"] << jobban_keylist
@@ -184,10 +181,9 @@ DEBUG
 	var/reason
 	for(var/ckey in jobban_keylist)
 		these_bans = jobban_keylist[ckey]
-		if(islist(these_bans))
-			for(var/this_rank in these_bans)
-				reason = these_bans[this_rank]
-				list_of_bans += "[ckey] - [this_rank]" + reason ? " ## [reason]" : null
+		for(var/this_rank in these_bans)
+			reason = these_bans[this_rank]
+			list_of_bans += "[ckey] - [this_rank]" + reason ? " ## [reason]" : null
 	for (var/i = 1; i <= length(list_of_bans); i++)
 		if( findtext(list_of_bans[i], "[X]") )
 			list_of_bans.Remove(list_of_bans[i])

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -176,7 +176,6 @@ DEBUG
 
 /proc/jobban_remove(X)
 
-	var/list/list_of_bans = list()
 	var/list/these_bans
 	var/reason
 	for(var/ckey in jobban_keylist)

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -86,7 +86,16 @@
 	set category = "Debug"
 
 	to_chat(usr, "<b>Jobbans active in this round.</b>")
-	for(var/t in jobban_keylist)
+	var/list/list_of_bans = list()
+	var/list/these_bans
+	var/reason
+	for(var/ckey in jobban_keylist)
+		these_bans = jobban_keylist[ckey]
+		if(islist(these_bans))
+			for(var/this_rank in these_bans)
+				reason = these_bans[this_rank]
+				list_of_bans += "[ckey] - [this_rank]" + reason ? " ## [reason]" : null
+	for(var/t in list_of_bans)
 		to_chat(usr, "[t]")
 
 /client/proc/print_jobban_old_filter()
@@ -99,7 +108,16 @@
 		return
 
 	to_chat(usr, "<b>Jobbans active in this round.</b>")
-	for(var/t in jobban_keylist)
+	var/list/list_of_bans = list()
+	var/list/these_bans
+	var/reason
+	for(var/ckey in jobban_keylist)
+		these_bans = jobban_keylist[ckey]
+		if(islist(these_bans))
+			for(var/this_rank in these_bans)
+				reason = these_bans[this_rank]
+				list_of_bans += "[ckey] - [this_rank]" + reason ? " ## [reason]" : null
+	for(var/t in list_of_bans)
 		if(findtext(t, filter))
 			to_chat(usr, "[t]")
 

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -86,17 +86,18 @@
 	set category = "Debug"
 
 	to_chat(usr, "<b>Jobbans active in this round.</b>")
-	var/list/list_of_bans = list()
+//	var/list/list_of_bans = list()
 	var/list/these_bans
 	var/reason
 	for(var/ckey in jobban_keylist)
 		these_bans = jobban_keylist[ckey]
-		if(islist(these_bans))
-			for(var/this_rank in these_bans)
-				reason = these_bans[this_rank]
-				list_of_bans += "[ckey] - [this_rank]" + reason ? " ## [reason]" : null
-	for(var/t in list_of_bans)
-		to_chat(usr, "[t]")
+//		if(islist(these_bans))
+		for(var/this_rank in these_bans)
+			reason = these_bans[this_rank]
+			to_chat(usr, "[ckey] - [this_rank]" + reason ? " ## [reason]" : null)
+//			list_of_bans += "[ckey] - [this_rank]" + reason ? " ## [reason]" : null
+//	for(var/t in list_of_bans)
+//		to_chat(usr, "[t]")
 
 /client/proc/print_jobban_old_filter()
 	set name = "Search Jobban Log"
@@ -108,18 +109,21 @@
 		return
 
 	to_chat(usr, "<b>Jobbans active in this round.</b>")
-	var/list/list_of_bans = list()
+//	var/list/list_of_bans = list()
 	var/list/these_bans
 	var/reason
+	var/t
 	for(var/ckey in jobban_keylist)
 		these_bans = jobban_keylist[ckey]
-		if(islist(these_bans))
-			for(var/this_rank in these_bans)
-				reason = these_bans[this_rank]
-				list_of_bans += "[ckey] - [this_rank]" + reason ? " ## [reason]" : null
-	for(var/t in list_of_bans)
-		if(findtext(t, filter))
-			to_chat(usr, "[t]")
+//		if(islist(these_bans))
+		for(var/this_rank in these_bans)
+			reason = these_bans[this_rank]
+			t = "[ckey] - [this_rank]" + reason ? " ## [reason]" : null
+			if(findtext(t, filter))
+				to_chat(usr, "[t]")
+	//for(var/t in list_of_bans)
+	//	if(findtext(t, filter))
+	//		to_chat(usr, "[t]")
 
 // For /vg/ Wiki docs
 /client/proc/dump_chemreactions()


### PR DESCRIPTION
## What this does
i heard in #35446 that checking job bans at roundstart is a slow process. this is an idea to maybe make the jobban checking faster by using nested lists rather than a monolithic flat list

one potential tradeoff is that initially loading and modifying the database itself requires an extra intermediate step, but reading from the banlist should hopefully be faster, and we can expect checking jobbans to be a lot more frequent than issuing or removing jobbans.

i dont really have experience messing with the database stuff in this context or access to the ban database so maybe someone with more experience can look over the idea and point me in the right direction or help test it

or maybe someone with access to the jobban database file can share it with me

also this isnt fully optimized and de-duplicated, moreso a concept to put out there and see if its worth pursuing and polishing

[wip][help]
