### PR TITLE
logging of player numbers at roundstart

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -317,6 +317,7 @@ var/datum/controller/gameticker/ticker
 	post_roundstart()
 	log_admin("Roundstart complete in [(get_game_time() - total_tick) / 10] seconds.")
 	message_admins("Roundstart complete in [(get_game_time() - total_tick) / 10] seconds.")
+	log_admin("Round started with [new_players_ready.len] players. There are [clients.len] players total. There are currently [admins.len] admins online")
 	return 1
 
 /mob/living/carbon/human/proc/make_fake_ai()


### PR DESCRIPTION
[logging]

## What this does
has the game log total player count, the number of players who played roundstart, and the number of admins online at roundstart
![round](https://github.com/vgstation-coders/vgstation13/assets/68451232/7b083a98-0072-4a75-90bc-aba04fb61802)


## Why it's good
stats autism

## How it was tested
booted up the game and looked at logs. tested while readied and not readied, as well as being booted to the lobby due to prefrences.