### PR TITLE
Pixel Shifting

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -6,6 +6,9 @@
 	pass_flags_self = PASSMOB
 	var/said_last_words = 0 // All mobs can now whisper as they die
 	var/list/alerts = list()
+	var/pixelshifting = FALSE
+	var/base_pixel_x = 0
+	var/base_pixel_y = 0
 
 /mob/variable_edited(var_name, old_value, new_value)
 	.=..()
@@ -222,7 +225,8 @@
 	original_density = density
 
 	mob_list += src
-
+	base_pixel_x = pixel_x
+	base_pixel_y = pixel_y
 	if(DEAD == stat)
 		dead_mob_list += src
 	else

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -368,12 +368,12 @@
 	//assorted replacements to make text feel "dumb"
 	message = replacetext(message, "he", "eh") //he, she, the -> eh, seh, teh, etc
 	message = replacetext(message, "ies", "is")
-	message = replacetext(message, "you", "u") 
+	message = replacetext(message, "you", "u")
 	message = replacetext(message, "iou", "ou") //delicous
 	message = replacetext(message, "xc", "x") //exited
 	message = replacetext(message, "air", "er") //cher, her
 	message = replacetext(message, "uni", "uin")
-	message = replacetext(message, "dg", "g") //knowlege, 
+	message = replacetext(message, "dg", "g") //knowlege,
 	message = replacetext(message, "tch", "ch") //bich
 	message = replacetext(message, "are", "ar")
 	message = replacetext(message, "pl", "pul")
@@ -410,7 +410,7 @@
 		var/list/words = splittext(message, " ")
 		words[rand(0, words.len)] = pick("um,", "umm,", "uh,", "uhh,")
 		message = jointext(words, " ")
-			
+
 	if(prob(35))
 		message = uppertext(message)
 		if(prob(50))
@@ -584,6 +584,17 @@ var/list/list/zones = list(list(LIMB_HEAD,LIMB_LEFT_ARM,LIMB_LEFT_HAND,LIMB_LEFT
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		H.set_attack_type(ATTACK_BITE)
+
+/mob/verb/toggle_pixelshift()
+	set name = "toggle_pixelshift"
+	set hidden = 1
+
+	if(ishuman(src))
+		var/mob/living/carbon/human/H = src
+		H.pixel_x = 0
+		H.pixel_y = 0
+		H.pixelshifting = !H.pixelshifting
+		to_chat(H, "<span class='notice'> Pixel-shifting [H.pixelshifting?"disabled":"enabled"].</span>")
 
 /proc/is_blind(A)
 	if(istype(A, /mob/living/carbon))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -295,6 +295,19 @@
 	if(!mob.canmove)
 		return
 
+	if(mob.pixelshifting)
+		if(Dir == EAST)
+			mob.pixel_x = min(8, mob.pixel_x + 1)
+		if(Dir == WEST)
+			mob.pixel_x = max(-8, mob.pixel_x - 1)
+		if(Dir == NORTH)
+			mob.pixel_y = min(16, mob.pixel_y + 1)
+		if(Dir == SOUTH)
+			mob.pixel_y = max(-16, mob.pixel_y - 1)
+		return
+	mob.pixel_x = mob.base_pixel_x
+	mob.pixel_y = mob.base_pixel_y
+
 	//if(istype(mob.loc, /turf/space) || (mob.flags & NOGRAV))
 	//	if(!mob.Process_Spacemove(0))	return 0
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -514,7 +514,9 @@ macro "hotkeymode"
 	elem "CTRL+SHIFT+UP"
 		name = "CTRL+SHIFT+UP"
 		command = ".fillmouse_released"
-
+	elem "C"
+		name = "C"
+		command = "toggle_pixelshift"
 
 menu "menu"
 	elem "client_menu"

--- a/interface/skin_azerty.dmf
+++ b/interface/skin_azerty.dmf
@@ -496,6 +496,9 @@ macro "hotkeymode"
 	elem "CTRL+SHIFT+UP"
 		name = "CTRL+SHIFT+UP"
 		command = ".fillmouse_released"
+	elem "C"
+		name = "C"
+		command = "toggle_pixelshift"
 
 
 menu "menu"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Adds pixel shifting - press C to toggle shifting mode on or off. While in shifting mode, your character will shift within their tile. Exiting shifting mode will reset your position to the center of the tile. This was minimally-tested and WILL have unforeseen consequences!
![1](https://github.com/user-attachments/assets/da37bee1-e733-412e-bfcb-0d7c1c0f15e2)

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Improves bar RP!

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Minimally!

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added pixel shifting.