### PR TITLE
Fixes jail and sleeper deactivation messages

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -232,7 +232,7 @@
 	if(!S.chassis.has_charge(S.energy_drain))
 		S.set_ready_state(1)
 		S.log_message("Deactivated.")
-		S.occupant_message("[src] deactivated - no power.")
+		S.occupant_message("[S] deactivated - no power.")
 		S.go_out()
 		return stop()
 	var/mob/living/carbon/M = S.occupant

--- a/code/game/mecha/equipment/tools/sec_tools.dm
+++ b/code/game/mecha/equipment/tools/sec_tools.dm
@@ -165,7 +165,7 @@
 	if(!J.chassis.has_charge(J.energy_drain))
 		J.set_ready_state(1)
 		J.log_message("Deactivated.")
-		J.occupant_message("[src] deactivated - no power.")
+		J.occupant_message("[J] deactivated - no power.")
 		for(var/cell in J.cells)
 			J.go_out(cell)
 		return stop()


### PR DESCRIPTION
[grammar]

## What this does
Closes #36929.

## How it was tested
spawning odysseus, adding sleeper, putting mob in sleeper, varediting mech cell charge to near 0 and letting it run out.

## Changelog
:cl:
 * spellcheck: The mounted sleepers and jail cells on mechs no longer print the object types to the occupant when they run out of power.