### PR TITLE
Hydroponic Trays now consume a bit of power

### DIFF
--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -6,6 +6,10 @@
 	flags = OPENCONTAINER | PROXMOVE // PROXMOVE could be added and removed as necessary if it causes lag
 	volume = 100
 
+	use_power = MACHINE_POWER_USE_IDLE
+	idle_power_usage = 10
+	active_power_usage = 50
+
 	machine_flags = SCREWTOGGLE | CROWDESTROY | WRENCHMOVE | FIXED2WORK | MULTIOUTPUT
 
 	var/draw_warnings = 1 // Set to 0 to stop it from drawing the alert lights.
@@ -13,6 +17,7 @@
 	var/last_update_icon = 0 // Since we're calling it more frequently than process(), let's at least make sure we're only calling it once per tick.
 	var/delayed_update_icon = 0
 	var/is_soil = 0
+	var/is_plastic = 0
 
 	// Plant maintenance vars
 	var/waterlevel = 100		// Water (max 100)

--- a/code/modules/hydroponics/hydro_tray_process.dm
+++ b/code/modules/hydroponics/hydro_tray_process.dm
@@ -2,6 +2,12 @@
 	//Do this even if we're not ready for a plant cycle.
 	process_reagents()
 
+	if (!is_soil && !is_plastic)
+		if (seed)
+			use_power = MACHINE_POWER_USE_ACTIVE
+		else
+			use_power = MACHINE_POWER_USE_IDLE
+
 	// Update values every cycle rather than every process() tick.
 	if(force_update)
 		force_update = 0


### PR DESCRIPTION
They previously didn't use any, so this is another brick on the perpetual edifice of trying to find new uses for the absurd amounts of power generated by engineering.

With 10 W while idle, and 50 W with a plant growing, this leaves box's Hydroponics still consuming less electricity than box's Kitchen while idle, and even if every tray has a plant, they overall consume less power than box's Medbay's main room.

:cl:
* tweak: Hydroponic Trays now consume a bit of power.  Just a bit though.