### PR TITLE
Detective Revolver Modification Changes/Nerfs

### DIFF
--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -24,8 +24,8 @@
 	if(!istype(loaded[1], /obj/item/ammo_casing/a357)) //only 357 explodes
 		return 1
 	if(!caliber[POINT357] || prob(70 - (dakka * 10))) //gun has 357 but isn't 357 firable, or not properly modified and fails luck
-		to_chat(M, "<span class='danger'>[src] blows up in your face.</span>")
-		explosion(get_turf(M), -1, -1, 0, 3, whodunnit = M)
+		M.visible_message("<span class='danger'>[src] explodes!</span>", "<span class='danger'>[src] explodes in your hand!</span>")
+		explosion(get_turf(M), -1, -1, -1, -1, whodunnit = M)
 		M.take_organ_damage(0,20)
 		M.drop_item(src, force_drop = 1)
 		qdel(src)
@@ -74,9 +74,11 @@
 					return
 				caliber[POINT357] = 1
 				desc = "The barrel and chamber assembly seems to have been modified."
-				to_chat(user, "<span class='warning'>You reinforce the barrel of [src]! Now it will fire .357 rounds.</span>")
 				if(CK && istype(CK))
 					perfect = 1
+					to_chat(user, "You reinforce the barrel of [src]! Now it can accept and safely fire .357 rounds.")
+				else
+					to_chat(user, "<span class='warning'>You shoddily reinforce the barrel of [src]! Now it can accept and fire .357 rounds.</span>")
 		else
 			to_chat(user, "<span class='notice'>You begin to revert the modifications to [src].</span>")
 			if(getAmmo())


### PR DESCRIPTION
@west3436 told me to open my own so oh boy here we go.

As an aside, further modifications from the following should be done in a future PR, such as changing explosion chance %s, changing what the traitor kit can do, etc.

## What this does
Changes detective revolvers so that they follow the following behavior:
### Unmodified
* Can load .38
* Can fire .38
### Modified with Screwdriver
* Can load .38 and .357
* Can safely fire .38
* Can fire .357 but with an explosion risk of 10%-60% based on bullets in gun
* The explosion will actually cause an explosion sound and show a visible message
* The gun will be deleted
### Modified with Traitor Kit
* Can load .38 and .357
* Can safely fire .38 and .357

## Why it's good
Fixes a 10 year old bug, causes a flame war, convinces detectives to use their regular knockdown bullets when stopping crime, closes #34628.

## How it was tested
![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/ec8847cd-6515-44e5-b1a4-4a4cfd867ce4)
![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/5d270aed-4d73-42b4-8ab1-6604ce3999b0)
bang bang bang BOOM (picture was me exploding it before i even could finish loading the gun)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Detective revolvers can now explode when improperly modified.