### PR TITLE
April Normal Day

### DIFF
--- a/__DEFINES/dates.dm
+++ b/__DEFINES/dates.dm
@@ -8,6 +8,7 @@
 #define ST_PATRICKS_DAY "St. Patrick's Day"
 #define EASTER "Easter"
 #define APRIL_FOOLS_DAY "April Fool's Day"
+#define APRIL_NORMAL_DAY "Normal Day"
 #define AUTISM_AWARENESS_DAY "Autism Awareness Day"
 #define FOUR_TWENTY "Four-Twenty"
 #define EARTH_DAY "Earth Day"

--- a/code/game/gamemodes/events/holidays/Holidays.dm
+++ b/code/game/gamemodes/events/holidays/Holidays.dm
@@ -43,7 +43,7 @@ var/global/Holiday = null
 
 		if(4) // Apr
 			if(DD != 1 && time2text(world.timeofday, "DDD") == "Sun") //no idea what would happen if april fools gets set twice so we check just in case
-				current_holidays += APRIL_FOOLS_DAY
+				current_holidays += list(APRIL_FOOLS_DAY, APRIL_NORMAL_DAY, APRIL_NORMAL_DAY, APRIL_NORMAL_DAY, APRIL_NORMAL_DAY, APRIL_NORMAL_DAY, APRIL_NORMAL_DAY, APRIL_NORMAL_DAY, APRIL_NORMAL_DAY, APRIL_NORMAL_DAY)
 			switch(DD)
 				if(1)
 					current_holidays += APRIL_FOOLS_DAY


### PR DESCRIPTION
## What this does
This adds April Normal Day, a holiday that's normal. It has no effect on the game other than wishing you a happy day when the round starts. This has a 9/10 chance of happening on any Sunday in April. This means that April's Fool's day only has a 1/10 chance of happening on Sundays on April if it isn't already April 1st. Compiled and tested locally.

## Why it's good
This allows us to keep more fools nonsense while still allowing higher pop Sundays to actually function as normal through April more often than not. An alternative to #36339

## Changelog
:cl:
 * rscdel: Reduced April's Fools day to 1/10 chance on April Sundays that aren't April 1st

