### PR TITLE
Fixes area overlays being additive when using blueprints or admin buildmode

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -335,7 +335,7 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 
 	//Create a visual effect over the edited area
 	edited_overlay = image('icons/turf/areas.dmi', currently_edited, "yellow")
-	edited_overlay.blend_mode = BLEND_OVERLAY//area default blend mode is BLEND_ADD, so alert lights look better. Which means we gotta override it here.
+	edited_overlay.plane = ABOVE_LIGHTING_PLANE
 	editor.client.images.Add(edited_overlay)
 
 	to_chat(editor, "<span class='info'>In this mode, you can add or modify tiles to the [currently_edited] area. When you're done, bring up the blueprints or leave the area.</span>")

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -335,6 +335,7 @@ these cannot rename rooms that are in by default BUT can rename rooms that are c
 
 	//Create a visual effect over the edited area
 	edited_overlay = image('icons/turf/areas.dmi', currently_edited, "yellow")
+	edited_overlay.blend_mode = BLEND_OVERLAY//area default blend mode is BLEND_ADD, so alert lights look better. Which means we gotta override it here.
 	editor.client.images.Add(edited_overlay)
 
 	to_chat(editor, "<span class='info'>In this mode, you can add or modify tiles to the [currently_edited] area. When you're done, bring up the blueprints or leave the area.</span>")

--- a/code/modules/admin/buildmode.dm
+++ b/code/modules/admin/buildmode.dm
@@ -184,6 +184,7 @@ var/global/list/obj/effect/bmode/buildholder/buildmodeholders = list()
 /obj/effect/bmode/buildmode/New()
 	..()
 	area_overlay = image('icons/turf/areas.dmi', "yellow")
+	area_overlay.blend_mode = BLEND_OVERLAY//area default blend mode is BLEND_ADD, so alert lights look better. Which means we gotta override it here.
 
 /obj/effect/bmode/buildmode/Destroy()
 	copycat = null

--- a/code/modules/admin/buildmode.dm
+++ b/code/modules/admin/buildmode.dm
@@ -184,7 +184,7 @@ var/global/list/obj/effect/bmode/buildholder/buildmodeholders = list()
 /obj/effect/bmode/buildmode/New()
 	..()
 	area_overlay = image('icons/turf/areas.dmi', "yellow")
-	area_overlay.blend_mode = BLEND_OVERLAY//area default blend mode is BLEND_ADD, so alert lights look better. Which means we gotta override it here.
+	area_overlay.plane = ABOVE_LIGHTING_PLANE
 
 /obj/effect/bmode/buildmode/Destroy()
 	copycat = null


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/6e25134d-3c9f-4af0-a66b-d6c266a7beab)

:cl:
* bugfix: Fixed area overlays being additive when using blueprints or admin buildmode.