### PR TITLE
Rampant Brand Intelligence random event tweaks

### DIFF
--- a/code/datums/helper_datums/command_alerts.dm
+++ b/code/datums/helper_datums/command_alerts.dm
@@ -727,7 +727,14 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 	alert_title = "Machine Learning Alert"
 
 /datum/command_alert/vending_machines/announce()
-	message = "Rampant brand intelligence has been detected aboard [station_name()], please stand-by."
+	message = "Rampant brand intelligence has been detected aboard [station_name()], be watchful for aggressive vending machines. If you find one of them broadcasting unusually agressive slogans, shut its speakers down."
+
+/datum/command_alert/vending_machines_end
+	name = "Rampant Brand Intelligence Purged"
+	alert_title = "Machine Learning Alert End"
+
+/datum/command_alert/vending_machines_end/announce()
+	message = "The rampant brand intelligence aboard [station_name()] has been purged. Vending machine behaviour should return to normal."
 
 /datum/command_alert/comms_blackout
 	name = "Ionospheric Anomalies - Telecommunications Failure"

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -41,20 +41,19 @@
 			var/obj/machinery/vending/infectedMachine = pick(vendingMachines)
 			vendingMachines.Remove(infectedMachine)
 			infectedVendingMachines.Add(infectedMachine)
+			infectedVendingMachines[infectedMachine] = infectedMachine.shut_up
 			infectedMachine.shut_up = 0
 			infectedMachine.shoot_inventory = 1
 
-			if(IsMultiple(activeFor, 12))
-				originMachine.speak(pick("Try our aggressive new marketing strategies!", \
-										 "You should buy products to feed your lifestyle obession!", \
-										 "Consume!", \
-										 "Your money can buy happiness!", \
-										 "Engage direct marketing!", \
-										 "Advertising is legalized lying! But don't let that put you off our great deals!", \
-										 "You don't want to buy anything? Yeah, well I didn't want to buy your mom either."))
+			originMachine.speak(pick("Try our aggressive new marketing strategies!", \
+									 "You should buy products to feed your lifestyle obession!", \
+									 "Consume!", \
+									 "Your money can buy happiness!", \
+									 "Engage direct marketing!", \
+									 "Advertising is legalized lying! But don't let that put you off our great deals!", \
+									 "You don't want to buy anything? Yeah, well I didn't want to buy your mom either."))
 
 /datum/event/brand_intelligence/end()
 	for(var/obj/machinery/vending/infectedMachine in infectedVendingMachines)
-		if(prob(90))
-			infectedMachine.shut_up = 1
-			infectedMachine.shoot_inventory = 0
+		infectedMachine.shut_up = infectedVendingMachines[infectedMachine]
+		infectedMachine.shoot_inventory = 0

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -57,3 +57,4 @@
 	for(var/obj/machinery/vending/infectedMachine in infectedVendingMachines)
 		infectedMachine.shut_up = infectedVendingMachines[infectedMachine]
 		infectedMachine.shoot_inventory = 0
+	command_alert(/datum/command_alert/vending_machines_end)


### PR DESCRIPTION
Hopefully that'll alleviate some of my frustrations with this event.

**Why it's good**: It raises the chances of players to even figure out what the event even is about, but I agree it's not good enough yet, the command alert should at least mention something about toggling the infected machine's speaker, and there should be another alert when the event ends.

It's 11 years old Cael code that has virtually never been touched ever since.

:cl:
* tweak: The following changes have been done to the Rampant Brand Intelligence event. The original infected vending machine is now guaranteed to emit one of its custom slogans when it infects another vending machine, making players more likely to find it (and to hear those slogans at all like jesus christ the odds were ridiculously low). When the event ends, ALL infected machines stop throwing items instead of only 90 percent, and their speakers now return to their previous value instead of always being deactivated.