### PR TITLE
Add logging to Chef Excellence's Special Sauce and always log & adminwarn on reagent transfers of dangerous reagents

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -1,4 +1,4 @@
-var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXIN, MINDBREAKER, SPIRITBREAKER, CYANIDE, IMPEDREZENE, LUBE)
+var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXIN, MINDBREAKER, SPIRITBREAKER, CYANIDE, IMPEDREZENE, LUBE, CHEFSPECIAL)
 
 /obj
 	var/origin_tech = null	//Used by R&D to determine what research bonuses it grants.

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -1,7 +1,7 @@
 //reagents that should adminwarn upon transfer
-var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXIN, MINDBREAKER, SPIRITBREAKER, CYANIDE, IMPEDREZENE, LUBE, CHEFSPECIAL)
+var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXIN, MINDBREAKER, SPIRITBREAKER, CYANIDE, IMPEDREZENE, LUBE, CHEFSPECIAL, AMANITIN)
 //dangerous reagents that should always be logged upon transfer no matter what
-var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECIAL)
+var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECIAL, AMANITIN)
 
 /obj
 	var/origin_tech = null	//Used by R&D to determine what research bonuses it grants.

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -1,4 +1,7 @@
+//reagents that should adminwarn upon transfer
 var/global/list/reagents_to_log = list(FUEL, PLASMA, PACID, SACID, AMUTATIONTOXIN, MINDBREAKER, SPIRITBREAKER, CYANIDE, IMPEDREZENE, LUBE, CHEFSPECIAL)
+//dangerous reagents that should always be logged upon transfer no matter what
+var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECIAL)
 
 /obj
 	var/origin_tech = null	//Used by R&D to determine what research bonuses it grants.

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -210,12 +210,11 @@ var/const/INGEST = 2
 		var/current_reagent_transfer = current_reagent.volume * part
 		if(preserve_data)
 			trans_data = current_reagent.data
-		var/log_this_reagent = (current_reagent.id in reagents_to_always_log)
-		if(log_this_reagent)
+		if(current_reagent.id in reagents_to_always_log)
 			log_transfer = TRUE
 		if(log_transfer)
 			logged_message += "[current_reagent_transfer]u of [current_reagent.name]"
-			if(log_this_reagent)
+			if(current_reagent.id in reagents_to_log)
 				adminwarn_message += "[current_reagent_transfer]u of <span class='warning'>[current_reagent.name]</span>"
 		if (to_mob)
 			R.add_reagent(current_reagent.id, (current_reagent_transfer * multiplier), trans_data, chem_temp, current_reagent.adj_temp)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -210,9 +210,12 @@ var/const/INGEST = 2
 		var/current_reagent_transfer = current_reagent.volume * part
 		if(preserve_data)
 			trans_data = current_reagent.data
+		var/log_this_reagent = (current_reagent.id in reagents_to_always_log)
+		if(log_this_reagent)
+			log_transfer = TRUE
 		if(log_transfer)
 			logged_message += "[current_reagent_transfer]u of [current_reagent.name]"
-			if(current_reagent.id in reagents_to_log)
+			if(log_this_reagent)
 				adminwarn_message += "[current_reagent_transfer]u of <span class='warning'>[current_reagent.name]</span>"
 		if (to_mob)
 			R.add_reagent(current_reagent.id, (current_reagent_transfer * multiplier), trans_data, chem_temp, current_reagent.adj_temp)

--- a/code/modules/reagents/reagents/reagents_toxin.dm
+++ b/code/modules/reagents/reagents/reagents_toxin.dm
@@ -148,6 +148,7 @@
 /datum/reagent/chefspecial/on_overdose(var/mob/living/M)
 	M.death(0)
 	M.attack_log += "\[[time_stamp()]\]<font color='red'>Died a quick and painless death by <font color='green'>Chef Excellence's Special Sauce</font>.</font>"
+	log_attack("[key_name(M)] was killed by Chef Excellence's Special Sauce (CHEFSPECIAL).")
 
 //Otherwise known as a "Mickey Finn"
 /datum/reagent/chloralhydrate


### PR DESCRIPTION
This is not grudgecode.

Right now the always logged reagents are advanced mutation toxin (the one that turns you into a simplemob slime), cyanide and special sauce. Let me know if you want any other reagents on this list.