### PR TITLE
Fixes Visually Reversed Belts

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -160,7 +160,7 @@
 			var/turf/T = get_step(loc, directions[i])
 			var/obj/machinery/conveyor/C = locate() in T
 			if(C && (C.dir & C.dir-1) && !C.smoothed) //found an unsmoothed diagonal conveyor belt
-				var/list/secondarydirections = conveyor_directions(C.dir) //retrieve its dirs
+				var/list/secondarydirections = conveyor_directions(C.dir, C.in_reverse) //retrieve its dirs
 				if(directions[i] == opposite_dirs[secondarydirections[i]]) //check if the direction it is pointing is towards/away from us, if necessary reverse it
 					in_reverse = 1
 					C.smoothed = 1


### PR DESCRIPTION
# i read big salmon letters

[goodbelt.webm](https://github.com/user-attachments/assets/cd4d8daa-c780-4c6e-a360-654395a2632c)

## What this does
Fixes belts that look like they're going backwards. Fixes #37353. Note that this does NOT fix the messed up Centcomm belts, which are facing crazy directions on nonsensical IDs with no levers on all maps. But it does fix the strange cargo belt and the strange garbage room belt.

## Why it's good
considering there's an ss14 fork being worked on and i'm doing ss13 code work, it's not good. But we cannot abandon our poor olde code. We cannot.

## How it was tested
Ran into the cargo bay and turned the conveyor on, threw a thing on it, ran to the garbage room, turned the light on, turned the conveyor on, pushed the SUBMIT PR button.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed conveyors moving strangely when next to certain diagonal belts
