### PR TITLE
Teleport Scroll Smoke-on-Cancel Fix

### DIFF
--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -52,6 +52,9 @@
 	var/A
 	A = input(user, "Area to jump to", "BOOYEA", A) as null|anything in teleportlocs
 
+	if(isnull(A))
+		return
+
 	var/area/thearea = teleportlocs[A]
 
 	if (!user || user.stat || user.restrained())


### PR DESCRIPTION
dorms said to bug report this but there was already a bug report and i can code so uhhhhhhh

## What this does
Fixes #34508. Smoke no longer sprays out of you if you try to use the wizard's teleport scroll and cancel.

## Why it's good
it's not, i can't spam free smoke anymore after looting a wizard, why am i fixing this

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Smoke no longer comes out of a teleport scroll when you cancel your destination selection.

[bugfix]