### PR TITLE
MetaStation Pipe Fixes

### DIFF
--- a/maps/metaclub.dmm
+++ b/maps/metaclub.dmm
@@ -9642,9 +9642,7 @@
 /obj/effect/landmark{
 	name = "lightsout"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	initialize_directions = 11
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/simulated/floor,
 /area/crew_quarters/sleep)
 "avM" = (
@@ -10109,16 +10107,9 @@
 /turf/simulated/wall,
 /area/security/evidence)
 "awN" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
-	initialize_directions = 11
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/crew_quarters/sleep)
+/obj/machinery/portable_atmospherics/pump,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "awP" = (
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -10174,7 +10165,7 @@
 /area/crew_quarters/sleep)
 "awV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/crew_quarters/sleep)
@@ -10521,9 +10512,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -11932,9 +11920,6 @@
 /area/crew_quarters/sleep)
 "aAL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -11947,17 +11932,11 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
-	initialize_directions = 11
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor,
 /area/crew_quarters/sleep)
 "aAN" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
-	initialize_directions = 11
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/wall,
 /area/crew_quarters/sleep)
 "aAO" = (
@@ -12620,23 +12599,27 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters/sleep)
 "aCh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/junction{
 	dir = 4;
 	icon_state = "pipe-j2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8;
+	initialize_directions = 11
+	},
 /turf/simulated/floor,
 /area/crew_quarters/sleep)
 "aCi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -12646,6 +12629,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -15241,6 +15227,9 @@
 /obj/item/weapon/stool{
 	pixel_y = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/simulated/floor,
 /area/crew_quarters/sleep)
 "aHg" = (
@@ -15801,6 +15790,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "red"
@@ -16200,6 +16190,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -16249,13 +16240,13 @@
 	},
 /area/crew_quarters/sleep)
 "aIN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/item/weapon/stool{
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor,
 /area/crew_quarters/sleep)
 "aIO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16897,9 +16888,7 @@
 	},
 /area/crew_quarters/sleep)
 "aJT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -16913,14 +16902,10 @@
 /turf/simulated/floor,
 /area/crew_quarters/sleep)
 "aJV" = (
-/obj/structure/closet/wardrobe/pjs,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 9
 	},
-/turf/simulated/floor{
-	icon_state = "vault";
-	tag = "icon-vault"
-	},
+/turf/simulated/floor,
 /area/crew_quarters/sleep)
 "aJW" = (
 /obj/structure/closet/wardrobe/pjs,
@@ -16931,9 +16916,6 @@
 /area/crew_quarters/sleep)
 "aJX" = (
 /obj/structure/closet/wardrobe/pjs,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/machinery/light/small,
 /turf/simulated/floor{
 	icon_state = "vault";
@@ -19222,7 +19204,6 @@
 /area/crew_quarters/locker)
 "aOf" = (
 /obj/machinery/atmospherics/unary/portables_connector,
-/obj/machinery/portable_atmospherics/pump,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -19236,7 +19217,6 @@
 /area/crew_quarters/locker)
 "aOg" = (
 /obj/machinery/atmospherics/unary/portables_connector,
-/obj/machinery/portable_atmospherics/pump,
 /obj/effect/decal/warning_stripes{
 	icon_state = "unloading"
 	},
@@ -21895,8 +21875,8 @@
 	pixel_y = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/layer_adapter/scrubbers/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/crew_quarters/locker)
@@ -31899,8 +31879,8 @@
 /obj/item/weapon/soap,
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /obj/item/weapon/reagent_containers/glass/bottle/bleach{
-	pixel_y = 6;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 6
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -46279,9 +46259,8 @@
 	name = "\improper Command Hallway"
 	})
 "bJv" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
-	initialize_directions = 11
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -46933,9 +46912,6 @@
 	})
 "bKG" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=11.1-Command-Starboard";
 	location = "11-Command-Port"
@@ -46945,18 +46921,18 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
 "bKH" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
-	initialize_directions = 11
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -48136,11 +48112,13 @@
 	name = "\improper Command Hallway"
 	})
 "bMx" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/hallway/primary/central)
 "bMy" = (
 /obj/structure/grille,
@@ -59910,6 +59888,9 @@
 	})
 "chD" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/simulated/floor{
 	icon_state = "whiteyellow"
 	},
@@ -63560,9 +63541,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -63597,13 +63576,13 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -65209,10 +65188,7 @@
 	name = "Firelock North"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
-	initialize_directions = 11
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -65244,9 +65220,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1;
 	name = "Firelock North"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -69588,8 +69561,8 @@
 "cxe" = (
 /obj/machinery/door/airlock/medical{
 	name = "Patient Room A";
-	req_access_txt = "5";
-	req_access_dir = 4
+	req_access_dir = 4;
+	req_access_txt = "5"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -70583,8 +70556,8 @@
 /area/science/storage)
 "cyK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1;
-	default_scrubbed_gases = list("plasma")
+	default_scrubbed_gases = list("plasma");
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/atmos)
@@ -71283,8 +71256,8 @@
 	})
 "czL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1;
-	default_scrubbed_gases = list("plasma")
+	default_scrubbed_gases = list("plasma");
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -72054,8 +72027,8 @@
 "cBg" = (
 /obj/machinery/door/airlock/medical{
 	name = "Patient Room B";
-	req_access_txt = "5";
-	req_access_dir = 4
+	req_access_dir = 4;
+	req_access_txt = "5"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -72106,8 +72079,8 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1;
-	default_scrubbed_gases = list("plasma")
+	default_scrubbed_gases = list("plasma");
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -82635,7 +82608,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitepurplefull"
@@ -82912,17 +82884,6 @@
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitepurple"
-	},
-/area/science/xenobiology)
-"cTt" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor{
-	icon_state = "white"
 	},
 /area/science/xenobiology)
 "cTu" = (
@@ -83361,7 +83322,6 @@
 /turf/simulated/floor/plating,
 /area/science/xenobiology)
 "cUr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -83845,8 +83805,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -106941,9 +106901,9 @@
 /area/shuttle/trade/start)
 "dYU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
+	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" );
 	name = "Outpost Air Scrubber";
-	on = 1;
-	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" )
+	on = 1
 	},
 /turf/simulated/floor/vox{
 	icon_state = "dark"
@@ -107005,10 +106965,10 @@
 /area/shuttle/trade/start)
 "dZe" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
+	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" );
 	dir = 8;
 	name = "Outpost Air Scrubber";
-	on = 1;
-	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" )
+	on = 1
 	},
 /obj/machinery/door_control{
 	id_tag = "vox_exterior";
@@ -107057,18 +107017,18 @@
 	pixel_x = 25
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
+	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" );
 	dir = 1;
 	name = "Outpost Air Scrubber";
-	on = 1;
-	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" )
+	on = 1
 	},
 /turf/simulated/floor/plating/vox,
 /area/shuttle/trade/start)
 "dZi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
+	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" );
 	name = "Outpost Air Scrubber";
-	on = 1;
-	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" )
+	on = 1
 	},
 /turf/simulated/floor/plating/vox,
 /area/shuttle/trade/start)
@@ -107121,9 +107081,9 @@
 	},
 /obj/structure/curtain/open/shower/right,
 /obj/machinery/atmospherics/unary/vent_scrubber{
+	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" );
 	name = "Outpost Air Scrubber";
-	on = 1;
-	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" )
+	on = 1
 	},
 /turf/simulated/floor/plating/vox,
 /area/shuttle/trade/start)
@@ -107440,10 +107400,10 @@
 /area/shuttle/trade/start)
 "dZU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
+	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" );
 	dir = 1;
 	name = "Outpost Air Scrubber";
-	on = 1;
-	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" )
+	on = 1
 	},
 /turf/simulated/floor/vox{
 	icon_state = "dark"
@@ -111110,8 +111070,8 @@
 /area/research_outpost/anomaly)
 "eja" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1;
-	default_scrubbed_gases = list("plasma")
+	default_scrubbed_gases = list("plasma");
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -116346,11 +116306,11 @@
 /area/vox_trading_post/hallway)
 "ete" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
+	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" );
 	dir = 4;
 	frequency = 1331;
 	name = "Outpost Air Scrubber";
-	on = 1;
-	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" )
+	on = 1
 	},
 /turf/simulated/floor/vox,
 /area/vox_station/tradepost)
@@ -116537,11 +116497,11 @@
 /area/vox_trading_post/hallway)
 "etz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
+	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" );
 	dir = 4;
 	frequency = 1331;
 	name = "Outpost Air Scrubber";
-	on = 1;
-	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" )
+	on = 1
 	},
 /obj/structure/closet/vox_raiders/trader,
 /turf/simulated/floor/vox,
@@ -117354,11 +117314,11 @@
 	})
 "evj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
+	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" );
 	dir = 8;
 	frequency = 1331;
 	name = "Outpost Air Scrubber";
-	on = 1;
-	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" )
+	on = 1
 	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor{
@@ -117567,11 +117527,11 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
+	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" );
 	dir = 8;
 	frequency = 1331;
 	name = "Outpost Air Scrubber";
-	on = 1;
-	default_scrubbed_gases = list( "carbon_dioxide", "plasma", "oxygen" )
+	on = 1
 	},
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/trading_floor{
@@ -126798,17 +126758,6 @@
 "mOq" = (
 /turf/simulated/floor/carpet,
 /area/security/main)
-"mTU" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/layer_adapter/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/crew_quarters/locker)
 "mWo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
@@ -128030,15 +127979,6 @@
 /area/security/toilet{
 	name = "Brig Dormitories"
 	})
-"rOH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/simulated/floor,
-/area/hallway/primary/central)
 "rOW" = (
 /obj/structure/cable/orange{
 	d2 = 2;
@@ -128374,15 +128314,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/brig)
-"taa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/simulated/floor,
-/area/hallway/primary/central)
 "tcq" = (
 /obj/structure/shuttle/diag_wall/smooth{
 	dir = 8
@@ -231588,7 +231519,7 @@ bdQ
 bdQ
 bIT
 bKG
-bMx
+bPH
 bOg
 bPH
 bPH
@@ -232090,7 +232021,7 @@ bFr
 bjR
 bIS
 bKH
-bJv
+bMN
 bMN
 bMN
 bMN
@@ -232112,7 +232043,7 @@ cke
 clo
 cmy
 cnN
-coZ
+crx
 cqw
 crx
 crx
@@ -247707,8 +247638,8 @@ cRm
 cRW
 cSC
 cSU
-cTt
-cTt
+cUr
+cUr
 cUr
 cUr
 cVp
@@ -250141,8 +250072,8 @@ aTS
 aUh
 aWM
 aXX
-aZq
-taa
+bJv
+cbl
 bcs
 bek
 bgp
@@ -250643,8 +250574,8 @@ nqn
 ttX
 oVK
 uyh
-bMN
-rOH
+bMx
+baF
 bcg
 bem
 bgr
@@ -253637,8 +253568,8 @@ atf
 awS
 atf
 atf
-adX
-adX
+awN
+awN
 adX
 aCc
 aFM
@@ -253650,7 +253581,7 @@ aCc
 aOg
 aPB
 aRm
-mTU
+iCI
 aUo
 aRi
 aWM
@@ -257658,9 +257589,9 @@ atg
 aEl
 aEF
 aFT
-aHf
+aIN
 aIL
-awX
+atg
 aLw
 aLw
 aLw
@@ -258151,7 +258082,7 @@ aqo
 arG
 atk
 avp
-awN
+azz
 axD
 ayp
 azz
@@ -258160,9 +258091,9 @@ aCf
 azz
 aEE
 aFS
-aHf
+aIN
 aIK
-aJV
+aJW
 aLw
 aML
 aOn
@@ -258662,8 +258593,8 @@ aCh
 azC
 aEH
 aFV
-aEH
-aIN
+aJV
+aIK
 aJX
 aLw
 aNu
@@ -259661,7 +259592,7 @@ avN
 awX
 atg
 azD
-awX
+atg
 aCj
 aDz
 atg


### PR DESCRIPTION
**Bibes :DDDD**
Small fixes to try and unfuck distro and scrubbery

MetaStation honestly needs an overhaul of the piping, but I really can't be assed to do that today.
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
![image](https://github.com/user-attachments/assets/4fae1048-a80d-4040-8857-e3f1805b8447)
![image](https://github.com/user-attachments/assets/2d1c5336-ad6c-4215-ae5a-1506d1ef7752)
![image](https://github.com/user-attachments/assets/33faf1a9-cff3-4288-a1cf-0cca36ef0805)
Fixes some pipenet issues around dorms, adds a few missing pipes, removes unneeded pipes from xenobio
Most importantly, removes the blue portapumps from Dorms and puts them in maints. Porta pumps seem to just passively increase distro pressure by around 2kPa per second.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Pressure should not passively increase overtime

## How it was tested
I compiled it and poked at the pipe net

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Minor pipenet fixes to MetaStation
 * tweak: Moved dorm portable pumps off of pipenet and into maints
