### PR TITLE
The plant analyzer will also tell you the chems in planted seeds.

### DIFF
--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -82,7 +82,7 @@
 
 	dat += "<h2>Reagent Data</h2>"
 
-	if(!grown_reagents) //checking if the thing is produce or seed
+	if(!grown_reagents || istype(target,/obj/machinery/portable_atmospherics/hydroponics))
 		dat += "This plant will produce: "
 		var/datum/reagent/N
 		for (var/rid in grown_seed.chems)

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -88,6 +88,7 @@
 		for (var/rid in grown_seed.chems)
 			N = chemical_reagents_list[rid]
 			dat += "<br>- [N.id]"
+		dat += "<br>" //so it doesn't overlap with the next part
 
 	if(grown_reagents && grown_reagents.reagent_list && grown_reagents.reagent_list.len)
 		dat += "This sample contains: "


### PR DESCRIPTION
I forgot to add this check when I first made it so the thing could check reagents on seeds so you could check them on the seed and the produce, but not the plant.
## Why it's good
Oversights bad. Fixes good.
## How it was tested
Got a tomato seed. scanned it, worked as it does. Planted it, scanned it, worked as intended, harvested it, scanned it, worked as it does.
:cl:
 * bugfix: Plant analyzers will now tell you the chems a plant is making when scanning a tray, as was intended.