### PR TITLE
Humans being gibbed will now drop all items by default

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -21,6 +21,7 @@
 		gib_radius = 6 //Your insides are all lubed, so gibs travel much further
 
 	anim(target = src, a_icon = 'icons/mob/mob.dmi', flick_anim = "gibbed-h", sleeptime = 15)
+	drop_all()
 	hgibs(loc, virus2, dna, species.flesh_color, species.blood_color, gib_radius)
 	spawn()
 		qdel(src)


### PR DESCRIPTION
Because it sucks when all items are lost.
It should have a minimal amount of unforeseen consequences, namely anything that would interact with the items being dropped, such as singularities.
If someone is affected by a devastation-range explosion it will still cause items to disappear.

:cl:
 * rscadd: Being gibbed will now always drop any items that were carried regardless of what caused the gibbing to happen.