### PR TITLE
pAIs can now rescan their owner's health directly from the health analyzer UI instead of needing to go back to the Medical Package menu to rescan.

### DIFF
--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -471,8 +471,7 @@
 		dat += text("<BR>\n<A href='?src=\ref[];software=medicalsupplement;sub=0'>Back</A><BR>", src)
 	if(subscreen == 2)
 		dat += {"<h3>Medical Analysis Suite</h3><br>
-				 <h4>Host Bioscan</h4><br>
-				"}
+				 <h4>Host Bioscan</h4>"}
 		var/mob/living/M = loc
 		if(!istype(M, /mob/living))
 			while (!istype(M, /mob/living))
@@ -482,6 +481,7 @@
 					dat += "<a href='byond://?src=\ref[src];software=medicalsupplement;sub=0'>Return to Records</a><br>"
 					subscreen = 0
 					return dat
+				dat += "<a href='byond://?src=\ref[src];software=medicalsupplement;sub=2'>Update Scan</a><br>"
 				dat += healthanalyze(M, src, TRUE)
 		dat += "<br/><a href='byond://?src=\ref[src];software=medicalsupplement;sub=0'>Return to Records</a><br>"
 	return dat


### PR DESCRIPTION
## What this does
![image](https://github.com/vgstation-coders/vgstation13/assets/67024428/9c1866c2-60ca-4846-8036-0f5ee976a452)
Adds this button
## Why it's good
Quality of Life. Makes monitoring your owner's health less tedious.
[tested], does not break the UI or anything, works as intended
:cl:
 * rscadd: pAIs can now rescan their owner's health directly from the health scanner menu.