### PR TITLE
Fixes attack_self() override for energy guns

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -109,7 +109,8 @@
 /obj/item/weapon/gun/energy/variable_edited(variable_name, old_value, new_value)
 	if(variable_name == "detachable_cell")
 		if(new_value) //New value is not 0 or null, give the verb
-			verbs += /obj/item/weapon/gun/energy/verb/detach_cell_verb
+			if(!verbs.Find(/obj/item/weapon/gun/energy/verb/detach_cell_verb))
+				verbs += /obj/item/weapon/gun/energy/verb/detach_cell_verb
 		else
 			verbs -= /obj/item/weapon/gun/energy/verb/detach_cell_verb
 	return ..()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -105,6 +105,15 @@
 // /obj/item/weapon/gun/energy/attack_self(mob/user)
 // 	return detach_cell(user)
 
+//Handles the detach cell verb for the energy gun, so that admins can adminbus it
+/obj/item/weapon/gun/energy/variable_edited(variable_name, old_value, new_value)
+	if(variable_name == "detachable_cell")
+		if(new_value) //New value is not 0 or null, give the verb
+			verbs += /obj/item/weapon/gun/energy/verb/detach_cell_verb
+		else
+			verbs -= /obj/item/weapon/gun/energy/verb/detach_cell_verb
+	return ..()
+
 /obj/item/weapon/gun/energy/verb/detach_cell_verb()
 	set name = "Detach cell"
 	set category = "Object"

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -101,8 +101,9 @@
 		return 1
 	return ..()
 
-/obj/item/weapon/gun/energy/attack_self(mob/user)
-	return detach_cell(user)
+//There is a verb for this!
+// /obj/item/weapon/gun/energy/attack_self(mob/user)
+// 	return detach_cell(user)
 
 /obj/item/weapon/gun/energy/verb/detach_cell_verb()
 	set name = "Detach cell"


### PR DESCRIPTION
Fixes #36464 

## What this does
Comments out the code for attack_self() that allowed detachable cells from guns to be taken out.
Adds a new var-edit check for energy guns where if the detachable_cell variable gets toggled on it will give the detach_cell verb to the gun, otherwise it removes it, which should allow preserving the previous functionality.
## Why it's good
Fixes a bug where you couldn't wield the Staff of Swip-Swap, and the attack_self() behavior didn't work out well with energy guns that toggled between states on attack_self() such as energy guns.
## How it was tested
Joined the game, wielded the Staff of Swip-Swap, grabbed an energy gun, modified its variable, detached and reattached cell, modified its variable, couldn't detach cell.
## Changelog
:cl:
 * bugfix: Fixed a year-old bug where the Staff of Swip-Swap couldn't be wielded. Now it can be wielded to empower the projectile, which allows it to go through windows.
 * bugfix: (Admins) Changing the "detachable_cell" variable for energy weapons will now also handle whether it will give the gun the respective "Detach Cell" verb or not.