### PR TITLE
Fixes the wrapping machine again

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -829,9 +829,10 @@
 			continue
 
 		A.forceMove(get_turf(src))
-		process_affecting(A)
-
-		items_moved++
+		if(process_affecting(A))
+			items_moved++
+			return
+		A.forceMove(out_T)
 
 /obj/machinery/autoprocessor/proc/process_affecting(var/atom/movable/target)
 	return
@@ -902,57 +903,60 @@
 
 /obj/machinery/autoprocessor/wrapping/process_affecting(var/atom/movable/target)
 	if(is_type_in_list(target, cannot_wrap))
-		return
+		return 0
 	if(istype(target, /obj/item) && smallpath)
 		if (packagewrap >= 1)
 			var/obj/item/I = target
-			var/obj/item/P = new smallpath(get_turf(src.loc),target,round(I.w_class))
+			var/obj/item/P = new smallpath(get_step(src, output_dir),target,round(I.w_class))
 			target.forceMove(P)
 			packagewrap += -1
 			if(syndiewrap)
 				syndiewrap += -1
 			tag_item(P)
+			return 1
 		else
 			if(world.time > next_sound)
 				playsound(get_turf(src), 'sound/machines/buzz-sigh.ogg', 50, 1)
 				next_sound = world.time + sound_delay
 				for(var/mob/M in hearers(src))
 					M.show_message("<b>[src]</b> announces, \"Please insert additional sheets of package wrap into \the [src].\"")
-				return 0
+			return 0
 	else if(is_type_in_list(target,wrappable_big_stuff) && bigpath)
 		if(istype(target,/obj/structure/closet))
 			var/obj/structure/closet/C = target
 			if(C.opened)
-				return
+				return 0
 		if(istype(target, /mob/living/simple_animal/hostile/mimic/crate))
 			var/mob/living/simple_animal/hostile/mimic/crate/MC = target
 			if(MC.angry)
-				return
+				return 0
 		if(packagewrap >= 3)
-			var/obj/item/P = new bigpath(get_turf(src.loc),target)
+			var/obj/item/P = new bigpath(get_step(src, output_dir),target)
 			target.forceMove(P)
 			packagewrap += -3
 			if(syndiewrap)
 				syndiewrap += -3
 			tag_item(P)
+			return 1
 		else
 			if(world.time > next_sound)
 				playsound(get_turf(src), 'sound/machines/buzz-sigh.ogg', 50, 1)
 				next_sound = world.time + sound_delay
 				for(var/mob/M in hearers(src))
 					M.show_message("<b>[src]</b> announces, \"Please insert additional sheets of package wrap into \the [src].\"")
-				return 0
+			return 0
 	else if(istype(target,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = target
 		if(syndiewrap >= 2)
 			syndiewrap += -2
 			packagewrap += -2
-			var/obj/present = new /obj/item/delivery/large(get_turf(src),H)
+			var/obj/present = new /obj/item/delivery/large(get_step(src, output_dir),H)
 			if (H.client)
 				H.client.perspective = EYE_PERSPECTIVE
 				H.client.eye = present
 			H.visible_message("<span class='warning'>\The [src] wraps [H]!</span>")
 			H.forceMove(present)
+			return 1
 		else
 			if(world.time > next_sound)
 				playsound(get_turf(src), 'sound/machines/buzz-sigh.ogg', 50, 1)
@@ -964,6 +968,7 @@
 		if(world.time > next_sound)
 			playsound(get_turf(src), 'sound/machines/buzz-sigh.ogg', 50, 1)
 			next_sound = world.time + sound_delay
+		return 0
 
 /obj/machinery/autoprocessor/wrapping/proc/tag_item(var/atom/movable/target)
 	if(istype(target,/obj/item/delivery))


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Spits out packages on the output direction's tile rather than dropping them on the tile the machine is located at.

## Why it's good
<!-- Explain why you think these changes are good. -->
This behavior is more in line with how other machines like the Autolathe behave when the output is changed. Closes #35760.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Wrapping machine now will output packages onto the output direction tile.
