### PR TITLE
View Variables Hotfix

### DIFF
--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -27,7 +27,7 @@ var/list/forbidden_varedit_object_types = list(
 	if(!C.can_edit_var(edited_variable, edited_datum?.type))
 		return
 
-	if(!edited_datum.can_edit_var(edited_variable))
+	if(istype(edited_datum, /datum) && !edited_datum.can_edit_var(edited_variable))
 		return
 
 	//Special case for "appearance", because appearance values can't be stored anywhere.


### PR DESCRIPTION
# VV Lists Work

## What this does
Fixes #37851. Caused by #37615. In an attempt to stop admins from accidentally breaking SQL by touching bad variables in a specific preferences datum, it also breaks any attempt to edit a list variable at all.

## Why it's good
Turnip made this bug report while trying to change rotisserie meat for some reason. If his plot was successful, terrible things might've happened. Is fixing this bug good? It's not.

## How it was tested
Ye olde test server. VV'd a variety of variables to confirm the effects of the bug. Confirmed the effects. Then implemented the change. The bug effects are no longer reproducible.
![image](https://github.com/user-attachments/assets/fec26633-51a0-493e-83b4-91ce1575f350)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Admins can VV lists again.
