### PR TITLE
Mob Ignition Fixes/Cleanup

### DIFF
--- a/code/ATMOSPHERICS/hvac/spaceheater.dm
+++ b/code/ATMOSPHERICS/hvac/spaceheater.dm
@@ -411,7 +411,7 @@
 	if(istype(user,/mob/living/carbon) && on)
 		var/mob/living/carbon/absolutemadman = user
 		absolutemadman.adjust_fire_stacks(1)
-		if(absolutemadman.IgniteMob())
+		if(absolutemadman.ignite())
 			absolutemadman.visible_message("<span class='danger'>[user] walks into \the [src], and is set alight!</span>", "<span class='danger'>You walk into \the [src], and are set alight!</span>")
 
 /obj/machinery/space_heater/campfire/stove/fireplace

--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -613,6 +613,10 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 /obj/effect/fire/burnLiquidFuel()
 	return 0
 
+/obj/effect/fire/Crossed(atom/movable/AM)
+	AM.ignite()
+	..()
+
 /obj/effect/fire/process()
 	if(timestopped)
 		return 0
@@ -657,7 +661,7 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	for(var/mob/living/carbon/human/M in S)
 		if(M.mutations.Find(M_UNBURNABLE))
 			continue
-		M.FireBurn(firelevel, FLAME_TEMPERATURE_PLASTIC, air_contents.return_pressure())
+		M.fire_act(air_contents, FLAME_TEMPERATURE_PLASTIC, air_contents.return_volume())
 
 	//Burn items in the turf.
 	for(var/atom/A in S)
@@ -880,53 +884,3 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 			firelevel = ZAS_firelevel_multiplier * mix_multiplier * dampening_multiplier
 
 	return max(0, firelevel)
-
-
-///////////////////////////////////////////////
-// BURNING MOBS
-///////////////////////////////////////////////
-/mob/living/proc/FireBurn(var/firelevel, var/last_temperature, var/pressure)
-	var/mx = 5 * firelevel/ZAS_firelevel_multiplier * min(pressure / ONE_ATMOSPHERE, 1)
-	apply_damage(2.5*mx, BURN)
-
-/mob/living/carbon/human/FireBurn(var/firelevel, var/last_temperature, var/pressure)
-	var/head_exposure = 1
-	var/chest_exposure = 1
-	var/groin_exposure = 1
-	var/legs_exposure = 1
-	var/arms_exposure = 1
-
-	//Get heat transfer coefficients for clothing.
-	for(var/obj/item/clothing/C in src)
-		if(is_holding_item(C))
-			continue
-		if(C.max_heat_protection_temperature >= last_temperature)
-			if(!is_slot_hidden(C.body_parts_covered,FULL_HEAD))
-				head_exposure = 0
-			if(!is_slot_hidden(C.body_parts_covered,UPPER_TORSO))
-				chest_exposure = 0
-			if(!is_slot_hidden(C.body_parts_covered,LOWER_TORSO))
-				groin_exposure = 0
-			if(!is_slot_hidden(C.body_parts_covered,LEGS))
-				legs_exposure = 0
-			if(!is_slot_hidden(C.body_parts_covered,ARMS))
-				arms_exposure = 0
-
-	//minimize this for low-pressure enviroments
-	var/mx = 5 * max(firelevel,1.5)/ZAS_firelevel_multiplier * min(pressure / ONE_ATMOSPHERE, 1)
-
-	//Always check these damage procs first if fire damage isn't working. They're probably what's wrong.
-	var/fire_tile_modifier = 4 //multiplier for damage received while standing on a fire tile
-	apply_damage(fire_tile_modifier*HEAD_FIRE_DAMAGE_MULTIPLIER*mx*head_exposure, BURN, LIMB_HEAD, 0, 0, used_weapon = "Fire")
-	apply_damage(fire_tile_modifier*CHEST_FIRE_DAMAGE_MULTIPLIER*mx*chest_exposure, BURN, LIMB_CHEST, 0, 0, used_weapon ="Fire")
-	apply_damage(fire_tile_modifier*GROIN_FIRE_DAMAGE_MULTIPLIER*mx*groin_exposure, BURN, LIMB_GROIN, 0, 0, used_weapon ="Fire")
-	apply_damage(fire_tile_modifier*LEGS_FIRE_DAMAGE_MULTIPLIER*mx*legs_exposure, BURN, LIMB_LEFT_LEG, 0, 0, used_weapon = "Fire")
-	apply_damage(fire_tile_modifier*LEGS_FIRE_DAMAGE_MULTIPLIER*mx*legs_exposure, BURN, LIMB_RIGHT_LEG, 0, 0, used_weapon = "Fire")
-	apply_damage(fire_tile_modifier*ARMS_FIRE_DAMAGE_MULTIPLIER*mx*arms_exposure, BURN, LIMB_LEFT_ARM, 0, 0, used_weapon = "Fire")
-	apply_damage(fire_tile_modifier*ARMS_FIRE_DAMAGE_MULTIPLIER*mx*arms_exposure, BURN, LIMB_RIGHT_ARM, 0, 0, used_weapon = "Fire")
-
-	if(head_exposure || chest_exposure || groin_exposure || legs_exposure || arms_exposure)
-		dizziness = 5
-		confused = 5
-		if(prob(25))
-			audible_scream()

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -1402,7 +1402,7 @@ var/list/arcane_tomes = list()
 
 	next_extinguish = world.time + extinguish_cooldown
 	to_chat(H, "<span class='warning'>Your armor automatically extinguishes the fire.</span>")
-	H.ExtinguishMob()
+	H.extinguish()
 
 //plasmaman stuff
 /obj/item/clothing/suit/cultrobes/regulate_temp_of_wearer(var/mob/living/carbon/human/H)
@@ -1519,7 +1519,7 @@ var/list/arcane_tomes = list()
 
 	next_extinguish = world.time + extinguish_cooldown
 	to_chat(H, "<span class='warning'>Your armor automatically extinguishes the fire.</span>")
-	H.ExtinguishMob()
+	H.extinguish()
 
 //plasmaman stuff
 /obj/item/clothing/suit/space/cult/regulate_temp_of_wearer(var/mob/living/carbon/human/H)

--- a/code/datums/gamemode/role/vampire_role.dm
+++ b/code/datums/gamemode/role/vampire_role.dm
@@ -407,7 +407,7 @@
 			else if(prob(35))
 				to_chat(H, "<span class='danger'>The holy flames continue to burn your flesh!</span>")
 			H.fire_stacks += 5
-			H.IgniteMob()
+			H.ignite()
 
 /datum/role/vampire/proc/remove_blood(var/amount)
 	blood_usable = max(0, blood_usable - amount)
@@ -532,13 +532,13 @@
 				else
 					to_chat(src, "<span class='danger'>You continue to burn!</span>")
 				fire_stacks += 5
-				IgniteMob()
+				ignite()
 		audible_scream()
 	else
 		switch(health)
 			if((-INFINITY) to 60)
 				fire_stacks++
-				IgniteMob()
+				ignite()
 	adjustFireLoss(3)
 
 /*

--- a/code/datums/religions.dm
+++ b/code/datums/religions.dm
@@ -261,7 +261,7 @@ var/list/tgui_religion_data
 	if (B.my_rel != src) // BLASPHEMY
 		to_chat(preacher, "<span class='warning'>You are a heathen to this God. You feel [B.my_rel.deity_name]'s wrath strike you for this blasphemy.</span>")
 		preacher.fire_stacks += 5
-		preacher.IgniteMob()
+		preacher.ignite()
 		preacher.audible_scream()
 		return FALSE
 	if (preacher != religiousLeader.current)

--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -181,7 +181,7 @@
 		if(!handle_suit)
 			target.bodytemperature = max(T0C + 29, target.bodytemperature - 5)
 			target.adjustFireLoss(10)
-			target.ExtinguishMob()
+			target.extinguish()
 
 			target.visible_message("<span class='warning'>A cloud of fine ice crystals engulfs [target]!</span>")
 

--- a/code/game/gamemodes/wizard/spellbook_oneuse.dm
+++ b/code/game/gamemodes/wizard/spellbook_oneuse.dm
@@ -419,7 +419,7 @@
 
 /obj/item/weapon/spellbook/oneuse/ringoffire/recoil(mob/living/carbon/user as mob)
 	user.adjust_fire_stacks(10)
-	user.IgniteMob()
+	user.ignite()
 	to_chat(user, "<span class = 'warning'>The book sets you alight!</span>")
 
 /obj/item/weapon/spellbook/oneuse/mirror_of_pain
@@ -462,7 +462,7 @@
 /obj/item/weapon/spellbook/oneuse/firebreath/recoil(mob/living/carbon/user)
 	to_chat(user, "<span class = 'warning'>You burst into flames!</span>")
 	user.adjust_fire_stacks(0.5)
-	user.IgniteMob()
+	user.ignite()
 
 /obj/item/weapon/spellbook/oneuse/snakes
 	spell = /spell/aoe_turf/conjure/snakes

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -33,7 +33,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 
 /obj/machinery/atmospherics/unary/cryo_cell/Entered(var/atom/movable/Obj, var/atom/OldLoc)
 	. = ..()
-	
+
 	if(OldLoc.type != src.type)
 		spawn(rand(0,6))
 			if(OldLoc.type != src.type)
@@ -641,7 +641,7 @@ var/global/list/cryo_health_indicator = list(	"full" = image("icon" = 'icons/obj
 		M.drop_item(I) // to avoid visual fuckery bobing. Doesn't do anything to items with cant_drop to avoid magic healing tube abuse.
 	update_icon()
 	nanomanager.update_uis(src)
-	M.ExtinguishMob()
+	M.extinguish()
 	M.throw_alert(SCREEN_ALARM_CRYO, /obj/abstract/screen/alert/object/cryo, new_master = src)
 	if(user)
 		if(M == user)

--- a/code/game/machinery/firefoam_popper.dm
+++ b/code/game/machinery/firefoam_popper.dm
@@ -165,7 +165,7 @@
 					if(F.reagents.has_reagent(WATER))
 						if(isliving(atm))
 							var/mob/living/M = atm
-							M.ExtinguishMob()
+							M.extinguish()
 						if(atm.on_fire)
 							atm.extinguish()
 	explosion(get_turf(src),0,0,0)

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -388,7 +388,7 @@
 								if(W.reagents.has_reagent(WATER))
 									if(isliving(atm)) // For extinguishing mobs on fire
 										var/mob/living/M = atm // Why isn't this handled by the reagent? - N3X
-										M.ExtinguishMob()
+										M.extinguish()
 									if(atm.on_fire) // For extinguishing objects on fire
 										atm.extinguish()
 									if(atm.molten) // Molten shit.

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -775,7 +775,7 @@
 	for(var/mob/living/cookedalive as anything in occupant)
 		if(cookedalive.fire_stacks < 5)
 			cookedalive.adjust_fire_stacks(1)
-			cookedalive.IgniteMob()
+			cookedalive.ignite()
 
 	return
 
@@ -802,7 +802,7 @@
 	if(equipment.len >= max_equip)
 		return 0
 	return max_equip - equipment.len
-	
+
 /obj/mecha/proc/is_killdozer()
 	for(var/obj/I in equipment)
 		if(istype(I, /obj/item/mecha_parts/mecha_equipment/passive/killdozer_kit))

--- a/code/game/objects/effects/fire_blast.dm
+++ b/code/game/objects/effects/fire_blast.dm
@@ -105,7 +105,7 @@
 /obj/effect/fire_blast/proc/burn_mob(mob/living/L, var/adjusted_fire_damage)
 	if(!L.on_fire)
 		L.adjust_fire_stacks(0.5)
-		L.IgniteMob()
+		L.ignite()
 
 	if(L.mutations.Find(M_RESIST_HEAT)) //Heat resistance protects you from damage, but you still get set on fire
 		return

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -194,7 +194,7 @@
 			return SUICIDE_ACT_BRUTELOSS
 	else if (is_hot())
 		user.visible_message("<span class='danger'>[user] is immolating \himself with \the [src]! It looks like \he's trying to commit suicide.</span>")
-		user.IgniteMob()
+		user.ignite()
 		return SUICIDE_ACT_FIRELOSS
 	else if (force >= 10)
 		user.visible_message("<span class='danger'>[user] is bludgeoning \himself with \the [src]! It looks like \he's trying to commit suicide.</span>")

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -390,7 +390,7 @@ var/list/obj/item/device/flashlight/lamp/lamps = list()
 	qdel(src)
 	if(!fuel)
 		return (SUICIDE_ACT_TOXLOSS)
-	user.IgniteMob()
+	user.ignite()
 	return (SUICIDE_ACT_TOXLOSS|SUICIDE_ACT_FIRELOSS)
 
 /obj/item/device/flashlight/flare/ever_bright/New()

--- a/code/game/objects/items/robot/robot_items/robot_axe.dm
+++ b/code/game/objects/items/robot/robot_items/robot_axe.dm
@@ -64,7 +64,7 @@
 /obj/item/weapon/pickaxe/plasmacutter/heat_axe/proc/HellFire(var/mob/living/victim)
 	if(isliving(victim) && active) //Just to be sure.
 		victim.adjust_fire_stacks(1)
-		if(victim.IgniteMob())
+		if(victim.ignite())
 			to_chat(victim, "<span class='danger'>You are lit on fire from the intense heat of the [name]!</span>")
 
 /obj/item/weapon/pickaxe/plasmacutter/heat_axe/preattack(atom/target, mob/user, proximity_flag)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -467,7 +467,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	var/turf/location = get_turf(src)
 	var/mob/living/M = get_holder_of_type(src,/mob/living)
 	if(isliving(loc))
-		M.IgniteMob()
+		M.ignite()
 	smoketime--
 	if (smoketime == 5 && ismob(loc))
 		to_chat(M, "<span class='warning'>Your [name] is about to go out.</span>")

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -294,7 +294,7 @@
 						if(W.reagents.has_reagent(WATER))
 							if(isliving(atm)) // For extinguishing mobs on fire
 								var/mob/living/M = atm                           // Why isn't this handled by the reagent? - N3X
-								M.ExtinguishMob()
+								M.extinguish()
 							if(atm.on_fire) // For extinguishing objects on fire
 								atm.extinguish()
 							if(atm.molten) // Molten shit.

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -23,7 +23,7 @@
 	user.emote("fart")
 	sleep(1 SECONDS) //Wait for it
 	user.fire_stacks += 5
-	user.IgniteMob()
+	user.ignite()
 	user.audible_scream()
 	return SUICIDE_ACT_FIRELOSS //Set ablaze and burned to crisps
 
@@ -127,13 +127,13 @@
 		if(V) //Vampire trying to use it
 			to_chat(user, "<span class='danger'>[my_rel.deity_name] channels through \the [src] and sets you ablaze for your blasphemy!</span>")
 			user.fire_stacks += 5
-			user.IgniteMob()
+			user.ignite()
 			user.audible_scream()
 			V.smitecounter += 50 //Once we are extinguished, we will be quite vulnerable regardless
 		else if(isanycultist(user)) //Cultist trying to use it
 			to_chat(user, "<span class='danger'>[my_rel.deity_name] channels through \the [src] and sets you ablaze for your blasphemy!</span>")
 			user.fire_stacks += 5
-			user.IgniteMob()
+			user.ignite()
 			user.audible_scream()
 		else //Literally anyone else than a Cultist using it, at this point it's just a big book
 			..() //WHACK

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -437,7 +437,7 @@
 	if (src.welding)
 		if(isliving(A))
 			var/mob/living/L = A
-			L.IgniteMob()
+			L.ignite()
 			remove_fuel(1)
 
 /obj/item/tool/weldingtool/attack_self(mob/user as mob)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -411,7 +411,7 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 /obj/suicide_act(var/mob/living/user)
 	if (is_hot())
 		user.visible_message("<span class='danger'>[user] is immolating \himself on \the [src]! It looks like \he's trying to commit suicide.</span>")
-		user.IgniteMob()
+		user.ignite()
 		return SUICIDE_ACT_FIRELOSS
 	else if (sharpness >= 1)
 		user.visible_message("<span class='danger'>[user] impales himself on \the [src]! It looks like \he's trying to commit suicide.</span>")

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -582,7 +582,7 @@
 		else
 			visible_message("<span class='warning'>\The [user] attempts to put out the fire on \the [target] with \the [src].</span>")
 			if(prob(extinguishingProb))
-				M.ExtinguishMob()
+				M.extinguish()
 				visible_message("<span class='notice'>\The [user] puts out the fire on \the [target].</span>")
 		return
 

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -26,7 +26,7 @@
 
 	next_extinguish = world.time + extinguish_cooldown
 	to_chat(H, "<span class='warning'>Your suit automatically extinguishes the fire.</span>")
-	H.ExtinguishMob()
+	H.extinguish()
 
 /obj/item/clothing/suit/space/plasmaman/regulate_temp_of_wearer(var/mob/living/carbon/human/H)
 	if(H.bodytemperature < T0C+37)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -75,7 +75,7 @@
 		for(var/atom/atm in T) //extinguishing things
 			if(isliving(atm)) // For extinguishing mobs on fire
 				var/mob/living/M = atm
-				M.ExtinguishMob()
+				M.extinguish()
 			if(atm.on_fire) // For extinguishing objects on fire
 				atm.extinguish()
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -624,3 +624,45 @@ emp_act
 
 /mob/living/carbon/human/beam_defense(var/obj/effect/beam/B)
 	return is_wearing_item(/obj/item/clothing/suit/reticulatedvest) ? 0.4 : 1
+
+/mob/living/carbon/human/FireBurn(firelevel = 0, temperature, pressure)
+	var/head_exposure = 1
+	var/chest_exposure = 1
+	var/groin_exposure = 1
+	var/legs_exposure = 1
+	var/arms_exposure = 1
+
+	//Get heat transfer coefficients for clothing.
+	for(var/obj/item/clothing/C in src)
+		if(is_holding_item(C))
+			continue
+		if(C.max_heat_protection_temperature >= temperature)
+			if(!is_slot_hidden(C.body_parts_covered,FULL_HEAD))
+				head_exposure = 0
+			if(!is_slot_hidden(C.body_parts_covered,UPPER_TORSO))
+				chest_exposure = 0
+			if(!is_slot_hidden(C.body_parts_covered,LOWER_TORSO))
+				groin_exposure = 0
+			if(!is_slot_hidden(C.body_parts_covered,LEGS))
+				legs_exposure = 0
+			if(!is_slot_hidden(C.body_parts_covered,ARMS))
+				arms_exposure = 0
+
+	//minimize this for low-pressure enviroments
+	var/mx = 5 * max(firelevel,1.5)/ZAS_firelevel_multiplier * min(pressure / ONE_ATMOSPHERE, 1)
+
+	//Always check these damage procs first if fire damage isn't working. They're probably what's wrong.
+	var/fire_tile_modifier = 4 //multiplier for damage received while standing on a fire tile
+	apply_damage(fire_tile_modifier*HEAD_FIRE_DAMAGE_MULTIPLIER*mx*head_exposure, BURN, LIMB_HEAD, 0, 0, used_weapon = "Fire")
+	apply_damage(fire_tile_modifier*CHEST_FIRE_DAMAGE_MULTIPLIER*mx*chest_exposure, BURN, LIMB_CHEST, 0, 0, used_weapon ="Fire")
+	apply_damage(fire_tile_modifier*GROIN_FIRE_DAMAGE_MULTIPLIER*mx*groin_exposure, BURN, LIMB_GROIN, 0, 0, used_weapon ="Fire")
+	apply_damage(fire_tile_modifier*LEGS_FIRE_DAMAGE_MULTIPLIER*mx*legs_exposure, BURN, LIMB_LEFT_LEG, 0, 0, used_weapon = "Fire")
+	apply_damage(fire_tile_modifier*LEGS_FIRE_DAMAGE_MULTIPLIER*mx*legs_exposure, BURN, LIMB_RIGHT_LEG, 0, 0, used_weapon = "Fire")
+	apply_damage(fire_tile_modifier*ARMS_FIRE_DAMAGE_MULTIPLIER*mx*arms_exposure, BURN, LIMB_LEFT_ARM, 0, 0, used_weapon = "Fire")
+	apply_damage(fire_tile_modifier*ARMS_FIRE_DAMAGE_MULTIPLIER*mx*arms_exposure, BURN, LIMB_RIGHT_ARM, 0, 0, used_weapon = "Fire")
+
+	if(head_exposure || chest_exposure || groin_exposure || legs_exposure || arms_exposure)
+		dizziness = 5
+		confused = 5
+		if(prob(25))
+			audible_scream()

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -69,7 +69,7 @@
 				if(!host.on_fire)
 					to_chat(host, "<span class='warning'>Your body reacts with the atmosphere and bursts into flame!</span>")
 				host.adjust_fire_stacks(0.5)
-				host.IgniteMob()
+				host.ignite()
 	else
 		var/obj/item/clothing/suit/PS=host.wear_suit
 		if(istype(PS))

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -1022,7 +1022,7 @@
 
 	qdel (src)
 
-/mob/living/carbon/slime/IgniteMob()
+/mob/living/carbon/slime/ignite()
 	return 0
 
 /mob/living/carbon/slime/ApplySlip(var/obj/effect/overlay/puddle/P)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -86,7 +86,7 @@
 	if(istype(get_turf(src),/turf/unsimulated/floor/brimstone))
 		FireBurn(11, 9001, ONE_ATMOSPHERE) // lag free weird way of doing it
 		fire_stacks = 11
-		IgniteMob() // ffffFIRE!!!! FIRE!!! FIRE!!
+		ignite() // ffffFIRE!!!! FIRE!!! FIRE!!
 	return 1
 
 // Apply connect damage
@@ -567,7 +567,7 @@ Thanks.
 	else
 		reagents.clear_reagents()
 	heal_overall_damage(1000, 1000)
-	ExtinguishMob()
+	extinguish()
 	fire_stacks = 0
 	/*
 	if(locked_to)
@@ -1136,7 +1136,7 @@ Thanks.
 				sleep(1 SECONDS)
 			CM.fire_stacks = 0
 			CM.visible_message("<span class='danger'>[CM] has successfully extinguished themselves!</span>","<span class='notice'>You extinguish yourself.</span>")
-			ExtinguishMob()
+			extinguish()
 			return
 
 		CM.resist_restraints()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -290,7 +290,6 @@
 
 /mob/living/extinguish()
 	..()
-	message_admins("extinguish() called on [src]")
 	update_fire()
 
 /mob/living/check_fire_protection()
@@ -316,7 +315,6 @@
 /mob/living/proc/handle_fire()
 	if((flags & INVULNERABLE) && on_fire)
 		extinguish()
-		message_admins("extinguished: if((flags & INVULNERABLE) && on_fire)")
 	if(fire_stacks < 0)
 		fire_stacks++ //If we've doused ourselves in water to avoid fire, dry off slowly
 		fire_stacks = min(0, fire_stacks)//So we dry ourselves back to default, nonflammable.
@@ -331,7 +329,6 @@
 			oxy = G.molar_density(GAS_OXYGEN)
 	if(oxy < (1 / CELL_VOLUME) || fire_stacks < 0)
 		extinguish() //If there's no oxygen in the tile we're on, put out the fire
-		message_admins("extinguished: if(oxy < (1 / CELL_VOLUME) || fire_stacks < 0)")
 		return 1
 	T.hotspot_expose(700, SMALL_FLAME, 1)
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -819,7 +819,7 @@
 /mob/living/simple_animal/hostile/asteroid/magmaw/fire_act(var/datum/gas_mixture/air, var/exposed_temperature, var/exposed_volume)
 	fire_resurrect(exposed_temperature)
 
-/mob/living/simple_animal/hostile/asteroid/magmaw/IgniteMob()
+/mob/living/simple_animal/hostile/asteroid/magmaw/ignite()
 	fire_resurrect(PLASMA_MINIMUM_BURN_TEMPERATURE)
 
 /mob/living/simple_animal/hostile/asteroid/magmaw/FireBurn(var/firelevel, var/last_temperature, var/pressure)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -710,9 +710,9 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 
 /mob/living/simple_animal/update_fire()
 	return
-/mob/living/simple_animal/IgniteMob()
+/mob/living/simple_animal/ignite()
 	return 0
-/mob/living/simple_animal/ExtinguishMob()
+/mob/living/simple_animal/extinguish()
 	return
 
 /mob/living/simple_animal/revive(refreshbutcher = 1)

--- a/code/modules/reagents/reagents/reagents_basic.dm
+++ b/code/modules/reagents/reagents/reagents_basic.dm
@@ -265,7 +265,7 @@
 			M.remove_silence()
 		if(isliving(M))
 			var/mob/living/L = M
-			L.ExtinguishMob()
+			L.extinguish()
 
 	//Water now directly damages slimes instead of being a turf check
 	if(isslime(M))

--- a/code/modules/reagents/reagents/reagents_religious.dm
+++ b/code/modules/reagents/reagents/reagents_religious.dm
@@ -33,7 +33,7 @@
 			M.make_visible(INVISIBLESPRAY)
 		if(isliving(M))
 			var/mob/living/L = M
-			L.ExtinguishMob()
+			L.extinguish()
 
 	//Water now directly damages slimes instead of being a turf check
 	if(isslime(M))

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -53,7 +53,7 @@
 	//Begin jaunting with an animation
 	anim(location = mobloc, a_icon = 'icons/mob/mob.dmi', flick_anim = enteranim, direction = target.dir, name = target.name,lay = target.layer+1,plane = target.plane)
 	if(mist)
-		target.ExtinguishMob()
+		target.extinguish()
 		var/datum/effect/system/steam_spread/steam = new /datum/effect/system/steam_spread()
 		steam.set_up(10, 0, mobloc)
 		steam.start()

--- a/code/modules/spells/targeted/feint.dm
+++ b/code/modules/spells/targeted/feint.dm
@@ -23,7 +23,7 @@
 	L.unlock_from()
 
 	anim(location = mobloc, target = L, a_icon = 'icons/mob/mob.dmi', flick_anim = "liquify", direction = L.dir, name = "water")
-	L.ExtinguishMob()
+	L.extinguish()
 	var/datum/effect/system/steam_spread/steam = new /datum/effect/system/steam_spread()
 	steam.set_up(10, 0, mobloc)
 	steam.start()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- Removed the snowflaked ignition & extinguishing procs for mobs and replaced them with the general ignite/extinguish procs.
- Moved most mob burning code from Fire.dm to more appropriate locations.
- Tweaked mob ignition; now you will ignite as soon as you walk into fire without having to wait for a fire process() tick.
- Fixed a bug resulting in mobs visually being on fire without actually burning up. Closes #13393 (80% confidence).

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
File cleanup & now people will actually be damaged while being on fire.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Set turfs on fire, walked into the fire, caught on fire, and saw that "on_fire" == 1.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed a bug where players would appear to be on fire without actually burning.
 * tweak: Mobs will now catch on fire as soon as they step into a fire.