### PR TITLE
SMES now show exact charge and max capacity

### DIFF
--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -204,7 +204,7 @@ var/global/list/battery_online =	list(
 	template["name"] = "SMES Unit" + (name_tag ? " ([name_tag])" : "")
 	template["demand"] = chargeload
 	template["isbattery"] = TRUE
-	template["charge"] = round(100 * charge/capacity)
+	template["charge"] = floor(100 * charge/capacity)
 
 	if (chargereceived > loaddemand)
 		template["charging"] = MONITOR_STATUS_BATTERY_CHARGING
@@ -224,7 +224,7 @@ var/global/list/battery_online =	list(
 	// this is the data which will be sent to the ui
 	var/data[0]
 	data["nameTag"] = name_tag
-	data["storedCapacity"] = round(100.0*charge/capacity, 0.1)
+	data["storedCapacity"] = floor(100 * charge/capacity)
 	data["charging"] = charging
 	data["chargeMode"] = chargemode
 	data["chargeLoad"] = round(chargereceived)

--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -204,7 +204,7 @@ var/global/list/battery_online =	list(
 	template["name"] = "SMES Unit" + (name_tag ? " ([name_tag])" : "")
 	template["demand"] = chargeload
 	template["isbattery"] = TRUE
-	template["charge"] = floor(100 * charge/capacity)
+	template["charge"] = round(100 * charge/capacity)
 
 	if (chargereceived > loaddemand)
 		template["charging"] = MONITOR_STATUS_BATTERY_CHARGING
@@ -224,7 +224,9 @@ var/global/list/battery_online =	list(
 	// this is the data which will be sent to the ui
 	var/data[0]
 	data["nameTag"] = name_tag
-	data["storedCapacity"] = floor(100 * charge/capacity)
+	data["storedCapacity"] = round(100 * charge/capacity)
+	data["charge"] = charge
+	data["capacity"] = capacity
 	data["charging"] = charging
 	data["chargeMode"] = chargemode
 	data["chargeLoad"] = round(chargereceived)

--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -224,7 +224,7 @@ var/global/list/battery_online =	list(
 	// this is the data which will be sent to the ui
 	var/data[0]
 	data["nameTag"] = name_tag
-	data["storedCapacity"] = round(100 * charge/capacity)
+	data["storedCapacity"] = round(100.0*charge/capacity, 0.1)
 	data["charge"] = charge
 	data["capacity"] = capacity
 	data["charging"] = charging

--- a/nano/templates/smes.tmpl
+++ b/nano/templates/smes.tmpl
@@ -6,7 +6,7 @@
 		Stored Capacity:
 	</div>
 	<div class="itemContent">
-		{{:helper.displayBar(data.storedCapacity, 0, 100, data.charging ? 'good' : 'average')}}
+		{{:helper.displayBar(data.storedCapacity, 0, 100, data.charging ? 'good' : 'average', data.charge + '/' + data.capacity)}}
 		<div class="statusValue">
 			{{:helper.round(data.storedCapacity)}}%
 		</div>


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
It's #33872, but for the SMES

## Why it's good
<!-- Explain why you think these changes are good. -->
Same reasons as #33872 I suppose, but also with SMES seemingly freezing at times (see #35544) I believe this might provide some more insight as to what's going on.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added precise charge and max capacity numbers to SMES UI
