### PR TITLE
Flatpack Printer Bluespace Bins

### DIFF
--- a/code/modules/research/mechanic/flatpacker.dm
+++ b/code/modules/research/mechanic/flatpacker.dm
@@ -47,7 +47,7 @@
 	if(!part)
 		return
 
-	if(!remove_materials(part))
+	if(!remove_materials(part) && !bluespace_materials(part))
 		stopped = 1
 		src.visible_message("<span class='notice'>The [src.name] beeps, \"Not enough materials to complete item.\"</span>")
 		return


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes Flatpack Fabricators not taking Bluespace Matter Bins' part sharing feature into account when printing flatpacks.


## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
We love and cherish our Mechanic players!

Closes #25215.
Closes #28298.
Closes #36828.


## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
- Scanned a machine, acquired a nanoprint, and added it to a flatpacker which only contained plastic.
- Added the necessary materials to Research's Prolathe.
- Installed Bluespace Matter Bins in both machines.
- Printed the machine successfully in the flatpacker.
- Confirmed materials were consumed from the Prolathe.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed Flatpack Fabricators not using parts shared via Bluespace Matter Bins.
