### PR TITLE
remove antique matter synthesizer access requirements

### DIFF
--- a/code/game/machinery/antiquemattersynth.dm
+++ b/code/game/machinery/antiquemattersynth.dm
@@ -45,7 +45,7 @@ list("category" = "machinery", "name" = "MSGS", "path" = /obj/machinery/atmosphe
 	density = 1
 	anchored = 0
 	machine_flags = WRENCHMOVE | FIXED2WORK | EMAGGABLE
-	req_access = list(access_engine_minor)
+	req_access = list()
 
 
 	var/consumption = 0 //How much are we set to draw off the net? Clamped between 0 and 2 GIGAWATT (2,000,000,000 Watts)


### PR DESCRIPTION
I feel compelled to make this change because i had to spend half my round arguing with a certain well-known HoP player just to get the access to work this thing while playing a hobo that bought this from the traders.

[tweak]
:cl:
 * tweak: removed access requirements from antique matter synthesizer
