### PR TITLE
Clumsy Peg Limb Gun Fixes

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -200,13 +200,17 @@
 		var/datum/organ/external/a_hand = H.get_active_hand_organ()
 		if(!a_hand.can_use_advanced_tools())
 			if(display_message)
-				to_chat(user, "<span class='warning'>Your [a_hand] doesn't have the dexterity to do this!</span>")
+				to_chat(user, "<span class='warning'>Your [a_hand.display_name] doesn't have the dexterity to do this!</span>")
 			return 0
 	return 1
 
 /obj/item/weapon/gun/proc/Fire(atom/target, mob/living/user, params, reflex = 0, struggle = 0, var/use_shooter_turf = FALSE)
 	//Exclude lasertag guns from the M_CLUMSY check.
 	. = reset_point_blank_shot()
+
+	if(!can_Fire(user, 1))
+		return
+
 	var/explode = FALSE
 	var/dehand = FALSE
 	if(istype(user, /mob/living))
@@ -232,9 +236,6 @@
 			M.drop_item(src, force_drop = 1)
 			qdel(src)
 			return
-
-	if(!can_Fire(user, 1))
-		return
 
 	add_fingerprint(user)
 	var/atom/originaltarget = target


### PR DESCRIPTION
# Honk

## What this does
This fixes an issue where a gun could explode even if you aren't capable of using it, and additionally fixes an issue where using an artifical hand with a gun gave a bugged message. This happens most commonly when using a peg hand on a clumsy clown, resulting in a spam of broken messages before the gun manages to explode despite being unable to use it. 

## Why it's good
Fixes #34777. Also, it's not, because things that can't use guns can't have it explode in their hands anymore. Funny removal.

## How it was tested
![image](https://github.com/user-attachments/assets/98c8143d-ca89-4012-8bae-a2d83d23f1fb)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed guns exploding when you couldn't even fire them in the first place.
