### PR TITLE
Floor burning sanity

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -341,31 +341,17 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 	update_paint_overlay()
 
 /turf/simulated/floor/proc/burn_tile()
-	if(istype(src,/turf/simulated/floor/engine))
-		return//Reinforced floors don't burn
-	if(istype(src,/turf/unsimulated/floor/asteroid))
-		return//Asteroid tiles don't burn
-	if(istype(src,/turf/simulated/floor/shuttle))
-		if(!(locate(/obj/effect/decal/cleanable/soot) in src))
-			new /obj/effect/decal/cleanable/soot(src)
-		burnt = 1
-	else if(is_metal_floor())
+	if(is_metal_floor())
 		icon_state = "damaged[pick(1,2,3,4,5)]"
-		burnt = 1
 	else if(is_plating())
 		icon_state = "panelscorched"
-		burnt = 1
 	else if(is_wood_floor())
 		icon_state = "wood-broken"
-		burnt = 1
 	else if((is_carpet_floor()) || (is_arcade_floor()))
 		icon_state = "carpet-broken"
-		burnt = 1
 	else if(is_grass_floor())
 		icon_state = "sand[pick("1","2","3")]"
-		burnt = 1
-	else if(is_mineral_floor())
-		burnt = 1
+	burnt = 1
 	update_paint_overlay()
 	extinguish()
 
@@ -387,6 +373,8 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 
 	if(floor_tile)
 		qdel(floor_tile)
+	if(burnt)
+		ChangeTurf(/turf/simulated/floor) //changes a fully-burnt tile into an inflammable tile
 	icon_plating = "plating"
 	set_light(0)
 	floor_tile = null

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -213,6 +213,9 @@
 		else
 			overlays.Add(image('icons/turf/floors.dmi', icon_state = "r_floor_unsec"))
 
+/turf/simulated/floor/engine/burn_tile()
+	return//Reinforced floors don't burn
+
 /turf/simulated/floor/engine/bolted
 	name = "bolted floor"
 	desc = "This floor has jutting bolts that would make crawling across it impossible."

--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -155,6 +155,12 @@
 /turf/simulated/floor/shuttle/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	return
 
+/turf/simulated/floor/shuttle/burn_tile()
+	if(!(locate(/obj/effect/decal/cleanable/soot) in src))
+		new /obj/effect/decal/cleanable/soot(src)
+	burnt = 1
+	..()
+
 /turf/simulated/floor/shuttle/airless
 	oxygen   = 0.01
 	nitrogen = 0.01


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Slightly refactors floor burning code and changes any burnt turf with plating removed to the standard /turf/simulated/floor to prevent empty floor tiles from burning if the previously had flammable tiles present.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Closes #36643.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
It wasn't! (I will test it later).

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Non-flammable turfs which used to have flammable floor tiles will no longer burn.