### PR TITLE
Fixes some effects of Deaf-Mute runes affecting silicons forever

### DIFF
--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -160,6 +160,10 @@
 		return
 	if(stunned > 0)
 		stunned -= 1
+	if(say_mute)
+		say_mute = max(say_mute-1, 0)
+	if(ear_deaf)
+		ear_deaf = max(ear_deaf-1, 0)
 
 	if(ai_flags & COREFORTIFY)
 		brute_damage_modifier = 0.33

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -111,6 +111,8 @@
 		ear_damage = max(ear_damage-0.05, 0)
 	if((sdisabilities & DEAF))
 		ear_deaf = TRUE
+	if(say_mute)
+		say_mute = max(say_mute-1, 0)
 
 	if(eye_blurry)
 		eye_blurry = max(eye_blurry-1,0)


### PR DESCRIPTION
Fixes #21363

:cl:
* bugfix: Fixed Deaf-Mute runes muting silicons forever and deafening AIs forever.