### PR TITLE
Removes the default trader suit from vox lockers, and also makes them all available in the trader vend

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -3341,6 +3341,10 @@ var/global/num_vending_terminals = 1
 		/obj/item/talonprosthetic = 3,
 		/obj/machinery/vending/sale/trader = 1,
 		/obj/item/weapon/storage/toolbox/paint = 1,
+		/obj/item/weapon/storage/box/smartbox/clothing_box/trader = 3,
+		/obj/item/weapon/storage/box/smartbox/clothing_box/carapace = 3,
+		/obj/item/weapon/storage/box/smartbox/clothing_box/aqua = 3,
+		/obj/item/weapon/storage/box/smartbox/clothing_box/stealth = 3,
 		)
 
 	prices = list(
@@ -3354,6 +3358,10 @@ var/global/num_vending_terminals = 1
 		/obj/item/talonprosthetic = 80,
 		/obj/machinery/vending/sale/trader = 80,
 		/obj/item/weapon/storage/toolbox/paint = 40,
+		/obj/item/weapon/storage/box/smartbox/clothing_box/trader = 30,
+		/obj/item/weapon/storage/box/smartbox/clothing_box/carapace = 30,
+		/obj/item/weapon/storage/box/smartbox/clothing_box/aqua = 30,
+		/obj/item/weapon/storage/box/smartbox/clothing_box/stealth = 30,
 		)
 	slogan_languages = list(LANGUAGE_VOX)
 

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -1272,6 +1272,33 @@
 	new /obj/item/clothing/suit/storage/wintercoat/fur_trapper(src)
 	..()
 
+/obj/item/weapon/storage/box/smartbox/clothing_box/trader
+	name = "Standard trader suit box"
+/obj/item/weapon/storage/box/smartbox/clothing_box/trader/New()
+	new /obj/item/clothing/head/helmet/space/vox/civ/trader(src)
+	new /obj/item/clothing/suit/space/vox/civ/trader(src) // standard brownsuit and helmet
+	..()
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/carapace
+	name = "Carapace trader suit box"
+/obj/item/weapon/storage/box/smartbox/clothing_box/carapace/New()
+	new /obj/item/clothing/head/helmet/space/vox/civ/trader/carapace(src)
+	new /obj/item/clothing/suit/space/vox/civ/trader/carapace(src) // carapace
+	..()
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/aqua
+	name = "Aqua trader suit box"
+/obj/item/weapon/storage/box/smartbox/clothing_box/aqua/New()
+	new /obj/item/clothing/head/helmet/space/vox/civ/trader/medic(src)
+	new /obj/item/clothing/suit/space/vox/civ/trader/medic(src) // aqua coloured hardsuit
+	..()
+
+/obj/item/weapon/storage/box/smartbox/clothing_box/stealth
+	name = "Stealth trader suit box"
+/obj/item/weapon/storage/box/smartbox/clothing_box/stealth/New()
+	new /obj/item/clothing/head/helmet/space/vox/civ/trader/stealth(src)
+	new /obj/item/clothing/suit/space/vox/civ/trader/stealth(src) // black hardsuit. Not capable of any form of stealth systems or shit like that
+	..()
 
 /obj/item/weapon/storage/box/biscuit
 	name = "biscuit box"

--- a/code/modules/maps/spawners/spawners.dm
+++ b/code/modules/maps/spawners/spawners.dm
@@ -857,19 +857,15 @@
  	icon_state = "space_supply"
 
 /obj/abstract/map/spawner/space/vox/trader/spacesuit/perform_spawn()
-	var/i = rand(1, 4) // 1 in 4 chance of spawning a single of listed below
+	var/i = rand(1, 3) // 1 in 4 chance of spawning a single of listed below
 	switch (i)
 		if (1)
-			new /obj/item/clothing/suit/space/vox/civ/trader(src.loc) // standard brownsuit and helmet
-			new /obj/item/clothing/head/helmet/space/vox/civ/trader(src.loc)
-
-		if (2)
 			new /obj/item/clothing/suit/space/vox/civ/trader/carapace(src.loc) // carapace
 			new /obj/item/clothing/head/helmet/space/vox/civ/trader/carapace(src.loc)
-		if (3)
+		if (2)
 			new /obj/item/clothing/suit/space/vox/civ/trader/medic(src.loc) // aqua coloured hardsuit
 			new /obj/item/clothing/head/helmet/space/vox/civ/trader/medic(src.loc)
-		if (4)
+		if (3)
 			new /obj/item/clothing/suit/space/vox/civ/trader/stealth(src.loc) // black hardsuit. Not capable of any form of stealth systems or shit like that
 			new /obj/item/clothing/head/helmet/space/vox/civ/trader/stealth(src.loc)
 	qdel(src)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
What it says on the tin, this was a request by Leon
Also makes them available in the trader vend shoutout to Kurf
## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
You spawn with the default suit anyway, more suit variety
## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
I spawned in and looked at the suits, the default one is not there anymore
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Removed the default trader suit from vox lockers, allowing the other suits to spawn more often.
 * rscadd: All trader suits are now available in the vox trader vendor.


