### PR TITLE
Fixes IED casings being deleted when not made in hands

### DIFF
--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -3,7 +3,7 @@
 //iedcasing assembly crafting//
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/attackby(var/obj/item/I, mob/user as mob)
 	if(istype(I, /obj/item/device/assembly/igniter))
-		var/obj/item/weapon/grenade/iedcasing/W = new /obj/item/weapon/grenade/iedcasing
+		var/obj/item/weapon/grenade/iedcasing/W = new /obj/item/weapon/grenade/iedcasing(loc)
 		W.underlays += image(src.icon, icon_state = src.icon_state)
 		user.create_in_hands(src, W, I, msg = "<span class='notice'>You stuff the [I] into the [src], emptying the contents beforehand.</span>")
 	else if(I.is_wirecutter(user))


### PR DESCRIPTION
[bugfix]

## What this does
Closes #36726.

## How it was tested
spawning soda can on the floor, spawning igniter, putting it into soda can on floor.

## Changelog
:cl:
 * bugfix: IEDs can now be made when not holding a can in hand again.