### PR TITLE
A hostile Old Vendotron will no longer destroy itself with the creatures it creates + Old Vendotron plate throwing fix

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks/egg.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/egg.dm
@@ -107,10 +107,12 @@
 	else
 		..()
 
-/obj/item/weapon/reagent_containers/food/snacks/egg/proc/hatch()
+/obj/item/weapon/reagent_containers/food/snacks/egg/proc/hatch(var/faction)
 	visible_message("[src] hatches with a quiet cracking sound.")
 	new/obj/item/trash/egg(loc)
-	new hatch_type(get_turf(src))
+	var/mob/living/L = new hatch_type(get_turf(src))
+	if(istype(L) && faction) //If it's mob/living, make it take the faction
+		L.faction = faction
 	processing_objects.Remove(src)
 	qdel(src)
 
@@ -159,22 +161,24 @@
 	icon_state = "egg-chaos"
 	can_color = FALSE
 
-/obj/item/weapon/reagent_containers/food/snacks/egg/chaos/hatch()
+/obj/item/weapon/reagent_containers/food/snacks/egg/chaos/hatch(var/faction)
 	var/turf/T = get_turf(src)
 	if(T)
 		playsound(src, 'sound/effects/phasein.ogg', 100, 1)
 		visible_message("\The [src] cracks open, revealing a realm of the unknown within. From that realm, something emerges.")
 		var/choice = pick(existing_typesof(/mob/living/simple_animal) - (boss_mobs + blacklisted_mobs))
-		new choice(T)
+		var/mob/living/simple_animal/A = new choice(T)
+		if(faction)
+			A.faction = faction
 	processing_objects.Remove(src)
 	qdel(src)
 
-/obj/item/weapon/reagent_containers/food/snacks/egg/chaos/instahatch/New()
-	..()
+/obj/item/weapon/reagent_containers/food/snacks/egg/chaos/instahatch/New(var/loc, var/faction)
+	..(loc)
 	var/time = rand(3,10)
 	spawn(time)
 		if(!gcDestroyed)
-			hatch()
+			hatch(faction)
 
 var/snail_egg_count = 0
 


### PR DESCRIPTION
## What this does
Makes the vendotron and creatures belong to a single "angry_vendotron" faction, meaning they will stop attacking each other.
Fixes Vendotron plate throwing so that it no longer tries to throw plates from a nullspaced vendotron instead of a mob vendotron, fixing a lot of runtimes in the process.
Slightly tweaks egg-hatching so that it can support inheriting custom factions, but nothing except the Vendotron calls that functionality in the code yet.
## Why it's good
Allows the Vendotron to remain menacing instead of killing itself by raining spiders all over itself. Also fixes plates so that they are actually thrown properly.
## How it was tested
Joined the game, emagged vendotron, checked creature factions, saw how the vendor was throwing plates.
## Changelog
:cl:
 * tweak: A neo-ultra-capitalism mode Old Vendotron will no longer kill itself by summoning a lot of hostile creatures that it would proceed to go to combat with, and now the creatures it creates become part of the same faction as it.
 * bugfix: Fixed the Old Vendotron's plate attack so that it will no longer throw plates on its own tile. It will now properly throw them away.