### PR TITLE
MotD for all +SERVER Admins

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1495,7 +1495,7 @@ var/obj/blend_test = null
 	set name = "Edit MotD"
 	set desc = "Appears to players upon lobby entry."
 
-	if(!check_rights(R_PERMISSIONS))
+	if(!check_rights(R_SERVER))
 		return
 	if(alert("You are about to edit the MotD, which is displayed to anyone who enters the lobby. All changes persist across rounds. Continue?", "Warning", "Yes", "Cancel") == "Cancel")
 		return


### PR DESCRIPTION
This is really Pomf's decision since he was the one who wanted MotD be to headmin only. However, this new permission limit is consistent with the hub panel. If we can trust people with that, surely we can trust people to not blank the MOTD?

@d3athrow 

No CL for admin change