### PR TITLE
Fixes Switchtool Wrench

### DIFF
--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -37,7 +37,7 @@
 	if(istype(target, /obj/item/weapon/storage) && !istype(target, /obj/item/weapon/storage/pill_bottle)) //we place automatically, but want pill bottles to be meltable
 		return
 	if(deployed)
-		if(!deployed.preattack(target, user))
+		if(!deployed.preattack(target, user, proximity_flag, click_parameters))
 			if(proximity_flag)
 				target.attackby(deployed, user)
 			deployed.afterattack(target, user, proximity_flag, click_parameters)


### PR DESCRIPTION
# Fixes Switchtool Wrench
![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/6f1a0972-178e-4c02-9a40-03f82620598e)
*once again you can now steal the merch computer with its own switchtool*

## What this does
Fixes #35690. Fixes #35773. As Kurf himself predicted, #34525 broke it when it added the wrench preattack function and proximity_flag/click_parameters arguments/checks. The switchtool preattack's subcall on the deployed item didn't include those arguments, so the new prox check always failed.

## Why it's good
this is not the nerf that the switchtool needs, even though it is one that it deserves.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Switchtool wrenches work once again.
 
[bugfix] [tested]