### PR TITLE
Phytochemistry Chemical mutation tweak

### DIFF
--- a/code/modules/hydroponics/hydroponics_mutations.dm
+++ b/code/modules/hydroponics/hydroponics_mutations.dm
@@ -43,15 +43,18 @@
 					seed.potency += round(min(hardcap - hardcap/2*log(10,seed.potency/hardcap*100),max_change*hardcap),0.1)
 					generic_mutation_message("quivers!")
 				if(PLANT_CHEMICAL)
-					var/check_success = FALSE
-					if(prob(50))
-						check_success = seed.remove_random_chemical()
-						if(check_success)
-							visible_message("<span class='notice'>\A gland on the [seed.display_name] withers and dies.</span>")
-					if(prob(50))
-						check_success = seed.add_random_chemical()
-						if(check_success)
-							visible_message("<span class='notice'>\The [seed.display_name] develops a strange-looking gland.</span>")
+					if(!seed.chems.len)
+						visible_message("<span class='notice'>\The [seed.display_name] grows an empty gland.</span>")
+					else
+						var/check_success = FALSE
+						if(prob(50) && seed.chems.len > 0)
+							check_success = seed.remove_random_chemical()
+							if(check_success)
+								visible_message("<span class='notice'>\A gland on the [seed.display_name] withers and dies.</span>")
+						if(prob(50))
+							check_success = seed.add_random_chemical()
+							if(check_success)
+								visible_message("<span class='notice'>\The [seed.display_name] develops a strange-looking gland.</span>")
 
 		if(GENE_MORPHOLOGY)
 			if(!specific_gene)


### PR DESCRIPTION
## What this does
Slightly tweaks the behaviour of phytochemistry's Chemical mutations:
If the plant has no chems, it will never gain chems; and if the plant is on its last chem it will not lose it until it gains at least 1 other beforehand.
## Why it's good
Makes the mutations on chemless plants like grass/weeds/etc more reliable, and ensures you DON'T lose the only chem in a plant if you wanted to buff them with mutagen.
## How it was tested
Planted 3 grass trays and 3 potato trays, dumped 20u mutagen on each, the grass never gained chems, and the potatoes only lost chems once it gained one beforehand.
:cl:
 * tweak: Chemical mutations in plants will not add produced chems if the plant had no produced chems in the first place, and will not remove the last chem.