### PR TITLE
Match Extinguishing Hotfix

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -63,11 +63,10 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	update_brightness()
 
 /obj/item/weapon/match/extinguish()
-	..()
-	if (lit)
+	if (lit > 0)
+		visible_message("<span class='notice'>\The [name] goes out.</span>")
 		lit = -1
 		update_brightness()
-		visible_message("<span class='notice'>\The [name] goes out.</span>")
 
 /obj/item/weapon/match/examine(mob/user)
 	..()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes a bug where cleaning a number of burnt matches would infinitely attempt to extinguish them.

## Why it's good
<!-- Explain why you think these changes are good. -->
Prevents lag via chatspam.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Matches now extinguish properly.
