### PR TITLE
Visible message when someone passes out from crit or paincrit

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_shock.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_shock.dm
@@ -8,6 +8,8 @@
 
 	if(health < config.health_threshold_softcrit) //Going under the crit threshold makes you immediately collapse
 		pain_shock_stage = max(pain_shock_stage, 61)
+		if(!isUnconscious())
+			visible_message("<B>[src]</B> passes out!","Your vision goes dark due to the pain!")
 	else if(pain_level >= BASE_CARBON_PAIN_RESIST)//Remaining over the pain threshold causes shock to increase over time
 		pain_shock_stage += 1
 	else
@@ -43,6 +45,8 @@
 
 		if(pain_shock_stage >= 120 && pain_shock_stage < 150)
 			if(prob(2))
+				if(!isUnconscious())
+					visible_message("<B>[src]</B> passes out!")
 				to_chat(src, "<span class='danger'>[pick("You black out!", "You feel like you could die any moment now.", "You're about to lose consciousness.")]</span>")
 				Paralyse(5)
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Adds a visible message to bystanders when someone passes out due to entering crit or paincrit.

## Why it's good
<!-- Explain why you think these changes are good. -->
It's now easier to tell when someone passes out or is just knocked down due to pain. Closes #9544.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added a visible message when someone passes out from crit or paincrit.
