### PR TITLE
landline bugfixes 

### DIFF
--- a/code/game/machinery/landline.dm
+++ b/code/game/machinery/landline.dm
@@ -74,6 +74,20 @@
 		linked_cord += cable1
 		linked_cord += cable2
 		
+/obj/landline/proc/reattach_cord(mob/user)
+	if(!phone)
+		to_chat(user, "<span class='warning'>There's no phone to fix!</span>")
+		return 	
+	if(phone.linked_landline)
+		to_chat(user, "<span class='warning'>\the [phone] is already connected!</span>")
+		return
+	if(linked_phone)
+		to_chat(user, "<span class='warning'>\the [phone] is connected elsewhere!</span>")
+		return
+	phone.linked_landline = src
+	linked_phone = phone
+	return TRUE
+		
 /obj/landline/proc/shake_phone_overlay(amplitude = 2)
 	if(!phone)
 		return
@@ -199,7 +213,8 @@
 	if(!user.drop_item(O))
 		to_chat(user, "<span class='warning'>It's stuck to your hand!</span>")
 		return
-	delete_cord()
+	if(linked_phone == O)
+		delete_cord()
 	if(calling)
 		if(calling.ringing)
 			calling.ringing = FALSE

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -334,7 +334,7 @@ var/list/requests_consoles_categorised = list("Command" = list(),"Engineering" =
 				
 			if(12) //last call log
 				dat += landline.last_call_log
-				dat += text("<BR><A href='?src=\ref[src];setScreen=0'>Back to main menu</A><BR>")
+				dat += text("<BR><A href='?src=\ref[src];setScreen=11'>Back</A><BR>")
 			
 			else	//main menu
 				screen = 0

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -603,6 +603,14 @@ var/list/requests_consoles_categorised = list("Command" = list(),"Engineering" =
 			updateUsrDialog()
 	if (istype(O, /obj/item/telephone) && landline)
 		landline.attackby(O, user)
+	if (istype(O, /obj/item/stack/cable_coil))
+		if(!open)
+			to_chat(user, "<span class='warning'>You need to remove the cover before you can fix the phone's wiring!</span>")
+			return
+		if(landline.reattach_cord(user))
+			user.visible_message("<span class='notice'>[user] re-attaches the [src]'s phone cord.</span>")
+			var/obj/item/stack/cable_coil/C = O
+			C.use(1)
 
 /obj/machinery/requests_console/verb/pick_up_phone()
 	set category = "Object"

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -496,6 +496,8 @@ var/list/requests_consoles_categorised = list("Command" = list(),"Engineering" =
 			if(!announcementConsole)
 				return
 			screen = 10
+		if(11)		//return to dialer
+			screen = 11
 		if(12)		//last call log
 			screen = 12
 		else		//main menu


### PR DESCRIPTION
## What this does
lets you re-attach phones with broken cables
makes the cord not vanish
fixes endcall spam
more updateusrdialog()'s
dialer back button now goes back 1 page instead of returning to main manu
## Why it's good
<!-- Explain why you think these changes are good. -->

## Changelog
 * bugfix: landline phones can now be reattached by using a cable coil on the requests console
 * bugfix: landline phone cables no longer vanish when a different phone is put on the RC
 * bugfix: it should now be harder to get a phone to play multiple "end call" tones at once
 * bugfix: phone logs auto-update more often