### PR TITLE
[revival] tile replace shortcut

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -555,6 +555,15 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 					make_tiled_floor(T)
 			else
 				to_chat(user, "<span class='warning'>This section is too damaged to support a tile. Use a welder to fix the damage.</span>")
+		else if(iscrowbar(user.get_inactive_hand()))
+			var/obj/item/stack/tile/T = C
+			if(istype(T))
+				if(T.type == floor_tile.type)
+					return
+				if(T.use(1))
+					floor_tile.forceMove(src)
+					floor_tile = null
+					make_tiled_floor(T)
 	else if(isshovel(C))
 		if(is_grass_floor())
 			playsound(src, 'sound/items/shovel.ogg', 50, 1)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -561,9 +561,27 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 				if(T.type == floor_tile.type)
 					return
 				if(T.use(1))
-					floor_tile.forceMove(src)
-					floor_tile = null
-					make_tiled_floor(T)
+					if(is_wood_floor())
+						qdel(floor_tile)
+						make_tiled_floor(T)
+						return
+					else
+						floor_tile.forceMove(src)
+						floor_tile = null
+						make_tiled_floor(T)
+						return
+			return
+		else if(istype(user.get_inactive_hand(), /obj/item/tool/screwdriver))
+			if(is_wood_floor())
+				var/obj/item/stack/tile/T = C
+				if(istype(T))
+					if(T.type == floor_tile.type)
+						return
+					if(T.use(1))
+						floor_tile.forceMove(src)
+						floor_tile = null
+						make_tiled_floor(T)
+			return
 	else if(isshovel(C))
 		if(is_grass_floor())
 			playsound(src, 'sound/items/shovel.ogg', 50, 1)


### PR DESCRIPTION
## What this does
Closes #34990
This is a modified revival of Dorian's floor tile replacing shortcut.
To do it, have a floor tile in your active hand, and a crowbar in your inactive hand.
Click floor tiles to instantly replace them AND have the old floor tile appear on the tile.

Preview:
![image](https://github.com/vgstation-coders/vgstation13/assets/26285377/76c771cb-c763-41f4-b950-c9ec2dc8a7b1)



[tested][qol]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: You can now replace tiles quickly by holding the stack of tiles in your main hand & a crowbar in your off hand.
 * rscadd: You can now replace wooden tiles quickly by holding the stack of tiles in your main hand & a screwdriver in your off hand. The crowbar can do this with wood tiles too, but it will destroy them.