### PR TITLE
Darkness-changing vision stuff such as mesons will no longer fade in and out, instead applying instantly

### DIFF
--- a/code/modules/clothing/glasses/scanners.dm
+++ b/code/modules/clothing/glasses/scanners.dm
@@ -39,6 +39,7 @@
 		if(iscarbon(M) && glasses == slot_glasses)
 			for(var/datum/visioneffect/H in stored_huds)
 				M.apply_hud(H)
+				M.update_perception()
 	..()
 
 /obj/item/clothing/glasses/scanner/unequipped(mob/living/carbon/M, var/from_slot = null)
@@ -46,6 +47,7 @@
 		for(var/datum/visioneffect/H in stored_huds)
 			M.remove_hud(H)
 	//the parent calls for a full redraw of the hud
+	M.update_perception()
 	..()
 
 /obj/item/clothing/glasses/scanner/update_icon()
@@ -71,6 +73,7 @@
 
 	update_icon()
 	C.update_inv_glasses()
+	C.update_perception()
 
 /obj/item/clothing/glasses/scanner/proc/enable(var/mob/living/carbon/C)
 	on = TRUE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1630,17 +1630,17 @@ Use this proc preferably at the end of an equipment loadout
 		var/max_alpha = 0
 		for (var/key in dark_plane.alphas)
 			max_alpha = max(dark_plane.alphas[key], max_alpha)
-		animate(dark_plane, alpha = max_alpha, color = dark_plane.colours, time = 10)
+		animate(dark_plane, alpha = max_alpha, color = dark_plane.colours, time = 0)
 	else if (dark_plane)
-		animate(dark_plane, alpha = initial(dark_plane.alpha), color = dark_plane.colours, time = 10)
+		animate(dark_plane, alpha = initial(dark_plane.alpha), color = dark_plane.colours, time = 0)
 
 	if (self_vision)
 		if (isturf(loc))
 			var/turf/T = loc
 			if (T.get_lumcount() <= 0 && (dark_plane.alpha <= 15) && (master_plane.blend_mode == BLEND_MULTIPLY))
-				animate(self_vision, alpha = self_vision.target_alpha, time = 10)
+				animate(self_vision, alpha = self_vision.target_alpha, time = 0)
 			else
-				animate(self_vision, alpha = 0, time = 10)
+				animate(self_vision, alpha = 0, time = 0)
 
 //Like forceMove(), but for dirs! used in atoms_movable.dm, mainly with chairs and vehicles
 /mob/change_dir(new_dir, var/changer)


### PR DESCRIPTION
That means things like applying mesons will instantly change the vision instead of doing the ugly shadow change

:cl:
 * tweak: Darkness vision changes such as from mesons will now apply instantly instead of gradually fading in or out.