### PR TITLE
Fix fire closet welded sprite

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -117,12 +117,6 @@
 /obj/structure/closet/firecloset/full/atoms_to_spawn()
 	return ..() + /obj/item/device/flashlight
 
-/obj/structure/closet/firecloset/update_icon()
-	if(!opened)
-		icon_state = icon_closed
-	else
-		icon_state = icon_opened
-
 
 /*
  * Tool Closet


### PR DESCRIPTION
Removes lesser update_icon() function that doesn't have the welded check for the overlay to fix issue #25086.

<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Removes a flawed function so it uses the proper one to fix https://github.com/vgstation-coders/vgstation13/issues/25086
## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Fire closet is now clearly welded
## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
![Screenshot 2025-01-15 163215](https://github.com/user-attachments/assets/39723425-a48f-4b69-b691-adda53111d9a)
Welded, opened, closed, and attempted to open welded closet.  All behaved as expected.
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
Fixed welded sprite for fire closet.
