### PR TITLE
Adds [stationname], [logo] macros for paperwork, and station name to hop paperwork

### DIFF
--- a/code/modules/paperwork/nano_paper.dm
+++ b/code/modules/paperwork/nano_paper.dm
@@ -50,6 +50,7 @@
 		\[large\] - \[/large\] : Increases the <span style=\"font-size:25px\">size</span> of the text.<br>
 		\[sign\] : Inserts a signature of your name in a foolproof way.<br>
 		\[stationname\] : Inserts the name of the station.<br>
+		\[logo\] : Inserts a medium-size Nanotrasen logo.<br>
 		\[field\] : Inserts an invisible field which lets you start type from there. Useful for forms.<br>
 		\[small\] - \[/small\] : Decreases the <span style=\"font-size:15px\">size</span> of the text.<br>
 		\[tiny\] - \[/tiny\] : Sharply decreases the <span style=\"font-size:10px\">size</span> of the text.<br>

--- a/code/modules/paperwork/nano_paper.dm
+++ b/code/modules/paperwork/nano_paper.dm
@@ -49,6 +49,7 @@
 		\[u\] - \[/u\] : Makes the text <u>underlined</u>.<br>
 		\[large\] - \[/large\] : Increases the <span style=\"font-size:25px\">size</span> of the text.<br>
 		\[sign\] : Inserts a signature of your name in a foolproof way.<br>
+		\[stationname\] : Inserts the name of the station.<br>
 		\[field\] : Inserts an invisible field which lets you start type from there. Useful for forms.<br>
 		\[small\] - \[/small\] : Decreases the <span style=\"font-size:15px\">size</span> of the text.<br>
 		\[tiny\] - \[/tiny\] : Sharply decreases the <span style=\"font-size:10px\">size</span> of the text.<br>

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -261,6 +261,7 @@
 		\[cell\] - Creates a new table cell.<br>
 		\[sign\] : Inserts a signature of your name in a foolproof way.<br>
 		\[stationname\] : Inserts the name of the station.<br>
+		\[logo\] : Inserts a medium-size Nanotrasen logo.<br>
 		\[field\] : Inserts an invisible field which lets you start type from there. Useful for forms.<br>
 		\[date\] : Inserts the current date in the format DAY MONTH, YEAR.<br>
 		\[time\] : Inserts the current station time.<br>

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -260,6 +260,7 @@
 		\[row\] - Creates a new table row.<br>
 		\[cell\] - Creates a new table cell.<br>
 		\[sign\] : Inserts a signature of your name in a foolproof way.<br>
+		\[stationname\] : Inserts the name of the station.<br>
 		\[field\] : Inserts an invisible field which lets you start type from there. Useful for forms.<br>
 		\[date\] : Inserts the current date in the format DAY MONTH, YEAR.<br>
 		\[time\] : Inserts the current station time.<br>

--- a/code/modules/paperwork/papers_preformatted.dm
+++ b/code/modules/paperwork/papers_preformatted.dm
@@ -69,12 +69,17 @@
 *     Head of Personnel     *
 *                           *
 ****************************/
+/obj/item/weapon/paper/hop
+	info = "paperwork goblin"
+
 /obj/item/weapon/paper/hop/additional_access
 	name = "Form AA/422"
 	fields = 8
+
+/obj/item/weapon/paper/hop/additional_access/New()
 	info = {"<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"></center> <br>
 	<span style=\"font-size:25px\"><center><b><i>AA/422: Additional Access Application</center></b></i></span> <br>
-	<span style=\"font-size:25px\"><center><i><b> NanoTrasen Science Station </b><span class=\"paper_field\"></span> </center></i></b></span> <br>
+	<span style=\"font-size:25px\"><center><i><b> NanoTrasen Science Station [station_name()] </b><span class=\"paper_field\"></span> </center></i></b></span> <br>
 	<hr> <br>
 	<b>Employee Name: </b><span class=\"paper_field\"></span> <br>
 	<b>Employee Signature: </b><span class=\"paper_field\"></span> <br>
@@ -88,13 +93,16 @@
 	<hr>
 	<b>I, the undersigned, approve the requested access for the oversigned:</b> <span class=\"paper_field\"></span><br>
 	<i><span style=\"font-size:15px\">The Head of Personnel must sign above and stamp this form to authorize the request before additional access can be applied to the requesting employee's ID. The Head(s) of Staff for the department(s) to which access is being granted must also be contacted and verbally authorize the request, where applicable. These guidelines must be followed or this form is void and illegal.</span></i>"}
+	..()
 
 /obj/item/weapon/paper/hop/job_transfer
 	name = "Form JBE/27"
 	fields = 8
+	
+/obj/item/weapon/paper/hop/job_transfer/New()	
 	info = {"<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"></center> <br>
 	<span style=\"font-size:25px\"><center><b><i>JBE/27: Job Transfer Request</center></b></i></span> <br>
-	<span style=\"font-size:25px\"><center><i><b> NanoTrasen Science Station Exodus </center></i></b></span> <br>
+	<span style=\"font-size:25px\"><center><i><b> NanoTrasen Science Station [station_name()] </center></i></b></span> <br>
 	<hr> <br>
 	<b>Employee Name: </b><span class=\"paper_field\"></span> <br>
 	<b>Employee Signature: </b><span class=\"paper_field\"></span> <br>
@@ -110,13 +118,16 @@
 	<b>HoP Name: </b><span class=\"paper_field\"></span> <br>
 	<b>HoP Signature: </b><span class=\"paper_field\"></span> <br>
 	<i><span style=\"font-size:15px\">The Head of Personnel must sign above and stamp this form to authorize the request before a job transfer can be applied to the requesting employee's ID. The Head(s) of Staff for the department(s) involved with the transfer must also be contacted and verbally authorize the transfer, where applicable. These guidelines must be followed or this form is void and illegal.</span></i>"}
+	..()
 
 /obj/item/weapon/paper/hop/demotion
 	name = "Form SLH/3A"
 	fields = 4
+	
+/obj/item/weapon/paper/hop/demotion/New()
 	info = {"<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"></center> <br>
 	<span style=\"font-size:25px\"><center><b><i>SLH-3A: Human Resources Demotion Record</center></b></i></span> <br>
-	<span style=\"font-size:25px\"><center><i><b> NanoTrasen Science Station Exodus </center></i></b></span> <br>
+	<span style=\"font-size:25px\"><center><i><b> NanoTrasen Science Station [station_name()] </center></i></b></span> <br>
 	<hr> <br>
 	<b>Demoted Employee: </b><span class=\"paper_field\"></span> <br>
 	<b>Former Assignment: </b><span class=\"paper_field\"></span> <br>
@@ -126,13 +137,16 @@
 	<hr> <br>
 	<b>Supervisor Signature: </b><span class=\"paper_field\"></span> <br>
 	<i><span style=\"font-size:15px\">If authorized, the document must be signed and stamped by the employee's supervisor. The Head of Personnel on site may then remove all departmental access from the ID and apply a <br>"Demoted\" job title. Incomplete or unstamped demotion records are void, and illegal demotions will be prosecuted in accordance with the law.</i></span>"}
+	..()
 
 /obj/item/weapon/paper/hop/replacement
 	name = "Form AA/418"
 	fields = 6
+	
+/obj/item/weapon/paper/hop/replacement/New()
 	info = {"<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"></center> <br>
 	<span style=\"font-size:25px\"><center><b><i>AA/418: ID Card / PDA Replacement Request</center></b></i></span> <br>
-	<span style=\"font-size:25px\"><center><i><b> NanoTrasen Science Station Exodus </center></i></b></span> <br>
+	<span style=\"font-size:25px\"><center><i><b> NanoTrasen Science Station [station_name()] </center></i></b></span> <br>
 	<hr> <br>
 	<b>Employee Name: </b><span class=\"paper_field\"></span> <br>
 	<b>Employee Signature: </b><span class=\"paper_field\"></span> <br>
@@ -144,13 +158,16 @@
 	<b>HoP Name: </b><span class=\"paper_field\"></span> <br>
 	<b>HoP Signature: </b><span class=\"paper_field\"></span> <br>
 	<i><span style=\"font-size:15px\">The Head of Personnel must sign above and stamp this form to authorize the request before a replacement identification card and/or personal data assistant may be issued. These guidelines must be followed or this form is void and illegal.</span></i>"}
+	..()
 
 /obj/item/weapon/paper/hop/evaluation
 	name = "Form SLH/5"
 	fields = 8
+	
+/obj/item/weapon/paper/hop/evaluation/New()
 	info = {"<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"></center> <br>
 	<span style=\"font-size:25px\"><center><b><i>SLH-5: Human Resources Employee Evaluation</center></b></i></span> <br>
-	<span style=\"font-size:25px\"><center><i><b> NanoTrasen Science Station Exodus </center></i></b></span> <br>
+	<span style=\"font-size:25px\"><center><i><b> NanoTrasen Science Station [station_name()] </center></i></b></span> <br>
 	<hr> <br>
 	<b>Employee: </b><span class=\"paper_field\"></span> <br>
 	<b>Assignment: </b><span class=\"paper_field\"></span> <br>
@@ -174,13 +191,16 @@
 	<hr> <br>
 	<b>Supervisor Signature: </b><span class=\"paper_field\"></span> <br>
 	<i><span style=\"font-size:15px\">To complete the evaluation, the employee's supervisor must sign above and stamp the document with the department stamp. Incomplete or unstamped evaluations will not be processed.</span></i>"}
+	..()
 
 /obj/item/weapon/paper/hop/weapon_permit
 	name = "Form AK/74"
 	fields = 7
+	
+/obj/item/weapon/paper/hop/weapon_permit/New()
 	info = {"<center><img src="http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png"></center> <br>
 	<span style=\"font-size:25px\"><center><b><i>AK/74: Weapons Permit Application</center></b></i></span> <br>
-	<span style=\"font-size:25px\"><center><i><b> NanoTrasen Science Station Exodus </center></i></b></span> <br>
+	<span style=\"font-size:25px\"><center><i><b> NanoTrasen Science Station [station_name()] </center></i></b></span> <br>
 	<hr> <br>
 	<b>Employee Name: </b><span class=\"paper_field\"></span> <br>
 	<b>Employee Signature: </b><span class=\"paper_field\"></span> <br>
@@ -196,6 +216,7 @@
 	<b>HoP Name: </b><span class=\"paper_field\"></span> <br>
 	<b>HoP Signature: </b><span class=\"paper_field\"></span> <br>
 	<i><span style=\"font-size:15px\">The Head of Personnel must sign above and stamp this form to authorize this application before a weapon permit can be applied to the requesting employee's ID. The Warden or Head of Security must also approve the issuing of any firearms from the armory, where applicable. These guidelines must be followed or this form is void and illegal.</span></i>"}
+	..()
 
 
 /****************************

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -99,6 +99,7 @@
 	t = replacetext(t, "\[date\]", "[current_date_string]")
 	t = replacetext(t, "\[time\]", "[worldtime2text()]")
 	t = replacetext(t, "\[stationname\]", "[station_name()]")
+	t = replacetext(t, "\[logo\]", "<img src=\"http://ss13.moe/wiki/images/1/17/NanoTrasen_Logo.png\">")
 
 	// tables ported from Baystation12 : https://github.com/Baystation12/Baystation12
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -98,6 +98,7 @@
 	t = replacetext(t, "\[field\]", "<span class=\"paper_field\"></span>")
 	t = replacetext(t, "\[date\]", "[current_date_string]")
 	t = replacetext(t, "\[time\]", "[worldtime2text()]")
+	t = replacetext(t, "\[stationname\]", "[station_name()]")
 
 	// tables ported from Baystation12 : https://github.com/Baystation12/Baystation12
 


### PR DESCRIPTION
![what](https://github.com/vgstation-coders/vgstation13/assets/8468269/6d86b7de-5695-4592-aeb0-1d793b05dbd5)
![why](https://github.com/vgstation-coders/vgstation13/assets/8468269/2e6b3e9f-7044-4481-81eb-511875a17386)

:cl:
 * rscadd: added [stationname] and [logo] macros to paperwork
 * spellcheck: HoP standard paperwork now states the proper station name instead of Exodus
