### PR TITLE
Ninjas will now always hit what they're aiming for.

### DIFF
--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -25,6 +25,7 @@
 /mob/living/carbon/proc/attacked_by(var/obj/item/I, var/mob/living/user, var/def_zone, var/originator = null, var/crit = FALSE, var/flavor)
 	if(!I || !user)
 		return FALSE
+	var/accuracy_modifier = get_total_accuracy_modifier(user, src) //Negative value make it more likely to hit, and the opposite for positive values
 	target_zone = null
 	var/power = I.force
 	if (ishuman(user))
@@ -33,13 +34,13 @@
 	if (crit)
 		power *= CRIT_MULTIPLIER
 	if(def_zone)
-		target_zone = get_zone_with_miss_chance(def_zone, src)
+		target_zone = get_zone_with_miss_chance(def_zone, src, accuracy_modifier)
 	else if(originator)
 		if(ismob(originator))
 			var/mob/M = originator
-			target_zone = get_zone_with_miss_chance(M.zone_sel.selecting, src)
+			target_zone = get_zone_with_miss_chance(M.zone_sel.selecting, src, accuracy_modifier)
 	else
-		target_zone = get_zone_with_miss_chance(user.zone_sel.selecting, src)
+		target_zone = get_zone_with_miss_chance(user.zone_sel.selecting, src, accuracy_modifier)
 
 	if(user == src) // Attacking yourself can't miss
 		if(isnull(user.zone_sel)) //If the mob attacks itself without a client controlling it and therefore has no zone select active. This could happen if a catatonic person wielding a sword slips.

--- a/code/modules/mob/living/carbon/human/combat.dm
+++ b/code/modules/mob/living/carbon/human/combat.dm
@@ -338,3 +338,12 @@
 		knock_out_teeth()
 	..(hurtAmount, knockAmount, hurtSound)
 
+/mob/living/carbon/human/get_attacker_accuracy_increase()
+	var/accuracy_bonus = 0
+	if(isninja(src)) //Ninjas are expert combatants
+		accuracy_bonus = 50
+	return accuracy_bonus
+
+/mob/living/carbon/human/get_defender_accuracy_decrease()
+	var/accuracy = 0
+	return accuracy

--- a/code/modules/mob/living/combat.dm
+++ b/code/modules/mob/living/combat.dm
@@ -150,3 +150,19 @@
 
 /mob/living/proc/calcTackleRange()
 	return 0
+
+//Attacker accuracy will decrease the miss chance
+//Defender accuracy will increase the miss chance
+//Used in /mob/living/carbon/proc/attacked_by(), in /code/modules/mob/living/carbon/combat.dm
+/proc/get_total_accuracy_modifier(var/mob/living/carbon/attacker, var/mob/living/carbon/defender)
+	var/total_accuracy = 0
+	var/attacker_accuracy_modifier = attacker.get_attacker_accuracy_increase()
+	var/defender_accuracy_modifier = defender.get_defender_accuracy_decrease()
+	total_accuracy = total_accuracy - attacker_accuracy_modifier + defender_accuracy_modifier
+	return total_accuracy
+
+/mob/living/proc/get_attacker_accuracy_increase()
+	return 0
+
+/mob/living/proc/get_defender_accuracy_decrease()
+	return 0


### PR DESCRIPTION
Yes, you CAN reliably aim for the hand now to try make someone drop their gun! Like a pro ninja!

Added backend accuracy system that can be modified by various factors as needed, works only for carbons that make use of the "can miss attacks" system.

:cl:
 * tweak: Ninjas will now always hit what they're aiming for in melee combat, and will never miss unintentionally.