### PR TITLE
Typo fix in command_alerts.dm and rcs.dm

### DIFF
--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -800,7 +800,7 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 
 /datum/command_alert/tradeprobe
 	alert_title = "Vox Trade Probe Approaching"
-	message = "Although there are no Vox Shoal traders in your viscinity, a trade probe has docked with the station at the usual location. It will remain for 10 minutes."
+	message = "Although there are no Vox Shoal traders in your vicinity, a trade probe has docked with the station at the usual location. It will remain for 10 minutes."
 
 /datum/command_alert/tradeprobe_depart
 	alert_title = "Vox Trade Probe Departing"

--- a/code/modules/telesci/rcs.dm
+++ b/code/modules/telesci/rcs.dm
@@ -141,7 +141,7 @@
 		return
 
 	if (no_station && user.z == map.zMainStation)
-		to_chat(user, "<span class='warning'>The safety prevents the sending of crates from the viscinity of Nanotrasen Station.</span>")
+		to_chat(user, "<span class='warning'>The safety prevents the sending of crates from the vicinity of Nanotrasen Station.</span>")
 		return
 
 	if (cell.charge < send_cost)


### PR DESCRIPTION


<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
closes #35992 , fixing two typos in in command_alerts.dm and rcs.dm


## Why it's good
<!-- Explain why you think these changes are good. -->
typo fixes are good

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Fixed a typo in command alerts and rcs messages.

