### PR TITLE
Cuts .38 weak bullet speed in half.

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -40,7 +40,7 @@
 	stun = 3
 	weaken = 5
 	embed = 0
-	projectile_speed = 0.5
+	projectile_speed = 1
 
 /obj/item/projectile/bullet/weakbullet/booze
 	name = "booze bullet"
@@ -49,6 +49,7 @@
 /obj/item/projectile/bullet/weakbullet/mech
 	stun = 0
 	weaken = 0
+	projectile_speed = 0.5
 
 /obj/item/projectile/bullet/weakbullet/booze/on_hit(var/atom/target, var/blocked = 0)
 	if(..(target, blocked))


### PR DESCRIPTION
Beforehand, the 5 second stun bullet took just about 130ms to travel 4 tiles a hit a person on the 5th. This is less than average human reaction time (especially accounting for ping) for a roundstart weapon that fires fast, stuns long enough to win a fight, and has 6 bullets in the chamber.

It is now doubled, so 0.26ms per 4 tiles.

:cl:
 * tweak: .38 weak bullets, mainly used in the detective's revolver, have had their speed cut in half.