### PR TITLE
Cyber horrors inject their cyber juices

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -50,6 +50,7 @@
 	if(check_shields(0, M))
 		return 0
 	M.unarmed_attack_mob(src)
+	return 1
 
 /mob/living/carbon/relaymove(var/mob/user, direction)
 	if(user in src.stomach_contents)

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -310,6 +310,7 @@
 
 /mob/living/carbon/slime/attack_animal(mob/living/simple_animal/M)
 	M.unarmed_attack_mob(src)
+	return 1
 
 /mob/living/carbon/slime/attack_paw(mob/living/carbon/monkey/M)
 	if(!(istype(M, /mob/living/carbon/monkey)))

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -296,7 +296,7 @@ var/static/list/ai_icon_states = list(
 		"Xerxes" = "ai-xerxes",
 		"Yes Man" = "yes-man",
 	)
-	
+
 /mob/living/silicon/ai/verb/pick_icon()
 	set category = "AI Commands"
 	set name = "Set AI Core Display"
@@ -579,6 +579,7 @@ var/static/list/ai_icon_states = list(
 
 /mob/living/silicon/ai/attack_animal(mob/living/simple_animal/M as mob)
 	M.unarmed_attack_mob(src)
+	return 1
 
 /mob/living/silicon/ai/reset_view(atom/A)
 	if(camera_light_on)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -945,6 +945,7 @@
 
 /mob/living/silicon/robot/attack_animal(mob/living/simple_animal/M)
 	M.unarmed_attack_mob(src)
+	return 1
 
 /mob/living/silicon/robot/attack_hand(mob/living/user)
 	add_fingerprint(user)

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -248,6 +248,7 @@
 		update_icons()
 	else
 		M.unarmed_attack_mob(src)
+		return 1
 
 /mob/living/simple_animal/construct/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	user.delayNextAttack(8)

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -152,7 +152,7 @@
 		user.forceMove(src)
 		src.update_icon()
 	else
-		..()
+		return ..()
 
 /mob/living/simple_animal/spiderbot/proc/transfer_personality(var/obj/item/device/mmi/M as obj)
 	src.mind = M.brainmob.mind

--- a/code/modules/mob/living/simple_animal/hostile/monster.dm
+++ b/code/modules/mob/living/simple_animal/hostile/monster.dm
@@ -80,9 +80,9 @@
 /mob/living/simple_animal/hostile/monster/cyber_horror/UnarmedAttack(atom/A)
 	if(ismob(A))
 		delayNextAttack(10)
-	if(A.attack_animal(src)) //Returns 0 if blocked
+	if(A.attack_animal(src)) //Returns 0 if blocked, returns 1 if the attack went through
 		var/mob/living/L = A
-		if(L.reagents)
+		if(istype(L) && L.reagents)
 			if(prob(nanobot_chance))
 				visible_message("<b><span class='warning'>[src] injects something into [L]!</span>")
 				L.reagents.add_reagent(MEDNANOBOTS, 2)

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -82,7 +82,7 @@
 			M.LevelUp(level_gain)
 		M.health = M.maxHealth
 		qdel(src)
-		return
+		return 1
 	..()
 
 /mob/living/simple_animal/hostile/mushroom/revive(refreshbutcher = 1)

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -343,7 +343,7 @@
 
 //Simple animals
 /mob/living/simple_animal/parrot/attack_animal(mob/living/simple_animal/M as mob)
-	..() //goodbye immortal parrots
+	. = ..() //goodbye immortal parrots
 
 	if(client)
 		return

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -444,6 +444,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 
 /mob/living/simple_animal/attack_animal(mob/living/simple_animal/M)
 	M.unarmed_attack_mob(src)
+	return 1
 
 /mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj)


### PR DESCRIPTION
## What this does
Fixes two bugs and fixes #36772 .
I accidentally caused cyber horrors to not inject at all for roughly 4 months because just about every use case of attack_animal doesn't return anything. This is fixed by making mob attack_animal() cases return 1.
The other bug was a potential runtime when trying to inject into something that was not mob/living. There wasn't a check for whether the target is mob/living, now there is.
## Why it's good
It's not. This is absolutely terrible for the game. Bugfixes are bad.
## How it was tested
Spawned 10 cyber horrors in a room and then spawned 1 human. Checked the human's reagents and the human had medical nanobots.

## Changelog
:cl:
 * bugfix: Fixed a 4-months-old bug where cyber horrors couldn't inject medical nanobots.