### PR TITLE
reduces the sporty threshold for tackling range

### DIFF
--- a/code/modules/mob/living/carbon/human/combat.dm
+++ b/code/modules/mob/living/carbon/human/combat.dm
@@ -307,7 +307,7 @@
 		var/obj/item/slowSuit = wear_suit
 		if(slowSuit.slowdown > NO_SLOWDOWN)
 			tR -= 1
-	if(reagents.get_sportiness()>=10)	//Not as easy as just a swig of sport drink
+	if(reagents.get_sportiness()>=5)
 		tR += 1
 	return max(0, tR)
 


### PR DESCRIPTION
## What this does
Reduces the sportiness check from 10 sportiness to 5 sportiness, meaning that downing a can of brawndo will give you a minor tackling range buff (+1 tile).
## Why it's good
Makes the buff actually available for players as I've genuinely never seen this feature being used, since the regularly available sporty chems (sugar, mint essence and sports drink) are too rare/weak to actually get to 10 sport.
:cl:
 * tweak: The tackling range check for sportiness is now actually reachable.