### PR TITLE
pulse demon balance

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -190,8 +190,8 @@
 /datum/dynamic_ruleset/latejoin/pulse_demon
 	name = "Pulse Demon Infiltration"
 	role_category = /datum/role/pulse_demon
-	enemy_jobs = list("Station Engineer","Chief Engineer")
-	required_enemies = list(1,1,1,1,1,1,1,1,1,1)
+	enemy_jobs = list("Station Engineer","Chief Engineer","Warden","Head of Security","Captain","AI","Cyborg")
+	required_enemies = list(2,2,2,2,2,2,2,2,2,2)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
 	weight_category = "Pulse"

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -869,8 +869,8 @@
 /datum/dynamic_ruleset/midround/from_ghosts/pulse_demon
 	name = "Pulse Demon Infiltration"
 	role_category = /datum/role/pulse_demon
-	enemy_jobs = list("Station Engineer","Chief Engineer")
-	required_enemies = list(1,1,1,1,1,1,1,1,1,1)
+	enemy_jobs = list("Station Engineer","Chief Engineer","Warden","Head of Security","Captain","AI","Cyborg")
+	required_enemies = list(2,2,2,2,2,2,2,2,2,2)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT
 	weight_category = "Pulse"

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -218,8 +218,6 @@
 
 /mob/living/simple_animal/hostile/pulse_demon/death(var/gibbed = 0)
 	..()
-	if(current_cable?.powernet)
-		current_cable.powernet.haspulsedemon = FALSE
 	var/turf/T = get_turf(src)
 	spark(src,rand(2,4))
 	var/heavyemp_radius = min(charge/50000, 20)
@@ -228,6 +226,11 @@
 	playsound(T,"pd_wail_sound",50,1)
 	qdel(src) // We vaporise into thin air
 
+/mob/living/simple_animal/hostile/pulse_demon/Destroy()
+	if(current_cable?.powernet)
+		current_cable.powernet.haspulsedemon = FALSE
+	. = ..()
+	
 /mob/living/simple_animal/hostile/pulse_demon/proc/is_under_tile()
 	var/turf/simulated/floor/F = get_turf(src)
 	return istype(F,/turf/simulated/floor) && F.floor_tile

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -272,7 +272,7 @@
 	else
 		if(new_cable)
 			current_cable = new_cable
-			if(current_cable.powernet)
+			if(current_cable?.powernet)
 				current_cable.powernet.haspulsedemon = TRUE
 			current_power = null
 			current_robot = null

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -76,6 +76,7 @@
 		current_cable = locate(/obj/structure/cable) in loc
 		if(!current_cable)
 			death()
+			return
 		if(current_cable.powernet)
 			current_cable.powernet.haspulsedemon = TRUE
 	else

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
@@ -232,7 +232,10 @@
 		return FALSE
 	if(istype(user,/mob/living/simple_animal/hostile/pulse_demon))
 		var/mob/living/simple_animal/hostile/pulse_demon/PD = user
-		if (PD.charge < charge_cost) // Custom charge handling
+		if(PD.emp_lock)
+			to_chat(PD, "<span class='warning'>You cannot use this ability while unable to regenerate.</span>")
+			return FALSE
+		if(PD.charge < charge_cost) // Custom charge handling
 			to_chat(PD, "<span class='warning'>You are too low on power, this spell needs a charge of [charge_cost]W to cast.</span>")
 			return FALSE
 	else //only pulse demons allowed

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -206,8 +206,13 @@ By design, d1 is the smallest direction and d2 is the highest
 	src.add_fingerprint(user)
 
 /obj/structure/cable/proc/report_load(mob/user)
-	if((powernet) && (powernet.avail > 0))		// is it powered?
-		to_chat(user, "<SPAN CLASS='warning'>Power network status report - Load: [format_watts(powernet.get_load())] - Available: [format_watts(powernet.avail)].</SPAN>")
+	if(powernet)
+		if(powernet.avail > 0)		// is it powered?
+			to_chat(user, "<SPAN CLASS='warning'>Power network status report - Load: [format_watts(powernet.get_load())] - Available: [format_watts(powernet.avail)].</SPAN>")
+		else
+			to_chat(user, "<SPAN CLASS='notice'>The cable is not powered.</SPAN>")
+		if(powernet.haspulsedemon)
+			to_chat(user, "<SPAN CLASS='warning'>Strange malicious pull on load detected, possible sentience.</SPAN>")
 	else
 		to_chat(user, "<SPAN CLASS='notice'>The cable is not powered.</SPAN>")
 

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -14,7 +14,7 @@
 	var/unsatisfied_priority = 1	// First load priority that did not reach full satisfaction last tick. Loads before it are 100% satisfied, loads after are 0% satisfied.
 									//  An unsatisfied_priority of 0 means either there was either no power or more than enough to cover every load, so priorities get the
 									//  same satisfaction (0% for no power, 100% for excess)
-
+	var/haspulsedemon = 0
 
 ////////////////////////////////////////////
 // POWERNET DATUM PROCS


### PR DESCRIPTION
[balance][gamemode]

## What this does
Closes #36585.

## Why it's good
makes it easier to find and stop, checks if they're gone

## Changelog
:cl:
 * tweak: Pulse demons can no longer use powers for a few seconds after being EMPed, like with health regeneration.
 * tweak: Heads of security, wardens, captains, AIs and cyborgs are now enemy jobs for pulse demons.
 * tweak: The enemy job requirements for pulse demons have been increased to 2 players.
 * tweak: Using a multitool on a cable will now show if a pulse demon is on the powernet.
 * tweak: EMP projectiles now collide with pulse demons even if they're under tiles.