### PR TITLE
Patron Des Arts tweak

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -4227,7 +4227,8 @@ var/global/list/obj/item/weapon/paper/lotto_numbers/lotto_papers = list()
 	product_slogans = list(
 		"Il est temps pour vous de jeter des perles devant ces porcs incultes.",
 		"Oui, j'ai capitulé. Vous pouvez aussi acheter des crayons maintenant.",
-		"Il y a la peinture sur toile, et puis il y a l'art véritable. Pouvez-vous voir la différence ?"
+		"Il y a la peinture sur toile, et puis il y a l'art véritable. Pouvez-vous voir la différence?",
+		"'Omelette du Fromage, Omelette du Fromage!' C'est tout ce que tu peux diiiiiire!"
 	)
 	product_ads = list(
 		"This is not a cigarette vendor."
@@ -4253,7 +4254,8 @@ var/global/list/obj/item/weapon/paper/lotto_numbers/lotto_papers = list()
 
 	contraband = list(
 		/obj/item/stack/sheet/wood/bigstack = 3,
-		/obj/item/clothing/mask/cigarette/pipe = 2
+		/obj/item/clothing/mask/cigarette/pipe = 2,
+		/obj/item/weapon/reagent_containers/food/snacks/omelette = 3
 		)
 
 	premium = list(


### PR DESCRIPTION
## What this does
Makes it so you can buy omelettes from the contraband list in the Patron des Arts (art vendor) and adds a thematically appropriate slogan line.
https://www.youtube.com/watch?v=2kArCRjT29w
https://www.youtube.com/watch?v=8nW3-9gdjYA
## Why it's good
I was on my way home with some recently purchased bread when I suddenly got hit with divine inspiration. I trust the divine.
We already have a couple out of place items in vendors for a pun (like the clown's water flower in the seed vendor or the pipe in this very same vendor), so why not this as well?
:cl:
 * rscadd: Artistic crewmembers might find themselves able to purchase a delightful dinner from their local art vendor's contraband stock.
 * rscadd: New line added to the art vendor slogans.