### PR TITLE
Fixes paintings appearing black when printed from the Remote Gallery Computer

### DIFF
--- a/code/modules/painting/paintings_custom.dm
+++ b/code/modules/painting/paintings_custom.dm
@@ -443,6 +443,7 @@
 		if (render)
 			rendered_icon = painting_data.render_on(icon(base_icon, base_icon_state))
 			rendered_nanomap = painting_data.render_nanomap(icon(base_icon, "[base_icon_state]-nano"))
+			rendered_nanomap.blend_mode = BLEND_ADD
 	else
 		name = base_name
 		desc = base_desc


### PR DESCRIPTION
Fixes #35588

:cl:
* bugfix: Fixed paintings appearing black when printed from the Remote Gallery Computer