### PR TITLE
allow cash registers to be put on tables

### DIFF
--- a/code/modules/Economy/POS.dm
+++ b/code/modules/Economy/POS.dm
@@ -135,6 +135,7 @@ var/const/POS_HEADER = {"<html>
 	density = 0
 	name = "point of sale"
 	desc = "Also known as a cash register, or, more commonly, \"robbery magnet\"."
+	pass_flags = PASSTABLE
 
 	var/id = 0
 	var/sales = 0


### PR DESCRIPTION
astounding this wasn't a thing before
suggested by @Dacendeth 
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Point of Sale / Cash Register machines can now be put back onto tables.
