### PR TITLE
Library QoL

### DIFF
--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -808,6 +808,7 @@
 	title = "A Crash Course in Virology"
 	book_width = 819
 	book_height = 516
+	id = 25
 	dat = {"<html>
 				<head>
 				<style>

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -27,10 +27,15 @@
 								/obj/item/weapon/tome, \
 								/obj/item/weapon/tome_legacy, \
 								/obj/item/weapon/spellbook, \
-								/obj/item/weapon/storage/bible)
+								/obj/item/weapon/storage/bible, \
+								/obj/item/dictionary)
 
 /obj/structure/bookcase/cultify()
 	return
+
+/obj/structure/bookcase/examine(mob/user)
+	..()
+	to_chat(user, "<span class='info'>It contains [english_list(contents)].</span>")
 
 /obj/structure/bookcase/initialize()
 	for(var/obj/item/I in loc)

--- a/code/modules/mob/living/simple_animal/bees/bees_items.dm
+++ b/code/modules/mob/living/simple_animal/bees/bees_items.dm
@@ -280,6 +280,7 @@
 	item_state ="bookHydroponicsBees"
 	author = "Beekeeper Dave"
 	title = "The Ins and Outs of Apiculture - A Precise Art"
+	id = 33
 	dat = {"<html>
 				<head>
 				<style>

--- a/code/modules/research/xenoarchaeology/manuals.dm
+++ b/code/modules/research/xenoarchaeology/manuals.dm
@@ -4,7 +4,8 @@
 	icon_state = "excavation"
 	item_state = "excavation"
 	author = "Professor Patrick Mason, Curator of the Antiquities Museum on Ichar VII"
-	title = "Out on the dig"
+	title = "Out on the dig, 2nd Edition"
+	id = 26
 	dat = {"<html>
 				<head>
 				<style>
@@ -100,7 +101,8 @@
 	icon_state = "excavation_old"
 	item_state = "book6"
 	author = "Professor Patrick Mason, Curator of the Antiquities Museum on Ichar VII"
-	title = "Out on the dig"
+	title = "Out on the dig, 1st Edition"
+	id = 27
 	dat = {"<html>
 				<head>
 				<style>
@@ -214,6 +216,7 @@
 	item_state = "book6"
 	author = "Winton Rice, Chief Mass Spectrometry Technician at the Institute of Applied Sciences on Arcadia"
 	title = "High powered mass spectrometry, a comprehensive guide"
+	id = 28
 	dat = {"<html>
 				<head>
 				<style>
@@ -285,6 +288,7 @@
 	item_state = "book6"
 	author = "Doctor Martin Boyle, Director Research at the Lower Hydrolian Sector Listening Array"
 	title = "Spectroscopy: Analysing the anomalies of the cosmos"
+	id = 29
 	dat = {"<html>
 				<head>
 				<style>
@@ -309,6 +313,7 @@
 	item_state = "book6"
 	author = "Jasper Pascal, Senior Lecturer in Materials Analysis at the University of Jol'Nar"
 	title = "Materials analysis and the chemical implications"
+	id = 30
 	dat = {"<html>
 				<head>
 				<style>
@@ -336,6 +341,7 @@
 	item_state = "book6"
 	author = "Norman York, formerly of the Tyrolion Institute on Titan"
 	title = "Anomalous materials and energies"
+	id = 31
 	dat = {"<html>
 				<head>
 				<style>
@@ -414,6 +420,7 @@
 	item_state = "book6"
 	author = "Elvin Schmidt"
 	title = "Cellular suspension, the new Cryogenics?"
+	id = 32
 	dat = {"<html>
 				<head>
 				<style>


### PR DESCRIPTION
I think the fact that these haven't been getting noticed is possibly telling

🆑 
* bugfix: Fixed nine manuals that couldn't print from the library computer. The two editions of Out on the Dig are no longer identically named.
* rscadd: You can now examine a bookcase to read the titles in it. You can also store nanodictionaries in a bookcase. 