### PR TITLE
Buff Roulette Revolver

### DIFF
--- a/code/modules/projectiles/guns/projectile/roulette.dm
+++ b/code/modules/projectiles/guns/projectile/roulette.dm
@@ -27,15 +27,22 @@
 		/obj/item/projectile/beam/lightning,
 		/obj/item/projectile/beam/procjectile,
 		/obj/item/projectile/beam/lightning/spell,
+		/obj/item/projectile/rocket,
 		/obj/item/projectile/rocket/nikita,
+		/obj/item/projectile/rocket/lowyield/extreme,
 		/obj/item/projectile/test,
+		/obj/item/projectile/friendlyCheck,
 		/obj/item/projectile/beam/emitter,
-		/obj/item/projectile/meteor,
 		/obj/item/projectile/spell_projectile,
 		/obj/item/projectile/stickybomb,
 		/obj/item/projectile/beam/lightlaser,
 		/obj/item/projectile/portalgun,
 		)
+
+	var/list/restrict_with_subtypes = list(
+		/obj/item/projectile/meteor,
+		/obj/item/projectile/immovablerod
+	)
 
 /obj/item/weapon/gun/projectile/roulette_revolver/New()
 	..()
@@ -64,6 +71,10 @@
 	var/chosen_projectile = pick(available_projectiles)
 	for(var/I in restricted_projectiles)
 		if(chosen_projectile == I)
+			choose_projectile()
+			return
+	for(var/I in restrict_with_subtypes)
+		if(ispath(chosen_projectile, I))
 			choose_projectile()
 			return
 	var/P = new chosen_projectile()

--- a/code/modules/projectiles/guns/projectile/roulette.dm
+++ b/code/modules/projectiles/guns/projectile/roulette.dm
@@ -68,6 +68,23 @@
 	else
 		to_chat(user, "<span class='info'>\The [src] has [shots_left] shots left.</span>")
 
+/obj/item/weapon/gun/projectile/roulette_revolver/attackby(obj/item/A, mob/user)
+	if(istype(A, /obj/item/weapon/conversion_kit) && restrict_with_subtypes?.len)
+		var/obj/item/weapon/conversion_kit/CK = A
+		if(!CK.open)
+			to_chat(user, "<span class='notice'>\The [CK] needs to be open to use.</span>")
+			return 1
+		if(do_after(user, src, 3 SECONDS))
+			desc += "The barrel and chamber assembly seems to have been modified."
+			to_chat(user, "<span class='danger'>You finish modifying \the [src]!</span>")
+			restrict_with_subtypes.Cut()
+			restricted_projectiles -= /obj/item/projectile/rocket
+			restricted_projectiles -= /obj/item/projectile/rocket/nikita
+			restricted_projectiles -= /obj/item/projectile/rocket/lowyield/extreme
+		return 1
+	else
+		..()
+
 /obj/item/weapon/gun/projectile/roulette_revolver/proc/choose_projectile()
 	var/chosen_projectile = pick(available_projectiles)
 	for(var/I in restricted_projectiles)

--- a/code/modules/projectiles/guns/projectile/roulette.dm
+++ b/code/modules/projectiles/guns/projectile/roulette.dm
@@ -37,6 +37,7 @@
 		/obj/item/projectile/stickybomb,
 		/obj/item/projectile/beam/lightlaser,
 		/obj/item/projectile/portalgun,
+		/obj/item/projectile/soulbullet,
 		)
 
 	var/list/restrict_with_subtypes = list(


### PR DESCRIPTION
For years, this gun was a dead find because a nonantag couldn't use it without getting banned. I have removed the chance of spawning a boss meteor, extreme rocket, standard rocket, or immovable rod (as well as some projectiles that runtime). That means you can finally shoot this thing in hallways as a nonantag if you have a valid target. No more round-ending blob cores.

The result is a lot more fun. I shot about 100 projectiles in testing and spawned a lot of underloved projectiles, including a cow missile, multiple cluwne or clown goblin rockets, mahoguny stuff, webs, emps, forbidden sun, etc. There are still explosive projectiles that do not breach like the low yield rocket and gyrojet round.

:cl:
* tweak: The roulette revolver now does NOT breach, meaning that it is safe for non-antagonists to use in a context where lethal weapons are permitted.