### PR TITLE
Fixes timer assemblies not repeating

### DIFF
--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -68,6 +68,9 @@
 				timing = 0
 			timer_end()
 			time = default_time
+			if(repeat)
+				spawn()
+					countdown()
 		updateUsrDialog()
 
 /obj/item/device/assembly/timer/update_icon()


### PR DESCRIPTION
[bugfix]

## What this does
Closes #37230.

## How it was tested
timing down with repeat on and then off

## Changelog
:cl:
 * bugfix: Timer assemblies now repeat properly again, if set to.