### PR TITLE
The nasa, exca., anom. suits, and cult robes from xenoarch finds are now contained in boxes. These contain both pieces of the suits.

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -1838,6 +1838,8 @@ var/list/arcane_tomes = list()
 			var/obj/item/I = stored_gear[slot]
 			stored_gear -= slot
 			I.forceMove(T)
+		for(var/obj/A in contents)
+			A.forceMove(T)
 	if (remaining)
 		QDEL_NULL(remaining)
 	..()

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -78,12 +78,6 @@
 	species_restricted =list("Human", "Insectoid")
 	body_parts_visible_override = 0
 
-//used for the xenoarch NASA suit find
-/obj/item/weapon/storage/box/large/nasasuit
-	desc = "There's a label on the box: 'Retired Space Suit'. The box is warped beyond use, but it could be used in research or broken down and remade."
-	can_only_hold = null
-	items_to_spawn = list(/obj/item/clothing/head/helmet/space/ancient, /obj/item/clothing/suit/space/ancient)
-
 //Clown Space Suit
 /obj/item/clothing/head/helmet/space/clown
 	name = "clown helmet"

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -58,6 +58,7 @@
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
 	siemens_coefficient = 0.9
 
+//NASA spacesuit
 /obj/item/clothing/suit/space/ancient //slightly better then an anomalist's space suit
 	name = "ancient space suit"
 	icon_state = "nasa"
@@ -76,6 +77,12 @@
 	armor = list(melee = 10, bullet = 10, laser = 10,energy = 10, bomb = 50, bio = 100, rad = 100)
 	species_restricted =list("Human", "Insectoid")
 	body_parts_visible_override = 0
+
+//used for the xenoarch NASA suit find
+/obj/item/weapon/storage/box/large/nasasuit
+	desc = "There's a label on the box: 'Retired Space Suit'. The box is warped beyond use, but it could be used in research or broken down and remade."
+	can_only_hold = null
+	items_to_spawn = list(/obj/item/clothing/head/helmet/space/ancient, /obj/item/clothing/suit/space/ancient)
 
 //Clown Space Suit
 /obj/item/clothing/head/helmet/space/clown

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -956,8 +956,7 @@
 	responsive_reagent = POTASSIUM
 
 /datum/find/spacesuit/spawn_item()
-	var/result = pick(/obj/item/clothing/suit/space/ancient, /obj/item/clothing/head/helmet/space/ancient)
-	return new result
+	return new /obj/item/weapon/storage/box/large/nasasuit
 
 /datum/find/excasuit
 	find_ID = ARCHAEO_EXCASUIT
@@ -966,8 +965,7 @@
 	responsive_reagent = POTASSIUM
 
 /datum/find/excasuit/spawn_item()
-	var/result = pick(/obj/item/clothing/suit/space/anomaly, /obj/item/clothing/head/helmet/space/anomaly)
-	return new result
+	return new /obj/item/weapon/storage/box/large/xa_excasuit
 
 /datum/find/anomsuit
 	find_ID = ARCHAEO_ANOMSUIT
@@ -976,8 +974,7 @@
 	responsive_reagent = POTASSIUM
 
 /datum/find/anomsuit/spawn_item()
-	var/result = pick(/obj/item/clothing/suit/bio_suit/anomaly/old, /obj/item/clothing/head/bio_hood/anomaly/old)
-	return new result
+	return new /obj/item/weapon/storage/box/large/xa_anomsuit
 
 /datum/find/lance
 	find_ID = ARCHAEO_LANCE

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -492,26 +492,7 @@
 	responsive_reagent = POTASSIUM
 
 /datum/find/cultrobes/spawn_item()
-
-	//75% chance to get a headgear
-	//25% chance to get a suit
-
-	//33% chance to get current cult hood/robes
-	//26.6% chance to get red cult hood/robes
-	//20% chance to get magus hood/robes
-	//13% chance to get current cult helmet/armor
-	//6.6% chance to get legacy cult helmet/armor
-
-	var/choice = pick(
-	25;/obj/item/clothing/suit/cultrobes,
-	20;/obj/item/clothing/suit/cultrobes/old,
-	45;/obj/item/clothing/head/magus,
-	15;/obj/item/clothing/suit/magusred,
-	30;/obj/item/clothing/head/helmet/space/cult,
-	10;/obj/item/clothing/suit/space/cult,
-	15;/obj/item/clothing/head/helmet/space/legacy_cult,
-	5;/obj/item/clothing/suit/space/legacy_cult)
-	return new choice
+	return new /obj/item/weapon/blood_tesseract/xenoarchfind
 
 /datum/find/soulstone
 	find_ID = ARCHAEO_SOULSTONE

--- a/code/modules/research/xenoarchaeology/finds/finds_misc.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_misc.dm
@@ -34,18 +34,22 @@
 	desc = "There's a label on the box: 'Retired Excavation Suit. Dispose ASAP'. The box is warped beyond use, but it could be used in research or broken down and remade."
 	can_only_hold = null
 	items_to_spawn = list(/obj/item/clothing/head/helmet/space/anomaly, /obj/item/clothing/suit/space/anomaly)
+	mech_flags = MECH_SCAN_FAIL
 
 /obj/item/weapon/storage/box/large/xa_anomsuit
 	desc = "There's a label on the box: 'Retired Anomaly Suit. Dispose ASAP'. The box is warped beyond use, but it could be used in research or broken down and remade."
 	can_only_hold = null
 	items_to_spawn = list(/obj/item/clothing/head/bio_hood/anomaly/old, /obj/item/clothing/suit/bio_suit/anomaly/old)
+	mech_flags = MECH_SCAN_FAIL
 
 /obj/item/weapon/storage/box/large/nasasuit
 	desc = "There's a label on the box: 'Retired Space Suit'. The box is warped beyond use, but it could be used in research or broken down and remade."
 	can_only_hold = null
 	items_to_spawn = list(/obj/item/clothing/head/helmet/space/ancient, /obj/item/clothing/suit/space/ancient)
+	mech_flags = MECH_SCAN_FAIL
 
 /obj/item/weapon/blood_tesseract/xenoarchfind
+	mech_flags = MECH_SCAN_FAIL //Redundant flag, but adding it just in case.
 
 /obj/item/weapon/blood_tesseract/xenoarchfind/New()
 	..()

--- a/code/modules/research/xenoarchaeology/finds/finds_misc.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_misc.dm
@@ -29,3 +29,34 @@
 					apply_image_decorations = 1
 				*/
 			//machinery type artifacts?
+
+/obj/item/weapon/storage/box/large/xa_excasuit
+	desc = "There's a label on the box: 'Retired Excavation Suit. Dispose ASAP'. The box is warped beyond use, but it could be used in research or broken down and remade."
+	can_only_hold = null
+	items_to_spawn = list(/obj/item/clothing/head/helmet/space/anomaly, /obj/item/clothing/suit/space/anomaly)
+
+/obj/item/weapon/storage/box/large/xa_anomsuit
+	desc = "There's a label on the box: 'Retired Anomaly Suit. Dispose ASAP'. The box is warped beyond use, but it could be used in research or broken down and remade."
+	can_only_hold = null
+	items_to_spawn = list(/obj/item/clothing/head/bio_hood/anomaly/old, /obj/item/clothing/suit/bio_suit/anomaly/old)
+
+/obj/item/weapon/storage/box/large/nasasuit
+	desc = "There's a label on the box: 'Retired Space Suit'. The box is warped beyond use, but it could be used in research or broken down and remade."
+	can_only_hold = null
+	items_to_spawn = list(/obj/item/clothing/head/helmet/space/ancient, /obj/item/clothing/suit/space/ancient)
+
+/obj/item/weapon/blood_tesseract/xenoarchfind
+
+/obj/item/weapon/blood_tesseract/xenoarchfind/New()
+	..()
+	var/list/choices = pick(
+		35;list(/obj/item/clothing/head/magus, /obj/item/clothing/suit/magusred),
+		25;list(/obj/item/clothing/suit/cultrobes/old),
+		20;list(/obj/item/clothing/suit/cultrobes),
+		15;list(/obj/item/clothing/head/helmet/space/cult, /obj/item/clothing/suit/space/cult),
+		5;list(/obj/item/clothing/head/helmet/space/legacy_cult, /obj/item/clothing/suit/space/legacy_cult)
+		)
+		//aims to retain something along the lines of the old rarity system for all the cult robes/suits.
+	for(var/I in choices)
+		I = new I(src)
+		contents += I

--- a/code/modules/research/xenoarchaeology/tools/anomaly_suit.dm
+++ b/code/modules/research/xenoarchaeology/tools/anomaly_suit.dm
@@ -34,16 +34,8 @@
 	item_state = "engspace_helmet"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/spacesuits.dmi', "right_hand" = 'icons/mob/in-hand/right/spacesuits.dmi')
 
-//used for the xenoarch old anomally suit find
-/obj/item/weapon/storage/box/large/xa_anomsuit
-	desc = "There's a label on the box: 'Retired Anomaly Suit. Dispose ASAP'. The box is warped beyond use, but it could be used in research or broken down and remade."
-	can_only_hold = null
-	items_to_spawn = list(/obj/item/clothing/head/bio_hood/anomaly/old, /obj/item/clothing/suit/bio_suit/anomaly/old)
-
-
 //Xenoarch space suit.
 //For the current standard suit see /obj/item/clothing/suit/space/rig/arch in "code\modules\clothing\spacesuits\rig.dm".
-
 /obj/item/clothing/suit/space/anomaly
 	name = "Excavation suit"
 	desc = "A pressure resistant excavation suit partially capable of insulating against exotic alien energies. There is a small tag on it that reads: 'Property of <s>Engineering</s> Research'."
@@ -59,9 +51,3 @@
 	item_state = "cespace_helmet"
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 100)
 	body_parts_visible_override = EYES|BEARD
-
-//used for the xenoarch old excavation suit find
-/obj/item/weapon/storage/box/large/xa_excasuit
-	desc = "There's a label on the box: 'Retired Excavation Suit. Dispose ASAP'. The box is warped beyond use, but it could be used in research or broken down and remade."
-	can_only_hold = null
-	items_to_spawn = list(/obj/item/clothing/head/helmet/space/anomaly, /obj/item/clothing/suit/space/anomaly)

--- a/code/modules/research/xenoarchaeology/tools/anomaly_suit.dm
+++ b/code/modules/research/xenoarchaeology/tools/anomaly_suit.dm
@@ -34,6 +34,13 @@
 	item_state = "engspace_helmet"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/spacesuits.dmi', "right_hand" = 'icons/mob/in-hand/right/spacesuits.dmi')
 
+//used for the xenoarch old anomally suit find
+/obj/item/weapon/storage/box/large/xa_anomsuit
+	desc = "There's a label on the box: 'Retired Anomaly Suit. Dispose ASAP'. The box is warped beyond use, but it could be used in research or broken down and remade."
+	can_only_hold = null
+	items_to_spawn = list(/obj/item/clothing/head/bio_hood/anomaly/old, /obj/item/clothing/suit/bio_suit/anomaly/old)
+
+
 //Xenoarch space suit.
 //For the current standard suit see /obj/item/clothing/suit/space/rig/arch in "code\modules\clothing\spacesuits\rig.dm".
 
@@ -52,3 +59,9 @@
 	item_state = "cespace_helmet"
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 100)
 	body_parts_visible_override = EYES|BEARD
+
+//used for the xenoarch old excavation suit find
+/obj/item/weapon/storage/box/large/xa_excasuit
+	desc = "There's a label on the box: 'Retired Excavation Suit. Dispose ASAP'. The box is warped beyond use, but it could be used in research or broken down and remade."
+	can_only_hold = null
+	items_to_spawn = list(/obj/item/clothing/head/helmet/space/anomaly, /obj/item/clothing/suit/space/anomaly)


### PR DESCRIPTION
## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Something I found a bit annoying about finding the old suits via xenoarch is that you'll find the one half of a suit and then never find the other.
This remedies the situation by containing both halves in a box and you get the box as the find from the dig.

**Update**
Cult robes have been packaged as well now as per request. They get stored in a snazzy cult tesseract that you can destroy to get the items inside. Simply throwing it will destroy it.

## Why it's good
<!-- Explain why you think these changes are good. -->
You're no longer screwed from finding the other half of a suit.
It's also nice because the box can be deconstructed in the DA for the anomaly research points.


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: NASA, Exca., and Anom. suits found from xenoarch dig sites are now found in boxes that contain both halves. The box can be DA'd for research.
 * rscadd: Cult robes and armor from xenoarch dig sites also come bundled in Tesseracts now. Destroying it by throwing it will yield it's contents.