### PR TITLE
Fixes derelict MoMMI laws when spawning

### DIFF
--- a/code/game/machinery/mommi_spawner.dm
+++ b/code/game/machinery/mommi_spawner.dm
@@ -135,6 +135,10 @@
 		// Make the MoMMI!
 		log_admin("([user.ckey]/[user]) became a MoMMI as a ghost.")
 		var/mob/living/silicon/robot/mommi/M = new mommi_type(loc)
+		if(locked_to_zlevel)
+			M.add_ion_law("[locked_law]")
+			var/turf/T = get_turf(src)
+			M.locked_to_z = T.z
 		M.key = user.key
 
 		PostMoMMIMaking(M)
@@ -158,11 +162,6 @@
 
 	if(M.mind.special_role)
 		M.mind.store_memory("In case you look at this after being borged, the objectives are only here until I find a way to make them not show up for you, as I can't simply delete them without screwing up round-end reporting.") //>signing your shit
-
-	if(locked_to_zlevel)
-		M.add_ion_law("[locked_law]")
-		var/turf/T = get_turf(src)
-		M.locked_to_z = T.z
 
 	spawn()
 		M.Namepick()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Derelict MoMMIs will now be shown their proper list of laws when spawning.

## Why it's good
<!-- Explain why you think these changes are good. -->
Closes #29522.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Derelict MoMMIs will now be shown their unique laws when spawning.