### PR TITLE
Fixes Endgame music

### DIFF
--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -959,6 +959,7 @@ var/global/list/loopModeNames=list(
 
 /obj/machinery/media/jukebox/superjuke/thematic
 	playlist_id="endgame"
+	use_power = 0
 
 /obj/machinery/media/jukebox/superjuke/thematic/update_music()
 	if(current_song && playing)


### PR DESCRIPTION
Fixes #30219
Fixes #30101
Fixes #36182

top kek 
![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/c4d471b7-1967-4f89-8732-4a1b61b20e13)

:cl:
* bugfix: Music should play again during thematic endgame events such as the Cult, Nuke Ops, or Supermatter Cascade.