### PR TITLE
Rig outfit datums QOL fix

### DIFF
--- a/code/datums/outfit/special_outfits/special.dm
+++ b/code/datums/outfit/special_outfits/special.dm
@@ -16,7 +16,13 @@
 /datum/outfit/special/rig/post_equip(var/mob/living/carbon/human/H)
 	..()
 	var/obj/item/clothing/suit/space/rig/R = H.wear_suit
-	R.toggle_suit()
+	if (istype(R))
+		R.toggle_suit()
+	else
+		// If the above check failed, this means we somehow couldn't remove the suit slot
+		// Which probably meant the admin forgot to toggle strip-items. For convenience we just spawn the suit
+		var/suit_type = items_to_spawn["Default"][slot_wear_suit_str]
+		new suit_type(get_turf(H))
 
 /datum/outfit/special/rig/gemsuit
 	outfit_name = "Wizard Gemsuit"
@@ -24,7 +30,7 @@
 		"Default" = list(
 			slot_wear_suit_str = /obj/item/clothing/suit/space/rig/wizard,
 			slot_gloves_str = /obj/item/clothing/gloves/purple,
-			slot_shoes_str = /obj/item/clothing/shoes/sandal,
+			slot_shoes_str = /obj/item/clothing/shoes/magboots/sandal,
 		),
 	)
 
@@ -36,12 +42,20 @@
 		),
 	)
 
+	items_to_collect = list(
+		/obj/item/clothing/shoes/magboots = GRASP_LEFT_HAND,
+	)
+
 /datum/outfit/special/rig/soviet_rig
 	outfit_name = "Soviet rigsuit"
 	items_to_spawn = list(
 		"Default" = list(
 			slot_wear_suit_str = /obj/item/clothing/suit/space/rig/soviet,
 		),
+	)
+
+	items_to_collect = list(
+		/obj/item/clothing/shoes/magboots = GRASP_LEFT_HAND,
 	)
 
 /datum/outfit/special/rig/engineer_rig
@@ -54,6 +68,10 @@
 		),
 	)
 
+	items_to_collect = list(
+		/obj/item/clothing/shoes/magboots = GRASP_LEFT_HAND,
+	)
+
 /datum/outfit/special/rig/ce_rig
 	outfit_name = "Chief engineer rig suit"
 	items_to_spawn = list(
@@ -62,6 +80,10 @@
 			slot_wear_mask_str = /obj/item/clothing/mask/breath,
 			slot_s_store_str = /obj/item/weapon/tank/jetpack/oxygen,
 		),
+	)
+
+	items_to_collect = list(
+		/obj/item/clothing/shoes/magboots = GRASP_LEFT_HAND,
 	)
 
 /datum/outfit/special/rig/mining_rig
@@ -74,6 +96,10 @@
 		),
 	)
 
+	items_to_collect = list(
+		/obj/item/clothing/shoes/magboots = GRASP_LEFT_HAND,
+	)
+
 /datum/outfit/special/rig/mining_rig
 	outfit_name = "Syndie rig suit"
 	items_to_spawn = list(
@@ -82,6 +108,10 @@
 			slot_wear_mask_str = /obj/item/clothing/mask/breath,
 			slot_s_store_str = /obj/item/weapon/tank/jetpack/oxygen,
 		),
+	)
+
+	items_to_collect = list(
+		/obj/item/clothing/shoes/magboots = GRASP_LEFT_HAND,
 	)
 
 /datum/outfit/special/rig/medical_rig
@@ -94,6 +124,10 @@
 		),
 	)
 
+	items_to_collect = list(
+		/obj/item/clothing/shoes/magboots = GRASP_LEFT_HAND,
+	)
+
 /datum/outfit/special/rig/atmos_rig
 	outfit_name = "Atmos rig suit"
 	items_to_spawn = list(
@@ -102,6 +136,10 @@
 			slot_wear_mask_str = /obj/item/clothing/mask/breath,
 			slot_s_store_str = /obj/item/weapon/tank/jetpack/oxygen,
 		),
+	)
+
+	items_to_collect = list(
+		/obj/item/clothing/shoes/magboots = GRASP_LEFT_HAND,
 	)
 
 // ----- Other suits

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -14,8 +14,21 @@
 	var/stomp_boot = "magboot"
 	var/stomp_hit = "crushes"
 	var/anchoring_system_examine = "Its mag-pulse traction system appears to be"
+	var/anchoring_system_name = "mag-pulse traction system"
+	var/change_icon = TRUE
 
 	var/obj/item/clothing/shoes/stored_shoes = null	//Shoe holder
+
+/obj/item/clothing/shoes/magboots/sandal
+	name = "magic sandals"
+	icon_state = "wizard"
+	desc = "Those sandals have been carefully hand-enchanted by unionised, fairly-paid labour in the Wizard Federation and are rated for extravehicular activity."
+	anchoring_system_examine = "Its gravity anchoring enchantement appears to be"
+	anchoring_system_name = "gravity anchoring enchantement"
+	stomp_boot = "sandal"
+	change_icon = FALSE
+	mag_slow =  NO_SLOWDOWN
+	w_class = W_CLASS_SMALL
 
 /obj/item/clothing/shoes/magboots/mob_can_equip(mob/living/carbon/human/user, slot, disable_warning = 0)
 	var/mob/living/carbon/human/H = user
@@ -102,7 +115,7 @@
 	clothing_flags &= ~(NOSLIP | MAGPULSE)
 	slowdown = SHACKLE_SHOES_SLOWDOWN
 	icon_state = "[base_state]1"
-	to_chat(user, "<span class='danger'>You override the mag-pulse traction system!</span>")
+	to_chat(user, "<span class='danger'>You override the [anchoring_system_name]!</span>")
 	user.update_inv_shoes()	//so our mob-overlays update
 
 /obj/item/clothing/shoes/magboots/attackby(var/obj/item/O, var/mob/user)
@@ -114,25 +127,27 @@
 			emagged = FALSE
 			slowdown = NO_SLOWDOWN
 			icon_state = "[base_state]0"
-			to_chat(user, "<span class='notice'>You restore the mag-pulse traction system.</span>")
+			to_chat(user, "<span class='notice'>You restore the [anchoring_system_name].</span>")
 			user.update_inv_shoes()	//so our mob-overlays update
 
 /obj/item/clothing/shoes/magboots/togglemagpulse(var/mob/user = usr)
 	if(user.isUnconscious())
 		return
 	if(emagged)
-		to_chat(user, "<span class='warning'>The mag-pulse traction system cannot be turned off!</span>")
+		to_chat(user, "<span class='warning'>The [anchoring_system_name] cannot be turned off!</span>")
 		return
 	if(clothing_flags & MAGPULSE)
 		clothing_flags &= ~(NOSLIP | MAGPULSE)
 		slowdown = NO_SLOWDOWN
-		icon_state = "[base_state]0"
-		to_chat(user, "You disable the mag-pulse traction system.")
+		if (change_icon)
+			icon_state = "[base_state]0"
+		to_chat(user, "<span class='notice'>You disable the [anchoring_system_name].</span>")
 	else
 		clothing_flags |= (NOSLIP | MAGPULSE)
 		slowdown = mag_slow
-		icon_state = "[base_state]1"
-		to_chat(user, "You enable the mag-pulse traction system.")
+		if (change_icon)
+			icon_state = "[base_state]1"
+		to_chat(user, "<span class='notice'>You enable the [anchoring_system_name].</span>")
 	user.update_inv_shoes()	//so our mob-overlays update
 
 /obj/item/clothing/shoes/magboots/examine(mob/user)


### PR DESCRIPTION
This just changes rig-outfit datums so that:
- mobs spawn with magboots in hand
- if the admin forgot to turn on "strip items", then the rig suit appears at the feet of the mob.

Wizard rig suits have enchanted sandals in lieu of magboots. I considered making them non-emaggable, but I thought it would be a funny inside joke. There is no non-adminbus way to get those magic magboots.

## Why it's good

Because I sometimes mess up the outfit datums rig equip.
