### PR TITLE
Adds extra conduction plate circuit board to exotic fish supply crate

### DIFF
--- a/code/datums/supply_packs/hydroponics.dm
+++ b/code/datums/supply_packs/hydroponics.dm
@@ -128,6 +128,7 @@
 					/obj/item/fish_eggs/glofish,
 					/obj/item/weapon/circuitboard/fishwall,
 					/obj/item/weapon/circuitboard/fishwall,
+					/obj/item/weapon/circuitboard/conduction_plate,
 					/obj/item/weapon/circuitboard/conduction_plate
 					)
 	cost = 40


### PR DESCRIPTION

## What this does
Closes #36384.

## Why it's good
for the extra walltank

## Changelog
:cl:
 * tweak: An extra conduction plate circuitboard has been added to the exotic fish crate, to match the number of walltank circuitboards