### PR TITLE
Changes wallets to not fit screwdrivers.

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -27,7 +27,6 @@
 		"/obj/item/weapon/pen",
 		"/obj/item/weapon/photo",
 		"/obj/item/weapon/reagent_containers/dropper",
-		"/obj/item/tool/screwdriver",
 		"/obj/item/blueprints/construction_permit",
 		"/obj/item/weapon/stamp")
 	slot_flags = SLOT_ID|SLOT_BELT


### PR DESCRIPTION

<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Removes screwdrivers from wallets because it's annoying that they go into wallets over your belt and I dont have a better solution and them fitting in there hardly matters anymore since everyone has a swiss army knife anyways if they want a screwdriver.
closes #34762 and #34406

## Why it's good
<!-- Explain why you think these changes are good. -->
Because lowers issue count and it makes wearing a toolbelt with wallet not awful.
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Screwdrivers no longer fit in wallets to prevent them from quick-equipping inside them over belts.
