### PR TITLE
Buffs H.U.E.Y upgrades (plus advanced mk2 weedkill one)

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -339,7 +339,7 @@
 		return FAILED_TO_ADD
 
 	G.can_hold.Add(/obj/item/seeds, /obj/item/weapon/disk/botany)
-	G.valid_containers.Add(/obj/item/weapon/storage/lockbox/diskettebox/open/botanydisk,/obj/item/weapon/storage/lockbox/diskettebox/open/large/botanydisk)
+	G.valid_containers.Add(/obj/item/weapon/storage/lockbox/diskettebox/open/botanydisk,/obj/item/weapon/storage/lockbox/diskettebox/large/open/botanydisk)
 
 /obj/item/borg/upgrade/hydro_adv
 	name = "service cyborg H.U.E.Y. MK-2 upgrade board"

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -316,7 +316,7 @@
 //Service Stuff
 /obj/item/borg/upgrade/hydro
 	name = "service cyborg H.U.E.Y. upgrade board"
-	desc = "Used to give a service cyborg hydroponics tools and upgrade their service gripper to be able to handle seeds and glass containers."
+	desc = "Used to give a service cyborg hydroponics tools and upgrade their service gripper to be able to handle seeds and diskettes."
 	icon_state = "mainboard"
 	required_modules = list(SERVICE_MODULE)
 	modules_to_add = list(
@@ -325,7 +325,10 @@
 		/obj/item/weapon/pickaxe/shovel/spade,
 		/obj/item/tool/wirecutters/clippers,
 		/obj/item/weapon/storage/bag/plants/portactor,
-		/obj/item/device/analyzer/plant_analyzer)
+		/obj/item/device/analyzer/plant_analyzer,
+		/obj/item/weapon/reagent_containers/glass/bottle/robot/water,
+		/obj/item/weapon/reagent_containers/glass/bottle/robot/eznutrient
+		)
 
 /obj/item/borg/upgrade/hydro/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
 	if(..())

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -319,7 +319,13 @@
 	desc = "Used to give a service cyborg hydroponics tools and upgrade their service gripper to be able to handle seeds and glass containers."
 	icon_state = "mainboard"
 	required_modules = list(SERVICE_MODULE)
-	modules_to_add = list(/obj/item/weapon/minihoe, /obj/item/tool/wirecutters/clippers, /obj/item/weapon/storage/bag/plants/portactor, /obj/item/device/analyzer/plant_analyzer)
+	modules_to_add = list(
+		/obj/item/weapon/minihoe,
+		/obj/item/weapon/hatchet,
+		/obj/item/weapon/pickaxe/shovel/spade,
+		/obj/item/tool/wirecutters/clippers,
+		/obj/item/weapon/storage/bag/plants/portactor,
+		/obj/item/device/analyzer/plant_analyzer)
 
 /obj/item/borg/upgrade/hydro/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
 	if(..())

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -339,6 +339,7 @@
 		return FAILED_TO_ADD
 
 	G.can_hold.Add(/obj/item/seeds, /obj/item/weapon/disk/botany)
+	G.valid_containers.Add(/obj/item/weapon/storage/lockbox/diskettebox/open/botanydisk,/obj/item/weapon/storage/lockbox/diskettebox/open/large/botanydisk)
 
 /obj/item/borg/upgrade/hydro_adv
 	name = "service cyborg H.U.E.Y. MK-2 upgrade board"

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -327,8 +327,7 @@
 		/obj/item/weapon/storage/bag/plants/portactor,
 		/obj/item/device/analyzer/plant_analyzer,
 		/obj/item/weapon/reagent_containers/glass/bottle/robot/water,
-		/obj/item/weapon/reagent_containers/glass/bottle/robot/eznutrient,
-		/obj/item/weapon/reagent_containers/glass/bottle/robot/insecticide
+		/obj/item/weapon/reagent_containers/glass/bottle/robot/eznutrient
 		)
 
 /obj/item/borg/upgrade/hydro/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -327,7 +327,8 @@
 		/obj/item/weapon/storage/bag/plants/portactor,
 		/obj/item/device/analyzer/plant_analyzer,
 		/obj/item/weapon/reagent_containers/glass/bottle/robot/water,
-		/obj/item/weapon/reagent_containers/glass/bottle/robot/eznutrient
+		/obj/item/weapon/reagent_containers/glass/bottle/robot/eznutrient,
+		/obj/item/weapon/reagent_containers/glass/bottle/robot/insecticide
 		)
 
 /obj/item/borg/upgrade/hydro/attempt_action(var/mob/living/silicon/robot/R,var/mob/living/user)
@@ -339,6 +340,18 @@
 		return FAILED_TO_ADD
 
 	G.can_hold.Add(/obj/item/seeds, /obj/item/weapon/disk/botany)
+
+/obj/item/borg/upgrade/hydro_adv
+	name = "service cyborg H.U.E.Y. MK-2 upgrade board"
+	desc = "Used to give a service cyborg more hydroponics tools to combat vines and mutate plants."
+	icon_state = "mainboard"
+	required_modules = list(SERVICE_MODULE)
+	required_upgrades = list(/obj/item/borg/upgrade/hydro)
+	modules_to_add = list(
+		/obj/item/floral_somatoray,
+		/obj/item/weapon/scythe,
+		/obj/item/weapon/reagent_containers/spray/plantbgone
+		)
 
 /obj/item/borg/upgrade/honk
 	name = "service cyborg H.O.N.K. upgrade board"

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -323,7 +323,7 @@ var/list/hydro_trays = list()
 			to_chat(user,"<span class='sinister'>You cannot dig into the soil.</span>")
 			return
 		if(dead)
-			remove_dead()
+			remove_dead(user)
 			return
 		if(seed)
 			var/obj/item/claypot/C = locate() in range(user,1)

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -317,7 +317,7 @@ var/list/hydro_trays = list()
 
 	else if(isshovel(O))
 		if(closed_system)
-			to_chat(user, "<span class='warning'>You can't transplant the plant while the lid is shut.</span>")
+			to_chat(user, "<span class='warning'>You can't dig soil while the lid is shut.</span>")
 			return
 		if(arcanetampered)
 			to_chat(user,"<span class='sinister'>You cannot dig into the soil.</span>")

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -315,79 +315,83 @@ var/list/hydro_trays = list()
 		to_chat(user, "<span class='warning'>You must place the pot on the ground and use a spade on \the [src] to make a transplant.</span>")
 		return
 
-	else if(seed && isshovel(O))
+	else if(isshovel(O))
 		if(closed_system)
 			to_chat(user, "<span class='warning'>You can't transplant the plant while the lid is shut.</span>")
 			return
 		if(arcanetampered)
 			to_chat(user,"<span class='sinister'>You cannot dig into the soil.</span>")
 			return
-		var/obj/item/claypot/C = locate() in range(user,1)
-		if(!C)
-			to_chat(user, "<span class='warning'>You need an empty clay pot next to you.</span>")
+		if(dead)
+			remove_dead()
 			return
-		if(C.being_potted)
-			to_chat(user, "<span class='warning'>You must finish transplanting your current plant before starting another.</span>")
-			return
-		playsound(loc, 'sound/items/shovel.ogg', 50, 1)
-		C.being_potted = TRUE
-		if(do_after(user, src, 50))
-			user.visible_message(	"<span class='notice'>[user] transplants \the [seed.display_name] into \the [C].</span>",
-									"<span class='notice'>[bicon(src)] You transplant \the [seed.display_name] into \the [C].</span>",
-									"<span class='notice'>You hear a ratchet.</span>")
+		if(seed)
+			var/obj/item/claypot/C = locate() in range(user,1)
+			if(!C)
+				to_chat(user, "<span class='warning'>You need an empty clay pot next to you.</span>")
+				return
+			if(C.being_potted)
+				to_chat(user, "<span class='warning'>You must finish transplanting your current plant before starting another.</span>")
+				return
+			playsound(loc, 'sound/items/shovel.ogg', 50, 1)
+			C.being_potted = TRUE
+			if(do_after(user, src, 50))
+				user.visible_message(	"<span class='notice'>[user] transplants \the [seed.display_name] into \the [C].</span>",
+										"<span class='notice'>[bicon(src)] You transplant \the [seed.display_name] into \the [C].</span>",
+										"<span class='notice'>You hear a ratchet.</span>")
 
-			var/obj/structure/flora/pottedplant/claypot/S = new(get_turf(C))
-			transfer_fingerprints(C, S)
-			S.paint_layers = C.paint_layers.Copy()
-			qdel(C)
+				var/obj/structure/flora/pottedplant/claypot/S = new(get_turf(C))
+				transfer_fingerprints(C, S)
+				S.paint_layers = C.paint_layers.Copy()
+				qdel(C)
 
-			if(seed.large)
-				S.icon_state += "-large"
+				if(seed.large)
+					S.icon_state += "-large"
 
-			var/plant_appearance = ""
-			if(dead)
-				plant_appearance = "dead"
-			else if(harvest)
-				if (harvest > 1)
-					plant_appearance = "harvest-[harvest]"
+				var/plant_appearance = ""
+				if(dead)
+					plant_appearance = "dead"
+				else if(harvest)
+					if (harvest > 1)
+						plant_appearance = "harvest-[harvest]"
+					else
+						plant_appearance = "harvest"
 				else
-					plant_appearance = "harvest"
+					plant_appearance = "stage-[growth_level]"
+
+				S.plant_image = image(seed.plant_dmi,plant_appearance)
+				S.plant_name = seed.display_name
+				S.name = "potted [S.plant_name]"
+				S.plantname = seed.name
+
+				if (seed.pollen && harvest >= seed.pollen_at_level)
+					S.pollen = seed.pollen
+					S.add_particles(seed.pollen)
+					S.adjust_particles(PVAR_SPAWNING, 0.05, seed.pollen)
+					S.adjust_particles(PVAR_PLANE, FLOAT_PLANE, seed.pollen)
+					S.adjust_particles(PVAR_POSITION, generator("box", list(-12,4), list(12,12)), seed.pollen)
+
+				if (seed.moody_lights)
+					S.update_moody_light_index("plant", seed.plant_dmi, "[plant_appearance]-moody")
+				else if (seed.biolum)
+					var/image/luminosity_gradient = image(icon, src, "moody_plant_mask")
+					luminosity_gradient.blend_mode = BLEND_INSET_OVERLAY
+					var/image/mask = image(seed.plant_dmi, src, plant_appearance)
+					mask.appearance_flags = KEEP_TOGETHER
+					mask.overlays += luminosity_gradient
+					S.update_moody_light_index("plant", image_override = mask)
+
+				if(seed.biolum)
+					S.set_light(get_biolum())
+					if(seed.biolum_colour)
+						S.light_color = seed.biolum_colour
+
+				remove_plant()
+				S.update_icon()
+				update_icon()
 			else
-				plant_appearance = "stage-[growth_level]"
-
-			S.plant_image = image(seed.plant_dmi,plant_appearance)
-			S.plant_name = seed.display_name
-			S.name = "potted [S.plant_name]"
-			S.plantname = seed.name
-
-			if (seed.pollen && harvest >= seed.pollen_at_level)
-				S.pollen = seed.pollen
-				S.add_particles(seed.pollen)
-				S.adjust_particles(PVAR_SPAWNING, 0.05, seed.pollen)
-				S.adjust_particles(PVAR_PLANE, FLOAT_PLANE, seed.pollen)
-				S.adjust_particles(PVAR_POSITION, generator("box", list(-12,4), list(12,12)), seed.pollen)
-
-			if (seed.moody_lights)
-				S.update_moody_light_index("plant", seed.plant_dmi, "[plant_appearance]-moody")
-			else if (seed.biolum)
-				var/image/luminosity_gradient = image(icon, src, "moody_plant_mask")
-				luminosity_gradient.blend_mode = BLEND_INSET_OVERLAY
-				var/image/mask = image(seed.plant_dmi, src, plant_appearance)
-				mask.appearance_flags = KEEP_TOGETHER
-				mask.overlays += luminosity_gradient
-				S.update_moody_light_index("plant", image_override = mask)
-
-			if(seed.biolum)
-				S.set_light(get_biolum())
-				if(seed.biolum_colour)
-					S.light_color = seed.biolum_colour
-
-			remove_plant()
-			S.update_icon()
-			update_icon()
-		else
-			C.being_potted = FALSE
-		return
+				C.being_potted = FALSE
+			return
 
 	else if(istype(O,/obj/item/tool/scalpel) || O.is_wirecutter(user))
 		if(!seed)

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -14,7 +14,7 @@
 /obj/item/weapon/disk/botany/attack_self(var/mob/user as mob)
 	if(genes.len)
 		var/choice = alert(user, "Are you sure you want to wipe the disk?", "Xenobotany Data", "No", "Yes")
-		if(src && user && genes && choice && choice == "Yes" && user.get_active_hand() == src)
+		if(src && user && genes && choice && choice == "Yes" && (user.get_active_hand() == src || istype(loc,/obj/item/weapon/gripper/service)))
 			to_chat(user, "You wipe the disk data.")
 			name = initial(name)
 			desc = initial(desc)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -280,9 +280,7 @@
 	S.max_amount = MEDICAL_MAX_KIT
 	S.amount = MEDICAL_MAX_KIT
 	modules += S
-	emag = new /obj/item/weapon/reagent_containers/spray(src)
-	emag.reagents.add_reagent(PACID, 250)
-	emag.name = "Polyacid spray"
+	emag = new /obj/item/weapon/reagent_containers/spray/pacid(src)
 
 	sensor_augs = list("Medical", "Disable")
 
@@ -406,9 +404,7 @@
 	modules += new /obj/item/weapon/mop(src)
 	modules += new /obj/item/device/lightreplacer/borg(src)
 	modules += new /obj/item/weapon/reagent_containers/glass/bucket(src)
-	emag = new /obj/item/weapon/reagent_containers/spray(src)
-	emag.reagents.add_reagent(LUBE, 250)
-	emag.name = "Lube spray"
+	emag = new /obj/item/weapon/reagent_containers/spray/lube(src)
 
 	fix_modules()
 

--- a/code/modules/reagents/reagent_containers/glass/bottle/robot.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle/robot.dm
@@ -6,6 +6,10 @@
 	volume = 60
 	var/reagent = ""
 
+/obj/item/weapon/reagent_containers/glass/bottle/robot/New()
+	..()
+	reagents.add_reagent(reagent, 60)
+
 /obj/item/weapon/reagent_containers/glass/bottle/robot/restock()
 	if(reagent && (reagents.get_reagent_amount(reagent) < volume))
 		reagents.add_reagent(reagent, 2)
@@ -17,20 +21,23 @@
 	//icon_state = "bottle16"
 	reagent = INAPROVALINE
 
-/obj/item/weapon/reagent_containers/glass/bottle/robot/inaprovaline/New()
-	..()
-	reagents.add_reagent(INAPROVALINE, 60)
-	return
-
-
 /obj/item/weapon/reagent_containers/glass/bottle/robot/antitoxin
 	name = "internal anti-toxin bottle"
 	desc = "A small bottle of Anti-toxins. Counters poisons, and repairs damage, a wonder drug."
 	icon = 'icons/obj/chemical.dmi'
 	//icon_state = "bottle17"
 	reagent = ANTI_TOXIN
+	
+/obj/item/weapon/reagent_containers/glass/bottle/robot/water
+	name = "internal water bottle"
+	desc = "A small bottle for watering plants."
+	icon = 'icons/obj/chemical.dmi'
+	//icon_state = "bottle17"
+	reagent = WATER
 
-/obj/item/weapon/reagent_containers/glass/bottle/robot/antitoxin/New()
-	..()
-	reagents.add_reagent(ANTI_TOXIN, 60)
-	return
+/obj/item/weapon/reagent_containers/glass/bottle/robot/eznutrient
+	name = "internal E-Z-nutrient bottle"
+	desc = "A small bottle for feeding plants."
+	icon = 'icons/obj/chemical.dmi'
+	//icon_state = "bottle17"
+	reagent = EZNUTRIENT

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -88,10 +88,8 @@
 	to_chat(user, "<span class='notice'>You switched [amount_per_transfer_from_this == 10 ? "on" : "off"] the pressure nozzle. You'll now use [amount_per_transfer_from_this] units per spray.</span>")
 
 /obj/item/weapon/reagent_containers/spray/restock()
-	if(name == "Polyacid spray")
-		reagents.add_reagent(PACID, 2)
-	else if(name == "Lube spray")
-		reagents.add_reagent(LUBE, 2)
+	if(preset_reagent)
+		reagents.add_reagent(preset_reagent, 2)
 
 /obj/item/weapon/reagent_containers/spray/proc/make_puff(var/atom/target, var/mob/user)
 	if((has_slimes & slimes_accepted) && preset_reagent)
@@ -187,6 +185,15 @@
 	desc = "You're unsure if this is meant to cull or create weeds. The Discount Dan logo is haphazardly slapped on top of a faded yellow 'W' and gray 'Y'"
 	slimes_accepted = SLIME_PYRITE
 	preset_reagent = FAKE_CREEP
+
+
+/obj/item/weapon/reagent_containers/spray/pacid
+	name = "Polyacid spray"
+	preset_reagent = PACID
+	
+/obj/item/weapon/reagent_containers/spray/lube
+	name = "Lube spray"
+	preset_reagent = LUBE
 
 //chemsprayer
 /obj/item/weapon/reagent_containers/spray/chemsprayer

--- a/code/modules/research/designs/borg_upgrades.dm
+++ b/code/modules/research/designs/borg_upgrades.dm
@@ -152,10 +152,10 @@
 	name = "Service cyborg H.U.E.Y. MK-2 upgrade"
 	desc = "Used to give a service cyborg tools to mutate plants and combat vines."
 	id = "borg_adv_service_module_hydro"
-	req_tech = list(Tc_BIOTECH = 4, Tc_ENGINEERING = 2, Tc_PROGRAMMING = 2)
+	req_tech = list(Tc_BIOTECH = 5, Tc_ENGINEERING = 4, Tc_PROGRAMMING = 4)
 	build_type = MECHFAB
-	materials = list(MAT_IRON=45000, MAT_GLASS=8000, MAT_PLASTIC=2500)
-	build_path = /obj/item/borg/upgrade/hydro
+	materials = list(MAT_IRON=55000, MAT_GLASS=16000, MAT_PLASTIC=5000, MAT_GOLD=2500, MAT_SILVER=2500)
+	build_path = /obj/item/borg/upgrade/hydro_adv
 	category = "Robotic_Upgrade_Modules"
 
 /datum/design/borg_service_upgrade_honk

--- a/code/modules/research/designs/borg_upgrades.dm
+++ b/code/modules/research/designs/borg_upgrades.dm
@@ -140,8 +140,18 @@
 
 /datum/design/borg_service_upgrade_hydro
 	name = "Service cyborg H.U.E.Y. upgrade"
-	desc = "Used to give a service cyborg hydroponics tools and upgrade their service gripper to be able to handle seeds, weed killers, sprayers and glass containers."
+	desc = "Used to give a service cyborg hydroponics tools and upgrade their service gripper to be able to handle seeds and botany disks."
 	id = "borg_service_module_hydro"
+	req_tech = list(Tc_BIOTECH = 4, Tc_ENGINEERING = 2, Tc_PROGRAMMING = 2)
+	build_type = MECHFAB
+	materials = list(MAT_IRON=45000, MAT_GLASS=8000, MAT_PLASTIC=2500)
+	build_path = /obj/item/borg/upgrade/hydro
+	category = "Robotic_Upgrade_Modules"
+
+/datum/design/borg_service_upgrade_hydro_adv
+	name = "Service cyborg H.U.E.Y. MK-2 upgrade"
+	desc = "Used to give a service cyborg tools to mutate plants and combat vines."
+	id = "borg_adv_service_module_hydro"
 	req_tech = list(Tc_BIOTECH = 4, Tc_ENGINEERING = 2, Tc_PROGRAMMING = 2)
 	build_type = MECHFAB
 	materials = list(MAT_IRON=45000, MAT_GLASS=8000, MAT_PLASTIC=2500)


### PR DESCRIPTION
[content][qol]

## What this does
Closes #37242.
From the requests on the upgrade:
Makes the gripper in this upgrade able to hold botany disks grabbed out of diskette boxes
Allows them to properly wipe disks
Gives them a spade, allows spades to remove dead plants when used on them. (covering both at once)
Gives them a water bottle that refills on recharge

Additionally:
Gives them a hatchet for logs (dunno about this)
Gives them a recharging eznutrient bottle
Also unsure about giving them a bottle of recharging insecticide, either in the first or second upgrade. What's the feedback on this?

And then gives them another "MK2" upgrade that needs biology 5, engineering 4 and data 4, focused on vine killing and mutating, gives them a floral somatoray, scythe and plantbgone spray. The spray automatically refills. (maybe some beekeeping stuff too like a gripper for apiaries, a net and bee stuff? also is the somatoray too much?)

On the backend, standardises all the spray and borg bottle autofill code

## Why it's good
makes botany more doable with this upgrade

## How it was tested
applying the upgrades, grabbing botany disks out of the box, wiping them after putting seed data on them, planting grass, using plantbgone, removing it with the spade, cutting a log with the hatchet

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Service cyborg H.U.E.Y upgrades now contain a spade, hatchet and recharging bottles of water and EZ nutrient.
 * rscadd: Service cyborgs can now get a MK2 H.U.E.Y upgrade from research, for biology 5, engineering 4 and data 4. Contains a floral somatoray, scythe and plant-b-gone spray.
 * tweak: Spades can now remove dead plants when used on it, to help borgs with them.
 * bugfix: H.U.E.Y borg service grippers can now wipe botany disks and take them out of diskette boxes.