### PR TITLE
ghosts can no longer anger the bees constantly

### DIFF
--- a/code/game/machinery/bees_apiary.dm
+++ b/code/game/machinery/bees_apiary.dm
@@ -82,6 +82,9 @@ var/list/apiaries_list = list()
 		update_icon()
 
 /obj/machinery/apiary/attack_hand(var/mob/user)
+	if(isobserver(user) && !isAdminGhost(user))
+		to_chat(user, "<span class='warning'>Your ghostly limb passes right through \the [src].</span>")
+		return
 	if(reagents.total_volume <= 0)
 		alert(user,"There's no honey to harvest yet!","[name]","Ok")
 		return


### PR DESCRIPTION
Adds a boilerplate check to apiary attack_hand(). Ensures that only admin ghosts can interact with apiaries, while regular ghosts will receive a message indicating they cannot interact with the object.

Recreated from original PR #37786 by aacovski.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: ghosts can't anger the bees/hornets via nests