### PR TITLE
Add DMI editor VSCode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
         "platymuus.dm-langclient",
-        "EditorConfig.EditorConfig"
+        "EditorConfig.EditorConfig",
+        "anturk.dmi-editor"
     ]
 }


### PR DESCRIPTION
This extension allows you to see icon state names, lets you zoom in icons properly, separates icons similar to Dream Maker, and lets you rename icon states inside of vscode

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added DMI editor extension support to VSCode
