### PR TITLE
Disables being able to pull people with blood magnetize while they are handcuffed.

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -2513,7 +2513,13 @@ var/list/seer_rituals = list()
 						new /obj/effect/bloodcult_jaunt(get_turf(L),L,pick(valid_turfs))
 						flick("cult_jaunt_land",landing_animation)
 		else
-			if(target.locked_to || !isturf(target.loc))
+			var/mob/living/carbon/carbonTarget = target
+			// Suggestion: make some sort of flag on an object preventing blood magnetism pulls instead of hardcoding a check here.
+			if(istype(carbonTarget) && carbonTarget.handcuffed)
+				to_chat(target, "<span class='warning'>You feel a tug from some force in the veil wanting to whisk you away... but your handcuffs anchor you into the mortal plane!</span>")
+				for(var/mob/living/L in contributors)
+					to_chat(activator, "<span class='warning'>The ritual failed, the target is being weighed down by some kind of device.</span>")
+			else if(target.locked_to || !isturf(target.loc))
 				to_chat(target, "<span class='warning'>You feel that some force wants to pull you through the veil, but cannot proceed while you are buckled or inside something.</span>")
 				for(var/mob/living/L in contributors)
 					to_chat(activator, "<span class='warning'>The ritual failed, the target seems to be anchored to where they are.</span>")


### PR DESCRIPTION
As the title says. It only disables pulling someone while they are cuffed, you can rejoin someone who is cuffed.

Note: I coded this in like 5-10 minutes, it just checks whether the mob/living/carbon.handcuffed is true, not sure if that will have other ramifications with other types of handcuffs or whatever. Will leave it open to discussion if they should be real cuffs only and other balance suggestions.

:cl:
 * tweak: Pulling someone with blood magnetize no longer works while they are cuffed.