### PR TITLE
Dynamic Event Repairs

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -180,6 +180,10 @@
 		result = first ^ second
 	return result
 
+//Returns a new list of only elements in both lists.
+/proc/andlist(var/list/A, var/list/B)
+	return A & B
+
 //Picks an element based on its weight
 /proc/pickweight(list/L)
 	if(!L || !L.len)

--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -674,7 +674,7 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 
 /datum/command_alert/eagles
 	name = "Airlock Access Removed"
-	message = "Centcomm airlock control override activated. Please take this time to get acquainted with your coworkers."
+	message = "Centcomm airlock control override activated. Access requirements lifted for all non-security and command airlocks."
 
 /datum/command_alert/bluespace_artillery
 	name = "Bluespace Artillery Strike Detected"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -821,45 +821,29 @@ var/global/floorIsLava = 0
 			<BR>
 			"}
 
-
+	/*Anything on this list should have a justifcation to be its own button instead of just the pickevent
+	Parenthesis usually specify the feature that makes this different than just spawning the event
+	Bus Only are events that don't trigger on their own, or were never actually made into event datums
+	*/
 	if(check_rights(R_FUN,0))
 		dat += {"
-			<B>'Random' Events</B><BR>
+			<B>Dynamic Events</B><BR>
+			<a href='?src=\ref[src];secretsfun=pick_event'>Pick a specific Dynamic Event</A><BR>
+			<a href='?src=\ref[src];secretsfun=roll_event'>Roll a random Dynamic Event</A><BR>
 			<BR>
-			<A href='?src=\ref[src];secretsfun=wave'>Spawn a wave of meteors (aka lagocolyptic shower)</A><BR>
-			<A href='?src=\ref[src];secretsfun=silent_meteors'>Spawn a wave of meteors with no warning</A><BR>
+			<A href='?src=\ref[src];secretsfun=vermin_infestation'>Vermin infestation (specify type and location)</A><BR>
+			<A href='?src=\ref[src];secretsfun=hostile_infestation'>Monster infestation (specify type and location)</A><BR>
+			<A href='?src=\ref[src];secretsfun=virus'>Virus Outbreak (lesser, greater, or custom)</A><BR>
+			<A href='?src=\ref[src];secretsfun=comms_blackout'>Communications blackout (silent or announced)</A><BR>
+			<A href='?src=\ref[src];secretsfun=breaklink'>Break the station's link with Central Command (indefinitely)</A><BR>
+			<A href='?src=\ref[src];secretsfun=makelink'>Fix the station's link with Central Command</A><BR>
+			<BR>
+			<B>Bus-Only Events</B>
+			<BR>
 			<A href='?src=\ref[src];secretsfun=gravity'>Toggle station artificial gravity</A><BR>
 			<A href='?src=\ref[src];secretsfun=gravanomalies'>Spawn a gravitational anomaly (aka lagitational anomolag)</A><BR>
 			<A href='?src=\ref[src];secretsfun=timeanomalies'>Spawn wormholes</A><BR>
-			<A href='?src=\ref[src];secretsfun=immovable'>Spawn an Immovable Rod</A><BR>
-			<A href='?src=\ref[src];secretsfun=immovablebig'>Spawn an Immovable Pillar</A><BR>
-			<A href='?src=\ref[src];secretsfun=immovablehyper'>Spawn an Immovable Monolith (highly destructive!)</A><BR>
-			<A href='?src=\ref[src];secretsfun=meaty_gores'>Trigger an Organic Debris Field</A><BR>
-			<A href='?src=\ref[src];secretsfun=fireworks'>Send some fireworks at the station</A><BR>
-			<A href='?src=\ref[src];secretsfun=old_vendotron_crash'>Launch an old vendotron at the station</A><BR>
-			<A href='?src=\ref[src];secretsfun=old_vendotron_teleport'>Teleport an old vendotron onto the station</A><BR>
-			<BR>
-			<A href='?src=\ref[src];secretsfun=blobwave'>Spawn a blob cluster</A><BR>
-			<A href='?src=\ref[src];secretsfun=aliens'>Trigger an Alien infestation</A><BR>
-			<A href='?src=\ref[src];secretsfun=alien_silent'>Spawn an Alien silently</A><BR>
-			<A href='?src=\ref[src];secretsfun=spiders'>Trigger a Spider infestation</A><BR>
-			<A href='?src=\ref[src];secretsfun=vermin_infestation'>Spawn a vermin infestation</A><BR>
-			<A href='?src=\ref[src];secretsfun=hostile_infestation'>Spawn a hostile creature infestation</A><BR>
-			<A href='?src=\ref[src];secretsfun=carp'>Trigger a Carp migration</A><BR>
-			<A href='?src=\ref[src];secretsfun=mobswarm'>Trigger mobs of your choice appearing out of thin air</A><BR>
-			<BR>
-			<A href='?src=\ref[src];secretsfun=spacevines'>Spawn Space-Vines</A><BR>
-			<A href='?src=\ref[src];secretsfun=radiation'>Irradiate the station</A><BR>
-			<A href='?src=\ref[src];secretsfun=virus'>Trigger a Virus Outbreak</A><BR>
-			<A href='?src=\ref[src];secretsfun=mass_hallucination'>Cause the crew to hallucinate</A><BR>
-			<BR>
-			<A href='?src=\ref[src];secretsfun=lightsout'>Trigger an Electrical Storm (breaks some lights)</A><BR>
-			<A href='?src=\ref[src];secretsfun=prison_break'>Trigger a Prison Break</A><BR>
-			<A href='?src=\ref[src];secretsfun=ionstorm'>Spawn an Ion Storm</A><BR>
-			<A href='?src=\ref[src];secretsfun=comms_blackout'>Trigger a communication blackout</A><BR>
-			<A href='?src=\ref[src];secretsfun=pda_spam'>Trigger a wave of PDA spams</A><BR>
-			<A href='?src=\ref[src];secretsfun=money_lotto'>Start a lotto draw</A><BR>
-			<a href='?src=\ref[src];secretsfun=pick_event'>Pick a random event from all possible random events (WARNING, NOT ALL ARE GUARANTEED TO WORK).</A><BR>
+			<A href='?src=\ref[src];secretsfun=mobswarm'>Any mob infestation (specify type only)</A><BR>
 			<BR>
 			<B>Fun Secrets</B><BR>
 			<BR>

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3761,9 +3761,15 @@
 access_ai_upload,access_teleporter,access_heads,access_captain,access_all_personal_lockers,access_rd,access_cmo,
 access_heads_vault,access_ce,access_hop,access_hos,access_RC_announce,access_keycard_auth,access_tcomsat,access_gateway,
 access_sec_doors,access_salvage_captain,access_cent_ert,access_syndicate,access_trade)
-				for(var/obj/machinery/door/airlock/W in all_doors)
+				var/list/filter = get_all_accesses() - no_eagle_access
+				for(var/obj/machinery/door/W in all_doors)
+					if(!W.req_access)
+						W.set_up_access()
 					if(W.z == map.zMainStation)
-						W.req_access -= no_eagle_access
+						if(W.req_access && W.req_access.len)
+							W.req_access = W.req_access - filter
+						if(W.req_one_access && W.req_one_access.len)
+							W.req_one_access = W.req_one_access - filter
 				message_admins("[key_name_admin(usr)] activated Egalitarian Station mode")
 				command_alert(/datum/command_alert/eagles)
 			if("dorf")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3382,21 +3382,7 @@
 					log_admin("[key_name(usr)] toggled gravity off.", 1)
 					message_admins("<span class='notice'>[key_name_admin(usr)] toggled gravity off.</span>", 1)
 					command_alert(/datum/command_alert/gravity_disabled)
-			if("wave")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","Meteor")
-				log_admin("[key_name(usr)] spawned a meteor wave", 1)
-				message_admins("<span class='notice'>[key_name_admin(usr)] spawned a meteor wave.</span>", 1)
-				new /datum/event/meteor_wave
 
-			if("blobwave")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","Blob Wave")
-				log_admin("[key_name(usr)] spawned a blob cluster", 1)
-				message_admins("<span class='notice'>[key_name_admin(usr)] spawned a blob cluster.</span>", 1)
-
-				if(alert(usr, "Spawn a blob cluster? (meteor blob, medium intensity, no Overminds)", "Blob Cluster", "Yes", "No") == "Yes")
-					new /datum/event/thing_storm/blob_shower
 			if("power")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","P")
@@ -3530,51 +3516,6 @@
 				for(var/mob/M in player_list)
 					if(M.stat != 2)
 						M.show_message(text("<span class='notice'>The chilling wind suddenly stops...</span>"), 1)
-/*				if("shockwave")
-				to_chat(world, "<span class='danger'><big>ALERT: STATION STRESS CRITICAL</big></span>")
-				sleep(60)
-				to_chat(world, "<span class='danger'><big>ALERT: STATION STRESS CRITICAL. TOLERABLE LEVELS EXCEEDED!</big></span>")
-				sleep(80)
-				to_chat(world, "<span class='danger'><big>ALERT: STATION STRUCTURAL STRESS CRITICAL. SAFETY MECHANISMS FAILED!</big></span>")
-				sleep(40)
-				for(var/mob/M in world)
-					shake_camera(M, 400, 1)
-				for(var/obj/structure/window/W in world)
-					spawn(0)
-						sleep(rand(10,400))
-						W.ex_act(rand(2,1))
-				for(var/obj/structure/grille/G in world)
-					spawn(0)
-						sleep(rand(20,400))
-						G.ex_act(rand(2,1))
-				for(var/obj/machinery/door/D in world)
-					spawn(0)
-						sleep(rand(20,400))
-						D.ex_act(rand(2,1))
-				for(var/turf/station/floor/Floor in world)
-					spawn(0)
-						sleep(rand(30,400))
-						Floor.ex_act(rand(2,1))
-				for(var/obj/structure/cable/Cable in world)
-					spawn(0)
-						sleep(rand(30,400))
-						Cable.ex_act(rand(2,1))
-				for(var/obj/structure/closet/Closet in world)
-					spawn(0)
-						sleep(rand(30,400))
-						Closet.ex_act(rand(2,1))
-				for(var/obj/machinery/Machinery in world)
-					spawn(0)
-						sleep(rand(30,400))
-						Machinery.ex_act(rand(1,3))
-				for(var/turf/station/wall/Wall in world)
-					spawn(0)
-						sleep(rand(30,400))
-						Wall.ex_act(rand(2,1)) */
-			if("wave")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","MW")
-				new /datum/event/meteor_wave
 
 			if("gravanomalies")
 				feedback_inc("admin_secrets_fun_used",1)
@@ -3584,18 +3525,12 @@
 				var/obj/effect/bhole/bh = new /obj/effect/bhole( T.loc, 30 )
 				spawn(rand(100, 600))
 					qdel(bh)
-
 			if("timeanomalies")	//dear god this code was awful :P Still needs further optimisation
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","STA")
 				//moved to its own dm so I could split it up and prevent the spawns copying variables over and over
 				//can be found in code\game\game_modes\events\wormholes.dm
 				wormhole_event()
-			if("spiders")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","SL")
-				new /datum/event/spider_infestation
-				message_admins("[key_name_admin(usr)] has spawned spiders", 1)
 			if("comms_blackout")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","CB")
@@ -3605,63 +3540,6 @@
 				else
 					communications_blackout(1)
 				message_admins("[key_name_admin(usr)] triggered a communications blackout.", 1)
-
-			if("pda_spam")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","PDA")
-				new /datum/event/pda_spam
-			if("money_lotto")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","PDA")
-				new /datum/event/money_lotto
-
-			if("carp")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","C")
-				var/choice = input("You sure you want to spawn carp?") in list("Badmin", "Cancel")
-				if(choice == "Badmin")
-					message_admins("[key_name_admin(usr)] has spawned carp.", 1)
-					new /datum/event/carp_migration
-			if("radiation")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","R")
-				message_admins("[key_name_admin(usr)] has irradiated the station", 1)
-				new /datum/event/radiation_storm
-			if("immovable")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","IR")
-				message_admins("[key_name_admin(usr)] has sent an immovable rod to the station", 1)
-				immovablerod()
-			if("immovablebig")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","IRB")
-				message_admins("[key_name_admin(usr)] has sent an immovable pillar to the station.", 1)
-				immovablerod(1)
-			if("immovablehyper")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","IRH")
-				message_admins("[key_name_admin(usr)] has sent an immovable monolith to the station. That one's gonna hurt.", 1)
-				immovablerod(2)
-			if("old_vendotron_crash")
-				feedback_inc("admin_secrets_fun_used", 1)
-				feedback_add_details("admin_secrets_fun_used","VENDC")
-				message_admins("[key_name_admin(usr)] has started an old vendotron crash event", 1)
-				new /datum/event/old_vendotron_crash
-			if("old_vendotron_teleport")
-				feedback_inc("admin_secrets_fun_used", 1)
-				feedback_add_details("admin_secrets_fun_used","VENDT")
-				message_admins("[key_name_admin(usr)] has started an old vendotron teleport event", 1)
-				new /datum/event/old_vendotron_teleport
-			if("prison_break")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","PB")
-				message_admins("[key_name_admin(usr)] has allowed a prison break", 1)
-				new /datum/event/prison_break
-			if("lightsout")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","LO")
-				message_admins("[key_name_admin(usr)] has triggered an electrical storm", 1)
-				new /datum/event/electrical_storm
 			if("blackout")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","BO")
@@ -3686,11 +3564,6 @@
 				for(var/obj/machinery/light_switch/LS in all_machines)
 					LS.toggle_switch(1)
 				message_admins("[key_name_admin(usr)] switched on all lights", 1)
-			if("radiation")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","RAD")
-				message_admins("[key_name_admin(usr)] has started a radiation event", 1)
-				new /datum/event/radiation_storm
 			if("floorlava")
 				if(floorIsLava)
 					to_chat(usr, "The floor is lava already.")
@@ -3884,9 +3757,13 @@
 			if("eagles")//SCRAW
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","EgL")
+				var/list/no_eagle_access = list(access_security,access_brig,access_armory,access_forensics_lockers,access_change_ids,
+access_ai_upload,access_teleporter,access_heads,access_captain,access_all_personal_lockers,access_rd,access_cmo,
+access_heads_vault,access_ce,access_hop,access_hos,access_RC_announce,access_keycard_auth,access_tcomsat,access_gateway,
+access_sec_doors,access_salvage_captain,access_cent_ert,access_syndicate,access_trade)
 				for(var/obj/machinery/door/airlock/W in all_doors)
-					if(W.z == map.zMainStation && !istype(get_area(W), /area/bridge) && !istype(get_area(W), /area/crew_quarters) && !istype(get_area(W), /area/security/prison))
-						W.req_access = list()
+					if(W.z == map.zMainStation)
+						W.req_access -= no_eagle_access
 				message_admins("[key_name_admin(usr)] activated Egalitarian Station mode")
 				command_alert(/datum/command_alert/eagles)
 			if("dorf")
@@ -3904,11 +3781,6 @@
 				var/show_log = alert(usr, "Show ion message?", "Message", "Yes", "No")
 				if(show_log == "Yes")
 					command_alert(/datum/command_alert/ion_storm)
-			if("spacevines")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","K")
-				new /datum/event/spacevine
-				message_admins("[key_name_admin(usr)] has spawned spacevines", 1)
 			if("onlyone")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","OO")
@@ -3986,6 +3858,11 @@
 				if(choice != "Cancel")
 					new choice
 					message_admins("[key_name_admin(usr)] spawned a custom event of type [choice].")
+			if("roll_event")
+				feedback_inc("admin_secrets_fun_used",1)
+				feedback_add_details("admin_secrets_fun_used","RE")
+				spawn_dynamic_event(TRUE)
+				message_admins("[key_name_admin(usr)] spawned random dynamic event.")
 			if("spawnadminbus")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","AB")
@@ -4414,26 +4291,6 @@
 				var/datum/event/hostile_infestation/hostile_infestation_event = new()
 				hostile_infestation_event.override_location = ol
 				hostile_infestation_event.override_monster = om
-			if("mass_hallucination")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","MH")
-				message_admins("[key_name_admin(usr)] made the whole crew trip balls.", 1)
-				new /datum/event/mass_hallucination
-			if("meaty_gores")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","ODF")
-				message_admins("[key_name_admin(usr)] has sent the station careening through a cloud of gore.", 1)
-				new /datum/event/thing_storm/meaty_gore
-			if("fireworks")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","HNY")
-				message_admins("[key_name_admin(usr)] has sent the station some lovely fireworks!. No that's not a euphamism for meteors. Actual Fireworks for a change.",1)
-				new /datum/event/thing_storm/fireworks
-			if("silent_meteors")
-				feedback_inc("admin_secrets_fun_used",1)
-				feedback_add_details("admin_secrets_fun_used","SILM")
-				message_admins("[key_name_admin(usr)] has spawned meteors without a command alert.", 1)
-				new /datum/event/meteor_shower/meteor_quiet
 
 			if("maint_access_brig")
 				for(var/obj/machinery/door/airlock/maintenance/M in all_doors)

--- a/code/modules/events/crickets.dm
+++ b/code/modules/events/crickets.dm
@@ -4,3 +4,6 @@
 			var/mob/living/simple_animal/cricket/C = new (SF.loc)
 			if(i==1)
 				C.wander = FALSE //first cricket should stay put behind the fridge
+
+/datum/event/cricketsbehindthefridge/can_start()
+	return 30

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -5,6 +5,7 @@
 	var/oneShot			= 0	//If true, then the event removes itself from the list of potential events on creation.
 
 	var/activeFor		= 0	//How long the event has existed. You don't need to change this.
+	var/last_fired		= 0 //When was the last time an event of this exact type fired?
 
 //Called by event dynamic, returns the percent chance to fire if successful, 0 otherwise.
 // Args: list: active_with_role. The number of jobs that have active members. Used as active_with_role["AI"] = number of active.
@@ -86,3 +87,14 @@
 		setup()
 		events.Add(src)
 	..()
+
+//Check the time since last fired, if at all.
+//Find the percentage of an hour that has passed since then in deciseconds.
+//For example, if 55 minutes have passed, 36000-33000 = 3000
+//Weight is lowered by this value over 300 deciseconds. As in the above example, 3000/300=10. Reduce weight by 10.
+//Almost no event can fire within 25 minutes of its last firing (~50 weight reduction)
+/datum/event/proc/recency_weight()
+	if(!last_fired)
+		return 0
+	var/time_until_recharge = (1 HOURS) - (world.time - last_fired)
+	return max(0,time_until_recharge / (30 SECONDS))

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -1,66 +1,57 @@
-var/list/event_last_fired = list()
+var/list/possibleEvents = list()
+//A list of events and their weights. These range from quite uncommon like a rod (15) to very common like carp (40)
 
 //Always triggers an event when called, dynamically chooses events based on job population
-/proc/spawn_dynamic_event()
-	if(!config.allow_random_events || map && map.dorf)
-		return
+/proc/spawn_dynamic_event(var/forced=FALSE)
+	if(!forced)
+		if(!config.allow_random_events || (map && map.dorf))
+			return
 
-	var/minutes_passed = world.time/600
-	var/roundstart_delay = 15
+		var/minutes_passed = world.time/600
+		var/roundstart_delay = 15
 
-	if (admin_disable_events)
-		message_admins("A random event was prevented from firing by admins.")
-		log_admin("A random event was prevented from firing by admins.")
-		return
+		if (admin_disable_events)
+			message_admins("A random event was prevented from firing by admins.")
+			log_admin("A random event was prevented from firing by admins.")
+			return
 
-	if(minutes_passed < roundstart_delay) //No events near roundstart
-		message_admins("Too early to trigger random event, aborting.")
-		return
+		if(minutes_passed < roundstart_delay) //No events near roundstart
+			message_admins("Too early to trigger random event, aborting.")
+			return
 
-	if(universe.name != "Normal")
-		message_admins("Universe isn't normal, aborting random event spawn.")
-		return
-	if(player_list.len < 1) //minimum pop of 1 to trigger events
-		message_admins("Too few players to trigger random event, aborting.")
-		return
+		if(universe.name != "Normal")
+			message_admins("Universe isn't normal, aborting random event spawn.")
+			return
+		if(player_list.len < 1) //minimum pop of 1 to trigger events
+			message_admins("Too few players to trigger random event, aborting.")
+			return
 	var/list/active_with_role = number_active_with_role()
 
-	// Maps event names to event chances
-	// For each chance, 100 represents "normal likelihood", anything below 100 is "reduced likelihood", anything above 100 is "increased likelihood"
-	// Events have to be manually added to this proc to happen
-	var/list/possibleEvents = list()
 
-	//see:
+	//Scraped PDA text events (like random news events) can be found in
 	// code\modules\Economy\Economy_Events.dm
 	// code\modules\Economy\Economy_Events_Mundane.dm
-	//Commented out for now. Let's be honest, a string of text on PDA is not worth a meteor shower or ion storm
-	//Will be re-implemented in the near future, its chance to proc will be independant from the other random events
-	//possibleEvents[/datum/event/news_event] = 100//
-	//possibleEvents[/datum/event/trivial_news] = 150//Gibson Gazette, taken from config/trivial.txt
-	//possibleEvents[/datum/event/mundane_news] = 100//Tau Ceti Daily
+	if(!possibleEvents.len)
+		for(var/type in subtypesof(/datum/event))
+			if((map.event_blacklist.len && map.event_blacklist.Find(type)) || (map.event_whitelist.len && !map.event_whitelist.Find(type)))
+				continue //Blacklisted, don't even create them
+			var/datum/event/E = new type(FALSE)
+			possibleEvents += E
 
-	//It is this coder's thought that weighting events on job counts is dumb and predictable as hell. 10 Engies ? Hope you like Meteors
-	//Instead, weighting goes from 100 (boring and common) to 10 (exceptional)
-	for(var/type in subtypesof(/datum/event))
-		if((map.event_blacklist.len && map.event_blacklist.Find(type)) || (map.event_whitelist.len && !map.event_whitelist.Find(type)))
-			possibleEvents[type] = 0
-			continue
-		var/datum/event/E = new type(FALSE)
-		var/value = E.can_start(active_with_role)
-		if(value > 0)
-			possibleEvents[type] = value
-		qdel(E)
+	var/list/drawing = list()
+	for(var/datum/event/E in possibleEvents)
+		drawing[E] = max(0,E.can_start(active_with_role) - E.recency_weight()) //Reminder: never have negatives when using pickweight
 
-	for(var/event_type in event_last_fired)
-		if(possibleEvents[event_type])
-			var/time_passed = world.time - event_last_fired[event_type]
-			var/full_recharge_after = 60 * 60 * 10 // Was 3 hours, changed to 1 hour since rounds rarely last that long anyways
-			var/weight_modifier = max(0, (full_recharge_after - time_passed) / 300)
-
-			possibleEvents[event_type] = max(possibleEvents[event_type] - weight_modifier, 0)
-
-	var/picked_event = pickweight(possibleEvents)
-	event_last_fired[picked_event] = world.time
+	var/datum/event/picked_event = pickweight(drawing)
+	if(!picked_event)
+		return
+	message_admins("EVENT: [picked_event] started with [drawing[picked_event]] weight.")
+	possibleEvents -= picked_event
+	if(!picked_event.oneShot)
+		var/newtype = picked_event.type
+		var/datum/event/to_add = new newtype(FALSE)
+		to_add.last_fired = world.time
+		possibleEvents += to_add //Replace with a new datum if it's not oneshot
 
 	// Debug code below here, very useful for testing so don't delete please.
 	var/debug_message = "Firing random event. "
@@ -72,16 +63,10 @@ var/list/event_last_fired = list()
 	debug_message += "|||Picked:[picked_event]"
 	log_debug(debug_message)
 
-	if(!picked_event)
-		return
-
-	//The event will add itself to the MC's event list
-	//and start working via the constructor.
-	new picked_event
+	picked_event.setup()
+	events.Add(picked_event)
 
 	score.eventsendured++
-
-	message_admins("[picked_event] firing. Time to have fun.")
 
 	return 1
 

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -7,13 +7,10 @@
 
 /datum/event/prison_break/can_start()
 	var/foundSomeone = FALSE
-	var/foundBasic = FALSE
 	for(var/area/A in areas)
 		if(istype(A, /area/security/prison) || istype(A, /area/security/brig))
 			prisonAreas += A
 			var/list/areaMobs = mobs_in_area(A,1)
-			if(areaMobs && areaMobs.len)
-				foundBasic = TRUE
 			for(var/mob/living/carbon/human/H in areaMobs)
 				if(H.stat)
 					continue
@@ -23,12 +20,6 @@
 					break
 		if(foundSomeone)
 			break
-	if(!prisonAreas || !prisonAreas.len)
-		world.log << "ERROR: Could not initate grey-tide. Unable find prison or brig area."
-	else if(!foundBasic)
-		world.log << "ERROR: Could not initate grey-tide. Unable find person in prison or brig areas."
-	else if(!foundSomeone)
-		world.log << "ERROR: Could not initate grey-tide. Unable find person in prison or brig areas without access."
 	return 50 * foundSomeone
 
 /datum/event/prison_break/setup()


### PR DESCRIPTION
One of two big bugfixes I wanted to do before the end of the year.

* Admins secret menu now has less superfluous event entries
* Admins may now choose to either choose an event to trigger OR trigger a random one using the normal weight logic
* Fixed the broken (since forever) Egalitarian Station adminbus event (not a dynamic event)

This is that bug I was talking about when I said trade probe works fine but there's a problem with events. The oneShot variable was completely depreciated after the last rewrite! This new refactor stores all the possible events as datums meaning they could even do operations and things before they trigger, and there are some more possibilities for coder mischief. You can even change how quickly an event recharges if you don't like the default hour (that existed prior to this).

:cl:
* bugfix: Fixed an oversight that caused Crickets Behind the Fridge event to never fire.
* bugfix: Fixed a bug where oneshot events (omega blizzard, greytide virus, trade probe, etc.) could trigger multiple times per shift.