### PR TITLE
You can now add whole eggs to pans on help intent without cracking them

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks/egg.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/egg.dm
@@ -27,7 +27,8 @@
 	var/static/list/allowed_targets = list(/obj/item/weapon/reagent_containers, /obj/structure/reagent_dispensers/cauldron)
 	if(!adjacency_flag || !is_type_in_list(target, allowed_targets) || !target.is_open_container())
 		return
-
+	if(user.a_intent == I_HELP)
+		return
 	if(target.reagents.is_full())
 		to_chat(user, "<span class='notice'>\The [target] is full!</span>")
 		return


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
You can now add whole eggs to pans on help intent, allowing you to cook egg recipes in them. This seems to be the easiest solution, as people that don't want to bother with the pan and prefer microwaves instead are not affected at all. This affects all reagent containers as well, if needed I can make a specific case for the pan.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Several people have complained about not being able to use eggs with pans, so this fixes it.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
I got my eggs and tried putting them into a pan on every intent.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: You can now add whole eggs to pans on help intent without cracking them, allowing you to to cook egg recipes in a pan again.

