### PR TITLE
fix lightreplacer runtime

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -459,7 +459,7 @@ This used to be handled by attackby() on the light fixtures and bulbs themselves
 	return best_light
 
 /obj/item/device/lightreplacer/proc/is_light_better(var/obj/item/weapon/light/tested, var/obj/item/weapon/light/comparison)
-	if(tested.status) //Is tested empty? If so, either it must be a tie or comparison wins, so tested cannot win.
+	if(tested?.status) //Is tested empty? If so, either it must be a tie or comparison wins, so tested cannot win.
 		return 0
 	if(tested.status >= LIGHT_BROKEN) //Is tested broken or burnt out? If so, it cannot win.
 		return 0

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -459,12 +459,12 @@ This used to be handled by attackby() on the light fixtures and bulbs themselves
 	return best_light
 
 /obj/item/device/lightreplacer/proc/is_light_better(var/obj/item/weapon/light/tested, var/obj/item/weapon/light/comparison)
+	if(tested.status) //Is tested empty? If so, either it must be a tie or comparison wins, so tested cannot win.
+		return 0
 	if(tested.status >= LIGHT_BROKEN) //Is tested broken or burnt out? If so, it cannot win.
 		return 0
 	if(tested.status < comparison.status) //Is tested closer to functional than comparison? If so, it wins.
 		return 1
-	if(tested.status) //Is tested empty? If so, either it must be a tie or comparison wins, so tested cannot win.
-		return 0
 
 	//Now we know both work, so all that is left is to test if tested wins by being HE.
 	if(findtextEx(tested.base_state, "he", 1, 3) && !findtextEx(comparison.base_state, "he", 1, 3))


### PR DESCRIPTION
## What this does
```
[20:12:51] Runtime in code/game/objects/items/devices/lightreplacer.dm,462: Cannot read null.status
  proc name: is light better (/obj/item/device/lightreplacer/proc/is_light_better)
  usr: Will Stainforth (personable) (/mob/living/carbon/human)
  usr.loc: The floor (282, 242, 1) (/turf/simulated/floor)
  src: the light replacer (/obj/item/device/lightreplacer/loaded/mixed)
  src.loc: Will Stainforth (/mob/living/carbon/human)
  call stack:
  the light replacer (/obj/item/device/lightreplacer/loaded/mixed): is light better(null, the high efficiency light tube (/obj/item/weapon/light/tube/he))
  the light replacer (/obj/item/device/lightreplacer/loaded/mixed): preattack(the floor (282,243,1) (/turf/simulated/floor), Will Stainforth (/mob/living/carbon/human), 1, "icon-x=28;icon-y=16;left=1;but...")
  Will Stainforth (/mob/living/carbon/human): ClickOn(the floor (282,243,1) (/turf/simulated/floor), "icon-x=28;icon-y=16;left=1;but...")
  the floor (282,243,1) (/turf/simulated/floor): Click(the floor (282,243,1) (/turf/simulated/floor), "mapwindow.map", "icon-x=28;icon-y=16;left=1;but...")
```

## Why it's good
- we switch the order to check status first instead of doing comparison with status first
