### PR TITLE
Overhaul to The Irons

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -56,7 +56,7 @@ var/const/AIRLOCK_WIRE_ONOPEN = 4096
 /datum/wires/airlock/GetInteractWindow()
 	var/obj/machinery/door/airlock/A = holder
 	. += ..()
-	. += text("<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]", (A.locked ? "The door bolts have fallen!" : "The door bolts look up."),
+	. += text("<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]", (A.locked ? "The door bolts have fallen!" : "The door bolts [A.boltsDestroyed ? "have been chopped!" : "look up."]"),
 	(A.lights ? "The door bolt lights are on." : "The door bolt lights are off!"),
 	((A.arePowerSystemsOn() && !(A.stat & NOPOWER)) ? "The test light is on." : "The test light is off!"),
 	(A.aiControlDisabled==0 ? "The 'AI control allowed' light is on." : "The 'AI control allowed' light is off."),
@@ -96,7 +96,7 @@ var/const/AIRLOCK_WIRE_ONOPEN = 4096
 			if(!mended)
 				//Cutting this wire also drops the door bolts, and mending it does not raise them. (This is what happens now, except there are a lot more wires going to door bolts at present)
 				if(A.locked!=1)
-					A.locked = 1
+					A.locked = A.boltsDestroyed ? 0 : 1
 				A.update_icon()
 
 		if(AIRLOCK_WIRE_AI_CONTROL)
@@ -145,7 +145,7 @@ var/const/AIRLOCK_WIRE_ONOPEN = 4096
 			//one wire for door bolts. Sending a pulse through this drops door bolts if they're not down (whether power's on or not),
 			//raises them if they are down (only if power's on)
 			if(!A.locked)
-				A.locked = 1
+				A.locked = A.boltsDestroyed ? 0 : 1
 				playsound(A, "sound/machines/door_bolt.ogg", 50, 1, -1)
 				for(var/mob/M in range(1, A))
 					to_chat(M, "You hear a metallic clunk from the bottom of the door.")

--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -37,7 +37,7 @@
 			update_icon()
 
 		if("lock")
-			locked = 1
+			locked = boltsDestroyed ? 0 : 1
 			playsound(loc, "sound/machines/door_bolt.ogg", 50, 1, -1)
 			update_icon()
 
@@ -55,7 +55,7 @@
 					sleep(2)
 				open(1)
 
-				locked = 1
+				locked =  boltsDestroyed ? 0 : 1
 				playsound(loc, "sound/machines/door_bolt.ogg", 50, 1, -1)
 				update_icon()
 			else
@@ -64,7 +64,7 @@
 					playsound(loc, "sound/machines/door_unbolt.ogg", 50, 1, -1)
 				close(1)
 
-				locked = 1
+				locked =  boltsDestroyed ? 0 : 1
 				playsound(loc, "sound/machines/door_bolt.ogg", 50, 1, -1)
 				sleep(2)
 				update_icon()
@@ -77,7 +77,7 @@
 				sleep(2)
 			open(1)
 
-			locked = 1
+			locked =  boltsDestroyed ? 0 : 1
 			playsound(loc, "sound/machines/door_bolt.ogg", 50, 1, -1)
 			update_icon()
 
@@ -87,7 +87,7 @@
 				playsound(loc, "sound/machines/door_unbolt.ogg", 50, 1, -1)
 			close(1)
 
-			locked = 1
+			locked =  boltsDestroyed ? 0 : 1
 			playsound(loc, "sound/machines/door_bolt.ogg", 50, 1, -1)
 			sleep(2)
 			update_icon()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1233,11 +1233,9 @@ About the new airlock wires panel:
 					if(do_after(user,src,breaktime))
 						to_chat(user, "<span class='notice'>You lift the airlock out of its track, exposing the bolts.</span>")
 						playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
-						animate(src, pixel_y = pixel_y + 5, time = 1)
+						animate(src, pixel_y += 5 , time = 1)
 						lifted = TRUE
-						src.busy=0
-					else
-						src.busy=0
+					src.busy=0
 				else
 					src.busy=1
 					to_chat(user, "<span class='notice'>You begin to lower \the [src] back into of its track..</span>")
@@ -1248,9 +1246,7 @@ About the new airlock wires panel:
 						pixel_y = initial(pixel_y)
 						lifted = FALSE
 						update_icon()
-						src.busy=0
-					else
-						src.busy=0
+					src.busy=0
 			else
 				pry(user)
 			return
@@ -1277,7 +1273,6 @@ About the new airlock wires panel:
 	else if (iscrowbar(I) || istype(I, /obj/item/weapon/fireaxe))
 		if(src.busy)
 			return
-		//src.busy = 1
 		var/beingcrowbarred = null
 		if(lifted)
 			if(istype(I, /obj/item/weapon/fireaxe))
@@ -1335,7 +1330,6 @@ About the new airlock wires panel:
 						to_chat(user, "<span class='warning'>You need to be wielding \the [F] to do that.</span>")
 				else
 					spawn(0)	close(1)
-		//src.busy = 0
 	else if (istype(I, /obj/item/weapon/card/emag))
 		emag_act(src)
 	else if(istype(I, /obj/item/stack/rods) && boltsDestroyed)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -26,6 +26,7 @@
 
 	custom_aghost_alerts=1
 	var/aiControlDisabled = 0 //If 1, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.
+	var/boltsDestroyed=0 //if 1, do not allow the door to be bolted
 	var/hackProof = 0 // if 1, this door can't be hacked by the AI
 	var/secondsMainPowerLost = 0 //The number of seconds until power is restored.
 	var/secondsBackupPowerLost = 0 //The number of seconds until power is restored.
@@ -836,6 +837,9 @@ About the new airlock wires panel:
 					//drop door bolts
 					if(src.isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
 						to_chat(usr, "You can't drop the door bolts - The door bolt dropping wire has been cut.")
+					else if (src.boltsDestroyed)
+						to_chat(usr, "You can't drop the door bolts - The door's bolts have been chopped.")
+						playsound(loc, "sound/machines/door_bolt.ogg", 50, 1, -1)
 					else if(src.locked!=1)
 						if(isobserver(usr) && !canGhostWrite(usr,src,"dropped bolts on"))
 							to_chat(usr, "<span class='warning'>Nope.</span>")
@@ -1217,16 +1221,36 @@ About the new airlock wires panel:
 			bashed_in(user, TRUE)
 		return
 	if(istype(I, /obj/item/tool/crowbar/halligan))
+		if (src.busy)
+			return
 		var/breaktime = 8 SECONDS
-		if(!operating && density && src.arePowerSystemsOn() && !((stat) & NOPOWER) && !welded)
-			if(locked && !lifted)
-				to_chat(user, "<span class='notice'>You begin to lift \the [src] out of its track, exposing the bolts.</span>")
-				playsound(src, 'sound/effects/rustle-metal.ogg', 50, 1)
-				if(do_after(user,src,breaktime))
-					to_chat(user, "<span class='notice'>You begin to lift the airlock out of its track, exposing the bolts.</span>")
-					playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
-					animate(src, pixel_y = pixel_y + 5, time = 1)
-					lifted = TRUE
+		if((!operating && src.arePowerSystemsOn() && !((stat) & NOPOWER) || locked) && !welded)
+			if(locked)
+				if (!lifted)
+					src.busy=1
+					to_chat(user, "<span class='notice'>You begin to lift \the [src] out of its track, exposing the bolts.</span>")
+					playsound(src, 'sound/effects/rustle-metal.ogg', 50, 1)
+					if(do_after(user,src,breaktime))
+						to_chat(user, "<span class='notice'>You lift the airlock out of its track, exposing the bolts.</span>")
+						playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
+						animate(src, pixel_y = pixel_y + 5, time = 1)
+						lifted = TRUE
+						src.busy=0
+					else
+						src.busy=0
+				else
+					src.busy=1
+					to_chat(user, "<span class='notice'>You begin to lower \the [src] back into of its track..</span>")
+					playsound(src, 'sound/effects/rustle-metal.ogg', 50, 1)
+					if(do_after(user,src,breaktime/4))
+						to_chat(user, "<span class='notice'>You lower the airlock back into its track.</span>")
+						playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
+						pixel_y = initial(pixel_y)
+						lifted = FALSE
+						update_icon()
+						src.busy=0
+					else
+						src.busy=0
 			else
 				pry(user)
 			return
@@ -1253,7 +1277,7 @@ About the new airlock wires panel:
 	else if (iscrowbar(I) || istype(I, /obj/item/weapon/fireaxe))
 		if(src.busy)
 			return
-		src.busy = 1
+		//src.busy = 1
 		var/beingcrowbarred = null
 		if(lifted)
 			if(istype(I, /obj/item/weapon/fireaxe))
@@ -1263,12 +1287,16 @@ About the new airlock wires panel:
 					if(H.get_strength() >= 2)
 						breaktime = 10 SECONDS
 					to_chat(user, "<span class='notice'>You begin chopping the bolts down.</span>")
+					src.busy = 1
 					if(!do_after(user, src, breaktime, 10, custom_checks = new /callback(I, /obj/item/weapon/fireaxe/proc/on_do_after)))
+						src.busy = 0
 						return
 					playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
+					boltsDestroyed=1
 					to_chat(user, "<span class='notice'>You finish chopping the bolts.</span>")
 					pixel_y = initial(pixel_y)
-					toggle_bolts()
+					locked = FALSE
+					src.busy=0
 					lifted = FALSE
 					update_icon()
 			return
@@ -1307,9 +1335,21 @@ About the new airlock wires panel:
 						to_chat(user, "<span class='warning'>You need to be wielding \the [F] to do that.</span>")
 				else
 					spawn(0)	close(1)
-		src.busy = 0
+		//src.busy = 0
 	else if (istype(I, /obj/item/weapon/card/emag))
 		emag_act(src)
+	else if(istype(I, /obj/item/stack/rods) && boltsDestroyed)
+		var/obj/item/stack/rods/rawd=I
+		if(rawd.amount <4)
+			to_chat(user, "<span class='warning'>You need 4 rods to repair the airlock's bolts.</span>")
+		else
+			playsound(loc, "sound/machines/click.ogg", 50, 1, -1)
+			to_chat(user, "<span class='notice'>You begin to replace the airlock's bolts</span>")
+			if (do_after(user,src,5 SECONDS))
+				rawd.use(4)
+				boltsDestroyed=0
+				playsound(loc, "sound/machines/door_bolt.ogg", 50, 1, -1)
+				to_chat(user, "<span class='notice'>You replace the airlock's bolts.</span>")
 	else
 		..(I, user)
 	add_fingerprint(user)
@@ -1339,13 +1379,18 @@ About the new airlock wires panel:
 		var/breaktime = 8 SECONDS
 		if(H.get_strength() >= 2)
 			breaktime = 4 SECONDS
-		to_chat(user, "<span class='notice'>\The [src]'s motors grind as you pry it open.</span>")
+		playsound(src,"sound/weapons/circsawhit.ogg")
+		src.busy=1
+		to_chat(user, "<span class='notice'>\The [src]'s motors grind as you pry it [density ? "open" : "shut"].</span>")
 		if(do_after(user,src,breaktime))
-			if(!(stat & (NOPOWER)) || src.arePowerSystemsOn())
-				spark(src, 5)
-				playsound(src,"sparks",75,1,-1)
-			open(1)
+			src.busy=0
+			if (density)
+				open(1)
+			else
+				close(1)
 			return 1
+		else
+			src.busy=0
 		return 0
 	else
 		return 0
@@ -1509,12 +1554,15 @@ About the new airlock wires panel:
 	locked = 0
 	playsound(loc, "sound/machines/door_unbolt.ogg", 50, 1, -1)
 	open()
-	locked = 1
-	playsound(loc, "sound/machines/door_bolt.ogg", 50, 1, -1)
+	if (!boltsDestroyed)
+		locked = 1
+		playsound(loc, "sound/machines/door_bolt.ogg", 50, 1, -1)
 	return
 
 /obj/machinery/door/airlock/proc/toggle_bolts()
-	locked = !locked
+	lifted = FALSE
+	pixel_y = initial(pixel_y)
+	locked = boltsDestroyed ? FALSE : !locked
 	if (locked == TRUE)
 		playsound(loc, "sound/machines/door_bolt.ogg", 50, 1, -1)
 	if (locked == FALSE)


### PR DESCRIPTION
[balance] [bugfix]

## What this does
Gives a bit of an overhaul to the irons (fire axe & halligan bar).
This fixes some bugs (such as only ever being able to chop bolts once time ever), but expands on the functionality of it.


## Why it's good
These changes not only fix bugs with the overall function, but give the pair of tools a more apparent application and use.
for example, the halligan can now be used to expedite the process of ventilating a room containing plasma, or can close doors which for whatever reason are kept open.
the bolt cutting has been made more unique of an ability, which can have some interesting effects on certain doors which are normally bolted, or serve as a counter to unwanted door bolting in other cases..
the irons have been historically unused due them not really offering anything for the average spaceman, as well as being generally unwieldy to carry around. This attempts to give them unique function what will make them a consideration with certain cases.

## Changelog
:cl:
* bugfix: you can now chop the bolts of unpowered airlocks
* bugfix: chopping bolts no longer breaks certain airlock interactions
* tweak: prying open airlocks with the halligan bar no longer creates sparks
* rscadd: the halligan bar can now pry airlocks shut
* tweak: chopping airlock bolts now removes the ability to bolt that airlock
* rscadd: chopped bolts can be repaired by using some rods on the airlock.
