### PR TITLE
Another pass at server side opti

### DIFF
--- a/code/modules/lighting/light_atom.dm
+++ b/code/modules/lighting/light_atom.dm
@@ -14,7 +14,7 @@
 	if(istype(T))
 		T.blocks_light = -1
 		for(var/atom/movable/light/L in range(9, T)) //view(world.view, dview_mob))
-			if (src in view(L, L.light_range))
+			if (get_dist(src, L) <= L.light_range)
 				if (world.tick_usage < TICK_LIMIT_RUNNING && ticker.current_state > GAME_STATE_PREGAME)
 					lighting_update_lights |= L
 				else

--- a/code/modules/lighting/light_effect_cast.dm
+++ b/code/modules/lighting/light_effect_cast.dm
@@ -116,10 +116,12 @@ var/list/ubiquitous_shadow_renders = list("*shadow2_4_90_1_0_1_1_-1", "*shadow2_
 
 	// No need to do the rest of the calculation if we know which turf got updated!!!
 	if (updated_turf)
-		if (!new_opacity)
-			affected_shadow_walls -= updated_turf
+		if (!new_opacity) // We are no longer opaque!!
+			if (updated_turf in affected_shadow_walls)
+				affected_shadow_walls -= updated_turf
 		else
-			affected_shadow_walls += updated_turf
+			if (updated_turf in view(light_range, src))
+				affected_shadow_walls += updated_turf
 		return
 
 	affected_shadow_walls = list()


### PR DESCRIPTION
#35636 helped a lot in server-side stuff (cast_light_init and CheckOcclusion were the biggest offenders), but it also wasn't the best iteration for `set_opacity` as it calls `view()` even for light atoms who are, realistically, not able to view the turf that changed density. Also, it doesn't seem useful to check view if the turf is already in the cached view.

Lastly, because those expensive operations weren't gated behind the subsystem, it could in theory go in overtime and chug the serb. This should now be less likely to happen.

Thank you for playing and helping me find issues!