### PR TITLE
Brig Medic Double HUD

### DIFF
--- a/code/datums/outfit/medical.dm
+++ b/code/datums/outfit/medical.dm
@@ -259,7 +259,10 @@
 				 "Brig Medic" = /obj/item/clothing/under/rank/medical/brigmedic,
 			),
 			slot_shoes_str = /obj/item/clothing/shoes/black,
-			slot_glasses_str = /obj/item/clothing/glasses/hud/health,
+			slot_glasses_str = list(
+				"Paramedic" = /obj/item/clothing/glasses/hud/health,
+				"Brig Medic" = /obj/item/clothing/glasses/hud/combinedsecmed
+			),
 			slot_wear_suit_str = list(
 				"Paramedic" = /obj/item/clothing/suit/storage/paramedic,
 				"Brig Medic" = /obj/item/clothing/suit/armor/vest/security/medic

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -73,18 +73,25 @@
 /obj/item/clothing/glasses/hud/health/attackby(obj/item/weapon/W, mob/user)
 	..()
 	if(istype(W, /obj/item/clothing/glasses/hud/security/scouter))
+		var/worn = FALSE
+		if(user.is_wearing_item(src, slot_glasses))
+			worn = TRUE
 		if(do_after(user, src, 1 SECONDS))
 			user.drop_item(src)
 			if(!user.drop_item(W))
 				to_chat(user, "<span class='warning'>You can't let go of \the [W].</span>")
 				return
-			var/obj/item/clothing/glasses/hud/combinedsecmed/I = new /obj/item/clothing/glasses/hud/combinedsecmed(src,W)
+			var/obj/item/clothing/glasses/hud/combinedsecmed/I = new /obj/item/clothing/glasses/hud/combinedsecmed(hhud = src, shud = W)
 			W.transfer_fingerprints_to(I)
 			I.base_health = src
 			I.base_sec = W
 			W.forceMove(I)
 			src.forceMove(I)
-			user.put_in_hands(I)
+			var/mob/living/carbon/human/H = user
+			if(worn && istype(H))
+				H.equip_to_slot_if_possible(I,slot_glasses,EQUIP_FAILACTION_DROP)
+			else
+				user.put_in_hands(I)
 			to_chat(user, "<span class='notice'>You synchronize \the [W] with \the [src].</span>")
 
 /obj/item/clothing/glasses/hud/health/cmo
@@ -171,18 +178,25 @@
 /obj/item/clothing/glasses/hud/security/scouter/attackby(obj/item/weapon/W, mob/user)
 	..()
 	if(istype(W, /obj/item/clothing/glasses/hud/health))
+		var/worn = FALSE
+		if(user.is_wearing_item(src, slot_glasses))
+			worn = TRUE
 		if(do_after(user, src, 1 SECONDS))
 			user.drop_item(src)
 			if(!user.drop_item(W))
 				to_chat(user, "<span class='warning'>You can't let go of \the [W].</span>")
 				return
-			var/obj/item/clothing/glasses/hud/combinedsecmed/I = new /obj/item/clothing/glasses/hud/combinedsecmed
+			var/obj/item/clothing/glasses/hud/combinedsecmed/I = new /obj/item/clothing/glasses/hud/combinedsecmed(hhud = W, shud = src)
 			W.transfer_fingerprints_to(I)
 			I.base_health = W
 			I.base_sec = src
 			W.forceMove(I)
 			src.forceMove(I)
-			user.put_in_hands(I)
+			var/mob/living/carbon/human/H = user
+			if(worn && istype(H))
+				H.equip_to_slot_if_possible(I,slot_glasses,EQUIP_FAILACTION_DROP)
+			else
+				user.put_in_hands(I)
 			to_chat(user, "<span class='notice'>You synchronize \the [W] with \the [src].</span>")
 
 
@@ -343,14 +357,15 @@
 	var/obj/item/clothing/glasses/hud/health/base_health = null
 	var/obj/item/clothing/glasses/hud/security/scouter/base_sec = null
 
-/obj/item/clothing/glasses/hud/combinedsecmed/New(var/obj/item/clothing/glasses/hud/health/hhud = null,
+/obj/item/clothing/glasses/hud/combinedsecmed/New(var/turf/location = null,
+												var/obj/item/clothing/glasses/hud/health/hhud = null,
 												var/obj/item/clothing/glasses/hud/security/scouter/shud = null)
 	..()
-	if(hhud)
+	if(istype(hhud))
 		base_health = hhud
 	else
 		base_health = new /obj/item/clothing/glasses/hud/health
-	if(shud)
+	if(istype(shud))
 		base_sec = shud
 	else
 		base_sec = new /obj/item/clothing/glasses/hud/security/scouter


### PR DESCRIPTION
# Brig Medic's Funny Toy
special thanks to @kilozombie for the equipped model sprite work

yep, here it is, it's what three whole people asked for! the ability to wear two scouters at once.

![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/5824fc24-9430-4626-8633-5d5797e47a09)
![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/5b8f59a0-b976-4bf8-b572-63f8da7a9863)

![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/546c5f68-8fe9-45b8-bb6c-6874ea2a61d1)

![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/0a8a783f-76bb-446f-beca-19afbeb2c648)
(Before #35685 gets merged)

![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/6ec8ea49-0e8b-4def-8e36-b418918dc9e3)
![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/71294196-3c25-4cf4-a4e0-31b95f811079)
(After, just pretend you see the second scouter in this one)

## What this does
Gives the Brig Medic a fancy new toy - a classic secHUD scouter that can be worn at the same time as a standard medical HUD. They start with it equipped alongside a medical HUD.

When worn alone, it's a terrible yet stylish security HUD that offers no flash protection and can't set people to arrest.

Combined, it can do everything a medical HUD and a security HUD can do, except provide flash protection and set people to arrest.

You can separate the two at will by using them in your hand. You can recombine them just as easily, by using one on the other. You can even scan them as needed with the mechanic if you want more.

## Why it's good
like the entire concept of the brig medic, it's not. But it's here anyway.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Gives the Brig Medic the Combined HUDs at roundstart

[UI] [sprites] [gameplay] [tested]