### PR TITLE
moves labelling behavior to preattack so you can put labels on storage items and other silly things

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -485,8 +485,8 @@
 		return
 
 	if(istype(W, /obj/item/weapon/hand_labeler))
-		to_chat(usr, "<span class='notice'>You begin positioning the label on \the [src]...</span>")
-		if(do_after(user, src, 3 SECONDS))
+		var/obj/item/weapon/hand_labeler/L = W
+		if(L.mode)
 			return
 
 	if(!can_be_inserted(W))

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -484,6 +484,11 @@
 		to_chat(user, "<span class='notice'>You [(storage_locked)? "" : "un"]lock \the [src] with \the [stkey].</span>")
 		return
 
+	if(istype(W, /obj/item/weapon/hand_labeler))
+		to_chat(usr, "<span class='notice'>You begin positioning the label on \the [src]...</span>")
+		if(do_after(user, src, 3 SECONDS))
+			return
+
 	if(!can_be_inserted(W))
 		if(istype(W, /obj/item/weapon/glue))
 			return

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -14,6 +14,7 @@
 	if(mode) //There's very few cases where you'd want to label something and also follow normal attack behavior
 		afterattack(target, user, proximity_flag, click_parameters)
 		return 1
+	..()
 
 /obj/item/weapon/hand_labeler/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if (!proximity_flag)

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -10,6 +10,11 @@
 	var/chars_left = 250 //Like in an actual label maker, uses an amount per character rather than per label.
 	var/mode = 0	//off or on.
 
+/obj/item/weapon/hand_labeler/preattack(atom/target, mob/user, proximity_flag, click_parameters)
+	if(mode) //There's very few cases where you'd want to label something and also follow normal attack behavior
+		afterattack(target, user, proximity_flag, click_parameters)
+		return 1
+
 /obj/item/weapon/hand_labeler/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if (!proximity_flag)
 		return


### PR DESCRIPTION
labelling is now called in preattack
![labeler](https://github.com/user-attachments/assets/a9387651-3725-41a2-b813-e491c89c7650)
![shard](https://github.com/user-attachments/assets/0a3e6e50-1eb8-4a7a-97e5-2278c508e216)


### Changelog
:cl:
 * experiment: You can now use hand labelers on storage items like boxes and backpacks, among other things. If you notice something breaking with labelling, report it.
