### PR TITLE
Crate Affordability Messaging Fix

### DIFF
--- a/code/game/machinery/computer/cargo.dm
+++ b/code/game/machinery/computer/cargo.dm
@@ -467,7 +467,10 @@ For vending packs, see vending_packs.dm*/
 		// check they can afford the order
 		if(P.cost * crates + total_money_req > account.money)
 			var/max_crates = round((account.money - total_money_req) / P.cost)
-			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
+			if(max_crates > 0)
+				to_chat(usr, "<span class='warning'>You can only afford [max_crates] crate[max_crates == 1 ? "" : "s"].</span>")
+			else
+				to_chat(usr, "<span class='warning'>You cannot afford any crates.</span>")
 			return
 		var/timeout = world.time + 600
 		var/reason = stripped_input(usr,"Why do you want this crate and where/to whom would you like it sent?","Reason/Destination:","",REASON_LEN)
@@ -833,7 +836,10 @@ For vending packs, see vending_packs.dm*/
 		if((P.cost * crates + total_money_req > account.money))
 			// Tell them how many they can actually afford if they can't afford their order
 			var/max_crates = round((account.money - total_money_req) / P.cost)
-			to_chat(usr, "<span class='warning'>You can only afford [max_crates] crates.</span>")
+			if(max_crates > 0)
+				to_chat(usr, "<span class='warning'>You can only afford [max_crates] crate[max_crates == 1 ? "" : "s"].</span>")
+			else
+				to_chat(usr, "<span class='warning'>You cannot afford any crates.</span>")
 			return
 		var/reason = stripped_input(usr,"Why do you want this crate and where/to whom would you like it sent?","Reason/Destination:","",REASON_LEN)
 		if(world.time > timeout)


### PR DESCRIPTION
# I can no longer afford 1 crates.

## What this does
Fixes #11988 and #37863 by changing the messaging around a bit. It now properly changes the message based on the number of crates you can afford.

## Why it's good
Because it fixes a long standing cargo quirk when mass-ordering crates that some may claim as "sovl", it's not. (RIP sovl)

## How it was tested
Used both the cargo side and public side computers.
![image](https://github.com/user-attachments/assets/b3648b02-9b6b-46c2-95cc-0c575badfde6)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * spellcheck: Fixed wonky cargo computer mass-crate-ordering messages.