### PR TITLE
Supermatter no longer stops delaminating while in space or in a crate.

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -293,7 +293,6 @@
 		damage += max((power-1600)/10, 0)
 		power = min(power, 1600)
 		damage *= 1.007
-		transfer_energy()
 		apply_mob_effects()
 	else // Otherwise do calculations to determine interactions with the local atmosphere. interact_with_local_atmosphere handles damage and power changes.
 		balance_with_atmosphere(L)


### PR DESCRIPTION
I'm interested to hear feedback on this. Essentially whenever a supermatter shard is over 10% delaminated, putting it into space or a crate will not stop it.  

Specifically, every tick while in space or a crate damage to the shard is multiplied by 1.007 if above 10% delamination. This means that while in space a 50% delaminated shard will blow up in 3.6 minutes, a 90% delaminated shard will blow up in 1 minute, and a 20% delaminated shard will blow up in 7 minutes.

I may also add a change so delaminating shards require cooler temps to stop delaminating if this gets positive feedback (i.e. a 0% shard will theoretically never delaminate in a room temperature room, but a 50% shard will continue delaminating unless in a colder room).

This also happens to fix a bug where while in space no hallucinations would be applied due to immediately stopping processing.

:cl:
 * tweak: Supermatter shards in the process of delamination will continue to delaminate while in space or in a secure crate.
