### PR TITLE
Grues will skeletonize humans instead of gibbing them

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -615,14 +615,14 @@
 //Eating sentient beings.
 
 /mob/living/simple_animal/hostile/grue/proc/handle_feed(var/mob/living/E)
-	if(isskellington(E)) //This also covers skeleton vox
-		to_chat(src, "<span class='warning'>There is nothing to eat! It is only bone!</span>")
+	if(isskellington(E)) //Don't let them eat the mob, does not apply to other skeleton races because it is more fun that way
+		to_chat(src, "<span class='warning'>It has no flesh to eat!</span>")
 		return
 	visible_message("<span class='danger'>\The [src] opens its mouth wide...</span>","<span class='danger'>You open your mouth wide, preparing to eat \the [E]!</span>")
 	busy=TRUE
 	if(do_mob(src , E, eattime, eattime, 0)) //check on every tick
-		if(isskellington(E)) //Sanity
-			to_chat(src, "<span class='warning'>Somehow the victim became a skeleton before you finished eating! You cannot eat it!</span>")
+		if(isskellington(E))
+			to_chat(src, "<span class='warning'>Somehow it already became a skeleton! You cannot eat it!</span>")
 			busy = FALSE
 			return
 		to_chat(src, "<span class='danger'>You have eaten \the [E]!</span>")
@@ -646,18 +646,26 @@
 		else
 			to_chat(src, "<span class='warning'>That creature didn't quite satisfy your hunger...</span>")
 		E.drop_all()
-		if(ishuman(E)) //Strip all the flesh from the mob if it's human
-			var/mob/living/carbon/human/H = E //The skeleton check is above so we don't need one here
+		if(can_skeletonize(E))
+			var/mob/living/carbon/human/H = E
+			gibs(H.loc, H.virus2, H.dna)
 			if(isvox(H))
 				H.set_species("Skeletal Vox")
 			else
 				H.set_species("Skellington")
 			H.regenerate_icons()
-			gibs(H.loc, H.virus2, H.dna)
 			H.death(FALSE)
 		else //Eat the mob otherwise
 			E.gib()
 	busy=FALSE
+
+//Determines whether the human will be gibbed or turned into a skeleton
+/mob/living/simple_animal/hostile/grue/proc/can_skeletonize(var/mob/living/E)
+	if(ishuman(E))
+		var/mob/living/carbon/human/H = E
+		if(H.species.anatomy_flags & NO_BLOOD)
+			return 0
+	return 1
 
 /mob/living/simple_animal/hostile/grue/proc/grue_stat_updates(var/feed_verbose = FALSE) //update stats, called by lifestage_updates() as well as handle_feed()
 

--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -615,16 +615,9 @@
 //Eating sentient beings.
 
 /mob/living/simple_animal/hostile/grue/proc/handle_feed(var/mob/living/E)
-	if(isskellington(E)) //Don't let them eat the mob, does not apply to other skeleton races because it is more fun that way
-		to_chat(src, "<span class='warning'>It has no flesh to eat!</span>")
-		return
 	visible_message("<span class='danger'>\The [src] opens its mouth wide...</span>","<span class='danger'>You open your mouth wide, preparing to eat \the [E]!</span>")
 	busy=TRUE
 	if(do_mob(src , E, eattime, eattime, 0)) //check on every tick
-		if(isskellington(E))
-			to_chat(src, "<span class='warning'>Somehow it already became a skeleton! You cannot eat it!</span>")
-			busy = FALSE
-			return
 		to_chat(src, "<span class='danger'>You have eaten \the [E]!</span>")
 		to_chat(E, "<span class='danger'>You have been eaten by a grue.</span>")
 
@@ -634,7 +627,7 @@
 		E.reagents.trans_to(src, E.reagents.total_volume)
 
 		//Upgrade the grue's stats as it feeds
-		if(E.mind) //eaten creature must have a mind to power up the grue
+		if(E.mind && !isskellington(E)) //eaten creature must have a mind to power up the grue, and mustn't be pure skeletons
 			playsound(src, 'sound/misc/grue_growl.ogg', 50, 1)
 			eatencount++					//makes the grue stronger
 			if(mind && mind.GetRole(GRUE)) //also increment the counter for objectives
@@ -644,7 +637,10 @@
 			eatencharge++ //can be spent on egg laying
 			grue_stat_updates(TRUE)
 		else
-			to_chat(src, "<span class='warning'>That creature didn't quite satisfy your hunger...</span>")
+			if(isskellington(E))
+				to_chat(src, "<span class='warning'>That creature was only bones, and didn't quite satisfy your hunger...</span>")
+			else
+				to_chat(src, "<span class='warning'>That creature didn't quite satisfy your hunger...</span>")
 		E.drop_all()
 		if(can_skeletonize(E))
 			var/mob/living/carbon/human/H = E

--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -642,7 +642,7 @@
 		E.drop_all()
 		if(can_skeletonize(E))
 			var/mob/living/carbon/human/H = E
-			gibs(H.loc, H.virus2, H.dna)
+			gibs(H.loc, H.virus2, H.dna, H.species.flesh_color, H.species.blood_color)
 			if(isvox(H))
 				H.set_species("Skeletal Vox")
 			else

--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -262,8 +262,6 @@
 	if(lifestage>=GRUE_JUVENILE && stance==HOSTILE_STANCE_IDLE && lightparams.dark_dim_light<GRUE_LIGHT)
 		var/list/feed_targets = list()
 		for(var/mob/living/carbon/C in range(1,get_turf(src)))
-			if(isskellington(C))
-				continue
 			feed_targets += C
 		if(feed_targets.len)
 			handle_feed(pick(feed_targets))

--- a/code/modules/mob/living/simple_animal/hostile/grue_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue_powers.dm
@@ -1,6 +1,6 @@
 /spell/targeted/grue_eat
 	name = "Eat"
-	desc = "Eat someone. Doesn't work on certain skeletons."
+	desc = "Eat someone."
 	user_type = USER_TYPE_GRUE
 	panel = "Grue"
 	hud_state = "grue_eat"

--- a/code/modules/mob/living/simple_animal/hostile/grue_powers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue_powers.dm
@@ -1,6 +1,6 @@
 /spell/targeted/grue_eat
 	name = "Eat"
-	desc = "Eat someone."
+	desc = "Eat someone. Doesn't work on certain skeletons."
 	user_type = USER_TYPE_GRUE
 	panel = "Grue"
 	hud_state = "grue_eat"


### PR DESCRIPTION
![spook](https://github.com/vgstation-coders/vgstation13/assets/41342767/dae97f94-4b35-49db-87d1-66be004b3b56)
(not pictured, the items that would actually drop from eaten people)

I think it's more fun this way. Plus if the skeletons come back for revenge against the grue they're way easier to defeat due to their double brute damage taken, but the grue won't get more powerful from eating them.

The grue is free to still tear the skeletons apart by eating it twice.

Additionally it can't actually skeletonize creatures that don't really have skeletons or are skeletons such as silicons, plasmamen, slime people, golems and so on. They will get gibbed instead.

## DO NOT MERGE UNTIL #36706 IS MERGED

:cl:
 * tweak: Grues will now strip the flesh off of the bones of humans they kill instead of gibbing them, unless they are races with no blood such as plasmamen. They can chomp them again to gib them.
 * tweak: Grues can no longer gain power from eating pure skeletons. Does not include plasmamen or liches.
