### PR TITLE
Vampires now get extra examination text when examining people

### DIFF
--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -90,6 +90,7 @@
 	var/datum/objective_holder/objectives=new
 	var/logo_icon = 'icons/logos.dmi'
 	var/logo_state = "synd-logo"
+	var/logo_image //Where the image itself gets stored
 
 	var/default_admin_voice = "Supreme Leader"
 	var/admin_voice_style = "radio" // check stylesheet.dm for a list of all possible styles
@@ -134,6 +135,8 @@
 	objectives.owner = M
 	stat_datum = new stat_datum_type()
 
+	//In case we want a simpler copy of the icon without creating the image over and over again, such as in examine text
+	logo_image = "<img src='data:image/png;base64,[icon2base64(icon(logo_icon, logo_state))]'>"
 	return 1
 
 /datum/role/proc/AssignToRole(var/datum/mind/M, var/override = 0, var/msg_admins = TRUE)
@@ -582,6 +585,10 @@
 		return
 	D.spend_midround_threat(amount)
 	D.threat_log += "[worldtime2text()]: [name] has decreased the threat amount by [amount]."
+
+//Additional text that appears when examining something.
+/datum/role/proc/role_examine_text_addition(var/target)
+	return
 
 /////////////////////////////THESE ROLES SHOULD GET MOVED TO THEIR OWN FILES ONCE THEY'RE GETTING ELABORATED/////////////////////////
 

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -702,9 +702,10 @@
 	if(H.species.anatomy_flags & NO_BLOOD) //Target cannot carry blood
 		return "<span class='warning'>[logo_image] This vessel is incapable of having any blood!</span>"
 	var/amount_of_blood = round(H.vessel.get_reagent_amount(BLOOD), 1)
+	var/blood_type = H.dna ? H.dna.b_type : null
 	if(amount_of_blood)
 		var/targetref = "\ref[H]"
-		text += "<span class='notice'>This vessel has <span class='danger'>[amount_of_blood]</span> units of blood left.</span>"
+		text += "<span class='notice'>This vessel has <span class='danger'>[amount_of_blood]</span> units of [blood_type ? "[blood_type] " : ""]blood left.</span>"
 		if(!H.mind) //Target has no mind
 			text += "<span class='warning'><br>This vessel only carries lifeless blood!</span>"
 		else if(!(targetref in feeders) || (feeders[targetref] < MAX_BLOOD_PER_TARGET)) //Target has not been fed upon or is below the empowering blood limit they can give

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -713,9 +713,9 @@
 			text += "<span class='warning'><br>This vessel's blood has no energy left for you...</span>"
 		if(H.check_body_part_coverage(MOUTH)) //Target is masked
 			if(!locate(/datum/power/vampire/mature) in current_powers) //Vampire is not mature enough to deal with that
-				text += "<span class='warning'><br>This vessel is masked! This will impede you from sucking their blood.</span>"
+				text += "<span class='warning'><br>This vessel wears a mask! This will impede you from sucking their blood.</span>"
 			else
-				text += "<span class='notice'><br>This vessel is masked, but this will not impede you because you are a <span class='bnotice'>mature</span> vampire!</span>"
+				text += "<span class='notice'><br>This vessel wears a mask, but this will not impede you because you are a <span class='bnotice'>mature</span> vampire!</span>"
 	else
 		return "<span class='warning'>[logo_image] This vessel is completely drained of all blood!</span>"
 	return "[logo_image] [text]"

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -689,3 +689,33 @@
 // If the target is weakened, the spells take less time to complete.
 /mob/living/carbon/proc/get_vamp_enhancements()
 	return ((knockdown ? 2 : 0) + (stunned ? 1 : 0) + (sleeping || paralysis ? 3 : 0))
+
+/datum/role/vampire/role_examine_text_addition(target)
+	if((!ishuman(antag.current)) || (target == antag.current)) //Vampire is not a human that can suck blood, or trying to examine themselves.
+		return
+	var/mob/living/carbon/human/H = target
+	if(!istype(H)) //Examined target is not a human.
+		return
+	var/text = ""
+	if(isReligiousLeader(H) || (locate(/obj/item/weapon/nullrod) in get_contents_in_object(H))) //Chaplains and protected targets can't be examined
+		return "<span class='danger'>[logo_image] This vessel is protected by a holy aura!</span>"
+	if(H.species.anatomy_flags & NO_BLOOD) //Target cannot carry blood
+		return "<span class='warning'>[logo_image] This vessel is incapable of having any blood!</span>"
+	var/amount_of_blood = round(H.vessel.get_reagent_amount(BLOOD), 1)
+	if(amount_of_blood)
+		var/targetref = "\ref[H]"
+		text += "<span class='notice'>This vessel has <span class='danger'>[amount_of_blood]</span> units of blood left.</span>"
+		if(!H.mind) //Target has no mind
+			text += "<span class='warning'><br>This vessel only carries lifeless blood!</span>"
+		else if(!(targetref in feeders) || (feeders[targetref] < MAX_BLOOD_PER_TARGET)) //Target has not been fed upon or is below the empowering blood limit they can give
+			text += "<span class='good'><br>This vessel's blood can empower you!</span>"
+		else
+			text += "<span class='warning'><br>This vessel's blood has no energy left for you...</span>"
+		if(H.check_body_part_coverage(MOUTH)) //Target is masked
+			if(!locate(/datum/power/vampire/mature) in current_powers) //Vampire is not mature enough to deal with that
+				text += "<span class='warning'><br>This vessel is masked! This will impede you from sucking their blood.</span>"
+			else
+				text += "<span class='notice'><br>This vessel is masked, but this will not impede you because you are a <span class='bnotice'>mature</span> vampire!</span>"
+	else
+		return "<span class='warning'>[logo_image] This vessel is completely drained of all blood!</span>"
+	return "[logo_image] [text]"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -479,7 +479,7 @@ its easier to just keep the beam vertical.
 			to_chat(user, "<a href='?src=\ref[src];bug=\ref[bug]'>There's something hidden in there.</a>")
 		else if(isobserver(user) || prob(100 / (distance + 2)))
 			to_chat(user, "There's something hidden in there.")
-	if(isliving(user))
+	if(isliving(user) && user.mind)
 		for(var/datum/role/R in get_list_of_elements(user.mind.antag_roles))
 			var/antag_text = R.role_examine_text_addition(src)
 			if(antag_text)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -479,6 +479,11 @@ its easier to just keep the beam vertical.
 			to_chat(user, "<a href='?src=\ref[src];bug=\ref[bug]'>There's something hidden in there.</a>")
 		else if(isobserver(user) || prob(100 / (distance + 2)))
 			to_chat(user, "There's something hidden in there.")
+	if(isliving(user))
+		for(var/datum/role/R in get_list_of_elements(user.mind.antag_roles))
+			var/antag_text = R.role_examine_text_addition(src)
+			if(antag_text)
+				to_chat(user, "[antag_text]\n")
 	INVOKE_EVENT(src, /event/examined, "user" = user)
 
 /atom/Topic(href, href_list)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -482,10 +482,11 @@
 				msg += "<a href='?src=\ref[src];purchaselog=`'>\[Show antag purchase log\]</a>\n"
 
 	//It's also here because the examine text is written from scratch for humans.
-	for(var/datum/role/R in get_list_of_elements(user.mind.antag_roles))
-		var/antag_text = R.role_examine_text_addition(src)
-		if(antag_text)
-			msg += "[antag_text]\n"
+	if(isliving(user) && user.mind)
+		for(var/datum/role/R in get_list_of_elements(user.mind.antag_roles))
+			var/antag_text = R.role_examine_text_addition(src)
+			if(antag_text)
+				msg += "[antag_text]\n"
 
 	if(flavor_text && can_show_flavor_text())
 		msg += "[print_flavor_text()]\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -481,6 +481,12 @@
 			if(O.antagHUD && mind && mind.antag_roles.len)
 				msg += "<a href='?src=\ref[src];purchaselog=`'>\[Show antag purchase log\]</a>\n"
 
+	//It's also here because the examine text is written from scratch for humans.
+	for(var/datum/role/R in get_list_of_elements(user.mind.antag_roles))
+		var/antag_text = R.role_examine_text_addition(src)
+		if(antag_text)
+			msg += "[antag_text]\n"
+
 	if(flavor_text && can_show_flavor_text())
 		msg += "[print_flavor_text()]\n"
 


### PR DESCRIPTION
Mainly determines whether the target can have their blood sucked and how much blood they have. Will point out details such as whether the target does not have any blood, whether the blood can benefit the vampire and so on.
Being a chaplain or having a null rod will block the vampire from knowing how much blood you have.
WON'T reveal any vampires nor thralls.
Added back-end support for examine text being granted by antagonist roles. Also each role stores an image of their role icon, because I thought it would be wasteful to recreate the icon over and over again.

:cl:
 * rscadd: Vampires can now see details about how much blood their targets have and whether they can be sucked. However, they won't see if someone is a vampire or a thrall. Chaplains and people that possess null rods will block this effect.