### PR TITLE
Regular AME tanks can refuel with radiation + Antimatter Decelerator buff.

### DIFF
--- a/code/modules/power/antimatter/containment_jar.dm
+++ b/code/modules/power/antimatter/containment_jar.dm
@@ -1,6 +1,7 @@
+var/list/decelerators = list()
 /obj/item/weapon/am_containment
 	name = "antimatter containment jar"
-	desc = "Holds antimatter. A few of these could blow an entire 21st-century lunar installation."
+	desc = "Holds antimatter. A few of these could blow an entire 21st-century lunar installation. Can be refueled if exposed to radiation."
 	icon = 'icons/obj/machines/new_ame.dmi'
 	icon_state = "jar"
 	item_state = "am_jar"
@@ -20,7 +21,13 @@
 
 /obj/item/weapon/am_containment/New()
 	..()
+	decelerators += src
 	update_icon()
+
+	
+/obj/item/weapon/am_containment/Destroy()
+	decelerators -= src
+	..()
 
 /obj/item/weapon/am_containment/update_icon()
 	overlays.len = 0
@@ -72,3 +79,6 @@
 	fuel = 30000
 	fuel_max = 30000
 	gauge_offset = 6
+
+/obj/item/weapon/am_containment/proc/receive_pulse(power)
+	fuel = min(fuel_max, fuel + round(power/25))

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -138,7 +138,7 @@ var/global/list/rad_collectors = list()
 	for(var/obj/machinery/power/rad_collector/R in rad_collectors)
 		if(get_dist(R, center) <= range) //Better than using orange() every process.
 			R.receive_pulse(power)
-	for(var/obj/item/weapon/am_containment/decelerator/D in decelerators)
+	for(var/obj/item/weapon/am_containment/D in decelerators)
 		if(get_dist(D, center) <= range)
 			D.receive_pulse(power)
 

--- a/code/modules/trader/crates/cloudnine.dm
+++ b/code/modules/trader/crates/cloudnine.dm
@@ -158,21 +158,16 @@ var/global/list/cloudnine_stuff = list(
 		return ..()
 	return FALSE
 
-var/list/decelerators = list()
 /obj/item/weapon/am_containment/decelerator
 	name = "antimatter decelerator"
-	desc = "Acts as a 'filter' to trap antiparticles emitted by radiation. In function, it can be used to power an antimatter engine and refuel itself with nearby radiation."
+	desc = "A large experimental antimatter tank that refuels 25x faster than its regular counterparts."
+	icon_state = "jar_big"
+	fuel = 10000
+	fuel_max = 10000
+	gauge_offset = 2
 
-/obj/item/weapon/am_containment/decelerator/New()
-	..()
-	decelerators += src
-
-/obj/item/weapon/am_containment/decelerator/Destroy()
-	decelerators -= src
-	..()
-
-/obj/item/weapon/am_containment/decelerator/proc/receive_pulse(power)
-	fuel = min(fuel_max, fuel + round(power/100))
+/obj/item/weapon/am_containment/decelerator/receive_pulse(power)
+	fuel = min(fuel_max, fuel + round(power))
 
 #define OMNIMODE_WIRE 0
 #define OMNIMODE_TOOL 1


### PR DESCRIPTION
## What this does
The AME tanks will now be able to refuel with radiation. To compensate for losing the uniqueness of the decelerator, the decelerators refuel 25x as fast and have 10000 fuel (from 1000).
The radiation refueling proc takes the distance from the rad source into consideration, so both will still refuel somewhat slowly unless you have them right next or under the radiation source (like the shard, for example).
## Why it's good
The refueling with rads mechanic is good but it is not seen that often 'cause it requires a trader to stock the decelerator, plus I like the idea of more synergistic engines where the SM keeps the fuckhuge AME alive.
## How it was tested
Spawned a regular tank and a decelerator, VV'd them to 0 fuel, placed an uranium tile, walked over it holding both tanks a couple times, they both refueled and the decelerator refueled faster.
Spawned an SM crystal, placed the two tanks next to it and threw a wrench at the crystal. Both tanks had refueled properly.

:cl:
 * rscadd: Regular antimatter tanks can now be refueled at a decent rate by exposing them to radiation.
 * tweak: Antimatter Decelerator tanks (the trader one) will refuel 25x faster than the regular tank and can hold 10x the fuel (10000).