### PR TITLE
Fixes racks dropping parts less frequently on less severe explosions

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -788,14 +788,14 @@
 			destroy(FALSE)
 		if(2.0)
 			if(prob(50))
-				destroy(TRUE)
-			else
 				destroy(FALSE)
+			else
+				destroy(TRUE)
 		if(3.0)
 			if(prob(25))
-				destroy(TRUE)
-			else
 				destroy(FALSE)
+			else
+				destroy(TRUE)
 
 /obj/structure/rack/proc/checkhealth()
 	if(health <= 0)


### PR DESCRIPTION
[bugfix][consistency]

## What this does
the less controversial change

## Changelog
:cl:
 * bugfix: Racks are no longer more likely to get vaporized if further away from an explosion, but rather less, as intended.