### PR TITLE
killdozer v1 - clarkeswithguns

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -321,6 +321,12 @@ var/list/discounted_items_of_the_round = list()
 	//jobs_with_discount = list("Assistant")
 	//would've liked to add a discount for dark skinned or nearsighted characters (closest to one eyed we have) but dunno how
 
+/datum/uplink_item/dangerous/mech_killdozer
+        name = "Mech Killdozer kit"
+        desc = "Three random weapons and a conversion kit that allows them to be attached to non-combat mechs. Mech not included."
+        item = /obj/item/weapon/storage/box/syndie_kit/mech_killdozer
+        cost = 10
+
 // STEALTHY WEAPONS
 // Any Syndicate item with applying lethal force to people without being easily detected (Ex: Syndicate Soap, Parapen, E-Bow)
 

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -97,9 +97,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/proc/can_attach(obj/mecha/M as obj)
 	if(istype(M))
-		if(M.equipment.len<M.max_equip)
 			return 1
-	return 0
 
 /obj/item/mecha_parts/mecha_equipment/proc/attach(obj/mecha/M as obj)
 	M.equipment += src

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -97,7 +97,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/proc/can_attach(obj/mecha/M as obj)
 	if(istype(M))
-			return 1
+		return 1
 
 /obj/item/mecha_parts/mecha_equipment/proc/attach(obj/mecha/M as obj)
 	M.equipment += src

--- a/code/game/mecha/equipment/passive/passive.dm
+++ b/code/game/mecha/equipment/passive/passive.dm
@@ -57,3 +57,19 @@
 		if(istype(W))
 			return 1
 	return 0
+
+/obj/item/mecha_parts/mecha_equipment/passive/killdozer_kit
+	name = "exosuit killdozer modkit"
+	desc = "This suspicious adapter allows various types of usually unsupported equipment to be attached to a mech."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "modkit"
+	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/newsprites_lefthand.dmi', "right_hand" = 'icons/mob/in-hand/right/newsprites_righthand.dmi')
+	is_activateable = FALSE
+	origin_tech = Tc_MATERIALS + "=3;" + Tc_MAGNETS + "=3;" + Tc_SYNDICATE + "=2;"
+	starting_materials = list(MAT_IRON = 12500, MAT_GLASS = 500)
+	
+/obj/item/mecha_parts/mecha_equipment/passive/killdozer_kit/detach()
+	if(chassis.equipment.len > 1)	//only detach if we're the only part left
+		playsound(chassis,'sound/machines/buzz-sigh.ogg',40,1)
+		return 0
+	..()

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -31,6 +31,7 @@
 	if(!action_checks(target))
 		return
 	if(!istype(chassis, /obj/mecha/working))
+		occupant_message("<span class='warning'>Hydraulic systems damaged or missing. Contact a technician specializing in working exosuits.</span>")
 		return
 	var/obj/mecha/working/W = chassis
 

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -654,6 +654,7 @@
 		)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/random_weapon/New()
+	..()
 	var/weapontype = pick(existing_typesof(/obj/item/mecha_parts/mecha_equipment/weapon) - blacklisted)
 	new weapontype (loc)
 	qdel(src)

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -637,3 +637,23 @@
 			projectiles--
 	else
 		..()
+
+/obj/item/mecha_parts/mecha_equipment/weapon/random_weapon
+	var/list/blacklisted = list(
+		/obj/item/mecha_parts/mecha_equipment/weapon,
+		/obj/item/mecha_parts/mecha_equipment/weapon/energy,
+		/obj/item/mecha_parts/mecha_equipment/weapon/ballistic,
+		/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang/metalfoam,
+		/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang/inflatable,
+		//leaving the banana mortar in because its funny
+		/obj/item/mecha_parts/mecha_equipment/weapon/honker,
+		/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/mousetrap_mortar,
+		/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/creampie_mortar,
+		///obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse,
+		///obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack,
+		)
+
+/obj/item/mecha_parts/mecha_equipment/weapon/random_weapon/New()
+	var/weapontype = pick(existing_typesof(/obj/item/mecha_parts/mecha_equipment/weapon) - blacklisted)
+	new weapontype (loc)
+	qdel(src)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -797,6 +797,17 @@
 		src.check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
 	return
 
+/obj/mecha/proc/get_remaining_equipment_slots()
+	if(equipment.len >= max_equip)
+		return 0
+	return max_equip - equipment.len
+	
+/obj/mecha/proc/is_killdozer()
+	for(var/obj/I in equipment)
+		if(istype(I, /obj/item/mecha_parts/mecha_equipment/passive/killdozer_kit))
+			return TRUE
+	return FALSE
+
 //////////////////////
 ////// AttackBy //////
 //////////////////////
@@ -817,7 +828,7 @@
 	if(istype(W, /obj/item/mecha_parts/mecha_equipment))
 		var/obj/item/mecha_parts/mecha_equipment/E = W
 		spawn()
-			if(E.can_attach(src))
+			if(E.can_attach(src) || is_killdozer()) && get_remaining_equipment_slots())
 				if(user.drop_item(W))
 					E.attach(src)
 					user.visible_message("[user] attaches [W] to [src]", "You attach [W] to [src]")

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -828,7 +828,7 @@
 	if(istype(W, /obj/item/mecha_parts/mecha_equipment))
 		var/obj/item/mecha_parts/mecha_equipment/E = W
 		spawn()
-			if(E.can_attach(src) || is_killdozer()) && get_remaining_equipment_slots())
+			if((E.can_attach(src) || is_killdozer()) && get_remaining_equipment_slots())
 				if(user.drop_item(W))
 					E.attach(src)
 					user.visible_message("[user] attaches [W] to [src]", "You attach [W] to [src]")

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -354,6 +354,15 @@
 		/obj/item/weapon/card/emag = 3,
 	)
 
+/obj/item/weapon/storage/box/syndie_kit/mech_killdozer	//mech not included
+	name = "box (KD)"
+	items_to_spawn = list(
+		/obj/item/mecha_parts/mecha_equipment/passive/killdozer_kit,
+		/obj/item/mecha_parts/mecha_equipment/weapon/random_weapon,
+		/obj/item/mecha_parts/mecha_equipment/weapon/random_weapon,
+		/obj/item/mecha_parts/mecha_equipment/weapon/random_weapon,
+	)
+
 //Syndicate Ayy Lmao Gear
 //The mothership sends its warmest regards
 /obj/item/weapon/storage/box/syndie_kit/ayylmao_harmor

--- a/code/modules/research/designs/robotics.dm
+++ b/code/modules/research/designs/robotics.dm
@@ -112,3 +112,13 @@
 	materials = list(MAT_IRON = 100, MAT_GLASS = 100)
 	category = "Misc"
 	build_path = /obj/item/device/mech_painter
+
+/datum/design/killdozer_modkit
+	name = "Exosuit Module Attachment Multi-adapter"
+	desc = "this never even shows up ingame???"
+	id = "killdozer_modkit"
+	req_tech = list(Tc_MATERIALS = 3, Tc_MAGNETS = 3, Tc_SYNDICATE = 2)
+	build_type = PROTOLATHE | MECHFAB
+	materials = list(MAT_IRON = 75000, MAT_GLASS = 1000) //about as expensive as 3 exosuit arms
+	category = "Robotics"
+	build_path = /obj/item/mecha_parts/mecha_equipment/passive/killdozer_kit


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
new item you can attach to all exosuits
the killdozer disables requirements on mech modules but uses up a slot - you can put 2 guns on a modified ripley
it also lets you put non-guns onto modified mechs, so you can put a sleeper and a phazon array on a gygax, or 3 banana mortars onto a clarke
closes #27615
![image](https://github.com/vgstation-coders/vgstation13/assets/159179330/8f8d8056-6b0c-4fd5-900f-87123440b580)
adds the killdozer to the traitor uplink and r&d(illegal 2)

## Why it's good

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: mecha killdozer kit - bypasses mech module requirements, letting you put guns on working mechs(or tools on combat mechs)
 * rscadd: add killdozer kit to uplink (10tc and comes with 3 random guns)
 * rscadd: add killdozer kit to r&d (illegal 2)
 