### PR TITLE
Makes roundend score affect next round's broken light, broken camera, and filth persistence levels.

### DIFF
--- a/code/controllers/subsystem/init/more_init_stuff.dm
+++ b/code/controllers/subsystem/init/more_init_stuff.dm
@@ -10,7 +10,7 @@ var/datum/subsystem/more_init/SSmore_init
 
 /datum/subsystem/more_init/Initialize(timeofday)
 	log_debug("Last crew score: [last_crewscore], camera break chance: [clamp(10-(last_crewscore/1000),0,25)],\
-		light tube break chance: [clamp(2-(last_crewscore/1000),0,4)], light bulb break chance: [clamp(5-(last_crewscore/1000),0,10)]")
+		light tube break chance: [clamp(2-(last_crewscore/5000),0,4)], light bulb break chance: [clamp(5-(last_crewscore/2000),0,10)]")
 	initialize_rune_words()
 	library_catalog.initialize()
 	init_mind_ui()

--- a/code/controllers/subsystem/init/more_init_stuff.dm
+++ b/code/controllers/subsystem/init/more_init_stuff.dm
@@ -9,6 +9,8 @@ var/datum/subsystem/more_init/SSmore_init
 	NEW_SS_GLOBAL(SSmore_init)
 
 /datum/subsystem/more_init/Initialize(timeofday)
+	log_debug("Last crew score: [last_crewscore], camera break chance: [clamp(10-(last_crewscore/1000),0,25)],\
+		light tube break chance: [clamp(2-(last_crewscore/1000),0,4)], light bulb break chance: [clamp(5-(last_crewscore/1000),0,10)]")
 	initialize_rune_words()
 	library_catalog.initialize()
 	init_mind_ui()

--- a/code/controllers/subsystem/init/more_init_stuff.dm
+++ b/code/controllers/subsystem/init/more_init_stuff.dm
@@ -9,7 +9,7 @@ var/datum/subsystem/more_init/SSmore_init
 	NEW_SS_GLOBAL(SSmore_init)
 
 /datum/subsystem/more_init/Initialize(timeofday)
-	log_debug("Last crew score: [last_crewscore], camera break chance: [clamp(10-(last_crewscore/1000),0,25)],\
+	log_debug("Last crew score: [last_crewscore], camera break chance: [clamp(10-(last_crewscore/1000),0,25)], \
 		light tube break chance: [clamp(2-(last_crewscore/5000),0,4)], light bulb break chance: [clamp(5-(last_crewscore/2000),0,10)]")
 	initialize_rune_words()
 	library_catalog.initialize()

--- a/code/controllers/subsystem/init/persistence_misc.dm
+++ b/code/controllers/subsystem/init/persistence_misc.dm
@@ -460,3 +460,17 @@ var/datum/subsystem/persistence_misc/SSpersistence_misc
 	var/name = "Brightest minds of Nanotrasen"
 	var/desc = "You made it to the top 5! You accumulated [record.fields["cash"]]  research points."
 	give_award(record.fields["ckey"], /obj/item/clothing/accessory/medal/gold, name, desc, FALSE)
+
+//Crew Score
+/datum/persistence_task/crewscore
+	execute = TRUE
+	name = "Crew Score"
+	file_path = "data/persistence/crewscore.json"
+
+var/last_crewscore = 0
+
+/datum/persistence_task/crewscore/on_init()
+	last_crewscore = read_file()
+
+/datum/persistence_task/crewscore/on_shutdown()
+	write_file(score.crewscore)

--- a/code/game/gamemodes/endgame/scoreboard/misc_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/misc_score.dm
@@ -153,6 +153,6 @@
 			score.arenabest += "[x] "
 
 	if(score.badmin_score)
-		score.crewscore = score.badmin_score + (badmin_override ? 0 : score.crewscore)
+		score.crewscore = score.badmin_score + (score.badmin_override ? 0 : score.crewscore)
 
 	return completions

--- a/code/game/gamemodes/endgame/scoreboard/misc_score.dm
+++ b/code/game/gamemodes/endgame/scoreboard/misc_score.dm
@@ -152,4 +152,7 @@
 		if(arena_leaderboard[x] == arena_top_score)
 			score.arenabest += "[x] "
 
+	if(score.badmin_score)
+		score.crewscore = score.badmin_score + (badmin_override ? 0 : score.crewscore)
+
 	return completions

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -90,6 +90,9 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	var/list/implant_phrases = list()
 	var/list/global_paintings = list()
 
+	var/badmin_score		= 0
+	var/badmin_override		= FALSE
+
 /datum/controller/gameticker/scoreboard/proc/main(var/dat)
 	ticker.mode.declare_completion()
 	dat += "[ticker.mode.dat]<HR>"
@@ -269,6 +272,9 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	var/list/dept_leaderboard = get_dept_leaderboard()
 	for (var/i = 1 to dept_leaderboard.len)
 		dat += "<B>#[i] - </B>[dept_leaderboard[i]] ($[dept_leaderboard[dept_leaderboard[i]]])<BR>"
+	
+	if(score.badmin_score)
+		dat += "<BR><span class='sinister'><B>Mysterious circumstances:</B> [score.badmin_score] Points)</span><BR>"
 
 	dat += "<HR><BR>"
 	dat += "<B><U>FINAL SCORE: [score.crewscore]</U></B><BR>"

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -274,7 +274,7 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 		dat += "<B>#[i] - </B>[dept_leaderboard[i]] ($[dept_leaderboard[dept_leaderboard[i]]])<BR>"
 	
 	if(score.badmin_score)
-		dat += "<BR><span class='sinister'><B>Mysterious circumstances:</B> [score.badmin_score] Points)</span><BR>"
+		dat += "<BR><span class='sinister'><B>Mysterious circumstances:</B> [score.badmin_score] Points</span><BR>"
 
 	dat += "<HR><BR>"
 	dat += "<B><U>FINAL SCORE: [score.crewscore]</U></B><BR>"

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -1,6 +1,7 @@
 #define CAMERA_MAX_HEALTH 120
 #define CAMERA_DEACTIVATE_HEALTH 45
 #define CAMERA_MIN_WEAPON_DAMAGE 5
+#define CAMERA_MAX_FAIL_CHANCE 25
 
 var/list/camera_names=list()
 /obj/machinery/camera
@@ -61,6 +62,8 @@ var/list/camera_names=list()
 
 /obj/machinery/camera/initialize()
 	..()
+	if(failure_chance)
+		failure_chance = clamp(failure_chance-(last_crewscore/1000),0,CAMERA_MAX_FAIL_CHANCE) // 25% at highest, 0% at lowest
 	if(prob(failure_chance))
 		deactivate()
 
@@ -593,3 +596,4 @@ var/list/camera_messages = list()
 #undef CAMERA_MAX_HEALTH
 #undef CAMERA_DEACTIVATE_HEALTH
 #undef CAMERA_MIN_WEAPON_DAMAGE
+#undef CAMERA_MAX_FAIL_CHANCE

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -133,6 +133,7 @@ var/list/admin_verbs_fun = list(
 	/client/proc/add_centcomm_order,
 	/client/proc/apes,
 	/client/proc/force_next_map,
+	/client/proc/rig_crew_score,
 	)
 var/list/admin_verbs_spawn = list(
 	/datum/admins/proc/spawn_atom, // Allows us to spawn instances

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1585,3 +1585,14 @@ var/obj/blend_test = null
 		output = "No unconnected vents/scrubbers found."
 
 	usr << browse (output, "window=unconnected-atmos-search")
+
+/client/proc/rig_crew_score()
+	set category = "Debug"
+	set name = "Rig crew score"
+	set desc = "Manually adjust round-end crew score."
+
+	if(!check_rights(R_FUN))
+		return
+
+	score.badmin_score = input(usr,"What score do you want?","Badmin score",score.badmin_score) as num
+	score.badmin_override = alert(usr,"Override or add to the round-end score?","Badmin score","Override","Add") == "Override"

--- a/code/modules/persistence/map_persistence_type.dm
+++ b/code/modules/persistence/map_persistence_type.dm
@@ -34,7 +34,9 @@
 //Note 2: The cap was added because reading 30k of objects crashes the server
 /datum/map_persistence_type/proc/writeSavefile()
 	var/list/finished_list = list()
+	var/old_max = arbitrary_max_objects
 	arbitrary_max_objects = round(clamp(arbitrary_max_objects-(score.crewscore/100),0,500)) //Crewscore of 50,000 makes the next station spotless!
+	log_debug("Map persistence \"[name]\" at [arbitrary_max_objects] max objects after crewscore calculations. (was [old_max])")
 	if(tracking.len > arbitrary_max_objects)
 		log_debug("Map persistence \"[name]\" hit the cap. [tracking.len - arbitrary_max_objects] objects did not make it.")
 		tracking.Cut(arbitrary_max_objects)

--- a/code/modules/persistence/map_persistence_type.dm
+++ b/code/modules/persistence/map_persistence_type.dm
@@ -34,6 +34,7 @@
 //Note 2: The cap was added because reading 30k of objects crashes the server
 /datum/map_persistence_type/proc/writeSavefile()
 	var/list/finished_list = list()
+	arbitrary_max_objects = round(clamp(arbitrary_max_objects-(score.crewscore/100),0,500)) //Crewscore of 50,000 makes the next station spotless!
 	if(tracking.len > arbitrary_max_objects)
 		log_debug("Map persistence \"[name]\" hit the cap. [tracking.len - arbitrary_max_objects] objects did not make it.")
 		tracking.Cut(arbitrary_max_objects)

--- a/code/modules/persistence/map_persistence_type.dm
+++ b/code/modules/persistence/map_persistence_type.dm
@@ -35,7 +35,7 @@
 /datum/map_persistence_type/proc/writeSavefile()
 	var/list/finished_list = list()
 	var/old_max = arbitrary_max_objects
-	arbitrary_max_objects = round(clamp(arbitrary_max_objects-(score.crewscore/100),0,500)) //Crewscore of 50,000 makes the next station spotless!
+	arbitrary_max_objects = round(clamp(arbitrary_max_objects-(score.crewscore/20),0,500)) //Crewscore of 10,000 makes the next station spotless!
 	log_debug("Map persistence \"[name]\" at [arbitrary_max_objects] max objects after crewscore calculations. (was [old_max])")
 	if(tracking.len > arbitrary_max_objects)
 		log_debug("Map persistence \"[name]\" hit the cap. [tracking.len - arbitrary_max_objects] objects did not make it.")

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -145,7 +145,7 @@ var/global/list/obj/machinery/light/alllights = list()
 		lights_area.lights += src
 
 	if(map.broken_lights && break_chance)
-		if(ticker && ticker.current_state == GAME_STATE_PREGAME)
+		if(ticker && ticker.current_state == GAME_STATE_PREGAME) // only change the chance before roundstart
 			break_chance = clamp(break_chance-(last_crewscore/5000),0,10) // 10% at highest, 0% at lowest
 		if(prob(break_chance))
 			broken(1)

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -144,7 +144,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	if(lights_area)
 		lights_area.lights += src
 
-	if(map.broken_lights)
+	if(map.broken_lights && break_chance)
 		if(ticker && ticker.current_state == GAME_STATE_PREGAME)
 			break_chance = clamp(break_chance-(last_crewscore/5000),0,10) // 10% at highest, 0% at lowest
 		if(prob(break_chance))

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -146,7 +146,7 @@ var/global/list/obj/machinery/light/alllights = list()
 
 	if(map.broken_lights && break_chance)
 		if(ticker && ticker.current_state == GAME_STATE_PREGAME) // only change the chance before roundstart
-			break_chance = clamp(break_chance-(last_crewscore/5000),0,10) // 10% at highest, 0% at lowest
+			break_chance = clamp(break_chance-(last_crewscore/5000),0,break_chance*2) // 10% at highest, 0% at lowest
 		if(prob(break_chance))
 			broken(1)
 

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -146,7 +146,7 @@ var/global/list/obj/machinery/light/alllights = list()
 
 	if(map.broken_lights && break_chance)
 		if(ticker && ticker.current_state == GAME_STATE_PREGAME) // only change the chance before roundstart
-			break_chance = clamp(break_chance-(last_crewscore/5000),0,break_chance*2) // 10% at highest, 0% at lowest
+			break_chance = clamp(break_chance-(last_crewscore/1000),0,break_chance*2) // 10% at highest, 0% at lowest
 		if(prob(break_chance))
 			broken(1)
 

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -145,8 +145,8 @@ var/global/list/obj/machinery/light/alllights = list()
 		lights_area.lights += src
 
 	if(map.broken_lights)
-		var/failure_chance = clamp(break_chance-(last_crewscore/5000),0,10) // 10% at highest, 0% at lowest
-		if(prob(failure_chance))
+		break_chance = clamp(break_chance-(last_crewscore/5000),0,10) // 10% at highest, 0% at lowest
+		if(prob(break_chance))
 			broken(1)
 
 /obj/machinery/light/supports_holomap()

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -145,7 +145,8 @@ var/global/list/obj/machinery/light/alllights = list()
 		lights_area.lights += src
 
 	if(map.broken_lights)
-		break_chance = clamp(break_chance-(last_crewscore/5000),0,10) // 10% at highest, 0% at lowest
+		if(ticker && ticker.current_state == GAME_STATE_PREGAME)
+			break_chance = clamp(break_chance-(last_crewscore/5000),0,10) // 10% at highest, 0% at lowest
 		if(prob(break_chance))
 			broken(1)
 

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -123,6 +123,7 @@ var/global/list/obj/machinery/light/alllights = list()
 	var/area/lights_area
 	var/spawn_with_bulb = /obj/item/weapon/light/tube
 	var/fitting = "tube"
+	var/break_chance = 2
 	var/rgb_upgrade = FALSE //add plastic to enable RGB mode
 
 	// No ghost interaction.
@@ -144,14 +145,9 @@ var/global/list/obj/machinery/light/alllights = list()
 		lights_area.lights += src
 
 	if(map.broken_lights)
-		//var/failure_mult = clamp(-(last_crewscore/10000),0,1) // 25% at highest, 0% at lowest
-		switch(fitting)
-			if("tube")
-				if(prob(2))
-					broken(1)
-			if("bulb")
-				if(prob(5))
-					broken(1)
+		var/failure_chance = clamp(break_chance-(last_crewscore/5000),0,10) // 10% at highest, 0% at lowest
+		if(prob(failure_chance))
+			broken(1)
 
 /obj/machinery/light/supports_holomap()
 	return TRUE
@@ -200,8 +196,9 @@ var/global/list/obj/machinery/light/alllights = list()
 
 /obj/machinery/light/small
 	icon_state = "lbulb1"
-	fitting = "bulb"
 	desc = "A small lighting fixture."
+	fitting = "bulb"
+	break_chance = 5
 	spawn_with_bulb = /obj/item/weapon/light/bulb
 
 /obj/machinery/light/small/broken
@@ -211,6 +208,7 @@ var/global/list/obj/machinery/light/alllights = list()
 /obj/machinery/light/spot
 	name = "spotlight"
 	fitting = "large tube"
+	break_chance = 0
 	spawn_with_bulb = /obj/item/weapon/light/tube/large
 
 /obj/machinery/light/built

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -144,6 +144,7 @@ var/global/list/obj/machinery/light/alllights = list()
 		lights_area.lights += src
 
 	if(map.broken_lights)
+		//var/failure_mult = clamp(-(last_crewscore/10000),0,1) // 25% at highest, 0% at lowest
 		switch(fitting)
 			if("tube")
 				if(prob(2))

--- a/code/modules/power/lighting/lighting.dm
+++ b/code/modules/power/lighting/lighting.dm
@@ -146,7 +146,7 @@ var/global/list/obj/machinery/light/alllights = list()
 
 	if(map.broken_lights && break_chance)
 		if(ticker && ticker.current_state == GAME_STATE_PREGAME) // only change the chance before roundstart
-			break_chance = clamp(break_chance-(last_crewscore/1000),0,break_chance*2) // 10% at highest, 0% at lowest
+			break_chance = clamp(break_chance-(last_crewscore/(10000/break_chance)),0,break_chance*2) // 10% at highest, 0% at lowest
 		if(prob(break_chance))
 			broken(1)
 


### PR DESCRIPTION
[gameplay]

## What this does
Makes rounds start with less or more broken cameras depending on crew score. 10000 gives none, while -15000 makes a quarter of them broken.
Makes rounds start with less or more broken lights depending on crew score. 10000 gives none, while -10000 makes lights twice as likely to be broken at the start of the round. (does not affect in-game chances)
Makes filth persistence lower the cap with higher score, making stations spotless from the last round at 10000.
Adds a debug admin verb for manually setting round-end crew score, with the option to override the normal crew score or add to it.

## Why it's good
Makes these actually do something again since we lost the lampreys. Also something relatively mild, to demonstrate it.

## How it was tested
Viewing debug logs after setting the crew score using the new debug admin verb.

## Changelog
:cl:
 * rscadd: Crew performance now has a bearing on the well being of future stations employees can be sent to, affecting camera and light quality as well as overall station cleanliness.