### PR TITLE
fixes deathripley issue

### DIFF
--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -88,7 +88,7 @@
 	step_energy_drain = 0
 	paintable = 0
 
-/obj/mecha/working/ripley/deathripley/New()
+/obj/mecha/working/ripley/mk2/firefighter/deathripley/New()
 	..()
 	new /obj/item/mecha_parts/mecha_equipment/tool/safety_clamp(src)
 	return


### PR DESCRIPTION
## What this does
Fixes an oversight with deathripleys, they forgot to update the new() call when updating the ripleys on #33995
## Why it's good
muh [bugfix] n [hotfix]

:cl:
 * bugfix: Death ripleys should now actually have the KILL CLAMP.