### PR TITLE
Ghost Costume Backpack Change

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -788,7 +788,7 @@ var/list/tag_suits_list = list()
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
 	hood = new /obj/item/clothing/head/bedsheet_ghost()
 	hood_suit_name = "robes"
-	body_parts_covered = FULL_BODY|HIDEBACK
+	body_parts_covered = FULL_BODY
 	body_parts_visible_override = FEET
 	force_hood = TRUE
 


### PR DESCRIPTION
Removed the restriction on backpacks with the ghost costume, as per [37310](https://github.com/vgstation-coders/vgstation13/issues/37310).

<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Makes it so the ghost costume doesn't hide/block the back slot.
## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
I'm not sure it is, this was certainly intentional when it was made.  I'd say consider for a moment before changing, although yvvel made the bug report so ???
## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Donning and doffing a backpack while wearing the costume.
![backpack](https://github.com/user-attachments/assets/881a2e36-9725-4f7b-8498-3ff8e32a935c)

🆑

tweak: Ghost costumes and backpacks can be worn simultaneously.