### PR TITLE
Fixes laser raycasts not properly deleting

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -130,7 +130,7 @@ var/list/beam_master = list()
 			spawn()
 				portal(last_hit.hit_atom)
 
-	shot_ray.draw(distance, icon, icon_state)
+	shot_ray.draw(distance, icon, icon_state, color_override = beam_color, color_shift = beam_shift)
 
 	if(gcDestroyed)
 		qdel(shot_ray)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -107,19 +107,16 @@ var/list/beam_master = list()
 	previous_turf = shot_ray.previous_turf
 	if(!gcDestroyed)
 		past_rays += shot_ray
-	else
-		shot_ray.fired_beam = null // hard-delete prevention
 
+	var/distance = MAX_BEAM_DISTANCE
 	if(isnull(hits) || hits.len == 0)
 		if(travel_range)
-			shot_ray.draw(travel_range, icon, icon_state, color_override = beam_color, color_shift = beam_shift)
-		else
-			shot_ray.draw(MAX_BEAM_DISTANCE, icon, icon_state, color_override = beam_color, color_shift = beam_shift)
+			distance = travel_range
 
 	else
 		var/rayCastHit/last_hit = hits[hits.len]
 
-		shot_ray.draw(last_hit.distance, icon, icon_state, color_override = beam_color, color_shift = beam_shift)
+		distance = last_hit.distance
 
 		if(last_hit.hit_type == RAY_CAST_REBOUND)
 			final_turf=null
@@ -132,6 +129,11 @@ var/list/beam_master = list()
 			ASSERT(!gcDestroyed)
 			spawn()
 				portal(last_hit.hit_atom)
+
+	shot_ray.draw(distance, icon, icon_state)
+
+	if(gcDestroyed)
+		qdel(shot_ray)
 
 /obj/item/projectile/beam/process()
 	var/vector/origin = atom2vector(starting)


### PR DESCRIPTION
[performance][tested]

## What this does
re attempts #27772, in the process Closes #27743.
tested by using SDQL to select all /ray and /rayCastHit type items after firing a laser, on default branch and after changes. this shows nothing after lasers were fired and then deleted as normal, whereas before this change it showed /ray/beam_ray and /rayCastHit types not being deleted right.