### PR TITLE
remove shapeshift

### DIFF
--- a/code/datums/gamemode/powers/vampire.dm
+++ b/code/datums/gamemode/powers/vampire.dm
@@ -16,9 +16,12 @@
 	cost = 0
 	spellpath = /spell/targeted/hypnotise
 
+/*
+// Who will fix Adacovsk's code? Not me.
 /datum/power/vampire/shapeshift
 	cost = 0
 	spellpath = /spell/shapeshift
+*/
 
 /datum/power/vampire/silentbite
 	cost = 0


### PR DESCRIPTION
This is adam's code.
he did not test the code.
it has been 2 years since it has been added.
it is an instant rejuvenate with a 20 second cooldown
it does not work well with nonhuman species
it causes icon errors
it has unforeseen consequences.
it should be removed.
no hard feelings adam

fixes #36152

:cl:
 * rscdel: removed vampire shapeshift