### PR TITLE
removes veersisms from box brig dorm/briefing area

### DIFF
--- a/maps/tgstation.dmm
+++ b/maps/tgstation.dmm
@@ -2362,9 +2362,12 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/item/weapon/reagent_containers/glass/rag{
-	desc = "For cleaning up messes. This one is a bit crusty...";
-	name = "crusty rag"
+/obj/machinery/door_control{
+	id_tag = "brig_toilet";
+	name = "Brig Toilet Bolts";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
@@ -2634,6 +2637,7 @@
 	})
 "aeq" = (
 /obj/machinery/door/airlock{
+	id_tag = "brig_toilet";
 	name = "Brig Toilets"
 	},
 /turf/simulated/floor{
@@ -3379,7 +3383,6 @@
 	dir = 8
 	},
 /obj/structure/curtain/open/shower/left,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -3656,8 +3659,8 @@
 /turf/simulated/floor,
 /area/security/range)
 "afV" = (
-/obj/structure/closet/wardrobe/pjs,
 /obj/item/toy/gasha/femsec,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/wood,
 /area/security/toilet{
 	name = "Brig Dormitories"
@@ -3695,10 +3698,7 @@
 /obj/machinery/light_switch{
 	pixel_y = -25
 	},
-/obj/structure/bookcase{
-	name = "bookcase (Adult)"
-	},
-/obj/effect/decal/cleanable/cobweb2,
+/obj/structure/closet/wardrobe/pjs,
 /turf/simulated/floor/wood,
 /area/security/toilet{
 	name = "Brig Dormitories"
@@ -4206,7 +4206,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "red"
@@ -4736,9 +4735,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "ahB" = (
 /obj/structure/disposalpipe/segment{
@@ -4754,24 +4751,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "ahD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "ahE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "redcorner"
@@ -4787,9 +4779,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "ahG" = (
 /obj/structure/disposalpipe/segment,
@@ -5227,15 +5217,6 @@
 	},
 /turf/simulated/floor,
 /area/security/warden)
-"air" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/weapon/stool{
-	pixel_y = 8
-	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/security/main)
 "ais" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -5267,9 +5248,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "aiv" = (
 /obj/structure/disposalpipe/segment,
@@ -5287,22 +5266,13 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/security/main)
-"aix" = (
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "aiy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 1
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "aiz" = (
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -5317,9 +5287,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "aiB" = (
 /obj/structure/disposalpipe/segment,
@@ -5752,9 +5720,7 @@
 /obj/effect/landmark/start{
 	name = "Security Officer"
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "aji" = (
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -5788,9 +5754,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "ajl" = (
 /obj/structure/disposalpipe/segment,
@@ -6412,9 +6376,7 @@
 	icon_state = "bot"
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "ake" = (
 /obj/structure/disposalpipe/segment,
@@ -6462,17 +6424,6 @@
 /obj/structure/table,
 /obj/item/weapon/storage/box/handcuffs,
 /obj/item/weapon/handcuffs,
-/turf/simulated/floor/carpet{
-	icon_state = "carpetnoconnect"
-	},
-/area/security/main)
-"akj" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/effect/landmark/start{
-	name = "Security Officer"
-	},
 /turf/simulated/floor/carpet{
 	icon_state = "carpetnoconnect"
 	},
@@ -7011,8 +6962,6 @@
 "akU" = (
 /obj/structure/closet/wardrobe/red,
 /obj/item/weapon/storage/box/holobadge,
-/obj/item/toy/gasha/greytide,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "red"
@@ -7069,7 +7018,6 @@
 	},
 /area/security/main)
 "akZ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/simulated/floor/carpet{
 	icon_state = "carpetnoconnect"
@@ -7467,13 +7415,6 @@
 	icon_state = "dark"
 	},
 /area/security/warden)
-"alD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/weapon/stool{
-	pixel_y = 8
-	},
-/turf/simulated/floor,
-/area/security/main)
 "alE" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -7488,9 +7429,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "alG" = (
 /obj/structure/disposalpipe/segment,
@@ -7829,9 +7768,7 @@
 /obj/effect/landmark/start{
 	name = "Security Officer"
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "amn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -7855,9 +7792,7 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "bot"
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "amq" = (
 /obj/structure/disposalpipe/segment,
@@ -7910,23 +7845,9 @@
 	icon_state = "red"
 	},
 /area/security/main)
-"amv" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start{
-	name = "Security Officer"
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpetnoconnect"
-	},
-/area/security/main)
 "amw" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "amx" = (
 /obj/structure/sign/securearea{
@@ -8219,9 +8140,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "amV" = (
 /obj/structure/disposalpipe/segment,
@@ -8240,9 +8159,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "amX" = (
 /turf/simulated/floor,
@@ -8562,9 +8479,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor,
 /area/security/main)
 "anH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -9587,6 +9502,7 @@
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
+/obj/item/toy/gasha/greytide,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "apA" = (
@@ -32336,9 +32252,9 @@
 	},
 /obj/machinery/door/window{
 	base_state = "right";
+	dir = 8;
 	name = "Library Desk Door";
-	req_access_txt = "37";
-	dir = 8
+	req_access_txt = "37"
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -36469,12 +36385,12 @@
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
+	desc = "Secret of the arts";
 	dir = 2;
 	icon_state = "shutter0";
 	id_tag = "art1";
 	name = "Art Shutters";
-	opacity = 0;
-	desc = "Secret of the arts"
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
 /area/storage/art)
@@ -60670,8 +60586,8 @@
 "cjC" = (
 /obj/machinery/door/airlock/medical{
 	name = "Patient Room 1";
-	req_access_txt = "5";
-	req_access_dir = 4
+	req_access_dir = 4;
+	req_access_txt = "5"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -61990,8 +61906,8 @@
 "cme" = (
 /obj/machinery/door/airlock/medical{
 	name = "Patient Room 2";
-	req_access_txt = "5";
-	req_access_dir = 4
+	req_access_dir = 4;
+	req_access_txt = "5"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -115550,12 +115466,12 @@
 /obj/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
+	desc = "Secret of the arts";
 	dir = 2;
 	icon_state = "shutter0";
 	id_tag = "art1";
 	name = "Art Shutters";
-	opacity = 0;
-	desc = "Secret of the arts"
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
 /area/storage/art)
@@ -116084,12 +116000,12 @@
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
+	desc = "Secret of the arts";
 	dir = 2;
 	icon_state = "shutter0";
 	id_tag = "art1";
 	name = "Art Shutters";
-	opacity = 0;
-	desc = "Secret of the arts"
+	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/plating,
@@ -116339,12 +116255,12 @@
 /obj/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
+	desc = "Secret of the arts";
 	dir = 2;
 	icon_state = "shutter0";
 	id_tag = "art1";
 	name = "Art Shutters";
-	opacity = 0;
-	desc = "Secret of the arts"
+	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/plating,
@@ -231298,11 +231214,11 @@ afR
 agu
 adR
 ahu
-air
+akb
 ajh
 akb
 akS
-alD
+akb
 amm
 akb
 anD
@@ -233808,7 +233724,7 @@ aep
 aep
 agT
 ahB
-aix
+amX
 ajo
 akh
 akY
@@ -234310,13 +234226,13 @@ afV
 aep
 agS
 ahA
-aix
+amX
 ajn
 ozD
 akX
 akg
 ams
-aix
+amX
 anI
 aon
 aoO
@@ -234812,13 +234728,13 @@ afX
 aep
 agV
 ahD
-aix
+amX
 ajq
-akj
+akk
 akX
 akk
 akk
-aix
+amX
 anL
 aoo
 aoO
@@ -235320,7 +235236,7 @@ aki
 akZ
 alI
 amt
-aix
+amX
 anK
 aoo
 aoO
@@ -235821,7 +235737,7 @@ ajs
 akk
 akX
 akk
-amv
+akk
 amZ
 anN
 aoo


### PR DESCRIPTION
i did this mostly for the bolt button and while i was in the area i did some of the other stuff i've been wanting to change

exact changes:
added bolt button to toilet
removed crusty rag from toilet
replaced adult bookcase in bedroom with second personal locker
removed dirt and grime in general
moved all the officer spawns back to the lockers
edit: forgot one; moved the toy greyshit from the locker to the flaps in maint

this PR is sponsored by SDMM 1.9.1
![sdmm_screenshot](https://github.com/user-attachments/assets/4443a900-1a25-4cda-92ca-2acc1426e94c)


## Changelog
:cl:
 * tweak: box brig: made some adjustments to the briefing and rest areas.
