### PR TITLE
Adds a lower bound on mols of oxygen for combustion

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -251,7 +251,7 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	//Rate at which energy is consumed from the burning atom and delivered to the fire.
 	//Provides the "heat" and "oxygen" portions of the fire triangle.
 	var/burnrate = (oxy_ratio/(MINOXY2BURN + rand(-2,2)*0.01)) * (temperature/T20C) //burnrate ~ 1 for standard air
-	if(burnrate < 0.1)
+	if(burnrate < 0.1 || (air[GAS_OXYGEN] * CELL_VOLUME < air.volume)) //evil fucking unit manipulation; extinguishes if less than 1mol O2 per tile in a zone
 		extinguish()
 		return
 
@@ -416,6 +416,8 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	if(!(G.temperature >= autoignition_temperature))
 		return
 	if(!(G.molar_ratio(GAS_OXYGEN) >= MINOXY2BURN))
+		return
+	if(G[GAS_OXYGEN] * CELL_VOLUME < G.volume) //if less than 1 mol/tile, no fire
 		return
 	if(prob(50))
 		ignite()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Combustion will now cease if the average mols/turf drops below 1.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Helps fighting fires by exposing the burning zone to space and closes #36667.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Tested igniting rooms, letting them cook, then breaching the floor with debug messages to monitor the mol count compared to the limit.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Fires will fail to ignite and will extinguish if mols of oxygen per tile drops below 1.