### PR TITLE
A human's head will now always drop when they are gibbed

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -10,8 +10,8 @@
 	for(var/datum/organ/external/E in src.organs)
 		if(istype(E, /datum/organ/external/chest) || istype(E, /datum/organ/external/groin)) //Really bad stuff happens when either get removed
 			continue
-		//Only make the limb drop if it's not too damaged
-		if(prob(100 - E.get_damage()))
+		//Only make the limb drop if it's not too damaged, or if it's the head
+		if(prob(100 - E.get_damage()) || istype(E, /datum/organ/external/head))
 			//Override the current limb status and don't cause an explosion
 			E.droplimb(1, 1)
 	for(var/datum/organ/external/cosmetic_organ in cosmetic_organs)


### PR DESCRIPTION
Pissed that you got removed from the round with no way to come back because of it? This is why!
Heads will still have a random chance to be blown up during explosions though, but that's because it depends on where it lands.
Thanks to @hacker-on-steroids for finding the issue!

:cl:
 * tweak: A human's head will now always drop if the human is gibbed.