### PR TITLE
Disables junglestation from being voted on

### DIFF
--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -185,6 +185,9 @@
 	path = "junglestation"
 	min_players=1 //placeholders - adjust later. Or don't. maybe it'll be fun in deadpop and highpop.
 	max_players=99
+//disabled voting. re-enable when jungle is good to run full time. should still be able to be bussed like this.
+/datum/next_map/junglestation/is_votable()
+	return FALSE
 
 /proc/get_votable_maps()
 	var/list/votable_maps = list()


### PR DESCRIPTION
[vote]

## What this does
what the title says. admins should still be able to push buttons to run it for testing/events
merge if the server vote is against keeping it.

## Why it's good
it needs more work

## How it was tested
clearly not that well.

## Changelog
:cl:
 * rscdel: NT Colony Gamma-8 is now undergoing renovations following several concerns raised by employees.