### PR TITLE
Plague mice will now get a message detailing their virus details when spawning

### DIFF
--- a/code/datums/gamemode/factions/plague_mice.dm
+++ b/code/datums/gamemode/factions/plague_mice.dm
@@ -33,7 +33,17 @@
 	/* With the disease set-up, store the detials of the disease in the mouse's memory */
 	var/datum/mind/mouse_mind = R.antag
 	mouse_mind.store_memory(plague.get_info(TRUE), forced = 1)
-	mouse_mind.store_memory("<hr>")
+	mouse_mind.store_memory("<hr>", forced = 1)
+	var/dat = "<span class='notice'>You carry a deadly plague with the following traits:</span>"
+	dat += "<br><span class='notice'>Strength / Robustness:</span> <b>[plague.strength]%</b> / <b>[plague.robustness]%</b>"
+	dat += "<br><span class='notice'>Infection chance:</span> <b>[plague.infectionchance]%</b>"
+	dat += "<br><span class='notice'>Chance of disease progressing:</span> <b>[plague.stageprob]%</b>"
+	dat += "<br><br><span class='notice'>Symptoms:</span>"
+	for(var/datum/disease2/effect/e in plague.effects)
+		dat += "<br><span class='notice'>Stage [e.stage] - <b>[e.name]</b>: <i>[e.desc]</span></i>"
+	dat += "<br><br><span class='notice'>The complete details of the disease are available in your memories, by opening your Notes.</span>"
+	spawn() //So that it shows up after the message of being a plague mouse
+		to_chat(M, dat)
 
 /datum/faction/plague_mice/OnPostSetup()
 	if (!plague || !invasion)


### PR DESCRIPTION
Instead of having to check notes. They can still check notes for a more comprehensive rundown.
Also fixes a tiny oversight where the proc that added "< hr >" was not having a variable set to what it should be.

:cl:
 * rscadd: Plague mice will now get a message detailing the basic details of the disease they are carrying.