### PR TITLE
weak sport chems buff

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1844,7 +1844,7 @@ var/list/weekend_days = list("Friday", "Saturday", "Sunday")
 
 // /datum/reagent/var/sport
 #define SPORTINESS_NONE 1
-#define SPORTINESS_SUGAR 1.2
+#define SPORTINESS_SUGAR 1.5
 #define SPORTINESS_SPORTS_DRINK 5
 
 //Luck-related defines


### PR DESCRIPTION
## What this does
Slightly buffs Sugar, Mint Toxin and Mint essence (weak sport chems) by raising their sportiness from 1.2 to 1.5.
## Why it's good
Former value was too small to be noticeable.
:cl:
 * tweak: Sugar, Mint Toxin and Mint Essence now have slightly better sport-improving performance (from 1.2 to 1.5).