### PR TITLE
Gets rid of painting replicas on the scoreboard

### DIFF
--- a/code/modules/html_interface/paintTool/custom_painting_datum.dm
+++ b/code/modules/html_interface/paintTool/custom_painting_datum.dm
@@ -171,7 +171,7 @@
 	var/author = ""
 	var/title = ""
 	var/description = ""
-	var/contributing_artists = list()
+	var/list/contributing_artists = list()
 	var/show_on_scoreboard = TRUE
 
 	var/copy = 0
@@ -201,17 +201,6 @@
 	QDEL_NULL(interface)
 
 	QDEL_NULL(mp_handler)
-
-/datum/custom_painting/proc/Copy()
-	var/datum/custom_painting/copy = new(parent, bitmap_width, bitmap_height, offset_x, offset_y, base_color)
-	copy.author = author
-	copy.title = title
-	copy.description = description
-	copy.bitmap = bitmap.Copy()
-	copy.nanomap = nanomap.Copy()
-	copy.components = components.Copy()
-	copy.has_nano_paint = has_nano_paint
-	return copy
 
 /datum/custom_painting/proc/set_parent(parent)
 	src.parent = parent

--- a/code/modules/html_interface/paintTool/custom_painting_datum.dm
+++ b/code/modules/html_interface/paintTool/custom_painting_datum.dm
@@ -3,6 +3,10 @@
 #define BRUSH_STRENGTH_MAX 1
 #define BRUSH_STRENGTH_MIN 0
 
+#define PAINTING_OC_ORIGINAL 0
+#define PAINTING_OC_COPY 1
+#define PAINTING_OC_MODIFIED_COPY 2
+
 /*
  * PAINTING UTENSIL DATUM
  *
@@ -174,7 +178,7 @@
 	var/list/contributing_artists = list()
 	var/show_on_scoreboard = TRUE
 
-	var/copy = 0
+	var/copy = PAINTING_OC_ORIGINAL
 
 	var/list/components = list()
 
@@ -372,6 +376,10 @@
 		for (var/i = 1; i <= nanomap.len; i++)
 			nanomap[i] = sanitize_hexcolor(nanomap[i])
 
+		if (copy == PAINTING_OC_COPY)
+			copy = PAINTING_OC_MODIFIED_COPY
+		show_on_scoreboard = TRUE
+
 		//Save and sanitize author, title and description
 		author = copytext(sanitize(url_decode(href_list["author"])), 1, MAX_NAME_LEN)
 		title = copytext(sanitize(url_decode(href_list["title"])), 1, MAX_NAME_LEN)
@@ -482,7 +490,7 @@
 	painting.title = title
 	painting.author = author
 	painting.description = description
-	painting.copy = 1
+	painting.copy = PAINTING_OC_COPY
 	painting.show_on_scoreboard = FALSE //sorry, OC only
 	return painting
 

--- a/code/modules/painting/paintings_custom.dm
+++ b/code/modules/painting/paintings_custom.dm
@@ -242,7 +242,9 @@
 	unlock_from()
 
 	// Painting info
-	P.set_painting_data(painting_data.Copy())
+	P.set_painting_data(painting_data)
+	painting_data = null //We're no longer the one holding the painting_data, so stop having vars pointing at it
+
 	P.rendered_icon = icon
 	P.rendered_nanomap = nanomap
 	P.base_name = base_name
@@ -456,7 +458,9 @@
 	var/obj/structure/painting/custom/P = new(user.loc)
 
 	// Painting info
-	P.set_painting_data(painting_data.Copy())
+	P.set_painting_data(painting_data)
+	painting_data = null //We're no longer the one holding the painting_data, so stop having vars pointing at it
+
 	P.icon = rendered_icon ? rendered_icon : icon(base_icon, base_icon_state)
 	P.nanomap = rendered_nanomap ? rendered_nanomap : image('icons/effects/32x32.dmi',P,"black")
 	P.icon_state = base_icon_state

--- a/code/modules/painting/paintings_custom.dm
+++ b/code/modules/painting/paintings_custom.dm
@@ -214,7 +214,9 @@
 		name = (painting_data.title ? ("\proper[painting_data.title]") : "untitled artwork") + (painting_data.author ? ", [comp ? "[comp] " : ""]by [painting_data.author]" : "[comp ? ", [comp]" : ""]")
 		desc = painting_data.description ? "A small plaque reads: \"<span class='info'>[painting_data.description]\"</span>" : "A painting... But what could it mean?"
 		if (painting_data.copy)
-			desc += "A tag on this artwork indicates that it's a replica reproduced from Nanotrasen's databanks."
+			desc += "\nA tag on this artwork indicates that it's a replica reproduced from Nanotrasen's databanks. "
+			if (painting_data.copy == PAINTING_OC_MODIFIED_COPY)
+				desc += "Seems like someone gave it a fresh coat of paint..."
 		if (render)
 			icon = painting_data.render_on(icon(base_icon, base_icon_state))
 			nanomap = painting_data.render_nanomap(icon(base_icon, "[base_icon_state]-nano"))
@@ -441,6 +443,10 @@
 		var/comp = painting_data.get_components()
 		name = (painting_data.title ? ("\proper[painting_data.title]") : "untitled artwork") + (painting_data.author ? ", [comp ? "[comp] " : ""]by [painting_data.author]" : "[comp ? ", [comp]" : ""]")
 		desc = painting_data.description ? "A small plaque reads: \"<span class='info'>[painting_data.description]\"</span>" : "A painting... But what could it mean?"
+		if (painting_data.copy)
+			desc += "\nA tag on this artwork indicates that it's a replica reproduced from Nanotrasen's databanks. "
+			if (painting_data.copy == PAINTING_OC_MODIFIED_COPY)
+				desc += "Seems like someone gave it a fresh coat of paint..."
 		if (render)
 			rendered_icon = painting_data.render_on(icon(base_icon, base_icon_state))
 			rendered_nanomap = painting_data.render_nanomap(icon(base_icon, "[base_icon_state]-nano"))


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
Gets rid of `/datum/custom_painting/proc/Copy()`.
Printed paintings were forgetting they were replicas every time you placed or removed them from a wall/easel, causing them to appear on the scoreboard on round end. The `Copy()` proc is to blame, as it wasn't updated with #35737 - an honest mistake, and one liable to happen again in the future for zero benefit. 
It's also an unnecessary expense, as it's only being called on conversion of a painting to and fro item (hand held) and structure (hung on a wall), to populate the newly created struct/item before qdeleting the old one - might as well just pass the datum over to the new struct/item and save ourselves from both copying the entire bitmap and coder headaches.

Closes #36080

<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Set up a local DB and put some logging to see what the contents of any painting's custom_painting datum were on qdel.
Made some paintings of letters: A, B, C. 
They were placed and removed from walls a couple times, checking logs to ensure that on conversion, the qdel showed a null "custom_painting" var, and that the same datum persists between item and struct using the view variables admin tool - No unintended deletions were found.
C was then deleted with an admin command, and logs were checked to confirm the custom_painting datum was actually getting deleted this time.
A and B were uploaded to the library, and replicas were ordered. A was marked with a dash of red paint to distinguish it from it's replica. Both replicas were hung on the wall, and examined: Both retained the "_A tag on this artwork indicates that it's a replica reproduced from Nanotrasen's databanks_" descriptor. The shuttle was called, and on round end, only an A with red and a single B were shown on the scoreboard.
New round, A and B were printed again, and a new C was painted. All were hung on the wall. Called the shuttle, only C showed up on the scoreboard.

Been trying to think of possible edge cases to try out and I can't come up with any.


## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Printed paintings should no longer clutter the round end scoreboard.