### PR TITLE
Fixes runtime on clumsy checking

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -690,7 +690,7 @@ a {
 		if(isrobot(user))
 			var/mob/living/silicon/robot/R = user
 			return HAS_MODULE_QUIRK(R, MODULE_IS_A_CLOWN)
-		return (M_CLUMSY in user.mutations) || user.reagents.has_reagent(INCENSE_BANANA) || user.reagents.has_reagent(HONKSERUM) || arcanetampered
+		return (M_CLUMSY in user.mutations) || (user.reagents?.has_reagent(INCENSE_BANANA)) || (user.reagents?.has_reagent(HONKSERUM)) || arcanetampered
 	return 0
 
 //Proc that handles NPCs (gremlins) "tampering" with this object.


### PR DESCRIPTION
[runtime][bugfix][consistency]

## What this does
should now allow the arcanetampered variable to be reached

## Changelog
:cl:
 * bugfix: Arcane tampered items now properly behave as clumsy on mobs without reagent holders. (that is, most non-human mobs)
