### PR TITLE
Fixes human cube interaction with ez bake machines

### DIFF
--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -341,7 +341,7 @@ var/global/ingredientLimit = 10
 	new_food.update_icon()
 	if(istype(ingredient,/obj/item/weapon/reagent_containers/food/snacks/monkeycube/humancube))
 		var/obj/item/weapon/reagent_containers/food/snacks/monkeycube/humancube/H = ingredient
-		qdel(H.containted_mob)
+		qdel(H.contained_mob)
 	ingredient = null
 	return new_food
 

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -339,6 +339,9 @@ var/global/ingredientLimit = 10
 	if (cooking_temperature && (new_food.reagents.chem_temp < cooking_temperature))
 		new_food.reagents.chem_temp = cooking_temperature
 	new_food.update_icon()
+	if(istype(ingredient,/obj/item/weapon/reagent_containers/food/snacks/monkeycube/humancube))
+		var/obj/item/weapon/reagent_containers/food/snacks/monkeycube/humancube/H = ingredient
+		qdel(H.containted_mob)
 	ingredient = null
 	return new_food
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Human cubes will now properly delete their contained human when cooked in a goofkitchen machine.

**Still need to test this**

## Why it's good
<!-- Explain why you think these changes are good. -->
Fixes #24320.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Humans cooked in the goofkitchen machines will now be deleted properly.