### PR TITLE
assorted fission reactor typofixes 

### DIFF
--- a/code/datums/supply_packs/engineering.dm
+++ b/code/datums/supply_packs/engineering.dm
@@ -448,7 +448,7 @@
 	containername = "Fission reactor starter kit"
 	group = "Engineering"
 	access = list(access_engine_major)
-	containsdesc = "Everything you need to build a very basic fission reactor. Comes with a pre-filled (albeit small) fuel rod."
+	containsdesc = "Everything you need to build a very basic fission reactor. Comes with a pre-filled (albeit small) fuel reservoir."
 	
 /datum/supply_packs/fissionreactor_expansion
 	contains = list(
@@ -475,13 +475,13 @@
 	contains = list(
 		/obj/item/weapon/fuelrod/large
 	)
-	name = "High-capacity fuel rod"
+	name = "High-capacity fuel reservoir"
 	cost = 100 //It's a one time purchance, really. somewhat costy, but not that much for a department. watch for meltdowns.
 	containertype = /obj/structure/closet/crate/secure/large/reinforced/shard/empty
-	containername = "Large fuel rod"
+	containername = "Large fuel reservoir"
 	group = "Engineering"
 	access = list(access_engine_major)
-	containsdesc = "An extra-large fuel rod, for extra power or for more complex fuel mixes. Use with extreme caution and control rods inserted."
+	containsdesc = "An extra-large fuel reservoir, for extra power or for more complex fuel mixes. Use with extreme caution and control rods inserted."
 		
 				
 		

--- a/code/game/objects/items/stacks/stack_recipes.dm
+++ b/code/game/objects/items/stacks/stack_recipes.dm
@@ -450,7 +450,7 @@ var/list/datum/stack_recipe/plasteel_recipes = list (
 	new/datum/stack_recipe("Reinforced machine frame",	/obj/machinery/constructable_frame/machine_frame/reinforced,	5,  time = 60, one_per_turf = 1	),
 	null,
 	new/datum/stack_recipe("Reactor casing frame",	/obj/structure/girder/reactor,	4,  time = 50, one_per_turf = 1	),
-	new/datum/stack_recipe("Reactor fuel rod",	/obj/item/weapon/fuelrod,	2,	time = 25),
+	new/datum/stack_recipe("Reactor fuel reservoir",	/obj/item/weapon/fuelrod,	2,	time = 25),
 	)
 
 /* ====================================================================

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -1381,7 +1381,7 @@ color:white;
 </head>
 <body>
 	
-<h1>Fission Reactors: a quick guide</h1>	
+<h1>Fission Reactors: A Quick Guide</h1>	
 <p>
 Though often said to be old, outdated technology, fission power should not be underestimated. Even a modest reactor is capable of powering a medium-sized station for several hours with no upkeep, and the dismissal of fission technology has delayed the uncovering of more recent discoveries in material sciences which may have been known decades earlier.
 </p>
@@ -1397,87 +1397,87 @@ building a reactor is an expensive endeavor, costing a lot of both time and reso
 	<li>2 scanning modules</li>
 	<li>2 micro-manipulators</li>
 	<li>1 console screen</li>
-	<li>fissile material and a fuel rod (provided in the starter kit)</li>
-	<li>circuit boards for the controller, fuel rod, and control rod assemblies</li>
-	<li>piping (partially included)</li>
-	<li>at least 1 thermoelectric generator (not included)</li>
-	<li>a welder, crowbar, screwdriver, wrench, and wirecutters (not included)</li>
+	<li>Fissile material and a fuel reservoir (provided in the starter kit)</li>
+	<li>Circuit boards for the controller, fuel rod, and control rod assemblies</li>
+	<li>Piping (partially included)</li>
+	<li>At least 1 thermoelectric generator (not included)</li>
+	<li>A welder, crowbar, screwdriver, wrench, and wirecutters (not included)</li>
 </ul>
 
-<b>additionally</b>, to make a isotopic separational combiner (the machine used to fill and additionally recycle spent fuel) you will need the following materials (provided in the starter kit):
+<b>Additionally</b>, to make a isotopic separational combiner (the machine used to fill and additionally recycle spent fuel) you will need the following materials (provided in the starter kit):
 <ul>
 	<li>5 sheets of metal</li>
 	<li>5 lengths of wire</li>
-	<li>2 mater bins</li>
+	<li>2 matter bins</li>
 	<li>2 scanning modules</li>
 	<li>1 micro-manipulator</li>
 	<li>1 console screen</li>
-	<li>the associated circuit board</li>
-	<li>piping (not included)</li>
+	<li>The associated circuitboard</li>
+	<li>Piping (not included)</li>
 </ul>
 <hr>
 <h2>How to construct the parts</h2>
-	<h3>Reactor casing</h3>
+	<h3>Reactor Casing</h3>
 	<ol>
-		<li>use 4 plasteel to construct a reactor casing frame in the desired location</li>
-		<li>insert 4 metal rods inside of the frame</li>
-		<li>use a screwdriver to fasten the rods</li>
-		<li>(optional) insert a straight pipe into the frame to make it a coolant port</li>
-		<li>(optional) use a crowbar to change the direction of the port</li>
-		<li>apply 2 plasteel as external plating</li>
-		<li>weld the external plating to the frame</li>
+		<li>Use 4 plasteel to construct a reactor casing frame in the desired location</li>
+		<li>Insert 4 metal rods inside of the frame</li>
+		<li>Use a screwdriver to fasten the rods</li>
+		<li>(Optional) Insert a straight pipe into the frame to make it a coolant port</li>
+		<li>(Optional) Use a crowbar to change the direction of the port</li>
+		<li>Install 2 plasteel sheets as external plating</li>
+		<li>Weld the external plating to the frame</li>
 	</ol>
 	
-	<h3>Control & Fuel rod assembly</h3>
+	<h3>Control & Fuel Rod Assembly</h3>
 	<ol>
-		<li>use 5 plasteel to construct a reinforced machine frame in the desired location</li>
-		<li>add 5 lengths of wiring to the machine</li>
-		<li>insert the corresponding circuit board</li>
-		<li>insert 2 metal rods inside of the frame</li>
-		<li>add a matter bin to the frame</li>
-		<li><b>if control rod:</b> add a micro-manipulator<br><b>if fuel rod:</b> add a scanning module</li>
-		<li>use a screwdriver to finish assembly</li>
+		<li>Use 5 plasteel to construct a reinforced machine frame in the desired location</li>
+		<li>Add 5 lengths of wiring to the machine</li>
+		<li>Insert the corresponding circuit board</li>
+		<li>Insert 2 metal rods inside of the frame</li>
+		<li>Add a matter bin to the frame</li>
+		<li><b>If control rod:</b> Add a micro-manipulator<br><b>If fuel rod:</b> Add a scanning module</li>
+		<li>Use a screwdriver to finish assembly</li>
 	</ol>	
 	
-	<h3>Reactor controller</h3>
+	<h3>Reactor Controller</h3>
 	<ol>
-		<li>use 5 plasteel to construct a reinforced machine frame in the desired location</li>
-		<li>add 5 lengths of wiring to the machine</li>
-		<li>insert the circuit board</li>
-		<li>insert 2 metal rods inside of the frame</li>
-		<li>add a matter bin, micro-manipulator, scanning module, and a console screen to the frame</li>
-		<li>use a screwdriver to finish assembly</li>
+		<li>Use 5 plasteel to construct a reinforced machine frame in the desired location</li>
+		<li>Add 5 lengths of wiring to the machine</li>
+		<li>Insert the circuit board</li>
+		<li>Insert 2 metal rods inside of the frame</li>
+		<li>Add a matter bin, micro-manipulator, scanning module, and a console screen to the frame</li>
+		<li>Use a screwdriver to finish assembly</li>
 	</ol>	
 	
-	<h3>Isotopic separational combiner</h3>
+	<h3>Isotopic Separational Combiner</h3>
 	<ol>
 		<li>Use 5 metal to construct a machine frame in the desired location</li>
-		<li>add 5 lengths of wiring to the machine</li>
-		<li>insert the circuit board</li>
-		<li>add a 2 matter bins, micro-manipulator, 2 scanning modules, and a console screen to the frame</li>
-		<li>use a screwdriver to finish assembly</li>
+		<li>Add 5 lengths of wiring to the machine</li>
+		<li>Insert the circuitboard</li>
+		<li>Add a 2 matter bins, micro-manipulator, 2 scanning modules, and a console screen to the frame</li>
+		<li>Use a screwdriver to finish assembly</li>
 	</ol>
 
-<h2>Design considerations</h2>	
+<h2>Design Considerations</h2>	
 <p>
-The design of a nuclear reactor is very important. build it wrong, and you may find yourself having a meltdown.
+The design of a nuclear reactor is very important. Build it wrong, and you may find yourself with a meltdown.
 
-	<h3>casing</h3>
-	the casing of a reactor should include the whole perimeter of it, with no gaps.
-	<h3>coolant ports</h3>
-	a reactor should have at least 2 ports, one for a coolant input, and another for output. coolant ports can be placed at any point in the casing.
+	<h3>Casing</h3>
+	The casing of a reactor should include the whole perimeter of it, with no gaps.
+	<h3>Coolant Ports</h3>
+	A reactor should have at least 2 ports, one for a coolant input, and another for output. coolant ports can be placed at any point in the casing.
 	<h3>controller</h3>
-	a reactor can only have 1 controller to it, and must be placed at a corner of a reactor.
-	<h3>fuel rods</h3>
-	fuel rods should be placed in the interior of the reactor. for each cardinally-adjacent fuel rod, a fuel rod will gain bonus power production without affecting fuel duration. Fuel duration is only affected by the number of fuel rod assemblies.
-	<h3>control rods</h3>
-	control rods are able to affect fuel rods in every ordinal direction around them. if a control rod is not affecting a fuel rod, then the reaction is unable to be stopped. it is recommended to have all fuel rods be controlled for safety reasons.
+	A reactor can only have 1 controller to it, and must be placed at a corner of a reactor.
+	<h3>Fuel Rods</h3>
+	Fuel rods should be placed in the interior of the reactor. For each cardinally-adjacent fuel rod, a fuel rod will gain bonus power production without affecting fuel duration. Fuel duration is only affected by the number of fuel rod assemblies.
+	<h3>Control Rods</h3>
+	Control rods are able to affect fuel rods in every ordinal direction around them. If a control rod is not affecting a fuel rod, then the reaction in that rod cannot be stopped. It is recommended to have all fuel rods be controlled for safety reasons.
 	
 	
 
 	
 	
-	<h3>Example designs</h3>
+	<h3>Example Designs</h3>
 	
 	<div style='border:2px black solid;background-color:LightSteelBlue;'>
 	<h3 style='text-decoration:underline;'>key</h3>
@@ -1513,10 +1513,10 @@ The design of a nuclear reactor is very important. build it wrong, and you may f
 	</table>
 	<b>The starter</b>
 	<div>
-		fuel rods: 1<br>
-		control rods: 1 <br>
-		fissile speed: 100%<br>
-		fuel reactivity: 100%<br>
+		Fuel rods: 1<br>
+		Control rods: 1 <br>
+		Fissile speed: 100%<br>
+		Fuel reactivity: 100%<br>
 	</div>
 	
 	<table class='reactor_schematic'>
@@ -1547,10 +1547,10 @@ The design of a nuclear reactor is very important. build it wrong, and you may f
 	</table>
 	<b>The upgrade</b>
 	<div>
-		fuel rods: 3<br>
-		control rods: 1 <br>
-		fissile speed: 300%<br>
-		fuel reactivity: 700%<br>
+		Fuel rods: 3<br>
+		Control rods: 1 <br>
+		Fissile speed: 300%<br>
+		Fuel reactivity: 700%<br>
 	</div>
 	
 		<table class='reactor_schematic'>
@@ -1637,71 +1637,71 @@ The design of a nuclear reactor is very important. build it wrong, and you may f
 	</table>
 	<b>For those up to the challenge</b>
 	<div>
-		fuel rods: 32<br>
-		control rods: 4 <br>
-		fissile speed: 3200%<br>
-		fuel reactivity: 12000%<br>
+		Fuel rods: 32<br>
+		Control rods: 4 <br>
+		Fissile speed: 3200%<br>
+		Fuel reactivity: 12000%<br>
 	</div>
 </p>
 
 
-<h2>Standard operation guide</h2>
-To avoid a catastrophic meltdown, a reactor must be monitored periodically to ensure that the temperature is not climbing too high.<br>
-Reactors can withstand temperatures up to 5500K, though the controller will activate a SCRAM protocol if the temperature exceeds 4500K. Once SCRAM is enabled, the control rods will be forced downwards and will remain on until the reactor has dropped below 1000K.<br>
-<sub>The circuit board is able to be modified so that autoSCRAM is disabled, however this practice is not endorsed by NanoTrasen, and the engineer assumes all liability for any damage to the station as a result of this.</sub>
+<h2>Standard Operation</h2>
+To avoid a catastrophic meltdown, a reactor must be monitored periodically to ensure that the temperature does NOT get too high.<br>
+Reactors can withstand temperatures up to 5500K, though the controller will activate a SCRAM protocol if the temperature exceeds 4500K. Once SCRAM is enabled, the control rods will be forced downwards and will remain down until the reactor has dropped below 1000K.<br>
+<sub>The circuitboard can able to be modified with a solder so that autoSCRAM is disabled, this practice is not endorsed by NanoTrasen, and the engineer assumes all liability for any damage to the station as a result of this.</sub>
 <br>
-Once your reactor is built, you will need to insert a fuel rod (one is provided in the starter kit). A reactor accepts only a single fuel rod, so it is encouraged to carefully prepare the fuel mixture in accordance to the design of the reactor.<br>
-Next, ensure that the coolant lines are operating as normal, and that there is adequate cooling for the output of your reactor. Once this is verified, return to the controller, and raise the control rods. It is recommended that this is done gradually, so that the engineer operating it can determine how far it can be safely pushed.<br>
+Once your reactor is built, you will need to insert a fuel reservoir (one is provided in the starter kit). A reactor accepts only a single fuel reservoir, so it is encouraged to carefully prepare the fuel mixture beforehand in accordance to the design of the reactor.<br>
+Next, ensure that the coolant lines are operating as normal, and that there is adequate cooling for the output of your reactor. Too little cooling and it might overheat, but too much and it'll won't heat enough. Once this is verified, return to the controller, and raise the control rods. It is recommended that this is done gradually, so that the engineer operating it can determine how far it can be safely pushed.<br>
 <br>
-Should the controller ever become unresponsive, a crowbar can be used to pry open the shielding and remove the fuel rod. Do note that if the reactor is still undergoing fission, you will need to overcome the safety locks, and you will most likely receive a dose of radiation, so some form of protection is advised when doing so, followed up by a hasty visit to the station's medical staff for an examination.<br>
+Should the controller ever become unresponsive, a crowbar can be used to pry open the shielding and remove the fuel reservoir. Do note that if the reactor is still undergoing fission, you will need to overcome the safety locks, and you will most likely receive a hefty dose of radiation, so some form of protection is advised when doing so, followed up by a hasty visit to the station's medical staff for an examination.<br>
 <br>
-Depending on a few factors, such as control rod insertion, construction, and fissile materials, a reactor will take between hours or tens of minutes to churn through a fuel rod. When this occurs, eject the spent rod, and replace it with a fresh one. If you are feeling unsatisfied with the current fuel mixture, the rod may be prematurely ejected.<br>
-Spent fuel contains a wide variety of fission byproducts, dependent on what was used in the fuel. Designing a fuel mixture involves a lot of compromises, between lifespan, power output, and fission products. Beginners are advised to stick to a mixture of pure uranium, as it is a very consistent source of power, and has a relatively long lifespan, which allows a reactor to be ran with less maintenance and worries.<br>
-Different sizes of fuel rods exist, with the starter kit coming with a fairly small rod. A standard fuel rod can be constructed at the workplace, using 2 plasteel sheets and forming them into shape. Additionally, a larger fuel rod can be ordered from your station's cargo department, though newer engineers are discouraged from using this, as the higher abundance of fuel can result in an unstable reactor which melts down, and proper use will require a significant amount of modification to the piping to accommodate the much greater heat generation.<br>
+Depending on a few factors, such as control rod insertion, construction, and fissile materials, a reactor will take between hours or tens of minutes to churn through a fuel reservoir. When this occurs, eject the spent reservoir, and replace it with a fresh one. If you are feeling unsatisfied with the current fuel mixture, the reservoir may be prematurely ejected.<br>
+Spent fuel contains a wide variety of fission byproducts, dependent on what was used in the fuel. Designing a fuel mixture involves a lot of compromises, between lifespan, power output, and fission products. Beginners are advised to stick to a mixture of pure uranium, as it is a very consistent source of power, and has a relatively long lifespan, which allows a reactor to be ran with little maintenance or worries.<br>
+Different sizes of fuel reservoirs exist, with the starter kit coming with a fairly small 30u rod. A standard 90u fuel reservoir can be constructed at the workplace, using 2 plasteel sheets and forming them into shape. Additionally, a large capacity, 210u reservoir can be ordered from your station's cargo department, though newer engineers are discouraged from using this, as the higher abundance of fuel can result in an unstable reactor prone to meltdowns; proper use will require a significant amount of modification to the piping to accommodate the much greater heat generation.<br>
 
 
 
 
-<h2>How to disassemble</h2>
+<h2>How to Disassemble</h2>
 	
-	<span style='font-weight:bold;color:red;font-size:125%;'>IMPORTANT: before disassembling a reactor, drain all coolant first, and make sure that it is not currently undergoing fission. Failure to do so may result in injury, destruction of property, or even death.</span>
+	<span style='font-weight:bold;color:red;font-size:125%;'>IMPORTANT: Before disassembling a reactor, drain all coolant first, and make sure that it is not currently undergoing fission. Failure to do so may result in injury, destruction of property, or even death.</span>
 
-	<h3>Reactor casing</h3>
+	<h3>Reactor Casing</h3>
 	<ol>
-		<li>use a welder to detach the external plating from the frame</li>
-		<li>use a crowbar to pry off the plating from the frame</li>
-		<li>(optional) use a wrench to remove the piping if there is any</li>
-		<li>use a screwdriver to loosen the internal rods</li>
-		<li>use wirecutters to remove the rods</li>
-		<li>use a wrench to disassemble the frame</li>
+		<li>Use a welder to detach the external plating from the frame</li>
+		<li>Use a crowbar to pry off the plating from the frame</li>
+		<li>(Optional) Use a wrench to remove the piping if there is any</li>
+		<li>Use a screwdriver to loosen the internal rods</li>
+		<li>Use wirecutters to remove the rods</li>
+		<li>Use a wrench to disassemble the frame</li>
 	</ol>
 	
-	<h3>Control & Fuel rod assembly, reactor controller</h3>
+	<h3>Control & Fuel Rod Assembly, Reactor controller</h3>
 	<ol>
-		<li>use a welder to detach the external plating from the frame</li>
-		<li>use a crowbar to remove the internal components from the frame</li>
-		<li>use wirecutters to remove the wiring from the frame</li>
-		<li>use a wrench to disassemble the frame.</li>
+		<li>Use a welder to detach the external plating from the frame</li>
+		<li>Use a crowbar to remove the internal components from the frame</li>
+		<li>Use wirecutters to remove the wiring from the frame</li>
+		<li>Use a wrench to disassemble the frame</li>
 	</ol>	
 	
 	<h3>Isotopic separational combiner</h3>
 	<ol>
-		<li>use a screwdriver to open the maintenance hatch</li>
-		<li>use a crowbar to pry out the electronics</li>
-		<li>use wirecutters to remove the wiring from the frame</li>
-		<li>use a wrench to disassemble the frame.</li>
+		<li>Use a screwdriver to open the maintenance hatch</li>
+		<li>Use a crowbar to pry out the electronics</li>
+		<li>Use wirecutters to remove the wiring from the frame</li>
+		<li>Use a wrench to disassemble the frame</li>
 		
 	</ol>
 
 <h2>Other notes</h2>
-	If you unscrew the maintenance hatch of a fuel rod assembly, you can add 4 metal sheets to it. Doing so will make the assembly not give any bonuses for adjacent fuel rods. You can undo this by removing the sheets with a crowbar.
+	If you unscrew the maintenance hatch of a fuel rod assembly, you can add 4 metal sheets to it. Doing so will make the assembly not give any bonuses for adjacent fuel rods. You can undo this by removing said sheets with a crowbar.<br>
+	Some compounds will transform upon irradiation, such as Tricordrazine, Doctor's Delight, Degenerate Calcium, Plasma and Radium, give them a try and see what comes out, you might be surprised.
 	<br>
-	<br>
-	standard fuel rods can be made with 2 plasteel sheets. these are bigger than the small one given by the starter kit, but smaller than the one orderable from cargo.
+	Standard fuel reservoirs can be made with 2 plasteel sheets. These are 3x bigger than the small one given by the starter kit, but still smaller than the specialized one orderable from cargo.
 
 <br>
 <br>
-<h3><u>table of fuels:</u></h3>
+<h3><u>Table of Fuels:</u></h3>
 <table>
 <tr>
 	<th>Fuel</th>

--- a/code/modules/fissionreactor/fuelmaker.dm
+++ b/code/modules/fissionreactor/fuelmaker.dm
@@ -1,6 +1,6 @@
 /*
 in this file:
-the machine which makes fuel rods have things in them.
+the machine which makes fuel reservoirs have things in them.
 */
 
 //because radon is a gas, we need to interface with gasses. yeah, this kind of sucks, but what are you gonna do? (inb4 make better code lol)
@@ -33,11 +33,11 @@ the machine which makes fuel rods have things in them.
 /obj/machinery/atmospherics/unary/fissionfuelmaker/attackby(var/obj/item/I,var/mob/user)
 	if(istype(I,/obj/item/weapon/fuelrod))
 		if(heldrod)
-			to_chat(user,"There's already a fuel rod inserted into \the [src].")
+			to_chat(user,"There's already a fuel reservoir inserted into \the [src].")
 		else
 			if(!user.drop_item(I))
 				return
-			to_chat(user,"You insert the fuel rod into \the [src].")
+			to_chat(user,"You insert the fuel reservoir into \the [src].")
 			I.forceMove(src)
 			heldrod=I
 			heldrod.fueldata.fuel=heldrod.fueldata.get_products() //process the fuel turning
@@ -48,7 +48,7 @@ the machine which makes fuel rods have things in them.
 			update_icon()
 		return
 	if(iscrowbar(I) && heldrod)
-		user.visible_message("<span class='notice'>[user] starts prying the fuel rod out of \the [src].</span>", "<span class='notice'>You start prying the fuel rod out of \the [src].</span>")
+		user.visible_message("<span class='notice'>[user] starts prying the fuel reservoir out of \the [src].</span>", "<span class='notice'>You start prying the fuel reservoir out of \the [src].</span>")
 		playsound(src,'sound/items/crowbar.ogg',50)
 		if(do_after(user, src,20))
 			heldrod.forceMove(loc)
@@ -134,7 +134,7 @@ the machine which makes fuel rods have things in them.
 		switch(href_list["action"])
 			if("eject_fuel")	
 				if(!heldrod)
-					to_chat(hclient.client,"There's no fuel rod to eject.")
+					to_chat(hclient.client,"There's no fuel reservoir to eject.")
 				else
 					heldrod.forceMove(src.loc)
 					heldrod.update_icon()
@@ -168,7 +168,7 @@ the machine which makes fuel rods have things in them.
 
 /obj/machinery/atmospherics/unary/fissionfuelmaker/proc/transfer_from_fuelrod(var/reagent_id,var/amount)
 	if(!heldrod)
-		return "no fuel rod"
+		return "no fuel reservoir"
 	if(reagent_id==RADON || reagent_id=="RADON")
 		if(air_contents)
 			var/actually_taken=heldrod.fueldata.take_shit_from(reagent_id,amount ,heldrod.fueldata.fuel)
@@ -190,7 +190,7 @@ the machine which makes fuel rods have things in them.
 
 /obj/machinery/atmospherics/unary/fissionfuelmaker/proc/transfer_to_fuelrod(var/reagent_id,var/amount)
 	if(!heldrod)
-		return "no fuel rod"
+		return "no fuel reservoir"
 	if(reagent_id==RADON || reagent_id=="RADON")
 		if(air_contents)
 			var/avalible_gas=air_contents.gas[GAS_RADON] || 0 
@@ -293,7 +293,7 @@ the machine which makes fuel rods have things in them.
 		</div>"}
 
 
-		html+={"<hr> <table style='width:100%;'><tr><td> Fuel Rod: [ heldrod ? "[heldrod.name]  \[[current_rodamt]/[heldrod.units_of_storage]\]" : "none" ] <a href='?src=\ref[interface];action=eject_fuel'>Eject</a></td> <td style='text-align:right;'>Transfer To Container</td> </tr>"}
+		html+={"<hr> <table style='width:100%;'><tr><td> Fuel Reservoir: [ heldrod ? "[heldrod.name]  \[[current_rodamt]/[heldrod.units_of_storage]\]" : "none" ] <a href='?src=\ref[interface];action=eject_fuel'>Eject</a></td> <td style='text-align:right;'>Transfer To Container</td> </tr>"}
 	
 		if(heldrod)
 			for(var/datum/reagent/R  in heldrod.fueldata.fuel.reagent_list)
@@ -302,7 +302,7 @@ the machine which makes fuel rods have things in them.
 
 
 		html+={"</table><hr><table style='width:100%;'><tr><td>
-Container: [container ? container : "none"][container ? " \[[container.reagents.total_volume]/[container.volume]\]" : ""] <a href='?src=\ref[interface];action=eject_cont'>Eject</a></td><td style='text-align:right;'> Transfer To Fuel Rod</td> </tr>"}
+Container: [container ? container : "none"][container ? " \[[container.reagents.total_volume]/[container.volume]\]" : ""] <a href='?src=\ref[interface];action=eject_cont'>Eject</a></td><td style='text-align:right;'> Transfer To Fuel Reservoir</td> </tr>"}
 
 		if(container)
 			for(var/datum/reagent/R in container.reagents.reagent_list)
@@ -344,9 +344,9 @@ Container: [container ? container : "none"][container ? " \[[container.reagents.
 	if(hatchopen)
 		to_chat(usr,"It looks like you could pry out the electronics.")
 	if(heldrod)
-		to_chat(usr,"There is a fuel rod inserted into it.")
+		to_chat(usr,"There is a fuel reservoir inserted into it.")
 	else
-		to_chat(usr,"The fuel rod receptacle is empty.")
+		to_chat(usr,"The fuel reservoir receptacle is empty.")
 		
 		
 		

--- a/code/modules/fissionreactor/items.dm
+++ b/code/modules/fissionreactor/items.dm
@@ -8,8 +8,8 @@ includes:
 
 
 /obj/item/weapon/fuelrod
-	name="fuel rod"
-	desc="holds various reagents for use in nuclear reactions."
+	name="fuel reservoir"
+	desc="Holds various reagents for use in nuclear reactions."
 	icon='icons/obj/fissionreactor/items.dmi'
 	icon_state="i_fuelrod_empty"
 	var/datum/fission_fuel/fueldata=null
@@ -31,8 +31,8 @@ includes:
 
 
 /obj/item/weapon/fuelrod/small
-	name="small fuel rod"
-	desc="a smaller fuel rod, for lower-power applications."
+	name="small fuel reservoir"
+	desc="A small container for lower-power applications."
 	icon_state="i_fuelrod_s_empty"
 	units_of_storage=30
 	
@@ -45,9 +45,9 @@ includes:
 		icon_state="i_fuelrod_s[fueldata.life>0 ? "" : "_depleted"]"	
 
 /obj/item/weapon/fuelrod/large
-	name="large fuel rod"
+	name="large fuel reservoir"
 	icon_state="i_fuelrod_l_empty"
-	desc="a very large fuel rod, for high-power or complex mixes. use with caution."
+	desc="A very large container, for high-power or complex mixes. Use with caution."
 	units_of_storage=210	
 
 /obj/item/weapon/fuelrod/large/update_icon()

--- a/code/modules/fissionreactor/misc.dm
+++ b/code/modules/fissionreactor/misc.dm
@@ -46,8 +46,8 @@ boxes used for cargo orders to make my life easier.
 	new /obj/item/pipe(src,0) //1 pipe (optional)
 	 
 /obj/item/weapon/storage/box/fissionsupply_fuelmaker
-	name="seperational isotopic combiner parts"
-	desc="Contains all the materials needed to assemble a seperational isotopic combiner."
+	name="separational isotopic combiner parts"
+	desc="Contains all the materials needed to assemble a separational isotopic combiner."
 	
 /obj/item/weapon/storage/box/fissionsupply_fuelmaker/New()
 	..()

--- a/code/modules/fissionreactor/objects_external.dm
+++ b/code/modules/fissionreactor/objects_external.dm
@@ -203,12 +203,12 @@ included:
 /obj/machinery/fissioncontroller/attackby(var/obj/I,var/mob/user)
 	if(istype(I,/obj/item/weapon/fuelrod))
 		if(currentfuelrod)
-			to_chat(user,"There's already a fuel rod inserted into \the [src].")
+			to_chat(user,"There's already a fuel reservoir inserted into \the [src].")
 		else
 			var/obj/item/weapon/fuelrod/newrod=I
 			if(!user.drop_item(newrod))
 				return
-			to_chat(user,"You insert the fuel rod into \the [src].")
+			to_chat(user,"You insert the fuel reservoir into \the [src].")
 			if(powered() && !(stat&BROKEN))
 				playsound(src,'sound/machines/fission/rc_fuelnone.ogg',50)
 			newrod.loc=null
@@ -219,9 +219,9 @@ included:
 	if(iscrowbar(I) && currentfuelrod)
 		if(associated_reactor?.considered_on())
 			if(user.a_intent==I_HELP) //spreading rads is in fact not very helpful
-				to_chat(user,"<span class='notice'>You're not sure it's safe to remove the fuel rod.</span>")
+				to_chat(user,"<span class='notice'>You're not sure it's safe to remove the fuel reservoir.</span>")
 				return
-			user.visible_message("<span class='warning'>[user] starts prying the fuel rod out of \the [src], even though the reactor is active!</span>", "<span class='warning'>You start prying the fuel rod out of \the [src], even though the reactor is active!</span>")
+			user.visible_message("<span class='warning'>[user] starts prying the fuel reservoir out of \the [src], even though the reactor is active!</span>", "<span class='warning'>You start prying the fuel reservoir out of \the [src], even though the reactor is active!</span>")
 			playsound(src,'sound/items/crowbar.ogg',50)
 			if(do_after(user, src,30))
 				currentfuelrod.forceMove(loc)
@@ -235,7 +235,7 @@ included:
 
 			return
 				
-		user.visible_message("<span class='notice'>[user] starts prying the fuel rod out of \the [src].</span>", "<span class='notice'>You start prying the fuel rod out of \the [src].</span>")
+		user.visible_message("<span class='notice'>[user] starts prying the fuel reservoir out of \the [src].</span>", "<span class='notice'>You start prying the fuel reservoir out of \the [src].</span>")
 		playsound(src,'sound/items/crowbar.ogg',50)
 		if(do_after(user, src,20) && currentfuelrod)
 			currentfuelrod.forceMove(loc)
@@ -370,13 +370,13 @@ included:
 	var/reactor_tempdisplay="[floor(associated_reactor.temperature)]K"
 	var/reactor_highesttempdisplay="[floor(highesttemp)]K"
 	if(tempdisplaymode==1) //C
-		coolant_tempdisplay="[floor(associated_reactor.coolant.temperature-273.15)]캜"
-		reactor_tempdisplay="[floor(associated_reactor.temperature-273.15)]캜"
-		reactor_highesttempdisplay="[floor(highesttemp-273.15)]캜"
+		coolant_tempdisplay="[floor(associated_reactor.coolant.temperature-273.15)]째C"
+		reactor_tempdisplay="[floor(associated_reactor.temperature-273.15)]째C"
+		reactor_highesttempdisplay="[floor(highesttemp-273.15)]째C"
 	else if(tempdisplaymode==2) //F (because this is really old, outdated tech (fission is soooo last millenium))
-		coolant_tempdisplay="[floor(1.8*associated_reactor.coolant.temperature-459.67)]캟"
-		reactor_tempdisplay="[floor(1.8*associated_reactor.temperature-459.67)]캟"
-		reactor_highesttempdisplay="[floor(1.8*highesttemp-459.67)]캟"
+		coolant_tempdisplay="[floor(1.8*associated_reactor.coolant.temperature-459.67)]째F"
+		reactor_tempdisplay="[floor(1.8*associated_reactor.temperature-459.67)]째F"
+		reactor_highesttempdisplay="[floor(1.8*highesttemp-459.67)]째F"
 	else if(tempdisplaymode==3) //R (because muh absolute scale)
 		coolant_tempdisplay="[floor(1.8*associated_reactor.coolant.temperature)]R"
 		reactor_tempdisplay="[floor(1.8*associated_reactor.temperature)]R"
@@ -530,7 +530,7 @@ included:
 		to_chat(usr, "<span class='warning'>The readouts indicate that the reactor is overheated, and that you should cool it down.</span>")
 	
 	if(!associated_reactor.fuel)
-		to_chat(usr, "The readouts indicate there's no fuel rod inserted.")
+		to_chat(usr, "The readouts indicate there's no fuel reservoir inserted.")
 	else
 		if(associated_reactor.fuel.life <=0)
 			to_chat(usr, "The readouts indicate that the fuel is depleted.")
@@ -652,7 +652,7 @@ included:
 				to_chat(hclient.client, "There's no fuel to eject!")
 				return
 			if(associated_reactor.considered_on())
-				to_chat(hclient.client, "The reactor safety locks prevent the fuel rod from being ejected!")
+				to_chat(hclient.client, "The reactor safety locks prevent the fuel reservoir from being ejected!")
 				return
 			currentfuelrod.forceMove(src.loc)
 			currentfuelrod=null	

--- a/code/modules/fissionreactor/objects_internal.dm
+++ b/code/modules/fissionreactor/objects_internal.dm
@@ -153,12 +153,12 @@ included:
 /obj/machinery/fissionreactor/fissionreactor_fuelrod/examine()
 	..()
 	if(associated_reactor)
-		to_chat(usr,"The lights indicate that there are [overlays.len] adjacent fuel rod assemblies")
+		to_chat(usr,"The lights indicate that there are [overlays.len] adjacent fuel rod assemblies.")
 		if(icon_state=="fuelrod_active")
-			to_chat(usr,"The center emits a blue glow.")
+			to_chat(usr,"The center is emitting a blue glow.")
 		
 	to_chat(usr,"The structure is held together firmly, it'll have to be cut in order to part it.")
-	to_chat(usr,"There is a maitinance hatch at the top, it is [hatchopen?"open":"screwed shut"].")
+	to_chat(usr,"There is a maintenance hatch at the top, it is [hatchopen?"open":"screwed shut"].")
 	
 /obj/machinery/fissionreactor/fissionreactor_fuelrod/update_icon()
 	icon_state="fuelrod_off"

--- a/code/modules/research/designs/boards/computer_engie.dm
+++ b/code/modules/research/designs/boards/computer_engie.dm
@@ -196,7 +196,7 @@
 	build_path = /obj/item/weapon/circuitboard/fission_reactor
 	
 /datum/design/fission_fuel_maker
-	name = "Circuit Design (Isotopic Seperational Combiner)"
+	name = "Circuit Design (Isotopic Separational Combiner)"
 	desc = "Allows for the construction of circuit boards used to seperate and combine different isotopes of materials"
 	id = "fission_control"
 	req_tech = list(Tc_PROGRAMMING = 4, Tc_ENGINEERING = 4)


### PR DESCRIPTION
## What this does
Typofixes and some small text tweaks

## Why it's good
Typofix and improper capitalization bad. Fix good.
Closes #37437
## How it was tested
Light bounced from the emitters in the monitor, in a specific black and white pattern, that pattern went through my eye and hit the retina, the stimulus got translated to a neural impulse that I then become aware of, and the text I read seems to be proper.

:cl:
 * spellcheck: Fixes several typos and improper capitalization on a bunch of fission reactor stuff.
 * spellcheck: Renames the Fuel Rod (object) to Fuel Reservoir, to reduce the confusion between the machinery fuel rod and the object, since no matter how many fuel rod cores you have in your reactor, you only ever need 1 (one) fuel rod (now reservoir).