### PR TITLE
Renames arcade machines on emag

### DIFF
--- a/code/game/machinery/computer/arcade/arcade.dm
+++ b/code/game/machinery/computer/arcade/arcade.dm
@@ -68,6 +68,7 @@
 
 /obj/machinery/computer/arcade/emag_act(mob/user)
 	game.emag_act(user)
+	name = game.name
 
 /obj/machinery/computer/arcade/arcane_act(mob/user)
 	game.emag_act(user) // until i come up with something better, reward differs for now though

--- a/code/game/machinery/computer/arcade/arcade.dm
+++ b/code/game/machinery/computer/arcade/arcade.dm
@@ -68,7 +68,6 @@
 
 /obj/machinery/computer/arcade/emag_act(mob/user)
 	game.emag_act(user)
-	name = game.name
 
 /obj/machinery/computer/arcade/arcane_act(mob/user)
 	game.emag_act(user) // until i come up with something better, reward differs for now though

--- a/code/game/machinery/computer/arcade/arcade_game.dm
+++ b/code/game/machinery/computer/arcade/arcade_game.dm
@@ -39,6 +39,8 @@
 	return 0
 
 /datum/arcade_game/proc/emag_act(mob/user)
+	if(holder)
+		holder.name = name
 
 /datum/arcade_game/proc/emp_act(var/severity)
 
@@ -467,6 +469,7 @@
 	return 0
 
 /datum/arcade_game/space_villain/emag_act(mob/user)
+	..()
 	if(is_cheater(user))
 		return
 


### PR DESCRIPTION
[bugfix]

## What this does
Closes #19249 
not sure if the subtlety is better though

## Changelog
:cl:
 * bugfix: Arcade machines now properly update their name on emag
