### PR TITLE
Adds attack sounds for pickaxes and derived tools

### DIFF
--- a/code/game/objects/items/robot/robot_items/robot_axe.dm
+++ b/code/game/objects/items/robot/robot_items/robot_axe.dm
@@ -12,6 +12,7 @@
 	attack_verb = list("chops", "cleaves", "tears", "cuts")
 	toolspeed = 0.5
 	toolsounds = list('sound/items/metal_impact.ogg')
+	hitsound = 'sound/weapons/empty.ogg'
 	var/list/activated_toolsounds = list('sound/items/Welder2.ogg')
 	var/active = FALSE
 	var/overheat = FALSE

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -82,6 +82,7 @@
 	origin_tech = Tc_MATERIALS + "=1;" + Tc_ENGINEERING + "=1"
 	attack_verb = list("hits", "pierces", "slices", "attacks")
 	toolsounds = list('sound/weapons/Genhit.ogg')
+	hitsound = "sound/weapons/bloodyslice.ogg"
 	var/drill_verb = "picking"
 	var/diggables = DIG_ROCKS
 	var/excavation_amount = 100
@@ -98,6 +99,7 @@
 	//icon_state = "sledgehammer" Waiting on sprite
 	desc = "A mining hammer made of reinforced metal. You feel like smashing your boss in the face with this."
 	drill_verb = "hammering"
+	hitsound = "sound/weapons/toolbox.ogg"
 
 /obj/item/weapon/pickaxe/silver
 	name = "silver pickaxe"
@@ -155,6 +157,7 @@
 	diggables = DIG_ROCKS | DIG_WALLS
 	drill_verb = "cutting"
 	toolsounds = list('sound/items/Welder.ogg')
+	hitsound = "sound/weapons/welderattack.ogg"
 
 /obj/item/weapon/pickaxe/plasmacutter/accelerator
 	name = "plasma cutter"
@@ -237,7 +240,7 @@
 	origin_tech = Tc_MATERIALS + "=2;" + Tc_POWERSTORAGE + "=3;" + Tc_ENGINEERING + "=2"
 	desc = "Yours is the drill that will pierce through the rock walls."
 	drill_verb = "drilling"
-
+	hitsound = 'sound/weapons/circsawhit.ogg'
 	diggables = DIG_ROCKS | DIG_SOIL //drills are multipurpose
 
 /obj/item/weapon/pickaxe/drill/diamond //When people ask about the badass leader of the mining tools, they are talking about ME!
@@ -272,8 +275,7 @@
 	w_type = RECYK_MISC
 	origin_tech = Tc_MATERIALS + "=1;" + Tc_ENGINEERING + "=1"
 	attack_verb = list("bashes", "bludgeons", "thrashes", "whacks")
-
-
+	hitsound = "trayhit"
 	toolspeed = 0.4
 	diggables = DIG_SOIL //soil only
 


### PR DESCRIPTION
[sound][oversight]

## What this does
Closes #14280.

## Why it's good
less silent shuffling

## How it was tested
attacking spawned humans with the objects

## Changelog
:cl:
 * tweak: Pickaxes, shovels, mining drills and plasma torches now have appropriate hit sounds when attacking people, instead of none at all.