### PR TITLE
Shows station budget info on "The weird" section of crew stats

### DIFF
--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -43,11 +43,12 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	var/disease_bad			= 0 //How many unique diseases currently affecting living mobs of cumulated danger >= 3
 	var/disease_most		= null //Most spread disease
 	var/disease_most_count	= 0 //Most spread disease
+
 	var/turfssingulod		= 0 //Amount of turfs eaten by singularities.
+
 	var/static/list/badvars		= list("deadcrew","deadsilicon","deadaipenalty","mess","litter","powerloss","atmoloss","stuffnotforwarded","disease_bad","turfssingulod")
 
 	//These ones are mainly for the stat panel
-	var/messbonus			= 0 //If there are no messes on the station anywhere, huge bonus
 	var/foodeaten			= 0 //How much food was consumed
 	var/clownabuse			= 0 //How many times a clown was punched, struck or otherwise maligned
 	var/slips				= 0 //How many people have slipped during this round
@@ -155,6 +156,8 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 		dat += "<B>Rescued Pets:</B> [score.rescuedpets] ([score.rescuedpets*50 + score.rescueianbonus] Points<BR>)"	
 	dat += "<B>Whole Station Powered:</B> [score.powerbonus ? "Yes" : "No"] ([score.powerbonus] Points)<BR>"
 	dat += "<B>Whole Station Airtight:</B> [score.atmobonus ? "Yes" : "No"] ([score.atmobonus] Points)<BR>"
+	if (score.machineupgrades > 0)
+		dat += "<B>Total Upgraded Machines Rating:</B> [score.machineupgrades] ([score.machineupgrades * 5] Points)<BR>"
 	if (score.disease_vaccine_score > 0)
 		dat += "<B>Isolated Vaccines:</B> [score.disease_vaccine] ([score.disease_vaccine_score] Points)<BR>"
 	if (score.disease_extracted > 0)

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -2,26 +2,39 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 
 /datum/controller/gameticker/scoreboard
 	var/crewscore 			= 0 //This is the overall var/score for the whole round
+
 	var/plasmashipped		= 0 //How much plasma has been sent to centcom?
 	var/stuffshipped		= 0 //How many centcom orders have cargo fulfilled?
 	var/stuffforwarded		= 0 //How many cargo forwards have been fulfilled?
 	var/stuffnotforwarded	= 0 //How many cargo forwards have not been fulfilled?
+
 	var/stuffharvested		= 0 //How many harvests have hydroponics done (per crop)?
 	var/oremined			= 0 //How many chunks of ore were smelted
+	var/meals				= 0 //How much food was actively cooked that day
+	var/slimes				= 0 //How many slimes were harvested
+	var/artifacts			= 0 //How many large artifacts were analyzed and activated
+
 	var/eventsendured		= 0 //How many random events did the station endure?
+
 	var/powerloss			= 0 //How many APCs have alarms (under 30 %)?
 	var/atmoloss			= 0 //How many air alarms are giving issues?
 	var/powerbonus			= 0 //If all APCs on the station are running optimally, big bonus
 	var/atmobonus			= 0 //If all air alarms on the station are running optimally, big bonus
 	var/maxpower			= 0 //Most watts in grid on any of the world's powergrids.
+
+	var/machineupgrades		= 0 //How many machines were upgraded?
+
 	var/escapees			= 0 //How many people got out alive?
 	var/deadcrew			= 0 //Humans who died during the round
 	var/deadsilicon			= 0 //Silicons who died during the round
 	var/deadaipenalty		= 0 //AIs who died during the round
 	var/rescuedpets			= 0 //how many pets were brought back to centcomm (alive)
 	var/rescueianbonus		= 0 //ian is a special little guy :)
+
 	var/mess				= 0 //How much messes on the floor went uncleaned
 	var/litter				= 0 //How much trash is laying on the station floor
+	var/messbonus			= 0 //If there are no messes on the station anywhere, huge bonus
+
 	var/meals				= 0 //How much food was actively cooked that day
 	var/slimes				= 0 //How many slimes were harvested
 	var/artifacts			= 0 //How many large artifacts were analyzed and activated

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -205,9 +205,9 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	dat += "<B>Final Station Budget:</B> $[num2text(totalfunds,50)]<BR>"
 	var/profit = totalfunds - init_station_funds
 	if (profit > 0)
-		dat += "<B>Station Profit:</B> +[num2text(profit,50)]<BR>"
+		dat += "<B>Station Profit:</B> +$[num2text(profit,50)]<BR>"
 	else if (profit < 0)
-		dat += "<B>Station Deficit:</B> [num2text(profit,50)]<BR>"
+		dat += "<B>Station Deficit:</B> -$[num2text(abs(profit),50)]<BR>"
 	if(score.foodeaten > 0)
 		dat += "<B>Food Eaten:</b> [score.foodeaten]<BR>"
 	if(score.clownabuse > 0)

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -35,9 +35,6 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	var/litter				= 0 //How much trash is laying on the station floor
 	var/messbonus			= 0 //If there are no messes on the station anywhere, huge bonus
 
-	var/meals				= 0 //How much food was actively cooked that day
-	var/slimes				= 0 //How many slimes were harvested
-	var/artifacts			= 0 //How many large artifacts were analyzed and activated
 	var/disease_good		= 0 //How many unique diseases currently affecting living mobs of cumulated danger <3
 	var/disease_vaccine		= null //Which many vaccine antibody isolated
 	var/disease_vaccine_score= 0 //the associated score

--- a/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
+++ b/code/game/gamemodes/endgame/scoreboard/scoreboard.dm
@@ -2,39 +2,29 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 
 /datum/controller/gameticker/scoreboard
 	var/crewscore 			= 0 //This is the overall var/score for the whole round
-
 	var/plasmashipped		= 0 //How much plasma has been sent to centcom?
 	var/stuffshipped		= 0 //How many centcom orders have cargo fulfilled?
 	var/stuffforwarded		= 0 //How many cargo forwards have been fulfilled?
 	var/stuffnotforwarded	= 0 //How many cargo forwards have not been fulfilled?
-
 	var/stuffharvested		= 0 //How many harvests have hydroponics done (per crop)?
 	var/oremined			= 0 //How many chunks of ore were smelted
-	var/meals				= 0 //How much food was actively cooked that day
-	var/slimes				= 0 //How many slimes were harvested
-	var/artifacts			= 0 //How many large artifacts were analyzed and activated
-
 	var/eventsendured		= 0 //How many random events did the station endure?
-
 	var/powerloss			= 0 //How many APCs have alarms (under 30 %)?
 	var/atmoloss			= 0 //How many air alarms are giving issues?
 	var/powerbonus			= 0 //If all APCs on the station are running optimally, big bonus
 	var/atmobonus			= 0 //If all air alarms on the station are running optimally, big bonus
 	var/maxpower			= 0 //Most watts in grid on any of the world's powergrids.
-
-	var/machineupgrades		= 0 //How many machines were upgraded?
-
 	var/escapees			= 0 //How many people got out alive?
 	var/deadcrew			= 0 //Humans who died during the round
 	var/deadsilicon			= 0 //Silicons who died during the round
 	var/deadaipenalty		= 0 //AIs who died during the round
 	var/rescuedpets			= 0 //how many pets were brought back to centcomm (alive)
 	var/rescueianbonus		= 0 //ian is a special little guy :)
-
 	var/mess				= 0 //How much messes on the floor went uncleaned
 	var/litter				= 0 //How much trash is laying on the station floor
-	var/messbonus			= 0 //If there are no messes on the station anywhere, huge bonus
-
+	var/meals				= 0 //How much food was actively cooked that day
+	var/slimes				= 0 //How many slimes were harvested
+	var/artifacts			= 0 //How many large artifacts were analyzed and activated
 	var/disease_good		= 0 //How many unique diseases currently affecting living mobs of cumulated danger <3
 	var/disease_vaccine		= null //Which many vaccine antibody isolated
 	var/disease_vaccine_score= 0 //the associated score
@@ -43,12 +33,11 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 	var/disease_bad			= 0 //How many unique diseases currently affecting living mobs of cumulated danger >= 3
 	var/disease_most		= null //Most spread disease
 	var/disease_most_count	= 0 //Most spread disease
-
 	var/turfssingulod		= 0 //Amount of turfs eaten by singularities.
-
 	var/static/list/badvars		= list("deadcrew","deadsilicon","deadaipenalty","mess","litter","powerloss","atmoloss","stuffnotforwarded","disease_bad","turfssingulod")
 
 	//These ones are mainly for the stat panel
+	var/messbonus			= 0 //If there are no messes on the station anywhere, huge bonus
 	var/foodeaten			= 0 //How much food was consumed
 	var/clownabuse			= 0 //How many times a clown was punched, struck or otherwise maligned
 	var/slips				= 0 //How many people have slipped during this round
@@ -156,8 +145,6 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 		dat += "<B>Rescued Pets:</B> [score.rescuedpets] ([score.rescuedpets*50 + score.rescueianbonus] Points<BR>)"	
 	dat += "<B>Whole Station Powered:</B> [score.powerbonus ? "Yes" : "No"] ([score.powerbonus] Points)<BR>"
 	dat += "<B>Whole Station Airtight:</B> [score.atmobonus ? "Yes" : "No"] ([score.atmobonus] Points)<BR>"
-	if (score.machineupgrades > 0)
-		dat += "<B>Total Upgraded Machines Rating:</B> [score.machineupgrades] ([score.machineupgrades * 5] Points)<BR>"
 	if (score.disease_vaccine_score > 0)
 		dat += "<B>Isolated Vaccines:</B> [score.disease_vaccine] ([score.disease_vaccine_score] Points)<BR>"
 	if (score.disease_extracted > 0)
@@ -198,12 +185,16 @@ var/global/datum/controller/gameticker/scoreboard/score = new()
 		dat += "<B>Nothing bad to report! Good job, crew!</B><BR>"
 
 	dat += "<BR><U>THE WEIRD</U><BR>"
-/*	<B>Final Station Budget:</B> $[num2text(totalfunds,50)]<BR>"
-	var/profit = totalfunds - 100000
+	var/totalfunds = 0
+	for(var/dept in department_accounts)
+		var/datum/money_account/act = department_accounts[dept]
+		totalfunds += act.money
+	dat += "<B>Final Station Budget:</B> $[num2text(totalfunds,50)]<BR>"
+	var/profit = totalfunds - init_station_funds
 	if (profit > 0)
 		dat += "<B>Station Profit:</B> +[num2text(profit,50)]<BR>"
 	else if (profit < 0)
-		dat += "<B>Station Deficit:</B> [num2text(profit,50)]<BR>"*/
+		dat += "<B>Station Deficit:</B> [num2text(profit,50)]<BR>"
 	if(score.foodeaten > 0)
 		dat += "<B>Food Eaten:</b> [score.foodeaten]<BR>"
 	if(score.clownabuse > 0)

--- a/code/modules/Economy/Accounts.dm
+++ b/code/modules/Economy/Accounts.dm
@@ -17,6 +17,7 @@ var/station_allowance = 0//This is what Nanotrasen will send to the Station Acco
 var/latejoiner_allowance = 0//Added to station_allowance and reset before every wage payout.
 var/station_funding = 0 //A bonus to the station allowance that persists between cycles. Admins can set this on the database.
 var/station_bonus = 0 //A bonus to station allowance that gets reset after wage payout. Admins can boost this too.
+var/init_station_funds = 0
 
 /proc/create_station_account()
 	if(!station_account)
@@ -42,6 +43,7 @@ var/station_bonus = 0 //A bonus to station allowance that gets reset after wage 
 	department_account.account_number = rand(11111, 99999)
 	department_account.remote_access_pin = rand(1111, 9999)
 	department_account.money = DEPARTMENT_START_FUNDS
+	init_station_funds += department_account.money
 	if(receives_wage == 1)
 		department_account.wage_gain = DEPARTMENT_START_WAGE
 		station_allowance += DEPARTMENT_START_WAGE + round(DEPARTMENT_START_WAGE/10)//overhead of 10%


### PR DESCRIPTION
[gameplay]

## What this does
re-enables some commented out code, was under "the weird" but could even make this a crew score thing if people wish for it

## Why it's good
shows how well finances are kept

## How it was tested
put captain debit card in ATM, withdraw 250, end round, see -250 in deficit

## Changelog
:cl:
 * rscadd: The station budget, profit and deficit are now made known to crew members at the end of their shift.
