### PR TITLE
Fixes cows mutated by phazon being clogged with old chemicals

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -174,6 +174,7 @@
 		milktype = pick((chemical_reagents_list - blocked_chems)) //paismoke reacts instantly inside the cow, so it just constantly makes a smoke cloud harmlessly
 		name = "[lowertext(milktype)] cow"
 		desc = "It smells faintly of grass and [milktype]."
+		milkable_reagents.clear_reagents()
 
 /mob/living/simple_animal/cow/attack_hand(mob/living/carbon/M as mob)
 	if(!stat && M.a_intent == I_DISARM && icon_state != icon_dead)


### PR DESCRIPTION
## What this does
This makes it so that when phazon changes the milktype of a cow, their udders also get emptied.

Closes #37292.

## Why it's good
This prevents mutated cows from being overfilled with milk/random chemicals, which removes the potential for a mutated cow to be softlocked in a state where it is full, but cannot be milked. 

## How it was tested
1. Spawn a cow
2. Check that its udders were filled with milk using VV
3. Inject it with phazon
4. Check again, ensuring that the milk was emptied, and that the new chemical was produced.

## Changelog
:cl:
 * bugfix: Fixes cow's udders being clogged with old chemicals after they were mutated by phazon.
