### PR TITLE
Fixes grue eating breaking when trying to eat monkeys

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -659,7 +659,8 @@
 		var/mob/living/carbon/human/H = E
 		if(H.species.anatomy_flags & NO_BLOOD)
 			return 0
-	return 1
+		return 1
+	return 0
 
 /mob/living/simple_animal/hostile/grue/proc/grue_stat_updates(var/feed_verbose = FALSE) //update stats, called by lifestage_updates() as well as handle_feed()
 


### PR DESCRIPTION
## What this does
Fixes a bug where a few pieces of code happened when they shouldn't have, because skeletonizing code returned 1 even if the mob wasn't a human.
## Why it's good
It stops ruining grue rounds.
## How it was tested
Became a grue and then tried ate a monkey. No errors.
## Changelog
:cl:
 * bugfix: Fixed a bug where eating non-humanoid things such as monkeys or creatures as a grue would cause an error and completely prevent the grue from using most abilities.