### PR TITLE
HF machete's anti kudzu properties now also applies to powercreeper

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -416,8 +416,12 @@
 
 /obj/item/weapon/melee/energy/hfmachete/proc/mob_moved(atom/movable/mover)
 	if(iscarbon(mover) && active)
-		for(var/obj/effect/plantsegment/P in range(mover,0))
-			qdel(P)
+		for(var/obj/P in range(mover,0))
+			if(istype(P, /obj/structure/cable/powercreeper))
+				var/obj/structure/cable/powercreeper/C = P
+				C.die()
+			else if(istype(P, /obj/effect/plantsegment))
+				qdel(P)
 
 /obj/item/weapon/melee/energy/hfmachete/attackby(obj/item/weapon/W, mob/living/user)
 	..()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Makes HF machetes kudzu killing feature also work on powercreeper.
closes #24264

https://github.com/vgstation-coders/vgstation13/assets/26881007/805c6880-7741-4510-87dc-c5e2fbfb7c50


## Why it's good
<!-- Explain why you think these changes are good. -->
To me this is a bugfix, but I suppose i'll say that I think it is because powercreeper is basically electronic kudzu and I feel like anyone who knwos about the kudzu slaying power of the HF machete would expect it to work on powercreeper too.
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: HF machete now kills powercreeper by walking through it, similarly to how it already did with kudzu.
