### PR TITLE
Grues should hopefully always force their victims to drop their items now

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -636,7 +636,6 @@
 			grue_stat_updates(TRUE)
 		else
 			to_chat(src, "<span class='warning'>That creature didn't quite satisfy your hunger...</span>")
-		E.death(1)
 		E.drop_all()
 		E.gib()
 	busy=FALSE


### PR DESCRIPTION
The code likely errored out because gib() was already calling death(1) so the mob's death was actually getting called twice when a grue would eat someone.
Thanks @nervere 

:cl:
 * bugfix: Fixed an issue where a mob's death would happen twice when eaten by a grue. This should also hopefully fix a bug where a victim's items would not always drop when being eaten by a grue.