### PR TITLE
Rename `lerp()` for 516 support

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -146,7 +146,7 @@ var/ZAS_fuel_energy_release_rate = zas_settings.Get(/datum/ZAS_Setting/fire_fuel
 
 /atom/proc/genSmoke(var/oxy,var/temp,var/turf/where,var/force_smoke = FALSE)
 	if(!force_smoke)
-		if(prob(clamp(lerp(temp,T20C,T0C + 1000,96,100),96,100))) //4% chance of smoke at 20C, 0% at 1000C
+		if(prob(clamp(lerp_generic(temp,T20C,T0C + 1000,96,100),96,100))) //4% chance of smoke at 20C, 0% at 1000C
 			return FALSE
 	var/smoke_density = clamp(5 * ((MINOXY2BURN/oxy) ** 2),1,5)
 	var/datum/effect/system/smoke_spread/bad/smoke = new

--- a/code/__HELPERS/maths.dm
+++ b/code/__HELPERS/maths.dm
@@ -112,7 +112,7 @@ var/const/Sqrt2	= 1.41421356
 /**
  * Generic lerp function.
  */
-/proc/lerp(x, x0, x1, y0 = 0, y1 = 1)
+/proc/lerp_generic(x, x0, x1, y0 = 0, y1 = 1)
     return y0 + (y1 - y0)*(x - x0)/(x1 - x0)
 
 /**
@@ -141,7 +141,7 @@ var/const/Sqrt2	= 1.41421356
  * This is the counterpart to the mix() function. It returns the actual
  * percentage x is at inside the [a, b] range.
  *
- * Note that this is theoretically equivalent to calling lerp(x, a, b)
+ * Note that this is theoretically equivalent to calling lerp_generic(x, a, b)
  * (y0 and y1 default to 0 and 1) but this one is slightly faster
  * because Byond is too dumb to optimize procs with default values. It
  * shouldn't matter which one you use (since there are no FP issues)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -473,7 +473,7 @@ var/global/list/reagents_to_always_log = list(AMUTATIONTOXIN, CYANIDE, CHEFSPECI
 		if(!smoking)
 			add_particles(PS_SMOKE)
 			smoking = TRUE
-		var/rate = clamp(lerp(G.temperature,autoignition_temperature * 0.75,autoignition_temperature,0.1,1),0.1,1)
+		var/rate = clamp(lerp_generic(G.temperature,autoignition_temperature * 0.75,autoignition_temperature,0.1,1),0.1,1)
 		adjust_particles(PVAR_SPAWNING,rate,PS_SMOKE)
 		sleep(10 SECONDS)
 		G = return_air()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does

516 adds a native `lerp()` proc. However, it's not a drop-in replacement for the behavior of /vg/'s existing `lerp()` proc. So to improve 516 support, the existing proc has been renamed to `lerp_generic()`
