### PR TITLE
Fire snuffing checks for heat resistant gloves

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1780,5 +1780,19 @@ var/global/list/image/blood_overlays = list()
 /obj/item/MiddleAltClick(var/mob/living/user)
 	if(src.on_fire)
 		extinguish()
-		user.visible_message("[user] snuffs out the burning [src].","You snuff out the burning [src], burning your hand in the process.")
+		var/prot = 0
+
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			if(H.gloves)
+				var/obj/item/clothing/gloves/G = H.gloves
+				if(G.max_heat_protection_temperature)
+					prot = (G.max_heat_protection_temperature > 360)
+		else
+			prot = 1
+
+		if(prot > 0 || (M_RESIST_HEAT in user.mutations) || (user.get_active_hand_organ()).is_robotic())
+			user.visible_message("[user] snuffs out the burning [src].","You snuff out the burning [src].")
+			return
 		user.apply_damage(10,BURN,(pick(LIMB_LEFT_HAND, LIMB_RIGHT_HAND)))
+		user.visible_message("[user] snuffs out the burning [src].","You snuff out the burning [src], burning your hand in the process.")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1777,7 +1777,9 @@ var/global/list/image/blood_overlays = list()
 	if (is_open_container())
 		. = max(. , 0.5) //Even if it's perfectly insulating, if it's open then some heat can be exchanged.
 
-/obj/item/MiddleAltClick(var/mob/living/user)
+/obj/item/MiddleAltClick(var/mob/user)
+	if(!isliving(user))
+		return
 	if(src.on_fire)
 		extinguish()
 		var/prot = 0
@@ -1790,9 +1792,9 @@ var/global/list/image/blood_overlays = list()
 					prot = (G.max_heat_protection_temperature > 360)
 		else
 			prot = 1
-
 		if(prot > 0 || (M_RESIST_HEAT in user.mutations) || (user.get_active_hand_organ()).is_robotic())
 			user.visible_message("[user] snuffs out the burning [src].","You snuff out the burning [src].")
 			return
-		user.apply_damage(10,BURN,(pick(LIMB_LEFT_HAND, LIMB_RIGHT_HAND)))
-		user.visible_message("[user] snuffs out the burning [src].","You snuff out the burning [src], burning your hand in the process.")
+		var/mob/living/L = user
+		L.apply_damage(10,BURN,(pick(LIMB_LEFT_HAND, LIMB_RIGHT_HAND)))
+		L.visible_message("[user] snuffs out the burning [src].","You snuff out the burning [src], burning your hand in the process.")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1792,7 +1792,8 @@ var/global/list/image/blood_overlays = list()
 					prot = (G.max_heat_protection_temperature > 360)
 		else
 			prot = 1
-		if(prot > 0 || (M_RESIST_HEAT in user.mutations) || (user.get_active_hand_organ()).is_robotic())
+		var/datum/organ/external/active_hand_organ = user.get_active_hand_organ()
+		if(prot > 0 || (M_RESIST_HEAT in user.mutations) || active_hand_organ?.is_robotic())
 			user.visible_message("[user] snuffs out the burning [src].","You snuff out the burning [src].")
 			return
 		var/mob/living/L = user


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Meant to include this in #35792 but was caught up in other work. Snuffing out burning items will no longer damage you if you are wearing heat resistant gloves (black, insulated, captain's, and Nanotrasen gloves), have the heat-resistance gene, or are using a robotic limb.

## Why it's good
<!-- Explain why you think these changes are good. -->
You probably wouldn't be too hurt if you snuffed something out while wearing heat resistantgloves. This gives additional functionality to heat resistant gloves.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Heat resistant gloves, the heat resistance gene, and robotic limbs prevent getting burned while snuffing out fires.