### PR TITLE
Pills no longer experience Thermal Entropy

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -112,6 +112,12 @@
 /obj/item/weapon/reagent_containers/pill/should_qdel_if_empty() //If you remove the reagents from this thing via smoke or IV drip or something, it shouldn't like it.
 	return 1													//This isn't an on_reagent_change() because so many things runtime if it is.
 
+/obj/item/weapon/reagent_containers/pill/thermal_entropy()
+	thermal_entropy_containers.Remove(src)
+
+/obj/item/weapon/reagent_containers/pill/get_heat_conductivity()
+	return 0
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Pills. END
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# Medbay Bandaid

## What this does
Pills are now contained in thermally-sealed casings. Whatever you put in there will stay that temperature. KEEP IN MIND: this PR doesn't touch the chemmaster's ambient temperature balancing. You need to take into account that the chemmaster is not thermally insulated so the process of making the pill may result in differences in the temperature of the chemicals you put in. Ice/potass pills are technically possible now, but you will need to make them in a coldroom.

## Why it's good
medbrains will stop complaining about killing their patients because their backpack pills got caught in a plasma fire

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Pills are no longer affected by external atmospheric temperatures.