### PR TITLE
Chronic Lime Disease, a new Stage 2 Symptom

### DIFF
--- a/code/modules/virus2/effect/stage_2.dm
+++ b/code/modules/virus2/effect/stage_2.dm
@@ -798,3 +798,17 @@
 	mob.Stun(5)
 	mob.vessel.remove_reagent(BLOOD,8)
 	active = 0
+
+/datum/disease2/effect/limedisease
+	name = "Chronic Lime Disease"
+	desc = "Unrelated to its Lyme counterpart, causes the infected to vomit limes. Goes well with some salt and tequila."
+	stage = 2
+	badness = EFFECT_DANGER_ANNOYING
+
+/datum/disease2/effect/limedisease/activate(var/mob/living/mob)
+	if (prob(30))
+		mob.say(pick("I could go for some tequila right now.", "Could go for something sour."))
+	if (prob(15))
+		mob.emote("me",1,"vomits up a... lime?")
+		playsound(mob.loc, 'sound/effects/splat.ogg', 50, 1)
+		new /obj/item/weapon/reagent_containers/food/snacks/grown/lime(get_turf(mob))

--- a/code/modules/virus2/effect/stage_3.dm
+++ b/code/modules/virus2/effect/stage_3.dm
@@ -84,6 +84,20 @@
 		playsound(mob.loc, 'sound/effects/splat.ogg', 50, 1)
 		new eggspawn(get_turf(mob))
 
+/datum/disease2/effect/limedisease
+	name = "Chronic Lime Disease"
+	desc = "Unrelated to its Lyme cousin, causes the infected to vomit limes. Goes well with some salt and tequila."
+	stage = 3
+	badness = EFFECT_DANGER_ANNOYING
+
+/datum/disease2/effect/limedisease/activate(var/mob/living/mob)
+	if (prob(30))
+		mob.say(pick("I could go for some tequila right now.", "Mmm... Tequila...", "Could go for something sour."))
+	if (prob(15))
+		mob.emote("me",1,"vomits up a... lime?")
+		playsound(mob.loc, 'sound/effects/splat.ogg', 50, 1)
+		new /obj/item/weapon/reagent_containers/food/snacks/grown/lime(get_turf(mob))
+
 /datum/disease2/effect/confusion
 	name = "Topographical Cretinism"
 	desc = "Attacks the infected's ability to differentiate left and right."

--- a/code/modules/virus2/effect/stage_3.dm
+++ b/code/modules/virus2/effect/stage_3.dm
@@ -84,19 +84,6 @@
 		playsound(mob.loc, 'sound/effects/splat.ogg', 50, 1)
 		new eggspawn(get_turf(mob))
 
-/datum/disease2/effect/limedisease
-	name = "Chronic Lime Disease"
-	desc = "Unrelated to its Lyme counterpart, causes the infected to vomit limes. Goes well with some salt and tequila."
-	stage = 3
-	badness = EFFECT_DANGER_ANNOYING
-
-/datum/disease2/effect/limedisease/activate(var/mob/living/mob)
-	if (prob(30))
-		mob.say(pick("I could go for some tequila right now.", "Could go for something sour."))
-	if (prob(15))
-		mob.emote("me",1,"vomits up a... lime?")
-		playsound(mob.loc, 'sound/effects/splat.ogg', 50, 1)
-		new /obj/item/weapon/reagent_containers/food/snacks/grown/lime(get_turf(mob))
 
 /datum/disease2/effect/confusion
 	name = "Topographical Cretinism"

--- a/code/modules/virus2/effect/stage_3.dm
+++ b/code/modules/virus2/effect/stage_3.dm
@@ -92,7 +92,7 @@
 
 /datum/disease2/effect/limedisease/activate(var/mob/living/mob)
 	if (prob(30))
-		mob.say(pick("I could go for some tequila right now.", "Mmm... Tequila...", "Could go for something sour."))
+		mob.say(pick("I could go for some tequila right now.", "Could go for something sour."))
 	if (prob(15))
 		mob.emote("me",1,"vomits up a... lime?")
 		playsound(mob.loc, 'sound/effects/splat.ogg', 50, 1)

--- a/code/modules/virus2/effect/stage_3.dm
+++ b/code/modules/virus2/effect/stage_3.dm
@@ -86,7 +86,7 @@
 
 /datum/disease2/effect/limedisease
 	name = "Chronic Lime Disease"
-	desc = "Unrelated to its Lyme cousin, causes the infected to vomit limes. Goes well with some salt and tequila."
+	desc = "Unrelated to its Lyme counterpart, causes the infected to vomit limes. Goes well with some salt and tequila."
 	stage = 3
 	badness = EFFECT_DANGER_ANNOYING
 


### PR DESCRIPTION
## What this does
Adds a stage 2 symptom that makes you vomit limes. (not to be confused with Chronic Lyme Disease)
## Why it's good
Funny less-than lethal symptom.

:cl:
 * rscadd: Spessmen might find themselves affected by Lime Disease, and are advised to procure some salt and tequila in that case.