### PR TITLE
Wiz card descriptions now only show when flipped

### DIFF
--- a/code/modules/games/cards/wizard_cards.dm
+++ b/code/modules/games/cards/wizard_cards.dm
@@ -75,9 +75,11 @@ var/global/list/wizard_cards_normal = list(
 		overlays -= char_image
 		icon_state = "wizcard_down"
 		name = "card"
+		desc = "A collectable trading card depicting various magical entities."
 	else
 		src.icon_state = initial(icon_state)
 		src.name = initial(src.name)
+		src.desc = initial(src.desc)
 		src.overlays += char_image
 
 /obj/item/toy/singlecard/wizard/attack_self(mob/user, params)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Wizard cards will now only show their unique descriptions when flipped.

## Why it's good
<!-- Explain why you think these changes are good. -->
Closes #24303.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Wizard cards now show their unique descriptions only when flipped.