### PR TITLE
re-enable deconverting revolutionaries through blunt force trauma to the head

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -307,9 +307,9 @@ emp_act
 				if(prob(final_force))
 					if(apply_effect(20, PARALYZE, armor))
 						visible_message("<span class='danger'>[src] has been knocked unconscious!</span>")
-						// if(src != user && I.damtype == BRUTE && isrev(src))
-						// 	ticker.mode.remove_revolutionary(mind)
-						// 	add_attacklogs(user, src, "de-converted from Revolutionary!")
+						if(src != user && I.damtype == BRUTE && isrev(src))
+						ticker.mode.remove_revolutionary(mind)
+						add_attacklogs(user, src, "de-converted from Revolutionary!")
 
 				if(bloody)//Apply blood
 					if(wear_mask)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -307,7 +307,7 @@ emp_act
 				if(prob(final_force))
 					if(apply_effect(20, PARALYZE, armor))
 						visible_message("<span class='danger'>[src] has been knocked unconscious!</span>")
-						if(isrevnothead() && stat != DEAD && src != user && I.damtype == BRUTE)
+						if(isrevnothead(src) && stat != DEAD && src != user && I.damtype == BRUTE)
 							var/datum/role/revolutionary/R = mind.GetRole(REV)
 							if(istype(R))
 								R.Drop()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -307,7 +307,7 @@ emp_act
 				if(prob(final_force))
 					if(apply_effect(20, PARALYZE, armor))
 						visible_message("<span class='danger'>[src] has been knocked unconscious!</span>")
-						if(mind && src != user && I.damtype == BRUTE && isrev(src))
+						if(mind && isrev(src) && stat != DEAD && src != user && I.damtype == BRUTE)
 							var/datum/role/revolutionary/R = mind.GetRole(REV)
 							if(istype(R))
 								R.Drop()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -307,7 +307,7 @@ emp_act
 				if(prob(final_force))
 					if(apply_effect(20, PARALYZE, armor))
 						visible_message("<span class='danger'>[src] has been knocked unconscious!</span>")
-						if(mind && isrev(src) && stat != DEAD && src != user && I.damtype == BRUTE)
+						if(isrevnothead() && stat != DEAD && src != user && I.damtype == BRUTE)
 							var/datum/role/revolutionary/R = mind.GetRole(REV)
 							if(istype(R))
 								R.Drop()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -307,9 +307,11 @@ emp_act
 				if(prob(final_force))
 					if(apply_effect(20, PARALYZE, armor))
 						visible_message("<span class='danger'>[src] has been knocked unconscious!</span>")
-						if(src != user && I.damtype == BRUTE && isrev(src))
-						ticker.mode.remove_revolutionary(mind)
-						add_attacklogs(user, src, "de-converted from Revolutionary!")
+						if(mind && src != user && I.damtype == BRUTE && isrev(src))
+							var/datum/role/revolutionary/R = mind.GetRole(REV)
+							if(istype(R))
+								R.Drop()
+								add_attacklogs(user, src, "de-converted from Revolutionary!")
 
 				if(bloody)//Apply blood
 					if(wear_mask)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -307,11 +307,10 @@ emp_act
 				if(prob(final_force))
 					if(apply_effect(20, PARALYZE, armor))
 						visible_message("<span class='danger'>[src] has been knocked unconscious!</span>")
-						if(isrevnothead(src) && stat != DEAD && src != user && I.damtype == BRUTE)
-							var/datum/role/revolutionary/R = mind.GetRole(REV)
-							if(istype(R))
-								R.Drop()
-								add_attacklogs(user, src, "de-converted from Revolutionary!")
+						var/datum/role/revolutionary/R = mind.GetRole(REV)
+						if(R && istype(R) && stat != DEAD && src != user && I.damtype == BRUTE)
+							R.Drop()
+							add_attacklogs(user, src, "de-converted from Revolutionary!")
 
 				if(bloody)//Apply blood
 					if(wear_mask)


### PR DESCRIPTION
## What this does
Title. Revolutonaries have a chance to be deconverted with a percent chance based upon the final force of the attack applied to them. For instance, if you get bashed in the head for 20 brute damage (after armor reductions are applied), there is a 20% chance you will be deconverted from a revolutionary. This chance 

## Why it's good
This was commented out in #16796 and was never brought back for whatever reason.
This feature allows security to more effectively deal with revolutionaries without outright killing them when the supply of implants has run dry.

P.S. - This is just me un-commenting a feature that used to exist. If you feel this implementation is flawed and could use improvement, let me know and I'll make adjustments.

EDIT:
Adjustments made:
- Revolutionaries cannot be deconverted through this method if already dead.

[balance][tweak]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Revolutionaries can once again be de-converted through blunt force trauma to the head. If dealt 20 brute damage (after armor reductions are applied), for example, there is a 20% chance of deconversion. The revolutionary must not be dead for this to work.