### PR TITLE
Lambo open space overlays

### DIFF
--- a/code/modules/multiz/turfs.dm
+++ b/code/modules/multiz/turfs.dm
@@ -233,6 +233,9 @@ var/list/open_overlay_depths
 			user.emote("flip")
 		return SUICIDE_ACT_CUSTOM
 
+/turf/simulated/floor/glass
+	var/obj/effect/glass_open_overlay/damage/overdamage
+
 /turf/simulated/floor/glass/New(loc)
 	..(loc)
 	if(get_base_turf(src.z) == /turf/simulated/open)
@@ -285,7 +288,8 @@ var/obj/effect/glass_open_overlay/plasma/openpgfloor
 					openpgfloor = new
 				vis_contents.Add(openpgfloor)
 		if(health < initial(health))
-			var/obj/effect/glass_open_overlay/damage/overdamage = new /obj/effect/glass_open_overlay/damage
+			if(!overdamage)
+				overdamage = new
 			overdamage.icon_state = icon_state
 			vis_contents.Add(overdamage)
 	else

--- a/code/modules/multiz/turfs.dm
+++ b/code/modules/multiz/turfs.dm
@@ -266,8 +266,9 @@ var/obj/effect/glass_open_overlay/plasma/openpgfloor
 	icon = 'icons/effects/floor_decals.dmi'
 
 /turf/simulated/floor/glass/update_icon()
-	..()
 	if(get_base_turf(src.z) == /turf/simulated/open)
+		vis_contents.Cut()
+		overlays.Cut()
 		if(make_openspace_view()) // Space below us
 			icon_state = "" // Remove any previous space stuff, if any
 		else
@@ -286,6 +287,8 @@ var/obj/effect/glass_open_overlay/plasma/openpgfloor
 			var/obj/effect/glass_open_overlay/damage/overdamage = new /obj/effect/glass_open_overlay/damage
 			overdamage.icon_state = icon_state
 			vis_contents.Add(overdamage)
+	else
+		..()
 
 /turf/simulated/floor/glass/AddDecal(var/image/decal)
 	if(get_base_turf(src.z) == /turf/simulated/open)

--- a/code/modules/multiz/turfs.dm
+++ b/code/modules/multiz/turfs.dm
@@ -235,6 +235,7 @@ var/list/open_overlay_depths
 
 /turf/simulated/floor/glass
 	var/obj/effect/glass_open_overlay/damage/overdamage
+	var/list/obj/effect/glass_open_overlay/decal/overdecals
 
 /turf/simulated/floor/glass/New(loc)
 	..(loc)
@@ -243,6 +244,13 @@ var/list/open_overlay_depths
 		plane = OPENSPACE_PLANE_START
 		layer = 0
 		update_icon()
+
+/turf/simulated/floor/glass/Destroy()
+	if(overdamage)
+		QDEL_NULL(overdamage)
+	if(overdecals)
+		QDEL_LIST(overdecals)
+	. = ..()
 
 /obj/effect/glass_open_overlay
 	name = "glass open overlay"
@@ -302,6 +310,9 @@ var/obj/effect/glass_open_overlay/plasma/openpgfloor
 		overdecal.icon_state = decal.icon_state
 		overdecal.dir = decal.dir
 		vis_contents.Add(overdecal)
+		if(!overdecals)
+			overdecals = list()
+		overdecals += overdecal
 	else
 		..()
 

--- a/code/modules/multiz/turfs.dm
+++ b/code/modules/multiz/turfs.dm
@@ -274,6 +274,7 @@ var/obj/effect/glass_open_overlay/plasma/openpgfloor
 		else
 			// We space background now, forget the vis contentsing of it
 			icon_state = "[((x + y) ^ ~(x * y) + z) % 25]"
+			return ..()
 		switch(glass_state)
 			if("glass_floor")
 				if(!opengfloor)

--- a/code/modules/multiz/turfs.dm
+++ b/code/modules/multiz/turfs.dm
@@ -100,29 +100,35 @@ var/static/list/no_spacemove_turfs = list(/turf/simulated/wall,/turf/unsimulated
 	layer = ABOVE_LIGHTING_LAYER
 	plane = OPEN_OVERLAY_PLANE
 
+var/list/open_overlay_depths
+
 /turf/simulated/open/update_icon()
 	make_openspace_view()
 
 /turf/simulated/proc/make_openspace_view()
-	var/alpha_to_subtract = 127
+	var/alpha_to_use = 127
 	overlays.Cut()
 	vis_contents.Cut()
 	var/turf/bottom
 	var/list/checked_belows = list()
 	for(bottom = GetBelow(src); isopenspace(bottom); bottom = GetBelow(bottom))
-		alpha_to_subtract /= 2
+		alpha_to_use /= 2
 		if(bottom.z in checked_belows) // To stop getting caught on this in infinite loops
 			return // Don't even render anything
 		checked_belows.Add(bottom.z)
-
 	if(!bottom || bottom == src)
 		return
-	var/obj/effect/open_overlay/overimage = new /obj/effect/open_overlay
-	overimage.alpha = 255 - alpha_to_subtract
-	overimage.color = rgb(0,0,0,overimage.alpha)
+	alpha_to_use = 255 - alpha_to_use
+	if(!open_overlay_depths)
+		open_overlay_depths = list()
+	if(!("[alpha_to_use]" in open_overlay_depths))
+		var/obj/effect/open_overlay/overimage = new /obj/effect/open_overlay
+		overimage.alpha = alpha_to_use
+		overimage.color = rgb(0,0,0,overimage.alpha)
+		open_overlay_depths["[alpha_to_use]"] = overimage
 	vis_contents += bottom
 	if(!istype(bottom,/turf/space)) // Space below us
-		vis_contents.Add(overimage)
+		vis_contents.Add(open_overlay_depths["[alpha_to_use]"])
 		return 1
 	return 0
 
@@ -235,20 +241,26 @@ var/static/list/no_spacemove_turfs = list(/turf/simulated/wall,/turf/unsimulated
 		layer = 0
 		update_icon()
 
-/obj/effect/open_overlay/glass
+/obj/effect/glass_open_overlay
 	name = "glass open overlay"
 	desc = "The window over the darkness of the abyss below"
 	icon = 'icons/turf/overlays.dmi'
-	icon_state = ""
+	icon_state = "glass_floor"
 	layer = 0
 	plane = GLASSTILE_PLANE
 
-/obj/effect/open_overlay/glass/damage
+/obj/effect/glass_open_overlay/plasma
+	icon_state = "plasma_glass_floor"
+
+var/obj/effect/glass_open_overlay/opengfloor
+var/obj/effect/glass_open_overlay/plasma/openpgfloor
+
+/obj/effect/glass_open_overlay/damage
 	name = "glass open overlay cracks"
 	desc = "The dent in the window over the darkness of the abyss below"
 	icon = 'icons/obj/structures.dmi'
 
-/obj/effect/open_overlay/glass/decal
+/obj/effect/glass_open_overlay/decal
 	name = "glass open overlay decal"
 	desc = "The decoration on the window over the darkness of the abyss below"
 	icon = 'icons/effects/floor_decals.dmi'
@@ -261,16 +273,23 @@ var/static/list/no_spacemove_turfs = list(/turf/simulated/wall,/turf/unsimulated
 		else
 			// We space background now, forget the vis contentsing of it
 			icon_state = "[((x + y) ^ ~(x * y) + z) % 25]"
-		var/obj/effect/open_overlay/glass/overglass = new /obj/effect/open_overlay/glass
-		overglass.icon_state = glass_state
-		vis_contents.Add(overglass)
-		var/obj/effect/open_overlay/glass/damage/overdamage = new /obj/effect/open_overlay/glass/damage
-		overdamage.icon_state = icon_state
-		vis_contents.Add(overdamage)
+		switch(glass_state)
+			if("glass_floor")
+				if(!opengfloor)
+					opengfloor = new
+				vis_contents.Add(opengfloor)
+			if("plasma_glass_floor")
+				if(!openpgfloor)
+					openpgfloor = new
+				vis_contents.Add(openpgfloor)
+		if(health < initial(health))
+			var/obj/effect/glass_open_overlay/damage/overdamage = new /obj/effect/glass_open_overlay/damage
+			overdamage.icon_state = icon_state
+			vis_contents.Add(overdamage)
 
 /turf/simulated/floor/glass/AddDecal(var/image/decal)
 	if(get_base_turf(src.z) == /turf/simulated/open)
-		var/obj/effect/open_overlay/glass/decal/overdecal = new /obj/effect/open_overlay/glass/decal
+		var/obj/effect/glass_open_overlay/decal/overdecal = new /obj/effect/glass_open_overlay/decal
 		overdecal.icon = decal.icon
 		overdecal.icon_state = decal.icon_state
 		overdecal.dir = decal.dir


### PR DESCRIPTION
[performance]

## What this does
removes duplicate objects for these icons
makes open space overlays pull from the same pool with an alpha value
makes glass overlays only vis contents from one object matching the icon state
makes damage overlay objects not created unless glass tiles are damaged
makes non multi-z part of update_icon not used on glass tiles on multi-z
removes duplicate glass damage icons on each update on multi-z
all of this only changes anything on multi-z maps. glass tiles function the same otherwise.

## Why it's good
helps with multi z performance

## How this was tested
on test_multiz, snowbox and roid

## Changelog
:cl:
 * bugfix: Multi-Z maps now have a lot less overlay objects.