### PR TITLE
mob deletion fix 1: giftwrap

### DIFF
--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -50,6 +50,8 @@
 			item_state = "gift-large"
 
 /obj/item/weapon/gift/attack_self(mob/user as mob)
+	for(var/I in contents)
+		user.put_in_hands(I)
 	user.drop_item(src, force_drop = 1)
 	if(gift)
 		user.put_in_active_hand(gift)


### PR DESCRIPTION
closes #36131
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: gift wrappers no longer delete people if used on a beartrap
