### PR TITLE
Makes deconstructing reinforced walls a bit faster

### DIFF
--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -56,7 +56,7 @@
 	update_paint_overlay()
 
 /turf/simulated/wall/r_wall/attackby(obj/item/W as obj, mob/user as mob)
-	user.delayNextAttack(W.attack_delay)
+	user.delayNextAttack(5)
 	if (!user.dexterity_check())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
@@ -350,6 +350,7 @@
 	//This is obsolete since reinforced false walls were commented out, but gotta slap the wall with my hand anyways !
 	else if(!d_state)
 		if(istype(W, /obj/item/tool/crowbar/red))
+			user.delayNextAttack(W.attack_delay)
 			playsound(src, "crowbar_hit", 50, 1, -1)
 		else
 			return attack_hand(user)


### PR DESCRIPTION
[tweak] [qol]

## What this does
Lowers the CD on attacking a reinforced wall from 1 second to 0.5
This lowers the time on a single wall when perfectly timed by around 4 seconds (it still takes about a minute either way for reference) but significantly speeds up removing more than one at a time since you can work on each one at the same time.

## Why it's good
After R walls got an attack cooldown deconstructing them en masse has felt really bad. The majority of time this is ever done is with vaults or with building projects, while this does slightly lower the time taken to remove a single wall it's still faster just to use thermite and I don't remember this ever being a problem even when the cooldown was zero before. Generally I think it'll just make it feel better when people actually want to interact with removing walls and be unnoticable when they have to.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 - tweak: Changed reinforced wall attack cd from 1 second to 0.5
