### PR TITLE
Gives pulse demon action to jump to any camera in an APC's area

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon.dm
@@ -62,6 +62,7 @@
 	var/obj/machinery/bot/current_bot								// Currently controlled bot
 	var/obj/item/weapon/gun/current_weapon							// Current gun we're controlling
 	var/datum/action/pd_leave_item/PLI
+	var/datum/action/pd_change_camera/PCC
 
 	//LISTS
 	var/list/image/cables_shown = list()							// In cable views
@@ -71,6 +72,7 @@
 /mob/living/simple_animal/hostile/pulse_demon/New()
 	..()
 	// Must be spawned on a power source or cable, or else die
+	PCC = new(src)
 	current_power = locate(/obj/machinery/power) in loc
 	if(!current_power)
 		current_cable = locate(/obj/structure/cable) in loc
@@ -79,6 +81,7 @@
 	else
 		if(istype(current_power,/obj/machinery/power/apc))
 			controlling_area = get_area(current_power)
+			PCC.Grant(src)
 		forceMove(current_power)
 	set_light(1.5,2,"#bbbb00")
 	add_spell(new /spell/pulse_demon/abilities, "pulsedemon_spell_ready", /obj/abstract/screen/movable/spell_master/pulse_demon)
@@ -252,6 +255,7 @@
 				return
 			if(current_apc.pulsecompromised)
 				controlling_area = get_area(current_power)
+				PCC.Grant(src)
 				to_chat(src, "<span class='notice'>You can interact with various electronic objects in the room while connected to the APC.</span>")
 			else
 				hijackAPC(current_apc)
@@ -269,6 +273,7 @@
 			if(!isturf(loc))
 				loc = get_turf(NewLoc)
 			controlling_area = null
+			PCC.Remove(src)
 			if(!moved)
 				forceMove(NewLoc)
 		else
@@ -475,6 +480,7 @@
 		current_apc.pulsecompromising = 0
 		current_apc.pulsecompromised = 1
 		controlling_area = get_area(current_power)
+		PCC.Grant(src)
 		to_chat(src,"<span class='notice'>Takeover complete.</span>")
 		// Add to the stats if we can
 		if(mind && mind.GetRole(PULSEDEMON))

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
@@ -649,3 +649,22 @@
 	else
 		owner.forceMove(get_turf(owner))
 	Remove(owner)
+
+/datum/action/pd_change_camera
+	name = "Change camera view"
+	desc = "Move to another camera in the area."
+	icon_icon = 'icons/mob/screen_ai.dmi'
+	button_icon_state = "camera"
+
+/datum/action/pd_change_camera/Trigger()
+	if(ispulsedemon(owner))
+		var/mob/living/simple_animal/hostile/pulse_demon/PD = owner
+		var/list/camstouse = list()
+		var/area/ourarea = get_area(PD)
+		for (var/obj/machinery/camera/C in cameranet.cameras)
+			if(get_area(C) == ourarea)
+				camstouse["[C.c_tag]"] += C
+		var/camtag = input(PD,"Choose a camera to jump to","Area cameras") as null|anything in camstouse
+		if(camtag)
+			var/obj/machinery/camera/ourcam = camstouse[camtag]
+			ourcam.attack_pulsedemon(PD)

--- a/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pulse_demon/pulsedemon_powers.dm
@@ -646,6 +646,7 @@
 		PD.current_robot = null
 		PD.current_bot = null
 		PD.current_weapon = null
+		PD.change_sight(removing = SEE_TURFS | SEE_MOBS | SEE_OBJS)
 	else
 		owner.forceMove(get_turf(owner))
 	Remove(owner)


### PR DESCRIPTION
[qol]

## What this does
when entering an APC, gives pulse demons an action button to jump to a list of cameras in the room the APC controls, gets removed when leaving control of the area.

## Why it's good
allows easier camera jumping since not all are visible from the APC

## Changelog
:cl:
 * tweak: Pulse demons now get a list of all cameras in the area they control to jump to, if in an APC.