### PR TITLE
Suit mod machine now actually replaces the alien suit rather than painting it.

### DIFF
--- a/code/game/machinery/suit_modifier.dm
+++ b/code/game/machinery/suit_modifier.dm
@@ -146,9 +146,9 @@
 			process_module_installation(H)
 			return
 		if(istype(worn_suit, /obj/item/clothing/suit/space/plasmaman))
-			process_suit_paint(H, plasmaman_suits)
+			process_suit_replace(H, plasmaman_suits)
 		else if(istype(worn_suit, /obj/item/clothing/suit/space/vox))
-			process_suit_paint(H, vox_suits)
+			process_suit_replace(H, vox_suits)
 		else
 			say("Unable to detect compatible spacesuit on [H].", class = "binaryradio")
 	else if((modules_to_install.len || cell) && !activated)
@@ -191,31 +191,29 @@
 			filtered_suit_list[entry] = list(suit_list[entry][SUIT_INDEX], suit_list[entry][HELMET_INDEX])
 	return filtered_suit_list
 
-/obj/machinery/suit_modifier/proc/process_suit_paint(mob/living/carbon/human/guy, list/suit_list)
+/obj/machinery/suit_modifier/proc/process_suit_replace(mob/living/carbon/human/guy, list/suit_list)
 	if(activated)
 		return
 	lock_atom(guy)
-	var/obj/item/clothing/suit/space/chosen_job = input(guy, "What kind of paint do you wish to apply?") as null|anything in filter_suit_list(guy, suit_list)
+	var/obj/item/clothing/suit/space/chosen_job = input(guy, "What kind of model do you wish to apply?") as null|anything in filter_suit_list(guy, suit_list)
 	if(!chosen_job || activated || guy.incapacitated() || guy.loc != loc)
 		unlock_atom(guy)
 		return
 	var/obj/item/clothing/suit/space/chosen_suit = suit_list[chosen_job][SUIT_INDEX]
-	var/obj/item/clothing/head/helmet/space/plasmaman/chosen_helmet = suit_list[chosen_job][HELMET_INDEX]
+	var/obj/item/clothing/head/helmet/space/chosen_helmet = suit_list[chosen_job][HELMET_INDEX]
 	activated = TRUE
 	use_power = MACHINE_POWER_USE_ACTIVE
 	activation_animation()
 	working_animation()
-	var/obj/item/clothing/suit/space/suit = guy.get_item_by_slot(slot_wear_suit)
-	suit.desc = "The colors are a bit dodgy."
-	suit.icon_state = initial(chosen_suit.icon_state)
-	guy.update_inv_wear_suit()
-	var/obj/item/clothing/head/helmet/space/helmet = guy.get_item_by_slot(slot_head)
-	if(istype(helmet))
-		helmet.icon_state = initial(chosen_helmet.icon_state)
-		desc = "The colors are a bit dodgy."
-		if(istype(helmet, /obj/item/clothing/head/helmet/space/plasmaman))
-			var/obj/item/clothing/head/helmet/space/plasmaman/special_snowflake = helmet
-			special_snowflake.base_state = initial(chosen_helmet.base_state)
+	var/obj/item/clothing/suit/space/oldsuit = guy.get_item_by_slot(slot_wear_suit)
+	if(oldsuit)
+		guy.equip_to_slot(new chosen_suit, slot_wear_suit)
+		qdel(oldsuit)
+		guy.update_inv_wear_suit()
+	var/obj/item/clothing/head/helmet/space/oldhelmet = guy.get_item_by_slot(slot_head)
+	if(oldhelmet)
+		guy.equip_to_slot(new chosen_helmet, slot_head)
+		qdel(oldhelmet)
 		guy.update_inv_head()
 	finished_animation()
 	unlock_atom(guy)


### PR DESCRIPTION
A code project request from #35283

## What this does
A functional redo/update of #30064.
The suit modifier now gives you the actual suit rather than just a fancy paintjob.

**PERSONAL CHANGES FROM REQUEST**
I've intentionally not done the material cost related stuff because I wanted to field the idea of just making it free assuming you have the access. The logic here is that if every locker had every respective suit and you could just go to that locker and get the respective suit, then what's the difference? IE if I had sec access, and I went to a sec locker, I'd have the suit regardless.

I'd be willing to entertain and code the idea of putting materials to it but I would like to see a counter argument to the above. I have some ideas for how to go about it already.

**BUG NOTICE**
Unrelated to my changes, but the processing animation on the machine didn't overlay on the mob. I will make a bug report about it. Just getting out ahead of the blaming that this PR caused this. I didn't extensively test for this bug and is just something I noticed in the testing of my own stuff.
Another bug is some of the jobs don't get the intended suit or aren't in the list. This was tested pre and post PR branch so it seems unrelated. I'd chalk this up to something with outfit datums or a naming convention between access and the datums.

## Why it's good
You can view the request's own reasoning in #35283, but to add my own two cents I think it's good to have visual clarity that matches expectations.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Suit modification stations now actually replace the suit for alien species (vox and plasmamen) rather than applying a "paint job"