### PR TITLE
Grue Health Regen scaling adjustment

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -7,7 +7,7 @@
 	can_butcher = TRUE
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/animal/grue
 	name = "grue"
-	real_name = "grue"y
+	real_name = "grue"
 	minbodytemp = 150 //resistant to cold
 
 	a_intent=I_HURT //Initialize these

--- a/code/modules/mob/living/simple_animal/hostile/grue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/grue.dm
@@ -7,7 +7,7 @@
 	can_butcher = TRUE
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/animal/grue
 	name = "grue"
-	real_name = "grue"
+	real_name = "grue"y
 	minbodytemp = 150 //resistant to cold
 
 	a_intent=I_HURT //Initialize these
@@ -665,7 +665,7 @@
 /mob/living/simple_animal/hostile/grue/proc/grue_stat_updates(var/feed_verbose = FALSE) //update stats, called by lifestage_updates() as well as handle_feed()
 
 	//health regen in darkness
-	lightparams.regenbonus = lightparams.base_regenbonus * (1.5 ** eatencount) //increased health regen in darkness
+	lightparams.regenbonus = lightparams.base_regenbonus * (1.1 ** eatencount) //increased health regen in darkness
 
 	//melee damage, 50 damage limit
 	melee_damage_lower = min(50, base_melee_dam_lw + (5 * eatencount))


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Changes Grues Health regen based on kills

```
Current Grue health regen based on consumes(1.5) 
0	4.5
1	6.75
2	10.125
3	15.1875
4	22.78125
5	34.171875
6	51.2578125
7	76.88671875
8	115.330078125
9	172.9951171875
10	259.49267578125
20	10 is already 100% per tick
```

```
This PR changes (1.1)
0	4.5
1	4.95
2	5.445
3	5.9895
4	6.58845
5	7.247295
6	7.9720245
7	8.76922695
8	9.646149645
9	10.6107646095
10	11.67184107045
20	30.2737497719652
```


## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Grues after 5+ kills basically are unkillable due to being able to just run away with their speed scaling, and I figured the speed is a fun aspect of the antag while the health regen is more frustrating to deal with as there's nothing really you can do if it runs away turbo fast and instantly heals and comes back over and over.

I will say that rewriting this to something more sane would ultimately be better but I am a simple one line changer.
## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Ate things and recorded the health regen changes for a few kills, then did math for rest of it.
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Grues health regen has been lowered massively
