### PR TITLE
Some fixes for wrapper code

### DIFF
--- a/code/game/objects/items/stacks/packagewrap.dm
+++ b/code/game/objects/items/stacks/packagewrap.dm
@@ -67,7 +67,7 @@
 	if(target.anchored)
 		to_chat(user, "<span class='notice'>You can't get the wrapping around \the [target].</span>")
 		return
-	if(target in user && !(target in user.held_items)) // Can wrap things in held items.
+	if( (target in user) && !(target in user.held_items)) // Can wrap things in held items.
 		to_chat(user, "<span class='notice'>That's not gonna work.</span>")
 		return
 	if(!proximity_flag)

--- a/code/game/objects/items/stacks/packagewrap.dm
+++ b/code/game/objects/items/stacks/packagewrap.dm
@@ -67,7 +67,7 @@
 	if(target.anchored)
 		to_chat(user, "<span class='notice'>You can't get the wrapping around \the [target].</span>")
 		return
-	if(target in user)
+	if(target in user && !(target in user.held_items)) // Can wrap things in held items.
 		to_chat(user, "<span class='notice'>That's not gonna work.</span>")
 		return
 	if(!proximity_flag)
@@ -85,13 +85,17 @@
 	if(istype(target, /obj/item) && smallpath)
 		if (amount >= 1)
 			var/obj/item/I = target
-			var/obj/item/P = new smallpath(get_turf(target.loc),target,round(I.w_class))
+			var/gift_in_hands = user.is_holding_item(target)
+			var/obj/item/P = new smallpath(get_turf(target),target,round(I.w_class))
 			if(!istype(target.loc, /turf))
 				if(user.client)
 					user.client.screen -= target
+			user.drop_item(target, force_drop = 1)
 			target.forceMove(P)
 			P.add_fingerprint(user)
 			use(1)
+			if (gift_in_hands)
+				user.put_in_hands(P)
 			to_chat(user, "<span class='notice'>You wrap \the [target] with \the [src].</span>")
 		else
 			to_chat(user, "<span class='warning'>You need more paper!</span>")
@@ -105,7 +109,7 @@
 			if(MC.angry)
 				return
 		if(amount >= 3)
-			var/obj/item/P = new bigpath(get_turf(target.loc),target)
+			var/obj/item/P = new bigpath(get_turf(target), target)
 			target.forceMove(P)
 			P.add_fingerprint(user)
 			use(3)

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -26,7 +26,7 @@
 	gift = target
 	update_icon()
 
-/obj/item/weapon/gift/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/weapon/gift/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/weapon/pen))
 		var/str = copytext(sanitize(input(user,"What should the label read? (max 52 characters)","Write a personal message!","") as message|null),1,MAX_NAME_LEN * 2)
 		if (!Adjacent(user) || user.stat)
@@ -51,9 +51,7 @@
 			icon_state = "gift-large"
 			item_state = "gift-large"
 
-/obj/item/weapon/gift/attack_self(mob/user as mob)
-	for(var/I in contents)
-		user.put_in_hands(I)
+/obj/item/weapon/gift/attack_self(mob/user)
 	user.drop_item(src, force_drop = 1)
 	if(gift)
 		user.put_in_active_hand(gift)
@@ -61,6 +59,8 @@
 		to_chat(user, "<span class='notice'>You unwrapped \a [gift]!</span>")
 	else
 		to_chat(user, "<span class='notice'>The gift was empty!</span>")
+	for (var/obj/item/I in contents)
+		I.forceMove(get_turf(user))
 	qdel(src)
 	return
 


### PR DESCRIPTION
This fixes #37448, which was probably always a bit gunky but nobody noticed before.

This adds some QoL to gift-handling, such as allowing a user to wrap a gift in its in their hands, and if so, puts the gift directly in their hands. While not strictly "realistic" to have such dexterity, I believe the QoL ouweigh the immulsions loss.

Tested.

:cl:
- bugfix: Wrapped items should no longer behave erratically after being unwrapped.
- tweak: You can now wrap items while holding them.