### PR TITLE
RPD list icons

### DIFF
--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -110,7 +110,8 @@
 			if(!T || ((C.flags & RCD_Z_DOWN) && !HasBelow(T.z)) || ((C.flags & RCD_Z_UP) && !HasAbove(T.z)))
 				continue
 			dat += C.schematic_list_line(interface,FALSE,src.selected==C)
-
+			for(var/client/client in interface.clients)
+				C.send_list_assets(client)
 		dat += "</ul>"
 
 	interface.updateLayout(dat)
@@ -256,7 +257,6 @@
 	if(selected)
 		for(var/client/client in interface.clients)
 			selected.send_assets(client)
-
 		interface.updateContent("schematic_options", selected.get_HTML(args))
 	else
 		interface.updateContent("schematic_options", " ")

--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -104,6 +104,15 @@
 
 	modifiers -= list("alt", "shift", "ctrl")
 
+/obj/item/device/rcd/rpd/attack_self(var/mob/user)
+	..()
+	for(var/cat in schematics)
+		var/list/L = schematics[cat]
+		for(var/datum/rcd_schematic/C in L)
+			for(var/client/client in interface.clients)
+				//world.log <<"THIS BETTER WORK"
+				C.send_list_assets(client)
+	
 
 /obj/item/device/rcd/rpd/rebuild_ui()
 	var/dat = ""
@@ -129,11 +138,13 @@
 		dat += "<b>[cat]:</b><ul style='list-style-type:disc'>"
 		var/list/L = schematics[cat]
 		for(var/datum/rcd_schematic/C in L)
+			for(var/client/client in interface.clients)
+				//world.log <<"what the fuck is going on?"
+				C.send_list_assets(client)
 			var/turf/T = get_turf(src)
 			if(!T || ((C.flags & RCD_Z_DOWN) && !HasBelow(T.z)) || ((C.flags & RCD_Z_UP) && !HasAbove(T.z)))
 				continue
 			dat += C.schematic_list_line(interface,FALSE,src.selected==C)
-
 		dat += "</ul>"
 
 	interface.updateLayout(dat)

--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -110,7 +110,6 @@
 		var/list/L = schematics[cat]
 		for(var/datum/rcd_schematic/C in L)
 			for(var/client/client in interface.clients)
-				//world.log <<"THIS BETTER WORK"
 				C.send_list_assets(client)
 	
 
@@ -139,7 +138,6 @@
 		var/list/L = schematics[cat]
 		for(var/datum/rcd_schematic/C in L)
 			for(var/client/client in interface.clients)
-				//world.log <<"what the fuck is going on?"
 				C.send_list_assets(client)
 			var/turf/T = get_turf(src)
 			if(!T || ((C.flags & RCD_Z_DOWN) && !HasBelow(T.z)) || ((C.flags & RCD_Z_UP) && !HasAbove(T.z)))

--- a/code/modules/RCD/schematic.dm
+++ b/code/modules/RCD/schematic.dm
@@ -107,7 +107,7 @@ params:
 /datum/rcd_schematic/proc/build_ui()
 	master.interface.updateLayout("<div id='schematic_options'> </div>")
 
-datum/rcd_schematic/proc/send_list_assets(var/client/client) //this is called when opening the menu to make sure the listed options have their icons.
+/datum/rcd_schematic/proc/send_list_assets(var/client/client) //this is called when opening the menu to make sure the listed options have their icons.
 	return //registering happens on the same proc unlike send_assets, since this is more specialized.
 
 /datum/rcd_schematic/proc/schematic_list_line(var/datum/html_interface/interface, var/fav=FALSE,var/selected=FALSE)

--- a/code/modules/RCD/schematic.dm
+++ b/code/modules/RCD/schematic.dm
@@ -10,6 +10,7 @@
 	var/list/overlays		= list()
 	var/obj/abstract/screen/schematics/ourobj
 	var/datum/selection_schematic/selected
+	var/list_icon=null //the icon that is displayed next to the name on the list.
 
 /datum/rcd_schematic/New(var/obj/item/device/rcd/n_master)
 	master = n_master
@@ -106,9 +107,13 @@ params:
 /datum/rcd_schematic/proc/build_ui()
 	master.interface.updateLayout("<div id='schematic_options'> </div>")
 
+datum/rcd_schematic/proc/send_list_assets(var/client/client) //this is called when opening the menu to make sure the listed options have their icons.
+	return //registering happens on the same proc unlike send_assets, since this is more specialized.
+
 /datum/rcd_schematic/proc/schematic_list_line(var/datum/html_interface/interface, var/fav=FALSE,var/selected=FALSE)
 	var/fav_html
 	var/class="'schem'"
+	var/image_html=""
 	// Important distinction: being favorited vs being rendered for the favorited list.
 	// The fav parameter means the latter.
 	if (master.favorites.Find(src))
@@ -124,7 +129,9 @@ params:
 
 	if (selected)
 		class="'schem_selected'"
-
-	return "<table class=[class]><tr>[fav_html]<td><a href='?src=\ref[interface];schematic=\ref[src];act=select' >[name]</a><td><tr></table>"
+	if (list_icon)
+		image_html="<img id='list_icon' src='[list_icon]'></img>"
+		
+	return "<table class=[class]><tr>[fav_html]<td><a href='?src=\ref[interface];schematic=\ref[src];act=select' >[image_html][name]</a><td><tr></table>"
 
 /datum/rcd_schematic/proc/MouseWheeled(var/mob/user, var/delta_x, var/delta_y, var/params)

--- a/code/modules/RCD/schematics/pipe.dm
+++ b/code/modules/RCD/schematics/pipe.dm
@@ -40,6 +40,12 @@
 
 	AM.investigation_log(I_RCD,"was deconstructed by [user]")
 
+
+/datum/rcd_schematic/decon_pipes/send_list_assets(var/client/client)
+	register_asset("RPD_ICON_[name].png", new/icon('icons/effects/condecon.dmi', "decon" ))
+	send_asset(client, "RPD_ICON_[name].png")
+	list_icon="RPD_ICON_[name].png"
+
 /datum/rcd_schematic/paint_pipes
 	name     = "Paint pipes"
 	category = "Utilities"
@@ -162,6 +168,11 @@
 		master.update_options_menu()
 	return 1
 
+/datum/rcd_schematic/paint_pipes/send_list_assets(var/client/client)
+	register_asset("RPD_ICON_[name].png", new/icon('icons/obj/painting_items.dmi', "paint_roller" ))
+	send_asset(client, "RPD_ICON_[name].png")
+	list_icon="RPD_ICON_[name].png"
+
 //METERS AND SENSORS.
 
 /datum/rcd_schematic/gsensor
@@ -181,6 +192,13 @@
 	playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
 	new /obj/item/pipe_gsensor(A, frequency, id)
 
+
+/datum/rcd_schematic/gsensor/send_list_assets(var/client/client)
+	register_asset("RPD_ICON_[name].png", new/icon('icons/obj/stationobjs.dmi', "gsensor0" ))
+	send_asset(client, "RPD_ICON_[name].png")
+	list_icon="RPD_ICON_[name].png"
+
+
 /datum/rcd_schematic/pmeter
 	name     = "Pipe meter"
 	category = "Devices"
@@ -198,6 +216,12 @@
 	playsound(master, 'sound/items/Deconstruct.ogg', 50, 1)
 	new /obj/item/pipe_meter(A, frequency, id)
 
+
+/datum/rcd_schematic/pmeter/send_list_assets(var/client/client)
+	register_asset("RPD_ICON_[name].png", new/icon('icons/obj/pipe-item.dmi', "meter" ))
+	send_asset(client, "RPD_ICON_[name].png")
+	list_icon="RPD_ICON_[name].png"
+
 //ACTUAL PIPES.
 
 /datum/rcd_schematic/pipe
@@ -209,6 +233,9 @@
 	var/pipe_type    = PIPE_BINARY
 	var/selected_dir = NORTH
 	var/layer        = PIPING_LAYER_DEFAULT //Layer selected, at 0, no layer picker will be available (disposals).
+	list_icon="RPD_ICON_0.png" //i would like to have placed this in the schematic_list_line proc, but it won't render.
+	//pipe_id constants are defined in /code/ATMOSPHERICS/pipe/construction.dm, by the way.
+	//"do NOT hardcode these, use the defines" - unfortunately we don't have the luxury because you can only do constant statements in defines.
 
 /datum/rcd_schematic/pipe/New(var/obj/item/device/rcd/n_master)
 	. = ..()
@@ -476,6 +503,14 @@
 
 	return ..()
 
+/datum/rcd_schematic/pipe/send_list_assets(var/client/client)
+	var/list/dirs=get_dirs()
+	if(!dirs || dirs.len==0)
+		return ..() //if there's no dirs, we can't really display that, now can we?
+	register_asset("RPD_ICON_[pipe_id].png", new/icon('icons/obj/pipe-item.dmi', pipeID2State[pipe_id + 1], dirs[2]))
+	send_asset(client, "RPD_ICON_[pipe_id].png") // [pipe_id]
+	list_icon="RPD_ICON_[pipe_id].png"
+
 //Disposal piping.
 /datum/rcd_schematic/pipe/disposal
 	category      = "Disposal Pipes"
@@ -483,6 +518,16 @@
 	layer         = 0 // Set to 0 to disable layer selection.
 	pipe_id       = DISP_PIPE_STRAIGHT
 	var/actual_id = 0 // This is needed because disposals construction code is a shit.
+
+
+/datum/rcd_schematic/pipe/disposal/send_list_assets(var/client/client)
+	var/list/dirs=get_dirs()
+	if(!dirs || dirs.len==0)
+		return ..()
+	register_asset("RPD_ICON_D_[pipe_id].png", new/icon('icons/obj/pipes/disposal.dmi', disposalpipeID2State[pipe_id + 1], dirs[2]))
+	send_asset(client, "RPD_ICON_D_[pipe_id].png")
+	list_icon="RPD_ICON_D_[pipe_id].png"
+
 
 /datum/rcd_schematic/pipe/disposal/register_icon(var/dir)
 	register_asset("RPD_D_[pipe_id]_[dir].png", new/icon('icons/obj/pipes/disposal.dmi', disposalpipeID2State[pipe_id + 1], dir))
@@ -630,6 +675,14 @@ var/global/list/disposalpipeID2State = list(
 
 	pipe_id		= PIPE_LAYER_ADAPTER
 	pipe_type	= PIPE_UNARY
+
+/datum/rcd_schematic/pipe/layer_adapter/send_list_assets(var/client/client)
+	var/list/dirs=get_dirs()
+	if(!dirs || dirs.len==0)
+		return ..()
+	register_asset("RPD_ICON_[pipe_id].png", new/icon('icons/obj/atmospherics/pipe_adapter.dmi', "adapter_5", dirs[2]))
+	send_asset(client, "RPD_ICON_[pipe_id].png")
+	list_icon="RPD_ICON_[pipe_id].png"
 
 /datum/rcd_schematic/pipe/layer_adapter/register_icon(var/dir)
 	for(var/layer = PIPING_LAYER_MIN to PIPING_LAYER_MAX)
@@ -859,6 +912,11 @@ var/global/list/disposalpipeID2State = list(
 	pipe_id		= DISP_END_BIN
 	actual_id	= 6
 	pipe_type	= PIPE_NONE //Will disable the icon.
+
+/datum/rcd_schematic/pipe/disposal/bin/send_list_assets(var/client/client)
+	register_asset("RPD_ICON_D_[pipe_id].png", new/icon('icons/obj/pipes/disposal.dmi', "condisposal"))
+	send_asset(client, "RPD_ICON_D_[pipe_id].png")
+	list_icon="RPD_ICON_D_[pipe_id].png"
 
 /datum/rcd_schematic/pipe/disposal/outlet
 	name		= "Outlet"

--- a/code/modules/html_interface/RCD/RCD.css
+++ b/code/modules/html_interface/RCD/RCD.css
@@ -199,4 +199,10 @@ left:160px;
 	font-weight:bold;
 }
 
-
+#list_icon{
+	background-color:rgba(0,0,0,0);
+	color:rgba(0,0,0,0);
+	border:none;
+	height:1em;
+	image-rendering:pixelated;
+}


### PR DESCRIPTION
[qol] [ui]

## What this does
adds icons next to pipes
also closes #35273
**notice: the menu has to be opened a second time for the icons to show because image loading is hard**

https://github.com/user-attachments/assets/ed1d4807-07bf-4e46-9390-052cb17ec03c


## Why it's good
easier recognition of items in the list, lets newer engis know what things are at a glance

## How it was tested
opened RPD menu, looked at icons.

## Changelog
:cl:
 * rscadd: The RPD will now display icons next to the names of pipes (you may have to re-open the menu to see them)
