### PR TITLE
(Temporarily) disables most autoignition and room-heating mechanics

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -49,12 +49,18 @@ Attach to transfer valve and open. BOOM.
 /atom/proc/burnFireFuel(used_fuel_ratio, used_reactants_ratio)
 	fire_fuel -= (fire_fuel * used_fuel_ratio * used_reactants_ratio) //* 5
 
-	var/turf/T = get_turf(loc)
-	if(T)
-		T.hotspot_expose(autoignition_temperature, CELL_VOLUME, surfaces=1)
+//Disabled burning items heating up the area.
+//Made fires disproportionately more dangerous, and in combination with autoignition led to a domino effect
+//where one item would heat up an area and cause other items to ignite and heat up the area until
+//the entire room was a firestorm.
+
+//To re-enable, un-comment the lines of code, and preferably replace get_turf(loc) below with T
+	// var/turf/T = get_turf(loc)
+	// if(T)
+	// 	T.hotspot_expose(autoignition_temperature, CELL_VOLUME, surfaces=1)
 	if(prob(8)) //8% chance of smoke creation per tick
 		var/datum/effect/system/smoke_spread/fire/smoke = new /datum/effect/system/smoke_spread()
-		smoke.set_up(4,0,T)
+		smoke.set_up(4,0,get_turf(loc))
 		smoke.time_to_live = 60 SECONDS
 		smoke.start()
 

--- a/code/controllers/subsystem/burnable.dm
+++ b/code/controllers/subsystem/burnable.dm
@@ -1,10 +1,17 @@
 var/datum/subsystem/burnable/SSburnable
 var/list/atom/burnableatoms = list()
 
+//Currently disabled in:
+//code/controllers/subsystem/burnable.dm (this file)
+//code/game/objects/objs.dm, in /obj/New()
+//code/ZAS/Fire.dm, in burnFireFuel()
+
+//To re-enable it here, change "SS_NO_FIRE" to "SS_KEEP_TIMING"
+
 /datum/subsystem/burnable
 	name          = "Burnable"
 	wait          = SS_WAIT_BURNABLE
-	flags         = SS_KEEP_TIMING
+	flags         = SS_NO_FIRE
 	priority      = SS_PRIORITY_BURNABLE
 	display_order = SS_DISPLAY_BURNABLE
 
@@ -23,24 +30,18 @@ var/list/atom/burnableatoms = list()
 /datum/subsystem/burnable/stat_entry()
 	..("P:[burnableatoms.len]")
 
-//Disabled because autoignition would too often turn rooms into firestorms due to a chain reaction
-//where one item would burn up, increase the room temperature (in code/ZAS/Fire.dm, proc/burnFireFuel()) and cause
-//other items to burn up.
-
-//To re-enable, remove the "return" and un-comment the lines of code.
-
 /datum/subsystem/burnable/fire(var/resumed = FALSE)
 	return
-	// if(!resumed)
-	// 	currentrun_index = burnableatoms.len
-	// 	currentrun = burnableatoms.Copy()
-	// var/c = currentrun_index
-	// while(c)
-	// 	currentrun[c]?.checkburn()
-	// 	c--
-	// 	if (MC_TICK_CHECK)
-	// 		break
-	// currentrun_index = c
+	if(!resumed)
+		currentrun_index = burnableatoms.len
+		currentrun = burnableatoms.Copy()
+	var/c = currentrun_index
+	while(c)
+		currentrun[c]?.checkburn()
+		c--
+		if (MC_TICK_CHECK)
+			break
+	currentrun_index = c
 
 #define MINOXY2BURN (1 / CELL_VOLUME)
 /atom/proc/checkburn()

--- a/code/controllers/subsystem/burnable.dm
+++ b/code/controllers/subsystem/burnable.dm
@@ -23,18 +23,24 @@ var/list/atom/burnableatoms = list()
 /datum/subsystem/burnable/stat_entry()
 	..("P:[burnableatoms.len]")
 
-/datum/subsystem/burnable/fire(var/resumed = FALSE)
+//Disabled because autoignition would too often turn rooms into firestorms due to a chain reaction
+//where one item would burn up, increase the room temperature (in code/ZAS/Fire.dm, proc/burnFireFuel()) and cause
+//other items to burn up.
 
-	if(!resumed)
-		currentrun_index = burnableatoms.len
-		currentrun = burnableatoms.Copy()
-	var/c = currentrun_index
-	while(c)
-		currentrun[c]?.checkburn()
-		c--
-		if (MC_TICK_CHECK)
-			break
-	currentrun_index = c
+//To re-enable, remove the "return" and un-comment the lines of code.
+
+/datum/subsystem/burnable/fire(var/resumed = FALSE)
+	return
+	// if(!resumed)
+	// 	currentrun_index = burnableatoms.len
+	// 	currentrun = burnableatoms.Copy()
+	// var/c = currentrun_index
+	// while(c)
+	// 	currentrun[c]?.checkburn()
+	// 	c--
+	// 	if (MC_TICK_CHECK)
+	// 		break
+	// currentrun_index = c
 
 #define MINOXY2BURN (1 / CELL_VOLUME)
 /atom/proc/checkburn()

--- a/code/controllers/subsystem/burnable.dm
+++ b/code/controllers/subsystem/burnable.dm
@@ -31,7 +31,6 @@ var/list/atom/burnableatoms = list()
 	..("P:[burnableatoms.len]")
 
 /datum/subsystem/burnable/fire(var/resumed = FALSE)
-	return
 	if(!resumed)
 		currentrun_index = burnableatoms.len
 		currentrun = burnableatoms.Copy()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -64,8 +64,13 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 		breakable_init()
 	if(is_cooktop)
 		add_component(/datum/component/cooktop)
-	if(autoignition_temperature)
-		burnableatoms+=src
+//Disabled because autoignition would too often turn rooms into firestorms due to a chain reaction
+//where one item would burn up, increase the room temperature (in code/ZAS/Fire.dm, proc/burnFireFuel()) and cause
+//other items to burn up.
+
+//To re-enable, un-comment the lines of code.
+	// if(autoignition_temperature)
+	// 	burnableatoms+=src
 
 //More cooking stuff:
 /obj/proc/can_cook() //Returns true if object is currently in a state that would allow for food to be cooked on it (eg. the grill is currently powered on). Can (and generally should) be overriden to check for more specific conditions.


### PR DESCRIPTION
Ever since #35306 was merged the server was terrorized by how easy it was to both intentionally and unintentionally set up room-consuming fires that would be very difficult to fix. There were two problems:
1) A sufficiently heated room would cause most objects inside to spontaneously combust, making it way easier to deliberately or accidentally set a room on fire.
2) The objects that were set on fire would themselves heat up the room even more, creating a domino effect where more and more objects would start burning up until there was nothing left to burn.

This PR (temporarily) disables autoignition mechanics (causing objects to no longer combust just because they are hot, and instead require a source of fire to ignite) and objects on fire heating rooms up, which prevents the domino effect of turning what used to be the bar into ash and dust.
Anything that will call hotspot_expose() may still set things on fire.
The code is intact, and will require un-commenting to make it work again.
Hopefully #35988 works out.

Thanks to @west3436 for helping!

:cl:
 * rscdel: Auto-ignition mechanics from air temperature has been disabled, and will now require previous conventional sources of being set on fire in order to be on fire.
 * rscdel: Items on fire will no longer produce temperatures by themselves. However, the fires they may produce, such as pie tins in contact with sparks, still will.
