### PR TITLE
tail attach retractor step only works on non-opened groins

### DIFF
--- a/code/modules/surgery/tail.dm
+++ b/code/modules/surgery/tail.dm
@@ -90,6 +90,13 @@
 		)
 	duration = 8 SECONDS
 
+/datum/surgery_step/tail/prepare_attach/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	..()
+	var/datum/organ/external/groin/groin = target.get_organ(LIMB_GROIN)
+	if(!(groin.open == 0))
+		return FALSE
+	return TRUE
+
 /datum/surgery_step/tail/prepare_attach/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/datum/organ/external/affected = target.get_cosmetic_organ(COSMETIC_ORGAN_TAIL)
 	user.visible_message("[user] is beginning to reposition flesh and nerve endings where [target]'s [affected.display_name] used to be with [tool].", \

--- a/code/modules/surgery/tail.dm
+++ b/code/modules/surgery/tail.dm
@@ -55,7 +55,8 @@
 	priority = 2
 
 /datum/surgery_step/tail/amputate/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	..()
+	if(!..())
+		return FALSE
 	var/datum/organ/external/tail/tail = target.get_cosmetic_organ(COSMETIC_ORGAN_TAIL)
 	if(!(tail.open == 1))
 		return FALSE
@@ -91,7 +92,8 @@
 	duration = 8 SECONDS
 
 /datum/surgery_step/tail/prepare_attach/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	..()
+	if(!..())
+		return FALSE
 	var/datum/organ/external/groin/groin = target.get_organ(LIMB_GROIN)
 	if(!(groin.open == 0))
 		return FALSE
@@ -125,7 +127,8 @@
 	tail_present = FALSE
 
 /datum/surgery_step/tail/attach/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	..()
+	if(!..())
+		return FALSE
 	var/datum/organ/external/tail/tail = target.get_cosmetic_organ(COSMETIC_ORGAN_TAIL)
 	if(!(tail.status & ORGAN_ATTACHABLE))
 		return FALSE


### PR DESCRIPTION
Fixes https://github.com/vgstation-coders/vgstation13/issues/36188

if you don't open groin via scalpel/retractor, and use a retractor, it will prepare tail attachment
if you have opened groin already (in preparation for kidney, gender surgery etc) it will ignore tail steps

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Tail attachment surgery retractor step only works on non-opened groins, no longer interferes with kidney/gender surgeries
