### PR TITLE
Cleans up mineral spread runtime

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -146,7 +146,8 @@ var/global/list/mineralSpawnChance[]
 /turf/unsimulated/mineral/New()
 	mineral_turfs += src
 	. = ..()
-	MineralSpread()
+	if(istype(src))
+		MineralSpread()
 	update_icon()
 
 var/list/icon_state_to_appearance = list()


### PR DESCRIPTION
[runtime]

## What this does
removes the runtime at line 149 in mine_turfs.dm that was calling this proc on the floors, which don't have the proc. no gameplay change i think
maybe there's a better way to do this than istype() on itself

## How it was tested
checking the turfs after spawning