### PR TITLE
Revert "Fixes Infinite Respawns"

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -19,9 +19,7 @@
 	verbs -= /mob/living/carbon/verb/mob_sleep
 
 /mob/living/carbon/brain/Destroy()
-	if(key || mind.key)
-		if(!key)
-			src.key = mind.key
+	if(key)				//If there is a mob connected to this thing. Have to check key twice to avoid false death reporting.
 		if(stat!=DEAD)	//If not dead.
 			death(1)	//Brains can die again. AND THEY SHOULD AHA HA HA HA HA HA
 	..()


### PR DESCRIPTION
Reverts vgstation-coders/vgstation13#37168

Closes #37197
Closes #37378

This fix causes several other critical bugs. Revert it until a better way to fix the exploit is figured out and in the mean time just ban people who abuse the exploit.