### PR TITLE
Tweak to blacksmithing materials

### DIFF
--- a/code/modules/mining/materials.dm
+++ b/code/modules/mining/materials.dm
@@ -365,6 +365,9 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 				var/atom/movable/victim = pick(target,user)
 				if(victim)
 					do_teleport(victim, get_turf(victim), 1*source.quality, asoundin = 'sound/effects/phasein.ogg')
+		if(prob(20/source.quality))
+			to_chat(user, "<span class = 'warning'>\The [source] phases out of reality!</span>")
+			qdel(source)
 
 /datum/material/plastic
 	name="Plastic"

--- a/code/modules/mining/materials.dm
+++ b/code/modules/mining/materials.dm
@@ -268,9 +268,9 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 	sheettype=/obj/item/stack/sheet/mineral/gold
 	cointype=/obj/item/weapon/coin/gold
 	color = "#F7C430" //rgb: 247, 196, 48
-	brunt_damage_mod = 0.5
+	brunt_damage_mod = 0.9
 	sharpness_mod = 0.5
-	quality_mod = 1.7
+	quality_mod = 1.8
 	melt_temperature = MELTPOINT_GOLD
 	cc_per_sheet = CC_PER_SHEET_GOLD
 
@@ -282,8 +282,8 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 	sheettype=/obj/item/stack/sheet/mineral/silver
 	cointype=/obj/item/weapon/coin/silver
 	color = "#D0D0D0" //rgb: 208, 208, 208
-	brunt_damage_mod = 0.7
-	sharpness_mod = 0.7
+	brunt_damage_mod = 0.5
+	sharpness_mod = 1.5
 	quality_mod = 1.5
 	melt_temperature = MELTPOINT_SILVER
 	cc_per_sheet = CC_PER_SHEET_SILVER
@@ -366,9 +366,6 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 				var/atom/movable/victim = pick(target,user)
 				if(victim)
 					do_teleport(victim, get_turf(victim), 1*source.quality, asoundin = 'sound/effects/phasein.ogg')
-		if(prob(20/source.quality))
-			to_chat(user, "<span class = 'warning'>\The [source] phases out of reality!</span>")
-			qdel(source)
 
 /datum/material/plastic
 	name="Plastic"
@@ -457,8 +454,8 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 	color = "#FFEDD2" //rgb: 255,237,238
 	brunt_damage_mod = 1.4
 	sharpness_mod = 0.6
-	quality_mod = 1.5
-	armor_mod = 1.75
+	quality_mod = 3 //stupidly rare material (not to mention blacksmithing itself almost never happens)
+	armor_mod = 1.75 //if only armorsmithing were a thing
 	cc_per_sheet = CC_PER_SHEET_MYTHRIL
 
 /datum/material/telecrystal

--- a/code/modules/mining/materials.dm
+++ b/code/modules/mining/materials.dm
@@ -282,12 +282,11 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 	sheettype=/obj/item/stack/sheet/mineral/silver
 	cointype=/obj/item/weapon/coin/silver
 	color = "#D0D0D0" //rgb: 208, 208, 208
-	brunt_damage_mod = 0.5
-	sharpness_mod = 1.5
+	brunt_damage_mod = 0.2
+	sharpness_mod = 1.8
 	quality_mod = 1.5
 	melt_temperature = MELTPOINT_SILVER
 	cc_per_sheet = CC_PER_SHEET_SILVER
-
 
 /datum/material/uranium
 	name="Uranium"


### PR DESCRIPTION
## What this does
Changes the sharp, brunt and quality modifiers for a couple materials. These values are only used in blacksmithing.
## Why it's good
Makes some metals more desirable in certain circumstances than others. Silver being sharp but mediocre as a blunt object means you'd want a silver sword as a weapon, not a silver hammer.
We already have this with Uranium, as it has a very high brunt modifier but an extremely low sharp modifier, meaning uranium swords are dogshit while uranium hammers are king (as far as damage is concerned).
For example:
(Silver as of this PR, Uranium using the current value)
A Legendary Uranium Hammer would have 32 Force, while a Legendary Silver Hammer would barely get to 4 Force
A Legendary Uranium Sword would have 6 Force, while a Legendary Silver Sword would have a noteworthy 60 Force.
This means you want Uranium for your blunt weapons, and Silver for your Sharp ones, clearly delineating what material is best for what.
Plasma was untouched cause it works best as a generalist, good for blunt and sharp, but not the best at it, bananium is it's own thing. 
## How it was tested
It wasn't, but it's just a couple of number changes.
:cl:
 * tweak: Changes the sharp, brunt, and quality modifiers for a couple materials:
 * tweak: Gold brunt modifier goes from 0.5x to 0.9x, and quality modifier from 1.7x to 1.8x
 * tweak: Silver brunt modifier goes from 0.7x to 0.2x, and sharpness modifier from 0.7x to 1.8x
 * tweak: Mythril quality modifier goes from 1.5x to 3x, to account for it being so scarce and generally being outperformed by Phazon and Bananium.