### PR TITLE
fix mob runtimes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
@@ -78,7 +78,8 @@
 	..()
 
 /mob/living/simple_animal/hostile/humanoid/kitchen/meatballer/adjustBruteLoss(var/damage)
-	if(prob(damage*(maxHealth/health)))
+	var/proc_chance = min(100, 130 - health/maxHealth*100)
+	if(!isDead() && prob(proc_chance))
 		fire_everything()
 	..()
 
@@ -223,7 +224,8 @@
 			return unlock_atom(L)
 
 /mob/living/simple_animal/hostile/humanoid/vampire/adjustBruteLoss(var/damage)
-	if(!isDead() && prob(damage*(maxHealth/health)) && world.time > last_jaunt + JAUNT_COOLDOWN)
+	var/proc_chance = min(100, 130 - health/maxHealth*100)
+	if(!isDead() && prob(proc_chance) && world.time > last_jaunt + JAUNT_COOLDOWN)
 		last_jaunt = world.time
 		jaunt_away()
 	..()
@@ -352,7 +354,8 @@
 
 /mob/living/simple_animal/hostile/gremlin/greytide/adjustBruteLoss()
 	..()
-	if(!isDead() && prob(30*(maxHealth/health)))
+	var/proc_chance = min(100, 130 - health/maxHealth*100)
+	if(!isDead() && prob(proc_chance))
 		visible_message("<span class = 'warning'>\The [src] looks to be annoyed!</span>")
 		annoyed = 1
 		spawn(rand(15 SECONDS, 45 SECONDS))


### PR DESCRIPTION
So there's some weird percentage prob(damage*(maxHealth/health) that makes 0 sense, so I modified it to stop division by 0 and hopefully restore intended behavior. With lower health, these mobs have a higher probability of procing

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
fixes proc values

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
- no more runtimes for multiple mobs: fix #36998

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
compiles

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: fix some mob runtimes and apply intended behavior
