### PR TITLE
Fixes clumsy people setting themselves on fire while lighting cigarettes

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -61,6 +61,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 	lit = 1
 	update_brightness()
 
+
 /obj/item/weapon/match/extinguish()
 	if (lit > 0)
 		visible_message("<span class='notice'>\The [name] goes out.</span>")
@@ -359,9 +360,7 @@ MATCHBOXES ARE ALSO IN FANCY.DM
 		if(Z.is_hot())
 			if (clumsy_check(user) && (prob(50)))
 				light("<span class='rose'>With a single flick of their wrist, [user] smoothly lights \his [name] </span><span class='danger'>as well as themselves</span><span class='rose'> with \the [W]. Damn, that's cool.</span>")
-				user.adjust_fire_stacks(0.5)
-				user.on_fire = 1
-				user.update_icon = 1
+				user.ignite()
 				playsound(user.loc, 'sound/effects/bamf.ogg', 50, 0)
 			else
 				light("<span class='rose'>With a single flick of their wrist, [user] smoothly lights \his [name] with \the [W]. Damn, that's cool.</span>")


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Clumsy people now will light themselves on fire 50% of the time when attempting to light a cigarette. This feature has been in code but I don't think it was implemented properly. It'll now use the consistent ignite() proc and should work fine.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Fixes old code and it's funny!

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
0% tested but it'll work.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Clumsy people will now properly catch on fire half the time when lighting a cigarette.