### PR TITLE
Ghost Fire Fix

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -525,6 +525,11 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	. = ..()
 	dir = pick(cardinal)
 	var/turf/T = get_turf(loc)
+	var/i = 0
+	for(var/obj/effect/fire/F in T)
+		i++
+	if(i>1)
+		qdel(src)
 	var/datum/gas_mixture/air_contents=T.return_air()
 	if(air_contents)
 		setfirelight(air_contents.calculate_firelevel(get_turf(src)), air_contents.temperature)

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -54,6 +54,7 @@
 	if (light)
 		light.destroy()
 		light = null
+	QDEL_NULL(firelightdummy)
 	. = ..()
 
 // Should always be used to change the opacity of an atom.


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Removes "ghost" fires and multiple-stacks of fires. Closes #36601.

## Why it's good
<!-- Explain why you think these changes are good. -->
Prevents multiple fire effects from stacking on each other as well as odd lighting overlays persisting after extinguishing a fire.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed ghost fire light overlays and multiple stacks of fire effects on one tile.