### PR TITLE
Sharpness through weapon blacksmithing now has a maximum value of 2.

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -885,7 +885,7 @@ a {
 		if(sharpness_flags && sharpness)
 			force = initial(force)*(material_type.sharpness_mod*(quality/B_AVERAGE))
 			throwforce = initial(throwforce)*(material_type.sharpness_mod*(quality/B_AVERAGE))
-			sharpness = initial(sharpness)*(material_type.sharpness_mod*(quality/B_AVERAGE))
+			sharpness = min(initial(sharpness)*(material_type.sharpness_mod*(quality/B_AVERAGE)), 2) //Don't let the sharpness get too crazy
 		else
 			force = initial(force)*(material_type.brunt_damage_mod*(quality/B_AVERAGE))
 			throwforce = initial(throwforce)*(material_type.brunt_damage_mod*(quality/B_AVERAGE))


### PR DESCRIPTION
## What this does
Puts a cap of 2 on the sharpness, because the sharpness values could get to ludicrous levels even if it didn't have much of a bearing on the gameplay.
## Why it's good
Less crazy weapons.
## How it was tested
It wasn't.
## Changelog
:cl:
 * tweak: There is now a limit of how sharp a weapon can become through blacksmithing.