### PR TITLE
Re-enables cameras on nukeops helmet and their borgs

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -335,5 +335,7 @@ var/list/obj/machinery/camera/cyborg_cams = list(
 
 	light_color = LIGHT_COLOR_YELLOW
 
+/obj/machinery/computer/security/nukies
+	network = list(CAMERANET_SS13,CAMERANET_NUKE)
 
 #undef DEFAULT_MAP_SIZE

--- a/maps/tgstation-snow.dmm
+++ b/maps/tgstation-snow.dmm
@@ -53244,7 +53244,7 @@
 	},
 /area/shuttle/nuclearops)
 "dwT" = (
-/obj/machinery/computer/security,
+/obj/machinery/computer/security/nukies,
 /turf/unsimulated/floor{
 	icon_state = "floor4"
 	},


### PR DESCRIPTION
[bugfix][content]

## What this does
Closes #1996.
left the issue open the longest and for almost 10 years award.

## Why it's good
ship and cameras bundle nukies can now check on their crew better

## How it was tested
putting a syndicate rigsuit on, turning the camera on with its action button, and checking the nuke op shuttle camera console.

## Changelog
:cl:
 * rscadd: Nukeop camera consoles now finally track their crew's rigsuits and uplink spawned borgs as they're meant to.