### PR TITLE
Give pipe meters linked to atmos consoles the same capabilities as gas sensors

### DIFF
--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -10,15 +10,6 @@
 
 	var/on = 1
 	var/list/metrics_monitored = list("pressure", "temperature")
-	//Flags:
-	// 1 for pressure
-	// 2 for temperature
-	// Output >= 4 includes gas composition
-	// 4 for oxygen concentration
-	// 8 for toxins concentration
-	// 16 for nitrogen concentration
-	// 32 for carbon dioxide concentration
-	// 64 for nitrous oxide concentration
 
 	machine_flags = WRENCHMOVE | MULTITOOL_MENU
 

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -14,6 +14,8 @@
 	active_power_usage = 4
 	machine_flags = MULTITOOL_MENU
 
+	var/list/metrics_monitored = list("pressure", "temperature", GAS_OXYGEN, GAS_PLASMA, GAS_NITROGEN, GAS_CARBON)
+
 /obj/machinery/meter/New(newloc, new_target, freq, id)
 	..(newloc)
 	src.target = new_target
@@ -88,22 +90,22 @@
 		signal.data = list(
 			"tag" = id_tag,
 			"device" = "AM",
-			"pressure" = round(env_pressure),
-			"temperature" = round(environment.temperature),
 			"sigtype" = "status"
 		)
 
+		signal.data["timestamp"] = world.time
+
 		var/total_moles = environment.total_moles
-		if(total_moles > 0)
-			signal.data["oxygen"] = round(100*environment[GAS_OXYGEN]/total_moles,0.1)
-			signal.data["toxins"] = round(100*environment[GAS_PLASMA]/total_moles,0.1)
-			signal.data["nitrogen"] = round(100*environment[GAS_NITROGEN]/total_moles,0.1)
-			signal.data["carbon_dioxide"] = round(100*environment[GAS_CARBON]/total_moles,0.1)
-		else
-			signal.data["oxygen"] = 0
-			signal.data["toxins"] = 0
-			signal.data["nitrogen"] = 0
-			signal.data["carbon_dioxide"] = 0
+		for(var/metric in metrics_monitored)
+			if(metric == "pressure")
+				signal.data["pressure"] = round(environment.return_pressure(), 0.1)
+			if(metric == "temperature")
+				signal.data["temperature"] = round(environment.temperature, 0.1)
+			else if(metric in XGM.gases)
+				signal.data[metric] = total_moles ? round(100 * environment[metric] / total_moles, 0.1) : 0
+		for(var/gas_ID in XGM.gases)
+			if(!signal.data[gas_ID])
+				signal.data[gas_ID] = 0
 
 		radio_connection.post_signal(src, signal)
 
@@ -142,12 +144,43 @@
 	return 1
 
 /obj/machinery/meter/multitool_menu(var/mob/user, var/obj/item/device/multitool/P)
-	return {"
+	var/dat = {"
 	<b>Main</b>
 	<ul>
 		<li><b>Frequency:</b> <a href="?src=\ref[src];set_freq=-1">[format_frequency(frequency)] GHz</a> (<a href="?src=\ref[src];set_freq=[initial(frequency)]">Reset</a>)</li>
 		<li>[format_tag("ID Tag","id_tag")]</li>
-	</ul>"}
+		<li>Monitor Pressure: <a href="?src=\ref[src];toggle_monitoring=pressure">[is_monitoring("pressure") ? "Yes" : "No"]</a>
+		<li>Monitor Temperature: <a href="?src=\ref[src];toggle_monitoring=temperature">[is_monitoring("temperature") ? "Yes" : "No"]</a>"}
+
+	for(var/gas_ID in XGM.gases)
+		var/datum/gas/gas_datum = XGM.gases[gas_ID]
+		dat += {"<li>Monitor [gas_datum.name] Concentration: <a href="?src=\ref[src];toggle_monitoring=[gas_ID]">[is_monitoring(gas_ID) ? "Yes" : "No"]</a>"}
+	dat += "</ul>"
+	return dat
+
+/obj/machinery/meter/multitool_topic(var/mob/user, var/list/href_list, var/obj/item/device/multitool/P)
+	. = ..()
+	if(.)
+		return .
+
+	if("toggle_monitoring" in href_list)
+		var/toggle_target = href_list["toggle_monitoring"]
+		if((toggle_target in XGM.gases) || toggle_target == "pressure" || toggle_target == "temperature")
+			toggle_monitoring(toggle_target)
+		return MT_UPDATE
+
+/obj/machinery/meter/proc/add_monitoring(var/input)
+	metrics_monitored |= input
+
+/obj/machinery/meter/proc/remove_monitoring(var/input)
+	metrics_monitored -= input
+
+/obj/machinery/meter/proc/toggle_monitoring(var/input)
+	if(!metrics_monitored.Remove(input))
+		metrics_monitored += input
+
+/obj/machinery/meter/proc/is_monitoring(var/input)
+	return metrics_monitored.Find(input)
 
 /obj/machinery/meter/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
 	if(!W.is_wrench(user))


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

I was surprised to see pipe meters on a gas tank console weren't reporting radon concentrations on a pipeline and decided to fix that.

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Allows pipe meters to report all XGM gasses, not just O2, N2, CO2 and plasma, and uses the same UI as gas sensors. Default behavior would be the same as before this PR, reporting just those 4 gasses, pressure and temperature.

Mostly copypaste from the gas sensor procs, as I couldn't figure out a nice way to have both use the same proc that didn't involve making one a child of the other, and I fear the mapping chaos that might  or might not result in.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Consistency with gas sensor behavior.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
I put plasma, N2O and CO2 into distro and confirmed they did appear in the relevant console. 
I then put in some radon and cryotheum, confirmed they weren't appearing, turned those on with a multitool, and confirmed they did appear now.
...Couldn't test volatile fuel and oxygen agent as I've no idea how to even obtain those.

## Changelog
[consistency ]
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Pipe meters linked to consoles scan now report the same gasses and be configured the same way as gas sensors.
