### PR TITLE
Removes fires resulting from explosions

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -101,14 +101,14 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 						src.break_tile_to_plating()
 					else
 						src.break_tile()
-					src.hotspot_expose(1000,CELL_VOLUME,surfaces=1)
+					src.hotspot_expose(500,CELL_VOLUME,surfaces=1)
 					if(prob(33))
 						var/obj/item/stack/sheet/metal/M = new /obj/item/stack/sheet/metal(get_turf(src))
 						M.amount = 1
 		if(3.0)
 			if (prob(50))
 				src.break_tile()
-				src.hotspot_expose(1000,CELL_VOLUME,surfaces=1)
+				src.hotspot_expose(500,CELL_VOLUME,surfaces=1)
 	return
 
 /turf/simulated/floor/blob_act()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Reduces hotspot exposure on tiles due to explosions from 1000K to 500K. This value is below all autoignition values, so rooms will no longer be set on fire by explosions.

## Why it's good
<!-- Explain why you think these changes are good. -->
Less conflagrations due to small explosions.

Closes #35978

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Explosions will no longer ignite entire rooms.
