### PR TITLE
Vampire Revive no longer gives you free blood

### DIFF
--- a/code/modules/spells/general/undeath.dm
+++ b/code/modules/spells/general/undeath.dm
@@ -71,7 +71,8 @@
 	var/mob/living/M = owner
 	var/datum/role/vampire/V = isvampire(M)
 	M.revive(FALSE)
-	V.remove_blood(V.blood_usable-10)
+	if (V.blood_usable>10)
+		V.remove_blood(V.blood_usable-10)
 	V.check_vampire_upgrade()
 	V.reviving = FALSE
 	to_chat(M, "<span class='sinister'>You awaken, ready to strike fear into the hearts of mortals once again.</span>")


### PR DESCRIPTION
As it says on the tin
Fixes #37608

 * bugfix: Vampire Revive no longer gives you free blood if you have less than 10 blood.
