### PR TITLE
The "Set Holiday" admin command will now show up in the admin's command panel

### DIFF
--- a/code/game/gamemodes/events/holidays/Holidays.dm
+++ b/code/game/gamemodes/events/holidays/Holidays.dm
@@ -154,7 +154,7 @@ var/global/Holiday = null
 
 //Allows GA and GM to set the Holiday variable
 /client/proc/Set_Holiday(T as text|null)
-	set name = ".Set Holiday"
+	set name = "Set Holiday"
 	set category = "Fun"
 	set desc = "Force-set the Holiday variable to make the game think it's a certain day."
 	if(!check_rights(R_SERVER))


### PR DESCRIPTION
## What this does
Makes the "Set Holiday" show up in the admin's "Fun" panel. It turns out that adding a dot before the name of a client proc causes it to not show up at all, even if it is available through command bar inputs.

## Why it's good
It's probably unintended that it was hidden, therefore it is a bugfix.

## How it was tested
Joined local (self-hosted) server, looked at Fun panel, it was there.

## Changelog
:cl:
 * bugfix: The "Set Holiday" admin command will now show up to admins in their command panel.