### PR TITLE
Makes suicides show proper unrevivable message on scanners and HUDs

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -756,10 +756,12 @@
 	return TRUE
 
 
-/mob/living/carbon/proc/check_can_revive() // doesn't check suicides
+/mob/living/carbon/proc/check_can_revive()
 	if (!isDead())
 		return CAN_REVIVE_NO
 	if (!mind)
+		return CAN_REVIVE_NO
+	if (mind.suicidng)
 		return CAN_REVIVE_NO
 	if (client)
 		return CAN_REVIVE_IN_BODY

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -761,7 +761,7 @@
 		return CAN_REVIVE_NO
 	if (!mind)
 		return CAN_REVIVE_NO
-	if (mind.suicidng)
+	if (mind.suiciding)
 		return CAN_REVIVE_NO
 	if (client)
 		return CAN_REVIVE_IN_BODY


### PR DESCRIPTION
[bugfix][consistency]

## What this does
Closes #36260.

## Changelog
:cl:
 * bugfix: Suicides now properly show corpses as unrevivable on health analysers and medHUDs