### PR TITLE
Reduce Bloodstone Health

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -1503,8 +1503,8 @@ var/list/cult_spires = list()
 	icon_state = "bloodstone-enter1"
 	icon = 'icons/obj/cult_64x64.dmi'
 	pixel_x = -16 * PIXEL_MULTIPLIER
-	health = 1800
-	maxHealth = 1800
+	health = 750
+	maxHealth = 750
 	sound_damaged = 'sound/effects/stone_hit.ogg'
 	sound_destroyed = 'sound/effects/stone_crumble.ogg'
 	plane = EFFECTS_PLANE
@@ -1663,16 +1663,6 @@ var/list/cult_spires = list()
 			takeDamage(50)
 		if (3)
 			takeDamage(10)
-
-/obj/structure/cult/bloodstone/singularity_act(var/singularity_size=0,var/obj/machinery/singularity/S)
-	switch(singularity_size)
-		if(1 to 4)
-			ex_act(3)
-		if(5 to 8)
-			ex_act(2)
-		if(9 to INFINITY)
-			ex_act(1)
-	return 0
 
 /obj/structure/cult/bloodstone/singularity_pull(S, current_size, repel = FALSE)//we don't want that one to come unanchored
 	return

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -1503,7 +1503,7 @@ var/list/cult_spires = list()
 	icon_state = "bloodstone-enter1"
 	icon = 'icons/obj/cult_64x64.dmi'
 	pixel_x = -16 * PIXEL_MULTIPLIER
-	health = 750
+	health = 1000
 	maxHealth = 750
 	sound_damaged = 'sound/effects/stone_hit.ogg'
 	sound_destroyed = 'sound/effects/stone_crumble.ogg'
@@ -1658,12 +1658,23 @@ var/list/cult_spires = list()
 /obj/structure/cult/bloodstone/ex_act(var/severity)
 	switch(severity)
 		if (1)
-			takeDamage(250)
+			takeDamage(200)
 		if (2)
 			takeDamage(50)
 		if (3)
 			takeDamage(10)
+/*
+/obj/structure/cult/bloodstone/singularity_act(var/singularity_size=0,var/obj/machinery/singularity/S)
+	switch(singularity_size)
+		if(1 to 4)
+			ex_act(3)
+		if(5 to 8)
+			ex_act(2)
+		if(9 to INFINITY)
+			ex_act(1)
+	return 0
 
+*/
 /obj/structure/cult/bloodstone/singularity_pull(S, current_size, repel = FALSE)//we don't want that one to come unanchored
 	return
 


### PR DESCRIPTION
## What this does
Significantly reduces the bloodstone's health from 1800 down to 1000, as well as removing the effective immunity it has to singularities. Since you essentially have to kill the entire cult in order to even get at the bloodstone it seems absurd that it has such a massive health pool. That's 6 entire lasers emptied into it after fighting a minimum of 9 people+constructs in a limited timeframe. This health reduction (alongside a slight reduction to dev range explosion damage) also means that the bloodstone is destroyed after a mere 5 shardbombs instead of 8.
This also removes the effective immunity that the bloodstone has to the singularity, as previously it could take a stage 3 singulo for a whopping 72 continuous seconds (36 ticks) or a level 4 and above one for 16 continuous seconds (8 ticks) which is a pretty big ask on something with random movement.

## Why it's good
It might actually be possible to break the bloodstone in a round where there aren't 6 squaddies trying to destroy it. Honestly with health values this high it might as well have been indestructible.

## How it was tested
Booted up a local server and shot it a few times, spawned a singularity on it.

## Changelog
 * tweak: Significantly reduced the bloodstone's health and removed its extremely high singularity resistance