### PR TITLE
Prevents ore processors from working as flatpacks

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -393,6 +393,9 @@
 	if(stat & (FORCEDISABLE | NOPOWER | BROKEN))
 		return
 
+	if(!isturf(loc)) //flatpack check
+		return
+
 	var/turf/in_T = get_step(src, in_dir)
 	var/turf/out_T = get_step(src, out_dir)
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Ore processing machines will no longer work while in a flatpack. Ideally this machine should be converted into one of the autoprocessor types, but this will do for now.

## Why it's good
<!-- Explain why you think these changes are good. -->
Closes #26128.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Ore processing machines will no longer work while in a flatpack.
