### PR TITLE
attack delay fixes - kick cooldown, shooting lockers/tables, throwing at lockers/tables

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -104,13 +104,11 @@
 	face_atom(A) // change direction to face what you clicked on
 
 	/* Picking items up and/or storing them/retrieving them from storage will not be affected by the attack delay. */
-	/* Requires that attack_type (indicates if bite or kick is active) is not set, and that in_throw_mode is not set. */
-	/* These restrictions are measures to ensure the attack delay bypass cannot be abused. */
+	/* Requires that in_throw_mode is not set to avoid bypassing the attack delayer using this system. */
+
 	var/ignore_attack_delay
 	if(!in_throw_mode && (isshelf(A) || istype(A, /obj/abstract/screen/storage) || (isitem(A) && !held_item)))
-		var/mob/living/carbon/human/H = src
-		if(!istype(H) || !H.attack_type) /* Allow for ignoring attack delay if the mob that passed the above check either isn't a humanoid mob, or if it is, isn't biting/kicking. */
-			ignore_attack_delay = 1
+		ignore_attack_delay = 1
 
 	if(attack_delayer.blocked() && !ignore_attack_delay) // This was next_move.  next_attack makes more sense.
 		return

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -104,9 +104,10 @@
 	face_atom(A) // change direction to face what you clicked on
 
 	/* Picking items up and/or storing them/retrieving them from storage will not be affected by the attack delay. */
-	/* Requires that attack_type (indicates if bite or kick is active) is not set. */
+	/* Requires that attack_type (indicates if bite or kick is active) is not set, and that in_throw_mode is not set. */
+	/* These restrictions are measures to ensure the attack delay bypass cannot be abused. */
 	var/ignore_attack_delay
-	if(isshelf(A) || istype(A, /obj/abstract/screen/storage) || (isitem(A) && !held_item))
+	if(!in_throw_mode && (isshelf(A) || istype(A, /obj/abstract/screen/storage) || (isitem(A) && !held_item)))
 		var/mob/living/carbon/human/H = src
 		if(!istype(H) || !H.attack_type) /* Allow for ignoring attack delay if the mob that passed the above check either isn't a humanoid mob, or if it is, isn't biting/kicking. */
 			ignore_attack_delay = 1

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -108,7 +108,7 @@
 	var/ignore_attack_delay
 	if(isshelf(A) || istype(A, /obj/abstract/screen/storage) || (isitem(A) && !held_item))
 		var/mob/living/carbon/human/H = src
-		if(!istype(H) || !H.attack_type)
+		if(!istype(H) || !H.attack_type) /* Allow for ignoring attack delay if the mob that passed the above check either isn't a humanoid mob, or if it is, isn't biting/kicking. */
 			ignore_attack_delay = 1
 
 	if(attack_delayer.blocked() && !ignore_attack_delay) // This was next_move.  next_attack makes more sense.

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -102,12 +102,16 @@
 		return
 
 	face_atom(A) // change direction to face what you clicked on
-	
-	var/storage
-	if(isshelf(A) || istype(A, /obj/abstract/screen/storage) || (isitem(A) && !get_active_hand())) // Picking items up and/or storing them/retrieving them from storage will not be affected by the attack delay.
-		storage = 1
-	
-	if(attack_delayer.blocked() && !storage) // This was next_move.  next_attack makes more sense.
+
+	/* Picking items up and/or storing them/retrieving them from storage will not be affected by the attack delay. */
+	/* Requires that attack_type (indicates if bite or kick is active) is not set. */
+	var/ignore_attack_delay
+	if(isshelf(A) || istype(A, /obj/abstract/screen/storage) || (isitem(A) && !held_item))
+		var/mob/living/carbon/human/H = src
+		if(!istype(H) || !H.attack_type)
+			ignore_attack_delay = 1
+
+	if(attack_delayer.blocked() && !ignore_attack_delay) // This was next_move.  next_attack makes more sense.
 		return
 //	to_chat(world, "next_attack is [next_attack] and world.time is [world.time]")
 	if(istype(loc,/obj/mecha))
@@ -192,9 +196,10 @@
 			RangedClickOn(A, params, held_item)
 
 /mob/proc/RangedClickOn(atom/A, params, obj/item/held_item)
+	if(attack_delayer.blocked())
+		return
 	if(held_item)
-		if(ismob(A))
-			delayNextAttack(held_item.attack_delay)
+		delayNextAttack(held_item.attack_delay)
 
 		if(!held_item.preattack(A, src, 0,  params))
 			held_item.afterattack(A,src,0,params) // 0: not Adjacent

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -105,7 +105,6 @@
 
 	/* Picking items up and/or storing them/retrieving them from storage will not be affected by the attack delay. */
 	/* Requires that in_throw_mode is not set to avoid bypassing the attack delayer using this system. */
-
 	var/ignore_attack_delay
 	if(!in_throw_mode && (isshelf(A) || istype(A, /obj/abstract/screen/storage) || (isitem(A) && !held_item)))
 		ignore_attack_delay = 1

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -33,8 +33,6 @@
 			O.material_type.on_use(O, src, null)
 
 /mob/living/carbon/human/proc/handleSpecialAttack(var/atom/A)
-	if(attack_delayer.blocked())
-		return
 	var/special_attack_result = SPECIAL_ATTACK_SUCCESS
 	switch(attack_type) //Special attacks - kicks, bites
 		if(ATTACK_KICK)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -33,6 +33,8 @@
 			O.material_type.on_use(O, src, null)
 
 /mob/living/carbon/human/proc/handleSpecialAttack(var/atom/A)
+	if(attack_delayer.blocked())
+		return
 	var/special_attack_result = SPECIAL_ATTACK_SUCCESS
 	switch(attack_type) //Special attacks - kicks, bites
 		if(ATTACK_KICK)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -34,7 +34,7 @@
 
 /mob/living/carbon/human/proc/handleSpecialAttack(var/atom/A)
 	if(attack_delayer.blocked())
-		return TRUE /* We don't want a failed bite/kick to turn into something else, like picking up an item. */
+		return FALSE
 	var/special_attack_result = SPECIAL_ATTACK_SUCCESS
 	switch(attack_type) //Special attacks - kicks, bites
 		if(ATTACK_KICK)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -33,6 +33,8 @@
 			O.material_type.on_use(O, src, null)
 
 /mob/living/carbon/human/proc/handleSpecialAttack(var/atom/A)
+	if(attack_delayer.blocked())
+		return FALSE
 	var/special_attack_result = SPECIAL_ATTACK_SUCCESS
 	switch(attack_type) //Special attacks - kicks, bites
 		if(ATTACK_KICK)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -34,7 +34,7 @@
 
 /mob/living/carbon/human/proc/handleSpecialAttack(var/atom/A)
 	if(attack_delayer.blocked())
-		return FALSE
+		return TRUE /* We don't want a failed bite/kick to turn into something else, like picking up an item. */
 	var/special_attack_result = SPECIAL_ATTACK_SUCCESS
 	switch(attack_type) //Special attacks - kicks, bites
 		if(ATTACK_KICK)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -209,7 +209,8 @@
 		share_contact_diseases(M,block,bleeding)
 
 /mob/living/carbon/human/attack_hand(var/mob/living/carbon/human/M)
-	//M.delayNextAttack(10)
+	if(attack_delayer.blocked())
+		return
 	if (istype(loc, /turf) && istype(loc.loc, /area/start))
 		to_chat(M, "No attacking people at spawn, you jackass.")
 		return

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -209,8 +209,6 @@
 		share_contact_diseases(M,block,bleeding)
 
 /mob/living/carbon/human/attack_hand(var/mob/living/carbon/human/M)
-	if(attack_delayer.blocked())
-		return
 	if (istype(loc, /turf) && istype(loc.loc, /area/start))
 		to_chat(M, "No attacking people at spawn, you jackass.")
 		return


### PR DESCRIPTION

## What this does
Fixes oversights in #36050 with a better implementation
- Can no longer kick without cooldown 
- Shooting lockers/crates is no longer without cooldown
- Throwing at lockers/crates is no longer without cooldown

This isn't ready for a merge yet, current commit is me trying to make something more efficient and in the process I broke some important stuff.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed kicks, ranged attacks against lockers/tables, and throws at lockers/tables being without cooldown.
