### PR TITLE
Paper bin burn rate adjustment

### DIFF
--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -19,7 +19,7 @@
 /obj/item/weapon/paper_bin/New()
 	..()
 	update_icon()
-	thermal_mass = thermal_mass + amount //snowflaked (not sorry)
+	thermal_mass = thermal_mass + amount * 0.1 //0.1 = paper thermal_mass
 
 /obj/item/weapon/paper_bin/black
 	crayon = "black"
@@ -69,7 +69,7 @@
 /obj/item/weapon/paper_bin/useThermalMass(var/used_mass)
 	..()
 	if(amount)
-		var/burnt_papers = round(amount-(thermal_mass - initial_thermal_mass))
+		var/burnt_papers = round((amount * 0.1)-(thermal_mass - initial_thermal_mass)) //0.1 = paper thermal_mass
 		for(var/i in 1 to burnt_papers)
 			var/obj/item/weapon/paper/P
 			if(papers.len > 0)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Burning paper bins is heavily snowflaked, currently resulting in each paper in a bin providing 1u of thermal_mass which leads to bins burning for a long time. This PR brings the value of contained papers back to their correct value of 0.1u of thermal mass each.

## Why it's good
<!-- Explain why you think these changes are good. -->
Consistency.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Papers stored in a paper bin while burning will use their correct thermal_mass values, no longer resulting in excessive burn times.