### PR TITLE
Possible fix to boomerangs killing the server

### DIFF
--- a/code/game/objects/items/weapons/boomerang.dm
+++ b/code/game/objects/items/weapons/boomerang.dm
@@ -66,7 +66,10 @@
 		var/T = get_turf(target)
 
 		for(var/step_n = 1 to circle_radius)
-			T = get_step(T, m_dir)
+			if(circle_radius > 50)
+				return
+			else
+				T = get_step(T, m_dir)
 
 		points.Add(T)
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
[bugfix] [oversight]
Attempts to fix the server crash we keep getting due to boomerangs, When I tested them from what I understood the shard would explode this made step_n like 100 million or something which made the circle radius on a boomerang infinity and then it tried to count from 1 to infinity I think? 
![image](https://github.com/vgstation-coders/vgstation13/assets/57334601/7b2ad025-c05d-46a3-98bd-6e935893eafd)
I have no idea if this is a good way to fix it but it does stop my local crashing so it seemed like better than nothing. If anyone who knows what they're doing wants to do this in a better way feel free and i'll close this because it might break something down the line I don't really know.

closes #36449

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Stops the server dying which is probably good
## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
I mapped in a shard and a bunch of boomerangs then blew myself and them up five times with the changes and without them. Crashed every time without didn't crash with.
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed a bug that caused boomerangs to kill the server.

