### PR TITLE
Fixes Plasmaman Suit Spam

### DIFF
--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -68,12 +68,11 @@
 			if(environment.total_moles && ((environment[GAS_OXYGEN] / environment.total_moles) >= OXYCONCEN_PLASMEN_IGNITION)) //How's the concentration doing?
 				if(!host.on_fire)
 					to_chat(host, "<span class='warning'>Your body reacts with the atmosphere and bursts into flame!</span>")
-				host.adjust_fire_stacks(0.5)
 				host.ignite()
 	else
 		var/obj/item/clothing/suit/PS=host.wear_suit
 		if(istype(PS))
-			if(host.fire_stacks > 0)
+			if(host.on_fire)
 				PS.Extinguish(host)
 			else
 				PS.regulate_temp_of_wearer(host)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b7ed1b75-c3bf-49bc-a6f0-84c99aa9cc49)

## What this does
Hotfixes plasmaman suits permanently spamming the chat with an extinguish message and additionally disabling the thermal regulation feature while doing so.

This occured because the suit checks for the depreciated ``fire_stacks`` variable, which was also set when a plasmaman catches on fire by taking off their suit. ``fire_stacks`` is not removed by anything other than stop+drop+roll and admin rejuv, so even though the suit would properly extinguish the fire, it would not clear this variable out, leading to an infinte loop of trying to put out a fire that isn't there. After conferring with @west3436, I've removed the use of the variable in favor of the now standard ``on_fire`` and simple ``ignite()`` variable and proc.

## Why it's good
Fixes #37120. 

## How it was tested
Plasmaman. Took off suit. Caught fire. Put suit back on. Extinguished. Repeated several times.
![image](https://github.com/user-attachments/assets/760308be-2e10-4299-ae44-01a0fe8db0bd)
(plasmaman breathing out a ~~gasp of agony~~sigh of relief as this bug is fixed.)
![image](https://github.com/user-attachments/assets/07c20acb-e5ab-42f4-bce1-782d992499bc)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Plasmaman Suits no longer get stuck in an infinite cycle of attempting to put out a non-existing fire.
