### PR TITLE
Bloodstone Melee Vulnerability

### DIFF
--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -110,9 +110,9 @@
 				playsound(src, sound_damaged, 75, 1)
 			if(isholyweapon(W))
 				playsound(loc, 'sound/weapons/welderattack.ogg', 50, 1)
-				takeDamage(W.force*2)
+				takeDamage(W.force*8) //Extra weak to holy
 			else
-				takeDamage(W.force)
+				takeDamage(W.force*4) //Weak to melee
 			if (W.attack_verb)
 				visible_message("<span class='warning'>\The [user] [pick(W.attack_verb)] \the [src] with \the [W].</span>")
 			else


### PR DESCRIPTION
tl;dnr: 
> melee weapons get 4x damage to bloodstone, rewarding you for attacking directly

I don't really have a lot of investment in this debate so no hard feelings if this idea is rejected. I only rarely log in lately so my opinion is more from past experience.

I feel the debate around bloodstones has two perspectives
> it's a tedious amount of damage to deal dumping lasers into it after you kill everyone
> the stone should be strong enough to be defensible by the cult squad if they got this far
> both sides: we want it to be an engaging high stakes finale, not a victory lap

I feel that by giving a huge bonus to melee damage, we encourage a big climactic finish where players try to smash the stone or fight off the cult so they can do so, not limited by running out of ammo after the fight is already over. Think of it like defusing the planted bomb in CS. With this change, you can toolbox a bloodstone in 30 hits, null rod/esword in 15, wielded fireaxe in 12.

🆑 
* tweak: Bloodstones are now extremely vulnerable to melee damage, especially holy melee damage like the null rod.