### PR TITLE
Stops AI jobbanned players from accepting malf

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -271,7 +271,7 @@
 /datum/dynamic_ruleset/proc/progressive_job_search()
 	for(var/job in job_priority)
 		for(var/mob/M in candidates)
-			if(progressive_job_check(M,job))
+			if(M.mind.assigned_role == job)
 				assigned += M
 				candidates -= M
 				return M
@@ -279,9 +279,6 @@
 	assigned += M
 	candidates -= M
 	return M
-
-/datum/dynamic_ruleset/proc/progressive_job_check(var/mob/M,var/job)
-	return M.mind.assigned_role == job
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -271,7 +271,7 @@
 /datum/dynamic_ruleset/proc/progressive_job_search()
 	for(var/job in job_priority)
 		for(var/mob/M in candidates)
-			if(M.mind.assigned_role == job)
+			if(progressive_job_check(M,job))
 				assigned += M
 				candidates -= M
 				return M
@@ -279,6 +279,9 @@
 	assigned += M
 	candidates -= M
 	return M
+
+/datum/dynamic_ruleset/proc/progressive_job_check(var/mob/M,var/job)
+	return M.mind.assigned_role == job
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -512,6 +512,8 @@ Assign your candidates in choose_candidates() instead.
 // You should `not` perform any null checks on M. M being null is a sign of a problem and should runtime.
 /datum/dynamic_ruleset/roundstart/malf/choose_candidates()
 	var/mob/M = progressive_job_search() //dynamic_rulesets.dm. Handles adding the guy to assigned.
+	if(!M)
+		return 0
 	if(M.mind.assigned_role != "AI")
 		for(var/mob/living/silicon/ai/player in player_list) //mode.candidates is everyone readied up, not to be confused with candidates
 			if(player != M)	// This should always be true but in case something goes terribly terribly wrong we definitely do not want to end up displacing the malf AI

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -527,9 +527,17 @@ Assign your candidates in choose_candidates() instead.
 	return (assigned.len > 0)
 
 /datum/dynamic_ruleset/roundstart/malf/progressive_job_search()
-	var/mob/M = ..()
-	if(!jobban_isbanned(M, "AI"))
-		return M
+	for(var/job in job_priority)
+		for(var/mob/M in candidates)
+			if(M.mind.assigned_role == job && !jobban_isbanned(M, "AI"))
+				assigned += M
+				candidates -= M
+				return M
+	while(candidates.len)
+		var/mob/M = pick_n_take(candidates)
+		if(!jobban_isbanned(M, "AI"))
+			assigned += M
+			return M
 
 /datum/dynamic_ruleset/roundstart/malf/execute()
 	var/datum/faction/malf/unction = find_active_faction_by_type(/datum/faction/malf)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -526,6 +526,9 @@ Assign your candidates in choose_candidates() instead.
 		assigned.Add(M)
 	return (assigned.len > 0)
 
+/datum/dynamic_ruleset/roundstart/malf/progressive_job_check(var/mob/M, var/job)
+	return ..() && !jobban_isbanned(M, "AI")
+
 /datum/dynamic_ruleset/roundstart/malf/execute()
 	var/datum/faction/malf/unction = find_active_faction_by_type(/datum/faction/malf)
 	if (!unction)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -526,8 +526,10 @@ Assign your candidates in choose_candidates() instead.
 		assigned.Add(M)
 	return (assigned.len > 0)
 
-/datum/dynamic_ruleset/roundstart/malf/progressive_job_check(var/mob/M, var/job)
-	return ..() && !jobban_isbanned(M, "AI")
+/datum/dynamic_ruleset/roundstart/malf/progressive_job_search()
+	var/mob/M = ..()
+	if(!jobban_isbanned(M, "AI"))
+		return M
 
 /datum/dynamic_ruleset/roundstart/malf/execute()
 	var/datum/faction/malf/unction = find_active_faction_by_type(/datum/faction/malf)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1570,7 +1570,7 @@ Values up to 1000 are allowed.", "FPS", fps) as null|num
 			for(var/role_id in table_type)
 				dat += "<tr><td>[capitalize(role_id)]</td>"
 				if(table_type[role_id]) //if mode is available on the server
-					if(jobban_isbanned(user, role_id) || (role_id == "pai candidate" && jobban_isbanned(user, "pAI")))
+					if(jobban_isbanned(user, role_id) || (role_id == "pai candidate" && jobban_isbanned(user, "pAI")) || (role_id == MALF && jobban_isbanned(user, "AI")))
 						dat += "<td class='bannedColumn' colspan='5'><b>\[BANNED]</b></td>"
 					else
 						var/wikiroute = role_wiki[role_id]


### PR DESCRIPTION
[bugfix]

## What this does
Closes #23072.

## How it was tested
force AI roundstart ruleset, job banned and unbanned

## Changelog
:cl:
 * bugfix: Malf AIs can no longer be played by AI jobbanned people.