### PR TITLE
Reduced Eclipse Duration

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_eclipse.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_eclipse.dm
@@ -29,7 +29,7 @@
 /proc/eclipse_trigger_random()
 	if (!sun || !sun.eclipse_manager)
 		return
-	sun.eclipse_manager.eclipse_start(rand(8 MINUTES, 12 MINUTES))
+	sun.eclipse_manager.eclipse_start(rand(4 MINUTES, 6 MINUTES))
 
 /datum/eclipse_manager/proc/eclipse_start(var/duration)
 	eclipse_start_time = world.time


### PR DESCRIPTION
## What this does
Changes the duration of eclipses from 8-12 minutes to 4-6 minutes. Note that typically the alert for a prolonged eclipse caused by a cultist happens 3 minutes after the natural end time, so this does function as a nerf to hidden cults, reducing the time from when they're presence is announced following an eclipse to 7-9 minutes down from 11-15 minutes.

## Why it's good
Random event eclipses last, in my opinion, way, way too long. You just have to sit in the dark unable to see anything, even if you packed a flashlight, for upwards of 10 minutes and I doubt anyone thinks that's terribly fun.

## How it was tested
Timed eclipse duration, clocked in at just over 4 minutes.

## Changelog
[gamemode]
[qol]
[tweak]
:cl:
 * tweak: Changed eclipse duration from 8-12 minutes to 4-6 minutes