### PR TITLE
Blueprint Rack

### DIFF
--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -400,3 +400,26 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 			continue
 		to_archive[T.id] = T.level
 	write_file(to_archive)
+
+/datum/persistence_task/saveblueprints/on_shutdown()
+	var/list/to_save = list()
+	var/saveable = 1
+	for(var/obj/structure/blueprintrack/BPR in blueprint_racks)
+		if(saveable >= 16)
+			break
+		for(var/obj/item/research_blueprint/BP in BPR)
+			to_save[saveable] = BP.build_type
+		saveable++
+	write_file(to_save)
+
+/datum/persistence_task/saveblueprints/on_init()
+	var/list/designs = read_file()
+	for(var/obj/structure/blueprintrack/BPR in blueprint_racks)
+		for(var/element in designs) //Counts 1 to 16
+			//1 = buildtype
+			if(!ispath(designs[element]))
+				continue
+			var/datum/design/D = FindTypeDesign(designs[element])
+			new /obj/item/research_blueprint(BPR, D) //creates a standard paper blueprint w/ design and inserts
+		BPR.update_icon()
+		break //only do this in one blueprint rack

--- a/code/modules/library/blueprintrack.dm
+++ b/code/modules/library/blueprintrack.dm
@@ -1,0 +1,78 @@
+var/list/blueprint_racks = list()
+
+/obj/structure/blueprintrack
+	name = "blueprint rack"
+	icon = 'icons/obj/library.dmi'
+	icon_state = "blueprintrack0"
+	anchored = TRUE
+	density = TRUE
+	opacity = FALSE
+	req_access = list(access_library, access_mechanic)
+	var/locked = TRUE
+	var/emagged = FALSE
+
+/obj/structure/blueprintrack/New()
+	..()
+	update_icon()
+	blueprint_racks += src
+
+/obj/structure/blueprintrack/Destroy()
+	blueprint_racks -= src
+	..()
+
+/obj/structure/blueprintrack/update_icon()
+	icon_state = "blueprintrack[contents.len]"
+	if(locked)
+		var/image/seal = image(icon, src, "rack_seal", ABOVE_OBJ_LAYER)
+		seal.plane = relative_plane(OBJ_PLANE)
+		overlays += seal
+
+/obj/structure/blueprintrack/attackby(obj/item/W, mob/user)
+	if(emagged && issolder(W))
+		var/obj/item/tool/solder/S = W
+		if(!S.remove_fuel(4,user))
+			return
+		S.playtoolsound(loc, 100)
+		if(do_after(user, src,4 SECONDS * S.work_speed))
+			S.playtoolsound(loc, 100)
+			emagged = FALSE
+			to_chat(user, "<span class='notice'>You repair the electronics inside the locking mechanism!</span>")
+		return
+
+	if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
+		if(emagged)
+			to_chat(user, "<span class='notice'>The lock seems broken.</span>")
+		else
+			if(src.allowed(user))
+				locked = !locked
+				to_chat(user, "<span class='notice'>You [ locked ? "lock" : "unlock"] \the [src].</span>")
+				update_icon()
+			else
+				to_chat(user, "<span class='warning'>Access denied.</span>")
+		return
+
+	if(isEmag(W) && !emagged)
+		emagged = TRUE
+		locked = FALSE
+		visible_message("<span class='danger'>The rack seal clunks loudly as it drops freely.</span>")
+		return
+
+	if(istype(W,/obj/item/research_blueprint))
+		if(contents.len >= 16)
+			to_chat(user, "<span class='warning'>\The [src] is full.</span>")
+			return
+		else
+			user.drop_item(W, src)
+			update_icon()
+
+	..()
+
+/obj/structure/blueprintrack/attack_hand(var/mob/user as mob)
+	if(!contents.len)
+		return
+	var/obj/item/choice = input("Retrieve which blueprint?") as null|obj in contents
+	if(choice)
+		if(user.incapacitated() || user.lying || !Adjacent(user))
+			return
+		user.put_in_hands(choice)
+		update_icon()

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1728,6 +1728,7 @@
 #include "code\modules\hydroponics\spreading\spreading.dm"
 #include "code\modules\hydroponics\spreading\spreading_growth.dm"
 #include "code\modules\hydroponics\spreading\spreading_response.dm"
+#include "code\modules\library\blueprintrack.dm"
 #include "code\modules\library\lib_items.dm"
 #include "code\modules\library\lib_machines.dm"
 #include "code\modules\library\lib_readme.dm"


### PR DESCRIPTION
Can be unlocked with librarian or mechanic access.
Up to 16 blueprints may persist between rounds if stored here. What will the mechanics of the past send you? A chem dispenser perhaps? A hand tele?

IAA inspection of blueprint rack may need to be a new job duty. Or I can just prevent illegal blueprints from persisting if that's better.

Needs to be mapped. (I am crying)

Limitations:
* No illegal scans (NT burns these)
* It ONLY saves the type, not the full design. This means you can't persist a machine with tier 4 parts.
* It ONLY saves what's in the machine at the end of shift. Took out a blueprint without returning it? It's gone. Someone logged on next shift and confiscated it? It's gone.
* You have to actually build the thing! Sure you have a hand tele blueprint but do you have the 50 phazon to make it?

🆑 
* rscadd: There is a new library blueprint rack that stores up to 16 blueprints between rounds for mechanics.