### PR TITLE
Fixes grammar, typos and formatting on small cage merch description (and all double full stops)

### DIFF
--- a/code/game/gamemodes/wizard/artifacts.dm
+++ b/code/game/gamemodes/wizard/artifacts.dm
@@ -36,7 +36,7 @@
 
 /datum/spellbook_artifact/staff_of_swapping
 	name = "Staff of Swapping"
-	desc = "An artefact that fires a glowing bolt of energy which transfers the caster and targets position in space. Wielding in it both hands increases the power of the staff, and allows it to pass through certain objects.."
+	desc = "An artefact that fires a glowing bolt of energy which transfers the caster and targets position in space. Wielding in it both hands increases the power of the staff, and allows it to pass through certain objects."
 	abbreviation = "SW"
 	price = 20
 	spawned_items = list(/obj/item/weapon/gun/energy/staff/swapper)

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -103,7 +103,7 @@
 	build_path = /obj/machinery/computer/card
 /obj/item/weapon/circuitboard/card/centcom
 	name = "Circuit board (CentCom ID Computer)"
-	desc = "A circuit board for running a computer used for granting access to areas at Central Command.."
+	desc = "A circuit board for running a computer used for granting access to areas at Central Command."
 	build_path = /obj/machinery/computer/card/centcom
 //obj/item/weapon/circuitboard/shield
 //	name = "Circuit board (Shield Control)"

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -797,7 +797,7 @@ to destroy them and players will be able to make replacements.
 
 /obj/item/weapon/circuitboard/reagentgrinder
 	name = "Circuit Board (All-In-One Grinder)"
-	desc = "A circuit board used to run a machine that grinds or juices solid items.."
+	desc = "A circuit board used to run a machine that grinds or juices solid items."
 	build_path = /obj/machinery/reagentgrinder
 	board_type = MACHINE
 	origin_tech = Tc_PROGRAMMING + "=3;" + Tc_ENGINEERING + "=2"

--- a/code/game/machinery/suit_dispenser.dm
+++ b/code/game/machinery/suit_dispenser.dm
@@ -19,7 +19,7 @@ var/list/dispenser_presets = list()
 
 /obj/machinery/suit_dispenser
 	name = "Suit Dispenser"
-	desc = "An industrial U-Tak-It Dispenser unit designed to fetch all kinds of space suits.."
+	desc = "An industrial U-Tak-It Dispenser unit designed to fetch all kinds of space suits."
 	icon = 'icons/obj/suitdispenser.dmi'
 	icon_state = "suitdispenser"
 	anchored = 1

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -159,7 +159,7 @@
 		O.name = "used stasis bag"
 		O.icon = src.icon
 		O.icon_state = "bodybag_used"
-		O.desc = "Pretty useless now.."
+		O.desc = "Pretty useless now."
 		qdel(src)
 
 /obj/structure/closet/body_bag/cryobag/MouseDropFrom(over_object, src_location, over_location)

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -622,7 +622,7 @@
 
 /obj/item/weapon/dnainjector/nofail/antijumpy
 	name = "DNA-Injector (Anti-Jumpy)"
-	desc = "Awwe.."
+	desc = "Awwe."
 	datatype = DNA2_BUF_SE
 	value = 0x001
 	//block = 2

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -5806,7 +5806,7 @@ access_sec_doors,access_salvage_captain,access_cent_ert,access_syndicate,access_
 					return FALSE
 				vars[href_list["change_zone_del"]] = new_limit
 			if ("z_del")
-				var/new_limit = input(usr, "Input the new z-level..", "Setting [href_list["change_zone_del"]]") as null|num
+				var/new_limit = input(usr, "Input the new z-level.", "Setting [href_list["change_zone_del"]]") as null|num
 				if (new_limit < 1 || new_limit > 6)
 					to_chat(usr, "<span class='warning'>Please enter a number between 1 and 6.</span>")
 					return FALSE

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -326,7 +326,7 @@ BLIND     // can't see anything
 
 /obj/item/clothing/glasses/welding/superior
 	name = "superior welding goggles"
-	desc = "Welding goggles made from more expensive materials, strangely smells like potatoes. Allows for better vision than normal goggles.."
+	desc = "Welding goggles made from more expensive materials, strangely smells like potatoes. Allows for better vision than normal goggles."
 	icon_state = "rwelding-g"
 	item_state = "rwelding-g"
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)

--- a/code/modules/events/money_spam.dm
+++ b/code/modules/events/money_spam.dm
@@ -59,7 +59,7 @@
 					"Deposit 100$ and get 300$ totally free!", \
 					" 100K NT.|WOWGOLD �nly $89            <HOT>", \
 					"We have been filed with a complaint from one of your customers in respect of their business relations with you.", \
-					"We kindly ask you to open the COMPLAINT REPORT (attached) to reply on this complaint..")
+					"We kindly ask you to open the COMPLAINT REPORT (attached) to reply on this complaint.")
 				if(4)
 					sender = pick("Buy Dr. Maxman", "Having dysfuctional troubles?")
 					message = pick("DR MAXMAN: REAL Doctors, REAL Science, REAL Results!", \

--- a/code/modules/genetics/side_effects.dm
+++ b/code/modules/genetics/side_effects.dm
@@ -21,7 +21,7 @@
 	duration = 30 SECONDS
 
 /datum/genetics/side_effect/genetic_burn/start(mob/living/carbon/human/H)
-	H.emote("me", 1, "starts turning very red..")
+	H.emote("me", 1, "starts turning very red.")
 
 /datum/genetics/side_effect/genetic_burn/finish(mob/living/carbon/human/H)
 	if(!H.reagents.has_reagent(DEXALIN))

--- a/code/modules/mob/dead/observer/verbs.dm
+++ b/code/modules/mob/dead/observer/verbs.dm
@@ -459,7 +459,7 @@
 /mob/dead/observer/verb/find_arena()
 	set category = "Ghost"
 	set name = "Find Arenas"
-	set desc = "Try to find an Arena to polish your robust bomb placement skills.."
+	set desc = "Try to find an Arena to polish your robust bomb placement skills."
 
 	if(!arenas.len)
 		to_chat(usr, "There are no arenas in the world! Ask the admins to spawn one.")

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -824,7 +824,7 @@
 	to_chat(user, "You pull the tab, you feel the drink heat up in your hands, and its horrible fumes hits your nose like a ton of bricks. You drop the soup in disgust.")
 	var/turf/T = get_turf(user.loc)
 	var/obj/item/weapon/reagent_containers/food/drinks/discount_ramen_hot/A = new /obj/item/weapon/reagent_containers/food/drinks/discount_ramen_hot(T)
-	A.desc += " It feels warm.." //This is required
+	A.desc += " It feels warm." //This is required
 	user.drop_from_inventory(src)
 	qdel(src)
 

--- a/code/modules/reagents/reagents/reagents_dan.dm
+++ b/code/modules/reagents/reagents/reagents_dan.dm
@@ -81,7 +81,7 @@
 /datum/reagent/refriedbeans
 	name = "Re-Fried Beans"
 	id = REFRIEDBEANS
-	description = "Mmm.."
+	description = "Mmm..."
 	reagent_state = REAGENT_STATE_LIQUID
 	color = "#6F884F" //rgb: 255,255,255 //to-do
 	nutriment_factor = 1 * REAGENTS_METABOLISM

--- a/code/modules/research/designs/boards/computer_engie.dm
+++ b/code/modules/research/designs/boards/computer_engie.dm
@@ -2,7 +2,7 @@
 
 /datum/design/atmosalerts
 	name = "Circuit Design (Atmosphere Alert)"
-	desc = "Allows for the construction of circuit boards used to build an atmosphere alert console.."
+	desc = "Allows for the construction of circuit boards used to build an atmosphere alert console."
 	id = "atmosalerts"
 	req_tech = list(Tc_PROGRAMMING = 2)
 	build_type = IMPRINTER

--- a/code/modules/spells/spider_spells.dm
+++ b/code/modules/spells/spider_spells.dm
@@ -76,7 +76,7 @@
 
 /spell/spider_eggs
 	name = "Lay Eggs"
-	desc = "Lay some eggs that will give birth to more spiderlings after a few minutes.."
+	desc = "Lay some eggs that will give birth to more spiderlings after a few minutes."
 	user_type = USER_TYPE_SPIDER
 
 	charge_max = 0

--- a/code/modules/store/items.dm
+++ b/code/modules/store/items.dm
@@ -269,7 +269,7 @@
 
 /datum/storeitem/critter_cage
 	name = "Small Cage"
-	desc = "A cage where to keep tiny animals safe. Fit with a drinking bottle that can be refilled."
+	desc = "A cage that keeps tiny animals safe. Fit with a drinking bottle that can be refilled."
 	typepath = /obj/item/critter_cage
 	cost = 60
 	category = "Luxury"

--- a/code/modules/store/items.dm
+++ b/code/modules/store/items.dm
@@ -268,8 +268,8 @@
 	category = "Luxury"
 
 /datum/storeitem/critter_cage
-	name = "small cage"
-	desc = "A cage where to keep tiny animals safe. Fit with a drinking bottle that can be refilled.."
+	name = "Small Cage"
+	desc = "A cage where to keep tiny animals safe. Fit with a drinking bottle that can be refilled."
 	typepath = /obj/item/critter_cage
 	cost = 60
 	category = "Luxury"

--- a/code/modules/virus2/curer.dm
+++ b/code/modules/virus2/curer.dm
@@ -17,7 +17,7 @@
 				container = I
 	if(istype(I,/obj/item/weapon/virusdish))
 		if(virusing)
-			to_chat(user, "<b>The pathogen materializer is still recharging..")
+			to_chat(user, "<b>The pathogen materializer is still recharging</b>")
 			return
 		var/obj/item/weapon/reagent_containers/glass/beaker/product = new(src.loc)
 

--- a/code/modules/virus2/effect/stage_1.dm
+++ b/code/modules/virus2/effect/stage_1.dm
@@ -74,7 +74,7 @@
 /datum/disease2/effect/headache
 	name = "Headache"
 	desc = "Gives the infected a light headache."
-	encyclopedia = "It won't actually cause any damage to the infected's organs.."
+	encyclopedia = "It won't actually cause any damage to the infected's organs."
 	stage = 1
 	badness = EFFECT_DANGER_FLAVOR
 
@@ -158,7 +158,7 @@
 /datum/disease2/effect/bee_vomit
 	name = "Melisso-Emeto Syndrome"
 	desc = "Converts the lungs of the infected into a bee-hive."
-	encyclopedia = "Giving the infected a steady drip of honey in exchange of coughing up a bee every so often. The higher the symptom strength, the more honey is generated, and the more bees will be coughed up and more often as well. While Honey is a great healing reagent, it is also high on nutrients. Expect to become fat quickly.."
+	encyclopedia = "Giving the infected a steady drip of honey in exchange of coughing up a bee every so often. The higher the symptom strength, the more honey is generated, and the more bees will be coughed up and more often as well. While Honey is a great healing reagent, it is also high on nutrients. Expect to become fat quickly."
 	stage = 1
 	badness = EFFECT_DANGER_ANNOYING
 	max_multiplier = 10


### PR DESCRIPTION
[grammar]

## What this does
Closes #37013.

## Changelog
:cl:
 * spellcheck: The merch computer entry for small cages now has a capitalised title, better grammar, and no extra full stop.
 * spellcheck: Every other erroneous double full stop has also been fixed.