### PR TITLE
Uplifts window damage overlays

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -144,10 +144,9 @@ var/list/one_way_windows
 		if(sound)
 			playsound(loc, 'sound/effects/Glasshit.ogg', 100, 1)
 		if(!damage_overlay)
-			damage_overlay = new(src)
+			damage_overlay = mutable_appearance(src)
 			damage_overlay.icon = icon('icons/obj/structures/window.dmi')
 			damage_overlay.dir = src.dir
-			damage_overlay.plane = FLOAT_PLANE
 			damage_overlay.layer = OBJ_LAYER
 			damage_overlay.blend_mode = BLEND_ADD
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -147,6 +147,9 @@ var/list/one_way_windows
 			damage_overlay = new(src)
 			damage_overlay.icon = icon('icons/obj/structures/window.dmi')
 			damage_overlay.dir = src.dir
+			damage_overlay.plane = FLOAT_PLANE
+			damage_overlay.layer = OBJ_LAYER
+			damage_overlay.blend_mode = BLEND_ADD
 
 		overlays -= damage_overlay
 


### PR DESCRIPTION
Fixes #36421

![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/ef916dd9-aba6-4ba5-814e-bbcab46f2d8c)

13spacemen's PR #36444 returns window cracks to their "Back then" appearance instead.

:cl:
* bugfix: Fixed and improved the cracks on damaged windows