### PR TITLE
Allows new weeds to overtake trays containing dead weeds

### DIFF
--- a/code/modules/hydroponics/hydro_tray_process.dm
+++ b/code/modules/hydroponics/hydro_tray_process.dm
@@ -29,7 +29,7 @@
 	// There's a chance for a weed explosion to happen if the weeds take over.
 	// Plants that are themselves weeds (weed_tolerance > 80) are unaffected.
 	if (get_weedlevel() >= WEEDLEVEL_MAX && prob(10))
-		if(!seed || get_weedlevel() >= seed.weed_tolerance + 20)
+		if(!seed || get_weedlevel() >= seed.weed_tolerance + 20 || dead)
 			weed_invasion()
 
 	// If there is no seed data (and hence nothing planted),


### PR DESCRIPTION
This should result in an abandoned hydroponics room always having some living weeds, instead of remaining forever the same after each tray has been overtaken by weeds that have subsequently died.

:cl:
* tweak: Hydroponic trays containing dead weeds may now be overtaken by fresh new weeds.