### PR TITLE
junga junga junga fix fix fix

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -2053,7 +2053,9 @@ var/global/list/adminbusteleportlocs = list()
 
 /area/surface/jungle/underground/zoned/ghettosurgery
 	name = "\improper Ghetto Surgery"
-	
+
+/area/surface/jungle/underground/zoned/ghettomining
+	name = "\improper Refinery"	
 
 /area/surface/jungle/zoned
 	forbid_apc=FALSE

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -2057,6 +2057,9 @@ var/global/list/adminbusteleportlocs = list()
 /area/surface/jungle/underground/zoned/ghettomining
 	name = "\improper Refinery"	
 
+/area/surface/jungle/underground/zoned/casino
+	name = "\improper Casino"	
+
 /area/surface/jungle/zoned
 	forbid_apc=FALSE
 	construction_zone=FALSE

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -194,7 +194,7 @@
 
 /obj/structure/fence/door/New()
 	..()
-
+	set_up_access()
 	update_door_status()
 
 /obj/structure/fence/door/opened
@@ -203,8 +203,10 @@
 
 /obj/structure/fence/door/attack_hand(mob/user)
 	if(can_open(user))
-		toggle(user)
-
+		if(open || check_access(user))
+			toggle(user)
+		else
+			playsound(loc, 'sound/machines/denied.ogg', 50, 1)
 	return 1
 
 /obj/structure/fence/door/proc/toggle(mob/user)

--- a/code/game/objects/structures/flora/flora.dm
+++ b/code/game/objects/structures/flora/flora.dm
@@ -11,10 +11,10 @@
 	update_icon()
 
 /obj/structure/flora/Destroy()
-	..()
 	if(istype(loc,/turf/unsimulated/floor/jungle/grass))
 		var/turf/unsimulated/floor/jungle/grass/G=loc
 		G.turf_speed_multiplier=1.1
+	..()
 
 /obj/structure/flora/update_icon()
 	clicked = new/icon(src.icon, src.icon_state, src.dir)
@@ -695,3 +695,61 @@
 /obj/structure/flora/rock/pile/snow/New()
 	..()
 	icon_state = "srockpile[rand(1,5)]"
+
+
+/obj/structure/flora/jungle_berries
+	name = "Berry Bush"
+	desc = "I eated the purple berries."
+	icon = 'icons/obj/hydroponics/berry.dmi'
+	icon_state="stage-6"
+	var/hasberries=FALSE
+	var/tickssincelastgrowth=0
+
+/obj/structure/flora/jungle_berries/New()
+	..()
+	processing_objects+=src
+	if(prob(25))
+		hasberries=TRUE
+	if(hasberries)
+		icon_state = "harvest"
+
+/obj/structure/flora/jungle_berries/Destroy()
+	..()
+	processing_objects-=src
+
+/obj/structure/flora/jungle_berries/attack_hand(var/mob/user)
+	if(hasberries)
+		hasberries=FALSE
+		tickssincelastgrowth=0
+		var/i=3
+		while(i)
+			new/obj/item/weapon/reagent_containers/food/snacks/grown/berries/jungle(loc)
+			i--
+			if(prob(50))
+				i=0
+		icon_state="stage-6"
+	else
+		..()
+
+/obj/structure/flora/jungle_berries/process()
+	if(!hasberries)
+		if(rand()<0.0284 && tickssincelastgrowth>5) //this gives us a regrow time of around 60 seconds for half of them to get there.
+			hasberries=TRUE
+			icon_state = "harvest"
+		tickssincelastgrowth++
+	..()
+	processing_objects+=src // flora is not normally an object which calls this proc, so we have to manually re-add it every cycle.
+
+/obj/item/weapon/reagent_containers/food/snacks/grown/berries/jungle
+	icon = 'icons/obj/hydroponics/berry.dmi'
+	icon_state = "produce2"
+	desc = "They taste like... burning."
+
+/obj/item/weapon/reagent_containers/food/snacks/grown/berries/jungle/New()
+	..()
+	icon_state = "produce2" //the icon state is set in ..()
+	reagents.add_reagent(NUTRIMENT,1) //we want 3 total. there's already 2 from ..()
+	bitesize=3 //consume it in 1 bite.
+	if(prob(33))
+		reagents.add_reagent(TOXIN,1)
+		bitesize=4

--- a/code/game/objects/structures/flora/flora.dm
+++ b/code/game/objects/structures/flora/flora.dm
@@ -730,7 +730,7 @@
 				i=0
 		icon_state="stage-6"
 	else
-		to_chat(user,"<span class='notice'>There's nothing grown yet./span>")
+		to_chat(user,"<span class='notice'>There's nothing grown yet.</span>")
 		..()
 
 /obj/structure/flora/jungle_berries/process()

--- a/code/game/objects/structures/flora/flora.dm
+++ b/code/game/objects/structures/flora/flora.dm
@@ -719,6 +719,7 @@
 
 /obj/structure/flora/jungle_berries/attack_hand(var/mob/user)
 	if(hasberries)
+		to_chat(user,"<span class='notice'>You pick some berries from \the [src]</span>")
 		hasberries=FALSE
 		tickssincelastgrowth=0
 		var/i=3
@@ -729,6 +730,7 @@
 				i=0
 		icon_state="stage-6"
 	else
+		to_chat(user,"<span class='notice'>There's nothing grown yet./span>")
 		..()
 
 /obj/structure/flora/jungle_berries/process()
@@ -739,17 +741,3 @@
 		tickssincelastgrowth++
 	..()
 	processing_objects+=src // flora is not normally an object which calls this proc, so we have to manually re-add it every cycle.
-
-/obj/item/weapon/reagent_containers/food/snacks/grown/berries/jungle
-	icon = 'icons/obj/hydroponics/berry.dmi'
-	icon_state = "produce2"
-	desc = "They taste like... burning."
-
-/obj/item/weapon/reagent_containers/food/snacks/grown/berries/jungle/New()
-	..()
-	icon_state = "produce2" //the icon state is set in ..()
-	reagents.add_reagent(NUTRIMENT,1) //we want 3 total. there's already 2 from ..()
-	bitesize=3 //consume it in 1 bite.
-	if(prob(33))
-		reagents.add_reagent(TOXIN,1)
-		bitesize=4

--- a/code/game/turfs/unsimulated/jungle.dm
+++ b/code/game/turfs/unsimulated/jungle.dm
@@ -128,6 +128,7 @@ var/list/foliage_choices=list(
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/jungle_berries,
 )
 
 var/list/foliage_replacments=list(

--- a/code/modules/maps/spawners/jungle_spawns.dm
+++ b/code/modules/maps/spawners/jungle_spawns.dm
@@ -16,6 +16,7 @@ var/list/junglemobs_safe=list(
 /mob/living/simple_animal/hostile/lizard/frog,
 /mob/living/simple_animal/parrot/jungle,
 /mob/living/simple_animal/capybara/jungle,
+/mob/living/carbon/monkey,
 )
 
 

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -1203,3 +1203,17 @@ var/list/strange_seed_product_blacklist = subtypesof(/obj/item/weapon/reagent_co
 	potency = 20
 	filling_color = "#7E80DE"
 	plantname = "flax"
+
+/obj/item/weapon/reagent_containers/food/snacks/grown/berries/jungle
+	icon = 'icons/obj/hydroponics/berry.dmi'
+	icon_state = "produce2"
+	desc = "They taste like... burning."
+
+/obj/item/weapon/reagent_containers/food/snacks/grown/berries/jungle/New()
+	..()
+	icon_state = "produce2" //the icon state is set in ..()
+	reagents.add_reagent(NUTRIMENT,1) //we want 3 total. there's already 2 from ..()
+	bitesize=3 //consume it in 1 bite.
+	if(prob(33))
+		reagents.add_reagent(TOXIN,1)
+		bitesize=4

--- a/code/modules/trader/crates/zincsaucier.dm
+++ b/code/modules/trader/crates/zincsaucier.dm
@@ -379,6 +379,15 @@ var/global/global_cricket_population = 0
 		update_icon_after_process = TRUE
 	..()
 
+//works as a lawnmower
+/obj/structure/bed/chair/vehicle/mower/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, var/glide_size_override = 0)
+	//if we successfully moved clear the flora in the current tile. We can't use newloc because we can't really check if we actually moved. i tried checking, and it doesn't work.
+	if(istype(loc,/turf))
+		var/turf/T=loc
+		for(var/obj/structure/flora/F in T.contents)
+			qdel(F)
+	return ..()
+
 /obj/effect/plantsegment/Crossed(var/atom/movable/AM)
 	if(istype(AM,/obj/structure/bed/chair/vehicle/mower))
 		die_off()

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -4379,6 +4379,12 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engineering/atmos_control)
+"bKt" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/ghettomining)
 "bKM" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/pen/blue{
@@ -5840,6 +5846,24 @@
 /obj/item/weapon/bedsheet/green,
 /turf/simulated/floor/vox/wood,
 /area/vox_trading_post/dorms)
+"cmp" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/pickaxe,
+/obj/item/weapon/pickaxe/shovel,
+/obj/item/weapon/pickaxe/shovel{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/weapon/pickaxe{
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/obj/item/clothing/head/hardhat/orange,
+/obj/item/clothing/head/hardhat/orange{
+	pixel_y = 11
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/ghettomining)
 "cmC" = (
 /obj/item/weapon/gun/portalgun,
 /obj/structure/displaycase/specops{
@@ -7264,7 +7288,7 @@
 "cMl" = (
 /obj/machinery/door/airlock/glass_mining{
 	name = "Cargo Bay";
-	req_access_txt = "31"
+	req_one_access_txt = "31;48"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -11007,6 +11031,12 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/sleeper)
+"ejh" = (
+/obj/machinery/conveyor{
+	id_tag = "ghetto_ore_proc_conv"
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/ghettomining)
 "ejx" = (
 /obj/effect/landmark/corpse/russian/ranged,
 /turf/simulated/floor/engine,
@@ -13253,6 +13283,20 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/tcomms_control_room)
+"fhN" = (
+/obj/machinery/light/small,
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/drinks/plastic/water{
+	pixel_y = 7
+	},
+/obj/item/weapon/reagent_containers/food/drinks/plastic/water{
+	pixel_x = 8
+	},
+/obj/item/weapon/reagent_containers/food/drinks/plastic/water{
+	pixel_x = -8
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/ghettomining)
 "fhT" = (
 /obj/machinery/hologram/holopad,
 /turf/unsimulated/floor/jungle/concrete,
@@ -19672,6 +19716,16 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"hKU" = (
+/obj/machinery/conveyor{
+	id_tag = "ghetto_ore_proc_conv"
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	flickering = 1
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/ghettomining)
 "hKV" = (
 /obj/structure/table/woodentable,
 /obj/structure/window/reinforced{
@@ -20080,6 +20134,12 @@
 	},
 /turf/simulated/floor,
 /area/security/perma)
+"hTi" = (
+/obj/machinery/mineral/processing_unit{
+	id_tag = "ghetto_ore_oreprocessor"
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/ghettomining)
 "hTr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -20191,6 +20251,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep)
+"hVD" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/machinery/light/small{
+	dir = 1;
+	invisibility = 1
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/ghettomining)
 "hVN" = (
 /obj/machinery/atmospherics/unary/heat_exchanger{
 	dir = 4
@@ -22130,6 +22199,16 @@
 	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
+"iOq" = (
+/obj/machinery/conveyor_switch/oneway{
+	id_tag = "ghetto_ore_proc_conv"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/ghettomining)
 "iOJ" = (
 /obj/machinery/camera{
 	name = "Spec. Ops. Center";
@@ -22426,6 +22505,18 @@
 	},
 /turf/simulated/floor,
 /area/engineering/supermatter_room)
+"iSK" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/ghettomining)
 "iSZ" = (
 /turf/simulated/floor/shuttle,
 /area/shuttle/ert/centcom)
@@ -23632,6 +23723,17 @@
 /obj/effect/glowshroom/single,
 /turf/simulated/floor/vox,
 /area/vox_trading_post/trade_processing)
+"jqI" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/ghettomining)
 "jqL" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/blue,
@@ -25325,6 +25427,19 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/ert/centcom)
+"jYZ" = (
+/obj/machinery/door/mineral/wood{
+	name = "Refinery"
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/ghettomining)
+"jZa" = (
+/obj/machinery/conveyor{
+	id_tag = "ghetto_ore_proc_conv";
+	dir = 4
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/ghettomining)
 "jZl" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/simulated/floor{
@@ -32595,6 +32710,9 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
+"mSe" = (
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/ghettomining)
 "mSh" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -36013,6 +36131,14 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/specops/centcom)
+"omH" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/ghettomining)
 "omL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -37430,6 +37556,9 @@
 	icon_state = "floor"
 	},
 /area/centcom/control)
+"oSu" = (
+/turf/simulated/wall/mineral/wood,
+/area/surface/jungle/underground/zoned/ghettomining)
 "oSw" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -42062,6 +42191,11 @@
 	tag = "icon-checker"
 	},
 /area/vox_trading_post/gardens)
+"qKn" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/treadmill,
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/ghettomining)
 "qKS" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/fancy/beer_box,
@@ -47390,6 +47524,13 @@
 	icon_state = "red"
 	},
 /area/security/lobby)
+"sQR" = (
+/obj/machinery/conveyor{
+	id_tag = "ghetto_ore_proc_conv";
+	dir = 8
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/ghettomining)
 "sRj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -56978,6 +57119,20 @@
 	},
 /turf/unsimulated/floor/jungle/concrete,
 /area/surface/jungle)
+"wCc" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/computer/smelting{
+	smelter_tag = "ghetto_ore_oreprocessor";
+	id_tag = "ghetto_ore_oreprocessor";
+	req_access = null
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/ghettomining)
 "wCd" = (
 /obj/machinery/light{
 	dir = 8
@@ -242409,12 +242564,12 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+oSu
+oSu
+oSu
+oSu
+oSu
+oSu
 rDI
 rDI
 rDI
@@ -242761,12 +242916,12 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+oSu
+ejh
+hTi
+hKU
+jZa
+oSu
 rDI
 rDI
 rDI
@@ -243113,12 +243268,12 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+oSu
+sQR
+wCc
+iOq
+jZa
+oSu
 rDI
 rDI
 rDI
@@ -243464,14 +243619,14 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+oSu
+oSu
+mSe
+mSe
+mSe
+mSe
+oSu
+oSu
 rDI
 rDI
 rDI
@@ -243816,14 +243971,14 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+oSu
+cmp
+mSe
+mSe
+mSe
+mSe
+fhN
+oSu
 rDI
 rDI
 rDI
@@ -244168,14 +244323,14 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+oSu
+hVD
+mSe
+mSe
+mSe
+omH
+qKn
+oSu
 rDI
 rDI
 rDI
@@ -244520,14 +244675,14 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+oSu
+iSK
+bKt
+bKt
+bKt
+jqI
+qKn
+oSu
 rDI
 rDI
 rDI
@@ -244872,14 +245027,14 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+oSu
+oSu
+oSu
+jYZ
+jYZ
+oSu
+oSu
+oSu
 rDI
 rDI
 rDI
@@ -245227,8 +245382,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -245579,8 +245734,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -245931,8 +246086,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -246283,8 +246438,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -246635,8 +246790,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -246987,8 +247142,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -247339,8 +247494,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -247691,8 +247846,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -248043,8 +248198,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -248395,33 +248550,33 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -248747,33 +248902,33 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -249124,8 +249279,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -249465,19 +249620,19 @@ rDI
 rDI
 rDI
 rDI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
 bRI
 bRI
-bRI
-bRI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
 rDI
 rDI
 rDI
@@ -249817,17 +249972,17 @@ rDI
 rDI
 rDI
 rDI
-bRI
-bRI
-bRI
-bRI
-bRI
-bRI
-bRI
-bRI
-bRI
-bRI
-bRI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
 bRI
 bRI
 rDI
@@ -250169,17 +250324,17 @@ rDI
 rDI
 rDI
 rDI
-bRI
-bRI
-bRI
-bRI
-bRI
-bRI
-bRI
-bRI
-bRI
-bRI
-bRI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
+rDI
 bRI
 bRI
 rDI
@@ -250521,10 +250676,10 @@ rDI
 rDI
 rDI
 rDI
-bRI
-bRI
-bRI
-bRI
+rDI
+rDI
+rDI
+rDI
 rDI
 rDI
 rDI
@@ -251929,10 +252084,10 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
+bRI
+bRI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -252281,17 +252436,17 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
 bRI
 bRI
 rDI
@@ -252633,17 +252788,17 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
 bRI
 bRI
 rDI
@@ -252985,10 +253140,10 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
+bRI
+bRI
+bRI
+bRI
 rDI
 rDI
 rDI

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -478,6 +478,12 @@
 	icon_state = "freezerfloor"
 	},
 /area/medical/surgery)
+"ajJ" = (
+/obj/structure/bed/chair/comfy/red{
+	name = "Dealer"
+	},
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "ajT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -910,6 +916,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/vox,
 /area/vox_trading_post/medbay)
+"asl" = (
+/obj/machinery/vending/snack,
+/turf/unsimulated/floor/jungle/path,
+/area/surface/jungle/fenced)
 "aso" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -1818,6 +1828,10 @@
 	},
 /turf/space/transit/north,
 /area)
+"aIw" = (
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "aIz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
@@ -2502,6 +2516,11 @@
 	dir = 1
 	},
 /area/engineering/atmos)
+"aXc" = (
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small,
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "aXg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/vox,
 /turf/simulated/floor/vox,
@@ -2978,6 +2997,12 @@
 	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
+"bgT" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/casino)
 "bgZ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -4234,6 +4259,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/wall,
 /area/medical/morgue)
+"bGp" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/stamp/denied{
+	icon_state = "stamp-accept";
+	name = "Big Blind";
+	pixel_x = 6
+	},
+/obj/item/weapon/stamp/denied{
+	pixel_x = -6;
+	name = "Little Blind"
+	},
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "bGE" = (
 /obj/structure/shuttle/diag_wall/black,
 /turf/unsimulated/floor/jungle/concrete,
@@ -6844,12 +6882,9 @@
 	},
 /area/janitor)
 "cEL" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar_backroom)
+/obj/machinery/vending/cola,
+/turf/unsimulated/floor/jungle/path,
+/area/surface/jungle/fenced)
 "cEO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
@@ -10198,6 +10233,12 @@
 	},
 /turf/simulated,
 /area/security/interrogation)
+"dUS" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "dUZ" = (
 /turf/simulated/floor/vox{
 	icon_state = "dark"
@@ -10828,6 +10869,13 @@
 /obj/structure/grille/window_spawner/reinforced/full,
 /turf/simulated/floor,
 /area/security/interrogation)
+"egq" = (
+/obj/machinery/door/airlock{
+	req_one_access_txt = "25;28";
+	name = "Bar Storage"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar_backroom)
 "egA" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -12587,6 +12635,12 @@
 	icon_state = "grimy"
 	},
 /area/chapel/office)
+"ePc" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "ePe" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -12839,6 +12893,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor,
 /area/supply/office)
+"eWO" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/table/woodentable,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 20
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/casino)
+"eXd" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet9-4"
+	},
+/area/surface/jungle/underground/zoned/casino)
 "eXm" = (
 /obj/structure/cable/orange{
 	icon_state = "2-4";
@@ -13074,6 +13143,12 @@
 /obj/item/weapon/bedsheet/brown,
 /turf/simulated/floor/wood,
 /area/surface/jungle)
+"fdA" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "fdG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
@@ -14187,6 +14262,10 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar_backroom)
 "fzM" = (
@@ -15099,6 +15178,11 @@
 	pixel_y = 4
 	},
 /obj/item/device/t_scanner{
+	pixel_y = 4
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50;
+	pixel_x = 5;
 	pixel_y = 4
 	},
 /turf/simulated/floor/wood,
@@ -16564,6 +16648,12 @@
 	},
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/fenced)
+"guG" = (
+/obj/machinery/door/mineral/wood{
+	name = "Refinery"
+	},
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "guN" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/laserproof,
@@ -19962,6 +20052,11 @@
 	tag = "icon-warnplate"
 	},
 /area/centcom/suppy)
+"hPn" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet5-1"
+	},
+/area/surface/jungle/underground/zoned/casino)
 "hPp" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -20341,6 +20436,9 @@
 	icon_state = "red"
 	},
 /area/security/main)
+"hXr" = (
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "hXG" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -20963,9 +21061,9 @@
 	icon_state = "0-4"
 	},
 /obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	desc = "A warning sign which reads 'CAUTION: ELECTRIC FENCE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE"
+	name = "CAUTION: ELECTRIC FENCE"
 	},
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/zoned/prison_yard)
@@ -22965,6 +23063,14 @@
 	icon_state = "white"
 	},
 /area/centcom/test)
+"jar" = (
+/obj/machinery/power/port_gen/pacman/super,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/casino)
 "jau" = (
 /turf/space,
 /area/random_vault)
@@ -23709,6 +23815,10 @@
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/escape/centcom)
+"jqc" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "jqt" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -24462,6 +24572,15 @@
 	icon_state = "whitepurple"
 	},
 /area/science/lab)
+"jFm" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "jFN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 1
@@ -25466,6 +25585,7 @@
 /area/library)
 "jZK" = (
 /obj/structure/table,
+/obj/item/ashtray,
 /turf/unsimulated/floor/jungle/path_plated,
 /area/crew_quarters/sleep)
 "jZW" = (
@@ -26360,6 +26480,10 @@
 	dir = 1
 	},
 /area/engineering/atmos_control)
+"ksS" = (
+/obj/structure/table/woodentable/poker,
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "ksX" = (
 /obj/machinery/computer/card,
 /obj/item/weapon/card/id/captains_spare,
@@ -27452,7 +27576,6 @@
 /turf/simulated/floor,
 /area/engineering/engine)
 "kQD" = (
-/obj/machinery/cooking/still,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -30909,6 +31032,14 @@
 	icon_state = "whiteyellow"
 	},
 /area/medical/chemistry)
+"mes" = (
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/small{
+	dir = 1;
+	invisibility = 1
+	},
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "mev" = (
 /turf/simulated/wall/shuttle/unsmoothed{
 	dir = 1;
@@ -31635,6 +31766,22 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/mining/station)
+"mtC" = (
+/obj/structure/table/woodentable,
+/obj/item/toy/cards{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/obj/item/toy/cards/une{
+	pixel_y = -1;
+	pixel_x = 5
+	},
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
+"mtQ" = (
+/obj/machinery/vending/discount,
+/turf/unsimulated/floor/jungle/path,
+/area/surface/jungle/fenced)
 "mtV" = (
 /obj/machinery/atmospherics/binary/pump{
 	on = 1
@@ -31998,9 +32145,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	desc = "A warning sign which reads 'CAUTION: ELECTRIC FENCE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE"
+	name = "CAUTION: ELECTRIC FENCE"
 	},
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/zoned/prison_yard)
@@ -34996,6 +35143,10 @@
 	icon_state = "white"
 	},
 /area/research_outpost/anomaly)
+"nQC" = (
+/obj/structure/bed/chair/wood/normal,
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "nQG" = (
 /obj/machinery/vending/wallmed1{
 	pixel_y = -30
@@ -38324,6 +38475,12 @@
 /obj/structure/bed/chair/folding,
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle)
+"phH" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/casino)
 "phK" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "warning";
@@ -40132,9 +40289,16 @@
 /area/security/prison)
 "pTP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/fence/door,
+/obj/structure/fence/door{
+	req_access_txt = "53";
+	name = "Vault"
+	},
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/fenced)
+"pUa" = (
+/obj/machinery/computer/slot_machine,
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "pUx" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/toxin{
@@ -40250,6 +40414,12 @@
 	icon_state = "dark"
 	},
 /area/vox_trading_post/gardens)
+"pWX" = (
+/obj/machinery/door/mineral/wood{
+	name = "Refinery"
+	},
+/turf/simulated/wall/mineral/wood,
+/area/surface/jungle/underground/zoned/casino)
 "pXe" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/simulated/floor,
@@ -41055,6 +41225,10 @@
 	icon_state = "brown"
 	},
 /area/supply/miningdock)
+"qmJ" = (
+/obj/machinery/vending/discount,
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "qng" = (
 /turf/simulated/floor,
 /area/medical/virology)
@@ -41619,6 +41793,11 @@
 /obj/item/weapon/stool,
 /turf/simulated/floor,
 /area/security/perma)
+"qyG" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet10-8"
+	},
+/area/surface/jungle/underground/zoned/casino)
 "qyK" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -45166,6 +45345,13 @@
 	icon_state = "white"
 	},
 /area/turret_protected/tcomms_control_room)
+"rSO" = (
+/obj/structure/bed/chair/wood/normal,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "rSW" = (
 /obj/item/weapon/coin/silver{
 	pixel_x = 7;
@@ -46654,6 +46840,11 @@
 /obj/structure/shuttle/engine/propulsion/right,
 /turf/space,
 /area/shuttle/nuclearops)
+"sxZ" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/surface/jungle/underground/zoned/casino)
 "syh" = (
 /turf/simulated/floor,
 /area/security/armory)
@@ -48063,6 +48254,11 @@
 /obj/docking_port/destination/research/outpost,
 /turf/simulated/floor,
 /area/research_outpost/entry)
+"taE" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet7-3"
+	},
+/area/surface/jungle/underground/zoned/casino)
 "tbh" = (
 /obj/machinery/camera{
 	dir = 5;
@@ -48125,6 +48321,10 @@
 /obj/structure/lattice,
 /turf/space,
 /area/centcom/specops)
+"tbZ" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/wood,
+/area/library)
 "tcp" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Spider Pen"
@@ -48441,6 +48641,13 @@
 	},
 /turf/simulated/floor,
 /area/engineering/atmos_control)
+"thC" = (
+/obj/machinery/light/small{
+	dir = 8;
+	flickering = 1
+	},
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "thL" = (
 /obj/machinery/door/airlock/centcom{
 	name = "SpecOps Access";
@@ -50306,9 +50513,9 @@
 	icon_state = "1-8"
 	},
 /obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	desc = "A warning sign which reads 'CAUTION: ELECTRIC FENCE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE"
+	name = "CAUTION: ELECTRIC FENCE"
 	},
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/zoned/prison_yard)
@@ -51142,6 +51349,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/cooking/still,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar_backroom)
 "umG" = (
@@ -51539,12 +51747,10 @@
 	},
 /area/medical/virology)
 "usy" = (
-/obj/machinery/door/airlock{
-	req_one_access_txt = "25;28";
-	name = "Bar Storage"
+/turf/simulated/floor/carpet{
+	icon_state = "carpet11-12"
 	},
-/turf/simulated/floor,
-/area/crew_quarters/bar_backroom)
+/area/surface/jungle/underground/zoned/casino)
 "usB" = (
 /obj/structure/rack{
 	dir = 8
@@ -52362,6 +52568,14 @@
 	},
 /turf/simulated,
 /area/mine/production)
+"uNJ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/carpet{
+	icon_state = "carpet11-12"
+	},
+/area/surface/jungle/underground/zoned/casino)
 "uNM" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -52487,6 +52701,13 @@
 	},
 /turf/simulated/floor/engine,
 /area/mine/explored)
+"uQp" = (
+/obj/machinery/light/small{
+	dir = 1;
+	invisibility = 1
+	},
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "uQr" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
@@ -53078,6 +53299,10 @@
 	icon_state = "white"
 	},
 /area/medical/storage)
+"vbC" = (
+/obj/machinery/vending/groans,
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "vbG" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -53829,6 +54054,9 @@
 	},
 /turf/simulated,
 /area/security/lobby)
+"vnP" = (
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/casino)
 "vnY" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor{
@@ -56672,6 +56900,20 @@
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/simulated/floor/server/bluegrid,
 /area/tcomms/chamber)
+"wtb" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/spacecash/c10,
+/obj/item/weapon/spacecash/c10{
+	pixel_y = 5
+	},
+/obj/item/weapon/spacecash/c10{
+	pixel_y = 10
+	},
+/obj/item/weapon/spacecash/c10{
+	pixel_y = -5
+	},
+/turf/simulated/floor/wood,
+/area/surface/jungle/underground/zoned/casino)
 "wtj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -59504,6 +59746,18 @@
 	icon_state = "yellow"
 	},
 /area/engineering/supermatter_room)
+"xxb" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/unsimulated/floor/jungle/bedrock,
+/area/surface/jungle/underground/zoned/casino)
 "xxe" = (
 /obj/structure/grille/window_spawner/reinforced/full,
 /obj/structure/cable/orange{
@@ -61083,6 +61337,9 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai_upload_foyer)
+"ydE" = (
+/turf/simulated/wall/mineral/wood,
+/area/surface/jungle/underground/zoned/casino)
 "ydQ" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 1;
@@ -121164,7 +121421,7 @@ jfO
 mpz
 trS
 mpz
-lis
+tbZ
 wDw
 wld
 edD
@@ -122242,7 +122499,7 @@ kxW
 kxW
 mZx
 rSu
-xor
+mtQ
 xor
 wld
 wld
@@ -122594,7 +122851,7 @@ oaW
 oaW
 vmT
 rSu
-xor
+asl
 xor
 xor
 xor
@@ -122946,7 +123203,7 @@ vUL
 oaW
 oRu
 rSu
-xor
+cEL
 xor
 xor
 xor
@@ -123298,9 +123555,9 @@ oaW
 oaW
 vjL
 rSu
-usy
 rSu
 rSu
+egq
 rSu
 rSu
 ooI
@@ -123652,7 +123909,7 @@ oWf
 rSu
 fzI
 kQD
-cEL
+pwL
 cbn
 rSu
 maR
@@ -252406,13 +252663,13 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+ydE
+ydE
+ydE
+ydE
+ydE
+ydE
+ydE
 rDI
 rDI
 rDI
@@ -252758,13 +253015,13 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+ydE
+hXr
+hXr
+hXr
+hXr
+hXr
+ydE
 rDI
 rDI
 rDI
@@ -253109,14 +253366,14 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+ydE
+ydE
+uQp
+fdA
+fdA
+hXr
+jqc
+ydE
 rDI
 rDI
 rDI
@@ -253461,14 +253718,14 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+ydE
+bGp
+hXr
+ksS
+ksS
+dUS
+hXr
+ydE
 rDI
 rDI
 rDI
@@ -253813,18 +254070,18 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+ydE
+mtC
+hXr
+ajJ
+ksS
+dUS
+hXr
+ydE
+ydE
+ydE
+ydE
+ydE
 rDI
 rDI
 rDI
@@ -254165,18 +254422,18 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+ydE
+wtb
+hXr
+ksS
+ksS
+dUS
+hXr
+ydE
+xxb
+phH
+eWO
+ydE
 rDI
 rDI
 rDI
@@ -254517,18 +254774,18 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+ydE
+ydE
+uQp
+ePc
+ePc
+hXr
+jqc
+ydE
+vnP
+bgT
+jar
+ydE
 rDI
 rDI
 rDI
@@ -254870,17 +255127,17 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+ydE
+hXr
+hXr
+hXr
+hXr
+hXr
+ydE
+pWX
+ydE
+ydE
+ydE
 rDI
 rDI
 rDI
@@ -255222,17 +255479,17 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+ydE
+ydE
+ydE
+aIw
+aIw
+ydE
+ydE
+hXr
+hXr
+jqc
+ydE
 rDI
 rDI
 rDI
@@ -255575,27 +255832,27 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+ydE
+thC
+sxZ
+taE
+taE
+taE
+taE
+taE
+hPn
+guG
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -255927,27 +256184,27 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+ydE
+hXr
+qyG
+usy
+usy
+uNJ
+usy
+usy
+eXd
+guG
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -256279,6 +256536,16 @@ rDI
 rDI
 rDI
 rDI
+ydE
+ydE
+aIw
+aIw
+ydE
+ydE
+hXr
+hXr
+hXr
+ydE
 rDI
 rDI
 rDI
@@ -256288,18 +256555,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -256630,6 +256887,17 @@ rDI
 rDI
 rDI
 rDI
+ydE
+ydE
+thC
+hXr
+hXr
+hXr
+ydE
+ydE
+vbC
+qmJ
+ydE
 rDI
 rDI
 rDI
@@ -256639,19 +256907,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -256982,6 +257239,17 @@ rDI
 rDI
 rDI
 rDI
+ydE
+hXr
+hXr
+hXr
+hXr
+hXr
+hXr
+ydE
+ydE
+ydE
+ydE
 rDI
 rDI
 rDI
@@ -256991,19 +257259,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -257334,6 +257591,14 @@ rDI
 rDI
 rDI
 rDI
+ydE
+mes
+dUS
+hXr
+hXr
+nQC
+aXc
+ydE
 rDI
 rDI
 rDI
@@ -257346,16 +257611,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -257686,6 +257943,14 @@ rDI
 rDI
 rDI
 rDI
+ydE
+pUa
+dUS
+hXr
+hXr
+nQC
+pUa
+ydE
 rDI
 rDI
 rDI
@@ -257698,16 +257963,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -258038,6 +258295,14 @@ rDI
 rDI
 rDI
 rDI
+ydE
+pUa
+jFm
+hXr
+hXr
+rSO
+pUa
+ydE
 rDI
 rDI
 rDI
@@ -258050,16 +258315,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -258390,6 +258647,14 @@ rDI
 rDI
 rDI
 rDI
+ydE
+ydE
+ydE
+ydE
+ydE
+ydE
+ydE
+ydE
 rDI
 rDI
 rDI
@@ -258402,16 +258667,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -258762,8 +259019,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -259114,8 +259371,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -259466,8 +259723,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -259818,8 +260075,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -260170,8 +260427,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -260522,8 +260779,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -260874,8 +261131,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -261226,8 +261483,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -261578,8 +261835,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -261930,8 +262187,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -262282,8 +262539,8 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
+bRI
+bRI
 rDI
 rDI
 rDI
@@ -262634,24 +262891,24 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
 bRI
 bRI
 bRI
@@ -262986,24 +263243,24 @@ rDI
 rDI
 rDI
 rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
-rDI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
+bRI
 bRI
 bRI
 bRI

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -2466,7 +2466,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark yellow corner";
+	icon_state = "dark yellow stripe";
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/engineering/reactor_room)
@@ -2791,6 +2791,20 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai_upload)
+"bcO" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/hidden{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/pathmarkers/red,
+/obj/effect/decal/warning_stripes/pathmarkers/red{
+	dir = 1;
+	tag = "icon-pathmarker (NORTH)"
+	},
+/turf/simulated/floor{
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)"
+	},
+/area/engineering/reactor_room)
 "bcZ" = (
 /obj/structure/window/full/reinforced,
 /turf/unsimulated/wall/fakeglass{
@@ -3681,24 +3695,6 @@
 	},
 /turf/simulated/wall,
 /area/crew_quarters/kitchen)
-"bvV" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/hidden/blue{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/pathmarkers/blue{
-	dir = 4;
-	tag = "icon-pathmarker (EAST)"
-	},
-/obj/effect/decal/warning_stripes/pathmarkers/blue{
-	dir = 8;
-	tag = "icon-pathmarker (WEST)"
-	},
-/turf/simulated/floor{
-	icon_state = "dark yellow stripe";
-	tag = "icon-vault (NORTHEAST)";
-	dir = 8
-	},
-/area/engineering/reactor_room)
 "bwa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -6632,6 +6628,12 @@
 	},
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/fenced)
+"cAf" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)"
+	},
+/area/engineering/reactor_room)
 "cAk" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/fancy/crayons,
@@ -7428,8 +7430,9 @@
 	tag = "icon-pathmarker (NORTH)"
 	},
 /turf/simulated/floor{
-	icon_state = "dark yellow corner";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 1
 	},
 /area/engineering/reactor_room)
 "cPS" = (
@@ -9001,13 +9004,6 @@
 	icon_state = "red"
 	},
 /area/security/prison)
-"dvx" = (
-/turf/simulated/floor{
-	icon_state = "dark yellow stripe";
-	tag = "icon-vault (NORTHEAST)";
-	dir = 9
-	},
-/area/engineering/antimatter_room)
 "dvA" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -9340,13 +9336,6 @@
 	icon_state = "gravsnow_corner"
 	},
 /area/syndicate_mothership)
-"dBh" = (
-/turf/simulated/floor{
-	icon_state = "dark yellow corner";
-	tag = "icon-vault (NORTHEAST)";
-	dir = 8
-	},
-/area/engineering/reactor_room)
 "dBm" = (
 /obj/structure/grille/window_spawner/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -9647,13 +9636,6 @@
 "dJa" = (
 /turf/simulated/floor/grass,
 /area/science/test_area)
-"dJb" = (
-/turf/simulated/floor{
-	icon_state = "dark yellow stripe";
-	tag = "icon-vault (NORTHEAST)";
-	dir = 8
-	},
-/area/engineering/reactor_room)
 "dJz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -10159,21 +10141,6 @@
 	icon_state = "red"
 	},
 /area/security/main)
-"dUs" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/hidden{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/pathmarkers/red,
-/obj/effect/decal/warning_stripes/pathmarkers/red{
-	dir = 1;
-	tag = "icon-pathmarker (NORTH)"
-	},
-/turf/simulated/floor{
-	icon_state = "dark yellow stripe";
-	tag = "icon-vault (NORTHEAST)";
-	dir = 1
-	},
-/area/engineering/reactor_room)
 "dUt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -10241,14 +10208,16 @@
 	},
 /area/tdome)
 "dWa" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor,
 /area/security/lobby)
@@ -13586,13 +13555,6 @@
 	dir = 4
 	},
 /area/engineering/supermatter_room)
-"foy" = (
-/turf/simulated/floor{
-	icon_state = "dark yellow corner";
-	tag = "icon-vault (NORTHEAST)";
-	dir = 1
-	},
-/area/engineering/reactor_room)
 "foS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
@@ -14533,13 +14495,6 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape/centcom)
-"fHB" = (
-/turf/simulated/floor{
-	icon_state = "dark yellow corner";
-	tag = "icon-vault (NORTHEAST)";
-	dir = 4
-	},
-/area/engineering/antimatter_room)
 "fHC" = (
 /obj/docking_port/destination/escape/shuttle/station{
 	dir = 4
@@ -15718,6 +15673,24 @@
 	icon_state = "white"
 	},
 /area/centcom/test)
+"gfX" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/hidden/blue{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/pathmarkers/blue{
+	dir = 4;
+	tag = "icon-pathmarker (EAST)"
+	},
+/obj/effect/decal/warning_stripes/pathmarkers/blue{
+	dir = 8;
+	tag = "icon-pathmarker (WEST)"
+	},
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 8
+	},
+/area/engineering/reactor_room)
 "ggb" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15902,6 +15875,21 @@
 /obj/structure/window/full/reinforced,
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/ert/centcom)
+"giJ" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/hidden{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/pathmarkers/red,
+/obj/effect/decal/warning_stripes/pathmarkers/red{
+	dir = 1;
+	tag = "icon-pathmarker (NORTH)"
+	},
+/turf/simulated/floor{
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 8
+	},
+/area/engineering/reactor_room)
 "giS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -19301,19 +19289,6 @@
 	icon_state = "dark-markings"
 	},
 /area/security/armory)
-"hDi" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/hidden/blue{
-	dir = 6
-	},
-/obj/effect/decal/warning_stripes/pathmarkers/blue{
-	dir = 4;
-	tag = "icon-pathmarker (EAST)"
-	},
-/obj/effect/decal/warning_stripes/pathmarkers/blue,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/engineering/reactor_room)
 "hDm" = (
 /obj/structure/rack,
 /obj/item/device/pda/security{
@@ -19411,6 +19386,13 @@
 	icon_state = "carpet14-10"
 	},
 /area/chapel/main)
+"hER" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 8
+	},
+/area/engineering/reactor_room)
 "hFa" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/fancy/cigarettes/shoalsticks,
@@ -24731,6 +24713,13 @@
 	tag = "icon-checker"
 	},
 /area/vox_trading_post/gardens)
+"jNN" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 1
+	},
+/area/engineering/reactor_room)
 "jNT" = (
 /turf/simulated/floor/engine,
 /area/science/xenobiology/specimen_6)
@@ -25475,6 +25464,13 @@
 /obj/structure/grille/window_spawner/reinforced,
 /turf/simulated,
 /area/research_outpost/atmos)
+"kdj" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 8
+	},
+/area/engineering/reactor_room)
 "kdl" = (
 /obj/structure/rack,
 /obj/machinery/firealarm{
@@ -26973,6 +26969,19 @@
 	icon_state = "white"
 	},
 /area/medical/storage)
+"kIn" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/hidden/blue{
+	dir = 6
+	},
+/obj/effect/decal/warning_stripes/pathmarkers/blue{
+	dir = 4;
+	tag = "icon-pathmarker (EAST)"
+	},
+/obj/effect/decal/warning_stripes/pathmarkers/blue,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/engineering/reactor_room)
 "kIA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -27474,6 +27483,18 @@
 	name = "plating"
 	},
 /area/centcom/evac)
+"kTB" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 4
+	},
+/area/engineering/reactor_room)
 "kTE" = (
 /turf/simulated/floor/bluegrid,
 /area/tdome)
@@ -28975,12 +28996,6 @@
 "lyS" = (
 /turf/simulated/wall,
 /area/surface/jungle/fenced)
-"lzd" = (
-/turf/simulated/floor{
-	icon_state = "dark yellow stripe";
-	tag = "icon-vault (NORTHEAST)"
-	},
-/area/engineering/antimatter_room)
 "lzr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -33991,21 +34006,6 @@
 	tag = "icon-brown (NORTH)"
 	},
 /area/supply/office)
-"nyW" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/hidden{
-	dir = 1
-	},
-/obj/effect/decal/warning_stripes/pathmarkers/red,
-/obj/effect/decal/warning_stripes/pathmarkers/red{
-	dir = 1;
-	tag = "icon-pathmarker (NORTH)"
-	},
-/turf/simulated/floor{
-	icon_state = "dark yellow corner";
-	tag = "icon-vault (NORTHEAST)";
-	dir = 8
-	},
-/area/engineering/reactor_room)
 "nzF" = (
 /obj/effect/glowshroom/single,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -36454,6 +36454,13 @@
 	icon_state = "dark neutral stripe"
 	},
 /area/centcom/suppy)
+"oxA" = (
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Lobby";
+	normalspeed = 0
+	},
+/turf/simulated,
+/area/security/lobby)
 "oxC" = (
 /obj/effect/landmark/start{
 	name = "Cargo Technician"
@@ -37220,6 +37227,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/science/telescience)
+"oMI" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)"
+	},
+/area/engineering/antimatter_room)
 "oMV" = (
 /obj/machinery/computer/message_monitor,
 /turf/simulated/floor{
@@ -38392,6 +38405,13 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/science/test_area)
+"pop" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 1
+	},
+/area/engineering/reactor_room)
 "poG" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
@@ -40819,13 +40839,6 @@
 	},
 /turf/simulated/floor/vox,
 /area/vox_trading_post/hallway)
-"qly" = (
-/turf/simulated/floor{
-	icon_state = "dark yellow stripe";
-	tag = "icon-vault (NORTHEAST)";
-	dir = 4
-	},
-/area/engineering/reactor_room)
 "qlD" = (
 /obj/structure/table/glass,
 /obj/item/weapon/aiModule/standard/oxygen,
@@ -41034,18 +41047,6 @@
 	icon_state = "cult"
 	},
 /area/crew_quarters/heads/hos)
-"qoO" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8";
-	d1 = 4;
-	d2 = 8
-	},
-/turf/simulated/floor{
-	icon_state = "dark yellow stripe";
-	tag = "icon-vault (NORTHEAST)";
-	dir = 8
-	},
-/area/engineering/reactor_room)
 "qoP" = (
 /obj/machinery/bodyscanner/upgraded,
 /turf/simulated/floor{
@@ -44289,15 +44290,6 @@
 	icon_state = "red"
 	},
 /area/security/prison)
-"rAX" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "dark yellow stripe";
-	tag = "icon-vault (NORTHEAST)"
-	},
-/area/engineering/reactor_room)
 "rAY" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -44507,6 +44499,13 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
+"rEX" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 4
+	},
+/area/engineering/reactor_room)
 "rFd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -45293,6 +45292,15 @@
 "rWK" = (
 /turf/simulated/wall,
 /area/janitor)
+"rWN" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)"
+	},
+/area/engineering/reactor_room)
 "rWO" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -45627,12 +45635,6 @@
 	},
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/fenced)
-"sbJ" = (
-/turf/simulated/floor{
-	icon_state = "dark yellow stripe";
-	tag = "icon-vault (NORTHEAST)"
-	},
-/area/engineering/reactor_room)
 "sbS" = (
 /obj/effect/decal/warning_stripes{
 	dir = 8;
@@ -46015,6 +46017,13 @@
 /obj/structure/window/barricade,
 /turf/simulated/floor/engine,
 /area/mine/explored)
+"sjW" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 4
+	},
+/area/engineering/antimatter_room)
 "skx" = (
 /obj/structure/dispenser,
 /turf/unsimulated/floor{
@@ -48384,13 +48393,6 @@
 	icon_state = "barber"
 	},
 /area/medical/cmo)
-"tiu" = (
-/turf/simulated/floor{
-	icon_state = "dark yellow stripe";
-	tag = "icon-vault (NORTHEAST)";
-	dir = 4
-	},
-/area/engineering/antimatter_room)
 "tiw" = (
 /obj/structure/table,
 /obj/item/weapon/kitchen/rollingpin,
@@ -51908,6 +51910,12 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/bridge)
+"uFq" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)"
+	},
+/area/engineering/antimatter_room)
 "uFw" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -53967,12 +53975,6 @@
 	},
 /turf/simulated/floor/vox,
 /area/vox_trading_post/docking)
-"vtm" = (
-/turf/simulated/floor{
-	icon_state = "dark yellow corner";
-	tag = "icon-vault (NORTHEAST)"
-	},
-/area/engineering/antimatter_room)
 "vtq" = (
 /obj/machinery/camera{
 	dir = 4
@@ -54005,6 +54007,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep)
+"vuh" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 8
+	},
+/area/engineering/reactor_room)
 "vur" = (
 /obj/item/weapon/storage/box/chemimp{
 	pixel_x = 5;
@@ -54429,13 +54443,6 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/science/test_area)
-"vBL" = (
-/obj/machinery/door/airlock/glass_security{
-	name = "Security Lobby";
-	normalspeed = 0
-	},
-/turf/simulated,
-/area/security/lobby)
 "vBW" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	on = 1
@@ -58155,6 +58162,13 @@
 	icon_state = "white"
 	},
 /area/science/lab)
+"wXZ" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 4
+	},
+/area/engineering/antimatter_room)
 "wYg" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 8
@@ -58711,12 +58725,6 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine)
-"xkL" = (
-/obj/machinery/atm{
-	pixel_y = -30
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep)
 "xkP" = (
 /turf/unsimulated/floor{
 	dir = 9;
@@ -59220,6 +59228,13 @@
 /mob/living/simple_animal/capybara/jungle,
 /turf/unsimulated/floor/jungle/grass,
 /area/surface/jungle)
+"xuh" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 9
+	},
+/area/engineering/antimatter_room)
 "xuR" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor,
@@ -59689,12 +59704,11 @@
 	},
 /area/medical/genetics)
 "xFY" = (
-/turf/simulated/floor{
-	icon_state = "dark yellow stripe";
-	tag = "icon-vault (NORTHEAST)";
-	dir = 1
+/obj/machinery/atm{
+	pixel_y = -30
 	},
-/area/engineering/reactor_room)
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep)
 "xFZ" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -60000,18 +60014,6 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/sleeper)
-"xLw" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8";
-	d1 = 4;
-	d2 = 8
-	},
-/turf/simulated/floor{
-	icon_state = "dark yellow corner";
-	tag = "icon-vault (NORTHEAST)";
-	dir = 4
-	},
-/area/engineering/reactor_room)
 "xLK" = (
 /obj/machinery/light{
 	dir = 1
@@ -105870,7 +105872,7 @@ tnZ
 xor
 xor
 xor
-vBL
+oxA
 nTD
 txd
 liY
@@ -107982,7 +107984,7 @@ tnZ
 maR
 iMQ
 xMH
-vBL
+oxA
 hnA
 vCr
 mRt
@@ -128350,7 +128352,7 @@ riz
 lqv
 jAP
 aPt
-xkL
+xFY
 jAP
 cXH
 wld
@@ -134074,13 +134076,13 @@ gdR
 gdR
 gdR
 pXV
-aVI
-qly
-qly
-qly
-qly
-qly
-xLw
+rWN
+rEX
+rEX
+rEX
+rEX
+rEX
+kTB
 kYu
 pXV
 pXV
@@ -134420,13 +134422,13 @@ qVF
 xZA
 bpo
 gdR
-vtm
-tiu
+oMI
+sjW
 eqT
-tiu
-fHB
+sjW
+wXZ
 pXV
-sbJ
+cAf
 gSN
 gSN
 gSN
@@ -134778,13 +134780,13 @@ uxZ
 uxZ
 nPf
 pXV
-sbJ
+cAf
 gSN
 qVO
 eRU
 eRU
 cOi
-xFY
+jNN
 aby
 vIM
 vIM
@@ -135124,7 +135126,7 @@ ejD
 fYw
 gTA
 gdR
-lzd
+uFq
 uxZ
 uxZ
 uxZ
@@ -135136,12 +135138,12 @@ qVO
 vmj
 eRU
 cOi
-dUs
+cPK
 iYU
 ern
-cPK
+bcO
 sYP
-qly
+rEX
 cNH
 vah
 pXV
@@ -135476,22 +135478,22 @@ aAD
 icJ
 mtn
 gdR
-lzd
+uFq
 uxZ
 uxZ
 uxZ
 qgI
 pXV
-rAX
+aVI
 gSN
 qVO
 vmj
 eRU
 cOi
-xFY
+jNN
 cQt
 rPJ
-sbJ
+cAf
 wxC
 jUg
 gbc
@@ -135834,19 +135836,19 @@ uxZ
 uxZ
 nPf
 pXV
-sbJ
+cAf
 gSN
 qVO
 eRU
 eRU
 cOi
-dUs
+cPK
 iYU
 pei
-nyW
+giJ
 ixz
-qoO
-bvV
+vuh
+gfX
 jSe
 pXV
 lIK
@@ -136183,16 +136185,16 @@ gdR
 bJg
 xGI
 ucv
-dvx
+xuh
 dam
 pXV
-sbJ
+cAf
 gSN
 gSN
 gSN
 gSN
 lFE
-xFY
+jNN
 cQt
 rPJ
 rPJ
@@ -136538,18 +136540,18 @@ wtj
 xcc
 gwJ
 pXV
-dBh
-dJb
-dJb
-dJb
+hER
+kdj
+kdj
+kdj
 uDe
-dJb
-foy
+kdj
+pop
 cQt
 rPJ
 rPJ
 cQt
-hDi
+kIn
 xcN
 jSP
 pXV
@@ -136902,7 +136904,7 @@ vIM
 ddu
 bgx
 gDj
-hDi
+kIn
 ahR
 pXV
 lIK

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -18087,6 +18087,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/science/server)
+"gYT" = (
+/mob/living/simple_animal/penguin/sombrero,
+/turf/unsimulated/floor/snow/dirt,
+/area/centcom/holding)
 "gYZ" = (
 /obj/machinery/bot/farmbot{
 	desc = "Serving 25 to life for drowning a botanist.";
@@ -326292,7 +326296,7 @@ ocC
 ocC
 fnW
 ipB
-rWw
+uLq
 mKl
 wvr
 nrq
@@ -326644,7 +326648,7 @@ ocC
 ocC
 fnW
 qDn
-uLq
+rWw
 qNU
 wvr
 nrq
@@ -331229,7 +331233,7 @@ aSV
 lQs
 lQs
 kTH
-lQs
+gYT
 lQs
 ptC
 ptC

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -54,9 +54,7 @@
 	d2 = 4
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "abN" = (
@@ -381,9 +379,7 @@
 	tag = "icon-pathmarker (NORTH)"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "ail" = (
@@ -2470,8 +2466,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
+	icon_state = "dark yellow corner";
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/engineering/reactor_room)
@@ -2966,9 +2961,7 @@
 	},
 /obj/machinery/atmospherics/binary/volume_pump,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "bgZ" = (
@@ -3688,6 +3681,24 @@
 	},
 /turf/simulated/wall,
 /area/crew_quarters/kitchen)
+"bvV" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/hidden/blue{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/pathmarkers/blue{
+	dir = 4;
+	tag = "icon-pathmarker (EAST)"
+	},
+/obj/effect/decal/warning_stripes/pathmarkers/blue{
+	dir = 8;
+	tag = "icon-pathmarker (WEST)"
+	},
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 8
+	},
+/area/engineering/reactor_room)
 "bwa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4028,9 +4039,7 @@
 "bCl" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "bCz" = (
@@ -4201,8 +4210,7 @@
 "bFH" = (
 /obj/machinery/camera,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
+	icon_state = "dark yellow stripe";
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/engineering/reactor_room)
@@ -4338,7 +4346,9 @@
 	pixel_y = 23
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 8
 	},
 /area/engineering/antimatter_room)
 "bJs" = (
@@ -7318,9 +7328,9 @@
 	},
 /obj/effect/decal/warning_stripes/pathmarkers/blue,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 4
 	},
 /area/engineering/reactor_room)
 "cNP" = (
@@ -7418,8 +7428,7 @@
 	tag = "icon-pathmarker (NORTH)"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
+	icon_state = "dark yellow corner";
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/engineering/reactor_room)
@@ -7452,9 +7461,7 @@
 	d2 = 8
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "cQD" = (
@@ -7933,7 +7940,9 @@
 /obj/item/device/am_shielding_container,
 /obj/item/device/am_shielding_container,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 1
 	},
 /area/engineering/antimatter_room)
 "daA" = (
@@ -8101,9 +8110,7 @@
 	},
 /obj/machinery/atmospherics/unary/portables_connector,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "ddI" = (
@@ -8994,6 +9001,13 @@
 	icon_state = "red"
 	},
 /area/security/prison)
+"dvx" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 9
+	},
+/area/engineering/antimatter_room)
 "dvA" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -9059,9 +9073,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "dwH" = (
@@ -9328,6 +9340,13 @@
 	icon_state = "gravsnow_corner"
 	},
 /area/syndicate_mothership)
+"dBh" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 8
+	},
+/area/engineering/reactor_room)
 "dBm" = (
 /obj/structure/grille/window_spawner/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -9628,6 +9647,13 @@
 "dJa" = (
 /turf/simulated/floor/grass,
 /area/science/test_area)
+"dJb" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 8
+	},
+/area/engineering/reactor_room)
 "dJz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -10133,6 +10159,21 @@
 	icon_state = "red"
 	},
 /area/security/main)
+"dUs" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/hidden{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/pathmarkers/red,
+/obj/effect/decal/warning_stripes/pathmarkers/red{
+	dir = 1;
+	tag = "icon-pathmarker (NORTH)"
+	},
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 1
+	},
+/area/engineering/reactor_room)
 "dUt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -11419,7 +11460,9 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 4
 	},
 /area/engineering/antimatter_room)
 "era" = (
@@ -11444,9 +11487,7 @@
 "ern" = (
 /obj/machinery/atmospherics/binary/volume_pump,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "erp" = (
@@ -12347,15 +12388,13 @@
 	},
 /area/medical/chemistry)
 "eNu" = (
-/obj/machinery/door/airlock/glass_security{
-	name = "Security Lobby";
-	normalspeed = 0
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/yellow,
+/obj/structure/grille/window_spawner/reinforced/full,
 /turf/simulated/floor,
 /area/security/lobby)
 "eNw" = (
@@ -12611,9 +12650,7 @@
 "eRq" = (
 /obj/machinery/atmospherics/unary/fissionfuelmaker,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "eRG" = (
@@ -12803,9 +12840,7 @@
 	d2 = 4
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "eXn" = (
@@ -12907,7 +12942,8 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/engineering/antimatter_room)
 "eZo" = (
@@ -13550,6 +13586,13 @@
 	dir = 4
 	},
 /area/engineering/supermatter_room)
+"foy" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 1
+	},
+/area/engineering/reactor_room)
 "foS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1;
@@ -14370,10 +14413,6 @@
 /obj/machinery/door/airlock/glass_atmos{
 	name = "Atmospherics"
 	},
-/obj/machinery/door/airlock/glass_atmos{
-	name = "Atmospherics";
-	normalspeed = 0
-	},
 /turf/simulated/floor,
 /area/engineering/atmos)
 "fFz" = (
@@ -14494,6 +14533,13 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape/centcom)
+"fHB" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 4
+	},
+/area/engineering/antimatter_room)
 "fHC" = (
 /obj/docking_port/destination/escape/shuttle/station{
 	dir = 4
@@ -14731,9 +14777,7 @@
 	d2 = 2
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "fMW" = (
@@ -15458,9 +15502,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "gbx" = (
@@ -15662,9 +15704,9 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 1
 	},
 /area/engineering/reactor_room)
 "gfO" = (
@@ -15999,9 +16041,7 @@
 	d2 = 8
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "glV" = (
@@ -16049,9 +16089,9 @@
 	d2 = 8
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 1
 	},
 /area/engineering/reactor_room)
 "gmH" = (
@@ -16104,9 +16144,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "gnA" = (
@@ -16323,9 +16361,7 @@
 	d2 = 2
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "grv" = (
@@ -16873,9 +16909,7 @@
 	tag = "icon-pathmarker (NORTH)"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "gDF" = (
@@ -18594,12 +18628,6 @@
 /turf/simulated/floor,
 /area/supply/office)
 "hnA" = (
-/obj/structure/bed/chair,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/camera{
 	dir = 8
 	},
@@ -19273,6 +19301,19 @@
 	icon_state = "dark-markings"
 	},
 /area/security/armory)
+"hDi" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/hidden/blue{
+	dir = 6
+	},
+/obj/effect/decal/warning_stripes/pathmarkers/blue{
+	dir = 4;
+	tag = "icon-pathmarker (EAST)"
+	},
+/obj/effect/decal/warning_stripes/pathmarkers/blue,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/engineering/reactor_room)
 "hDm" = (
 /obj/structure/rack,
 /obj/item/device/pda/security{
@@ -19573,9 +19614,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "hIO" = (
@@ -19925,9 +19964,7 @@
 	initialize_directions = 11
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "hQf" = (
@@ -21461,9 +21498,9 @@
 	tag = "icon-pathmarker (WEST)"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 8
 	},
 /area/engineering/reactor_room)
 "ixG" = (
@@ -22108,9 +22145,7 @@
 	amount = 60
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "iOJ" = (
@@ -22759,9 +22794,7 @@
 	d2 = 8
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "iYX" = (
@@ -23560,7 +23593,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/closet/secure_closet/warden,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -24973,9 +25005,9 @@
 	tag = "icon-pathmarker (EAST)"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 1
 	},
 /area/engineering/reactor_room)
 "jSw" = (
@@ -25019,9 +25051,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "jSV" = (
@@ -25109,9 +25139,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "jUq" = (
@@ -25227,9 +25255,7 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "jXm" = (
@@ -25418,9 +25444,7 @@
 "kcB" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "kcD" = (
@@ -27660,9 +27684,7 @@
 "kYu" = (
 /obj/machinery/light,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "kYF" = (
@@ -28107,9 +28129,7 @@
 	d2 = 4
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "liP" = (
@@ -28955,6 +28975,12 @@
 "lyS" = (
 /turf/simulated/wall,
 /area/surface/jungle/fenced)
+"lzd" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)"
+	},
+/area/engineering/antimatter_room)
 "lzr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -30057,8 +30083,16 @@
 "lSA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/bed/chair,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "red"
@@ -30638,9 +30672,7 @@
 	amount = 50
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "mcu" = (
@@ -32696,9 +32728,7 @@
 	pixel_x = -6
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "mVo" = (
@@ -32915,9 +32945,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "mYN" = (
@@ -33834,9 +33862,6 @@
 /area/surface/jungle)
 "nuc" = (
 /obj/machinery/disposal/compactor,
-/obj/machinery/atm{
-	pixel_x = 32
-	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "brown"
@@ -33966,6 +33991,21 @@
 	tag = "icon-brown (NORTH)"
 	},
 /area/supply/office)
+"nyW" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/hidden{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/pathmarkers/red,
+/obj/effect/decal/warning_stripes/pathmarkers/red{
+	dir = 1;
+	tag = "icon-pathmarker (NORTH)"
+	},
+/turf/simulated/floor{
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 8
+	},
+/area/engineering/reactor_room)
 "nzF" = (
 /obj/effect/glowshroom/single,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -34781,7 +34821,9 @@
 /area/science/test_area)
 "nPf" = (
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 1
 	},
 /area/engineering/antimatter_room)
 "nPm" = (
@@ -34984,12 +35026,6 @@
 	},
 /area/bridge)
 "nTD" = (
-/obj/structure/bed/chair,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "red"
@@ -36468,9 +36504,7 @@
 	d2 = 8
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "oyf" = (
@@ -37775,6 +37809,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atm{
+	pixel_x = -30
+	},
 /turf/simulated/floor,
 /area/supply/lobby)
 "pam" = (
@@ -37998,9 +38035,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "pes" = (
@@ -38454,9 +38489,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "pqH" = (
@@ -39146,9 +39179,7 @@
 	},
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "pDU" = (
@@ -39157,11 +39188,6 @@
 /area/centcom/ert)
 "pEt" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/cable/yellow{
@@ -39169,6 +39195,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/bed/chair,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "red"
@@ -40223,9 +40250,7 @@
 	d2 = 8
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "pZK" = (
@@ -40510,7 +40535,9 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 1
 	},
 /area/engineering/antimatter_room)
 "qgJ" = (
@@ -40792,6 +40819,13 @@
 	},
 /turf/simulated/floor/vox,
 /area/vox_trading_post/hallway)
+"qly" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 4
+	},
+/area/engineering/reactor_room)
 "qlD" = (
 /obj/structure/table/glass,
 /obj/item/weapon/aiModule/standard/oxygen,
@@ -41000,6 +41034,18 @@
 	icon_state = "cult"
 	},
 /area/crew_quarters/heads/hos)
+"qoO" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 8
+	},
+/area/engineering/reactor_room)
 "qoP" = (
 /obj/machinery/bodyscanner/upgraded,
 /turf/simulated/floor{
@@ -44243,6 +44289,15 @@
 	icon_state = "red"
 	},
 /area/security/prison)
+"rAX" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)"
+	},
+/area/engineering/reactor_room)
 "rAY" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -44822,9 +44877,7 @@
 /area/science/lab)
 "rPJ" = (
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "rQr" = (
@@ -44904,9 +44957,7 @@
 	amount = 50
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "rRT" = (
@@ -45576,6 +45627,12 @@
 	},
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/fenced)
+"sbJ" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)"
+	},
+/area/engineering/reactor_room)
 "sbS" = (
 /obj/effect/decal/warning_stripes{
 	dir = 8;
@@ -46348,9 +46405,7 @@
 	on = 1
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "svd" = (
@@ -47785,9 +47840,9 @@
 	tag = "icon-pathmarker (WEST)"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 4
 	},
 /area/engineering/reactor_room)
 "sZq" = (
@@ -48141,9 +48196,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "tgV" = (
@@ -48331,6 +48384,13 @@
 	icon_state = "barber"
 	},
 /area/medical/cmo)
+"tiu" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 4
+	},
+/area/engineering/antimatter_room)
 "tiw" = (
 /obj/structure/table,
 /obj/item/weapon/kitchen/rollingpin,
@@ -50477,6 +50537,9 @@
 /area/maintenance/disposal)
 "ucv" = (
 /obj/structure/cable/orange,
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "dark-markings"
@@ -51168,7 +51231,8 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)"
 	},
 /area/engineering/antimatter_room)
 "uqp" = (
@@ -51698,9 +51762,9 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 8
 	},
 /area/engineering/reactor_room)
 "uDm" = (
@@ -52772,9 +52836,9 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 4
 	},
 /area/engineering/reactor_room)
 "vav" = (
@@ -53112,9 +53176,7 @@
 	tag = "icon-pathmarker (WEST)"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "vgi" = (
@@ -53905,6 +53967,12 @@
 	},
 /turf/simulated/floor/vox,
 /area/vox_trading_post/docking)
+"vtm" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)"
+	},
+/area/engineering/antimatter_room)
 "vtq" = (
 /obj/machinery/camera{
 	dir = 4
@@ -54361,6 +54429,13 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/science/test_area)
+"vBL" = (
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Lobby";
+	normalspeed = 0
+	},
+/turf/simulated,
+/area/security/lobby)
 "vBW" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	on = 1
@@ -54464,7 +54539,9 @@
 	on = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 8
 	},
 /area/engineering/antimatter_room)
 "vDX" = (
@@ -54781,9 +54858,7 @@
 	d2 = 2
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "vIV" = (
@@ -56215,9 +56290,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "wnm" = (
@@ -56449,7 +56522,9 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 8
 	},
 /area/engineering/antimatter_room)
 "wtp" = (
@@ -56612,9 +56687,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "wxE" = (
@@ -57410,9 +57483,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "wMK" = (
@@ -58246,7 +58317,9 @@
 "xcc" = (
 /obj/machinery/power/am_control_unit,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 1
 	},
 /area/engineering/antimatter_room)
 "xcj" = (
@@ -58284,9 +58357,7 @@
 	tag = "icon-pathmarker (NORTH)"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "xcO" = (
@@ -58640,6 +58711,12 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine)
+"xkL" = (
+/obj/machinery/atm{
+	pixel_y = -30
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep)
 "xkP" = (
 /turf/unsimulated/floor{
 	dir = 9;
@@ -58805,10 +58882,12 @@
 /area/chapel/office)
 "xnX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/glass_security{
-	name = "Security Lobby";
-	normalspeed = 0
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
 	},
+/obj/structure/grille/window_spawner/reinforced/full,
 /turf/simulated,
 /area/security/lobby)
 "xnZ" = (
@@ -59609,6 +59688,13 @@
 	icon_state = "white"
 	},
 /area/medical/genetics)
+"xFY" = (
+/turf/simulated/floor{
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 1
+	},
+/area/engineering/reactor_room)
 "xFZ" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -59684,7 +59770,9 @@
 	d2 = 8
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "dark yellow stripe";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 10
 	},
 /area/engineering/antimatter_room)
 "xGM" = (
@@ -59912,6 +60000,18 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/sleeper)
+"xLw" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark yellow corner";
+	tag = "icon-vault (NORTHEAST)";
+	dir = 4
+	},
+/area/engineering/reactor_room)
 "xLK" = (
 /obj/machinery/light{
 	dir = 1
@@ -60884,9 +60984,7 @@
 	pixel_y = 18
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 "yeZ" = (
@@ -61231,9 +61329,7 @@
 	d2 = 2
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault";
-	tag = "icon-vault (NORTHEAST)"
+	icon_state = "dark"
 	},
 /area/engineering/reactor_room)
 
@@ -105774,7 +105870,7 @@ tnZ
 xor
 xor
 xor
-tgB
+vBL
 nTD
 txd
 liY
@@ -107886,7 +107982,7 @@ tnZ
 maR
 iMQ
 xMH
-tgB
+vBL
 hnA
 vCr
 mRt
@@ -109660,8 +109756,8 @@ ePq
 cqH
 sMS
 asz
-bci
 eEB
+bci
 cfn
 mHK
 uIZ
@@ -110738,8 +110834,8 @@ hFS
 pMx
 vVo
 gaI
-gaI
 rUS
+gaI
 gaI
 vzX
 pCm
@@ -128254,7 +128350,7 @@ riz
 lqv
 jAP
 aPt
-lgW
+xkL
 jAP
 cXH
 wld
@@ -133979,12 +134075,12 @@ gdR
 gdR
 pXV
 aVI
-rPJ
-rPJ
-rPJ
-rPJ
-rPJ
-cQt
+qly
+qly
+qly
+qly
+qly
+xLw
 kYu
 pXV
 pXV
@@ -134324,13 +134420,13 @@ qVF
 xZA
 bpo
 gdR
-nPf
-nPf
+vtm
+tiu
 eqT
-nPf
-nPf
+tiu
+fHB
 pXV
-rPJ
+sbJ
 gSN
 gSN
 gSN
@@ -134682,13 +134778,13 @@ uxZ
 uxZ
 nPf
 pXV
-rPJ
+sbJ
 gSN
 qVO
 eRU
 eRU
 cOi
-rPJ
+xFY
 aby
 vIM
 vIM
@@ -135028,7 +135124,7 @@ ejD
 fYw
 gTA
 gdR
-nPf
+lzd
 uxZ
 uxZ
 uxZ
@@ -135040,12 +135136,12 @@ qVO
 vmj
 eRU
 cOi
-cPK
+dUs
 iYU
 ern
 cPK
 sYP
-rPJ
+qly
 cNH
 vah
 pXV
@@ -135380,22 +135476,22 @@ aAD
 icJ
 mtn
 gdR
-nPf
+lzd
 uxZ
 uxZ
 uxZ
 qgI
 pXV
-aVI
+rAX
 gSN
 qVO
 vmj
 eRU
 cOi
-rPJ
+xFY
 cQt
 rPJ
-rPJ
+sbJ
 wxC
 jUg
 gbc
@@ -135738,19 +135834,19 @@ uxZ
 uxZ
 nPf
 pXV
-rPJ
+sbJ
 gSN
 qVO
 eRU
 eRU
 cOi
-cPK
+dUs
 iYU
 pei
-cPK
+nyW
 ixz
-cQt
-vgd
+qoO
+bvV
 jSe
 pXV
 lIK
@@ -136087,16 +136183,16 @@ gdR
 bJg
 xGI
 ucv
-nPf
+dvx
 dam
 pXV
-rPJ
+sbJ
 gSN
 gSN
 gSN
 gSN
 lFE
-rPJ
+xFY
 cQt
 rPJ
 rPJ
@@ -136442,18 +136538,18 @@ wtj
 xcc
 gwJ
 pXV
-rPJ
-rPJ
-rPJ
-rPJ
+dBh
+dJb
+dJb
+dJb
 uDe
-rPJ
-rPJ
+dJb
+foy
 cQt
 rPJ
 rPJ
 cQt
-cNH
+hDi
 xcN
 jSP
 pXV
@@ -136806,7 +136902,7 @@ vIM
 ddu
 bgx
 gDj
-cNH
+hDi
 ahR
 pXV
 lIK

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -5862,6 +5862,13 @@
 /obj/item/clothing/head/hardhat/orange{
 	pixel_y = 11
 	},
+/obj/item/weapon/storage/bag/ore{
+	pixel_x = -9
+	},
+/obj/item/weapon/storage/bag/ore{
+	pixel_x = 13;
+	pixel_y = 6
+	},
 /turf/unsimulated/floor/jungle/bedrock,
 /area/surface/jungle/underground/zoned/ghettomining)
 "cmC" = (


### PR DESCRIPTION
* removes a duplicate locker in warden
* removes a duplicate door in atmos
* moves the ATM in cargo lobby to the left side
* adds a new ATM in dorms (possibly closes #37789)
* moved the security entrance doors to better line up
* adds a public access ore smelter in the tunnels
* adds a casino underground
* adds a few more vending machines
* adds another metal stack to tool storage
* makes fences lockable and applies that to botany and vault
* adds monkies to the friendly spawn pool
* adds a new foliage which grows berries you can eat. careful, they may be poisonous!
* makes botany's mower mow foliage (deletes it).

## Changelog
:cl:
 * bugfix: some minor jungle fixes and additions