### PR TITLE
higher TEG ciurculator flow

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/circulator.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/circulator.dm
@@ -57,7 +57,7 @@
 
 		//Calculate necessary moles to transfer using PV = nRT.
 		recent_moles_transferred = (last_pressure_delta * air2.volume / (air1.temperature * R_IDEAL_GAS_EQUATION))		//Uses the volume of the whole network, not just itself.
-		volume_capacity_used = min((last_pressure_delta * air1.volume / 3) / (input_starting_pressure * air1.volume), 1)	//How much of the gas in the input air volume is consumed.
+		volume_capacity_used = min(last_pressure_delta * air1.volume / (input_starting_pressure * air1.volume), 1)	//How much of the gas in the input air volume is consumed.
 
 		//Calculate energy generated from kinetic turbine.
 		//Most of the below are constants. Instead, think of it as 0.051702*air1.volume*min(pressure difference, starting pressure)


### PR DESCRIPTION
[tweak]

alternative to #36431 

## What this does
increases the max flow rate of the TEG so that it can go to 100%. this affects power output and gas use rates.
![Capture](https://github.com/vgstation-coders/vgstation13/assets/68451232/19e14421-d213-4f06-939e-56bf8e295cbf)


## Why it's good
fixes the flow rate being stuck at 33%.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: the TEG can now use 100% of its flow capacity instead of being limited to 33%