### PR TITLE
Botany chems now tick and get consumed at the same rate.

### DIFF
--- a/code/modules/reagents/reagents/reagents_basic.dm
+++ b/code/modules/reagents/reagents/reagents_basic.dm
@@ -201,9 +201,10 @@
 		return
 	T.add_toxinlevel(2)
 	if(T.reagents.get_reagent_amount(id) > 0)
-		if(prob(15))
+		if(prob(30))
 			T.mutate(GENE_MORPHOLOGY)
-			T.reagents.remove_reagent(id, 1)
+			if(prob(50))
+				T.reagents.remove_reagent(id, 1)
 
 /datum/reagent/silicon
 	name = "Silicon"

--- a/code/modules/reagents/reagents/reagents_drug.dm
+++ b/code/modules/reagents/reagents/reagents_drug.dm
@@ -101,9 +101,10 @@
 		return
 	var/amount = T.reagents.get_reagent_amount(id)
 	if(amount >= 1)
-		if(prob(15))
+		if(prob(30))
 			T.mutate(GENE_DEVELOPMENT)
-			T.reagents.remove_reagent(id, 1)
+			if(prob(50))
+				T.reagents.remove_reagent(id, 1)
 	else if(amount > 0)
 		T.reagents.remove_reagent(id, amount)
 
@@ -227,11 +228,10 @@
 		return
 	var/amount = T.reagents.get_reagent_amount(id)
 	if(amount >= 1)
-		if(prob(15))
+		if(prob(30))
 			T.mutate(GENE_METABOLISM)
-			T.reagents.remove_reagent(id, 1)
-		if(prob(15))
-			T.mutate(GENE_METABOLISM)
+			if(prob(50))
+				T.reagents.remove_reagent(id, 1)
 	else if(amount > 0)
 		T.reagents.remove_reagent(id, amount)
 

--- a/code/modules/reagents/reagents/reagents_material.dm
+++ b/code/modules/reagents/reagents/reagents_material.dm
@@ -165,9 +165,10 @@
 		return
 	var/amount = T.reagents.get_reagent_amount(id)
 	if(amount >= 1)
-		if(prob(15))
+		if(prob(30))
 			T.mutate(GENE_BIOLUMINESCENCE)
-			T.reagents.remove_reagent(id, 1)
+			if(prob(50))
+				T.reagents.remove_reagent(id, 1)
 	else if(amount > 0)
 		T.reagents.remove_reagent(id, amount)
 

--- a/code/modules/reagents/reagents/reagents_medical.dm
+++ b/code/modules/reagents/reagents/reagents_medical.dm
@@ -708,9 +708,10 @@ var/global/list/charcoal_doesnt_remove=list(
 		return
 	var/amount = T.reagents.get_reagent_amount(id)
 	if(amount >= 1)
-		if(prob(15))
+		if(prob(30))
 			T.mutate(GENE_XENOPHYSIOLOGY)
-			T.reagents.remove_reagent(id, 1)
+			if(prob(50))
+				T.reagents.remove_reagent(id, 1)
 	else if(amount > 0)
 		T.reagents.remove_reagent(id, amount)
 
@@ -950,11 +951,10 @@ var/global/list/charcoal_doesnt_remove=list(
 		return
 	var/amount = T.reagents.get_reagent_amount(id)
 	if(amount >= 1)
-		if(prob(15))
+		if(prob(30))
 			T.mutate(GENE_ECOPHYSIOLOGY)
-			T.reagents.remove_reagent(id, 1)
-		if(prob(15))
-			T.mutate(GENE_ECOPHYSIOLOGY)
+			if(prob(50))
+				T.reagents.remove_reagent(id, 1)
 	else if(amount > 0)
 		T.reagents.remove_reagent(id, amount)
 

--- a/code/modules/reagents/reagents/reagents_medical.dm
+++ b/code/modules/reagents/reagents/reagents_medical.dm
@@ -404,11 +404,10 @@
 		return
 	var/amount = T.reagents.get_reagent_amount(id)
 	if(amount >= 1)
-		if(prob(15))
+		if(prob(30))
 			T.mutate(GENE_ECOLOGY)
-			T.reagents.remove_reagent(id, 1)
-		if(prob(15))
-			T.mutate(GENE_ECOLOGY)
+			if(prob(50))
+				T.reagents.remove_reagent(id, 1)
 	else if(amount > 0)
 		T.reagents.remove_reagent(id, amount)
 

--- a/code/modules/reagents/reagents/reagents_toxin.dm
+++ b/code/modules/reagents/reagents/reagents_toxin.dm
@@ -448,9 +448,10 @@
 		return
 	var/amount = T.reagents.get_reagent_amount(id)
 	if(amount >= 1)
-		if(prob(15))
+		if(prob(30))
 			T.mutate(GENE_PHYTOCHEMISTRY)
-			T.reagents.remove_reagent(id, 1)
+			if(prob(50))
+				T.reagents.remove_reagent(id, 1)
 	else if(amount > 0)
 		T.reagents.remove_reagent(id, amount)
 


### PR DESCRIPTION
## What this does
Most botanist can tell you that some mutagens take forever to tick, with plants just straight up growing up before the mutagen ticks, meaning you don't get to mutate the species.
This PR tweaks all plant mutagens to have the same chance of ticking, and makes them all get consumed at the same rate, since some of the mutagens got consumed faster/slower.
Does not change the mutations themselves, but rather the odds of the reagents triggering them and getting consumed in the process (Currently only Hyperzine, Bicaridine and Kelotane proc fast with a chance to not get consumed).
To be clear: This makes all chems have a 30% chance of ticking, instead of 2 chances of 15% (Hyperzine, Bicaridine, Kelotane), which averages out to around 29% odds of ticking, or a single chance of 15% (every other chem).
## Why it's good
More reliable mutagens are good for plant mutations. 
## How it was tested
Wasn't, but it's a simple tweak and it should behave as normal, just ticking the reagents in a sensible amount of time.
:cl:
 * tweak: All botany mutagens now take the same average time to tick and to get consumed (as fast as the previous fast chems). 