### PR TITLE
Allow for some wiggle room with SMES orders

### DIFF
--- a/code/game/centcomm_orders/orders_engineering.dm
+++ b/code/game/centcomm_orders/orders_engineering.dm
@@ -36,7 +36,7 @@
 /datum/centcomm_order/department/engineering/portable_smes/ExtraChecks(var/obj/machinery/power/battery/portable/P)
 	if (!istype(P))
 		return 0
-	if (P.charge < P.capacity)
+	if (P.charge/P.capacity < 0.995) //Allow for some rounding error wiggle room
 		return 0
 	return 1
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
[bugfix]

## What this does
Bit of a bandaid fix for #35544 that doesn't really address the root issue. Portable SMES with a charge above 99.5% will be admitted by the Centcomm order as "fully charged"

## Why it's good
Addresses #35544, if only partially. But I wouldn't call it an actual fix.