### PR TITLE
typofix on the viper poster

### DIFF
--- a/code/game/objects/effects/decals/posters/vgposters.dm
+++ b/code/game/objects/effects/decals/posters/vgposters.dm
@@ -26,7 +26,7 @@
 
 /datum/poster/vg_6//45
 	name = "Termination Of The Self"
-	desc = "A portrait of a famous philospher who challenged the boundaries of mortality."
+	desc = "A portrait of a famous philosopher who challenged the boundaries of mortality."
 	icon_state="vgposter6"
 
 /datum/poster/vg_7//46


### PR DESCRIPTION
## What this does
typofix

## Why it's good
typofix
:cl:
 * spellcheck: typofixes the viper poster description
