### PR TITLE
Vendor coinbox and vendpack qol

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -1165,7 +1165,8 @@ to destroy them and players will be able to make replacements.
 	req_components = list(
 							/obj/item/weapon/stock_parts/matter_bin = 1,
 							/obj/item/weapon/stock_parts/manipulator = 1,
-							/obj/item/weapon/stock_parts/scanning_module = 1)
+							/obj/item/weapon/stock_parts/scanning_module = 1,
+							/obj/item/stack/sheet/metal = 1)
 
 /obj/item/weapon/circuitboard/pdapainter
 	name = "Circuit Board (PDA Painter)"

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -261,7 +261,7 @@
 											break
 								to_chat(user, desc)
 
-								if(P && P.loc != src && ! (istype(P, /obj/item/stack)))
+								if(P && P.loc != src && ! (istype(P, /obj/item/stack/cable_coil)))
 									to_chat(user, "<span class='warning'>You cannot add that component to the machine!</span>")
 
 /obj/machinery/constructable_frame/machine_frame/proc/set_build_state(var/state)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -261,7 +261,7 @@
 											break
 								to_chat(user, desc)
 
-								if(P && P.loc != src && ! (istype(P, /obj/item/stack/cable_coil)))
+								if(P && P.loc != src && ! (istype(P, /obj/item/stack)))
 									to_chat(user, "<span class='warning'>You cannot add that component to the machine!</span>")
 
 /obj/machinery/constructable_frame/machine_frame/proc/set_build_state(var/state)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -1166,7 +1166,7 @@ to destroy them and players will be able to make replacements.
 							/obj/item/weapon/stock_parts/matter_bin = 1,
 							/obj/item/weapon/stock_parts/manipulator = 1,
 							/obj/item/weapon/stock_parts/scanning_module = 1,
-							/obj/item/stack/sheet/metal = 1)
+							/obj/item/weapon/storage/lockbox/coinbox = 1)
 
 /obj/item/weapon/circuitboard/pdapainter
 	name = "Circuit Board (PDA Painter)"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -141,7 +141,8 @@ var/global/num_vending_terminals = 1
 		/obj/item/weapon/circuitboard/vendomat,\
 		/obj/item/weapon/stock_parts/matter_bin,\
 		/obj/item/weapon/stock_parts/manipulator,\
-		/obj/item/weapon/stock_parts/scanning_module\
+		/obj/item/weapon/stock_parts/scanning_module,\
+		/obj/item/weapon/storage/lockbox/coinbox\
 	)
 
 	RefreshParts()
@@ -154,8 +155,6 @@ var/global/num_vending_terminals = 1
 		last_slogan = world.time + rand(0, slogan_delay)
 
 		power_change()
-
-	coinbox = new(src)
 
 	for(var/langname in slogan_languages)
 		if(istext(langname))
@@ -186,13 +185,14 @@ var/global/num_vending_terminals = 1
 
 /obj/machinery/vending/RefreshParts()
 	var/manipcount = 0
-	var/obj/item/stack/sheet/metal/S = locate() in component_parts
-	if(S)
-		qdel(S) //hotfix so it doesn't show up. TODO: write a better system for excluding stuff like this on built machines and test it all
 	for(var/obj/item/weapon/stock_parts/SP in component_parts)
 		if(istype(SP, /obj/item/weapon/stock_parts/manipulator))
 			manipcount += SP.rating
 	shoot_chance = manipcount * 3
+	
+	coinbox = locate() in component_parts
+	if(!coinbox)
+		coinbox = new(src)
 
 /obj/machinery/vending/Destroy()
 	if(wires)
@@ -293,7 +293,6 @@ var/global/num_vending_terminals = 1
 				if(user.machine==src)
 					newmachine.attack_hand(user)
 				component_parts = 0
-				qdel(coinbox)
 				qdel(src)
 			else
 				is_being_filled = FALSE

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -186,6 +186,9 @@ var/global/num_vending_terminals = 1
 
 /obj/machinery/vending/RefreshParts()
 	var/manipcount = 0
+	var/obj/item/stack/sheet/metal/S = locate() in component_parts
+	if(S)
+		qdel(S) //hotfix so it doesn't show up. TODO: write a better system for excluding stuff like this on built machines and test it all
 	for(var/obj/item/weapon/stock_parts/SP in component_parts)
 		if(istype(SP, /obj/item/weapon/stock_parts/manipulator))
 			manipcount += SP.rating

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -201,15 +201,18 @@ var/global/num_vending_terminals = 1
 /obj/machinery/vending/splashable()
 	return FALSE
 
+/obj/machinery/vending/spillContents(destroy_chance)
+	. = ..()
+	dump_vendpack_and_coinbox()
+
 /obj/machinery/vending/proc/dump_vendpack_and_coinbox()
 	if(product_records.len && cardboard) //Only spit out if we have slotted cardboard
+		var/obj/structure/vendomatpack/custom/newpack = new(src.loc)
 		if(is_custom_machine)
-			var/obj/structure/vendomatpack/custom/newpack = new(src.loc)
 			for(var/obj/item/I in custom_stock)
 				I.forceMove(newpack)
 				custom_stock.Remove(I)
 		else
-			var/obj/structure/vendomatpack/partial/newpack = new(src.loc)
 			newpack.stock = products
 			newpack.secretstock = contraband
 			newpack.preciousstock = premium
@@ -220,7 +223,8 @@ var/global/num_vending_terminals = 1
 			newpack.targetvendomat = src.type
 
 	if(coinbox)
-		coinbox.forceMove(get_turf(src))
+		coinbox.forceMove(src.loc)
+		coinbox = null
 
 /obj/machinery/vending/examine(var/mob/user)
 	..()

--- a/code/game/objects/items/stacks/stack_recipes.dm
+++ b/code/game/objects/items/stacks/stack_recipes.dm
@@ -411,6 +411,7 @@ var/list/datum/stack_recipe/metal_recipes = list (
 	new/datum/stack_recipe("cannonball", /obj/item/cannonball/iron, 20, time = 4 SECONDS, one_per_turf = 0, on_floor = 1),
 	new/datum/stack_recipe("frying pan", /obj/item/weapon/reagent_containers/pan, 10, time = 4 SECONDS, one_per_turf = 0, on_floor = 0),
 	new/datum/stack_recipe("lunch box", /obj/item/weapon/storage/lunchbox/metal, 1, time = 2 SECONDS, one_per_turf = 0, on_floor = 0),
+	new/datum/stack_recipe("coinbox", /obj/item/weapon/storage/lockbox/coinbox/allaccess, 1, time = 2 SECONDS, one_per_turf = 0, on_floor = 0),
 	null,
 	blacksmithing_recipes,
 	null,

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -281,6 +281,9 @@
 	icon_closed = "coinbox"
 	icon_broken = "coinbox+b"
 
+/obj/item/weapon/storage/lockbox/coinbox/allaccess	
+	req_one_access = null
+
 /obj/item/weapon/storage/lockbox/lawgiver
 	name = "lockbox (lawgiver)"
 	req_one_access = list(access_armory)

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -275,8 +275,8 @@
 	throwforce = 10
 	storage_slots = 20
 	req_one_access = list(access_qm)
-	locked = 1
-	broken = 0
+	starting_materials = list(MAT_IRON = CC_PER_SHEET_METAL)
+	w_type = RECYK_ELECTRONIC
 	icon_locked = "coinbox+l"
 	icon_closed = "coinbox"
 	icon_broken = "coinbox+b"


### PR DESCRIPTION
[qol][bugfix]

## What this does
allows vendpacks and coinboxes to come out of vendors on crowbar destruction and not just explosions or blobs.
fixes coinboxes not coming out anymore at all.
allows coinboxes to be recycled in smelters and the autolathe and etc.
to compensate this, their frames now need coinboxes as a component part, and can be built from 1 sheet of metal, but with no access requirements like roundstart vendors have.
Closes #9892.

## Why it's good
stops coinboxes from being duplicated indefinitely and occupying space.

## How it was tested
calling ex_act on the vendors, screwdriver and crowbar destroying them, and putting them back together and screwdriving it to completion.

## Changelog
:cl:
 * bugfix: Coinboxes can now come out of vending machines again.
 * tweak: Coinboxes and vendpacks now eject from crowbar destroying vending machines. Vendpacks still require inserted cardboard for this.
 * tweak: Coinboxes can now be recycled for metal, under the electronics category.
 * tweak: To compensate coinboxes being recyclable, and as to not be an infinite metal source, they are now required in their frame build step. A no access requirement version of them can be built as a metal stack recipe to aid this.