### PR TITLE
Secret Repo Decommissioning 3: Account Age Checks

### DIFF
--- a/code/_secrets.dm
+++ b/code/_secrets.dm
@@ -1,6 +1,0 @@
-//A file for the #include-ing of other files outside of the open source repository
-/proc/secret_check_one(var/mob/M,var/list/href_list)
-	return FALSE
-
-/proc/secret_check_two(var/mob/M,var/list/href_list)
-	return FALSE

--- a/code/modules/atmos_automation/console.dm
+++ b/code/modules/atmos_automation/console.dm
@@ -146,7 +146,7 @@
 /obj/machinery/computer/general_air_control/atmos_automation/Topic(href,href_list)
 	if(..())
 		return 1
-	if(secret_check_two(usr, href_list))
+	if(AAC_age_check(usr, href_list))
 		return 1
 	if(href_list["on"])
 		on = !on
@@ -291,6 +291,11 @@
 
 		onclose(usr, "AAC_assemblies")
 
+/obj/machinery/computer/general_air_control/atmos_automation/proc/AAC_age_check(var/mob/M,var/list/href_list)
+	if(href_list["on"] || href_list["runonce"])
+		if(M.client && !M.client.holder && M.client.player_age < 30)
+			message_admins("[key_name(M)] attempted to [href_list["on"] ? "toggle" : "single-run"] an AAC script despite their player age of [M.client.player_age].")
+			return TRUE
 
 /obj/machinery/computer/general_air_control/atmos_automation/proc/MakeCompare(var/datum/automation/a, var/datum/automation/b, var/comparetype)
 	var/datum/automation/compare/compare=new(src)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -108,7 +108,7 @@
 	if(!client)
 		return 0
 
-	if(secret_check_one(src,href_list))
+	if(voting_age_check(src,href_list))
 		return 0
 
 	if(href_list["show_preferences"])
@@ -496,6 +496,12 @@
 
 		Broadcast_Message(speech, vmask=null, data=0, compression=0, level=list(0,1))
 		qdel(speech)
+
+/proc/voting_age_check(var/mob/M,var/list/href_list)
+	if(href_list["votepollid"] && href_list["votetype"])
+		if(M.client && !M.client.holder && M.client.player_age < 30)
+			message_admins("[key_name(M)] attempted to vote in poll # [href_list["votepollid"]] despite their player age of [M.client.player_age].")
+			return TRUE
 
 /mob/new_player/proc/LateChoices()
 

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -89,7 +89,6 @@
 #include "__DEFINES\weapons.dm"
 #include "__DEFINES\world.dm"
 #include "__DEFINES\ZAS.dm"
-#include "code\_secrets.dm"
 #include "code\hub.dm"
 #include "code\names.dm"
 #include "code\world.dm"

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -89,6 +89,7 @@
 #include "__DEFINES\weapons.dm"
 #include "__DEFINES\world.dm"
 #include "__DEFINES\ZAS.dm"
+#include "code\_secrets.dm"
 #include "code\hub.dm"
 #include "code\names.dm"
 #include "code\world.dm"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Moves account age checks for server votes and AAC script execution to the public repo.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Transparency and eventual compliance with AGPL requirements.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
It wasn't! It's just a copy-paste, so nothing will break. Procnames have been changed to prevent a secret repo conflict.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Account age checks for voting and AAC scripting have been moved to the public repo.