### PR TITLE
Fixes Traitor Purchase Log Access Exploit

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -212,7 +212,8 @@
 	if(!ticker || !ticker.mode)
 		alert("Ticker and Game Mode aren't initialized yet!", "Alert")
 		return
-
+	if(!check_rights(R_ADMIN))
+		return
 	var/out = {"<TITLE>Role purchase log</TITLE><B>[name]</B>[(current&&(current.real_name!=name))?" (as [current.real_name])":""]<BR>Assigned job: [assigned_role]<hr>"}
 	if(current.spell_list && current.spell_list.len)
 		out += "Known spells:<BR>"


### PR DESCRIPTION


## What this does
This closes a bug where you could view traitor/wizard/ling/etc purchases as a non-admin via href exploit.

## Why it's good
Security can't see if you're a traitor via an exploit when they arrest you, additionally confirming what you've purchased.

## How it was tested
Open role panel, deadmin, click button on still-open role panel. Fastest way to test.
![image](https://github.com/user-attachments/assets/bdfcc58a-6eee-4974-ad00-0ebffa49974c)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Closed exploit where you could see what a traitor purchased as a non-admin
