### PR TITLE
Various Economy Account Fixes

### DIFF
--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -433,13 +433,18 @@ var/station_bonus = 0 //A bonus to station allowance that gets reset after wage 
 				station_bonus = new_bonus
 			if("toggle_account")
 				if(detailed_account_view)
-					detailed_account_view.disabled = detailed_account_view.disabled ? 0 : 2
+					if(detailed_account_view == station_account)
+						visible_message("<span class='warning'>The station account cannot be modified in this way.</span>")
+					else
+						detailed_account_view.disabled = detailed_account_view.disabled ? 0 : 2
 			if("edit_wage_payout")
 				var/acc_num = text2num(href_list["account_num"])
 				var/datum/money_account/acc = get_money_account_global(acc_num)
-				if(acc)
+				if(acc == station_account)
+					visible_message("<span class='warning'>The station account cannot be modified in this way.</span>")
+				else if(acc)
 					var/new_payout = input(usr, "Select a new payout for this account", "New payout", acc.wage_gain) as null|num
-					if(new_payout >= 0 && new_payout != null)
+					if(new_payout != null && new_payout >= 0)
 						if(new_payout > ARBITRARILY_LARGE_NUMBER)
 							//10x what the entire station should be earning
 							spark(loc, 3, FALSE)

--- a/code/modules/Economy/AdminTools.dm
+++ b/code/modules/Economy/AdminTools.dm
@@ -37,7 +37,7 @@
                 var/datum/money_account/acc = get_money_account_global(acc_num)
                 if(acc)
                     var/new_payout = input(usr, "Select a new payout for this account", "New payout", acc.wage_gain) as null|num
-                    if(new_payout && new_payout >= 0)
+                    if(new_payout != null && new_payout >= 0)
                         acc.wage_gain = new_payout
                     detailed_account_view = acc
 


### PR DESCRIPTION
# But I wanna be paid 2.29179e+07!

## What this does
This fixes #36650 by prohibiting the station account's wages by being tampered with. Also fixes a bug with the admin econ panel where wages could not be set to 0. Finally, prevents the station account from being administratively disabled.

## Why it's good
Because you can no longer make infinite money by merely changing a number, it's not.

## How it was tested
Attempted to use the account db to do bad things to the station account and failed.
Before:
![image](https://github.com/user-attachments/assets/93fff375-f472-46fc-b759-f91bf87085fc)
After:
![image](https://github.com/user-attachments/assets/a7b66b2b-ecba-49ea-90fe-f78feac17be8)

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * bugfix: Fixed an exploit with the account DB where someone could set the station to be paid infinite money from a mysterious source.