### PR TITLE
Vampires don't get as much usable blood out of their victims anymore

### DIFF
--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -1,4 +1,5 @@
 #define MAX_BLOOD_PER_TARGET 200
+#define BLOOD_UNIT_DRAIN_MULTIPLIER 2 //How many units of blood get drained from victim at a time per point of blood the vampire gains
 
 /datum/role/vampire
 	id = VAMPIRE
@@ -214,7 +215,7 @@
 		if(blood_total_before != blood_total)
 			to_chat(assailant, "<span class='notice'>You have accumulated [blood_total] [blood_total > 1 ? "units" : "unit"] of blood[blood_usable_before != blood_usable ?", and have [blood_usable] left to use." : "."]</span>")
 		check_vampire_upgrade()
-		target.vessel.remove_reagent(BLOOD,blood)
+		target.vessel.remove_reagent(BLOOD,blood * BLOOD_UNIT_DRAIN_MULTIPLIER)
 		var/mob/living/carbon/V = assailant
 		if(V)
 			var/fatty_chemicals = target.reagents.has_any_reagents(list(CHEESYGLOOP, CORNOIL)) //If the target has these chemicals in his blood the vampire can get fat from sucking blood.

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -195,7 +195,7 @@
 			feeders[targetref] = 0
 		var/mature = locate(/datum/power/vampire/mature) in current_powers
 		if(target.stat < DEAD) //alive
-			blood = min(mature ? 40 : 20, target.vessel.get_reagent_amount(BLOOD)) // if they have less than 20 blood, give them the remnant else they get 20 blood
+			blood = min(mature ? 40 : 20, target.vessel.get_reagent_amount(BLOOD)/BLOOD_UNIT_DRAIN_MULTIPLIER) // if they have less than 20 blood, give them the remnant else they get 20 blood
 			if (feeders[targetref] < MAX_BLOOD_PER_TARGET)
 				blood_total += blood
 			else
@@ -206,7 +206,7 @@
 			var/datum/organ/external/head/head_organ = target.get_organ(LIMB_HEAD)
 			head_organ.add_autopsy_data("sharp teeth", 1)
 		else
-			blood = min(mature ? 20 : 10, target.vessel.get_reagent_amount(BLOOD)) // The dead only give 10 blood
+			blood = min(mature ? 20 : 10, target.vessel.get_reagent_amount(BLOOD)/BLOOD_UNIT_DRAIN_MULTIPLIER) // The dead only give 10 blood
 			if (feeders[targetref] < MAX_BLOOD_PER_TARGET)
 				blood_total += blood
 			else

--- a/code/modules/reagents/reagents/reagents_bio.dm
+++ b/code/modules/reagents/reagents/reagents_bio.dm
@@ -198,6 +198,7 @@
 						var/blood_total_before = V.blood_total
 						var/blood_usable_before = V.blood_usable
 						var/divisor = (locate(/datum/power/vampire/mature) in V.current_powers) ? min(2,foundmob.stat + 1) : (min(2,foundmob.stat + 1)*2)
+						divisor = divisor * BLOOD_UNIT_DRAIN_MULTIPLIER
 						if (!(targetref in V.feeders))
 							V.feeders[targetref] = 0
 						if (V.feeders[targetref] < MAX_BLOOD_PER_TARGET)


### PR DESCRIPTION
Problem:
- Vampires gain so much blood that one or two victims is enough to let them spam their abilities for a long while. All of their abilities, including teleporting around, giving people bad diseases, stunning everyone nearby etc.
- One victim is enough to let the vampire thrall 3 people indefinitely.

Solution:
- Vampires now drain 2 units of blood for every 1 unit they gain. This also means they suck their victims dry faster (normal vampires will do it in a minute and 20 seconds, mature ones in about 40 seconds).

I've weighed the odds over the concerning rate of blood drain and I came to the conclusion that a mature vampire tends to have far more dangerous tools to kill crewmembers faster with than just by draining their blood.

This should put a roadblock in the way of a vampire by putting more pressure in how many abilities they can use at a time, because they never really have to worry about ever running out of blood in their current state, and should also reduce the number of thralls they tend to create. At the same time it also provides a benefit to vampires by making them stay less time trying to get the most blood out of a victim.

This change also applies to consuming blood through direct ingestion.

:cl:
 * tweak: Vampires now drain blood at a rate of 2 units of blood per blood of point they receive, which has a dual effect of reducing the amount of usable blood a vampire gets out of a human (which used to be excessive) and allowing vampires to spend less time sucking players to get all of their blood.