### PR TITLE
Holomen don't suffocate nor get intoxicated by gases

### DIFF
--- a/code/modules/mob/living/simple_animal/hologram/hologram.dm
+++ b/code/modules/mob/living/simple_animal/hologram/hologram.dm
@@ -5,6 +5,9 @@
 	icon_state = "holo2"
 	icon_living = "holo2"
 	icon_dead = null
+	min_oxy = 0
+	max_tox = 0
+	max_co2 = 0 //we're made of light we don't have lungs
 	mob_property_flags = MOB_HOLOGRAPHIC
 	var/atom/atom_to_mimic
 	var/login_text = "You are a hologram. You can perform a few basic functions, and are unable to leave the holodeck.\


### PR DESCRIPTION
## What this does
Holomen no longer suffocate on low air conditions nor get intoxicated by atmospheric gases. They are light projections, not actual living creatures.
Closes #36912
Closes #31435
## Why it's good
Kinda weird for the hologram to suffocate from lack of air he doesn't breathe.
## How it was tested
Spawned a hologram, breached the room. They lived.
:cl:
 * tweak: Holomen no longer suffocate on low air conditions nor get intoxicated by atmospheric gases.