### PR TITLE
Alleviate issues with policetape

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -271,7 +271,7 @@ var/list/all_doors = list()
 	if(!ticker)
 		return 0
 	for (var/obj/O in src.loc)
-		if (O.blocks_doors())
+		if (O.blocks_doors(src))
 			return 0
 	if(arcanetampered && arcane_linked_door && arcane_linked_door.density)
 		spawn(1)
@@ -316,7 +316,7 @@ var/list/all_doors = list()
 		return
 
 	for (var/obj/O in src.loc)
-		if (O.blocks_doors())
+		if (O.blocks_doors(src))
 			return 0
 
 	if(arcanetampered && arcane_linked_door && !arcane_linked_door.density)

--- a/code/game/objects/items/policetape.dm
+++ b/code/game/objects/items/policetape.dm
@@ -164,7 +164,7 @@
 	if(proximity_flag == 0)//Check adjacency.
 		return 0
 
-	if(istype(target, /obj/machinery/door/airlock) || istype(target, /obj/machinery/door/firedoor))	//Make sure we can tape the target.
+	if(istype(target, /obj/machinery/door/airlock))	//Make sure we can tape the target.
 		var/turf = get_turf(target)
 
 		//Check to see if the object already has any tape of any kind on it.
@@ -181,7 +181,9 @@
 			to_chat(user, "<span class='notice'>You placed \the [src].</span>")
 			return 1
 
-/obj/item/tape/blocks_doors()
+/obj/item/tape/blocks_doors(var/obj/machinery/door/D)
+	if (istype(D, /obj/machinery/door/firedoor/border_only))
+		return FALSE
 	return TRUE
 
 /obj/item/tape/Bumped(var/atom/movable/AM)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -138,7 +138,7 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 
 /obj/item/proc/is_used_on(obj/O, mob/user)
 
-/obj/proc/blocks_doors()
+/obj/proc/blocks_doors(var/obj/machinery/door/D)
 	return 0
 
 /obj/proc/install_pai(obj/item/device/paicard/P)

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -143,7 +143,9 @@
 /obj/structure/window/barricade/full/setup_border_dummy()
 	return
 
-/obj/structure/window/barricade/full/blocks_doors()
+/obj/structure/window/barricade/full/blocks_doors(var/obj/machinery/door/D)
+	if (istype(D, /obj/machinery/door/firedoor/border_only))
+		return FALSE
 	return TRUE
 
 /obj/structure/window/barricade/full/Cross(atom/movable/mover, turf/target, height = 1.5, air_group = 0)


### PR DESCRIPTION
![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/9953d006-8d9d-4c9a-9f4d-69883d884380)

Before:
* From the top, you can rip the police tape apart
* From the bottom you cannot do anything

After:
* From the top, you can rip the police tape apart
* From the bottom you can rip the police tape apart after opening the firedoor

:cl:
* bugfix: You can now remove police tape and barricades built over firedoors, although you need to open them first (which can be done now).