### PR TITLE
juicy fruit splashes in an area

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -114,6 +114,8 @@ var/list/special_fruits = list()
 	if(seed.juicy)
 		splat_decal(get_turf(hit_atom))
 		splat_reagent_reaction(get_turf(hit_atom),user)
+		var/splasharea = (seed.juicy*round((seed.potency/100), 1)) //2 at 200 potency
+		reagents.splashplosion(splasharea, TRUE)
 		visible_message("<span class='notice'>The [src.name] has been squashed.</span>","<span class='moderate'>You hear a smack.</span>")
 		qdel(src)
 		return

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -114,7 +114,7 @@ var/list/special_fruits = list()
 	if(seed.juicy)
 		splat_decal(get_turf(hit_atom))
 		splat_reagent_reaction(get_turf(hit_atom),user)
-		var/splasharea = (seed.juicy*round((seed.potency/100), 1)) //2 at 200 potency
+		var/splasharea = (seed.juicy*ceil(seed.potency/100) //2 at 200 potency
 		reagents.splashplosion(splasharea, TRUE)
 		visible_message("<span class='notice'>The [src.name] has been squashed.</span>","<span class='moderate'>You hear a smack.</span>")
 		qdel(src)

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -114,7 +114,7 @@ var/list/special_fruits = list()
 	if(seed.juicy)
 		splat_decal(get_turf(hit_atom))
 		splat_reagent_reaction(get_turf(hit_atom),user)
-		var/splasharea = (seed.juicy*ceil(seed.potency/100) //2 at 200 potency
+		var/splasharea = (seed.juicy*ceil(seed.potency/100)) //2 at 200 potency
 		reagents.splashplosion(splasharea, TRUE)
 		visible_message("<span class='notice'>The [src.name] has been squashed.</span>","<span class='moderate'>You hear a smack.</span>")
 		qdel(src)


### PR DESCRIPTION
## What this does
Juicy fruit will splash its reagents in an area, like half-reacted grenades do, 2 tiles radius around the target tile at 200 potency (grenades have a 4 tile radius regardless of the amount of unreacted reagents)
## Why it's good
Juicy fruit is kinda meh, making it splash its contents is interesting and can lead to interesting splices.
## How it was tested
Spawned tomatoes, VV'd it to 10, 100 and 200 potency, threw them and splash area increased according to the potency.
:cl:
 * rscadd: Juicy fruit will splash its reagents in an area.