### PR TITLE
Fire Heat Hotfix

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -390,7 +390,8 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 
 /atom/movable/ignite()
 	..()
-	firelightdummy = new (src)
+	if(!firelightdummy)
+		firelightdummy = new (src)
 
 /atom/proc/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(flammable && !on_fire)
@@ -582,11 +583,6 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	. = ..()
 	dir = pick(cardinal)
 	var/turf/T = get_turf(loc)
-	var/i = 0
-	for(var/obj/effect/fire/F in T)
-		i++
-	if(i>1)
-		qdel(src)
 	var/datum/gas_mixture/air_contents=T.return_air()
 	if(air_contents)
 		setfirelight(air_contents.calculate_firelevel(get_turf(src)), air_contents.temperature)
@@ -600,6 +596,10 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 /obj/effect/fire/proc/Extinguish()
 	for(var/atom/A in loc)
 		A.extinguish()
+	qdel(src)
+
+/obj/effect/fire/extinguish() //lol
+	QDEL_NULL(firelightdummy)
 	qdel(src)
 
 /obj/effect/fire/process()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes fires not actually burning things.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Closes a bug introduced in #36603 while better addressing the root cause of the lighting issue.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Burned several rooms successfully. Burned a single wooden tile room with various objects to confirm no lighting overlays lingered after burning. Verified the contents of the tile and objects did not include erroneous firelight overlays.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fire will actually heat things up again.