### PR TITLE
Screwdriving False Walls Works and Does Not Runtime

### DIFF
--- a/code/datums/hud/meson_hud.dm
+++ b/code/datums/hud/meson_hud.dm
@@ -61,6 +61,9 @@ var/list/meson_images = list()
 		meson_images -= meson_image
 	if(is_on_mesons)
 		meson_image = image(icon,loc,icon_state,layer,dir)
+		//in case of the mover event calling this proc on something sent to the nullspace realm...
+		if(isnull(loc) || !meson_image)
+			return
 		meson_image.plane = relative_plane_to_plane(plane, loc.plane)
 		meson_images += meson_image
 		for (var/mob/L in meson_wearers)

--- a/code/datums/hud/meson_hud.dm
+++ b/code/datums/hud/meson_hud.dm
@@ -60,9 +60,11 @@ var/list/meson_images = list()
 				L.client.images -= meson_image
 		meson_images -= meson_image
 	if(is_on_mesons)
-		meson_image = image(icon,loc,icon_state,layer,dir)
 		//in case of the mover event calling this proc on something sent to the nullspace realm...
-		if(isnull(loc) || !meson_image)
+		if(isnull(loc))
+			return
+		meson_image = image(icon,loc,icon_state,layer,dir)
+		if(!meson_image)
 			return
 		meson_image.plane = relative_plane_to_plane(plane, loc.plane)
 		meson_images += meson_image

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -192,7 +192,10 @@
 			user.visible_message("[user] tightens some bolts on the wall.", "You tighten the bolts on the wall.")
 			W.playtoolsound(T, 50)
 			if(!mineral || mineral == "metal")
-				T.ChangeTurf(text2path("/turf/simulated/wall/[reinforced ? "r_wall" : ""]"))
+				if(reinforced)
+					T.ChangeTurf(/turf/simulated/wall/r_wall)
+				else
+					T.ChangeTurf(/turf/simulated/wall)
 			else
 				T.ChangeTurf(text2path("/turf/simulated/wall/mineral/[mineral]"))
 			qdel(src)


### PR DESCRIPTION
A two for one bugfix special, with a bonus efficiency improvement.

![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/58ac7aca-14c3-4056-8104-2e78e0a01f4f)

## What this does
This PR does three things:
1) Fixes regular false walls getting deleted when a screwdriver is used on them, instead of them turning into actual walls. This was fixed by replacing ``wall/`` with ``wall``. This fixes #36422.
2) Removes a string search for a type, replacing it with hardcoded types.
3) Stops a runtime from happening due to an event forcing an ``update_meson_image()`` call on an atom that's been destroyed (and nullspaced as a result), but without the ``is_on_mesons`` flag set to false yet. This fixes #36423.

## Why it's good
restores the ability to lock people in their hidden rooms with just a screwdriver.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Normal false walls now properly turn into their standard wall type when screwdrivered instead of being deleted.