### PR TITLE
makes fission reactors much cheaper

### DIFF
--- a/code/datums/supply_packs/engineering.dm
+++ b/code/datums/supply_packs/engineering.dm
@@ -443,7 +443,7 @@
 	
 	)
 	name = "Fission reactor starter kit"
-	cost = 450 //Includes a lot of plasteel. Fuck you, ask the miners for more you socially inept jobbie.
+	cost = 300 //Includes a lot of plasteel. Fuck you, ask the miners for more you socially inept jobbie.
 	containertype = /obj/structure/closet/crate/secure/large/reinforced/shard/empty
 	containername = "Fission reactor starter kit"
 	group = "Engineering"
@@ -463,7 +463,7 @@
 		/obj/item/weapon/storage/box/fissionsupply_casing,
 	)
 	name = "Fission reactor expansion pak"
-	cost = 175 //See above.
+	cost = 100 //See above.
 	containertype = /obj/structure/closet/crate/secure/large/reinforced/shard/empty
 	containername = "Fission reactor expansion pak"
 	group = "Engineering"
@@ -475,7 +475,7 @@
 		/obj/item/weapon/fuelrod/large
 	)
 	name = "High-capacity fuel reservoir"
-	cost = 100 //It's a one time purchance, really. somewhat costy, but not that much for a department. watch for meltdowns.
+	cost = 75 //It's a one time purchase, really. somewhat costly, but not that much for a department. watch for meltdowns.
 	containertype = /obj/structure/closet/crate/secure/large/reinforced/shard/empty
 	containername = "Large fuel reservoir"
 	group = "Engineering"

--- a/code/modules/fissionreactor/misc.dm
+++ b/code/modules/fissionreactor/misc.dm
@@ -9,6 +9,12 @@ boxes used for cargo orders to make my life easier.
 	name="fission reactor controller parts"
 	desc="Contains all the materials needed to assemble a fission reactor controller."
 
+/obj/item/weapon/storage/box/fissionsupply_controller/attack_self(mob/user)
+	for(var/obj/O in contents)
+		O.forceMove(user.loc)
+	contents=null
+	..()
+	
 /obj/item/weapon/storage/box/fissionsupply_controller/New()
 	..()
 	new /obj/item/weapon/circuitboard/fission_reactor(src)
@@ -25,6 +31,12 @@ boxes used for cargo orders to make my life easier.
 	name="fission reactor assembly parts"
 	desc="Contains all the materials needed to assemble a fission assembly, minus the appropriate circuit board."
 
+/obj/item/weapon/storage/box/fissionsupply_genericassembly/attack_self(mob/user)
+	for(var/obj/O in contents)
+		O.forceMove(user.loc)
+	contents=null
+	..()
+	
 /obj/item/weapon/storage/box/fissionsupply_genericassembly/New()
 	..()
 	new /obj/item/stack/sheet/plasteel(src,5)//5 plasteel
@@ -38,6 +50,13 @@ boxes used for cargo orders to make my life easier.
 /obj/item/weapon/storage/box/fissionsupply_casing
 	name="fission reactor casing parts"
 	desc="Contains all the materials needed to assemble a single fission reactor casing."
+
+/obj/item/weapon/storage/box/fissionsupply_casing/attack_self(mob/user)
+	for(var/obj/O in contents)
+		O.forceMove(user.loc)
+	contents=null
+	..()
+	
 	
 /obj/item/weapon/storage/box/fissionsupply_casing/New()
 	..()
@@ -48,6 +67,12 @@ boxes used for cargo orders to make my life easier.
 /obj/item/weapon/storage/box/fissionsupply_fuelmaker
 	name="separational isotopic combiner parts"
 	desc="Contains all the materials needed to assemble a separational isotopic combiner."
+
+/obj/item/weapon/storage/box/fissionsupply_fuelmaker/attack_self(mob/user)
+	for(var/obj/O in contents)
+		O.forceMove(user.loc)
+	contents=null
+	..()
 	
 /obj/item/weapon/storage/box/fissionsupply_fuelmaker/New()
 	..()
@@ -66,9 +91,6 @@ boxes used for cargo orders to make my life easier.
 
 /obj/item/weapon/fuelrod/small/starter/New()
 	..()
-	//fueldata.fuel.add_reagent(URANIUM,150)
 	fueldata.add_shit_to(URANIUM,units_of_storage,fueldata.fuel)
 	fueldata.rederive_stats()
 	fueldata.life=1
-	
-	


### PR DESCRIPTION
[balance] [tweak]

## What this does
changes the cost of the fission reactor cargo order from 450 to 300
changes the cost of the reactor expansion cargo order from 175 to 100
changes the cost of the large fuel rod cargo order from 100 to 75
makes all reactor part boxes drop contents on the floor when clicked on in hand

## Why it's good
nobody really uses these engines because they're not stock with any station, but also because they're a massive undertaking to make. they are intentionally costly for balance, however, i way overshot it, to the point where it gates people from using it in real games.
for reference, a SM shard is 300 credits, a TEG is 125 total, and a R-UST is probably 105 total if you need 1 of each crate.
also the box dissasembling makes construction easier, since you won't have to fumble with boxes and items so much. just click and drop.

## How it was tested
went in game, clicked on some boxes, checked cargo. ordered a crate, opened it then clicked on more boxes.

## Changelog
:cl:
 * tweak: greatly reduced the cost of fission reactors
 * tweak: fission reactor part boxes can now be clicked on while in hand to drop their parts on the floor, for assembling convenience.