### PR TITLE
Fixing a bunch of hydro tray and canister related issues

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -253,6 +253,9 @@ var/global/list/ghdel_profiling = list()
 /atom/proc/is_open_container()
 	return flags & OPENCONTAINER
 
+/atom/proc/reagent_transfer_message(var/transfer_amt)
+	return "<span class='notice'>You transfer [transfer_amt] units of the solution to \the [src.name].</span>"
+
 // For when we want an open container that doesn't show its reagents on examine
 /atom/proc/hide_own_reagents()
 	return FALSE

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -217,6 +217,12 @@
 			src.update_icon()
 		nanomanager.update_uis(src)
 
+		//Updating the pipenet if we're on a connector
+		if (connected_port)
+			var/datum/pipe_network/P = connected_port.return_network(src)
+			if (P)
+				P.update = 1
+
 	if(air_contents.return_pressure() < 1)
 		can_label = 1
 	else

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -559,21 +559,6 @@
 			var/mob/living/carbon/human/H = user
 			to_chat(user, "<span class='good'>Would you like to know more?</span> <a href='?src=\ref[H.glasses];scan=\ref[src]'>\[Scan\]</a>")
 
-/obj/machinery/portable_atmospherics/hydroponics/proc/receive_pulse(var/pulse_strength)
-	if (seed && !closed_system)//if the lid is closed, the plant is radiation immune.
-		pulse_strength /= 50
-		if (prob(pulse_strength))
-			if (age <= 4)
-				//young plants mutate more easily
-				if (length(seed.mutants))
-					mutate_species()
-				else
-					mutate()
-			else if (prob(pulse_strength/2))
-				//older plants have between 1.125% and 1.875% chance to mutate per burst
-				//at 15 burst total this amounts to about 19% chance of at least one small mutation occurring
-				mutate()
-
 /obj/machinery/portable_atmospherics/hydroponics/proc/hydrovision(mob/user)
 	hydro_hud_scan(user, src)
 	return FALSE

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -275,6 +275,9 @@
 		return
 
 	else if(seed && isshovel(O))
+		if(closed_system)
+			to_chat(user, "<span class='warning'>You can't transplant the plant while the lid is shut.</span>")
+			return
 		if(arcanetampered)
 			to_chat(user,"<span class='sinister'>You cannot dig into the soil.</span>")
 			return
@@ -349,7 +352,10 @@
 		var/obj/item/seeds/seeds = seed.spawn_seed_packet(get_turf(user))
 		if(arcanetampered)
 			seeds.arcanetampered = arcanetampered
-		to_chat(user, "You take a sample from the [seed.display_name].")
+		if(closed_system)
+			to_chat(user, "You carefully pass \the [O] through the tray's access port, and take a sample from the [seed.display_name].")
+		else
+			to_chat(user, "You take a sample from the [seed.display_name].")
 		add_planthealth(-rand(3,5)*10)
 
 		if(prob(30))
@@ -364,7 +370,10 @@
 	else if (ishoe(O))
 
 		if(get_weedlevel() > 0)
-			user.visible_message("<span class='alert'>[user] starts uprooting the weeds.</span>", "<span class='alert'>You remove the weeds from the [src].</span>")
+			if(closed_system)
+				user.visible_message("<span class='alert'>[user] starts uprooting the weeds.</span>", "<span class='alert'>You pass \the [O] through the access port and remove the weeds from the [src].</span>")
+			else
+				user.visible_message("<span class='alert'>[user] starts uprooting the weeds.</span>", "<span class='alert'>You remove the weeds from the [src].</span>")
 			weedlevel = 0
 			update_icon()
 		else
@@ -479,6 +488,12 @@
 	else
 		examine(user) //using examine() to display the reagents inside the tray as well
 
+/obj/machinery/portable_atmospherics/hydroponics/reagent_transfer_message(var/transfer_amt)
+	if (closed_system)
+		return "<span class='notice'>You open \the [src.name]'s injection port and transfer [transfer_amt] units of the solution in it.</span>"
+	else
+		return "<span class='notice'>You transfer [transfer_amt] units of the solution to \the [src.name].</span>"
+
 /obj/machinery/portable_atmospherics/hydroponics/examine(mob/user)
 	..()
 	view_contents(user)
@@ -521,7 +536,7 @@
 			var/turf/T = loc
 			var/datum/gas_mixture/environment
 
-			if(closed_system && (connected_port || holding))
+			if(closed_system)
 				environment = air_contents
 
 			if(!environment)
@@ -544,6 +559,21 @@
 			var/mob/living/carbon/human/H = user
 			to_chat(user, "<span class='good'>Would you like to know more?</span> <a href='?src=\ref[H.glasses];scan=\ref[src]'>\[Scan\]</a>")
 
+/obj/machinery/portable_atmospherics/hydroponics/proc/receive_pulse(var/pulse_strength)
+	if (seed && !closed_system)//if the lid is closed, the plant is radiation immune.
+		pulse_strength /= 50
+		if (prob(pulse_strength))
+			if (age <= 4)
+				//young plants mutate more easily
+				if (length(seed.mutants))
+					mutate_species()
+				else
+					mutate()
+			else if (prob(pulse_strength/2))
+				//older plants have between 1.125% and 1.875% chance to mutate per burst
+				//at 15 burst total this amounts to about 19% chance of at least one small mutation occurring
+				mutate()
+
 /obj/machinery/portable_atmospherics/hydroponics/proc/hydrovision(mob/user)
 	hydro_hud_scan(user, src)
 	return FALSE
@@ -558,10 +588,6 @@
 
 	closed_system = !closed_system
 	to_chat(usr, "You [closed_system ? "close" : "open"] the tray's lid.")
-	if(closed_system)
-		flags &= ~OPENCONTAINER
-	else
-		flags |= OPENCONTAINER
 
 	update_icon()
 	add_fingerprint(usr)

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -81,8 +81,6 @@
 	)
 
 	RefreshParts()
-	if(closed_system)
-		flags &= ~OPENCONTAINER
 
 /obj/machinery/portable_atmospherics/hydroponics/RefreshParts()
 	var/capcount = 0

--- a/code/modules/hydroponics/hydro_tray_process.dm
+++ b/code/modules/hydroponics/hydro_tray_process.dm
@@ -109,7 +109,7 @@
 	var/turf/T = get_turf(src)
 	var/datum/gas_mixture/environment
 	// If we're closed, take from our internal sources.
-	if(closed_system && (connected_port || holding))
+	if(closed_system)
 		environment = air_contents
 	else if(!environment && istype(T))
 		environment = T.return_air()
@@ -267,12 +267,14 @@
 		environment.update_values()
 
 	// Handle gas production.
-	// If we're attached to a pipenet, then we should let the pipenet know we might have modified some gasses
-	//if (closed_system && connected_port)
-	//'	update_connected_network()
 	if(seed.exude_gasses && seed.exude_gasses.len)
 		for(var/gas in seed.exude_gasses)
 			environment.adjust_gas(gas, max(1,round((seed.exude_gasses[gas]*round(seed.potency))/seed.exude_gasses.len)))
+	// If we're attached to a pipenet, then we should let the pipenet know we might have modified some gasses
+	if (closed_system && connected_port)
+		var/datum/pipe_network/P = connected_port.return_network(src)
+		if (P)
+			P.update = 1
 
 /obj/machinery/portable_atmospherics/hydroponics/proc/check_kpa(var/datum/gas_mixture/environment)
 	var/pressure = environment.return_pressure()

--- a/code/modules/hydroponics/hydroponics_mutations.dm
+++ b/code/modules/hydroponics/hydroponics_mutations.dm
@@ -11,6 +11,8 @@
 /obj/machinery/portable_atmospherics/hydroponics/proc/mutate(var/gene)
 	if(!seed)
 		return
+	if(dead)
+		return
 	if(seed.immutable)
 		return
 	if(age < 3 && length(seed.mutants) && gene)
@@ -202,19 +204,27 @@
 				if(PLANT_SPREAD)
 					seed.spread = (seed.spread + 1) % 3
 					if(src && seed && seed.spread == 1)
-						visible_message("<span class='notice'>\The [seed.display_name] shift[seed.plural ? "":"s"] in the tray!</span>")
+						if (closed_system)
+							visible_message("<span class='notice'>\The [seed.display_name] shift[seed.plural ? "":"s"] in the tray, but remain[seed.plural ? "":"s"] contained by the lid!</span>")
+						else
+							visible_message("<span class='notice'>\The [seed.display_name] shift[seed.plural ? "":"s"] in the tray!</span>")
 						spawn(20)
 							var/datum/seed/newseed = seed.diverge()
 							newseed.spread = 1
 							var/turf/T = get_turf(src)
-							new /obj/effect/plantsegment(T, newseed)
+							if (!closed_system)
+								new /obj/effect/plantsegment(T, newseed)
 							msg_admin_attack("a random chance hydroponics mutation has spawned limited growth creeper vines ([newseed.display_name]). <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a>")
 					else if(src && seed && seed.spread == 2)
-						visible_message("<span class='notice'>\The [seed.display_name] spasm[seed.plural ? "":"s"] visibly, violently thrashing in the tray!</span>")
+						if (closed_system)
+							visible_message("<span class='notice'>\The [seed.display_name] spasm[seed.plural ? "":"s"] visibly, violently thrashing in the tray, although contained behind [seed.plural ? "their":"its"] lid!</span>")
+						else
+							visible_message("<span class='notice'>\The [seed.display_name] spasm[seed.plural ? "":"s"] visibly, violently thrashing in the tray!</span>")
 						var/datum/seed/newseed = seed.diverge()
 						newseed.spread = 2
 						var/turf/T = get_turf(src)
-						new /obj/effect/plantsegment(T, newseed)
+						if (!closed_system)
+							new /obj/effect/plantsegment(T, newseed)
 						msg_admin_attack("a random chance hydroponics mutation has spawned space vines ([newseed.display_name]). <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a>")
 					else
 						visible_message("<span class='notice'>\The [seed.display_name] recede[seed.plural ? "":"s"] into the tray.</span>")

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -321,7 +321,7 @@ var/list/LOGGED_SPLASH_REAGENTS = list(FUEL, THERMITE)
 
 		if(success)
 			if (success > 0)
-				to_chat(user, "<span class='notice'>You transfer [success] units of the solution to \the [target].</span>")
+				to_chat(user, target.reagent_transfer_message(success))
 
 			return (success)
 	if(!success)


### PR DESCRIPTION
Fixes #36864
Fixes #35551

:cl:
* bugfix: Fixed gases leaving hydro trays despite their lid being closed.
* bugfix: Fixed vines spawning outside hydro trays despite their lid being closed when they have just acquired the mutation.
* bugfix: Dead plants can no longer mutate further.
* bugfix: Fixed connected pipes not updating their atmosphere as they should when canisters and hydroponic trays connected to them change their content.
* tweak: You can now pour water and nutriments inside hydroponic trays even with their lid closed. The flavor text is slightly different to reflect you using its injection port. Likewise using a hoe or clippers on a tray now has flavor text specify that you use its access port.