### PR TITLE
Cleans up disintegrator ray code

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/human/grey.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/grey.dm
@@ -357,7 +357,7 @@
 /mob/living/simple_animal/hostile/humanoid/grey/soldier/regular/Life()
 	..()
 	if(scramble == 0)
-		projectiletype = /obj/item/projectile/beam/immolationray
+		projectiletype = /obj/item/projectile/beam/scorchray/immolationray
 		projectilesound = 'sound/weapons/ray1.ogg'
 		icon_state = "greysoldier"
 		icon_living = "greysoldier"
@@ -543,7 +543,7 @@
 	waterproof = 1
 	var/shield_up = 0
 
-	projectiletype = /obj/item/projectile/beam/immolationray
+	projectiletype = /obj/item/projectile/beam/scorchray/immolationray
 	projectilesound = 'sound/weapons/ray1.ogg'
 	retreat_distance = 3
 	minimum_distance = 3
@@ -707,7 +707,7 @@
 	speak = list("Sweeping sector, prepared for EVA maneuvers.","Praise the mothership, and all hail the Chairman.","Air supply capacity check is green.","Terminate all unauthorized personnel and unidentified xenofauna.")
 	speak_chance = 1
 
-	projectiletype = /obj/item/projectile/beam/immolationray
+	projectiletype = /obj/item/projectile/beam/scorchray/immolationray
 	projectilesound = 'sound/weapons/ray1.ogg'
 	retreat_distance = 5
 	minimum_distance = 5
@@ -1041,7 +1041,7 @@
 
 	faction = "mothership"
 
-	projectiletype = /obj/item/projectile/beam/atomizationray
+	projectiletype = /obj/item/projectile/beam/scorchray/atomizationray
 	projectilesound = 'sound/weapons/ray1.ogg'
 	retreat_distance = 8
 	minimum_distance = 8

--- a/code/modules/mob/living/simple_animal/hostile/mothership_creatures.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mothership_creatures.dm
@@ -123,7 +123,7 @@
 	speed = 3
 
 	ranged = 1
-	projectiletype = /obj/item/projectile/beam/immolationray/upgraded // A unique beam that deals more damage than a regular immolation ray and can destroy walls
+	projectiletype = /obj/item/projectile/beam/scorchray/immolationray/upgraded // A unique beam that deals more damage than a regular immolation ray and can destroy walls
 	projectilesound = 'sound/weapons/ray1.ogg'
 	retreat_distance = 8 // It will attempt to linger at a distance just outside of a player's typical field of view, firing shots while deflecting return fire off its armor
 	minimum_distance = 8

--- a/code/modules/projectiles/guns/energy/disintegrator.dm
+++ b/code/modules/projectiles/guns/energy/disintegrator.dm
@@ -53,7 +53,7 @@
 	fire_sound = 'sound/weapons/ray1.ogg'
 
 	charge_cost = 50 //How much energy is needed to fire.
-	projectile_type = "/obj/item/projectile/beam/immolationray"
+	projectile_type = "/obj/item/projectile/beam/scorchray/immolationray"
 	origin_tech = Tc_COMBAT + "=4;" + Tc_MAGNETS + "=2;" + Tc_MATERIALS + "=2"
 	modifystate = "heavydisintegratorimmolate"
 	fire_delay = 1.2 SECONDS // Here to slightly counterbalance the more damaging ray, but a lot less noticeable than the laser cannon
@@ -76,7 +76,7 @@
 			mode = 0
 			fire_sound = 'sound/weapons/ray1.ogg'
 			to_chat(user, "<span class='warning'>\The [src] is now set to immolate.</span>")
-			projectile_type = "/obj/item/projectile/beam/immolationray"
+			projectile_type = "/obj/item/projectile/beam/scorchray/immolationray"
 			modifystate = "heavydisintegratorimmolate"
 			if (power_supply.charge > 0)
 				playsound(user,'sound/weapons/egun_toggle_taser.ogg',70,0,-5)
@@ -95,7 +95,7 @@
 	fire_sound = 'sound/weapons/ray1.ogg'
 
 	charge_cost = 50 //How much energy is needed to fire.
-	projectile_type = "/obj/item/projectile/beam/atomizationray"
+	projectile_type = "/obj/item/projectile/beam/scorchray/atomizationray"
 	origin_tech = Tc_COMBAT + "=5;" + Tc_MATERIALS + "=3" + Tc_POWERSTORAGE + "=4"
 	fire_delay = 0.6 SECONDS // Barely noticeable, mostly here to allow the firing noise .ogg to finish ~0.55 seconds
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -482,35 +482,32 @@ var/list/beam_master = list()
 /obj/item/projectile/beam/scorchray/on_hit(var/atom/target, var/blocked = 0)
 	if(!..())
 		return 0
-	var/mob/living/M = target
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = M
-		var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
-		if (H.isDead())
-			if (H.species.anatomy_flags & NO_BLOOD) // This way it should only apply to the more fleshy species (To-Do: Add animations for mushmen, catbeasts, skrell, and unathi)
-				return 0
-			var/lying_animation = "dust-h2-nohead" //Defaults to humanoid ashing sprites if it doesn't get changed
-			var/standing_animation = "dust-h-nohead"
-			if(isgrey(H))
-				lying_animation = "dust-g2-nohead"
-				standing_animation = "dust-g-nohead"
-			else if(isvox(H))
-				lying_animation = "dust-v2-nohead"
-				standing_animation = "dust-v-nohead"
-			else if(isinsectoid(H))
-				lying_animation = "dust-i2-nohead"
-				standing_animation = "dust-i-nohead"
-			H.visible_message("<span class='danger'>[H.name]'s body disintegrates into ash!</span>")
-			playsound(target.loc, 'sound/items/Welder.ogg', 100, 1)
-			H.drop_all() // So their gear doesn't all get deleted
-			if(head_organ)
-				head_organ.droplimb(1,1) // Their body melts, but the head flies off (so they can be revived)
-			if(H.lying)
-				anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = lying_animation, sleeptime = 15)
-			else
-				anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = standing_animation, sleeptime = 15)
-			new /obj/effect/decal/cleanable/ash(get_turf(target))
-			qdel(H)
+	var/mob/living/carbon/human/H = target
+	if(!istype(H) || !H.isDead() || !(H.species.anatomy_flags & NO_BLOOD)) //Not human, not dead or doesn't have blood
+		return 1 // This way it should only apply to the more fleshy species (To-Do: Add animations for mushmen, catbeasts, skrell, and unathi)
+	var/lying_animation = "dust-h2-nohead" //Defaults to humanoid ashing sprites if it doesn't get changed
+	var/standing_animation = "dust-h-nohead"
+	if(isgrey(H))
+		lying_animation = "dust-g2-nohead"
+		standing_animation = "dust-g-nohead"
+	else if(isvox(H))
+		lying_animation = "dust-v2-nohead"
+		standing_animation = "dust-v-nohead"
+	else if(isinsectoid(H))
+		lying_animation = "dust-i2-nohead"
+		standing_animation = "dust-i-nohead"
+	H.visible_message("<span class='danger'>[H.name]'s body disintegrates into ash!</span>")
+	playsound(target.loc, 'sound/items/Welder.ogg', 100, 1)
+	H.drop_all() // So their gear doesn't all get deleted
+	var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
+	if(head_organ)
+		head_organ.droplimb(1,1) // Their body melts, but the head flies off (so they can be revived)
+	if(H.lying)
+		anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = lying_animation, sleeptime = 15)
+	else
+		anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = standing_animation, sleeptime = 15)
+	new /obj/effect/decal/cleanable/ash(get_turf(target))
+	qdel(H)
 	return 1
 
 /obj/item/projectile/beam/scorchray/immolationray

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -488,237 +488,45 @@ var/list/beam_master = list()
 			if (H.isDead())
 				if (H.species.anatomy_flags & NO_BLOOD) // This way it should only apply to the more fleshy species (To-Do: Add animations for mushmen, catbeasts, skrell, and unathi)
 					return 0
+				var/lying_animation = "dust-h2-nohead" //Defaults to humanoid ashing sprites if it doesn't get changed
+				var/standing_animation = "dust-h-nohead"
 				if(isgrey(H))
-					H.visible_message("<span class='danger'>[H.name]'s body disintegrates into ash!</span>")
-					playsound(target.loc, 'sound/items/Welder.ogg', 100, 1)
-
-					if(H.lying)
-						H.drop_all() // So their gear doesn't all get deleted
-						head_organ.droplimb(1,1) // Their body melts, but the head flies off (so they can be revived)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-g2-nohead", sleeptime = 15)
-					else
-						H.drop_all()
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-g-nohead", sleeptime = 15)
-
-					new /obj/effect/decal/cleanable/ash(get_turf(target))
-					qdel(H)
-
-				if(isvox(H))
-					H.visible_message("<span class='danger'>[H.name]'s body disintegrates into ash!</span>")
-					playsound(target.loc, 'sound/items/Welder.ogg', 100, 1)
-
-					if(H.lying)
-						H.drop_all() // So their gear doesn't all get deleted
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-v2-nohead", sleeptime = 15)
-					else
-						H.drop_all()
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-v-nohead", sleeptime = 15)
-
-					new /obj/effect/decal/cleanable/ash(get_turf(target))
-					qdel(H)
-
-				if(isinsectoid(H))
-					H.visible_message("<span class='danger'>[H.name]'s body disintegrates into ash!</span>")
-					playsound(target.loc, 'sound/items/Welder.ogg', 100, 1)
-
-					if(H.lying)
-						H.drop_all() // So their gear doesn't all get deleted
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-i2-nohead", sleeptime = 15)
-					else
-						H.drop_all()
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-i-nohead", sleeptime = 15)
-
-					new /obj/effect/decal/cleanable/ash(get_turf(target))
-					qdel(H)
-
-				if(ishuman(H))
-					H.visible_message("<span class='danger'>[H.name]'s body disintegrates into ash!</span>")
-					playsound(target.loc, 'sound/items/Welder.ogg', 100, 1)
-
-					if(H.lying)
-						H.drop_all() // So their gear doesn't all get deleted
-						head_organ.droplimb(1,1) // Their body melts, but the head flies off
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-h2-nohead", sleeptime = 15)
-					else
-						H.drop_all()
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-h-nohead", sleeptime = 15)
-
-					new /obj/effect/decal/cleanable/ash(get_turf(target))
-					qdel(H)
+					lying_animation = "dust-g2-nohead"
+					standing_animation = "dust-g-nohead"
+				else if(isvox(H))
+					lying_animation = "dust-v2-nohead"
+					standing_animation = "dust-v-nohead"
+				else if(isinsectoid(H))
+					lying_animation = "dust-i2-nohead"
+					standing_animation = "dust-i-nohead"
+				H.visible_message("<span class='danger'>[H.name]'s body disintegrates into ash!</span>")
+				playsound(target.loc, 'sound/items/Welder.ogg', 100, 1)
+				if(H.lying)
+					H.drop_all() // So their gear doesn't all get deleted
+					head_organ.droplimb(1,1) // Their body melts, but the head flies off (so they can be revived)
+					anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = lying_animation, sleeptime = 15)
+				else
+					H.drop_all()
+					head_organ.droplimb(1,1)
+					anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = standing_animation, sleeptime = 15)
+				new /obj/effect/decal/cleanable/ash(get_turf(target))
+				qdel(H)
 		else
 			return 1
 
-/obj/item/projectile/beam/immolationray
+/obj/item/projectile/beam/scorchray/immolationray
 	name = "immolation ray"
 	icon_state = "immolationray"
 	damage = 45
-	fire_sound = 'sound/weapons/ray1.ogg'
 
-/obj/item/projectile/beam/immolationray/on_hit(var/atom/target, var/blocked = 0)
-	if(istype(target, /mob/living))
-		var/mob/living/M = target
-		if(ishuman(target))
-			var/mob/living/carbon/human/H = M
-			var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
-			if (H.isDead())
-				if (H.species.anatomy_flags & NO_BLOOD) // This way it should only apply to the more fleshy species (To-Do: Add animations for mushmen, catbeasts, skrell, and unathi)
-					return 0
-				if(isgrey(H))
-					H.visible_message("<span class='danger'>[H.name]'s body disintegrates into ash!</span>")
-					playsound(target.loc, 'sound/items/Welder.ogg', 100, 1)
-
-					if(H.lying)
-						H.drop_all() // So their gear doesn't all get deleted
-						head_organ.droplimb(1,1) // Their body melts, but the head flies off (so they can be revived)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-g2-nohead", sleeptime = 15)
-					else
-						H.drop_all()
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-g-nohead", sleeptime = 15)
-
-					new /obj/effect/decal/cleanable/ash(get_turf(target))
-					qdel(H)
-
-				if(isvox(H))
-					H.visible_message("<span class='danger'>[H.name]'s body disintegrates into ash!</span>")
-					playsound(target.loc, 'sound/items/Welder.ogg', 100, 1)
-
-					if(H.lying)
-						H.drop_all() // So their gear doesn't all get deleted
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-v2-nohead", sleeptime = 15)
-					else
-						H.drop_all()
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-v-nohead", sleeptime = 15)
-
-					new /obj/effect/decal/cleanable/ash(get_turf(target))
-					qdel(H)
-
-				if(isinsectoid(H))
-					H.visible_message("<span class='danger'>[H.name]'s body disintegrates into ash!</span>")
-					playsound(target.loc, 'sound/items/Welder.ogg', 100, 1)
-
-					if(H.lying)
-						H.drop_all() // So their gear doesn't all get deleted
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-i2-nohead", sleeptime = 15)
-					else
-						H.drop_all()
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-i-nohead", sleeptime = 15)
-
-					new /obj/effect/decal/cleanable/ash(get_turf(target))
-					qdel(H)
-
-				if(ishuman(H))
-					H.visible_message("<span class='danger'>[H.name]'s body disintegrates into ash!</span>")
-					playsound(target.loc, 'sound/items/Welder.ogg', 100, 1)
-
-					if(H.lying)
-						H.drop_all() // So their gear doesn't all get deleted
-						head_organ.droplimb(1,1) // Their body melts, but the head flies off (so they can be revived)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-h2-nohead", sleeptime = 15)
-					else
-						H.drop_all()
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-h-nohead", sleeptime = 15)
-
-					new /obj/effect/decal/cleanable/ash(get_turf(target))
-					qdel(H)
-		else
-			return 1
-
-/obj/item/projectile/beam/immolationray/upgraded // Exclusively used by the hoverdisc drone
+/obj/item/projectile/beam/scorchray/immolationray/upgraded // Exclusively used by the hoverdisc drone
 	damage = 55
 	destroy = 1
 
-/obj/item/projectile/beam/atomizationray
+/obj/item/projectile/beam/scorchray/atomizationray
 	name = "atomization ray"
 	icon_state = "atomray"
 	damage = 40
-	fire_sound = 'sound/weapons/ray1.ogg'
-
-/obj/item/projectile/beam/atomizationray/on_hit(var/atom/target, var/blocked = 0)
-	if(istype(target, /mob/living))
-		var/mob/living/M = target
-		if(ishuman(target))
-			var/mob/living/carbon/human/H = M
-			var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
-			if (H.isDead())
-				if (H.species.anatomy_flags & NO_BLOOD) // This way it should only apply to the more fleshy species (To-Do: Add animations for mushmen, catbeasts, skrell, and unathi)
-					return 0
-				if(isgrey(H))
-					H.visible_message("<span class='danger'>[H.name]'s body disintegrates into ash!</span>")
-					playsound(target.loc, 'sound/items/Welder.ogg', 100, 1)
-
-					if(H.lying)
-						H.drop_all() // So their gear doesn't all get deleted
-						head_organ.droplimb(1,1) // Their body melts, but the head flies off (so they can be revived)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-g2-nohead", sleeptime = 15)
-					else
-						H.drop_all()
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-g-nohead", sleeptime = 15)
-
-					new /obj/effect/decal/cleanable/ash(get_turf(target))
-					qdel(H)
-
-				if(isvox(H))
-					H.visible_message("<span class='danger'>[H.name]'s body disintegrates into ash!</span>")
-					playsound(target.loc, 'sound/items/Welder.ogg', 100, 1)
-
-					if(H.lying)
-						H.drop_all() // So their gear doesn't all get deleted
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-v2-nohead", sleeptime = 15)
-					else
-						H.drop_all()
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-v-nohead", sleeptime = 15)
-
-					new /obj/effect/decal/cleanable/ash(get_turf(target))
-					qdel(H)
-
-				if(isinsectoid(H))
-					H.visible_message("<span class='danger'>[H.name]'s body disintegrates into ash!</span>")
-					playsound(target.loc, 'sound/items/Welder.ogg', 100, 1)
-
-					if(H.lying)
-						H.drop_all() // So their gear doesn't all get deleted
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-i2-nohead", sleeptime = 15)
-					else
-						H.drop_all()
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-i-nohead", sleeptime = 15)
-
-					new /obj/effect/decal/cleanable/ash(get_turf(target))
-					qdel(H)
-
-				if(ishuman(H))
-					H.visible_message("<span class='danger'>[H.name]'s body disintegrates into ash!</span>")
-					playsound(target.loc, 'sound/items/Welder.ogg', 100, 1)
-
-					if(H.lying)
-						H.drop_all() // So their gear doesn't all get deleted
-						head_organ.droplimb(1,1) // Their body melts, but the head flies off (so they can be revived)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-h2-nohead", sleeptime = 15)
-					else
-						H.drop_all()
-						head_organ.droplimb(1,1)
-						anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = "dust-h-nohead", sleeptime = 15)
-
-					new /obj/effect/decal/cleanable/ash(get_turf(target))
-					qdel(H)
-		else
-			return 1
 
 /obj/item/projectile/beam/lightlaser
 	name = "light laser"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -480,39 +480,38 @@ var/list/beam_master = list()
 	fire_sound = 'sound/weapons/ray1.ogg'
 
 /obj/item/projectile/beam/scorchray/on_hit(var/atom/target, var/blocked = 0)
-	if(istype(target, /mob/living))
-		var/mob/living/M = target
-		if(ishuman(target))
-			var/mob/living/carbon/human/H = M
-			var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
-			if (H.isDead())
-				if (H.species.anatomy_flags & NO_BLOOD) // This way it should only apply to the more fleshy species (To-Do: Add animations for mushmen, catbeasts, skrell, and unathi)
-					return 0
-				var/lying_animation = "dust-h2-nohead" //Defaults to humanoid ashing sprites if it doesn't get changed
-				var/standing_animation = "dust-h-nohead"
-				if(isgrey(H))
-					lying_animation = "dust-g2-nohead"
-					standing_animation = "dust-g-nohead"
-				else if(isvox(H))
-					lying_animation = "dust-v2-nohead"
-					standing_animation = "dust-v-nohead"
-				else if(isinsectoid(H))
-					lying_animation = "dust-i2-nohead"
-					standing_animation = "dust-i-nohead"
-				H.visible_message("<span class='danger'>[H.name]'s body disintegrates into ash!</span>")
-				playsound(target.loc, 'sound/items/Welder.ogg', 100, 1)
-				if(H.lying)
-					H.drop_all() // So their gear doesn't all get deleted
-					head_organ.droplimb(1,1) // Their body melts, but the head flies off (so they can be revived)
-					anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = lying_animation, sleeptime = 15)
-				else
-					H.drop_all()
-					head_organ.droplimb(1,1)
-					anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = standing_animation, sleeptime = 15)
-				new /obj/effect/decal/cleanable/ash(get_turf(target))
-				qdel(H)
-		else
-			return 1
+	if(!..())
+		return 0
+	var/mob/living/M = target
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = M
+		var/datum/organ/external/head/head_organ = H.get_organ(LIMB_HEAD)
+		if (H.isDead())
+			if (H.species.anatomy_flags & NO_BLOOD) // This way it should only apply to the more fleshy species (To-Do: Add animations for mushmen, catbeasts, skrell, and unathi)
+				return 0
+			var/lying_animation = "dust-h2-nohead" //Defaults to humanoid ashing sprites if it doesn't get changed
+			var/standing_animation = "dust-h-nohead"
+			if(isgrey(H))
+				lying_animation = "dust-g2-nohead"
+				standing_animation = "dust-g-nohead"
+			else if(isvox(H))
+				lying_animation = "dust-v2-nohead"
+				standing_animation = "dust-v-nohead"
+			else if(isinsectoid(H))
+				lying_animation = "dust-i2-nohead"
+				standing_animation = "dust-i-nohead"
+			H.visible_message("<span class='danger'>[H.name]'s body disintegrates into ash!</span>")
+			playsound(target.loc, 'sound/items/Welder.ogg', 100, 1)
+			H.drop_all() // So their gear doesn't all get deleted
+			if(head_organ)
+				head_organ.droplimb(1,1) // Their body melts, but the head flies off (so they can be revived)
+			if(H.lying)
+				anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = lying_animation, sleeptime = 15)
+			else
+				anim(target = H, a_icon = 'icons/mob/mob.dmi', flick_anim = standing_animation, sleeptime = 15)
+			new /obj/effect/decal/cleanable/ash(get_turf(target))
+			qdel(H)
+	return 1
 
 /obj/item/projectile/beam/scorchray/immolationray
 	name = "immolation ray"


### PR DESCRIPTION
Now checks for parent's on_hit code
Also checks whether the target has a head, to avoid runtimes
Made every other type of ray a subtype of scorchray, because there wasn't a real difference between them other than damage and sprites
Compressed a lot of lines of code, removed "isliving()" check because it's checked in the parent

:cl:
 * bugfix: Improved the alien scorch/immolation/atomizing ray code, removing a few potential errors with the way it has been turning targets to dust.