### PR TITLE
Stack storage fixes

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -19,17 +19,3 @@
 	pixel_x = (rand(0,4)-4) * PIXEL_MULTIPLIER
 	pixel_y = (rand(0,4)-4) * PIXEL_MULTIPLIER
 	..()
-
-
-// Since the sheetsnatcher was consolidated into weapon/storage/bag we now use
-// item/attackby() properly, making this unnecessary
-
-/*/obj/item/stack/sheet/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if (istype(W, /obj/item/weapon/storage/bag/sheetsnatcher))
-		var/obj/item/weapon/storage/bag/sheetsnatcher/S = W
-		if(!S.mode)
-			S.add(src,user)
-		else
-			for (var/obj/item/stack/sheet/stack in locate(src.x,src.y,src.z))
-				S.add(stack,user)
-	..()*/

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -419,13 +419,19 @@ var/global/list/plantbag_colour_choices = list("plantbag", "green red stripe", "
 /obj/item/weapon/storage/bag/sheetsnatcher
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "sheetsnatcher"
-	name = "Sheet Snatcher 9000"
+	name = "Sheet Snatcher"
 	desc = "A patented Nanotrasen storage system designed for any kind of mineral sheet."
 	w_class = W_CLASS_MEDIUM
 	storage_slots = 50
-	max_combined_w_class = 15 //Borgs get more because >specialization
+	max_combined_w_class = 18
 	can_only_hold = list("/obj/item/stack/sheet")
 	cant_hold = list("/obj/item/stack/sheet/mineral/sandstone","/obj/item/stack/sheet/wood")
+
+
+/obj/item/weapon/storage/bag/sheetsnatcher/borg
+	name = "Sheet Snatcher 9000"
+	desc = ""
+	max_combined_w_class = 30 //Borgs get more because >specialization
 
 // -----------------------------
 //          Gadget Bag

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -423,8 +423,9 @@ var/global/list/plantbag_colour_choices = list("plantbag", "green red stripe", "
 	desc = "A patented Nanotrasen storage system designed for any kind of mineral sheet."
 	w_class = W_CLASS_MEDIUM
 	storage_slots = 50
-	max_combined_w_class = 30 //Borgs get more because >specialization
+	max_combined_w_class = 15 //Borgs get more because >specialization
 	can_only_hold = list("/obj/item/stack/sheet")
+	cant_hold = list("/obj/item/stack/sheet/mineral/sandstone","/obj/item/stack/sheet/wood")
 
 // -----------------------------
 //          Gadget Bag

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -128,9 +128,9 @@
 	icon_state = "mining_satchel"
 	slot_flags = SLOT_BELT | SLOT_POCKET
 	w_class = W_CLASS_MEDIUM
-	storage_slots = 50
+	storage_slots = 21
 	fits_max_w_class = 3
-	max_combined_w_class = 200 //Doesn't matter what this is, so long as it's more or equal to storage_slots * ore.w_class
+	max_combined_w_class = 21 //Doesn't matter what this is, so long as it's more or equal to storage_slots * types of ore found on the mine
 	can_only_hold = list("/obj/item/stack/ore")
 	display_contents_with_number = TRUE
 
@@ -413,149 +413,18 @@ var/global/list/plantbag_colour_choices = list("plantbag", "green red stripe", "
 	can_only_hold = list("/obj/item/weapon/reagent_containers/glass/bottle","/obj/item/weapon/reagent_containers/pill","/obj/item/weapon/reagent_containers/syringe")
 
 // -----------------------------
-//        Sheet Snatcher
+//    Sheet Snatcher (Cyborg)
 // -----------------------------
-// Because it stacks stacks, this doesn't operate normally.
-// However, making it a storage/bag allows us to reuse existing code in some places. -Sayu
 
 /obj/item/weapon/storage/bag/sheetsnatcher
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "sheetsnatcher"
-	name = "Sheet Snatcher"
-	desc = "A patented Nanotrasen storage system designed for any kind of mineral sheet."
-
-	var/capacity = 300; //the number of sheets it can carry.
-	w_class = W_CLASS_MEDIUM
-
-	allow_quick_empty = 1 // this function is superceded
-
-/obj/item/weapon/storage/bag/sheetsnatcher/New()
-	..()
-	//verbs -= /obj/item/weapon/storage/verb/quick_empty
-	//verbs += /obj/item/weapon/storage/bag/sheetsnatcher/quick_empty
-
-/obj/item/weapon/storage/bag/sheetsnatcher/can_be_inserted(obj/item/W as obj, stop_messages = FALSE)
-	if(!istype(W,/obj/item/stack/sheet) || istype(W,/obj/item/stack/sheet/mineral/sandstone) || istype(W,/obj/item/stack/sheet/wood))
-		if(!stop_messages)
-			to_chat(usr, "The snatcher does not accept [W].")
-		return FALSE //I don't care, but the existing code rejects them for not being "sheets" *shrug* -Sayu
-	var/current = 0
-	for(var/obj/item/stack/sheet/S in contents)
-		current += S.amount
-	if(capacity == current)//If it's full, you're done
-		if(!stop_messages)
-			to_chat(usr, "<span class='warning'>The snatcher is full.</span>")
-		return FALSE
-	return TRUE
-
-
-// Modified handle_item_insertion.  Would prefer not to, but...
-/obj/item/weapon/storage/bag/sheetsnatcher/handle_item_insertion(obj/item/W as obj, prevent_warning = FALSE)
-	var/obj/item/stack/sheet/S = W
-	if(!istype(S))
-		return FALSE
-
-	var/amount
-	var/inserted = FALSE
-	var/current = 0
-	for(var/obj/item/stack/sheet/S2 in contents)
-		current += S2.amount
-	if(capacity < current + S.amount)//If the stack will fill it up
-		amount = capacity - current
-	else
-		amount = S.amount
-
-	for(var/obj/item/stack/sheet/sheet in contents)
-		if(S.type == sheet.type) // we are violating the amount limitation because these are not sane objects
-			sheet.amount += amount	// they should only be removed through procs in this file, which split them up.
-			S.amount -= amount
-			inserted = TRUE
-			break
-
-	if(!inserted || !S.amount)
-		usr.u_equip(S,1)
-		usr.update_icons()	//update our overlays
-		if (usr.client && usr.s_active != src)
-			usr.client.screen -= S
-		//S.dropped(usr)
-		if(!S.amount)
-			QDEL_NULL (S)
-		else
-			S.forceMove(src)
-
-	orient2hud(usr)
-	if(usr.s_active)
-		usr.s_active.show_to(usr)
-	update_icon()
-	return TRUE
-
-
-// Sets up numbered display to show the stack size of each stored mineral
-// NOTE: numbered display is turned off currently because it's broken
-/obj/item/weapon/storage/bag/sheetsnatcher/orient2hud(mob/user as mob)
-	var/adjusted_contents = contents.len
-
-	//Numbered contents display
-	var/list/datum/numbered_display/numbered_contents
-	if(display_contents_with_number)
-		numbered_contents = list()
-		adjusted_contents = 0
-		for(var/obj/item/stack/sheet/I in contents)
-			adjusted_contents++
-			var/datum/numbered_display/D = new/datum/numbered_display(I)
-			D.number = I.amount
-			numbered_contents.Add( D )
-
-	var/row_num = 0
-	var/col_count = min(7,storage_slots) -1
-	if (adjusted_contents > 7)
-		row_num = round((adjusted_contents-1) / 7) // 7 is the maximum allowed width.
-	src.standard_orient_objs(row_num, col_count, numbered_contents)
-	return
-
-
-// Modified quick_empty verb drops appropriate sized stacks
-/obj/item/weapon/storage/bag/sheetsnatcher/quick_empty()
-	var/location = get_turf(src)
-	for(var/obj/item/stack/sheet/S in contents)
-		while(S.amount)
-			var/obj/item/stack/sheet/N = new S.type(location)
-			var/stacksize = min(S.amount,N.max_amount)
-			N.amount = stacksize
-			S.amount -= stacksize
-		if(!S.amount)
-			QDEL_NULL (S) // todo: there's probably something missing here
-	orient2hud(usr)
-	if(usr.s_active)
-		usr.s_active.show_to(usr)
-	update_icon()
-
-// Instead of removing
-/obj/item/weapon/storage/bag/sheetsnatcher/remove_from_storage(obj/item/W, atom/new_location, var/force = 0, var/refresh = 1)
-	var/obj/item/stack/sheet/S = W
-	if(!istype(S))
-		return FALSE
-
-	//I would prefer to drop a new stack, but the item/attack_hand code
-	// that calls this can't receive a different object than you clicked on.
-	//Therefore, make a new stack internally that has the remainder.
-	// -Sayu
-
-	if(S.amount > S.max_amount)
-		var/obj/item/stack/sheet/temp = new S.type(src)
-		temp.amount = S.amount - S.max_amount
-		S.amount = S.max_amount
-
-	return ..(S,new_location)
-
-// -----------------------------
-//    Sheet Snatcher (Cyborg)
-// -----------------------------
-
-/obj/item/weapon/storage/bag/sheetsnatcher/borg
 	name = "Sheet Snatcher 9000"
-	desc = ""
-	capacity = 500//Borgs get more because >specialization
+	desc = "A patented Nanotrasen storage system designed for any kind of mineral sheet."
+	w_class = W_CLASS_MEDIUM
+	storage_slots = 50
+	max_combined_w_class = 30 //Borgs get more because >specialization
+	can_only_hold = list("/obj/item/stack/sheet")
 
 // -----------------------------
 //          Gadget Bag

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -426,6 +426,7 @@ var/global/list/plantbag_colour_choices = list("plantbag", "green red stripe", "
 	max_combined_w_class = 18
 	can_only_hold = list("/obj/item/stack/sheet")
 	cant_hold = list("/obj/item/stack/sheet/mineral/sandstone","/obj/item/stack/sheet/wood")
+	//display_contents_with_number = TRUE //used to be broken with old snowflake behaviour, now works. uncomment to add it.
 
 
 /obj/item/weapon/storage/bag/sheetsnatcher/borg

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -128,9 +128,9 @@
 	icon_state = "mining_satchel"
 	slot_flags = SLOT_BELT | SLOT_POCKET
 	w_class = W_CLASS_MEDIUM
-	storage_slots = 21
+	storage_slots = 50
 	fits_max_w_class = 3
-	max_combined_w_class = 21 //Doesn't matter what this is, so long as it's more or equal to storage_slots * types of ore found on the mine
+	max_combined_w_class = 200 //Doesn't matter what this is, so long as it's more or equal to storage_slots * ore.w_class
 	can_only_hold = list("/obj/item/stack/ore")
 	display_contents_with_number = TRUE
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -348,7 +348,7 @@
 	if(istype(W,/obj/item/stack))
 		var/obj/item/stack/S = W
 		for(var/obj/item/stack/otherS in src)
-			if(otherS.amount < otherS.max_amount && istype(otherS,S.type))
+			if(otherS.amount < otherS.max_amount && otherS.type == S.type)
 				return TRUE
 	if(storage_slots && (contents.len >= storage_slots))
 		if(!stop_messages)
@@ -377,7 +377,7 @@
 	if(istype(W,/obj/item/stack))
 		var/obj/item/stack/S = W
 		for(var/obj/item/stack/otherS in src)
-			if(otherS.amount < otherS.max_amount && istype(otherS,S.type))
+			if(otherS.amount < otherS.max_amount && otherS.type == S.type)
 				var/remaining = otherS.max_amount - otherS.amount
 				var/to_transfer = remaining
 				if(S.amount > remaining)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -378,7 +378,7 @@
 		var/obj/item/stack/S = W
 		for(var/obj/item/stack/otherS in src)
 			if(otherS.amount < otherS.max_amount && otherS.type == S.type)
-				var/to_transfer = S.amount > otherS.max_amount - otherS.amount ? otherS.max_amount - otherS.amount : S.amount
+				var/to_transfer = min(S.amount, otherS.max_amount - otherS.amount)
 				otherS.amount += to_transfer
 				if(usr)
 					add_fingerprint(usr)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -378,15 +378,8 @@
 		var/obj/item/stack/S = W
 		for(var/obj/item/stack/otherS in src)
 			if(otherS.amount < otherS.max_amount && otherS.type == S.type)
-				var/remaining = otherS.max_amount - otherS.amount
-				var/to_transfer = remaining
-				if(S.amount > remaining)
-					S.use(remaining)
-					otherS.amount = otherS.max_amount
-				else
-					to_transfer = S.amount
-					otherS.amount += S.amount
-					qdel(S)
+				var/to_transfer = S.amount > otherS.max_amount - otherS.amount ? S.amount : otherS.max_amount - otherS.amount
+				otherS.amount += to_transfer
 				if(usr)
 					add_fingerprint(usr)
 					if(!prevent_warning)
@@ -394,6 +387,7 @@
 						for(var/mob/M in viewers(usr, null)) //If someone is standing close enough, they can tell what it is, otherwise they can only see large or normal items from a distance
 							if (!stealthy(usr) && (M in range(1) || W.w_class >= W_CLASS_MEDIUM))
 								M.show_message("<span class='notice'>[usr] puts \the [W] into \the [src].</span>")
+				S.use(to_transfer)
 				refresh_all()
 				return 1
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -227,7 +227,7 @@
 			var/found = 0
 			for(var/datum/numbered_display/ND in numbered_contents)
 				if(ND.sample_object.type == I.type)
-					ND.number += ND.sample_object.get_storage_number_display_value()
+					ND.number += I.get_storage_number_display_value()
 					found = 1
 					break
 			if(!found)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -378,7 +378,7 @@
 		var/obj/item/stack/S = W
 		for(var/obj/item/stack/otherS in src)
 			if(otherS.amount < otherS.max_amount && otherS.type == S.type)
-				var/to_transfer = S.amount > otherS.max_amount - otherS.amount ? S.amount : otherS.max_amount - otherS.amount
+				var/to_transfer = S.amount > otherS.max_amount - otherS.amount ? otherS.max_amount - otherS.amount : S.amount
 				otherS.amount += to_transfer
 				if(usr)
 					add_fingerprint(usr)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -353,7 +353,6 @@
 				if(otherS.amount < otherS.max_amount)
 					return TRUE
 				stacktypefound = TRUE
-				break
 	if((storage_slots && (contents.len >= storage_slots)) || (get_sum_w_class() + W.w_class > max_combined_w_class))
 		if(!stop_messages)
 			to_chat(usr, "<span class='notice'>\The [src] is full[stacktypefound ? " of this kind of stack": ""], make some space.</span>")

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -383,9 +383,10 @@
 				if(usr)
 					add_fingerprint(usr)
 					if(!prevent_warning)
-						to_chat(usr, "You add [to_transfer] [((to_transfer > 1) && S.irregular_plural) ? S.irregular_plural : "[S.singular_name]\s"] to \the [otherS]. It now contains [otherS.amount] [(otherS.irregular_plural && otherS.amount > 1) ? otherS.irregular_plural : "[otherS.singular_name]"].")
 						for(var/mob/M in viewers(usr, null)) //If someone is standing close enough, they can tell what it is, otherwise they can only see large or normal items from a distance
-							if (!stealthy(usr) && (M in range(1) || W.w_class >= W_CLASS_MEDIUM))
+							if(M == usr)
+								to_chat(usr, "You add [to_transfer] [((to_transfer > 1) && S.irregular_plural) ? S.irregular_plural : "[S.singular_name]\s"] to \the [otherS]. It now contains [otherS.amount] [(otherS.irregular_plural && otherS.amount > 1) ? otherS.irregular_plural : "[otherS.singular_name]"].")
+							else if (!stealthy(usr) && (M in range(1) || W.w_class >= W_CLASS_MEDIUM))
 								M.show_message("<span class='notice'>[usr] puts \the [W] into \the [src].</span>")
 				S.use(to_transfer)
 				refresh_all()
@@ -405,9 +406,10 @@
 		add_fingerprint(usr)
 
 		if(!prevent_warning && !istype(W, /obj/item/weapon/gun/energy/crossbow))
-			to_chat(usr, "<span class='notice'>You put \the [W] into \the [src].</span>")
 			for(var/mob/M in viewers(usr, null)) //If someone is standing close enough, they can tell what it is, otherwise they can only see large or normal items from a distance
-				if (!stealthy(usr) && (M in range(1) || W.w_class >= W_CLASS_MEDIUM))
+				if(M == usr)
+					to_chat(usr, "<span class='notice'>You put \the [W] into \the [src].</span>")
+				else if (!stealthy(usr) && (M in range(1) || W.w_class >= W_CLASS_MEDIUM))
 					M.show_message("<span class='notice'>[usr] puts \the [W] into \the [src].</span>")
 
 	W.mouse_opacity = 2 //So you can click on the area around the item to equip it, instead of having to pixel hunt

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -345,19 +345,19 @@
 				to_chat(usr, "<span class='notice'>\The [W] is too big for \the [src].</span>")
 			return 0
 
+	var/stacktypefound = FALSE
 	if(istype(W,/obj/item/stack))
 		var/obj/item/stack/S = W
 		for(var/obj/item/stack/otherS in src)
-			if(otherS.amount < otherS.max_amount && otherS.type == S.type)
-				return TRUE
-	if(storage_slots && (contents.len >= storage_slots))
+			if(otherS.type == S.type)
+				if(otherS.amount < otherS.max_amount)
+					return TRUE
+				stacktypefound = TRUE
+				break
+	if((storage_slots && (contents.len >= storage_slots)) || (get_sum_w_class() + W.w_class > max_combined_w_class))
 		if(!stop_messages)
-			to_chat(usr, "<span class='notice'>\The [src] is full, make some space.</span>")
+			to_chat(usr, "<span class='notice'>\The [src] is full[stacktypefound ? " of this kind of stack": ""], make some space.</span>")
 		return 0 //Storage item is full
-	if(get_sum_w_class() + W.w_class > max_combined_w_class)
-		if(!stop_messages)
-			to_chat(usr, "<span class='notice'>\The [src] is full, make some space.</span>")
-		return 0
 
 	if(W.w_class >= src.w_class && (istype(W, /obj/item/weapon/storage)))
 		if(!istype(src, /obj/item/weapon/storage/backpack/holding))	//bohs should be able to hold backpacks again. The override for putting a boh in a boh is in backpack.dm.

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -394,6 +394,7 @@
 						for(var/mob/M in viewers(usr, null)) //If someone is standing close enough, they can tell what it is, otherwise they can only see large or normal items from a distance
 							if (!stealthy(usr) && (M in range(1) || W.w_class >= W_CLASS_MEDIUM))
 								M.show_message("<span class='notice'>[usr] puts \the [W] into \the [src].</span>")
+				refresh_all()
 				return 1
 
 	if(usr) //WHYYYYY

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -508,7 +508,7 @@
 	modules += new /obj/item/weapon/extinguisher/mini(src)
 	modules += new /obj/item/weapon/storage/bag/ore/auto(src)
 	modules += new /obj/item/weapon/pickaxe/drill/borg(src)
-	modules += new /obj/item/weapon/storage/bag/sheetsnatcher(src)
+	modules += new /obj/item/weapon/storage/bag/sheetsnatcher/borg(src)
 	modules += new /obj/item/device/mining_scanner(src)
 	modules += new /obj/item/weapon/gun/energy/kinetic_accelerator/cyborg(src)
 	modules += new /obj/item/weapon/gripper/no_use/inserter(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -508,7 +508,7 @@
 	modules += new /obj/item/weapon/extinguisher/mini(src)
 	modules += new /obj/item/weapon/storage/bag/ore/auto(src)
 	modules += new /obj/item/weapon/pickaxe/drill/borg(src)
-	modules += new /obj/item/weapon/storage/bag/sheetsnatcher/borg(src)
+	modules += new /obj/item/weapon/storage/bag/sheetsnatcher(src)
 	modules += new /obj/item/device/mining_scanner(src)
 	modules += new /obj/item/weapon/gun/energy/kinetic_accelerator/cyborg(src)
 	modules += new /obj/item/weapon/gripper/no_use/inserter(src)


### PR DESCRIPTION
[bugfix][qol]

## What this does
changes how stacks are placed into bags, making them stack automatically if possible.
removes all the snowflake code for sheet snatchers since this system they used now works in general with new code.
Closes #27141.
Closes #32857.

## Why it's good
makes putting stacks in bags nicer.

## How it was tested
putting stacks into bags, examining their numbers on things that allow it; specifically the ore loaders, also picking up ore off the ground with them.

## Changelog
:cl:
 * tweak: Placing stacks into storage items now automatically adds it to stacks of the same type, if possible.
 * tweak: Ore satchels and derivatives now show the number of ores in all stacks per type.
 * bugfix: Sheet snatchers no longer cause bad screen issues.