### PR TITLE
Burning Mob Fix

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -67,9 +67,9 @@ var/global/disable_vents     = 0
 #define BODYTEMP_HEAT_DAMAGE_LIMIT 360.15 // The limit the human body can take before it starts taking damage from heat.
 #define BODYTEMP_COLD_DAMAGE_LIMIT 220.15 // The limit the human body can take before it starts taking damage from coldness.
 
-#define SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE 5000	//These need better heat protect
-#define FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE 30000 //what max_heat_protection_temperature is set to for firesuit quality headwear. MUST NOT BE 0.
-#define FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE 30000 //for fire helmet quality items (red and white hardhats)
+#define SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE 1250	//These need better heat protect
+#define FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE 2500 //what max_heat_protection_temperature is set to for firesuit quality headwear. MUST NOT BE 0.
+#define FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE 2500 //for fire helmet quality items (red and white hardhats)
 
 #define HELMET_MAX_HEAT_PROTECTION_TEMPERATURE 600	//For normal helmets
 

--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -67,9 +67,9 @@ var/global/disable_vents     = 0
 #define BODYTEMP_HEAT_DAMAGE_LIMIT 360.15 // The limit the human body can take before it starts taking damage from heat.
 #define BODYTEMP_COLD_DAMAGE_LIMIT 220.15 // The limit the human body can take before it starts taking damage from coldness.
 
-#define SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE 1250	//These need better heat protect
-#define FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE 2500 //what max_heat_protection_temperature is set to for firesuit quality headwear. MUST NOT BE 0.
-#define FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE 2500 //for fire helmet quality items (red and white hardhats)
+#define SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE 5000	//These need better heat protect
+#define FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE 30000 //what max_heat_protection_temperature is set to for firesuit quality headwear. MUST NOT BE 0.
+#define FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE 30000 //for fire helmet quality items (red and white hardhats)
 
 #define HELMET_MAX_HEAT_PROTECTION_TEMPERATURE 600	//For normal helmets
 

--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -646,7 +646,7 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	for(var/mob/living/carbon/human/M in loc)
 		if(M.mutations.Find(M_UNBURNABLE))
 			continue
-		M.FireBurn(firelevel, air_contents.temperature, air_contents.return_pressure())
+		M.FireBurn(firelevel, FLAME_TEMPERATURE_PLASTIC, air_contents.return_pressure())
 
 	//Burn items in the turf.
 	for(var/atom/A in loc)
@@ -901,7 +901,7 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 				arms_exposure = 0
 
 	//minimize this for low-pressure enviroments
-	var/mx = 5 * firelevel/ZAS_firelevel_multiplier * min(pressure / ONE_ATMOSPHERE, 1)
+	var/mx = 5 * max(firelevel,1.5)/ZAS_firelevel_multiplier * min(pressure / ONE_ATMOSPHERE, 1)
 
 	//Always check these damage procs first if fire damage isn't working. They're probably what's wrong.
 	var/fire_tile_modifier = 4 //multiplier for damage received while standing on a fire tile


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes mobs taking no/very little damage while standing in fires.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Fire rework decoupled the subjective "fire_level" var from all fires except for plasmafires. The FireBurn proc which is called on mobs used this value which is always 0 for non-plasmafires, so mobs were not being damaged at all. Additionally, the temperature fed into the calculation used the ambient temperature rather than the flame temperature, so even at a higher firelevel mobs would still not be damaged at all unless the fire was already massive.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Walked through and stood in a burning fire and adjusted the damage ratio to be similar to what it was prior to fire rework.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed mobs not being damaged while standing in fires.
