### PR TITLE
Whitelists conveyors on the cargo shuttle.

### DIFF
--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -312,7 +312,7 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 			continue
 		var/contcount
 		for(var/atom/A in T.contents)
-			if(islightingoverlay(A))
+			if(islightingoverlay(A) || istype(A, /obj/machinery/conveyor))
 				continue
 			contcount++
 		if(contcount)


### PR DESCRIPTION
A while ago boxer and I tried to automate the cargo shuttle by installing a conveyor on every tile. I thought it would be very cool to "automate" the shuttle a bit by placing conveyors on it, such that you could move the crates faster. It was only after I bought a bunch of stuff and called the shuttle that we saw that literally nothing spawned and I lost the money, goods and got disappointed.
## What this does
Whitelists conveyors for the cargo shuttle empty tile checks. This means that the shuttle will treat tiles with conveyors as regular "empty" tiles and will spawn crates as if the conveyors were not there. **This does not add any conveyors, just allows them to be built without issues.**
[tested] it by buying a lot of crates, they all spawned fine. Then sent some cargo requests and they worked properly, paying the respective money. Finally, got some crate forwards and they forwarded fine.
## Why it's good
Allows an enterprising QM (or hardworking cargo tech) to make their lives a little bit easier by upgrading the cargo shuttle with conveyor belts.
:cl:
 * rscadd: The cargo shuttle can now be upgraded with conveyor belts.