### PR TITLE
Stinking up a location via having carp pheromones will no longer be prevented by someone in the vicinity being dead

### DIFF
--- a/code/modules/reagents/reagents/reagents_bio.dm
+++ b/code/modules/reagents/reagents/reagents_bio.dm
@@ -305,7 +305,7 @@
 	if(prob(5)) //5% chance of stinking per life()
 		for(var/mob/living/carbon/C in oview(stench_radius, M)) //All other carbons in 4 tile radius (excluding our mob)
 			if(C.stat)
-				return
+				continue
 			if(istype(C.wear_mask))
 				var/obj/item/clothing/mask/c_mask = C.wear_mask
 				if(c_mask.body_parts_covered & MOUTH)


### PR DESCRIPTION
## What this does
Turns a "return" into a "continue"
## Why it's good
I don't know.
## How it was tested
It wasn't.
## Changelog
:cl:
 * bugfix: Fixed a bug where a person that has carp pheromones in their system would not stink up the place properly if someone nearby was dead, which would unpredictably cause the message to not reliably show up to other players in the area.