### PR TITLE
MoMMIs no longer drop modules when below 100 charge

### DIFF
--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -177,7 +177,7 @@ var/static/list/mat2type = list(
 			else
 				to_chat(R, "<span class='warning'>Your cell has no charge to use this with!</span>")
 		else
-			to_chat(R, "<span class='warning'>Your need a cell to use this!</span>")
+			to_chat(R, "<span class='warning'>You need a cell to use this!</span>")
 
 /obj/item/device/material_synth/preloaded/admin/create_material(mob/user, var/material)
 	var/obj/item/stack/sheet/material_type = material

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -153,36 +153,24 @@ var/static/list/mat2type = list(
 			if(amount)
 				if(TakeCost(amount, modifier, R))
 					var/obj/item/stack/sheet/inside_sheet = (locate(material_type) in R.module.modules)
+					var/newsheet = 0
 					if(!inside_sheet)
-						var/obj/item/stack/sheet/created_sheet = new material_type(R.module)
-						R.module.modules += created_sheet
-						if(amount <= created_sheet.max_amount)
-							created_sheet.amount += (amount-created_sheet.amount)
-							to_chat(R, "<span class='notice'>Added [amount] of [initial(material_type.name)] to the stack.</span>")
-						else
-							if(created_sheet.amount <= created_sheet.max_amount)
-								var/transfer_amount = min(created_sheet.max_amount - created_sheet.amount, amount)
-								created_sheet.amount += (transfer_amount-1)
-								amount -= transfer_amount
-							if(amount >= 1 && (created_sheet.amount >= created_sheet.max_amount))
-								to_chat(R, "<span class='warning'>Dropping [amount], you cannot hold anymore of [initial(material_type.name)].</span>")
-								var/obj/item/stack/sheet/dropped_sheet = new material_type(get_turf(src))
-								dropped_sheet.amount = (amount - 1)
-
+						inside_sheet = new material_type(R.module)
+						R.module.modules += inside_sheet
+						newsheet = 1
+					if((inside_sheet.amount + (amount*newsheet)) <= inside_sheet.max_amount)
+						inside_sheet.amount += amount-(inside_sheet.amount*newsheet)
+						to_chat(R, "<span class='notice'>Added [amount] of [initial(material_type.name)] to the stack.</span>")
+						return
 					else
-						if((inside_sheet.amount + amount) <= inside_sheet.max_amount)
-							inside_sheet.amount += amount
-							to_chat(R, "<span class='notice'>Added [amount] of [initial(material_type.name)] to the stack.</span>")
-							return
-						else
-							if(inside_sheet.amount <= inside_sheet.max_amount)
-								var/transfer_amount = min(inside_sheet.max_amount - inside_sheet.amount, amount)
-								inside_sheet.amount += transfer_amount
-								amount -= transfer_amount
-							if(amount >= 1 && (inside_sheet.amount >= inside_sheet.max_amount))
-								to_chat(R, "<span class='warning'>Dropping [amount], you cannot hold anymore of [initial(material_type.name)].</span>")
-								var/obj/item/stack/sheet/dropped_sheet = new material_type(get_turf(src))
-								dropped_sheet.amount = amount
+						if(inside_sheet.amount <= inside_sheet.max_amount)
+							var/transfer_amount = min(inside_sheet.max_amount - inside_sheet.amount, amount)
+							inside_sheet.amount += (transfer_amount-newsheet)
+							amount -= transfer_amount
+						if(amount >= 1 && (inside_sheet.amount >= inside_sheet.max_amount))
+							to_chat(R, "<span class='warning'>Dropping [amount], you cannot hold anymore of [initial(material_type.name)].</span>")
+							var/obj/item/stack/sheet/dropped_sheet = new material_type(get_turf(src))
+							dropped_sheet.amount = amount-newsheet
 					R.module.rebuild()
 					R.hud_used.update_robot_modules_display()
 					return

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -221,7 +221,10 @@ var/static/list/mat2type = list(
 
 /obj/item/device/material_synth/examine(mob/user)
 	..()
-	to_chat(user, "[istype(src, /obj/item/device/material_synth/robot) ? "It's been set to draw power from a power cell." : "It currently holds [matter]/[MAX_MATSYNTH_MATTER] matter-units."]")
+	if(istype(src, /obj/item/device/material_synth/robot))
+		to_chat(user, "It's been set to draw power from a power cell.")
+	else
+		to_chat(user, "It currently holds [matter]/[MAX_MATSYNTH_MATTER] matter-units.")
 
 /obj/item/device/material_synth/attackby(var/obj/O, mob/user)
 	if(istype(O, /obj/item/stack/rcd_ammo))

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -142,11 +142,10 @@ var/static/list/mat2type = list(
 	return 1
 
 /obj/item/device/material_synth/robot/create_material(mob/user, var/material)
-	var/obj/item/stack/sheet/material_type = material
-
 	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
 		if(R && R.cell && R.cell.charge)
+			var/obj/item/stack/sheet/material_type = material
 			if(material_type)
 				var/modifier = get_mat_cost(initial(active_material.perunit))
 				var/amount = input(user, "How many sheets of [initial(material_type.name)] do you want to synthesize? (0 - 50)", "Material Synthesizer") as num

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -104,12 +104,12 @@ var/static/list/mat2type = list(
 	icon_state = "mat_synth[mode ? "on" : "off"]"
 
 /obj/item/device/material_synth/proc/get_mat_cost(var/per_unit)
-		if (per_unit < 2000)
-			return MAT_COST_RARE
-		else if (per_unit < 3750)
-			return MAT_COST_MEDIUM
-		else
-			return MAT_COST_COMMON
+	if (per_unit < 2000)
+		return MAT_COST_RARE
+	else if (per_unit < 3750)
+		return MAT_COST_MEDIUM
+	else
+		return MAT_COST_COMMON
 
 /obj/item/device/material_synth/proc/create_material(mob/user, var/material)
 	var/obj/item/stack/sheet/material_type = material
@@ -168,7 +168,7 @@ var/static/list/mat2type = list(
 								inside_sheet.amount += (transfer_amount-newsheet)
 								amount -= transfer_amount
 							if(amount >= 1 && (inside_sheet.amount >= inside_sheet.max_amount))
-								to_chat(R, "<span class='warning'>Dropping [amount], you cannot hold anymore of [initial(material_type.name)].</span>")
+								to_chat(R, "<span class='warning'>Dropping [amount] sheets, you cannot hold anymore [initial(material_type.name)].</span>")
 								var/obj/item/stack/sheet/dropped_sheet = new material_type(get_turf(src))
 								dropped_sheet.amount = amount-newsheet
 						R.module.rebuild()

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -146,42 +146,41 @@ var/static/list/mat2type = list(
 
 	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
-		if(R && R.cell && R.cell.charge && material_type)
-			var/modifier = get_mat_cost(initial(active_material.perunit))
-			var/amount = input(user, "How many sheets of [initial(material_type.name)] do you want to synthesize? (0 - 50)", "Material Synthesizer") as num
-			amount = clamp(round(amount, 1), 0, 50)
-			if(amount)
-				if(TakeCost(amount, modifier, R))
-					var/obj/item/stack/sheet/inside_sheet = (locate(material_type) in R.module.modules)
-					var/newsheet = 0
-					if(!inside_sheet)
-						inside_sheet = new material_type(R.module)
-						R.module.modules += inside_sheet
-						newsheet = 1
-					if((inside_sheet.amount + (amount*newsheet)) <= inside_sheet.max_amount)
-						inside_sheet.amount += amount-(inside_sheet.amount*newsheet)
-						to_chat(R, "<span class='notice'>Added [amount] of [initial(material_type.name)] to the stack.</span>")
+		if(R && R.cell && R.cell.charge)
+			if(material_type)
+				var/modifier = get_mat_cost(initial(active_material.perunit))
+				var/amount = input(user, "How many sheets of [initial(material_type.name)] do you want to synthesize? (0 - 50)", "Material Synthesizer") as num
+				amount = clamp(round(amount, 1), 0, 50)
+				if(amount)
+					if(TakeCost(amount, modifier, R))
+						var/obj/item/stack/sheet/inside_sheet = (locate(material_type) in R.module.modules)
+						var/newsheet = 0
+						if(!inside_sheet)
+							inside_sheet = new material_type(R.module)
+							R.module.modules += inside_sheet
+							newsheet = 1
+						if((inside_sheet.amount + (amount*newsheet)) <= inside_sheet.max_amount)
+							inside_sheet.amount += amount-(inside_sheet.amount*newsheet)
+							to_chat(R, "<span class='notice'>Added [amount] of [initial(material_type.name)] to the stack.</span>")
+							return
+						else
+							if(inside_sheet.amount <= inside_sheet.max_amount)
+								var/transfer_amount = min(inside_sheet.max_amount - inside_sheet.amount, amount)
+								inside_sheet.amount += (transfer_amount-newsheet)
+								amount -= transfer_amount
+							if(amount >= 1 && (inside_sheet.amount >= inside_sheet.max_amount))
+								to_chat(R, "<span class='warning'>Dropping [amount], you cannot hold anymore of [initial(material_type.name)].</span>")
+								var/obj/item/stack/sheet/dropped_sheet = new material_type(get_turf(src))
+								dropped_sheet.amount = amount-newsheet
+						R.module.rebuild()
+						R.hud_used.update_robot_modules_display()
 						return
 					else
-						if(inside_sheet.amount <= inside_sheet.max_amount)
-							var/transfer_amount = min(inside_sheet.max_amount - inside_sheet.amount, amount)
-							inside_sheet.amount += (transfer_amount-newsheet)
-							amount -= transfer_amount
-						if(amount >= 1 && (inside_sheet.amount >= inside_sheet.max_amount))
-							to_chat(R, "<span class='warning'>Dropping [amount], you cannot hold anymore of [initial(material_type.name)].</span>")
-							var/obj/item/stack/sheet/dropped_sheet = new material_type(get_turf(src))
-							dropped_sheet.amount = amount-newsheet
-					R.module.rebuild()
-					R.hud_used.update_robot_modules_display()
-					return
-				else
-					to_chat(R, "<span class='warning'>You can't make that much [initial(material_type.name)] without shutting down!</span>")
-					return
-
-		else if(R.cell.charge)
-			to_chat(R, "<span class='warning'>You need to select a sheet type first!</span>")
-			return
-
+						to_chat(R, "<span class='warning'>You can't make that much [initial(material_type.name)] without shutting down!</span>")
+						return
+			else
+				to_chat(R, "<span class='warning'>You need to select a sheet type first!</span>")
+				return
 	return 1
 
 /obj/item/device/material_synth/preloaded/admin/create_material(mob/user, var/material)

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -123,7 +123,7 @@ var/static/list/mat2type = list(
 
 		if (unit_can_produce >= 1)
 			tospawn = input(user, "How many sheets of [initial(material_type.name)] do you want to synthesize? (0 - [unit_can_produce])", "Material Synthesizer") as num
-			tospawn = clamp(round(tospawn), 0, unit_can_produce)
+			tospawn = clamp(round(tospawn, 1), 0, unit_can_produce)
 
 			if (tospawn >= 1 && TakeCost(tospawn, modifier, user))
 				var/obj/item/stack/sheet/spawned_sheet = new material_type(get_turf(src))
@@ -148,7 +148,7 @@ var/static/list/mat2type = list(
 		var/mob/living/silicon/robot/R = user
 		if(R && R.cell && R.cell.charge && material_type)
 			var/modifier = get_mat_cost(initial(active_material.perunit))
-			var/amount = input(user, "How many sheets of [initial(material_type.name)] do you want to synthesize", "Material Synthesizer") as num
+			var/amount = input(user, "How many sheets of [initial(material_type.name)] do you want to synthesize? (0 - 50)", "Material Synthesizer") as num
 			amount = clamp(round(amount, 1), 0, 50)
 			if(amount)
 				if(TakeCost(amount, modifier, R))

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -153,12 +153,12 @@ var/static/list/mat2type = list(
 				if(amount)
 					if(TakeCost(amount, modifier, R))
 						var/obj/item/stack/sheet/inside_sheet = (locate(material_type) in R.module.modules)
-						var/newsheet = 0
+						var/newsheet = FALSE
 						if(!inside_sheet)
 							inside_sheet = new material_type(R.module)
 							R.module.modules += inside_sheet
-							newsheet = 1
-						if((inside_sheet.amount + (amount*newsheet)) <= inside_sheet.max_amount)
+							newsheet = TRUE
+						if((inside_sheet.amount + (amount*(!newsheet))) <= inside_sheet.max_amount)
 							inside_sheet.amount += amount-(inside_sheet.amount*newsheet)
 							to_chat(R, "<span class='notice'>Added [amount] of [initial(material_type.name)] to the stack.</span>")
 							return

--- a/code/modules/mob/living/silicon/mommi/mommi_inventory.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_inventory.dm
@@ -13,8 +13,10 @@
 	if(!W)
 		return FALSE
 	if(cell && cell.charge <= ROBOT_LOW_POWER)
-		drop_item(W)
-		return FALSE
+		if(!is_in_modules(W))
+			drop_item(W)
+			return FALSE
+		return TRUE
 	if(istype(W, /obj/item/device/material_synth) && !is_in_modules(W)) //Crab no
 		drop_item(W)
 		return FALSE


### PR DESCRIPTION
[hotfix][bugfix]

## What this does
Closes #27601.
code cleanup along the way as I tested

## Changelog
:cl:
 * bugfix: MoMMIs below 100 charge no longer drop their modules on the floor when selecting them.
 * tweak: MoMMI material synths now have better feedback for being out of power or having no cell.
