### PR TITLE
Moves Art Storage/Restores Old Library

### DIFF
--- a/maps/tgstation.dmm
+++ b/maps/tgstation.dmm
@@ -13806,10 +13806,6 @@
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
 "awp" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	name = "Firelock North"
-	},
 /obj/machinery/door/airlock/glass_security{
 	name = "Detective";
 	req_access_txt = "4"
@@ -13824,6 +13820,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	name = "Firelock South"
 	},
 /turf/simulated/floor,
 /area/security/detectives_office)
@@ -15163,6 +15162,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fore)
 "ayY" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
 /turf/simulated/floor{
 	icon_state = "red"
 	},
@@ -16392,43 +16394,75 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aBA" = (
-/obj/structure/sign/poster{
-	icon_state = "vgposter3";
-	pixel_y = 32
-	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/abstract/map/paint_coat,
-/obj/item/weapon/reagent_containers/glass/metal_bucket/paint/filled/white,
-/turf/simulated/floor,
-/area/maintenance/fpmaint)
-"aBB" = (
-/obj/structure/sign/poster{
-	icon_state = "bsposter7";
-	pixel_y = 32
+/obj/item/weapon/reagent_containers/glass/metal_bucket/paint/filled/random{
+	pixel_y = 8
 	},
+/obj/item/weapon/reagent_containers/glass/metal_bucket/paint{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/weapon/reagent_containers/glass/metal_bucket/paint{
+	pixel_x = 4
+	},
+/obj/machinery/door_control{
+	id_tag = "art1";
+	name = "Art Shutters Control";
+	pixel_x = -28
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "showroomfloor";
+	tag = "icon-showroomfloor (NORTH)"
+	},
+/area/storage/art)
+"aBB" = (
 /obj/abstract/map/paint_coat/paint_stroke{
 	dir = 8
 	},
-/turf/simulated/floor,
-/area/maintenance/fpmaint)
-"aBC" = (
-/obj/structure/sign/poster{
-	icon_state = "poster7";
-	pixel_y = 32
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "showroomfloor";
+	tag = "icon-showroomfloor (NORTH)"
 	},
+/area/storage/art)
+"aBC" = (
 /obj/abstract/map/paint_coat,
 /obj/item/paint_roller,
-/turf/simulated/floor,
-/area/maintenance/fpmaint)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "showroomfloor";
+	tag = "icon-showroomfloor (NORTH)"
+	},
+/area/storage/art)
 "aBD" = (
-/obj/structure/block,
 /obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
+/obj/structure/easel,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "showroomfloor";
+	tag = "icon-showroomfloor (NORTH)"
+	},
+/area/storage/art)
 "aBE" = (
-/obj/structure/block,
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
+/obj/item/mounted/frame/painting/custom/landscape,
+/obj/item/painting_brush{
+	pixel_x = -8;
+	pixel_y = 16
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "showroomfloor";
+	tag = "icon-showroomfloor (NORTH)"
+	},
+/area/storage/art)
 "aBF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -17110,8 +17144,28 @@
 	dir = 1;
 	icon_state = "border_roller_progress"
 	},
-/turf/simulated/floor,
-/area/maintenance/fpmaint)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/stack/sheet/wood/bigstack,
+/obj/item/device/rcd/tile_painter{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/weapon/chisel{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/weapon/chisel{
+	pixel_x = 16
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "showroomfloor";
+	tag = "icon-showroomfloor (NORTH)"
+	},
+/area/storage/art)
 "aDk" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -17536,30 +17590,34 @@
 /turf/simulated/floor/plating,
 /area/maintenance/ghettobar)
 "aEh" = (
-/obj/machinery/light/small{
-	dir = 8;
-	flickering = 1
+/obj/machinery/door/airlock/glass{
+	name = "Art Storage"
 	},
-/obj/item/weapon/reagent_containers/glass/metal_bucket/paint/filled/random{
-	pixel_y = 8
+/obj/structure/curtain/open{
+	color = "#854636"
 	},
-/obj/item/weapon/reagent_containers/glass/metal_bucket/paint/filled/random{
-	pixel_x = -4;
-	pixel_y = 2
+/obj/machinery/door/firedoor/border_only{
+	dir = 1;
+	name = "Firelock North"
 	},
-/obj/item/weapon/reagent_containers/glass/metal_bucket/paint/filled/random{
-	pixel_x = 4;
-	pixel_y = -2
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "showroomfloor";
+	tag = "icon-showroomfloor (NORTH)"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
+/area/storage/art)
 "aEi" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Backup Art Storage";
 	req_access_txt = "12"
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
+/area/storage/art)
 "aEj" = (
 /obj/structure/closet/crate{
 	name = "Gold Crate"
@@ -18216,27 +18274,25 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aFB" = (
-/obj/item/weapon/reagent_containers/glass/metal_bucket/paint{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/weapon/reagent_containers/glass/metal_bucket/paint{
-	pixel_x = 4
-	},
-/obj/abstract/map/paint_coat/paint_stroke{
+/obj/structure/block,
+/turf/simulated/floor{
 	dir = 1;
-	icon_state = "splatter"
+	icon_state = "showroomfloor";
+	tag = "icon-showroomfloor (NORTH)"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
+/area/storage/art)
 "aFC" = (
 /obj/structure/sign/poster{
 	icon_state = "bsposter8";
 	pixel_y = -32
 	},
-/obj/structure/mannequin/wood,
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
+/obj/machinery/vending/art,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "showroomfloor";
+	tag = "icon-showroomfloor (NORTH)"
+	},
+/area/storage/art)
 "aFD" = (
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/plating,
@@ -18249,27 +18305,42 @@
 /obj/item/weapon/storage/fancy/crayons{
 	pixel_x = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
-"aFF" = (
-/obj/structure/table,
-/obj/item/weapon/chisel{
-	pixel_x = 10;
+/obj/item/weapon/storage/toolbox/paint{
+	pixel_y = 8
+	},
+/obj/item/weapon/reagent_containers/glass/bottle/acetone{
+	pixel_x = 6;
 	pixel_y = 2
 	},
-/obj/item/weapon/chisel{
-	pixel_x = 16
+/obj/structure/cable/yellow,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
+/obj/machinery/power/apc{
+	pixel_y = -24
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "showroomfloor";
+	tag = "icon-showroomfloor (NORTH)"
+	},
+/area/storage/art)
+"aFF" = (
+/obj/structure/table,
 /obj/structure/sign/poster{
 	icon_state = "poster4";
 	pixel_y = -32
 	},
-/obj/item/device/rcd/tile_painter{
-	pixel_x = -2;
+/obj/machinery/sewing_machine{
 	pixel_y = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "showroomfloor";
+	tag = "icon-showroomfloor (NORTH)"
+	},
+/area/storage/art)
 "aFG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -25619,7 +25690,7 @@
 /area/maintenance/fsmaint2)
 "aVw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/library)
 "aVy" = (
 /obj/structure/bed/chair/office/dark,
@@ -25628,14 +25699,14 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/library)
 "aVz" = (
 /obj/structure/bed/chair/office/dark,
 /obj/machinery/camera{
 	name = "Library North"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/library)
 "aVA" = (
 /obj/structure/disposalpipe/segment{
@@ -25648,7 +25719,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/library)
 "aVC" = (
 /obj/structure/crematorium,
@@ -26518,7 +26589,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/library)
 "aXs" = (
 /turf/simulated/floor/wood,
@@ -26527,13 +26598,13 @@
 /obj/structure/table/woodentable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/library)
 "aXu" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder,
 /obj/item/weapon/pen,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/library)
 "aXv" = (
 /obj/machinery/newscaster{
@@ -26545,7 +26616,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/library)
 "aXx" = (
 /turf/simulated/floor{
@@ -27225,16 +27296,21 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /turf/simulated/floor/wood,
 /area/library)
 "aYU" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "red"
+	},
+/area/hallway/primary/fore)
 "aYV" = (
 /obj/machinery/light{
 	dir = 4
@@ -28131,7 +28207,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/library)
 "baS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -28147,13 +28223,13 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/library)
 "baU" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/library)
 "baV" = (
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -29758,7 +29834,7 @@
 /area/hydroponics)
 "bek" = (
 /obj/structure/bookcase{
-	name = "bookcase (Private)"
+	name = "bookcase (Reference)"
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -30602,15 +30678,14 @@
 	},
 /area/hydroponics)
 "bfK" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/easel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "showroomfloor";
+	tag = "icon-showroomfloor (NORTH)"
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/turf/simulated/floor/wood,
-/area/library)
+/area/storage/art)
 "bfL" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -31540,18 +31615,24 @@
 /turf/simulated/floor/wood,
 /area/library)
 "bhJ" = (
-/obj/structure/table/woodentable,
-/obj/item/device/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
+/obj/structure/mannequin/wood,
+/obj/machinery/light_switch{
+	pixel_x = 27
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "showroomfloor";
+	tag = "icon-showroomfloor (NORTH)"
+	},
+/area/storage/art)
 "bhK" = (
 /obj/machinery/camera{
 	dir = 8;
 	name = "Library South"
 	},
+/obj/structure/table/woodentable,
+/obj/item/weapon/storage/lockbox/diskettebox/large/full,
+/obj/machinery/disk_duplicator,
 /turf/simulated/floor/wood,
 /area/library)
 "bhL" = (
@@ -32252,6 +32333,12 @@
 "bjk" = (
 /obj/machinery/status_display{
 	pixel_y = 32
+	},
+/obj/machinery/door/window{
+	base_state = "right";
+	name = "Library Desk Door";
+	req_access_txt = "37";
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -32976,11 +33063,11 @@
 	},
 /area/hydroponics)
 "bkP" = (
-/obj/machinery/vending/art,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/area/storage/art)
+/turf/simulated/floor/wood,
+/area/library)
 "bkQ" = (
 /obj/structure/table/woodentable,
 /obj/machinery/computer/accounting,
@@ -34581,13 +34668,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	on = 1
-	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/storage/art)
+/turf/simulated/floor,
+/area/hallway/primary/starboard)
 "bnP" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -34609,19 +34691,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/storage/art)
+/turf/simulated/floor,
+/area/hallway/primary/starboard)
 "bnQ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -34635,33 +34710,14 @@
 	dir = 8;
 	name = "Firelock West"
 	},
-/obj/machinery/door/airlock/glass{
-	name = "Art Storage"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/curtain/open{
-	color = "#854636"
+/obj/machinery/door/airlock/glass{
+	name = "Library"
 	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
+/turf/simulated/floor/carpet,
 /area/library)
-"bnR" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/storage/art)
 "bnS" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -34676,8 +34732,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/siding/gold,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/library)
 "bnT" = (
 /obj/structure/cable/yellow{
@@ -34691,8 +34746,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/siding/gold,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/library)
 "bnU" = (
 /obj/structure/cable/yellow{
@@ -34700,12 +34754,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/siding/gold,
-/turf/simulated/floor/wood,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/simulated/floor{
+	icon_state = "red"
+	},
+/area/hallway/primary/fore)
 "bnV" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -35704,26 +35760,14 @@
 	dir = 4;
 	name = "Research Outpost Hallway Engineering"
 	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/storage/art)
+/turf/simulated/floor,
+/area/hallway/primary/starboard)
 "bpH" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
-/obj/item/weapon/reagent_containers/glass/metal_bucket/paint/filled/random{
-	pixel_x = -12;
-	pixel_y = 8
-	},
-/obj/item/weapon/reagent_containers/glass/metal_bucket/paint/filled/random{
-	pixel_x = 10;
-	pixel_y = 12
-	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/storage/art)
+/turf/simulated/floor,
+/area/hallway/primary/starboard)
 "bpI" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/camera{
@@ -35732,22 +35776,18 @@
 	},
 /turf/simulated/floor,
 /area/hydroponics)
-"bpJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/wood{
-	icon = 'icons/turf/floors_wood.dmi';
-	icon_state = "26"
-	},
-/area/library)
 "bpK" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/simulated/floor/wood{
-	icon = 'icons/turf/floors_wood.dmi';
-	icon_state = "26"
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/area/library)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "showroomfloor";
+	tag = "icon-showroomfloor (NORTH)"
+	},
+/area/storage/art)
 "bpL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -35758,19 +35798,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/simulated/wall,
+/obj/machinery/door/airlock/glass{
+	name = "Library"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8;
+	name = "Firelock West"
+	},
+/turf/simulated/floor/carpet,
 /area/library)
 "bpN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/bed/chair/comfy/black{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/siding/gold{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet,
 /area/library)
 "bpO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36417,16 +36459,24 @@
 /turf/simulated/floor/plating,
 /area/hydroponics)
 "brc" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "art1";
+	name = "Art Shutters";
+	opacity = 0;
+	desc = "Secret of the arts"
+	},
+/turf/simulated/floor/plating,
 /area/storage/art)
 "brd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -36447,26 +36497,16 @@
 /turf/simulated/floor/plating,
 /area/hydroponics)
 "brg" = (
-/obj/structure/table,
-/obj/item/weapon/storage/toolbox/paint{
-	pixel_y = 8
+/obj/structure/bed/chair{
+	dir = 8
 	},
-/obj/item/weapon/reagent_containers/glass/bottle/acetone{
-	pixel_x = 6;
-	pixel_y = 2
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "showroomfloor";
-	tag = "icon-showroomfloor (NORTH)"
-	},
-/area/storage/art)
+/turf/simulated/floor,
+/area/hallway/primary/starboard)
 "brh" = (
-/obj/structure/easel,
-/turf/simulated/floor/wood{
-	icon = 'icons/turf/floors_wood.dmi';
-	icon_state = "26"
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
 	},
+/turf/simulated/floor/wood,
 /area/library)
 "bri" = (
 /obj/machinery/firealarm{
@@ -37233,23 +37273,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/glass{
-	name = "Art Storage"
-	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/storage/art)
+/turf/simulated/floor,
+/area/hallway/primary/starboard)
 "bsP" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/door/airlock/glass{
+	name = "Library"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/door/firedoor/border_only{
+	name = "Firelock South"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/carpet,
 /area/library)
 "bsQ" = (
 /obj/structure/grille,
@@ -37834,6 +37867,9 @@
 /obj/machinery/camera{
 	name = "Starboard Primary Hallway Library"
 	},
+/obj/machinery/atm{
+	pixel_y = 32
+	},
 /turf/simulated/floor,
 /area/hallway/primary/starboard)
 "bug" = (
@@ -37862,9 +37898,6 @@
 "bul" = (
 /obj/machinery/camera{
 	name = "Starboard Primary Hallway Chapel"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
 	},
 /turf/simulated/floor,
 /area/hallway/primary/starboard)
@@ -114882,13 +114915,8 @@
 /turf/simulated/floor/plating,
 /area/medical/virology)
 "hXz" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/library)
+/turf/simulated/wall,
+/area/hallway/primary/fore)
 "ieA" = (
 /obj/structure/table,
 /obj/item/device/camera,
@@ -114922,8 +114950,16 @@
 /obj/abstract/map/paint_coat/paint_stroke{
 	dir = 1
 	},
-/turf/simulated/floor,
-/area/maintenance/fpmaint)
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1;
+	on = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "showroomfloor";
+	tag = "icon-showroomfloor (NORTH)"
+	},
+/area/storage/art)
 "ioQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -114986,11 +115022,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "iGm" = (
-/obj/structure/easel,
-/obj/item/mounted/frame/painting/custom/landscape,
-/obj/item/painting_brush{
-	pixel_x = -8;
-	pixel_y = 16
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -115030,18 +115071,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
-"joC" = (
-/obj/structure/table,
-/obj/machinery/sewing_machine{
-	pixel_y = 4
-	},
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/storage/art)
 "jwl" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1551;
@@ -115098,17 +115127,6 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/virology)
-"jTA" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/library)
 "kmh" = (
 /obj/structure/table,
 /obj/item/weapon/folder/white,
@@ -115169,21 +115187,6 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
 /area/maintenance/virology_maint)
-"kKP" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/reagent_containers/food/drinks/mug{
-	pixel_x = 6;
-	pixel_y = -6
-	},
-/obj/effect/decal/warning_stripes/siding/gold{
-	dir = 8
-	},
-/obj/item/weapon/reagent_containers/glass/kettle/full{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/turf/simulated/floor/wood,
-/area/library)
 "kLr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -115235,17 +115238,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/virology_maint)
 "lFe" = (
-/obj/structure/table/woodentable,
-/obj/item/device/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
+/obj/machinery/atmospherics/unary/vent_pump{
+	on = 1
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/turf/simulated/floor,
+/area/hallway/primary/starboard)
 "lJf" = (
 /obj/machinery/optable,
 /turf/simulated/floor{
@@ -115253,20 +115253,24 @@
 	},
 /area/medical/surgery_ghetto)
 "lXf" = (
-/obj/item/weapon/reagent_containers/glass/metal_bucket/paint/filled/random{
-	pixel_x = 10;
-	pixel_y = 12
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
 	},
-/turf/simulated/floor{
+/obj/machinery/alarm{
 	dir = 1;
-	icon_state = "showroomfloor";
-	tag = "icon-showroomfloor (NORTH)"
+	pixel_y = -22
 	},
-/area/storage/art)
-"lYr" = (
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/library)
+"lYr" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor,
+/area/hallway/primary/starboard)
 "mgq" = (
 /obj/machinery/light{
 	dir = 1
@@ -115405,13 +115409,7 @@
 	},
 /area/engineering/atmos)
 "obs" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/rack,
-/obj/item/weapon/hand_labeler,
-/obj/item/weapon/storage/box/labels,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
+/turf/simulated/wall,
 /area/storage/art)
 "ogM" = (
 /obj/machinery/light{
@@ -115425,15 +115423,13 @@
 	},
 /area/medical/virology)
 "ohk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/structure/rack,
-/obj/item/stack/sheet/wood/bigstack,
-/obj/item/weapon/chisel,
-/obj/item/device/rcd/tile_painter,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	dir = 1;
+	icon_state = "showroomfloor";
+	tag = "icon-showroomfloor (NORTH)"
 	},
 /area/storage/art)
 "orE" = (
@@ -115452,17 +115448,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/vox_trading_post/vault)
-"otR" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/library)
 "ovu" = (
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall,
@@ -115555,21 +115540,29 @@
 	},
 /area/vox_trading_post/trade_processing)
 "pqh" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 8;
-	name = "Library Desk Door";
-	req_access_txt = "37"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "art1";
+	name = "Art Shutters";
+	opacity = 0;
+	desc = "Secret of the arts"
+	},
+/turf/simulated/floor/plating,
+/area/storage/art)
 "prh" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/curtain/open{
-	color = "#854636"
-	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/library)
 "pxo" = (
 /obj/effect/decal/warning_stripes{
@@ -115735,18 +115728,6 @@
 	},
 /turf/space,
 /area/shuttle/escape/centcom)
-"rbv" = (
-/obj/structure/table,
-/obj/item/weapon/storage/fancy/crayons,
-/obj/item/paint_roller,
-/obj/item/painting_brush{
-	pixel_y = -10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/storage/art)
 "rkr" = (
 /obj/structure/table,
 /obj/item/critter_cage/with_mouse{
@@ -115790,25 +115771,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/hallway)
-"rFb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/storage/art)
 "rFS" = (
-/obj/structure/easel,
-/obj/machinery/light,
-/turf/simulated/floor/wood{
-	icon = 'icons/turf/floors_wood.dmi';
-	icon_state = "26"
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/glass/kettle/full{
+	pixel_x = -6;
+	pixel_y = 6
 	},
+/obj/item/weapon/reagent_containers/food/drinks/mug{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/wood,
 /area/library)
 "rIi" = (
 /obj/structure/disposalpipe/segment{
@@ -115899,17 +115873,6 @@
 	icon_state = "white"
 	},
 /area/medical/virology_break)
-"sxx" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/storage/art)
 "sEf" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -115984,14 +115947,11 @@
 	},
 /area/lawoffice)
 "tCL" = (
-/obj/machinery/door/firedoor/border_only{
-	name = "Firelock South"
+/obj/machinery/alarm{
+	pixel_y = 25
 	},
-/obj/machinery/door/airlock/glass{
-	name = "Library"
-	},
-/turf/simulated/floor/wood,
-/area/library)
+/turf/simulated/floor,
+/area/hallway/primary/starboard)
 "tGh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -116114,14 +116074,26 @@
 /turf/simulated/floor/wood,
 /area/library)
 "uBa" = (
-/obj/structure/table/woodentable,
-/obj/machinery/disk_duplicator,
-/obj/item/weapon/storage/lockbox/diskettebox/large/full,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "art1";
+	name = "Art Shutters";
+	opacity = 0;
+	desc = "Secret of the arts"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/simulated/floor/plating,
+/area/storage/art)
 "uCb" = (
 /obj/structure/table,
 /obj/machinery/camera{
@@ -116357,20 +116329,26 @@
 	},
 /area/medical/virology)
 "vJD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id_tag = "art1";
+	name = "Art Shutters";
+	opacity = 0;
+	desc = "Secret of the arts"
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor,
-/area/hallway/primary/starboard)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/simulated/floor/plating,
+/area/storage/art)
 "vKv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -116433,11 +116411,12 @@
 /turf/simulated/floor/wood,
 /area/library)
 "wqs" = (
-/obj/item/stack/tile/metal{
-	amount = 15
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "showroomfloor";
+	tag = "icon-showroomfloor (NORTH)"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
+/area/storage/art)
 "wJa" = (
 /obj/machinery/disease2/incubator,
 /turf/simulated/floor{
@@ -116598,8 +116577,7 @@
 /turf/simulated/wall/shuttle,
 /area/shuttle/escape/centcom)
 "xUT" = (
-/obj/structure/bookcase/manuals,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/library)
 "xWo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -116622,7 +116600,7 @@
 /area/crew_quarters/bar)
 "yal" = (
 /obj/structure/bed/chair/comfy/black{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -215782,7 +215760,7 @@ arR
 awT
 ayc
 ayX
-awr
+hXz
 aaa
 aaa
 aaa
@@ -216284,7 +216262,7 @@ arR
 awS
 ayb
 ayW
-awr
+hXz
 aaa
 aaa
 aaa
@@ -216786,7 +216764,7 @@ arR
 awU
 ayd
 ayZ
-awr
+hXz
 aaa
 aaa
 aaa
@@ -217288,7 +217266,7 @@ awn
 awU
 ayd
 ayY
-awr
+hXz
 aaa
 aaa
 aaa
@@ -217790,12 +217768,12 @@ awp
 awW
 ayf
 azb
-awr
-awr
-awr
-awr
-awr
-awr
+obs
+obs
+obs
+obs
+obs
+obs
 aIa
 wVB
 aKG
@@ -218292,12 +218270,12 @@ awo
 awV
 aye
 aza
-awr
+brc
 aBA
 aDj
-aEh
 aFB
-awr
+aFB
+obs
 aHZ
 aFq
 aKG
@@ -218793,13 +218771,13 @@ avC
 arR
 nKb
 ayh
-aza
-awr
+aYU
+vJD
 aBC
 inK
-axP
-iGm
-awr
+aFB
+aFB
+obs
 aIb
 aFq
 aKG
@@ -219296,12 +219274,12 @@ arR
 awX
 ayg
 azc
-awr
+aEh
 aBB
 wqs
-axP
+wqs
 aFC
-awr
+obs
 cmX
 aFq
 aKG
@@ -219796,14 +219774,14 @@ arR
 arR
 arR
 awU
-ayh
-aza
-awr
+ayk
+bnU
+uBa
+bfK
 aBE
-aBE
-axP
+ohk
 aFF
-awr
+obs
 axP
 aFq
 aKH
@@ -220300,12 +220278,12 @@ awq
 awY
 ayi
 azd
-awr
+pqh
 aBD
-aBE
-axP
+bhJ
+bpK
 aFE
-awr
+obs
 axP
 aFq
 aKG
@@ -220802,12 +220780,12 @@ awr
 awU
 ayh
 aza
-awr
-awr
-awr
+obs
+obs
+obs
 aEi
-awr
-awr
+obs
+obs
 axP
 aFq
 aKJ
@@ -221307,7 +221285,7 @@ aze
 aAr
 aBF
 aDk
-aBF
+iGm
 aFG
 aGW
 aBF
@@ -255966,12 +255944,12 @@ aXq
 aXq
 aPR
 aXq
+aXq
+aXq
 hKR
-brc
-brc
 bnP
 bpG
-brc
+bsO
 bsO
 bud
 bvj
@@ -256469,12 +256447,12 @@ aSG
 aSG
 aSG
 aSG
-joC
-lXf
+aSG
+aSG
 bnO
 bpH
-rbv
-rFb
+brd
+brd
 brd
 bvk
 bwF
@@ -256968,15 +256946,15 @@ aYT
 baS
 bct
 hoI
-bfK
+wpR
 bhI
+wpR
+uxN
 aSG
-bkP
-obs
-bnR
-ohk
+bnO
+bpL
 brg
-sxx
+brg
 bsK
 bvn
 bwJ
@@ -257469,11 +257447,11 @@ aXr
 aXr
 baR
 aXs
-uYs
+hoI
 aXs
 bhI
-aSG
-aSG
+aXs
+uxN
 aSG
 bnQ
 bpM
@@ -257968,20 +257946,20 @@ aSG
 aSG
 aVz
 aXu
-aYU
+pQs
 baU
 aXs
-uYs
-aXs
-bhI
-wpR
 xUT
-aXs
+xUT
+xUT
+xUT
+xUT
+xUT
 bnT
-bpJ
-brh
-otR
-btU
+baW
+yal
+aSG
+lFe
 bvh
 bwG
 bxZ
@@ -258474,15 +258452,15 @@ aXt
 baT
 bcu
 prh
-bcu
-bcu
-bcu
-bcu
-bcu
+prh
+prh
+prh
+prh
+prh
 bnS
-bpK
+vaZ
 rFS
-hXz
+aSG
 buf
 bvm
 bwI
@@ -258973,19 +258951,19 @@ aUf
 aVB
 aXw
 aXw
-baW
+bkP
+aGR
+bek
+aXs
+uYs
 aXs
 uxN
 aXs
-aXs
-aXs
-lYr
-aXs
-bnU
-bpJ
+gFl
+baW
 brh
-hXz
-bsK
+aSG
+tCL
 bpL
 bwG
 bsK
@@ -259478,14 +259456,14 @@ aYV
 baV
 bcv
 bek
-uBa
-lFe
-pqh
-pQs
 aXs
-bnU
-bpJ
-brh
+uYs
+aXs
+uxN
+aXs
+gFl
+baW
+xUT
 bsP
 bsK
 bpL
@@ -259983,12 +259961,12 @@ bel
 bfL
 bhK
 aXs
-bhJ
-aGR
-jTA
+aXs
+aXs
+gFl
 bpN
-kKP
-aSG
+xUT
+bsP
 bsK
 bpL
 bwG
@@ -260493,7 +260471,7 @@ yal
 aSG
 buh
 bpL
-vJD
+bwG
 byd
 byd
 bBz
@@ -260991,8 +260969,8 @@ bkS
 bms
 bnW
 vaZ
-aXs
-tCL
+lXf
+aSG
 bsK
 bpL
 bwG
@@ -261493,9 +261471,9 @@ bkR
 bmr
 bnV
 baW
-aXs
-tCL
-btT
+brh
+aSG
+lYr
 bvg
 bwO
 byd


### PR DESCRIPTION
Moves Art Storage from being close to library to be near Detective's Office. Reconstructs old Library. Boxstation only.

<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->
[general][box]
<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
Makes maintenance art storage room into a functional art storage.
Moves all previous art storage unique things (art vendor, sewing machine) to new place and removes current art storage.
Remakes old library.
Also makes Detective's Office firelock face outwards into the hallway like every other firelock instead of inwards.

Unused Art Storage:
![OldMaint](https://github.com/user-attachments/assets/71e0927e-0c2c-4163-b2e3-5f302fc012cc)

Current Art Storage/Library:
![OldLibrary](https://github.com/user-attachments/assets/f38de031-8dbc-49b5-9222-f3600234a911)


Updated Art Storage:
![NewArt](https://github.com/user-attachments/assets/0b66f95d-3c39-4c12-8e32-9eb16145d7ef)

Updated Library:
![NewLibrary](https://github.com/user-attachments/assets/5108af82-ac84-46b4-a4a0-e5a856e29d9a)


## Why it's good
The unused art storage room gets some use - becomes functional, and is a good place for assistants or other roles to be close to security with an excuse of being artisticly inclined. Might make sec more jumpy with suspicious assistants, opens up reasons to get close to security. Art vendor, the sewing machine and few other art items been moved to the new room.
Change of library to return it to form doesn't remove any of it's functions (actually, instead of 2 air alarms for whatever reason, it now only has one again), the research archive and other machines are still there, but more importantly, the small hallway inlet is back to provide cover for hallway shootouts or chases.

## How it was tested
Compiled the copy, loaded to confirm map changes.
Checked the wiring, the areas, the APCs, the vents/scrubbers, the fire alarms, the art vendor, the airlock permissions, the shutters and all that stuff both in the new Art Storage and the updated Library.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rcsadd: Maintenance Art Storage is no longer part of maintenance.
 * tweak: Library is back with it's hallway nook.