### PR TITLE
removes jungle from rotation

### DIFF
--- a/code/datums/next_map.dm
+++ b/code/datums/next_map.dm
@@ -185,6 +185,9 @@
 	path = "junglestation"
 	min_players=1 //placeholders - adjust later. Or don't. maybe it'll be fun in deadpop and highpop.
 	max_players=99
+//disabled voting. re-enable when jungle is good to run full time. should still be able to be bussed like this.
+/datum/next_map/junglestation/is_votable()
+	return FALSE
 
 /proc/get_votable_maps()
 	var/list/votable_maps = list()


### PR DESCRIPTION
reopen of #37821
it was voted on, 10 for, 20 against

## Changelog
:cl:
 * rscdel: NanoTrasen has taken note of employee complaints, and has unassigned all personnel from NT Colony Gamma-8, to be further renovated until it is up to standards. (Junglestation is no longer voteable, thank you for the feedback. Remember that suggestions and bug reports are still being taken.)
