### PR TITLE
More hard dels tracking

### DIFF
--- a/code/datums/gamemode/role/malf/hackabilities.dm
+++ b/code/datums/gamemode/role/malf/hackabilities.dm
@@ -10,6 +10,12 @@
 /datum/malfhack_ability/New(var/obj/machinery/M)
 	machine = M
 
+/datum/malfhack_ability/Destroy()
+	if (machine) // In case we got destroyed but the machine wasn't, this can happen in edge cases.
+		machine.hack_abilities -= src
+		machine = null
+	. = ..()
+
 /datum/malfhack_ability/proc/activate(var/mob/living/silicon/A)
 	var/datum/role/malfAI/M = A.mind.GetRole(MALF)
 	if(!istype(A) || !istype(M))

--- a/code/datums/gamemode/role/malf/hacking.dm
+++ b/code/datums/gamemode/role/malf/hacking.dm
@@ -9,7 +9,7 @@
 	var/malf_disrupted = FALSE
 	var/aicontrolbypass = FALSE
 
-	var/hack_abilities = list(
+	var/list/hack_abilities = list(
 		/datum/malfhack_ability/toggle/disable,
 		/datum/malfhack_ability/oneuse/overload_quiet
 	)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -76,9 +76,6 @@
 	if (isturf(loc) && opacity)
 		T = loc
 		T.reconsider_lights()
-	var/turf/simulated/S = get_turf(src)
-	if (istype(S))
-		S.zone?.burnable_atoms -= src
 
 	if(materials)
 		QDEL_NULL(materials)
@@ -98,6 +95,9 @@
 
 	break_all_tethers()
 
+	for(var/atom/movable/AM in src)
+		qdel(AM)
+
 	forceMove(null, harderforce = TRUE)
 
 	if (T)
@@ -105,9 +105,6 @@
 
 	if(virtualhearer)
 		QDEL_NULL(virtualhearer)
-
-	for(var/atom/movable/AM in src)
-		qdel(AM)
 
 	. = ..()
 
@@ -482,6 +479,12 @@
 	var/list/atom/old_locs = locs //locs is implicitly copied on assignment, not aliased
 	var/atom/old_loc = loc //Just for convenience; should be equivalent to old_locs[1].
 	var/list/atom/uncrossing
+
+	if (destination == null)
+		var/turf/simulated/S = get_turf(old_loc)
+		if (istype(S))
+			S.zone?.burnable_atoms -= src
+
 	if(isturf(loc)) //obounds() provides nonsense results when Ref.loc isn't a turf.
 		uncrossing = obounds(src)
 	else

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -208,6 +208,7 @@ Class Procs:
 	for(var/datum/malfhack_ability/MH in hack_abilities)
 		MH.machine = null
 		qdel(MH)
+	hack_abilities = null
 	qdel(hack_overlay)
 
 	..()

--- a/code/game/objects/items/devices/PDA/radio.dm
+++ b/code/game/objects/items/devices/PDA/radio.dm
@@ -31,6 +31,10 @@
 	if(ticker && ticker.current_state == GAME_STATE_PLAYING)
 		initialize()
 
+/obj/item/radio/integrated/signal/Destroy()
+	radio_controller.remove_object(src, frequency)
+	. = ..()
+
 /obj/item/radio/integrated/signal/initialize()
 	if (!radio_controller)
 		return

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -35,7 +35,6 @@
 /obj/item/stack/Destroy()
 	if (usr && usr.machine==src)
 		usr << browse(null, "window=stack")
-	src.forceMove(null)
 	..()
 
 /obj/item/stack/examine(mob/user)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -132,11 +132,14 @@ var/creating_arena = FALSE
 	..()
 
 /mob/dead/observer/Destroy()
-	..()
+	var/datum/gamemode/dynamic/dyn_mode = ticker.mode
+	if (istype(dyn_mode))
+		dyn_mode.dead_players -= src
 	unregister_event(/event/after_move, src, nameof(src::update_holomaps()))
 	QDEL_NULL(station_holomap)
 	ghostMulti = null
 	observers.Remove(src)
+	return ..()
 
 /mob/dead/observer/proc/update_holomaps()
 	if(station_holomap)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -26,6 +26,11 @@
 
 	if(addicted_chems)
 		QDEL_NULL(addicted_chems)
+
+	var/datum/gamemode/dynamic/dyn_mode = ticker.mode
+	if (istype(dyn_mode))
+		dyn_mode.living_players -= src
+
 	. = ..()
 
 /mob/living/examine(var/mob/user, var/size = "", var/show_name = TRUE, var/show_icon = TRUE) //Show the mob's size and whether it's been butchered

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -53,6 +53,11 @@
 	attack_delayer = null
 	special_delayer = null
 	throw_delayer = null
+
+	dark_plane = null
+	self_vision = null
+	master_plane = null
+
 	QDEL_NULL(hud_used)
 	for(var/atom/movable/leftovers in src)
 		qdel(leftovers)


### PR DESCRIPTION
None of these are particularily crippling but I do see them happening sometimes.
All references prefs are taken from
https://game.ss13.moe/logs/2025/runtime/2025-05-27-runtime.log

- malfhack_ability

Fairly straightforward. They were correctly removed from a machine was qdel'd, but not the other way around.
This seems to happen fairly often in rounds with a malfAI present:
```
	/datum/malfhack_ability/toggle/disable : 23
	/datum/malfhack_ability/oneuse/overload_quiet : 30
```

- burnables part Deux (including stacks)

Stacks were sending themselves to nullspace way too early in the Destroy() chain. I fixed that but it seems that the best way was to just remove things from the burnable lists if they were sent to nullspace. Maybe this should be an event? It should, but I feel too lazy to code it properly. I'll make it an event if West/Dilt/Exxion yells at me.

Stacks don't del often but they *always* hard del:
```
/obj/item/stack/sheet/glass/glass/bigstack : 2
	/obj/item/stack/sheet/metal/bigstack : 2
	/obj/item/stack/sheet/wood/bigstack : 1
	/obj/item/stack/medical/bruise_pack : 1
	/obj/item/stack/medical/ointment : 1
```

- /obj/item/radio/integrated/signal

Were never removed from the radio controller even though they were added in their `New()`. 
This a rare delete but it happens nonetheless, mostly when bots or headsets are hard-deleted:
```
	/obj/item/radio/integrated/signal/bot/floorbot : 1
```

- vision planes

Those are entirely my fault tbh. The mob vars aren't nulled. This happens every time a mob with a client is deleted. This is fairly rare but can happen during explosions, gibbing, or singulo.

```
	/obj/abstract/screen/plane/dark : 33
	/obj/abstract/screen/plane/master : 33
	/obj/abstract/screen/plane/self_vision : 32
```

- observers/mobs

Still held in dynamic mode lists. This can add up a bit in longer round.

```
/mob/dead/observer : 24
```

I wouldn't count on this fix solving those hdels, because mobs are properly referenced in a bajillion different places (sleeping procs, verbs, whatever) but this does help the theoretical case.