### PR TITLE
More cryotheum balancing and bugfixes.

### DIFF
--- a/code/ATMOSPHERICS/hvac/cryotheum_resonator.dm
+++ b/code/ATMOSPHERICS/hvac/cryotheum_resonator.dm
@@ -10,6 +10,8 @@
 	machine_flags = EMAGGABLE | WRENCHMOVE | FIXED2WORK | SHUTTLEWRENCH
 	var/activated = FALSE
 	var/obj/item/bluespace_crystal/crystal
+	ghost_read = 0
+	ghost_write = 0
 
 /obj/machinery/cryotheum_resonator/examine(mob/user)
 	..()
@@ -127,9 +129,9 @@
 		if(istype(crystal, /obj/item/bluespace_crystal/artificial))
 			amount = 120
 		else if(istype(crystal, /obj/item/bluespace_crystal/flawless))
-			amount = 250
+			amount = 950
 		else
-			amount = 630
+			amount = 240
 	if(emagged)
 		amount *= 1.2
 	return amount
@@ -161,7 +163,11 @@
 			update_icon()
 
 /obj/machinery/cryotheum_resonator/attack_hand(mob/user as mob)
-	src.add_fingerprint(user)
+	if(issilicon(user))
+		add_hiddenprint(user)
+	else
+		add_fingerprint(user)
+	..()
 	if(!anchored)
 		to_chat(user, "\The [src] needs to be anchored first!")
 		return

--- a/code/ATMOSPHERICS/hvac/cryotheum_resonator.dm
+++ b/code/ATMOSPHERICS/hvac/cryotheum_resonator.dm
@@ -163,10 +163,7 @@
 			update_icon()
 
 /obj/machinery/cryotheum_resonator/attack_hand(mob/user as mob)
-	if(issilicon(user))
-		add_hiddenprint(user)
-	else
-		add_fingerprint(user)
+	add_fingerprint(user)
 	..()
 	if(!anchored)
 		to_chat(user, "\The [src] needs to be anchored first!")

--- a/code/ZAS/XGM_gases.dm
+++ b/code/ZAS/XGM_gases.dm
@@ -59,6 +59,7 @@
 /datum/gas/plasma
 	id = GAS_PLASMA
 	name = "Plasma"
+	short_name = "Plasma"
 
 	//Note that this has a significant impact on TTV yield.
 	//Because it is so high, any leftover plasma soaks up a lot of heat and drops the yield pressure.

--- a/code/ZAS/XGM_reactions.dm
+++ b/code/ZAS/XGM_reactions.dm
@@ -5,7 +5,7 @@
 // Used for caching purposes. Returns true if this reaction can occur inside this mixture - i.e. the necessary reagents are inside the mixture. Caching_flags
 // determine when this function is called - if no flags, it will be called constantly on every update to a mixture. Additional flags will improve efficiency by
 // reducing calls.
-/datum/gas_reaction/proc/reaction_is_possible( datum/gas_mixture/mixture )
+/datum/gas_reaction/proc/reaction_is_possible(datum/gas_mixture/mixture)
 	return FALSE
 
 // Given that this reaction is the only reaction occuring in mixture, how much of each reagent would it use up this tick? Values must be accurate, since if for instance
@@ -27,10 +27,11 @@
 	name = "Cryotheum-Oxygen Reaction"
 
 /datum/gas_reaction/cryotheum_oxygen_reaction/reaction_is_possible(datum/gas_mixture/mixture)
-	return mixture[GAS_CRYOTHEUM] > 0 && mixture[GAS_OXYGEN] > 0
+	return mixture[GAS_CRYOTHEUM] > 0 && mixture.molar_density(GAS_CRYOTHEUM) * CELL_VOLUME > MOLES_CRYOTHEUM_VISIBLE && mixture[GAS_OXYGEN] > 0
 
 /datum/gas_reaction/cryotheum_oxygen_reaction/reaction_amounts_requested(datum/gas_mixture/mixture)
 	var/to_return[] = list()
+	// Reach maximum efficiency when the Cryo:Oxy ratio is 1:50 or higher. Any less and scale linearly, i.e. 1:100 is half speed.
 	var/catalyst_coefficient = min(1.0, mixture[GAS_CRYOTHEUM] / mixture[GAS_OXYGEN] * 50)
 	to_return[GAS_OXYGEN] = catalyst_coefficient * mixture[GAS_OXYGEN]*0.0015
 	return to_return
@@ -38,8 +39,8 @@
 /datum/gas_reaction/cryotheum_oxygen_reaction/perform_reaction(datum/gas_mixture/mixture, reactant_amounts)
 	var/reaction_coefficient = reactant_amounts[GAS_OXYGEN]
 	mixture[GAS_OXYGEN] = max(0, mixture[GAS_OXYGEN] - reaction_coefficient)
-	// -120000 times 0.0015 * mols of oxygen should reduce a normal room by about 1.7C every time this ticks.
-	mixture.add_thermal_energy( reaction_coefficient * -120000, 232.8952)
+	// Should reduce a normal room down to a minimum of around -30C in less than a minute.
+	mixture.add_thermal_energy( reaction_coefficient * -170000, 242.8952)
 
 
 // Cryotheum reacts with itself in the presence of plasma, disappearing but drastically lowering temperatures. Small amounts of gas will near-instantly turn to 0.1K, whereas
@@ -48,10 +49,11 @@
 	name = "Plasma Catalyzed Cryotheum Reaction"
 
 /datum/gas_reaction/cryotheum_plasma_reaction/reaction_is_possible(datum/gas_mixture/mixture)
-	return mixture[GAS_CRYOTHEUM] > 0 && mixture[GAS_PLASMA] > 0
+	return mixture[GAS_CRYOTHEUM] > 0 && mixture.molar_density(GAS_PLASMA) * CELL_VOLUME > MOLES_PLASMA_VISIBLE
 
 /datum/gas_reaction/cryotheum_plasma_reaction/reaction_amounts_requested(datum/gas_mixture/mixture)
 	var/to_return[] = list()
+	// Reach maximum efficiency when the Plasma/Cryo ratio is 1:10 or higher. Any less and scale linearly, i.e. 1:20 is half speed.
 	var/catalyst_coefficient = min(1.0, mixture[GAS_PLASMA] / mixture[GAS_CRYOTHEUM] * 10)
 	to_return[GAS_CRYOTHEUM] = catalyst_coefficient * mixture[GAS_CRYOTHEUM]*0.2
 	return to_return

--- a/code/ZAS/XGM_reactions.dm
+++ b/code/ZAS/XGM_reactions.dm
@@ -27,7 +27,7 @@
 	name = "Cryotheum-Oxygen Reaction"
 
 /datum/gas_reaction/cryotheum_oxygen_reaction/reaction_is_possible(datum/gas_mixture/mixture)
-	return mixture[GAS_CRYOTHEUM] > 0 && mixture.molar_density(GAS_CRYOTHEUM) * CELL_VOLUME > MOLES_CRYOTHEUM_VISIBLE && mixture[GAS_OXYGEN] > 0
+	return mixture[GAS_CRYOTHEUM] > 0 && QUANTIZE(mixture.molar_density(GAS_CRYOTHEUM)) * CELL_VOLUME > MOLES_CRYOTHEUM_VISIBLE && mixture[GAS_OXYGEN] > 0
 
 /datum/gas_reaction/cryotheum_oxygen_reaction/reaction_amounts_requested(datum/gas_mixture/mixture)
 	var/to_return[] = list()
@@ -40,7 +40,9 @@
 	var/reaction_coefficient = reactant_amounts[GAS_OXYGEN]
 	mixture[GAS_OXYGEN] = max(0, mixture[GAS_OXYGEN] - reaction_coefficient)
 	// Should reduce a normal room down to a minimum of around -30C in less than a minute.
-	mixture.add_thermal_energy( reaction_coefficient * -170000, 242.8952)
+	var/const/temp_loss_per_one_reaction = -170000
+	var/const/min_oxy_reaction_temperature = 242.8952
+	mixture.add_thermal_energy( reaction_coefficient * temp_loss_per_one_reaction, min_oxy_reaction_temperature)
 
 
 // Cryotheum reacts with itself in the presence of plasma, disappearing but drastically lowering temperatures. Small amounts of gas will near-instantly turn to 0.1K, whereas
@@ -49,7 +51,7 @@
 	name = "Plasma Catalyzed Cryotheum Reaction"
 
 /datum/gas_reaction/cryotheum_plasma_reaction/reaction_is_possible(datum/gas_mixture/mixture)
-	return mixture[GAS_CRYOTHEUM] > 0 && mixture.molar_density(GAS_PLASMA) * CELL_VOLUME > MOLES_PLASMA_VISIBLE
+	return mixture[GAS_CRYOTHEUM] > 0 && QUANTIZE(mixture.molar_density(GAS_PLASMA)) * CELL_VOLUME > MOLES_PLASMA_VISIBLE
 
 /datum/gas_reaction/cryotheum_plasma_reaction/reaction_amounts_requested(datum/gas_mixture/mixture)
 	var/to_return[] = list()
@@ -65,4 +67,5 @@
 	var/distance_to_min_temp = max(0, mixture.temperature - 0.1)
 	var/logarithmic_modifier = max(0, log(40, distance_to_min_temp+1))
 	// Arbitrary number to reduce temperature by a significant amount, hardcapped at the minimum temperature.
-	mixture.add_thermal_energy( logarithmic_modifier * reaction_coefficient * -700000, 0.1)
+	var/const/temp_loss_per_one_reaction = -700000
+	mixture.add_thermal_energy( logarithmic_modifier * reaction_coefficient * temp_loss_per_one_reaction, 0.1)

--- a/code/ZAS/Zone.dm
+++ b/code/ZAS/Zone.dm
@@ -90,7 +90,6 @@ Class Procs:
 	ASSERT(!invalid)
 	ASSERT(istype(T))
 	ASSERT(T.zone == src)
-	soft_assert(T in contents, "Lists are weird broseph")
 #endif
 
 	T.c_copy_air()
@@ -133,10 +132,11 @@ Class Procs:
 /zone/proc/c_invalidate()
 	invalid = 1
 	SSair.remove_zone(src)
+	for(var/turf/simulated/T in contents)
+		handle_events_remove(T)
 	#ifdef ZASDBG
 	for(var/turf/simulated/T in contents)
 		T.dbg(invalid_zone)
-		handle_events_remove(T)
 	#endif
 
 /zone/proc/rebuild()
@@ -151,7 +151,6 @@ Class Procs:
 		//T.dbg(invalid_zone)
 		T.needs_air_update = 0 //Reset the marker so that it will be added to the list.
 		SSair.mark_for_update(T)
-		handle_events_add(T)
 
 //Gets a list of the gas_mixtures of all zones connected to this one through arbitrarily many sleeping edges.
 //This is to cut down somewhat on differentials across open doors.
@@ -213,7 +212,7 @@ Class Procs:
 // In an ideal non-BYOND environment we could use something like events to hookup each ice tile to. However, our in-house implementation of events suck for performance. So you
 // can just hardcode the check here.
 /zone/proc/check_for_events()
-	// Only initialize ice_puddle_list and do these checks after cryotheum has been introduced to the zone.
+	// Only initialize ice_puddle_list and check for ice-related temperature events after cryotheum has been introduced to the zone.
 	if( ice_puddle_list != null )
 		for(var/obj/effect/overlay/puddle/ice/existing_ice in ice_puddle_list)
 			existing_ice.current_temp = air.temperature
@@ -234,12 +233,12 @@ Class Procs:
 
 /zone/proc/handle_events_add(turf/simulated/T)
 	for(var/obj/effect/overlay/puddle/ice/ice_puddle in T)
-		if( ice_puddle_list == null )
+		if(ice_puddle_list == null)
 			ice_puddle_list = list()
 		ice_puddle_list |= ice_puddle
 
 /zone/proc/handle_events_remove(turf/simulated/T)
-	if( ice_puddle_list != null )
+	if(ice_puddle_list != null)
 		for(var/obj/effect/overlay/puddle/ice/ice_puddle in T)
 			ice_puddle_list -= ice_puddle
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -338,6 +338,10 @@
 		for(var/obj/effect/decal/cleanable/C in src)
 			qdel(C)//enough with footprints floating in space
 
+	if(!istype(N, /turf/simulated))
+		for(var/obj/effect/overlay/puddle/ice/P in src)
+			qdel(P)
+
 	//Rebuild turf
 	var/turf/T = src
 	env = T.air //Get the air before the change


### PR DESCRIPTION
Fixes various cryotheum bugs and does minor balancing.

:cl:
 * bugfix: Ice tiles immediately disappear if the tile its on is switched to space.
 * bugfix: Fixed ghosts being able to interact with the Cryotheum Resonator.
 * bugfix: Fixed some ZAS events occurring at wrong times.
 * bugfix: Fixed plasma not having a name in some instances.
 * tweak: The Cryotheum-Oxygen reaction now requires a high enough Cryotheum density for it to occur (enough for it to be visible in the air, and an equivalent volume ratio for pipes). Same for Plasma-Cryotheum, except that it's Plasma that has to be visible.
 * tweak: Various Cryotheum minor tweaks, like bluespace crystal amount rebalancing and increasing the minimum tempreature for Cryo-Oxy to around -30C from -40C.