### PR TITLE
Venom Sword Suit Storage

### DIFF
--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -47,7 +47,7 @@
 	desc = "Bluer than the standard model."
 	base_icon_state = "labcoat_cmo"
 	item_state = "labcoat_cmo"
-	allowed = list(/obj/item/device/analyzer,/obj/item/stack/medical,/obj/item/weapon/dnainjector,/obj/item/weapon/reagent_containers/dropper,/obj/item/weapon/reagent_containers/syringe,/obj/item/weapon/reagent_containers/hypospray,/obj/item/device/healthanalyzer,/obj/item/device/antibody_scanner,/obj/item/device/flashlight/pen,/obj/item/weapon/minihoe,/obj/item/weapon/switchtool,/obj/item/roller,/obj/item/weapon/autopsy_scanner/healthanalyzerpro)
+	allowed = list(/obj/item/device/analyzer,/obj/item/stack/medical,/obj/item/weapon/dnainjector,/obj/item/weapon/reagent_containers/dropper,/obj/item/weapon/reagent_containers/syringe,/obj/item/weapon/reagent_containers/hypospray,/obj/item/device/healthanalyzer,/obj/item/device/antibody_scanner,/obj/item/device/flashlight/pen,/obj/item/weapon/minihoe,/obj/item/weapon/switchtool,/obj/item/roller,/obj/item/weapon/autopsy_scanner/healthanalyzerpro,/obj/item/weapon/sword/venom)
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 70, rad = 0)
 	species_fit = list(VOX_SHAPED, GREY_SHAPED, INSECT_SHAPED)
 	sterility = 50


### PR DESCRIPTION
## What this does
Adds the venom sword to the suit storage list for the CMO's coat.

## Why it's good
The venom sword is funny, and this will encourage its use.

## How it was tested
I put the venom sword in the suit storage slot. I then verified it couldn't hold other swords.

## Changelog
[tweak]
:cl:
 * tweak: Added the venom sword to the CMO coat suit storage list.