### PR TITLE
Blacksmithing quality affects tool-use speed.

### DIFF
--- a/__DEFINES/math_physics.dm
+++ b/__DEFINES/math_physics.dm
@@ -59,4 +59,6 @@
 
 #define IS_INT(x) (x == round(x))
 
+#define fancytrunc(x, y) (floor(x*(y*10))/(y*10)) //X is the value to truncate, Y is the trunc multiplier, i.e: x,3 would truncate to the thousandth. 
+
 #define GLIDE_SIZE_OF_A_WALKING_HUMAN 2.4615386

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1688,6 +1688,7 @@ var/global/objects_thrown_when_explode = FALSE
 		armor["melee"] = min(90, armor["melee"]*(material_type.armor_mod*(quality/B_AVERAGE)))
 		armor["bullet"] = min(90, armor["bullet"]*(material_type.armor_mod*(quality/B_AVERAGE)))
 		armor["laser"] = min(90, armor["laser"]*(material_type.armor_mod*(quality/B_AVERAGE)))
+	toolspeed = fancytrunc(toolspeed * (0.6687**(quality-4)),2)
 
 /////// DISEASE STUFF //////////////////////////////////////////////////////////////////////////
 

--- a/code/modules/blacksmithing/blacksmithing.dm
+++ b/code/modules/blacksmithing/blacksmithing.dm
@@ -92,7 +92,7 @@
 /obj/item/smithing_placeholder/attackby(obj/item/I, mob/user)
 	if(ishammer(I))
 		strike(I, user)
-		user.delayNextAttack(1 SECONDS)
+		user.delayNextAttack(1.4-(0.1*I.quality) SECONDS)
 	else if (I.is_hot())
 		heat(I.is_hot(), I, user)
 


### PR DESCRIPTION
## What this does
The quality of a product affects its toolspeed.
An awful quality pickaxe mines around 3x slower than a regular one, while a legendary quality one can match (but not surpass) a diamond drill.
Hammers scale down by 1/10th of a second per quality level, so a legendary quality hammer can hammer (for smithing purposes) twice per second, while an awful quality hammer would take slightly longer to hammer, around 0.3s extra.
Toolspeed only affects when an item is USED as a tool, like a pickaxe mining, not when the same item is used as a weapon, so it would not affect weapon delay.
## Why it's good
Rewards (and punishes) the efforts when making a pickaxe for faster mining, or better hammer for faster smithing, so a space hobo can mine at similar speeds to a proper Miner (albeit slowed down by the makeshift suit) if they make a good pickaxe, and a blacksmith can build a good arsenal easier if they take the time to make a superb hammer.
## How it was tested
Spawn as Space Hobo
Spawned gold sheets
Made pickaxe, VV'd strikes to 1 million, quenched, got a legendary pickaxe, mines at the same speed as a diamond drill.
Made a legendary hammer via VV, hammered twice per second, while an awful one hammered slower than normal.
Closes #37774 
:cl:
 * rscadd: Blacksmithing quality affects tool speed, with higher than average (4) quality working faster, and lower than average working slower. Pickaxes mine 3x slower on the worst quality and as fast as a diamond drill at the best quality. Hammers are 1/10th of a second faster (or slower) than the average per quality level.