### PR TITLE
[Cult 4] Blood Stone Balance & Fixes

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -108,7 +108,11 @@
 	//			playsound(src, W.hitsound, 50, 1, -1)
 			if (sound_damaged)
 				playsound(src, sound_damaged, 75, 1)
-			takeDamage(W.force)
+			if(isholyweapon(W))
+				playsound(loc, 'sound/weapons/welderattack.ogg', 50, 1)
+				takeDamage(W.force*2)
+			else
+				takeDamage(W.force)
 			if (W.attack_verb)
 				visible_message("<span class='warning'>\The [user] [pick(W.attack_verb)] \the [src] with \the [W].</span>")
 			else
@@ -1659,6 +1663,19 @@ var/list/cult_spires = list()
 			takeDamage(50)
 		if (3)
 			takeDamage(10)
+
+/obj/structure/cult/bloodstone/singularity_act(var/singularity_size=0,var/obj/machinery/singularity/S)
+	switch(singularity_size)
+		if(1 to 4)
+			ex_act(3)
+		if(5 to 8)
+			ex_act(2)
+		if(9 to INFINITY)
+			ex_act(1)
+	return 0
+
+/obj/structure/cult/bloodstone/singularity_pull(S, current_size, repel = FALSE)//we don't want that one to come unanchored
+	return
 
 /obj/structure/cult/bloodstone/update_icon()
 	if (!ready)

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -256,6 +256,7 @@
 		if (O.damtype == HALLOSS)
 			damage = 0
 		if(isholyweapon(O))
+			playsound(loc, 'sound/weapons/welderattack.ogg', 50, 1)
 			damage *= 2
 			purge = 3
 		adjustBruteLoss(damage)


### PR DESCRIPTION
:cl:
* tweak: Cult Structures now take double damage from holy weapons (such as Null Rods)
* soundadd: Cult Structures and Constructs now emit a burning sound when hit by holy weapons.
* bugfix: The Blood Stone no longer gets instantly deleted by singularities, but instead takes damage over time. Damage depends on singularity size.
* bugfix: The Blood Stone can no longer get unanchored by singularities or the Gravity Well Gun.