### PR TITLE
A bunch of small wizard changes

### DIFF
--- a/__DEFINES/spell_defines.dm
+++ b/__DEFINES/spell_defines.dm
@@ -22,6 +22,7 @@
 #define LOSE_IN_TRANSFER 16384 //If your mind is transferred, you'll lose this spell.
 #define IS_HARMFUL 32768	//For pacify checks to determine whether the spell can be cast
 #define NO_TURNING 65536 //User does not turn around to face the target when using the spell
+#define NO_SPELLBOOK 131072 //Does not show up in the spell list for spellbook purposes
 
 //invocation
 #define SpI_SHOUT	"shout"

--- a/code/_onclick/hud/spell_screen_objects.dm
+++ b/code/_onclick/hud/spell_screen_objects.dm
@@ -93,14 +93,16 @@
 	if(spell.connected_button) //we have one already, for some reason
 		if(spell.connected_button in spell_objects)
 			return
-		else
+		else //Bring it to the new spellmaster!
+			if(spell.connected_button.spellmaster)
+				spell.connected_button.spellmaster.spell_objects.Remove(spell.connected_button)
 			spell_objects.Add(spell.connected_button)
+			spell.connected_button.spellmaster = src
 			toggle_open(2)
 			return
 
 	if(spell.spell_flags & NO_BUTTON) //no button to add if we don't get one
 		return
-
 	var/obj/abstract/screen/spell/newscreen = new /obj/abstract/screen/spell
 	newscreen.spellmaster = src
 	newscreen.spell = spell

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -71,7 +71,7 @@
 /datum/role/wizard/PostMindTransfer(var/mob/living/new_character, var/mob/living/old_character)
 	. = ..()
 	for (var/spell/S in old_character.spell_list)
-		if (S.user_type == USER_TYPE_WIZARD && !(S.spell_flags & LOSE_IN_TRANSFER))
+		if ((S.user_type == (USER_TYPE_WIZARD || USER_TYPE_SPELLBOOK)) && !(S.spell_flags & LOSE_IN_TRANSFER))
 			new_character.add_spell(S)
 
 /datum/role/wizard/GetScoreboard()

--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -370,11 +370,13 @@
 /datum/spellbook_artifact/nogunallowed
 	name = "No Gun Allowed"
 	abbreviation = "NGA"
-	desc = "Forgo the use of guns in exchange for magical power. Some within the Wizard Federation have lobbied to make this spell a legal obligation."
+	desc = "Forgo the use of guns in exchange for magical power. Some within the Wizard Federation have lobbied to make this spell a legal obligation. Non-refundable."
 	price = -1 * Sp_BASE_PRICE
 	one_use = TRUE
 
 /datum/spellbook_artifact/nogunallowed/can_buy(var/mob/user)
+	for(var/spell/passive/nogunallowed/NG in user.spell_list) //In case the user gets hold of a second spellbook
+		return FALSE
 	return iswizard(user) || isapprentice(user) || ismagician(user)
 
 /datum/spellbook_artifact/nogunallowed/purchased(mob/living/carbon/human/H)

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -63,6 +63,8 @@
 
 	for(var/wizard_spell in getAllWizSpells())
 		var/spell/S = new wizard_spell
+		if(S.spell_flags & NO_SPELLBOOK)
+			continue
 		all_spells += wizard_spell
 		if(!S.holiday_required.len || (Holiday in S.holiday_required))
 			switch(S.specialization)

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -334,7 +334,12 @@
 		var/buy_type = text2path(href_list["spell"])
 
 		if(ispath(buy_type, /spell)) //Passed a spell typepath
-			if(locate(buy_type) in usr.spell_list)
+			var/found_same_spell = FALSE
+			for(var/spell/spell_path_to_check in usr.spell_list)
+				if(buy_type == spell_path_to_check.type)
+					found_same_spell = TRUE
+					break
+			if(found_same_spell)
 				to_chat(usr, "<span class='notice'>You already know that spell. Perhaps you'd like to upgrade it instead?</span>")
 
 			else if(buy_type in all_spells)

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -19,7 +19,7 @@
 	var/list/misc_spells = list()
 
 	//Unlike the list above, the available_artifacts list builds itself from all subtypes of /datum/spellbook_artifact
-	var/static/list/available_artifacts = list()
+	var/list/available_artifacts = list()
 
 	var/static/list/available_potions = list(
 		/obj/item/potion/healing = Sp_BASE_PRICE,

--- a/code/game/gamemodes/wizard/spellbook_oneuse.dm
+++ b/code/game/gamemodes/wizard/spellbook_oneuse.dm
@@ -453,7 +453,7 @@
 	desc = "This book has several completely blank pages."
 
 /obj/item/weapon/spellbook/oneuse/firebreath
-	spell = /spell/targeted/projectile/dumbfire/fireball/firebreath
+	spell = /spell/targeted/projectile/dumbfire/firebreath
 	spellname = "fire breath"
 	icon_state = "bookfirebreath"
 	desc = "This book's pages are singed."

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -74,9 +74,8 @@
 	desc = "\An [lifestage_name()] [colour] slime."
 	icon_state = "[iconstate_color()] [lifestage_name()] slime"
 	real_name = name
-	spawn (1)
+	spawn (0)
 		regenerate_icons()
-		to_chat(src, "<span class='notice'>Your icons have been generated!</span>")
 	..()
 
 /mob/living/carbon/slime/proc/lifestage_updates()

--- a/code/modules/mob/spells.dm
+++ b/code/modules/mob/spells.dm
@@ -18,14 +18,17 @@
 					mind.wizard_spells += spell_to_add
 				return 1
 
-	var/obj/abstract/screen/movable/spell_master/new_spell_master = new master_type //we're here because either we didn't find our type(or we have no spell masters to attach t)
-	if(client)
-		src.client.screen += new_spell_master
-	new_spell_master.spell_holder = src
-	new_spell_master.add_spell(spell_to_add)
-	if(spell_base)
-		new_spell_master.icon_state = spell_base
-	spell_masters.Add(new_spell_master)
+	//Don't do the spellmaster menu stuff if there's not supposed to be a button for the spell
+	var/create_spellmaster = !(spell_to_add.spell_flags & NO_BUTTON)
+	if(create_spellmaster)
+		var/obj/abstract/screen/movable/spell_master/new_spell_master = new master_type //we're here because either we didn't find our type(or we have no spell masters to attach t)
+		if(client)
+			src.client.screen += new_spell_master
+		new_spell_master.spell_holder = src
+		new_spell_master.add_spell(spell_to_add)
+		if(spell_base)
+			new_spell_master.icon_state = spell_base
+		spell_masters.Add(new_spell_master)
 	spell_list.Add(spell_to_add)
 	spell_to_add.on_added(src)
 	if(mind && iswizard)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -292,6 +292,7 @@
 	if(!new_species || !(new_species in all_species))
 		new_species = pick(whitelisted_species)
 	new_human.set_species(new_species)
+	new_human.regenerate_icons()
 	if(isliving(src))
 		var/mob/living/L = src
 		new_human.languages |= L.languages

--- a/code/modules/spells/passive/no_clothes.dm
+++ b/code/modules/spells/passive/no_clothes.dm
@@ -6,4 +6,5 @@
 	hud_state = "wiz_noclothes"
 	price = 2 * Sp_BASE_PRICE
 	specialization = SSUTILITY
+	range = SELFCAST
 //The no_clothes check exists in spell_code.dm

--- a/code/modules/spells/passive/no_gun_allowed.dm
+++ b/code/modules/spells/passive/no_gun_allowed.dm
@@ -1,5 +1,3 @@
-//This spell is checked in code/modules/mob/mob_helpers.dm, no_gun_allowed_spellcheck()
-
 /spell/passive/nogunallowed
 	name = "No Gun Allowed"
 	abbreviation = "NG"
@@ -7,6 +5,7 @@
 	hud_state = "wiz_noclothes"
 	user_type = USER_TYPE_WIZARD
 	spell_flags = NO_BUTTON|NO_SPELLBOOK //Already exists in the artifact section
+	range = SELFCAST
 
 /spell/passive/nogunallowed/on_added(mob/user)
 	user.flags |= HONORABLE_NOGUNALLOWED

--- a/code/modules/spells/passive/no_gun_allowed.dm
+++ b/code/modules/spells/passive/no_gun_allowed.dm
@@ -1,9 +1,12 @@
+//This spell is checked in code/modules/mob/mob_helpers.dm, no_gun_allowed_spellcheck()
+
 /spell/passive/nogunallowed
 	name = "No Gun Allowed"
 	abbreviation = "NG"
 	desc = "Forgo the use of guns in exchange for magical power. Some within the Wizard Federation have lobbied to make this spell a legal obligation."
 	hud_state = "wiz_noclothes"
-	spell_flags = NO_BUTTON
+	user_type = USER_TYPE_WIZARD
+	spell_flags = NO_BUTTON|NO_SPELLBOOK //Already exists in the artifact section
 
 /spell/passive/nogunallowed/on_added(mob/user)
 	user.flags |= HONORABLE_NOGUNALLOWED

--- a/code/modules/spells/targeted/pacify.dm
+++ b/code/modules/spells/targeted/pacify.dm
@@ -21,13 +21,15 @@
 	hud_state = "wiz_pacify"
 
 /spell/targeted/pacify/cast(list/targets, mob/user)
-	..()
+	if(!isturf(targets[1])) //If something or someone that wasn't a turf gets directly clicked, we get the target's turf instead
+		var/list/turf_target = list()
+		turf_target.Add(get_turf(targets[1]))
+		targets = turf_target
 	if(targets)
 		if(user.reagents)
 			user.reagents.add_reagent(CHILLWAX, 4 + (spell_levels[Sp_POWER]/2))
 		var/turf/target = targets[1]
-		if(isturf(target))
-			target.vis_contents += new /obj/effect/overlay/pacify_aoe(target, spell_levels[Sp_POWER], spell_levels[Sp_RANGE])
+		target.vis_contents += new /obj/effect/overlay/pacify_aoe(target, spell_levels[Sp_POWER], spell_levels[Sp_RANGE])
 
 /spell/targeted/pacify/apply_upgrade(upgrade_type)
 	switch(upgrade_type)
@@ -54,7 +56,7 @@
 /spell/targeted/pacify/is_valid_target(atom/target, mob/user, options, bypass_range = 0)
 	if(!istype(target))
 		return 0
-	return (isturf(target))
+	return (get_turf(target) in view(range, user))
 
 /obj/effect/overlay/pacify_aoe
 	name = "energy field"

--- a/code/modules/spells/targeted/projectile/fireball.dm
+++ b/code/modules/spells/targeted/projectile/fireball.dm
@@ -15,7 +15,6 @@
 	range = 20
 	cooldown_min = 20 //10 deciseconds reduction per rank
 
-	spell_flags = 0
 	spell_aspect_flags = SPELL_FIRE
 	duration = 20
 	projectile_speed = 1

--- a/code/modules/spells/targeted/projectile/firebreath.dm
+++ b/code/modules/spells/targeted/projectile/firebreath.dm
@@ -1,35 +1,40 @@
-/spell/targeted/projectile/dumbfire/fireball/firebreath
+/spell/targeted/projectile/dumbfire/firebreath
 	name = "Fire Breath"
+	abbreviation = "FB"
 	desc = "This spell allows you to spew a plume of fire."
 	user_type = USER_TYPE_WIZARD
 	specialization = SSOFFENSIVE
 
 	proj_type = /obj/item/projectile/fire_breath
 
-	price = Sp_BASE_PRICE / 2
 	school = "evocation"
-	invocation = "SPY'SI MEAT'A'BAL"
-
+	price = Sp_BASE_PRICE / 2
+	charge_max = 100
 	spell_flags = WAIT_FOR_CLICK | IS_HARMFUL
+	invocation = "SPY'SI MEAT'A'BAL"
+	invocation_type = SpI_SHOUT
+	range = 20
+	cooldown_min = 20
+
 	spell_aspect_flags = SPELL_FIRE
+	duration = 20
+	projectile_speed = 1
 	dumbfire = 0
 
-	amt_dam_brute = 0
-	amt_dam_fire = 0
 	var/pressure = ONE_ATMOSPHERE * 4.5
 	level_max = list(Sp_TOTAL = 8, Sp_SPEED = 4, Sp_POWER = 4)
 
 	hud_state = "wiz_firebreath"
 
-/spell/targeted/projectile/dumbfire/fireball/firebreath/spawn_projectile(var/location, var/direction)
+/spell/targeted/projectile/dumbfire/firebreath/spawn_projectile(var/location, var/direction)
 	return new proj_type(location,direction,P = pressure)
 
-/spell/targeted/projectile/dumbfire/fireball/firebreath/get_upgrade_info(upgrade_type, level)
+/spell/targeted/projectile/dumbfire/firebreath/get_upgrade_info(upgrade_type, level)
 	if(upgrade_type == Sp_POWER)
 		return "Increase the size of the fire plume."
 	return ..()
 
-/spell/targeted/projectile/dumbfire/fireball/firebreath/empower_spell()
+/spell/targeted/projectile/dumbfire/firebreath/empower_spell()
 	spell_levels[Sp_POWER]++
 
 	var/current_name = name


### PR DESCRIPTION
Fixes #36120 
Fixes #31981 
Fixes #21771 
Fixes #17346

:cl:
 * bugfix: Buying a spell that has no spell menu button will no longer create a phantom spell menu if it is the first spell in it.
 * tweak: Ancient spellbook spells will now properly be counted as wizard spells that get transferred alongside regular wizard spells.
 * bugfix: Fixed an oversight where it was possible for a wizard to get points for the "No Gun Allowed" restriction multiple times, provided that he had extra spellbooks.
 * bugfix: Fixed a bug where the "No Gun Allowed" restriction wasn't transferred when the wizard transformed into something else, meaning that they would be able to use guns.
 * bugfix: Fixed a bug where artifacts that could be purchased only one time could be repurchased again after buying the wizard's spellbook bundle or after summoning magic, which also fixes an exploit where it was possible to infinitely buy Summon Magic as long as the wizard bought No Gun Allowed after every cast.
 * bugfix: The "No Clothes" passive will no longer say it has "Range: 7", but instead "Range: Self".
 * bugfix: Players who got transformed into humanoids will now properly retain their spells.
 * bugfix: Being transformed into a slime will no longer give you a chat message that says "Your icons have been generated!".
 * bugfix: Victims of a Staff of Change's humanoid transformation will now immediately update their sprites rather than after a short moment.
 * bugfix: Fixed a nearly 5 years old bug where Fireball could be used while pacified.
 * bugfix: Fixed a bug where it was impossible to buy Fireball after buying Fire Breath. Fire Breath is now its own independent spell, and the way the spellbook searches for known spells in a player's mind has been changed to fix the edge-case bug where buying a sub-type of a spell would prevent that spell from being purchased.
 * bugfix: Targeting someone directly with Pacify will now cast the spell at their location.
 * bugfix: Pacify can no longer be targeted at tiles that are not in the player's view. No, you can't use mesons to do it either, but you can use the Scrying Orb.