### PR TITLE
Fixing missing hair from the round end scoreboard and probably other places

### DIFF
--- a/code/_onclick/mindUI/adminbus.dm
+++ b/code/_onclick/mindUI/adminbus.dm
@@ -60,7 +60,7 @@
 			I.pixel_y = 38
 			I.dir = SOUTH
 			if(i <= A.passengers.len)
-				I.overlays += getFlatIcon(A.passengers[i],SOUTH,0)
+				I.overlays += getFlatIconDeluxe(sort_image_datas(get_content_image_datas(A.passengers[i])), override_dir = SOUTH)
 			overlays += I
 
 //------------------------------------------------------------

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -116,7 +116,6 @@
 		result.Insert(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(H)), override_dir = NORTH, ignore_spawn_items = TRUE),  "", dir = NORTH)
 		result.Insert(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(H)), override_dir = EAST, ignore_spawn_items = TRUE),  "", dir = EAST)
 		result.Insert(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(H)), override_dir = WEST, ignore_spawn_items = TRUE),  "", dir = WEST)
-		result.Crop(1,1,32,32)
 
 		G.fields["photo"]		= result
 		L.fields["image"]		= result

--- a/code/datums/gamemode/role/role.dm
+++ b/code/datums/gamemode/role/role.dm
@@ -326,7 +326,7 @@
 		var/icon/sprotch = icon('icons/effects/blood.dmi', "sprotch")
 		text += "<img src='data:image/png;base64,[icon2base64(sprotch)]' style='position:relative; top:10px;'/>"
 	else
-		var/icon/flat = getFlatIcon(M, SOUTH, 0, 1)
+		var/icon/flat = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(M)), override_dir = SOUTH)
 		if(M.stat == DEAD)
 			if (ishuman(M) || ismonkey(M))
 				flat.Turn(90)

--- a/code/datums/hud/account_hud.dm
+++ b/code/datums/hud/account_hud.dm
@@ -73,7 +73,7 @@
 		if(!check_HUD_visibility(perp, M))
 			continue
 		if(perp.head && istype(perp.head,/obj/item/clothing/head/tinfoil)) //Tinfoil hat? Move along.
-			S = getStaticIcon(getFlatIcon(perp))
+			S = getStaticIcon(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(perp)), override_dir = SOUTH))
 			C.images += image(S, perp, "hudstatic")
 			continue
 		var/obj/item/weapon/card/id/card = perp.get_id_card()
@@ -96,7 +96,7 @@
 					cash += bankacc.money
 				cashdisplay = "$[cash]"
 			if(cash < povertyline)
-				S = getStaticIcon(getFlatIcon(perp))
+				S = getStaticIcon(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(perp)), override_dir = SOUTH))
 				C.images += image(S, perp, "hudstatic")
 			holder.maptext = "<span class='maptext yell black_outline' style='text-align: center; vertical-align: top; color: white;'>[cashdisplay]</span>"
 			C.images += holder

--- a/code/game/gamemodes/endgame/scoreboard/department_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/department_score.dm
@@ -115,7 +115,7 @@
 	var/pai_completions = ""
 	var/completions = ""
 	for(var/mob/living/silicon/player in player_list)
-		var/icon/flat = getFlatIcon(player)
+		var/icon/flat = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(player)), override_dir = SOUTH)
 		if(istype(player, /mob/living/silicon/ai))
 			var/mob/living/silicon/ai/ai = player
 			if(ai.stat != DEAD)

--- a/code/game/gamemodes/endgame/scoreboard/misc_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/misc_score.dm
@@ -27,7 +27,7 @@
 				var/title = painting.painting_data.title
 				if(!title)
 					title = "Nameless"
-				var/icon/flat = getFlatIcon(painting)
+				var/icon/flat = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(painting	)), override_dir = SOUTH)
 				row1 += {"<td><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'></td>"}
 				row2 += {"<td>"[title]"</td>"}
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -634,27 +634,27 @@ var/datum/controller/gameticker/ticker
 	if(platinum_tier.len)
 		text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(platinum)]'> <b>Platinum Trophy</b> (never removed his clothes, kept his bomb dispenser until the end, and escaped on the shuttle):"}
 		for (var/mob/M in platinum_tier)
-			var/icon/flat = getFlatIcon(M, SOUTH, 1, 1)
+			var/icon/flat = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(M)), override_dir = SOUTH)
 			text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> <b>[M.key]</b> as <b>[M.real_name]</b>"}
 	if(gold_tier.len)
 		text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(gold)]'> <b>Gold Trophy</b> (kept his bomb dispenser until the end, and escaped on the shuttle):"}
 		for (var/mob/M in gold_tier)
-			var/icon/flat = getFlatIcon(M, SOUTH, 1, 1)
+			var/icon/flat = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(M)), override_dir = SOUTH)
 			text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> <b>[M.key]</b> as <b>[M.real_name]</b>"}
 	if(silver_tier.len)
 		text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(silver)]'> <b>Silver Trophy</b> (kept his bomb dispenser until the end, and escaped in a pod):"}
 		for (var/mob/M in silver_tier)
-			var/icon/flat = getFlatIcon(M, SOUTH, 1, 1)
+			var/icon/flat = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(M)), override_dir = SOUTH)
 			text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> <b>[M.key]</b> as <b>[M.real_name]</b>"}
 	if(bronze_tier.len)
 		text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(bronze)]'> <b>Bronze Trophy</b> (kept his bomb dispenser until the end):"}
 		for (var/mob/M in bronze_tier)
-			var/icon/flat = getFlatIcon(M, SOUTH, 1, 1)
+			var/icon/flat = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(M)), override_dir = SOUTH)
 			text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> <b>[M.key]</b> as <b>[M.real_name]</b>"}
 	if(special_tier.len)
 		text += "<br><b>Special Mention</b> to those adorable MoMMis:"
 		for (var/mob/M in special_tier)
-			var/icon/flat = getFlatIcon(M, SOUTH, 1, 1)
+			var/icon/flat = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(M)), override_dir = SOUTH)
 			text += {"<br><img class='icon' src='data:image/png;base64,[iconsouth2base64(flat)]'> <b>[M.key]</b> as <b>[M.name]</b>"}
 
 	return text

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -78,7 +78,7 @@
 			module = R.module ? "[R.modtype] Module" : "No Module Installed",
 			master = R.connected_ai,
 			emagged = R.emagged,
-			borgimage = iconsouth2base64(getFlatIcon(R)),
+			borgimage = iconsouth2base64(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(R)), override_dir = SOUTH)),
 			ref = ref(R)
 		)
 		data["cyborgs"] += list(cyborg_data)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -130,11 +130,11 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	var/icon/alpha_mask = new('icons/effects/effects.dmi', "scanline")
 	colored_holo.AddAlphaMask(alpha_mask)//Finally, let's mix in a distortion effect.
 	holo.icon = colored_holo
-	
-	var/icon/colored_ray = getFlatIcon(ray)
+
+	var/icon/colored_ray = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(ray)), override_dir = SOUTH)
 	colored_ray.ColorTone(A.holocolor)
 	ray.icon = colored_ray
-	
+
 	A.current = src
 	master = A//AI is the master.
 	use_power = MACHINE_POWER_USE_ACTIVE//Active power usage.

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -41,7 +41,7 @@
 			location = A.name || "Unknown",
 			active = M.selected ? M.selected.name : "None",
 			status = M.state,
-			mechaimage = iconsouth2base64(getFlatIcon(M)),
+			mechaimage = iconsouth2base64(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(M)), override_dir = SOUTH)),
 			log = TR.get_mecha_log(),
 			ref = ref(M)
 		)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -566,7 +566,7 @@
 	J.Shift(WEST, 13)
 	underlays += J
 	overlays += image(icon = icon, icon_state = "device")
-	rendered = getFlatIcon(src)
+	rendered = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(src)), override_dir = SOUTH)
 
 /obj/item/toy/bomb/examine(mob/user)
 	..()

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -119,11 +119,11 @@
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom/plated_food = snack
 		if (plated_food.ingredients.len)
 			var/obj/item/weapon/reagent_containers/food/snacks/ingredient = pick(plated_food.ingredients)
-			newcolor = ingredient.filling_color != "#FFFFFF" ? ingredient.filling_color : AverageColor(getFlatIcon(ingredient, ingredient.dir, 0), 1, 1)
+			newcolor = ingredient.filling_color != "#FFFFFF" ? ingredient.filling_color : AverageColor(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(ingredient)), override_dir = ingredient.dir), 1, 1)
 		else
-			newcolor = snack.filling_color != "#FFFFFF" ? snack.filling_color : AverageColor(getFlatIcon(snack, snack.dir, 0), 1, 1)
+			newcolor = snack.filling_color != "#FFFFFF" ? snack.filling_color : AverageColor(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(snack)), override_dir = snack.dir), 1, 1)
 	else
-		newcolor = snack.filling_color != "#FFFFFF" ? snack.filling_color : AverageColor(getFlatIcon(snack, snack.dir, 0), 1, 1)
+		newcolor = snack.filling_color != "#FFFFFF" ? snack.filling_color : AverageColor(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(snack)), override_dir = snack.dir), 1, 1)
 	food_overlay.color = newcolor
 	overlays += food_overlay
 
@@ -223,11 +223,11 @@
 			var/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom/plated_food = snack
 			if (plated_food.ingredients.len)
 				var/obj/item/weapon/reagent_containers/food/snacks/ingredient = pick(plated_food.ingredients)
-				newcolor = ingredient.filling_color != "#FFFFFF" ? ingredient.filling_color : AverageColor(getFlatIcon(ingredient, ingredient.dir, 0), 1, 1)
+				newcolor = ingredient.filling_color != "#FFFFFF" ? ingredient.filling_color : AverageColor(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(ingredient)), override_dir = ingredient.dir), 1, 1)
 			else
-				newcolor = snack.filling_color != "#FFFFFF" ? snack.filling_color : AverageColor(getFlatIcon(snack, snack.dir, 0), 1, 1)
+				newcolor = snack.filling_color != "#FFFFFF" ? snack.filling_color : AverageColor(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(snack)), override_dir = snack.dir), 1, 1)
 		else
-			newcolor = snack.filling_color != "#FFFFFF" ? snack.filling_color : AverageColor(getFlatIcon(snack, snack.dir, 0), 1, 1)
+			newcolor = snack.filling_color != "#FFFFFF" ? snack.filling_color : AverageColor(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(snack)), override_dir = snack.dir), 1, 1)
 		food_overlay.color = newcolor
 		overlays += food_overlay
 	else
@@ -235,11 +235,11 @@
 		if (istype(snack, /obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom))
 			var/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom/plated_food = snack
 			if (plated_food.ingredients.len)
-				food_to_load = getFlatIcon(pick(plated_food.ingredients)) // So the plate doesn't appear on the fork
+				food_to_load = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(pick(plated_food.ingredients)))) // So the plate doesn't appear on the fork
 			else
-				food_to_load = getFlatIcon(snack)
+				food_to_load = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(snack)))
 		else
-			food_to_load = getFlatIcon(snack)
+			food_to_load = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(snack)))
 		food_to_load.Scale(16,16)
 		food_overlay = image(food_to_load)
 		food_overlay.pixel_x = 8 * PIXEL_MULTIPLIER + pixel_x
@@ -371,11 +371,11 @@
 	if (istype(snack, /obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom/plated_food = snack
 		if (plated_food.ingredients.len)
-			food_to_load = getFlatIcon(pick(plated_food.ingredients)) // So the plate doesn't appear on the fork
+			food_to_load = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(pick(plated_food.ingredients)))) // So the plate doesn't appear on the fork
 		else
-			food_to_load = getFlatIcon(snack)
+			food_to_load = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(snack)))
 	else
-		food_to_load = getFlatIcon(snack)
+		food_to_load = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(snack)))
 	food_to_load.Scale(16,16)
 	food_overlay = image(food_to_load)
 	food_overlay.pixel_x = 8 * PIXEL_MULTIPLIER + pixel_x

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -127,7 +127,7 @@
 		src.icon_state = "glassbox2[locked]"
 	overlays.len = 0
 	if(occupant)
-		var/icon/occupant_icon=getFlatIcon(occupant)
+		var/icon/occupant_icon=getFlatIconDeluxe(sort_image_datas(get_content_image_datas(occupant)))
 		occupant_icon.Scale(19,19)
 		occupant_overlay = image(occupant_icon)
 		occupant_overlay.pixel_x= 8 * PIXEL_MULTIPLIER

--- a/code/game/objects/structures/stool_bed_chair_nest/guillotine.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/guillotine.dm
@@ -43,7 +43,7 @@
 			victim_head.appearance = victim.appearance
 			victim_head.transform = matrix()
 			victim_head.dir = SOUTH
-			var/icon/victim_head_icon = getFlatIcon(victim_head, cache = 0, exact = 1)
+			var/icon/victim_head_icon = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(victim_head)), override_dir = SOUTH)
 			victim_head_icon.Crop(1,23,32,32)
 			victim_head.overlays.len = 0
 			victim_head.underlays.len = 0

--- a/code/libs/Get Flat Icon/Get Flat Icon Deluxe.dm
+++ b/code/libs/Get Flat Icon/Get Flat Icon Deluxe.dm
@@ -44,9 +44,13 @@ cons:
 #define GFI_DX_MAX		13	// Remember to keep this updated should you need to keep track of more variables
 
 
-/proc/getFlatIconDeluxe(list/image_datas, var/turf/center, var/radius = 0, var/override_dir = 0, var/ignore_spawn_items = FALSE)
+/proc/getFlatIconDeluxe(list/image_datas, var/turf/center, var/radius = 0, var/override_dir = 0, var/ignore_spawn_items = FALSE, var/large_canvas = FALSE)
 
-	var/icon/flat = icon('icons/effects/224x224.dmi',"empty") // Final flattened icon
+	var/icon/flat	 // Final flattened icon
+	if (large_canvas)
+		flat = icon('icons/effects/224x224.dmi',"empty")
+	else
+		flat = icon('icons/effects/32x32.dmi', "blank")
 	var/icon/add // Icon of overlay being added
 
 	for(var/data in image_datas)

--- a/code/libs/Get Flat Icon/Get Flat Icon.dm
+++ b/code/libs/Get Flat Icon/Get Flat Icon.dm
@@ -1,4 +1,7 @@
 
+//MOSTLY DEPRECATED, USE GET FLAT ICON DELUXE INSTEAD.
+//still used somewhat by maprendering.dm
+
 /* *********************************************************************
         _____      _     ______ _       _     _____
        / ____|    | |   |  ____| |     | |   |_   _|

--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -443,7 +443,7 @@ var/global/ingredientLimit = 10
 	if(cooks_in_reagents)
 		transfer_reagents_to_food(C) //add the stuff from the machine
 	C.name = "[ingredient.name] cereal"
-	var/image/I = image(getFlatIcon(ingredient, ingredient.dir, 0))
+	var/image/I = image(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(ingredient)), override_dir = ingredient.dir))
 	I.transform *= 0.7
 	C.extra_food_overlay.overlays += I
 	C.update_icon()

--- a/code/modules/food/customizables.dm
+++ b/code/modules/food/customizables.dm
@@ -388,7 +388,7 @@
 			extra_food_overlay.overlays -= topping //thank you Comic
 		if(!fullyCustom && !stackIngredients && overlays.len)
 			extra_food_overlay.overlays -= filling //we can't directly modify the overlay, so we have to remove it and then add it again
-			var/newcolor = S.filling_color != "#FFFFFF" ? S.filling_color : AverageColor(getFlatIcon(S, S.dir, 0), 1, 1)
+			var/newcolor = S.filling_color != "#FFFFFF" ? S.filling_color : AverageColor(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(S)), override_dir = S.dir), 1, 1)
 			filling.color = BlendRGB(filling.color, newcolor, 1/ingredients.len)
 			extra_food_overlay.overlays += image(filling)
 		else
@@ -439,7 +439,7 @@
 		if(istype(S) && S.filling_color != "#FFFFFF")
 			I.color = S.filling_color
 		else
-			I.color = AverageColor(getFlatIcon(S, S.dir, 0), 1, 1)
+			I.color = AverageColor(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(S)), override_dir = S.dir), 1, 1)
 		if(stackIngredients)
 			I.pixel_y = ingredients.len * 2 * PIXEL_MULTIPLIER
 	if(fullyCustom || stackIngredients)
@@ -728,7 +728,7 @@
 				S.reagents.trans_to(src,S.reagents.total_volume)
 				ingredients += S
 				updateName()
-				var/newcolor = S.filling_color != "#FFFFFF" ? S.filling_color : AverageColor(getFlatIcon(S, S.dir, 0), 1, 1)
+				var/newcolor = S.filling_color != "#FFFFFF" ? S.filling_color : AverageColor(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(S)), override_dir = S.dir), 1, 1)
 				filling.color = BlendRGB(filling.color, newcolor, 1/ingredients.len)
 				update_icon()
 		else
@@ -768,7 +768,7 @@
 	if(S.filling_color != "#FFFFFF")
 		I.color = S.filling_color
 	else
-		I.color = AverageColor(getFlatIcon(S, S.dir, 0), 1, 1)
+		I.color = AverageColor(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(S)), override_dir = S.dir), 1, 1)
 	return I
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/customizable/Destroy()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -364,7 +364,7 @@
 
 	var/icon/res = get_base_photo_icon()
 
-	var/icon/img = getFlatIconDeluxe(sorted_data, center, (photo_size-1)/2)
+	var/icon/img = getFlatIconDeluxe(sorted_data, center, (photo_size-1)/2, large_canvas = TRUE)
 	res.Blend(img,ICON_OVERLAY)
 
 	return res
@@ -868,7 +868,6 @@
 	result.Insert(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(L)), override_dir = NORTH),  "", dir = NORTH)
 	result.Insert(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(L)), override_dir = EAST),  "", dir = EAST)
 	result.Insert(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(L)), override_dir = WEST),  "", dir = WEST)
-	result.Crop(1,1,32,32)
 	return result
 
 /obj/machinery/photobooth/proc/print_photo(var/mob/living/L)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -105,7 +105,7 @@
 
 				if (istype(TrashItem, /obj/item/trash/plate))
 					var/obj/item/trash/plate/P = TrashItem
-					P.trash_color = filling_color != "#FFFFFF" ? filling_color : AverageColor(getFlatIcon(src, dir, 0), 1, 1)
+					P.trash_color = filling_color != "#FFFFFF" ? filling_color : AverageColor(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(src)), override_dir = dir	), 1, 1)
 					P.update_icon()
 
 				if(ismob(old_loc))
@@ -417,7 +417,7 @@
 			C.icon_state = crumb_icon
 			C.name = crumb_icon
 			C.dir = pick(cardinal)
-			C.color = filling_color != "#FFFFFF" ? filling_color : AverageColor(getFlatIcon(src, dir, 0), 1, 1)
+			C.color = filling_color != "#FFFFFF" ? filling_color : AverageColor(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(src)), override_dir = dir), 1, 1)
 			if (random_filling_colors?.len > 0)
 				filling_color = pick(random_filling_colors)
 		if (virus2?.len)

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -206,7 +206,7 @@ var/list/special_fruits = list()
 		if(filling_color != "#FFFFFF")
 			S.color = filling_color
 		else
-			S.color = AverageColor(getFlatIcon(src, src.dir, 0), 1, 1)
+			S.color = AverageColor(getFlatIconDeluxe(sort_image_datas(get_content_image_datas(src)), override_dir = dir), 1, 1)
 		S.name = "[seed.seed_name] smudge"
 	if(seed.biolum && seed.biolum_colour)
 		S.set_light(1, l_color = seed.biolum_colour)

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -277,7 +277,7 @@ For the main html chat area
 	if (isicon(obj))
 		return bicon(obj)
 
-	var/icon/I = getFlatIcon(obj)
+	var/icon/I = getFlatIconDeluxe(sort_image_datas(get_content_image_datas(obj)))
 	return bicon(I)
 
 /proc/to_chat(target, message)
@@ -369,6 +369,6 @@ For the main html chat area
 		to_chat(M, message)
 	log_game("DEADCHAT: [message]")
 	return 1
-		
+
 /datum/log	//exists purely to capture to_chat() output
 	var/log = ""


### PR DESCRIPTION
The simple explanation is that getFlatIcon() never checked whether overlays had overlays themselves, and since #36236, hair and facial hair are precisely that. my good little getFlatIconDeluxe() however handles nested overlays just fine.

Thus, getFlatIcon() has been mostly phased out, and replaced by getFlatIconDeluxe(), except in some maprenderer files since I assume it's probably less costly in those instances.

Fixes #36315

:cl:
* bugfix: Fixed people missing their hair and facial hair on the round end scoreboard.