### PR TITLE
Fixes godmode not preventing pressurised lung ruptures

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_breath.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_breath.dm
@@ -59,7 +59,7 @@
 
 				if(!breath || breath.total_moles < BREATH_MOLES / 5 || breath.total_moles > BREATH_MOLES * 5)
 					if(prob(20))
-						L.damage += 1
+						L.take_damage(1,1)
 					if(!is_lung_ruptured() && L.damage > 2)
 						var/chance_break = (L.damage / L.min_broken_damage)*100
 						if(prob(chance_break))


### PR DESCRIPTION
[bugfix][consistency]

## What this does
converts this line to the general take_damage proc, also causes some consistency with robotic lungs preventing the damage by 20%
the proc also supports making the damage silent, which i decided to enable for consistency with old behaviour. would anyone find this to be a good idea to change as to give players a warning that it's about to happen?

## Changelog
:cl:
 * bugfix: Admin test dummies and other godmode creatures no longer get ruptured lungs in a vacuum
 * tweak: Robotic lung damage prevention now also works in vaccums, decreasing damage taken by 20% like from other sources