### PR TITLE
Appearance bans block showing flavor text in game

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2119,6 +2119,9 @@
 	// Or being a husk...
 	if(M_HUSK in mutations)
 		return FALSE
+	// Or being appearance banned...
+	if(appearance_isbanned(src))
+		return FALSE
 	// ...means no flavor text for you. Otherwise, good to go.
 	return TRUE
 


### PR DESCRIPTION
[tweak]

## What this does
Closes #23633.

## Why it's good
[consistency]

## Changelog
:cl:
 * tweak: Appearance banned players can no longer have examined flavor text. They can still edit it in their profile for after their ban, if expired.