### PR TITLE
Tweaks to the caber

### DIFF
--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -326,7 +326,7 @@
 
 /obj/item/weapon/caber
 	name = "\improper Ullapool Caber"
-	desc = "A potato-masher style hand grenade. Only explodes when swung against a target while the safety grip is on."
+	desc = "A potato-masher style hand grenade. Only explodes when swung against a target while the safety grip is on. Can recharge once a minute."
 	icon_state = "ullapoolcaber"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/swords_axes.dmi', "right_hand" = 'icons/mob/in-hand/right/swords_axes.dmi')
 	siemens_coefficient = 0 //wooden handle
@@ -337,7 +337,7 @@
 	w_class = W_CLASS_SMALL //fits in your pocket
 	attack_verb = list("blasts", "smacks", "smashes")
 	var/exploded = FALSE
-	var/admintier = FALSE
+	var/admintier = TRUE
 	var/rechargetime = 30 //1 minute between each boom, only used by the admincaber
 	var/timer = 0
 
@@ -357,7 +357,7 @@
 		attack_verb = list("blasts", "explodes")
 	if(!cant_drop)
 		attack_verb = list("smacks", "smashes")
-	if(admintier && exploded) //only admin tier cabers have a recharge timer
+	if(admintier && exploded)
 		timer += 1
 	if(admintier && timer == rechargetime)
 		timer = 0
@@ -381,12 +381,11 @@
 			exploded = TRUE
 			icon_state = "ullapoolcaberexploded"
 			sharpness = 1.3 //ragged metal edges are kinda like a serrated knife
-			sharpness_flags = SHARP_BLADE //ever cut yourself when opening a can of whatever with a can opener? same deal here
+			sharpness_flags = SHARP_TIP | SERRATED_EDGE | INSULATED_EDGE //ever cut yourself when opening a can of whatever with a can opener? same deal here, sharp spikes, uneven ragged metal and wooden handle
 		else
 			playsound(target, 'sound/misc/caber_hitsound.ogg', 100, 0)
 	else
 		playsound(target, 'sound/misc/caber_hitsound.ogg', 100, 0)
-//TO DO: make inhand update properly when exploded or restored
 //TO DO: less self damage the more inebriated you are, with max immunity at or near liver death levels
 //TO DO: explosion when used against walls or windows
 

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -338,7 +338,7 @@
 	attack_verb = list("blasts", "smacks", "smashes")
 	var/exploded = FALSE
 	var/admintier = TRUE
-	var/rechargetime = 30 //1 minute between each boom, only used by the admincaber
+	var/rechargetime = 30 //1 minute between each boom
 	var/timer = 0
 
 /obj/item/weapon/caber/New()
@@ -381,7 +381,7 @@
 			exploded = TRUE
 			icon_state = "ullapoolcaberexploded"
 			sharpness = 1.3 //ragged metal edges are kinda like a serrated knife
-			sharpness_flags = SHARP_TIP | SERRATED_EDGE | INSULATED_EDGE //ever cut yourself when opening a can of whatever with a can opener? same deal here, sharp spikes, uneven ragged metal and wooden handle
+			sharpness_flags = SHARP_TIP | SERRATED_BLADE | INSULATED_EDGE //ever cut yourself when opening a can of whatever with a can opener? same deal here, sharp spikes, uneven ragged metal and wooden handle
 		else
 			playsound(target, 'sound/misc/caber_hitsound.ogg', 100, 0)
 	else


### PR DESCRIPTION
## What this does
When I made the caber, I forgot about the existence of the proper sharpness flags for when it was exploded, it is NOT a sharp blade, it's a sharp tip with serrated edges (jagged metal), plus a wooden handle, so it has been updated to have the sharp tip, serrated edge and insulated tip flags when detonated, instead of sharp edge.
For pretty much the same price as the caber, you could get the esword, which doesn't self harm when used, plus, the caber being a single charge also meant that it was pretty much just an overly expensive syndie toolbox (as far as damage is concerned) after exploding, so it can now recharge, once per minute.
## Why it's good
Buffs a rarely used weapon and gives an incentive to use it.
## How it was tested
It wasn't, but it's just a change of a few flags, no new behaviours.
## Changelog
:cl:
 * tweak: The Caber can now self recharge once per minute and has the proper sharpness flags when on its detonated state.
