### PR TITLE
Fixes gas sensor runtime on detecting no gases

### DIFF
--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -84,7 +84,7 @@
 			if(metric == "temperature")
 				signal.data["temperature"] = round(air_sample.temperature,0.1)
 			else if(metric in XGM.gases)
-				signal.data[metric] = round(100 * air_sample[metric] / total_moles, 0.1)
+				signal.data[metric] = total_moles ? round(100 * air_sample[metric] / total_moles, 0.1) : 0
 		for(var/gas_ID in XGM.gases)
 			if(!signal.data[gas_ID])
 				signal.data[gas_ID] = 0


### PR DESCRIPTION
[runtime][bugfix]

## What this does
stops this runtiming if there's no moles detected at all, since this line makes it divide by zero

## Changelog
:cl:
 * bugfix: Gas sensors now properly output signals if no gases are detected, if set to detect specific ones.