### PR TITLE
cow and goat milking tweak

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -93,7 +93,7 @@
 		if(istype(O, /obj/item/weapon/reagent_containers/glass))
 			user.visible_message("<span class='notice'>[user] milks [src] using \the [O].</span>")
 			var/obj/item/weapon/reagent_containers/glass/G = O
-			var/transfered = udder.trans_id_to(G, MILK, rand(5,10))
+			var/transfered = udder.trans_id_to(G, MILK, rand(15,25))
 			if(G.reagents.total_volume >= G.volume)
 				to_chat(user, "<span class='warning'>[O] is full.</span>")
 			if(!transfered)
@@ -149,7 +149,7 @@
 	if(stat == CONSCIOUS && istype(O, /obj/item/weapon/reagent_containers/glass))
 		user.visible_message("<span class='notice'>[user] milks [src] using \the [O].</span>")
 		var/obj/item/weapon/reagent_containers/glass/G = O
-		var/transfered = reagents.trans_id_to(G, milktype, rand(5,10))
+		var/transfered = reagents.trans_id_to(G, milktype, rand(15,25))
 		if(G.reagents.total_volume >= G.volume)
 			to_chat(user, "<span class='warning'>[O] is full.</span>")
 		if(!transfered)


### PR DESCRIPTION
## What this does
Increases the amount of milk milked from a cow/goat per attempt.
## Why it's good
Been messing with the choco cows for a couple rounds and they feel really cumbersome to milk, you genuinely have to click like 30 times for a bucketful, and each milking event is limited by the attack delay, so you cannot milk faster than once per second, raising the volume transferred a bit for QoL seems fair.
## How it was tested
Wasn't, but it's just a small numbers tweak.
:cl:
 * tweak: Cow and goat milking should be slightly faster now.