### PR TITLE
Slimes become ravenous when near monkeys and store a little more nutrition

### DIFF
--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -45,6 +45,15 @@
 	//Status updates, death etc.
 	handle_regular_status_updates()
 
+//Causes the slime to be hungry if it has a preferred food in range, which for now is just monkeys
+//Helps facilitate a faster xenobio by having the slimes eat sooner instead of waiting until they are hungry again
+/mob/living/carbon/slime/proc/preferred_food_in_vicinity()
+	for(var/mob/living/L in view(5, src))
+		if(is_type_in_list(L, preferred_food))
+			if(!(L.health <= -70)) //If the target can still be fed upon by the slime
+				return 1
+	return 0
+
 /mob/living/carbon/slime/proc/AIprocess()  // the master AI process
 
 //	to_chat(world, "AI proc started.")
@@ -66,6 +75,8 @@
 			if(0 to 149)
 				starving = 1
 	AIproc = 1
+	if(!hungry && !starving) //Not hungry nor starving, make it hungry if it has a preferred food in range
+		hungry = preferred_food_in_vicinity()
 //	to_chat(world, "AIproc [AIproc] && stat != 2 [stat] && (attacked > 0 [attacked] || starving [starving] || hungry [hungry] || Victim [Victim] || Target [Target]")
 	while(AIproc && stat != 2 && (attacked > 0 || starving || hungry || Victim))
 		if(Victim) // can't eat AND have this little process at the same time
@@ -437,7 +448,7 @@
 					starving = 1
 
 		else
-			switch(nutrition)			// 1000 max nutrition
+			switch(nutrition)			// 1200 max nutrition
 				if(501 to 700)
 					if(prob(25))
 						hungry = 1
@@ -454,7 +465,8 @@
 
 		if(!Target)
 			var/list/targets = list()
-
+			if(!hungry && !starving)
+				hungry = preferred_food_in_vicinity()
 			if(hungry || starving) //Only add to the list if we need to
 				for(var/mob/living/L in view(7,src))
 

--- a/code/modules/mob/living/carbon/slime/powers.dm
+++ b/code/modules/mob/living/carbon/slime/powers.dm
@@ -98,12 +98,8 @@
 						if(powerlevel > 10)
 							powerlevel = 10
 
-				if(slime_lifestage == SLIME_ADULT)
-					if(nutrition > 1200)
-						nutrition = 1200
-				else
-					if(nutrition > 1000)
-						nutrition = 1000
+				if(nutrition > 1200)
+					nutrition = 1200
 
 				Victim.updatehealth()
 				updatehealth()

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -33,6 +33,8 @@
 	var/list/Friends = list() // A list of potential friends
 	var/list/FriendsWeight = list() // A list containing values respective to Friends. This determines how many times a slime "likes" something. If the slime likes it more than 2 times, it becomes a friend
 
+	var/list/preferred_food = list(/mob/living/carbon/monkey) //Will ignore hungry checks and try to eat the types in the list ASAP.
+
 	var/list/speech_buffer = list()
 
 	// slimes pass on genetic data, so all their offspring have the same "Friends",
@@ -83,7 +85,7 @@
 		if (SLIME_BABY)
 			maxHealth = 150
 			health = 150
-			nutrition = 700 // 1000 = max
+			nutrition = 700 // 1200 = max
 			speak_emote = list("hums")
 		if (SLIME_ADULT)
 			maxHealth = 200
@@ -201,14 +203,11 @@
 
 	if(statpanel("Status"))
 		stat(null, "Health: [round((health / maxHealth) * 100)]%")
-
-		if(slime_lifestage == SLIME_ADULT)
-			stat(null, "Nutrition: [nutrition]/1200")
-			if(amount_grown >= 10)
+		stat(null, "Nutrition: [nutrition]/1200")
+		if(amount_grown >= 10)
+			if(slime_lifestage == SLIME_ADULT)
 				stat(null, "You can reproduce!")
-		else
-			stat(null, "Nutrition: [nutrition]/1000")
-			if(amount_grown >= 10)
+			else
 				stat(null, "You can evolve!")
 
 		stat(null,"Power Level: [powerlevel]")


### PR DESCRIPTION
## What this does
The presence of monkeys will now cause slimes to be considered hungry, which means they will be more likely to immediately try to feed on anyone in range, most likely on the monkeys. This also makes them slightly more dangerous to the user.
Allows smaller slimes to store up to 1200 nutrition compared to 1000, because otherwise with this change they'd feed too fast on the monkeys before they grew and the usual "place 2 monkeys into the cage" system wouldn't work.
## Why it's good
Allows Xenobiology to develop faster, considering how long it can take for the slimes to feed on the monkeys and grow. Usually they just sit there doing nothing without feeding. It will still take a few minutes for a slime to split, and maybe longer depending on the RNG roll for how many points they accumulate that determines when they'll actually turn into adult slimes or otherwise split.
## How it was tested
Fed the slimes.
## Changelog
:cl:
 * tweak: Slimes will now become ravenous in the presence of monkeys, causing them to become hungry and thus try to eat anything they can reach (including the monkeys), which also allows the slimes to feed far sooner on the monkeys than they otherwise would.
 * tweak: Slimes can now store slightly more nutrition, meaning that they can develop into adult slimes and then split by eating two monkeys in a smaller form instead of having to eat a monkey in a smaller form and another monkey in a larger form.