### PR TITLE
A Series of Unatomic Fire Bugfixes

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -1223,7 +1223,7 @@ var/list/cult_spires = list()
 	if (isturf(loc))
 		var/turf/simulated/L = loc
 		if(istype(L))
-			L.hotspot_expose(TEMPERATURE_FLAME, SMALL_FLAME, surfaces = 1)//we start fires in plasma atmos
+			L.hotspot_expose(TEMPERATURE_FLAME, SMALL_FLAME, 0)//we start fires in plasma atmos
 			var/datum/gas_mixture/env = L.return_air()
 			if (env.total_moles > 0)//we cannot manipulate temperature in a vacuum
 				if(env.temperature != set_temperature + T0C)

--- a/code/datums/gamemode/factions/legacy_cult/runes.dm
+++ b/code/datums/gamemode/factions/legacy_cult/runes.dm
@@ -375,7 +375,7 @@
 	playsound(U, 'sound/items/Welder2.ogg', 25, 1)
 	var/turf/T = get_turf(U)
 	if(T)
-		T.hotspot_expose(700,SMALL_FLAME,surfaces=1)
+		T.hotspot_expose(700,SMALL_FLAME,1)
 	var/rune = src // detaching the proc - in theory
 	empulse(U, (range_red - 2), range_red)
 	qdel(rune)
@@ -1302,14 +1302,14 @@
 					else
 						to_chat(M, "<span class='warning'>The rune suddenly ignites, burning you!</span>")
 					var/turf/T = get_turf(R)
-					T.hotspot_expose(700,SMALL_FLAME,surfaces=1)
+					T.hotspot_expose(700,SMALL_FLAME,1)
 		for(var/obj/effect/decal/cleanable/blood/B in effects_list)
 			if(B.blood_DNA == src.blood_DNA)
 				for(var/mob/living/M in orange(1,B))
 					M.take_overall_damage(0,5)
 					to_chat(M, "<span class='warning'>The blood suddenly ignites, burning you!</span>")
 					var/turf/T = get_turf(B)
-					T.hotspot_expose(700,SMALL_FLAME,surfaces=1)
+					T.hotspot_expose(700,SMALL_FLAME,1)
 					qdel(B)
 		qdel(src)
 

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -290,7 +290,7 @@
 				if(prob(30))
 					spark(src)
 				T.ex_act(3)
-				T.hotspot_expose(1000,MEDIUM_FLAME,1,surfaces=1)
+				T.hotspot_expose(1000,MEDIUM_FLAME,1,1)
 
 /obj/machinery/computer/HolodeckControl/proc/derez(var/obj/obj , var/silent = 1)
 
@@ -334,7 +334,7 @@
 						spark(T, 2)
 						if(T)
 							T.temperature = 5000
-							T.hotspot_expose(50000,FULL_FLAME,1,surfaces=1)
+							T.hotspot_expose(50000,FULL_FLAME,1,1)
 
 		active = 1
 	else
@@ -381,7 +381,7 @@
 					spark(T, 2)
 					if(T)
 						T.temperature = 5000
-						T.hotspot_expose(50000,FULL_FLAME,1,surfaces=1)
+						T.hotspot_expose(50000,FULL_FLAME,1,1)
 			if(L.name=="Holocarp Spawn")
 				new /mob/living/simple_animal/hostile/carp/holocarp(L.loc)
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -293,7 +293,7 @@
 		napalm.adjust_gas(GAS_PLASMA, toxinsToDeduce)
 		target_tile.assume_air(napalm)
 		spawn (0)
-			target_tile.hotspot_expose(temperature, MEDIUM_FLAME, surfaces=1)
+			target_tile.hotspot_expose(temperature, MEDIUM_FLAME, 1)
 	for(var/obj/structure/falsewall/plasma/F in range(3,src))//Hackish as fuck, but until fire_act works, there is nothing I can do -Sieve
 		var/turf/T = get_turf(F)
 		T.ChangeTurf(/turf/simulated/wall/mineral/plasma/)

--- a/code/game/machinery/doors/mineral.dm
+++ b/code/game/machinery/doors/mineral.dm
@@ -183,7 +183,7 @@
 		napalm.adjust_gas(GAS_PLASMA, toxinsToDeduce)
 
 		target_tile.assume_air(napalm)
-		spawn (0) target_tile.hotspot_expose(temperature, MEDIUM_FLAME,surfaces=1)
+		spawn (0) target_tile.hotspot_expose(temperature, MEDIUM_FLAME,1)
 
 		hardness -= toxinsToDeduce/100
 		CheckHardness()

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -32,8 +32,8 @@ var/global/list/igniters = list()
 /obj/machinery/igniter/process()	//ugh why is this even in process()?
 	if (src.on && !(stat & (NOPOWER|FORCEDISABLE)) )
 		var/turf/location = src.loc
-		if (isturf(location))
-			location.hotspot_expose(1000,MEDIUM_FLAME,1,surfaces=1)
+		var/surf = isturf(location)?TRUE:FALSE
+		location.hotspot_expose(1000,MEDIUM_FLAME,1,surf)
 	return 1
 
 /obj/machinery/igniter/proc/toggle_state()
@@ -142,8 +142,8 @@ var/global/list/igniters = list()
 	src.last_spark = world.time
 	use_power(1000)
 	var/turf/location = src.loc
-	if (isturf(location))
-		location.hotspot_expose(1000,MEDIUM_FLAME,1,surfaces=1)
+	var/surf = isturf(location)?TRUE:FALSE
+	location.hotspot_expose(1000,MEDIUM_FLAME,1,surf)
 	return 1
 
 /obj/machinery/sparker/emp_act(severity)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -178,8 +178,7 @@ steam.start() -- spawns the effect
 		return
 	else
 		var/turf/T = src.loc
-		if(istype(T, /turf) && prob(1))
-			T.hotspot_expose(SPARK_TEMP, SMALL_FLAME, surfaces = surfaceburn)
+		T.hotspot_expose(SPARK_TEMP, SMALL_FLAME, surfaceburn)
 		step(src,move_dir)
 	energy--
 

--- a/code/game/objects/effects/fire_blast.dm
+++ b/code/game/objects/effects/fire_blast.dm
@@ -98,7 +98,7 @@
 
 			var/turf/T2 = get_turf(src)
 			if(T2)
-				T2.hotspot_expose((blast_temperature * 2) + 380,MEDIUM_FLAME, surfaces = T2)
+				T2.hotspot_expose((blast_temperature * 2) + 380,MEDIUM_FLAME, 1)
 			sleep(2)
 		qdel(src)
 

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -39,7 +39,7 @@
 	for(var/turf/simulated/floor/target in range(1,src))
 		if(!target.blocks_air)
 			target.zone.air.adjust_gas(GAS_PLASMA, 30)
-			target.hotspot_expose(1000, FULL_FLAME, surfaces = 1)
+			target.hotspot_expose(1000, FULL_FLAME, 1)
 	qdel(src)
 
 /obj/effect/mine/kick

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -170,7 +170,7 @@
 		return
 	update_icon()
 	if(istype(T)) //Start a fire if possible
-		T.hotspot_expose(source_temperature, SMALL_FLAME, surfaces = 0)
+		T.hotspot_expose(source_temperature, SMALL_FLAME, 0)
 
 /obj/item/candle/attack_self(mob/user as mob)
 	if(lit)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -540,7 +540,7 @@ var/global/msg_id = 0
 		M.show_message("<span class='warning'>Your [src] explodes!</span>", 1)
 
 	if(T)
-		T.hotspot_expose(700,SMALL_FLAME,1)
+		T.hotspot_expose(700,SMALL_FLAME,0)
 
 		explosion(T, -1, -1, 2, 3, whodunnit = user)
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -311,7 +311,8 @@
 /obj/item/device/flashlight/flare/process()
 	var/turf/pos = get_turf(src)
 	if(pos)
-		pos.hotspot_expose(heat_production, LARGE_FLAME, 1)
+		var/surf = isturf(loc)?TRUE:FALSE
+		pos.hotspot_expose(heat_production, LARGE_FLAME, surf)
 	fuel = max(fuel - 1, 0)
 	if(!fuel || !on)
 		turn_off()

--- a/code/game/objects/items/incense.dm
+++ b/code/game/objects/items/incense.dm
@@ -173,7 +173,7 @@
 		//are we on a turf? or held by a mob that's on a turf? or in a thurible (that's on the ground or held by a mob?)
 		if (istype(location) && (isturf(loc) || (ismob(loc) && isturf(loc.loc)) || (istype(loc,/obj/item/weapon/thurible) && (isturf(loc.loc) || (ismob(loc.loc) && isturf(loc.loc.loc))))))//I'm sorry
 			if (location)
-				location.hotspot_expose(source_temperature, SMALL_FLAME, surfaces = 0)
+				location.hotspot_expose(source_temperature, SMALL_FLAME, 0)
 				anim(target = location, a_icon = 'icons/effects/160x160.dmi', flick_anim = "incense", offX = -WORLD_ICON_SIZE*2+pixel_x, offY = -WORLD_ICON_SIZE*2+pixel_y)
 				if (location.zone)//is there a simulated atmosphere where we are?
 

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -148,8 +148,9 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 		update_brightness()
 		if(M)
 			to_chat(M, "The flame on \the [src] suddenly goes out in a weak fashion.")
-	if(location && istype(loc,/turf)) //only hotspot expose if it's physically on the floor
-		location.hotspot_expose(source_temperature, SMALL_FLAME, 1)
+	if(location)
+		var/surf = isturf(loc)?TRUE:FALSE
+		location.hotspot_expose(source_temperature, SMALL_FLAME, surf)
 		return
 
 /obj/item/weapon/match/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
@@ -175,8 +176,9 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 
 /obj/item/weapon/match/strike_anywhere/s_a_k/process()//never burns out, extra swiss quality magic matches
 	var/turf/location = get_turf(src)
-	if(location && istype(loc,/turf))
-		location.hotspot_expose(source_temperature, SMALL_FLAME, 1)
+	if(location)
+		var/surf = isturf(loc)?TRUE:FALSE
+		location.hotspot_expose(source_temperature, SMALL_FLAME, surf)
 
 /obj/item/weapon/match/strike_anywhere/afterattack(atom/target, mob/user, prox_flags)
 	if(!prox_flags == 1)
@@ -498,8 +500,9 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 			M.u_equip(src, 0)	//Un-equip it so the overlays can update
 		qdel(src)
 		return
-	if(location && istype(loc,/turf))
-		location.hotspot_expose(source_temperature, SMALL_FLAME, 1)
+	if(location)
+		var/surf = isturf(loc)?TRUE:FALSE
+		location.hotspot_expose(source_temperature, SMALL_FLAME, surf)
 	//Oddly specific and snowflakey reagent transfer system below
 	if(reagents && reagents.total_volume)	//Check if it has any reagents at all
 		if(iscarbon(M) && ((src == M.wear_mask) || (loc == M.wear_mask))) //If it's in the human/monkey mouth, transfer reagents to the mob
@@ -857,8 +860,9 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 				M.update_inv_wear_mask(0)
 		update_brightness()
 		return
-	if(location && istype(loc,/turf))
-		location.hotspot_expose(source_temperature, SMALL_FLAME, 1)
+	if(location)
+		var/surf = isturf(loc)?TRUE:FALSE
+		location.hotspot_expose(source_temperature, SMALL_FLAME, surf)
 	return
 
 /obj/item/clothing/mask/cigarette/pipe/attack_self(mob/user as mob) //Refills the pipe. Can be changed to an attackby later, if loose tobacco is added to vendors or something. //Later meaning never
@@ -1072,8 +1076,9 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 
 /obj/item/weapon/lighter/process()
 	var/turf/location = get_turf(src)
-	if(location && istype(loc,/turf))
-		location.hotspot_expose(source_temperature, SMALL_FLAME, 1)
+	if(location)
+		var/surf = isturf(loc)?TRUE:FALSE
+		location.hotspot_expose(source_temperature, SMALL_FLAME, surf)
 	if(!fueltime)
 		fueltime = world.time + 100
 	if(world.time > fueltime)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -386,8 +386,9 @@
 		var/mob/M = location
 		if(M.is_holding_item(src))
 			location = get_turf(M)
-	if (istype(location, /turf) && welding)
-		location.hotspot_expose(source_temperature, MEDIUM_FLAME, 1)
+	if (welding)
+		var/surf = isturf(loc)?TRUE:FALSE
+		location.hotspot_expose(source_temperature, MEDIUM_FLAME, surf)
 
 /obj/item/tool/weldingtool/attack(mob/M as mob, mob/user as mob)
 	if(hasorgans(M))

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -564,6 +564,7 @@ a {
 
 /obj/update_icon()
 	if(ash_covered)
+		overlays -= charred_overlay
 		process_charred_overlay()
 	return
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -58,6 +58,9 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 	var/is_cooktop //If true, the object can be used in conjunction with a cooking vessel, eg. a frying pan, to cook food.
 	var/obj/item/weapon/reagent_containers/pan/cookvessel //The vessel being used to cook food in. If generalized out to other types of vessels, make sure to also generalize the frying pan's cook_start(), etc. as well.
 
+	//Is the object covered in ash?
+	var/ash_covered = FALSE
+
 /obj/New()
 	..()
 	if(breakable_flags)
@@ -288,6 +291,7 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 	..()
 	if (cleanliness >= CLEANLINESS_WATER)
 		unglue()
+		ash_covered = FALSE
 
 /obj/proc/cultify()
 	qdel(src)
@@ -418,7 +422,8 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 		return SUICIDE_ACT_BRUTELOSS
 
 /obj/ignite()
-	..()
+	. = ..()
+	ash_covered = TRUE
 	remove_particles(PS_SMOKE)
 
 /obj/singularity_act()
@@ -558,6 +563,8 @@ a {
 	onclose(user, "mtcomputer")
 
 /obj/update_icon()
+	if(ash_covered)
+		process_charred_overlay()
 	return
 
 /mob/proc/unset_machine()

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -19,7 +19,8 @@
 	else
 		var/turf/location = get_turf(loc)
 		if(location)
-			location.hotspot_expose(1000,LARGE_FLAME,1)
+			var/surf = isturf(loc)?TRUE:FALSE
+			location.hotspot_expose(1000,LARGE_FLAME,surf)
 
 		spark(src)
 

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -94,8 +94,9 @@
 		else
 			return
 
-	if (istype(location, /turf))
-		location.hotspot_expose(700, SMALL_FLAME, 0)
+	var/surf = isturf(loc)?TRUE:FALSE
+	location = get_turf(src)
+	location.hotspot_expose(700, SMALL_FLAME, surf)
 
 /obj/item/clothing/head/cakehat/attack_self(mob/user as mob)
 	if(status > 1)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- Items covered in ash will now retain the ash when their states are cycled (ie a lit welder will still be ashed when unlit)
- Areas should not be able to catch on fire, preventing server mustard gas.
- Held things or flaming things in a container will no longer hotspot_expose and ignite the ground beneath them.
- Fires on flammable liquids will now spread more rapidly.
- Refactored burning welding fuel puddles.

## Why it's good
<!-- Explain why you think these changes are good. -->
Closes #36534.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Items covered in ash will now retain the ash when their states are cycled (ie a lit welder will still be ashed when unlit).
 * bugfix: Held things or flaming things in a container will no longer hotspot_expose and ignite the ground beneath them.
 * tweak: Fires on flammable liquids will now spread more rapidly.

