### PR TITLE
fix sound runtime

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -205,7 +205,7 @@
 					sounds_to_play = T.footstep_sound
 
 			stepstaken = 0
-			if (!sounds_to_play)
+			if (!sounds_to_play?.len)
 				return
 			playsound(src, pick(sounds_to_play), step_volume, 1, range)
 			


### PR DESCRIPTION
```
[23:07:30] Runtime in code/modules/mob/living/carbon/human/human_movement.dm,210: pick() from empty list
  proc name: Move (/mob/living/carbon/human/Move)
  usr: Remi Meadows (djkramer) (/mob/living/carbon/human)
  usr.loc: Sand (114, 86, 2) (/turf/unsimulated/beach/sand)
  src: Remi Meadows (/mob/living/carbon/human)
  src.loc: Sand (114,86,2) (/turf/unsimulated/beach/sand)
  call stack:
  Remi Meadows (/mob/living/carbon/human): Move(Sand (114,86,2) (/turf/unsimulated/beach/sand), 2, 0, 0, 0)
  Djkramer (/client): Move(the surface (114,87,2) (/turf/unsimulated/floor/mars/air), 2, 0, 0, 0)
```

## What this does
- some turfs don't have sounds associated with them
- we get a null list or empty list of sounds
- can't pick from an empty list, so we ensure we check its empty first

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
fix runtime

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
compiles
