### PR TITLE
Fixes Odd Damage Behaviors

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -262,12 +262,23 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 
 		var/brute_was = picked.brute_dam
 		var/burn_was = picked.burn_dam
+		var/damage_cap = picked.max_damage - picked.get_health() //the limb cannot take more than this much damage
 		//Multiplied damage is already handled at the limb level
 		update |= picked.take_damage(brute,burn,sharp,edge,used_weapon, no_damage_modifier = no_damage_change, spread_damage = FALSE)
-		brute	-= (picked.brute_dam - brute_was)
+		if(!picked.is_existing())
+			//the organ got cut off or removed! the organ takes no damage in these cases for some reason...
+			//So we'll rule in favor of the damage taker and assume the organ took the most it can accept from both
+			brute	-= damage_cap
+			burn	-= damage_cap
+		else if(picked.max_damage - picked.get_health() > 0)
+			//since the damage cannot spread: if we did not max out the limb's damage, then we're done!
+			break
+		else
+			//The organ has taken the maximum damage it's allowed, we will have leftover damage
+			brute	-= (picked.brute_dam - brute_was)
+			burn	-= (picked.burn_dam - burn_was)
 		if(brute < 0)
 			brute = 0
-		burn	-= (picked.burn_dam - burn_was)
 		if(burn < 0)
 			burn = 0
 		parts -= picked


### PR DESCRIPTION
# Two More Mysteries of Xivvis
it's past my bedtime so here we go

## What this does
This PR fixes two issues with damage.
1) Resistance Cascades. If you took a low amount of a damage type you resisted via take_overall_damage() (called by such things as little roomba robots and VV damaging someone), the damage would cascade like the following image instead of doing less total damage.
>If you had 50% burn resist and took 10 damage, you'd expect to take 5 damage right? Nah, you took 10, just in 5, 2.5, 1.25, etc steps across your whole body.

![image](https://github.com/user-attachments/assets/ef1917ca-488d-4a36-a60f-5e00ef80716a)

2) Weakness Cascades. If you took a high amount of a damage type (from any source, not just take_overall_damage procs) you were weak against, you would take dramatically more damage.
>If you're a Diona and you were shot in the hand by a 40 damage laser, you would instantly die despite only expecting to take 100 damage at most, as you would take 40 to the hand, 100-40 = 60 to your arm, which increased to 150, so actually 75 taken by the arm, 75 cascading to the chest. Increased to 187.5, 150 taken by the chest, remaining 37.5 to the head, increased to 93.75. Total 358.75 damage from a 40 damage laser.

![image](https://github.com/user-attachments/assets/7974b694-dad5-4bd1-b323-c499d302605e)

3) Gibbed/Dropped Limbs Didn't Count As Damage. See issue 1 above, but if take_overall_damage gibbed/cut off a limb, it would treat it as 0 damage inflicted and keep attempting to inflict the damage to other limbs.

New behavior is as follows.

Resistances are factored in take_overall_health in the form of checking to see if the limb has taken the maximum damage it could from the damage. If it didn't, then there's going to be clearly no damage left at all. Additionally, gibbed/cut off limbs are factored in as having had the maximum damage the limb could have taken before continuing to spread the damage, favoring the target (it assumes that the remaining health could've been taken as both brute and burn at the same time).
> A plasmeme taking 10 fire damage from a take_overall_damage call, such as from biting a powered crepe, picking up a novaflower, etc, now only takes 5 damage, instead of 5 + 2.5 + 1.25 etc

Weaknesses are factored into limb damage spreading now - only the original damage amount is allowed to spread, not any bonus damage. 
> If you shoot a diona with a 30 damage laser on their 40 health hand, the hand will take (75, but capped to) 40 damage, and not deal any to the arm since all 30 original damage was applied.

> In another case, if you shoot the 30 damage laser on a hand that already had 20 burn damage, then after hitting the 40 damage cap on the hand, the 10 leftover damage would apply to the arm (and the diona weakness would apply here again, causing 25 damage to the arm).

## Why it's good
Fixes #25553. Fixes #36481.

## How it was tested
Plasma man vs Roomba
![image](https://github.com/user-attachments/assets/e40b0c33-b524-4a81-83a2-c9a43ccc2325)
![image](https://github.com/user-attachments/assets/b815442a-f7f2-4144-9fc1-891dbe8a4f93)

Diona vs Laser
![image](https://github.com/user-attachments/assets/d58244b9-b509-40c3-8e4c-b13f3c617588)
![image](https://github.com/user-attachments/assets/7f228ed2-6da2-428c-a1d7-ffdf6f970310)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed various damage cascades from occuring on human mobs
