### PR TITLE
Fixes Lazarus injector not reviving simple animals who died of heat

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -735,6 +735,7 @@ var/global/list/animal_count = list() //Stores types, and amount of animals of t
 		maxHealth = initial(maxHealth)
 		maxHealth -= (initial(maxHealth) / meat_amount) * meat_taken
 	health = maxHealth
+	bodytemperature = initial(bodytemperature)
 	..(0)
 
 /mob/living/simple_animal/proc/make_babies() // <3 <3 <3


### PR DESCRIPTION
Closes #37494

## Testing

Brought salem to the library, used firebreath to set it on fire, waited for him to die of heat, revived him.
He survived.

:cl:
- bugfix: Lazarus-revived mobs who died of heat damage will no longer die again shortly after being revived.