### PR TITLE
Gives Admins Power to VV Gun Projectile Variables

### DIFF
--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -243,6 +243,12 @@
 	A.yo = U.y - T.y
 	A.xo = U.x - T.x
 	A.OnFired()
+	var/obj/item/weapon/gun/G = installed
+	if(G.bullet_overrides)
+		for(var/bvar in A.vars)
+			for(var/o in G.bullet_overrides)
+				if(bvar == o)
+					A.vars[bvar] = G.bullet_overrides[o]
 	spawn()
 		A.process()
 	return

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -802,7 +802,7 @@ var/list/admin_verbs_mod = list(
 		//effect vars
 		"stun", "weaken", "paralyze", "irradiate", "eyeblur", "drowsy", "agony", "jittery",
 		//appearance/misc vars
-		"icon", "icon_state", "color", "silenced", "manual variable entry"
+		"icon (upload dmi)", "icon_state", "color", "silenced", "manual variable entry"
 	)
 
 	var/inputvar
@@ -827,7 +827,11 @@ var/list/admin_verbs_mod = list(
 		if("damage_type")
 			newvalue = input(usr, "What type of damage should the projectile deal (it can only deal one, sorry)?", "Var: [inputvar]") as null|anything in list("brute", "oxy", "tox", "fire", "clone", "brain")
 		if("nodamage")
-			newvalue = input(usr, "Should the gun do damage on hit?", "Var: [inputvar]") as null|anything in list(TRUE, FALSE)
+			newvalue = input(usr, "Should the gun NOT do damage on hit?", "Var: [inputvar]") as null|anything in list("True", "False")
+			if(newvalue == "True")
+				newvalue = TRUE
+			else
+				newvalue = FALSE
 		if("what armor resists (flag)")
 			newvalue = input(usr, "What armor type should resist this damage?", "Var: [inputvar]") as null|anything in list("melee", "bullet", "laser", "energy", "bomb", "bio", "rad")
 			inputvar = "flag"
@@ -846,6 +850,11 @@ var/list/admin_verbs_mod = list(
 			if(isnull(inputvar))
 				return
 			newvalue = variable_set(usr)
+		if("icon (upload dmi)")
+			newvalue = input(usr, "Choose an icon file for your new projectile!", "Var: [inputvar]") as null|icon
+			inputvar = "icon"
+		if("icon_state")
+			newvalue = input(usr, "What icon_state to set?", "Var: [inputvar]") as null|text
 		else
 			newvalue = variable_set(usr)
 	if(isnull(newvalue))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -785,7 +785,7 @@ var/list/admin_verbs_mod = list(
 
 /client/proc/gun_override(var/obj/item/weapon/gun/G in world)
 	set category = "Fun"
-	set name = "Override Gun Variables"
+	set name = "Override Projectile Vars"
 	set desc = "Give a gun special rules"
 
 	//dumb temporary override please fix this if we can get a list of these
@@ -802,7 +802,7 @@ var/list/admin_verbs_mod = list(
 		//effect vars
 		"stun", "weaken", "paralyze", "irradiate", "eyeblur", "drowsy", "agony", "jittery",
 		//appearance/misc vars
-		"icon", "icon_state", "color", "silenced",
+		"icon", "icon_state", "color", "silenced", "manual variable entry"
 	)
 
 	var/inputvar
@@ -841,6 +841,11 @@ var/list/admin_verbs_mod = list(
 			newvalue = input(usr, "What color (RGB format, example: #00ff00)?", "Var: [inputvar]") as null|color
 		if("silenced")
 			newvalue = input(usr, "Should the gun have no text when fired?", "Var: [inputvar]") as null|anything in list(TRUE, FALSE)
+		if("manual variable entry")
+			inputvar = input(usr, "What variable name to manually insert and then edit (verify it!)?", "Var: [inputvar]") as null|text
+			if(isnull(inputvar))
+				return
+			newvalue = variable_set(usr)
 		else
 			newvalue = variable_set(usr)
 	if(isnull(newvalue))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -806,8 +806,7 @@ var/list/admin_verbs_mod = list(
 	)
 
 	var/inputvar
-	if(!G.bullet_overrides)
-		G.bullet_overrides = list()
+	G.bullet_overrides ||= list()
 	if(!G.bullet_overrides.len)
 		inputvar = input(usr, "What variable would you like to change?", "Gun Variables") as null|anything in projectile_vars
 	else

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -133,6 +133,7 @@ var/list/admin_verbs_fun = list(
 	/client/proc/add_centcomm_order,
 	/client/proc/apes,
 	/client/proc/force_next_map,
+	/client/proc/gun_override,
 	)
 var/list/admin_verbs_spawn = list(
 	/datum/admins/proc/spawn_atom, // Allows us to spawn instances
@@ -256,6 +257,7 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/play_local_sound,
 	/client/proc/play_sound,
 	/client/proc/object_talk,
+	/client/proc/gun_override,
 	/client/proc/cmd_admin_gib_self,
 	/client/proc/drop_bomb,
 	/client/proc/drop_emp,
@@ -780,6 +782,76 @@ var/list/admin_verbs_mod = list(
 	log_admin("[key_name(usr)] made [O] at [O.x], [O.y], [O.z] say \"[message]\"")
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] made [O] at [O.x], [O.y], [O.z]. say \"[message]\"</span>", 1)
 	feedback_add_details("admin_verb","OT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/client/proc/gun_override(var/obj/item/weapon/gun/G in world)
+	set category = "Fun"
+	set name = "Override Gun Variables"
+	set desc = "Give a gun special rules"
+
+	//dumb temporary override please fix this if we can get a list of these
+	//remains here to remind you of what could have been.
+	/*
+	var/obj/item/projectile/tempproj = new
+	var/list/projectile_vars = sortList(tempproj.vars)
+	qdel(tempproj)
+	*/
+
+	var/list/projectile_vars = list(
+		//damage/main vars
+		"damage", "damage_type", "nodamage", "what armor resists (flag)", "projectile_speed", "travel_range",
+		//effect vars
+		"stun", "weaken", "paralyze", "irradiate", "eyeblur", "drowsy", "agony", "jittery",
+		//appearance/misc vars
+		"icon", "icon_state", "color", "silenced",
+	)
+
+	var/inputvar
+	if(!G.bullet_overrides)
+		G.bullet_overrides = list()
+	if(!G.bullet_overrides.len)
+		inputvar = input(usr, "What variable would you like to change?", "Gun Variables") as null|anything in projectile_vars
+	else
+		var/existing_bullet_override_pick = input(usr, "Would you like to edit an existing variable or add a new one?", "Gun Variables") as null|anything in G.bullet_overrides + "(ADD VAR)"
+		if(!existing_bullet_override_pick)
+			return
+		else if(existing_bullet_override_pick == "(ADD VAR)")
+			inputvar = input(usr, "What variable would you like to change?", "Gun Variables") as null|anything in projectile_vars
+		else
+			inputvar = existing_bullet_override_pick
+	if(!inputvar)
+		return
+	var/newvalue
+	switch(inputvar)
+		if("damage","irradiate")
+			newvalue = input(usr, "How much damage should the projectile deal?", "Var: [inputvar]") as null|num
+		if("damage_type")
+			newvalue = input(usr, "What type of damage should the projectile deal (it can only deal one, sorry)?", "Var: [inputvar]") as null|anything in list("brute", "oxy", "tox", "fire", "clone", "brain")
+		if("nodamage")
+			newvalue = input(usr, "Should the gun do damage on hit?", "Var: [inputvar]") as null|anything in list(TRUE, FALSE)
+		if("what armor resists (flag)")
+			newvalue = input(usr, "What armor type should resist this damage?", "Var: [inputvar]") as null|anything in list("melee", "bullet", "laser", "energy", "bomb", "bio", "rad")
+			inputvar = "flag"
+		if("projectile_speed")
+			newvalue = input(usr, "How much time (in deciseconds) should the bullet delay between tile movements? (examples, Taser electrode is 1, Glock bullets are 0.5)?", "Var: [inputvar]") as null|num
+		if("travel_range")
+			newvalue = input(usr, "How far should the projectile travel before vanishing? (0 to go indefinitely)", "Gun Variables") as null|num
+		if("stun","weaken","paralyze","eyeblur","agony","jittery")
+			newvalue = input(usr, "New effect value? Most go down 1 per tick.", "Var: [inputvar]") as null|num
+		if("color")
+			newvalue = input(usr, "What color (RGB format, example: #00ff00)?", "Var: [inputvar]") as null|color
+		if("silenced")
+			newvalue = input(usr, "Should the gun have no text when fired?", "Var: [inputvar]") as null|anything in list(TRUE, FALSE)
+		else
+			newvalue = variable_set(usr)
+	if(isnull(newvalue))
+		return
+	G.bullet_overrides[inputvar] = newvalue
+	to_chat(usr,"Current list of projectile edits:")
+	for(var/result in G.bullet_overrides)
+		to_chat(usr,"[result]: [G.bullet_overrides[result]]")
+	log_admin("[key_name(usr)] overrode [G]'s projectile variable [inputvar] to [newvalue].")
+	message_admins("<span class='adminnotice'>[key_name_admin(usr)] overrode [G]'s projectile variable [inputvar] to [newvalue].</span>", 1)
+	feedback_add_details("admin_verb","GOR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/deadmin_self()
 	set name = "De-admin self"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -79,6 +79,12 @@
 	var/gun_miss_message //Message that shows up as an addition to the message text
 	var/gun_miss_message_replace //If toggled on, will cause gun_miss_message to replace the entire missing message
 
+	//This is a list that allows admins to alter projectile properties mid-round via assoc list.
+	//Usage: vv the gun, C a new list, add text variable equal to the variable name you want to change,
+	//Then set an associative value equal to the new value you want to change it to.
+	//aka if you want to change the damage to 25, add a list with entry: text damage and associated value num 25
+	var/list/bullet_overrides
+
 /obj/item/weapon/gun/New()
 	..()
 	if(isHandgun())
@@ -333,6 +339,12 @@
 		in_chamber.projectile_miss_message = gun_miss_message
 	if(gun_miss_message_replace)
 		in_chamber.projectile_miss_message_replace = gun_miss_message_replace
+
+	if(bullet_overrides)
+		for(var/bvar in in_chamber.vars)
+			for(var/o in bullet_overrides)
+				if(bvar == o)
+					in_chamber.vars[bvar] = bullet_overrides[o]
 
 	spawn()
 		if(in_chamber)


### PR DESCRIPTION
# Encouraging bad admin behavior since 2024
![image](https://github.com/user-attachments/assets/36cddd38-481f-43e0-a160-8fa34815b19a)

## What this does
This adds a list variable called ``bullet_overrides`` to all guns, null by default. This is a list of variables that will replace the projectile's variables when it is fired. To use it, you need to follow these steps:
### EASY MODE
0) have +FUN
1) right click gun
2) choose variable
3) fun begins

![image](https://github.com/user-attachments/assets/1cf3e2ba-2fa9-4901-af74-d393ba49541d)
![image](https://github.com/user-attachments/assets/476a1b55-9e8f-48ac-b169-162bf135837f)
![image](https://github.com/user-attachments/assets/cab6662e-7cd8-4380-946f-8dad84ff8a5a)
![image](https://github.com/user-attachments/assets/0919cdf8-ab80-43a7-ab2e-62a69e33def3)
![image](https://github.com/user-attachments/assets/a8a02ce2-e744-456a-8dd0-9c862bacdc94)

### POWER USER MODE
0) have +VAREDIT
1) Add (C) an empty list to this variable 
2) Add (E) text entries to the list depending on what you want to change, with associated variables being the value you want to set them to
3) Fire away

For example, if you want to make your laser deal 10 TOX damage on hit instead of the default laser damage, you would:
1) vv your desired gun
2) (C) add an empty list to ``bullet_overrides``
![image](https://github.com/user-attachments/assets/6c54871e-b3e5-4660-b57c-0cb9f7475f6d)
3) (E) Add var, text, ``damage`` no quotes or anything, yes associate a value, num, ``10``
![image](https://github.com/user-attachments/assets/44990a9b-fa8d-4b3b-b69f-a670261fc3a3)
![image](https://github.com/user-attachments/assets/61771801-0618-49b8-8d51-0a74c95e06ae)
![image](https://github.com/user-attachments/assets/c86ab90a-bbc8-4885-8d64-243681a428ff)
![image](https://github.com/user-attachments/assets/2245f0a0-0ed9-4f83-a619-7a5b598bed36)
![image](https://github.com/user-attachments/assets/88c3b27e-f40f-449c-a0ff-84fe0eb02a57)
4) Add another variable, text, ``damage_type``, yes associate a value, text, ``tox``
5) Done.
(TL NOTE: this didn't affect the taser projectile, which has a bonus ``nodamage = 1`` variable that must also be changed!)
![image](https://github.com/user-attachments/assets/6d8a6e3a-08d0-47ab-95a6-005ce1ccd4c0)
(Shot this dummy 3 times with laser set to LETHALS)
![image](https://github.com/user-attachments/assets/5ed60f0e-05ab-418a-9518-a1784fa45a05)

## Why it's good
Oh boy is it not good for the players. Hoooo boy.

## How it was tested
See above images for some examples.
