### PR TITLE
The Blitzkrieg syndiebot (nuke ops) now has an emag.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -544,6 +544,7 @@
 /obj/item/weapon/robot_module/syndicate/blitzkrieg/New()
 	..()
 
+	modules += new /obj/item/weapon/card/emag(src)
 	modules += new /obj/item/tool/wrench(src) //This thing supposed to be a hacked and modded combat cyborg, is it really going to be stopped by a chair or table?
 	modules += new /obj/item/weapon/pinpointer/nukeop(src)
 	modules += new /obj/item/weapon/gun/projectile/automatic/c20r(src)


### PR DESCRIPTION
## What this does
Gives the Blitzkrieg borg module (nuke ops) an emag.
## Why it's good
You're supposed to be a massive threat but a single access-limited airlock stops all mayhem. Also parity with the other syndiebot module (crisis), which has an emag.
## How it was tested
It wasn't, but it's a 1 line change.
:cl:
 * rscadd: Blitzkrieg module cyborgs (Nuke Ops) now carry an emag for door busting purposes.