### PR TITLE
Policy on account blocking added to the code of conduct.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,6 +8,14 @@ If this sort of language offends you in any way then please go away or grow thic
 
 Beyond that, we welcome absolutely anyone to learn to code with our mess of an engine to contribute to our mess of a game, and are happy to help you learn to hate BYOND as much as we do.
 
+##### PRs and Account Blocking
+
+By opening a PR here you agree to not block any user involved with us via the native github blocking feature, else your PR will be closed until the users are unblocked.
+
+This is to avoid community conflicts since blocking a user [stops them from interacting with it](https://docs.github.com/en/communities/maintaining-your-safety-on-github/blocking-a-user-from-your-personal-account) in every way. 
+
+Use this [userscript](https://github.com/Mottie/GitHub-userscripts/blob/master/github-issue-comments.user.js) to block them on your end instead if you need to.
+
 ##### Notes on content
 
 The game we are maintaining is a roleplaying simulation of a dystopian future. The content hosted on this repository is a work of fiction and does not reflect the opinions of the people contributing to it.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -12,9 +12,9 @@ Beyond that, we welcome absolutely anyone to learn to code with our mess of an e
 
 By opening a PR here you agree to not block any user involved with us via the native github blocking feature, else your PR will be closed until the users are unblocked.
 
-This is to avoid community conflicts since blocking a user [stops them from interacting with it](https://docs.github.com/en/communities/maintaining-your-safety-on-github/blocking-a-user-from-your-personal-account) in every way. 
+This is to avoid community conflicts since blocking a user [stops them from interacting with PRs and Issues](https://docs.github.com/en/communities/maintaining-your-safety-on-github/blocking-a-user-from-your-personal-account) in every way. 
 
-Use this [userscript](https://github.com/Mottie/GitHub-userscripts/blob/master/github-issue-comments.user.js) to block them on your end instead if you need to.
+Use this [userscript](https://github.com/Mottie/GitHub-userscripts/blob/master/github-issue-comments.user.js) to block them on your end instead if you need to, and report them to the collabs if you're genuinely being harassed.
 
 ##### Notes on content
 


### PR DESCRIPTION
Blocking people with the github blocking "feature" stops them from interacting with your PR in every way, even if they're collaborators, silencing their opinions completely not only for you, but for everyone else.
Avoiding unnecessary drama is better in the long run.

Use this [userscript](https://github.com/Mottie/GitHub-userscripts/blob/master/github-issue-comments.user.js) instead if you REALLY want to block someone from your sight.

### Why?
It has been unofficial policy for a while to heavily discourage account blocking for the aforementioned reasons, and west decided that you should not be blocking users unless you're being harassed, lest your PR gets closed.