### PR TITLE
Research Archive Quality of Life

### DIFF
--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -405,6 +405,12 @@
 		new /obj/item/weapon/disk(src)
 	update_icon()
 
+/obj/item/weapon/storage/lockbox/diskettebox/archive
+	name = "archival diskette box"
+	desc = "Please copy in library."
+	storage_slots = 9
+	mech_flags = MECH_SCAN_FAIL
+
 
 //---------------------------------PRESETS END-----------------------------
 

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -148,6 +148,12 @@ The required techs are the following:
 	//log_admin("[total] for [part.name]")
 	return total
 
+//Do something to this buildable right after we finish building it
+//obj/O: The freshly created object
+//obj/machinery/r_n_d/fabricator/F: the machine where the object was just manufactured
+/datum/design/proc/after_craft(var/obj/O, var/obj/machinery/r_n_d/fabricator/F)
+	return
+
 ////////////////////////////////////////
 //Disks for transporting design datums//
 ////////////////////////////////////////

--- a/code/modules/research/designs/data.dm
+++ b/code/modules/research/designs/data.dm
@@ -58,6 +58,25 @@
 	category = "Data"
 	build_path = /obj/item/weapon/disk/tech_disk
 
+/datum/design/archive_diskset
+	name = "Archive-Ready Diskset"
+	desc = "A set of nine disks ready to be archived. The disks are printed with the technology data from this terminal in a process that is convenient but very resource wasteful."
+	req_tech = list(Tc_PROGRAMMING = 5)
+	build_type = PROTOLATHE
+	materials = list(MAT_IRON = 20000, MAT_GLASS = 10000)
+	id = "archivedisks"
+	category = "Data"
+	build_path = /obj/item/weapon/storage/lockbox/diskettebox/archive
+
+/datum/design/archive_diskset/after_craft(var/obj/O, var/obj/machinery/r_n_d/fabricator/F)
+	for(var/datum/tech/T in get_list_of_elements(F.linked_console.files.known_tech))
+		if(T.id in list("syndicate", "Nanotrasen", "anomaly"))
+			continue
+		var/obj/item/weapon/disk/tech_disk/TD = new(O)
+		TD.stored = create_tech(T.id)
+		TD.stored.level = T.level
+	O.update_icon()
+
 /datum/design/botany_disk
 	name = "Floral Data Disk"
 	desc = "Produce additional disks for copying botany genetic data."

--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -351,6 +351,7 @@
 			being_built.forceMove(L) //Put the thing in the lockbox
 			L.name += " ([being_built.name])"
 			being_built = L //Building the lockbox now, with the thing in it
+		part.after_craft(being_built,src)
 		var/turf/output = get_output()
 		being_built.forceMove(get_turf(output))
 		being_built.anchored = 0

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -333,7 +333,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		for(var/ID in files.known_tech)
 			var/datum/tech/T = files.known_tech[ID]
 			if(href_list["copy_tech_ID"] == T.id)
-				t_disk.stored = T
+				t_disk.stored = create_tech(T.id)
+				t_disk.stored.level = T.level
 				break
 		screen = 1.2
 
@@ -735,8 +736,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "Current Research Levels:<BR><BR>"
 			for(var/ID in files.known_tech)
 				var/datum/tech/T = files.known_tech[ID]
-				dat += {"[T.name]<BR>
-					* Level: [T.level]<BR>
+				dat += {"[T.name]: level [T.level]<BR>
 					* Summary: [T.desc]<HR>"}
 
 		if(1.2) //Technology Disk Menu

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -112,13 +112,7 @@ var/global/list/hidden_tech = list(
 /datum/research/proc/AddTech2Known(var/datum/tech/T)
 	var/datum/tech/known = GetKTechByID(T.id)
 	if(!known)
-		var/createtype = /datum/tech
-		for(var/type in subtypesof(/datum/tech))
-			var/datum/tech/attempt = type
-			if(initial(attempt.id) == T.id)
-				createtype = type
-				break
-		known = new createtype()
+		known = create_tech(T.id)
 		known_tech[T.id] = known
 	if(T.level > known.level)
 		known.level = T.level
@@ -187,6 +181,16 @@ var/global/list/hidden_tech = list(
 	if(goal_level==-1)
 		goal_level=max_level
 	..()
+
+//Creates a tech of the specific subtype you are looking for by id
+/proc/create_tech(var/Tid)
+	var/createtype = /datum/tech
+	for(var/type in subtypesof(/datum/tech))
+		var/datum/tech/attempt = type
+		if(initial(attempt.id) == Tid)
+			createtype = type
+			break
+	return new createtype()
 
 //Trunk Technologies (don't require any other techs and you start knowning them).
 
@@ -310,7 +314,10 @@ datum/tech/robotics
 
 /obj/item/weapon/disk/tech_disk/examine(mob/user)
 	..()
-	to_chat(user,"<span class='info'>It contains [stored.id] [stored.level] research.</span>")
+	if(stored)
+		to_chat(user,"<span class='info'>It contains [stored.id] [stored.level] research.</span>")
+	else
+		to_chat(user,"<span class='warning'>It has no data.</span>")
 
 /obj/item/weapon/disk/tech_disk/nanotrasen
 	name = "Technology Disk (Nanotrasen 1)"


### PR DESCRIPTION
Also fixed some examine text runtimes.
This adds a powerful new after_craft proc for fabricators, so you can have designs that do something to their object after printing. For example, you could use a normal cell path and set its charge to 0 instead of having to create an empty cell object to print. Or you could do customized stuff, like have a character lathe their initials into something. Whatever.

🆑 
* tweak: You can examine the research archive to view all currently archived levels. When you insert a disk, it will instantly try to archive it instead of requiring an extra click.
* tweak: You can now print an entire archive-ready diskset at R&D once you reach data 5. This is much more expensive than loading disks with data by hand, but much more convenient. Overall you save ~60 clicks.
* tweak: When you view research levels on an R&D computer, the full page is easier to view.