### PR TITLE
Makes fire alarms always check for shelter inside before putting one in

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1327,6 +1327,9 @@ FIRE ALARM
 	src.add_fingerprint(user)
 
 	if (istype(W,/obj/item/inflatable/shelter))
+		if(shelter)
+			to_chat(user, "<span class='warning'>[src] already has a shelter, remove it to put this one in.</span>")
+			return
 		qdel(W)
 		shelter = TRUE
 		update_icon()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1328,7 +1328,7 @@ FIRE ALARM
 
 	if (istype(W,/obj/item/inflatable/shelter))
 		if(shelter)
-			to_chat(user, "<span class='warning'>[src] already has a shelter, remove it to put this one in.</span>")
+			to_chat(user, "<span class='warning'>\The [src] already has a shelter, remove it to put this one in.</span>")
 			return
 		qdel(W)
 		shelter = TRUE


### PR DESCRIPTION
[bugfix][sanity]

## What this does
Closes #37495.

## How it was tested
Trying to put a shelter in a fire alarm that already has one via clicking and the browser.

## Changelog
:cl:
 * bugfix: Fire alarms no longer accept shelters if they already have one, making them unretrievable.
