### PR TITLE
fixes #37356

### DIFF
--- a/code/modules/power/antimatter/containment_jar.dm
+++ b/code/modules/power/antimatter/containment_jar.dm
@@ -82,3 +82,4 @@ var/list/decelerators = list()
 
 /obj/item/weapon/am_containment/proc/receive_pulse(power)
 	fuel = min(fuel_max, fuel + round(power/25))
+	update_icon()


### PR DESCRIPTION
fixes #37356

Trivial one line fix to make icon update properly when it gets a radiation pulse, only did it because it was so easy a clown could do it.

🆑 
* bugfix: AM containment jars now properly update sprite when recharged with radiation.