### PR TITLE
Endless Fire Fix

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -546,6 +546,10 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	if(!flammable || check_fire_protection() || thermal_mass <= 0)
 		return FALSE
 
+	var/datum/gas_mixture = return_air()
+	if(air_contents[GAS_OXYGEN] < 1)
+		return FALSE
+
 	var/in_fire = FALSE
 	on_fire=1
 
@@ -625,7 +629,6 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	//Fires shouldn't spawn in areas or mobs, but it has happened...
 	if(!istype(loc,/turf))
 		qdel(src)
-		CRASH("Fire was created at src->loc: [src]->[loc] instead of a turf.")
 
 	// Get location and check if it is in a proper ZAS zone.
 	var/turf/simulated/S = get_turf(loc)
@@ -641,7 +644,7 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	if(!air_contents.check_recombustability(S))
 		Extinguish()
 	else if(air_contents.check_recombustability(S) == 1)
-		if((air_contents.molar_ratio(GAS_OXYGEN)) < (MINOXY2BURN + rand(-2,2)*0.01))
+		if((air_contents.molar_ratio(GAS_OXYGEN)) < (MINOXY2BURN + rand(-2,2)*0.01) || (air_contents[GAS_OXYGEN] < 1)) //extinguish if the ratio of fuel:oxygen is too low or if there isn't enough oxygen present at all
 			Extinguish()
 			return
 

--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -546,7 +546,7 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 	if(!flammable || check_fire_protection() || thermal_mass <= 0)
 		return FALSE
 
-	var/datum/gas_mixture = return_air()
+	var/datum/gas_mixture/air_contents = return_air()
 	if(air_contents[GAS_OXYGEN] < 1)
 		return FALSE
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Prevents fires from starting or continuing to burn if there is less than 1 mol of oxygen in the zone.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Prevents infinite fires and closes #36721.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Set a room on fire and let it burn out naturally due to improper oxygen ratio.
Set a breached room on fire and ensured fires stopped spawning at less than 1 mol Oxygen.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed fires spawning endlessly in breached rooms.