### PR TITLE
Vox and plasmaman orderlies will no longer spawn with an extra paralytic injector

### DIFF
--- a/code/datums/outfit/medical.dm
+++ b/code/datums/outfit/medical.dm
@@ -387,7 +387,6 @@
 			slot_wear_suit_str = /obj/item/clothing/suit/space/plasmaman/medical,
 			slot_head_str = /obj/item/clothing/head/helmet/space/plasmaman/medical,
 			slot_wear_mask_str =  /obj/item/clothing/mask/breath/,
-			slot_l_store_str = /obj/item/weapon/reagent_containers/hypospray/autoinjector/paralytic_injector,
 			slot_r_store_str = /obj/item/weapon/soap,
 		),
 		/datum/species/vox = list(
@@ -398,7 +397,6 @@
 			slot_wear_suit_str = /obj/item/clothing/suit/space/vox/civ/medical,
 			slot_head_str = /obj/item/clothing/head/helmet/space/vox/civ/medical,
 			slot_wear_mask_str =  /obj/item/clothing/mask/breath/vox,
-			slot_l_store_str = /obj/item/weapon/reagent_containers/hypospray/autoinjector/paralytic_injector,
 			slot_r_store_str = /obj/item/weapon/soap,
 		),
 	)


### PR DESCRIPTION
It turns out that non-human orderlies (plasmaman and vox, specifically) spawned with an extra paralytic injector, giving them 5 injectors compared to the default of 4. Paralytic injectors are already strong enough because there is no defense against them other than not getting close to the user (they are effectively parapens), so it ends up as a clear advantage based on species by having an extra use of a tool whose limit is that it is in limited supply.

:cl:
 * rscdel: Vox and plasmaman Orderlies will no longer spawn with an extra paralytic injector in their pocket.