### PR TITLE
Nerfs weak .38 stun and knockdown duration from 5->1 

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -37,13 +37,14 @@
 	name = "weak bullet"
 	icon_state = "bbshell"
 	damage = 10
-	stun = 3
+	stun = 1
 	weaken = 5
 	embed = 0
 	projectile_speed = 0.5
 
 /obj/item/projectile/bullet/weakbullet/booze
 	name = "booze bullet"
+	stun = 3
 	projectile_speed = 0.5
 
 /obj/item/projectile/bullet/weakbullet/mech

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -38,13 +38,13 @@
 	icon_state = "bbshell"
 	damage = 10
 	stun = 1
-	weaken = 5
+	weaken = 1
 	embed = 0
 	projectile_speed = 0.5
 
 /obj/item/projectile/bullet/weakbullet/booze
 	name = "booze bullet"
-	stun = 3
+	weaken = 5
 	projectile_speed = 0.5
 
 /obj/item/projectile/bullet/weakbullet/mech


### PR DESCRIPTION
Mainly nerfs detective revolver, but also glock. These things fire way too fast and penetrate glass and such.
:cl:
 * tweak: .38 weak bullet stun duration reduced to 1 second from 5.