### PR TITLE
fix candle runtime

### DIFF
--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -1,7 +1,3 @@
-//Items labled as 'trash' for the trash bag.
-//TODO: Make this an item var or something...
-
-//Added by Jack Rost
 /obj/item/trash
 	icon = 'icons/obj/trash.dmi'
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/trash.dmi', "right_hand" = 'icons/mob/in-hand/right/trash.dmi')
@@ -228,7 +224,7 @@
 
 /obj/item/trash/candle/New(turf/loc, var/obj/item/candle/source)
 	..()
-	if (source)
+	if (istype(source, /obj/item/candle))
 		color = source.color
 	else
 		color = COLOR_DEFAULT_CANDLE

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -222,10 +222,10 @@
 	w_type=RECYK_WAX
 	var/image/wick
 
-/obj/item/trash/candle/New(turf/loc, var/obj/item/candle/source)
+/obj/item/trash/candle/New(turf/loc)
 	..()
-	if (istype(source, /obj/item/candle))
-		color = source.color
+	if (istype(src, /obj/item/candle))
+		color = src.color
 	else
 		color = COLOR_DEFAULT_CANDLE
 	wick = image(icon,src,"candle4-wick")


### PR DESCRIPTION
```
[01:33:54] Runtime in code/game/objects/items/trash.dm,232: Cannot read 1.color
  proc name: New (/obj/item/trash/candle/New)
  src: the candle (/obj/item/trash/candle)
  src.loc: the floor (299,249,1) (/turf/simulated/floor)
  call stack:
  the candle (/obj/item/trash/candle): New(the floor (299,249,1) (/turf/simulated/floor), 1, "candle4", "#be0000", 2, 0, 0)
  trash (/datum/map_persistence_type/trash): create(the floor (299,249,1) (/turf/simulated/floor), /list (/list))
  trash (/datum/map_persistence_type/trash): readSavefile()
  Persistence - Map (/datum/subsystem/persistence_map): Initialize(200340)
  Master (/datum/controller/master): Setup()
```

## What this does
- type check to prevent runtime
- value 1 was being passed into candle (age) instead of source (src)
- compiles

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->

