### PR TITLE
Sand crafting menu for making sandstone

### DIFF
--- a/code/game/objects/items/stacks/stack_recipes.dm
+++ b/code/game/objects/items/stacks/stack_recipes.dm
@@ -682,3 +682,11 @@ var/list/datum/stack_recipe/ralloy_recipes = list (
 	new/datum/stack_recipe/dorf("dorf chair", /obj/structure/bed/chair, one_per_turf = TRUE, on_floor = TRUE, inherit_material = TRUE, gen_quality = TRUE),
 	new/datum/stack_recipe/dorf("training sword", /obj/item/weapon/melee/training_sword, 4, time = 12,	on_floor = TRUE, inherit_material = TRUE, gen_quality = TRUE),
 	)
+
+/* ========================================================================
+							SAND RECIPES
+======================================================================== */
+
+var/list/datum/stack_recipe/sand_recipes = list (
+	new/datum/stack_recipe("sandstone", /obj/item/stack/sheet/mineral/sandstone, 1, 1, 50),
+	)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -79,14 +79,9 @@
 			if(atm.on_fire) // For extinguishing objects on fire
 				atm.extinguish()
 
-/obj/item/stack/ore/glass/attack_self(mob/living/user as mob) //It's magic I ain't gonna explain how instant conversion with no tool works. -- Urist
-	var/location = get_turf(user)
-	for(var/obj/item/stack/ore/glass/sandToConvert in location)
-		drop_stack(/obj/item/stack/sheet/mineral/sandstone, location, sandToConvert.amount, user)
-		sandToConvert.use(sandToConvert.amount)
-
-	drop_stack(/obj/item/stack/sheet/mineral/sandstone, location, 1, user)
-	use(1)
+/obj/item/stack/ore/glass/New(var/loc, var/amount=null)
+	recipes = sand_recipes
+	..()
 
 /obj/item/stack/ore/plasma
 	name = "\improper plasma ore"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Adds a sand recipe menu, currently only for crafting sandstone, alternative pr of #36742 
## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
It's lets you make multiple sandstones without being forced to rapidly click and futureproofs for additional sand recipes to be added(sandcastles pls)
## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
spawned a bunch of sand, scooped it all up, made bricks, checked runtimes and found none.
![image](https://github.com/vgstation-coders/vgstation13/assets/26881007/ee0b571b-f4c1-445e-9405-f6df3158e935)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Crafting sandstone is now done in a crafting menu for rapid sandstone production.
