### PR TITLE
Bioballistic Delivery System Multi-Splice Option

### DIFF
--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -331,6 +331,7 @@
 	icon_state = "traitgun"
 	disk_needs_genes = 1
 	var/mode = GENEGUN_MODE_SPLICE
+	var/times_to_splice = 1
 
 /obj/machinery/botany/editor/New()
 	..()
@@ -356,6 +357,7 @@
 
 	data["activity"] = active
 	data["mode"] = mode
+	data["times_to_splice"] = times_to_splice
 
 	if(loaded_disk && loaded_disk.genes.len)
 		data["disk"] = 1
@@ -391,6 +393,12 @@
 	if(..())
 		return 1
 
+	if( href_list["increase_splice_amount"])
+		if(times_to_splice<10)
+			times_to_splice++
+		else
+			times_to_splice = 1
+
 	if(href_list["apply_gene"])
 		if(!loaded_disk || !loaded_seed)
 			return
@@ -408,7 +416,11 @@
 			loaded_seed.modified = 101
 
 		for(var/datum/plantgene/gene in loaded_disk.genes)
-			loaded_seed.seed.apply_gene(gene, mode, usr)
+			if(mode == GENEGUN_MODE_SPLICE)
+				for(var/i = 0, i < times_to_splice, i++) //multisplice
+					loaded_seed.seed.apply_gene(gene, mode, usr)
+			else
+				loaded_seed.seed.apply_gene(gene, mode, usr)
 
 	else if(href_list["toggle_mode"])
 		switch(mode)
@@ -420,3 +432,14 @@
 	usr.set_machine(src)
 	src.add_fingerprint(usr)
 	return 1
+
+/obj/machinery/botany/editor/process()
+//current bug: longer delay time is affecting both splice and merge modes.
+	if(!active)
+		return
+	if(mode == GENEGUN_MODE_SPLICE)
+		if(world.time > last_action + (action_time*times_to_splice)/time_coeff)
+			finished_task()
+	else
+		if(world.time > last_action + action_time/time_coeff)
+			finished_task()

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -439,7 +439,7 @@
 	if(!active)
 		return
 	if(mode == GENEGUN_MODE_SPLICE)
-		if(world.time > last_action + (action_time*times_to_splice)/time_coeff)
+		if(world.time > last_action + ((action_time-times_to_splice)*times_to_splice)/time_coeff) //this formula slightly decreases splice time as values get higher.
 			finished_task()
 	else
 		if(world.time > last_action + action_time/time_coeff)

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -393,12 +393,19 @@
 	if(..())
 		return 1
 
-	if( href_list["increase_splice_amount"])
-		if(times_to_splice<10)
+	if( href_list["change_splice_amount"])
+		var/new_amount = input(usr, "Enter the number of times to perform the SPLICE command: (Between 1 and 10)","Enter Multsplice Coefficient") as num
+		if(new_amount>10)
+			new_amount = 10
+		else if(new_amount<1)
+			new_amount = 1
+		times_to_splice = new_amount
+
+		/*if(times_to_splice<10)
 			times_to_splice++
 		else
 			times_to_splice = 1
-
+*/
 	if(href_list["apply_gene"])
 		if(!loaded_disk || !loaded_seed)
 			return

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -401,11 +401,6 @@
 			new_amount = 1
 		times_to_splice = new_amount
 
-		/*if(times_to_splice<10)
-			times_to_splice++
-		else
-			times_to_splice = 1
-*/
 	if(href_list["apply_gene"])
 		if(!loaded_disk || !loaded_seed)
 			return
@@ -441,7 +436,6 @@
 	return 1
 
 /obj/machinery/botany/editor/process()
-//current bug: longer delay time is affecting both splice and merge modes.
 	if(!active)
 		return
 	if(mode == GENEGUN_MODE_SPLICE)

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -395,10 +395,7 @@
 
 	if( href_list["change_splice_amount"])
 		var/new_amount = input(usr, "Enter the number of times to perform the SPLICE command: (Between 1 and 10)","Enter Multsplice Coefficient",times_to_splice) as num
-		if(new_amount>10)
-			new_amount = 10
-		else if(new_amount<1)
-			new_amount = 1
+		new_amount = clamp(1,new_amount,10)
 		times_to_splice = new_amount
 
 	if(href_list["apply_gene"])

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -394,7 +394,7 @@
 		return 1
 
 	if( href_list["change_splice_amount"])
-		var/new_amount = input(usr, "Enter the number of times to perform the SPLICE command: (Between 1 and 10)","Enter Multsplice Coefficient") as num
+		var/new_amount = input(usr, "Enter the number of times to perform the SPLICE command: (Between 1 and 10)","Enter Multsplice Coefficient",times_to_splice) as num
 		if(new_amount>10)
 			new_amount = 10
 		else if(new_amount<1)

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -439,7 +439,7 @@
 	if(!active)
 		return
 	if(mode == GENEGUN_MODE_SPLICE)
-		if(world.time > last_action + ((action_time-times_to_splice)*times_to_splice)/time_coeff) //this formula slightly decreases splice time as values get higher.
+		if(world.time > last_action + ((action_time-times_to_splice-(times_to_splice/2))*times_to_splice)/time_coeff) //this formula slightly decreases splice time as values get higher.
 			finished_task()
 	else
 		if(world.time > last_action + action_time/time_coeff)

--- a/nano/templates/botany_editor.tmpl
+++ b/nano/templates/botany_editor.tmpl
@@ -52,19 +52,22 @@ Used In File(s): \code\modules\hydroponics\seed_machines.dm
 			<div class = "itemContentSmall">
 				{{if data.mode == 1}}
 					{{:helper.link('SPLICE', 'shuffle', {'toggle_mode' : 1}, null)}}
-					<br>
-					<div class = "itemLabel">
-						MULTISPLICE:
-					</div>
-					<div class = "itemContent">
-						{{:data.times_to_splice}}
-					</div>
-					{{:helper.link('CHANGE', null, {'increase_splice_amount' : 1}, null)}}
 				{{else}}
 					{{:helper.link('PURGE', 'arrowstop-1-s', {'toggle_mode' : 1}, null)}}
 				{{/if}}
 			</div>
 		</div>
+		{{if data.mode == 1}}
+			<br>
+			<div class = "item">
+				<div class = "itemLabel">
+					Multi-Splice:
+				</div>
+				<div class = "itemContent">
+				{{:helper.link(data.times_to_splice, null, {'change_splice_amount' : 1}, null)}}
+				</div>
+			</div>
+		{{/if}}
 	{{else}}
 		<div class="notice">No target seed packet loaded</div>
 	{{/if}}

--- a/nano/templates/botany_editor.tmpl
+++ b/nano/templates/botany_editor.tmpl
@@ -52,6 +52,14 @@ Used In File(s): \code\modules\hydroponics\seed_machines.dm
 			<div class = "itemContentSmall">
 				{{if data.mode == 1}}
 					{{:helper.link('SPLICE', 'shuffle', {'toggle_mode' : 1}, null)}}
+					<br>
+					<div class = "itemLabel">
+						MULTISPLICE:
+					</div>
+					<div class = "itemContent">
+						{{:data.times_to_splice}}
+					</div>
+					{{:helper.link('CHANGE', null, {'increase_splice_amount' : 1}, null)}}
 				{{else}}
 					{{:helper.link('PURGE', 'arrowstop-1-s', {'toggle_mode' : 1}, null)}}
 				{{/if}}


### PR DESCRIPTION
adds a multi-splice option to seed machine.
[multisplice.webm](https://github.com/vgstation-coders/vgstation13/assets/25192877/66051d47-50f8-4ffe-b108-4a7da4bc0ff7)

## What this does
The seed editor now has a feature called Multi-Splice. It defaults to 1(this is just a single splice) but can be changed to a maximum of 10. The multiplier will determine how many Splices a seed receives during the splice action (2 = 2x Splice, 3=3x, etc.). The time to complete scales with the multiplier so a Multi-Splice action of 10 will take 10 times as long to finish as a single splice.

this option only appears in Splice mode and not Purge mode as Purges don't need/benefit from multiple uses.

## Why it's good
Improves quality of life for botanists. Gone are the days where you have to sit at the machine and spam splice into a seed and mentally track the number of splices. 

EDIT:
slightly tweaked the speed values to reduce splice times in scale with the multiplier amount:
this results in slightly quicker multisplices at higher values
it looks something like:
_(X-Y-(Y/2))*Y_
where:
_X = time to splice once 
Y = Splice Multiplier_

ie: a multisplice of 10(the max), takes 35 real world seconds
[qol]

:cl:
 * rscadd: Bioballistic Delivery System now has a multi-splice option which allows for multiple splices in one go. The time to complete the splice will scale proportionally with the number of splices so a large amount of splices will take longer to complete.
