### PR TITLE
Ignition Nerf

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1175,9 +1175,9 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define AUTOIGNITION_TRIGGER 500.00 //temperature at which an area begins checking for autoignition
 
 // flame sizes (% of cell volume occupied by a flame)
-#define SMALL_FLAME 250 //a match, a candle, or a lighter (10% chance to ignite)
-#define MEDIUM_FLAME 625 //a single burning object on the ground (25%)
-#define LARGE_FLAME 1250 //a healthy campfire (50%)
+#define SMALL_FLAME 25 //a match, a candle, or a lighter (1% chance to ignite)
+#define MEDIUM_FLAME 250 //a single burning object on the ground (10%)
+#define LARGE_FLAME 675 //a healthy campfire (25%)
 #define FULL_FLAME 2500 //floor to ceiling flames
 
 //////////////////

--- a/code/datums/gamemode/role/malf/hackabilities.dm
+++ b/code/datums/gamemode/role/malf/hackabilities.dm
@@ -241,7 +241,7 @@
 			T.cover.shake_animation(4, 4, 0.2 SECONDS, 20)
 	else
 		machine.shake_animation(4, 4, 0.2 SECONDS, 20)
-	spark(machine)
+	spark(machine, surfaceburn = TRUE)
 	spawn(4 SECONDS)
 		if(machine)
 			explosion(get_turf(machine), -1, 2, 3, 4) // Welding tank sized explosion

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -138,7 +138,7 @@ var/global/list/igniters = list()
 
 
 	flick("[base_state]-spark", src)
-	spark(src, 2)
+	spark(src, 2, surfaceburn = TRUE)
 	src.last_spark = world.time
 	use_power(1000)
 	var/turf/location = src.loc

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -213,7 +213,7 @@ steam.start() -- spawns the effect
 				var/obj/effect/sparks/nosurfaceburn/sparks = new /obj/effect/sparks/nosurfaceburn(location)
 				sparks.start(nextdir)
 // This sparks.
-/proc/spark(var/atom/loc, var/amount = 3, var/cardinals = TRUE, var/surfaceburn = TRUE) //surfaceburn means the sparks can ignite things on the ground. set it to false to keep eg. portals like in the time agent event from burning down the station
+/proc/spark(var/atom/loc, var/amount = 3, var/cardinals = TRUE, var/surfaceburn = FALSE) //surfaceburn means the sparks can ignite things on the ground. set it to false to keep eg. portals like in the time agent event from burning down the station
 	loc = get_turf(loc)
 	var/datum/effect/system/spark_spread/S = new
 	S.set_up(amount, cardinals, loc)

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -22,7 +22,7 @@
 			var/surf = isturf(loc)?TRUE:FALSE
 			location.hotspot_expose(1000,LARGE_FLAME,surf)
 
-		spark(src)
+		spark(src, surfaceburn = TRUE)
 
 		if (istype(src.loc,/obj/item/device/assembly_holder))
 			if (istype(src.loc.loc, /obj/structure/reagent_dispensers/))


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Removes the ability for sparks to ignite items unless they are produced by one of the following sources:
- Igniter (object)
- Igniter (machine)
- Malf AI Overload

Additionally, further reduced the probabilities for smaller hot objects such as lighters or cigarettes to start fires; now it will be more likely that the burning item will simply burn out before igniting something. Closes #36563.

## Why it's good
<!-- Explain why you think these changes are good. -->
Lots of things cause sparks; starting raging fires because of common activities is not fun.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Sparks will no longer ignite things except for a few exceptions.
 * tweak: Reduced the chance for smaller items to ignite the turfs they're on top of.
