### PR TITLE
Fixes a server crash with timers

### DIFF
--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -68,7 +68,7 @@
 				timing = 0
 			timer_end()
 			time = default_time
-			if(repeat)
+			if(repeat && time > 0)
 				spawn()
 					countdown()
 		updateUsrDialog()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
timers repeating things every 0 seconds is bad, removes that ability.
## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Server crash bad
## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
set time to 0 and repeat, didnt repeat infinite times a second.
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Timers can no longer crash the server.

