### PR TITLE
Better Area Alert Visuals

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -12,7 +12,7 @@ var/area/space_area
 	var/list/obj/machinery/light_switch/lightswitches = list()
 	var/list/obj/machinery/light/lights = list()
 	var/list/area_turfs
-	plane = ABOVE_LIGHTING_PLANE
+	plane = LIGHTING_PLANE
 	layer = MAPPING_AREA_LAYER
 	var/base_turf_type = null
 	var/shuttle_can_crush = TRUE
@@ -346,8 +346,10 @@ var/area/space_area
 /area/proc/updateicon()
 	if (!areaapc)
 		icon_state = null
+		luminosity = 0
 		return
 	if ((fire || eject || party || radalert) && ((!requires_power)?(!requires_power):power_environ))//If it doesn't require power, can still activate this proc.
+		luminosity = 1
 		// Highest priority at the top.
 		if(radalert && !fire)
 			icon_state = "radiation"
@@ -364,6 +366,7 @@ var/area/space_area
 	else
 	//	new lighting behaviour with obj lights
 		icon_state = null
+		luminosity = 0
 
 
 /*


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/eeff0b2f-3bfa-4ad1-a43f-8dbeb2e3c3f4)

https://github.com/user-attachments/assets/d974c96a-1822-4809-ae32-18ef45db30b6

(old on the left, new on the right)

:cl:
* tweak: The area lights that appear during alerts are now additive, meaning that they don't make your eyes hurt as much, and improve visibility and mood overall.