### PR TITLE
Allows Admins to Toggle Dexterity for Monkeys and Brain Damaged Humans

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1769,7 +1769,7 @@ var/datum/record_organ //This is just a dummy proc, not storing any variables he
 		if(!G.dexterity_check())//some gloves might make it harder to interact with complex technologies, or fit your index in a gun's trigger
 			return FALSE
 	if(getBrainLoss() >= 60)
-		if(!reagents.has_reagent(METHYLIN))//methylin supercedes brain damage, but not uncomfortable gloves
+		if(!(reagents.has_reagent(METHYLIN) ||  is_dexterous))//methylin and the is_dextrous var supercede brain damage, but not uncomfortable gloves
 			return FALSE
 	return TRUE//humans are dexterous enough by default
 

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -461,6 +461,8 @@
 		return TRUE
 	if(reagents.has_reagent(METHYLIN))
 		return TRUE
+	if(is_dexterous)
+		return TRUE
 	return FALSE//monkeys can't use complex things by default unless they're high on methylin
 
 /mob/living/carbon/monkey/reset_layer()

--- a/code/modules/mob/living/carbon/monkey/vox.dm
+++ b/code/modules/mob/living/carbon/monkey/vox.dm
@@ -74,7 +74,7 @@
 		..()
 
 /mob/living/carbon/monkey/vox/put_in_hand_check(var/obj/item/W) //Silly chicken, you don't have hands
-	if(src.reagents.has_reagent(GRAVY) || src.reagents.has_reagent(METHYLIN))
+	if(src.reagents.has_reagent(GRAVY) || src.reagents.has_reagent(METHYLIN) || (is_dexterous))
 		return 1
 	else
 		return 0

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -295,3 +295,5 @@
 	var/list/crit_rampup = list() // Of the form timestamp/damage
 
 	var/list/huds = list() // List of active huds on a mob
+
+	var/is_dexterous = FALSE //surely this won't make everyone undexterous

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -296,4 +296,4 @@
 
 	var/list/huds = list() // List of active huds on a mob
 
-	var/is_dexterous = FALSE //surely this won't make everyone undexterous
+	var/is_dexterous = FALSE //allows mobs to be made dextrous, mostly for monkeys


### PR DESCRIPTION
## What this does
This adds a dexterity variable that can be toggled on any mob that mimics most of the effects of methylin on monkeys, allowing them to permanently use machines, fire weaponry, understand galcom. Technically this can be toggled on any mob, though simple mobs are still unable to use machinery for whatever reason. This also allows highly brain damaged humans to use machinery and weaponry.

## Why it's good
Methylin has an OD that causes toxin and brain damage, this gives admins an option to permanently give someone the effects without any further maintenance.

## How it was tested
Made sure this didn't prevent humans from using machinery, made sure everything functioned as intended on monkeys, chickens, and flaming skulls. Skulls can use machinery, but the lack of hands means they can't do much with most of them.

## Changelog
:cl:
 * rscadd: Added the is_dexterous variable to mob.dmi that mimics most of the effects of methylin.