### PR TITLE
Prevents cargo borgs from wrapping their modules

### DIFF
--- a/code/game/objects/items/stacks/packagewrap.dm
+++ b/code/game/objects/items/stacks/packagewrap.dm
@@ -39,6 +39,8 @@
 		return
 	if(istype(target,/obj/machinery/autoprocessor/wrapping))
 		return
+	if(issilicon(user) && target.loc == user)
+		return
 	if(!is_type_in_list(target, cannot_wrap))
 		if(istype(target, /obj/item/weapon/storage))
 			to_chat(user, "<span class='notice'>You start wrapping \the [target] with \the [src].</span>")

--- a/code/game/objects/items/stacks/packagewrap.dm
+++ b/code/game/objects/items/stacks/packagewrap.dm
@@ -39,7 +39,7 @@
 		return
 	if(istype(target,/obj/machinery/autoprocessor/wrapping))
 		return
-	if(issilicon(user) && target.loc == user)
+	if(issilicon(user) && istype(target.loc,/obj/item/weapon/robot_module))
 		return
 	if(!is_type_in_list(target, cannot_wrap))
 		if(istype(target, /obj/item/weapon/storage))
@@ -57,6 +57,8 @@
 	if(!istype(target))
 		return
 	if(istype(target,/obj/machinery/autoprocessor/wrapping))
+		return
+	if(issilicon(user) && istype(target.loc,/obj/item/weapon/robot_module))
 		return
 	if(is_type_in_list(target, cannot_wrap))
 		to_chat(user, "<span class='notice'>You can't wrap that.</span>")


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Supply borgs can no longer package wrap their modules, rendering them completely unusable.

## Why it's good
<!-- Explain why you think these changes are good. -->
Closes #32928.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Supply borgs can no longer package wrap their modules.