### PR TITLE
Allows Syndicate Challengers to appear at 15 pop, down from 20.

### DIFF
--- a/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets_roundstart.dm
@@ -83,7 +83,7 @@
 	cost = 15
 	var/traitor_threshold = 4
 	var/additional_cost = 5
-	requirements = list(101,101,101,101,10,10,10,10,10,10)
+	requirements = list(101,101,101,20,10,10,10,10,10,10)
 	high_population_requirement = 15
 
 // -- Currently a copypaste of traitors. Could be fixed to be less copy & paste.


### PR DESCRIPTION
## What this does
This PR will lower the minimum pop down from 20 to 15 pop in order to roll Syndicate Challengers. This should cause it to appear more, since it's been notably absent for a good while now. 

Here are the last occurances of the mode:
02/16/2025
01/18/2025
01/15/2025
11/18/2024
Don't really know what happened on February 16th to push it into hiding, but here we are.

## Why it's good
modes should roll more than once every 6 months

## How it was tested
dilt looked at it with his arms crossed and nodded

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Challengers now can roll at 15pop.
 