### PR TITLE
fixes the pAI "Update Scan" medical supplement button not working.

### DIFF
--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -557,7 +557,7 @@
 					dat += "<a href='byond://?src=\ref[src];software=[SOFT_MS];sub=0'>Return to Records</a><br>"
 					subscreen = 0
 					return dat
-				dat += "<a href='byond://?src=\ref[src];software=medicalsupplement;sub=2'>Update Scan</a><br>"
+				dat += "<a href='byond://?src=\ref[src];software=[SOFT_MS];sub=2'>Update Scan</a><br>"
 				dat += healthanalyze(M, src, TRUE)
 		dat += "<br/><a href='byond://?src=\ref[src];software=[SOFT_MS];sub=0'>Return to Records</a><br>"
 	return dat


### PR DESCRIPTION
## What this does
Title. 
## Why it's good
[bugfix] [hotfix]

:cl:
 * bugfix: Fixes the update scan button on the pAI's medical supplement not working.