### PR TITLE
Another client-side opti suggested by the BYONDers

### DIFF
--- a/code/modules/lighting/light_effect.dm
+++ b/code/modules/lighting/light_effect.dm
@@ -40,7 +40,6 @@
 
 /atom/movable/light/wall_lighting
 	base_light_color_state = "black"
-	appearance_flags = KEEP_TOGETHER | TILE_BOUND
 	animate_movement = NO_STEPS
 
 	var/list/shadow_component_turfs = list()
@@ -48,7 +47,7 @@
 
 /atom/movable/light/secondary_shadow
 	base_light_color_state = "black"
-	appearance_flags = KEEP_TOGETHER | TILE_BOUND
+	appearance_flags = TILE_BOUND
 	animate_movement = NO_STEPS
 
 	var/dir_to_source


### PR DESCRIPTION
Since we don't actually have overlapping icons in the wall-lighting stuff, we can afford not to use `KEEP_TOGETHER`. 
Tests show some small visual difference if you are a ghost, but none as a player.

Benchmarking: 

![image](https://github.com/vgstation-coders/vgstation13/assets/31417754/8794494b-f249-4bae-a9b2-08650b07096b)
