### PR TITLE
Fixes grille spawned windows not having proper density

### DIFF
--- a/code/game/objects/effects/spawners/grille_window_spawner.dm
+++ b/code/game/objects/effects/spawners/grille_window_spawner.dm
@@ -21,7 +21,7 @@
 		if(get_area(src) == get_area(there) && (locate(/obj/structure/grille) in there))
 			continue
 		var/obj/structure/window/new_window = new window_path(loc)
-		new_window.dir = direction
+		new_window.change_dir(direction)
 
 /obj/structure/grille/window_spawner/full
 	icon_state = "windowgrille_full"


### PR DESCRIPTION
[bugfix]

## What this does
Closes #37473.

## How it was tested
loading the abandoned ship roundstart, doing things as mentioned in the issue.

## Changelog
:cl:
 * bugfix: Windows in the abandoned spaceship are now properly dense again.
