### PR TITLE
Fixes check antagonists midround & latejoin injection timer displays

### DIFF
--- a/__DEFINES/role_datums_defines.dm
+++ b/__DEFINES/role_datums_defines.dm
@@ -278,13 +278,16 @@
 #define INTERCEPT_TIME_LOW 10 MINUTES
 #define INTERCEPT_TIME_HIGH 18 MINUTES
 
-// -- Injection delays (in ticks, ie, you need the /20 to get the real result)
+// -- Injection delays (in ticks, ie, you need the /20 to get the real result) (/SS_WAIT_TICKER is clearer actually)
 
-#define LATEJOIN_DELAY_MIN (5 MINUTES)/20
-#define LATEJOIN_DELAY_MAX (30 MINUTES)/20
+#define LATEJOIN_DELAY_MIN (5 MINUTES)/(SS_WAIT_TICKER)
+#define LATEJOIN_DELAY_MAX (30 MINUTES)/(SS_WAIT_TICKER)
 
-#define MIDROUND_DELAY_MIN (5 MINUTES)/20
-#define MIDROUND_DELAY_MAX (30 MINUTES)/20
+#define MIDROUND_DELAY_MIN (5 MINUTES)/(SS_WAIT_TICKER)
+#define MIDROUND_DELAY_MAX (30 MINUTES)/(SS_WAIT_TICKER)
+
+#define MIDROUND_EXTENDED_DELAY_MIN (20 MINUTES)/(SS_WAIT_TICKER)
+#define MIDROUND_EXTENDED_DELAY_MAX (35 MINUTES)/(SS_WAIT_TICKER)
 
 // -- Rulesets flags
 

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -99,8 +99,8 @@ var/stacking_limit = 90
 	else
 		dat += "none.<br>"
 	dat += "<br>Injection Timers: (<b>[GetInjectionChance()]%</b> chance)<BR>"
-	dat += "Latejoin: [latejoin_injection_cooldown>60 ? "[round(latejoin_injection_cooldown/60,0.1)] minutes" : "[latejoin_injection_cooldown] seconds"] <a href='?_src_=holder;injectnow=1'>\[Now!\]</A><BR>"
-	dat += "Midround: [midround_injection_cooldown>60 ? "[round(midround_injection_cooldown/60,0.1)] minutes" : "[midround_injection_cooldown] seconds"] <a href='?_src_=holder;injectnow=2'>\[Now!\]</A><BR>"
+	dat += "Latejoin: [round(latejoin_injection_cooldown*2/60)]m [(latejoin_injection_cooldown*2) % 60]s <a href='?_src_=holder;injectnow=1'>\[Now!\]</A><BR>"
+	dat += "Midround: [round(midround_injection_cooldown*2/60)]m [(midround_injection_cooldown*2) % 60]s <a href='?_src_=holder;injectnow=2'>\[Now!\]</A><BR>"
 	return jointext(dat, "")
 
 /datum/gamemode/dynamic/Topic(href, href_list)
@@ -635,7 +635,7 @@ var/stacking_limit = 90
 				message_admins("DYNAMIC MODE: Couldn't ready-up a single ruleset. Lack of eligible candidates, population, or threat.")
 				log_admin("DYNAMIC MODE: Couldn't ready-up a single ruleset. Lack of eligible candidates, population, or threat.")
 		else
-			midround_injection_cooldown = rand(600,1050)
+			midround_injection_cooldown = rand(MIDROUND_EXTENDED_DELAY_MIN, MIDROUND_EXTENDED_DELAY_MAX)
 
 
 /datum/gamemode/dynamic/proc/update_playercounts()


### PR DESCRIPTION
backend:
* in the admin Check Antagonists panel, the timers for the next Latejoin and Midround attempts are both easier to read, and now properly convert the process() ticks into seconds.

Before:
![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/e3c2e0bc-d5fc-4e8d-8962-c0dbacd31a78)

After
![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/3d2cc278-6d47-4a22-9e1d-f74a6018e819)
