### PR TITLE
Stops players scooping up pulse demons and putting them in cages

### DIFF
--- a/code/game/objects/structures/mouse_cage.dm
+++ b/code/game/objects/structures/mouse_cage.dm
@@ -54,6 +54,9 @@
 		if (!critter && istype (O,/obj/item/weapon/holder/animal))
 			var/obj/item/weapon/holder/animal/store = O
 			var/mob/living/simple_animal/inside = store.stored_mob
+			if(!inside.tangibility)
+				to_chat(user, "<span class='warning'>\The [inside] cannot be held by \the [src]!</span>")
+				return
 			if (inside.size > SIZE_TINY)
 				to_chat(user, "<span class='warning'>\The [inside] is too big for \the [src]!</span>")
 				return

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -362,6 +362,7 @@
 /mob/living/simple_animal/hostile/pulse_demon/scoop_up(mob/M)
 	if(!is_under_tile())
 		if(M.is_wearing_item(/obj/item/clothing/gloves/golden,slot_gloves))
+			shockMob(M)
 			return ..()
 		to_chat(M,"<span class ='warning'>Your hands go right through \the [src] as you try to pick it up!</span>")
 		shockMob(M)

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -359,6 +359,14 @@
 	if(!is_under_tile())
 		visible_message("<span class ='notice'>\the [AM] goes right through \the [src]!</span>")
 
+/mob/living/simple_animal/hostile/pulse_demon/scoop_up(mob/M)
+	if(!is_under_tile())
+		if(M.is_wearing_item(/obj/item/clothing/gloves/golden,slot_gloves))
+			return ..()
+		to_chat(M,"<span class ='warning'>Your hands go right through \the [src] as you try to pick it up!</span>")
+		shockMob(M)
+	return 0
+
 // Unless...
 /mob/living/simple_animal/hostile/pulse_demon/Crossed(atom/movable/AM)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
@@ -422,6 +422,7 @@
 	L.yo = TTarget.y - T.y
 	L.xo = TTarget.x - T.x
 	L.process()
+	unlock_from() // just in case
 	forceMove(TTarget)
 
 /spell/pulse_demon/remote_hijack


### PR DESCRIPTION
[bugfix][oversight]

## What this does
Closes #36410.
adds an exception to still allow scooping up for golden gloves, albeit with the same shock properties tied to siemens coefficient. putting them in cages will still not work with them.

## Changelog
:cl:
 * bugfix: Players can no longer scoop up pulse demons, and will get shocked if they try to do so without insulation. Golden gloves will still allow them to be scooped up, but with their shock protection still taken into account.
 * bugfix: Small cages no longer successfully contain pulse demons.
 * bugfix: If pulse demons somehow end up in these cages anyways, cable hopping will no longer freeze them in place.