### PR TITLE
Fixes snowball projectiles having been invisible for the past 9 years

### DIFF
--- a/code/game/gamemodes/endgame/xmas/snowman.dm
+++ b/code/game/gamemodes/endgame/xmas/snowman.dm
@@ -168,6 +168,7 @@
 	stun = 1
 	weaken = 1
 	stutter = 1
+	lock_angle = TRUE
 
 /obj/item/projectile/snowball/to_bump(atom/A as mob|obj|turf|area)
 	.=..()


### PR DESCRIPTION
Like, I made them in 2014, then reworked projectiles in 2015, so they worked as intended for less than a year! But snowmen were rare enough that this went unnoticed, until following Dilt's admin gun toys made people realize that snowball projectiles didn't show up properly.

:cl:
* bugfix: Snowballs thrown by snowmen are now properly visible as they travel, after 9 fucking years.