### PR TITLE
Allows mobs forcemoved into wooden crates to spawn when pried open

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -14,8 +14,8 @@
 	if(iscrowbar(W))
 		new /obj/item/stack/sheet/wood(src)
 		var/turf/T = get_turf(src)
-		for(var/obj/O in contents)
-			O.forceMove(T)
+		for(var/atom/movable/AM in contents)
+			AM.forceMove(T)
 		user.visible_message("<span class='notice'>[user] pries \the [src] open.</span>", \
 							 "<span class='notice'>You pry open \the [src].</span>", \
 							 "<span class='notice'>You hear splitting wood.</span>")


### PR DESCRIPTION
[consistency][administration][easyfix]

## What this does
Closes #36646.

## How it was tested
proc call forceMove() on human mob into the crate, pry open.

## Changelog
:cl:
 * bugfix: Mobs that end up inside large wooden crates now show up when they get dismantled.