### PR TITLE
Fixes player panel search tool displaying empty rows

### DIFF
--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -107,7 +107,7 @@
 								if ( search.innerText.toLowerCase().indexOf(filter) == -1 )
 								{
 									//document.write("a");
-									//ltr.removeChild(tr);
+    								tr.parentNode.removeChild(tr);
 									td.innerHTML = "";
 									i--;
 								}
@@ -402,4 +402,4 @@
 
 	dat += "</table></body></html>"
 
-	usr << browse(HTML_SKELETON(dat), "window=players;size=640x480")
+	usr << browse(dat, "window=players;size=640x480")


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dcb69fa4-9d02-4b80-8b12-e4c1baab54e0)

I will be 100% honest, this change is powered by an LLM because I wasn't about to check that ugly ass JS code from 2013.
But I did test it. It should work in both 516 and 515 clients connecting to the game now.

I also removed an extra `HTML_SKELETON` since the admin panel is already properly formed HTML.
Thanks to ApopheticOrder for the report.