### PR TITLE
Allows AI to retrack people who come back on cameras

### DIFF
--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -26,11 +26,11 @@
 	INVOKE_EVENT(M, /event/camera_sight_changed, "mover" = M)
 	return 1
 
-/*/datum/dna/gene/basic/psychic_resist/deactivate(var/mob/M, var/connected, var/flags)
+/datum/dna/gene/basic/psychic_resist/deactivate(var/mob/M, var/connected, var/flags)
 	if(!..())
 		return 0
 	INVOKE_EVENT(M, /event/camera_sight_changed, "mover" = M)
-	return 1*/ // Allows retracking, uncomment to enable
+	return 1
 
 /////////////////////////
 // Stealth Enhancers

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -206,13 +206,12 @@
 /mob/living/silicon/ai/proc/on_camera_change()
 	if(eyeobj && currently_tracking)
 		var/cantrack = can_track_atom(currently_tracking)
-		/*if(!eyeobj.locked_to && cantrack) // Retracking code
+		if(!eyeobj.locked_to && cantrack)
 			to_chat(src, "Target is trackable again.")
 			currently_tracking.lock_atom(eyeobj,/datum/locking_category/ai_eye)
-		else */if(!cantrack && eyeobj.locked_to == currently_tracking)
+		else if(!cantrack && eyeobj.locked_to == currently_tracking)
 			to_chat(src, "Target is no longer trackable.")
-			//eyeobj.unlock_from()
-			stop_ai_tracking() // remove this if you want retracking
+			eyeobj.unlock_from()
 
 /mob/living/silicon/ai/proc/stop_ai_tracking()
 	if(currently_tracking)

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -197,7 +197,7 @@
 	currently_tracking.register_event(/event/after_move,src,nameof(src::on_camera_change()))
 	currently_tracking.register_event(/event/destroyed,src,nameof(src::stop_ai_tracking()))
 	currently_tracking.register_event(/event/equipped,src,nameof(src::on_camera_change()))
-	//currently_tracking.register_event(/event/unequipped,src,nameof(src::on_camera_change()))
+	currently_tracking.register_event(/event/unequipped,src,nameof(src::on_camera_change()))
 	currently_tracking.register_event(/event/camera_sight_changed,src,nameof(src::on_camera_change()))
 	to_chat(src, "Now tracking [currently_tracking.name] on camera.")
 
@@ -219,7 +219,7 @@
 		currently_tracking.unregister_event(/event/after_move,src,nameof(src::on_camera_change()))
 		currently_tracking.unregister_event(/event/destroyed,src,nameof(src::stop_ai_tracking()))
 		currently_tracking.unregister_event(/event/equipped,src,nameof(src::on_camera_change()))
-		//currently_tracking.unregister_event(/event/unequipped,src,nameof(src::on_camera_change()))
+		currently_tracking.unregister_event(/event/unequipped,src,nameof(src::on_camera_change()))
 		currently_tracking.unregister_event(/event/camera_sight_changed,src,nameof(src::on_camera_change()))
 		if(eyeobj?.locked_to == currently_tracking)
 			eyeobj.unlock_from()

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -58,9 +58,9 @@ var/list/megaphone_channels = list("DISABLE" = 0) + stationchannels
 /obj/item/device/megaphone/madscientist/pickup(mob/user)
 	INVOKE_EVENT(user, /event/camera_sight_changed, "mover" = user)
 
-/*/obj/item/device/megaphone/madscientist/dropped(mob/user)
+/obj/item/device/megaphone/madscientist/dropped(mob/user)
 	..()
-	INVOKE_EVENT(user, /event/camera_sight_changed, "mover" = user)*/ // Allows retracking, uncomment to enable
+	INVOKE_EVENT(user, /event/camera_sight_changed, "mover" = user)
 
 /obj/item/device/megaphone/madscientist/attack_self(mob/living/user as mob)
 	show_ui(user)


### PR DESCRIPTION
[content]

## What this does
enables the commented out code, as requested by @SonixApache
Closes #37193.

## Why it's good
makes target tracking more convenient

## How it was tested
tracking a mob on a conveyor belt, same as last AI tracking PR

## Changelog
:cl:
 * rscadd: AIs now retrack their targets as soon as they come back into view.