### PR TITLE
Fixes isolation centrifuge runtime

### DIFF
--- a/code/modules/virus2/centrifuge.dm
+++ b/code/modules/virus2/centrifuge.dm
@@ -563,7 +563,8 @@
 /obj/machinery/disease2/centrifuge/breakdown()
 	for (var/i = 1 to vial_data.len)
 		var/isolation_centrifuge_vial/vial_datum = vial_data[i]
-		vial_datum.vial.forceMove(loc)
+		if(vial_datum?.vial)
+			vial_datum.vial.forceMove(loc)
 		vial_data[i] = null
 
 	special = CENTRIFUGE_LIGHTSPECIAL_OFF

--- a/code/modules/virus2/centrifuge.dm
+++ b/code/modules/virus2/centrifuge.dm
@@ -563,8 +563,7 @@
 /obj/machinery/disease2/centrifuge/breakdown()
 	for (var/i = 1 to vial_data.len)
 		var/isolation_centrifuge_vial/vial_datum = vial_data[i]
-		if(vial_datum?.vial)
-			vial_datum.vial.forceMove(loc)
+		vial_datum?.vial?.forceMove(loc)
 		vial_data[i] = null
 
 	special = CENTRIFUGE_LIGHTSPECIAL_OFF


### PR DESCRIPTION
[runtime][bugfix]

## What this does
Closes #31393.

## Changelog
:cl:
 * bugfix: Virology isolation centrifuges now properly remove all vials when broken down.