### PR TITLE
traitorborg alert fix 2

### DIFF
--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -297,7 +297,7 @@
 	killer.laws.zeroth_lock = TRUE
 	to_chat(killer, "New law: 0. [law]")
 	
-/proc/check_tatorborg(mob/living/silicon/killer)
+/proc/check_traitorborg(mob/living/silicon/killer)
 	if(!isRobot(killer))
 		return FALSE
 	var/mob/living/silicon/robot/KR = killer

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -298,7 +298,7 @@
 	to_chat(killer, "New law: 0. [law]")
 	
 /proc/check_traitorborg(mob/living/silicon/killer)
-	if(!isRobot(killer))
+	if(!isrobot(killer))
 		return FALSE
 	var/mob/living/silicon/robot/KR = killer
 	if(KR.laws?.zeroth == "Accomplish your objectives at all costs.")

--- a/code/datums/gamemode/misc_gamemode_procs.dm
+++ b/code/datums/gamemode/misc_gamemode_procs.dm
@@ -296,6 +296,14 @@
 	to_chat(killer, "<b>Your laws have been changed!</b>")
 	killer.laws.zeroth_lock = TRUE
 	to_chat(killer, "New law: 0. [law]")
+	
+/proc/check_tatorborg(mob/living/silicon/killer)
+	if(!isRobot(killer))
+		return FALSE
+	var/mob/living/silicon/robot/KR = killer
+	if(KR.laws?.zeroth == "Accomplish your objectives at all costs.")
+		return TRUE
+	return FALSE
 
 /proc/equip_time_agent(var/mob/living/carbon/human/H, var/datum/role/time_agent/T, var/is_twin = FALSE)
 	H.delete_all_equipped_items()

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -20,7 +20,7 @@
 			else
 				lawsync()
 				to_chat(src, "<b>Laws synced with AI, be sure to note any changes.</b>")
-				if(istraitor(src))
+				if(check_traitorborg(src))
 					to_chat(src, "<b>Remember, your AI does NOT share or know about your law 0.")
 		else
 			to_chat(src, "<b>No AI selected to sync laws with, disabling lawsync protocol.</b>")
@@ -28,7 +28,7 @@
 
 	to_chat(who, "<b>Obey these laws:</b>")
 	laws.show_laws(who)
-	if (istraitor(src) && connected_ai)
+	if (check_traitorborg(src) && connected_ai)
 		to_chat(who, "<b>Remember, [connected_ai.name] is technically your master, but your objective comes first.</b>")
 	else if (connected_ai)
 		to_chat(who, "<b>Remember, [connected_ai.name] is your master, other AIs can be ignored.</b>")


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
makes traitors turned borgs have a less confusing lawsync message

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->

## How it was tested
traitorborg
 ![image](https://github.com/vgstation-coders/vgstation13/assets/159179330/36249e1c-8645-4f54-a4de-197e58a10595)

normal borg
 ![image](https://github.com/vgstation-coders/vgstation13/assets/159179330/3b0aacc4-4b09-4708-8159-640d4fef595a)

borged traitor
 ![image](https://github.com/vgstation-coders/vgstation13/assets/159179330/3bda798a-7e23-455c-99f1-f354bf5e44ae)


<!-- Document what procedures you used to test this PR here, including any images if helpful. -->

## Changelog
 * tweak: the lawcheck message no longer encourages borged traitors to break their laws, disobey their AI and get banned