### PR TITLE
Fixes possible molar ratio runtime

### DIFF
--- a/code/ZAS/_gas_mixture.dm
+++ b/code/ZAS/_gas_mixture.dm
@@ -132,7 +132,7 @@
 	return temperature * heat_capacity()
 
 /datum/gas_mixture/proc/molar_ratio(g) //ratio of moles of the input gas to total mols of all gasses in the area
-	return src[g] / total_moles
+	return total_moles && (src[g] / total_moles) //&& short circuits if total_moles is 0, and returns the second expression if it is not.
 
 /datum/gas_mixture/proc/molar_density(g) //Per liter. You should probably be using pressure instead, but considering this had to be made, you wouldn't be the first not to.
 	return (g ? src[g] : total_moles) / volume


### PR DESCRIPTION
[runtime]
```
[19:11:51] Runtime in code/ZAS/_gas_mixture.dm,135: Division by zero
  proc name: molar ratio (/datum/gas_mixture/proc/molar_ratio)
  src: /datum/gas_mixture (/datum/gas_mixture)
  call stack:
  /datum/gas_mixture (/datum/gas_mixture): molar ratio("oxygen")
  the effect (/obj/effect/fire): process()
  Air (/datum/subsystem/air): process part(4)
  Air (/datum/subsystem/air): fire(1)
  Air (/datum/subsystem/air): ignite(1)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```
