### PR TITLE
Revert "fix turf/area runtime"

### DIFF
--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -331,11 +331,8 @@ var/list/map_dimension_cache = list()
 	if(!isarea(instance))
 		WARNING("Instance at [members[index]] is not an area!")
 	if(!isspace(instance)) //Space is the default area and contains every loaded turf by default
-		var/turf/T = locate(xcrd,ycrd,zcrd)
-		if(T)
-			var/area/old_area = get_area(T) // Use get_area() instead of direct access
-			T.change_area(old_area, instance)
-			spawned_atoms.Add(instance)
+		instance.contents.Add(locate(xcrd,ycrd,zcrd))
+		spawned_atoms.Add(instance)
 
 	if(use_preloader && instance)
 		_preloader.load(instance)


### PR DESCRIPTION
Reverts vgstation-coders/vgstation13#37823

we're guessing this is causing the off-station area fuckery

~~i did not even partially test this~~ 
I did test this and it fixes the DJ sat area, as well as the derelict. Thus this resolves #37840 and resolves #37839.
~~@adacovsk test your code a lil more so we don't run into this kinda shit again.~~
honestly i don't know how you'd even test for this since it doesn't seem to throw any runtimes or other issues