### PR TITLE
Friendly Carp Ranching Fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -213,6 +213,8 @@
 /mob/living/simple_animal/hostile/carp/friendly
 	desc = "A denizen of deep space. This one seems somewhat docile."
 	var/angry = FALSE
+	species_type = /mob/living/simple_animal/hostile/carp/friendly
+	childtype = /mob/living/simple_animal/hostile/carp/baby/friendly
 
 /mob/living/simple_animal/hostile/carp/friendly/CanAttack(var/atom/the_target)
 	if(angry)
@@ -226,6 +228,8 @@
 /mob/living/simple_animal/hostile/carp/baby/friendly
 	desc = "A baby space carp. This one seems somewhat docile docile."
 	var/angry = FALSE
+	species_type = /mob/living/simple_animal/hostile/carp/friendly
+	childtype = /mob/living/simple_animal/hostile/carp/baby/friendly
 
 /mob/living/simple_animal/hostile/carp/baby/friendly/CanAttack(var/atom/the_target)
 	if(angry)


### PR DESCRIPTION
# Fish Ranchers Rejoice

## What this does
Grugstation is coming, and friendly fish are on the menu. Unfortunately, breeding them resulted in hostile baby fish. And friendly baby fish that grew up became hostile adults. This PR fixes these issues.

## Why it's good
Considering that the ranchers won't get to panic while running around as their seemingly domesticiated fish go feral on them anymore, it isn't.

## How it was tested
For speed purposes, I called the procs directly instead of manually breeding.
![image](https://github.com/user-attachments/assets/e61d1f69-d6eb-40fa-bc18-dff726645052)
![image](https://github.com/user-attachments/assets/335aa6d9-f8d1-40b3-a4d8-0497a47e4e15)
And calling grow_up on the baby resulted in...
![image](https://github.com/user-attachments/assets/e70629d9-ef2b-480e-a3e5-0b048cc7ba26)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Friendly carp ranching will no longer result in hostile carp.
