### PR TITLE
Prevent flax oil from trying to match the color of glue

### DIFF
--- a/code/modules/painting/paint_reagents.dm
+++ b/code/modules/painting/paint_reagents.dm
@@ -195,6 +195,9 @@
 
 /datum/reagent/flaxoil/special_behaviour()
 	var/list/other_reagents = holder.reagent_list - src
+	for (var/datum/reagent/R in other_reagents)
+		if (R.id == GLUE) //Adding glue lets us turn flax oil into acrylic which won't change color any longer, so we probably don't want to match the color of glue
+			other_reagents -= R
 	if (other_reagents.len <= 0)
 		return
 	var/target_color = mix_color_from_reagents(other_reagents)


### PR DESCRIPTION

:cl:
* bugfix: Producing Acrylic by adding Glue to Flax Oil no longer causes the Flax Oil to try and match the color of Glue.