### PR TITLE
Cryotheum Fixes

### DIFF
--- a/code/ATMOSPHERICS/datum_pipe_network.dm
+++ b/code/ATMOSPHERICS/datum_pipe_network.dm
@@ -117,12 +117,14 @@
 	for(var/datum/gas_mixture/gas in gases)
 		air_transient.volume += gas.volume
 		air_transient.merge(gas, FALSE)
+	air_transient.update_values()
 
 	if(air_transient.volume > 0)
 		//Allow air mixture to react
 		if(air_transient.react())
 			update = 1
-		air_transient.reaction_tick()
+		if(air_transient.reaction_tick())
+			update = 1
 
 		air_transient.update_values()
 		for(var/datum/gas_mixture/gas in gases)

--- a/code/ZAS/_gas_mixture.dm
+++ b/code/ZAS/_gas_mixture.dm
@@ -139,6 +139,25 @@
 /datum/gas_mixture/proc/partial_pressure(g)
 	return total_moles && (src[g] / total_moles * pressure) //&& short circuits if total_moles is 0, and returns the second expression if it is not.
 
+// Returns the temperature in a rounded Kelvin format.
+/datum/gas_mixture/proc/temperature_kelvin_pretty()
+	if(temperature > 5)
+		return round(temperature,0.1)
+	else if(temperature > 0.1)
+		return round(temperature,0.01)
+	else
+		return round(temperature,0.0001)
+
+
+// Returns the temperature in a rounded Celsius format.
+/datum/gas_mixture/proc/temperature_celsius_pretty()
+	if(temperature > 5)
+		return round(temperature-T0C,0.1)
+	else if(temperature > 0.1)
+		return round(temperature-T0C,0.01)
+	else
+		return round(temperature-T0C,0.0001)
+
 ///////////////////////////////
 //PV=nRT - related procedures//
 ///////////////////////////////
@@ -535,7 +554,7 @@ var/static/list/sharing_lookup_table = list(0.30, 0.40, 0.48, 0.54, 0.60, 0.66)
 			if(reaction.reaction_is_possible(src))
 				possible_reactions += reaction
 
-// Ticks all reactions once.
+// Ticks all reactions once. Returns true if any reactions were performed, otherwise false.
 /datum/gas_mixture/proc/reaction_tick()
 	cache_reactions()
 	if(allow_reactions && possible_reactions.len)
@@ -570,3 +589,6 @@ var/static/list/sharing_lookup_table = list(0.30, 0.40, 0.48, 0.54, 0.60, 0.66)
 		// Now actually perform the reactions.
 		for(var/datum/gas_reaction/reaction in reaction_to_requested)
 			reaction.perform_reaction(src, reaction_to_requested[reaction])
+		return TRUE
+	else
+		return FALSE

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -123,6 +123,7 @@
 	for(var/gas_id in gas_thresholds)
 		var/datum/airalarm_threshold/our_threshold = gas_thresholds[gas_id]
 		to_return.gas_thresholds[gas_id] = our_threshold.deep_copy()
+	to_return.temperature_threshold = temperature_threshold.deep_copy()
 	to_return.other_gas_threshold = other_gas_threshold.deep_copy()
 	to_return.pressure_threshold = pressure_threshold.deep_copy()
 	to_return.target_temperature = target_temperature
@@ -170,6 +171,7 @@
 	for(var/gas_id in gas_thresholds)
 		var/datum/airalarm_threshold/our_threshold = gas_thresholds[gas_id]
 		to_return.gas_thresholds[gas_id] = our_threshold.deep_copy()
+	to_return.temperature_threshold = temperature_threshold.deep_copy()
 	to_return.other_gas_threshold = other_gas_threshold.deep_copy()
 	to_return.pressure_threshold = pressure_threshold.deep_copy()
 	to_return.target_temperature = target_temperature

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -112,7 +112,7 @@
 	if (src.target)
 		var/datum/gas_mixture/environment = target.return_air()
 		if(environment)
-			t += "The pressure gauge reads [round(environment.return_pressure(), 0.01)] kPa; [round(environment.temperature,0.01)]K ([round(environment.temperature-T0C,0.01)]&deg;C)"
+			t += "The pressure gauge reads [round(environment.return_pressure(), 0.01)] kPa; [environment.temperature_kelvin_pretty()]K ([environment.temperature_celsius_pretty()]&deg;C)"
 		else
 			t += "The sensor error light is blinking."
 	else

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -392,7 +392,7 @@ Subject's pulse: ??? BPM"})
 		message += "<span class='bnotice'><B>[bicon(container)] Results of [container] scan:</span></B>"
 	if(total_moles)
 		message += "<br>[human_standard && abs(pressure - ONE_ATMOSPHERE) > 10 ? "<span class='bad'>" : "<span class='notice'>"] Pressure: [round(pressure, 0.1)] kPa</span>"
-		
+
 		for (var/id in scanned.gas)
 			var/class = "notice"
 			var/moles = scanned[id]
@@ -412,7 +412,9 @@ Subject's pulse: ??? BPM"})
 						class = "bad"
 			message += "<br><span class='[class]'>[gas.name]: [round(moles, 0.1)] mol, [round(concentration*100)]%</span>"
 
-		message += "<br>[human_standard && !IsInRange(scanned.temperature, BODYTEMP_COLD_DAMAGE_LIMIT, BODYTEMP_HEAT_DAMAGE_LIMIT) ? "<span class='bad'>" : "<span class='notice'>"] Temperature: [round(scanned.temperature,0.1)]K ([round(scanned.temperature-T0C)]&deg;C)"
+		var/kelvinTemperatureDisplay = scanned.temperature_kelvin_pretty()
+		var/celsiusTemperatureDisplay = scanned.temperature_celsius_pretty()
+		message += "<br>[human_standard && !IsInRange(scanned.temperature, BODYTEMP_COLD_DAMAGE_LIMIT, BODYTEMP_HEAT_DAMAGE_LIMIT) ? "<span class='bad'>" : "<span class='notice'>"] Temperature: [kelvinTemperatureDisplay]K ([celsiusTemperatureDisplay]&deg;C)"
 		message += "<br><span class='notice'>Heat capacity: [round(scanned.heat_capacity(), 0.01)]</span>"
 	else
 		message += "<br><span class='warning'>No gasses detected[container && !istype(container, /turf) ? " in \the [container]." : ""]!</span>"

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -80,9 +80,8 @@
 	dat += "<tr><td><b>Potency</b></td><td>[round(grown_seed.potency, 0.01)]</td></tr>"
 	dat += "</table>"
 
-	if(grown_reagents && grown_reagents.reagent_list && grown_reagents.reagent_list.len)
 	dat += "<h2>Reagent Data</h2>"
-		
+
 	if(!grown_reagents) //checking if the thing is produce or seed
 		dat += "This plant will produce: "
 		var/datum/reagent/N
@@ -135,7 +134,7 @@
 
 	dat += "It has a toxin affinity of [grown_seed.toxin_affinity] "
 	if(grown_seed.toxin_affinity < 5)
-		dat += "and will get damaged if exposed to them.<br>" 
+		dat += "and will get damaged if exposed to them.<br>"
 	else if(grown_seed.toxin_affinity > 7)
 		dat += "and will require toxins as a fluid, getting damaged if exposed to water.<br>"
 	else if(grown_seed.toxin_affinity >= 5 && grown_seed.toxin_affinity <= 7)
@@ -156,7 +155,7 @@
 		dat += "It is remarkably resistant to them.<br>"
 	else
 		dat += "It is average.<br>"
-		
+
 	if(grown_seed.consume_gasses)
 		for(var/gas in grown_seed.consume_gasses)
 			dat += "It will consume [grown_seed.consume_gasses[gas]] moles of [gas] from the environment per cycle.<br>"

--- a/code/modules/mob/dead/observer/verbs.dm
+++ b/code/modules/mob/dead/observer/verbs.dm
@@ -292,7 +292,7 @@
 			var/is_safe = gas.is_human_safe(environment[g], environment)
 			to_chat(src, "<span class='[is_safe ? "notice" : "warning"]'>[XGM.name[g]]: [round(environment[g] / total_moles * 100)]% ([round(environment.molar_density(g) * CELL_VOLUME, 0.01)] moles)</span>")
 
-		to_chat(src, "<span class='notice'>Temperature: [round(environment.temperature - T0C, 0.01)]&deg;C</span>")
+		to_chat(src, "<span class='notice'>Temperature: [environment.temperature_celsius_pretty()]&deg;C</span>")
 		to_chat(src, "<span class='notice'>Heat Capacity: [round(environment.heat_capacity() / tiles, 0.01)]</span>")
 
 /mob/dead/observer/verb/view_manfiest()


### PR DESCRIPTION
Cryotheum now operates properly in pipenets (this includes in pipes as well as canisters connected to a connector). 
Also while I was at it I slightly improved the temperature indicators for the atmospheric analyzer, pipe meter, and ghost "analyze air". It's not perfect but still better than before - shouldn't be telling you it's below absolute zero at least.

Also fixes #36304

🆑
* bugfix: Fixes gas reactions not working in pipes.
* bugfix: Fixes air alarm temperature thresholds being broken.
* tweak: Adjusts how temperatures are displayed on scanners (more precision at lower temperatures, so no more below absolute zero).