### PR TITLE
Lets detectives use click drag to open the camera bugs cigarette packet

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -708,6 +708,9 @@
 /obj/item/device/radio/phone/surveillance/attackby(obj/item/I, mob/user)
 	cigbox.attackby(I,user)
 
+/obj/item/device/radio/phone/surveillance/MouseDropFrom(obj/over_object)
+	cigbox.MouseDropFrom(over_object)
+
 /obj/item/device/radio/bug
 	name = "cigarette butt"
 	desc = "A manky old cigarette butt."


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.
Not including sections of the template may result in having your PR closed.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request
Common labels include bugfix, content, tweak, and balance. Enclose them in [ square brackets. -->

<!-- You can post a header, sample images, and/or simple description here for a quick summary. -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
What it says on the tin
## Why it's good
<!-- Explain why you think these changes are good, or otherwise why you wanted to make them and have them merged. -->
It was a request
## How it was tested
<!-- Document what procedures you used to test this PR here, including any images if helpful. -->
Click drag works
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Detectives can now open their camera bugs cigarette packet with click drag.

