### PR TITLE
Fixes hostile mob's friends list entries getting deleted while in use

### DIFF
--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -95,7 +95,7 @@
 	if (ismob(target))
 		target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been [what_done] by [user_txt][object_txt].[intent_txt][addition_txt]</font>")
 		if (!iscarbon(user))
-			QDEL_NULL(target.lastassailant)
+			target.lastassailant = null
 
 	if (ismob(user) && ismob(target))
 		target.assaulted_by(user)

--- a/code/modules/runescape/runescape_pvp.dm
+++ b/code/modules/runescape/runescape_pvp.dm
@@ -59,16 +59,7 @@ var/list/non_standard_maint_areas = list(
 
 /mob/proc/assaulted_by(var/mob/M,var/weak_assault=FALSE)
 	if(!iscarbon(M))
-		var/ref_in_use = FALSE
-		if(istype(src, /mob/living/simple_animal/hostile))
-			var/mob/living/simple_animal/hostile/H = src
-			for(var/datum/weakref/friend in H.friends)
-				if(friend.get() == lastassailant.get())
-					lastassailant = null
-					ref_in_use = TRUE
-					break;
-		if(!ref_in_use)
-			QDEL_NULL(lastassailant)
+		lastassailant = null
 	else
 		lastassailant = makeweakref(M)
 

--- a/code/modules/runescape/runescape_pvp.dm
+++ b/code/modules/runescape/runescape_pvp.dm
@@ -59,7 +59,16 @@ var/list/non_standard_maint_areas = list(
 
 /mob/proc/assaulted_by(var/mob/M,var/weak_assault=FALSE)
 	if(!iscarbon(M))
-		QDEL_NULL(lastassailant)
+		var/ref_in_use = FALSE
+		if(istype(src, /mob/living/simple_animal/hostile))
+			var/mob/living/simple_animal/hostile/H = src
+			for(var/datum/weakref/friend in H.friends)
+				if(friend.get() == lastassailant.get())
+					lastassailant = null
+					ref_in_use = TRUE
+					break;
+		if(!ref_in_use)
+			QDEL_NULL(lastassailant)
 	else
 		lastassailant = makeweakref(M)
 


### PR DESCRIPTION
## What this does
~~Adds a check to ensure that the lastassailant weakref isn't also being used by a hostile mob for its friends list, preventing mobs from forgetting their friends.~~
Replaces lastassailant weakref deletion with setting to null.
Closes #37240.

## Why it's good
This fixes issues with tamed mobs randomly deciding that they no longer are your friend. Most notably this fixes Lazarus injected mobs from turning on you 5 seconds after you get into a fight with something.

## How it was tested
How I found this issue:
1. Noticed that lazarus mobs only became aggressive after combat in a live round.
2. Spawned a goliath
3. Killed it
4. Revived it with a lazarus injector
5. Opened the mob's friends list in VV.
6. Spawned a basilisk to fight the goliath
7. Noticed that my entry in the friends list's GCDestroyed variable gets set to "Goodbye world!" after the mob gets hit
8. Noticed it gets deleted/set to null shortly afterward

How I tested it was fixed:
1. Add the changes
2. Using the same procedure as before, spawn, kill, and revive a goliath.
3. Spawn a zombie
4. Punch the zombie
5. Let them fight
6. Verified that the zombie's lastassailant was null
7. Verified the goliath's frends list was intact

## Changelog
🆑 
 * bugfix: Fixes an issue where hostile mob's friends list entries get deleted while in use after they take damage.