### PR TITLE
Skeletons and liches no longer have damage overlays

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -158,6 +158,8 @@ var/global/list/playable_species = list("Human")
 
 	var/datum/speech_filter/speech_filter
 
+	var/list/damage_overlays = list("brute", "burn") //What damage overlays will be rendered on the species when harmed
+
 /datum/species/New()
 	..()
 	if(all_species[name])
@@ -457,6 +459,7 @@ var/global/list/playable_species = list("Human")
 					You have no skin, no blood, no lips, and only just enough brain to function.<br>\
 					You can not eat normally, as your necrotic state only permits you to only eat raw flesh. As you lack skin, you can not be injected via syringe.<br>\
 					You are also incredibly weak to brute damage, but you're fast and don't need to breathe, so that's going for you."
+	damage_overlays = list()
 
 /datum/species/skellington/conditional_playable()
 	var/MM = text2num(time2text(world.timeofday, "MM"))
@@ -1272,6 +1275,7 @@ var/list/has_died_as_golem = list()
 					A more refined version of the skellington, you're not as brittle, but not quite as fast.<br>\
 					You have no skin, no blood, and only a brain to guide you.<br>\
 					You can not eat normally, as your necrotic state permits you to only eat raw flesh. As you lack skin, you can not be injected via syringe."
+	damage_overlays = list()
 
 /datum/species/lich/gib(mob/living/carbon/human/H)
 	..()

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -721,7 +721,11 @@ Note that amputating the affected organ does in fact remove the infection from t
 	var/tburn = 0
 	var/tbrute = 0
 
-	if(burn_dam == 0)
+	var/datum/species/species = src.species || owner.species
+
+	if(species && !species.damage_overlays.Find("burn")) //Species has disabled burn damaged overlays
+		tburn = 0
+	else if((burn_dam == 0))
 		tburn = 0
 	else if(burn_dam < (max_damage * 0.25 / 2))
 		tburn = 1
@@ -730,7 +734,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 	else
 		tburn = 3
 
-	if(brute_dam == 0)
+	if(species && !species.damage_overlays.Find("brute")) //Species has disabled brute damage overlays
+		tbrute = 0
+	else if(brute_dam == 0)
 		tbrute = 0
 	else if(brute_dam < (max_damage * 0.25 / 2))
 		tbrute = 1


### PR DESCRIPTION
Because it showed up all red and bloody and looked extremely ugly because it assumed that the skeleton's limbs were healthy and fleshy and not just bone.
Plus with the lack of visible damage it could be more easy to pull off faking death and then spooking people. Think of the applications!

:cl:
 * tweak: Skeletons and liches will no longer look bloody nor burnt when damaged by brute damage or burn damage respectively. Watch out for skeletons that are probably still alive!