### PR TITLE
Plant analyzers now give more detailed information.

### DIFF
--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -14,7 +14,7 @@
 
 /obj/item/device/analyzer/plant_analyzer
 	name = "plant analyzer"
-	desc = "A hand-held botanical scanner that reports detailed information about seeds, plants and produce. 
+	desc = "A hand-held botanical scanner that reports detailed information about seeds, plants and produce."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "hydro"
 	item_state = "analyzer"

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -93,7 +93,7 @@
 	if(grown_reagents && grown_reagents.reagent_list && grown_reagents.reagent_list.len)
 		dat += "This sample contains: "
 		for(var/datum/reagent/R in grown_reagents.reagent_list)
-			dat += "<br>- [R.id], [grown_reagents.get_reagent_amount(R.id)] unit(s)"
+			dat += "<br>- [R.id], [grown_reagents.get_reagent_amount(R.id)] unit[grown_reagents.get_reagent_amount(R.id) == 1 ? "" : "s"]"
 
 	dat += "<h2>Other Data</h2>"
 

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -14,6 +14,7 @@
 
 /obj/item/device/analyzer/plant_analyzer
 	name = "plant analyzer"
+	desc = "A hand-held botanical scanner that reports detailed information about seeds, plants and produce. 
 	icon = 'icons/obj/device.dmi'
 	icon_state = "hydro"
 	item_state = "analyzer"

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -171,7 +171,7 @@
 		if(1)
 			dat += "It is omnivorous and will eat tray pests and weeds for sustenance.<br>"
 		if(2)
-			dat	+= "It is voracious and poses a significant threat to living things around it.<br>"
+			dat	+= "It is carnivorous and poses a significant threat to living things around it.<br>"
 
 	if(grown_seed.alter_temp)
 		dat += "It will gradually alter the local room temperature to match its ideal habitat.<br>"

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -161,7 +161,7 @@
 		for(var/gas in grown_seed.consume_gasses)
 			dat += "It will consume [grown_seed.consume_gasses[gas]] moles of [gas] from the environment per cycle.<br>"
 	if(grown_seed.gas_absorb)
-		dat += "It will absorb the consumed gases, slowly gaining potency as it does.<br> Its produce will absorb the consumed gases and slowly turn them into reagents.<br>"
+		dat += "It will absorb the consumed gases, slowly gaining potency as it does.<br>Its produce can also absorb the consumed gases and will slowly turn them into reagents.<br>"
 	if(grown_seed.exude_gasses)
 		for(var/gas in grown_seed.exude_gasses)
 			var/amount = max(1,round((grown_seed.exude_gasses[gas]*round(grown_seed.potency))/grown_seed.exude_gasses.len))

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -81,9 +81,17 @@
 	dat += "</table>"
 
 	if(grown_reagents && grown_reagents.reagent_list && grown_reagents.reagent_list.len)
-		dat += "<h2>Reagent Data</h2>"
+	dat += "<h2>Reagent Data</h2>"
+		
+	if(!grown_reagents) //checking if the thing is produce or seed
+		dat += "This plant will produce: "
+		var/datum/reagent/N
+		for (var/rid in grown_seed.chems)
+			N = chemical_reagents_list[rid]
+			dat += "<br>- [N.id]"
 
-		dat += "<br>This sample contains: "
+	if(grown_reagents && grown_reagents.reagent_list && grown_reagents.reagent_list.len)
+		dat += "This sample contains: "
 		for(var/datum/reagent/R in grown_reagents.reagent_list)
 			dat += "<br>- [R.id], [grown_reagents.get_reagent_amount(R.id)] unit(s)"
 
@@ -151,12 +159,13 @@
 		
 	if(grown_seed.consume_gasses)
 		for(var/gas in grown_seed.consume_gasses)
-			dat += "It will consume [gas] from the environment.<br>"
+			dat += "It will consume [grown_seed.consume_gasses[gas]] moles of [gas] from the environment per cycle.<br>"
 	if(grown_seed.gas_absorb)
-		dat += "It will turn absorbed gasses into reagents.<br>"
+		dat += "It will absorb the consumed gases, slowly gaining potency as it does.<br> Its produce will absorb the consumed gases and slowly turn them into reagents.<br>"
 	if(grown_seed.exude_gasses)
 		for(var/gas in grown_seed.exude_gasses)
-			dat += "It will exude [gas] into the environment.<br>"
+			var/amount = max(1,round((grown_seed.exude_gasses[gas]*round(grown_seed.potency))/grown_seed.exude_gasses.len))
+			dat += "It will exude [amount] moles of [gas] into the environment per cycle.<br>"
 
 	switch(grown_seed.spread)
 		if(1)

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -117,7 +117,7 @@
 	else if(grown_seed.toxin_affinity > 7)
 		dat += "It requires [grown_seed.fluid_consumption] units of toxins per cycle.<br>"
 	else if(grown_seed.toxin_affinity >= 5 && grown_seed.toxin_affinity <= 7)
-		dat += "it requires [grown_seed.fluid_consumption * 0.5] of both water and toxins per cycle.<br>"
+		dat += "It requires [grown_seed.fluid_consumption * 0.5] of both water and toxins per cycle.<br>"
 
 	dat += "It thrives in a temperature of [grown_seed.ideal_heat] Kelvin and can tolerate deviations of up to [grown_seed.heat_tolerance] Kelvin.<br>"
 

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -105,110 +105,105 @@
 		dat += "The mature plant will produce [grown_seed.products.len == 1 ? "fruit" : "[grown_seed.products.len] varieties of fruit"].<br>"
 
 	if(grown_seed.nutrient_consumption == 0)
-		dat += "It does not require nutrient to subsist.<br>"
-	else if(grown_seed.nutrient_consumption < 2)
-		dat += "It consumes a small amount of nutrient.<br>"
-	else if(grown_seed.nutrient_consumption > 3)
-		dat += "It requires a heavy supply of nutrient.<br>"
+		dat += "It does not require nutrients to subsist.<br>"
 	else
-		dat += "It requires a moderate supply of nutrient.<br>"
+		dat += "It consumes [grown_seed.nutrient_consumption] units of nutrient per cycle.<br>"
 
 	if(grown_seed.fluid_consumption == 0)
-		dat += "It does not require fluids to subsist.<br>"
-	else if(grown_seed.fluid_consumption < 1)
-		dat += "It requires very little fluids.<br>"
-	else if(grown_seed.fluid_consumption > 5)
-		dat += "It requires a large amount of fluids.<br>"
+		dat += "It does not require any fluids to subsist.<br>"
+	else if(grown_seed.toxin_affinity < 5)
+		dat += "It requires [grown_seed.fluid_consumption] units of water per cycle.<br>"
+	else if(grown_seed.toxin_affinity > 7)
+		dat += "It requires [grown_seed.fluid_consumption] units of toxins per cycle.<br>"
+	else if(grown_seed.toxin_affinity >= 5 && grown_seed.toxin_affinity <= 7)
+		dat += "it requires [grown_seed.fluid_consumption * 0.5] of both water and toxins per cycle.<br>"
+
+	dat += "It thrives in a temperature of [grown_seed.ideal_heat] Kelvin and can tolerate deviations of up to [grown_seed.heat_tolerance] Kelvin.<br>"
+
+	dat += "It can tolerate pressures between [grown_seed.lowkpa_tolerance] and [grown_seed.highkpa_tolerance] kPa.<br>"
+
+	dat += "It thrives in a light level of [grown_seed.ideal_light] lumen[grown_seed.ideal_light == 1 ? "" : "s"], and can tolerate a deviation of up to [grown_seed.light_tolerance] lumen[grown_seed.light_tolerance == 1 ? "" : "s"] from it.<br>"
+
+	dat += "It has a toxin affinity of [grown_seed.toxin_affinity] "
+	if(grown_seed.toxin_affinity < 5)
+		dat += "and will get damaged if exposed to them.<br>" 
+	else if(grown_seed.toxin_affinity > 7)
+		dat += "and will require toxins as a fluid, getting damaged if exposed to water.<br>"
+	else if(grown_seed.toxin_affinity >= 5 && grown_seed.toxin_affinity <= 7)
+		dat += "and requires both water and toxins, being able somewhat to tolerate either.<br>"
+
+	dat += "It has a pest tolerance of [grown_seed.pest_tolerance]. "
+	if(grown_seed.pest_tolerance < 30)
+		dat += "It is highly sensitive to them.<br>"
+	else if(grown_seed.pest_tolerance > 70)
+		dat += "It is remarkably resistant to them.<br>"
 	else
-		dat += "It requires a stable supply of fluids.<br>"
+		dat += "It is average.<br>"
 
-	dat += "It thrives in a temperature of [grown_seed.ideal_heat] Kelvin."
-
-	if(grown_seed.lowkpa_tolerance < 20)
-		dat += "<br>It is well adapted to low pressure levels."
-	if(grown_seed.highkpa_tolerance > 220)
-		dat += "<br>It is well adapted to high pressure levels."
-
-	if(grown_seed.heat_tolerance > 50)
-		dat += "<br>It is well adapted to a range of temperatures."
-	else if(grown_seed.heat_tolerance < 10)
-		dat += "<br>It is very sensitive to temperature shifts."
-
-	dat += "<br>It thrives in a light level of [grown_seed.ideal_light] lumen[grown_seed.ideal_light == 1 ? "" : "s"]."
-
+	dat += "It has a weed tolerance of [grown_seed.weed_tolerance]. "
+	if(grown_seed.weed_tolerance < 30)
+		dat += "It is highly sensitive to them.<br>"
+	else if(grown_seed.weed_tolerance > 70)
+		dat += "It is remarkably resistant to them.<br>"
+	else
+		dat += "It is average.<br>"
+		
 	if(grown_seed.consume_gasses)
 		for(var/gas in grown_seed.consume_gasses)
-			dat += "<br>It will consume [gas] from the environment."
+			dat += "It will consume [gas] from the environment.<br>"
 	if(grown_seed.gas_absorb)
-		dat += "<br>It will turn absorbed gasses into reagents."
+		dat += "It will turn absorbed gasses into reagents.<br>"
 	if(grown_seed.exude_gasses)
 		for(var/gas in grown_seed.exude_gasses)
-			dat += "<br>It will exude [gas] into the environment."
-
-	if(grown_seed.light_tolerance > 7)
-		dat += "<br>It is well adapted to a range of light levels."
-	else if(grown_seed.light_tolerance < 3)
-		dat += "<br>It is very sensitive to light level shifts."
-
-	if(grown_seed.toxin_affinity < 5)
-		dat += "<br>It is highly sensitive to toxins."
-	else if(grown_seed.toxin_affinity > 7)
-		dat += "<br>It has a remarkable affinity for toxins."
-
-	if(grown_seed.pest_tolerance < 30)
-		dat += "<br>It is highly sensitive to pests."
-	else if(grown_seed.pest_tolerance > 70)
-		dat += "<br>It is remarkably resistant to pests."
-
-	if(grown_seed.weed_tolerance < 30)
-		dat += "<br>It is highly sensitive to weeds."
-	else if(grown_seed.weed_tolerance > 70)
-		dat += "<br>It is remarkably resistant to weeds."
+			dat += "It will exude [gas] into the environment.<br>"
 
 	switch(grown_seed.spread)
 		if(1)
-			dat += "<br>It is capable of growing beyond the confines of a tray."
+			dat += "It is capable of growing beyond the confines of a tray.<br>"
 		if(2)
-			dat += "<br>It is a robust and vigorous vine that will spread rapidly."
+			dat += "It is a robust and vigorous vine that will spread rapidly.<br>"
 
 	if(grown_seed.hematophage)
-		dat += "<br>It is a highly specialized hematophage that will only draw nutrients from blood."
+		dat += "It is a highly specialized hematophage that will only draw nutrients from blood.<br>"
 
 	switch(grown_seed.voracious)
 		if(1)
-			dat += "<br>It is carnivorous and will eat tray pests and weeds for sustenance."
+			dat += "It is omnivorous and will eat tray pests and weeds for sustenance.<br>"
 		if(2)
-			dat	+= "<br>It is carnivorous and poses a significant threat to living things around it."
+			dat	+= "It is voracious and poses a significant threat to living things around it.<br>"
 
 	if(grown_seed.alter_temp)
-		dat += "<br>It will gradually alter the local room temperature to match it's ideal habitat."
+		dat += "It will gradually alter the local room temperature to match its ideal habitat.<br>"
 
 	if(grown_seed.ligneous)
-		dat += "<br>It is a ligneous plant with strong and robust stems."
+		dat += "It is a ligneous plant with strong and robust stems.<br>"
 
 	if(grown_seed.thorny)
-		dat += "<br>It possesses a cover of sharp thorns."
+		dat += "It possesses a cover of sharp thorns.<br>"
 
 	if(grown_seed.stinging)
-		dat += "<br>It possesses a cover of fine stingers capable of releasing chemicals on touch."
+		dat += "It possesses a cover of fine stingers capable of releasing chemicals on touch.<br>"
 
 	if(grown_seed.teleporting)
-		dat += "<br>It possesses a high degree of temporal/spatial instability and may cause spontaneous bluespace disruptions."
+		dat += "It possesses a high degree of temporal/spatial instability and may cause spontaneous bluespace disruptions.<br>"
 
 	switch(grown_seed.juicy)
 		if(1)
-			dat += "<br>Its fruit is soft-skinned and abudantly juicy."
+			dat += "Its fruit is soft-skinned and abudantly juicy.<br>"
 		if(2)
-			dat	+= "<br>Its fruit is excessively soft and juicy."
+			dat	+= "Its fruit is excessively soft and juicy.<br>"
 
 	if(grown_seed.biolum)
-		dat += "<br>It is [grown_seed.biolum_colour ? "<font color='[grown_seed.biolum_colour]'>bio-luminescent</font>" : "bio-luminescent"]."
+		if(grown_seed.biolum_colour == "#FFFFFF")
+			dat += "It is bio-luminescent and glows pure white.<br>" //exception for shardlime
+		else
+			dat += "It is [grown_seed.biolum_colour ? "<font color='[grown_seed.biolum_colour]'>bio-luminescent</font>" : "bio-luminescent"].<br>"
 
 	if(dat)
 		dat = jointext(dat,"")
 		last_data = dat
-		dat += "<br><br>\[<a href='?src=\ref[src];print=1'>print report</a>\] \[<a href='?src=\ref[src];clear=1'>clear</a>\]"
-		user << browse(dat,"window=plant_analyzer_\ref[src];size=400x500")
+		dat += "<br>\[<a href='?src=\ref[src];print=1'>print report</a>\] \[<a href='?src=\ref[src];clear=1'>clear</a>\]"
+		user << browse(dat,"window=plant_analyzer_\ref[src];size=500x600")
 	return
 
 /obj/item/device/analyzer/plant_analyzer/attack_self(mob/user as mob)

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -108,16 +108,16 @@
 	if(grown_seed.nutrient_consumption == 0)
 		dat += "It does not require nutrients to subsist.<br>"
 	else
-		dat += "It consumes [grown_seed.nutrient_consumption] units of nutrient per cycle.<br>"
+		dat += "It consumes [grown_seed.nutrient_consumption] unit[grown_seed.nutrient_consumption == 1 ? "" : "s"] of nutrient per cycle.<br>"
 
 	if(grown_seed.fluid_consumption == 0)
 		dat += "It does not require any fluids to subsist.<br>"
 	else if(grown_seed.toxin_affinity < 5)
-		dat += "It requires [grown_seed.fluid_consumption] units of water per cycle.<br>"
+		dat += "It requires [grown_seed.fluid_consumption] unit[grown_seed.fluid_consumption == 1 ? "" : "s"] of water per cycle.<br>"
 	else if(grown_seed.toxin_affinity > 7)
-		dat += "It requires [grown_seed.fluid_consumption] units of toxins per cycle.<br>"
+		dat += "It requires [grown_seed.fluid_consumption] unit[grown_seed.fluid_consumption == 1 ? "" : "s"] of toxins per cycle.<br>"
 	else if(grown_seed.toxin_affinity >= 5 && grown_seed.toxin_affinity <= 7)
-		dat += "It requires [grown_seed.fluid_consumption * 0.5] of both water and toxins per cycle.<br>"
+		dat += "It requires [grown_seed.fluid_consumption * 0.5] unit[grown_seed.fluid_consumption == 1 ? "" : "s"] of both water and toxins per cycle.<br>"
 
 	dat += "It thrives in a temperature of [grown_seed.ideal_heat] Kelvin and can tolerate deviations of up to [grown_seed.heat_tolerance] Kelvin.<br>"
 

--- a/code/modules/hydroponics/hydroponics_reagents.dm
+++ b/code/modules/hydroponics/hydroponics_reagents.dm
@@ -6,7 +6,7 @@
 
 /obj/machinery/portable_atmospherics/hydroponics/proc/add_nutrientlevel(var/amount, var/bloody = FALSE)
 	if(amount < 0)
-		nutrientlevel = round(max(0, nutrientlevel + amount))
+		nutrientlevel = round(max(0, nutrientlevel + amount),0.01)
 		if(nutrientlevel < 1)
 			add_planthealth(-rand(1,3) * HYDRO_SPEED_MULTIPLIER)
 			affect_growth(-1)
@@ -15,7 +15,7 @@
 			return
 		if(seed && seed.hematophage && !bloody)
 			return
-		nutrientlevel = round(min(nutrientlevel + amount, NUTRIENTLEVEL_MAX))
+		nutrientlevel = round(min(nutrientlevel + amount, NUTRIENTLEVEL_MAX),0.01)
 	update_icon_after_process = 1
 
 /obj/machinery/portable_atmospherics/hydroponics/proc/get_nutrientlevel()
@@ -23,11 +23,11 @@
 
 /obj/machinery/portable_atmospherics/hydroponics/proc/add_waterlevel(var/amount)
 	if(amount > 0)
-		waterlevel = round(min(waterlevel + amount,WATERLEVEL_MAX))
-		toxinlevel = round(max(toxinlevel - amount/2, 0))
+		waterlevel = round(min(waterlevel + amount,WATERLEVEL_MAX),0.01)
+		toxinlevel = round(max(toxinlevel - amount/2, 0),0.01)
 	else
 		//Remove or uptake water
-		waterlevel = round(max(0, waterlevel + amount))
+		waterlevel = round(max(0, waterlevel + amount),0.01)
 		if(waterlevel < 1)
 			add_planthealth(-rand(1,3) * HYDRO_SPEED_MULTIPLIER)
 			affect_growth(-1)
@@ -42,7 +42,7 @@
 	else
 		pestlevel = round(max(0, pestlevel + amount))
 	update_icon_after_process = 1
-	
+
 /obj/machinery/portable_atmospherics/hydroponics/proc/get_pestlevel()
 	return pestlevel
 
@@ -52,17 +52,17 @@
 	else
 		weedlevel = round(max(0, weedlevel + amount))
 	update_icon_after_process = 1
-	
+
 /obj/machinery/portable_atmospherics/hydroponics/proc/get_weedlevel()
 	return weedlevel
 
 /obj/machinery/portable_atmospherics/hydroponics/proc/add_toxinlevel(var/amount)
 	if(amount > 0)
-		toxinlevel = round(min(toxinlevel + amount,TOXINLEVEL_MAX))
-		waterlevel = round(max(waterlevel - amount/2, 0))
+		toxinlevel = round(min(toxinlevel + amount,TOXINLEVEL_MAX),0.01)
+		waterlevel = round(max(waterlevel - amount/2, 0),0.01)
 	else
 		//Remove or uptake toxins
-		toxinlevel = round(max(0, toxinlevel + amount))
+		toxinlevel = round(max(0, toxinlevel + amount),0.01)
 		if(seed && !dead)
 			if(toxinlevel < 1 && !(seed.toxin_affinity < 5))
 				add_planthealth(-rand(1,3) * HYDRO_SPEED_MULTIPLIER)
@@ -86,6 +86,6 @@
 		if(get_planthealth() < 1)
 			die()
 	update_icon_after_process = 1
-			
+
 /obj/machinery/portable_atmospherics/hydroponics/proc/get_planthealth()
 	return plant_health


### PR DESCRIPTION
## What this does
Changes the plant analyzer so it gives numerical values for ideal pressure/light, tolerated pressure/light, toxin affinity, weed/pest resistance, fluid/nutrient consumption, gas consumed/produced per cycle and what reagents are produced by the seed.
Also bugfixes some stuff I found while testing this.
Should look like this:
![image](https://github.com/vgstation-coders/vgstation13/assets/67024428/acd768b0-02c8-4125-a0cf-6a9a05e83fe1)
Thanks to Dilt, Kurf and CrazyAmphibian for pointers while making this.
Closes #2849
## Why it's good
More detailed information is useful for splicing.
[tested][qol]
:cl:
 * rscadd: Plant analyzers will now output more detailed information about the plant's assorted stats (toxin affinity, weed/pest tolerance, ideal temperature/light, tolerated deviations from the ideal, gas consumed/produced per cycle), with numerical values, and what reagents can be produced by the seed.
 * bugfix: Fixes plants consuming more or less water/toxin/nutriment than they should due to rounding.
 * bugfix: In the event of the plant glowing white, the plant analyzer will now say that it glows pure white, instead of recoloring the word 'bioluminescent' white, rendering it unreadable.