### PR TITLE
Buffs the phazon-nothing reaction.

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -4176,9 +4176,9 @@
 	name = "Random chemical"
 	id = "random"
 	result = null
-	required_reagents = list(NOTHING = 10, PHAZON = 10)
+	required_reagents = list(NOTHING = 1, PHAZON = 1)
 	required_catalysts = list(MUTAGEN = 10, ENZYME = 10)
-	result_amount = 1
+	result_amount = 5
 
 /datum/chemical_reaction/fake_creep // Xenomorph weeds aka creep.
 	name = "Dan's Purple Drank"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -4177,7 +4177,7 @@
 	id = "random"
 	result = null
 	required_reagents = list(NOTHING = 1, PHAZON = 1)
-	required_catalysts = list(MUTAGEN = 10, ENZYME = 10)
+	required_catalysts = list(MUTAGEN = 5, ENZYME = 5)
 	result_amount = 5
 
 /datum/chemical_reaction/fake_creep // Xenomorph weeds aka creep.


### PR DESCRIPTION
## What this does
![Random chemical reaction](https://github.com/vgstation-coders/vgstation13/assets/67024428/587a6148-d15a-4a0a-b217-b8d1f08d3ad3)
As you can see here, ever since it was added, it has only been made 38 times (names censored), mainly due to just how stupidly expensive it is and how little yield it gives. You need to procure 10 phazon sheets to make the required 10u of phazon salt, and when reacting you only got 1u of whatever chemical you made, which would most likely be a drink.
You need 1.5 compressed matter cartridges to make 1 sheet of phazon, which gives only 1u of phazon salt.
Assume we make 2 sheets (so it's 3 matter cartridges instead of 1.5), this costs 16 metal sheets and 8 glass sheets on a roundstart autolathe (or 8.96 and 4.48 sheets respectively in a pico-manipulator lathe).
Simply to acquire enough phazon sheets (10) for this recipe, you need to burn 80 whole metal sheets and 40 glass sheets using roundstart lathes, and 44.8/22.4 respectively on an upgraded lathe.
This is too much even for an "easter egg" reaction.

This buffs the reaction to cost 1u of both nothing and phazon, and has a yield of 5u, instead of just 1u. Still expensive, as it still requires phazon, but not ridiculously so. And it requires 5u of each catalyst instead of 10 (more consistent with other catalysts)
## Why it's good
Makes a unique interesting reaction cheaper and now viable to make.
:cl:
 * tweak: The Phazon-Nothing reaction now costs 1u of phazon and 1u of Nothing to make, and gives 5u of reagent in return. It now requires 5u of Mutagen and 5u of Enzyme as catalysts instead of 10 of each.