### PR TITLE
Create Racial Fallbacks

### DIFF
--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -179,3 +179,6 @@
 	for(var/i = 1 to sounds)
 		newname += pick(vox_name_syllables)
 	return capitalize(newname)
+
+/datum/species/skellington/skelevox/fallback()
+	return all_species["Vox"]

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -181,4 +181,4 @@
 	return capitalize(newname)
 
 /datum/species/skellington/skelevox/fallback()
-	return all_species["Vox"]
+	return "Vox"

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -340,6 +340,9 @@ var/global/list/playable_species = list("Human")
 /datum/species/proc/conditional_playable()
 	return 0
 
+/datum/species/proc/fallback()
+	return all_species["Human"]
+
 /datum/species/human
 	name = "Human"
 	known_languages = list(LANGUAGE_HUMAN)
@@ -465,6 +468,8 @@ var/global/list/playable_species = list("Human")
 	var/MM = text2num(time2text(world.timeofday, "MM"))
 	return MM == 10 //October
 
+/datum/species/skellington/fallback()
+	return all_species["Plasmaman"]
 
 /datum/species/skellington/handle_speech(var/datum/speech/speech, mob/living/carbon/human/H)
 	if (prob(25))

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -341,7 +341,7 @@ var/global/list/playable_species = list("Human")
 	return 0
 
 /datum/species/proc/fallback()
-	return all_species["Human"]
+	return "Human"
 
 /datum/species/human
 	name = "Human"
@@ -469,7 +469,7 @@ var/global/list/playable_species = list("Human")
 	return MM == 10 //October
 
 /datum/species/skellington/fallback()
-	return all_species["Plasmaman"]
+	return "Plasmaman"
 
 /datum/species/skellington/handle_speech(var/datum/speech/speech, mob/living/carbon/human/H)
 	if (prob(25))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -677,11 +677,9 @@
 		chosen_species = all_species[prefs.species]
 	if(chosen_species && (check_rights(R_ADMIN, 0) || chosen_species.flags & PLAYABLE || chosen_species.conditional_playable()))
 		new_character.set_species(prefs.species)
-	else
-		to_chat(usr, "Your preferences had a non-playable species, so you were reverted to the default species.")
-		var/datum/species/defaultspec = chosen_species.fallback()
-		if(defaultspec)
-			new_character.set_species(defaultspec)
+	else if(chosen_species.fallback())
+		to_chat(usr, "Your preferences had a non-playable species, so you were reverted to [chosen_species.fallback()] (default for [chosen_species]).")
+		new_character.set_species(chosen_species.fallback())
 
 	var/datum/language/chosen_language
 	if(prefs.language)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -679,6 +679,9 @@
 		new_character.set_species(prefs.species)
 	else
 		to_chat(usr, "Your preferences had a non-playable species, so you were reverted to the default species.")
+		var/datum/species/defaultspec = chosen_species.fallback()
+		if(defaultspec)
+			new_character.set_species(defaultspec)
 
 	var/datum/language/chosen_language
 	if(prefs.language)


### PR DESCRIPTION
fixes #36135

Not tested!


🆑 
* bugfix: Rather than defaulting you to human when you select skellington or skelevox out of season, the game will instead spawn you as a plasmaman or vox. This also avoids some unfortunate latespawns for skelevox traders after October.