### PR TITLE
Cows will mutate their milk type if exposed to phazon

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -169,6 +169,11 @@
 	if(stat == CONSCIOUS)
 		if(milkable_reagents && prob(reagent_regen_chance_per_tick))
 			milkable_reagents.add_reagent(milktype, rand(min_reagent_regen_per_tick, max_reagent_regen_per_tick))
+	if(src.reagents.has_reagent(PHAZON) && milktype != PHAZON) //if you roll the 1 in around 540 chances, you deserve your fountain of infinite phazon, godspeed
+		var/list/blocked_chems = list(ADMINORDRAZINE, PROCIZINE)
+		milktype = pick((chemical_reagents_list - blocked_chems)) //paismoke reacts instantly inside the cow, so it just constantly makes a smoke cloud harmlessly
+		name = "[lowertext(milktype)] cow"
+		desc = "It smells faintly of grass and [milktype]."
 
 /mob/living/simple_animal/cow/attack_hand(mob/living/carbon/M as mob)
 	if(!stat && M.a_intent == I_DISARM && icon_state != icon_dead)


### PR DESCRIPTION
## What this does
Requested by sacredatom and I liked the idea.
Giving Phazon to a cow will mutate its milk type to any chem except Adminordrazine or Procizine.
If the cow mutates phazon making, it will not mutate further, as a reward for having rolled the 1/540 chances successfully.
The expected roll for getting the phazon cow is approx the 540th, meaning 540 ticks (18 minutes), and 108u of phazon salts (meaning 108 phazon sheets). This is expensive enough that rewarding the excessive investment is fair in my eyes.
Keep in mind that the cow metabolizes the chems it produces, so there's a fair chance for the cow to just die from exposure to the new chem it makes as milk (such as if it started making cyanide).
## Why it's good
Gives another use to phazon and cows. You might get lucky and get a Gold cow, or a Vodka cow, or a Butter cow, or a Discount Dan's Special Sauce cow, etc.
## How it was tested
Spawned 2 cows, gave the first 100u phazon, the other 5u.
The first one continued cycling between chems, the second one cycled for a bit then settled into making Hydrogen.
:cl:
 * rscadd: Cows will mutate their milk type when exposed to Phazon, unless they themselves can make Phazon, in which case they will not mutate their milk further.