### PR TITLE
turfs can be puddles, kind of. also makes jungle water wet.

### DIFF
--- a/__DEFINES/turfs.dm
+++ b/__DEFINES/turfs.dm
@@ -15,3 +15,7 @@
 #define MINE_DIFFICULTY_GLHF 9
 
 #define MINE_DURATION 100
+
+#define TURF_REAGENT_ENTER		(1 << 0)
+#define TURF_REAGENT_EXIT		(1 << 1)
+#define TURF_REAGENT_PROCESS	(1 << 2)

--- a/__DEFINES/turfs.dm
+++ b/__DEFINES/turfs.dm
@@ -16,6 +16,15 @@
 
 #define MINE_DURATION 100
 
-#define TURF_REAGENT_ENTER		(1 << 0)
-#define TURF_REAGENT_EXIT		(1 << 1)
-#define TURF_REAGENT_PROCESS	(1 << 2)
+/*
+TURF_REAGENT_ENTER - applies the reagents when a mob or obj enters the turf
+TURF_REAGENT_EXIT - same as above, but upon exiting
+TURF_REAGENT_PROCESS - applies the reagents to all mobs in the turf when process is fired (roughly every 2 seconds)
+TURF_REAGENT_INGORES_INVULNERABLE - applies reagents to mobs, even if they have the INVULNERABLE flag
+TURF_REAGENT_FILLS_CONTAINERS - allows mobs to click on the turf with a reagent container in hand to fill it with the reagents.
+*/
+#define TURF_REAGENT_ENTER					(1 << 0)
+#define TURF_REAGENT_EXIT					(1 << 1)
+#define TURF_REAGENT_PROCESS				(1 << 2)
+#define TURF_REAGENT_INGORES_INVULNERABLE	(1 << 3)
+#define TURF_REAGENT_FILLS_CONTAINERS		(1 << 4)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -818,7 +818,7 @@
 						R.reaction_animal(A, turf_reagent_method , turf_reagent_amount)
 					else
 						R.reaction_mob(A, turf_reagent_method , turf_reagent_amount, ALL_LIMBS)
-			else if ( istype(A,/obj) )
+			else if ( istype(A,/obj/machinery) || istype(A,/obj/item)  || istype(A,/obj/structure) )
 				R.reaction_obj(A, turf_reagent_amount)
 			
 			qdel(R)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -818,7 +818,7 @@
 						R.reaction_animal(A, turf_reagent_method , turf_reagent_amount)
 					else
 						R.reaction_mob(A, turf_reagent_method , turf_reagent_amount, ALL_LIMBS)
-			else if (isobj(A) && !istype(A,/atom/movable/lighting_overlay))
+			else if ( istype(A,/obj) )
 				R.reaction_obj(A, turf_reagent_amount)
 			
 			qdel(R)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -99,8 +99,7 @@
 	universe.OnTurfTick(src)
 	if((reagent_interaction_flags & TURF_REAGENT_PROCESS))
 		for(var/mob/M in contents)
-			if( (!(M.flags & INVULNERABLE)) || (reagent_interaction_flags & TURF_REAGENT_INGORES_INVULNERABLE) )
-				GiveReagentsTo(M)
+			GiveReagentsTo(M)
 
 /turf/initialize()
 	..()
@@ -125,12 +124,7 @@
 
 /turf/Exit(atom/movable/mover, atom/target)
 	if(reagent_interaction_flags & TURF_REAGENT_EXIT)
-		if(istype(mover,/mob))
-			var/mob/M=mover
-			if( (!(M.flags & INVULNERABLE)) || (reagent_interaction_flags & TURF_REAGENT_INGORES_INVULNERABLE) )
-				GiveReagentsTo(M)
-		else
-			GiveReagentsTo(mover)
+		GiveReagentsTo(mover)
 	return TRUE
 
 /turf/Exited(atom/movable/mover, atom/newloc)
@@ -144,12 +138,7 @@
 			if(!AM.Cross(mover))
 				return FALSE
 	if(reagent_interaction_flags & TURF_REAGENT_ENTER)
-		if(istype(mover,/mob))
-			var/mob/M=mover
-			if( (!(M.flags & INVULNERABLE)) || (reagent_interaction_flags & TURF_REAGENT_INGORES_INVULNERABLE) )
-				GiveReagentsTo(M)
-		else
-			GiveReagentsTo(mover)
+		GiveReagentsTo(mover)
 
 /turf/Entered(atom/movable/A as mob|obj, atom/OldLoc)
 	if(movement_disabled)
@@ -823,10 +812,12 @@
 			R.adj_temp = turf_reagents_temp
 
 			if (ismob(A))
-				if (isanimal(A))
-					R.reaction_animal(A, turf_reagent_method , turf_reagent_amount)
-				else
-					R.reaction_mob(A, turf_reagent_method , turf_reagent_amount, ALL_LIMBS)
+				var/mob/M=A
+				if( (!(M.flags & INVULNERABLE)) || (reagent_interaction_flags & TURF_REAGENT_INGORES_INVULNERABLE) )
+					if (isanimal(A))
+						R.reaction_animal(A, turf_reagent_method , turf_reagent_amount)
+					else
+						R.reaction_mob(A, turf_reagent_method , turf_reagent_amount, ALL_LIMBS)
 			else if (isobj(A) && !istype(A,/atom/movable/lighting_overlay))
 				R.reaction_obj(A, turf_reagent_amount)
 			

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -86,7 +86,6 @@
 	var/turf_reagent_method = TOUCH
 	var/turf_reagents_limited = null // if a non-null value, will treat it as a limited resivoir and will drain by reducing this number.
 	var/turf_reagents_temp = 0 //this uses strange reagent temperature stuff. i don't know what kind of unit method it's using but it's here regardless.
-	var/turf_reagent_fills_containers = TRUE // if true, we can click on it with a beaker in hand to fill it
 
 /turf/examine(mob/user)
 	..()
@@ -98,9 +97,10 @@
 /turf/proc/process()
 	set waitfor = FALSE
 	universe.OnTurfTick(src)
-	if(reagent_interaction_flags & TURF_REAGENT_PROCESS)
+	if((reagent_interaction_flags & TURF_REAGENT_PROCESS))
 		for(var/mob/M in contents)
-			GiveReagentsTo(M)
+			if( (!(M.flags & INVULNERABLE)) || (reagent_interaction_flags & TURF_REAGENT_INGORES_INVULNERABLE) )
+				GiveReagentsTo(M)
 
 /turf/initialize()
 	..()
@@ -125,7 +125,12 @@
 
 /turf/Exit(atom/movable/mover, atom/target)
 	if(reagent_interaction_flags & TURF_REAGENT_EXIT)
-		GiveReagentsTo(mover)
+		if(istype(mover,/mob))
+			var/mob/M=mover
+			if( (!(M.flags & INVULNERABLE)) || (reagent_interaction_flags & TURF_REAGENT_INGORES_INVULNERABLE) )
+				GiveReagentsTo(M)
+		else
+			GiveReagentsTo(mover)
 	return TRUE
 
 /turf/Exited(atom/movable/mover, atom/newloc)
@@ -139,7 +144,12 @@
 			if(!AM.Cross(mover))
 				return FALSE
 	if(reagent_interaction_flags & TURF_REAGENT_ENTER)
-		GiveReagentsTo(mover)
+		if(istype(mover,/mob))
+			var/mob/M=mover
+			if( (!(M.flags & INVULNERABLE)) || (reagent_interaction_flags & TURF_REAGENT_INGORES_INVULNERABLE) )
+				GiveReagentsTo(M)
+		else
+			GiveReagentsTo(mover)
 
 /turf/Entered(atom/movable/A as mob|obj, atom/OldLoc)
 	if(movement_disabled)
@@ -769,7 +779,7 @@
 
 /turf/attackby(var/obj/item/I, var/mob/user)
 	//if you're using this and it's not triggering, ensure your turf is calling ..() properly
-	if(turf_reagent_amount!=null && turf_reagent_fills_containers && istype(I,/obj/item/weapon/reagent_containers))
+	if(turf_reagent_amount!=null && (reagent_interaction_flags & TURF_REAGENT_FILLS_CONTAINERS) && istype(I,/obj/item/weapon/reagent_containers))
 		to_chat(user,"<span class='notice'>You fill \the [I] from \the [src]</span>")
 		var/obj/item/weapon/reagent_containers/RC=I
 		for(var/RID in turf_reagents)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -79,6 +79,15 @@
 	var/list/footstep_sound_barefoot = list()
 	var/list/footstep_sound_claw = list()
 
+	//reagent stuff
+	var/list/turf_reagents = list() //a list of reagent ids, associated with their relative amount. eg WATER=1 these numbers should sum to 1, though.
+	var/reagent_interaction_flags = 0
+	var/turf_reagent_amount = null // null = do not make any reagents and skip the code
+	var/turf_reagent_method = TOUCH
+	var/turf_reagents_limited = null // if a non-null value, will treat it as a limited resivoir and will drain by reducing this number.
+	var/turf_reagents_temp = 0 //this uses strange reagent temperature stuff. i don't know what kind of unit method it's using but it's here regardless.
+	var/turf_reagent_fills_containers = TRUE // if true, we can click on it with a beaker in hand to fill it
+
 /turf/examine(mob/user)
 	..()
 	if(bullet_marks)
@@ -89,6 +98,9 @@
 /turf/proc/process()
 	set waitfor = FALSE
 	universe.OnTurfTick(src)
+	if(reagent_interaction_flags & TURF_REAGENT_PROCESS)
+		for(var/mob/M in contents)
+			GiveReagentsTo(M)
 
 /turf/initialize()
 	..()
@@ -112,6 +124,8 @@
 	return 0
 
 /turf/Exit(atom/movable/mover, atom/target)
+	if(reagent_interaction_flags & TURF_REAGENT_EXIT)
+		GiveReagentsTo(mover)
 	return TRUE
 
 /turf/Exited(atom/movable/mover, atom/newloc)
@@ -124,6 +138,8 @@
 		for(var/atom/movable/AM in src)
 			if(!AM.Cross(mover))
 				return FALSE
+	if(reagent_interaction_flags & TURF_REAGENT_ENTER)
+		GiveReagentsTo(mover)
 
 /turf/Entered(atom/movable/A as mob|obj, atom/OldLoc)
 	if(movement_disabled)
@@ -751,6 +767,20 @@
 /turf/proc/remove_rot()
 	return
 
+/turf/attackby(var/obj/item/I, var/mob/user)
+	//if you're using this and it's not triggering, ensure your turf is calling ..() properly
+	if(turf_reagent_amount!=null && turf_reagent_fills_containers && istype(I,/obj/item/weapon/reagent_containers))
+		to_chat(user,"<span class='notice'>You fill \the [I] from \the [src]</span>")
+		var/obj/item/weapon/reagent_containers/RC=I
+		for(var/RID in turf_reagents)
+			RC.reagents.add_reagent(RID,turf_reagents[RID]*RC.amount_per_transfer_from_this)
+		if(turf_reagents_limited!=null)
+			turf_reagents_limited-=RC.amount_per_transfer_from_this
+			if(turf_reagents_limited<=0)
+				OnEmptyReagents()
+		return TRUE
+	return ..()
+		
 //Pathnode stuff
 
 /turf/proc/FindPathNode(var/id)
@@ -766,3 +796,36 @@
 	..()
 	if (cleanliness >= CLEANLINESS_BLEACH)
 		remove_paint_overlay(TRUE)
+
+//reagent things
+
+/turf/proc/GiveReagentsTo(var/atom/A)
+	if(!A)
+		return
+	if(turf_reagent_amount==null)
+		return
+	
+	for(var/RID in turf_reagents)
+		var/datum/reagent/D = chemical_reagents_list[RID]
+		if(D)
+			var/datum/reagent/R = new D.type()
+			R.volume = turf_reagent_amount * turf_reagents[RID]
+			R.adj_temp = turf_reagents_temp
+
+			if (ismob(A))
+				if (isanimal(A))
+					R.reaction_animal(A, turf_reagent_method , turf_reagent_amount)
+				else
+					R.reaction_mob(A, turf_reagent_method , turf_reagent_amount, ALL_LIMBS)
+			else if (isobj(A) && !istype(A,/atom/movable/lighting_overlay))
+				R.reaction_obj(A, turf_reagent_amount)
+			
+			qdel(R)
+
+	if(turf_reagents_limited!=null)
+		turf_reagents_limited-=turf_reagent_amount
+		if(turf_reagents_limited<=0)
+			OnEmptyReagents()
+
+/turf/proc/OnEmptyReagents()
+	turf_reagent_amount = null

--- a/code/game/turfs/unsimulated/jungle.dm
+++ b/code/game/turfs/unsimulated/jungle.dm
@@ -389,7 +389,7 @@ var/list/foliage_replacments=list(
 	plane = ABOVE_OBJ_PLANE
 	DIGGING_BLOCKED = "Something tells you that this is a really bad idea."
 	turf_reagents = list(WATER=1.0)
-	reagent_interaction_flags = TURF_REAGENT_ENTER
+	reagent_interaction_flags = TURF_REAGENT_ENTER | TURF_REAGENT_FILLS_CONTAINERS
 	turf_reagent_amount = 5
 
 /turf/unsimulated/floor/jungle/water_deep
@@ -401,7 +401,7 @@ var/list/foliage_replacments=list(
 	plane = MOB_PLANE
 	DIGGING_BLOCKED = "Something tells you that this is a really bad idea."
 	turf_reagents = list(WATER=1.0)
-	reagent_interaction_flags = TURF_REAGENT_ENTER
+	reagent_interaction_flags = TURF_REAGENT_ENTER | TURF_REAGENT_FILLS_CONTAINERS
 	turf_reagent_amount = 10
 
 

--- a/code/game/turfs/unsimulated/jungle.dm
+++ b/code/game/turfs/unsimulated/jungle.dm
@@ -66,7 +66,7 @@
 		return ..()
 		return FALSE
 	if(!construction_allowed)
-		return FALSE
+		return ..()
 	
 	if(C.type== /obj/item/stack/tile/metal) // lattice -> plating
 		var/obj/item/stack/tile/T = C
@@ -388,6 +388,9 @@ var/list/foliage_replacments=list(
 	turf_speed_multiplier=1.75
 	plane = ABOVE_OBJ_PLANE
 	DIGGING_BLOCKED = "Something tells you that this is a really bad idea."
+	turf_reagents = list(WATER=1.0)
+	reagent_interaction_flags = TURF_REAGENT_ENTER
+	turf_reagent_amount = 5
 
 /turf/unsimulated/floor/jungle/water_deep
 	name="Deep Water"
@@ -397,6 +400,9 @@ var/list/foliage_replacments=list(
 	turf_speed_multiplier=2.5
 	plane = MOB_PLANE
 	DIGGING_BLOCKED = "Something tells you that this is a really bad idea."
+	turf_reagents = list(WATER=1.0)
+	reagent_interaction_flags = TURF_REAGENT_ENTER
+	turf_reagent_amount = 10
 
 
 /turf/unsimulated/floor/jungle/sand

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -64,8 +64,6 @@
 /datum/reagent/proc/reaction_mob(var/mob/living/M, var/method = TOUCH, var/volume, var/list/zone_sels = ALL_LIMBS, var/allow_permeability = TRUE, var/list/splashplosion=list())
 	set waitfor = 0
 
-	if(!holder)
-		return 1
 	if(!istype(M))
 		return 1
 	if((src.id in M.tolerated_chems) && M.tolerated_chems[src.id] && M.tolerated_chems[src.id] >= volume)
@@ -75,7 +73,7 @@
 	src = null
 
 	//If the chemicals are in a smoke cloud, do not let the chemicals "penetrate" into the mob's system (balance station 13) -- Doohl
-	if(self.holder && allow_permeability && !istype(self.holder.my_atom, /obj/effect/smoke/chem))
+	if(allow_permeability && !istype(self.holder?.my_atom, /obj/effect/smoke/chem))
 		if(method == TOUCH)
 
 			var/chance = 1
@@ -96,7 +94,7 @@
 
 			chance = chance * 100
 
-			if(self.id == HOLYWATER && istype(self.holder.my_atom, /obj/item/weapon/reagent_containers/food/drinks/bottle/holywater))
+			if(self.id == HOLYWATER && istype(self.holder?.my_atom, /obj/item/weapon/reagent_containers/food/drinks/bottle/holywater))
 				if(M.reagents)
 					M.reagents.add_reagent(self.id, min(5,self.volume/2)) //holy water flasks only splash 5u at a time. But for deconversion purposes they will always be ingested.
 			else if(prob(chance) && !block)


### PR DESCRIPTION
[honk] [exploitable]

## What this does
allows turfs to have reagents that are applied to a player and may fill containers.
This also makes it so that the water turfs on junglestation "splash" the user with water when walked in, and can be used to fill glasses/beakers.
![Capture](https://github.com/user-attachments/assets/d2bc93ea-6039-479a-8ca8-f3c4e3a6d98f)


## Why it's good
muh immulsions
also the code is fairly robust, so other coders can use it for their turfs to expand interactions

## How it was tested
went in game and tested with a jungle water turf. went in it, and was able to fill a container

---

## guide for admin button pushing

* step 1: locate your desired turf, and open the varedit menu
* step 2: find the list `turf_reagents` and add an associated entry, with the index being your reagent, and the value being the reagent proportion
* step 2.5: locate the reagent id, which can be found in `__DEFINES/reagents.dm`
* step 2.5.5: your list should look something like `list(water=0.5, potassium=0.5)`
* step 3: set the variable `turf_reagent_amount` to how many of the reagents you want the turf to give
* step 4: set the variable `reagent_interaction_flags` according to how you want them applied.

  * TURF_REAGENT_ENTER (1) applies regents upon entering the turf
  * TURF_REAGENT_EXIT (2) same as above, but exiting turf
  * TURF_REAGENT_PROCESS (4) applies to all mobs on turf every process (2 seconds) cycle
  * TURF_REAGENT_IGNORES_INVULNERABLE (8) ignores mob invulnerability flag when applying reagents
  * TURF_REAGENT_FILLS_CONTAINERS (16) allows clicking on turf with a container to fill it with the reagents

* step 5: (optional) if you want the reagents to run out, set the variable `turf_reagents_limited` to that number
* step 6: (optional) to change how the reagents are given, modify the variable `turf_reagent_method`. by default it is TOUCH (1), but it could be INGEST (2)
---
## Changelog
:cl:
 * rscadd: Turfs can now act as a reagent dispenser, if the coders set it up. watch out, and greys beware of water!
