### PR TITLE
fix map name

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -338,7 +338,7 @@ var/updated_stats = 0
 		to_chat(src, "<span class='info'>Changelog has changed since your last visit.</span>")
 
 	//Set map label to correct map name
-	winset_wrapper("rpane.mapb", "text=[map.nameLong]") 
+	winset_wrapper("rpane.mapb", "text=\"[map.nameLong]\"")
 
 	if (round_end_info)
 		winset_wrapper("rpane.round_end", "is-visible=true")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -338,7 +338,7 @@ var/updated_stats = 0
 		to_chat(src, "<span class='info'>Changelog has changed since your last visit.</span>")
 
 	//Set map label to correct map name
-	winset_wrapper(src, "rpane.mapb", "text=\"[map.nameLong]\"")
+	winset_wrapper("rpane.mapb", "text=[map.nameLong]") 
 
 	if (round_end_info)
 		winset_wrapper("rpane.round_end", "is-visible=true")


### PR DESCRIPTION
no idea what I'm doing but it shows "Box" instead of MapName when I host a server:

![image](https://github.com/user-attachments/assets/485915ce-4567-400f-824b-63c5f7e18efd)


Closes #37726

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: you can see the map name again
