### PR TITLE
Fixed a bug that allowed for possibly infinite implants, maybe.

### DIFF
--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -48,11 +48,18 @@
 	if(istype(W, /obj/item/weapon/implanter))
 		var/obj/item/weapon/implanter/L = W
 		if(!L.imp)
-			forceMove(L)
-			user.show_message("<span class='warning'>You load \the [src] into \the [L].</span>")
-			L.imp = src
-			L.update()
-			return
+			if(!user.is_holding_item(src)) //Implant is not held
+				forceMove(L)
+				user.show_message("<span class='warning'>You load \the [src] into \the [L].</span>")
+				L.imp = src
+				L.update()
+			else if(user.drop_item(src, get_turf(user))) //Implant is held, try to drop it first
+				forceMove(L)
+				user.show_message("<span class='warning'>You load \the [src] into \the [L].</span>")
+				L.imp = src
+				L.update()
+			else //super-glued to user's hands
+				user.show_message("<span class='warning'>\The [src] is stuck in your hand!</span>")
 
 // Used by the implants that are activated by emotes.
 /obj/item/weapon/implant/proc/trigger(emote, mob/source)


### PR DESCRIPTION
- Implants will now be properly removed from hand when using an empty implanter on them
- Implants will not be taken if they are superglued to the user's hand

:cl:
 * bugfix: Implants no longer remain in the user's hand after using an empty implanter on them, which would also fill the implanter. In addition, superglued implants cannot be removed from the user's hand via the implanter.
