### PR TITLE
Disables grue antag from firing randomly.

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -247,8 +247,8 @@
 	weight = BASE_RULESET_WEIGHT
 	weight_category = "Grue"
 	cost = 20
-	requirements = list(70,60,50,40,30,20,10,10,10,10)
-	high_population_requirement = 10
+	requirements = list(101,101,101,101,101,101,101,101,101,101)
+	high_population_requirement = 101
 	logo = "grue-logo"
 	repeatable = TRUE
 	var/list/grue_spawn_spots=list()

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -915,8 +915,8 @@
 	weight = BASE_RULESET_WEIGHT
 	weight_category = "Grue"
 	cost = 20
-	requirements = list(70,60,50,40,30,20,10,10,10,10)
-	high_population_requirement = 10
+	requirements = list(101,101,101,101,101,101,101,101,101,101)
+	high_population_requirement = 101
 	logo = "grue-logo"
 	repeatable = TRUE
 	var/list/grue_spawn_spots=list()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Basically prevents grue from automatically firing
## Why it's good
<!-- Explain why you think these changes are good. -->
Grue is a poorly balanced gamebreaking antag focused around round removal and broken game mechanics and it shouldnt be playable in this condition
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscdel: Grue ruleset can no longer randomly fire

