### PR TITLE
Adds ways to check for arcane tampering and confirm removal of it

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -899,6 +899,7 @@ its easier to just keep the beam vertical.
 			var/mob/M = arcanetampered
 			M.arcane_tampered_atoms.Remove(src)
 		arcanetampered = FALSE
+		visible_message("<span class='sinister'>The arcane properties of \the [src] vanish!</span>")
 		for(var/atom/A in contents)
 			A.bless()
 	blessed = 1

--- a/code/game/objects/items/weapons/null_rod.dm
+++ b/code/game/objects/items/weapons/null_rod.dm
@@ -81,6 +81,22 @@
 			to_chat(user, "<span class='warning'>A structure suddenly emerges from the ground!</span>")
 		call(/obj/effect/rune_legacy/proc/revealrunes)(src)//revealing legacy runes as well because why not
 
+/obj/item/weapon/nullrod/preattack(atom/target, mob/user, proximity_flag, click_parameters)
+	target.arcane_message(user)
+	return ..()
+
+/atom/proc/arcane_message(mob/user)
+	if(arcanetampered)
+		to_chat(user, "<span class='sinister'>\The [src] has arcane aura to it!</span>")
+		. = 1
+		if(contents.len)
+			to_chat(user, "<span class='sinister'>And inside \the [src]...</span>")
+			for(var/atom/A in src)
+				. |= A.arcane_message(user)
+			if(!.)
+				to_chat(user, "<span class='notice'>Nothing of note.</span>")
+
+
 /obj/item/weapon/nullrod/pickup(mob/living/user as mob)
 	if(user.mind)
 		if(isReligiousLeader(user))

--- a/code/game/objects/items/weapons/null_rod.dm
+++ b/code/game/objects/items/weapons/null_rod.dm
@@ -88,13 +88,13 @@
 /atom/proc/arcane_message(mob/user)
 	if(arcanetampered)
 		to_chat(user, "<span class='sinister'>\The [src] has an arcane aura to it!</span>")
-		. = 1
 		if(contents.len)
 			to_chat(user, "<span class='sinister'>And inside \the [src]...</span>")
 			for(var/atom/A in src)
 				. |= A.arcane_message(user)
 			if(!.)
 				to_chat(user, "<span class='notice'>Nothing of note.</span>")
+		. = 1
 
 
 /obj/item/weapon/nullrod/pickup(mob/living/user as mob)

--- a/code/game/objects/items/weapons/null_rod.dm
+++ b/code/game/objects/items/weapons/null_rod.dm
@@ -87,7 +87,7 @@
 
 /atom/proc/arcane_message(mob/user)
 	if(arcanetampered)
-		to_chat(user, "<span class='sinister'>\The [src] has arcane aura to it!</span>")
+		to_chat(user, "<span class='sinister'>\The [src] has an arcane aura to it!</span>")
 		. = 1
 		if(contents.len)
 			to_chat(user, "<span class='sinister'>And inside \the [src]...</span>")


### PR DESCRIPTION
[qol]

## What this does
lets using null rods on item show if something is arcane tampered, along with anything in its contents that is
shows a message confirming the property removal on blessing

## Why it's good
clarity for finding these items and removal of their properties

## How it was tested
hitting things with null rods, splashing with holy water

## Changelog
:cl:
 * rscadd: Null rods can now show if something is arcane tampered by hitting it with them.
 * rscadd: Blessing an arcane tampered item now shows a message confirming the removal of this property to nearby people.