### PR TITLE
Critical bugfix for slimes

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -97,6 +97,11 @@
 
 	power = I.modify_attack_power(power, M, user) //Apply any special modifiers to the power here.
 
+	var/is_crit = I.on_attack(M,user)
+	if (is_crit == CRITICAL_HIT)
+		power *= CRIT_MULTIPLIER
+
+
 	if(!(ishuman(M) || ismonkey(M)))
 		if(istype(M, /mob/living/carbon/slime))
 			var/mob/living/carbon/slime/slime = M
@@ -208,9 +213,6 @@
 						to_chat(user, "<span class='warning'>You attack [M] with [I]!</span>")
 				else
 					to_chat(user, "<span class='warning'>You attack [M] with [I]!</span>")
-	var/is_crit = I.on_attack(M,user)
-	if (is_crit == CRITICAL_HIT)
-		power *= CRIT_MULTIPLIER
 
 	if(istype(M, /mob/living/carbon))
 		var/mob/living/carbon/C = M


### PR DESCRIPTION
## What this does
Fixes critical hits so that they are taken into consideration when smacking slimes away.

## Why it's good
No.

## How it was tested
Repeatedly hit slimes after setting the server to April Fools Day, critical hits always batted them away.

## Changelog
:cl:
 * bugfix: Fixed a critical bug with slimes so that critical hits will now affect how likely they are to be pushed away when hit.