### PR TITLE
Makes admin jumping to areas ignore dense content if possible

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -497,13 +497,12 @@
 	return 1
 
 /proc/is_blocked_turf(var/turf/T)
-	var/cant_pass = 0
 	if(T.density)
-		cant_pass = 1
+		return 1
 	for(var/atom/A in T)
 		if(A.density)//&&A.anchored
-			cant_pass = 1
-	return cant_pass
+			return 1
+	return 0
 
 //if needs_item is 0 it won't need any item that existed in "holding" to finish
 /proc/do_mob(var/mob/user , var/mob/target, var/delay = 30, var/numticks = 10, var/needs_item = 1) //This is quite an ugly solution but i refuse to use the old request system.

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -497,7 +497,7 @@
 	return 1
 
 /proc/is_blocked_turf(var/turf/T)
-	return T.density || T.has_dense_content()
+	return T.density || T.has_dense_content() != 0
 
 //if needs_item is 0 it won't need any item that existed in "holding" to finish
 /proc/do_mob(var/mob/user , var/mob/target, var/delay = 30, var/numticks = 10, var/needs_item = 1) //This is quite an ugly solution but i refuse to use the old request system.

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -497,12 +497,7 @@
 	return 1
 
 /proc/is_blocked_turf(var/turf/T)
-	if(T.density)
-		return 1
-	for(var/atom/A in T)
-		if(A.density)//&&A.anchored
-			return 1
-	return 0
+	return T.density || T.has_dense_content()
 
 //if needs_item is 0 it won't need any item that existed in "holding" to finish
 /proc/do_mob(var/mob/user , var/mob/target, var/delay = 30, var/numticks = 10, var/needs_item = 1) //This is quite an ugly solution but i refuse to use the old request system.

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -68,7 +68,7 @@
 	smoke.start()
 	var/list/L = list()
 	for(var/turf/T in get_area_turfs(thearea.type))
-		if(!T.density && !T.has_dense_content())
+		if(!is_blocked_turf(T))
 			L+=T
 
 	if(!L.len)

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -68,14 +68,8 @@
 	smoke.start()
 	var/list/L = list()
 	for(var/turf/T in get_area_turfs(thearea.type))
-		if(!T.density)
-			var/clear = 1
-			for(var/obj/O in T)
-				if(O.density)
-					clear = 0
-					break
-			if(clear)
-				L+=T
+		if(!T.density && !T.has_dense_content())
+			L+=T
 
 	if(!L.len)
 		to_chat(user, "The spell matrix was unable to locate a suitable teleport destination for an unknown reason. Sorry.")

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -68,8 +68,14 @@
 	smoke.start()
 	var/list/L = list()
 	for(var/turf/T in get_area_turfs(thearea.type))
-		if(!is_blocked_turf(T))
-			L+=T
+		if(!T.density)
+			var/clear = 1
+			for(var/obj/O in T)
+				if(O.density)
+					clear = 0
+					break
+			if(clear)
+				L+=T
 
 	if(!L.len)
 		to_chat(user, "The spell matrix was unable to locate a suitable teleport destination for an unknown reason. Sorry.")

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -15,14 +15,19 @@
 			return
 
 		var/list/turfs = list()
+		var/list/backup_turfs = list()
 		for(var/turf/T in A)
-			if(!T.density && !T.has_dense_content())
-				turfs.Add(T)
+			if(!T.density)
+				backup_turfs.Add(T)
+				if(!T.has_dense_content())
+					turfs.Add(T)
 
 		var/turf/T = pick_n_take(turfs)
 		if(!T)
-			to_chat(src, "Nowhere to jump to!")
-			return
+			T = pick_n_take(backup_turfs)
+			if(!T)
+				to_chat(src, "Nowhere to jump to!")
+				return
 		usr.unlock_from()
 		usr.teleport_to(T)
 

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -18,9 +18,10 @@
 		var/list/backup_turfs = list()
 		for(var/turf/T in A)
 			if(!T.density)
-				backup_turfs.Add(T)
 				if(!T.has_dense_content())
 					turfs.Add(T)
+				else
+					backup_turfs.Add(T)
 
 		var/turf/T = pick_n_take(turfs)
 		if(!T)

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -16,9 +16,8 @@
 
 		var/list/turfs = list()
 		for(var/turf/T in A)
-			if(T.density)
-				continue
-			turfs.Add(T)
+			if(!T.density && !T.has_dense_content())
+				turfs.Add(T)
 
 		var/turf/T = pick_n_take(turfs)
 		if(!T)


### PR DESCRIPTION
[qol][administration]

## What this does
applies has_dense_content proc to this

## Why it's good
stops admins getting stuck in glass when jumping

## Changelog
:cl:
 * tweak: Admin jumping to an area no longer gets them stuck in dense objects if possible.