### PR TITLE
Clicking improvements for combat

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -462,6 +462,4 @@
 
 //Currently used to allow a little bit of freedom in click-dragging for melee combat in _onclick/drag_drop.dm
 /mob/living/MouseDown(location, control, params, var/past_time)
-	var/client/C = client
-	if(C)
-		C.click_held_down_time = world.timeofday
+	usr.client.click_held_down_time = world.timeofday

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -461,5 +461,7 @@
 		W.MouseWheeled(src, delta_x, delta_y, params)
 
 //Currently used to allow a little bit of freedom in click-dragging for melee combat in _onclick/drag_drop.dm
-/client/MouseDown(location, control, params, var/past_time)
-	click_held_down_time = world.timeofday
+/mob/living/MouseDown(location, control, params, var/past_time)
+	var/client/C = client
+	if(C)
+		C.click_held_down_time = world.timeofday

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -6,11 +6,13 @@
 //BYOND has a quirk (maybe bug?) where, if you initiate a clickdrag with one mouse button, any clicks with another button during the drag hit the object being dragged.
 //This allowed you to, for example, start a middle-click drag on someone and then have an aimbot that allows you to effortlessly hit them in melee or ranged combat as long as you held MMB.
 //This code discards clicks performed during a drag to prevent this.
-/client/Click(object, location, control, params)
-	var/list/p = params2list(params)
-	if(p["drag"])
-		return
-	..()
+
+//As of 2024 this code has been commented out because the bug/exploit is no longer active.
+// /client/Click(object, location, control, params)
+// 	var/list/p = params2list(params)
+// 	if(p["drag"])
+// 		return
+// 	..()
 
 /*
 	Before anything else, defer these calls to a per-mobtype handler.  This allows us to
@@ -457,3 +459,7 @@
 	var/obj/item/W = get_active_hand()
 	if (W)
 		W.MouseWheeled(src, delta_x, delta_y, params)
+
+//Currently used to allow a little bit of freedom in click-dragging for melee combat in _onclick/drag_drop.dm
+/atom/MouseDown(location, control, params, var/past_time)
+	click_held_down_time = world.timeofday

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -461,5 +461,5 @@
 		W.MouseWheeled(src, delta_x, delta_y, params)
 
 //Currently used to allow a little bit of freedom in click-dragging for melee combat in _onclick/drag_drop.dm
-/atom/MouseDown(location, control, params, var/past_time)
+/client/MouseDown(location, control, params, var/past_time)
 	click_held_down_time = world.timeofday

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -1,3 +1,5 @@
+#define CLICKDRAG_DELAY_WINDOW 2 //Set this in deciseconds (1/10th of a second) for how long a player is allowed to drag to a tile to click the target
+
 /*
 	MouseDrop:
 
@@ -8,6 +10,17 @@
 /atom/MouseDrop(atom/over_object,src_location,over_location,src_control,over_control,params)
 	if(!over_object) //Dragged to the stat panel
 		return
+	if(src == over_object) //Click-dragged onto the same entity
+		return Click(src, over_control, params)
+	if(istype(over_object, /turf))
+		var/current_time = world.timeofday
+		//This compares an atom variable, click_held_down_time, that gets set by MouseDown() equal to the world.timeofday back then
+		//to MouseDrop's current world.timeofday. If click_held_down_time plus the delay is smaller than
+		//the present world.timeofday then the player is allowed to click-drag their target into the
+		//floor to click them, which allows better hitting during twitchy combat scenarios
+		if((current_time < click_held_down_time + CLICKDRAG_DELAY_WINDOW))
+			if(Adjacent(over_object)) //A turf near it.
+				return Click(src, over_control, params)
 	var/list/params_list = params2list(params)
 	if(params_list["ctrl"]) //More modifiers can be added - check click.dm
 		spawn(0)

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -12,16 +12,6 @@
 		return
 	if(src == over_object) //Click-dragged onto the same entity
 		return Click(src, over_control, params)
-	if(istype(over_object, /turf))
-		var/current_time = world.timeofday
-		var/client/C = usr.client
-		//This compares a client variable, click_held_down_time, that gets set by MouseDown() equal to the world.timeofday back then
-		//to MouseDrop's current world.timeofday. If click_held_down_time plus the delay is smaller than
-		//the present world.timeofday then the player is allowed to click-drag their target into the
-		//floor to click them, which allows better hitting during twitchy combat scenarios
-		if((current_time < C.click_held_down_time + CLICKDRAG_DELAY_WINDOW))
-			if(Adjacent(over_object)) //A turf near it.
-				return Click(src, over_control, params)
 	var/list/params_list = params2list(params)
 	if(params_list["ctrl"]) //More modifiers can be added - check click.dm
 		spawn(0)
@@ -39,6 +29,19 @@
 // receive a mousedrop
 /atom/proc/MouseDropTo(atom/over_object,mob/user,src_location,over_location,src_control,over_control,params)
 	return
+
+/mob/living/MouseDrop(atom/over_object, src_location, over_location, src_control, over_control, params)
+	if(istype(over_object, /turf))
+		var/current_time = world.timeofday
+		var/client/C = usr.client
+		//This compares a client variable, click_held_down_time, that gets set by MouseDown() equal to the world.timeofday back then
+		//to MouseDrop's current world.timeofday. If click_held_down_time plus the delay is smaller than
+		//the present world.timeofday then the player is allowed to click-drag their target into the
+		//floor to click them, which allows better hitting during twitchy combat scenarios
+		if((current_time < C.click_held_down_time + CLICKDRAG_DELAY_WINDOW))
+			if(Adjacent(over_object)) //A turf near it.
+				return Click(src, over_control, params)
+	..()
 
 /obj/MouseDropTo(atom/over_object, mob/user)
 	if(material_type)

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -14,11 +14,12 @@
 		return Click(src, over_control, params)
 	if(istype(over_object, /turf))
 		var/current_time = world.timeofday
-		//This compares an atom variable, click_held_down_time, that gets set by MouseDown() equal to the world.timeofday back then
+		var/client/C = usr.client
+		//This compares a client variable, click_held_down_time, that gets set by MouseDown() equal to the world.timeofday back then
 		//to MouseDrop's current world.timeofday. If click_held_down_time plus the delay is smaller than
 		//the present world.timeofday then the player is allowed to click-drag their target into the
 		//floor to click them, which allows better hitting during twitchy combat scenarios
-		if((current_time < click_held_down_time + CLICKDRAG_DELAY_WINDOW))
+		if((current_time < C.click_held_down_time + CLICKDRAG_DELAY_WINDOW))
 			if(Adjacent(over_object)) //A turf near it.
 				return Click(src, over_control, params)
 	var/list/params_list = params2list(params)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -24,7 +24,6 @@ var/global/list/ghdel_profiling = list()
 	var/penetration_dampening = 5 //drains some of a projectile's penetration power whenever it goes through the atom
 	var/throw_impact_sound = 'sound/weapons/genhit2.ogg'
 	var/admin_desc //Allows admins to see admin-exclusive examines, such as notifications for custom variables
-	var/click_held_down_time //Used by MouseDown in _onclick/click.dm
 
 	///Chemistry.
 	var/datum/reagents/reagents = null

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -24,6 +24,7 @@ var/global/list/ghdel_profiling = list()
 	var/penetration_dampening = 5 //drains some of a projectile's penetration power whenever it goes through the atom
 	var/throw_impact_sound = 'sound/weapons/genhit2.ogg'
 	var/admin_desc //Allows admins to see admin-exclusive examines, such as notifications for custom variables
+	var/click_held_down_time //Used by MouseDown in _onclick/click.dm
 
 	///Chemistry.
 	var/datum/reagents/reagents = null

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -23,7 +23,8 @@
 	var/datum/tooltip/tooltips //datum that controls the displaying and hiding of tooltips
 	var/list/radial_menu_anchors = list() //keeping track of open menus so we're not gonna have several on top of each other.
 	var/list/radial_menus = list()
-	
+	var/click_held_down_time //Used by MouseDown in _onclick/click.dm
+
 		///////////////
 		//SOUND STUFF//
 		///////////////
@@ -80,7 +81,7 @@
 	var/obj/abstract/screen/plane_master/ghost_planemaster_dummy/darkness_planemaster_dummy = null
 	var/obj/abstract/screen/plane_master/ghost_planemaster/fakecamera_planemaster = null
 	var/obj/abstract/screen/plane_master/ghost_planemaster_dummy/fakecamera_planemaster_dummy = null
-	
+
 
 
 	// This gets set by goonchat.


### PR DESCRIPTION
You ever got into a combat scenario where you ended up just clicking repeatedly and it just didn't seem to register somehow? It's a bit complicated but here's what usually happens:
- Generally twitchy mouse movements could end up click-dragging the target in a brief window of time between holding down the click button and releasing it, which is fine and dandy AS LONG AS it doesn't stop hovering over the target. The moment it stops hovering above the target it won't register as a click anymore when you hover it back onto the target.
- You're likely to just click-drag into the floor.

This PR helps against both problems:
- Click-dragging into the same target will ALWAYS click that target.
- If you end up click-dragging into an adjacent floor within 0.2 seconds after you held down the mouse button (which is extremely fast and basically you won't be affected if you want to click-drag something instead of clicking something) then you click the target.

Many thanks to @Exxion as the adjacency click-dragging would have either been a massive pain in the ass to do or just not possible were it not for his help.

Also comments out code related to a click-drag-related exploit that has been fixed years ago on BYOND's side (it didn't work when I tested it with the code removed).

:cl:
 * experiment: Corrected possible instances of unintentional click-dragging during combat so that they now count as regular clicks, making it easier to hit targets during frantic situations.