### PR TITLE
FIXES BAGULOOSE QUICK EQUIP EXPLOIT

### DIFF
--- a/code/game/objects/items/weapons/storage/bluespace.dm
+++ b/code/game/objects/items/weapons/storage/bluespace.dm
@@ -39,6 +39,7 @@
 	var/list/recursive_list = recursive_type_check(W, /obj/item/weapon/storage/backpack/holding)
 	if(recursive_list.len) // Placing a bag of holding into another will singuloose when stored inside other objects too, such as when on your back or on a diona's back and stuffed in
 		singulocreate(recursive_list, usr)
+		return
 
 //BoH+BoH=Singularity, WAS commented out
 /obj/item/weapon/storage/backpack/holding/proc/singulocreate(var/list/obj/item/weapon/storage/backpack/holding/Hs, var/mob/user)

--- a/code/game/objects/items/weapons/storage/bluespace.dm
+++ b/code/game/objects/items/weapons/storage/bluespace.dm
@@ -33,13 +33,12 @@
 	qdel(user)
 
 /obj/item/weapon/storage/backpack/holding/handle_item_insertion(obj/item/W, prevent_warning)
+	. = ..()
 	if(W == src)
 		return // HOLY FUCKING SHIT WHY STORAGE CODE, WHY - pomf
 	var/list/recursive_list = recursive_type_check(W, /obj/item/weapon/storage/backpack/holding)
 	if(recursive_list.len) // Placing a bag of holding into another will singuloose when stored inside other objects too, such as when on your back or on a diona's back and stuffed in
 		singulocreate(recursive_list, usr)
-		return
-	. = ..()
 
 //BoH+BoH=Singularity, WAS commented out
 /obj/item/weapon/storage/backpack/holding/proc/singulocreate(var/list/obj/item/weapon/storage/backpack/holding/Hs, var/mob/user)

--- a/code/game/objects/items/weapons/storage/bluespace.dm
+++ b/code/game/objects/items/weapons/storage/bluespace.dm
@@ -32,14 +32,14 @@
 	user.drop_item(src)
 	qdel(user)
 
-/obj/item/weapon/storage/backpack/holding/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	. = ..()
+/obj/item/weapon/storage/backpack/holding/handle_item_insertion(obj/item/W, prevent_warning)
 	if(W == src)
 		return // HOLY FUCKING SHIT WHY STORAGE CODE, WHY - pomf
 	var/list/recursive_list = recursive_type_check(W, /obj/item/weapon/storage/backpack/holding)
 	if(recursive_list.len) // Placing a bag of holding into another will singuloose when stored inside other objects too, such as when on your back or on a diona's back and stuffed in
-		singulocreate(recursive_list, user)
+		singulocreate(recursive_list, usr)
 		return
+	. = ..()
 
 //BoH+BoH=Singularity, WAS commented out
 /obj/item/weapon/storage/backpack/holding/proc/singulocreate(var/list/obj/item/weapon/storage/backpack/holding/Hs, var/mob/user)


### PR DESCRIPTION
[bugfix][ITSLOOSE]

## What this does
Closes #36674.

## How it was tested
clicking the bag with the other bag, and quick equipping.

## Changelog
:cl:
 * bugfix: Quick equipping a bag of holding into another bag of holding no longer bypasses baguloosing.