### PR TITLE
Maybe fixes the weird smaller-sized UIs on win11

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -102,6 +102,7 @@
 	if (width && height)
 		window_size = "size=[width]x[height];"
 	user << browse(get_content(), "window=[window_id];[window_size][window_options]")
+	winset(user, window_id, "[window_size]")
 	if (use_onclose)
 		onclose(user, window_id, ref)
 

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -347,6 +347,7 @@ function loadPage(list) {
 	html += "</html>"
 
 	usr << browse(HTML_SKELETON(html), "window=variables\ref[D];size=475x650")
+	winset(usr, "variables\ref[D]", "size=475x650")
 
 /client/proc/debug_variable(name, value, list/searched, var/datum/DA = null)
 	var/html = ""
@@ -454,6 +455,7 @@ function loadPage(list) {
 		html += debug_variable(null, L)
 
 	usr << browse(HTML_SKELETON(html), "window=listedit\ref[L];size=475x650")
+	winset(usr, "listedit\ref[L]", "size=475x650")
 
 /client/proc/view_var_Topic(href, href_list, hsrc)
 	//This should all be moved over to datum/admins/Topic() or something ~Carn

--- a/code/datums/gamemode/dynamic/dynamic.dm
+++ b/code/datums/gamemode/dynamic/dynamic.dm
@@ -147,6 +147,7 @@ var/stacking_limit = 90
 	out += "<B>Remaining midround threat/threat_level:</B> [midround_threat]/[midround_threat_level]"
 
 	usr << browse(HTML_SKELETON(out), "window=threatlog;size=700x500")
+	winset(usr, "threatlog", "size=700x500")
 
 /datum/gamemode/dynamic/GetScoreboard()
 

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_buildings.dm
@@ -649,6 +649,7 @@
 							dat += "<li><span style='color:#FFFF00'><b>[C.real_name]</b></span></li> - Prisoner of [gaoler.name][extra]"
 				dat += {"</ul>"}
 				user << browse(HTML_SKELETON_TITLE_STYLE("Cult Roster", dat, style), "window=cultroster;size=600x400")
+				winset(usr, "cultroster", "size=600x400")
 				onclose(user, "cultroster")
 			if ("Look through Veil")
 				if(user.hud_used && user.hud_used.holomap_obj)

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_items.dm
@@ -187,6 +187,7 @@ var/list/arcane_tomes = list()
 
 	usr << browse_rsc('icons/tomebg.png', "tomebg.png")
 	usr << browse(tome_text(), "window=arcanetome;size=900x600")
+	winset(usr, "arcanetome", "size=900x600")
 
 /obj/item/weapon/tome/attack(var/mob/living/M, var/mob/living/user)
 	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has had the [name] used on him by [user.name] ([user.ckey])</font>")
@@ -234,6 +235,7 @@ var/list/arcane_tomes = list()
 	if(iscultist(user) && state == TOME_OPEN)
 		usr << browse_rsc('icons/tomebg.png', "tomebg.png")
 		usr << browse(tome_text(), "window=arcanetome;size=900x600")
+		winset(usr, "arcanetome", "size=900x600")
 
 /obj/item/weapon/tome/dropped(var/mob/user)
 	usr << browse(null, "window=arcanetome")
@@ -262,6 +264,7 @@ var/list/arcane_tomes = list()
 			state = TOME_OPEN
 			usr << browse_rsc('icons/tomebg.png', "tomebg.png")
 			usr << browse(tome_text(), "window=arcanetome;size=900x600")
+			winset(usr, "arcanetome", "size=900x600")
 		else
 			icon_state = "tome"
 			item_state = "tome"
@@ -298,6 +301,7 @@ var/list/arcane_tomes = list()
 				if (state == TOME_OPEN)
 					usr << browse_rsc('icons/tomebg.png', "tomebg.png")
 					usr << browse(tome_text(), "window=arcanetome;size=900x600")
+					winset(usr, "arcanetome", "size=900x600")
 		else
 			to_chat(user, "<span class='warning'>This tome cannot contain any more talismans. Use or remove some first.</span>")
 
@@ -456,6 +460,7 @@ var/list/arcane_tomes = list()
 				T.talismans.Remove(src)
 				user << browse_rsc('icons/tomebg.png', "tomebg.png")
 				user << browse(T.tome_text(), "window=arcanetome;size=900x600")
+				winset(user, "arcanetome", "size=900x600")
 				user.put_in_hands(src)
 		return
 

--- a/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
+++ b/code/datums/gamemode/factions/bloodcult/bloodcult_runespells.dm
@@ -747,6 +747,7 @@
 			var/mob/M = target.loc
 			M << browse_rsc('icons/tomebg.png', "tomebg.png")
 			M << browse(target.tome_text(), "window=arcanetome;size=537x375")
+			winset(M, "arcanetome", "size=537x375")
 	else
 		to_chat(activator, "<span class='warning'>This tome cannot contain any more talismans.</span>")
 	qdel(src)

--- a/code/datums/gamemode/factions/legacy_cult/talisman.dm
+++ b/code/datums/gamemode/factions/legacy_cult/talisman.dm
@@ -144,6 +144,7 @@
 <A href='?src=\ref[src];rune=construct'>Da A'ig Osk</A> - Summons a construct shell for use with captured souls. It is too large to carry on your person.<BR>"}
 //<A href='?src=\ref[src];rune=armor'>Sa tatha najin</A> - Allows you to summon armored robes and an unholy blade<BR> //Kept for reference
 	usr << browse(HTML_SKELETON(dat), "window=id_com;size=350x200")
+	winset(usr, "id_com", "size=350x200")
 	return
 
 

--- a/code/datums/gamemode/powers/powers.dm
+++ b/code/datums/gamemode/powers/powers.dm
@@ -334,7 +334,7 @@
 	"}
 
 	usr << browse(HTML_SKELETON(dat), "window=powers;size=900x480")
-
+	winset(usr, "powers", "size=900x480")
 
 
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -196,7 +196,7 @@
 		if (faith.religiousLeader == src)
 			output += "You can convert people by [faith.convert_method] <br />"
 	recipient << browse(output,"window=memory;size=700x500")
-
+	winset(recipient, "memory", "size=700x500")
 
 /datum/mind/proc/role_panel()
 	if(!ticker || !ticker.mode)
@@ -224,6 +224,7 @@
 	//<a href='?src=\ref[src];obj_announce=1'>Announce objectives</a><br><br>"} TODO: make sure that works
 
 	usr << browse(HTML_SKELETON(out), "window=role_panel[src];size=700x500")
+	winset(usr, "role_panel[src]", "size=700x500")
 
 /datum/mind/proc/role_purchase_log()
 	if(!ticker || !ticker.mode)
@@ -255,6 +256,7 @@
 					out += "[entry]<BR>"
 
 	usr << browse(HTML_SKELETON(out), "window=role_purchase_log[src];size=300x500")
+	winset(usr, "role_panel[src]", "size=700x500")
 
 /datum/mind/proc/get_faction_list()
 	var/list/all_factions = list()

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -154,6 +154,7 @@ var/list/nuclear_bombs = list()
 		<A href='?src=\ref[src];type=7'>7</A>-<A href='?src=\ref[src];type=8'>8</A>-<A href='?src=\ref[src];type=9'>9</A><BR>\n
 		<A href='?src=\ref[src];type=R'>R</A>-<A href='?src=\ref[src];type=0'>0</A>-<A href='?src=\ref[src];type=E'>E</A><BR>\n</TT>"}
 		user << browse(HTML_SKELETON(dat), "window=nuclearbomb;size=300x400")
+		winset(user, "nuclearbomb", "size=300x400")
 		onclose(user, "nuclearbomb")
 	else if (src.deployable)
 		if(removal_stage < 5)

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -211,6 +211,7 @@
 	dat += "</body>"
 
 	user << browse(HTML_SKELETON(dat), "window=spellbook;size=[book_window_size]")
+	winset(user, "spellbook", "size=[book_window_size]")
 	onclose(user, "spellbook")
 
 /obj/item/weapon/spellbook/proc/build_description(var/mob/user, var/spell_path) //Building sounds more coderlike doesn't it

--- a/code/game/machinery/ATM.dm
+++ b/code/game/machinery/ATM.dm
@@ -284,6 +284,7 @@ log transactions
 			reconnect_database()
 
 		user << browse(HTML_SKELETON(dat),"window=atm;size=550x650")
+		winset(user, "atm", "size=550x650")
 	else
 		user << browse(null,"window=atm")
 

--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -107,6 +107,7 @@
 	"}
 
 	user << browse(HTML_SKELETON(dat), "window=freezer;size=400x500")
+	winset(user, "freezer", "size=400x500")
 	onclose(user, "freezer")
 
 /obj/machinery/atmospherics/unary/cold_sink/freezer/Topic(href, href_list)
@@ -275,6 +276,7 @@
 	"}
 
 	user << browse(HTML_SKELETON(dat), "window=heater;size=400x500")
+	winset(user, "heater", "size=400x500")
 	onclose(user, "heater")
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/Topic(href, href_list)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -642,6 +642,7 @@
 	dat += "[(on) ? "<A href='?src=\ref[src];turnoff=1'>\[EMERGENCY STOP\]</A> <i>: cancels the current job.</i><BR>" : ""]"
 	dat += text("<BR><BR><A href='?src=\ref[];mach_close=\ref[src]'>Close</A>", user)
 	user << browse(HTML_SKELETON(dat), "window=\ref[src];size=400x500")
+	winset(usr, "\ref[src]", "size=400x500")
 	onclose(user, "\ref[src]")
 
 

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -332,6 +332,7 @@
 
 	dat += text("<BR><A href='?src=\ref[];mach_close=scanconsole'>Close</A>", user)
 	user << browse(HTML_SKELETON(dat), "window=scanconsole;size=430x600")
+	winset(user, "spellbook", "size=430x600")
 	return
 
 

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -65,6 +65,7 @@
 		t += text("Uses Left: [uses]. <A href='?src=\ref[src];toggleUse=1'>Activate the dispenser?</A><br>\n")
 
 	user << browse(HTML_SKELETON(t), "window=computer;size=575x450")
+	winset(user, "computer", "size=575x450")
 	onclose(user, "computer")
 	return
 

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -287,6 +287,7 @@ var/global/mulebot_count = 0
 			dat += "The bot is in maintenance mode and cannot be controlled.<BR>"
 
 	user << browse(HTML_SKELETON_TITLE("Mulebot [suffix ? "([suffix])" : ""]", dat), "window=mulebot;size=350x500")
+	winset(user, "mulebot", "size=350x500")
 	onclose(user, "mulebot")
 	return
 

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -188,6 +188,7 @@
 	user.set_machine(src)
 	var/dat = ui_text(user)
 	user << browse(HTML_SKELETON(jointext(dat, null)), "window=computer;size=400x500")
+	winset(user, "computer", "size=400x500")
 	onclose(user, "computer")
 
 /obj/machinery/computer/HolodeckControl/Topic(href, href_list)

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -306,6 +306,7 @@ var/list/message_monitors = list()
 	dat += "</body>"
 	message = defaultmsg
 	user << browse(HTML_SKELETON(dat), "window=message;size=700x700")
+	winset(user, "message", "size=700x700")
 	onclose(user, "message")
 	return
 

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -171,6 +171,7 @@
 
 	dat += "<BR><BR><A href='?src=\ref[user];mach_close=computer'>Close</A></TT></BODY></HTML>"
 	user << browse(HTML_SKELETON(dat), "window=computer;size=400x500")
+	winset(user, "computer", "size=400x500")
 	add_fingerprint(usr)
 	onclose(user, "computer")
 	return

--- a/code/game/machinery/computer/prisonshuttle.dm
+++ b/code/game/machinery/computer/prisonshuttle.dm
@@ -55,6 +55,7 @@ var/prison_shuttle_timeleft = 0
 		\n<A href='?src=\ref[user];mach_close=computer'>Close</A>"}
 
 	user << browse(HTML_SKELETON(dat), "window=computer;size=575x450")
+	winset(user, "computer", "size=575x450")
 	onclose(user, "computer")
 
 

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -206,6 +206,7 @@
 		else
 			dat += text("<A href='?src=\ref[];choice=Log In'>{Log In}</A>", src)
 	user << browse(HTML_SKELETON_TITLE("Security Records", "<TT>[dat]</TT>"), "window=secure_rec;size=600x400")
+	winset(user, "secure_rec", "size=600x400")
 	onclose(user, "secure_rec")
 	return
 

--- a/code/game/machinery/computer/shuttle_computers.dm
+++ b/code/game/machinery/computer/shuttle_computers.dm
@@ -287,6 +287,7 @@
 			<a href='?src=\ref[src];admin_reset=1'>Reset shuttle</a><br><i>Revert the shuttle's areas to initial state</i><br>"}
 
 	user << browse(HTML_SKELETON(dat), "window=shuttle_control;size=575x450")
+	winset(user, "shuttle_control", "size=575x450")
 	onclose(user, "shuttle_control")
 
 /// Only pass `user` if the mob is directly interacting through the UI.

--- a/code/game/machinery/computer/specops_shuttle.dm
+++ b/code/game/machinery/computer/specops_shuttle.dm
@@ -274,6 +274,7 @@ var/specops_shuttle_timeleft = 0
 		\n<A href='?src=\ref[user];mach_close=computer'>Close</A>"}
 
 	user << browse(HTML_SKELETON(dat), "window=computer;size=575x450")
+	winset(user, "computer", "size=575x450")
 	onclose(user, "computer")
 	return
 

--- a/code/game/machinery/computer/syndicate_specops_shuttle.dm
+++ b/code/game/machinery/computer/syndicate_specops_shuttle.dm
@@ -210,6 +210,7 @@ var/syndicate_elite_shuttle_timeleft = 0
 		\n<A href='?src=\ref[user];mach_close=computer'>Close</A>"}
 
 	user << browse(HTML_SKELETON(dat), "window=computer;size=575x450")
+	winset(user, "computer", "size=575x450")
 	onclose(user, "computer")
 	return
 

--- a/code/game/machinery/computer/tetris.dm
+++ b/code/game/machinery/computer/tetris.dm
@@ -274,6 +274,7 @@ var/list/deleted_machines_tetris_highscores = list()
 	</body>
 	</html>"}
 	user << browse(dat, "window=tetris;size=600x850")
+	winset(user, "tetris", "size=600x850")
 	user.set_machine(src)
 	onclose(user, "tetris")
 

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -155,6 +155,7 @@
 	dat += {"<br/><br/><a href='?src=\ref[user];mach_close=computer'>Close</a>
 			</TT></BODY></HTML>"}
 	user << browse(HTML_SKELETON(dat), "window=computer;size=400x500")
+	winset(user, "computer", "size=400x500")
 	onclose(user, "computer")
 
 

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -266,6 +266,7 @@
 		Path: {<a href='?src=\ref[src];operation=setpath'>[path]</a>}<br>
 		Moving: <a href='?src=\ref[src];operation=togglemoving'>[moving ? "Enabled":"Disabled"]</a>"}
 	user << browse(HTML_SKELETON(dat), "window=magnet;size=400x500")
+	winset(user, "magnet", "size=400x500")
 	onclose(user, "magnet")
 
 /obj/machinery/magnetic_controller/Topic(href, href_list)

--- a/code/game/machinery/metaldetector.dm
+++ b/code/game/machinery/metaldetector.dm
@@ -169,6 +169,7 @@
 		"}
 
 		user << browse(HTML_SKELETON(dat), "window=detector;size=575x300")
+		winset(user, "magnet", "size=575x300")
 		onclose(user, "detector")
 		return
 

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -560,6 +560,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 
 
 		M << browse(HTML_SKELETON(dat), "window=newscaster_main;size=400x600")
+		winset(M, "newscaster_main", "size=400x600")
 		onclose(M, "newscaster_main")
 
 /obj/machinery/newscaster/Topic(href, href_list)
@@ -1266,6 +1267,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 
 		dat+="<BR><HR><div align='center'>[curr_page+1]</div>"
 		usr << browse("<body style='background-color:#969696;color:black;'>[dat]</body>", "window=newspaper_main;size=400x400")
+		winset(usr, "newspaper_main", "size=400x400")
 		onclose(usr, "newspaper_main")
 	else
 		to_chat(user, "The paper is full of intelligible symbols!")

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -298,6 +298,7 @@
 			//onclose(user, "suit_storage_unit")
 
 	user << browse(HTML_SKELETON(dat), "window=suit_storage_unit;size=400x500")
+	winset(user, "suit_storage_unit", "size=400x500")
 	onclose(user, "suit_storage_unit")
 	return
 

--- a/code/game/machinery/telecomms/logbrowser.dm
+++ b/code/game/machinery/telecomms/logbrowser.dm
@@ -143,6 +143,7 @@ var/list/static/list_of_animal_types = typesof(/mob/living/simple_animal)
 
 
 	user << browse(HTML_SKELETON(dat), "window=comm_monitor;size=575x400")
+	winset(user, "comm_monitor", "size=575x400")
 	onclose(user, "server_control")
 
 	temp = ""

--- a/code/game/machinery/telecomms/telemonitor.dm
+++ b/code/game/machinery/telecomms/telemonitor.dm
@@ -86,6 +86,7 @@
 
 
 	user << browse(HTML_SKELETON(dat), "window=comm_monitor;size=575x400")
+	winset(user, "comm_monitor", "size=575x450")
 	onclose(user, "server_control")
 
 	temp = ""

--- a/code/game/machinery/telecomms/traffic_control.dm
+++ b/code/game/machinery/telecomms/traffic_control.dm
@@ -136,6 +136,7 @@
 
 
 	user << browse(HTML_SKELETON(dat), "window=traffic_control;size=575x400")
+	winset(user, "traffic_control", "size=575x450")
 	onclose(user, "server_control")
 
 	temp = ""

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -909,6 +909,7 @@ var/global/num_vending_terminals = 1
 			dat += "<br><br><i>Note: Remember to slide your ID on this machine to link your account. Once this is done, sliding your ID will enable editing and loading.</i>"
 
 	user << browse(HTML_SKELETON(dat), "window=vending;size=400x[vertical]")
+	winset(user, "vending", "size=400x[vertical]")
 	onclose(user, "vending")
 
 // returns the wire panel text

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -214,6 +214,7 @@ var/global/msg_id = 0
 	dat = jointext(dat,"") //Optimize BYOND's shittiness by making "dat" actually a list of strings and join it all together afterwards! Yes, I'm serious, this is actually a big deal
 
 	user << browse(HTML_SKELETON(dat), "window=pda;size=400x444;border=1;can_resize=1;can_minimize=0")
+	winset(user, "pda", "size=400x444")
 	onclose(user, "pda", src)
 
 /obj/item/device/pda/Topic(href, href_list)

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -560,6 +560,7 @@
 			dat += "<img src='tmp_photo_[note].png' width = '192' style='image-rendering: pixelated'><BR>"
 	dat += "</body></html>"
 	usr << browse(HTML_SKELETON(dat), "window=log;size=400x444;border=1;can_resize=1;can_close=1;can_minimize=0")
+	winset(usr, "log", "size=400x444")
 
 /mob/living/silicon/ai/proc/cmd_show_message_log()
 	if(usr.isDead())
@@ -579,6 +580,7 @@
 				dat += "<img src='tmp_photo_[note].png' width = '192' style='image-rendering: pixelated'><BR>"
 		dat += "</body></html>"
 		usr << browse(HTML_SKELETON(dat), "window=log;size=400x444;border=1;can_resize=1;can_close=1;can_minimize=0")
+		winset(usr, "log", "size=400x444")
 	else
 		to_chat(usr, "You do not have a PDA. You should make an issue report about this.")
 

--- a/code/game/objects/items/devices/healthanalyzerpro.dm
+++ b/code/game/objects/items/devices/healthanalyzerpro.dm
@@ -108,6 +108,7 @@
 			to_chat(user, "<span class='bnotice'>Accessing Prior Scan Result</span>")
 			if(mode == PRO_AUTOPSY_SCAN || mode == PRO_BODY_SCAN)
 				user << browse(HTML_SKELETON(last_reading), "window=borerscan;size=430x600")
+				winset(user, "borerscan", "size=430x600")
 			else
 				to_chat(user, last_reading)
 		else
@@ -166,6 +167,7 @@
 		else
 			to_chat(user, "<span class='info'>Autopsy analysis of [M] concluded.</span>")
 			user << browse(HTML_SKELETON(dat), "window=borerscan;size=430x600")
+			winset(user, "borerscan", "size=430x600")
 			last_reading = dat
 			last_scantime = world.time
 
@@ -190,6 +192,7 @@
 		var/dat
 		dat = format_occupant_data(get_occupant_data(M),1) //basic scan in unupgraded body analyzer
 		user << browse(HTML_SKELETON(dat), "window=borerscan;size=430x600")
+		winset(user, "borerscan", "size=430x600")
 		last_reading = dat
 		last_scantime = world.time
 	return

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -95,6 +95,7 @@
 	<BR> <B> Valve status: </B> [ valve_open ? "<A href='?src=\ref[src];open=1'>Closed</A> <B>Open</B>" : "<B>Closed</B> <A href='?src=\ref[src];open=1'>Open</A>"]"}
 
 	user << browse(HTML_SKELETON(dat), "window=trans_valve;size=600x300")
+	winset(user, "trans_valve", "size=600x300")
 	onclose(user, "trans_valve")
 	return
 

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -105,6 +105,7 @@
 		<A href='?src=\ref[src];type=7'>7</A>-<A href='?src=\ref[src];type=8'>8</A>-<A href='?src=\ref[src];type=9'>9</A><BR>\n
 		<A href='?src=\ref[src];type=R'>R</A>-<A href='?src=\ref[src];type=0'>0</A>-<A href='?src=\ref[src];type=E'>E</A><BR>\n</TT>"}
 	user << browse(HTML_SKELETON(dat), "window=caselock;size=300x280")
+	winset(user, "caselock", "size=300x280")
 
 /obj/item/weapon/storage/secure/Topic(href, href_list)
 	..()

--- a/code/hub.dm
+++ b/code/hub.dm
@@ -42,6 +42,7 @@ var/global/byond_hub_playercount = OPEN_TO_HUB_PLAYERCOUNT_DEFAULT
 	"}
 
 	usr << browse(HTML_SKELETON(dat), "window=admin2;size=600x400")
+	winset(usr, "admin2", "size=600x400")
 	return
 
 /world/proc/update_status()

--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -327,6 +327,7 @@ var/station_bonus = 0 //A bonus to station allowance that gets reset after wage 
 							</tr>"}
 					dat += "</table>"
 		user << browse(HTML_SKELETON(dat),"window=account_db;size=700x650")
+		winset(user, "account_db", "size=700x650")
 	else
 		user << browse(null,"window=account_db")
 

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -540,3 +540,4 @@
 		qdel(select_query)
 
 	usr << browse(HTML_SKELETON(output),"window=lookupbans;size=900x500")
+	winset(usr, "lookupbans", "size=900x500")

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -218,6 +218,7 @@ var/savefile/Banlist
 	dat += {"</table>
 		<HR><B>Bans:</B> <FONT COLOR=blue>(U) = Unban , (E) = Edit Ban</FONT> - <FONT COLOR=green>([count] Bans)</FONT><HR><table border=1 rules=all frame=void cellspacing=0 cellpadding=3 >[dat]"}
 	usr << browse(HTML_SKELETON(dat), "window=unbanp;size=875x400")
+	winset(usr, "unbanp", "size=875x400")
 
 //////////////////////////////////// DEBUG ////////////////////////////////////
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -243,6 +243,7 @@ var/global/floorIsLava = 0
 	"}
 
 	usr << browse(HTML_SKELETON(body), "window=adminplayeropts-\ref[M];size=550x515")
+	winset(usr, "adminplayeropts-\ref[M]", "size=550x515")
 	feedback_add_details("admin_verb","SPP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 
@@ -332,7 +333,7 @@ var/global/floorIsLava = 0
 				dat += "</b>"
 
 	usr << browse(HTML_SKELETON(dat), "window=player_notes;size=400x400")
-
+	winset(usr, "player_notes", "size=400x400")
 
 /datum/admins/proc/player_has_info(var/key as text)
 	var/savefile/info = new("data/player_saves/[copytext(key, 1, 2)]/[key]/info.sav")
@@ -408,6 +409,7 @@ var/global/floorIsLava = 0
 		</body></html>"}
 
 	usr << browse(HTML_SKELETON(dat), "window=adminplayerinfo;size=480x480")
+	winset(usr, "adminplayerinfo", "size=480x480")
 
 /datum/admins/proc/access_news_network() //MARKER
 	set category = "Fun"
@@ -651,6 +653,7 @@ var/global/floorIsLava = 0
 //	to_chat(world, "Channelname: [src.admincaster_feed_channel.channel_name] [src.admincaster_feed_channel.author]")
 //	to_chat(world, "Msg: [src.admincaster_feed_message.author] [src.admincaster_feed_message.body]")
 	usr << browse(HTML_SKELETON(dat), "window=admincaster_main;size=400x600")
+	winset(usr, "admincaster_main", "size=400x600")
 	onclose(usr, "admincaster_main")
 
 
@@ -667,6 +670,7 @@ var/global/floorIsLava = 0
 		dat += text("<tr><td>[t] (<A href='?src=\ref[src];removejobban=[r]'>unban</A>)</td></tr>")
 	dat += "</table>"
 	usr << browse(HTML_SKELETON(dat), "window=ban;size=400x400")
+	winset(usr, "ban", "size=400x400")
 
 /datum/admins/proc/Game()
 	if(!check_rights(0))
@@ -729,6 +733,7 @@ var/global/floorIsLava = 0
 	dat += "<A href ='?src=\ref[src];religions=1&display=1'>Manage religions</A><br>"
 
 	usr << browse(HTML_SKELETON(dat), "window=admin2;size=280x370")
+	winset(usr, "admin2", "size=280x370")
 	return
 
 /datum/admins/proc/dynamic_mode_options(mob/user)
@@ -765,6 +770,7 @@ var/global/floorIsLava = 0
 		"}
 
 	user << browse(HTML_SKELETON(dat), "window=dyn_mode_options;size=900x650")
+	winset(usr, "dyn_mode_options", "size=900x650")
 
 /datum/admins/proc/Secrets()
 	if(!check_rights(0))
@@ -1625,6 +1631,7 @@ var/alien_ship_location = 1 // 0 = base , 1 = mine
 	dat += "<hr><br><center>ADVANCED: <a href='?_src_=vars;Vars=\ref[end_credits]'>Debug Credits Datum</A></center>"
 
 	usr << browse(HTML_SKELETON(dat), "window=creditspanel;size=600x800")
+	winset(usr, "creditspanel", "size=600x800")
 
 /datum/admins/proc/PersistencePanel()
 	if(!check_rights(0))
@@ -1647,6 +1654,7 @@ var/alien_ship_location = 1 // 0 = base , 1 = mine
 		dat += "Max [T.max_per_turf] per turf. Lasts up to [T.max_age] rounds.<hr>"
 
 	usr << browse(HTML_SKELETON(dat), "window=persistencepanel;size=350x600")
+	winset(usr, "persistencepanel", "size=350x600")
 
 /datum/admins/proc/ViewAllRods()
 	if(!check_rights(0))
@@ -1661,3 +1669,4 @@ var/alien_ship_location = 1 // 0 = base , 1 = mine
 		dat += "<br/>"
 
 	usr << browse(HTML_SKELETON(dat), "window=rodswindow;size=350x300")
+	winset(usr, "rodswindow", "size=350x300")

--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -58,6 +58,7 @@ var/global/list/investigations=list(
 
 /datum/log_controller/proc/read(var/mob/user)
 	user << browse(HTML_SKELETON_TITLE(subject, file2text(handle)),"window=investigate[subject];size=800x300")
+	winset(user, "investigate[subject]", "size=800x300")
 
 // Calls our own formatting functions, but then appends to the global log.
 /atom/proc/investigation_log(var/subject, var/message)

--- a/code/modules/admin/admin_mass_del_in_zone.dm
+++ b/code/modules/admin/admin_mass_del_in_zone.dm
@@ -17,7 +17,7 @@
 		return FALSE
 
 	src = usr.client.holder // why lummox why
-	
+
 	var/list/dat = list()
 	dat += {"<h3>Mass deletion in a zone</h3>"
 	"Delete all the atoms of a given type in a zone given by z, x, and y coordinates."
@@ -35,3 +35,4 @@
 	"<a href='?src=\ref[src];change_zone_del=exec'>Delete it.</a>'"}
 
 	usr << browse(HTML_SKELETON(jointext(dat, "")), "window=mass_del_in_zone;size=490x310")
+	winset(usr, "mass_del_in_zone", "size=490x310")

--- a/code/modules/admin/artifacts_panel.dm
+++ b/code/modules/admin/artifacts_panel.dm
@@ -183,3 +183,4 @@
 		"}
 
 	usr << browse(HTML_SKELETON(dat), "window=artifactspanel;size=840x450")
+	winset(usr, "artifactspanel", "size=840x450")

--- a/code/modules/admin/body_archive_panel.dm
+++ b/code/modules/admin/body_archive_panel.dm
@@ -54,3 +54,4 @@
 		"}
 
 	usr << browse(HTML_SKELETON(dat), "window=bodyarchivepanel;size=860x640")
+	winset(usr, "bodyarchivepanel", "size=860x640")

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -45,3 +45,4 @@
 
 	dat += "</body></html>"
 	usr << browse(HTML_SKELETON(dat), "window=roundstatus;size=750x500")
+	winset(usr, "roundstatus", "size=750x500")

--- a/code/modules/admin/climate_panel.dm
+++ b/code/modules/admin/climate_panel.dm
@@ -34,3 +34,4 @@
 		"}
 
 	usr << browse(HTML_SKELETON(dat), "window=climatepanel;size=360x175")
+	winset(usr, "climatepanel", "size=360x175")

--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -7,3 +7,4 @@
 		create_mob_html = replacetext(create_mob_html, "null /* object types */", "\"[mobjs]\"")
 
 	user << browse(replacetext(create_mob_html, "/* ref src */", "\ref[src]"), "window=create_mob;size=700x500")
+	winset(user, "create_mob", "size=700x500")

--- a/code/modules/admin/create_object.dm
+++ b/code/modules/admin/create_object.dm
@@ -8,7 +8,7 @@
 		create_object_html = replacetext(create_object_html, "null /* object types */", "\"[objectjs]\"")
 
 	user << browse(replacetext(create_object_html, "/* ref src */", "\ref[src]"), "window=create_object;size=700x500")
-
+	winset(user, "create_object", "size=700x500")
 
 /datum/admins/proc/quick_create_object(var/mob/user)
 
@@ -27,3 +27,4 @@
 		quick_create_object_html = replacetext(quick_create_object_html, "null /* object types */", "\"[objectjs]\"")
 
 	user << browse(replacetext(quick_create_object_html, "/* ref src */", "\ref[src]"), "window=quick_create_object;size=700x500")
+	winset(user, "quick_create_object", "size=700x500")

--- a/code/modules/admin/create_turf.dm
+++ b/code/modules/admin/create_turf.dm
@@ -7,3 +7,4 @@
 		create_turf_html = replacetext(create_turf_html, "null /* object types */", "\"[turfjs]\"")
 
 	user << browse(replacetext(create_turf_html, "/* ref src */", "\ref[src]"), "window=create_turf;size=700x500")
+	winset(user, "create_turf", "size=700x500")

--- a/code/modules/admin/diseases_panel.dm
+++ b/code/modules/admin/diseases_panel.dm
@@ -66,4 +66,4 @@
 		"}
 
 	usr << browse(HTML_SKELETON(dat), "window=diseasespanel;size=705x450")
-
+	winset(usr, "diseasespanel", "size=705x450")

--- a/code/modules/admin/emergency_shuttle_panel.dm
+++ b/code/modules/admin/emergency_shuttle_panel.dm
@@ -67,3 +67,4 @@
 
 	dat += "</body></html>"
 	usr << browse(HTML_SKELETON(dat), "window=emergencyshuttle;size=440x500")
+	winset(usr, "emergencyshuttle", "size=440x500")

--- a/code/modules/admin/newbanjob.dm
+++ b/code/modules/admin/newbanjob.dm
@@ -226,7 +226,8 @@ var/savefile/Banlistjob
 	dat += {"</table>
 		<HR><B>Bans:</B> <FONT COLOR=blue>(U) = Unban , </FONT> - <FONT COLOR=green>([count] Bans)</FONT><HR><table border=1 rules=all frame=void cellspacing=0 cellpadding=3 >[dat]"}
 	usr << browse(HTML_SKELETON(dat), "window=unbanp;size=875x400")
-
+	winset(usr, "unbanp", "size=875x400")
+	
 /*/datum/admins/proc/permjobban(ckey, computerid, reason, bannedby, temp, minutes, rank)
 	if(AddBanjob(ckey, computerid, reason, usr.ckey, 0, 0, job))
 		to_chat(M, "<span class='warning'><BIG><B>You have been banned from [job] by [usr.client.ckey].\nReason: [reason].</B></BIG></span>")

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -53,6 +53,7 @@
 </html>"}
 
 	usr << browse(HTML_SKELETON(output),"window=editrights;size=600x500")
+	winset(usr, "editrights", "size=600x500")
 
 /datum/admins/proc/log_admin_rank_modification(var/adm_ckey, var/new_rank)
 	if(config.admin_legacy_system)

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -341,6 +341,7 @@
 	"}
 
 	usr << browse(HTML_SKELETON(dat), "window=players;size=600x480")
+	winset(usr, "players", "size=600x480")
 
 //The old one
 /datum/admins/proc/player_panel_old()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1403,6 +1403,7 @@
 		body = "<body>[jobs]</body>"
 		dat = "<tt>[header][body]</tt>"
 		usr << browse(HTML_SKELETON(dat), "window=jobban2;size=800x490")
+		winset(usr, "jobban2", "size=800x490")
 		return
 
 	//JOBBAN'S INNARDS
@@ -4437,6 +4438,7 @@ access_sec_doors,access_salvage_captain,access_cent_ert,access_syndicate,access_
 				for(var/sig in lawchanges)
 					dat += "[sig]<BR>"
 				usr << browse(HTML_SKELETON(dat), "window=lawchanges;size=800x500")
+				winset(usr, "lawchanges", "size=800x500")
 			if("list_job_debug")
 				var/dat = "<B>Job Debug info.</B><HR>"
 				if(job_master)
@@ -4448,6 +4450,7 @@ access_sec_doors,access_salvage_captain,access_cent_ert,access_syndicate,access_
 							continue
 						dat += "job: [job.title], current_positions: [job.current_positions], total_positions: [job.get_total_positions()] <BR>"
 					usr << browse(HTML_SKELETON(dat), "window=jobdebug;size=600x500")
+					winset(usr, "jobdebug", "size=600x500")
 			if("showailaws")
 				output_ai_laws()
 			if("showgm")
@@ -4465,6 +4468,7 @@ access_sec_doors,access_salvage_captain,access_cent_ert,access_syndicate,access_
 						dat += text("<tr><td>[]</td><td>[]</td></tr>", H.name, H.get_assignment())
 				dat += "</table>"
 				usr << browse(HTML_SKELETON(dat), "window=manifest;size=440x410")
+				winset(usr, "manifest", "size=440x410")
 			// if("check_antagonist")
 			// 	check_antagonists()
 			if("emergency_shuttle_panel")
@@ -4477,6 +4481,7 @@ access_sec_doors,access_salvage_captain,access_cent_ert,access_syndicate,access_
 						dat += "<tr><td>[H]</td><td>[H.dna.unique_enzymes]</td><td>[H.dna.b_type]</td></tr>"
 				dat += "</table>"
 				usr << browse(HTML_SKELETON(dat), "window=DNA;size=440x410")
+				winset(usr, "DNA", "size=440x410")
 			if("fingerprints")
 				var/dat = "<B>Showing Fingerprints.</B><HR>"
 				dat += "<table cellspacing=5><tr><th>Name</th><th>Fingerprints</th></tr>"
@@ -4490,6 +4495,7 @@ access_sec_doors,access_salvage_captain,access_cent_ert,access_syndicate,access_
 							dat += "<tr><td>[H]</td><td>H.dna = null</td></tr>"
 				dat += "</table>"
 				usr << browse(HTML_SKELETON(dat), "window=fingerprints;size=440x410")
+				winset(usr, "fingerprints", "size=440x410")
 			if("show_admin_log")
 				var/dat = "<B>Admin Log<HR></B>"
 				for(var/l in admin_log)
@@ -5945,3 +5951,4 @@ access_sec_doors,access_salvage_captain,access_cent_ert,access_syndicate,access_
 			text += "<A HREF='?src=\ref[src];religions=global_subtle_pm&rel=\ref[R]'>Subtle PM all believers</a> <br/>"
 	text += "<A HREF='?src=\ref[src];religions=new'>Bus in a new religion</a> <br/>"
 	usr << browse(HTML_SKELETON(jointext(text, "")), "window=admin2;size=300x370")
+	winset(usr, "admin2", "size=300x370")

--- a/code/modules/admin/verbs/atmosdebug.dm
+++ b/code/modules/admin/verbs/atmosdebug.dm
@@ -36,6 +36,8 @@
 
 	output += "</ul>"
 	usr << browse(HTML_SKELETON(output),"window=pipereport;size=1000x500")
+	winset(usr, "pipereport", "size=1000x500")
+
 /client/proc/powerdebug()
 	set category = "Mapping"
 	set name = "Check Power"
@@ -64,3 +66,4 @@
 
 	output += "</ul><br>[empty_nets] powernets without nodes detected, [low_nets] with less than 10 cables."
 	usr << browse(HTML_SKELETON(output),"window=pipereport;size=1000x500")
+	winset(usr, "pipereport", "size=1000x500")

--- a/code/modules/admin/verbs/check_customitem_activity.dm
+++ b/code/modules/admin/verbs/check_customitem_activity.dm
@@ -25,6 +25,7 @@ var/inactive_keys = "None<br>"
 		dat += "<a href='?src=\ref[src];_src_=holder;populate_inactive_customitems=1'>Populate list (requires an active database connection)</a><br>"
 
 	usr << browse(HTML_SKELETON(dat), "window=inactive_customitems;size=600x480")
+	winset(usr, "inactive_customitems", "size=600x480")
 
 /proc/populate_inactive_customitems_list(var/client/C)
 	//set background = 1

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -83,6 +83,7 @@
 
 	output += "</ul>"
 	usr << browse(HTML_SKELETON(output),"window=airreport;size=1000x500")
+	winset(usr, "airreport", "size=1000x500")
 	feedback_add_details("admin_verb","mCRP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/intercom_view()
@@ -420,7 +421,7 @@ var/global/movement_disabled_exception //This is the client that calls the proc,
 		neighbour = locate() in get_step(get_turf(C),C.d2)
 		if(!neighbour || neighbour.get_powernet() != C.get_powernet())
 			error_str += "<span class = 'warning'>Disconnected wire at [formatJumpTo(get_turf(C))]</span><br>"
-	
+
 	var/datum/browser/popup = new(usr, "Wire connections", usr.name, 300, 400)
 	popup.set_content(error_str)
 	popup.open()
@@ -497,3 +498,4 @@ var/global/movement_disabled_exception //This is the client that calls the proc,
 
 	output += "</ul><br>[bad_pipes] bad pipes detected."
 	usr << browse(HTML_SKELETON(output),"window=distrowastemixreport;size=1000x500")
+	winset(usr, "distrowastemixreport", "size=1000x500")

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -22,6 +22,7 @@
 		"}
 
 	usr << browse(HTML_SKELETON(dat), "window=oneclickantag;size=400x400")
+	winset(usr, "oneclickantag", "size=400x400")
 	return
 
 

--- a/code/modules/client/preferences/preferences_ui.dm
+++ b/code/modules/client/preferences/preferences_ui.dm
@@ -537,6 +537,7 @@
 		</center></tt>"}
 	user << browse(null, "window=preferences")
 	user << browse(HTML_SKELETON(HTML), "window=disabil;size=350x300")
+	winset(user, "disabil", "size=350x300")
 	return
 
 /datum/preferences/proc/SetRecords(mob/user)
@@ -573,6 +574,7 @@
 		</center></tt>"}
 	user << browse(null, "window=preferences")
 	user << browse(HTML_SKELETON(HTML), "window=records;size=350x300")
+	winset(user, "records", "size=350x300")
 	return
 
 

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -53,6 +53,7 @@ var/list/tag_suits_list = list()
 		return
 	else
 		H << browse(get_window_text(H),"window=laser_tag_window;size=700x500")
+		winset(H, "laser_tag_window", "size=700x500")
 
 /obj/item/clothing/suit/tag/proc/get_window_text(var/mob/living/carbon/human/H)
 	var/dat = list()
@@ -91,6 +92,7 @@ var/list/tag_suits_list = list()
 		<b><a href='?src=\ref[src]&edition_done=\ref[my_laser_tag_game]'>Done</a></b>
 	""}
 	user << browse(HTML_SKELETON(dat),"window=laser_tag_window2;size=250x250")
+	winset(user, "laser_tag_window2", "size=250x250")
 
 /obj/item/clothing/suit/tag/Topic(href, href_list)
 	if(..())
@@ -101,6 +103,7 @@ var/list/tag_suits_list = list()
 		game.handle_new_player(player, usr)
 		my_laser_tag_game = game
 		usr << browse(HTML_SKELETON(get_window_text(usr)),"window=laser_tag_window;size=500x250")
+		winset(usr, "laser_tag_window", "size=500x250")
 		return
 
 	if (href_list["create_game"])
@@ -111,6 +114,7 @@ var/list/tag_suits_list = list()
 		game.handle_new_player(player, usr)
 		refresh_edit_window(usr, game)
 		usr << browse(HTML_SKELETON(get_window_text(usr)),"window=laser_tag_window;size=500x250")
+		winset(usr, "laser_tag_window", "size=500x250")
 		return
 
 	// Game parametrisation
@@ -189,6 +193,7 @@ var/list/tag_suits_list = list()
 		var/datum/laser_tag_game/game = locate(href_list["leave_game"])
 		game.kick_player(usr)
 		usr << browse(HTML_SKELETON(get_window_text(usr)),"window=laser_tag_window;size=500x250")
+		winset(usr, "laser_tag_window", "size=500x250")
 		return
 
 	if (href_list["clear_gamertag"])

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -214,6 +214,7 @@
 		last_data = dat
 		dat += "<br>\[<a href='?src=\ref[src];print=1'>print report</a>\] \[<a href='?src=\ref[src];clear=1'>clear</a>\]"
 		user << browse(HTML_SKELETON(dat),"window=plant_analyzer_\ref[src];size=500x600")
+		winset(user, "account_db", "size=700x650")
 	return
 
 /obj/item/device/analyzer/plant_analyzer/attack_self(mob/user as mob)

--- a/code/modules/library/computers/checkout.dm
+++ b/code/modules/library/computers/checkout.dm
@@ -535,6 +535,7 @@
 			return*/
 		var/book_text = "<TT><I>[PVB.title] by [PVB.author].</I></TT> <BR>[PVB.content]"
 		usr << browse(HTML_SKELETON(book_text), "window=[PVB.title];size=600x800")
+		winset(usr, PVB.title, "size=600x800")
 
 	if(href_list["delqueue"])
 		var/slot = text2num(href_list["delqueue"])

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -260,6 +260,7 @@
 		if(!isobserver(user))
 			user.visible_message("<span class='notice'>[user] opens a manual titled \"[src.title]\" and begins reading intently.</span>")
 		user << browse(dat, "window=[name];size=[book_width]x[book_height]")
+		winset(user, name, "size=[book_width]x[book_height]")
 		return
 	// typechecking src is the big gay but here it's kinda the most straightforward way to handle.
 	// Manuals have well-formed HTML so HTML_SKELETON isn't needed here
@@ -267,8 +268,10 @@
 		if(!isobserver(user))
 			user.visible_message("<span class='notice'>[user] opens a manual titled \"[src.title]\" and begins reading intently.</span>")
 		user << browse(dat, "window=[name];size=[book_width]x[book_height]")
+		winset(user, name, "size=[book_width]x[book_height]")
 	if(src.dat)
 		user << browse(HTML_SKELETON("<TT><I>Penned by [author].</I></TT> <BR>[dat]"), "window=[name];size=[book_width]x[book_height]")
+		winset(user, name, "size=[book_width]x[book_height]")
 		if(!isobserver(user))
 			user.visible_message("<span class='notice'>[user] opens a book titled \"[src.title]\" and begins reading intently.</span>")
 		onclose(user, "book")

--- a/code/modules/mob/dead/observer/verbs.dm
+++ b/code/modules/mob/dead/observer/verbs.dm
@@ -304,6 +304,7 @@
 	dat += data_core.get_manifest(OOC = 1)
 
 	src << browse(HTML_SKELETON(dat), "window=manifest;size=370x420;can_close=1")
+	winset(src, "manifest", "size=370x420")
 
 //Used for drawing on walls with blood puddles as a spooky ghost.
 /mob/dead/verb/bloody_doodle()

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -111,6 +111,7 @@
 			</body>
 			</html>"}
 	src << browse(HTML_SKELETON(dat), "window=pai;size=640x480;border=0;can_close=1;can_resize=1;can_minimize=1;titlebar=1")
+	winset(src, "pai", "size=640x480")
 	onclose(usr, "pai")
 	temp = null
 	return

--- a/code/modules/mob/living/simple_animal/borer/verbs_attached_chest.dm
+++ b/code/modules/mob/living/simple_animal/borer/verbs_attached_chest.dm
@@ -51,6 +51,7 @@
 		var/dat
 		dat = format_host_data(get_host_data())
 		src << browse(HTML_SKELETON(dat), "window=borerscan;size=430x600")
+		winset(src, "borerscan", "size=430x600")
 		return
 
 /mob/living/simple_animal/borer/proc/get_host_data()

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -215,6 +215,7 @@
 		dat +=	"<br><b>Headset:</b> <a href='?src=\ref[src];add_inv=ears'>Nothing</a>"
 
 	user << browse(HTML_SKELETON(dat), "window=mob[real_name];size=325x500")
+	winset(src, "mob[real_name]", "size=325x500")
 	onclose(user, "mob[real_name]")
 
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1249,6 +1249,7 @@ Use this proc preferably at the end of an equipment loadout
 					Version: [byond_version].[byond_build] Revision: [return_revision()]
 					<iframe src='http://ss13.moe/issues/?ckey=[ckey(key)]&address=[world.internet_address]:[world.port]&byondver=[byond_version].[byond_build]&revision=[return_revision()]' style='border:none' width='480' height='480' scroll=no></iframe>"}
 	src << browse(HTML_SKELETON(dat), "window=github;size=480x480")
+	winset(src, "github", "size=480x480")
 
 /client/verb/changes()
 	set name = "Changelog"
@@ -1275,6 +1276,7 @@ Use this proc preferably at the end of an equipment loadout
 		'html/changelog.html'
 		)
 	src << browse('html/changelog.html', "window=changes;size=675x650")
+	winset(src, "changes", "size=675x650")
 
 	if(prefs.get_pref(/datum/preference_setting/string/changelog) != changelog_hash)
 		prefs.SetChangelog(ckey, changelog_hash)

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -67,6 +67,7 @@
 					'html/changelog.html'
 					)
 				src << browse('html/changelog.html', "window=changes;size=675x650")
+				winset(src, "changes", "size=675x650")
 				client.prefs.SetChangelog(ckey, changelog_hash)
 				winset(client, "rpane.changelog", "background-color=none;font-style=;")
 #endif

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -667,6 +667,7 @@
 	dat += "</table>"
 	dat += "</center>"
 	src << browse(HTML_SKELETON(dat), "window=latechoices;size=360x640;can_close=1")
+	winset(src, "latechoices", "size=360x640")
 
 
 /mob/new_player/proc/create_human(var/datum/preferences/prefs)
@@ -843,6 +844,7 @@
 	dat += job_master.display_prediction()
 
 	src << browse(HTML_SKELETON(dat), "window=manifest;size=370x420;can_close=1")
+	winset(src, "manifest", "size=370x420")
 
 /mob/new_player/proc/ViewManifest()
 	var/dat = {"<html><body>
@@ -850,6 +852,7 @@
 	dat += data_core.get_manifest(OOC = 1)
 
 	src << browse(HTML_SKELETON(dat), "window=manifest;size=370x420;can_close=1")
+	winset(src, "manifest", "size=370x420")
 
 /mob/new_player/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, glide_size_override = 0)
 	return 0

--- a/code/modules/mob/new_player/poll.dm
+++ b/code/modules/mob/new_player/poll.dm
@@ -35,7 +35,7 @@
 		output += "</table>"
 		qdel(select_query)
 		src << browse(HTML_SKELETON(output),"window=playerpolllist;size=500x300")
-
+		winset(src, "playerpolllist", "size=500x300")
 
 
 /mob/new_player/proc/poll_player(var/pollid = -1)
@@ -135,6 +135,7 @@
 				output += "</div>"
 
 				src << browse(HTML_SKELETON(output),"window=playerpoll;size=500x250")
+				winset(src, "playerpoll", "size=500x250")
 
 			//Polls with a text input
 			if("TEXT")
@@ -181,6 +182,7 @@
 					output += "[vote_text]"
 
 				src << browse(HTML_SKELETON(output),"window=playerpoll;size=500x500")
+				winset(src, "playerpoll", "size=500x500")
 
 			//Polls with a text input
 			if("NUMVAL")
@@ -265,6 +267,8 @@
 						</form>"}
 					qdel(option_query)
 				src << browse(HTML_SKELETON(output),"window=playerpoll;size=500x500")
+				winset(src, "playerpoll", "size=500x500")
+
 			if("SELECT_ALL_THAT_APPLY")
 				var/datum/DBQuery/voted_query = SSdbcore.NewQuery("SELECT optionid FROM erro_poll_vote WHERE pollid = :id AND ckey = :ckey", list("id" = pollid, "ckey" = "[usr.ckey]"))
 				if(!voted_query.Execute())
@@ -335,6 +339,7 @@
 				output += "</div>"
 
 				src << browse(HTML_SKELETON(output),"window=playerpoll;size=500x250")
+				winset(src, "playerpoll", "size=500x250")
 		return
 
 /mob/new_player/proc/vote_on_poll(var/pollid = -1, var/optionid = -1, var/select_all_that_apply = 0)

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -460,6 +460,7 @@ nanoui is used to open and update nano browser uis
 		window_size = "size=[width]x[height];"
 	update_status(0)
 	user << browse(get_html(), "window=[window_id];[window_size][window_options]")
+	winset(user, window_id, window_size)
 	winset(user, "mapwindow.map", "focus=true") // return keyboard focus to map
 	on_close_winset()
 	//onclose(user, window_id)

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -79,6 +79,7 @@
 		dat += "<tr><td><a href='?src=\ref[src];retrieve=\ref[P]'>[P.name]</a></td></tr>"
 	dat += "</table></center>"
 	user << browse("<html><head><title>[name]</title></head><body>[dat]</body></html>", "window=filingcabinet;size=350x300")
+	winset(user, "filingcabinet", "size=350x300")
 
 	return
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -60,6 +60,7 @@
 		user << browse_rsc(img.img, "tmp_photo.png")
 		info_image = "<img src='tmp_photo.png' width='192' style='image-rendering: pixelated' /><br><a href='?src=\ref[src];picture=1'>Remove</a><br>"
 	user << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY[color ? " bgcolor=[src.color]":""]>[info_image][info_text][stamps]</BODY></HTML>", "window=[name];size=[display_x]x[display_y]")
+	winset(user, name, "size=[display_x]x[display_y]")
 	onclose(user, "[name]")
 
 /obj/item/weapon/paper/update_icon()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -83,6 +83,7 @@
 		+ "<img src='tmp_photo.png' width='[displaylength]' style='image-rendering: pixelated' />" \
 		+ "[scribble ? "<br>Written on the back:<br><i>[scribble]</i>" : ""]"\
 		+ "</body></html>", "window=book;size=[displaylength]x[scribble ? displaylength+108 : displaylength]")
+	winset(user, "book", "size=[displaylength]x[scribble ? displaylength+108 : displaylength]")
 	if(info) //Would rather not display a blank line of text
 		to_chat(user, info)
 	onclose(user, "[name]")

--- a/code/modules/power/rust/fuel_compressor.dm
+++ b/code/modules/power/rust/fuel_compressor.dm
@@ -50,6 +50,7 @@ var/const/max_assembly_amount = 300
 	t += {"<hr>
 		<A href='?src=\ref[src];close=1'>Close</A><BR>"}
 	user << browse(HTML_SKELETON(t), "window=fuelcomp;size=500x300")
+	winset(user, "fuelcomp", "size=500x300")
 	user.set_machine(src)
 
 	//var/locked

--- a/code/modules/power/rust/fuel_control.dm
+++ b/code/modules/power/rust/fuel_control.dm
@@ -114,6 +114,7 @@
 		<A href='?src=\ref[src];refresh=1'>Refresh</A>
 		<A href='?src=\ref[src];close=1'>Close</A><BR>"}
 	user << browse(HTML_SKELETON(dat), "window=fuel_control;size=800x400")
+	winset(user, "fuel_control", "size=800x400")
 	user.set_machine(src)
 
 /obj/machinery/computer/rust_fuel_control/Topic(href, href_list)

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -274,6 +274,7 @@
 		dat += "<span class='warning'><B>No compatible attached compressor found.</span>"
 
 	user << browse(HTML_SKELETON(dat), "window=computer;size=400x500")
+	winset(user, "computer", "size=400x500")
 	onclose(user, "computer")
 	return
 

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -37,6 +37,7 @@
 	update_dat()
 
 	user << browse("<TITLE>Temperature Gun Configuration</TITLE><HR>[dat]", "window=tempgun;size=510x102")
+	winset(user, "tempgun", "size=510x102")
 	onclose(user, "tempgun")
 
 /obj/item/weapon/gun/energy/temperature/emag_act(mob/user)
@@ -108,7 +109,7 @@
 			if (src == M.machine)
 				update_dat()
 				M << browse("<TITLE>Temperature Gun Configuration</TITLE><HR>[dat]", "window=tempgun;size=510x102")
-
+				winset(M, "tempgun", "size=510x102")
 
 	if(power_supply)
 		power_supply.give(50)

--- a/code/modules/projectiles/guns/projectile/constructable/flamethrower.dm
+++ b/code/modules/projectiles/guns/projectile/constructable/flamethrower.dm
@@ -199,6 +199,7 @@
 		user.set_machine(src)
 		var/dat = text("<TT><B>Flamethrower (<A HREF='?src=\ref[src];light=1'>[lit ? "<font color='red'>Lit</font>" : "Unlit"]</a>)</B><BR>\n Tank Pressure: [ptank ? "[ptank.air_contents.return_pressure()]" : "No tank loaded."]<BR>\nPercentage to throw: <A HREF='?src=\ref[src];amount=-100'>-</A> <A HREF='?src=\ref[src];amount=-10'>-</A> <A HREF='?src=\ref[src];amount=-1'>-</A> [throw_percent] <A HREF='?src=\ref[src];amount=1'>+</A> <A HREF='?src=\ref[src];amount=10'>+</A> <A HREF='?src=\ref[src];amount=100'>+</A><BR>\n<A HREF='?src=\ref[src];remove=1'>Remove plasmatank</A> - <A HREF='?src=\ref[src];close=1'>Close</A></TT>")
 		user << browse(HTML_SKELETON(dat), "window=flamethrower;size=600x300")
+		winset(user, "flamethrower", "size=600x300")
 		onclose(user, "flamethrower", src)
 
 /obj/item/weapon/gun/projectile/flamethrower/Topic(href,href_list[])

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -306,6 +306,7 @@
 				dat += "[S.name] <A href='?src=\ref[src];send_to=[S.server_id]'> (Transfer)</A><BR>"
 			dat += "<HR><A href='?src=\ref[src];main=1'>Main Menu</A>"
 	user << browse(HTML_SKELETON_TITLE("R&D Server Control", dat), "window=server_control;size=575x400")
+	winset(user, "server_control", "size=575x400")
 	onclose(user, "server_control")
 	return
 

--- a/code/modules/research/xenoarchaeology/machinery/artifact_harvester.dm
+++ b/code/modules/research/xenoarchaeology/machinery/artifact_harvester.dm
@@ -137,6 +137,7 @@
 	dat += "<HR>"
 	dat += "<A href='?src=\ref[src];refresh=1'>Refresh</A> <A href='?src=\ref[src];close=1'>Close<BR>"
 	user << browse(HTML_SKELETON(dat), "window=artharvester;size=450x500")
+	winset(user, "artharvester", "size=450x500")
 	onclose(user, "artharvester")
 
 /obj/machinery/artifact_harvester/process()

--- a/code/modules/research/xenoarchaeology/tools/ano_device_battery.dm
+++ b/code/modules/research/xenoarchaeology/tools/ano_device_battery.dm
@@ -113,6 +113,7 @@ var/list/anomaly_power_utilizers = list()
 	dat += "<a href='?src=\ref[src]'>Refresh</a> <a href='?src=\ref[src];close=1'>Close</a>"
 
 	user << browse(HTML_SKELETON(dat), "window=anodevice;size=400x500")
+	winset(user, "anodevice", "size=400x500")
 	onclose(user, "anodevice")
 
 /obj/item/weapon/anodevice/process()

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -135,6 +135,7 @@
 	dat += "<A href='?src=\ref[src];refresh=1'>Refresh console</A><br>"
 	dat += "<A href='?src=\ref[src];close=1'>Close console</A>"
 	user << browse(HTML_SKELETON(dat), "window=suspension;size=500x400")
+	winset(user, "suspension", "size=400x500")
 	onclose(user, "suspension")
 
 /obj/machinery/suspension_gen/Topic(href, href_list)

--- a/code/modules/research/xenoarchaeology/tools/tools_depthscanner.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_depthscanner.dm
@@ -118,6 +118,7 @@
 	dat += "<A href='?src=\ref[src];refresh=1'>Refresh</a><br>"
 	dat += "<A href='?src=\ref[src];close=1'>Close</a><br>"
 	user << browse(HTML_SKELETON(dat),"window=depth_scanner;size=300x500")
+	winset(user, "depth_scanner", "size=300x500")
 	onclose(user, "depth_scanner")
 
 /obj/item/device/depth_scanner/Topic(href, href_list)

--- a/code/modules/research/xenoarchaeology/tools/tools_locater.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_locater.dm
@@ -75,6 +75,7 @@
 
 	dat += "<A href='?src=\ref[src];close=1'>Close</a><br>"
 	user << browse(HTML_SKELETON(dat),"window=locater;size=300x150")
+	winset(user, "locater", "size=300x150")
 	onclose(user, "locater")
 
 /obj/item/device/beacon_locator/Topic(href, href_list)

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -105,6 +105,7 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 			<li><A href='?src=\ref[src];triggerevent=Revoke Emergency Maintenance Access'>Revoke Emergency Maintenance Access</A></li>
 			</ul>"}
 		user << browse(HTML_SKELETON(dat), "window=keycard_auth;size=500x300")
+		winset(user, "keycard_auth", "size=500x300")
 	if(screen == 2)
 
 		dat += "Please swipe your card to authorize the following event: <b>[event]</b>"
@@ -113,6 +114,7 @@ var/global/list/obj/machinery/keycard_auth/authenticators = list()
 
 		dat += "<p><A href='?src=\ref[src];reset=1'>Back</A>"
 		user << browse(HTML_SKELETON(dat), "window=keycard_auth;size=500x300")
+		winset(user, "keycard_auth", "size=500x300")
 	return
 
 

--- a/code/modules/virus2/curer.dm
+++ b/code/modules/virus2/curer.dm
@@ -64,6 +64,7 @@
 		dat = "Please insert a container."
 
 	user << browse(HTML_SKELETON(dat), "window=computer;size=400x500")
+	winset(user, "computer", "size=400x500")
 	onclose(user, "computer")
 	return
 

--- a/code/modules/virus2/isolator.dm
+++ b/code/modules/virus2/isolator.dm
@@ -93,6 +93,7 @@
 				else
 					dat += "<li><em>No pathogen</em></li>"
 	user << browse(HTML_SKELETON_TITLE("Pathogenic Isolator", "Isolator menu:<BR><BR>[dat]</ul>"), "window=isolator;size=575x400")
+	winset(user, "isolator", "size=575x400")
 	onclose(user, "isolator")
 	return
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -42,6 +42,7 @@
 	set desc = "Show Server Rules."
 	set hidden = 1
 	src << browse(file(RULES_FILE), "window=rules;size=480x320")
+	winset(src, "rules", "size=480x320")
 #undef RULES_FILE
 
 /client/verb/hotkeys_help()

--- a/maps/randomvaults/objects.dm
+++ b/maps/randomvaults/objects.dm
@@ -654,6 +654,7 @@
 
 	var/dat = text("<B>Engine Ejection Module</B><HR>\nStatus: Ejected<BR>\n<BR>\nCountdown: N/60 \[Reset\]<BR>\n<BR>\nEngine Ejected!<BR>\n<BR>\n<A href='?src=\ref[];mach_close=computer'>Close</A>", user)
 	user << browse(HTML_SKELETON(dat), "window=computer;size=400x500")
+	winset(user, "computer", "size=400x500")
 
 /obj/machinery/computer/ejectedengine/shield
 	name = "Shield Control Console"
@@ -667,6 +668,7 @@
 
 	var/dat = text("<B>Shield Generator Control</B><HR>\n<font color=red>Error:</font> Cannot locate projector array<BR>\n<font color=red>Error:</font> Cannot locate shield capacitors<BR>\n<font color=red>Error:</font> Cannot locate command signal<BR>\n<BR>\n<A href='?src=\ref[];mach_close=computer'>Close</A>", user)
 	user << browse(HTML_SKELETON(dat), "window=computer;size=400x500")
+	winset(user, "computer", "size=400x500")
 
 /obj/machinery/door/firedoor/red
 	name = "\improper Firelock"


### PR DESCRIPTION
This was on advice of Lummox; the idea is that the windows that pop up are too small because Windows creates a drop-shadow effect (among other things) that take up space and the actual browser window is too small. You see, the `browse` parameters aren't about the size of the browser window, but the size of the pop-up.

`winset`, however, should fix the internal window size.

This should close #37697. Maybe.

Given that TGUI already uses this system and isn't affected, I think lummox was on the right track. This was minimally tested (since I don't experience the bug in the first place) but I did check the syntax I use in `winset` was correct.