### PR TITLE
Exotic Seed crate tweak

### DIFF
--- a/code/datums/supply_packs/hydroponics.dm
+++ b/code/datums/supply_packs/hydroponics.dm
@@ -234,8 +234,8 @@
 	name = "Exotic seeds"
 	contains = list(/obj/item/seeds/dionanode,
 					/obj/item/seeds/dionanode,
-					/obj/item/seeds/libertymycelium,
-					/obj/item/seeds/reishimycelium,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
 					/obj/item/seeds/random,
 					/obj/item/seeds/random,
 					/obj/item/seeds/random,


### PR DESCRIPTION
Reishi and Liberty Cap seeds are really easy to get from a hacked plant vendor, and those vendors are usually hacked more often than not. Reishi and Liberty Caps are not used that often, definitely not enough to warrant having them on a crate whose main use is the exotic seeds.
## What this does
Removes the Reishi seed and the Liberty Cap seed from the exotic seeds crate, replacing them 2 extra randomized seeds.
## Why it's good
Buffs the exotic seeds crate, meaning you need to buy less overall crates to get the same amount of exotic seeds, since reishi and liberty caps are already available from the roundstart vendor and are not grown that often to justify having them in the crate.
:cl:
 * rscadd: Exotic Seeds crates now have 2 extra randomized seeds.
 * rscdel: Exotic Seeds crates no longer carry Reishi nor Liberty cap seeds.
