### PR TITLE
Wizard stuff fixes

### DIFF
--- a/code/datums/gamemode/role/rambler.dm
+++ b/code/datums/gamemode/role/rambler.dm
@@ -139,7 +139,7 @@
 	charge_max = 100
 	max_targets = 1
 	spell_flags = WAIT_FOR_CLICK
-	compatible_mobs = list(/mob/living)
+	valid_targets = list(/mob/living)
 	hud_state = "rambler-vow"
 
 /spell/targeted/lockinvow/cast(list/targets, mob/user = user)

--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -264,7 +264,7 @@
 	range = SELFCAST
 	max_targets = 1
 	selection_type = "range"
-	compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
+	valid_targets = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	cast_sound = 'sound/effects/bamf.ogg'
 
 	hud_state = "gen_immolate"

--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -145,7 +145,7 @@
 
 	override_base = "genetic"
 	hud_state = "gen_ice"
-	compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
+	valid_targets = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 
 /spell/targeted/cryokinesis/cast(list/targets)
 	..()
@@ -213,7 +213,7 @@
 	hud_state = "gen_eat"
 
 	cast_sound = 'sound/items/eatfood.ogg'
-	compatible_mobs = list(
+	valid_targets = list(
 		/obj/item,
 		/mob/living/simple_animal/parrot,
 		/mob/living/simple_animal/cat,
@@ -247,14 +247,14 @@
 		return 0
 	if(get_dist(usr, target) > range)
 		return 0
-	return is_type_in_list(target, compatible_mobs)
+	return is_type_in_list(target, valid_targets)
 
 /spell/targeted/eat/choose_targets(mob/user = usr)
 	var/list/targets = list()
 
 	if(max_targets == 0) //unlimited
 		for(var/atom/movable/target in view_or_range(range, user, selection_type))
-			if(!is_type_in_list(target, compatible_mobs) && !istype(target, /obj/item))
+			if(!is_type_in_list(target, valid_targets) && !istype(target, /obj/item))
 				continue
 			if(istype(target, /obj/item/weapon/implant))
 				var/obj/item/weapon/implant/implant = target
@@ -270,7 +270,7 @@
 			for(var/atom/movable/M in view_or_range(range, user, selection_type))
 				if(!(spell_flags & INCLUDEUSER) && M == user)
 					continue
-				if(!is_type_in_list(M, compatible_mobs) && !istype(M, /obj/item))
+				if(!is_type_in_list(M, valid_targets) && !istype(M, /obj/item))
 					continue
 				if(istype(M, /obj/item/weapon/implant))
 					var/obj/item/weapon/implant/implant = M
@@ -320,10 +320,10 @@
 	if(!(spell_flags & INCLUDEUSER) && (user in targets))
 		targets -= user
 
-	if(compatible_mobs && compatible_mobs.len)
+	if(valid_targets && valid_targets.len)
 		for(var/mob/living/target in targets) //filters out all the non-compatible mobs
 			var/found = 0
-			for(var/mob_type in compatible_mobs)
+			for(var/mob_type in valid_targets)
 				if(istype(target, mob_type))
 					found = 1
 			if(!found)
@@ -542,7 +542,7 @@
 	range = 1
 	max_targets = 1
 	selection_type = "range"
-	compatible_mobs = list(/mob/living/carbon/human)
+	valid_targets = list(/mob/living/carbon/human)
 
 	hud_state = "wiz_hulk"
 	override_base = "genetic"
@@ -593,7 +593,7 @@
 	charge_type = Sp_RECHARGE
 	charge_max = 100
 
-	compatible_mobs = list(/mob/living/carbon)
+	valid_targets = list(/mob/living/carbon)
 
 	hud_state = "gen_rmind"
 	override_base = "genetic"

--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -133,7 +133,7 @@
 	spell_flags = SELECTABLE|TALKED_BEFORE
 	override_base = "genetic"
 	hud_state = "gen_project"
-	compatible_mobs = list(/mob/living/carbon/human, /datum/mind)
+	valid_targets = list(/mob/living/carbon/human, /datum/mind)
 	mind_affecting = 1
 	var/telepathy_type = SPECIFIC_TELEPATHY
 	var/targeted = 0

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -285,7 +285,7 @@
 			H.forceMove(get_turf(src))
 		charges--
 		update_icon()
-	else //backup in case the mob was logged out on death
+	else if(!revive_action) //backup in case the mob was logged out on death
 		revive_action = new(phylactery = src)
 		revive_action.Grant(original)
 
@@ -306,6 +306,7 @@
 		to_chat(owner, "Somehow, you clicked this alert but the phylactery was destroyed and your body wasn't dusted, report this to coders.")
 		return
 	phylac.revive_soul(owner)
+	qdel(src)
 
 /obj/item/phylactery/proc/unbind()
 	if(bound_soul)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -191,6 +191,7 @@
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "phylactery_empty_noglow"
 	var/charges = 0
+	var/datum/action/phylacteryrevive/revive_action
 	var/mob/bound_soul
 	var/datum/mind/bound_mind
 
@@ -199,9 +200,9 @@
 	if(user.mind == bound_mind)
 		to_chat(user, "<span class='notice'>It has [charges ? "[charges]" : "no"] charges left!</span>")
 	if(iswizard(user)) //Wizards are scholars
-		to_chat(user, "<span class='notice'>This is a phylactery! Whoever is bound to it will come back as a lich wherever the phylactery may be, as long as it is charged.</span>")
-		to_chat(user, "<span class='notice'>You can charge it using filled soulstones. The more charges you have, the faster you will revive.</span>")
-		to_chat(user, "<span class='notice'>The phylactery will revive you faster the closer you are to it when perishing, up to ten times faster if you are 3 tiles away from it.</span>")
+		to_chat(user, "<span class='notice'>This is a phylactery! Whoever is bound to it will come back as a lich wherever the phylactery may be, as long as it is charged.<BR>\
+						You can charge it using filled soulstones. The more charges you have, the faster you will revive.<BR>\
+						The phylactery will revive you faster the closer you are to it when perishing, up to ten times faster if you are 3 tiles away from it.</span>")
 
 /obj/item/phylactery/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/soulstone))
@@ -218,6 +219,7 @@
 
 /obj/item/phylactery/Destroy()
 	if(bound_soul)
+		QDEL_NULL(revive_action)
 		bound_soul.unregister_event(/event/death, src, nameof(src::revive_soul()))
 		bound_soul.unregister_event(/event/z_transition, src, nameof(src::z_block()))
 		to_chat(bound_soul, "<span class = 'warning'><b>You feel your form begin to unwind!</b></span>")
@@ -257,7 +259,7 @@
 		unbind()
 		return
 	var/mob/living/original = user
-	if(original.mind)
+	if(original.mind && original.ckey)
 		var/mob/living/carbon/human/H = new /mob/living/carbon/human/lich(src)
 		H.real_name = original.real_name
 		H.flavor_text = original.flavor_text
@@ -281,8 +283,29 @@
 		spawn(release_time)
 			to_chat(H, "<span class = 'notice'>\The [src] permits you exit from it.</span>")
 			H.forceMove(get_turf(src))
-	charges--
-	update_icon()
+		charges--
+		update_icon()
+	else //backup in case the mob was logged out on death
+		revive_action = new(phylactery = src)
+		revive_action.Grant(original)
+
+/datum/action/phylacteryrevive
+	name = "Return to Life"
+	desc = "Regenerate your body as a lich."
+	icon_icon = 'icons/obj/wizard.dmi'
+	button_icon_state = "phylactery"
+	var/obj/item/phylactery/phylac
+
+/datum/action/phylacteryrevive/New(location, obj/item/phylactery)
+	..()
+	if(phylactery)
+		phylac = phylactery
+
+/datum/action/phylacteryrevive/Trigger()
+	if(!phylac)
+		to_chat(owner, "Somehow, you clicked this alert but the phylactery was destroyed and your body wasn't dusted, report this to coders.")
+		return
+	phylac.revive_soul(owner)
 
 /obj/item/phylactery/proc/unbind()
 	if(bound_soul)

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -110,7 +110,7 @@ Doesn't work on other aliens/AI.*/
 	insufficient_holder_msg = "<span class='alien'>Not enough plasma stored.</span>"
 
 	range = 2
-	compatible_mobs = list(/mob/living/carbon/alien)
+	valid_targets = list(/mob/living/carbon/alien)
 
 //Does it take charge before casting? How to transfer to new alien
 /spell/targeted/alientransferplasma/cast(var/list/targets, mob/user)

--- a/code/modules/mob/living/simple_animal/hostile/arcane_golem.dm
+++ b/code/modules/mob/living/simple_animal/hostile/arcane_golem.dm
@@ -117,4 +117,4 @@
 	return FALSE
 
 /mob/living/simple_animal/hostile/arcane_golem/shares_arcane_golem_spell(mob/living/simple_animal/hostile/arcane_golem/other)
-	return master_spell == other.master_spell
+	return istype(other) ? master_spell == other.master_spell : FALSE

--- a/code/modules/mob/living/simple_animal/hostile/arcane_golem.dm
+++ b/code/modules/mob/living/simple_animal/hostile/arcane_golem.dm
@@ -106,3 +106,15 @@
 	visible_message("<span class='warning'>\The <b>[src]</b> shatters into pieces!</span>")
 	new /obj/item/weapon/ectoplasm (src.loc)
 	qdel(src)
+
+/mob/proc/get_arcane_golems() // helper proc to get the golems
+	var/spell/aoe_turf/conjure/arcane_golem/S = locate() in spell_list
+	if(S)
+		return S.golems
+	return list()
+
+/mob/proc/shares_arcane_golem_spell(mob/living/simple_animal/hostile/arcane_golem/other)
+	return FALSE
+
+/mob/living/simple_animal/hostile/arcane_golem/shares_arcane_golem_spell(mob/living/simple_animal/hostile/arcane_golem/other)
+	return master_spell == other.master_spell

--- a/code/modules/mob/living/simple_animal/hostile/grue_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue_powers.dm
@@ -10,7 +10,7 @@
 	charge_type = Sp_RECHARGE
 	charge_max = 0 SECONDS
 	range = 1
-	compatible_mobs = list(/mob/living/carbon)
+	valid_targets = list(/mob/living/carbon)
 
 /spell/targeted/grue_eat/cast(var/list/targets, mob/living/simple_animal/hostile/grue/user)
 	if (!isturf(user.loc))

--- a/code/modules/spells/aoe_turf/conjure/arcane_golem.dm
+++ b/code/modules/spells/aoe_turf/conjure/arcane_golem.dm
@@ -55,6 +55,12 @@
 			AG.master_spell = null
 			golems.Remove(AG)
 
+/mob/proc/get_arcane_golems() // helper proc to get the golems
+	var/spell/aoe_turf/conjure/arcane_golem/S = locate() in spell_list
+	if(S)
+		return S.golems
+	return list()
+
 /spell/aoe_turf/conjure/arcane_golem/on_creation(mob/living/simple_animal/hostile/arcane_golem/AG, mob/user)
 	AG.faction = "wizard" // so they get along with other wizard mobs
 	to_chat(user, "<span class='sinister'>You infuse \the [AG] with your mana and knowledge. If it dies, your arcane abilities will be affected.</span>")

--- a/code/modules/spells/aoe_turf/conjure/arcane_golem.dm
+++ b/code/modules/spells/aoe_turf/conjure/arcane_golem.dm
@@ -55,12 +55,6 @@
 			AG.master_spell = null
 			golems.Remove(AG)
 
-/mob/proc/get_arcane_golems() // helper proc to get the golems
-	var/spell/aoe_turf/conjure/arcane_golem/S = locate() in spell_list
-	if(S)
-		return S.golems
-	return list()
-
 /spell/aoe_turf/conjure/arcane_golem/on_creation(mob/living/simple_animal/hostile/arcane_golem/AG, mob/user)
 	AG.faction = "wizard" // so they get along with other wizard mobs
 	to_chat(user, "<span class='sinister'>You infuse \the [AG] with your mana and knowledge. If it dies, your arcane abilities will be affected.</span>")

--- a/code/modules/spells/general/lightning.dm
+++ b/code/modules/spells/general/lightning.dm
@@ -16,6 +16,7 @@
 	invocation = "ZAP MUTHA FUH KA"
 	invocation_type = SpI_SHOUT
 	hud_state = "wiz_zap"
+	valid_targets = list(/mob/living,/obj/machinery/bot,/obj/mecha)
 
 	var/basedamage = 50
 	var/bounces = 0
@@ -29,11 +30,6 @@
 /spell/lightning/New()
 	..()
 	chargeoverlay = image("icon" = 'icons/mob/mob.dmi', "icon_state" = "sithlord")
-
-/spell/lightning/is_valid_target(atom/target, mob/user, options, bypass_range = 0)
-	if(options)
-		return (target in options)
-	return ((target in view_or_range(range, user, selection_type)) && (istype(target, /mob/living) || istype(target, /obj/machinery/bot) || istype(target, /obj/mecha)))
 
 /spell/lightning/quicken_spell()
 	if(!can_improve(Sp_SPEED))

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -161,6 +161,8 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 		var/mob/M = target
 		if(user in M.get_arcane_golems())
 			return FALSE
+		if(user.shares_arcane_golem_spell(M))
+			return FALSE
 	if(bypass_range && istype(target, /mob/living))
 		return TRUE
 	if(options)

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -64,6 +64,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	var/selection_type = "view"		//can be "range" or "view"
 	var/atom/movable/holder			//where the spell is. Normally the user, can be an item
 	var/duration = 0 //how long the spell lasts
+	var/list/valid_targets = list(/mob/living)
 
 	var/list/spell_levels = list(Sp_SPEED = 0, Sp_POWER = 0) //the current spell levels - total spell levels can be obtained by just adding the two values
 	var/list/level_max = list(Sp_TOTAL = 4, Sp_SPEED = 4, Sp_POWER = 0) //maximum possible levels in each category. Total does cover both.
@@ -156,11 +157,15 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 	return
 
 /spell/proc/is_valid_target(atom/target, mob/user, options, bypass_range = 0)
+	if(ismob(target))
+		var/mob/M = target
+		if(user in M.get_arcane_golems())
+			return FALSE
 	if(bypass_range && istype(target, /mob/living))
 		return TRUE
 	if(options)
 		return (target in options)
-	return ((target in view_or_range(range, user, selection_type)) && istype(target, /mob/living))
+	return ((target in view_or_range(range, user, selection_type)) && is_type_in_list(target, valid_targets))
 
 /spell/proc/perform(mob/user = usr, skipcharge = 0, list/target_override)
 	if(!holder)

--- a/code/modules/spells/targeted/buttbots_revenge.dm
+++ b/code/modules/spells/targeted/buttbots_revenge.dm
@@ -15,7 +15,7 @@
 	level_max = list(Sp_TOTAL = 5, Sp_SPEED = 4, Sp_POWER = 1)
 	sparks_spread = 1
 	sparks_amt = 4
-	compatible_mobs = list(/mob/living/carbon/human,/mob/living/carbon/monkey)
+	valid_targets = list(/mob/living/carbon/human,/mob/living/carbon/monkey)
 
 	amt_knockdown = 8
 	amt_stunned = 8

--- a/code/modules/spells/targeted/card.dm
+++ b/code/modules/spells/targeted/card.dm
@@ -9,7 +9,7 @@
 	spell_flags = WAIT_FOR_CLICK
 	invocation_type = SpI_SHOUT
 	max_targets = 1
-	compatible_mobs = list(/mob/living/carbon/human)
+	valid_targets = list(/mob/living/carbon/human)
 	level_max = list(Sp_TOTAL = 0, Sp_SPEED = 0, Sp_POWER = 0) //You can't quicken this, this would be kind of useless
 	hud_state = "card_trick"
 	var/current_card

--- a/code/modules/spells/targeted/disease.dm
+++ b/code/modules/spells/targeted/disease.dm
@@ -17,6 +17,7 @@
 
 	override_base = "vamp"
 	hud_state = "vampire_disaese"
+	valid_targets = list(/mob/living/carbon)
 
 	var/blood_cost = 50
 
@@ -24,11 +25,6 @@
 	. = ..()
 	if (!user.vampire_power(blood_cost, CONSCIOUS))
 		return FALSE
-
-/spell/targeted/disease/is_valid_target(atom/target, mob/user, options, bypass_range = 0)
-	if(!istype(target, /mob/living/carbon))
-		return FALSE
-	return ..()
 
 /spell/targeted/disease/cast(var/list/targets, var/mob/user)
 	if (targets.len > 1)

--- a/code/modules/spells/targeted/disorient.dm
+++ b/code/modules/spells/targeted/disorient.dm
@@ -19,7 +19,7 @@
 	amt_stuttering = 86
 	mind_affecting = 1
 
-	compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
+	valid_targets = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	spell_flags = WAIT_FOR_CLICK
 
 	hud_state = "wiz_disorient"

--- a/code/modules/spells/targeted/enthrall.dm
+++ b/code/modules/spells/targeted/enthrall.dm
@@ -17,6 +17,7 @@
 
 	override_base = "vamp"
 	hud_state = "vampire_enthrall"
+	valid_targets = list(/mob/living/carbon/human) // Can only enthrall humans
 
 	var/blood_cost = 150
 
@@ -24,12 +25,6 @@
 	. = ..()
 	if (!user.vampire_power(blood_cost, CONSCIOUS))
 		return FALSE
-
-/spell/targeted/enthrall/is_valid_target(atom/target, mob/user, options, bypass_range = 0)
-	if (!ishuman(target)) // Can only enthrall humans
-		return FALSE
-	return ..()
-
 
 /spell/targeted/enthrall/cast(var/list/targets, var/mob/user)
 	if (targets.len > 1)

--- a/code/modules/spells/targeted/equip/cape.dm
+++ b/code/modules/spells/targeted/equip/cape.dm
@@ -19,7 +19,7 @@
 
 	override_base = "vamp"
 
-	compatible_mobs = list(/mob/living/carbon/human)
+	valid_targets = list(/mob/living/carbon/human)
 	equipped_summons = list(SLOT_WEAR_SUIT_STR = /obj/item/clothing/suit/storage/draculacoat)
 
 	hud_state = "vamp_coat"

--- a/code/modules/spells/targeted/equip/clowncurse.dm
+++ b/code/modules/spells/targeted/equip/clowncurse.dm
@@ -17,7 +17,7 @@
 	sparks_spread = 1
 	sparks_amt = 4
 
-	compatible_mobs = list(/mob/living/carbon/human)
+	valid_targets = list(/mob/living/carbon/human)
 
 	hud_state = "wiz_clown"
 

--- a/code/modules/spells/targeted/equip/frenchcurse.dm
+++ b/code/modules/spells/targeted/equip/frenchcurse.dm
@@ -16,7 +16,7 @@
 	sparks_spread = 1
 	sparks_amt = 4
 
-	compatible_mobs = list(/mob/living/carbon/human)
+	valid_targets = list(/mob/living/carbon/human)
 
 	hud_state = "wiz_mime"
 

--- a/code/modules/spells/targeted/equip/horsemask.dm
+++ b/code/modules/spells/targeted/equip/horsemask.dm
@@ -17,7 +17,7 @@
 	selection_type = "range"
 	spell_flags = WAIT_FOR_CLICK
 
-	compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
+	valid_targets = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 
 	hud_state = "wiz_horse"
 

--- a/code/modules/spells/targeted/equip/robesummon.dm
+++ b/code/modules/spells/targeted/equip/robesummon.dm
@@ -23,7 +23,7 @@
 
 	cooldown_min = 50
 
-	compatible_mobs = list(/mob/living/carbon/human)
+	valid_targets = list(/mob/living/carbon/human)
 
 	hud_state = "wiz_robesummon"
 

--- a/code/modules/spells/targeted/fist.dm
+++ b/code/modules/spells/targeted/fist.dm
@@ -17,6 +17,13 @@
 
 	hud_state = "wiz_fist"
 
+/spell/targeted/fist/is_valid_target(atom/target, mob/user, options, bypass_range)
+	if(target in user.get_arcane_golems())
+		return FALSE
+	if((target in doppelgangers) && doppelgangers[target] == user)
+		return FALSE
+	return ..()	
+
 /spell/targeted/fist/cast(var/list/targets)
 	var/mob/living/L = holder
 	if(istype(L) && L.has_hand_check()) //Can't punch if you have no haaands

--- a/code/modules/spells/targeted/fist.dm
+++ b/code/modules/spells/targeted/fist.dm
@@ -13,7 +13,7 @@
 	max_targets = 3
 	spell_flags = NEEDSCLOTHES | LOSE_IN_TRANSFER | IS_HARMFUL
 
-	compatible_mobs = list(/mob/living)
+	valid_targets = list(/mob/living)
 
 	hud_state = "wiz_fist"
 

--- a/code/modules/spells/targeted/flesh_to_stone.dm
+++ b/code/modules/spells/targeted/flesh_to_stone.dm
@@ -14,7 +14,7 @@
 	invocation_type = SpI_SHOUT
 	amt_stunned = 5//just exists to make sure the statue "catches" them
 	cooldown_min = 200 //100 deciseconds reduction per rank
-	compatible_mobs = list(/mob/living)
+	valid_targets = list(/mob/living)
 
 	hud_state = "wiz_statue"
 

--- a/code/modules/spells/targeted/genetic.dm
+++ b/code/modules/spells/targeted/genetic.dm
@@ -60,7 +60,7 @@ code\game\\dna\genes\goon_powers.dm
 
 	price = 0.5 * Sp_BASE_PRICE //Half of the normal spell price
 	user_type = USER_TYPE_WIZARD
-	compatible_mobs = list(/mob/living/carbon) //Silicons don't have DNA
+	valid_targets = list(/mob/living/carbon) //Silicons don't have DNA
 
 /spell/targeted/genetic/mutate
 	name = "Mutate"

--- a/code/modules/spells/targeted/heal.dm
+++ b/code/modules/spells/targeted/heal.dm
@@ -14,7 +14,7 @@
 	invocation_type = SpI_SHOUT
 	message = "<span class='sinister'>You feel refreshed.<span>"
 	level_max = list(Sp_TOTAL = 3, Sp_SPEED = 2, Sp_POWER = 1, Sp_RANGE = 1)
-	compatible_mobs = list(/mob/living)
+	valid_targets = list(/mob/living)
 
 	max_targets = 1
 

--- a/code/modules/spells/targeted/hypnotise.dm
+++ b/code/modules/spells/targeted/hypnotise.dm
@@ -22,7 +22,7 @@
 	hud_state = "vampire_hypno"
 
 	var/blood_cost = 10
-	compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
+	valid_targets = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 
 /spell/targeted/hypnotise/cast_check(skipcharge = 0, mob/user = usr)
 	. = ..()

--- a/code/modules/spells/targeted/ice_barrage.dm
+++ b/code/modules/spells/targeted/ice_barrage.dm
@@ -13,7 +13,7 @@
 	cooldown_min = 30
 
 	hud_state = "ice_barrage"
-	compatible_mobs = list(/mob/living)
+	valid_targets = list(/mob/living)
 
 /spell/targeted/ice_barrage/cast(var/list/targets, mob/user)
 	..()

--- a/code/modules/spells/targeted/invoke_emotion.dm
+++ b/code/modules/spells/targeted/invoke_emotion.dm
@@ -14,7 +14,7 @@ var/global/list/invoked_emotions = list()
 	range = 9
 	charge_max = 150
 	cooldown_min = 10
-	compatible_mobs = list(/mob/living/carbon)
+	valid_targets = list(/mob/living/carbon)
 	spell_levels = list(Sp_SPEED = 0, Sp_POWER = 0, Sp_MOVE = 0)
 	level_max = list(Sp_TOTAL = 7, Sp_SPEED = 1, Sp_POWER = 5, Sp_MOVE = 1)
 

--- a/code/modules/spells/targeted/mind_transfer.dm
+++ b/code/modules/spells/targeted/mind_transfer.dm
@@ -14,7 +14,7 @@
 	mind_affecting = 1
 	range = 1
 	cooldown_min = 200 //100 deciseconds reduction per rank
-	compatible_mobs = list(/mob/living/carbon/human,/mob/living/carbon/monkey) //which types of mobs are affected by the spell. NOTE: change at your own risk
+	valid_targets = list(/mob/living/carbon/human,/mob/living/carbon/monkey) //which types of mobs are affected by the spell. NOTE: change at your own risk
 
 	var/list/protected_roles = list("Wizard","Changeling","Cultist") //which roles are immune to the spell
 	var/msg_wait = 500 //how long in deciseconds it waits before telling that body doesn't feel right or mind swap robbed of a spell

--- a/code/modules/spells/targeted/parrotmorph.dm
+++ b/code/modules/spells/targeted/parrotmorph.dm
@@ -16,7 +16,7 @@
 	selection_type = "range"
 
 
-	compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
+	valid_targets = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 
 	hud_state = "wiz_parrotmorph"
 

--- a/code/modules/spells/targeted/projectile/projectile.dm
+++ b/code/modules/spells/targeted/projectile/projectile.dm
@@ -55,6 +55,8 @@ If the spell_projectile is seeking, it will update its target every process and 
 	for(var/mob/living/M in range(spell_holder, cast_prox_range))
 		if(M == user && !(spell_flags & INCLUDEUSER))
 			continue
+		if(user in M.get_arcane_golems())
+			continue
 		if(spell_holder.Adjacent(M))
 			targets += M
 	return targets

--- a/code/modules/spells/targeted/projectile/projectile.dm
+++ b/code/modules/spells/targeted/projectile/projectile.dm
@@ -52,9 +52,6 @@ If the spell_projectile is seeking, it will update its target every process and 
 
 /spell/targeted/projectile/proc/choose_prox_targets(mob/user = usr, var/atom/movable/spell_holder)
 	var/list/targets = list()
-	var/userisgolem = FALSE
-	if(istype(user,/mob/living/simple_animal/hostile/arcane_golem))
-		userisgolem = TRUE
 	for(var/mob/living/M in range(spell_holder, cast_prox_range))
 		if(M == user && !(spell_flags & INCLUDEUSER))
 			continue

--- a/code/modules/spells/targeted/projectile/projectile.dm
+++ b/code/modules/spells/targeted/projectile/projectile.dm
@@ -52,10 +52,15 @@ If the spell_projectile is seeking, it will update its target every process and 
 
 /spell/targeted/projectile/proc/choose_prox_targets(mob/user = usr, var/atom/movable/spell_holder)
 	var/list/targets = list()
+	var/userisgolem = FALSE
+	if(istype(user,/mob/living/simple_animal/hostile/arcane_golem))
+		userisgolem = TRUE
 	for(var/mob/living/M in range(spell_holder, cast_prox_range))
 		if(M == user && !(spell_flags & INCLUDEUSER))
 			continue
 		if(user in M.get_arcane_golems())
+			continue
+		if(user.shares_arcane_golem_spell(M))
 			continue
 		if(spell_holder.Adjacent(M))
 			targets += M

--- a/code/modules/spells/targeted/punch.dm
+++ b/code/modules/spells/targeted/punch.dm
@@ -13,7 +13,7 @@
 	invocation_type = SpI_SHOUT
 	max_targets = 1
 	range = 1
-	compatible_mobs = list(/mob/living, /obj/mecha)
+	valid_targets = list(/mob/living, /obj/mecha)
 	hud_state = "wiz_punch"
 	var/empowered = 0
 	var/mob/living/present_target //A placeholder proc that records the target for the purpose of actually getting the impact handled.

--- a/code/modules/spells/targeted/retard.dm
+++ b/code/modules/spells/targeted/retard.dm
@@ -11,7 +11,7 @@
 	range = 3 // Target anyone within 3 tiles of you
 	amt_dam_brain = 90 //90 brain damage
 	max_targets = 1 // Can only target one person
-	compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/monkey) // Only works on humans and monkeys
+	valid_targets = list(/mob/living/carbon/human, /mob/living/carbon/monkey) // Only works on humans and monkeys
 	spell_flags = WAIT_FOR_CLICK | IS_HARMFUL //Click on whoever you want to get brain damaged
 	message = "<span class='danger'>You feel dumber!<span>" //What the victim sees when affected
 	mind_affecting = 1 //Blocked by tinfoil hat

--- a/code/modules/spells/targeted/roidrat_punch.dm
+++ b/code/modules/spells/targeted/roidrat_punch.dm
@@ -7,7 +7,7 @@
 	charge_max = 300 // Much longer cooldown than the wizard spell
 	spell_flags = IS_HARMFUL | WAIT_FOR_CLICK
 	invocation_type = SpI_NONE
-	compatible_mobs = list(/mob/living) // Unlike the other version, this one can't target and destroy mechs
+	valid_targets = list(/mob/living) // Unlike the other version, this one can't target and destroy mechs
 	hud_state = "gen_hulk"
 
 /spell/targeted/punch/roidrat/invocation(mob/user, list/targets) // No invocation on this one, just raw muscle

--- a/code/modules/spells/targeted/shoesnatch.dm
+++ b/code/modules/spells/targeted/shoesnatch.dm
@@ -17,7 +17,7 @@
 	selection_type = "range"
 
 	level_max = list(Sp_TOTAL = 5, Sp_SPEED = 4, Sp_POWER = 1)
-	compatible_mobs = list(/mob/living/carbon/human)
+	valid_targets = list(/mob/living/carbon/human)
 
 	hud_state = "wiz_shoes"
 

--- a/code/modules/spells/targeted/summon_snacks.dm
+++ b/code/modules/spells/targeted/summon_snacks.dm
@@ -23,7 +23,7 @@
 	cooldown_min = 150
 	selection_type = "range"
 	range = 7
-	compatible_mobs = list(/mob/living/carbon)
+	valid_targets = list(/mob/living/carbon)
 	spell_levels = list(Sp_SPEED = 0, Sp_POWER = 0, Sp_AMOUNT = 0, Sp_MOVE = 0)
 	level_max = list(Sp_TOTAL = 16, Sp_SPEED = 3, Sp_POWER = 1, Sp_AMOUNT = 5, Sp_MOVE = 7)
 	var/menuType = SUMMON_SNACKS_FILLING

--- a/code/modules/spells/targeted/targeted.dm
+++ b/code/modules/spells/targeted/targeted.dm
@@ -7,6 +7,7 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 /spell/targeted //can mean aoe for mobs (limited/unlimited number) or one target mob
 	spell_flags = SELECTABLE
 	user_type = USER_TYPE_NOUSER
+	valid_targets = list()
 	var/max_targets = 1 //leave 0 for unlimited targets in range, more for limited number of casts (can all target one guy, depends on target_ignore_prev) in range
 	var/target_ignore_prev = 1 //only important if max_targets > 1, affects if the spell can be cast multiple times at one person from one cast
 
@@ -30,8 +31,6 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 	var/amt_eye_blurry = 0
 	var/mind_affecting = 0 //Determines if it can be blocked by PSY_RESIST or tinfoil hat
 
-	var/list/compatible_mobs = list()
-
 /spell/targeted/is_valid_target(atom/target, mob/user, options, bypass_range = 0)
 	if(!(spell_flags & INCLUDEUSER) && target == user)
 		return 0
@@ -41,7 +40,7 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 		var/mob/M = target
 		if (!user.can_mind_interact(M.mind))
 			return 0
-	return !compatible_mobs.len || is_type_in_list(target, compatible_mobs)
+	return !valid_targets.len || is_type_in_list(target, valid_targets)
 
 /spell/targeted/choose_targets(mob/user = usr)
 	if(mind_affecting && tinfoil_check(user))
@@ -105,10 +104,10 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 			for(var/mob/living/M in starting_targets)
 				if(!(spell_flags & INCLUDEUSER) && M == user)
 					continue
-				if(compatible_mobs && compatible_mobs.len)
-					if(!is_type_in_list(M, compatible_mobs))
+				if(valid_targets && valid_targets.len)
+					if(!is_type_in_list(M, valid_targets))
 						continue
-				if(compatible_mobs && compatible_mobs.len && !is_type_in_list(M, compatible_mobs))
+				if(valid_targets && valid_targets.len && !is_type_in_list(M, valid_targets))
 					continue
 				if(mind_affecting)
 					if(iscarbon(user))
@@ -138,7 +137,7 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 		for(var/mob/living/target in starting_targets)
 			if(!(spell_flags & INCLUDEUSER) && target == user)
 				continue
-			if(compatible_mobs && !is_type_in_list(target, compatible_mobs))
+			if(valid_targets && !is_type_in_list(target, valid_targets))
 				continue
 			possible_targets += target
 
@@ -168,9 +167,9 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 	if(!(spell_flags & INCLUDEUSER) && (user in targets))
 		targets -= user
 
-	if(compatible_mobs && compatible_mobs.len)
+	if(valid_targets && valid_targets.len)
 		for(var/mob/living/target in targets) //filters out all the non-compatible mobs
-			if(!is_type_in_list(target, compatible_mobs))
+			if(!is_type_in_list(target, valid_targets))
 				targets -= target
 
 	return targets

--- a/code/modules/spells/targeted/targeted.dm
+++ b/code/modules/spells/targeted/targeted.dm
@@ -36,9 +36,11 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 		return 0
 	if(!(range == GLOBALCAST) && !bypass_range && !(range == SELFCAST && target == user) && (options && !(target in options))) //Shouldn't be necessary but a good check in case of overrides
 		return 0
-	if(ismob(target) && mind_affecting)
+	if(ismob(target))
 		var/mob/M = target
-		if (!user.can_mind_interact(M.mind))
+		if (mind_affecting && !user.can_mind_interact(M.mind))
+			return 0
+		if(user in M.get_arcane_golems())
 			return 0
 	return !valid_targets.len || is_type_in_list(target, valid_targets)
 

--- a/code/modules/spells/targeted/targeted.dm
+++ b/code/modules/spells/targeted/targeted.dm
@@ -42,6 +42,8 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 			return 0
 		if(user in M.get_arcane_golems())
 			return 0
+		if(user.shares_arcane_golem_spell(M))
+			return 0
 	return !valid_targets.len || is_type_in_list(target, valid_targets)
 
 /spell/targeted/choose_targets(mob/user = usr)

--- a/code/modules/spells/targeted/wrap.dm
+++ b/code/modules/spells/targeted/wrap.dm
@@ -12,7 +12,7 @@
 	invocation_type = SpI_SHOUT
 	amt_stunned = 5//just exists to make sure the giftwrap "catches" them
 	cooldown_min = 30 //100 deciseconds reduction per rank
-	compatible_mobs = list(/mob/living)
+	valid_targets = list(/mob/living)
 
 	hud_state = "wrap"
 


### PR DESCRIPTION
[bugfix][oversight]

## What this does
Closes #15019.
Closes #20331.
Closes #22648.
Closes #27355.
Closes #32909.

## Changelog
:cl:
 * tweak: Magic missiles, fist and lightning from arcane golems no longer target their master or the master's other golems.
 * tweak: Fist no longer targets your own arcane golems or doppelgangers.
 * bugfix: Phylacteries no longer spawn an uncontrolled lich if you die with one activated while logged out or ghosting. Instead, an action alert is granted to do it at any time if so.