### PR TITLE
Makes timers and proximity sensors actually count down to the second from activation

### DIFF
--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -266,7 +266,7 @@
 	ign.secured = 1
 	ign.holder = src
 	var/obj/item/device/assembly/timer/tmr = new(src)
-	tmr.time=5
+	tmr.time=10
 	tmr.secured = 1
 	tmr.holder = src
 	a_left = tmr

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -269,7 +269,6 @@
 	tmr.time=5
 	tmr.secured = 1
 	tmr.holder = src
-	processing_objects.Add(tmr)
 	a_left = tmr
 	a_right = ign
 	secured = 1

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -112,8 +112,7 @@
 
 /obj/item/device/assembly/prox_sensor/proc/countdown()
 	if(timing)
-		updateUsrDialog()
-		if(time >= 0)
+		if(time > 0)
 			spawn(10)
 				time--
 				countdown()
@@ -121,6 +120,7 @@
 			timing = 0
 			toggle_scan()
 			time = default_time
+		updateUsrDialog()
 
 /obj/item/device/assembly/prox_sensor/dropped()
 	spawn(0)

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -53,6 +53,7 @@
 		return 0//Cooldown check
 	timing = !timing
 	update_icon()
+	countdown()
 	return 0
 
 /obj/item/device/assembly/prox_sensor/toggle_secure()
@@ -109,14 +110,17 @@
 				in_proximity = FALSE
 				sense()
 
+/obj/item/device/assembly/prox_sensor/proc/countdown()
 	if(timing)
+		updateUsrDialog()
 		if(time >= 0)
-			time--
+			spawn(10)
+				time--
+				countdown()
 		else
 			timing = 0
 			toggle_scan()
 			time = default_time
-		updateUsrDialog()
 
 /obj/item/device/assembly/prox_sensor/dropped()
 	spawn(0)
@@ -158,7 +162,7 @@
 		return 0
 	var/second = time % 60
 	var/minute = (time - second) / 60
-	var/dat = text("<TT><B>Proximity Sensor</B>\n[] []:[]\n<A href='?src=\ref[];tp=-30'>-</A> <A href='?src=\ref[];tp=-1'>-</A> <A href='?src=\ref[];tp=1'>+</A> <A href='?src=\ref[];tp=30'>+</A>\n</TT>", (timing ? text("<A href='?src=\ref[];time=0'>Arming</A>", src) : text("<A href='?src=\ref[];time=1'>Not Arming</A>", src)), minute, second, src, src, src, src)
+	var/dat = text("<TT><B>Proximity Sensor</B>\n[] []:[]\n<A href='?src=\ref[];tp=-30'>-</A> <A href='?src=\ref[];tp=-1'>-</A> <A href='?src=\ref[];tp=1'>+</A> <A href='?src=\ref[];tp=30'>+</A>\n</TT>", (timing ? text("<A href='?src=\ref[];time=1'>Arming</A>", src) : text("<A href='?src=\ref[];time=1'>Not Arming</A>", src)), minute, second, src, src, src, src)
 	dat += text("<BR>Range: <A href='?src=\ref[];range=-1'>-</A> [] <A href='?src=\ref[];range=1'>+</A>", src, range, src)
 
 	dat += {"<BR><A href='?src=\ref[src];scanning=1'>[scanning?"Armed":"Unarmed"]</A> (Movement sensor active when armed!)
@@ -182,8 +186,7 @@
 		toggle_scan()
 
 	if(href_list["time"])
-		timing = text2num(href_list["time"])
-		update_icon()
+		activate()
 
 	if(href_list["tp"])
 		var/tp = text2num(href_list["tp"])

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -34,17 +34,15 @@
 		return 0//Cooldown check
 
 	timing = !timing
-
+	message_admins("[key_name_admin(usr)] [timing ? "started" : "stopped"] a timer at [formatJumpTo(src)]")
 	update_icon()
+	countdown()
 	return 0
 
 /obj/item/device/assembly/timer/toggle_secure()
 	secured = !secured
-	if(secured)
-		processing_objects.Add(src)
-	else
+	if(!secured)
 		timing = 0
-		processing_objects.Remove(src)
 	update_icon()
 	return secured
 
@@ -59,16 +57,18 @@
 		process_cooldown()
 	return
 
-/obj/item/device/assembly/timer/process()
+/obj/item/device/assembly/timer/proc/countdown()
 	if(timing)
+		updateUsrDialog()
 		if(time > 0)
-			time--
+			spawn(10)
+				time--
+				countdown()
 		else
 			if(!repeat)
 				timing = 0
 			timer_end()
 			time = default_time
-		updateUsrDialog()
 
 /obj/item/device/assembly/timer/update_icon()
 	overlays.len = 0
@@ -87,7 +87,7 @@
 		return 0
 	var/second = time % 60
 	var/minute = (time - second) / 60
-	var/dat = text("<TT><B>Timing Unit</B>\n[] []:[]\n<A href='?src=\ref[];tp=-30'>-</A> <A href='?src=\ref[];tp=-1'>-</A> <A href='?src=\ref[];tp=1'>+</A> <A href='?src=\ref[];tp=30'>+</A>\n</TT>", (timing ? text("<A href='?src=\ref[];time=0'>Timing</A>", src) : text("<A href='?src=\ref[];time=1'>Not Timing</A>", src)), minute, second, src, src, src, src)
+	var/dat = text("<TT><B>Timing Unit</B>\n[] []:[]\n<A href='?src=\ref[];tp=-30'>-</A> <A href='?src=\ref[];tp=-1'>-</A> <A href='?src=\ref[];tp=1'>+</A> <A href='?src=\ref[];tp=30'>+</A>\n</TT>", (timing ? text("<A href='?src=\ref[];time=1'>Timing</A>", src) : text("<A href='?src=\ref[];time=1'>Not Timing</A>", src)), minute, second, src, src, src, src)
 	dat += "<BR><BR><A href='?src=\ref[src];set_default_time=1'>After countdown, reset time to [(default_time - default_time%60)/60]:[(default_time % 60)]</A>"
 	dat += "<BR><BR><A href='?src=\ref[src];toggle_mode=1'>Mode: [repeat ? TIMEMODE_REPEAT : TIMEMODE_ONCE]</A>"
 	user << browse(dat, "window=timer")
@@ -105,9 +105,7 @@
 		return
 
 	if(href_list["time"])
-		timing = text2num(href_list["time"])
-		message_admins("[key_name_admin(usr)] [timing ? "started" : "stopped"] a timer at [formatJumpTo(src)]")
-		update_icon()
+		activate()
 
 	if(href_list["tp"])
 		var/tp = text2num(href_list["tp"])
@@ -121,7 +119,6 @@
 		default_time = time
 
 	updateUsrDialog()
-	return
 
 /obj/item/device/assembly/timer/send_to_past(var/duration)
 	..()

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -59,7 +59,6 @@
 
 /obj/item/device/assembly/timer/proc/countdown()
 	if(timing)
-		updateUsrDialog()
 		if(time > 0)
 			spawn(10)
 				time--
@@ -69,6 +68,7 @@
 				timing = 0
 			timer_end()
 			time = default_time
+		updateUsrDialog()
 
 /obj/item/device/assembly/timer/update_icon()
 	overlays.len = 0


### PR DESCRIPTION
[bugfix]

## What this does
previously the countdown was a two second gap between each tick countdown instead of the more intuitive one second, and synced to the global object process system instead of being from the moment it was activated
adjusts all the preset chem grenade timers to take the same length as the old system for consistency, let me know if this is a good change or not (without this, they would take 5 seconds to prime instead of still taking 10)

## Why it's good
more intuitive behaviour

## How it was tested
clicking the "timing" button on the timer and proximity sensor windows, using tear gas grenades

## Changelog
:cl:
 * bugfix: Timer and proximity sensor assemblies now accurately tick their timers down to the second instead of every two seconds, and timed from the moment they were activated. For consistency, all pre-spawned chem grenades now have their arm time doubled as to make them activate in the same amount of time as before this change.
 * bugfix: Proximity sensors now count down to zero in the same manner as timers.