### PR TITLE
Some clearer map element loading error messages

### DIFF
--- a/code/datums/map_elements.dm
+++ b/code/datums/map_elements.dm
@@ -58,9 +58,11 @@ var/list/datum/map_element/map_elements = list()
 			spawned_atoms = maploader.load_map(file, z, x, y, src, rotation, overwrite, clipmin_x, clipmax_x, clipmin_y, clipmax_y, clipmin_z, clipmax_z)
 			initialize(spawned_atoms)
 			return spawned_atoms
+		WARNING("[file_path] is not a file!")
 	else //No file specified - empty map element
 		//These variables are usually set by the map loader. Here we have to set them manually
 		initialize(list()) //Initialize with an empty list
+		WARNING("[file_path] is an empty or non-existant map element!")
 		return 1
 
 	return 0

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -328,7 +328,8 @@ var/list/map_dimension_cache = list()
 
 	//Locate the area object
 	instance = locate(members[index])
-
+	if(!isarea(instance))
+		WARNING("Instance at [members[index]] is not an area!")
 	if(!isspace(instance)) //Space is the default area and contains every loaded turf by default
 		instance.contents.Add(locate(xcrd,ycrd,zcrd))
 		spawned_atoms.Add(instance)
@@ -399,6 +400,8 @@ var/list/map_dimension_cache = list()
 	_preloader.setup(attributes, path)
 
 	var/turf/T = locate(x,y,z)
+	if(!T)
+		WARNING("Turf at [x], [y], [z] not found!")
 	if(ispath(path, /turf)) //Turfs use ChangeTurf
 		if(path != T.type)
 			instance = T.ChangeTurf(path, allow = 1)
@@ -416,6 +419,8 @@ var/list/map_dimension_cache = list()
 	var/timetook2instance = world.timeofday - timestart
 	if(timetook2instance > 1)
 		log_debug("Slow atom instance. [instance] ([instance.type]) at [T?.x],[T?.y],[T?.z] took [timetook2instance/10] seconds to instance.")
+	//if(!instance)
+		//WARNING("No instance created or found at [T?.x],[T?.y],[T?.z]!")
 	return instance
 
 //text trimming (both directions) helper proc

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -382,6 +382,8 @@ var/list/map_dimension_cache = list()
 		var/atom/new_atom = instance_atom(members[index],members_attributes[index],xcrd,ycrd,zcrd,rotate)
 		spawned_atoms.Add(new_atom)
 
+	if(!spawned_atoms.len)
+		WARNING("No atoms spawned in grid parse! (Model key: [model])")
 	return spawned_atoms
 
 ////////////////

--- a/code/modules/randomMaps/vaults.dm
+++ b/code/modules/randomMaps/vaults.dm
@@ -455,7 +455,7 @@
 			if(amount <= 0)
 				break
 		else
-			message_admins("<span class='danger'>Can't find [ME.file_path]!</span>")
+			message_admins("<span class='danger'>[ME.file_path] could not be loaded!</span>")
 
 		CHECK_TICK
 


### PR DESCRIPTION
[administration]

## What this does
adds more than just the misleading "Can't find [mapname]!" one, changes that to just saying something was wrong with loading it, and then adds actual messages for if the map can't be found.

## Why it's good
less ambiguous for error hunting

## Changelog
:cl:
 * tweak: Map element loading error messages are now clearer, and only state if the map "can't be found" if it actually can't, plus gives an error message if part of the grid could not be parsed, if the last part of a grid section is not an area, if a turf could not be found to instance an atom on, or if an atom could not be instanced.