### PR TITLE
Alerts pager now fits on the CE belt

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -121,7 +121,8 @@
 		"/obj/item/airshield_projector",
 		"/obj/item/tool/irons",
 		"/obj/item/device/radio",
-		"/obj/item/device/gps"
+		"/obj/item/device/gps",
+		"/obj/item/device/pager"
 		)
 
 /obj/item/weapon/storage/belt/utility/chief/full/New() //This is mostly for testing I guess


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
The station alerts pager can now be placed on the CE belt.

## Why it's good
<!-- Explain why you think these changes are good. -->
Closes #35851 

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: The station alerts pager can now be placed on the CE's belt