### PR TITLE
Restores Meson Goggle Protection when Turned Off

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -674,7 +674,7 @@ var/list/obj/machinery/singularity/white_hole_candidates
 		if(M.stat == CONSCIOUS)
 			if(istype(M,/mob/living/carbon/human))
 				var/mob/living/carbon/human/H = M
-				if(H.hasHUD(HUD_MESON) && current_size < 11)
+				if((H.hasHUD(HUD_MESON) || istype(H.glasses, /obj/item/clothing/glasses/scanner/meson)) && current_size < 11)
 					to_chat(H, "<span class='notice'>You stare directly into \the [src], good thing you had your protective eyewear on!</span>")
 					return
 				else

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -674,7 +674,7 @@ var/list/obj/machinery/singularity/white_hole_candidates
 		if(M.stat == CONSCIOUS)
 			if(istype(M,/mob/living/carbon/human))
 				var/mob/living/carbon/human/H = M
-				if((H.hasHUD(HUD_MESON) || istype(H.glasses, /obj/item/clothing/glasses/scanner/meson)) && current_size < 11)
+				if((H.hasHUD(HUD_MESON) || istype(H.glasses, /obj/item/clothing/glasses/scanner/meson) || istype(H.glasses, /obj/item/clothing/glasses/scanner/dual/chiefengineer)) && current_size < 11)
 					to_chat(H, "<span class='notice'>You stare directly into \the [src], good thing you had your protective eyewear on!</span>")
 					return
 				else

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -344,8 +344,9 @@
 	env.merge(removed)
 
 	for(var/mob/living/carbon/human/l in view(src, min(7, round(power ** 0.25)))) // If they can see it without mesons on.  Bad on them.
-		if(!l.hasHUD(HUD_MESON))
-			l.hallucination = max(0, min(200, l.hallucination + power * config_hallucination_power * sqrt( 1 / max(1,get_dist(l, src)) ) ) )
+		if(l.hasHUD(HUD_MESON) || istype(l.glasses, /obj/item/clothing/glasses/scanner/meson))
+			continue
+		l.hallucination = max(0, min(200, l.hallucination + power * config_hallucination_power * sqrt( 1 / max(1,get_dist(l, src)) ) ) )
 
 	for(var/mob/living/l in range(src, round((power / 100) ** 0.25)))
 		var/rads = (power / 50) * sqrt(1/(max(get_dist(l, src), 1)))

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -343,8 +343,8 @@
 
 	env.merge(removed)
 
-	for(var/mob/living/carbon/human/l in view(src, min(7, round(power ** 0.25)))) // If they can see it without mesons on.  Bad on them.
-		if(l.hasHUD(HUD_MESON) || istype(l.glasses, /obj/item/clothing/glasses/scanner/meson))
+	for(var/mob/living/carbon/human/l in view(src, min(7, round(power ** 0.25)))) // If they can see it without s on.  Bad on them.
+		if(l.hasHUD(HUD_MESON) || istype(l.glasses, /obj/item/clothing/glasses/scanner/meson) || istype(l.glasses, /obj/item/clothing/glasses/scanner/dual/chiefengineer))
 			continue
 		l.hallucination = max(0, min(200, l.hallucination + power * config_hallucination_power * sqrt( 1 / max(1,get_dist(l, src)) ) ) )
 


### PR DESCRIPTION
At least two people have mentioned this to me so now it's time to make a PR to fix it.

## What this does
Currently, due to sneakycode in #35633 ( :cold_sweat: ), mesons no longer give protection against supermatter hallucinations or singularity stun on examine when the goggles are turned off. They must be on. This PR restores the ability for meson goggles to protect against these effects even while off.
Formally Closes #35908. 

## Why it's good
I don't think it makes sense, having goggles that proect you even when they're off... but it's a quality of life for engineers who hate how mesons make the game look.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Restored mesons ability to protect against hallucinations while turned off.
