### PR TITLE
Blacklists Vox from Security department.

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -40,6 +40,8 @@
 	outfit_datum = /datum/outfit/warden
 	minimal_player_age = 7
 
+	species_blacklist = list("Vox")
+
 /datum/job/detective
 	title = "Detective"
 	faction = "Station"
@@ -53,6 +55,8 @@
 	alt_titles = list("Forensic Technician","Gumshoe", "Private Eye")
 	outfit_datum = /datum/outfit/detective
 	minimal_player_age = 7
+
+	species_blacklist = list("Vox")
 
 /datum/job/detective/post_init(var/mob/living/carbon/human/H)
 	genemutcheck(H, SOBERBLOCK)
@@ -71,6 +75,8 @@
 	minimal_access = list(access_weapons, access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels)
 	minimal_player_age = 7
 	outfit_datum = /datum/outfit/officer
+
+	species_blacklist = list("Vox")
 
 /datum/job/officer/get_total_positions()
 	. = ..()


### PR DESCRIPTION
## What this does
Blacklists Vox from Security Officer, Warden and Detective. They can still play as Brig Medics though.

## Why it's good

1. Kills the Vox-curity quasi-metaclub in the womb.

The vox quasi-metaclub going on every other populated round, with half of Security personnel (or more!) being poopbirds, them constantly powergayming with lethals/shotguns at the slightest sight of antagonism and often abandoning their duties to cater to their own feathery flock finally grew really tiresome on me, and I'd be willing to bet not on me only.
It also gives me very unpleasant flashbacks about similar, much more malignant furry Security metaclubs on some _other_ SS13 servers.

2. Roleplay inconsistency (minor point since /vg/ is a LRP server)

Makes no sense for the supposed illiterate space gypsies to be hired as peacekeeping grunts with legitimate power over humans by a turbo-capitalist xenophobic giga-corporation.

### I understand this is fairly controversial so I'm adding the proper tags and would like to hear everybody's opinion regarding the issue.

## Changelog
:cl:
 * rscdel: NanoTrasen no longer hires Vox as Security personnel.

[discussion] [controversial] [vote]