### PR TITLE
Makes the transfer function on the Genetics console cause as much radiation as an injector

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -1082,7 +1082,7 @@
 				src.connected.occupant.dna.SE = buf.dna.SE
 				src.connected.occupant.dna.UpdateSE()
 				domutcheck(src.connected.occupant,src.connected)
-			src.connected.occupant.radiation += rand(20,50)
+			src.connected.occupant.radiation += rand(1,10)
 			return 1
 
 		if (bufferOption == "createInjector")


### PR DESCRIPTION
## What this does
Reduces the random 20 to 50 radiation to 1 to 10 radiation transfer for the "transfer" function (which causes it to give the same radiation as the injector), after I accidentally nearly irradiated someone's character to death because I just wanted to transfer a bunch of times instead of bothering with injectors.
## Why it's good
Gives a better reason to use the DNA scanning console instead of the injectors, because injectors are already better in almost every way except time to apply.
If there are concerns about using it as a way to kill someone then it doesn't really affect that because you can still just irradiate the person altogether using the other functions for it, namely the power, duration and "irradiate" buttons.
## How it was tested
It wasn't. It just changes two numbers.

## Changelog
:cl:
 * tweak: The Genetics' DNA Scanner's "transfer" function will now only irradiate as much as a DNA injector would, which is far less.