### PR TITLE
Anchor arms give tackle bonus

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -195,6 +195,12 @@
 	item_state = "anchorarms"
 	species_fit = list(VOX_SHAPED, INSECT_SHAPED)
 
+/obj/item/clothing/gloves/anchor_arms/offenseTackleBonus()
+	return 15
+
+/obj/item/clothing/gloves/anchor_arms/defenseTackleBonus()
+	return 15
+
 /obj/item/clothing/gloves/neorussian
 	name = "neo-Russian gloves"
 	desc = "Utilizes a non-slip technology that allows you to never drop your precious bottles of vodka."


### PR DESCRIPTION
## What this does
Anchor arms now give a slight tackle boost to offense and defense (15) but not to range.
## Why it's good
Look at those arms man, you could tackle the heavens with those.
## How it was tested
Spawned the arms, tackled a naked monkeyman 10 times, succeeded the tackle roll each time.
:cl:
 * rscadd: Anchor arms now give a slight tackling boost to offense and defense.