### PR TITLE
Killer pheromones

### DIFF
--- a/__DEFINES/reagents.dm
+++ b/__DEFINES/reagents.dm
@@ -164,6 +164,7 @@
 #define HOLYSALTS 			"holysalts"
 #define CREATINE 			"creatine"
 #define CARPPHEROMONES 			"carppheromones"
+#define KILLERPHEROMONES 		"killerpheromones"
 #define BLACKPEPPER 			"blackpepper"
 #define CINNAMON 			"cinnamon"
 #define ZAMSPICES			"zamspices"

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -684,6 +684,7 @@
 	display_name = "killer tomato plant"
 	plant_dmi = 'icons/obj/hydroponics/killertomato.dmi'
 	products = list(/obj/item/weapon/reagent_containers/food/snacks/grown/killertomato)
+	chems = list(NUTRIMENT = list(1,10), KILLERPHEROMONES = list(5,4))
 	mutants = null
 
 	yield = 2

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -8,7 +8,7 @@
 		if(!L.stat)
 			stance = HOSTILE_STANCE_ATTACK
 			return L
-		else
+		else if(!L.reagents || !L.reagents.has_reagent(KILLERPHEROMONES))
 			enemies -= L
 	else if(istype(A, /obj/mecha))
 		var/obj/mecha/M = A

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1302,6 +1302,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/meat/tomatomeat/New()
 	..()
 	reagents.add_reagent(NUTRIMENT, 3)
+	reagents.add_reagent(KILLERPHEROMONES, 3)
 	src.bitesize = 6
 
 /obj/item/weapon/reagent_containers/food/snacks/meat/spiderleg

--- a/code/modules/reagents/reagents/reagents_bio.dm
+++ b/code/modules/reagents/reagents/reagents_bio.dm
@@ -320,7 +320,7 @@
 	color = "#993300"
 	custom_metabolism = 2
 	density = 109.06
-	//var/list/mob/living/simple_animal/hostile/retaliate/horde = list()
+	var/list/mob/living/simple_animal/hostile/retaliate/horde = list()
 
 /datum/reagent/killer_pheromones/on_mob_life(var/mob/living/M)
 	if(..())
@@ -343,21 +343,21 @@
 			continue
 
 		R.Retaliate()
-		//horde += R
+		horde += R
 		alerted++
 		break
 
 	if(alerted >= 2)
 		to_chat(M,"<span class='danger'>YOU HAVE ALERTED THE HORDE!</span>")
 
-/*/datum/reagent/killer_pheromones/reagent_deleted() // uncomment if necessary
+/datum/reagent/killer_pheromones/reagent_deleted() // uncomment if necessary
 	if(..())
 		return 1
 	if(!holder)
 		return
 	var/mob/M =  holder.my_atom
 	for(var/mob/living/simple_animal/hostile/retaliate/R in horde)
-		R.enemies -= M*/
+		R.enemies -= M
 
 /datum/reagent/ectoplasm
 	name = "Ectoplasm"

--- a/code/modules/reagents/reagents/reagents_bio.dm
+++ b/code/modules/reagents/reagents/reagents_bio.dm
@@ -320,7 +320,7 @@
 	color = "#993300"
 	custom_metabolism = 2
 	density = 109.06
-	//var/list/enemies
+	//var/list/mob/living/simple_animal/hostile/retaliate/horde = list()
 
 /datum/reagent/killer_pheromones/on_mob_life(var/mob/living/M)
 	if(..())
@@ -339,23 +339,25 @@
 	
 	var/alerted = FALSE
 	for(var/mob/living/simple_animal/hostile/retaliate/R in view(stench_radius, M)) //All other retaliating hostile mobs in radius
-		if(R == M || R.stat)
+		if(R == M || R.stat || (M in R.enemies))
 			continue
 
 		R.Retaliate()
-		//enemies |= R.enemies
+		//horde += R
 		alerted = TRUE
 		break
 
 	if(alerted)
 		to_chat(M,"<span class='danger'>YOU HAVE ALERTED THE HORDE!</span>")
 
-/*/datum/reagent/killer_pheromones/reagent_deleted() // TODO: remove all mobs attacking you maybe
+/*/datum/reagent/killer_pheromones/reagent_deleted() // uncomment if necessary
 	if(..())
 		return 1
 	if(!holder)
 		return
-	var/mob/M =  holder.my_atom*/
+	var/mob/M =  holder.my_atom
+	for(var/mob/living/simple_animal/hostile/retaliate/R in horde)
+		R.enemies -= M*/
 
 /datum/reagent/ectoplasm
 	name = "Ectoplasm"

--- a/code/modules/reagents/reagents/reagents_bio.dm
+++ b/code/modules/reagents/reagents/reagents_bio.dm
@@ -350,7 +350,7 @@
 	if(alerted >= 2)
 		to_chat(M,"<span class='danger'>YOU HAVE ALERTED THE HORDE!</span>")
 
-/datum/reagent/killer_pheromones/reagent_deleted() // uncomment if necessary
+/datum/reagent/killer_pheromones/reagent_deleted()
 	if(..())
 		return 1
 	if(!holder)

--- a/code/modules/reagents/reagents/reagents_bio.dm
+++ b/code/modules/reagents/reagents/reagents_bio.dm
@@ -339,7 +339,7 @@
 	
 	var/alerted = 0
 	for(var/mob/living/simple_animal/hostile/retaliate/R in view(stench_radius, M)) //All other retaliating hostile mobs in radius
-		if(R == M || R.stat || (M in R.enemies))
+		if(R == M || R.stat || R.hostile || (M in R.enemies))
 			continue
 
 		R.Retaliate()

--- a/code/modules/reagents/reagents/reagents_bio.dm
+++ b/code/modules/reagents/reagents/reagents_bio.dm
@@ -337,17 +337,17 @@
 
 	var/stench_radius = clamp(volume * 0.1, 1, 6) //Stench starts out with 1 tile radius and grows after every 10 reagents on you
 	
-	var/alerted = FALSE
+	var/alerted = 0
 	for(var/mob/living/simple_animal/hostile/retaliate/R in view(stench_radius, M)) //All other retaliating hostile mobs in radius
 		if(R == M || R.stat || (M in R.enemies))
 			continue
 
 		R.Retaliate()
 		//horde += R
-		alerted = TRUE
+		alerted++
 		break
 
-	if(alerted)
+	if(alerted >= 2)
 		to_chat(M,"<span class='danger'>YOU HAVE ALERTED THE HORDE!</span>")
 
 /*/datum/reagent/killer_pheromones/reagent_deleted() // uncomment if necessary

--- a/code/modules/reagents/reagents/reagents_bio.dm
+++ b/code/modules/reagents/reagents/reagents_bio.dm
@@ -312,6 +312,51 @@
 
 			to_chat(C, "<span class='warning'>You are engulfed by a [pick("tremendous", "foul", "disgusting", "horrible")] stench emanating from [M]!</span>")
 
+/datum/reagent/killer_pheromones
+	name = "Killer Pheromones"
+	id = KILLERPHEROMONES
+	description = "A viscous liquid with a strong smell that resembles blood and ketchup, which is like blood in the water to killer tomatoes if air was water."
+	reagent_state = REAGENT_STATE_LIQUID
+	color = "#993300"
+	custom_metabolism = 2
+	density = 109.06
+	//var/list/enemies
+
+/datum/reagent/killer_pheromones/on_mob_life(var/mob/living/M)
+	if(..())
+		return 1
+
+	if(!tick)
+		to_chat(M,"<span class='bad'><b>You feel like [pick("you're alerting a horde", "something is waiting to pounce on you", "carnivorous beings are nearby")]! [pick("Do you, perhaps...?","Maybe... just maybe...")]</b></span>")
+
+	if(volume < 3)
+		if(volume <= custom_metabolism)
+			to_chat(M,"<span class='good'>You feel [pick("like the coast is clear", "out of danger", "less threatened")]!</span>")
+		else if(!(tick%4))
+			to_chat(M,"<span class='notice'>You feel [pick("further from danger", "like you're losing something chasing you", "less hunted down")]...</span>")
+
+	var/stench_radius = clamp(volume * 0.1, 1, 6) //Stench starts out with 1 tile radius and grows after every 10 reagents on you
+	
+	var/alerted = FALSE
+	for(var/mob/living/simple_animal/hostile/retaliate/R in view(stench_radius, M)) //All other retaliating hostile mobs in radius
+		if(R == M || R.stat)
+			continue
+
+		R.Retaliate()
+		//enemies |= R.enemies
+		alerted = TRUE
+		break
+
+	if(alerted)
+		to_chat(M,"<span class='danger'>YOU HAVE ALERTED THE HORDE!</span>")
+
+/*/datum/reagent/killer_pheromones/reagent_deleted() // TODO: remove all mobs attacking you maybe
+	if(..())
+		return 1
+	if(!holder)
+		return
+	var/mob/M =  holder.my_atom*/
+
 /datum/reagent/ectoplasm
 	name = "Ectoplasm"
 	id = ECTOPLASM


### PR DESCRIPTION
[content]

## What this does
creates this reagant, harvested from killer tomatoes that aren't set down as well as killer tomato meat, with a base unit value of 5 plus any potency divided by 4. (so 200 potency gives 60 units) when consumed by a mob, activates a stench radius much like the carp kind, except what this one does is make every "retaliatable" type hostile mob attack the player within the radius, peaking at 6 tiles with 60 units (1 tile per 10 units) which stops when the reagent is removed from the system, for each mob made hostile this way.

## Why it's good
fun botany chem

## How it was tested
adding 50u of the reagent to the player around snowmen.

## Changelog
:cl:
 * rscadd: A new reagent "killer pheromones" can be harvested from killer tomato plants and killer tomato meat. When consumed, this makes all mobs that can become hostile from attacks go after the player in a radius based on amount consumed. All mobs made hostile from this method then become calm towards the player again when the reagent is removed from their system.