### PR TITLE
Fixes a 7 year old bug regarding blunt limb gibbing

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -199,11 +199,11 @@
 					if(prob((5 * brute) * sharp)) //sharp things have a greater chance to sever based on how sharp they are
 						droplimb(1)
 						return
-				else if(!sharp && brute > 15) //Massive blunt damage can result in limb explosion
-					if(prob((brute/7.5)**3)) //15 dmg - 8% chance, 22 dmg - 27%, 30 dmg - 64%, anything higher than ~35 is a guaranteed limbgib
-						explode()
-						return
-				else if(brute > 20 && prob(2 * brute)) //non-sharp hits with force greater than 20 can cause limbs to sever, too (smaller chance)
+				//15 dmg - 8% chance, 22 dmg - 27%, 30 dmg - 64%, anything higher than ~35 is a guaranteed limbgib
+				else if((brute > 15) && prob((brute/7.5)**3)) //Massive blunt damage can result in limb explosion
+					explode()
+					return
+				else if((brute > 20) && prob(2 * brute)) //non-sharp hits with force greater than 20 can cause limbs to sever, too (smaller chance)
 					droplimb(1)
 					return
 


### PR DESCRIPTION
## What this does
Rewrites a check so that it now behaves properly; non-sharp weapons that hit for more than 20 damage will now have a chance to drop the limb from the sheer damage caused if it is broken, instead of gibbing it. This check runs after the check for gibbing it fails.
## Why it's good
Fixes a legacy bug.
## How it was tested
Beat up an in-game human using a melee weapon with 25 force.
## Changelog
:cl:
 * bugfix: Fixed a 7-year-old bug where non-sharp items with enough force did not have any chance of ripping off a limb as opposed to turning it into gibs. The check has now been fixed and now strong blunt melee weapons have a chance to rip off a broken limb instead of gibbing a broken limb.