### PR TITLE
Tech Datums Fix

### DIFF
--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -376,13 +376,12 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 	if(!research_archive_datum)
 		research_archive_datum = new /datum/research()
 	var/list/techs = read_file()
-	log_debug("DEBUG ARCHIVE: [json_encode(techs)]")
+	//world.log << "DEBUG ARCHIVE: [json_encode(techs)]"
 	var/skip_reporting = TRUE
 	for(var/obj/machinery/computer/rdconsole/C in machines)
 		for(var/element in techs)
 			var/datum/tech/T = C.files.known_tech[element]
 			if(!T)
-				message_admins("DEBUG ARCHIVE: Aborted [element], [C.files.known_tech[element]] failed.")
 				continue
 			T.level = text2num(techs[element])
 			if(skip_reporting && (T.level>1))

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -111,12 +111,18 @@ var/global/list/hidden_tech = list(
 //Input: datum/tech; Output: Null
 /datum/research/proc/AddTech2Known(var/datum/tech/T)
 	var/datum/tech/known = GetKTechByID(T.id)
-	if(known)
-		if(T.level > known.level)
-			known.level = T.level
-		return 1
-	known_tech[T.id] = T
-	return 2
+	if(!known)
+		var/createtype = /datum/tech
+		for(var/type in subtypesof(/datum/tech))
+			var/datum/tech/attempt = type
+			if(initial(attempt.id) == T.id)
+				createtype = type
+				break
+		known = new createtype()
+		known_tech[T.id] = known
+	if(T.level > known.level)
+		known.level = T.level
+	return
 
 /datum/research/proc/AddDesign2Known(var/datum/design/D)
 	if(!(D in known_designs))

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -71,6 +71,10 @@
 			var/datum/tech/T = files.known_tech[ID]
 			if(prob(1))
 				T.level = 0 // This never happens, so make it dramatic. T.level--
+				message_admins("[src] lost [T.id] tech levels due to heat damage.")
+				for(var/obj/machinery/computer/rdservercontrol/SC in machines)
+					SC.screen = -1 //Display an alert
+					SC.updateUsrDialog()
 				changed=1
 		if(changed)
 			files.RefreshResearch()
@@ -241,6 +245,9 @@
 	var/dat = ""
 
 	switch(screen)
+		if(-1)
+			dat += "Alert! Technology data lost due to server heat damage.<BR><BR>"
+			dat += "<HR><A href='?src=\ref[src];main=1'>Main Menu</A>"
 		if(0) //Main Menu
 			dat += "Connected Servers:<BR><BR>"
 


### PR DESCRIPTION
The second bug I wanted to fix before the end of year. This was kind of a pain to hunt down.
fixes #34186

🆑 
* bugfix: Fixed every single machine in the universe sharing the same set of tech datums. This is why you didn't have to sync the computers anymore, because they were psychically communicating. This means you also have to actually use the research archive to benefit from it.
* rscadd: The research server controller will now display a message if it lost tech levels due to overheating. Previously there was no indication at all.