### PR TITLE
Fixed certain regular emotes showing up in observer chat

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -69,11 +69,19 @@
 
 	var/turf/T = get_turf(user) // for pAIs
 
-	for(var/mob/M in dead_mob_list)
-		if (!M.client)
-			continue //skip leavers
-		if(isobserver(M) && M.client.prefs && (M.client.prefs.toggles & CHAT_GHOSTSIGHT) && !(M in viewers(user)))
-			M.show_message(formatFollow(user) + " " + msg)
+
+	// Copypasted here because emote/me/run_emote() overrides the parent's run_emote() check and some things would call the "me" emote instead.
+	var/obs_pass = TRUE
+	// Don't hear simple mobs without a client.
+	if (istype(user, /mob/living/simple_animal) && !user.client)
+		obs_pass = FALSE
+
+	if(obs_pass)
+		for(var/mob/M in dead_mob_list)
+			if (!M.client)
+				continue //skip leavers
+			if(isobserver(M) && M.client.prefs && (M.client.prefs.toggles & CHAT_GHOSTSIGHT) && !(M in viewers(user)))
+				M.show_message(formatFollow(user) + " " + msg)
 
 	if(emote_type & EMOTE_VISIBLE)
 		user.visible_message(msg)


### PR DESCRIPTION
## What this does
Fixes the "me" emote so that it now properly filters messages for observers the same way emotes do, which means that animals that do custom "me" emotes will no longer spam observer chat.
## Why it's good
More in line with the functionality that it is meant to have.
## How it was tested
Waited as a ghost for a few minutes, no messages except from nearby mobs.
## Changelog
:cl:
 * bugfix: Fixed a bug where certain animal emotes would still show up in deadchat despite not being supposed to.