### PR TITLE
Welding Fuel Ignites Instantly

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -508,7 +508,10 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 				ignite()
 				igniting = 1
 		if(surfaces)
-			if((flammable || flammable_reagent_check()) && !on_fire)
+			if(flammable_reagent_check())
+				ignite()
+				igniting = 1
+			else if(flammable && !on_fire)
 				if(prob(exposed_volume * 100 / CELL_VOLUME))
 					ignite()
 					igniting = 1


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Removes the probability check for igniting welding fuel puddles.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
It's more reasonable to expect a match will light a puddle of welding fuel rather than it only having a small chance to do so.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Dumped welding fuel on the ground and threw various things into it to confirm it still ignited. Confirmed regular (non-puddle) ignition works as intended.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Welding fuel puddles ignite instantly.