### PR TITLE
Hotfix: Fixes PAI chargeloop and chemsynth/foodsynth bug

### DIFF
--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -719,7 +719,7 @@ Target Machine: "}
 		else
 			charge = 0
 			return 0
-		sleep(10)
+		sleep(1 SECONDS)
 
 // EMP Shielding, just a description
 /mob/living/silicon/pai/proc/softwareShield()

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -249,7 +249,7 @@
 			if(href_list["chem"])
 				if(!get_holder_of_type(loc, /mob))
 					to_chat(src, "<span class='warning'>You must have a carrier to inject with chemicals!</span>")
-				else if(chargeloop("chemsynth"))
+				else if(chargeloop(SOFT_CS))
 					var/mob/M = get_holder_of_type(loc, /mob)
 					if(M) //Sanity
 						M.reagents.add_reagent(href_list["chem"], 15)
@@ -257,7 +257,7 @@
 				else
 					to_chat(src, "<span class='warning'>Charge interrupted.</span>")
 		if(SOFT_FS)
-			if(href_list["food"] && chargeloop("foodsynth"))
+			if(href_list["food"] && chargeloop(SOFT_FS))
 				var/foodType = href_list["food"]
 				var/found = FALSE
 				for (var/name in synthable_default_food)
@@ -376,7 +376,7 @@
 		if(s == SOFT_CS)
 			dat += "<a href='byond://?src=\ref[src];software=[SOFT_CS];sub=0'>Chemical Synthesizer</a> <br>"
 		if(s == SOFT_FS)
-			dat += "<a href='byond://?src=\ref[src];software=[SOFT_CS];sub=0'>Nutrition Synthesizer</a> <br>"
+			dat += "<a href='byond://?src=\ref[src];software=[SOFT_FS];sub=0'>Nutrition Synthesizer</a> <br>"
 	dat += "<br>"
 
 	// Navigation
@@ -719,7 +719,7 @@ Target Machine: "}
 		else
 			charge = 0
 			return 0
-		sleep(1 SECONDS)
+		sleep(10)
 
 // EMP Shielding, just a description
 /mob/living/silicon/pai/proc/softwareShield()


### PR DESCRIPTION
[bugfix] [hotfix]
chargeloop was using an outdated string instead of its proper define thus failing.
chemsynth and foodsynth had the same define in one instance leading to both options opening the same.
its fixed now.
Resolves #36058
:cl:
 * bugfix: PAI foodsynth and chemsynth now work properly