### PR TITLE
Fixes Diseases Appearing on All HUDs

### DIFF
--- a/code/datums/hud/pathogen_hud.dm
+++ b/code/datums/hud/pathogen_hud.dm
@@ -5,7 +5,7 @@ var/list/science_goggles_wearers = list()
 /datum/visioneffect/pathogen
 	name = "pathogen hud"
 
-/datum/visioneffect/on_apply(var/mob/M)
+/datum/visioneffect/pathogen/on_apply(var/mob/M)
 	..()
 	if(!M.client)
 		return
@@ -27,7 +27,7 @@ var/list/science_goggles_wearers = list()
 	..()
 	M.overlay_fullscreen("science", /obj/abstract/screen/fullscreen/science)
 
-/datum/visioneffect/on_remove(var/mob/M)
+/datum/visioneffect/pathogen/on_remove(var/mob/M)
 	..()
 	if(!M.client)
 		return


### PR DESCRIPTION
how could this happen to me

[glassesonoff.webm](https://github.com/vgstation-coders/vgstation13/assets/69739118/a4692ac5-035e-4f0f-829b-7bbe72f9d3ed)

## What this does
Fixes a huge bug that I missed in testing somehow. Makes diseases stop appearing when you use any HUD glasses at all. Fixes #35665.

## Why it's good
security can't see the diseases that the crew carry anymore, and nerfs medical so that they can't either unless they get the funny purple goggles

## Changelog
[bugfix] [hotfix] [ui]
:cl:
 * bugfix: Fixed pathogens showing up on non-science goggles