### PR TITLE
Makes civil war wizards spawn in team-separate dens

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -303,7 +303,7 @@
 		var/mob/living/carbon/human/H = M.create_human(M.client.prefs)
 		var/list/acceptable_wizardstarts = list()
 		for(var/obj/effect/landmark/L in wizardstart)
-			if(newWizard.faction == WPF || newWizard.faction = PFW)
+			if(newWizard.faction == WPF || newWizard.faction == PFW)
 				var/datum/faction/wizard/civilwar/CW = newWizard.faction
 				var/turf/T = get_turf(L)
 				if(T && CW.our_den && T.map_element == CW.our_den)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -301,7 +301,16 @@
 		else
 			PFW.HandleRecruitedRole(newWizard)
 		var/mob/living/carbon/human/H = M.create_human(M.client.prefs)
-		H.forceMove(pick(wizardstart))
+		var/list/acceptable_wizardstarts = list()
+		for(var/obj/effect/landmark/L in wizardstart)
+			if(newWizard.faction?.type == /datum/faction/wizard/civilwar)
+				var/datum/faction/wizard/civilwar/CW = newWizard.faction
+				var/turf/T = get_turf(L)
+				if(T && CW.our_den && T.map_element == CW.our_den)
+					acceptable_wizardstarts += L
+		if(!acceptable_wizardstarts.len)
+			acceptable_wizardstarts = wizardstart
+		H.forceMove(pick(acceptable_wizardstarts))
 		H.key = M.client.ckey
 		qdel(M)
 		newWizard.AssignToRole(H.mind,1)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -309,6 +309,7 @@
 				if(T && CW.our_den && T.map_element == CW.our_den)
 					acceptable_wizardstarts += L
 		if(!acceptable_wizardstarts.len)
+			message_admins("<span class='danger'>Something went wrong with putting [M.client.key] into a unique den! Using default wizard spawning for them.</span>")
 			acceptable_wizardstarts = wizardstart
 		H.forceMove(pick(acceptable_wizardstarts))
 		H.key = M.client.ckey

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -311,6 +311,7 @@
 		if(!acceptable_wizardstarts.len)
 			message_admins("<span class='danger'>Something went wrong with putting [M.client.key] into a unique den! Using default wizard spawning for them.</span>")
 			acceptable_wizardstarts = wizardstart
+			newWizard.spawnedwrong = TRUE
 		H.forceMove(pick(acceptable_wizardstarts))
 		H.key = M.client.ckey
 		qdel(M)

--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -303,7 +303,7 @@
 		var/mob/living/carbon/human/H = M.create_human(M.client.prefs)
 		var/list/acceptable_wizardstarts = list()
 		for(var/obj/effect/landmark/L in wizardstart)
-			if(newWizard.faction?.type == /datum/faction/wizard/civilwar)
+			if(newWizard.faction == WPF || newWizard.faction = PFW)
 				var/datum/faction/wizard/civilwar/CW = newWizard.faction
 				var/turf/T = get_turf(L)
 				if(T && CW.our_den && T.map_element == CW.our_den)

--- a/code/datums/gamemode/factions/wizard.dm
+++ b/code/datums/gamemode/factions/wizard.dm
@@ -13,10 +13,13 @@
 	hud_icons = list("wizard-logo","apprentice-logo")
 	default_admin_voice = "Wizard Federation"
 	admin_voice_style = "notice"
+	var/datum/map_element/dungeon/wizard_den/our_den
+	var/dentype = /datum/map_element/dungeon/wizard_den
 
 /datum/faction/wizard/New()
 	..()
-	load_dungeon(/datum/map_element/dungeon/wizard_den)
+	our_den = new dentype
+	load_dungeon(our_den)
 
 /datum/faction/wizard/civilwar
 	var/enemy_faction
@@ -39,6 +42,7 @@
 	name = "The Peoples' Front for Wizards"
 	desc = "The PFW are a faction within the Wizard Federation. The only people they hate more than Nanotrasen are the Wizardly Peoples' Front."
 	enemy_faction = /datum/faction/wizard/civilwar/wpf
+	dentype = /datum/map_element/dungeon/wizard_den/enemy_faction
 
 /datum/faction/wizard/HandleNewMind(var/datum/mind/M)
 	..()
@@ -72,3 +76,5 @@
 
 /datum/map_element/dungeon/wizard_den/pre_load()
 	file_path = "maps/misc/wizardden[rand(1,5)].dmm"
+
+/datum/map_element/dungeon/wizard_den/enemy_faction // just so it's unique

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -14,6 +14,8 @@
 	//Can get lost through absorbing
 	var/list/spells_from_spellbook = list()
 	var/list/spells_from_absorb = list()
+	var/spawnedwrong = FALSE // only set during civil war if the unique den thing didn't work somehow
+
 //Does not show spells because the scoreboard code overrides it
 
 	var/list/artifacts_bought = list()
@@ -61,6 +63,8 @@
 				if("The Wizardly Peoples' Front","The Peoples' Front for Wizards")
 					to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='info'>You are a Space Wizard!</br></span>")
 					to_chat(antag.current, "<span class='danger'>The Wizard Federation is in civil war! Plan your strategy in the den and coordinate with your teammate! You are part of [faction]. Enemy wizards will not have a visible wizard icon, but friendly wizards will.</br></span>")
+					if(spawnedwrong)
+						to_chat(antag.current, "<span class='danger' style='font-size:14pt'>The den is neutral ground! Do NOT fight here!</br></span>")
 					to_chat(antag.current, "<span class='info'>[faction.desc]</span>")
 				else
 					to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='danger'>You are a Space Wizard!!</br></span>")

--- a/code/datums/gamemode/role/wizard.dm
+++ b/code/datums/gamemode/role/wizard.dm
@@ -61,7 +61,6 @@
 				if("The Wizardly Peoples' Front","The Peoples' Front for Wizards")
 					to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='info'>You are a Space Wizard!</br></span>")
 					to_chat(antag.current, "<span class='danger'>The Wizard Federation is in civil war! Plan your strategy in the den and coordinate with your teammate! You are part of [faction]. Enemy wizards will not have a visible wizard icon, but friendly wizards will.</br></span>")
-					to_chat(antag.current, "<span class='danger' style='font-size:14pt'>The den is neutral ground! Do NOT fight here!</br></span>")
 					to_chat(antag.current, "<span class='info'>[faction.desc]</span>")
 				else
 					to_chat(antag.current, "<img src='data:image/png;base64,[icon2base64(logo)]' style='position: relative; top: 10;'/> <span class='danger'>You are a Space Wizard!!</br></span>")


### PR DESCRIPTION
[gamemode]

## What this does
uses the changes in #33873 to load another one of these for the other team to spawn in
removes the line about not fighting in the den as a neutral zone because it's no longer necessary (can add it back on request)

## Why it's good
less likely to be around your hostiles from the start

## How it was tested
creating one of the civil war factions via role panel wizard role being put on player

## Changelog
:cl:
 * tweak: The warring factions in wizard civil wars now get wizard dens all to themselves, at last!