### PR TITLE
Frames should match paintings printed from the painting archive now

### DIFF
--- a/code/modules/library/computers/remote_gallery_access.dm
+++ b/code/modules/library/computers/remote_gallery_access.dm
@@ -136,9 +136,23 @@
 /obj/machinery/computer/library/checkout/remote_gallery/make_external_book(var/datum/cachedbook/newbook)
 	if(!newbook)
 		return
-	var/obj/item/mounted/frame/painting/custom/C = new(get_turf(src))
+
+	var/obj/item/mounted/frame/painting/custom/C
+	var/datum/custom_painting/painting_data = json2painting(newbook.content, newbook.title, newbook.author, newbook.description)
+
+	//pick a canvas that fits the bitmap size.
+	if (painting_data.bitmap_width == 24)
+		if (painting_data.bitmap_height == 24)
+			C = new/obj/item/mounted/frame/painting/custom/large(get_turf(src))
+		else
+			C = new/obj/item/mounted/frame/painting/custom/landscape(get_turf(src))
+	else if(painting_data.bitmap_height == 24)
+		C = new/obj/item/mounted/frame/painting/custom/portrait(get_turf(src))
+	else
+		C = new/obj/item/mounted/frame/painting/custom(get_turf(src))
+
 	C.name = "[newbook.title] by [newbook.author]"
 	C.desc = newbook.description
-	C.set_painting_data(json2painting(newbook.content, newbook.title, newbook.author, newbook.description))
+	C.set_painting_data(painting_data)
 	C.update_painting(TRUE)
 	return C


### PR DESCRIPTION
0% tested, I have no idea how to setup a DB on local.

## What this does
The painting archive prints all paintings onto the base type `/painting/custom/`, which uses canvas and frame sprites meant for 14x14 paintings and clashes with the painting's actual size. This makes the printer attempt to identify and use the correct `/painting/custom/` subtype based on painting data loaded from the DB.

The real solution would have frames drawn dynamically instead, so if for some reason someone were to add a 12x32 canvas, they won't have to remember to add the sizes to some if/else tree. But, I wasn't sure how to do it then, and I still don't know how now.

## Why it's good
Fixes #35762

## Changelog
:cl:
 * bugfix: Paintings printed from the archive should have appropriately sized frames now.
