### PR TITLE
Europa Lights server side optimisation

### DIFF
--- a/code/modules/lighting/light_atom.dm
+++ b/code/modules/lighting/light_atom.dm
@@ -18,7 +18,7 @@
 				if (world.tick_usage < TICK_LIMIT_RUNNING && ticker.current_state > GAME_STATE_PREGAME)
 					lighting_update_lights |= L
 				else
-					L.cast_light(get_turf(src))
+					L.cast_light(get_turf(src), newopacity)
 
 /atom/proc/copy_light(var/atom/other)
 	light_range = other.light_range

--- a/code/modules/lighting/light_atom.dm
+++ b/code/modules/lighting/light_atom.dm
@@ -13,11 +13,12 @@
 	var/turf/T = get_turf(src)
 	if(istype(T))
 		T.blocks_light = -1
-		for(var/atom/movable/light/L in range(world.view, T)) //view(world.view, dview_mob))
-			if (world.tick_usage < TICK_LIMIT_RUNNING && ticker.current_state > GAME_STATE_PREGAME)
-				lighting_update_lights |= L
-			else
-				L.cast_light()
+		for(var/atom/movable/light/L in range(9, T)) //view(world.view, dview_mob))
+			if (src in view(L, L.light_range))
+				if (world.tick_usage < TICK_LIMIT_RUNNING && ticker.current_state > GAME_STATE_PREGAME)
+					lighting_update_lights |= L
+				else
+					L.cast_light(get_turf(src))
 
 /atom/proc/copy_light(var/atom/other)
 	light_range = other.light_range

--- a/code/modules/lighting/light_effect_cast.dm
+++ b/code/modules/lighting/light_effect_cast.dm
@@ -68,21 +68,21 @@ var/list/ubiquitous_shadow_renders = list("*shadow2_4_90_1_0_1_1_-1", "*shadow2_
 
 
 // Cast_light() is the "master proc". It does everything in order.
-/atom/movable/light/proc/cast_light(var/turf/updated_turf)
+/atom/movable/light/proc/cast_light(var/turf/updated_turf, var/new_opacity)
 	cast_light_init(updated_turf) // -- Clean up old vars, initialise stuff, in particular, selects the walls to draw shadows on.
 	cast_main_light() // -- Casts the main light source - a square - and the circular mask overlay.
 	update_light_dir() // -- Updates dir. Only useful for some cases.
 	cast_shadows() // -- Casts the masking shadows on the walls.
 	update_appearance() // -- Wrap up everything. Apply filters, apply colours, and voilà.
 
-/atom/movable/light/secondary_shadow/cast_light(var/turf/updated_turf)
+/atom/movable/light/secondary_shadow/cast_light(var/turf/updated_turf, var/new_opacity)
 	return // We don't cast light ourself!
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------------------------
 // -- Main light atom
 
 // Initialisation of the cast_light proc.
-/atom/movable/light/proc/cast_light_init(var/turf/updated_turf)
+/atom/movable/light/proc/cast_light_init(var/turf/updated_turf, var/new_opacity)
 
 	filters = list()
 	temp_appearance = list()
@@ -116,7 +116,10 @@ var/list/ubiquitous_shadow_renders = list("*shadow2_4_90_1_0_1_1_-1", "*shadow2_
 
 	// No need to do the rest of the calculation if we know which turf got updated!!!
 	if (updated_turf)
-		affected_shadow_walls -= updated_turf
+		if (!new_opacity)
+			affected_shadow_walls -= updated_turf
+		else
+			affected_shadow_walls += updated_turf
 		return
 
 	affected_shadow_walls = list()
@@ -162,7 +165,7 @@ var/list/ubiquitous_shadow_renders = list("*shadow2_4_90_1_0_1_1_-1", "*shadow2_
 	if (updated_turf)
 		for (var/list/L in shadow_component_atoms)
 			if (updated_turf in L)
-				L -= updated_turf
+				affected_shadow_walls -= updated_turf
 		return
 
 	shadow_component_turfs = list()

--- a/code/modules/lighting/light_effect_cast.dm
+++ b/code/modules/lighting/light_effect_cast.dm
@@ -166,7 +166,7 @@ var/list/ubiquitous_shadow_renders = list("*shadow2_4_90_1_0_1_1_-1", "*shadow2_
 		for (var/list/L in shadow_component_atoms)
 			if (updated_turf in L)
 				affected_shadow_walls -= updated_turf
-		return
+				return
 
 	shadow_component_turfs = list()
 

--- a/code/modules/lighting/light_effect_cast.dm
+++ b/code/modules/lighting/light_effect_cast.dm
@@ -68,27 +68,26 @@ var/list/ubiquitous_shadow_renders = list("*shadow2_4_90_1_0_1_1_-1", "*shadow2_
 
 
 // Cast_light() is the "master proc". It does everything in order.
-/atom/movable/light/proc/cast_light()
-	cast_light_init() // -- Clean up old vars, initialise stuff, in particular, selects the walls to draw shadows on.
+/atom/movable/light/proc/cast_light(var/turf/updated_turf)
+	cast_light_init(updated_turf) // -- Clean up old vars, initialise stuff, in particular, selects the walls to draw shadows on.
 	cast_main_light() // -- Casts the main light source - a square - and the circular mask overlay.
 	update_light_dir() // -- Updates dir. Only useful for some cases.
 	cast_shadows() // -- Casts the masking shadows on the walls.
 	update_appearance() // -- Wrap up everything. Apply filters, apply colours, and voilà.
 
-/atom/movable/light/secondary_shadow/cast_light()
+/atom/movable/light/secondary_shadow/cast_light(var/turf/updated_turf)
 	return // We don't cast light ourself!
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------------------------
 // -- Main light atom
 
 // Initialisation of the cast_light proc.
-/atom/movable/light/proc/cast_light_init()
+/atom/movable/light/proc/cast_light_init(var/turf/updated_turf)
 
 	filters = list()
 	temp_appearance = list()
 	temp_appearance_shadows = list()
 	cull_light_turfs()
-	affected_shadow_walls = list()
 	pre_rendered_shadows = list()
 	found_prerendered_white_light_glob = FALSE
 
@@ -114,6 +113,13 @@ var/list/ubiquitous_shadow_renders = list("*shadow2_4_90_1_0_1_1_-1", "*shadow2_
 		if (LIGHT_REGULAR_FLICKER)
 			animate(src, alpha = 180, time = 5, loop = -1, easing = CIRCULAR_EASING)
 			animate(alpha = 255, time = 5, loop = -1, easing = CIRCULAR_EASING)
+
+	// No need to do the rest of the calculation if we know which turf got updated!!!
+	if (updated_turf)
+		affected_shadow_walls -= updated_turf
+		return
+
+	affected_shadow_walls = list()
 
 	var/list/cached_view = view(distance_to_wall_illum, src)
 	for (var/thing in cached_view)
@@ -141,16 +147,26 @@ var/list/ubiquitous_shadow_renders = list("*shadow2_4_90_1_0_1_1_-1", "*shadow2_
 
 // -- DIFFERENCE: We look at turfs in a particular spiral order
 // We don't add turfs to `affecting_turfs`.
-/atom/movable/light/wall_lighting/cast_light_init()
+/atom/movable/light/wall_lighting/cast_light_init(var/turf/updated_turf)
 	. = ..()
 
-	shadow_component_turfs = list()
+	var/turf/last_turf_in_group = null
+	var/list/turf_group = list()
+
+	// Need to dynamically redraw atoms...
 	for (var/stuff in shadow_component_atoms)
 		qdel(stuff)
 		shadow_component_atoms -= stuff
 
-	var/turf/last_turf_in_group = null
-	var/list/turf_group = list()
+	// But turf can only be updated lazily.
+	if (updated_turf)
+		for (var/list/L in shadow_component_atoms)
+			if (updated_turf in L)
+				L -= updated_turf
+		return
+
+	shadow_component_turfs = list()
+
 	// Need to do it in a spiral to ensure our group_turfs are connex.
 	for (var/turf/T in spiral_block(get_turf(src), light_range, only_view = TRUE))
 


### PR DESCRIPTION
Euro lights work more or less fine as far as **server** lag is concerned, but one thing I didn't anticipate is that when there's more than 1 or 2 players close to the station, they open doors and move around much more often that a lone tester would.

In fact, over a 3 hours round, `cast_light_init()` gets called hundreds of thousands of times. It only goes up to 0.6 overtime (less so than goonlights) but it is by far the most expensive light proc; the other expensive light procs are contained in  `cast_light_init()` (check if the turfs have the light level of occlusion, and do a spiral block for wall-lighting).

This means that the light atoms must constantly recalculate the turfs they are being cast on. This can causes some server lag, and server lag means latency (especially, unreliable latency kind), and latency means client chug.

I aim to fix this by optimising the way light is calculated when you open/close doors: now only the lights who are specifically affected by the door will be recast, and they won't recalculate their entire turf list - they will just change it to take into account that one turf.

This should help. I tested it.