### PR TITLE
Fixes some DB queries failing on some systems

### DIFF
--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -138,7 +138,7 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 			load_admins()
 			return
 
-		var/datum/DBQuery/query = SSdbcore.NewQuery("SELECT ckey, rank, level, flags FROM erro_admin")
+		var/datum/DBQuery/query = SSdbcore.NewQuery("SELECT `ckey`, `rank`, `level`, `flags` FROM erro_admin")
 		if(!query.Execute(FALSE))
 			message_admins("Error: [query.ErrorMsg()]")
 			log_sql("Error: [query.ErrorMsg()]")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -939,7 +939,7 @@ var/list/admin_verbs_mod = list(
 			to_chat(src, "You are already an admin.")
 			verbs -= /client/proc/readmin
 			return
-		var/datum/DBQuery/query = SSdbcore.NewQuery("SELECT ckey, rank, level, flags FROM erro_admin WHERE ckey = :ckey", list("ckey" = ckey))
+		var/datum/DBQuery/query = SSdbcore.NewQuery("SELECT `ckey`, `rank`, `level`, `flags` FROM erro_admin WHERE `ckey` = :ckey", list("ckey" = ckey))
 		if(!query.Execute())
 			log_sql("Error: [query.ErrorMsg()]")
 			qdel(query)


### PR DESCRIPTION
This one is rather easy to review. `level` is a reserved SQL keyword on some DB engines. Doesn't appear to be the case for the server (thankfully), but is definitively the case on my own local engine.  I couldn't log in as an admin even though all my other DB stuff worked, and I figured out this was why.