### PR TITLE
Cryotheum balancing and sliding objects across ice.

### DIFF
--- a/code/ZAS/XGM_gases.dm
+++ b/code/ZAS/XGM_gases.dm
@@ -128,7 +128,7 @@
 /datum/gas/cryotheum
 	id = GAS_CRYOTHEUM
 	name = "Cryotheum"
-	short_name = "O<sub>2</sub>C"
+	short_name = "O<sub>2</sub>β"
 	specific_heat = 10
 
 	molar_mass = 0.032

--- a/code/ZAS/XGM_reactions.dm
+++ b/code/ZAS/XGM_reactions.dm
@@ -68,7 +68,7 @@
 	// the more it cools. This exists for a lot of reasons, but the big one is that cryotheum was broken as a way to cool engines by simply pumping a bunch of cryotheum into
 	// it. This will help cement it as more of a plasma-cooling method while still allowing it as an engine cooling method in some scenarios.
 	var/const/min_temp = 0.1
-	var/distance_to_min_temp = max(0, mixture.temperature - min_temp)
+	var/distance_to_min_temp = max(0.00001, mixture.temperature - min_temp)
 	// Cooling coefficient with the current numbers will reach a max of 6 at around 10K and will scale down from there, reaching around 0.4 at 300K and 0.13 at 1000K.
 	var/cooling_coefficient = min(1, 80 / distance_to_min_temp) + min(5, 50 / distance_to_min_temp)
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -879,14 +879,24 @@
 /atom/movable/proc/process_inertia(turf/start)
 	set waitfor = 0
 	if(Process_Spacemove(1))
-		inertia_dir  = 0
+		inertia_dir = 0
 		return
 
 	sleep(INERTIA_MOVEDELAY)
 
 	if(can_apply_inertia() && (src.loc == start))
 		if(!inertia_dir)
-			return //inertia_dir = last_move
+			return
+
+		set_glide_size(DELAY2GLIDESIZE(INERTIA_MOVEDELAY))
+		step(src, inertia_dir)
+
+/atom/movable/proc/process_inertia_ignore_gravity(turf/start)
+	sleep(INERTIA_MOVEDELAY)
+
+	if(can_apply_inertia() && (src.loc == start))
+		if(!inertia_dir)
+			return
 
 		set_glide_size(DELAY2GLIDESIZE(INERTIA_MOVEDELAY))
 		step(src, inertia_dir)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -127,8 +127,17 @@
 	//THIS IS OLD TURF ENTERED CODE
 	var/loopsanity = 100
 
+
+
+	var/obj/A_obj = A
 	if(!src.has_gravity())
 		inertial_drift(A)
+	else if(istype(A_obj))
+		var/obj/effect/overlay/puddle/ice/this_puddle = locate(/obj/effect/overlay/puddle/ice) in src
+		if(!this_puddle || !A_obj.last_move)
+			A.inertia_dir = 0
+		else
+			A.process_inertia_ignore_gravity(src)
 	else
 		A.inertia_dir = 0
 


### PR DESCRIPTION
Note that my implementation of inertia for ice is quite janky and essentially included hardcoding in a check for ice puddles with existing space inertia code. Also whenever any /obj/ moves, it will perform a check of whether there's an ice puddle in the new tile, which might hurt performance. 

Also, there's a long standing bug with inertia that became evident whenever occasionally I would notice that pushing a locker across an icy floor would sometimes not slide it, requiring an additional push. This is because of asynchronous operations not performing in the correct order in regards to step animations, on enter turf behavior, etc., as well as confusion with the shitcode as there is both a inertia_dir and a last_move which do very similar things. 
I will attempt to fix that later.

:cl:
 * rscadd: Objects like lockers and other pushables now properly slide on ice.
 * tweak: Changed Cryotheum's abbreviation to include a greek character.
 * tweak: Edited cryotheum-plasma reaction so that it's more efficient at cooling at low temps (within 10.1K and below) but diminishes in efficiency as the temperature increases (the same amount of cryotheum is consumed in the reaction no matter the temperature, only the cooling power is affected).