### PR TITLE
Moves the robot tail on the mechfab from Robot to Misc.

### DIFF
--- a/code/modules/research/designs/robot.dm
+++ b/code/modules/research/designs/robot.dm
@@ -65,7 +65,7 @@
 	req_tech = list(Tc_ENGINEERING = 1)
 	build_type = MECHFAB
 	build_path = /obj/item/robot_parts/tail
-	category = "Robot"
+	category = "Misc"
 	materials = list(MAT_IRON=15000)
 
 /datum/design/robot/head


### PR DESCRIPTION
## What this does
Title. Should fix the Quick Robot button making the tail despite robots not having tails. Closes #36121.
## Why it's good
Borgs don't have robotic tails.
:cl:
 * tweak: Moves the robotic tail on the mechfab from Robot to Misc.