### PR TITLE
Fixes a bunch of issues with drinking glasses

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
@@ -21,20 +21,19 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/on_reagent_change()
 	..()
+	flammable = 0
+	if(!molotov)
+		lit = 0
+		light_color = null
+		set_light(0)
+	origin_tech = ""
+	available_drinks.Cut()
 	update_icon()
 
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/update_icon()
 	..()
 	overlays.len = 0
 	can_flip = FALSE
-	flammable = 0
-	if(!molotov)
-		lit = 0
-	light_color = null
-	set_light(0)
-	origin_tech = ""
-	switching = FALSE
-	available_drinks.Cut()
 
 	if (reagents.reagent_list.len > 0)
 		if(reagents.has_reagent(BLACKCOLOR))


### PR DESCRIPTION
Fixes #35718
Fixes #35719

:cl:
* bugfix: Fixed Scientist's Serendipity no longer being deconstructable for tech levels.
* bugfix: Fixed B52 and similar flammable drinks no longer being actually flammable.
* bugfix: Fixed Changeling Sting drink no longer properly randomizing its content.