### PR TITLE
SMES units will now show the correct amount of charge

### DIFF
--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -225,8 +225,8 @@ var/global/list/battery_online =	list(
 	var/data[0]
 	data["nameTag"] = name_tag
 	data["storedCapacity"] = round(100.0*charge/capacity, 0.1)
-	data["charge"] = charge
-	data["capacity"] = capacity
+	data["charge"] = charge/SMESRATE //Compensates for the input/output rate
+	data["capacity"] = capacity/SMESRATE
 	data["charging"] = charging
 	data["chargeMode"] = chargemode
 	data["chargeLoad"] = round(chargereceived)

--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -225,8 +225,8 @@ var/global/list/battery_online =	list(
 	var/data[0]
 	data["nameTag"] = name_tag
 	data["storedCapacity"] = round(100.0*charge/capacity, 0.1)
-	data["charge"] = charge ? charge/SMESRATE : 0; //Compensates for the input/output rate
-	data["capacity"] = capacity ? capacity/SMESRATE : 0;
+	data["charge"] = charge ? charge/SMESRATE : 0 //Compensates for the input/output rate
+	data["capacity"] = capacity ? capacity/SMESRATE : 0
 	data["charging"] = charging
 	data["chargeMode"] = chargemode
 	data["chargeLoad"] = round(chargereceived)

--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -225,8 +225,8 @@ var/global/list/battery_online =	list(
 	var/data[0]
 	data["nameTag"] = name_tag
 	data["storedCapacity"] = round(100.0*charge/capacity, 0.1)
-	data["charge"] = charge/SMESRATE //Compensates for the input/output rate
-	data["capacity"] = capacity/SMESRATE
+	data["charge"] = charge ? charge/SMESRATE : 0 //Compensates for the input/output rate
+	data["capacity"] = capacity ? capacity/SMESRATE : 0
 	data["charging"] = charging
 	data["chargeMode"] = chargemode
 	data["chargeLoad"] = round(chargereceived)

--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -225,8 +225,8 @@ var/global/list/battery_online =	list(
 	var/data[0]
 	data["nameTag"] = name_tag
 	data["storedCapacity"] = round(100.0*charge/capacity, 0.1)
-	data["charge"] = charge ? charge/SMESRATE : 0 //Compensates for the input/output rate
-	data["capacity"] = capacity ? capacity/SMESRATE : 0
+	data["charge"] = charge ? charge/SMESRATE : 0; //Compensates for the input/output rate
+	data["capacity"] = capacity ? capacity/SMESRATE : 0;
 	data["charging"] = charging
 	data["chargeMode"] = chargemode
 	data["chargeLoad"] = round(chargereceived)


### PR DESCRIPTION
Internally they have a multiplier called "SMESRATE" set to a value of 0,05 that determines its power values.

:cl:
 * bugfix: SMES units will now show the correct amount of charge that is stored and can be stored.
