### PR TITLE
The security camera console tgui will now fully close

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -218,6 +218,9 @@ var/list/obj/machinery/camera/cyborg_cams = list(
 /obj/machinery/computer/security/ui_close(mob/user)
 	// Unregister map objects
 	user.client.clear_map(map_name)
+	// Fully clear it while we're at it
+	var/datum/tgui/ui = SStgui.get_open_ui(user, src)
+	SStgui.force_close_window(user, ui.window.id)
 
 /obj/machinery/computer/security/proc/show_camera_static()
 	cam_screen.vis_contents.Cut()


### PR DESCRIPTION
In the wake of #37622. It probably doesn't matter but it feels safer that way. I tested and this does not break anything.