### PR TITLE
Fixes CTRL+F on 516

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -131,6 +131,8 @@
 		client.haszoomed = 0
 
 	update_colour()
+	if (client.byond_version >= 516)
+		winset(client, null, list("browser-options"="find,refresh,byondstorage"))
 
 	if(client)
 		client.CAN_MOVE_DIAGONALLY = 0


### PR DESCRIPTION
Pasted from TG, tested

![image](https://github.com/user-attachments/assets/d7bb4523-50a3-424e-be5e-5d484f57c6c8)

:cl:
- bugfix: The CTRL+F and F5 control should now work again in HTML interfaces (and are arguably more modern).