### PR TITLE
Fixed a number of slime emotes not being able to be emoted

### DIFF
--- a/code/modules/mob/living/carbon/slime/emote.dm
+++ b/code/modules/mob/living/carbon/slime/emote.dm
@@ -1,5 +1,5 @@
 /datum/emote/living/carbon/slime/
-	mob_type_allowed_typelist = list(/mob/living/carbon/monkey)
+	mob_type_allowed_typelist = list(/mob/living/carbon/slime)
 
 /datum/emote/living/carbon/slime/bounce
 	key = "bounce"


### PR DESCRIPTION
## What this does
Fixes a bug where slimes could not do about 4 of the emotes they were meant to be able to do. 
## Why it's good
It's a bugfix.
## How it was tested
Spawned 100 slimes and waited until they did all the emotes they are meant to automatically do at a low chance every tick.
## Changelog
:cl:
 * bugfix: Fixed a 7-year-old bug where slimes wouldn't do roughly 4 of the emotes they were meant to do once in a while because the emote system was checking to see if they were a monkey. They can now bounce, jiggle, light up for a bit and vibrate.