### PR TITLE
Fixes certain toggles not saving for admins & ex-admins

### DIFF
--- a/code/modules/client/preferences/pref_datums.dm
+++ b/code/modules/client/preferences/pref_datums.dm
@@ -149,7 +149,7 @@
 // Binary flags
 /datum/preference_setting/binary_flag
 	default_setting = 0
-	var/max_binary_value = (1 << 12)
+	var/max_binary_value = (1 << 20)
 	var/toggles = list() // The actual flag toggles this is checking against
 
 /datum/preference_setting/binary_flag/sanitize_setting(var/new_setting)


### PR DESCRIPTION
Closes #37690
Pretty sure ex-admins/admins who have the admin prefs (who are a higher binary flag) values are more affected than others. However I might be wrong.