### PR TITLE
Slime code clean-up

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -103,70 +103,8 @@
 			if(prob(25))
 				to_chat(user, "<span class='warning'>[I] passes right through [M]!</span>")
 				return 0
-
-			if(power > 0)
-				slime.attacked += 10
-
-			if(slime.Discipline && prob(50))	// wow, buddy, why am I getting attacked??
-				slime.Discipline = 0
-
-			if(power >= 3)
-				if(slime.slime_lifestage == SLIME_ADULT)
-					if(prob(5 + round(power/2)))
-
-						if(slime.Victim)
-							if(prob(80) && !slime.client)
-								slime.Discipline++
-						slime.Victim = null
-						slime.anchored = 0
-
-						spawn()
-							if(slime)
-								slime.SStun = 1
-								sleep(rand(5,20))
-								if(slime)
-									slime.SStun = 0
-
-						spawn(0)
-							if(slime)
-								slime.canmove = 0
-								step_away(slime, user)
-								if(prob(25 + power))
-									sleep(2)
-									if(slime && user)
-										step_away(slime, user)
-								slime.canmove = 1
-
-				else
-					if(prob(10 + power*2))
-						if(slime)
-							if(slime.Victim)
-								if(prob(80) && !slime.client)
-									slime.Discipline++
-
-									if(slime.Discipline == 1)
-										slime.attacked = 0
-
-								spawn()
-									if(slime)
-										slime.SStun = 1
-										sleep(rand(5,20))
-										if(slime)
-											slime.SStun = 0
-
-							slime.Victim = null
-							slime.anchored = 0
-
-
-						spawn(0)
-							if(slime && user)
-								step_away(slime, user)
-								slime.canmove = 0
-								if(prob(25 + power*4))
-									sleep(2)
-									if(slime && user)
-										step_away(slime, user)
-								slime.canmove = 1
+			//Handles pushing slimes off of targets, making them hostile from being attacked etc.
+			slime.slime_item_attacked(src, user, power) //The code has been moved to code/modules/mob/living/carbon/slime/slime.dm
 
 		var/showname = ""
 		if(user)

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -1028,6 +1028,40 @@
 /mob/living/carbon/slime/ApplySlip(var/obj/effect/overlay/puddle/P)
 	return FALSE
 
+//This was previously added directly in item_attack.dm in handle_attack()
+//Now it's its own proc that gets called there, freeing up roughly 61 lines of code
+/mob/living/carbon/slime/proc/slime_item_attacked(var/obj/item/I, var/mob/living/user, var/force)
+	if(force > 0)
+		attacked += 10
+
+	if(Discipline && prob(50))	// wow, buddy, why am I getting attacked??
+		Discipline = 0
+
+	if(force >= 3)
+		var/probability = isslimeadult(src) ? (prob(5 + round(force/2))) : (prob(10 + force*2))
+		if(probability) //We basically roll the check already in the above variable, to save up on copypaste by not having two separate rolls
+			if(Victim) //Can only be disciplined if they are currently attacking someone
+				if(prob(80) && !client)
+					Discipline++
+					attacked = !isslimeadult(src) //Adult slimes will not stop attacking, since discipline doesn't affect them.
+			Victim = null
+			anchored = 0
+			spawn()
+				if(src)
+					SStun = 1
+					sleep(rand(5,20))
+					if(src)
+						SStun = 0
+			spawn(0)
+				if(src)
+					canmove = 0
+					step_away(src, user)
+					if(prob(25 + force * (isslimeadult(src) ? 1 : 4)))
+						sleep(2)
+						if(src && user)
+							step_away(src, user)
+					canmove = 1
+
 //////////////////////////////Old shit from metroids/RoRos, and the old cores, would not take much work to re-add them////////////////////////
 
 /*


### PR DESCRIPTION
## What this does
Cleans up the item_attack.dm's dreaded 61-line slime code and moves it to the slime.dm file, while shortening it to 29 lines of code.

## Why it's good
I am gatekeeping people out of finding out why this is good. They can find out why this is good themselves.

## How it was tested
Attacked a slime in-game.

## Changelog
:cl:
 * bugfix: Cleaned a section of the game's code where item attacks against slimes were defined. It should now be easier for future coders to read the piece of code where it used to be.