### PR TITLE
Some footsteps fixes

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -942,6 +942,7 @@ var/global/maxStackDepth = 10
 	var/step_sound = ""
 	var/stepstaken = 1
 	var/modulo_steps = 2 //if stepstaken is a multiplier of modulo_steps, play the sound. Does not work if modulo_steps < 1
+	var/range_override = -10
 	cloth_layer = SHOES_LAYER
 	cloth_icon = 'icons/mob/feet.dmi'
 	starting_materials = list(MAT_FABRIC = 1250)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -942,7 +942,7 @@ var/global/maxStackDepth = 10
 	var/step_sound = ""
 	var/stepstaken = 1
 	var/modulo_steps = 2 //if stepstaken is a multiplier of modulo_steps, play the sound. Does not work if modulo_steps < 1
-	var/range_override = -10
+	var/footsteps_range = -4
 	cloth_layer = SHOES_LAYER
 	cloth_icon = 'icons/mob/feet.dmi'
 	starting_materials = list(MAT_FABRIC = 1250)

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -160,6 +160,7 @@
 	footprint_type = /obj/effect/decal/cleanable/blood/tracks/footprints/clown
 
 	step_sound = "clownstep"
+	range_override = 0
 
 /obj/item/clothing/shoes/clown_shoes/New()
 	..()

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -160,7 +160,7 @@
 	footprint_type = /obj/effect/decal/cleanable/blood/tracks/footprints/clown
 
 	step_sound = "clownstep"
-	range_override = 0
+	footsteps_range = 0
 
 /obj/item/clothing/shoes/clown_shoes/New()
 	..()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -190,11 +190,9 @@
 				var/obj/item/clothing/shoes/S = shoes
 				if (S.step_sound) //shoes override
 					sounds_to_play = S.step_sound
+					range = S.footsteps_range
 				else //otherwise just use the turf's sound
 					sounds_to_play = T.footstep_sound
-				if (S.range_override != -10)
-					range = S.range_override
-
 			else
 				var/datum/organ/external/foot = has_vulnerable_foot()
 				if (foot)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -177,10 +177,13 @@
 			modulo = S.modulo_steps<modulo? S.modulo_steps : modulo
 		if (stepstaken % modulo == 0) //once every other step by default, so that it doesn't spam too much (shoes override)
 			var/step_volume = 50
+			var/range = -4
 			var/list/sounds_to_play
 			
 			var/turf/T = get_turf(src)
 			if (!T || !T.footstep_sound || istype(T, /turf/space))
+				return
+			if (locate(/obj/machinery/conveyor) in T.contents)
 				return
 
 			if(shoes && istype(shoes, /obj/item/clothing/shoes)) //shoes
@@ -188,7 +191,10 @@
 				if (S.step_sound) //shoes override
 					sounds_to_play = S.step_sound
 				else //otherwise just use the turf's sound
-					sounds_to_play = T.footstep_sound 
+					sounds_to_play = T.footstep_sound
+				if (S.range_override != -10)
+					range = S.range_override
+
 			else
 				var/datum/organ/external/foot = has_vulnerable_foot()
 				if (foot)
@@ -203,7 +209,7 @@
 			stepstaken = 0
 			if (!sounds_to_play)
 				return
-			playsound(src, pick(sounds_to_play), step_volume, 1, -4)
+			playsound(src, pick(sounds_to_play), step_volume, 1, range)
 			
 
 


### PR DESCRIPTION
Added range override for shoes, for now only works with clown shoes to let them have their original range.
Known issues for now:

- Being thrown by a mass driver still makes footsteps
- Footsteps may be a little bit too quiet?

Next prs will add some more sounds (eg. skrell walking sounds)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Clown shoes are 7 range again.
 * bugfix: People won't make sounds when they're on a conveyor belt anymore.

