### PR TITLE
Peg limbs can now be properly torn off from someone with less damaging force

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -196,7 +196,7 @@
 					return
 			else
 				if(sharp || is_peg())
-					if(prob((5 * brute) * sharp)) //sharp things have a greater chance to sever based on how sharp they are
+					if(prob((5 * brute) * (sharp ? sharp : 1))) //sharp things have a greater chance to sever based on how sharp they are
 						droplimb(1)
 						return
 				else if(!sharp && brute > 15) //Massive blunt damage can result in limb explosion


### PR DESCRIPTION
## What this does
Fixes a bug where a check for peg limbs taking damage never properly kicked in because it was sharing the same check as sharpness, but if sharpness was 0 then the peg limb could never be removed by non-sharp weapons despite being intended to. This fixes it.
## Why it's good
What? Can't find the reason why it's good on your own? Try a more casual pull request.
## How it was tested
Attacked a human with a peg limb with a toolbox until it came off.
## Changelog
:cl:
 * bugfix: Fixed a 7-year-old bug where peg limbs couldn't be properly removed by less damaging weapons.