### PR TITLE
Better hair GFI fix

### DIFF
--- a/code/libs/Get Flat Icon/Get Flat Icon Deluxe.dm
+++ b/code/libs/Get Flat Icon/Get Flat Icon Deluxe.dm
@@ -162,10 +162,7 @@ cons:
 		if (!istype(parent[GFI_DX_ATOM],/obj/effect/blob)) // blob connection overlays use custom dirs
 			data[GFI_DX_DIR] = parent[GFI_DX_DIR]
 		if (to_sort:plane == FLOAT_PLANE)
-			if (parent[GFI_DX_STATE] == "bald_s")//because hair and beard overlays are on an overlay already themselves. sigh.
-				data[GFI_DX_PLANE] = parent[GFI_DX_PLANE]
-				data[GFI_DX_LAYER] = parent[GFI_DX_LAYER]
-			else if (is_underlay)
+			if (is_underlay)
 				data[GFI_DX_PLANE] = parent[GFI_DX_PLANE] - 0.1
 			else
 				data[GFI_DX_PLANE] = parent[GFI_DX_PLANE] + 0.1

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -296,33 +296,31 @@ var/global/list/damage_icon_parts = list()
 		if(update_icons)
 			update_icons()
 		return
-	var/mutable_appearance/hair_overlay = mutable_appearance('icons/mob/hair_styles.dmi', "bald_s", -HAIR_LAYER)
+	var/list/hair_overlays = list()
 	var/hair_suffix = check_hidden_head_flags(MASKHEADHAIR) ? "s2" : "s" // s2 = cropped icon
 	if(my_appearance.f_style && !(check_hidden_flags(get_clothing_items(), HIDEBEARDHAIR, force_check = TRUE))) //If the beard is hidden, don't draw it
 		var/datum/sprite_accessory/facial_hair_style = facial_hair_styles_list[my_appearance.f_style]
 		if((facial_hair_style) && (species.name in facial_hair_style.species_allowed))
-			var/mutable_appearance/facial_hair_overlay = mutable_appearance(facial_hair_style.icon, "[facial_hair_style.icon_state]_s")
+			var/mutable_appearance/facial_hair_overlay = mutable_appearance(facial_hair_style.icon, "[facial_hair_style.icon_state]_s", -HAIR_LAYER)
 			if(facial_hair_style.do_colouration)
 				facial_hair_overlay.color = COLOR_MATRIX_ADD(rgb(my_appearance.r_facial, my_appearance.g_facial, my_appearance.b_facial))
-			hair_overlay.overlays += facial_hair_overlay
+			hair_overlays += facial_hair_overlay
 	if(my_appearance.h_style && !(check_hidden_flags(get_clothing_items(), HIDEHEADHAIR, force_check = TRUE))) //If the hair is hidden, don't draw it
 		var/datum/sprite_accessory/hair_style = hair_styles_list[my_appearance.h_style]
 		if((hair_style) && (species.name in hair_style.species_allowed))
-			var/mutable_appearance/hair_style_overlay
 			if(isvox(src))
 				if(my_appearance.r_hair > 7)
 					my_appearance.r_hair = rand(1,7)
-				hair_style_overlay = mutable_appearance(hair_style.icon, "[hair_style.icon_state]_[my_appearance.r_hair]_[hair_suffix]")
-			else
-				hair_style_overlay = mutable_appearance(hair_style.icon, "[hair_style.icon_state]_[hair_suffix]")
-				if(hair_style.do_colouration)
-					hair_style_overlay.color = COLOR_MATRIX_ADD(rgb(my_appearance.r_hair, my_appearance.g_hair, my_appearance.b_hair))
-				if(hair_style.additional_accessories)
-					hair_style_overlay.overlays += mutable_appearance(hair_style.icon, "[hair_style.icon_state]_acc")
-			hair_overlay.overlays += hair_style_overlay
+			var/mutable_appearance/hair_overlay = mutable_appearance(hair_style.icon, "[hair_style.icon_state][isvox(src) ? "_[my_appearance.r_hair]" : ""]_[hair_suffix]", -HAIR_LAYER)
+			if(hair_style.do_colouration)
+				hair_overlay.color = COLOR_MATRIX_ADD(rgb(my_appearance.r_hair, my_appearance.g_hair, my_appearance.b_hair))
+			if(hair_style.additional_accessories)
+				hair_overlay.overlays += mutable_appearance(hair_style.icon, "[hair_style.icon_state]_acc", -HAIR_LAYER)
+			hair_overlays += hair_overlay
 	if(body_alphas.len)
-		hair_overlay.alpha = get_lowest_body_alpha()
-	overlays += overlays_standing[HAIR_LAYER] = hair_overlay
+		for(var/mutable_appearance/overlay_image as anything in hair_overlays)
+			overlay_image.alpha = get_lowest_body_alpha()
+	overlays += overlays_standing[HAIR_LAYER] = hair_overlays
 	if(update_icons)
 		update_icons()
 


### PR DESCRIPTION
Didn't like how  anti-futureproof the hair fix was [checking if the icon state was "bald_s"], actually talked to Deity about it but it got merged pretty fast

I reverted that icon state check in GFI, and changed hair overlays
previously there was a base hair MA, with the facial hair and hair being separate MAs added as overlays on the base MA
now the facial hair and hair MAs are added to a list instead, which gets passed to HAIR_LAYER overlays

tested, works fine

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Slightly tweaked hair overlay generation
