### PR TITLE
Ghost follow and teleport fixes

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -63,7 +63,7 @@
 				continue
 			var/T = get_turf(user)
 			if(isobserver(M) && M.client && (M.client.prefs.toggles & CHAT_GHOSTSIGHT) && !(M in viewers(T)))
-				M.show_message(formatFollow(M, user) + " " + msg)
+				M.show_message(formatFollow(user) + " " + msg)
 				if (user.client && M?.client?.prefs.mob_chat_on_map && get_dist(M, user) < M?.client.view)
 					M.create_chat_message(user, null, msg_runechat, "", list("italics"))
 

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -63,7 +63,7 @@
 				continue
 			var/T = get_turf(user)
 			if(isobserver(M) && M.client && (M.client.prefs.toggles & CHAT_GHOSTSIGHT) && !(M in viewers(T)))
-				M.show_message("<a href='?src=\ref[M];follow=\ref[user]'>(Follow)</a> " + msg)
+				M.show_message(formatFollow(M, user) + " " + msg)
 				if (user.client && M?.client?.prefs.mob_chat_on_map && get_dist(M, user) < M?.client.view)
 					M.create_chat_message(user, null, msg_runechat, "", list("italics"))
 

--- a/code/datums/recruiter.dm
+++ b/code/datums/recruiter.dm
@@ -28,10 +28,10 @@
 	subject=_subject
 
 /datum/recruiter/proc/recruiting_player(var/mob/dead/observer/O)
-	player_volunteering.invoke_async(O, "<a href='?src=\ref[O];jump=\ref[subject]'>Teleport</a> | <a href='?src=\ref[src];signup=\ref[O]'>Retract</a>")
+	player_volunteering.invoke_async(O, "[formatGhostJump(subject)] | <a href='?src=\ref[src];signup=\ref[O]'>Retract</a>")
 
 /datum/recruiter/proc/nonrecruiting_player(var/mob/dead/observer/O)
-	player_not_volunteering.invoke_async(O, "<a href='?src=\ref[O];jump=\ref[subject]'>Teleport</a> | <a href='?src=\ref[src];signup=\ref[O]'>Sign up</a>")
+	player_not_volunteering.invoke_async(O, "[formatGhostJump(subject)] | <a href='?src=\ref[src];signup=\ref[O]'>Sign up</a>")
 
 /datum/recruiter/proc/request_player()
 	currently_querying = list()
@@ -46,13 +46,13 @@
 
 		currently_querying |= O
 		recruiting_player(O)
-		//to_chat(O, "<span class='recruit'>Someone is harvesting [display_name]. You have been added to the list of potential ghosts. (<a href='?src=\ref[O];jump=\ref[subject]'>Teleport</a> | <a href='?src=\ref[src];signup=\ref[O]'>Retract</a>)</span>")
+		//to_chat(O, "<span class='recruit'>Someone is harvesting [display_name]. You have been added to the list of potential ghosts. ([formatGhostJump(subject)] | <a href='?src=\ref[src];signup=\ref[O]'>Retract</a>)</span>")
 
 	for(var/mob/dead/observer/O in dead_mob_list - active_candidates)
 		if(!check_observer(O))
 			continue
 		nonrecruiting_player(O)
-		//to_chat(O, "<span class='recruit'>Someone is harvesting [display_name]. (<a href='?src=\ref[O];jump=\ref[subject]'>Teleport</a> | <a href='?src=\ref[src];signup=\ref[O]'>Sign up</a>)</span>")
+		//to_chat(O, "<span class='recruit'>Someone is harvesting [display_name]. ([formatGhostJump(subject)] | <a href='?src=\ref[src];signup=\ref[O]'>Sign up</a>)</span>")
 
 	spawn(recruitment_timeout)
 		if(!currently_querying || currently_querying.len==0)

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -143,7 +143,7 @@
 
 	for (var/mob/M in dead_mob_list)
 		if(!istype(M,/mob/new_player) && !istype(M,/mob/living/carbon/brain)) //No meta-evesdropping
-			rendered = "<font color=\"#EE4000\"><i><span class='game say'>Blob Telepathy, <span class='name'>[name]</span> <a href='byond://?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>(Follow)</a> <span class='message'>[message_a]</span></span></i></font>"
+			rendered = "<font color=\"#EE4000\"><i><span class='game say'>Blob Telepathy, <span class='name'>[name]</span> [formatFollow(M,src)] <span class='message'>[message_a]</span></span></i></font>"
 			M.show_message(rendered, 2)
 
 /mob/camera/blob/emote(act, m_type = null, message = null, ignore_status = FALSE, arguments)

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -143,7 +143,7 @@
 
 	for (var/mob/M in dead_mob_list)
 		if(!istype(M,/mob/new_player) && !istype(M,/mob/living/carbon/brain)) //No meta-evesdropping
-			rendered = "<font color=\"#EE4000\"><i><span class='game say'>Blob Telepathy, <span class='name'>[name]</span> [formatFollow(M,src)] <span class='message'>[message_a]</span></span></i></font>"
+			rendered = "<font color=\"#EE4000\"><i><span class='game say'>Blob Telepathy, <span class='name'>[name]</span> [formatFollow(src)] <span class='message'>[message_a]</span></span></i></font>"
 			M.show_message(rendered, 2)
 
 /mob/camera/blob/emote(act, m_type = null, message = null, ignore_status = FALSE, arguments)

--- a/code/game/objects/items/devices/PDA/apps/messenger.dm
+++ b/code/game/objects/items/devices/PDA/apps/messenger.dm
@@ -274,7 +274,7 @@
         msg_id++
         for(var/mob/dead/observer/M in player_list)
             if(!multicast_message && M.stat == DEAD && M.client && (M.client.prefs.toggles & CHAT_GHOSTPDA)) // src.client is so that ghosts don't have to listen to mice
-                M.show_message("[formatFollow(M,U)] <span class='game say'>PDA Message - <span class='name'>\
+                M.show_message("[formatFollow(U)] <span class='game say'>PDA Message - <span class='name'>\
                     [U.real_name][U.real_name == pda_device.owner ? "" : " (as [pda_device.owner])"]</span> -> <span class='name'>[P.owner]</span>: <span class='message'>[t]</span>\
                     [pda_device.photo ? " (<a href='byond://?src=\ref[P_app];choice=viewPhoto;image=\ref[pda_device.photo];skiprefresh=1;target=\ref[reply_to]'>View Photo</a>)</span>" : ""]")
 

--- a/code/game/objects/items/devices/PDA/apps/messenger.dm
+++ b/code/game/objects/items/devices/PDA/apps/messenger.dm
@@ -274,7 +274,7 @@
         msg_id++
         for(var/mob/dead/observer/M in player_list)
             if(!multicast_message && M.stat == DEAD && M.client && (M.client.prefs.toggles & CHAT_GHOSTPDA)) // src.client is so that ghosts don't have to listen to mice
-                M.show_message("<a href='?src=\ref[M];follow=\ref[U]'>(Follow)</a> <span class='game say'>PDA Message - <span class='name'>\
+                M.show_message("[formatFollow(M,U)] <span class='game say'>PDA Message - <span class='name'>\
                     [U.real_name][U.real_name == pda_device.owner ? "" : " (as [pda_device.owner])"]</span> -> <span class='name'>[P.owner]</span>: <span class='message'>[t]</span>\
                     [pda_device.photo ? " (<a href='byond://?src=\ref[P_app];choice=viewPhoto;image=\ref[pda_device.photo];skiprefresh=1;target=\ref[reply_to]'>View Photo</a>)</span>" : ""]")
 

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -326,7 +326,7 @@ var/global/image/ghostimg = image("icon"='icons/mob/mob.dmi',"icon_state"="ghost
 	if(istype(mob, /mob/new_player))
 		return //One extra layer of sanity
 	if(istype(mob,/mob/dead/observer))
-		var/reference = formatFollow(mob,speaker)
+		var/reference = formatFollow(speaker)
 		message = reference+" "+message
 		to_chat(mob, message)
 	else

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -326,8 +326,8 @@ var/global/image/ghostimg = image("icon"='icons/mob/mob.dmi',"icon_state"="ghost
 	if(istype(mob, /mob/new_player))
 		return //One extra layer of sanity
 	if(istype(mob,/mob/dead/observer))
-		var/reference = "<a href='?src=\ref[mob];follow=\ref[speaker]'>(Follow)</a> "
-		message = reference+message
+		var/reference = formatFollow(mob,speaker)
+		message = reference+" "+message
 		to_chat(mob, message)
 	else
 		to_chat(mob, message)

--- a/code/modules/bomberman/bomberman.dm
+++ b/code/modules/bomberman/bomberman.dm
@@ -987,28 +987,12 @@ var/global/list/arena_spawnpoints = list()//used by /mob/dead/observer/Logout()
 		message_admins("[key_name_admin(user.client)] created a \"[size]\" Bomberman arena at [center.loc.name] ([center.x],[center.y],[center.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[center.x];Y=[center.y];Z=[center.z]'>JMP</A>)")
 		log_game("[key_name_admin(user.client)] created a \"[size]\" Bomberman arena at [center.loc.name] ([center.x],[center.y],[center.z]) ")
 
-		if(!BT)
-			BT = new
 		for(var/mob/dead/observer/O in player_list)
-			to_chat(O, "<spawn class='notice'><b>[user.client.key] created a \"[size]\" Bomberman arena at [center.loc.name]. <A HREF='?src=\ref[BT];targetarena=\ref[src]'>Click here to JUMP to it.</A></b></span>")
+			to_chat(O, "<spawn class='notice'><b>[user.client.key] created a \"[size]\" Bomberman arena at [center.loc.name]. <A HREF='?src=\ref[SSmob];targetarena=\ref[src]'>Click here to JUMP to it.</A></b></span>")
 		return 1
 	else
 		qdel(src)
 		return 0
-
-var/datum/bomberman_topic/BT // global single item to persist for each check below
-
-/datum/bomberman_topic/Topic(href, href_list)
-	var/datum/bomberman_arena/targetarena = locate(href_list["targetarena"])
-	if(targetarena)
-		if(istype(usr,/mob/dead/observer))
-			var/mob/dead/observer/O = usr
-			if(O.locked_to)
-				O.manual_stop_follow(O.locked_to)
-			O.forceMove(targetarena.center)
-			to_chat(O, "Remember to enable darkness to be able to see the spawns. Click on a green spawn between rounds to register on it.")
-	else
-		to_chat(usr, "That arena doesn't seem to exist anymore.")
 
 /datum/bomberman_arena/proc/spawn_player(var/turf/T, var/mob/M)
 	M.forceMove(T)

--- a/code/modules/bomberman/bomberman.dm
+++ b/code/modules/bomberman/bomberman.dm
@@ -987,14 +987,28 @@ var/global/list/arena_spawnpoints = list()//used by /mob/dead/observer/Logout()
 		message_admins("[key_name_admin(user.client)] created a \"[size]\" Bomberman arena at [center.loc.name] ([center.x],[center.y],[center.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[center.x];Y=[center.y];Z=[center.z]'>JMP</A>)")
 		log_game("[key_name_admin(user.client)] created a \"[size]\" Bomberman arena at [center.loc.name] ([center.x],[center.y],[center.z]) ")
 
+		if(!BT)
+			BT = new
 		for(var/mob/dead/observer/O in player_list)
-			to_chat(O, "<spawn class='notice'><b>[user.client.key] created a \"[size]\" Bomberman arena at [center.loc.name]. <A HREF='?src=\ref[O];jumptoarenacood=1;targetarena=\ref[src]'>Click here to JUMP to it.</A></b></span>")
+			to_chat(O, "<spawn class='notice'><b>[user.client.key] created a \"[size]\" Bomberman arena at [center.loc.name]. <A HREF='?src=\ref[BT];targetarena=\ref[src]'>Click here to JUMP to it.</A></b></span>")
 		return 1
 	else
 		qdel(src)
 		return 0
 
+var/datum/bomberman_topic/BT // global single item to persist for each check below
 
+/datum/bomberman_topic/Topic(href, href_list)
+	var/datum/bomberman_arena/targetarena = locate(href_list["targetarena"])
+	if(targetarena)
+		if(istype(usr,/mob/dead/observer))
+			var/mob/dead/observer/O = usr
+			if(O.locked_to)
+				O.manual_stop_follow(O.locked_to)
+			O.forceMove(targetarena.center)
+			to_chat(O, "Remember to enable darkness to be able to see the spawns. Click on a green spawn between rounds to register on it.")
+	else
+		to_chat(usr, "That arena doesn't seem to exist anymore.")
 
 /datum/bomberman_arena/proc/spawn_player(var/turf/T, var/mob/M)
 	M.forceMove(T)

--- a/code/modules/events/immovablerod.dm
+++ b/code/modules/events/immovablerod.dm
@@ -89,7 +89,7 @@ var/list/all_rods = list()
 
 /obj/item/projectile/immovablerod/throw_at(atom/end)
 	for(var/mob/dead/observer/people in observers)
-		to_chat(people, "<span class = 'notice'>\A [src] has been thrown at the station, [formatFollow(people,src,"Follow it")]</span>")
+		to_chat(people, "<span class = 'notice'>\A [src] has been thrown at the station, [formatFollow(src,"Follow it")]</span>")
 	original = end
 	starting = loc
 	current = loc

--- a/code/modules/events/immovablerod.dm
+++ b/code/modules/events/immovablerod.dm
@@ -89,7 +89,7 @@ var/list/all_rods = list()
 
 /obj/item/projectile/immovablerod/throw_at(atom/end)
 	for(var/mob/dead/observer/people in observers)
-		to_chat(people, "<span class = 'notice'>\A [src] has been thrown at the station, <a href='?src=\ref[people];follow=\ref[src]'>Follow it</a></span>")
+		to_chat(people, "<span class = 'notice'>\A [src] has been thrown at the station, [formatFollow(people,src,"Follow it")]</span>")
 	original = end
 	starting = loc
 	current = loc

--- a/code/modules/events/old_vendotron_event/vendor_teleport_event.dm
+++ b/code/modules/events/old_vendotron_event/vendor_teleport_event.dm
@@ -64,7 +64,7 @@
 /obj/effect/old_vendotron_entrance/New()
 	..()
 	for(var/mob/dead/observer/people in observers)
-		to_chat(people, "<span class = 'notice'>\A [src] has been thrown at the station, <a href='?src=\ref[people];follow=\ref[src]'>Follow it</a></span>")
+		to_chat(people, "<span class = 'notice'>\A [src] has been thrown at the station, [formatFollow(people,src,"Follow it")]</span>")
 
 /obj/effect/old_vendotron_entrance/proc/aestheticEntrance()
 	animate(src, alpha = 255, transform = matrix()*2, time = 3 SECONDS)

--- a/code/modules/events/old_vendotron_event/vendor_teleport_event.dm
+++ b/code/modules/events/old_vendotron_event/vendor_teleport_event.dm
@@ -64,7 +64,7 @@
 /obj/effect/old_vendotron_entrance/New()
 	..()
 	for(var/mob/dead/observer/people in observers)
-		to_chat(people, "<span class = 'notice'>\A [src] has been thrown at the station, [formatFollow(people,src,"Follow it")]</span>")
+		to_chat(people, "<span class = 'notice'>\A [src] has been thrown at the station, [formatFollow(src,"Follow it")]</span>")
 
 /obj/effect/old_vendotron_entrance/proc/aestheticEntrance()
 	animate(src, alpha = 255, transform = matrix()*2, time = 3 SECONDS)

--- a/code/modules/hydroponics/seed_mobs.dm
+++ b/code/modules/hydroponics/seed_mobs.dm
@@ -43,13 +43,13 @@
 			continue
 
 		currently_querying |= O
-		to_chat(O, "<span class='recruit'>Someone is harvesting [display_name]. You have been added to the list of potential ghosts. (<a href='?src=\ref[O];jump=\ref[host]'>Teleport</a> | <a href='?src=\ref[src];signup=\ref[O]'>Retract</a>)</span>")
+		to_chat(O, "<span class='recruit'>Someone is harvesting [display_name]. You have been added to the list of potential ghosts. ([formatGhostJump(host)] | <a href='?src=\ref[src];signup=\ref[O]'>Retract</a>)</span>")
 
 	for(var/mob/dead/observer/O in dead_mob_list - active_candidates)
 		if(!check_observer(O))
 			continue
 
-		to_chat(O, "<span class='recruit'>Someone is harvesting [display_name]. (<a href='?src=\ref[O];jump=\ref[host]'>Teleport</a> | <a href='?src=\ref[src];signup=\ref[O]'>Sign up</a>)</span>")
+		to_chat(O, "<span class='recruit'>Someone is harvesting [display_name]. ([formatGhostJump(host)] | <a href='?src=\ref[src];signup=\ref[O]'>Sign up</a>)</span>")
 
 	spawn(600)
 		if(!currently_querying || !currently_querying.len)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -413,12 +413,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/proc/manual_follow(var/atom/movable/target)
 	if(target)
 		var/turf/targetloc = get_turf(target)
+		if(targetloc && targetloc.holy && (!invisibility || islegacycultist(src)))
+			to_chat(usr, "<span class='warning'>You cannot follow a mob standing on holy grounds!</span>")
+			return
 		var/area/targetarea = get_area(target)
 		if(targetarea && targetarea.anti_ethereal && !isAdminGhost(usr))
 			to_chat(usr, "<span class='sinister'>You can sense a sinister force surrounding that mob, your spooky body itself refuses to follow it.</span>")
-			return
-		if(targetloc && targetloc.holy && (!invisibility || islegacycultist(src)))
-			to_chat(usr, "<span class='warning'>You cannot follow a mob standing on holy grounds!</span>")
 			return
 		if(target != src)
 			if(locked_to)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -473,7 +473,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			return
 
 		if (href_list["jump"])
-			var/mob/target = locate(href_list["jump"])
+			var/target = locate(href_list["jump"])
 			if(target && target != usr)
 				to_chat(O, "Teleporting to [target]...")
 				var/turf/pos = get_turf(O)
@@ -486,7 +486,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 						O.manual_stop_follow(O.locked_to)
 					O.forceMove(T)
 			else
-				to_chat(O, "That mob doesn't seem to exist anymore, or is you.")
+				to_chat(O, "That thing doesn't seem to exist anymore, or is you.")
 			return
 
 		if(href_list["targetarena"])

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -468,23 +468,26 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 					var/mob/living/silicon/ai/M = target
 					target = M.eyeobj
 				O.manual_follow(target)
-				return
+			else
+				to_chat(O, "That mob doesn't seem to exist anymore.")
+			return
 
 		if (href_list["jump"])
 			var/mob/target = locate(href_list["jump"])
-			var/mob/A = usr;
-			to_chat(A, "Teleporting to [target]...")
 			if(target && target != usr)
-				var/turf/pos = get_turf(A)
+				to_chat(A, "Teleporting to [target]...")
+				var/turf/pos = get_turf(O)
 				var/turf/T=get_turf(target)
 				if(T != pos)
 					if(!T)
-						to_chat(A, "<span class='warning'>Target not in a turf.</span>")
+						to_chat(O, "<span class='warning'>Target not in a turf.</span>")
 						return
 					if(O.locked_to)
 						O.manual_stop_follow(O.locked_to)
 					O.forceMove(T)
-					return
+			else
+				to_chat(O, "That mob doesn't seem to exist anymore, or is you.")
+			return
 
 		if(href_list["targetarena"])
 			var/datum/bomberman_arena/targetarena = locate(href_list["targetarena"])

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -453,33 +453,37 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			if(istype(A))
 				A.reenter_corpse()
 
-	//BEGIN TELEPORT HREF CODE
 	if(usr != src)
 		return
 	..()
 
-	if(href_list["follow"])
-		var/target = locate(href_list["follow"])
-		if(target)
-			if(isAI(target))
-				var/mob/living/silicon/ai/M = target
-				target = M.eyeobj
-			manual_follow(target)
+//BEGIN TELEPORT HREF CODE
+/datum/subsystem/mob/Topic(href, href_list)
+	if(istype(usr,/mob/dead/observer))
+		var/mob/dead/observer/O = usr
+		if(href_list["follow"])
+			var/target = locate(href_list["follow"])
+			if(target)
+				if(isAI(target))
+					var/mob/living/silicon/ai/M = target
+					target = M.eyeobj
+				O.manual_follow(target)
 
-	if (href_list["jump"])
-		var/mob/target = locate(href_list["jump"])
-		var/mob/A = usr;
-		to_chat(A, "Teleporting to [target]...")
-		if(target && target != usr)
-			var/turf/pos = get_turf(A)
-			var/turf/T=get_turf(target)
-			if(T != pos)
-				if(!T)
-					to_chat(A, "<span class='warning'>Target not in a turf.</span>")
-					return
-				if(locked_to)
-					manual_stop_follow(locked_to)
-				forceMove(T)
+		if (href_list["jump"])
+			var/mob/target = locate(href_list["jump"])
+			var/mob/A = usr;
+			to_chat(A, "Teleporting to [target]...")
+			if(target && target != usr)
+				var/turf/pos = get_turf(A)
+				var/turf/T=get_turf(target)
+				if(T != pos)
+					if(!T)
+						to_chat(A, "<span class='warning'>Target not in a turf.</span>")
+						return
+					if(O.locked_to)
+						O.manual_stop_follow(O.locked_to)
+					O.forceMove(T)
+	return ..()
 
 //END TELEPORT HREF CODE
 
@@ -522,7 +526,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if (get_dist(source_turf, src) <= world.view) // If this isn't true, we can't be in view, so no need for costlier proc.
 		if (source_turf in view(src))
 			rendered_speech = "<B>[rendered_speech]</B>"
-			to_chat(src, "[formatFollow(src,source)] [rendered_speech]")
+			to_chat(src, "[formatFollow(source)] [rendered_speech]")
 
 /mob/dead/observer/hasHUD(var/hud_kind)
 	switch(hud_kind)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -532,7 +532,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if (get_dist(source_turf, src) <= world.view) // If this isn't true, we can't be in view, so no need for costlier proc.
 		if (source_turf in view(src))
 			rendered_speech = "<B>[rendered_speech]</B>"
-			to_chat(src, "<a href='?src=\ref[src];follow=\ref[source]'>(Follow)</a> [rendered_speech]")
+			to_chat(src, "[formatFollow(src,source)] [rendered_speech]")
 
 /mob/dead/observer/hasHUD(var/hud_kind)
 	switch(hud_kind)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -496,7 +496,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 				if(O.locked_to)
 					O.manual_stop_follow(O.locked_to)
 				O.forceMove(targetarena.center)
-				to_chat(O, "Remember to enable darkness to be able to see the spawns. Click on a green spawn between rounds to register on it.")
+				to_chat(O, "Click on a green spawn between rounds to register on it.")
 			else
 				to_chat(O, "That arena doesn't seem to exist anymore.")
 			return

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -466,7 +466,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			if(target)
 				if(isAI(target))
 					var/mob/living/silicon/ai/M = target
-					target = M.eyeobj
+					if(!istype(M.loc,/obj/item/device/aicard))
+						target = M.eyeobj
 				O.manual_follow(target)
 			else
 				to_chat(O, "That mob doesn't seem to exist anymore.")

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -485,6 +485,17 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 						O.manual_stop_follow(O.locked_to)
 					O.forceMove(T)
 					return
+
+		if(href_list["targetarena"])
+			var/datum/bomberman_arena/targetarena = locate(href_list["targetarena"])
+			if(targetarena)
+				if(O.locked_to)
+					O.manual_stop_follow(O.locked_to)
+				O.forceMove(targetarena.center)
+				to_chat(O, "Remember to enable darkness to be able to see the spawns. Click on a green spawn between rounds to register on it.")
+			else
+				to_chat(O, "That arena doesn't seem to exist anymore.")
+			return
 	return ..()
 
 //END TELEPORT HREF CODE

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -481,16 +481,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 					manual_stop_follow(locked_to)
 				forceMove(T)
 
-	if(href_list["jumptoarenacood"])
-		var/datum/bomberman_arena/targetarena = locate(href_list["targetarena"])
-		if(targetarena)
-			if(locked_to)
-				manual_stop_follow(locked_to)
-			usr.forceMove(targetarena.center)
-			to_chat(usr, "Remember to enable darkness to be able to see the spawns. Click on a green spawn between rounds to register on it.")
-		else
-			to_chat(usr, "That arena doesn't seem to exist anymore.")
-
 //END TELEPORT HREF CODE
 
 /mob/dead/observer/html_mob_check()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -475,7 +475,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if (href_list["jump"])
 			var/mob/target = locate(href_list["jump"])
 			if(target && target != usr)
-				to_chat(A, "Teleporting to [target]...")
+				to_chat(O, "Teleporting to [target]...")
 				var/turf/pos = get_turf(O)
 				var/turf/T=get_turf(target)
 				if(T != pos)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -468,6 +468,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 					var/mob/living/silicon/ai/M = target
 					target = M.eyeobj
 				O.manual_follow(target)
+				return
 
 		if (href_list["jump"])
 			var/mob/target = locate(href_list["jump"])
@@ -483,6 +484,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 					if(O.locked_to)
 						O.manual_stop_follow(O.locked_to)
 					O.forceMove(T)
+					return
 	return ..()
 
 //END TELEPORT HREF CODE

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -54,4 +54,4 @@
 					say_testing(src, "/mob/dead/observer/Hear(): CHAT_GHOSTRADIO is disabled, blocking. ([client.prefs.toggles] & [CHAT_GHOSTRADIO]) = [client.prefs.toggles & CHAT_GHOSTRADIO]")
 					return
 
-	to_chat(src, "[formatFollow(src,source)] [rendered_speech]")
+	to_chat(src, "[formatFollow(source)] [rendered_speech]")

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -54,4 +54,4 @@
 					say_testing(src, "/mob/dead/observer/Hear(): CHAT_GHOSTRADIO is disabled, blocking. ([client.prefs.toggles] & [CHAT_GHOSTRADIO]) = [client.prefs.toggles & CHAT_GHOSTRADIO]")
 					return
 
-	to_chat(src, "<a href='?src=\ref[src];follow=\ref[source]'>(Follow)</a> [rendered_speech]")
+	to_chat(src, "[formatFollow(src,source)] [rendered_speech]")

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -67,7 +67,7 @@
 			var/mindname = (src.mind && src.mind.name) ? "[src.mind.name]" : "[real_name]"
 			var/died_as = (mindname == real_name) ? "" : " (died as [real_name])"
 			for(var/mob/M in get_deadchat_hearers())
-				var/rendered = "\proper[formatFollow(M,src)] <span class='game deadsay'> \The <span class='name'>[mindname][died_as]</span> has died at \the <span class='name'>[get_area(place_of_death)]</span>.</span>"
+				var/rendered = "\proper[formatFollow(src)] <span class='game deadsay'> \The <span class='name'>[mindname][died_as]</span> has died at \the <span class='name'>[get_area(place_of_death)]</span>.</span>"
 				to_chat(M, rendered)
 			log_game("[key_name(src)] has died at [get_area(place_of_death)]. Coordinates: ([get_coordinates_string(src)])")
 		is_dying = FALSE

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -67,7 +67,7 @@
 			var/mindname = (src.mind && src.mind.name) ? "[src.mind.name]" : "[real_name]"
 			var/died_as = (mindname == real_name) ? "" : " (died as [real_name])"
 			for(var/mob/M in get_deadchat_hearers())
-				var/rendered = "\proper<a href='?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>(Follow)</a><span class='game deadsay'> \The <span class='name'>[mindname][died_as]</span> has died at \the <span class='name'>[get_area(place_of_death)]</span>.</span>"
+				var/rendered = "\proper[formatFollow(M,src)] <span class='game deadsay'> \The <span class='name'>[mindname][died_as]</span> has died at \the <span class='name'>[get_area(place_of_death)]</span>.</span>"
 				to_chat(M, rendered)
 			log_game("[key_name(src)] has died at [get_area(place_of_death)]. Coordinates: ([get_coordinates_string(src)])")
 		is_dying = FALSE

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -73,7 +73,7 @@
 		if (!M.client)
 			continue //skip leavers
 		if(isobserver(M) && M.client.prefs && (M.client.prefs.toggles & CHAT_GHOSTSIGHT) && !(M in viewers(user)))
-			M.show_message(formatFollow(M,user) + " " + msg)
+			M.show_message(formatFollow(user) + " " + msg)
 
 	if(emote_type & EMOTE_VISIBLE)
 		user.visible_message(msg)

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -73,7 +73,7 @@
 		if (!M.client)
 			continue //skip leavers
 		if(isobserver(M) && M.client.prefs && (M.client.prefs.toggles & CHAT_GHOSTSIGHT) && !(M in viewers(user)))
-			M.show_message("<a href='?src=\ref[M];follow=\ref[user]'>(Follow)</a> " + msg)
+			M.show_message(formatFollow(M,user) + " " + msg)
 
 	if(emote_type & EMOTE_VISIBLE)
 		user.visible_message(msg)

--- a/code/modules/mob/living/carbon/alien/larva/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/larva/alien_embryo.dm
@@ -19,7 +19,7 @@
 		for(var/mob/dead/observer/O in get_active_candidates(ROLE_ALIEN,poll="[affected_mob] has been infected by \a [src]!"))
 			if(O.client && O.client.desires_role(ROLE_ALIEN))
 				if(check_observer(O))
-					to_chat(O, "<span class=\"recruit\">You have automatically been signed up for \a [src]. (<a href='?src=\ref[O];jump=\ref[src]'>Teleport</a> | <a href='?src=\ref[src];signup=\ref[O]'>Retract</a>)</span>")
+					to_chat(O, "<span class=\"recruit\">You have automatically been signed up for \a [src]. ([formatGhostJump(src)] | <a href='?src=\ref[src];signup=\ref[O]'>Retract</a>)</span>")
 					ghost_volunteers += O
 		spawn(0)
 			AddInfectionImages(affected_mob)
@@ -135,7 +135,7 @@
 			picked = affected_mob.key //Pick the person who was infected
 		else
 			for(var/mob/dead/observer/O in candidates)
-				to_chat(O, "<span class=\"recruit\">\a [src] is about to burst out of \the [affected_mob]!(<a href='?src=\ref[O];jump=\ref[src]'>Teleport</a> | <a href='?src=\ref[src];signup=\ref[O]'>Sign Up</a>)</span>")
+				to_chat(O, "<span class=\"recruit\">\a [src] is about to burst out of \the [affected_mob]!([formatGhostJump(src)] | <a href='?src=\ref[src];signup=\ref[O]'>Sign Up</a>)</span>")
 
 	else
 		picked = ghostpicked.key
@@ -143,7 +143,7 @@
 		stage = 4 // Let's try again later.
 		var/list/candidates = get_active_candidates(ROLE_ALIEN, buffer=ALIEN_SELECT_AFK_BUFFER, poll=1)
 		for(var/mob/dead/observer/O in candidates) //Shiggy
-			to_chat(O, "<span class=\"recruit\">\a [src] is about to burst out of \the [affected_mob]!(<a href='?src=\ref[O];jump=\ref[src]'>Teleport</a> | <a href='?src=\ref[src];signup=\ref[O]'>Sign Up</a>)</span>")
+			to_chat(O, "<span class=\"recruit\">\a [src] is about to burst out of \the [affected_mob]!([formatGhostJump(src)] | <a href='?src=\ref[src];signup=\ref[O]'>Sign Up</a>)</span>")
 		return
 
 	if(affected_mob.lying)

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -960,7 +960,7 @@
 		if(O.client)
 			var/area/A = get_area(src)
 			if(A)
-				to_chat(O, "<span class=\"recruit\">Golem rune created in [A.name]. (<a href='?src=\ref[O];jump=\ref[src]'>Teleport</a> | <a href='?src=\ref[src];signup=\ref[O]'>Sign Up</a>)</span>")
+				to_chat(O, "<span class=\"recruit\">Golem rune created in [A.name]. ([formatGhostJump(src)] | <a href='?src=\ref[src];signup=\ref[O]'>Sign Up</a>)</span>")
 
 /obj/effect/golem_rune/Topic(href,href_list)
 	if("signup" in href_list)

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -197,7 +197,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 	for(var/mob/dead/observer/O in player_list) // We handle polling ourselves.
 		if(O.client && get_role_desire_str(O.client.prefs.roles[ROLE_PAI]) != "Never")
 			if(check_recruit(O))
-				to_chat(O, "<span class='recruit'>A pAI card is looking for personalities. (<a href='?src=\ref[src];signup=1'>Sign Up</a> | <a href='?src=\ref[O];follow=\ref[p]'>Teleport</a>)</span>")
+				to_chat(O, "<span class='recruit'>A pAI card is looking for personalities. (<a href='?src=\ref[src];signup=1'>Sign Up</a> | [formatFollow(O,p,"Teleport")])</span>")
 				//question(O.client)
 
 /datum/paiController/proc/check_recruit(var/mob/dead/observer/O)

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -197,7 +197,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 	for(var/mob/dead/observer/O in player_list) // We handle polling ourselves.
 		if(O.client && get_role_desire_str(O.client.prefs.roles[ROLE_PAI]) != "Never")
 			if(check_recruit(O))
-				to_chat(O, "<span class='recruit'>A pAI card is looking for personalities. (<a href='?src=\ref[src];signup=1'>Sign Up</a> | [formatFollow(O,p,"Teleport")])</span>")
+				to_chat(O, "<span class='recruit'>A pAI card is looking for personalities. (<a href='?src=\ref[src];signup=1'>Sign Up</a> | [formatFollow(p,"Teleport")])</span>")
 				//question(O.client)
 
 /datum/paiController/proc/check_recruit(var/mob/dead/observer/O)

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -332,7 +332,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 			if(istype(M, /mob/new_player))
 				continue
 			if(istype(M,/mob/dead/observer)  && (M.client && M.client.prefs.toggles & CHAT_GHOSTEARS || (get_turf(src) in view(M))))
-				var/controls = "<a href='byond://?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>Follow</a>"
+				var/controls = formatFollow(M,src,"Follow")
 				if(M.client.holder)
 					controls+= " | <A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>"
 				var/rendered="<span class='borer'>Thought-speech, <b>[truename]</b> ([controls]) in <b>[host]</b>'s [limb_to_name(hostlimb)]: [encoded_message]</span>"

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -332,7 +332,7 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 			if(istype(M, /mob/new_player))
 				continue
 			if(istype(M,/mob/dead/observer)  && (M.client && M.client.prefs.toggles & CHAT_GHOSTEARS || (get_turf(src) in view(M))))
-				var/controls = formatFollow(M,src,"Follow")
+				var/controls = formatFollow(src,"Follow")
 				if(M.client.holder)
 					controls+= " | <A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>"
 				var/rendered="<span class='borer'>Thought-speech, <b>[truename]</b> ([controls]) in <b>[host]</b>'s [limb_to_name(hostlimb)]: [encoded_message]</span>"

--- a/code/modules/mob/living/simple_animal/borer/captive_brain.dm
+++ b/code/modules/mob/living/simple_animal/borer/captive_brain.dm
@@ -23,7 +23,7 @@
 			if(istype(M, /mob/new_player))
 				continue
 			if(istype(M,/mob/dead/observer)  && (M.client && M.client.prefs.toggles & CHAT_GHOSTEARS))
-				var/controls = "<a href='byond://?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>Follow</a>"
+				var/controls = formatFollow(M,src,"Follow")
 				if(M.client.holder)
 					controls+= " | <A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>"
 				var/rendered="<span class='thoughtspeech'>Thought-speech, <b>[src.name]</b> ([controls]) -> <b>[B.truename]:</b> [message]</span>"

--- a/code/modules/mob/living/simple_animal/borer/captive_brain.dm
+++ b/code/modules/mob/living/simple_animal/borer/captive_brain.dm
@@ -23,7 +23,7 @@
 			if(istype(M, /mob/new_player))
 				continue
 			if(istype(M,/mob/dead/observer)  && (M.client && M.client.prefs.toggles & CHAT_GHOSTEARS))
-				var/controls = formatFollow(M,src,"Follow")
+				var/controls = formatFollow(src,"Follow")
 				if(M.client.holder)
 					controls+= " | <A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>"
 				var/rendered="<span class='thoughtspeech'>Thought-speech, <b>[src.name]</b> ([controls]) -> <b>[B.truename]:</b> [message]</span>"

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -74,7 +74,7 @@ var/list/global_deadchat_listeners = list()
 	log_say("[name]/[key_name(src)] (@[location_text]) Deadsay: [message]")
 
 	for(var/mob/M in get_deadchat_hearers())
-		to_chat(M, "[formatFollow(M,src)] <span class='name'>[name]</span>[alt_name] <span class='message'>[message]</span></span>")
+		to_chat(M, "[formatFollow(src)] <span class='name'>[name]</span>[alt_name] <span class='message'>[message]</span></span>")
 
 /mob/proc/get_ear()
 	// returns an atom representing a location on the map from which this

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -73,12 +73,8 @@ var/list/global_deadchat_listeners = list()
 	var/location_text = get_coordinates_string(src)
 	log_say("[name]/[key_name(src)] (@[location_text]) Deadsay: [message]")
 
-	var/list/hearers = get_deadchat_hearers()
-	if(hearers)
-		for(var/mob/M in hearers)
-			var/rendered = "<span class='game deadsay'><a href='byond://?src=\ref[M];follow2=\ref[M];follow=\ref[src]'>(Follow)</a>"
-			rendered += "<span class='name'> [name]</span>[alt_name] <span class='message'>[message]</span></span>"
-			to_chat(M, rendered)
+	for(var/mob/M in get_deadchat_hearers())
+		to_chat(M, "[formatFollow(M,src)] <span class='name'>[name]</span>[alt_name] <span class='message'>[message]</span></span>")
 
 /mob/proc/get_ear()
 	// returns an atom representing a location on the map from which this

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -977,17 +977,8 @@ var/list/obj/machinery/singularity/white_hole_candidates
 			qdel(target_singulo)
 
 			var/message = "<span class='recruit'>An admin has begun DEADCHAT-CONTROLLED SINGULARITY!<br>It is on <b>ANARCHY</b> mode.<br>Simply type UP, DOWN, LEFT, or RIGHT to move the singularity.<br>Cooldown per person is currently [new_singulo.input_cooldown/10] seconds.<br>"
-			for(var/mob/M in player_list)
-				if(istype(M, /mob/new_player) || !M.client)
-					continue
-				if(M.client && M.client.holder && M.client.holder.rights & R_ADMIN && (M.client.prefs.toggles & CHAT_DEAD)) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only give to Administrators and above
-					to_chat(M, message + "<a href='?src=\ref[M];follow=\ref[new_singulo]'>(Follow)</a>")
-				else if(M.client && M.stat == DEAD && !istype(M, /mob/dead/observer/deafmute) && (M.client.prefs.toggles & CHAT_DEAD))
-					to_chat(M, message + "<a href='?src=\ref[M];follow=\ref[new_singulo]'>(Follow)</a>")
-				else if(M.client && istype(M,/mob/living/carbon/brain) && (M.client.prefs.toggles & CHAT_DEAD))
-					var/mob/living/carbon/brain/B = M
-					if(B.brain_dead_chat())
-						to_chat(M, message + "<a href='?src=\ref[M];follow=\ref[new_singulo]'>(Follow)</a>")
+			for(var/mob/M in get_deadchat_hearers())
+				to_chat(M, message + formatFollow(M,new_singulo))
 		else if(option_chosen == "Democracy")
 			var/interval = input("Please enter the interval that the singulo makes a move in seconds.", "Interval") as num
 			if(!interval)
@@ -1011,17 +1002,8 @@ var/list/obj/machinery/singularity/white_hole_candidates
 			qdel(target_singulo)
 
 			var/message = "<span class='recruit'>An admin has begun DEADCHAT-CONTROLLED SINGULARITY!<br>It is on <b>DEMOCRACY</b> mode.<br>Simply type UP, DOWN, LEFT, or RIGHT to cast a vote on which direction it should move. Your vote will be your latest message.<br>The singulo will move every [new_singulo.democracy_cooldown/10] seconds. Votes start now!<br>"
-			for(var/mob/M in player_list)
-				if(istype(M, /mob/new_player) || !M.client)
-					continue
-				if(M.client && M.client.holder && M.client.holder.rights & R_ADMIN && (M.client.prefs.toggles & CHAT_DEAD))
-					to_chat(M, message + "<a href='?src=\ref[M];follow=\ref[new_singulo]'>(Follow)</a>")
-				else if(M.client && M.stat == DEAD && !istype(M, /mob/dead/observer/deafmute) && (M.client.prefs.toggles & CHAT_DEAD))
-					to_chat(M, message + "<a href='?src=\ref[M];follow=\ref[new_singulo]'>(Follow)</a>")
-				else if(M.client && istype(M,/mob/living/carbon/brain) && (M.client.prefs.toggles & CHAT_DEAD))
-					var/mob/living/carbon/brain/B = M
-					if(B.brain_dead_chat())
-						to_chat(M, message + "<a href='?src=\ref[M];follow=\ref[new_singulo]'>(Follow)</a>")
+			for(var/mob/M in get_deadchat_hearers())
+				to_chat(M, message + formatFollow(M,new_singulo))
 
 /obj/machinery/singularity/special
 	name = "specialarity"

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -978,7 +978,7 @@ var/list/obj/machinery/singularity/white_hole_candidates
 
 			var/message = "<span class='recruit'>An admin has begun DEADCHAT-CONTROLLED SINGULARITY!<br>It is on <b>ANARCHY</b> mode.<br>Simply type UP, DOWN, LEFT, or RIGHT to move the singularity.<br>Cooldown per person is currently [new_singulo.input_cooldown/10] seconds.<br>"
 			for(var/mob/M in get_deadchat_hearers())
-				to_chat(M, message + formatFollow(M,new_singulo))
+				to_chat(M, message + formatFollow(new_singulo))
 		else if(option_chosen == "Democracy")
 			var/interval = input("Please enter the interval that the singulo makes a move in seconds.", "Interval") as num
 			if(!interval)
@@ -1003,7 +1003,7 @@ var/list/obj/machinery/singularity/white_hole_candidates
 
 			var/message = "<span class='recruit'>An admin has begun DEADCHAT-CONTROLLED SINGULARITY!<br>It is on <b>DEMOCRACY</b> mode.<br>Simply type UP, DOWN, LEFT, or RIGHT to cast a vote on which direction it should move. Your vote will be your latest message.<br>The singulo will move every [new_singulo.democracy_cooldown/10] seconds. Votes start now!<br>"
 			for(var/mob/M in get_deadchat_hearers())
-				to_chat(M, message + formatFollow(M,new_singulo))
+				to_chat(M, message + formatFollow(new_singulo))
 
 /obj/machinery/singularity/special
 	name = "specialarity"

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -354,10 +354,10 @@ For the main html chat area
 				if(B.brain_dead_chat())
 					. += M
 
-/proc/formatFollow(var/mob/source,var/mob/target,var/custom_text="(Follow)")
+/proc/formatFollow(var/mob/target,var/custom_text="(Follow)")
 	return "<a href='?src=\ref[SSmob];follow=\ref[target]'>[custom_text]</a>"
 
-/proc/formatGhostJump(var/mob/source,var/mob/target,var/custom_text="Teleport")
+/proc/formatGhostJump(var/mob/target,var/custom_text="Teleport")
 	return "<a href='?src=\ref[SSmob];jump=\ref[target]'>[custom_text]</a>"
 
 /* This proc only handles sending the message to everyone who can hear deadchat. Formatting that message is up to you! Consider using <span class='game deadsay'></span> on your message! */

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -355,7 +355,10 @@ For the main html chat area
 					. += M
 
 /proc/formatFollow(var/mob/source,var/mob/target,var/custom_text="(Follow)")
-	return "<a href='?src=\ref[source];follow=\ref[target]'>[custom_text]</a>"
+	return "<a href='?src=\ref[SSmob];follow=\ref[target]'>[custom_text]</a>"
+
+/proc/formatGhostJump(var/mob/source,var/mob/target,var/custom_text="Teleport")
+	return "<a href='?src=\ref[SSmob];jump=\ref[target]'>[custom_text]</a>"
 
 /* This proc only handles sending the message to everyone who can hear deadchat. Formatting that message is up to you! Consider using <span class='game deadsay'></span> on your message! */
 /* Kinda useless if your message needs to include an href, though... */

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -337,7 +337,7 @@ For the main html chat area
 		target << output(url_encode(message), "browseroutput:output")
 
 /proc/get_deadchat_hearers()
-	var/list/hearers = list()
+	. = list()
 	for(var/mob/M in player_list)
 		if(!M.client)
 			continue
@@ -346,18 +346,16 @@ For the main html chat area
 
 		else if(M.client.prefs.toggles & CHAT_DEAD)
 			if(M.client.holder && M.client.holder.rights & R_ADMIN) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only give to Administrators and above
-				hearers += M
-				continue
+				. += M
 			else if(M.stat == DEAD && !istype(M, /mob/dead/observer/deafmute))
-				hearers += M
-				continue
+				. += M
 			else if(istype(M,/mob/living/carbon/brain))
 				var/mob/living/carbon/brain/B = M
 				if(B.brain_dead_chat())
-					hearers += M
-					continue
-	. = hearers
-	return .
+					. += M
+
+/proc/formatFollow(var/mob/source,var/mob/target,var/custom_text="(Follow)")
+	return "<a href='?src=\ref[source];follow=\ref[target]'>[custom_text]</a>"
 
 /* This proc only handles sending the message to everyone who can hear deadchat. Formatting that message is up to you! Consider using <span class='game deadsay'></span> on your message! */
 /* Kinda useless if your message needs to include an href, though... */


### PR DESCRIPTION
[bugfix][qol]

## What this does
makes old (follow) links you saw in deadchat as a ghost still work if you're a different ghost mob object later in the round (such as from even re entering and exiting your corpse)
Closes #31973.

## How it was tested
roundstart, wait for station pets to emote, follow them, possess a different one, ghost, then follow again.
AIizing self as human, saying something, adminghosting, spawning test dummy with intellicard beside it after ghosting, carding it, ghosting again, following the AI from the heard speech's old follow link.

## Changelog
:cl:
 * bugfix: The (follow), teleport and bomberman arena links in ghost chat no longer fail to work if the ghost re enters their corpse and exits it again.
 * bugfix: Following a carded AI will now actually send you to the AI card.
 * tweak: The (follow) and teleport deadchat links now inform the user if their targets no longer exist.