### PR TITLE
RPD UI: slime extract edition

### DIFF
--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -305,6 +305,8 @@
 		return
 
 	src.build_all = !src.build_all
+	if (interface)
+		rebuild_ui() 
 	to_chat(usr, "You [build_all ? "enable" : "disable"] the multilayer mode.")
 
 /obj/item/device/rcd/rpd/proc/autowrench()
@@ -315,6 +317,8 @@
 		return
 
 	src.autowrench = !src.autowrench
+	if (interface)
+		rebuild_ui() 
 	to_chat(usr, "You [autowrench ? "enable" : "disable"] the automatic wrenching mode.")
 
 /obj/item/device/rcd/rpd/admin

--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -192,6 +192,7 @@
 	if(build_all && istype(selected, /datum/rcd_schematic/pipe))
 		var/datum/rcd_schematic/pipe/our_schematic = selected //typecast
 		if(our_schematic.layer) // this is needed because disposal pipe schematic datums are retarded
+			var/oldlayer=layer
 			for(var/layer in 1 to 5)
 				busy  = TRUE // Busy to prevent switching schematic while it's in use.
 				our_schematic.set_layer(layer)
@@ -210,6 +211,8 @@
 							to_chat(user, "<span class='warning'>\the [src]'s error light flickers.</span>")
 
 				busy = FALSE
+			layer=oldlayer
+			our_schematic.set_layer(layer)
 			return 1
 
 	busy  = TRUE // Busy to prevent switching schematic while it's in use.

--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -111,9 +111,9 @@
 	var/autotext=""
 	
 	if (has_metal_slime)//build_all
-		multitext=" <div style='margin-top:1em;'>Multilayer Mode: <a href='?src=\ref[interface];toggle_multi=1'><span class='[build_all? "schem_selected" : "schem"]'>[build_all ? "On" : "Off"]</span></a></div> "
+		multitext=" <div style='margin-top:1em;'><b>Multilayer Mode: </b><a href='?src=\ref[interface];toggle_multi=1'><span class='[build_all? "schem_selected" : "schem"]'>[build_all ? "On" : "Off"]</span></a></div> "
 	if (has_yellow_slime)//build_all
-		autotext=" <div style='margin-top:1em;'>Autowrench: <a href='?src=\ref[interface];toggle_auto=1'><span class='[autowrench? "schem_selected" : "schem"]'>[autowrench ? "On" : "Off"]</span></a></div> "
+		autotext=" <div style='margin-top:1em;'><b>Autowrench: </b><a href='?src=\ref[interface];toggle_auto=1'><span class='[autowrench? "schem_selected" : "schem"]'>[autowrench ? "On" : "Off"]</span></a></div> "
 
 	dat += {"
 		<b>Selected:</b> <span id="selectedname"></span>
@@ -143,6 +143,32 @@
 		interface.updateContent("selectedname", selected.name)
 
 	rebuild_favs()
+
+/obj/item/device/rcd/rpd/update_options_menu()
+	if(selected)
+		for(var/client/client in interface.clients)
+			selected.send_assets(client)
+		var/schematichtml=selected.get_HTML(args)
+		if (build_all)
+			schematichtml=replacetext(replacetext(schematichtml,"id=\"layer\"","id=\"layer_selected\""),"id=\"layer_center\"","id=\"layer_center_selected\"")
+		if (autowrench)
+			schematichtml=replacetext(replacetext(schematichtml,"id=\"layer_selected\"","id=\"layer_selectedauto\""),"id=\"layer_center_selected\"","id=\"layer_center_selectedauto\"")
+		interface.updateContent("schematic_options", schematichtml )
+	else
+		interface.updateContent("schematic_options", " ")
+
+
+/obj/item/device/rcd/rpd/Topic(var/href, var/list/href_list)
+	..()
+	if (href_list["toggle_auto"])
+		autowrench=has_yellow_slime ? !autowrench : 0
+		rebuild_ui()
+		return TRUE
+	if (href_list["toggle_multi"])
+		build_all=has_metal_slime ? !build_all : 0
+		rebuild_ui()
+		return TRUE
+	
 
 
 
@@ -186,16 +212,6 @@
 					favorites.Swap(index, index - 1)
 
 				rebuild_favs()
-			if("toggle_multi")
-				if (has_metal_slime)
-					build_all = !build_all
-					rebuild_ui()
-					return 1
-			if("toggle_auto")
-				if (has_yellow_slime)
-					autowrench = !autowrench
-					rebuild_ui()
-					return 1
 		return 1
 
 	// The href didn't get handled by us so we pass it down to the selected schematic.

--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -259,7 +259,7 @@
 	if(build_all && istype(selected, /datum/rcd_schematic/pipe))
 		var/datum/rcd_schematic/pipe/our_schematic = selected //typecast
 		if(our_schematic.layer) // this is needed because disposal pipe schematic datums are retarded
-			var/oldlayer=layer
+			var/oldlayer=data["pipe_layer"] //why is this variable not just part of the RPD???
 			for(var/layer in 1 to 5)
 				busy  = TRUE // Busy to prevent switching schematic while it's in use.
 				our_schematic.set_layer(layer)
@@ -278,8 +278,9 @@
 							to_chat(user, "<span class='warning'>\the [src]'s error light flickers.</span>")
 
 				busy = FALSE
-			layer=oldlayer
-			our_schematic.set_layer(layer)
+				data["pipe_layer"]=oldlayer
+			data["pipe_layer"]=oldlayer
+			our_schematic.set_layer(oldlayer)
 			return 1
 
 	busy  = TRUE // Busy to prevent switching schematic while it's in use.

--- a/code/modules/html_interface/RCD/RCD.css
+++ b/code/modules/html_interface/RCD/RCD.css
@@ -151,6 +151,22 @@ left:160px;
 	border:0px;
 	background-color:#D00;
 }
+#layer_selectedauto{
+	border-radius:2px;
+	padding:0px;
+	border:0px;
+	margin:0px;
+	background-color:#15C;
+}
+#layer_center_selectedauto{
+	border-radius:2px;
+	padding:0px;
+	border:0px;
+	margin:0px;
+	background-color:#14B;
+}
+
+
 
 #layer:hover{
 	background-color:#e7e7e7;
@@ -164,6 +180,13 @@ left:160px;
 #layer_center_selected:hover{
 	background-color:#f33;
 }
+#layer_selectedauto:hover{
+	background-color:#38F;
+}
+#layer_center_selectedauto:hover{
+	background-color:#37E;
+}
+
 
 #selectedname{
 	color:#fff;


### PR DESCRIPTION
[ui] [qol] [bugfix]

## What this does
https://github.com/vgstation-coders/vgstation13/assets/68451232/154ea4b1-07c4-40bd-bba1-d3aeed6ee037

adds buttons and visuals for if autowrench or multilayer mode is enabled
fixes the multilayer mode changing your selected layer when used

## Why it's good
adds a more convenient way to turn these modes on and off
it also (unatomically but the code to fix it was right there so...) makes the multilayer mode more convenient to use by not changing your settings.

## Changelog
:cl:
 * rscadd: the RPD will now show buttons for toggling autowrench and multilayer when relevant
 * rscadd: the RPD's pipe layer selectors will indicate if autowrench or multilayer is enabled
 * bugfix: the RPD will no longer change the current layer when multilayer is disabled

