### PR TITLE
allow PKA vouchers to be redeemed in snaxi's surface mine

### DIFF
--- a/code/game/objects/items/vouchers.dm
+++ b/code/game/objects/items/vouchers.dm
@@ -45,7 +45,7 @@
 
 /obj/item/voucher/warp/kinetic_accelerator/vouch_condition()
 	var/turf/T = get_turf(src)
-	if(istype(T.loc, /area/mine/explored)||istype(T.loc, /area/mine/unexplored))
+	if(istype(T.loc, /area/mine/explored)||istype(T.loc, /area/mine/unexplored)||istype(T.loc, /area/surface/mine))
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
## What this does
title, fixes #36073

## Why it's good
makes more sense to the player than having to go to the roid, makes snaxi mining less tiresome/tedious

[tweak]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: PKA's will now properly spawn in Snaxi's surface mine.