### PR TITLE
Makes it so dexalin plus also works for hydroponics xenophysiology mutations.

### DIFF
--- a/code/modules/reagents/reagents/reagents_medical.dm
+++ b/code/modules/reagents/reagents/reagents_medical.dm
@@ -714,6 +714,21 @@ var/global/list/charcoal_doesnt_remove=list(
 	if(holder.has_any_reagents(LEXORINS))
 		holder.remove_reagents(LEXORINS, 2 * REM)
 
+/datum/reagent/dexalinp/on_plant_life(obj/machinery/portable_atmospherics/hydroponics/T)
+	if(!holder)
+		return
+	if(!T)
+		T = holder.my_atom //Try to find the mob through the holder
+	if(!istype(T)) //Still can't find it, abort
+		return
+	var/amount = T.reagents.get_reagent_amount(id)
+	if(amount >= 1)
+		if(prob(30))
+			T.mutate(GENE_XENOPHYSIOLOGY)
+			T.reagents.remove_reagent(id, 1)
+	else if(amount > 0)
+		T.reagents.remove_reagent(id, amount)
+
 /datum/reagent/dietine
 	name = "Dietine"
 	id = DIETINE


### PR DESCRIPTION
Currently it only checks for Dexalin or Thymol.
## What this does
Makes it so the xenophysiology mutations can be triggered with Dexalin Plus. 
Dexalin Plus xenophysiology mutations happen slightly faster than using Dexalin or Thymol.
## Why it's good
Feels right since dexalinplus is pretty much fancier dexalin.
:cl:
 * rscadd: Dexalin Plus will now also trigger Xenophysiology mutations, at a slightly faster rate than regular Dexalin or Thymol.