### PR TITLE
Plate cutting fixes

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -628,8 +628,11 @@
 			"<span class='notice'>You inaccurately slice \the [src] with \the [W]!</span>")
 			slices_lost = rand(1, min(1, round(slices_num/2))) //Randomly lose a few slices along the way, but at least one and up to half
 		var/reagents_per_slice = reagents.total_volume/slices_num //Figure out how much reagents each slice inherits (losing slices loses reagents)
+		var/atom/place_to_spawn = loc
+		if(istype(loc,/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom)) // so things slice off these plates properly
+			place_to_spawn = place_to_spawn.loc
 		for(var/i = 1 to (slices_num - slices_lost)) //Transfer those reagents
-			var/obj/item/weapon/reagent_containers/food/snacks/slice = new slice_path(src.loc)
+			var/obj/item/weapon/reagent_containers/food/snacks/slice = new slice_path(place_to_spawn)
 			if(istype(src, /obj/item/weapon/reagent_containers/food/snacks/customizable)) //custom sliceable foods have overlays we need to apply
 				var/obj/item/weapon/reagent_containers/food/snacks/customizable/C = src
 				var/obj/item/weapon/reagent_containers/food/snacks/customizable/S = slice

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -617,10 +617,10 @@
 		contents += W
 		return 1 //No afterattack here
 
-/obj/item/weapon/reagent_containers/food/snacks/proc/slice_act(mob/user,var/sharpness)
+/obj/item/weapon/reagent_containers/food/snacks/proc/slice_act(mob/user,obj/item/W)
 	if(slice_path && slices_num && slices_num > 0)
 		var/slices_lost = 0
-		if(sharpness >= 1.2)
+		if(W.is_sharp() >= 1.2)
 			user.visible_message("<span class='notice'>[user] slices \the [src].</span>", \
 			"<span class='notice'>You slice \the [src].</span>")
 		else
@@ -668,9 +668,9 @@
 		visible_message("<span class='warning'>The items sloppily placed within fall out of \the [src]!</span>")
 		return 1
 
-/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom/slice_act(mob/user) // to stop plate duplication memes
+/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom/slice_act(mob/user,obj/item/W) // to stop plate duplication memes
 	for(var/obj/item/weapon/reagent_containers/food/snacks/S in src)
-		. |= S.slice_act()
+		. |= S.slice_act(user,W)
 
 /obj/item/weapon/reagent_containers/food/snacks/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	..()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -58,12 +58,10 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/Destroy()
 	QDEL_NULL(dip)
-	var/atom/place_to_spawn = loc
-	if(istype(loc,/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom)) // consistency
-		place_to_spawn = place_to_spawn.loc
+	var/turf/T = get_turf(src)
 	if(contents.len)
 		for(var/atom/movable/A in src)
-			A.forceMove(place_to_spawn)
+			A.forceMove(T)
 		visible_message("<span class='warning'>The items sloppily placed within fall out of \the [src]!</span>")
 	..()
 
@@ -620,9 +618,6 @@
 		return 1 //No afterattack here
 
 /obj/item/weapon/reagent_containers/food/snacks/proc/slice_act(mob/user,obj/item/W)
-	var/atom/place_to_spawn = loc
-	if(istype(loc,/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom)) // so things slice off these plates properly
-		place_to_spawn = place_to_spawn.loc
 	if(slice_path && slices_num && slices_num > 0)
 		var/slices_lost = 0
 		if(W.is_sharp() >= 1.2)
@@ -634,7 +629,7 @@
 			slices_lost = rand(1, min(1, round(slices_num/2))) //Randomly lose a few slices along the way, but at least one and up to half
 		var/reagents_per_slice = reagents.total_volume/slices_num //Figure out how much reagents each slice inherits (losing slices loses reagents)
 		for(var/i = 1 to (slices_num - slices_lost)) //Transfer those reagents
-			var/obj/item/weapon/reagent_containers/food/snacks/slice = new slice_path(place_to_spawn)
+			var/obj/item/weapon/reagent_containers/food/snacks/slice = new slice_path(get_turf(src))
 			if(istype(src, /obj/item/weapon/reagent_containers/food/snacks/customizable)) //custom sliceable foods have overlays we need to apply
 				var/obj/item/weapon/reagent_containers/food/snacks/customizable/C = src
 				var/obj/item/weapon/reagent_containers/food/snacks/customizable/S = slice
@@ -669,7 +664,7 @@
 		return 1
 	if(contents.len) //Food item is not sliceable but still has items hidden inside. Using a knife on it should be an easy way to get them out.
 		for(var/atom/movable/A in src)
-			A.forceMove(place_to_spawn)
+			A.forceMove(get_turf(src))
 		visible_message("<span class='warning'>The items sloppily placed within fall out of \the [src]!</span>")
 		return 1
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -58,10 +58,12 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/Destroy()
 	QDEL_NULL(dip)
-	var/turf/T = get_turf(src)
+	var/atom/place_to_spawn = loc
+	if(istype(loc,/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom)) // consistency
+		place_to_spawn = place_to_spawn.loc
 	if(contents.len)
 		for(var/atom/movable/A in src)
-			A.forceMove(T)
+			A.forceMove(place_to_spawn)
 		visible_message("<span class='warning'>The items sloppily placed within fall out of \the [src]!</span>")
 	..()
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -636,9 +636,7 @@
 			qdel(src) //So long and thanks for all the fish
 			return 1
 		if(contents.len) //Food item is not sliceable but still has items hidden inside. Using a knife on it should be an easy way to get them out.
-			for(var/atom/movable/A in src)
-				A.forceMove(get_turf(src))
-			visible_message("<span class='warning'>The items sloppily placed within fall out of \the [src]!</span>")
+			dump_items_within()
 			return 1
 
 	if (istype(W, /obj/item/candle)) //candles added on afterattack
@@ -663,6 +661,16 @@
 		add_fingerprint(user)
 		contents += W
 		return 1 //No afterattack here
+
+/obj/item/weapon/reagent_containers/food/snacks/proc/dump_items_within()
+	for(var/atom/movable/A in src)
+		A.forceMove(get_turf(src))
+	visible_message("<span class='warning'>The items sloppily placed within fall out of \the [src]!</span>")
+
+/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom/dump_items_within() // to stop plate duplication memes
+	for(var/obj/item/weapon/reagent_containers/food/snacks/S in src)
+		if(S.contents.len)
+			S.dump_items_within()
 
 /obj/item/weapon/reagent_containers/food/snacks/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	..()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -591,54 +591,9 @@
 		if(!isturf(src.loc) || !(locate(/obj/structure/table) in src.loc) && !(locate(/obj/item/weapon/tray) in src.loc))
 			to_chat(user, "<span class='notice'>You cannot slice \the [src] here! You need a table or at least a tray.</span>")
 			return 1
-		if(slice_path && slices_num && slices_num > 0)
-			var/slices_lost = 0
-			if(W.is_sharp() >= 1.2)
-				user.visible_message("<span class='notice'>[user] slices \the [src].</span>", \
-				"<span class='notice'>You slice \the [src].</span>")
-			else
-				user.visible_message("<span class='notice'>[user] inaccurately slices \the [src] with \the [W]!</span>", \
-				"<span class='notice'>You inaccurately slice \the [src] with \the [W]!</span>")
-				slices_lost = rand(1, min(1, round(slices_num/2))) //Randomly lose a few slices along the way, but at least one and up to half
-			var/reagents_per_slice = reagents.total_volume/slices_num //Figure out how much reagents each slice inherits (losing slices loses reagents)
-			for(var/i = 1 to (slices_num - slices_lost)) //Transfer those reagents
-				var/obj/item/weapon/reagent_containers/food/snacks/slice = new slice_path(src.loc)
-				if(istype(src, /obj/item/weapon/reagent_containers/food/snacks/customizable)) //custom sliceable foods have overlays we need to apply
-					var/obj/item/weapon/reagent_containers/food/snacks/customizable/C = src
-					var/obj/item/weapon/reagent_containers/food/snacks/customizable/S = slice
-					S.name = "[C.name][S.name]"
-					S.filling.color = C.filling.color
-					S.extra_food_overlay.overlays += S.filling
-					S.overlays += S.filling
-				if(luckiness && isitem(slice))
-					var/obj/item/sliceItem = slice
-					sliceItem.luckiness += luckiness / slices_num
-				reagents.trans_to(slice, reagents_per_slice)
-				for (var/C in visible_condiments)
-					var/image/I = image('icons/obj/condiment_overlays.dmi',slice,C)
-					I.color = visible_condiments[C]
-					slice.extra_food_overlay.overlays += I
-					slice.overlays += I
-				if (candles.len > 0)
-					var/image/candle = pick(candles)
-					candles.Remove(candle)
-					candle.pixel_x = 0
-					candle.pixel_y = 0
-					slice.candles += candle
-					slice.candles_state = candles_state
-					if (slice.candles_state == CANDLES_LIT)
-						slice.set_light(CANDLE_LUM,0.5,LIGHT_COLOR_FIRE)
-				else if (always_candles)
-					slice.candles_state = candles_state
-					if (slice.candles_state == CANDLES_LIT)
-						slice.set_light(CANDLE_LUM,0.5,LIGHT_COLOR_FIRE)
-				slice.update_icon() //So hot slices start steaming right away
-			qdel(src) //So long and thanks for all the fish
+		if(slice_act(user,W.is_sharp()))
 			return 1
-		if(contents.len) //Food item is not sliceable but still has items hidden inside. Using a knife on it should be an easy way to get them out.
-			dump_items_within()
-			return 1
-
+		
 	if (istype(W, /obj/item/candle)) //candles added on afterattack
 		return 0
 
@@ -662,15 +617,60 @@
 		contents += W
 		return 1 //No afterattack here
 
-/obj/item/weapon/reagent_containers/food/snacks/proc/dump_items_within()
-	for(var/atom/movable/A in src)
-		A.forceMove(get_turf(src))
-	visible_message("<span class='warning'>The items sloppily placed within fall out of \the [src]!</span>")
+/obj/item/weapon/reagent_containers/food/snacks/proc/slice_act(mob/user,var/sharpness)
+	if(slice_path && slices_num && slices_num > 0)
+		var/slices_lost = 0
+		if(sharpness >= 1.2)
+			user.visible_message("<span class='notice'>[user] slices \the [src].</span>", \
+			"<span class='notice'>You slice \the [src].</span>")
+		else
+			user.visible_message("<span class='notice'>[user] inaccurately slices \the [src] with \the [W]!</span>", \
+			"<span class='notice'>You inaccurately slice \the [src] with \the [W]!</span>")
+			slices_lost = rand(1, min(1, round(slices_num/2))) //Randomly lose a few slices along the way, but at least one and up to half
+		var/reagents_per_slice = reagents.total_volume/slices_num //Figure out how much reagents each slice inherits (losing slices loses reagents)
+		for(var/i = 1 to (slices_num - slices_lost)) //Transfer those reagents
+			var/obj/item/weapon/reagent_containers/food/snacks/slice = new slice_path(src.loc)
+			if(istype(src, /obj/item/weapon/reagent_containers/food/snacks/customizable)) //custom sliceable foods have overlays we need to apply
+				var/obj/item/weapon/reagent_containers/food/snacks/customizable/C = src
+				var/obj/item/weapon/reagent_containers/food/snacks/customizable/S = slice
+				S.name = "[C.name][S.name]"
+				S.filling.color = C.filling.color
+				S.extra_food_overlay.overlays += S.filling
+				S.overlays += S.filling
+			if(luckiness && isitem(slice))
+				var/obj/item/sliceItem = slice
+				sliceItem.luckiness += luckiness / slices_num
+			reagents.trans_to(slice, reagents_per_slice)
+			for (var/C in visible_condiments)
+				var/image/I = image('icons/obj/condiment_overlays.dmi',slice,C)
+				I.color = visible_condiments[C]
+				slice.extra_food_overlay.overlays += I
+				slice.overlays += I
+			if (candles.len > 0)
+				var/image/candle = pick(candles)
+				candles.Remove(candle)
+				candle.pixel_x = 0
+				candle.pixel_y = 0
+				slice.candles += candle
+				slice.candles_state = candles_state
+				if (slice.candles_state == CANDLES_LIT)
+					slice.set_light(CANDLE_LUM,0.5,LIGHT_COLOR_FIRE)
+			else if (always_candles)
+				slice.candles_state = candles_state
+				if (slice.candles_state == CANDLES_LIT)
+					slice.set_light(CANDLE_LUM,0.5,LIGHT_COLOR_FIRE)
+			slice.update_icon() //So hot slices start steaming right away
+		qdel(src) //So long and thanks for all the fish
+		return 1
+	if(contents.len) //Food item is not sliceable but still has items hidden inside. Using a knife on it should be an easy way to get them out.
+		for(var/atom/movable/A in src)
+			A.forceMove(get_turf(src))
+		visible_message("<span class='warning'>The items sloppily placed within fall out of \the [src]!</span>")
+		return 1
 
-/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom/dump_items_within() // to stop plate duplication memes
+/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom/slice_act(mob/user) // to stop plate duplication memes
 	for(var/obj/item/weapon/reagent_containers/food/snacks/S in src)
-		if(S.contents.len)
-			S.dump_items_within()
+		. |= S.slice_act()
 
 /obj/item/weapon/reagent_containers/food/snacks/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	..()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -591,7 +591,7 @@
 		if(!isturf(src.loc) || !(locate(/obj/structure/table) in src.loc) && !(locate(/obj/item/weapon/tray) in src.loc))
 			to_chat(user, "<span class='notice'>You cannot slice \the [src] here! You need a table or at least a tray.</span>")
 			return 1
-		if(slice_act(user,W.is_sharp()))
+		if(slice_act(user,W))
 			return 1
 		
 	if (istype(W, /obj/item/candle)) //candles added on afterattack


### PR DESCRIPTION
[bugfix]

## What this does
Closes #35698.
Closes #35158.

## How it was tested
put sandwich slice on plate, cut with knife and then laser scalpel, doing the same with a turkey and a cake.

## Changelog
:cl:
 * bugfix: Putting non sliceable objects on a plate and cutting them no longer leaves behind a non-plated pseudo duplication of the food within, instead, any items placed inside the food on a plate is moved out.
 * bugfix: Sliceable objects can now be sliced when put on a plate, leaving the plate behind.