### PR TITLE
Wizards without butts will no longer power conduction plates

### DIFF
--- a/code/modules/fish/fish_tank.dm
+++ b/code/modules/fish/fish_tank.dm
@@ -808,7 +808,7 @@
 		add_avail(power)
 		return
 	for(var/mob/living/carbon/human/H in loc)
-		if(iswizard(H) && !H.stat)
+		if(iswizard(H) && !H.stat && H.op_stage.butt != SURGERY_NO_BUTT)
 			power += FIRE_CARBON_ENERGY_RELEASED*H.health/H.maxHealth
 			H.adjustFireLoss(3)
 			if(prob(10))

--- a/code/modules/fish/fish_tank.dm
+++ b/code/modules/fish/fish_tank.dm
@@ -808,7 +808,7 @@
 		add_avail(power)
 		return
 	for(var/mob/living/carbon/human/H in loc)
-		if(iswizard(H) && !H.stat && H.op_stage.butt != SURGERY_NO_BUTT)
+		if(H.mind.wizard_spells.len && !H.stat)
 			power += FIRE_CARBON_ENERGY_RELEASED*H.health/H.maxHealth
 			H.adjustFireLoss(3)
 			if(prob(10))


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Removing a wizard's ass will now prevent them from producing power on a conduction plate. Conduction plates will now also generate power if a non-wizard has a magical ass.

## Why it's good
<!-- Explain why you think these changes are good. -->
Consistency; closes #36064 and still provides people a way to squeeze power out of a wizard after neutering their spells.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Wizards without butts will no longer power conduction plates.
 * tweak: Non-wizards with a magical butt will now generate power on conduction plates.