### PR TITLE
Cat Behaviors

### DIFF
--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -96,7 +96,8 @@
 		set_broken()
 		setDensity(FALSE)
 
-
+/obj/machinery/computer/cat_comfy()
+	return TRUE
 
 /obj/machinery/computer/update_icon()
 	..()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -540,6 +540,11 @@ Class Procs:
 			to_chat(user, "<span class='warning'>You momentarily forget how to use [src].</span>")
 			return 1
 
+	var/mob/cat = locate(/mob/living/simple_animal/cat) in loc
+	if(cat)
+		to_chat(user, "<span class='warning'>\The [cat] is in the way!</span>")
+		return 1
+
 	src.add_fingerprint(user)
 	return 0
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1606,6 +1606,10 @@ var/global/list/image/blood_overlays = list()
 /obj/item/proc/on_restraint_apply(var/mob/living/carbon/C)
 	return
 
+/obj/item/cat_act(mob/M)
+	visible_message("<span class='danger'>\The [M] bats \the [src].</span>")
+	throw_at(get_step(src, pick(cardinal)),1,1)
+
 //Called when user clicks on an object while looking through a camera (passed to the proc as [eye])
 /obj/item/proc/remote_attack(atom/target, mob/user, atom/movable/eye)
 	return

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -696,6 +696,14 @@ a {
 /obj/proc/npc_tamper_act(mob/living/L)
 	return NPC_TAMPER_ACT_FORGET
 
+//Cat likes to sit on this
+/obj/proc/cat_comfy()
+	return FALSE
+
+//What cats do to this when in a fell mood
+/obj/proc/cat_act(mob/M)
+	return
+
 /obj/actual_send_to_future(var/duration)
 	var/turf/current_turf = get_turf(src)
 	var/datum/current_loc = loc

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -298,6 +298,9 @@
 	layer = OBJ_LAYER
 	plane = OBJ_PLANE
 
+/obj/structure/bed/chair/comfy/cat_comfy()
+	return TRUE
+
 /obj/structure/bed/chair/comfy/attackby(var/obj/item/W, var/mob/user)
 	if (W.is_wrench(user))
 		for (var/atom/movable/AM in src)

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -13,11 +13,14 @@
 	name = "bar stool"
 	desc = "Apply butt. Get drunk."
 	icon_state = "bar-stool"
-	
+
 /obj/item/weapon/stool/cushion
 	name = "cushion"
 	desc = "Apply butt. Get comfy."
 	icon_state = "cushion"
+
+/obj/item/weapon/stool/cushion/cat_comfy()
+	return TRUE
 
 /obj/item/weapon/stool/hologram
 	sheet_type = null

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -139,6 +139,14 @@
 			I.forceMove(get_turf(src))
 	..()
 
+/obj/structure/bookcase/cat_act(mob/M)
+	visible_message("<span class='danger'>\The [M] sharpens [M.gender == FEMALE ? "her" : "his"] claws on \the [src].</span>")
+	playsound(src, "paper_tear.ogg", 50, 1, -5)
+	shake(1,3)
+	for(var/obj/item/I in contents)
+		if(is_type_in_list(I, valid_types))
+			I.forceMove(get_turf(src))
+
 /obj/structure/bookcase/update_icon()
 	if(contents.len < 5)
 		icon_state = "book-[contents.len]"
@@ -228,6 +236,12 @@
 /obj/item/weapon/book/cultify()
 	new /obj/item/weapon/tome_legacy(loc)
 	..()
+
+/obj/item/weapon/book/cat_act(mob/M)
+	visible_message("<span class='danger'>\The [M] shreds \the [src].</span>")
+	for(var/i = 1 to rand(3,4))
+		new /obj/item/weapon/paper/crumpled(loc)
+	qdel(src)
 
 /obj/item/weapon/book/proc/read_a_motherfucking_book(mob/user)
 	if(carved)

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -1,3 +1,11 @@
+#define CAT_TABLE_OFFSET 8
+#define CAT_MOOD_YEARNING 0
+#define CAT_MOOD_STRAYING 1
+#define CAT_MOOD_PLAYFUL 2
+#define CAT_MOOD_FELL 3
+#define CAT_MOOD_SLEEPY 4
+#define CAT_MOOD_COZY 5
+
 //Cat
 /mob/living/simple_animal/cat
 	name = "cat"
@@ -35,54 +43,229 @@
 	var/mob/living/simple_animal/mouse/movement_target=null
 	var/kill_verbs = list("splats", "toys with", "worries")
 	var/growl_verbs = list("hisses and spits", "mrowls fiercely", "growls")
-
+	pass_flags = PASSTABLE | PASSMACHINE
 	held_items = list()
 
-//RUNTIME IS ALIVE! SQUEEEEEEEE~
-/mob/living/simple_animal/cat/Runtime
-	name = "Runtime"
-	desc = "GCAT"
-	icon_state = "cat"
-	icon_living = "cat"
-	icon_dead = "cat_dead"
-	gender = FEMALE
-	is_pet = TRUE
+	var/mood = CAT_MOOD_PLAYFUL
+	var/current_mood_time = 0 //Time on this mood
+	var/moods_since_yearning = 0 //For deciding to go home
+	var/last_loc = null //Used to check if we have made progress
+	var/area/cathome = null //For returning on yearn
+	var/area/goalarea = null //For straying
+	var/list/mood_weights = list(
+		CAT_MOOD_YEARNING = 12,
+		CAT_MOOD_STRAYING = 12,
+		CAT_MOOD_PLAYFUL = 12,
+		CAT_MOOD_FELL = 12,
+		CAT_MOOD_SLEEPY = 12,
+		CAT_MOOD_COZY = 12)
+	var/list/valid_stray_zones = list(/area/crew_quarters/sleep,/area/crew_quarters/toilet,
+/area/crew_quarters/locker,/area/crew_quarters/bar,/area/crew_quarters/kitchen,/area/chapel,/area/hallway/secondary/exit,
+/area/hallway/secondary/entry,/area/engineering/break_room,/area/medical/break_room,/area/science/breakroom,/area/supply/office,
+/area/janitor,/area/security/main)
 
-/mob/living/simple_animal/cat/Runtime/on_reagent_change()
-	if(src.icon_living != "original")
-		var/m_amount = reagents.get_reagent_amount(METHYLIN)
-		if(m_amount >= 4) /* We want 5 units, but we're accounting for metabolism ticks here. */
-			reagents.remove_reagent_by_type(METHYLIN, m_amount)
-			playsound(src, 'sound/effects/bubbles.ogg', 80, 1)
-			for(var/mob/M in view())
-				to_chat(M, "<span class='notice'>\The [src]'s fur vibrates and shimmers as a mind-enhancing solution flows through \his... and \she transforms!</span>") /* BYOND doesn't have an equivalent macro for "her"... */
-			espify()
+/mob/living/simple_animal/cat/New()
+	..()
+	cathome = get_area(src)
 
-/mob/living/simple_animal/cat/Proc
-	name = "Proc"
+/mob/living/simple_animal/cat/Destroy()
+	..()
+	last_loc = null
+	cathome = null
+	goalarea = null
 
-/mob/living/simple_animal/cat/salem
-	name = "Salem"
-	desc = "Meow."
-	icon_state = "salem"
-	icon_living= "salem"
-	icon_dead= "salem_dead"
-	gender = FEMALE
-	holder_type = /obj/item/weapon/holder/animal/salem
+/mob/living/simple_animal/cat/prewander(destination)
+	if(!hastable(loc) && hastable(destination))
+		visible_message("<span class='notice'>\The [src] leaps up onto the table!</span>")
+		do_leap()
+	return ..()
 
-/mob/living/simple_animal/cat/kitten
-	name = "kitten"
-	desc = "D'aaawwww!"
-	icon_state = "kitten"
-	icon_living = "kitten"
-	icon_dead = "kitten_dead"
-	gender = NEUTER
-	size = SIZE_TINY
+/mob/living/simple_animal/cat/wander_move(dest)
+	if(mood == CAT_MOOD_PLAYFUL)
+		var/list/zoom_places = view(1,src)
+		for(var/i = 1 to 5)
+			Move(zoom_places)
+			sleep(2)
+
+	else
+		..()
+
+/mob/living/simple_animal/cat/Move(destination)
+	last_loc = loc
+	..()
+	update_icon = TRUE //may need to hop down
+
+/mob/living/simple_animal/cat/proc/hastable(turf/newloc)
+	if(!istype(newloc))
+		return FALSE
+	if(locate(/obj/structure/table) in newloc)
+		return TRUE
+	return FALSE
+
+/mob/living/simple_animal/cat/proc/comfiness_check(turf/newloc)
+	for(var/obj/O in newloc)
+		if(O.cat_comfy())
+			return TRUE
+	return FALSE
+
+/mob/living/simple_animal/cat/update_icon()
+	..()
+	pixel_y = hastable(loc) ? CAT_TABLE_OFFSET : 0
+	if(isUnconscious())
+		icon_state = initial(icon_state) + "_dead"
+		return
+	if(resting)
+		icon_state = initial(icon_state) + "_rest"
+
+/mob/living/simple_animal/cat/proc/do_leap()
+	animate(src, pixel_y = CAT_TABLE_OFFSET*1.5, time = CAT_TABLE_OFFSET/2, easing = QUAD_EASING | EASE_OUT)
+	spawn(CAT_TABLE_OFFSET/2)
+		animate(src, pixel_y = CAT_TABLE_OFFSET, time = CAT_TABLE_OFFSET/4, easing = QUAD_EASING | EASE_IN)
+
+/mob/living/simple_animal/cat/proc/pick_mood()
+	//YEARNING = Goes home
+	//STRAYING = Goes to a random room
+	//Fell: Automatic if attacked
+	//COZY = Seeks out a place to lay, plays rest animation
+	//Automaticly if completed straying or yearning
+
+	var/list/possible_moods = mood_weights.Copy()
+	//Step 1: Location-based
+	possible_moods[mood] = 0 //No chance of picking current mood
+	if(get_area(src) == cathome)
+		possible_moods[CAT_MOOD_YEARNING] = 0 //Can't yearn when at home
+		possible_moods[CAT_MOOD_SLEEPY] *= 2
+	else
+		possible_moods[CAT_MOOD_SLEEPY] *= 0.5
+	if(z != map.zMainStation)
+		possible_moods[CAT_MOOD_STRAYING] = 0
+	//Step 2: Apply current-mood effects
+	switch(mood)
+		if(CAT_MOOD_YEARNING)
+			//If we are still yearning, we never fully reached home
+			goalarea = null
+			possible_moods[CAT_MOOD_FELL] *= 1.25
+			possible_moods[CAT_MOOD_COZY] *= 1.25
+
+		if(CAT_MOOD_STRAYING)
+			//We just wandered a while but never got where we wanted to
+			goalarea = null
+			possible_moods[CAT_MOOD_FELL] *= 2
+			possible_moods[CAT_MOOD_YEARNING] *= 2
+
+		if(CAT_MOOD_PLAYFUL)
+			//No longer playful, reset wander freq
+			turns_per_move = 5
+			possible_moods[CAT_MOOD_FELL] *= 0.5
+			possible_moods[CAT_MOOD_SLEEPY] *= 1.5
+
+		if(CAT_MOOD_FELL)
+			//We are no longer in a Fell mood, stop hissing
+			emote_sound = list("sound/voice/catmeow.ogg")
+			possible_moods[CAT_MOOD_PLAYFUL] *= 0.25
+			possible_moods[CAT_MOOD_STRAYING] *= 3
+			possible_moods[CAT_MOOD_SLEEPY] *= 1.5
+
+		if(CAT_MOOD_SLEEPY)
+			//We are not going to be sleepy after this, so immediately clear sleepiness
+			sleeping = 0
+			possible_moods[CAT_MOOD_PLAYFUL] *= 2
+			possible_moods[CAT_MOOD_FELL] *= 2
+
+		if(CAT_MOOD_COZY)
+			//No longer comfy, can wander
+			wander = TRUE
+			possible_moods[CAT_MOOD_SLEEPY] *= 2
+			possible_moods[CAT_MOOD_YEARNING] *= 0.25
+			possible_moods[CAT_MOOD_STRAYING] *= 0.25
+
+	//Step 3: Apply stat-based effects
+	if(size == SIZE_TINY)
+		possible_moods[CAT_MOOD_PLAYFUL] *= 2 //kittens are more playful
+	if(health<maxHealth)
+		//This formula looks more complicated than it is.
+		//Get the percent health (e.g.: 40%). Then take the inverse of that, so 0.6
+		//Then add 1, and round to nearest 0.25, so 1.6 ~= 1.5
+		var/weight = round(1+(1-(health/maxHealth)),0.25)
+		possible_moods[CAT_MOOD_SLEEPY] *= weight
+		possible_moods[CAT_MOOD_FELL] *= weight
+
+	//Step 4: Yearn
+	if(moods_since_yearning>1)
+		possible_moods[CAT_MOOD_YEARNING] *= moods_since_yearning-1 //e.g.: 3 moods = 2x
+
+	set_mood(pickweight(possible_moods))
+
+/mob/living/simple_animal/cat/proc/set_mood(numood)
+	mood = numood
+	current_mood_time = 0
+	if(get_area(src) != cathome) //Only increase if not at home
+		moods_since_yearning++
+	else
+		moods_since_yearning = 0
+	update_icon()
+	switch(mood)
+		if(CAT_MOOD_PLAYFUL)
+			turns_per_move = 2
+		if(CAT_MOOD_YEARNING)
+			goalarea = cathome
+		if(CAT_MOOD_STRAYING)
+			goalarea = pick_straying()
+		if(CAT_MOOD_COZY)
+			wander = FALSE
+
+/mob/living/simple_animal/cat/proc/pick_straying()
+	var/list/searchareas = shuffle(areas.Copy())
+
+	for(var/area/A in searchareas)
+		if(is_type_in_list(A,valid_stray_zones))
+			goalarea = A
+			return
 
 /mob/living/simple_animal/cat/Life()
 	if(timestopped)
 		return 0 //under effects of time magick
 
+	sleeping = max(sleeping-1,0) //Same rate as carbons)
+	current_mood_time++
+
+	if(current_mood_time>120+rand(0,60)) //Can't pick a mood under 4 minutes. Then, the odds increase per second (guaranteed at 5 min).
+		pick_mood()
+
+	if(isUnconscious())
+		health = min(health+1, maxHealth) //Heal while sleeping
+		if(mood!=CAT_MOOD_SLEEPY)
+			set_mood(CAT_MOOD_SLEEPY)
+		if(prob(5))
+			playsound(loc, 'sound/voice/catpurr.ogg', 50, 1)
+		return ..()
+
+	resting = FALSE //We are not asleep, so stop resting. This will be activated again if we are comfy.
+	switch(mood)
+		if(CAT_MOOD_SLEEPY)
+			sleeping += 150 //5 minutes at 2 sec per tick
+		//No special behavior for playful, but wanders more and does wild movement when wandering
+		if(CAT_MOOD_YEARNING, CAT_MOOD_STRAYING)
+			if(loc == last_loc) //Why haven't we made progress? Meow!
+				playsound(loc, 'sound/voice/catmeow.ogg', 50, 1)
+				visible_message("\The [src] meows impatiently!")
+		//Cozy: Check if we have arrived at our movement_target so we can lay down
+		if(CAT_MOOD_COZY)
+			if(comfiness_check())
+				resting = TRUE
+				update_icon()
+
+		//Fell: Attack things
+		if(CAT_MOOD_FELL)
+			var/list/valid_fell_targets = list(/obj/structure/bookcase,/obj/item)
+			var/list/ire = list()
+			for(var/obj/O in view(1,src))
+				if(istype(O,valid_fell_targets))
+					O+=ire
+			var/obj/chosen = pick(ire)
+			chosen?.cat_act()
+
+	//Perform other behaviors
 	if (!isUnconscious())
 		//MICE!
 		if(isturf(loc))
@@ -132,6 +315,10 @@
 
 /mob/living/simple_animal/cat/proc/react_to_touch(mob/M)
 	if(M && !isUnconscious())
+		if(mood == CAT_MOOD_FELL)
+			playsound(loc, 'sound/voice/cathiss.ogg', 50, 1)
+			emote("me", EMOTE_AUDIBLE, "hisses.")
+			return
 		switch(M.a_intent)
 			if(I_HELP)
 				var/image/heart = image('icons/mob/animal.dmi',src,"heart-ani2")
@@ -139,15 +326,86 @@
 				flick_overlay(heart, list(M.client), 20)
 				emote("me", EMOTE_AUDIBLE, "purrs.")
 				playsound(loc, 'sound/voice/catpurr.ogg', 50, 1)
+				if(prob(5))
+					set_mood(CAT_MOOD_PLAYFUL)
 			if(I_HURT)
 				playsound(loc, 'sound/voice/cathiss.ogg', 50, 1)
 				emote("me", EMOTE_AUDIBLE, "hisses.")
+	if(sleeping)
+		sleeping -= 10
+		if(sleeping <= 0)
+			pick_mood()
 
 /mob/living/simple_animal/cat/proc/espify()
 	desc = "The product of irresponsible chemistry. She's acutely aware of your presence."
 	icon_state = "original"
 	icon_living = "original"
 	icon_dead = "original_dead"
+
+//Subtypes
+//RUNTIME IS ALIVE! SQUEEEEEEEE~
+/mob/living/simple_animal/cat/Runtime
+	name = "Runtime"
+	desc = "GCAT"
+	icon_state = "cat"
+	icon_living = "cat"
+	icon_dead = "cat_dead"
+	gender = FEMALE
+	is_pet = TRUE
+	mood_weights = list(
+		CAT_MOOD_YEARNING = 4,
+		CAT_MOOD_STRAYING = 12,
+		CAT_MOOD_PLAYFUL = 0,
+		CAT_MOOD_FELL = 0,
+		CAT_MOOD_SLEEPY = 12,
+		CAT_MOOD_COZY = 12)
+	valid_stray_zones = list(/area/medical/medbay,/area/medical/medbay2,/area/medical/break_room,/area/medical/patient_room1,/area/medical/patient_room2,
+/area/medical/chemistry,/area/medical/cryo,/area/medical/storage,/area/medical/genetics,/area/medical/sleeper,/area/medical/paramedics)
+
+/mob/living/simple_animal/cat/Runtime/on_reagent_change()
+	if(src.icon_living != "original")
+		var/m_amount = reagents.get_reagent_amount(METHYLIN)
+		if(m_amount >= 4) /* We want 5 units, but we're accounting for metabolism ticks here. */
+			reagents.remove_reagent_by_type(METHYLIN, m_amount)
+			playsound(src, 'sound/effects/bubbles.ogg', 80, 1)
+			for(var/mob/M in view())
+				to_chat(M, "<span class='notice'>\The [src]'s fur vibrates and shimmers as a mind-enhancing solution flows through \his... and \she transforms!</span>") /* BYOND doesn't have an equivalent macro for "her"... */
+			espify()
+
+/mob/living/simple_animal/cat/Proc
+	name = "Proc"
+
+/mob/living/simple_animal/cat/salem
+	name = "Salem"
+	desc = "Meow."
+	icon_state = "salem"
+	icon_living= "salem"
+	icon_dead= "salem_dead"
+	gender = FEMALE
+	holder_type = /obj/item/weapon/holder/animal/salem
+	//Salem always more likely to return home and be cozy
+	mood_weights = list(
+		CAT_MOOD_YEARNING = 24,
+		CAT_MOOD_STRAYING = 12,
+		CAT_MOOD_PLAYFUL = 12,
+		CAT_MOOD_FELL = 12,
+		CAT_MOOD_SLEEPY = 12,
+		CAT_MOOD_COZY = 36)
+
+/mob/living/simple_animal/cat/kitten
+	name = "kitten"
+	desc = "D'aaawwww!"
+	icon_state = "kitten"
+	icon_living = "kitten"
+	icon_dead = "kitten_dead"
+	gender = NEUTER
+	size = SIZE_TINY
+
+
+/*********************
+*    Snakes			 *
+* Should not be cats *
+*********************/
 
 /mob/living/simple_animal/cat/snek/react_to_touch(mob/M)
 	return 0 // SNAKES DO NOT MEOW. WHY ARE THEY A CAT SUBTYPE?
@@ -166,6 +424,7 @@
 	emote_sound = list() // stops snakes purring
 	kill_verbs = list("strikes at", "splats", "bites", "lunges at")
 	growl_verbs = list("hisses")
+	pass_flags = 0
 
 	species_type = /mob/living/simple_animal/cat/snek
 	butchering_drops = null

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -188,6 +188,10 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 			set_glide_size(DELAY2GLIDESIZE(0.5 SECONDS))
 		Move(dest)
 
+// Cancels wander if false
+/mob/living/simple_animal/proc/prewander(destination)
+	return TRUE
+
 /mob/living/simple_animal/proc/check_environment_susceptibility()
 	return TRUE
 
@@ -268,9 +272,10 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 					while(must_wander && destination == loc && attempts > 0)
 						destination = get_step(src, pick_n_take(our_options))
 						attempts--
-					wander_move(destination)
-					turns_since_move = 0
-					INVOKE_EVENT(src, /event/after_move)
+					if(prewander(destination))
+						wander_move(destination)
+						turns_since_move = 0
+						INVOKE_EVENT(src, /event/after_move)
 
 	handle_automated_speech()
 

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -89,6 +89,9 @@
 	papers -= Obj
 	..()
 
+/obj/item/weapon/paper_bin/cat_comfy()
+	return TRUE
+
 /obj/item/weapon/paper_bin/MouseDropFrom(atom/over_object)
 	MouseDropPickUp(over_object)
 	return ..()


### PR DESCRIPTION
This technically counts as a librarian PR

How it started
* Cats can leap up onto tables with a little animation
* Cats can stand on computers and other machines rendering them unusable

How it's going
* Cats have six moods with logic governing which to pick
  * Different cats have different base weights to moods
* While yearning, a cat will try to return to its home (area it started the shift in) and meow repeatedly if blocked
* While straying, a cat will try to go to a random area from a list, most of which are public but includes some lobbies and break rooms
  * Runtime will only stray to medbay zones
* While in a playful mood, the cat will idle move more often and sometimes zoom around
* While in a fell mood, the cat will bat around items (glass can be destroyed) or shaking down bookcases.
* While in a sleepy mood, the cat will sleep.
* While in a cozy mood, the cat will seek out a comfy spot (such as a computer keyboard, paper bin, or cushion) and then play its resting animation.

Only thing left is pathfinding for yearn/stray and then testing

Things I cut because this is already too bloated but might be cool if someone wants to code them
* Cats follow MULE laser
* Do something with ball of yarn (knitting needles)
* Cat toys
* Catnip
* Cats use sit animation before pouncing on mice
* Playful mood cats try to get humans to pet them
* Fell mood cats can NPC tamper computers (no library or medbay computer has any NPC tampers yet)

🆑 
* rscadd: Cats can now leap onto tables, block your use of machines, and have a whole list of attitudes.