### PR TITLE
pulse demons consider atmos techs enemies

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_latejoin.dm
@@ -190,7 +190,7 @@
 /datum/dynamic_ruleset/latejoin/pulse_demon
 	name = "Pulse Demon Infiltration"
 	role_category = /datum/role/pulse_demon
-	enemy_jobs = list("Station Engineer","Chief Engineer","Warden","Head of Security","Captain","AI","Cyborg")
+	enemy_jobs = list("Station Engineer","Atmospheric Technician","Chief Engineer","Warden","Head of Security","Captain","AI","Cyborg")
 	required_enemies = list(2,2,2,2,2,2,2,2,2,2)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_midround.dm
@@ -869,7 +869,7 @@
 /datum/dynamic_ruleset/midround/from_ghosts/pulse_demon
 	name = "Pulse Demon Infiltration"
 	role_category = /datum/role/pulse_demon
-	enemy_jobs = list("Station Engineer","Chief Engineer","Warden","Head of Security","Captain","AI","Cyborg")
+	enemy_jobs = list("Station Engineer","Atmospheric Technician","Chief Engineer","Warden","Head of Security","Captain","AI","Cyborg")
 	required_enemies = list(2,2,2,2,2,2,2,2,2,2)
 	required_candidates = 1
 	weight = BASE_RULESET_WEIGHT


### PR DESCRIPTION
[tweak] [gamemode]
## What this does
makes the pulse demon ruleset factor atmos techs in when deciding to spawn

## Why it's good
departmental consistency. atmos techs and station engineers have very similar roles in practice so it makes sense to treat them as such.

## How it was tested
i didn't, but it's a very simple change so i don't see how it could go wrong.

## Changelog
:cl:
 * tweak: pulse demons will now fire with atmospheric technicians
