### PR TITLE
fix grilles repaired directly using rods not being dense

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -206,7 +206,6 @@
 		ASSERT(istype(W, /obj/item/stack)) //in case someone adds a grille with a non-stackable item as a grille_material
 		var/obj/item/stack/stack = W
 		health = initial(health)
-		broken = 0
 		healthcheck()
 		user.visible_message("<span class='notice'>[user] repairs the [src] with [stack].</span>", \
 		"<span class='notice'>You repair the [src] with [stack].</span>")


### PR DESCRIPTION
density failed to update since `healthcheck()` saw broken was set to 0
oversight from #35457
closes #36002
[bugfix]

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Grilles repaired directly using rods are no longer ethereal/pass-through.