### PR TITLE
Pull Request Template Changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,22 @@
 <!--
 Pull requests must be atomic. Change one set of related things at a time.
 Test your changes. PRs that were not tested will not be accepted.
+Not including sections of the template may result in having your PR closed.
 
-You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
+You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
+Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->
+
+<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->
 
 ## What this does
 <!-- Describe here all changes included in the PR. -->
 <!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
 
 ## Why it's good
-<!-- Explain why you think these changes are good. -->
+<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
+
+## How it was tested
+<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
 
 ## Changelog
 <!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->


### PR DESCRIPTION
Template updates for future PRs? I'm sure ready for people to ignore them! Please place your comments below on any possible changes to this template while we're here.

## What this does
Changes the default template for Github Pull Requests, adding an additional field to explain how it was tested, and adding some additional clarifiying comments.

## Why it's good
Provides a dedicated section to explain what tests a PR may have done beforehand, helping collabs and other code reviewers find missed tests and squash bugs before the code is merged.

## How it was tested
it wasn't

## Changelog
Github system changes, no CL needed.