### PR TITLE
TEG flow rate fix

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -188,14 +188,14 @@
 	data["output"] = format_watts(last_gen)
 
 	if(circ1)
-		data["first_flow_cap"] = round(circ1.volume_capacity_used * 100)
+		data["first_flow_cap"] = round(circ1.volume_capacity_used * 100 * 3) //we are multiplying by 3 here because the circulator divides its flow rate by 3. supposedly this is for lube, however lube does not actually affect the flow rate, only produce more power. if that is changed, remove the 3x here.
 		data["first_in_pressure"] = round(circ1.air1.return_pressure(), 1)
 		data["first_in_temp"] = round(circ1.air1.temperature, 1)
 		data["first_out_pressure"] = round(circ1.air2.return_pressure(), 1)
 		data["first_out_temp"] = round(circ1.air2.temperature, 1)
 
 	if(circ2)
-		data["second_flow_cap"] = round(circ2.volume_capacity_used * 100)
+		data["second_flow_cap"] = round(circ2.volume_capacity_used * 100 * 3)
 		data["second_in_pressure"] = round(circ2.air1.return_pressure(), 1)
 		data["second_in_temp"] = round(circ2.air1.temperature, 1)
 		data["second_out_pressure"] = round(circ2.air2.return_pressure(), 1)


### PR DESCRIPTION
[bugfix] [ui]

alternative to #36435

## What this does
fixes the teg being capped at 33% by changing the display number. no actual change to output has been made.
![Capture](https://github.com/vgstation-coders/vgstation13/assets/68451232/c7250ede-c4b6-434c-bf87-86f8d9c76195)


## Why it's good
fixes weird issue

## Changelog
:cl:
 * bugfix: the TEG will now show its flow rate up to 100% instead of 33%
