### PR TITLE
Hub entry shows round time, shuttle time, map, next map

### DIFF
--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -115,6 +115,12 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 	endtime = world.time + delay * 10
 	timelimit = delay
 
+/datum/emergency_shuttle/proc/get_shuttle_timer()
+	var/shuttle_time_left = timeleft()
+	if(shuttle_time_left)
+		return "[add_zero(num2text((shuttle_time_left / 60) % 60),2)]:[add_zero(num2text(shuttle_time_left % 60), 2)]"
+	return ""
+
 // sets the shuttle direction
 // 1 = towards SS13, -1 = back to centcom
 /datum/emergency_shuttle/proc/setdirection(var/dirn)
@@ -265,7 +271,7 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 
 				command_alert(/datum/command_alert/emergency_shuttle_left)
 				vote_preload()
-				
+
 				/* Handle jukebox updates */
 				spawn()
 					for(var/obj/machinery/media/jukebox/superjuke/shuttle/SJ in machines)

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -141,7 +141,7 @@ var/global/list/status_displays = list() //This list contains both normal status
 		if(MODE_SHUTTLE_TIMER)				//emergency shuttle timer
 			if(emergency_shuttle.online)
 				var/line1
-				var/line2 = get_shuttle_timer()
+				var/line2 = emergency_shuttle.get_shuttle_timer()
 				if(emergency_shuttle.location == 1)
 					line1 = "-ETD-"
 				else
@@ -200,7 +200,7 @@ var/global/list/status_displays = list() //This list contains both normal status
 				ETwut = "-ETD-"
 			else
 				ETwut = "-ETA-"
-			to_chat(user, "<span class='info'>The display says:<br>\t<xmp>[ETwut]</xmp><br>\t<xmp>[get_shuttle_timer()]</xmp></span>")
+			to_chat(user, "<span class='info'>The display says:<br>\t<xmp>[ETwut]</xmp><br>\t<xmp>[emergency_shuttle.get_shuttle_timer()]</xmp></span>")
 		if(MODE_MESSAGE)
 			to_chat(user, "<span class='info'>The display says:<br>\t<xmp>[message1]</xmp><br>\t<xmp>[message2]</xmp></span>")
 
@@ -229,12 +229,6 @@ var/global/list/status_displays = list() //This list contains both normal status
 	var/new_text = {"<div style="font-size:[FONT_SIZE];color:[FONT_COLOR];font:'[FONT_STYLE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
 	if(maptext != new_text)
 		maptext = new_text
-
-/obj/machinery/status_display/proc/get_shuttle_timer()
-	var/timeleft = emergency_shuttle.timeleft()
-	if(timeleft)
-		return "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]"
-	return ""
 
 /obj/machinery/status_display/proc/get_supply_shuttle_timer()
 	if(SSsupply_shuttle.moving)
@@ -381,7 +375,7 @@ var/global/list/status_display_images = list(
 		if(stat & (BROKEN|NOPOWER|FORCEDISABLE))
 			to_chat(user, "<span class='warning'>Unable to connect to [src] (error #[(stat & BROKEN) ? "120" : "408"])</span>")
 			return
-			
+
 		var/new_icon = input(A, "Load an image to be desplayed on [src].", "AI status display") in status_display_images
 
 		if(new_icon)

--- a/code/hub.dm
+++ b/code/hub.dm
@@ -68,6 +68,12 @@ var/global/byond_hub_playercount = OPEN_TO_HUB_PLAYERCOUNT_DEFAULT
 	s = replacetext(s, "\[playercount\]", "[players]")
 	s = replacetext(s, "\[station_name\]", "[station_name()]")
 	s = replacetext(s, "\[map_name\]", "[map.nameLong]")
+	s += "<br>Time: <b>[get_game_time()]</b>"
+	if(emergency_shuttle.online && emergency_shuttle.location != 2)
+		s += " | Shuttle: <b>[emergency_shuttle.location == 1 ? "ETD" : "ETA"] [emergency_shuttle.get_shuttle_timer()]"
+	s += "<br>Map: <b>[map.nameLong]</b>"
+	if(vote.winner && vote.map_paths)
+		s += " | Next: <b>[vote.map_paths[vote.winner]]</b>"
 
 	/* does this help? I do not know */ 	// neither do I!
 	if (src.status != s)


### PR DESCRIPTION
## Why it's good
More info in the hub is always good, you can get more players if the map looks interesting
For example most other servers don't have Horizon or Taxi or whatever, so new players may join in order to check out the /vg/ exclusive maps
Having an idea of roundstart/end is also good

Also codewise moved the shuttle timer proc off status displays
<!-- Explain why you think these changes are good. -->

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Hub entry shows round time, shuttle time, map, next map
