### PR TITLE
partial revert of #36066

### DIFF
--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -259,7 +259,6 @@
 	if(build_all && istype(selected, /datum/rcd_schematic/pipe))
 		var/datum/rcd_schematic/pipe/our_schematic = selected //typecast
 		if(our_schematic.layer) // this is needed because disposal pipe schematic datums are retarded
-			var/oldlayer=data["pipe_layer"] //why is this variable not just part of the RPD???
 			for(var/layer in 1 to 5)
 				busy  = TRUE // Busy to prevent switching schematic while it's in use.
 				our_schematic.set_layer(layer)
@@ -278,9 +277,6 @@
 							to_chat(user, "<span class='warning'>\the [src]'s error light flickers.</span>")
 
 				busy = FALSE
-				data["pipe_layer"]=oldlayer
-			data["pipe_layer"]=oldlayer
-			our_schematic.set_layer(oldlayer)
 			return 1
 
 	busy  = TRUE // Busy to prevent switching schematic while it's in use.


### PR DESCRIPTION
[bugfix]

## What this does
closes #36325 by removing some code added in #36066
removes a bug where layers would get messed up due to the RPD trying to remember your previous layer.
remembering layers when swapping to/from multilayer mode is a far lower priority than the multilayer mode working correctly.

## Changelog
:cl:
 * rscdel: the RPD will no longer try to remember which layer you selected when swapping from multilayer mode, as it led to severe issues that broke the RPD