### PR TITLE
unpowered uvent overlay fix

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -70,7 +70,7 @@
 	overlays = null
 	icon_state = welded ? "weld" : "base"
 
-	if (on && ~stat & (FORCEDISABLE|NOPOWER|BROKEN))
+	if (on && !(stat & (FORCEDISABLE|NOPOWER|BROKEN)))
 		overlays += pump_direction ? "out" : "in"
 
 	..()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
fixes a part of #35711

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->

## How it was tested
![image](https://github.com/user-attachments/assets/40b0104a-c15d-424c-bd89-5c012f222e51)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: vent pumps no longer appear on when unpowered
