### PR TITLE
Updates the outdated SQL schemas that we have

### DIFF
--- a/SQL/feedback_schema.sql
+++ b/SQL/feedback_schema.sql
@@ -1,134 +1,368 @@
-CREATE TABLE `erro_admin` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `ckey` varchar(32) NOT NULL,
-  `rank` varchar(32) NOT NULL DEFAULT 'Administrator',
-  `level` int(2) NOT NULL DEFAULT '0',
-  `flags` int(16) NOT NULL DEFAULT '0',
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=latin1 ;
+-- phpMyAdmin SQL Dump
+-- version 5.2.1
+-- https://www.phpmyadmin.net/
+--
+-- Host: 127.0.0.1:3306
+-- Generation Time: Jun 07, 2025 at 04:52 PM
+-- Server version: 9.1.0
+-- PHP Version: 8.3.14
 
-CREATE TABLE `erro_admin_log` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+START TRANSACTION;
+
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+
+--
+-- Database: `feedback`
+--
+CREATE DATABASE IF NOT EXISTS `feedback` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+USE `feedback`;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `admin_sessions`
+--
+
+CREATE TABLE IF NOT EXISTS `admin_sessions` (
+  `sessID` char(36) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `ckey` varchar(255) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
+  `expires` datetime DEFAULT NULL,
+  `IP` varchar(255) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
+  PRIMARY KEY (`sessID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `customitems`
+--
+
+CREATE TABLE IF NOT EXISTS `customitems` (
+  `cuiCKey` varchar(36) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `cuiRealName` varchar(60) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `cuiPath` varchar(255) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `cuiDescription` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `cuiReason` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `cuiPropAdjust` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `cuiJobMask` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  PRIMARY KEY (`cuiCKey`,`cuiRealName`,`cuiPath`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `erro_admin`
+--
+
+CREATE TABLE IF NOT EXISTS `erro_admin` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `ckey` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `rank` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL DEFAULT 'Administrator',
+  `level` int NOT NULL DEFAULT '0',
+  `flags` int NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `erro_admin_log`
+--
+
+CREATE TABLE IF NOT EXISTS `erro_admin_log` (
+  `id` int NOT NULL AUTO_INCREMENT,
   `datetime` datetime NOT NULL,
-  `adminckey` varchar(32) NOT NULL,
-  `adminip` varchar(18) NOT NULL,
-  `log` text NOT NULL,
+  `adminckey` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `adminip` varchar(18) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `log` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=latin1 ;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
-CREATE TABLE `erro_ban` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `erro_ban`
+--
+
+CREATE TABLE IF NOT EXISTS `erro_ban` (
+  `id` int NOT NULL AUTO_INCREMENT,
   `bantime` datetime NOT NULL,
-  `serverip` varchar(32) NOT NULL,
-  `bantype` varchar(32) NOT NULL,
-  `reason` text NOT NULL,
-  `job` varchar(32) DEFAULT NULL,
-  `duration` int(11) NOT NULL,
-  `rounds` int(11) DEFAULT NULL,
+  `serverip` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `bantype` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `reason` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `job` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
+  `duration` int NOT NULL,
+  `rounds` int DEFAULT NULL,
   `expiration_time` datetime NOT NULL,
-  `ckey` varchar(32) NOT NULL,
-  `computerid` varchar(32) NOT NULL,
-  `ip` varchar(32) NOT NULL,
-  `a_ckey` varchar(32) NOT NULL,
-  `a_computerid` varchar(32) NOT NULL,
-  `a_ip` varchar(32) NOT NULL,
-  `who` text NOT NULL,
-  `adminwho` text NOT NULL,
-  `edits` text,
+  `ckey` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `computerid` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `ip` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `a_ckey` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `a_computerid` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `a_ip` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `who` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `adminwho` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `edits` text CHARACTER SET latin1 COLLATE latin1_swedish_ci,
   `unbanned` tinyint(1) DEFAULT NULL,
   `unbanned_datetime` datetime DEFAULT NULL,
-  `unbanned_ckey` varchar(32) DEFAULT NULL,
-  `unbanned_computerid` varchar(32) DEFAULT NULL,
-  `unbanned_ip` varchar(32) DEFAULT NULL,
+  `unbanned_ckey` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
+  `unbanned_computerid` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
+  `unbanned_ip` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
+  `unbanned_notification` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=latin1 ;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
-CREATE TABLE `erro_feedback` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `erro_connection_log`
+--
+
+CREATE TABLE IF NOT EXISTS `erro_connection_log` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `datetime` datetime DEFAULT NULL,
+  `serverip` varchar(45) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
+  `ckey` varchar(45) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
+  `ip` varchar(18) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
+  `computerid` varchar(45) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `erro_feedback`
+--
+
+CREATE TABLE IF NOT EXISTS `erro_feedback` (
+  `id` int NOT NULL AUTO_INCREMENT,
   `time` datetime NOT NULL,
-  `round_id` int(8) NOT NULL,
-  `var_name` varchar(32) NOT NULL,
-  `var_value` int(16) DEFAULT NULL,
-  `details` text,
+  `round_id` int NOT NULL,
+  `var_name` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `var_value` int DEFAULT NULL,
+  `details` text CHARACTER SET latin1 COLLATE latin1_swedish_ci,
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM  DEFAULT CHARSET=latin1 ;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
-CREATE TABLE `erro_player` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `ckey` varchar(32) NOT NULL,
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `erro_player`
+--
+
+CREATE TABLE IF NOT EXISTS `erro_player` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `ckey` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
   `firstseen` datetime NOT NULL,
   `lastseen` datetime NOT NULL,
-  `ip` varchar(18) NOT NULL,
-  `computerid` varchar(32) NOT NULL,
-  `lastadminrank` varchar(32) NOT NULL DEFAULT 'Player',
-  `accountjoined` date NULL,
+  `ip` varchar(18) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `computerid` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `lastadminrank` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL DEFAULT 'Player',
+  `accountjoined` date DEFAULT NULL,
+  `fingerprint` varchar(255) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `ckey` (`ckey`)
-) ENGINE=InnoDB  DEFAULT CHARSET=latin1 ;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
-CREATE TABLE `erro_poll_option` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `pollid` int(11) NOT NULL,
-  `text` varchar(255) NOT NULL,
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `erro_poll_option`
+--
+
+CREATE TABLE IF NOT EXISTS `erro_poll_option` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `pollid` int NOT NULL,
+  `text` varchar(255) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
   `percentagecalc` tinyint(1) NOT NULL DEFAULT '1',
-  `minval` int(3) DEFAULT NULL,
-  `maxval` int(3) DEFAULT NULL,
-  `descmin` varchar(32) DEFAULT NULL,
-  `descmid` varchar(32) DEFAULT NULL,
-  `descmax` varchar(32) DEFAULT NULL,
+  `minval` int DEFAULT NULL,
+  `maxval` int DEFAULT NULL,
+  `descmin` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
+  `descmid` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
+  `descmax` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=latin1 ;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
-CREATE TABLE `erro_poll_question` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `polltype` varchar(16) NOT NULL DEFAULT 'OPTION',
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `erro_poll_question`
+--
+
+CREATE TABLE IF NOT EXISTS `erro_poll_question` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `polltype` varchar(16) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL DEFAULT 'OPTION',
   `starttime` datetime NOT NULL,
   `endtime` datetime NOT NULL,
-  `question` varchar(255) NOT NULL,
+  `question` varchar(255) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
   `adminonly` tinyint(1) DEFAULT '0',
-  `multiplechoiceoptions` int(2) DEFAULT NULL,
-  `createdby_ckey` varchar(45) NULL DEFAULT NULL,
-  `createdby_ip` varchar(45) NULL DEFAULT NULL,
+  `multiplechoiceoptions` int DEFAULT NULL,
+  `createdby_ckey` varchar(45) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
+  `createdby_ip` varchar(45) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
+  `hidden` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=latin1 ;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
-CREATE TABLE `erro_poll_textreply` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `erro_poll_textreply`
+--
+
+CREATE TABLE IF NOT EXISTS `erro_poll_textreply` (
+  `id` int NOT NULL AUTO_INCREMENT,
   `datetime` datetime NOT NULL,
-  `pollid` int(11) NOT NULL,
+  `pollid` int NOT NULL,
+  `ckey` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `ip` varchar(18) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `replytext` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `adminrank` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL DEFAULT 'Player',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `erro_poll_vote`
+--
+
+CREATE TABLE IF NOT EXISTS `erro_poll_vote` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `datetime` datetime NOT NULL,
+  `pollid` int NOT NULL,
+  `optionid` int NOT NULL,
+  `ckey` varchar(255) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `ip` varchar(16) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `adminrank` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `rating` int DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `erro_privacy`
+--
+
+CREATE TABLE IF NOT EXISTS `erro_privacy` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `datetime` datetime NOT NULL,
+  `ckey` varchar(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `option` varchar(128) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `karma`
+--
+
+CREATE TABLE IF NOT EXISTS `karma` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `spendername` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `spenderkey` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `receivername` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `receiverkey` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `receiverrole` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `receiverspecial` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `isnegative` tinyint(1) NOT NULL,
+  `spenderip` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `time` datetime NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `karmatotals`
+--
+
+CREATE TABLE IF NOT EXISTS `karmatotals` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `byondkey` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `karma` int NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `library`
+--
+
+CREATE TABLE IF NOT EXISTS `library` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `author` mediumtext NOT NULL,
+  `title` mediumtext NOT NULL,
+  `content` mediumtext NOT NULL,
+  `category` mediumtext NOT NULL,
+  `description` mediumtext NOT NULL,
   `ckey` varchar(32) NOT NULL,
-  `ip` varchar(18) NOT NULL,
-  `replytext` text NOT NULL,
-  `adminrank` varchar(32) NOT NULL DEFAULT 'Player',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=latin1 ;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
-CREATE TABLE `erro_poll_vote` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `datetime` datetime NOT NULL,
-  `pollid` int(11) NOT NULL,
-  `optionid` int(11) NOT NULL,
-  `ckey` varchar(255) NOT NULL,
-  `ip` varchar(16) NOT NULL,
-  `adminrank` varchar(32) NOT NULL,
-  `rating` int(2) DEFAULT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=latin1 ;
+-- --------------------------------------------------------
 
-CREATE TABLE `erro_privacy` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `datetime` datetime NOT NULL,
-  `ckey` varchar(32) NOT NULL,
-  `option` varchar(128) NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=latin1 ;
+--
+-- Table structure for table `painting_db`
+--
 
-CREATE TABLE IF NOT EXISTS erro_connection_log (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `datetime` datetime DEFAULT NULL,
-  `serverip` varchar(45) DEFAULT NULL,
-  `ckey` varchar(45) DEFAULT NULL,
-  `ip` varchar(18) DEFAULT NULL,
-  `computerid` varchar(45) DEFAULT NULL,
+CREATE TABLE IF NOT EXISTS `painting_db` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `author` text CHARACTER SET latin1 COLLATE latin1_swedish_ci,
+  `title` text CHARACTER SET latin1 COLLATE latin1_swedish_ci,
+  `content` text CHARACTER SET latin1 COLLATE latin1_swedish_ci,
+  `category` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `description` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `ckey` text CHARACTER SET latin1 COLLATE latin1_swedish_ci,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB  DEFAULT CHARSET=latin1 ;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `population`
+--
+
+CREATE TABLE IF NOT EXISTS `population` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `playercount` int DEFAULT NULL,
+  `admincount` int DEFAULT NULL,
+  `time` datetime NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `testdb`
+--
+
+CREATE TABLE IF NOT EXISTS `testdb` (
+  `id` int NOT NULL,
+  `text` text CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `_migrations`
+--
+
+CREATE TABLE IF NOT EXISTS `_migrations` (
+  `pkgID` varchar(15) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `version` int NOT NULL,
+  PRIMARY KEY (`pkgID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+COMMIT;
+
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;

--- a/SQL/players2.sql
+++ b/SQL/players2.sql
@@ -1,102 +1,148 @@
-CREATE TABLE `body` (
-        `ID`                            INTEGER PRIMARY KEY AUTOINCREMENT,
-        `player_ckey`           TEXT NOT NULL,
-        `player_slot`           INTEGER NOT NULL,
-        `hair_red`                      INTEGER,
-        `hair_green`            INTEGER,
-        `hair_blue`                     INTEGER,
-        `facial_red`            INTEGER,
-        `facial_green`          INTEGER,
-        `facial_blue`           INTEGER,
-        `skin_tone`                     INTEGER,
-        `hair_style_name`       TEXT,
-        `facial_style_name`     TEXT,
-        `eyes_red`                      INTEGER,
-        `eyes_green`            INTEGER,
-        `eyes_blue`                     INTEGER,
-        `underwear`                     INTEGER,
-        `backbag`                       INTEGER,
-        `b_type`                        TEXT,
-        FOREIGN KEY(player_ckey, player_slot) REFERENCES players(player_ckey, player_slot) ON DELETE CASCADE,
-        UNIQUE(player_ckey, player_slot)
+
+-- Table: players
+CREATE TABLE players (
+    ID                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    player_ckey         TEXT    NOT NULL,
+    player_slot         INTEGER NOT NULL,
+    ooc_notes           TEXT,
+    real_name           TEXT,
+    random_name         INTEGER,
+    random_body         INTEGER,
+    gender              TEXT,
+    age                 INTEGER,
+    species             TEXT,
+    language            TEXT,
+    med_record          TEXT,
+    sec_record          TEXT,
+    gen_record          TEXT,
+    player_alt_titles   TEXT,
+    be_special          TEXT,
+    disabilities        INTEGER,
+    nanotrasen_relation TEXT,
+    bank_security 		INTEGER,
+    wage_ratio  		INTEGER,
+    UNIQUE ( player_ckey, player_slot )
 );
-CREATE TABLE `jobs` (
-        `ID`                            INTEGER PRIMARY KEY AUTOINCREMENT,
-        `player_ckey`           TEXT NOT NULL,
-        `player_slot`           INTEGER NOT NULL,
-        `alternate_option`      INTEGER,
-        `job_civilian_high`     INTEGER,
-        `job_civilian_med`      INTEGER,
-        `job_civilian_low`      INTEGER,
-        `job_medsci_high`       INTEGER,
-        `job_medsci_med`        INTEGER,
-        `job_medsci_low`        INTEGER,
-        `job_engsec_high`       INTEGER,
-        `job_engsec_med`        INTEGER,
-        `job_engsec_low`        INTEGER, jobs TEXT,
-        FOREIGN KEY(player_ckey, player_slot) REFERENCES players(player_ckey, player_slot) ON DELETE CASCADE,
-        UNIQUE(player_ckey, player_slot)
+
+
+-- Table: body
+CREATE TABLE body (
+    ID                INTEGER PRIMARY KEY AUTOINCREMENT,
+    player_ckey       TEXT    NOT NULL,
+    player_slot       INTEGER NOT NULL,
+    hair_red          INTEGER,
+    hair_green        INTEGER,
+    hair_blue         INTEGER,
+    facial_red        INTEGER,
+    facial_green      INTEGER,
+    facial_blue       INTEGER,
+    skin_tone         INTEGER,
+    hair_style_name   TEXT,
+    facial_style_name TEXT,
+    eyes_red          INTEGER,
+    eyes_green        INTEGER,
+    eyes_blue         INTEGER,
+    underwear         INTEGER,
+    backbag           INTEGER,
+    b_type            TEXT,
+    FOREIGN KEY ( player_ckey, player_slot ) REFERENCES players ( player_ckey, player_slot ) ON DELETE CASCADE,
+    UNIQUE ( player_ckey, player_slot )
 );
-CREATE TABLE `players` (
-        `ID`                                    INTEGER PRIMARY KEY AUTOINCREMENT,
-        `player_ckey`                   TEXT NOT NULL,
-        `player_slot`                   INTEGER NOT NULL,
-        `ooc_notes`                             TEXT,
-        `real_name`                             TEXT,
-        `random_name`                   INTEGER,
-        `gender`                                TEXT,
-        `age`                                   INTEGER,
-        `species`                               TEXT,
-        `language`                              TEXT,
-        `flavor_text`                   TEXT,
-        `med_record`                    TEXT,
-        `sec_record`                    TEXT,
-        `gen_record`                    TEXT,
-        `player_alt_titles`             TEXT,
-        `be_special`                    TEXT,
-        `disabilities`                  INTEGER,
-        `nanotrasen_relation`   TEXT, random_body INTEGER DEFAULT 0, bank_security INTEGER DEFAULT 1, wage_ratio,
-        UNIQUE(player_ckey, player_slot)
+
+
+-- Table: jobs
+CREATE TABLE jobs (
+    ID                INTEGER PRIMARY KEY AUTOINCREMENT,
+    player_ckey       TEXT    NOT NULL,
+    player_slot       INTEGER NOT NULL,
+    alternate_option  INTEGER,
+    job_civilian_high INTEGER,
+    job_civilian_med  INTEGER,
+    job_civilian_low  INTEGER,
+    job_medsci_high   INTEGER,
+    job_medsci_med    INTEGER,
+    job_medsci_low    INTEGER,
+    job_engsec_high   INTEGER,
+    job_engsec_med    INTEGER,
+    job_engsec_low    INTEGER,
+    jobs              TEXT,
+    FOREIGN KEY ( player_ckey, player_slot ) REFERENCES players ( player_ckey, player_slot ) ON DELETE CASCADE,
+    UNIQUE ( player_ckey, player_slot )
 );
-CREATE TABLE [client_roles] ([ckey] TEXT NOT NULL, [slot] INTEGER NOT NULL, [role] TEXT NOT NULL, [preference] INTEGER NOT NULL, PRIMARY KEY ([ckey], [slot], [role]), FOREIGN KEY ([ckey], [slot]) REFERENCES [players] ([player_ckey], [player_slot]) ON DELETE CASCADE);
-CREATE TABLE IF NOT EXISTS "limbs" (
-        `ID`    INTEGER PRIMARY KEY AUTOINCREMENT,
-        `player_ckey`   TEXT NOT NULL,
-        `player_slot`   INTEGER NOT NULL,
-        `l_arm` TEXT,
-        `r_arm` TEXT,
-        `l_leg` TEXT,
-        `r_leg` TEXT,
-        `l_foot`        TEXT,
-        `r_foot`        TEXT,
-        `l_hand`        TEXT,
-        `r_hand`        TEXT,
-        `heart` TEXT,
-        `eyes`  TEXT,
-        `lungs` TEXT,
-        `kidneys`       TEXT,
-        `liver` TEXT
+
+
+-- Table: limbs
+CREATE TABLE limbs (
+    ID          INTEGER PRIMARY KEY AUTOINCREMENT,
+    player_ckey TEXT    NOT NULL,
+    player_slot INTEGER NOT NULL,
+    l_arm       TEXT,
+    r_arm       TEXT,
+    l_leg       TEXT,
+    r_leg       TEXT,
+    l_foot      TEXT,
+    r_foot      TEXT,
+    l_hand      TEXT,
+    r_hand      TEXT,
+    heart       TEXT,
+    eyes        TEXT,
+    FOREIGN KEY ( player_ckey, player_slot ) REFERENCES players ( player_ckey, player_slot ) ON DELETE CASCADE,
+    UNIQUE ( player_ckey, player_slot )
 );
-CREATE TABLE IF NOT EXISTS "client" (
-        `ID`    INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-        `ckey`  INTEGER UNIQUE,
-        `ooc_color`     TEXT,
-        `lastchangelog` TEXT,
-        `UI_style`      TEXT,
-        `default_slot`  INTEGER,
-        `toggles`       INTEGER,
-        `UI_style_color`        TEXT,
-        `UI_style_alpha`        INTEGER,
-        `randomslot`    INTEGER,
-        `volume`        INTEGER,
-        `special`       INTEGER,
-        `warns` INTEGER,
-        `warnbans`      INTEGER,
-        `usewmp`        INTEGER,
-        `usenanoui`     INTEGER
-, progress_bars INTEGER DEFAULT 1, space_parallax INTEGER DEFAULT 1, space_dust INTEGER DEFAULT 1, parallax_speed INTEGER DEFAULT 2, tooltips INTEGER DEFAULT 1, stumble INTEGER DEFAULT 0, attack_animation INTEGER DEFAULT 0, pulltoggle INTEGER DEFAULT 1, credits TEXT DEFAULT 'Always', jingle TEXT DEFAULT 'Classics', hear_voicesound INTEGER DEFAULT 0, hear_instruments INTEGER DEFAULT 1, ambience_volume INTEGER DEFAULT 25, credits_volume INTEGER DEFAULT 75, window_flashing INTEGER DEFAULT 1, antag_objectives INTEGER DEFAULT 0, typing_indicator INTEGER DEFAULT 0, mob_chat_on_map INTEGER DEFAULT 0, max_chat_length INTEGER DEFAULT 68, obj_chat_on_map INTEGER DEFAULT 0, no_goonchat_for_obj INTEGER DEFAULT 0, tgui_fancy INTEGER DEFAULT 1, show_warning_next_time INTEGER DEFAULT 0, last_warned_message TEXT DEFAULT '', warning_admin TEXT DEFAULT '', fps INTEGER DEFAULT 0, headset_sound);
-CREATE TABLE _migrations (
-        pkgID TEXT NOT NULL,
-        version INTEGER NOT NULL,
-        PRIMARY KEY(pkgID)
+
+
+-- Table: client
+CREATE TABLE client (
+    ID             INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    ckey           INTEGER UNIQUE,
+    ooc_color      TEXT,
+    lastchangelog  TEXT,
+    UI_style       TEXT,
+    default_slot   INTEGER,
+    toggles        INTEGER,
+    UI_style_color TEXT,
+    UI_style_alpha INTEGER,
+    randomslot     INTEGER,
+    volume         INTEGER,
+    special        INTEGER,
+    warns          INTEGER,
+    warnbans       INTEGER,
+    usewmp         INTEGER,
+    usenanoui      INTEGER,
+    tooltips       INTEGER,
+    space_parallax INTEGER,
+    space_dust     INTEGER,
+    parallax_speed INTEGER,
+    stumble        INTEGER,
+    attack_animation INTEGER,
+    pulltoggle     INTEGER,
+    credits        TEXT,
+    jingle         TEXT,
+    hear_voicesound INTEGER,
+    hear_instruments INTEGER,
+    ambience_volume INTEGER,
+    credits_volume INTEGER,
+    headset_sound INTEGER,
+    antag_objectives INTEGER,
+	typing_indicator INTEGER,
+	mob_chat_on_map INTEGER,
+	max_chat_length INTEGER,
+	obj_chat_on_map INTEGER,
+	no_goonchat_for_obj INTEGER,
+	tgui_fancy INTEGER,
+	show_warning_next_time INTEGER DEFAULT 0,
+	last_warned_message TEXT DEFAULT '',
+	warning_admin TEXT DEFAULT '',
+	fps INTEGER DEFAULT 0
+);
+
+
+-- Table: client_roles
+CREATE TABLE client_roles (
+    ckey       TEXT    NOT NULL,
+    slot       INTEGER NOT NULL,
+    role       TEXT    NOT NULL,
+    preference INTEGER NOT NULL,
+    PRIMARY KEY ( ckey, slot, role ),
+    FOREIGN KEY ( ckey, slot ) REFERENCES players ( player_ckey, player_slot ) ON DELETE CASCADE
 );

--- a/SQL/players2.sql
+++ b/SQL/players2.sql
@@ -1,148 +1,102 @@
-
--- Table: players
-CREATE TABLE players (
-    ID                  INTEGER PRIMARY KEY AUTOINCREMENT,
-    player_ckey         TEXT    NOT NULL,
-    player_slot         INTEGER NOT NULL,
-    ooc_notes           TEXT,
-    real_name           TEXT,
-    random_name         INTEGER,
-    random_body         INTEGER,
-    gender              TEXT,
-    age                 INTEGER,
-    species             TEXT,
-    language            TEXT,
-    med_record          TEXT,
-    sec_record          TEXT,
-    gen_record          TEXT,
-    player_alt_titles   TEXT,
-    be_special          TEXT,
-    disabilities        INTEGER,
-    nanotrasen_relation TEXT,
-    bank_security 		INTEGER,
-    wage_ratio  		INTEGER,
-    UNIQUE ( player_ckey, player_slot )
+CREATE TABLE `body` (
+        `ID`                            INTEGER PRIMARY KEY AUTOINCREMENT,
+        `player_ckey`           TEXT NOT NULL,
+        `player_slot`           INTEGER NOT NULL,
+        `hair_red`                      INTEGER,
+        `hair_green`            INTEGER,
+        `hair_blue`                     INTEGER,
+        `facial_red`            INTEGER,
+        `facial_green`          INTEGER,
+        `facial_blue`           INTEGER,
+        `skin_tone`                     INTEGER,
+        `hair_style_name`       TEXT,
+        `facial_style_name`     TEXT,
+        `eyes_red`                      INTEGER,
+        `eyes_green`            INTEGER,
+        `eyes_blue`                     INTEGER,
+        `underwear`                     INTEGER,
+        `backbag`                       INTEGER,
+        `b_type`                        TEXT,
+        FOREIGN KEY(player_ckey, player_slot) REFERENCES players(player_ckey, player_slot) ON DELETE CASCADE,
+        UNIQUE(player_ckey, player_slot)
 );
-
-
--- Table: body
-CREATE TABLE body (
-    ID                INTEGER PRIMARY KEY AUTOINCREMENT,
-    player_ckey       TEXT    NOT NULL,
-    player_slot       INTEGER NOT NULL,
-    hair_red          INTEGER,
-    hair_green        INTEGER,
-    hair_blue         INTEGER,
-    facial_red        INTEGER,
-    facial_green      INTEGER,
-    facial_blue       INTEGER,
-    skin_tone         INTEGER,
-    hair_style_name   TEXT,
-    facial_style_name TEXT,
-    eyes_red          INTEGER,
-    eyes_green        INTEGER,
-    eyes_blue         INTEGER,
-    underwear         INTEGER,
-    backbag           INTEGER,
-    b_type            TEXT,
-    FOREIGN KEY ( player_ckey, player_slot ) REFERENCES players ( player_ckey, player_slot ) ON DELETE CASCADE,
-    UNIQUE ( player_ckey, player_slot )
+CREATE TABLE `jobs` (
+        `ID`                            INTEGER PRIMARY KEY AUTOINCREMENT,
+        `player_ckey`           TEXT NOT NULL,
+        `player_slot`           INTEGER NOT NULL,
+        `alternate_option`      INTEGER,
+        `job_civilian_high`     INTEGER,
+        `job_civilian_med`      INTEGER,
+        `job_civilian_low`      INTEGER,
+        `job_medsci_high`       INTEGER,
+        `job_medsci_med`        INTEGER,
+        `job_medsci_low`        INTEGER,
+        `job_engsec_high`       INTEGER,
+        `job_engsec_med`        INTEGER,
+        `job_engsec_low`        INTEGER, jobs TEXT,
+        FOREIGN KEY(player_ckey, player_slot) REFERENCES players(player_ckey, player_slot) ON DELETE CASCADE,
+        UNIQUE(player_ckey, player_slot)
 );
-
-
--- Table: jobs
-CREATE TABLE jobs (
-    ID                INTEGER PRIMARY KEY AUTOINCREMENT,
-    player_ckey       TEXT    NOT NULL,
-    player_slot       INTEGER NOT NULL,
-    alternate_option  INTEGER,
-    job_civilian_high INTEGER,
-    job_civilian_med  INTEGER,
-    job_civilian_low  INTEGER,
-    job_medsci_high   INTEGER,
-    job_medsci_med    INTEGER,
-    job_medsci_low    INTEGER,
-    job_engsec_high   INTEGER,
-    job_engsec_med    INTEGER,
-    job_engsec_low    INTEGER,
-    jobs              TEXT,
-    FOREIGN KEY ( player_ckey, player_slot ) REFERENCES players ( player_ckey, player_slot ) ON DELETE CASCADE,
-    UNIQUE ( player_ckey, player_slot )
+CREATE TABLE `players` (
+        `ID`                                    INTEGER PRIMARY KEY AUTOINCREMENT,
+        `player_ckey`                   TEXT NOT NULL,
+        `player_slot`                   INTEGER NOT NULL,
+        `ooc_notes`                             TEXT,
+        `real_name`                             TEXT,
+        `random_name`                   INTEGER,
+        `gender`                                TEXT,
+        `age`                                   INTEGER,
+        `species`                               TEXT,
+        `language`                              TEXT,
+        `flavor_text`                   TEXT,
+        `med_record`                    TEXT,
+        `sec_record`                    TEXT,
+        `gen_record`                    TEXT,
+        `player_alt_titles`             TEXT,
+        `be_special`                    TEXT,
+        `disabilities`                  INTEGER,
+        `nanotrasen_relation`   TEXT, random_body INTEGER DEFAULT 0, bank_security INTEGER DEFAULT 1, wage_ratio,
+        UNIQUE(player_ckey, player_slot)
 );
-
-
--- Table: limbs
-CREATE TABLE limbs (
-    ID          INTEGER PRIMARY KEY AUTOINCREMENT,
-    player_ckey TEXT    NOT NULL,
-    player_slot INTEGER NOT NULL,
-    l_arm       TEXT,
-    r_arm       TEXT,
-    l_leg       TEXT,
-    r_leg       TEXT,
-    l_foot      TEXT,
-    r_foot      TEXT,
-    l_hand      TEXT,
-    r_hand      TEXT,
-    heart       TEXT,
-    eyes        TEXT,
-    FOREIGN KEY ( player_ckey, player_slot ) REFERENCES players ( player_ckey, player_slot ) ON DELETE CASCADE,
-    UNIQUE ( player_ckey, player_slot )
+CREATE TABLE [client_roles] ([ckey] TEXT NOT NULL, [slot] INTEGER NOT NULL, [role] TEXT NOT NULL, [preference] INTEGER NOT NULL, PRIMARY KEY ([ckey], [slot], [role]), FOREIGN KEY ([ckey], [slot]) REFERENCES [players] ([player_ckey], [player_slot]) ON DELETE CASCADE);
+CREATE TABLE IF NOT EXISTS "limbs" (
+        `ID`    INTEGER PRIMARY KEY AUTOINCREMENT,
+        `player_ckey`   TEXT NOT NULL,
+        `player_slot`   INTEGER NOT NULL,
+        `l_arm` TEXT,
+        `r_arm` TEXT,
+        `l_leg` TEXT,
+        `r_leg` TEXT,
+        `l_foot`        TEXT,
+        `r_foot`        TEXT,
+        `l_hand`        TEXT,
+        `r_hand`        TEXT,
+        `heart` TEXT,
+        `eyes`  TEXT,
+        `lungs` TEXT,
+        `kidneys`       TEXT,
+        `liver` TEXT
 );
-
-
--- Table: client
-CREATE TABLE client (
-    ID             INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-    ckey           INTEGER UNIQUE,
-    ooc_color      TEXT,
-    lastchangelog  TEXT,
-    UI_style       TEXT,
-    default_slot   INTEGER,
-    toggles        INTEGER,
-    UI_style_color TEXT,
-    UI_style_alpha INTEGER,
-    randomslot     INTEGER,
-    volume         INTEGER,
-    special        INTEGER,
-    warns          INTEGER,
-    warnbans       INTEGER,
-    usewmp         INTEGER,
-    usenanoui      INTEGER,
-    tooltips       INTEGER,
-    space_parallax INTEGER,
-    space_dust     INTEGER,
-    parallax_speed INTEGER,
-    stumble        INTEGER,
-    attack_animation INTEGER,
-    pulltoggle     INTEGER,
-    credits        TEXT,
-    jingle         TEXT,
-    hear_voicesound INTEGER,
-    hear_instruments INTEGER,
-    ambience_volume INTEGER,
-    credits_volume INTEGER,
-    headset_sound INTEGER,
-    antag_objectives INTEGER,
-	typing_indicator INTEGER,
-	mob_chat_on_map INTEGER,
-	max_chat_length INTEGER,
-	obj_chat_on_map INTEGER,
-	no_goonchat_for_obj INTEGER,
-	tgui_fancy INTEGER,
-	show_warning_next_time INTEGER DEFAULT 0,
-	last_warned_message TEXT DEFAULT '',
-	warning_admin TEXT DEFAULT '',
-	fps INTEGER DEFAULT 0
-);
-
-
--- Table: client_roles
-CREATE TABLE client_roles (
-    ckey       TEXT    NOT NULL,
-    slot       INTEGER NOT NULL,
-    role       TEXT    NOT NULL,
-    preference INTEGER NOT NULL,
-    PRIMARY KEY ( ckey, slot, role ),
-    FOREIGN KEY ( ckey, slot ) REFERENCES players ( player_ckey, player_slot ) ON DELETE CASCADE
+CREATE TABLE IF NOT EXISTS "client" (
+        `ID`    INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        `ckey`  INTEGER UNIQUE,
+        `ooc_color`     TEXT,
+        `lastchangelog` TEXT,
+        `UI_style`      TEXT,
+        `default_slot`  INTEGER,
+        `toggles`       INTEGER,
+        `UI_style_color`        TEXT,
+        `UI_style_alpha`        INTEGER,
+        `randomslot`    INTEGER,
+        `volume`        INTEGER,
+        `special`       INTEGER,
+        `warns` INTEGER,
+        `warnbans`      INTEGER,
+        `usewmp`        INTEGER,
+        `usenanoui`     INTEGER
+, progress_bars INTEGER DEFAULT 1, space_parallax INTEGER DEFAULT 1, space_dust INTEGER DEFAULT 1, parallax_speed INTEGER DEFAULT 2, tooltips INTEGER DEFAULT 1, stumble INTEGER DEFAULT 0, attack_animation INTEGER DEFAULT 0, pulltoggle INTEGER DEFAULT 1, credits TEXT DEFAULT 'Always', jingle TEXT DEFAULT 'Classics', hear_voicesound INTEGER DEFAULT 0, hear_instruments INTEGER DEFAULT 1, ambience_volume INTEGER DEFAULT 25, credits_volume INTEGER DEFAULT 75, window_flashing INTEGER DEFAULT 1, antag_objectives INTEGER DEFAULT 0, typing_indicator INTEGER DEFAULT 0, mob_chat_on_map INTEGER DEFAULT 0, max_chat_length INTEGER DEFAULT 68, obj_chat_on_map INTEGER DEFAULT 0, no_goonchat_for_obj INTEGER DEFAULT 0, tgui_fancy INTEGER DEFAULT 1, show_warning_next_time INTEGER DEFAULT 0, last_warned_message TEXT DEFAULT '', warning_admin TEXT DEFAULT '', fps INTEGER DEFAULT 0, headset_sound);
+CREATE TABLE _migrations (
+        pkgID TEXT NOT NULL,
+        version INTEGER NOT NULL,
+        PRIMARY KEY(pkgID)
 );


### PR DESCRIPTION
The SQL schema hasn't been updated in years. This used to be not a problem since migrations automagically brought users to the latest versions. Migrations don't work as well in 516 and I couldn't find a way to solve them as easily.

Regardless, having something up-to-date in the codebase for new users testing DBs is probably good. The schema was generated using PhPmyAdmin. I tried something similar for the SQLite but the output was ugly, so I didn't do it.