### PR TITLE
fix cooking machine runtimes

### DIFF
--- a/code/modules/food/cooking_machines.dm
+++ b/code/modules/food/cooking_machines.dm
@@ -486,11 +486,7 @@ var/global/ingredientLimit = 10
 	var/fry_reagent_temp = T0C + 170 //target temperature of the frying reagent
 
 /obj/machinery/cooking/deepfryer/initialize()
-	..()
-	if(stat & (FORCEDISABLE | NOPOWER | BROKEN))
-		reagents.add_reagent(fry_reagent, 300)
-	else
-		reagents.add_reagent(fry_reagent, 300, reagtemp = fry_reagent_temp)
+	. = ..() // Call parent initialize
 
 /obj/machinery/cooking/deepfryer/process()
 	if(stat & (FORCEDISABLE | NOPOWER | BROKEN))
@@ -691,6 +687,9 @@ var/global/ingredientLimit = 10
 	cooks_in_reagents = 1
 
 	is_cooktop = TRUE //Allows frying pans to be placed on top of it.
+
+/obj/machinery/cooking/grill/initialize()
+	. = ..() // Call parent initialize
 
 /obj/machinery/cooking/grill/validateIngredient(var/obj/item/I)
 	. = ..()


### PR DESCRIPTION
```
[04:07:18] Runtime in code/__HELPERS/unsorted.dm,1270: double reagents creation for /obj/machinery/cooking/grill
  proc name: stack trace (/proc/stack_trace)
  src: null
  call stack:
  stack trace("double reagents creation for /...")
  the grill (/obj/machinery/cooking/grill): create reagents(50)
  the grill (/obj/machinery/cooking/grill): initialize()
  Objects (/datum/subsystem/obj): Initialize(292369)
  Master (/datum/controller/master): Setup()
[04:07:19] Runtime in code/__HELPERS/unsorted.dm,1270: double reagents creation for /obj/machinery/cooking/deepfryer
  proc name: stack trace (/proc/stack_trace)
  src: null
  call stack:
  stack trace("double reagents creation for /...")
  the deep fryer (/obj/machinery/cooking/deepfryer): create reagents(400)
  the deep fryer (/obj/machinery/cooking/deepfryer): initialize()
  the deep fryer (/obj/machinery/cooking/deepfryer): initialize()
  Objects (/datum/subsystem/obj): Initialize(292369)
```

- simplifies logic to just depend on parent init
- compiles
