### PR TITLE
reduced AAC restrictions

### DIFF
--- a/code/modules/atmos_automation/console.dm
+++ b/code/modules/atmos_automation/console.dm
@@ -292,9 +292,10 @@
 		onclose(usr, "AAC_assemblies")
 
 /obj/machinery/computer/general_air_control/atmos_automation/proc/AAC_age_check(var/mob/M,var/list/href_list)
-	if(href_list["on"] || href_list["runonce"])
-		if(M.client && !M.client.holder && M.client.player_age < 30)
-			message_admins("[key_name(M)] attempted to [href_list["on"] ? "toggle" : "single-run"] an AAC script despite their player age of [M.client.player_age].")
+	if(href_list["read"])
+		if(M.client && !M.client.holder && M.client.player_age < 7)
+			to_chat(M, "<span class=warning>Code importing functionality is not available yet. Keep playing to unlock it.</span>")
+			message_admins("[key_name(M)] attempted to import an AAC script despite their player age of [M.client.player_age].")
 			return TRUE
 
 /obj/machinery/computer/general_air_control/atmos_automation/proc/MakeCompare(var/datum/automation/a, var/datum/automation/b, var/comparetype)

--- a/code/modules/atmos_automation/console.dm
+++ b/code/modules/atmos_automation/console.dm
@@ -295,6 +295,7 @@
 	if(href_list["read"])
 		if(M.client && !M.client.holder && M.client.player_age < 7)
 			to_chat(M, "<span class=warning>Code importing functionality is not available yet. Keep playing to unlock it.</span>")
+			to_chat(M, "<span class=warning>Importing functionality is unavailable for new personnel. Please wait an additional [7 - M.client.player_age] days before use.</span>")
 			message_admins("[key_name(M)] attempted to import an AAC script despite their player age of [M.client.player_age].")
 			return TRUE
 

--- a/code/modules/atmos_automation/console.dm
+++ b/code/modules/atmos_automation/console.dm
@@ -294,7 +294,6 @@
 /obj/machinery/computer/general_air_control/atmos_automation/proc/AAC_age_check(var/mob/M,var/list/href_list)
 	if(href_list["read"])
 		if(M.client && !M.client.holder && M.client.player_age < 7)
-			to_chat(M, "<span class=warning>Code importing functionality is not available yet. Keep playing to unlock it.</span>")
 			to_chat(M, "<span class=warning>Importing functionality is unavailable for new personnel. Please wait an additional [7 - M.client.player_age] days before use.</span>")
 			message_admins("[key_name(M)] attempted to import an AAC script despite their player age of [M.client.player_age].")
 			return TRUE


### PR DESCRIPTION
[tweak]
## What this does
applies the AAC restriction to only the import code functionality. additionaly, it will send a message to the user if their account is too new, and reduces the age check from 30 days to 7.
these changes were discussed in the discord and in #36627
![Capture](https://github.com/vgstation-coders/vgstation13/assets/68451232/fc358722-9d96-4b97-b707-2206798c87ba)

## Why it's good
allows newer engineers to use the TEG without help, and allows them to experiment with the AAC while learning how things work.

## How it was tested
i had to var edit my player age and remove the client.holder to test, so hopefully it's good


## Changelog
:cl:
 * tweak: Newer accounts may use the AAC, though the import functionality is still restricted
