### PR TITLE
Tool Sound Fixes/Backup Sounds for Tools/Surgery

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1731,13 +1731,30 @@ var/global/objects_thrown_when_explode = FALSE
 				perp.infect_disease2(D, notes="(Blood, from picking up \a [src])")
 
 /obj/item/proc/playtoolsound(atom/A, var/volume = 75, vary = TRUE, extrarange = null)
-	if(A && toolsounds)
-		var/tool_sound = pick(toolsounds)
-		playsound(A, tool_sound, volume, TRUE, vary)
+	if(!A)
+		return
+	var/tool_sound
+	if(toolsounds)
+		tool_sound = pick(toolsounds)
+	else if(surgerysound)
+		tool_sound = surgerysound
+	else if(hitsound)
+		tool_sound = hitsound
+	if(tool_sound)
+		playsound(A, tool_sound, volume, vary, extrarange)
 
 /obj/item/proc/playsurgerysound(atom/A, var/volume = 75)
-	if(A && surgerysound)
-		playsound(A, surgerysound, volume, vary = TRUE)
+	if(!A)
+		return
+	var/tool_sound
+	if(surgerysound)
+		tool_sound = surgerysound
+	else if(toolsounds)
+		tool_sound = pick(toolsounds)
+	else if(hitsound)
+		tool_sound = hitsound
+	if(tool_sound)
+		playsound(A, tool_sound, volume, vary = TRUE)
 
 /obj/item/proc/NoiseDampening()	// checked on headwear by flashbangs
 	return FALSE


### PR DESCRIPTION
# Sound Bugfixes and Backups

## What this does
This PR fixes a strange bug where applying restraints can be heard from far further away than intended. Because of a bug in the ordering of arguments, extrarange was never used when calling playtoolsound.

Additionally, this PR adds checks for backup sounds when using tools/surgery tools when they are lacking sounds. They will first attempt to check the proper sound source (tool for tool use, surgery for surgery use), then attempt to check the other, and finally try their generic on-hit noise. If all of these fail, only then will no sound be played.

## Why it's good
Can't hear grenades being made across the whole screen. And, sounds play more often when using unusual tools.

## How it was tested
Only basic testing with random tools on random objects.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixes certain sounds from being heard from further away than intended.
 * tweak: Tools/surgery tools without sounds will attempt to play other possibly related sounds before giving up.