### PR TITLE
makes welderbombs not give bubble sound or message on heating anymore

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -583,6 +583,7 @@
 	required_reagents = list(FUEL = 1)
 	required_temp = AUTOIGNITION_WELDERFUEL
 	result_amount = 1
+	quiet = 1
 	var/fire_temp = AUTOIGNITION_WELDERFUEL
 	var/power = 0
 


### PR DESCRIPTION
[bugfix][tweak]

## What this does
restores it to how it was before fuel bomb changes

## Why it's good
consistency with how it used to be

## Changelog
:cl:
 * bugfix: The solution no longer bubbles in sound or visible messages in welderbombs, as it was before