### PR TITLE
vending machines do not advertise to clientless mobs; vending machinery electrification time fixed

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1149,13 +1149,15 @@ var/global/num_vending_terminals = 1
 		return
 
 	if(src.seconds_electrified > 0)
-		src.seconds_electrified--
+		src.seconds_electrified -= 2 /* Machinery processing happens every 2 seconds. */
 
 	//Pitch to the people!  Really sell it!
-	if((last_slogan + slogan_delay <= world.time) && (product_slogans.len > 0) && !shut_up)
+	if(!shut_up && (last_slogan + slogan_delay <= world.time) && (product_slogans.len > 0))
 		var/mob/living/carbon/human/target
 		var/target_dist
 		for(var/mob/living/carbon/human/H in view(7, src)) //We are only going to look for customers that can probably pay
+			if(!H.client)
+				continue
 			var/H_dist = get_dist(H,src)
 			if(!target || (H_dist < target_dist))
 				target = H //pick the closest human


### PR DESCRIPTION
## What this does
- Currently, vending machines decrement their electrification time once every two seconds, despite the intention (as shown by the variable name `seconds_electrified`) being, well, every second. This effectively means that any vending machine with `seconds_electrified = 30` (default value when you pulse the wire) will actually be electrified for 60 seconds. I have fixed this, so they are now only electrified for 30.
- Vending machines no longer waste time doing math to advertise to people that will never see it.
- Vending machines set to not advertise will do one (1) less calculation when the speaker is silenced. This effect is so minuscule it will never really matter, but hey, it's technically better.

## Why it's good
Faster.

[system]

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Vending machines are now electrified for the proper amount of time.
