### PR TITLE
Ash & Smoke Visuals Removal

### DIFF
--- a/__DEFINES/_macros.dm
+++ b/__DEFINES/_macros.dm
@@ -222,7 +222,7 @@
 
 #define isrealobject(A) (istype(A, /obj/item) || istype(A, /obj/structure) || istype(A, /obj/machinery) || istype(A, /obj/mecha))
 
-#define iscleanaway(A) (istype(A,/obj/effect/decal/cleanable) || (istype(A,/obj/effect/overlay) && !istype(A,/obj/effect/overlay/puddle) && !istype(A, /obj/effect/overlay/hologram)) || istype(A,/obj/effect/rune_legacy) || (A.ErasableRune()) || istype(A,/obj/effect/ash))
+#define iscleanaway(A) (istype(A,/obj/effect/decal/cleanable) || (istype(A,/obj/effect/overlay) && !istype(A,/obj/effect/overlay/puddle) && !istype(A, /obj/effect/overlay/hologram)) || istype(A,/obj/effect/rune_legacy) || (A.ErasableRune()))
 
 #define ismatrix(A) (istype(A, /matrix))
 

--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -94,9 +94,6 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	var/fire_sprite = "fire"
 	var/fire_overlay = null
 
-	var/image/charred_overlay = null
-	var/last_char = 0
-
 	var/atom/movable/firelightdummy/firelightdummy
 
 /atom/movable/New()
@@ -163,76 +160,6 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	if(reagents?.total_volume)
 		return TRUE
 
-//charred overlay procs taken from Deity's food temperature overlays system (see food.dm)
-var/global/list/image/charred_overlays = list()
-
-/atom/proc/set_charred_overlay()
-	return
-
-/atom/proc/update_charred_overlay(var/char_alpha)
-	return
-
-/atom/proc/process_charred_overlay()
-	return
-
-/obj/set_charred_overlay()
-	if(update_charred_overlay())
-		return
-
-	var/icon/I = new /icon(icon, icon_state)
-	I.Blend(rgb(255,255,255),ICON_ADD)
-	I.Blend(new /icon('icons/effects/effects.dmi', "char"),ICON_MULTIPLY)
-
-	var/image/img = image(I)
-	img.name = "charred_overlay"
-	charred_overlays["[type][icon_state]"] = img
-	update_charred_overlay()
-
-/obj/update_charred_overlay(var/char_alpha = 96)
-	if(charred_overlays["[type][icon_state]"])
-		if (charred_overlay)
-			overlays -= charred_overlay
-		charred_overlay = mutable_appearance(charred_overlays["[type][icon_state]"])
-		charred_overlay.appearance_flags = RESET_COLOR|RESET_ALPHA|KEEP_TOGETHER
-		charred_overlay.alpha = char_alpha
-		overlays += charred_overlay
-		return 1
-
-/obj/process_charred_overlay()
-	if(thermal_mass)
-		var/c_alpha = 96 + clamp((64*(1-(thermal_mass/initial_thermal_mass))),0,64)
-		if(!charred_overlays["[type][icon_state]"])
-			set_charred_overlay()
-		else
-			update_charred_overlay(c_alpha)
-		last_char = world.time
-	else
-		if(prob(10)) //10% chance each tick of item getting charred
-			set_charred_overlay()
-
-/obj/effect/process_charred_overlay()
-	return
-
-/turf/process_charred_overlay()
-	if(locate(/obj/effect/ash) in src)
-		var/obj/effect/ash/A = locate(/obj/effect/ash) in src
-		if(flammable)
-			A.alpha = clamp((80*(1-(thermal_mass/initial_thermal_mass))),0,80) //turf's char overlays aren't as harsh as objects'
-		else
-			A.alpha = 40
-	else
-		new /obj/effect/ash(src)
-
-/obj/effect/ash
-	name = "ash"
-	icon_state = "char"
-	alpha = 0
-	anchored = 1
-	mouse_opacity = 0
-
-/obj/effect/ash/clean_act(var/cleanliness)
-	if(cleanliness >= CLEANLINESS_WATER)
-		qdel(src)
 /**
  * Burns solid objects and produces heat.
  *
@@ -281,9 +208,6 @@ var/global/list/image/charred_overlays = list()
 	var/delta_m = 0.20 * burnrate * ZAS_mass_consumption_multiplier
 	useThermalMass(delta_m)
 	genSmoke(oxy_ratio,temperature,T)
-
-	if(world.time - last_char >= 10 SECONDS)
-		process_charred_overlay()
 
 	//Change in internal energy = energy produced by combustion (assuming perfect combustion).
 	heat_out = material.heating_value * delta_m
@@ -419,15 +343,12 @@ var/global/list/image/charred_overlays = list()
 	if(flammable && !on_fire)
 		ignite()
 		return 1
-	else
-		process_charred_overlay()
-	return 0
 
 /atom/proc/checkburn()
 	if(on_fire)
 		return
 	if(!flammable)
-		return
+		CRASH("[src] was added to burnableatoms despite not being flammable!")
 	//if an object is not on fire, is flammable, and is in an environment with temperature above its autoignition temp & sufficient oxygen, ignite it
 	if(thermal_mass <= 0)
 		ashify()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -467,8 +467,6 @@ its easier to just keep the beam vertical.
 	if(on_fire)
 		user.simple_message("<span class='danger'>OH SHIT! IT'S ON FIRE!</span>",\
 			"<span class='info'>It's on fire, man.</span>")
-	if(charred_overlay)
-		to_chat(user, "<span class='info'>It's covered in ash.</span>")
 	if(min_harm_label && harm_labeled)
 		if(harm_labeled < min_harm_label)
 			to_chat(user, harm_label_examine[1])
@@ -551,8 +549,6 @@ its easier to just keep the beam vertical.
 /atom/proc/clean_act(var/cleanliness)//1 = contact with water (splashed with water, removes glue from objs), 2 = space cleaner or efficient cleaning (showers, sink, soap), 3 = bleach
 	if (cleanliness >= CLEANLINESS_SPACECLEANER)
 		clean_blood()
-		if(charred_overlay)
-			overlays -= charred_overlay
 	if (cleanliness >= CLEANLINESS_BLEACH)
 		color = ""
 	if (cleanliness >= CLEANLINESS_WATER)//I mean, not sure why we'd ever add a rank below water but, futur-proofing and all that jazz

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -53,8 +53,6 @@ BREATHALYZER
 			if(istype(A,/obj/))
 				var/obj/O = A
 				O.t_scanner_expose()
-			else if(istype(A,/obj/effect/ash))
-				continue
 			else if(istype(A,/mob/living/carbon))
 				var/mob/living/carbon/C = A
 				if(C.alpha < OPAQUE || (C.invisibility > 0 && C.invisibility < INVISIBILITY_OBSERVER) || length(C.body_alphas))

--- a/code/game/objects/items/trader.dm
+++ b/code/game/objects/items/trader.dm
@@ -200,12 +200,6 @@
 		else if(P.wet == TURF_WET_WATER)
 			reagents.add_reagent(WATER,1)
 		qdel(P)
-	for(var/obj/effect/ash/A in T)
-		if(reagents.is_full())
-			visible_message("<span class='warning'>\The [src] sputters, wet tank full!</span>")
-			break
-		reagents.add_reagent(CARBON,1)
-		qdel(A)
 	T.clean_blood()
 	for(var/obj/item/trash/R in T)
 		if(trash.len >= max_trash)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -59,9 +59,6 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 	var/is_cooktop //If true, the object can be used in conjunction with a cooking vessel, eg. a frying pan, to cook food.
 	var/obj/item/weapon/reagent_containers/pan/cookvessel //The vessel being used to cook food in. If generalized out to other types of vessels, make sure to also generalize the frying pan's cook_start(), etc. as well.
 
-	//Is the object covered in ash?
-	var/ash_covered = FALSE
-
 /obj/New()
 	..()
 	if(breakable_flags)
@@ -292,7 +289,6 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 	..()
 	if (cleanliness >= CLEANLINESS_WATER)
 		unglue()
-		ash_covered = FALSE
 
 /obj/proc/cultify()
 	qdel(src)
@@ -425,28 +421,6 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 /obj/ignite()
 	if(!istype(loc, /turf)) //Prevent things from burning if worn, held, or inside something else. Storage containers will eject their contents when ignited, allowing for burning of the contents.
 		return
-	. = ..()
-	ash_covered = TRUE
-	remove_particles(PS_SMOKE)
-
-/obj/item/checkburn()
-	if(!flammable)
-		burnableatoms -= src
-		CRASH("[src] was added to burnableatoms despite not being flammable!")
-	if(on_fire)
-		return
-	var/datum/gas_mixture/G = return_air()
-	if(!G)
-		return
-	if(G.temperature >= (autoignition_temperature * 0.75))
-		if(!smoking)
-			add_particles(PS_SMOKE)
-			smoking = TRUE
-		var/rate = clamp(lerp(G.temperature,autoignition_temperature * 0.75,autoignition_temperature,0.1,1),0.1,1)
-		adjust_particles(PVAR_SPAWNING,rate,PS_SMOKE)
-	else
-		remove_particles(PS_SMOKE)
-		smoking = FALSE
 	..()
 
 /obj/singularity_act()
@@ -586,9 +560,6 @@ a {
 	onclose(user, "mtcomputer")
 
 /obj/update_icon()
-	if(ash_covered)
-		overlays -= charred_overlay
-		process_charred_overlay()
 	return
 
 /mob/proc/unset_machine()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -79,8 +79,6 @@
 	..()
 	if(bullet_marks)
 		to_chat(user, "It has [bullet_marks > 1 ? "some holes" : "a hole"] in it.")
-	if(locate(/obj/effect/ash) in src)
-		to_chat(user, "It is covered in ashes.")
 
 /turf/proc/process()
 	set waitfor = FALSE


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Removes the ash visuals on burnt objects and tiles as well as the black smoke which appears on objects nearing their autoignition temperature.

## Why it's good
<!-- Explain why you think these changes are good. -->
Removing these visuals cuts the burnable subsystem cost in half, reducing the noticeable stutter every 7 seconds when the subsystem pulses. This does _not_ remove the smoke clouds produced by fires. If this system can be optimized in the future I will attempt to bring it back, but for now performance is more important than visuals.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscdel: Removed ash production from fires.
 * rscdel: Removed objects smoking while nearing their autoignition temperatures.