### PR TITLE
Adds a reason field for job priorities

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -18,6 +18,8 @@ var/global/alt_job_limit = 0 //list of alternate jobs available for new hires
 	var/list/crystal_ball = list() //This should be an assoc. list. Job = # of players ready. Configured by predict_manifest() in obj.dm
 
 	var/priority_jobs_remaining = 3 //Limit on how many prioritized jobs can be had at once.
+	var/priority_justification = "" //Message to joiners about why jobs are prioritised
+
 	var/list/labor_consoles = list()
 	var/list/assistant_second_chance = list()
 
@@ -175,6 +177,9 @@ var/global/alt_job_limit = 0 //list of alternate jobs available for new hires
 			to_chat(player, "<span class='notice'>The [rank] job is [job.priority ? "now highly requested!" : "no longer highly requested."]</span>")
 		return 1
 	return 0
+
+/datum/controller/occupations/proc/SetPriorityJustification(justification)
+	priority_justification = strip_html(justification)
 
 /datum/controller/occupations/proc/PrioritzeDeparmentHead(var/datum/job/job)
 	if(job.department == "Civilian")

--- a/code/game/machinery/computer/labor.dm
+++ b/code/game/machinery/computer/labor.dm
@@ -24,6 +24,7 @@ var/list/labor_console_categories = list(
 	var/closing = "" //Same, except to close a slot
 	var/toggling_priority = "" //If this variable is set with a job's title, the user will be prompted to swipe to prioritize/deprioritize.
 	var/selected_category = "Civilian"
+	var/justification = "" // TODO: move this var out somewhere else
 
 	var/icon/verified_overlay
 	var/icon/awaiting_overlay
@@ -59,6 +60,8 @@ var/list/labor_console_categories = list(
 			dat += "<b>Closing</b> <div class='line'>[uppertext(closing)]</div> Job Slot"
 		else if(toggling_priority != "")
 			dat += "<b>[job_master.IsJobPrioritized(toggling_priority) ? "Deprioritizing" : "Prioritizing"]</b> <div class='line'>[uppertext(toggling_priority)]</div> Job Slot"
+			if(!job_master.IsJobPrioritized(toggling_priority))
+				dat += "<br><A href='?src=\ref[src];reason=1'>Write Justification</A>"
 		dat += "<br><br><A href='?src=\ref[src];cancel=1'>CANCEL</A>"
 		if(isAdminGhost(user))
 			dat += "<br><br><div class='line'>...or...</div><A href='?src=\ref[src];adminhax=1'>CHEEKY ADMINGHOST-ONLY CARD BYPASS BUTTON</A>"
@@ -108,6 +111,8 @@ var/list/labor_console_categories = list(
 /obj/machinery/computer/labor/proc/verified(mob/user, var/delay = TRUE)
 	if(awaiting_swipe == TRUE)
 		if((toggling_priority != "" && job_master.TogglePriority(toggling_priority, user)) || (freeing != "" && job_master.FreeRole(freeing, user)) || (closing != "" && job_master.CloseRole(closing, user)))
+			if(justification)
+				job_master.SetPriorityJustification(justification)
 			awaiting_swipe = FALSE
 			verifying = TRUE
 			update_icon()
@@ -210,6 +215,9 @@ var/list/labor_console_categories = list(
 				to_chat(usr,"<span class='warning'>That's odd. You could've sworn the CHEEKY ADMINGHOST-ONLY CARD BYPASS BUTTON button was there just a second ago!")
 				return
 			verified(usr, FALSE)
+
+		else if(href_list["reason"])
+			justification = input(src,"Enter a reason for justifying job priorities","Priority justification","") as text
 
 		else if(href_list["cancel"])
 			cancel_swipe()

--- a/code/game/machinery/computer/labor.dm
+++ b/code/game/machinery/computer/labor.dm
@@ -61,7 +61,7 @@ var/list/labor_console_categories = list(
 		else if(toggling_priority != "")
 			dat += "<b>[job_master.IsJobPrioritized(toggling_priority) ? "Deprioritizing" : "Prioritizing"]</b> <div class='line'>[uppertext(toggling_priority)]</div> Job Slot"
 			if(!job_master.IsJobPrioritized(toggling_priority))
-				dat += "<br><A href='?src=\ref[src];reason=1'>Write Justification</A>"
+				dat += "<br><br><A href='?src=\ref[src];reason=1'>Write Justification</A>"
 		dat += "<br><br><A href='?src=\ref[src];cancel=1'>CANCEL</A>"
 		if(isAdminGhost(user))
 			dat += "<br><br><div class='line'>...or...</div><A href='?src=\ref[src];adminhax=1'>CHEEKY ADMINGHOST-ONLY CARD BYPASS BUTTON</A>"
@@ -217,7 +217,7 @@ var/list/labor_console_categories = list(
 			verified(usr, FALSE)
 
 		else if(href_list["reason"])
-			justification = input(src,"Enter a reason for justifying job priorities","Priority justification","") as text
+			justification = input(usr,"Enter a reason for justifying job priorities","Priority justification","") as text
 
 		else if(href_list["cancel"])
 			cancel_swipe()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -572,6 +572,8 @@
 
 			dat += "<tr[color ? " class='reqalt'" : " class='request'"]><td><a href='byond://?src=\ref[src];SelectedJob=[job.title]'>[job.title]</a></td><td>[job.current_positions]</td><td>[highprior[job]]</td></tr>"
 			color = !color
+		if(job_master.priority_justification != "")
+			dat += "<tr><th class='reqhead' colspan=3>Justification: [job_master.priority_justification]</th></tr>"
 	else
 		dat += "<tr><th class='reqhead' colspan=3><a style='color:white' href='byond://?src=\ref[src];RequestPrio=1'>Request High Priority Jobs</a></th></tr>"
 


### PR DESCRIPTION
[content]

## What this does
adds this as an input field to labor administration consoles.
shows up under high priority jobs for latejoiners
Closes #21657.

## Why it's good
more context to *why* these jobs are needed

## How it was tested
setting it on the console, swiping card, setting ckey to null to log out before and after

## Changelog
:cl:
 * rscadd: Labor administration consoles can now set a reason for prioritising a job. This will show up to latejoining players if not blank.