### PR TITLE
Makes autoharvest happen as soon as produce is ready

### DIFF
--- a/code/modules/hydroponics/hydro_tray_process.dm
+++ b/code/modules/hydroponics/hydro_tray_process.dm
@@ -87,15 +87,14 @@
 		force_update = 1
 		process()
 
-	if(harvest && seed.harvest_repeat == 2)
-		autoharvest()
-
 	// If enough time (in cycles, not ticks) has passed since the plant was harvested, we're ready to harvest again.
 	if(!dead && seed.products && seed.products.len)
 		if (age > seed.production)
 			if ((age - lastproduce) > seed.production && !harvest)
 				harvest = 1
 				lastproduce = age
+				if(seed.harvest_repeat == 2)
+					autoharvest()
 		else
 			if(harvest) //It's a baby plant ready to harvest... must have aged backwards!
 				harvest = 0

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -58,11 +58,10 @@
 	if(prob(80))
 		age++
 
-	if(harvest && (seed.harvest_repeat == 2))
-		autoharvest()
-
 	if(!harvest && prob(3) && age > mature_time + seed.production)
 		harvest = 1
+		if(seed.harvest_repeat == 2)
+			autoharvest()
 
 	update_icon()
 


### PR DESCRIPTION
[bugfix]

## What this does
Closes #33597.

## Changelog
:cl:
 * bugfix: Auto-harvest seeds now no longer need to wait a full production cycle after being harvestable to autoharvest their produce.