### PR TITLE
Fixes assembly interaction window refreshing

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -394,7 +394,7 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 			_using |= usr
 		if(_using && _using.len)
 			for(var/mob/M in _using) // Only check things actually messing with us.
-				if (!M || !M.client || !is_holder_of(M,src))  // NOT ON MOB
+				if (!M || !M.client || !in_range(loc,M))  // NOT ON MOB
 					_using.Remove(M)
 					continue
 				is_in_use = 1

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -387,6 +387,24 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 					attack_hand(M, TRUE)
 		in_use = is_in_use
 
+/obj/item/updateUsrDialog()
+	if(in_use)
+		var/is_in_use = 0
+		if(usr)
+			_using |= usr
+		if(_using && _using.len)
+			for(var/mob/M in _using) // Only check things actually messing with us.
+				if ((M.client && M.machine == src && src.loc == M))
+					is_in_use = 1
+					src.attack_self(M)
+				if (isMoMMI(M))
+					if ((M.client && M.machine == src && src.loc == M)) // && M.machine == src is omitted because if we triggered this by using the dialog, it doesn't matter if our machine changed in between triggering it and this - the dialog is probably still supposed to refresh.
+						is_in_use = 1
+						src.attack_self(M)
+
+		// check for TK users
+		in_use = is_in_use
+
 /obj/proc/updateDialog()
 	// Check that people are actually using the machine. If not, don't update anymore.
 	if(in_use)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -397,14 +397,8 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 				if (!M || !M.client || !is_holder_of(M,src))  // NOT ON MOB
 					_using.Remove(M)
 					continue
-
-				if ((M.client && M.machine == src && src.loc == M))
-					is_in_use = 1
-					src.attack_self(M)
-				if (isMoMMI(M))
-					if ((M.client && M.machine == src && src.loc == M)) // && M.machine == src is omitted because if we triggered this by using the dialog, it doesn't matter if our machine changed in between triggering it and this - the dialog is probably still supposed to refresh.
-						is_in_use = 1
-						src.attack_self(M)
+				is_in_use = 1
+				src.attack_self(M)
 
 		// check for TK users
 		in_use = is_in_use

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -394,6 +394,10 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 			_using |= usr
 		if(_using && _using.len)
 			for(var/mob/M in _using) // Only check things actually messing with us.
+				if (!M || !M.client || !is_holder_of(M,src))  // NOT ON MOB
+					_using.Remove(M)
+					continue
+
 				if ((M.client && M.machine == src && src.loc == M))
 					is_in_use = 1
 					src.attack_self(M)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -180,8 +180,7 @@
 				QDEL_NULL(beam)
 			process()
 
-	if(usr)
-		attack_self(usr)
+	updateUsrDialog()
 
 
 /***************************IBeam*********************************/

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -150,8 +150,6 @@
 	var/dat = text("<B>Status</B>: []<BR>\n<B>Visibility</B>: []<BR>", (on ? text("<A href='?src=\ref[];state=0'>ON</A>", src) : text("<A href='?src=\ref[];state=1'>OFF</A>", src)), (src.visible ? text("<A href='?src=\ref[];visible=0'>visible</A>", src) : text("<A href='?src=\ref[];visible=1'>infrared</A>", src)))
 
 	dat += {"<B>Direction</B>: <A href='?src=\ref[src];direction=1'>[dir2text(dir)]</A><BR>"}
-	dat += {"<BR><BR><A href='?src=\ref[src];refresh=1'>Refresh</A>
-		<BR><BR><A href='?src=\ref[src];close=1'>Close</A>"}
 	user << browse("<TITLE>Infrared Laser</TITLE><HR>[dat]", "window=infra")
 	onclose(user, "infra")
 
@@ -172,10 +170,6 @@
 		if(beam)
 			beam.set_visible(visible)
 		update_icon()
-
-	if(href_list["close"])
-		usr << browse(null, "window=infra")
-		return
 
 	if(href_list["direction"])
 		var/choice = input("What direction will you aim the laser toward?","Infrared Laser") as null|anything in list("NORTH", "EAST", "SOUTH", "WEST")

--- a/code/modules/assembly/light_tiler.dm
+++ b/code/modules/assembly/light_tiler.dm
@@ -82,7 +82,6 @@
 	<p><a href='?src=\ref[src];change_color=1'>Change color</a> | <a href='?src=\ref[src];toggle_set_state=1'>Light floors will be turned <b>[set_state ? "ON" : "OFF"]</b></a></p>
 	<BR>
 	<p><a href='?src=\ref[src];apply=1'>Activate</a></p>
-	<p><a href='?src=\ref[src];refresh=1'>Refresh</a></p>
 	"}
 
 	var/datum/browser/popup = new(user, "\ref[src]", "[src]", 500, 300, src)
@@ -126,9 +125,6 @@
 			work_mode = MODE_ADDING
 			to_chat(usr, "<span class='info'>When applied to light floors, \the [src] will now connect to them.</span>")
 
-		if(usr)
-			attack_self(usr)
-
 	if(href_list["toggle_set_state"])
 		set_state = !set_state
 
@@ -137,16 +133,10 @@
 		else
 			to_chat(usr, "<span class='info'>Light floors will be turned off.</span>")
 
-		if(usr)
-			attack_self(usr)
-
 	if(href_list["delete_all"])
 		to_chat(usr, "<span class='notice'>Disconnected [connected_floors.len] tiles from the network.</span>")
 
 		connected_floors = list()
-
-		if(usr)
-			attack_self(usr)
 
 	if(href_list["change_color"])
 		var/new_color = input(usr, "Please select a new color for \the [src].", "[src]", rgb(color_r,color_g,color_b)) as color
@@ -160,15 +150,10 @@
 
 		to_chat(usr, "<span class='info'>Changed color to [color_r];[color_g];[color_b]!</span>")
 
-		if(usr)
-			attack_self(usr)
-
 	if(href_list["apply"])
 		change_floors()
 
-	if(href_list["refresh"])
-		if(usr)
-			attack_self(usr)
+	updateUsrDialog()
 
 /obj/item/device/assembly/light_tile_control/proc/change_floors()
 	if(last_used + cooldown_max > world.time)

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -109,13 +109,14 @@
 				in_proximity = FALSE
 				sense()
 
-	if(timing && (time >= 0))
-		time--
-	if(timing && time <= 0)
-		timing = 0
-		toggle_scan()
-		time = default_time
-	return
+	if(timing)
+		if(time >= 0)
+			time--
+		else
+			timing = 0
+			toggle_scan()
+			time = default_time
+		updateUsrDialog()
 
 /obj/item/device/assembly/prox_sensor/dropped()
 	spawn(0)
@@ -162,9 +163,7 @@
 
 	dat += {"<BR><A href='?src=\ref[src];scanning=1'>[scanning?"Armed":"Unarmed"]</A> (Movement sensor active when armed!)
 		<BR><BR><A href='?src=\ref[src];set_default_time=1'>After countdown, reset time to [(default_time - default_time%60)/60]:[(default_time % 60)]</A>
-		<BR><BR><A href='?src=\ref[src];refresh=1'>Refresh</A>
-		<BR><BR><A href='?src=\ref[src];toggle_mode=1'>Mode: [constant_pulse ? PROXMODE_CONSTANT : PROXMODE_ENTER]</A>
-		<BR><BR><A href='?src=\ref[src];close=1'>Close</A>"}
+		<BR><BR><A href='?src=\ref[src];toggle_mode=1'>Mode: [constant_pulse ? PROXMODE_CONSTANT : PROXMODE_ENTER]</A>"}
 	user << browse(dat, "window=prox")
 	onclose(user, "prox")
 	return
@@ -201,11 +200,6 @@
 	
 	if(href_list["toggle_mode"])
 		constant_pulse = !constant_pulse
-		return
-
-	if(href_list["close"])
-		usr << browse(null, "window=prox")
-		return
 
 	if(usr)
 		attack_self(usr)

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -201,9 +201,7 @@
 	if(href_list["toggle_mode"])
 		constant_pulse = !constant_pulse
 
-	if(usr)
-		attack_self(usr)
-
+	updateUsrDialog()
 	return
 
 #undef VALUE_SCANNING

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -120,9 +120,7 @@
 	if(href_list["set_default_time"])
 		default_time = time
 
-	if(usr)
-		attack_self(usr)
-
+	updateUsrDialog()
 	return
 
 /obj/item/device/assembly/timer/send_to_past(var/duration)

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -60,15 +60,15 @@
 	return
 
 /obj/item/device/assembly/timer/process()
-	if(timing && (time > 0))
-		time--
-	if(timing && time <= 0)
-		if(!repeat)
-			timing = 0
-		timer_end()
-		time = default_time
-	return
-
+	if(timing)
+		if(time > 0)
+			time--
+		else
+			if(!repeat)
+				timing = 0
+			timer_end()
+			time = default_time
+		updateUsrDialog()
 
 /obj/item/device/assembly/timer/update_icon()
 	overlays.len = 0
@@ -88,11 +88,8 @@
 	var/second = time % 60
 	var/minute = (time - second) / 60
 	var/dat = text("<TT><B>Timing Unit</B>\n[] []:[]\n<A href='?src=\ref[];tp=-30'>-</A> <A href='?src=\ref[];tp=-1'>-</A> <A href='?src=\ref[];tp=1'>+</A> <A href='?src=\ref[];tp=30'>+</A>\n</TT>", (timing ? text("<A href='?src=\ref[];time=0'>Timing</A>", src) : text("<A href='?src=\ref[];time=1'>Not Timing</A>", src)), minute, second, src, src, src, src)
-
 	dat += "<BR><BR><A href='?src=\ref[src];set_default_time=1'>After countdown, reset time to [(default_time - default_time%60)/60]:[(default_time % 60)]</A>"
-	dat += {"<BR><BR><A href='?src=\ref[src];refresh=1'>Refresh</A>
-		<BR><BR><A href='?src=\ref[src];toggle_mode=1'>Mode: [repeat ? TIMEMODE_REPEAT : TIMEMODE_ONCE]</A>
-		<BR><BR><A href='?src=\ref[src];close=1'>Close</A>"}
+	dat += "<BR><BR><A href='?src=\ref[src];toggle_mode=1'>Mode: [repeat ? TIMEMODE_REPEAT : TIMEMODE_ONCE]</A>"
 	user << browse(dat, "window=timer")
 	onclose(user, "timer")
 	return
@@ -119,11 +116,6 @@
 	
 	if(href_list["toggle_mode"])
 		repeat = !repeat
-		return
-
-	if(href_list["close"])
-		usr << browse(null, "window=timer")
-		return
 
 	if(href_list["set_default_time"])
 		default_time = time

--- a/code/modules/reagents/dartgun.dm
+++ b/code/modules/reagents/dartgun.dm
@@ -168,20 +168,6 @@
 /obj/item/weapon/gun/dartgun/can_hit(var/mob/living/target as mob, var/mob/living/user as mob)
 	return 1
 
-/obj/item/weapon/gun/dartgun/updateUsrDialog()
-	if(in_use)
-		var/is_in_use = 0
-		if ((usr.client && usr.machine == src && src.loc == usr))
-			is_in_use = 1
-			src.attack_self(usr)
-		if (isMoMMI(usr))
-			if ((usr.client && usr.machine == src && src.loc == usr)) // && M.machine == src is omitted because if we triggered this by using the dialog, it doesn't matter if our machine changed in between triggering it and this - the dialog is probably still supposed to refresh.
-				is_in_use = 1
-				src.attack_self(usr)
-
-		// check for TK users
-		in_use = is_in_use
-
 /obj/item/weapon/gun/dartgun/attack_self(mob/user)
 	user.set_machine(src)
 	in_use = 1


### PR DESCRIPTION
[UI][bugfix][qol]

## What this does
removes the now unnecessary refresh and close buttons from timers, proximity sensors and infrared sensors.
makes them refresh when their timers tick down.
makes updateUsrDialog work on items on your possesion or in range, code taken and modified from dartguns.

## How it was tested
activating the timers on each, adding a beaker to dartguns.

## Changelog
:cl:
 * bugfix: The mode change buttons on assemblies now properly refresh them.
 * tweak: Assembly windows now refresh as the timers tick down, instead of manually with the refresh button.
 * tweak: Unnecessary close and refresh buttons have now been removed from the UIs of timers, proximity sensors, infrared sensors and light tile remotes as these functions happen normally now.