### PR TITLE
Revert "Fixed get_icon_dir_count"

### DIFF
--- a/__DEFINES/rust_g.dm
+++ b/__DEFINES/rust_g.dm
@@ -46,7 +46,6 @@
 
 #define rustg_dmi_strip_metadata(fname) call_ext(RUST_G, "dmi_strip_metadata")(fname)
 #define rustg_dmi_create_png(path, width, height, data) call_ext(RUST_G, "dmi_create_png")(path, width, height, data)
-#define rustg_dmi_icon_state_dirs(fname, icon_state_name) call_ext(RUST_G, "dmi_icon_state_dirs")("[fname]", icon_state_name)
 
 #define rustg_noise_get_at_coordinates(seed, x, y) call_ext(RUST_G, "noise_get_at_coordinates")(seed, x, y)
 

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -169,33 +169,19 @@
 	else
 		return FALSE
 
-/// Returns the number of directions a given icon_state has, or 0 if it's not 1, 4 or 8 (such as in the case of an animated state)
-/proc/get_icon_dir_count(what, icon_state)
-	#define TEMP_FILE "data/tmp/rustg_icon_states.dmi"
-	if(isfile(what))
-		var/into_path = "[what]"
-		if(length(into_path))
-			// compiled
-			. = rustg_dmi_icon_state_dirs(into_path, icon_state)
-		else
-			// runtime
-			if(!fcopy(what, TEMP_FILE))
-				CRASH("failed to fcopy")
-			. = rustg_dmi_icon_state_dirs(TEMP_FILE, icon_state)
-			if(!fdel(TEMP_FILE))
-				CRASH("failed to fdel")
-	else if(isicon(what))
-		// always runtime
-		if(!fcopy(what, TEMP_FILE))
-			CRASH("failed to fcopy")
-		. = rustg_dmi_icon_state_dirs(TEMP_FILE, icon_state)
-		if(!fdel(TEMP_FILE))
-			CRASH("failed to fdel")
-	else if(istext(what))
-		// assume path on server
-		. = rustg_dmi_icon_state_dirs(what, icon_state)
-	. = text2num(.)
-	#undef TEMP_FILE
+//returns the number of direction a given icon_state has, or 0 if it's not 1, 4 or 8 (such as in the case of an animated state)
+//should be accurate most of the time, but no guarrantees
+/proc/get_icon_dir_count(icon, icon_state)
+	var/iconKey = "misc"
+	iconCache[iconKey] << icon(icon,icon_state)
+	var/haystack = "[iconCache.ExportText(iconKey)]"
+	if (findtextEx(haystack, "iVBORw0KGgoAAAANSUhEUgAAACAAAAAg"))//yeah I found those patterns by reading strings of icons converted to base64
+		return 1
+	if (findtextEx(haystack, "iVBORw0KGgoAAAANSUhEUgAAACAAAABA"))
+		return 4
+	if (findtextEx(haystack, "iVBORw0KGgoAAAANSUhEUgAAACAAAABg"))
+		return 8
+	return 0 //unknown pattern, most likely something animated, oh well. be sure to account for that in your proc call.
 
 //clamps the HSV brightness of an RGB color to [lower, upper]
 /proc/ColorVClamp(var/rgb, var/lower = 0, var/upper = 255)

--- a/code/libs/Get Flat Icon/Get Flat Icon Deluxe.dm
+++ b/code/libs/Get Flat Icon/Get Flat Icon Deluxe.dm
@@ -84,7 +84,7 @@ cons:
 			//making sure that our icon can turn
 			var/dir = data[GFI_DX_DIR]
 			if (dir != SOUTH) // south-facing atoms shouldn't pose any problem
-				var/icon_directions = get_icon_dir_count(data[GFI_DX_ICON], data[GFI_DX_STATE])
+				var/icon_directions = get_icon_dir_count(data[GFI_DX_ICON],data[3])
 				if (icon_directions == 1)
 					data[GFI_DX_DIR] = SOUTH // if the icon has only one direction we HAVE to face south
 				else if (icon_directions == 4)

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -5,4 +5,3 @@
 /player_saves
 last_git_commit_hash.txt
 /spritesheets/*
-rustg_tmp_icon.dmi


### PR DESCRIPTION
Reverts vgstation-coders/vgstation13#35840

The server died after this was merged. Given the library is used for other stuff as well, it's possible that e.g. something changed in the SQL API that's now failing and preventing it from starting up.
I don't have logs or anything, and I don't know which version of the library @ShiftyRail used last time, or with which features were enabled.