### PR TITLE
Fixes PDA messaging while dead

### DIFF
--- a/code/game/objects/items/devices/PDA/apps/messenger.dm
+++ b/code/game/objects/items/devices/PDA/apps/messenger.dm
@@ -220,7 +220,7 @@
     if(!t)
         t = input(U, "Please enter message", "Message to [P]", null) as text|null
         t = copytext(parse_emoji(sanitize(t)), 1, MAX_MESSAGE_LEN)
-        if (!t || P_app.toff || (!in_range(pda_device, U) && pda_device.loc != U)) //If no message, messaging is off, and we're either out of range or not in usr
+        if (!t || P_app.toff || U.stat || (!in_range(pda_device, U) && pda_device.loc != U)) //If no message, messaging is off, and we're either dead, unconscious, out of range or not in usr
             return
 
         if (last_text && world.time < last_text + 5)
@@ -327,8 +327,8 @@
     t = copytext(sanitize(t), 1, MAX_MESSAGE_LEN)
 
     var/datum/pda_app/messenger/message_app = locate(/datum/pda_app/messenger) in pda_device.applications
-    //If no message or messenger, messaging is off, and we're either out of range or not in usr
-    if (!message_app ||!t || message_app.toff || (!in_range(pda_device, user) && pda_device.loc != user))
+    //If no message or messenger, messaging is off, and we're either dead, unconscious, out of range or not in usr
+    if (!message_app ||!t || message_app.toff || user.stat || (!in_range(pda_device, user) && pda_device.loc != user))
         return
     if (message_app.last_text && world.time < message_app.last_text + 5)
         return


### PR DESCRIPTION
[bugfix][sanity]

## What this does
Closes #34866.

## Changelog
:cl:
 * bugfix: PDA messages can no longer be sent by the dead if the message window is still open.