### PR TITLE
Allows Vampires to Bite Mask Wearing Crew

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -137,10 +137,10 @@
 		to_chat(M, "<span class='warning'> You cannot do this while on the ground!</span>")
 		return FALSE
 
-	if(H.check_body_part_coverage(MOUTH))
-		if(!locate(/datum/power/vampire/mature) in current_powers)
-			to_chat(M, "<span class='warning'>Remove their mask!</span>")
-			return FALSE
+	//if(H.check_body_part_coverage(MOUTH))
+	//	if(!locate(/datum/power/vampire/mature) in current_powers)
+	//		to_chat(M, "<span class='warning'>Remove their mask!</span>")
+	//		return FALSE
 
 	if(vampire_teeth?.amount == 0)
 		to_chat(M, "<span class='warning'>You cannot suck blood with no teeth!</span>")


### PR DESCRIPTION
Just comments out the lines preventing vampires from biting crew wearing masks.

**Why**
I end up as a vampire a lot, and in my experience mask "protection" is actually worse for the victim 
- Forced to disrespect clowns and mimes 
- Forced to nearly/accidentally murder vox
- Promotes taze -> maint drag -> cuff routine, as removing the mask eats into bite time your abilities give you without cuffs
- Implied smooching, embarrassing

It's never prevented me from biting someone, just made it worse for the person being bitten. 

:cl:
 * tweak: Vampires can now bite crew who are wearing a mask