### PR TITLE
fixes colour mishap

### DIFF
--- a/code/modules/reagents/reagents/reagents_medical.dm
+++ b/code/modules/reagents/reagents/reagents_medical.dm
@@ -668,7 +668,7 @@ var/global/list/charcoal_doesnt_remove=list(
 	id = DEXALIN
 	description = "Dexalin is used in the treatment of oxygen deprivation."
 	reagent_state = REAGENT_STATE_LIQUID
-	color = "#C2733F" //rgb: 74, 230, 252
+	color = "#4CE9FF" //rgb: 74, 230, 252
 	density = 2.28
 	specheatcap = 0.91
 
@@ -701,7 +701,7 @@ var/global/list/charcoal_doesnt_remove=list(
 	id = DEXALINP
 	description = "Dexalin Plus is used in the treatment of oxygen deprivation. Its highly effective."
 	reagent_state = REAGENT_STATE_LIQUID
-	color = "#C2733F" //rgb: 74, 230, 252
+	color = "#4CE9FF" //rgb: 74, 230, 252
 	density = 4.14
 	specheatcap = 0.29
 


### PR DESCRIPTION
## What this does
Fixes dexalin looking orange instead of cyan.

## Why it's good
Fixes a mistake I made when making #36658.
## How it was tested
I checked the hex colours twice to make sure it was in fact the proper cyan instead of the accidental orange.
[bugfix][hotfix]
:cl:
 * bugfix: Dexalin and Dexplus should be cyan as intended (instead of orange).