### PR TITLE
null ref runtime fix?

### DIFF
--- a/code/_hooks/events.dm
+++ b/code/_hooks/events.dm
@@ -352,6 +352,13 @@
 		var/procName = handler[EVENT_HANDLER_PROCNAME_INDEX]
 		// not |= because `null |= list()` is a runtime error
 		// but `null = null | list()` is not.
+
+		// Check if object still exists
+		if(isnull(objRef) || QDELETED(objRef))
+			// Clean up dead reference
+			event_handlers -= key
+			continue
+
 		. = . | call(objRef, procName)(arglist(arguments))
 
 /**

--- a/code/_hooks/events.dm
+++ b/code/_hooks/events.dm
@@ -354,7 +354,7 @@
 		// but `null = null | list()` is not.
 
 		// Check if object still exists
-		if(isnull(objRef) || QDELETED(objRef))
+		if(isnull(objRef))
 			// Clean up dead reference
 			event_handlers -= key
 			continue

--- a/code/_hooks/events.dm
+++ b/code/_hooks/events.dm
@@ -354,7 +354,7 @@
 		// but `null = null | list()` is not.
 
 		// Check if object still exists
-		if(isnull(objRef))
+		if(isnull(objRef) || QDELETED(objRef))
 			// Clean up dead reference
 			event_handlers -= key
 			continue


### PR DESCRIPTION
```
[17:59:42] Runtime in code/_hooks/events.dm,355: Cannot execute null.target_density_change().
  proc name: invoke event (/datum/proc/invoke_event)
  src: the plating (227,261,1) (/turf/simulated/floor/plating)
  call stack:
  the plating (227,261,1) (/turf/simulated/floor/plating): invoke event(/event/density_change (/event/density_change), /list (/list))
  the plating (227,261,1) (/turf/simulated/floor/plating): densityChanged()
  the metal rod (/obj/item/stack/rods): densityChanged()
  the metal rod (/obj/item/stack/rods): setDensity(1)
  the metal rod (/obj/item/stack/rods): GotoAirflowDest(6.02884)
  /connection_edge/unsimulated (/connection_edge/unsimulated): flow(/list (/list), 60.2884, 0)
  /connection_edge/unsimulated (/connection_edge/unsimulated): tick()
  Air (/datum/subsystem/air): process part(3)
  Air (/datum/subsystem/air): fire(0)
  Air (/datum/subsystem/air): ignite(1)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing()
```

## What this does
Getting a lot of these runtimes, which I don't know much about. This is just a Claude Sonnet 4 response

## Why it's good
- removes null ref events

## How it was tested
untested