### PR TITLE
Faster Beak/Claw Butchering

### DIFF
--- a/code/datums/helper_datums/butchering.dm
+++ b/code/datums/helper_datums/butchering.dm
@@ -422,12 +422,12 @@
 		if(H.organ_has_mutation(LIMB_HEAD, M_BEAK))
 			var/obj/item/mask = H.get_item_by_slot(slot_wear_mask)
 			if(!mask || !(mask.body_parts_covered & MOUTH)) //If our mask doesn't cover mouth, we can use our beak to help us while butchering
-				butchSpeed += 0.25
+				butchSpeed += 0.5
 				if(!toolName)
 					toolName = "beak"
 		if(H.organ_has_mutation(H.get_active_hand_organ(), M_CLAWS))
 			if(!istype(H.gloves))
-				butchSpeed += 0.25
+				butchSpeed += 0.5
 				if(!toolName)
 					toolName = "claws"
 	else


### PR DESCRIPTION
## What this does
This doubles the speed of butchering using a beak or claw, making it take around 4 seconds instead of 8. Using a beak or claw to butcher is still noticeably slower than using a pen and leagues slower than kitchen knife. The new speed is demonstrated below alongside other common butchery tools.

https://github.com/vgstation-coders/vgstation13/assets/111808553/fd524613-57dd-40c7-a7c3-d40b7826f588


## Why it's good
Butchering with natural tools took ages to complete. This makes it a bit less painful to do without making it more powerful than the tools that every other spaceman already starts with.

## Changelog
:cl:
 * tweak: doubled the speed of beak and claw butchery