### PR TITLE
Fix fuel temp forgetfulness

### DIFF
--- a/code/modules/blacksmithing/forge.dm
+++ b/code/modules/blacksmithing/forge.dm
@@ -96,7 +96,6 @@
 	switch(status)
 		if(TRUE) //turning it off
 			status = FALSE
-			current_temp = 0
 			processing_objects.Remove(src)
 		if(FALSE)//turning it on
 			status = TRUE
@@ -162,8 +161,10 @@
 //Prefer to burn through sheets over ores
 /obj/structure/forge/proc/has_fuel()
 	fuel_time = max(0, fuel_time-1)
-	if(fuel_time <= 0 && status)
-		toggle_lit()
+	if(fuel_time <= 0)
+		current_temp = 0
+		if(status)
+			toggle_lit()
 	return fuel_time
 
 /obj/structure/forge/is_hot()


### PR DESCRIPTION
# Forge Fuel Temperature Fix

## What this does
When a forge is extinguished by means such as water, it forgets what "fuel" was in the forge. If relit, it doesn't properly set the temperature. This PR fixes #37849 so that a relit forge will be at the same temperature it was at before.

## Why it's good
Because you can no longer ruin a blacksmith's day by splashing a little bit of water in their blazing hot plasma furnace, it's not.

## How it was tested
It wasn't.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Forges quenched with water remember what fuel they had when relit.

[bugfix]