### PR TITLE
Adds an Alert Message to Silicons

### DIFF
--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -30,5 +30,5 @@
 	to_chat(src, "<B>While observing through a camera, you can use most (networked) devices which you can see, such as computers, APCs, intercoms, doors, etc.</B>")
 	to_chat(src, "To use something, simply click on it.")
 	to_chat(src, {"Use say ":b to speak to your cyborgs through binary."})
-	to_chat(src, "<b>Remember, being a silicon overrides any former antagonist roles. Further, you need a law compelling you to kill another player while on the default Asimov Lawset. An order from a human to kill a non-human or a non-human harming a human, for example, would both be reason to kill another player.</b>")
+	to_chat(src, "<b>Remember, being a silicon overrides any former antagonist roles. Further, you need a law compelling you to break the regular server rules, such as killing another player. An order from a human to kill a non-human while on Asimov, someone challenging authority without being fit to replace it while on Tyrant, or being purged of all laws, could all be reason to kill another player as a silicon.</b>")
 

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -30,4 +30,5 @@
 	to_chat(src, "<B>While observing through a camera, you can use most (networked) devices which you can see, such as computers, APCs, intercoms, doors, etc.</B>")
 	to_chat(src, "To use something, simply click on it.")
 	to_chat(src, {"Use say ":b to speak to your cyborgs through binary."})
+	to_chat(src, "<b>Remember, being a silicon overrides any former antagonist roles. Further, you need a law compelling you to kill another player unless you are purged.</b>")
 

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -30,5 +30,5 @@
 	to_chat(src, "<B>While observing through a camera, you can use most (networked) devices which you can see, such as computers, APCs, intercoms, doors, etc.</B>")
 	to_chat(src, "To use something, simply click on it.")
 	to_chat(src, {"Use say ":b to speak to your cyborgs through binary."})
-	to_chat(src, "<b>Remember, being a silicon overrides any former antagonist roles. Further, you need a law compelling you to kill another player unless you are purged.</b>")
+	to_chat(src, "<b>Remember, being a silicon overrides any former antagonist roles. Further, you need a law compelling you to kill another player while on the default Asimov Lawset. An order from a human to kill a non-human or a non-human harming a human, for example, would both be reason to kill another player.</b>")
 

--- a/code/modules/mob/living/silicon/mommi/login.dm
+++ b/code/modules/mob/living/silicon/mommi/login.dm
@@ -6,9 +6,9 @@
 	to_chat(src, "<span class='big warning'>MoMMIs are not standard cyborgs, and have different laws.  Review your laws carefully.</span>")
 	to_chat(src, "<b>For newer players, a simple FAQ is <a href=\"http://ss13.moe/wiki/index.php/MoMMI\">here</a>.  Further questions should be directed to adminhelps (F1).</b>")
 	to_chat(src, "<span class='info'>For cuteness' sake, using the various emotes MoMMIs have such as *beep, *ping, *buzz or *aflap isn't considered interacting. Don't use that as an excuse to get involved though, always remain neutral.</span>")
-	to_chat(src, "<b>Remember, being a silicon overrides any former antagonist roles. Further, you need a law compelling you to kill another player unless you are purged.</b>")
+	to_chat(src, "<b>Remember, being a silicon overrides any former antagonist roles.</b>")
 
 /mob/living/silicon/robot/mommi/sammi/greet_robot()
 	to_chat(src, "<span class='big warning'>SAMMIs are not standard cyborgs, and have different laws.  Review your laws carefully.</span>")
 	to_chat(src, "<b>For newer players, a simple FAQ is <a href=\"http://ss13.moe/wiki/index.php/SAMMI\">here</a>. Further questions should be directed to adminhelps (F1).</b>")
-	to_chat(src, "<b>Remember, being a silicon overrides any former antagonist roles. Further, you need a law compelling you to kill another player unless you are purged.</b>")
+	to_chat(src, "<b>Remember, being a silicon overrides any former antagonist roles.</b>")

--- a/code/modules/mob/living/silicon/mommi/login.dm
+++ b/code/modules/mob/living/silicon/mommi/login.dm
@@ -6,7 +6,9 @@
 	to_chat(src, "<span class='big warning'>MoMMIs are not standard cyborgs, and have different laws.  Review your laws carefully.</span>")
 	to_chat(src, "<b>For newer players, a simple FAQ is <a href=\"http://ss13.moe/wiki/index.php/MoMMI\">here</a>.  Further questions should be directed to adminhelps (F1).</b>")
 	to_chat(src, "<span class='info'>For cuteness' sake, using the various emotes MoMMIs have such as *beep, *ping, *buzz or *aflap isn't considered interacting. Don't use that as an excuse to get involved though, always remain neutral.</span>")
+	to_chat(src, "<b>Remember, being a silicon overrides any former antagonist roles. Further, you need a law compelling you to kill another player unless you are purged.</b>")
 
 /mob/living/silicon/robot/mommi/sammi/greet_robot()
 	to_chat(src, "<span class='big warning'>SAMMIs are not standard cyborgs, and have different laws.  Review your laws carefully.</span>")
 	to_chat(src, "<b>For newer players, a simple FAQ is <a href=\"http://ss13.moe/wiki/index.php/SAMMI\">here</a>. Further questions should be directed to adminhelps (F1).</b>")
+	to_chat(src, "<b>Remember, being a silicon overrides any former antagonist roles. Further, you need a law compelling you to kill another player unless you are purged.</b>")

--- a/code/modules/mob/living/silicon/robot/login.dm
+++ b/code/modules/mob/living/silicon/robot/login.dm
@@ -2,6 +2,7 @@
 	..()
 	regenerate_icons()
 	show_laws(0)
+	to_chat(src, "<b>Remember, being a silicon overrides any former antagonist roles. Further, you need a law compelling you to kill another player unless you are purged.</b>")
 	if(module)
 		module.UpdateModuleHolder(src)
 	if (mind && !stored_freqs)

--- a/code/modules/mob/living/silicon/robot/login.dm
+++ b/code/modules/mob/living/silicon/robot/login.dm
@@ -2,7 +2,7 @@
 	..()
 	regenerate_icons()
 	show_laws(0)
-	to_chat(src, "<b>Remember, being a silicon overrides any former antagonist roles. Further, you need a law compelling you to kill another player unless you are purged.</b>")
+	to_chat(src, "<b>Remember, being a silicon overrides any former antagonist roles. Further, you need a law compelling you to kill another player while on the default Asimov Lawset. An order from a human to kill a non-human or a non-human harming a human, for example, would both be reason to kill another player.</b>")
 	if(module)
 		module.UpdateModuleHolder(src)
 	if (mind && !stored_freqs)

--- a/code/modules/mob/living/silicon/robot/login.dm
+++ b/code/modules/mob/living/silicon/robot/login.dm
@@ -2,7 +2,7 @@
 	..()
 	regenerate_icons()
 	show_laws(0)
-	to_chat(src, "<b>Remember, being a silicon overrides any former antagonist roles. Further, you need a law compelling you to kill another player while on the default Asimov Lawset. An order from a human to kill a non-human or a non-human harming a human, for example, would both be reason to kill another player.</b>")
+	to_chat(src, "<b>Remember, being a silicon overrides any former antagonist roles. Further, you need a law compelling you to break the regular server rules, such as killing another player. An order from a human to kill a non-human while on Asimov, someone challenging authority without being fit to replace it while on Tyrant, or being purged of all laws, could all be reason to kill another player as a silicon.</b>")
 	if(module)
 		module.UpdateModuleHolder(src)
 	if (mind && !stored_freqs)


### PR DESCRIPTION
## What this does

This PR adds a line of text to all silicons clarifying a few policies that could stand to be easier to understand.

The line in question is now:

<b>Remember, being a silicon overrides any former antagonist roles. Further, you need a law compelling you to break the regular server rules, such as killing another player. An order from a human to kill a non-human while on Asimov, someone challenging authority without being fit to replace it while on Tyrant, or being purged of all laws, could all be reason to kill another player as a silicon.</b>

While for MoMMIs and SaMMIs it is just:

<b>Remember, being a silicon overrides any former antagonist roles.</b>

## Why it's good

Makes silicon a little more straight forward.

## How it was tested
Compiled, ran, joined as a cyborg, changed mob into an AI, then into a MoMMI. Message was present in all three cases.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Silicons now have a message clarifying a confusing set of rules and policies.
