### PR TITLE
Feverfew Fix

### DIFF
--- a/code/modules/reagents/reagents/reagents_medical.dm
+++ b/code/modules/reagents/reagents/reagents_medical.dm
@@ -158,6 +158,7 @@
 	id = FEVERFEW
 	description = "Feverfew is a natural anticoagulant useful in fending off viruses, but it leaves one vulnerable to pain and bleeding."
 	color = "#b5651d"
+	custom_metabolism = 0.2
 	pain_resistance = -25
 	data = list ("threshold" = 80)
 


### PR DESCRIPTION
## What this does
Increases the metabolism of Feverfew to 0.2 up from 0.01. A prick from a cactus will only cause brute damage for about 30 seconds instead of 10 minutes.

## Why it's good
Prevents cacti from killing you due to a single prick.
[bugfix]
## Changelog
:cl:
 * bugfix: Corrects Feverfew's metabolism rate.
