### PR TITLE
Fixes the Detective Revolver shooting .357 by default

### DIFF
--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -3,7 +3,7 @@
 	name = "revolver"
 	icon_state = "detective"
 	max_shells = 6
-	caliber = list(POINT38 = 1, POINT357 = 1)
+	caliber = list(POINT38 = 1, POINT357 = 0)
 	origin_tech = Tc_COMBAT + "=2;" + Tc_MATERIALS + "=2"
 	ammo_type = "/obj/item/ammo_casing/c38"
 	recoil = 3
@@ -13,9 +13,9 @@
 /obj/item/weapon/gun/projectile/detective/special_check(var/mob/living/carbon/human/M) //to see if the gun fires 357 rounds safely. A non-modified revolver randomly blows up
 	if(getAmmo()) //this is a good check, I like this check
 		var/obj/item/ammo_casing/AC = loaded[1]
-		if(caliber[POINT38] == 0) //if it's been modified, this is true
+		if(caliber[POINT38] == 1) //unmodified revolver always fires
 			return 1
-		if(istype(AC, /obj/item/ammo_casing/a357) && !perfect && prob(70 - (getAmmo() * 10)))	//minimum probability of 10, maximum of 60
+		if(istype(AC, /obj/item/ammo_casing/a357) &&  (caliber[POINT357] == 1) && !perfect && prob(70 - (getAmmo() * 10)))	//minimum probability of 10, maximum of 60
 			to_chat(M, "<span class='danger'>[src] blows up in your face.</span>")
 			M.take_organ_damage(0,20)
 			M.drop_item(src, force_drop = 1)
@@ -63,6 +63,7 @@
 					to_chat(user, "<span class='notice'>You can't modify it!</span>")
 					return
 				caliber[POINT38] = 0
+				caliber[POINT357] = 1
 				desc = "The barrel and chamber assembly seems to have been modified."
 				to_chat(user, "<span class='warning'>You reinforce the barrel of [src]! Now it will fire .357 rounds.</span>")
 				if(CK && istype(CK))
@@ -79,6 +80,7 @@
 					to_chat(user, "<span class='notice'>You can't modify it!</span>")
 					return
 				caliber[POINT38] = 1
+				caliber[POINT357] = 0
 				desc = initial(desc)
 				to_chat(user, "<span class='warning'>You remove the modifications on [src]! Now it will fire .38 rounds.</span>")
 				perfect = 0


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Prevents the detective revolver from accepting and shooting .357 rounds without consequence. This restores the intended functionality of requiring you to either use a screwdriver on the revolver for a chance to explode in your hands while using .357 rounds or to use the conversion kit with no risk of exploding.

## Why it's good
<!-- Explain why you think these changes are good. -->
Closes #34628.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: The detective revolver can no longer fire .357 rounds without consequences if a conversion kit isn't used on it first.
