### PR TITLE
awards end of round points for rescuing pets (and marks more animals as pets)

### DIFF
--- a/code/game/gamemodes/endgame/scoreboard/misc_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/misc_score.dm
@@ -124,6 +124,17 @@
 	for(var/mob/living/simple_animal/SA in dead_mob_list)
 		if(SA.is_pet)
 			score.deadpets++
+	for(var/mob/living/simple_animal/SA in mob_list)
+		if(SA.is_pet && SA.stat != DEAD)
+			var/turf/T = get_turf(SA)
+			if(!T)
+				continue
+			if(istype(T.loc, /area/shuttle/escape/centcom) || istype(T.loc, /area/shuttle/escape_pod1/centcom) || istype(T.loc, /area/shuttle/escape_pod2/centcom) || istype(T.loc, /area/shuttle/escape_pod3/centcom) || istype(T.loc, /area/shuttle/escape_pod5/centcom))
+				score.rescuedpets++
+				if(SA.type==/mob/living/simple_animal/corgi/Ian) //VIC (very important corgi)
+					score.rescueianbonus=100
+	score.crewscore+=score.rescueianbonus
+	score.crewscore+=score.rescuedpets*50
 
 	score.time = round(world.time/10) //One point for every five seconds. One minute is 12 points, one hour 720 points
 	if(is_research_fully_archived())

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -18,6 +18,8 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	var/deadcrew			= 0 //Humans who died during the round
 	var/deadsilicon			= 0 //Silicons who died during the round
 	var/deadaipenalty		= 0 //AIs who died during the round
+	var/rescuedpets			= 0 //how many pets were brought back to centcomm (alive)
+	var/rescueianbonus		= 0 //ian is a special little guy :)
 	var/mess				= 0 //How much messes on the floor went uncleaned
 	var/litter				= 0 //How much trash is laying on the station floor
 	var/meals				= 0 //How much food was actively cooked that day
@@ -139,6 +141,8 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 		dat += "<B>Cargo Crates Forwarded:</B> [score.stuffforwarded] ([score.stuffforwarded * 50] Points)<BR>"
 	if(score.oremined > 0)
 		dat += "<B>Ore Smelted:</B> [score.oremined] ([score.oremined] Points)<BR>"
+	if(score.rescuedpets)
+		dat += "<B>Rescued Pets:</B> [score.rescuedpets] ([score.rescuedpets*50 + score.rescueianbonus] Points<BR>)"	
 	dat += "<B>Whole Station Powered:</B> [score.powerbonus ? "Yes" : "No"] ([score.powerbonus] Points)<BR>"
 	dat += "<B>Whole Station Airtight:</B> [score.atmobonus ? "Yes" : "No"] ([score.atmobonus] Points)<BR>"
 	if (score.disease_vaccine_score > 0)

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -69,6 +69,7 @@
 	icon_dead= "salem_dead"
 	gender = FEMALE
 	holder_type = /obj/item/weapon/holder/animal/salem
+	is_pet=TRUE
 
 /mob/living/simple_animal/cat/kitten
 	name = "kitten"
@@ -175,6 +176,7 @@
 /mob/living/simple_animal/cat/snek/corpus
 	name = "Corpus"
 	density = 0
+	is_pet=TRUE
 
 var/list/wizard_snakes = list()
 

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -540,6 +540,7 @@
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "tenderizes"
+	is_pet=TRUE
 
 /mob/living/simple_animal/mouse/mouse_op
 	name = "mouse operative"

--- a/code/modules/mob/living/simple_animal/friendly/penguin.dm
+++ b/code/modules/mob/living/simple_animal/friendly/penguin.dm
@@ -50,3 +50,4 @@
 
 	desc = "This penguin knows how to party."
 	icon_state = "penguin_sombrero"
+	is_pet=TRUE


### PR DESCRIPTION
## What this does
Makes it so that a rescued pet (being in a pod/shuttle alive when the shuttle docks) will award 50 points.
except ian, who will award 150 points.

additionally, this marks corpus, salem, and Peng Peng as pets.

suggested on discord, was pretty easy to code.

## Why it's good
adds some fun flavor to rounds. is funny.

## How it was tested
went into game, dragged some pets on shuttle, saw numbers when round ended

## Changelog
:cl:
 * rscadd: NT is now awarding bonuses for the safe return of beloved station pets to centcomm.
