### PR TITLE
Fixes Get Flat Icon Deluxe failing to grab any of the icon's overlays or underlays. Fixing Photography and Photo Booth.

### DIFF
--- a/code/libs/Get Flat Icon/Get Flat Icon Deluxe.dm
+++ b/code/libs/Get Flat Icon/Get Flat Icon Deluxe.dm
@@ -204,11 +204,11 @@ cons:
 	content_data = list(my_data)
 	var/list/underlays = to_sort:underlays
 	var/list/overlays = to_sort:overlays
-	for(var/image/underlay in underlays)
+	for(var/underlay in underlays)
 		var/list/L = get_content_image_datas(underlay,my_data, is_underlay = TRUE)
 		if (L)
 			content_data += L
-	for(var/image/overlay in overlays)
+	for(var/overlay in overlays)
 		var/list/L = get_content_image_datas(overlay,my_data)
 		if (L)
 			content_data += L


### PR DESCRIPTION
Fixes #36313

![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/ff5acad6-adff-43eb-8adb-7f4fc905d23d)
![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/b4191caa-559f-4b5f-9517-b3523164346a)


:cl:
* bugfix: Fixed Photography and Photo Booths.