### PR TITLE
hotfix for imidazoline blindness curing

### DIFF
--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -2,7 +2,7 @@
 /// Droppers.
 ////////////////////////////////////////////////////////////////////////////////
 /obj/item/weapon/reagent_containers/dropper
-	name = "Dropper"
+	name = "dropper"
 	desc = "A dropper. Transfers 5 units."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "dropper0"
@@ -42,11 +42,11 @@
 			update_icon()
 			return
 	user.visible_message("<span class='danger'>[user] squirts something into [M]'s eyes!</span>", "<span class='notice'>You squirt something into [M]'s eyes.</span>")
-	src.reagents.reaction_dropper(M)
-	src.reagents.remove_any(amount_per_transfer_from_this)
 	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been squirted with [src.name] by [user.name] ([user.ckey]). Reagents: [reagents.get_reagent_ids(1)]</font>")
 	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to squirt [M.name] ([M.key]). Reagents: [reagents.get_reagent_ids(1)]</font>")
 	msg_admin_attack("[user.name] ([user.ckey]) squirted [M.name] ([M.key]) with [src.name]. Reagents: [reagents.get_reagent_ids(1)] (INTENT: [uppertext(user.a_intent)]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+	src.reagents.reaction_dropper(M)
+	src.reagents.remove_any(amount_per_transfer_from_this)
 	if(!iscarbon(user))
 		M.LAssailant = null
 	else

--- a/code/modules/reagents/reagents/reagents_medical.dm
+++ b/code/modules/reagents/reagents/reagents_medical.dm
@@ -824,7 +824,7 @@ var/global/list/charcoal_doesnt_remove=list(
 			var/obj/item/eyes_covered = H.get_body_part_coverage(EYES)
 			if(eyes_covered)
 				return
-			else //eyedrops, why not
+			if(TARGET_EYES in zone_sels) /* If you're targeting eyes specifically, splashing the reagent into them will also work. */
 				var/datum/organ/internal/eyes/E = H.internal_organs_by_name["eyes"]
 				if(istype(E) && !E.robotic)
 					M.eye_blurry = 0
@@ -849,6 +849,8 @@ var/global/list/charcoal_doesnt_remove=list(
 				M.eye_blind = 0
 				if(E.damage > 0)
 					E.damage = 0 //cosmic technologies
+				if(M.sdisabilities & BLIND)
+					M.sdisabilities ^= BLIND
 				to_chat(H,"<span class='notice'>Your eyes feel better.</span>")
 
 /datum/reagent/inacusiate


### PR DESCRIPTION
## What this does
Pretty sure what happened here is I cut and paste a block of code while testing these changes, thus not actually adding the functionality for curing eye damage from the droppers. I deeply apologize for not catching my mistake!

Also fixed some (unrelated) admin/attack logs that never worked for droppers.
Fixes #36144

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Splashing imidazoline into someone's eyes (such as from a beaker) will now also cure their eye damage.
 * bugfix: Fixed imidazoline in droppers not properly curing blindness.
 * bugfix: Fixed the admin/attack logs for droppers not properly displaying reagents.
