### PR TITLE
Hallucinations Don't Fake Doorshock

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -384,10 +384,17 @@ About the new airlock wires panel:
 					user.delayNextMove(10)
 					spawn (10)
 						src.justzap = 0
-		else if(user.hallucination > 50 && prob(10) && src.operating == 0)
-			to_chat(user, "<span class='danger'>You feel a powerful shock course through your body!</span>")
-			user.adjustHalLoss(10)
-			user.AdjustStunned(10)
+		else if(user.client && user.hallucination > 50 && prob(10) && !operating)
+			//access denied
+			user << 'sound/machines/denied.ogg'
+			var/image/haldoor = image(icon,loc,"door_deny",ABOVE_DOOR_LAYER)
+			haldoor.plane = relative_plane(OBJ_PLANE)
+			user.client.images += haldoor
+			user.delayNextMove(3) //Stop for 3 frames, same as the hallucination
+			user.ear_deaf += 1 //Deafen them just for one tick so they don't hear the door open for real
+			spawn(6)
+				user.client.images -= haldoor
+				QDEL_NULL(haldoor)
 	..(user)
 
 /obj/machinery/door/airlock/proc/isElectrified()


### PR DESCRIPTION
Instead of hallucinations causing doorshock, they can instead
* Plays a fake denied sound just to you
* Deafen you for one tick so you can't hear the door opening
* Put a hallucinated "denied" flash over the door that only you can see
* Delay your move (0.3 seconds) so you can't move into the opening door

Basically it makes it seem like you don't have access to the door

🆑 
* tweak: Instead of fake doorshock, hallucinations can fake no access