### PR TITLE
fix sound runtime

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -205,7 +205,7 @@
 					sounds_to_play = T.footstep_sound
 
 			stepstaken = 0
-			if (!sounds_to_play)
+			if (!sounds_to_play?.len)
 				return
 			playsound(src, pick(sounds_to_play), step_volume, 1, range)
 			


### PR DESCRIPTION


  Description:
  Some turfs don't have sounds associated with them, causes a runtime error when trying to pick from an empty list of
  sounds.

  ## Changes
  - Changed `if (!sounds_to_play)` to `if (!sounds_to_play?.len)` in human_movement.dm
  - Uses safe navigation operator to prevent runtime errors

  ## Test plan
  - [x] Compile the code
  - [x] Test movement on turfs without footstep sounds  
  - [x] Verify no runtime errors occur
