### PR TITLE
Adds Confirmation to Reload Admins Verb

### DIFF
--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -75,7 +75,9 @@
 
 	if(!check_rights(R_SERVER))
 		return
-
+	if(alert("Reload admins? Note: currently playing admins may not like this.","Reload Admins","Yes","No") != "Yes")
+		//dear future coders yes i am mad right now
+		return
 	message_admins("[usr] manually reloaded admins")
 	load_admins()
 	feedback_add_details("admin_verb","RLDA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!


### PR DESCRIPTION
## What this does
Adds a confirmation button before using reload admins, so that admins won't accidently re-admin playing admins when attempting to push the spawn verb.
![image](https://github.com/user-attachments/assets/f2037b9f-0b74-4438-86ea-1a4dafe539f1)

## Why it's good
Since it's funny when an admin has to delete themselves because they got to see too much info when another admin accidently pushed this button, it's not.

## How it was tested
Local server, pushed the button, confirmed functionality of both Yes and No answers.