### PR TITLE
Part 1 of removing unused monkey defense code when attacked with items

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -224,9 +224,6 @@
 				if(istype(src, /mob/living/carbon/slime))
 					M.adjustBrainLoss(power)
 				else
-					if(istype(M, /mob/living/carbon/monkey))
-						var/mob/living/carbon/monkey/K = M
-						power = K.defense(power,def_zone)
 					M.take_organ_damage(power)
 					if (prob(33) && I.force) // Added blood for whacking non-humans too
 						var/turf/location = M.loc
@@ -234,9 +231,6 @@
 							location:add_blood_floor(M)
 			if("fire")
 				if (!(M_RESIST_COLD in M.mutations))
-					if(istype(M, /mob/living/carbon/monkey))
-						var/mob/living/carbon/monkey/K = M
-						power = K.defense(power,def_zone)
 					M.take_organ_damage(0, power)
 					to_chat(M, "Aargh it burns!")
 


### PR DESCRIPTION
## What this does
Removes unused code for attacking monkeys, because the code never fired for monkeys. Monkeys being attacked by weapons is already handled mostly under carbon-related damage code as well as their own code

## Why it's good
Cleaner code.

## How it was tested
It did not need testing, because it is inside a check that excludes carbons, thus it would never fire.

## Changelog
:cl:
 * bugfix: Removed unused code regarding monkeys being attacked with items, and the monkeys already take damage through other systems.