### PR TITLE
Fixes cloning pod atmosphere related issues.

### DIFF
--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -327,6 +327,7 @@
 
 			//Also heal some oxyloss ourselves because inaprovaline is so bad at preventing it!!
 			occupant.adjustOxyLoss(-4)
+			occupant.nobreath = 15
 
 			use_power(7500) //This might need tweaking.
 			return

--- a/code/modules/medical/cloning.dm
+++ b/code/modules/medical/cloning.dm
@@ -249,6 +249,7 @@
 	isslimeperson(H) ? H.adjustToxLoss(75) : H.adjustCloneLoss(150) // 75 for slime people due to their tox_mod of 2
 	H.adjustBrainLoss(upgraded ? 0 : (heal_level + 50 + rand(10, 30))) // The rand(10, 30) will come out as extra brain damage
 	H.Paralyse(4)
+	H.nobreath = 15
 	H.stat = H.status_flags & BUDDHAMODE ? CONSCIOUS : UNCONSCIOUS //There was a bug which allowed you to talk for a few seconds after being cloned, because your stat wasn't updated until next Life() tick. This is a fix for this!
 
 	//Here let's calculate their health so the pod doesn't immediately eject them!!!


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Gives nobreathe to everyone in cloning and for a limited time afterwards, the same bonus given to people jumping out of cryo. This prevents lung damage and also catching on fire as a plasmaman.

fixes #37323
## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Allows plasmaman to be cloned again, also removes gasp spamming from people in the cloning pod as well.
## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
I cloned a plasmaman and a vox, percieved expected results while in cloninig pod and nobreathe going away after leaving the pod
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Plasmaman can be cloned again.
 * tweak: Cloning now gives you the same leeway for getting internals as popping out of cryo.
