### PR TITLE
Jungle fix 5

### DIFF
--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -79,8 +79,8 @@
 			qdel(target)
 			on_successful_use(user)
 
-	else if(istype(target,/turf/simulated))
-		var/turf/simulated/T = target
+	else if(istype(target,/turf))
+		var/turf/T = target
 		var/list/cleanables = list()
 
 		for(var/obj/effect/decal/cleanable/CC in T)
@@ -96,11 +96,13 @@
 			if(CC.on_wall == target)
 				cleanables += CC
 
-		if (T.advanced_graffiti)
-			T.overlays -= T.advanced_graffiti_overlay
-			T.advanced_graffiti_overlay = null
-			qdel(T.advanced_graffiti)
-			cleanables += "advanced graffiti"
+		if (istype(T,/turf/simulated))
+			var/turf/simulated/ST=T
+			if(ST.advanced_graffiti)
+				ST.overlays -= ST.advanced_graffiti_overlay
+				ST.advanced_graffiti_overlay = null
+				qdel(ST.advanced_graffiti)
+				cleanables += "advanced graffiti"
 
 		if(!cleanables.len)
 			user.simple_message("<span class='notice'>You fail to clean anything.</span>",

--- a/code/game/objects/structures/vehicles/vehicle.dm
+++ b/code/game/objects/structures/vehicles/vehicle.dm
@@ -137,9 +137,11 @@
 					if(!istype(W, keytype))
 						to_chat(user, "<span class='warning'>\The [W] doesn't fit into \the [src]'s ignition.</span>")
 						return
+					var/obj/item/key/K=W
 					if(mykey && mykey != W)
-						to_chat(user, "<span class='warning'>\The [src] is paired to a different key.</span>")
-						return
+						if(!vin || !K.vin || K.vin!=vin) //if neither have a vin id, or they don't match (since they default as null)
+							to_chat(user, "<span class='warning'>\The [src] is paired to a different key.</span>")
+							return
 				if(((M_CLUMSY in user.mutations) || user.getBrainLoss() >= 60) && prob(50))
 					to_chat(user, "<span class='warning'>You try to insert \the [W] to \the [src]'s ignition but you miss the slot!</span>")
 					return
@@ -178,6 +180,12 @@
 /obj/structure/bed/chair/vehicle/proc/check_key(var/mob/user)
 	if(!keytype)
 		return 1
+	if(vin)
+		if(heldkey && heldkey.vin == vin)
+			return TRUE
+		for(var/obj/item/key/K in user.held_items)
+			if(istype(K,keytype) && K.vin==vin)
+				return TRUE
 	if(mykey)
 		return heldkey == mykey || user.is_holding_item(mykey)
 	return istype(heldkey, keytype) || user.find_held_item_by_type(keytype)

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -4665,7 +4665,10 @@
 	},
 /area/shuttle/nuclearops)
 "bQz" = (
-/obj/structure/bed/chair/vehicle/tractor,
+/obj/structure/bed/chair/vehicle/tractor{
+	vin = "CARGO_TRACTORS";
+	name = "cargo tractor"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	dir = 4;
@@ -6222,7 +6225,7 @@
 /turf/simulated/floor,
 /area/security/perma)
 "ctg" = (
-/obj/machinery/cart,
+/obj/machinery/cart/cargo,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	dir = 4;
@@ -7151,6 +7154,10 @@
 	},
 /obj/machinery/camera{
 	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	flickering = 1
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -25856,6 +25863,20 @@
 "kmB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table/glass,
+/obj/item/key/tractor{
+	name = "cargo tractor key";
+	vin = "CARGO_TRACTORS"
+	},
+/obj/item/key/tractor{
+	name = "cargo tractor key";
+	vin = "CARGO_TRACTORS";
+	pixel_x = 8
+	},
+/obj/item/key/tractor{
+	name = "cargo tractor key";
+	vin = "CARGO_TRACTORS";
+	pixel_x = -8
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "brown";
@@ -29360,9 +29381,22 @@
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle)
 "lIh" = (
-/obj/machinery/disposal/compactor,
-/turf/simulated/wall,
-/area/supply/sorting)
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/weapon/cell{
+	maxcharge = 2000;
+	pixel_y = 9;
+	pixel_x = 3
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown";
+	tag = "icon-brown (NORTH)"
+	},
+/area/supply/storage)
 "lIn" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -31046,6 +31080,18 @@
 	})
 "mmn" = (
 /obj/structure/closet/secure_closet/quartermaster,
+/obj/item/key/tractor{
+	name = "cargo tractor key";
+	vin = "CARGO_TRACTORS"
+	},
+/obj/item/key/tractor{
+	name = "cargo tractor key";
+	vin = "CARGO_TRACTORS"
+	},
+/obj/item/key/tractor{
+	name = "cargo tractor key";
+	vin = "CARGO_TRACTORS"
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "brown"
@@ -32144,7 +32190,10 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/mining/station)
 "mLy" = (
-/obj/structure/bed/chair/vehicle/tractor,
+/obj/structure/bed/chair/vehicle/tractor{
+	vin = "CARGO_TRACTORS";
+	name = "cargo tractor"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	dir = 8;
@@ -43372,6 +43421,10 @@
 	dir = 2;
 	req_access_txt = "63"
 	},
+/obj/item/device/deskbell/signaler/brig{
+	pixel_y = 8;
+	name = "Front gate checkpoint bell"
+	},
 /turf/simulated/floor,
 /area/security/checkpoint2)
 "rqo" = (
@@ -44299,7 +44352,10 @@
 /turf/simulated/floor/grass,
 /area/science/test_area)
 "rEK" = (
-/obj/structure/bed/chair/vehicle/tractor,
+/obj/structure/bed/chair/vehicle/tractor{
+	vin = "CARGO_TRACTORS";
+	name = "cargo tractor"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor,
 /area/supply/sorting)
@@ -45629,7 +45685,7 @@
 	},
 /area/centcom/control)
 "sfH" = (
-/obj/machinery/cart,
+/obj/machinery/cart/cargo,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	dir = 4
@@ -45906,7 +45962,7 @@
 /turf/simulated/floor,
 /area/mine/production)
 "sog" = (
-/obj/machinery/cart,
+/obj/machinery/cart/cargo,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
 	dir = 4
@@ -47025,13 +47081,6 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
-	},
-/obj/machinery/door_control{
-	id_tag = "cell1_yard";
-	name = "cell 1 yard access";
-	pixel_x = -5;
-	pixel_y = 32;
-	req_access_txt = "3"
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor{
@@ -52183,7 +52232,7 @@
 /turf/space/transit/south,
 /area)
 "uSO" = (
-/obj/machinery/cart,
+/obj/machinery/cart/cargo,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor,
 /area/supply/sorting)
@@ -55066,7 +55115,7 @@
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/fenced)
 "vSi" = (
-/obj/machinery/cart,
+/obj/machinery/cart/cargo,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
 	dir = 8
@@ -55124,7 +55173,7 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "vTl" = (
-/obj/machinery/cart,
+/obj/machinery/cart/cargo,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
 	dir = 8;
@@ -118245,7 +118294,7 @@ ngP
 fNs
 thY
 thY
-fNs
+lIh
 jse
 wJi
 idZ
@@ -120717,7 +120766,7 @@ wOM
 wOM
 wOM
 wOM
-lIh
+wOM
 wOM
 ucP
 tCs

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -22746,6 +22746,17 @@
 	icon_state = "whitepurple"
 	},
 /area/science/hallway)
+"iZq" = (
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_y = 5
+	},
+/obj/structure/table/woodentable,
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_y = -1;
+	pixel_x = 2
+	},
+/turf/simulated/floor/wood,
+/area/surface/jungle)
 "iZA" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio/intercom/medbay/broadcast_nospeaker{
@@ -80828,7 +80839,7 @@ wAq
 wAq
 wAq
 wAq
-wAq
+iZq
 oHr
 lIK
 lIK
@@ -106293,8 +106304,8 @@ tnZ
 tnZ
 tnZ
 maR
-kyt
-tsV
+snf
+snf
 hey
 jRn
 bWd
@@ -106645,7 +106656,7 @@ jgK
 tnZ
 tnZ
 maR
-iMQ
+snf
 dCE
 kiH
 wpj
@@ -106997,7 +107008,7 @@ nwK
 tnZ
 tnZ
 maR
-iMQ
+snf
 xMH
 tgB
 rTQ
@@ -107349,8 +107360,8 @@ tnZ
 tnZ
 tnZ
 maR
-iMQ
-xMH
+kyt
+hLG
 eNu
 pEt
 ebT

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -1940,6 +1940,11 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Science Lobby"
+	},
 /turf/simulated/floor,
 /area/science/hallway)
 "aMf" = (
@@ -2222,6 +2227,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/beacon,
 /turf/simulated/floor,
 /area/teleporter)
 "aSq" = (
@@ -3908,6 +3914,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Security Lobby"
+	},
 /turf/simulated/floor,
 /area/security/lobby)
 "bAm" = (
@@ -4559,6 +4570,11 @@
 	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Medical Lobby"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -6699,13 +6715,13 @@
 /turf/space,
 /area/shuttle/transport1/centcom)
 "cCM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown";
-	tag = "icon-brown (NORTH)"
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Theatre"
 	},
-/area/supply/lobby)
+/turf/simulated/floor/wood,
+/area/surface/jungle/zoned/outdoor_bar)
 "cDH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8390,11 +8406,9 @@
 /turf/unsimulated/floor/jungle/bedrock,
 /area/surface/jungle/underground/zoned/speakeasy)
 "did" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown";
-	tag = "icon-brown (NORTH)"
+	dir = 4;
+	icon_state = "brown"
 	},
 /area/supply/lobby)
 "die" = (
@@ -9028,6 +9042,12 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/syndicate_elite/mothership)
+"dwn" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "unloading"
+	},
+/turf/simulated/floor,
+/area/supply/storage)
 "dwx" = (
 /turf/simulated/floor{
 	icon_state = "carpet"
@@ -11549,6 +11569,17 @@
 	icon_state = "floor5"
 	},
 /area/alien)
+"etJ" = (
+/obj/effect/landmark/start{
+	name = "Assistant"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	freq = 1400;
+	location = "Tool Storage"
+	},
+/turf/simulated/floor/wood,
+/area/surface/jungle/zoned/storage_shed)
 "etT" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor,
@@ -16515,6 +16546,21 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration/centcom)
+"gwa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	freq = 1400;
+	location = "QM #3"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/turf/simulated/floor,
+/area/supply/storage)
 "gwq" = (
 /turf/unsimulated/floor/jungle/path_plated{
 	icon_state = "junglestation6";
@@ -25191,8 +25237,19 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	one_way = 1
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	freq = 1400;
+	location = "QM #1"
+	},
+/obj/machinery/bot/mulebot{
+	home_destination = "QM #1";
+	suffix = "#1"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "brown"
@@ -27421,7 +27478,7 @@
 	one_way = 1
 	},
 /turf/simulated/floor{
-	dir = 1;
+	dir = 9;
 	icon_state = "neutral"
 	},
 /area/maintenance/disposal)
@@ -27522,6 +27579,13 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/sleeper)
+"kVF" = (
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown";
+	tag = "icon-brown (NORTH)"
+	},
+/area/supply/lobby)
 "kWj" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4
@@ -29567,7 +29631,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/supply/lobby)
 "lKW" = (
 /obj/machinery/bodyscanner{
@@ -30932,7 +30999,10 @@
 	dir = 4;
 	on = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
 /area/supply/lobby)
 "mkg" = (
 /obj/structure/window/reinforced{
@@ -32632,12 +32702,13 @@
 	},
 /area/engineering/reactor_room)
 "mVo" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
-	initialize_directions = 11
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Bazaar"
 	},
-/turf/simulated/floor,
-/area/supply/storage)
+/turf/unsimulated/floor/jungle/path,
+/area/surface/jungle/zoned/tradearea)
 "mVO" = (
 /obj/structure/table,
 /obj/item/weapon/storage/bag/plasticbag{
@@ -33317,7 +33388,7 @@
 "nkI" = (
 /obj/machinery/computer/pda_terminal,
 /turf/simulated/floor{
-	dir = 1;
+	dir = 9;
 	icon_state = "brown";
 	tag = "icon-brown (NORTH)"
 	},
@@ -33766,7 +33837,10 @@
 /obj/machinery/atm{
 	pixel_x = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/supply/lobby)
 "nuy" = (
 /obj/effect/decal/warning_stripes{
@@ -34108,11 +34182,13 @@
 	},
 /area/science/hallway)
 "nED" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Library"
 	},
-/turf/simulated/floor,
-/area/supply/storage)
+/turf/simulated/floor/wood,
+/area/library)
 "nEZ" = (
 /obj/machinery/power/treadmill{
 	dir = 8
@@ -37496,11 +37572,13 @@
 /turf/simulated/floor,
 /area/security/brig)
 "oXo" = (
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutral"
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Dorms"
 	},
-/area/maintenance/disposal)
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep)
 "oXv" = (
 /obj/structure/grille/window_spawner/reinforced,
 /turf/simulated,
@@ -39272,6 +39350,11 @@
 	},
 /area/science/robotics)
 "pIx" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Chapel"
+	},
 /turf/simulated/floor/carpet{
 	icon_state = "carpet9-4"
 	},
@@ -43125,6 +43208,12 @@
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
+/obj/machinery/door_control{
+	id_tag = "recycleshutter";
+	name = "Recycling Shutters";
+	req_access_txt = "31";
+	pixel_x = -24
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "brown";
@@ -44484,6 +44573,16 @@
 	tag = "icon-checker (NORTHEAST)"
 	},
 /area/science/rd)
+"rHF" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Art Area"
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wood_26"
+	},
+/area/surface/jungle/zoned/art_zone)
 "rHY" = (
 /turf/simulated/floor/engine,
 /area/science/xenobiology/specimen_3)
@@ -44613,7 +44712,10 @@
 /obj/machinery/camera{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/supply/lobby)
 "rMB" = (
 /obj/structure/grille/window_spawner/reinforced/full,
@@ -48621,6 +48723,9 @@
 	},
 /area/security/interrogation)
 "toQ" = (
+/obj/effect/decal/warning_stripes{
+	icon_state = "unloading"
+	},
 /turf/simulated/floor{
 	icon_state = "brown"
 	},
@@ -48743,7 +48848,10 @@
 /obj/machinery/light_switch{
 	pixel_x = 28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/supply/lobby)
 "tsw" = (
 /obj/effect/glowshroom/single,
@@ -48753,7 +48861,7 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "neutral"
+	icon_state = "neutralcorner"
 	},
 /area/maintenance/disposal)
 "tsU" = (
@@ -51736,6 +51844,14 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/bridge)
+"uFw" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Bar"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "uFM" = (
 /obj/item/weapon/stool/cushion{
 	pixel_y = 12
@@ -52459,8 +52575,19 @@
 "uWi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/window/reinforced{
-	dir = 4;
-	one_way = 1
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	freq = 1400;
+	location = "QM #2"
+	},
+/obj/machinery/bot/mulebot{
+	home_destination = "QM #2";
+	suffix = "#2"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
 	},
 /turf/simulated/floor,
 /area/supply/storage)
@@ -55807,17 +55934,13 @@
 /turf/simulated/floor,
 /area/supply/miningdock)
 "wgH" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Engineering Lobby"
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown";
-	tag = "icon-brown (NORTH)"
-	},
-/area/supply/lobby)
+/turf/simulated/floor,
+/area/engineering/break_room)
 "wgM" = (
 /obj/machinery/light{
 	dir = 1
@@ -106344,7 +106467,7 @@ tnZ
 tnZ
 tnZ
 tnZ
-tnZ
+mVo
 fWT
 tnZ
 fWT
@@ -117975,7 +118098,7 @@ lJn
 iXH
 fer
 hAU
-fUK
+cCM
 uAs
 cGB
 ean
@@ -119350,8 +119473,8 @@ ijh
 oWM
 pSp
 aPO
-oWM
-oWM
+dwn
+dwn
 toQ
 llh
 cHd
@@ -119702,7 +119825,7 @@ oWM
 oWM
 pSp
 lHk
-uWi
+gwa
 uWi
 jXm
 tPy
@@ -120047,10 +120170,10 @@ qqK
 fGX
 oWM
 oWM
+oWM
+oWM
+oWM
 fYP
-mVo
-mVo
-mVo
 kcc
 lRl
 mbl
@@ -120400,9 +120523,9 @@ ouc
 oWM
 oWM
 oWM
-nED
-nED
-nED
+oWM
+oWM
+oWM
 oWM
 aIC
 pfB
@@ -121832,7 +121955,7 @@ xor
 wld
 qhG
 ijG
-mpz
+nED
 mpz
 mpz
 gOX
@@ -124272,7 +124395,7 @@ tVE
 mAq
 stB
 xwU
-oXo
+sHR
 dEu
 sgL
 qqK
@@ -124635,11 +124758,11 @@ hUZ
 hnw
 cDH
 mNL
-nxe
-xbb
-xbb
+kVF
+did
+did
 mkc
-xbb
+did
 dIw
 wld
 xor
@@ -124987,7 +125110,7 @@ brY
 btG
 sTq
 oQc
-cCM
+bAt
 bAt
 bAt
 qgR
@@ -125339,7 +125462,7 @@ mDT
 pIB
 lqU
 nUH
-wgH
+joj
 oBB
 mDL
 mDL
@@ -125691,7 +125814,7 @@ eXG
 oxC
 jfW
 iBP
-did
+gQV
 fgb
 esb
 esb
@@ -125721,7 +125844,7 @@ sXU
 edD
 edD
 esU
-dqa
+uFw
 sIe
 sIe
 nkN
@@ -130944,7 +131067,7 @@ gnK
 xgj
 fgx
 lgW
-lgW
+oXo
 nVJ
 aPt
 lgW
@@ -135575,7 +135698,7 @@ mSW
 gHV
 wld
 wld
-jYs
+rHF
 jYs
 jYs
 jYs
@@ -138756,7 +138879,7 @@ iMQ
 wld
 wld
 vay
-moC
+wgH
 moC
 upN
 ksH
@@ -145084,7 +145207,7 @@ wld
 kzq
 nvA
 ptI
-ptI
+etJ
 vFj
 kzq
 wld


### PR DESCRIPTION
* closes #37778
* closes #37776
* makes the tractors in cargo use shared keys that spawn on the table (and in QM's locker)
* adds a desk bell to the front gate so security knows to let you in (they will ignore it)
* fixes a misplaced item
* adds some more lights
* gives hobo spawns a couple toolboxes
* fixes broken security wiring
* adds mules and navigation beacons (mules are still broken tho lol)

:cl:
 * bugfix: unga bunga junga fixes