### PR TITLE
An alternate voting method

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -33,7 +33,7 @@
 	var/allow_vote_restart = 0 			// allow votes to restart
 	var/allow_vote_mode = 0				// allow votes to change mode
 	var/toggle_maps = 0					// Change from votable maps = 0 to all compiled maps = 1
-	var/toggle_vote_method = 1			// Toggle voting methods: Weighted = 1, Majority = 2, Persistent = 3, Random = 4
+	var/toggle_vote_method = 5			// Toggle voting methods: Weighted = 1, Majority = 2, Persistent = 3, Random = 4, Non-previous weighted = 5.
 	var/allow_admin_jump = 1			// allows admin jumping
 	var/allow_admin_spawning = 1		// allows admin item spawning
 	var/allow_admin_rev = 1				// allows admin revives


### PR DESCRIPTION
[controversial] [vote]

## What this does
adds a new voting method which reduces the probability of the current item being voted for. (eg, if it is a map, the currently-loaded map will have a reduced chance of winning than it normally would)
the exact numbers is that it reduces voting power by 25%, though this number can be changed easily in a var. This reduction is done last in the checks, so an option will never be dropped due to not getting enough votes because of this change.

## Why it's good
more map variety leads to a wider variety of gameplay and reduces burnout of players. Additionally, having more attention on other maps will lead to more issues in them being found and (theoretically) fixed.

## How it was tested
it wasn't. i just couldn't get my local server to compile the maps.

## Changelog
:cl:
 * tweak: map voting will now use a slightly changed voting method to promote more map variety
