### PR TITLE
Masks now provide some insulation to your breath (in other words, scarves and ski masks are now viable on Snaxi)

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_breath.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_breath.dm
@@ -94,6 +94,11 @@
 				var/obj/location_as_object = loc
 				location_as_object.handle_internal_lifeform(src, 0)
 
+	if(wear_mask)//Insulated masks will protect you from the elements you breath somewhat
+		var/temp_difference = bodytemperature - breath.temperature
+		var/temp_change = (1 - wear_mask.heat_conductivity) * temp_difference
+		breath.temperature += temp_change
+
 	handle_breath(breath)
 
 	if(species)

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -130,7 +130,7 @@
 		temperature_alert = TEMP_ALARM_HEAT_STRONG
 	else if(has_reagent_in_blood(FROSTOIL))
 		temperature_alert = TEMP_ALARM_COLD_STRONG
-	else if(!(get_thermal_loss(loc.return_air()) > 0.1) || bodytemperature > T0C + 50)
+	else if(!(get_thermal_loss(loc.return_air()) > 0.1) || bodytemperature > T0C + 50 || undergoing_hypothermia() || undergoing_hyperthermia())
 		switch(bodytemperature) //310.055 optimal body temp
 			if(370 to INFINITY)
 				temperature_alert = TEMP_ALARM_HEAT_STRONG


### PR DESCRIPTION
All masks have 60% insulation by default, scarves and ski masks have 80% insulation. When breathing air, your mask now filters its insulation % from the temperature difference between the environment and your body. Internals remain the safest mask to wear in extreme environments.

note: this doesn't reduce the rate of hypothermia, but at least you won't take cold burn damage and get "icicles in your lungs".

:cl:
* rscadd: Scarves, Ski Masks, and to a lower extent masks in general now actually offer some protection from the damage caused by breathing in extreme temperatures. Wear a scarf to stop having icicles in your lungs when outdoors on Snaxi.