### PR TITLE
Using a pen on a cyborg prior to MMI/posibrain insertion will force its name

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -244,7 +244,11 @@
 			feedback_inc("cyborg_birth",1)
 
 			spawn()
-				O.Namepick()
+				if(created_name)
+					O.name = created_name
+					O.namepick_uses = 0
+				else
+					O.Namepick()
 
 			qdel(src)
 		else


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Using a pen on a robot endoskeleton will now force a name on the cyborg when an occupied MMI or posibrain is inserted. This appears to be the intended functionality but was either removed or never fully implemented.

## Why it's good
<!-- Explain why you think these changes are good. -->
Closes #35866.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Naming a cyborg endoskeleton will now force the name onto the completed cyborg.
