### PR TITLE
fix derpspeech runtime

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -406,10 +406,11 @@
 	if(prob(70))
 		var/regex/duplicate = new("(\\w)(?=\\1)", "g")
 		message = replacetext(message, duplicate, "") //duplicate letters into one letter, for all words
-	if(prob(20)) //occasionally replaces one word with umm.
+	if(prob(20))
 		var/list/words = splittext(message, " ")
-		words[rand(0, words.len)] = pick("um,", "umm,", "uh,", "uhh,")
-		message = jointext(words, " ")
+		if(words.len > 0) // Check if the list has any words
+			words[rand(1, words.len)] = pick("um,", "umm,", "uh,", "uhh,")
+			message = jointext(words, " ")
 			
 	if(prob(35))
 		message = uppertext(message)


### PR DESCRIPTION
`[20:52:06] Runtime in code/modules/mob/mob_helpers.dm,411: list index out of bounds`

## What this does
- 1-based indexing rather than 0

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
- sanity check and fix runtime