### PR TITLE
Fixes certain objects not affecting contents inside when hit by explosions

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -352,28 +352,11 @@
 	interact(user)
 
 /obj/machinery/sleeper/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			for(var/atom/movable/A as mob|obj in src)
-				A.forceMove(loc)
-				ex_act(severity)
-			qdel(src)
-			return
-		if(2.0)
-			if(prob(50))
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(loc)
-					ex_act(severity)
-				qdel(src)
-				return
-		if(3.0)
-			if(prob(25))
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(loc)
-					ex_act(severity)
-				qdel(src)
-				return
-	return
+	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+		for(var/atom/movable/A as mob|obj in src)
+			A.forceMove(loc)
+			A.ex_act(severity)
+		qdel(src)
 
 /obj/machinery/sleeper/emp_act(severity)
 	if(stat & (BROKEN|NOPOWER|FORCEDISABLE))

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -270,29 +270,11 @@
 	return
 
 /obj/machinery/bodyscanner/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			for(var/atom/movable/A as mob|obj in src)
-				A.forceMove(loc)
-				ex_act(severity)
-			qdel(src)
-			return
-		if(2.0)
-			if(prob(50))
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(loc)
-					ex_act(severity)
-				qdel(src)
-				return
-		if(3.0)
-			if(prob(25))
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(loc)
-					ex_act(severity)
-				qdel(src)
-				return
-		else
-	return
+	if (prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+		for(var/atom/movable/A as mob|obj in src)
+			A.forceMove(loc)
+			A.ex_act(severity)
+		qdel(src)
 
 /obj/machinery/bodyscanner/blob_act()
 	if(prob(50))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -331,42 +331,19 @@
 	qdel(src)
 	return new_closet
 
-// this should probably use dump_contents()
 /obj/structure/closet/ex_act(severity)
 	var/obj/item/weapon/circuitboard/airlock/E
-	switch(severity)
-		if(1)
-			broken = 1
-			if(has_electronics)//If it's got electronics, generate them/pull them out
-				E = dump_electronics()
-				E.forceMove(src)
-			for(var/atom/movable/A in src)//pulls everything else out of the locker and hits it with an explosion
-				A.forceMove(src.loc)
-				A.ex_act(severity++)
-			dump_contents()
-			qdel(src)
-		if(2)
-			if(prob(50))
-				broken = 1
-				if(has_electronics)
-					E = dump_electronics()
-					E.forceMove(src)
-				for (var/atom/movable/A as mob|obj in src)
-					A.forceMove(src.loc)
-					A.ex_act(severity++)
-				dump_contents()
-				qdel(src)
-		if(3)
-			if(prob(5))
-				broken = 1
-				if(has_electronics)
-					E = dump_electronics()
-					E.forceMove(src)
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(src.loc)
-					A.ex_act(severity++)
-				dump_contents()
-				qdel(src)
+	var/probdivide = severity == 3 ? 20 : severity
+	if(prob(100/probdivide)) //1 = 100, 2 = 50, 3 = 5
+		broken = 1
+		if(has_electronics)//If it's got electronics, generate them/pull them out
+			E = dump_electronics()
+			E.forceMove(src)
+		for(var/atom/movable/A in src)//pulls everything else out of the locker and hits it with an explosion
+			A.forceMove(src.loc)
+			A.ex_act(severity++)
+		dump_contents()
+		qdel(src)
 
 /obj/structure/closet/shuttle_act()
 	for(var/atom/movable/AM in contents)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -83,27 +83,12 @@
 			to_chat(user, "<span class='info'>\The [src]'s light display indicates there is a potential clone candidate inside.</span>")
 
 /obj/structure/morgue/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			for(var/atom/movable/A in src)
-				A.forceMove(src.loc)
-				A.ex_act(severity)
-			qdel(src)
-			return
-		if(2.0)
-			if(prob(50))
-				for(var/atom/movable/A in src)
-					A.forceMove(src.loc)
-					A.ex_act(severity)
-				qdel(src)
-				return
-		if(3.0)
-			if(prob(5))
-				for(var/atom/movable/A in src)
-					A.forceMove(src.loc)
-					A.ex_act(severity)
-				qdel(src)
-				return
+	var/probdivide = severity == 3 ? 20 : severity
+	if (prob(100/probdivide)) //1 = 100, 2 = 50, 3 = 5
+		for(var/atom/movable/A as mob|obj in src)
+			A.forceMove(loc)
+			A.ex_act(severity)
+		qdel(src)
 
 /obj/structure/morgue/alter_health() //???????????????
 	return src.loc
@@ -146,9 +131,9 @@
 		if(istype(A, /mob/living/simple_animal/scp_173)) //I have no shame. Until someone rewrites this shitcode extroadinaire, I'll just snowflake over it
 			continue
 		if(!A.anchored)
-			A.forceMove(src)				
+			A.forceMove(src)
 	qdel(connected)
-	
+
 	var/list/inside = recursive_type_check(src, /mob)
 	for(var/mob/M in inside)
 		if(M.mind && !M.client) //!M.client = mob has ghosted out of their body
@@ -291,24 +276,12 @@
 		icon_state = "crema1"
 
 /obj/structure/crematorium/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			for(var/atom/movable/A as mob|obj in src)
-				A.forceMove(src.loc)
-				ex_act(severity)
-			qdel(src)
-		if(2.0)
-			if (prob(50))
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(src.loc)
-					ex_act(severity)
-				qdel(src)
-		if(3.0)
-			if (prob(5))
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(src.loc)
-					ex_act(severity)
-				qdel(src)
+	var/probdivide = severity == 3 ? 20 : severity
+	if (prob(100/probdivide)) //1 = 100, 2 = 50, 3 = 5
+		for(var/atom/movable/A as mob|obj in src)
+			A.forceMove(loc)
+			A.ex_act(severity)
+		qdel(src)
 
 /obj/structure/crematorium/alter_health()
 	return src.loc

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -19,7 +19,9 @@
 
 
 /obj/structure/sign/ex_act(severity)
-	switch(severity)
+	qdel(src)
+	// old code preserved below for fun. just why.
+	/*switch(severity)
 		if(1.0)
 			qdel(src)
 			return
@@ -30,7 +32,7 @@
 			qdel(src)
 			return
 		else
-	return
+	return*/
 
 /obj/structure/sign/blob_act()
 	qdel(src)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -783,19 +783,11 @@
 	return ..()
 
 /obj/structure/rack/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			destroy(FALSE)
-		if(2.0)
-			if(prob(50))
-				destroy(TRUE)
-			else
-				destroy(FALSE)
-		if(3.0)
-			if(prob(25))
-				destroy(TRUE)
-			else
-				destroy(FALSE)
+	// previously 3 severity had a higher chance of deleting the parts than 2 severity, made no sense so reversed it. fits in the formula well too.
+	if(prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+		destroy(FALSE)
+	else
+		destroy(TRUE)
 
 /obj/structure/rack/proc/checkhealth()
 	if(health <= 0)

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -28,7 +28,6 @@
 			AM.forceMove(loc)
 			// TODO: What the fuck are you doing
 			AM.ex_act(severity++)
-			. += AM
 		qdel(src)
 
 /obj/structure/transit_tube_pod/proc/empty_pod(atom/location)

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -23,7 +23,7 @@
 
 // When destroyed by explosions, properly handle contents.
 /obj/structure/transit_tube_pod/ex_act(severity)
-	if(severity < 2 && prob(100 - ((severity-1)*50))) // 1 = 100, 2 = 50, 3 = 0
+	if(severity < 3 && prob(100 - ((severity-1)*50))) // 1 = 100, 2 = 50, 3 = 0
 		for(var/atom/movable/AM in contents)
 			AM.forceMove(loc)
 			// TODO: What the fuck are you doing

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -19,29 +19,17 @@
 	for(var/atom/movable/AM in contents)
 		AM.loc = loc
 
-	..()	
+	..()
 
 // When destroyed by explosions, properly handle contents.
 /obj/structure/transit_tube_pod/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			for(var/atom/movable/AM in contents)
-				AM.forceMove(loc)
-				// TODO: What the fuck are you doing
-				AM.ex_act(severity++)
-
-			qdel(src)
-			return
-		if(2.0)
-			if(prob(50))
-				for(var/atom/movable/AM in contents)
-					AM.forceMove(loc)
-					AM.ex_act(severity++)
-
-				qdel(src)
-				return
-		if(3.0)
-			return
+	if(severity < 2 && prob(100 - ((severity-1)*50))) // 1 = 100, 2 = 50, 3 = 0
+		for(var/atom/movable/AM in contents)
+			AM.forceMove(loc)
+			// TODO: What the fuck are you doing
+			AM.ex_act(severity++)
+			. += AM
+		qdel(src)
 
 /obj/structure/transit_tube_pod/proc/empty_pod(atom/location)
 	if(!location)
@@ -49,13 +37,13 @@
 	for(var/atom/movable/M in contents)
 		M.forceMove(location)
 	update_icon()
-	
+
 /obj/structure/transit_tube_pod/Process_Spacemove()
 	if(moving) //No drifting while moving in the tubes
 		return TRUE
 	else
 		return ..()
-	
+
 /obj/structure/transit_tube_pod/proc/follow_tube(var/reverse_launch)
 	if(moving)
 		return
@@ -128,8 +116,8 @@
 
 			while(isturf(loc) && Move(get_step(loc, dir)))
 
-		moving = 0	
-	
+		moving = 0
+
 /obj/structure/transit_tube_pod/attackby(obj/item/W as obj, mob/user as mob)
 	if(iswelder(W))
 		var/obj/item/tool/weldingtool/WT = W
@@ -141,7 +129,7 @@
 			TTFP.circuitry = new /obj/item/weapon/circuitboard/mecha/transitpod(TTFP)
 			qdel(src)
 		return 1
-		
+
 /obj/structure/transit_tube_pod/examine(mob/user)
 	..()
 	show_occupants(user)
@@ -157,7 +145,7 @@
 			return
 
 	to_chat(user, "<span class='info'>The tube pod looks empty.</span>")
-	
+
 // Should I return a copy here? If the caller edits or del()s the returned
 //  datum, there might be problems if I don't...
 //	Shut up bitch, let's do it MY way

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -521,29 +521,11 @@
 	..()
 
 /obj/machinery/cloning/clonepod/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			for(var/atom/movable/A as mob|obj in src)
-				A.forceMove(loc)
-				ex_act(severity)
-			qdel(src)
-			return
-		if(2.0)
-			if (prob(50))
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(loc)
-					ex_act(severity)
-				qdel(src)
-				return
-		if(3.0)
-			if (prob(25))
-				for(var/atom/movable/A as mob|obj in src)
-					A.forceMove(loc)
-					ex_act(severity)
-				qdel(src)
-				return
-		else
-	return
+	if(prob(100 / (2**(severity-1)))) //1 = 100, 2 = 50, 3 = 25
+		for(var/atom/movable/A as mob|obj in src)
+			A.forceMove(loc)
+			A.ex_act(severity)
+		qdel(src)
 
 /obj/machinery/cloning/clonepod/MouseDropTo(obj/item/weapon/reagent_containers/food/snacks/meat/M, mob/living/user)
 	var/busy = FALSE

--- a/code/modules/mining/ore_box.dm
+++ b/code/modules/mining/ore_box.dm
@@ -68,7 +68,7 @@
 	stored_ores.Cut()
 
 /obj/structure/ore_box/ex_act(severity)
-	if(severity < 2 && prob(100-((severity-1)*50))) // 1= 100, 2 = 50, 3 = 0
+	if(severity < 3 && prob(100-((severity-1)*50))) // 1= 100, 2 = 50, 3 = 0
 		dump_everything()
 		qdel(src)
 

--- a/code/modules/mining/ore_box.dm
+++ b/code/modules/mining/ore_box.dm
@@ -68,14 +68,9 @@
 	stored_ores.Cut()
 
 /obj/structure/ore_box/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			dump_everything()
-			qdel(src)
-		if(2.0)
-			if (prob(50))
-				dump_everything()
-				qdel(src)
+	if(severity < 2 && prob(100-((severity-1)*50))) // 1= 100, 2 = 50, 3 = 0
+		dump_everything()
+		qdel(src)
 
 /obj/structure/ore_box/proc/try_add_ore(var/obj/item/stack/ore/O)
 	if (!O.can_orebox)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -180,11 +180,8 @@
 	return TRUE
 
 /obj/machinery/power/supermatter/ex_act(severity,var/mob/whodunnit)
-	switch(severity)
-		if(3.0)
-			return //Should be improved
-		else
-			return explode(whodunnit)
+	if(severity < 3) // TODO: Should be improved(?)
+		return explode(whodunnit)
 
 /obj/machinery/power/supermatter/shard/singularity_act(current_size, obj/machinery/singularity/S)
 	var/super = FALSE


### PR DESCRIPTION
[bugfix][consistency]

## What this does
takes the bugfixes from #34153, along with its relevant code refactors

## Changelog
:cl:
 * bugfix: Exploded body scanners, sleepers, cloning pods, morgue trays and cremators now properly affect mobs inside when destroyed.
 * tweak: Racks no longer have their parts more likely to be destroyed in low intensity explosions than medium ones.