### PR TITLE
Fixes Dropping Things While Inside Objects

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -220,7 +220,7 @@
 	if(held_items[index])
 		return 0
 
-	if(!Adjacent(W) && isatom(W.loc) && !W.arcanetampered)
+	if(!Adjacent(W) && isturf(W.loc) && !W.arcanetampered)
 		return 0
 
 	if((W.flags & MUSTTWOHAND) && !(M_STRONG in mutations))


### PR DESCRIPTION
Now traders won't drop their pinpointers into space round start, and people can change clothes in a locker again.

## What this does
Fixes #36468, caused by #36362 when attempting to add sanity to telekinesis and picking up objects you build or make at a distance. While you could create objects still with TK, the idea was that the finished product wouldn't just poof in your hand, but would instead be dropped on the floor where you built it. This worked, but it also broke putting things in your hands while you were inside any object, such as an emergency airbag or a locker.

## Why it's good
Traders don't immediately just drop their outpost finder, people can unequip things in a locker, stuff doesn't just fall out of sleepers or cryo tubes anymore.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: You can now hold objects while in an object again.
