### PR TITLE
very inelegantly fixes TGUI black squares

### DIFF
--- a/code/__HELPERS/datum.dm
+++ b/code/__HELPERS/datum.dm
@@ -2,6 +2,7 @@
 	var/list/datum_components
 	var/list/active_timers
 	var/list/open_uis
+	var/dontpool_tgui = FALSE
 
 /datum/proc/initialize()
 	return TRUE

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -88,7 +88,7 @@ var/datum/subsystem/tgui/SStgui
 		if(!window)
 			window = new(user.client, window_id, pooled = TRUE)
 		// Skip windows with acquired locks
-		if(window.locked)
+		if(window.locked || window.dontpool)
 			continue
 		if(window.status == TGUI_WINDOW_READY)
 			return window

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -31,13 +31,20 @@ var/list/obj/machinery/camera/cyborg_cams = list(
 		/datum/malfhack_ability/toggle/disable,
 		/datum/malfhack_ability/oneuse/overload_quiet
 	)
+	dontpool_tgui = TRUE
+
+	var/map_name_counter = 0
+	var/old_map_name = 0
 
 /obj/machinery/computer/security/initialize()
 	..()
 	tv_monitors += src
 	// Map name has to start and end with an A-Z character,
 	// and definitely NOT with a square bracket or even a number.
-	map_name = "camera_console_[ref(src)]_map"
+	map_name = "camera_console_[ref(src)]_map_[map_name_counter]"
+	initialize_map_objects()
+
+/obj/machinery/computer/security/proc/initialize_map_objects()
 	// Initialize map objects
 	cam_screen = new
 	cam_screen.name = "screen"
@@ -101,6 +108,7 @@ var/list/obj/machinery/camera/cyborg_cams = list(
 		return
 	if(!is_operational())
 		return
+	map_name_counter++ // For the next time we open the UI... to fix later....................
 	tgui_interact(user)
 
 /obj/machinery/computer/security/tgui_interact(mob/user, datum/tgui/ui)
@@ -108,6 +116,16 @@ var/list/obj/machinery/camera/cyborg_cams = list(
 
 	// Update the camera, showing static if necessary and updating data if the location has moved.
 	update_active_camera_screen()
+
+	if (old_map_name != map_name_counter)
+		cam_screen.assigned_map = map_name
+		map_name = "camera_console_[ref(src)]_map_[map_name_counter]"
+		cam_screen.screen_loc = "[map_name]:1,1"
+		for (var/obj/abstract/screen/instance in cam_plane_masters)
+			instance.screen_loc = "[map_name]:CENTER"
+			instance.del_on_map_removal = FALSE
+		cam_background.assigned_map = map_name
+		old_map_name = map_name_counter
 
 	if(!ui)
 		// Register map objects
@@ -123,6 +141,7 @@ var/list/obj/machinery/camera/cyborg_cams = list(
 	var/list/data = list()
 	data["network"] = network
 	data["activeCamera"] = null
+	data["mapRef"] = map_name
 	if(active_camera)
 		data["activeCamera"] = list(
 			"name" = active_camera.c_tag,
@@ -133,7 +152,6 @@ var/list/obj/machinery/camera/cyborg_cams = list(
 
 /obj/machinery/computer/security/ui_static_data()
 	var/list/data = list()
-	data["mapRef"] = map_name
 	var/list/cameras = get_available_cameras()
 	data["cameras"] = list()
 	for(var/i in cameras)

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -37,6 +37,8 @@
 	var/datum/ui_state/state = null
 	/// Rate limit client refreshes to prevent DoS.
 	var/refresh_cooldown = 0
+	/// Should this be pooled or not
+	var/dontpool = FALSE
 
 /**
  * public
@@ -60,6 +62,7 @@
 	src.src_object = src_object
 	src.window_key = "\ref[src_object]-main"
 	src.interface = interface
+	dontpool = src_object.dontpool_tgui
 	if(title)
 		src.title = title
 	src.state = src_object.ui_state(user)
@@ -98,7 +101,8 @@
 			fancy = user.client.prefs.tgui_fancy,
 			assets = list(
 				get_tg_asset_datum(/datum/tg_asset/simple/tgui),
-			))
+			),
+			dontpool = src.dontpool)
 	else
 		window.send_message("ping")
 	send_assets()

--- a/code/modules/tgui/tgui_window.dm
+++ b/code/modules/tgui/tgui_window.dm
@@ -28,6 +28,7 @@
 
 	var/list/oversized_payloads = list()
 
+	var/dontpool
 /**
  * public
  *
@@ -64,10 +65,12 @@
 		assets = list(),
 		inline_html = "",
 		inline_js = "",
-		inline_css = "")
+		inline_css = "",
+		dontpool = FALSE)
 	log_tgui(client,
 		context = "[id]/initialize",
-		window = src)
+		window = src,
+		)
 	if(!client)
 		return
 	src.initial_fancy = fancy
@@ -76,6 +79,7 @@
 	src.initial_inline_js = inline_js
 	src.initial_inline_css = inline_css
 	status = TGUI_WINDOW_LOADING
+	src.dontpool = dontpool
 	fatally_errored = FALSE
 	// Build window options
 	var/options = "file=[id].html;can_minimize=0;auto_format=0;"


### PR DESCRIPTION
A lot of thanks to Pomf for doing most of the work on the reproducibility issue.

Closes #37620

## Technical notes

This is a hack. I'm still not exactly sure what's wrong with the TGUI byondUI element, but basically.

- create a `ByondUI` with the right `mapref` for the security camera console;
- this element lingers around in the TGUI window, and ends up being displayed even on UIs that do not require it.

You can thus easily reproduce this bug by interacting with a camera console, closing it, and opening any TGUI window. The black square will happen. It is clear it is related to the security camera console, as can be seen here:

![image](https://github.com/user-attachments/assets/884febc5-1749-4b3f-8eeb-f1d0d5d44037)

I tried a few different ways to soft-solve this. Closing all TGUIs don't work. Regenerating a fresh `screen_map` doesn't work. 

Forcing the camera console to not be pooled *does* fix the rogue black square, but with the issue that the camera console will no longer work after *one* use. I have then decided to constantly change the `screen_map` name every time the user `tgui_interact`s with the computer.

I found something interesting, which is that the computer now works for exactly one map tick. Sure enough, this gives an intuitive understanding of the problem; after you close the security camera computer, it seems that the `screen_map` name is no longer valid, and a new one must be attributed.

Sure enough, if you change the `screen_map` name every time the user opens up a new interface of the camera console, it works again, and the rogue black sqaures are gone.

**I'm not happy with this solution.** It's very suboptimal to not pool your TGUI windows. And I think we could run into problem constantly creating new `screen_map` names every time somone uses the camera console. I also think this may breaks the security cameras when they are used by more than two people, but I am not sure.

**when/if the TGUI maintainers find a better fix**, this band-aid solution can and should be reverted.
This could be a byond issue that is hard to identify but this fixes works for now.

### How this was tested

I created the conditions to reproduce the bug after the fix (open a GPS after interacting with a camera console). The black squares do not appear. Camera consoles still work.

:cl:
- bugfix: Should fix rogue black squares in TGUI interfaces. Please do make a bug report if you see them appearing again!