### PR TITLE
The Emphasis Update

### DIFF
--- a/code/datums/chat_message.dm
+++ b/code/datums/chat_message.dm
@@ -114,6 +114,8 @@ var/runechat_icon = null
 		if(word)
 			text = replacetext(text, word, "<b>[word]</b>")
 
+	text = check_emphasis(text)
+
 	// Append radio icon if comes from a radio
 	if (extra_classes.Find("spoken_into_radio"))
 		if (!runechat_icon)

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -38,7 +38,7 @@
 			return
 
 	say_testing(src, "/mob/dead/observer/Hear(): source=[source], frequency=[speech.frequency], source_turf=[formatJumpTo(source_turf)]")
-
+	rendered_speech = check_emphasis(rendered_speech)
 	if (get_dist(source_turf, src) <= get_view_range())
 		rendered_speech = "<B>[rendered_speech]</B>"
 		if (client?.prefs.mob_chat_on_map && (client.prefs.obj_chat_on_map || ismob(speech.speaker)))

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -333,14 +333,6 @@ var/list/headset_modes = list(
 		show_message(rendered_message, type, deaf_message, deaf_type, src)
 	return rendered_message
 
-/proc/check_emphasis(text)
-	var/regex/italics = regex("\\~(.*?)\\~","g")
-	text = italics.Replace(text, "<i>$1</i>")
-
-	var/regex/bold = regex("\\*(.*?)\\*","g")
-	text = bold.Replace(text, "<b>$1</b>")
-
-	return text
 
 /mob/living/proc/hear_radio_only()
 	return 0

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -304,6 +304,12 @@ var/list/headset_modes = list(
 		for(var/T in syndicate_code_response)
 			rendered_message = replacetext(rendered_message, html_encode(T), "<i style='color: red;'>[html_encode(T)]</i>")
 
+	var/regex/tilde = regex("\\~(.*?)\\~","g")
+	rendered_message = tilde.Replace(rendered_message, "<i>$1</i>")
+
+	var/regex/asterisk = regex("\\*(.*?)\\*","g")
+	rendered_message = asterisk.Replace(rendered_message, "<b>$1</b>")
+	
 	//AI mentions
 	if(isAI(src) && speech.frequency && !findtextEx(speech.job,"AI") && (speech.name != name))
 		var/mob/living/silicon/ai/ai = src

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -304,11 +304,11 @@ var/list/headset_modes = list(
 		for(var/T in syndicate_code_response)
 			rendered_message = replacetext(rendered_message, html_encode(T), "<i style='color: red;'>[html_encode(T)]</i>")
 
-	var/regex/tilde = regex("\\~(.*?)\\~","g")
-	rendered_message = tilde.Replace(rendered_message, "<i>$1</i>")
+	var/regex/italics_tilde = regex("\\~(.*?)\\~","g")
+	rendered_message = italics_tilde.Replace(rendered_message, "<i>$1</i>")
 
-	var/regex/asterisk = regex("\\*(.*?)\\*","g")
-	rendered_message = asterisk.Replace(rendered_message, "<b>$1</b>")
+	var/regex/bold_asterisk = regex("\\*(.*?)\\*","g")
+	rendered_message = bold_asterisk.Replace(rendered_message, "<b>$1</b>")
 	
 	//AI mentions
 	if(isAI(src) && speech.frequency && !findtextEx(speech.job,"AI") && (speech.name != name))

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -304,11 +304,7 @@ var/list/headset_modes = list(
 		for(var/T in syndicate_code_response)
 			rendered_message = replacetext(rendered_message, html_encode(T), "<i style='color: red;'>[html_encode(T)]</i>")
 
-	var/regex/italics_tilde = regex("\\~(.*?)\\~","g")
-	rendered_message = italics_tilde.Replace(rendered_message, "<i>$1</i>")
-
-	var/regex/bold_asterisk = regex("\\*(.*?)\\*","g")
-	rendered_message = bold_asterisk.Replace(rendered_message, "<b>$1</b>")
+	rendered_message = check_emphasis(rendered_message)
 	
 	//AI mentions
 	if(isAI(src) && speech.frequency && !findtextEx(speech.job,"AI") && (speech.name != name))
@@ -336,6 +332,15 @@ var/list/headset_modes = list(
 	else if (istype(speech.speaker, /obj/item/device/assembly/speaker) || istype(speech.speaker, /obj/item/device/assembly_frame)) //Speakers will still work if no_goonchat_for_obj is set to TRUE
 		show_message(rendered_message, type, deaf_message, deaf_type, src)
 	return rendered_message
+
+/proc/check_emphasis(text)
+	var/regex/italics = regex("\\~(.*?)\\~","g")
+	text = italics.Replace(text, "<i>$1</i>")
+
+	var/regex/bold = regex("\\*(.*?)\\*","g")
+	text = bold.Replace(text, "<b>$1</b>")
+
+	return text
 
 /mob/living/proc/hear_radio_only()
 	return 0

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -2236,5 +2236,15 @@ Use this proc preferably at the end of an equipment loadout
 		spawn()
 			src.update_music()
 
+/proc/check_emphasis(text)
+	var/regex/italics = regex("\\_(.*?)\\_","g")
+	text = italics.Replace(text, "<i>$1</i>")
+
+	var/regex/bold = regex("\\|(.*?)\\|","g")
+	text = bold.Replace(text, "<b>$1</b>")
+
+	return text
+
+
 #undef MOB_SPACEDRUGS_HALLUCINATING
 #undef MOB_MINDBREAKER_HALLUCINATING


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
As it says on the tin, adds emphasis: | text | for **bold** text, _ text _ for _italics_. I got it to work with runechat! These symbols should work fine. I've decided to not use asterisks since it wouldn't work well with emotes.
I'm going to see if I can make asterisks work.
TO DO:

- [x] Make it work with runechat 
- [ ] Find the right symbols to use - I need a new character I can't use _ AAAAAAAAAUGH
- [x] Make it work with dead mobs too

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
I think more flavor options are good.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->

![spess](https://github.com/user-attachments/assets/c1956e47-6001-4372-8d27-d51820716ee5)
Runechat works as well. I spawned in as a character and tried all the combinations. I also joined on a guest account to see if ghosts see the rendered text. Everything should work as expected.


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added emphasis! | text | for bold text, _ text _ for italics.

