### PR TITLE
Fixes manuals

### DIFF
--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -249,6 +249,24 @@
 		return
 	if (!isobserver(user))
 		playsound(user, "pageturn", 50, 1, -5)
+	if(wiki_page)
+		dat = {"
+		<html>
+		<body style="margin:5px;padding:0px;overflow:hidden">
+			<iframe width='100%' height='100%' frameborder="0" style="overflow:hidden;height:100%;width:100%" src="http://ss13.moe/wiki/index.php?title=[wiki_page]&printable=yes"></iframe>
+		</body>
+		</html>
+		"}
+		if(!isobserver(user))
+			user.visible_message("<span class='notice'>[user] opens a manual titled \"[src.title]\" and begins reading intently.</span>")
+		user << browse(dat, "window=[name];size=[book_width]x[book_height]")
+		return
+	// typechecking src is the big gay but here it's kinda the most straightforward way to handle.
+	// Manuals have well-formed HTML so HTML_SKELETON isn't needed here
+	if (istype(src, /obj/item/weapon/book/manual))
+		if(!isobserver(user))
+			user.visible_message("<span class='notice'>[user] opens a manual titled \"[src.title]\" and begins reading intently.</span>")
+		user << browse(dat, "window=[name];size=[book_width]x[book_height]")
 	if(src.dat)
 		user << browse(HTML_SKELETON("<TT><I>Penned by [author].</I></TT> <BR>[dat]"), "window=[name];size=[book_width]x[book_height]")
 		if(!isobserver(user))


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0d6fe6d3-5ea1-447e-a23c-8104a383cabe)

![image](https://github.com/user-attachments/assets/2b1652f2-b878-4cc1-834f-a0b0bf772463)

Works for wiki and non-wiki pages. Not the most elegant solution but it does work.
Fixes # ... Oh wait! Nobody actually reported this! How strange is that!!!!!!!!