### PR TITLE
Bunch of Cult fixes and admin qol

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -239,7 +239,7 @@
 		if (BLOODCULT_STAGE_NORMAL)
 			dat += "<br>Eclipse progress: [round((eclipse_progress/eclipse_target)*100)]%"
 		else
-			if (sun && sun.eclipse_manager)
+			if (sun && sun.eclipse != ECLIPSE_NOT_YET)
 				var/seconds_to_eclipse = (sun.eclipse_manager.eclipse_start_time - cult_founding_time)/10
 				dat += "<br>Eclipse arrival: [round(seconds_to_eclipse/3600)]h [add_zero(num2text(round(seconds_to_eclipse/60) % 60), 2)]m [add_zero(num2text(round(seconds_to_eclipse) % 60), 2)]s"
 
@@ -516,6 +516,26 @@
 	var/list/dat = ..()
 
 	dat += "<br>accumulated devotion: [total_devotion]"
+	if (stage == BLOODCULT_STAGE_NORMAL)
+		var/eclipse_remaining = eclipse_target - eclipse_progress
+		var/eclipse_ticks_to_go_at_current_rate = 999999
+		if (eclipse_increments > 0)
+			eclipse_ticks_to_go_at_current_rate = eclipse_remaining / max(0.1, eclipse_increments)
+			if(SSticker.initialized)
+				eclipse_ticks_to_go_at_current_rate *= (SSticker.wait/10)
+			var/hours_to_go = round(eclipse_ticks_to_go_at_current_rate/3600)
+			var/minutes_to_go = add_zero(num2text(round(eclipse_ticks_to_go_at_current_rate/60) % 60), 2)
+			var/seconds_to_go = add_zero(num2text(round(eclipse_ticks_to_go_at_current_rate) % 60), 2)
+			dat += "<br>estimated time until Eclipse: [hours_to_go]h [minutes_to_go]m [seconds_to_go]s"
+		else
+			dat += "<br>with no cultists left around, the Eclipse won't manifest this round."
+	else if (sun && sun.eclipse_manager)
+		var/seconds_to_eclipse = (sun.eclipse_manager.eclipse_start_time - cult_founding_time)/10
+		dat += "<br>the Eclipse arrived after [round(seconds_to_eclipse/3600)]h [add_zero(num2text(round(seconds_to_eclipse/60) % 60), 2)]m [add_zero(num2text(round(seconds_to_eclipse) % 60), 2)]s"
+
+
+
+	dat += "<br>estimated time before Eclipse: [total_devotion]"
 	dat += "<br>available rituals: "
 	for (var/ritual_slot in rituals)
 		if (rituals[ritual_slot])
@@ -567,6 +587,12 @@
 			var/mob/M = R.antag.current
 			to_chat(M, "<span class='sinister'>This number might rise up to 9 as more people arrive aboard the station. The first Artificer, Wraith, and Juggernaut each do not take up a slot. Check your panel to the left to set your role and get more information.</span>")
 	AnnounceObjectives()
+	if (sun)
+		switch(sun.eclipse)
+			if (ECLIPSE_ONGOING)
+				stage(BLOODCULT_STAGE_READY)
+			if (ECLIPSE_OVER)
+				stage(BLOODCULT_STAGE_MISSED)
 	..()
 
 //we don't really have a use for that right now but there are plans for it.

--- a/code/datums/gamemode/factions/bloodcult/bloodcult.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult.dm
@@ -532,10 +532,6 @@
 	else if (sun && sun.eclipse_manager)
 		var/seconds_to_eclipse = (sun.eclipse_manager.eclipse_start_time - cult_founding_time)/10
 		dat += "<br>the Eclipse arrived after [round(seconds_to_eclipse/3600)]h [add_zero(num2text(round(seconds_to_eclipse/60) % 60), 2)]m [add_zero(num2text(round(seconds_to_eclipse) % 60), 2)]s"
-
-
-
-	dat += "<br>estimated time before Eclipse: [total_devotion]"
 	dat += "<br>available rituals: "
 	for (var/ritual_slot in rituals)
 		if (rituals[ritual_slot])

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_eclipse.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_eclipse.dm
@@ -23,7 +23,8 @@
 	var/datum/faction/bloodcult/cult = find_active_faction_by_type(/datum/faction/bloodcult)
 	if (!cult)
 		return
-	sun.eclipse_manager.eclipse_start(cult.eclipse_window)
+	if (sun.eclipse == ECLIPSE_NOT_YET)
+		sun.eclipse_manager.eclipse_start(cult.eclipse_window)
 
 /proc/eclipse_trigger_random()
 	if (!sun || !sun.eclipse_manager)

--- a/code/datums/gamemode/factions/legacy_cult/narsie.dm
+++ b/code/datums/gamemode/factions/legacy_cult/narsie.dm
@@ -26,11 +26,13 @@ var/global/list/narsie_list = list()
 /obj/machinery/singularity/narsie/New()
 	..()
 	narsie_list.Add(src)
-	power_machines.Remove(src)//Don't want Nar-Sie hungering for singularity beacons
 
 /obj/machinery/singularity/narsie/Destroy()
 	narsie_list.Remove(src)
 	..()
+
+/obj/machinery/singularity/narsie/seeks_beacon()
+	return FALSE//Don't want Nar-Sie hungering for singularity beacons
 
 /obj/machinery/singularity/narsie/large
 	name = "Nar-Sie"

--- a/code/datums/gamemode/role/cultist.dm
+++ b/code/datums/gamemode/role/cultist.dm
@@ -582,6 +582,10 @@
 		to_chat(user, "<span class='warning'>You do not have enough space to write a proper rune.</span>")
 		return
 
+	if(istype(user.loc, /turf/space))
+		to_chat(user, "<span class='warning'>Get over a solid surface first!</span>")
+		return
+
 	var/turf/T = get_turf(user)
 	var/obj/effect/rune/rune = locate() in T
 

--- a/code/game/machinery/singularity_beacon.dm
+++ b/code/game/machinery/singularity_beacon.dm
@@ -57,7 +57,7 @@
 			visible_message("<span class='warning'>\The [src] suddenly springs to life, only to shut down halfway through startup.</span>")
 		return
 	for(var/obj/machinery/singularity/singulo in power_machines)
-		if(singulo.z == z)
+		if(singulo.seeks_beacon() && (singulo.z == z))
 			singulo.target = src
 	icon_state = "[icontype]1"
 	active = 1

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -93,6 +93,9 @@ var/list/obj/machinery/singularity/white_hole_candidates
 		color= initial(color)
 	..()
 
+/obj/machinery/singularity/proc/seeks_beacon()
+	return TRUE
+
 /obj/machinery/singularity/proc/link_a_wormhole()
 	var/obj/machinery/singularity/other = null
 	do

--- a/code/modules/spells/aoe_turf/conjure/construct.dm
+++ b/code/modules/spells/aoe_turf/conjure/construct.dm
@@ -481,6 +481,9 @@
 	if (rune)
 		to_chat(user,"<span class='warning'>You cannot draw on top of an already existing rune.</span>")
 		return 1
+	if(istype(T, /turf/space))
+		to_chat(user, "<span class='warning'>Get over a solid surface first!</span>")
+		return 1
 	return 0
 
 /spell/aoe_turf/conjure/path_entrance/on_creation(var/obj/effect/rune/R, var/mob/user)
@@ -520,6 +523,9 @@
 	var/obj/effect/rune/rune = locate() in T
 	if (rune)
 		to_chat(user,"<span class='warning'>You cannot draw on top of an already existing rune.</span>")
+		return 1
+	if(istype(T, /turf/space))
+		to_chat(user, "<span class='warning'>Get over a solid surface first!</span>")
 		return 1
 	return 0
 


### PR DESCRIPTION
Fixes #36780

backend:
* Admins can now check the estimated Eclipse timer from the Check Antagonists panel
![image](https://github.com/vgstation-coders/vgstation13/assets/7573912/9dc4bfdc-54e7-44b1-871c-51dc07318904)

:cl:
* bugfix: Fixed Nar-Sie being braindead
* bugfix: Using a Cult Pamphlet after a random Eclipse has already started, or is already over, properly updates the Cult's stage.
* bugfix: Fixed cult runes being writable directly on top of space tiles.