### PR TITLE
Magic is stored in the ass

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -92,6 +92,12 @@
 	if(user.is_blind())
 		to_chat(user, "<span class='info'>You open \the [src] and run your fingers across the parchment. Suddenly, the pages coalesce in your mind!</span>")
 
+	if(istype(user,/mob/living/carbon))
+		var/mob/living/carbon/C = user
+		if(C.op_stage.butt == SURGERY_NO_BUTT)
+			to_chat(user, "<span class='info'>You are missing your ass! It would be pointless to attempt to learn magic without an ass to store it in.</span>")
+			return
+
 	user.set_machine(src)
 
 	var/dat

--- a/code/game/gamemodes/wizard/spellbook_oneuse.dm
+++ b/code/game/gamemodes/wizard/spellbook_oneuse.dm
@@ -18,6 +18,11 @@
 	name += spellname
 
 /obj/item/weapon/spellbook/oneuse/attack_self(mob/user)
+	if(istype(user,/mob/living/carbon))
+		var/mob/living/carbon/C = user
+		if(C.op_stage.butt == SURGERY_NO_BUTT)
+			to_chat(user, "<span class='info'>You are missing your ass! It would be pointless to attempt to learn magic without an ass to store it in.</span>")
+			return
 	var/spell/S = new spell(user)
 	for(var/spell/knownspell in user.spell_list)
 		if(knownspell.type == S.type)
@@ -360,15 +365,8 @@
 
 /obj/item/weapon/spellbook/oneuse/buttbot/recoil(mob/living/carbon/user as mob)
 	if(istype(user, /mob/living/carbon/human))
-		var/mob/living/carbon/C = user
-		if(C.op_stage.butt != 4)
-			var/obj/item/clothing/head/butt/B = new(C.loc)
-			B.transfer_buttdentity(C)
-			C.op_stage.butt = 4
-			to_chat(user, "<span class='warning'>Your ass just blew up!</span>")
-		playsound(src, 'sound/effects/superfart.ogg', 50, 1)
-		C.apply_damage(40, BRUTE, LIMB_GROIN)
-		C.apply_damage(10, BURN, LIMB_GROIN)
+		var/mob/living/carbon/human/H = user
+		H.butt_blast()
 		qdel(src)
 
 /obj/item/weapon/spellbook/oneuse/lightning

--- a/code/game/machinery/bots/buttbot.dm
+++ b/code/game/machinery/bots/buttbot.dm
@@ -22,6 +22,8 @@ Here it is: Buttbot.
 	var/sincelastfart = 0
 	flags = HEAR
 
+	var/obj/item/clothing/head/butt/stored_ass
+
 /obj/machinery/bot/buttbot/attack_hand(mob/living/user as mob)
 	. = ..()
 	if (.)
@@ -60,7 +62,7 @@ Here it is: Buttbot.
 	src.visible_message("<span class='danger'>[src] blows apart!</span>", 1)
 	playsound(src, 'sound/effects/superfart.ogg', 50, 1) //A fitting end
 	var/turf/Tsec = get_turf(src)
-	new /obj/item/clothing/head/butt(Tsec)
+	stored_ass.forceMove(Tsec)
 
 	if (prob(50))
 		new /obj/item/robot_parts/l_arm(Tsec)
@@ -79,9 +81,9 @@ Here it is: Buttbot.
 		var/obj/machinery/bot/buttbot/A = new /obj/machinery/bot/buttbot(T)
 		A.name = src.created_name
 		to_chat(user, "<span class='notice'>You roughly shove the robot arm into the ass! Butt Butt!</span>")//I don't even.
-
 		user.drop_from_inventory(src)
-		qdel(src)
+		A.stored_ass = src
+		src.forceMove(A)
 	else if (istype(W, /obj/item/weapon/pen))
 		var/t = stripped_input(user, "Enter new robot name", src.name, src.created_name)
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1377,12 +1377,12 @@
 			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Cluwne;jobban4=\ref[M]'><font color=red>Cluwne</font></a></td>"
 		else
 			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Cluwne;jobban4=\ref[M]'>Cluwne</a></td>"
-		
+
 		if(jobban_isbanned(M, "artist")) //so people can't make paintings
 			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=artist;jobban4=\ref[M]'><font color=red>Artist</font></a></td>"
 		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=artist;jobban4=\ref[M]'>Artist</a></td>"	
-		
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=artist;jobban4=\ref[M]'>Artist</a></td>"
+
 		jobs += "</tr></table>"
 
 		body = "<body>[jobs]</body>"
@@ -2926,15 +2926,10 @@
 			return
 
 		if(H.op_stage.butt != 4) // does the target have an ass
-			var/obj/item/clothing/head/butt/B = new(H.loc)
-			B.transfer_buttdentity(H)
-			H.op_stage.butt = 4 //No having two butts.
+			H.butt_blast()
 			to_chat(H, "<span class='warning'>Your ass was just blown off by an unknown force!</span>")
 			log_admin("[key_name(H)] was buttblasted by [src.owner]")
 			message_admins("[key_name(H)] was buttblasted by [src.owner]")
-			playsound(H, 'sound/effects/superfart.ogg', 50, 1)
-			H.apply_damage(40, BRUTE, LIMB_GROIN)
-			H.apply_damage(10, BURN, LIMB_GROIN)
 			H.Knockdown(8)
 			H.Stun(8)
 		else

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -279,6 +279,8 @@
 	var/s_tone = 0.0
 	var/created_name = "Buttbot"
 
+	var/list/spells = list()
+
 /obj/item/clothing/head/butt/proc/transfer_buttdentity(var/mob/living/carbon/H)
 	name = "[H.real_name]'s butt"
 	return

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -53,7 +53,7 @@
 				to_chat(user, "<span class='deadsay'>It seems particularly lifeless, but not yet gone. Perhaps it will regain some of its luster later...</span>")
 				return
 		to_chat(user, "<span class='deadsay'>This one seems unresponsive.</span>")// Should probably make this more realistic, but this message ties it in with MMI errors.
-		if(!brainmob.mind)  
+		if(!brainmob.mind)
 			to_chat(user, "<span class='deadsay'>It shows no signs of sentience.</span>") //monkeyman or NPC
 		return
 
@@ -62,6 +62,8 @@
 	..()
 
 	var/mob/living/carbon/human/H = target
+	for(var/spell/spell in H.mind.wizard_spells)
+		H.remove_spell(spell)
 	H.dropBorers()
 	var/obj/item/organ/internal/brain/B = src
 	if(istype(B) && istype(H))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2204,11 +2204,25 @@
 	if(wear_suit && wear_suit.get_cell())
 		return wear_suit.get_cell()
 
+/mob/living/carbon/human/proc/butt_blast()
+	var/mob/living/carbon/C = src
+	if(C.op_stage.butt != SURGERY_NO_BUTT)
+		if(remove_butt())
+			to_chat(src, "<span class='warning'>Your ass just blew up!</span>")
+	playsound(src, 'sound/effects/superfart.ogg', 50, 1)
+	C.apply_damage(40, BRUTE, LIMB_GROIN)
+	C.apply_damage(10, BURN, LIMB_GROIN)
+	score.assesblasted++
+
 // Returns null on failure, the butt on success.
 /mob/living/carbon/human/proc/remove_butt(var/where = loc)
 	if(op_stage.butt == SURGERY_NO_BUTT)
 		return
 	var/obj/item/clothing/head/butt/donkey = new(where)
+	if(mind.wizard_spells)
+		donkey.spells.Add(mind.wizard_spells)
+		for(var/spell/spell in mind.wizard_spells)
+			remove_spell(spell)
 	donkey.transfer_buttdentity(src)
 	op_stage.butt = SURGERY_NO_BUTT
 	return donkey

--- a/code/modules/spells/targeted/buttbots_revenge.dm
+++ b/code/modules/spells/targeted/buttbots_revenge.dm
@@ -27,20 +27,15 @@
 /spell/targeted/buttbots_revenge/cast(var/list/targets)
 	..()
 	for(var/mob/living/target in targets)
-		if(ishuman(target) || ismonkey(target))
-			var/mob/living/carbon/C = target
-			if(C.op_stage.butt != 4) // does the target have an ass
-				if(summon_bot)
-					new /obj/machinery/bot/buttbot(C.loc)
-				else
-					var/obj/item/clothing/head/butt/B = new(C.loc)
-					B.transfer_buttdentity(C)
-				C.op_stage.butt = 4 //No having two butts.
-				to_chat(C, "<span class='warning'>Your ass just blew up!</span>")
-			playsound(src, 'sound/effects/superfart.ogg', 50, 1)
-			C.apply_damage(40, BRUTE, LIMB_GROIN)
-			C.apply_damage(10, BURN, LIMB_GROIN)
-			score.assesblasted++
+		if(ishuman(target))
+			var/mob/living/carbon/human/H = target
+			H.butt_blast()
+			if(summon_bot)
+				var/obj/machinery/bot/buttbot/assbot = new /obj/machinery/bot/buttbot(H.loc)
+				for(var/obj/item/clothing/head/butt/B in H.loc)
+					assbot.stored_ass = B
+					B.forceMove(assbot)
+					break
 	return
 
 /spell/targeted/buttbots_revenge/empower_spell()

--- a/code/modules/surgery/butt.dm
+++ b/code/modules/surgery/butt.dm
@@ -291,6 +291,9 @@
 	affected.status |= ORGAN_BLEEDING
 
 	var/obj/item/clothing/head/butt/B = tool
+	if(B.spells)
+		for(var/spell/spell in B.spells)
+			target.add_spell(spell, iswizard = TRUE)
 	user.u_equip(B,1)
 	qdel(B)
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Wizard spells are now stored in the ass. To remove a wizard's spells, simply remove its ass. Applying the magical ass to someone will give them the spells stored in the ass.

## Why it's good
<!-- Explain why you think these changes are good. -->
Offers the crew a new way to eliminate the threat a wizard poses without having to kill the wizard.
Closes #29280.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Wizard spells are now stored in the ass - remove a wizard's ass to remove its magic.
