### PR TITLE
IDs no longer Melt when PDA Bombed

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -19,7 +19,7 @@
 	var/associated_account_number = 0
 
 	var/list/files = list(  )
-	autoignition_temperature = AUTOIGNITION_PLASTIC
+	autoignition_temperature = 0 //ID cards and other cards don't melt in fire
 
 /obj/item/weapon/card/data
 	name = "data disk"


### PR DESCRIPTION
# Un-buffs the PDA Bombs

## What this does
Due to autoignition changes, IDs almost always melted after being exploded by a PDA bomb. This PR makes IDs unmeltable in a fire, so that a PDA bomb won't destroy the ID by melting it. Fixes #35795.

## Why it's good
<!-- Explain why you think these changes are good. -->
Don't have to beg the HoP for a new ID after the 3rd round in a row of PDA bombs.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: PDA Bombs no longer melt IDs

[bugfix]