### PR TITLE
RPD menu floats

### DIFF
--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -95,9 +95,9 @@
 	var/dat = ""
 
 	dat += {"
-		<b>Selected:</b> <span id="selectedname"></span>
-		<h2>Options</h2>
 		<div id="schematic_options">
+		</div>
+		<div id="schematic_options2">
 		</div>
 		<h2>Available schematics</h2>
 		<div id='fav_list'></div>
@@ -258,8 +258,10 @@
 		for(var/client/client in interface.clients)
 			selected.send_assets(client)
 		interface.updateContent("schematic_options", selected.get_HTML(args))
+		interface.updateContent("schematic_options2", selected.get_HTML(args)) //don't question it, it just works.
 	else
 		interface.updateContent("schematic_options", " ")
+		interface.updateContent("schematic_options2", " ")
 
 // Called by schematics to delay their actions
 /obj/item/device/rcd/proc/delay(var/mob/user, var/atom/target, var/amount)

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -97,8 +97,6 @@
 	dat += {"
 		<div id="schematic_options">
 		</div>
-		<div id="schematic_options2">
-		</div>
 		<h2>Available schematics</h2>
 		<div id='fav_list'></div>
 	"}
@@ -258,10 +256,8 @@
 		for(var/client/client in interface.clients)
 			selected.send_assets(client)
 		interface.updateContent("schematic_options", selected.get_HTML(args))
-		interface.updateContent("schematic_options2", selected.get_HTML(args)) //don't question it, it just works.
 	else
 		interface.updateContent("schematic_options", " ")
-		interface.updateContent("schematic_options2", " ")
 
 // Called by schematics to delay their actions
 /obj/item/device/rcd/proc/delay(var/mob/user, var/atom/target, var/amount)

--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -120,7 +120,7 @@
 	dat += {"
 		<div style="padding-bottom:1em;" id="schematic_options2">
 		</div>
-		<div id="schematic_options">
+		<div id="schematic_options1">
 		</div>
 
 		<h2>Available schematics</h2>
@@ -165,10 +165,10 @@
 			schematichtml=replacetext(replacetext(schematichtml,"id=\"layer_selected\"","id=\"layer_selectedauto\""),"id=\"layer_center_selected\"","id=\"layer_center_selectedauto\"")
 		schematichtml+=multitext
 		schematichtml+=autotext
-		interface.updateContent("schematic_options", schematichtml )
+		interface.updateContent("schematic_options1", schematichtml )
 		interface.updateContent("schematic_options2", schematichtml )
 	else
-		interface.updateContent("schematic_options", " ")
+		interface.updateContent("schematic_options1", " ")
 		interface.updateContent("schematic_options2", " ")
 
 

--- a/code/modules/RCD/RPD.dm
+++ b/code/modules/RCD/RPD.dm
@@ -115,21 +115,14 @@
 
 /obj/item/device/rcd/rpd/rebuild_ui()
 	var/dat = ""
-	var/multitext=""
-	var/autotext=""
-	
-	if (has_metal_slime)//build_all
-		multitext=" <div style='margin-top:1em;'><b>Multilayer Mode: </b><a href='?src=\ref[interface];toggle_multi=1'><span class='[build_all? "schem_selected" : "schem"]'>[build_all ? "On" : "Off"]</span></a></div> "
-	if (has_yellow_slime)//build_all
-		autotext=" <div style='margin-top:1em;'><b>Autowrench: </b><a href='?src=\ref[interface];toggle_auto=1'><span class='[autowrench? "schem_selected" : "schem"]'>[autowrench ? "On" : "Off"]</span></a></div> "
 
+	//i don't know why i have to add padding to the bottom of the RPD, but it doesn't look right otherwise.
 	dat += {"
-		<b>Selected:</b> <span id="selectedname"></span>
-		<h2>Options</h2>
+		<div style="padding-bottom:1em;" id="schematic_options2">
+		</div>
 		<div id="schematic_options">
 		</div>
-		[multitext]
-		[autotext]
+
 		<h2>Available schematics</h2>
 		<div id='fav_list'></div>
 	"}
@@ -155,6 +148,14 @@
 
 /obj/item/device/rcd/rpd/update_options_menu()
 	if(selected)
+		var/multitext=""
+		var/autotext=""
+	
+		if (has_metal_slime)//build_all
+			multitext=" <div style='margin-top:1em;'><b>Multilayer Mode: </b><a href='?src=\ref[interface];toggle_multi=1'><span class='[build_all? "schem_selected" : "schem"]'>[build_all ? "On" : "Off"]</span></a></div> "
+		if (has_yellow_slime)//build_all
+			autotext=" <div style='margin-top:1em;'><b>Autowrench: </b><a href='?src=\ref[interface];toggle_auto=1'><span class='[autowrench? "schem_selected" : "schem"]'>[autowrench ? "On" : "Off"]</span></a></div> "
+	
 		for(var/client/client in interface.clients)
 			selected.send_assets(client)
 		var/schematichtml=selected.get_HTML(args)
@@ -162,9 +163,13 @@
 			schematichtml=replacetext(replacetext(schematichtml,"id=\"layer\"","id=\"layer_selected\""),"id=\"layer_center\"","id=\"layer_center_selected\"")
 		if (autowrench)
 			schematichtml=replacetext(replacetext(schematichtml,"id=\"layer_selected\"","id=\"layer_selectedauto\""),"id=\"layer_center_selected\"","id=\"layer_center_selectedauto\"")
+		schematichtml+=multitext
+		schematichtml+=autotext
 		interface.updateContent("schematic_options", schematichtml )
+		interface.updateContent("schematic_options2", schematichtml )
 	else
 		interface.updateContent("schematic_options", " ")
+		interface.updateContent("schematic_options2", " ")
 
 
 /obj/item/device/rcd/rpd/Topic(var/href, var/list/href_list)

--- a/code/modules/html_interface/RCD/RCD.css
+++ b/code/modules/html_interface/RCD/RCD.css
@@ -209,7 +209,7 @@ left:160px;
 	image-rendering:pixelated;
 }
 
-#schematic_options{ /*this is a really, really awful way to lay things out.*/
+#schematic_options1{ /*this is a really, really awful way to lay things out.*/
 	visibility: hidden;
 }
 #schematic_options2{ /*but it's not my fault IE doesn't support sticky positioning.*/

--- a/code/modules/html_interface/RCD/RCD.css
+++ b/code/modules/html_interface/RCD/RCD.css
@@ -2,6 +2,8 @@
 /*updated by crazyamphibian*/
 
 body{
+background-image:none;
+background-color:#272727; /*it's very sensitive to the order of things here, for some reason.*/
 line-height:100%
 }
 
@@ -205,4 +207,15 @@ left:160px;
 	border:none;
 	height:1em;
 	image-rendering:pixelated;
+}
+
+#schematic_options{ /*this is a really, really awful way to lay things out.*/
+	visibility: hidden;
+}
+#schematic_options2{ /*but it's not my fault IE doesn't support sticky positioning.*/
+	position:fixed;
+	background:linear-gradient(rgb(57,57,57) 0%,rgb(72,72,72) 4%  , rgb(39,39,39) 100%); /*emulating the background of nanotrasen.css. it's an image, but images don't play nice here.*/
+	width:100%;
+	left:0px;
+	top:0em;
 }

--- a/code/modules/html_interface/RCD/RCD.css
+++ b/code/modules/html_interface/RCD/RCD.css
@@ -209,6 +209,15 @@ left:160px;
 	image-rendering:pixelated;
 }
 
+#schematic_options{ /*because we removed the gradient earlier, we have to re-add it back*/
+	background:linear-gradient(rgb(57,57,57) 0%,rgb(72,72,72) 4%  , rgb(39,39,39) 100%);
+	width:100%;
+	left:-50px
+	top:0px;
+	padding:1em;
+	margin-top:-7px;
+	margin-left:-10px;
+}
 #schematic_options1{ /*this is a really, really awful way to lay things out.*/
 	visibility: hidden;
 }


### PR DESCRIPTION




[dnm] [ui] [qol]

## What this does
changes the top part of the RPD menu to always be shown on the screen.

https://github.com/user-attachments/assets/ca9cd946-d07c-45b9-b40e-5c5df65829a4

<!-- ![2](https://github.com/user-attachments/assets/b3cab276-a6b4-4c57-8c44-7bb6f2c8c1b2)
![3](https://github.com/user-attachments/assets/46aa5a99-aec2-4a24-808b-eb823aba43a9) -->


## Why it's good
easier to use. you can see more things, less scrolling.

## How it was tested
spawned RPD and messed with stuff

## Changelog
:cl:
 * tweak: Changed the RPD menu so that the options are always visible
