### PR TITLE
Removes minimum player count for roid and deff.

### DIFF
--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -59,7 +59,6 @@
 /datum/next_map/deff
 	name = "Defficiency"
 	path = "Defficiency"
-	min_players = 25
 
 /datum/next_map/dorf
 	name = "DorfStation"
@@ -125,7 +124,6 @@
 /datum/next_map/roid
 	name = "Asteroid Station"
 	path = "RoidStation"
-	min_players = 25
 
 /datum/next_map/snaxi
 	name = "Snow Station"


### PR DESCRIPTION
## What this does
Removes minimum player count for roid and deff. 

## Why it's good
We rarely hit above 25 players. The lowpop maps lowkey suck. 95% of the lowpop rounds get played on box, 5% get played on meta. I 100% made up that statistic, but if you ask anyone else who plays lowpop, it's pretty true. This gives us some map variety for lowpop. I'd be open to removing player gates for other maps if people wanted. I chose these two because they're the two alt-maps that I would say are generally liked by the playerbase.

## How it was tested
Didn't test, change is simple enough I am 100% sure it works.

## Changelog
 * tweak: Changed minimum pop needed to vote for deff and roid to 0.
