### PR TITLE
fix infinite zombies

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -264,6 +264,10 @@
 		success = TRUE
 		var/mob/living/carbon/human/H = target
 		if(H.stat)
+			if(H.locked_to)
+				H.locked_to = 0
+				H.anchored = 0
+			
 			if(raisetype)
 				H.dropBorers()
 				var/mob/living/simple_animal/hostile/necro/skeleton/spooky = new /mob/living/simple_animal/hostile/necro/skeleton(get_turf(H), user, H)


### PR DESCRIPTION
Removes anchor before zombifying. Fixes issue with necromancer staff spawning zombies.

Changes:
- Unlocks and un-anchors human target before necromancy
- Prevents infinite wheelchair zombies with necro staff
- Ensures proper state cleanup before zombification

Recreated from original PR #37785 by aacovski.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: no more infinite zombies from corpses in wheelchairs