### PR TITLE
Fixes ghosted mobs duplicating their attack logs

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -95,7 +95,6 @@
 		transfer_to_without_current(new_character)
 		return
 
-	//new_character.attack_log += current.attack_log
 	new_character.attack_log += "\[[time_stamp()]\]: mind transfer from [current] to [new_character]"
 
 	for (var/role in antag_roles)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -258,7 +258,6 @@ Works together with spawning an observer, noted above.
 		if (deafmute)
 			ghostype = /mob/dead/observer/deafmute
 		var/mob/dead/observer/ghost = new ghostype(src, flags)	//Transfer safety to observer spawning proc.
-		ghost.attack_log += src.attack_log // Keep our attack logs.
 		var/timetocheck = timeofdeath
 		if (isbrain(src))
 			var/mob/living/carbon/brain/brainmob = src


### PR DESCRIPTION
Something I noticed while working on #37563 

Tested by toolboxing myself and ghosting. Logs no longer duplicated. Re-entered corpse and dragged myself back. Works fine.
All stuff related to attack logs is already duplicated in `mob.dna2`. I think there's a risk of losing a mob's attack logs if 

a) someone gets their body vaporised
b) they use a midround role

... but that was probably already a thing it would be creating a new mind from the start. Worth noting that all/most major attack events are stored in global attack logs for retrival.

## Why it's good

Easier to search attack logs + bugfix