### PR TITLE
Fix Glass Tiles being invisible

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -160,7 +160,7 @@ var/list/datum/stack_recipe/rglass_recipes = list (
 	new/datum/stack_recipe("window", /obj/structure/window/reinforced/loose, 1, time = 10, on_floor = TRUE),
 	new/datum/stack_recipe("full window", /obj/structure/window/full/reinforced/loose, 2, time = 10, on_floor = TRUE),
 	new/datum/stack_recipe("windoor", /obj/structure/windoor_assembly/, 5, time = 10, start_unanchored = TRUE, on_floor = TRUE),
-	new/datum/stack_recipe("glass tile", /obj/item/stack/glass_tile/rglass, 1, time = 2, on_floor = TRUE),
+	new/datum/stack_recipe("glass tile", /obj/item/stack/tile/rglass, 1, time = 2, on_floor = TRUE),
 	)
 
 var/list/datum/stack_recipe/plasmaglass_recipes = list (
@@ -172,5 +172,5 @@ var/list/datum/stack_recipe/plasmarglass_recipes = list (
 	new/datum/stack_recipe("window", /obj/structure/window/reinforced/plasma/loose, 1, time = 10, on_floor = TRUE),
 	new/datum/stack_recipe("full window", /obj/structure/window/full/reinforced/plasma/loose, 2, time = 10, on_floor = TRUE),
 	new/datum/stack_recipe("windoor", /obj/structure/windoor_assembly/plasma, 5, time = 10, start_unanchored = TRUE, on_floor = TRUE),
-	new/datum/stack_recipe("glass tile", /obj/item/stack/glass_tile/rglass/plasma, 1, time = 2, on_floor = TRUE),
+	new/datum/stack_recipe("glass tile", /obj/item/stack/tile/rglass/plasma, 1, time = 2, on_floor = TRUE),
 	)

--- a/code/game/objects/items/stacks/tiles/tiles.dm
+++ b/code/game/objects/items/stacks/tiles/tiles.dm
@@ -190,7 +190,7 @@
 					return
 
 
-/obj/item/stack/glass_tile/rglass/afterattack(atom/target, mob/user, adjacent, params)
+/obj/item/stack/tile/rglass/afterattack(atom/target, mob/user, adjacent, params)
 	if(adjacent)
 		if(isturf(target) || istype(target, /obj/structure/lattice))
 			var/turf/T = get_turf(target)
@@ -200,14 +200,14 @@
 					build(T)
 					use(1)
 
-/obj/item/stack/glass_tile/rglass
+/obj/item/stack/tile/rglass
 	name = "glass tile"
 	singular_name = "tile"
 	desc = "A relatively clear reinforced glass tile."
 	icon_state = "tile_rglass"
 	max_amount = 60
 
-/obj/item/stack/glass_tile/rglass/proc/build(turf/S as turf)
+/obj/item/stack/tile/rglass/proc/build(turf/S as turf)
 	var/obj/structure/lattice/L = S.canBuildCatwalk(src)
 	if(istype(L))
 		playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
@@ -221,13 +221,13 @@
 
 
 
-/obj/item/stack/glass_tile/rglass/plasma
+/obj/item/stack/tile/rglass/plasma
 	name = "plasma glass tile"
 	singular_name = "tile"
 	desc = "A relatively clear reinforced plasma glass tile."
 	icon_state = "tile_plasmarglass"
 
-/obj/item/stack/glass_tile/rglass/plasma/build(turf/S as turf)
+/obj/item/stack/tile/rglass/plasma/build(turf/S as turf)
 	var/obj/structure/lattice/L = S.canBuildCatwalk(src)
 	if(istype(L))
 		playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)

--- a/maps/randomvaults/mining/mining_surprise_items.dm
+++ b/maps/randomvaults/mining/mining_surprise_items.dm
@@ -204,7 +204,7 @@
 					if(is_type_in_list(O,list(/obj/item/stack/sheet/glass/plasmaglass,
 											/obj/item/stack/sheet/glass/plasmarglass,
 											/obj/item/weapon/shard/plasma,
-											/obj/item/stack/glass_tile/rglass/plasma,
+											/obj/item/stack/tile/rglass/plasma,
 											/obj/item/weapon/stock_parts/console_screen/reinforced/plasma)))
 						// not bothered to write plasma glass tile lines
 						M.say(pick("Well, you gone and smelted some plasma alright, but you got too much of that there glass in it to be any use to me.",


### PR DESCRIPTION
by making them subtypes of /tile jesus christ why weren't they already?
![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/acbb3e9a-b8a6-4ad5-b630-da6bfbb12668)
/glass_tile wasn't even used anywhere except with the /rglass subtype so I just completely removed it.

:cl:
* bugfix: Fixed glass tiles still being invisible.