### PR TITLE
removes burndamage from hot food/drink

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -695,7 +695,6 @@ trans_to_atmos(var/datum/gas_mixture/target, var/amount=1, var/multiplier=1, var
 				custom_pain_msg = "Pain sears [which_organ ? " your " + which_organ.display_name : ""]!"
 			H.custom_pain(custom_pain_msg, post_mod_predicted_dmg >= SCALD_AGONIZING, post_mod_predicted_dmg >= SCALD_PAINFUL)
 		L.apply_effect(burn_dmg, AGONY) //pain
-		L.apply_damage(burn_dmg, BURN, which_organ)
 
 #undef SCALD_PAINFUL
 #undef SCALD_AGONIZING


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
You will no longer take burn damage from eating things that are too hot, you will take agony damage still which heals naturally over time and cant ever kill you on it's own.


## Why it's good
<!-- Explain why you think these changes are good. -->
Dying to drinking hot cofee is dumb, not being able to consume medicine designed to help you when things get too hot is extremely frustrating and this mitigates the majority of that.
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscdel: Hot food and drink will no longer be able to inflict real burns on you.
 