### PR TITLE
Box Hotfix

### DIFF
--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -24006,9 +24006,21 @@
 	pixel_y = 25
 	},
 /obj/structure/table/woodentable,
-/obj/item/weapon/dice/d20,
-/obj/item/weapon/dice,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/weapon/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/stack/package_wrap,
+/obj/item/weapon/storage/pill_bottle/dice,
+/obj/item/weapon/dice{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/weapon/dice/d20{
+	pixel_x = -5;
+	pixel_y = 1
+	},
 /turf/simulated/floor/wood,
 /area/library)
 "bte" = (
@@ -24066,13 +24078,13 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/library)
 "btr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/library)
 "bts" = (
 /obj/structure/disposalpipe/segment{
@@ -25067,7 +25079,7 @@
 /obj/structure/table/woodentable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/library)
 "byd" = (
 /obj/structure/morgue{
@@ -29556,7 +29568,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/library)
 "bRt" = (
 /obj/structure/rack{
@@ -91939,13 +91951,7 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/stack/package_wrap,
-/obj/item/weapon/storage/pill_bottle/dice,
+/obj/machinery/vending/games,
 /turf/simulated/floor/wood,
 /area/library)
 "ovZ" = (
@@ -97052,7 +97058,6 @@
 	},
 /area/tdome)
 "qmt" = (
-/obj/structure/table/woodentable,
 /obj/item/weapon/stool/cushion{
 	pixel_y = 12
 	},
@@ -100057,13 +100062,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/library)
-"rsx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/library)
 "rsA" = (
 /obj/structure/morgue,
@@ -264333,7 +264332,7 @@ ovK
 btr
 bRs
 bRs
-rsx
+bGh
 bEA
 beV
 bEA
@@ -264641,7 +264640,7 @@ scX
 oVo
 bBi
 xxd
-qmt
+qFs
 bEA
 bEO
 gYJ
@@ -264944,7 +264943,7 @@ tHo
 uAJ
 bEA
 jou
-bEA
+qmt
 xRz
 xNC
 iCk


### PR DESCRIPTION
This was caused because I was working on three copies of Box (with Snowbox and Castle) without realizing that not all of them are up to date in maintenance. So I copied over a different maint shape by accident, causing a wall double and small pipe break (it didn't cut off anywhere because of redundant pipes). The interior of the library was fine (except for a lost games vendor) because I checked it in game but I didn't catch the doubled walls outside of the library.

I have been workshopping with NW on a compromise with the art storage, this PR isn't that. This just fixes the doubled walls+pipes in maint and missing vendor, so it's not a substance change. It also moves Salem off the table at NW's insistence though.

No CL for hotfix