### PR TITLE
Fixes Map Spawner Hard Dels

### DIFF
--- a/code/game/objects/effects/decals/floor_decals.dm
+++ b/code/game/objects/effects/decals/floor_decals.dm
@@ -9,6 +9,7 @@
 	I.pixel_y = pixel_y
 	I.color=color
 	T.AddDecal(I)
+	I = null
 	qdel(src)
 
 /obj/effect/decal/warning_stripes/oldstyle

--- a/code/modules/maps/spawners/pick_spawner.dm
+++ b/code/modules/maps/spawners/pick_spawner.dm
@@ -26,7 +26,7 @@
 		map_pickspawners[category] = list()
 	map_pickspawners[category] += src
 
-/obj/abstract/map/spawner/pick_spawner/Destroy()
+/obj/abstract/map/spawner/pick_spawner/kill_spawner()
 	if(category && map_pickspawners[category])
 		map_pickspawners[category] -= src
 	..()
@@ -45,7 +45,7 @@
 			var/obj/abstract/map/spawner/pick_spawner/winner = pickweight(possible_spawners)
 			winner.perform_spawn() //It automatically removes itself from the list when spawning.
 		for(var/obj/abstract/map/spawner/pick_spawner/loser in map_pickspawners[category])
-			qdel(loser) //They automatically remove themselves from the list in their Destroy().
+			loser.kill_spawner() //They automatically remove themselves from the list here.
 
 
 

--- a/code/modules/maps/spawners/spawners.dm
+++ b/code/modules/maps/spawners/spawners.dm
@@ -24,7 +24,11 @@
 		else
 			if(prob(chance))
 				CreateItem(pick(to_spawn))
-	qdel(src)
+	kill_spawner()
+
+/obj/abstract/map/spawner/proc/kill_spawner() //prevents hard dels
+	to_spawn = list()
+	src.forceMove(null, harderforce = TRUE)
 
 /obj/abstract/map/spawner/proc/CreateItem(new_item_type)
 	var/obj/spawned = new new_item_type(loc)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes a large number of hard dels which potentially were causing lag spikes at roundstart by properly clearing an image ref (decal spawners) or by nullspacing the spawner as it was attempting to qdel itself prior to SSGarbage starting (pickspawners).

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Performance.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Started a local server and spawned several vaults known to cause hard dels with the associated spawners and noted a lack of said hard dels.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed some map-related hard dels.