### PR TITLE
Cleans up trailing line of code

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -245,7 +245,6 @@
 		take_damage(min(power, BREAKARMOR_MEDIUM), skip_break = TRUE, mute = FALSE) //Cap recoil damage at BREAKARMOR_MEDIUM to avoid a powerful weapon also needing really strong armor to avoid breaking apart when used. Be verbose about the item being damaged if applicable.
 		try_break(hit_atom = M) //Break the item and spill any reagents onto the target.
 
-		. = TRUE //The attack always lands
 		M.updatehealth()
 	I.add_fingerprint(user)
 


### PR DESCRIPTION
## What this does
Erases an unnecessary line of code from item_attack.dm

## Why it's good
One line less of code that didn't do anything.

## How it was tested
The server tested it over the course of months during which it was accidentally moved from near the end of the proc to under breakable items code when the respective pull requests were made and literally nothing happened. The ". = TRUE" is redundant and was marked as redundant by other people back when it was added years ago, and on top of that only two items check for handle_attack()'s output and in a context where the line of code does not kick in (condiments and pills have their own attack procs that don't call handle_attack()).

## Changelog
:cl:
 * bugfix: Removed a redundant line of code in item attacking code that did not do anything.