### PR TITLE
Jungle 7 fixes

### DIFF
--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -173,7 +173,7 @@ Frequency:
 
 /obj/item/weapon/hand_tele/attack_self(mob/user as mob)
 	var/turf/current_location = get_turf(user)//What turf is the user on?
-	if(!current_location||current_location.z==2||current_location.z>=7)//If turf was not found or they're on z level 2 or >7 which does not currently exist.
+	if(!current_location||current_location.z==map.zCentcomm||current_location.z>=7)//If turf was not found or they're on z level 2 or >7 which does not currently exist.
 		to_chat(user, "<span class='notice'>\The [src] is malfunctioning.</span>")
 		return
 

--- a/code/game/turfs/unsimulated/jungle.dm
+++ b/code/game/turfs/unsimulated/jungle.dm
@@ -329,6 +329,10 @@ var/list/foliage_replacments=list(
 		if(do_after(user, src, 20/s ))
 			ChangeTurf(/turf/unsimulated/floor/jungle/dirt)
 
+
+/turf/unsimulated/floor/jungle/path/can_place_cables()
+	return TRUE
+
 /turf/unsimulated/floor/jungle/path/ex_act(severity)	
 	switch(severity)
 		if(1)
@@ -580,6 +584,8 @@ var/list/foliage_replacments=list(
 /turf/unsimulated/floor/jungle/bedrock/ex_act(severity)	
 	return
 
+/turf/unsimulated/floor/jungle/bedrock/can_place_cables()
+	return TRUE
 
 /turf/unsimulated/floor/jungle/worldborder
 	density=TRUE

--- a/code/modules/cmc/crew.dm
+++ b/code/modules/cmc/crew.dm
@@ -93,8 +93,14 @@ Crew Monitor by Paul, based on the holomaps by Deity
 	..()
 	if(!holomap_z_levels_mapped.len)
 		holomap_z_levels_mapped = list(map.zMainStation, map.zAsteroid, map.zDerelict)
+		if(map.zAdditionalStationZlevel>0)
+			holomap_z_levels_mapped+=map.zAdditionalStationZlevel
 	if(!holomap_z_levels_unmapped.len)
-		holomap_z_levels_unmapped = list(map.zTCommSat, map.zDeepSpace)
+		holomap_z_levels_unmapped = list()
+		if(map.zTCommSat>0)
+			holomap_z_levels_unmapped+=map.zTCommSat
+		if(map.zDeepSpace>0)
+			holomap_z_levels_unmapped+=map.zDeepSpace		
 
 /obj/machinery/computer/crew/Destroy()
 	deactivateAll()

--- a/maps/junglestation.dm
+++ b/maps/junglestation.dm
@@ -7,10 +7,16 @@
 	nameShort = "Jungle"
 	nameLong = "Jungle Station"
 	map_dir = "junglestation"
-	zAsteroid = 4
+	
 	zMainStation = 1
-	zCentcomm = 3
 	zAdditionalStationZlevel = 2
+	zCentcomm = 3
+	zAsteroid = 4
+	zDerelict = 5
+	
+	zDeepSpace = -1
+	zTCommSat = -1
+	
 	zLevels = list(
 		/datum/zLevel/junglesurface,
 		/datum/zLevel/jungleunderground,

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -1699,8 +1699,8 @@
 /obj/machinery/light_switch{
 	pixel_x = 28
 	},
-/turf/simulated/floor{
-	icon_state = "carpet"
+/turf/simulated/floor/carpet{
+	icon_state = "carpet11-12"
 	},
 /area/science/hallway)
 "aFO" = (
@@ -1790,9 +1790,6 @@
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/fenced)
 "aHH" = (
-/obj/machinery/light_switch{
-	pixel_x = -28
-	},
 /obj/machinery/disposal/compactor,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
@@ -2277,6 +2274,9 @@
 "aSI" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 25
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/engineering/break_room)
@@ -9133,9 +9133,7 @@
 /turf/simulated/floor,
 /area/supply/storage)
 "dwx" = (
-/turf/simulated/floor{
-	icon_state = "carpet"
-	},
+/turf/simulated/floor/carpet,
 /area/science/hallway)
 "dwG" = (
 /obj/machinery/atmospherics/binary/pump,
@@ -9643,7 +9641,7 @@
 /obj/item/device/mmi,
 /obj/item/device/mmi,
 /obj/item/device/mmi,
-/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -11531,8 +11529,8 @@
 /obj/machinery/optable{
 	name = "Robotics Operating Table"
 	},
-/obj/structure/window/reinforced/tinted,
-/obj/structure/window/reinforced/tinted{
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -13422,7 +13420,7 @@
 /turf/simulated/floor/engine,
 /area/science/xenobiology/specimen_2)
 "fiQ" = (
-/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -15563,8 +15561,8 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "carpet"
+/turf/simulated/floor/carpet{
+	icon_state = "carpet7-3"
 	},
 /area/science/hallway)
 "gaI" = (
@@ -18191,6 +18189,11 @@
 	icon_state = "yellowcorner"
 	},
 /area/engineering/engine)
+"haV" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet5-1"
+	},
+/area/science/hallway)
 "hbh" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -18536,8 +18539,8 @@
 	pixel_y = 6
 	},
 /obj/structure/table,
-/turf/simulated/floor{
-	icon_state = "carpet"
+/turf/simulated/floor/carpet{
+	icon_state = "carpet10-8"
 	},
 /area/science/hallway)
 "hij" = (
@@ -30203,8 +30206,8 @@
 /area/medical/surgery)
 "lPY" = (
 /obj/structure/bed/chair,
-/turf/simulated/floor{
-	icon_state = "carpet"
+/turf/simulated/floor/carpet{
+	icon_state = "carpet14-10"
 	},
 /area/science/hallway)
 "lQa" = (
@@ -32653,9 +32656,7 @@
 /area/surface/jungle/fenced)
 "mLW" = (
 /obj/structure/table,
-/turf/simulated/floor{
-	icon_state = "carpet"
-	},
+/turf/simulated/floor/carpet,
 /area/science/hallway)
 "mMm" = (
 /turf/simulated/floor{
@@ -33776,7 +33777,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/space,
+/turf/simulated/floor,
 /area/research_outpost/maintstore1{
 	icon_state = "toxstorage";
 	name = "Toxins Storage"
@@ -36809,6 +36810,15 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor,
 /area/supply/office)
+"oxF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/break_room)
 "oxJ" = (
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -43426,6 +43436,9 @@
 /area/medical/paramedics)
 "rfJ" = (
 /obj/structure/closet/lawcloset,
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "rga" = (
@@ -48631,6 +48644,11 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai)
+"thg" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/science/hallway)
 "thl" = (
 /obj/structure/window/reinforced{
 	one_way = 1
@@ -49197,8 +49215,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor{
-	icon_state = "carpet"
+/turf/simulated/floor/carpet{
+	icon_state = "carpet14-10"
 	},
 /area/science/hallway)
 "tpD" = (
@@ -49307,9 +49325,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = 28
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -49662,7 +49677,7 @@
 /obj/structure/table,
 /obj/item/clothing/gloves/latex,
 /turf/simulated/floor/carpet{
-	icon_state = "carpet13-5"
+	icon_state = "carpet9-4"
 	},
 /area/science/hallway)
 "tyO" = (
@@ -53105,7 +53120,7 @@
 /obj/machinery/computer/operating{
 	name = "Robotics Operating Computer"
 	},
-/obj/structure/window/reinforced/tinted{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -55550,6 +55565,9 @@
 /obj/machinery/camera{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "yellow";
 	dir = 1
@@ -57294,9 +57312,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor{
-	icon_state = "carpet"
-	},
+/turf/simulated/floor/carpet,
 /area/science/hallway)
 "wza" = (
 /obj/machinery/computer/atmos_alert,
@@ -57395,6 +57411,11 @@
 	},
 /turf/simulated/wall/shuttle/unsmoothed/black,
 /area/syndicate_mothership/elite_squad)
+"wAM" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet14-10"
+	},
+/area/science/hallway)
 "wBh" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/engine)
@@ -138054,7 +138075,7 @@ oEI
 hhB
 sKT
 qBo
-sKT
+oxF
 tew
 dvq
 rdz
@@ -140102,9 +140123,9 @@ cLz
 iLp
 iLp
 sUd
-dwx
+thg
 gaG
-voO
+haV
 iRG
 qCI
 rNK
@@ -141158,7 +141179,7 @@ jcS
 xIb
 mfN
 sUd
-dwx
+wAM
 dwx
 tfl
 gRa

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -25555,6 +25555,19 @@
 	dir = 6
 	},
 /area/engineering/atmos_control)
+"jWs" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 1
+	},
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -6
+	},
+/turf/simulated/floor{
+	icon_state = "freezerfloor"
+	},
+/area/crew_quarters/captain)
 "jWx" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -138214,7 +138227,7 @@ dCc
 mSW
 oXt
 jPq
-mSW
+jWs
 mSW
 wld
 wld

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -177,6 +177,13 @@
 	},
 /turf/simulated/floor/shuttle/plating,
 /area/centcom/evac)
+"ady" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 1
+	},
+/turf/unsimulated/floor/jungle/path_plated,
+/area/surface/jungle/fenced)
 "adI" = (
 /obj/structure/cult_legacy/tome,
 /obj/item/clothing/under/suit_jacket/red,
@@ -764,10 +771,10 @@
 	},
 /area/hydroponics)
 "aoI" = (
-/obj/machinery/vending/engivend,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/machinery/vending/coffee,
 /turf/simulated/floor,
 /area/engineering/engine)
 "apc" = (
@@ -1533,6 +1540,13 @@
 	},
 /turf/simulated/floor,
 /area/engineering/mechanics)
+"aCN" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 1
+	},
+/turf/unsimulated/floor/jungle/path_plated,
+/area/surface/jungle/fenced)
 "aCS" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
@@ -8368,7 +8382,7 @@
 "dgC" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering";
-	req_one_access_txt = "11;24"
+	req_access_txt = "11"
 	},
 /obj/structure/cable/orange{
 	icon_state = "1-2";
@@ -9001,7 +9015,7 @@
 "dtV" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Reactor Room";
-	req_one_access_txt = "10;24"
+	req_access_txt = "10"
 	},
 /obj/structure/cable/orange{
 	icon_state = "4-8";
@@ -12664,7 +12678,7 @@
 "eON" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Supermatter Room";
-	req_one_access_txt = "10;24"
+	req_access_txt = "10"
 	},
 /obj/structure/cable/orange{
 	icon_state = "4-8";
@@ -14573,7 +14587,8 @@
 /area/science/hallway)
 "fEA" = (
 /obj/machinery/door/airlock/glass_atmos{
-	name = "Atmospherics"
+	name = "Atmospherics";
+	req_access_txt = "24"
 	},
 /turf/simulated/floor,
 /area/engineering/atmos)
@@ -18411,6 +18426,7 @@
 "hef" = (
 /obj/structure/closet/secure_closet/engineering_atmos,
 /obj/structure/window/reinforced,
+/obj/item/weapon/tank/emergency_oxygen/double,
 /turf/simulated/floor{
 	icon_state = "yellow";
 	dir = 8
@@ -19022,6 +19038,13 @@
 	icon_state = "carpet3-0"
 	},
 /area/chapel/main)
+"hqV" = (
+/obj/structure/fence/door{
+	dir = 4;
+	req_access_txt = "24"
+	},
+/turf/unsimulated/floor/jungle/path_plated,
+/area/surface/jungle/zoned/atmos_outside)
 "hqY" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -26000,10 +26023,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/vending/tool,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/machinery/vending/snack,
 /turf/simulated/floor,
 /area/engineering/engine)
 "kfF" = (
@@ -26281,7 +26304,7 @@
 "klr" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Supermatter Room";
-	req_one_access_txt = "10;24"
+	req_access_txt = "10"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -26773,7 +26796,9 @@
 /turf/simulated,
 /area/mine/explored)
 "kvT" = (
-/obj/machinery/door/airlock/glass_atmos,
+/obj/machinery/door/airlock/glass_atmos{
+	req_access_txt = "24"
+	},
 /turf/simulated/floor,
 /area/engineering/atmos_control)
 "kwa" = (
@@ -32970,7 +32995,8 @@
 /area/security/lobby)
 "mRH" = (
 /obj/machinery/door/airlock/glass_atmos{
-	name = "Atmospherics"
+	name = "Atmospherics";
+	req_access_txt = "24"
 	},
 /obj/structure/cable/orange{
 	icon_state = "4-8";
@@ -34561,7 +34587,7 @@
 "nCS" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering";
-	req_one_access_txt = "11;24"
+	req_access_txt = "11"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -42807,6 +42833,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/item/weapon/tank/emergency_oxygen/double,
 /turf/simulated/floor{
 	icon_state = "yellow";
 	dir = 8
@@ -47254,6 +47281,9 @@
 /obj/structure/grille/window_spawner/reinforced/full,
 /turf/simulated,
 /area/shuttle/trade/start)
+"sCN" = (
+/turf/unsimulated/floor/jungle/path_plated,
+/area/surface/jungle/zoned/atmos_outside)
 "sCY" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/space,
@@ -48633,7 +48663,7 @@
 "tew" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering";
-	req_one_access_txt = "11;24"
+	req_access_txt = "11"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
@@ -48826,8 +48856,8 @@
 	},
 /obj/machinery/door/window{
 	name = "Atmospherics Monitoring";
-	req_access_txt = "32";
-	dir = 2
+	dir = 2;
+	req_one_access_txt = "11;24"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -50026,7 +50056,9 @@
 /turf/simulated/floor,
 /area/engineering/engine)
 "tCN" = (
-/obj/structure/fence/door,
+/obj/structure/fence/door{
+	req_access_txt = "10;24"
+	},
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/zoned/atmos_outside)
 "tCU" = (
@@ -52515,7 +52547,7 @@
 "uFO" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "AME Room";
-	req_one_access_txt = "11;24"
+	req_access_txt = "11"
 	},
 /obj/structure/cable/orange{
 	icon_state = "4-8";
@@ -136833,8 +136865,8 @@ vEs
 wld
 maR
 iMQ
-xMH
-wld
+vsz
+aCN
 vay
 qTP
 xkn
@@ -137185,8 +137217,8 @@ wnO
 wld
 maR
 iMQ
-xMH
-wld
+vsz
+aCN
 vay
 qTP
 xkn
@@ -137537,8 +137569,8 @@ wld
 wld
 maR
 iMQ
-xMH
-wld
+vsz
+aCN
 vay
 qTP
 flh
@@ -138241,7 +138273,7 @@ wld
 wld
 vhv
 xOV
-qcB
+iDZ
 qcB
 jkg
 oEI
@@ -138593,8 +138625,8 @@ wld
 wld
 xor
 iMQ
-wld
-wld
+bBI
+ady
 vay
 qTP
 wSQ
@@ -138945,8 +138977,8 @@ wld
 wld
 xor
 iMQ
-wld
-wld
+bBI
+ady
 vay
 qTP
 moC
@@ -139297,8 +139329,8 @@ wld
 xor
 xor
 iMQ
-wld
-wld
+vhv
+ady
 vay
 nql
 moC
@@ -147042,21 +147074,21 @@ eOA
 eOA
 eOA
 eOA
-cge
-cge
-auf
-auf
-auf
-auf
-auf
-auf
-auf
-auf
-auf
-auf
-auf
-auf
-auf
+rRT
+dhG
+jyd
+jyd
+jyd
+jyd
+jyd
+jyd
+jyd
+jyd
+jyd
+hqV
+jyd
+jyd
+jyd
 jsN
 tRU
 ifp
@@ -147394,21 +147426,21 @@ snf
 snf
 snf
 snf
-rRT
-dhG
-jyd
-jyd
-jyd
-jyd
-jyd
-jyd
-jyd
-jyd
-jyd
-jyd
-jyd
-jyd
-jyd
+cge
+sCN
+sCN
+sCN
+sCN
+sCN
+sCN
+sCN
+sCN
+sCN
+sCN
+sCN
+sCN
+sCN
+sCN
 jsN
 jsN
 jsN

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -1779,16 +1779,15 @@
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/zoned/botanty_outside)
 "aHG" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/airlock/command{
+	name = "Captain's Quarters";
+	req_access_txt = "20"
 	},
-/obj/machinery/camera{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/simulated/floor{
+	icon_state = "grimy"
 	},
-/turf/unsimulated/floor/jungle/path_plated,
-/area/surface/jungle/fenced)
+/area/crew_quarters/captain)
 "aHH" = (
 /obj/machinery/disposal/compactor,
 /turf/simulated/floor/carpet,
@@ -2892,11 +2891,6 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/bridge)
-"ben" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet10-8"
-	},
-/area/crew_quarters/captain)
 "beB" = (
 /turf/simulated/wall,
 /area/security/prison)
@@ -5123,16 +5117,10 @@
 /turf/simulated/wall/r_wall,
 /area/storage/tech)
 "bYg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/turf/simulated/floor/carpet{
+	icon_state = "carpet10-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/unsimulated/floor/jungle/path_plated,
-/area/surface/jungle/fenced)
+/area/crew_quarters/captain)
 "bYw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5175,6 +5163,18 @@
 	icon_state = "red"
 	},
 /area/security/prison)
+"bZo" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin/blue{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/melee/chainofcommand{
+	pixel_x = 13
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/simulated/floor/wood,
+/area/crew_quarters/captain)
 "bZP" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/donkpockets,
@@ -6624,6 +6624,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/fenced)
+"cyZ" = (
+/obj/machinery/light/small{
+	dir = 1;
+	invisibility = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/captain)
 "czn" = (
 /obj/machinery/light_switch{
 	pixel_y = -28
@@ -6795,11 +6804,20 @@
 /turf/simulated,
 /area/security/checkpoint2)
 "cCb" = (
-/obj/machinery/door/airlock{
-	name = "Private Restroom"
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper{
+	pixel_x = 6
+	},
+/obj/item/weapon/folder/blue{
+	pixel_x = -6;
+	pixel_y = -1
+	},
+/obj/item/weapon/pen{
+	pixel_x = -7;
+	pixel_y = 8
 	},
 /turf/simulated/floor{
-	icon_state = "freezerfloor"
+	icon_state = "grimy"
 	},
 /area/crew_quarters/captain)
 "cCm" = (
@@ -7078,18 +7096,6 @@
 	},
 /turf/unsimulated/floor/jungle/concrete,
 /area/surface/jungle/landing)
-"cId" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 17
-	},
-/obj/structure/mirror{
-	pixel_y = 31
-	},
-/turf/simulated/floor{
-	icon_state = "freezerfloor"
-	},
-/area/crew_quarters/captain)
 "cIe" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -7836,7 +7842,7 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/turf/unsimulated/floor/jungle/grass,
+/turf/unsimulated/floor/jungle/grass/no_flora,
 /area/surface/jungle/fenced)
 "cWF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -8581,6 +8587,18 @@
 	icon_state = "freezerfloor"
 	},
 /area/surface/jungle)
+"dlf" = (
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/simulated/floor/carpet{
+	icon_state = "carpet11-12"
+	},
+/area/crew_quarters/captain)
 "dli" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -8939,6 +8957,11 @@
 	},
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/fenced)
+"dsV" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet14-10"
+	},
+/area/science/hallway)
 "dsW" = (
 /obj/structure/grille/window_spawner/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -8946,13 +8969,6 @@
 	},
 /turf/simulated,
 /area/research_outpost/gearstore)
-"dtd" = (
-/obj/structure/table/woodentable,
-/obj/structure/displaycase/captains_laser,
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/captain)
 "dti" = (
 /obj/item/weapon/storage/box/labels,
 /obj/item/weapon/hand_labeler,
@@ -9160,9 +9176,7 @@
 /turf/simulated/floor,
 /area/supply/storage)
 "dwx" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet14-10"
-	},
+/turf/simulated/floor/carpet,
 /area/science/hallway)
 "dwG" = (
 /obj/machinery/atmospherics/binary/pump,
@@ -9206,9 +9220,6 @@
 	},
 /turf/simulated/floor,
 /area/engineering/supermatter_room)
-"dxE" = (
-/turf/simulated/floor/carpet,
-/area/science/hallway)
 "dxI" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/full/reinforced,
@@ -9247,6 +9258,13 @@
 	icon_state = "white"
 	},
 /area/medical/genetics)
+"dyE" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet/captain,
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/captain)
 "dyG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -10862,11 +10880,8 @@
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/fenced)
 "efD" = (
-/obj/structure/bed,
-/obj/item/weapon/bedsheet/captain,
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
+/obj/structure/filingcabinet,
+/turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "efR" = (
 /obj/structure/table/woodentable,
@@ -12000,6 +12015,12 @@
 	},
 /turf/unsimulated/floor/jungle/concrete,
 /area/surface/jungle)
+"ezJ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/captain)
 "ezS" = (
 /mob/living/silicon/decoy{
 	name = "A.L.I.C.E."
@@ -12018,6 +12039,14 @@
 	name = "plating"
 	},
 /area/centcom/evac)
+"eAh" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/captain)
 "eAj" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -12223,15 +12252,9 @@
 /turf/simulated/floor,
 /area/supply/sorting)
 "eHg" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
+/obj/machinery/light,
 /turf/simulated/floor/carpet{
-	icon_state = "carpet11-12"
+	icon_state = "carpet9-4"
 	},
 /area/crew_quarters/captain)
 "eHh" = (
@@ -12353,11 +12376,6 @@
 	icon_state = "cult"
 	},
 /area/lawoffice)
-"eKm" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet14-10"
-	},
-/area/crew_quarters/captain)
 "eKC" = (
 /turf/simulated/floor/plating,
 /area/centcom/suppy)
@@ -13114,6 +13132,11 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
+"faP" = (
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/captain)
 "faZ" = (
 /turf/simulated/floor/shuttle{
 	icon_state = "floor2"
@@ -13500,12 +13523,11 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "fjR" = (
-/obj/structure/closet/secure_closet/captains,
-/obj/machinery/light_switch{
-	pixel_y = -24
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/captain)
+/turf/unsimulated/floor/jungle/grass,
+/area/surface/jungle/fenced)
 "fjX" = (
 /obj/structure/closet/wardrobe/pjs,
 /obj/machinery/light/small{
@@ -15067,13 +15089,8 @@
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/zoned/outdoor_bar)
 "fPn" = (
-/obj/machinery/door/airlock/command{
-	name = "Captain's Quarters";
-	req_access_txt = "20"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor{
-	icon_state = "grimy"
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
 	},
 /area/crew_quarters/captain)
 "fPu" = (
@@ -15694,12 +15711,6 @@
 	icon_state = "red"
 	},
 /area/security/brig)
-"gcU" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/captain)
 "gcX" = (
 /obj/structure/grille/window_spawner/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -18711,18 +18722,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/surface/jungle)
-"hlQ" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin/blue{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/melee/chainofcommand{
-	pixel_x = 13
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/simulated/floor/wood,
-/area/crew_quarters/captain)
 "hlX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
@@ -20530,6 +20529,14 @@
 	icon_state = "red"
 	},
 /area/security/main)
+"hXk" = (
+/obj/machinery/door/airlock{
+	name = "Private Restroom"
+	},
+/turf/simulated/floor{
+	icon_state = "freezerfloor"
+	},
+/area/crew_quarters/captain)
 "hXr" = (
 /turf/simulated/floor/wood,
 /area/surface/jungle/underground/zoned/casino)
@@ -20968,12 +20975,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/disposal)
-"igC" = (
-/obj/machinery/light,
-/turf/simulated/floor/carpet{
-	icon_state = "carpet9-4"
-	},
-/area/crew_quarters/captain)
 "igR" = (
 /obj/machinery/atmospherics/unary/vent/high_volume{
 	dir = 1
@@ -21178,11 +21179,6 @@
 	icon_state = "dark"
 	},
 /area/vox_trading_post/gardens)
-"ikG" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
-	},
-/area/science/hallway)
 "ikV" = (
 /obj/structure/bed,
 /turf/unsimulated/floor{
@@ -22967,10 +22963,6 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/bridge)
-"iXr" = (
-/obj/structure/filingcabinet,
-/turf/simulated/floor/wood,
-/area/crew_quarters/captain)
 "iXu" = (
 /obj/structure/bed/chair,
 /turf/unsimulated/floor{
@@ -24132,6 +24124,13 @@
 /obj/item/weapon/bedsheet/yellow,
 /turf/simulated/floor/wood,
 /area/surface/jungle)
+"juY" = (
+/obj/structure/closet/secure_closet/captains,
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/captain)
 "jvb" = (
 /obj/structure/grille/window_spawner/reinforced/full,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -24591,9 +24590,9 @@
 /area/research_outpost/atmos)
 "jDF" = (
 /turf/simulated/floor/carpet{
-	icon_state = "carpet13-5"
+	icon_state = "carpet5-1"
 	},
-/area/crew_quarters/captain)
+/area/science/hallway)
 "jDK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -24638,6 +24637,13 @@
 	},
 /turf/unsimulated/floor/jungle/grass,
 /area/surface/jungle)
+"jEt" = (
+/obj/structure/table/woodentable,
+/obj/structure/displaycase/captains_laser,
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/captain)
 "jEA" = (
 /obj/structure/bed/chair/comfy/teal{
 	dir = 4
@@ -26617,14 +26623,12 @@
 /turf/simulated/floor/wood,
 /area/surface/jungle/underground/zoned/casino)
 "ksX" = (
-/obj/machinery/light/small{
-	dir = 1;
-	invisibility = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/captain)
+/obj/machinery/light/small,
+/turf/unsimulated/floor/jungle/path_plated,
+/area/surface/jungle/fenced)
 "ktj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/yellow{
@@ -34427,23 +34431,6 @@
 	icon_state = "dark-markings"
 	},
 /area/centcom/specops)
-"nzQ" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/paper{
-	pixel_x = 6
-	},
-/obj/item/weapon/folder/blue{
-	pixel_x = -6;
-	pixel_y = -1
-	},
-/obj/item/weapon/pen{
-	pixel_x = -7;
-	pixel_y = 8
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/captain)
 "nzV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
@@ -35273,14 +35260,15 @@
 	},
 /turf/unsimulated/floor/jungle/concrete,
 /area/surface/jungle/landing)
-"nPC" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+"nPL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
 	},
-/turf/simulated/floor{
-	icon_state = "grimy"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/crew_quarters/captain)
+/turf/simulated/floor,
+/area/engineering/break_room)
 "nPN" = (
 /turf/simulated/floor,
 /area/engineering/supermatter_room)
@@ -37405,14 +37393,6 @@
 	icon_state = "dark"
 	},
 /area/science/robotics)
-"oGL" = (
-/obj/structure/bed/chair,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/simulated/floor/wood,
-/area/crew_quarters/captain)
 "oGR" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/bag/clipboard,
@@ -38088,6 +38068,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep)
+"oXt" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 17
+	},
+/obj/structure/mirror{
+	pixel_y = 31
+	},
+/turf/simulated/floor{
+	icon_state = "freezerfloor"
+	},
+/area/crew_quarters/captain)
 "oXv" = (
 /obj/structure/grille/window_spawner/reinforced,
 /turf/simulated,
@@ -42246,6 +42238,13 @@
 "qDw" = (
 /turf/simulated/floor/wood,
 /area/surface/jungle/fenced)
+"qDz" = (
+/obj/machinery/hologram/holopad,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/captain)
 "qDJ" = (
 /obj/machinery/door/unpowered/shuttle,
 /turf/simulated/floor/shuttle,
@@ -46135,6 +46134,9 @@
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/fenced)
 "sbS" = (
@@ -46432,10 +46434,13 @@
 	},
 /area/tdome)
 "shg" = (
-/turf/simulated/floor{
-	icon_state = "grimy"
+/obj/machinery/account_database,
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 1
 	},
-/area/crew_quarters/captain)
+/turf/simulated/floor,
+/area/bridge/meeting_room)
 "shJ" = (
 /obj/structure/grille/window_spawner/reinforced,
 /turf/simulated,
@@ -48669,16 +48674,13 @@
 	},
 /area/science/hallway)
 "tfs" = (
+/obj/structure/bed/chair,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/unsimulated/floor/jungle/path_plated,
-/area/surface/jungle/fenced)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/simulated/floor/wood,
+/area/crew_quarters/captain)
 "tfx" = (
 /obj/item/weapon/pickaxe,
 /turf/simulated/floor/asteroid,
@@ -49552,11 +49554,6 @@
 	icon_state = "redyellowfull"
 	},
 /area/tdome/tdomeadmin)
-"ttI" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet5-1"
-	},
-/area/crew_quarters/captain)
 "ttK" = (
 /turf/simulated/floor/server,
 /area/tcomms/chamber)
@@ -50035,6 +50032,11 @@
 	icon_state = "toxlab";
 	name = "Toxins"
 	})
+"tDr" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet14-10"
+	},
+/area/crew_quarters/captain)
 "tDw" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -51411,11 +51413,6 @@
 	icon_state = "dark-markings"
 	},
 /area/centcom/specops)
-"ujJ" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet5-1"
-	},
-/area/science/hallway)
 "ujQ" = (
 /obj/structure/table/reinforced,
 /obj/item/ashtray/plastic{
@@ -52539,6 +52536,11 @@
 /obj/structure/grille/window_spawner/reinforced_plasma,
 /turf/simulated/floor/engine,
 /area/science/telescience)
+"uGW" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/science/hallway)
 "uGY" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -53170,14 +53172,6 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/bridge)
-"uVd" = (
-/obj/machinery/account_database,
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/bridge/meeting_room)
 "uVo" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/firealarm{
@@ -54250,13 +54244,6 @@
 "vnA" = (
 /turf/simulated/wall,
 /area/engineering/break_room)
-"vnC" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/captain)
 "vnJ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -57576,14 +57563,10 @@
 /turf/simulated/wall/shuttle/unsmoothed/black,
 /area/syndicate_mothership/elite_squad)
 "wAM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
+/turf/simulated/floor/carpet{
+	icon_state = "carpet5-1"
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/engineering/break_room)
+/area/crew_quarters/captain)
 "wBh" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/engine)
@@ -61303,11 +61286,6 @@
 	icon_state = "white"
 	},
 /area/medical/sleeper)
-"xXv" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
-	},
-/area/crew_quarters/captain)
 "xXD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -61938,6 +61916,11 @@
 	name = "plating"
 	},
 /area/centcom/suppy)
+"ykF" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet13-5"
+	},
+/area/crew_quarters/captain)
 "ykW" = (
 /obj/item/device/radio/intercom/medbay{
 	pixel_y = -30
@@ -131146,7 +131129,7 @@ eea
 nDK
 waf
 jUa
-jUa
+xVS
 jUa
 jUa
 jUa
@@ -131498,7 +131481,7 @@ llD
 wIs
 xTT
 mEG
-mEG
+lUD
 mEG
 mEG
 mEG
@@ -131849,8 +131832,8 @@ nVJ
 aPt
 lgW
 lqv
-wld
-wld
+nre
+psY
 wld
 wld
 wld
@@ -132201,8 +132184,8 @@ jAP
 aPt
 lgW
 lqv
-wld
-wld
+nre
+psY
 wld
 wld
 wld
@@ -132554,7 +132537,7 @@ iLk
 lgW
 jAP
 cVR
-wld
+psY
 wld
 wld
 wld
@@ -132905,8 +132888,8 @@ xrU
 lgW
 yju
 jAP
-wld
-wld
+nre
+psY
 wld
 wld
 wld
@@ -133257,29 +133240,29 @@ jAP
 jOW
 jAP
 jAP
+nre
+psY
 wld
-kyt
-tsV
-aHG
-tsV
-tsV
-tsV
-tsV
-tsV
-tsV
-tsV
-tsV
-tsV
-tsV
-tsV
-tsV
-tsV
-tsV
-tsV
-tsV
-tsV
-bYg
-tfs
+jaT
+wld
+wld
+wld
+wld
+wld
+wld
+wld
+fjR
+wld
+wld
+wld
+wld
+wld
+fjR
+wld
+wld
+wld
+xMH
+psY
 maR
 wld
 gts
@@ -133609,9 +133592,9 @@ jAP
 lgW
 lgW
 jAP
-wld
+nre
 psY
-wld
+nre
 iVX
 iVX
 iVX
@@ -133632,7 +133615,7 @@ wld
 wld
 xMH
 psY
-maR
+ksX
 gts
 gts
 fmX
@@ -133961,9 +133944,9 @@ jAP
 lWw
 lgW
 jAP
-wld
+nre
 psY
-wld
+nre
 iVX
 tkz
 bnw
@@ -134315,7 +134298,7 @@ yaH
 jAP
 oqo
 psY
-wld
+nre
 iVX
 vLr
 gaB
@@ -134352,7 +134335,7 @@ vEO
 vEO
 bsD
 vEO
-uVd
+shg
 kFf
 hWk
 aSg
@@ -135403,10 +135386,10 @@ uIW
 vuD
 gat
 mSW
-xXv
+fPn
 tlY
 tlY
-ttI
+wAM
 mSW
 mSW
 kYF
@@ -135755,10 +135738,10 @@ npQ
 izt
 iXn
 mSW
-eKm
+tDr
 lXe
 rYt
-jDF
+ykF
 mSW
 mSW
 jTQ
@@ -136107,10 +136090,10 @@ iCf
 cYA
 gBj
 mSW
-ben
+bYg
 tvl
+dlf
 eHg
-igC
 mSW
 mSW
 mSW
@@ -136463,7 +136446,7 @@ xzO
 lSL
 bdk
 vWT
-hlQ
+bZo
 nIC
 ddp
 rZO
@@ -136471,7 +136454,7 @@ hmE
 bAm
 sLr
 fsJ
-efD
+dyE
 mSW
 wld
 wld
@@ -136814,14 +136797,14 @@ qeB
 dGF
 pBW
 fbA
-oGL
+tfs
 bmi
 usf
 pxf
 dGF
 dGF
-fPn
-nPC
+aHG
+eAh
 fsJ
 fsJ
 mSW
@@ -137165,17 +137148,17 @@ gts
 mSW
 mPT
 cGy
-gcU
-vnC
+ezJ
+qDz
 oZe
 mPT
 sRO
 mPT
-fjR
+juY
 mSW
-ksX
+cyZ
 coc
-nzQ
+cCb
 mSW
 wld
 wld
@@ -137525,9 +137508,9 @@ pPh
 hce
 hOW
 mSW
-shg
-shg
-dtd
+faP
+faP
+jEt
 mSW
 wld
 wld
@@ -137856,7 +137839,7 @@ wld
 wld
 xMH
 psY
-maR
+ksX
 gts
 gts
 hhQ
@@ -137877,7 +137860,7 @@ mPT
 mPT
 mPT
 mSW
-cCb
+hXk
 mSW
 mSW
 mSW
@@ -138225,11 +138208,11 @@ kUj
 kUj
 kUj
 qGf
-iXr
+efD
 mPT
 dCc
 mSW
-cId
+oXt
 jPq
 mSW
 mSW
@@ -138252,7 +138235,7 @@ oEI
 hhB
 sKT
 qBo
-wAM
+nPL
 tew
 dvq
 rdz
@@ -138566,7 +138549,7 @@ mEG
 mEG
 mEG
 mEG
-mEG
+qAR
 mEG
 mEG
 qtJ
@@ -140300,9 +140283,9 @@ cLz
 iLp
 iLp
 sUd
-ikG
+uGW
 gaG
-ujJ
+jDF
 iRG
 qCI
 rNK
@@ -141356,8 +141339,8 @@ jcS
 xIb
 mfN
 sUd
+dsV
 dwx
-dxE
 tfl
 gRa
 kNI

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -1256,11 +1256,6 @@
 /obj/item/clothing/gloves/latex,
 /turf/simulated/floor,
 /area/research_outpost/entry)
-"axA" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet5-1"
-	},
-/area/science/hallway)
 "axD" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -9141,7 +9136,9 @@
 /turf/simulated/floor,
 /area/supply/storage)
 "dwx" = (
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet14-10"
+	},
 /area/science/hallway)
 "dwG" = (
 /obj/machinery/atmospherics/binary/pump,
@@ -9533,6 +9530,15 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/disposal)
+"dEP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/break_room)
 "dFe" = (
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
@@ -11828,15 +11834,6 @@
 	icon_state = "white"
 	},
 /area/medical/medbay)
-"ewA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/engineering/break_room)
 "ewI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/disposal/compactor,
@@ -15311,6 +15308,11 @@
 	},
 /turf/simulated,
 /area/medical/cmo)
+"fUB" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/science/hallway)
 "fUK" = (
 /turf/simulated/floor/wood,
 /area/surface/jungle/zoned/outdoor_bar)
@@ -29023,11 +29025,6 @@
 	icon_state = "white"
 	},
 /area/science/xenobiology)
-"ltL" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
-	},
-/area/science/hallway)
 "ltQ" = (
 /obj/structure/displaycase/lamarr,
 /turf/simulated/floor{
@@ -43054,9 +43051,6 @@
 	pixel_y = -3
 	},
 /obj/item/weapon/storage/box/buckshotshells,
-/obj/machinery/light_switch{
-	pixel_y = 27
-	},
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
@@ -49301,6 +49295,9 @@
 	icon_state = "carpet7-3"
 	},
 /area/chapel/main)
+"trD" = (
+/turf/simulated/floor/carpet,
+/area/science/hallway)
 "trM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57439,7 +57436,7 @@
 /area/syndicate_mothership/elite_squad)
 "wAM" = (
 /turf/simulated/floor/carpet{
-	icon_state = "carpet14-10"
+	icon_state = "carpet5-1"
 	},
 /area/science/hallway)
 "wBh" = (
@@ -138104,7 +138101,7 @@ oEI
 hhB
 sKT
 qBo
-ewA
+dEP
 tew
 dvq
 rdz
@@ -140152,9 +140149,9 @@ cLz
 iLp
 iLp
 sUd
-ltL
+fUB
 gaG
-axA
+wAM
 iRG
 qCI
 rNK
@@ -141208,8 +141205,8 @@ jcS
 xIb
 mfN
 sUd
-wAM
 dwx
+trD
 tfl
 gRa
 kNI

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -2856,10 +2856,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	canSpawnMice = 0;
-	dir = 1;
-	on = 1
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -2894,6 +2892,11 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/bridge)
+"ben" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet10-8"
+	},
+/area/crew_quarters/captain)
 "beB" = (
 /turf/simulated/wall,
 /area/security/prison)
@@ -3259,7 +3262,11 @@
 	},
 /area/science/lab)
 "bmi" = (
-/obj/structure/bed/chair,
+/obj/structure/table/woodentable,
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/pen/fountain/cap,
+/obj/item/weapon/stamp/captain,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "bmo" = (
@@ -3958,8 +3965,8 @@
 /turf/simulated/floor,
 /area/security/lobby)
 "bAm" = (
-/obj/machinery/suit_storage_unit/captain,
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/simulated/wall/r_wall,
 /area/crew_quarters/captain)
 "bAt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -5996,12 +6003,10 @@
 /turf/unsimulated/floor/jungle/grass,
 /area/surface/jungle)
 "coc" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/melee/chainofcommand,
-/obj/machinery/light_switch{
-	pixel_y = -28
+/obj/structure/bed/chair/comfy/teal,
+/turf/simulated/floor{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "coo" = (
 /obj/structure/cable/yellow{
@@ -6790,13 +6795,12 @@
 /turf/simulated,
 /area/security/checkpoint2)
 "cCb" = (
-/obj/structure/filingcabinet,
-/obj/structure/window/reinforced{
-	dir = 4;
-	one_way = 1
+/obj/machinery/door/airlock{
+	name = "Private Restroom"
 	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "freezerfloor"
+	},
 /area/crew_quarters/captain)
 "cCm" = (
 /obj/structure/shuttle/diag_wall/smooth{
@@ -7074,6 +7078,18 @@
 	},
 /turf/unsimulated/floor/jungle/concrete,
 /area/surface/jungle/landing)
+"cId" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 17
+	},
+/obj/structure/mirror{
+	pixel_y = 31
+	},
+/turf/simulated/floor{
+	icon_state = "freezerfloor"
+	},
+/area/crew_quarters/captain)
 "cIe" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -8161,9 +8177,10 @@
 /turf/simulated/floor,
 /area/mine/production)
 "ddp" = (
-/obj/machinery/keycard_auth{
-	pixel_x = -24
+/obj/machinery/status_display{
+	pixel_x = -32
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "dds" = (
@@ -8929,6 +8946,13 @@
 	},
 /turf/simulated,
 /area/research_outpost/gearstore)
+"dtd" = (
+/obj/structure/table/woodentable,
+/obj/structure/displaycase/captains_laser,
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/captain)
 "dti" = (
 /obj/item/weapon/storage/box/labels,
 /obj/item/weapon/hand_labeler,
@@ -9182,6 +9206,9 @@
 	},
 /turf/simulated/floor,
 /area/engineering/supermatter_room)
+"dxE" = (
+/turf/simulated/floor/carpet,
+/area/science/hallway)
 "dxI" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/full/reinforced,
@@ -9478,6 +9505,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/disposal/compactor,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "dCo" = (
@@ -9530,15 +9558,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/disposal)
-"dEP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/engineering/break_room)
 "dFe" = (
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
@@ -10843,16 +10862,12 @@
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/fenced)
 "efD" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
+/obj/structure/bed,
+/obj/item/weapon/bedsheet/captain,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown";
-	tag = "icon-brown (NORTH)"
+	icon_state = "grimy"
 	},
-/area/supply/sorting)
+/area/crew_quarters/captain)
 "efR" = (
 /obj/structure/table/woodentable,
 /obj/machinery/recharger{
@@ -12211,7 +12226,13 @@
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
 	},
-/turf/simulated/floor/carpet,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/simulated/floor/carpet{
+	icon_state = "carpet11-12"
+	},
 /area/crew_quarters/captain)
 "eHh" = (
 /obj/structure/table/woodentable,
@@ -12332,6 +12353,11 @@
 	icon_state = "cult"
 	},
 /area/lawoffice)
+"eKm" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet14-10"
+	},
+/area/crew_quarters/captain)
 "eKC" = (
 /turf/simulated/floor/plating,
 /area/centcom/suppy)
@@ -13107,8 +13133,9 @@
 /turf/space,
 /area/centcom/specops)
 "fbA" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8;
+	initialize_directions = 11
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -13473,9 +13500,12 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "fjR" = (
-/obj/machinery/account_database,
+/obj/structure/closet/secure_closet/captains,
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood,
-/area/bridge/meeting_room)
+/area/crew_quarters/captain)
 "fjX" = (
 /obj/structure/closet/wardrobe/pjs,
 /obj/machinery/light/small{
@@ -13932,9 +13962,10 @@
 	},
 /area/supply/miningdock)
 "fsJ" = (
-/obj/structure/table/woodentable,
-/obj/structure/displaycase/captains_laser,
-/turf/simulated/floor/wood,
+/obj/structure/curtain/open/bed,
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
 /area/crew_quarters/captain)
 "fta" = (
 /obj/machinery/r_n_d/fabricator/mechanic_fab/flatpacker,
@@ -15036,8 +15067,14 @@
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/zoned/outdoor_bar)
 "fPn" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/wood,
+/obj/machinery/door/airlock/command{
+	name = "Captain's Quarters";
+	req_access_txt = "20"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
 /area/crew_quarters/captain)
 "fPu" = (
 /obj/structure/table/glass,
@@ -15308,11 +15345,6 @@
 	},
 /turf/simulated,
 /area/medical/cmo)
-"fUB" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
-	},
-/area/science/hallway)
 "fUK" = (
 /turf/simulated/floor/wood,
 /area/surface/jungle/zoned/outdoor_bar)
@@ -15662,6 +15694,12 @@
 	icon_state = "red"
 	},
 /area/security/brig)
+"gcU" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/captain)
 "gcX" = (
 /obj/structure/grille/window_spawner/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -18673,6 +18711,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/surface/jungle)
+"hlQ" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin/blue{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/melee/chainofcommand{
+	pixel_x = 13
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/simulated/floor/wood,
+/area/crew_quarters/captain)
 "hlX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor{
@@ -18726,12 +18776,8 @@
 	},
 /area/science/lab)
 "hmE" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/camera{
-	dir = 4
-	},
+/obj/machinery/suit_storage_unit/captain,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "hmF" = (
@@ -20922,6 +20968,12 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/disposal)
+"igC" = (
+/obj/machinery/light,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet9-4"
+	},
+/area/crew_quarters/captain)
 "igR" = (
 /obj/machinery/atmospherics/unary/vent/high_volume{
 	dir = 1
@@ -21126,6 +21178,11 @@
 	icon_state = "dark"
 	},
 /area/vox_trading_post/gardens)
+"ikG" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/science/hallway)
 "ikV" = (
 /obj/structure/bed,
 /turf/unsimulated/floor{
@@ -21379,6 +21436,7 @@
 /obj/machinery/light_switch{
 	pixel_y = -28
 	},
+/obj/machinery/light,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "brown"
@@ -22909,6 +22967,10 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/bridge)
+"iXr" = (
+/obj/structure/filingcabinet,
+/turf/simulated/floor/wood,
+/area/crew_quarters/captain)
 "iXu" = (
 /obj/structure/bed/chair,
 /turf/unsimulated/floor{
@@ -24528,8 +24590,9 @@
 /turf/simulated/floor/plating,
 /area/research_outpost/atmos)
 "jDF" = (
-/obj/machinery/light,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet13-5"
+	},
 /area/crew_quarters/captain)
 "jDK" = (
 /obj/structure/cable/yellow{
@@ -25060,8 +25123,12 @@
 	},
 /area/hydroponics)
 "jPq" = (
-/obj/machinery/disposal/compactor,
-/turf/simulated/floor/wood,
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "freezerfloor"
+	},
 /area/crew_quarters/captain)
 "jPw" = (
 /obj/structure/table/reinforced,
@@ -25400,6 +25467,7 @@
 	pixel_x = 28
 	},
 /obj/machinery/hologram/holopad,
+/obj/machinery/teleport/hub,
 /turf/simulated/floor,
 /area/teleporter)
 "jUa" = (
@@ -26549,9 +26617,13 @@
 /turf/simulated/floor/wood,
 /area/surface/jungle/underground/zoned/casino)
 "ksX" = (
-/obj/machinery/computer/card,
-/obj/item/weapon/card/id/captains_spare,
-/turf/simulated/floor/wood,
+/obj/machinery/light/small{
+	dir = 1;
+	invisibility = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
 /area/crew_quarters/captain)
 "ktj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -34355,6 +34427,23 @@
 	icon_state = "dark-markings"
 	},
 /area/centcom/specops)
+"nzQ" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper{
+	pixel_x = 6
+	},
+/obj/item/weapon/folder/blue{
+	pixel_x = -6;
+	pixel_y = -1
+	},
+/obj/item/weapon/pen{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/captain)
 "nzV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor{
@@ -34700,12 +34789,10 @@
 /turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/fenced)
 "nIC" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin/blue{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/keycard_auth{
+	pixel_x = -24
 	},
-/obj/item/weapon/pen,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "nIM" = (
@@ -35186,6 +35273,14 @@
 	},
 /turf/unsimulated/floor/jungle/concrete,
 /area/surface/jungle/landing)
+"nPC" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/captain)
 "nPN" = (
 /turf/simulated/floor,
 /area/engineering/supermatter_room)
@@ -37310,6 +37405,14 @@
 	icon_state = "dark"
 	},
 /area/science/robotics)
+"oGL" = (
+/obj/structure/bed/chair,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/simulated/floor/wood,
+/area/crew_quarters/captain)
 "oGR" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/bag/clipboard,
@@ -39252,12 +39355,9 @@
 	},
 /area/centcom/control)
 "pxf" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
-	},
-/obj/effect/landmark/start{
-	name = "Captain"
-	},
+/obj/machinery/computer/card,
+/obj/item/weapon/card/id/captains_spare,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "pxg" = (
@@ -40999,10 +41099,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
 	},
 /obj/effect/landmark/start{
 	name = "Cargo Technician"
@@ -45887,9 +45983,13 @@
 /turf/unsimulated/floor/jungle/concrete,
 /area/shuttle/supply)
 "rZO" = (
-/obj/machinery/status_display{
-	pixel_x = -32
+/obj/machinery/light{
+	dir = 8
 	},
+/obj/machinery/camera{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "rZU" = (
@@ -46332,9 +46432,10 @@
 	},
 /area/tdome)
 "shg" = (
-/obj/machinery/teleport/hub,
-/turf/simulated/floor,
-/area/teleporter)
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/captain)
 "shJ" = (
 /obj/structure/grille/window_spawner/reinforced,
 /turf/simulated,
@@ -47584,8 +47685,15 @@
 	},
 /area/centcom)
 "sLr" = (
-/obj/structure/closet/secure_closet/captains,
-/turf/simulated/floor/wood,
+/obj/structure/closet/cabinet,
+/obj/machinery/atmospherics/unary/vent_pump{
+	canSpawnMice = 0;
+	dir = 1;
+	on = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
 /area/crew_quarters/captain)
 "sLQ" = (
 /obj/effect/decal/warning_stripes{
@@ -49022,7 +49130,9 @@
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet7-3"
+	},
 /area/crew_quarters/captain)
 "tme" = (
 /obj/machinery/light,
@@ -49295,9 +49405,6 @@
 	icon_state = "carpet7-3"
 	},
 /area/chapel/main)
-"trD" = (
-/turf/simulated/floor/carpet,
-/area/science/hallway)
 "trM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -49445,6 +49552,11 @@
 	icon_state = "redyellowfull"
 	},
 /area/tdome/tdomeadmin)
+"ttI" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet5-1"
+	},
+/area/crew_quarters/captain)
 "ttK" = (
 /turf/simulated/floor/server,
 /area/tcomms/chamber)
@@ -49494,7 +49606,12 @@
 	},
 /area/lawoffice)
 "tvl" = (
-/turf/simulated/floor/carpet,
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
+	},
+/turf/simulated/floor/carpet{
+	icon_state = "carpet11-12"
+	},
 /area/crew_quarters/captain)
 "tvo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51294,6 +51411,11 @@
 	icon_state = "dark-markings"
 	},
 /area/centcom/specops)
+"ujJ" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet5-1"
+	},
+/area/science/hallway)
 "ujQ" = (
 /obj/structure/table/reinforced,
 /obj/item/ashtray/plastic{
@@ -51823,10 +51945,13 @@
 	},
 /area/crew_quarters/heads/hos)
 "usf" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/folder/blue,
-/obj/item/weapon/pen/fountain/cap,
-/obj/item/weapon/stamp/captain,
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Captain"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "usm" = (
@@ -53045,6 +53170,14 @@
 	tag = "icon-vault (NORTHEAST)"
 	},
 /area/bridge)
+"uVd" = (
+/obj/machinery/account_database,
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/bridge/meeting_room)
 "uVo" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/firealarm{
@@ -54117,6 +54250,13 @@
 "vnA" = (
 /turf/simulated/wall,
 /area/engineering/break_room)
+"vnC" = (
+/obj/machinery/hologram/holopad,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/captain)
 "vnJ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -56057,6 +56197,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "vWX" = (
@@ -57435,10 +57576,14 @@
 /turf/simulated/wall/shuttle/unsmoothed/black,
 /area/syndicate_mothership/elite_squad)
 "wAM" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet5-1"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
 	},
-/area/science/hallway)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/break_room)
 "wBh" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/engine)
@@ -58371,6 +58516,7 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow,
+/obj/machinery/light,
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "brown"
@@ -61157,6 +61303,11 @@
 	icon_state = "white"
 	},
 /area/medical/sleeper)
+"xXv" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/crew_quarters/captain)
 "xXD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -121507,7 +121658,7 @@ qfU
 jAx
 eHP
 vLH
-iua
+wZY
 iua
 bbB
 wOM
@@ -122915,7 +123066,7 @@ sgL
 qqK
 vrm
 pfB
-wZY
+iua
 sEw
 wxh
 iua
@@ -123267,7 +123418,7 @@ sgL
 qqK
 vrm
 vPt
-efD
+hFy
 thl
 vKe
 hFy
@@ -133849,7 +134000,7 @@ mAb
 tTL
 bsD
 vEO
-kFf
+ouV
 kFf
 kFf
 kFf
@@ -134200,9 +134351,9 @@ vEO
 vEO
 vEO
 bsD
-qEg
+vEO
+uVd
 kFf
-dNU
 hWk
 aSg
 hWk
@@ -134552,9 +134703,9 @@ ntr
 mIk
 cIY
 fvF
-fjR
+qEg
+ouV
 kFf
-kYF
 hWk
 dRk
 hWk
@@ -134906,7 +135057,7 @@ mSW
 mSW
 mSW
 mSW
-shg
+dNU
 hWk
 beY
 hWk
@@ -134917,12 +135068,12 @@ maR
 ibi
 wld
 wld
-wld
-wld
-wld
-wld
-wld
-wld
+jYs
+aAy
+iJY
+jYs
+pap
+nph
 wld
 maR
 iMQ
@@ -135252,13 +135403,13 @@ uIW
 vuD
 gat
 mSW
-mPT
-tvl
+xXv
 tlY
 tlY
-tvl
+ttI
 mSW
-hWk
+mSW
+kYF
 hWk
 hWk
 fil
@@ -135268,13 +135419,13 @@ dSH
 xKy
 ibi
 wld
-jYs
-aAy
-iJY
-jYs
-pap
-nph
 wld
+jYs
+jYs
+jYs
+jYs
+jYs
+qQG
 wld
 maR
 iMQ
@@ -135604,11 +135755,11 @@ npQ
 izt
 iXn
 mSW
-mPT
-tvl
+eKm
 lXe
 rYt
-tvl
+jDF
+mSW
 mSW
 jTQ
 hWk
@@ -135620,13 +135771,13 @@ whf
 ltH
 nJE
 wld
-jYs
-jYs
-jYs
-jYs
-jYs
-qQG
 wld
+jYs
+aAy
+iJY
+jYs
+plL
+ttF
 wld
 maR
 iMQ
@@ -135956,11 +136107,10 @@ iCf
 cYA
 gBj
 mSW
-mPT
+ben
 tvl
 eHg
-eHg
-jDF
+igC
 mSW
 mSW
 mSW
@@ -135969,16 +136119,17 @@ mSW
 mSW
 mSW
 mSW
+mSW
+mSW
+gHV
 wld
 wld
-wld
+rHF
 jYs
-aAy
-iJY
 jYs
-plL
-ttF
-wld
+jYs
+jYs
+jYs
 wld
 maR
 iMQ
@@ -136312,7 +136463,7 @@ xzO
 lSL
 bdk
 vWT
-mPT
+hlQ
 nIC
 ddp
 rZO
@@ -136320,17 +136471,17 @@ hmE
 bAm
 sLr
 fsJ
+efD
 mSW
-gHV
 wld
 wld
-rHF
-jYs
-jYs
-jYs
-jYs
-jYs
 wld
+jYs
+aAy
+iJY
+jYs
+jDN
+ppF
 wld
 maR
 iMQ
@@ -136663,26 +136814,26 @@ qeB
 dGF
 pBW
 fbA
-cGy
+oGL
 bmi
 usf
 pxf
-ksX
-mPT
-mPT
-mPT
-qGf
+dGF
+dGF
+fPn
+nPC
+fsJ
+fsJ
 mSW
 wld
 wld
 wld
 jYs
-aAy
-iJY
 jYs
-jDN
-ppF
-wld
+jYs
+jYs
+jYs
+vEs
 wld
 maR
 iMQ
@@ -137014,27 +137165,27 @@ gts
 mSW
 mPT
 cGy
-mPT
-cGy
-fPn
+gcU
+vnC
 oZe
 mPT
 sRO
 mPT
-mPT
-mPT
+fjR
+mSW
+ksX
 coc
+nzQ
 mSW
 wld
 wld
 wld
 jYs
+aAy
+iJY
 jYs
-jYs
-jYs
-jYs
-vEs
-wld
+gWk
+wnO
 wld
 maR
 iMQ
@@ -137368,24 +137519,24 @@ mPT
 cGy
 mPT
 cGy
-mPT
 suf
 vkI
 pPh
-cCb
 hce
 hOW
-hOW
+mSW
+shg
+shg
+dtd
 mSW
 wld
 wld
 wld
-jYs
-aAy
-iJY
-jYs
-gWk
-wnO
+wld
+wld
+wld
+wld
+wld
 wld
 wld
 maR
@@ -137725,11 +137876,11 @@ mPT
 mPT
 mPT
 mPT
-mPT
-mPT
-mPT
 mSW
-wld
+cCb
+mSW
+mSW
+mSW
 wld
 wld
 wld
@@ -138073,15 +138224,15 @@ rBS
 kUj
 kUj
 kUj
-mPT
-mPT
+qGf
+iXr
 mPT
 dCc
-mPT
-mPT
+mSW
+cId
 jPq
 mSW
-wld
+mSW
 wld
 wld
 wld
@@ -138101,7 +138252,7 @@ oEI
 hhB
 sKT
 qBo
-dEP
+wAM
 tew
 dvq
 rdz
@@ -140149,9 +140300,9 @@ cLz
 iLp
 iLp
 sUd
-fUB
+ikG
 gaG
-wAM
+ujJ
 iRG
 qCI
 rNK
@@ -141206,7 +141357,7 @@ xIb
 mfN
 sUd
 dwx
-trD
+dxE
 tfl
 gRa
 kNI

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -1256,6 +1256,11 @@
 /obj/item/clothing/gloves/latex,
 /turf/simulated/floor,
 /area/research_outpost/entry)
+"axA" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet5-1"
+	},
+/area/science/hallway)
 "axD" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -6742,6 +6747,9 @@
 /obj/machinery/light_switch{
 	pixel_x = 28
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/research_outpost/hallway)
 "cBk" = (
@@ -11820,6 +11828,15 @@
 	icon_state = "white"
 	},
 /area/medical/medbay)
+"ewA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/break_room)
 "ewI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/disposal/compactor,
@@ -17072,6 +17089,9 @@
 	pixel_y = -1;
 	pixel_x = 30
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/mine/production)
 "gDT" = (
@@ -18189,11 +18209,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/engineering/engine)
-"haV" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet5-1"
-	},
-/area/science/hallway)
 "hbh" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -29008,6 +29023,11 @@
 	icon_state = "white"
 	},
 /area/science/xenobiology)
+"ltL" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/science/hallway)
 "ltQ" = (
 /obj/structure/displaycase/lamarr,
 /turf/simulated/floor{
@@ -33312,6 +33332,7 @@
 	name = "Production Room";
 	network = list("MINE")
 	},
+/obj/machinery/light/small,
 /turf/simulated/floor,
 /area/mine/production)
 "mZt" = (
@@ -36810,15 +36831,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor,
 /area/supply/office)
-"oxF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/engineering/break_room)
 "oxJ" = (
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -40663,6 +40675,10 @@
 	dir = 4;
 	id_tag = "mining_mint"
 	},
+/obj/machinery/light/small{
+	dir = 1;
+	invisibility = 1
+	},
 /turf/simulated/floor,
 /area/mine/production)
 "qar" = (
@@ -42188,6 +42204,10 @@
 	name = "EVA";
 	network = list("MINE")
 	},
+/obj/machinery/light/small{
+	dir = 8;
+	flickering = 1
+	},
 /turf/simulated/floor,
 /area/mine/eva)
 "qEF" = (
@@ -42309,6 +42329,9 @@
 "qGO" = (
 /obj/machinery/mineral/processing_unit{
 	id_tag = "mining_smelter"
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/mine/production)
@@ -44734,6 +44757,9 @@
 "rCl" = (
 /obj/machinery/light_switch{
 	pixel_x = 28
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/mine/eva)
@@ -48644,11 +48670,6 @@
 	icon_state = "dark"
 	},
 /area/turret_protected/ai)
-"thg" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
-	},
-/area/science/hallway)
 "thl" = (
 /obj/structure/window/reinforced{
 	one_way = 1
@@ -49482,6 +49503,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light_switch{
 	pixel_x = -27
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/mine/production)
@@ -50558,6 +50582,9 @@
 /obj/machinery/mineral/stacking_machine{
 	id_tag = "mining_stacker"
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/mine/production)
 "tQW" = (
@@ -50907,9 +50934,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/atmos)
@@ -51060,7 +51086,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/space,
+/turf/simulated/floor,
 /area/mine/maintenance)
 "uei" = (
 /obj/structure/grille,
@@ -58090,6 +58116,9 @@
 	dir = 4;
 	name = "Storage Room";
 	network = list("MINE")
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/mine/production)
@@ -138075,7 +138104,7 @@ oEI
 hhB
 sKT
 qBo
-oxF
+ewA
 tew
 dvq
 rdz
@@ -140123,9 +140152,9 @@ cLz
 iLp
 iLp
 sUd
-thg
+ltL
 gaG
-haV
+axA
 iRG
 qCI
 rNK

--- a/maps/junglestation.dmm
+++ b/maps/junglestation.dmm
@@ -1074,7 +1074,7 @@
 /area/security/prison)
 "aux" = (
 /obj/structure/table/woodentable,
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/wood,
 /area/surface/jungle/underground/zoned/speakeasy)
 "avb" = (
 /obj/machinery/door_control{
@@ -2755,7 +2755,9 @@
 	pixel_y = 6;
 	pixel_x = 7
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
 /area/surface/jungle/underground/zoned/ghettosurgery)
 "bbX" = (
 /obj/effect/glowshroom/single,
@@ -2920,7 +2922,7 @@
 /area/teleporter)
 "bfb" = (
 /obj/item/weapon/stool/bar,
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/wood,
 /area/surface/jungle/underground/zoned/speakeasy)
 "bfq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3001,7 +3003,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/casino)
 "bgZ" = (
 /obj/machinery/light/small{
@@ -3362,7 +3364,9 @@
 /area/security/main)
 "boo" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
 /area/medical/sleeper)
 "boD" = (
 /obj/structure/table,
@@ -4000,7 +4004,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
 /area/surface/jungle/underground/zoned/ghettosurgery)
 "bBf" = (
 /obj/structure/cable/orange{
@@ -4421,7 +4427,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/ghettomining)
 "bKM" = (
 /obj/structure/table/woodentable,
@@ -5907,7 +5913,7 @@
 	pixel_x = 13;
 	pixel_y = 6
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/ghettomining)
 "cmC" = (
 /obj/item/weapon/gun/portalgun,
@@ -7077,7 +7083,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/wood,
 /area/surface/jungle/underground/zoned/speakeasy)
 "cIf" = (
 /obj/structure/bed,
@@ -8379,7 +8385,9 @@
 	pixel_y = -1;
 	pixel_x = 27
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
 /area/medical/sleeper)
 "dgV" = (
 /obj/machinery/conveyor{
@@ -8479,7 +8487,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/wood,
 /area/surface/jungle/underground/zoned/speakeasy)
 "did" = (
 /turf/simulated/floor{
@@ -8646,10 +8654,10 @@
 /turf/space,
 /area/centcom/specops)
 "dnj" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/camera{
+	dir = 8
 	},
-/turf/unsimulated/floor/jungle/grass,
+/turf/unsimulated/floor/jungle/grass/no_flora,
 /area/surface/jungle/fenced)
 "dnI" = (
 /obj/structure/cable/yellow{
@@ -9507,16 +9515,12 @@
 	},
 /area/security/brig)
 "dEn" = (
-/obj/machinery/door/airlock/glass_atmos{
-	name = "Atmospherics"
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
 	},
-/obj/structure/cable/orange{
-	icon_state = "4-8";
-	d1 = 4;
-	d2 = 8
-	},
-/turf/simulated/floor,
-/area/engineering/atmos)
+/obj/structure/grille/window_spawner/reinforced/full,
+/turf/simulated,
+/area/engineering/engine)
 "dEu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10659,7 +10663,9 @@
 /obj/machinery/door/mineral/wood{
 	name = "Quack Doctor "
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
 /area/surface/jungle/underground/zoned/ghettosurgery)
 "ebT" = (
 /obj/structure/cable/yellow{
@@ -10684,7 +10690,9 @@
 	dir = 4
 	},
 /obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
 /area/surface/jungle/underground/zoned/ghettosurgery)
 "ecv" = (
 /obj/structure/table,
@@ -11090,7 +11098,7 @@
 /obj/machinery/conveyor{
 	id_tag = "ghetto_ore_proc_conv"
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/ghettomining)
 "ejx" = (
 /obj/effect/landmark/corpse/russian/ranged,
@@ -11547,7 +11555,7 @@
 "erp" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/wood,
 /area/surface/jungle/underground/zoned/speakeasy)
 "ers" = (
 /obj/structure/bed/chair{
@@ -12449,7 +12457,7 @@
 	},
 /obj/structure/cable/yellow,
 /obj/structure/grille/window_spawner/reinforced/full,
-/turf/simulated/floor,
+/turf/simulated,
 /area/security/lobby)
 "eNw" = (
 /obj/machinery/light,
@@ -12602,17 +12610,13 @@
 	name = "Supermatter Room";
 	req_one_access_txt = "10;24"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
-	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_y = 32
+/obj/structure/cable/orange{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
 /turf/simulated/floor,
-/area/engineering/supermatter_room)
+/area/engineering/engine)
 "eOV" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "right";
@@ -12901,7 +12905,8 @@
 /obj/item/stack/sheet/mineral/uranium{
 	amount = 20
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/obj/item/tool/wrench,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/casino)
 "eXd" = (
 /turf/simulated/floor/carpet{
@@ -13377,7 +13382,7 @@
 /obj/item/weapon/reagent_containers/food/drinks/plastic/water{
 	pixel_x = -8
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/ghettomining)
 "fhT" = (
 /obj/machinery/hologram/holopad,
@@ -15151,7 +15156,9 @@
 /area/supply/storage)
 "fSx" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
 /area/medical/sleeper)
 "fSA" = (
 /obj/structure/table/woodentable,
@@ -17123,11 +17130,22 @@
 /turf/simulated/floor/shuttle/plating,
 /area/shuttle/mining/station)
 "gFu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/door/airlock/highsecurity{
+	aiControlDisabled = 1;
+	name = "Telecommunications Access";
+	req_access_txt = "61";
+	req_one_access_txt = ""
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
-/area/engineering/engine)
+/turf/simulated/floor,
+/area/turret_protected/tcomms_control_room)
 "gFE" = (
 /obj/structure/table,
 /turf/unsimulated/floor{
@@ -19825,7 +19843,7 @@
 	dir = 8;
 	flickering = 1
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/ghettomining)
 "hKV" = (
 /obj/structure/table/woodentable,
@@ -19893,7 +19911,7 @@
 	})
 "hLS" = (
 /obj/structure/reagent_dispensers/beerkeg,
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/wood,
 /area/surface/jungle/underground/zoned/speakeasy)
 "hMp" = (
 /turf/simulated/floor{
@@ -20160,7 +20178,9 @@
 	pixel_x = -24;
 	pixel_y = -4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
 /area/medical/sleeper)
 "hRA" = (
 /obj/structure/cable/yellow{
@@ -20185,7 +20205,9 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/hidden/blue{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
 /area/medical/sleeper)
 "hRV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20244,7 +20266,7 @@
 /obj/machinery/mineral/processing_unit{
 	id_tag = "ghetto_ore_oreprocessor"
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/ghettomining)
 "hTr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20325,7 +20347,9 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/hidden/blue{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
 /area/medical/sleeper)
 "hUH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -20364,7 +20388,7 @@
 	dir = 1;
 	invisibility = 1
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/ghettomining)
 "hVN" = (
 /obj/machinery/atmospherics/unary/heat_exchanger{
@@ -20852,22 +20876,19 @@
 /turf/simulated,
 /area/mine/explored)
 "ifI" = (
-/obj/machinery/door/airlock/highsecurity{
-	aiControlDisabled = 1;
-	name = "Telecommunications Access";
-	req_access_txt = "61";
-	req_one_access_txt = ""
+/obj/machinery/camera{
+	dir = 1
 	},
-/obj/structure/cable/orange{
-	icon_state = "4-8";
-	d1 = 4;
-	d2 = 8
+/obj/structure/sign/directions/security{
+	dir = 8;
+	pixel_y = -23
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/sign/directions/trader{
+	dir = 8;
+	pixel_y = -31
 	},
-/turf/simulated/floor,
-/area/engineering/engine)
+/turf/unsimulated/floor/jungle/grass,
+/area/surface/jungle/fenced)
 "ifY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -21311,11 +21332,12 @@
 	},
 /area/centcom/holding)
 "iqz" = (
-/obj/structure/sign/directions/engineering{
-	pixel_y = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/simulated/wall,
-/area/engineering/break_room)
+/turf/unsimulated/floor/jungle/path_plated,
+/area/surface/jungle/fenced)
 "iqC" = (
 /obj/structure/deathsquad_tele,
 /obj/structure/catwalk,
@@ -21989,7 +22011,9 @@
 	},
 /obj/item/tool/wirecutters,
 /obj/item/stack/rods,
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
 /area/surface/jungle/underground/zoned/ghettosurgery)
 "iFP" = (
 /obj/machinery/disease2/diseaseanalyser,
@@ -22316,7 +22340,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/ghettomining)
 "iOJ" = (
 /obj/machinery/camera{
@@ -22501,7 +22525,7 @@
 /area/centcom/ert)
 "iQO" = (
 /obj/machinery/media/jukebox/bar,
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/wood,
 /area/surface/jungle/underground/zoned/speakeasy)
 "iQR" = (
 /obj/machinery/light/small{
@@ -22624,7 +22648,7 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/ghettomining)
 "iSZ" = (
 /turf/simulated/floor/shuttle,
@@ -22999,7 +23023,12 @@
 /obj/item/stack/sheet/mineral/uranium{
 	amount = 5
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
 /area/surface/jungle/underground/zoned/ghettosurgery)
 "iZo" = (
 /obj/structure/cable/yellow{
@@ -23073,7 +23102,10 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/casino)
 "jau" = (
 /turf/space,
@@ -23853,7 +23885,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/ghettomining)
 "jqL" = (
 /obj/structure/bed,
@@ -24567,7 +24599,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
 /area/surface/jungle/underground/zoned/ghettosurgery)
 "jEO" = (
 /obj/structure/closet/secure_closet/scientist,
@@ -24622,7 +24656,9 @@
 /turf/space,
 /area/shuttle/specops/centcom)
 "jGF" = (
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
 /area/surface/jungle/underground/zoned/ghettosurgery)
 "jGU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -24671,7 +24707,9 @@
 /area/turret_protected/ai)
 "jHx" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
 /area/surface/jungle/underground/zoned/ghettosurgery)
 "jHC" = (
 /obj/machinery/camera{
@@ -25568,7 +25606,7 @@
 	id_tag = "ghetto_ore_proc_conv";
 	dir = 4
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/ghettomining)
 "jZl" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -26042,12 +26080,8 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/gardens)
 "kkg" = (
-/obj/structure/grille/window_spawner/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/simulated,
-/area/engineering/supermatter_room)
+/turf/simulated/wall/r_wall,
+/area/surface/jungle/zoned/reactor_outside)
 "kkk" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -26091,16 +26125,17 @@
 	},
 /area/supply/qm)
 "kkC" = (
-/obj/structure/sign/directions/security{
-	dir = 8;
+/obj/machinery/light/small,
+/obj/structure/sign/directions/medical{
+	pixel_y = -32;
+	dir = 8
+	},
+/obj/structure/sign/directions/evac{
+	dir = 1;
+	pixel_y = -41
+	},
+/obj/structure/sign/directions/engineering{
 	pixel_y = -23
-	},
-/obj/structure/sign/directions/trader{
-	dir = 8;
-	pixel_y = -31
-	},
-/obj/machinery/camera{
-	dir = 1
 	},
 /turf/unsimulated/floor/jungle/grass,
 /area/surface/jungle/fenced)
@@ -26137,16 +26172,21 @@
 /turf/simulated/floor/bluegrid,
 /area/tdome)
 "klr" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Supermatter Room";
+	req_one_access_txt = "10;24"
 	},
-/obj/machinery/light_switch{
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/disposal/compactor,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_y = 32
+	},
 /turf/simulated/floor,
-/area/engineering/break_room)
+/area/engineering/engine)
 "klz" = (
 /obj/structure/grille/window_spawner/reinforced,
 /obj/structure/cable/yellow{
@@ -26174,7 +26214,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/wood,
 /area/surface/jungle/underground/zoned/speakeasy)
 "kmm" = (
 /turf/simulated/floor,
@@ -29054,16 +29094,15 @@
 	},
 /area/centcom/test)
 "lvt" = (
-/obj/structure/sign/directions/science{
-	pixel_y = -21;
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/simulated/floor{
+	icon_state = "yellow";
 	dir = 1
 	},
-/obj/structure/sign/directions/carg{
-	dir = 1;
-	pixel_y = -30
-	},
-/turf/unsimulated/floor/jungle/grass,
-/area/surface/jungle/fenced)
+/area/engineering/break_room)
 "lvW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window{
@@ -29832,7 +29871,7 @@
 	pixel_y = 7;
 	pixel_x = 8
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/wood,
 /area/surface/jungle/underground/zoned/speakeasy)
 "lJr" = (
 /obj/machinery/ignition_switch{
@@ -31886,7 +31925,9 @@
 /obj/item/weapon/kitchen/utensil/fork,
 /obj/item/tool/crowbar,
 /obj/item/weapon/lighter,
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
 /area/surface/jungle/underground/zoned/ghettosurgery)
 "mwn" = (
 /turf/simulated/floor{
@@ -32821,17 +32862,16 @@
 	},
 /area/security/lobby)
 "mRH" = (
-/obj/machinery/light/small,
-/obj/structure/sign/directions/medical{
-	pixel_y = -32;
-	dir = 8
+/obj/machinery/door/airlock/glass_atmos{
+	name = "Atmospherics"
 	},
-/obj/structure/sign/directions/evac{
-	dir = 1;
-	pixel_y = -41
+/obj/structure/cable/orange{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
-/turf/unsimulated/floor/jungle/grass,
-/area/surface/jungle/fenced)
+/turf/simulated/floor,
+/area/engineering/engine)
 "mRJ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -32869,7 +32909,7 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "mSe" = (
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/ghettomining)
 "mSh" = (
 /obj/structure/bed/chair/office/dark{
@@ -33002,7 +33042,9 @@
 /obj/effect/landmark/start{
 	name = "Medical Doctor"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
 /area/medical/sleeper)
 "mVb" = (
 /obj/structure/table,
@@ -33028,7 +33070,7 @@
 	freq = 1400;
 	location = "Bazaar"
 	},
-/turf/unsimulated/floor/jungle/path,
+/turf/unsimulated/floor/jungle/path_plated,
 /area/surface/jungle/zoned/tradearea)
 "mVO" = (
 /obj/structure/table,
@@ -33392,10 +33434,11 @@
 /area/centcom/ert)
 "nbR" = (
 /obj/structure/grille/window_spawner/reinforced,
-/turf/simulated/floor{
-	icon_state = "white"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/area/medical/virology)
+/turf/simulated,
+/area/engineering/engine)
 "nbS" = (
 /obj/machinery/teleport/station,
 /turf/unsimulated/floor{
@@ -33952,22 +33995,16 @@
 /turf/unsimulated/floor/jungle/concrete,
 /area/surface/jungle)
 "nql" = (
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Engineering";
-	req_one_access_txt = "11;24"
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Engineering Lobby"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/turf/simulated/floor{
+	icon_state = "yellow";
 	dir = 1
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "Engineering";
-	name = "Engineering Security Doors";
-	opacity = 0
-	},
-/turf/simulated/floor,
-/area/surface/jungle)
+/area/engineering/break_room)
 "nqp" = (
 /mob/living/carbon/monkey,
 /turf/simulated/floor{
@@ -34227,7 +34264,7 @@
 /area/mine/explored)
 "nwq" = (
 /obj/machinery/light/small,
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/wood,
 /area/surface/jungle/underground/zoned/speakeasy)
 "nwA" = (
 /mob/living/simple_animal/hostile/bear/brownbear{
@@ -34380,7 +34417,7 @@
 	dir = 1;
 	pixel_y = -41
 	},
-/turf/unsimulated/floor/jungle/grass,
+/turf/unsimulated/floor/jungle/grass/no_flora,
 /area/surface/jungle/fenced)
 "nBR" = (
 /obj/machinery/light/small{
@@ -34414,9 +34451,23 @@
 /turf/simulated/floor/vox,
 /area/vox_trading_post/docking)
 "nCS" = (
-/obj/structure/grille/window_spawner/reinforced/full,
-/turf/simulated,
-/area/engineering/atmos)
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Engineering";
+	req_one_access_txt = "11;24"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "Engineering";
+	name = "Engineering Security Doors";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/engineering/engine)
 "nCT" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes{
@@ -35326,7 +35377,9 @@
 /obj/item/weapon/hatchet,
 /obj/item/weapon/kitchen/utensil/knife/large,
 /obj/item/tool/screwdriver,
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
 /area/surface/jungle/underground/zoned/ghettosurgery)
 "nUt" = (
 /obj/machinery/computer/arcade,
@@ -36299,7 +36352,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/ghettomining)
 "omL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -36747,7 +36800,7 @@
 	name = "Security Lobby";
 	normalspeed = 0
 	},
-/turf/simulated,
+/turf/simulated/floor,
 /area/security/lobby)
 "oxC" = (
 /obj/effect/landmark/start{
@@ -37147,17 +37200,14 @@
 	},
 /area/crew_quarters/kitchen)
 "oEI" = (
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Supermatter Room";
-	req_one_access_txt = "10;24"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
 	},
-/obj/structure/cable/orange{
-	icon_state = "4-8";
-	d1 = 4;
-	d2 = 8
+/turf/simulated/floor{
+	icon_state = "yellow";
+	dir = 1
 	},
-/turf/simulated/floor,
-/area/engineering/supermatter_room)
+/area/engineering/break_room)
 "oEW" = (
 /obj/structure/rack{
 	dir = 8
@@ -37271,12 +37321,9 @@
 /turf/simulated/wall/mineral/wood,
 /area/surface/jungle)
 "oHy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
 /obj/structure/grille/window_spawner/reinforced/full,
 /turf/simulated,
-/area/engineering/atmos)
+/area/engineering/engine)
 "oHF" = (
 /obj/machinery/atmospherics/miner/nitrogen,
 /turf/simulated/floor/engine{
@@ -37350,7 +37397,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
 /area/surface/jungle/underground/zoned/ghettosurgery)
 "oJt" = (
 /turf/unsimulated/floor{
@@ -37655,7 +37704,7 @@
 	pixel_x = -3;
 	pixel_y = 6
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/wood,
 /area/surface/jungle/underground/zoned/speakeasy)
 "oQJ" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -38483,7 +38532,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/casino)
 "phK" = (
 /obj/effect/decal/warning_stripes{
@@ -39605,7 +39654,7 @@
 	},
 /obj/structure/grille/window_spawner/reinforced/full,
 /turf/simulated/floor,
-/area/engineering/atmos)
+/area/engineering/engine)
 "pGv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -39738,20 +39787,14 @@
 "pJT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/glass_security{
-	name = "Security Checkpoint";
-	req_access_txt = "1"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Checkpoint";
+	req_access_txt = "1"
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -40422,7 +40465,7 @@
 /obj/machinery/door/mineral/wood{
 	name = "Refinery"
 	},
-/turf/simulated/wall/mineral/wood,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/casino)
 "pXe" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -42384,7 +42427,7 @@
 "qKn" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/treadmill,
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/ghettomining)
 "qKS" = (
 /obj/structure/table/woodentable,
@@ -42798,14 +42841,10 @@
 /turf/simulated/floor,
 /area/security/armory)
 "qTP" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
+/turf/simulated/floor{
+	icon_state = "yellow";
+	dir = 1
 	},
-/obj/machinery/camera{
-	dir = 4
-	},
-/turf/simulated/floor,
 /area/engineering/break_room)
 "qTV" = (
 /obj/structure/table/reinforced,
@@ -43437,12 +43476,6 @@
 	},
 /area/engineering/atmos)
 "rhl" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/vending/security,
 /turf/simulated/floor{
 	dir = 9;
@@ -43648,9 +43681,6 @@
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
@@ -43661,6 +43691,11 @@
 	pixel_y = 7
 	},
 /obj/item/weapon/pen,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "red"
@@ -44008,7 +44043,9 @@
 /area/shuttle/striketeam/centcom)
 "rrt" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
 /area/surface/jungle/underground/zoned/ghettosurgery)
 "rrK" = (
 /obj/structure/shuttle/engine/propulsion,
@@ -44229,12 +44266,11 @@
 /turf/simulated/floor/plating/vox,
 /area/vox_trading_post/atmos)
 "rvH" = (
-/obj/structure/fence{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/fence,
-/turf/unsimulated/floor/jungle/path_plated,
-/area/surface/jungle/zoned/atmos_outside)
+/turf/simulated/wall/r_wall,
+/area/turret_protected/tcomms_control_room)
 "rvI" = (
 /obj/machinery/door/poddoor{
 	id_tag = "CentComPort";
@@ -44552,7 +44588,9 @@
 "rzZ" = (
 /obj/machinery/optable,
 /obj/machinery/light/small,
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor{
+	icon_state = "hydrofloor"
+	},
 /area/surface/jungle/underground/zoned/ghettosurgery)
 "rAp" = (
 /obj/machinery/power/apc{
@@ -45470,7 +45508,7 @@
 /area/security/lobby)
 "rTU" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/space,
+/turf/unsimulated/floor/jungle/concrete,
 /area/shuttle/mining/station)
 "rTV" = (
 /obj/machinery/r_n_d/server/core,
@@ -45898,8 +45936,8 @@
 	dir = 4;
 	pixel_x = 10
 	},
-/obj/machinery/shower{
-	dir = 4
+/obj/structure/mirror{
+	pixel_x = 24
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
@@ -47731,7 +47769,7 @@
 	id_tag = "ghetto_ore_proc_conv";
 	dir = 8
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/ghettomining)
 "sRj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47856,7 +47894,7 @@
 /area/supply/office)
 "sTr" = (
 /obj/machinery/vending/boozeomat,
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/wood,
 /area/surface/jungle/underground/zoned/speakeasy)
 "sTs" = (
 /obj/effect/decal{
@@ -48438,10 +48476,9 @@
 	name = "Engineering";
 	req_one_access_txt = "11;24"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -48450,7 +48487,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor,
-/area/surface/jungle)
+/area/engineering/engine)
 "teC" = (
 /obj/machinery/vending/discount,
 /turf/unsimulated/floor/jungle/path_plated,
@@ -49069,6 +49106,11 @@
 /obj/machinery/door/airlock/glass_security{
 	name = "Prison Wing";
 	req_access_txt = "2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/security/prison)
@@ -50274,7 +50316,10 @@
 	dir = 1;
 	invisibility = 1
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/obj/effect/decal/warning_stripes{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/wood,
 /area/surface/jungle/underground/zoned/speakeasy)
 "tMB" = (
 /obj/structure/morgue,
@@ -50717,7 +50762,7 @@
 	},
 /area/centcom/test)
 "tWM" = (
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/wood,
 /area/surface/jungle/underground/zoned/speakeasy)
 "tWQ" = (
 /obj/structure/grille/window_spawner/reinforced,
@@ -51668,7 +51713,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
 /area/medical/sleeper)
 "urA" = (
 /obj/machinery/ai_slipper{
@@ -54059,7 +54106,7 @@
 /turf/simulated,
 /area/security/lobby)
 "vnP" = (
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/casino)
 "vnY" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -55496,11 +55543,18 @@
 	},
 /area/centcom/specops)
 "vNu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/camera{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
-/area/storage/tech)
+/turf/simulated/floor{
+	icon_state = "yellow";
+	dir = 1
+	},
+/area/engineering/break_room)
 "vNA" = (
 /obj/structure/grille/window_spawner/reinforced,
 /turf/simulated,
@@ -56396,12 +56450,18 @@
 /turf/simulated/floor,
 /area/supply/miningdock)
 "wgH" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=2";
-	freq = 1400;
-	location = "Engineering Lobby"
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
 	},
-/turf/simulated/floor,
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/obj/machinery/disposal/compactor,
+/turf/simulated/floor{
+	icon_state = "yellow";
+	dir = 1
+	},
 /area/engineering/break_room)
 "wgM" = (
 /obj/machinery/light{
@@ -57335,10 +57395,6 @@
 	},
 /turf/simulated/wall/shuttle/unsmoothed/black,
 /area/syndicate_mothership/elite_squad)
-"wAM" = (
-/turf/space,
-/turf/unsimulated/floor/jungle/grass,
-/area/surface/jungle)
 "wBh" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/engine)
@@ -57384,7 +57440,7 @@
 	id_tag = "ghetto_ore_oreprocessor";
 	req_access = null
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/ghettomining)
 "wCd" = (
 /obj/machinery/light{
@@ -57536,7 +57592,7 @@
 	dir = 1;
 	pixel_y = 25
 	},
-/turf/unsimulated/floor/jungle/grass,
+/turf/unsimulated/floor/jungle/grass/no_flora,
 /area/surface/jungle/fenced)
 "wEY" = (
 /obj/structure/grille,
@@ -58470,7 +58526,7 @@
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8
 	},
-/turf/space,
+/turf/unsimulated/floor/jungle/concrete,
 /area/shuttle/research/station)
 "wWG" = (
 /obj/structure/rack,
@@ -59711,7 +59767,9 @@
 	pixel_x = 6;
 	pixel_y = 3
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
 /area/medical/sleeper)
 "xwK" = (
 /obj/structure/grille,
@@ -59760,7 +59818,7 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/turf/unsimulated/floor/jungle/bedrock,
+/turf/simulated/floor/plating,
 /area/surface/jungle/underground/zoned/casino)
 "xxe" = (
 /obj/structure/grille/window_spawner/reinforced/full,
@@ -101364,9 +101422,9 @@ lWz
 lWz
 uXj
 opc
-uXL
-uXL
-uXL
+xor
+xor
+xor
 cCa
 vtq
 uwH
@@ -108743,19 +108801,19 @@ xor
 xor
 xor
 xor
-wld
-wld
-wld
+nre
+nre
+nre
 xor
 xor
 xor
 xor
 xor
-wld
-wld
-wld
-wld
-wld
+nre
+nre
+nre
+nre
+nre
 maR
 iMQ
 qSc
@@ -114375,19 +114433,19 @@ wld
 xor
 xor
 xor
-wld
-wld
-wld
+nre
+nre
+nre
 xor
 xor
 xor
-wld
-wld
-wld
-wld
-wld
-wld
-wld
+nre
+nre
+nre
+nre
+nre
+nre
+nre
 maR
 iMQ
 xMH
@@ -117899,8 +117957,8 @@ xor
 xor
 wld
 wld
-wld
-ndk
+nre
+oqo
 rWK
 rWK
 rWK
@@ -125696,7 +125754,7 @@ rlM
 qmw
 dFr
 dFr
-nbR
+dKH
 dKH
 aeN
 aeN
@@ -129872,7 +129930,7 @@ wld
 wld
 wld
 wld
-xor
+wld
 xMH
 psY
 vhv
@@ -130223,8 +130281,8 @@ wld
 wld
 wld
 wld
-xor
-xor
+wld
+wld
 xMH
 sCf
 tsV
@@ -130576,7 +130634,7 @@ wld
 wld
 xor
 xor
-wld
+xor
 aWo
 rOD
 rOD
@@ -130636,7 +130694,7 @@ mUo
 snf
 iRw
 lIK
-wAM
+lIK
 lIK
 lIK
 lIK
@@ -130935,8 +130993,8 @@ vhZ
 hzP
 hzP
 mOx
-wld
-wld
+nre
+nre
 xMH
 psY
 maR
@@ -130984,11 +131042,11 @@ wld
 wld
 wld
 wld
-mUo
+lFu
 snf
 iRw
 lIK
-wAM
+lIK
 lIK
 lIK
 lIK
@@ -131279,7 +131337,7 @@ wld
 wld
 wld
 xor
-jaT
+dnj
 lyS
 bzK
 xor
@@ -131287,8 +131345,8 @@ hzP
 hzP
 hzP
 pdc
-jaT
-wld
+dnj
+nre
 xMH
 psY
 maR
@@ -131321,22 +131379,22 @@ wld
 wld
 wld
 wld
+iXV
+iXV
+iXV
+iXV
+iXV
+iXV
+iXV
+iXV
+iXV
+iXV
 wld
 wld
 wld
 wld
 wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-lFu
+mUo
 snf
 iRw
 lIK
@@ -131663,25 +131721,25 @@ nTf
 maR
 iMQ
 xMH
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
+slM
+slM
+slM
+slM
+maD
+maD
+maD
+maD
+maD
+maD
 iXV
-iXV
-iXV
-iXV
-iXV
-iXV
-iXV
-iXV
-iXV
+glH
+xTm
+uYK
+mhi
+frH
+ukn
+uHE
+ugz
 iXV
 wld
 wld
@@ -131992,7 +132050,7 @@ iDO
 rFo
 xHR
 tCm
-wld
+nre
 xMH
 psY
 maR
@@ -132016,24 +132074,24 @@ maR
 iMQ
 bYw
 slM
-slM
-slM
-slM
+viQ
+fyu
+fId
 maD
-maD
-maD
-maD
-maD
-maD
-iXV
-glH
-xTm
-uYK
-mhi
-frH
-ukn
-uHE
-ugz
+kRa
+vQH
+hah
+sFV
+nGW
+haJ
+aEz
+ttK
+ttK
+ttK
+ttK
+ttK
+ttK
+ttK
 iXV
 wld
 wld
@@ -132344,7 +132402,7 @@ yji
 nMo
 mOa
 tCm
-wld
+nre
 xMH
 psY
 maR
@@ -132368,34 +132426,34 @@ maR
 iMQ
 xMH
 slM
-viQ
-fyu
-fId
-maD
-kRa
-vQH
-hah
-sFV
-nGW
-haJ
-aEz
-ttK
-ttK
-ttK
-ttK
-ttK
-ttK
-ttK
+sNg
+unD
+ouk
+fhK
+nmx
+bjF
+pjH
+osQ
+osQ
+spA
+xrD
+iaq
+gPP
+vfL
+vfL
+vfL
+kuE
+tks
 iXV
-wld
-wld
-wld
-wld
-wld
-mUo
-snf
-iRw
-lIK
+pXV
+pXV
+pEU
+pEU
+pEU
+pXV
+pXV
+pXV
+pXV
 lIK
 lIK
 lIK
@@ -132696,7 +132754,7 @@ tfe
 hVc
 lyg
 tCm
-wld
+nre
 xMH
 psY
 maR
@@ -132720,33 +132778,33 @@ maR
 iMQ
 xMH
 slM
-sNg
-unD
-ouk
-fhK
-nmx
-bjF
-pjH
-osQ
-osQ
-spA
-xrD
-iaq
-gPP
-vfL
-vfL
-vfL
-kuE
-tks
+xGO
+rir
+imt
+pGm
+jdb
+doS
+bzO
+rZf
+gTQ
+rMB
+eAj
+noz
+noz
+ttK
+ttK
+jxh
+cow
+jZs
 iXV
-pXV
-pXV
-pEU
-pEU
-pEU
-pXV
-pXV
-pXV
+eRq
+dwG
+oxY
+gru
+gru
+fMF
+liN
+mcl
 pXV
 lIK
 lIK
@@ -133072,33 +133130,33 @@ xKy
 iMQ
 xMH
 slM
-xGO
+iKv
 rir
-imt
-pGm
-jdb
-doS
-bzO
-rZf
-gTQ
-rMB
-eAj
-noz
-noz
+vqJ
+gyN
+gTN
+bgd
+gNr
+ijp
+wuc
+bbc
+siT
+bWP
 ttK
 ttK
-jxh
+ofF
+woG
 cow
 jZs
 iXV
-eRq
-dwG
-oxY
-gru
-gru
-fMF
-liN
-mcl
+rRA
+wmK
+rPJ
+rPJ
+rPJ
+rPJ
+pDK
+iOo
 pXV
 lIK
 lIK
@@ -133424,33 +133482,33 @@ jUa
 rcM
 xMH
 slM
-iKv
+utx
 rir
-vqJ
-gyN
-gTN
-bgd
-gNr
-ijp
-wuc
-bbc
-siT
-bWP
-ttK
-ttK
-ofF
-woG
-cow
+lZC
+pBZ
+nqU
+rSH
+lLE
+lLE
+pZZ
+daH
+hPh
+cKL
+wsB
+vfL
+vfL
+vfL
+lQe
 jZs
 iXV
-rRA
-wmK
+mVb
 rPJ
 rPJ
 rPJ
 rPJ
-pDK
-iOo
+rPJ
+cQt
+jXe
 pXV
 lIK
 lIK
@@ -133770,39 +133828,39 @@ rOD
 rOD
 rOD
 rOD
-rOD
+iqz
 rOD
 rOD
 rOD
 ulu
 slM
-utx
-rir
-lZC
-pBZ
-nqU
-rSH
-lLE
-lLE
-pZZ
-daH
-hPh
-cKL
-wsB
-vfL
-vfL
-vfL
-lQe
-jZs
+hED
+hjt
+jld
+fcT
+bHJ
+wyj
+kpo
+pXT
+env
+rMB
+vei
+sEI
+fGI
+hNN
+eKg
+gzN
+wZo
+mhT
 iXV
-mVb
 rPJ
 rPJ
 rPJ
 rPJ
 rPJ
+bCl
 cQt
-jXe
+rPJ
 pXV
 lIK
 lIK
@@ -134122,46 +134180,46 @@ wld
 wld
 wld
 wld
-nJu
-dnj
-wld
-wld
-ndk
+yam
+yam
+dlz
+yam
+yam
 slM
-hED
-hjt
-jld
-fcT
-bHJ
-wyj
-kpo
-pXT
-env
-rMB
-vei
-sEI
-fGI
-hNN
-eKg
-gzN
-wZo
-mhT
+slM
+slM
+slM
+maD
+gFu
+rvH
+maD
+maD
+maD
 iXV
-rPJ
-rPJ
-rPJ
-rPJ
-rPJ
-bCl
-cQt
-rPJ
+iXV
+iXV
+iXV
+iXV
+iXV
+iXV
+iXV
+iXV
+iXV
+rWN
+rEX
+rEX
+rEX
+rEX
+rEX
+kTB
+kYu
 pXV
-lIK
-lIK
-lIK
-lIK
-lIK
-lIK
+pXV
+pXV
+pXV
+pXV
+pXV
+pXV
 lIK
 lIK
 lIK
@@ -134475,44 +134533,44 @@ wld
 wld
 wld
 yam
-yam
-dlz
-yam
-yam
-ePx
-wBh
-wBh
-wBh
-wBh
-ifI
-gFu
-cLV
-cLV
-cLV
-cLV
-cLV
-cLV
+bxe
+uGY
+tLN
+bLv
+iYv
+dnd
+sXw
+eNU
+bUT
+rbp
+hpr
+oZU
+doD
+tUY
+qVF
+xZA
+bpo
 gdR
-gdR
-gdR
-gdR
-gdR
-gdR
+oMI
+sjW
+eqT
+sjW
+wXZ
 pXV
-rWN
-rEX
-rEX
-rEX
-rEX
-rEX
-kTB
-kYu
-pXV
-pXV
-pXV
-pXV
-pXV
-pXV
+cAf
+gSN
+gSN
+gSN
+gSN
+gSN
+gmp
+liN
+yeX
+pqz
+gnz
+tgU
+kcB
+kcB
 pXV
 lIK
 lIK
@@ -134827,44 +134885,44 @@ wld
 wld
 wld
 yam
-bxe
-uGY
-tLN
-bLv
-iYv
-dnd
-sXw
-eNU
-bUT
-rbp
-hpr
+alk
+qvG
+aCm
+oyr
+ePx
+sOk
+iwN
+jBA
+xnj
+sNB
+lMc
 oZU
-doD
-tUY
-qVF
-xZA
-bpo
+nMt
+myK
+aAD
+oGR
+sGO
 gdR
-oMI
-sjW
-eqT
-sjW
-wXZ
+uqo
+uxZ
+uxZ
+uxZ
+nPf
 pXV
 cAf
 gSN
-gSN
-gSN
-gSN
-gSN
-gmp
-liN
-yeX
-pqz
-gnz
-tgU
-kcB
-kcB
+qVO
+eRU
+eRU
+cOi
+jNN
+aby
+vIM
+vIM
+ymh
+pZv
+rPJ
+wMj
 pXV
 lIK
 lIK
@@ -135179,44 +135237,44 @@ wld
 wld
 wld
 yam
-alk
+nRj
 qvG
 aCm
-oyr
+kdl
 ePx
-sOk
+dsr
 iwN
-jBA
-xnj
-sNB
-lMc
+bHC
+efp
+csL
+oQJ
 oZU
-nMt
+kjt
 myK
-aAD
-oGR
-sGO
+ejD
+fYw
+gTA
 gdR
-uqo
+uFq
 uxZ
 uxZ
 uxZ
 nPf
 pXV
-cAf
+bFH
 gSN
 qVO
-eRU
+vmj
 eRU
 cOi
-jNN
-aby
-vIM
-vIM
-ymh
-pZv
-rPJ
-wMj
+cPK
+iYU
+ern
+bcO
+sYP
+rEX
+cNH
+vah
 pXV
 lIK
 lIK
@@ -135529,46 +135587,46 @@ xMH
 wld
 wld
 wld
-wld
+ndk
 yam
 nRj
 qvG
 aCm
-kdl
+iai
 ePx
-dsr
+xiL
 iwN
-bHC
-efp
+dhY
+bUT
 csL
-oQJ
+wZm
 oZU
-kjt
-myK
-ejD
-fYw
-gTA
+dvM
+xNX
+aAD
+icJ
+mtn
 gdR
 uFq
 uxZ
 uxZ
 uxZ
-nPf
+qgI
 pXV
-bFH
+aVI
 gSN
 qVO
 vmj
 eRU
 cOi
-cPK
-iYU
-ern
-bcO
-sYP
-rEX
-cNH
-vah
+jNN
+cQt
+rPJ
+cAf
+wxC
+jUg
+gbc
+gfL
 pXV
 lIK
 lIK
@@ -135878,49 +135936,49 @@ wld
 maR
 iMQ
 xMH
-wld
-wld
-wld
-wld
+ifI
+vnA
+vnA
+vnA
 yam
-nRj
-qvG
+kQa
+oRk
 aCm
-iai
+xoz
 ePx
-xiL
-iwN
-dhY
+qyK
+nKD
+bUT
 bUT
 csL
-wZm
+rjt
 oZU
-dvM
-xNX
-aAD
-icJ
-mtn
+mGq
+eSp
+wzx
+gAb
+nLf
 gdR
-uFq
+eZg
+sJJ
 uxZ
 uxZ
-uxZ
-qgI
+nPf
 pXV
-aVI
+cAf
 gSN
 qVO
-vmj
+eRU
 eRU
 cOi
-jNN
-cQt
-rPJ
-cAf
-wxC
-jUg
-gbc
-gfL
+cPK
+iYU
+pei
+giJ
+ixz
+vuh
+gfX
+jSe
 pXV
 lIK
 lIK
@@ -136232,47 +136290,47 @@ iMQ
 xMH
 kkC
 vnA
-vnA
-vnA
-yam
-kQa
-oRk
+vNu
+toB
+nec
+anD
+gZi
 aCm
-xoz
-ePx
-qyK
-nKD
+gZE
+urp
+kfy
+aoI
 bUT
 bUT
-csL
-rjt
-oZU
-mGq
-eSp
-wzx
-gAb
-nLf
+qeT
+hGT
+cLV
+pLw
+bEJ
+xxe
+xxe
+xxe
 gdR
-eZg
-sJJ
-uxZ
-uxZ
-nPf
+bJg
+xGI
+ucv
+xuh
+dam
 pXV
 cAf
 gSN
-qVO
-eRU
-eRU
-cOi
-cPK
-iYU
-pei
-giJ
-ixz
-vuh
-gfX
-jSe
+gSN
+gSN
+gSN
+lFE
+jNN
+cQt
+rPJ
+rPJ
+eXm
+pZv
+vgd
+mYM
 pXV
 lIK
 lIK
@@ -136582,49 +136640,49 @@ wld
 maR
 iMQ
 xMH
-mRH
-iqz
+wld
+vay
 qTP
-toB
-nec
-anD
-gZi
-aCm
-gZE
-urp
-kfy
-aoI
-bUT
-bUT
-qeT
-hGT
-cLV
-pLw
-bEJ
-xxe
-xxe
-xxe
+xkn
+geF
+mWv
+nau
+irr
+qSo
+cAC
+iWr
+yjQ
+yjQ
+yjQ
+pam
+lMM
+wCd
+pam
+iQy
+lRQ
+uQH
+wQI
 gdR
-bJg
-xGI
-ucv
-xuh
-dam
+xnv
+vDV
+wtj
+xcc
+gwJ
 pXV
-cAf
-gSN
-gSN
-gSN
-gSN
-lFE
-jNN
+hER
+kdj
+kdj
+kdj
+uDe
+kdj
+pop
 cQt
 rPJ
 rPJ
-eXm
-pZv
-vgd
-mYM
+cQt
+kIn
+xcN
+jSP
 pXV
 lIK
 lIK
@@ -136936,47 +136994,47 @@ iMQ
 xMH
 wld
 vay
-moC
+qTP
 xkn
-geF
-mWv
-nau
-irr
-qSo
-cAC
-iWr
-yjQ
-yjQ
-yjQ
-pam
-lMM
-wCd
-pam
-iQy
-lRQ
-uQH
-wQI
+rvJ
+frp
+uqw
+fta
+lND
+urp
+kHV
+bUT
+bUT
+bUT
+rDw
+xmg
+gSc
+rDw
+dHt
+bUT
+bUT
+kyF
 gdR
-xnv
-vDV
-wtj
-xcc
-gwJ
+uFO
+tgX
+ljl
+lMI
+gdR
 pXV
-hER
-kdj
-kdj
-kdj
-uDe
-kdj
-pop
-cQt
 rPJ
 rPJ
-cQt
+rPJ
+sva
+hPZ
+hIz
+vIM
+glU
+vIM
+ddu
+bgx
+gDj
 kIn
-xcN
-jSP
+ahR
 pXV
 lIK
 lIK
@@ -137288,47 +137346,47 @@ iMQ
 xMH
 wld
 vay
-moC
-xkn
-rvJ
-frp
-uqw
-fta
-lND
+qTP
+flh
+vHN
+xWu
 urp
-kHV
+ePx
+xiB
+ePx
+nLc
+uxP
 bUT
 bUT
-bUT
-rDw
-xmg
-gSc
-rDw
-dHt
-bUT
-bUT
-kyF
-gdR
-uFO
-tgX
-ljl
-lMI
-gdR
+fqb
+ylX
+xnj
+lbe
+ylX
+xnj
+xnj
+vSo
+txg
+wTA
+irx
+xOl
+cgA
+dbC
 pXV
-rPJ
-rPJ
-rPJ
-sva
-hPZ
-hIz
-vIM
-glU
-vIM
-ddu
-bgx
-gDj
-kIn
-ahR
+ozP
+ozP
+ozP
+vnz
+dtV
+pXV
+ozP
+ozP
+ozP
+ozP
+ozP
+fYD
+xtN
+pXV
 pXV
 lIK
 lIK
@@ -137636,52 +137694,52 @@ wld
 wld
 wld
 maR
-iMQ
-xMH
-wld
-vay
-moC
-flh
-vHN
-xWu
-urp
-ePx
-xiB
-ePx
-nLc
-uxP
+nkZ
+bhN
+eCz
+vZt
+lvt
+bIp
+fTu
+bhn
+fTu
+nCS
+nJg
+pAB
+dWS
 bUT
 bUT
-fqb
-ylX
-xnj
-lbe
-ylX
-xnj
-xnj
-vSo
-txg
-wTA
-irx
-xOl
-cgA
-dbC
-pXV
-ozP
-ozP
-ozP
-vnz
-dtV
-pXV
-ozP
-ozP
-ozP
-ozP
-ozP
-fYD
-xtN
-pXV
-pXV
+bUT
+rDw
+bpj
+epZ
+oKe
+tCU
+feq
+feq
+mSz
+feq
+feq
+grm
+uwL
+kSB
+mAa
+mAm
+kie
+jNv
+vUV
+nJt
+fzq
+wBh
+hFE
+oAq
+jSw
+bvi
+jSw
+dFQ
+dFQ
+mdi
+mdi
 lIK
 lIK
 lIK
@@ -137987,51 +138045,51 @@ wld
 wld
 wld
 wld
-maR
-nkZ
-bhN
-eCz
-vZt
-fTu
-bIp
-fTu
-bhn
-fTu
+vhv
+xOV
+qcB
+qcB
+jkg
+oEI
+hhB
+sKT
+qBo
+sKT
 tew
-nJg
-pAB
-dWS
-bUT
-bUT
-bUT
-rDw
-bpj
-epZ
-oKe
-tCU
-feq
-feq
-mSz
-feq
-feq
-grm
-uwL
-kSB
-mAa
-mAm
-kie
-jNv
-vUV
-nJt
-fzq
-wBh
-hFE
-oAq
-jSw
-bvi
-jSw
-dFQ
-dFQ
+dvq
+rdz
+lwi
+aSe
+nsT
+kQw
+hwk
+yhm
+oQF
+oQF
+oIg
+oQF
+oQF
+qFQ
+oQF
+oQF
+oQF
+wjK
+tkp
+xnj
+xnj
+xnj
+xnj
+xnj
+xnj
+gih
+xLp
+snE
+gaW
+fZC
+eyi
+fZC
+eyi
+snE
 mdi
 mdi
 lIK
@@ -138339,50 +138397,50 @@ wld
 wld
 wld
 wld
-vhv
-xOV
-qcB
-qcB
-jkg
-sKT
-hhB
-sKT
-qBo
-sKT
-nql
-dvq
-rdz
-lwi
-aSe
-nsT
-kQw
-hwk
-yhm
+xor
+iMQ
+wld
+wld
+vay
+qTP
+wSQ
+upN
+uPR
+omk
+omk
+omk
+omk
+nZi
+jSb
+dYv
+sxx
+tCA
+pGK
 oQF
+cjj
+vvS
+oKp
+oKp
+aTz
+gHe
+jey
 oQF
-oIg
-oQF
-oQF
-qFQ
-oQF
-oQF
-oQF
-wjK
-tkp
-xnj
-xnj
-xnj
-xnj
-xnj
-xnj
-gih
+uMe
+lBP
+bUT
+bUT
+joZ
+bUT
+bUT
+bUT
+vUB
 xLp
-snE
-gaW
 fZC
-eyi
-fZC
-eyi
+oAq
+oAq
+oAq
+oAq
+jSw
 snE
 mdi
 mdi
@@ -138696,45 +138754,45 @@ iMQ
 wld
 wld
 vay
+qTP
 moC
-wSQ
 upN
-uPR
+mAg
+iWH
+arN
+uRa
 omk
-omk
-omk
-omk
-nZi
+pMo
 jSb
-dYv
-sxx
-tCA
-pGK
-oQF
-cjj
-vvS
-oKp
+xkr
+tAd
+qNC
+avt
+yft
+ydy
+ant
+eTs
 oKp
 aTz
 gHe
-jey
+nVu
 oQF
-uMe
-lBP
-bUT
-bUT
-joZ
-bUT
-bUT
-bUT
-vUB
+oBE
+bBf
+jbo
+dWK
+wHE
+dWK
+dWK
+jbo
+eBx
 xLp
-fZC
+bvi
 oAq
 oAq
 oAq
 oAq
-jSw
+eyi
 snE
 mdi
 mdi
@@ -139048,45 +139106,45 @@ iMQ
 wld
 wld
 vay
-moC
+nql
 moC
 upN
-mAg
-iWH
-arN
-uRa
+ksH
+vvp
+vik
+cfy
 omk
 pMo
-jSb
-xkr
-tAd
-qNC
-avt
-yft
-ydy
-ant
+bUT
+xmg
+gSc
+rDw
+pGK
+bSk
 eTs
-oKp
-aTz
-gHe
-nVu
+axD
+lgJ
+apH
+mub
+eTs
+eTs
 oQF
-oBE
-bBf
-jbo
-dWK
-wHE
-dWK
-dWK
-jbo
-eBx
-xLp
-bvi
+jrp
+pLq
+gYs
+dtH
+gOM
+qzp
+xoB
+qZe
+jKB
+wBh
+oKw
 oAq
 oAq
 oAq
 oAq
-eyi
+jSw
 snE
 mdi
 mdi
@@ -139399,46 +139457,46 @@ xor
 iMQ
 wld
 wld
-vay
+jgU
 wgH
-moC
-upN
+aSI
+thv
 ksH
-vvp
-vik
-cfy
-omk
-pMo
-bUT
-xmg
-gSc
-rDw
-pGK
-bSk
-eTs
-axD
-lgJ
-apH
-mub
-eTs
-eTs
+vjV
+hZd
+dXU
+dgC
+gnm
+cis
+emR
+cis
+haR
+hDc
 oQF
-jrp
-pLq
-gYs
-dtH
-gOM
-qzp
-xoB
-qZe
-jKB
+oKp
+kAz
+jYw
+czD
+mat
+vLv
+bqx
+oQF
+klr
+eON
 wBh
-oKw
+nbR
+xLp
+nbR
+nbR
+xLp
+nbR
+wBh
+kkg
+kkg
+bvi
 oAq
 oAq
-oAq
-oAq
-jSw
+eyi
 snE
 mdi
 mdi
@@ -139749,48 +139807,48 @@ xor
 wld
 grk
 gNi
-wld
-lvt
+mPV
+uUI
 jgU
-klr
-aSI
-thv
-ksH
-vjV
-hZd
-dXU
-dgC
-gnm
-cis
-emR
-cis
-haR
-hDc
+jgU
+jgU
+omk
+rzX
+pps
+cKg
+ryI
+omk
+tQf
+vKK
+dHt
+rDw
+xpA
+wBh
 oQF
-oKp
-kAz
-jYw
-czD
-mat
-vLv
-bqx
 oQF
-eON
-oEI
+oIg
+oQF
+oQF
+qFQ
+oQF
+oQF
+oQF
+vst
+drO
+iUr
+ttL
+eiG
+ttL
+ttL
+eiG
+ttL
+mIC
+paF
 hkB
-kkg
-wnC
-kkg
-kkg
-wnC
-kkg
-hkB
-hkB
-hkB
-bvi
+fZC
 oAq
 oAq
-eyi
+jSw
 snE
 mdi
 mdi
@@ -140101,48 +140159,48 @@ wld
 wld
 iMQ
 wld
-mPV
+wld
 uUI
-uUI
-uUI
-uUI
-omk
-rzX
-pps
-cKg
-ryI
-omk
-tQf
-vKK
-dHt
+bwZ
+nCT
+tfT
+ihY
+tTD
+wZM
+lUM
+uVo
+bKg
+iBV
+jPT
+pao
 rDw
-xpA
+mNY
 bXX
-bXX
-bXX
-vNu
-bXX
-bXX
+mos
+yfa
+oEW
+xSL
+tUa
 mIf
+ced
+usB
 bXX
-bXX
-bXX
-vst
-drO
-iUr
-ttL
-eiG
-ttL
-ttL
-eiG
-ttL
-mIC
-paF
+qLv
+lfB
+aAv
+kkk
+exJ
+ude
+gCb
+vXd
+mYF
+nPN
+xxa
 hkB
-fZC
+bvi
 oAq
 oAq
-jSw
+eyi
 snE
 mdi
 mdi
@@ -140459,43 +140517,43 @@ bwZ
 nCT
 tfT
 ihY
-tTD
-wZM
-lUM
-uVo
-bKg
-iBV
-jPT
-pao
+wkT
+mSh
+tRL
+xLk
+ihY
+quT
 rDw
-mNY
-bXX
-mos
-yfa
-oEW
-xSL
-tUa
-mIf
+dHt
+tBJ
+avt
+pYj
+ubz
 ced
-usB
+sao
+lkM
+oCp
+bBb
+ced
+vqK
 bXX
-qLv
-lfB
-aAv
-kkk
-exJ
-ude
-gCb
-vXd
-mYF
+fMy
+lKq
 nPN
-xxa
+nPN
+nPN
+nPN
+nPN
+nPN
+nPN
+nPN
+ktK
 hkB
-bvi
+fZC
 oAq
 oAq
+kPq
 eyi
-snE
 mdi
 mdi
 lIK
@@ -140807,29 +140865,29 @@ iMQ
 wld
 wld
 uUI
-bwZ
+uWB
 nCT
 tfT
 ihY
-wkT
-mSh
-tRL
-xLk
+eCj
+bzx
+hZs
+jVS
 ihY
-quT
-rDw
-dHt
-tBJ
-avt
-pYj
-ubz
+oce
+wdq
+ssC
+xxV
+xot
+bXX
+xUc
+nIW
+lKy
+sYa
+dcU
+bXX
 ced
-sao
-lkM
-oCp
-bBb
-ced
-vqK
+avQ
 bXX
 fMy
 lKq
@@ -140841,14 +140899,14 @@ nPN
 nPN
 nPN
 nPN
-ktK
+uQK
 hkB
-fZC
-oAq
-oAq
-kPq
-eyi
-mdi
+hkB
+hkB
+hkB
+hkB
+sqq
+hbi
 mdi
 lIK
 lIK
@@ -141159,49 +141217,49 @@ iMQ
 wld
 wld
 uUI
-uWB
+bwZ
 nCT
 tfT
+omk
+wCf
+kvT
+nnL
 ihY
-eCj
-bzx
-hZs
-jVS
-ihY
-oce
-wdq
-ssC
-xxV
-xot
+omk
+pGo
+mRH
+dEn
+oHy
+oHy
 bXX
-xUc
-nIW
-lKy
-sYa
-dcU
 bXX
-ced
-avQ
 bXX
+bXX
+bXX
+bXX
+bXX
+bXX
+bXX
+bXX
+nAw
+lfB
+arC
+uYj
+uYj
+arC
+uYj
+uYj
+arC
+dxs
+urP
+rqo
 fMy
-lKq
 nPN
-nPN
-nPN
-nPN
-nPN
-nPN
-nPN
-nPN
-uQK
-hkB
-hkB
-hkB
-hkB
+urP
 hkB
 sqq
+sqq
 hbi
-mdi
 lIK
 lIK
 lIK
@@ -141511,49 +141569,49 @@ gNi
 wld
 wld
 uUI
-bwZ
-nCT
-tfT
-omk
-wCf
-kvT
-nnL
-ihY
-omk
-pGo
-dEn
-oHy
-nCS
-nCS
-bXX
-bXX
-bXX
-bXX
-bXX
-bXX
-bXX
-bXX
-bXX
-bXX
-nAw
-lfB
-arC
-uYj
-uYj
-arC
-uYj
-uYj
-arC
-dxs
-urP
-rqo
-fMy
+fus
+fus
+fus
+nRZ
+nOV
+fus
+qPb
+hef
+duJ
+pVg
+jlK
+gYk
+vPA
+pra
+nJa
+auf
+auf
+rvr
+sFD
+igR
+rvr
+sFD
+nir
+sSo
+qNK
+lKq
+vWo
+eor
+eor
+tgi
+brK
+brK
+dkW
+rai
+lsd
+wnC
+nNG
 nPN
 urP
 hkB
-sqq
-sqq
-hbi
+lIK
+lIK
+lIK
 lIK
 lIK
 lIK
@@ -141863,45 +141921,45 @@ wld
 wld
 wld
 uUI
-fus
-fus
-fus
-nRZ
-nOV
-fus
-qPb
-hef
-duJ
-pVg
-jlK
-gYk
-vPA
-pra
-nJa
-auf
-auf
+wvA
+gsG
+gsG
+gsG
+sjB
+gsG
+eZo
+gsG
+yhF
+obd
+jBk
+dFf
+sDs
+gNe
+kBt
+pOh
+hUH
 rvr
-sFD
-igR
-rvr
-sFD
+ubk
 nir
-sSo
-qNK
-lKq
-vWo
-eor
-eor
-tgi
-brK
-brK
-dkW
-rai
-lsd
-wnC
-nNG
-nPN
+rvr
+ubk
+nir
+shJ
+fxe
+iTk
+hjj
+uuB
+gPv
+cEm
+uBP
+uuB
+bUn
+itH
 urP
+wnC
+anw
+nPN
+wPK
 hkB
 lIK
 lIK
@@ -142215,23 +142273,23 @@ wld
 wld
 wld
 uUI
-wvA
+cPE
+cPE
+cPE
+bBv
+jQh
+xNn
+aJs
 gsG
 gsG
 gsG
-sjB
 gsG
-eZo
+lZI
 gsG
-yhF
-obd
-jBk
-dFf
-sDs
-gNe
-kBt
-pOh
-hUH
+hfE
+nJa
+auf
+gri
 rvr
 ubk
 nir
@@ -142239,21 +142297,21 @@ rvr
 ubk
 nir
 shJ
-fxe
+dfy
 iTk
 hjj
 uuB
-gPv
-cEm
-uBP
+waJ
+waJ
+waJ
 uuB
 bUn
 itH
 urP
 wnC
-anw
-nPN
-wPK
+fJh
+fWA
+vEC
 hkB
 lIK
 lIK
@@ -142567,45 +142625,45 @@ wld
 wld
 wld
 uUI
-cPE
-cPE
-cPE
-bBv
-jQh
-xNn
-aJs
+bdc
+mZK
+soi
+aWS
+izN
 gsG
 gsG
+gsG
+jbN
 gsG
 gsG
 lZI
 gsG
-hfE
+keI
 nJa
 auf
 gri
-rvr
-ubk
-nir
-rvr
-ubk
-nir
+auf
+fdG
+xfk
+xfk
+tfO
+hUH
 shJ
-dfy
-iTk
-hjj
+iqV
+lfB
+yeZ
 uuB
-waJ
-waJ
-waJ
+ods
+mno
+ods
 uuB
-bUn
+atV
 itH
 urP
 wnC
-fJh
-fWA
-vEC
+ofq
+nPN
+urP
 hkB
 lIK
 lIK
@@ -142919,15 +142977,15 @@ wld
 wld
 wld
 uUI
-bdc
+enZ
 mZK
 soi
-aWS
-izN
+mej
 gsG
 gsG
 gsG
-jbN
+gsG
+gsG
 gsG
 gsG
 lZI
@@ -142937,25 +142995,25 @@ nJa
 auf
 gri
 auf
-fdG
-xfk
-xfk
-tfO
-hUH
+auf
+auf
+auf
+auf
+gri
 shJ
 iqV
-lfB
-yeZ
+iTk
+hjj
 uuB
-ods
-mno
-ods
+hOh
+qwH
+hOh
 uuB
-atV
+bUn
 itH
 urP
 wnC
-ofq
+ggq
 nPN
 urP
 hkB
@@ -143261,28 +143319,28 @@ xor
 xor
 xor
 wld
-wld
-wld
-wld
-iMQ
-wld
-wld
+qpG
+qpG
+qpG
+gKl
+qpG
+qpG
 wld
 wld
 wld
 uUI
-enZ
+bdc
 mZK
 soi
-mej
+dFg
+gsG
+ePe
+ePe
 gsG
 gsG
 gsG
-gsG
-gsG
-gsG
-gsG
-lZI
+hRb
+suC
 gsG
 keI
 nJa
@@ -143299,17 +143357,17 @@ iqV
 iTk
 hjj
 uuB
-hOh
-qwH
-hOh
+uBb
+uuB
+uBb
 uuB
 bUn
 itH
-urP
-wnC
-ggq
-nPN
-urP
+uQK
+hkB
+hkB
+hkB
+hkB
 hkB
 lIK
 lIK
@@ -143613,12 +143671,12 @@ wld
 wld
 wld
 wld
-qpG
-qpG
-qpG
-gKl
-qpG
-qpG
+kzq
+sfj
+rrm
+cEc
+fHl
+kzq
 wld
 wld
 wld
@@ -143626,43 +143684,43 @@ uUI
 bdc
 mZK
 soi
-dFg
-gsG
-ePe
-ePe
-gsG
-gsG
-gsG
-hRb
-suC
-gsG
-keI
+orY
+ull
+rhk
+gvt
+cPE
+cPE
+cPE
+ftH
+eFV
+cPE
+eXK
 nJa
 auf
 gri
 auf
 auf
-auf
+fUv
 auf
 auf
 gri
-shJ
-iqV
-iTk
-hjj
-uuB
-uBb
-uuB
-uBb
-uuB
-bUn
-itH
-uQK
+sSo
+lkq
+bWK
+ksf
+gSl
+fwh
+gan
+fwh
+gSl
+eIS
+lKq
+arz
 hkB
 hkB
-hkB
-hkB
-hkB
+lIK
+lIK
+lIK
 lIK
 lIK
 lIK
@@ -143966,50 +144024,50 @@ wld
 wld
 wld
 kzq
-sfj
-rrm
-cEc
-fHl
+lnJ
+ptI
+ptI
+uhA
 kzq
 wld
 wld
-wld
+mPV
 uUI
-bdc
-mZK
-soi
-orY
-ull
-rhk
-gvt
-cPE
-cPE
-cPE
-ftH
-eFV
-cPE
-eXK
+uUI
 nJa
-auf
+nJa
+nJa
+nJa
+nJa
+nJa
+nJa
+fEA
+nJa
+nJa
+iXY
+nJa
+nJa
+uUI
+mLa
 gri
 auf
 auf
-fUv
+auf
 auf
 auf
 gri
 sSo
-lkq
-bWK
-ksf
-gSl
-fwh
-gan
-fwh
-gSl
-eIS
-lKq
-arz
+lYn
+iSJ
+arC
+hpB
+sYm
+aAv
+tjO
+ifB
+arC
+cvk
+lQF
 hkB
 hkB
 lIK
@@ -144318,32 +144376,32 @@ wld
 wld
 wld
 kzq
-lnJ
+sBr
 ptI
 ptI
-uhA
+nZH
 kzq
 wld
 wld
-mPV
-uUI
-uUI
-nJa
-nJa
-nJa
-nJa
-nJa
-nJa
-nJa
-fEA
-nJa
-nJa
-iXY
-nJa
-nJa
-uUI
-mLa
-gri
+wld
+cge
+cge
+auf
+auf
+qLk
+ryg
+sFD
+xfk
+xfk
+xfk
+sFD
+xfk
+gHY
+xfk
+xfk
+xCB
+xfk
+xPQ
 auf
 auf
 auf
@@ -144351,17 +144409,17 @@ auf
 auf
 gri
 sSo
-lYn
-iSJ
-arC
-hpB
-sYm
-aAv
-tjO
-ifB
-arC
-cvk
-lQF
+nrn
+hYY
+lcs
+gjg
+fof
+gjg
+hYY
+gjg
+lcs
+hYY
+wJf
 hkB
 hkB
 lIK
@@ -144669,12 +144727,12 @@ wld
 wld
 wld
 wld
-kzq
-sBr
+qpG
+vrD
 ptI
 ptI
-nZH
-kzq
+gEV
+qpG
 wld
 wld
 wld
@@ -144682,20 +144740,20 @@ cge
 cge
 auf
 auf
-qLk
-ryg
-sFD
-xfk
-xfk
-xfk
-sFD
-xfk
-gHY
-xfk
-xfk
-xCB
-xfk
-xPQ
+wzI
+auf
+rwX
+auf
+auf
+auf
+ppx
+auf
+qHw
+auf
+auf
+auf
+auf
+gri
 auf
 auf
 auf
@@ -144703,17 +144761,17 @@ auf
 auf
 gri
 sSo
-nrn
-hYY
-lcs
-gjg
-fof
-gjg
-hYY
-gjg
-lcs
-hYY
-wJf
+wnC
+wnC
+aFp
+wnC
+wnC
+rga
+wnC
+wnC
+aFp
+wnC
+wnC
 hkB
 hkB
 lIK
@@ -145021,53 +145079,53 @@ wld
 wld
 wld
 wld
-qpG
-vrD
+kzq
+txp
 ptI
 ptI
-gEV
-qpG
+lrN
+kzq
 wld
 wld
 wld
 cge
 cge
-auf
-auf
-wzI
-auf
-rwX
-auf
-auf
-auf
-ppx
-auf
-qHw
-auf
-auf
-auf
-auf
-gri
+faf
+nmC
+ido
+dBT
+gMI
+dBT
+dzd
+qOk
+aBj
+qOk
+xZa
 auf
 auf
 auf
-auf
-auf
-gri
-sSo
-wnC
-wnC
-aFp
-wnC
-wnC
-rga
-wnC
-wnC
-aFp
-wnC
-wnC
-hkB
-hkB
+kNh
+qPP
+xfk
+xfk
+bif
+xfk
+xfk
+xPQ
+cge
+hML
+hML
+oTY
+hML
+hML
+hML
+hML
+hML
+oTY
+hML
+hML
+jWG
+jWG
 lIK
 lIK
 lIK
@@ -145374,10 +145432,10 @@ wld
 wld
 wld
 kzq
-txp
+nvA
 ptI
-ptI
-lrN
+etJ
+vFj
 kzq
 wld
 wld
@@ -145385,28 +145443,28 @@ wld
 cge
 cge
 faf
-nmC
-ido
-dBT
-gMI
-dBT
-dzd
-qOk
-aBj
-qOk
-xZa
+bCW
 auf
 auf
 auf
-kNh
-qPP
+fUv
+auf
+auf
+fOb
+auf
+auf
+auf
+auf
+auf
+fJA
+fdG
+dCv
 xfk
+ien
 xfk
-bif
-xfk
-xfk
-xPQ
-cge
+wdA
+olB
+tCN
 hML
 hML
 oTY
@@ -145727,8 +145785,8 @@ wld
 wld
 kzq
 nvA
-ptI
-etJ
+jfa
+fSK
 vFj
 kzq
 wld
@@ -145741,24 +145799,24 @@ bCW
 auf
 auf
 auf
-fUv
-auf
-auf
-fOb
 auf
 auf
 auf
+hVN
 auf
 auf
-fJA
-fdG
-dCv
-xfk
-ien
-xfk
-wdA
-olB
-tCN
+auf
+auf
+irl
+kNh
+auf
+bmo
+auf
+kNh
+auf
+bmo
+irl
+cge
 hML
 hML
 oTY
@@ -146077,39 +146135,39 @@ wld
 wld
 wld
 wld
+qpG
+qpG
 kzq
-nvA
-jfa
-fSK
-vFj
 kzq
+qpG
+qpG
 wld
 wld
 wld
 cge
 cge
-faf
-bCW
+auf
+sVP
+dBT
+nmC
+nmC
+nmC
+nmC
+nmC
+rMl
 auf
 auf
 auf
 auf
-auf
-auf
-hVN
-auf
-auf
-auf
-auf
-irl
-kNh
-auf
-bmo
-auf
-kNh
-auf
-bmo
-irl
+jsN
+hXG
+mWR
+qLW
+jsN
+hXG
+tcI
+qLW
+jsN
 cge
 hML
 hML
@@ -146429,49 +146487,49 @@ wld
 wld
 wld
 wld
-qpG
-qpG
-kzq
-kzq
-qpG
-qpG
 wld
 wld
 wld
+wld
+wld
+wld
+wld
+wld
+quU
 cge
 cge
+vzr
+ido
+xyL
+emj
+emj
+emj
+emj
+emj
 auf
-sVP
-dBT
-nmC
-nmC
-nmC
-nmC
-nmC
-rMl
 auf
 auf
 auf
 auf
 jsN
-hXG
-mWR
-qLW
+bOz
+dQO
+xOf
 jsN
-hXG
-tcI
-qLW
+aUl
+nuy
+pPM
 jsN
 cge
 hML
 hML
-oTY
-hML
-hML
-hML
-hML
-hML
-oTY
+chi
+dzZ
+dzZ
+dzZ
+dzZ
+dzZ
+wvZ
 hML
 hML
 jWG
@@ -146747,9 +146805,9 @@ ifw
 eaO
 die
 pxG
-wld
-wld
-wld
+nre
+nre
+nre
 hsh
 hsh
 hsh
@@ -146764,69 +146822,69 @@ oay
 rGg
 qli
 viD
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-wld
-quU
+eOA
+eOA
+eOA
+eOA
+eOA
+bar
+eOA
+eOA
+eOA
+eOA
+eOA
+eOA
+eOA
+eOA
+eOA
+eOA
+eOA
+eOA
+eOA
+eOA
+eOA
+eOA
+eOA
+eOA
+eOA
+eOA
 cge
 cge
-vzr
-ido
-xyL
-emj
-emj
-emj
-emj
-emj
+auf
+auf
+auf
+auf
+auf
+auf
+auf
+auf
 auf
 auf
 auf
 auf
 auf
 jsN
-bOz
-dQO
-xOf
+tRU
+ifp
+lHB
 jsN
-aUl
-nuy
-pPM
+hFZ
+lgL
+gqv
 jsN
-cge
-hML
-hML
-chi
-dzZ
-dzZ
-dzZ
-dzZ
-dzZ
-wvZ
-hML
-hML
-jWG
+rRT
+jtm
+jtm
+jtm
+jtm
+jtm
+jtm
+jtm
+jtm
+jtm
+jtm
+jtm
+wbS
 jWG
 lIK
 lIK
@@ -147116,33 +147174,33 @@ hEF
 kpE
 sLj
 viD
-eOA
-eOA
-eOA
-eOA
-eOA
-bar
-eOA
-eOA
-eOA
-eOA
-eOA
-eOA
-eOA
-eOA
-eOA
-eOA
-eOA
-eOA
-eOA
-eOA
-eOA
-eOA
-eOA
-eOA
-eOA
-eOA
-rvH
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+snf
+rRT
 dhG
 jyd
 jyd
@@ -147158,15 +147216,16 @@ jyd
 jyd
 jyd
 jsN
-tRU
-ifp
-lHB
 jsN
-hFZ
-lgL
-gqv
 jsN
-rRT
+jsN
+jsN
+jsN
+jsN
+jsN
+jsN
+dhG
+jtm
 jtm
 jtm
 jtm
@@ -147179,7 +147238,6 @@ jtm
 jtm
 jtm
 wbS
-jWG
 lIK
 lIK
 lIK
@@ -147468,70 +147526,70 @@ gCy
 kpE
 mSC
 viD
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-snf
-rRT
-jyd
-jyd
-jyd
-jyd
-jyd
-jyd
-jyd
-jyd
-jyd
-jyd
-jyd
-jyd
-jyd
-jyd
-jsN
-jsN
-jsN
-jsN
-jsN
-jsN
-jsN
-jsN
-jsN
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
+lWz
 dhG
-jtm
-jtm
-jtm
-jtm
-jtm
-jtm
-jtm
-jtm
-jtm
-jtm
-jtm
-jtm
-wbS
+jyd
+jyd
+jyd
+jyd
+jyd
+jyd
+jyd
+jyd
+jyd
+jyd
+jyd
+jyd
+jyd
+jyd
+dhG
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
 lIK
 lIK
 lIK
@@ -147820,33 +147878,33 @@ xQw
 jeO
 pIx
 viD
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-lWz
-opc
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
+lIK
 lIK
 lIK
 lIK
@@ -269638,7 +269696,7 @@ rDI
 rDI
 rDI
 bRI
-bRI
+hMT
 rDI
 rDI
 rDI
@@ -269989,8 +270047,8 @@ rDI
 rDI
 rDI
 rDI
-bRI
-hMT
+rDI
+rDI
 rDI
 rDI
 rDI


### PR DESCRIPTION
[bugfix] [mapping]
* fixed broken wiring in security
* fixed hand teleporter not respecting the z-levels
* closes #37797
* closes #37799
* closes #37798
* adds more flooring to the underground
* closes #37809
* closes #37807
* closes #37806
* closes #37805
* closes #37804
* closes #37803
* closes #37810
* closes #37811
* closes #37812
* makes wires peaceable on jungle paths and bedrock
* closes #37813
* adds more lights to recycling
* closes #37814
* probably closes #37802, since it moves it behind a windoor


## Changelog
:cl:
 * bugfix: jungle has less issues
