### PR TITLE
revert "remove attack delay affecting picking up and storing/retrieving items"

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -57,11 +57,12 @@
 
 #define MAX_ITEM_DEPTH	3 //how far we can recurse before we can't get an item
 
-/mob/proc/ClickOn(var/atom/A, var/params)
+/mob/proc/ClickOn( var/atom/A, var/params )
 	if(!click_delayer)
 		click_delayer = new
 	if(timestopped)
 		return 0 //under effects of time magick
+
 	if(click_delayer.blocked())
 		return
 	click_delayer.setDelay(1)
@@ -104,12 +105,8 @@
 		return
 
 	face_atom(A) // change direction to face what you clicked on
-	
-	var/storage
-	if(isshelf(A) || istype(A, /obj/abstract/screen/storage) || (isitem(A) && !get_active_hand())) // Picking items up and/or storing them/retrieving them from storage will not be affected by the attack delay.
-		storage = 1
-	
-	if(attack_delayer.blocked() && !storage) // This was next_move.  next_attack makes more sense.
+
+	if(attack_delayer.blocked()) // This was next_move.  next_attack makes more sense.
 		return
 //	to_chat(world, "next_attack is [next_attack] and world.time is [world.time]")
 	if(istype(loc,/obj/mecha))

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -150,6 +150,8 @@
 	globalscreen = 1
 
 /obj/abstract/screen/storage/Click(location, control, params)
+	if(usr.attack_delayer.blocked())
+		return
 	if(usr.incapacitated())
 		return 1
 	if (istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech


### PR DESCRIPTION
This PR broke kicking and the attack cooldown for shooting at lockers/tables.
As much as I'd like to fix it, I just don't have the time now, and I've irresponsibly left this broken for long enough. Sorry.
This concept is definitely worth revisiting later, but a more robust solution is required.
closes #36199 
closes #36191