### PR TITLE
Attempts to fix CWC apprentices

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -289,7 +289,7 @@
 
 /datum/dynamic_ruleset/roundstart/cwc/execute()
 	var/datum/faction/wizard/civilwar/wpf/WPF = ticker.mode.CreateFaction(/datum/faction/wizard/civilwar/wpf, null, 1)
-	var/datum/faction/wizard/civilwar/wpf/PFW = ticker.mode.CreateFaction(/datum/faction/wizard/civilwar/pfw, null, 1)
+	var/datum/faction/wizard/civilwar/pfw/PFW = ticker.mode.CreateFaction(/datum/faction/wizard/civilwar/pfw, null, 1)
 	for(var/mob/new_player/M in assigned)
 		var/datum/role/wizard/newWizard = new
 		if (WPF.members.len < PFW.members.len)

--- a/code/game/gamemodes/wizard/apprentice_contract.dm
+++ b/code/game/gamemodes/wizard/apprentice_contract.dm
@@ -187,7 +187,9 @@ var/list/wizard_apprentice_setups_by_name = list()
 	if(owner.GetRole(WIZARD))
 		var/datum/faction/wizard/civilwar/CW = find_active_faction_by_typeandmember(/datum/faction/wizard/civilwar, WIZARD, owner)
 		if(CW) //Apprentice is being drafted into the civil war
-			CW.HandleRecruitedRole(apprentice_role)
+			contract_faction.HandleRemovedRole(apprentice_role) //Remove the apprentice from the contract faction
+			contract_faction.HandleRemovedRole(owner) //The master is no longer a contract master, everyone is in this together
+			CW.HandleRecruitedRole(apprentice_role) //Bring the apprentice into the owner's civil war faction
 	apprentice_role.Greet(GREET_DEFAULT)
 	apprentice_role.AnnounceObjectives()
 	if(forced_apprentice_name)

--- a/code/game/gamemodes/wizard/apprentice_contract.dm
+++ b/code/game/gamemodes/wizard/apprentice_contract.dm
@@ -190,6 +190,7 @@ var/list/wizard_apprentice_setups_by_name = list()
 			contract_faction.HandleRemovedRole(apprentice_role) //Remove the apprentice from the contract faction
 			contract_faction.HandleRemovedRole(owner) //The master is no longer a contract master, everyone is in this together
 			CW.HandleRecruitedRole(apprentice_role) //Bring the apprentice into the owner's civil war faction
+			CW.HandleRecruitedRole(owner) //HandleRemovedRole removes a role's faction and orphans the role, this should help
 	apprentice_role.Greet(GREET_DEFAULT)
 	apprentice_role.AnnounceObjectives()
 	if(forced_apprentice_name)

--- a/code/game/gamemodes/wizard/apprentice_contract.dm
+++ b/code/game/gamemodes/wizard/apprentice_contract.dm
@@ -184,6 +184,10 @@ var/list/wizard_apprentice_setups_by_name = list()
 		contract_faction.forgeObjectives()
 
 	var/datum/role/wizard_apprentice/apprentice_role = contract_faction.HandleRecruitedMind(apprentice.mind, override = TRUE)
+	if(owner.GetRole(WIZARD))
+		var/datum/faction/wizard/civilwar/CW = find_active_faction_by_typeandmember(/datum/faction/wizard/civilwar, WIZARD, owner)
+		if(CW) //Apprentice is being drafted into the civil war
+			CW.HandleRecruitedRole(apprentice_role)
 	apprentice_role.Greet(GREET_DEFAULT)
 	apprentice_role.AnnounceObjectives()
 	if(forced_apprentice_name)


### PR DESCRIPTION
If the recruiter is a wizard then it will search for whether the recruiter is in a civil war faction. If it is then the faction will add the apprentice to it.
At least that's what it is supposed to do. I can't really test it.
Also fixed a typo.

:cl:
 * experimental: Attempted to fix apprentices during CWC such that they are actually counted as part of the civil war instead of only caring about their master, which could lead to friendly fire as the apprentice could not see the other members of their master's civil war faction.