### PR TITLE
Transit tube station fixes

### DIFF
--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -2,7 +2,7 @@
 // Mappers: use "Generate Instances from Directions" for this
 //  one.
 /obj/structure/transit_tube/station
-	name = "station tube station"
+	name = "transit tube station"
 	icon = 'icons/obj/pipes/transit_tube_station.dmi'
 	icon_state = "closed"
 	pixel_x = 0

--- a/code/game/objects/structures/transit_tubes/transit_tube.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube.dm
@@ -110,6 +110,7 @@
 				TTF.anchored = 1
 				if(istype(TTF,/obj/structure/transit_tube_frame/station))
 					var/obj/structure/transit_tube_frame/station/TTS = TTF
+					TTS.electronics = new(TTF)
 					if(req_access && req_access.len > 0)
 						TTS.electronics.conf_access = req_access
 					else if(req_one_access && req_one_access.len > 0)


### PR DESCRIPTION
[bugfix]

## What this does
Closes #33038.
Closes #34209.
turns out it was runtiming at the non existant electronics being set before it could qdel

## Changelog
:cl:
 * bugfix: Transit tube stations now properly revert into frames instead of leaving behind a copy of itself when the glass is welded off.
 * bugfix: Welding the glass off of a transit tube station no longer leaves behind no electronics inside the frame.
 * spellcheck: Transit tube stations are no longer called "station tube stations"