### PR TITLE
mob deletion fix 2: bodybag recycler

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -10,7 +10,7 @@
 	var/obj/structure/closet/body_bag/R = new /obj/structure/closet/body_bag(user.loc)
 	R.add_fingerprint(user)
 	qdel(src)
-
+	
 
 /obj/item/weapon/storage/box/bodybags
 	name = "body bag kit"
@@ -41,6 +41,7 @@
 	density = 0
 	sound_file = 'sound/items/zip.ogg'
 	autoignition_temperature = AUTOIGNITION_PLASTIC
+	w_type = NOT_RECYCLABLE
 
 /obj/structure/closet/body_bag/attackby(obj/item/W, mob/user)
 	if(istype(W,/obj/item/stack/sheet/metal))


### PR DESCRIPTION
did you know closed crates/lockers can't be recycled since they're solid? but since bodybags aren't solid they can
closes #34484
there's a couple more ways to delete stuff by drilling/recycling containers
ie put brain in toolbox, recycle toolbox
or put a body into a locker, then drill it(has to be a basic locker)

a more proper fix would be to have all closets/boxes drop their contents but that would certainly cause unforeseen consequences
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: deployed bodybags can no longer be recycled

