### PR TITLE
N2O high temperature decomposition

### DIFF
--- a/code/ZAS/XGM_reactions.dm
+++ b/code/ZAS/XGM_reactions.dm
@@ -88,8 +88,7 @@
 	var/to_return=list()
 	var/cratio=(mixture.temperature-300-T0C)/900
 	cratio*=  1- (1/((mixture.pressure/ONE_ATMOSPHERE)+1)) //higher pressures make more reactions happen
-	cratio=max(0,cratio)**0.5
-	cratio=min(0.95,cratio)
+	cratio=min(0.95,max(0,cratio)**0.5)
 	to_return[GAS_SLEEPING]=mixture[GAS_SLEEPING]*cratio
 	return to_return	
 	

--- a/code/ZAS/XGM_reactions.dm
+++ b/code/ZAS/XGM_reactions.dm
@@ -75,3 +75,35 @@
 	// Arbitrary number to reduce temperature by a significant amount.
 	var/const/base_temp_loss_per_one_reaction = -240000
 	mixture.add_thermal_energy( cooling_coefficient * reaction_coefficient * base_temp_loss_per_one_reaction, 0.1)
+
+
+/datum/gas_reaction/n2o_thermal_decomposition
+	name = "N2O decomposition"
+	
+/datum/gas_reaction/n2o_thermal_decomposition/reaction_is_possible(datum/gas_mixture/mixture)
+	return mixture.temperature>=300+T0C && mixture[GAS_SLEEPING]>0
+
+
+/datum/gas_reaction/n2o_thermal_decomposition/reaction_amounts_requested( datum/gas_mixture/mixture )
+	var/to_return=list()
+	var/cratio=(mixture.temperature-300-T0C)/900
+	cratio*=  1- (1/((mixture.pressure/ONE_ATMOSPHERE)+1)) //higher pressures make more reactions happen
+	cratio=max(0,cratio)**0.5
+	cratio=min(0.95,cratio)
+	to_return[GAS_SLEEPING]=mixture[GAS_SLEEPING]*cratio
+	return to_return	
+	
+	
+/datum/gas_reaction/n2o_thermal_decomposition/perform_reaction( datum/gas_mixture/mixture, reactant_amounts )
+	if(!reactant_amounts)
+		return
+	var/const/decomposition_energy=82050 //82.05 Kj/mol
+	var/moles_n2o=reactant_amounts[GAS_SLEEPING]
+	
+	mixture[GAS_OXYGEN]+=reactant_amounts[GAS_SLEEPING]*0.5
+	mixture[GAS_NITROGEN]+=moles_n2o
+	mixture[GAS_SLEEPING]=max(0,mixture[GAS_SLEEPING]-moles_n2o)
+	
+	mixture.add_thermal_energy(moles_n2o*decomposition_energy)
+	
+	mixture.update_values()


### PR DESCRIPTION
[controversial] [tweak]

## What this does
Backports behavior from SS14's atmos to /vg/.
N2O will decompose into N2 and O2 at high temperatures (beginning at 300C), and release heat when doing so. The rate at which this happens is determined by temperature (capping out at around 1200C) and pressure (higher pressures result in more decomposition)

## Why it's good
It adds some more nuance to /vg/'s pretty simple atmospheric system. Additionally, specific to this reaction, the following can be done:
* if the N2/O2 miners are destroyed/stolen, the station can still make breathable air using this as a fallback
* N2O can be used as a single gas fuel in burn chambers to produce a bit of power
* Burn chambers can use N2O instead of O2 to reduce strain on distro
* The different burn ratio uses less plasma than a standard mix, so more can be reserved for cooling or other atmos things.
* Makes an N2O flood more interesting should a fire break out
* **MUH IMMULSIONS**

but more importantly, it gives N2O a use for atmos, since as it stands currently, it's unused for anything other than flooding.

## How it was tested
Threw some N2O into a burn chamber, it broke down and heated up. VV'd a canister of it, and it also broke down and heated up.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: The Nanotrasen scientific committee has just been informed that nitrous oxide does in fact decompose at high temperatures, and have corrected their physics models across all stations.
