### PR TITLE
Quick equip fixes

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -418,7 +418,7 @@
 	return 1
 
 /obj/item/weapon/storage/can_quick_store(var/obj/item/I)
-	return can_be_inserted(I,1)
+	return can_use() && can_be_inserted(I,1)
 
 /obj/item/weapon/storage/quick_store(var/obj/item/I,mob/user)
 	..()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -205,9 +205,6 @@
 			return
 		if(user.drop_item(I, src))
 			attach_accessory(A, user)
-		if(iscarbon(loc))
-			var/mob/living/carbon/carbon_wearer = loc
-			carbon_wearer.update_inv_by_slot(slot_flags)
 		return 1
 	if(I.is_screwdriver(user))
 		for(var/obj/item/clothing/accessory/accessory in priority_accessories())
@@ -437,6 +434,9 @@
 	if(user)
 		to_chat(user, "<span class='notice'>You attach [accessory] to [src].</span>")
 		accessory.add_fingerprint(user)
+	if(iscarbon(loc))
+		var/mob/living/carbon/carbon_wearer = loc
+		carbon_wearer.update_inv_by_slot(slot_flags)
 
 /obj/item/clothing/proc/priority_accessories()
 	if(!accessories.len)


### PR DESCRIPTION
[bugfix]

## What this does
Closes #37171.
Closes #37157.

## How it was tested
calling can_quick_store() on lockbox for an item when locked vs not
quick equipping and unequipping stuff on clothes

## Changelog
:cl:
 * bugfix: Lockboxes can no longer be quick stored into if locked and not broken.
 * bugfix: Quick equipping accessories to clothes now updates the icon properly.