### PR TITLE
removed confirm prompt for start now

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1091,9 +1091,6 @@ var/global/floorIsLava = 0
 	if(!ticker)
 		alert("Unable to start the game as it is not set up.")
 		return
-	var/confirm = alert("Start the round RIGHT NOW?", "Start", "Yes", "Cancel")
-	if(confirm == "Cancel")
-		return
 	if(ticker.current_state == GAME_STATE_PREGAME)
 		ticker.current_state = GAME_STATE_SETTING_UP
 		log_admin("[usr.key] has started the game.")


### PR DESCRIPTION

## Why it's good
extremely annoying when you're testing code to have to pointlessly hit enter

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: The "Start Now" verb no longer asks for confirmation
