### PR TITLE
Castle Station now allows building silicons again

### DIFF
--- a/maps/tgstation-sec.dm
+++ b/maps/tgstation-sec.dm
@@ -72,7 +72,6 @@
 
 	center_x = 226
 	center_y = 254
-	can_have_robots = FALSE
 
 /datum/map/active/ruleset_multiplier(var/datum/dynamic_ruleset/DR)
 	if(istype(DR, /datum/dynamic_ruleset/roundstart/nuclear))


### PR DESCRIPTION
They appealed their ban from Castle with a glowing voucher because they haven't tyrannized any station in a while.
Done by request.

:cl:
 * rscadd: Castle Station now allows silicons to be constructed again.