### PR TITLE
Adds mining surprise and hobo shack areas to global areas list

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -2851,6 +2851,7 @@ var/list/shack_names = list("abandoned","deserted","forsaken","stranded","isolat
 			allthings.change_area(src, new_area)
 
 	new_area.tag = "[new_area.type]/\ref[ME]"
+	areas |= new_area
 
 	var/pick_name = pick(shack_names)
 	shack_names -= pick_name

--- a/code/modules/mining/surprise.dm
+++ b/code/modules/mining/surprise.dm
@@ -367,6 +367,7 @@ var/global/list/mining_surprises = typesof(/mining_surprise)-/mining_surprise
 
 	room.UpdateTurfs()
 	postProcessRoom(room)
+	areas |= complex_area
 	rooms += room
 	message_admins("Room spawned at [formatJumpTo(start_loc)]")
 


### PR DESCRIPTION
[bugfix]

## What this does
noticed these don't show up in the areas list for iterations purposes, hope this helps

## Why it's good
lighting is back on them

## How it was tested
loading the map up and looking around the mine, admin jump to area verb

## Changelog
:cl:
 * bugfix: The hobo shacks and mine surprises now have dynamic lighting again.
 * bugfix: Ghosts and admins can now jump to the areas of mining surprises and hobo shacks.