### PR TITLE
Fixed a particular case of non-binary gender emoting showing the wrong text

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -118,6 +118,9 @@
 						message = replacetext(message, "they", "she")
 					if(findtext(message, "%s"))
 						message = replacetext(message, "%s", "s")
+				else //Plural or neuter
+					if(findtext(message, "%s"))
+						message = replacetext(message, "%s", "")
 	return message
 
 /datum/emote/proc/select_message_type(mob/user)


### PR DESCRIPTION

## What this does
Fixes it so that "plural" and "neuter" genders (or just any gender) will now properly remove the "%s" mark from any emote that contains it, but it is only the surrendering emote. This combined with #36802 should also fix cases where cyborg surrendering would say "they surrender%s!"
## Why it's good
It's just a tiny bugfix.
## How it was tested
Set in-game mob's gender to nothing, emoted the surrender emote
## Changelog
:cl:
 * bugfix: Surrendering via a character that wasn't male nor female should no longer say "they surrender%s!", and will now properly say "they surrender!".