### PR TITLE
Forcemoving certain things now disconnects nearby or contained items

### DIFF
--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -101,6 +101,14 @@
 		return TRUE
 	return FALSE
 
+/obj/machinery/portable_atmospherics/forceMove(atom/destination, step_x, step_y, no_tp, harderforce, glide_size_override)
+	if(connected_port)
+		disconnect()
+		visible_message("<span class='warning'>\The [src] gets yanked off of its port!</span>")
+		pixel_x = 0
+		pixel_y = 0
+	. = ..()
+
 /obj/machinery/portable_atmospherics/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 
 	var/obj/icon = src

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -254,9 +254,10 @@
 	..()
 
 /obj/machinery/recharge_station/forceMove(atom/destination, step_x, step_y, no_tp, harderforce, glide_size_override)
-	var/mob/M = go_out()
-	if(istype(M))
-		visible_message("<span class='warning'>\The [src] ejects [M]!</span>")
+	if(!isturf(destination))
+		var/mob/M = go_out()
+		if(istype(M))
+			visible_message("<span class='warning'>\The [src] ejects [M]!</span>")
 	. = ..()
 	
 /obj/machinery/recharge_station/proc/go_out(var/turf/T)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -253,6 +253,12 @@
 		build_icon()
 	..()
 
+/obj/machinery/recharge_station/forceMove(atom/destination, step_x, step_y, no_tp, harderforce, glide_size_override)
+	var/mob/M = go_out()
+	if(istype(M))
+		visible_message("<span class='warning'>\The [src] ejects [M]!</span>")
+	. = ..()
+	
 /obj/machinery/recharge_station/proc/go_out(var/turf/T)
 	if(!T)
 		T = get_turf(src)
@@ -270,6 +276,7 @@
 			occupant.client.eye = occupant.client.mob
 			occupant.client.perspective = MOB_PERSPECTIVE
 		occupant.forceMove(T)
+	. = occupant
 	occupant = null
 	build_icon()
 	src.use_power = MACHINE_POWER_USE_IDLE
@@ -277,7 +284,6 @@
 	for (var/atom/movable/x in src.contents)
 		if(!(x in upgrade_holder | component_parts))
 			x.forceMove(src.loc)
-	return
 
 /obj/machinery/recharge_station/proc/restock_modules()
 	if(isrobot(occupant))

--- a/code/game/machinery/singularity_beacon.dm
+++ b/code/game/machinery/singularity_beacon.dm
@@ -33,6 +33,13 @@
 		QDEL_NULL(power_connection)
 	. = ..()
 
+/obj/machinery/singularity_beacon/forceMove(atom/destination, step_x, step_y, no_tp, harderforce, glide_size_override)
+	deactivate()
+	if(power_connection.connected)
+		power_connection.disconnect()
+		visible_message("<span class='warning'>\The [src] disconnects from the cable!</span>")
+	. = ..()
+
 /obj/machinery/singularity_beacon/get_cell()
 	return cell
 

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -51,13 +51,6 @@
 
 /obj/structure/bed/AltClick(mob/user as mob)
 	buckle_mob(user, user)
-
-/obj/structure/bed/forceMove(atom/destination, step_x, step_y, no_tp, harderforce, glide_size_override)
-	if(!isturf(destination))
-		var/atom/movable/M = manual_unbuckle()
-		if(istype(M))
-			visible_message("<span class='warning'>\The [src] is ripped from [M]!</span>")
-	. = ..()
 	
 /obj/structure/bed/verb/buckle_in_out()
 	set name = "Buckle In/Out"

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -53,9 +53,10 @@
 	buckle_mob(user, user)
 
 /obj/structure/bed/forceMove(atom/destination, step_x, step_y, no_tp, harderforce, glide_size_override)
-	var/atom/movable/M = manual_unbuckle()
-	if(istype(M))
-		visible_message("<span class='warning'>\The [src] is ripped from [M]!</span>")
+	if(!isturf(destination))
+		var/atom/movable/M = manual_unbuckle()
+		if(istype(M))
+			visible_message("<span class='warning'>\The [src] is ripped from [M]!</span>")
 	. = ..()
 	
 /obj/structure/bed/verb/buckle_in_out()

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -52,6 +52,12 @@
 /obj/structure/bed/AltClick(mob/user as mob)
 	buckle_mob(user, user)
 
+/obj/structure/bed/forceMove(atom/destination, step_x, step_y, no_tp, harderforce, glide_size_override)
+	var/atom/movable/M = manual_unbuckle()
+	if(istype(M))
+		visible_message("<span class='warning'>\The [src] is ripped from [M]!</span>")
+	. = ..()
+	
 /obj/structure/bed/verb/buckle_in_out()
 	set name = "Buckle In/Out"
 	set category = "Object"
@@ -67,6 +73,12 @@
 		buckle_mob(usr, usr)
 
 /obj/structure/bed/proc/manual_unbuckle(var/mob/user, var/resisting = FALSE)
+	if(!user)
+		if(is_locking(mob_lock_type))
+			user = get_locked(mob_lock_type)[1]
+		if(!user)
+			return
+
 	if(user.isStunned())
 		return FALSE
 
@@ -111,6 +123,7 @@
 						H.visible_message("<span class='alert'>[H] collapses to the ground after standing up too fast.</span>", "<span class='warning'>Your vision swims as you fall over.</span>")
 						H.lastAnemia=world.time
 		playsound(src, 'sound/misc/buckle_unclick.ogg', 50, 1)
+		return M
 	return TRUE
 
 /obj/structure/bed/arcane_act(mob/user)

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -69,6 +69,13 @@
 	var/headlights = FALSE
 	var/explodes_fueltanks = FALSE
 
+/obj/structure/bed/chair/vehicle/forceMove(atom/destination, step_x, step_y, no_tp, harderforce, glide_size_override)
+	if(!isturf(destination))
+		var/atom/movable/M = manual_unbuckle()
+		if(istype(M))
+			visible_message("<span class='warning'>\The [src] is ripped from [M]!</span>")
+	. = ..()
+
 /obj/structure/bed/chair/vehicle/proc/getMovementDelay()
 	return movement_delay
 

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -71,10 +71,15 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	var/strength = null
 	var/desc_holder = null
 
+/obj/structure/particle_accelerator/New()
+	..()
+	register_event(/event/after_move, src, nameof(src::move_deactivate()))
+
 /obj/structure/particle_accelerator/Destroy()
 	construction_state = 0
 	if(master)
 		master.part_scan()
+	unregister_event(/event/after_move, src, nameof(src::move_deactivate()))
 	..()
 
 /obj/structure/particle_accelerator/end_cap
@@ -132,17 +137,10 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	..()
 	return
 
-/obj/structure/particle_accelerator/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
-	..()
+/obj/structure/particle_accelerator/proc/move_deactivate()
 	if(master && master.active)
 		master.toggle_power()
 		investigation_log(I_SINGULO,"was moved whilst active; it <font color='red'>powered down</font>.")
-	
-/obj/structure/particle_accelerator/forceMove(atom/destination, step_x, step_y, no_tp, harderforce, glide_size_override)
-	if(master && master.active)
-		master.toggle_power()
-		investigation_log(I_SINGULO,"was moved whilst active; it <font color='red'>powered down</font>.")
-	. = ..()
 	
 /obj/structure/particle_accelerator/ex_act(severity)
 	switch(severity)
@@ -280,7 +278,6 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	var/strength = 0
 	var/desc_holder = null
 
-
 /obj/machinery/particle_accelerator/verb/rotate()
 	set name = "Rotate Clockwise"
 	set category = "Object"
@@ -416,15 +413,3 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 			use_power = MACHINE_POWER_USE_IDLE
 		update_icon()
 		return 1
-
-/obj/machinery/particle_accelerator/control_box/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
-	..()
-	if(active)
-		toggle_power()
-		investigation_log(I_SINGULO,"was moved whilst active; it <font color='red'>powered down</font>.")
-	
-/obj/machinery/particle_accelerator/control_box/forceMove(atom/destination, step_x, step_y, no_tp, harderforce, glide_size_override)
-	if(active)
-		toggle_power()
-		investigation_log(I_SINGULO,"was moved whilst active; it <font color='red'>powered down</font>.")
-	. = ..()

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -423,7 +423,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 		toggle_power()
 		investigation_log(I_SINGULO,"was moved whilst active; it <font color='red'>powered down</font>.")
 	
-/obj/machinery/particle_accelerator/control_box/forceMove(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
+/obj/machinery/particle_accelerator/control_box/forceMove(atom/destination, step_x, step_y, no_tp, harderforce, glide_size_override)
 	if(active)
 		toggle_power()
 		investigation_log(I_SINGULO,"was moved whilst active; it <font color='red'>powered down</font>.")

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -132,13 +132,18 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	..()
 	return
 
-
 /obj/structure/particle_accelerator/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()
 	if(master && master.active)
 		master.toggle_power()
 		investigation_log(I_SINGULO,"was moved whilst active; it <font color='red'>powered down</font>.")
-
+	
+/obj/structure/particle_accelerator/forceMove(atom/destination, step_x, step_y, no_tp, harderforce, glide_size_override)
+	if(master && master.active)
+		master.toggle_power()
+		investigation_log(I_SINGULO,"was moved whilst active; it <font color='red'>powered down</font>.")
+	. = ..()
+	
 /obj/structure/particle_accelerator/ex_act(severity)
 	switch(severity)
 		if(1.0)
@@ -412,7 +417,13 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 		update_icon()
 		return 1
 
-/obj/machinery/particle_accelerator/forceMove(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
+/obj/machinery/particle_accelerator/control_box/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
+	..()
+	if(active)
+		toggle_power()
+		investigation_log(I_SINGULO,"was moved whilst active; it <font color='red'>powered down</font>.")
+	
+/obj/machinery/particle_accelerator/control_box/forceMove(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	if(active)
 		toggle_power()
 		investigation_log(I_SINGULO,"was moved whilst active; it <font color='red'>powered down</font>.")

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -411,3 +411,9 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 			use_power = MACHINE_POWER_USE_IDLE
 		update_icon()
 		return 1
+
+/obj/machinery/particle_accelerator/forceMove(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
+	if(active)
+		toggle_power()
+		investigation_log(I_SINGULO,"was moved whilst active; it <font color='red'>powered down</font>.")
+	. = ..()

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -27,9 +27,11 @@
 	wires = new(src)
 	connected_parts = list()
 	update_icon()
+	register_event(/event/after_move, src, nameof(src::move_deactivate()))
 	..()
 
 /obj/machinery/particle_accelerator/control_box/Destroy()
+	unregister_event(/event/after_move, src, nameof(src::move_deactivate()))
 	if(active)
 		toggle_power()
 
@@ -37,6 +39,11 @@
 		QDEL_NULL(wires)
 
 	..()
+
+/obj/machinery/particle_accelerator/control_box/proc/move_deactivate()
+	if(active)
+		toggle_power()
+		investigation_log(I_SINGULO,"was moved whilst active; it <font color='red'>powered down</font>.")
 
 /obj/machinery/particle_accelerator/control_box/attack_hand(mob/user as mob)
 	if(construction_state >= 3)


### PR DESCRIPTION
[bugfix][hotfix]

## What this does
Closes #35646.
Closes #34557.
Closes #27172.
Closes #26635.
Closes #13259.
hotfix as in mobs can now no longer be carried around in the things if they're buckled to vehicle you took in.

## How this was tested
with the subspace tunneller and the target's connected items, what else?

## Changelog
:cl:
 * bugfix: Bound or subspace tunnelled portable atmospherics, power sinks and singulo beacons now properly disconnect on movement.
 * bugfix: Singularity pulled power sinks now properly turn off when off a cable.
 * bugfix: Bound, carted or subspace tunnelled particle accelerators now turn off.
 * tweak: Subspace tunnelled vehicles now unbuckle the mob on them, if any.
 * tweak: Subspace tunnelled cyborg recharging stations now eject the cyborg inside.