### PR TITLE
Standardises and fixes mob status updates

### DIFF
--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -34,7 +34,10 @@
 				break
 		dreaming = 0
 
-/mob/living/carbon/proc/handle_dreams()
+/mob/living/proc/handle_dreams()
+	return //TODO: maybe one day?
+
+/mob/living/carbon/handle_dreams()
 	if(prob(5) && !dreaming)
 		dream()
 

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -18,6 +18,8 @@ Gunshots/explosions/opening doors/less rare audio (done)
 	var/obj/halitem
 	var/hal_screwyhud = 0 //1 - critical, 2 - dead, 3 - oxygen indicator, 4 - toxin indicator
 	var/handling_hal = 0
+
+/mob/living // for the sleep checks pls merge back if you know a better way kthx
 	var/hal_crit = 0
 
 /mob/living/carbon/proc/handle_hallucinations()

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -16,6 +16,8 @@
 
 	see_in_dark = 8
 
+	sleep_emote = "hiss"
+
 	var/plasma = 250
 	var/max_plasma = 500
 	var/neurotoxin_cooldown = 0

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -298,25 +298,23 @@
 	if(.)
 		stat = DEAD
 
+/mob/living/carbon/alien/humanoid/handle_crit_updates()
+	. = ..()
+	if(.)
+		if( health <= 20 && prob(1) )
+			spawn(0)
+				emote("gasp")
+		if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
+			adjustOxyLoss(1)
+
 /mob/living/carbon/alien/humanoid/handle_regular_status_updates()
 	. = ..()
 	if(stat != DEAD)				//ALIVE. LIGHTS ARE ON
 
-		//UNCONSCIOUS. NO-ONE IS HOME
-		if((getOxyLoss() > 50 || config.health_threshold_crit > health) && !(status_flags & BUDDHAMODE))
-			if( health <= 20 && prob(1) )
-				spawn(0)
-					emote("gasp")
-			if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
-				adjustOxyLoss(1)
-
-		else if(sleeping)
+		if(!paralysis && sleeping)
 			if( prob(10) && health )
 				spawn(0)
 					emote("hiss")
-		//CONSCIOUS
-		else
-			stat = CONSCIOUS
 
 		/*	What in the living hell is this?*/
 		if(move_delay_add > 0)

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -295,8 +295,7 @@
 
 
 /mob/living/carbon/alien/humanoid/handle_regular_status_updates()
-	updatehealth()
-
+	. = ..()
 	if(stat != DEAD)				//ALIVE. LIGHTS ARE ON
 		if((health < config.health_threshold_dead || !has_brain()) && !(status_flags & BUDDHAMODE))
 			death()
@@ -328,7 +327,6 @@
 		//Other
 		if(!stunned)
 			update_icons()
-	return ..()
 
 
 /mob/living/carbon/alien/humanoid/handle_regular_hud_updates()

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -52,9 +52,6 @@
 	//stuff in the stomach
 	handle_stomach()
 
-
-	//Status updates, death etc.
-	handle_regular_status_updates()
 	update_canmove()
 
 	// Grabbing
@@ -297,13 +294,10 @@
 	return //TODO: DEFERRED
 
 
-/mob/living/carbon/alien/humanoid/proc/handle_regular_status_updates()
+/mob/living/carbon/alien/humanoid/handle_regular_status_updates()
 	updatehealth()
 
-	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
-		blinded = 1
-		silent = 0
-	else				//ALIVE. LIGHTS ARE ON
+	if(stat != DEAD)				//ALIVE. LIGHTS ARE ON
 		if((health < config.health_threshold_dead || !has_brain()) && !(status_flags & BUDDHAMODE))
 			death()
 			blinded = 1
@@ -318,16 +312,8 @@
 					emote("gasp")
 			if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 				adjustOxyLoss(1)
-			Paralyse(3)
 
-		if(paralysis)
-			AdjustParalysis(-1)
-			blinded = 1
-			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
 		else if(sleeping)
-			sleeping = max(sleeping-1, 0)
-			blinded = 1
-			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
 			if( prob(10) && health )
 				spawn(0)
 					emote("hiss")
@@ -339,44 +325,10 @@
 		if(move_delay_add > 0)
 			move_delay_add = max(0, move_delay_add - rand(1, 2))
 
-		//Eyes
-		if(sdisabilities & BLIND)		//disabled-blind, doesn't get better on its own
-			blinded = 1
-		else if(eye_blind)			//blindness, heals slowly over time
-			eye_blind = max(eye_blind-1,0)
-			blinded = 1
-		else if(eye_blurry)	//blurry eyes heal slowly
-			eye_blurry = max(eye_blurry-1, 0)
-
-		//Ears
-		if(sdisabilities & DEAF)		//disabled-deaf, doesn't get better on its own
-			ear_deaf = max(ear_deaf, 1)
-		else if(ear_deaf)			//deafness, heals slowly over time
-			ear_deaf = max(ear_deaf-1, 0)
-		else if(ear_damage < 25)	//ear damage heals slowly under this threshold. otherwise you'll need earmuffs
-			ear_damage = max(ear_damage-0.05, 0)
-
 		//Other
-		if(stunned)
-			AdjustStunned(-1)
-			if(!stunned)
-				update_icons()
-
-		if(knockdown)
-			knockdown = max(knockdown-1,0)	//before you get mad Rockdtben: I done this so update_canmove isn't called multiple times
-
-		if(stuttering)
-			stuttering = max(stuttering-1, 0)
-
-		if(say_mute)
-			say_mute = max(say_mute-1, 0)
-
-		if(silent)
-			silent = max(silent-1, 0)
-
-		if(druggy)
-			druggy = max(druggy-1, 0)
-	return 1
+		if(!stunned)
+			update_icons()
+	return ..()
 
 
 /mob/living/carbon/alien/humanoid/handle_regular_hud_updates()

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -293,16 +293,14 @@
 
 	return //TODO: DEFERRED
 
+/mob/living/carbon/alien/humanoid/check_dead()
+	. = ..()
+	if(.)
+		stat = DEAD
 
 /mob/living/carbon/alien/humanoid/handle_regular_status_updates()
 	. = ..()
 	if(stat != DEAD)				//ALIVE. LIGHTS ARE ON
-		if((health < config.health_threshold_dead || !has_brain()) && !(status_flags & BUDDHAMODE))
-			death()
-			blinded = 1
-			stat = DEAD
-			silent = 0
-			return 1
 
 		//UNCONSCIOUS. NO-ONE IS HOME
 		if((getOxyLoss() > 50 || config.health_threshold_crit > health) && !(status_flags & BUDDHAMODE))

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -307,12 +307,6 @@
 		if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 			adjustOxyLoss(1)
 
-/mob/living/carbon/alien/handle_sleep() // larvae are the same here
-	..()
-	if( prob(10) && health )
-		spawn(0)
-			emote("hiss")
-
 /mob/living/carbon/alien/handle_regular_status_updates()
 	. = ..()
 	if(stat != DEAD)				//ALIVE. LIGHTS ARE ON

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -307,22 +307,23 @@
 		if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 			adjustOxyLoss(1)
 
-/mob/living/carbon/alien/humanoid/handle_regular_status_updates()
+/mob/living/carbon/alien/handle_sleep() // larvae are the same here
+	..()
+	if( prob(10) && health )
+		spawn(0)
+			emote("hiss")
+
+/mob/living/carbon/alien/handle_regular_status_updates()
 	. = ..()
 	if(stat != DEAD)				//ALIVE. LIGHTS ARE ON
-
-		if(!paralysis && sleeping)
-			if( prob(10) && health )
-				spawn(0)
-					emote("hiss")
-
 		/*	What in the living hell is this?*/
 		if(move_delay_add > 0)
 			move_delay_add = max(0, move_delay_add - rand(1, 2))
 
-		//Other
-		if(!stunned)
-			update_icons()
+/mob/living/carbon/alien/humanoid/handle_regular_status_updates()
+	. = ..()
+	if(stat != DEAD && !stunned)
+		update_icons()
 
 
 /mob/living/carbon/alien/humanoid/handle_regular_hud_updates()

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -225,8 +225,7 @@
 	return //TODO: DEFERRED
 
 /mob/living/carbon/alien/larva/handle_regular_status_updates()
-	updatehealth()
-
+	. = ..()
 	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
 		if((health < -25 || !has_brain()) && !(status_flags & BUDDHAMODE))
 			death()
@@ -260,8 +259,6 @@
 		/*	What in the living hell is this?*/
 		if(move_delay_add > 0)
 			move_delay_add = max(0, move_delay_add - rand(1, 2))
-	return ..()
-
 
 /mob/living/carbon/alien/larva/handle_regular_hud_updates()
 

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -231,22 +231,20 @@
 		silent = 0
 		return 1
 
+/mob/living/carbon/alien/larva/handle_crit_updates()
+	if( (getOxyLoss() > 25) || (0 > health) )
+		//if( health <= 20 && prob(1) )
+		//	spawn(0)
+		//		emote("gasp")
+		if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
+			adjustOxyLoss(1)
+
 /mob/living/carbon/alien/larva/handle_regular_status_updates()
 	. = ..()
 	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
 
-		//UNCONSCIOUS. NO-ONE IS HOME
-		if( (getOxyLoss() > 25) || (0 > health) )
-			//if( health <= 20 && prob(1) )
-			//	spawn(0)
-			//		emote("gasp")
-			if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
-				adjustOxyLoss(1)
-
 		if(paralysis)
-			AdjustParalysis(-2)
-			blinded = 1
-			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
+			AdjustParalysis(-1) // extra -1 for larvae for some reason
 		else if(sleeping)
 			sleeping = max(sleeping-1, 0)
 			blinded = 1
@@ -254,9 +252,6 @@
 			if( prob(10) && health )
 				spawn(0)
 					emote("hiss_")
-		//CONSCIOUS
-		else
-			stat = CONSCIOUS
 
 		/*	What in the living hell is this?*/
 		if(move_delay_add > 0)

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -52,8 +52,6 @@
 	//stuff in the stomach
 	//handle_stomach()
 
-	//Status updates, death etc.
-	handle_regular_status_updates()
 	update_canmove()
 
 	// Grabbing
@@ -226,13 +224,10 @@
 
 	return //TODO: DEFERRED
 
-/mob/living/carbon/alien/larva/proc/handle_regular_status_updates()
+/mob/living/carbon/alien/larva/handle_regular_status_updates()
 	updatehealth()
 
-	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
-		blinded = 1
-		silent = 0
-	else				//ALIVE. LIGHTS ARE ON
+	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
 		if((health < -25 || !has_brain()) && !(status_flags & BUDDHAMODE))
 			death()
 			blinded = 1
@@ -246,7 +241,6 @@
 			//		emote("gasp")
 			if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 				adjustOxyLoss(1)
-			Paralyse(3)
 
 		if(paralysis)
 			AdjustParalysis(-2)
@@ -266,43 +260,7 @@
 		/*	What in the living hell is this?*/
 		if(move_delay_add > 0)
 			move_delay_add = max(0, move_delay_add - rand(1, 2))
-
-		//Eyes
-		if(sdisabilities & BLIND)	//disabled-blind, doesn't get better on its own
-			blinded = 1
-		else if(eye_blind)			//blindness, heals slowly over time
-			eye_blind = max(eye_blind-1,0)
-			blinded = 1
-		else if(eye_blurry)	//blurry eyes heal slowly
-			eye_blurry = max(eye_blurry-1, 0)
-
-		//Ears
-		if(sdisabilities & DEAF)	//disabled-deaf, doesn't get better on its own
-			ear_deaf = max(ear_deaf, 1)
-		else if(ear_deaf)			//deafness, heals slowly over time
-			ear_deaf = max(ear_deaf-1, 0)
-		else if(ear_damage < 25)	//ear damage heals slowly under this threshold.
-			ear_damage = max(ear_damage-0.05, 0)
-
-		//Other
-		if(stunned)
-			AdjustStunned(-1)
-
-		if(knockdown)
-			knockdown = max(knockdown-1,0)	//before you get mad Rockdtben: I done this so update_canmove isn't called multiple times
-
-		if(say_mute)
-			say_mute = max(say_mute-1, 0)
-
-		if(stuttering)
-			stuttering = max(stuttering-1, 0)
-
-		if(silent)
-			silent = max(silent-1, 0)
-
-		if(druggy)
-			druggy = max(druggy-1, 0)
-	return 1
+	return ..()
 
 
 /mob/living/carbon/alien/larva/handle_regular_hud_updates()

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -241,21 +241,8 @@
 
 /mob/living/carbon/alien/larva/handle_regular_status_updates()
 	. = ..()
-	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
-
-		if(paralysis)
-			AdjustParalysis(-1) // extra -1 for larvae for some reason
-		else if(sleeping)
-			sleeping = max(sleeping-1, 0)
-			blinded = 1
-			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
-			if( prob(10) && health )
-				spawn(0)
-					emote("hiss_")
-
-		/*	What in the living hell is this?*/
-		if(move_delay_add > 0)
-			move_delay_add = max(0, move_delay_add - rand(1, 2))
+	if(stat != DEAD && paralysis)
+		AdjustParalysis(-1) // extra -1 for larvae for some reason
 
 /mob/living/carbon/alien/larva/handle_regular_hud_updates()
 

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -234,11 +234,6 @@
 /mob/living/carbon/alien/larva/handle_regular_status_updates()
 	. = ..()
 	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
-		if((health < -25 || !has_brain()) && !(status_flags & BUDDHAMODE))
-			death()
-			blinded = 1
-			silent = 0
-			return 1
 
 		//UNCONSCIOUS. NO-ONE IS HOME
 		if( (getOxyLoss() > 25) || (0 > health) )

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -224,6 +224,13 @@
 
 	return //TODO: DEFERRED
 
+/mob/living/carbon/alien/larva/check_dead()
+	if((health < -25 || !has_brain()) && !(status_flags & BUDDHAMODE))
+		death()
+		blinded = 1
+		silent = 0
+		return 1
+
 /mob/living/carbon/alien/larva/handle_regular_status_updates()
 	. = ..()
 	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -124,8 +124,7 @@
 
 
 /mob/living/carbon/brain/handle_regular_status_updates()
-	updatehealth()
-
+	. = ..()
 	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
 		if( !container && (health < config.health_threshold_dead || ((world.time - timeofhostdeath) > config.revival_brain_life)) )
 			death()
@@ -185,7 +184,6 @@
 					alert = 0
 					to_chat(src, "<span class='warning'>All systems restored.</span>")
 					emp_damage -= 1
-	return ..()
 
 
 /mob/living/carbon/brain/handle_regular_hud_updates()

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -123,14 +123,16 @@
 	return //TODO: DEFERRED
 
 
+/mob/living/carbon/brain/check_dead()
+	if( !container && (health < config.health_threshold_dead || ((world.time - timeofhostdeath) > config.revival_brain_life)) )
+		death()
+		blinded = 1
+		silent = 0
+		return 1
+
 /mob/living/carbon/brain/handle_regular_status_updates()
 	. = ..()
 	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
-		if( !container && (health < config.health_threshold_dead || ((world.time - timeofhostdeath) > config.revival_brain_life)) )
-			death()
-			blinded = 1
-			silent = 0
-			return 1
 
 		//Handling EMP effect in the Life(), it's made VERY simply, and has some additional effects handled elsewhere
 		if(emp_damage)			//This is pretty much a damage type only used by MMIs, dished out by the emp_act

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -26,8 +26,6 @@
 	if(environment)	// More error checking -- TLE
 		handle_environment(environment)
 
-	//Status updates, death etc.
-	handle_regular_status_updates()
 	update_canmove()
 
 	if(client)
@@ -125,13 +123,10 @@
 	return //TODO: DEFERRED
 
 
-/mob/living/carbon/brain/proc/handle_regular_status_updates()	//TODO: comment out the unused bits >_>
+/mob/living/carbon/brain/handle_regular_status_updates()
 	updatehealth()
 
-	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
-		blinded = 1
-		silent = 0
-	else				//ALIVE. LIGHTS ARE ON
+	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
 		if( !container && (health < config.health_threshold_dead || ((world.time - timeofhostdeath) > config.revival_brain_life)) )
 			death()
 			blinded = 1
@@ -190,23 +185,7 @@
 					alert = 0
 					to_chat(src, "<span class='warning'>All systems restored.</span>")
 					emp_damage -= 1
-
-		//Other
-		if(stunned)
-			AdjustStunned(-1)
-
-		if(knockdown)
-			knockdown = max(knockdown-1,0)	//before you get mad Rockdtben: I done this so update_canmove isn't called multiple times
-
-		if(stuttering)
-			stuttering = max(stuttering-1, 0)
-
-		if(silent)
-			silent = max(silent-1, 0)
-
-		if(druggy)
-			druggy = max(druggy-1, 0)
-	return 1
+	return ..()
 
 
 /mob/living/carbon/brain/handle_regular_hud_updates()

--- a/code/modules/mob/living/carbon/complex/complex_defines.dm
+++ b/code/modules/mob/living/carbon/complex/complex_defines.dm
@@ -1,4 +1,5 @@
 /mob/living/carbon/complex
+	sleep_emote = "snore"
 	var/icon_state_standing
 	var/icon_state_lying
 	var/icon_state_dead

--- a/code/modules/mob/living/carbon/complex/life.dm
+++ b/code/modules/mob/living/carbon/complex/life.dm
@@ -266,11 +266,7 @@
 /mob/living/carbon/complex/handle_regular_status_updates()
 	updatehealth()
 
-	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
-		blinded = 1
-		silent = 0
-	else				//ALIVE. LIGHTS ARE ON
-		updatehealth()
+	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
 		if((health < config.health_threshold_dead || !has_brain()) && !(status_flags & BUDDHAMODE))
 			death()
 			blinded = 1
@@ -285,74 +281,16 @@
 					emote("gasp")
 			if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 				adjustOxyLoss(1)
-			Paralyse(3)
-		if(halloss > 100)
-			visible_message("<B>[src]</B> slumps to the ground, too weak to continue fighting.","<span class='notice'>You're in too much pain to keep going.</span>")
-			Paralyse(10)
-			setHalLoss(99)
 
-		if(paralysis)
-			AdjustParalysis(-1)
-			blinded = 1
-			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
-			if(halloss > 0)
-				adjustHalLoss(-3)
-		else if(sleeping)
+		if(!paralysis && sleeping)
 			handle_dreams()
-			adjustHalLoss(-3)
-			sleeping = max(sleeping-1, 0)
-			blinded = 1
-			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
 			if( prob(10) && health && !hal_crit )
 				spawn(0)
 					emote("snore")
 		else if(resting)
 			if(halloss > 0)
 				adjustHalLoss(-3)
-		//CONSCIOUS
-		else if(undergoing_hypothermia() >= SEVERE_HYPOTHERMIA)
-			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
-		else
-			stat = CONSCIOUS
-			if(halloss > 0)
-				adjustHalLoss(-1)
-
-		//Eyes
-		if(sdisabilities & BLIND)	//disabled-blind, doesn't get better on its own
-			blinded = 1
-		else if(eye_blind)			//blindness, heals slowly over time
-			eye_blind = max(eye_blind-1,0)
-			blinded = 1
-		else if(eye_blurry)			//blurry eyes heal slowly
-			eye_blurry = max(eye_blurry-1, 0)
-
-		//Ears
-		if(sdisabilities & DEAF)		//disabled-deaf, doesn't get better on its own
-			ear_deaf = max(ear_deaf, 1)
-		else if(ear_deaf)			//deafness, heals slowly over time
-			ear_deaf = max(ear_deaf-1, 0)
-		else if(ear_damage < 25)	//ear damage heals slowly under this threshold. otherwise you'll need earmuffs
-			ear_damage = max(ear_damage-0.05, 0)
-
-		//Other
-		if(stunned)
-			AdjustStunned(-1)
-
-		if(knockdown)
-			knockdown = max(knockdown-1,0)	//before you get mad Rockdtben: I done this so update_canmove isn't called multiple times
-
-		if(say_mute)
-			say_mute = max(say_mute-1, 0)
-
-		if(stuttering)
-			stuttering = max(stuttering-1, 0)
-
-		if(silent)
-			silent = max(silent-1, 0)
-
-		if(druggy)
-			druggy = max(druggy-1, 0)
-	return 1
+	return ..()
 
 /mob/living/carbon/complex/proc/handle_chemicals_in_body()
 

--- a/code/modules/mob/living/carbon/complex/life.dm
+++ b/code/modules/mob/living/carbon/complex/life.dm
@@ -33,9 +33,6 @@
 	//Check if we're on fire
 	handle_fire()
 
-	//Status updates, death etc.
-	handle_regular_status_updates()
-
 	update_canmove()
 
 	if(client)
@@ -266,7 +263,7 @@
 
 
 
-/mob/living/carbon/complex/proc/handle_regular_status_updates()
+/mob/living/carbon/complex/handle_regular_status_updates()
 	updatehealth()
 
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP

--- a/code/modules/mob/living/carbon/complex/life.dm
+++ b/code/modules/mob/living/carbon/complex/life.dm
@@ -268,16 +268,17 @@
 	if(.)
 		stat = DEAD
 
+/mob/living/carbon/complex/handle_crit_updates()
+	if( (getOxyLoss() > 25) || (config.health_threshold_crit > health) )
+		if( health <= 20 && prob(1) )
+			spawn(0)
+				emote("gasp")
+		if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
+			adjustOxyLoss(1)
+
 /mob/living/carbon/complex/handle_regular_status_updates()
 	. = ..()
 	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
-		//UNCONSCIOUS. NO-ONE IS HOME
-		if( (getOxyLoss() > 25) || (config.health_threshold_crit > health) )
-			if( health <= 20 && prob(1) )
-				spawn(0)
-					emote("gasp")
-			if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
-				adjustOxyLoss(1)
 
 		if(!paralysis && sleeping)
 			handle_dreams()

--- a/code/modules/mob/living/carbon/complex/life.dm
+++ b/code/modules/mob/living/carbon/complex/life.dm
@@ -264,8 +264,7 @@
 
 
 /mob/living/carbon/complex/handle_regular_status_updates()
-	updatehealth()
-
+	. = ..()
 	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
 		if((health < config.health_threshold_dead || !has_brain()) && !(status_flags & BUDDHAMODE))
 			death()
@@ -290,7 +289,6 @@
 		else if(resting)
 			if(halloss > 0)
 				adjustHalLoss(-3)
-	return ..()
 
 /mob/living/carbon/complex/proc/handle_chemicals_in_body()
 

--- a/code/modules/mob/living/carbon/complex/life.dm
+++ b/code/modules/mob/living/carbon/complex/life.dm
@@ -276,18 +276,12 @@
 		if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 			adjustOxyLoss(1)
 
-/mob/living/carbon/complex/handle_regular_status_updates()
-	. = ..()
-	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
-
-		if(!paralysis && sleeping)
-			handle_dreams()
-			if( prob(10) && health && !hal_crit )
-				spawn(0)
-					emote("snore")
-		else if(resting)
-			if(halloss > 0)
-				adjustHalLoss(-3)
+/mob/living/carbon/complex/handle_sleep()
+	..()
+	handle_dreams()
+	if( prob(10) && health && !hal_crit )
+		spawn(0)
+			emote("snore")
 
 /mob/living/carbon/complex/proc/handle_chemicals_in_body()
 

--- a/code/modules/mob/living/carbon/complex/life.dm
+++ b/code/modules/mob/living/carbon/complex/life.dm
@@ -263,16 +263,14 @@
 
 
 
+/mob/living/carbon/complex/check_dead()
+	. = ..()
+	if(.)
+		stat = DEAD
+
 /mob/living/carbon/complex/handle_regular_status_updates()
 	. = ..()
 	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
-		if((health < config.health_threshold_dead || !has_brain()) && !(status_flags & BUDDHAMODE))
-			death()
-			blinded = 1
-			stat = DEAD
-			silent = 0
-			return 1
-
 		//UNCONSCIOUS. NO-ONE IS HOME
 		if( (getOxyLoss() > 25) || (config.health_threshold_crit > health) )
 			if( health <= 20 && prob(1) )

--- a/code/modules/mob/living/carbon/complex/life.dm
+++ b/code/modules/mob/living/carbon/complex/life.dm
@@ -276,13 +276,6 @@
 		if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 			adjustOxyLoss(1)
 
-/mob/living/carbon/complex/handle_sleep()
-	..()
-	handle_dreams()
-	if( prob(10) && health && !hal_crit )
-		spawn(0)
-			emote("snore")
-
 /mob/living/carbon/complex/proc/handle_chemicals_in_body()
 
 	burn_calories(HUNGER_FACTOR,1)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -1,4 +1,6 @@
 /mob/living/carbon/human
+	sleep_emote = "snore"
+	sleep_emote_prob = 2
 	//Hair colour and style are in apperance.dm
 
 	var/multicolor_skin_r = 0	//Only used when the human has a species datum with the MULTICOLOR anatomical flag

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -181,7 +181,6 @@ var/global/list/organ_damage_overlays = list(
 		return //We go ahead and process them 5 times for HUD images and other stuff though.
 	handle_environment(environment)
 	handle_fire()
-	handle_regular_status_updates()	//Optimized a bit
 	update_canmove()
 	//Update our name based on whether our face is obscured/disfigured
 	handle_regular_hud_updates()

--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -21,6 +21,9 @@
 		if(hallucination)
 			if(hallucination >= 20 && !handling_hal)
 				spawn handle_hallucinations() //The not boring kind!
+		else
+			for(var/atom/a in hallucinations)
+				qdel(a)
 
 		//Eyes
 		if(!species.has_organ["eyes"]) //Presumably if a species has no eyes, they see via something else.

--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -1,10 +1,7 @@
 //Refer to life.dm for caller
 
-/mob/living/carbon/human/proc/handle_regular_status_updates()
-	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
-		blinded = 1
-		silent = 0
-	else				//ALIVE. LIGHTS ARE ON
+/mob/living/carbon/human/handle_regular_status_updates()
+	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
 
 		//Sobering multiplier.
 		//Sober block grants quadruple the alcohol metabolism.
@@ -27,15 +24,7 @@
 
 		//UNCONSCIOUS. NO-ONE IS HOME
 		if((getOxyLoss() > 50 || config.health_threshold_crit > health) && !(status_flags & BUDDHAMODE))
-			Paralyse(3)
 			species.OnCrit(src)
-
-			/* Done by handle_breath()
-			if( health <= 20 && prob(1) )
-				spawn(0)
-					emote("gasp")
-			if(!reagents.has_reagent(INAPROVALINE))
-				adjustOxyLoss(1)*/
 		else
 			species.OutOfCrit(src)
 
@@ -43,135 +32,22 @@
 			if(hallucination >= 20 && !handling_hal)
 				spawn handle_hallucinations() //The not boring kind!
 
-			if(hallucination<=2)
-				hallucination = 0
-				halloss = 0
-			else
-				hallucination -= 2
-
-		else
-			for(var/atom/a in hallucinations)
-				qdel(a)
-
-			if(halloss > 100)
-				to_chat(src, "<span class='notice'>You're in too much pain to keep going...</span>")
-				for(var/mob/O in oviewers(src, null))
-					O.show_message("<B>[src]</B> slumps to the ground, too weak to continue fighting.", 1)
-				Paralyse(10)
-				setHalLoss(99)
-
-		if(paralysis)
-			AdjustParalysis(-1)
-			blinded = 1
-			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
-			if(halloss > 0)
-				adjustHalLoss(-3)
-		else if(sleeping)
+		if(!paralysis && sleeping)
 			handle_dreams()
-			adjustHalLoss(-3)
-			sleeping = max(sleeping-1, 0)
-			blinded = 1
-			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
 			if(prob(2) && health && !hal_crit)
 				spawn(0)
 					emote("snore")
-		else if(undergoing_hypothermia() >= SEVERE_HYPOTHERMIA)
-			blinded = 1
-			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
-		//CONSCIOUS
-		else
-			stat = CONSCIOUS
-			if(halloss > 0)
-				adjustHalLoss(-1)
-
-		if(resting && halloss > 0)
-			adjustHalLoss(-3)
 
 		//Eyes
 		if(!species.has_organ["eyes"]) //Presumably if a species has no eyes, they see via something else.
 			eye_blind =  0
 			blinded =    0
 			eye_blurry = 0
-		else if(!has_eyes())           //Eyes cut out? Permablind.
-			eye_blind =  1
-			blinded =    1
-			eye_blurry = 0
-		else if(sdisabilities & BLIND) //Disabled-blind, doesn't get better on its own
-			blinded =    1
-			eye_blurry = 0
-		else if(eye_blind)		       //Blindness, heals slowly over time
-			eye_blind =  max(eye_blind - 1, 0)
-			blinded =    1
 		else if(istype(glasses, /obj/item/clothing/glasses/sunglasses/blindfold)) //Resting your eyes with a blindfold heals blurry eyes faster
 			eye_blurry = max(eye_blurry - 3, 0)
 			blinded =    1
-		else if(eye_blurry)
-			eye_blurry = max(eye_blurry - 1, 0)
-
-		//Ears
-		if(sdisabilities & DEAF) //Disabled-deaf, doesn't get better on its own
-			ear_deaf = max(ear_deaf, 1)
-		else if(earprot()) //Resting your ears with earmuffs heals ear damage faster
-			ear_damage = max(ear_damage - 0.15, 0)
-			ear_deaf = max(ear_deaf, 1) //This MUST be above the following else if or deafness cures itself while wearing earmuffs
-		else if(ear_deaf) //Deafness, heals slowly over time
-			ear_deaf = max(ear_deaf - 1, 0)
-		else if(ear_damage < 25) //Ear damage heals slowly under this threshold. otherwise you'll need earmuffs
-			ear_damage = max(ear_damage - 0.05, 0)
 
 		handle_dizziness()
 		handle_jitteriness()
 
-		//Flying
-		if(flying)
-			spawn()
-				animate(src, pixel_y = pixel_y + 5 * PIXEL_MULTIPLIER, time = 10, loop = 1, easing = SINE_EASING)
-			spawn(10)
-				if(flying)
-					animate(src, pixel_y = pixel_y - 5 * PIXEL_MULTIPLIER, time = 10, loop = 1, easing = SINE_EASING)
-
-		//Other
-		if(stunned)
-			AdjustStunned(-1)
-
-		if(knockdown)
-			knockdown = max(knockdown - 1,0) //Before you get mad Rockdtben: I done this so update_canmove isn't called multiple times
-
-		if(say_mute)
-			say_mute = max(say_mute-1, 0)
-
-		if(stuttering)
-			stuttering = max(stuttering - 1, 0)
-		if(slurring)
-			slurring = max(slurring - (1 * sober_str), 0)
-		if(silent)
-			silent = max(silent - 1, 0)
-
-		if(druggy)
-			druggy = max(druggy - 1, 0)
-			if(!druggy)
-				to_chat(src, "It looks like you are back in Kansas.")
-
-		if(teleportitis)
-			teleportitis = max(teleportitis - 1, 0)
-			if(prob(10))
-				do_teleport(src, get_turf(src), 7)
-		if(timeslip)
-			timeslip = max(timeslip - 1, 0)
-			if(prob(10))
-				switch(pick(list(1,2,3)))
-					if(1)
-						attempt_past_send(5 SECONDS, TRUE)
-					if(2)
-						attempt_future_send(5 SECONDS, TRUE)
-					else
-						timestop(src, 5 SECONDS, 1, TRUE)
-/*
-		// Increase germ_level regularly
-		if(prob(40))
-			germ_level += 1
-		// If you're dirty, your gloves will become dirty, too.
-		if(gloves && germ_level > gloves.germ_level && prob(10))
-			gloves.germ_level += 1
-*/
-	return 1
+	return ..()

--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -1,7 +1,7 @@
 //Refer to life.dm for caller
 
 /mob/living/carbon/human/handle_regular_status_updates()
-	..()
+	. = ..()
 	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
 
 		//Sobering multiplier.
@@ -46,6 +46,3 @@
 		else if(istype(glasses, /obj/item/clothing/glasses/sunglasses/blindfold)) //Resting your eyes with a blindfold heals blurry eyes faster
 			eye_blurry = max(eye_blurry - 3, 0)
 			blinded =    1
-
-		handle_dizziness()
-		handle_jitteriness()

--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -25,7 +25,7 @@
 			for(var/atom/a in hallucinations)
 				qdel(a)
 
-/mob/living/carbon/human/handle_blind()
+/mob/living/carbon/human/handle_blind_updates()
 	if(!species.has_organ["eyes"]) //Presumably if a species has no eyes, they see via something else.
 		eye_blind =  0
 		blinded =    0

--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -11,30 +11,23 @@
 	else
 		species.OutOfCrit(src)
 
+/mob/living/carbon/human/handle_sleep()
+	..()
+	handle_dreams()
+	if( prob(2) && health && !hal_crit )
+		spawn(0)
+			emote("snore")
+
 /mob/living/carbon/human/handle_regular_status_updates()
 	. = ..()
 	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
-
-		//Sobering multiplier.
-		//Sober block grants quadruple the alcohol metabolism.
-		var/sober_str =! (M_SOBER in mutations) ? 1:4
-
 		if(!in_stasis)
 			handle_organs()	//Optimized.
 			handle_blood()
 
-		//The analgesic effect wears off slowly
-		pain_numb = max(0, pain_numb - 1)
-
 		if(hallucination)
 			if(hallucination >= 20 && !handling_hal)
 				spawn handle_hallucinations() //The not boring kind!
-
-		if(!paralysis && sleeping)
-			handle_dreams()
-			if(prob(2) && health && !hal_crit)
-				spawn(0)
-					emote("snore")
 
 		//Eyes
 		if(!species.has_organ["eyes"]) //Presumably if a species has no eyes, they see via something else.

--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -11,13 +11,6 @@
 	else
 		species.OutOfCrit(src)
 
-/mob/living/carbon/human/handle_sleep()
-	..()
-	handle_dreams()
-	if( prob(2) && health && !hal_crit )
-		spawn(0)
-			emote("snore")
-
 /mob/living/carbon/human/handle_regular_status_updates()
 	. = ..()
 	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON

--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -1,4 +1,8 @@
 //Refer to life.dm for caller
+/mob/living/carbon/human/check_dead()
+	. = ..()
+	if(.)
+		emote("deathgasp", message = TRUE)
 
 /mob/living/carbon/human/handle_regular_status_updates()
 	. = ..()
@@ -11,13 +15,6 @@
 		if(!in_stasis)
 			handle_organs()	//Optimized.
 			handle_blood()
-
-		if((health <= config.health_threshold_dead || !has_brain()) && !(status_flags & BUDDHAMODE))
-			emote("deathgasp", message = TRUE)
-			death()
-			blinded = 1
-			silent = 0
-			return 1
 
 		//The analgesic effect wears off slowly
 		pain_numb = max(0, pain_numb - 1)

--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -4,6 +4,13 @@
 	if(.)
 		emote("deathgasp", message = TRUE)
 
+/mob/living/carbon/human/handle_crit_updates()
+	//UNCONSCIOUS. NO-ONE IS HOME
+	if((getOxyLoss() > 50 || config.health_threshold_crit > health) && !(status_flags & BUDDHAMODE))
+		species.OnCrit(src)
+	else
+		species.OutOfCrit(src)
+
 /mob/living/carbon/human/handle_regular_status_updates()
 	. = ..()
 	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
@@ -18,12 +25,6 @@
 
 		//The analgesic effect wears off slowly
 		pain_numb = max(0, pain_numb - 1)
-
-		//UNCONSCIOUS. NO-ONE IS HOME
-		if((getOxyLoss() > 50 || config.health_threshold_crit > health) && !(status_flags & BUDDHAMODE))
-			species.OnCrit(src)
-		else
-			species.OutOfCrit(src)
 
 		if(hallucination)
 			if(hallucination >= 20 && !handling_hal)

--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -1,13 +1,13 @@
 //Refer to life.dm for caller
 
 /mob/living/carbon/human/handle_regular_status_updates()
+	..()
 	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
 
 		//Sobering multiplier.
 		//Sober block grants quadruple the alcohol metabolism.
 		var/sober_str =! (M_SOBER in mutations) ? 1:4
 
-		updatehealth() //TODO
 		if(!in_stasis)
 			handle_organs()	//Optimized.
 			handle_blood()
@@ -49,5 +49,3 @@
 
 		handle_dizziness()
 		handle_jitteriness()
-
-	return ..()

--- a/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_status_updates.dm
@@ -25,11 +25,13 @@
 			for(var/atom/a in hallucinations)
 				qdel(a)
 
-		//Eyes
-		if(!species.has_organ["eyes"]) //Presumably if a species has no eyes, they see via something else.
-			eye_blind =  0
-			blinded =    0
-			eye_blurry = 0
-		else if(istype(glasses, /obj/item/clothing/glasses/sunglasses/blindfold)) //Resting your eyes with a blindfold heals blurry eyes faster
-			eye_blurry = max(eye_blurry - 3, 0)
-			blinded =    1
+/mob/living/carbon/human/handle_blind()
+	if(!species.has_organ["eyes"]) //Presumably if a species has no eyes, they see via something else.
+		eye_blind =  0
+		blinded =    0
+		eye_blurry = 0
+	else if(istype(glasses, /obj/item/clothing/glasses/sunglasses/blindfold)) //Resting your eyes with a blindfold heals blurry eyes faster
+		eye_blurry = max(eye_blurry - 3, 0)
+		blinded =    1
+	else
+		..()

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -541,15 +541,14 @@
 	updatehealth()
 	return //TODO: DEFERRED
 
+/mob/living/carbon/monkey/check_dead()
+	. = ..()
+	if(.)
+		stat = DEAD
+
 /mob/living/carbon/monkey/handle_regular_status_updates()
 	. = ..()
 	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
-		if((health < config.health_threshold_dead || !has_brain()) && !(status_flags & BUDDHAMODE))
-			death()
-			blinded = 1
-			stat = DEAD
-			silent = 0
-			return 1
 
 		//UNCONSCIOUS. NO-ONE IS HOME
 		if((getOxyLoss() > 25 || config.health_threshold_crit > health) && !(status_flags & BUDDHAMODE))

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -554,6 +554,13 @@
 		if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 			adjustOxyLoss(1)
 
+/mob/living/carbon/monkey/handle_blind_updates()
+	if(istype(glasses, /obj/item/clothing/glasses/sunglasses/blindfold)) //Resting your eyes with a blindfold heals blurry eyes faster
+		eye_blurry = max(eye_blurry - 3, 0)
+		blinded =    1
+	else
+		..()
+
 /mob/living/carbon/monkey/handle_regular_hud_updates()
 	if(!client)
 		return

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -554,13 +554,6 @@
 		if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 			adjustOxyLoss(1)
 
-/mob/living/carbon/monkey/handle_sleep()
-	..()
-	handle_dreams()
-	if( prob(10) && health && !hal_crit )
-		spawn(0)
-			emote("snore")
-
 /mob/living/carbon/monkey/handle_regular_hud_updates()
 	if(!client)
 		return

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -542,10 +542,8 @@
 	return //TODO: DEFERRED
 
 /mob/living/carbon/monkey/handle_regular_status_updates()
-	updatehealth()
-
+	. = ..()
 	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
-		updatehealth()
 		if((health < config.health_threshold_dead || !has_brain()) && !(status_flags & BUDDHAMODE))
 			death()
 			blinded = 1
@@ -569,8 +567,6 @@
 		else if(resting)
 			if(halloss > 0)
 				adjustHalLoss(-3)
-	
-	return ..()
 
 /mob/living/carbon/monkey/handle_regular_hud_updates()
 	if(!client)

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -554,18 +554,12 @@
 		if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 			adjustOxyLoss(1)
 
-/mob/living/carbon/monkey/handle_regular_status_updates()
-	. = ..()
-	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
-
-		if(!paralysis && sleeping)
-			handle_dreams()
-			if( prob(10) && health && !hal_crit )
-				spawn(0)
-					emote("snore")
-		else if(resting)
-			if(halloss > 0)
-				adjustHalLoss(-3)
+/mob/living/carbon/monkey/handle_sleep()
+	..()
+	handle_dreams()
+	if( prob(10) && health && !hal_crit )
+		spawn(0)
+			emote("snore")
 
 /mob/living/carbon/monkey/handle_regular_hud_updates()
 	if(!client)

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -65,9 +65,6 @@
 	//Check if we're on fire
 	handle_fire()
 
-	//Status updates, death etc.
-	handle_regular_status_updates()
-
 	update_canmove()
 
 	if(client)
@@ -544,13 +541,10 @@
 	updatehealth()
 	return //TODO: DEFERRED
 
-/mob/living/carbon/monkey/proc/handle_regular_status_updates()
+/mob/living/carbon/monkey/handle_regular_status_updates()
 	updatehealth()
 
-	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
-		blinded = 1
-		silent = 0
-	else				//ALIVE. LIGHTS ARE ON
+	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
 		updatehealth()
 		if((health < config.health_threshold_dead || !has_brain()) && !(status_flags & BUDDHAMODE))
 			death()
@@ -566,77 +560,17 @@
 					emote("gasp")
 			if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
 				adjustOxyLoss(1)
-			Paralyse(3)
-		if(halloss > 100)
-			to_chat(src, "<span class='notice'>You're in too much pain to keep going...</span>")
-			for(var/mob/O in oviewers(src, null))
-				O.show_message("<B>[src]</B> slumps to the ground, too weak to continue fighting.", 1)
-			Paralyse(10)
-			setHalLoss(99)
 
-		if(paralysis)
-			AdjustParalysis(-1)
-			blinded = 1
-			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
-			if(halloss > 0)
-				adjustHalLoss(-3)
 		else if(sleeping)
 			handle_dreams()
-			adjustHalLoss(-3)
-			sleeping = max(sleeping-1, 0)
-			blinded = 1
-			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
 			if( prob(10) && health && !hal_crit )
 				spawn(0)
 					emote("snore")
 		else if(resting)
 			if(halloss > 0)
 				adjustHalLoss(-3)
-		//CONSCIOUS
-		else if(undergoing_hypothermia() >= SEVERE_HYPOTHERMIA)
-			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
-		else
-			stat = CONSCIOUS
-			if(halloss > 0)
-				adjustHalLoss(-1)
-
-		//Eyes
-		if(sdisabilities & BLIND)	//disabled-blind, doesn't get better on its own
-			blinded = 1
-		else if(eye_blind)			//blindness, heals slowly over time
-			eye_blind = max(eye_blind-1,0)
-			blinded = 1
-		else if(eye_blurry)			//blurry eyes heal slowly
-			eye_blurry = max(eye_blurry-1, 0)
-
-		//Ears
-		if(sdisabilities & DEAF)		//disabled-deaf, doesn't get better on its own
-			ear_deaf = max(ear_deaf, 1)
-		else if(ear_deaf)			//deafness, heals slowly over time
-			ear_deaf = max(ear_deaf-1, 0)
-		else if(ear_damage < 25)	//ear damage heals slowly under this threshold. otherwise you'll need earmuffs
-			ear_damage = max(ear_damage-0.05, 0)
-
-		//Other
-		if(stunned)
-			AdjustStunned(-1)
-
-		if(knockdown)
-			knockdown = max(knockdown-1,0)	//before you get mad Rockdtben: I done this so update_canmove isn't called multiple times
-
-		if(stuttering)
-			stuttering = max(stuttering-1, 0)
-
-		if(say_mute)
-			say_mute = max(say_mute-1, 0)
-
-		if(silent)
-			silent = max(silent-1, 0)
-
-		if(druggy)
-			druggy = max(druggy-1, 0)
-	return 1
-
+	
+	return ..()
 
 /mob/living/carbon/monkey/handle_regular_hud_updates()
 	if(!client)

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -546,19 +546,19 @@
 	if(.)
 		stat = DEAD
 
+/mob/living/carbon/monkey/handle_crit_updates()
+	if((getOxyLoss() > 25 || config.health_threshold_crit > health) && !(status_flags & BUDDHAMODE))
+		if( health <= 20 && prob(1) )
+			spawn(0)
+				emote("gasp")
+		if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
+			adjustOxyLoss(1)
+
 /mob/living/carbon/monkey/handle_regular_status_updates()
 	. = ..()
 	if(stat != DEAD)	//ALIVE. LIGHTS ARE ON
 
-		//UNCONSCIOUS. NO-ONE IS HOME
-		if((getOxyLoss() > 25 || config.health_threshold_crit > health) && !(status_flags & BUDDHAMODE))
-			if( health <= 20 && prob(1) )
-				spawn(0)
-					emote("gasp")
-			if(!reagents.has_any_reagents(list(INAPROVALINE,PRESLOMITE)))
-				adjustOxyLoss(1)
-
-		else if(sleeping)
+		if(!paralysis && sleeping)
 			handle_dreams()
 			if( prob(10) && health && !hal_crit )
 				spawn(0)

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -10,6 +10,7 @@
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/animal/monkey
 	species_type = /mob/living/carbon/monkey
 	treadmill_speed = 0.8 //Slow apes!
+	sleep_emote = "snore"
 	var/attack_text = "bites"
 	var/languagetoadd = LANGUAGE_MONKEY
 	var/namenumbers = TRUE

--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -42,9 +42,6 @@
 	if(environment)
 		handle_environment(environment)
 
-	//Status updates, death etc.
-	handle_regular_status_updates()
-
 /mob/living/carbon/slime/proc/AIprocess()  // the master AI process
 
 //	to_chat(world, "AI proc started.")
@@ -238,7 +235,7 @@
 
 	return //TODO: DEFERRED
 
-/mob/living/carbon/slime/proc/handle_regular_status_updates()
+/mob/living/carbon/slime/handle_regular_status_updates()
 
 
 	if(slime_lifestage == SLIME_ADULT)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -113,6 +113,31 @@
 		spawn(0)
 			emote(sleep_emote)
 
+/mob/living/proc/handle_blind()
+	if(!has_eyes())           //Eyes cut out? Permablind.
+		eye_blind =  1
+		blinded =    1
+		eye_blurry = 0
+	else if(sdisabilities & BLIND) //Disabled-blind, doesn't get better on its own
+		blinded =    1
+		eye_blurry = 0
+	else if(eye_blind)		       //Blindness, heals slowly over time
+		eye_blind =  max(eye_blind - 1, 0)
+		blinded =    1
+	else if(eye_blurry)
+		eye_blurry = max(eye_blurry - 1, 0)
+
+/mob/living/proc/handle_deaf()
+	if(sdisabilities & DEAF) //Disabled-deaf, doesn't get better on its own
+		ear_deaf = max(ear_deaf, 1)
+	else if(earprot()) //Resting your ears with earmuffs heals ear damage faster
+		ear_damage = max(ear_damage - 0.15, 0)
+		ear_deaf = max(ear_deaf, 1) //This MUST be above the following else if or deafness cures itself while wearing earmuffs
+	else if(ear_deaf) //Deafness, heals slowly over time
+		ear_deaf = max(ear_deaf - 1, 0)
+	else if(ear_damage < 25) //Ear damage heals slowly under this threshold. otherwise you'll need earmuffs
+		ear_damage = max(ear_damage - 0.05, 0)
+
 /mob/living/proc/handle_regular_status_updates() //Refer to life.dm for caller
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
 		blinded = 1
@@ -123,7 +148,7 @@
 		//Sober block grants quadruple the alcohol metabolism.
 		var/sober_str =! (M_SOBER in mutations) ? 1:4
 
-		updatehealth() //TODO
+		updatehealth() //TODO: this comment said TODO when this coder found it, but todo what?
 
 		if(check_dead())
 			return 1
@@ -168,30 +193,8 @@
 		if(resting && halloss > 0)
 			adjustHalLoss(-3)
 
-		//Eyes
-		else if(!has_eyes())           //Eyes cut out? Permablind.
-			eye_blind =  1
-			blinded =    1
-			eye_blurry = 0
-		else if(sdisabilities & BLIND) //Disabled-blind, doesn't get better on its own
-			blinded =    1
-			eye_blurry = 0
-		else if(eye_blind)		       //Blindness, heals slowly over time
-			eye_blind =  max(eye_blind - 1, 0)
-			blinded =    1
-		else if(eye_blurry)
-			eye_blurry = max(eye_blurry - 1, 0)
-
-		//Ears
-		if(sdisabilities & DEAF) //Disabled-deaf, doesn't get better on its own
-			ear_deaf = max(ear_deaf, 1)
-		else if(earprot()) //Resting your ears with earmuffs heals ear damage faster
-			ear_damage = max(ear_damage - 0.15, 0)
-			ear_deaf = max(ear_deaf, 1) //This MUST be above the following else if or deafness cures itself while wearing earmuffs
-		else if(ear_deaf) //Deafness, heals slowly over time
-			ear_deaf = max(ear_deaf - 1, 0)
-		else if(ear_damage < 25) //Ear damage heals slowly under this threshold. otherwise you'll need earmuffs
-			ear_damage = max(ear_damage - 0.05, 0)
+		handle_blind()
+		handle_deaf()
 
 		//Flying
 		if(flying)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -104,10 +104,14 @@
 		return 1
 
 /mob/living/proc/handle_sleep()
+	handle_dreams()
 	adjustHalLoss(-3)
 	sleeping = max(sleeping-1, 0)
 	blinded = 1
 	stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
+	if(sleep_emote && prob(sleep_emote_prob) && health && !hal_crit)
+		spawn(0)
+			emote(sleep_emote)
 
 /mob/living/proc/handle_regular_status_updates() //Refer to life.dm for caller
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -98,6 +98,11 @@
 		return 1
 	return 0
 
+/mob/living/proc/handle_crit_updates()
+	if((getOxyLoss() > 50 || config.health_threshold_crit > health) && !(status_flags & BUDDHAMODE))
+		Paralyse(3)
+		return 1
+
 /mob/living/proc/handle_regular_status_updates() //Refer to life.dm for caller
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
 		blinded = 1
@@ -117,8 +122,7 @@
 		pain_numb = max(0, pain_numb - 1)
 
 		//UNCONSCIOUS. NO-ONE IS HOME
-		if((getOxyLoss() > 50 || config.health_threshold_crit > health) && !(status_flags & BUDDHAMODE))
-			Paralyse(3)
+		handle_crit_updates()
 
 		if(hallucination)
 			if(hallucination<=2)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -103,6 +103,12 @@
 		Paralyse(3)
 		return 1
 
+/mob/living/proc/handle_sleep()
+	adjustHalLoss(-3)
+	sleeping = max(sleeping-1, 0)
+	blinded = 1
+	stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
+
 /mob/living/proc/handle_regular_status_updates() //Refer to life.dm for caller
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
 		blinded = 1
@@ -149,10 +155,7 @@
 			if(halloss > 0)
 				adjustHalLoss(-3)
 		else if(sleeping)
-			adjustHalLoss(-3)
-			sleeping = max(sleeping-1, 0)
-			blinded = 1
-			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
+			handle_sleep()
 		else if(undergoing_hypothermia() >= SEVERE_HYPOTHERMIA)
 			blinded = 1
 			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -211,6 +211,8 @@
 			if(!druggy)
 				to_chat(src, "It looks like you are back in Kansas.")
 
+		handle_dizziness()
+		handle_jitteriness()
 		if(teleportitis)
 			teleportitis = max(teleportitis - 1, 0)
 			if(prob(10))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -193,8 +193,8 @@
 		if(resting && halloss > 0)
 			adjustHalLoss(-3)
 
-		handle_blind()
-		handle_deaf()
+		handle_blind_updates()
+		handle_deaf_updates()
 
 		//Flying
 		if(flying)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -209,10 +209,10 @@
 			AdjustStunned(-1)
 
 		if(knockdown)
-			knockdown = max(knockdown - 1,0) //Before you get mad Rockdtben: I done this so update_canmove isn't called multiple times
+			AdjustKnockdown(-1) //Before you get mad Rockdtben: I done this so update_canmove isn't called multiple times
 
 		if(say_mute)
-			say_mute = max(say_mute-1, 0)
+			AdjustMute(-1)
 
 		if(stuttering)
 			stuttering = max(stuttering - 1, 0)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -140,11 +140,7 @@
 				halloss = 0
 			else
 				hallucination -= 2
-
 		else
-			for(var/atom/a in hallucinations)
-				qdel(a)
-
 			if(halloss > 100)
 				to_chat(src, "<span class='notice'>You're in too much pain to keep going...</span>")
 				for(var/mob/O in oviewers(src, null))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -113,7 +113,7 @@
 		spawn(0)
 			emote(sleep_emote)
 
-/mob/living/proc/handle_blind()
+/mob/living/proc/handle_blind_updates()
 	if(!has_eyes())           //Eyes cut out? Permablind.
 		eye_blind =  1
 		blinded =    1
@@ -127,7 +127,7 @@
 	else if(eye_blurry)
 		eye_blurry = max(eye_blurry - 1, 0)
 
-/mob/living/proc/handle_deaf()
+/mob/living/proc/handle_deaf_updates()
 	if(sdisabilities & DEAF) //Disabled-deaf, doesn't get better on its own
 		ear_deaf = max(ear_deaf, 1)
 	else if(earprot()) //Resting your ears with earmuffs heals ear damage faster

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -83,11 +83,149 @@
 			mutations.Remove(M_HARDCORE)
 			to_chat(src, "<span class='notice'>You feel like a pleb.</span>")
 	handle_beams()
+	handle_regular_status_updates()
 	if(istype(get_turf(src),/turf/unsimulated/floor/brimstone))
 		FireBurn(11, 9001, ONE_ATMOSPHERE) // lag free weird way of doing it
 		fire_stacks = 11
 		IgniteMob() // ffffFIRE!!!! FIRE!!! FIRE!!
 	return 1
+
+/mob/living/handle_regular_status_updates() //Refer to life.dm for caller
+	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
+		blinded = 1
+		silent = 0
+	else				//ALIVE. LIGHTS ARE ON
+
+		//Sobering multiplier.
+		//Sober block grants quadruple the alcohol metabolism.
+		var/sober_str =! (M_SOBER in mutations) ? 1:4
+
+		updatehealth() //TODO
+
+		if((health <= config.health_threshold_dead || !has_brain()) && !(status_flags & BUDDHAMODE))
+			death()
+			blinded = 1
+			silent = 0
+			return 1
+
+		//The analgesic effect wears off slowly
+		pain_numb = max(0, pain_numb - 1)
+
+		//UNCONSCIOUS. NO-ONE IS HOME
+		if((getOxyLoss() > 50 || config.health_threshold_crit > health) && !(status_flags & BUDDHAMODE))
+			Paralyse(3)
+
+		if(hallucination)
+			if(hallucination<=2)
+				hallucination = 0
+				halloss = 0
+			else
+				hallucination -= 2
+
+		else
+			for(var/atom/a in hallucinations)
+				qdel(a)
+
+			if(halloss > 100)
+				to_chat(src, "<span class='notice'>You're in too much pain to keep going...</span>")
+				for(var/mob/O in oviewers(src, null))
+					O.show_message("<B>[src]</B> slumps to the ground, too weak to continue fighting.", 1)
+				Paralyse(10)
+				setHalLoss(99)
+
+		if(paralysis)
+			AdjustParalysis(-1)
+			blinded = 1
+			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
+			if(halloss > 0)
+				adjustHalLoss(-3)
+		else if(sleeping)
+			adjustHalLoss(-3)
+			sleeping = max(sleeping-1, 0)
+			blinded = 1
+			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
+		else if(undergoing_hypothermia() >= SEVERE_HYPOTHERMIA)
+			blinded = 1
+			stat = status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS
+		//CONSCIOUS
+		else
+			stat = CONSCIOUS
+			if(halloss > 0)
+				adjustHalLoss(-1)
+
+		if(resting && halloss > 0)
+			adjustHalLoss(-3)
+
+		//Eyes
+		else if(!has_eyes())           //Eyes cut out? Permablind.
+			eye_blind =  1
+			blinded =    1
+			eye_blurry = 0
+		else if(sdisabilities & BLIND) //Disabled-blind, doesn't get better on its own
+			blinded =    1
+			eye_blurry = 0
+		else if(eye_blind)		       //Blindness, heals slowly over time
+			eye_blind =  max(eye_blind - 1, 0)
+			blinded =    1
+		else if(eye_blurry)
+			eye_blurry = max(eye_blurry - 1, 0)
+
+		//Ears
+		if(sdisabilities & DEAF) //Disabled-deaf, doesn't get better on its own
+			ear_deaf = max(ear_deaf, 1)
+		else if(earprot()) //Resting your ears with earmuffs heals ear damage faster
+			ear_damage = max(ear_damage - 0.15, 0)
+			ear_deaf = max(ear_deaf, 1) //This MUST be above the following else if or deafness cures itself while wearing earmuffs
+		else if(ear_deaf) //Deafness, heals slowly over time
+			ear_deaf = max(ear_deaf - 1, 0)
+		else if(ear_damage < 25) //Ear damage heals slowly under this threshold. otherwise you'll need earmuffs
+			ear_damage = max(ear_damage - 0.05, 0)
+
+		//Flying
+		if(flying)
+			spawn()
+				animate(src, pixel_y = pixel_y + 5 * PIXEL_MULTIPLIER, time = 10, loop = 1, easing = SINE_EASING)
+			spawn(10)
+				if(flying)
+					animate(src, pixel_y = pixel_y - 5 * PIXEL_MULTIPLIER, time = 10, loop = 1, easing = SINE_EASING)
+
+		//Other
+		if(stunned)
+			AdjustStunned(-1)
+
+		if(knockdown)
+			knockdown = max(knockdown - 1,0) //Before you get mad Rockdtben: I done this so update_canmove isn't called multiple times
+
+		if(say_mute)
+			say_mute = max(say_mute-1, 0)
+
+		if(stuttering)
+			stuttering = max(stuttering - 1, 0)
+		if(slurring)
+			slurring = max(slurring - (1 * sober_str), 0)
+		if(silent)
+			silent = max(silent - 1, 0)
+
+		if(druggy)
+			druggy = max(druggy - 1, 0)
+			if(!druggy)
+				to_chat(src, "It looks like you are back in Kansas.")
+
+		if(teleportitis)
+			teleportitis = max(teleportitis - 1, 0)
+			if(prob(10))
+				do_teleport(src, get_turf(src), 7)
+		if(timeslip)
+			timeslip = max(timeslip - 1, 0)
+			if(prob(10))
+				switch(pick(list(1,2,3)))
+					if(1)
+						attempt_past_send(5 SECONDS, TRUE)
+					if(2)
+						attempt_future_send(5 SECONDS, TRUE)
+					else
+						timestop(src, 5 SECONDS, 1, TRUE)
+		return 1
 
 // Apply connect damage
 /mob/living/beam_connect(var/obj/effect/beam/B)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -90,7 +90,15 @@
 		IgniteMob() // ffffFIRE!!!! FIRE!!! FIRE!!
 	return 1
 
-/mob/living/handle_regular_status_updates() //Refer to life.dm for caller
+/mob/living/proc/check_dead()
+	if((health <= config.health_threshold_dead || !has_brain()) && !(status_flags & BUDDHAMODE))
+		death()
+		blinded = 1
+		silent = 0
+		return 1
+	return 0
+
+/mob/living/proc/handle_regular_status_updates() //Refer to life.dm for caller
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
 		blinded = 1
 		silent = 0
@@ -102,10 +110,7 @@
 
 		updatehealth() //TODO
 
-		if((health <= config.health_threshold_dead || !has_brain()) && !(status_flags & BUDDHAMODE))
-			death()
-			blinded = 1
-			silent = 0
+		if(check_dead())
 			return 1
 
 		//The analgesic effect wears off slowly

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -85,3 +85,5 @@
 	var/blood_color2	//color of this creature's blood for gibbing purposes (humanoids have their own species-defined values)
 	var/flesh_color2	//color of this creature's flesh for meat purposes (humanoids have their own species-defined values)
 	var/tangibility = 1 //can this mob be interacted with things hitting it and etc?
+	var/sleep_emote		//the emote ran when a mob sleeps
+	var/sleep_emote_prob = 10 //the chance they have to do it

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -158,12 +158,6 @@
 		handle_regular_hud_updates()
 	if(life_handle_health())
 		return
-	if(stunned > 0)
-		stunned -= 1
-	if(say_mute)
-		say_mute = max(say_mute-1, 0)
-	if(ear_deaf)
-		ear_deaf = max(ear_deaf-1, 0)
 
 	if(ai_flags & COREFORTIFY)
 		brute_damage_modifier = 0.33

--- a/code/modules/mob/living/silicon/pai/life.dm
+++ b/code/modules/mob/living/silicon/pai/life.dm
@@ -21,8 +21,7 @@
 		health = maxHealth - getBruteLoss() - getFireLoss()
 
 /mob/living/silicon/pai/handle_regular_status_updates()
-
-	updatehealth()
+	. = ..()
 
 	if(sleeping)
 		Paralyse(3)
@@ -55,5 +54,3 @@
 		blinded = 1
 		stat = DEAD
 		return 1
-
-	return ..()

--- a/code/modules/mob/living/silicon/pai/life.dm
+++ b/code/modules/mob/living/silicon/pai/life.dm
@@ -20,6 +20,11 @@
 	else
 		health = maxHealth - getBruteLoss() - getFireLoss()
 
+/mob/living/silicon/pai/check_dead()
+	if(health <= 0 && !isDead()) //die only once
+		death()
+		return 1
+	
 /mob/living/silicon/pai/handle_regular_status_updates()
 	. = ..()
 
@@ -29,10 +34,6 @@
 
 	if(resting)
 		Knockdown(5)
-
-	if(health <= 0 && stat != 2) //die only once
-		death()
-		return 1
 
 	if (stat != DEAD) //Alive.
 		if (paralysis || stunned || knockdown) //Stunned etc.

--- a/code/modules/mob/living/silicon/pai/life.dm
+++ b/code/modules/mob/living/silicon/pai/life.dm
@@ -50,8 +50,3 @@
 
 		else	//Not stunned.
 			stat = 0
-
-	else //Dead.
-		blinded = 1
-		stat = DEAD
-		return 1

--- a/code/modules/mob/living/silicon/pai/life.dm
+++ b/code/modules/mob/living/silicon/pai/life.dm
@@ -25,12 +25,12 @@
 		death()
 		return 1
 	
+/mob/living/silicon/pai/handle_sleep()
+	Paralyse(3)
+	sleeping = max(sleeping-1, 0)
+
 /mob/living/silicon/pai/handle_regular_status_updates()
 	. = ..()
-
-	if(sleeping)
-		Paralyse(3)
-		sleeping--
 
 	if(resting)
 		Knockdown(5)

--- a/code/modules/mob/living/silicon/pai/life.dm
+++ b/code/modules/mob/living/silicon/pai/life.dm
@@ -20,7 +20,7 @@
 	else
 		health = maxHealth - getBruteLoss() - getFireLoss()
 
-/mob/living/silicon/pai/proc/handle_regular_status_updates()
+/mob/living/silicon/pai/handle_regular_status_updates()
 
 	updatehealth()
 
@@ -33,8 +33,9 @@
 
 	if(health <= 0 && stat != 2) //die only once
 		death()
+		return 1
 
-	if (stat != 2) //Alive.
+	if (stat != DEAD) //Alive.
 		if (paralysis || stunned || knockdown) //Stunned etc.
 			stat = 1
 			if (stunned > 0)
@@ -52,34 +53,7 @@
 
 	else //Dead.
 		blinded = 1
-		stat = 2
+		stat = DEAD
+		return 1
 
-	if (stuttering)
-		stuttering--
-
-	if (eye_blind)
-		eye_blind--
-		blinded = 1
-
-	if (ear_deaf > 0)
-		ear_deaf--
-	if (say_mute > 0)
-		say_mute--
-	if (ear_damage < 25)
-		ear_damage -= 0.05
-		ear_damage = max(ear_damage, 0)
-
-	if (sdisabilities & BLIND)
-		blinded = 1
-	if (sdisabilities & DEAF)
-		ear_deaf = 1
-
-	if (eye_blurry > 0)
-		eye_blurry--
-		eye_blurry = max(0, eye_blurry)
-
-	if (druggy > 0)
-		druggy--
-		druggy = max(0, druggy)
-
-	return 1
+	return ..()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -77,6 +77,7 @@
 /mob/living/silicon/robot/check_dead()
 	if(health <= 0 && !isDead()) //die only once
 		death()
+		return 1
 
 /mob/living/silicon/robot/handle_regular_status_updates()
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -74,7 +74,7 @@
 		stat = UNCONSCIOUS
 
 
-/mob/living/silicon/robot/proc/handle_regular_status_updates()
+/mob/living/silicon/robot/handle_regular_status_updates()
 	updatehealth()
 
 	if(sleeping)
@@ -95,30 +95,6 @@
 		blinded = TRUE
 		stat = DEAD
 
-	if(stunned > 0)
-		AdjustStunned(-1)
-	if(knockdown > 0)
-		AdjustKnockdown(-1)
-	if(paralysis > 0)
-		AdjustParalysis(-1)
-	if(stuttering)
-		stuttering = max(stuttering-1, 0)
-	if(eye_blind)
-		eye_blind = max(eye_blind-1,0)
-	if(ear_deaf)
-		ear_deaf = max(ear_deaf-1,0)
-	if(ear_damage < 25)
-		ear_damage = max(ear_damage-0.05, 0)
-	if((sdisabilities & DEAF))
-		ear_deaf = TRUE
-	if(say_mute)
-		say_mute = max(say_mute-1, 0)
-
-	if(eye_blurry)
-		eye_blurry = max(eye_blurry-1,0)
-	if(druggy)
-		druggy = max(druggy-1,0)
-
 	if(jitteriness)
 		jitteriness = max(jitteriness-1,0)
 	handle_jitteriness()
@@ -131,7 +107,7 @@
 	if(radio)
 		radio.on = is_component_functioning("radio")
 
-	return TRUE
+	return ..()
 
 /mob/living/silicon/robot/proc/handle_sensor_modes()
 	change_sight(removing = SEE_TURFS|SEE_MOBS|SEE_OBJS|BLIND)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -79,6 +79,9 @@
 		death()
 		return 1
 
+/mob/living/silicon/handle_crit_updates()
+	return
+
 /mob/living/silicon/robot/handle_regular_status_updates()
 	. = ..()
 	if(sleeping)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -82,12 +82,12 @@
 /mob/living/silicon/handle_crit_updates()
 	return
 
+/mob/living/silicon/robot/handle_sleep()
+	Paralyse(3)
+	sleeping = max(sleeping-1, 0)
+
 /mob/living/silicon/robot/handle_regular_status_updates()
 	. = ..()
-	if(sleeping)
-		Paralyse(3)
-		sleeping = max(sleeping-1, 0)
-
 	if(resting)
 		Knockdown(5)
 	setDensity(!(lying))

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -86,6 +86,16 @@
 	Paralyse(3)
 	sleeping = max(sleeping-1, 0)
 
+/mob/living/silicon/robot/handle_jitteriness()
+	if(jitteriness)
+		jitteriness = max(jitteriness-1,0)
+	..()
+	
+/mob/living/silicon/robot/handle_dizziness()
+	if(dizziness)
+		dizziness = max(0, dizziness - 1)
+	..()
+
 /mob/living/silicon/robot/handle_regular_status_updates()
 	. = ..()
 	if(resting)
@@ -98,11 +108,6 @@
 	else if(!(status_flags & BUDDHAMODE)) //Dead.
 		blinded = TRUE
 		stat = DEAD
-
-	if(jitteriness)
-		jitteriness = max(jitteriness-1,0)
-	if(dizziness)
-		dizziness = max(0, dizziness - 1)
 
 	if(camera && !scrambledcodes)
 		camera.status = !(isDead() || wires.IsCameraCut())

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -96,10 +96,8 @@
 
 	if(jitteriness)
 		jitteriness = max(jitteriness-1,0)
-	handle_jitteriness()
 	if(dizziness)
 		dizziness = max(0, dizziness - 1)
-	handle_dizziness()
 
 	if(camera && !scrambledcodes)
 		camera.status = !(isDead() || wires.IsCameraCut())

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -74,6 +74,10 @@
 		stat = UNCONSCIOUS
 
 
+/mob/living/silicon/robot/check_dead()
+	if(health <= 0 && !isDead()) //die only once
+		death()
+
 /mob/living/silicon/robot/handle_regular_status_updates()
 	. = ..()
 	if(sleeping)
@@ -83,9 +87,6 @@
 	if(resting)
 		Knockdown(5)
 	setDensity(!(lying))
-
-	if(health <= 0 && !isDead()) //die only once
-		death()
 
 	if(!isDead()) //Alive.
 		blinded = !(paralysis || is_component_functioning("camera"))

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -75,8 +75,7 @@
 
 
 /mob/living/silicon/robot/handle_regular_status_updates()
-	updatehealth()
-
+	. = ..()
 	if(sleeping)
 		Paralyse(3)
 		sleeping = max(sleeping-1, 0)
@@ -106,8 +105,6 @@
 		camera.status = !(isDead() || wires.IsCameraCut())
 	if(radio)
 		radio.on = is_component_functioning("radio")
-
-	return ..()
 
 /mob/living/silicon/robot/proc/handle_sensor_modes()
 	change_sight(removing = SEE_TURFS|SEE_MOBS|SEE_OBJS|BLIND)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -191,6 +191,15 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 /mob/living/simple_animal/proc/check_environment_susceptibility()
 	return TRUE
 
+/mob/living/simple_animal/handle_crit_updates()
+	if(health <= 0 && stat != DEAD)
+		death()
+		return 0
+
+/mob/living/simple_animal/handle_jitteriness()
+	..()
+	jitteriness = max(0, jitteriness - 1)
+
 /mob/living/simple_animal/Life()
 	if(timestopped)
 		return 0 //under effects of time magick
@@ -209,48 +218,13 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 			src.delayedRegen()
 		return 0
 
-	if(health <= 0 && stat != DEAD)
-		death()
-		return 0
-
 	life_tick++
 
 	health = min(health, maxHealth)
 
-	if(stunned)
-		AdjustStunned(-1)
-	if(knockdown)
-		AdjustKnockdown(-1)
-	if(paralysis)
-		AdjustParalysis(-1)
 	update_canmove()
 
-	handle_jitteriness()
-	jitteriness = max(0, jitteriness - 1)
-
-	//Eyes
-	if(sdisabilities & BLIND)	//disabled-blind, doesn't get better on its own
-		blinded = 1
-	else if(eye_blind)			//blindness, heals slowly over time
-		eye_blind = max(eye_blind - 1, 0)
-		blinded = 1
-	else
-		if(eye_blurry)	//blurry eyes heal slowly
-			eye_blurry = max(eye_blurry - 1, 0)
-		blinded = null
-
-	//Ears
-	if(sdisabilities & DEAF)	//disabled-deaf, doesn't get better on its own
-		ear_deaf = max(ear_deaf, 1)
-	else if(ear_deaf)			//deafness, heals slowly over time
-		ear_deaf = max(ear_deaf-1, 0)
-	else if(ear_damage < 25)	//ear damage heals slowly under this threshold.
-		ear_damage = max(ear_damage-0.05, 0)
-
 	remove_confused(1)
-
-	if(say_mute)
-		say_mute = max(say_mute-1, 0)
 
 	if(purge)
 		purge -= 1


### PR DESCRIPTION
[bugfix][cleanup]

## What this does
redefines this proc down to the /mob/living level and calls it there, cuts out redundant code
splits parts for death, sleeping, blindness, deafness and crit into their own procs
Closes #28179.
Closes #18953.

## Changelog
:cl:
 * bugfix: Bad status effects are no longer permanent on simple mobs.