### PR TITLE
Buffs Projectile Pastry

### DIFF
--- a/code/modules/spells/targeted/projectile/pie_throw.dm
+++ b/code/modules/spells/targeted/projectile/pie_throw.dm
@@ -7,12 +7,10 @@
 
 	school = "evocation"
 	charge_max = 100
-	spell_flags = 0
 	invocation = "FLA'K PA'STRY"
 	invocation_type = SpI_SHOUT
 	range = 20
 
-	spell_aspect_flags = SPELL_FIRE
 	spell_flags = WAIT_FOR_CLICK | IS_HARMFUL
 	duration = 20
 	projectile_speed = 1
@@ -28,6 +26,12 @@
 				return "The spell can't be made any more powerful than this!"
 			return "Allows you to throw an extra pie, and increases the throwing damage of each pie by 4."
 	return ..()
+
+/spell/targeted/projectile/pie/get_upgrade_price(upgrade_type)
+	if(upgrade_type == Sp_SPEED)
+		return quicken_price
+	if(upgrade_type == Sp_POWER)
+		return Sp_BASE_PRICE * 0.5
 
 /spell/targeted/projectile/pie/empower_spell()
 	spell_levels[Sp_POWER]++
@@ -45,4 +49,4 @@
 			var/obj/pie = new pie_to_spawn(T)
 			to_chat(user, "You summon and throw \a [pie].")
 			pie.throw_at(target, range, (spell_levels[Sp_POWER]+1)*20)
-			sleep(5)
+			sleep(max(1, 5/spell_levels[Sp_POWER]))

--- a/code/modules/spells/targeted/projectile/pie_throw.dm
+++ b/code/modules/spells/targeted/projectile/pie_throw.dm
@@ -27,9 +27,8 @@
 			return "Allows you to throw an extra pie, and increases the throwing damage of each pie by 4."
 	return ..()
 
+//It only has empowerment as an available upgrade
 /spell/targeted/projectile/pie/get_upgrade_price(upgrade_type)
-	if(upgrade_type == Sp_SPEED)
-		return quicken_price
 	if(upgrade_type == Sp_POWER)
 		return Sp_BASE_PRICE * 0.5
 


### PR DESCRIPTION
Will throw pies faster the more pies there are to be thrown (down to a minimum of a pie per 0.1 seconds)
Halved empowerment cost, because there are many more, better spells you could get for the price of what it took to empower the Projectile Pastry spell.
Cleaned up the code, and Projectile Pastry is no longer considered a fire-based spell. The pie tins could be lit on fire but it doesn't actually produce any heat on its own, which is what fire-based spells do.

:cl:
 * bugfix: The Projectile Pastry spell will no longer be considered a fire-based spell.
 * tweak: The Projectile Pastry spell now costs half as much to empower.
 * tweak: The Projectile Pastry spell now throws pies faster the more pies there are to throw.
