### PR TITLE
Fixes runechat scrambling non understood speech twice

### DIFF
--- a/code/datums/chat_message.dm
+++ b/code/datums/chat_message.dm
@@ -230,9 +230,6 @@ var/runechat_icon = null
 		if (5 to 16)
 			extra_classes += "very_small"
 
-	if (message_language && !say_understands(speaker, message_language))
-		raw_message = message_language.scramble(raw_message)
-
 	// Display visual above source
 	new /datum/chatmessage(raw_message, speaker, src, extra_classes)
 


### PR DESCRIPTION
[bugfix]

## What this does
Closes #34859.

## How it was tested
gonna find a way to then update this.

## Changelog
:cl:
 * bugfix: Runechat no longer rescrambles speech of non-understood languages.