### PR TITLE
fix 404 on node download

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -11,7 +11,7 @@
 
 #node version
 export NODE_VERSION=16
-export NODE_VERSION_PRECISE=22.10
+export NODE_VERSION_PRECISE=22.10.0
 
 # SpacemanDMM git tag
 #export SPACEMAN_DMM_VERSION=suite-1.7.1


### PR DESCRIPTION
node fails to bootstrap as this generates a bad url
![image](https://github.com/user-attachments/assets/566cd8cb-8cc0-45dc-968c-36da00547c86)
![image](https://github.com/user-attachments/assets/aeed0ad6-ed3d-4dbf-8c60-6edba67507f4)

the correct path has a `.0` on the end

![image](https://github.com/user-attachments/assets/7b699957-74bc-4855-bac3-f234d1323150)
