### PR TITLE
Fixes butchering drops on various robot type simplemobs

### DIFF
--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -1063,6 +1063,7 @@
 	minbodytemp = 0
 
 	mob_property_flags = MOB_ROBOTIC
+	meat_type = null
 
 	environment_smash_flags = 0
 

--- a/maps/randomvaults/spessmart.dm
+++ b/maps/randomvaults/spessmart.dm
@@ -357,6 +357,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 	max_n2 = 0
 	minbodytemp = 0
 	mob_property_flags = MOB_ROBOTIC
+	meat_type = null
 
 /mob/living/simple_animal/robot/New()
 	..()
@@ -672,6 +673,7 @@ var/list/clothing_prices = list()	//gets filled on initialize()
 
 	faction = "spessmart"
 	mob_property_flags = MOB_ROBOTIC
+	meat_type = null
 
 	var/alert_on_movement = 1 //If moved, trigger an alert and become agressive
 


### PR DESCRIPTION
[bugfix][consistency]

## What this does
Closes #33413.

## How it was tested
gibbing them.

## Changelog
:cl:
 * bugfix: Fast food vault cookbots, spessmart bots and dusky no longer drop meat when gibbed.