### PR TITLE
Blacklists aliens from Security department.

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -40,6 +40,8 @@
 	outfit_datum = /datum/outfit/warden
 	minimal_player_age = 7
 
+	species_whitelist = list("Human")
+
 /datum/job/detective
 	title = "Detective"
 	faction = "Station"
@@ -53,6 +55,8 @@
 	alt_titles = list("Forensic Technician","Gumshoe", "Private Eye")
 	outfit_datum = /datum/outfit/detective
 	minimal_player_age = 7
+
+	species_whitelist = list("Human")
 
 /datum/job/detective/post_init(var/mob/living/carbon/human/H)
 	genemutcheck(H, SOBERBLOCK)
@@ -71,6 +75,8 @@
 	minimal_access = list(access_weapons, access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels)
 	minimal_player_age = 7
 	outfit_datum = /datum/outfit/officer
+
+	species_whitelist = list("Human")
 
 /datum/job/officer/get_total_positions()
 	. = ..()


### PR DESCRIPTION
## What this does
Blacklists xenos from Security Officer, Warden and Detective. They can still play as Brig Medics though.

## Why it's good

1. Kills any possible furry Security metaclub in the womb.

A preventive measure against any malignant furry Security metaclubs forming in the future, like on some _other_ SS13 servers. I cannot point fingers, but let's just say it seems as if this is the right time for such a change.

2. Roleplay inconsistency (minor point since /vg/ is a LRP server).

Makes no sense for the inferior alien species widely abused and exploited for cheap labor to be hired as peacekeeping grunts with legitimate power over humans by a turbo-capitalist xenophobic giga-corporation.

3. Command jobs inconsistency.

The three most important Command positions that have legitimate authority to manage the rest of Space Station 13 crew - Captain, Head of Security and Head of Personnel - are currently whitelisted to be Humans only. It is very important for their loyal minions, whose task is to protect corporate and Command interests and who thus were granted authority to subdue the violators of such interests to also be Humans only, as to minimise the risks of potential internal discord on the grounds of speciesm (this rarely happens nowadays, but the point still stands).

![voxispox](https://github.com/vgstation-coders/vgstation13/assets/155526839/c0820596-5c3b-4650-8f02-b67fff4b121e)

### I understand this is fairly controversial so I'm adding the proper tags and would like to hear everybody's opinion regarding the issue.

## Changelog
:cl:
 * rscdel: NanoTrasen no longer hires aliens for Security personnel.

[discussion] [controversial] [vote]