### PR TITLE
Small soap/brick sock fix

### DIFF
--- a/code/modules/projectiles/guns/projectile/constructable/sockweapons.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/sockweapons.dm
@@ -29,12 +29,14 @@
 
 /obj/item/weapon/soap_sock/attack_self(mob/user)
 	to_chat(user, "<span class='notice'>You remove the soap from \the [src].</span>")
+	user.drop_item(src, force_drop = 1)
 	user.put_in_hands(src.base_sock)
 	user.put_in_hands(src.base_soap)
 	qdel(src)
 
 /obj/item/weapon/brick_sock/attack_self(mob/user)
 	to_chat(user, "<span class='notice'>You remove the brick from \the [src].</span>")
+	user.drop_item(src, force_drop = 1)
 	user.put_in_hands(new /obj/item/stack/sheet/mineral/brick(user))
 	user.put_in_hands(src.base_sock)
 	qdel(src)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Deconstructing the soap or brick socks now places both input items into your hands rather than dropping one on the ground.

## Why it's good
<!-- Explain why you think these changes are good. -->
Consistency

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Soap/brick-sock weapons no longer drop an item on the ground when you deconstruct them.