### PR TITLE
Processor conveyor actions now only check if humans are lying down

### DIFF
--- a/code/game/machinery/kitchen/processor.dm
+++ b/code/game/machinery/kitchen/processor.dm
@@ -250,9 +250,9 @@
 		if(items_transferred == 0 && !is_full())
 			return FALSE
 	else
-		if(isliving(AM))
-			var/mob/living/L = AM
-			if(!L.lying)
+		if(ishuman(AM))
+			var/mob/living/carbon/human/H = AM
+			if(!H.lying)
 				return FALSE
 		var/datum/food_processor_process/P = select_recipe(AM)
 		if (!P)


### PR DESCRIPTION
## What this does
Closes #34522.
non-player-controlled borg and capybara methods are fairly non standard and so not included

## Changelog
:cl:
 * bugfix: Only humans conveyord into a food processor are now required to lie down, as simplemobs generally do not codewise.