### PR TITLE
Itty Bitty ghettomed bugfix

### DIFF
--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -18,7 +18,7 @@
 /datum/surgery_step/internal/remove_embryo
 	allowed_tools = list(
 		/obj/item/tool/hemostat = 100,
-		"wirecutters" = 75,
+		/obj/item/tool/wirecutters = 75,
 		/obj/item/weapon/kitchen/utensil/fork = 20,
 		)
 	blood_level = 2
@@ -161,7 +161,7 @@
 	allowed_tools = list(
 		/obj/item/stack/nanopaste = 100,
 		/obj/item/tool/bonegel = 30,
-		"screwdriver" = 70,
+		/obj/item/tool/screwdriver = 70,
 		)
 
 	duration = 7 SECONDS
@@ -306,7 +306,7 @@
 
 	allowed_tools = list(
 		/obj/item/tool/hemostat = 100,
-		"wirecutters" = 75,
+		/obj/item/tool/wirecutters = 75,
 		/obj/item/weapon/kitchen/utensil/fork = 20,
 		)
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
Fixes an issue when using wirecutters and screwdriver for procedures would result in "you dont know what to do with this" message appearing.
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Why it's good
We love ghettomed.
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->

## How it was tested
tweaked the file to properly point to the wirecutters and screwdriver, worked as intended instead of "you don't know what to do" message.
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixes error message while using wirecutters or screwdrivers for ghetto surgery.
