### PR TITLE
Fixed an important wizard bug plus a few other things

### DIFF
--- a/code/_onclick/hud/spell_screen_objects.dm
+++ b/code/_onclick/hud/spell_screen_objects.dm
@@ -90,19 +90,16 @@
 	if(!spell)
 		return
 
+	if(spell.spell_flags & NO_BUTTON) //no button to add if we don't get one
+		return
 	if(spell.connected_button) //we have one already, for some reason
 		if(spell.connected_button in spell_objects)
 			return
-		else //Bring it to the new spellmaster!
-			if(spell.connected_button.spellmaster)
-				spell.connected_button.spellmaster.spell_objects.Remove(spell.connected_button)
+		else
 			spell_objects.Add(spell.connected_button)
-			spell.connected_button.spellmaster = src
 			toggle_open(2)
 			return
 
-	if(spell.spell_flags & NO_BUTTON) //no button to add if we don't get one
-		return
 	var/obj/abstract/screen/spell/newscreen = new /obj/abstract/screen/spell
 	newscreen.spellmaster = src
 	newscreen.spell = spell

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -87,9 +87,10 @@
 	var/mob/living/carbon/human/H = antag.current
 	var/has_nothing = TRUE //No spells, no potions, no artifacts
 
+	//Includes one-use spellbooks and the big spellbook
 	if(spells_from_spellbook.len)
-		has_nothing = FALSE
 		. += "<BR>[has_nothing ? "T" : "Additionally, t"]he wizard learned:<BR>"
+		has_nothing = FALSE
 		for(var/spell/S in spells_from_spellbook)
 			var/icon/tempimage
 			if(S.override_icon != "")
@@ -114,15 +115,17 @@
 	var/list/dummy_list = H.spell_list - (spells_from_spellbook + spells_from_absorb)
 	if(dummy_list.len)
 		var/has_an_uncategorized_wizard_spell = FALSE
-		for(var/spell/S in H.spell_list)
+		for(var/spell/S in dummy_list)
 			if(S.is_wizard_spell())
 				has_an_uncategorized_wizard_spell = TRUE
-				has_nothing = FALSE
 				break
 		if(has_an_uncategorized_wizard_spell)
 			//This implies adminbus or other shenanigans that could grant wizard spells
 			. += "<BR>[has_nothing ? "T" : "Additionally, t"]he wizard somehow knew, through divine help or other means:<BR>"
+			has_nothing = FALSE
 			for(var/spell/S in dummy_list)
+				if(!S.is_wizard_spell())
+					continue
 				var/icon/tempimage
 				if(S.override_icon != "")
 					tempimage = icon(S.override_icon, S.hud_state)
@@ -132,11 +135,15 @@
 
 	//Artifacts and potions, if the wizard bought any
 	if(artifacts_bought.len || potions_bought.len)
+		. += "<BR>[has_nothing ? "T" : "Additionally, t"]he wizard bought:<BR>"
 		has_nothing = FALSE
-		. += "<BR>[has_nothing ? "T" : "Additionally, t"]he wizard brought:<BR>"
 		for(var/entry in artifacts_bought)
 			. += "[entry]<BR>"
 		for(var/entry in potions_bought)
 			. += "[entry]<BR>"
 	if(has_nothing)
 		. += "The wizard used only the magic of charisma this round."
+
+//Mostly handled in the scoreboard
+/datum/role/wizard/GetBought()
+	return ""

--- a/code/datums/gamemode/role/wizard_apprentice.dm
+++ b/code/datums/gamemode/role/wizard_apprentice.dm
@@ -82,3 +82,7 @@
 	//Zero wizard spells known at all, could have been absorbed by someone else
 	if(!has_wizard_spell)
 		. += "The [apprentice_type] apprentice somehow forgot everything he learned in magic school."
+
+//Handled in GetScoreboard()
+/datum/role/wizard_apprentice/GetBought()
+	return ""

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -138,6 +138,7 @@
 
 	if (hasFactionsWithHUDIcons())
 		update_faction_icons()
+	INVOKE_EVENT(src, /event/after_mind_transfer, "mind" = src)
 
 /datum/mind/proc/store_memory(new_text, var/forced)
 	if(!forced)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -214,6 +214,7 @@
 			charges++
 			update_icon()
 			S.icon_state = "soulstone"
+			S.shade = null
 			qdel(sacrifice)
 	else
 		..()

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -265,6 +265,11 @@
 		var/mob/living/carbon/human/H = new /mob/living/carbon/human/lich(src)
 		H.real_name = original.real_name
 		H.flavor_text = original.flavor_text
+		//So that non-wizards can enjoy the spells.
+		//Wizards are already doing their own transfer_spell and doing that while the mob is mindless leads to bugs
+		if((!iswizard(original) && !isapprentice(original)))
+			for(var/spell/S in original.mind.wizard_spells)
+				transfer_spell(H, original, S)
 		//Let's give the lich some spooky clothes. Including non-wizards.
 		H.equip_to_slot_or_del(new /obj/item/clothing/head/wizard/skelelich(H), slot_head)
 		H.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe/skelelich(H), slot_wear_suit)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -213,6 +213,7 @@
 			S.name = initial(S.name)
 			charges++
 			update_icon()
+			S.icon_state = "soulstone"
 			qdel(sacrifice)
 	else
 		..()
@@ -263,8 +264,6 @@
 		var/mob/living/carbon/human/H = new /mob/living/carbon/human/lich(src)
 		H.real_name = original.real_name
 		H.flavor_text = original.flavor_text
-		for(var/spell/S in original.mind.wizard_spells)
-			transfer_spell(H, original, S)
 		//Let's give the lich some spooky clothes. Including non-wizards.
 		H.equip_to_slot_or_del(new /obj/item/clothing/head/wizard/skelelich(H), slot_head)
 		H.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe/skelelich(H), slot_wear_suit)

--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -325,7 +325,7 @@
 /datum/spellbook_artifact/phylactery
 	name = "phylactery"
 	desc = "Creates a soulbinding artifact that, upon the death of the user, resurrects them as best it can. You must bind yourself to this through making an incision on your palm, holding the phylactery in that hand, and squeezing it."
-	spawned_items = list(/obj/item/phylactery, /obj/item/clothing/head/wizard/lich, /obj/item/clothing/suit/wizrobe/lich, /obj/item/soulstone)
+	spawned_items = list(/obj/item/clothing/head/wizard/lich, /obj/item/clothing/suit/wizrobe/lich, /obj/item/soulstone, /obj/item/phylactery)
 
 
 /datum/spellbook_artifact/darkness

--- a/code/game/gamemodes/wizard/spellbook_oneuse.dm
+++ b/code/game/gamemodes/wizard/spellbook_oneuse.dm
@@ -35,11 +35,9 @@
 		var/datum/role/wizard/W = user.mind.GetRole(WIZARD)
 		if(istype(W))
 			W.spells_from_spellbook += S
-			W.spells_from_absorb += S
 		var/datum/role/wizard_apprentice/WA = user.mind.GetRole(WIZAPP)
 		if(istype(WA))
 			WA.spells_from_spellbook += S
-			WA.spells_from_absorb += S
 		to_chat(user, "<span class='notice'>you rapidly read through the arcane book. Suddenly you realize you understand [spellname]!</span>")
 		user.attack_log += text("\[[time_stamp()]\] <font color='orange'>[user.real_name] ([user.ckey]) learned the spell [spellname] ([S]).</font>")
 		onlearned(user)

--- a/code/modules/mob/spells.dm
+++ b/code/modules/mob/spells.dm
@@ -87,4 +87,4 @@
 		return
 	old_character.remove_spell(spell_to_transfer, on_removed = FALSE)
 	new_character.add_spell(spell_to_transfer, on_added = FALSE)
-	spell_to_transfer.on_transfer()
+	spell_to_transfer.on_transfer(new_character)

--- a/code/modules/mob/spells.dm
+++ b/code/modules/mob/spells.dm
@@ -58,10 +58,17 @@
 	if(!spell_masters || !spell_masters.len)
 		return
 
-	var/obj/abstract/screen/movable/spell_master/master = spell_to_remove.connected_button.spellmaster
-	if(!(master in spell_masters))
-		return
-	master.remove_spell(spell_to_remove)
+	var/obj/abstract/screen/movable/spell_master/master
+	//Runtime prevention!
+	//Some spells, such as No Gun Allowed, may not have associated spellmaster buttons, which would break things
+	//Instead, check to see if it even has a button to remove
+	if(spell_to_remove.connected_button)
+		if(spell_to_remove.connected_button.spellmaster)
+			master = spell_to_remove.connected_button.spellmaster
+	if(master)
+		if(!(master in spell_masters))
+			return
+		master.remove_spell(spell_to_remove)
 
 	if(mind && mind.wizard_spells)
 		mind.wizard_spells.Remove(spell_to_remove)

--- a/code/modules/spells/passive/no_gun_allowed.dm
+++ b/code/modules/spells/passive/no_gun_allowed.dm
@@ -10,5 +10,8 @@
 /spell/passive/nogunallowed/on_added(mob/user)
 	user.flags |= HONORABLE_NOGUNALLOWED
 
+/spell/passive/nogunallowed/on_removed(mob/user)
+	user.flags &= HONORABLE_NOGUNALLOWED
+
 /spell/passive/nogunallowed/on_transfer(mob/user)
 	user.flags |= HONORABLE_NOGUNALLOWED

--- a/code/modules/spells/targeted/absorb.dm
+++ b/code/modules/spells/targeted/absorb.dm
@@ -100,11 +100,9 @@
 	//Handle the attacker
 	var/datum/role/wizard/absorber_W = absorbed.mind.GetRole(WIZARD)
 	if(istype(absorber_W))
-		absorber_W.spells_from_spellbook += S
 		absorber_W.spells_from_absorb += S
 	var/datum/role/wizard_apprentice/absorber_WA = absorbed.mind.GetRole(WIZAPP)
 	if(istype(absorber_WA))
-		absorber_WA.spells_from_spellbook += S
 		absorber_WA.spells_from_absorb += S
 
 /obj/effect/absorb_effect


### PR DESCRIPTION
Also cleaned up a few redundant things
The culprit of the missing spells appears to have been transfer_spells getting called twice if the user was a wizard, which would cause the attached spells to be sent to a mob with no mind (as the transfer happened before) and the spells would not be getting added to the mind's actual list of spells because the user's mind wasn't there yet, and once a second transfer would happen the spells would be lost since "technically" the mind's wizard_spells list was empty.

:cl:
 * bugfix: Fixed a bug where reviving at least twice with the phylactery would completely wipe out the lich's list of spells.
 * bugfix: Fixed a runtime caused by an attempt to find a spell's button in the spell menu when it didn't have any (such as the No Gun Allowed spell)
 * bugfix: A soulstone that is used to fuel a phylactery will now properly change to its inert icon. It will also no longer allow the user for a brief period of time to summon the shade it just used on the phylactery, which did nothing.
 * bugfix: Fixed a bug where certain elements for the No Gun Allowed, Bind Object and Magical Wardrobe spells were not being properly transferred due to a missing "user" variable.
 * bugfix: No Gun Allowed will now properly allow someone to fire a weapon again when removed.
 * bugfix: Fixed a bug where the wizard and wizard's apprentice scoreboards would show spells learned from spellbooks as being absorbed.
 * bugfix: Should fix an error with the wizard and wizard's apprentice scoreboard where spells would show up at least twice, and generally improved them a little.
 * tweak: Adjusted the phylactery set's spawns so that the phylactery itself is more likely to appear above the necromancer clothes instead of under them.