### PR TITLE
Fixes changing status displays from the comms console

### DIFF
--- a/nano/templates/comm_console.tmpl
+++ b/nano/templates/comm_console.tmpl
@@ -100,13 +100,13 @@ Used In File(s): /code/game/machinery/computers/communications.dm
 		<h3>Presets</h3>
 		{{for data.stat_display.presets}}
 			<div class="line">
-				<div class="statusLabel">{{:helper.link(value.label,'info',{'operation':'setstat','statdisp':name},null,(name==data.stat_display.type?'linkOn':''))}}</div>
+				<div class="statusLabel">{{:helper.link(value.label,'info',{'operation':'setstat','statdisp':value.name},null,(value.name==data.stat_display.type?'linkOn':''))}}</div>
 			</div>
 		{{/for}}
 		<h3>Alerts</h3>
 		{{for data.stat_display.alerts}}
 			<div class="line">
-				<div class="statusLabel">{{:helper.link(value.label,'alert',{'operation':'setstat','statdisp':'alert','alert':alert},null,(name==data.stat_display.type?'linkOn':''))}}</div>
+				<div class="statusLabel">{{:helper.link(value.label,'alert',{'operation':'setstat','statdisp':'alert','alert':value.alert},null,(value.alert==data.stat_display.type?'linkOn':''))}}</div>
 			</div>
 		{{/for}}
 		<h3>Messages</h3>


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Restores the "set status display" functionality on the Communications Consoles. #2174 broke this feature nearly 10 years ago and it took 5 years for the first bug report on it to be posted!

## Why it's good
<!-- Explain why you think these changes are good. -->
Closes #28870 and closes #25127.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Changing status displays from comms consoles now works as intended.