### PR TITLE
Add "Blow on" verb to foods

### DIFF
--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -8,6 +8,11 @@
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/food.dmi', "right_hand" = 'icons/mob/in-hand/right/food.dmi')
 	possible_transfer_amounts = null
 	volume = 50 //Food can contain a beaker's worth of reagents unless specified otherwise. Do note large servings of complex food items can contain well over 50 reagents total
+	
+/obj/item/weapon/reagent_containers/food/verb/blow()
+	set name = "Blow"
+	set category = "Object"
+	MiddleAltClick(usr)
 
 /obj/item/weapon/reagent_containers/food/New()
 	..()

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -9,8 +9,8 @@
 	possible_transfer_amounts = null
 	volume = 50 //Food can contain a beaker's worth of reagents unless specified otherwise. Do note large servings of complex food items can contain well over 50 reagents total
 	
-/obj/item/weapon/reagent_containers/food/verb/blow()
-	set name = "Blow"
+/obj/item/weapon/reagent_containers/food/verb/blow_on()
+	set name = "Blow on"
 	set category = "Object"
 	MiddleAltClick(usr)
 


### PR DESCRIPTION
## What this does
Add a "Blow on" verb to the right-click menu for food items.

## Why it's good
Because not everyone knows you can Alt+MiddleClick your food to cool it.

## Changelog
:cl:
 * rscadd: Add a "Blow on" verb to the right-click menu for food items.