### PR TITLE
Glagow's Stage 3

### DIFF
--- a/code/modules/virus2/effect/stage_2.dm
+++ b/code/modules/virus2/effect/stage_2.dm
@@ -170,22 +170,6 @@
 	if (prob(30))
 		mob.jitteriness += 10
 
-
-/datum/disease2/effect/drunk
-	name = "Glasgow Syndrome"
-	desc = "Causes the infected to synthesize pure ethanol."
-	encyclopedia = "Without a cure, the infected's liver is sure to die, also effect strength increases the rate at which ethanol is synthesized."
-	stage = 2
-	badness = EFFECT_DANGER_HARMFUL
-	multiplier = 3
-	max_multiplier = 7
-
-/datum/disease2/effect/drunk/activate(var/mob/living/mob)
-	to_chat(mob, "<span class='notice'>You feel like you had one hell of a party!</span>")
-	if (mob.reagents.get_reagent_amount(GLASGOW) < multiplier*5)
-		mob.reagents.add_reagent(GLASGOW, multiplier*5)
-
-
 /datum/disease2/effect/gaben
 	name = "Gaben Syndrome"
 	desc = "Makes the infected incredibly fat."

--- a/code/modules/virus2/effect/stage_3.dm
+++ b/code/modules/virus2/effect/stage_3.dm
@@ -58,6 +58,20 @@
 /datum/disease2/effect/hallucinations/activate(var/mob/living/mob)
 	mob.hallucination += 25
 
+/datum/disease2/effect/drunk
+	name = "Glasgow Syndrome"
+	desc = "Causes the infected to synthesize pure ethanol."
+	encyclopedia = "Without a cure, the infected's liver is sure to die, also effect strength increases the rate at which ethanol is synthesized."
+	stage = 3
+	badness = EFFECT_DANGER_HARMFUL
+	multiplier = 3
+	max_multiplier = 7
+
+/datum/disease2/effect/drunk/activate(var/mob/living/mob)
+	to_chat(mob, "<span class='notice'>You feel like you had one hell of a party!</span>")
+	if (mob.reagents.get_reagent_amount(GLASGOW) < multiplier*5)
+		mob.reagents.add_reagent(GLASGOW, multiplier*5)
+
 /datum/disease2/effect/giggle
 	name = "Uncontrolled Laughter Effect"
 	desc = "Gives the infected a sense of humor."


### PR DESCRIPTION
[tweak]
## What this does
Changes Glasgow's to a stage 3 symptom instead of stage 2 making it both much less likely to roll, and take longer to manifest.

## Why it's good
Glasgow's being the only stage 2 danger 4 symptom means that it was rolling near constantly. This prevents glasgow's from appearing 33% of the time a random disease appears

## Changelog
:cl:
 * tweak: Changes Glasgows from stage 2 to stage 3.