### PR TITLE
Wall peeping fixes

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -167,12 +167,17 @@
 			return
 
 	if(bullet_marks)
-		peeper = user
-		peeper.reset_view(src)
-		peeper.visible_message("<span class='notice'>[peeper] leans in and looks through \the [src].</span>", \
-		"<span class='notice'>You lean in and look through \the [src].</span>")
-		register_event(/event/moved, peeper, /turf/simulated/wall/proc/reset_view)
-		src.add_fingerprint(peeper)
+		if(!peeper)
+			peeper = user
+			peeper.reset_view(src)
+			peeper.visible_message("<span class='notice'>[peeper] leans in and looks through \the [src].</span>", \
+			"<span class='notice'>You lean in and look through \the [src].</span>")
+			peeper.register_event(/event/moved, src, nameof(src::reset_view()))
+		else if(peeper == user)
+			reset_view()
+		else
+			to_chat(user,"<span class='warning'>Someone is already looking through \the [src], wait your turn.</span>")
+		src.add_fingerprint(user)
 		return ..()
 
 	user.visible_message("<span class='notice'>[user] pushes \the [src].</span>", \
@@ -184,7 +189,9 @@
 /turf/simulated/wall/proc/reset_view(atom/movable/mover)
 	if(peeper)
 		peeper.reset_view()
-		unregister_event(/event/moved, peeper, /turf/simulated/wall/proc/reset_view)
+		peeper.visible_message("<span class='notice'>[peeper] stops looking through \the [src].</span>", \
+		"<span class='notice'>You stop looking through \the [src].</span>")
+		peeper.unregister_event(/event/moved, src, nameof(src::reset_view()))
 		peeper = null
 
 /turf/simulated/wall/proc/attack_rotting(mob/user as mob)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -186,9 +186,11 @@
 	src.add_fingerprint(user)
 	return ..()
 
-/turf/simulated/wall/proc/reset_view(atom/movable/mover)
+/turf/simulated/wall/proc/reset_view(atom/movable/mover, var/adjacency_check = TRUE)
 	var/list/mob/living/mobs2reset
 	if(isliving(mover) && (mover in peepers))
+		if(adjacency_check && Adjacent(mover))
+			return
 		mobs2reset = list(mover)
 	else if(!mover)
 		mobs2reset = peepers.Copy()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -185,6 +185,7 @@
 	if(peeper)
 		peeper.reset_view()
 		unregister_event(/event/moved, peeper, /turf/simulated/wall/proc/reset_view)
+		peeper = null
 
 /turf/simulated/wall/proc/attack_rotting(mob/user as mob)
 	if(istype(src, /turf/simulated/wall/r_wall)) //I wish I didn't have to do typechecks

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -168,7 +168,7 @@
 
 	if(bullet_marks)
 		if(user in peepers)
-			reset_view(user)
+			reset_view(user, FALSE)
 		else
 			if(!peepers)
 				peepers = list()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -168,10 +168,10 @@
 
 	if(bullet_marks)
 		peeper = user
-		peeper.client.perspective = EYE_PERSPECTIVE
-		peeper.client.eye = src
+		peeper.reset_view(src)
 		peeper.visible_message("<span class='notice'>[peeper] leans in and looks through \the [src].</span>", \
 		"<span class='notice'>You lean in and look through \the [src].</span>")
+		register_event(/event/moved, peeper, /turf/simulated/wall/proc/reset_view)
 		src.add_fingerprint(peeper)
 		return ..()
 
@@ -181,11 +181,10 @@
 	src.add_fingerprint(user)
 	return ..()
 
-/turf/simulated/wall/proc/reset_view()
-	if(!peeper)
-		return
-	peeper.client.eye = peeper.client.mob
-	peeper.client.perspective = MOB_PERSPECTIVE
+/turf/simulated/wall/proc/reset_view(atom/movable/mover)
+	if(peeper)
+		peeper.reset_view()
+		unregister_event(/event/moved, peeper, /turf/simulated/wall/proc/reset_view)
 
 /turf/simulated/wall/proc/attack_rotting(mob/user as mob)
 	if(istype(src, /turf/simulated/wall/r_wall)) //I wish I didn't have to do typechecks

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -749,13 +749,6 @@ Thanks.
 	if(T != loc)
 		handle_hookchain(Dir)
 
-	if(client && client.eye && istype(client.eye,/turf/simulated/wall))
-		var/turf/simulated/wall/W = client.eye
-		if (!Adjacent(W))
-			client.eye = src
-			client.perspective = MOB_PERSPECTIVE
-			W.peeper = null
-
 	if(.)
 		for(var/obj/item/weapon/gun/G in targeted_by) //Handle moving out of the gunner's view.
 			var/mob/living/M = G.loc

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -907,7 +907,7 @@ Use this proc preferably at the end of an equipment loadout
 		//END HUMAN
 /mob/proc/reset_view(atom/A)
 	if (client)
-		if (istype(A))
+		if (A)
 			client.perspective = EYE_PERSPECTIVE
 			client.eye = A
 		else

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1839,9 +1839,13 @@ Use this proc preferably at the end of an equipment loadout
 	return FALSE
 
 /mob/proc/isTeleViewing(var/client_eye)
-	return istype(client_eye,/obj/machinery/camera) ||\
-			istype(client_eye,/obj/item/projectile/rocket/nikita) ||\
-			(istype(client_eye,/turf/simulated/wall) && Adjacent(client_eye))
+	if(istype(client_eye,/obj/machinery/camera))
+		return 1
+	if(istype(client_eye,/obj/item/projectile/rocket/nikita))
+		return 1
+	if(istype(client_eye,/turf/simulated/wall) && Adjacent(client_eye))
+		return 1
+	return 0
 
 /mob/proc/html_mob_check()
 	return 0

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -907,7 +907,7 @@ Use this proc preferably at the end of an equipment loadout
 		//END HUMAN
 /mob/proc/reset_view(atom/A)
 	if (client)
-		if (istype(A, /atom/movable))
+		if (istype(A))
 			client.perspective = EYE_PERSPECTIVE
 			client.eye = A
 		else
@@ -1839,11 +1839,9 @@ Use this proc preferably at the end of an equipment loadout
 	return FALSE
 
 /mob/proc/isTeleViewing(var/client_eye)
-	if(istype(client_eye,/obj/machinery/camera))
-		return 1
-	if(istype(client_eye,/obj/item/projectile/rocket/nikita))
-		return 1
-	return 0
+	return istype(client_eye,/obj/machinery/camera) ||\
+			istype(client_eye,/obj/item/projectile/rocket/nikita) ||\
+			(istype(client_eye,/turf/simulated/wall) && Adjacent(client_eye))
 
 /mob/proc/html_mob_check()
 	return 0


### PR DESCRIPTION
[bugfix][qol]

## What this does
[Demonstration](https://github.com/vgstation-coders/vgstation13/assets/87321915/9ed8ac23-b059-4a5a-be59-a0f745365980)
Closes #35161
makes it a bit nicer to use

## Why it's good
you wouldn't need to move away from a wall to stop looking.

## Changelog
:cl:
 * bugfix: Peeping through a hole in a wall no longer resets your view after a short moment.
 * bugfix: Walls now allow multiple users to peep through holes without issue.
 * tweak: Players can now click on the wall again to unpeep from it, instead of only being able to do it from moving away.