### PR TITLE
Mothership Lab Vault (A bit more forgiveness)

### DIFF
--- a/maps/randomvaults/dungeons/habitation.dmm
+++ b/maps/randomvaults/dungeons/habitation.dmm
@@ -135,10 +135,6 @@
 /obj/item/seeds/pitcher,
 /turf/unsimulated/floor/ayy/fancy,
 /area/vault/mothership_lab/hobo)
-"aY" = (
-/obj/effect/narration/mothership_lab/raidertunnel2,
-/turf/unsimulated/floor/lab_asteroid,
-/area/vault/mothership_lab/raidtunnel_lower)
 "bb" = (
 /obj/machinery/space_heater,
 /turf/unsimulated/floor/ayy/maint,
@@ -2329,6 +2325,10 @@
 /obj/item/weapon/barricade_kit,
 /turf/unsimulated/floor/ayy,
 /area/vault/mothership_lab/habitation)
+"tE" = (
+/obj/effect/narration/mothership_lab/raidertunnel2,
+/turf/unsimulated/floor/lab_asteroid,
+/area/vault/mothership_lab/raidtunnel_lower)
 "tF" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
@@ -5311,9 +5311,7 @@
 /turf/unsimulated/floor/lab_sterile,
 /area/vault/mothership_lab/habitation)
 "UL" = (
-/obj/machinery/r_n_d/fabricator/mechanic_fab/autolathe/ammolathe{
-	desc = "Produces guns, ammunition, and firearm accessories."sss
-	},
+/obj/machinery/r_n_d/fabricator/mechanic_fab/autolathe/ammolathe,
 /turf/unsimulated/floor/lab_asteroid,
 /area/vault/mothership_lab/raidtunnel_lower)
 "UM" = (
@@ -9263,7 +9261,7 @@ mz
 fd
 pe
 fS
-aY
+tE
 mz
 mz
 ek

--- a/maps/randomvaults/dungeons/habitation.dmm
+++ b/maps/randomvaults/dungeons/habitation.dmm
@@ -9308,7 +9308,7 @@ Pr
 sN
 mz
 bC
-mz
+au
 Gy
 sN
 sN

--- a/maps/randomvaults/dungeons/habitation.dmm
+++ b/maps/randomvaults/dungeons/habitation.dmm
@@ -135,6 +135,10 @@
 /obj/item/seeds/pitcher,
 /turf/unsimulated/floor/ayy/fancy,
 /area/vault/mothership_lab/hobo)
+"aY" = (
+/obj/effect/narration/mothership_lab/raidertunnel2,
+/turf/unsimulated/floor/lab_asteroid,
+/area/vault/mothership_lab/raidtunnel_lower)
 "bb" = (
 /obj/machinery/space_heater,
 /turf/unsimulated/floor/ayy/maint,
@@ -586,7 +590,14 @@
 /turf/unsimulated/floor/ayy/maint,
 /area/vault/mothership_lab/hobo)
 "fd" = (
-/obj/structure/ore_box,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpse/grey/soldier_unarmed,
+/obj/item/device/flashlight/flare/ever_bright,
+/obj/effect/decal/cleanable/blood{
+	basecolor = "#CFAAAA";
+	blood_color = "#CFAAAA";
+	icon_state = "floor5"
+	},
 /turf/unsimulated/floor/lab_asteroid,
 /area/vault/mothership_lab/raidtunnel_lower)
 "fh" = (
@@ -697,6 +708,11 @@
 /obj/item/stack/cable_coil,
 /turf/unsimulated/floor/ayy/maint,
 /area/vault/mothership_lab/cave)
+"fS" = (
+/obj/structure/window/barricade,
+/obj/item/weapon/beartrap/ied/armed,
+/turf/unsimulated/floor/lab_asteroid,
+/area/vault/mothership_lab/raidtunnel_lower)
 "fW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/barricade/full/block,
@@ -790,7 +806,6 @@
 /area/vault/mothership_lab/habitation)
 "gG" = (
 /obj/structure/cage/autoclose/cover,
-/obj/effect/landmark/corpse/grey/soldier_unarmed,
 /obj/effect/decal/cleanable/blood{
 	basecolor = "#CFAAAA";
 	blood_color = "#CFAAAA"
@@ -1058,6 +1073,10 @@
 /obj/structure/bed/ayy1,
 /turf/unsimulated/floor/ayy/fancy,
 /area/vault/mothership_lab/habitation)
+"jo" = (
+/obj/item/stack/medical/bruise_pack,
+/turf/unsimulated/floor/lab_sterile,
+/area/vault/mothership_lab/cave)
 "jr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1651,6 +1670,7 @@
 	blood_color = "#CFAAAA";
 	icon_state = "floor2"
 	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/unsimulated/floor/lab_asteroid,
 /area/vault/mothership_lab/raidtunnel_lower)
 "nY" = (
@@ -1698,6 +1718,13 @@
 /obj/machinery/vending/hydroseeds,
 /turf/unsimulated/floor/ayy/maint,
 /area/vault/mothership_lab/habitation)
+"oy" = (
+/obj/machinery/recharger/self_powered{
+	pixel_y = 30
+	},
+/obj/item/device/flashlight/flare/ever_bright,
+/turf/unsimulated/floor/lab_asteroid,
+/area/vault/mothership_lab/raidtunnel_lower)
 "oE" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1779,7 +1806,6 @@
 "pe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/trap/frog_trap/raider,
-/obj/item/device/flashlight/flare/ever_bright,
 /turf/unsimulated/floor/lab_asteroid,
 /area/vault/mothership_lab/raidtunnel_lower)
 "pf" = (
@@ -2199,6 +2225,12 @@
 /obj/item/weapon/pickaxe/drill,
 /turf/unsimulated/floor/lab_asteroid,
 /area/vault/mothership_lab/raidtunnel_lower)
+"sF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/recharger,
+/obj/item/weapon/gun/energy/smalldisintegrator,
+/turf/unsimulated/floor,
+/area/vault/mothership_lab/cave)
 "sI" = (
 /obj/structure/ladder{
 	height = 1;
@@ -3933,8 +3965,8 @@
 "HO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip{
-	basecolor = "#2299FC";
-	blood_color = "#2299FC"
+	basecolor = "#CFAAAA";
+	blood_color = "#CFAAAA"
 	},
 /turf/unsimulated/floor/lab_asteroid,
 /area/vault/mothership_lab/raidtunnel_lower)
@@ -4637,9 +4669,8 @@
 /turf/unsimulated/floor,
 /area/vault/mothership_lab/cave)
 "Pr" = (
-/obj/effect/decal/cleanable/cobweb2,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
+/obj/effect/decal/cleanable/cobweb2,
 /turf/unsimulated/floor/lab_asteroid,
 /area/vault/mothership_lab/raidtunnel_lower)
 "Pu" = (
@@ -5280,8 +5311,9 @@
 /turf/unsimulated/floor/lab_sterile,
 /area/vault/mothership_lab/habitation)
 "UL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/r_n_d/fabricator/mechanic_fab/autolathe/ammolathe{
+	desc = "Produces guns, ammunition, and firearm accessories."sss
+	},
 /turf/unsimulated/floor/lab_asteroid,
 /area/vault/mothership_lab/raidtunnel_lower)
 "UM" = (
@@ -5710,6 +5742,11 @@
 /obj/machinery/chem_dispenser/booze_dispenser,
 /turf/unsimulated/floor/lab_sterile,
 /area/vault/mothership_lab/habitation)
+"Yq" = (
+/obj/structure/ore_box,
+/obj/item/weapon/pickaxe/drill,
+/turf/unsimulated/floor/lab_asteroid,
+/area/vault/mothership_lab/raidtunnel_lower)
 "Ys" = (
 /obj/structure/window/barricade{
 	dir = 1
@@ -7383,8 +7420,8 @@ Xb
 Vy
 uh
 WJ
-WJ
-Vy
+jo
+sF
 kF
 uh
 gd
@@ -8504,7 +8541,7 @@ ib
 ib
 ub
 ek
-gz
+UL
 mz
 sN
 mz
@@ -8645,7 +8682,7 @@ ib
 ib
 ub
 ek
-zk
+oy
 Gs
 kt
 sN
@@ -8910,7 +8947,7 @@ RF
 fz
 Aw
 mz
-vY
+Gy
 ek
 ub
 ib
@@ -9128,9 +9165,9 @@ gz
 eq
 sN
 bC
-UL
+mz
 sN
-sN
+Yq
 ek
 ek
 ek
@@ -9178,8 +9215,8 @@ GB
 sN
 sN
 sN
-qI
-mz
+bC
+au
 qI
 ek
 Td
@@ -9189,7 +9226,7 @@ Aw
 lt
 ek
 sN
-sN
+Gy
 mz
 ek
 ub
@@ -9223,12 +9260,12 @@ yY
 yY
 bC
 mz
-mz
-pe
-sN
-mz
-sN
 fd
+pe
+fS
+aY
+mz
+mz
 ek
 ek
 ek
@@ -9269,18 +9306,18 @@ ub
 ek
 ek
 ek
-ek
-au
+Pr
 sN
-sN
-sN
-sN
-sN
-fj
 mz
+bC
+au
+Gy
 sN
 sN
+mz
+qI
 sN
+mz
 sN
 sN
 ek
@@ -9316,16 +9353,16 @@ ib
 ub
 ub
 ub
-ub
 ek
-Pr
-mz
+ek
+ek
+ek
+ek
+qI
 mz
 sN
-mz
 sN
-sN
-vY
+Gy
 mz
 sN
 qI
@@ -9363,10 +9400,10 @@ ib
 ib
 ib
 ib
-ib
 ub
-ek
-ek
+ub
+ub
+ub
 ek
 ek
 ek
@@ -9412,7 +9449,7 @@ ib
 ib
 ib
 ib
-ub
+ib
 ub
 ub
 ub

--- a/maps/randomvaults/dungeons/habitation.dmm
+++ b/maps/randomvaults/dungeons/habitation.dmm
@@ -9308,7 +9308,7 @@ Pr
 sN
 mz
 bC
-au
+mz
 Gy
 sN
 sN
@@ -9355,9 +9355,9 @@ ek
 ek
 ek
 ek
-ek
 qI
 mz
+sN
 sN
 sN
 Gy

--- a/maps/randomvaults/mothership_lab.dm
+++ b/maps/randomvaults/mothership_lab.dm
@@ -487,7 +487,7 @@
 	play_sound = 'sound/ambience/ambigen3.ogg'
 
 /obj/effect/narration/mothership_lab/raidertunnel2 // This tunnel be for pirates, matey
-	msg = "There is a soft scratching sound, like claws scraping against rock. And you swear you hear soft whispers in the dark. Something is waiting for you just ahead."
+	msg = "There is a soft scratching sound, like claws scraping against rock. And you swear you hear low whispers in the dark. Something is waiting for you just ahead."
 
 /obj/effect/narration/mothership_lab/habitationdeck // This deck be a bad place
 	msg = "As you enter the habitation deck, you see a chaotic scene highlighted by the dim red light of emergency flares. Scorched plating, bullet impacts, blood, and makeshift barricades are scattered everywhere."

--- a/maps/randomvaults/mothership_lab.dm
+++ b/maps/randomvaults/mothership_lab.dm
@@ -486,6 +486,9 @@
 	msg = "As you climb the ladder you find yourself in a hastily dug tunnel. Dark crevices and collapsed piles of rock rubble make this a prime place for an ambush. You should be cautious."
 	play_sound = 'sound/ambience/ambigen3.ogg'
 
+/obj/effect/narration/mothership_lab/raidertunnel2 // This tunnel be for pirates, matey
+	msg = "There is a soft scratching sound, like claws scraping against rock. And you swear you hear soft whispers in the dark. Something is waiting for you just ahead."
+
 /obj/effect/narration/mothership_lab/habitationdeck // This deck be a bad place
 	msg = "As you enter the habitation deck, you see a chaotic scene highlighted by the dim red light of emergency flares. Scorched plating, bullet impacts, blood, and makeshift barricades are scattered everywhere."
 	play_sound = 'sound/ambience/spookymaint2.ogg'

--- a/maps/randomvaults/mothership_lab.dmm
+++ b/maps/randomvaults/mothership_lab.dmm
@@ -569,8 +569,7 @@
 /area/vault/mothership_lab/entrance)
 "jH" = (
 /obj/structure/rack,
-/obj/item/weapon/pickaxe/shovel,
-/obj/item/weapon/pickaxe/shovel,
+/obj/item/weapon/gun/energy/smalldisintegrator,
 /turf/unsimulated/floor/airless{
 	dir = 10;
 	icon_state = "asteroidwarning"
@@ -760,6 +759,19 @@
 	},
 /turf/unsimulated/floor/ayy,
 /area/vault/mothership_lab/entrance)
+"mr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/guncabinet{
+	anchored = 1;
+	name = "raider gun cabinet";
+	req_access = null
+	},
+/obj/item/ammo_storage/magazine/m380auto,
+/obj/item/ammo_storage/magazine/m380auto,
+/obj/item/weapon/gun/projectile/glock,
+/obj/item/weapon/gun/projectile/glock,
+/turf/unsimulated/floor/lab_asteroid,
+/area/vault/mothership_lab/raidtunnel_upper)
 "mu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/floor/asteroid/air,
@@ -769,6 +781,8 @@
 /area/vault/mothership_lab/asteroid)
 "my" = (
 /obj/structure/rack,
+/obj/item/weapon/pickaxe/shovel,
+/obj/item/weapon/pickaxe/shovel,
 /obj/item/weapon/pickaxe/drill,
 /obj/item/weapon/pickaxe/drill,
 /obj/item/weapon/pickaxe/drill,
@@ -1798,7 +1812,6 @@
 /obj/item/clothing/shoes/jackboots/mothership,
 /obj/item/clothing/under/grey/grey_scout,
 /obj/structure/closet/crate/ayy,
-/obj/item/weapon/reagent_containers/food/snacks/zambiscuit_radical,
 /turf/unsimulated/floor/ayy/fancy,
 /area/vault/mothership_lab/entrance)
 "zX" = (
@@ -1943,7 +1956,9 @@
 /obj/structure/table,
 /obj/item/weapon/paper,
 /obj/item/weapon/pen/multi,
-/obj/item/weapon/gun/energy/smalldisintegrator,
+/obj/machinery/recharger{
+	pixel_x = 30
+	},
 /turf/unsimulated/floor/ayy/maint,
 /area/vault/mothership_lab/entrance)
 "BX" = (
@@ -3101,9 +3116,7 @@
 	},
 /obj/item/clothing/suit/armor/mothership/explorer,
 /obj/item/clothing/head/helmet/mothership_explorer,
-/obj/item/weapon/reagent_containers/food/snacks/zambiscuit_radical,
-/obj/item/weapon/reagent_containers/food/snacks/zambiscuit_radical,
-/obj/item/weapon/reagent_containers/food/snacks/zambiscuit_radical,
+/obj/item/weapon/card/id/mothership_soldier,
 /turf/unsimulated/floor/ayy/fancy,
 /area/vault/mothership_lab/entrance)
 "Ww" = (
@@ -5132,7 +5145,7 @@ GL
 GL
 MD
 Qz
-bq
+mr
 cn
 MQ
 Qz
@@ -5274,7 +5287,7 @@ Au
 Qz
 Qz
 Qz
-MQ
+nd
 Qz
 MD
 zr


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes. PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation or the coding discord (you can find an invite link on the irc or the thread) to discuss your changes, or if you need help.

== SELF LABELLING PRs ==
You can now self-label your PR! The syntax is simple. Just put [<labeltag>] anywhere in your PR,
where <labeltag> is to be replaced by one of the following (allowing with the resultant tag)
just ctrl+f the list or something. I know it's long.

administration = "Logging / Administration"
away = "Mapping (Away Mission :earth_africa:)"
bagel = "Mapping (Bagel :o:)"
box = "Mapping (Box :baby:)"
bugfix = "Bug / Fix"
bus = "Mapping (Bus :bus:)"
byond = "T-Thanks BYOND"
consistency = "Consistency Issue"
controversial = "Controversial"
deff = "Mapping (Deff :wastebasket:)"
discussion = "Discussion"
dnm = "✋ Do Not Merge ✋"
easy = "Easy Fix"
exploitable = "Exploitable"
featureloss = "Feature Loss"
featurerequest = "Feature Request"
first = "good first issue"
formatting = "Grammar / Formatting"
gamemode = "Gameplay / Gamemode"
gameplay = "Gameplay / Gamemode"
general = "Mapping (General :world_map:)"
goonchat = "Goonchat"
grammar = "Grammar / Formatting"
help = "help wanted"
hotfix = "Hotfix"
libvg = "libvg"
logging = "Logging / Administration"
meta = "Mapping (Meta :no_mobile_phones:)"
needspritework = "Needs Spritework"
oversight = "Oversight"
packed = "Mapping (Packed :package:)"
parallax = "Parallax"
qol = "❤️ Quality of Life ❤️"
roid = "Mapping (Roidstation :pick:)"
role = "Role Datums"
roleissue = "Role Datums Issue"
runtime = "Runtime Log"
sanity = "Sanity / Ghosthands"
snowmap = "Mapping (Snowmap ❄)"
sound = "Sound"
sprites = "Sprites"
spriteworkdone = "Spritework Done Needs Coder"
system = "System"
taxi = "Mapping (Taxi :taxi:)"
tested = "100%  tested"
tweak = "Tweak"
ui = "UI"
vault = "Mapping (Vault :question:)"
vote = "⛔ Requires Server Vote ⛔"
wip = "WiP"

== CHANGELOGS ==
Changelogs can be attached either by following the instructions in html/changelogs/example.yml, or by attaching an in-body changelog like the one attached to your PR automatically.

For the keys you can use in an in-body changelog, they are the same as described in example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!

Valid Prefixes:
bugfix
wip (For works in progress)
tweak
soundadd
sounddel
rscdel (general deleting of nice things)
rscadd (general adding of nice things)
imageadd
imagedel
spellcheck (typo fixes)
experiment
tgs (TG-ported fixes?)

An example changelog is attached to this PR for your convenience:
-->
## Regular Scheduled Mothership Lab Maintenance ##
I decided to do a little work on improving the start of the mothership lab for hobos and hapless explorers who stumble upon it. The general intent of these changes was to increase the chance that a hobo or random explorer finds something to arm themselves with before going into battle against the rather tough mobs that inhabit the vault.

I also made one of the cruelest parts of the vault a bit more obvious, so a player can take note and avoid it more easily.

### Changes (With screenshots) ###
![image](https://github.com/vgstation-coders/vgstation13/assets/81007356/9b4909e3-f80a-4d63-8505-84fdfd3c6db7)
- Added a locker with two glocks to the entrance of the vox raider tunnel, in the cage room

![image](https://github.com/vgstation-coders/vgstation13/assets/81007356/becd3619-19c2-4849-bcaa-11673f44957f)
- Moved the disintegrator that was previously inside the mining explosives shed (guarded by the GDR Trooper) to one of the racks outside

![image](https://github.com/vgstation-coders/vgstation13/assets/81007356/4e01c40a-b59e-4b5f-8761-2a700f6b8df7)
- Added a soldier ID card to one of the lockers in the explorer gear storage, so the disintegrator in the secure crate nearby can be accessed more easily

![image](https://github.com/vgstation-coders/vgstation13/assets/81007356/67aca0ba-4fd9-4d42-bb21-b05bb22a4f5f)
- Added a disintegrator and recharger near the dead laborer in the abandoned maintenance area of the habitation deck

![image](https://github.com/vgstation-coders/vgstation13/assets/81007356/2767b794-89fe-4dd3-985e-018d5c677b53)
- Made the vox assassin ambush spot more obvious, with an additional narrative warning when a player gets very close

![image](https://github.com/vgstation-coders/vgstation13/assets/81007356/3ce4b814-9855-4dca-a8b3-766faab3f579)
- Added an ammolathe to the vox raider armory

[vault]

:cl:
 * tweak: Made the start of the mothership lab vault a bit more forgiving