### PR TITLE
Adds admintesting pulse demon to mob blacklist

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -317,7 +317,8 @@ var/list/blacklisted_mobs = list(
 		/mob/living/simple_animal/hostile/asteroid/goliath/david/dave,	// Isn't supposed to be spawnable by xenobio
 		/mob/living/simple_animal/hostile/bunnybot,						// See viscerator
 		/mob/living/carbon/human/NPC,									// Unfinished, with its own AI that conflicts with player movements.
-		/mob/living/simple_animal/hostile/pulse_demon/,					// Your motherfucking life ends in 0 seconds.
+		/mob/living/simple_animal/hostile/pulse_demon,					// Your motherfucking life ends in 0 seconds.
+		/mob/living/simple_animal/hostile/pulse_demon/maxedout,			// Admin testing mob, do not ever spawn otherwise.
 		/mob/living/simple_animal/hostile/slime,						// Instantly kills player and destroys the MC.
 		)
 


### PR DESCRIPTION
[bugfix][consistency]

## What this does
Closes #36405.

## Changelog
:cl:
 * bugfix: Maxed-out pulse demons are also now blacklisted from mob spawns along with their normal variants.