### PR TITLE
Fixes General Fab Producing Chems

### DIFF
--- a/code/modules/research/fabricators.dm
+++ b/code/modules/research/fabricators.dm
@@ -352,6 +352,7 @@
 			L.name += " ([being_built.name])"
 			being_built = L //Building the lockbox now, with the thing in it
 		part.after_craft(being_built,src)
+		after_craft(part)
 		var/turf/output = get_output()
 		being_built.forceMove(get_turf(output))
 		being_built.anchored = 0
@@ -372,6 +373,10 @@
 /obj/machinery/r_n_d/fabricator/arcane_act(mob/user)
 	..()
 	return "B'NUS D'CKS!"
+
+//The newly created object is still held as being_built
+/obj/machinery/r_n_d/fabricator/proc/after_craft(datum/design/part)
+	return
 
 //max_length is, from the top of the list, the parts you want to queue down to
 /obj/machinery/r_n_d/fabricator/proc/add_part_set_to_queue(set_name, max_length)

--- a/code/modules/research/mechanic/mechanic_fabs.dm
+++ b/code/modules/research/mechanic/mechanic_fabs.dm
@@ -183,3 +183,10 @@
 		else
 			return 0
 	return 0
+
+/obj/machinery/r_n_d/fabricator/mechanic_fab/after_craft(datum/design/part)
+	if(!being_built || !being_built.reagents)
+		return
+	being_built.reagents?.clear_reagents()
+	for(var/obj/O in being_built.contents)
+		O.reagents?.clear_reagents()


### PR DESCRIPTION
I've been meaning to get around to this one for ages. There are so many problems where a coder or mapper wants to give players one beaker or glass bottle of something, and then whoops mechanics make it with plastic. Instead of going to chemistry and engaging with chemistry to make bleach, they clone bleach bottles with plastic. Instead of doing color mixing to make acrylics they like, they just clone the random paint can over and over. Instead of interacting with the other engineers and getting sulfuric acid from engineering (or a visit to chemistry), they clone a glass bottle of sulfuric acid. This definitely doesn't fix every general fab oversight, but it definitely fixes a lot of them.

The worst part about this oversight is that a normal glass bottle is exactly the same cost as a bottle containing anything - even rezadone for example. The cost of a toolbox full of paints is the same as an empty gray toolbox.

This is better than adding mech scan fail to everything ever because:
* It's more maintainable. You don't have to teach every coder ever that their new bottle needs to have mech scan fail or include snowflaked inflated costs somehow.
* More immersive. You can still scan a bleach bottle and make a new bleach bottle, but if you want bleach you need to dispense it from the chem dispenser.

:cl:
* bugfix: The general fab no longer duplicates chems.