### PR TITLE
Some on_hit fixes

### DIFF
--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -358,7 +358,7 @@
 /obj/structure/bed/chair/vehicle/bullet_act(var/obj/item/projectile/Proj)
 	var/hitrider = 0
 	if(istype(Proj, /obj/item/projectile/ion))
-		Proj.on_hit(src, 2)
+		Proj.on_hit(src, 100)
 		return
 
 	if(occupant)

--- a/code/modules/mob/living/carbon/complex/combat.dm
+++ b/code/modules/mob/living/carbon/complex/combat.dm
@@ -6,8 +6,8 @@
 
 /mob/living/carbon/complex/bullet_act(var/obj/item/projectile/P, var/def_zone)
 	if(check_shields(P.damage, P))
-		P.on_hit(src, 2)
-		return 2
+		P.on_hit(src, 100)
+		return PROJECTILE_COLLISION_BLOCKED
 	return (..(P , def_zone))
 
 /mob/living/carbon/complex/attack_hand(mob/living/M)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -64,7 +64,7 @@
 
 	var/absorb = run_armor_check(def_zone, P.flag, armor_penetration = P.armor_penetration)
 	if(absorb >= 100)
-		P.on_hit(src,2)
+		P.on_hit(src,100)
 		return PROJECTILE_COLLISION_BLOCKED
 	if(!P.nodamage)
 		var/damage = run_armor_absorb(def_zone, P.flag, P.damage)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -155,7 +155,7 @@
 /mob/living/silicon/bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj.nodamage)
 		adjustBruteLoss(Proj.damage)
-	Proj.on_hit(src,2)
+	Proj.on_hit(src,100)
 	return PROJECTILE_COLLISION_DEFAULT
 
 /mob/living/silicon/apply_effect(var/effect = 0,var/effecttype = STUN, var/blocked = 0)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -155,7 +155,7 @@
 /mob/living/silicon/bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj.nodamage)
 		adjustBruteLoss(Proj.damage)
-	Proj.on_hit(src,100)
+	Proj.on_hit(src,100) //They are immune to on_hit effects, just take the damage
 	return PROJECTILE_COLLISION_DEFAULT
 
 /mob/living/silicon/apply_effect(var/effect = 0,var/effecttype = STUN, var/blocked = 0)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -155,7 +155,7 @@
 /mob/living/silicon/bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj.nodamage)
 		adjustBruteLoss(Proj.damage)
-	Proj.on_hit(src,100) //They are immune to on_hit effects, just take the damage
+	Proj.robot_on_hit(src,100) //Unique variant of on_hit
 	return PROJECTILE_COLLISION_DEFAULT
 
 /mob/living/silicon/apply_effect(var/effect = 0,var/effecttype = STUN, var/blocked = 0)

--- a/code/modules/mob/living/simple_animal/hostile/mannequin.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mannequin.dm
@@ -147,7 +147,7 @@
 
 	var/absorb = run_armor_check(def_zone, P.flag, armor_penetration = P.armor_penetration)
 	if(absorb >= 100)
-		P.on_hit(src,2)
+		P.on_hit(src,100)
 		return PROJECTILE_COLLISION_BLOCKED
 	if(!P.nodamage)
 		var/damage = run_armor_absorb(def_zone, P.flag, P.damage)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -157,6 +157,11 @@ var/list/impact_master = list()
 		playsound(loc, hitsound, 35, 1)
 	return 1
 
+//A special on_hit variant that gets applied to robots, for when you want some things to affect robots but not everything.
+//Code that checks for this is in code/modules/mob/living/silicon/silicon.dm
+/obj/item/projectile/proc/robot_on_hit(var/atom/atarget, var/blocked = 0)
+	return on_hit(atarget, blocked)
+
 /obj/item/projectile/proc/check_fire(var/mob/living/target as mob, var/mob/living/user as mob)  //Checks if you can hit them or not.
 	if(!istype(target) || !istype(user))
 		return 0

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -36,6 +36,16 @@
 	spawn(30)
 		X.tazed = 0
 
+//Robots get slowed down
+/obj/item/projectile/energy/electrode/robot_on_hit(var/mob/living/atarget, var/blocked)
+	QDEL_NULL(tracker_datum)
+	if(atarget.tazed == 0)
+		atarget.movement_speed_modifier -= 0.75
+		spawn(30)
+			atarget.movement_speed_modifier += 0.75
+	atarget.tazed = 1
+	spawn(30)
+		atarget.tazed = 0
 
 /*/vg/ EDIT
 	agony = 40

--- a/code/modules/spells/aoe_turf/conjure/forcewall.dm
+++ b/code/modules/spells/aoe_turf/conjure/forcewall.dm
@@ -80,8 +80,9 @@ Unwall spell, sadly has to be targeted to be any fun to use
 /obj/effect/forcefield/bullet_act(var/obj/item/projectile/Proj, var/def_zone)
 	var/turf/T = get_turf(src.loc)
 	if(T)
-		for(var/mob/M in T)
-			Proj.on_hit(M,M.bullet_act(Proj, def_zone))
+		var/mob/M = pick(T.contents)
+		if(M)
+			M.bullet_act(Proj, def_zone)
 	return ..()
 
 /obj/effect/forcefield/wizard

--- a/code/modules/spells/aoe_turf/conjure/forcewall.dm
+++ b/code/modules/spells/aoe_turf/conjure/forcewall.dm
@@ -81,8 +81,7 @@ Unwall spell, sadly has to be targeted to be any fun to use
 	var/turf/T = get_turf(src.loc)
 	if(T)
 		var/mob/M = pick(T.contents)
-		if(M)
-			M.bullet_act(Proj, def_zone)
+		M?.bullet_act(Proj, def_zone)
 	return ..()
 
 /obj/effect/forcefield/wizard


### PR DESCRIPTION
Updates some on_hit effects so that they properly get blocked when they should be blocked, which means that martians carrying 5 or 6 riot shields can now menace the station.
The most important part of this change is that it fixes on_hit so that it never happens to silicons, as it was intended and which was broken for about 5 years.
Fixed Force Wall causing a projectile fired into it to not only hit everyone in the force wall but also apply on_hit effects regardless of protection.
PROJECTILE_COLLISION_BLOCKED has a value of 2.
Added a new projectile proc, robot_on_hit, which is called by silicons. By default it calls regular on_hit which will get blocked, but it can be overridden in order to allow projectiles to do unique robot effects, should the need arise. Tasers now slow down cyborgs this way.

:cl:
 * bugfix: Martians will now properly block projectile effects using their shields.
 * bugfix: Fixed a few instances in the code where having full protection against a projectile attack would still cause projectile effects to happen, even when it should be completely blocked.
 * bugfix: Fixed a 5-year-old bug where silicons were unintentionally subjected to various projectile effects such as syringes from syringe guns. However, they have retained their weakness to slowdown caused by tasers.
 * bugfix: Force Wall will now only pick one character on its turf to deal damage to if it is impacted by a projectile, as opposed to affecting every single character, and will now respect whether the user could block the attack or not.
