### PR TITLE
Fire Breath and Ring of Fire are now unleashed.

### DIFF
--- a/code/game/objects/effects/fire_blast.dm
+++ b/code/game/objects/effects/fire_blast.dm
@@ -98,7 +98,7 @@
 
 			var/turf/T2 = get_turf(src)
 			if(T2)
-				T2.hotspot_expose((blast_temperature * 2) + 380,500)
+				T2.hotspot_expose((blast_temperature * 2) + 380,500, surfaces = T2)
 			sleep(2)
 		qdel(src)
 

--- a/code/modules/spells/targeted/projectile/firebreath.dm
+++ b/code/modules/spells/targeted/projectile/firebreath.dm
@@ -27,7 +27,7 @@
 	hud_state = "wiz_firebreath"
 
 /spell/targeted/projectile/dumbfire/firebreath/spawn_projectile(var/location, var/direction)
-	return new proj_type(location,direction,P = pressure)
+	return new proj_type(location, direction, P = pressure, Temp = AUTOIGNITION_WELDERFUEL)
 
 /spell/targeted/projectile/dumbfire/firebreath/get_upgrade_info(upgrade_type, level)
 	if(upgrade_type == Sp_POWER)

--- a/code/modules/spells/targeted/projectile/firebreath.dm
+++ b/code/modules/spells/targeted/projectile/firebreath.dm
@@ -27,7 +27,7 @@
 	hud_state = "wiz_firebreath"
 
 /spell/targeted/projectile/dumbfire/firebreath/spawn_projectile(var/location, var/direction)
-	return new proj_type(location, direction, P = pressure, Temp = AUTOIGNITION_WELDERFUEL)
+	return new proj_type(location, direction, P = pressure)
 
 /spell/targeted/projectile/dumbfire/firebreath/get_upgrade_info(upgrade_type, level)
 	if(upgrade_type == Sp_POWER)


### PR DESCRIPTION
This is technically a bugfix because the fire blast effects didn't do hotspot_expose properly, missing the "surfaces" variable.
However, thanks to that they can now properly ignite all the things they used to not be able to, including pools of welding fuel, wooden furniture and more.
Thanks to @Exxion for the help!

:cl:
 * rscadd: Fire Breath and Ring of Fire are now unleashed; they can now properly set objects on fire, including spilled welding fuel.