### PR TITLE
adds safety logging for quick equip baguloosing

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -501,6 +501,7 @@ var/global/msg_id = 0
 			(istype(I,/obj/item/weapon/spacecash) && id && id.virtual_wallet)
 
 /obj/item/device/pda/quick_store(var/obj/item/I,mob/user)
+	..()
 	return !(attackby(I,user))
 
 /obj/item/device/pda/proc/add_to_virtual_wallet(var/amount, var/mob/user, var/atom/giver)

--- a/code/game/objects/items/weapons/storage/bluespace.dm
+++ b/code/game/objects/items/weapons/storage/bluespace.dm
@@ -12,6 +12,9 @@
 	fits_max_w_class = W_CLASS_LARGE
 	max_combined_w_class = 28
 
+/mob
+	var/last_quick_stored = 0
+
 /obj/item/weapon/storage/backpack/holding/return_air()//prevents hot food from getting cold while in it.
 	return
 
@@ -31,6 +34,15 @@
 	user.visible_message("<span class = 'danger'><b>[user] puts \the [src.name] on the ground and jumps inside, never to be seen again.<</b></span>")
 	user.drop_item(src)
 	qdel(user)
+
+/obj/item/weapon/storage/backpack/holding/quick_store(var/obj/item/I,mob/user)
+	if(world.time - user.last_quick_stored < 3) // to handle mistakenly doing it fast, plus any info about the baguloose is shown below anyways
+		var/list/recursive_list = recursive_type_check(I, /obj/item/weapon/storage/backpack/holding)
+		if(recursive_list.len) 
+			message_admins("[key_name_admin(user)] created a baguloose from quick equipping fast, might be worth noting.")
+			log_game("[key_name(user)] created a baguloose from quick equipping fast, might be worth noting.")
+	user.last_quick_stored = world.time
+	return ..()
 
 /obj/item/weapon/storage/backpack/holding/handle_item_insertion(obj/item/W, prevent_warning)
 	. = ..()

--- a/code/game/objects/items/weapons/storage/bluespace.dm
+++ b/code/game/objects/items/weapons/storage/bluespace.dm
@@ -12,9 +12,6 @@
 	fits_max_w_class = W_CLASS_LARGE
 	max_combined_w_class = 28
 
-/client
-	var/last_quick_stored_boh = 0
-
 /obj/item/weapon/storage/backpack/holding/return_air()//prevents hot food from getting cold while in it.
 	return
 
@@ -37,12 +34,11 @@
 
 /obj/item/weapon/storage/backpack/holding/quick_store(var/obj/item/I,mob/user)
 	if(user.client)
-		if(world.time - user.client.last_quick_stored_boh < 3) // to handle mistakenly doing it fast, plus any info about the baguloose is shown below anyways
+		if(world.time - user.client.last_quick_stored < 3) // to handle mistakenly doing it fast, plus any info about the baguloose is shown below anyways
 			var/list/recursive_list = recursive_type_check(I, /obj/item/weapon/storage/backpack/holding)
 			if(recursive_list.len) 
 				message_admins("[key_name_admin(user)] created a baguloose from quick equipping fast, might be worth noting.")
 				log_game("[key_name(user)] created a baguloose from quick equipping fast, might be worth noting.")
-		user.client.last_quick_stored_boh = world.time
 	return ..()
 
 /obj/item/weapon/storage/backpack/holding/handle_item_insertion(obj/item/W, prevent_warning)

--- a/code/game/objects/items/weapons/storage/bluespace.dm
+++ b/code/game/objects/items/weapons/storage/bluespace.dm
@@ -33,7 +33,7 @@
 	qdel(user)
 
 /obj/item/weapon/storage/backpack/holding/quick_store(var/obj/item/I,mob/user)
-	if(user.client)
+	if(user?.client)
 		if(world.time - user.client.last_quick_stored < 3) // to handle mistakenly doing it fast, plus any info about the baguloose is shown below anyways
 			var/list/recursive_list = recursive_type_check(I, /obj/item/weapon/storage/backpack/holding)
 			if(recursive_list.len) 

--- a/code/game/objects/items/weapons/storage/bluespace.dm
+++ b/code/game/objects/items/weapons/storage/bluespace.dm
@@ -12,8 +12,8 @@
 	fits_max_w_class = W_CLASS_LARGE
 	max_combined_w_class = 28
 
-/mob
-	var/last_quick_stored = 0
+/client
+	var/last_quick_stored_boh = 0
 
 /obj/item/weapon/storage/backpack/holding/return_air()//prevents hot food from getting cold while in it.
 	return
@@ -36,12 +36,13 @@
 	qdel(user)
 
 /obj/item/weapon/storage/backpack/holding/quick_store(var/obj/item/I,mob/user)
-	if(world.time - user.last_quick_stored < 3) // to handle mistakenly doing it fast, plus any info about the baguloose is shown below anyways
-		var/list/recursive_list = recursive_type_check(I, /obj/item/weapon/storage/backpack/holding)
-		if(recursive_list.len) 
-			message_admins("[key_name_admin(user)] created a baguloose from quick equipping fast, might be worth noting.")
-			log_game("[key_name(user)] created a baguloose from quick equipping fast, might be worth noting.")
-	user.last_quick_stored = world.time
+	if(user.client)
+		if(world.time - user.client.last_quick_stored_boh < 3) // to handle mistakenly doing it fast, plus any info about the baguloose is shown below anyways
+			var/list/recursive_list = recursive_type_check(I, /obj/item/weapon/storage/backpack/holding)
+			if(recursive_list.len) 
+				message_admins("[key_name_admin(user)] created a baguloose from quick equipping fast, might be worth noting.")
+				log_game("[key_name(user)] created a baguloose from quick equipping fast, might be worth noting.")
+		user.client.last_quick_stored_boh = world.time
 	return ..()
 
 /obj/item/weapon/storage/backpack/holding/handle_item_insertion(obj/item/W, prevent_warning)

--- a/code/game/objects/items/weapons/storage/bluespace.dm
+++ b/code/game/objects/items/weapons/storage/bluespace.dm
@@ -34,11 +34,11 @@
 
 /obj/item/weapon/storage/backpack/holding/quick_store(var/obj/item/I,mob/user)
 	if(user?.client)
-		if(world.time - user.client.last_quick_stored < 3) // to handle mistakenly doing it fast, plus any info about the baguloose is shown below anyways
-			var/list/recursive_list = recursive_type_check(I, /obj/item/weapon/storage/backpack/holding)
-			if(recursive_list.len) 
-				message_admins("[key_name_admin(user)] created a baguloose from quick equipping fast, might be worth noting.")
-				log_game("[key_name(user)] created a baguloose from quick equipping fast, might be worth noting.")
+		var/list/recursive_list = recursive_type_check(I, /obj/item/weapon/storage/backpack/holding)
+		if(recursive_list.len)
+			var/report = " created a baguloose from quick equipping in [(world.time - user.client.last_quick_stored) / 10] seconds, might be worth noting."
+			message_admins("[key_name_admin(user)][report]") // any info about the baguloose is shown below anyways
+			log_game("[key_name(user)][report]")
 	return ..()
 
 /obj/item/weapon/storage/backpack/holding/handle_item_insertion(obj/item/W, prevent_warning)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -399,6 +399,7 @@
 	return can_be_inserted(I,1)
 
 /obj/item/weapon/storage/quick_store(var/obj/item/I,mob/user)
+	..()
 	return handle_item_insertion(I,0)
 
 //Call this proc to handle the removal of an item from the storage item. The item will be moved to the atom sent as new_target

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -682,7 +682,12 @@ a {
 /obj/proc/can_quick_store(var/obj/item/I) //proc used to check that the current object can store another through quick equip
 	return 0
 
+/client
+	var/last_quick_stored = 0
+
 /obj/proc/quick_store(var/obj/item/I,mob/user) //proc used to handle quick storing
+	if(user?.client)
+		user.client.last_quick_stored = world.time
 	return 0
 
 /**

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -138,6 +138,7 @@
 			return 1
 
 /obj/item/clothing/quick_store(var/obj/item/I,mob/user)
+	..()
 	for(var/obj/item/clothing/accessory/storage/A in accessories)
 		if(A.hold && A.hold.handle_item_insertion(I,0))
 			return 1


### PR DESCRIPTION
[administration]

## What this does
patches a concern raised in #36676, where if people quick equip too fast it might baguloose by mistake. this message highlights any time this may happen.

## Why it's good
less accidental BWOINKs.

## How it was tested
quick equipping the bag fast.

## Changelog
:cl:
 * rscadd: Admins now get a message if a bag of holding was quick equipped into another bag of holding really fast with hotkeys.