### PR TITLE
Civilian Starting Storage Items

### DIFF
--- a/code/datums/outfit/cargo.dm
+++ b/code/datums/outfit/cargo.dm
@@ -166,6 +166,11 @@
 		),
 	)
 
+	items_to_collect = list(
+		/obj/item/weapon/storage/belt/slim = SURVIVAL_BOX,
+		/obj/item/clothing/accessory/storage/fannypack = SURVIVAL_BOX
+	)
+
 	pda_type = /obj/item/device/pda/cargo
 	pda_slot = slot_belt
 	id_type = /obj/item/weapon/card/id/supply

--- a/code/datums/outfit/civilian.dm
+++ b/code/datums/outfit/civilian.dm
@@ -109,6 +109,7 @@
 	items_to_collect = list(
 		/obj/abstract/spawn_all/bartender = SURVIVAL_BOX,
 		/obj/item/weapon/reagent_containers/food/drinks/shaker = slot_l_store_str,
+		/obj/item/weapon/storage/fancy/beer_box = GRASP_LEFT_HAND
 	)
 
 	pda_type = /obj/item/device/pda/bar


### PR DESCRIPTION
One of the last PRs Hina made before leaving the server was to take away plastic bags from 3 civilian roles. There was some support for alternatives to replace the plastic bag, and this does that.

I feel like the fanny pack is by far more thematic for the techie, but at one slot it's almost a joke item. So as a compromise I've included both the fanny pack and the slim belt. Also, this might be a good way to introduce new players to the idea of accessories, since cargo tech is a newbie-friendly role.

:cl:
* rscadd: The bartender now spawns holding a six pack of beer. The cargo technician now gets both a slim belt and fanny pack as storage solutions. 