### PR TITLE
fix slimepeople still showing on CMC after death

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -980,8 +980,7 @@ var/list/has_died_as_golem = list()
 
 /datum/species/slime/handle_death(var/mob/living/carbon/human/H, gibbed) //Handles any species-specific death events (such as dionaea nymph spawns).
 	H.dropBorers(gibbed)
-	for(var/atom/movable/I in H.contents)
-		I.forceMove(H.loc)
+	H.unequip_everything()
 	anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "liquify", sleeptime = 15)
 	if(!gibbed)
 		handle_slime_puddle(H)


### PR DESCRIPTION
This happened because, before this PR, slimepeople would have all of their items `forceMove()`'d from their body right before death, instead of properly unequipping their items. This means that the dead human mob inside their slime puddle still had the dropped equipment "equipped", i.e., the jumpsuit was referenced in the `w_uniform` variable.

Slimepeople now properly drop all of their equipped items.
Requested by Falcon2346.
[bugfix]

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Slimepeople no longer incorrectly show up on the Crew Monitoring Console after turning into a dead slime puddle.