### PR TITLE
Extinguisher cabinets now refill extinguishers

### DIFF
--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -28,6 +28,11 @@
 			if(user.drop_item(O, src))
 				has_extinguisher = O
 				to_chat(user, "<span class='notice'>You place [O] in [src].</span>")
+				if(!O.reagents.is_full())
+					var/avail_vol = O.reagents.maximum_volume - O.reagents.total_volume
+					O.reagents.add_reagent(WATER, avail_vol)
+					playsound(src, 'sound/effects/refill.ogg', 50, 1)
+					to_chat(user, "<span class='notice'>\The [src] refills \the [O] using its internal water supply.</span>")
 		else
 			opened = !opened
 	else if(iswelder(O))


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fire extinguisher cabinets will now refill non-full extinguishers when they are placed back into the cabinet.

## Why it's good
<!-- Explain why you think these changes are good. -->
Water tanks aren't always within reach of a fire, whereas extinguisher cabinets are plentiful. This gives people fighting fires easier access to a refill.

Closes #35953.
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:.
 * tweak: Fire extinguisher cabinets now refill fire extinguishers.
