### PR TITLE
Fixes Most Screwdriver/Wrench/Wirecutter Special Tool Interactions

### DIFF
--- a/code/datums/helper_datums/construction_datum.dm
+++ b/code/datums/helper_datums/construction_datum.dm
@@ -100,7 +100,7 @@
 		text = replacetext(text, "{es}", "es")
 		text = replacetext(text, "{ies}", "ies")
 		text = replacetext(text,"{USER}","[user]")
-	text = replacetext(text,"{HOLDER}","[holder]")
+	text = replacetext(text,"{HOLDER}","\the [holder.name]")
 	return text
 
 /datum/construction/proc/construct_message(step, mob/user, atom/movable/used_atom)

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -150,7 +150,7 @@ var/global/mulebot_count = 0
 		if(user.drop_item(C, src))
 			cell = C
 			updateDialog()
-	else if((istype(I,/obj/item/tool/wirecutters)||istype(I,/obj/item/device/multitool)) && user.a_intent != I_HURT)
+	else if((I.is_wirecutter(user) || I.is_multitool(user)) && user.a_intent != I_HURT)
 		attack_hand(user)
 	else if(I.is_screwdriver(user) && user.a_intent != I_HURT)
 		if(locked)

--- a/code/game/machinery/vending_packs.dm
+++ b/code/game/machinery/vending_packs.dm
@@ -257,7 +257,7 @@
 	return
 
 /obj/structure/stackopacks/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(istype(W,/obj/item/tool/wirecutters) || istype(W,/obj/item/weapon/shard) || istype(W,/obj/item/weapon/kitchen/utensil/knife/large) || istype(W,/obj/item/tool/circular_saw) || istype(W, /obj/item/weapon/hatchet) || istype(W, /obj/item/weapon/kitchen/utensil/knife))
+	if(W.is_wirecutter(user) || istype(W,/obj/item/weapon/shard) || istype(W,/obj/item/weapon/kitchen/utensil/knife/large) || istype(W,/obj/item/tool/circular_saw) || istype(W, /obj/item/weapon/hatchet) || istype(W, /obj/item/weapon/kitchen/utensil/knife))
 		var/turf/T = get_turf(src)
 		for(var/obj/O in contents)
 			O.forceMove(T)

--- a/code/game/objects/items/devices/deskbell.dm
+++ b/code/game/objects/items/devices/deskbell.dm
@@ -269,7 +269,7 @@
 					to_chat(user, "<span class='warning'>You must add wires first.</span>")
 					return
 			if(1)
-				if(istype(W,/obj/item/tool/wirecutters))
+				if(W.is_wirecutter(user))
 					if(has_signaler)
 						to_chat(user, "<span class='warning'>You must remove the signaler first.</span>")
 						return

--- a/code/game/objects/items/devices/rigbuilding.dm
+++ b/code/game/objects/items/devices/rigbuilding.dm
@@ -53,7 +53,7 @@
 			to_chat(user, "You don't have enough cable to wire \the [src].")
 			return
 
-	else if(istype(W, /obj/item/tool/wirecutters))
+	else if(W.is_wirecutter(user))
 		if(buildstate == RIG_WIRED)
 			to_chat(user, "You secure the wiring in \the [src].")
 			W.playtoolsound(src, 50)

--- a/code/game/objects/items/gum.dm
+++ b/code/game/objects/items/gum.dm
@@ -113,7 +113,7 @@
 /obj/item/gum/attackby(var/obj/item/W, var/mob/user)
 	if(locked_to)
 		var/datum/locking_category/category = locked_to.get_lock_cat_for(src)
-		if(istype(category, /datum/locking_category/gum_stuck) && is_type_in_list(W, list(/obj/item/weapon/chisel, /obj/item/tool/screwdriver)))
+		if(istype(category, /datum/locking_category/gum_stuck) && is_type_in_list(W, list(/obj/item/weapon/chisel, /obj/item/tool/screwdriver, /obj/item/tool/solder/screw)))
 			playsound(src, "sound/items/screwdriver.ogg", 10, 1, -1)
 			if(do_after(user, src, 5 SECONDS) && locked_to)
 				to_chat(user, "You pry \the [src] loose from \the [locked_to].")

--- a/code/game/objects/items/stacks/sheets/light.dm
+++ b/code/game/objects/items/stacks/sheets/light.dm
@@ -15,7 +15,7 @@
 	max_amount = 60
 
 /obj/item/stack/light_w/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if(istype(O,/obj/item/tool/wirecutters))
+	if(O.is_wirecutter(user))
 		var/obj/item/stack/cable_coil/CC = new/obj/item/stack/cable_coil(user.loc)
 		CC.amount = 2
 		amount--

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -267,7 +267,7 @@
 		to_chat(user, "<span class='notice'>You wrap the exposed wires around the cell.</span>")
 		src.update_icon()
 
-	if (istype(I, /obj/item/tool/screwdriver))
+	if (I.is_screwdriver())
 		if (!power_supply)
 			return
 

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -267,7 +267,7 @@
 		to_chat(user, "<span class='notice'>You wrap the exposed wires around the cell.</span>")
 		src.update_icon()
 
-	if (I.is_screwdriver())
+	if (I.is_screwdriver(user))
 		if (!power_supply)
 			return
 

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -31,7 +31,7 @@
 											"/obj/item/weapon/chisel:chisel" = null,
 											"/obj/item/device/multitool:multitool" = null)
 	var/obj/item/deployed //what's currently in use
-	var/removing_item = /obj/item/tool/screwdriver //the type of item that lets you take tools out
+	var/can_remove_items = TRUE //if you can remove items with a screwdriver
 
 /obj/item/weapon/switchtool/preattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(istype(target, /obj/item/weapon/storage) && !istype(target, /obj/item/weapon/storage/pill_bottle)) //we place automatically, but want pill bottles to be meltable
@@ -91,7 +91,7 @@
 		choose_deploy(user)
 
 /obj/item/weapon/switchtool/attackby(var/obj/item/used_item, mob/user)
-	if(istype(used_item, removing_item)) //if it's the thing that lets us remove tools and we have something to remove
+	if(can_remove_items && used_item.is_screwdriver()) //if it's the thing that lets us remove tools and we have something to remove
 		var/no_modules = TRUE
 		for(var/module in stored_modules)
 			if(stored_modules[module])
@@ -429,7 +429,7 @@
 	undeploy_sound = "sound/weapons/switchsound.ogg"
 	light_color =  LIGHT_COLOR_CYAN
 	mech_flags = MECH_SCAN_ILLEGAL
-	removing_item = null
+	can_remove_items = FALSE
 	var/has_tech = 0
 	var/hcolor = "CYAN"
 	starting_materials = null

--- a/code/game/objects/items/weapons/switchtool.dm
+++ b/code/game/objects/items/weapons/switchtool.dm
@@ -91,7 +91,7 @@
 		choose_deploy(user)
 
 /obj/item/weapon/switchtool/attackby(var/obj/item/used_item, mob/user)
-	if(can_remove_items && used_item.is_screwdriver()) //if it's the thing that lets us remove tools and we have something to remove
+	if(can_remove_items && used_item.is_screwdriver(user)) //if it's the thing that lets us remove tools and we have something to remove
 		var/no_modules = TRUE
 		for(var/module in stored_modules)
 			if(stored_modules[module])

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -307,7 +307,7 @@
 /obj/item/tool/weldingtool/attackby(obj/item/W as obj, mob/user as mob)
 	if(user.is_in_modules(src))
 		return
-	if(istype(W,/obj/item/tool/screwdriver))
+	if(W.is_screwdriver())
 		if(welding)
 			to_chat(user, "<span class='warning'>Stop welding first!</span>")
 			return

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -307,7 +307,7 @@
 /obj/item/tool/weldingtool/attackby(obj/item/W as obj, mob/user as mob)
 	if(user.is_in_modules(src))
 		return
-	if(W.is_screwdriver())
+	if(W.is_screwdriver(user))
 		if(welding)
 			to_chat(user, "<span class='warning'>Stop welding first!</span>")
 			return

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -567,6 +567,7 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 			to_chat(user, "<span class='warning'>You must remove the plating first.</span>")
 		return
 	else if(istype(C, /obj/item/stack/tile))
+		var/obj/item/offhand = user.get_inactive_hand()
 		if(istype(C, /obj/item/stack/tile/metal/plasteel))
 			to_chat(user, "<span class='warning'>This floor needs something to anchor this kind of tile to, add some rods first.</span>")
 		else if(is_plating())
@@ -576,7 +577,7 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 					make_tiled_floor(T)
 			else
 				to_chat(user, "<span class='warning'>This section is too damaged to support a tile. Use a welder to fix the damage.</span>")
-		else if(iscrowbar(user.get_inactive_hand()))
+		else if(iscrowbar(offhand))
 			var/obj/item/stack/tile/T = C
 			if(istype(T))
 				if(T.type == floor_tile.type)
@@ -592,7 +593,7 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 						make_tiled_floor(T)
 						return
 			return
-		else if(istype(user.get_inactive_hand(), /obj/item) && user.get_inactive_hand().is_screwdriver())
+		else if(istype(offhand, /obj/item) && offhand.is_screwdriver(user))
 			if(is_wood_floor())
 				var/obj/item/stack/tile/T = C
 				if(istype(T))

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -592,7 +592,7 @@ var/global/list/turf/simulated/floor/phazontiles = list()
 						make_tiled_floor(T)
 						return
 			return
-		else if(istype(user.get_inactive_hand(), /obj/item/tool/screwdriver))
+		else if(istype(user.get_inactive_hand(), /obj/item) && user.get_inactive_hand().is_screwdriver())
 			if(is_wood_floor())
 				var/obj/item/stack/tile/T = C
 				if(istype(T))

--- a/code/modules/clothing/accessories/holster.dm
+++ b/code/modules/clothing/accessories/holster.dm
@@ -193,6 +193,7 @@
 	return is_type_in_list(W, list(\
 		/obj/item/weapon/kitchen/utensil, \
 		/obj/item/tool/screwdriver, \
+		/obj/item/tool/solder, \
 		/obj/item/tool/wirecutters, \
 		/obj/item/weapon/pen, \
 		/obj/item/tool/scalpel, \

--- a/code/modules/fish/fish_items.dm
+++ b/code/modules/fish/fish_items.dm
@@ -113,7 +113,7 @@
 	force = 3
 
 /obj/item/weapon/fish/shark/attackby(var/obj/item/O, var/mob/user)
-	if(istype(O, /obj/item/tool/wirecutters))
+	if(O.is_wirecutter(user))
 		to_chat(user, "You rip out the teeth of \the [src]!")
 		new /obj/item/weapon/fish/toothless_shark(get_turf(src))
 		new /obj/item/stack/teeth/shark(get_turf(src), 10)
@@ -242,7 +242,7 @@
 	icon_state = "lobster_steamed_simple"
 
 /obj/item/weapon/steamed_lobster_simple_uncracked/attackby(var/obj/item/O, var/mob/user) // cracking the shell of a steamed lobstroso, simple version
-	if(istype(O, /obj/item/tool/wirecutters))
+	if(O.is_wirecutter(user))
 		to_chat(user, "<span class='notice'>You crack open the shell of \the [src]!")
 		new /obj/item/weapon/reagent_containers/food/snacks/steamed_lobster_simple(get_turf(src))
 		qdel(src)
@@ -256,7 +256,7 @@
 	icon_state = "lobster_steamed_deluxe"
 
 /obj/item/weapon/steamed_lobster_deluxe_uncracked/attackby(var/obj/item/O, var/mob/user) // cracking the shell of a steamed lobstroso
-	if(istype(O, /obj/item/tool/wirecutters))
+	if(O.is_wirecutter(user))
 		to_chat(user, "<span class='notice'>You crack open the shell of \the [src]!")
 		new /obj/item/weapon/reagent_containers/food/snacks/steamed_lobster_deluxe(get_turf(src))
 		qdel(src)

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -388,7 +388,7 @@ var/list/hydro_trays = list()
 			C.being_potted = FALSE
 		return
 
-	else if(is_type_in_list(O, list(/obj/item/tool/wirecutters, /obj/item/tool/scalpel)))
+	else if(istype(O,/obj/item/tool/scalpel) || O.is_wirecutter(user))
 		if(!seed)
 			to_chat(user, "There is nothing to take a sample from in \the [src].")
 			return

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -533,7 +533,7 @@
 		string_attached = 1
 		to_chat(user, "<span class='notice'>You attach a string to \the [name].</span>")
 		CC.use(1)
-	else if(istype(W,/obj/item/tool/wirecutters) )
+	else if(W.is_wirecutter(user))
 		if(!string_attached)
 			..()
 			return

--- a/code/modules/projectiles/guns/projectile/constructable/siegecannon.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/siegecannon.dm
@@ -33,7 +33,7 @@
 	if(istype(W, /obj/item/weapon/reagent_containers))
 		fillCannon(W, user)
 		return 1
-	if(W.is_wrench())
+	if(W.is_wrench(user))
 		wrenchAnchor(user, W, 5)	//Half a second to wrench. Being able to turn it via verb while anchored is intentional.
 	else if((istype(W, /obj/item/weapon/stamp/clown) || istype(W, /obj/item/toy/crayon/rainbow)) && !beenClowned)
 		becomeClownnon(W, user)

--- a/code/modules/spacepods/construction.dm
+++ b/code/modules/spacepods/construction.dm
@@ -1,4 +1,5 @@
 /obj/structure/spacepod_frame
+	name = "spacepod frame"
 	density = 1
 	opacity = 0
 
@@ -57,7 +58,7 @@
 				list(
 					Co_DESC = "A space pod with unwelded bulkhead panelling exposed.",
 					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/tool/wrench,
+						Co_KEY      = "is_wrench",
 						Co_VIS_MSG  = "{USER} unbolt{s} {HOLDER}'s bulkhead panelling.",
 					),
 					Co_NEXTSTEP = list(
@@ -74,7 +75,7 @@
 						Co_VIS_MSG  = "{USER} pop{s} {HOLDER}'s bulkhead panelling loose.",
 					),
 					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/tool/wrench,
+						Co_KEY      = "is_wrench",
 						Co_VIS_MSG  = "{USER} secure{s} {HOLDER}'s bulkhead panelling."
 					)
 				),
@@ -82,7 +83,7 @@
 				list(
 					Co_DESC = "A naked space pod with an exposed core. How lewd.",
 					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/tool/wrench,
+						Co_KEY      = "is_wrench",
 						Co_VIS_MSG  = "{USER} unsecure{s} {HOLDER}'s core."
 					),
 					Co_NEXTSTEP = list(
@@ -99,7 +100,7 @@
 						Co_VIS_MSG  = "{USER} delicately remove{s} the core from {HOLDER} with a crowbar."
 					),
 					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/tool/wrench,
+						Co_KEY      = "is_wrench",
 						Co_VIS_MSG  = "{USER} secure{s} the core's bolts."
 					)
 				),
@@ -107,7 +108,7 @@
 				list(
 					Co_DESC = "A wired pod frame with a secured mainboard.",
 					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/tool/screwdriver,
+						Co_KEY      = "is_screwdriver",
 						Co_VIS_MSG  = "{USER} unsecure{s} the mainboard."
 					),
 					Co_NEXTSTEP = list(
@@ -125,7 +126,7 @@
 						Co_VIS_MSG  = "{USER} prie{s} out the mainboard."
 					),
 					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/tool/screwdriver,
+						Co_KEY      = "is_screwdriver",
 						Co_VIS_MSG  = "{USER} secure{s} the mainboard."
 					)
 				),
@@ -133,7 +134,7 @@
 				list(
 					Co_DESC = "A wired pod frame.",
 					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/tool/screwdriver,
+						Co_KEY      = "is_screwdriver",
 						Co_VIS_MSG  = "{USER} unclip{s} {HOLDER}'s wiring harnesses."
 					),
 					Co_NEXTSTEP = list(
@@ -147,11 +148,11 @@
 				list(
 					Co_DESC = "A crudely-wired pod frame.",
 					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/tool/wirecutters,
+						Co_KEY      = "is_wirecutter",
 						Co_VIS_MSG  = "{USER} cut{s} out {HOLDER}'s wiring."
 					),
 					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/tool/screwdriver,
+						Co_KEY      = "is_screwdriver",
 						Co_VIS_MSG  = "{USER} adjust{s} the wiring."
 					)
 				),
@@ -201,7 +202,7 @@
 				list(
 					Co_DESC = "A space pod with unsecured armor.",
 					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/tool/wrench,
+						Co_KEY      = "is_wrench",
 						Co_VIS_MSG  = "{USER} unsecure{s} {HOLDER}'s armor."
 					),
 					Co_NEXTSTEP = list(
@@ -218,7 +219,7 @@
 						Co_VIS_MSG  = "{USER} remove{s} {HOLDER}'s armor."
 					),
 					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/tool/wrench,
+						Co_KEY      = "is_wrench",
 						Co_VIS_MSG  = "{USER} bolt{s} down {HOLDER}'s armor."
 					)
 				),
@@ -247,7 +248,7 @@
 				list(
 					Co_DESC = "A space pod with unsecured armor.",
 					Co_BACKSTEP = list(
-						Co_KEY      = /obj/item/tool/wrench,
+						Co_KEY      = "is_wrench",
 						Co_VIS_MSG  = "{USER} unsecure{s} {HOLDER}'s armor."
 					),
 					Co_NEXTSTEP = list(
@@ -264,7 +265,7 @@
 						Co_VIS_MSG  = "{USER} remove{s} {HOLDER}'s armor."
 					),
 					Co_NEXTSTEP = list(
-						Co_KEY      = /obj/item/tool/wrench,
+						Co_KEY      = "is_wrench",
 						Co_VIS_MSG  = "{USER} bolt{s} down {HOLDER}'s armor."
 					)
 				),

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -8,7 +8,7 @@
 /datum/surgery_step/glue_bone
 	allowed_tools = list(
 		/obj/item/tool/bonegel = 100,
-		/obj/item/tool/screwdriver = 75,
+		"screwdriver" = 75,
 		)
 	can_infect = 1
 	blood_level = 1
@@ -46,7 +46,7 @@
 /datum/surgery_step/set_bone
 	allowed_tools = list(
 		/obj/item/tool/bonesetter = 100,
-		/obj/item/tool/wrench = 75,
+		"wrench" = 75,
 		)
 
 	duration = 6 SECONDS
@@ -85,7 +85,7 @@
 /datum/surgery_step/mend_skull
 	allowed_tools = list(
 		/obj/item/tool/bonesetter = 100,
-		/obj/item/tool/wrench = 75,
+		"wrench"= 75,
 		)
 
 	duration = 6 SECONDS
@@ -119,7 +119,7 @@
 /datum/surgery_step/finish_bone
 	allowed_tools = list(
 		/obj/item/tool/bonegel = 100,
-		/obj/item/tool/screwdriver = 75,
+		"screwdriver" = 75,
 		)
 
 	can_infect = 1

--- a/code/modules/surgery/brainrepair.dm
+++ b/code/modules/surgery/brainrepair.dm
@@ -7,7 +7,7 @@
 /datum/surgery_step/brain/bone_chips
 	allowed_tools = list(
 		/obj/item/tool/hemostat = 100,
-		/obj/item/tool/wirecutters = 75,
+		"wirecutter" = 75,
 		/obj/item/weapon/kitchen/utensil/fork = 20,
 		)
 

--- a/code/modules/surgery/butt.dm
+++ b/code/modules/surgery/butt.dm
@@ -209,7 +209,7 @@
 	allowed_tools = list(
 		/obj/item/tool/bonegel = 100,
 		/obj/item/tool/bonesetter/bone_mender = 100,
-		/obj/item/tool/screwdriver = 75,
+		"screwdriver" = 75,
 		)
 
 	duration = 5 SECONDS

--- a/code/modules/surgery/butt.dm
+++ b/code/modules/surgery/butt.dm
@@ -49,7 +49,7 @@
 
 
 ///////sepARATE ANUS///////
-/datum/surgery_step/butt/seperate_anus/tool_quality(obj/item/tool)
+/datum/surgery_step/butt/seperate_anus/tool_quality(obj/item/tool, mob/living/user)
 	. = ..()
 	if(!tool.is_sharp())
 		return 0
@@ -122,12 +122,11 @@
 
 
 ///////CAUTERIZE BUTT/////////
-/datum/surgery_step/butt/cauterize_butt/tool_quality(obj/item/tool)
-	if(tool.is_hot())
-		for (var/T in allowed_tools)
-			if (istype(tool,T))
-				return allowed_tools[T]
-	return 0
+/datum/surgery_step/butt/cauterize_butt/tool_quality(obj/item/tool, mob/living/user)
+	. = ..()
+	if(!tool.is_hot())
+		return 0
+
 /datum/surgery_step/butt/cauterize_butt
 	allowed_tools = list(
 		/obj/item/tool/cautery = 100,
@@ -303,12 +302,11 @@
 
 
 ///////CAUTERIZE NEW BUTT/////////
-/datum/surgery_step/butt_replace/cauterize/tool_quality(obj/item/tool)
-	if(tool.is_hot())
-		for (var/T in allowed_tools)
-			if (istype(tool,T))
-				return allowed_tools[T]
-	return 0
+/datum/surgery_step/butt_replace/cauterize/tool_quality(obj/item/tool, mob/living/user)
+	. = ..()
+	if(!tool.is_hot())
+		return 0
+
 /datum/surgery_step/butt_replace/cauterize
 	allowed_tools = list(
 		/obj/item/tool/cautery = 100,

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -195,7 +195,7 @@
 	allowed_tools = list(
 		/obj/item/tool/bonegel = 100,
 		/obj/item/tool/bonesetter/bone_mender = 100,
-		/obj/item/tool/screwdriver = 75,
+		"screwdriver" = 75,
 		)
 
 	duration = 2 SECONDS

--- a/code/modules/surgery/eye.dm
+++ b/code/modules/surgery/eye.dm
@@ -19,7 +19,7 @@
 
 
 //////CUT OPEN///////
-/datum/surgery_step/eye/cut_open/tool_quality(obj/item/tool)
+/datum/surgery_step/eye/cut_open/tool_quality(obj/item/tool, mob/living/user)
 	. = ..()
 	if(!tool.is_sharp())
 		return 0
@@ -126,12 +126,11 @@
 	eyes.take_damage(5, 0)
 
 //////CAUTERIZE///////
-/datum/surgery_step/eye/cauterize/tool_quality(obj/item/tool)
-	if(tool.is_hot())
-		for (var/T in allowed_tools)
-			if (istype(tool,T))
-				return allowed_tools[T]
-	return 0
+/datum/surgery_step/eye/cauterize/tool_quality(obj/item/tool, mob/living/user)
+	. = ..()
+	if(!tool.is_hot())
+		return 0
+
 /datum/surgery_step/eye/cauterize
 	allowed_tools = list(
 		/obj/item/tool/cautery = 100,

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -16,7 +16,7 @@
 
 
 ///////CUT FACE/////////
-/datum/surgery_step/generic/cut_face/tool_quality(obj/item/tool)
+/datum/surgery_step/generic/cut_face/tool_quality(obj/item/tool, mob/living/user)
 	. = ..()
 	if(!tool.is_sharp())
 		return 0
@@ -117,12 +117,11 @@
 
 
 ////////CAUTERIZE////////
-/datum/surgery_step/face/cauterize/tool_quality(obj/item/tool)
-	if(tool.is_hot())
-		for (var/T in allowed_tools)
-			if (istype(tool,T))
-				return allowed_tools[T]
-	return 0
+/datum/surgery_step/face/cauterize/tool_quality(obj/item/tool, mob/living/user)
+	. = ..()
+	if(!tool.is_hot())
+		return 0
+
 /datum/surgery_step/face/cauterize
 	allowed_tools = list(
 		/obj/item/tool/cautery = 100,

--- a/code/modules/surgery/genderchange.dm
+++ b/code/modules/surgery/genderchange.dm
@@ -44,7 +44,7 @@
 		/obj/item/tool/scalpel = 100,
 		/obj/item/weapon/kitchen/utensil/knife/large = 75,
 		/obj/item/weapon/hatchet = 50,
-		/obj/item/tool/wirecutters = 35,
+		"wirecutter" = 35,
 		)
 
 	priority = 10 //Fuck sakes

--- a/code/modules/surgery/genderchange.dm
+++ b/code/modules/surgery/genderchange.dm
@@ -34,7 +34,7 @@
 
 
 //////RESHAPE GENITALS//////
-/datum/surgery_step/reshape_genitals/tool_quality(obj/item/tool)
+/datum/surgery_step/reshape_genitals/tool_quality(obj/item/tool, mob/living/user)
 	. = ..()
 	if(!tool.is_sharp())
 		return 0

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -28,7 +28,7 @@
 
 
 //////CUT WITH LASER(cut+clamp)//////////
-/datum/surgery_step/generic/cut_with_laser/tool_quality(obj/item/tool)
+/datum/surgery_step/generic/cut_with_laser/tool_quality(obj/item/tool, mob/living/user)
 	. = ..()
 	if(!tool.is_sharp())
 		return 0
@@ -130,7 +130,7 @@
 
 
 ////////CUT OPEN/////////
-/datum/surgery_step/generic/cut_open/tool_quality(obj/item/tool)
+/datum/surgery_step/generic/cut_open/tool_quality(obj/item/tool, mob/living/user)
 	. = ..()
 	if(!tool.is_sharp())
 		return 0
@@ -284,12 +284,11 @@
 
 
 /////////CAUTERIZE///////
-/datum/surgery_step/generic/cauterize/tool_quality(obj/item/tool)
-	if(tool.is_hot())
-		for (var/T in allowed_tools)
-			if (istype(tool,T))
-				return allowed_tools[T]
-	return 0
+/datum/surgery_step/generic/cauterize/tool_quality(obj/item/tool, mob/living/user)
+	. = ..()
+	if(!tool.is_hot())
+		return 0
+
 /datum/surgery_step/generic/cauterize
 	allowed_tools = list(
 	/obj/item/tool/cautery = 100,
@@ -379,7 +378,7 @@
 
 
 /////////BIOFOAM INJECTION///////
-/datum/surgery_step/generic/injectfoam/tool_quality(obj/item/tool)
+/datum/surgery_step/generic/injectfoam/tool_quality(obj/item/tool, mob/living/user)
 	. = ..()
 	if(!tool.is_sharp())
 		return 0

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -121,12 +121,11 @@
 
 
 //////PREPARE///////
-/datum/surgery_step/head/prepare/tool_quality(obj/item/tool)
-	if(tool.is_hot())
-		for (var/T in allowed_tools)
-			if (istype(tool,T))
-				return allowed_tools[T]
-	return 0
+/datum/surgery_step/head/prepare/tool_quality(obj/item/tool, mob/living/user)
+	. = ..()
+	if(!tool.is_hot())
+		return 0
+
 /datum/surgery_step/head/prepare
 	allowed_tools = list(
 		/obj/item/tool/cautery = 100,

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -253,7 +253,7 @@
 	affected.createwound(CUT, 20)
 	if (affected.implants.len)
 		var/fail_prob = 10
-		fail_prob += 100 - tool_quality(tool)
+		fail_prob += 100 - tool_quality(user, tool)
 		if (prob(fail_prob))
 			var/obj/item/weapon/implant/imp = affected.implants[1]
 			user.visible_message("<span class='warning'>Something beeps inside [target]'s [affected.display_name]!</span>")

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -172,7 +172,7 @@
 /datum/surgery_step/cavity/implant_removal
 	allowed_tools = list(
 		/obj/item/tool/hemostat = 100,
-		/obj/item/tool/wirecutters = 75,
+		"wirecutters" = 75,
 		/obj/item/weapon/talisman = 70,
 		/obj/item/weapon/kitchen/utensil/fork = 20,
 		)

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -73,12 +73,11 @@
 
 
 ///////CLOSE SPACE/////
-/datum/surgery_step/cavity/close_space/tool_quality(obj/item/tool)
-	if(tool.is_hot())
-		for (var/T in allowed_tools)
-			if (istype(tool,T))
-				return allowed_tools[T]
-	return 0
+/datum/surgery_step/cavity/close_space/tool_quality(obj/item/tool, mob/living/user)
+	. = ..()
+	if(!tool.is_hot())
+		return 0
+
 /datum/surgery_step/cavity/close_space
 	priority = 2
 	allowed_tools = list(
@@ -253,7 +252,7 @@
 	affected.createwound(CUT, 20)
 	if (affected.implants.len)
 		var/fail_prob = 10
-		fail_prob += 100 - tool_quality(user, tool)
+		fail_prob += 100 - tool_quality(tool, user)
 		if (prob(fail_prob))
 			var/obj/item/weapon/implant/imp = affected.implants[1]
 			user.visible_message("<span class='warning'>Something beeps inside [target]'s [affected.display_name]!</span>")

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -18,7 +18,7 @@
 /datum/surgery_step/internal/remove_embryo
 	allowed_tools = list(
 		/obj/item/tool/hemostat = 100,
-		/obj/item/tool/wirecutters = 75,
+		"wirecutters" = 75,
 		/obj/item/weapon/kitchen/utensil/fork = 20,
 		)
 	blood_level = 2
@@ -161,7 +161,7 @@
 	allowed_tools = list(
 		/obj/item/stack/nanopaste = 100,
 		/obj/item/tool/bonegel = 30,
-		/obj/item/tool/screwdriver = 70,
+		"screwdriver" = 70,
 		)
 
 	duration = 7 SECONDS
@@ -306,7 +306,7 @@
 
 	allowed_tools = list(
 		/obj/item/tool/hemostat = 100,
-		/obj/item/tool/wirecutters = 75,
+		"wirecutters" = 75,
 		/obj/item/weapon/kitchen/utensil/fork = 20,
 		)
 

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -237,7 +237,7 @@
 
 
 //////DETACH ORGAN////
-/datum/surgery_step/internal/detatch_organ/tool_quality(obj/item/tool)
+/datum/surgery_step/internal/detatch_organ/tool_quality(obj/item/tool, mob/living/user)
 	. = ..()
 	if(!tool.is_sharp())
 		return 0

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -57,7 +57,7 @@
 
 
 //////FIX DEAD TISSUE/////
-/datum/surgery_step/fix_dead_tissue/tool_quality(obj/item/tool)
+/datum/surgery_step/fix_dead_tissue/tool_quality(obj/item/tool, mob/living/user)
 	. = ..()
 	if(!tool.is_sharp())
 		return 0

--- a/code/modules/surgery/robolimbs.dm
+++ b/code/modules/surgery/robolimbs.dm
@@ -21,7 +21,7 @@
 
 
 //////CUT///////
-/datum/surgery_step/limb/cut/tool_quality(obj/item/tool)
+/datum/surgery_step/limb/cut/tool_quality(obj/item/tool, mob/living/user)
 	. = ..()
 	if(!tool.is_sharp())
 		return 0
@@ -97,12 +97,11 @@
 
 
 //////PREPARE///////
-/datum/surgery_step/limb/prepare/tool_quality(obj/item/tool)
-	if(tool.is_hot())
-		for (var/T in allowed_tools)
-			if (istype(tool,T))
-				return allowed_tools[T]
-	return 0
+/datum/surgery_step/limb/prepare/tool_quality(obj/item/tool, mob/living/user)
+	. = ..()
+	if(!tool.is_hot())
+		return 0
+
 /datum/surgery_step/limb/prepare
 	allowed_tools = list(
 		/obj/item/tool/cautery = 100,

--- a/code/modules/surgery/slimes.dm
+++ b/code/modules/surgery/slimes.dm
@@ -12,7 +12,7 @@
 
 
 //////CUT FLESH//////
-/datum/surgery_step/slime/cut_flesh/tool_quality(obj/item/tool)
+/datum/surgery_step/slime/cut_flesh/tool_quality(obj/item/tool, mob/living/user)
 	. = ..()
 	if(!tool.is_sharp())
 		return 0
@@ -49,7 +49,7 @@
 
 
 //////CUT INNARDS///////
-/datum/surgery_step/slime/cut_innards/tool_quality(obj/item/tool)
+/datum/surgery_step/slime/cut_innards/tool_quality(obj/item/tool, mob/living/user)
 	. = ..()
 	if(!tool.is_sharp())
 		return 0

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -20,17 +20,17 @@
 	var/digging = FALSE
 
 	//returns how well tool is suited for this step
-/datum/surgery_step/proc/tool_quality(obj/item/tool)
+/datum/surgery_step/proc/tool_quality(mob/living/user, obj/item/tool)
 	for (var/T in allowed_tools)
 		if (!istext(T) && istype(tool,T))
 			return allowed_tools[T]
 		if (!istype(tool,/obj/item))
 			continue
-		if (T == "screwdriver" && tool.is_screwdriver())
+		if (T == "screwdriver" && tool.is_screwdriver(user))
 			return allowed_tools[T]
-		if (T == "wrench" && tool.is_wrench())
+		if (T == "wrench" && tool.is_wrench(user))
 			return allowed_tools[T]
-		if (T == "wirecutter" && tool.is_wirecutter())
+		if (T == "wirecutter" && tool.is_wirecutter(user))
 			return allowed_tools[T]
 	return 0
 
@@ -141,7 +141,7 @@
 	for(var/datum/surgery_step/S in surgery_steps)
 		//check if tool is right or close enough and if this step is possible
 		sleep_fail = 0
-		if(S.tool_quality(tool))
+		if(S.tool_quality(user, tool))
 			var/canuse = S.can_use(user, M, target_area, tool)
 			if(canuse == -1)
 				sleep_fail = 1
@@ -156,7 +156,7 @@
 
 				var/selection = user.zone_sel ? user.zone_sel.selecting : null //Check if the zone selection hasn't changed
 				//We had proper tools! (or RNG smiled.) and user did not move or change hands.
-				if(do_mob(user, M, S.duration * tool.toolspeed) && (success_override == SURGERY_SUCCESS_ALWAYS || (success_override == SURGERY_SUCCESS_NORMAL && (prob(S.tool_quality(tool) / (sleep_fail + clumsy + 1))))) && (!user.zone_sel || selection == user.zone_sel.selecting)) //Last part checks whether the zone selection hasn't changed
+				if(do_mob(user, M, S.duration * tool.toolspeed) && (success_override == SURGERY_SUCCESS_ALWAYS || (success_override == SURGERY_SUCCESS_NORMAL && (prob(S.tool_quality(user, tool) / (sleep_fail + clumsy + 1))))) && (!user.zone_sel || selection == user.zone_sel.selecting)) //Last part checks whether the zone selection hasn't changed
 					M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had surgery [S.type] with \the [tool] successfully completed by [user.name] ([user.ckey])</font>")
 					user.attack_log += text("\[[time_stamp()]\] <font color='red'>Successfully completed surgery [S.type] with \the [tool] on [M.name] ([M.ckey])</font>")
 					log_attack("<font color='red'>[user.name] ([user.ckey]) used \the [tool] to successfully complete surgery type [S.type] on [M.name] ([M.ckey])</font>")

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -20,7 +20,7 @@
 	var/digging = FALSE
 
 	//returns how well tool is suited for this step
-/datum/surgery_step/proc/tool_quality(mob/living/user, obj/item/tool)
+/datum/surgery_step/proc/tool_quality(obj/item/tool, mob/living/user)
 	for (var/T in allowed_tools)
 		if (!istext(T) && istype(tool,T))
 			return allowed_tools[T]
@@ -141,7 +141,7 @@
 	for(var/datum/surgery_step/S in surgery_steps)
 		//check if tool is right or close enough and if this step is possible
 		sleep_fail = 0
-		if(S.tool_quality(user, tool))
+		if(S.tool_quality(tool, user))
 			var/canuse = S.can_use(user, M, target_area, tool)
 			if(canuse == -1)
 				sleep_fail = 1
@@ -156,7 +156,7 @@
 
 				var/selection = user.zone_sel ? user.zone_sel.selecting : null //Check if the zone selection hasn't changed
 				//We had proper tools! (or RNG smiled.) and user did not move or change hands.
-				if(do_mob(user, M, S.duration * tool.toolspeed) && (success_override == SURGERY_SUCCESS_ALWAYS || (success_override == SURGERY_SUCCESS_NORMAL && (prob(S.tool_quality(user, tool) / (sleep_fail + clumsy + 1))))) && (!user.zone_sel || selection == user.zone_sel.selecting)) //Last part checks whether the zone selection hasn't changed
+				if(do_mob(user, M, S.duration * tool.toolspeed) && (success_override == SURGERY_SUCCESS_ALWAYS || (success_override == SURGERY_SUCCESS_NORMAL && (prob(S.tool_quality(tool, user) / (sleep_fail + clumsy + 1))))) && (!user.zone_sel || selection == user.zone_sel.selecting)) //Last part checks whether the zone selection hasn't changed
 					M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had surgery [S.type] with \the [tool] successfully completed by [user.name] ([user.ckey])</font>")
 					user.attack_log += text("\[[time_stamp()]\] <font color='red'>Successfully completed surgery [S.type] with \the [tool] on [M.name] ([M.ckey])</font>")
 					log_attack("<font color='red'>[user.name] ([user.ckey]) used \the [tool] to successfully complete surgery type [S.type] on [M.name] ([M.ckey])</font>")

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -22,7 +22,15 @@
 	//returns how well tool is suited for this step
 /datum/surgery_step/proc/tool_quality(obj/item/tool)
 	for (var/T in allowed_tools)
-		if (istype(tool,T))
+		if (!istext(T) && istype(tool,T))
+			return allowed_tools[T]
+		if (!istype(tool,/obj/item))
+			continue
+		if (T == "screwdriver" && tool.is_screwdriver())
+			return allowed_tools[T]
+		if (T == "wrench" && tool.is_wrench())
+			return allowed_tools[T]
+		if (T == "wirecutter" && tool.is_wirecutter())
 			return allowed_tools[T]
 	return 0
 

--- a/code/modules/surgery/tooth.dm
+++ b/code/modules/surgery/tooth.dm
@@ -146,7 +146,7 @@
 /datum/surgery_step/tooth_extract/pull_tooth
 	allowed_tools = list(
 		/obj/item/tool/hemostat = 100,
-		/obj/item/tool/wirecutters = 50,
+		"wirecutter" = 50,
 		/obj/item/device/assembly/mousetrap = 10,	//I don't know. Don't ask me. But I'm leaving it because hilarity.
 		)
 

--- a/code/modules/surgery/tooth.dm
+++ b/code/modules/surgery/tooth.dm
@@ -114,7 +114,7 @@
 /datum/surgery_step/tooth_extract/set_jaws
 	allowed_tools = list(
 		/obj/item/tool/bonesetter = 100,
-		/obj/item/tool/wrench = 75,
+		"wrench" = 75,
 		)
 
 	duration = 6 SECONDS
@@ -196,7 +196,7 @@
 /datum/surgery_step/tooth_extract/reset
 	allowed_tools = list(
 		/obj/item/tool/bonesetter = 100,
-		/obj/item/tool/wrench = 75,
+		"wrench" = 75,
 		)
 
 	duration = 6 SECONDS

--- a/code/modules/trader/crates/cloudnine.dm
+++ b/code/modules/trader/crates/cloudnine.dm
@@ -187,10 +187,10 @@ var/global/list/cloudnine_stuff = list(
 	mode = !mode
 	to_chat(user, "<span class='notice'>You toggle the tool into [mode ? "multitool" : "wirecutter"] mode.</span>")
 
-/obj/item/device/multitool/omnitool/is_wirecutter()
+/obj/item/device/multitool/omnitool/is_wirecutter(mob/user)
 	return !mode
 
-/obj/item/device/multitool/omnitool/is_multitool()
+/obj/item/device/multitool/omnitool/is_multitool(mob/user)
 	return mode
 
 var/list/omnitoolable = list(/obj/machinery/alarm,/obj/machinery/power/apc)


### PR DESCRIPTION
# They were broken?

Yep, ever try using a screwsolder?

![image](https://github.com/user-attachments/assets/6e19bc0b-d78f-4974-8551-dd48f0365a4d)


## What this does
This fixes a lot of interactions between things that want a screwdriver, wrench, or wirecutters, and would only accept their basic forms. This means that you can use an omnitool on wirecutter mode to cut out wires on more things, use a screwsolder to build a spacepod, or even use a swiss army knife in your surgery. Can't use the coin as a screwdriver in surgery though, the harm and heal intents conflict.

Additionally, the screwsolder can be used in more situations where a general screwdriver can be used, including being slotted in a knife holster.

I fixed a capitalization bug in construction datums while I was there as well.

EDIT: Also, standardized a bunch of surgery checks so that they call the base tool_quality proc and then afterward call their specific additional conditions (such as ``!tool.is_hot()`` or ``!tool.is_sharp()``).

## Why it's good
Fixes #36899 and a bunch of unreported other building bugs with non-standard tools.

## How it was tested
Tons of building and unbuilding, including mob hurting and unhurting.
![image](https://github.com/user-attachments/assets/0e60b98c-f592-4414-8104-1a35be4b149c)
![image](https://github.com/user-attachments/assets/bab64190-8367-40c6-9fa9-74fdaa6bec4b)


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Screwsolders, omnitools, and switchtools can be used in more situations.
