### PR TITLE
Computers will now enter idle mode if they haven't been used in a while

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -118,6 +118,7 @@ var/list/obj/machinery/camera/cyborg_cams = list(
 		// Open UI
 		ui = new(user, src, tgui_interface)
 		ui.open()
+	set_active(5) //the proc is repeatedly called for as long as the cameras are watched
 
 /obj/machinery/computer/security/ui_data()
 	var/list/data = list()

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -44,12 +44,9 @@
 		A.send_poweralert(src)
 
 /obj/machinery/computer/station_alert/attack_hand(mob/user)
-	add_fingerprint(user)
-	if(stat & (BROKEN|NOPOWER|FORCEDISABLE))
+	if(..())
 		return
-	interact(user)
-	return
-
+	return interact(user)
 
 /obj/machinery/computer/station_alert/interact(mob/user)
 	usr.set_machine(src)


### PR DESCRIPTION
As an alternative to #35975 this PR makes it so that computers that aren't being actively used will not consume as much power.
Also fixes a bug where the station alerts console wasn't as thorough.
I should probably look into disabling moody lights when they're in power-saving mode.

## Why it's good
I don't think computers should be ghetto power sinks. It's also a more dynamic element than the other PR because instead of it being a static number change it's a number change that happens with some player interaction.

:cl:
 * rscadd: Nanotrasen's IT department has realized that they forgot to enable the "idle mode" power-saving setting on the station's computers and most monitors, which has caused computers to needlessly consume far more power than they should. Now they will properly enter a power-saving mode when they are not in use.
 * bugfix: Fixed Station Alert consoles not being as thorough in their checks for whether they can be used.