### PR TITLE
Cult Polish and admin QoL

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -538,10 +538,13 @@
 		switch(choice)
 			if ("first ritual")
 				replace_rituals(RITUAL_FACTION_1)
+				check_antagonists()
 			if ("second ritual")
 				replace_rituals(RITUAL_FACTION_2)
+				check_antagonists()
 			if ("third ritual")
 				replace_rituals(RITUAL_FACTION_3)
+				check_antagonists()
 
 /datum/faction/bloodcult/HandleNewMind(var/datum/mind/M)
 	. = ..()

--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -235,6 +235,13 @@
 
 
 	dat += "<br>Accumulated devotion: [total_devotion]"
+	switch(stage)
+		if (BLOODCULT_STAGE_NORMAL)
+			dat += "<br>Eclipse progress: [round((eclipse_progress/eclipse_target)*100)]%"
+		else
+			if (sun && sun.eclipse_manager)
+				var/seconds_to_eclipse = (sun.eclipse_manager.eclipse_start_time - cult_founding_time)/10
+				dat += "<br>Eclipse arrival: [round(seconds_to_eclipse/3600)]h [add_zero(num2text(round(seconds_to_eclipse/60) % 60), 2)]m [add_zero(num2text(round(seconds_to_eclipse) % 60), 2)]s"
 
 	if (cult_won)
 		dat += "<br><font color='green'><B>[end_message]</B></font>"
@@ -414,7 +421,8 @@
 							if (M)
 								to_chat(M, "<span class='sinister'>Someone has completed a ritual, rewarding the entire cult...soon another ritual will take its place.</span>")
 						spawn(10 MINUTES)
-							replace_rituals(ritual_slot)
+							if (!rituals[ritual_slot])
+								replace_rituals(ritual_slot)
 
 #define HUDICON_BLINKDURATION 10
 /datum/faction/bloodcult/update_hud_icons(var/offset = 0,var/factions_with_icons = 0)
@@ -502,6 +510,50 @@
 	previously_converted |= R.antag
 	if (R.antag.name in deconverted)
 		deconverted -= R.antag.name
+
+
+/datum/faction/bloodcult/AdminPanelEntry(var/datum/admins/A)
+	var/list/dat = ..()
+
+	dat += "<br>accumulated devotion: [total_devotion]"
+	dat += "<br>available rituals: "
+	for (var/ritual_slot in rituals)
+		if (rituals[ritual_slot])
+			var/datum/bloodcult_ritual/my_ritual = rituals[ritual_slot]
+			dat += "[my_ritual.name] - "
+		else
+			dat += "<i>cooldown</i> - "
+	dat += "<a href='?src=\ref[src]&mind=\ref[antag]&replaceritual=1'>\[Replace\]</a>"
+	return dat
+
+/datum/faction/Topic(href, href_list)
+	..()
+
+	if(!usr.check_rights(R_ADMIN))
+		message_admins("[usr] tried to access bloodcult faction Topic() without permissions.")
+		return
+
+	if(href_list["replaceritual"])
+		var/choice = alert(src,"Which ritual do you want to replace?","Replace Ritual","first ritual","second ritual","third ritual")
+		switch(choice)
+			if ("first ritual")
+				replace_rituals(RITUAL_FACTION_1)
+			if ("second ritual")
+				replace_rituals(RITUAL_FACTION_2)
+			if ("third ritual")
+				replace_rituals(RITUAL_FACTION_3)
+
+
+
+/datum/role/cultist/RoleTopic(href, href_list, var/datum/mind/M, var/admin_auth)
+	..()
+	if (!usr.client.holder)
+		return FALSE
+	if (href_list["givedevotion"])
+		var/amount = input("How much would you like to give?", "Giving devotion") as null|num
+		if (!amount)
+			return FALSE
+		gain_devotion(amount, DEVOTION_TIER_4)
 
 /datum/faction/bloodcult/HandleNewMind(var/datum/mind/M)
 	. = ..()

--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -534,7 +534,7 @@
 		return
 
 	if(href_list["replaceritual"])
-		var/choice = alert(src,"Which ritual do you want to replace?","Replace Ritual","first ritual","second ritual","third ritual")
+		var/choice = alert(usr,"Which ritual do you want to replace?","Replace Ritual","first ritual","second ritual","third ritual")
 		switch(choice)
 			if ("first ritual")
 				replace_rituals(RITUAL_FACTION_1)
@@ -542,18 +542,6 @@
 				replace_rituals(RITUAL_FACTION_2)
 			if ("third ritual")
 				replace_rituals(RITUAL_FACTION_3)
-
-
-
-/datum/role/cultist/RoleTopic(href, href_list, var/datum/mind/M, var/admin_auth)
-	..()
-	if (!usr.client.holder)
-		return FALSE
-	if (href_list["givedevotion"])
-		var/amount = input("How much would you like to give?", "Giving devotion") as null|num
-		if (!amount)
-			return FALSE
-		gain_devotion(amount, DEVOTION_TIER_4)
 
 /datum/faction/bloodcult/HandleNewMind(var/datum/mind/M)
 	. = ..()

--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -523,10 +523,10 @@
 			dat += "[my_ritual.name] - "
 		else
 			dat += "<i>cooldown</i> - "
-	dat += "<a href='?src=\ref[src]&mind=\ref[antag]&replaceritual=1'>\[Replace\]</a>"
+	dat += "<a href='?src=\ref[src];replaceritual=1'>\[Replace\]</a><br>"
 	return dat
 
-/datum/faction/Topic(href, href_list)
+/datum/faction/bloodcult/Topic(href, href_list)
 	..()
 
 	if(!usr.check_rights(R_ADMIN))

--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -532,19 +532,20 @@
 	if(!usr.check_rights(R_ADMIN))
 		message_admins("[usr] tried to access bloodcult faction Topic() without permissions.")
 		return
-
+	if(!usr.client || !usr.client.holder)
+		return
 	if(href_list["replaceritual"])
 		var/choice = alert(usr,"Which ritual do you want to replace?","Replace Ritual","first ritual","second ritual","third ritual")
 		switch(choice)
 			if ("first ritual")
 				replace_rituals(RITUAL_FACTION_1)
-				check_antagonists()
+				usr.client.holder.check_antagonists()
 			if ("second ritual")
 				replace_rituals(RITUAL_FACTION_2)
-				check_antagonists()
+				usr.client.holder.check_antagonists()
 			if ("third ritual")
 				replace_rituals(RITUAL_FACTION_3)
-				check_antagonists()
+				usr.client.holder.check_antagonists()
 
 /datum/faction/bloodcult/HandleNewMind(var/datum/mind/M)
 	. = ..()

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -1473,7 +1473,7 @@ var/list/cult_spires = list()
 
 /obj/structure/cult/pillar/update_icon()
 	icon_state = "pillar[alt ? "alt": ""]2"
-	set_light(1, 2, LIGHT_COLOR_RED)
+	set_light(1.5, 2.5, LIGHT_COLOR_RED)
 	overlays.len = 0
 	if (health < maxHealth/3)
 		icon_state = "pillar[alt ? "alt": ""]0"

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_eclipse.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_eclipse.dm
@@ -65,7 +65,8 @@
 				to_chat(M, "<span class='sinister'>The Eclipse is entering overtime. Even though its time as run out, Nar-Sie won't let it end as long as the Tear Reality rune is still active, or the Blood Stone is still standing.</span>")
 		else if (!problem_announcement && (world.time >= eclipse_problem_announcement))
 			problem_announcement = TRUE
-			command_alert(/datum/command_alert/eclipse_too_long)
+			if (cult.stage == BLOODCULT_STAGE_READY)//no point warning the crew if the cult has already made itself known
+				command_alert(/datum/command_alert/eclipse_too_long)
 
 /datum/eclipse_manager/proc/eclipse_end()
 	processing_objects -= src

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -116,8 +116,10 @@
 		switch(choice)
 			if ("first ritual")
 				replace_rituals(RITUAL_CULTIST_1)
+				antag.role_panel()
 			if ("second ritual")
 				replace_rituals(RITUAL_CULTIST_2)
+				antag.role_panel()
 
 /datum/role/cultist/process()
 	..()

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -97,8 +97,9 @@
 			return {"<a href='?_src_=holder;adminplayeropts=\ref[AP]'>astral projecting</a>"}
 	return "logged out"
 
-/datum/role/cultist/AdminPanelEntry(var/show_logo = FALSE,var/datum/admins/A)
-	var/dat = ..()
+
+/datum/role/cultist/extraPanelButtons()
+	var/dat = ""
 	dat += "  - <a href='?src=\ref[src]&mind=\ref[antag]&givedevotion=1'>Give devotion ([devotion])</a>"
 	dat += "<br>rituals: "
 	for (var/ritual_slot in rituals)
@@ -108,6 +109,11 @@
 		else
 			dat += "<i>cooldown</i> - "
 	dat += "<a href='?src=\ref[src]&mind=\ref[antag]&replaceritual=1'>\[Replace\]</a>"
+	return dat
+
+/datum/role/cultist/AdminPanelEntry(var/show_logo = FALSE,var/datum/admins/A)
+	var/dat = ..()
+	dat += "  - <a href='?src=\ref[src]&mind=\ref[antag]&givedevotion=1'>Give devotion ([devotion])</a>"
 	return dat
 
 /datum/role/cultist/RoleTopic(href, href_list, var/datum/mind/M, var/admin_auth)
@@ -120,7 +126,7 @@
 			return FALSE
 		gain_devotion(amount, DEVOTION_TIER_4)
 	if (href_list["replaceritual"])
-		var/choice = alert(src,"Which ritual do you want to replace?","Replace Ritual","first ritual","second ritual")
+		var/choice = alert(usr,"Which ritual do you want to replace?","Replace Ritual","first ritual","second ritual")
 		switch(choice)
 			if ("first ritual")
 				replace_rituals(RITUAL_CULTIST_1)

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -97,20 +97,6 @@
 			return {"<a href='?_src_=holder;adminplayeropts=\ref[AP]'>astral projecting</a>"}
 	return "logged out"
 
-
-/datum/role/cultist/extraPanelButtons()
-	var/dat = ""
-	dat += "  - <a href='?src=\ref[src]&mind=\ref[antag]&givedevotion=1'>Give devotion ([devotion])</a>"
-	dat += "<br>rituals: "
-	for (var/ritual_slot in rituals)
-		if (rituals[ritual_slot])
-			var/datum/bloodcult_ritual/my_ritual = rituals[ritual_slot]
-			dat += "[my_ritual.name] - "
-		else
-			dat += "<i>cooldown</i> - "
-	dat += "<a href='?src=\ref[src]&mind=\ref[antag]&replaceritual=1'>\[Replace\]</a>"
-	return dat
-
 /datum/role/cultist/AdminPanelEntry(var/show_logo = FALSE,var/datum/admins/A)
 	var/dat = ..()
 	dat += "  - <a href='?src=\ref[src]&mind=\ref[antag]&givedevotion=1'>Give devotion ([devotion])</a>"
@@ -262,6 +248,15 @@
 
 /datum/role/cultist/extraPanelButtons()
 	var/dat = ""
+	dat += "  - <a href='?src=\ref[src]&mind=\ref[antag]&givedevotion=1'>Give devotion ([devotion])</a>"
+	dat += "<br>rituals: "
+	for (var/ritual_slot in rituals)
+		if (rituals[ritual_slot])
+			var/datum/bloodcult_ritual/my_ritual = rituals[ritual_slot]
+			dat += "[my_ritual.name] - "
+		else
+			dat += "<i>cooldown</i> - "
+	dat += "<a href='?src=\ref[src]&mind=\ref[antag]&replaceritual=1'>\[Replace\]</a>"
 	if (mentor)
 		dat = "<br>Currently under the mentorship of <b>[mentor.antag.name]/([mentor.antag.key])</b><br>"
 	if (acolytes.len)

--- a/code/game/objects/items/soulstone.dm
+++ b/code/game/objects/items/soulstone.dm
@@ -227,16 +227,6 @@
 		var/obj/item/organ/external/head/target_head = target
 		victim = target_head.brainmob
 
-	if (victim)
-		//First off let's check that the cult isn't bypassing its convertee cap
-		if (iscultist(user))
-			if (!iscultist(victim))
-				var/datum/faction/bloodcult/cult = find_active_faction_by_type(/datum/faction/bloodcult)
-				if (cult && !cult.CanConvert())
-					if (!blade || victim.isDead())
-						to_chat(user, "<span class='danger'>The cult has too many members already, \the [soul_receptacle] won't let you take their soul. Although you could bypass this restriction by sacrificing them at an Altar with this blade instead.</span>")
-					return
-
 	if (iscarbon(target))
 		init_body(target,user)
 

--- a/code/game/objects/items/soulstone.dm
+++ b/code/game/objects/items/soulstone.dm
@@ -220,7 +220,6 @@
 	if (istype(receptacle, /obj/item/soulstone/gem))
 		gem = TRUE
 
-	var/mob/victim
 	if (iscarbon(target))
 		victim = target
 	else if (istype(target, /obj/item/organ/external/head))

--- a/code/game/objects/items/soulstone.dm
+++ b/code/game/objects/items/soulstone.dm
@@ -221,12 +221,6 @@
 		gem = TRUE
 
 	if (iscarbon(target))
-		victim = target
-	else if (istype(target, /obj/item/organ/external/head))
-		var/obj/item/organ/external/head/target_head = target
-		victim = target_head.brainmob
-
-	if (iscarbon(target))
 		init_body(target,user)
 
 	if (istype(target, /obj/item/organ/external/head))

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -44,4 +44,4 @@
 			dat += "<br/>"
 
 	dat += "</body></html>"
-	usr << browse(dat, "window=roundstatus;size=700x500")
+	usr << browse(dat, "window=roundstatus;size=750x500")


### PR DESCRIPTION
backend:
* Admins can now easily check which rituals are available for each cultists.

:cl:
* rscadd: The round end scoreboard now indicates how close the Cult was from reaching the Eclipse, or if it did, when it occurred.
* tweak: Slightly increased the luminosity and range of obsidian pillars during the Eclipse.
* bugfix: Fixed soulstone failing to capture past the cultist cap, it now properly creates a non-cultist shade bound to its master. You can ultimately bypass the cap by using the Reincarnation rune to put the shade in a new human body as a cultist, if you go the extra mile.