### PR TITLE
Adds Missing Shuttlecrush Edit to Shuttle Magic

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -4991,6 +4991,14 @@ access_sec_doors,access_salvage_captain,access_cent_ert,access_syndicate,access_
 			if("can rotate")
 				new_value = input(usr,"0 - rotation disabled, 1 - rotation enabled","Shuttle editing",S.can_rotate) as num
 				S.can_rotate = new_value
+			if("destroy areas")
+				new_value = input(usr,"Allow this shuttle to crush into areas? Currently set to: [S.destroy_everything ? "True" : "False"]","Shuttle editing") as null|anything in list("CRUSH","No crush")
+				if(new_value == "CRUSH")
+					S.destroy_everything = TRUE
+				else if(new_value == "No crush")
+					S.destroy_everything = FALSE
+				else
+					return
 			if("DEFINED LOCATIONS")
 				to_chat(usr, "To prevent accidental mistakes, you can only set these locations to docking ports in the shuttle's memory (use the \"Add a destination docking port to a shuttle\" command)")
 


### PR DESCRIPTION
# Nobody told the coders...

![image](https://github.com/user-attachments/assets/6b8ee67a-2d22-478e-847b-bc597dad00e9)


## What this does
Fixes the dead option in the Shuttle Magic panel to toggle the destroy_everything variable. Most admins with vv used things like vv to directly edit the variable, but admins without this ability desired the option to edit this value.

## Why it's good
silent can shuttlecrush people

## How it was tested
Opened the panel, tried the options out on various shuttles, canceling, verifying the variable was changed, etc.
![image](https://github.com/user-attachments/assets/4921bdb0-deeb-49ad-95b7-b2237d34749e)
