### PR TITLE
fix mob runtimes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
@@ -78,7 +78,8 @@
 	..()
 
 /mob/living/simple_animal/hostile/humanoid/kitchen/meatballer/adjustBruteLoss(var/damage)
-	if(prob(damage*(maxHealth/health)))
+	var/proc_chance = min(100, damage + (100 - health/maxHealth*100))
+	if(prob(proc_chance))
 		fire_everything()
 	..()
 
@@ -223,7 +224,8 @@
 			return unlock_atom(L)
 
 /mob/living/simple_animal/hostile/humanoid/vampire/adjustBruteLoss(var/damage)
-	if(!isDead() && prob(damage*(maxHealth/health)) && world.time > last_jaunt + JAUNT_COOLDOWN)
+	var/proc_chance = min(100, 130 - health/maxHealth*100)
+	if(!isDead() && prob(proc_chance) && world.time > last_jaunt + JAUNT_COOLDOWN)
 		last_jaunt = world.time
 		jaunt_away()
 	..()
@@ -352,7 +354,8 @@
 
 /mob/living/simple_animal/hostile/gremlin/greytide/adjustBruteLoss()
 	..()
-	if(!isDead() && prob(30*(maxHealth/health)))
+	var/proc_chance = min(100, 30 + (100 - health/maxHealth*100))
+	if(!isDead() && prob(proc_chance))
 		visible_message("<span class = 'warning'>\The [src] looks to be annoyed!</span>")
 		annoyed = 1
 		spawn(rand(15 SECONDS, 45 SECONDS))

--- a/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
@@ -78,7 +78,7 @@
 	..()
 
 /mob/living/simple_animal/hostile/humanoid/kitchen/meatballer/adjustBruteLoss(var/damage)
-	var/proc_chance = min(100, damage + (100 - health/maxHealth*100))
+	var/proc_chance = min(100, (130 - health/maxHealth*100))
 	if(!isDead() && prob(proc_chance))
 		fire_everything()
 	..()
@@ -354,7 +354,7 @@
 
 /mob/living/simple_animal/hostile/gremlin/greytide/adjustBruteLoss()
 	..()
-	var/proc_chance = min(100, 30 + (100 - health/maxHealth*100))
+	var/proc_chance = min(100, (130 - health/maxHealth*100))
 	if(!isDead() && prob(proc_chance))
 		visible_message("<span class = 'warning'>\The [src] looks to be annoyed!</span>")
 		annoyed = 1

--- a/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
@@ -79,7 +79,7 @@
 
 /mob/living/simple_animal/hostile/humanoid/kitchen/meatballer/adjustBruteLoss(var/damage)
 	var/proc_chance = min(100, damage + (100 - health/maxHealth*100))
-	if(prob(proc_chance))
+	if(!isDead() && prob(proc_chance))
 		fire_everything()
 	..()
 

--- a/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
@@ -78,7 +78,7 @@
 	..()
 
 /mob/living/simple_animal/hostile/humanoid/kitchen/meatballer/adjustBruteLoss(var/damage)
-	var/proc_chance = min(100, (130 - health/maxHealth*100))
+	var/proc_chance = clamp(damage*(maxHealth/min(health,1)),0,100)
 	if(!isDead() && prob(proc_chance))
 		fire_everything()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
@@ -224,7 +224,7 @@
 			return unlock_atom(L)
 
 /mob/living/simple_animal/hostile/humanoid/vampire/adjustBruteLoss(var/damage)
-	var/proc_chance = min(100, 130 - health/maxHealth*100)
+	var/proc_chance = clamp(damage*(maxHealth/min(health,1)),0,100)
 	if(!isDead() && prob(proc_chance) && world.time > last_jaunt + JAUNT_COOLDOWN)
 		last_jaunt = world.time
 		jaunt_away()
@@ -352,9 +352,9 @@
 /mob/living/simple_animal/hostile/gremlin/greytide/electrocute_act()
 	return //Gremtide cometh
 
-/mob/living/simple_animal/hostile/gremlin/greytide/adjustBruteLoss()
+/mob/living/simple_animal/hostile/gremlin/greytide/adjustBruteLoss(var/damage)
 	..()
-	var/proc_chance = min(100, (130 - health/maxHealth*100))
+	var/proc_chance = var/proc_chance = clamp(damage*(maxHealth/min(health,1)),0,100)
 	if(!isDead() && prob(proc_chance))
 		visible_message("<span class = 'warning'>\The [src] looks to be annoyed!</span>")
 		annoyed = 1

--- a/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
+++ b/code/modules/mob/living/simple_animal/hostile/human/halloween.dm
@@ -354,7 +354,7 @@
 
 /mob/living/simple_animal/hostile/gremlin/greytide/adjustBruteLoss(var/damage)
 	..()
-	var/proc_chance = var/proc_chance = clamp(damage*(maxHealth/min(health,1)),0,100)
+	var/proc_chance = clamp(damage*(maxHealth/min(health,1)),0,100)
 	if(!isDead() && prob(proc_chance))
 		visible_message("<span class = 'warning'>\The [src] looks to be annoyed!</span>")
 		annoyed = 1


### PR DESCRIPTION
Fixes runtime errors for multiple mobs, specifically addressing a "weird percentage prob(damage*(maxHealth/health)" calculation that could cause division by zero. The changes:
- Stop division by zero
- Restore intended behavior
- Increase probability of proc for mobs with lower health

Replaced problematic probability calculations with safer alternatives for vampire, meatballer, and greytide mobs.

Recreated from original PR #37787 by aacovski.
