### PR TITLE
Fixes/refactors Simpolinol

### DIFF
--- a/code/modules/reagents/random_reagent_effect.dm
+++ b/code/modules/reagents/random_reagent_effect.dm
@@ -28,7 +28,7 @@
 /// ------------- Explode
 /datum/random_reagent_effect/explode
 	name = "Explode"
-	activation_chance = 20
+	activation_chance = 8
 	var/explode_strength
 
 #define NO_GIBS 0
@@ -72,7 +72,7 @@
 /// ------------- Healing
 /datum/random_reagent_effect/simple_heal_damage
 	name = "Simple heal/damage"
-	activation_chance = 100 // Always picked 
+	activation_chance = 100 // Always picked
 	var/list/healing_values = list(
 		"brute" = 0,
 		"oxy" = 0,
@@ -91,7 +91,7 @@
 			// 80% of the effect to heal (neg dmg)
 			if (prob(80))
 				healing_values[dmg_type] =- healing_values[dmg_type]
-			investigative_log += "damage [dmg_type]: [healing_values[dmg_type]] -- "
+			investigative_log += "-- damage [dmg_type]: [healing_values[dmg_type]] "
 
 /datum/random_reagent_effect/simple_heal_damage/on_human_life(mob/living/carbon/human/H)
 	// We hate hardcoding here
@@ -135,7 +135,7 @@
 /// --------- Kill users
 /datum/random_reagent_effect/kill
 	name = "Kill"
-	activation_chance = 4
+	activation_chance = 2
 	investigative_log = "kill user -- "
 
 /datum/random_reagent_effect/kill/on_human_life(mob/living/carbon/human/H)
@@ -266,7 +266,7 @@
 	var/total_hallucination_damage
 
 /datum/random_reagent_effect/hallucination/on_pick()
-	var/generator/value_rng = generator("num", 10, 0.2, LINEAR_RAND) // Uniform distribution for 10 to 0.2
+	var/generator/value_rng = generator("num", 10, 0.2, LINEAR_RAND).Rand() // Uniform distribution for 10 to 0.2
 	total_hallucination_damage = value_rng
 	investigative_log = "-- does hallucination damage for [total_hallucination_damage]"
 

--- a/code/modules/reagents/random_reagent_effect.dm
+++ b/code/modules/reagents/random_reagent_effect.dm
@@ -1,0 +1,274 @@
+/// --- Actual random reagent effects
+
+/datum/random_reagent_effect
+	var/name = ""
+	var/activation_chance = 0
+	var/investigative_log
+
+/// When the reagent effect is initialised
+/// Default behaviour: prob(activation_chance)
+/datum/random_reagent_effect/proc/can_be_picked()
+	return prob(activation_chance)
+
+/// When the reagent effect is initialised
+/datum/random_reagent_effect/proc/on_pick()
+
+/// Called on human Life()
+/datum/random_reagent_effect/proc/on_human_life(var/mob/living/carbon/human/H)
+
+/// Called on the first tick inside a human
+/datum/random_reagent_effect/proc/on_human_life_zeroth(var/mob/living/carbon/human/H)
+
+// Log a text message in mob's attack logs
+/datum/random_reagent_effect/proc/log_effect(var/mob/M, var/msg)
+	M.attack_log += text("\[[time_stamp()]\]: <font color='orange'>[msg] (<a href='?_src_=vars;Vars=\ref[src]'>[src]</a>)</font>")
+	log_attack("[M.name] ([M.ckey]) [msg] ([src] \ref[src])")
+	msg_admin_attack("[M.name] ([M.ckey]) [msg] (<a href='?_src_=vars;Vars=\ref[src]'>RR</a>) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[M.x];Y=[M.y];Z=[M.z]'>JMP</a>)")
+
+/// ------------- Explode
+/datum/random_reagent_effect/explode
+	name = "Explode"
+	activation_chance = 20
+	var/explode_strength
+
+#define NO_GIBS 0
+#define GIBS 1
+#define SMALL_EXPLOSION 2
+#define BREACH_NORMAL 3
+#define BREACH_REINFORCED 4
+
+/datum/random_reagent_effect/explode/on_pick()
+	explode_strength = pick(
+		1000; GIBS, // Just gibs
+		 500; SMALL_EXPLOSION, // Small explosion
+		 400; BREACH_NORMAL, // Breaches normal floor
+		 100; BREACH_REINFORCED, // Breaches reinforced floor
+	)
+	investigative_log = "Pikced effect 'explode' with strength [explode_strength] -- "
+
+/datum/random_reagent_effect/explode/on_human_life(var/mob/living/carbon/human/H)
+	H.death(explode_strength)
+	switch(explode_strength)
+		if(NO_GIBS)
+			log_effect(H, "was killed instantly")
+		if(GIBS)
+			log_effect(H, "was gibbed")
+		if(SMALL_EXPLOSION)
+			log_effect(H, "exploded (small)")
+			explosion(get_turf(H), 0, 0, 1, 3, whodunnit=H)
+		if(BREACH_NORMAL)
+			log_effect(H, "exploded (medium)")
+			explosion(get_turf(H), 0, 1, 3, 5, whodunnit=H)
+		if(BREACH_REINFORCED to INFINITY)
+			log_effect(H, "exploded (large)")
+			explosion(get_turf(H), 1, 3, 5, 7, whodunnit=H)
+	return
+
+#undef GIBS
+#undef SMALL_EXPLOSION
+#undef BREACH_NORMAL
+#undef BREACH_REINFORCED
+
+/// ------------- Healing
+/datum/random_reagent_effect/simple_heal_damage
+	name = "Simple heal/damage"
+	activation_chance = 100 // Always picked 
+	var/list/healing_values = list(
+		"brute" = 0,
+		"oxy" = 0,
+		"tox" = 0,
+		"fire" = 0,
+		"clone" = 0,
+		"brain" = 0,
+	)
+
+/datum/random_reagent_effect/simple_heal_damage/on_pick()
+	var/generator/total_value_rng = generator("num", 10, 0.2, LINEAR_RAND) // Uniform distribution for 10 to 0.2
+	for (var/dmg_type in healing_values)
+		var/activation_prob = (dmg_type != "clone") ? 30 : 8 // 30% to activate regular damage type. 8% chance to activate clone
+		if (prob(activation_prob))
+			healing_values[dmg_type] = total_value_rng.Rand()
+			// 80% of the effect to heal (neg dmg)
+			if (prob(80))
+				healing_values[dmg_type] =- healing_values[dmg_type]
+			investigative_log += "damage [dmg_type]: [healing_values[dmg_type]] -- "
+
+/datum/random_reagent_effect/simple_heal_damage/on_human_life(mob/living/carbon/human/H)
+	// We hate hardcoding here
+	H.adjustBruteLoss(healing_values["brute"] *REM)
+	H.adjustOxyLoss(healing_values["oxy"]*REM)
+	H.adjustToxLoss(healing_values["tox"]*REM)
+	H.adjustFireLoss(healing_values["fire"]*REM)
+	H.adjustCloneLoss(healing_values["clone"]*REM)
+	H.adjustBrainLoss(healing_values["brain"]**REM)
+
+
+/// ------ Transform women into men
+/datum/random_reagent_effect/tf_inverse
+	name = "Anti-estradiol (female to male tf)"
+	activation_chance = 8
+	investigative_log = "transform women into men -- "
+
+/datum/random_reagent_effect/tf_inverse/on_human_life(mob/living/carbon/human/H)
+	if(isjusthuman(H) && H.gender != MALE)
+		H.emote("faint")
+		var/obj/effect/smoke/smoke = new /obj/effect/smoke(get_turf(H))
+		smoke.time_to_live = 1
+		H.gender = MALE
+
+		H.my_appearance.h_style = pick("Bald", "Bedhead", "Bedhead 2", "Bowl", "Skinhead", "Balding Hair", "Nitori", "Manbun")
+		H.my_appearance.f_style = pick("Neckbeard", "Full Beard", "Unshaven")
+		H.my_appearance.s_tone = rand(-10, 10)
+
+		H.my_appearance.r_eyes = H.my_appearance.g_eyes = H.my_appearance.b_eyes = 0
+		H.my_appearance.r_facial = H.my_appearance.r_hair = 20
+		H.my_appearance.g_facial = H.my_appearance.g_hair = 20
+		H.my_appearance.b_facial = H.my_appearance.b_hair = 20
+
+		H.update_hair()
+		H.update_body()
+		H.regenerate_icons()
+		H.check_dna_integrity()
+		H.update_dna_from_appearance()
+		log_effect(H, "was transformed into a man")
+
+/// --------- Kill users
+/datum/random_reagent_effect/kill
+	name = "Kill"
+	activation_chance = 4
+	investigative_log = "kill user -- "
+
+/datum/random_reagent_effect/kill/on_human_life(mob/living/carbon/human/H)
+	H.visible_message("<span class='warning'>\The [H] suddenly collapses!</span>")
+	H.death()
+
+/// --------- Catbeast transformation
+/datum/random_reagent_effect/tf_catbeast
+	name = "TF Catbeast"
+	activation_chance = 1
+	investigative_log = "transform user into catbeast -- "
+
+/datum/random_reagent_effect/tf_catbeast/on_human_life(mob/living/carbon/human/H)
+	if (!iscatbeast(H))
+		H.set_species("Tajaran", transfer_damage = TRUE)
+		H.regenerate_icons()
+		H.emote("me", MESSAGE_HEAR, pick("meows", "mews"))
+		playsound(H, 'sound/voice/catmeow.ogg', 100)
+		log_effect(H, "was transformed into a catbeast")
+
+
+/// --------- Simple mob transformation
+/datum/random_reagent_effect/tf_simplemob
+	name = "TF Simple mob"
+	activation_chance = 4
+	var/picked_mob_type
+
+/datum/random_reagent_effect/tf_simplemob/on_pick()
+	// This is a BIT ugly but eeeh
+	var/picked_number = generator("num", 0, 150, LINEAR_RAND).Rand()
+	switch(picked_number)
+		if (0 to 100)
+			picked_mob_type = pick(
+				/mob/living/simple_animal/capybara, /mob/living/simple_animal/cat,
+				/mob/living/simple_animal/cat/kitten, /mob/living/simple_animal/cat/snek,
+				/mob/living/simple_animal/chick, /mob/living/simple_animal/chicken,
+				/mob/living/simple_animal/corgi, /mob/living/simple_animal/corgi/puppy,
+				/mob/living/simple_animal/corgi/saint, /mob/living/simple_animal/corgi/sasha,
+				/mob/living/simple_animal/cow, /mob/living/simple_animal/crab,
+				/mob/living/simple_animal/hamster, /mob/living/simple_animal/hostile/retaliate/goat,
+				/mob/living/simple_animal/hostile/retaliate/goat/wooly, /mob/living/simple_animal/parrot,
+				/mob/living/simple_animal/penguin, /mob/living/simple_animal/penguin/chick,
+				/mob/living/simple_animal/rabbit, /mob/living/simple_animal/rabbit/bunny,
+			)
+		if (100 to 130) // Uncommon
+			picked_mob_type = pick(
+				/mob/living/simple_animal/borer, /mob/living/simple_animal/puddi/happy,
+				/mob/living/simple_animal/puddi/anger, /mob/living/simple_animal/spiderbot,
+			)
+		if (130 to 145) // Dangerous
+			picked_mob_type = pick(
+				/mob/living/simple_animal/amogusflash,
+				/mob/living/simple_animal/hostile/asteroid/basilisk, /mob/living/simple_animal/hostile/asteroid/goldgrub,
+				/mob/living/simple_animal/hostile/asteroid/goliath, /mob/living/simple_animal/hostile/asteroid/rockernaut,
+				/mob/living/simple_animal/hostile/bear, /mob/living/simple_animal/hostile/carp,
+				/mob/living/simple_animal/hostile/giant_spider/hunter, /mob/living/simple_animal/hostile/pitbull,
+				/mob/living/simple_animal/slime, /mob/living/simple_animal/slime/adult,
+			)
+		if (145 to 150) // Owned
+			picked_mob_type = pick(
+				/mob/living/simple_animal/hostile/retaliate/clown, /mob/living/simple_animal/hostile/retaliate/cluwne,
+				/mob/living/simple_animal/hostile/retaliate/faguette, /mob/living/simple_animal/hostile/retaliate/mime,
+			)
+	investigative_log = "transform user into [picked_mob_type] -- "
+
+/datum/random_reagent_effect/tf_simplemob/on_human_life(mob/living/carbon/human/H)
+	var/mob/living/simple_animal/animal = new picked_mob_type(get_turf(H))
+	animal.name = get_first_word(H.name)
+	animal.real_name = get_first_word(H.real_name)
+	animal.flavor_text = H.flavor_text
+	animal.gender = H.gender
+	animal.desc = "Something is off about this one."
+	animal.faction = H.faction
+	animal.meat_type = H.meat_type
+	animal.attack_log = H.attack_log.Copy()
+	H.reagents.trans_to(animal.reagents, animal.reagents.maximum_volume)
+
+	animal.health = 100
+	animal.maxHealth = 100
+	animal.stop_automated_movement = TRUE
+	animal.wander = FALSE
+	animal.speak_chance = 0
+	animal.can_breed = FALSE //No ERP allowed
+
+	H.Premorph()
+	H.audible_scream()
+	H.mind.transfer_to(animal)
+	log_effect(animal, "was transformed into a simplemob")
+	var/obj/effect/smoke/smoke = new /obj/effect/smoke(get_turf(H))
+	smoke.time_to_live = 1
+	qdel(H)
+	return
+
+/// ------- Scramble damage
+
+/datum/random_reagent_effect/scramble_damage
+	name = "Scramble damage"
+	activation_chance = 10
+	investigative_log = "-- scramble damage "
+
+/datum/random_reagent_effect/scramble_damage/on_human_life_zeroth(mob/living/carbon/human/H)
+	if(!(H.status_flags&GODMODE))
+		var/damage_msg = "[H.getBruteLoss()]/[H.getOxyLoss()]/[H.getToxLoss()]/[H.getFireLoss()]/[H.getCloneLoss()]"
+		var/damage_budget = H.getOxyLoss() + H.getToxLoss() + H.getCloneLoss()
+		H.setOxyLoss(0)
+		H.setToxLoss(0)
+		H.setCloneLoss(0)
+		for(var/datum/organ/external/O in H.organs)
+			if(O.is_organic() && O.is_existing())
+				damage_budget += O.brute_dam + O.burn_dam
+				O.brute_dam = O.burn_dam = 0
+
+		while(damage_budget>0)
+			var/damage_amount = rand(max(damage_budget, 1))
+			var/proc_tocall = pick("adjustBruteLoss", "adjustOxyLoss", "adjustToxLoss", "adjustFireLoss", "adjustCloneLoss")
+			// This is le silly.
+			call(H, proc_tocall)(damage_amount)
+			damage_budget -= damage_amount
+		damage_msg += " to [H.getBruteLoss()]/[H.getOxyLoss()]/[H.getToxLoss()]/[H.getFireLoss()]/[H.getCloneLoss()]"
+		log_effect(H, "had their damage scrambled ([damage_msg])")
+
+
+/// ------- Hallucination
+
+/datum/random_reagent_effect/hallucination
+	name = "Hallucination"
+	activation_chance = 10
+	var/total_hallucination_damage
+
+/datum/random_reagent_effect/hallucination/on_pick()
+	var/generator/value_rng = generator("num", 10, 0.2, LINEAR_RAND) // Uniform distribution for 10 to 0.2
+	total_hallucination_damage = value_rng
+	investigative_log = "-- does hallucination damage for [total_hallucination_damage]"
+
+/datum/random_reagent_effect/hallucination/on_human_life(mob/living/carbon/human/H)
+	H.hallucination += total_hallucination_damage

--- a/code/modules/reagents/random_reagent_effect.dm
+++ b/code/modules/reagents/random_reagent_effect.dm
@@ -64,6 +64,7 @@
 			explosion(get_turf(H), 1, 3, 5, 7, whodunnit=H)
 	return
 
+#undef NO_GIBS
 #undef GIBS
 #undef SMALL_EXPLOSION
 #undef BREACH_NORMAL
@@ -100,7 +101,7 @@
 	H.adjustToxLoss(healing_values["tox"]*REM)
 	H.adjustFireLoss(healing_values["fire"]*REM)
 	H.adjustCloneLoss(healing_values["clone"]*REM)
-	H.adjustBrainLoss(healing_values["brain"]**REM)
+	H.adjustBrainLoss(healing_values["brain"]*REM)
 
 
 /// ------ Transform women into men
@@ -181,12 +182,12 @@
 				/mob/living/simple_animal/penguin, /mob/living/simple_animal/penguin/chick,
 				/mob/living/simple_animal/rabbit, /mob/living/simple_animal/rabbit/bunny,
 			)
-		if (100 to 130) // Uncommon
+		if (101 to 130) // Uncommon
 			picked_mob_type = pick(
 				/mob/living/simple_animal/borer, /mob/living/simple_animal/puddi/happy,
 				/mob/living/simple_animal/puddi/anger, /mob/living/simple_animal/spiderbot,
 			)
-		if (130 to 145) // Dangerous
+		if (131 to 145) // Dangerous
 			picked_mob_type = pick(
 				/mob/living/simple_animal/amogusflash,
 				/mob/living/simple_animal/hostile/asteroid/basilisk, /mob/living/simple_animal/hostile/asteroid/goldgrub,
@@ -195,7 +196,7 @@
 				/mob/living/simple_animal/hostile/giant_spider/hunter, /mob/living/simple_animal/hostile/pitbull,
 				/mob/living/simple_animal/slime, /mob/living/simple_animal/slime/adult,
 			)
-		if (145 to 150) // Owned
+		if (146 to 150) // Owned
 			picked_mob_type = pick(
 				/mob/living/simple_animal/hostile/retaliate/clown, /mob/living/simple_animal/hostile/retaliate/cluwne,
 				/mob/living/simple_animal/hostile/retaliate/faguette, /mob/living/simple_animal/hostile/retaliate/mime,
@@ -228,7 +229,6 @@
 	var/obj/effect/smoke/smoke = new /obj/effect/smoke(get_turf(H))
 	smoke.time_to_live = 1
 	qdel(H)
-	return
 
 /// ------- Scramble damage
 

--- a/code/modules/reagents/random_reagent_effect.dm
+++ b/code/modules/reagents/random_reagent_effect.dm
@@ -165,7 +165,8 @@
 
 /datum/random_reagent_effect/tf_simplemob/on_pick()
 	// This is a BIT ugly but eeeh
-	var/picked_number = generator("num", 0, 150, LINEAR_RAND).Rand()
+	var/random_generator = generator("num", 0, 150)
+	var/picked_pumber = random_generator.Rand()
 	switch(picked_number)
 		if (0 to 100)
 			picked_mob_type = pick(

--- a/code/modules/reagents/random_reagent_effect.dm
+++ b/code/modules/reagents/random_reagent_effect.dm
@@ -165,8 +165,8 @@
 
 /datum/random_reagent_effect/tf_simplemob/on_pick()
 	// This is a BIT ugly but eeeh
-	var/random_generator = generator("num", 0, 150)
-	var/picked_pumber = random_generator.Rand()
+	var/generator/rand = generator("num", 0, 150)
+	var/picked_number = rand.Rand()
 	switch(picked_number)
 		if (0 to 100)
 			picked_mob_type = pick(
@@ -267,7 +267,8 @@
 	var/total_hallucination_damage
 
 /datum/random_reagent_effect/hallucination/on_pick()
-	var/generator/value_rng = generator("num", 10, 0.2, LINEAR_RAND).Rand() // Uniform distribution for 10 to 0.2
+	var/generator/rand = generator("num", 10, 0.2, LINEAR_RAND)
+	var/value_rng = rand.Rand()
 	total_hallucination_damage = value_rng
 	investigative_log = "-- does hallucination damage for [total_hallucination_damage]"
 

--- a/code/modules/reagents/randomized_reagent.dm
+++ b/code/modules/reagents/randomized_reagent.dm
@@ -20,7 +20,6 @@
 
 		// Check if the effect can be picked
 		if (!the_effect.can_be_picked())
-			message_admins("[the_effect] couldn't be picked")
 			continue
 
 		the_effect.on_pick()
@@ -29,7 +28,7 @@
 
 	I.write("<small>[time_stamp()]</small> \ref[src] || Randomized <a href='?_src_=vars;Vars=\ref[src]'>[src]</a>[investigate_text]<br />")
 
-			
+
 /datum/randomized_reagent/all_effects
 	always_pick_effects = list(
 		/datum/random_reagent_effect/explode,
@@ -46,10 +45,10 @@
 	if(tick==0)
 		for (var/datum/random_reagent_effect/effect in picked_effects)
 			effect.on_human_life_zeroth(H)
-	
+
 	for (var/datum/random_reagent_effect/effect in picked_effects)
 		effect.on_human_life(H)
-		
+
 	H.updatehealth()
 
 /datum/randomized_reagent/proc/log_effect(var/mob/M, var/msg)

--- a/code/modules/reagents/randomized_reagent.dm
+++ b/code/modules/reagents/randomized_reagent.dm
@@ -1,20 +1,11 @@
+/// This gives a robust OOP framework for a reagent with a variety of random effects.
 /datum/randomized_reagent
-	var/brute = 0
-	var/oxy   = 0
-	var/tox   = 0
-	var/fire  = 0
-	var/clone = 0
-	var/brain = 0
-	var/hallucination = 0
 
-	var/explode = 0
+	/// Effects you always pick
+	var/list/always_pick_effects = list()
 
-	var/kill        = FALSE
-	var/tf_simpmob  = null
-	var/tf_immerse  = FALSE
-	var/tf_catbeast = FALSE
-
-	var/scramble_damage = FALSE
+	/// A list of all actual effects we have picked this time
+	var/list/datum/random_reagent_effect/picked_effects = list()
 
 /datum/randomized_reagent/New()
 	. = ..()
@@ -24,194 +15,42 @@
 	var/datum/log_controller/I = investigations[I_CHEMS]
 	var/investigate_text = ""
 
-	for(var/K in vars)
-		if(issaved(vars[K]) && (vars[K] != initial(vars[K])))
-			var/V = vars[K]
-			if(isnull(V)) V = "null"
-			if(isnum(V))  V = round(V, 0.1)
-			investigate_text += " - [K] [V]"
+	for (var/effect in always_pick_effects)
+		var/datum/random_reagent_effect/the_effect = new effect
+
+		// Check if the effect can be picked
+		if (!the_effect.can_be_picked())
+			message_admins("[the_effect] couldn't be picked")
+			continue
+
+		the_effect.on_pick()
+		picked_effects += the_effect
+		investigate_text += the_effect.investigative_log
 
 	I.write("<small>[time_stamp()]</small> \ref[src] || Randomized <a href='?_src_=vars;Vars=\ref[src]'>[src]</a>[investigate_text]<br />")
 
-/datum/randomized_reagent/all_effects/randomize()
-	for(var/K in vars)
-		if(issaved(vars[K]) && (vars[K] != initial(vars[K])))
-			vars[K] = initial(vars[K])
-
-	// Modifiers, do nothing on their own
-	if(prob(8))
-		explode = pick(
-			1000; 1, // Just gibs
-			 500; 2, // Small explosion
-			 400; 3, // Breaches normal floor
-			 100; 4, // Breaches reinforced floor
-		)
-
-	// Standard damage types
-	var/generator/rng = generator("num", 10, 0.2, LINEAR_RAND) // Second numeric argument is more likely
-	for(var/K in list("brute", "oxy", "tox", "fire", "clone", "brain"))
-		var/P = (K!="clone")?15:1; // Room-temperature clone damage healing should be rare
-		if(prob(P))
-			vars[K] = rng.Rand()
-			if(prob(80)) // Heal most of the time
-				vars[K] = -vars[K]
-
-	// Effects to discourage unethical testing by non-antags
-	tf_immerse  = prob(4)   // Turn female humans into boring males
-	kill        = prob(2)   // Instant death
-	tf_catbeast = prob(0.5) // Transform into a catbeast
-
-	if(prob(2)) // Transform into a simple animal
-		tf_simpmob = pick(
-			/mob/living/simple_animal/capybara, /mob/living/simple_animal/cat,
-			/mob/living/simple_animal/cat/kitten, /mob/living/simple_animal/cat/snek,
-			/mob/living/simple_animal/chick, /mob/living/simple_animal/chicken,
-			/mob/living/simple_animal/corgi, /mob/living/simple_animal/corgi/puppy,
-			/mob/living/simple_animal/corgi/saint, /mob/living/simple_animal/corgi/sasha,
-			/mob/living/simple_animal/cow, /mob/living/simple_animal/crab,
-			/mob/living/simple_animal/hamster, /mob/living/simple_animal/hostile/retaliate/goat,
-			/mob/living/simple_animal/hostile/retaliate/goat/wooly, /mob/living/simple_animal/parrot,
-			/mob/living/simple_animal/penguin, /mob/living/simple_animal/penguin/chick,
-			/mob/living/simple_animal/rabbit, /mob/living/simple_animal/rabbit/bunny,
-
-			25; list( // Uncommon
-				/mob/living/simple_animal/borer, /mob/living/simple_animal/puddi/happy,
-				/mob/living/simple_animal/puddi/anger, /mob/living/simple_animal/spiderbot
-			),
-			1; list( // Dangerous
-				/mob/living/simple_animal/amogusflash,
-				/mob/living/simple_animal/hostile/asteroid/basilisk, /mob/living/simple_animal/hostile/asteroid/goldgrub,
-				/mob/living/simple_animal/hostile/asteroid/goliath, /mob/living/simple_animal/hostile/asteroid/rockernaut,
-				/mob/living/simple_animal/hostile/bear, /mob/living/simple_animal/hostile/carp,
-				/mob/living/simple_animal/hostile/giant_spider/hunter, /mob/living/simple_animal/hostile/pitbull,
-				/mob/living/simple_animal/slime, /mob/living/simple_animal/slime/adult
-			),
-			1; list( // You poor bastard
-				/mob/living/simple_animal/hostile/retaliate/clown, /mob/living/simple_animal/hostile/retaliate/cluwne,
-				/mob/living/simple_animal/hostile/retaliate/faguette, /mob/living/simple_animal/hostile/retaliate/mime
-			),
-		)
-
-		if(islist(tf_simpmob))
-			tf_simpmob = pick(tf_simpmob)
-
-	// Misc
-	scramble_damage = prob(5)
-	if(prob(5))
-		hallucination = rng.Rand()
-
-	..()
+			
+/datum/randomized_reagent/all_effects
+	always_pick_effects = list(
+		/datum/random_reagent_effect/explode,
+		/datum/random_reagent_effect/simple_heal_damage,
+		/datum/random_reagent_effect/kill,
+		/datum/random_reagent_effect/tf_catbeast,
+		/datum/random_reagent_effect/tf_inverse,
+		/datum/random_reagent_effect/tf_simplemob,
+		/datum/random_reagent_effect/hallucination,
+		/datum/random_reagent_effect/scramble_damage,
+	)
 
 /datum/randomized_reagent/proc/on_human_life(var/mob/living/carbon/human/H, var/tick)
 	if(tick==0)
-		on_human_life_zeroth(H)
-
-	if(kill)
-		H.death(explode)
-		switch(explode)
-			if(0)
-				log_effect(H, "was killed instantly")
-			if(1)
-				log_effect(H, "was gibbed")
-			if(2)
-				log_effect(H, "exploded (small)")
-				explosion(get_turf(H), 0, 0, 1, 3, whodunnit=H)
-			if(3)
-				log_effect(H, "exploded (medium)")
-				explosion(get_turf(H), 0, 1, 3, 5, whodunnit=H)
-			if(4 to INFINITY)
-				log_effect(H, "exploded (large)")
-				explosion(get_turf(H), 1, 3, 5, 7, whodunnit=H)
-		return
-
-	if(tf_simpmob)
-		var/mob/living/simple_animal/S = new tf_simpmob(get_turf(H))
-		S.name = get_first_word(H.name)
-		S.real_name = get_first_word(H.real_name)
-		S.flavor_text = H.flavor_text
-		S.gender = H.gender
-		S.desc = "Something is off about this one."
-		S.faction = H.faction
-		S.meat_type = H.meat_type
-		S.attack_log = H.attack_log.Copy()
-		H.reagents.trans_to(S.reagents, S.reagents.maximum_volume)
-
-		S.health = 100
-		S.maxHealth = 100
-		S.stop_automated_movement = TRUE
-		S.wander = FALSE
-		S.speak_chance = 0
-		S.can_breed = FALSE //No ERP allowed
-		S.is_pet = FALSE //No ERP allowed
-
-		H.Premorph()
-		H.audible_scream()
-		H.mind.transfer_to(S)
-		log_effect(S, "was transformed into a simplemob")
-		var/obj/effect/smoke/smoke = new /obj/effect/smoke(get_turf(H))
-		smoke.time_to_live = 1
-		if(explode)
-			hgibs(get_turf(H), H.virus2, H.dna, H.species.flesh_color, H.species.blood_color, explode*explode)
-		qdel(H)
-		return
-
-	if(tf_catbeast && !iscatbeast(H))
-		H.set_species("Tajaran", transfer_damage = TRUE)
-		H.regenerate_icons()
-		H.emote("me", MESSAGE_HEAR, pick("meows", "mews"))
-		playsound(H, 'sound/voice/catmeow.ogg', 100)
-		log_effect(H, "was transformed into a catbeast")
-
-	if(tf_immerse && isjusthuman(H) && H.gender != MALE)
-		H.emote("faint")
-		var/obj/effect/smoke/smoke = new /obj/effect/smoke(get_turf(H))
-		smoke.time_to_live = 1
-		H.gender = MALE
-
-		H.my_appearance.h_style = pick("Bald", "Bedhead", "Bedhead 2", "Bowl", "Skinhead", "Balding Hair", "Nitori", "Manbun")
-		H.my_appearance.f_style = pick("Neckbeard", "Full Beard", "Unshaven")
-		H.my_appearance.s_tone = rand(-10, 10)
-
-		H.my_appearance.r_eyes = H.my_appearance.g_eyes = H.my_appearance.b_eyes = 0
-		H.my_appearance.r_facial = H.my_appearance.r_hair = 20
-		H.my_appearance.g_facial = H.my_appearance.g_hair = 20
-		H.my_appearance.b_facial = H.my_appearance.b_hair = 20
-
-		H.update_hair()
-		H.update_body()
-		H.regenerate_icons()
-		H.check_dna_integrity()
-		H.update_dna_from_appearance()
-		log_effect(H, "was transformed into a man")
-
-	H.hallucination += hallucination
-	H.adjustBruteLoss(brute*REM)
-	H.adjustOxyLoss(oxy*REM)
-	H.adjustToxLoss(tox*REM)
-	H.adjustFireLoss(fire*REM)
-	H.adjustCloneLoss(clone*REM)
-	H.adjustBrainLoss(brain*REM)
+		for (var/datum/random_reagent_effect/effect in picked_effects)
+			effect.on_human_life_zeroth(H)
+	
+	for (var/datum/random_reagent_effect/effect in picked_effects)
+		effect.on_human_life(H)
+		
 	H.updatehealth()
-
-/datum/randomized_reagent/proc/on_human_life_zeroth(var/mob/living/carbon/human/H)
-	if(scramble_damage && !(H.status_flags&GODMODE))
-		var/damage_msg = "[H.getBruteLoss()]/[H.getOxyLoss()]/[H.getToxLoss()]/[H.getFireLoss()]/[H.getCloneLoss()]"
-		var/damage_budget = H.getOxyLoss() + H.getToxLoss() + H.getCloneLoss()
-		H.setOxyLoss(0)
-		H.setToxLoss(0)
-		H.setCloneLoss(0)
-		for(var/datum/organ/external/O in H.organs)
-			if(O.is_organic() && O.is_existing())
-				damage_budget += O.brute_dam + O.burn_dam
-				O.brute_dam = O.burn_dam = 0
-
-		while(damage_budget>0)
-			var/D = rand(max(damage_budget, 1))
-			var/P = pick("adjustBruteLoss", "adjustOxyLoss", "adjustToxLoss", "adjustFireLoss", "adjustCloneLoss")
-			call(H,P)(D)
-			damage_budget -= D
-		damage_msg += " to [H.getBruteLoss()]/[H.getOxyLoss()]/[H.getToxLoss()]/[H.getFireLoss()]/[H.getCloneLoss()]"
-		log_effect(H, "had their damage scrambled ([damage_msg])")
 
 /datum/randomized_reagent/proc/log_effect(var/mob/M, var/msg)
 	M.attack_log += text("\[[time_stamp()]\]: <font color='orange'>[msg] (<a href='?_src_=vars;Vars=\ref[src]'>[src]</a>)</font>")
@@ -219,6 +58,7 @@
 	msg_admin_attack("[M.name] ([M.ckey]) [msg] (<a href='?_src_=vars;Vars=\ref[src]'>RR</a>) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[M.x];Y=[M.y];Z=[M.z]'>JMP</a>)")
 
 var/list/datum/randomized_reagent/randomized_reagents = list()
+
 /proc/create_randomized_reagents()
 	randomized_reagents.Cut()
 	randomized_reagents[SIMPOLINOL] = new /datum/randomized_reagent/all_effects

--- a/code/modules/reagents/reagents/reagents_medical.dm
+++ b/code/modules/reagents/reagents/reagents_medical.dm
@@ -1508,13 +1508,15 @@ var/global/list/charcoal_doesnt_remove=list(
 		return
 	var/mob/living/carbon/human/H = M
 
+	/*
 	if(!H.ckey)
 		H.adjustToxLoss(5)
 	if((!H.client) || H.client.is_afk())
 		if(prob(30))
 			H.vomit(0,1)
 		return
-
+	*/
+	
 	randomized_reagents[SIMPOLINOL].on_human_life(H, tick)
 
 /datum/reagent/srejuvenate

--- a/code/modules/reagents/reagents/reagents_medical.dm
+++ b/code/modules/reagents/reagents/reagents_medical.dm
@@ -1508,15 +1508,15 @@ var/global/list/charcoal_doesnt_remove=list(
 		return
 	var/mob/living/carbon/human/H = M
 
-	/*
+	
 	if(!H.ckey)
 		H.adjustToxLoss(5)
 	if((!H.client) || H.client.is_afk())
 		if(prob(30))
 			H.vomit(0,1)
 		return
-	*/
 	
+
 	randomized_reagents[SIMPOLINOL].on_human_life(H, tick)
 
 /datum/reagent/srejuvenate

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2498,6 +2498,7 @@
 #include "code\modules\reagents\dartgun.dm"
 #include "code\modules\reagents\fission.dm"
 #include "code\modules\reagents\grenade_launcher.dm"
+#include "code\modules\reagents\random_reagent_effect.dm"
 #include "code\modules\reagents\randomized_reagent.dm"
 #include "code\modules\reagents\reagent_containers.dm"
 #include "code\modules\reagents\reagent_dispenser.dm"


### PR DESCRIPTION
## Foreword

Simpolinol is a chemical which heals simple mobs, added in #26236. It was made to have random, interesting reaction on human mobs (with a client) in #33312. While the concept was interesting, the execution was very poor and I suspect untested. It is unclear if the probabilities were too low or the code was bugged, but it never seem to have worked.

Requested by ArthurDentist

## What this does

This completly refactors the random reagent mechanic in a way that is sane, easy to debug and understand, and can be further elaborate on. This time, the code works (I tested it). The probabilities of the healing effects have been bumped slightly so that the chemical isn't mute all the time.

## Why it's good

Restores a broken feature with inherent round-variety and funny screencap, and also a system easier to work with than the mess of hardcode that was before.

## How it was tested

Playtested a few rounds to see if the random reagent was correctly generated, played with the probabilities of effect generation to see if they reliably triggered, then varedited the reagent datum to test if the effect worked.

## Changelog
:cl:
- bugfix: Fixes Simpolinol having seemingly no effects on non-simple mobs. It should correctly have interesting random effects now.
- experimental: Simpolinol has not been approved for human clinical trials yet. Experiment at your own risk.