### PR TITLE
Fixes lit vs ignited inconsistencies

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -345,6 +345,17 @@
 	user.visible_message("<span class='notice'>[user] activates the flare.</span>", "<span class='notice'>You pull the cord on the flare, activating it!</span>")
 	Light(user)
 
+
+/obj/item/device/flashlight/flare/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	if(on)
+		return
+	ignite()
+
+/obj/item/device/flashlight/flare/ignite()
+	if(on)
+		return
+	Light()
+
 /obj/item/device/flashlight/flare/proc/Light(var/mob/user as mob)
 	on = 1
 	src.force = on_damage

--- a/code/game/objects/items/incense.dm
+++ b/code/game/objects/items/incense.dm
@@ -111,6 +111,11 @@
 		return
 	burn()
 
+/obj/item/incense_stick/ignite()
+	if(lit)
+		return
+	burn()
+
 /obj/item/incense_stick/is_hot()
 	if(lit)
 		return source_temperature

--- a/code/game/objects/items/incense.dm
+++ b/code/game/objects/items/incense.dm
@@ -235,6 +235,11 @@
 		var/mob/M = loc
 		M.update_inv_hands()
 
+/obj/item/incense_stick/extinguish()
+	lit = 0
+	update_icon()
+	..()
+
 /obj/item/incense_stick/proc/set_fragrance(var/newfrag)
 	if(fragrance == newfrag)
 		return FALSE

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -55,7 +55,6 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	return 0
 
 /obj/item/weapon/match/ignite(temperature)
-	. = ..()
 	light()
 
 /obj/item/weapon/match/proc/light()
@@ -220,6 +219,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	slot_flags = SLOT_MASK|SLOT_EARS
 	goes_in_mouth = TRUE
 	var/lit = 0
+	flammable = FALSE //cigs are LIT not IGNITED
 	var/overlay_on = "ciglit" //Apparently not used
 	var/type_butt = /obj/item/trash/cigbutt
 	var/lastHolder = null
@@ -313,6 +313,11 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	update_icon()
 
 /obj/item/clothing/mask/cigarette/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	if(lit)
+		return
+	ignite()
+
+/obj/item/clothing/mask/cigarette/ignite()
 	if(lit)
 		return
 	light("<span class='danger'>The raging fire sets \the [src] alight.</span>")
@@ -924,6 +929,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	attack_verb = list("prods", "pokes")
 	light_color = LIGHT_COLOR_FIRE
 	var/lit = 0
+	flammable = FALSE //lit not ignited
 	var/base_icon = "lighter"
 	surgerysound = 'sound/items/cautery.ogg'
 	var/light_icon = "lighter-light"

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -3,6 +3,7 @@
 	penetration_dampening = 5
 	var/hasbolts = FALSE
 
+	pass_flags_self = PASSMACHINE
 
 /obj/structure/examine(mob/user)
 	..()

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -3,8 +3,6 @@
 	penetration_dampening = 5
 	var/hasbolts = FALSE
 
-	pass_flags_self = PASSMACHINE
-
 /obj/structure/examine(mob/user)
 	..()
 	if(hasbolts)

--- a/code/modules/projectiles/guns/projectile/constructable/flamethrower.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/flamethrower.dm
@@ -236,6 +236,11 @@
 		C.update_inv_hands()
 	return
 
+/obj/item/weapon/gun/projectile/flamethrower/extinguish()
+	lit = 0
+	update_icon()
+	..()
+
 /obj/item/weapon/gun/projectile/flamethrower/full/New(var/loc)
 	..()
 	weldtool = new /obj/item/tool/weldingtool(src)

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -2211,6 +2211,24 @@
 			var/obj/item/weapon/reagent_containers/food/snacks/donut/D = I
 			D.dip(src, user)
 
+/obj/item/weapon/reagent_containers/food/drinks/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	if(!(molotov == 1))
+		return
+	if(lit)
+		return
+	ignite()
+
+/obj/item/weapon/reagent_containers/food/drinks/ignite()
+	if(lit)
+		return
+	light("<span class='danger'>The raging fire sets \the [src] alight.</span>")
+
+/obj/item/weapon/reagent_containers/food/drinks/extinguish()
+	lit = 0
+	update_brightness()
+	update_icon()
+	..()
+
 /obj/item/weapon/reagent_containers/food/drinks/molotov
 	name = "incendiary cocktail"
 	smashtext = ""


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Some items have a "lit" var which should take precedence over "on_fire". A cigarette should not catch on fire, it should be lit. This PR ensures when items which can be lit are lit when ignited rather than set on fire and also ensures they are unlit when extinguished.

## Why it's good
<!-- Explain why you think these changes are good. -->
Consistency; prevents dropping a cigarette from starting a fire using itself as fuel.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Improved consistency in lit items igniting and being extinguished.
