### PR TITLE
Jiggle Crate Items

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -16,12 +16,6 @@
 	var/sound_effect_open = 'sound/machines/click.ogg'
 	var/sound_effect_close = 'sound/machines/click.ogg'
 
-/obj/structure/closet/crate/open(mob/user)
-	for(var/obj/item/I in contents)
-		if(I.w_class <= W_CLASS_SMALL)
-			jiggle(I)
-	..()
-
 /obj/structure/closet/crate/proc/jiggle(var/obj/item/I)
 	var/jx = I.w_class == W_CLASS_TINY ? 7 : 3
 	var/jy = I.w_class == W_CLASS_TINY ? 3 : 1
@@ -452,6 +446,10 @@
 	if(!src.can_open())
 		return 0
 	playsound(src, sound_effect_open, 15, 1, -3)
+
+	for(var/obj/item/I in contents)
+		if(I.w_class <= W_CLASS_SMALL)
+			jiggle(I)
 
 	dump_contents()
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -16,6 +16,18 @@
 	var/sound_effect_open = 'sound/machines/click.ogg'
 	var/sound_effect_close = 'sound/machines/click.ogg'
 
+/obj/structure/closet/crate/open(mob/user)
+	for(var/obj/item/I in contents)
+		if(I.w_class <= W_CLASS_SMALL)
+			jiggle(I)
+	..()
+
+/obj/structure/closet/crate/proc/jiggle(var/obj/item/I)
+	var/jx = I.w_class == W_CLASS_TINY ? 7 : 3
+	var/jy = I.w_class == W_CLASS_TINY ? 3 : 1
+	I.pixel_x = rand(-jx,jx)
+	I.pixel_y = rand(-jy,jy)
+
 /obj/structure/closet/crate/basic
 	has_lock_type = /obj/structure/closet/crate/secure/basic
 


### PR DESCRIPTION
When you open a crate, it jiggles before opening. More if tiny, less if small, not at all if it's medium or larger. The amount is very conservative and a normal distribution will put most near 0,0 anyway. This is CRATE ONLY, not for lockers.
![image](https://github.com/vgstation-coders/vgstation13/assets/9782036/cb52c471-829f-4413-8411-1e79be04aafc)
![image](https://github.com/vgstation-coders/vgstation13/assets/9782036/daf52cca-df8c-43f4-b16c-0bb2ef164b66)
![image](https://github.com/vgstation-coders/vgstation13/assets/9782036/48282636-1920-4409-812f-d82fa9ad61b1)

Fully expecting a 1200-word post from Manopolis

> Why it's good

I was disappointed my ice chest of sodas and beers stacks all of them in a perfect file


🆑 
* rscadd: Small items now jiggle around in crates.