### PR TITLE
Attacking non-carbons with burn melee damage will no longer spam "Aargh it burns!" over and over again

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -238,7 +238,6 @@
 						var/mob/living/carbon/monkey/K = M
 						power = K.defense(power,def_zone)
 					M.take_organ_damage(0, power)
-					to_chat(M, "Aargh it burns!")
 
 	//Break the item if applicable.
 	if(power && (I.breakable_flags & BREAKABLE_AS_MELEE) && (I.breakable_flags & BREAKABLE_MOB) && (I.damtype == BRUTE))


### PR DESCRIPTION
## What this does
When attacking non-carbons with an item they ALWAYS get a message with every single hit that says "Aargh it burns!". This is notable with items such as the scrying orb considering how rare melee burn damage is, and this affected silicons. This PR removes the message.

## Why it's good
Less unnecessary spam. Silicons can rejoice now.

## How it was tested
Attacked self as a syndicate blitz cyborg with the Heat Axe. No message.

## Changelog
:cl:
 * rscdel: Creatures and silicons that are attacked by burn-causing melee weapons such as the scrying orb will no longer be spammed with "Aargh it burns!" in every attack.