### PR TITLE
Adds Client Version to Bug Report

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1233,8 +1233,8 @@ Use this proc preferably at the end of an equipment loadout
 	set name = "Github Report"
 	set category = "OOC"
 	var/dat = {"	<title>/vg/station Github Ingame Reporting</title>
-					Revision: [return_revision()]
-					<iframe src='http://ss13.moe/issues/?ckey=[ckey(key)]&address=[world.internet_address]:[world.port]&revision=[return_revision()]' style='border:none' width='480' height='480' scroll=no></iframe>"}
+					Version: [byond_version].[byond_build] Revision: [return_revision()]
+					<iframe src='http://ss13.moe/issues/?ckey=[ckey(key)]&address=[world.internet_address]:[world.port]&byondver=[byond_version].[byond_build]&revision=[return_revision()]' style='border:none' width='480' height='480' scroll=no></iframe>"}
 	src << browse(dat, "window=github;size=480x480")
 
 /client/verb/changes()


### PR DESCRIPTION
## What this does
This adds an explicit byond client version + build in bug reports. It won't have any effect until @d3athrow adjusts some web server code to have this version number appear in the reports automatically.

## Why it's good
Better chance of figuring out if a reported bug is caused by a specific client version.

## How it was tested
Technically not fully tested due to needing web server changes, but the data should be passed correctly.
![image](https://github.com/vgstation-coders/vgstation13/assets/69739118/8a6b9329-97c4-45f8-9d7a-b085d8c8563f)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Bug reports now show byond client version and build.
