### PR TITLE
Lightreplacer runtime

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -80,7 +80,12 @@ This used to be handled by attackby() on the light fixtures and bulbs themselves
 	if(!gather_loc || !isturf(gather_loc))
 		return 0
 	var/obj/machinery/light/lightfixture = locate() in gather_loc.contents
+	if(!lightfixture)
+		return 0
 	var/obj/item/weapon/light/best_light = get_best_light(lightfixture)
+	if(!best_light)
+		to_chat(user, span_warning("No suitable light bulbs available in [src]."))
+		return 0
 	if(lightfixture && lightfixture.current_bulb && is_light_better(best_light, lightfixture.current_bulb))
 		. = ReplaceLight(lightfixture, usr)
 		return .

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -80,7 +80,7 @@ This used to be handled by attackby() on the light fixtures and bulbs themselves
 	if(!gather_loc || !isturf(gather_loc))
 		return 0
 	var/obj/machinery/light/lightfixture = locate() in gather_loc.contents
-	if(!lightfixture || !lightfixture.current_bulb)
+	if(!lightfixture && !lightfixture.current_bulb)
 		return 0
 	var/obj/item/weapon/light/best_light = get_best_light(lightfixture)
 	if(!best_light)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -84,9 +84,7 @@ This used to be handled by attackby() on the light fixtures and bulbs themselves
 		// No light fixture found, try to gather light items from the turf
 		for(var/obj/O in gather_loc.contents)
 			. = insert_if_possible(O)
-			if(.)
-				return .
-		return 0
+		return .
 	
 	var/obj/item/weapon/light/best_light = get_best_light(lightfixture)
 	if(!best_light)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -80,12 +80,12 @@ This used to be handled by attackby() on the light fixtures and bulbs themselves
 	if(!gather_loc || !isturf(gather_loc))
 		return 0
 	var/obj/machinery/light/lightfixture = locate() in gather_loc.contents
-	if(!lightfixture)
+	if(!lightfixture || !lightfixture.current_bulb)
 		return 0
 	var/obj/item/weapon/light/best_light = get_best_light(lightfixture)
 	if(!best_light)
 		return 0
-	if(lightfixture && lightfixture.current_bulb && is_light_better(best_light, lightfixture.current_bulb))
+	if(is_light_better(best_light, lightfixture.current_bulb))
 		. = ReplaceLight(lightfixture, usr)
 		return .
 	else if(lightfixture && !lightfixture.current_bulb)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -84,7 +84,6 @@ This used to be handled by attackby() on the light fixtures and bulbs themselves
 		return 0
 	var/obj/item/weapon/light/best_light = get_best_light(lightfixture)
 	if(!best_light)
-		to_chat(user, span_warning("No suitable light bulbs available in [src]."))
 		return 0
 	if(lightfixture && lightfixture.current_bulb && is_light_better(best_light, lightfixture.current_bulb))
 		. = ReplaceLight(lightfixture, usr)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -80,22 +80,24 @@ This used to be handled by attackby() on the light fixtures and bulbs themselves
 	if(!gather_loc || !isturf(gather_loc))
 		return 0
 	var/obj/machinery/light/lightfixture = locate() in gather_loc.contents
-	if(!lightfixture && !lightfixture.current_bulb)
+	if(!lightfixture)
+		// No light fixture found, try to gather light items from the turf
+		for(var/obj/O in gather_loc.contents)
+			. = insert_if_possible(O)
+			if(.)
+				return .
 		return 0
+	
 	var/obj/item/weapon/light/best_light = get_best_light(lightfixture)
 	if(!best_light)
 		return 0
-	if(is_light_better(best_light, lightfixture.current_bulb))
-		. = ReplaceLight(lightfixture, usr)
+	
+	// Replace light if fixture has no bulb or if we have a better bulb
+	if(!lightfixture.current_bulb || is_light_better(best_light, lightfixture.current_bulb))
+		. = ReplaceLight(lightfixture, user)
 		return .
-	else if(lightfixture && !lightfixture.current_bulb)
-		. = ReplaceLight(lightfixture, usr)
-		if(.)
-			return .
-	else
-		for(var/obj/O in gather_loc.contents)
-			. = insert_if_possible(O)
-		return .
+	
+	return 0
 
 /obj/item/device/lightreplacer/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/stack/sheet/glass/glass))

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -92,8 +92,7 @@ This used to be handled by attackby() on the light fixtures and bulbs themselves
 	
 	// Replace light if fixture has no bulb or if we have a better bulb
 	if(!lightfixture.current_bulb || is_light_better(best_light, lightfixture.current_bulb))
-		. = ReplaceLight(lightfixture, user)
-		return .
+		return ReplaceLight(lightfixture, user)
 	
 	return 0
 


### PR DESCRIPTION
something other than light fixtures are being passed to lightreplacer. #37816 helped me find the root of the problem

## What this does
- adds some checks for lightreplacer
- original PR didn't look into what was being passed, this PR does
- 0 being passed to best_light which likely means no fixture
- just more checks

## Why it's good
- eliminate runtime

## How it was tested
- hosted server, tested random items in boxes for light replacer, replaced lights, replaced broken lights ,etc.
