### PR TITLE
Accounts Auditing

### DIFF
--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -819,5 +819,5 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 	alert_title = "Financial Audit Required"
 
 /datum/command_alert/suspicious_wages/announce(login, account)
-	message = "Central Command has noticed a suspicious increase in wages. User [login] has assigned a new wage to [account] with a payroll greater than the entire station's budget. Please conduct an emergency audit."
+	message = "Central Command has noticed a suspicious increase in wages. A database action logged in as [login] has assigned a new wage to [account] with a payroll greater than the entire station's budget. Please conduct an emergency audit."
 	..()

--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -814,3 +814,10 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 /datum/command_alert/archive_thanks/announce()
 	message = "The Research Archive Project extends its profound thanks to [english_list(important_archivists)] for completing the research archival work this shift. There will be an extra stipend in the next pay cycle."
 	..()
+
+/datum/command_alert/suspicious_wages
+	alert_title = "Financial Audit Required"
+
+/datum/command_alert/suspicious_wages/announce(login, account)
+	message = "Central Command has noticed a suspicious increase in wages. User [login] has assigned a new wage to [account] with a payroll greater than the entire station's budget. Please conduct an emergency audit."
+	..()

--- a/code/modules/paperwork/papers_dynamic.dm
+++ b/code/modules/paperwork/papers_dynamic.dm
@@ -183,3 +183,26 @@
 /obj/item/weapon/paper/inventory/armory
 	name = "\improper Armory Inventory Manifest"
 	areastocheck = list(/area/security/armory,/area/security/warden)
+
+/obj/item/weapon/paper/audit/New(loc, user, account, wage, newwage)
+	name = "Wage Audit - [account]"
+	display_x = 500
+	display_y = 600
+	info = {"<html><style>
+			body {color: #000000; background: #ccffff;}
+			h1 {color: #000000; font-size:30px;}
+			fieldset {width:140px;}
+			</style>
+			<body>
+			<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"> <h1>ATTN: Internal Affairs</h1></center>
+			An unusual wage increase has been authorized at the accounts database on your station. Although command staff have broad latitude to set wages within reason, there are documented cases of abuse, off-books dealing, cryptographic sequencing, and even simple security errors such as leaving a computer logged in without supervision. For this reason, Internal Affairs is requested to audit the following recent wage modification.<BR>
+			Account name: [account]<BR>
+			Old wage: [wage]<BR>
+			New wage: [newwage]<BR>
+			Name on authorizing ID: [user]<BR>
+			Time of operation: [worldtime2text()]<BR><BR>
+			We wish you the best of luck in your investigation. This paper should be taken as official authorization to inspect the Accounts Database.<BR>
+			<I>Central Command Audits Department</I>
+			</body></html>"}
+	CentcommStamp(src)
+	..()


### PR DESCRIPTION
I could have just fixed the bug, but I thought this was more fun for everyone.
* If you try to input a wage over 10000 (about 10x what the whole station earns), it causes the machine to shoot out sparks and fail! You couldn't get this much anyway.
* If you put in a wage more than the entire station earned last cycle, it triggers an announcement requesting a high priority audit.
* If you double someone's wage, it requests a low-priority audit. These are almost always okay, but it gives the IAA some roleplaying potential.
* Admin ghosts do not trigger audits.
* Sharp-eyed users might notice there are some ways to avoid triggering the audit if you're careful. Be sneaky, spaceman...

![image](https://github.com/vgstation-coders/vgstation13/assets/9782036/f9ad852f-d431-4ea7-9b6f-0bdde3882c3d)
Uh oh, I gave myself more than the entire station earned.

![image](https://github.com/vgstation-coders/vgstation13/assets/9782036/dcd3a1cf-32eb-4656-8189-b34a0f60754e)
Someone with an emag just gave me 2000 per cycle. It wasn't me, really.

🆑 
* bugfix: Fixed a bug where you could cause an infinite error with unprotected input on wages.
* rscadd: You may now trigger an audit with suspicious wage modifications.
* rscadd: You can now repair the Accounts Database if it is emagged.