### PR TITLE
[Cult 4] Shorter post-Nar-Sie emergency shuttle timers

### DIFF
--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -115,7 +115,7 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 // sets the time left to a given delay (in seconds)
 /datum/emergency_shuttle/proc/settimeleft(var/delay)
 	if (extremely_hihg_speed)
-		endtime = world.time + 600
+		endtime = world.time + 60 SECONDS
 		timelimit = 60
 	else
 		endtime = world.time + delay * 10

--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -45,6 +45,8 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 
 	var/was_early_launched = FALSE //had timer shortened to 10 seconds
 
+	var/extremely_hihg_speed = FALSE
+
 	// call the shuttle
 	// if not called before, set the endtime to T+600 seconds
 	// otherwise if outgoing, switch to incoming
@@ -112,8 +114,12 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 
 // sets the time left to a given delay (in seconds)
 /datum/emergency_shuttle/proc/settimeleft(var/delay)
-	endtime = world.time + delay * 10
-	timelimit = delay
+	if (extremely_hihg_speed)
+		endtime = world.time + 600
+		timelimit = 60
+	else
+		endtime = world.time + delay * 10
+		timelimit = delay
 
 /datum/emergency_shuttle/proc/get_shuttle_timer()
 	var/shuttle_time_left = timeleft()

--- a/code/datums/gamemode/factions/legacy_cult/narsie.dm
+++ b/code/datums/gamemode/factions/legacy_cult/narsie.dm
@@ -58,11 +58,13 @@ var/global/list/narsie_list = list()
 				narsie_spawn_animation()
 				if(!narsie_cometh)//so we don't initiate Hell more than one time.
 					if (emergency_shuttle)
+						emergency_shuttle.extremely_hihg_speed = TRUE
 						emergency_shuttle.incall()
 						emergency_shuttle.can_recall = 0
-						if(emergency_shuttle.endtime > world.timeofday + 2400 && emergency_shuttle.location != 1 && !emergency_shuttle.departed)
-							emergency_shuttle.settimeleft(240)
-
+						if(emergency_shuttle.endtime > world.timeofday + 600 && emergency_shuttle.location != 1 && !emergency_shuttle.departed)
+							emergency_shuttle.settimeleft(60)
+						spawn(5 SECONDS)
+							command_alert(/datum/command_alert/narsie_has_risen)
 					ticker.StartThematic("endgame")
 
 					SetUniversalState(/datum/universal_state/hell)

--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -646,6 +646,12 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 	force_report = 1
 	message = "Destruction of the Blood Stone has been confirmed. The Cult's power aboard the station will be greatly diminished."
 
+/datum/command_alert/narsie_has_risen
+	name = "Nar-Sie Has Risen"
+	alert_title = "Emergency Evacuation"
+	force_report = 1
+	message = "The station will not stay in this plane for much longer. At great expense, we are dispatching an Emergency Shuttle to your Escape dock within the next minute, and it will be leaving after an short stop. We recommend keeping any Enemies of the Corporation off the vessel. It's leaving with or without you."
+
 //////////////BLOOD CULT
 
 /*


### PR DESCRIPTION

:cl:
* tweak: A new announcement now appears following Nar-Sie's rise that warns the crew that a special emergency shuttle was dispatched. This shuttle arrives at the station after a minute, stays for a minute, and returns to Centcomm in just a minute. So the round now ends only 3 minutes after the cult's victory.