### PR TITLE
fix candle runtime

### DIFF
--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -14,7 +14,7 @@
 	var/age = 1 //For map persistence. +1 per round that this item has survived. After a certain amount, it will not carry on to the next round anymore.
 	//var/global/list/trash_items = list()
 
-/obj/item/trash/New(var/loc, var/age, var/icon_state, var/color, var/dir, var/pixel_x, var/pixel_y)
+/obj/item/trash/New(var/loc, var/age, var/icon_state, var/color, var/dir, var/pixel_x, var/pixel_y, var/obj/item/source))
 	if(age)
 		setPersistenceAge(age)
 	if(icon_state)
@@ -226,10 +226,10 @@
 	w_type=RECYK_WAX
 	var/image/wick
 
-/obj/item/trash/candle/New(turf/loc)
+/obj/item/trash/candle/New(turf/loc, var/obj/item/source)
 	..()
-	if (istype(src, /obj/item/candle))
-		color = src.color
+	if (istype(source, /obj/item/candle))
+		color = source.color
 	else
 		color = COLOR_DEFAULT_CANDLE
 	wick = image(icon,src,"candle4-wick")

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -14,7 +14,7 @@
 	var/age = 1 //For map persistence. +1 per round that this item has survived. After a certain amount, it will not carry on to the next round anymore.
 	//var/global/list/trash_items = list()
 
-/obj/item/trash/New(var/loc, var/age, var/icon_state, var/color, var/dir, var/pixel_x, var/pixel_y, var/obj/item/source))
+/obj/item/trash/New(var/loc, var/age, var/icon_state, var/color, var/dir, var/pixel_x, var/pixel_y, var/obj/item/source)
 	if(age)
 		setPersistenceAge(age)
 	if(icon_state)

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -226,10 +226,10 @@
 	w_type=RECYK_WAX
 	var/image/wick
 
-/obj/item/trash/candle/New(turf/loc, var/obj/item/candle/source)
+/obj/item/trash/candle/New(turf/loc)
 	..()
-	if (source)
-		color = source.color
+	if (istype(src, /obj/item/candle))
+		color = src.color
 	else
 		color = COLOR_DEFAULT_CANDLE
 	wick = image(icon,src,"candle4-wick")

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -228,7 +228,7 @@
 
 /obj/item/trash/candle/New(turf/loc, var/obj/item/source)
 	..()
-	if (istype(source, /obj/item/candle))
+	if (source && istype(source, /obj/item/candle))
 		color = source.color
 	else
 		color = COLOR_DEFAULT_CANDLE


### PR DESCRIPTION
Fixes a runtime by adding a type check. Prevents a runtime by adding a type check. Corrects an issue where value 1 was incorrectly passed instead of source (src).

Recreated from original PR #37796 by aacovski.