### PR TITLE
log votes publicly

### DIFF
--- a/code/modules/html_interface/voting/voting.dm
+++ b/code/modules/html_interface/voting/voting.dm
@@ -254,6 +254,8 @@ var/global/datum/controller/vote/vote = new()
 				var/map_choice = forced_map ? forced_map : winner
 				watchdog.map_path = map_paths[map_choice]
 				log_game("Players voted and chose.... [watchdog.map_path]!")
+	for(var/ckey in voters)
+		log_vote("[ckey] voted for [get_vote(ckey)].")
 
 	if(restart)
 		to_chat(world, "World restarting due to vote...")


### PR DESCRIPTION
these 2 lines of code i github edited in should make all votes public in the logs. They were already available in the logs through calculating href options against results, but this makes it more easy. Hopefully this will encourage less shitty voting. Glasnost if you will.

:cl:
 * tweak: votes are now publicly logged.