### PR TITLE
Makes "on station" a bit more literal and inclusive for scoreboards

### DIFF
--- a/code/game/gamemodes/endgame/scoreboard/department_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/department_score.dm
@@ -77,7 +77,7 @@
 /datum/controller/gameticker/scoreboard/proc/service_score()
 	//Janitor
 	//Check how many uncleaned mess are on the station.
-	var/list/valid_areas = the_station_areas.Copy() - typesof(/area/holodeck) //excluding these for now because subtypes are on z2 normally
+	var/list/valid_areas = (the_station_areas.Copy() - typesof(/area/holodeck)) + /area/holodeck/alphadeck
 	for(var/obj/effect/decal/cleanable/M in decals)
 		var/area/A = get_area(M)
 		if(is_type_in_list(A,valid_areas))

--- a/code/game/gamemodes/endgame/scoreboard/department_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/department_score.dm
@@ -48,7 +48,7 @@
 			skip_power_loss = 1
 	if(!skip_power_loss)
 		for(var/obj/machinery/power/apc/A in power_machines)
-			if(A.z != map.zMainStation)
+			if(!is_type_in_list(get_area(A),the_station_areas))
 				continue
 			for(var/obj/item/weapon/cell/C in A.contents)
 				if(C.percent() < 30)
@@ -60,7 +60,7 @@
 		score.powerbonus = 2500
 
 	for(var/obj/machinery/alarm/A2 in air_alarms)
-		if(A2.z != map.zMainStation)
+		if(!is_type_in_list(get_area(A2),the_station_areas))
 			continue
 		var/area/this_area = get_area(A2)
 		if(max(A2.local_danger_level, this_area.atmosalm-1) > 0)
@@ -78,17 +78,13 @@
 	//Janitor
 	//Check how many uncleaned mess are on the station. We can't run through cleanable for reasons, so yeah, long
 	for(var/obj/effect/decal/cleanable/M in decals)
-		if(M.z != map.zMainStation) //Won't work on multi-Z stations, but will do for now
-			continue
-		if(M.messcheck())
+		var/area/A = get_area(M)
+		if(is_type_in_list(A,the_station_areas))
 			score.mess++
 	for(var/obj/item/trash/T in trash_items)
-		if(T.z != map.zMainStation) //Won't work on multi-Z stations, but will do for now
-			continue
 		var/area/A = get_area(T)
-		if(istype(A,/area/surface/junkyard))
-			continue
-		score.litter++
+		if(is_type_in_list(A,the_station_areas))
+			score.litter++
 	if(score.mess < 5 && score.litter < 5) //Not a single mess or litter on station
 		score.messbonus = 5000
 

--- a/code/game/gamemodes/endgame/scoreboard/department_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/department_score.dm
@@ -77,7 +77,7 @@
 /datum/controller/gameticker/scoreboard/proc/service_score()
 	//Janitor
 	//Check how many uncleaned mess are on the station.
-	var/list/valid_areas = the_station_areas.Copy() - typesof(/area/holodeck)
+	var/list/valid_areas = the_station_areas.Copy() - typesof(/area/holodeck) //excluding these for now because subtypes are on z2 normally
 	for(var/obj/effect/decal/cleanable/M in decals)
 		var/area/A = get_area(M)
 		if(is_type_in_list(A,valid_areas))

--- a/code/game/gamemodes/endgame/scoreboard/department_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/department_score.dm
@@ -76,14 +76,15 @@
 
 /datum/controller/gameticker/scoreboard/proc/service_score()
 	//Janitor
-	//Check how many uncleaned mess are on the station. We can't run through cleanable for reasons, so yeah, long
+	//Check how many uncleaned mess are on the station.
+	var/list/valid_areas = the_station_areas.Copy() - typesof(/area/holodeck)
 	for(var/obj/effect/decal/cleanable/M in decals)
 		var/area/A = get_area(M)
-		if(is_type_in_list(A,the_station_areas))
+		if(is_type_in_list(A,valid_areas))
 			score.mess++
 	for(var/obj/item/trash/T in trash_items)
 		var/area/A = get_area(T)
-		if(is_type_in_list(A,the_station_areas))
+		if(is_type_in_list(A,valid_areas))
 			score.litter++
 	if(score.mess < 5 && score.litter < 5) //Not a single mess or litter on station
 		score.messbonus = 5000

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -165,8 +165,10 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 		dat += "<B>Destroyed Silicons:</B> [score.deadsilicon] ([find_active_faction_by_type(/datum/faction/malf) ? score.deadsilicon * 500 : score.deadsilicon * -500] Points)<BR>"
 	if (score.deadaipenalty > 0)
 		dat += "<B>AIs Destroyed:</B> [score.deadaipenalty] ([find_active_faction_by_type(/datum/faction/malf) ? score.deadaipenalty * 1000 : score.deadaipenalty * -1000] Points)<BR>"
-	dat += "<B>Uncleaned Messes:</B> [score.mess] (-[score.mess] Points)<BR>"
-	dat += "<B>Trash on Station:</B> [score.litter] (-[score.litter] Points)<BR>"
+	if(score.mess > 0)
+		dat += "<B>Uncleaned Messes:</B> [score.mess] (-[score.mess] Points)<BR>"
+	if(score.litter > 0)
+		dat += "<B>Trash on Station:</B> [score.litter] (-[score.litter] Points)<BR>"
 	if(score.stuffnotforwarded > 0)
 		dat += "<B>Cargo Crates Not Forwarded:</B> [score.stuffnotforwarded] (-[score.stuffnotforwarded * 25] Points)<BR>"
 	if (score.powerloss > 0)

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -11,10 +11,13 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	var/eventsendured		= 0 //How many random events did the station endure?
 	var/powerloss			= 0 //How many APCs have alarms (under 30 %)?
 	var/atmoloss			= 0 //How many air alarms are giving issues?
+	var/powerbonus			= 0 //If all APCs on the station are running optimally, big bonus
+	var/atmobonus			= 0 //If all air alarms on the station are running optimally, big bonus
 	var/maxpower			= 0 //Most watts in grid on any of the world's powergrids.
 	var/escapees			= 0 //How many people got out alive?
 	var/deadcrew			= 0 //Humans who died during the round
 	var/deadsilicon			= 0 //Silicons who died during the round
+	var/deadaipenalty		= 0 //AIs who died during the round
 	var/mess				= 0 //How much messes on the floor went uncleaned
 	var/litter				= 0 //How much trash is laying on the station floor
 	var/meals				= 0 //How much food was actively cooked that day
@@ -28,12 +31,11 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	var/disease_bad			= 0 //How many unique diseases currently affecting living mobs of cumulated danger >= 3
 	var/disease_most		= null //Most spread disease
 	var/disease_most_count	= 0 //Most spread disease
+	var/turfssingulod		= 0 //Amount of turfs eaten by singularities.
+	var/static/list/badvars		= list("deadcrew","deadsilicon","deadaipenalty","mess","litter","powerloss","atmoloss","stuffnotforwarded","disease_bad","turfssingulod")
 
 	//These ones are mainly for the stat panel
-	var/powerbonus			= 0 //If all APCs on the station are running optimally, big bonus
-	var/atmobonus			= 0 //If all air alarms on the station are running optimally, big bonus
 	var/messbonus			= 0 //If there are no messes on the station anywhere, huge bonus
-	var/deadaipenalty		= 0 //AIs who died during the round
 	var/foodeaten			= 0 //How much food was consumed
 	var/clownabuse			= 0 //How many times a clown was punched, struck or otherwise maligned
 	var/slips				= 0 //How many people have slipped during this round
@@ -65,7 +67,6 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	var/largest_TTV			= 0 //The largest Tank Transfer Valve explosion this round
 	var/deadpets			= 0 //Only counts 'special' simple_mobs, like Ian, Poly, Runtime, Sasha etc
 	var/buttbotfarts		= 0 //Messages mimicked by buttbots.
-	var/turfssingulod		= 0 //Amount of turfs eaten by singularities.
 	var/shardstouched		= 0 //+1 for each pair of shards that bump into eachother.
 	var/kudzugrowth			= 0 //Amount of kudzu tiles successfully grown, even if they were later eradicated.
 	var/nukedefuse			= 9999 //Seconds the nuke had left when it was defused.
@@ -179,6 +180,12 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 		dat += "<B>Tiles destroyed by a singularity:</B> [score.turfssingulod] (-[round(score.turfssingulod/2)] Points)<BR>"
 	if(score.disease_bad > 0)
 		dat += "<B>Bad diseases in living mobs:</B> [score.disease_bad] (-[score.disease_bad * 50] Points)<BR>"
+	var/badfound = FALSE
+	for(var/variable in src.badvars)
+		if(vars[variable] > 0)
+			badfound = TRUE
+	if(!badfound)
+		dat += "<B>Nothing bad to report! Good job, crew!</B><BR>"
 
 	dat += "<BR><U>THE WEIRD</U><BR>"
 /*	<B>Final Station Budget:</B> $[num2text(totalfunds,50)]<BR>"

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -183,12 +183,6 @@ var/list/infected_cleanables = list()
 			perp.add_blood_to_feet(amount, basecolor, blood_DNA)
 			amount--
 
-/obj/effect/decal/cleanable/proc/messcheck(var/obj/effect/decal/cleanable/M)
-	return 1
-
-
-
-
 ///////////////////CULT BLOODSPILL STUFF/////////////////////////////////////
 
 /obj/effect/decal/cleanable/proc/bloodspill_add()


### PR DESCRIPTION
[tweak][bugfix]

## What this does
if theres messes or trash in space near the station like from meaty gores, it no longer counts as "on station" now

## Why it's good
more literal and stops people having to spacewalk to do janitor work

## Changelog
:cl:
 * tweak: Messes and trash found outside of the station on the same z-level no longer count as "on station" for scoreboards
 * tweak: If nothing shows up under "the bad" in the scoreboard, a special message is given relating to it
 * bugfix: Station power, atmos alarms, messes and trash no longer only count for the main level on multi-Z maps