### PR TITLE
Reverts the Roulette Revolver nerf (#35752)

### DIFF
--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -611,6 +611,8 @@
 /obj/structure/turret/gun_turret/New()
 	..()
 	roulette_projectiles = existing_typesof(/obj/item/projectile) - restricted_roulette_projectiles
+	for(var/projectile_types in restrict_with_subtypes)
+		roulette_projectiles -= typesof(projectile_types)
 
 /obj/structure/turret/gun_turret/examine(mob/user)
 	..()

--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -611,8 +611,6 @@
 /obj/structure/turret/gun_turret/New()
 	..()
 	roulette_projectiles = existing_typesof(/obj/item/projectile) - restricted_roulette_projectiles
-	for(var/projectile_types in restrict_with_subtypes)
-		roulette_projectiles -= typesof(projectile_types)
 
 /obj/structure/turret/gun_turret/examine(mob/user)
 	..()

--- a/code/modules/projectiles/guns/projectile/roulette.dm
+++ b/code/modules/projectiles/guns/projectile/roulette.dm
@@ -13,6 +13,7 @@ var/list/restricted_roulette_projectiles = list(
 	/obj/item/projectile/beam/lightlaser,
 	/obj/item/projectile/portalgun,
 	/obj/item/projectile/hookshot,
+	/obj/item/projectile/friendlyCheck,
 	)
 
 /obj/item/weapon/gun/projectile/roulette_revolver

--- a/code/modules/projectiles/guns/projectile/roulette.dm
+++ b/code/modules/projectiles/guns/projectile/roulette.dm
@@ -5,23 +5,13 @@ var/list/restricted_roulette_projectiles = list(
 	/obj/item/projectile/beam/lightning,
 	/obj/item/projectile/beam/procjectile,
 	/obj/item/projectile/beam/lightning/spell,
-	/obj/item/projectile/rocket,
 	/obj/item/projectile/rocket/nikita,
-	/obj/item/projectile/rocket/lowyield/extreme,
 	/obj/item/projectile/test,
-	/obj/item/projectile/friendlyCheck,
 	/obj/item/projectile/beam/emitter,
 	/obj/item/projectile/spell_projectile,
 	/obj/item/projectile/stickybomb,
 	/obj/item/projectile/beam/lightlaser,
 	/obj/item/projectile/portalgun,
-	/obj/item/projectile/soulbullet,
-	)
-
-var/list/restrict_with_subtypes = list(
-		/obj/item/projectile/meteor,
-		/obj/item/projectile/hookshot,
-		/obj/item/projectile/immovablerod
 	)
 
 /obj/item/weapon/gun/projectile/roulette_revolver
@@ -69,23 +59,6 @@ var/list/restrict_with_subtypes = list(
 	else
 		to_chat(user, "<span class='info'>\The [src] has [shots_left] shots left.</span>")
 
-/obj/item/weapon/gun/projectile/roulette_revolver/attackby(obj/item/A, mob/user)
-	if(istype(A, /obj/item/weapon/conversion_kit) && restrict_with_subtypes?.len)
-		var/obj/item/weapon/conversion_kit/CK = A
-		if(!CK.open)
-			to_chat(user, "<span class='notice'>\The [CK] needs to be open to use.</span>")
-			return 1
-		if(do_after(user, src, 3 SECONDS))
-			desc += "The barrel and chamber assembly seems to have been modified."
-			to_chat(user, "<span class='danger'>You finish modifying \the [src]!</span>")
-			restrict_with_subtypes.Cut()
-			restricted_roulette_projectiles -= /obj/item/projectile/rocket
-			restricted_roulette_projectiles -= /obj/item/projectile/rocket/nikita
-			restricted_roulette_projectiles -= /obj/item/projectile/rocket/lowyield/extreme
-		return 1
-	else
-		..()
-
 /obj/item/weapon/gun/projectile/roulette_revolver/proc/choose_projectile()
 	if(bullet_type_override)
 		in_chamber = new bullet_type_override
@@ -93,10 +66,6 @@ var/list/restrict_with_subtypes = list(
 	var/chosen_projectile = pick(available_projectiles)
 	for(var/I in restricted_roulette_projectiles)
 		if(chosen_projectile == I)
-			choose_projectile()
-			return
-	for(var/I in restrict_with_subtypes)
-		if(ispath(chosen_projectile, I))
 			choose_projectile()
 			return
 	var/P = new chosen_projectile()

--- a/code/modules/projectiles/guns/projectile/roulette.dm
+++ b/code/modules/projectiles/guns/projectile/roulette.dm
@@ -12,10 +12,12 @@ var/list/restricted_roulette_projectiles = list(
 	/obj/item/projectile/stickybomb,
 	/obj/item/projectile/beam/lightlaser,
 	/obj/item/projectile/portalgun,
-	/obj/item/projectile/hookshot,
 	/obj/item/projectile/friendlyCheck,
 	)
 
+var/list/restrict_with_subtypes = list(
+		/obj/item/projectile/hookshot,
+	)
 /obj/item/weapon/gun/projectile/roulette_revolver
 	name = "\improper Roulette Revolver"
 	desc = "A strange-looking revolver. Its construction appears somewhat slapdash."
@@ -68,6 +70,10 @@ var/list/restricted_roulette_projectiles = list(
 	var/chosen_projectile = pick(available_projectiles)
 	for(var/I in restricted_roulette_projectiles)
 		if(chosen_projectile == I)
+			choose_projectile()
+			return
+	for(var/I in restrict_with_subtypes)
+		if(ispath(chosen_projectile, I))
 			choose_projectile()
 			return
 	var/P = new chosen_projectile()

--- a/code/modules/projectiles/guns/projectile/roulette.dm
+++ b/code/modules/projectiles/guns/projectile/roulette.dm
@@ -12,6 +12,7 @@ var/list/restricted_roulette_projectiles = list(
 	/obj/item/projectile/stickybomb,
 	/obj/item/projectile/beam/lightlaser,
 	/obj/item/projectile/portalgun,
+	/obj/item/projectile/hookshot,
 	)
 
 /obj/item/weapon/gun/projectile/roulette_revolver

--- a/code/modules/projectiles/guns/projectile/roulette.dm
+++ b/code/modules/projectiles/guns/projectile/roulette.dm
@@ -17,6 +17,7 @@ var/list/restricted_roulette_projectiles = list(
 
 var/list/restrict_with_subtypes = list(
 		/obj/item/projectile/hookshot,
+		/obj/item/projectile/meteor/blob, //includes the nodes
 	)
 /obj/item/weapon/gun/projectile/roulette_revolver
 	name = "\improper Roulette Revolver"


### PR DESCRIPTION
## What this does
Brings back the beloved TRUE roulette revolver by reverting #35752.
## Why it's good
That PR? It was cringe. It brought no joy, and was merged despite a sizable contingent of players disliking it.
## How it was tested
It wasn't, but I literally just undid the changes on the aforementioned PR
:cl:
 * tweak: Roulette Revolvers are back to their pre-nerf status, sans blob meteors and hookshots, those are still blocked.