### PR TITLE
Adds full list of possible syndicate codewords to traitor info book

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -173,6 +173,9 @@ var/list/syndicate_code_response //Code response for traitors.
 	/N
 	*/
 
+var/global/list/syndinouns = list("love","hate","anger","peace","pride","sympathy","bravery","loyalty","honesty","integrity","compassion","charity","success","courage","deceit","skill","beauty","brilliance","pain","misery","beliefs","dreams","justice","truth","faith","liberty","knowledge","thought","information","culture","trust","dedication","progress","education","hospitality","leisure","trouble","friendships", "relaxation")
+var/global/list/syndidrinks = list("vodka and tonic","gin fizz","bahama mama","manhattan","black Russian","whiskey soda","long island tea","margarita","Irish coffee"," manly dwarf","Irish cream","doctor's delight","Beepsky Smash","tequila sunrise","brave bull","gargle blaster","bloody mary","whiskey cola","white Russian","vodka martini","martini","Cuba libre","kahlua","vodka","wine","moonshine")
+
 /proc/generate_code_phrase()//Proc is used for phrase and response in master_controller.dm
 
 	var/list/code_phrase = list()//What is returned when the proc finishes.
@@ -184,8 +187,6 @@ var/list/syndicate_code_response //Code response for traitors.
 	)
 
 	var/safety[] = list(1,2,3)//Tells the proc which options to remove later on.
-	var/nouns[] = list("love","hate","anger","peace","pride","sympathy","bravery","loyalty","honesty","integrity","compassion","charity","success","courage","deceit","skill","beauty","brilliance","pain","misery","beliefs","dreams","justice","truth","faith","liberty","knowledge","thought","information","culture","trust","dedication","progress","education","hospitality","leisure","trouble","friendships", "relaxation")
-	var/drinks[] = list("vodka and tonic","gin fizz","bahama mama","manhattan","black Russian","whiskey soda","long island tea","margarita","Irish coffee"," manly dwarf","Irish cream","doctor's delight","Beepsky Smash","tequila sunrise","brave bull","gargle blaster","bloody mary","whiskey cola","white Russian","vodka martini","martini","Cuba libre","kahlua","vodka","wine","moonshine")
 
 	var/names[] = list()
 	for(var/datum/data/record/t in data_core.general)//Picks from crew manifest.
@@ -212,12 +213,12 @@ var/list/syndicate_code_response //Code response for traitors.
 						code_phrase.Insert(0, pick(get_all_jobs()))
 				safety -= 1
 			if(2)
-				code_phrase.Insert(0, pick(drinks))
+				code_phrase.Insert(0, pick(syndidrinks))
 				safety -= 2
 			if(3)
 				switch(rand(1,3))//Nouns, adjectives, verbs. Can be selected more than once.
 					if(1)
-						code_phrase.Insert(0, pick(nouns))
+						code_phrase.Insert(0, pick(syndinouns))
 					if(2)
 						code_phrase.Insert(0, pick(adjectives))
 					if(3)

--- a/code/datums/outfit/security.dm
+++ b/code/datums/outfit/security.dm
@@ -164,7 +164,7 @@
 
 	items_to_spawn = list(
 		"Default" = list(
-			slot_ears_str = /obj/item/device/radio/headset/headset_sec,
+			slot_ears_str = /obj/item/device/radio/headset/headset_sec/det,
 			slot_w_uniform_str = list(
 				"Forensic Technician" = /obj/item/clothing/under/det,
 				"Gumshoe" = /obj/item/clothing/under/det/noir,
@@ -193,7 +193,7 @@
 			slot_l_store_str = /obj/item/weapon/lighter/zippo,
 		),
 		/datum/species/plasmaman = list(
-			slot_ears_str = /obj/item/device/radio/headset/headset_sec,
+			slot_ears_str = /obj/item/device/radio/headset/headset_sec/det,
 			slot_w_uniform_str = list(
 				"Forensic Technician" = /obj/item/clothing/under/det,
 				"Gumshoe" =  /obj/item/clothing/under/det/noir,
@@ -214,7 +214,7 @@
 			slot_l_store_str = /obj/item/weapon/lighter/zippo,
 		),
 		/datum/species/vox = list(
-			slot_ears_str = /obj/item/device/radio/headset/headset_sec,
+			slot_ears_str = /obj/item/device/radio/headset/headset_sec/det,
 			slot_w_uniform_str = list(
 				"Forensic Technician" = /obj/item/clothing/under/det,
 				"Gumshoe" = /obj/item/clothing/under/det/noir,

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -84,6 +84,10 @@
 	item_state = "headset"
 	init_keyslot2_type = /obj/item/device/encryptionkey/headset_sec
 
+/obj/item/device/radio/headset/headset_sec/det
+	name = "detective radio headset"
+	desc = "This is used by your hard boiled gumshoe. To access the security channel, use :s."
+
 /obj/item/device/radio/headset/headset_eng
 	name = "engineering radio headset"
 	desc = "When the engineers wish to chat like girls. To access the engineering channel, use :e. "

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -87,6 +87,15 @@
 /obj/item/device/radio/headset/headset_sec/det
 	name = "detective radio headset"
 	desc = "This is used by your hard boiled gumshoe. To access the security channel, use :s."
+	var/filter_codewords = FALSE
+
+/obj/item/device/radio/headset/headset_sec/det/text_misc()
+	return "Codeword filtering is <A href='byond://?src=\ref[src];togglecodewords=1'>[filter_codewords ? "ON" : "OFF"]</A><br>"
+
+/obj/item/device/radio/headset/headset_sec/det/Topic(href, href_list)
+	if(!..() && href_list["togglecodewords"])
+		filter_codewords = !filter_codewords
+		update_check()
 
 /obj/item/device/radio/headset/headset_eng
 	name = "engineering radio headset"

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -106,9 +106,12 @@
 
 	for (var/ch_name in channels)
 		dat+=text_sec_channel(ch_name, channels[ch_name])
-	dat+={"[text_wires()]</TT></body></html>"}
+	dat+={"[text_misc()][text_wires()]</TT></body></html>"}
 	user << browse(dat, "window=radio")
 	onclose(user, "radio")
+	return
+
+/obj/item/device/radio/proc/text_misc()
 	return
 
 /obj/item/device/radio/proc/text_wires()
@@ -194,17 +197,20 @@
 				channels[chan_name] &= ~FREQ_LISTENING
 			else
 				channels[chan_name] |= FREQ_LISTENING
-	if (!( master ))
-		if (istype(loc, /mob))
+	update_check()
+	add_fingerprint(usr)
+
+/obj/item/device/radio/proc/update_check()
+	if (!master)
+		if (ismob(loc))
 			interact(loc)
 		else
 			updateDialog()
 	else
-		if (istype(master.loc, /mob))
+		if (ismob(master.loc))
 			interact(master.loc)
 		else
 			updateDialog()
-	add_fingerprint(usr)
 
 /obj/item/device/radio/proc/isWireCut(var/index)
 	return wires.IsIndexCut(index)

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -573,7 +573,14 @@
 				<h2><img src='data:image/png;base64,[icon2base64(icon('icons/logos.dmi', "synd-logo"))]' style='position: relative; top: 8;'><a id="Syndicate">The Syndicate</h2>
 
                 <p>The Syndicate is an alliance composed of Nanotrasen’s most disreputable corporate competitors. They are the most notorious threat we face, and have made it their goal to challenge our influence in this sector. In an attempt to do this, they have funneled saboteurs into our workforce, and at times even send strike teams to destroy our stations by using nuclear devices. Syndicate operators are to be detained immediately, and in some extreme cases, terminated on sight. Their distinctive red attire has been attributed to the scavenged soviet spacesuits from the fourth Cold War era that their operatives use as combat armor and EVA equipment.
-
+				<p>The following is a list of all known possible Syndicate code phrases and responses:</p>
+				<p>[english_list(syndinouns)]</p>
+				<p>[english_list(adjectives)]</p>
+				<p>[english_list(verbs)]</p>
+				<p>[english_list(syndidrinks)]</p>
+				<p>[english_list(get_all_jobs())]</p>
+				<p>As well as any given name of your crew members.</p>
+				
 				<h3>Traitors</h3>
 				<p>Agents of the Syndicate have infiltrated many of our space stations and operate among us. This vast network of sleeper cells defies all investigation, and as such pre-emptive attempts at discovering infiltrators is discouraged by company policy (see Space Law and Standard Operating Procedure). However, agents come equipped with an uplink filled with "telecrystals" (TCs), hidden in their PDAs. When the Syndicate activates them, they are able to use this uplink to transport contraband aboard our stations to assist their attempts to cause wanton sabotage and destruction. Syndicate contraband can be a quick identifier of these saboteurs.
 

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -579,7 +579,9 @@
 				<p>[english_list(verbs)]</p>
 				<p>[english_list(syndidrinks)]</p>
 				<p>[english_list(get_all_jobs())]</p>
-				<p>As well as any given name of your crew members.</p>
+				<p>[english_list(first_names_male)]</p>
+				<p>[english_list(first_names_female)]</p>
+				<p>[english_list(last_names)]</p>
 				
 				<h3>Traitors</h3>
 				<p>Agents of the Syndicate have infiltrated many of our space stations and operate among us. This vast network of sleeper cells defies all investigation, and as such pre-emptive attempts at discovering infiltrators is discouraged by company policy (see Space Law and Standard Operating Procedure). However, agents come equipped with an uplink filled with "telecrystals" (TCs), hidden in their PDAs. When the Syndicate activates them, they are able to use this uplink to transport contraband aboard our stations to assist their attempts to cause wanton sabotage and destruction. Syndicate contraband can be a quick identifier of these saboteurs.

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -505,8 +505,8 @@
 	fits_max_w_class = W_CLASS_MEDIUM
 	can_add_combinedwclass = TRUE
 	items_to_spawn = list(
-		/obj/item/device/radio/headset/headset_sec,
-			/obj/item/clothing/glasses/hud/tracking/detective,
+		/obj/item/device/radio/headset/headset_sec/det,
+		/obj/item/clothing/glasses/hud/tracking/detective,
 		/obj/item/clothing/gloves/black,
 		/obj/item/weapon/storage/belt/detective,
 		/obj/item/weapon/switchtool/switchblade,

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -735,7 +735,7 @@
 	corpseuniform = /obj/item/clothing/under/det
 	corpsesuit = /obj/item/clothing/suit/storage/det_suit
 	corpseback = /obj/item/weapon/storage/backpack
-	corpseradio = /obj/item/device/radio/headset/headset_sec
+	corpseradio = /obj/item/device/radio/headset/headset_sec/det
 	corpsegloves = /obj/item/clothing/gloves/black
 	corpseshoes = /obj/item/clothing/shoes/brown
 	corpsepocket1 = /obj/item/weapon/lighter/zippo

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -298,7 +298,7 @@ var/list/headset_modes = list(
 
 	var/obj/item/device/radio/headset/headset_sec/det/DH = get_item_by_slot(slot_ears)
 	if(DH && istype(DH) && DH.filter_codewords)
-		var/list/all_possible_syndi_phrases = syndinouns + syndidrinks + verbs + adjectives
+		var/list/all_possible_syndi_phrases = syndinouns + syndidrinks + verbs + adjectives + get_all_jobs() + first_names_male + first_names_female + last_names
 		for(var/T in all_possible_syndi_phrases)
 			rendered_message = replacetext(rendered_message, html_encode(T), "<i style='color: red;'>[html_encode(T)]</i>")
 	//checking for syndie codephrases if person is a tator

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -296,8 +296,12 @@ var/list/headset_modes = list(
 	if(!say_understands((istype(AM) ? AM : speech.speaker),speech.language)|| force_compose) //force_compose is so AIs don't end up without their hrefs.
 		rendered_message = render_speech(speech)
 
+	if(istype(get_item_by_slot(slot_ears),/obj/item/device/radio/headset/headset_sec/det))
+		var/list/all_possible_syndi_phrases = syndinouns + syndidrinks + verbs + adjectives
+		for(var/T in all_possible_syndi_phrases)
+			rendered_message = replacetext(rendered_message, html_encode(T), "<i style='color: red;'>[html_encode(T)]</i>")
 	//checking for syndie codephrases if person is a tator
-	if(src.mind.GetRole(TRAITOR) || src.mind.GetRole(NUKE_OP) || src.mind.GetRole(CHALLENGER))
+	else if(src.mind.GetRole(TRAITOR) || src.mind.GetRole(NUKE_OP) || src.mind.GetRole(CHALLENGER))
 		for(var/T in syndicate_code_phrase)
 			rendered_message = replacetext(rendered_message, html_encode(T), "<b style='color: red;'>[html_encode(T)]</b>")
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -296,7 +296,8 @@ var/list/headset_modes = list(
 	if(!say_understands((istype(AM) ? AM : speech.speaker),speech.language)|| force_compose) //force_compose is so AIs don't end up without their hrefs.
 		rendered_message = render_speech(speech)
 
-	if(istype(get_item_by_slot(slot_ears),/obj/item/device/radio/headset/headset_sec/det))
+	var/obj/item/device/radio/headset/headset_sec/det/DH = get_item_by_slot(slot_ears)
+	if(DH && istype(DH) && DH.filter_codewords)
 		var/list/all_possible_syndi_phrases = syndinouns + syndidrinks + verbs + adjectives
 		for(var/T in all_possible_syndi_phrases)
 			rendered_message = replacetext(rendered_message, html_encode(T), "<i style='color: red;'>[html_encode(T)]</i>")


### PR DESCRIPTION
[tweak]

## What this does
specifically, the ones sec use. it does **not** reveal the current words in the round.
also adds functionality to detective headsets to highlight these possible words in red when heard. note that traitors who have them memorised override this feature and only hear their own.

## Why it's good
keeps sec in the know about the concept of this stuff without giving anything away (codediving has the same effect anyways)

## How it was tested
opening the book, using a detective headset and saying the phrases.

## Changelog
:cl:
 * rscadd: The full list of possible syndicate code phrases has been added to security guides on traitors. Note, this does not specifically reveal the current ones in use in a round.
 * rscadd: Detective headsets can now have all possible syndicate codewords highlighted in red, but again, not just the ones currently used in the round.