### PR TITLE
New wiz spell: Curse of Norwood

### DIFF
--- a/code/game/gamemodes/wizard/spellbook_oneuse.dm
+++ b/code/game/gamemodes/wizard/spellbook_oneuse.dm
@@ -566,6 +566,14 @@
 	disabled_from_bundle = 1
 
 
+///// Norwood curse ////
+
+/obj/item/weapon/spellbook/oneuse/norwood
+	spell = /spell/targeted/norwood_curse
+	spellname = "norwood"
+	icon_state ="bookmindswap" // To fix!
+	desc = "This book suddenly stops about 29 pages in. After, it is written 'it's over' in every language that has ever existed, will ever exist, and even in some which shouldn't theoretically exist."
+
 ///// ANCIENT SPELLBOOK /////
 
 /obj/item/weapon/spellbook/oneuse/ancient //the ancient spellbook contains weird and dangerous spells that aren't otherwise available to purchase, only available via the spellbook bundle

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -629,7 +629,8 @@
 	flags = FPRINT
 	w_class = W_CLASS_TINY
 
-	var/shattered = 0
+	var/shattered = FALSE
+	var/norwood_cursed = FALSE
 
 /obj/item/weapon/pocket_mirror/attack_self(mob/user)
 	if(shattered)
@@ -666,6 +667,14 @@
 		H = user
 	if(!H)
 		return
+	if (norwood_cursed)
+		if (isjusthuman(H))
+			to_chat(H, "<span class = 'userwarning'>Oh no! It's the curse of Norwood!</span>")
+			H.visible_message("<span class='warning'>[H]'s hair vanishes in a flash!</span>")
+			H.my_appearance.h_style = "Bald"
+			H.update_hair()
+			H.my_appearance.permanently_bald = TRUE
+			return
 	if(arcanetampered)
 		to_chat(user, "<span class='sinister'>You feel different.</span>")
 		H.Humanize(pick("Unathi","Tajaran","Insectoid","Grey",/*and worst of all*/"Vox"))

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -4,9 +4,11 @@
 	desc = "Mirror mirror on the wall, who's the most robust of them all? Touching the mirror will bring out Nanotrasen's state of the art hair modification system."
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "mirror"
-	density = 0
-	anchored = 1
-	var/shattered = 0
+	density = FALSE
+	anchored = TRUE
+	var/shattered = FALSE
+	/// Whether or not using this mirror makes you permanently bald or not.
+	var/norwood_cursed = FALSE
 
 /obj/structure/mirror/proc/can_use(mob/living/user, mob/living/carbon/human/target)
 	if(shattered)
@@ -103,6 +105,13 @@
 			if(species_hair.len)
 				var/new_style = input(user, "Select a hair style", "Grooming", target.my_appearance.h_style) as null|anything in species_hair
 				if(!new_style || !attempt(user, target, which))
+					return
+				if (norwood_cursed)
+					to_chat(target, "<span class = 'userwarning'>Oh no! It's the curse of Norwood!</span>")
+					target.visible_message("<span class='warning'>[target]'s hair vanishes in a flash!</span>")
+					target.my_appearance.h_style = "Bald"
+					target.update_hair()
+					target.my_appearance.permanently_bald = TRUE
 					return
 				target.my_appearance.h_style = new_style
 				target.update_hair()

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -24,12 +24,16 @@
 	var/g_eyes = 0
 	var/b_eyes = 0
 
+	var/permanently_bald = FALSE
+
 /mob/living/carbon/human/
 	var/datum/human_appearance/my_appearance
 
 /mob/living/carbon/human/proc/switch_appearance(var/datum/human_appearance/new_looks)
 	if (!istype(new_looks))
 		return
+	if (my_appearance.permanently_bald && new_looks.h_style != "Bald")
+		to_chat(src, "<span class='warning'>It is no use! The Curse O' Norwood is too strong!</span>")
 	my_appearance = new_looks
 	regenerate_icons()
 

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -34,6 +34,7 @@
 		return
 	if (my_appearance.permanently_bald && new_looks.h_style != "Bald")
 		to_chat(src, "<span class='warning'>It is no use! The Curse O' Norwood is too strong!</span>")
+		new_looks.h_style = "Bald"
 	my_appearance = new_looks
 	regenerate_icons()
 

--- a/code/modules/spells/targeted/norwood.dm
+++ b/code/modules/spells/targeted/norwood.dm
@@ -8,7 +8,7 @@
 	charge_type = Sp_RECHARGE
 
 	school = "transmutation"
-	charge_max = 600
+	charge_max = 10 SECONDS
 	spell_flags = WAIT_FOR_CLICK | IS_HARMFUL
 	cooldown_min = 4 SECONDS
 	range = 1

--- a/code/modules/spells/targeted/norwood.dm
+++ b/code/modules/spells/targeted/norwood.dm
@@ -1,0 +1,37 @@
+/spell/targeted/norwood_curse
+	name = "Curse of Norwood"
+	desc = "Target a person to make them permanently bald and sad. Target mirrors to infuse them with the curse of norwood."
+	abbreviation = "CoN"
+	user_type = USER_TYPE_WIZARD
+	specialization = SSOFFENSIVE
+
+	charge_type = Sp_RECHARGE
+
+	school = "transmutation"
+	charge_max = 600
+	spell_flags = WAIT_FOR_CLICK | IS_HARMFUL
+	cooldown_min = 4 SECONDS
+	range = 1
+	max_targets = 1
+	invocation = "C'R'S O' N'WOOD!"
+
+	invocation_type = SpI_SHOUT
+
+	hud_state = "pumpkin"
+
+/spell/targeted/norwood_curse/cast(var/list/targets, mob/user)
+	..()
+	for(var/mob/living/carbon/human/target in targets)
+		if(isjusthuman(target))
+			to_chat(target, "<span class = 'userwarning'>Oh no! It's the curse of Norwood!</span>")
+			target.my_appearance.h_style = "Bald"
+			target.update_hair()
+			target.my_appearance.permanently_bald = TRUE
+
+	for(var/obj/structure/mirror/M in targets)
+		to_chat(user, "<span class='notice'>Mwahaha! This [M] is now cursed! Any soul attempting to use it shall lose their hair!</span>")
+		M.norwood_cursed = TRUE
+
+	for(var/obj/item/weapon/pocket_mirror/M in targets)
+		to_chat(user, "<span class='notice'>Mwahaha! This [M] is now cursed! Any soul attempting to use it shall lose their hair!</span>")
+		M.norwood_cursed = TRUE

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2842,6 +2842,7 @@
 #include "code\modules\spells\targeted\ice_barrage.dm"
 #include "code\modules\spells\targeted\invoke_emotion.dm"
 #include "code\modules\spells\targeted\mind_transfer.dm"
+#include "code\modules\spells\targeted\norwood.dm"
 #include "code\modules\spells\targeted\pacify.dm"
 #include "code\modules\spells\targeted\parrotmorph.dm"
 #include "code\modules\spells\targeted\prestidigitation.dm"


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does

![image](https://github.com/user-attachments/assets/ebe31222-d9a8-4159-8f7d-a0f3609434af)

This adds a silly wizard spell that makes people bald, forever, until they get cloned. It can be used to trap mirrors.
By default this is a no-robes spell.

It costs as normal as a normal spell and has a 10 seconds cooldown. I'll probably need to change the cost slightly at some point.

Sadly, it's unsprited. Spriters for a spellbook and spell icon welcome!

## Why it's good

Funny little meme spell to antagonise static players.

## How it was tested

I spawned an NPC and I norwood'd her. I norwood'd a mirror and I got bald.

## Changelog

:cl:
 * rscadd: Adds the Curse O' Norwood spell to the wizard.