### PR TITLE
Bulk order empty lunchboxes from Cargo

### DIFF
--- a/code/datums/supply_packs/hospitality.dm
+++ b/code/datums/supply_packs/hospitality.dm
@@ -91,6 +91,30 @@
 	access = list(access_kitchen)
 	group = "Hospitality"
 
+/datum/supply_packs/lunchboxes
+	name = "Empty lunchbox crate"
+	contains = list(/obj/item/weapon/storage/lunchbox/plastic/nt
+					/obj/item/weapon/storage/lunchbox/plastic/nt
+					/obj/item/weapon/storage/lunchbox/plastic/nt
+					/obj/item/weapon/storage/lunchbox/plastic/nt
+					/obj/item/weapon/storage/lunchbox/plastic/nt)
+	cost = 25
+	containertype = /obj/structure/closet/crate/freezer
+	containername = "lunchbox crate"
+	containsdesc = "Contains five empty standard issue NT Lunchboxes. Lunch sold seperately"
+	group = "Hospitality"
+
+/datum/supply_packs/randomised/collectable_lunchboxes
+	name = "Collectable lunchbox crate"
+	num_contained = 5
+	contains = list(/obj/item/weapon/storage/lunchbox/plastic/nt/random)
+	cost = 50
+	containertype = /obj/structure/closet/crate/freezer
+	containername = "collectable lunchbox crate"
+	containsdesc = "Contains five empty collectable lunchboxes. A crate for serious lunch connoisseurs"
+	group = "Hospitality"
+
+
 /datum/supply_packs/party
 	name = "Party equipment"
 	contains = list(/obj/item/weapon/storage/box/drinkingglasses,

--- a/code/datums/supply_packs/hospitality.dm
+++ b/code/datums/supply_packs/hospitality.dm
@@ -93,10 +93,10 @@
 
 /datum/supply_packs/lunchboxes
 	name = "Empty lunchbox crate"
-	contains = list(/obj/item/weapon/storage/lunchbox/plastic/nt
-					/obj/item/weapon/storage/lunchbox/plastic/nt
-					/obj/item/weapon/storage/lunchbox/plastic/nt
-					/obj/item/weapon/storage/lunchbox/plastic/nt
+	contains = list(/obj/item/weapon/storage/lunchbox/plastic/nt,
+					/obj/item/weapon/storage/lunchbox/plastic/nt,
+					/obj/item/weapon/storage/lunchbox/plastic/nt,
+					/obj/item/weapon/storage/lunchbox/plastic/nt,
 					/obj/item/weapon/storage/lunchbox/plastic/nt)
 	cost = 25
 	containertype = /obj/structure/closet/crate/freezer


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
Adds two new crates which can be ordered from cargo. One contains five empty, standard lunchboxes for 25 credits. The other contains five empty collectable lunchboxes at a cost of 50. 

## Why it's good
Think this is a nice addition for any chef who wants to do a lunchbox gimmick. Normally you get collectable lunchboxes from the merch vendor one at a time, but this just gives you another method of getting them in bulk. 

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Can now bulk order empty lunchboxes (standard and collectable) from cargo. 
