### PR TITLE
prevent malfunctioning AI from hacking supermatters

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -583,7 +583,7 @@
 	set_frequency(O.frequency)
 	return 1
 
-/obj/machinery/supermatter/malfhack_valid(var/mob/living/silicon/malf)
+/obj/machinery/power/supermatter/malfhack_valid(var/mob/living/silicon/malf)
 	if(..())
 		to_chat(malf, "<span class='warning'>You cannot hack the [src] as it has nothing for you to interface with!</span>")
 		return FALSE

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -681,3 +681,8 @@
 		screen = !screen
 
 	return TRUE
+
+/obj/machinery/computer/supermatter/malfhack_valid(var/mob/living/silicon/malf)
+	if(..())
+		to_chat(malf, "<span class='warning'>You cannot hack the [src] as it has nothing for you to interface with!</span>")
+		return FALSE

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -583,6 +583,11 @@
 	set_frequency(O.frequency)
 	return 1
 
+/obj/machinery/supermatter/malfhack_valid(var/mob/living/silicon/malf)
+	if(..())
+		to_chat(malf, "<span class='warning'>You cannot hack the [src] as it has nothing for you to interface with!</span>")
+		return FALSE
+
 /obj/machinery/computer/supermatter
 	name = "supermatter monitoring computer"
 	desc = "Monitors ambient temperature and stability of a linked shard to provide early warning information regarding delamination. Can be linked up to supermatter with a matching frequency and id_tag using a multitool. While using a multitool on supermatter is safe, Nanotrasen accepts no responsibility or liability for sudden rushes of wind or radiation poisoning."
@@ -681,8 +686,3 @@
 		screen = !screen
 
 	return TRUE
-
-/obj/machinery/computer/supermatter/malfhack_valid(var/mob/living/silicon/malf)
-	if(..())
-		to_chat(malf, "<span class='warning'>You cannot hack the [src] as it has nothing for you to interface with!</span>")
-		return FALSE

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -585,7 +585,7 @@
 
 /obj/machinery/power/supermatter/malfhack_valid(var/mob/living/silicon/malf)
 	if(..())
-		to_chat(malf, "<span class='warning'>You cannot hack the [src] as it has nothing for you to interface with!</span>")
+		to_chat(malf, "<span class='warning'>You cannot hack \the [src] as it has nothing for you to interface with!</span>")
 		return FALSE
 
 /obj/machinery/computer/supermatter


### PR DESCRIPTION
## What this does
Currently, malfunctioning AIs can hack supermatters and supermatter shards like any other machine, and similarly turn them off (???) and blow them up, also like any other machine. Aside from the fact that this doesn't even make any sense as it's not an electronic device connected to the grid at all, it's also clearly unintended. In fact, the reason why it has these abilities at all is because all machines have a `hack_abilities` list with "turn on/off" and "blow up" as the defaults.

When you "explode" a supermatter, it's a single tile explosion with no interactions. See this demonstration:

![FpU1dxYzoL](https://github.com/vgstation-coders/vgstation13/assets/26285377/4317c4a0-7f80-4066-8404-b496c7f568e2)

This is rather lame, isn't it? While I welcome someone to dream up a new malf AI interaction with the supermatter, presently this oversight in the malf hacking code basically allows an AI to delete any supermatter for free, and possibly irreversibly grief its power output by "turning it off".


## Why it's good
The current interaction between malfunctioning AI's and the supermatter shard is an oversight at best, and is a very unsatisfying way to antagonize at worst, by straight up deleting the shard. Again, someone else is more than welcome to add a unique interaction here, but until that time, the ability to hack the shard should be disabled.

[oversight]

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Malfunctioning AI's can no longer hack a supermatter and delete it with a lackluster explosion.