### PR TITLE
Removes mice as cargo technicians

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -416,6 +416,9 @@
 	visible_message("<span class = 'warning'>\The [src] explodes!</span>")
 	gib()
 
+/mob/living/simple_animal/mouse/canMouseDrag()
+	return FALSE
+
 /*
  * Common mouse types
  */


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Mice can no longer mouse-drop items, meaning they can no longer drag crates into disposal bins or do any other task that requires mouse-dropping.

## Why it's good
<!-- Explain why you think these changes are good. -->
Closes #28774.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Mice can no longer drag crates into disposal bins.
