### PR TITLE
Archive Hotfix + QoL

### DIFF
--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -807,3 +807,10 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 /datum/command_alert/tradeaversion_mismanagement
 	alert_title = "Trade Probe Rerouted"
 	message = "A Vox trade probe rerouted away from the station after determining that employee wages were too low to justify a visit."
+
+/datum/command_alert/archive_thanks
+	alert_title = "Science Thanks You"
+
+/datum/command_alert/archive_thanks/announce()
+	message = "The Research Archive Project extends its profound thanks to [english_list(important_archivists)] for completing the research archival work this shift. There will be an extra stipend in the next pay cycle."
+	..()

--- a/code/game/gamemodes/endgame/scoreboard/misc_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/misc_score.dm
@@ -126,6 +126,8 @@
 			score.deadpets++
 
 	score.time = round(world.time/10) //One point for every five seconds. One minute is 12 points, one hour 720 points
+	if(is_research_fully_archived())
+		score.crewscore += 1800
 	score.crewscore -= score.deadcrew * 250 //Human beans aren't free
 	score.crewscore += score.eventsendured * 200 //Events fine every 10 to 15 and are uncommon
 	score.crewscore += score.escapees * 100 //Two rescued human beans are worth a dead one

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -128,6 +128,8 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	dat += "<U>THE GOOD:</U><BR>"
 	dat += "<B>Length of Shift:</B> [round(world.time/600)] Minutes ([round(score.time * 0.2)] Points)<BR>"
 	dat += "<B>Shuttle Escapees:</B> [score.escapees] ([score.escapees * 100] Points)<BR>"
+	if(is_research_fully_archived())
+		dat += "<B>Research was <span class='good'>fully completed</span> due to the work of:</B> [english_list(important_archivists)] (1800 Points)<BR>"
 	if(score.eventsendured > 0)
 		dat += "<B>Random Events Endured:</B> [score.eventsendured] ([score.eventsendured * 200] Points)<BR>"
 	if(score.meals > 0)

--- a/code/game/machinery/disk_duplicator.dm
+++ b/code/game/machinery/disk_duplicator.dm
@@ -54,7 +54,7 @@
 	for(var/obj/item/weapon/stock_parts/scanning_module/SM in component_parts)
 		T3 = 2*SM.rating
 		break
-	copy_duration = (10 - max(1,min(T1,T2,T3))) // Better scanning module, micro laser AND manipulator reduce copy duration
+	copy_duration = max(1, (6 - min(T1,T2,T3))) // Better scanning module, micro laser AND manipulator reduce copy duration
 
 /obj/machinery/disk_duplicator/examine(var/mob/user)
 	..()
@@ -372,6 +372,7 @@ var/list/inserted_datadisk_cache = list()
 			var/obj/item/weapon/disk/tech_disk/source = disk_source
 			if (source.stored)
 				copy.stored = new source.stored.type(copy)
+				copy.stored.level = source.stored.level
 		if (/obj/item/weapon/disk/shuttle_coords) // "shuttle destination disk"
 			var/obj/item/weapon/disk/shuttle_coords/copy = C
 			var/obj/item/weapon/disk/shuttle_coords/source = disk_source

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -399,6 +399,13 @@
 		new /obj/item/weapon/disk(src)
 	update_icon()
 
+/obj/item/weapon/storage/lockbox/diskettebox/large/full/New()
+	..()
+	for(var/i = 1 to storage_slots)
+		new /obj/item/weapon/disk(src)
+	update_icon()
+
+
 //---------------------------------PRESETS END-----------------------------
 
 /obj/item/weapon/storage/lockbox/diskettebox/update_icon()

--- a/code/modules/research/designs/data.dm
+++ b/code/modules/research/designs/data.dm
@@ -28,6 +28,16 @@
 	category = "Data"
 	build_path = /obj/item/weapon/paper_bin/nano
 
+/datum/design/diskette_box
+	name = "Diskette Box"
+	desc = "A small box for storing additional disks."
+	id = "disk_box"
+	req_tech = list(Tc_MATERIALS = 2)
+	build_type = PROTOLATHE
+	materials = list(MAT_GLASS = 50, MAT_IRON = 200)
+	category = "Data"
+	build_path = /obj/item/weapon/storage/lockbox/diskettebox
+
 /datum/design/design_disk
 	name = "Design Storage Disk"
 	desc = "Produce additional disks for storing device designs."

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -308,6 +308,10 @@ datum/tech/robotics
 	src.pixel_x = rand(-5, 5) * PIXEL_MULTIPLIER
 	src.pixel_y = rand(-5, 5) * PIXEL_MULTIPLIER
 
+/obj/item/weapon/disk/tech_disk/examine(mob/user)
+	..()
+	to_chat(user,"<span class='info'>It contains [stored.id] [stored.level] research.</span>")
+
 /obj/item/weapon/disk/tech_disk/nanotrasen
 	name = "Technology Disk (Nanotrasen 1)"
 


### PR DESCRIPTION
Remember how I said those bugs with research being globalized were interfering with testing the research archive? Now I was able to fix all those bugs!
Not included on CL below: new big box of diskettes intended for the library.

![image](https://github.com/vgstation-coders/vgstation13/assets/9782036/801d359d-3126-43bb-afcd-9e04eadc16d9)


🆑 
* bugfix: Hotfix with research archive not properly increasing levels.
* rscadd: You can now print diskette boxes at the protolathe. You can examine a tech disk to view its loaded tech and level. 
* rscadd: Special announcement, scoreboard entry, and wage reward for completing archival research.
* tweak: Disk duplicator works faster.