### PR TITLE
Vault Spawning Point System

### DIFF
--- a/code/game/shuttles/brokeufo.dm
+++ b/code/game/shuttles/brokeufo.dm
@@ -4,6 +4,7 @@
 /datum/map_element/vault/brokeufo
 	name = "Broken UFO"
 	file_path = "maps/randomvaults/brokeufo.dmm"
+	spawn_cost = 3
 
 /datum/map_element/vault/brokeufo/initialize(list/objects)
 	..()

--- a/code/game/shuttles/lightship.dm
+++ b/code/game/shuttles/lightship.dm
@@ -4,10 +4,11 @@
 /datum/map_element/vault/lightship
 	name = "Light Speed Ship"
 	file_path = "maps/randomvaults/lightspeedship.dmm"
+	spawn_cost = 3
 
 /datum/map_element/vault/lightship/initialize(list/objects)
 	..()
-		
+
 /datum/shuttle/lightship
 	name = "light speed ship"
 
@@ -34,7 +35,7 @@
 	add_dock(/obj/docking_port/destination/syndicate/west)
 	add_dock(/obj/docking_port/destination/syndicate/northwest)
 
-	
+
 
 /obj/machinery/computer/shuttle_control/lightship
 	icon_state = "syndishuttle"
@@ -42,7 +43,7 @@
 	light_color = LIGHT_COLOR_RED
 
 /obj/machinery/computer/shuttle_control/lightship/New() //Main shuttle_control code is in code/game/machinery/computer/shuttle_computer.dm
-	
+
 	var/global/datum/shuttle/lightship/lightship_shuttle = new(starting_area=/area/shuttle/lightship/start)
 	lightship_shuttle.initialize()
 	link_to(lightship_shuttle)

--- a/code/modules/randomMaps/vault_definitions.dm
+++ b/code/modules/randomMaps/vault_definitions.dm
@@ -179,7 +179,7 @@ var/list/existing_vaults = list()
 /datum/map_element/vault/ejectedengine
 	file_path = "maps/randomvaults/ejectedengine.dmm"
 	can_rotate = TRUE
-	spawn_cost = 4
+	spawn_cost = 3
 
 /datum/map_element/vault/droneship
 	file_path = "maps/randomvaults/droneship.dmm"
@@ -187,7 +187,6 @@ var/list/existing_vaults = list()
 
 /datum/map_element/vault/amelab
 	file_path = "maps/randomvaults/amelab.dmm"
-	can_rotate = TRUE
 	spawn_cost = 3
 
 /datum/map_element/vault/meteorlogical_station

--- a/code/modules/randomMaps/vault_definitions.dm
+++ b/code/modules/randomMaps/vault_definitions.dm
@@ -12,6 +12,9 @@ var/list/existing_vaults = list()
 
 	var/base_turf_type = /turf/space //The "default" turf type that surrounds this vault. If it differs from the z-level's base turf type (for example if this vault is loaded on a snow map), all turfs of this type will be replaced with turfs of the z-level's base turf type
 
+	var/spawn_cost = 3	//The amount of "points" a vault costs to spawn, much larger/complicated vaults costing more, with simpler costing less
+	//Spawn cost's will be defined even if inheretence makes it redundant, this is because vault makers are often less experienced with code and so the clarity will help
+
 /datum/map_element/vault/initialize(list/objects)
 	..(objects)
 	existing_vaults.Add(src)
@@ -35,10 +38,12 @@ var/list/existing_vaults = list()
 /datum/map_element/vault/icetruck_crash
 	file_path = "maps/randomvaults/icetruck_crash.dmm"
 	can_rotate = TRUE
+	spawn_cost = 1
 
 /datum/map_element/vault/asteroid_temple
 	file_path = "maps/randomvaults/asteroid_temple.dmm"
 	can_rotate = TRUE
+	spawn_cost = 2
 
 /datum/map_element/vault/asteroid_temple/initialize(list/objects)
 	..(objects)
@@ -59,31 +64,36 @@ var/list/existing_vaults = list()
 /datum/map_element/vault/gingerbread_house
 	file_path = "maps/randomvaults/gingerbread_house.dmm"
 	can_rotate = TRUE
+	spawn_cost = 4
 
 /datum/map_element/vault/tommyboyasteroid
 	file_path = "maps/randomvaults/tommyboyasteroid.dmm"
 	can_rotate = TRUE
+	spawn_cost = 1
 
 /datum/map_element/vault/hivebot_factory
 	file_path = "maps/randomvaults/hivebot_factory.dmm"
 	can_rotate = TRUE
+	spawn_cost = 3
 
 /datum/map_element/vault/pretty_rad_clubhouse
 	file_path = "maps/randomvaults/pretty_rad_clubhouse.dmm"
 	can_rotate = TRUE
-
+	spawn_cost = 2
 /datum/map_element/vault/clown_base
 	file_path = "maps/randomvaults/clown_base.dmm"
 	can_rotate = TRUE
+	spawn_cost = 3
 
 /datum/map_element/vault/rust
 	file_path = "maps/randomvaults/rust.dmm"
 	can_rotate = TRUE
-
+	spawn_cost = 2
 /datum/map_element/vault/dance_revolution
 	name = "Dance Dance Revolution"
 	file_path = "maps/randomvaults/dance_revolution.dmm"
 	var/obj/structure/dance_dance_revolution/machine
+	spawn_cost = 2
 
 /datum/map_element/vault/dance_revolution/initialize(list/objects)
 	.=..()
@@ -108,13 +118,16 @@ var/list/existing_vaults = list()
 /datum/map_element/vault/spacegym
 	file_path = "maps/randomvaults/spacegym.dmm"
 	can_rotate = TRUE
+	spawn_cost = 1
 
 /datum/map_element/vault/oldarmory
 	file_path = "maps/randomvaults/oldarmory.dmm"
 	can_rotate = TRUE
+	spawn_cost = 4
 
 /datum/map_element/vault/spacepond
 	file_path = "maps/randomvaults/spacepond.dmm"
+	spawn_cost = 1
 
 /datum/map_element/vault/spacepond/pre_load()
 	load_dungeon(/datum/map_element/dungeon/wine_cellar,rotation)
@@ -125,26 +138,32 @@ var/list/existing_vaults = list()
 /datum/map_element/vault/iou_vault
 	file_path = "maps/randomvaults/iou_fort.dmm"
 	can_rotate = TRUE
+	spawn_cost = 1
 
 /datum/map_element/vault/biodome
 	file_path = "maps/randomvaults/biodome.dmm"
+	spawn_cost = 2
 
-/datum/map_element/vault/iou_vault
-	file_path = "maps/randomvaults/iou_fort.dmm"
+///datum/map_element/vault/iou_vault
+//	file_path = "maps/randomvaults/iou_fort.dmm"	//Why was this in here twice?
 
 /datum/map_element/vault/asteroids
 	file_path = "maps/randomvaults/asteroids.dmm"
 	can_rotate = TRUE
+	spawn_cost = 2
 
 /datum/map_element/vault/listening
 	file_path = "maps/randomvaults/listening.dmm"
+	spawn_cost = 3
 
 /datum/map_element/vault/hivebot_crash
 	file_path = "maps/randomvaults/hivebot_crash.dmm"
 	can_rotate = TRUE
+	spawn_cost = 1
 
 /datum/map_element/vault/prison
 	file_path = "maps/randomvaults/prison_ship.dmm"
+	spawn_cost = 2
 
 /datum/map_element/vault/prison/pre_load()
 	load_dungeon(/datum/map_element/dungeon/prison,rotation)
@@ -155,55 +174,70 @@ var/list/existing_vaults = list()
 /datum/map_element/vault/AIsat
 	file_path = "maps/randomvaults/AIsat.dmm"
 	can_rotate = TRUE
+	spawn_cost = 1
 
 /datum/map_element/vault/ejectedengine
 	file_path = "maps/randomvaults/ejectedengine.dmm"
 	can_rotate = TRUE
+	spawn_cost = 4
 
 /datum/map_element/vault/droneship
 	file_path = "maps/randomvaults/droneship.dmm"
+	spawn_cost = 3
 
 /datum/map_element/vault/amelab
 	file_path = "maps/randomvaults/amelab.dmm"
 	can_rotate = TRUE
+	spawn_cost = 3
 
 /datum/map_element/vault/meteorlogical_station
 	file_path = "maps/randomvaults/meteorlogical_station.dmm"
+	spawn_cost = 4
 
 /datum/map_element/vault/taxi_engi
 	file_path = "maps/randomvaults/taxi_engineering.dmm"
 	can_rotate = TRUE
+	spawn_cost = 2
 
 /datum/map_element/vault/ice_comet
 	file_path = "maps/randomvaults/ice_comet.dmm"
 	can_rotate = TRUE
+	spawn_cost = 1
 
 /datum/map_element/vault/research_facility
 	file_path = "maps/randomvaults/research_facility.dmm"
 	can_rotate = TRUE
+	spawn_cost = 4
 
 /datum/map_element/vault/zoo_truck
 	file_path = "maps/randomvaults/zoo_truck.dmm"
 	can_rotate = TRUE
+	spawn_cost = 3
 
 /datum/map_element/vault/syndiecargo
 	file_path = "maps/randomvaults/syndiecargo.dmm"
+	spawn_cost = 4
 
 /datum/map_element/vault/black_site_prism
 	file_path = "maps/randomvaults/black_site_prism.dmm"
+	spawn_cost = 4
 
 /datum/map_element/vault/skeleton_den
 	file_path = "maps/randomvaults/rattlemebones.dmm"
+	spawn_cost = 3
 
 /datum/map_element/vault/beach_party
 	file_path = "maps/randomvaults/beach_party.dmm"
+	spawn_cost = 1
 
 /datum/map_element/vault/zathura
 	file_path = "maps/randomvaults/house.dmm"
 	can_rotate = TRUE
+	spawn_cost = 1
 
 /datum/map_element/vault/spy_sat
 	file_path = "maps/randomvaults/spy_satellite.dmm"
+	spawn_cost = 3
 
 /datum/map_element/vault/spy_sat/pre_load()
 	load_dungeon(/datum/map_element/dungeon/satellite_deployment,rotation)
@@ -213,27 +247,34 @@ var/list/existing_vaults = list()
 
 /datum/map_element/vault/ironchef
 	file_path = "maps/randomvaults/ironchef.dmm"
+	spawn_cost = 3
 
 /datum/map_element/vault/assistantslair
 	file_path = "maps/randomvaults/assistantslair.dmm"
+	spawn_cost = 3
 
 /datum/map_element/vault/asteroidfield
 	file_path = "maps/randomvaults/asteroidfield.dmm"
 	can_rotate = TRUE
+	spawn_cost = 2
 
 /datum/map_element/vault/clownroid
 	file_path = "maps/randomvaults/clownroid.dmm"
 	can_rotate = TRUE
+	spawn_cost = 3
 
 /datum/map_element/vault/goonesat
 	file_path = "maps/randomvaults/goonesat.dmm"
 	can_rotate = TRUE
+	spawn_cost = 3
 
 /datum/map_element/vault/podstation
 	file_path = "maps/randomvaults/podstation.dmm"
+	spawn_cost = 2
 
 /datum/map_element/vault/mini_station
 	file_path = "maps/randomvaults/mini_station.dmm"
+	spawn_cost = 2
 
 /datum/map_element/dungeon/habitation
 	file_path = "maps/randomvaults/dungeons/habitation.dmm"
@@ -244,6 +285,11 @@ var/list/existing_vaults = list()
 /datum/map_element/vault/fastfoodjoint
 	name = "Fast food joint"
 	file_path = "maps/randomvaults/fastfoodjoint.dmm"
+	spawn_cost = 2
+
+/datum/map_element/vault/laundromat
+	file_path = "maps/randomvaults/laundromat.dmm"
+	spawn_cost = 3
 
 /datum/map_element/vault/laundromat/pre_load()
 	load_dungeon(/datum/map_element/dungeon/laundromat_drug_lab,rotation)

--- a/code/modules/randomMaps/vault_definitions.dm
+++ b/code/modules/randomMaps/vault_definitions.dm
@@ -144,9 +144,6 @@ var/list/existing_vaults = list()
 	file_path = "maps/randomvaults/biodome.dmm"
 	spawn_cost = 2
 
-///datum/map_element/vault/iou_vault
-//	file_path = "maps/randomvaults/iou_fort.dmm"	//Why was this in here twice?
-
 /datum/map_element/vault/asteroids
 	file_path = "maps/randomvaults/asteroids.dmm"
 	can_rotate = TRUE

--- a/code/modules/randomMaps/vault_definitions.dm
+++ b/code/modules/randomMaps/vault_definitions.dm
@@ -123,7 +123,7 @@ var/list/existing_vaults = list()
 /datum/map_element/vault/oldarmory
 	file_path = "maps/randomvaults/oldarmory.dmm"
 	can_rotate = TRUE
-	spawn_cost = 4
+	spawn_cost = 5
 
 /datum/map_element/vault/spacepond
 	file_path = "maps/randomvaults/spacepond.dmm"
@@ -220,7 +220,7 @@ var/list/existing_vaults = list()
 
 /datum/map_element/vault/black_site_prism
 	file_path = "maps/randomvaults/black_site_prism.dmm"
-	spawn_cost = 4
+	spawn_cost = 5
 
 /datum/map_element/vault/skeleton_den
 	file_path = "maps/randomvaults/rattlemebones.dmm"

--- a/code/modules/randomMaps/vaults.dm
+++ b/code/modules/randomMaps/vaults.dm
@@ -8,6 +8,7 @@
 
 #define MINIMUM_VAULT_AMOUNT 5 //Amount of guaranteed vault spawns
 #define MAXIMUM_VAULT_AMOUNT 15
+#define VAULT_POINT_MULTIPLIER 3.5
 
 #define MAX_VAULT_WIDTH  80 //Vaults bigger than that have a slight chance of overlapping with other vaults
 #define MAX_VAULT_HEIGHT 80
@@ -69,7 +70,7 @@
 
 	var/list/list_of_vaults = get_map_element_objects()
 
-	var/vault_number = rand(MINIMUM_VAULT_AMOUNT, min(list_of_vaults.len, MAXIMUM_VAULT_AMOUNT))
+	var/vault_number = (rand(MINIMUM_VAULT_AMOUNT, min(list_of_vaults.len, MAXIMUM_VAULT_AMOUNT)) * VAULT_POINT_MULTIPLIER)
 
 	#ifdef SPAWN_ALL_VAULTS
 	#warn Spawning ALL vaults!
@@ -445,11 +446,14 @@
 			else if(config.disable_vault_rotation)
 				message_admins("<span class='info'>[ME.file_path] was not rotated, DISABLE_VAULT_ROTATION enabled in config.</span>")
 			successes++
-			if(amount > 0)
-				amount--
-
-				if(amount == 0)
-					break
+			if(amount > 0)	//Allowing overflow is intentional, ie: 1 point left and the last picked vault costs 4 points
+				if(istype(ME, /datum/map_element/vault))
+					var/datum/map_element/vault/VE = ME
+					amount -= VE.spawn_cost
+				else
+					amount--
+			if(amount <= 0)
+				break
 		else
 			message_admins("<span class='danger'>Can't find [ME.file_path]!</span>")
 

--- a/code/modules/randomMaps/vaults.dm
+++ b/code/modules/randomMaps/vaults.dm
@@ -8,7 +8,7 @@
 
 #define MINIMUM_VAULT_AMOUNT 5 //Amount of guaranteed vault spawns
 #define MAXIMUM_VAULT_AMOUNT 15
-#define VAULT_POINT_MULTIPLIER 3.5
+#define VAULT_POINT_MULTIPLIER 3
 
 #define MAX_VAULT_WIDTH  80 //Vaults bigger than that have a slight chance of overlapping with other vaults
 #define MAX_VAULT_HEIGHT 80

--- a/maps/randomvaults/keycard_vault.dm
+++ b/maps/randomvaults/keycard_vault.dm
@@ -10,6 +10,7 @@
 /datum/map_element/vault/keycards
 	name = "Keycard-gate vault entrance"
 	file_path = "maps/randomvaults/keycard_entrance.dmm"
+	spawn_cost = 3
 	can_rotate = FALSE // It has dungeons, which don't rotate well for now
 	var/difficulty = 0 // 0 to generate randomly, see preset variants below
 	var/datum/map_element/dungeon/keycard_vault/thevault

--- a/maps/randomvaults/mothership_lab.dm
+++ b/maps/randomvaults/mothership_lab.dm
@@ -1,6 +1,7 @@
 /datum/map_element/vault/mothership_lab
 	name = "Mothership Lab"
 	file_path = "maps/randomvaults/mothership_lab.dmm"
+	spawn_cost = 5
 
 	can_rotate = 0 // I doubt it would work
 

--- a/maps/randomvaults/sokoban.dm
+++ b/maps/randomvaults/sokoban.dm
@@ -3,6 +3,7 @@
 /datum/map_element/vault/sokoban
 	name = "Sokoban"
 	file_path = "maps/randomvaults/sokoban_entrance.dmm"
+	spawn_cost = 3
 
 	var/list/available_levels = list(
 	"maps/randomvaults/dungeons/sokoban/A.dmm",

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -168,6 +168,7 @@ var/list/shop_prices = list( //Cost in space credits
 /datum/map_element/vault/supermarket
 	name = "Spessmart"
 	file_path = "maps/randomvaults/spessmart.dmm"
+	spawn_cost = 5
 
 	var/customer_has_entered = FALSE
 


### PR DESCRIPTION
This is something I've been wanting for years now, and the vault contest was a great excuse to do it myself.

### What this changes

Vaults currently spawn completely randomly with equal weight, a number between 5 and 15 is picked, and that's how many vaults you get. 

What this does is add a point value to every vault, which is then subtracted from a total (RNG based) point value when spawning. Meaning **more small scenery-based vaults can spawn, while not being in (as much) direct competition with larger round altering vaults**, so both scenery enjoyers and loot piñata hunters benefit.  

### The math

Including this for transparency, this will increase the total number of vaults that spawn by a noticable, but not too significant number. 
Old: **Number between 5 - 15 = amount of vaults**
New: **Number between 5 - 15, multiplied by 3 = amount of vault spawn points.** 
This is based on a **1 - 5 point scale. So the multiplier of 3 is meant to be an "average" vault cost, effectively equal to what we do now.

### Big List of Vault Point Costs
Balance was based around danger, time investment, rewards, and in some cases chance of finding/engaging with it at all. Also personal opinion.

**1 Point**
- Ice truck crash
- Tommy boy asteroid
- Space gym
- Space Pond
- IOU vault
- Hivebot crash
- AI satellite
- Ice comet
- Beach party
- Zathura

**2 Points**
- Asteroid Temple
- Mechanic Clubhouse
- RUST
- Dance Dance Revolution
- Biodome
- Asteroids
- Prison Ship
- Taxi Engineering
- Asteroid Field
- Pod Station
- Mini Station
- Fast Food Joint

**3 Points**
- Broke UFO
- Lightship
- Hivebot Factory
- Clown Base
- Listening Satellite
- Drone Ship
- AME Lab
- Zoo Truck
- Skeleton Den
- Spy Satellite
- Iron Chef
- Assistant's Lair
- Clown Roid
- Goon Sat
- Laundromat
- Keycard Vault
- Sokoban
 
**4 Points**
- Gingerbread House
- Ejected Engine
- Meteorlogical Station
- Research Facility
- Syndie Cargo

**5 Points**
- Mothership Lab
- Black Site Prism
- Old Armory
- Spessmart

I'm not 100% set on the balance of these, and I might be overlooking something so please let me know if I forgot some 2 point vault has something that should make it 4 points or something.

Finally, this also fixed an oversight that prevented the Laundromat vault from spawning.

Closes #27385 


:cl:
 * rscadd: Introduces a point cost system for vault spawning, so more small vaults can spawn without replacing larger ones.
 * bugfix: The Laundromat vault can now spawn properly
 * bugfix: The AME vault will no longer break due to rotating

