### PR TITLE
Improves `GC_FINDREF` using built-in BYOND tools

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -163,8 +163,8 @@ List of hard deletions:"}
 	// 3 references which are a result of reference search:
 	// - FindRef(D) itself
 	// - garbage/fire(), where it has been located()
-	// - var/atom/movable/A, which is a local copying the thing
-	FINDREF_OUTPUT("we found [found]. Discarding this proc and callers, DM tells us there is [refcount(D) - 3] references hanging.")
+	// - var/atom/movable/A = D, which is a local copy of the thing
+	FINDREF_OUTPUT("we found [found]. Discarding this proc and callers, DM tells us we have [refcount(D) - 3] reference hanging.")
 
 /datum/subsystem/garbage/proc/LookForRefs(var/datum/D, var/datum/targ)
 	. = 0

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -160,7 +160,7 @@ List of hard deletions:"}
 		found += LookForRefs(R, D)
 	found += LookForRefs(world, D)
 	found += LookForListRefs(global.vars, D, null, "global.vars") //You can't pretend global is a datum like you can with clients and world. It'll compile, but throw completely nonsensical runtimes.
-	FINDREF_OUTPUT("we found [found]")
+	FINDREF_OUTPUT("we found [found]. DM tells us there is [refcount(D)] references hanging.")
 
 /datum/subsystem/garbage/proc/LookForRefs(var/datum/D, var/datum/targ)
 	. = 0

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -160,7 +160,11 @@ List of hard deletions:"}
 		found += LookForRefs(R, D)
 	found += LookForRefs(world, D)
 	found += LookForListRefs(global.vars, D, null, "global.vars") //You can't pretend global is a datum like you can with clients and world. It'll compile, but throw completely nonsensical runtimes.
-	FINDREF_OUTPUT("we found [found]. DM tells us there is [refcount(D)] references hanging.")
+	// 3 references which are a result of reference search:
+	// - FindRef(D) itself
+	// - garbage/fire(), where it has been located()
+	// - var/atom/movable/A, which is a local copying the thing
+	FINDREF_OUTPUT("we found [found]. Discarding this proc and callers, DM tells us there is [refcount(D) - 3] references hanging.")
 
 /datum/subsystem/garbage/proc/LookForRefs(var/datum/D, var/datum/targ)
 	. = 0


### PR DESCRIPTION
I found this while browsing the ref.
I found that it consistently overestimates references by 3.

To convince myself of it, I loaded a branch where I had taken care of screen hdels. I compared this with baseline. Because I managed to solve this hdel, FindRef() was accurate in its diagnosis.

However, if FindRef() finds 1, `refcount()` finds 4. With some experiment I was able to show that this is because refcount also counts local variables and duplicates. I explained where the 3 extra refs come from and substracted them.