### PR TITLE
Better Soup

### DIFF
--- a/code/modules/reagents/reagents/reagents_medical.dm
+++ b/code/modules/reagents/reagents/reagents_medical.dm
@@ -176,7 +176,7 @@
 	density = 0.63
 	specheatcap = 4.21
 	data = list(
-		"threshold" = 10,
+		"threshold" = 35,
 		)
 
 /datum/reagent/antipathogenic/tomato_soup/on_mob_life(var/mob/living/M)

--- a/code/modules/reagents/reagents/reagents_medical.dm
+++ b/code/modules/reagents/reagents/reagents_medical.dm
@@ -175,6 +175,7 @@
 	color = "#731008" //rgb: 115, 16, 8
 	density = 0.63
 	specheatcap = 4.21
+	custom_metabolism = REAGENTS_METABOLISM
 	data = list(
 		"threshold" = 35,
 		)


### PR DESCRIPTION
Tomato soup you expect to cure weak diseases, but it only cures up to 10 robustness. Can you name a time you've EVER seen a virus with strength 10 or less? This PR buffs that.

🆑 
* tweak: Tomato soup now cures up to 35 robustness diseases, and also doesn't sit in your system for an hour.