### PR TITLE
Limbs should be a bit easier to rip off and a few other changes

### DIFF
--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -607,7 +607,7 @@ Helpers For Both Variants
 	base_state = "blade"
 	active_state = "blade1"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/swords_axes.dmi', "right_hand" = 'icons/mob/in-hand/right/swords_axes.dmi')
-	activeforce = 35
+	activeforce = 40
 	sharpness_on = 2
 	siemens_coefficient = 0
 	onsound = null

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -607,7 +607,7 @@ Helpers For Both Variants
 	base_state = "blade"
 	active_state = "blade1"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/swords_axes.dmi', "right_hand" = 'icons/mob/in-hand/right/swords_axes.dmi')
-	activeforce = 40
+	activeforce = 35
 	sharpness_on = 2
 	siemens_coefficient = 0
 	onsound = null

--- a/code/datums/gamemode/role/ninja.dm
+++ b/code/datums/gamemode/role/ninja.dm
@@ -608,6 +608,7 @@ Helpers For Both Variants
 	active_state = "blade1"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/swords_axes.dmi', "right_hand" = 'icons/mob/in-hand/right/swords_axes.dmi')
 	activeforce = 40
+	sharpness_on = 2
 	siemens_coefficient = 0
 	onsound = null
 	actions_types = list(/datum/action/item_action/toggle_teleport)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -885,7 +885,7 @@ a {
 		if(sharpness_flags && sharpness)
 			force = initial(force)*(material_type.sharpness_mod*(quality/B_AVERAGE))
 			throwforce = initial(throwforce)*(material_type.sharpness_mod*(quality/B_AVERAGE))
-			sharpness = initial(sharpness)*(material_type.sharpness_mod*(quality/B_AVERAGE))
+			sharpness = min(initial(sharpness)*(material_type.sharpness_mod*(quality/B_AVERAGE)), 2) //Don't let the sharpness get too crazy
 		else
 			force = initial(force)*(material_type.brunt_damage_mod*(quality/B_AVERAGE))
 			throwforce = initial(throwforce)*(material_type.brunt_damage_mod*(quality/B_AVERAGE))

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -192,16 +192,16 @@
 					return
 			else
 				if(sharp || is_peg())
-					if(prob((5 * brute) * sharp)) //sharp things have a greater chance to sever based on how sharp they are
+					if(prob((5 * brute) * (sharp ? sharp : 1))) //sharp things have a greater chance to sever based on how sharp they are
 						droplimb(1)
 						return
+				//15 dmg - 8% chance, 22 dmg - 27%, 30 dmg - 64%, anything higher than ~35 is a guaranteed limbgib
+				else if((brute > 15) && prob((brute/7.5)**3)) //Massive blunt damage can result in limb explosion
+					explode()
+					return
 				else if((brute > 20) && prob(2 * brute)) //non-sharp hits with force greater than 20 can cause limbs to sever, too (smaller chance)
 					droplimb(1)
 					return
-				else if(brute > 15) //Massive blunt damage can result in limb explosion
-					if(prob((brute/7.5)**3)) //15 dmg - 8% chance, 22 dmg - 27%, 30 dmg - 64%, anything higher than ~35 is a guaranteed limbgib
-						explode()
-						return
 
 		//items of exceptional sharpness and damage are capable of severing the limb below its damage threshold, the necessary threshold scaling inversely with sharpness
 		else if(sharp > 1)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -204,11 +204,11 @@
 						return
 
 		//items of exceptional sharpness and damage are capable of severing the limb below its damage threshold, the necessary threshold scaling inversely with sharpness
-		else if(sharp)
+		else if(sharp > 1)
 			//Damage overflow, only the remaining damage after the reduction will be counted for the subsequent calculations
-			var/damage_overflow = (get_health() + brute) * sharp - max_damage * config.organ_health_multiplier
+			var/damage_overflow = get_health() + brute * sharp - max_damage * config.organ_health_multiplier
 			if(damage_overflow > 0)
-				if(prob((5 * (damage_overflow * sharp)) * (sharp - 1))) //the same chance multiplier based on sharpness applies here as well
+				if(prob(2 * (damage_overflow * sharp - 0.5) * (sharp - 1))) //the same chance multiplier based on sharpness applies here as well
 					droplimb(1)
 					return
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -177,12 +177,12 @@
 				burn *= species.burn_mod
 
 	//If limb took enough damage, try to cut or tear it off
-	if(body_part != UPPER_TORSO && body_part != LOWER_TORSO) //As hilarious as it is, getting hit on the chest too much shouldn't effectively gib you.
+	if(body_part != UPPER_TORSO && body_part != LOWER_TORSO && config.limbs_can_break) //As hilarious as it is, getting hit on the chest too much shouldn't effectively gib you.
 		var/threshold_multiplier = 1
 		if(isslimeperson(owner))
 			threshold_multiplier = 0
 		//Brute weapons can destroy limbs if they are already heavily damaged
-		if(config.limbs_can_break && get_health() >= max_damage * config.organ_health_multiplier * threshold_multiplier)
+		if(get_health() >= max_damage * config.organ_health_multiplier * threshold_multiplier)
 			if(isslimeperson(owner))
 				var/chance_multiplier = 1
 				if(istype(src, /datum/organ/external/head))
@@ -204,9 +204,11 @@
 						return
 
 		//items of exceptional sharpness and damage are capable of severing the limb below its damage threshold, the necessary threshold scaling inversely with sharpness
-		else if(sharp >= 2) //Minimum of 2 sharpness required
-			if(config.limbs_can_break && ((get_health() + brute) >= (max_damage * config.organ_health_multiplier)/sharp))
-				if(prob((5 * (brute * sharp)) * (sharp - 1))) //the same chance multiplier based on sharpness applies here as well
+		else if(sharp)
+			//Damage overflow, only the remaining damage after the reduction will be counted for the subsequent calculations
+			var/damage_overflow = (get_health() + brute) * sharp - max_damage * config.organ_health_multiplier
+			if(damage_overflow > 0)
+				if(prob((5 * (damage_overflow * sharp)) * (sharp - 1))) //the same chance multiplier based on sharpness applies here as well
 					droplimb(1)
 					return
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -181,6 +181,7 @@
 		var/threshold_multiplier = 1
 		if(isslimeperson(owner))
 			threshold_multiplier = 0
+		//Brute weapons can destroy limbs if they are already heavily damaged
 		if(config.limbs_can_break && get_health() >= max_damage * config.organ_health_multiplier * threshold_multiplier)
 			if(isslimeperson(owner))
 				var/chance_multiplier = 1
@@ -194,18 +195,20 @@
 					if(prob((5 * brute) * sharp)) //sharp things have a greater chance to sever based on how sharp they are
 						droplimb(1)
 						return
-				else if(!sharp && brute > 15) //Massive blunt damage can result in limb explosion
+				else if((brute > 20) && prob(2 * brute)) //non-sharp hits with force greater than 20 can cause limbs to sever, too (smaller chance)
+					droplimb(1)
+					return
+				else if(brute > 15) //Massive blunt damage can result in limb explosion
 					if(prob((brute/7.5)**3)) //15 dmg - 8% chance, 22 dmg - 27%, 30 dmg - 64%, anything higher than ~35 is a guaranteed limbgib
 						explode()
 						return
-				else if(brute > 20 && prob(2 * brute)) //non-sharp hits with force greater than 20 can cause limbs to sever, too (smaller chance)
+
+		//items of exceptional sharpness and damage are capable of severing the limb below its damage threshold, the necessary threshold scaling inversely with sharpness
+		else if(sharp >= 2) //Minimum of 2 sharpness required
+			if(config.limbs_can_break && ((get_health() + brute) >= (max_damage * config.organ_health_multiplier)/sharp))
+				if(prob((5 * (brute * sharp)) * (sharp - 1))) //the same chance multiplier based on sharpness applies here as well
 					droplimb(1)
 					return
-
-		else if((config.limbs_can_break && sharp == 100) || ((sharp >= 2) && (config.limbs_can_break && brute_dam + burn_dam >= (max_damage * config.organ_health_multiplier)/sharp))) //items of exceptional sharpness are capable of severing the limb below its damage threshold, the necessary threshold scaling inversely with sharpness
-			if(prob((5 * (brute * sharp)) * (sharp - 1))) //the same chance multiplier based on sharpness applies here as well
-				droplimb(1)
-				return
 
 	//High brute damage or sharp objects may damage internal organs
 	if(internal_organs != null)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -204,7 +204,7 @@
 					return
 
 		//items of exceptional sharpness and damage are capable of severing the limb below its damage threshold, the necessary threshold scaling inversely with sharpness
-		else if(sharp > 1)
+		else if(sharp > 1 && (body_part != HEAD)) //Don't allow too-easy decapitations with this!
 			//Damage overflow, only the remaining damage after the reduction will be counted for the subsequent calculations
 			var/damage_overflow = get_health() + brute * sharp - max_damage * config.organ_health_multiplier
 			if(damage_overflow > 0)


### PR DESCRIPTION
It turns out that regardless of the damage done by a weapon a weapon would have always required at least 2 hits to take off a limb because the limb removal code always checked for the limb's health at that moment.
This PR fixes it by allowing limbs to be taken off in one hit IF the sharpness value is above 1, and only if a calculated damage (multiplied by sharpness and considering the limb's current damage) surpasses the limb's maximum health enough. Limbs removed in one hit do not damage the victim because they are clean cuts. This is the same as the previous limb removal functionality.
Notably, this allows the Bloodlust and the Ninja's energy blade to cut off hands and feet (NOT arms and legs) in one hit. It also gives the Ninja's energy blade a 15% chance to remove an arm or leg in one hit.
The executioner's blade has a 30% chance to remove a hand or foot in one hit.
The changes do not apply to heads.

In addition, this PR also fixes a 7 year old bug that prevented weapons with over 20 brute damage from delimbing through sheer force (as opposed to gibbing). The issue was that the conditions that would have called that code would have always been intercepted by previous conditions regardless of condition. Keep in mind that this code only runs when against blunt weapons while the limb has taken maximum damage. You should see more limbs dropping from high-damage blunt weapons as opposed to being gibbed.
Also fixes another 7 year old bug that prevented peg limbs from being removed by non-sharp damage.

Increased the energy blade's sharpness to 2, which is the reason I made the PR. It didn't actually have the sharpness required to remove limbs in one hit.

Limited the amount of sharpness that an item can get through blacksmithing to 2, to avoid insane instances of sharpness that could allow instantly delimbing a limb (except for the torso and head). They can still have a really high chance of delimbing, however.

:cl:
 * bugfix: Fixed a 7 year old bug that prevented very strong brute damage from ripping damaged limbs off as opposed to gibbing them.
 * bugfix: Fixed another 7 year old bug that only allowed peg limbs to be ripped off using sharp weapons when it was intended for non-sharp weapons to do it too.
 * tweak: The Bloodlust (made from combining two high-frequency machetes) and the Ninja's energy blade can now take off hands and feet in one hit. The Ninja's blade also has a 15% chance to remove an arm or leg in one hit. Note that cutting off a foot is not the same as cutting off a leg, and only cutting the leg will knock down a target.
 * tweak: The Ninja's energy blade is now sharper.
 * tweak: Tweaked the formula used for sharper weapons when it comes to delimbing targets. Sharper-than-usual weapons will now generally take at least one less hit to remove a limb.
 * tweak: The amount of sharpness a weapon can have through crafting is now limited to a smaller but still very impressive number.