### PR TITLE
Fixes anim() interaction with firedoor causing them to become crossable

### DIFF
--- a/__DEFINES/atom_locking_and_control.dm
+++ b/__DEFINES/atom_locking_and_control.dm
@@ -6,6 +6,7 @@
 #define CANT_BE_MOVED_BY_LOCKED_MOBS 4
 #define LOCKED_CAN_LIE_AND_STAND     8
 #define LOCKED_STAY_INSIDE			16
+#define DONT_MESS_WITH_DENSITY		32
 
 // Flags for atom.lockflags
 #define DENSE_WHEN_LOCKED            1

--- a/code/datums/locking_category.dm
+++ b/code/datums/locking_category.dm
@@ -25,8 +25,9 @@
 
 	AM.anchored = TRUE
 
-	if (flags & DENSE_WHEN_LOCKING || AM.lockflags & DENSE_WHEN_LOCKED)
-		owner.setDensity(TRUE)
+	if (!(flags & DONT_MESS_WITH_DENSITY))
+		if (flags & DENSE_WHEN_LOCKING || AM.lockflags & DENSE_WHEN_LOCKED)
+			owner.setDensity(TRUE)
 
 	AM.pixel_x += pixel_x_offset * PIXEL_MULTIPLIER
 	AM.pixel_y += pixel_y_offset * PIXEL_MULTIPLIER
@@ -89,21 +90,22 @@
 
 	AM.anchored = initial(AM.anchored)
 
-	// Okay so now we have to loop through ALL of the owner's locked atoms and their categories to see if the owner still needs to be dense.
-	var/found = FALSE
-	if (flags & DENSE_WHEN_LOCKING || AM.lockflags & DENSE_WHEN_LOCKED)
-		for (var/atom/movable/candidate in owner.locked_atoms)
-			if (candidate.lockflags & DENSE_WHEN_LOCKED)
-				found = TRUE
-				break
+	if (!(flags & DONT_MESS_WITH_DENSITY))
+		// Okay so now we have to loop through ALL of the owner's locked atoms and their categories to see if the owner still needs to be dense.
+		var/found = FALSE
+		if (flags & DENSE_WHEN_LOCKING || AM.lockflags & DENSE_WHEN_LOCKED)
+			for (var/atom/movable/candidate in owner.locked_atoms)
+				if (candidate.lockflags & DENSE_WHEN_LOCKED)
+					found = TRUE
+					break
 
-			var/datum/locking_category/cat = owner.locked_atoms[candidate]
-			if (cat.flags & DENSE_WHEN_LOCKING)
-				found = TRUE
-				break
+				var/datum/locking_category/cat = owner.locked_atoms[candidate]
+				if (cat.flags & DENSE_WHEN_LOCKING)
+					found = TRUE
+					break
 
-	if (!found)
-		owner.setDensity(initial(owner.density))
+		if (!found)
+			owner.setDensity(initial(owner.density))
 
 	if (ismob(AM))
 		var/mob/M = AM

--- a/code/game/turfs/turf_flick_animations.dm
+++ b/code/game/turfs/turf_flick_animations.dm
@@ -72,7 +72,7 @@
 		animation.transform = trans
 	if (target && ismovable(target))
 		var/atom/movable/AM = target
-		AM.lock_atom(animation, /datum/locking_category/buckle)
+		AM.lock_atom(animation, /datum/locking_category/animation)
 	if(a_icon_state)
 		animation.icon_state = a_icon_state
 	else
@@ -84,6 +84,9 @@
 		qdel(animation)
 
 	return animation
+
+/datum/locking_category/animation
+	flags = DONT_MESS_WITH_DENSITY
 
 /*
 //called when the tile is cultified


### PR DESCRIPTION
Fixes #37011

:cl:
* bugfix: Fixed being able to walk through closed Firelocks after clicking on them while not having permission due to dangerous atmos conditions.