### PR TITLE
Bookcases Burning

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -367,7 +367,7 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	if(check_fire_protection())
 		return 0
 
-	if(!istype(loc, /turf)) //worn or held items don't ignite (for now >:^) )
+	if(!isturf(loc)) //worn or held items don't ignite (for now >:^) )
 		return 0
 
 	if(!flammable)
@@ -389,8 +389,7 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	return 1
 
 /atom/movable/ignite()
-	..()
-	if(!firelightdummy)
+	if(..() && !firelightdummy)
 		firelightdummy = new (src)
 
 /atom/proc/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
@@ -607,15 +606,22 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	QDEL_NULL(firelightdummy)
 	qdel(src)
 
+
+/obj/effect/fire/burnSolidFuel()
+	return 0
+
+/obj/effect/fire/burnLiquidFuel()
+	return 0
+
 /obj/effect/fire/process()
 	if(timestopped)
 		return 0
 	. = 1
 
 	//Fires shouldn't spawn in areas or mobs, but it has happened...
-	if(istype(loc,/area) || istype(loc,/mob))
+	if(!istype(loc,/turf))
 		qdel(src)
-		CRASH("Fire was created at [loc] instead of a turf.")
+		CRASH("Fire was created at src->loc: [src]->[loc] instead of a turf.")
 
 	// Get location and check if it is in a proper ZAS zone.
 	var/turf/simulated/S = get_turf(loc)
@@ -648,14 +654,15 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	setfirelight(firelevel, air_contents.temperature)
 
 	//Burn mobs.
-	for(var/mob/living/carbon/human/M in loc)
+	for(var/mob/living/carbon/human/M in S)
 		if(M.mutations.Find(M_UNBURNABLE))
 			continue
 		M.FireBurn(firelevel, FLAME_TEMPERATURE_PLASTIC, air_contents.return_pressure())
 
 	//Burn items in the turf.
-	for(var/atom/A in loc)
-		A.fire_act(air_contents, air_contents.temperature, air_contents.return_volume())
+	for(var/atom/A in S)
+		if(A.loc == S)
+			A.fire_act(air_contents, air_contents.temperature, air_contents.return_volume())
 
 	//Burn the turf, too.
 	S.fire_act(air_contents, air_contents.temperature, air_contents.return_volume())
@@ -759,7 +766,7 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	var/solid_burn_products
 	var/liquid_burn_products
 	if(T)
-		if(T.flammable) //burn the turf
+		if(T.on_fire) //burn the turf
 			solid_burn_products = T.burnSolidFuel()
 			if(solid_burn_products)
 				combustion_energy += solid_burn_products["heat_out"]
@@ -767,7 +774,7 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 				combustion_co2_prod += solid_burn_products["co2_prod"]
 				max_temperature = max(max_temperature, solid_burn_products["max_temperature"])
 		for(var/atom/A in T)
-			if(A.flammable) //burn items on the turf
+			if(A.on_fire) //burn items on the turf
 				solid_burn_products = A.burnSolidFuel()
 				if(solid_burn_products)
 					combustion_energy += solid_burn_products["heat_out"]

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -75,11 +75,11 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 			if(W_CLASS_MEDIUM)
 				thermal_mass = 1.0
 			if(W_CLASS_LARGE)
-				thermal_mass = 10.0
+				thermal_mass = 5.0
 			if(W_CLASS_HUGE)
-				thermal_mass = 25.0 //combo breaker but 100kg is way too heavy
+				thermal_mass = 20.0
 			if(W_CLASS_GIANT)
-				thermal_mass = 100
+				thermal_mass = 50.0
 	if(thermal_mass)
 		initial_thermal_mass = thermal_mass
 	if(flammable)
@@ -425,11 +425,9 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 		return SUICIDE_ACT_BRUTELOSS
 
 /obj/ignite()
-	if(!isturf(loc)) //Prevent things from burning if worn, held, or inside something else. Storage containers will eject their contents when ignited, allowing for burning of the contents.
-		return
-	ash_covered = TRUE
-	remove_particles(PS_SMOKE)
-	return ..()
+	if(..())
+		ash_covered = TRUE
+		remove_particles(PS_SMOKE)
 
 /obj/item/checkburn()
 	if(!flammable)

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -44,6 +44,10 @@
 			I.forceMove(src)
 	update_icon()
 
+/obj/structure/bookcase/ignite()
+	..()
+	QDEL_NULL(firelightdummy) //prevent people from grabbing "fire" from the bookcase
+
 /obj/structure/bookcase/proc/healthcheck()
 
 	if(health <= 0)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
A few small fire fixes:
- Halved table and chair fire fuel so that they will actually burn up before a room runs out of oxygen.
- Prevented firelightdummies from spawning in bookcases so players won't be able to try and grab "fire" out of a burning bookcase.
- Small tweaks to ensure fires do not spawn anywhere other than on a simulated turf.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Bugs are bad.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Tested burning the bar before and after the fire fuel changes and confirmed tables and chairs burn out quicker.
Tested burning bookcases with and without books and attempting to grab books from them. Confirmed books inside bookcases are not on fire while in the bookcase.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: You can no longer grab "fire" out of a burning bookcase.
 * tweak: Wooden tables and chairs will now burn twice as fast.