### PR TITLE
gymrat interaction text fix

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
@@ -6,9 +6,9 @@
 	icon_state = "gymrat"
 	icon_living = "gymrat"
 	icon_dead = "gymrat-dead"
-	response_help  = "pets the"
-	response_disarm = "gently pushes aside the"
-	response_harm   = "stamps on the"
+	response_help  = "pets"
+	response_disarm = "gently pushes aside"
+	response_harm   = "stomps on the"
 	treadmill_speed = 6
 	health = 30
 	maxHealth = 30
@@ -334,8 +334,8 @@
 	desc = "It's yoked! Holy shit!"
 	icon_state = "roidrat"
 	icon_living = "roidrat"
-	response_help  = "massages the"
-	response_disarm = "stares jealously at the"
+	response_help  = "massages"
+	response_disarm = "stares jealously at"
 	response_harm   = "angrily kicks the"
 	treadmill_speed = 3 // CARDIO IS FOR DWEEBS
 	health = 150 // Damn, brother


### PR DESCRIPTION
## What this does
It no longer says "the the gym rat" when interacting with a gym/pompadour/roid rat
Also changes stamps for stomps, cause while both are valid, I feel stomp is more appropriate due to the hostility involved.
Closes #35651
:cl:
 * spellcheck: Removes a duplicate "the" when interacting with a gym rat or its variants.
 * spellcheck: Changes stamps for stomps when harm intent interacting with a gym rat.