### PR TITLE
fix shift duration timestamp in join game menu and check antags menu

### DIFF
--- a/__DEFINES/global.dm
+++ b/__DEFINES/global.dm
@@ -85,6 +85,8 @@ var/station_name = null
 var/game_version = "veegee"
 var/changelog_hash = ""
 var/game_year = (text2num(time2text(world.realtime, "YYYY")) + 544)
+var/time_taken_to_init = 0
+var/roundstart_timestamp = 0
 
 var/going = 1.0
 var/master_mode = "extended"//"extended"

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -37,7 +37,7 @@
 //Returns the world time in english
 /proc/worldtime2text(timestamp = world.time, give_seconds = FALSE)
 	if(timestamp == world.time)
-		timestamp -= Master.time_taken_to_init
+		timestamp -= time_taken_to_init
 	return "[add_zero((round(((timestamp / 600) + 55) / 60) + 11) % 24, 2)]:[add_zero(round(((timestamp / 600) + 55) % 60), 2)]\
 	[give_seconds ? " : [add_zero(round(timestamp / 10) % 60, 2)]" : ""]"
 
@@ -62,6 +62,10 @@
 	if(m > 0)
 		. += "[m]m "
 	. += "[s]s"
+
+/proc/getShiftDuration()
+	return altFormatTimeDuration(world.timeofday - roundstart_timestamp)
+
 
 /proc/time_stamp()
 	return time2text(world.timeofday, "hh:mm:ss")

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -66,7 +66,6 @@
 /proc/getShiftDuration()
 	return altFormatTimeDuration(world.timeofday - roundstart_timestamp)
 
-
 /proc/time_stamp()
 	return time2text(world.timeofday, "hh:mm:ss")
 

--- a/code/controllers/mc/master.dm
+++ b/code/controllers/mc/master.dm
@@ -35,8 +35,6 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 	var/init_time
 	var/tickdrift = 0
 
-	var/time_taken_to_init = 0
-
 	var/sleep_delta
 
 	var/make_runtime = 0

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -720,6 +720,8 @@ var/datum/controller/gameticker/ticker
 					qdel(obj)
 
 		to_chat(world, "<span class='notice'><B>Enjoy the game!</B></span>")
+		roundstart_timestamp = world.timeofday
+
 		//Holiday Round-start stuff	~Carn
 		Holiday_Game_Start()
 

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -6,7 +6,7 @@
 	var/dat = "<html><head><title>Round Status</title></head><body><h2>Round Status</h2>"
 
 	dat += {"Current Game Mode: <B>[ticker.mode.name]</B><BR>
-			Shift duration: <B>[getShiftDuration()]</B><BR>
+		Shift duration: <B>[getShiftDuration()]</B><BR>
 		<A HREF='?src=\ref[src];emergency_shuttle_panel=1'><B>Emergency Shuttle Panel</B></A><BR>"}
 
 	dat += "<a href='?src=\ref[src];delay_round_end=1'>[ticker.delay_end ? "End Round Normally" : "Delay Round End"]</a><br>"

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -6,7 +6,7 @@
 	var/dat = "<html><head><title>Round Status</title></head><body><h2>Round Status</h2>"
 
 	dat += {"Current Game Mode: <B>[ticker.mode.name]</B><BR>
-		Round Duration: <B>[round(world.time / 36000)]:[add_zero("[world.time / 600 % 60]", 2)]:[world.time / 100 % 6][world.time / 100 % 10]</B><BR>
+			Shift duration: <B>[getShiftDuration()]</B><BR>
 		<A HREF='?src=\ref[src];emergency_shuttle_panel=1'><B>Emergency Shuttle Panel</B></A><BR>"}
 
 	dat += "<a href='?src=\ref[src];delay_round_end=1'>[ticker.delay_end ? "End Round Normally" : "Delay Round End"]</a><br>"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -498,10 +498,6 @@
 		qdel(speech)
 
 /mob/new_player/proc/LateChoices()
-	var/mills = world.time // 1/10 of a second, not real milliseconds but whatever
-	//var/secs = ((mills % 36000) % 600) / 10 //Not really needed, but I'll leave it here for refrence.. or something
-	var/mins = (mills % 36000) / 600
-	var/hours = mills / 36000
 
 	var/list/highprior = new()
 	var/list/heads = new()
@@ -525,7 +521,7 @@
 		.manifest tr.requested_department td {background-color: #00FF00}
 		.manifest th.reqhead td {background-color: #844}
 		.manifest tr.reqalt td {background-color: #FCC}
-		</style></head><body><center>Round Duration: [round(hours)]h [round(mins)]m<br>"}
+		</style></head><body><center>Shift duration: [getShiftDuration()]<br>"}
 	if(emergency_shuttle) //In case Nanotrasen decides reposess CentComm's shuttles.
 		if(emergency_shuttle.direction == 2) //Shuttle is going to centcomm, not recalled
 			dat += "<font color='red'><b>The station has been evacuated.</b></font><br>"


### PR DESCRIPTION
## What this does
title

## Why it's good
currently it displays the time since init finished, which is incorrect
[bugfix]
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: The "Join Game" and "Check Antagonist" menus now display the proper shift duration.
