### PR TITLE
Security airlocks in 3 maps will no longer each have randomized wires

### DIFF
--- a/maps/bagelstation.dm
+++ b/maps/bagelstation.dm
@@ -32,13 +32,14 @@
 	center_y = 236
 
 //All security airlocks have randomized wires
-/obj/machinery/door/airlock/glass_security/New()
-	.=..()
-	wires = new /datum/wires/airlock/secure(src)
+//Disabled from the game
+// /obj/machinery/door/airlock/glass_security/New()
+// 	.=..()
+// 	wires = new /datum/wires/airlock/secure(src)
 
-/obj/machinery/door/airlock/security/New()
-	.=..()
-	wires = new /datum/wires/airlock/secure(src)
+// /obj/machinery/door/airlock/security/New()
+// 	.=..()
+// 	wires = new /datum/wires/airlock/secure(src)
 
 #include "bagelstation.dmm"
 #endif

--- a/maps/defficiency.dm
+++ b/maps/defficiency.dm
@@ -79,13 +79,14 @@
 	add_dock(/obj/docking_port/destination/research/outpost)
 
 //All security airlocks have randomized wires
-/obj/machinery/door/airlock/glass_security/New()
-	.=..()
-	wires = new /datum/wires/airlock/secure(src)
+//Disabled from the game
+// /obj/machinery/door/airlock/glass_security/New()
+// 	.=..()
+// 	wires = new /datum/wires/airlock/secure(src)
 
-/obj/machinery/door/airlock/security/New()
-	.=..()
-	wires = new /datum/wires/airlock/secure(src)
+// /obj/machinery/door/airlock/security/New()
+// 	.=..()
+// 	wires = new /datum/wires/airlock/secure(src)
 
 ////////////////////////////////////////////////////////////////
 

--- a/maps/lowfatbagel.dm
+++ b/maps/lowfatbagel.dm
@@ -32,13 +32,14 @@
 	center_y = 247
 
 //All security airlocks have randomized wires
-/obj/machinery/door/airlock/glass_security/New()
-	.=..()
-	wires = new /datum/wires/airlock/secure(src)
+//Disabled from the game
+// /obj/machinery/door/airlock/glass_security/New()
+// 	.=..()
+// 	wires = new /datum/wires/airlock/secure(src)
 
-/obj/machinery/door/airlock/security/New()
-	.=..()
-	wires = new /datum/wires/airlock/secure(src)
+// /obj/machinery/door/airlock/security/New()
+// 	.=..()
+// 	wires = new /datum/wires/airlock/secure(src)
 
 #include "lowfatbagel.dmm"
 #endif


### PR DESCRIPTION
## What this does
Disables the lines of code that randomize the Security wires on Bagel, Defficiency and Lowfat Bagel.
The magenta squares represent affected airlocks
![airlocks_bagel](https://github.com/user-attachments/assets/e27b5fb8-63a7-4ed4-ab7b-682ee3adaf58)
![airlocks_deff](https://github.com/user-attachments/assets/35b149a5-e521-43d5-8b84-bab046e38b49)
![airlocks_lowfat](https://github.com/user-attachments/assets/0413dd7b-58f9-4134-ac11-22bf1925cd60)
Each one of these had its own randomized wires.
Dorfstation also has randomized wires but they're mostly for unpowered and abandoned Security areas. If they can get them to work, then they should have a little bit extra security.
## Why it's good
Feels arbitrary compared to almost every other map (no other map really features randomized airlock wires), plus it was a detriment for both people that looked to break inside and the Security officers staffing them in case someone messed with the airlocks; it was made to severely slow down intruders but if the intruders bolt the airlocks and/or shock them then the officers (who rarely have insulated gloves) would have to find the right wires over and over again and risk getting shocked. That's not fun for anyone. And it rarely deters antagonists too who have their own breaking-in methods such as emags or teleportation.
It's discouraging to players that don't know much about the game too, since it's an unmentioned element of 3 maps. 
## How it was tested
Entered the maps, grabbed a few tools and checked the airlock wires.
## Changelog
:cl:
 * tweak: Bagel, Defficiency and Lowfat Bagel no longer have randomized Security airlock wires.