### PR TITLE
Disables Contract of Apprenticeship during Civil War of Casters

### DIFF
--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -98,6 +98,9 @@
 	abbreviation = "CT"
 	spawned_items = list(/obj/item/wizard_apprentice_contract)
 
+/datum/spellbook_artifact/apprentice/can_buy(var/mob/user)
+	return is_not_civil_war_caster(user)
+
 /datum/spellbook_artifact/bundle
 	name = "Spellbook Bundle"
 	desc = "Feeling adventurous? Buy this bundle and receive seven random spellbooks! Who knows what spells you will get? (Warning, each spell book may only be used once! No refunds)."
@@ -177,6 +180,21 @@
 		return TRUE
 
 	return FALSE
+
+//For things that you do not want to be multiplied several times over during a civil war
+/datum/spellbook_artifact/proc/is_not_civil_war_caster(var/mob/user)
+	if (!ticker || !ticker.mode || !istype(ticker.mode,/datum/gamemode/dynamic))
+		return TRUE
+
+	if (!user.mind)
+		return FALSE
+
+	var/datum/role/wizard/myWizard = user.mind.GetRole(WIZARD)
+
+	if(istype(myWizard.GetFaction(), /datum/faction/wizard/civilwar))
+		return FALSE
+
+	return TRUE
 
 //SUMMON GUNS
 /datum/spellbook_artifact/summon_guns


### PR DESCRIPTION
Apprentices are pretty broken on the code side of things when it comes to being handled by the CWC faction code.

On top of that when there's already 4 wizards and then someone sends another 5-6 wizards to cause mayhem it leads to the sort of gunk that got Summon Guns banned from anything that isn't a roundstart wizard. Why is the Wizards Federation sending apprentices into the civil war now? Let them have their own fight! Every apprentice caught in the bloodshed is an apprentice that won't become a proper wizard. Plus it leads to a lot of friendly fire because the apprentices don't actually share the CWC faction so they can't tell who's an ally. I've seen pitbulls and other creatures summoned by mages attack their own apprentices because of this.

Does not affect midround wizards.

:cl:
 * rscdel: The Contract of Apprenticeship can no longer be purchased by Civil War wizards.