### PR TITLE
Fixes problems regarding hitting missing limbs

### DIFF
--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -45,7 +45,7 @@
 	if(ishuman(src)) //Human check, because it isn't easy to override all this code
 		var/datum/organ/external/affecting = get_organ(target_zone)
 		if(affecting.status & ORGAN_DESTROYED) //Target zone ended up on a missing limb, count it as a miss
-			missing_due_to_no_limb_text = "[user] misses [src] with \the [I] due aiming at where their <span class='danger'>[affecting.display_name]</span> used to be!"
+			missing_due_to_no_limb_text = "[user] misses [src] with \the [I] due to aiming at where their <span class='danger'>[affecting.display_name]</span> used to be!"
 			target_zone = null
 
 	if(user == src) // Attacking yourself can't miss

--- a/code/modules/mob/living/carbon/combat.dm
+++ b/code/modules/mob/living/carbon/combat.dm
@@ -41,6 +41,13 @@
 	else
 		target_zone = get_zone_with_miss_chance(user.zone_sel.selecting, src)
 
+	var/missing_due_to_no_limb_text //Offers an unique missing sound message to clue players in as to why they missed
+	if(ishuman(src)) //Human check, because it isn't easy to override all this code
+		var/datum/organ/external/affecting = get_organ(target_zone)
+		if(affecting.status & ORGAN_DESTROYED) //Target zone ended up on a missing limb, count it as a miss
+			missing_due_to_no_limb_text = "[user] misses [src] with \the [I] due aiming at where their <span class='danger'>[affecting.display_name]</span> used to be!"
+			target_zone = null
+
 	if(user == src) // Attacking yourself can't miss
 		if(isnull(user.zone_sel)) //If the mob attacks itself without a client controlling it and therefore has no zone select active. This could happen if a catatonic person wielding a sword slips.
 			target_zone = pick("head", "eyes", "mouth")
@@ -48,7 +55,10 @@
 			target_zone = user.zone_sel.selecting
 
 	if(!target_zone && !src.stat)
-		visible_message("<span class='borange'>[user] misses [src] with \the [I]!</span>")
+		if(missing_due_to_no_limb_text)
+			visible_message("<span class='borange'>[missing_due_to_no_limb_text]</span>")
+		else
+			visible_message("<span class='borange'>[user] misses [src] with \the [I]!</span>")
 		add_logs(user, src, "missed", admin=1, object=I, addition="intended damage: [power]")
 		if(I.miss_sound)
 			playsound(loc, I.miss_sound, 50)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -249,12 +249,13 @@ emp_act
 
 	if (!affecting)
 		return FALSE
-	if(affecting.status & ORGAN_DESTROYED)
-		if(originator)
-			to_chat(originator, "What [affecting.display_name]?")
-		else
-			to_chat(user, "What [affecting.display_name]?")
-		return FALSE
+
+	// if(affecting.status & ORGAN_DESTROYED)
+	// 	if(originator)
+	// 		to_chat(originator, "What [affecting.display_name]?")
+	// 	else
+	// 		to_chat(user, "What [affecting.display_name]?")
+	// 	return FALSE
 	var/hit_area = affecting.display_name
 
 	if(istype(I.attack_verb, /list) && I.attack_verb.len && !(I.flags & NO_ATTACK_MSG))

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -853,17 +853,17 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 		//Robotic limbs explode if sabotaged.
 		if(status & ORGAN_ROBOT && !no_explode && sabotaged)
-			owner.visible_message("<span class='danger'>\The [owner]'s [display_name] explodes violently!</span>", \
-			"<span class='danger'>Your [display_name] explodes violently!</span>", \
-			"<span class='danger'>You hear an explosion followed by a scream!</span>")
+			owner.visible_message("<span class='moderate'>\The [owner]'s [display_name] explodes violently!</span>", \
+			"<span class='moderate'>Your [display_name] explodes violently!</span>", \
+			"<span class='moderate'>You hear an explosion followed by a scream!</span>")
 			explosion(get_turf(owner), -1, -1, 2, 3, whodunnit = owner)
 			spark(src, 5, FALSE)
 
 		if(organ)
 			if(display_message)
-				owner.visible_message("<span class='danger'>[owner.name]'s [display_name] flies off in an arc.</span>", \
-				"<span class='danger'>Your [display_name] goes flying off!</span>", \
-				"<span class='danger'>You hear a terrible sound of ripping tendons and flesh.</span>")
+				owner.visible_message("<span class='moderate'>[owner.name]'s [display_name] flies off in an arc!</span>", \
+				"<span class='moderate'>Your [display_name] goes flying off!</span>", \
+				"<span class='moderate'>You hear a terrible sound of ripping tendons and flesh!</span>")
 
 			//Throw organs around
 			var/randomdir = pick(cardinal)


### PR DESCRIPTION
![image](https://github.com/vgstation-coders/vgstation13/assets/41342767/18242f13-e5d7-4c50-b474-34a09403645b)
(the limb message has an exclamation mark now)
![image](https://github.com/vgstation-coders/vgstation13/assets/41342767/e58df064-49c3-4d1c-81e2-f66385ac5f81)
(the typo was corrected so now it's "due to aiming")

- Will now no longer hit missing limbs, and instead landing hits on missing limbs will count as missing the attack
- This is functionally the same as the previous behavior
- Removed the "What (limb)?" message
- Added message for when missing someone was caused by aiming at their missing limb
- Changed the color of the limb loss message to better distinguish it from combat-related red text.

And yes, people with no limbs are statistically more robust at dodging.

:cl:
 * bugfix: You can no longer attack missing limbs. Attacking a missing limb will now count as a miss, with an unique message explaining which limb would have been hit.
 * spellcheck: Changed the font color of the limbs exploding or flying off from a human character to a darker red in order to distinguish it from the usual bold red text that is common in combat.