### PR TITLE
Lucky coins with a string have a second chance to be pulled out successfully, scaling with coin luck.

### DIFF
--- a/code/game/machinery/candymachine.dm
+++ b/code/game/machinery/candymachine.dm
@@ -59,6 +59,9 @@
 				if(prob(30))
 					to_chat(user, "<SPAN CLASS='notice'>You were able to force the knob around and successfully pulled \the [real_coin] out before [src] could swallow it.</SPAN>")
 					user.put_in_hands(O)
+				else if(prob(real_coin.luckiness/10))
+					to_chat(user, "<SPAN CLASS='notice'>You just barely were able to pull \the [real_coin] out before [src] could swallow it, lucky!</SPAN>")
+					user.put_in_hands(O)
 				else
 					to_chat(user, "<SPAN CLASS='notice'>You weren't able to pull \the [real_coin] out fast enough, the machine ate it, string and all.</SPAN>")
 					qdel(O)

--- a/code/game/machinery/clawmachine.dm
+++ b/code/game/machinery/clawmachine.dm
@@ -249,6 +249,9 @@
 					if(prob(50))
 						to_chat(user, "<span class='notice'>You manage to yank \the [C] back out before the machine swallows it!</span>")
 						user.put_in_hands(O)
+					else if(prob(C.luckiness/10))
+						to_chat(user, "<SPAN CLASS='notice'>You just barely manage to yank \the [C] out before machine swallows it! Lucky!</SPAN>")
+						user.put_in_hands(O)
 					else
 						to_chat(user, "<span class='notice'>You weren't able to pull \the [C] out in time and the machine swallows it, string and all.</span>")
 						qdel(O)

--- a/code/game/machinery/gashapon.dm
+++ b/code/game/machinery/gashapon.dm
@@ -25,6 +25,9 @@
 					if(prob(30))
 						to_chat(user, "<SPAN CLASS='notice'>You were able to force the knob around and successfully pulled \the [O] out before [src] could swallow it.</SPAN>")
 						user.put_in_hands(O)
+					else if(prob(real_coin.luckiness/10))
+						to_chat(user, "<SPAN CLASS='notice'>You just barely were able to pull \the [O] out before [src] could swallow it, lucky!</SPAN>")
+						user.put_in_hands(O)
 					else
 						to_chat(user, "<SPAN CLASS='notice'>You weren't able to pull \the [O] out fast enough, the machine ate it, string and all.</SPAN>")
 						qdel(O)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1088,6 +1088,9 @@ var/global/num_vending_terminals = 1
 				if(prob(50))
 					to_chat(user, "<SPAN CLASS='notice'>You successfully pulled \the [coin] out before \the [src] could swallow it.</SPAN>")
 					return_coin = 1
+				else if(prob(real_coin.luckiness/10))
+					to_chat(user, "<SPAN CLASS='notice'>You just barely were able to pull \the [coin] out before [src] could swallow it, lucky!</SPAN>")
+					return_coin = 1
 				else
 					to_chat(user, "<SPAN CLASS='notice'>You weren't able to pull \the [coin] out fast enough, the machine ate it, string and all.</SPAN>")
 


### PR DESCRIPTION
## What this does
Lucky coins on a string now have a second chance to be pulled out successfully, scaling with coin luck (not yours).
## Why it's good
I like the idea of luck having more effects in-game, and this is somewhat tame, considering that lucky coins are very rare, and most coins have very little luck.
## How it was tested
String lucky coin -> VV to 999999999999999 luckiness -> use on machine -> coin returns each time
String coin -> use on machine -> coin returns based on the regular odds

:cl:
 * rscadd: Lucky coins on a string have a second chance to be pulled out successfully, scaling with coin luck (not yours).