### PR TITLE
Revert "Makes the emergency shuttle and status display process timed to the second"

### DIFF
--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -42,7 +42,6 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 	var/voting_cache = 0
 
 	var/warmup_sound = 0
-	var/takeoff = 0
 
 	var/was_early_launched = FALSE //had timer shortened to 10 seconds
 
@@ -343,7 +342,7 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 
 			online = 0
 
-/datum/emergency_shuttle/proc/process(tick)
+/datum/emergency_shuttle/proc/process()
 	if(!online || shutdown)
 		return
 
@@ -353,11 +352,6 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 	if(timeleft < 0)		// Sanity
 		timeleft = 0
 
-
-	for(var/obj/machinery/status_display/S in status_displays)
-		if(S.mode == 1)
-			S.update()
-
 	if(timeleft > 6)
 		warmup_sound = 0
 
@@ -366,10 +360,9 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 
 			/* --- Shuttle is in transit toward centcom --- */
 			if(direction == 2)
-				if(tick % 20 == 0)
-					for(var/obj/structure/shuttle/engine/propulsion/P in shuttle.linked_area)
-						spawn()
-							P.shoot_exhaust(backward = 3)
+				for(var/obj/structure/shuttle/engine/propulsion/P in shuttle.linked_area)
+					spawn()
+						P.shoot_exhaust(backward = 3)
 
 				var/collision_imminent = FALSE
 				for(var/datum/shuttle/escape/pod/pod in escape_pods)
@@ -422,8 +415,7 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 				warmup_sound = 1
 				hyperspace_sounds("begin")
 			// Just before it leaves, close the damn doors!
-			if(timeleft <= 2 && !takeoff)
-				takeoff = 1
+			if(timeleft == 2 || timeleft == 1)
 				for(var/obj/machinery/door/unpowered/shuttle/D in shuttle.linked_area)
 					spawn(0)
 						D.close()

--- a/code/controllers/subsystem/emergency_shuttle.dm
+++ b/code/controllers/subsystem/emergency_shuttle.dm
@@ -4,7 +4,7 @@ var/datum/subsystem/emergency_shuttle/SSemergency_shuttle
 /datum/subsystem/emergency_shuttle
 	name       = "Emergency Shuttle"
 	init_order = SS_INIT_EMERGENCY_SHUTTLE
-	wait       = 1
+	wait       = 2 SECONDS
 	flags      = SS_KEEP_TIMING | SS_NO_TICK_CHECK
 
 
@@ -20,4 +20,4 @@ var/datum/subsystem/emergency_shuttle/SSemergency_shuttle
 
 
 /datum/subsystem/emergency_shuttle/fire(resumed = FALSE)
-	emergency_shuttle.process(times_fired)
+	emergency_shuttle.process()

--- a/code/controllers/subsystem/supply_shuttle.dm
+++ b/code/controllers/subsystem/supply_shuttle.dm
@@ -19,7 +19,7 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 	name       = "Supply Shuttle"
 	init_order = SS_INIT_SUPPLY_SHUTTLE
 	flags      = SS_NO_TICK_CHECK
-	wait       = 1
+	wait       = 1 SECONDS
 	//supply points have been replaced with MONEY MONEY MONEY - N3X
 	var/credits_per_slip = 5
 	var/credits_per_crate = 5
@@ -101,10 +101,6 @@ var/datum/subsystem/supply_shuttle/SSsupply_shuttle
 
 		centcomm_last_order = world.time
 		centcomm_order_cooldown = rand(modified_min,modified_max)
-
-	for(var/obj/machinery/status_display/supply/S in supply_displays)
-		if(S.mode == 4)
-			S.update()
 
 /datum/supply_order
 	var/ordernum

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -17,8 +17,7 @@
 #define MODE_IMAGE				3
 #define MODE_CARGO_TIMER		4
 
-var/global/list/status_displays = list() //This list contains both normal status displays, and AI status displays
-var/global/list/supply_displays = list()
+var/global/list/status_displays = list() //This list contains both normal status displays, and AI status dispays
 
 /obj/machinery/status_display
 	icon = 'icons/obj/status_display.dmi'
@@ -63,10 +62,6 @@ var/global/list/supply_displays = list()
 	if (ticker && ticker.current_state == GAME_STATE_PLAYING)
 		initialize()
 
-/obj/machinery/status_display/supply/New()
-	..()
-	supply_displays |= src
-
 /obj/machinery/status_display/initialize()
 	..()
 	if(radio_controller)
@@ -76,14 +71,16 @@ var/global/list/supply_displays = list()
 	.=..()
 	status_displays -= src
 
-/obj/machinery/status_display/supply/Destroy()
-	.=..()
-	supply_displays -= src
-
 // timed process
 /obj/machinery/status_display/process()
-	if(mode != MODE_SHUTTLE_TIMER && mode != MODE_CARGO_TIMER) // handled in their subsystems
-		update()
+	if(stat & (FORCEDISABLE|NOPOWER))
+		remove_display()
+		return
+	if(spookymode)
+		spookymode = 0
+		remove_display()
+		return
+	update()
 
 /obj/machinery/status_display/attack_ai(mob/user)
 	if(spookymode)
@@ -134,13 +131,6 @@ var/global/list/supply_displays = list()
 	// set what is displayed
 
 /obj/machinery/status_display/proc/update()
-	if(stat & (FORCEDISABLE|NOPOWER))
-		remove_display()
-		return
-	if(spookymode)
-		spookymode = 0
-		remove_display()
-		return
 	if(friendc && mode!=4) //Makes all status displays except supply shuttle timer display the eye -- Urist
 		set_picture("ai_friend")
 		return


### PR DESCRIPTION
Reverts vgstation-coders/vgstation13#36388 due to a bug where the escape shuttle will immediately leave BEFORE arriving at the station if it takes too long to dock, usually due to shuttle crushing a mob or two. Speeding up the subsystem was a bad idea with unforseen consequences...

This should probably be reimplemented by putting the displays on their own, faster subsystem, and call the dedicated ``/datum/emergency_shuttle/proc/timeleft()`` function to get the true timeleft and implement a similar solution with shuttles in general.

## Why it's good
Admins don't have to deal with the game state breaking anymore. Closes #36886.

## How it was tested
The PR this is reverting was tested, but it wasn't stress tested enough.