### PR TITLE
Fixes mythril coins recycling but giving no mythril.

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -515,7 +515,7 @@
 	credits = 1000
 
 /obj/item/weapon/coin/mythril
-	material="mythril"
+	material=MAT_MYTHRIL
 	name = "mythril coin"
 	desc = "An expensive coin minted long ago from extremely rare, light, non-conductive metal."
 	icon_state = "coin_mythril"


### PR DESCRIPTION
Turns out the recycling proc checks for the material type, and it expects a MAT_IRON style define, but since mythril had the material type defined as is, it failed.
Of note is that Adamantine coins, Pomfcoins and Pumfcoins still fail and spit out a warning, but adamantine isn't defined as a recyclable material at all, and pomf/pumfcoins are their own thing.
![image](https://github.com/vgstation-coders/vgstation13/assets/67024428/27ab4628-c0ef-46d9-b895-07ab51923da7)
## What this does
Fixes mythril coins recycling but giving zero material.
## Why it's good
Fixes an oversight.
## How it was tested
Spawned a couple mythril coins, recycled them, then made some coins with the press, recycled them, both work as intended.
:cl:
 * bugfix: Mythril coins will now recycle properly.
