### PR TITLE
Cult Armor Nerfs

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -1314,7 +1314,7 @@ var/list/arcane_tomes = list()
 	item_state = "cultrobes"
 	flags = FPRINT
 	allowed = list(/obj/item/weapon/melee/cultblade,/obj/item/weapon/melee/soulblade,/obj/item/weapon/tome,/obj/item/weapon/talisman,/obj/item/weapon/blood_tesseract,/obj/item/weapon/tank)
-	armor = list(melee = 50, bullet = 30, laser = 30,energy = 20, bomb = 25, bio = 25, rad = 0)
+	armor = list(melee = 40, bullet = 15, laser = 15,energy = 20, bomb = 25, bio = 25, rad = 0)
 	siemens_coefficient = 0
 	heat_conductivity = ARMOUR_HEAT_CONDUCTIVITY
 	species_fit = list(VOX_SHAPED, INSECT_SHAPED, PLASMAMAN_SHAPED)
@@ -1421,7 +1421,7 @@ var/list/arcane_tomes = list()
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/cultstuff.dmi', "right_hand" = 'icons/mob/in-hand/right/cultstuff.dmi')
 	icon_state = "culthelmet"
 	item_state = "culthelmet"
-	armor = list(melee = 60, bullet = 50, laser = 50,energy = 15, bomb = 50, bio = 30, rad = 30)
+	armor = list(melee = 60, bullet = 25, laser = 25,energy = 15, bomb = 50, bio = 30, rad = 30)
 	siemens_coefficient = 0
 	species_fit = list(VOX_SHAPED, UNDEAD_SHAPED, INSECT_SHAPED, PLASMAMAN_SHAPED)
 	clothing_flags = PLASMAGUARD|CONTAINPLASMAMAN
@@ -1450,7 +1450,7 @@ var/list/arcane_tomes = list()
 	w_class = W_CLASS_MEDIUM
 	allowed = list(/obj/item/weapon/tome,/obj/item/weapon/melee/cultblade,/obj/item/weapon/melee/soulblade,/obj/item/weapon/tank,/obj/item/weapon/tome,/obj/item/weapon/talisman,/obj/item/weapon/blood_tesseract)
 	slowdown = HARDSUIT_SLOWDOWN_MED
-	armor = list(melee = 60, bullet = 50, laser = 50,energy = 15, bomb = 50, bio = 30, rad = 30)
+	armor = list(melee = 60, bullet = 25, laser = 25,energy = 15, bomb = 50, bio = 30, rad = 30)
 	siemens_coefficient = 0
 	species_fit = list(VOX_SHAPED, UNDEAD_SHAPED, INSECT_SHAPED, PLASMAMAN_SHAPED)
 	clothing_flags = PLASMAGUARD|CONTAINPLASMAMAN|ONESIZEFITSALL


### PR DESCRIPTION
[tweak]
## What this does
Cult Armor has frankly absurd armor values for something that takes 60 seconds of standing at a forge to get. The armor values for cult armor that actually matter are as follows: 

melee = 60, bullet = 50, laser = 50

For reference, the rigsuits worn by nukies is melee = 60, bullet = 50, laser = 30, weaker than armor that an entire cult can be outfitted the cost of about 10 minutes of your time, less if your cult is more construct heavy. I've halved the laser and bullet resist, dropping them to 25 each. This still puts it as significantly more bullet resistant than the security rigsuit, but ever so slightly weaker than it at resisting lasers. However, this alone would make the cult robes a better option in combat than the armor as they possess the following values:

melee = 50, bullet = 30, laser = 30

and so I've also reduced the cult robe values to melee = 40, bullet = 15, laser = 15. I've been thoroughly assured that the armor values don't matter, so I'm sure no one will notice a significant difference.

As a final note, someone floated the idea to me of leaving the armor values unchanged but restricting cultists wearing them to melee weapons. This would be a far superior alternative but I'm not capable of making such a change. If someone else does I'll happily close this.

## Why it's good
Cults no longer have access to what might be the best armor in the game out of the box for very little investment.

## Changelog
:cl:
 * tweak: Changed the armor values of cult robes and armor.