### PR TITLE
lich hardsuit uses the correct helmet

### DIFF
--- a/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
+++ b/code/modules/clothing/spacesuits/rig_subtypes/rig_subtypes.dm
@@ -250,6 +250,7 @@
 	item_state = "lichking_armour"
 	species_restricted = list(UNDEAD_SHAPED)
 	body_parts_covered = ARMS|LEGS|FULL_TORSO|HANDS
+	head_type=/obj/item/clothing/head/helmet/space/rig/wizard/lich_king
 
 //Medical Rig
 /obj/item/clothing/head/helmet/space/rig/medical


### PR DESCRIPTION
[bugfix]

## What this does
makes the lich hardsuit use the correct helmet
![Capture](https://github.com/user-attachments/assets/018be276-de53-41d8-973b-aa405bb1b3f1)


## Why it's good
fixes oversight

## How it was tested
tried suit on, correct helmet had.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: The lich hardsuit will now use the correct helmet