### PR TITLE
Fire tweaks

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -434,6 +434,12 @@ var/global/objects_thrown_when_explode = FALSE
 	//transfers diseases between the mob and the item
 	disease_contact(user)
 
+	if(src.on_fire)
+		var/mob/living/L = user
+		L.visible_message("<span class='warning'>\The [src] burns [L]'s hands!</span>", "<span class='warning'>Your hands are burned by \the [src]!</span>")
+		L.drop_item(src, force_drop = 1)
+		L.apply_damage(10,BURN,L.get_active_hand_organ())
+
 /obj/item/requires_dexterity(mob/user)
 	return TRUE
 
@@ -1770,3 +1776,9 @@ var/global/list/image/blood_overlays = list()
 	. = heat_conductivity
 	if (is_open_container())
 		. = max(. , 0.5) //Even if it's perfectly insulating, if it's open then some heat can be exchanged.
+
+/obj/item/MiddleAltClick(var/mob/living/user)
+	if(src.on_fire)
+		extinguish()
+		user.visible_message("[user] snuffs out the burning [src].","You snuff out the burning [src], burning your hand in the process.")
+		user.apply_damage(10,BURN,(pick(LIMB_LEFT_HAND, LIMB_RIGHT_HAND)))

--- a/code/modules/food/customizables.dm
+++ b/code/modules/food/customizables.dm
@@ -69,6 +69,7 @@
 	var/list/plates = list() // If the plates are stacked, they come here
 	var/new_stack = 0 // allows mappers to create plate stacks
 	var/trash_color = null
+	autoignition_temperature = null
 
 /obj/item/trash/plate/clean
 	icon_state = "cleanplate"

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -14,6 +14,7 @@ var/list/special_fruits = list()
 	var/hydroflags = 0
 	var/datum/seed/seed
 	var/fragrance
+	autoignition_temperature = AUTOIGNITION_FABRIC
 
 	icon = 'icons/obj/hydroponics/apple.dmi'
 	icon_state = "produce"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
- You can now alt-middle-click any burning object to snuff the fire out in exchange for your hands being burned (closes #35616).
- Attempting to pick up a burning item will cause you to immediately drop the item while burning your hand.
- Plates are no longer flammable (closes #35490).
- Harvested crops will now burn (closes #35520).

## Why it's good
<!-- Explain why you think these changes are good. -->
Provides crewmembers with a quick way to prevent a small fire from snowballing into a conflagration at the cost of some burn damage.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Plates are no longer flammable.
 * bugfix: Harvested crops will now burn.
 * rscadd: You can now alt-middle-click any burning object to snuff the fire out in exchange for your hands being burned.
 * rscadd: Attempting to pick up a burning item will cause you to immediately drop the item while burning your hand.
