### PR TITLE
Fixes deadchat message formatting

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -74,7 +74,7 @@ var/list/global_deadchat_listeners = list()
 	log_say("[name]/[key_name(src)] (@[location_text]) Deadsay: [message]")
 
 	for(var/mob/M in get_deadchat_hearers())
-		to_chat(M, "[formatFollow(src)] <span class='name'>[name]</span>[alt_name] <span class='message'>[message]</span></span>")
+		to_chat(M, "<span class='game deadsay'>[formatFollow(src)] <span class='name'>[name]</span>[alt_name] <span class='message'>[message]</span></span>")
 
 /mob/proc/get_ear()
 	// returns an atom representing a location on the map from which this


### PR DESCRIPTION
[bugfix]

## How it was tested
speaking in dchat

## Changelog
:cl:
 * bugfix: Speaking in deadchat is now properly color formatted again.