### PR TITLE
Certain latejoin rulesets now have the same requirements as their midround equivalents

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -66,6 +66,17 @@
 	repeatable = TRUE
 	flags = TRAITOR_RULESET
 
+/datum/dynamic_ruleset/latejoin/infiltrator/ready(var/forced = 0)
+	if (forced)
+		return ..()
+	var/player_count = mode.living_players.len
+	var/antag_count = mode.living_antags.len
+	var/max_traitors = round(player_count / 10) + 1
+	if(required_candidates > player_count)
+		return 0
+	if(antag_count < max_traitors && prob(mode.midround_threat_level))//adding traitors if the antag population is getting low
+		return ..()
+	return 0
 
 /datum/dynamic_ruleset/latejoin/infiltrator/execute()
 	var/mob/M = pick(assigned)
@@ -96,6 +107,16 @@
 	requirements = list(90,90,70,40,30,20,10,10,10,10)
 	high_population_requirement = 40
 	repeatable = TRUE
+
+/datum/dynamic_ruleset/latejoin/raginmages/ready(var/forced=0)
+	if (forced)
+		return ..()
+	if(locate(/datum/dynamic_ruleset/roundstart/cwc) in mode.executed_rules)
+		message_admins("Rejected Ragin' Mages as there was a Civil War.")
+		return 0 //This is elegantly skipped by specific ruleset.
+		//This means that all ragin mages in CWC will be called only by that ruleset.
+	else
+		return ..()
 
 /datum/dynamic_ruleset/latejoin/raginmages/execute()
 	var/mob/M = pick(assigned)
@@ -133,6 +154,17 @@
 	logo = "ninja-logo"
 
 	repeatable = TRUE
+
+/datum/dynamic_ruleset/latejoin/ninja/ready(var/forced=0)
+	if (forced)
+		return ..()
+	var/player_count = mode.living_players.len
+	var/antag_count = mode.living_antags.len
+	var/max_traitors = round(player_count / 10) + 1
+	if ((antag_count < max_traitors) && prob(mode.midround_threat_level))
+		return ..()
+	return 0
+
 
 /datum/dynamic_ruleset/latejoin/ninja/execute()
 	var/mob/M = pick(assigned)


### PR DESCRIPTION
Namely traitors, wizards and space ninjas. The latejoin variants lacked the extra conditions involved in their midround equivalents, meaning that:
- Traitors didn't care how many antags there were based on living crewmembers nor the RNG chance to add them based on midround threat level (equivalent to the midround threat points at the start of the game)
- Wizards didn't care if there already was a Civil War of Casters
- Space ninjas had the same deal as latejoin traitors did

This brings them to parity, but as a consequence makes latejoin traitors and ninjas significantly rarer.

:cl:
 * tweak: Traitors, wizards and space ninjas from freshly-arrived crewmembers now respect the same checks that midround traitors, wizards and ninjas do. As a consequence, this makes them (except for the wizard) significantly rarer.