### PR TITLE
Painting/scoreboard maintenance

### DIFF
--- a/code/game/gamemodes/endgame/scoreboard/misc_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/misc_score.dm
@@ -7,7 +7,7 @@
 	if(gallery.len) //the list of all artworks
 		var/list/artworks = list() //list of authors, for sorting later
 		for(var/obj/structure/painting/custom/painting in gallery)
-			if(painting.show_on_scoreboard && !painting.painting_data.is_blank())
+			if(painting.painting_data.show_on_scoreboard && !painting.painting_data.is_blank())
 				var/painting_author = painting.painting_data.author
 				if(!painting_author)
 					painting_author = "Anonymous"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1377,6 +1377,12 @@
 			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Cluwne;jobban4=\ref[M]'><font color=red>Cluwne</font></a></td>"
 		else
 			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Cluwne;jobban4=\ref[M]'>Cluwne</a></td>"
+		
+		if(jobban_isbanned(M, "artist")) //so people can't make paintings
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=artist;jobban4=\ref[M]'><font color=red>Artist</font></a></td>"
+		else
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=artist;jobban4=\ref[M]'>Artist</a></td>"	
+		
 		jobs += "</tr></table>"
 
 		body = "<body>[jobs]</body>"

--- a/code/modules/html_interface/paintTool/custom_painting_datum.dm
+++ b/code/modules/html_interface/paintTool/custom_painting_datum.dm
@@ -172,6 +172,7 @@
 	var/title = ""
 	var/description = ""
 	var/contributing_artists = list()
+	var/show_on_scoreboard = TRUE
 
 	var/copy = 0
 
@@ -493,6 +494,7 @@
 	painting.author = author
 	painting.description = description
 	painting.copy = 1
+	painting.show_on_scoreboard = FALSE //sorry, OC only
 	return painting
 
 #undef PENCIL_STRENGTH_MAX

--- a/code/modules/painting/paintings_custom.dm
+++ b/code/modules/painting/paintings_custom.dm
@@ -26,7 +26,6 @@
 	var/base_icon_state = "blank"
 	var/frame_icon = 'icons/obj/painting_items.dmi'
 	var/frame_icon_state = "frame"
-	var/show_on_scoreboard = TRUE
 
 	var/image/nanomap
 


### PR DESCRIPTION
requested by blitzikaze

:cl:
 * rscdel: printed paintings no longer show up on the scoreboard
 * experiment: admemes can now actually artistban people from the job ban panel
 * tweak: painting scoreboard var moved from painting object to custom painting datum (so VV painting -> datum if you want to ban a painting)
