### PR TITLE
Fixes window grille spawners borking if spawned midround

### DIFF
--- a/code/game/objects/effects/spawners/grille_window_spawner.dm
+++ b/code/game/objects/effects/spawners/grille_window_spawner.dm
@@ -4,10 +4,9 @@
 	var/window_path = /obj/structure/window
 	var/full_path
 
-/obj/structure/grille/window_spawner/New()
+/obj/structure/grille/window_spawner/spawned_by_map_element(datum/map_element/ME)
 	. = ..()
-	if(ticker?.current_state == GAME_STATE_PLAYING)
-		initialize()
+	initialize()
 
 /obj/structure/grille/window_spawner/initialize()
 	icon = 'icons/obj/structures.dmi'

--- a/code/game/objects/effects/spawners/grille_window_spawner.dm
+++ b/code/game/objects/effects/spawners/grille_window_spawner.dm
@@ -6,7 +6,8 @@
 
 /obj/structure/grille/window_spawner/spawned_by_map_element(datum/map_element/ME)
 	. = ..()
-	initialize()
+	if(ticker?.current_state == GAME_STATE_PLAYING)
+		initialize()
 
 /obj/structure/grille/window_spawner/initialize()
 	icon = 'icons/obj/structures.dmi'

--- a/code/game/objects/effects/spawners/grille_window_spawner.dm
+++ b/code/game/objects/effects/spawners/grille_window_spawner.dm
@@ -4,6 +4,11 @@
 	var/window_path = /obj/structure/window
 	var/full_path
 
+/obj/structure/grille/window_spawner/New()
+	. = ..()
+	if(ticker?.current_state == GAME_STATE_PLAYING)
+		initialize()
+
 /obj/structure/grille/window_spawner/initialize()
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "grille0"


### PR DESCRIPTION
[bugfix]

## What this does
Closes #37287.

## How it was tested
loading the skipjack and entering it

## Changelog
:cl:
 * bugfix: Skipjacks now have proper windows again.