### PR TITLE
fix turf/area runtime

### DIFF
--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -330,7 +330,7 @@ var/list/map_dimension_cache = list()
 	instance = locate(members[index])
 	if(!isarea(instance))
 		WARNING("Instance at [members[index]] is not an area!")
-	if(!isspace(instance))
+	if(!isspace(instance)) //Space is the default area and contains every loaded turf by default
 		var/turf/T = locate(xcrd,ycrd,zcrd)
 		if(T)
 			var/area/old_area = get_area(T) // Use get_area() instead of direct access

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -330,11 +330,11 @@ var/list/map_dimension_cache = list()
 	instance = locate(members[index])
 	if(!isarea(instance))
 		WARNING("Instance at [members[index]] is not an area!")
-	var/turf/T = locate(xcrd,ycrd,zcrd)
-	if(T)
-		var/area/old_area = get_area(T) // Use get_area() instead of direct access
-		T.change_area(old_area, instance)
-		spawned_atoms.Add(instance)
+		var/turf/T = locate(xcrd,ycrd,zcrd)
+		if(T)
+			var/area/old_area = get_area(T) // Use get_area() instead of direct access
+			T.change_area(old_area, instance)
+			spawned_atoms.Add(instance)
 
 	if(use_preloader && instance)
 		_preloader.load(instance)

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -330,6 +330,7 @@ var/list/map_dimension_cache = list()
 	instance = locate(members[index])
 	if(!isarea(instance))
 		WARNING("Instance at [members[index]] is not an area!")
+	if(isspace(instance))
 		var/turf/T = locate(xcrd,ycrd,zcrd)
 		if(T)
 			var/area/old_area = get_area(T) // Use get_area() instead of direct access

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -330,8 +330,10 @@ var/list/map_dimension_cache = list()
 	instance = locate(members[index])
 	if(!isarea(instance))
 		WARNING("Instance at [members[index]] is not an area!")
-	if(!isspace(instance)) //Space is the default area and contains every loaded turf by default
-		instance.contents.Add(locate(xcrd,ycrd,zcrd))
+	var/turf/T = locate(xcrd,ycrd,zcrd)
+	if(T)
+		var/area/old_area = get_area(T) // Use get_area() instead of direct access
+		T.change_area(old_area, instance)
 		spawned_atoms.Add(instance)
 
 	if(use_preloader && instance)

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -330,7 +330,7 @@ var/list/map_dimension_cache = list()
 	instance = locate(members[index])
 	if(!isarea(instance))
 		WARNING("Instance at [members[index]] is not an area!")
-	if(isspace(instance))
+	if(!isspace(instance))
 		var/turf/T = locate(xcrd,ycrd,zcrd)
 		if(T)
 			var/area/old_area = get_area(T) // Use get_area() instead of direct access


### PR DESCRIPTION
Uses get_area() which is a built-in BYOND proc that "safely gets a turf's area". Recreated from original PR #37820 by aacovski.

