### PR TITLE
Wooden Wall Chopping Nerfs

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -640,8 +640,8 @@
   * * mob/user - the user who will see the progress bar
   * * atom/target - the atom the progress bar will be attached to
   * * delay - duration in deciseconds of the delay
-  * * numticks - how many times the failure conditions will be checked throughout the duration
-  * * needhand - if TRUE, the item in the hands of the user needs to stay the same throughout the duration
+  * * numticks - how many times the failure conditions will be checked throughout the duration. default 10
+  * * needhand - if TRUE, the item in the hands of the user needs to stay the same throughout the duration.
   * * use_user_turf - if TRUE, the turf of the user is checked instead of its location
   * * custom_checks - if specified, the return value of this callback (called every `delay/numticks` seconds) will determine whether the action succeeded
   */

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -641,7 +641,7 @@
   * * atom/target - the atom the progress bar will be attached to
   * * delay - duration in deciseconds of the delay
   * * numticks - how many times the failure conditions will be checked throughout the duration. default 10
-  * * needhand - if TRUE, the item in the hands of the user needs to stay the same throughout the duration.
+  * * needhand - if TRUE, the item in the hands of the user needs to stay the same throughout the duration
   * * use_user_turf - if TRUE, the turf of the user is checked instead of its location
   * * custom_checks - if specified, the return value of this callback (called every `delay/numticks` seconds) will determine whether the action succeeded
   */

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -79,6 +79,7 @@
 	attack_verb = list("attacks", "chops", "cleaves", "tears", "cuts")
 	flags = FPRINT | TWOHANDABLE | SLOWDOWN_WHEN_CARRIED
 	slowdown = FIREAXE_SLOWDOWN
+	toolsounds = list('sound/effects/woodcuttingshort.ogg')
 
 	var/list/forbidden_floors = list(
 		/turf/simulated/floor/vault,

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -46,7 +46,6 @@
 			W.playtoolsound(src, 100)
 			new material(get_turf(src), 2)
 			qdel(src)
-		return
 	else
 		..()
 

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -37,7 +37,10 @@
 				"<span class='notice'>You start chopping at \the [src] with \the [W].</span>", \
 				"<span class='warning'>You hear the sound of wood being cut.</span>")
 		W.playtoolsound(src, 100)
-		if(do_after(user, src, 50))
+		var/choptime = 50
+		if(istype(W, /obj/item/weapon/fireaxe))
+			choptime = 10
+		if(do_after(user, src, choptime))
 			user.visible_message("<span class='warning'>[user] smashes through \the [src] with \the [W].</span>", \
 						"<span class='notice'>You smash through \the [src].</span>")
 			W.playtoolsound(src, 100)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -33,13 +33,17 @@
 
 /obj/structure/girder/wood/attackby(var/obj/item/W, var/mob/user)
 	if(W.sharpness_flags & CHOPWOOD)
-		playsound(src, 'sound/effects/woodcuttingshort.ogg', 50, 1)
-		user.visible_message("<span class='warning'>[user] smashes through \the [src] with \the [W].</span>", \
-							"<span class='notice'>You smash through \the [src].</span>",\
-							"<span class='warning'>You hear the sound of wood being cut</span>"
-							)
-		qdel(src)
-		new material(get_turf(src), 2)
+		user.visible_message("<span class='notice'>[user] starts chopping at \the [src] with \the [W].</span>", \
+				"<span class='notice'>You start chopping at \the [src] with \the [W].</span>", \
+				"<span class='warning'>You hear the sound of wood being cut.</span>")
+		W.playtoolsound(src, 100)
+		if(do_after(user, src, 50))
+			user.visible_message("<span class='warning'>[user] smashes through \the [src] with \the [W].</span>", \
+						"<span class='notice'>You smash through \the [src].</span>")
+			W.playtoolsound(src, 100)
+			new material(get_turf(src), 2)
+			qdel(src)
+		return
 	else
 		..()
 

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -29,7 +29,6 @@
 						"<span class='notice'>You smash through \the [src].</span>")
 			W.playtoolsound(src, 100)
 			dismantle_wall()
-		return
 	else
 		..()
 

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -17,12 +17,16 @@
 
 /turf/simulated/wall/mineral/wood/attackby(var/obj/item/W, var/mob/user)
 	if(W.sharpness_flags & CHOPWOOD)
-		playsound(src, 'sound/effects/woodcuttingshort.ogg', 50, 1)
-		user.visible_message("<span class='warning'>[user] smashes through \the [src] with \the [W].</span>", \
-							"<span class='notice'>You smash through \the [src].</span>",\
-							"<span class='warning'>You hear the sound of wood being cut</span>"
-							)
-		dismantle_wall()
+		user.visible_message("<span class='notice'>[user] starts chopping at \the [src] with \the [W].</span>", \
+				"<span class='notice'>You start chopping at \the [src] with \the [W].</span>", \
+				"<span class='warning'>You hear the sound of wood being cut.</span>")
+		W.playtoolsound(src, 100)
+		if(do_after(user, src, 50))
+			user.visible_message("<span class='warning'>[user] smashes through \the [src] with \the [W].</span>", \
+						"<span class='notice'>You smash through \the [src].</span>")
+			W.playtoolsound(src, 100)
+			dismantle_wall()
+		return
 	else
 		..()
 

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -21,7 +21,10 @@
 				"<span class='notice'>You start chopping at \the [src] with \the [W].</span>", \
 				"<span class='warning'>You hear the sound of wood being cut.</span>")
 		W.playtoolsound(src, 100)
-		if(do_after(user, src, 50))
+		var/choptime = 50
+		if(istype(W, /obj/item/weapon/fireaxe))
+			choptime = 10
+		if(do_after(user, src, choptime))
 			user.visible_message("<span class='warning'>[user] smashes through \the [src] with \the [W].</span>", \
 						"<span class='notice'>You smash through \the [src].</span>")
 			W.playtoolsound(src, 100)

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -291,6 +291,7 @@
 	origin_tech = Tc_MATERIALS + "=2;" + Tc_COMBAT + "=1"
 	attack_verb = list("chops", "tears", "cuts")
 	surgerysound = 'sound/items/hatchetsurgery.ogg'
+	toolsounds = list('sound/effects/woodcuttingshort.ogg')
 
 /obj/item/weapon/hatchet/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	playsound(loc, 'sound/weapons/bladeslice.ogg', 50, 1, -1)


### PR DESCRIPTION
# No Instant Venting of Grugstation

## What this does
This adds a do_after for cutting down wood walls and girders. Currently, the walls just get instantly removed. Now, it takes a short amount of time. It also moves the sound effect for chopping into the hatchet/tool used.

By special request, fireaxes take less time, but not instant.

## Why it's good
Because you can no longer instantly vent Grugstation, it's not.

## How it was tested
![image](https://github.com/user-attachments/assets/7a7e0ed2-c4ee-4c72-9179-d13ab20a6d62)
Chop, chop chop, chop!!

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Wooden walls and girders now take time to chop down (5 seconds). Fireaxes are faster (1 second).
