### PR TITLE
Disables ambience while on the login screen

### DIFF
--- a/code/controllers/subsystem/ambient_sound.dm
+++ b/code/controllers/subsystem/ambient_sound.dm
@@ -19,7 +19,9 @@ var/datum/subsystem/ambientsound/SSambience
 		return
 	for (var/client/C in clients)
 		if(C && (C.prefs.toggles & SOUND_AMBIENCE))
-			C.handle_ambience()
+			var/mob/new_player/NP = C.mob
+			if(!istype(NP))
+				C.handle_ambience()
 
 /*
 Ambience system.


### PR DESCRIPTION
Not a good idea for it to play while the lobby is still playing some nice tunes, and there's no station anywhere.

:cl:
 * tweak: Ambience will no longer play on the login screen.