### PR TITLE
Animal recycler fixes

### DIFF
--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -54,9 +54,9 @@
 	if(istype(O, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/G = O
 		target = G.affecting
-	else if(istype(O, /obj/item/weapon/holder))
+	/*else if(istype(O, /obj/item/weapon/holder))
 		var/obj/item/weapon/holder/H = O
-		target = H.stored_mob
+		target = H.stored_mob*/
 	if(istype(target))
 		if((target.key || target.ckey) && !emagged)
 			failmsg = "\the [target] is too sapient for the recycler."

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -59,9 +59,9 @@
 	if(istype(O, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/G = O
 		target = G.affecting
-	/*else if(istype(O, /obj/item/weapon/holder))
+	else if(istype(O, /obj/item/weapon/holder))
 		var/obj/item/weapon/holder/H = O
-		target = H.stored_mob*/
+		target = H.stored_mob
 	if(istype(target))
 		if((target.key || target.ckey) && !emagged)
 			failmsg = "\the [target] is too sapient for \the [src]."

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -39,7 +39,7 @@
 	minimum_animals = max(1,4 - (manipcount/2)) //Tier 1 = 3, Tier 2 = 2, Tier 3 = 1
 	if(lasercount >= 3)
 		can_recycle_live = TRUE
-		desc = "A machine used for recycling simple animals into animal cubes."
+		desc = "A machine used for recycling animals into animal cubes."
 
 /obj/machinery/monkey_recycler/attackby(var/obj/item/O, var/mob/user)
 	if(..())

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -39,6 +39,7 @@
 	minimum_animals = max(1,4 - (manipcount/2)) //Tier 1 = 3, Tier 2 = 2, Tier 3 = 1
 	if(lasercount >= 3)
 		can_recycle_live = TRUE
+		desc = "A machine used for recycling simple animals into animal cubes."
 
 /obj/machinery/monkey_recycler/attackby(var/obj/item/O, var/mob/user)
 	if(..())

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -73,7 +73,7 @@
 			if(user) // necessary line, or else the holder or grab could be spammed to abuse this for more monkey cubes
 				user.drop_item(O,force_drop = 1)
 			var/ourtype = target.type
-			if(emagged)
+			if(target.key && emagged)
 				for(var/datum/body_archive/archive in body_archives)
 					if(archive && archive.key == target.key)
 						ref_body_archives.Add(archive)
@@ -94,8 +94,6 @@
 		failmsg = "<span class='warning'>[failmsg]</span>"
 		if(user)
 			to_chat(user, failmsg)
-		else
-			visible_message(failmsg)
 	return FALSE
 
 /obj/machinery/monkey_recycler/attack_hand(var/mob/user as mob)

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -1,5 +1,5 @@
 /obj/machinery/monkey_recycler
-	name = "Animal Recycler"
+	name = "\improper Animal Recycler"
 	desc = "A machine used for recycling dead animals into animal cubes."
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "grinder"
@@ -59,11 +59,11 @@
 		target = H.stored_mob*/
 	if(istype(target))
 		if((target.key || target.ckey) && !emagged)
-			failmsg = "\the [target] is too sapient for the recycler."
+			failmsg = "\the [target] is too sapient for \the [src]."
 		else if(target.stat == CONSCIOUS && !can_recycle_live)
-			failmsg = "\the [target] is struggling far too much to put it in the recycler."
+			failmsg = "\the [target] is struggling far too much to put it in \the [src]."
 		else if(target.abiotic())
-			failmsg = "\the [target] may not have abiotic items on."
+			failmsg = "\the [target] may not have abiotic items on in \the [src]."
 		else
 			if(user) // necessary line, or else the holder or grab could be spammed to abuse this for more monkey cubes
 				user.drop_item(O,force_drop = 1)
@@ -79,12 +79,12 @@
 			use_power(500)
 			src.grinded[ourtype]++
 			if(user)
-				to_chat(user, "<span class='notice'>The machine now has [grinded[ourtype]] animals worth of material of this type stored.</span>")
+				to_chat(user, "<span class='notice'>\the [src] now has [grinded[ourtype]] animals worth of material of this type stored.</span>")
 			else
-				visible_message("<span class='notice'>The machine now has [grinded[ourtype]] animals worth of material of this type stored.</span>")
+				visible_message("<span class='notice'>\the [src] now has [grinded[ourtype]] animals worth of material of this type stored.</span>")
 			return TRUE
 	else
-		failmsg = "The machine only accepts animals!"
+		failmsg = "\the [src] only accepts animals!"
 	if(failmsg)
 		failmsg = "<span class='warning'>[failmsg]</span>"
 		if(user)

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -46,72 +46,52 @@
 	process_monkey(O, user)
 
 /obj/machinery/monkey_recycler/conveyor_act(var/atom/movable/AM, var/obj/machinery/conveyor/CB)
-	if(isliving(AM))
-		var/mob/living/target = AM
-		if(target.stat == CONSCIOUS && !can_recycle_live)
-			return FALSE
-		if((target.key || target.ckey) && !emagged)
-			return FALSE
-		if(target.abiotic())
-			return FALSE
-		else
-			var/ourtype = target.type
-			for(var/datum/body_archive/archive in body_archives)
-				if(archive.key == target.key)
-					ref_body_archives.Add(archive)
-			qdel(target)
-			playsound(src, 'sound/machines/juicer.ogg', 50, 1)
-			use_power(500)
-			src.grinded[ourtype]++
-			visible_message("<span class='notice'>The machine now has [grinded[ourtype]] worth of material stored for this animal.</span>")
-			return TRUE
-	return FALSE
+	return process_monkey(AM)
 
 /obj/machinery/monkey_recycler/proc/process_monkey(var/obj/item/O, var/mob/user)
+	var/mob/living/target = O
+	var/failmsg
 	if(istype(O, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/G = O
-		var/grabbed = G.affecting
-		if(isliving(grabbed))
-			var/mob/living/target = grabbed
-			if((target.key || target.ckey) && !emagged)
-				to_chat(user, "<span class='warning'>\the [target] is too sapient for the recycler.</span>")
-				return
-			if(target.stat == CONSCIOUS && !can_recycle_live)
-				to_chat(user, "<span class='warning'>\the [target] is struggling far too much to put it in the recycler.</span>")
-				return
-			if(target.abiotic())
-				to_chat(user, "<span class='warning'>\the [target] may not have abiotic items on.</span>")
-				return
-			else
-				user.drop_item(G, force_drop = 1)
-				var/ourtype = target.type
-				QDEL_NULL(target)
-				to_chat(user, "<span class='notice'>You stuff \the [target] in the machine.")
-				playsound(src, 'sound/machines/juicer.ogg', 50, 1)
-				use_power(500)
-				src.grinded[ourtype]++
-				to_chat(user, "<span class='notice'>The machine now has [grinded[ourtype]] animals worth of material of this type stored.</span>")
-		else
-			to_chat(user, "<span class='warning'>The machine only accepts animals!</span>")
-	else if(isliving(O))
-		var/mob/living/target = O
+		target = G.affecting
+	else if(istype(O, /obj/item/weapon/holder))
+		var/obj/item/weapon/holder/H = O
+		target = H.stored_mob
+	if(istype(target))
 		if((target.key || target.ckey) && !emagged)
-			to_chat(user, "<span class='warning'>\the [target] is too sapient for the recycler.</span>")
-			return
-		if(target.stat == CONSCIOUS && !can_recycle_live)
-			to_chat(user, "<span class='warning'>\the [target] is struggling far too much to put it in the recycler.</span>")
-			return
-		if(target.abiotic())
-			to_chat(user, "<span class='warning'>\the [target] may not have abiotic items on.</span>")
-			return
+			failmsg = "\the [target] is too sapient for the recycler."
+		else if(target.stat == CONSCIOUS && !can_recycle_live)
+			failmsg = "\the [target] is struggling far too much to put it in the recycler."
+		else if(target.abiotic())
+			failmsg = "\the [target] may not have abiotic items on."
 		else
+			if(user) // necessary line, or else the holder or grab could be spammed to abuse this for more monkey cubes
+				user.drop_item(O,force_drop = 1)
 			var/ourtype = target.type
-			QDEL_NULL(target)
-			to_chat(user, "<span class='notice'>You stuff \the [target] in the machine.</span>")
+			if(emagged)
+				for(var/datum/body_archive/archive in body_archives)
+					if(archive && archive.key == target.key)
+						ref_body_archives.Add(archive)
+			qdel(target)
+			if(user)
+				to_chat(user, "<span class='notice'>You stuff \the [target] in the machine.</span>")
 			playsound(src, 'sound/machines/juicer.ogg', 50, 1)
 			use_power(500)
 			src.grinded[ourtype]++
-			to_chat(user, "<span class='notice'>The machine now has [grinded[ourtype]] animals worth of material of this type stored.</span>")
+			if(user)
+				to_chat(user, "<span class='notice'>The machine now has [grinded[ourtype]] animals worth of material of this type stored.</span>")
+			else
+				visible_message("<span class='notice'>The machine now has [grinded[ourtype]] animals worth of material of this type stored.</span>")
+			return TRUE
+	else
+		failmsg = "The machine only accepts animals!"
+	if(failmsg)
+		failmsg = "<span class='warning'>[failmsg]</span>"
+		if(user)
+			to_chat(user, failmsg)
+		else
+			visible_message(failmsg)
+	return FALSE
 
 /obj/machinery/monkey_recycler/attack_hand(var/mob/user as mob)
 	if(..())
@@ -129,19 +109,19 @@
 		var/obj/item/weapon/reagent_containers/food/snacks/monkeycube/wrapped/MW = new(src.loc)
 		if(ref_body_archives.len)
 			for(var/datum/body_archive/BA in ref_body_archives)
-				if(BA.mob_type == pickedtype)
+				if(BA && BA.mob_type == pickedtype)
 					var/mob/living/temp_M = new pickedtype
 					var/mob/living/M = temp_M.actually_reset_body(archive = BA, our_mind = get_mind_by_key(BA.key))
 					M.forceMove(MW)
 					MW.contained_mob = M
-					MW.name = "[MW] cube"
+					MW.name = "[M] cube"
 					ref_body_archives.Remove(BA)
 					qdel(temp_M)
 					break
 		else
-			var/mob/living/MW_mob = new pickedtype(MW)
-			MW.contained_mob = MW_mob
-			MW.name = "[MW_mob] cube"
+			var/mob/living/MW_mob = pickedtype
+			MW.contained_mob = pickedtype
+			MW.name = "[initial(MW_mob.name)] cube"
 		to_chat(user, "<span class='notice'>The machine's display flashes that it has [grinded[pickedtype]] animals worth of material of this type left.</span>")
 	else
 		to_chat(user, "<span class='warning'>The machine needs at least [minimum_animals] same type animal\s worth of material to produce an animal cube.</span>")

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -49,6 +49,10 @@
 /obj/machinery/monkey_recycler/conveyor_act(var/atom/movable/AM, var/obj/machinery/conveyor/CB)
 	return process_monkey(AM)
 
+/obj/machinery/monkey_recycler/emag_act(mob/user)
+	. = ..()
+	emagged = 1
+
 /obj/machinery/monkey_recycler/proc/process_monkey(var/obj/item/O, var/mob/user)
 	var/mob/living/target = O
 	var/failmsg
@@ -63,7 +67,7 @@
 			failmsg = "\the [target] is too sapient for \the [src]."
 		else if(target.stat == CONSCIOUS && !can_recycle_live)
 			failmsg = "\the [target] is struggling far too much to put it in \the [src]."
-		else if(target.abiotic())
+		else if(target.abiotic(1))
 			failmsg = "\the [target] may not have abiotic items on in \the [src]."
 		else
 			if(user) // necessary line, or else the holder or grab could be spammed to abuse this for more monkey cubes

--- a/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gym_rats.dm
@@ -88,7 +88,7 @@
 				to_chat(src, text("<span class='warning'>You find something!</span>"))
 				new /obj/item/weapon/reagent_containers/food/snacks/meat/scraps(src.loc)
 
-	if(is_type_in_list(A, edibles)) // If we click on something edible, it's time to chow down!
+	if(is_type_in_list(A, edibles) && A != loc) // If we click on something edible, it's time to chow down! // dumb hotfix so they don't eat themselves inside an animal cube
 		delayNextAttack(10)
 		chowdown(A)
 	if(is_type_in_list(A, gym_equipments)) // If we click on gym equipment, it's time to work out!


### PR DESCRIPTION
[bugfix][grammar]

## What this does
Closes #35661.
## Changelog
:cl:
 * bugfix: Gym rats no longer eat the animal cube they're inside of, deleting themselves.
 * bugfix: Animal recyclers are now properly emaggable.
 * bugfix: Sentient mobs now have their animal cubes named right when spawned from animal recyclers.
 * bugfix: Sentient mobs can now be pulled out of animal recyclers intact if not conveyored in and the recyclers are emagged.
 * bugfix: Humans now need to be stripped to be animal recycled, like in a gibber.
 * tweak: Mobs held in hand can now be put into animal recyclers.
 * tweak: The description for the animal recycler no longer mentions "dead" animals if it has been upgraded sufficiently enough for recycling live animals.