### PR TITLE
Possess/release fixes

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -295,7 +295,7 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/enable_debug_verbs,
 	/client/proc/mob_list,
 	/client/proc/possess,
-	/proc/release,
+	/client/proc/release,
 	/client/proc/gc_dump_hdl,
 	/client/proc/create_map_element
 	)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -223,8 +223,7 @@ var/list/admin_verbs_debug = list(
 	/client/proc/edit_motd,
 	)
 var/list/admin_verbs_possess = list(
-	/proc/possess,
-	/proc/release
+	/client/proc/possess
 	)
 var/list/admin_verbs_permissions = list(
 	/client/proc/edit_admin_permissions
@@ -295,7 +294,7 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/cmd_debug_tog_aliens,
 	/client/proc/enable_debug_verbs,
 	/client/proc/mob_list,
-	/proc/possess,
+	/client/proc/possess,
 	/proc/release,
 	/client/proc/gc_dump_hdl,
 	/client/proc/create_map_element

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -295,7 +295,6 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/enable_debug_verbs,
 	/client/proc/mob_list,
 	/client/proc/possess,
-	/client/proc/release,
 	/client/proc/gc_dump_hdl,
 	/client/proc/create_map_element
 	)

--- a/code/modules/admin/verbs/possess.dm
+++ b/code/modules/admin/verbs/possess.dm
@@ -49,8 +49,8 @@
 
 	mob.forceMove(thing.loc) // Appear where the object you were controlling is -- TLE
 	mob.client.eye = mob
-	mob.verbs -= /client/proc/release
 	mob.verbs += /client/proc/possess
+	mob.verbs -= /client/proc/release
 
 	if(actual)
 		actual.break_control()

--- a/code/modules/admin/verbs/possess.dm
+++ b/code/modules/admin/verbs/possess.dm
@@ -1,51 +1,56 @@
-/proc/possess(obj/O as obj in world)
+/client/proc/possess(obj/O as obj in world)
 	set name = "Possess Obj"
 	set category = "Object"
 
 	if(istype(O,/obj/machinery/singularity))
 		if(config.forbid_singulo_possession)
-			to_chat(usr, "It is forbidden to possess singularities.")
+			to_chat(mob, "It is forbidden to possess singularities.")
 			return
 
 	var/turf/T = get_turf(O)
 
 	if(T)
-		log_admin("[key_name(usr)] has possessed [O] ([O.type]) at ([T.x], [T.y], [T.z])")
-		message_admins("[key_name(usr)] has possessed [O] ([O.type]) at ([T.x], [T.y], [T.z])", 1)
+		log_admin("[key_name(mob)] has possessed [O] ([O.type]) at ([T.x], [T.y], [T.z])")
+		message_admins("[key_name(mob)] has possessed [O] ([O.type]) at ([T.x], [T.y], [T.z])", 1)
 	else
-		log_admin("[key_name(usr)] has possessed [O] ([O.type]) at an unknown location")
-		message_admins("[key_name(usr)] has possessed [O] ([O.type]) at an unknown location", 1)
+		log_admin("[key_name(mob)] has possessed [O] ([O.type]) at an unknown location")
+		message_admins("[key_name(mob)] has possessed [O] ([O.type]) at an unknown location", 1)
 
-	if(!usr.control_object.len) //If you're not already possessing something...
-		usr.name_archive = usr.real_name
+	if(!mob.control_object.len) //If you're not already possessing something...
+		mob.name_archive = mob.real_name
 
-	usr.forceMove(O)
-	usr.real_name = O.name
-	usr.name = O.name
-	var/datum/control/new_control = new /datum/control/lock_move(usr, O)
-	usr.control_object.Add(new_control)
+	mob.forceMove(O)
+	mob.real_name = O.name
+	mob.name = O.name
+	var/datum/control/new_control = new /datum/control/lock_move(mob, O)
+	mob.control_object.Add(new_control)
+	mob.verbs += /client/proc/release
+	mob.verbs -= /client/proc/possess
 	new_control.take_control()
+	O.register_event(/event/destroyed, src, nameof(src::release()))
 	feedback_add_details("admin_verb","PO") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/proc/release(obj/O as obj in world)
+/client/proc/release(obj/O as obj in world)
 	set name = "Release Obj"
 	set category = "Object"
-	//usr.loc = get_turf(usr)
+	//mob.loc = get_turf(mob)
 	var/datum/control/actual
-	for(var/datum/control/C in usr.control_object)
+	for(var/datum/control/C in mob.control_object)
 		if(C.controlled == O)
 			actual = C
 			break
-	if(actual && usr.name_archive) //if you have a name archived and if you are actually relassing an object
-		usr.real_name = usr.name_archive
-		usr.name = usr.real_name
-		if(ishuman(usr))
-			var/mob/living/carbon/human/H = usr
+	if(actual && mob.name_archive) //if you have a name archived and if you are actually relassing an object
+		mob.real_name = mob.name_archive
+		mob.name = mob.real_name
+		if(ishuman(mob))
+			var/mob/living/carbon/human/H = mob
 			H.update_name()
-//		usr.regenerate_icons() //So the name is updated properly
+//		mob.regenerate_icons() //So the name is updated properly
 
-	usr.forceMove(O.loc) // Appear where the object you were controlling is -- TLE
-	usr.client.eye = usr
+	mob.forceMove(O.loc) // Appear where the object you were controlling is -- TLE
+	mob.client.eye = mob
+	mob.verbs -= /client/proc/release
+	mob.verbs += /client/proc/possess
 
 	if(actual)
 		actual.break_control()
@@ -56,6 +61,5 @@
 	set desc = "Give this guy possess/release verbs"
 	set category = "Debug"
 	set name = "Give Possessing Verbs"
-	M.verbs += /proc/possess
-	M.verbs += /proc/release
+	M.verbs += /client/proc/possess
 	feedback_add_details("admin_verb","GPV") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/possess.dm
+++ b/code/modules/admin/verbs/possess.dm
@@ -1,5 +1,5 @@
 /client
-	var/possessing = 0
+	var/atom/possessing = null
 
 /client/proc/possess(obj/thing as obj in world)
 	set name = "Possess/Release Object"
@@ -23,7 +23,7 @@
 
 		mob.forceMove(thing.loc) // Appear where the object you were controlling is -- TLE
 		mob.client.eye = mob
-		possessing = 0
+		possessing = null
 		thing.unregister_event(/event/destroyed, src, nameof(src::possess()))
 
 		if(actual)
@@ -48,7 +48,7 @@
 		mob.name = thing.name
 		var/datum/control/new_control = new /datum/control/lock_move(mob, thing)
 		mob.control_object.Add(new_control)
-		possessing = 1
+		possessing = thing
 		new_control.take_control()
 		thing.register_event(/event/destroyed, src, nameof(src::possess()))
 		feedback_add_details("admin_verb","PO") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/possess.dm
+++ b/code/modules/admin/verbs/possess.dm
@@ -30,13 +30,13 @@
 	O.register_event(/event/destroyed, src, nameof(src::release()))
 	feedback_add_details("admin_verb","PO") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/proc/release(obj/O as obj in world)
+/client/proc/release(obj/thing as obj in world)
 	set name = "Release Obj"
 	set category = "Object"
 	//mob.loc = get_turf(mob)
 	var/datum/control/actual
 	for(var/datum/control/C in mob.control_object)
-		if(C.controlled == O)
+		if(C.controlled == thing)
 			actual = C
 			break
 	if(actual && mob.name_archive) //if you have a name archived and if you are actually relassing an object
@@ -47,7 +47,7 @@
 			H.update_name()
 //		mob.regenerate_icons() //So the name is updated properly
 
-	mob.forceMove(O.loc) // Appear where the object you were controlling is -- TLE
+	mob.forceMove(thing.loc) // Appear where the object you were controlling is -- TLE
 	mob.client.eye = mob
 	mob.verbs -= /client/proc/release
 	mob.verbs += /client/proc/possess

--- a/code/modules/admin/verbs/possess.dm
+++ b/code/modules/admin/verbs/possess.dm
@@ -6,11 +6,12 @@
 	set category = "Object"
 	set desc = "Posess or release an object"
 
+	var/atom/possessing_old
 	if(possessing)
 		//mob.loc = get_turf(mob)
 		var/datum/control/actual
 		for(var/datum/control/C in mob.control_object)
-			if(C.controlled == thing)
+			if(C.controlled == possessing)
 				actual = C
 				break
 		if(actual && mob.name_archive) //if you have a name archived and if you are actually releasing an object
@@ -23,6 +24,7 @@
 
 		mob.forceMove(thing.loc) // Appear where the object you were controlling is -- TLE
 		mob.client.eye = mob
+		possessing_old = possessing
 		possessing = null
 		thing.unregister_event(/event/destroyed, src, nameof(src::possess()))
 
@@ -30,7 +32,7 @@
 			actual.break_control()
 			qdel(actual)
 		feedback_add_details("admin_verb","RO") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	else
+	if(possessing_old != thing)
 		if(config.forbid_singulo_possession && istype(thing,/obj/machinery/singularity))
 			to_chat(mob, "It is forbidden to possess singularities.")
 			return

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -235,20 +235,24 @@
 	return
 
 /client/proc/Move_object(direct)
+	. = 0
 	for(var/datum/control/C in mob.control_object)
 		if(!C.controller)
 			mob.control_object.Remove(C)
 			qdel(C)
 			continue
 		C.Move_object(direct)
+		. = 1
 
 /client/proc/Dir_object(direct)
+	. = 0
 	for(var/datum/control/C in mob.orient_object)
 		if(!C.controller)
 			mob.orient_object.Remove(C)
 			qdel(C)
 			continue
 		C.Orient_object(direct)
+		. = 1
 
 /client/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	if(move_delayer.next_allowed > world.time)
@@ -490,14 +494,13 @@
 			if(A && A.anti_ethereal && !isAdminGhost(mob))
 				to_chat(mob, "<span class='sinister'>A dark forcefield prevents you from entering the area.</span>")
 			else
+				var/blocked = FALSE
 				if((T && T.holy) && isobserver(mob))
 					var/mob/dead/observer/observer = mob
 					if(observer.invisibility == 0 || observer.mind && (find_active_faction_by_member(observer.mind.GetRole(LEGACY_CULTIST)) || find_active_faction_by_member(iscultist(observer))))
 						to_chat(mob, "<span class='warning'>You cannot get past holy grounds while you are in this plane of existence!</span>")
-					else
-						mob.forceEnter(get_step(mob, direct))
-						mob.dir = direct
-				else
+						blocked = TRUE
+				else if(!blocked && !Move_object(direct) && !Dir_object(direct))
 					mob.forceEnter(get_step(mob, direct))
 					mob.dir = direct
 			if(istype(T, /turf/simulated/open)) // Stair movement down
@@ -517,7 +520,7 @@
 				movedelay = ETHEREAL_IMPROVED_MOVEDELAY
 			mob.set_glide_size(DELAY2GLIDESIZE(movedelay))
 			var/turf/newLoc = get_step(mob,direct)
-			if(!(newLoc.turf_flags & NOJAUNT) && !newLoc.holy)
+			if(!(newLoc.turf_flags & NOJAUNT) && !newLoc.holy && !Move_object(direct) && !Dir_object(direct))
 				mob.forceEnter(newLoc)
 				mob.dir = direct
 			else


### PR DESCRIPTION
[bugfix]

## What this does
Closes #11592.

## How it was tested
as an adminghost

## Changelog
:cl:
 * bugfix: Ghosts can now properly admin possess objects.
 * bugfix: Deleting an item now properly releases possession, if any.
 * tweak: Posessing and releasing is now handled in one verb.
 * tweak: The possession verb now releases the mob from the previous object it was possessing.