### PR TITLE
fixes #37387

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -221,7 +221,8 @@
 		return 0
 
 	// adjacent only loc checks one way around, so first part is necessary, also for anything inside too
-	if(W.loc && !W.recursive_in_contents_of(src) && !Adjacent(W) && !W.arcanetampered)
+	//By using the item's adjacent check instead of the user's, we allow for some item exceptions (e.g.: battlemat)
+	if(W.loc && !W.recursive_in_contents_of(src) && !W.Adjacent(src) && !W.arcanetampered)
 		return 0
 
 	if((W.flags & MUSTTWOHAND) && !(M_STRONG in mutations))


### PR DESCRIPTION
Should fix #37387

Tested by Dacendeth

The problem was caused in objects/items.dm L448. The game would correctly identify that the game piece is adjacent due to the battlemat exception - passing the adjacent test - but then fail the put_in_hand check because from the mob's perspective they are not adjacent. Thus, it uses the fallback of moving the item to the user's tile (without resetting its pixel offset). By changing the test inside pickup to use the item's adjacency, it should go to hand.

🆑 
* bugfix: Battlemats allow you to pick up game pieces no matter what side of the board you are sitting on.