### PR TITLE
fix gmt wraparound (negative seconds) on shift duration, no more decimalized seconds on shift duration

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -52,9 +52,9 @@
 		. += "[(m<10)?"0":""][m]:"
 	. += "[(s<10)?"0":""][s]"
 
-/proc/altFormatTimeDuration(var/deciseconds)
+/proc/altFormatTimeDuration(var/deciseconds, var/show_seconds = TRUE)
 	var/m = round(deciseconds / 600)
-	var/s = (deciseconds % 600)/10
+	var/s = round((deciseconds % 600)/10)
 	var/h = round(m / 60)
 	m = m % 60
 	if(h > 0)
@@ -64,7 +64,7 @@
 	. += "[s]s"
 
 /proc/getShiftDuration()
-	return altFormatTimeDuration(world.timeofday - roundstart_timestamp)
+	return altFormatTimeDuration(world.time - roundstart_timestamp)
 
 /proc/time_stamp()
 	return time2text(world.timeofday, "hh:mm:ss")

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -720,7 +720,7 @@ var/datum/controller/gameticker/ticker
 					qdel(obj)
 
 		to_chat(world, "<span class='notice'><B>Enjoy the game!</B></span>")
-		roundstart_timestamp = world.timeofday
+		roundstart_timestamp = world.time
 
 		//Holiday Round-start stuff	~Carn
 		Holiday_Game_Start()


### PR DESCRIPTION
## What this does
title
bug happened because i used `world.timeofday` instead of `world.time`
`world.timeofday` is time since 00:00 gmt so if it hid midnight gmt it'd wrap around to the negatives
i didnt use `world.time` initially since the BYOND documentation says that `world.time` does not increment when no one is on the server, but @DamianX informed me that turned off that feature some years ago
(the ability to turn off that feature is not noted in the byond documentation)

fixes #36574
fixes #36549 
fixes #36488

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed shift duration on the "Join Game" menu wrapping around to the negatives when midnight GMT occurred.
