### PR TITLE
Fixes DEFINE typo.

### DIFF
--- a/__DEFINES/game.dm
+++ b/__DEFINES/game.dm
@@ -27,7 +27,7 @@
 #define HIGHROLLER_SLOWDOWN 1.4
 
 #define COMMAND_POSITIONS list("Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer")
-#define ENGINEERING_POSITIONS list("Chief Engineer", "Station  Engineer", "Atmospheric Technician", "Mechanic")
+#define ENGINEERING_POSITIONS list("Chief Engineer", "Station Engineer", "Atmospheric Technician", "Mechanic")
 #define MEDICAL_POSITIONS list("Chief Medical Officer", "Medical Doctor", "Geneticist", "Virologist", "Paramedic", "Chemist", "Orderly")
 #define SCIENCE_POSITIONS list("Research Director", "Scientist", "Geneticist", "Roboticist", "Mechanic")
 #define CIVILIAN_POSITIONS list("Head of Personnel", "Bartender", "Botanist", "Chef", "Janitor", "Librarian", "Internal Affairs Agent", "Chaplain", "Clown", "Mime", "Assistant")


### PR DESCRIPTION
## What this does
The DEFINE for ENGINEERING_POSITIONS didn't properly check for Station Engineers, since the string it looked for had a double space. This removes the double space.
[hotfix][bugfix]