### PR TITLE
Phazon weapons will now blink themselves to a random tile nearby instead of deleting themselves.

### DIFF
--- a/code/modules/mining/materials.dm
+++ b/code/modules/mining/materials.dm
@@ -365,9 +365,6 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 				var/atom/movable/victim = pick(target,user)
 				if(victim)
 					do_teleport(victim, get_turf(victim), 1*source.quality, asoundin = 'sound/effects/phasein.ogg')
-		if(prob(20/source.quality))
-			to_chat(user, "<span class = 'warning'>\The [source] phases out of reality!</span>")
-			qdel(source)
 
 /datum/material/plastic
 	name="Plastic"

--- a/code/modules/mining/materials.dm
+++ b/code/modules/mining/materials.dm
@@ -365,6 +365,9 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 				var/atom/movable/victim = pick(target,user)
 				if(victim)
 					do_teleport(victim, get_turf(victim), 1*source.quality, asoundin = 'sound/effects/phasein.ogg')
+		if(prob(20/source.quality)
+			to_chat(user, "<span class = 'warning'>\The [source] teleports away!</span>")
+			do_teleport(source, get_turf(source), 1.45*source.quality, asoundin = 'sound/effects/phasein.ogg') //teleports to a random tile within up to 13 tiles of itself, based on quality
 
 /datum/material/plastic
 	name="Plastic"

--- a/code/modules/mining/materials.dm
+++ b/code/modules/mining/materials.dm
@@ -365,7 +365,7 @@ var/global/list/initial_materials	//Stores all the matids = 0 in helping New
 				var/atom/movable/victim = pick(target,user)
 				if(victim)
 					do_teleport(victim, get_turf(victim), 1*source.quality, asoundin = 'sound/effects/phasein.ogg')
-		if(prob(20/source.quality)
+		if(prob(20/source.quality))
 			to_chat(user, "<span class = 'warning'>\The [source] teleports away!</span>")
 			do_teleport(source, get_turf(source), 1.45*source.quality, asoundin = 'sound/effects/phasein.ogg') //teleports to a random tile within up to 13 tiles of itself, based on quality
 


### PR DESCRIPTION
## What this does
Phazon weapons will no longer have a high chance of deleting themselves when used and will instead teleport away somewhere nearby, with the radius equaling quality *1.45
## Why it's good
Having a hard autismo-made weapon/hammer have a 1 in 100 chance to delete itself whenever it's used for _anything_ is lame.
## How it was tested
It wasn't, but it shouldn't break anything.
:cl:
 * tweak: Phazon weapons and hammers (blacksmithing) will no longer delete themselves when used a bunch, and will instead teleport to a random tile within a radius around itself, scaling with quality, up to a radius of 13 tiles with legendary weapons. 