### PR TITLE
Rename vars that override internal vars

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -1,9 +1,9 @@
-/proc/dopage(src,target)
+/proc/dopage(source,target)
 	var/href_list
 	var/href
-	href_list = params2list("src=\ref[src]&[target]=1")
-	href = "src=\ref[src];[target]=1"
-	src:Topic(href, href_list)
+	href_list = params2list("src=\ref[source]&[target]=1")
+	href = "src=\ref[source];[target]=1"
+	source:Topic(href, href_list)
 	return null
 
 /proc/get_area(const/atom/O)

--- a/code/game/machinery/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
+++ b/code/game/machinery/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
@@ -56,13 +56,13 @@
 	
 /obj/machinery/atmospherics/trinary/proc/set_frequency(new_frequency)
 
-/obj/machinery/atmospherics/trinary/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+/obj/machinery/atmospherics/trinary/buildFrom(var/mob/user,var/obj/item/pipe/pipe)
 	if(!(pipe.dir in list(NORTH, SOUTH, EAST, WEST)) && src.mirror) //because the dir isn't in the right set, we want to make the mirror kind
 		var/obj/machinery/atmospherics/trinary/mirrored_pipe = new mirror(src.loc)
 		pipe.dir = turn(pipe.dir, -45)
 		qdel(src)
 		mirrored_pipe.setPipingLayer(pipe.piping_layer)
-		return mirrored_pipe.buildFrom(usr, pipe)
+		return mirrored_pipe.buildFrom(user, pipe)
 	dir = pipe.dir
 	initialize_directions = pipe.get_pipe_dir()
 	if (pipe.pipename)

--- a/code/game/machinery/ATMOSPHERICS/he_pipes.dm
+++ b/code/game/machinery/ATMOSPHERICS/he_pipes.dm
@@ -36,14 +36,14 @@
 	initialize_directions_he = initialize_directions	// The auto-detection from /pipe is good enough for a simple HE pipe
 	// BubbleWrap END
 
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/buildFrom(var/mob/user,var/obj/item/pipe/pipe)
 	dir = pipe.dir
 	initialize_directions = 0
 	initialize_directions_he = pipe.get_pipe_dir()
 	//var/turf/T = loc
 	//level = T.intact ? 2 : 1
 	if(!initialize(1))
-		to_chat(usr, "Unable to build pipe here;  It must be connected to a machine, or another pipe that has a connection.")
+		to_chat(user, "Unable to build pipe here;  It must be connected to a machine, or another pipe that has a connection.")
 		return 0
 	build_network()
 	if (node1)
@@ -181,12 +181,12 @@
 			initialize_directions_he = WEST
 	// BubbleWrap END
 
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/buildFrom(var/mob/user,var/obj/item/pipe/pipe)
 	dir = pipe.dir
 	initialize_directions = pipe.get_pdir()
 	initialize_directions_he = pipe.get_hdir()
 	if (!initialize(1))
-		to_chat(usr, "There's nothing to connect this junction to! (with how the pipe code works, at least one end needs to be connected to something, otherwise the game deletes the segment)")
+		to_chat(user, "There's nothing to connect this junction to! (with how the pipe code works, at least one end needs to be connected to something, otherwise the game deletes the segment)")
 		return 0
 	build_network()
 	if (node1)
@@ -242,12 +242,12 @@
 		if(WEST)
 			initialize_directions_he = NORTH|EAST|SOUTH
 
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold/buildFrom(var/mob/user,var/obj/item/pipe/pipe)
 	dir = pipe.dir
 	initialize_directions_he = pipe.get_hdir()
 	initialize(1)
 	if (!node1 && !node2 && !node3)
-		to_chat(usr, "There's nothing to connect this manifold to!")
+		to_chat(user, "There's nothing to connect this manifold to!")
 		return 0
 	build_network()
 	if (node1)
@@ -312,12 +312,12 @@
 	..()
 	initialize_directions_he = NORTH|SOUTH|EAST|WEST
 
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold4w/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/he_manifold4w/buildFrom(var/mob/user,var/obj/item/pipe/pipe)
 	dir = pipe.dir
 	initialize_directions_he = pipe.get_hdir()
 	initialize(1)
 	if (!node1 && !node2 && !node3 && !node4)
-		to_chat(usr, "There's nothing to connect this manifold to!")
+		to_chat(user, "There's nothing to connect this manifold to!")
 		return 0
 	build_network()
 	if (node1)

--- a/code/game/machinery/ATMOSPHERICS/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/ATMOSPHERICS/pipe/pipe_dispenser.dm
@@ -216,11 +216,11 @@ Nah
 */
 
 //Allow you to drag-drop disposal pipes into it
-/obj/machinery/pipedispenser/disposal/MouseDropTo(var/obj/structure/disposalconstruct/pipe, mob/usr)
-	if(!usr.canmove || usr.stat || usr.restrained())
+/obj/machinery/pipedispenser/disposal/MouseDropTo(var/obj/structure/disposalconstruct/pipe, mob/user)
+	if(!user.canmove || user.stat || user.restrained())
 		return
 
-	if (!istype(pipe) || get_dist(usr, src) > 1 || get_dist(src,pipe) > 2 )
+	if (!istype(pipe) || get_dist(user, src) > 1 || get_dist(src,pipe) > 2 )
 		return
 
 	if (pipe.anchored)

--- a/code/game/machinery/ATMOSPHERICS/pipes.dm
+++ b/code/game/machinery/ATMOSPHERICS/pipes.dm
@@ -149,7 +149,7 @@
 			initialize_directions = SOUTH|WEST
 	..()
 
-/obj/machinery/atmospherics/pipe/simple/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+/obj/machinery/atmospherics/pipe/simple/buildFrom(var/mob/user,var/obj/item/pipe/pipe)
 	dir = pipe.dir
 	initialize_directions = pipe.get_pipe_dir()
 	var/turf/T = loc
@@ -157,7 +157,7 @@
 	update_planes_and_layers()
 	initialize(1)
 	if(!node1&&!node2)
-		to_chat(usr, "<span class='warning'>There's nothing to connect this pipe section to! A pipe segment must be connected to at least one other object!</span>")
+		to_chat(user, "<span class='warning'>There's nothing to connect this pipe section to! A pipe segment must be connected to at least one other object!</span>")
 		return 0
 	update_icon()
 	build_network()
@@ -453,7 +453,7 @@
 	layer = PIPE_LAYER
 	var/global/image/manifold_centre = image('icons/obj/pipes.dmi',"manifold_centre")
 
-/obj/machinery/atmospherics/pipe/manifold/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+/obj/machinery/atmospherics/pipe/manifold/buildFrom(var/mob/user,var/obj/item/pipe/pipe)
 	dir = pipe.dir
 	initialize_directions = pipe.get_pipe_dir()
 	var/turf/T = loc
@@ -462,7 +462,7 @@
 
 	initialize(1)
 	if(!node1&&!node2&&!node3)
-		to_chat(usr, "<span class='warning'>There's nothing to connect this manifold to! A pipe segment must be connected to at least one other object!</span>")
+		to_chat(user, "<span class='warning'>There's nothing to connect this manifold to! A pipe segment must be connected to at least one other object!</span>")
 		return 0
 	update_icon() // Skipped in initialize()!
 	build_network()
@@ -703,7 +703,7 @@
 	var/global/image/manifold4w_centre = image('icons/obj/pipes.dmi',"manifold4w_centre")
 
 
-/obj/machinery/atmospherics/pipe/manifold4w/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+/obj/machinery/atmospherics/pipe/manifold4w/buildFrom(var/mob/user,var/obj/item/pipe/pipe)
 	dir = pipe.dir
 	initialize_directions = pipe.get_pipe_dir()
 	var/turf/T = loc
@@ -711,7 +711,7 @@
 	update_planes_and_layers()
 	initialize(1)
 	if(!node1 && !node2 && !node3 && !node4)
-		to_chat(usr, "<span class='warning'>There's nothing to connect this manifold to! A pipe segment must be connected to at least one other object!</span>")
+		to_chat(user, "<span class='warning'>There's nothing to connect this manifold to! A pipe segment must be connected to at least one other object!</span>")
 		return 0
 	update_icon()
 	build_network()
@@ -985,7 +985,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/setPipingLayer(var/new_layer = PIPING_LAYER_DEFAULT)
 	piping_layer = PIPING_LAYER_DEFAULT
 
-/obj/machinery/atmospherics/pipe/layer_manifold/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+/obj/machinery/atmospherics/pipe/layer_manifold/buildFrom(var/mob/user,var/obj/item/pipe/pipe)
 	dir = pipe.dir
 	initialize_directions = pipe.get_pipe_dir()
 	var/turf/T = loc
@@ -993,7 +993,7 @@
 	update_planes_and_layers()
 	initialize(1)
 	if(!(locate(/obj/machinery/atmospherics) in layer_nodes) && !other_node)
-		to_chat(usr, "<span class='warning'>There's nothing to connect this manifold to! A pipe segment must be connected to at least one other object!</span>")
+		to_chat(user, "<span class='warning'>There's nothing to connect this manifold to! A pipe segment must be connected to at least one other object!</span>")
 		return 0
 	update_icon()
 	build_network()
@@ -1195,7 +1195,7 @@
 /obj/machinery/atmospherics/pipe/layer_adapter/setPipingLayer(var/new_layer = PIPING_LAYER_DEFAULT)
 	piping_layer = new_layer
 
-/obj/machinery/atmospherics/pipe/layer_adapter/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+/obj/machinery/atmospherics/pipe/layer_adapter/buildFrom(var/mob/user,var/obj/item/pipe/pipe)
 	dir = pipe.dir
 	initialize_directions = pipe.get_pipe_dir()
 	var/turf/T = loc
@@ -1203,7 +1203,7 @@
 	update_planes_and_layers()
 	initialize(1)
 	if(!mid_node && !layer_node)
-		to_chat(usr, "<span class='warning'>There's nothing to connect this adapter to! A pipe segment must be connected to at least one other object!</span>")
+		to_chat(user, "<span class='warning'>There's nothing to connect this adapter to! A pipe segment must be connected to at least one other object!</span>")
 		return 0
 	update_icon()
 	build_network()

--- a/code/game/machinery/computer/arcade/arcade_game.dm
+++ b/code/game/machinery/computer/arcade/arcade_game.dm
@@ -17,10 +17,10 @@
 	if(isobserver(usr) && !isAdminGhost(usr) && !holder.haunted)
 		return TRUE
 
-/datum/arcade_game/proc/import_data(var/list/args)
-	if(!args || !args["arcade_type"])
+/datum/arcade_game/proc/import_data(var/list/arguments)
+	if(!arguments || !arguments["arcade_type"])
 		return 0
-	if(args["arcade_type"] != type)
+	if(arguments["arcade_type"] != type)
 		return 0
 	return 1
 
@@ -132,23 +132,23 @@
 				"arcade_type" = type,
 				)
 
-/datum/arcade_game/space_villain/import_data(var/list/args)
+/datum/arcade_game/space_villain/import_data(var/list/arguments)
 	if(!..())
 		return
-	name = args["name"]
-	emagged = args["emagged"]
-	enemy_name = args["enemy_name"]
-	temp = args["temp"]
-	player_hp = args["player_hp"]
-	player_max_hp = args["player_max_hp"]
-	player_mp = args["player_mp"]
-	player_max_mp = args["player_max_mp"]
-	enemy_hp = args["enemy_hp"]
-	enemy_max_hp = args["enemy_max_hp"]
-	enemy_mp = args["enemy_mp"]
-	enemy_max_mp = args["enemy_max_mp"]
-	gameover = args["gameover"]
-	blocked = args["blocked"]
+	name = arguments["name"]
+	emagged = arguments["emagged"]
+	enemy_name = arguments["enemy_name"]
+	temp = arguments["temp"]
+	player_hp = arguments["player_hp"]
+	player_max_hp = arguments["player_max_hp"]
+	player_mp = arguments["player_mp"]
+	player_max_mp = arguments["player_max_mp"]
+	enemy_hp = arguments["enemy_hp"]
+	enemy_max_hp = arguments["enemy_max_hp"]
+	enemy_mp = arguments["enemy_mp"]
+	enemy_max_mp = arguments["enemy_max_mp"]
+	gameover = arguments["gameover"]
+	blocked = arguments["blocked"]
 
 /datum/arcade_game/space_villain/get_dat()
 	var/dat = "<a href='byond://?src=\ref[src];close=1'>Close</a>"

--- a/code/game/objects/items/stacks/stack_recipes.dm
+++ b/code/game/objects/items/stacks/stack_recipes.dm
@@ -31,39 +31,39 @@
 	src.z_up_required = z_up_required
 	src.z_down_required = z_down_required
 
-/datum/stack_recipe/proc/can_build_here(var/mob/usr, var/turf/T)
+/datum/stack_recipe/proc/can_build_here(var/mob/user, var/turf/T)
 	if(one_per_turf && locate(result_type) in T)
-		to_chat(usr, "<span class='warning'>There is another [title] here!</span>")
+		to_chat(user, "<span class='warning'>There is another [title] here!</span>")
 		return 0
 	if(on_floor && (istype(T, /turf/space)))
-		to_chat(usr, "<span class='warning'>\The [title] must be constructed on solid floor!</span>")
+		to_chat(user, "<span class='warning'>\The [title] must be constructed on solid floor!</span>")
 		return 0
 	return 1
 
-/datum/stack_recipe/proc/finish_building(var/mob/usr, var/obj/item/stack/S, var/R) //This will be called after the recipe is done building, useful for doing something to the result if you want.
+/datum/stack_recipe/proc/finish_building(var/mob/user, var/obj/item/stack/S, var/R) //This will be called after the recipe is done building, useful for doing something to the result if you want.
 	return R
 
 /datum/stack_recipe/proc/before_build(var/mob/user)
 	return TRUE
 
-/datum/stack_recipe/proc/build(var/mob/usr, var/obj/item/stack/S, var/multiplier = 1, var/turf/construct_loc)
-	if (!before_build(usr))
+/datum/stack_recipe/proc/build(var/mob/user, var/obj/item/stack/S, var/multiplier = 1, var/turf/construct_loc)
+	if (!before_build(user))
 		return
 	if (S.amount < req_amount*multiplier)
 		if (res_amount*multiplier>1)
-			to_chat(usr, "<span class='warning'>You haven't got enough [S.irregular_plural ? S.irregular_plural : "[S.singular_name]\s"] to build [res_amount*multiplier] [title]\s!</span>")
+			to_chat(user, "<span class='warning'>You haven't got enough [S.irregular_plural ? S.irregular_plural : "[S.singular_name]\s"] to build [res_amount*multiplier] [title]\s!</span>")
 		else
-			to_chat(usr, "<span class='warning'>You haven't got enough [S.irregular_plural ? S.irregular_plural : "[S.singular_name]\s"] to build \the [title]!</span>")
+			to_chat(user, "<span class='warning'>You haven't got enough [S.irregular_plural ? S.irregular_plural : "[S.singular_name]\s"] to build \the [title]!</span>")
 		return
 	if(!construct_loc)
-		construct_loc = usr.loc
-	if (!can_build_here(usr, construct_loc))
+		construct_loc = user.loc
+	if (!can_build_here(user, construct_loc))
 		return
 	var/current_work = round(world.time)
 	S.last_work = current_work
 	if (time)
 		var/actual_time = S.time_modifier(time)
-		if (!do_after(usr, get_turf(S), actual_time))
+		if (!do_after(user, get_turf(S), actual_time))
 			S.stop_build(current_work == S.last_work)
 			return
 	if (S.amount < req_amount*multiplier)
@@ -77,17 +77,17 @@
 			var/found = FALSE
 			if(ispath(looking_for, /obj/item/stack))
 				req_amount = other_reqs[looking_for]
-			if(ispath(usr.get_inactive_hand(), looking_for))
+			if(ispath(user.get_inactive_hand(), looking_for))
 				found = TRUE
 				if(req_amount) //It's of a stack/sheet subtype
-					var/obj/item/stack/SS = usr.get_inactive_hand()
+					var/obj/item/stack/SS = user.get_inactive_hand()
 					if(SS.amount < req_amount)
 						found = FALSE
 					else
 						stacks_to_consume.Add(SS)
 						stacks_to_consume[S] = req_amount
 					continue
-			for(var/obj/I in range(get_turf(usr),1))
+			for(var/obj/I in range(get_turf(user),1))
 				if(ispath(looking_for, I))
 					found = TRUE
 					if(req_amount) //It's of a stack/sheet subtype
@@ -102,7 +102,7 @@
 				return
 	var/atom/O
 	if(ispath(result_type, /obj/item/stack))
-		O = drop_stack(result_type, construct_loc, (max_res_amount>1 ? res_amount*multiplier : 1), usr)
+		O = drop_stack(result_type, construct_loc, (max_res_amount>1 ? res_amount*multiplier : 1), user)
 		var/obj/item/stack/SS = O
 		SS.update_materials()
 	else
@@ -110,25 +110,25 @@
 			O = new result_type(construct_loc)
 
 	S.stop_build(current_work == S.last_work)
-	O.change_dir(usr.dir)
+	O.change_dir(user.dir)
 	if(start_unanchored)
 		var/obj/A = O
 		A.anchored = 0
-	var/put_in_hand = finish_building(usr, S, O)
+	var/put_in_hand = finish_building(user, S, O)
 
 	//if (R.max_res_amount>1)
 	//	var/obj/item/stack/new_item = O
 	//	new_item.amount = R.res_amount*multiplier
-	//	//new_item.add_to_stacks(usr)
+	//	//new_item.add_to_stacks(user)
 
 	S.use(req_amount*multiplier)
 	for(var/obj/item/stack/SS in stacks_to_consume)
 		SS.use(stacks_to_consume[SS])
 	if (S.amount<=0)
-		usr.before_take_item(S)
+		user.before_take_item(S)
 		if(put_in_hand && istype(O,/obj/item))
-			usr.put_in_hands(O)
-	O.add_fingerprint(usr)
+			user.put_in_hands(O)
+	O.add_fingerprint(user)
 	//BubbleWrap - so newly formed boxes are empty //This is pretty shitcode but I'm not fixing it because even if sloth is a sin I am already going to hell anyways
 	if (istype(O, /obj/item/weapon/storage) )
 		for(var/obj/item/I in O)
@@ -150,28 +150,28 @@
 /* =====================================================================
 							METAL RECIPES
 ===================================================================== */
-/datum/stack_recipe/chair/can_build_here(var/mob/usr, var/turf/T)
+/datum/stack_recipe/chair/can_build_here(var/mob/user, var/turf/T)
 	if(one_per_turf)
 		for(var/atom/movable/AM in T)
 			if(istype(AM, /obj/structure/bed/chair/vehicle)) //Bandaid to allow people in vehicles (and wheelchairs) build chairs
 				continue
 			else if(istype(AM, /obj/structure/bed/chair))
-				to_chat(usr, "<span class='warning'>There is already a chair here!</span>")
+				to_chat(user, "<span class='warning'>There is already a chair here!</span>")
 				return 0
 	if(on_floor && (istype(T, /turf/space)))
-		to_chat(usr, "<span class='warning'>\The [title] must be constructed on solid floor!</span>")
+		to_chat(user, "<span class='warning'>\The [title] must be constructed on solid floor!</span>")
 		return 0
 	return 1
 
-/datum/stack_recipe/chair/finish_building(var/mob/usr, var/obj/item/stack/S, var/R) //This will be called after the recipe is done building, useful for doing something to the result if you want.
+/datum/stack_recipe/chair/finish_building(var/mob/user, var/obj/item/stack/S, var/R) //This will be called after the recipe is done building, useful for doing something to the result if you want.
 	var/obj/structure/bed/chair/new_chair = R
 	if (istype(new_chair))
 		new_chair.handle_layer()
 	return R
 
-/datum/stack_recipe/conveyor_frame/can_build_here(var/mob/usr, var/turf/T)
+/datum/stack_recipe/conveyor_frame/can_build_here(var/mob/user, var/turf/T)
 	if(on_floor && (istype(T, /turf/space)))
-		to_chat(usr, "<span class='warning'>\The [title] must be constructed on solid floor!</span>")
+		to_chat(user, "<span class='warning'>\The [title] must be constructed on solid floor!</span>")
 		return 0
 	return 1
 
@@ -185,7 +185,7 @@
 	src.gen_quality = gen_quality
 
 
-/datum/stack_recipe/dorf/finish_building(mob/usr, var/obj/item/stack/S, var/obj/R)
+/datum/stack_recipe/dorf/finish_building(mob/user, var/obj/item/stack/S, var/obj/R)
 	if(inherit_material)
 		var/datum/material/mat
 		var/datum/materials/materials_list = new
@@ -224,7 +224,7 @@
 	..()
 	src.req_strikes = required_strikes
 
-/datum/stack_recipe/blacksmithing/finish_building(mob/usr, var/obj/item/stack/S, var/obj/R)
+/datum/stack_recipe/blacksmithing/finish_building(mob/user, var/obj/item/stack/S, var/obj/R)
 	// Figure out main material from stack
 	if(istype(S, /obj/item/stack/sheet/))
 		var/obj/item/stack/sheet/SS = S
@@ -251,7 +251,7 @@
 			R.materials.addRatioFrom(A.materials, other_reqs[req]/res_amount)
 
 	//Yeah nah let's put you in a blacksmith_placeholder
-	var/obj/item/I = new /obj/item/smithing_placeholder(usr.loc, S, R, req_strikes)
+	var/obj/item/I = new /obj/item/smithing_placeholder(user.loc, S, R, req_strikes)
 	I.name = "unforged [R.name]"
 	return I
 
@@ -612,11 +612,11 @@ var/list/datum/stack_recipe/cloth_recipes_with_tool = list (
 
 	return TRUE
 
-/datum/stack_recipe/cloth/finish_building(var/mob/usr, var/obj/item/stack/S, var/obj/R)
+/datum/stack_recipe/cloth/finish_building(var/mob/user, var/obj/item/stack/S, var/obj/R)
 	R.color = S.color
 	return R
 
-/datum/stack_recipe/cloth/composite/finish_building(var/mob/usr, var/obj/item/stack/S, var/R)
+/datum/stack_recipe/cloth/composite/finish_building(var/mob/user, var/obj/item/stack/S, var/R)
 	var/obj/item/clothing/under/composite/new_clothing = R
 	new_clothing.color = S.color
 	new_clothing.permanent_parts =  extra_data.Copy()
@@ -631,7 +631,7 @@ var/list/datum/stack_recipe/wax_recipes = list (
 	new/datum/stack_recipe/wax("candle",                           /obj/item/candle                            ),
 	)
 
-/datum/stack_recipe/wax/finish_building(var/mob/usr, var/obj/item/stack/S, var/obj/R)
+/datum/stack_recipe/wax/finish_building(var/mob/user, var/obj/item/stack/S, var/obj/R)
 	R.color = S.color
 	if (R.color in colors_all)
 		R.name = "[colors_all[R.color]] [R.name]"
@@ -640,7 +640,7 @@ var/list/datum/stack_recipe/wax_recipes = list (
 /* ========================================================================
 							LEATHER RECIPES
 ======================================================================== */
-/datum/stack_recipe/leather/finish_building(var/mob/usr, var/obj/item/stack/S, var/obj/R)
+/datum/stack_recipe/leather/finish_building(var/mob/user, var/obj/item/stack/S, var/obj/R)
 	if(istype(S, /obj/item/stack/sheet/leather))
 		var/obj/item/stack/sheet/leather/L = S
 		if(findtext(lowertext(R.name), "leather"))

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -264,10 +264,10 @@ Frequency:
 		turfs += T
 	return pick(turfs)
 
-/obj/item/weapon/hand_tele/AltClick(var/mob/usr)
-	if((usr.incapacitated() || !Adjacent(usr)))
+/obj/item/weapon/hand_tele/AltClick(var/mob/user)
+	if((user.incapacitated() || !Adjacent(user)))
 		return
-	choose_destination(usr)
+	choose_destination(user)
 
 /obj/item/weapon/hand_tele/process()
 	charge = min(HANDTELE_MAX_CHARGE,charge+1)

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -122,27 +122,27 @@
 	feedback_add_details("admin_verb","VMAL")
 
 //Used by the other procs to actually send the selected logs to the user
-/proc/obtain_log(var/path = null, src)
-	if(path && src)
-		message_admins("[key_name_admin(src)] accessed file: [path]")
-		log_admin("[key_name(src)] accessed file: [path]")
+/proc/obtain_log(var/path = null, source)
+	if(path && source)
+		message_admins("[key_name_admin(source)] accessed file: [path]")
+		log_admin("[key_name(source)] accessed file: [path]")
 		#ifdef RUNWARNING
 		#if DM_VERSION > 506 && DM_VERSION < 508
 			#warn Run is deprecated and disabled for some fucking reason in 507.1275/6, if you have a version that doesn't have run() disabled then comment out #define RUNWARNING in setup.dm
-		src << ftp(file(path))
+		source << ftp(file(path))
 		#else
 		var/method = alert("How do you want to get the logs?",,"Save to file","Open in notepad")
 		if(method == "Save to file")
-			src << ftp(file(path))
+			source << ftp(file(path))
 		else if(method == "Open in notepad")
-			src << run(file(path))
+			source << run(file(path))
 		#endif
 		#else
 		var/method = alert("How do you want to get the logs?",,"Save to file","Open in notepad")
 		if(method == "Save to file")
-			src << ftp(file(path))
+			source << ftp(file(path))
 		else if(method == "Open in notepad")
-			src << run(file(path))
+			source << run(file(path))
 		#endif
 	else
-		to_chat(src, "Error, no log file or src passed to obtain_log")
+		to_chat(source, "Error, no log file or src passed to obtain_log")

--- a/code/modules/dna/genes/speech.dm
+++ b/code/modules/dna/genes/speech.dm
@@ -19,8 +19,8 @@
 /datum/speech_filter/proc/addWordReplacement(var/orig,var/replacement, var/case_sensitive=0)
 	return addReplacement("\\b[orig]\\b",replacement, case_sensitive)
 
-/datum/speech_filter/proc/addCallback(var/orig,var/callback,var/list/args)
-	return addExpression(orig,callback,args)
+/datum/speech_filter/proc/addCallback(var/orig,var/callback,var/list/arguments)
+	return addExpression(orig,callback,arguments)
 
 /datum/speech_filter/proc/addExpression(var/orig,var/action,var/list/replacetext, var/flags)
 	expressions[orig]=new action(orig,replacetext,flags)

--- a/code/modules/ext_scripts/python.dm
+++ b/code/modules/ext_scripts/python.dm
@@ -15,14 +15,14 @@
 		arg = "'[arg]'"
 	return arg
 
-/proc/ext_python(var/script, var/args, var/scriptsprefix = 1, var/log_command=0)
+/proc/ext_python(var/script, var/arguments, var/scriptsprefix = 1, var/log_command=0)
 	if(scriptsprefix)
 		script = "scripts/" + script
 
 	if(world.system_type == MS_WINDOWS)
 		script = replacetext(script, "/", "\\")
 
-	var/command = config.python_path + " " + script + " " + args
+	var/command = config.python_path + " " + script + " " + arguments
 	if(log_command)
 		testing(command)
 	return shell(command)

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -934,9 +934,9 @@ var/global/borer_unlock_types_leg = typesof(/datum/unlockable/borer/leg) - /datu
 
 // So we can hear our host doing things.
 // NOTE:  We handle both visible and audible emotes because we're a brainslug that can see the impulses and shit.
-/mob/living/simple_animal/borer/proc/host_emote(var/list/args)
-	src.show_message(args["message"], args["m_type"])
-	host_brain.show_message(args["message"], args["m_type"])
+/mob/living/simple_animal/borer/proc/host_emote(var/list/arguments)
+	src.show_message(arguments["message"], arguments["m_type"])
+	host_brain.show_message(arguments["message"], arguments["m_type"])
 
 /mob/living/simple_animal/borer/proc/ventcrawl()
 	set name = "Crawl through Vent"

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -146,7 +146,7 @@
 	var/turf/T = src.loc			// hide if turf is not intact
 	hide(!T.is_plating())
 
-/obj/machinery/atmospherics/pipe/zpipe/up/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+/obj/machinery/atmospherics/pipe/zpipe/up/buildFrom(var/mob/user,var/obj/item/pipe/pipe)
 	dir = pipe.dir
 	initialize_directions = pipe.get_pipe_dir()
 	var/turf/T = loc
@@ -154,7 +154,7 @@
 	update_planes_and_layers()
 	initialize(1)
 	if(!node1&&!node2)
-		to_chat(usr, "<span class='warning'>There's nothing to connect this pipe section to! A pipe segment must be connected to at least one other object!</span>")
+		to_chat(user, "<span class='warning'>There's nothing to connect this pipe section to! A pipe segment must be connected to at least one other object!</span>")
 		return 0
 	update_icon()
 	build_network()
@@ -197,7 +197,7 @@
 	var/turf/T = src.loc			// hide if turf is not intact
 	hide(!T.is_plating())
 
-/obj/machinery/atmospherics/pipe/zpipe/down/buildFrom(var/mob/usr,var/obj/item/pipe/pipe)
+/obj/machinery/atmospherics/pipe/zpipe/down/buildFrom(var/mob/user,var/obj/item/pipe/pipe)
 	dir = pipe.dir
 	initialize_directions = pipe.get_pipe_dir()
 	var/turf/T = loc
@@ -205,7 +205,7 @@
 	update_planes_and_layers()
 	initialize(1)
 	if(!node1&&!node2)
-		to_chat(usr, "<span class='warning'>There's nothing to connect this pipe section to! A pipe segment must be connected to at least one other object!</span>")
+		to_chat(user, "<span class='warning'>There's nothing to connect this pipe section to! A pipe segment must be connected to at least one other object!</span>")
 		return 0
 	update_icon()
 	build_network()


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes #37739

OpenDream is adding `src`, `usr`, and `args` to the `SoftReservedKeyword` pragma: https://github.com/OpenDreamProject/OpenDream/pull/2307

This PR renames `var/usr` to `var/user`, `var/src` to `var/source`, and `var/args` to `var/arguments`.

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->

This pragma is currently set as an error on /vg/, because using internal var names for declared var names is cringe.

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->

bro it's a var rename

## Changelog

bro it's a var rename
