### PR TITLE
Fixes jamming people into cyborg rechargers

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -472,10 +472,6 @@
 	if(L.stat == DEAD)
 		to_chat(user, "<span class='warning'>[O] is already dead!</span>")
 		return
-	user.visible_message("[user] starts stuffing \the [L] into \the [src].", "You start stuffing \the [L] into \the [src].")
-	var/locMob = L.loc
-	if(!do_after(user, src, 20))
-		return
-	if(locMob != L.loc)
-		return
-	mob_enter(O)
+	user.visible_message("[user] starts stuffing \the [O] into \the [src].", "You start stuffing \the [O] into \the [src].")
+	if(do_after_many(user,list(O,src), 20))
+		mob_enter(O)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -472,5 +472,10 @@
 	if(L.stat == DEAD)
 		to_chat(user, "<span class='warning'>[O] is already dead!</span>")
 		return
-	if(do_after(user, src, 20))
-		mob_enter(O)
+	user.visible_message("[user] starts stuffing \the [L] into \the [src].", "You start stuffing \the [L] into \the [src].")
+	var/locMob = L.loc
+	if(!do_after(user, src, 20))
+		return
+	if(locMob != L.loc)
+		return
+	mob_enter(O)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Bugfix to ensure someone can run away while being dragged into a cyborg recharger (and its autoborger variant).

## Why it's good
<!-- Explain why you think these changes are good. -->
Closes #35778.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: You will no longer be autoborged if you run away before being stuffed into the recharging station.
