### PR TITLE
Pauses more subsystems during explosions

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -53,9 +53,14 @@ var/explosion_shake_message_cooldown = 0
 				message_admins("If uncapped, its size would have been ([round(true_range*0.25)], [round(true_range*0.5)], [round(true_range)])")
 				log_game("If uncapped, its size would have been ([round(true_range*0.25)], [round(true_range*0.5)], [round(true_range)])")
 
-		//Pause the lighting updates for a bit.
+		//Pause some updates for a bit.
 		var/postponeCycles = max(round(devastation_range/8),1)
-		SSlighting.postpone(postponeCycles)
+		if(postponeCycles)
+			SSlighting.postpone(postponeCycles)
+			SSair.postpone(postponeCycles)
+			SSburnable.postpone(postponeCycles)
+			SSpower.postpone(postponeCycles)
+			SSpipenet.postpone(postponeCycles)
 
 		var/x0 = epicenter.x
 		var/y0 = epicenter.y


### PR DESCRIPTION
[performance]

## What this does
pauses the air, pipeline, burnable and power subsystems during them as well as lighting, which was already being paused

## Why it's good
cuts down the time it takes by over half, with nukes

## How it was tested
nuke sized explosion, 3 times on 3 different startups, set off where the AI core would spawn in on box station. down from 40 seconds average to 15-16 seconds.
```
## DEBUG: Explosion(226,241,1)(d30,h60,l120): Took 15.2 seconds.
## DEBUG: Explosion(226,241,1)(d30,h60,l120): Took 16.3 seconds.
```
## Changelog
:cl:
 * tweak: Explosions now process more than twice as fast.