### PR TITLE
Melting Revival

### DIFF
--- a/__DEFINES/math_physics.dm
+++ b/__DEFINES/math_physics.dm
@@ -46,7 +46,7 @@
 #define MELTPOINT_GOLD (T0C+1064)
 #define MELTPOINT_SILVER (T0C+961.8)
 #define MELTPOINT_URANIUM (T0C+1132)
-#define MELTPOINT_POTASSIUM (T0C+63.5)
+#define MELTPOINT_POTASSIUM (T0C+63.5) //Bananium meltpoint, lmao
 #define MELTPOINT_BRASS (T0C+940)
 #define MELTPOINT_MYTHRIL (T0C+893) //Using sterling silver (because silver steel) as base
 

--- a/code/controllers/subsystem/burnable.dm
+++ b/code/controllers/subsystem/burnable.dm
@@ -38,12 +38,15 @@ var/list/atom/burnableatoms = list()
 
 #define MINOXY2BURN (1 / CELL_VOLUME)
 /atom/proc/checkburn()
+	var/datum/gas_mixture/G = return_air()
 	if(on_fire)
-		var/datum/gas_mixture/G = return_air()
 		if(!G || G.molar_density(GAS_OXYGEN) < MINOXY2BURN) //no oxygen so it goes out
 			extinguish()
 	else if(autoignition_temperature && isturf(loc))
-		var/datum/gas_mixture/G = return_air()
 		if(G && G.temperature >= autoignition_temperature && G.molar_density(GAS_OXYGEN) >= MINOXY2BURN)
 			ignite()
+	else if(melt_temperature && isturf(loc))
+		if(G && G.temperature >= melt_temperature)
+			message_admins("Melting [src] via burnable.dm.") //DEBUG
+			melt()
 #undef MINOXY2BURN

--- a/code/controllers/subsystem/burnable.dm
+++ b/code/controllers/subsystem/burnable.dm
@@ -47,6 +47,5 @@ var/list/atom/burnableatoms = list()
 			ignite()
 	else if(melt_temperature && isturf(loc))
 		if(G && G.temperature >= melt_temperature)
-			message_admins("Melting [src] via burnable.dm.") //DEBUG
 			melt()
 #undef MINOXY2BURN

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -391,7 +391,7 @@
 				broke()
 				playsound(src, 'sound/machines/ding.ogg', 50, 1)
 				empty()
-				var/obj/item/trash/slag/gunk = new(src)
+				var/obj/effect/decal/slag/plastic/gunk = new(src)
 				gunk.forceMove(src.loc)
 				return
 

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -390,9 +390,10 @@
 					return
 				broke()
 				playsound(src, 'sound/machines/ding.ogg', 50, 1)
+				O.forceMove(src.loc)
 				empty()
-				var/obj/effect/decal/slag/plastic/gunk = new(src)
-				gunk.forceMove(src.loc)
+				O.melt()
+				src.visible_message("<span class='warning'>Molten plastic pours from the microwave!</span>")
 				return
 
 		// If there's just one item and no reagents, warm it up

--- a/code/game/objects/effects/decals/slag.dm
+++ b/code/game/objects/effects/decals/slag.dm
@@ -11,7 +11,12 @@
 
 /obj/effect/decal/slag/proc/slaggify(var/obj/O)
 	// This is basically a crude recycler doohicky
+	message_admins("Slaggifying [src] with input object [O].") //DEBUG
 	if (O.recycle(materials))
+		message_admins("O: [O].") //DEBUG
+		message_admins("materials: [materials].") //DEBUG
+		message_admins("O.materials: [O.materials].") //DEBUG
+		message_admins("O.recycle(materials):[O.recycle(materials)].") //DEBUG
 		if(melt_temperature==0)
 			// Set up our solidification temperature.
 			melt_temperature=O.melt_temperature
@@ -24,6 +29,8 @@
 			icon_state="slaghot"
 			processing_objects.Add(src)
 			set_light(2)
+	else
+		message_admins("No materials found in [O].") //DEBUG
 
 /obj/effect/decal/slag/Destroy()
 	set_light(0)
@@ -100,5 +107,3 @@
 		user.visible_message("<span class=\"attack\">[user.name] hits \the [src] with \his [W.name].</span>", \
 			"<span class=\"attack\">You fail to damage \the [src] with your [W.name]!</span>", \
 			"You hear someone hitting something.")
-
-/obj/effect/decal/slag/plastic

--- a/code/game/objects/effects/decals/slag.dm
+++ b/code/game/objects/effects/decals/slag.dm
@@ -11,12 +11,7 @@
 
 /obj/effect/decal/slag/proc/slaggify(var/obj/O)
 	// This is basically a crude recycler doohicky
-	message_admins("Slaggifying [src] with input object [O].") //DEBUG
 	if (O.recycle(materials))
-		message_admins("O: [O].") //DEBUG
-		message_admins("materials: [materials].") //DEBUG
-		message_admins("O.materials: [O.materials].") //DEBUG
-		message_admins("O.recycle(materials):[O.recycle(materials)].") //DEBUG
 		if(melt_temperature==0)
 			// Set up our solidification temperature.
 			melt_temperature=O.melt_temperature
@@ -29,8 +24,6 @@
 			icon_state="slaghot"
 			processing_objects.Add(src)
 			set_light(2)
-	else
-		message_admins("No materials found in [O].") //DEBUG
 
 /obj/effect/decal/slag/Destroy()
 	set_light(0)

--- a/code/game/objects/effects/decals/slag.dm
+++ b/code/game/objects/effects/decals/slag.dm
@@ -100,3 +100,5 @@
 		user.visible_message("<span class=\"attack\">[user.name] hits \the [src] with \his [W.name].</span>", \
 			"<span class=\"attack\">You fail to damage \the [src] with your [W.name]!</span>", \
 			"You hear someone hitting something.")
+
+/obj/effect/decal/slag/plastic

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -311,11 +311,6 @@ var/list/crushed_cans_cache = list()
 	. = ..()
 	.["color"] = name//a bit hacky but at least it works
 
-/obj/item/trash/slag
-	name = "slag"
-	desc = "Electronics burnt to a crisp."
-	icon_state = "slag"
-
 /obj/item/trash/used_tray
 	name = "dirty tray"
 	icon_state	= "tray_plastic_used"

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -260,13 +260,9 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 	return w_type
 
 /obj/melt()
-	message_admins("Melting [src].") //DEBUG
 	var/obj/effect/decal/slag/slag=locate(/obj/effect/decal/slag) in get_turf(src)
-	if(slag)
-		message_admins("Existing slag: [slag].") //DEBUG
 	if(!slag)
 		slag = new(get_turf(src))
-		message_admins("New slag [slag] at [get_turf(src)].") //DEBUG
 	slag.slaggify(src)
 
 /obj/proc/is_conductor(var/siemens_min = 0.5)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -64,7 +64,7 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 		breakable_init()
 	if(is_cooktop)
 		add_component(/datum/component/cooktop)
-	if(autoignition_temperature)
+	if(autoignition_temperature || melt_temperature)
 		burnableatoms+=src
 
 //More cooking stuff:
@@ -260,9 +260,13 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 	return w_type
 
 /obj/melt()
+	message_admins("Melting [src].") //DEBUG
 	var/obj/effect/decal/slag/slag=locate(/obj/effect/decal/slag) in get_turf(src)
+	if(slag)
+		message_admins("Existing slag: [slag].") //DEBUG
 	if(!slag)
 		slag = new(get_turf(src))
+		message_admins("New slag [slag] at [get_turf(src)].") //DEBUG
 	slag.slaggify(src)
 
 /obj/proc/is_conductor(var/siemens_min = 0.5)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -259,13 +259,11 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 		return 1
 	return w_type
 
-/*
 /obj/melt()
 	var/obj/effect/decal/slag/slag=locate(/obj/effect/decal/slag) in get_turf(src)
 	if(!slag)
 		slag = new(get_turf(src))
 	slag.slaggify(src)
-*/
 
 /obj/proc/is_conductor(var/siemens_min = 0.5)
 	if(src.siemens_coefficient >= siemens_min)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -66,5 +66,5 @@
 /obj/structure/animationBolt(var/mob/firer)
 	new /mob/living/simple_animal/hostile/mimic/copy(loc, src, firer, duration=SPELL_ANIMATION_TTL)
 
-/obj/melt() //no melting for structures, yet
-	return 0
+/obj/structure/melt() //no melting for structures, yet
+	return

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -65,3 +65,6 @@
 
 /obj/structure/animationBolt(var/mob/firer)
 	new /mob/living/simple_animal/hostile/mimic/copy(loc, src, firer, duration=SPELL_ANIMATION_TTL)
+
+/obj/melt() //no melting for structures, yet
+	return 0

--- a/code/modules/mining/debug_shit.dm
+++ b/code/modules/mining/debug_shit.dm
@@ -3,3 +3,8 @@
 	..()
 	for(var/ore_id in materials.storage)
 		materials.addAmount(ore_id, 20)
+
+/obj/item/stack/ore/slag/hax/New()
+	..()
+	for(var/ore_id in mats.storage)
+		mats.addAmount(ore_id, 20)

--- a/code/modules/mining/debug_shit.dm
+++ b/code/modules/mining/debug_shit.dm
@@ -3,8 +3,3 @@
 	..()
 	for(var/ore_id in materials.storage)
 		materials.addAmount(ore_id, 20)
-
-/obj/item/stack/ore/slag/hax/New()
-	..()
-	for(var/ore_id in mats.storage)
-		mats.addAmount(ore_id, 20)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -144,7 +144,7 @@
 	melt_temperature = MELTPOINT_GLASS
 	starting_materials = list(MAT_PHAZON = CC_PER_SHEET_PHAZON)
 
-/obj/item/stack/ore/slag // this slag item is used for blacksmithing only - for slag as a result of items melting, see /obj/effect/decal/slag
+/obj/item/stack/ore/slag
 	name = "\improper slag"
 	desc = "Completely useless unless recycled."
 	icon_state = "slag"

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -144,7 +144,7 @@
 	melt_temperature = MELTPOINT_GLASS
 	starting_materials = list(MAT_PHAZON = CC_PER_SHEET_PHAZON)
 
-/obj/item/stack/ore/slag
+/obj/item/stack/ore/slag // this slag item is used for blacksmithing only - for slag as a result of items melting, see /obj/effect/decal/slag
 	name = "\improper slag"
 	desc = "Completely useless unless recycled."
 	icon_state = "slag"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Revives a feature disabled [9 years ago](https://github.com/vgstation-coders/vgstation13/commit/cd34a3eb07d1f77cbbbd22b2b01eca8ebd83d87c) which allows non-flammable items to melt into slag puddles. Slag puddles will be molten until the room cools below the melting temperature, after which you can destroy them then process the broken slag items in a recycler to restore the materials. Note that this implementation currently only affects objects so as to prevent engines breaking. Structures and turf melting can be implemented at a later time.

I am seeking input on this - please see the todo list below.

Todo:
- [ ] Reassess slag creation. The current method creates a generic slag puddle regardless of material and stores the materials inside. An alternative would be to make unique slag puddles for each material with unique sprites. This could result in certain slag puddles (such as plastic or wax) catching on fire and burning once the room gets even hotter.
- [ ] Reassess slag removal. The current method requires cooling the room enough to cool the slag puddle until it hardens, attacking the puddle with an item which does >= 15 damage, then bringing the remains to the recycler. An alternative method would be to simply weld the slag puddle for material sheets once it has cooled and hardened.
- [ ] Fix slag recycling - the previous implementation doesn't actually work. Slag items do not recycle and stacking more than one together clears the slag item's materials list.
- [ ] Add melt_temperature values to applicable items (might do this in a separate PR). Many items already have these values.

## Why it's good
<!-- Explain why you think these changes are good. -->
Expands the fire system while restoring an old feature. The previous iteration was disabled due to performance issues. As melting can use the system implemented in #35306, this new method results in minimal lag.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Non-flammable items can now melt if they get too hot. Destroy the cooled slag and throw the remains in a recycler to reclaim the materials.
