### PR TITLE
Adds a user pref to enable pixel movement

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -240,6 +240,7 @@ var/const/MAX_SAVE_SLOTS = 16
 
 	var/tgui_fancy = TRUE
 	var/fps = -1
+	var/pixel_movement = FALSE
 
 	var/client/client
 	var/saveloaded = 0
@@ -411,6 +412,8 @@ var/const/MAX_SAVE_SLOTS = 16
 	<a href='?_src_=prefs;preference=stumble'><b>[(stumble) ? "Yes" : "No"]</b></a><br>
 	<b>Pulling action:</b>
 	<a href='?_src_=prefs;preference=pulltoggle'><b>[(pulltoggle) ? "Toggle Pulling" : "Always Pull"]</b></a><br>
+	<b>Enable pixel movement:</b>
+	<a href='?_src_=prefs;preference=pixel_movement'><b>[(pixel_movement) ? "Yes" : "No"]</b></a><br>
 	<b>Solo Antag Objectives:</b>
 	<a href='?_src_=prefs;preference=antag_objectives'><b>[(antag_objectives) ? "Standard" : "Freeform"]</b></a><br>
 	<b>Say bubbles:</b>
@@ -1260,6 +1263,12 @@ Values up to 1000 are allowed.", "FPS", fps) as null|num
 					hear_instruments = !hear_instruments
 				if("pulltoggle")
 					pulltoggle = !pulltoggle
+				if("pixel_movement")
+					pixel_movement = !pixel_movement
+					if(pixel_movement)
+						client.mob?.enable_pixel_movement()
+					else
+						client.mob?.disable_pixel_movement()
 
 				if("ghost_deadchat")
 					toggles ^= CHAT_DEAD

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -135,6 +135,9 @@
 	if(client)
 		client.CAN_MOVE_DIAGONALLY = 0
 
+		if(client.prefs.pixel_movement)
+			enable_pixel_movement()
+
 	if(iscluwnebanned(src) && (timeofdeath > 0 || !iscluwne(src)))
 		log_admin("Cluwnebanned player [key_name(src)] attempted to join and was kicked.")
 		message_admins("<span class='notice'>Cluwnebanned player [key_name(src)] attempted to join and was kicked.</span>", 1)

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -12,6 +12,8 @@
 
 	remove_spell_channeling() //remove spell channeling before we log out
 
+	disable_pixel_movement()
+
 	nanomanager.user_logout(src) // this is used to clean up (remove) this user's Nano UIs
 
 	player_list -= src

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -598,7 +598,7 @@
 	target.add_fingerprint(src)
 
 /mob/proc/movement_delay()
-	return (base_movement_tally() * movement_tally_multiplier())
+	return (base_movement_tally() * movement_tally_multiplier()) * (step_size / WORLD_ICON_SIZE)
 
 /mob/proc/base_movement_tally()
 	switch(m_intent)
@@ -621,6 +621,16 @@
 			. = T.adjust_slowdown(src, .)
 		if(movement_speed_modifier)
 			. *= (1/movement_speed_modifier)
+
+/mob/proc/enable_pixel_movement()
+	appearance_flags &= ~TILE_MOVER
+	step_size = 8
+	bound_x = 8
+	bound_width = 16
+	bound_height = 16
+
+/mob/proc/disable_pixel_movement()
+	appearance_flags |= TILE_MOVER
 
 /mob/living/carbon/proc/toggle_move_intent()
 	if(legcuffed)


### PR DESCRIPTION
Pixel movement is a controversial feature, so, following our standard practice, this adds it as a client preference that defaults to off.
For the sake of fairness, diagonal movement is still disabled.

Known bug: The preference doesn't save between rounds.