### PR TITLE
add client verb in ooc tab to check ur own byond version

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1269,6 +1269,13 @@ Use this proc preferably at the end of an equipment loadout
 		prefs.SetChangelog(ckey, changelog_hash)
 		winset(src, "rpane.changelog", "background-color=none;font-style=;")
 
+/client/verb/check_my_byond_version()
+	set name = "Check My BYOND Version"
+	set category = "OOC"
+	var/output = {"Your BYOND version is: <b>[byond_version].[byond_build]</b><br>
+		You can view all of the latest server-compatible BYOND builds here: https://www.byond.com/download/build/[world.byond_version]/"}
+	usr << browse(output, "window=byond-version-data");
+
 /mob/verb/observe()
 	set name = "Observe"
 	set category = "OOC"


### PR DESCRIPTION
## Why it's good
because doing it normally is annoying

[qol]

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Added a client verb, found in the OOC tab, called Check-My-BYOND-Version. This verb shows your current major and minor version, along with a link to find BYOND builds compatible with the server's current version.