### PR TITLE
Extravagant wizards that wanna show off can now buy a ten million gallon hat from the magivend's premium stock.

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -2367,6 +2367,7 @@ var/global/num_vending_terminals = 1
 		)	//No one can get to the machine to hack it anyways; for the lulz - Microwave
 	premium = list(
 		/obj/item/clothing/back/magiccape = 1,
+		/obj/item/clothing/head/cowboy/dimma/magic = 1,
 		)
 	specials = list(
 		/obj/item/weapon/storage/box/smartbox/clothing_box/hallowiz = "10", //throughout october

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -587,6 +587,11 @@
 	icon_state = "cowboydimma"
 	wear_override = new/icon("icon" = 'icons/mob/dimma.dmi', "icon_state" = "cowboydimma")
 
+/obj/item/clothing/head/cowbow/dimma/magic
+	name = "ten million spells hat"
+	desc = "Some claim that the magical power of its user is directly tied to how tall the hat is."
+	wizard_garb = TRUE
+
 /obj/item/clothing/head/christmas/santahat/red
 	name = "red santa hat"
 	desc = "Not quite as magical as the real thing, but it flops over one ear and itches your head just the same."

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -587,7 +587,7 @@
 	icon_state = "cowboydimma"
 	wear_override = new/icon("icon" = 'icons/mob/dimma.dmi', "icon_state" = "cowboydimma")
 
-/obj/item/clothing/head/cowbow/dimma/magic
+/obj/item/clothing/head/cowboy/dimma/magic
 	name = "ten million spells hat"
 	desc = "Some claim that the magical power of its user is directly tied to how tall the hat is."
 	wizard_garb = TRUE


### PR DESCRIPTION
## What this does
Adds a magical ten million gallon hat to the magivend.
## Why it's good
Lets you play in hard(er) mode since you need to buy the prestidigitation bundle (costing you 20 points) to access it (via coin) and it also makes you very obvious.
![image](https://github.com/vgstation-coders/vgstation13/assets/67024428/4522a705-37e7-43d9-a7e9-5473877d3a61)
:cl:
 * rscadd: Wizards that wanna show off can buy a magical ten million gallon hat from the magivend's premium stock, should they have a coin available.