### PR TITLE
Prevents pulse demon from firing

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -196,8 +196,8 @@
 	weight = BASE_RULESET_WEIGHT
 	weight_category = "Pulse"
 	cost = 25
-	requirements = list(70,40,20,20,20,20,15,15,5,5)
-	high_population_requirement = 10
+	requirements = list(101,101,101,101,101,101,101,101,101,101)
+	high_population_requirement = 101
 	logo = "pulsedemon-logo"
 
 	repeatable = TRUE

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -875,8 +875,8 @@
 	weight = BASE_RULESET_WEIGHT
 	weight_category = "Pulse"
 	cost = 20
-	requirements = list(70,40,20,20,20,20,15,15,5,5)
-	high_population_requirement = 10
+	requirements = list(101,101,101,101,101,101,101,101,101,101)
+	high_population_requirement = 101
 	logo = "pulsedemon-logo"
 	var/list/cables_to_spawn_at = list()
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Basically prevents pulse demon from firing automatically.
## Why it's good
<!-- Explain why you think these changes are good. -->
General complaints to remove this, a "minor" antag that has the power to end the round, the primary way to counter it just feels cheesy and boring and make rounds feel unfun to play on both sides (turning off power for 20 mins)
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:

 * rscdel: Prevents Pulse demon from randomly firing.

