### PR TITLE
Fixes chameleon alpha not resetting on removal

### DIFF
--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -68,6 +68,7 @@
 /datum/dna/gene/basic/stealth/chameleon/deactivate(var/mob/M, var/connected, var/flags)
 	if(!..())
 		return 0
+	M.alphas["chameleon_stealth"] = 255
 	M.unregister_event(/event/moved, src, nameof(src::mob_moved()))
 	return 1
 


### PR DESCRIPTION
[bugfix]

## What this does
Closes #36971.

## How it was tested
activating chameleon gene, moving, deactivating it

## Changelog
:cl:
 * bugfix: The chameleon DNA gene now properly sets mob alpha back to normal when deactivated.