### PR TITLE
Fixes ankh horn using all the sand stack

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -86,9 +86,9 @@
 /obj/item/stack/ore/glass/attackby(obj/item/weapon/W, mob/user)
 	..()
 	if(istype(W))
-		var/obj/item/weapon/bikehorn/HONKER = W
-		if(HONKER.can_honk_baton)
-			user.create_in_hands(src, /obj/item/weapon/bikehorn/ankhhorn, W, msg = "You call upon the blessings of the Sun God as you cover \the [W] with \the [src].")
+		var/obj/item/weapon/bikehorn/honker = W
+		if(honker.can_honk_baton)
+			user.create_in_hands(honker, /obj/item/weapon/bikehorn/ankhhorn, src, uses=1, msg = "<span class='notice'>You call upon the blessings of the Sun God as you cover \the [W] with \the [src].</span>")
 
 /obj/item/stack/ore/plasma
 	name = "\improper plasma ore"


### PR DESCRIPTION
Just a case of two vars not in the right order.
Closes #37479

## How it was tested

Made a horn with 1 sand stack = consume all
Make a horn with 2 sands stack = just consume one

Additionally add a `notice` span to the creation message.

## Changelog
:cl:
* bugfix: Fixes Ankh Horn using all the sand available in a stack instead of just one stack.