### PR TITLE
Making unit tests and map compiling work in CI again

### DIFF
--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -22,7 +22,7 @@
 		"an eclipse","a sandwich so tall that it pierces the heavens","things you people wouldn't believe","attack ships on fire off the shoulder of Orion","C-beams glittering in the dark near the Tannhäuser Gate",
 		"the xenoarchaeologist", "the xenobiologist", "getting reincarnated in another world","a hat pile so tall that it pierces the heavens","a wheelchair ride pile so tall that it pierces the heavens",
 		"bees","a cryptographic sequencer","the singularity","mr. clean","a dual sword made of pure energy","a welding tool being held to a fuel tank","a cascading supermatter sea",
-		"a rat of incredible muscular mass","a cuban mariachi wearing a green mask",
+		"a rat of incredible muscular mass","a cuban mariachi wearing a green mask","shoes mysteriously disappearing",
 		)
 	spawn(0)
 		for(var/i = rand(1,4),i > 0, i--)

--- a/tools/travis/travis_utils.py
+++ b/tools/travis/travis_utils.py
@@ -15,8 +15,7 @@ except AttributeError:
 # So... Travis kills it.
 # Thanks DM.
 # This repeats messages like travis_wait (which I couldn't get working) does to prevent that.
-@asyncio.coroutines
-def run_with_timeout_guards(args):
+async def run_with_timeout_guards(args):
     target_process = yield from asyncio.create_subprocess_exec(*args, stderr=asyncio.subprocess.STDOUT)
     task = ensure_future(print_timeout_guards())
 
@@ -24,8 +23,7 @@ def run_with_timeout_guards(args):
     task.cancel()
     return ret
 
-@asyncio.coroutines
-def print_timeout_guards():
+async def print_timeout_guards():
     while True:
         yield from asyncio.sleep(8*60)
         print("Keeping Travis alive. Ignore this!")

--- a/tools/travis/travis_utils.py
+++ b/tools/travis/travis_utils.py
@@ -15,7 +15,7 @@ except AttributeError:
 # So... Travis kills it.
 # Thanks DM.
 # This repeats messages like travis_wait (which I couldn't get working) does to prevent that.
-@asyncio.coroutine
+@asyncio.coroutines
 def run_with_timeout_guards(args):
     target_process = yield from asyncio.create_subprocess_exec(*args, stderr=asyncio.subprocess.STDOUT)
     task = ensure_future(print_timeout_guards())
@@ -24,7 +24,7 @@ def run_with_timeout_guards(args):
     task.cancel()
     return ret
 
-@asyncio.coroutine
+@asyncio.coroutines
 def print_timeout_guards():
     while True:
         yield from asyncio.sleep(8*60)

--- a/tools/travis/travis_utils.py
+++ b/tools/travis/travis_utils.py
@@ -16,16 +16,16 @@ except AttributeError:
 # Thanks DM.
 # This repeats messages like travis_wait (which I couldn't get working) does to prevent that.
 async def run_with_timeout_guards(args):
-    target_process = yield from asyncio.create_subprocess_exec(*args, stderr=asyncio.subprocess.STDOUT)
+    target_process = await asyncio.create_subprocess_exec(*args, stderr=asyncio.subprocess.STDOUT)
     task = ensure_future(print_timeout_guards())
 
-    ret = yield from target_process.wait()
+    ret = await target_process.wait()
     task.cancel()
     return ret
 
 async def print_timeout_guards():
     while True:
-        yield from asyncio.sleep(8*60)
+        await asyncio.sleep(8*60)
         print("Keeping Travis alive. Ignore this!")
 
 # Windows needs a different event loop to manage subprocesses


### PR DESCRIPTION
[ci]
i'm guessing nobody noticed this because the compile error on the travis script was cancelling the checks resulting in them "passing" with no actual unit tests or map compilation done
disclaimer: dream flufftext line added for the purpose of the CI running to show unit tests, can remove if needed
