### PR TITLE
Ports most emag attackby() to emag_act()

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -27,6 +27,7 @@
 		var/obj/item/weapon/card/emag/E = W
 		if(E.canUse(user,src))
 			emag_act(user)
+			return 1
 
 /mob/living/attackby(obj/item/I, mob/user, var/no_delay = 0, var/originator = null, var/def_zone = null)
 	if(!no_delay)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -23,6 +23,10 @@
 		visible_message("<span class='danger'>[src] has been hit by [user] with [W].</span>")
 	if(W.material_type)
 		W.material_type.on_use(W, src, user)
+	if(can_emag() && isEmag(W))
+		var/obj/item/weapon/card/emag/E = W
+		if(E.canUse(user,src))
+			emag_act(user)
 
 /mob/living/attackby(obj/item/I, mob/user, var/no_delay = 0, var/originator = null, var/def_zone = null)
 	if(!no_delay)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -27,6 +27,10 @@
 
 /atom/movable/proc/emag_check(obj/item/weapon/card/emag/E, mob/user)
 	if(can_emag() && istype(E) && E.canUse(user,src))
+		if(E.arcanetampered && prob(50))
+			arcane_act(user)
+			if(prob(50))
+				return TRUE
 		emag_act(user)
 		return TRUE
 	return FALSE

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -23,11 +23,15 @@
 		visible_message("<span class='danger'>[src] has been hit by [user] with [W].</span>")
 	if(W.material_type)
 		W.material_type.on_use(W, src, user)
+	return emag_check()
+
+/atom/movable/proc/emag_check(obj/item/W, mob/user)
 	if(can_emag() && isEmag(W))
 		var/obj/item/weapon/card/emag/E = W
 		if(E.canUse(user,src))
 			emag_act(user)
-			return 1
+			return TRUE
+	return FALSE
 
 /mob/living/attackby(obj/item/I, mob/user, var/no_delay = 0, var/originator = null, var/def_zone = null)
 	if(!no_delay)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -25,12 +25,10 @@
 		W.material_type.on_use(W, src, user)
 	return emag_check()
 
-/atom/movable/proc/emag_check(obj/item/W, mob/user)
-	if(can_emag() && isEmag(W))
-		var/obj/item/weapon/card/emag/E = W
-		if(E.canUse(user,src))
-			emag_act(user)
-			return TRUE
+/atom/movable/proc/emag_check(obj/item/weapon/card/emag/E, mob/user)
+	if(can_emag() && istype(E) && E.canUse(user,src))
+		emag_act(user)
+		return TRUE
 	return FALSE
 
 /mob/living/attackby(obj/item/I, mob/user, var/no_delay = 0, var/originator = null, var/def_zone = null)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -586,6 +586,9 @@ its easier to just keep the beam vertical.
 /atom/proc/singularity_pull()
 	return
 
+/atom/proc/can_emag()
+	return TRUE
+
 /atom/proc/emag_act(var/mob/user)
 	return
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -56,6 +56,7 @@ var/global/list/ghdel_profiling = list()
 	/// The chat color var, without alpha.
 	var/chat_color_hover
 
+	var/emagged = 0 // Some things other than machinery can be
 	var/arcanetampered = 0 //A looot of things can be
 
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -57,6 +57,7 @@ var/global/list/ghdel_profiling = list()
 	var/chat_color_hover
 
 	var/emagged = 0 // Some things other than machinery can be
+	var/emag_cost = 0 // Emag energy cost (in MJ)
 	var/arcanetampered = 0 //A looot of things can be
 
 
@@ -586,6 +587,15 @@ its easier to just keep the beam vertical.
 
 /atom/proc/singularity_pull()
 	return
+
+/**
+ * Returns the cost of emagging this machine (emag_cost by default)
+ * @param user /mob The mob that used the emag.
+ * @param emag /obj/item/weapon/card/emag The emag used on this device.
+ * @return number Cost to emag.
+ */
+/atom/proc/getEmagCost(var/mob/user, var/obj/item/weapon/card/emag/emag)
+	return emag_cost
 
 /atom/proc/can_emag()
 	return TRUE

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -715,7 +715,7 @@
 				to_chat(user, "<span class='notice'>Unable to repair with the maintenance panel closed.</span>")
 		else
 			to_chat(user, "<span class='notice'>[src] does not need a repair.</span>")
-	else if (istype(W, /obj/item/weapon/card/emag) && emagged < 2)
+	else if (isEmag(W) && emagged < 2)
 		emag_act(user)
 	else
 		if(isobj(W))

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -715,8 +715,8 @@
 				to_chat(user, "<span class='notice'>Unable to repair with the maintenance panel closed.</span>")
 		else
 			to_chat(user, "<span class='notice'>[src] does not need a repair.</span>")
-	else if (isEmag(W) && emagged < 2)
-		emag_act(user)
+	else if (emagged < 2)
+		emag_check(W,user)
 	else
 		if(isobj(W))
 			W.on_attack(src, user)

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -26,6 +26,7 @@
 	luminosity = 3
 	use_power = MACHINE_POWER_USE_NONE
 	pAImovement_delay = 1
+	machine_flags = EMAGGABLE
 	var/icon_initial //To get around all that pesky hardcoding of icon states, don't put modifiers on this one
 	var/obj/item/weapon/card/id/botcard			// the ID card that the bot "holds"
 	var/mob/living/simple_animal/hostile/pulse_demon/PD_occupant // for when they take over them

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -23,7 +23,6 @@
 	//var/lasers = 0
 
 	var/threatlevel = 0
-//var/emagged = 0 //Emagged Secbots view everyone as a criminal
 	var/check_records = 1 //Does it check security records?
 	var/arrest_type = 0 //If true, don't handcuff
 

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -136,11 +136,8 @@ var/global/mulebot_count = 0
 // other: chance to knock rider off bot
 /obj/machinery/bot/mulebot/attackby(obj/item/I, mob/user)
 	user.delayNextAttack(I.attack_delay)
-	if(isEmag(I))
-		toggle_lock(user, TRUE)
-		to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] [src]'s controls!</span>")
-		flick("[icon_initial]-emagged", src)
-		playsound(src, 'sound/effects/sparks1.ogg', 100, 0)
+	if(emag_check(I,user))
+		return	
 	else if(istype(I, /obj/item/weapon/card/id))
 		if(toggle_lock(user))
 			to_chat(user, "<span class='notice'>Controls [(locked ? "locked" : "unlocked")].</span>")
@@ -187,6 +184,11 @@ var/global/mulebot_count = 0
 			user.visible_message("<span class='warning'>[user] knocks [load] off [src] with \the [I]!</span>", "<span class='warning'>You knock [load] off [src] with \the [I]!</span>")
 		. = ..()
 
+/obj/machinery/bot/mulebot/emag_act(mob/user)
+	toggle_lock(user, TRUE)
+	to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] [src]'s controls!</span>")
+	flick("[icon_initial]-emagged", src)
+	playsound(src, 'sound/effects/sparks1.ogg', 100, 0)
 
 /obj/machinery/bot/mulebot/ex_act(var/severity)
 	unload(0)

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -136,7 +136,7 @@ var/global/mulebot_count = 0
 // other: chance to knock rider off bot
 /obj/machinery/bot/mulebot/attackby(obj/item/I, mob/user)
 	user.delayNextAttack(I.attack_delay)
-	if(istype(I,/obj/item/weapon/card/emag))
+	if(isEmag(I))
 		toggle_lock(user, TRUE)
 		to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] [src]'s controls!</span>")
 		flick("[icon_initial]-emagged", src)

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -16,7 +16,6 @@
 	req_one_access = list(access_security, access_forensics_lockers)
 	control_filter = RADIO_SECBOT
 	var/check_records = 1
-//	var/emagged = 0 //Emagged Secbots view everyone as a criminal
 
 	var/idcheck = 0 //If true, arrest people with no IDs
 	var/weaponscheck = 0 //If true, arrest people for weapons if they lack access	var/check_records = 1 //Does it check security records?

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -57,7 +57,7 @@ var/global/list/atmos_controllers = list()
 	return interact(user)
 
 /obj/machinery/computer/atmoscontrol/attackby(var/obj/item/I as obj, var/mob/user as mob)
-	if(istype(I, /obj/item/weapon/card/emag))
+	if(isEmag(I))
 		return //lazy hackfix for the UI opening and not updating when using an emag with the UI closed
 	return ..()
 
@@ -271,7 +271,7 @@ var/global/list/atmos_controllers = list()
 		if (istype(I, /obj/item/device/pda))
 			var/obj/item/device/pda/pda = I
 			I = pda.id
-		if (istype(I,/obj/item/weapon/card/emag))
+		if(isEmag(I))
 			emag_act(I, usr)
 		if (I && istype(I))
 			log_in_id = I

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -271,8 +271,7 @@ var/global/list/atmos_controllers = list()
 		if (istype(I, /obj/item/device/pda))
 			var/obj/item/device/pda/pda = I
 			I = pda.id
-		if(isEmag(I))
-			emag_act(I, usr)
+		emag_check(I,M)
 		if (I && istype(I))
 			log_in_id = I
 		return 1

--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -212,11 +212,6 @@ For vending packs, see vending_packs.dm*/
 
 	add_fingerprint(user)
 
-	if(istype(I,/obj/item/weapon/card/emag) && !hacked)
-		to_chat(user, "<span class='notice'>Special supplies unlocked.</span>")
-		hacked = 1
-		can_order_contraband = 1
-		return
 	if(I.is_screwdriver(user))
 		I.playtoolsound(loc, 50)
 		if(do_after(user, src, 20))
@@ -251,11 +246,13 @@ For vending packs, see vending_packs.dm*/
 	else
 		return ..()
 
-/obj/machinery/computer/supplycomp/emag_ai(mob/living/silicon/ai/A)
-	to_chat(A, "<span class='warning'>Special supplies unlocked.</span>")
-	hacked = 1
-	can_order_contraband = 1
-
+/obj/machinery/computer/supplycomp/emag_act(mob/user)
+	if(!hacked)
+		to_chat(user, "<span class='warning'>Special supplies unlocked.</span>")
+		hacked = 1
+		can_order_contraband = 1
+	else
+		return ..()
 
 /obj/machinery/computer/supplycomp/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open=NANOUI_FOCUS)
 	if(!current_acct)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1611,5 +1611,5 @@ About the new airlock wires panel:
 		aiControlDisabled = 0
 
 /obj/machinery/door/airlock/tackled(mob/living/carbon/human/user)
-	if(ishuman(user) && isEmag(user.wear_id)
+	if(ishuman(user) && isEmag(user.wear_id))
 		emag_act()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -59,7 +59,7 @@
 	explosion_block = 1
 
 	emag_cost = 1 // in MJ
-	machine_flags = SCREWTOGGLE | WIREJACK
+	machine_flags = SCREWTOGGLE | WIREJACK | EMAGGABLE
 	animation_delay = 5
 
 	hack_abilities = list(

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1337,7 +1337,7 @@ About the new airlock wires panel:
 						to_chat(user, "<span class='warning'>You need to be wielding \the [F] to do that.</span>")
 				else
 					spawn(0)	close(1)
-	else if (istype(I, /obj/item/weapon/card/emag))
+	else if(isEmag(I))
 		emag_act(src)
 	else if(istype(I, /obj/item/stack/rods) && boltsDestroyed)
 		var/obj/item/stack/rods/rawd=I
@@ -1611,5 +1611,5 @@ About the new airlock wires panel:
 		aiControlDisabled = 0
 
 /obj/machinery/door/airlock/tackled(mob/living/carbon/human/user)
-	if(ishuman(user) && istype(user.wear_id, /obj/item/weapon/card/emag))
+	if(ishuman(user) && isEmag(user.wear_id)
 		emag_act()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1337,8 +1337,8 @@ About the new airlock wires panel:
 						to_chat(user, "<span class='warning'>You need to be wielding \the [F] to do that.</span>")
 				else
 					spawn(0)	close(1)
-	else if(isEmag(I))
-		emag_act(src)
+	else if(emag_check(I,user))
+		return
 	else if(istype(I, /obj/item/stack/rods) && boltsDestroyed)
 		var/obj/item/stack/rods/rawd=I
 		if(rawd.amount <4)
@@ -1611,5 +1611,5 @@ About the new airlock wires panel:
 		aiControlDisabled = 0
 
 /obj/machinery/door/airlock/tackled(mob/living/carbon/human/user)
-	if(ishuman(user) && isEmag(user.wear_id))
-		emag_act(user)
+	if(ishuman(user))
+		emag_check(user.wear_id,user)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1612,4 +1612,4 @@ About the new airlock wires panel:
 
 /obj/machinery/door/airlock/tackled(mob/living/carbon/human/user)
 	if(ishuman(user) && isEmag(user.wear_id))
-		emag_act()
+		emag_act(user)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -383,7 +383,10 @@ var/global/list/alert_overlays_global = list()
 	if(density)
 		door_animate("spark")
 		sleep(6)
-		open()
+		if(isAI(user) || ispulsedemon(user))
+			open()
+		else
+			force_open(user)
 		sleep(8)
 	blocked = TRUE
 	update_icon()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -360,13 +360,7 @@ var/global/list/alert_overlays_global = list()
 			to_chat(user, "<span class = 'attack'>\The [src] is not welded or otherwise blocked.</span>")
 
 	if(isEmag(C))
-		if(density)
-			door_animate("spark")
-			sleep(6)
-			force_open(user, C)
-			sleep(8)
-		blocked = TRUE
-		update_icon()
+		emag_act(user)
 		return
 
 	do_interaction(user, C)
@@ -384,7 +378,7 @@ var/global/list/alert_overlays_global = list()
 			flick("door_deny", src)
 			anim(target = src, a_icon = icon, flick_anim = "door_deny-moody", sleeptime = 5, plane = ABOVE_LIGHTING_PLANE, blend = BLEND_ADD)
 
-/obj/machinery/door/firedoor/emag_ai(mob/living/silicon/ai/A)
+/obj/machinery/door/firedoor/emag_act(mob/user)
 	if(density)
 		door_animate("spark")
 		sleep(6)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -76,6 +76,8 @@ var/global/list/alert_overlays_global = list()
 
 	animation_delay_predensity_opening = 3
 	animation_delay_predensity_closing = 7
+	
+	machine_flags = SCREWTOGGLE | EMAGGABLE
 
 	var/list/alert_overlays_local
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -359,8 +359,7 @@ var/global/list/alert_overlays_global = list()
 		else
 			to_chat(user, "<span class = 'attack'>\The [src] is not welded or otherwise blocked.</span>")
 
-	if(isEmag(C))
-		emag_act(user)
+	if(emag_check(C,user))
 		return
 
 	do_interaction(user, C)

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -15,6 +15,9 @@
 	if (!locked)
 		..()
 
+/obj/machinery/door/unpowered/emag_check(obj/item/weapon/card/emag/E, mob/user)
+	return FALSE
+
 /obj/machinery/door/unpowered/attack_hand(mob/user as mob)
 	if(istype(user,/mob/dead/observer))
 		return

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -12,14 +12,8 @@
 
 /obj/machinery/door/unpowered/attackby(obj/item/I as obj, mob/user as mob)
 	// TODO: is energy blade only attack circuity like emag?
-	if(isEmag(I))
-		return
-
-	if (locked)
-		return
-
-	..()
-	return
+	if (!locked)
+		..()
 
 /obj/machinery/door/unpowered/attack_hand(mob/user as mob)
 	if(istype(user,/mob/dead/observer))

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -12,7 +12,7 @@
 
 /obj/machinery/door/unpowered/attackby(obj/item/I as obj, mob/user as mob)
 	// TODO: is energy blade only attack circuity like emag?
-	if (istype(I, /obj/item/weapon/card/emag))
+	if(isEmag(I))
 		return
 
 	if (locked)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -124,7 +124,6 @@ Class Procs:
 	penetration_dampening = 5
 
 	var/stat = 0
-	var/emagged = 0
 	var/use_power = MACHINE_POWER_USE_IDLE
 		//0 = dont run the auto
 		//1 = run auto, use idle

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -671,6 +671,9 @@ Class Procs:
 /obj/machinery/proc/getEmagCost(var/mob/user, var/obj/item/weapon/card/emag/emag)
 	return emag_cost
 
+/obj/machinery/can_emag()
+	return machine_flags & EMAGGABLE
+
 /obj/machinery/attackby(var/obj/item/O, var/mob/user)
 	..()
 
@@ -678,12 +681,6 @@ Class Procs:
 
 	if(O.is_cookvessel && is_cooktop)
 		return 1
-
-	if(isEmag(O) && machine_flags & EMAGGABLE)
-		var/obj/item/weapon/card/emag/E = O
-		if(E.canUse(user,src))
-			emag_act(user)
-			return 1
 
 	if(O.is_wrench(user) && wrenchable()) //make sure this is BEFORE the fixed2work check
 		if(!panel_open)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -153,11 +153,7 @@ Class Procs:
 	 * Machine construction/destruction/emag flags.
 	 */
 	var/machine_flags = 0
-
-	/**
-	 * Emag energy cost (in MJ).
-	 */
-	var/emag_cost = 1
+	emag_cost = 1
 
 	var/inMachineList = 1 // For debugging.
 	var/obj/item/weapon/card/id/scan = null	//ID inserted for identification, if applicable
@@ -659,16 +655,6 @@ Class Procs:
 	// Disable emaggability. Note that some machines such as the Communications Computer might be emaggable multiple times.
 	machine_flags &= ~EMAGGABLE
 	spark(src)
-
-
-/**
- * Returns the cost of emagging this machine (emag_cost by default)
- * @param user /mob The mob that used the emag.
- * @param emag /obj/item/weapon/card/emag The emag used on this device.
- * @return number Cost to emag.
- */
-/obj/machinery/proc/getEmagCost(var/mob/user, var/obj/item/weapon/card/emag/emag)
-	return emag_cost
 
 /obj/machinery/can_emag()
 	return machine_flags & EMAGGABLE

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -674,7 +674,7 @@ Class Procs:
 	return machine_flags & EMAGGABLE
 
 /obj/machinery/attackby(var/obj/item/O, var/mob/user)
-	..()
+	. = ..()
 
 	add_fingerprint(user)
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -59,7 +59,6 @@ var/global/num_vending_terminals = 1
 	var/list/slogan_languages = list()
 	var/icon_vend				//Icon_state when vending!
 	var/icon_deny				//Icon_state when vending!
-	//var/emagged = 0			//Ignores if somebody doesn't have card access to that machine.
 	var/seconds_electrified = 0	//Shock customers like an airlock.
 	var/shoot_inventory = 0		//Fire items at customers! We're broken!
 	var/shut_up = 0				//Stop spouting those godawful pitches!

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -549,7 +549,7 @@ var/global/num_vending_terminals = 1
 		var/obj/item/weapon/spacecash/C = W
 		pay_with_cash(C, user)
 
-	else if(istype(W, /obj/item/weapon/card/emag))
+	else if(isEmag(W))
 		visible_message("<span class='info'>[usr] swipes a card through [src].</span>")
 		to_chat(user, "<span class='notice'>You swipe \the [W] through [src]</span>")
 		if (emag_act())

--- a/code/game/objects/items/beacon.dm
+++ b/code/game/objects/items/beacon.dm
@@ -8,7 +8,6 @@ var/global/list/obj/item/beacon/beacons = list()
 	item_state = "signaler"
 	var/code = "electronic"
 	var/frequency = 1459
-	var/emagged = 0
 	origin_tech = Tc_BLUESPACE + "=1"
 	flags = FPRINT
 	w_type = RECYK_PLASTIC

--- a/code/game/objects/items/cookie_synth.dm
+++ b/code/game/objects/items/cookie_synth.dm
@@ -7,7 +7,6 @@
 	var/toxin = FALSE
 	var/toxin_type = CHLORALHYDRATE
 	var/toxin_amount = 10
-	var/emagged = FALSE
 	var/sound_type = 'sound/machines/click.ogg'
 	var/cooldown = 0
 	var/delay = 15 SECONDS

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -17,7 +17,6 @@
 	origin_tech = Tc_MAGNETS + "=3;" + Tc_MATERIALS + "=2"
 	w_type = RECYK_ELECTRONIC
 	flammable = TRUE
-	var/emagged = 0
 	var/upgraded
 	var/device_mode = LIGHTREPLACER_BASIC
 

--- a/code/game/objects/items/devices/maracas.dm
+++ b/code/game/objects/items/devices/maracas.dm
@@ -11,7 +11,6 @@
 	slot_flags = SLOT_BELT
 	flammable = TRUE
 
-	var/emagged = 0//our maracas are different - Deity Link
 	var/triggered = 0 //Do not make it explode twice
 
 /obj/item/device/maracas/cubanpete

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -31,7 +31,6 @@ var/static/list/mat2type = list(
 	origin_tech = Tc_ENGINEERING + "=4;" + Tc_MATERIALS + "=5;" + Tc_POWERSTORAGE + "=3"
 
 	var/mode = 1 //0 is material selection, 1 is material production
-	var/emagged = 0
 
 	var/obj/item/stack/sheet/active_material = /obj/item/stack/sheet/metal
 	var/list/materials_scanned = list("metal" = /obj/item/stack/sheet/metal,

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -11,7 +11,6 @@
 	flammable = TRUE
 
 	var/spamcheck = 0
-	var/emagged = 0
 	var/insults = 0
 	var/list/insultmsgs = list("FUCK EVERYONE!", "I'M A TATER!", "ALL SECURITY TO SHOOT ME ON SIGHT!", "I HAVE A BOMB!", "CAPTAIN IS A COMDOM!", "FOR THE SYNDICATE!")
 

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -24,13 +24,11 @@
 		speech.message = pick(insultmsgs)
 		insults--
 
-/obj/item/device/megaphone/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/weapon/card/emag) && !emagged)
+/obj/item/device/megaphone/emag_act(mob/user)
+	if(!emagged)
 		to_chat(user, "<span class='warning'>You overload \the [src]'s voice synthesizer.</span>")
 		emagged = 1
 		insults = rand(1, 3) //to prevent dickflooding
-		return
-	return
 
 /obj/item/device/megaphone/madscientist
 	name = "mad scientist megaphone"

--- a/code/game/objects/items/devices/sound_synth.dm
+++ b/code/game/objects/items/devices/sound_synth.dm
@@ -13,7 +13,6 @@
 	var/selected_sound = "sound/items/bikehorn.ogg"
 	var/shiftpitch = 1
 	var/volume = 50
-	var/emagged = 0
 
 	var/list/sound_list_emagged = list(
 	"Blob Pulse" = "selected_sound=sound/effects/blob_pulse.ogg&shiftpitch=1&volume=100",

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -9,7 +9,6 @@
 	w_type = RECYK_ELECTRONIC
 	melt_temperature = MELTPOINT_PLASTIC
 	flammable = TRUE
-	var/emagged = 0.0
 	var/recording = 0.0
 	var/playing = 0.0
 	var/timerecorded = 0.0

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -28,16 +28,14 @@
 		timestamp += timerecorded
 		storedinfo += "\[[time2text(timerecorded*10,"mm:ss")]\] [speech.name]:  \"[html_encode(speech.message)]\""
 
-/obj/item/device/taperecorder/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	..()
-	if(istype(W, /obj/item/weapon/card/emag))
-		if(emagged == 0)
-			emagged = 1
-			recording = 0
-			to_chat(user, "<span class='warning'>PZZTTPFFFT</span>")
-			icon_state = "taperecorderidle"
-		else
-			to_chat(user, "<span class='warning'>It is already emagged!</span>")
+/obj/item/device/taperecorder/emag_act(mob/user)
+	if(!emagged)
+		emagged = 1
+		recording = 0
+		to_chat(user, "<span class='warning'>PZZTTPFFFT</span>")
+		icon_state = "taperecorderidle"
+	else
+		to_chat(user, "<span class='warning'>It is already emagged!</span>")
 
 /obj/item/device/taperecorder/proc/explode()
 	var/turf/T = get_turf(loc)

--- a/code/game/objects/items/devices/whistle.dm
+++ b/code/game/objects/items/devices/whistle.dm
@@ -12,7 +12,6 @@
 
 	var/nextuse = 0
 	var/cooldown = 2 SECONDS
-	var/emagged = 0
 	var/insults = 0//just in case
 
 /obj/item/device/hailer/proc/say_your_thing()

--- a/code/game/objects/items/devices/whistle.dm
+++ b/code/game/objects/items/devices/whistle.dm
@@ -48,13 +48,11 @@
 						"<span class='warning'>You hear the computerized voice of a security hailer: \"[message]\"</span>")
 	do_your_sound(user)
 
-/obj/item/device/hailer/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/weapon/card/emag) && !emagged)
+/obj/item/device/hailer/emag_act(mob/user)
+	if(!emagged)
 		to_chat(user, "<span class='warning'>You overload \the [src]'s voice synthesizer.</span>")
 		emagged = 1
 		insults = rand(1, 3)//to prevent dickflooding
-		return
-	return
 
 /obj/item/device/hailer/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(world.time < nextuse)

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -340,12 +340,9 @@
 			return
 	return
 
-/obj/item/robot_parts/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W,/obj/item/weapon/card/emag))
-		if(sabotaged)
-			to_chat(user, "<span class='warning'>[src] is already sabotaged!</span>")
-		else
-			to_chat(user, "<span class='warning'>You slide [W] into the dataport on [src] and short out the safeties.</span>")
-			sabotaged = 1
-		return
-	..()
+/obj/item/robot_parts/emag_act(mob/user)
+	if(sabotaged)
+		to_chat(user, "<span class='warning'>[src] is already sabotaged!</span>")
+	else
+		to_chat(user, "<span class='warning'>You slide the cryptographic sequencer into the dataport on [src] and short out the safeties.</span>")
+		sabotaged = 1

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -914,8 +914,8 @@
 	icon_state = "newcop"
 	var/emagged = 0
 
-/obj/item/toy/gasha/newcop/attackby(obj/item/I, mob/user)
-	if(isEmag(I) && !emagged)
+/obj/item/toy/gasha/newcop/emag_act(mob/user)
+	if(!emagged)
 		to_chat(user, "<span class='warning'>You turned the toy into a bomb!</span>")
 		emagged = 1
 
@@ -926,10 +926,6 @@
 		sleep(5)
 		explosion(get_turf(src), -1,1,4, whodunnit = user)
 		qdel(src)
-	else
-		return
-
-
 
 /obj/item/toy/gasha/jani
 	name = "toy janitor"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -912,7 +912,6 @@
 	name = "toy nuke-op"
 	desc = "Mildly explosive."
 	icon_state = "newcop"
-	var/emagged = 0
 
 /obj/item/toy/gasha/newcop/emag_act(mob/user)
 	if(!emagged)

--- a/code/game/objects/items/weapons/ai_modules/AI_modules.dm
+++ b/code/game/objects/items/weapons/ai_modules/AI_modules.dm
@@ -186,13 +186,11 @@ Refactored AI modules by N3X15
 	var/datum/ai_laws/randomize/RLS = new
 	laws.inherent = RLS.inherent
 	return 1
-/obj/item/weapon/aiModule/randomize/attackby(var/obj/item/I, mob/user as mob)
-	..()
-	if(istype(I, /obj/item/weapon/card/emag))
-		spark(src, 5)
-		qdel(src)
-		to_chat(user,"<span class='warning'>You connect various wires from the cryptographic sequencer to the module, and overwrite its internal memory.</span>")
-		new /obj/item/weapon/aiModule/emaggedrandomize(get_turf(user))
+/obj/item/weapon/aiModule/randomize/emag_act(mob/user)
+	spark(src, 5)
+	qdel(src)
+	to_chat(user,"<span class='warning'>You connect various wires from the cryptographic sequencer to the module, and overwrite its internal memory.</span>")
+	new /obj/item/weapon/aiModule/emaggedrandomize(get_turf(user))
 
 /*************** Emagged Randomize ********************/
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -183,6 +183,9 @@
 		var/datum/organ/external/organ = target_living.get_organ(zone)
 		target_living.emag_act(user, organ, src)
 
+/mob/living/carbon/human/emag_check(obj/item/weapon/card/emag/E, mob/user) //handled above!
+	return FALSE
+
 var/list/global/id_cards = list()
 
 /obj/item/weapon/card/id

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -63,6 +63,7 @@
 	item_state = "card-id"
 	slot_flags = SLOT_ID
 	origin_tech = Tc_MAGNETS + "=2;" + Tc_SYNDICATE + "=2"
+	flags = FPRINT | NO_ATTACK_MSG //because of overrides
 
 	/**
 	 * Number of uses left.  -1 = infinite

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -182,15 +182,6 @@
 		var/zone = ran_zone(user.zone_sel.selecting, 100)
 		var/datum/organ/external/organ = target_living.get_organ(zone)
 		target_living.emag_act(user, organ, src)
-		return
-	if(istype(target,/obj/machinery))
-		return // Handled in machine attackby()
-	if(arcanetampered && prob(50))
-		target.arcane_act(user)
-		if(prob(50))
-			return
-	target.emag_act(user)
-
 
 var/list/global/id_cards = list()
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -174,7 +174,7 @@
 
 //perform individual emag_act() stuff on children overriding the method here
 /obj/item/weapon/card/emag/afterattack(var/atom/target, mob/user, proximity)
-	if(!proximity || !canUse(use,target))
+	if(!proximity || !canUse(user,target))
 		return
 	if (istype(target, /mob/living/carbon/human))
 		var/mob/living/carbon/target_living = target

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -176,7 +176,7 @@
 /obj/item/weapon/card/emag/afterattack(var/atom/target, mob/user, proximity)
 	if(!proximity || !canUse(user,target))
 		return
-	if (istype(target, /mob/living/carbon/human))
+	if (ishuman(target))
 		var/mob/living/carbon/target_living = target
 		//get target zone with 0% chance of missing
 		var/zone = ran_zone(user.zone_sel.selecting, 100)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -131,14 +131,14 @@
 		nticks = 0
 		processing_objects.Remove(src)
 
-/obj/item/weapon/card/emag/proc/canUse(var/mob/user, var/obj/machinery/M)
+/obj/item/weapon/card/emag/proc/canUse(var/mob/user, var/atom/A)
 	// We've already checked for emaggability.  All we do here is check cost.
 
 	// Infinite uses?  Just return true.
 	if(energy < 0)
 		return 1
 
-	var/cost=M.getEmagCost(user,src)
+	var/cost=A.getEmagCost(user,src)
 
 	// Free to emag?  Return true every time.
 	if(cost == 0)
@@ -174,7 +174,7 @@
 
 //perform individual emag_act() stuff on children overriding the method here
 /obj/item/weapon/card/emag/afterattack(var/atom/target, mob/user, proximity)
-	if(!proximity)
+	if(!proximity || !canUse(use,target))
 		return
 	if (istype(target, /mob/living/carbon/human))
 		var/mob/living/carbon/target_living = target

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -82,18 +82,14 @@
 	if(user)
 		user.update_inv_hands()
 
-/obj/item/weapon/melee/defibrillator/attackby(obj/item/weapon/W,mob/user)
-	if(istype(W,/obj/item/weapon/card/emag))
-		emagged = !src.emagged
-		if(emagged)
-			to_chat(user, "<span class='warning'>You short out [src]'s safety protocols.</span>")
-			overlays += image(icon = icon, icon_state = "defib_emag")
-		else
-			to_chat(user, "<span class='notice'>You reset [src]'s safety protocols.</span>")
-			overlays.len = 0
+/obj/item/weapon/melee/defibrillator/emag_act(mob/user)
+	emagged = !emagged
+	if(emagged)
+		to_chat(user, "<span class='warning'>You short out [src]'s safety protocols.</span>")
+		overlays += image(icon = icon, icon_state = "defib_emag")
 	else
-		. = ..()
-	return
+		to_chat(user, "<span class='notice'>You reset [src]'s safety protocols.</span>")
+		overlays.len = 0
 
 /obj/item/weapon/melee/defibrillator/attack(mob/M,mob/user)
 	if(!ishuman(M))

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -18,7 +18,6 @@
 
 	var/charges = 10
 	var/ready = 0
-	var/emagged = 0
 	var/defib_delay = 30
 
 	var/defib_tool = "paddles"

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -21,7 +21,6 @@
 	var/l_set = 0
 	var/l_setshort = 0
 	var/l_hacking = 0
-	var/emagged = 0
 	var/open = 0
 	w_class = W_CLASS_MEDIUM
 	fits_max_w_class = W_CLASS_SMALL

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -37,16 +37,6 @@
 
 /obj/item/weapon/storage/secure/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(code_locked)
-		if ( istype(W, /obj/item/weapon/card/emag) && (!src.emagged))
-			emagged = 1
-			src.overlays += image('icons/obj/storage/storage.dmi', icon_sparking)
-			sleep(6)
-			overlays.len = 0
-			overlays += image('icons/obj/storage/storage.dmi', icon_locking)
-			code_locked = 0
-			to_chat(user, "You short out the lock on [src].")
-			return
-
 		if (W.is_screwdriver(user))
 			if (do_after(user, src, 20))
 				src.open =! src.open
@@ -76,6 +66,15 @@
 	// -> storage/attackby() what with handle insertion, etc
 	. = ..()
 
+/obj/item/weapon/storage/secure/emag_act(mob/user)
+	if(code_locked && !emagged)
+		emagged = 1
+		src.overlays += image('icons/obj/storage/storage.dmi', icon_sparking)
+		sleep(6)
+		overlays.len = 0
+		overlays += image('icons/obj/storage/storage.dmi', icon_locking)
+		code_locked = 0
+		to_chat(user, "You short out the lock on [src].")
 
 /obj/item/weapon/storage/secure/MouseDropFrom(over_object, src_location, over_location)
 	if (code_locked)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -170,8 +170,8 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 	if(handle_item_attack(W, user))
 		return
 	
-	if(isEmag(W))
-		. = ..()
+	if(emag_check(W,user))
+		. = 1
 			
 	if(can_take_pai && istype(W, /obj/item/device/paicard))
 		if(integratedpai)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -169,7 +169,10 @@ var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXI
 
 	if(handle_item_attack(W, user))
 		return
-
+	
+	if(isEmag(W))
+		. = ..()
+			
 	if(can_take_pai && istype(W, /obj/item/device/paicard))
 		if(integratedpai)
 			to_chat(user, "<span class = 'notice'>There's already a Personal AI inserted.</span>")

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -85,8 +85,8 @@
 		else
 			to_chat(user, "<span class='notice'>The locker appears to be broken.</span>")
 			return
-	else if(isEmag(W) && !broken)
-		emag_act(user)
+	else if(!broken && emag_check(W,user))
+		return
 	else if(iswelder(W) && canweld())
 		var/obj/item/tool/weldingtool/WT = W
 		if(!WT.remove_fuel(1,user))

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -86,14 +86,7 @@
 			to_chat(user, "<span class='notice'>The locker appears to be broken.</span>")
 			return
 	else if(isEmag(W) && !broken)
-		broken = TRUE
-		locked = FALSE
-		desc = "It appears to be broken."
-		icon_state = icon_off
-		flick(icon_broken, src)
-		for(var/mob/O in viewers(user, 3))
-			O.show_message("<span class='warning'>The locker has been broken by [user] with an electromagnetic card!</span>", 1, "You hear a faint electrical spark.", 2)
-		update_icon()
+		emag_act(user)
 	else if(iswelder(W) && canweld())
 		var/obj/item/tool/weldingtool/WT = W
 		if(!WT.remove_fuel(1,user))
@@ -106,6 +99,17 @@
 		return
 	else
 		togglelock(user)
+
+/obj/structure/closet/secure_closet/emag_act(mob/user)
+	if(!broken)
+		broken = TRUE
+		locked = FALSE
+		desc = "It appears to be broken."
+		icon_state = icon_off
+		flick(icon_broken, src)
+		for(var/mob/O in viewers(user, 3))
+			O.show_message("<span class='warning'>The locker has been broken by [user] with an electromagnetic card!</span>", 1, "You hear a faint electrical spark.", 2)
+		update_icon()
 
 /obj/structure/closet/secure_closet/relaymove(mob/user)
 	if(user.stat || !isturf(src.loc))

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -583,7 +583,16 @@
 			return 0
 
 /obj/structure/closet/crate/secure/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if ( istype(W, /obj/item/weapon/card/emag) && locked &&!broken)
+	if(istype(W, /obj/item/weapon/card) && !opened && !broken)
+		togglelock(user)
+		return
+	else if(W.is_screwdriver(user) && !opened && !locked && src.has_lockless_type)
+		remove_lock(user)
+		return
+	return ..()
+
+/obj/structure/closet/crate/secure/emag_act(mob/user)
+	if(locked && !broken)
 		overlays.len = 0
 		overlays += emag
 		overlays += sparks
@@ -592,14 +601,6 @@
 		src.locked = 0
 		src.broken = 1
 		to_chat(user, "<span class='notice'>You unlock \the [src].</span>")
-		return
-	else if(istype(W, /obj/item/weapon/card) && !opened && !broken)
-		togglelock(user)
-		return
-	else if(W.is_screwdriver(user) && !opened && !locked && src.has_lockless_type)
-		remove_lock(user)
-		return
-	return ..()
 
 /obj/structure/closet/crate/secure/verb/verb_togglelock()
 	set src in oview(1) // One square distance

--- a/code/game/objects/structures/vehicles/clowncart.dm
+++ b/code/game/objects/structures/vehicles/clowncart.dm
@@ -208,8 +208,8 @@
 				reagents.add_reagent(BANANA, bananas) //adding banan back
 		else
 			to_chat(user, "<span class='warning'>The HONKTech pump is not strong enough to do that yet. Reinforce it with more bananium sheets first.</span>")
-	else if(isEmag(W)) //emag
-		emag_act(user)
+	else if(emag_check(W,user)) //emag
+		return
 	else if(istype(W, /obj/item/weapon/stamp/))
 		if(mode == MODE_DRAWING)
 			if(istype(W, /obj/item/weapon/stamp/captain))

--- a/code/game/objects/structures/vehicles/clowncart.dm
+++ b/code/game/objects/structures/vehicles/clowncart.dm
@@ -34,7 +34,6 @@
 	var/trail //Trail from banana pie
 	var/colour1 = "#000000" //Change it by using stamps
 	var/colour2 = "#3D3D3D" //Default is boring black
-	var/emagged = 0			//Does something maybe
 	var/honk				//Timer to prevent spamming honk
 
 /obj/structure/bed/chair/vehicle/clowncart/process()

--- a/code/game/objects/structures/vehicles/clowncart.dm
+++ b/code/game/objects/structures/vehicles/clowncart.dm
@@ -209,10 +209,8 @@
 				reagents.add_reagent(BANANA, bananas) //adding banan back
 		else
 			to_chat(user, "<span class='warning'>The HONKTech pump is not strong enough to do that yet. Reinforce it with more bananium sheets first.</span>")
-	else if(istype(W, /obj/item/weapon/card/emag)) //emag
-		if(!emagged)
-			emagged = 1
-			visible_message("<span class='warning'>[src]'s eyes glow eerily red for a second.</span>")
+	else if(isEmag(W)) //emag
+		emag_act(user)
 	else if(istype(W, /obj/item/weapon/stamp/))
 		if(mode == MODE_DRAWING)
 			if(istype(W, /obj/item/weapon/stamp/captain))
@@ -259,6 +257,11 @@
 				colour1 = "#000000"
 				colour2 = "#6D6D6D"
 				to_chat(user, "Selected color: Boring Black")
+		
+/obj/structure/bed/chair/vehicle/clowncart/emag_act(mob/user)
+	if(!emagged)
+		emagged = 1
+		visible_message("<span class='warning'>[src]'s eyes glow eerily red for a second.</span>")
 
 /obj/structure/bed/chair/vehicle/clowncart/relaymove(mob/user, direction)
 	if(user.incapacitated())

--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -406,8 +406,7 @@ var/station_bonus = 0 //A bonus to station allowance that gets reset after wage 
 						access_level = 0
 				else
 					var/obj/item/I = usr.get_active_hand()
-					if(isEmag(I))
-						emag_act(usr)
+					if(emag_check(I,usr))
 						return
 					if (istype(I, /obj/item/weapon/card/id))
 						var/obj/item/weapon/card/id/C = I

--- a/code/modules/Economy/EFTPOS.dm
+++ b/code/modules/Economy/EFTPOS.dm
@@ -162,8 +162,8 @@
 			if("reset")
 				//reset the access code - requires HoP/captain access
 				var/obj/item/I = usr.get_active_hand()
-				if (isEmag(I))
-					emag_act(usr)
+				if (emag_check(I,user))
+					return
 				else if (istype(I, /obj/item/weapon/card))
 					var/obj/item/weapon/card/id/C = I
 					if((access_cent_captain in C.access) || (access_hop in C.access) || (access_captain in C.access))

--- a/code/modules/Economy/EFTPOS.dm
+++ b/code/modules/Economy/EFTPOS.dm
@@ -162,7 +162,7 @@
 			if("reset")
 				//reset the access code - requires HoP/captain access
 				var/obj/item/I = usr.get_active_hand()
-				if (emag_check(I,user))
+				if (emag_check(I,usr))
 					return
 				else if (istype(I, /obj/item/weapon/card))
 					var/obj/item/weapon/card/id/C = I

--- a/code/modules/Economy/EFTPOS.dm
+++ b/code/modules/Economy/EFTPOS.dm
@@ -162,14 +162,13 @@
 			if("reset")
 				//reset the access code - requires HoP/captain access
 				var/obj/item/I = usr.get_active_hand()
-				if (istype(I, /obj/item/weapon/card))
+				if (isEmag(I))
+					emag_act(usr)
+				else if (istype(I, /obj/item/weapon/card))
 					var/obj/item/weapon/card/id/C = I
 					if((access_cent_captain in C.access) || (access_hop in C.access) || (access_captain in C.access))
 						access_code = 0
 						to_chat(usr, "[bicon(src)] <span class='info'>Access code reset to 0.</span>")
-				else if (istype(I, /obj/item/weapon/card/emag))
-					access_code = 0
-					to_chat(usr, "[bicon(src)] <span class='info'>Access code reset to 0.</span>")
 
 	src.attack_self(usr)
 
@@ -184,8 +183,13 @@
 			playsound(src, 'sound/machines/alert.ogg', 50, 1)
 			visible_message("[bicon(src)] \The [src] buzzes.")
 
-
 /obj/item/device/eftpos/proc/scan_card(var/obj/item/weapon/card/I)
 	if (istype(I, /obj/item/weapon/card))
 		charge_card(I)
 	//emag?
+
+//emag
+/obj/item/device/eftpos/emag_act(mob/user)
+	access_code = 0
+	to_chat(user, "[bicon(src)] <span class='info'>Access code reset to 0.</span>")
+	

--- a/code/modules/RCD/tile painter.dm
+++ b/code/modules/RCD/tile painter.dm
@@ -10,8 +10,6 @@
 
 	sparky				= 0
 
-	var/emagged 		= 0
-
 	schematics = list(/datum/rcd_schematic/clear_decals)
 
 /obj/item/device/rcd/tile_painter/New()

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -322,16 +322,7 @@
 
 /obj/item/clothing/accessory/holobadge/attackby(var/obj/item/O as obj, var/mob/user as mob)
 
-	if (istype(O, /obj/item/weapon/card/emag))
-		if (emagged)
-			to_chat(user, "<span class='warning'>[src] is already cracked.</span>")
-			return
-		else
-			emagged = 1
-			to_chat(user, "<span class='warning'>You swipe [O] and crack the holobadge security checks.</span>")
-			return
-
-	else if(istype(O, /obj/item/weapon/card/id) || istype(O, /obj/item/device/pda))
+	if(istype(O, /obj/item/weapon/card/id) || istype(O, /obj/item/device/pda))
 
 		var/obj/item/weapon/card/id/id_card = null
 
@@ -350,6 +341,13 @@
 			to_chat(user, "[src] rejects your insufficient access rights.")
 		return
 	..()
+
+/obj/item/clothing/accessory/holobadge/emag_act(mob/user)
+	if (emagged)
+		to_chat(user, "<span class='warning'>[src] is already cracked.</span>")
+	else
+		emagged = 1
+		to_chat(user, "<span class='warning'>You swipe the cryptographic sequencer and crack the holobadge security checks.</span>")
 
 /obj/item/clothing/accessory/holobadge/attack(mob/living/carbon/human/M, mob/living/user)
 	if(isliving(user))

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -305,7 +305,6 @@
 	_color = "holobadge"
 	slot_flags = SLOT_BELT
 
-	var/emagged = 0 //Emagging removes Sec check.
 	var/stored_name = null
 
 /obj/item/clothing/accessory/holobadge/cord

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -14,7 +14,6 @@
 	var/stomp_boot = "magboot"
 	var/stomp_hit = "crushes"
 	var/anchoring_system_examine = "Its mag-pulse traction system appears to be"
-	var/emagged = FALSE
 
 	var/obj/item/clothing/shoes/stored_shoes = null	//Shoe holder
 

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -230,7 +230,6 @@
 		"Dramatic" = 'sound/effects/dramatic_short.ogg',
 		"Random" = CLOWNSHOES_RANDOM_SOUND)
 	var/random_sound = 0
-	var/emagged = 0
 
 /obj/item/clothing/shoes/clown_shoes/advanced/attack_self(mob/living/user)
 	if(user.mind && !clumsy_check(user))

--- a/code/modules/hydroponics/floral_somatoray.dm
+++ b/code/modules/hydroponics/floral_somatoray.dm
@@ -74,20 +74,24 @@
 
 /obj/item/floral_somatoray/attackby(var/obj/item/weapon/W, var/mob/user)
 	if(isEmag(W) || issolder(W))
-		if (emagged)
-			if (issolder(W))
-				to_chat(user, "<span class='warning'>You repair the safety limit of the [src.name]!</span>")
-				desc = initial(desc)
-				emagged = FALSE
-				update_icon()
-			else
-				to_chat(user, "The safeties are already de-activated.")
-		else
-			emagged = TRUE
-			to_chat(user, "<span class='warning'>You short out the safety limit of the [src.name]!</span>")
-			desc += " It seems to have it's safety features de-activated."
-			playsound(user, 'sound/effects/sparks4.ogg', 50, 1)
+		if (emagged && issolder(W))
+			to_chat(user, "<span class='warning'>You repair the safety limit of the [src.name]!</span>")
+			desc = initial(desc)
+			emagged = FALSE
 			update_icon()
+		else
+			emag_act(user)
+
+/obj/item/floral_somatoray/emag_act(mob/user)
+	if (emagged)
+		to_chat(user, "The safeties are already de-activated.")
+	else
+		emagged = TRUE
+		to_chat(user, "<span class='warning'>You short out the safety limit of the [src.name]!</span>")
+		desc += " It seems to have it's safety features de-activated."
+		playsound(user, 'sound/effects/sparks4.ogg', 50, 1)
+		update_icon()
+	
 
 /obj/item/floral_somatoray/attack(var/mob/living/M, var/mob/living/user, var/def_zone, var/originator=null)
 	return

--- a/code/modules/hydroponics/floral_somatoray.dm
+++ b/code/modules/hydroponics/floral_somatoray.dm
@@ -20,7 +20,6 @@
 		GENE_XENOPHYSIOLOGY		=	"#8AFF81",
 		)
 	var/isSomatoraying = FALSE
-	var/emagged = FALSE
 	var/charge_speed = 10//how many ticks do you have to stand before the radiation comes out
 
 	var/image/mode_color

--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -947,7 +947,7 @@ var/global/list/loopModeNames=list(
 
 /obj/machinery/media/jukebox/superjuke/attackby(obj/item/W, mob/user)
 	// NO FUN ALLOWED.  Emag list is included, anyway.
-	if(istype(W, /obj/item/weapon/card/emag))
+	if(isEmag(W))
 		to_chat(user, "<span class='warning'>Your [W] refuses to touch \the [src]!</span>")
 		return
 	..()
@@ -1074,7 +1074,7 @@ var/global/list/loopModeNames=list(
 
 /obj/machinery/media/jukebox/holyjuke/attackby(obj/item/W, mob/user)
 	// EMAG DOES NOTHING
-	if(istype(W, /obj/item/weapon/card/emag))
+	if(isEmag(W))
 		to_chat(user, "<span class='warning'>A guiltiness fills your heart as a higher power pushes away \the [W]!</span>")
 		return
 	..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -56,7 +56,6 @@
 	mob_push_flags = ALLMOBS //trundle trundle
 
 	var/opened = FALSE
-	var/emagged = FALSE
 	var/pulsecompromised = FALSE //Used for pulsedemons
 	var/illegal_weapons = FALSE
 	var/wiresexposed = FALSE

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -128,19 +128,18 @@
 		else
 			to_chat(user, "<span class='warning'>You swipe your card, with no effect.</span>")
 			return 0
-	else if (istype(O, /obj/item/weapon/card/emag))
-		if (emagged)
-			to_chat(user, "<span class='warning'>[src] is already overloaded - better run.</span>")
-			return 0
-		else
-			emagged = 1
-			to_chat(user, "<span class='notice'>You short out the security protocols and overload [src]'s cell, priming it to explode in a short time.</span>")
-			spawn(100)	to_chat(src, "<span class='warning'>Your cell seems to be outputting a lot of power...</span>")
-			spawn(200)	to_chat(src, "<span class='warning'>Internal heat sensors are spiking! Something is badly wrong with your cell!</span>")
-			spawn(300)	src.explode()
-
 	else
 		return ..()
+
+/mob/living/simple_animal/spiderbot/emag_act(mob/user)
+	if (emagged)
+		to_chat(user, "<span class='warning'>[src] is already overloaded - better run.</span>")
+	else
+		emagged = 1
+		to_chat(user, "<span class='notice'>You short out the security protocols and overload [src]'s cell, priming it to explode in a short time.</span>")
+		spawn(100)	to_chat(src, "<span class='warning'>Your cell seems to be outputting a lot of power...</span>")
+		spawn(200)	to_chat(src, "<span class='warning'>Internal heat sensors are spiking! Something is badly wrong with your cell!</span>")
+		spawn(300)	src.explode()
 
 /mob/living/simple_animal/spiderbot/attack_animal(var/mob/user as mob)
 	if(istype(user,/mob/living/simple_animal/mouse) && !(src.mmi || src.mouse))

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -38,7 +38,6 @@
 
 	var/obj/item/held_item = null //Storage for single item they can hold.
 	var/lob_range = 3
-	var/emagged = 0               //IS WE EXPLODEN?
 	var/syndie = 0                //IS WE SYNDICAT? (currently unused)
 	speed = 1                    //Spiderbots gotta go fast.
 	pass_flags = PASSTABLE | PASSRAILING

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -561,7 +561,7 @@
 				nanomanager.update_uis(src)
 			else
 				to_chat(user, "<span class='warning'>Access denied.</span>")
-	else if (istype(W, /obj/item/weapon/card/emag) && !(emagged || malfhack))		// trying to unlock with an emag card
+	else if (isEmag(W) && !(emagged || malfhack))		// trying to unlock with an emag card
 		if(opened)
 			to_chat(user, "You must close the cover to swipe an ID card.")
 		else if(wiresexposed)

--- a/code/modules/power/rust/fuel_compressor.dm
+++ b/code/modules/power/rust/fuel_compressor.dm
@@ -7,7 +7,7 @@ var/const/max_assembly_amount = 300
 	var/list/new_assembly_quantities = list("Deuterium" = 150,"Tritium" = 150,"Rodinium-6" = 0,"Stravium-7" = 0, "Pergium" = 0, "Dilithium" = 0)
 	var/compressed_matter = 0
 	anchored = 1
-
+	machine_flags = EMAGGABLE
 	var/opened = 1 //0=closed, 1=opened
 	var/locked = 0
 	var/has_electronics = 0 // 0 - none, bit 1 - circuitboard, bit 2 - wires

--- a/code/modules/power/rust/fuel_compressor_construction.dm
+++ b/code/modules/power/rust/fuel_compressor_construction.dm
@@ -81,20 +81,6 @@
 				to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 
-	else if (isEmag(W) && !emagged)		// trying to unlock with an emag card
-		if(opened)
-			to_chat(user, "You must close the cover to swipe an ID card.")
-		else
-			flick("apc-spark", src)
-			if (do_after(user, src,6))
-				if(prob(50))
-					emagged = 1
-					locked = 0
-					to_chat(user, "You emag the port interface.")
-				else
-					to_chat(user, "You fail to [ locked ? "unlock" : "lock"] the compressor interface.")
-		return
-
 	else if (istype(W, /obj/item/stack/cable_coil) && opened && !(has_electronics & 2))
 		var/obj/item/stack/cable_coil/C = W
 		if(C.amount < 10)
@@ -145,3 +131,17 @@
 		return
 
 	..()
+
+/obj/machinery/rust_fuel_compressor/emag_act(mob/user)
+	if(!emagged)
+		if(opened)
+			to_chat(user, "You must close the cover to swipe an ID card.")
+		else
+			flick("apc-spark", src)
+			if (do_after(user,src,6))
+				if(prob(50))
+					emagged = 1
+					locked = 0
+					to_chat(user, "You emag the port interface.")
+				else
+					to_chat(user, "You fail to [ locked ? "unlock" : "lock"] the compressor interface.")

--- a/code/modules/power/rust/fuel_compressor_construction.dm
+++ b/code/modules/power/rust/fuel_compressor_construction.dm
@@ -81,7 +81,7 @@
 				to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 
-	else if (istype(W, /obj/item/weapon/card/emag) && !emagged)		// trying to unlock with an emag card
+	else if (isEmag(W) && !emagged)		// trying to unlock with an emag card
 		if(opened)
 			to_chat(user, "You must close the cover to swipe an ID card.")
 		else

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -40,8 +40,8 @@
 	user << browse("<TITLE>Temperature Gun Configuration</TITLE><HR>[dat]", "window=tempgun;size=510x102")
 	onclose(user, "tempgun")
 
-/obj/item/weapon/gun/energy/temperature/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/weapon/card/emag) && !emagged)
+/obj/item/weapon/gun/energy/temperature/emag_act(mob/user)
+	if(!emagged)
 		emagged = 1
 		to_chat(user, "<span class='caution'>You double the gun's temperature cap! Individuals hit by now searing beams will burst into flames!</span>")
 		desc = "A gun that changes the body temperature of its targets. Its temperature cap has been hacked."

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -19,7 +19,6 @@
 	var/powercostcolor = ""
 	var/tempcolor = ""
 
-	var/emagged = 0			//ups the temperature cap from 500 to 1000, targets hit by beams over 500 Kelvin will burst into flames
 	var/dat = ""
 
 /obj/item/weapon/gun/energy/temperature/New()

--- a/code/modules/projectiles/guns/projectile/rocketlauncher.dm
+++ b/code/modules/projectiles/guns/projectile/rocketlauncher.dm
@@ -155,12 +155,10 @@
 		explosion(src.loc, 1, 3, 5, 8, whodunnit = user) //Using the actual rocket damage, instead of the very old, super nerfed value
 		return SUICIDE_ACT_BRUTELOSS
 
-/obj/item/weapon/gun/projectile/rocketlauncher/nikita/attackby(var/obj/item/A as obj, mob/user as mob)
-	if(istype(A, /obj/item/weapon/card/emag) && !emagged)
+/obj/item/weapon/gun/projectile/rocketlauncher/nikita/emag_act(mob/user)
+	if(!emagged)
 		emagged = 1
 		to_chat(user, "<span class='warning'>You disable \the [src]'s idiot security!</span>")
-	else
-		..()
 
 /obj/item/weapon/gun/projectile/rocketlauncher/nikita/process_chambered()
 	if(..())

--- a/code/modules/projectiles/guns/projectile/rocketlauncher.dm
+++ b/code/modules/projectiles/guns/projectile/rocketlauncher.dm
@@ -135,7 +135,6 @@
 	fire_sound = 'sound/weapons/rocket.ogg'
 	ammo_type = "/obj/item/ammo_casing/rocket_rpg/nikita"
 	var/obj/item/projectile/rocket/nikita/fired = null
-	var/emagged = 0
 
 /obj/item/weapon/gun/projectile/rocketlauncher/nikita/update_icon()
 	return

--- a/code/modules/projectiles/projectile/rocket.dm
+++ b/code/modules/projectiles/projectile/rocket.dm
@@ -139,7 +139,6 @@
 	var/obj/item/weapon/gun/projectile/rocketlauncher/nikita/nikita = null
 	var/steps_since_last_turn = 0
 	var/last_dir = null
-	var/emagged = 0//the value is set by the Nikita when it fires it
 
 /obj/item/projectile/rocket/nikita/OnFired()
 	nikita = shot_from

--- a/code/modules/recycling/compactor.dm
+++ b/code/modules/recycling/compactor.dm
@@ -104,15 +104,15 @@
 		wrenchAnchor(user, I)
 		power_change()
 		return
-	if(isEmag(I) && can_emag())
-		emag_act(user)
+	if(emag_check(I,user))
 		return 1
 	..()
 
 /obj/machinery/disposal/compactor/emag_act(mob/user)
-	emagged = !emagged
-	to_chat(user, "<span class='notice'>You disable the safety features.</span>")
-	. = ..()
+	if(!emagged)
+		emagged = 1
+		to_chat(user, "<span class='notice'>You disable the safety features.</span>")
+		. = ..()
 
 /obj/machinery/disposal/compactor/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()

--- a/code/modules/recycling/compactor.dm
+++ b/code/modules/recycling/compactor.dm
@@ -104,16 +104,15 @@
 		wrenchAnchor(user, I)
 		power_change()
 		return
-	if(isEmag(I))
+	if(isEmag(I) && can_emag())
 		emag_act(user)
-		return
+		return 1
 	..()
 
 /obj/machinery/disposal/compactor/emag_act(mob/user)
-	if(!emagged)
-		. = ..()
-		emagged = 1
-		to_chat(user, "<span class='notice'>You disable the safety features.</span>")
+	emagged = !emagged
+	to_chat(user, "<span class='notice'>You disable the safety features.</span>")
+	. = ..()
 
 /obj/machinery/disposal/compactor/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()

--- a/code/modules/recycling/compactor.dm
+++ b/code/modules/recycling/compactor.dm
@@ -2,7 +2,7 @@
 	name = "trash compactor"
 	desc = "A machine used to alleviate recycling problems in the absence of a disposal network."
 	icon_state = "compactor_on" //New sprite indicating fullness?
-	machine_flags = WRENCHMOVE | FIXED2WORK
+	machine_flags = WRENCHMOVE | FIXED2WORK | EMAGGABLE
 	flags = FPRINT
 	template_path = "disposalsbincompactor.tmpl"
 

--- a/code/modules/recycling/compactor.dm
+++ b/code/modules/recycling/compactor.dm
@@ -104,17 +104,13 @@
 		wrenchAnchor(user, I)
 		power_change()
 		return
-	if(!emagged && istype(I,/obj/item/weapon/card/emag))
-		playsound(src, 'sound/effects/sparks4.ogg', 75, 1)
-		emagged = 1
-		to_chat(user, "<span class='notice'>You disable the safety features.</span>")
-		return
 	..()
 
-/obj/machinery/disposal/compactor/emag_ai(mob/living/silicon/ai/A)
-	emagged = 1
-	to_chat(A, "<span class='notice'>You disable the safety features.</span>")
-	
+/obj/machinery/disposal/compactor/emag_act(mob/user)
+	if(!emagged)
+		. = ..()
+		emagged = 1
+		to_chat(user, "<span class='notice'>You disable the safety features.</span>")
 
 /obj/machinery/disposal/compactor/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	..()

--- a/code/modules/recycling/compactor.dm
+++ b/code/modules/recycling/compactor.dm
@@ -106,6 +106,7 @@
 		return
 	if(isEmag(I))
 		emag_act(user)
+		return
 	..()
 
 /obj/machinery/disposal/compactor/emag_act(mob/user)

--- a/code/modules/recycling/compactor.dm
+++ b/code/modules/recycling/compactor.dm
@@ -104,6 +104,8 @@
 		wrenchAnchor(user, I)
 		power_change()
 		return
+	if(isEmag(I))
+		emag_act(user)
 	..()
 
 /obj/machinery/disposal/compactor/emag_act(mob/user)

--- a/code/modules/research/mechanic/component_exchanger.dm
+++ b/code/modules/research/mechanic/component_exchanger.dm
@@ -15,7 +15,6 @@
 	starting_materials = null
 	w_type = RECYK_ELECTRONIC
 	origin_tech = Tc_MAGNETS + "=2;" + Tc_ENGINEERING + "=4;" + Tc_MATERIALS + "=5;" + Tc_PROGRAMMING + "=3"
-	var/emagged = 0 //So we can emag it for "improved" functionality
 	var/working = 0 //Busy check to make sure the user doesn't try to multi-task (this causes serious problems)
 
 	allow_quick_gather = 1

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -312,7 +312,7 @@
 /obj/machinery/computer/rdservercontrol/attackby(var/obj/item/weapon/D as obj, var/mob/user as mob)
 
 	add_fingerprint(user)
-
+	updateUsrDialog()
 	if(D.is_screwdriver(user))
 		D.playtoolsound(src, 50)
 		if(do_after(user, src, 20))
@@ -341,12 +341,14 @@
 				A.anchored = 1
 				src.transfer_fingerprints_to(A)
 				qdel(src)
-	else if(istype(D, /obj/item/weapon/card/emag) && !emagged)
-		playsound(src, 'sound/effects/sparks4.ogg', 75, 1)
+	else 
+		return ..()
+
+/obj/machinery/computer/rdservercontrol/emag_act(mob/user)
+	if(!emagged)
+		. = ..()
 		emagged = 1
 		to_chat(user, "<span class='notice'>You disable the security protocols</span>")
-	src.updateUsrDialog()
-	return
 
 /obj/machinery/r_n_d/server/derelict
 	name = "Derelict R&D Server"

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -8,6 +8,7 @@
 	icon_state = "suspension2-b"
 	density = 1
 	req_access = list(access_science)
+	machine_flags = EMAGGABLE
 	var/obj/item/weapon/cell/cell
 	var/obj/item/weapon/card/id/auth_card
 	var/locked = 1

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -150,7 +150,7 @@
 		if (istype(I, /obj/item/weapon/card))
 			if(usr.drop_item(I, src))
 				auth_card = I
-				if(attempt_unlock(I))
+				if(attempt_unlock(I,usr))
 					to_chat(usr, "<span class='info'>You insert [I], the console flashes \'<i>Access granted.</a>\'</span>")
 				else
 					to_chat(usr, "<span class='warning'>You insert [I], the console flashes \'<i>Access denied.</a>\'</span>")
@@ -249,10 +249,10 @@
 		else
 			to_chat(user, "<span class='warning'>Remove [auth_card] first.</span>")
 
-/obj/machinery/suspension_gen/proc/attempt_unlock(var/obj/item/weapon/card/C)
+/obj/machinery/suspension_gen/proc/attempt_unlock(var/obj/item/weapon/card/C,var/mob/user)
 	if(!open)
-		if(isEmag(C))
-			emag_act()
+		if(emag_check(C,user))
+			return
 		else if(istype(C, /obj/item/weapon/card/id) && check_access(C))
 			locked = 0
 		if(!locked)

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -251,15 +251,18 @@
 
 /obj/machinery/suspension_gen/proc/attempt_unlock(var/obj/item/weapon/card/C)
 	if(!open)
-		if(istype(C, /obj/item/weapon/card/emag) && cell.charge > 0)
-			//put sparks here
-			if(prob(95))
-				locked = 0
+		if(isEmag(C))
+			emag_act()
 		else if(istype(C, /obj/item/weapon/card/id) && check_access(C))
 			locked = 0
-
 		if(!locked)
 			return 1
+
+/obj/machinery/suspension_gen/emag_act(mob/user)
+	if(cell.charge > 0)
+		. = ..()
+		if(prob(95))
+			locked = 0
 
 //checks for whether the machine can be activated or not should already have occurred by this point
 /obj/machinery/suspension_gen/proc/activate()

--- a/code/modules/telesci/rcs.dm
+++ b/code/modules/telesci/rcs.dm
@@ -116,8 +116,8 @@
 		to_chat(user, "<span class = 'caution'>You emag the RCS. Click on it to toggle between modes.</span>")
 
 /obj/item/weapon/rcs/attackby(var/obj/item/W, var/mob/user)
-	if(isEmag(W))
-		emag_act(user)
+	if(emag_check(W,user))
+		return
 	else if(W.is_screwdriver(user))
 		if(cell)
 			cell.updateicon()

--- a/code/modules/telesci/rcs.dm
+++ b/code/modules/telesci/rcs.dm
@@ -110,13 +110,15 @@
 		else
 			to_chat(user, "<span class = 'caution'> The telepad locator has become uncalibrated.</span>")
 
-
-/obj/item/weapon/rcs/attackby(var/obj/item/W, var/mob/user)
-	if(isEmag(W) && !emagged)
+/obj/item/weapon/rcs/emag_act(mob/user)
+	if(!emagged)
 		emagged = 1
 		spark(src, 5)
 		to_chat(user, "<span class = 'caution'>You emag the RCS. Click on it to toggle between modes.</span>")
 
+/obj/item/weapon/rcs/attackby(var/obj/item/W, var/mob/user)
+	if(isEmag(W))
+		emag_act(user)
 	else if(W.is_screwdriver(user))
 		if(cell)
 			cell.updateicon()

--- a/code/modules/telesci/rcs.dm
+++ b/code/modules/telesci/rcs.dm
@@ -77,7 +77,6 @@
 	throw_range = 5
 	var/obj/item/weapon/cell/high/cell = null
 	var/mode    = MODE_NORMAL
-	var/emagged = FALSE
 	var/send_cost = 1500
 	var/send_note = FALSE
 	var/no_station = FALSE

--- a/goon/code/obj/machinery/bot/chefbot.dm
+++ b/goon/code/obj/machinery/bot/chefbot.dm
@@ -164,8 +164,8 @@
 
 /obj/machinery/bot/chefbot/attackby(obj/item/W as obj, mob/user as mob)
 	..()
-	if(isEmag(W))
-		emag_act(user, W)
+	if(emag_check(W,user))
+		return
 	else
 		src.visible_message("<span class = 'warning'>[user] hits [src] with [W]!</span>")
 		if(prob(1))

--- a/goon/code/obj/machinery/bot/chefbot.dm
+++ b/goon/code/obj/machinery/bot/chefbot.dm
@@ -164,7 +164,7 @@
 
 /obj/machinery/bot/chefbot/attackby(obj/item/W as obj, mob/user as mob)
 	..()
-	if(istype(W, /obj/item/weapon/card/emag))
+	if(isEmag(W))
 		emag_act(user, W)
 	else
 		src.visible_message("<span class = 'warning'>[user] hits [src] with [W]!</span>")


### PR DESCRIPTION
[consistency][bugfix]

## What this does
makes a lot of snowflaked cryptographic sequencer card interactions generalised to emag_act()
changes the istype in code to the macro for cleanup
makes emagged a var on every atom
allows any atom to have an emag cost, makes the check count for anything emagged (note that this still functionally goes unused due to our infinite emag system, but it is a fun adminbus idea)

## Why it's good
more stuff for ai and pulse demon with the emag power to use

## How it was tested
see changelog for stuff tested

## Changelog
:cl:
 * tweak: AIs and pulse demons can now emag many more things a cryptographic sequencer already can, including mulebots, megaphones, tape recorders, security hailers, robot parts, nukeop gasha toys, the randomize AI module, defibrilators, secure closets, secure crates, secure lockboxes, the clowncart, EFTPOS scanners, holobadges, floral somatorays, spiderbots, temperature guns, nikitas, trash compactors, R&D server control computer, suspension generators, RUST fuel compressors and rapid crate senders.
 * tweak: Pulse demons can now emag supply computers and firedoors.
 * bugfix: The EFTPOS emag now works.