### PR TITLE
Secret Repo Decommissioning 1: Cult Runes

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells_special.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells_special.dm
@@ -440,3 +440,91 @@ DRAIN BLOOD: 	Travel 	Blood 	Self
 BLOOD BOIL: 	Destroy See 	Blood
 
 */
+
+//Previously hosted in the secret repo.
+
+////////////////////////////////////////////////////////////////////
+//																  //
+//						MANIFEST GHOST							  //
+//																  //
+////////////////////////////////////////////////////////////////////
+//Used to let cultists allow ghosts back into the game as some near-invincible warriors. Removed since it was obviously OP and un-fun to play against.
+//This version just lets you turn nearby ghosts visible.
+
+/datum/rune_spell/manifestghost
+	secret = TRUE
+	name = "Manifest Ghosts"
+	desc = "Imbues nearby ghosts with residues of occult magic, turning them slightly tangible, able to be seen and to draw in blood."
+	desc_talisman = "Imbues nearby ghosts with residues of occult magic, turning them slightly tangible, able to be seen and to draw in blood."
+	invocation = "Gal'h'rfikk harfrandid mud'gib!"
+	word1 = /datum/rune_word/blood
+	word2 = /datum/rune_word/see
+	word3 = /datum/rune_word/travel
+	page = ""
+
+/datum/rune_spell/manifestghost/cast()
+	if (istype(spell_holder, /obj/effect/rune))
+		var/obj/effect/rune/R = spell_holder
+		R.one_pulse()
+
+	var/turf/T = get_turf(spell_holder)
+	playsound(T, 'sound/effects/conceal.ogg', 50, 0, -2)
+
+	var/datum/role/cultist/C = activator.mind.GetRole(CULTIST)
+	for(var/mob/dead/O in range(T,7))
+		if(O.invisibility != 0)
+			var/dist = cheap_pythag(O.x - T.x, O.y - T.y)
+			if (dist>=8)
+				continue
+			shadow(O,T,"rune_blind")
+			C.gain_devotion(50, DEVOTION_TIER_3, "visible_ghost", O)
+			spawn(5)
+				O.cultify()
+				O.visible_message("<span class='sinister'>Black dust flies around and consolidates around the ghostly shape of \the [O].</span>","<span class='sinister'>The dust emanating from [activator]'s [spell_holder] sticks to your form, you are now visible to all mortals and can write in blood.</span>")
+
+	qdel(spell_holder)
+
+////////////////////////////////////////////////////////////////////
+//																  //
+//							BLOOD BOIL							  //
+//																  //
+////////////////////////////////////////////////////////////////////
+//Used to require 3 cultists to cast and would deal heavy damage to every non-cultists in view, with also a chance of detonating every rune in view.
+//This version just lets you boil nearby blood in containers to 100°C, and clean every blood splatter in range.
+
+/datum/rune_spell/bloodboil
+	secret = TRUE
+	name = "Blood Boil"
+	desc = "Boils blood in visible containers. Not in humans unfortunately. Also evaporates all visible blood splatters."
+	desc_talisman = "Boils blood in visible containers. Not in humans unfortunately. Also evaporates all visible blood splatters."
+	invocation = "Dedo ol'btoh!"
+	word1 = /datum/rune_word/destroy
+	word2 = /datum/rune_word/see
+	word3 = /datum/rune_word/blood
+	page = ""
+
+/datum/rune_spell/bloodboil/cast()
+	if (istype(spell_holder, /obj/effect/rune))
+		var/obj/effect/rune/R = spell_holder
+		R.one_pulse()
+
+	var/turf/T = get_turf(spell_holder)
+	playsound(T, 'sound/effects/blow.ogg', 75, 0, -3)
+
+	for(var/obj/item/weapon/reagent_containers/RC in dview(world.view, T, INVISIBILITY_MAXIMUM))
+		if(RC.reagents.has_reagent(BLOOD))
+			if (RC.reagents.chem_temp < 373.15)
+				playsound(RC.loc, 'sound/effects/bubbles.ogg', 80, 1)
+				RC.reagents.chem_temp = 373.15
+				RC.update_icon()
+
+	for(var/obj/effect/decal/cleanable/C in dview(world.view, T, INVISIBILITY_MAXIMUM))
+		if (C.counts_as_blood)
+			var/erase_color = DEFAULT_BLOOD
+			if (C.basecolor)
+				erase_color = C.basecolor
+			anim(target = get_turf(C), a_icon = 'icons/effects/deityrunes.dmi', flick_anim = "[pick(rune_words_english)]-erase", lay = C.layer+0.1, col = erase_color, plane = C.plane)
+			qdel(C)
+
+
+	qdel(spell_holder)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Part 1 of several PRs to remove code from the secret repo to comply with AGPL license terms. These two runes existed in Cult 1 & 2 and have remained in the secret repo in this form but required guesswork to identify the phrasing.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Transparency and eventual compliance with AGPL requirements.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
It's just a copy-paste job, but I did confirm the runes work just fine.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Moved secret cult runes to the main repo.