### PR TITLE
Disables autoignition fire subsystem.

### DIFF
--- a/code/controllers/subsystem/burnable.dm
+++ b/code/controllers/subsystem/burnable.dm
@@ -4,7 +4,9 @@ var/list/atom/burnableatoms = list()
 /datum/subsystem/burnable
 	name          = "Burnable"
 	wait          = SS_WAIT_BURNABLE
-	flags         = SS_KEEP_TIMING
+	//flags       = SS_KEEP_TIMING
+	flags 	      = SS_NO_FIRE
+	can_fire      = FALSE
 	priority      = SS_PRIORITY_BURNABLE
 	display_order = SS_DISPLAY_BURNABLE
 


### PR DESCRIPTION
[controversial] [discussion]
## What this does
Disables frustratingly !!FUN!! and disproportionately destructive feature.
Does **not** touch the Thermal Entropy.

Closes #35874 

## Why it's good
Let me quote my own wall of text I built past week:

> The fact that there have been over 9000 different tweaks and rebalances to this nu-fire-temperature subsystem and it still sucks ass is a definite proof it's shit and should be cut from the code entirely. Then, if someone actually capable and knowledgable about IRL fires makes it right we can judge if it would benefit the server in general or not.
> 
> I for one did not enjoy constantly trying and failing to extinguish cigarette butts and burnt messes on chef's counter that round when one careless grue melted the entire station by accident. It was kino, yes, but this one good round when that lone bag of sugar in the Kitchen actually turned into caramel for the first time ever since this subsystem was introduced was not worth all of the pure suffering players had to endure in all of the previous rounds.
> 
> Neither do I enjoy chemical pills being frozen in my personal medkit after I return from a space trip, nor do I like waiting for 10 seconds after microwaving my donk-pocket for it to be edible. I hate how often I get to see the hot/cold temperature indicator in the right corner of my game screen in your average round. It's frustrating and, most importantly, it's **NOT FUN.**
> 
> I know they fixed the cigarette butts, yet my point still stands. Yesterday it was cigarette butts, today apparently it's paper bins, tomorrow it will be some other annoying and frustrating shit. Just cut this shit entirely.

Cutting this feature along with every tweak made to it up to this day entirely proved to be a sisyphean feat, so simply disabling it will do.

I would also like to add that, unlike Thermal Entropy, this has actually proven to be really hilarious and even kino on occasion. However, considering how seriously frustrating it can be due to its sheer robustness, many people have mixed feelings towards these changes and would rather see them heavily tweaked than removed. I myself had rounds where this was either a frustrating reason for a shuttle call or a truly epic round-ender, so let's have a discussion if this is worth having in the game or not.
## Changelog
:cl:
 * rscdel: Disabled items autoignition.