### PR TITLE
Fixes condiment bottle inconsistencies

### DIFF
--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -83,7 +83,10 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 			manipcount += SP.rating-1
 		if(istype(SP, /obj/item/weapon/stock_parts/micro_laser))
 			lasercount += SP.rating-1
-	max_bottle_size = initial(max_bottle_size) + lasercount*5
+	if(!condi) //everything except the condimaster
+		max_bottle_size = initial(max_bottle_size) + lasercount*5
+	else
+		max_bottle_size = initial(max_bottle_size) + lasercount*12.5
 	max_pill_count = initial(max_pill_count) + manipcount*5
 	max_pill_size = initial(max_pill_size) + manipcount*25
 

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -813,6 +813,7 @@ var/global/list/pillIcon2Name = list("oblong purple-pink", "oblong green-white",
 	chem_board = /obj/item/weapon/circuitboard/condimaster
 	windowtype = "condi_master"
 	moody_state = "overlay_condimaster"
+	max_bottle_size = 50
 
 /obj/machinery/chem_master/electrolytic
 	name = "\improper Electrolytic ChemMaster"

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -599,7 +599,7 @@
 
 /obj/item/weapon/reagent_containers/food/condiment/exotic/New()
 	..()
-	reagents.add_reagent(pickweight(possible_exotic_condiments), 30)
+	reagents.add_reagent(pickweight(possible_exotic_condiments), 50)
 
 /obj/item/weapon/reagent_containers/food/condiment/coco
 	name = "cocoa powder"


### PR DESCRIPTION
## What this does
All of the spawned bottles, be them adminspawned, mapped (like the salt shaker, universal enzyme bottle, pepper mill, etc), bought from a vendor (malt vinegar, salt and pepper shakers, discount dan's bottle, etc) or bought from the supply crates have a max volume of 50u, and contain 50u of reagents. Even the empty condiment bottles from the condiment bottle boxes have a max volume of 50u.
However, the condimaster only makes 30u bottles. And while the crates of condiment bottles have a 50u capacity, they only contain 30u of condiment. 
This fixes that inconsistency so the condiment crate bottles are filled with 50u, and lets the condimaster make 50u bottles. Closes #35910
## Why it's good
[consistency] is good, fixes a major disparity between the bottles that are spawned in, made in the condimaster and purchased.
:cl:
 * tweak: Condimasters can now make 50u condiment bottles, to match the capacity of all other condiment bottles in the game.
 * tweak: Condiment bottles from the Exotic Garnish crate now have 50u of condiment inside them, to match the contents of all other (filled) condiment bottles in the game.
 * tweak: The condimaster can produce 100u volume bottles when upgraded with ultra-high power micro-lasers.