### PR TITLE
Proper welder and drill deconstruction of false walls

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -424,7 +424,7 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 		return BORDER_2NDTILE
 	if (locate(/obj/structure/falsewall) in T2)
 		return BORDER_2NDTILE
-	if (locate(/obj/structure/falserwall) in T2)
+	if (locate(/obj/structure/falsewall/rwall) in T2)
 		return BORDER_2NDTILE
 
 	return BORDER_NONE

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -424,8 +424,6 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 		return BORDER_2NDTILE
 	if (locate(/obj/structure/falsewall) in T2)
 		return BORDER_2NDTILE
-	if (locate(/obj/structure/falsewall/rwall) in T2)
-		return BORDER_2NDTILE
 
 	return BORDER_NONE
 

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -214,9 +214,19 @@
 					"<span class='warning'>You hear welding noises.</span>")
 					dismantle()
 
-		if( istype(W, /obj/item/weapon/pickaxe) )
-			var/obj/item/weapon/pickaxe/used_pick = W
-			if(used_pick.diggables & DIG_WALLS)
+		if(istype(W, /obj/item/weapon/pickaxe))
+			var/obj/item/weapon/pickaxe/PK = W
+			if(!(PK.diggables & DIG_WALLS))
+				return
+			if(mineral == "diamond")
+				return
+
+			user.visible_message("<span class='warning'>[user] begins [PK.drill_verb] straight into \the [src].</span>", \
+			"<span class='notice'>You begin [PK.drill_verb] straight into \the [src].</span>")
+			PK.playtoolsound(src, 100)
+			if(do_after(user, src, (MINE_DURATION * PK.toolspeed) * 10))
+				user.visible_message("<span class='notice'>[user]'s [PK] tears though the last of \the [src], leaving nothing but a girder.</span>", \
+				"<span class='notice'>Your [PK] tears though the last of \the [src], leaving nothing but a girder.</span>")
 				dismantle()
 	else
 		to_chat(user, "<span class='notice'>You can't reach, close it first!</span>")
@@ -236,7 +246,10 @@
 		var/M = text2path("/obj/item/stack/sheet/mineral/[mineral]")
 		if(M)
 			new M(T, 2)
-	new /obj/structure/girder/displaced(T, 2)
+	if(reinforced)
+		new /obj/structure/girder/reinforced/displaced(T)
+	else
+		new /obj/structure/girder/displaced(T)
 	qdel(src)
 
 /obj/structure/falsewall/suicide_act(var/mob/living/user)
@@ -255,11 +268,9 @@
 /obj/structure/falsewall/rwall
 	name = "reinforced wall"
 	desc = "A huge chunk of reinforced metal and anchored rods used to separate rooms and keep all but the most equipped crewmen out."
-	icon = 'icons/turf/walls.dmi'
 	icon_state = "r_wall"
 	density = 1
 	opacity = 1
-	anchored = 1
 	reinforced = 1
 
 /*

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -238,17 +238,16 @@
 		return
 	if(reinforced)
 		new /obj/item/stack/sheet/plasteel(T, 2)
-	if(mineral == "metal")
-		new /obj/item/stack/sheet/metal(T, 2)
-	else if(mineral == "wood")
-		new /obj/item/stack/sheet/wood(T, 2)
-	else
-		var/M = text2path("/obj/item/stack/sheet/mineral/[mineral]")
-		if(M)
-			new M(T, 2)
-	if(reinforced)
 		new /obj/structure/girder/reinforced/displaced(T)
 	else
+		if(mineral == "metal")
+			new /obj/item/stack/sheet/metal(T, 2)
+		else if(mineral == "wood")
+			new /obj/item/stack/sheet/wood(T, 2)
+		else
+			var/M = text2path("/obj/item/stack/sheet/mineral/[mineral]")
+			if(M)
+				new M(T, 2)
 		new /obj/structure/girder/displaced(T)
 	qdel(src)
 

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -104,6 +104,7 @@
 	desc = "A huge chunk of metal used to separate rooms."
 	anchored = 1
 	icon = 'icons/turf/walls.dmi'
+	var/reinforced = 0
 	var/mineral = "metal"
 	var/opening = 0
 	is_on_mesons = TRUE
@@ -113,14 +114,12 @@
 	var/static/list/smoothables = list(
 		/turf/simulated/wall,
 		/obj/structure/falsewall,
-		/obj/structure/falserwall,
 	)
 	return smoothables
 
 /obj/structure/falsewall/closed
 	density = 1
 	opacity = 1
-
 
 /obj/structure/falsewall/examine(var/mob/user)
 	..()
@@ -137,19 +136,15 @@
 
 		for(var/obj/structure/falsewall/W in range(temploc,1))
 			W.relativewall()
-
-		for(var/obj/structure/falserwall/W in range(temploc,1))
-			W.relativewall()
 	..()
-
 
 /obj/structure/falsewall/relativewall()
 
 	if(!density)
-		icon_state = "[mineral]fwall_open"
+		icon_state = reinforced ? "frwall_open" : "[mineral]fwall_open"
 		return
 
-	icon_state = "[mineral][..()]"
+	icon_state = "[reinforced ? "rwall" : mineral][..()]"
 
 /obj/structure/falsewall/attack_ai(mob/user as mob)
 	if(isMoMMI(user))
@@ -160,11 +155,12 @@
 	if(opening)
 		return
 
+	var/wallword = reinforced ? "frwall" : "[mineral]fwall"
 	if(density)
 		opening = 1
-		icon_state = "[mineral]fwall_open"
+		icon_state = "[wallword]_open"
 		update_meson_image()
-		flick("[mineral]fwall_opening", src)
+		flick("[wallword]_opening", src)
 		loc.mouse_opacity = 1
 		sleep(5)
 		setDensity(FALSE)
@@ -172,8 +168,8 @@
 		opening = 0
 	else
 		opening = 1
-		flick("[mineral]fwall_closing", src)
-		icon_state = "[mineral]0"
+		flick("[wallword]_closing", src)
+		icon_state = reinforced ? "r_wall" : "[mineral]0"
 		setDensity(TRUE)
 		sleep(5)
 		set_opacity(1)
@@ -181,14 +177,6 @@
 		opening = 0
 		loc.mouse_opacity = 0
 		update_meson_image()
-
-/obj/structure/falsewall/update_icon()//Calling icon_update will refresh the smoothwalls if it's closed, otherwise it will make sure the icon is correct if it's open
-	..()
-	if(density)
-		icon_state = "[mineral]0"
-		src.relativewall()
-	else
-		icon_state = "[mineral]fwall_open"
 
 /obj/structure/falsewall/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(opening)
@@ -202,39 +190,54 @@
 			return
 		if(W.is_screwdriver(user))
 			user.visible_message("[user] tightens some bolts on the wall.", "You tighten the bolts on the wall.")
+			W.playtoolsound(T, 50)
 			if(!mineral || mineral == "metal")
-				T.ChangeTurf(/turf/simulated/wall)
+				T.ChangeTurf(text2path("/turf/simulated/wall/[reinforced ? "r_wall" : ""]"))
 			else
 				T.ChangeTurf(text2path("/turf/simulated/wall/mineral/[mineral]"))
 			qdel(src)
 
-		if( iswelder(W) )
+		if(iswelder(W))
 			var/obj/item/tool/weldingtool/WT = W
-			if(WT.welding )
-				if(!mineral)
-					T.ChangeTurf(/turf/simulated/wall)
-				else
-					T.ChangeTurf(text2path("/turf/simulated/wall/mineral/[mineral]"))
-				if(mineral != "plasma")//Stupid shit keeps me from pushing the attackby() to plasma walls -Sieve
-					T = get_turf(src)
-					T.attackby(W,user)
-				qdel(src)
+			if(WT.isOn() && WT.get_fuel() >= 1)
+				user.visible_message("<span class='warning'>[user] begins slicing through \the [src]'s outer plating.</span>", \
+				"<span class='notice'>You begin slicing through \the [src]'s outer plating.</span>", \
+				"<span class='warning'>You hear welding noises.</span>")
+				playsound(src, 'sound/items/Welder.ogg', 100, 1)
+
+				if(WT.do_weld(user, src, 100, 1))
+					if(!istype(src))
+						return
+					playsound(src, 'sound/items/Welder.ogg', 100, 1)
+					user.visible_message("<span class='warning'>[user] slices through \the [src]'s outer plating.</span>", \
+					"<span class='notice'>You slice through \the [src]'s outer plating.</span>", \
+					"<span class='warning'>You hear welding noises.</span>")
+					dismantle()
+
+		if( istype(W, /obj/item/weapon/pickaxe) )
+			var/obj/item/weapon/pickaxe/used_pick = W
+			if(used_pick.diggables & DIG_WALLS)
+				dismantle()
 	else
 		to_chat(user, "<span class='notice'>You can't reach, close it first!</span>")
 
-	if( istype(W, /obj/item/weapon/pickaxe) )
-		var/obj/item/weapon/pickaxe/used_pick = W
-		if(!(used_pick.diggables & DIG_WALLS))
-			return
-		var/turf/T = get_turf(src)
-		if(!mineral)
-			T.ChangeTurf(/turf/simulated/wall)
-		else
-			T.ChangeTurf(text2path("/turf/simulated/wall/mineral/[mineral]"))
-		if(mineral != "plasma")
-			T = get_turf(src)
-			T.attackby(W,user)
-		qdel(src)
+
+/obj/structure/falsewall/proc/dismantle()
+	var/turf/T = get_turf(src)
+	if(!T)
+		return
+	if(reinforced)
+		new /obj/item/stack/sheet/plasteel(T, 2)
+	if(mineral == "metal")
+		new /obj/item/stack/sheet/metal(T, 2)
+	else if(mineral == "wood")
+		new /obj/item/stack/sheet/wood(T, 2)
+	else
+		var/M = text2path("/obj/item/stack/sheet/mineral/[mineral]")
+		if(M)
+			new M(T, 2)
+	new /obj/structure/girder/displaced(T, 2)
+	qdel(src)
 
 /obj/structure/falsewall/suicide_act(var/mob/living/user)
 	if(density)
@@ -249,7 +252,7 @@
  * False R-Walls
  */
 
-/obj/structure/falserwall	// why isn't this a child type?
+/obj/structure/falsewall/rwall
 	name = "reinforced wall"
 	desc = "A huge chunk of reinforced metal and anchored rods used to separate rooms and keep all but the most equipped crewmen out."
 	icon = 'icons/turf/walls.dmi'
@@ -257,132 +260,7 @@
 	density = 1
 	opacity = 1
 	anchored = 1
-	var/mineral = "metal"
-	var/opening = 0
-	is_on_mesons = TRUE
-
-/obj/structure/falserwall/examine(var/mob/user)
-	..()
-	if(Adjacent(user))
-		to_chat(user, "<span class='rose'>Now that you're standing close to it, that wall appears a bit odd.</span>")
-
-/obj/structure/falserwall/canSmoothWith()
-	var/static/list/smoothables = list(
-		/turf/simulated/wall,
-		/obj/structure/falsewall,
-		/obj/structure/falserwall,
-	)
-	return smoothables
-
-/obj/structure/falserwall/Destroy()
-	var/temploc = src.loc
-	loc.mouse_opacity = 1
-
-	spawn(10)
-		for(var/turf/simulated/wall/W in range(temploc,1))
-			W.relativewall()
-
-		for(var/obj/structure/falsewall/W in range(temploc,1))
-			W.relativewall()
-
-		for(var/obj/structure/falserwall/W in range(temploc,1))
-			W.relativewall()
-	..()
-
-/obj/structure/falserwall/Destroy()
-
-	var/temploc = src.loc
-	loc.mouse_opacity = 1
-
-	spawn(10)
-		for(var/turf/simulated/wall/W in range(temploc,1))
-			W.relativewall()
-
-		for(var/obj/structure/falsewall/W in range(temploc,1))
-			W.relativewall()
-
-		for(var/obj/structure/falserwall/W in range(temploc,1))
-			W.relativewall()
-	..()
-
-
-/obj/structure/falserwall/attack_ai(mob/user as mob)
-	if(isMoMMI(user))
-		src.add_hiddenprint(user)
-		attack_hand(user)
-
-/obj/structure/falserwall/attack_hand(mob/user as mob)
-	if(opening)
-		return
-
-	if(density)
-		opening = 1
-		// Open wall
-		icon_state = "frwall_open"
-		update_meson_image()
-		flick("frwall_opening", src)
-		loc.mouse_opacity = 1
-		sleep(5)
-		setDensity(FALSE)
-		set_opacity(0)
-		opening = 0
-	else
-		opening = 1
-		icon_state = "r_wall"
-		flick("frwall_closing", src)
-		setDensity(TRUE)
-		sleep(5)
-		set_opacity(1)
-		relativewall()
-		opening = 0
-		loc.mouse_opacity = 0
-		update_meson_image()
-
-/obj/structure/falserwall/relativewall()
-
-	if(!density)
-		icon_state = "frwall_open"
-		return
-	icon_state = "rwall[..()]"
-
-/obj/structure/falserwall/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(opening)
-		to_chat(user, "<span class='warning'>You must wait until the door has stopped moving.</span>")
-		return
-
-	if(W.is_screwdriver(user))
-		var/turf/T = get_turf(src)
-		user.visible_message("[user] tightens some bolts on the r wall.", "You tighten the bolts on the wall.")
-		T.ChangeTurf(/turf/simulated/wall/r_wall) //Why not make rwall?
-		qdel(src)
-
-	if( iswelder(W) )
-		var/obj/item/tool/weldingtool/WT = W
-		if( WT.remove_fuel(0,user) )
-			var/turf/T = get_turf(src)
-			T.ChangeTurf(/turf/simulated/wall)
-			T = get_turf(src)
-			T.attackby(W,user)
-			qdel(src)
-
-	else if( istype(W, /obj/item/weapon/pickaxe) )
-		var/obj/item/weapon/pickaxe/used_pick = W
-		if(!(used_pick.diggables & DIG_WALLS))
-			return
-		var/turf/T = get_turf(src)
-		T.ChangeTurf(/turf/simulated/wall)
-		T = get_turf(src)
-		T.attackby(W,user)
-		qdel(src)
-
-/obj/structure/falserwall/suicide_act(var/mob/living/user)
-	if(density)
-		attack_hand(user)
-		sleep(15)
-	user.forceMove(get_turf(src))
-	attack_hand(user)
-	to_chat(viewers(user), "<span class='danger'>[user] is crushing \himself with the [src]! It looks like \he's trying to commit suicide.</span>")
-	return(SUICIDE_ACT_BRUTELOSS)
+	reinforced = 1
 
 /*
  * Uranium Falsewalls

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -236,7 +236,7 @@
 						S.use(use_amount)
 						user.visible_message("<span class='warning'>[user] creates a false reinforced wall!</span>", \
 						"<span class='notice'>You create a false reinforced wall. Push on it to open or close the passage.</span>")
-						var/obj/structure/falserwall/FW = new /obj/structure/falserwall(src.loc)
+						var/obj/structure/falsewall/rwall/FW = new /obj/structure/falsewall/rwall(src.loc)
 						FW.add_hiddenprint(user)
 						FW.add_fingerprint(user)
 						qdel(src)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -450,6 +450,11 @@
 	icon_state = "reinforced"
 	state = 2
 
+/obj/structure/girder/reinforced/displaced
+	name = "displaced reinforced girder"
+	icon_state = "r_displaced"
+	anchored = 0
+
 /obj/structure/cultgirder
 	name = "cult girder"
 	icon = 'icons/obj/cult.dmi'

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -37,7 +37,6 @@
 	var/static/list/smoothables = list(
 		/turf/simulated/wall,
 		/obj/structure/falsewall,
-		/obj/structure/falsewall/rwall,
 	)
 	return smoothables
 

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -37,7 +37,7 @@
 	var/static/list/smoothables = list(
 		/turf/simulated/wall,
 		/obj/structure/falsewall,
-		/obj/structure/falserwall,
+		/obj/structure/falsewall/rwall,
 	)
 	return smoothables
 

--- a/maps/randomvaults/assistantslair.dmm
+++ b/maps/randomvaults/assistantslair.dmm
@@ -28,7 +28,7 @@
 /area/vault/assistantlair)
 "ag" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/falserwall,
+/obj/structure/falsewall/rwall,
 /turf/simulated/floor/plating,
 /area/vault/assistantlair)
 "ah" = (
@@ -214,7 +214,7 @@
 /turf/simulated/floor/plating,
 /area/vault/assistantlair)
 "aM" = (
-/obj/structure/falserwall,
+/obj/structure/falsewall/rwall,
 /turf/simulated/floor/plating,
 /area/vault/assistantlair)
 "aN" = (
@@ -506,7 +506,7 @@
 /turf/simulated/floor/wood,
 /area/vault/assistantlair)
 "bH" = (
-/obj/structure/falserwall,
+/obj/structure/falsewall/rwall,
 /turf/simulated/floor/wood,
 /area/vault/assistantlair)
 "bI" = (

--- a/maps/randomvaults/dungeons/keycard_vault_normal.dmm
+++ b/maps/randomvaults/dungeons/keycard_vault_normal.dmm
@@ -63,7 +63,7 @@
 /turf/simulated/floor/plating,
 /area/vault/keycard)
 "M" = (
-/obj/structure/falserwall,
+/obj/structure/falsewall/rwall,
 /turf/simulated/floor/plating,
 /area/vault/keycard)
 "N" = (

--- a/maps/randomvaults/fastfoodjoint.dmm
+++ b/maps/randomvaults/fastfoodjoint.dmm
@@ -2419,7 +2419,7 @@
 	locked = 1;
 	req_access_txt = "53"
 	},
-/obj/structure/falserwall/doorobscurer,
+/obj/structure/falsewall/rwall/doorobscurer,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},

--- a/maps/randomvaults/meteorlogical_station.dmm
+++ b/maps/randomvaults/meteorlogical_station.dmm
@@ -347,7 +347,7 @@
 /turf/simulated/floor/wood,
 /area/vault/meteorlogical)
 "bc" = (
-/obj/structure/falserwall,
+/obj/structure/falsewall/rwall,
 /turf/simulated/floor/plating,
 /area/vault/meteorlogical)
 "bd" = (

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -1027,7 +1027,7 @@
 /obj/item/device/pda/clown/broken/attack_self(mob/user)
 	INVOKE_EVENT(src, /event/item_attack_self, "user" = user) // Minimalist version of original function
 
-/obj/structure/falserwall/doorobscurer
+/obj/structure/falsewall/rwall/doorobscurer
 	layer = ABOVE_DOOR_LAYER
 
 /mob/living/simple_animal/hostile/retaliate/cookbot


### PR DESCRIPTION
[bugfix][consistency][tweak]

## What this does
Closes #36284.
compresses the separate rwall object into a subtype

## Changelog
:cl:
 * bugfix: Reinforced false walls can now be taken apart by a welder.
 * tweak: Deconstructing false walls (and reinforced false walls) now has a delay like normal walls.