### PR TITLE
remove scaling armor penetration from grue attacks

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -648,8 +648,6 @@
 	//melee damage, 50 damage limit
 	melee_damage_lower = min(50, base_melee_dam_lw + (5 * eatencount))
 	melee_damage_upper = min(50, base_melee_dam_up + (5 * eatencount))
-	//How much armor they ignore on hit, +10% armor penetration for every target consumed up to 50% of armor ignored, meaning 80% damage reduction becomes 40%.
-	armor_modifier = max(0.5, 1 - (0.1 * eatencount))
 
 	//speed bonus in dark and dim conditions
 	lightparams.speed_m_dark_dim_light[1]=max(1/2,lightparams.base_speed_m_dark_dim_light[1]/(1.2 ** eatencount))//faster in darkness


### PR DESCRIPTION
## What this does
Revert grues having armor penetration from #35247, while keeping the upper limit to their damage.

## Why it's good
Grues are not the main characters of the game. They do not need to be "balanced" in such a way that they can have an answer to everything the crew does to prepare against it, such as wearing heavy armor. They are a side-antagonist that is already able to drain light (its main weakness) and reproduce to create more crew-gibbing monsters.

If a crewman is able to armor himself such that he is prepared to fight a grue, good for him. Grues should absolutely not have the ability to ignore 50% of somebody's armor with their attacks that already deal enormous damage. There is good reason that there is only one other example of armor penetration (stomping): it's neither fun nor intuitive.

[balance]

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Grue attacks no longer penetrate armor.
