### PR TITLE
Fixes Mech Bay console not producing lights as it should

### DIFF
--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -221,19 +221,10 @@
 		recharge_port.stop_charge()
 
 /obj/machinery/computer/mech_bay_power_console/power_change()
-	if(stat & BROKEN)
-		icon_state = initial(icon_state) +"_broken"
+	..()
+	if(stat & (BROKEN|NOPOWER))
 		if(recharge_port)
 			recharge_port.stop_charge()
-	else if(powered())
-		icon_state = initial(icon_state)
-		stat &= ~NOPOWER
-	else
-		spawn(rand(0, 15))
-			icon_state = initial(icon_state)+"_nopower"
-			stat |= NOPOWER
-			if(recharge_port)
-				recharge_port.stop_charge()
 
 /obj/machinery/computer/mech_bay_power_console/set_broken()
 	icon_state = initial(icon_state)+"_broken"


### PR DESCRIPTION

![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/ee7e6c8d-faa2-4664-85ad-3336abfa8399)

:cl:
* bugfix: Mech Bay consoles finally produce light like other computers do.