### PR TITLE
Shuttle wall destruction fixes

### DIFF
--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -7,7 +7,7 @@
 	melt_temperature = 0 // Doesn't melt.
 	flags = INVULNERABLE
 	walltype = "swall"
-
+	hardness = 100 // nohulkz
 
 /turf/simulated/wall/shuttle/canSmoothWith()
 	var/static/list/smoothables = list(
@@ -44,7 +44,10 @@
 /turf/simulated/wall/shuttle/ex_act(severity)
 	return
 
-/turf/simulated/wall/shuttle/mech_drill_act(severity)
+/turf/simulated/wall/shuttle/dismantle_wall(devastated, explode)
+	return
+
+/turf/simulated/wall/shuttle/attack_rotting(mob/user)
 	return
 
 /turf/simulated/wall/shuttle/attack_animal(var/mob/living/simple_animal/M)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -206,15 +206,13 @@
 		peepers -= L
 
 /turf/simulated/wall/proc/attack_rotting(mob/user as mob)
-	if(istype(src, /turf/simulated/wall/r_wall)) //I wish I didn't have to do typechecks
-		to_chat(user, "<span class='notice'>This [src] feels rather unstable.</span>")
-		return
-	else
-		//Should be a normal wall or a mineral wall, SHOULD
-		user.visible_message("<span class='warning'>\The [src] crumbles under [user]'s touch.</span>", \
-		"<span class='notice'>\The [src] crumbles under your touch.</span>")
-		dismantle_wall()
-		return
+	//Should be a normal wall or a mineral wall, SHOULD
+	user.visible_message("<span class='warning'>\The [src] crumbles under [user]'s touch.</span>", \
+	"<span class='notice'>\The [src] crumbles under your touch.</span>")
+	dismantle_wall()
+	
+/turf/simulated/wall/r_wall/attack_rotting(mob/user as mob)
+	to_chat(user, "<span class='notice'>This [src] feels rather unstable.</span>")
 
 /turf/simulated/wall/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	user.delayNextAttack(W.attack_delay)


### PR DESCRIPTION
[bugfix]

## What this does
restores these to old behaviour from before them being wall turfs
hulks can no longer smash then down (but can still impotently smash against them with the sound)
wallrot no longer knocks them down, like with rwalls
blobs can no longer destroy them

## How it was tested
rot() proc on walls and pushing them, the hulk gene, becoming a blob in the role panel

## Changelog
:cl:
 * bugfix: Hulks, wallrot and blobs no longer destroy shuttle walls