### PR TITLE
Makes it impossible for dynamic to roll blood cult

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -327,8 +327,8 @@
 	weight = BASE_RULESET_WEIGHT
 	weight_category = "Cult"
 	cost = 30
-	requirements = list(90,80,60,30,20,10,10,10,10,10)
-	high_population_requirement = 40
+	requirements = list(101,101,101,101,101,101,101,101,101,101)
+	high_population_requirement = 101
 	var/cultist_cap = list(2,2,3,4,4,4,4,4,4,4)
 	//Readd this once proper round ending rituals are added
 	//flags = HIGHLANDER_RULESET


### PR DESCRIPTION
[gamemode]
[based]

<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
It's been more than 2 years since blood cult has gone from a game mode that had a clear start, progression and an end-game to an unfinished dogshit freeform mess on the promise that it will be **fixed later**©
People had a lot of opinions on 3.0 but I'm sure everyone can agree that it was actually finished and functional to a degree
Personally whenever I see blood cult nowadays it makes my stomach turn the same way Time Agent did back when it had barely anything working at all.

It's time to shelve it.
## What this does
Stops dynamic from rolling blood cult

## Why it's good
We'll probably see more of everyone's favourite tried and tested round ending antags with a real end-game firing, like Nuke Ops and Revolution, instead of whatever mess cult is.
<!-- Explain why you think these changes are good. -->

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Makes blood cult impossible to fire naturally
