### PR TITLE
Fixes Compiler Warnings by Removing a Single Space

### DIFF
--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -624,7 +624,7 @@
 /obj/machinery/bot/emag_act(mob/user)
 	if(emagged >= 2)
 		return
- 	if(locked)
+	if(locked)
 		locked = 0
 		emagged = 1
 		if(user)


### PR DESCRIPTION
# AAAAAAAA

## What this does
Removes a space added by #37288 (i'm blaming github suggested changes somehow magically conjuring a space in my copy paste), so that the compiler no longer screams.

## Why it's good
since it eases the pain of coders, it's not

## How it was tested
push green arrow, no warnings