### PR TITLE
Sundays in April are also April Fool's Day

### DIFF
--- a/code/game/gamemodes/events/holidays/Holidays.dm
+++ b/code/game/gamemodes/events/holidays/Holidays.dm
@@ -42,6 +42,8 @@ var/global/Holiday = null
 					current_holidays += ST_PATRICKS_DAY
 
 		if(4) // Apr
+			if((DD != 1) && (time2text(world.timeofday, "DDD") == "Sat" || time2text(world.timeofday, "DDD") == "Sun")) //no idea what would happen if april fools gets set twice so we check just in case
+				current_holidays += APRIL_FOOLS_DAY
 			switch(DD)
 				if(1)
 					current_holidays += APRIL_FOOLS_DAY

--- a/code/game/gamemodes/events/holidays/Holidays.dm
+++ b/code/game/gamemodes/events/holidays/Holidays.dm
@@ -42,7 +42,7 @@ var/global/Holiday = null
 					current_holidays += ST_PATRICKS_DAY
 
 		if(4) // Apr
-			if((DD != 1) && (time2text(world.timeofday, "DDD") == "Sat" || time2text(world.timeofday, "DDD") == "Sun")) //no idea what would happen if april fools gets set twice so we check just in case
+			if(DD != 1 && time2text(world.timeofday, "DDD") == "Sun") //no idea what would happen if april fools gets set twice so we check just in case
 				current_holidays += APRIL_FOOLS_DAY
 			switch(DD)
 				if(1)


### PR DESCRIPTION
## What this does
Makes it so during April, all sundays are treated as April Fool's.
Does not touch the April Fool's on April 1st.
## Why it's good
We have a lot of cool, funny or interesting things gated strictly behind April Fool's, so they are almost never relevant because it only happens once a year, adding more days would give people some leeway to play around, and spreading it like this would avoid players getting fed up with it as much, since it wouldn't be a straight week.
:cl:
 * rscadd: April Fool's now also happens on Sundays during the month of April.