### PR TITLE
Ladders (the adminbus update)

### DIFF
--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -6,13 +6,13 @@ var/list/ladders = list()
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "ladder11"
 	anchored = 1
-	var/custom_message_up = "climb up"
-	var/custom_message_down = "climb down"
-	var/custom_message_others_up = "climbs up"
-	var/custom_message_others_down = "climbs down"
-	var/custom_upanddown = "Go up or down the ladder?"
-	var/custom_upanddown_up = "Up"
-	var/custom_upanddown_down = "Down"
+	var/custom_message_up = ""
+	var/custom_message_down = ""
+	var/custom_message_others_up = ""
+	var/custom_message_others_down = ""
+	var/custom_upanddown = ""
+	var/custom_upanddown_up = ""
+	var/custom_upanddown_down = ""
 	var/id = null
 	var/height = 0							//the 'height' of the ladder. higher numbers are considered physically higher
 	var/obj/structure/ladder/down = null	//the ladder below this one
@@ -85,34 +85,30 @@ var/list/ladders = list()
 	else	//wtf make your ladders properly assholes
 		icon_state = "ladder00"
 
-/obj/structure/ladder/attack_hand(mob/user as mob)
+/obj/structure/ladder/proc/go_up(mob/user)
+	user.visible_message("<span class='notice'>[user] [custom_message_others_up? custom_message_others_up : "climbs up the ladder!"]</span>", \
+								"<span class='notice'>You [custom_message_up? custom_message_up : "climb up the ladder!"]</span>")
+	climb(user, get_turf(up))
+	up.add_fingerprint(user)
+/obj/structure/ladder/proc/go_down(mob/user)
+	user.visible_message("<span class='notice'>[user] [custom_message_others_down? custom_message_others_down : "climbs down the ladder!"]</span>", \
+								"<span class='notice'>You [custom_message_down? custom_message_down : "climb down the ladder!"]</span>")
+	climb(user, get_turf(down))
+	down.add_fingerprint(user)
+
+/obj/structure/ladder/attack_hand(mob/user)
 	if(up && down)
-		var/choice = alert("[custom_upanddown]", "[src]", "[custom_upanddown_up]",  "[custom_upanddown_down]", "Cancel")
-		if(choice == "[custom_upanddown_up]")
-			user.visible_message("<span class='notice'>[user] [custom_message_others_up] \the [src]!</span>", \
-								"<span class='notice'>You [custom_message_up] \the [src]!</span>")
-			climb(user, get_turf(up))
-			up.add_fingerprint(user)
-		if(choice == "[custom_upanddown_down]")
-			user.visible_message("<span class='notice'>[user] [custom_message_others_down] \the [src]!</span>", \
-								"<span class='notice'>You [custom_message_down] \the [src]!</span>")
-			climb(user, get_turf(down))
-			down.add_fingerprint(user)
+		var/choice = alert("[custom_upanddown?custom_upanddown : "Go up or down the ladder?"]", "[src]", "[custom_upanddown_up?custom_upanddown_up : "Up"]",  "[custom_upanddown_down?custom_upanddown_down : "Down"]", "Cancel")
+		if(choice == "[custom_upanddown_up]" || choice == "Up")
+			go_up(user)
+		if(choice == "[custom_upanddown_down]" || choice == "Down")
+			go_down(user)
 		if(choice == "Cancel")
 			return
-
 	else if(up)
-		user.visible_message("<span class='notice'>[user] [custom_message_others_up] \the [src]!</span>", \
-							 "<span class='notice'>You [custom_message_up] \the [src]!</span>")
-		climb(user, get_turf(up))
-		up.add_fingerprint(user)
-
+		go_up(user)
 	else if(down)
-		user.visible_message("<span class='notice'>[user] [custom_message_others_down] \the [src]!</span>", \
-							 "<span class='notice'>You [custom_message_down] \the [src]!</span>")
-		climb(user, get_turf(down))
-		down.add_fingerprint(user)
-
+		go_down(user)
 	else
 		to_chat(user, "<span class='notice'>This [src] is broken!</span>")
 

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -6,6 +6,13 @@ var/list/ladders = list()
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "ladder11"
 	anchored = 1
+	var/custom_message_up = "climb up"
+	var/custom_message_down = "climb down"
+	var/custom_message_others_up = "climbs up"
+	var/custom_message_others_down = "climbs down"
+	var/custom_upanddown = "Go up or down the ladder?"
+	var/custom_upanddown_up = "Up"
+	var/custom_upanddown_down = "Down"
 	var/id = null
 	var/height = 0							//the 'height' of the ladder. higher numbers are considered physically higher
 	var/obj/structure/ladder/down = null	//the ladder below this one
@@ -80,34 +87,34 @@ var/list/ladders = list()
 
 /obj/structure/ladder/attack_hand(mob/user as mob)
 	if(up && down)
-		switch( alert("Go up or down the ladder?", "Ladder", "Up", "Down", "Cancel") )
-			if("Up")
-				user.visible_message("<span class='notice'>[user] climbs up \the [src]!</span>", \
-									 "<span class='notice'>You climb up \the [src]!</span>")
-				climb(user, get_turf(up))
-				up.add_fingerprint(user)
-			if("Down")
-				user.visible_message("<span class='notice'>[user] climbs down \the [src]!</span>", \
-									 "<span class='notice'>You climb down \the [src]!</span>")
-				climb(user, get_turf(down))
-				down.add_fingerprint(user)
-			if("Cancel")
-				return
+		var/choice = alert("[custom_upanddown]", "[src]", "[custom_upanddown_up]",  "[custom_upanddown_down]", "Cancel")
+		if(choice == "[custom_upanddown_up]")
+			user.visible_message("<span class='notice'>[user] [custom_message_others_up] \the [src]!</span>", \
+								"<span class='notice'>You [custom_message_up] \the [src]!</span>")
+			climb(user, get_turf(up))
+			up.add_fingerprint(user)
+		if(choice == "[custom_upanddown_down]")
+			user.visible_message("<span class='notice'>[user] [custom_message_others_down] \the [src]!</span>", \
+								"<span class='notice'>You [custom_message_down] \the [src]!</span>")
+			climb(user, get_turf(down))
+			down.add_fingerprint(user)
+		if(choice == "Cancel")
+			return
 
 	else if(up)
-		user.visible_message("<span class='notice'>[user] climbs up \the [src]!</span>", \
-							 "<span class='notice'>You climb up \the [src]!</span>")
+		user.visible_message("<span class='notice'>[user] [custom_message_others_up] \the [src]!</span>", \
+							 "<span class='notice'>You [custom_message_up] \the [src]!</span>")
 		climb(user, get_turf(up))
 		up.add_fingerprint(user)
 
 	else if(down)
-		user.visible_message("<span class='notice'>[user] climbs down \the [src]!</span>", \
-							 "<span class='notice'>You climb down \the [src]!</span>")
+		user.visible_message("<span class='notice'>[user] [custom_message_others_down] \the [src]!</span>", \
+							 "<span class='notice'>You [custom_message_down] \the [src]!</span>")
 		climb(user, get_turf(down))
 		down.add_fingerprint(user)
 
 	else
-		to_chat(user, "<span class='notice'>This ladder is broken!</span>")
+		to_chat(user, "<span class='notice'>This [src] is broken!</span>")
 
 	add_fingerprint(user)
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Requested by SacredAtom, who wanted to have more customizable ladders. Now you can have control over all ladder messages, from going down (var/custom_message_down (shown to you) and var/custom_message_others_down (shown to others) and up (same thing).
If the ladder goes both ways, you can even now customize the alert message it shows, with var/custom_upanddown, var/custom_upanddown_up and var/custom_upanddown_down. Of course this is all adminbus only.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
More tools to do more immersive adminbuses is always fun and good.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
I tested all the custom messages in every configuration.
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
* rscadd: Admins can now use more immersive ladders in their admin buses.