### PR TITLE
Converts hand and mop washing in sinks to normal action delays

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -518,39 +518,34 @@
 
 	to_chat(usr, "<span class='notice'>You start washing your hands.</span>")
 
-	busy = 1
-	sleep(40)
-	busy = 0
+	busy = TRUE
+	if (do_after(M,src, 40))
+		M.clean_blood()
+		if(ishuman(M))
+			M:update_inv_gloves()
+			var/mob/living/carbon/human/HM = M
 
-	if(!Adjacent(M))
-		return		//Person has moved away from the sink
+			if(!HM.gloves && HM.species && HM.species.anatomy_flags & ACID4WATER)
+				HM.adjustFireLossByPart(rand(5, 10), LIMB_LEFT_HAND, src)
+				HM.adjustFireLossByPart(rand(5, 10), LIMB_RIGHT_HAND, src)
 
-	M.clean_blood()
-	if(ishuman(M))
-		M:update_inv_gloves()
-		var/mob/living/carbon/human/HM = M
-
-		if(!HM.gloves && HM.species && HM.species.anatomy_flags & ACID4WATER)
-			HM.adjustFireLossByPart(rand(5, 10), LIMB_LEFT_HAND, src)
-			HM.adjustFireLossByPart(rand(5, 10), LIMB_RIGHT_HAND, src)
-
-	for(var/mob/V in viewers(src, null))
-		V.show_message("<span class='notice'>[M] washes their hands using \the [src].</span>")
+		M.visible_message("<span class='notice'>[M] washes \his hands using \the [src].</span>","<span class='notice'>You wash your hands using \the [src].</span>")
+	busy = FALSE
 
 /obj/structure/sink/mop_act(obj/item/weapon/mop/M, mob/user)
 	if(busy)
 		return 1
 	user.visible_message("<span class='notice'>[user] puts \the [M] underneath the running water.","<span class='notice'>You put \the [M] underneath the running water.</span>")
-	busy = 1
-	sleep(40)
-	busy = 0
-	M.clean_blood()
-	if(M.reagents.maximum_volume > M.reagents.total_volume)
-		playsound(src, 'sound/effects/slosh.ogg', 25, 1)
-		M.reagents.add_reagent(WATER, min(M.reagents.maximum_volume - M.reagents.total_volume, 50))
-		user.visible_message("<span class='notice'>[user] finishes soaking \the [M], \he could clean the entire station with that.</span>","<span class='notice'>You finish soaking \the [M], you feel as if you could clean anything now, even the Chef's backroom...</span>")
-	else
-		user.visible_message("<span class='notice'>[user] removes \the [M], cleaner than before.</span>","<span class='notice'>You remove \the [M] from \the [src], it's all nice and sparkly now but somehow didnt get it any wetter.</span>")
+	busy = TRUE
+	if (do_after(user,src, 40))
+		M.clean_blood()
+		if(M.reagents.maximum_volume > M.reagents.total_volume)
+			playsound(src, 'sound/effects/slosh.ogg', 25, 1)
+			M.reagents.add_reagent(WATER, min(M.reagents.maximum_volume - M.reagents.total_volume, 50))
+			user.visible_message("<span class='notice'>[user] finishes soaking \the [M], \he could clean the entire station with that.</span>","<span class='notice'>You finish soaking \the [M], you feel as if you could clean anything now, even the Chef's backroom...</span>")
+		else
+			user.visible_message("<span class='notice'>[user] removes \the [M], cleaner than before.</span>","<span class='notice'>You remove \the [M] from \the [src], it's all nice and sparkly now but somehow didnt get it any wetter.</span>")
+	busy = FALSE
 	return 1
 
 /obj/structure/sink/attackby(obj/item/O as obj, mob/user as mob)


### PR DESCRIPTION
[consistency]

## What this does
makes it work the same as washing items

## How it was tested
putting a mop under it, then eswording a mob and washing hands in the sink after it

## Changelog
:cl:
 * bugfix: Washing hands and mops in the sink now use the same delay bars as washing other items.