### PR TITLE
Fixes cricket spawn

### DIFF
--- a/code/modules/events/crickets.dm
+++ b/code/modules/events/crickets.dm
@@ -1,5 +1,7 @@
 /datum/event/cricketsbehindthefridge/start()
 	for(var/obj/machinery/smartfridge/SF in machines)
+		if(SF.z != map.zMainStation)
+			continue
 		for(var/i = 1 to rand(3,4))
 			var/mob/living/simple_animal/cricket/C = new (SF.loc)
 			if(i==1)


### PR DESCRIPTION
fixes  #37340

Not tested, I didn't redownload the game, but I did know this is something I could fix from the web editor in 2 minutes. Downside: no more crickets on the derelict if you needed those as a mommi, I guess. Alternative fix could be to only blacklist centcomm instead of whitelisting the station.

🆑 
* bugfix: Crickets will now only spawn on the station as a consequence of Crickets Behind the Fridge event.