### PR TITLE
Blacksmithing Quality of Life Pass

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -641,8 +641,8 @@
   * * atom/target - the atom the progress bar will be attached to
   * * delay - duration in deciseconds of the delay
   * * numticks - how many times the failure conditions will be checked throughout the duration. default 10
-  * * needhand - if TRUE, the item in the hands of the user needs to stay the same throughout the duration
-  * * use_user_turf - if TRUE, the turf of the user is checked instead of its location
+  * * needhand - if TRUE, the item in the hands of the user needs to stay the same throughout the duration. default TRUE
+  * * use_user_turf - if TRUE, the turf of the user is checked instead of its location. default FALSE
   * * custom_checks - if specified, the return value of this callback (called every `delay/numticks` seconds) will determine whether the action succeeded
   */
 /proc/do_after(var/mob/user as mob, var/atom/target, var/delay as num, var/numticks = 10, var/needhand = TRUE, var/use_user_turf = FALSE, callback/custom_checks)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -190,7 +190,7 @@ steam.start() -- spawns the effect
 	else
 		location = get_turf(loca)
 
-/datum/effect/system/spark_spread/start(surfaceburn = TRUE)
+/datum/effect/system/spark_spread/start(surfaceburn = TRUE, silent = FALSE)
 	if (holder)
 		location = get_turf(holder)
 	if(!location)
@@ -201,7 +201,8 @@ steam.start() -- spawns the effect
 	else
 		directions = alldirs.Copy()
 
-	playsound(location, "sparks", 100, 1)
+	if(!silent)
+		playsound(location, "sparks", 100, 1)
 	for (var/i = 1 to number)
 		var/nextdir=pick_n_take(directions)
 		if(nextdir)
@@ -211,12 +212,22 @@ steam.start() -- spawns the effect
 			else
 				var/obj/effect/sparks/nosurfaceburn/sparks = new /obj/effect/sparks/nosurfaceburn(location)
 				sparks.start(nextdir)
-// This sparks.
-/proc/spark(var/atom/loc, var/amount = 3, var/cardinals = TRUE, var/surfaceburn = FALSE) //surfaceburn means the sparks can ignite things on the ground. set it to false to keep eg. portals like in the time agent event from burning down the station
+/**
+  * This sparks.
+  *
+  * Generates some sparks at specified location
+  * Arguments:
+  * * atom/loc - where the sparks are set off
+  * * amount - how many sparks, default 3
+  * * cardinals - if true, sparks will not spread diagonally, default TRUE
+  * * surfaceburn - if it starts fires, default FALSE
+  * * silent - if TRUE, the initial spark won't make noise, default FALSE
+  */
+/proc/spark(var/atom/loc, var/amount = 3, var/cardinals = TRUE, var/surfaceburn = FALSE, var/silent = FALSE)
 	loc = get_turf(loc)
 	var/datum/effect/system/spark_spread/S = new
 	S.set_up(amount, cardinals, loc)
-	S.start(surfaceburn)
+	S.start(surfaceburn, silent)
 
 #undef SPARK_TEMP
 

--- a/code/game/objects/items/stacks/stack_recipes.dm
+++ b/code/game/objects/items/stacks/stack_recipes.dm
@@ -253,7 +253,7 @@
 	//Yeah nah let's put you in a blacksmith_placeholder
 	var/obj/item/I = new /obj/item/smithing_placeholder(usr.loc, S, R, req_strikes)
 	I.name = "unforged [R.name]"
-	return 0
+	return I
 
 var/datum/stack_recipe_list/blacksmithing_recipes = new("blacksmithing recipes", list(
 	new/datum/stack_recipe/blacksmithing("hammer head", /obj/item/item_head/hammer_head,			4, time = 5 SECONDS, required_strikes = 6),

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -858,7 +858,7 @@ a {
 	if(additional_description)
 		desc = "[initial(desc)] \n [additional_description]"
 
-/obj/proc/dorfify(var/datum/material/mat, var/additional_quality, var/min_quality)
+/obj/proc/dorfify(var/datum/material/mat, var/additional_quality, var/min_quality = 0)
 	if(mat)
 		/*var/icon/original = icon(icon, icon_state) Icon operations keep making mustard gas
 		if(mat.color)

--- a/code/modules/blacksmithing/forge.dm
+++ b/code/modules/blacksmithing/forge.dm
@@ -15,6 +15,7 @@
 	var/fuel_time //How long is left, in deciseconds
 	var/current_temp
 	var/current_thermal_energy
+	light_color = LIGHT_COLOR_ORANGE
 
 /obj/structure/forge/update_icon()
 	if(status)
@@ -66,11 +67,12 @@
 		return 1
 	else if(I.is_hot() && status == FALSE)
 		to_chat(user, "<span class = 'notice'>You attempt to light \the [src] with \the [I].</span>")
-		if(do_after(user, I, 3 SECONDS))
+		if(do_after(user, src, 3 SECONDS))
 			if(!has_fuel())
 				to_chat(user, "<span class = 'warning'>\The [src] does not light.</span>")
 				return 0
-			toggle_lit()
+			if(status == FALSE) //spam clicking the forge is bad
+				toggle_lit()
 			return 1
 	else if(iscrowbar(I))
 		to_chat(user, "<span class = 'notice'>You begin to disassemble \the [src].</span>")
@@ -92,9 +94,19 @@
 			status = FALSE
 			current_temp = 0
 			processing_objects.Remove(src)
+			set_light(0,0)
 		if(FALSE)//turning it on
 			status = TRUE
 			processing_objects.Add(src)
+			switch(current_temp)
+				if(MELTPOINT_GOLD)
+					set_light(2,2)
+				if(MELTPOINT_STEEL)
+					set_light(2,3)
+				if(TEMPERATURE_PLASMA to INFINITY)
+					set_light(3,3)
+				else
+					set_light(2,2)
 	on_fire = status
 	update_icon()
 	return status

--- a/code/modules/blacksmithing/forge.dm
+++ b/code/modules/blacksmithing/forge.dm
@@ -40,6 +40,7 @@
 			if(current_temp < TEMPERATURE_PLASMA)
 				current_temp = TEMPERATURE_PLASMA
 			fuel_time+= 10
+			fuel_update_light()
 			return 1
 	else if(istype(I, /obj/item/stack/ore/plasma))
 		to_chat(user, "<span class = 'notice'>You toss \the [I] into \the [src].</span>")
@@ -48,6 +49,7 @@
 			if(current_temp < TEMPERATURE_PLASMA)
 				current_temp = TEMPERATURE_PLASMA
 			fuel_time += 15
+			fuel_update_light()
 			return 1
 	else if(istype(I, /obj/item/stack/sheet/wood))
 		var/obj/item/stack/sheet/wood/W = I
@@ -56,6 +58,7 @@
 			if(current_temp < MELTPOINT_GOLD)
 				current_temp = MELTPOINT_GOLD
 			fuel_time += 10
+			fuel_update_light()
 			return 1
 	else if(istype(I, /obj/item/weapon/grown/log))
 		to_chat(user, "<span class = 'notice'>You toss \the [I] into \the [src].</span>")
@@ -64,6 +67,7 @@
 		if(current_temp < MELTPOINT_STEEL)
 			current_temp = MELTPOINT_STEEL
 		fuel_time += 5
+		fuel_update_light()
 		return 1
 	else if(I.is_hot() && status == FALSE)
 		to_chat(user, "<span class = 'notice'>You attempt to light \the [src] with \the [I].</span>")
@@ -94,22 +98,27 @@
 			status = FALSE
 			current_temp = 0
 			processing_objects.Remove(src)
-			set_light(0,0)
 		if(FALSE)//turning it on
 			status = TRUE
 			processing_objects.Add(src)
-			switch(current_temp)
-				if(MELTPOINT_GOLD)
-					set_light(2,2)
-				if(MELTPOINT_STEEL)
-					set_light(2,3)
-				if(TEMPERATURE_PLASMA to INFINITY)
-					set_light(3,3)
-				else
-					set_light(2,2)
+	fuel_update_light()
 	on_fire = status
 	update_icon()
 	return status
+
+/obj/structure/forge/proc/fuel_update_light()
+	if(!status) //Forge is off
+		set_light(0,0)
+	else //Forge is lit!
+		switch(current_temp)
+			if(MELTPOINT_GOLD)
+				set_light(2,2)
+			if(MELTPOINT_STEEL)
+				set_light(2,3)
+			if(TEMPERATURE_PLASMA to INFINITY)
+				set_light(3,3)
+			else
+				set_light(2,2)
 
 /obj/structure/forge/attack_hand(mob/user)
 	if(heating)

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -11,6 +11,14 @@
 // The proc you should always use to set the light of this atom.
 // Nonesensical value for l_color default, so we can detect if it gets set to null.
 #define NONSENSICAL_VALUE -99999
+
+/**
+  * Changes the lighting of the atom, then calls update_light. Arguments left null will not be changed.
+  * Arguments:
+  * * l_range - Range of the light in tiles. 0 is off, and anything higher than 0 that's below 1.4 is floored to 1.4
+  * * l_power - Intensity of the light
+  * * l_color - Color of the light in hex
+  */
 /atom/proc/set_light(var/l_range, var/l_power, var/l_color = NONSENSICAL_VALUE)
 	if(l_range > 0 && l_range < MINIMUM_USEFUL_LIGHT_RANGE)
 		l_range = MINIMUM_USEFUL_LIGHT_RANGE	//Brings the range up to 1.4, which is just barely brighter than the soft lighting that surrounds players.


### PR DESCRIPTION
# Smithing QoL
![image](https://github.com/user-attachments/assets/9896ae09-3cbe-4588-a3c1-bf00b7dc504b)

## What this does
This is a somewhat unatomic PR of Blacksmithing QoL changes,

### Changes Unforged Item Appearance
![image](https://github.com/user-attachments/assets/061826a2-5491-4ae9-b082-88f1ebc88b72)
Instead of looking identical to the material that they're made from, unforged blacksmithing items look like a smaller version. This helps for faster identification of where you dropped it in the stack of materials you'll no doubt be using.
### Smithing Lighting
![image](https://github.com/user-attachments/assets/e265f016-a4fa-4252-891a-0020d3767920)
Forges now emit warm light, with an intensity varying depending on what fuel you use. Unforged items that are heated also emit a faint light. Now you can see what the heck you're doing in your dark forge!
### Hammering Sparks
![image](https://github.com/user-attachments/assets/609b387e-b521-4836-873d-0f00f0d584dd)
Sparks (that CAN catch small objects on fire if you are not careful) are now emitted when you strike an unforged item with your hammer. Keep papers away from the forge!
### Ready to Quench Messaging
![image](https://github.com/user-attachments/assets/e0199aea-b275-4d7a-a06b-247086bcdbe1)
With high quality hammers, it was common to simply not get the message that your unforged item was ready to be quenched. This bug has been fixed.
### Quality Estimating
![image](https://github.com/user-attachments/assets/fb0d2ce5-c13c-45ec-a241-b9b03a590742)
You can now estimate the quality of your unforged work. When it's ready to be quenched, examining it will give an estimate of quality, ranging between the worst possible and best possible. Now you don't have to calculate and memorize exact strike counts anymore to get your chance at legendary results!
### Quenching Takes Time
![image](https://github.com/user-attachments/assets/b744eecd-104f-4860-956d-d9e023541d1c)
Quenching items is now a do_after, taking one second to finish The finished item will appear in your hands, saving you a click to pick it back up from under your body.
### Cooldown Messaging
![image](https://github.com/user-attachments/assets/079bc8ca-000d-463d-aa45-f9960a9aad04)
If you wait too long and your heated forged item cools down, it will now actually have a message informing you of this (and the faint light it emits goes away).
### And other minor updates/bugfixes

* Commentary changes on do_after
* Commentary changes on set_light
* Sparks can now be made silently
* Making a blacksmithing item that uses up your whole stack will now have the item appear in the hand where the stack used to be, similarly to other stack-crafted items
* Fixes a bug where a blacksmithing item would claim to be heated up and ready to forge, but not actually be ready to forge
* Spam-clicking the forge with fuel will no longer break it, or cause it to light with no ability to heat objects

## Why it's good
Eases the tedium of smithing just a little bit by increasing the atmosphere.

## How it was tested
Got ye hammer, forge, and anvil. Lit the forge with various fuels. Made various blacksmithing items. Saw tiny mineral items. Hammered and made many sparks. Quenched items. Died to radiation/toxins from uranium and plasma forging.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Blacksmiths can now estimate the quality of their result before quenching their work by examining it.
 * rscadd: Smithing now has several new visual effects, including lighting, hot sparks, and visibly different unforged items.
 * bugfix: Fixed several blacksmithing bugs, including lighting cold forges that can't heat anything.
