### PR TITLE
Art Vendor replacement for Art Storages

### DIFF
--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -107626,7 +107626,14 @@
 /area/engineering/engineering_auxiliary)
 "uiL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/vending/art,
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/paint{
+	pixel_y = 8
+	},
+/obj/item/weapon/reagent_containers/glass/bottle/acetone{
+	pixel_x = 6;
+	pixel_y = 2
+	},
 /turf/simulated/floor,
 /area/storage/art)
 "uiO" = (
@@ -109196,6 +109203,10 @@
 	dir = 1;
 	on = 1
 	},
+/obj/item/weapon/reagent_containers/glass/metal_bucket/paint/filled/random{
+	pixel_x = -8;
+	pixel_y = -6
+	},
 /turf/simulated/floor,
 /area/storage/art)
 "uNX" = (
@@ -109227,6 +109238,10 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
+	},
+/obj/item/weapon/reagent_containers/glass/metal_bucket/paint/filled/random{
+	pixel_x = -8;
+	pixel_y = 12
 	},
 /turf/simulated/floor,
 /area/storage/art)


### PR DESCRIPTION
As agreed with @Kurfursten 

![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/4c5c6be9-e544-43e9-a768-696eed5190d0)

:cl:
* tweak: Maps have had the art vending machine in their Art Storage rooms replaced with some of the new painting items.