### PR TITLE
Merch Computer SFX

### DIFF
--- a/code/modules/store/items.dm
+++ b/code/modules/store/items.dm
@@ -11,9 +11,10 @@
 
 /datum/storeitem/proc/deliver(var/mob/user,var/obj/machinery/computer/merch/merchcomp)
 	var/thing = new typepath(merchcomp.loc)
+	var/turf/T = get_turf(merchcomp)
+	T.turf_animation('icons/effects/96x96.dmi',"beamin",-32,0,MOB_LAYER+1,'sound/weapons/emitter2.ogg',anim_plane = EFFECTS_PLANE)
 	if(istype(typepath,/obj/item/weapon/storage))
 		var/obj/item/weapon/storage/S = thing
-		user.put_in_hands(S)
 		if(station_does_not_tip)
 			var/list/additional_types = list(
 				IRRADIATEDBEANS,


### PR DESCRIPTION
# The Stuff Is Zapped Directly to You!
[dazoop.webm](https://github.com/vgstation-coders/vgstation13/assets/69739118/1d1f5303-08cf-47fe-908d-3a30d3e124e3)

## What this does
This adds a typing sound, delay, and a bluespace warping effect (the admin zoop) to the Merch Computer.

This PR comes from the fact that the computer is (mostly, ROGAN!!!) infinite stock, with no refills like a vending machine. It's likely that these small, branded items might just be warped directly to the station on request. So, why not?

When adding the sound effect, I found that the tile animation effect does not stack if spammed. So, some typing on a keyboard effects later, we have the above result.

The computer will also give a buzz if you can't afford what you're paying for.

## Why it's good
typing noise on computer good! and a delightfully devilish nerf to those pesky switchtool users, now they have to wait two seconds to get their fix...

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added new effects when ordering from the Merch Computer
 * spellcheck: Added an examine description for the Merch Computer

[sound] [tested]