### PR TITLE
More Fire Fixes

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -439,7 +439,7 @@ var/global/list/image/charred_overlays = list()
  * * soh - Unused.
  * * surfaces - Whether or not the hotspot should ignite any atoms in the turf in addition to gasses (Boolean).
  */
-/turf/proc/hotspot_expose(var/exposed_temperature, var/exposed_volume, var/soh = 0, var/surfaces=0)
+/turf/proc/hotspot_expose(var/exposed_temperature, var/exposed_volume = CELL_VOLUME, var/soh = 0, var/surfaces=0)
 	return 0
 
 /turf/simulated/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
@@ -642,7 +642,7 @@ var/global/list/image/charred_overlays = list()
 					continue
 				//Spread the fire.
 				if(!(locate(/obj/effect/fire) in enemy_tile))
-					if(prob(round(burn_duration/5) + ZAS_fire_spread_chance+100*(firelevel/ZAS_firelevel_multiplier)) && S.Cross(null, enemy_tile, 0,0) && enemy_tile.Cross(null, S, 0,0))
+					if(prob(clamp(50*round(burn_duration/5) + ZAS_fire_spread_chance + 25*firelevel,0,100)) && S.Cross(null, enemy_tile, 0,0) && enemy_tile.Cross(null, S, 0,0))
 						new/obj/effect/fire(enemy_tile)
 	//seperate part of the present gas
 	//this is done to prevent the fire burning all gases in a single pass

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -119,6 +119,8 @@ Class Procs:
 	layer = MACHINERY_LAYER
 	flammable = FALSE
 
+	pass_flags_self = PASSMACHINE
+
 	penetration_dampening = 5
 
 	var/stat = 0
@@ -214,6 +216,11 @@ Class Procs:
 	qdel(hack_overlay)
 
 	..()
+
+/obj/machinery/Cross(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+	if(istype(mover) && mover.checkpass(pass_flags_self))
+		return TRUE
+	return ..()
 
 /obj/machinery/projectile_check()
 	return PROJREACT_OBJS

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -11,8 +11,9 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	icon = 'icons/effects/effects.dmi'
 	mouse_opacity = 0
 	flags = 0
+	density = 0
 	w_type = NOT_RECYCLABLE
-	pass_flags = PASSTABLE|PASSGRILLE|PASSMACHINE|PASSRAILING
+	pass_flags = PASSTABLE | PASSGRILLE | PASSMACHINE | PASSGIRDER | PASSRAILING
 
 /obj/effect/dissolvable()
 	return 0
@@ -28,25 +29,14 @@ would spawn and follow the beaker, even if it is carried or thrown.
 
 /obj/effect/water/New()
 	. = ..()
-	//var/turf/T = src.loc
-	//if (istype(T, /turf))
-	//	T.firelevel = 0 //TODO: FIX
 
 	spawn(70)
 		qdel(src)
 
 /obj/effect/water/Destroy()
-	//var/turf/T = src.loc
-	//if (istype(T, /turf))
-	//	T.firelevel = 0 //TODO: FIX
-
 	..()
 
 /obj/effect/water/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
-	//var/turf/T = src.loc
-	//if (istype(T, /turf))
-	//	T.firelevel = 0 //TODO: FIX
-
 	if (--life < 1)
 		//SN src = null
 		qdel(src)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -130,7 +130,7 @@
 				P.red_portal = null
 				P.sync_portals()
 	if (marke_sparks)
-		spark(loc, 5)
+		spark(loc, 5, surfaceburn = FALSE)
 	..()
 
 /obj/effect/portal/cultify()

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -3,6 +3,7 @@
 	w_class = W_CLASS_MEDIUM
 	icon = 'icons/obj/inflatable.dmi'
 	w_type = RECYK_PLASTIC
+	flammable = FALSE
 	melt_temperature = MELTPOINT_PLASTIC
 	starting_materials = list(MAT_PLASTIC = 1.5*CC_PER_SHEET_MISC)
 

--- a/code/modules/reagents/reagents/reagents_basic.dm
+++ b/code/modules/reagents/reagents/reagents_basic.dm
@@ -315,7 +315,7 @@
 	var/hotspot = (locate(/obj/effect/fire) in T)
 	if(hotspot)
 		var/datum/gas_mixture/G = T.return_air()
-		G.temperature = max(G.temperature - rand(1,5),T20C) //water extinguishers can only cool to 20C
+		G.temperature = max(G.temperature - (0.10 * rand(1,5)),T20C) //water extinguishers can only cool to 20C
 		qdel(hotspot)
 
 /datum/reagent/water/reaction_obj(var/obj/O, var/volume)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- Sparks created when wormholes disappear will no longer start fires throughout the station.
- Fire extinguishers now properly extinguish tiles with machinery on them such as disposal bins, jukeboxes, etc.
- Drastically reduced the cooling power of standard fire extinguishers.
- Inflatable shelters are no longer flammable while deflated.
- Hot items will now always ignite gaseous plasma.
- Fire spreads slightly quicker and will spread rapidly during plasmafloods.

## Why it's good
<!-- Explain why you think these changes are good. -->
Closes #36509.
Closes #36510.
Closes #36515.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Wormholes despawning will no longer create station-wide fires.
 * bugfix: Fire extinguisher spray will now properly pass through machinery.
 * tweak: Reduced the cooling power of fire extinguishers.
