### PR TITLE
Sleight of Teeth is now quiet.

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -163,22 +163,26 @@
 
 	var/mob/assailant = antag.current
 	var/targetref = "\ref[target]"
-	var/blood = 0
+	var/blood = 0 //How much blood will be sucked
 	var/blood_total_before = blood_total
 	var/blood_usable_before = blood_usable
 	assailant.attack_log += text("\[[time_stamp()]\] <font color='red'>Bit [key_name(target)] in the neck and draining their blood.</font>")
 	target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been bit in the neck by [key_name(assailant)].</font>")
 	log_attack("[key_name(assailant)] bit [key_name(target)] in the neck")
 
-	to_chat(antag.current, "<span class='danger'>You latch on firmly to \the [target]'s neck.</span>")
-	target.show_message("<span class='userdanger'>\The [assailant] latches on to your neck!</span>")
+	if(!silentbite)
+		to_chat(antag.current, "<span class='danger'>You latch on firmly to \the [target]'s neck.</span>")
+		target.show_message("<span class='userdanger'>\The [assailant] latches on to your neck!</span>")
+	else
+		to_chat(antag.current, "<span class='warning'>You quietly latch on to \the [target]'s neck...")
 
 	if(!iscarbon(assailant))
 		target.LAssailant = null
 	else
 		target.LAssailant = assailant
 		target.assaulted_by(assailant)
-	while(do_mob(assailant, target, (5 SECONDS) * (silentbite + 1)))
+	var/initial_silentbite = silentbite //No switching bite types after latching onto someone
+	while(do_mob(assailant, target, (5 SECONDS) * (initial_silentbite + 1)))
 		if(!isvampire(assailant))
 			to_chat(assailant, "<span class='warning'>Your fangs have disappeared!</span>")
 			draining = null
@@ -204,7 +208,8 @@
 			else
 				to_chat(assailant, "<span class='warning'>Their blood quenches your thirst but won't let you become any stronger. You need to find new prey.</span>")
 			blood_usable += blood
-			target.adjustBruteLoss(1)
+			if(!initial_silentbite) //If the bite is silent, do not tip the target that something is wrong.
+				target.adjustBruteLoss(1)
 			var/datum/organ/external/head/head_organ = target.get_organ(LIMB_HEAD)
 			head_organ.add_autopsy_data("sharp teeth", 1)
 		else

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -25,11 +25,7 @@
 			if(!V.silentbite)
 				playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
 				src.visible_message("<span class='danger'>\The [M] has bitten \the [src]!</span>", "<span class='userdanger'>You were bitten by \the [M]!</span>")
-			else
-				to_chat(M, "<span class='danger'>You start to slowly reach for [src]'s neck to bite it!.</span>")
-			var/mature = (locate(/datum/power/vampire/mature) in V.current_powers) ? 2 : 1
-			if(!V.silentbite || do_mob(M, src, (30 SECONDS) / mature))
-				V.handle_bloodsucking(src)
+			V.handle_bloodsucking(src)
 			return
 	//end vampire code
 


### PR DESCRIPTION
No longer has an initial wind-up time of 30 seconds, 15 if mature. Instead applies immediately.
No longer plays a sound when biting someone, nor alert anyone, not even the target. The target is likely to notice something wrong if they start feeling woozy after spending a minute near a random guy and then get told "you don't have a lot of blood".
The bite type will not change during blood sucking, if you want to perform loud biting then you'll have to re-bite the target while Sleight of Teeth is not active.
Compared to regular sucking the Sleight of Teeth sucking is 2x slower, at 10 seconds instead of regular sucking's 5.

:cl:
 * rscadd: The "Sleight of Teeth" vampire ability has been improved; It will no longer take an initial 30 seconds before starting the process, it will not inform the victim nor any nearby target of the blood sucking and it will not deal 1 brute damage compared to regular blood-sucking. Dine and dash today!