### PR TITLE
Reduces "computer" power consumption by 66%

### DIFF
--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -6,8 +6,8 @@
 	density = 1
 	anchored = 1.0
 	use_power = MACHINE_POWER_USE_IDLE
-	idle_power_usage = 300
-	active_power_usage = 300
+	idle_power_usage = 100
+	active_power_usage = 100
 	var/obj/item/weapon/circuitboard/circuit = null //if circuit==null, computer can't disassembly
 	var/processing = 0
 	var/empproof = FALSE // For plasma glass builds


### PR DESCRIPTION
Okay so it turns out that the "computer" parent consumes 300W of power every tick, but there are two problems:
- Nothing really justifies the constant power usage, computers remain unused most of the time and they each dwarf the power usage of most other devices; what a computer consumes in one tick just by existing an airlock would have to open and close about 6 times to consume.
- They are placed just about everywhere on most maps (quite a lot of things are of the "computer" type). How much? Well over a hundred on most maps. Every arcade cabinet is a computer, every entertainment monitor is a computer, the Bridge is full of computers, there's computers in Security, there's computers in Engineering and Robotics and in Medbay, just lots and lots of them placed around without much restraint.

This PR reduces the power consumption of computers from 300W to 100W. It cut off the power load on Box by about 26kW.

:cl:
 * tweak: Consoles will now consume 100W instead of 300W, making them less taxing on the station's power net.