### PR TITLE
Makes sensed explosions show up on bhangmeter database properly without holominimaps

### DIFF
--- a/code/controllers/subsystem/init/more_init_stuff.dm
+++ b/code/controllers/subsystem/init/more_init_stuff.dm
@@ -26,6 +26,7 @@ var/datum/subsystem/more_init/SSmore_init
 	create_global_parallax_icons()
 	log_debug("  Finished caching space parallax simulation in [stop_watch(watch)]s.", FALSE)
 
+	init_sensed_explosions_list()
 	if (!config.skip_minimap_generation)
 		watch=start_watch()
 		generateHoloMinimaps()
@@ -53,6 +54,10 @@ var/datum/subsystem/more_init/SSmore_init
 	centcomm_store = new
 	create_randomized_reagents()
 	log_debug("Finished doing the other misc. initializations in [stop_watch(watch)]s.", FALSE)
+
+/proc/init_sensed_explosions_list()
+	for (var/z = 1 to world.maxz)
+		sensed_explosions["z[z]"] = list()
 
 /proc/cache_machinery_components_rating()
 	var/list/cache = list()

--- a/code/game/machinery/computer/bhangmeter.dm
+++ b/code/game/machinery/computer/bhangmeter.dm
@@ -293,9 +293,8 @@ var/list/list/sensed_explosions = list()
 	cap = overcap
 
 	explosion_icon = icon('icons/480x480.dmi', "blank")
-	sensed_explosions["z[z]"] += list(src)
-	var/list/z_sensed = sensed_explosions["z[z]"]
-	ID = "[z]-[add_zero(z_sensed.len,3)]"
+	sensed_explosions["z[z]"] += src
+	ID = "[z]-[add_zero(sensed_explosions["z[z]"].len,3)]"
 
 /datum/sensed_explosion/Destroy()
 	sensed_explosions["z[z]"] -= src

--- a/code/game/machinery/computer/bhangmeter.dm
+++ b/code/game/machinery/computer/bhangmeter.dm
@@ -293,8 +293,9 @@ var/list/list/sensed_explosions = list()
 	cap = overcap
 
 	explosion_icon = icon('icons/480x480.dmi', "blank")
-	sensed_explosions["z[z]"] += src
-	ID = "[z]-[add_zero(sensed_explosions["z[z]"].len,3)]"
+	sensed_explosions["z[z]"] += list(src)
+	var/list/z_sensed = sensed_explosions["z[z]"]
+	ID = "[z]-[add_zero(z_sensed.len,3)]"
 
 /datum/sensed_explosion/Destroy()
 	sensed_explosions["z[z]"] -= src

--- a/code/modules/html_interface/map/station_map.dm
+++ b/code/modules/html_interface/map/station_map.dm
@@ -52,7 +52,6 @@
 			bhangmap_base.Blend("#FFBD00",ICON_MULTIPLY)
 			bhangcanvas.Blend(bhangmap_base,ICON_OVERLAY)
 		extraMiniMaps["[HOLOMAP_EXTRA_BHANGBASEMAP]_[z]"] = bhangcanvas
-		sensed_explosions["z[z]"] = list()
 	//----------------------------------
 
 	//Station Holomaps display the map of the Z-Level they were built on.


### PR DESCRIPTION
[bugfix][runtime]

## What this does
was runtiming at this line, so investigated and fixed it

## Changelog
:cl:
 * bugfix: Bhangmeter database entries now properly show up if holominimaps are disabled