### PR TITLE
Made the Plague Mice disease far more dangerous

### DIFF
--- a/code/datums/gamemode/factions/plague_mice.dm
+++ b/code/datums/gamemode/factions/plague_mice.dm
@@ -67,9 +67,9 @@
 			EFFECT_DANGER_HARMFUL	= 3,
 			EFFECT_DANGER_DEADLY	= 5,
 			)
-		plague.origin = "Black Plague"
+		plague.origin = pick("Black Plague", "Javorian Pox", "Gray Death", "Doom of Pandyssia")
 
-		plague.spread = SPREAD_BLOOD|SPREAD_CONTACT|SPREAD_AIRBORNE//gotta ensure that our mice can spread that disease
+		plague.spread = SPREAD_BLOOD|SPREAD_CONTACT|SPREAD_AIRBORNE|SPREAD_COLONY//gotta ensure that our mice can spread that disease
 
 		plague.color = "#ADAEAA"
 		plague.pattern = 3

--- a/code/datums/gamemode/factions/plague_mice.dm
+++ b/code/datums/gamemode/factions/plague_mice.dm
@@ -67,8 +67,14 @@
 			EFFECT_DANGER_HARMFUL	= 3,
 			EFFECT_DANGER_DEADLY	= 5,
 			)
-		plague.origin = pick("Black Plague", "Javorian Pox", "Gray Death", "Doom of Pandyssia", "Thrassian Plague",
-							"Redlight", "Khaara Bacterium", "MEV-1")
+		if(prob(2)) //Dan's Discount products are notoriously bad
+			plague.origin = "Discount Dan's Gas Station Sushi"
+		else if(Holiday == APRIL_FOOLS_DAY)
+			plague.origin = pick("Nurgle's Cauldron", "Deadly Africanized Water", "Public Bathroom", "Thrax",
+								"A spaceman got a mouse disease, this is what happened to his body")
+		else
+			plague.origin = pick("Black Plague", "Javorian Pox", "Gray Death", "Doom of Pandyssia", "Thrassian Plague",
+								"Redlight", "Khaara Bacterium", "MEV-1")
 
 		plague.spread = SPREAD_BLOOD|SPREAD_CONTACT|SPREAD_AIRBORNE|SPREAD_COLONY//gotta ensure that our mice can spread that disease
 

--- a/code/datums/gamemode/factions/plague_mice.dm
+++ b/code/datums/gamemode/factions/plague_mice.dm
@@ -55,17 +55,17 @@
 
 		var/list/anti = list(
 			ANTIGEN_BLOOD	= 0,
-			ANTIGEN_COMMON	= 1,
-			ANTIGEN_RARE	= 2,
-			ANTIGEN_ALIEN	= 0,
+			ANTIGEN_COMMON	= 0,
+			ANTIGEN_RARE	= 1,
+			ANTIGEN_ALIEN	= 2,
 			)
 		var/list/bad = list(
 			EFFECT_DANGER_HELPFUL	= 0,
 			EFFECT_DANGER_FLAVOR	= 0,
 			EFFECT_DANGER_ANNOYING	= 1,
 			EFFECT_DANGER_HINDRANCE	= 1,
-			EFFECT_DANGER_HARMFUL	= 2,
-			EFFECT_DANGER_DEADLY	= 3,
+			EFFECT_DANGER_HARMFUL	= 3,
+			EFFECT_DANGER_DEADLY	= 5,
 			)
 		plague.origin = "Black Plague"
 
@@ -74,8 +74,12 @@
 		plague.color = "#ADAEAA"
 		plague.pattern = 3
 		plague.pattern_color = "#EE9A9C"
+		plague.stage = 4 //4 stages, unlocks the really dangerous symptoms rather than just DNA Degradation
+		plague.speed = 4 //Takes about 50 seconds to advance to the next stage
 
-		plague.makerandom(list(80,100),list(25,50),anti,bad,null)
+		plague.makerandom(list(90,100),list(40,75),anti,bad,null)
+		for(var/datum/disease2/effect/e in plague.effects)
+			e.chance *= 2 //More likely to trigger symptoms per tick
 
 		diseaseID = "[plague.uniqueID]-[plague.subID]"
 

--- a/code/datums/gamemode/factions/plague_mice.dm
+++ b/code/datums/gamemode/factions/plague_mice.dm
@@ -67,7 +67,8 @@
 			EFFECT_DANGER_HARMFUL	= 3,
 			EFFECT_DANGER_DEADLY	= 5,
 			)
-		plague.origin = pick("Black Plague", "Javorian Pox", "Gray Death", "Doom of Pandyssia")
+		plague.origin = pick("Black Plague", "Javorian Pox", "Gray Death", "Doom of Pandyssia", "Thrassian Plague",
+							"Redlight", "Khaara Bacterium", "MEV-1")
 
 		plague.spread = SPREAD_BLOOD|SPREAD_CONTACT|SPREAD_AIRBORNE|SPREAD_COLONY//gotta ensure that our mice can spread that disease
 


### PR DESCRIPTION
The plague mice are almost always more of a footnote in a round rather than a pandemic starter, and there was always a decent chance Virology already made a cure for the antigens they were carrying. The disease itself also wasn't particularly that lethal, the worst it tended to do was end up with the DNA Degradation stage as its third and final stage, which is particularly slow.

Changes:
- Now has 4 stages, allowing it to carry the vastly more dangerous stage 4 symptoms.
- Its progression speed has been massively increased, and it will take mere minutes for it to reach the max stage.
- Now can only have rare and alien (really rare) antigens, making it less likely for there to already be a cure for it.
- The chances for the symptom effects to trigger every tick have been doubled.
- Its average infection chance and robustness have been further increased.
- Now penetrates hardsuits. Biohazard suits are still immune.
- Now has a lot of possible origins which are just references, including April Fools versions. Has a 2% chance of its origin being from a Discount Dan's Gas Station Sushi.

This should help make the plague mice far more threatening (given that they are barely threatening as it is) and give Medbay a real challenge in the process. How many times have you seen a biohazard suit being used?

:cl:
 * tweak: The plague carried by the Plague Mice has been made far more dangerous. Establish a quarantine and avoid the mice!