### PR TITLE
Machine upgrades add to roundend score

### DIFF
--- a/__DEFINES/setup.dm
+++ b/__DEFINES/setup.dm
@@ -1213,6 +1213,7 @@ var/default_colour_matrix = list(1,0,0,0,\
 #define SHUTTLEWRENCH	1024 //if this flag exists, the computer can be wrenched on shuttle floors
 #define SECUREDPANEL 2048 //it won't let you open the deconstruction panel if you don't have the linked account number. Originally used for custom vending machines
 #define MULTIOUTPUT 4096 //Let's you set the output location with a multitool
+#define UPGRADENOSCORE 8192 //Incase the machine use is nothing but malicious
 
 #define MAX_N_OF_ITEMS 999 // Used for certain storage machinery, BYOND infinite loop detector doesn't look things over 1000.
 

--- a/code/game/gamemodes/endgame/scoreboard/department_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/department_score.dm
@@ -73,7 +73,7 @@
 	score.crewscore += score.powerbonus
 	score.crewscore -= score.atmoloss * 50 //You too, atmos techs
 	score.crewscore += score.atmobonus
-	score.crewscore += score.machineupgrades * 10 //Mechanics reap rewards too now
+	score.crewscore += score.machineupgrades * 5 //Mechanics reap rewards too now
 
 /datum/controller/gameticker/scoreboard/proc/service_score()
 	//Janitor

--- a/code/game/gamemodes/endgame/scoreboard/department_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/department_score.dm
@@ -73,6 +73,7 @@
 	score.crewscore += score.powerbonus
 	score.crewscore -= score.atmoloss * 50 //You too, atmos techs
 	score.crewscore += score.atmobonus
+	score.crewscore += score.machineupgrades * 10 //Mechanics reap rewards too now
 
 /datum/controller/gameticker/scoreboard/proc/service_score()
 	//Janitor

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -157,7 +157,7 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	dat += "<B>Whole Station Powered:</B> [score.powerbonus ? "Yes" : "No"] ([score.powerbonus] Points)<BR>"
 	dat += "<B>Whole Station Airtight:</B> [score.atmobonus ? "Yes" : "No"] ([score.atmobonus] Points)<BR>"
 	if (score.machineupgrades > 0)
-		dat += "<B>Total Machine Upgrade Ratings:</B> [score.machineupgrades] ([score.machineupgrades * 10] Points)<BR>"
+		dat += "<B>Total Machine Upgrade Ratings:</B> [score.machineupgrades] ([score.machineupgrades * 5] Points)<BR>"
 	if (score.disease_vaccine_score > 0)
 		dat += "<B>Isolated Vaccines:</B> [score.disease_vaccine] ([score.disease_vaccine_score] Points)<BR>"
 	if (score.disease_extracted > 0)

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -2,29 +2,39 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 
 /datum/controller/gameticker/scoreboard
 	var/crewscore 			= 0 //This is the overall var/score for the whole round
+
 	var/plasmashipped		= 0 //How much plasma has been sent to centcom?
 	var/stuffshipped		= 0 //How many centcom orders have cargo fulfilled?
 	var/stuffforwarded		= 0 //How many cargo forwards have been fulfilled?
 	var/stuffnotforwarded	= 0 //How many cargo forwards have not been fulfilled?
+
 	var/stuffharvested		= 0 //How many harvests have hydroponics done (per crop)?
 	var/oremined			= 0 //How many chunks of ore were smelted
+	var/meals				= 0 //How much food was actively cooked that day
+	var/slimes				= 0 //How many slimes were harvested
+	var/artifacts			= 0 //How many large artifacts were analyzed and activated
+
 	var/eventsendured		= 0 //How many random events did the station endure?
+
 	var/powerloss			= 0 //How many APCs have alarms (under 30 %)?
 	var/atmoloss			= 0 //How many air alarms are giving issues?
 	var/powerbonus			= 0 //If all APCs on the station are running optimally, big bonus
 	var/atmobonus			= 0 //If all air alarms on the station are running optimally, big bonus
 	var/maxpower			= 0 //Most watts in grid on any of the world's powergrids.
+
+	var/machineupgrades		= 0 //How many machines were upgraded?
+
 	var/escapees			= 0 //How many people got out alive?
 	var/deadcrew			= 0 //Humans who died during the round
 	var/deadsilicon			= 0 //Silicons who died during the round
 	var/deadaipenalty		= 0 //AIs who died during the round
 	var/rescuedpets			= 0 //how many pets were brought back to centcomm (alive)
 	var/rescueianbonus		= 0 //ian is a special little guy :)
+
 	var/mess				= 0 //How much messes on the floor went uncleaned
 	var/litter				= 0 //How much trash is laying on the station floor
-	var/meals				= 0 //How much food was actively cooked that day
-	var/slimes				= 0 //How many slimes were harvested
-	var/artifacts			= 0 //How many large artifacts were analyzed and activated
+	var/messbonus			= 0 //If there are no messes on the station anywhere, huge bonus
+
 	var/disease_good		= 0 //How many unique diseases currently affecting living mobs of cumulated danger <3
 	var/disease_vaccine		= null //Which many vaccine antibody isolated
 	var/disease_vaccine_score= 0 //the associated score
@@ -33,11 +43,12 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	var/disease_bad			= 0 //How many unique diseases currently affecting living mobs of cumulated danger >= 3
 	var/disease_most		= null //Most spread disease
 	var/disease_most_count	= 0 //Most spread disease
+
 	var/turfssingulod		= 0 //Amount of turfs eaten by singularities.
+
 	var/static/list/badvars		= list("deadcrew","deadsilicon","deadaipenalty","mess","litter","powerloss","atmoloss","stuffnotforwarded","disease_bad","turfssingulod")
 
 	//These ones are mainly for the stat panel
-	var/messbonus			= 0 //If there are no messes on the station anywhere, huge bonus
 	var/foodeaten			= 0 //How much food was consumed
 	var/clownabuse			= 0 //How many times a clown was punched, struck or otherwise maligned
 	var/slips				= 0 //How many people have slipped during this round
@@ -145,6 +156,8 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 		dat += "<B>Rescued Pets:</B> [score.rescuedpets] ([score.rescuedpets*50 + score.rescueianbonus] Points<BR>)"	
 	dat += "<B>Whole Station Powered:</B> [score.powerbonus ? "Yes" : "No"] ([score.powerbonus] Points)<BR>"
 	dat += "<B>Whole Station Airtight:</B> [score.atmobonus ? "Yes" : "No"] ([score.atmobonus] Points)<BR>"
+	if (score.machineupgrades > 0)
+		dat += "<B>Total Machine Upgrade Ratings:</B> [score.machineupgrades] ([score.machineupgrades * 10] Points)<BR>"
 	if (score.disease_vaccine_score > 0)
 		dat += "<B>Isolated Vaccines:</B> [score.disease_vaccine] ([score.disease_vaccine_score] Points)<BR>"
 	if (score.disease_extracted > 0)

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -157,7 +157,7 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	dat += "<B>Whole Station Powered:</B> [score.powerbonus ? "Yes" : "No"] ([score.powerbonus] Points)<BR>"
 	dat += "<B>Whole Station Airtight:</B> [score.atmobonus ? "Yes" : "No"] ([score.atmobonus] Points)<BR>"
 	if (score.machineupgrades > 0)
-		dat += "<B>Total Machine Upgrade Ratings:</B> [score.machineupgrades] ([score.machineupgrades * 5] Points)<BR>"
+		dat += "<B>Total Upgraded Machines Rating:</B> [score.machineupgrades] ([score.machineupgrades * 5] Points)<BR>"
 	if (score.disease_vaccine_score > 0)
 		dat += "<B>Isolated Vaccines:</B> [score.disease_vaccine] ([score.disease_vaccine_score] Points)<BR>"
 	if (score.disease_extracted > 0)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -197,7 +197,7 @@
 									O.forceMove(components_in_use)
 								else
 									O.forceMove(null)
-								new_machine.component_parts += O
+								new_machine.add_part(O)
 							if(circuit.contain_parts)
 								circuit.forceMove(components_in_use)
 							else

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -159,6 +159,8 @@ Class Procs:
 	var/obj/item/weapon/card/id/scan = null	//ID inserted for identification, if applicable
 	var/id_tag = null // Identify the machine
 
+	var/upgrades_to_score = TRUE //Incase the machine use is nothing but malicious
+
 /obj/machinery/cultify()
 	var/list/random_structure = list(
 		/obj/structure/cult_legacy/talisman,
@@ -204,7 +206,8 @@ Class Procs:
 			AM.forceMove(loc)
 			component_parts -= AM
 */
-	component_parts = null
+	for(var/part in component_parts)
+		remove_part(part)
 	for(var/datum/malfhack_ability/MH in hack_abilities)
 		MH.machine = null
 		qdel(MH)
@@ -561,6 +564,7 @@ Class Procs:
 
 /obj/machinery/proc/spillContents(var/destroy_chance = 0)
 	for(var/obj/I in component_parts)
+		remove_part(I)
 		if(prob(destroy_chance))
 			qdel(I)
 		else
@@ -797,8 +801,8 @@ Class Procs:
 						if(B.get_rating() > A.get_rating())
 							W.remove_from_storage(B, src)
 							W.handle_item_insertion(A, 1)
-							component_parts -= A
-							component_parts += B
+							remove_part(A)
+							add_part(B)
 							B.forceMove(null)
 							to_chat(user, "<span class='notice'>[A.name] replaced with [B.name].</span>")
 							shouldplaysound = 1 //Only play the sound when parts are actually replaced!
@@ -812,6 +816,16 @@ Class Procs:
 				to_chat(user, "<span class='notice'>    [C.name]</span>")
 		return 1
 	return 0
+
+/obj/machinery/proc/add_part(obj/item/weapon/stock_parts/S, atom/location)
+	component_parts += S
+	if(upgrades_to_score && istype(S) && (S.rating > 1))
+		score.machineupgrades += (S.rating - 1)
+
+/obj/machinery/proc/remove_part(obj/item/weapon/stock_parts/S)
+	component_parts -= S
+	if(upgrades_to_score && istype(S) && (S.rating > 1))
+		score.machineupgrades -= (S.rating - 1)
 
 //exclusively for use with machines being made from the flatpacker
 //works like the parts exchange but because we only call this from a certain location
@@ -834,8 +848,8 @@ Class Procs:
 			for(var/obj/item/B in M)
 				if(istype(B, P) && istype(A, P))
 					if(B.get_rating() > A.get_rating()) //base rating parts should not be added (they already shouldn't be in this list, but whatever)
-						component_parts -= A
-						component_parts += B
+						remove_part(A)
+						add_part(B)
 						M -= B //if you don't remove the part, one upgraded part will replace everything in the recipe
 						B.forceMove(null)
 						break

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -159,8 +159,6 @@ Class Procs:
 	var/obj/item/weapon/card/id/scan = null	//ID inserted for identification, if applicable
 	var/id_tag = null // Identify the machine
 
-	var/upgrades_to_score = TRUE //Incase the machine use is nothing but malicious
-
 /obj/machinery/cultify()
 	var/list/random_structure = list(
 		/obj/structure/cult_legacy/talisman,
@@ -819,12 +817,12 @@ Class Procs:
 
 /obj/machinery/proc/add_part(obj/item/weapon/stock_parts/S, atom/location)
 	component_parts += S
-	if(upgrades_to_score && istype(S) && (S.rating > 1))
+	if(!(machine_flags & UPGRADENOSCORE) && istype(S) && (S.rating > 1))
 		score.machineupgrades += (S.rating - 1)
 
 /obj/machinery/proc/remove_part(obj/item/weapon/stock_parts/S)
 	component_parts -= S
-	if(upgrades_to_score && istype(S) && (S.rating > 1))
+	if(!(machine_flags & UPGRADENOSCORE) && istype(S) && (S.rating > 1))
 		score.machineupgrades -= (S.rating - 1)
 
 //exclusively for use with machines being made from the flatpacker

--- a/code/game/objects/items/weapons/storage/RPED.dm
+++ b/code/game/objects/items/weapons/storage/RPED.dm
@@ -23,6 +23,7 @@
 
 /obj/item/weapon/storage/bag/gadgets/part_replacer/bluespace/admin
 	var/stock_rating = 4
+	admin_desc = "This one seems to have infinite parts. Use this in hand to change the ratings of stock parts applied."
 
 /obj/item/weapon/storage/bag/gadgets/part_replacer/bluespace/admin/attack_self(mob/user)
 	if(user.check_rights(R_ADMIN))

--- a/code/game/objects/items/weapons/storage/RPED.dm
+++ b/code/game/objects/items/weapons/storage/RPED.dm
@@ -21,6 +21,28 @@
 	storage_slots = 200
 	bluespace = TRUE
 
+/obj/item/weapon/storage/bag/gadgets/part_replacer/bluespace/admin
+	var/stock_rating = 4
+
+/obj/item/weapon/storage/bag/gadgets/part_replacer/bluespace/admin/attack_self(mob/user)
+	if(user.check_rights(R_ADMIN))
+		stock_rating = clamp(input(user,"Which part rating to use?","Part ratings",4) as num,2,4)
+	else
+		..()
+
+/obj/item/weapon/storage/bag/gadgets/part_replacer/bluespace/admin/preattack(atom/target, mob/user, adjacent, params)
+	if(user.check_rights(R_ADMIN))
+		QDEL_LIST(contents)
+		if(stock_rating > 1)
+			for(var/part in subtypesof(/obj/item/weapon/stock_parts))
+				var/obj/item/weapon/stock_parts/S = part
+				if(initial(S.rating) >= stock_rating)
+					for(var/i in 1 to 10)
+						new part(src)
+						handle_item_insertion(S, 1)	
+		to_chat(user,"[src] contains: [counted_english_list(contents)]")
+	. = ..()
+
 /obj/item/weapon/storage/bag/gadgets/part_replacer/proc/play_rped_sound()
 	//Plays the sound for RPED exhanging or installing parts.
 	playsound(src, 'sound/items/rped.ogg', 40, 1)

--- a/code/game/objects/items/weapons/storage/RPED.dm
+++ b/code/game/objects/items/weapons/storage/RPED.dm
@@ -36,7 +36,7 @@
 		if(stock_rating > 1)
 			for(var/part in subtypesof(/obj/item/weapon/stock_parts))
 				var/obj/item/weapon/stock_parts/S = part
-				if(initial(S.rating) >= stock_rating)
+				if(initial(S.rating) == stock_rating)
 					for(var/i in 1 to 10)
 						new part(src)
 						handle_item_insertion(S, 1)	

--- a/code/modules/research/mechanic/component_exchanger.dm
+++ b/code/modules/research/mechanic/component_exchanger.dm
@@ -182,10 +182,10 @@
 
 
 	//Move the old part into our component exchanger
-	M.component_parts -= P
+	M.remove_part(P)
 	handle_item_insertion(P, 1)
 	//Move the new part into the machine
 	remove_from_storage(R, M)
-	M.component_parts += R
+	M.add_part(R)
 	//Update the machine's parts
 	playsound(src, 'sound/items/Deconstruct.ogg', 50, 1) //User feedback


### PR DESCRIPTION
[content]

## What this does
in particular, it adds 5 points to the score for any rating above 1 per part, so for example the application of 5 tier 4 parts would net 75 points (15 (rating minus 1 time 5) times 5)
adds an admin version of the bluespace RPED that never runs out of certain tier parts when used by an admin, selectable on self use only for admins.

## Why it's good
incentivises and rewards doing this properly.

## How it was tested
applying upgrades to machines, destroying some of them, ending the round.

## Changelog
:cl:
 * rscadd: Machine upgrades now add to the round end score, at the rate of 5 points for every part rating above 1, per part. Removing or destroying these parts in machines subtracts from this score.
