### PR TITLE
Circulator Crate Description Fix

### DIFF
--- a/code/datums/supply_packs/engineering.dm
+++ b/code/datums/supply_packs/engineering.dm
@@ -292,7 +292,7 @@
 	containername = "atmospheric circulator crate"
 	group = "Engineering"
 	access = list(access_engine_minor)
-	containsdesc = "Two circulators for a thermoelectric generator. Requires the generator itself to function (not included)."
+	containsdesc = "One circulator for a thermoelectric generator. Requires the generator and a second circulator to function (not included)."
 
 /datum/supply_packs/supermatter_shard
 	contains = list(/obj/machinery/power/supermatter/shard)


### PR DESCRIPTION
The PR that we needed but didn't deserve.

## What this does
Currently, the description reads that the crate comes with two circulators. It actually comes with one. This PR updates the description to correctly state it comes with only a single circulator.

Fixes #36266, caused by #35326 when I added descriptions to everything but clearly didn't turn on my brain for some of them.

## Why it's good
it was funny when the first person ordered the crate expecting two circulators but receiving only one, but now it's less funny so time to fix it!

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed the TEG Circulator Crate incorrect description

[bugfix][grammar]