### PR TITLE
Makes golem runes use recruiter for recruitment

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1732,8 +1732,6 @@ var/proccalls = 1
 #define JINGLE_CLASSIC "Classics"
 #define JINGLE_ALL "All"
 
-#define GOLEM_RESPAWN_TIME 10 MINUTES	//how much time must pass before someone who dies as an adamantine golem can use the golem rune again
-
 #define BEESPECIES_NORMAL	"bee"
 #define BEESPECIES_VOX		"chill bug"
 #define BEESPECIES_HORNET	"hornet"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2121,7 +2121,7 @@
 
 /datum/chemical_reaction/slime_extract/slimegolem/on_reaction(var/datum/reagents/holder)
 	var/obj/effect/decal/cleanable/golem_rune/Z = new /obj/effect/decal/cleanable/golem_rune(get_turf(holder.my_atom))
-	Z.creator = usr ? usr : null
+	Z.creator = usr
 	..()
 
 /datum/chemical_reaction/slime_extract/slimediamond2

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2120,9 +2120,8 @@
 	required_container = /obj/item/slime_extract/adamantine
 
 /datum/chemical_reaction/slime_extract/slimegolem/on_reaction(var/datum/reagents/holder)
-	var/obj/effect/golem_rune/Z = new /obj/effect/golem_rune
-	Z.forceMove(get_turf(holder.my_atom))
-	Z.announce_to_ghosts()
+	var/obj/effect/decal/cleanable/golem_rune/Z = new /obj/effect/decal/cleanable/golem_rune(get_turf(holder.my_atom))
+	Z.creator = usr ? usr : null
 	..()
 
 /datum/chemical_reaction/slime_extract/slimediamond2


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Makes the xenobiology adamantine golem runes recruit from deadchat similarly to most other ghost roles like pAIs, posibrains, borer eggs etc. The rune tries to recruit 5 seconds after being made. If nobody signs up, it goes inactive for 5 minutes and then tries again.

I also turned the runes into cleanable decals so that it's possible to get rid of them if they start to annoy you. They persist through persistence, but persistent versions don't recruit (might be really funny if they did though).

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->

The way these currently work is horrible. When a human clicks on them, one of the ghosts currently in the same tile as the rune gets *forcibly turned into a golem*. Clicking on them as a ghost to "sign up" doesn't really do anything besides change the colour of the rune from blue to green -- if you're signed up and someone clicks on a rune, it won't do anything unless your ghost is on top of the rune when the click happens. All this also has next to no useful feedback for anyone involved.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Made a rune, ghosted, signed up for the recruitment. Also tried cleaning up an actively recruiting rune using soap (nothing exploded).

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Adamantine golem runes made in xenobiology now use ghost recruitment mechanics similar to posibrains and borer eggs. The rune will try to recruit a ghost every 5 minutes for as long as it exists. The runes can now also be cleaned up like any other decal using e.g. soap.