### PR TITLE
Butt removal surgery now removes spells as intended

### DIFF
--- a/code/game/gamemodes/wizard/spellbook_oneuse.dm
+++ b/code/game/gamemodes/wizard/spellbook_oneuse.dm
@@ -36,7 +36,7 @@
 		recoil(user)
 	else
 		S.refund_price = 0 // So that they can't be refunded
-		user.add_spell(S)
+		user.add_spell(S, iswizard = TRUE)
 		to_chat(user, "<span class='notice'>you rapidly read through the arcane book. Suddenly you realize you understand [spellname]!</span>")
 		user.attack_log += text("\[[time_stamp()]\] <font color='orange'>[user.real_name] ([user.ckey]) learned the spell [spellname] ([S]).</font>")
 		onlearned(user)

--- a/code/modules/surgery/butt.dm
+++ b/code/modules/surgery/butt.dm
@@ -155,7 +155,7 @@
 	if(target.mind.wizard_spells)
 		B.spells.Add(target.mind.wizard_spells)
 		for(var/spell/spell in target.mind.wizard_spells)
-			remove_spell(spell)
+			target.remove_spell(spell)
 	B.transfer_buttdentity(target)
 	target.op_stage.butt = 4
 

--- a/code/modules/surgery/butt.dm
+++ b/code/modules/surgery/butt.dm
@@ -152,6 +152,10 @@
 	user.visible_message("<span class='notice'>[user] finishes cauterizing [target]'s ass with \the [tool].</span>",		\
 	"<span class='notice'>You have cauterized [target]'s ass with \the [tool].</span>")
 	var/obj/item/clothing/head/butt/B = new(target.loc)
+	if(target.mind.wizard_spells)
+		B.spells.Add(target.mind.wizard_spells)
+		for(var/spell/spell in target.mind.wizard_spells)
+			remove_spell(spell)
 	B.transfer_buttdentity(target)
 	target.op_stage.butt = 4
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
I failed to implement magic transfer on ass removal and only included it on ass addition - this fix provides the intended functionality of magic removal when asses are removed surgically, rather than just when they are blown off. Additionally, single-use spellbooks previously would not have their spells removed on ass removal but now do.

## Why it's good
<!-- Explain why you think these changes are good. -->
Bugfix. Closes #36114.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Spells will now be properly removed via surgery.
 * bugfix: Spells obtained via single-use spellbooks will be removed on ass removal.