### PR TITLE
fix turf/area runtime

### DIFF
--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -331,8 +331,11 @@ var/list/map_dimension_cache = list()
 	if(!isarea(instance))
 		WARNING("Instance at [members[index]] is not an area!")
 	if(!isspace(instance)) //Space is the default area and contains every loaded turf by default
-		instance.contents.Add(locate(xcrd,ycrd,zcrd))
-		spawned_atoms.Add(instance)
+		var/turf/T = locate(xcrd,ycrd,zcrd)
+		if(T)
+			var/area/old_area = get_area(T)  // Use get_area() instead of direct access
+			T.change_area(old_area, instance)
+			spawned_atoms.Add(instance)
 
 	if(use_preloader && instance)
 		_preloader.load(instance)


### PR DESCRIPTION
```
[18:37:55] Runtime in code/modules/awaymissions/maploader/reader.dm,334: cannot append to list
  proc name: parse grid (/dmm_suite/proc/parse_grid)
  src: /dmm_suite (/dmm_suite)
  call stack:
  /dmm_suite (/dmm_suite): parse grid("/obj/machinery/conveyor,/turf/...", 351, 201, 4, 270, 0)
  /dmm_suite (/dmm_suite): load map(maps/randomvaults/hivebot_fact..., 4, 330, 191, /datum/map_element/vault/hiveb... (/datum/map_element/vault/hivebot_factory), 270, 0, 1, 20, 1, 25, 1, inf)
  /datum/map_element/vault/hiveb... (/datum/map_element/vault/hivebot_factory): load(330, 191, 4, 270, 0, 0, 0, inf, 0, inf, 0, inf)
  populate area with vaults(the random vault area (/area/random_vault), /list (/list), 36, 2, /proc/stay_in_vault_area (/proc/stay_in_vault_area), 0)
  generate vaults()
  Map (/datum/subsystem/map): Initialize(814690)
  Master (/datum/controller/master): Setup()
```

## What this does
- get_area() is a built-in BYOND proc that safely gets a turf's area
- It handles null cases properly

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
compiles
