### PR TITLE
Fixes haunting not updating ghost minimap

### DIFF
--- a/code/controllers/subsystem/init/more_init_stuff.dm
+++ b/code/controllers/subsystem/init/more_init_stuff.dm
@@ -27,7 +27,7 @@ var/datum/subsystem/more_init/SSmore_init
 	log_debug("  Finished caching space parallax simulation in [stop_watch(watch)]s.", FALSE)
 
 	init_sensed_explosions_list()
-	if (!config.skip_minimap_generation)
+	if (!config.skip_holominimap_generation)
 		watch=start_watch()
 		generateHoloMinimaps()
 		log_debug("  Finished holominimaps in [stop_watch(watch)]s.", FALSE)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -128,13 +128,19 @@ var/creating_arena = FALSE
 		cultify()
 
 	start_poltergeist_cooldown() //FUCK OFF GHOSTS
+	register_event(/event/after_move, src, nameof(src::update_holomaps()))
 	..()
 
 /mob/dead/observer/Destroy()
 	..()
+	unregister_event(/event/after_move, src, nameof(src::update_holomaps()))
 	QDEL_NULL(station_holomap)
 	ghostMulti = null
 	observers.Remove(src)
+
+/mob/dead/observer/proc/update_holomaps()
+	if(station_holomap)
+		station_holomap.update_holomap()
 
 /mob/dead/observer/hasFullAccess()
 	return isAdminGhost(src)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -476,6 +476,7 @@
 				var/mob/dead/observer/observer = mob
 				if(observer.locked_to) //Ghosts can move at any time to unlock themselves (in theory from following a mob)
 					observer.manual_stop_follow(observer.locked_to)
+				observer.update_holomaps()
 			var/movedelay = GHOST_MOVEDELAY
 			if(isobserver(mob))
 				var/mob/dead/observer/observer = mob

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -476,9 +476,6 @@
 				var/mob/dead/observer/observer = mob
 				if(observer.locked_to) //Ghosts can move at any time to unlock themselves (in theory from following a mob)
 					observer.manual_stop_follow(observer.locked_to)
-
-				if (observer.station_holomap)
-					observer.station_holomap.update_holomap()
 			var/movedelay = GHOST_MOVEDELAY
 			if(isobserver(mob))
 				var/mob/dead/observer/observer = mob


### PR DESCRIPTION
[bugfix]

## What this does
Closes #36439.

## How this was tested
by not skipping holominimap generation, and creating a level 5 singulo and haunting that.

## Changelog
:cl:
 * bugfix: Ghosts now update their holomap position when haunting something.
 * bugfix: Holominimap generation now actually checks for the right line for skipping in the config, instead of the minimap one by mistake.