### PR TITLE
Fixes stack materials not updating when in storage

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -378,7 +378,7 @@
 		for(var/obj/item/stack/otherS in src)
 			if(otherS.amount < otherS.max_amount && otherS.type == S.type)
 				var/to_transfer = min(S.amount, otherS.max_amount - otherS.amount)
-				otherS.amount += to_transfer
+				otherS.add(to_transfer)
 				if(usr)
 					add_fingerprint(usr)
 					if(!prevent_warning)


### PR DESCRIPTION
[bugfix][itsloose]

## What this does
Closes #37041.

## How it was tested
drill for ores, pick up with satchel, put in ore processor

## Changelog
:cl:
 * bugfix: Putting stacks in storage now properly updates their materials.