### PR TITLE
Time Release Pill Timer Tweak

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -357,7 +357,7 @@
 		return
 	var/timer = round(reagents.get_reagent_amount(SUGAR),1)
 	forceMove(M)
-	spawn(timer*30)
+	spawn(timer*100)
 		reagents.del_reagent(SUGAR)
 		reagents.reaction(M, INGEST)
 		reagents.trans_to(M, reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -357,7 +357,7 @@
 		return
 	var/timer = round(reagents.get_reagent_amount(SUGAR),1)
 	forceMove(M)
-	spawn(timer*100)
+	spawn(timer*10 SECONDS) //10 seconds per unit of sugar
 		reagents.del_reagent(SUGAR)
 		reagents.reaction(M, INGEST)
 		reagents.trans_to(M, reagents.total_volume)


### PR DESCRIPTION
## What this does
Tweaks time release pills to take as long to activate as the sugar in the pill would take to metabolize. Previously each unit of sugar would grant 3 seconds before the chemicals are released, however this ups that time to 10 seconds, as long as a single unit of sugar takes to metabolize outside of a time release pill.

## Why it's good
This is far more intuitive, as the time it takes for the payload to be released is what you would expect rather than a much shorter duration. 

## Changelog
:cl:
* tweak: Time release pills take longer to release their payload, consistent with sugar's rate of metabolism.
 [consistency] 
