### PR TITLE
Don't create a new label when the DMAPI updater action runs

### DIFF
--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -42,6 +42,6 @@ jobs:
         destination_branch: "Bleeding-Edge"
         pr_title: "Automatic TGS DMAPI Update"
         pr_body: "This pull request updates the TGS DMAPI to the latest version. Please note any changes that may be breaking or unimplemented in your codebase by checking what changes are in the definitions file: code/__DEFINES/tgs.dm before merging."
-        pr_label: "Tools"
+        pr_label: "System"
         pr_allow_empty: false
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Y'all don't have `Tools`