### PR TITLE
New fireball upgrade: Safety

### DIFF
--- a/__DEFINES/spell_defines.dm
+++ b/__DEFINES/spell_defines.dm
@@ -36,6 +36,7 @@
 #define Sp_MOVE		"mobility"
 #define Sp_AMOUNT	"amount"
 #define Sp_RANGE	"range"
+#define Sp_MISC     "miscellaneous"
 
 #define Sp_TOTAL	"total"
 

--- a/code/modules/spells/targeted/projectile/fireball.dm
+++ b/code/modules/spells/targeted/projectile/fireball.dm
@@ -37,7 +37,7 @@
 
 /spell/targeted/projectile/dumbfire/fireball/get_upgrade_price(upgrade_type)
 	if(upgrade_type == Sp_MISC) //Safety comes at a premium
-		return 60
+		return 40
 	return ..()
 
 /spell/targeted/projectile/dumbfire/fireball/apply_upgrade(upgrade_type)


### PR DESCRIPTION
An extremely expensive 40-point upgrade that makes the wizard immune to their own fireballs and the shrapnel that results from it. This, in total, would make Fireball an **60-point investment**, which is 3/5ths for a wizard that doesn't take No Gun Allowed and half the total points for a wizard that takes No Gun Allowed. Just to launch a fireball that they can survive. This is under the assumption that there are plenty of extremely fatal combinations that could be made with about 60 points of spell points.
Also adds a new "miscellaneous" spell level type which could have more spells ported to it in the future.

## Why it's good
More options, either the wizard puts on the training wheels and cripples their loadout variety or they ignore it and work with the fireball interaction that has always existed, but it should generally feel a bit less bad for the wizard, as they can either put a huge drain on their spell points just to be able to use Fireballs safely or they don't. It's balanced by the huge cost of 80 points just to have a safe fireball.

:cl:
 * rscadd: The Wizards Federation has announced a new possible upgrade for the iconic Fireball spell. Since the number of surviving Fireball users is in the single digit percentages, as they all almost inevitably blast themselves with it or get utterly annihilated by the shrapnel launched by it, they have seen fit to allow wizards to be able to acquire an immunity to Fireballing themselves, as well as to the shrapnel launched by the explosion. The immunity, however, costs an additional 40 spell points, which is more than half of a default wizard's available point pool when excluding the cost of the Fireball spell itself.