### PR TITLE
May fix the login failure issue on 516

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -149,7 +149,7 @@ var/updated_stats = 0
 		bunker_setting = 1
 		load_bunker()
 	if(config)
-		winset_wrapper() // The TG people told me to do it. If this fails for reason X or Y, the entire client/New() will runtime and we'll be in huge trouble.
+		winset_wrapper(null, "window1.msay_output.style=[config.world_style_config];") // The TG people told me to do it. If this fails for reason X or Y, the entire client/New() will runtime and we'll be in huge trouble.
 	else
 		to_chat(src, "<span class='warning'>The stylesheet wasn't properly setup call an administrator to reload the stylesheet or relog.</span>")
 
@@ -331,22 +331,22 @@ var/updated_stats = 0
 		prefs.save_preferences_sqlite(src, src.ckey)
 
 	if(prefs.lastchangelog != changelog_hash) //bolds the changelog button on the interface so we know there are updates.
-		winset(src, "rpane.changelog", "background-color=#eaeaea;font-style=bold")
+		winset_wrapper("rpane.changelog", "background-color=#eaeaea;font-style=bold")
 		prefs.SetChangelog(ckey,changelog_hash)
 		to_chat(src, "<span class='info'>Changelog has changed since your last visit.</span>")
 
 	//Set map label to correct map name
-	winset(src, "rpane.mapb", "text=\"[map.nameLong]\"")
+	winset_wrapper(src, "rpane.mapb", "text=\"[map.nameLong]\"")
 
 	if (round_end_info)
-		winset(src, "rpane.round_end", "is-visible=true")
-		winset(src, "rpane.last_round_end", "is-visible=false")
+		winset_wrapper("rpane.round_end", "is-visible=true")
+		winset_wrapper("rpane.last_round_end", "is-visible=false")
 	else if (last_round_end_info)
-		winset(src, "rpane.round_end", "is-visible=false")
-		winset(src, "rpane.last_round_end", "is-visible=true")
+		winset_wrapper("rpane.round_end", "is-visible=false")
+		winset_wrapper("rpane.last_round_end", "is-visible=true")
 	else
-		winset(src, "rpane.round_end", "is-visible=false")
-		winset(src, "rpane.last_round_end", "is-visible=false")
+		winset_wrapper("rpane.round_end", "is-visible=false")
+		winset_wrapper("rpane.last_round_end", "is-visible=false")
 
 	if (runescape_pvp)
 		to_chat(src, "<span class='userdanger'>WARNING: Wilderness mode is enabled; players can only harm one another in maintenance areas!</span>")
@@ -359,8 +359,9 @@ var/updated_stats = 0
 
 	fps = (prefs.fps < 0) ? RECOMMENDED_CLIENT_FPS : prefs.fps
 
-/client/proc/winset_wrapper()
-	winset(src, null, "window1.msay_output.style=[config.world_style_config];")
+// This is wrapped so that if the winset fucks up somehow, this doesn't crash the entire client login proc.
+/client/proc/winset_wrapper(control_id, params)
+	winset(src, control_id, params)
 
 	//////////////
 	//DISCONNECT//

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -149,7 +149,7 @@ var/updated_stats = 0
 		bunker_setting = 1
 		load_bunker()
 	if(config)
-		winset(src, null, "window1.msay_output.style=[config.world_style_config];")
+		winset_wrapper() // The TG people told me to do it. If this fails for reason X or Y, the entire client/New() will runtime and we'll be in huge trouble.
 	else
 		to_chat(src, "<span class='warning'>The stylesheet wasn't properly setup call an administrator to reload the stylesheet or relog.</span>")
 
@@ -358,6 +358,9 @@ var/updated_stats = 0
 		tooltips = new /datum/tooltip(src)
 
 	fps = (prefs.fps < 0) ? RECOMMENDED_CLIENT_FPS : prefs.fps
+
+/client/proc/winset_wrapper()
+	winset(src, null, "window1.msay_output.style=[config.world_style_config];")
 
 	//////////////
 	//DISCONNECT//


### PR DESCRIPTION
Apparently you can have a "bad winset" and it crashes the entire proc the winset is running in.
This is particularily bad for `/client/New()` since it breaks basically everything.

This is something the TG people told me to do to at least mitigate it. I /think/ what's happening is that our clients try to log in to the serb several times (due to latency), causing a series of Login/Logout, crashes, etc.

I can't really notice it locally due to better latency to my own computer (duh).

Sorry everyone