### PR TITLE
Fixes unforeseen consequences regarding death() code

### DIFF
--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -35,42 +35,41 @@
 
 /mob/proc/death(gibbed)
 	var/turf/place_of_death = get_turf(src)
-	spawn()
-		if(is_dying)
-			var/deathstring = "[src] at ([get_coordinates_string(src)]) had death() called (with var/gibbed = [gibbed]) while already dying!"
-			log_debug(deathstring)
-			message_admins(deathstring)
-			return
-		is_dying = TRUE
-		timeofdeath = world.time
-		INVOKE_EVENT(src, /event/death, "user" = src, "body_destroyed" = gibbed)
-		living_mob_list -= src
-		dead_mob_list += src
-		stat_collection.add_death_stat(src,place_of_death)
-		if(runescape_skull_display && ticker)//we died, begone skull
-			if ("\ref[src]" in ticker.runescape_skulls)
-				var/datum/runescape_skull_data/the_data = ticker.runescape_skulls["\ref[src]"]
-				ticker.runescape_skulls -= "\ref[src]"
-				qdel(the_data)
-		if(client)
-			client.color = initial(client.color)
-		for(var/obj/item/I in src)
-			I.OnMobDeath(src)
-		for(var/atom/A in arcane_tampered_atoms)
-			A.bless()
-		if(spell_masters && spell_masters.len)
-			for(var/obj/abstract/screen/movable/spell_master/spell_master in spell_masters)
-				spell_master.on_holder_death(src)
-		if(transmogged_from)
-			transmog_death()
-		if(client || mind)
-			var/mindname = (src.mind && src.mind.name) ? "[src.mind.name]" : "[real_name]"
-			var/died_as = (mindname == real_name) ? "" : " (died as [real_name])"
-			for(var/mob/M in get_deadchat_hearers())
-				var/rendered = "\proper[formatFollow(src)] <span class='game deadsay'> \The <span class='name'>[mindname][died_as]</span> has died at \the <span class='name'>[get_area(place_of_death)]</span>.</span>"
-				to_chat(M, rendered)
-			log_game("[key_name(src)] has died at [get_area(place_of_death)]. Coordinates: ([get_coordinates_string(src)])")
-		is_dying = FALSE
+	if(is_dying)
+		var/deathstring = "[src] at ([get_coordinates_string(src)]) had death() called (with var/gibbed = [gibbed]) while already dying!"
+		log_debug(deathstring)
+		message_admins(deathstring)
+		return
+	is_dying = TRUE
+	timeofdeath = world.time
+	INVOKE_EVENT(src, /event/death, "user" = src, "body_destroyed" = gibbed)
+	living_mob_list -= src
+	dead_mob_list += src
+	stat_collection.add_death_stat(src,place_of_death)
+	if(runescape_skull_display && ticker)//we died, begone skull
+		if ("\ref[src]" in ticker.runescape_skulls)
+			var/datum/runescape_skull_data/the_data = ticker.runescape_skulls["\ref[src]"]
+			ticker.runescape_skulls -= "\ref[src]"
+			qdel(the_data)
+	if(client)
+		client.color = initial(client.color)
+	for(var/obj/item/I in src)
+		I.OnMobDeath(src)
+	for(var/atom/A in arcane_tampered_atoms)
+		A.bless()
+	if(spell_masters && spell_masters.len)
+		for(var/obj/abstract/screen/movable/spell_master/spell_master in spell_masters)
+			spell_master.on_holder_death(src)
+	if(transmogged_from)
+		transmog_death()
+	if(client || mind)
+		var/mindname = (src.mind && src.mind.name) ? "[src.mind.name]" : "[real_name]"
+		var/died_as = (mindname == real_name) ? "" : " (died as [real_name])"
+		for(var/mob/M in get_deadchat_hearers())
+			var/rendered = "\proper[formatFollow(src)] <span class='game deadsay'> \The <span class='name'>[mindname][died_as]</span> has died at \the <span class='name'>[get_area(place_of_death)]</span>.</span>"
+			to_chat(M, rendered)
+		log_game("[key_name(src)] has died at [get_area(place_of_death)]. Coordinates: ([get_coordinates_string(src)])")
+	is_dying = FALSE
 
 /mob/proc/transmog_death()
 	var/obj/transmog_body_container/C = transmogged_from


### PR DESCRIPTION
## What this does
Removes the spawn() from the mob/proc/death() code, which caused it to be called after the rest of the code such as item destruction or the mob getting qdel'd.
It broke:
- The SPS. If an SPS user got gibbed/ashed then it would not trigger the SPS at all, so now officers will trigger the SPS if they get destroyed by something like the singularity or a supermatter shard.

This does not make grue eating trigger the SPS yet because every item gets dropped first.
## Why it's good
Fixes bugs.
## How it was tested
Joined the game, ran into shards while doing things such as carrying SPS, phylactery functions as intended.
## Changelog
:cl:
 * bugfix: Fixed a bug where the SPS would not perform an alarm if the wearer was gibbed or turned to ash.