### PR TITLE
HUD Glasses/Goggles Bugfixes and Tweaks

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -320,6 +320,7 @@
 	item_state = "investigation"
 	darkness_view = -1
 	eyeprot = 1
+	nearsighted_modifier = -3
 	hud_types = list(/datum/visioneffect/security/arrest,
 					/datum/visioneffect/job,
 					/datum/visioneffect/implant)
@@ -383,6 +384,7 @@
 	icon_state = "wagemonocle"
 	species_fit = list(VOX_SHAPED)
 	mech_flags = MECH_SCAN_ILLEGAL
+	nearsighted_modifier = -3
 	hud_types = list(/datum/visioneffect/accountdb/wage,
 					/datum/visioneffect/job)
 
@@ -412,6 +414,7 @@
 	icon_state = "aviators_gold"
 	darkness_view = -1
 	eyeprot = 1
+	nearsighted_modifier = -3
 	hud_types = list(/datum/visioneffect/job)
 
 /*

--- a/code/modules/clothing/glasses/scanners.dm
+++ b/code/modules/clothing/glasses/scanners.dm
@@ -179,7 +179,7 @@
 	hud_types = list(/datum/visioneffect/pathogen)
 
 	glasses_fit = TRUE
-	on = TRUE
+	on = FALSE
 
 /obj/item/clothing/glasses/scanner/science/prescription
 	name = "prescription science goggles"
@@ -187,9 +187,12 @@
 	species_fit = list(GREY_SHAPED, INSECT_SHAPED)
 
 /obj/item/clothing/glasses/scanner/science/update_icon()
+	return
+/*
 	if (!on)
 		icon_state = "mesonoff"
 	else
 		icon_state = initial(icon_state)
+*/
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/modules/mob/dead/observer/verbs.dm
+++ b/code/modules/mob/dead/observer/verbs.dm
@@ -61,11 +61,13 @@
 	for(var/datum/visioneffect/H in huds)
 		if(istype(H,/datum/visioneffect/security))
 			remove_hud(H)
+			detected_hud = TRUE
 		else if(istype(H,/datum/visioneffect/job))
 			remove_hud(H)
+			detected_hud = TRUE
 		else if(istype(H,/datum/visioneffect/implant))
 			remove_hud(H)
-		detected_hud = TRUE
+			detected_hud = TRUE
 	if(detected_hud)
 		to_chat(src, "<span class='notice'><B>Security HUD disabled.</B></span>")
 	else

--- a/code/modules/mob/living/silicon/robot/robot_verbs.dm
+++ b/code/modules/mob/living/silicon/robot/robot_verbs.dm
@@ -144,6 +144,8 @@
 			if("Security")
 				sensor_mode = SEC_HUD
 				apply_hud_by_type(/datum/visioneffect/security/arrest)
+				apply_hud_by_type(/datum/visioneffect/job)
+				apply_hud_by_type(/datum/visioneffect/implant)
 				to_chat(src, "<span class='notice'>Security records overlay enabled.</span>")
 			if("Medical")
 				sensor_mode = MED_HUD


### PR DESCRIPTION
# HUD Tweaks
![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/89f062d9-13a4-481f-a7a3-1167f05497ad)
(they start off now)

## What this does
This changes science goggles back to their old behavior: They start off by default, and retain their normal sprite while off (instead of the mesonoff sprite).

WageHUDs and Detective Tracking Glasses are now prescription glasses by default.

Edit: And now Toggle SecHUD works when you have other HUDs on. Due to a bug on my part, it would think you had sechuds on if you had any HUD on at all and not add a new instance of them.

Edit2: Fixes #35759. Borgs now have a full security HUD again!

## Why it's good
people asked me to do things so doing them is good right. right? retains the soul of the original science goggles i guess!

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Science Goggles now follow old behavior - they start off by default and no longer use the off meson goggle sprite.
 * bugfix: Ghost SecHUDs can now be turned on when you have other HUDs on.
 * bugfix: Borgs now have a fully functional Security HUD again.
 * tweak: WageHUDs and Detective Tracking Glasses are now prescription glasses by default.

[bugfix] [tested]