### PR TITLE
Allows variables and procs to accept variables of other datums and proc call returns

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -179,7 +179,7 @@ var/list/admin_verbs_debug = list(
 	/client/proc/reload_admins,
 	/client/proc/restart_controller,
 	/client/proc/enable_debug_verbs,
-	/client/proc/callproc,
+	/client/proc/calladvproc,
 	/client/proc/cmd_admin_dump_machine_type_list, // /vg/
 	/client/proc/disable_bloodvirii,       // /vg
 	/client/proc/reload_style_sheet,
@@ -281,7 +281,7 @@ var/list/admin_verbs_hideable = list(
 	/datum/admins/proc/adjump,
 	/client/proc/restart_controller,
 	/client/proc/cmd_admin_list_open_jobs,
-	/client/proc/callproc,
+	/client/proc/calladvproc,
 	/client/proc/Debug2,
 	/client/proc/reload_admins,
 	/client/proc/cmd_debug_make_powernets,

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -49,14 +49,13 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 			if(class == "Client")
 				for(var/client/C in clients)
 					stufftocall += C
+			else if(class == "Mob")
+				stufftocall = mob_list
 			else
 				for(var/atom/A in world)
 					switch(class)
 						if("Obj")
 							if(isobj(A))
-								stufftocall += A
-						if("Mob")
-							if(ismob(A))
 								stufftocall += A
 						if("Area or Turf")
 							if(isarea(A) || isturf(A))

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -139,7 +139,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		if(!L.len)
 			returntext = "\[Empty list\]"
 		else
-			returntext = "<a href='?_src_=vars;List=\ref[.]'>\[List\]</A>"
+			returntext = "<a href='?_src_=vars;List=\ref[.]'>[json_encode(L)]</A>"
 			spawn(PROC_RESULT_KEEP_TIME)
 				. = null
 	to_chat(user, "<span class='notice'>[procname] returned: [returntext]</span>")

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -81,7 +81,6 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 
 	var/lst[] // List reference
 	lst = new/list() // Make the list
-	var/returnval = null
 	var/targetselected = !isnull(target)
 
 	var/procname = input("Proc path, eg: /proc/fake_blood","Path:", null) as text|null
@@ -118,27 +117,26 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 			return
 
 		log_admin("[key_name(src)] called [target]'s [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"].")
-		returnval = call(target,procname)(arglist(lst)) // Pass the lst as an argument list to the proc
+		. = call(target,procname)(arglist(lst)) // Pass the lst as an argument list to the proc
 	else
 		//this currently has no hascall protection. wasn't able to get it working.
 		log_admin("[key_name(src)] called [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"].")
-		returnval = call(procname)(arglist(lst)) // Pass the lst as an argument list to the proc
+		. = call(procname)(arglist(lst)) // Pass the lst as an argument list to the proc
 
-	var/returntext = returnval
-	if(isnull(returnval))
+	var/returntext = .
+	if(isnull(.))
 		returntext = "null"
-	else if(returnval == "")
+	else if(. == "")
 		returntext = "\"\" (empty string)"
-	else if(isdatum(returnval))
-		returntext = "[returnval] <a href='?_src_=vars;Vars=\ref[returnval]'>\[VV\]</A>"
+	else if(isdatum(.))
+		returntext = "[.] <a href='?_src_=vars;Vars=\ref[.]'>\[VV\]</A>"
 		spawn(PROC_RESULT_KEEP_TIME)
-			returnval = null
-	else if(islist(returnval))
-		returntext = "<a href='?_src_=vars;List=\ref[returnval]'>\[List\]</A>"
+			. = null
+	else if(islist(.))
+		returntext = "<a href='?_src_=vars;List=\ref[.]'>\[List\]</A>"
 		spawn(PROC_RESULT_KEEP_TIME)
-			returnval = null
+			. = null
 	to_chat(user, "<span class='notice'>[procname] returned: [returntext]</span>")
-	return returnval
 
 /client/proc/Cell()
 	set category = "Debug"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -36,83 +36,82 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	if(!check_rights(R_DEBUG))
 		return
 
-	spawn(0)
-		var/target = null
-		var/targetselected = 0
-		var/lst[] // List reference
-		lst = new/list() // Make the list
-		var/returnval = null
-		var/class = null
+	var/target = null
+	var/targetselected = 0
+	var/lst[] // List reference
+	lst = new/list() // Make the list
+	var/returnval = null
+	var/class = null
 
-		switch(alert("Proc owned by something?",,"Yes","No"))
-			if("Yes")
-				targetselected = 1
-				class = input("Proc owned by...","Owner",null) as null|anything in list("Obj","Mob","Area or Turf","Client")
-				switch(class)
-					if("Obj")
-						target = input("Enter target:","Target",usr) as obj in world
-					if("Mob")
-						target = input("Enter target:","Target",usr) as mob in world
-					if("Area or Turf")
-						target = input("Enter target:","Target",usr.loc) as area|turf in world
-					if("Client")
-						var/list/keys = list()
-						for(var/client/C)
-							keys += C
-						target = input("Please, select a player!", "Selection", null, null) as null|anything in keys
-					else
-						return
-			if("No")
-				target = null
-				targetselected = 0
+	switch(alert("Proc owned by something?",,"Yes","No"))
+		if("Yes")
+			targetselected = 1
+			class = input("Proc owned by...","Owner",null) as null|anything in list("Obj","Mob","Area or Turf","Client")
+			switch(class)
+				if("Obj")
+					target = input("Enter target:","Target",usr) as obj in world
+				if("Mob")
+					target = input("Enter target:","Target",usr) as mob in world
+				if("Area or Turf")
+					target = input("Enter target:","Target",usr.loc) as area|turf in world
+				if("Client")
+					var/list/keys = list()
+					for(var/client/C)
+						keys += C
+					target = input("Please, select a player!", "Selection", null, null) as null|anything in keys
+				else
+					return
+		if("No")
+			target = null
+			targetselected = 0
 
-		var/procname = input("Proc path, eg: /proc/fake_blood","Path:", null) as text|null
-		if(!procname)
+	var/procname = input("Proc path, eg: /proc/fake_blood","Path:", null) as text|null
+	if(!procname)
+		return
+
+	// Do not make this a global reference. Global references can be cleared out.
+	if (istype(target, /datum/subsystem/dbcore/))
+		to_chat(usr, "<span class='red'>Never use atom proc call to inject SQL.</span>")
+		message_admins("[key_name(usr)] used atom proc call on the db controller.")
+		log_admin("[key_name(usr)] used atom proc call on the db controller.")
+		return
+
+	if(target && !hascall(target, procname))
+		to_chat(usr, "<span class='red'>Error: callproc(): target has no such call [procname].</span>")
+		return
+
+	var/argnum = input("Number of arguments","Number:",0) as num|null
+	if(!argnum && (argnum!=0))
+		return
+
+	lst.len = argnum // Expand to right length
+	//TODO: make a list to store whether each argument was initialised as null.
+	//Reason: So we can abort the proccall if say, one of our arguments was a mob which no longer exists
+	//this will protect us from a fair few errors ~Carn
+
+	var/i
+	for(i = 1, i < argnum + 1, i++) // Lists indexed from 1 forwards in byond
+		lst[i] = variable_set(src)
+
+	if(targetselected)
+		if(!target)
+			to_chat(usr, "<span class='red'>Error: callproc(): owner of proc no longer exists.</span>")
 			return
 
-		// Do not make this a global reference. Global references can be cleared out.
-		if (istype(target, /datum/subsystem/dbcore/))
-			to_chat(usr, "<span class='red'>Never use atom proc call to inject SQL.</span>")
-			message_admins("[key_name(usr)] used atom proc call on the db controller.")
-			log_admin("[key_name(usr)] used atom proc call on the db controller.")
-			return
+		log_admin("[key_name(src)] called [target]'s [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"].")
+		returnval = call(target,procname)(arglist(lst)) // Pass the lst as an argument list to the proc
+	else
+		//this currently has no hascall protection. wasn't able to get it working.
+		log_admin("[key_name(src)] called [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"].")
+		returnval = call(procname)(arglist(lst)) // Pass the lst as an argument list to the proc
 
-		if(target && !hascall(target, procname))
-			to_chat(usr, "<span class='red'>Error: callproc(): target has no such call [procname].</span>")
-			return
-
-		var/argnum = input("Number of arguments","Number:",0) as num|null
-		if(!argnum && (argnum!=0))
-			return
-
-		lst.len = argnum // Expand to right length
-		//TODO: make a list to store whether each argument was initialised as null.
-		//Reason: So we can abort the proccall if say, one of our arguments was a mob which no longer exists
-		//this will protect us from a fair few errors ~Carn
-
-		var/i
-		for(i = 1, i < argnum + 1, i++) // Lists indexed from 1 forwards in byond
-			lst[i] = variable_set(src)
-
-		if(targetselected)
-			if(!target)
-				to_chat(usr, "<span class='red'>Error: callproc(): owner of proc no longer exists.</span>")
-				return
-
-			log_admin("[key_name(src)] called [target]'s [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"].")
-			returnval = call(target,procname)(arglist(lst)) // Pass the lst as an argument list to the proc
-		else
-			//this currently has no hascall protection. wasn't able to get it working.
-			log_admin("[key_name(src)] called [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"].")
-			returnval = call(procname)(arglist(lst)) // Pass the lst as an argument list to the proc
-
-		. = returnval // let's grab it here before it gets processed below
-		if(isnull(returnval))
-			returnval = "null"
-		else if(returnval == "")
-			returnval = "\"\" (empty string)"
-		to_chat(usr, "<span class='notice'>[procname] returned: [returnval]</span>")
-		feedback_add_details("admin_verb","APC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	. = returnval // let's grab it here before it gets processed below
+	if(isnull(returnval))
+		returnval = "null"
+	else if(returnval == "")
+		returnval = "\"\" (empty string)"
+	to_chat(usr, "<span class='notice'>[procname] returned: [returnval]</span>")
+	feedback_add_details("admin_verb","APC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/callatomproc(var/datum/target as anything)
 	set category = "Debug"
@@ -121,52 +120,51 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	if(!check_rights(R_DEBUG))
 		return
 
-	spawn(0)
-		var/lst[] // List reference
-		lst = new/list() // Make the list
-		var/returnval = null
+	var/lst[] // List reference
+	lst = new/list() // Make the list
+	var/returnval = null
 
-		var/procname = input("Proc path, eg: /proc/fake_blood","Path:", null) as text|null
-		if(!procname)
-			return
+	var/procname = input("Proc path, eg: /proc/fake_blood","Path:", null) as text|null
+	if(!procname)
+		return
 
-		if(!hascall(target, procname))
-			to_chat(usr, "<span class='red'>Error: callatomproc(): target has no such call [procname].</span>")
-			return
+	if(!hascall(target, procname))
+		to_chat(usr, "<span class='red'>Error: callatomproc(): target has no such call [procname].</span>")
+		return
 
-		var/argnum = input("Number of arguments","Number:",0) as num|null
-		if(!argnum && (argnum!=0))
-			return
+	var/argnum = input("Number of arguments","Number:",0) as num|null
+	if(!argnum && (argnum!=0))
+		return
 
-		lst.len = argnum // Expand to right length
-		//TODO: make a list to store whether each argument was initialised as null.
-		//Reason: So we can abort the proccall if say, one of our arguments was a mob which no longer exists
-		//this will protect us from a fair few errors ~Carn
+	lst.len = argnum // Expand to right length
+	//TODO: make a list to store whether each argument was initialised as null.
+	//Reason: So we can abort the proccall if say, one of our arguments was a mob which no longer exists
+	//this will protect us from a fair few errors ~Carn
 
-		var/i
-		for(i = 1, i < argnum + 1, i++) // Lists indexed from 1 forwards in byond
-			lst[i] = variable_set(src)
+	var/i
+	for(i = 1, i < argnum + 1, i++) // Lists indexed from 1 forwards in byond
+		lst[i] = variable_set(src)
 
-		log_admin("[key_name(src)] called [target]'s [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"].")
-		returnval = call(target,procname)(arglist(lst)) // Pass the lst as an argument list to the proc
+	log_admin("[key_name(src)] called [target]'s [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"].")
+	returnval = call(target,procname)(arglist(lst)) // Pass the lst as an argument list to the proc
 
-		if(isnull(returnval))
-			returnval = "null"
-		else if(returnval == "")
-			returnval = "\"\" (empty string)"
+	if(isnull(returnval))
+		returnval = "null"
+	else if(returnval == "")
+		returnval = "\"\" (empty string)"
 
-		var/returntext = returnval
-		if(istype(returnval, /datum))
-			returntext = "[returnval] <a href='?_src_=vars;Vars=\ref[returnval]'>\[VV\]</A>"
-			spawn(PROC_RESULT_KEEP_TIME)
-				returnval = null
-		else if(istype(returnval, /list))
-			returntext = "<a href='?_src_=vars;List=\ref[returnval]'>\[List\]</A>"
-			spawn(PROC_RESULT_KEEP_TIME)
-				returnval = null
+	var/returntext = returnval
+	if(istype(returnval, /datum))
+		returntext = "[returnval] <a href='?_src_=vars;Vars=\ref[returnval]'>\[VV\]</A>"
+		spawn(PROC_RESULT_KEEP_TIME)
+			returnval = null
+	else if(istype(returnval, /list))
+		returntext = "<a href='?_src_=vars;List=\ref[returnval]'>\[List\]</A>"
+		spawn(PROC_RESULT_KEEP_TIME)
+			returnval = null
 
-		to_chat(usr, "<span class='notice'>[procname] returned: [returntext]</span>")
-		feedback_add_details("admin_verb","APC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	to_chat(usr, "<span class='notice'>[procname] returned: [returntext]</span>")
+	feedback_add_details("admin_verb","APC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/Cell()
 	set category = "Debug"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -61,6 +61,8 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 							stufftocall += A
 					IN_ROUND_CHECK_TICK //bam. now it doesn't freeze the game anymore
 			target = input("Enter target", "Target:", class == "Area or Turf" ? usr.loc : usr, null) as null|anything in stufftocall
+			if(!target)
+				return
 
 	callproc(usr,target)
 	feedback_add_details("admin_verb","APC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -109,8 +109,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	//Reason: So we can abort the proccall if say, one of our arguments was a mob which no longer exists
 	//this will protect us from a fair few errors ~Carn
 
-	var/i
-	for(i = 1, i < argnum + 1, i++) // Lists indexed from 1 forwards in byond
+	for(var/i = 1, i < argnum + 1, i++)
 		lst[i] = variable_set(src)
 
 	if(targetselected)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -129,15 +129,15 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		returntext = "null"
 	else if(returnval == "")
 		returntext = "\"\" (empty string)"
-	if(istype(returnval, /datum))
+	else if(isdatum(returnval))
 		returntext = "[returnval] <a href='?_src_=vars;Vars=\ref[returnval]'>\[VV\]</A>"
 		spawn(PROC_RESULT_KEEP_TIME)
 			returnval = null
-	else if(istype(returnval, /list))
+	else if(islist(returnval))
 		returntext = "<a href='?_src_=vars;List=\ref[returnval]'>\[List\]</A>"
 		spawn(PROC_RESULT_KEEP_TIME)
 			returnval = null
-	to_chat(user, "<span class='notice'>[procname] returned: [returnval]</span>")
+	to_chat(user, "<span class='notice'>[procname] returned: [returntext]</span>")
 	return returnval
 
 /client/proc/Cell()

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -42,20 +42,22 @@ now actually filters to a type, redundant procs cut down
 	var/class = null
 
 	if(alert("Proc owned by something?","Proc call","Yes","No") == "Yes")
-		class = input("Proc owned by what type of atom? (eg. /obj/machinery)","Owner",null) as text
-		if(!class)
-			return
-		class = filter_typelist_input("Select an atom type", "Spawn Atom", get_matching_types(class, /atom))
-		
+		class = input("Proc owned by...","Owner",null) as null|anything in list("Atom","Client")
 		var/list/stufftocall = list()
-		if(class == "/client")
-			stufftocall = clients
-		else
-			for(var/atom/A in world)
-				if(istype(A,class))
-					stufftocall |= A
-				IN_ROUND_CHECK_TICK //bam. now it doesn't freeze the game anymore
+		switch(class)
+			if("Client")
+				stufftocall = clients
+			if("Atom")
+				class = input("Proc owned by what type of atom? (eg. /obj/machinery)","Owner",null) as text
+				if(!class)
+					return
+				class = filter_typelist_input("Select an atom type", "Spawn Atom", get_matching_types(class, /atom))
+				for(var/atom/A in world)
+					if(istype(A,class))
+						stufftocall["[A] ([ref(A)])"] = A
+					IN_ROUND_CHECK_TICK //bam. now it doesn't freeze the game anymore
 		target = input("Enter target", "Target:", ispath(class,/area) || ispath(class,/turf) ? usr.loc : usr, null) as null|anything in stufftocall
+		target = stufftocall[target]
 		if(!target)
 			return
 
@@ -92,7 +94,7 @@ now actually filters to a type, redundant procs cut down
 		return
 
 	if(target && !hascall(target, procname))
-		to_chat(user, "<span class='red'>Error: calladvproc(): target has no such call [procname].</span>")
+		to_chat(user, "<span class='red'>Error: calladvproc(): target [target] has no such call [procname].</span>")
 		return
 
 	var/argnum = input("Number of arguments","Number:",0) as num|null

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -106,6 +106,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 			log_admin("[key_name(src)] called [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"].")
 			returnval = call(procname)(arglist(lst)) // Pass the lst as an argument list to the proc
 
+		. = returnval // let's grab it here before it gets processed below
 		if(isnull(returnval))
 			returnval = "null"
 		else if(returnval == "")

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -53,13 +53,12 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 				stufftocall = mob_list
 			else
 				for(var/atom/A in world)
-					switch(class)
-						if("Obj")
-							if(isobj(A))
-								stufftocall += A
-						if("Area or Turf")
-							if(isarea(A) || isturf(A))
-								stufftocall += A
+					if(class == "Obj")
+						if(isobj(A))
+							stufftocall += A
+					else if(class == "Area or Turf")
+						if(isarea(A) || isturf(A))
+							stufftocall += A
 					IN_ROUND_CHECK_TICK //bam. now it doesn't freeze the game anymore
 			target = input("Enter target", "Target:", class == "Area or Turf" ? usr.loc : usr, null) as null|anything in stufftocall
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -133,9 +133,13 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		spawn(PROC_RESULT_KEEP_TIME)
 			. = null
 	else if(islist(.))
-		returntext = "<a href='?_src_=vars;List=\ref[.]'>\[List\]</A>"
-		spawn(PROC_RESULT_KEEP_TIME)
-			. = null
+		var/list/L = .
+		if(!L.len)
+			returntext = "\[Empty list\]"
+		else
+			returntext = "<a href='?_src_=vars;List=\ref[.]'>\[List\]</A>"
+			spawn(PROC_RESULT_KEEP_TIME)
+				. = null
 	to_chat(user, "<span class='notice'>[procname] returned: [returntext]</span>")
 
 /client/proc/Cell()

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -237,13 +237,18 @@ var/list/forbidden_varedit_object_types = list(
 		return var_inside_list_helper(new_value)
 	else if(isdatum(new_value))
 		return var_inside_datum_helper(new_value)
+	return new_value
 
 /proc/var_inside_list_helper(new_value) // so it can go recursively
 	if(islist(new_value))
-		if(alert(usr, "This appears to be a list, use a var in this?","Variable inside list","No","Yes") == "Yes")
-			var/list/L = new_value
-			new_value = input("Select item in list:", "Varedit list") in L
-			return var_inside_detect_helper(new_value)
+		var/list/L = new_value
+		if(L.len)
+			if(alert(usr, "This appears to be a populated list, use a var in this?","Variable inside list","No","Yes") == "Yes")
+				new_value = input("Select item in list:", "Varedit list") in L
+				if(L[new_value])
+					if(alert(usr, "This has an associated value of [L[new_value]], use it?","Associated list variable","No","Yes") == "Yes")
+						new_value = L[new_value]
+				return var_inside_detect_helper(new_value)
 	return new_value
 
 /proc/var_inside_datum_helper(new_value) // so it can go recursively

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -245,9 +245,9 @@ var/list/forbidden_varedit_object_types = list(
 		if(L.len)
 			if(alert(usr, "This appears to be a populated list, use a var in this?","Variable inside list","No","Yes") == "Yes")
 				new_value = input("Select item in list:", "Varedit list") in L
-				if((new_value in L) && L[new_value])
+				/*if((new_value in L) && L[new_value])
 					if(alert(usr, "This has an associated value of [L[new_value]], use it?","Associated list variable","No","Yes") == "Yes")
-						new_value = L[new_value]
+						new_value = L[new_value]*/ // sadly no associated lists today because BYOND is weird about this
 				return var_inside_detect_helper(new_value)
 	return new_value
 

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -55,6 +55,7 @@ var/list/forbidden_varedit_object_types = list(
 	#define V_LIST_EMPTY "empty_list"
 	#define V_LIST "list"
 	#define V_OBJECT "object"
+	#define V_OBJECT_VAR "object_variable"
 	#define V_ICON "icon"
 	#define V_FILE "file"
 	#define V_CLIENT "client"
@@ -115,6 +116,7 @@ var/list/forbidden_varedit_object_types = list(
 		"empty list"      = V_LIST_EMPTY,
 		"list"  = V_LIST,
 		"object (nearby)" = V_OBJECT,
+		"object var (nearby)" = V_OBJECT_VAR,
 		"icon"   = V_ICON,
 		"file"   = V_FILE,
 		"client" = V_CLIENT,
@@ -176,6 +178,13 @@ var/list/forbidden_varedit_object_types = list(
 			if(V_OBJECT)
 				new_value = input("Select reference:", window_title, old_value) as mob|obj|turf|area in range(8, get_turf(user))
 
+			if(V_OBJECT_VAR)
+				var/atom/A = input("Select reference:", window_title, old_value) as mob|obj|turf|area in range(8, get_turf(user))
+				if(istype(A))
+					new_value = A.vars[input("Select variable:", window_title, old_value) in A.vars]
+					if(isdatum(new_value))
+						new_value = var_inside_datum_helper(new_value)
+
 			if(V_FILE)
 				new_value = input("Pick file:", window_title) as file
 
@@ -219,6 +228,15 @@ var/list/forbidden_varedit_object_types = list(
 		if(logging)
 			log_admin("[key_name(usr)] modified [edited_datum]'s [edited_variable] to [html_encode(new_value)]")
 
+	return new_value
+
+/proc/var_inside_datum_helper(new_value,window_title,old_value) // so it can go recursively
+	if(isdatum(new_value))
+		if(alert(usr, "This appears to be a datum, use a var in this?","Variable inside datum","No","Yes") == "Yes")
+			var/datum/D = new_value
+			new_value = D.vars[input("Select variable:", window_title, old_value) in D.vars]
+			if(isdatum(new_value))
+				return var_inside_datum_helper(new_value,window_title,old_value)
 	return new_value
 
 	#undef V_MARKED_DATUM

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -248,9 +248,9 @@ var/list/forbidden_varedit_object_types = list(
 
 /proc/var_inside_datum_helper(new_value) // so it can go recursively
 	if(isdatum(new_value))
+		var/datum/D = new_value
 		if(alert(usr, "This appears to be a datum, use a var in this?","Variable inside [D]","No","Yes") == "Yes")
-			var/datum/D = new_value
-			new_value = D.vars[input("Select variable:", "Varedit [D]", old_value) in D.vars]
+			new_value = D.vars[input("Select variable:", "Varedit [D]") in D.vars]
 			return var_inside_detect_helper(new_value)
 	return new_value
 

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -182,6 +182,9 @@ var/list/forbidden_varedit_object_types = list(
 				var/atom/A = input("Select reference:", window_title, old_value) as mob|obj|turf|area in range(8, get_turf(user))
 				if(istype(A))
 					new_value = A.vars[input("Select variable:", window_title, old_value) in A.vars]
+					if(istype(new_value,/datum/weakref))
+						var/datum/weakref/W = new_value
+						new_value = W.get()
 					if(isdatum(new_value))
 						new_value = var_inside_datum_helper(new_value)
 

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -124,7 +124,7 @@ var/list/forbidden_varedit_object_types = list(
 		"matrix" = V_MATRIX,
 		"null"   = V_NULL,
 		)
-		if(C.check_rights(R_DEBUG))
+		if(usr.check_rights(R_DEBUG))
 			choices += list("proc call" = V_PROC)
 
 		if (!acceptsLists)

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -62,6 +62,7 @@ var/list/forbidden_varedit_object_types = list(
 	#define V_NULL "null"
 	#define V_CANCEL "cancel"
 	#define V_MATRIX "matrix"
+	#define V_PROC "proc_call"
 
 	var/new_variable_type
 	var/old_value = null //Old value of the variable
@@ -123,6 +124,8 @@ var/list/forbidden_varedit_object_types = list(
 		"matrix" = V_MATRIX,
 		"null"   = V_NULL,
 		)
+		if(C.check_rights(R_DEBUG))
+			choices += list("proc call" = V_PROC)
 
 		if (!acceptsLists)
 			choices -= V_LIST
@@ -213,6 +216,10 @@ var/list/forbidden_varedit_object_types = list(
 
 			if(V_MATRIX)
 				new_value = matrix()
+
+			if(V_PROC)
+				if(C)
+					new_value = C.callproc()
 
 			else
 				to_chat(user, "Unknown type: [selected_type]")

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -245,7 +245,7 @@ var/list/forbidden_varedit_object_types = list(
 		if(L.len)
 			if(alert(usr, "This appears to be a populated list, use a var in this?","Variable inside list","No","Yes") == "Yes")
 				new_value = input("Select item in list:", "Varedit list") in L
-				if(L[new_value])
+				if((new_value in L) && L[new_value])
 					if(alert(usr, "This has an associated value of [L[new_value]], use it?","Associated list variable","No","Yes") == "Yes")
 						new_value = L[new_value]
 				return var_inside_detect_helper(new_value)

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -238,7 +238,7 @@ var/list/forbidden_varedit_object_types = list(
 	else if(isdatum(new_value))
 		return var_inside_datum_helper(new_value)
 
-/proc/var_inside_list_helper(new_value,old_value) // so it can go recursively
+/proc/var_inside_list_helper(new_value) // so it can go recursively
 	if(islist(new_value))
 		if(alert(usr, "This appears to be a list, use a var in this?","Variable inside list","No","Yes") == "Yes")
 			var/list/L = new_value
@@ -246,7 +246,7 @@ var/list/forbidden_varedit_object_types = list(
 			return var_inside_detect_helper(new_value)
 	return new_value
 
-/proc/var_inside_datum_helper(new_value,old_value) // so it can go recursively
+/proc/var_inside_datum_helper(new_value) // so it can go recursively
 	if(isdatum(new_value))
 		if(alert(usr, "This appears to be a datum, use a var in this?","Variable inside [D]","No","Yes") == "Yes")
 			var/datum/D = new_value

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -182,7 +182,7 @@ var/list/forbidden_varedit_object_types = list(
 				var/atom/A = input("Select reference:", window_title, old_value) as mob|obj|turf|area in range(8, get_turf(user))
 				if(istype(A))
 					new_value = A.vars[input("Select variable:", window_title, old_value) in A.vars]
-					new_value = var_inside_detect_helper(new_value,window_title,old_value)
+					new_value = var_inside_detect_helper(new_value)
 
 			if(V_FILE)
 				new_value = input("Pick file:", window_title) as file
@@ -229,29 +229,29 @@ var/list/forbidden_varedit_object_types = list(
 
 	return new_value
 
-/proc/var_inside_detect_helper(new_value,window_title,old_value)
+/proc/var_inside_detect_helper(new_value)
 	if(istype(new_value,/datum/weakref))
 		var/datum/weakref/W = new_value
 		new_value = W.get()
 	if(islist(new_value))
-		return var_inside_list_helper(new_value,window_title,old_value)
+		return var_inside_list_helper(new_value)
 	else if(isdatum(new_value))
-		return var_inside_datum_helper(new_value,window_title,old_value)
+		return var_inside_datum_helper(new_value)
 
-/proc/var_inside_list_helper(new_value,window_title,old_value) // so it can go recursively
+/proc/var_inside_list_helper(new_value,old_value) // so it can go recursively
 	if(islist(new_value))
 		if(alert(usr, "This appears to be a list, use a var in this?","Variable inside list","No","Yes") == "Yes")
 			var/list/L = new_value
-			new_value = input("Select item in list:", window_title, old_value) in L
-			return var_inside_detect_helper(new_value,window_title,old_value)
+			new_value = input("Select item in list:", "Varedit list") in L
+			return var_inside_detect_helper(new_value)
 	return new_value
 
-/proc/var_inside_datum_helper(new_value,window_title,old_value) // so it can go recursively
+/proc/var_inside_datum_helper(new_value,old_value) // so it can go recursively
 	if(isdatum(new_value))
-		if(alert(usr, "This appears to be a datum, use a var in this?","Variable inside datum","No","Yes") == "Yes")
+		if(alert(usr, "This appears to be a datum, use a var in this?","Variable inside [D]","No","Yes") == "Yes")
 			var/datum/D = new_value
-			new_value = D.vars[input("Select variable:", window_title, old_value) in D.vars]
-			return var_inside_detect_helper(new_value,window_title,old_value)
+			new_value = D.vars[input("Select variable:", "Varedit [D]", old_value) in D.vars]
+			return var_inside_detect_helper(new_value)
 	return new_value
 
 	#undef V_MARKED_DATUM

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -219,7 +219,7 @@ var/list/forbidden_varedit_object_types = list(
 
 			if(V_PROC)
 				if(C)
-					new_value = C.callproc()
+					new_value = C.calladvproc()
 
 			else
 				to_chat(user, "Unknown type: [selected_type]")


### PR DESCRIPTION
[administration]

## What this does
allows this on variable setting and proc call arguments
accepts vars from atoms nearby
if var is a datum or list, prompts the player if they want a var inside that or just the thing itself. this can be recursive
weakref datums automatically resolve the targeted thing for this
code cutdown and consistency for atom proccall and advanced proccall verbs
also makes them accept proc calls if the caller has debug flags on

## Why it's good
even more customisation for these (for example, lets admins swap the seed datum of a plant without marking datums)

## How it was tested
calling say() on the player with the value of the player's real_name var, and then with on the item name of the ID inside their PDA as accessed via contents lists
advanced proc call prune_list_to_type() with arguments of the player's backpack and type of /obj/item/weapon/storage

## Changelog
:cl:
 * rscadd: Admins can now set variables and call procs based on variables inside atoms nearby, with the option for variables inside their datums or lists recursively. Note that with procguns and procizine that this will use the variable as-is from the time this was set.
 * rscadd: Admins can now set variables to called procs, if they have debug rights.
 * tweak: Empty lists from proc call returns now no longer link to a list, just displaying [Empty list] instead, to disambiguate from first glance.
 * tweak: Lists from proc call returns now also display the contents of the list in the output chat message, using json_encode()
 * bugfix: Datums and lists are now properly formatted in the text output of advanced proccall debugs.