### PR TITLE
WageHUDs

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -59,6 +59,7 @@
 		/obj/item/device/gps/secure/command,
 		/obj/item/weapon/card/debit/preferred/department/civilian,
 		/obj/item/mulebot_laser,
+		/obj/item/clothing/glasses/hud/wage,
 	)
 
 /obj/structure/closet/secure_closet/hop2


### PR DESCRIPTION
# WageHUDs
![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/52727807-0cbb-4e9a-a2da-55f92850c82f)
![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/1f046f78-ca0c-431f-a977-8827098d307b)

## What this does
Adds a classy WageHUD monocle to the game, available in the HoP's locker at roundstart. It displays the subject's current job and wage, and you can view the otherwise inaccessible employment records by examining the subject.

The device will work so long as the subject has a valid account attached to the ID, and the accounts database is up. Otherwise...

[wageerror.webm](https://github.com/vgstation-coders/vgstation13/assets/69739118/1caad7e2-b940-4548-b686-e63b581d3563)

- Tinfoil hats block the whole process.
- If there is no ID, you won't see any job or wage.
- If there's an ID, the job shown is the same as what any security HUD would show.
- If there's no account DB or there's an issue with linking the WageHUD to the database (you can attempt to force a relink by using the hud in your hand), then the diplay will error out and show gibberish instead of the wage.
- If the account DB is fine but the ID simply has a bad account number set, "ERR" will be shown.

## Why it's good
The HoP can now immediately tell if you forgot to set your account number on your fancy new ID.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Adds WageHUDs to the HoP's locker.

[UI] [sprites] [gameplay] [tested]