### PR TITLE
Fire smoke transparency

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -465,6 +465,7 @@ steam.start() -- spawns the effect
 
 /datum/effect/system/smoke_spread/fire/start()
 	transparency_rate = 25 // 25% chance that a smoke stack will be transparent
+	..()
 
 /datum/effect/system/smoke_spread/bad
 	smoke_type = /obj/effect/smoke/bad

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -424,6 +424,10 @@ steam.start() -- spawns the effect
 	var/time_to_live = 10 SECONDS
 	var/transparency_rate = 0 // Percent of smoke stacks spawned which will be transparent
 
+
+/datum/effect/system/smoke_spread/fire
+	transparency_rate = 25 // 25% chance that a smoke stack will be transparent
+
 /datum/effect/system/smoke_spread/set_up(n = 5, c = 0, loca, direct)
 	if(n > 10)
 		n = 10
@@ -462,10 +466,6 @@ steam.start() -- spawns the effect
 				if (smoke)
 					qdel(smoke)
 				src.total_smoke--
-
-/datum/effect/system/smoke_spread/fire/start()
-	transparency_rate = 25 // 25% chance that a smoke stack will be transparent
-	..()
 
 /datum/effect/system/smoke_spread/bad
 	smoke_type = /obj/effect/smoke/bad

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -422,6 +422,7 @@ steam.start() -- spawns the effect
 	var/direction
 	var/smoke_type = /obj/effect/smoke
 	var/time_to_live = 10 SECONDS
+	var/transparency_rate = 0 // Percent of smoke stacks spawned which will be transparent
 
 /datum/effect/system/smoke_spread/set_up(n = 5, c = 0, loca, direct)
 	if(n > 10)
@@ -444,6 +445,8 @@ steam.start() -- spawns the effect
 			if(holder)
 				src.location = get_turf(holder)
 			var/obj/effect/smoke/smoke = new smoke_type(src.location)
+			if(prob(transparency_rate))
+				smoke.opacity = FALSE
 			smoke.time_to_live = time_to_live
 			total_smoke++
 			var/direction = src.direction
@@ -460,6 +463,8 @@ steam.start() -- spawns the effect
 					qdel(smoke)
 				src.total_smoke--
 
+/datum/effect/system/smoke_spread/fire/start()
+	transparency_rate = 25 // 25% chance that a smoke stack will be transparent
 
 /datum/effect/system/smoke_spread/bad
 	smoke_type = /obj/effect/smoke/bad


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Alternative to #35800 - rather than halving the smoke chance, fire smoke now has a 1/4th chance to be transparent. Visibility is still significantly reduced, but you can often see further than just one tile ahead of you now.

## Why it's good
<!-- Explain why you think these changes are good. -->
Slightly increased visibility in a burning room.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Smoke from fires is now transparent 25% of the time.
