### PR TITLE
Prevents the Station Alerts Pager for issuing alerts for non-station areas

### DIFF
--- a/code/game/objects/items/devices/pager.dm
+++ b/code/game/objects/items/devices/pager.dm
@@ -22,12 +22,12 @@ var/list/pager_list = list()
 	var/last_alert_time = 0
 	var/alert_delay = 10 SECONDS
 	var/last_alert = ""
-	var/covered_areas
+	var/list/covered_areas = list()
 
 /obj/item/device/pager/New()
 	..()
 	pager_list += src
-	var/blockedtypes = typesof(/area/research_outpost,/area/mine,/area/derelict,/area/djstation,/area/vox_trading_post,/area/tcommsat)
+	var/blockedtypes = typesof(/area/derelict,/area/djstation,/area/vox_trading_post,/area/tcommsat)
 	for(var/atype in (typesof(/area) - blockedtypes))
 		var/area/B = locate(atype) in areas
 		covered_areas += B

--- a/code/game/objects/items/devices/pager.dm
+++ b/code/game/objects/items/devices/pager.dm
@@ -22,10 +22,15 @@ var/list/pager_list = list()
 	var/last_alert_time = 0
 	var/alert_delay = 10 SECONDS
 	var/last_alert = ""
+	var/covered_areas
 
 /obj/item/device/pager/New()
 	..()
 	pager_list += src
+	var/blockedtypes = typesof(/area/research_outpost,/area/mine,/area/derelict,/area/djstation,/area/vox_trading_post,/area/tcommsat)
+	for(var/atype in (typesof(/area) - blockedtypes))
+		var/area/B = locate(atype) in areas
+		covered_areas += B
 	//default pager settings
 	prefs["Power"] = "quiet"
 	prefs["Fire"] = "loud"
@@ -107,6 +112,8 @@ var/list/pager_list = list()
 	update_icon()
 
 /obj/item/device/pager/proc/triggerAlarm(var/class, area/A)
+	if(!(A in covered_areas))
+		return
 	if(muted)
 		return
 	var/alarmlevel = prefs[class]


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Stops the Station Alerts Pager from alarming if power is lost off-station (derelict, outpost, mine, etc).

## Why it's good
<!-- Explain why you think these changes are good. -->
Closes #36326.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: The Station Alerts Pager will no longer alert you when off-station areas have alarms.
