### PR TITLE
Stops lighters and flares from setting things on fire while they are not lit

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -310,7 +310,7 @@
 
 /obj/item/device/flashlight/flare/process()
 	var/turf/pos = get_turf(src)
-	if(pos)
+	if(pos && on)
 		var/surf = isturf(loc)?TRUE:FALSE
 		pos.hotspot_expose(heat_production, LARGE_FLAME, surf)
 	fuel = max(fuel - 1, 0)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -148,7 +148,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 		update_brightness()
 		if(M)
 			to_chat(M, "The flame on \the [src] suddenly goes out in a weak fashion.")
-	if(location)
+	if(location && lit == 1)
 		var/surf = isturf(loc)?TRUE:FALSE
 		location.hotspot_expose(source_temperature, SMALL_FLAME, surf)
 		return
@@ -176,7 +176,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 
 /obj/item/weapon/match/strike_anywhere/s_a_k/process()//never burns out, extra swiss quality magic matches
 	var/turf/location = get_turf(src)
-	if(location)
+	if(location && lit == 1)
 		var/surf = isturf(loc)?TRUE:FALSE
 		location.hotspot_expose(source_temperature, SMALL_FLAME, surf)
 
@@ -500,7 +500,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 			M.u_equip(src, 0)	//Un-equip it so the overlays can update
 		qdel(src)
 		return
-	if(location)
+	if(location && lit == 1)
 		var/surf = isturf(loc)?TRUE:FALSE
 		location.hotspot_expose(source_temperature, SMALL_FLAME, surf)
 	//Oddly specific and snowflakey reagent transfer system below
@@ -860,7 +860,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 				M.update_inv_wear_mask(0)
 		update_brightness()
 		return
-	if(location)
+	if(location && lit == 1)
 		var/surf = isturf(loc)?TRUE:FALSE
 		location.hotspot_expose(source_temperature, SMALL_FLAME, surf)
 	return
@@ -1076,7 +1076,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 
 /obj/item/weapon/lighter/process()
 	var/turf/location = get_turf(src)
-	if(location)
+	if(location && lit == 1)
 		var/surf = isturf(loc)?TRUE:FALSE
 		location.hotspot_expose(source_temperature, SMALL_FLAME, surf)
 	if(!fueltime)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Title

## Why it's good
<!-- Explain why you think these changes are good. -->
This is silly

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Unlit lighters, matches, cigarettes, and flares will no longer start fires.