### PR TITLE
Possible fix for shuttle leaving early

### DIFF
--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -236,8 +236,6 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 /datum/emergency_shuttle/proc/shuttle_phase(var/phase, var/casual = 1)
 	switch (phase)
 		if ("station")
-			location = 1
-
 			if(shuttle && istype(shuttle,/datum/shuttle/escape))
 				var/datum/shuttle/escape/E = shuttle
 				E.open_all_doors()
@@ -253,6 +251,9 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 				send2ickdiscord("The **Emergency Shuttle** has docked with the station.")
 				command_alert(/datum/command_alert/emergency_shuttle_docked)
 				world << sound('sound/AI/shuttledock.ogg')
+
+			location = 1
+
 			if(ticker)
 				ticker.shuttledocked_time = world.time / 10
 				ticker.mode.ShuttleDocked(1)

--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -236,14 +236,6 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 /datum/emergency_shuttle/proc/shuttle_phase(var/phase, var/casual = 1)
 	switch (phase)
 		if ("station")
-			if(shuttle && istype(shuttle,/datum/shuttle/escape))
-				var/datum/shuttle/escape/E = shuttle
-				E.open_all_doors()
-				if(!E.move_to_dock(E.dock_station, 0, E.dir)) //Throw everything forward, on chance that there's anybody in the shuttle
-					message_admins("WARNING: THE EMERGENCY SHUTTLE COULDN'T MOVE TO THE STATION! PANIC PANIC PANIC")
-			else
-				message_admins("WARNING: THERE IS NO EMERGENCY SHUTTLE! PANIC")
-
 			if (!casual)
 				settimeleft(SHUTTLELEAVETIME)
 				send2mainirc("The Emergency Shuttle has docked with the station.")
@@ -253,6 +245,14 @@ var/global/datum/emergency_shuttle/emergency_shuttle
 				world << sound('sound/AI/shuttledock.ogg')
 
 			location = 1
+
+			if(shuttle && istype(shuttle,/datum/shuttle/escape))
+				var/datum/shuttle/escape/E = shuttle
+				E.open_all_doors()
+				if(!E.move_to_dock(E.dock_station, 0, E.dir)) //Throw everything forward, on chance that there's anybody in the shuttle
+					message_admins("WARNING: THE EMERGENCY SHUTTLE COULDN'T MOVE TO THE STATION! PANIC PANIC PANIC")
+			else
+				message_admins("WARNING: THERE IS NO EMERGENCY SHUTTLE! PANIC")
 
 			if(ticker)
 				ticker.shuttledocked_time = world.time / 10


### PR DESCRIPTION
[bugfix]

## What this does
moves all the code that sets the time left on the shuttle dock to before the code that moves it (where shuttle crushing happens)
Closes #36886.

## How it was tested
spawning clothed copies of a spawned character in buildmode where the escape shuttle lands and letting them get gibbed

## Changelog
:cl:
 * bugfix: Escape shuttles no longer leave prematurely if crushing too many objects underneath