### PR TITLE
Cult Conversion rune now properly removes any pre-existing cuffs before applying cult cuffs

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -1120,6 +1120,11 @@ var/list/converted_minds = list()
 				if (isalien(victim))
 					victim.Paralyse(8)
 
+				//let's start by removing any cuffs they might already have
+				if (victim.handcuffed)
+					var/obj/item/weapon/handcuffs/cuffs = victim.handcuffed
+					victim.u_equip(cuffs)
+
 				var/obj/item/weapon/handcuffs/cult/restraints = new(victim)
 				victim.handcuffed = restraints
 				restraints.on_restraint_apply(victim)//a jolt of pain to slow them down


### PR DESCRIPTION
Fixes #35934

:cl:
* bugfix: Cult Conversion rune now properly removes any pre-existing cuffs before applying cult cuffs.