### PR TITLE
disarm intent as an alternative to alt-middleclick

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -428,6 +428,12 @@ var/global/objects_thrown_when_explode = FALSE
 			return
 		//user.next_move = max(user.next_move+2,world.time + 2)
 	add_fingerprint(user)
+	
+	if(src.on_fire)
+		if(user.a_intent && user.a_intent == I_DISARM)
+			extinguish_with_hands(user)
+			return //don't pick it up immediately, you have to click it again after it's extinguished
+	
 	if(can_pickup(user) && !user.put_in_active_hand(src))
 		forceMove(get_turf(user))
 
@@ -1778,6 +1784,9 @@ var/global/list/image/blood_overlays = list()
 		. = max(. , 0.5) //Even if it's perfectly insulating, if it's open then some heat can be exchanged.
 
 /obj/item/MiddleAltClick(var/mob/user)
+	extinguish_with_hands(user)
+
+/obj/item/proc/extinguish_with_hands(var/mob/user)
 	if(!isliving(user))
 		return
 	if(src.on_fire)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -429,7 +429,7 @@ var/global/objects_thrown_when_explode = FALSE
 		//user.next_move = max(user.next_move+2,world.time + 2)
 	add_fingerprint(user)
 	
-	if(src.on_fire)
+	if(on_fire)
 		if(user.a_intent && user.a_intent == I_DISARM)
 			extinguish_with_hands(user)
 			return //don't pick it up immediately, you have to click it again after it's extinguished
@@ -440,7 +440,7 @@ var/global/objects_thrown_when_explode = FALSE
 	//transfers diseases between the mob and the item
 	disease_contact(user)
 
-	if(src.on_fire)
+	if(on_fire)
 		var/mob/living/L = user
 		L.visible_message("<span class='warning'>\The [src] burns [L]'s hands!</span>", "<span class='warning'>Your hands are burned by \the [src]!</span>")
 		L.drop_item(src, force_drop = 1)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
lets you extinguish stuff by using disarm intent as well as the old alt-middleclick

## Why it's good
less esoteric hotkeys... good? FEWER

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: disarm intent will now also extinguish burning items