### PR TITLE
[MDB IGNORE] Makes more things recyclable

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1118,6 +1118,7 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define RECYK_PLASTIC    7
 #define RECYK_FABRIC     8
 #define RECYK_WAX	     9
+#define RECYK_CARDBOARD	 10
 
 ////////////////
 // job.info_flags

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -255,6 +255,8 @@
 /obj/item/trash/liquidfood
 	name = "\improper \"LiquidFood\" ration"
 	icon_state = "liquidfood"
+	starting_materials = list(MAT_PLASTIC = 100)
+	w_type=RECYK_PLASTIC
 
 /obj/item/trash/chicken_bucket
 	name = "chicken bucket"

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -71,19 +71,19 @@
 	name = "\improper Busta-Nuts box"
 	icon_state = "busta_nut"
 	starting_materials = list(MAT_CARDBOARD = 370)
-	w_type=RECYK_MISC
+	w_type=RECYK_CARDBOARD
 
 /obj/item/trash/oldempirebar
 	name = "\improper Old Empire Bar wrapper"
 	icon_state = "old_empire_bar"
 	starting_materials = list(MAT_CARDBOARD = 370)
-	w_type=RECYK_MISC
+	w_type=RECYK_CARDBOARD
 
 /obj/item/trash/raisins
 	name = "\improper 4no raisins box"
 	icon_state= "4no_raisins"
 	starting_materials = list(MAT_CARDBOARD = 370)
-	w_type=RECYK_MISC
+	w_type=RECYK_CARDBOARD
 
 /obj/item/trash/candy
 	name = "candy wrapper"
@@ -105,7 +105,7 @@
 	name = "popcorn box"
 	icon_state = "popcorn"
 	starting_materials = list(MAT_CARDBOARD = 370)
-	w_type=RECYK_MISC
+	w_type=RECYK_CARDBOARD
 
 /obj/item/trash/popcorn/hoppers
 	name = "hoppers box"
@@ -115,17 +115,19 @@
 	name = "\improper Scaredy's Private Reserve Beef Jerky bag"
 	icon_state = "sosjerky"
 	starting_materials = list(MAT_CARDBOARD = 370)
-	w_type=RECYK_MISC
+	w_type=RECYK_CARDBOARD
 
 /obj/item/trash/syndi_cakes
 	name = "\improper Syndi cakes box"
 	icon_state = "syndi_cakes"
 	starting_materials = list(MAT_CARDBOARD = 370)
-	w_type=RECYK_MISC
+	w_type=RECYK_CARDBOARD
 
 /obj/item/trash/discountchocolate
 	name = "\improper Discount Dan's Chocolate Bar wrapper"
 	icon_state = "danbar"
+	starting_materials = list(MAT_CARDBOARD = 50)
+	w_type=RECYK_CARDBOARD
 
 /obj/item/trash/chips/donitos
 	name = "\improper Donitos bag"
@@ -193,6 +195,8 @@
 	icon_state = "pietin_assembly"
 	autoignition_temperature = 0
 	siemens_coefficient = 2
+	starting_materials = list(MAT_IRON = 100)
+	w_type = RECYK_METAL
 	melt_temperature = MELTPOINT_SILICON
 
 /obj/item/trash/wired_pietin_assembly/attackby(obj/item/W, mob/user)
@@ -215,14 +219,20 @@
 /obj/item/trash/pistachios
 	name = "pistachios pack"
 	icon_state = "pistachios_pack"
+	starting_materials = list(MAT_PLASTIC = 25, MAT_IRON = 25, MAT_CARDBOARD = 25)
+	w_type=RECYK_PLASTIC
 
 /obj/item/trash/semki
 	name = "pemki pack"
 	icon_state = "semki_pack"
+	starting_materials = list(MAT_PLASTIC = 25, MAT_IRON = 25, MAT_CARDBOARD = 25)
+	w_type=RECYK_PLASTIC
 
 /obj/item/trash/tray
 	name = "tray"
 	icon_state = "tray"
+	starting_materials = list(MAT_PLASTIC = 100)
+	w_type=RECYK_PLASTIC
 
 /obj/item/trash/candle
 	name = "candle"
@@ -251,7 +261,7 @@
 	icon_state = "kfc_bucket"
 	species_fit = list(INSECT_SHAPED, VOX_SHAPED)
 	starting_materials = list(MAT_CARDBOARD = 3750)
-	w_type=RECYK_MISC
+	w_type=RECYK_CARDBOARD
 	armor = list(melee = 1, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 	slot_flags = SLOT_HEAD
 
@@ -259,13 +269,13 @@
 	name = "fries cone"
 	icon_state = "used_cone"
 	starting_materials = list(MAT_CARDBOARD = 3750)
-	w_type=RECYK_MISC
+	w_type=RECYK_CARDBOARD
 
 /obj/item/trash/fries_punet
 	name = "fries punnet"
 	icon_state = "used_punnet"
 	starting_materials = list(MAT_CARDBOARD = 3750)
-	w_type=RECYK_MISC
+	w_type=RECYK_CARDBOARD
 
 /obj/item/trash/mannequin/cultify()
 	if(icon_state != "mannequin_cult_empty")
@@ -290,7 +300,7 @@
 	icon_state = "byond"
 	starting_materials = list(MAT_CARDBOARD = 370)
 	autoignition_temperature = AUTOIGNITION_PAPER
-	w_type=RECYK_MISC
+	w_type=RECYK_CARDBOARD
 
 var/list/crushed_cans_cache = list()
 
@@ -345,7 +355,7 @@ var/list/crushed_cans_cache = list()
 	desc = "Electronics burnt to a crisp."
 	icon_state = "slag"
 	starting_materials = list(MAT_IRON = 100)
-	w_type=RECYK_MISC
+	w_type=RECYK_METAL
 
 /obj/item/trash/used_tray
 	name = "dirty tray"
@@ -363,13 +373,13 @@ var/list/crushed_cans_cache = list()
 	name = "zam notraisins"
 	icon_state	= "zam_notraisins_rubbish"
 	starting_materials = list(MAT_CARDBOARD = 370)
-	w_type=RECYK_MISC
+	w_type=RECYK_CARDBOARD
 
 /obj/item/trash/zam_sliderwrapper
 	name = "zam slider wrapper"
 	icon_state	= "zam_spiderslider_wrapper"
 	starting_materials = list(MAT_CARDBOARD = 370)
-	w_type=RECYK_MISC
+	w_type=RECYK_CARDBOARD
 
 /obj/item/trash/egg
 	name = "egg shell"

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -153,6 +153,8 @@
 /obj/item/trash/waffles
 	name = "waffle tray"
 	icon_state = "waffles"
+	starting_materials = list(MAT_IRON = 100)
+	w_type = RECYK_METAL
 
 /obj/item/trash/pietin
 	name = "pie tin"
@@ -160,6 +162,7 @@
 	autoignition_temperature = 450 //snowflaked value low enough to catch on fire from sparks
 	siemens_coefficient = 2 //Do not touch live wires
 	starting_materials = list(MAT_IRON = 100)
+	w_type = RECYK_METAL
 	melt_temperature = MELTPOINT_SILICON //Not as high as steel
 
 /obj/item/trash/pietin/attackby(obj/item/W, mob/user)
@@ -226,6 +229,7 @@
 	icon = 'icons/obj/candle.dmi'
 	icon_state = "candle4"
 	starting_materials = list(MAT_WAX = (4*CC_PER_SHEET_WAX/5))
+	w_type=RECYK_WAX
 	var/image/wick
 
 /obj/item/trash/candle/New(turf/loc, var/obj/item/candle/source)
@@ -358,10 +362,14 @@ var/list/crushed_cans_cache = list()
 /obj/item/trash/zam_notraisins
 	name = "zam notraisins"
 	icon_state	= "zam_notraisins_rubbish"
+	starting_materials = list(MAT_CARDBOARD = 370)
+	w_type=RECYK_MISC
 
 /obj/item/trash/zam_sliderwrapper
 	name = "zam slider wrapper"
 	icon_state	= "zam_spiderslider_wrapper"
+	starting_materials = list(MAT_CARDBOARD = 370)
+	w_type=RECYK_MISC
 
 /obj/item/trash/egg
 	name = "egg shell"

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -94,7 +94,7 @@
 /obj/item/trash/chips
 	name = "chips bag"
 	icon_state = "chips"
-	starting_materials = list(MAT_PLASTIC = 50, MAT_IRON = 25, MAT_WOOD = 25) // chip bags are usually plastic, aluminum and paper
+	starting_materials = list(MAT_PLASTIC = 50, MAT_IRON = 25, MAT_CARDBOARD = 25) // chip bags are usually plastic, aluminum and paper
 	w_type=RECYK_PLASTIC
 
 /obj/item/trash/chips/cheesie
@@ -384,7 +384,7 @@ var/list/crushed_cans_cache = list()
 	name = "condiment packet"
 	desc= ""
 	icon_state	= "misc_small"
-	starting_materials = list(MAT_PLASTIC = 50, MAT_IRON = 25, MAT_WOOD = 25)
+	starting_materials = list(MAT_PLASTIC = 50, MAT_IRON = 25, MAT_CARDBOARD = 25)
 	w_type=RECYK_PLASTIC
 
 /obj/item/trash/packet/New()

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -59,6 +59,14 @@
 /obj/item/trash/attack(mob/M as mob, mob/living/user as mob)
 	return
 
+/turf/proc/trashbomb(var/range = 7, var/intensity = 1) // for testing, and maybe some other fun idea someday!
+	var/typespawn
+	var/list/types = subtypesof(/obj/item/trash)
+	for(var/turf/T in spiral_block(src, range))
+		for(var/i in 1 to intensity)
+			typespawn = pick(types)
+			new typespawn(T)
+
 /obj/item/trash/bustanuts
 	name = "\improper Busta-Nuts box"
 	icon_state = "busta_nut"
@@ -80,15 +88,18 @@
 /obj/item/trash/candy
 	name = "candy wrapper"
 	icon_state= "candy"
-
-/obj/item/trash/cheesie
-	name = "\improper Cheesie honkers bag"
-	icon_state = "cheesie_honkers"
+	starting_materials = list(MAT_PLASTIC = 50)
+	w_type=RECYK_PLASTIC
 
 /obj/item/trash/chips
 	name = "chips bag"
 	icon_state = "chips"
+	starting_materials = list(MAT_PLASTIC = 50, MAT_IRON = 25, MAT_WOOD = 25) // chip bags are usually plastic, aluminum and paper
+	w_type=RECYK_PLASTIC
 
+/obj/item/trash/chips/cheesie
+	name = "\improper Cheesie honkers bag"
+	icon_state = "cheesie_honkers"
 
 /obj/item/trash/popcorn
 	name = "popcorn box"
@@ -116,21 +127,23 @@
 	name = "\improper Discount Dan's Chocolate Bar wrapper"
 	icon_state = "danbar"
 
-/obj/item/trash/donitos
+/obj/item/trash/chips/donitos
 	name = "\improper Donitos bag"
 	icon_state = "donitos"
 
-/obj/item/trash/donitos_coolranch
+/obj/item/trash/chips/donitos_coolranch
 	name = "\improper Donitos Cool Ranch bag"
 	icon_state = "donitos_coolranch"
 
-/obj/item/trash/danitos
+/obj/item/trash/chips/danitos
 	name = "\improper Danitos bag"
 	icon_state = "danitos"
 
 /obj/item/trash/dangles
 	name = "\improper Dangles can"
 	icon_state = "dangles"
+	starting_materials = list(MAT_PLASTIC = 150, MAT_CARDBOARD = 100)
+	w_type=RECYK_PLASTIC
 	autoignition_temperature = AUTOIGNITION_PLASTIC
 	fire_fuel = 0
 
@@ -146,6 +159,7 @@
 	icon_state = "pietin"
 	autoignition_temperature = 450 //snowflaked value low enough to catch on fire from sparks
 	siemens_coefficient = 2 //Do not touch live wires
+	starting_materials = list(MAT_IRON = 100)
 	melt_temperature = MELTPOINT_SILICON //Not as high as steel
 
 /obj/item/trash/pietin/attackby(obj/item/W, mob/user)
@@ -326,13 +340,17 @@ var/list/crushed_cans_cache = list()
 	name = "slag"
 	desc = "Electronics burnt to a crisp."
 	icon_state = "slag"
+	starting_materials = list(MAT_IRON = 100)
+	w_type=RECYK_MISC
 
 /obj/item/trash/used_tray
 	name = "dirty tray"
 	icon_state	= "tray_plastic_used"
 	desc = "No nutrition left, just memories."
+	starting_materials = list(MAT_PLASTIC = 100)
+	w_type=RECYK_PLASTIC
 
-/obj/item/trash/used_tray2
+/obj/item/trash/used_tray/type2
 	name = "used tray"
 	icon_state	= "tray_plastic2_used"
 	desc = "Whoever said a tray is most useful when it is empty must not have been hungry."
@@ -354,72 +372,67 @@ var/list/crushed_cans_cache = list()
 /obj/item/trash/egg/borer
 	icon_state	= "borer egg-growing"
 
-/obj/item/trash/misc_packet
+/obj/item/trash/packet
 	name = "condiment packet"
-	desc = "A used condiment packet."
+	desc= ""
 	icon_state	= "misc_small"
+	starting_materials = list(MAT_PLASTIC = 50, MAT_IRON = 25, MAT_WOOD = 25)
+	w_type=RECYK_PLASTIC
 
-/obj/item/trash/ketchup_packet
+/obj/item/trash/packet/New()
+	. = ..()
+	if(desc == "")
+		var/thename = "\proper [name]"
+		desc = "A used [thename]."
+
+/obj/item/trash/packet/ketchup
 	name = "ketchup packet"
-	desc = "A used ketchup packet."
 	icon_state	= "ketchup_small"
 
-/obj/item/trash/ketchup_packet
-	name = "hotsauce packet"
-	desc = "A used hotsauce packet."
-	icon_state	= "hotsauce_small"
-
-/obj/item/trash/mayo_packet
+/obj/item/trash/packet/mayo
 	name = "mayonnaise packet"
-	desc = "A used mayonnaise packet."
 	icon_state	= "mayo_small"
 
-/obj/item/trash/soysauce_packet
+/obj/item/trash/packet/soysauce
 	name = "soy sauce packet"
-	desc = "A used soy sauce packet."
 	icon_state	= "soysauce_small"
 
-/obj/item/trash/vinegar_packet
+/obj/item/trash/packet/vinegar
 	name = "malt vinegar packet"
-	desc = "A used vinegar packet."
 	icon_state	= "vinegar_small"
 
-/obj/item/trash/hotsauce_packet
+/obj/item/trash/packet/hotsauce
 	name = "hotsauce packet"
-	desc = "A used hotsauce packet."
 	icon_state	= "hotsauce_small"
 
-/obj/item/trash/zamitos_o
+/obj/item/trash/chips/zamitos_o
 	name = "Zamitos: Original Flavor"
 	desc = "Crumbs to crumbs."
 	icon_state	= "zamitos_o"
 
-/obj/item/trash/zamitos_bg
+/obj/item/trash/chips/zamitos_bg
 	name = "Zamitos: Blue Goo Flavor"
 	desc = "Someone around here is a goo eater."
 	icon_state	= "zamitos_bg"
 
-/obj/item/trash/zamitos_sj
+/obj/item/trash/chips/zamitos_sj
 	name = "Zamitos: Spicy Stok Jerky Flavor"
 	desc = "The end of a meat-flavored era."
 	icon_state	= "zamitos_sj"
 
-/obj/item/trash/zamspices_packet
+/obj/item/trash/packet/zamspices
 	name = "zam spices packet"
-	desc = "A used Zam spices packet."
 	icon_state	= "zamspices_small"
 
-/obj/item/trash/zammild_packet
+/obj/item/trash/packet/zammild
 	name = "zam's mild sauce packet"
-	desc = "A used Zam's mild sauce packet."
 	icon_state	= "zammild_small"
 
-/obj/item/trash/zamspicytoxin_packet
+/obj/item/trash/packet/zamspicytoxin
 	name = "zam's spicy sauce packet"
-	desc = "A used Zam's spicy sauce packet."
 	icon_state	= "zamspicytoxin_small"
 
-/obj/item/trash/discount_packet
+/obj/item/trash/packet/discount
 	name = "Discount Dan's Special Sauce"
 	desc = "Contained 40% less sauce than competing products!"
 	icon_state	= "discount_small"

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -671,6 +671,8 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	icon = 'icons/obj/clothing/masks.dmi'
 	icon_state = "cigbutt"
 	w_class = W_CLASS_TINY
+	starting_materials = list(MAT_CARDBOARD = 50)
+	w_type = RECYK_MISC
 	throwforce = 1
 	autoignition_temperature = 0 //The filter doesn't burn
 
@@ -686,6 +688,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	desc = "Leftovers of a fancy smoke."
 	icon = 'icons/obj/clothing/masks.dmi'
 	icon_state = "goldencarpbutt"
+	starting_materials = list(MAT_CARDBOARD = 49, MAT_GOLD = 1)
 
 /obj/item/trash/cigbutt/starlightbutt
 	name = "cigarette butt"

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -297,7 +297,7 @@ var/global/list/plantbag_colour_choices = list("plantbag", "green red stripe", "
 	fits_max_w_class = 3
 	max_combined_w_class = 28 //Doesn't matter what this is, so long as it's more or equal to storage_slots * plants.w_class
 	w_class = W_CLASS_MEDIUM
-	can_only_hold = list("/obj/item/weapon/reagent_containers/food/snacks","/obj/item/weapon/reagent_containers/food/drinks","/obj/item/weapon/reagent_containers/food/condiment","/obj/item/weapon/kitchen/utensil","/obj/item/trash/soda_cans")
+	can_only_hold = list("/obj/item/weapon/reagent_containers/food/snacks","/obj/item/weapon/reagent_containers/food/drinks","/obj/item/weapon/reagent_containers/food/condiment","/obj/item/weapon/kitchen/utensil","/obj/item/trash/soda_cans","/obj/item/trash/packet")
 	var/vending_update = FALSE
 
 /obj/item/weapon/storage/bag/food/New()
@@ -305,9 +305,6 @@ var/global/list/plantbag_colour_choices = list("plantbag", "green red stripe", "
 	for (var/obj/item/weapon/reagent_containers/food/snacks/F in contents)
 		if(F.trash)
 			can_only_hold |= "[F.trash]"
-	for (var/obj/item/weapon/reagent_containers/food/condiment/small/C in contents)
-		if(C.trash_type)
-			can_only_hold |= "[C.trash_type]"
 	if(vending_update)
 		for (var/obj/O in contents)
 			O.on_vending_machine_spawn()

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -297,7 +297,7 @@ var/global/list/plantbag_colour_choices = list("plantbag", "green red stripe", "
 	fits_max_w_class = 3
 	max_combined_w_class = 28 //Doesn't matter what this is, so long as it's more or equal to storage_slots * plants.w_class
 	w_class = W_CLASS_MEDIUM
-	can_only_hold = list("/obj/item/weapon/reagent_containers/food/snacks","/obj/item/weapon/reagent_containers/food/drinks","/obj/item/weapon/reagent_containers/food/condiment","/obj/item/weapon/kitchen/utensil")
+	can_only_hold = list("/obj/item/weapon/reagent_containers/food/snacks","/obj/item/weapon/reagent_containers/food/drinks","/obj/item/weapon/reagent_containers/food/condiment","/obj/item/weapon/kitchen/utensil","/obj/item/trash/soda_cans")
 	var/vending_update = FALSE
 
 /obj/item/weapon/storage/bag/food/New()

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -297,7 +297,22 @@ var/global/list/plantbag_colour_choices = list("plantbag", "green red stripe", "
 	fits_max_w_class = 3
 	max_combined_w_class = 28 //Doesn't matter what this is, so long as it's more or equal to storage_slots * plants.w_class
 	w_class = W_CLASS_MEDIUM
-	can_only_hold = list("/obj/item/weapon/reagent_containers/food/snacks","/obj/item/weapon/reagent_containers/food/drinks","/obj/item/weapon/reagent_containers/food/condiment","/obj/item/weapon/kitchen/utensil","/obj/item/trash/packet")
+	can_only_hold = list("/obj/item/weapon/reagent_containers/food/snacks","/obj/item/weapon/reagent_containers/food/drinks","/obj/item/weapon/reagent_containers/food/condiment","/obj/item/weapon/kitchen/utensil")
+	var/vending_update = FALSE
+
+/obj/item/weapon/storage/bag/food/New()
+	..()
+	for (var/obj/item/weapon/reagent_containers/food/snacks/F in contents)
+		if(F.trash)
+			can_only_hold |= "[F.trash]"
+	for (var/obj/item/weapon/reagent_containers/food/condiment/small/C in contents)
+		if(C.trash_type)
+			can_only_hold |= "[C.trash_type]"
+	if(vending_update)
+		for (var/obj/O in contents)
+			O.on_vending_machine_spawn()
+			O.update_icon()
+	update_icon()
 
 /obj/item/weapon/storage/bag/food/update_icon()
 	if(contents.len < 1)
@@ -307,30 +322,26 @@ var/global/list/plantbag_colour_choices = list("plantbag", "green red stripe", "
 /obj/item/weapon/storage/bag/food/return_air()//prevents hot food from getting cold while in it.
 	return
 
-/obj/item/weapon/storage/bag/food/menu1/New()
-	..()
-	new/obj/item/weapon/reagent_containers/food/snacks/monkeyburger(src)//6 nutriments
-	new/obj/item/weapon/reagent_containers/food/snacks/fries/cone(src)//4 nutriments
-	new/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cola(src)//-3 drowsy
-	new/obj/item/weapon/reagent_containers/food/condiment/small/ketchup(src)
-	new/obj/item/weapon/reagent_containers/food/condiment/small/mayo(src)
-	for (var/obj/O in contents)
-		O.on_vending_machine_spawn()
-		O.update_icon()
-	update_icon()
+/obj/item/weapon/storage/bag/food/menu1
+	items_to_spawn = list(
+		/obj/item/weapon/reagent_containers/food/snacks/monkeyburger,//6 nutriments
+		/obj/item/weapon/reagent_containers/food/snacks/fries/cone,//4 nutriments
+		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cola,//-3 drowsy
+		/obj/item/weapon/reagent_containers/food/condiment/small/ketchup,
+		/obj/item/weapon/reagent_containers/food/condiment/small/mayo
+	)
+	vending_update = TRUE
 
-/obj/item/weapon/storage/bag/food/menu2/New()
-	..()
-	new/obj/item/weapon/reagent_containers/food/snacks/bigbiteburger(src)//14 nutriments
-	new/obj/item/weapon/reagent_containers/food/snacks/cheesyfries/punnet(src)//6 nutriments
-	new/obj/item/weapon/kitchen/utensil/fork/plastic(src)
-	new/obj/item/weapon/reagent_containers/food/drinks/soda_cans/space_mountain_wind(src)//-7 drowsy, -1 sleepy
-	new/obj/item/weapon/reagent_containers/food/condiment/small/ketchup(src)
-	new/obj/item/weapon/reagent_containers/food/condiment/small/mayo(src)
-	for (var/obj/O in contents)
-		O.on_vending_machine_spawn()
-		O.update_icon()
-	update_icon()
+/obj/item/weapon/storage/bag/food/menu2
+	items_to_spawn = list(
+		/obj/item/weapon/reagent_containers/food/snacks/bigbiteburger,//14 nutriments
+		/obj/item/weapon/reagent_containers/food/snacks/cheesyfries/punnet,//6 nutriments
+		/obj/item/weapon/kitchen/utensil/fork/plastic,
+		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/space_mountain_wind,//-7 drowsy, -1 sleepy
+		/obj/item/weapon/reagent_containers/food/condiment/small/ketchup,
+		/obj/item/weapon/reagent_containers/food/condiment/small/mayo
+	)
+	vending_update = TRUE
 
 /obj/item/weapon/storage/bag/zam_food
 	icon = 'icons/obj/kitchen.dmi'
@@ -349,35 +360,35 @@ var/global/list/plantbag_colour_choices = list("plantbag", "green red stripe", "
 		icon_state = "Zam_foodbag0"
 	else icon_state = "Zam_foodbag1"
 
-/obj/item/weapon/storage/bag/zam_food/zam_menu1/New()
-	..()
-	new/obj/item/weapon/reagent_containers/food/snacks/greytvdinner1/wrapped(src)//18 nutriments
-	new/obj/item/weapon/reagent_containers/food/snacks/zamitos(src)
-	new/obj/item/weapon/kitchen/utensil/fork/teflon(src)
-	new/obj/item/weapon/reagent_containers/food/drinks/soda_cans/zam_trustytea(src)//tea you can't trust
-	new/obj/item/weapon/reagent_containers/food/condiment/small/zammild(src)
-	new/obj/item/weapon/reagent_containers/food/condiment/small/zamspicytoxin(src)
-	update_icon()
+/obj/item/weapon/storage/bag/zam_food/zam_menu1
+	items_to_spawn = list(
+		/obj/item/weapon/reagent_containers/food/snacks/greytvdinner1/wrapped,//18 nutriments
+		/obj/item/weapon/reagent_containers/food/snacks/zamitos,
+		/obj/item/weapon/kitchen/utensil/fork/teflon,
+		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/zam_trustytea,//tea you can't trust
+		/obj/item/weapon/reagent_containers/food/condiment/small/zammild,
+		/obj/item/weapon/reagent_containers/food/condiment/small/zamspicytoxin
+	)
 
-/obj/item/weapon/storage/bag/zam_food/zam_menu2/New()
-	..()
-	new/obj/item/weapon/reagent_containers/food/snacks/greytvdinner2/wrapped(src)//15 nutriments
-	new/obj/item/weapon/reagent_containers/food/snacks/zamitos(src)
-	new/obj/item/weapon/kitchen/utensil/fork/teflon(src)
-	new/obj/item/weapon/reagent_containers/food/drinks/soda_cans/zam_formicfizz(src)//yum yum melts my tum
-	new/obj/item/weapon/reagent_containers/food/condiment/small/zammild(src)
-	new/obj/item/weapon/reagent_containers/food/condiment/small/zamspicytoxin(src)
-	update_icon()
+/obj/item/weapon/storage/bag/zam_food/zam_menu2
+	items_to_spawn = list(
+		/obj/item/weapon/reagent_containers/food/snacks/greytvdinner2/wrapped,//15 nutriments
+		/obj/item/weapon/reagent_containers/food/snacks/zamitos,
+		/obj/item/weapon/kitchen/utensil/fork/teflon,
+		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/zam_formicfizz,//yum yum melts my tum
+		/obj/item/weapon/reagent_containers/food/condiment/small/zammild,
+		/obj/item/weapon/reagent_containers/food/condiment/small/zamspicytoxin
+	)
 
-/obj/item/weapon/storage/bag/zam_food/zam_menu3/New()
-	..()
-	new/obj/item/weapon/reagent_containers/food/snacks/greytvdinner3/wrapped(src)//12 nutriments
-	new/obj/item/weapon/reagent_containers/food/snacks/zamitos(src)
-	new/obj/item/weapon/kitchen/utensil/fork/teflon(src)
-	new/obj/item/weapon/reagent_containers/food/drinks/soda_cans/zam_sulphuricsplash(src)
-	new/obj/item/weapon/reagent_containers/food/condiment/small/zammild(src)
-	new/obj/item/weapon/reagent_containers/food/condiment/small/zamspicytoxin(src)
-	update_icon()
+/obj/item/weapon/storage/bag/zam_food/zam_menu3
+	items_to_spawn = list(
+		/obj/item/weapon/reagent_containers/food/snacks/greytvdinner3/wrapped,//12 nutriments
+		/obj/item/weapon/reagent_containers/food/snacks/zamitos,
+		/obj/item/weapon/kitchen/utensil/fork/teflon,
+		/obj/item/weapon/reagent_containers/food/drinks/soda_cans/zam_sulphuricsplash,
+		/obj/item/weapon/reagent_containers/food/condiment/small/zammild,
+		/obj/item/weapon/reagent_containers/food/condiment/small/zamspicytoxin
+	)
 
 // -----------------------------
 //          Borg Food bag

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -297,7 +297,7 @@ var/global/list/plantbag_colour_choices = list("plantbag", "green red stripe", "
 	fits_max_w_class = 3
 	max_combined_w_class = 28 //Doesn't matter what this is, so long as it's more or equal to storage_slots * plants.w_class
 	w_class = W_CLASS_MEDIUM
-	can_only_hold = list("/obj/item/weapon/reagent_containers/food/snacks","/obj/item/weapon/reagent_containers/food/drinks","/obj/item/weapon/reagent_containers/food/condiment","/obj/item/weapon/kitchen/utensil")
+	can_only_hold = list("/obj/item/weapon/reagent_containers/food/snacks","/obj/item/weapon/reagent_containers/food/drinks","/obj/item/weapon/reagent_containers/food/condiment","/obj/item/weapon/kitchen/utensil","/obj/item/trash/packet")
 
 /obj/item/weapon/storage/bag/food/update_icon()
 	if(contents.len < 1)

--- a/code/modules/maps/spawners/spawners.dm
+++ b/code/modules/maps/spawners/spawners.dm
@@ -494,7 +494,7 @@
 		/obj/item/clothing/mask/facehugger/toy,
 		/obj/item/trash/candle,
 		/obj/item/trash/candy,
-		/obj/item/trash/cheesie,
+		/obj/item/trash/chips/cheesie,
 		/obj/item/trash/chips,
 		/obj/item/trash/plate,
 		/obj/item/trash/popcorn,

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -702,10 +702,8 @@
 
 /obj/item/weapon/lazarus_injector/update_icon()
 	..()
-	if(loaded)
-		icon_state = "lazarus_hypo"
-	else
-		icon_state = "lazarus_empty"
+	icon_state = loaded ? "lazarus_hypo" : "lazarus_empty"
+	w_type = loaded ? RECYK_ELECTRONIC : RECYK_METAL
 
 /obj/item/weapon/lazarus_injector/afterattack(atom/target, mob/user, proximity_flag)
 	if(!loaded)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -695,6 +695,8 @@
 	w_class = W_CLASS_SMALL
 	throw_speed = 3
 	throw_range = 5
+	starting_materials = list(MAT_IRON = 200)
+	w_type = RECYK_ELECTRONIC
 	var/loaded = 1
 	var/refreshes_drops = FALSE
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -12,6 +12,7 @@
 	item_state = "paper"
 	throwforce = 0
 	w_class = W_CLASS_TINY
+	starting_materials = list(MAT_CARDBOARD = 40)
 	w_type = RECYK_WOOD
 	throw_range = 1
 	throw_speed = 1

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -694,7 +694,7 @@
 	icon_state = "packet_"
 	possible_transfer_amounts = list(1, 5)
 	amount_per_transfer_from_this = 1
-	var/trash_type = /obj/item/trash/misc_packet
+	var/trash_type = /obj/item/trash/packet
 	var/custom = FALSE
 
 /obj/item/weapon/reagent_containers/food/condiment/small/afterattack(obj/target, mob/user , flag, params)
@@ -784,7 +784,7 @@
 	name = "ketchup packet"
 	desc = "You feel more American already."
 	condiment_overlay = KETCHUP
-	trash_type = /obj/item/trash/ketchup_packet
+	trash_type = /obj/item/trash/packet/ketchup
 
 /obj/item/weapon/reagent_containers/food/condiment/small/ketchup/New()
 	..()
@@ -794,7 +794,7 @@
 	name = "mayonnaise packet"
 	desc = "Still not an instrument."
 	condiment_overlay = MAYO
-	trash_type = /obj/item/trash/mayo_packet
+	trash_type = /obj/item/trash/packet/mayo
 
 /obj/item/weapon/reagent_containers/food/condiment/small/mayo/New()
 	..()
@@ -804,7 +804,7 @@
 	name = "soy sauce packet"
 	desc = "Tasty soy sauce in a convenient tiny packet."
 	condiment_overlay = SOYSAUCE
-	trash_type = /obj/item/trash/soysauce_packet
+	trash_type = /obj/item/trash/packet/soysauce
 
 /obj/item/weapon/reagent_containers/food/condiment/small/soysauce/New()
 	..()
@@ -814,7 +814,7 @@
 	name = "malt vinegar packet"
 	desc = "Perfect for smaller portions of fish and chips."
 	condiment_overlay = VINEGAR
-	trash_type = /obj/item/trash/vinegar_packet
+	trash_type = /obj/item/trash/packet/vinegar
 
 /obj/item/weapon/reagent_containers/food/condiment/small/vinegar/New()
 	..()
@@ -824,7 +824,7 @@
 	name = "hotsauce packet"
 	desc = "For those who can't handle the real heat."
 	condiment_overlay = "hotsauce"
-	trash_type = /obj/item/trash/hotsauce_packet
+	trash_type = /obj/item/trash/packet/hotsauce
 
 /obj/item/weapon/reagent_containers/food/condiment/small/hotsauce/New()
 	..()
@@ -834,7 +834,7 @@
 	name = "Zam Spices Packet"
 	desc = "A tiny packet of mothership spices."
 	condiment_overlay = ZAMSPICES
-	trash_type = /obj/item/trash/zamspices_packet
+	trash_type = /obj/item/trash/packet/zamspices
 
 /obj/item/weapon/reagent_containers/food/condiment/small/zamspices/New()
 	..()
@@ -844,7 +844,7 @@
 	name = "Zam's Mild Sauce Packet"
 	desc = "More portable than the bottle, just as tasty."
 	condiment_overlay = ZAMMILD
-	trash_type = /obj/item/trash/zammild_packet
+	trash_type = /obj/item/trash/packet/zammild
 
 /obj/item/weapon/reagent_containers/food/condiment/small/zammild/New()
 	..()
@@ -854,7 +854,7 @@
 	name = "Zam's Spicy Sauce Packet"
 	desc = "More portable than the bottle, just as spicy."
 	condiment_overlay = ZAMSPICYTOXIN
-	trash_type = /obj/item/trash/zamspicytoxin_packet
+	trash_type = /obj/item/trash/packet/zamspicytoxin
 
 /obj/item/weapon/reagent_containers/food/condiment/small/zamspicytoxin/New()
 	..()
@@ -864,7 +864,7 @@
 	name = "Discount Dan's Special Sauce"
 	desc = "Discount Dan brings you his very own special blend of delicious ingredients in one discount sauce!"
 	condiment_overlay = DISCOUNT
-	trash_type = /obj/item/trash/discount_packet
+	trash_type = /obj/item/trash/packet/discount
 
 /obj/item/weapon/reagent_containers/food/condiment/small/discount/New()
 	..()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -2265,7 +2265,7 @@
 	name = "Cheesie Honkers"
 	icon_state = "cheesie_honkers"
 	desc = "Bite sized cheesie snacks that will honk all over your mouth."
-	trash = /obj/item/trash/cheesie
+	trash = /obj/item/trash/chips/cheesie
 	food_flags = FOOD_ANIMAL | FOOD_LACTOSE //cheese
 	filling_color = "#FFCC33"
 	base_crumb_chance = 30
@@ -2333,7 +2333,7 @@
 	name = "Donitos"
 	desc = "Ranch or cool ranch?"
 	icon_state = "donitos"
-	trash = /obj/item/trash/donitos
+	trash = /obj/item/trash/chips/donitos
 	filling_color = "#C06800"
 	base_crumb_chance = 30
 
@@ -2346,7 +2346,7 @@
 	name = "Donitos Cool Ranch"
 	desc = "Cool ranch."
 	icon_state = "donitos_coolranch"
-	trash = /obj/item/trash/donitos_coolranch
+	trash = /obj/item/trash/chips/donitos_coolranch
 
 /obj/item/weapon/reagent_containers/food/snacks/donitos/coolranch/New()
 	..()
@@ -2356,7 +2356,7 @@
 	name = "Danitos"
 	desc = "For only the most MLG hardcore robust spessmen."
 	icon_state = "danitos"
-	trash = /obj/item/trash/danitos
+	trash = /obj/item/trash/chips/danitos
 	filling_color = "#FF9933"
 	base_crumb_chance = 30
 
@@ -5291,7 +5291,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/zamitos
 	name = "Zamitos: Original Flavor"
 	desc = "An overly processed taste that reminds you of days past when you snacked on these as a small greyling."
-	trash = /obj/item/trash/zamitos_o
+	trash = /obj/item/trash/chips/zamitos_o
 	icon_state = "zamitos_original"
 	filling_color = "#F7CE7B"
 
@@ -5300,7 +5300,7 @@
 	if(prob(30))
 		name = "Zamitos: Blue Goo Flavor"
 		desc = "Not as filling as the original flavor, and the texture is strange."
-		trash = /obj/item/trash/zamitos_bg
+		trash = /obj/item/trash/chips/zamitos_bg
 		icon_state = "zamitos_bluegoo"
 		filling_color = "#5BC9DD"
 		reagents.add_reagent(NUTRIMENT, 1)
@@ -5314,7 +5314,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/zamitos_stokjerky
 	name = "Zamitos: Spicy Stok Jerky Flavor"
 	desc = "Meat-flavored crisps with three different seasonings! Almost as good as real meat."
-	trash = /obj/item/trash/zamitos_sj
+	trash = /obj/item/trash/chips/zamitos_sj
 	icon_state = "zamitos_stokjerky"
 	filling_color = "#A66626"
 
@@ -8152,7 +8152,7 @@ var/global/list/bomb_like_items = list(/obj/item/device/transfer_valve, /obj/ite
 /obj/item/weapon/reagent_containers/food/snacks/greygreens
 	name = "Grey Greens"
 	desc = "A dish beloved by greys since first contact, acidic vegetables seasoned with soy sauce."
-	trash = /obj/item/trash/used_tray2
+	trash = /obj/item/trash/used_tray/type2
 	icon_state = "greygreens"
 	base_crumb_chance = 0
 
@@ -8165,7 +8165,7 @@ var/global/list/bomb_like_items = list(/obj/item/device/transfer_valve, /obj/ite
 /obj/item/weapon/reagent_containers/food/snacks/stuffedpitcher
 	name = "Stuffed Pitcher"
 	desc = "A delicious grey alternative to a stuffed pepper. Very acidic."
-	trash = /obj/item/trash/used_tray2
+	trash = /obj/item/trash/used_tray/type2
 	icon_state = "stuffedpitcher"
 	food_flags = FOOD_ANIMAL
 	base_crumb_chance = 0
@@ -8178,7 +8178,7 @@ var/global/list/bomb_like_items = list(/obj/item/device/transfer_valve, /obj/ite
 /obj/item/weapon/reagent_containers/food/snacks/nymphsperil
 	name = "Nymph's Peril"
 	desc = "A diona nymph steamed in sulphuric acid then stuffed with fried rice. Ruthlessly delicious!"
-	trash = /obj/item/trash/used_tray2
+	trash = /obj/item/trash/used_tray/type2
 	icon_state = "yahireatsbugs"
 	food_flags = FOOD_MEAT
 	base_crumb_chance = 0

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -92,7 +92,7 @@
 	volume = 5
 	flags = FPRINT
 	starting_materials = list(MAT_PLASTIC = 200)
-	w_type = RECYK_PLASTIC
+	w_type = RECYK_ELECTRONIC
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/attack(mob/M as mob, mob/user as mob)
 	..()
@@ -101,10 +101,8 @@
 	update_icon()
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/update_icon()
-	if(reagents.total_volume > 0)
-		icon_state = "autoinjector1"
-	else
-		icon_state = "autoinjector0"
+	icon_state = "autoinjector[reagents.total_volume > 0 ? 1 : 0]"
+	w_type = reagents.total_volume > 0 ? RECYK_ELECTRONIC : RECYK_PLASTIC
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/examine(mob/user)
 	..()
@@ -122,13 +120,10 @@
 	flags = FPRINT
 	refill_reagent_list = list(BIOFOAM = 15)
 	starting_materials = list(MAT_IRON = 200)
-	w_type = RECYK_ELECTRONIC
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biofoam_injector/update_icon()
-	if(reagents.total_volume > 0)
-		icon_state = "biofoam1"
-	else
-		icon_state = "biofoam0"
+	icon_state = "biofoam[reagents.total_volume > 0 ? 1 : 0]"
+	w_type = reagents.total_volume > 0 ? RECYK_ELECTRONIC : RECYK_METAL
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/paralytic_injector
 	name = "paralytic injector"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -121,7 +121,7 @@
 	volume = 15
 	flags = FPRINT
 	refill_reagent_list = list(BIOFOAM = 15)
-	starting_materials = list(MAT_METAL = 200)
+	starting_materials = list(MAT_IRON = 200)
 	w_type = RECYK_ELECTRONIC
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biofoam_injector/update_icon()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -91,6 +91,8 @@
 	amount_per_transfer_from_this = 5
 	volume = 5
 	flags = FPRINT
+	starting_materials = list(MAT_PLASTIC = 200)
+	w_type = RECYK_PLASTIC
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/attack(mob/M as mob, mob/user as mob)
 	..()
@@ -119,6 +121,8 @@
 	volume = 15
 	flags = FPRINT
 	refill_reagent_list = list(BIOFOAM = 15)
+	starting_materials = list(MAT_METAL = 200)
+	w_type = RECYK_ELECTRONIC
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biofoam_injector/update_icon()
 	if(reagents.total_volume > 0)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -385,7 +385,7 @@
 /obj/machinery/sorting_machine/recycling
 	name = "Recycling Sorting Machine"
 
-	var/list/selected_types = list("Glasses", "Metals/Minerals", "Electronics", "Plastic", "Fabric", "Wax")
+	var/list/selected_types = list("Glasses", "Metals/Minerals", "Electronics", "Plastic", "Fabric", "Wax", "Cardboard")
 	var/list/types[9]
 
 /obj/machinery/sorting_machine/recycling/New()
@@ -409,6 +409,7 @@
 	types[RECYK_PLASTIC]    = "Plastic"
 	types[RECYK_FABRIC]     = "Fabric"
 	types[RECYK_WAX]        = "Wax"
+	types[RECYK_CARDBOARD]  = "Cardboard"
 	types[RECYK_MISC]       = "Miscellaneous"
 
 /obj/machinery/sorting_machine/recycling/process()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -386,7 +386,7 @@
 	name = "Recycling Sorting Machine"
 
 	var/list/selected_types = list("Glasses", "Metals/Minerals", "Electronics", "Plastic", "Fabric", "Wax", "Cardboard")
-	var/list/types[9]
+	var/list/types[10]
 
 /obj/machinery/sorting_machine/recycling/New()
 	. = ..()

--- a/maps/misc/voxshuttle.dmm
+++ b/maps/misc/voxshuttle.dmm
@@ -890,7 +890,7 @@
 /turf/simulated/floor/shuttle/plating/vox,
 /area/shuttle/vox/station)
 "ce" = (
-/obj/item/trash/danitos,
+/obj/item/trash/chips/danitos,
 /turf/simulated/floor/shuttle/plating/vox,
 /area/shuttle/vox/station)
 "cf" = (

--- a/maps/misc/wizardden1.dmm
+++ b/maps/misc/wizardden1.dmm
@@ -446,7 +446,7 @@
 /area/wizard_station)
 "XB" = (
 /obj/structure/table/woodentable,
-/obj/item/trash/cheesie,
+/obj/item/trash/chips/cheesie,
 /turf/unsimulated/floor{
 	dir = 8;
 	icon_state = "wood"

--- a/maps/randomvaults/ButtonPusher.dmm
+++ b/maps/randomvaults/ButtonPusher.dmm
@@ -273,7 +273,7 @@
 	},
 /area/vault/radioactivelab)
 "gA" = (
-/obj/item/trash/danitos,
+/obj/item/trash/chips/danitos,
 /obj/item/trash/oldempirebar{
 	pixel_x = -6;
 	pixel_y = 7
@@ -2251,7 +2251,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/trash/donitos_coolranch,
+/obj/item/trash/chips/donitos_coolranch,
 /turf/simulated/floor/plating,
 /area/vault/radioactivelab)
 "VZ" = (

--- a/maps/randomvaults/assistantslair.dmm
+++ b/maps/randomvaults/assistantslair.dmm
@@ -41,7 +41,7 @@
 /area/vault/assistantlair)
 "aj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/trash/danitos,
+/obj/item/trash/chips/danitos,
 /turf/simulated/floor/plating,
 /area/vault/assistantlair)
 "ak" = (
@@ -1176,7 +1176,7 @@
 /area/vault/assistantlair)
 "dM" = (
 /obj/structure/table,
-/obj/item/trash/cheesie,
+/obj/item/trash/chips/cheesie,
 /obj/item/clothing/gloves/yellow,
 /turf/simulated/floor/plating{
 	icon_state = "panelscorched"

--- a/maps/randomvaults/dungeons/habitation.dmm
+++ b/maps/randomvaults/dungeons/habitation.dmm
@@ -4760,7 +4760,7 @@
 /turf/unsimulated/floor/ayy/maint,
 /area/vault/mothership_lab/cave)
 "Qc" = (
-/obj/item/trash/zamitos_sj,
+/obj/item/trash/chips/zamitos_sj,
 /turf/unsimulated/floor/ayy/maint,
 /area/vault/mothership_lab/cave)
 "Ql" = (
@@ -5068,7 +5068,7 @@
 /turf/unsimulated/floor/ayy,
 /area/vault/mothership_lab/administration)
 "SF" = (
-/obj/item/trash/zamitos_bg,
+/obj/item/trash/chips/zamitos_bg,
 /mob/living/simple_animal/hostile/humanoid/vox/spaceraider/medic{
 	dir = 4
 	},

--- a/maps/randomvaults/fastfoodjoint.dmm
+++ b/maps/randomvaults/fastfoodjoint.dmm
@@ -295,7 +295,7 @@
 "ge" = (
 /obj/structure/table/plastic,
 /obj/item/trash/fries_cone,
-/obj/item/trash/ketchup_packet,
+/obj/item/trash/packet/ketchup,
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -2;
 	pixel_y = 4
@@ -1698,7 +1698,7 @@
 /area/vault/fastfood)
 "JZ" = (
 /obj/structure/table/plastic,
-/obj/item/trash/donitos,
+/obj/item/trash/chips/donitos,
 /obj/item/weapon/kitchen/utensil/fork,
 /obj/item/weapon/reagent_containers/food/condiment/mustard{
 	pixel_x = 5;

--- a/maps/randomvaults/podstation.dmm
+++ b/maps/randomvaults/podstation.dmm
@@ -1044,7 +1044,7 @@
 /area/vault/podstation/interior)
 "sb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/trash/mayo_packet,
+/obj/item/trash/packet/mayo,
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
@@ -1800,7 +1800,7 @@
 /area/vault/podstation/exterior)
 "NF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/trash/mayo_packet,
+/obj/item/trash/packet/mayo,
 /turf/unsimulated/floor/airless{
 	icon_state = "asteroidfloor"
 	},
@@ -1808,7 +1808,7 @@
 "NS" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/trash/chips,
-/obj/item/trash/donitos_coolranch,
+/obj/item/trash/chips/donitos_coolranch,
 /obj/item/trash/fries_punet,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/storage/fancy/cigarettes/shoalsticks,
@@ -2193,8 +2193,8 @@
 /obj/item/weapon/storage/wallet,
 /obj/item/trash/fries_cone,
 /obj/item/trash/fries_cone,
-/obj/item/trash/ketchup_packet,
-/obj/item/trash/vinegar_packet,
+/obj/item/trash/packet/ketchup,
+/obj/item/trash/packet/vinegar,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/hanging_lantern{
 	dir = 4

--- a/maps/randomvaults/snaxi/bearcave.dmm
+++ b/maps/randomvaults/snaxi/bearcave.dmm
@@ -7,7 +7,7 @@
 /turf/unsimulated/floor/snow/cave,
 /area/vault/bearcave)
 "e" = (
-/obj/item/trash/danitos,
+/obj/item/trash/chips/danitos,
 /turf/unsimulated/floor/snow/cave,
 /area/vault/bearcave)
 "g" = (


### PR DESCRIPTION
[tweak][consistency]

## What this does
Closes #35889.
Closes #35852.

## Why it's good
less useless stuff to eject into space from disposals or clog up the sorting pile

## Changelog
:cl:
 * tweak: Many many more kinds of trash, as well as paper and used autoinjectors and lazarus injectors, can now be recyclable into materials in disposals.
 * tweak: Recycling sorters now have a cardboard category, enabled by default.
 * bugfix: Discarded trash from food now fit in their delivery bags.