### PR TITLE
Minor Space Pod Fixes

### DIFF
--- a/code/modules/spacepods/construction.dm
+++ b/code/modules/spacepods/construction.dm
@@ -40,11 +40,12 @@
 	QDEL_NULL(construct)
 
 /obj/structure/spacepod_frame/unarmored/attackby(obj/item/W, mob/user)
-	if(!construct || !construct.action(W, user))
+	if(!construct)
 		if(istype(W,/obj/item/pod_parts/armor/civ))
 			construct = new /datum/construction/reversible/pod/unarmored/civ(src)
 		else if(istype(W, /obj/item/pod_parts/armor/taxi))
 			construct = new /datum/construction/reversible/pod/unarmored/taxi(src)
+	..()
 
 /////////////////////////////////
 // CONSTRUCTION STEPS


### PR DESCRIPTION
# Small, but powerful

## What this does
Fixes an unreported issue where you could make an invincible wall by half-building a space pod.

Additionally, this fixes another unreported issue where you had to click twice to add armor to your space pod.

~~Finally, this moves the up facing sprite of one of the mid-construction steps over by one pixel so that it matches the other steps.~~ Fixed by #37179!

## Why it's good
uhhhhhhhhhhh

## How it was tested
i built a space pod and it worked with one click on the armor step, and the sprite looked normal.
