### PR TITLE
Fixes beartraps on the meteorological vault

### DIFF
--- a/maps/randomvaults/meteorlogical_station.dmm
+++ b/maps/randomvaults/meteorlogical_station.dmm
@@ -223,9 +223,7 @@
 /turf/simulated/floor/shuttle/brig,
 /area/vault/meteorlogical)
 "aM" = (
-/obj/item/weapon/beartrap{
-	armed = 1
-	},
+/obj/item/weapon/beartrap/armed,
 /turf/simulated/floor/shuttle/brig,
 /area/vault/meteorlogical)
 "aN" = (


### PR DESCRIPTION
[vault]

## What this does
Closes #37052.
was thankfully just this vault.

## Changelog
:cl:
 * bugfix: The armed beartraps on the meteorological station vault now look as they're supposed to.