### PR TITLE
Removes atmos related xenoarch large effects and triggers from natural gen

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
@@ -1,3 +1,5 @@
+#define BLACKLISTED_EFFECTS "/datum/artifact_effect - /datum/artifact_effect/gas - /datum/artifact_effect/heat - /datum/artifact_effect/cold" //format this with "- /datum/artifact_effect/NAME".
+
 var/list/excavated_large_artifacts = list()
 var/list/destroyed_large_artifacts = list()
 var/list/razed_large_artifacts = list()//destroyed while still inside a rock wall/boulder
@@ -42,7 +44,7 @@ var/list/razed_large_artifacts = list()//destroyed while still inside a rock wal
 
 /obj/machinery/artifact/proc/generate_effect()
 	//setup primary effect
-	var/effecttype = pick(typesof(/datum/artifact_effect) - /datum/artifact_effect)
+	var/effecttype = pick(typesof(/datum/artifact_effect) - BLACKLISTED_EFFECTS)
 	primary_effect = new effecttype(src, 1) //pass the 1 so that the effect knows to generate a trigger
 	primary_effect.artifact_id = "[artifact_id]a"
 	spawn(1)	//delay logging so if admin tools override/other fuckery occurs the logs still end up correct
@@ -53,7 +55,7 @@ var/list/razed_large_artifacts = list()//destroyed while still inside a rock wal
 
 	//75% chance to have a secondary effect
 	if(prob(75))
-		effecttype = pick(typesof(/datum/artifact_effect) - /datum/artifact_effect)
+		effecttype = pick(typesof(/datum/artifact_effect) - BLACKLISTED_EFFECTS)
 		secondary_effect = new effecttype(src, 1, FALSE)
 		secondary_effect.artifact_id = "[artifact_id]b"
 		spawn(1)
@@ -243,3 +245,5 @@ var/list/razed_large_artifacts = list()//destroyed while still inside a rock wal
 
 /obj/machinery/artifact/can_overload()
 	return 0
+
+#undef BLACKLISTED_EFFECTS

--- a/code/modules/research/xenoarchaeology/artifact/effect.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effect.dm
@@ -1,3 +1,5 @@
+#define BLACKLISTED_TRIGGERS "/datum/artifact_trigger - /datum/artifact_trigger/gas - /datum/artifact_trigger/pressure - /datum/artifact_trigger/temperature"
+
 //override procs in children as necessary
 /datum/artifact_effect
 	var/effecttype = "unknown"		//purely used for admin checks ingame, not needed any more
@@ -190,9 +192,9 @@
 	if(effect == ARTIFACT_EFFECT_TOUCH)
 		triggertype = /datum/artifact_trigger/touch
 	else if (primary_effect)
-		triggertype = pick(typesof(/datum/artifact_trigger) - /datum/artifact_trigger)
+		triggertype = pick(typesof(/datum/artifact_trigger) - BLACKLISTED_TRIGGERS)
 	else
-		triggertype = pick(typesof(/datum/artifact_trigger) - /datum/artifact_trigger - /datum/artifact_trigger/pay2use)
+		triggertype = pick(typesof(/datum/artifact_trigger) - BLACKLISTED_TRIGGERS - /datum/artifact_trigger/pay2use)
 
 	trigger = new triggertype(src)
 
@@ -215,3 +217,5 @@
 	copy_for_battery = null
 	holder = null
 	..()
+
+#undef BLACKLISTED_TRIGGERS


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Exactly what it says on the tin.
It removes the atmos related triggers (temp, pressure, gas type) and the effects (heating, cooling, and gas synth) from the xenoarch large artifacts.
This doesn't remove them from the game entirely though. You can still admin spawn large artifacts with these triggers/effects and any other means of creation.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
I HATE THE ATMOS-CHRIST I HATE THE ATMOS-CHRIST I HATE THE ATMOS-CHRIST I HATE THE ATMOS-CHRIST I HATE THE ATMOS-CHRIST I HATE THE ATMOS-CHRIST I HATE THE ATMOS-CHRIST I HATE THE ATMOS-CHRIST I HATE THE ATMOS-CHRIST I HATE THE ATMOS-CHRIST I HATE THE ATMOS-CHRIST I HATE THE ATMOS-CHRIST I HATE THE ATMOS-CHRIST

Jokes aside, atmos related stuff is by far the worst trigger/effect conditions when you ask most players familiar with the process, including myself. When considered together on each side of triggers/effects, they occupy a good chunk of each list as there is 3 in each which is roughly a 1 in 3 chance. There is still plenty of experimentation that doesn't require you to plasma flood the room or create skeleton crushing pressure rooms to get an artifact that charges batteries or harms you further.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
It isn't. If you want to spend the time hunting for a natural large artifact with another layer of RNG to get it to have atmos related effects then be my guest.
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscdel: Large artifacts from xenoarch with the random effects/triggers no longer naturally appear with atmos related effects/triggers.