### PR TITLE
Fixes metal bucket being renamed paint buckets after adding any liquid in them

### DIFF
--- a/code/modules/painting/paint_bucket.dm
+++ b/code/modules/painting/paint_bucket.dm
@@ -26,7 +26,7 @@ var/global/list/paint_types = subtypesof(/datum/reagent/paint)
 
 	var/icon/spots
 	var/last_pigments = ""
-	var/name_base = "paint bucket"
+	var/name_base = "metal bucket"
 	var/icon_lid = "paint_cover"
 //-------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #35746

:cl:
* bugfix: Fixed metal bucket being renamed paint buckets after adding any liquid in them