### PR TITLE
Fixes borgs catching on fire during repairs

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -434,11 +434,6 @@
 			to_chat(user, "<span class='warning'>That was stupid of you.</span>")
 			explosion(get_turf(A),-1,0,3)
 			return
-	if (src.welding)
-		if(isliving(A))
-			var/mob/living/L = A
-			L.ignite()
-			remove_fuel(1)
 
 /obj/item/tool/weldingtool/attack_self(mob/user as mob)
 	toggle(user)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -164,14 +164,15 @@
 
 /mob/living/silicon/robot/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(!module)
-		..()
-		return
+		return ..()
 	if(module && locate(/obj/item/borg/fire_shield, module.modules))
 		return
 	..()
 
 //Robots on fire
 /mob/living/silicon/robot/handle_fire()
+	if(!module)
+		return
 	if(..() || locate(/obj/item/borg/fire_shield, module.modules))
 		return
 	adjustFireLoss(3)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -164,8 +164,8 @@
 
 /mob/living/silicon/robot/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(!module)
-		return ..()
-	if(module && locate(/obj/item/borg/fire_shield, module.modules))
+		..()
+	if(locate(/obj/item/borg/fire_shield, module.modules))
 		return
 	..()
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes borgs or humans with robotic limbs catching on fire while being repaired. IgniteMob() contained unused logic for igniting someone covered in welding fuel, so doing a blanket replacement of it with ignite() exposed logic which would simply set mobs on fire if they were attacked by a welding tool in a manner which didn't damage them (in this case, when they were being repaired).

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Allows borgs to be repaired once more.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Repaired a damaged cyborg and a human with a damaged robotic limb and confirmed they did not ignite.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed borgs and humans with robotic limbs catching on fire when repaired.
