### PR TITLE
Food and reagents in your hands and backpack no longer freeze while in space

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -484,6 +484,9 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 
 	var/diff = air.temperature - reagents.chem_temp
 
+	if (!isturf(loc) && (air.pressure < 100))//low pressure environments slow down entropy, unless the item is laid directly onto the floor so space meat remains frozen until brought in
+		diff *= air.pressure
+
 	//we only bother if there's less than a 1 degree difference
 	if (abs(diff) < 2)
 		thermal_entropy_containers.Remove(src)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -485,7 +485,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 	var/diff = air.temperature - reagents.chem_temp
 
 	if (!isturf(loc) && (air.pressure < 100))//low pressure environments slow down entropy, unless the item is laid directly onto the floor so space meat remains frozen until brought in
-		diff *= air.pressure
+		diff *= air.pressure/100
 
 	//we only bother if there's less than a 1 degree difference
 	if (abs(diff) < 2)


### PR DESCRIPTION
They may be allowed to freeze by dropping them directly onto a space turf still.

![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/c786f353-afa1-48b0-a8ca-8f557f15fbb6)

In more general terms, entropy is now proportional to the air pressure when said pressure is below 100kPa (so below room pressure basically), unless the item is directly placed on the floor. When pressure = 0 such as in space, this means that held items or ones in containers no longer experience entropy at all.

**Obviously this also applies to pills and other types of reagent containers, and whether they're in your pockets, backpack, belt, etc.**

:cl:
* tweak: Food and reagents in your hands and backpack no longer freeze while in space. They may be allowed to freeze by dropping them directly onto a space turf still. In more general terms, held items and ones in containers now experience reduced or no entropy in low pressure environments.