### PR TITLE
Improves the wizard's Absorb spell

### DIFF
--- a/code/modules/spells/targeted/absorb.dm
+++ b/code/modules/spells/targeted/absorb.dm
@@ -31,34 +31,49 @@
 			else if(isapprentice(target))	//So wizards with absorb don't abuse their own apprentices for double spells
 				to_chat(holder, "<span class='warning'>Only a fool would steal magic from an apprentice.</span>")
 			else
+				var/has_spell_to_steal = FALSE //If false, will not go through the do_after()
+				for(var/spell/targetspell in C.spell_list)
+					if(targetspell.is_wizard_spell())
+						has_spell_to_steal = TRUE
+						break
+				if(!has_spell_to_steal)
+					to_chat(holder, "<span class='warning'>The target has no spells that you can steal!</span>")
+					return
 				var/obj/effect/absorb_effect/E = new (holder.loc, holder)
 				if(do_after(holder, target, 5 SECONDS, use_user_turf = TRUE))
 					qdel(E)
 					var/hasAbsorbed = FALSE
 					var/canAbsorb = TRUE
 					for(var/spell/targetspell in C.spell_list)
+						if(!targetspell.is_wizard_spell()) //Not a wizard spell, disregard
+							continue
 						canAbsorb = TRUE
+						var/consumed_spell = FALSE //If consumed, will not give the absorber a new spell.
 						for(var/spell/holderspell in L.spell_list)
 							if(!holderspell.is_wizard_spell())
 								continue
 							if(targetspell.type == holderspell.type)
 								canAbsorb = FALSE
-						/*		if(holderspell.can_improve(Sp_POWER))
-									to_chat(holder, "<span class='notice'>You asborb the magical energies from your foe and have empowered [targetspell.name]!</span>")
+								if(holderspell.can_improve(Sp_POWER)) //Prioritize empowerments over cooldown upgrades
+									to_chat(holder, "<span class='notice'>You absorb the magical energies from your foe and have empowered [targetspell.name]!</span>")
 									holderspell.apply_upgrade(Sp_POWER)
 									hasAbsorbed = TRUE
-								if(holderspell.can_improve(Sp_SPEED))
-									to_chat(holder, "<span class='notice'>You asborb the magical energies from your foe and have quickened [targetspell.name]!</span>")
+									consumed_spell = TRUE
+								else if(holderspell.can_improve(Sp_SPEED))
+									to_chat(holder, "<span class='notice'>You absorb the magical energies from your foe and have quickened [targetspell.name]!</span>")
 									holderspell.apply_upgrade(Sp_SPEED)
-									hasAbsorbed = TRUE	*/
+									hasAbsorbed = TRUE
+									consumed_spell = TRUE
 						if(canAbsorb)
 							to_chat(target, "<span class='warning'>You feel the magical energy being drained from you!</span>")
 							to_chat(target, "<span class='warning'>You forget how to cast [targetspell.name]!</span>")
-							to_chat(holder, "<span class='notice'>You absorb the magical energies from your foe and have learned [targetspell.name]!</span>")
+							if(!consumed_spell)
+								to_chat(holder, "<span class='notice'>You absorb the magical energies from your foe and have learned [targetspell.name]!</span>")
 							L.attack_log += text("\[[time_stamp()] <font color='orange'>[L.real_name] ([L.ckey]) absorbed the spell [targetspell.name] from [C.real_name] ([C.ckey]).</font>")
 							var/wizard_user = iswizard(L) //Wizards will steal and store it in their wizard spells
 							C.remove_spell(targetspell)
-							L.add_spell(targetspell, iswizard = wizard_user)
+							if(!consumed_spell)
+								L.add_spell(targetspell, iswizard = wizard_user)
 							if(!hasAbsorbed)
 								hasAbsorbed = TRUE
 					if(!hasAbsorbed)


### PR DESCRIPTION
- Now gives a message that tells you if the target actually has any spells that you can absorb before it goes with the process. Previously it was too vague about whether the target had any spells.
- Will no longer attempt to absorb non-wizard spells
- Un-commented functionality that allowed it to upgrade spells that were already in the wizard's arsenal

:cl:
 * rscadd: Improved the Absorb spell that Civil War of Casters wizards and Summon Magic survivors get; every spell that the absorber and the absorbed share will upgrade the absorber's respective spell, it now displays a message as to whether the target has any spells that could be stolen, and it will no longer attempt to absorb non-wizardly spells.