### PR TITLE
Clownshoes sound fix

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -939,7 +939,7 @@ var/global/maxStackDepth = 10
 	sterility = 50
 
 	species_restricted = list("exclude","Unathi","Tajaran","Muton")
-	var/step_sound = ""
+	var/list/step_sound = null
 	var/stepstaken = 1
 	var/modulo_steps = 2 //if stepstaken is a multiplier of modulo_steps, play the sound. Does not work if modulo_steps < 1
 	var/footsteps_range = -4

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -255,7 +255,7 @@
 
 	if(Adjacent(user))
 		if(step_sound == CLOWNSHOES_RANDOM_SOUND)
-			step_sound = sounds_clownstep
+			step_sound = "clownstep"
 			to_chat(user, "<span class='sinister'>You set [src]'s step sound to always be random!</span>")
 			random_sound = 1
 		else
@@ -281,7 +281,6 @@
 
 		if(random_sound)
 			step_sound = sound_list[pick(sound_list)]
-	..()
 
 /obj/item/clothing/shoes/clown_shoes/advanced/emag_act(var/mob/user) //Causes the shoes to play a sound every step instead of 2
 	..()

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -159,7 +159,7 @@
 	species_fit = list(INSECT_SHAPED, VOX_SHAPED)
 	footprint_type = /obj/effect/decal/cleanable/blood/tracks/footprints/clown
 
-	step_sound = "clownstep"
+	step_sound = sounds_clownstep
 	footsteps_range = 0
 
 /obj/item/clothing/shoes/clown_shoes/New()
@@ -256,7 +256,7 @@
 
 	if(Adjacent(user))
 		if(step_sound == CLOWNSHOES_RANDOM_SOUND)
-			step_sound = "clownstep"
+			step_sound = sounds_clownstep
 			to_chat(user, "<span class='sinister'>You set [src]'s step sound to always be random!</span>")
 			random_sound = 1
 		else
@@ -617,7 +617,7 @@
 	footprint_type = /obj/effect/decal/cleanable/blood/tracks/footprints/clown
 	species_fit = list(VOX_SHAPED)
 
-	step_sound = "clownstep"
+	step_sound = sounds_clownstep
 
 /obj/item/clothing/shoes/clownshoespsyche/attackby(obj/item/weapon/W, mob/user)
 	..()

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -617,8 +617,9 @@
 	species_fit = list(VOX_SHAPED)
 
 /obj/item/clothing/shoes/clownshoespsyche/New()
-	step_sound = sounds_clownstep
 	..()
+	step_sound = sounds_clownstep
+
 
 /obj/item/clothing/shoes/clownshoespsyche/attackby(obj/item/weapon/W, mob/user)
 	..()

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -282,6 +282,8 @@
 		if(random_sound)
 			step_sound = sound_list[pick(sound_list)]
 
+	..()
+
 /obj/item/clothing/shoes/clown_shoes/advanced/emag_act(var/mob/user) //Causes the shoes to play a sound every step instead of 2
 	..()
 	if(!emagged)

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -158,12 +158,11 @@
 	_color = "clown"
 	species_fit = list(INSECT_SHAPED, VOX_SHAPED)
 	footprint_type = /obj/effect/decal/cleanable/blood/tracks/footprints/clown
-
-	step_sound = sounds_clownstep
 	footsteps_range = 0
 
 /obj/item/clothing/shoes/clown_shoes/New()
 	..()
+	step_sound = sounds_clownstep
 	if(Holiday == APRIL_FOOLS_DAY)
 		modulo_steps = 1 //Honk on every step
 
@@ -617,7 +616,9 @@
 	footprint_type = /obj/effect/decal/cleanable/blood/tracks/footprints/clown
 	species_fit = list(VOX_SHAPED)
 
+/obj/item/clothing/shoes/clownshoespsyche/New()
 	step_sound = sounds_clownstep
+	..()
 
 /obj/item/clothing/shoes/clownshoespsyche/attackby(obj/item/weapon/W, mob/user)
 	..()

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -166,14 +166,14 @@
 	icon_state = "vox-stealth"
 	item_state = "vox-stealth"
 	desc = "A sleek black suit. It seems to have a tail, and is very heavy."
-	var/step_sound = ""
+	var/list/step_sound = null
 
 /obj/item/clothing/suit/space/vox/stealth/New()
   ..()
   if(Holiday == APRIL_FOOLS_DAY)
     name = "vox suit"
     desc = "Squeak."
-    step_sound = "clownstep"
+    step_sound = sounds_clownstep
 
 /obj/item/clothing/suit/space/vox/stealth/step_action()
     if(ishuman(loc)&&Holiday == APRIL_FOOLS_DAY)
@@ -312,19 +312,17 @@
 	icon_state = "vox-stealth"
 	item_state = "vox-stealth"
 	desc = "A sleek black suit. It seems to have a tail, and is very heavy."
-	var/step_sound = ""
+	var/list/step_sound = null
 
 /obj/item/clothing/suit/space/vox/civ/trader/stealth/New()
   ..()
   if(Holiday == APRIL_FOOLS_DAY)
     name = "vox suit"
     desc = "Squeak."
-    step_sound = "clownstep"
+    step_sound = sounds_clownstep
 
 /obj/item/clothing/suit/space/vox/civ/trader/stealth/step_action()
-    if(ishuman(loc)&&Holiday == APRIL_FOOLS_DAY)
-        var/mob/living/carbon/human/H = loc
-        playsound(H, step_sound, 20, 1)
+    return
 
 /obj/item/clothing/head/helmet/space/vox/civ/trader/stealth //blackhelmet
 	name = "alien stealth helmet"

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -166,14 +166,14 @@
 	icon_state = "vox-stealth"
 	item_state = "vox-stealth"
 	desc = "A sleek black suit. It seems to have a tail, and is very heavy."
-	var/list/step_sound = null
+	var/step_sound = ""
 
 /obj/item/clothing/suit/space/vox/stealth/New()
   ..()
   if(Holiday == APRIL_FOOLS_DAY)
     name = "vox suit"
     desc = "Squeak."
-    step_sound = sounds_clownstep
+    step_sound = "clownstep"
 
 /obj/item/clothing/suit/space/vox/stealth/step_action()
     if(ishuman(loc)&&Holiday == APRIL_FOOLS_DAY)
@@ -312,17 +312,19 @@
 	icon_state = "vox-stealth"
 	item_state = "vox-stealth"
 	desc = "A sleek black suit. It seems to have a tail, and is very heavy."
-	var/list/step_sound = null
+	var/step_sound = ""
 
 /obj/item/clothing/suit/space/vox/civ/trader/stealth/New()
   ..()
   if(Holiday == APRIL_FOOLS_DAY)
     name = "vox suit"
     desc = "Squeak."
-    step_sound = sounds_clownstep
+    step_sound = "clownstep"
 
 /obj/item/clothing/suit/space/vox/civ/trader/stealth/step_action()
-    return
+	if(ishuman(loc)&&Holiday == APRIL_FOOLS_DAY)
+		var/mob/living/carbon/human/H = loc
+		playsound(H, step_sound, 20, 1)
 
 /obj/item/clothing/head/helmet/space/vox/civ/trader/stealth //blackhelmet
 	name = "alien stealth helmet"

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -97,7 +97,7 @@
 	allowed = list(/obj/item/weapon/reagent_containers/food/snacks/grown/banana, /obj/item/weapon/bananapeel, /obj/item/weapon/soap, /obj/item/weapon/reagent_containers/spray, /obj/item/weapon/tank)
 	slowdown = HARDSUIT_SLOWDOWN_LOW
 
-	var/step_sound = "clownstep"
+	var/list/step_sound = step_sound
 	var/footstep = 1	//used for squeeks whilst walking
 
 /obj/item/clothing/suit/space/clown/step_action()

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -97,7 +97,7 @@
 	allowed = list(/obj/item/weapon/reagent_containers/food/snacks/grown/banana, /obj/item/weapon/bananapeel, /obj/item/weapon/soap, /obj/item/weapon/reagent_containers/spray, /obj/item/weapon/tank)
 	slowdown = HARDSUIT_SLOWDOWN_LOW
 
-	var/list/step_sound = step_sound
+	var/list/step_sound = sounds_clownstep
 	var/footstep = 1	//used for squeeks whilst walking
 
 /obj/item/clothing/suit/space/clown/step_action()

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -96,8 +96,7 @@
 	species_restricted = list("exclude",VOX_SHAPED)
 	allowed = list(/obj/item/weapon/reagent_containers/food/snacks/grown/banana, /obj/item/weapon/bananapeel, /obj/item/weapon/soap, /obj/item/weapon/reagent_containers/spray, /obj/item/weapon/tank)
 	slowdown = HARDSUIT_SLOWDOWN_LOW
-
-	var/list/step_sound = sounds_clownstep
+	var/step_sound = "clownstep"
 	var/footstep = 1	//used for squeeks whilst walking
 
 /obj/item/clothing/suit/space/clown/step_action()

--- a/code/modules/mob/living/carbon/human/footsteps.dm
+++ b/code/modules/mob/living/carbon/human/footsteps.dm
@@ -1,6 +1,11 @@
 #define FOOTSOUND_HUMAN 1
 #define FOOTSOUND_VOX 2
 
+var/list/sounds_clownstep = list(
+	'sound/effects/footstep/clownstep1.ogg',
+	'sound/effects/footstep/clownstep2.ogg'
+)
+
 var/list/sounds_asteroid = list(
 	'sound/effects/footstep/asteroid1.ogg',
 	'sound/effects/footstep/asteroid2.ogg',

--- a/code/modules/mob/living/carbon/human/footsteps.dm
+++ b/code/modules/mob/living/carbon/human/footsteps.dm
@@ -4,7 +4,7 @@
 var/list/sounds_clownstep = list(
 	'sound/effects/footstep/clownstep1.ogg',
 	'sound/effects/footstep/clownstep2.ogg'
-)
+	)
 
 var/list/sounds_asteroid = list(
 	'sound/effects/footstep/asteroid1.ogg',

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -205,10 +205,13 @@
 					sounds_to_play = T.footstep_sound
 
 			stepstaken = 0
-			if (!sounds_to_play?.len)
+			if(!sounds_to_play)
 				return
-			playsound(src, pick(sounds_to_play), step_volume, 1, range)
-			
+			if (istype(sounds_to_play, /list) && sounds_to_play.len)
+				playsound(src, pick(sounds_to_play), step_volume, 1, range)
+			else
+				playsound(src, sounds_to_play, step_volume, 1, range)
+				
 
 
 /mob/living/carbon/human/CheckSlip(slip_on_walking = FALSE, overlay_type = TURF_WET_WATER, slip_on_magbooties = FALSE)


### PR DESCRIPTION
Unbeknownst to me `step_sound` can take strings, lists, and assoc lists.... which is a problem. This PR standardizes it a little bit, except for special items.

## What this does
- changes clownshoes to `var/list/step_sound` instead of a string, but keeps the special cases and checks them in human_movement.dm appropriately

## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
Closes #37841

## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
- hosted server, used clownshoes, advanced clownshoes, psychclownshoes, we got squeaks, random squeaks, specific sounds, etc.
- no runtimes

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: clownshoes work again