### PR TITLE
Shields now protect against even more stuff

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -216,7 +216,7 @@
 			M.assaulted_by(user)
 
 /obj/item/weapon/melee/baton/throw_impact(atom/hit_atom)
-	if(prob(50))
+	if(prob(50)) //Landed handle-first into the target
 		return ..()
 	if(!isliving(hit_atom) || !status)
 		return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -47,6 +47,8 @@
 		displayed_holomap.update_holomap()
 
 /mob/living/carbon/attack_animal(mob/living/simple_animal/M as mob)//humans and slimes have their own
+	if(check_shields(0, M))
+		return 0
 	M.unarmed_attack_mob(src)
 
 /mob/living/carbon/relaymove(var/mob/user, direction)

--- a/code/modules/mob/living/carbon/human/human_attackanimal.dm
+++ b/code/modules/mob/living/carbon/human/human_attackanimal.dm
@@ -1,5 +1,0 @@
-/mob/living/carbon/human/attack_animal(mob/living/simple_animal/M)
-	if(check_shields(0, M))
-		return 0
-
-	M.unarmed_attack_mob(src)

--- a/code/modules/mob/living/simple_animal/hostile/monster.dm
+++ b/code/modules/mob/living/simple_animal/hostile/monster.dm
@@ -76,13 +76,16 @@
 			adjustBruteLoss(25)
 			emp_damage+=25
 
-/mob/living/simple_animal/hostile/monster/cyber_horror/AttackingTarget()
-	..()
-	var/mob/living/L = target
-	if(L.reagents)
-		if(prob(nanobot_chance))
-			visible_message("<b><span class='warning'>[src] injects something into [L]!</span>")
-			L.reagents.add_reagent(MEDNANOBOTS, 2)
+//Override the UnarmedAttack in order to allow checking for whether the attack actually goes through
+/mob/living/simple_animal/hostile/monster/cyber_horror/UnarmedAttack(atom/A)
+	if(ismob(A))
+		delayNextAttack(10)
+	if(A.attack_animal(src)) //Returns 0 if blocked
+		var/mob/living/L = A
+		if(L.reagents)
+			if(prob(nanobot_chance))
+				visible_message("<b><span class='warning'>[src] injects something into [L]!</span>")
+				L.reagents.add_reagent(MEDNANOBOTS, 2)
 
 /mob/living/simple_animal/hostile/monster/cyber_horror/death(var/gibbed = FALSE)
 	..(gibbed)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -502,6 +502,10 @@
 		for(var/atom/A in T)
 			if (A == src)
 				continue
+			if(iscarbon(A))
+				var/mob/living/carbon/C = A
+				if(C.check_shields(throwforce, src))
+					continue
 			var/list/hit_zone = user && user.zone_sel ? list(user.zone_sel.selecting) : ALL_LIMBS
 			reagents.reaction(A, zone_sels = hit_zone)
 		return 1
@@ -8776,7 +8780,7 @@ var/global/list/bomb_like_items = list(/obj/item/device/transfer_valve, /obj/ite
 	child_type = /obj/item/weapon/reagent_containers/food/snacks/sugarcube
 	child_volume = 3
 
-/obj/item/weapon/reagent_containers/food/snacks/multispawner/sugarcube/New()	
+/obj/item/weapon/reagent_containers/food/snacks/multispawner/sugarcube/New()
 	..()
 	reagents.add_reagent(SUGAR, 15) //spawns 5
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -39,7 +39,10 @@
 		if(H.species && (H.species.chem_flags & NO_INJECT))
 			to_chat(user, "<span classs='notice'>\The [src]'s needle fails to pierce [H]")
 			return
-
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		if(C.check_shields(0, src))
+			return
 	var/inject_message = "<span class='notice'>You inject [M] with [src].</span>"
 	if(M == user)
 		inject_message = "<span class='notice'>You inject yourself with [src].</span>"

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -1959,7 +1959,6 @@
 #include "code\modules\mob\living\carbon\human\examine.dm"
 #include "code\modules\mob\living\carbon\human\human.dm"
 #include "code\modules\mob\living\carbon\human\human_attackalien.dm"
-#include "code\modules\mob\living\carbon\human\human_attackanimal.dm"
 #include "code\modules\mob\living\carbon\human\human_attackhand.dm"
 #include "code\modules\mob\living\carbon\human\human_attackpaw.dm"
 #include "code\modules\mob\living\carbon\human\human_damage.dm"


### PR DESCRIPTION
There were a few more things that bypassed shields and directly affected someone.
- Hyposprays and autoinjectors (when even unarmed hugs can get blocked by a shield, how can these bypass them altogether?)
- Cyber horror attacks (this also means player-controlled cyber horrors now have a chance to inject targets)
- Fruits that could get squished when thrown at a target and splash their chemicals all over a target (the chemicals no longer physically phase through shields)

The shield will now protect against those.
Also fixes a shield bug and allows them to work on carbons when defending against simple-mobs.

:cl:
 * tweak: Shields will now protect against hyposprays/autoinjectors, a cyber horror's injection attack and squishable fruits.
 * rscadd: Player-controlled cyber horrors now have a proper random chance to inject someone with nanobots per attack instead of being unable to do so.
 * bugfix: Monkeys, martians and possibly even xenomorphs will now properly defend themselves with shields when attacked by creatures.