### PR TITLE
Signaler verb category fix

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -222,6 +222,7 @@
 	set src in usr
 	set name = "Threaten to push the button!"
 	set desc = "BOOOOM!"
+	set category = "Object"
 
 	if(usr && !usr.incapacitated())
 		var/mob/user = usr


### PR DESCRIPTION
## What this does
A signaler's verb for threatening to push a button no longer creates a new tab.

## Why it's good
Consistency.

## Changelog
:cl:
 * tweak: Signalers now have their verb appear in an "Object" tab.
