### PR TITLE
Fixes the specific heat capacity of Radium and all the reagents made from it being 1000x higher than meant to

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -6,6 +6,8 @@
 
 	Are you adding a toxic reagent? Remember to update bees_apiary.dm 's lists of toxic reagents accordingly.
 
+	REGARDING SPECHEATCAP, IF YOU'RE NOT SURE JUST KEEP IT AT WATER'S OR AT 1. IF YOU GET SOMETHING IN THE HUNDREDS OR HIGHER YOU'RE PROBABLY DOING SOMETHING VERY WRONG
+
 	It is very common to use REAGENTS_METABOLISM (0.2) or REM / REGEANTS_EFFECT_MULTIPLIER (0.5) in the reagent files.
 
 */

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -6,17 +6,7 @@
 
 	Are you adding a toxic reagent? Remember to update bees_apiary.dm 's lists of toxic reagents accordingly.
 
-	Not sure what to have your density and SHC as? No IRL equivalent you can google? Use the components of the reagent
-		density = (for(components of recipe) total_mass += component density* component volume)/volume of result. E.G
-			6 SALINE = 3 SODIUMCHLORIDE, 5 WATER, 1 AMMONIA
-				density = ((1 + (2.09*3) + (1*5) + (0.51*1))/6) = 2.22 (rounded to 2dp)
-
-		SHC = (for(components of recipe) total_SHC *= component SHC)
-
-
-	NO DON'T DO THAT, IF YOU'RE NOT SURE JUST KEEP IT AT WATER'S. IF YOU GET SOMETHING ABOVE 10 LET ALONE IN THE HUNDREDS YOU'RE PROBABLY DOING SOMETHING VERY WRONG
-
-	It is very common to use REAGENTS_METABOLISM (0.2) or REM / REGEANTS_EFFECT_MULTIPLIER (0.5) in this file.
+	It is very common to use REAGENTS_METABOLISM (0.2) or REM / REGEANTS_EFFECT_MULTIPLIER (0.5) in the reagent files.
 
 */
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3885,7 +3885,7 @@
 	id = DEGENERATECALCIUM
 	result = DEGENERATECALCIUM
 	required_reagents = list(MILK = 1, MUTAGEN = 1)
-	required_temp = T0C + 88 //Mutagen is very hard to heat up, so I don't recommend making more than 10u of this at a time
+	required_temp = T0C + 88
 	result_amount = 1
 
 /datum/chemical_reaction/ironrot

--- a/code/modules/reagents/reagents/reagents_basic.dm
+++ b/code/modules/reagents/reagents/reagents_basic.dm
@@ -167,7 +167,7 @@
 	reagent_state = REAGENT_STATE_SOLID
 	color = COLOR_RADIUM//"#61F09A" //rgb: 101, 242, 156
 	density = 5
-	specheatcap = 94
+	specheatcap = 0.094
 	flags = CHEMFLAG_PIGMENT
 	paint_light = PAINTLIGHT_LIMITED
 

--- a/code/modules/reagents/reagents/reagents_drink.dm
+++ b/code/modules/reagents/reagents/reagents_drink.dm
@@ -535,7 +535,7 @@
 	color = "#100800" //rgb: 16, 8, 0
 	adj_sleepy = -2
 	density = 4.17
-	specheatcap = 124
+	specheatcap = 1.24
 	glass_icon_state = "nuka_colaglass"
 	glass_name = "\improper Nuka Cola"
 	glass_desc = "Don't cry. Don't raise your eye. It's only nuclear wasteland."

--- a/code/modules/reagents/reagents/reagents_drug.dm
+++ b/code/modules/reagents/reagents/reagents_drug.dm
@@ -29,7 +29,7 @@
 	var/has_mouse_bulked = 0
 	custom_metabolism = 0.1
 	density = 6.82
-	specheatcap = 678.67
+	specheatcap = 0.67867
 
 /datum/reagent/creatine/reagent_deleted()
 	if(..())

--- a/code/modules/reagents/reagents/reagents_food.dm
+++ b/code/modules/reagents/reagents/reagents_food.dm
@@ -374,7 +374,7 @@
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#365E30" //rgb: 54, 94, 48
 	density = 9.68
-	specheatcap = 101.01
+	specheatcap = 1.0101
 
 /datum/reagent/fishbleach
 	name = "Fish Bleach"

--- a/code/modules/reagents/reagents/reagents_material.dm
+++ b/code/modules/reagents/reagents/reagents_material.dm
@@ -140,7 +140,7 @@
 	reagent_state = REAGENT_STATE_SOLID
 	color = "#B8B8C0" //rgb: 184, 184, 192
 	density = 19.05
-	specheatcap = 124
+	specheatcap = 0.124
 
 /datum/reagent/uranium/on_mob_life(var/mob/living/M)
 	if(..())

--- a/code/modules/reagents/reagents/reagents_medical.dm
+++ b/code/modules/reagents/reagents/reagents_medical.dm
@@ -338,7 +338,7 @@
 	custom_metabolism = 0.05
 	overdose_am = REAGENTS_OVERDOSE
 	density = 1.67
-	specheatcap = 721.98
+	specheatcap = 0.72198
 
 /datum/reagent/arithrazine/on_mob_life(var/mob/living/M)
 	if(..())
@@ -512,7 +512,7 @@ var/global/list/charcoal_doesnt_remove=list(
 	var/has_been_armstrong = 0
 	var/armstronged_at = 0 //world.time
 	density = 134.21
-	specheatcap = 5143.18
+	specheatcap = 5.14318
 
 /datum/reagent/comnanobots/reagent_deleted()
 	if(..())
@@ -617,7 +617,7 @@ var/global/list/charcoal_doesnt_remove=list(
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#ccffb3" //rgb: 204, 255, 179
 	density = 3.9
-	specheatcap = 128.12
+	specheatcap = 0.12812
 	custom_metabolism = 0.1
 
 /datum/reagent/degeneratecalcium/on_mob_life(var/mob/living/M)
@@ -782,7 +782,7 @@ var/global/list/charcoal_doesnt_remove=list(
 	custom_metabolism = 0.05
 	overdose_am = REAGENTS_OVERDOSE
 	density = 3.25
-	specheatcap = 52.20
+	specheatcap = 0.5220
 
 /datum/reagent/hyronalin/on_mob_life(var/mob/living/M)
 	if(..())
@@ -962,7 +962,7 @@ var/global/list/charcoal_doesnt_remove=list(
 	color = "#C0C0C0"
 	custom_metabolism = 0.2
 	density = 4.92
-	specheatcap = 150.53
+	specheatcap = 0.15053
 
 //The anti-nutriment
 /datum/reagent/lipozine
@@ -973,7 +973,7 @@ var/global/list/charcoal_doesnt_remove=list(
 	nutriment_factor = -10 * REAGENTS_METABOLISM
 	color = "#BBEDA4" //rgb: 187, 237, 164
 	density = 2.63
-	specheatcap = 381.13
+	specheatcap = 0.38113
 
 /datum/reagent/lipozine/on_mob_life(var/mob/living/M)
 	if(..())
@@ -994,7 +994,7 @@ var/global/list/charcoal_doesnt_remove=list(
 	var/spawning_horror = 0
 	var/percent_machine = 0
 	density = 96.64
-	specheatcap = 199.99
+	specheatcap = 0.19999
 
 /datum/reagent/mednanobots/on_mob_life(var/mob/living/M)
 	if(..())
@@ -1081,7 +1081,7 @@ var/global/list/charcoal_doesnt_remove=list(
 	custom_metabolism = 0.03
 	overdose_am = REAGENTS_OVERDOSE/2
 	density = 4.09
-	specheatcap = 45.59
+	specheatcap = 4.559
 
 /datum/reagent/methylin/on_mob_life(var/mob/living/M)
 	if(..())
@@ -1102,7 +1102,7 @@ var/global/list/charcoal_doesnt_remove=list(
 	dupeable = FALSE
 	color = "#3E3959" //rgb: 62, 57, 89
 	density = 236.6
-	specheatcap = 199.99
+	specheatcap = 0.19999
 
 /datum/reagent/oxycodone
 	name = "Oxycodone"
@@ -1240,7 +1240,7 @@ var/global/list/charcoal_doesnt_remove=list(
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#1A1A1A" //rgb: 26, 26, 26
 	density = 2.46
-	specheatcap = 12439.3 //Good fucking luck
+	specheatcap = 0.124393
 
 /datum/reagent/phalanximine/on_mob_life(var/mob/living/M)
 	if(..())
@@ -1382,7 +1382,7 @@ var/global/list/charcoal_doesnt_remove=list(
 	color = "#C8A5DC" //rgb: 200, 165, 220
 	overdose_am = REAGENTS_OVERDOSE
 	density = 1.97
-	specheatcap = 512.61
+	specheatcap = 0.51261
 
 /datum/reagent/ryetalyn/on_mob_life(var/mob/living/M)
 	if(..())

--- a/code/modules/reagents/reagents/reagents_misc.dm
+++ b/code/modules/reagents/reagents/reagents_misc.dm
@@ -39,7 +39,7 @@
 	var/light_intensity = 4
 	var/initial_color = null
 	density = 3.46
-	specheatcap = 512.3
+	specheatcap = 0.5123
 	flags = CHEMFLAG_PIGMENT
 	paint_light = PAINTLIGHT_LIMITED
 

--- a/code/modules/reagents/reagents/reagents_reactive.dm
+++ b/code/modules/reagents/reagents/reagents_reactive.dm
@@ -7,7 +7,7 @@
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#634848" //rgb: 99, 72, 72
 	density = 13.49 //our ingredients are pretty dense
-	specheatcap = 208.4
+	specheatcap = 0.2084
 	custom_metabolism = 0.01 //oh shit what are you doin
 
 /datum/reagent/aminomician
@@ -17,7 +17,7 @@
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#634848" //rgb: 99, 72, 72
 	density = 13.49 //our ingredients are pretty dense
-	specheatcap = 208.4
+	specheatcap = 0.2084
 	custom_metabolism = 0.01 //oh shit what are you doin
 
 /datum/reagent/aminocyprinidol
@@ -26,7 +26,7 @@
 	description = "An extremely dangerous, flesh-replicating material, mutated by exposure to God-knows-what. Do not mix with nutriment under any circumstances."
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#cb42f4" //rgb: 203, 66, 244
-	density = 111.75 //our ingredients are extremely dense, especially carppheromones
+	density = 0.11175 //our ingredients are extremely dense, especially carppheromones
 	specheatcap = ARBITRARILY_LARGE_NUMBER //Is partly made out of leporazine, so you're not heating this up.
 	custom_metabolism = 0.01 //oh shit what are you doin
 
@@ -37,7 +37,7 @@
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#634848" //rgb: 99, 72, 72
 	density = 15.49 //our ingredients are pretty dense
-	specheatcap = 208.4
+	specheatcap = 0.2084
 	custom_metabolism = 0.01 //oh shit what are you doin
 
 //Foam precursor

--- a/code/modules/reagents/reagents/reagents_toxin.dm
+++ b/code/modules/reagents/reagents/reagents_toxin.dm
@@ -412,7 +412,7 @@
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#13BC5E" //rgb: 19, 188, 94
 	density = 3.35
-	specheatcap = 96.86
+	specheatcap = 0.09686
 
 /datum/reagent/mutagen/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume, var/list/zone_sels = ALL_LIMBS)
 	if(..())


### PR DESCRIPTION
also uranium technically.

Fixes #34075

:cl:
* bugfix: Fixed the specific heat capacity of radium being 1000 higher than it should, resulting in those of mutagen and dozens of other reagents that are made from those also having ridiculously high specific heat capacities, and consequently being a pain in the ass to heat up. TLDR, you can now boil mutagen in a bunsen burner.