### PR TITLE
Plants can now reach their full 200 potency potential (instead of a measly 198).

### DIFF
--- a/code/modules/hydroponics/hydroponics_mutations.dm
+++ b/code/modules/hydroponics/hydroponics_mutations.dm
@@ -30,9 +30,9 @@
 				if(PLANT_POTENCY)
 					if(seed.potency <= 0)
 						return
-					var/hardcap = 200
-					var/max_change = 0.10 //percent
-					seed.potency += round(min(hardcap - hardcap/2*round(log(10,seed.potency/hardcap*100),0.01),max_change*hardcap),0.1)
+					var/hardcap = 200.15 //finally fixes the 198 potency thing
+					var/max_change = 0.11 //percent
+					seed.potency += round(min(hardcap - hardcap/2*log(10,seed.potency/hardcap*100),max_change*hardcap),0.1)
 					generic_mutation_message("quivers!")
 				if(PLANT_CHEMICAL)
 					var/check_success = FALSE


### PR DESCRIPTION
## What this does
Fixes the potency formula such that it now actually peaks at 200, instead of 198.
## Why it's good
The hardcap is supposed to be 200, but it never properly reached 200 because of a quirk of the formula.
[bugfix][hotfix]
This took way too long to test.
Potency properly reaches 200 with all starting potencies I tested (1, 10, 20, 57, 100, 150 and 198).
:cl:
 * bugfix: Plant potency can now reach 200 potency properly, instead of stopping at 198.