### PR TITLE
More wizard changes and fixes

### DIFF
--- a/code/_onclick/hud/spell_screen_objects.dm
+++ b/code/_onclick/hud/spell_screen_objects.dm
@@ -16,6 +16,7 @@
 
 /obj/abstract/screen/movable/spell_master/Destroy()
 	..()
+	to_chat(world, "destroyed the spell_master!")
 	for(var/obj/abstract/screen/spell/spells in spell_objects)
 		spells.spellmaster = null
 	spell_objects = null
@@ -281,6 +282,7 @@
 
 /obj/abstract/screen/spell/Destroy()
 	..()
+	to_chat(world, "destroyed the screen/spell!")
 	spell = null
 	last_charged_icon = null
 	if(spellmaster)

--- a/code/_onclick/hud/spell_screen_objects.dm
+++ b/code/_onclick/hud/spell_screen_objects.dm
@@ -16,7 +16,6 @@
 
 /obj/abstract/screen/movable/spell_master/Destroy()
 	..()
-	to_chat(world, "destroyed the spell_master!")
 	for(var/obj/abstract/screen/spell/spells in spell_objects)
 		spells.spellmaster = null
 	spell_objects = null
@@ -282,7 +281,6 @@
 
 /obj/abstract/screen/spell/Destroy()
 	..()
-	to_chat(world, "destroyed the screen/spell!")
 	spell = null
 	last_charged_icon = null
 	if(spellmaster)

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -70,9 +70,10 @@
 
 /datum/role/wizard/PostMindTransfer(var/mob/living/new_character, var/mob/living/old_character)
 	. = ..()
-	for (var/spell/S in old_character.spell_list)
-		if ((S.user_type == (USER_TYPE_WIZARD || USER_TYPE_SPELLBOOK)) && !(S.spell_flags & LOSE_IN_TRANSFER))
-			new_character.add_spell(S)
+	for (var/spell/S in antag.wizard_spells) //Bring back all their wizard spells
+		if (!(S.spell_flags & LOSE_IN_TRANSFER))
+			//Transfer the spell without doing on_added() or on_removed(), instead doing on_transfer()
+			transfer_spell(new_character, old_character, S)
 
 /datum/role/wizard/GetScoreboard()
 	. = ..()
@@ -82,7 +83,7 @@
 		if(H.spell_list)
 			bought_nothing = FALSE
 			. += "<BR>The wizard knew:<BR>"
-			for(var/spell/S in H.spell_list)
+			for(var/spell/S in antag.wizard_spells)
 				var/icon/tempimage
 				if(S.override_icon != "")
 					tempimage = icon(S.override_icon, S.hud_state)

--- a/code/datums/gamemode/role/wizard_apprentice.dm
+++ b/code/datums/gamemode/role/wizard_apprentice.dm
@@ -17,6 +17,9 @@
 	if(!.)
 		return
 	equip_wizard(antag.current, apprentice = TRUE)
+	antag.current.flavor_text = null
+	antag.current.faction = "wizard"
+	antag.mob_legacy_fac = "wizard"
 
 /datum/role/wizard_apprentice/Greet(var/greeting,var/custom)
 	if(!greeting)
@@ -32,9 +35,9 @@
 
 /datum/role/wizard_apprentice/PostMindTransfer(var/mob/living/new_character, var/mob/living/old_character)
 	. = ..()
-	for (var/spell/S in old_character.spell_list)
-		if (S.user_type == USER_TYPE_WIZARD && !(S.spell_flags & LOSE_IN_TRANSFER))
-			new_character.add_spell(S)
+	for (var/spell/S in antag.wizard_spells)
+		if (!(S.spell_flags & LOSE_IN_TRANSFER))
+			transfer_spell(new_character, old_character, S)
 
 /datum/role/wizard_apprentice/GetScoreboard()
 	. = ..()
@@ -45,8 +48,6 @@
 		return
 
 	. += "<BR>The apprentice knew:<BR>"
-	for(var/spell/S in H.spell_list)
-		if(S.user_type != USER_TYPE_WIZARD)
-			continue
+	for(var/spell/S in antag.wizard_spells)
 		var/icon/tempimage = icon('icons/mob/screen_spells.dmi', S.hud_state)
 		. += "<img class='icon' src='data:image/png;base64,[iconsouth2base64(tempimage)]'> [S.name]<BR>"

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -40,11 +40,12 @@ Obviously, requires DNA2.
 /datum/dna/gene/basic/grant_spell/hulk/OnMobLife(var/mob/living/carbon/human/M)
 	if(!istype(M))
 		return
-	if(M_HULK in M.mutations && !M.hulk_gene_active)
+	if((M_HULK in M.mutations) && M.hulk_gene_active)
 		var/timeleft = M.hulk_time - world.time
 		if(M.health <= 25 || timeleft <= 0)
-			M.hulk_time=0 // Just to be sure.
+			M.hulk_time = 0
 			M.mutations.Remove(M_HULK)
+			M.hulk_gene_active = FALSE
 			M.update_mutations()		//update our mutation overlays
 			M.update_body()
 			to_chat(M, "<span class='warning'>You suddenly feel very weak.</span>")
@@ -77,9 +78,8 @@ Obviously, requires DNA2.
 /spell/targeted/genetic/hulk/before_cast(list/targets, user, bypass_range)
 	var/mob/living/carbon/human/H = user
 	if(istype(H) && (M_HULK in H.mutations))
-		if(H.hulk_time || H.hulk_gene_active)
-			to_chat(user, "<span class='warning'>You are already hulking out!</span>")
-			return 0
+		to_chat(user, "<span class='warning'>You are already hulking out!</span>")
+		return list()
 	return ..()
 
 /spell/targeted/genetic/hulk/cast(list/targets, mob/user)
@@ -95,9 +95,6 @@ Obviously, requires DNA2.
 		//M.say(pick("",";")+pick("HULK MAD","YOU MADE HULK ANGRY")) // Just a note to security.
 		log_admin("[key_name(M)] has hulked out! ([formatJumpTo(M)])")
 		message_admins("[key_name(M)] has hulked out! ([formatJumpTo(M)])")
-		spawn(duration)
-			if(M)
-				M.hulk_gene_active = FALSE
 	return
 
 /datum/dna/gene/basic/grant_spell/farsight

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -6,6 +6,7 @@ Obviously, requires DNA2.
 
 // When hulk was first applied (world.time).
 /mob/living/carbon/human/var/hulk_time = 0
+/mob/living/carbon/human/var/hulk_gene_active = FALSE //To avoid bugging out with the wizard's Mutate spell, differentiates them
 
 // In decaseconds.
 #define HULK_DURATION 300 // How long the effects last
@@ -39,7 +40,7 @@ Obviously, requires DNA2.
 /datum/dna/gene/basic/grant_spell/hulk/OnMobLife(var/mob/living/carbon/human/M)
 	if(!istype(M))
 		return
-	if(M_HULK in M.mutations)
+	if(M_HULK in M.mutations && !M.hulk_gene_active)
 		var/timeleft = M.hulk_time - world.time
 		if(M.health <= 25 || timeleft <= 0)
 			M.hulk_time=0 // Just to be sure.
@@ -73,6 +74,14 @@ Obviously, requires DNA2.
 	desc = "Get mad!  For [duration/10] seconds, anyway."
 	..()
 
+/spell/targeted/genetic/hulk/before_cast(list/targets, user, bypass_range)
+	var/mob/living/carbon/human/H = user
+	if(istype(H) && (M_HULK in H.mutations))
+		if(H.hulk_time || H.hulk_gene_active)
+			to_chat(user, "<span class='warning'>You are already hulking out!</span>")
+			return 0
+	return ..()
+
 /spell/targeted/genetic/hulk/cast(list/targets, mob/user)
 	if (istype(user.loc,/mob))
 		to_chat(usr, "<span class='warning'>You can't hulk out right now!</span>")
@@ -82,9 +91,13 @@ Obviously, requires DNA2.
 		M.mutations.Add(M_HULK)
 		M.update_mutations()		//update our mutation overlays
 		M.update_body()
+		M.hulk_gene_active = TRUE
 		//M.say(pick("",";")+pick("HULK MAD","YOU MADE HULK ANGRY")) // Just a note to security.
 		log_admin("[key_name(M)] has hulked out! ([formatJumpTo(M)])")
 		message_admins("[key_name(M)] has hulked out! ([formatJumpTo(M)])")
+		spawn(duration)
+			if(M)
+				M.hulk_gene_active = FALSE
 	return
 
 /datum/dna/gene/basic/grant_spell/farsight

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -261,9 +261,8 @@
 		var/mob/living/carbon/human/H = new /mob/living/carbon/human/lich(src)
 		H.real_name = original.real_name
 		H.flavor_text = original.flavor_text
-		for(var/spell/S in original.spell_list)
-			original.remove_spell(S)
-			H.add_spell(S)
+		for(var/spell/S in original.mind.wizard_spells)
+			transfer_spell(H, original, S)
 		//Let's give the lich some spooky clothes. Including non-wizards.
 		H.equip_to_slot_or_del(new /obj/item/clothing/head/wizard/skelelich(H), slot_head)
 		H.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe/skelelich(H), slot_wear_suit)

--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -307,10 +307,10 @@
 	H.nutrition += 1000
 	H.update_mutations()
 
-	H.add_spell(new/spell/passive/noclothes)
-	H.add_spell(new/spell/aoe_turf/conjure/snowmobile)
-	H.add_spell(new/spell/targeted/wrapping_paper)
-	H.add_spell(new/spell/aoe_turf/conjure/gingerbreadman)
+	H.add_spell(new/spell/passive/noclothes, iswizard = TRUE)
+	H.add_spell(new/spell/aoe_turf/conjure/snowmobile, iswizard = TRUE)
+	H.add_spell(new/spell/targeted/wrapping_paper, iswizard = TRUE)
+	H.add_spell(new/spell/aoe_turf/conjure/gingerbreadman, iswizard = TRUE)
 //	H.add_spell(new/spell/targeted/flesh_to_coal)
 
 	to_chat(world,'sound/misc/santa.ogg')
@@ -351,14 +351,14 @@
 
 /datum/spellbook_artifact/prestidigitation/purchased(mob/living/carbon/human/H)
 	..()
-	H.add_spell(new/spell/targeted/spark)
-	H.add_spell(new/spell/targeted/extinguish)
-	H.add_spell(new/spell/targeted/clean)
-	H.add_spell(new/spell/targeted/unclean)
-	H.add_spell(new/spell/targeted/create_trinket)
-	H.add_spell(new/spell/targeted/cool_object)
-	H.add_spell(new/spell/targeted/warm_object)
-	H.add_spell(new/spell/targeted/color_change)
+	H.add_spell(new/spell/targeted/spark, iswizard = TRUE)
+	H.add_spell(new/spell/targeted/extinguish, iswizard = TRUE)
+	H.add_spell(new/spell/targeted/clean, iswizard = TRUE)
+	H.add_spell(new/spell/targeted/unclean, iswizard = TRUE)
+	H.add_spell(new/spell/targeted/create_trinket, iswizard = TRUE)
+	H.add_spell(new/spell/targeted/cool_object, iswizard = TRUE)
+	H.add_spell(new/spell/targeted/warm_object, iswizard = TRUE)
+	H.add_spell(new/spell/targeted/color_change, iswizard = TRUE)
 
 /datum/spellbook_artifact/blindingspeed
 	name = "Boots of Blinding Speed"
@@ -381,4 +381,4 @@
 
 /datum/spellbook_artifact/nogunallowed/purchased(mob/living/carbon/human/H)
 	..()
-	H.add_spell (new/spell/passive/nogunallowed)
+	H.add_spell (new/spell/passive/nogunallowed, iswizard = TRUE)

--- a/code/modules/mob/living/simple_animal/hostile/pitbull.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pitbull.dm
@@ -47,10 +47,10 @@
 	return L
 
 /mob/living/simple_animal/hostile/pitbull/Life()
-	if(prob(treachery_chance))
-		Treachery() //empties the friend list and faction allignment
-
-	if(treacherous && prob(calmdown_chance))
+	if(!treacherous)
+		if(prob(treachery_chance))
+			Treachery() //empties the friend list and faction allignment
+	else if(treacherous && prob(calmdown_chance))
 		Calmdown() //repopulates the friend list and realligns our faction
 	..()
 

--- a/code/modules/mob/spells.dm
+++ b/code/modules/mob/spells.dm
@@ -11,12 +11,12 @@
 			if(spell_master.type == master_type)
 				spell_list.Add(spell_to_add)
 				spell_master.add_spell(spell_to_add)
-				if(on_added) //If we want to call this spell proc
-					spell_to_add.on_added(src)
 				if(mind && iswizard)
 					if(!mind.wizard_spells)
 						mind.wizard_spells = list()
 					mind.wizard_spells += spell_to_add
+				if(on_added) //If we want to call this spell proc
+					spell_to_add.on_added(src)
 				return 1
 
 	//Don't do the spellmaster menu stuff if there's not supposed to be a button for the spell
@@ -31,12 +31,12 @@
 			new_spell_master.icon_state = spell_base
 		spell_masters.Add(new_spell_master)
 	spell_list.Add(spell_to_add)
-	if(on_added)
-		spell_to_add.on_added(src)
 	if(mind && iswizard)
 		if(!mind.wizard_spells)
 			mind.wizard_spells = list()
 		mind.wizard_spells += spell_to_add
+	if(on_added)
+		spell_to_add.on_added(src)
 	return 1
 
 /mob/proc/cast_spell(spell/spell_to_cast, list/targets)
@@ -63,10 +63,10 @@
 		return
 	master.remove_spell(spell_to_remove)
 
-	if(on_removed)
-		spell_to_remove.on_removed(src)
 	if(mind && mind.wizard_spells)
 		mind.wizard_spells.Remove(spell_to_remove)
+	if(on_removed)
+		spell_to_remove.on_removed(src)
 	spell_list.Remove(spell_to_remove)
 	return 1
 

--- a/code/modules/spells/aoe_turf/conjure/snakes.dm
+++ b/code/modules/spells/aoe_turf/conjure/snakes.dm
@@ -19,7 +19,7 @@
 	delete_snakes()
 	if(!..())
 		user.visible_message("<span class='warning'>\The [user]'s body splits into a mass of snakes!</span>","<span class='notice'>Your body splits into a mass of snakes.</span>")
-		user.transmogrify(/mob/living/simple_animal/cat/snek/wizard, TRUE)
+		user.transmogrify(/mob/living/simple_animal/cat/snek/wizard, TRUE, FALSE)
 
 /spell/aoe_turf/conjure/snakes/summon_object(var/type, var/location)
 	return new type(location, holder)

--- a/code/modules/spells/aoe_turf/magic_wardrobe.dm
+++ b/code/modules/spells/aoe_turf/magic_wardrobe.dm
@@ -21,14 +21,13 @@
 	var/wardrobeHealth = 100
 
 /spell/aoe_turf/conjure/magical_wardrobe/on_added(mob/user)
-	spawn() //Makes the other spell appear after the main spell in wizard_spells
-		mWRecall = new /spell/targeted/magical_wardrobe_recall
-		mWRecall.mCloset = magicCloset
-		if(user.mind)
-			if(!user.mind.wizard_spells)
-				user.mind.wizard_spells = list()
-			user.mind.wizard_spells += mWRecall
-		user.add_spell(mWRecall)
+	mWRecall = new /spell/targeted/magical_wardrobe_recall
+	mWRecall.mCloset = magicCloset
+	if(user.mind)
+		if(!user.mind.wizard_spells)
+			user.mind.wizard_spells = list()
+		user.mind.wizard_spells += mWRecall
+	user.add_spell(mWRecall)
 
 /spell/aoe_turf/conjure/magical_wardrobe/on_removed(mob/user)
 	for(var/spell/targeted/magical_wardrobe_recall/mgr in user.spell_list)

--- a/code/modules/spells/aoe_turf/magic_wardrobe.dm
+++ b/code/modules/spells/aoe_turf/magic_wardrobe.dm
@@ -21,13 +21,14 @@
 	var/wardrobeHealth = 100
 
 /spell/aoe_turf/conjure/magical_wardrobe/on_added(mob/user)
-	mWRecall = new /spell/targeted/magical_wardrobe_recall
-	mWRecall.mCloset = magicCloset
-	if(user.mind)
-		if(!user.mind.wizard_spells)
-			user.mind.wizard_spells = list()
-		user.mind.wizard_spells += mWRecall
-	user.add_spell(mWRecall)
+	spawn() //Makes the other spell appear after the main spell in wizard_spells
+		mWRecall = new /spell/targeted/magical_wardrobe_recall
+		mWRecall.mCloset = magicCloset
+		if(user.mind)
+			if(!user.mind.wizard_spells)
+				user.mind.wizard_spells = list()
+			user.mind.wizard_spells += mWRecall
+		user.add_spell(mWRecall)
 
 /spell/aoe_turf/conjure/magical_wardrobe/on_removed(mob/user)
 	for(var/spell/targeted/magical_wardrobe_recall/mgr in user.spell_list)
@@ -113,6 +114,11 @@
 	if(mWSummon)
 		mWSummon.mCloset = magicCloset
 
+//Set the new player as the user
+/spell/aoe_turf/conjure/magical_wardrobe/on_transfer(mob/user)
+	if(magicCloset)
+		magicCloset.theWiz = user
+
 /spell/aoe_turf/conjure/magical_wardrobe/proc/clearClosets()
 	magicCloset = null
 	if(mWRecall)
@@ -131,12 +137,15 @@
 	range = SELFCAST
 	var/obj/structure/closet/magical_wardrobe/mCloset = null
 
-/spell/targeted/magical_wardrobe_recall/cast(list/targets, mob/user)
+/spell/targeted/magical_wardrobe_recall/before_cast(list/targets, user, bypass_range)
 	if(!mCloset)
 		to_chat(user, "<span class='warning'>You don't have a wardrobe to recall to!</span>")
-	else
-		do_teleport(user, mCloset, 0)
-		mCloset.wardrobeToggle()
+		return 0
+	return ..()
+
+/spell/targeted/magical_wardrobe_recall/cast(list/targets, mob/user)
+	do_teleport(user, mCloset, 0)
+	mCloset.wardrobeToggle()
 
 /spell/magical_wardrobe_summon
 	name = "Wardrobe Summon"
@@ -150,12 +159,15 @@
 /spell/magical_wardrobe_summon/choose_targets(mob/user = usr)
 	return list(user)
 
+/spell/magical_wardrobe_summon/before_cast(list/targets, user, bypass_range)
+	if(!mCloset)
+		to_chat(user, "<span class='warning'>You don't have a wardrobe to recall to!</span>")
+		return 0
+	return ..()
+
 /spell/magical_wardrobe_summon/cast(list/targets, mob/user)
-	if(mCloset)
-		do_teleport(mCloset, user, 0)
-		mCloset.wardrobeToggle()
-	else
-		to_chat(user, "<span class='warning'>You don't have a wardrobe to summon!</span>")
+	do_teleport(mCloset, user, 0)
+	mCloset.wardrobeToggle()
 
 
 /obj/structure/closet/magical_wardrobe

--- a/code/modules/spells/aoe_turf/magic_wardrobe.dm
+++ b/code/modules/spells/aoe_turf/magic_wardrobe.dm
@@ -140,7 +140,7 @@
 /spell/targeted/magical_wardrobe_recall/before_cast(list/targets, user, bypass_range)
 	if(!mCloset)
 		to_chat(user, "<span class='warning'>You don't have a wardrobe to recall to!</span>")
-		return 0
+		return list()
 	return ..()
 
 /spell/targeted/magical_wardrobe_recall/cast(list/targets, mob/user)
@@ -162,7 +162,7 @@
 /spell/magical_wardrobe_summon/before_cast(list/targets, user, bypass_range)
 	if(!mCloset)
 		to_chat(user, "<span class='warning'>You don't have a wardrobe to recall to!</span>")
-		return 0
+		return list()
 	return ..()
 
 /spell/magical_wardrobe_summon/cast(list/targets, mob/user)

--- a/code/modules/spells/passive/no_gun_allowed.dm
+++ b/code/modules/spells/passive/no_gun_allowed.dm
@@ -9,3 +9,6 @@
 
 /spell/passive/nogunallowed/on_added(mob/user)
 	user.flags |= HONORABLE_NOGUNALLOWED
+
+/spell/passive/nogunallowed/on_transfer(mob/user)
+	user.flags |= HONORABLE_NOGUNALLOWED

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -428,11 +428,16 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 			return 0
 
 	//gentling check
-	if((user_type == USER_TYPE_WIZARD) && (holder == user))
+	if((is_wizard_spell()) && (holder == user))
 		if(user.is_gentled())
 			return 0
 
 	return 1
+
+/spell/proc/is_wizard_spell()
+	if(user_type == USER_TYPE_WIZARD || USER_TYPE_SPELLBOOK)
+		return TRUE
+	return FALSE
 
 /spell/proc/check_charge(var/skipcharge, mob/user)
 	//Arcane golems have no cooldowns on their spells
@@ -656,6 +661,9 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	return
 
 /spell/proc/on_holder_death(mob/user)
+	return
+
+/spell/proc/on_transfer(mob/user)
 	return
 
 //To batch-remove wizard spells. Linked to mind.dm.

--- a/code/modules/spells/targeted/absorb.dm
+++ b/code/modules/spells/targeted/absorb.dm
@@ -56,15 +56,16 @@
 							to_chat(target, "<span class='warning'>You forget how to cast [targetspell.name]!</span>")
 							to_chat(holder, "<span class='notice'>You absorb the magical energies from your foe and have learned [targetspell.name]!</span>")
 							L.attack_log += text("\[[time_stamp()] <font color='orange'>[L.real_name] ([L.ckey]) absorbed the spell [targetspell.name] from [C.real_name] ([C.ckey]).</font>")
+							var/wizard_user = iswizard(L) //Wizards will steal and store it in their wizard spells
 							C.remove_spell(targetspell)
-							L.add_spell(targetspell)
+							L.add_spell(targetspell, iswizard = wizard_user)
 							if(!hasAbsorbed)
 								hasAbsorbed = TRUE
 					if(!hasAbsorbed)
 						to_chat(holder, "<span class='notice'>You find magical energy within your foe, but there is nothing new to learn.</span>")
 					if(iswizard(target))	//Wizards aren't wizards without magic! Dust their asses if they're a wizard
+						C.visible_message("<span class='sinister'>[C.real_name] dissolves in a burst of light!</span>")
 						target.dust()
-						L.visible_message("<span class='sinister'>[C.real_name] dissolves in a burst of light!</span>")
 				if(E)		//Remove portal effect if the absorbtion is cancelled early.
 					qdel(E)
 

--- a/code/modules/spells/targeted/absorb.dm
+++ b/code/modules/spells/targeted/absorb.dm
@@ -39,7 +39,7 @@
 					for(var/spell/targetspell in C.spell_list)
 						canAbsorb = TRUE
 						for(var/spell/holderspell in L.spell_list)
-							if(targetspell.user_type != USER_TYPE_WIZARD && targetspell.user_type != USER_TYPE_SPELLBOOK)
+							if(!holderspell.is_wizard_spell())
 								continue
 							if(targetspell.type == holderspell.type)
 								canAbsorb = FALSE
@@ -54,7 +54,7 @@
 						if(canAbsorb)
 							to_chat(target, "<span class='warning'>You feel the magical energy being drained from you!</span>")
 							to_chat(target, "<span class='warning'>You forget how to cast [targetspell.name]!</span>")
-							to_chat(holder, "<span class='notice'>You asborb the magical energies from your foe and have learned [targetspell.name]!</span>")
+							to_chat(holder, "<span class='notice'>You absorb the magical energies from your foe and have learned [targetspell.name]!</span>")
 							L.attack_log += text("\[[time_stamp()] <font color='orange'>[L.real_name] ([L.ckey]) absorbed the spell [targetspell.name] from [C.real_name] ([C.ckey]).</font>")
 							C.remove_spell(targetspell)
 							L.add_spell(targetspell)

--- a/code/modules/spells/targeted/genetic.dm
+++ b/code/modules/spells/targeted/genetic.dm
@@ -79,6 +79,21 @@ code\game\\dna\genes\goon_powers.dm
 	hud_state = "wiz_hulk"
 	user_type = USER_TYPE_WIZARD
 
+/spell/targeted/genetic/mutate/before_cast(list/targets, user, bypass_range)
+	var/mob/living/carbon/human/H = user
+	if(istype(H) && (M_HULK in H.mutations))
+		if(H.hulk_time || H.hulk_gene_active)
+			to_chat(user, "<span class='warning'>You are already a hulk!</span>")
+			return list()
+	return ..()
+
+/spell/targeted/genetic/mutate/cast(list/targets)
+	..()
+	var/mob/living/carbon/human/H = targets[1]
+	H.hulk_time = world.time + duration
+	H.update_mutations()		//update our mutation overlays
+	H.update_body()
+
 /spell/targeted/genetic/mutate/highlander
 	name = "Become Highlander"
 	desc = "Temporarily turn into a mighty highlander who cannot be stunned."

--- a/code/modules/spells/targeted/genetic.dm
+++ b/code/modules/spells/targeted/genetic.dm
@@ -22,11 +22,16 @@ code\game\\dna\genes\goon_powers.dm
 			target.mutations.Add(x)
 		target.disabilities |= disabilities
 		target.update_mutations()	//update target's mutation overlays
+		var/mob/living/carbon/human/H = target
+		if(istype(H))
+			H.update_body()
 		spawn(duration)
 			for(var/x in mutations)
 				target.mutations.Remove(x)
 			target.disabilities &= ~disabilities
 			target.update_mutations()
+			if(istype(H))
+				H.update_body()
 	return
 
 /spell/targeted/genetic/blind
@@ -82,17 +87,9 @@ code\game\\dna\genes\goon_powers.dm
 /spell/targeted/genetic/mutate/before_cast(list/targets, user, bypass_range)
 	var/mob/living/carbon/human/H = user
 	if(istype(H) && (M_HULK in H.mutations))
-		if(H.hulk_time || H.hulk_gene_active)
-			to_chat(user, "<span class='warning'>You are already a hulk!</span>")
-			return list()
+		to_chat(user, "<span class='warning'>You are already a hulk!</span>")
+		return list()
 	return ..()
-
-/spell/targeted/genetic/mutate/cast(list/targets)
-	..()
-	var/mob/living/carbon/human/H = targets[1]
-	H.hulk_time = world.time + duration
-	H.update_mutations()		//update our mutation overlays
-	H.update_body()
 
 /spell/targeted/genetic/mutate/highlander
 	name = "Become Highlander"
@@ -101,6 +98,15 @@ code\game\\dna\genes\goon_powers.dm
 	mutations = list(M_HULK)
 	message = "<span class='notice'>You feel powerful! Nobody can take you down! It's time to take some heads!</span>"
 	user_type = USER_TYPE_OTHER
+
+//The same check as the parent except with a different message
+/spell/targeted/genetic/mutate/highlander/before_cast(list/targets, user, bypass_range)
+	var/mob/living/carbon/human/H = user
+	if(istype(H) && (M_HULK in H.mutations))
+		to_chat(user, "<span class='warning'>You already cannot be stunned!</span>")
+		return list()
+	return ..()
+
 
 /spell/targeted/genetic/eat_weed
 	name = "Eat Weeds"

--- a/code/modules/spells/targeted/push.dm
+++ b/code/modules/spells/targeted/push.dm
@@ -38,7 +38,10 @@
 	var/area/prospective = pick(areas)
 	while(!thearea)
 		if(prospective.type != /area)
-			var/turf/T = pick(get_area_turfs(prospective.type))
+			var/list/prospective_turfs = get_area_turfs(prospective.type)
+			if(!prospective_turfs.len) //An in-game area somehow lost its turfs, search for another one
+				continue
+			var/turf/T = pick(prospective_turfs)
 			if(T.z == holder.z)
 				thearea = prospective
 				break

--- a/code/modules/spells/targeted/recall.dm
+++ b/code/modules/spells/targeted/recall.dm
@@ -47,7 +47,6 @@
 		/obj/machinery/light,									//light bulbs and tubes
 		/obj/machinery/media/receiver/boombox/wallmount,		//sound systems
 		/obj/machinery/keycard_auth,							//keycard authentication devices
-		/obj/structure/closet/magical_wardrobe,					//a magical wardrobe closet
 		/obj/landline,											//telephone landlines
 		/obj/effect/phone_cord,									//the telephone cord effect
 		/obj/item/telephone,									//telephones
@@ -168,14 +167,13 @@
 	bound_icon = null
 
 /spell/targeted/bound_object/on_added(mob/user)
-	spawn() //So that the spell gets added after the main spell in wizard_spells
-		if(alert(user, "You can unbind the chosen object by middle-clicking the spell icon. You can also have a dedicated spell for unbinding. Do you want this?",,"Yes","No") == "Yes")
-			var/spell/unbind/unbind = new /spell/unbind
-			if(user.mind)
-				if(!user.mind.wizard_spells)
-					user.mind.wizard_spells = list()
-				user.mind.wizard_spells += unbind
-			user.add_spell(unbind)
+	if(alert(user, "You can unbind the chosen object by middle-clicking the spell icon. You can also have a dedicated spell for unbinding. Do you want this?",,"Yes","No") == "Yes")
+		var/spell/unbind/unbind = new /spell/unbind
+		if(user.mind)
+			if(!user.mind.wizard_spells)
+				user.mind.wizard_spells = list()
+			user.mind.wizard_spells += unbind
+		user.add_spell(unbind)
 
 /spell/targeted/bound_object/on_removed(mob/user)
 	clear_bound()

--- a/code/modules/spells/targeted/recall.dm
+++ b/code/modules/spells/targeted/recall.dm
@@ -47,6 +47,10 @@
 		/obj/machinery/light,									//light bulbs and tubes
 		/obj/machinery/media/receiver/boombox/wallmount,		//sound systems
 		/obj/machinery/keycard_auth,							//keycard authentication devices
+		/obj/structure/closet/magical_wardrobe,					//a magical wardrobe closet
+		/obj/landline,											//telephone landlines
+		/obj/effect/phone_cord,									//the telephone cord effect
+		/obj/item/telephone,									//telephones
 		)
 	//Generally extremely dangerous things that could spell doom and devastation for anyone nearby, possibly the wizard too
 	var/list/empower_limited = list(
@@ -112,11 +116,19 @@
 						return 0
 			has_object = 1
 			bound = target
-			bound_icon = image(target.icon, target.icon_state, layer = HUD_ITEM_LAYER)
-			connected_button.overlays += bound_icon
+			draw_bound_object(bound)
 			to_chat(user, "You bind \the [target] to yourself.")
 			channel_spell(force_remove = 1)
 	return 1
+
+//Creates the item's sprite for the spell sprite
+/spell/targeted/bound_object/proc/draw_bound_object(var/obj/target)
+	if(!connected_button || !target)
+		return
+	connected_button.overlays -= bound_icon
+	bound_icon = null
+	bound_icon = image(target.icon, target.icon_state, layer = HUD_ITEM_LAYER)
+	connected_button.overlays += bound_icon
 
 /spell/targeted/bound_object/empower_spell()
 	var/upgrade_desc
@@ -151,22 +163,28 @@
 /spell/targeted/bound_object/proc/clear_bound()
 	has_object = 0
 	bound = null
-	connected_button.overlays -= bound_icon
+	if(connected_button)
+		connected_button.overlays -= bound_icon
 	bound_icon = null
 
 /spell/targeted/bound_object/on_added(mob/user)
-	if(alert(user, "You can unbind the chosen object by middle-clicking the spell icon. You can also have a dedicated spell for unbinding. Do you want this?",,"Yes","No") == "Yes")
-		var/spell/unbind/unbind = new /spell/unbind
-		if(user.mind)
-			if(!user.mind.wizard_spells)
-				user.mind.wizard_spells = list()
-			user.mind.wizard_spells += unbind
-		user.add_spell(unbind)
+	spawn() //So that the spell gets added after the main spell in wizard_spells
+		if(alert(user, "You can unbind the chosen object by middle-clicking the spell icon. You can also have a dedicated spell for unbinding. Do you want this?",,"Yes","No") == "Yes")
+			var/spell/unbind/unbind = new /spell/unbind
+			if(user.mind)
+				if(!user.mind.wizard_spells)
+					user.mind.wizard_spells = list()
+				user.mind.wizard_spells += unbind
+			user.add_spell(unbind)
 
 /spell/targeted/bound_object/on_removed(mob/user)
 	clear_bound()
 	for(var/spell/unbind/spell in user.spell_list)
 		user.remove_spell(spell)
+
+//The connected button is regenerated, have it re-draw the image
+/spell/targeted/bound_object/on_transfer(mob/user)
+	draw_bound_object(bound)
 
 /spell/unbind
 	name = "Unbind"

--- a/code/modules/surgery/butt.dm
+++ b/code/modules/surgery/butt.dm
@@ -157,7 +157,7 @@
 		for(var/spell/spell in target.mind.wizard_spells)
 			target.remove_spell(spell)
 	B.transfer_buttdentity(target)
-	target.op_stage.butt = 4
+	target.op_stage.butt = SURGERY_NO_BUTT
 
 /datum/surgery_step/butt/cauterize_butt/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='warning'>[target] lets out a small fart, which gets set alight with [user]'s [tool]!</span>" , \


### PR DESCRIPTION
Fixes #34823 
Fixes #34577
Fixes #34347 
Fixes #33762
Fixes #32203

:cl:
 * tweak: The Magic Closet's other spells that bring the wizard to it or bring the closet to the wizard will no longer go on cooldown if the closet does not exist.
 * tweak: Wizards will no longer die if their snake form during "Become Snakes" dies.
 * tweak: "Bind Object" will now maintain the bound item after a mind transference.
 * tweak: Wizards will now store Absorbed spells in their list of wizard spells.
 * bugfix: Apprentices are now considered as belonging properly to the wizard faction, meaning that they will no longer be attacked by wizardly constructs such as pitbulls (most of the time). In addition, their flavor text will now be properly removed.
 * bugfix: The Prestidigitation, Santa bundle and No Gun Allowed spells will now be properly considered wizard-specific spells when purchased from the spellbook.
 * bugfix: If wizard apprentices somehow manage to learn forbidden spellbook spells they will now be properly transferred during mind transference.
 * bugfix: Forbidden spellbook spells will now be properly blocked by gentling.
 * bugfix: Fixed a rare bug where the "Push" spell would fail to push a target if the area it selected did not have any tiles, which would only happen if the area existed at some point during the game but then stopped existing.
 * bugfix: Fixed the Mutate spell immediately ending early if the wizard had the Hulk gene.
 * bugfix: Hulk Out, Mutate and Become Highlander can no longer be stacked. Not that it did anything useful but it breaks things. Also added different messages for each ability when attempting to do so.
 * bugfix: Wizards and Apprentices will now display their current wizardly spells at the round-end scoreboard rather than every single spell and spell-like ability they know.
 * bugfix: Attempting to use Mind Transfer on a target that is already preparing to cast a spell (AKA in the state where they have to click something to cast the spell) should no longer break Mind Transfer so hard that it creates a living dummy being.
 * bugfix: Fixed a runtime in regards to wizard spells from wizard antagonists being transferred to a new character, such as through Mind Transfer or the Staff of Change.
 * bugfix: The Request Console's phone and cords can no longer be bound by Bind Object.
 * bugfix: The "Mutate" and "Become Highlander" spells will now properly make their recipients green and mean.
 * bugfix: Fixed a bug where a wizard's message about dissolving in a burst of light after being Absorbed (the magic-stealing spell) was centered on the absorber rather than the absorbed.
 * spellcheck: Fixed a small typo in the wizard's "Absorb" spell (during Civil War of Casters) when absorbing another wizard's spells.
