### PR TITLE
MULEs Work Again

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1332,7 +1332,7 @@ var/default_colour_matrix = list(1,0,0,0,\
 //	null << "[x][a]")
 #endif
 
-#define ASTAR_DEBUG 1
+#define ASTAR_DEBUG 0
 #if ASTAR_DEBUG == 1
 #warn "Astar debug is on. Don't forget to turn it off after you've done :)"
 #define astar_debug(text) to_chat(world, text)

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1332,10 +1332,10 @@ var/default_colour_matrix = list(1,0,0,0,\
 //	null << "[x][a]")
 #endif
 
-#define ASTAR_DEBUG 0
+#define ASTAR_DEBUG 1
 #if ASTAR_DEBUG == 1
 #warn "Astar debug is on. Don't forget to turn it off after you've done :)"
-#define astar_debug(text) //to_chat(world, text)
+#define astar_debug(text) to_chat(world, text)
 #define astar_debug_mulebots(text) to_chat(world, text)
 #else
 #define astar_debug(text)

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -496,6 +496,7 @@
 				target = get_turf(signal.source)
 			path = list()
 			patrol_path = list()
+			destinations_queue = list()
 			return 1
 		if ("switch_power")
 			if (on)
@@ -516,11 +517,14 @@
 /datum/bot/order/mule
 	var/atom/thing_to_load
 	var/unload_here = FALSE
+	var/unload_dir = 0
 
-/datum/bot/order/mule/New(var/turf/place_to_go, var/atom/thing, _unload_here = FALSE)
+/datum/bot/order/mule/New(var/turf/place_to_go, var/atom/thing, _unload_here = FALSE, var/unload_direction)
 	destination = place_to_go
 	thing_to_load = thing
 	unload_here = _unload_here
+	unload_dir = unload_direction
+	astar_debug_mulebots("Order up! [destination] [thing_to_load] [unload_here] [unload_dir]!")
 
 /datum/bot/order/mule/unload
 

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -12,7 +12,7 @@
 #if ASTAR_DEBUG == 1
 #define log_astar_bot(text) visible_message("[src] : [text]")
 #define log_astar_beacon(text) //to_chat(world, "[src] : [text]")
-#define log_astar_command(text) //to_chat(world, "[src] : [text]")
+#define log_astar_command(text) to_chat(world, "[src] : [text]")
 #else
 #define log_astar_bot(text)
 #define log_astar_beacon(text)
@@ -171,8 +171,8 @@
 
 /obj/machinery/bot/proc/decay_oldtargets()
 	for(var/i in old_targets)
-		log_astar_bot("[i] [old_targets[i]]")
-		if(--old_targets[i] == 0)
+		log_astar_bot("old target: [i] [old_targets[i]]")
+		if(--old_targets[i] <= 0)
 			remove_oldtarget(i)
 
 // Can we move to the next tile or not ?

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -55,7 +55,8 @@ var/global/mulebot_count = 0
 						//7 = no destination beacon found (or no route)
 
 	var/refresh = 1		// true to refresh dialogue
-	var/auto_return = 1	// true if auto return to home beacon after unload
+	var/auto_unload = 1	// true if auto return to home beacon after unload
+	var/auto_return = 1	// true if auto return to home beacon after arriving at destination
 	var/auto_pickup = 1 // true if auto-pickup at beacon
 
 	var/obj/item/weapon/cell/cell
@@ -99,6 +100,7 @@ var/global/mulebot_count = 0
 	cell = new(src)
 	cell.charge = 2000
 	cell.maxcharge = 2000
+	set_light(initial(luminosity))
 
 /obj/machinery/bot/mulebot/initialize()
 	. = ..()
@@ -257,6 +259,7 @@ var/global/mulebot_count = 0
 			dat += "<A href='byond://?src=\ref[src];op=destination'>Set Destination</A><BR>"
 			dat += "<A href='byond://?src=\ref[src];op=setid'>Set Bot ID</A><BR>"
 			dat += "<A href='byond://?src=\ref[src];op=sethome'>Set Home</A><BR>"
+			dat += "<A href='byond://?src=\ref[src];op=autounl'>Toggle Auto Unload Crate</A> ([auto_unload ? "On":"Off"])<BR>"
 			dat += "<A href='byond://?src=\ref[src];op=autoret'>Toggle Auto Return Home</A> ([auto_return ? "On":"Off"])<BR>"
 			dat += "<A href='byond://?src=\ref[src];op=autopick'>Toggle Auto Pickup Crate</A> ([auto_pickup ? "On":"Off"])<BR>"
 
@@ -299,6 +302,9 @@ var/global/mulebot_count = 0
 			return "Unable to reach destination"
 	return ..()
 
+/obj/machinery/bot/mulebot/proc/return_load()
+	return is_locking(/datum/locking_category/mulebot) && get_locked(/datum/locking_category/mulebot)[1]
+
 /obj/machinery/bot/mulebot/execute_signal_command(var/datum/signal/signal, var/command)
 	if (..())
 		return
@@ -332,6 +338,7 @@ var/global/mulebot_count = 0
 			if("power")
 				if (src.on)
 					turn_off()
+					icon_state = "[icon_initial]0"
 				else if (cell && !open)
 					if (!turn_on())
 						to_chat(usr, "<span class='warning'>You can't switch on [src].</span>")
@@ -379,7 +386,13 @@ var/global/mulebot_count = 0
 
 			if("destination")
 				refresh=0
-				var/new_dest = copytext(sanitize(input("Enter new destination tag", "Mulebot [suffix ? "([suffix])" : ""]", destination) as text|null),1,MAX_NAME_LEN)
+				var/list/foundbeacons = list()
+				for (var/obj/machinery/navbeacon/found in navbeacons)
+					if(!found.location || !isturf(found.loc))
+						continue
+					if(found.freq == 1400)
+						foundbeacons.Add(found.location)
+				var/new_dest = input(usr, "Set the new destination", "New mulebot destination") as null|anything in foundbeacons
 				refresh=1
 				if(new_dest && Adjacent(usr) && !usr.stat)
 					set_destination(new_dest)
@@ -395,7 +408,13 @@ var/global/mulebot_count = 0
 
 			if("sethome")
 				refresh=0
-				var/new_home = copytext(sanitize(input("Enter new home tag", "Mulebot [suffix ? "([suffix])" : ""]", home_destination) as text|null),1,MAX_MESSAGE_LEN)
+				var/list/foundbeacons = list()
+				for (var/obj/machinery/navbeacon/found in navbeacons)
+					if(!found.location || !isturf(found.loc))
+						continue
+					if(found.freq == 1400)
+						foundbeacons.Add(found.location)
+				var/new_home = input(usr, "Set the new destination", "New mulebot destination") as null|anything in foundbeacons
 				refresh=1
 				if(new_home && Adjacent(usr) && !usr.stat)
 					home_destination = new_home
@@ -408,6 +427,9 @@ var/global/mulebot_count = 0
 						unload(dir)
 					else
 						unload(0)
+
+			if("autounl")
+				auto_unload = !auto_unload
 
 			if("autoret")
 				auto_return = !auto_return
@@ -431,6 +453,26 @@ var/global/mulebot_count = 0
 // returns true if the bot has power
 /obj/machinery/bot/mulebot/proc/has_power()
 	return !open && cell && cell.charge > 0 && wires.HasPower()
+
+/obj/machinery/bot/mulebot/turn_on()
+	if(!cell)
+		return
+	if(cell.charge <= 0)
+		return
+	..()
+
+/obj/machinery/bot/mulebot/turn_off()
+	..()
+	icon_state = "[icon_initial]0"
+	summoned = FALSE
+	target = null
+	destination = ""
+	new_destination = ""
+	current_order = null
+	destinations_queue = list()
+	mode = MODE_IDLE
+	path = list()
+	frustration = 0 //how it feels to be free of this code
 
 /obj/machinery/bot/mulebot/proc/toggle_lock(mob/user, ignore_access = FALSE)
 	if(allowed(user) || ignore_access)
@@ -519,6 +561,8 @@ var/global/mulebot_count = 0
 
 	lock_atom(C, /datum/locking_category/mulebot)
 
+	mode = MODE_IDLE
+
 /obj/machinery/bot/mulebot/proc/can_load(var/atom/movable/C)
 	if (C.anchored)
 		return FALSE
@@ -540,27 +584,25 @@ var/global/mulebot_count = 0
 
 	var/atom/movable/load = get_locked(/datum/locking_category/mulebot)[1]
 
-	if(current_order?.unload_here)
-		unlock_atom(load)
-		load.forceMove(current_order.destination)
-		if(istype(current_order.thing_to_load, /obj/machinery/cart/cargo))
-			var/obj/machinery/cart/cargo/cart = current_order.thing_to_load
-			cart.load(load)
-		return
-
 	mode = MODE_LOADING
 	overlays.len = 0
 	if(integratedpai)
 		overlays += image('icons/obj/aibots.dmi', "mulebot1_pai")
-	unlock_atom(load)
 
-	if(dirn)
+	if(current_order?.unload_here)
+		unlock_atom(load)
 		var/turf/T = src.loc
-		T = get_step(T,dirn)
-		if(Cross(load,T))//Can't get off onto anything that wouldn't let you pass normally
-			step(load, dirn)
-		else
-			load.forceMove(src.loc)//Drops you right there, so you shouldn't be able to get yourself stuck
+		load.forceMove(src.loc) //Drops you right there, so you shouldn't be able to get yourself stuck
+		if(dirn)
+			dirn = text2num(dirn)
+			astar_debug_mulebots("attempting unload in [dirn] from [T]!")
+			T = get_step(T,dirn)
+			if(T.Cross())//Can't get off onto anything that wouldn't let you pass normally
+				astar_debug_mulebots("correctly unloaded in a direction. [T]!")
+				load.forceMove(T)
+		if(istype(current_order.thing_to_load, /obj/machinery/cart/cargo))
+			var/obj/machinery/cart/cargo/cart = current_order.thing_to_load
+			cart.load(load)
 
 	// in case non-load items end up in contents, dump every else too
 	// this seems to happen sometimes due to race conditions //There are no race conditions in BYOND. It's single-threaded.
@@ -617,26 +659,44 @@ var/global/mulebot_count = 0
 	signal.transmission_method = 1
 	var/list/keyval = list(
 		"findbeacon" = new_dest,
+		"bot" = src,
 	)
 	signal.data = keyval
 	frequency.post_signal(src, signal, filter = RADIO_NAVBEACONS)
 	astar_debug_mulebots("requesting path on freq [frequency.frequency]")
 
 /obj/machinery/bot/mulebot/receive_signal(datum/signal/signal)
+	var/command = signal.data["command"]
+	if (signal.data["target"])
+		if (src != locate(signal.data["target"]))
+			return
+	else if (signal.data["bot"])
+		if (src != signal.data["bot"])
+			return
+	else
+		return
+	if(!on)
+		if(command == "switch_power")
+			execute_signal_command(signal, command)
+			return 1
+		else
+			return 0
 	var/recv = signal.data["beacon"]
 	if(recv && recv == new_destination)	// if the recvd beacon location matches the set destination, then we will navigate there
 		astar_debug_mulebots("new destination recieved and acknoweldged from navbeacons, [recv]")
 		destination = new_destination
 		new_destination = ""
 		target = signal.source.loc
+		var/dumpdir = 0
+		if(signal.data["dir"])
+			dumpdir = signal.data["dir"]
+		var/datum/bot/order/mule/new_order = new(get_turf(target), null, auto_unload, dumpdir)
+		destinations_queue.Add(new_order)
 		awaiting_beacon = 0
+		if(auto_return && (recv != home_destination))
+			set_destination(home_destination)
 		return 1
 	// -- Command signals --
-	if (signal.data["target"])
-		var/obj/machinery/bot/mulebot/chosen_mulebot = locate(signal.data["target"])
-		if (chosen_mulebot != src)
-			return
-	var/command = signal.data["command"]
 	if (!auto_pickup)
 		auto_pickup = signal.data["auto_pickup"]
 
@@ -673,7 +733,8 @@ var/global/mulebot_count = 0
 	coolingdown = TRUE
 	spawn(run_over_cooldown)
 		coolingdown = FALSE
-
+/*
+//Depreciated but here as a reference
 /obj/machinery/bot/mulebot/at_path_target()
 	src.visible_message("[src] makes a chiming sound!", "You hear a chime.")
 	playsound(src, 'sound/machines/chime.ogg', 50, 0)
@@ -705,6 +766,7 @@ var/global/mulebot_count = 0
 	else
 		mode = MODE_IDLE	// otherwise go idle
 	return ..()
+*/
 
 // called when bot bumps into anything
 /obj/machinery/bot/mulebot/to_bump(var/atom/obs)
@@ -836,10 +898,12 @@ var/global/mulebot_count = 0
 	new /obj/effect/decal/cleanable/blood/oil(src.loc)
 	unload(0)
 	qdel(src)
-/*
+
 /obj/machinery/bot/mulebot/process_pathing()
 	astar_debug_mulebots("process_pathing mulebot")
 	if(path.len)
+		mode = MODE_MOVING
+		icon_state = "[icon_initial][(wires.MobAvoid() != 0)]"
 		set_glide_size(DELAY2GLIDESIZE(SS_WAIT_BOTS/steps_per))
 		if(!process_astar_path()) // either end of path or couldn't move
 			if(frustration > 15) // obstacle found
@@ -847,28 +911,33 @@ var/global/mulebot_count = 0
 					//TODO
 				var/turf/obstacle = path[1]
 				var/stop_a_tile_before = current_order.thing_to_load != null
-				path = get_path_to(src, current_order.destination, 30, stop_a_tile_before, botcard, TRUE, obstacle)
+				path = get_path_to(src, current_order.destination, 300, stop_a_tile_before, botcard, TRUE, obstacle)
 				frustration = 0
 			else // end of path
 				return
-		spawn(SS_WAIT_BOTS/steps_per)
-			process_pathing()
+		//spawn(SS_WAIT_BOTS/steps_per)
+		//	process_pathing()
 	else
 		if (destination && !(destinations_queue.len))
-			var/datum/bot/order/mule/new_order = new(get_turf(target), null, FALSE)
+			var/datum/bot/order/mule/new_order = new(get_turf(target), null, auto_unload)
+			astar_debug_mulebots("destination_queue empty but destination defined: [destination]")
+			destination = ""
 			destinations_queue.Add(new_order)
 		if(destinations_queue.len)
 			astar_debug_mulebots("destination_queue non empty, [destination]")
 			current_order = shift(destinations_queue)
 			var/stop_a_tile_before = current_order.thing_to_load != null
-			path = get_path_to(src, current_order.destination, 30, stop_a_tile_before, botcard)
-			if(path.len)
-				process_pathing()
+			path = get_path_to(src, current_order.destination, 300, stop_a_tile_before, botcard)
+			if(!path.len)
+				astar_debug_mulebots("Empty path returned")
+				handle_destination_arrival()
 
 /obj/machinery/bot/mulebot/process_astar_path()
 	if(gcDestroyed)
 		return FALSE
-
+	if(!cell.use(2))
+		turn_off()
+		return FALSE
 	Move(path[1])
 	if(get_turf(src) != path[1])
 		if(on_path_step_fail(path[1]))
@@ -883,15 +952,33 @@ var/global/mulebot_count = 0
 	return TRUE
 
 /obj/machinery/bot/mulebot/proc/handle_destination_arrival()
-	if(current_order.unload_here)
-		unload()
+	astar_debug_mulebots("dest arrived!")
+	destination = ""
+	if(current_order.unload_here && is_locking(/datum/locking_category/mulebot))
+		astar_debug_mulebots("unloading in [current_order.unload_dir] direction!")
+		unload(current_order.unload_dir)
 	else if(current_order.thing_to_load)
 		load(current_order.thing_to_load)
 		current_order.thing_to_load = null
+	else if(auto_pickup && !is_locking(/datum/locking_category/mulebot))
+		// not loaded and ready to load up!
+		var/atom/movable/AM
+		if(!wires.LoadCheck())		// if emagged, load first unanchored thing we find
+			for(var/atom/movable/A in get_step(loc,text2num(current_order.unload_dir)))
+				if(!A.anchored)
+					AM = A
+					break
+		else			// otherwise, look for crates only
+			for(var/i=1,i<=can_load.len,i++)
+				var/loadin_type = can_load[i]
+				AM = locate(loadin_type) in get_step(loc,text2num(current_order.unload_dir))
+				if(AM)
+					load(AM)
+					break
 	playsound(loc, 'sound/machines/ping.ogg', 50, 0)
 	frustration = 0
 	current_order = null
-	astar_debug_mulebots("dest arrived!")
+	mode = MODE_IDLE
 	icon_state = "[icon_initial]0"
 	if (summoned)
 		summoned  = FALSE
@@ -932,7 +1019,7 @@ var/global/mulebot_count = 0
 		return FALSE
 	destinations_queue += order
 	return TRUE
-*/
+
 /obj/item/proc/is_pointer(var/mob/user)
 	return FALSE
 
@@ -944,6 +1031,7 @@ var/global/mulebot_count = 0
 
 /obj/item/mulebot_laser
 	name = "mulebot laser pointing device"
+	desc = "A label shows this device being pointed at a MULEbot."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "airprojector"
 	var/mode = LOAD_OR_MOVE_HERE
@@ -966,13 +1054,13 @@ var/global/mulebot_count = 0
 
 /obj/item/mulebot_laser/attack_self(mob/user)
 	var/mode_txt
+	mode = !mode
 	switch (mode)
 		if (LOAD_OR_MOVE_HERE)
 			mode_txt = "loading"
 		if (UNLOAD_HERE)
 			mode_txt = "unloading"
 	to_chat(user, "<span class='notice'>You change the mode to [mode_txt].</span>")
-	mode = !mode
 
 /obj/item/mulebot_laser/verb/clear_assigned_mulebot()
 	if (usr.incapacitated())

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -310,7 +310,8 @@ var/global/mulebot_count = 0
 			return
 		else // It's a new destination !
 			astar_debug_mulebots("New destination started: [command]")
-			start()
+			set_destination(command)
+			//start()
 
 // returns the wire panel text
 /obj/machinery/bot/mulebot/proc/wires()
@@ -591,7 +592,9 @@ var/global/mulebot_count = 0
 			else if(newdir == (EAST + WEST))
 				newdir = EAST
 			goingdir = newdir
-		next.AddTracks(/obj/effect/decal/cleanable/blood/tracks/wheels,list(),0,goingdir,currentBloodColor)
+		if(bloodiness)
+			next.AddTracks(/obj/effect/decal/cleanable/blood/tracks/wheels,list(),0,goingdir,currentBloodColor)
+			bloodiness--
 
 // starts bot moving to current destination
 /obj/machinery/bot/mulebot/proc/start()
@@ -629,8 +632,8 @@ var/global/mulebot_count = 0
 		awaiting_beacon = 0
 		return 1
 	// -- Command signals --
-	if (signal.data["assigned_mulebot"])
-		var/obj/machinery/bot/mulebot/chosen_mulebot = locate(signal.data["assigned_mulebot"])
+	if (signal.data["target"])
+		var/obj/machinery/bot/mulebot/chosen_mulebot = locate(signal.data["target"])
 		if (chosen_mulebot != src)
 			return
 	var/command = signal.data["command"]
@@ -833,7 +836,7 @@ var/global/mulebot_count = 0
 	new /obj/effect/decal/cleanable/blood/oil(src.loc)
 	unload(0)
 	qdel(src)
-
+/*
 /obj/machinery/bot/mulebot/process_pathing()
 	astar_debug_mulebots("process_pathing mulebot")
 	if(path.len)
@@ -845,12 +848,8 @@ var/global/mulebot_count = 0
 				var/turf/obstacle = path[1]
 				var/stop_a_tile_before = current_order.thing_to_load != null
 				path = get_path_to(src, current_order.destination, 30, stop_a_tile_before, botcard, TRUE, obstacle)
-				if(path.len)
-					bots_list.Remove(src)
 				frustration = 0
 			else // end of path
-				if(!(src in bots_list))
-					bots_list.Add(src)
 				return
 		spawn(SS_WAIT_BOTS/steps_per)
 			process_pathing()
@@ -859,12 +858,11 @@ var/global/mulebot_count = 0
 			var/datum/bot/order/mule/new_order = new(get_turf(target), null, FALSE)
 			destinations_queue.Add(new_order)
 		if(destinations_queue.len)
-			astar_debug_mulebots("destination_queue non empty")
+			astar_debug_mulebots("destination_queue non empty, [destination]")
 			current_order = shift(destinations_queue)
 			var/stop_a_tile_before = current_order.thing_to_load != null
 			path = get_path_to(src, current_order.destination, 30, stop_a_tile_before, botcard)
 			if(path.len)
-				bots_list.Remove(src)
 				process_pathing()
 
 /obj/machinery/bot/mulebot/process_astar_path()
@@ -893,6 +891,12 @@ var/global/mulebot_count = 0
 	playsound(loc, 'sound/machines/ping.ogg', 50, 0)
 	frustration = 0
 	current_order = null
+	astar_debug_mulebots("dest arrived!")
+	icon_state = "[icon_initial]0"
+	if (summoned)
+		summoned  = FALSE
+		destination = ""
+		target = null
 
 // returns true if it's still below the frustration threshold
 /obj/machinery/bot/mulebot/on_path_step_fail(var/turf/next)
@@ -928,7 +932,7 @@ var/global/mulebot_count = 0
 		return FALSE
 	destinations_queue += order
 	return TRUE
-
+*/
 /obj/item/proc/is_pointer(var/mob/user)
 	return FALSE
 
@@ -1010,7 +1014,7 @@ var/global/mulebot_count = 0
 		point_effect(/obj/effect/decal/point/go_here, tile, atom)
 
 	if (my_mulebot)
-		signal.data["assigned_mulebot"] = "[\ref(my_mulebot)]"
+		signal.data["target"] = "[\ref(my_mulebot)]"
 
 	radio_connection.post_signal(src, signal, filter = RADIO_MULEBOT)
 

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -88,14 +88,17 @@ var/list/navbeacons = list()
 	// if found, return a signal
 /obj/machinery/navbeacon/receive_signal(datum/signal/signal)
 	var/request = signal.data["findbeacon"]
+	var/bot = null
+	if(signal.data["bot"])
+		bot = signal.data["bot"]
 	if(request && ((request in codes) || request == "any" || request == location))
 		spawn(1)
-			astar_debug_mulebots("navbeacons accepted request [request] and posted its own location")
-			post_signal(request)
+			astar_debug_mulebots("navbeacons accepted request [request] from [bot] and posted its own location")
+			post_signal(request, bot)
 
 	// return a signal giving location and transponder codes
 
-/obj/machinery/navbeacon/proc/post_signal(request, var/mulebot_signal = FALSE)
+/obj/machinery/navbeacon/proc/post_signal(request, var/mulebot = null)
 	var/datum/radio_frequency/frequency = radio_controller.return_frequency(freq)
 	if(!frequency)
 		return
@@ -110,8 +113,13 @@ var/list/navbeacons = list()
 
 	for(var/key in codes)
 		signal.data[key] = codes[key]
+		astar_debug_mulebots("Key: [key] - [codes[key]]")
 
-	astar_debug_mulebots("navbeacon [location] posted signal with request [request] on freq [freq].")
+	if(mulebot)
+		astar_debug_mulebots("Bot: [mulebot]")
+		signal.data["bot"] = mulebot
+
+	astar_debug_mulebots("navbeacon [location] posted signal with request [request] for [mulebot] on freq [freq].")
 
 	frequency.post_signal(src, signal, filter = RADIO_NAVBEACONS)
 

--- a/code/game/objects/items/devices/PDA/cart/civilian.dm
+++ b/code/game/objects/items/devices/PDA/cart/civilian.dm
@@ -229,16 +229,24 @@
 				<a href='?src=\ref[cart_device.radio];bot=\ref[mule];command=summon;user=\ref[user]'>[mule.summoned ? "Halt" : "Summon"] <br/>
 				<a href='?src=\ref[cart_device.radio];bot=\ref[mule];command=switch_power;user=\ref[user]'>Turn [mule.on ? "off" : "on"] <br/>
 				<a href='?src=\ref[cart_device.radio];bot=\ref[mule];command=return_home;user=\ref[user]'>Send home</a> <br/>
-				<a href='?src=\ref[cart_device.radio];bot=\ref[mule];command=[cart_device.saved_destination];user=\ref[user]'>Send to:</a> <a href='?src=\ref[src];change_destination=1'>[cart_device.saved_destination] - EDIT</a> <br/>
+				<a href='?src=\ref[cart_device.radio];bot=\ref[mule];command=send_to;place=\ref[cart_device.saved_destination];user=\ref[user]'>Send to: [cart_device.saved_destination]</a> - <a href='?src=\ref[src];change_destination=1'>EDIT</a> <br/>
 				</li>"}
 	dat += "</ul>"
 	return dat
 
 /datum/pda_app/cart/mulebot/Topic(href, href_list)
-    if(..())
-        return
-    if(href_list["change_destination"])
-        var/new_dest = stripped_input(usr, "Set the new destination", "New mulebot destination")
-        if (new_dest)
-            cart_device.saved_destination = new_dest
-    refresh_pda()
+	if (..())
+		return
+	if (href_list["change_destination"])
+		var/list/foundbeacons = list()
+		for (var/obj/machinery/navbeacon/found in navbeacons)
+			if(!found.location || !isturf(found.loc))
+				continue
+			if(found.freq == 1400)
+				foundbeacons.Add(found.location)
+				astar_debug("Frequency located: [found.location]")
+		var/new_dest = input(usr, "Set the new destination", "New mulebot destination") as null|anything in foundbeacons
+		if (new_dest)
+			astar_debug("Set saved_dest as: [new_dest]")
+			cart_device.saved_destination = new_dest
+	refresh_pda()

--- a/code/game/objects/items/devices/PDA/cart/civilian.dm
+++ b/code/game/objects/items/devices/PDA/cart/civilian.dm
@@ -225,12 +225,17 @@
 		if (mule.z != user.z)
 			continue
 		dat += {"<li>
-				<i>[mule]</i>: [mule.return_status()] in [get_area_name(mule)] <br/>
-				<a href='?src=\ref[cart_device.radio];bot=\ref[mule];command=summon;user=\ref[user]'>[mule.summoned ? "Halt" : "Summon"] <br/>
-				<a href='?src=\ref[cart_device.radio];bot=\ref[mule];command=switch_power;user=\ref[user]'>Turn [mule.on ? "off" : "on"] <br/>
-				<a href='?src=\ref[cart_device.radio];bot=\ref[mule];command=return_home;user=\ref[user]'>Send home</a> <br/>
-				<a href='?src=\ref[cart_device.radio];bot=\ref[mule];command=send_to;place=\ref[cart_device.saved_destination];user=\ref[user]'>Send to: [cart_device.saved_destination]</a> - <a href='?src=\ref[src];change_destination=1'>EDIT</a> <br/>
-				</li>"}
+				<i>[mule]</i> - Charge: [mule.cell ? mule.cell.percent() : 0]%<br/>
+				[mule.return_status()] in [get_area_name(mule)]<br/>"}
+		var/atom/load = mule.return_load()
+		if(load)
+			dat += {"Loaded: [load.name] <br/>"}
+		if(mule.on)
+			dat +=	{"<a href='?src=\ref[cart_device.radio];bot=\ref[mule];command=summon;user=\ref[user]'>[mule.summoned ? "Halt" : "Summon"] </a><br/>"}
+		dat += {"<a href='?src=\ref[cart_device.radio];bot=\ref[mule];command=switch_power;user=\ref[user]'>Turn [mule.on ? "off" : "on"]</a> <br/>"}
+		if(mule.on)
+			dat += {"<a href='?src=\ref[cart_device.radio];bot=\ref[mule];command=return_home;user=\ref[user]'>Send home</a> <br/><a href='?src=\ref[cart_device.radio];bot=\ref[mule];command=send_to;place=\ref[cart_device.saved_destination];user=\ref[user]'>Send to: [cart_device.saved_destination]</a> - <a href='?src=\ref[src];change_destination=1'>EDIT</a> <br/>
+			</li>"}
 	dat += "</ul>"
 	return dat
 
@@ -244,9 +249,7 @@
 				continue
 			if(found.freq == 1400)
 				foundbeacons.Add(found.location)
-				astar_debug("Frequency located: [found.location]")
 		var/new_dest = input(usr, "Set the new destination", "New mulebot destination") as null|anything in foundbeacons
 		if (new_dest)
-			astar_debug("Set saved_dest as: [new_dest]")
 			cart_device.saved_destination = new_dest
 	refresh_pda()

--- a/code/game/objects/items/devices/PDA/radio.dm
+++ b/code/game/objects/items/devices/PDA/radio.dm
@@ -83,7 +83,11 @@
 		signal.source = src
 		signal.transmission_method = 1
 		signal.data["target"] = href_list["bot"]
-		signal.data["command"] = href_list["command"]
+		if(href_list["command"] == "send_to")
+			log_astar_command("Sending to: [locate(href_list["bot"])]")
+			signal.data["command"] = locate(href_list["place"])
+		else
+			signal.data["command"] = href_list["command"]
 		radio_connection.post_signal(src, signal)
 
 		if (istype(loc.loc, /obj/item/device/pda))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -492,7 +492,7 @@
 	for(var/dir in cardinal)
 		T = get_step(src, dir)
 		if(istype(T) && !T.density)
-			if(!LinkBlockedWithAccess(src, T, ID))
+			if(!LinkBlockedWithAccess(T, src, ID))
 				L.Add(T)
 	return L
 


### PR DESCRIPTION
# MULEs Work Again
![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/c832fc8b-b308-41d1-b360-ff1dc37cdd64)

## What this does
Makes MULEs work again, while also keeping all the fancy features from #31944 such as the laser pointer.

There's a large changelog of small bugs that were fixed, see below for more details. Some easy QOL features were added as well, such as a menu showing all the valid navbeacons available as delivery destinations, and a slight improvement to the cargo PDA app.

Fixes #35545, #33854, #32455, #26208. However, the PR did not test pAIs inside of MULEs, so the issues with those may persist. Additionally, this code is an absolute MESS. If there are any new bugs, try to be descriptive as possible on where you run into them.

## Why it's good
You can send your hacked MULE down the halls with your PDA again just like old times.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

 * bugfix: MULEs actually work now.
 * bugfix: Cargo PDA app also works.
 * bugfix: MULE lights no longer blink forever.
 * rscadd: The Cargo PDA app now includes some upgrades: a select-your-destination menu, a cell-charge display, and a description of what it's carrying.
 * rscadd: Local MULE configurations also show this menu where possible.
 * bugfix: MULE Laser Pointers correctly identify if they are loading/unloading, and you can now load/unload adjacent crates.
 * bugfix: MULEs will now correctly listen for commands that mention them directly - no longer will all the bots respond at once.
 * rscadd: Large order queues can be cleared by summoning the MULE to your location, or power cycling it.
 * bugfix: MULEs automatically unload when they are sent to a beacon with a load.
 * bugfix: MULEs automatically load when they are sent to a beacon without a load, and there's something they can pick up there.
 * bugfix: MULEs will automatically return to their home base after going to their destination.
 * bugfix: The above three settings are configurable, but are on by default.
 * bugfix: MULEs can now navigate to far away navbeacons.
 * bugfix: MULEs should correctly report their status, ie: moving, idle, etc.
 * rscadd: MULEs now use power. 2 units per step. You can view their charge via the PDA or directly on the MULE.
 * bugfix: Boxstation Janitor Navbeacon now points the correct direction for delivery.
 * bugfix: Fixes indefinitely decaying old bot targets (floorbots, etc)


:cl:
* bugfix: MULEs work again, won't blink forever, properly report status.
* bugfix: MULE laser pointer now properly works, including loading and unloading.
* rscadd: The MULE PDA app works and is now more descriptive + selects from valid destinations.
* bugfix: MULEs once again use charge from their internal power cell.
* bugfix: Bots will never get stuck ignoring a target permanently as an old target.