### PR TITLE
Fixes Dynamic midround rulesets that polled ghosts counting less candidates than they should

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -102,7 +102,7 @@
 	return TRUE
 
 /datum/dynamic_ruleset/midround/from_ghosts/ready(var/forced = 0)
-	if (required_candidates > (dead_players.len + list_observers.len) && !forced)
+	if ((required_candidates > (dead_players.len + list_observers.len)) && !forced)
 		return 0
 	return ..()
 


### PR DESCRIPTION
Problem: trim_list(), which filters potential candidates for various rulesets, didn't play nicely with from_ghosts type rulesets because significantly less ghost and dead candidates were counted for it. Namely:
- Ghosts and observers that had "No" on their preferences would be counted, but not ghosts that had it set to "Never"
- The role you had as a living character still counted, meaning that ghosts that used to be part of "protected" or "restricted" jobs wouldn't be considered for whether a "from ghosts" ruleset could fire.

This patches it by ignoring a few conditions in the midround ruleset's trim_list() if the candidate is a ghost and if the code is specifically counting ghosts.
This oversight affected:
- Ragin' Mages (hasn't fired naturally since August)
- Nuclear Operatives (hasn't fired naturally since December)
- Blob Storms (has fired once a month)
- Revolutionary Squad (hasn't fired since around September)
- Space Ninja Attack (fires far less frequently than the latejoin version, has fired twice this month and before that the last time it fired was in August)
- Soul Rambler Migration
- Time Agent Anomaly (has only fired twice this year)
- Loose Catbeast (seems to be the least affected because of its relaxed conditions to appear)
- Vox Heist
- Plague Mice Invasion
- Spider Infestation
- Alien Infestation
- Pulse Demon Infiltration (has only fired once this year)
- Grue Infestation
- Prisoner Transfer

Thanks to Rhydens for reporting the bug!

:cl:
 * bugfix: Fixed an oversight that caused midround Dynamic rulesets that asked ghosts to participate to fire less times than intended.
 * tweak: Preference settings will no longer have an effect on what ghost-playable roles may appear during a round.