### PR TITLE
arcane tampered door fix

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -407,29 +407,34 @@ var/list/all_doors = list()
 	// Cache current z-level for comparison
 	var/current_z = src.z
 	
-	// Filter valid doors with optimized conditions
-	var/list/valid_doors = list()
-	for(var/obj/machinery/door/door in all_doors)
-		if(door.z != current_z)
-			continue
-		if(!door.arcane_linkable())
-			continue
-		if(door == src)
-			continue
-		valid_doors += door
+	// Track doors we've tested and found invalid
+	var/list/tested_invalid = list()
+	var/attempts = 0
+	var/max_attempts = all_doors.len // Can't be more attempts than total doors
 	
-	// No valid doors found
-	if(!valid_doors.len)
-		return ""
+	while(attempts < max_attempts)
+		// Create candidate pool excluding tested invalid doors and self
+		var/list/candidates = all_doors - tested_invalid - src
+		
+		// No more candidates to test
+		if(!candidates.len)
+			break
+		
+		var/obj/machinery/door/candidate = pick(candidates)
+		
+		// Check if this door is valid
+		if(candidate.z == current_z && candidate.arcane_linkable())
+			// Found valid door - set up bidirectional linking
+			arcane_linked_door = candidate
+			candidate.arcanetampered = arcanetampered
+			candidate.arcane_linked_door = src
+			return "D'R ST'K!"
+		
+		// Door was invalid - add to exclusion list for next iteration
+		tested_invalid += candidate
+		attempts++
 	
-	// Select a random valid door
-	arcane_linked_door = pick(valid_doors)
-	
-	// Set up bidirectional linking
-	arcane_linked_door.arcanetampered = arcanetampered
-	arcane_linked_door.arcane_linked_door = src
-	
-	return "D'R ST'K!"
+	return ""
 
 /obj/machinery/door/proc/arcane_linkable()
 	// no windoors, blocked doors or centcomm pls

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -399,16 +399,37 @@ var/list/all_doors = list()
 
 /obj/machinery/door/arcane_act(mob/user)
 	..()
-	if(arcane_linkable() && all_doors.len > 1)
-		var/list/door_selection = all_doors.Copy()
-		while(!arcane_linked_door || arcane_linked_door == src || arcane_linked_door.z != src.z || !arcane_linked_door.arcane_linkable())
-			arcane_linked_door = pick_n_take(door_selection)
-			if(!door_selection.len)
-				break
-		if(arcane_linked_door)
-			arcane_linked_door.arcanetampered = arcanetampered
-			arcane_linked_door.arcane_linked_door = src
-		return "D'R ST'K!"
+	
+	// Early exit if linking isn't possible
+	if(!arcane_linkable() || all_doors.len <= 1)
+		return ""
+	
+	// Cache current z-level for comparison
+	var/current_z = src.z
+	
+	// Filter valid doors with optimized conditions
+	var/list/valid_doors = list()
+	for(var/obj/machinery/door/door in all_doors)
+		if(door.z != current_z)
+			continue
+		if(!door.arcane_linkable())
+			continue
+		if(door == src)
+			continue
+		valid_doors += door
+	
+	// No valid doors found
+	if(!valid_doors.len)
+		return ""
+	
+	// Select a random valid door
+	arcane_linked_door = pick(valid_doors)
+	
+	// Set up bidirectional linking
+	arcane_linked_door.arcanetampered = arcanetampered
+	arcane_linked_door.arcane_linked_door = src
+	
+	return "D'R ST'K!"
 
 /obj/machinery/door/proc/arcane_linkable()
 	// no windoors, blocked doors or centcomm pls


### PR DESCRIPTION
- sometimes some arcane tampered doors don't work (the spell fails) and the door works as normal and you can't tamper them again

## What this does
- makes the code more readable
- might make the code slightly faster? (O(1) most likely, O(n) at worst, as opposed to copy lists and iterating through whole list)
- allows for doors to be tampered again

## Why it's good
- it's no fun if your spell fails and you can't cast the spell on the door again
- Closes #36905


## How it was tested
- tampered like 50 doors
![image](https://github.com/user-attachments/assets/96b04149-3cc8-4bf3-8785-24c1e8403080)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: can cast arcane tamper on doors again after already tampered/bugged out