### PR TITLE
Fixes Hub Timezone Offsets

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -27,12 +27,12 @@
 	return wtime + (time_offset + wusage) * world.tick_lag
 
 /proc/game_start_elapsed_time(give_seconds = FALSE)
-	if(!ticker)
+	if(!ticker || ticker.current_state < GAME_STATE_PLAYING)
 		return
 	if(!give_seconds)
-		return time2text(world.time - (ticker.gamestart_time*10), "hh:mm")
+		return time2text(world.time - (ticker.gamestart_time*10), "hh:mm", 0)
 	else
-		return time2text(world.time - (ticker.gamestart_time*10), "hh:mm:ss")
+		return time2text(world.time - (ticker.gamestart_time*10), "hh:mm:ss", 0)
 
 //Returns the world time in english
 /proc/worldtime2text(timestamp = world.time, give_seconds = FALSE)

--- a/code/hub.dm
+++ b/code/hub.dm
@@ -72,6 +72,8 @@ var/global/byond_hub_playercount = OPEN_TO_HUB_PLAYERCOUNT_DEFAULT
 		s += "<br><b>STARTING</b>"
 	else if(ticker.current_state <= GAME_STATE_PREGAME && going && ticker.pregame_timeleft)
 		s += "<br>Starting: <b>[round(ticker.pregame_timeleft - world.timeofday) / 10]</b>"
+	else if(ticker.current_state == GAME_STATE_SETTING_UP)
+		s += "<br>Starting: <b>Now</b>"
 	else if(ticker.current_state == GAME_STATE_PLAYING)
 		s += "<br>Time: <b>[game_start_elapsed_time()]</b>"
 	else if(ticker.current_state == GAME_STATE_FINISHED)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
Hub time hours were weird, it was many hours ahead since time2text has a timezone arg
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Why it's good
its now UTC+0, since world.time is in UTC. so hub time starts at 00:00 finally
<!-- Explain why you think these changes are good. -->

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Hub time is FINALLY accurate
