### PR TITLE
Fixes keycard vault load error message

### DIFF
--- a/maps/randomvaults/keycard_vault.dm
+++ b/maps/randomvaults/keycard_vault.dm
@@ -44,7 +44,8 @@
 		qdel(LM)
 
 /datum/map_element/vault/keycards/load()
-	var/list/turfs = ..()
+	. = ..()
+	var/list/turfs = .
 	ASSERT(thevault)
 	ASSERT(turfs.len)
 	var/offset = -1
@@ -75,7 +76,8 @@
 	var/datum/map_element/vault/keycards/parent
 
 /datum/map_element/dungeon/keycard_vault/load()
-	var/list/turfs = ..()
+	. = ..()
+	var/list/turfs = .
 	ASSERT(parent)
 	ASSERT(turfs.len)
 	var/offset = -1


### PR DESCRIPTION
[vault][bugfix]

## What this does
turns out everything was loading just fine, it was throwing the error because the subcall wasn't returning a non 0 value properly
Closes #34872.

## Changelog
:cl:
 * bugfix: Admin messages for the keycard vault entrance no longer falsely report that it failed to load
