### PR TITLE
Shuttle Chair Next to Intercom Welder Fix

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -648,7 +648,7 @@
 	ghost_can_rotate = TRUE
 
 /obj/structure/bed/chair/shuttle/attackby(var/obj/item/W, var/mob/user)
-	var/mob/M = locate() in loc//so attacking people isn't made harder by the seats' bulkiness
+	var/mob/living/M = locate() in loc //so attacking people isn't made harder by the seats' bulkiness
 	if (M && M != user)
 		return M.attackby(W,user)
 	if(istype(W, /obj/item/assembly/shock_kit))


### PR DESCRIPTION
Another mystery from Dacendeth.

## Why can't you use a welder on a shuttle chair when there's an intercom next to it?
Why indeed.

![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/c76499ac-1def-4835-88b2-776822b716d2)

## What this does
Intercoms have an invisible mob called a "virtual hearer" that sits on the same tile as the intercom. When things are spoken, nearby mobs hear it (not machines!). Since the intercom is a machine, it needs the virtual hearer to listen to speech. All well and good.

Shuttle chairs, being large and bulky, have a special check when attacked to forward attacks to the first mob locate()'d under them so that trying to hit someone hiding behind the chair isn't a click-the-pixel challenge.

The issue is that the mob locator was locating the invisible hearer generated by the intercom (which is not actually on the wall but is on the floor next to the wall). Attacking the chair would result in changing your target to the virtual hearer. Since you can't attack this virtual hearer normally, your attack would fail without any text or feedback in chat. This PR makes the shuttle chair search for an actual living mob instead. Shoutout to @DamianX.

This also had the funny side effect of detecting ghosts if you attacked a chair while a ghost was on that same turf, leading to a funny way to see if you were being spooked.

## Why it's good
Since this removes a way of detecting if ghosts are near you, it's not.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Intercoms no longer prevent you from using tools on shuttle chairs.
 * bugfix: You can no longer detect if a ghost is on a shuttle chair's turf by attacking a shuttle chair with a tool such as a wrench and seeing if you get a message back or not.