### PR TITLE
tesla cannon typofix

### DIFF
--- a/code/modules/projectiles/guns/energy/tesla.dm
+++ b/code/modules/projectiles/guns/energy/tesla.dm
@@ -1,7 +1,7 @@
 #define MIN_TO_FIRE MEGAWATT
 
 /obj/item/weapon/gun/tesla
-	name = "\improper Telsa Cannon"
+	name = "\improper Tesla Cannon"
 	desc = "It's a tesla cannon."
 	icon = 'icons/obj/gun_experimental.dmi'
 	icon_state = "teslacannon_ready"


### PR DESCRIPTION
took 4 fucking years for someone to notice that the thing said telsa instead of tesla
:cl:
 * spellcheck: Nanotrasen now stocks proper Tesla cannon, rather than their Space Temu knock-off, named Telsa.
