### PR TITLE
Makes "no" the default option on clipping on admin map element loading

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1201,7 +1201,7 @@ var/list/admin_verbs_mod = list(
 	var/clipmax_y = INFINITY
 	var/clipmin_z = 0
 	var/clipmax_z = INFINITY
-	if(alert("Clip map to bounds?","Map element loading","Yes","No") == "Yes")
+	if(alert("Clip map to bounds?","Map element loading","No","Yes") == "Yes")
 		clipmin_x = input(usr, "Minimum X to clip at", "Map element loading", "1") as null|num
 		if(clipmin_x == null)
 			return


### PR DESCRIPTION
[administration]

## What this does
swaps yes and no, making "no" the option pressing enter defaults on when the window is up

## Why it's good
no extra default menu you have to press tab to avoid (now the clipping one needs it)

## How it was tested
loading a map element

## Changelog
:cl:
 * tweak: "No" is now the default option when being asked to clip a map element to bounds when loading a custom one