### PR TITLE
add tech origin for goonecode

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1199,6 +1199,7 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define MECH_SCAN_FAIL		1 // Cannot be scanned at all.
 #define MECH_SCAN_ILLEGAL	2 // Can only be scanned by the antag scanner.
 #define MECH_SCAN_ACCESS	4 // Can only be scanned with the access required for the machine
+#define MECH_SCAN_GOONECODE 8 // Cannot be scanned and gives a "this is closed source!" message on scan attempt.
 
 
 // EMOTES!

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -830,8 +830,8 @@
 	icon = 'icons/obj/module.dmi'
 	icon_state = "gooncode"
 	w_class = W_CLASS_TINY
-	origin_tech = Tc_MATERIALS + "=10;" + Tc_PLASMATECH + "=5;" + Tc_SYNDICATE + "=3;" + Tc_PROGRAMMING + "=10;" + Tc_BLUESPACE + "=5;" + Tc_POWERSTORAGE + "=5" + Tc_BIOTECH + "=6"
-	mech_flags = MECH_SCAN_FAIL //It's the holy grail!
+	origin_tech = Tc_MATERIALS + "=10;" + Tc_PLASMATECH + "=6;" + Tc_SYNDICATE + "=6;" + Tc_PROGRAMMING + "=-10;" + Tc_BLUESPACE + "=6;" + Tc_POWERSTORAGE + "=6;" + Tc_BIOTECH + "=6;" + Tc_NANOTRASEN + "1"
+	mech_flags = MECH_SCAN_GOONECODE //It's closed source!
 
 /obj/item/toy/gooncode/suicide_act(var/mob/living/user)
 	to_chat(viewers(user), "<span class = 'danger'>[user] is using [src.name]! It looks like \he's trying to re-add poo!</span>")

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -831,6 +831,7 @@
 	icon_state = "gooncode"
 	w_class = W_CLASS_TINY
 	origin_tech = Tc_MATERIALS + "=10;" + Tc_PLASMATECH + "=5;" + Tc_SYNDICATE + "=3;" + Tc_PROGRAMMING + "=10;" + Tc_BLUESPACE + "=5;" + Tc_POWERSTORAGE + "=5" + Tc_BIOTECH + "=6"
+	mech_flags = MECH_SCAN_FAIL //It's the holy grail!
 
 /obj/item/toy/gooncode/suicide_act(var/mob/living/user)
 	to_chat(viewers(user), "<span class = 'danger'>[user] is using [src.name]! It looks like \he's trying to re-add poo!</span>")

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -830,7 +830,7 @@
 	icon = 'icons/obj/module.dmi'
 	icon_state = "gooncode"
 	w_class = W_CLASS_TINY
-	origin_tech = Tc_MATERIALS + "=10;" + Tc_PLASMATECH + "=5;" + Tc_SYNDICATE + "=3;" + Tc_PROGRAMMING + "=10;" + Tc_BLUESPACE + "=5;" + Tc_POWERSTORAGE + "=5"
+	origin_tech = Tc_MATERIALS + "=10;" + Tc_PLASMATECH + "=5;" + Tc_SYNDICATE + "=3;" + Tc_PROGRAMMING + "=10;" + Tc_BLUESPACE + "=5;" + Tc_POWERSTORAGE + "=5" + Tc_BIOTECH + "=6"
 
 /obj/item/toy/gooncode/suicide_act(var/mob/living/user)
 	to_chat(viewers(user), "<span class = 'danger'>[user] is using [src.name]! It looks like \he's trying to re-add poo!</span>")

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -830,6 +830,7 @@
 	icon = 'icons/obj/module.dmi'
 	icon_state = "gooncode"
 	w_class = W_CLASS_TINY
+	origin_tech = Tc_MATERIALS + "=10;" + Tc_PLASMATECH + "=5;" + Tc_SYNDICATE + "=3;" + Tc_PROGRAMMING + "=10;" + Tc_BLUESPACE + "=5;" + Tc_POWERSTORAGE + "=5"
 
 /obj/item/toy/gooncode/suicide_act(var/mob/living/user)
 	to_chat(viewers(user), "<span class = 'danger'>[user] is using [src.name]! It looks like \he's trying to re-add poo!</span>")

--- a/code/modules/research/mechanic/device_analyser.dm
+++ b/code/modules/research/mechanic/device_analyser.dm
@@ -80,6 +80,10 @@
 	// Objects that cannot be scanned
 	if((O.mech_flags & MECH_SCAN_FAIL)==MECH_SCAN_FAIL)
 		return 0
+	
+	if((O.mech_flags & MECH_SCAN_GOONECODE)==MECH_SCAN_GOONECODE)
+		to_chat(user, "<span class='notice'>Your device blinks red and a message appears: <span class='warning'>\"ERROR: CLOSED SOURCE SOFTWARE; INCOMPATIBLE WITH GPLv3.\"</span></span>")
+		return 0
 
 	var/list/techlist = O.give_tech_list() //Some items may have a specific techlist. Currently only used for solar assemblies, since they don't hold a circuitboard.
 	if(techlist)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
title

## Why it's good
cool reward for retrieving goonecode if no admins are online

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Goonecode now has a tech origin and can be put in the destructive analyzer.
