### PR TITLE
Makes medical nanobots heal broken bones

### DIFF
--- a/code/modules/reagents/reagents/reagents_medical.dm
+++ b/code/modules/reagents/reagents/reagents_medical.dm
@@ -1042,13 +1042,17 @@ var/global/list/charcoal_doesnt_remove=list(
 			for(var/datum/wound/internal_bleeding/W in E.wounds)
 				W.heal_damage(0.8, TRUE)
 				holder.remove_reagent(MEDNANOBOTS, 0.25)
+			if (E.status & ORGAN_BROKEN)
+				E.status &= ~ORGAN_BROKEN //What do I owe you?
+				E.status &= ~ORGAN_SPLINTED //Nothing, it's for free!
+				holder.remove_reagent(MEDNANOBOTS, 0.10)
+			if (E.status & ORGAN_BLEEDING)
+				E.status &= ~ORGAN_BLEEDING //FOR FREE?!
+				holder.remove_reagent(MEDNANOBOTS, 0.10)
 		for(var/datum/organ/internal/I in H.internal_organs)
 			if(I.damage)
 				I.damage = max(0, I.damage - 5) //Heals a whooping 5 organ damage.
 				holder.remove_reagent(MEDNANOBOTS, 0.10) //Less so it doesn't vanish the nanobot supply
-			I.status &= ~ORGAN_BROKEN //What do I owe you?
-			I.status &= ~ORGAN_SPLINTED //Nothing, it's for free!
-			I.status &= ~ORGAN_BLEEDING //FOR FREE?!
 	if(M.getOxyLoss() || M.getBruteLoss(TRUE) || M.getToxLoss() || M.getFireLoss(TRUE) || M.getCloneLoss())
 		M.adjustOxyLoss(-5)
 		M.heal_organ_damage(5, 5) //Heals Brute and Burn. It heals the mob, not individual organs.


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Makes medical nanobots actually heal broken bones, as the previous code did nothing. However, if there's a high amount of brute damage, the bone breaks immediately again while nanobots heal the damage. (the bone will then be fixed again). This is a feature I guess.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Bugfix good.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
I spawned in, broke my bones, got nanobots and saw that they got fixed.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Medical nanobots can now fix broken bones. Watch out, the bone mending process might be painful!

