### PR TITLE
buffs lotto number jackpot event odds

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3924,7 +3924,7 @@ var/station_jackpot = 1000000
 		to_chat(user,"<span class='notice'>The winning numbers are [english_list(winning_numbers)]</span>")
 
 #define LOTTO_SAMPLE 6
-#define LOTTO_BALLCOUNT 32 //lottery is a topdefine/bottomdefine system
+#define LOTTO_BALLCOUNT 18 //lottery is a topdefine/bottomdefine system
 #if LOTTO_BALLCOUNT < LOTTO_SAMPLE
 #define LOTTO_BALLCOUNT LOTTO_SAMPLE
 #endif


### PR DESCRIPTION
[tweak][balance]

## What this does
increases the odds of winning anything from them 20-fold

## Why it's good
only one person i asked actually won anything and it was the lowest tier prize

## How it was tested
factorial 18 divided by (factorial 13 times factorial 5), all multiplied by 6 (1 in 54,108 for jackpot)

## Changelog
:cl:
 * tweak: Lotto tickets with numbers from the random event are now more likely to be winners, as the highest ballcount is now 18 and not 32.
