### PR TITLE
CE Contacts

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -244,3 +244,21 @@
 		R.toggle_light(owner)
 		return TRUE
 	return FALSE
+
+/datum/action/item_action/toggle_meson_scanner //Only used for the CE contacts, so it's named separately
+	name = "Toggle meson scanner"
+	icon_icon = 'icons/obj/clothing/glasses.dmi'
+	button_icon_state = "meson"
+
+/datum/action/item_action/alt/Trigger()
+	if(!IsAvailable())
+		return FALSE
+	if(target)
+		var/obj/item/I = target
+		I.AltClick(owner)
+	return TRUE
+
+/datum/action/item_action/alt/toggle_material_scanner
+	name = "Toggle material scanner"
+	icon_icon = 'icons/obj/clothing/glasses.dmi'
+	button_icon_state = "material"

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -34,6 +34,7 @@
 		/obj/item/clothing/glasses/scanner/material,
 		/obj/item/weapon/card/debit/preferred/department/engineering,
 		/obj/item/weapon/reagent_containers/food/snacks/monkeycube/gourmonger,
+		/obj/item/clothing/glasses/scanner/dual/chiefengineer
 	)
 
 /obj/structure/closet/secure_closet/engineering_electrical

--- a/code/modules/clothing/glasses/scanners.dm
+++ b/code/modules/clothing/glasses/scanners.dm
@@ -184,7 +184,7 @@
 	actions_types = list(/datum/action/item_action/toggle_meson_scanner, /datum/action/item_action/alt/toggle_material_scanner)
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
 	glasses_fit = TRUE
-	prescription_type = /obj/item/clothing/glasses/scanner/meson/prescription
+	nearsighted_modifier = -3
 	hud_types = list(/datum/visioneffect/meson,/datum/visioneffect/material)
 
 /obj/item/clothing/glasses/scanner/dual/chiefengineer/examine(mob/user)

--- a/code/modules/clothing/glasses/scanners.dm
+++ b/code/modules/clothing/glasses/scanners.dm
@@ -89,6 +89,18 @@
 	to_chat(C, "You turn \the [src] off.")
 	C.handle_regular_hud_updates()
 
+/obj/item/clothing/glasses/scanner/proc/toggle_slot(var/mob/living/carbon/C, slot)
+	var/datum/hud/H = stored_huds[slot]
+	if(!H)
+		return
+	if(H in C.huds) //Detect if it is currently on
+		C.remove_hud(H)
+		to_chat(C, "You turn \the [H] off.")
+	else
+		C.apply_hud(H)
+		to_chat(C, "You turn \the [H] off.")
+	C.handle_regular_hud_updates()
+
 //This is for harm labels blocking your vision. It also will stop most huds...
 //Though, some are overridden for reality (labels won't stop your thermals, but you will be blind otherwise)
 /obj/item/clothing/glasses/scanner/harm_label_update()
@@ -162,6 +174,65 @@
 		icon_state = "mesonoff"
 	else
 		icon_state = initial(icon_state)
+
+/obj/item/clothing/glasses/scanner/dual/chiefengineer
+	name = "chief engineer's advanced contacts"
+	desc = "Combines the power of mesons and material scanners. They even sport serious eye protection."
+	icon = 'icons/obj/items.dmi'
+	icon_state = "contact"
+	mech_flags = MECH_SCAN_FAIL
+	eyeprot = 3
+	actions_types = list(/datum/action/item_action/toggle_meson_scanner, /datum/action/item_action/alt/toggle_material_scanner)
+	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
+	glasses_fit = TRUE
+	prescription_type = /obj/item/clothing/glasses/scanner/meson/prescription
+	hud_types = list(/datum/visioneffect/meson,/datum/visioneffect/material)
+
+/obj/item/clothing/glasses/scanner/dual/chiefengineer/examine(mob/user)
+	..()
+	to_chat(user,"<span class='info'>Alt-click to toggle material scanner.</span>")
+
+/obj/item/clothing/glasses/scanner/dual/update_icon()
+	return //contacts don't change
+
+/obj/item/clothing/glasses/scanner/dual/toggle()
+	var/mob/C = usr
+	if (!usr)
+		if (!ismob(loc))
+			return
+		C = loc
+	if (C.incapacitated())
+		return
+	if(loc != C)
+		return
+
+	toggle_slot(C,1)
+	playsound(C,'sound/misc/click.ogg',30,0,-5)
+	update_icon()
+	C.update_inv_glasses()
+
+/obj/item/clothing/glasses/scanner/dual/AltClick(mob/user)
+	if (user.incapacitated())
+		return
+	if(src.loc != user)
+		return
+	toggle_slot(user,2)
+	playsound(user,'sound/misc/click.ogg',30,0,-5)
+	update_icon()
+	user.handle_regular_hud_updates()
+
+/obj/item/clothing/glasses/scanner/dual/unequipped(mob/living/carbon/M, var/from_slot = null)
+	..()
+	on = 0
+
+/obj/item/clothing/glasses/scanner/dual/update_icon()
+	on = 0
+	if(iscarbon(loc))
+		var/mob/living/carbon/C = loc
+		for(var/datum/hud/H in stored_huds)
+			if(H in C.huds)
+				on = 1
+	..()
 
 /*
 	PATHOGEN HUD

--- a/code/modules/clothing/glasses/scanners.dm
+++ b/code/modules/clothing/glasses/scanners.dm
@@ -181,7 +181,6 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "contact"
 	mech_flags = MECH_SCAN_FAIL
-	eyeprot = 3
 	actions_types = list(/datum/action/item_action/toggle_meson_scanner, /datum/action/item_action/alt/toggle_material_scanner)
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
 	glasses_fit = TRUE


### PR DESCRIPTION
Not yet added to locker because of my other PR

Backend: you can now have more than one toggleable hud on a single glasses item

![image](https://github.com/vgstation-coders/vgstation13/assets/9782036/45b70846-d855-4d27-8cb7-5a3311370e11)

🆑 
* rscadd: CE now gets contacts that protect eyes and the user can independently toggle material and meson scanners.