### PR TITLE
Adds More Ways to Stop No Shoe Slowdown

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -941,18 +941,16 @@ a {
 			if(ishuman(AM))
 				var/mob/living/carbon/human/H = AM
 				var/danger = FALSE
+				var/datum/organ/external/foot = H.has_vulnerable_foot()
+				if(foot)
+					danger = TRUE
 
-				var/datum/organ/external/foot = H.pick_usable_organ(LIMB_LEFT_FOOT, LIMB_RIGHT_FOOT)
-				if(foot && !H.organ_has_mutation(foot, M_STONE_SKIN) && !H.check_body_part_coverage(FEET))
-					if(foot.is_organic())
-						danger = TRUE
-
-						if(!H.lying && H.feels_pain())
-							H.Knockdown(knockdown)
-							H.Stun(knockdown)
-						if(foot.take_damage(damage, 0))
-							H.UpdateDamageIcon()
-						H.updatehealth()
+					if(!H.lying && H.feels_pain())
+						H.Knockdown(knockdown)
+						H.Stun(knockdown)
+					if(foot.take_damage(damage, 0))
+						H.UpdateDamageIcon()
+					H.updatehealth()
 
 				to_chat(AM, "<span class='[danger ? "danger" : "notice"]'>You step in \the [src]!</span>")
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -379,6 +379,20 @@ emp_act
 	apply_damage(damage, BRUTE, ourfoot)
 	return TRUE
 
+/**
+ * Returns a random valid foot if the mob has a foot unprotected by clothing, robolimb metal, or stone skin mutation.
+ * Otherwise, returns FALSE
+ */
+/mob/living/carbon/human/proc/has_vulnerable_foot()
+	if(check_body_part_coverage(FEET))
+		return FALSE
+	var/list/limbs_to_check = shuffle(list(LIMB_LEFT_FOOT,LIMB_RIGHT_FOOT)) //pick randomly
+	for(var/has_organ in limbs_to_check)
+		var/datum/organ/external/foot = pick_usable_organ(has_organ)
+		if(foot && foot.is_organic() && !organ_has_mutation(foot, M_STONE_SKIN))
+			return foot
+	return FALSE
+
 /mob/living/carbon/human/proc/bloody_hands(var/mob/living/source, var/amount = 3)
 	if (ishuman(source))
 		var/mob/living/carbon/human/H = source

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -64,7 +64,7 @@
 /mob/living/carbon/human/movement_tally_multiplier()
 	. = ..()
 	if(!reagents.has_any_reagents(HYPERZINES))
-		if(!shoes)
+		if(!shoes && has_vulnerable_foot())
 			. *= NO_SHOES_SLOWDOWN
 	if(M_FAT in mutations) // hyperzine can't save you, fatty!
 		. *= 1.5


### PR DESCRIPTION
# What do you mean rigsuits have boots

## What this does
This removes the shoe slowdown caused by not wearing shoes if you are: wearing something that has shoes built in, if you are in possession of non-fleshy feet which are solid metal/wood, or if your feet have the STONE SKIN mutation.

## Why it's good
Consistency?

## How it was tested
Took off shoes and tested several conditions including throwing on rigsuits and robotizing feet into robolimbs.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Certain outfits and robotic parts prevent no-shoe slowdown.
