### PR TITLE
Fixes Nar-Sie runtime should a Singularity Beacon get activated

### DIFF
--- a/code/datums/gamemode/factions/legacy_cult/narsie.dm
+++ b/code/datums/gamemode/factions/legacy_cult/narsie.dm
@@ -26,6 +26,7 @@ var/global/list/narsie_list = list()
 /obj/machinery/singularity/narsie/New()
 	..()
 	narsie_list.Add(src)
+	power_machines.Remove(src)//Don't want Nar-Sie hungering for singularity beacons
 
 /obj/machinery/singularity/narsie/Destroy()
 	narsie_list.Remove(src)


### PR DESCRIPTION
:cl:
* Fixed a bug that would cause Nar-Sie to runtime when trying to move if a Singularity Beacon gets activated.