### PR TITLE
Reduces smoke chance by 20%

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -52,7 +52,7 @@ Attach to transfer valve and open. BOOM.
 	var/turf/T = get_turf(loc)
 	if(T)
 		T.hotspot_expose(autoignition_temperature, CELL_VOLUME, surfaces=1)
-	if(prob(5)) //5% chance of smoke creation per tick
+	if(prob(8)) //8% chance of smoke creation per tick
 		var/datum/effect/system/smoke_spread/fire/smoke = new /datum/effect/system/smoke_spread()
 		smoke.set_up(4,0,T)
 		smoke.time_to_live = 60 SECONDS

--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -52,7 +52,7 @@ Attach to transfer valve and open. BOOM.
 	var/turf/T = get_turf(loc)
 	if(T)
 		T.hotspot_expose(autoignition_temperature, CELL_VOLUME, surfaces=1)
-	if(prob(10)) //10% chance of smoke creation per tick
+	if(prob(5)) //5% chance of smoke creation per tick
 		var/datum/effect/system/smoke_spread/fire/smoke = new /datum/effect/system/smoke_spread()
 		smoke.set_up(4,0,T)
 		smoke.time_to_live = 60 SECONDS


### PR DESCRIPTION
## What this does
Halves the chance for smoke to appear during fires.
Since fires are big and not contained to single tiles, there should still be a decent amount of smoke, but not as much as before (about 80% as much).
## Why it's good
You can now see the pretty neon bluewhite glow of a fire without being overwhelmed by extreme amounts of smoke.. 
This is the most amount of smoke after a bar fire before the change:
![Top Secret Capitalist Object 7 2024-01-20 113437](https://github.com/vgstation-coders/vgstation13/assets/67024428/75e6b396-c8a1-4ec8-a481-3fd3c5b5686a)
This is the most amount after the change:
![image](https://github.com/vgstation-coders/vgstation13/assets/67024428/623ccbb2-56fe-4bcd-8166-190c76e32a39)
## Changelog
:cl:
 * tweak: Reduces the chance for a fire to produce smoke by 20%.