### PR TITLE
Burning objects now create fires on ignition

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -97,7 +97,7 @@ Attach to transfer valve and open. BOOM.
 	if(fire_dmi && fire_sprite)
 		fire_overlay = image(fire_dmi,fire_sprite)
 		overlays += fire_overlay
-
+	new /obj/effect/fire(src)
 	var/atom/movable/AM = src
 	if(istype(AM))
 		firelightdummy = new (src)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Objects set on fire via the ignite() proc will now create a fire on their tile. Currently, hotspot_expose() will ignite a tile and set objects on the tile on fire, but only igniting a specific item will not ignite the tile.

## Why it's good
<!-- Explain why you think these changes are good. -->
Currently, any items which are set on fire via ignite() will burn up properly but don't actually heat the room. As ignite() is only called directly on items in a few niche cases (emagged microwaves, cult items being splashed with salt, etc), this will not result in any noticeable change for players starting fires by other means. 

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Directly igniting an object via ignite() will now create a fire on the object's turf.