### PR TITLE
Additional HUD Fixes

### DIFF
--- a/code/datums/hud/job_hud.dm
+++ b/code/datums/hud/job_hud.dm
@@ -41,7 +41,7 @@
 		else
 			holder = perp.hud_list[ID_HUD + "_shifted"]
 			if(!istype(holder, /image/hud))
-				perp.hud_list[ID_HUD + "_shifted"] = new/image/hud('icons/mob/hud.dmi', M, "hudblank")
+				perp.hud_list[ID_HUD + "_shifted"] = new/image/hud('icons/mob/hud.dmi', perp, "hudblank")
 				holder = perp.hud_list[ID_HUD + "_shifted"]
 				holder.pixel_y = offset
 		if(!holder)

--- a/code/modules/reagents/reagents/reagents_ethanol.dm
+++ b/code/modules/reagents/reagents/reagents_ethanol.dm
@@ -383,10 +383,10 @@
 				if(istype(M.current.loc,/obj/mecha))
 					imageloc = M.current.loc
 					imagelocB = M.current.loc
-				var/image/I = new/image/hud('icons/mob/HUD.dmi', loc = imageloc, icon_state = "metaclub")
+				var/image/I = image('icons/mob/HUD.dmi', loc = imageloc, icon_state = "metaclub")
 				I.plane = ANTAG_HUD_PLANE
 				M.current.client.images += I
-				var/image/J = new/image/hud('icons/mob/HUD.dmi', loc = imagelocB, icon_state = "metaclub")
+				var/image/J = image('icons/mob/HUD.dmi', loc = imagelocB, icon_state = "metaclub")
 				J.plane = ANTAG_HUD_PLANE
 				new_buddy.current.client.images += J
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
Fix for the brig medic HUDs showing everyone else's job on yourself, and a fix for metabuddy working for a single tick on yourself and then never working ever again. Fixes #35970. Fixes #35968.

## Why it's good
Metagang can rise up again. And less cursed brig medic HUDs.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Metabuddy works again!
 * bugfix: Brig Medic HUD no longer claims you work every job around you.

[bugfix] [ui]