### PR TITLE
Soft Suits fit in a backpack

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1111,7 +1111,7 @@ var/global/maxStackDepth = 10
 	icon_state = "space"
 	item_state = "s_suit"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/spacesuits.dmi', "right_hand" = 'icons/mob/in-hand/right/spacesuits.dmi')
-	w_class = W_CLASS_LARGE//bulky item
+	w_class = W_CLASS_MEDIUM//fits in a bag now
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.02
 	flags = FPRINT

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -4,6 +4,7 @@
 
 /obj/item/clothing/suit/space/unathi
 	name = "unathi space suit"
+	w_class = W_CLASS_LARGE
 
 /obj/item/clothing/head/helmet/space/unathi/breacher
 	name = "unathi breacher helmet"
@@ -112,7 +113,6 @@
 
 //Raider Gear
 /obj/item/clothing/suit/space/vox
-	w_class = W_CLASS_MEDIUM
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_storage,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs,/obj/item/weapon/tank)
 	slowdown = HARDSUIT_SLOWDOWN_HIGH
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
@@ -738,7 +738,6 @@
 	desc = "An outdated pressure suit that was once standard issue for spacefaring grey explorers. It's compact enough to be stored in a bag."
 	armor = list(melee = 20, bullet = 5, laser = 20, energy = 5, bomb = 15, bio = 100, rad = 10)
 	allowed = list(/obj/item/weapon/tank, /obj/item/weapon/gun/energy/smalldisintegrator)
-	w_class = W_CLASS_MEDIUM
 	species_restricted = list(GREY_SHAPED)
 	species_fit = list(GREY_SHAPED)
 

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -4,7 +4,6 @@
 
 /obj/item/clothing/suit/space/unathi
 	name = "unathi space suit"
-	w_class = W_CLASS_LARGE
 
 /obj/item/clothing/head/helmet/space/unathi/breacher
 	name = "unathi breacher helmet"

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -52,7 +52,6 @@
 	desc = "Yarr."
 	icon_state = "pirate"
 	item_state = "pirate"
-	w_class = W_CLASS_MEDIUM
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_storage,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/tank/emergency_nitrogen)
 	slowdown = NO_SLOWDOWN
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -3,7 +3,6 @@
 /obj/item/clothing/suit/space/plasmaman
 	name = "plasmaman suit"
 	desc = "A special containment suit designed to protect a plasmaman's volatile body from outside exposure and quickly extinguish it in emergencies."
-	w_class = W_CLASS_MEDIUM
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_storage,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs,/obj/item/weapon/tank)
 	slowdown = HARDSUIT_SLOWDOWN_LOW
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 0)

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -119,6 +119,7 @@ var/list/all_hardsuit_pieces = list(HARDSUIT_HEADGEAR,HARDSUIT_GLOVES,HARDSUIT_B
 	icon_state = "rig-engineering"
 	item_state = "eng_hardsuit"
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/clothing.dmi', "right_hand" = 'icons/mob/in-hand/right/clothing.dmi')
+	w_class = W_CLASS_LARGE
 	slowdown = HARDSUIT_SLOWDOWN_LOW
 	species_fit = list(GREY_SHAPED, TAJARAN_SHAPED, INSECT_SHAPED)
 	species_restricted = list("exclude",VOX_SHAPED)

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -14,7 +14,6 @@
 	icon_state = "syndicate"
 	item_state = "space_suit_syndicate"
 	desc = "Has a tag on it: Totally not property of a hostile corporation, honest!"
-	w_class = W_CLASS_MEDIUM
 	species_fit = list(VOX_SHAPED, INSECT_SHAPED)
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_storage,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/handcuffs, /obj/item/weapon/tank)
 	slowdown = HARDSUIT_SLOWDOWN_LOW


### PR DESCRIPTION
## What this does
Makes all space suits aside from rigsuits medium sized so they'll fit in a bag.

## Why it's good
Fixes an inconsistency with soft suits where standard ones cannot be put in a bag but all racial ones (vox, plasmamen, grey) can.

## How it was tested
spawned as an engineer, went to EVA, made sure rig suits didn't fit in my bag and soft suits did

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
tweak: made the default space suit size medium instead of large.