### PR TITLE
Knocking off an APC's cover will now properly unexpose the wires.

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -679,6 +679,7 @@
 			user.delayNextAttack(8)
 			if (prob(20))
 				opened = 2
+				wiresexposed = 0 //The cover is gone
 				user.visible_message("<span class='warning'>The APC cover was knocked down with the [W.name] by [user.name]!</span>", \
 					"<span class='warning'>You knock down the APC cover with your [W.name]!</span>", \
 					"You hear something metallic being hit, and falling on the floor.")


### PR DESCRIPTION
Because this led to shunted malfunctioning AIs being invincible if the wires were exposed and then the cover got knocked off. This happened TWICE and the AI won once because of that.

:cl:
 * bugfix: APCs with their covers knocked off will now properly unexpose the wires.