### PR TITLE
pedestale -> pedestal

### DIFF
--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -281,20 +281,20 @@
 
 /obj/item/trash/mannequin/cultify()
 	if(icon_state != "mannequin_cult_empty")
-		name = "cult mannequin pedestale"
+		name = "cult mannequin pedestal"
 		icon_state = "mannequin_cult_empty"
 
 /obj/item/trash/mannequin
-	name = "mannequin pedestale"
+	name = "mannequin pedestal"
 	icon = 'icons/obj/mannequin.dmi'
 	icon_state = "mannequin_empty"
 
 /obj/item/trash/mannequin/cult
-	name = "cult mannequin pedestale"
+	name = "cult mannequin pedestal"
 	icon_state = "mannequin_cult_empty"
 
 /obj/item/trash/mannequin/large
-	name = "cyber mannequin pedestale"
+	name = "cyber mannequin pedestal"
 	icon_state = "mannequin_cyber_empty"
 
 /obj/item/trash/byond_box


### PR DESCRIPTION
fixes #36302
[grammar]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed mannequin's trash item being called a "pedestale" instead of pedestal.