### PR TITLE
Circular Saws can Chop Trees

### DIFF
--- a/code/game/objects/structures/flora/flora.dm
+++ b/code/game/objects/structures/flora/flora.dm
@@ -165,7 +165,7 @@
 /obj/structure/flora/tree/attackby(obj/item/W, mob/living/user)
 	..()
 
-	if(istype(W, /obj/item/weapon))
+	if(istype(W, /obj/item))
 		if(W.sharpness_flags & (CHOPWOOD|SERRATED_BLADE))
 			health -= (user.get_strength() * W.force)
 			playsound(loc, 'sound/effects/woodcuttingshort.ogg', 50, 1)


### PR DESCRIPTION
# The Medical Buff We All Deserve

## What this does
This changes one line so that any object, not just weapons, can cut down trees if they have the proper flags (CHOPWOOD or SERRATED_EDGE). In practice, this permits the circular saw, plasma saw, and switchtool with saw to cut down trees. Great timing for Grugstation!

## Why it's good
Saw go brrrrr.

## How it was tested
![image](https://github.com/user-attachments/assets/5361e915-b54e-4247-a0e4-bd94ec26ca13)
CHOP, CHOP CHOP, CHOP!

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Circular saws and variants can chop down trees.
