### PR TITLE
Allows medical belts to hold thermometers and stethoscopes

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -170,6 +170,7 @@
 		"/obj/item/device/flashlight/pen",
 		"/obj/item/clothing/mask/surgical",
 		"/obj/item/clothing/gloves/latex",
+		"/obj/item/clothing/accessory/stethoscope",
 		"/obj/item/device/mass_spectrometer",
 		"/obj/item/device/reagent_scanner",
 		"/obj/item/device/gps/paramedic",
@@ -179,6 +180,7 @@
 		"/obj/item/weapon/electrolyzer",
 		"/obj/item/weapon/autopsy_scanner/healthanalyzerpro",
 		"/obj/item/weapon/depocket_wand/suit",
+		"/obj/item/weapon/thermometer",
 		"/obj/item/taperoll/viro",
 		"/obj/item/taperoll/syndie/viro"
 	)


### PR DESCRIPTION
[consistency]

## What this does
Closes #37034.

## Changelog
:cl:
 * bugfix: Thermometers and stethoscopes can now fit in medical belts