### PR TITLE
fix derpspeech runtime

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -408,7 +408,8 @@
 		message = replacetext(message, duplicate, "") //duplicate letters into one letter, for all words
 	if(prob(20)) //occasionally replaces one word with umm.
 		var/list/words = splittext(message, " ")
-		words[rand(0, words.len)] = pick("um,", "umm,", "uh,", "uhh,")
+		if(words.len > 0) // Check if the list has any words
+			words[rand(1, words.len)] = pick("um,", "umm,", "uh,", "uhh,")
 		message = jointext(words, " ")
 			
 	if(prob(35))


### PR DESCRIPTION
Fixed a runtime error in the code related to list indexing. Specifically addressed a "Runtime in code/modules/mob/mob_helpers.dm,411: list index out of bounds"

Recreated from original PR #37817 by aacovski.