### PR TITLE
Limits the maximum amount of ZAS-induced stunning to 10 seconds

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -55,7 +55,7 @@ atom/movable/GotoAirflowDest(n)
 		return FALSE
 	if(knockdown <= 0)
 		to_chat(src, "<span class='warning'>The sudden rush of air knocks you over!</span>")
-	SetKnockdown(rand(differential/20,differential/10))
+	SetKnockdown(min(rand(differential/20,differential/10), 5))
 	last_airflow_stun = world.time
 
 /mob/living/silicon/airflow_stun()
@@ -78,7 +78,7 @@ atom/movable/GotoAirflowDest(n)
 
 	if(knockdown <= 0)
 		to_chat(src, "<span class='warning'>The sudden rush of air knocks you over!</span>")
-	SetKnockdown(rand(differential/20,differential/10))
+	SetKnockdown(min(rand(differential/20,differential/10), 5))
 	last_airflow_stun = world.time
 
 /atom/movable/proc/check_airflow_movable(n)


### PR DESCRIPTION
Because sometimes due to odd calculations someone can end up knocked down like that for more than a minute.

Only affects airflow, not colliding into objects.

Can still be stunlocked by airflow if it's actively happening.

:cl:
 * tweak: Airflow mechanics now have a limit of knocking down unfortunate victims for a maximum of 10 seconds.