### PR TITLE
Cargo Shuttle Scrubbing

### DIFF
--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -124,7 +124,7 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 
 		if(!destination)
 			message_admins("WARNING: Cargo shuttle unable to find the station!")
-			warning("Cargo shuttle can't find centcomm")
+			warning("Cargo shuttle can't find station")
 	else //at station
 		for(var/obj/structure/shuttle/engine/propulsion/P in cargo_shuttle.linked_area)
 			spawn()
@@ -168,6 +168,12 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 	for(var/datum/centcomm_order/O in deferred_orders)
 		if(O.CheckShuttleObject(A,in_crate,preserve))
 			return
+
+/datum/subsystem/supply_shuttle/proc/scrub()
+	for (var/obj/effect/decal/cleanable/C in cargo_shuttle.linked_area)
+		qdel(C)
+	for (var/obj/effect/rune/R in cargo_shuttle.linked_area)
+		qdel(R)
 
 /datum/subsystem/supply_shuttle/proc/sell()
 

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -412,6 +412,7 @@ For vending packs, see vending_packs.dm*/
 
 			SSsupply_shuttle.moving = -1
 			SSsupply_shuttle.sell()
+			SSsupply_shuttle.scrub()
 			SSsupply_shuttle.send()
 		else
 			SSsupply_shuttle.moving = 1


### PR DESCRIPTION
Fixes #36183

:cl:
* bugfix: The Cargo Shuttle now receives thorough sanitation upon its arrival at Centcomm. Any impurities detected such as oil or blood residue gets erased from existence as the shuttle passes through Centcomm's emancipation grill.