### PR TITLE
bigger and clearer vampire thrall deconvert text

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -569,7 +569,7 @@
 /datum/role/thrall/Greet(var/you_are = TRUE)
 	var/dat
 	if (you_are)
-		dat = "<span class='danger'>You are a Thrall!</br> You are slaved to <b>[master.antag.current]</b> [faction?"under the [faction.name].":"."]</span>"
+		dat = "<span class='danger'>You are a Thrall!</br> You are slaved to <b>[master.antag.current]</b> [faction?"under [faction.name].":"."]</span>"
 	dat += {""}
 	to_chat(antag.current, dat)
 	to_chat(antag.current, "<B>You must complete the following tasks:</B>")
@@ -586,7 +586,8 @@
 	log_admin("[key_name(M)] was dethralled, his master was [key_name(master.antag)]. [formatJumpTo(get_turf(antag.current))]")
 	if (deconverted)
 		M.visible_message("<span class='big danger'>[M] suddenly becomes calm and collected again, \his eyes clear up.</span>",
-		"<span class='big notice'>Your blood cools down and you are inhabited by a sensation of untold calmness.</span>")
+		"<span class='warning'><b>Your blood cools down and you are inhabited by a sensation of untold calmness.</b></span>")
+		to_chat(M, "<span class='big warning'>You are no longer a slave to [master.antag.current]'s whims, having <b>escaped your thralldom.<b></span>")
 	update_faction_icons()
 	return ..()
 


### PR DESCRIPTION
## What this does
Did you know vampire thralls can be deconverted? Neither did I. Anyway, the deconversion text was in blue and was unclear as to what actually just happened. The text is now red, bolded in some places (different than the screenshot, I changed it to the last few words), and clear to the user that they're no longer a vampiric thrall.
![image](https://github.com/vgstation-coders/vgstation13/assets/26285377/908924bb-d479-4f57-a21b-257e224fac69)

## Why it's good
Some vampire thralls from the last round expressed to me that their deconversion was very unclear, this should make it better.
[tweak]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Vampire thrall deconversion text is now far more noticeable and clear as to what happened.