### PR TITLE
[PROBABLY] fixes screen hdels

### DIFF
--- a/code/_onclick/hud/ai.dm
+++ b/code/_onclick/hud/ai.dm
@@ -15,6 +15,7 @@
 	using.icon_state = "camera"
 	using.screen_loc = ui_ai_camera_list
 	adding += using
+	using.pointer_to_list = &adding
 
 //Track
 	using = new /obj/abstract/screen/nocontext
@@ -23,6 +24,7 @@
 	using.icon_state = "track"
 	using.screen_loc = ui_ai_track_with_camera
 	adding += using
+	using.pointer_to_list = &adding
 
 //Camera light
 	using = new /obj/abstract/screen/nocontext
@@ -31,6 +33,7 @@
 	using.icon_state = "camera_light"
 	using.screen_loc = ui_ai_camera_light
 	adding += using
+	using.pointer_to_list = &adding
 
 //Crew Manifest
 	using = new /obj/abstract/screen/nocontext
@@ -39,6 +42,7 @@
 	using.icon_state = "manifest"
 	using.screen_loc = ui_ai_crew_manifest
 	adding += using
+	using.pointer_to_list = &adding
 
 //Alerts
 	using = new /obj/abstract/screen/nocontext
@@ -47,6 +51,7 @@
 	using.icon_state = "alerts"
 	using.screen_loc = ui_ai_alerts
 	adding += using
+	using.pointer_to_list = &adding
 
 //Announcement
 	using = new /obj/abstract/screen/nocontext
@@ -55,6 +60,7 @@
 	using.icon_state = "announcement"
 	using.screen_loc = ui_ai_announcement
 	adding += using
+	using.pointer_to_list = &adding
 
 //Shuttle
 	using = new /obj/abstract/screen/nocontext
@@ -63,6 +69,7 @@
 	using.icon_state = "call_shuttle"
 	using.screen_loc = ui_ai_shuttle
 	adding += using
+	using.pointer_to_list = &adding
 
 //Laws
 	using = new /obj/abstract/screen/nocontext
@@ -71,6 +78,7 @@
 	using.icon_state = "state_laws"
 	using.screen_loc = ui_ai_state_laws
 	adding += using
+	using.pointer_to_list = &adding
 
 //PDA message
 	using = new /obj/abstract/screen/nocontext
@@ -79,6 +87,7 @@
 	using.icon_state = "pda_send"
 	using.screen_loc = ui_ai_pda_send
 	adding += using
+	using.pointer_to_list = &adding
 
 //PDA log
 	using = new /obj/abstract/screen/nocontext
@@ -87,6 +96,7 @@
 	using.icon_state = "pda_receive"
 	using.screen_loc = ui_ai_pda_log
 	adding += using
+	using.pointer_to_list = &adding
 
 //Take image
 	using = new /obj/abstract/screen/nocontext
@@ -95,6 +105,7 @@
 	using.icon_state = "take_picture"
 	using.screen_loc = ui_ai_take_picture
 	adding += using
+	using.pointer_to_list = &adding
 
 //View images
 	using = new /obj/abstract/screen/nocontext
@@ -103,6 +114,7 @@
 	using.icon_state = "view_images"
 	using.screen_loc = ui_ai_view_images
 	adding += using
+	using.pointer_to_list = &adding
 
 //Radio Configuration
 	using = new /obj/abstract/screen/nocontext
@@ -111,5 +123,6 @@
 	using.icon_state = "change_radio"
 	using.screen_loc = ui_ai_config_radio
 	adding += using
+	using.pointer_to_list = &adding
 
 	mymob.client.screen += adding

--- a/code/_onclick/hud/alien.dm
+++ b/code/_onclick/hud/alien.dm
@@ -15,6 +15,9 @@
 	src.adding += using
 	action_intent = using
 
+	using.pointer_to_var = &action_intent
+	using.pointer_to_list = &adding
+
 //intent small hud objects
 	var/icon/ico
 
@@ -29,6 +32,9 @@
 	src.adding += using
 	help_intent = using
 
+	using.pointer_to_var = &help_intent
+	using.pointer_to_list = &adding
+
 	ico = new('icons/mob/screen1_alien.dmi', "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 	ico.DrawBox(rgb(255,255,255,1),ico.Width()/2,ico.Height()/2,ico.Width(),ico.Height())
@@ -39,6 +45,9 @@
 	using.layer = HUD_ABOVE_ITEM_LAYER
 	src.adding += using
 	disarm_intent = using
+
+	using.pointer_to_var = &disarm_intent
+	using.pointer_to_list = &adding
 
 	ico = new('icons/mob/screen1_alien.dmi', "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
@@ -51,6 +60,9 @@
 	src.adding += using
 	grab_intent = using
 
+	using.pointer_to_var = &grab_intent
+	using.pointer_to_list = &adding
+
 	ico = new('icons/mob/screen1_alien.dmi', "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 	ico.DrawBox(rgb(255,255,255,1),1,1,ico.Width()/2,ico.Height()/2)
@@ -61,6 +73,9 @@
 	using.layer = HUD_ABOVE_ITEM_LAYER
 	src.adding += using
 	hurt_intent = using
+
+	using.pointer_to_var = &hurt_intent
+	using.pointer_to_list = &adding
 
 //end intent small hud objects
 
@@ -73,6 +88,9 @@
 	src.adding += using
 	move_intent = using
 
+	using.pointer_to_var = &move_intent
+	using.pointer_to_list = &adding
+
 	using = new /obj/abstract/screen
 	using.name = "drop"
 	using.icon = 'icons/mob/screen1_alien.dmi'
@@ -80,6 +98,8 @@
 	using.screen_loc = ui_drop_throw
 	using.layer = HUD_BASE_LAYER
 	src.adding += using
+
+	using.pointer_to_list = &adding
 
 //equippable shit
 	init_hand_icons('icons/mob/screen1_alien.dmi')
@@ -92,6 +112,7 @@
 	using.screen_loc = ui_swaphand1
 	using.layer = HUD_BASE_LAYER
 	src.adding += using
+	using.pointer_to_list = &adding
 
 	using = new /obj/abstract/screen/inventory
 	using.name = "hand"
@@ -101,6 +122,7 @@
 	using.screen_loc = ui_swaphand2
 	using.layer = HUD_BASE_LAYER
 	src.adding += using
+	using.pointer_to_list = &adding
 
 	//pocket 1
 	inv_box = new /obj/abstract/screen/inventory
@@ -111,6 +133,7 @@
 	inv_box.slot_id = slot_l_store
 	inv_box.layer = HUD_BASE_LAYER
 	src.adding += inv_box
+	inv_box.pointer_to_list = &adding
 
 	//pocket 2
 	inv_box = new /obj/abstract/screen/inventory
@@ -121,29 +144,34 @@
 	inv_box.slot_id = slot_r_store
 	inv_box.layer = HUD_BASE_LAYER
 	src.adding += inv_box
+	inv_box.pointer_to_list = &adding
 
 	mymob.throw_icon = new /obj/abstract/screen
 	mymob.throw_icon.icon = 'icons/mob/screen1_alien.dmi'
 	mymob.throw_icon.icon_state = "act_throw_off"
 	mymob.throw_icon.name = "throw"
 	mymob.throw_icon.screen_loc = ui_drop_throw
+	mymob.throw_icon.pointer_to_var = &mymob.throw_icon
 
 	mymob.healths = new /obj/abstract/screen
 	mymob.healths.icon = 'icons/mob/screen1_alien.dmi'
 	mymob.healths.icon_state = "health0"
 	mymob.healths.name = "health"
 	mymob.healths.screen_loc = ui_alien_health
+	mymob.healths.pointer_to_var = &mymob.healths
 
 	mymob.pullin = new /obj/abstract/screen
 	mymob.pullin.icon = 'icons/mob/screen1_alien.dmi'
 	mymob.pullin.icon_state = "pull0"
 	mymob.pullin.name = "pull"
 	mymob.pullin.screen_loc = ui_pull_resist
+	mymob.pullin.pointer_to_var = &mymob.pullin
 
 	mymob.zone_sel = new /obj/abstract/screen/zone_sel
 	mymob.zone_sel.icon = 'icons/mob/screen1_alien.dmi'
 	mymob.zone_sel.overlays.len = 0
 	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
+	mymob.zone_sel.pointer_to_var = &mymob.zone_sel
 
 	plasma_hud()
 
@@ -158,3 +186,4 @@
 	vampire_blood_display.name = "Alien Plasma"
 	vampire_blood_display.icon_state = "dark128"
 	vampire_blood_display.screen_loc = ui_under_health
+	vampire_blood_display.pointer_to_var = &vampire_blood_display

--- a/code/_onclick/hud/alien_larva.dm
+++ b/code/_onclick/hud/alien_larva.dm
@@ -14,6 +14,9 @@
 	src.adding += using
 	action_intent = using
 
+	using.pointer_to_var = &action_intent
+	using.pointer_to_list = &adding
+
 	using = new /obj/abstract/screen
 	using.name = "mov_intent"
 	using.dir = SOUTHWEST
@@ -23,11 +26,16 @@
 	src.adding += using
 	move_intent = using
 
+	using.pointer_to_var = &move_intent
+	using.pointer_to_list = &adding
+
 	mymob.healths = new /obj/abstract/screen
 	mymob.healths.icon = 'icons/mob/screen1_alien.dmi'
 	mymob.healths.icon_state = "health0"
 	mymob.healths.name = "health"
 	mymob.healths.screen_loc = ui_alien_health
+
+	mymob.healths.pointer_to_var = &mymob.healths
 
 	mymob.pullin = new /obj/abstract/screen
 	mymob.pullin.icon = 'icons/mob/screen1_alien.dmi'
@@ -35,9 +43,13 @@
 	mymob.pullin.name = "pull"
 	mymob.pullin.screen_loc = ui_pull_resist
 
+	mymob.pullin.pointer_to_var = &mymob.pullin
+
 	mymob.zone_sel = new /obj/abstract/screen/zone_sel
 	mymob.zone_sel.overlays.len = 0
 	mymob.zone_sel.overlays += image("icon" = 'icons/mob/zone_sel.dmi', "icon_state" = text("[]", mymob.zone_sel.selecting))
+
+	mymob.zone_sel.pointer_to_var = &mymob.zone_sel
 
 	mymob.client.reset_screen()
 

--- a/code/_onclick/hud/grinch.dm
+++ b/code/_onclick/hud/grinch.dm
@@ -15,6 +15,9 @@
 	src.adding += using
 	action_intent = using
 
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &action_intent
+
 //intent small hud objects
 	var/icon/ico
 
@@ -29,6 +32,9 @@
 	src.adding += using
 	help_intent = using
 
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &help_intent
+
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 	ico.DrawBox(rgb(255,255,255,1),ico.Width()/2,ico.Height()/2,ico.Width(),ico.Height())
@@ -39,6 +45,9 @@
 	using.layer = HUD_ABOVE_ITEM_LAYER
 	src.adding += using
 	disarm_intent = using
+
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &disarm_intent
 
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
@@ -51,6 +60,9 @@
 	src.adding += using
 	grab_intent = using
 
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &grab_intent
+
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 	ico.DrawBox(rgb(255,255,255,1),1,1,ico.Width()/2,ico.Height()/2)
@@ -61,6 +73,9 @@
 	using.layer = HUD_ABOVE_ITEM_LAYER
 	src.adding += using
 	hurt_intent = using
+
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &hurt_intent
 
 //end intent small hud objects
 
@@ -73,6 +88,9 @@
 	src.adding += using
 	move_intent = using
 
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &move_intent
+
 	using = new /obj/abstract/screen
 	using.name = "drop"
 	using.icon = ui_style
@@ -80,6 +98,8 @@
 	using.screen_loc = ui_drop_throw
 	using.layer = HUD_BASE_LAYER
 	src.adding += using
+
+	using.pointer_to_list = &adding
 
 	init_hand_icons(ui_style)
 
@@ -96,6 +116,8 @@
 	using.layer = HUD_BASE_LAYER
 	src.adding += using
 
+	using.pointer_to_list = &adding
+
 	using = new /obj/abstract/screen/inventory
 	using.name = "hand"
 	using.dir = SOUTH
@@ -104,6 +126,8 @@
 	using.screen_loc = ui_swaphand2
 	using.layer = HUD_BASE_LAYER
 	src.adding += using
+
+	using.pointer_to_list = &adding
 
 	#undef ui_equip_hologram
 	#undef ui_swaphand_hologram1
@@ -115,6 +139,9 @@
 	using.icon_state = "act_equip"
 	using.screen_loc = ui_equip
 	src.adding += using
+
+	using.pointer_to_list = &adding
+
 /*
 	using = new /obj/abstract/screen
 	using.name = "resist"
@@ -135,6 +162,8 @@
 	inv_box.layer = HUD_BASE_LAYER
 	src.adding += inv_box
 
+	inv_box.pointer_to_list = &adding
+
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "i_clothing"
 	inv_box.dir = SOUTH
@@ -145,11 +174,15 @@
 	inv_box.layer = HUD_BASE_LAYER
 	src.adding += inv_box
 
+	inv_box.pointer_to_list = &adding
+
 	mymob.throw_icon = new /obj/abstract/screen
 	mymob.throw_icon.icon = ui_style
 	mymob.throw_icon.icon_state = "act_throw_off"
 	mymob.throw_icon.name = "throw"
 	mymob.throw_icon.screen_loc = ui_drop_throw
+
+	mymob.throw_icon.pointer_to_var = &mymob.throw_icon
 
 	mymob.healths = new /obj/abstract/screen
 	mymob.healths.icon = ui_style
@@ -157,16 +190,22 @@
 	mymob.healths.name = "health"
 	mymob.healths.screen_loc = ui_health
 
+	mymob.healths.pointer_to_var = &mymob.healths
+
 	mymob.pullin = new /obj/abstract/screen
 	mymob.pullin.icon = ui_style
 	mymob.pullin.icon_state = "pull0"
 	mymob.pullin.name = "pull"
 	mymob.pullin.screen_loc = ui_pull_resist
 
+	mymob.pullin.pointer_to_var = &mymob.pullin
+
 	mymob.zone_sel = new /obj/abstract/screen/zone_sel
 	mymob.zone_sel.icon = ui_style
 	mymob.zone_sel.overlays.len = 0
 	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
+
+	mymob.zone_sel.pointer_to_var = &mymob.pullin
 
 	mymob.client.reset_screen()
 

--- a/code/_onclick/hud/hologram.dm
+++ b/code/_onclick/hud/hologram.dm
@@ -179,6 +179,8 @@
 
 	//Handle the gun settings buttons
 	mymob.gun_setting_icon = new /obj/abstract/screen/gun/mode
+	mymob.healths.pointer_to_var = &mymob.gun_setting_icon
+
 	if (mymob.client)
 		if (mymob.client.gun_mode) // If in aim mode, correct the sprite
 			mymob.gun_setting_icon.dir = 2
@@ -188,6 +190,9 @@
 			if (mymob.client.target_can_click)
 				mymob.item_use_icon.dir = 1
 			src.adding += mymob.item_use_icon
+
+			mymob.item_use_icon.pointer_to_list = &src.adding
+
 			mymob.gun_move_icon = new /obj/abstract/screen/gun/move
 			if (mymob.client.target_can_move)
 				mymob.gun_move_icon.dir = 1
@@ -195,7 +200,10 @@
 				if (mymob.client.target_can_run)
 					mymob.gun_run_icon.dir = 1
 				src.adding += mymob.gun_run_icon
+				mymob.gun_run_icon.pointer_to_list = &src.adding
+
 			src.adding += mymob.gun_move_icon
+			mymob.gun_move_icon.pointer_to_list = &src.adding
 
 	mymob.client.reset_screen()
 

--- a/code/_onclick/hud/hologram.dm
+++ b/code/_onclick/hud/hologram.dm
@@ -15,6 +15,9 @@
 	src.adding += using
 	action_intent = using
 
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &action_intent
+
 //intent small hud objects
 	var/icon/ico
 
@@ -29,6 +32,9 @@
 	src.adding += using
 	help_intent = using
 
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &help_intent
+
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 	ico.DrawBox(rgb(255,255,255,1),ico.Width()/2,ico.Height()/2,ico.Width(),ico.Height())
@@ -39,6 +45,9 @@
 	using.layer = HUD_ABOVE_ITEM_LAYER
 	src.adding += using
 	disarm_intent = using
+
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &disarm_intent
 
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
@@ -51,6 +60,9 @@
 	src.adding += using
 	grab_intent = using
 
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &grab_intent
+
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 	ico.DrawBox(rgb(255,255,255,1),1,1,ico.Width()/2,ico.Height()/2)
@@ -61,6 +73,9 @@
 	using.layer = HUD_ABOVE_ITEM_LAYER
 	src.adding += using
 	hurt_intent = using
+
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &hurt_intent
 
 //end intent small hud objects
 
@@ -73,6 +88,9 @@
 	src.adding += using
 	move_intent = using
 
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &move_intent
+
 	using = new /obj/abstract/screen
 	using.name = "drop"
 	using.icon = ui_style
@@ -80,6 +98,8 @@
 	using.screen_loc = ui_drop_throw
 	using.layer = HUD_BASE_LAYER
 	src.adding += using
+
+	using.pointer_to_list = &adding
 
 	init_hand_icons(ui_style)
 
@@ -96,6 +116,8 @@
 	using.layer = HUD_BASE_LAYER
 	src.adding += using
 
+	using.pointer_to_list = &adding
+
 	using = new /obj/abstract/screen/inventory
 	using.name = "hand"
 	using.dir = SOUTH
@@ -104,6 +126,8 @@
 	using.screen_loc = ui_swaphand2
 	using.layer = HUD_BASE_LAYER
 	src.adding += using
+
+	using.pointer_to_list = &adding
 
 	#undef ui_equip_hologram
 	#undef ui_swaphand_hologram1
@@ -115,6 +139,8 @@
 	using.icon_state = "act_equip"
 	using.screen_loc = ui_equip
 	src.adding += using
+
+	using.pointer_to_list = &adding
 /*
 	using = new /obj/abstract/screen
 	using.name = "resist"
@@ -134,6 +160,8 @@
 	inv_box.layer = HUD_BASE_LAYER
 	src.adding += inv_box
 
+	inv_box.pointer_to_list = &adding
+
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "i_clothing"
 	inv_box.dir = SOUTH
@@ -143,6 +171,8 @@
 	inv_box.screen_loc = ui_belt
 	inv_box.layer = HUD_BASE_LAYER
 	src.adding += inv_box
+
+	inv_box.pointer_to_list = &adding
 
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "o_clothing"
@@ -154,11 +184,15 @@
 	inv_box.layer = HUD_BASE_LAYER
 	src.adding += inv_box
 
+	inv_box.pointer_to_list = &adding
+
 	mymob.throw_icon = new /obj/abstract/screen
 	mymob.throw_icon.icon = ui_style
 	mymob.throw_icon.icon_state = "act_throw_off"
 	mymob.throw_icon.name = "throw"
 	mymob.throw_icon.screen_loc = ui_drop_throw
+
+	mymob.throw_icon.pointer_to_var = &mymob.throw_icon
 
 	mymob.healths = new /obj/abstract/screen
 	mymob.healths.icon = ui_style
@@ -166,16 +200,22 @@
 	mymob.healths.name = "health"
 	mymob.healths.screen_loc = ui_health
 
+	mymob.healths.pointer_to_var = &mymob.healths
+
 	mymob.pullin = new /obj/abstract/screen
 	mymob.pullin.icon = ui_style
 	mymob.pullin.icon_state = "pull0"
 	mymob.pullin.name = "pull"
 	mymob.pullin.screen_loc = ui_pull_resist
 
+	mymob.pullin.pointer_to_var = &mymob.pullin
+
 	mymob.zone_sel = new /obj/abstract/screen/zone_sel
 	mymob.zone_sel.icon = ui_style
 	mymob.zone_sel.overlays.len = 0
 	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
+
+	mymob.pullin.pointer_to_var = &mymob.zone_sel
 
 	//Handle the gun settings buttons
 	mymob.gun_setting_icon = new /obj/abstract/screen/gun/mode

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -277,6 +277,8 @@ var/global/obj/abstract/screen/clicker/catcher = new()
 	holomap_obj.mouse_opacity = 0
 	holomap_obj.alpha = 255
 
+	holomap_obj.pointer_to_var = &holomap_obj
+
 	mymob.client.screen += src.holomap_obj
 
 	reload_fullscreen()

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -167,6 +167,10 @@ var/global/obj/abstract/screen/clicker/catcher = new()
 		src.hand_hud_objects += inv_box
 		src.adding += inv_box
 
+		inv_box.pointer_to_list = &src.other
+		inv_box.pointer_to_secondary_list = &src.other
+		inv_box.pointer_to_var = &null
+
 /datum/hud/proc/update_hand_icons()
 	var/obj/abstract/screen/inventory/example = locate(/obj/abstract/screen/inventory) in hand_hud_objects
 

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -167,9 +167,8 @@ var/global/obj/abstract/screen/clicker/catcher = new()
 		src.hand_hud_objects += inv_box
 		src.adding += inv_box
 
-		inv_box.pointer_to_list = &src.other
-		inv_box.pointer_to_secondary_list = &src.other
-		inv_box.pointer_to_var = &null
+		inv_box.pointer_to_list = &src.hand_hud_objects
+		inv_box.pointer_to_secondary_list = &src.adding
 
 /datum/hud/proc/update_hand_icons()
 	var/obj/abstract/screen/inventory/example = locate(/obj/abstract/screen/inventory) in hand_hud_objects

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -266,7 +266,7 @@
 	using.alpha = ui_alpha
 	src.adding += using
 
-	inv_box.pointer_to_list = &src.alpha
+	inv_box.pointer_to_list = &src.adding
 
 	using = new /obj/abstract/screen
 	using.name = "equip"

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -17,6 +17,9 @@
 	src.adding += using
 	action_intent = using
 
+	using.pointer_to_list = &src.adding
+	using.pointer_to_var = &action_intent
+
 //intent small hud objects
 	var/icon/ico
 
@@ -31,6 +34,9 @@
 	src.adding += using
 	help_intent = using
 
+	using.pointer_to_list = &src.adding
+	using.pointer_to_var = &help_intent
+
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 	ico.DrawBox(rgb(255,255,255,1),ico.Width()/2,ico.Height()/2,ico.Width(),ico.Height())
@@ -41,6 +47,9 @@
 	using.layer = HUD_ABOVE_ITEM_LAYER
 	src.adding += using
 	disarm_intent = using
+
+	using.pointer_to_list = &src.adding
+	using.pointer_to_var = &disarm_intent
 
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
@@ -53,6 +62,9 @@
 	src.adding += using
 	grab_intent = using
 
+	using.pointer_to_list = &src.adding
+	using.pointer_to_var = &grab_intent
+
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 	ico.DrawBox(rgb(255,255,255,1),1,1,ico.Width()/2,ico.Height()/2)
@@ -63,6 +75,9 @@
 	using.layer = HUD_ABOVE_ITEM_LAYER
 	src.adding += using
 	hurt_intent = using
+
+	using.pointer_to_list = &src.adding
+	using.pointer_to_var = &hurt_intent
 
 //end intent small hud objects
 
@@ -77,6 +92,9 @@
 	src.adding += using
 	move_intent = using
 
+	using.pointer_to_list = &src.adding
+	using.pointer_to_var = &move_intent
+
 	using = new /obj/abstract/screen
 	using.name = "drop"
 	using.icon = ui_style
@@ -86,6 +104,8 @@
 	using.color = ui_color
 	using.alpha = ui_alpha
 	src.hotkeybuttons += using
+
+	using.pointer_to_list = &src.hotkeybuttons
 
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "i_clothing"
@@ -99,6 +119,8 @@
 	inv_box.alpha = ui_alpha
 	src.other += inv_box
 
+	inv_box.pointer_to_list = &src.other
+
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "o_clothing"
 	inv_box.dir = SOUTH
@@ -110,6 +132,8 @@
 	inv_box.color = ui_color
 	inv_box.alpha = ui_alpha
 	src.other += inv_box
+
+	inv_box.pointer_to_list = &src.other
 
 	init_hand_icons(ui_style, ui_color, ui_alpha)
 
@@ -124,6 +148,8 @@
 	using.alpha = ui_alpha
 	src.adding += using
 
+	inv_box.pointer_to_list = &src.adding
+
 	using = new /obj/abstract/screen/inventory
 	using.name = "hand"
 	using.dir = SOUTH
@@ -134,6 +160,8 @@
 	using.color = ui_color
 	using.alpha = ui_alpha
 	src.adding += using
+
+	inv_box.pointer_to_list = &src.adding
 
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "id"
@@ -147,6 +175,8 @@
 	inv_box.alpha = ui_alpha
 	src.adding += inv_box
 
+	inv_box.pointer_to_list = &src.adding
+
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "mask"
 	inv_box.dir = NORTH
@@ -158,6 +188,8 @@
 	inv_box.color = ui_color
 	inv_box.alpha = ui_alpha
 	src.other += inv_box
+
+	inv_box.pointer_to_list = &src.adding
 
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "back"
@@ -171,6 +203,8 @@
 	inv_box.alpha = ui_alpha
 	src.adding += inv_box
 
+	inv_box.pointer_to_list = &src.adding
+
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "storage1"
 	inv_box.icon = ui_style
@@ -182,6 +216,8 @@
 	inv_box.alpha = ui_alpha
 	src.adding += inv_box
 
+	inv_box.pointer_to_list = &src.adding
+
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "storage2"
 	inv_box.icon = ui_style
@@ -192,6 +228,8 @@
 	inv_box.color = ui_color
 	inv_box.alpha = ui_alpha
 	src.adding += inv_box
+
+	inv_box.pointer_to_list = &src.adding
 
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "suit storage"
@@ -205,6 +243,8 @@
 	inv_box.alpha = ui_alpha
 	src.adding += inv_box
 
+	inv_box.pointer_to_list = &src.adding
+
 	using = new /obj/abstract/screen
 	using.name = "resist"
 	using.icon = ui_style
@@ -215,6 +255,8 @@
 	using.alpha = ui_alpha
 	src.hotkeybuttons += using
 
+	inv_box.pointer_to_list = &src.hotkeybuttons
+
 	using = new /obj/abstract/screen
 	using.name = "toggle"
 	using.icon = ui_style
@@ -224,6 +266,8 @@
 	using.alpha = ui_alpha
 	src.adding += using
 
+	inv_box.pointer_to_list = &src.alpha
+
 	using = new /obj/abstract/screen
 	using.name = "equip"
 	using.icon = ui_style
@@ -232,6 +276,8 @@
 	using.color = ui_color
 	using.alpha = ui_alpha
 	src.adding += using
+
+	inv_box.pointer_to_list = &src.adding
 
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "gloves"
@@ -244,6 +290,8 @@
 	inv_box.alpha = ui_alpha
 	src.other += inv_box
 
+	inv_box.pointer_to_list = &src.other
+
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "eyes"
 	inv_box.icon = ui_style
@@ -254,6 +302,8 @@
 	inv_box.color = ui_color
 	inv_box.alpha = ui_alpha
 	src.other += inv_box
+
+	inv_box.pointer_to_list = &src.other
 
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "ears"
@@ -266,6 +316,8 @@
 	inv_box.alpha = ui_alpha
 	src.other += inv_box
 
+	inv_box.pointer_to_list = &src.other
+
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "head"
 	inv_box.icon = ui_style
@@ -276,6 +328,8 @@
 	inv_box.color = ui_color
 	inv_box.alpha = ui_alpha
 	src.other += inv_box
+
+	inv_box.pointer_to_list = &src.other
 
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "shoes"
@@ -288,6 +342,8 @@
 	inv_box.alpha = ui_alpha
 	src.other += inv_box
 
+	inv_box.pointer_to_list = &src.other
+
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "belt"
 	inv_box.icon = ui_style
@@ -299,6 +355,8 @@
 	inv_box.alpha = ui_alpha
 	src.adding += inv_box
 
+	inv_box.pointer_to_list = &src.adding
+
 	mymob.throw_icon = new /obj/abstract/screen
 	mymob.throw_icon.icon = ui_style
 	mymob.throw_icon.icon_state = "act_throw_off"
@@ -307,6 +365,9 @@
 	mymob.throw_icon.color = ui_color
 	mymob.throw_icon.alpha = ui_alpha
 	src.hotkeybuttons += mymob.throw_icon
+
+	mymob.throw_icon.pointer_to_list = &src.adding
+	mymob.throw_icon.pointer_to_var = &mymob.throw_icon
 
 	mymob.kick_icon = new /obj/abstract/screen
 	mymob.kick_icon.name = "kick"
@@ -317,6 +378,9 @@
 	mymob.kick_icon.alpha = ui_alpha
 	src.hotkeybuttons += mymob.kick_icon
 
+	mymob.kick_icon.pointer_to_list = &src.hotkeybuttons
+	mymob.kick_icon.pointer_to_var = &mymob.kick_icon
+
 	mymob.bite_icon = new /obj/abstract/screen
 	mymob.bite_icon.name = "bite"
 	mymob.bite_icon.icon = ui_style
@@ -326,17 +390,24 @@
 	mymob.bite_icon.alpha = ui_alpha
 	src.hotkeybuttons += mymob.bite_icon
 
+	mymob.bite_icon.pointer_to_list = &src.hotkeybuttons
+	mymob.bite_icon.pointer_to_var = &mymob.kick_icon
+
 	mymob.internals = new /obj/abstract/screen
 	mymob.internals.icon = ui_style
 	mymob.internals.icon_state = "internal0"
 	mymob.internals.name = "internal"
 	mymob.internals.screen_loc = ui_internal
 
+	mymob.internals.pointer_to_var = &mymob.internals
+
 	mymob.healths = new /obj/abstract/screen
 	mymob.healths.icon = ui_style
 	mymob.healths.icon_state = "health0"
 	mymob.healths.name = "health"
 	mymob.healths.screen_loc = ui_health
+
+	mymob.healths.pointer_to_var = &mymob.healths
 
 	mymob.pullin = new /obj/abstract/screen
 	mymob.pullin.icon = ui_style
@@ -345,7 +416,8 @@
 	mymob.pullin.screen_loc = ui_pull_resist
 	src.hotkeybuttons += mymob.pullin
 
-	mymob.pain = new /obj/abstract/screen
+	mymob.bite_icon.pointer_to_list = &src.hotkeybuttons
+	mymob.healths.pointer_to_var = &mymob.pullin
 
 	mymob.zone_sel = new /obj/abstract/screen/zone_sel
 	mymob.zone_sel.icon = ui_style
@@ -356,6 +428,8 @@
 
 	//Handle the gun settings buttons
 	mymob.gun_setting_icon = new /obj/abstract/screen/gun/mode
+	mymob.healths.pointer_to_var = &mymob.gun_setting_icon
+
 	if (mymob.client)
 		if (mymob.client.gun_mode) // If in aim mode, correct the sprite
 			mymob.gun_setting_icon.dir = 2
@@ -365,6 +439,9 @@
 			if (mymob.client.target_can_click)
 				mymob.item_use_icon.dir = 1
 			src.adding += mymob.item_use_icon
+
+			mymob.item_use_icon.pointer_to_list = &src.adding
+
 			mymob.gun_move_icon = new /obj/abstract/screen/gun/move
 			if (mymob.client.target_can_move)
 				mymob.gun_move_icon.dir = 1
@@ -372,7 +449,10 @@
 				if (mymob.client.target_can_run)
 					mymob.gun_run_icon.dir = 1
 				src.adding += mymob.gun_run_icon
+				mymob.gun_run_icon.pointer_to_list = &src.adding
+
 			src.adding += mymob.gun_move_icon
+			mymob.gun_move_icon.pointer_to_list = &src.adding
 
 	mymob.client.reset_screen()
 

--- a/code/_onclick/hud/martian.dm
+++ b/code/_onclick/hud/martian.dm
@@ -17,6 +17,9 @@
 	src.adding += using
 	action_intent = using
 
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &action_intent
+
 //intent small hud objects
 	var/icon/ico
 
@@ -31,6 +34,9 @@
 	src.adding += using
 	help_intent = using
 
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &help_intent
+
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 	ico.DrawBox(rgb(255,255,255,1),ico.Width()/2,ico.Height()/2,ico.Width(),ico.Height())
@@ -41,6 +47,9 @@
 	using.layer = HUD_ABOVE_ITEM_LAYER
 	src.adding += using
 	disarm_intent = using
+
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &disarm_intent
 
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
@@ -53,6 +62,9 @@
 	src.adding += using
 	grab_intent = using
 
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &grab_intent
+
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 	ico.DrawBox(rgb(255,255,255,1),1,1,ico.Width()/2,ico.Height()/2)
@@ -63,6 +75,9 @@
 	using.layer = HUD_ABOVE_ITEM_LAYER
 	src.adding += using
 	hurt_intent = using
+
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &hurt_intent
 
 //end intent small hud objects
 
@@ -75,6 +90,9 @@
 	src.adding += using
 	move_intent = using
 
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &move_intent
+
 	using = new /obj/abstract/screen
 	using.name = "drop"
 	using.icon = ui_style
@@ -82,6 +100,8 @@
 	using.screen_loc = ui_drop_throw
 	using.layer = HUD_BASE_LAYER
 	src.adding += using
+
+	using.pointer_to_list = &adding
 
 	init_hand_icons(ui_style)
 
@@ -97,6 +117,8 @@
 	using.layer = HUD_BASE_LAYER
 	src.adding += using
 
+	using.pointer_to_list = &adding
+
 	using = new /obj/abstract/screen/inventory
 	using.name = "hand"
 	using.dir = SOUTH
@@ -105,6 +127,8 @@
 	using.screen_loc = ui_swaphand_martian2
 	using.layer = HUD_BASE_LAYER
 	src.adding += using
+
+	using.pointer_to_list = &adding
 
 	#undef ui_swaphand_martian1
 	#undef ui_swaphand_martian2
@@ -117,6 +141,8 @@
 	using.layer = HUD_BASE_LAYER
 	src.adding += using
 
+	using.pointer_to_list = &adding
+
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "head"
 	inv_box.icon = ui_style
@@ -126,11 +152,15 @@
 	inv_box.layer = HUD_BASE_LAYER
 	src.adding += inv_box
 
+	inv_box.pointer_to_list = &adding
+
 	mymob.throw_icon = new /obj/abstract/screen
 	mymob.throw_icon.icon = ui_style
 	mymob.throw_icon.icon_state = "act_throw_off"
 	mymob.throw_icon.name = "throw"
 	mymob.throw_icon.screen_loc = ui_drop_throw
+
+	mymob.throw_icon.pointer_to_var = &mymob.throw_icon
 
 	mymob.internals = new /obj/abstract/screen
 	mymob.internals.icon = ui_style
@@ -138,11 +168,15 @@
 	mymob.internals.name = "internal"
 	mymob.internals.screen_loc = ui_internal
 
+	mymob.internals.pointer_to_var = &mymob.internals
+
 	mymob.healths = new /obj/abstract/screen
 	mymob.healths.icon = ui_style
 	mymob.healths.icon_state = "health0"
 	mymob.healths.name = "health"
 	mymob.healths.screen_loc = ui_health
+
+	mymob.healths.pointer_to_var = &mymob.healths
 
 	mymob.pullin = new /obj/abstract/screen
 	mymob.pullin.icon = ui_style
@@ -150,14 +184,20 @@
 	mymob.pullin.name = "pull"
 	mymob.pullin.screen_loc = ui_pull_resist
 
+	mymob.pullin.pointer_to_var = &mymob.pullin
+
 	mymob.zone_sel = new /obj/abstract/screen/zone_sel
 	mymob.zone_sel.icon = ui_style
 	mymob.zone_sel.overlays.len = 0
 	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
 
+	mymob.zone_sel.pointer_to_var = &mymob.zone_sel
+
+
 	//Handle the gun settings buttons
 	mymob.gun_setting_icon = new /obj/abstract/screen/gun/mode
-	mymob.gun_setting_icon.icon = ui_style
+	mymob.healths.pointer_to_var = &mymob.gun_setting_icon
+
 	if (mymob.client)
 		if (mymob.client.gun_mode) // If in aim mode, correct the sprite
 			mymob.gun_setting_icon.dir = 2
@@ -167,6 +207,9 @@
 			if (mymob.client.target_can_click)
 				mymob.item_use_icon.dir = 1
 			src.adding += mymob.item_use_icon
+
+			mymob.item_use_icon.pointer_to_list = &src.adding
+
 			mymob.gun_move_icon = new /obj/abstract/screen/gun/move
 			if (mymob.client.target_can_move)
 				mymob.gun_move_icon.dir = 1
@@ -174,7 +217,10 @@
 				if (mymob.client.target_can_run)
 					mymob.gun_run_icon.dir = 1
 				src.adding += mymob.gun_run_icon
+				mymob.gun_run_icon.pointer_to_list = &src.adding
+
 			src.adding += mymob.gun_move_icon
+			mymob.gun_move_icon.pointer_to_list = &src.adding
 
 	mymob.client.reset_screen()
 

--- a/code/_onclick/hud/mommi.dm
+++ b/code/_onclick/hud/mommi.dm
@@ -55,7 +55,7 @@
 	inv_box.layer = HUD_BASE_LAYER
 	src.adding += inv_box
 
-	inv.pointer_to_list = &adding
+	inv_box.pointer_to_list = &adding
 
 	// Intent
 	using = new /obj/abstract/screen

--- a/code/_onclick/hud/mommi.dm
+++ b/code/_onclick/hud/mommi.dm
@@ -17,6 +17,8 @@
 	using.screen_loc = ui_movi	// Set the location
 	src.adding += using			// Place using in our adding list
 
+	using.pointer_to_list = &adding
+
 	// Module select
 	using = new /obj/abstract/screen
 	using.name = INV_SLOT_TOOL
@@ -26,6 +28,9 @@
 	using.screen_loc = ui_inv2
 	src.adding += using			// Place using in our adding list
 	M.inv_tool = using			// Save this using as our MoMMI's inv_sight
+
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &M.inv_tool
 
 	using = new /obj/abstract/screen
 	using.name = INV_SLOT_SIGHT
@@ -37,6 +42,9 @@
 	M.sensor = using
 	// End of module select
 
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &M.sensor
+
 	// Head
 	inv_box = new /obj/abstract/screen/inventory
 	inv_box.name = "head"
@@ -46,6 +54,8 @@
 	inv_box.slot_id = slot_head
 	inv_box.layer = HUD_BASE_LAYER
 	src.adding += inv_box
+
+	inv.pointer_to_list = &adding
 
 	// Intent
 	using = new /obj/abstract/screen
@@ -57,6 +67,9 @@
 	src.adding += using
 	action_intent = using
 
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &action_intent
+
 	// Health
 	mymob.healths = new /obj/abstract/screen
 	mymob.healths.icon = 'icons/mob/screen1_robot.dmi'
@@ -64,12 +77,16 @@
 	mymob.healths.name = "health"
 	mymob.healths.screen_loc = ui_borg_health
 
+	mymob.healths.pointer_to_var = &mymob.healths
+
 	// Installed Module
 	mymob.hands = new /obj/abstract/screen
 	mymob.hands.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.hands.icon_state = "nomod"
 	mymob.hands.name = "module"
 	mymob.hands.screen_loc = ui_mommi_module
+
+	mymob.hands.pointer_to_var = &mymob.healths
 
 	// Module Panel
 	using = new /obj/abstract/screen
@@ -80,6 +97,8 @@
 	using.layer = HUD_BASE_LAYER
 	src.adding += using
 
+	using.pointer_to_list = &adding
+
 	//Robot Module Hud
 	using = new /obj/abstract/screen
 	using.dir = SOUTHWEST
@@ -89,12 +108,17 @@
 	src.adding += using
 	M.robot_modules_background = using
 
+	using.pointer_to_list = &adding
+	using.pointer_to_var = &M.robot_modules_background
+
 	// Store
 	mymob.throw_icon = new /obj/abstract/screen
 	mymob.throw_icon.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.throw_icon.icon_state = "store"
 	mymob.throw_icon.name = "store"
 	mymob.throw_icon.screen_loc = ui_mommi_store
+
+	mymob.throw_icon.pointer_to_var = &mymob.throw_icon
 
 	// Pulling
 	mymob.pullin = new /obj/abstract/screen
@@ -103,11 +127,15 @@
 	mymob.pullin.name = "pull"
 	mymob.pullin.screen_loc = ui_borg_pull
 
+	mymob.pullin.pointer_to_var = &mymob.pullin
+
 	// Zone
 	mymob.zone_sel = new /obj/abstract/screen/zone_sel
 	mymob.zone_sel.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.zone_sel.overlays.len = 0
 	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
+
+	mymob.zone_sel.pointer_to_var = &mymob.zone_sel
 
 	// Reset the client's screen
 	mymob.client.reset_screen()

--- a/code/_onclick/hud/monkey.dm
+++ b/code/_onclick/hud/monkey.dm
@@ -253,10 +253,10 @@
 				if (mymob.client.target_can_run)
 					mymob.gun_run_icon.dir = 1
 				src.adding += mymob.gun_run_icon
-				mymob.item_use_icon.gun_run_icon = &src.adding
+				mymob.gun_run_icon.pointer_to_list = &src.adding
 
 			src.adding += mymob.gun_move_icon
-			mymob.item_use_icon.gun_move_icon = &src.adding
+			mymob.gun_move_icon.pointer_to_list = &src.adding
 
 	mymob.client.reset_screen()
 

--- a/code/_onclick/hud/monkey.dm
+++ b/code/_onclick/hud/monkey.dm
@@ -15,6 +15,9 @@
 	src.adding += using
 	action_intent = using
 
+	using.pointer_to_list = &src.adding
+	using.pointer_to_var = &action_intent
+
 //intent small hud objects
 	var/icon/ico
 
@@ -29,6 +32,9 @@
 	src.adding += using
 	help_intent = using
 
+	using.pointer_to_list = &src.adding
+	using.pointer_to_var = &help_intent
+
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 	ico.DrawBox(rgb(255,255,255,1),ico.Width()/2,ico.Height()/2,ico.Width(),ico.Height())
@@ -39,6 +45,9 @@
 	using.layer = HUD_ABOVE_ITEM_LAYER
 	src.adding += using
 	disarm_intent = using
+
+	using.pointer_to_list = &src.adding
+	using.pointer_to_var = &disarm_intent
 
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
@@ -51,6 +60,9 @@
 	src.adding += using
 	grab_intent = using
 
+	using.pointer_to_list = &src.adding
+	using.pointer_to_var = &grab_intent
+
 	ico = new(ui_style, "black")
 	ico.MapColors(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, -1,-1,-1,-1)
 	ico.DrawBox(rgb(255,255,255,1),1,1,ico.Width()/2,ico.Height()/2)
@@ -61,6 +73,9 @@
 	using.layer = HUD_ABOVE_ITEM_LAYER
 	src.adding += using
 	hurt_intent = using
+
+	using.pointer_to_list = &src.adding
+	using.pointer_to_var = &hurt_intent
 
 //end intent small hud objects
 
@@ -73,6 +88,9 @@
 	src.adding += using
 	move_intent = using
 
+	using.pointer_to_list = &src.adding
+	using.pointer_to_var = &move_intent
+
 	if(MO.held_items.len)
 		using = new /obj/abstract/screen
 		using.name = "drop"
@@ -82,6 +100,8 @@
 		using.layer = HUD_BASE_LAYER
 		src.adding += using
 
+		using.pointer_to_list = &src.adding
+
 		using = new /obj/abstract/screen
 		using.name = "throw"
 		using.icon = ui_style
@@ -89,6 +109,8 @@
 		using.screen_loc = ui_drop_throw
 		using.layer = HUD_BASE_LAYER
 		src.adding += using
+
+		using.pointer_to_list = &src.adding
 
 	init_hand_icons(ui_style)
 	if(MO.held_items.len > 1)
@@ -101,6 +123,8 @@
 		using.layer = HUD_BASE_LAYER
 		src.adding += using
 
+		using.pointer_to_list = &src.adding
+
 		using = new /obj/abstract/screen/inventory
 		using.name = "hand"
 		using.dir = SOUTH
@@ -110,6 +134,8 @@
 		using.layer = HUD_BASE_LAYER
 		src.adding += using
 
+		using.pointer_to_list = &src.adding
+
 	using = new /obj/abstract/screen
 	using.name = "resist"
 	using.icon = ui_style
@@ -117,6 +143,8 @@
 	using.screen_loc = ui_pull_resist
 	using.layer = HUD_BASE_LAYER
 	src.adding += using
+
+	using.pointer_to_list = &src.adding
 
 	if(MO.canWearClothes)
 		inv_box = new /obj/abstract/screen/inventory
@@ -129,6 +157,8 @@
 		inv_box.layer = HUD_BASE_LAYER
 		src.adding += inv_box
 
+		inv_box.pointer_to_list = &src.adding
+
 	if(MO.canWearHats)
 		inv_box = new /obj/abstract/screen/inventory
 		inv_box.name = "head"
@@ -139,6 +169,8 @@
 		inv_box.layer = HUD_BASE_LAYER
 		src.adding += inv_box
 
+		inv_box.pointer_to_list = &src.adding
+
 	if(MO.canWearGlasses)
 		inv_box = new /obj/abstract/screen/inventory
 		inv_box.name = "eyes"
@@ -148,6 +180,8 @@
 		inv_box.slot_id = slot_glasses
 		inv_box.layer = HUD_BASE_LAYER
 		src.adding += inv_box
+
+		inv_box.pointer_to_list = &src.adding
 
 	if(MO.canWearMasks)
 		inv_box = new /obj/abstract/screen/inventory
@@ -160,6 +194,8 @@
 		inv_box.layer = HUD_BASE_LAYER
 		src.adding += inv_box
 
+		inv_box.pointer_to_list = &src.adding
+
 	if(MO.canWearBack)
 		inv_box = new /obj/abstract/screen/inventory
 		inv_box.name = "back"
@@ -170,6 +206,8 @@
 		inv_box.slot_id = slot_back
 		inv_box.layer = HUD_BASE_LAYER
 		src.adding += inv_box
+
+		inv_box.pointer_to_list = &src.adding
 
 	mymob.internals = new /obj/abstract/screen
 	mymob.internals.icon = ui_style
@@ -205,6 +243,9 @@
 			if (mymob.client.target_can_click)
 				mymob.item_use_icon.dir = 1
 			src.adding += mymob.item_use_icon
+
+			mymob.item_use_icon.pointer_to_list = &src.adding
+
 			mymob.gun_move_icon = new /obj/abstract/screen/gun/move
 			if (mymob.client.target_can_move)
 				mymob.gun_move_icon.dir = 1
@@ -212,7 +253,10 @@
 				if (mymob.client.target_can_run)
 					mymob.gun_run_icon.dir = 1
 				src.adding += mymob.gun_run_icon
+				mymob.item_use_icon.gun_run_icon = &src.adding
+
 			src.adding += mymob.gun_move_icon
+			mymob.item_use_icon.gun_move_icon = &src.adding
 
 	mymob.client.reset_screen()
 

--- a/code/_onclick/hud/other_mobs.dm
+++ b/code/_onclick/hud/other_mobs.dm
@@ -331,7 +331,7 @@
 	vampire_blood_display.name = "Charge"
 	vampire_blood_display.icon_state = "dark128"
 	vampire_blood_display.screen_loc = ui_under_health
-	vampire_blood_display.pointer_to_var = &mymob.vampire_blood_display
+	vampire_blood_display.pointer_to_var = &vampire_blood_display
 
 	mymob.client.reset_screen()
 

--- a/code/_onclick/hud/other_mobs.dm
+++ b/code/_onclick/hud/other_mobs.dm
@@ -9,6 +9,8 @@
 	mymob.visible.name = "visible"
 	mymob.visible.screen_loc = ui_health
 
+	mymob.visible.pointer_to_var = &mymob.visible
+
 	mymob.client.reset_screen()
 
 	mymob.client.screen += list(mymob.visible)
@@ -21,11 +23,15 @@
 	mymob.healths.name = "health"
 	mymob.healths.screen_loc = ui_health
 
+	mymob.healths.pointer_to_var = &mymob.healths
+
 	mymob.pullin = new /obj/abstract/screen
 	mymob.pullin.icon = 'icons/mob/screen1_corgi.dmi'
 	mymob.pullin.icon_state = "pull0"
 	mymob.pullin.name = "pull"
 	mymob.pullin.screen_loc = ui_construct_pull
+
+	mymob.pullin.pointer_to_var = &mymob.pullin
 
 	mymob.client.reset_screen()
 
@@ -41,11 +47,15 @@
 	mymob.healths.name = "health"
 	mymob.healths.screen_loc = ui_construct_health
 
+	mymob.healths.pointer_to_var = &mymob.healths
+
 	mymob.pullin = new /obj/abstract/screen
 	mymob.pullin.icon = 'icons/mob/screen1_slime.dmi'
 	mymob.pullin.icon_state = "pull0"
 	mymob.pullin.name = "pull"
 	mymob.pullin.screen_loc = ui_construct_pull
+
+	mymob.pullin.pointer_to_var = &mymob.pullin
 
 	mymob.zone_sel = new /obj/abstract/screen/zone_sel
 	mymob.zone_sel.icon = 'icons/mob/screen1_slime.dmi'
@@ -64,17 +74,22 @@
 	mymob.healths.name = "health"
 	mymob.healths.screen_loc = ui_construct_health
 
+	mymob.healths.pointer_to_var = &mymob.healths
+
 	mymob.pullin = new /obj/abstract/screen
 	mymob.pullin.icon = 'icons/mob/screen1_shade.dmi'
 	mymob.pullin.icon_state = "pull0"
 	mymob.pullin.name = "pull"
 	mymob.pullin.screen_loc = ui_construct_pull
 
+	mymob.pullin.pointer_to_var = &mymob.pullin
+
 	mymob.zone_sel = new /obj/abstract/screen/zone_sel
 	mymob.zone_sel.icon = 'icons/mob/screen1_shade.dmi'
 	mymob.zone_sel.overlays.len = 0
 	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
 
+	mymob.zone_sel.pointer_to_var = &mymob.zone_sel
 
 	////////SOUL BLADE HUD ELEMENTS////////
 	mymob.healths2 = new /obj/abstract/screen
@@ -82,6 +97,8 @@
 	mymob.healths2.icon_state = "blade_ok"
 	mymob.healths2.name = "blade integrity"
 	mymob.healths2.screen_loc = ui_construct_sword
+
+	mymob.healths2.pointer_to_var = &mymob.healths2
 	///////////////////////////////////////
 
 	mymob.client.reset_screen()
@@ -95,11 +112,13 @@
 	mymob.healths.icon_state = "borer_health0"
 	mymob.healths.name = "health"
 	mymob.healths.screen_loc = ui_construct_health
+	mymob.healths.pointer_to_var = &mymob.healths2
 
 	mymob.zone_sel = new /obj/abstract/screen/zone_sel
 	mymob.zone_sel.icon = 'icons/mob/screen1_borer.dmi'
 	mymob.zone_sel.overlays.len = 0
 	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
+	mymob.zone_sel.pointer_to_var = &mymob.zone_sel
 
 	mymob.client.reset_screen()
 
@@ -123,17 +142,20 @@
 		mymob.healths.icon_state = "[constructtype]_health0"
 		mymob.healths.name = "health"
 		mymob.healths.screen_loc = ui_construct_health
+		mymob.healths.pointer_to_var = &mymob.healths
 
 		mymob.pullin = new /obj/abstract/screen
 		mymob.pullin.icon = 'icons/mob/screen1_construct.dmi'
 		mymob.pullin.icon_state = "pull0"
 		mymob.pullin.name = "pull"
 		mymob.pullin.screen_loc = ui_construct_pull
+		mymob.pullin.pointer_to_var = &mymob.pullin
 
 		mymob.zone_sel = new /obj/abstract/screen/zone_sel
 		mymob.zone_sel.icon = 'icons/mob/screen1_construct.dmi'
 		mymob.zone_sel.overlays.len = 0
 		mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
+		mymob.zone_sel.pointer_to_var = &mymob.zone_sel
 
 	mymob.client.reset_screen()
 
@@ -145,6 +167,7 @@
 	vampire_blood_display.name = "Vampire Blood"
 	vampire_blood_display.icon_state = "dark128"
 	vampire_blood_display.screen_loc = ui_under_health
+	vampire_blood_display.pointer_to_var = &vampire_blood_display
 
 	mymob.client.screen += list(vampire_blood_display)
 
@@ -153,6 +176,7 @@
 	streamer_display.name = "Streaming Stats"
 	streamer_display.icon = null
 	streamer_display.screen_loc = ui_more_under_health_and_to_the_left
+	streamer_display.pointer_to_var = &streamer_display
 
 	mymob.client.screen += list(streamer_display)
 
@@ -162,9 +186,9 @@
 	vampire_blood_display.name = "Changeling Chems"
 	vampire_blood_display.icon_state = "dark128"
 	vampire_blood_display.screen_loc = ui_under_health
+	vampire_blood_display.pointer_to_var = &vampire_blood_display
 
 	mymob.client.screen += list(vampire_blood_display)
-
 
 /datum/hud/proc/countdown_blob()
 
@@ -173,6 +197,7 @@
 	countdown_display.name = "Burst Countdown"
 	countdown_display.icon_state = "countdown_blob"
 	countdown_display.screen_loc = ui_under_health
+	countdown_display.pointer_to_var = &countdown_display
 
 	mymob.client.screen += list(countdown_display)
 
@@ -183,6 +208,7 @@
 	countdown_display.name = "Primitive Countdown"
 	countdown_display.icon_state = "countdown_monkey"
 	countdown_display.screen_loc = ui_under_health
+	countdown_display.pointer_to_var = &countdown_display
 
 	mymob.client.screen += list(countdown_display)
 
@@ -193,9 +219,9 @@
 	countdown_display.icon = 'icons/mob/screen_countdowns.dmi'
 	countdown_display.icon_state = "countdown_default"
 	countdown_display.screen_loc = ui_under_health
+	countdown_display.pointer_to_var = &countdown_display
 
 	mymob.client.screen += list(countdown_display)
-
 
 /datum/hud/proc/cult_hud(ui_style = 'icons/mob/screen1_cult.dmi')
 
@@ -205,12 +231,15 @@
 	cult_Act_display.icon_state = ""
 	cult_Act_display.screen_loc = ui_cult_Act
 	pulse_atom(cult_Act_display)
+	cult_Act_display.pointer_to_var = &cult_Act_display
 
 	cult_tattoo_display = new /obj/abstract/screen
 	cult_tattoo_display.icon = ui_style
 	cult_tattoo_display.name = "Arcane Tattoos: none"
 	cult_tattoo_display.icon_state = ""
 	cult_tattoo_display.screen_loc = ui_cult_tattoos
+	cult_tattoo_display.pointer_to_var = &cult_tattoo_display
+
 	//pulse_atom(cult_tattoo_display)
 
 	if (mymob?.client)
@@ -242,17 +271,20 @@
 	mymob.healths.icon_state = "health0"
 	mymob.healths.name = "health"
 	mymob.healths.screen_loc = ui_construct_health
+	mymob.healths.pointer_to_var = &mymob.healths
 
 	mymob.pullin = new /obj/abstract/screen
 	mymob.pullin.icon = 'icons/mob/screen1_spider.dmi'
 	mymob.pullin.icon_state = "pull0"
 	mymob.pullin.name = "pull"
 	mymob.pullin.screen_loc = ui_construct_pull
+	mymob.pullin.pointer_to_var = &mymob.pullin
 
 	mymob.zone_sel = new /obj/abstract/screen/zone_sel
 	mymob.zone_sel.icon = 'icons/mob/screen1_spider.dmi'
 	mymob.zone_sel.overlays.len = 0
 	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
+	mymob.zone_sel.pointer_to_var = &mymob.zone_sel
 
 	mymob.client.screen += list(mymob.healths, mymob.pullin, mymob.zone_sel)
 
@@ -263,7 +295,7 @@
 		spider_food_display.icon_state = "spider_spell_base"
 		spider_food_display.name = "Food"
 		spider_food_display.screen_loc = ui_under_health
-
+		spider_food_display.pointer_to_var = &spider_food_display
 		mymob.client.screen += list(spider_food_display)
 
 		if (!istype(mymob,/mob/living/simple_animal/hostile/giant_spider/nurse/queen_spider))
@@ -272,7 +304,7 @@
 			spider_queen_counter.icon_state = "spider_spell_base"
 			spider_queen_counter.name = "Queen Requirement"
 			spider_queen_counter.screen_loc = ui_more_under_health
-
+			spider_queen_counter.pointer_to_var = &spider_queen_counter
 			mymob.client.screen += list(spider_queen_counter)
 
 	//Spiderling
@@ -282,6 +314,7 @@
 		spiderling_growth_display.icon_state = "spider_spell_base"
 		spiderling_growth_display.name = "Growth"
 		spiderling_growth_display.screen_loc = ui_under_health
+		spiderling_growth_display.pointer_to_var = &spiderling_growth_display
 
 		mymob.client.screen += list(spiderling_growth_display)
 
@@ -292,11 +325,13 @@
 	mymob.healths.icon_state = "health0"
 	mymob.healths.name = "health"
 	mymob.healths.screen_loc = ui_health
+	mymob.healths.pointer_to_var = &mymob.healths
 
 	vampire_blood_display = new /obj/abstract/screen
 	vampire_blood_display.name = "Charge"
 	vampire_blood_display.icon_state = "dark128"
 	vampire_blood_display.screen_loc = ui_under_health
+	vampire_blood_display.pointer_to_var = &mymob.vampire_blood_display
 
 	mymob.client.reset_screen()
 
@@ -309,11 +344,13 @@
 	mymob.healths.icon_state = "health0"
 	mymob.healths.name = "health"
 	mymob.healths.screen_loc = ui_health
+	mymob.healths.pointer_to_var = &mymob.healths
 
 	mymob.healths2 = new /obj/abstract/screen
 	mymob.healths2.icon= 'icons/mob/screen1_grue.dmi'
 	mymob.healths2.icon_state= "lightlevel_dim"
 	mymob.healths2.name= "darkness"
 	mymob.healths2.screen_loc=ui_under_health
+	mymob.healths2.pointer_to_var = &mymob.healths2
 
 	mymob.client.screen += list(mymob.healths,mymob.healths2)

--- a/code/_onclick/hud/pai.dm
+++ b/code/_onclick/hud/pai.dm
@@ -5,6 +5,8 @@
 	mymob.zone_sel.overlays.len = 0
 	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
 
+	mymob.zone_sel.pointer_to_var = &mymob.zone_sel
+
 	mymob.client.reset_screen()
 
 	mymob.client.screen += list(mymob.zone_sel)

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -3,7 +3,7 @@
 	src.other = list()
 
 	var/obj/abstract/screen/using
-
+	var/mob/living/silicon/robot/R = mymob
 
 //Radio
 	using = new /obj/abstract/screen
@@ -14,6 +14,8 @@
 	using.screen_loc = ui_movi
 	src.adding += using
 
+	using.pointer_to_list = &adding
+
 //Module select
 
 	using = new /obj/abstract/screen
@@ -23,7 +25,11 @@
 	using.icon_state = "sight"
 	using.screen_loc = ui_borg_sight
 	src.adding += using
-	mymob:sensor = using
+	R.sensor = using
+
+	using.pointer_to_var = &R.sensor
+	using.pointer_to_list = &adding
+
 
 	using = new /obj/abstract/screen
 	using.name = "module1"
@@ -32,7 +38,10 @@
 	using.icon_state = "inv1"
 	using.screen_loc = ui_inv1
 	src.adding += using
-	mymob:inv1 = using
+	R.inv1 = using
+
+	using.pointer_to_var = &R.inv1
+	using.pointer_to_list = &adding
 
 	using = new /obj/abstract/screen
 	using.name = "module2"
@@ -41,7 +50,10 @@
 	using.icon_state = "inv2"
 	using.screen_loc = ui_inv2
 	src.adding += using
-	mymob:inv2 = using
+	R.inv2 = using
+
+	using.pointer_to_var = &R.inv2
+	using.pointer_to_list = &adding
 
 	using = new /obj/abstract/screen
 	using.name = "module3"
@@ -50,7 +62,10 @@
 	using.icon_state = "inv3"
 	using.screen_loc = ui_inv3
 	src.adding += using
-	mymob:inv3 = using
+	R.inv3 = using
+
+	using.pointer_to_var = &R.inv3
+	using.pointer_to_list = &adding
 
 	using = new /obj/abstract/screen
 	using.dir = SOUTHWEST
@@ -58,7 +73,10 @@
 	using.icon_state = "block"
 	using.layer = HUD_BASE_LAYER
 	src.adding += using
-	mymob:robot_modules_background = using
+	R.robot_modules_background = using
+
+	using.pointer_to_var = &R.robot_modules_background
+	using.pointer_to_list = &adding
 
 //End of module select
 
@@ -72,12 +90,17 @@
 	src.adding += using
 	action_intent = using
 
+	using.pointer_to_var = &R.robot_modules_background
+	using.pointer_to_list = &adding
+
 //Health
 	mymob.healths = new /obj/abstract/screen
 	mymob.healths.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.healths.icon_state = "health0"
 	mymob.healths.name = "health"
-	mymob.healths.screen_loc = ui_borg_health 
+	mymob.healths.screen_loc = ui_borg_health
+
+	using.pointer_to_var = &mymob.healths
 
 //Installed Module
 	mymob.hands = new /obj/abstract/screen
@@ -85,6 +108,8 @@
 	mymob.hands.icon_state = "nomod"
 	mymob.hands.name = "module"
 	mymob.hands.screen_loc = ui_borg_module
+
+	using.pointer_to_var = &mymob.hands
 
 //Module Panel
 	using = new /obj/abstract/screen
@@ -95,12 +120,16 @@
 	using.layer = HUD_BASE_LAYER
 	src.adding += using
 
+	using.pointer_to_list = &adding
+
 //Store
 	mymob.throw_icon = new /obj/abstract/screen
 	mymob.throw_icon.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.throw_icon.icon_state = "store"
 	mymob.throw_icon.name = "store"
 	mymob.throw_icon.screen_loc = ui_borg_store
+
+	using.pointer_to_list = &adding
 
 //Photography stuff
 	mymob.camera_icon = new /obj/abstract/screen
@@ -109,11 +138,15 @@
 	mymob.camera_icon.name = "Take Image"
 	mymob.camera_icon.screen_loc = ui_borg_camera
 
+	mymob.camera_icon.pointer_to_var  = &mymob.camera_icon
+
 	mymob.album_icon = new /obj/abstract/screen
 	mymob.album_icon.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.album_icon.icon_state = "album"
 	mymob.album_icon.name = "View Images"
 	mymob.album_icon.screen_loc = ui_borg_album
+
+	mymob.album_icon.pointer_to_var  = &mymob.album_icon
 
 	mymob.pullin = new /obj/abstract/screen
 	mymob.pullin.icon = 'icons/mob/screen1_robot.dmi'
@@ -121,13 +154,19 @@
 	mymob.pullin.name = "pull"
 	mymob.pullin.screen_loc = ui_borg_pull
 
+	mymob.pullin.pointer_to_var  = &mymob.pullin
+
 	mymob.zone_sel = new /obj/abstract/screen/zone_sel
 	mymob.zone_sel.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.zone_sel.overlays.len = 0
 	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
 
+	mymob.zone_sel.pointer_to_var  = &mymob.zone_sel
+
 	//Handle the gun settings buttons
 	mymob.gun_setting_icon = new /obj/abstract/screen/gun/mode
+	mymob.healths.pointer_to_var = &mymob.gun_setting_icon
+
 	if (mymob.client)
 		if (mymob.client.gun_mode) // If in aim mode, correct the sprite
 			mymob.gun_setting_icon.dir = 2
@@ -137,6 +176,9 @@
 			if (mymob.client.target_can_click)
 				mymob.item_use_icon.dir = 1
 			src.adding += mymob.item_use_icon
+
+			mymob.item_use_icon.pointer_to_list = &src.adding
+
 			mymob.gun_move_icon = new /obj/abstract/screen/gun/move
 			if (mymob.client.target_can_move)
 				mymob.gun_move_icon.dir = 1
@@ -144,7 +186,10 @@
 				if (mymob.client.target_can_run)
 					mymob.gun_run_icon.dir = 1
 				src.adding += mymob.gun_run_icon
+				mymob.gun_run_icon.pointer_to_list = &src.adding
+
 			src.adding += mymob.gun_move_icon
+			mymob.gun_move_icon.pointer_to_list = &src.adding
 
 	mymob.client.reset_screen()
 

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -90,28 +90,10 @@
 	src.adding += using
 	action_intent = using
 
-	using.pointer_to_var = &R.robot_modules_background
+	using.pointer_to_var = &action_intent
 	using.pointer_to_list = &adding
 
-//Health
-	mymob.healths = new /obj/abstract/screen
-	mymob.healths.icon = 'icons/mob/screen1_robot.dmi'
-	mymob.healths.icon_state = "health0"
-	mymob.healths.name = "health"
-	mymob.healths.screen_loc = ui_borg_health
-
-	using.pointer_to_var = &mymob.healths
-
-//Installed Module
-	mymob.hands = new /obj/abstract/screen
-	mymob.hands.icon = 'icons/mob/screen1_robot.dmi'
-	mymob.hands.icon_state = "nomod"
-	mymob.hands.name = "module"
-	mymob.hands.screen_loc = ui_borg_module
-
-	using.pointer_to_var = &mymob.hands
-
-//Module Panel
+	//Module Panel
 	using = new /obj/abstract/screen
 	using.name = "panel"
 	using.icon = 'icons/mob/screen1_robot.dmi'
@@ -122,44 +104,69 @@
 
 	using.pointer_to_list = &adding
 
-//Store
-	mymob.throw_icon = new /obj/abstract/screen
-	mymob.throw_icon.icon = 'icons/mob/screen1_robot.dmi'
-	mymob.throw_icon.icon_state = "store"
-	mymob.throw_icon.name = "store"
-	mymob.throw_icon.screen_loc = ui_borg_store
+//Health
+	using = new /obj/abstract/screen
+	using.icon = 'icons/mob/screen1_robot.dmi'
+	using.icon_state = "health0"
+	using.name = "health"
+	using.screen_loc = ui_borg_health
 
-	using.pointer_to_list = &adding
+	mymob.healths = using
+	using.pointer_to_var = &mymob.healths
+
+//Installed Module
+	using = new /obj/abstract/screen
+	using.icon = 'icons/mob/screen1_robot.dmi'
+	using.icon_state = "nomod"
+	using.name = "module"
+	using.screen_loc = ui_borg_module
+
+	mymob.hands = using
+	mymob.hands.pointer_to_var = &mymob.hands
+
+//Store
+	using = new /obj/abstract/screen
+	using.icon = 'icons/mob/screen1_robot.dmi'
+	using.icon_state = "store"
+	using.name = "store"
+	using.screen_loc = ui_borg_store
+
+	mymob.throw_icon = using
+	using.pointer_to_var = &mymob.throw_icon
 
 //Photography stuff
-	mymob.camera_icon = new /obj/abstract/screen
-	mymob.camera_icon.icon = 'icons/mob/screen1_robot.dmi'
-	mymob.camera_icon.icon_state = "camera"
-	mymob.camera_icon.name = "Take Image"
-	mymob.camera_icon.screen_loc = ui_borg_camera
+	using = new /obj/abstract/screen
+	using.icon = 'icons/mob/screen1_robot.dmi'
+	using.icon_state = "camera"
+	using.name = "Take Image"
+	using.screen_loc = ui_borg_camera
+	mymob.camera_icon = using
 
-	mymob.camera_icon.pointer_to_var  = &mymob.camera_icon
+	using.pointer_to_var = &mymob.camera_icon
 
-	mymob.album_icon = new /obj/abstract/screen
-	mymob.album_icon.icon = 'icons/mob/screen1_robot.dmi'
-	mymob.album_icon.icon_state = "album"
-	mymob.album_icon.name = "View Images"
-	mymob.album_icon.screen_loc = ui_borg_album
+	using = new /obj/abstract/screen
+	using.icon = 'icons/mob/screen1_robot.dmi'
+	using.icon_state = "album"
+	using.name = "View Images"
+	using.screen_loc = ui_borg_album
+	mymob.album_icon = using
 
-	mymob.album_icon.pointer_to_var  = &mymob.album_icon
+	using.pointer_to_var  = &mymob.album_icon
 
-	mymob.pullin = new /obj/abstract/screen
-	mymob.pullin.icon = 'icons/mob/screen1_robot.dmi'
-	mymob.pullin.icon_state = "pull0"
-	mymob.pullin.name = "pull"
-	mymob.pullin.screen_loc = ui_borg_pull
+	using = new /obj/abstract/screen
+	using.icon = 'icons/mob/screen1_robot.dmi'
+	using.icon_state = "pull0"
+	using.name = "pull"
+	using.screen_loc = ui_borg_pull
+	mymob.album_icon = using
 
-	mymob.pullin.pointer_to_var  = &mymob.pullin
+	using.pointer_to_var  = &mymob.album_icon
 
 	mymob.zone_sel = new /obj/abstract/screen/zone_sel
 	mymob.zone_sel.icon = 'icons/mob/screen1_robot.dmi'
 	mymob.zone_sel.overlays.len = 0
 	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
+	mymob.zone_sel = using
 
 	mymob.zone_sel.pointer_to_var  = &mymob.zone_sel
 
@@ -193,7 +200,7 @@
 
 	mymob.client.reset_screen()
 
-	mymob.client.screen += list( mymob.throw_icon, mymob.zone_sel, mymob.hands, mymob.healths, mymob.pullin, mymob.gun_setting_icon, mymob.camera_icon, mymob.album_icon)
+	mymob.client.screen += list( mymob.throw_icon, using, mymob.hands, mymob.healths, using, mymob.gun_setting_icon, using, using)
 	mymob.client.screen += src.adding + src.other
 
 	return

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -158,17 +158,15 @@
 	using.icon_state = "pull0"
 	using.name = "pull"
 	using.screen_loc = ui_borg_pull
-	mymob.album_icon = using
+	mymob.pullin = using
 
-	using.pointer_to_var  = &mymob.album_icon
+	using.pointer_to_var  = &mymob.pullin
 
-	mymob.zone_sel = new /obj/abstract/screen/zone_sel
-	mymob.zone_sel.icon = 'icons/mob/screen1_robot.dmi'
-	mymob.zone_sel.overlays.len = 0
-	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
-	mymob.zone_sel = using
-
-	mymob.zone_sel.pointer_to_var  = &mymob.zone_sel
+	var/obj/abstract/screen/zone_sel/ZS = new /obj/abstract/screen/zone_sel
+	ZS.icon = 'icons/mob/screen1_robot.dmi'
+	ZS.overlays.len = 0
+	ZS.overlays += image('icons/mob/zone_sel.dmi', "[ZS.selecting]")
+	mymob.zone_sel = ZS
 
 	//Handle the gun settings buttons
 	mymob.gun_setting_icon = new /obj/abstract/screen/gun/mode
@@ -200,7 +198,7 @@
 
 	mymob.client.reset_screen()
 
-	mymob.client.screen += list( mymob.throw_icon, using, mymob.hands, mymob.healths, using, mymob.gun_setting_icon, using, using)
+	mymob.client.screen += list( mymob.throw_icon, mymob.zone_sel, mymob.hands, mymob.healths, mymob.pullin, mymob.gun_setting_icon, mymob.camera_icon, mymob.album_icon)
 	mymob.client.screen += src.adding + src.other
 
 	return

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -25,6 +25,37 @@
 	var/pointer_to_var
 
 /obj/abstract/screen/Destroy()
+	// Screens live in many places, in many lists, and many vars.
+	// Ideally, you should want to null the screen vars when the parent object is qdeleted.
+	// However, this cannot always be possible due to either technical debt, or in some cases the screen object being deleted without its parent being deleted.
+	// This pointer is here to tell the screen object where it lives and to `null` it appropriately.
+	// As a note, DM pointers are not *really* pointers. They can rather be viewed as tunnels.
+	// var/pointer = &object is basically creating a {object_holder_var, read_var["object"]} instruction.
+	// And *pointer = null is basically telling DM {object_holder_var, set_var["object"] = null} instruction [roughly speaking]..
+	// So this clever trick allows us to null the var holding us hostage WITHOUT knowing it by name.
+	// This is, by the way, an intended usage of pointers according to the ref.
+
+	// One weakness of this implementation is that the instruction {object_holder_var, read_var["object"]} holds an internal reference to object_holder_var.
+	// This should only be a problem if the screen obj's object_holder_var is destroyed but the HUD/screen obj isn't.
+	// This shouldn't happen.
+
+	// This block is wrapped in try/catch because if you use pointers wrong it throws a runtime and could crash the entire Destroy() proc. Better be safe than sorry.
+	try
+		if (pointer_to_var)
+			*pointer_to_var = null
+		if (pointer_to_list)
+			var/list/L = *pointer_to_list
+			L -= src
+		if (pointer_to_secondary_list)
+			var/list/L = *pointer_to_secondary_list
+			L -= src
+	catch (var/exception/E)
+		log_debug("Error in handling screen objects pointers. [E.name] at file [E.file] and [E.line]")
+
+	pointer_to_var = null
+	pointer_to_list = null
+	pointer_to_secondary_list = null
+
 	animate(src)
 	master = null
 	..()

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -20,6 +20,10 @@
 	appearance_flags = NO_CLIENT_COLOR
 	plane = HUD_PLANE
 
+	var/pointer_to_list
+	var/pointer_to_secondary_list
+	var/pointer_to_var
+
 /obj/abstract/screen/Destroy()
 	animate(src)
 	master = null


### PR DESCRIPTION
This one is by far the biggest offender. I'll put on the reasoning for the mechanics of this change here:

```
// Screens live in many places, in many lists, and many vars.
	// Ideally, you should want to null the screen vars when the parent object is qdeleted.
	// However, this cannot always be possible due to either technical debt, or in some cases the screen object being deleted without its parent being deleted.
	// This pointer is here to tell the screen object where it lives and to `null` it appropriately.
	// As a note, DM pointers are not *really* pointers. They can rather be viewed as tunnels.
	// var/pointer = &object is basically creating a {object_holder_var, read_var["object"]} instruction.
	// And *pointer = null is basically telling DM {object_holder_var, set_var["object"] = null} instruction [roughly speaking]..
	// So this clever trick allows us to null the var holding us hostage WITHOUT knowing it by name.
	// This is, by the way, an intended usage of pointers according to the ref.

	// One weakness of this implementation is that the instruction {object_holder_var, read_var["object"]} holds an internal reference to object_holder_var.
	// This should only be a problem if the screen obj's object_holder_var is destroyed but the HUD/screen obj isn't.
	// This shouldn't happen.
```

`x%` tested where x > 0 but x < 1. I spawned a human mob and inventory worked fine. I can't reliably reproduce those screen hard dels locally anyway. If that breaks stuff just revert it. It shouldn't.

Credits @Exxion for the idea.

# Why it's good for the game

Screen hard dels are probably the single biggest cause of lag we have on the entire server : 

```
	/obj/abstract/screen : 536
``` 
in a highpop round which is about 20% of the 2436 hard dels that were in this round