### PR TITLE
CE Belt Preequip

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -125,20 +125,18 @@
 
 /obj/item/weapon/storage/belt/utility/chief/full/New() //This is mostly for testing I guess
 	..()
-	new /obj/item/tool/crowbar(src)
-	new /obj/item/tool/screwdriver(src)
+	new /obj/item/tool/crowbar/halligan(src)
 	new /obj/item/tool/weldingtool/hugetank(src)
 	new /obj/item/tool/wirecutters(src)
 	new /obj/item/tool/wrench(src)
+	new /obj/item/tool/solder/screw(src)
 	new /obj/item/device/multitool(src)
-	new /obj/item/stack/cable_coil(src)
-	new /obj/item/stack/cable_coil(src)
-	new /obj/item/device/t_scanner(src)
-	new /obj/item/device/analyzer(src)
-	new /obj/item/tool/solder/pre_fueled(src)
 	new /obj/item/device/silicate_sprayer(src)
-	new /obj/item/device/rcd/rpd(src)
-	new /obj/item/device/rcd/matter/engineering/pre_loaded(src)
+	new /obj/item/device/t_scanner/advanced(src)
+	new /obj/item/device/analyzer(src)
+	new /obj/item/weapon/inflatable_dispenser(src)
+	new /obj/item/stack/cable_coil(src)
+
 
 
 /obj/item/weapon/storage/belt/medical

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -25,21 +25,15 @@
 		/obj/item/weapon/cartridge/ce,
 		/obj/item/device/radio/headset/heads/ce,
 		/obj/item/weapon/storage/box/inflatables,
-		/obj/item/weapon/inflatable_dispenser,
-		/obj/item/weapon/storage/toolbox/mechanical,
-		/obj/item/device/t_scanner/advanced,
 		/obj/item/device/device_analyser/advanced,
 		/obj/item/clothing/suit/storage/hazardvest,
 		/obj/item/clothing/mask/gas,
-		/obj/item/device/multitool,
 		/obj/item/device/flash,
 		/obj/item/device/gps/engineering,
-		/obj/item/weapon/storage/belt/utility/chief,
+		/obj/item/weapon/storage/belt/utility/chief/full,
 		/obj/item/clothing/glasses/scanner/material,
 		/obj/item/weapon/card/debit/preferred/department/engineering,
 		/obj/item/weapon/reagent_containers/food/snacks/monkeycube/gourmonger,
-		/obj/item/tool/solder/screw,
-		/obj/item/tool/crowbar/halligan
 	)
 
 /obj/structure/closet/secure_closet/engineering_electrical

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2194,7 +2194,6 @@
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\clown.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\cluwne.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\cockatrice.dm"
-#include "code\modules\mob\living\simple_animal\hostile\retaliate\creatinecricket.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\drone.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\faguette.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\mime.dm"

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2194,6 +2194,7 @@
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\clown.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\cluwne.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\cockatrice.dm"
+#include "code\modules\mob\living\simple_animal\hostile\retaliate\creatinecricket.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\drone.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\faguette.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\mime.dm"


### PR DESCRIPTION
This is something I have been meaning to do for ages to save myself time every shift setup

The chief engineer belt now spawns equipped with all the tools that spawn inside your locker anyway (halligan, screwsolder, multitool, mechanical toolbox items, inflatables dispenser, p-ray scanner).

Reduces locker clutter, speeds up shift prep.

🆑 
* tweak: Some tools moved onto the chief engineer's belt from his locker.