### PR TITLE
Fire axe floor removal intent + blacklist

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -80,6 +80,14 @@
 	flags = FPRINT | TWOHANDABLE | SLOWDOWN_WHEN_CARRIED
 	slowdown = FIREAXE_SLOWDOWN
 
+	var/list/forbidden_floors = list(
+		/turf/simulated/floor/vault,
+		/turf/simulated/floor/engine,
+		/turf/simulated/floor/beach,
+		/turf/simulated/floor/shuttle,
+		/turf/simulated/floor/plating/snow
+	)
+
 /obj/item/weapon/fireaxe/update_wield(mob/user)
 	..()
 	item_state = "fireaxe[wielded ? 1 : 0]"
@@ -106,7 +114,10 @@
 			W.shatter()
 		else
 			QDEL_NULL(A)
-	else if(A && wielded && (istype(A, /turf/simulated/floor))) //removes floor plating
+	else if(A && wielded && istype(A, /turf/simulated/floor) && user.a_intent == I_HELP) //removes floor plating
+		if(is_type_in_list(A,forbidden_floors))
+			to_chat(user, "<span class='notice'>\The [src] isn't strong enough to break \the [A].</span>")
+			return
 		var/turf/simulated/floor/T = A
 		to_chat(viewers(user), "<span class='danger'>[user] begins to remove the plating using \the [src]!</span>")
 		var/breaktime = 6 SECONDS


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fire axes now require the user to be in HELP intent to remove floors, consistent with the behavior of crowbars. Additionally, a floor blacklist has been added to prevent removing reinforced floors, shuttle floors, beaches, snow, and vault floors.

## Why it's good
<!-- Explain why you think these changes are good. -->
Fire axes have been difficult to use as a weapon since the floor removal feature was added - this will allow players to resume spamming attacks at their opponent.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Fire axes now will only remove floors on help intent.
 * rscadd: Fire axes can no longer remove reinforced floors, shuttle floors, beaches, snow, or vault floors..