### PR TITLE
More autoignition tweaks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -279,7 +279,7 @@
 	icon = 'icons/obj/doors/Doorplasma.dmi'
 	mineral = "plasma"
 
-	autoignition_temperature = 300
+	autoignition_temperature = AUTOIGNITION_WELDERFUEL
 	fire_fuel = 10
 
 /obj/machinery/door/airlock/plasma/ignite(temperature)

--- a/code/game/machinery/vending_packs.dm
+++ b/code/game/machinery/vending_packs.dm
@@ -233,7 +233,7 @@
 	var/foldable = /obj/item/stack/sheet/cardboard
 	var/foldable_amount = 4
 
-	autoignition_temperature = 522 // Kelvin
+	autoignition_temperature = AUTOIGNITION_PAPER
 	fire_fuel = 2
 
 /obj/item/emptyvendomatpack/attack_self()

--- a/code/game/objects/items/airbag.dm
+++ b/code/game/objects/items/airbag.dm
@@ -6,7 +6,6 @@
 	item_state = "syringe_kit"
 	w_class = W_CLASS_SMALL
 	slot_flags = SLOT_BELT
-	autoignition_temperature = AUTOIGNITION_PROTECTIVE
 
 /obj/item/airbag/proc/deploy(mob/user)
 	icon = 'icons/obj/objects.dmi'

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -260,7 +260,7 @@
 	name = "discarded BYOND support package"
 	icon_state = "byond"
 	starting_materials = list(MAT_CARDBOARD = 370)
-	autoignition_temperature = 522
+	autoignition_temperature = AUTOIGNITION_PAPER
 	w_type=RECYK_MISC
 
 var/list/crushed_cans_cache = list()

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -17,7 +17,7 @@
 	actions_types = list(/datum/action/item_action/convert)
 	rustle_sound = "pageturn"
 
-	autoignition_temperature = 522 // Kelvin
+	autoignition_temperature = AUTOIGNITION_PAPER
 	fire_fuel = 2
 
 /obj/item/weapon/storage/bible/suicide_act(var/mob/living/user)
@@ -333,7 +333,7 @@
 		deconvertee.take_overall_damage(10)//it's a painful process no matter what.
 		var/turf/T = get_turf(deconvertee)
 		anim(target = deconvertee, a_icon = 'icons/effects/effects.dmi', flick_anim = "cult_jaunt_land", lay = SNOW_OVERLAY_LAYER, plane = EFFECTS_PLANE)
-		
+
 		switch(success)
 			if (DECONVERSION_ACCEPT)
 				var/mob/living/simple_animal/hostile/shade/redshade_A = new(T)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -30,7 +30,7 @@
 	foldable = /obj/item/stack/sheet/cardboard	//BubbleWrap
 	starting_materials = list(MAT_CARDBOARD = 3750)
 	w_type=RECYK_MISC
-	autoignition_temperature = 522 // Kelvin
+	autoignition_temperature = AUTOIGNITION_PAPER
 	fire_fuel = 2
 	autoignition_temperature = AUTOIGNITION_PAPER
 	on_armory_manifest = TRUE
@@ -47,7 +47,7 @@
 	storage_slots = 21
 	max_combined_w_class = 42 // 21*2
 
-	autoignition_temperature = 530 // Kelvin
+	autoignition_temperature = AUTOIGNITION_PAPER
 	fire_fuel = 3
 
 /obj/item/weapon/storage/box/surveillance

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -8,6 +8,8 @@
 	plane = ABOVE_HUMAN_PLANE
 	var/ctype = 1
 	var/holo = FALSE
+	autoignition_temperature = AUTOIGNITION_PLASTIC
+	fire_fuel = 2
 
 /obj/structure/curtain/closed/left
 	ctype = 2

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -35,7 +35,6 @@
 /turf/simulated/floor/vox/wood
 	icon_state = "wood"
 
-	autoignition_temperature = AUTOIGNITION_WOOD
 	fire_fuel = 10
 	soot_type = null
 	melt_temperature = 0 // Doesn't melt.
@@ -63,7 +62,6 @@
 	name = "floor"
 	icon_state = "wood"
 
-	autoignition_temperature = AUTOIGNITION_WOOD
 	fire_fuel = 10
 	soot_type = null
 	melt_temperature = 0 // Doesn't melt.

--- a/code/modules/painting/easel.dm
+++ b/code/modules/painting/easel.dm
@@ -18,6 +18,8 @@
 	var/rest_sprite_height = 2 // How many pixels of the easel rest should sjut out under the canvas
 
 	starting_materials = list(MAT_WOOD = 3*CC_PER_SHEET_WOOD)
+	autoignition_temperature = AUTOIGNITION_WOOD
+	fire_fuel = 5
 
 /obj/structure/easel/New()
 	..()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- Replaces magic number autoignition values with existing constants.
- Makes the personal airbag fireproof like the emergency shelter (likely closes #35846)
- Removes autoignition values from wood floors. This isn't behaving as intended and will be looked at in a future PR.
- Added autoignition temperatures to easels and curtains.

## Why it's good
<!-- Explain why you think these changes are good. -->
Consistent code standards and more fire.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Easels and curtains will now auto-ignite.
 * tweak: Personal airbag is now fireproof, in line with emergency shelters.
