### PR TITLE
[DNM] Added a cycling state toggle to pathogen huds

### DIFF
--- a/code/datums/hud/pathogen_hud.dm
+++ b/code/datums/hud/pathogen_hud.dm
@@ -25,7 +25,12 @@ var/list/science_goggles_wearers = list()
 
 /datum/visioneffect/pathogen/process_hud(var/mob/M)
 	..()
-	M.overlay_fullscreen("science", /obj/abstract/screen/fullscreen/science)
+	if(M.get_item_by_slot(slot_glasses))
+		var/obj/item/clothing/glasses/MS = M.get_item_by_slot(slot_glasses) //State: 0:off, 1:purple overlay + virus scan, 2:no overlay + virus scan
+		if((MS.multiple_states == 1) || (!initial(MS.multiple_states)))
+			M.overlay_fullscreen("science", /obj/abstract/screen/fullscreen/science)
+		else
+			M.clear_fullscreen("science",0)
 
 /datum/visioneffect/pathogen/on_remove(var/mob/M)
 	..()

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -9,13 +9,15 @@
 	slot_flags = SLOT_EYES
 	flammable = FALSE
 	var/vision_flags = 0
-	var/darkness_view = 0//Base human is 2
+	var/darkness_view = 0 //Base human is 2
 	var/invisa_view = 0
 	var/cover_hair = 0
 	var/see_invisible = 0
 	var/see_in_dark = 0
 	var/seedarkness = TRUE
 	var/prescription_type = null
+	var/on //For HUDs/scanners
+	var/multiple_states //Set this var to the MAXIMUM states when on. IE if you had 2 different active states then 0:off, 1:state regular active, 2:state alt. active
 	min_harm_label = 12
 	harm_label_examine = list("<span class='info'>A label is covering one lens, but doesn't reach the other.</span>","<span class='warning'>A label covers the lenses!</span>")
 	species_restricted = list("exclude","Muton")
@@ -28,6 +30,14 @@
 	var/my_dark_plane_alpha_override_value
 	cloth_layer = GLASSES_LAYER
 	cloth_icon = 'icons/mob/eyes.dmi'
+
+/obj/item/clothing/glasses/New()
+	..()
+	if(multiple_states) //see "var multiple_states"'s comment above
+		if(on)
+			multiple_states = 1
+		else
+			multiple_states = 0
 
 /obj/item/clothing/glasses/proc/update_perception(var/mob/living/carbon/human/M)
 	return

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -104,34 +104,40 @@
 	mech_flags = MECH_SCAN_ILLEGAL
 	actions_types = list(/datum/action/item_action/toggle_goggles)
 	prescription_type = null
-	var/on = FALSE
+	on = FALSE
+	multiple_states = 2
 	var/datum/visioneffect/pathogen/stored_pathogen_hud = null
 
 /obj/item/clothing/glasses/hud/health/cmo/New()
 	..()
 	stored_pathogen_hud = new /datum/visioneffect/pathogen
+	//Parent New() sets up "multiple_states" var
 
 /obj/item/clothing/glasses/hud/health/cmo/attack_self(mob/user)
 	toggle(user)
 
 /obj/item/clothing/glasses/hud/health/cmo/proc/toggle(mob/user)
-	if (user.incapacitated())
+	if(user.incapacitated())
 		return
 
 	playsound(user,'sound/misc/click.ogg',30,0,-5)
-	if (on)
-		on = FALSE
-		to_chat(user, "You turn the pathogen scanner off.")
-		disable(user)
+	if(multiple_states >= initial(multiple_states))
+		multiple_states = 0
+		if(on)
+			on = FALSE
+			to_chat(user, "You turn the pathogen scanner off.")
+			disable(user)
 	else
-		on = TRUE
-		to_chat(user, "You turn the pathogen scanner on.")
-		enable(user)
+		multiple_states++
+		to_chat(user, "You turn the pathogen scanner on[multiple_states >= 1 ? " to [multiple_states]" : ""].")
+		if(!on)
+			on = TRUE
+			enable(user)
 	user.handle_regular_hud_updates()
 
 /obj/item/clothing/glasses/hud/health/cmo/equipped(mob/M, slot)
 	if(slot == slot_glasses)
-		if (on)
+		if(on)
 			enable(M)
 	..()
 
@@ -142,11 +148,11 @@
 
 /obj/item/clothing/glasses/hud/health/cmo/proc/enable(mob/M)
 	var/toggle = 0
-	if (ishuman(M))
+	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if (H.glasses == src)
 			toggle = 1
-	if (ismonkey(M))
+	if(ismonkey(M))
 		var/mob/living/carbon/monkey/H = M
 		if (H.glasses == src)
 			toggle = 1

--- a/code/modules/clothing/glasses/scanners.dm
+++ b/code/modules/clothing/glasses/scanners.dm
@@ -3,7 +3,8 @@
 /obj/item/clothing/glasses/scanner
 	item_state = "glasses"
 	species_fit = list(GREY_SHAPED)
-	var/on = TRUE
+	on = TRUE
+	multiple_states = FALSE //Set this var to the MAXIMUM states when on. IE if you had 2 different active states then 0:off, 1:state A, 2:state B
 	var/list/stored_huds = list() // Stores a hud datum instance to apply to a mob
 	var/list/hud_types = list() // What HUD the glasses provides, if any
 
@@ -22,7 +23,6 @@
 
 /obj/item/clothing/glasses/scanner/attack_self()
 	toggle()
-
 
 /obj/item/clothing/glasses/scanner/equipped(var/mob/living/carbon/M, glasses)
 	if(istype(M, /mob/living/carbon/monkey))
@@ -66,10 +66,18 @@
 		return
 
 	playsound(C,'sound/misc/click.ogg',30,0,-5)
-	if (on)
-		disable(C)
+	if(initial(multiple_states))
+		if((multiple_states >= initial(multiple_states)) && on) //Move to off in cycle
+			multiple_states = 0
+			disable(C)
+		else //Move a step forward in cycle
+			multiple_states++
+			enable(C)
 	else
-		enable(C)
+		if(on)
+			disable(C)
+		else
+			enable(C)
 
 	update_icon()
 	C.update_inv_glasses()
@@ -81,7 +89,7 @@
 	if(src == C.get_item_by_slot(slot_glasses))
 		for(var/datum/visioneffect/H in stored_huds)
 			C.apply_hud(H)
-	to_chat(C, "You turn \the [src] on.")
+	to_chat(C, "You turn \the [src] on[multiple_states >= 1 ? " to [multiple_states]" : ""].")
 	C.handle_regular_hud_updates()
 
 /obj/item/clothing/glasses/scanner/proc/disable(var/mob/living/carbon/C)
@@ -253,6 +261,7 @@
 
 	glasses_fit = TRUE
 	on = FALSE
+	multiple_states = 2 //State: 0:off, 1:purple overlay + virus scan, 2:no overlay + virus scan
 
 /obj/item/clothing/glasses/scanner/science/prescription
 	name = "prescription science goggles"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
# DNM

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
CMO hud and science goggle (pathogen goggles) now cycle the visual state.
Off -> (Purple overlay + Viruses) -> (No overlay + Viruses) -> [loop back to off]
## Why it's good
<!-- Explain why you think these changes are good. -->
Some people don't like to live in Barney vision when there's a virus around, some people do, this gives you the option. Who doesn't love options?
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: CMO hud and science goggle (pathogen goggles) now cycle the visual state. IE Off -> (Purple overlay + Viruses) -> (No overlay + Viruses) -> [loop back to off]
