### PR TITLE
Silicons now have a new surrender text

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -293,6 +293,7 @@ var/list/animals_with_wings = list(
 	key_third_person = "surrenders"
 	key_shorthand = "sur"
 	message = "puts their hands on their head and falls to the ground. They surrender%s!"
+	message_mobtype = list(/mob/living/silicon/robot = "powers down its systems and lies still. It surrenders!")
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/surrender/run_emote(mob/user, params)


### PR DESCRIPTION
## What this does
Replaces the usual surrender text with "powers down its systems and lies still. It surrenders!", because frankly robots can't really "put their hands on their head and fall to the ground", given the lack of real hands.

## Why it's good
It makes more sense for the robot to power down and lie still, since surrendering also stuns the user.
## How it was tested
Spawned as an in-game cyborg, surrendered, message appeared.
## Changelog
:cl:
 * rscadd: Robots now have an unique message when surrendering.