### PR TITLE
Fixes non existant escape pods crashing into shuttle

### DIFF
--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -216,6 +216,7 @@
 
 /obj/machinery/podcomputer/Destroy()
 	linked_pod?.podcomputer = null
+	linked_pod?.crashing_this_pod = FALSE
 	..()
 
 /obj/machinery/podcomputer/process()


### PR DESCRIPTION
[bugfix]

## What this does
Closes #37491.
Uses Kurfurst's suggestion.

## How it was tested
Emagging the pod computers and then having an adminspawned-shard-fed singularity eat all of the shuttle turfs before it gets sent off.

## Changelog
:cl:
 * bugfix: Escape pods must now exist before they can be sent crashing into the escape shuttle.