### PR TITLE
Pulse demons now ignore vines properly

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -322,6 +322,9 @@
 	visible_message("<span class ='warning'>The [Proj] goes right through \the [src]!</span>")
 	return
 
+/mob/living/simple_animal/hostile/pulse_demon/vine_protected()
+	return 1
+
 // Dumb moves
 /mob/living/simple_animal/hostile/pulse_demon/kick_act(mob/living/carbon/human/user)
 	if(!is_under_tile())


### PR DESCRIPTION
[bugfix]

## What this does
Closes #33065.

## Changelog
:cl:
 * bugfix: Vines no longer pull pulse demons in.