### PR TITLE
Brute Damage Causing Burns Bugfix

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -343,16 +343,10 @@
 	var/datum/species/species = src.species || owner.species
 
 	//First check whether we can widen an existing wound
-	if(wounds.len > 0 && prob(50 + owner.number_wounds * 10))
-		if((type == CUT || type == BRUISE) && damage >= 5)
-			var/datum/wound/W = pick(wounds)
-			if(W.amount == 1 && W.started_healing())
-				W.open_wound(damage)
-				if(prob(25))
-					owner.visible_message("<span class='warning'>The wound on [owner.name]'s [display_name] widens with a nasty ripping sound.</span>", \
-					"<span class='warning'>The wound on your [display_name] widens with a nasty ripping sound.</span>", \
-					"You hear a nasty ripping noise, as if flesh is being torn apart.")
-				return
+	if(widenwound(type, damage))
+		update_damages()
+		owner.updatehealth()
+		return
 
 	//Creating wound
 	var/datum/wound/W
@@ -397,6 +391,35 @@
 
 	update_damages()
 	owner.updatehealth()
+
+/**
+ * Tries to expand an existing wound. Returns TRUE if successful.
+ *
+ * Arguments
+ * * type - Damage type inflicted. Expects CUT or BRUISE
+ * * damage - Amount of post-modifier damage inflicted
+ */
+/datum/organ/external/proc/widenwound(var/type = CUT, var/damage)
+	if(!wounds.len)
+		return
+	if(damage < 5)
+		return
+	if(!(type == CUT || type == BRUISE))
+		return
+	if(!prob(50 + owner.number_wounds * 10))
+		return
+	var/list/valid_wounds = list()
+	for(var/datum/wound/testwound in wounds)
+		if(testwound.amount == 1 && !istype(testwound, /datum/wound/burn/) && testwound.started_healing())
+			valid_wounds += testwound
+	if(valid_wounds.len)
+		var/datum/wound/W = pick(valid_wounds)
+		W.open_wound(damage)
+		if(prob(25))
+			owner.visible_message("<span class='warning'>The wound on [owner.name]'s [display_name] widens with a nasty ripping sound.</span>", \
+			"<span class='warning'>The wound on your [display_name] widens with a nasty ripping sound.</span>", \
+			"You hear a nasty ripping noise, as if flesh is being torn apart.")
+		return TRUE
 
 /****************************************************
 			   PROCESSING & UPDATING


### PR DESCRIPTION

## What this does
Fixes... uhh he never made the bug report. This PR fixes a rare albeit hilarious bug where sometimes when taking brute damage, you would actually take burn damage somehow. This was caused by the code that expands existing wounds not checking for the appropriate damage type.

Example: Remember that door you failed to hack roundstart? That burn wound on your hand, despite being cured like 30 minutes ago, has remained on you in the form of a grizzly burn scar with 0 damage! Later, when someone hits you in that same hand with a 10 melee damage shotgun, the damage initially attempts to expand an existing wound before creating its own. Hey, look, it's an old burn damage burn scar! Riiiip, 10 burn damage.

## Why it's good
Because it removes a funny bug, it's not. But I guess consistency is good. If you get hit with brute damage, you expect to take brute damage.

## How it was tested
![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/607c3e30-f09d-4bce-ac6f-ef83c44bfd02)

me realizing how terrible our wound code is

(Tested via attacking self with various medical tools and lighters while using VV alongside debug messages to confirm status of wounds inflicted)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Brute damage no longer causes or worsens burn wounds.
