### PR TITLE
Allows kinetic accelerator warp vouchers in miner belts

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -409,7 +409,8 @@
 		"/obj/item/device/wormhole_jaunter",
 		"/obj/item/weapon/lazarus_injector",
 		"/obj/item/weapon/anobattery",
-		"/obj/item/weapon/mining_drone_cube")
+		"/obj/item/weapon/mining_drone_cube",
+		"/obj/item/voucher/warp/kinetic_accelerator")
 
 /obj/item/weapon/storage/belt/lazarus
 	name = "trainer's belt"


### PR DESCRIPTION
[tweak][consistency]

## What this does
Allows the warp vouchers for these guns in the belts, as the guns themselves are allowed in it

## Why it's good
Annoying to not be able to store these here too

## Changelog
:cl:
 * tweak: Kinetic accelerator warp vouchers now fit in mining gear belts.
