### PR TITLE
Borg cell and component refactoring

### DIFF
--- a/__DEFINES/qdel.dm
+++ b/__DEFINES/qdel.dm
@@ -1,11 +1,15 @@
 #define QDEL_NULL(item) qdel(item); item = null
 #define QDEL_LIST(L) if(L) { for(var/I in L) { qdel(I); } }
 #define QDEL_LIST_ASSOC(L) if(L) { for(var/I in L) { qdel(L[I]); qdel(I); } }
+#define QDEL_LIST_ASSOC_VALUES(L) if(L) { for(var/I in L) { qdel(L[I]); } }
 
 #define QDEL_LIST_NULL(L) QDEL_LIST(L); L = null
-#define QDEL_LIST_ASSOC_NULL(L) QDEL_LIST_ASSOC(L); L = null
 #define QDEL_LIST_CUT(L) QDEL_LIST(L); L.Cut()
+#define QDEL_LIST_ASSOC_NULL(L) QDEL_LIST_ASSOC(L); L = null
 #define QDEL_LIST_ASSOC_CUT(L) QDEL_LIST_ASSOC(L); L.Cut()
+#define QDEL_LIST_ASSOC_VALUES_NULL(L) QDEL_LIST_ASSOC_VALUES(L); L = null
+#define QDEL_LIST_ASSOC_VALUES_CUT(L) QDEL_LIST_ASSOC_VALUES(L); L.Cut()
+
 
 // QDEL macros borrowed from TG
 #define QDELETED(X) (!X || X.gcDestroyed)

--- a/__DEFINES/silicon.dm
+++ b/__DEFINES/silicon.dm
@@ -50,9 +50,11 @@ var/global/list/mommi_modules = list(
 //Global list of all Cyborg/MoMMI modules. If you add a new list and forget to add it to this one i'll fucking break your neck.
 var/global/list/all_robot_modules = default_nanotrasen_robot_modules + emergency_nanotrasen_robot_modules + syndicate_robot_modules + special_robot_modules + mommi_modules
 
-/proc/getAvailableRobotModules()
+/proc/getAvailableRobotModules(mob/user)
 	var/list/pickable_modules = default_nanotrasen_robot_modules.Copy()
-	if(security_level >= SEC_LEVEL_RED)
+	if(user && user.check_rights(R_ADMIN))
+		pickable_modules += (emergency_nanotrasen_robot_modules + syndicate_robot_modules + special_robot_modules)
+	else if(security_level >= SEC_LEVEL_RED)
 		pickable_modules += emergency_nanotrasen_robot_modules
 	return pickable_modules
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -986,6 +986,23 @@ its easier to just keep the beam vertical.
 /atom/proc/get_cell()
 	return
 
+/atom/proc/get_cell_charge(var/mob/living/silicon/robot/R)
+	if(istype(R))
+		var/obj/item/weapon/cell/Rcell = R.get_cell()
+		if(Rcell)
+			return Rcell.charge
+	return 0
+
+/atom/proc/use_cell_charge(var/mob/living/silicon/robot/R,var/amount,var/silent=FALSE)
+	if(istype(R))
+		var/obj/item/weapon/cell/Rcell = R.get_cell()
+		if(!Rcell || Rcell.charge < amount)
+			if(!silent)
+				to_chat(R, "<span class='warning'>You don't have enough charge to use \the [src].</span>")
+			return FALSE
+		return Rcell.use(amount)
+	return FALSE
+
 /atom/proc/on_syringe_injection(var/mob/user, var/obj/item/weapon/reagent_containers/syringe/tool)
 	if(!reagents)
 		return INJECTION_RESULT_FAIL

--- a/code/game/machinery/autoborger.dm
+++ b/code/game/machinery/autoborger.dm
@@ -208,7 +208,7 @@
 			enable_namepick=!enable_namepick
 		if("force_class")
 			var/list/modules = list("(Robot's Choice)")
-			modules += getAvailableRobotModules()
+			modules += getAvailableRobotModules(usr)
 			var/sel_mod = input("Please, select a module!", "Robot", null, null) as null|anything in modules
 			if(!sel_mod)
 				return

--- a/code/game/machinery/autoborger.dm
+++ b/code/game/machinery/autoborger.dm
@@ -90,8 +90,10 @@
 	// Delete the items or they'll all pile up in a single tile and lag
 	// skipnaming disables namepick on New(). It's annoying as fuck on malf.  Later on, we enable or disable namepick.
 	if(R)
-		R.cell.maxcharge = robot_cell_charge
-		R.cell.charge = robot_cell_charge
+		var/obj/item/weapon/cell/Rcell = R.get_cell()
+		if (Rcell)
+			Rcell.maxcharge = robot_cell_charge
+			Rcell.charge = robot_cell_charge
 
 	 	// So he can't jump out the gate right away.
 		R.SetKnockdown(5)

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -70,11 +70,15 @@
 	for(var/mob/living/silicon/robot/R in cyborg_list)
 		if(!can_control(R,user))
 			continue
+		var/percent = null
+		var/obj/item/weapon/cell/Rcell = get_cell()
+		if(Rcell)
+			percent = Rcell.percent
 		var/list/cyborg_data = list(
 			"name" = R.name,
 			"locked_down" = R.lockdown,
 			"status" = R.stat,
-			"charge" = R.cell ? R.cell.percent() : null,
+			"charge" = percent,
 			"module" = R.module ? "[R.modtype] Module" : "No Module Installed",
 			"master" = R.connected_ai,
 			"emagged" = R.emagged,

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -73,7 +73,7 @@
 		var/percent = null
 		var/obj/item/weapon/cell/Rcell = get_cell()
 		if(Rcell)
-			percent = Rcell.percent
+			percent = Rcell.percent()
 		var/list/cyborg_data = list(
 			"name" = R.name,
 			"locked_down" = R.lockdown,

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -70,15 +70,12 @@
 	for(var/mob/living/silicon/robot/R in cyborg_list)
 		if(!can_control(R,user))
 			continue
-		var/percent = null
 		var/obj/item/weapon/cell/Rcell = get_cell()
-		if(Rcell)
-			percent = Rcell.percent()
 		var/list/cyborg_data = list(
 			"name" = R.name,
 			"locked_down" = R.lockdown,
 			"status" = R.stat,
-			"charge" = percent,
+			"charge" = Rcell ? Rcell.percent() : null,
 			"module" = R.module ? "[R.modtype] Module" : "No Module Installed",
 			"master" = R.connected_ai,
 			"emagged" = R.emagged,

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -70,7 +70,7 @@
 	for(var/mob/living/silicon/robot/R in cyborg_list)
 		if(!can_control(R,user))
 			continue
-		var/obj/item/weapon/cell/Rcell = get_cell()
+		var/obj/item/weapon/cell/Rcell = R.get_cell()
 		var/list/cyborg_data = list(
 			"name" = R.name,
 			"locked_down" = R.lockdown,

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -331,10 +331,13 @@
 			if(istype(O, /obj/item/weapon/cell))
 				var/obj/item/weapon/cell/some_cell = O
 				var/obj/item/weapon/cell/Rcell = R.get_cell()
+				var/word = null
 				if(!Rcell)
-					to_chat(R, "<big><span class='notice'>Power Cell replacement available. You may opt in with the 'Apply Cell Upgrade' verb in the Object tab.</span></big>")
+					word = "replacement"
 				else if(some_cell.maxcharge > Rcell.maxcharge)
-					to_chat(R, "<span class='notice'>Power Cell upgrade available. You may opt in with the 'Apply Cell Upgrade' verb in the Object tab.</span>")
+					word = "upgrade"
+				if(word)
+					to_chat(R, "<big><span class='notice'>Power Cell replacement available. You may opt in with the 'Apply Cell Upgrade' verb in the Object tab.</span></big>")
 	else if(ishuman(R) && autoborger && !is_borging)
 		do_autoborg()
 

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -337,7 +337,7 @@
 				else if(some_cell.maxcharge > Rcell.maxcharge)
 					word = "upgrade"
 				if(word)
-					to_chat(R, "<big><span class='notice'>Power Cell replacement available. You may opt in with the 'Apply Cell Upgrade' verb in the Object tab.</span></big>")
+					to_chat(R, "<big><span class='notice'>Power Cell [word] available. You may opt in with the 'Apply Cell Upgrade' verb in the Object tab.</span></big>")
 	else if(ishuman(R) && autoborger && !is_borging)
 		do_autoborg()
 

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -327,7 +327,6 @@
 	build_icon()
 	src.use_power = MACHINE_POWER_USE_ACTIVE
 	if(isrobot(R))
-		var/mob/living/silicon/robot/RR = R
 		for(var/obj/O in upgrade_holder)
 			if(istype(O, /obj/item/weapon/cell))
 				var/obj/item/weapon/cell/some_cell = O

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -108,12 +108,14 @@
 		return
 	if(world.timeofday >= upgrade_finished && upgrade_finished != -1)
 		if(istype(upgrading, /obj/item/weapon/cell))
-			if(R.cell)
-				R.cell.updateicon()
-				R.cell.forceMove(get_turf(src))
+			var/obj/item/weapon/cell/Rcell = R.get_cell()
+			if (Rcell)
+				Rcell.updateicon()
+				Rcell.forceMove(get_turf(src))
 			upgrade_holder -= upgrading
 			upgrading.forceMove(R)
-			R.cell = upgrading
+			var/datum/robot_component/cell_component = R.components["power cell"]
+			cell_component.install(null,upgrading)
 			upgrading = 0
 			upgrade_finished = -1
 			to_chat(R, "<span class='notice'>Upgrade completed.</span>")
@@ -329,11 +331,11 @@
 		for(var/obj/O in upgrade_holder)
 			if(istype(O, /obj/item/weapon/cell))
 				var/obj/item/weapon/cell/some_cell = O
-				if(!RR.cell)
-					to_chat(usr, "<big><span class='notice'>Power Cell replacement available. You may opt in with the 'Apply Cell Upgrade' verb in the Object tab.</span></big>")
-				else
-					if(some_cell.maxcharge > RR.cell.maxcharge)
-						to_chat(usr, "<span class='notice'>Power Cell upgrade available. You may opt in with the 'Apply Cell Upgrade' verb in the Object tab.</span></big>")
+				var/obj/item/weapon/cell/Rcell = R.get_cell()
+				if(!Rcell)
+					to_chat(R, "<big><span class='notice'>Power Cell replacement available. You may opt in with the 'Apply Cell Upgrade' verb in the Object tab.</span></big>")
+				else if(some_cell.maxcharge > Rcell.maxcharge)
+					to_chat(R, "<span class='notice'>Power Cell upgrade available. You may opt in with the 'Apply Cell Upgrade' verb in the Object tab.</span>")
 	else if(ishuman(R) && autoborger && !is_borging)
 		do_autoborg()
 
@@ -413,8 +415,10 @@
 		is_borging = FALSE
 		return
 
-	R.cell.maxcharge = 5000
-	R.cell.charge = 5000
+	var/obj/item/weapon/cell/Rcell = R.get_cell()
+	if(Rcell)
+		Rcell.maxcharge = 5000
+		Rcell.charge = 5000
 	R.SetKnockdown(3)
 
 	R.custom_name = pick(autoborg_silly_names)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1796,19 +1796,3 @@ var/global/objects_thrown_when_explode = FALSE
 		var/mob/living/L = user
 		L.apply_damage(10,BURN,(pick(LIMB_LEFT_HAND, LIMB_RIGHT_HAND)))
 		L.visible_message("[user] snuffs out the burning [src].","You snuff out the burning [src], burning your hand in the process.")
-
-/obj/item/proc/get_borg_cellcharge(var/mob/living/silicon/robot/R)
-	if(istype(R))
-		var/obj/item/weapon/cell/Rcell = R.get_cell()
-		if(Rcell)
-			return Rcell.charge
-	return 0
-
-/obj/item/proc/use_borg_cellcharge(var/mob/living/silicon/robot/R,var/amount)
-	if(istype(R))
-		var/obj/item/weapon/cell/Rcell = R.get_cell()
-		if(!Rcell || Rcell.charge < amount)
-			to_chat(R, "<span class='warning'>You don't have enough charge to use \the [src].</span>")
-			return FALSE
-		return Rcell.use(amount)
-	return FALSE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1809,6 +1809,5 @@ var/global/objects_thrown_when_explode = FALSE
 		if(!Rcell || Rcell.charge < amount)
 			to_chat(R, "<span class='warning'>You don't have enough charge to use \the [src].</span>")
 			return FALSE
-		Rcell.use(amount)
-		return TRUE
+		return Rcell.use(amount)
 	return FALSE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1802,6 +1802,7 @@ var/global/objects_thrown_when_explode = FALSE
 		var/obj/item/weapon/cell/Rcell = R.get_cell()
 		if(Rcell)
 			return Rcell.charge
+	return 0
 
 /obj/item/proc/use_borg_cellcharge(var/mob/living/silicon/robot/R,var/amount)
 	if(istype(R))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1796,3 +1796,18 @@ var/global/objects_thrown_when_explode = FALSE
 		var/mob/living/L = user
 		L.apply_damage(10,BURN,(pick(LIMB_LEFT_HAND, LIMB_RIGHT_HAND)))
 		L.visible_message("[user] snuffs out the burning [src].","You snuff out the burning [src], burning your hand in the process.")
+
+/obj/item/proc/get_borg_cellcharge(var/mob/living/silicon/robot/R)
+	if(istype(R))
+		var/obj/item/weapon/cell/Rcell = R.get_cell()
+		if(Rcell)
+			return Rcell.charge
+	return null
+
+/obj/item/proc/use_borg_cellcharge(var/mob/living/silicon/robot/R,var/amount)
+	if(istype(R))
+		var/obj/item/weapon/cell/Rcell = R.get_cell()
+		if(!Rcell || Rcell.charge < amount)
+			to_chat(R, "<span class='warning'>You don't have enough charge to use \the [src].</span>")
+		else
+			Rcell.use(amount)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1802,12 +1802,13 @@ var/global/objects_thrown_when_explode = FALSE
 		var/obj/item/weapon/cell/Rcell = R.get_cell()
 		if(Rcell)
 			return Rcell.charge
-	return null
 
 /obj/item/proc/use_borg_cellcharge(var/mob/living/silicon/robot/R,var/amount)
 	if(istype(R))
 		var/obj/item/weapon/cell/Rcell = R.get_cell()
 		if(!Rcell || Rcell.charge < amount)
 			to_chat(R, "<span class='warning'>You don't have enough charge to use \the [src].</span>")
-		else
-			Rcell.use(amount)
+			return FALSE
+		Rcell.use(amount)
+		return TRUE
+	return FALSE

--- a/code/game/objects/items/cookie_synth.dm
+++ b/code/game/objects/items/cookie_synth.dm
@@ -44,7 +44,7 @@
 	if(!(istype(A, /obj/structure/table) || isturf(A) || put_in_hands)) //if it's a table, a turf, or it's being activated via AltClick()
 		return
 	if(isrobot(user))
-		if(get_borg_cellcharge() < 400)
+		if(get_borg_cellcharge(user) < 400)
 			to_chat(user,"<span class='warning'>You do not have enough power to use [src].</span>")
 			return
 	if(cooldown > world.time)
@@ -57,9 +57,7 @@
 	to_chat(user,"<span class='info'>Fabricating [lowertext(S.name)]..")
 	if(toxin)
 		S.reagents.add_reagent(toxin_type, toxin_amount)
-	if(isrobot(user))
-		var/mob/living/silicon/robot/R = user
-		use_borg_cellcharge(100)
+	use_borg_cellcharge(user,100)
 	cooldown = world.time + delay
 	return S
 

--- a/code/game/objects/items/cookie_synth.dm
+++ b/code/game/objects/items/cookie_synth.dm
@@ -44,8 +44,7 @@
 	if(!(istype(A, /obj/structure/table) || isturf(A) || put_in_hands)) //if it's a table, a turf, or it's being activated via AltClick()
 		return
 	if(isrobot(user))
-		var/mob/living/silicon/robot/R = user
-		if(!R.cell || R.cell.charge < 400)
+		if(get_borg_cellcharge() < 400)
 			to_chat(user,"<span class='warning'>You do not have enough power to use [src].</span>")
 			return
 	if(cooldown > world.time)
@@ -60,7 +59,7 @@
 		S.reagents.add_reagent(toxin_type, toxin_amount)
 	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
-		R.cell.charge -= 100
+		use_borg_cellcharge(100)
 	cooldown = world.time + delay
 	return S
 

--- a/code/game/objects/items/cookie_synth.dm
+++ b/code/game/objects/items/cookie_synth.dm
@@ -44,7 +44,7 @@
 	if(!(istype(A, /obj/structure/table) || isturf(A) || put_in_hands)) //if it's a table, a turf, or it's being activated via AltClick()
 		return
 	if(isrobot(user))
-		if(get_borg_cellcharge(user) < 400)
+		if(get_cell_charge(user) < 400)
 			to_chat(user,"<span class='warning'>You do not have enough power to use [src].</span>")
 			return
 	if(cooldown > world.time)
@@ -57,7 +57,7 @@
 	to_chat(user,"<span class='info'>Fabricating [lowertext(S.name)]..")
 	if(toxin)
 		S.reagents.add_reagent(toxin_type, toxin_amount)
-	use_borg_cellcharge(user,100)
+	use_cell_charge(user,100)
 	cooldown = world.time + delay
 	return S
 

--- a/code/game/objects/items/devices/chem_synth.dm
+++ b/code/game/objects/items/devices/chem_synth.dm
@@ -284,7 +284,7 @@
 	return 0
 
 /obj/item/device/chem_synth/robot/take_cost(var/amount, var/rarity_multiplier, mob/user)
-	return use_borg_cellcharge(amount * rarity_multiplier * POWER_PER_REAGENT) || 0
+	return use_borg_cellcharge(user,amount * rarity_multiplier * POWER_PER_REAGENT) || 0
 
 /obj/item/device/chem_synth/admin/take_cost(var/amount, var/rarity_multiplier, mob/user)
 	return 1

--- a/code/game/objects/items/devices/chem_synth.dm
+++ b/code/game/objects/items/devices/chem_synth.dm
@@ -284,13 +284,7 @@
 	return 0
 
 /obj/item/device/chem_synth/robot/take_cost(var/amount, var/rarity_multiplier, mob/user)
-	if(isrobot(user))
-		var/mob/living/silicon/robot/robo = user
-		var/used = robo.cell.use(amount * rarity_multiplier * POWER_PER_REAGENT)
-		if(!used)
-			to_chat(user, "<span class='warning'>You cannot synthesize this much without shutting down!</span>")
-		return used
-	return 0
+	return use_borg_cellcharge(amount * rarity_multiplier * POWER_PER_REAGENT) || 0
 
 /obj/item/device/chem_synth/admin/take_cost(var/amount, var/rarity_multiplier, mob/user)
 	return 1

--- a/code/game/objects/items/devices/chem_synth.dm
+++ b/code/game/objects/items/devices/chem_synth.dm
@@ -284,7 +284,7 @@
 	return 0
 
 /obj/item/device/chem_synth/robot/take_cost(var/amount, var/rarity_multiplier, mob/user)
-	return use_borg_cellcharge(user,amount * rarity_multiplier * POWER_PER_REAGENT) || 0
+	return use_cell_charge(user,amount * rarity_multiplier * POWER_PER_REAGENT) || 0
 
 /obj/item/device/chem_synth/admin/take_cost(var/amount, var/rarity_multiplier, mob/user)
 	return 1

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -478,7 +478,7 @@ This used to be handled by attackby() on the light fixtures and bulbs themselves
 		added_glass = clamp(added_glass, 7500, (glass_max - glass))
 		if(use_borg_cellcharge(user,added_glass * 0.1))
 			add_glass(added_glass, 2)
-			to_chat(usr, "<span class='notice'>\The [src] synthesizes[added_glass] units of glass.</span>")
+			to_chat(usr, "<span class='notice'>\The [src] synthesizes [added_glass] units of glass.</span>")
 			return 1
 	return 0
 

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -473,16 +473,13 @@ This used to be handled by attackby() on the light fixtures and bulbs themselves
 		return 0
 
 /obj/item/device/lightreplacer/proc/recharge(mob/user)
-	if(isrobot(user))
-		var/mob/living/silicon/robot/R = user
-		if(R && R.cell && R.cell.charge && (glass < glass_max))
-			var/added_glass = 0
-			added_glass = clamp(added_glass, 7500, (glass_max - glass))
-			if(R.cell.use(added_glass * 0.1))
-				add_glass(added_glass, 2)
-				to_chat(usr, "<span class='notice'>\The [src] synthesizes[added_glass] units of glass.</span>")
-				return 1
-		to_chat(usr, "<span class='warning'>You don't have enough charge to synthesize more glass!</span>")
+	if(get_borg_cellcharge(user) && (glass < glass_max))
+		var/added_glass = 0
+		added_glass = clamp(added_glass, 7500, (glass_max - glass))
+		if(use_borg_cellcharge(user,added_glass * 0.1))
+			add_glass(added_glass, 2)
+			to_chat(usr, "<span class='notice'>\The [src] synthesizes[added_glass] units of glass.</span>")
+			return 1
 	return 0
 
 /obj/item/device/lightreplacer/proc/dump_supply(mob/user)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -473,10 +473,10 @@ This used to be handled by attackby() on the light fixtures and bulbs themselves
 		return 0
 
 /obj/item/device/lightreplacer/proc/recharge(mob/user)
-	if(get_borg_cellcharge(user) && (glass < glass_max))
+	if(get_cell_charge(user) && (glass < glass_max))
 		var/added_glass = 0
 		added_glass = clamp(added_glass, 7500, (glass_max - glass))
-		if(use_borg_cellcharge(user,added_glass * 0.1))
+		if(use_cell_charge(user,added_glass * 0.1))
 			add_glass(added_glass, 2)
 			to_chat(usr, "<span class='notice'>\The [src] synthesizes [added_glass] units of glass.</span>")
 			return 1

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -141,7 +141,7 @@ var/static/list/mat2type = list(
 	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
 		if(R && R.get_cell())
-			if(get_borg_cellcharge())
+			if(get_borg_cellcharge(R))
 				var/obj/item/stack/sheet/material_type = material
 				if(material_type)
 					var/modifier = get_mat_cost(initial(active_material.perunit))

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -141,7 +141,7 @@ var/static/list/mat2type = list(
 	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
 		if(R && R.get_cell())
-			if(get_borg_cellcharge(R))
+			if(get_cell_charge(R))
 				var/obj/item/stack/sheet/material_type = material
 				if(material_type)
 					var/modifier = get_mat_cost(initial(active_material.perunit))
@@ -287,4 +287,4 @@ var/static/list/mat2type = list(
 	return 0
 
 /obj/item/device/material_synth/robot/TakeCost(var/spawned, var/modifier, mob/user)
-	return use_borg_cellcharge(user,spawned * modifier * MAT_SYNTH_ROBO)
+	return use_cell_charge(user,spawned * modifier * MAT_SYNTH_ROBO)

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -140,8 +140,8 @@ var/static/list/mat2type = list(
 /obj/item/device/material_synth/robot/create_material(mob/user, var/material)
 	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
-		if(R && R.cell)
-			if(R.cell.charge)
+		if(R && R.get_cell())
+			if(get_borg_cellcharge())
 				var/obj/item/stack/sheet/material_type = material
 				if(material_type)
 					var/modifier = get_mat_cost(initial(active_material.perunit))
@@ -287,7 +287,4 @@ var/static/list/mat2type = list(
 	return 0
 
 /obj/item/device/material_synth/robot/TakeCost(var/spawned, var/modifier, mob/user)
-	if(isrobot(user))
-		var/mob/living/silicon/robot/R = user
-		return R.cell.use(spawned * modifier * MAT_SYNTH_ROBO)
-	return
+	return use_borg_cellcharge(spawned * modifier * MAT_SYNTH_ROBO)

--- a/code/game/objects/items/devices/mat_synth.dm
+++ b/code/game/objects/items/devices/mat_synth.dm
@@ -287,4 +287,4 @@ var/static/list/mat2type = list(
 	return 0
 
 /obj/item/device/material_synth/robot/TakeCost(var/spawned, var/modifier, mob/user)
-	return use_borg_cellcharge(spawned * modifier * MAT_SYNTH_ROBO)
+	return use_borg_cellcharge(user,spawned * modifier * MAT_SYNTH_ROBO)

--- a/code/game/objects/items/robot/robot_items/robot_axe.dm
+++ b/code/game/objects/items/robot/robot_items/robot_axe.dm
@@ -52,14 +52,8 @@
 	(active && isrobot(loc)) ? processing_objects.Add(src) : processing_objects.Remove(src)
 
 /obj/item/weapon/pickaxe/plasmacutter/heat_axe/process()
-	if(isrobot(loc)) //Sanity is never enough.
-		var/mob/living/silicon/robot/robot = loc
-		if(active && robot && robot.cell)
-			var/consume = rand(100,250)
-			if(robot.cell.charge <= consume)
-				toggleActive()
-			robot.cell.use(consume)
-	else
+	var/consume = rand(100,250)
+	if(!use_borg_cellcharge(loc,consume))
 		toggleActive()
 
 /obj/item/weapon/pickaxe/plasmacutter/heat_axe/proc/HellFire(var/mob/living/victim)

--- a/code/game/objects/items/robot/robot_items/robot_axe.dm
+++ b/code/game/objects/items/robot/robot_items/robot_axe.dm
@@ -53,7 +53,7 @@
 
 /obj/item/weapon/pickaxe/plasmacutter/heat_axe/process()
 	var/consume = rand(100,250)
-	if(!use_borg_cellcharge(loc,consume))
+	if(!use_cell_charge(loc,consume))
 		toggleActive()
 
 /obj/item/weapon/pickaxe/plasmacutter/heat_axe/proc/HellFire(var/mob/living/victim)

--- a/code/game/objects/items/robot/robot_items/robot_elec_arm.dm
+++ b/code/game/objects/items/robot/robot_items/robot_elec_arm.dm
@@ -12,7 +12,7 @@
 
 	M.assaulted_by(user)
 
-	use_borg_cellcharge(30)
+	use_borg_cellcharge(user,30)
 
 	M.Knockdown(5)
 	if (M.stuttering < 5)

--- a/code/game/objects/items/robot/robot_items/robot_elec_arm.dm
+++ b/code/game/objects/items/robot/robot_items/robot_elec_arm.dm
@@ -12,7 +12,7 @@
 
 	M.assaulted_by(user)
 
-	use_borg_cellcharge(user,30)
+	use_cell_charge(user,30)
 
 	M.Knockdown(5)
 	if (M.stuttering < 5)

--- a/code/game/objects/items/robot/robot_items/robot_elec_arm.dm
+++ b/code/game/objects/items/robot/robot_items/robot_elec_arm.dm
@@ -12,7 +12,7 @@
 
 	M.assaulted_by(user)
 
-	user.cell.charge -= 30
+	use_borg_cellcharge(30)
 
 	M.Knockdown(5)
 	if (M.stuttering < 5)

--- a/code/game/objects/items/robot/robot_items/robot_gripper.dm
+++ b/code/game/objects/items/robot/robot_items/robot_gripper.dm
@@ -175,13 +175,14 @@
 
 	else if(isrobot(target))//Robots repairing themselves? What can go wrong.
 		var/mob/living/silicon/robot/A = target
-		if(A.opened && A.cell)
-			if(!gripper_safety_check(user, A.cell))//Only allowed if the user pass the safety check.
-				if(grip_item(A.cell, user, FALSE))
-					A.cell.update_icon()
+		var/obj/item/weapon/cell/cell = A.get_cell()
+		if(A.opened && cell)
+			if(!gripper_safety_check(user, cell))//Only allowed if the user pass the safety check.
+				if(grip_item(cell, user, FALSE))
+					cell.update_icon()
 					A.updateicon()
-					A.cell = null
-					user.visible_message("<span class='danger'>[user] removes the power cell from [A]!</span>", "You remove the power cell.")
+					cell = null
+					user.visible_message("<span class='danger'>[user] removes \the [cell] from [A]!</span>", "You remove \the [cell].")
 
 /obj/item/weapon/gripper/chemistry //Used to handle glass containers and pills.
 	name = "chemistry gripper"

--- a/code/game/objects/items/robot/robot_items/robot_gripper.dm
+++ b/code/game/objects/items/robot/robot_items/robot_gripper.dm
@@ -179,9 +179,9 @@
 		if(A.opened && cell)
 			if(!gripper_safety_check(user, cell))//Only allowed if the user pass the safety check.
 				if(grip_item(cell, user, FALSE))
+					A.clear_cell()
 					cell.update_icon()
 					A.updateicon()
-					cell = null
 					user.visible_message("<span class='danger'>[user] removes \the [cell] from [A]!</span>", "You remove \the [cell].")
 
 /obj/item/weapon/gripper/chemistry //Used to handle glass containers and pills.

--- a/code/game/objects/items/robot/robot_items/robot_gripper.dm
+++ b/code/game/objects/items/robot/robot_items/robot_gripper.dm
@@ -175,14 +175,17 @@
 
 	else if(isrobot(target))//Robots repairing themselves? What can go wrong.
 		var/mob/living/silicon/robot/A = target
+		if(!A.opened)
+			return
 		var/obj/item/weapon/cell/cell = A.get_cell()
-		if(A.opened && cell)
-			if(!gripper_safety_check(user, cell))//Only allowed if the user pass the safety check.
-				if(grip_item(cell, user, FALSE))
-					A.clear_cell()
-					cell.update_icon()
-					A.updateicon()
-					user.visible_message("<span class='danger'>[user] removes \the [cell] from [A]!</span>", "You remove \the [cell].")
+		if(!cell)
+			return
+		if(!gripper_safety_check(user, cell))//Only allowed if the user pass the safety check.
+			if(grip_item(cell, user, FALSE))
+				A.clear_cell()
+				cell.update_icon()
+				A.updateicon()
+				user.visible_message("<span class='danger'>[user] removes \the [cell] from [A]!</span>", "You remove \the [cell].")
 
 /obj/item/weapon/gripper/chemistry //Used to handle glass containers and pills.
 	name = "chemistry gripper"

--- a/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
+++ b/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
@@ -21,10 +21,10 @@
 
 	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
-		if(get_borg_cellcharge() < 1200)
+		if(get_borg_cellcharge(user) < 1200)
 			to_chat(user, "<span class='warning'>You don't have enough charge to do this!</span>")
 			return
-		use_borg_cellcharge(1000)
+		use_borg_cellcharge(user,1000)
 		if(R.emagged)
 			safety = FALSE
 		if(R.connected_ai)

--- a/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
+++ b/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
@@ -21,10 +21,10 @@
 
 	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
-		if(R.cell.charge < 1200)
+		if(get_borg_cellcharge() < 1200)
 			to_chat(user, "<span class='warning'>You don't have enough charge to do this!</span>")
 			return
-		R.cell.charge -= 1000
+		use_borg_cellcharge(1000)
 		if(R.emagged)
 			safety = FALSE
 		if(R.connected_ai)

--- a/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
+++ b/code/game/objects/items/robot/robot_items/robot_harm_alarm.dm
@@ -21,10 +21,10 @@
 
 	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
-		if(get_borg_cellcharge(user) < 1200)
+		if(get_cell_charge(user) < 1200)
 			to_chat(user, "<span class='warning'>You don't have enough charge to do this!</span>")
 			return
-		use_borg_cellcharge(user,1000)
+		use_cell_charge(user,1000)
 		if(R.emagged)
 			safety = FALSE
 		if(R.connected_ai)

--- a/code/game/objects/items/robot/robot_items/robot_hug.dm
+++ b/code/game/objects/items/robot/robot_items/robot_hug.dm
@@ -97,7 +97,7 @@
 						user.visible_message("<span class='danger'>[user] shocks [M]. It does not seem to have an effect</span>", \
 							"<span class='danger'>You shock [M] to no effect.</span>")
 				playsound(loc, 'sound/effects/sparks2.ogg', 50, 1, -1)
-				user.cell.charge -= 500
+				use_borg_cellcharge(500)
 				shock_cooldown = TRUE
 				spawn(2 SECONDS)
 				shock_cooldown = FALSE
@@ -112,7 +112,7 @@
 				playsound(loc, 'sound/weapons/crushhug.ogg', 50, 1, -1)
 				M.adjustBruteLoss(20)
 				add_logs(user, M, "crushed with \the [src]", admin = (user.ckey && M.ckey))
-				user.cell.charge -= 300
+				use_borg_cellcharge(300)
 				crush_cooldown = TRUE
 				spawn(2 SECONDS)
 				crush_cooldown = FALSE

--- a/code/game/objects/items/robot/robot_items/robot_hug.dm
+++ b/code/game/objects/items/robot/robot_items/robot_hug.dm
@@ -97,7 +97,7 @@
 						user.visible_message("<span class='danger'>[user] shocks [M]. It does not seem to have an effect</span>", \
 							"<span class='danger'>You shock [M] to no effect.</span>")
 				playsound(loc, 'sound/effects/sparks2.ogg', 50, 1, -1)
-				use_borg_cellcharge(user,500)
+				use_cell_charge(user,500)
 				shock_cooldown = TRUE
 				spawn(2 SECONDS)
 				shock_cooldown = FALSE
@@ -112,7 +112,7 @@
 				playsound(loc, 'sound/weapons/crushhug.ogg', 50, 1, -1)
 				M.adjustBruteLoss(20)
 				add_logs(user, M, "crushed with \the [src]", admin = (user.ckey && M.ckey))
-				use_borg_cellcharge(user,300)
+				use_cell_charge(user,300)
 				crush_cooldown = TRUE
 				spawn(2 SECONDS)
 				crush_cooldown = FALSE

--- a/code/game/objects/items/robot/robot_items/robot_hug.dm
+++ b/code/game/objects/items/robot/robot_items/robot_hug.dm
@@ -97,7 +97,7 @@
 						user.visible_message("<span class='danger'>[user] shocks [M]. It does not seem to have an effect</span>", \
 							"<span class='danger'>You shock [M] to no effect.</span>")
 				playsound(loc, 'sound/effects/sparks2.ogg', 50, 1, -1)
-				use_borg_cellcharge(500)
+				use_borg_cellcharge(user,500)
 				shock_cooldown = TRUE
 				spawn(2 SECONDS)
 				shock_cooldown = FALSE
@@ -112,7 +112,7 @@
 				playsound(loc, 'sound/weapons/crushhug.ogg', 50, 1, -1)
 				M.adjustBruteLoss(20)
 				add_logs(user, M, "crushed with \the [src]", admin = (user.ckey && M.ckey))
-				use_borg_cellcharge(300)
+				use_borg_cellcharge(user,300)
 				crush_cooldown = TRUE
 				spawn(2 SECONDS)
 				crush_cooldown = FALSE

--- a/code/game/objects/items/robot/robot_items/robot_hypospray.dm
+++ b/code/game/objects/items/robot/robot_items/robot_hypospray.dm
@@ -43,10 +43,10 @@
 
 	charge_tick = 0
 
-	if(get_borg_cellcharge(loc))
+	if(get_cell_charge(loc))
 		var/datum/reagents/reagents = reagent_list[mode]
 		if(reagents.total_volume < reagents.maximum_volume) // don't recharge reagents and drain power if the storage is full
-			use_borg_cellcharge(loc,charge_cost) // take power from borg
+			use_cell_charge(loc,charge_cost) // take power from borg
 			reagents.add_reagent(reagent_ids[mode], 5) // and fill hypo with reagent.
 
 	return 1

--- a/code/game/objects/items/robot/robot_items/robot_hypospray.dm
+++ b/code/game/objects/items/robot/robot_items/robot_hypospray.dm
@@ -43,15 +43,11 @@
 
 	charge_tick = 0
 
-	if(isrobot(loc))
-		var/mob/living/silicon/robot/robot = loc
-
-		if(robot && robot.cell)
-			var/datum/reagents/reagents = reagent_list[mode]
-
-			if(reagents.total_volume < reagents.maximum_volume) // don't recharge reagents and drain power if the storage is full
-				robot.cell.use(charge_cost) // take power from borg
-				reagents.add_reagent(reagent_ids[mode], 5) // and fill hypo with reagent.
+	if(get_borg_cellcharge())
+		var/datum/reagents/reagents = reagent_list[mode]
+		if(reagents.total_volume < reagents.maximum_volume) // don't recharge reagents and drain power if the storage is full
+			use_borg_cellcharge(loc,charge_cost) // take power from borg
+			reagents.add_reagent(reagent_ids[mode], 5) // and fill hypo with reagent.
 
 	return 1
 

--- a/code/game/objects/items/robot/robot_items/robot_hypospray.dm
+++ b/code/game/objects/items/robot/robot_items/robot_hypospray.dm
@@ -43,7 +43,7 @@
 
 	charge_tick = 0
 
-	if(get_borg_cellcharge())
+	if(get_borg_cellcharge(loc))
 		var/datum/reagents/reagents = reagent_list[mode]
 		if(reagents.total_volume < reagents.maximum_volume) // don't recharge reagents and drain power if the storage is full
 			use_borg_cellcharge(loc,charge_cost) // take power from borg

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -262,15 +262,11 @@
 			if(chest.extension)
 				O.component_extension = chest.extension
 				O.upgrade_components()
-			O.cell = chest.cell
-			O.cell.forceMove(O)
+			var/datum/robot_component/cell_component = O.components["power cell"]
+			cell_component.wrapped = chest.cell
+			cell_component.installed = 1
+			chest.cell.forceMove(O)
 			W.forceMove(O) //Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.
-
-			// Since we "magically" installed a cell, we also have to update the correct component.
-			if(O.cell)
-				var/datum/robot_component/cell_component = O.components["power cell"]
-				cell_component.wrapped = O.cell
-				cell_component.installed = 1
 
 			feedback_inc("cyborg_birth",1)
 

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -275,8 +275,9 @@
 /obj/item/weapon/melee/baton/loaded/borg/deductcharge(var/chrgdeductamt)
 	if (isrobot(loc))
 		var/mob/living/silicon/robot/R = loc
-		if (R.cell)
-			R.cell.use(hitcost)
+		var/obj/item/weapon/cell/Rcell = R.get_cell()
+		if (Rcell)
+			Rcell.use(hitcost)
 
 /obj/item/weapon/melee/baton/harm
 	desc = "A baton for permanently incapacitating people with."

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -273,11 +273,7 @@
 	return
 
 /obj/item/weapon/melee/baton/loaded/borg/deductcharge(var/chrgdeductamt)
-	if (isrobot(loc))
-		var/mob/living/silicon/robot/R = loc
-		var/obj/item/weapon/cell/Rcell = R.get_cell()
-		if (Rcell)
-			Rcell.use(hitcost)
+	use_borg_cellcharge(loc,hitcost)
 
 /obj/item/weapon/melee/baton/harm
 	desc = "A baton for permanently incapacitating people with."

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -273,7 +273,7 @@
 	return
 
 /obj/item/weapon/melee/baton/loaded/borg/deductcharge(var/chrgdeductamt)
-	use_borg_cellcharge(loc,hitcost)
+	use_cell_charge(loc,hitcost)
 
 /obj/item/weapon/melee/baton/harm
 	desc = "A baton for permanently incapacitating people with."

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -583,10 +583,7 @@
 			user.stuttering = 10
 			user.Knockdown(10)
 			if(isrobot(user))
-				var/mob/living/silicon/robot/R = user
-				var/obj/item/weapon/cell/Rcell = R.get_cell()
-				if(Rcell)
-					Rcell.charge -= 20
+				use_cell_charge(user,20)
 			else
 				B.deductcharge(1)
 			user.visible_message( \

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -584,7 +584,9 @@
 			user.Knockdown(10)
 			if(isrobot(user))
 				var/mob/living/silicon/robot/R = user
-				R.cell.charge -= 20
+				var/obj/item/weapon/cell/Rcell = R.get_cell()
+				if(Rcell)
+					Rcell.charge -= 20
 			else
 				B.deductcharge(1)
 			user.visible_message( \

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -314,10 +314,7 @@
 		return 0
 
 	var/cellcharge = get_borg_cellcharge(user)
-	if(!cellcharge)
-		return
-
-	return cellcharge / cell_power_per_energy
+	return cellcharge ? cellcharge / cell_power_per_energy : 0
 
 //Matter based RCDs.
 /obj/item/device/rcd/matter

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -313,7 +313,7 @@
 	if(!isrobot(user))
 		return 0
 
-	var/cellcharge = get_borg_cellcharge()
+	var/cellcharge = get_borg_cellcharge(user)
 	if(!cellcharge)
 		return
 

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -307,7 +307,7 @@
 	var/cell_power_per_energy = 30
 
 /obj/item/device/rcd/borg/use_energy(var/amount, var/mob/user)
-	use_borg_cellcharge(amount * cell_power_per_energy)
+	use_borg_cellcharge(user,amount * cell_power_per_energy)
 
 /obj/item/device/rcd/borg/get_energy(var/mob/user)
 	if(!isrobot(user))

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -307,10 +307,10 @@
 	var/cell_power_per_energy = 30
 
 /obj/item/device/rcd/borg/use_energy(var/amount, var/mob/user)
-	use_borg_cellcharge(user,amount * cell_power_per_energy)
+	use_cell_charge(user,amount * cell_power_per_energy)
 
 /obj/item/device/rcd/borg/get_energy(var/mob/user)
-	return get_borg_cellcharge(user) / cell_power_per_energy
+	return get_cell_charge(user) / cell_power_per_energy
 
 //Matter based RCDs.
 /obj/item/device/rcd/matter

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -310,9 +310,6 @@
 	use_borg_cellcharge(user,amount * cell_power_per_energy)
 
 /obj/item/device/rcd/borg/get_energy(var/mob/user)
-	if(!isrobot(user))
-		return 0
-
 	var/cellcharge = get_borg_cellcharge(user)
 	return cellcharge ? cellcharge / cell_power_per_energy : 0
 

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -310,8 +310,7 @@
 	use_borg_cellcharge(user,amount * cell_power_per_energy)
 
 /obj/item/device/rcd/borg/get_energy(var/mob/user)
-	var/cellcharge = get_borg_cellcharge(user)
-	return cellcharge ? cellcharge / cell_power_per_energy : 0
+	return get_borg_cellcharge(user) / cell_power_per_energy
 
 //Matter based RCDs.
 /obj/item/device/rcd/matter

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -307,26 +307,17 @@
 	var/cell_power_per_energy = 30
 
 /obj/item/device/rcd/borg/use_energy(var/amount, var/mob/user)
-	if(!isrobot(user))
-		return
-
-	var/mob/living/silicon/robot/R = user
-
-	if(!R.cell)
-		return
-
-	R.cell.use(amount * cell_power_per_energy)
+	use_borg_cellcharge(amount * cell_power_per_energy)
 
 /obj/item/device/rcd/borg/get_energy(var/mob/user)
 	if(!isrobot(user))
 		return 0
 
-	var/mob/living/silicon/robot/R = user
-
-	if(!R.cell)
+	var/cellcharge = get_borg_cellcharge()
+	if(!cellcharge)
 		return
 
-	return R.cell.charge / cell_power_per_energy
+	return cellcharge ? cellcharge / cell_power_per_energy
 
 //Matter based RCDs.
 /obj/item/device/rcd/matter

--- a/code/modules/RCD/RCD.dm
+++ b/code/modules/RCD/RCD.dm
@@ -317,7 +317,7 @@
 	if(!cellcharge)
 		return
 
-	return cellcharge ? cellcharge / cell_power_per_energy
+	return cellcharge / cell_power_per_energy
 
 //Matter based RCDs.
 /obj/item/device/rcd/matter

--- a/code/modules/RCD/engie.dm
+++ b/code/modules/RCD/engie.dm
@@ -232,8 +232,7 @@
 /obj/item/device/rcd/borg/engineering/attack_self(var/mob/user)
 	if(!isrobot(user))
 		return
-	var/cellcharge = get_borg_cellcharge(user)
-	matter= cellcharge ? cellcharge / cell_power_per_energy : 0
+	matter = get_borg_cellcharge(user) / cell_power_per_energy
 
 	rebuild_ui()	
 	interface.show(user)
@@ -371,8 +370,7 @@
 
 	if(!isrobot(user))
 		return 1
-	var/cellcharge = get_borg_cellcharge(user)
-	matter= cellcharge ? cellcharge / cell_power_per_energy : 0
+	matter = get_borg_cellcharge(user) / cell_power_per_energy
 
 	var/c=selected_schem.build(A,user)
 	if(!c)
@@ -380,8 +378,7 @@
 	else
 		use_energy(c, user)
 		
-		cellcharge = get_borg_cellcharge(user)
-		matter= cellcharge ? cellcharge / cell_power_per_energy : 0
+		matter = get_borg_cellcharge(user) / cell_power_per_energy
 		
 		rebuild_ui()
 	return 1	

--- a/code/modules/RCD/engie.dm
+++ b/code/modules/RCD/engie.dm
@@ -232,7 +232,7 @@
 /obj/item/device/rcd/borg/engineering/attack_self(var/mob/user)
 	if(!isrobot(user))
 		return
-	matter = get_borg_cellcharge(user) / cell_power_per_energy
+	matter = get_energy(user)
 
 	rebuild_ui()	
 	interface.show(user)
@@ -370,7 +370,7 @@
 
 	if(!isrobot(user))
 		return 1
-	matter = get_borg_cellcharge(user) / cell_power_per_energy
+	matter = get_energy(user)
 
 	var/c=selected_schem.build(A,user)
 	if(!c)
@@ -378,7 +378,7 @@
 	else
 		use_energy(c, user)
 		
-		matter = get_borg_cellcharge(user) / cell_power_per_energy
+		matter = get_energy(user)
 		
 		rebuild_ui()
 	return 1	

--- a/code/modules/RCD/engie.dm
+++ b/code/modules/RCD/engie.dm
@@ -380,7 +380,7 @@
 	else
 		use_energy(c, user)
 		
-		var/cellcharge = get_borg_cellcharge()
+		cellcharge = get_borg_cellcharge()
 		matter= cellcharge ? cellcharge / cell_power_per_energy : 0
 		
 		rebuild_ui()

--- a/code/modules/RCD/engie.dm
+++ b/code/modules/RCD/engie.dm
@@ -232,11 +232,8 @@
 /obj/item/device/rcd/borg/engineering/attack_self(var/mob/user)
 	if(!isrobot(user))
 		return
-	var/mob/living/silicon/robot/R = user
-	if(!R.cell)
-		matter=0
-	else
-		matter=R.cell.charge / cell_power_per_energy
+	var/cellcharge = get_borg_cellcharge()
+	matter= cellcharge ? cellcharge / cell_power_per_energy : 0
 
 	rebuild_ui()	
 	interface.show(user)
@@ -374,11 +371,8 @@
 
 	if(!isrobot(user))
 		return 1
-	var/mob/living/silicon/robot/R = user
-	if(!R.cell)
-		matter=0
-	else
-		matter=R.cell.charge / cell_power_per_energy
+	var/cellcharge = get_borg_cellcharge()
+	matter= cellcharge ? cellcharge / cell_power_per_energy : 0
 
 	var/c=selected_schem.build(A,user)
 	if(!c)
@@ -386,10 +380,8 @@
 	else
 		use_energy(c, user)
 		
-		if(!R.cell)
-			matter=0
-		else
-			matter=R.cell.charge / cell_power_per_energy
+		var/cellcharge = get_borg_cellcharge()
+		matter= cellcharge ? cellcharge / cell_power_per_energy : 0
 		
 		rebuild_ui()
 	return 1	

--- a/code/modules/RCD/engie.dm
+++ b/code/modules/RCD/engie.dm
@@ -232,7 +232,7 @@
 /obj/item/device/rcd/borg/engineering/attack_self(var/mob/user)
 	if(!isrobot(user))
 		return
-	var/cellcharge = get_borg_cellcharge()
+	var/cellcharge = get_borg_cellcharge(user)
 	matter= cellcharge ? cellcharge / cell_power_per_energy : 0
 
 	rebuild_ui()	
@@ -371,7 +371,7 @@
 
 	if(!isrobot(user))
 		return 1
-	var/cellcharge = get_borg_cellcharge()
+	var/cellcharge = get_borg_cellcharge(user)
 	matter= cellcharge ? cellcharge / cell_power_per_energy : 0
 
 	var/c=selected_schem.build(A,user)
@@ -380,7 +380,7 @@
 	else
 		use_energy(c, user)
 		
-		cellcharge = get_borg_cellcharge()
+		cellcharge = get_borg_cellcharge(user)
 		matter= cellcharge ? cellcharge / cell_power_per_energy : 0
 		
 		rebuild_ui()

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -75,9 +75,9 @@
 		//M.custom_name = created_name
 
 		brainmob.mind.transfer_to(M)
-		var/datum/robot_component/C = M.components["power cell"]
-		C.wrapped = locate(/obj/item/weapon/cell) in contents
-		C.wrapped.forceMove(M)
+		var/obj/item/weapon/cell/ourcell = locate(/obj/item/weapon/cell) in contents
+		ourcell.forceMove(M)
+		M.add_cell(ourcell)
 		src.forceMove(M)//Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.
 		M.mmi = src
 

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -75,8 +75,9 @@
 		//M.custom_name = created_name
 
 		brainmob.mind.transfer_to(M)
-		M.cell = locate(/obj/item/weapon/cell) in contents
-		M.cell.forceMove(M)
+		var/datum/robot_component/C = M.components["power cell"]
+		C.wrapped = locate(/obj/item/weapon/cell) in contents
+		C.wrapped.forceMove(M)
 		src.forceMove(M)//Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.
 		M.mmi = src
 

--- a/code/modules/mob/living/silicon/emote.dm
+++ b/code/modules/mob/living/silicon/emote.dm
@@ -126,7 +126,7 @@
 	set name = "Power Warning"
 
 	if(stat != DEAD)
-		if(!get_cell_charge())
+		if(!get_cell_charge(src))
 			visible_message("The power warning light on <span class='name'>[src]</span> flashes urgently.")
 			to_chat(src, "<span class='info' style=\"font-family:Courier\">You announce you are operating in low power mode.</span>")
 			playsound(loc, 'sound/machines/buzz-two.ogg', 50, 0)

--- a/code/modules/mob/living/silicon/emote.dm
+++ b/code/modules/mob/living/silicon/emote.dm
@@ -126,7 +126,7 @@
 	set name = "Power Warning"
 
 	if(stat != DEAD)
-		if(!cell || !cell.charge)
+		if(!get_cell_charge())
 			visible_message("The power warning light on <span class='name'>[src]</span> flashes urgently.")
 			to_chat(src, "<span class='info' style=\"font-family:Courier\">You announce you are operating in low power mode.</span>")
 			playsound(loc, 'sound/machines/buzz-two.ogg', 50, 0)

--- a/code/modules/mob/living/silicon/mommi/examine.dm
+++ b/code/modules/mob/living/silicon/mommi/examine.dm
@@ -26,11 +26,11 @@
 		msg += "Its utility claw is gripping [bicon(I)] [I.gender==PLURAL?"some":"a"] [I.name].\n"
 
 	if(opened)
-		msg += "<span class='warning'>Its cover is open and the power cell is [cell ? "installed" : "missing"].</span>\n"
+		msg += "<span class='warning'>Its cover is open and the power cell is [get_cell() ? "installed" : "missing"].</span>\n"
 	else
 		msg += "Its cover is closed.\n"
 
-	if(cell && cell.charge <= 0)
+	if(get_cell_charge() <= 0)
 		msg += "<span class='warning'>Its battery indicator is blinking red!</span>\n"
 
 	switch(src.stat)

--- a/code/modules/mob/living/silicon/mommi/examine.dm
+++ b/code/modules/mob/living/silicon/mommi/examine.dm
@@ -30,7 +30,7 @@
 	else
 		msg += "Its cover is closed.\n"
 
-	if(get_cell_charge() <= 0)
+	if(get_cell_charge(src) <= 0)
 		msg += "<span class='warning'>Its battery indicator is blinking red!</span>\n"
 
 	switch(src.stat)

--- a/code/modules/mob/living/silicon/mommi/mommi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi.dm
@@ -132,11 +132,11 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 	else if(istype(W, /obj/item/weapon/cell) && opened)	// trying to put a cell inside
 		if(wiresexposed)
 			to_chat(user, "Close the panel first.")
-		else if(cell)
+		else if(get_cell())
 			to_chat(user, "There is a power cell already installed.")
 		else
 			user.drop_item(W, src)
-			cell = W
+			add_cell(W,user)
 			to_chat(user, "You insert the power cell.")
 		updateicon()
 
@@ -146,12 +146,12 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 		else
 			to_chat(user, "You can't reach the wiring.")
 
-	else if(W.is_screwdriver(user) && opened && !cell)	// haxing
+	else if(W.is_screwdriver(user) && opened && !get_cell())	// haxing
 		wiresexposed = !wiresexposed
 		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
 		updateicon()
 
-	else if(W.is_screwdriver(user) && opened && cell)	// radio
+	else if(W.is_screwdriver(user) && opened && get_cell())	// radio
 		if(radio)
 			radio.attackby(W,user)//Push it to the radio to let it handle everything
 		else
@@ -189,12 +189,13 @@ They can only use one tool at a time, they can't choose modules, and they have 1
 	add_fingerprint(user)
 
 	if(opened && !wiresexposed && (!isMoMMI(user)))
+		var/obj/item/weapon/cell/cell = get_cell()
 		if(cell)
 			cell.updateicon()
 			cell.add_fingerprint(user)
 			user.put_in_active_hand(cell)
 			to_chat(user, "You remove \the [cell].")
-			cell = null
+			clear_cell()
 			updateicon()
 			return
 

--- a/code/modules/mob/living/silicon/mommi/mommi_inventory.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_inventory.dm
@@ -12,7 +12,7 @@
 	// And before you ask, this is how /mob handles NULLs, too.
 	if(!W)
 		return FALSE
-	if(get_cell_charge() <= ROBOT_LOW_POWER)
+	if(get_cell_charge(src) <= ROBOT_LOW_POWER)
 		if(!is_in_modules(W))
 			drop_item(W)
 			return FALSE

--- a/code/modules/mob/living/silicon/mommi/mommi_inventory.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_inventory.dm
@@ -12,7 +12,7 @@
 	// And before you ask, this is how /mob handles NULLs, too.
 	if(!W)
 		return FALSE
-	if(cell && cell.charge <= ROBOT_LOW_POWER)
+	if(get_cell_charge() <= ROBOT_LOW_POWER)
 		if(!is_in_modules(W))
 			drop_item(W)
 			return FALSE

--- a/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
@@ -164,7 +164,7 @@
 			to_chat(user, "<span class='notice'>You anchor the SAMMI to the floor.</span>")
 			anchored = 1
 			add_cell(cellhold)
-			clear_cell()
+			cellhold = null
 			if(icon_state == "sammi_offline")
 				icon_state = "sammi_offline_a"
 			else

--- a/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
+++ b/code/modules/mob/living/silicon/mommi/mommi_subtypes/sammi.dm
@@ -125,12 +125,12 @@
 	if (istype(W, /obj/item/weapon/cell) && opened)	// trying to put a cell inside
 		if(wiresexposed)
 			to_chat(user, "Close the wiring panel first.")
-		else if(cell || cellhold)
+		else if(get_cell() || cellhold)
 			to_chat(user, "There is a power cell already installed.")
 		else
 			user.drop_item(W, src)
 			if(anchored)
-				cell = W
+				add_cell(W,user)
 			else
 				cellhold = W
 			to_chat(user, "You insert the power cell.")
@@ -152,8 +152,8 @@
 		if(anchored)
 			to_chat(user, "<span class='notice'>You unbolt the SAMMI from the floor.</span>")
 			anchored = 0
-			cellhold = cell
-			cell = null
+			cellhold = get_cell()
+			clear_cell()
 			if(icon_state == "sammi_offline_a")
 				icon_state = "sammi_offline"
 			else
@@ -163,8 +163,8 @@
 		else
 			to_chat(user, "<span class='notice'>You anchor the SAMMI to the floor.</span>")
 			anchored = 1
-			cell = cellhold
-			cellhold = null
+			add_cell(cellhold)
+			clear_cell()
 			if(icon_state == "sammi_offline")
 				icon_state = "sammi_offline_a"
 			else
@@ -201,9 +201,10 @@
 
 	if(user != src)
 		if(opened && !wiresexposed)
+			var/obj/item/weapon/cell/cell = get_cell()
 			if(cell || cellhold)
 				if(cellhold)
-					cell = cellhold
+					add_cell(cellhold)
 					cellhold = null
 				if(cell)
 					cell.updateicon()
@@ -221,8 +222,8 @@
 	..()
 	laws = new sammi_base_law_type
 	module = new /obj/item/weapon/robot_module/sammi(src)
-	cellhold = cell
-	cell = null
+	cellhold = get_cell()
+	clear_cell()
 
 /mob/living/silicon/robot/mommi/sammi/ghost()
 	//if(src.subtype == "sammi")

--- a/code/modules/mob/living/silicon/mommi/update_icons.dm
+++ b/code/modules/mob/living/silicon/mommi/update_icons.dm
@@ -25,7 +25,7 @@
 		else
 			icon_state = "[base_icon]"
 
-	if(!stat && cell != null)
+	if(!stat && get_cell())
 		eyes = image(icon,"eyes-[base_icon][emagged?"-emagged":""]", ABOVE_LIGHTING_LAYER)
 		if(plane == HIDING_MOB_PLANE) // Hiding MoMMIs
 			overlay_plane = FLOAT_PLANE
@@ -45,7 +45,7 @@
 	if(opened)
 		if(wiresexposed)
 			overlays += image(icon = icon, icon_state = "[has_icon(icon, "[base_icon]-ov-openpanel +w")? "[icon_state]-ov-openpanel +w" : "ov-openpanel +w"]")
-		else if(cell)
+		else if(get_cell())
 			overlays += image(icon = icon, icon_state = "[has_icon(icon, "[base_icon]-ov-openpanel +c")? "[icon_state]-ov-openpanel +c" : "ov-openpanel +c"]")
 		else
 			overlays += image(icon = icon, icon_state = "[has_icon(icon, "[base_icon]-ov-openpanel -c")? "[icon_state]-ov-openpanel -c" : "ov-openpanel -c"]")

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -193,7 +193,7 @@
 	return C && C.installed == COMPONENT_INSTALLED && C.toggled && C.is_powered()
 
 /mob/living/silicon/robot/proc/exchange_parts(mob/user, obj/item/weapon/storage/bag/gadgets/part_replacer/W)
-	if (W.bluespace || wiresexposed || opened)
+	/*if (W.bluespace || wiresexposed || opened)
 		var/shouldplaysound = FALSE
 		for(var/V in components)
 			var/datum/robot_component/C = components[V]
@@ -219,7 +219,8 @@
 							shouldplaysound = TRUE //Only play the sound when parts are actually replaced!
 							break
 		if(shouldplaysound)
-			W.play_rped_sound()
+			W.play_rped_sound()*/
+	return
 
 /obj/item/broken_device
 	name = "broken component"

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -128,16 +128,16 @@
 		electronics_damage = I.electronics_damage
 		brute_damage = I.brute_damage
 		if(owner.can_diagnose())
-			to_chat(src, "<span class='info' style=\"font-family:Courier\">New power source installed. Type: [I.name]. Charge: [I.charge] out of [I.maxcharge].</span>")
+			to_chat(owner, "<span class='info' style=\"font-family:Courier\">New power source installed. Type: [I.name]. Charge: [I.charge] out of [I.maxcharge].</span>")
 		if(I.occupant)
-			to_chat(I.occupant,"<span class='notice'>You are now inside \the [src], in control of its targeting.</span>")
+			to_chat(I.occupant,"<span class='notice'>You are now inside \the [owner], in control of its targeting.</span>")
 			owner.pulsecompromised = 1
-			I.occupant.loc = src
-			I.occupant.current_robot = src
+			I.occupant.loc = owner
+			I.occupant.current_robot = owner
 			I.occupant = null
-			to_chat(src, "<span class='danger'>ERRORERRORERROR</span>")
+			to_chat(owner, "<span class='danger'>ERRORERRORERROR</span>")
 			spawn(2 SECONDS)
-				to_chat(src, "<span class='danger'>ALERT: ELECTRICAL MALEVOLENCE DETECTED, TARGETING SYSTEMS HIJACKED, REPORT ALL UNWANTED ACTIVITY IN VERBAL FORM</span>")
+				to_chat(owner, "<span class='danger'>ALERT: ELECTRICAL MALEVOLENCE DETECTED, TARGETING SYSTEMS HIJACKED, REPORT ALL UNWANTED ACTIVITY IN VERBAL FORM</span>")
 
 /datum/robot_component/cell/uninstall(var/mob/user,var/loud = FALSE)
 	installed = COMPONENT_MISSING

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -54,7 +54,8 @@
 			owner.visible_message("A click sounds from <span class='name'>[owner]</span>, indicating the automatic cover release failsafe.")
 			if(owner.can_diagnose())
 				to_chat(owner, "<span class='notice' style=\"font-family:Courier\">Cover auto-unlocked.</span>")
-	wrapped = G
+	else
+		wrapped = G
 
 	// The thing itself isn't there anymore, but some fried remains are.
 	installed = COMPONENT_BROKEN

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -36,7 +36,7 @@
 	if(wrapped)
 		to_chat(user, "You remove \the [wrapped].")
 		if(owner.can_diagnose())
-			to_chat(owner, "<span class='info' style=\"font-family:Courier\">[istype(wrapped, /obj/item/broken_device) ? "Destroyed [src]" : "Functional [wrapped.name]"] removed.</span>")
+			to_chat(owner, "<span class='info' style=\"font-family:Courier\">[installed == COMPONENT_BROKEN ? "Destroyed [src]" : "Functional [wrapped.name]"] removed.</span>")
 		if(istype(wrapped,/obj/item/robot_parts/robot_component))
 			var/obj/item/robot_parts/robot_component/I = wrapped
 			I.brute_damage = brute_damage

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -42,7 +42,6 @@
 			I.brute_damage = brute_damage
 			I.electronics_damage = electronics_damage
 			I.isupgrade = upgraded
-		return wrapped
 
 /datum/robot_component/proc/destroy()
 	var/obj/item/broken_device/G = new/obj/item/broken_device
@@ -115,17 +114,7 @@
 	owner.updateicon()
 
 /datum/robot_component/cell/install(var/mob/user,var/obj/item/robot_parts/robot_component/I)
-	user.drop_item(I, src)
-	if(owner.cell)
-		to_chat(user, "You swap the power cell within with the new cell in your hand.")
-		var/obj/item/weapon/cell/oldpowercell = owner.cell
-		oldpowercell.electronics_damage = electronics_damage
-		oldpowercell.brute_damage = brute_damage
-		user.put_in_hands(oldpowercell)
-		if(owner.can_diagnose())
-			to_chat(owner, "<span class='info' style=\"font-family:Courier\">Cell removed.</span>")
-	else
-		to_chat(user, "You insert the power cell.")
+	to_chat(user, "You insert \the [I].")
 	owner.cell = I
 	installed = COMPONENT_INSTALLED
 	wrapped = I
@@ -142,6 +131,15 @@
 		to_chat(src, "<span class='danger'>ERRORERRORERROR</span>")
 		spawn(2 SECONDS)
 			to_chat(src, "<span class='danger'>ALERT: ELECTRICAL MALEVOLENCE DETECTED, TARGETING SYSTEMS HIJACKED, REPORT ALL UNWANTED ACTIVITY IN VERBAL FORM</span>")
+
+/datum/robot_component/cell/uninstall(var/mob/user)
+	installed = COMPONENT_MISSING
+	if(owner.cell)
+		to_chat(user, "You remove \the [owner.cell].")
+		owner.cell.electronics_damage = electronics_damage
+		owner.cell.brute_damage = brute_damage
+		if(owner.can_diagnose())
+			to_chat(owner, "<span class='info' style=\"font-family:Courier\">Cell removed.</span>")
 
 /datum/robot_component/radio
 	name = "radio"

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -30,7 +30,7 @@
 		if(owner.can_diagnose())
 			to_chat(owner, "<span class='info' style=\"font-family:Courier\">New [I.name] installed.</span>")
 
-/datum/robot_component/proc/uninstall(var/mob/user)
+/datum/robot_component/proc/uninstall(var/mob/user,var/loud = FALSE)
 	if(installed == COMPONENT_INSTALLED)
 		installed = FALSE
 	if(wrapped)
@@ -132,10 +132,14 @@
 		spawn(2 SECONDS)
 			to_chat(src, "<span class='danger'>ALERT: ELECTRICAL MALEVOLENCE DETECTED, TARGETING SYSTEMS HIJACKED, REPORT ALL UNWANTED ACTIVITY IN VERBAL FORM</span>")
 
-/datum/robot_component/cell/uninstall(var/mob/user)
+/datum/robot_component/cell/uninstall(var/mob/user,var/loud = FALSE)
 	installed = COMPONENT_MISSING
 	if(owner.cell)
-		to_chat(user, "You remove \the [owner.cell].")
+		if(loud)
+			user.visible_message("<span class='warning'>[user] removes [owner]'s [owner.cell.name].</span>", \
+			"<span class='notice'>You remove [owner]'s [owner.cell.name].</span>")
+		else
+			to_chat(user, "You remove \the [owner.cell].")
 		owner.cell.electronics_damage = electronics_damage
 		owner.cell.brute_damage = brute_damage
 		if(owner.can_diagnose())

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -177,17 +177,6 @@
 	energy_consumption = 0
 	max_damage = 30
 
-/mob/living/silicon/robot/proc/initialize_components()
-	// This only initializes the components, it doesn't set them to installed.
-
-	components["actuator"] = new/datum/robot_component/actuator(src)
-	components["radio"] = new/datum/robot_component/radio(src)
-	components["power cell"] = new/datum/robot_component/cell(src)
-	components["diagnosis unit"] = new/datum/robot_component/diagnosis_unit(src)
-	components["camera"] = new/datum/robot_component/camera(src)
-	components["comms"] = new/datum/robot_component/binary_communication(src)
-	components["armour"] = new/datum/robot_component/armour(src)
-
 /mob/living/silicon/robot/proc/is_component_functioning(module_name)
 	var/datum/robot_component/C = components[module_name]
 	return C && C.installed == COMPONENT_INSTALLED && C.toggled && C.is_powered()

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -197,15 +197,27 @@
 		var/shouldplaysound = FALSE
 		for(var/V in components)
 			var/datum/robot_component/C = components[V]
-			for(var/obj/item/robot_parts/robot_component/I in W.contents)
-				if(!C.installed || (I.isupgrade && !C.upgraded) && istype(I, C.external_type))
-					C.uninstall(user)
-					if(C.wrapped)
-						W.handle_item_insertion(C.wrapped, 1)
-					C.install(user,I)
-					W.remove_from_storage(I, null)
-					shouldplaysound = TRUE //Only play the sound when parts are actually replaced!
-					break
+			if(!C.installed)
+				for(var/obj/item/robot_parts/robot_component/I in W.contents)
+					if((I.isupgrade && !C.upgraded) && istype(I, C.external_type))
+						C.uninstall(user)
+						if(C.wrapped)
+							W.handle_item_insertion(C.wrapped, 1)
+						C.install(user,I)
+						W.remove_from_storage(I, null)
+						shouldplaysound = TRUE //Only play the sound when parts are actually replaced!
+						break
+				if(istype(C.wrapped,/obj/item/weapon/cell))
+					var/obj/item/weapon/cell/cell = C.wrapped
+					for(var/obj/item/weapon/cell/I2 in W.contents)
+						if((I2.rating > cell.rating))
+							C.uninstall(user)
+							if(C.wrapped)
+								W.handle_item_insertion(C.wrapped, 1)
+							C.install(user,I2)
+							W.remove_from_storage(I2, null)
+							shouldplaysound = TRUE //Only play the sound when parts are actually replaced!
+							break
 		if(shouldplaysound)
 			W.play_rped_sound()
 

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -58,7 +58,6 @@
 
 	// The thing itself isn't there anymore, but some fried remains are.
 	installed = COMPONENT_BROKEN
-	uninstall()
 	if(owner.can_diagnose())
 		to_chat(owner, "<span class='alert' style=\"font-family:Courier\">Warning: Critical damage to [brokenpartname] sustained. Component offline.</span>")
 
@@ -114,6 +113,35 @@
 	..()
 	owner.cell = null
 	owner.updateicon()
+
+/datum/robot_component/cell/install(var/mob/user,var/obj/item/robot_parts/robot_component/I)
+	user.drop_item(I, src)
+	if(owner.cell)
+		to_chat(user, "You swap the power cell within with the new cell in your hand.")
+		var/obj/item/weapon/cell/oldpowercell = owner.cell
+		oldpowercell.electronics_damage = electronics_damage
+		oldpowercell.brute_damage = brute_damage
+		user.put_in_hands(oldpowercell)
+		if(owner.can_diagnose())
+			to_chat(owner, "<span class='info' style=\"font-family:Courier\">Cell removed.</span>")
+	else
+		to_chat(user, "You insert the power cell.")
+	owner.cell = I
+	installed = COMPONENT_INSTALLED
+	wrapped = I
+	electronics_damage = owner.cell.electronics_damage
+	brute_damage = owner.cell.brute_damage
+	if(owner.can_diagnose())
+		to_chat(src, "<span class='info' style=\"font-family:Courier\">New power source installed. Type: [owner.cell.name]. Charge: [owner.cell.charge] out of [owner.cell.maxcharge].</span>")
+	if(owner.cell.occupant)
+		to_chat(owner.cell.occupant,"<span class='notice'>You are now inside \the [src], in control of its targeting.</span>")
+		owner.pulsecompromised = 1
+		owner.cell.occupant.loc = src
+		owner.cell.occupant.current_robot = src
+		owner.cell.occupant = null
+		to_chat(src, "<span class='danger'>ERRORERRORERROR</span>")
+		spawn(2 SECONDS)
+			to_chat(src, "<span class='danger'>ALERT: ELECTRICAL MALEVOLENCE DETECTED, TARGETING SYSTEMS HIJACKED, REPORT ALL UNWANTED ACTIVITY IN VERBAL FORM</span>")
 
 /datum/robot_component/radio
 	name = "radio"

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -1,27 +1,48 @@
 // TODO: remove the robot.mmi and robot.cell variables and completely rely on the robot component system
 
-/datum/robot_component/var/name
-/datum/robot_component/var/installed = COMPONENT_MISSING
-/datum/robot_component/var/powered = FALSE
-/datum/robot_component/var/toggled = TRUE
-/datum/robot_component/var/brute_damage = 0
-/datum/robot_component/var/electronics_damage = 0
-/datum/robot_component/var/vulnerability = 1
-/datum/robot_component/var/energy_consumption = 0
-/datum/robot_component/var/max_damage = 30 //WHY THE FUCK IS THE DEFAULT MAX DAMAGE 30 ARE YOU STUPID
-/datum/robot_component/var/mob/living/silicon/robot/owner
-
-// The actual device object that has to be installed for this.
-/datum/robot_component/var/external_type = null
-
-// The wrapped device(e.g. radio), only set if external_type isn't null
-/datum/robot_component/var/obj/item/wrapped = null
+/datum/robot_component
+	var/name
+	var/installed = COMPONENT_MISSING
+	var/powered = FALSE
+	var/toggled = TRUE
+	var/brute_damage = 0
+	var/electronics_damage = 0
+	var/vulnerability = 1
+	var/energy_consumption = 0
+	var/max_damage = 30 //WHY THE FUCK IS THE DEFAULT MAX DAMAGE 30 ARE YOU STUPID
+	var/mob/living/silicon/robot/owner
+	var/upgraded = FALSE
+	var/external_type = null // The actual device object that has to be installed for this.
+	var/obj/item/wrapped = null // The wrapped device(e.g. radio), only set if external_type isn't null
 
 /datum/robot_component/New(mob/living/silicon/robot/R)
 	src.owner = R
 
-/datum/robot_component/proc/install()
-/datum/robot_component/proc/uninstall()
+/datum/robot_component/proc/install(var/mob/user,var/obj/item/robot_parts/robot_component/I)
+	if(istype(I))
+		installed = COMPONENT_INSTALLED
+		wrapped = I
+		electronics_damage = I.electronics_damage
+		brute_damage = I.brute_damage
+		vulnerability = I.vulnerability
+		upgraded = I.isupgrade
+		to_chat(user, "<span class='notice'>You install the [I.name].</span>")
+		if(owner.can_diagnose())
+			to_chat(owner, "<span class='info' style=\"font-family:Courier\">New [I.name] installed.</span>")
+
+/datum/robot_component/proc/uninstall(var/mob/user)
+	if(installed == COMPONENT_INSTALLED)
+		installed = FALSE
+	if(wrapped)
+		to_chat(user, "You remove \the [wrapped].")
+		if(owner.can_diagnose())
+			to_chat(owner, "<span class='info' style=\"font-family:Courier\">[istype(wrapped, /obj/item/broken_device) ? "Destroyed [src]" : "Functional [wrapped.name]"] removed.</span>")
+		if(istype(wrapped,/obj/item/robot_parts/robot_component))
+			var/obj/item/robot_parts/robot_component/I = wrapped
+			I.brute_damage = brute_damage
+			I.electronics_damage = electronics_damage
+			I.isupgrade = upgraded
+		return wrapped
 
 /datum/robot_component/proc/destroy()
 	var/obj/item/broken_device/G = new/obj/item/broken_device
@@ -132,6 +153,23 @@
 /mob/living/silicon/robot/proc/is_component_functioning(module_name)
 	var/datum/robot_component/C = components[module_name]
 	return C && C.installed == COMPONENT_INSTALLED && C.toggled && C.is_powered()
+
+/mob/living/silicon/robot/proc/exchange_parts(mob/user, obj/item/weapon/storage/bag/gadgets/part_replacer/W)
+	if (W.bluespace || wiresexposed || opened)
+		var/shouldplaysound = FALSE
+		for(var/V in components)
+			var/datum/robot_component/C = components[V]
+			for(var/obj/item/robot_parts/robot_component/I in W.contents)
+				if(!C.installed || (I.isupgrade && !C.upgraded) && istype(I, C.external_type))
+					C.uninstall(user)
+					if(C.wrapped)
+						W.handle_item_insertion(C.wrapped, 1)
+					C.install(user,I)
+					W.remove_from_storage(I, null)
+					shouldplaysound = TRUE //Only play the sound when parts are actually replaced!
+					break
+		if(shouldplaysound)
+			W.play_rped_sound()
 
 /obj/item/broken_device
 	name = "broken component"

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -18,8 +18,9 @@
 /datum/robot_component/New(mob/living/silicon/robot/R)
 	src.owner = R
 
-/datum/robot_component/proc/install(var/mob/user,var/obj/item/robot_parts/robot_component/I)
-	if(istype(I))
+/datum/robot_component/proc/install(var/mob/user,var/obj/item/W)
+	if(istype(W,/obj/item/robot_parts/robot_component))
+		var/obj/item/robot_parts/robot_component/I = W
 		installed = COMPONENT_INSTALLED
 		wrapped = I
 		electronics_damage = I.electronics_damage
@@ -86,8 +87,9 @@
 	if(toggled == FALSE)
 		powered = FALSE
 		return
-	if(owner.cell.charge >= energy_consumption)
-		owner.cell.use(energy_consumption)
+	var/obj/item/weapon/cell/cell = owner.get_cell()
+	if(cell && cell.charge >= energy_consumption)
+		cell.use(energy_consumption)
 		powered = TRUE
 	else
 		powered = FALSE
@@ -108,42 +110,47 @@
 	name = "power cell"
 	max_damage = 50
 
+/datum/robot_component/cell/New(mob/living/silicon/robot/R)
+	. = ..()
+	external_type = R.cell_type
+
 /datum/robot_component/cell/destroy()
 	..()
-	owner.cell = null
 	owner.updateicon()
 
-/datum/robot_component/cell/install(var/mob/user,var/obj/item/robot_parts/robot_component/I)
-	to_chat(user, "You insert \the [I].")
-	owner.cell = I
-	installed = COMPONENT_INSTALLED
-	wrapped = I
-	electronics_damage = owner.cell.electronics_damage
-	brute_damage = owner.cell.brute_damage
-	if(owner.can_diagnose())
-		to_chat(src, "<span class='info' style=\"font-family:Courier\">New power source installed. Type: [owner.cell.name]. Charge: [owner.cell.charge] out of [owner.cell.maxcharge].</span>")
-	if(owner.cell.occupant)
-		to_chat(owner.cell.occupant,"<span class='notice'>You are now inside \the [src], in control of its targeting.</span>")
-		owner.pulsecompromised = 1
-		owner.cell.occupant.loc = src
-		owner.cell.occupant.current_robot = src
-		owner.cell.occupant = null
-		to_chat(src, "<span class='danger'>ERRORERRORERROR</span>")
-		spawn(2 SECONDS)
-			to_chat(src, "<span class='danger'>ALERT: ELECTRICAL MALEVOLENCE DETECTED, TARGETING SYSTEMS HIJACKED, REPORT ALL UNWANTED ACTIVITY IN VERBAL FORM</span>")
+/datum/robot_component/cell/install(var/mob/user,var/obj/item/W)
+	if(istype(W,/obj/item/weapon/cell))
+		var/obj/item/weapon/cell/I = W
+		to_chat(user, "You insert \the [I].")
+		installed = COMPONENT_INSTALLED
+		wrapped = I
+		electronics_damage = I.electronics_damage
+		brute_damage = I.brute_damage
+		if(owner.can_diagnose())
+			to_chat(src, "<span class='info' style=\"font-family:Courier\">New power source installed. Type: [I.name]. Charge: [I.charge] out of [I.maxcharge].</span>")
+		if(I.occupant)
+			to_chat(I.occupant,"<span class='notice'>You are now inside \the [src], in control of its targeting.</span>")
+			owner.pulsecompromised = 1
+			I.occupant.loc = src
+			I.occupant.current_robot = src
+			I.occupant = null
+			to_chat(src, "<span class='danger'>ERRORERRORERROR</span>")
+			spawn(2 SECONDS)
+				to_chat(src, "<span class='danger'>ALERT: ELECTRICAL MALEVOLENCE DETECTED, TARGETING SYSTEMS HIJACKED, REPORT ALL UNWANTED ACTIVITY IN VERBAL FORM</span>")
 
 /datum/robot_component/cell/uninstall(var/mob/user,var/loud = FALSE)
 	installed = COMPONENT_MISSING
-	if(owner.cell)
-		if(loud)
-			user.visible_message("<span class='warning'>[user] removes [owner]'s [owner.cell.name].</span>", \
-			"<span class='notice'>You remove [owner]'s [owner.cell.name].</span>")
-		else
-			to_chat(user, "You remove \the [owner.cell].")
-		owner.cell.electronics_damage = electronics_damage
-		owner.cell.brute_damage = brute_damage
-		if(owner.can_diagnose())
-			to_chat(owner, "<span class='info' style=\"font-family:Courier\">Cell removed.</span>")
+	if(loud)
+		user.visible_message("<span class='warning'>[user] removes [owner]'s [wrapped.name].</span>", \
+		"<span class='notice'>You remove [owner]'s [wrapped.name].</span>")
+	else
+		to_chat(user, "You remove \the [wrapped].")
+	if(owner.can_diagnose())
+		to_chat(owner, "<span class='info' style=\"font-family:Courier\">Cell removed.</span>")
+	if(istype(wrapped,/obj/item/weapon/cell))
+		var/obj/item/weapon/cell/I = wrapped
+		I.electronics_damage = electronics_damage
+		I.brute_damage = brute_damage
 
 /datum/robot_component/radio
 	name = "radio"

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -1,4 +1,4 @@
-// TODO: remove the robot.mmi and robot.cell variables and completely rely on the robot component system
+// TODO: remove the robot.mmi variable and completely rely on the robot component system
 
 /datum/robot_component
 	var/name

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -181,8 +181,8 @@
 	var/datum/robot_component/C = components[module_name]
 	return C && C.installed == COMPONENT_INSTALLED && C.toggled && C.is_powered()
 
-/mob/living/silicon/robot/proc/exchange_parts(mob/user, obj/item/weapon/storage/bag/gadgets/part_replacer/W)
-	/*if (W.bluespace || wiresexposed || opened)
+/*/mob/living/silicon/robot/proc/exchange_parts(mob/user, obj/item/weapon/storage/bag/gadgets/part_replacer/W)
+	if (W.bluespace || wiresexposed || opened)
 		var/shouldplaysound = FALSE
 		for(var/V in components)
 			var/datum/robot_component/C = components[V]
@@ -215,7 +215,6 @@
 				var/datum/robot_component/C = components[V2]
 				if(C.wrapped)
 					to_chat(user, "<span class='notice'>    [C.wrapped.name]</span>")*/
-	return
 
 /obj/item/broken_device
 	name = "broken component"

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -129,6 +129,7 @@
 		brute_damage = I.brute_damage
 		if(owner.can_diagnose())
 			to_chat(owner, "<span class='info' style=\"font-family:Courier\">New power source installed. Type: [I.name]. Charge: [I.charge] out of [I.maxcharge].</span>")
+		owner.updateicon()
 		if(I.occupant)
 			to_chat(I.occupant,"<span class='notice'>You are now inside \the [owner], in control of its targeting.</span>")
 			owner.pulsecompromised = 1

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -208,7 +208,13 @@
 							shouldplaysound = TRUE //Only play the sound when parts are actually replaced!
 							break
 		if(shouldplaysound)
-			W.play_rped_sound()*/
+			W.play_rped_sound()
+		else
+			to_chat(user, "<span class='notice'>Following components detected in [src]:</span>")
+			for(var/V2 in components)
+				var/datum/robot_component/C = components[V2]
+				if(C.wrapped)
+					to_chat(user, "<span class='notice'>    [C.wrapped.name]</span>")*/
 	return
 
 /obj/item/broken_device

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -92,7 +92,7 @@
 	qdel(aicamera)
 	if(camera)
 		qdel(camera)
-	QDEL_LIST_ASSOC(components)
+	QDEL_LIST_ASSOC_VALUES_NULL(components)
 	if(mmi)//Safety for when a cyborg gets dust()ed. Or there is no MMI inside.
 		var/turf/T = get_turf(loc)//To hopefully prevent run time errors.
 		if(T)

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -86,6 +86,13 @@
 //If there's an MMI in the robot, have it ejected when the mob goes away. --NEO
 /mob/living/silicon/robot/Destroy()
 	cyborg_list -= src
+	qdel(wires)
+	qdel(station_holomap)
+	qdel(radio)
+	qdel(aicamera)
+	if(camera)
+		qdel(camera)
+	QDEL_LIST_ASSOC(components)
 	if(mmi)//Safety for when a cyborg gets dust()ed. Or there is no MMI inside.
 		var/turf/T = get_turf(loc)//To hopefully prevent run time errors.
 		if(T)

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -24,11 +24,11 @@
 				msg += "Its [G.name] is gripping [G.wrapped.gender==PLURAL?"some":"a"] [bicon(G.wrapped)] [G.wrapped.name].\n"
 
 	if(opened)
-		msg += "<span class='warning'>Its cover is open and the power cell is [cell ? "installed" : "missing"].</span>\n"
+		msg += "<span class='warning'>Its cover is open and the power cell is [get_cell() ? "installed" : "missing"].</span>\n"
 	else
 		msg += "Its cover is closed.\n"
 
-	if(!cell || (cell && cell.charge <= 0))
+	if(!get_cell_charge())
 		msg += "<span class='warning'>Its battery indicator is blinking red!</span>\n"
 
 	switch(stat)

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -28,7 +28,7 @@
 	else
 		msg += "Its cover is closed.\n"
 
-	if(!get_cell_charge())
+	if(!get_cell_charge(src))
 		msg += "<span class='warning'>Its battery indicator is blinking red!</span>\n"
 
 	switch(stat)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -45,16 +45,16 @@
 	adjustFireLoss(0)
 
 /mob/living/silicon/robot/proc/use_power()
-	if(cell && is_component_functioning("power cell"))
-		if(cell.charge <= 0)
+	if(get_cell() && is_component_functioning("power cell"))
+		if(get_cell_charge() <= 0)
 			uneq_all()
 		else
-			if(cell.charge <= ROBOT_LOW_POWER)
+			if(get_cell_charge() <= ROBOT_LOW_POWER)
 				uneq_all()
-				cell.use(1)
+				use_cell_charge(1)
 			else
 				for(var/M in get_all_slots())
-					cell.use(3)
+					use_cell_charge(3)
 
 			for(var/V in components)
 				var/datum/robot_component/C = components[V]

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -46,15 +46,15 @@
 
 /mob/living/silicon/robot/proc/use_power()
 	if(get_cell() && is_component_functioning("power cell"))
-		if(get_cell_charge() <= 0)
+		if(get_cell_charge(src) <= 0)
 			uneq_all()
 		else
-			if(get_cell_charge() <= ROBOT_LOW_POWER)
+			if(get_cell_charge(src) <= ROBOT_LOW_POWER)
 				uneq_all()
-				use_cell_charge(1)
+				use_cell_charge(src,1)
 			else
 				for(var/M in get_all_slots())
-					use_cell_charge(3)
+					use_cell_charge(src,3)
 
 			for(var/V in components)
 				var/datum/robot_component/C = components[V]

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -703,50 +703,11 @@
 				updateicon()
 
 	else if(istype(W, /obj/item/weapon/cell) && opened)	// trying to put a cell inside
-		var/datum/robot_component/C = components["power cell"]
 		if(wiresexposed)
 			to_chat(user, "Close the panel first.")
 			return
-		else if(cell)
-			to_chat(user, "You swap the power cell within with the new cell in your hand.")
-			var/obj/item/weapon/cell/oldpowercell = cell
-			C.wrapped = null
-			C.installed = COMPONENT_MISSING
-			cell = W
-			oldpowercell.electronics_damage = C.electronics_damage
-			oldpowercell.brute_damage = C.brute_damage
-			user.drop_item(W, src)
-			user.put_in_hands(oldpowercell)
-			if(can_diagnose())
-				to_chat(src, "<span class='info' style=\"font-family:Courier\">Cell removed.</span>")
-			C.installed = COMPONENT_INSTALLED
-			C.wrapped = W
-			C.electronics_damage = cell.electronics_damage
-			C.brute_damage = cell.brute_damage
-			C.install()
-			if(can_diagnose())
-				to_chat(src, "<span class='info' style=\"font-family:Courier\">New power source installed. Type: [cell.name]. Charge: [cell.charge] out of [cell.maxcharge].</span>")
-		else
-			user.drop_item(W, src)
-			cell = W
-			to_chat(user, "You insert the power cell.")
-
-			C.installed = COMPONENT_INSTALLED
-			C.wrapped = W
-			C.electronics_damage = cell.electronics_damage
-			C.brute_damage = cell.brute_damage
-			C.install()
-			if(can_diagnose())
-				to_chat(src, "<span class='info' style=\"font-family:Courier\">New power source installed. Type: [cell.name]. Charge: [cell.charge] out of [cell.maxcharge].</span>")
-		if(cell.occupant)
-			to_chat(cell.occupant,"<span class='notice'>You are now inside \the [src], in control of its targeting.</span>")
-			pulsecompromised = 1
-			cell.occupant.loc = src
-			cell.occupant.current_robot = src
-			cell.occupant = null
-			to_chat(src, "<span class='danger'>ERRORERRORERROR</span>")
-			spawn(2 SECONDS)
-				to_chat(src, "<span class='danger'>ALERT: ELECTRICAL MALEVOLENCE DETECTED, TARGETING SYSTEMS HIJACKED, REPORT ALL UNWANTED ACTIVITY IN VERBAL FORM</span>")
+		var/datum/robot_component/C = components["power cell"]
+		C.install(user)
 		updateicon()
 
 	else if(iswiretool(W))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1339,8 +1339,7 @@
 
 //Currently only used for borg movement, to avoid awkward situations where borgs with RTG or basic cells are always slowed down
 /mob/living/silicon/robot/proc/get_percentage_power_for_movement()
-	var/obj/item/weapon/cell/cell = get_cell()
-	clamp(round(cell.maxcharge/4), 0, SILI_LOW_TRIGGER)
+	return clamp(round(get_cell_maxcharge()/4), 0, SILI_LOW_TRIGGER)
 
 /mob/living/silicon/robot/ignite()
 	if(module && locate(/obj/item/borg/fire_shield, module.modules))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -277,6 +277,8 @@
 		choose_icon()
 
 	SetEmagged(emagged) // Update emag status and give/take emag modules away
+	if(check_rights(R_ADMIN))
+		throw_alert(SCREEN_ALARM_ROBOT_RESET, /obj/abstract/screen/alert/robot/reset_self, 0)
 
 /mob/living/silicon/robot/proc/set_module_sprites(var/list/new_sprites)
 	if(new_sprites && new_sprites.len)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -42,7 +42,15 @@
 	var/obj/machinery/camera/camera = null
 
 	// Components are basically robot organs.
-	var/list/components = list()
+	var/list/components = list(
+		"actuator" = /datum/robot_component/actuator
+		"radio" = /datum/robot_component/radio
+		"power cell" = /datum/robot_component/cell
+		"diagnosis unit" = /datum/robot_component/diagnosis_unit
+		"camera" = /datum/robot_component/camera
+		"comms" = /datum/robot_component/binary_communication
+		"armour" = /datum/robot_component/armour
+	)
 	var/component_extension = null
 
 	var/obj/item/device/mmi/mmi = null
@@ -120,9 +128,9 @@
 		if(wires.IsCameraCut()) // 5 = BORG CAMERA
 			camera.status = 0
 
-	initialize_components()
 	// Create all the robot parts.
 	for(var/V in components)
+		components[V] = new components[V](src)
 		var/datum/robot_component/C = components[V]
 		C.installed = COMPONENT_INSTALLED
 		C.wrapped = new C.external_type

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1311,24 +1311,24 @@
 	if(cellcomp)
 		return cellcomp.wrapped
 
-/mob/living/silicon/robot/get_cell_charge()
+/mob/living/silicon/robot/proc/get_cell_charge()
 	var/obj/item/weapon/cell/cell = get_cell()
 	return cell ? cell.charge : 0
 
-/mob/living/silicon/robot/get_cell_charge_fraction()
+/mob/living/silicon/robot/proc/get_cell_charge_fraction()
 	var/obj/item/weapon/cell/cell = get_cell()
 	return cell ? cell.charge/cell.maxcharge : 0
 
-/mob/living/silicon/robot/get_cell_maxcharge()
+/mob/living/silicon/robot/proc/get_cell_maxcharge()
 	var/obj/item/weapon/cell/cell = get_cell()
 	return cell ? cell.maxcharge : 0
 
-/mob/living/silicon/robot/use_cell_charge(var/amount)
+/mob/living/silicon/robot/proc/use_cell_charge(var/amount)
 	var/obj/item/weapon/cell/cell = get_cell()
 	if(cell)
 		cell.use(amount)
 
-/mob/living/silicon/robot/drain_cell()
+/mob/living/silicon/robot/proc/drain_cell()
 	var/obj/item/weapon/cell/cell = get_cell()
 	if(cell)
 		cell.charge = 0

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -897,15 +897,10 @@
 	if(opened && !wiresexposed && (!istype(user, /mob/living/silicon)))
 		var/datum/robot_component/cell_component = components["power cell"]
 		if(cell)
-			cell.electronics_damage = cell_component.electronics_damage
-			cell.brute_damage = cell_component.brute_damage
+			cell_component.uninstall(user,TRUE)
 			cell.updateicon()
 			cell.add_fingerprint(user)
 			user.put_in_hands(cell)
-			user.visible_message("<span class='warning'>[user] removes [src]'s [cell.name].</span>", \
-			"<span class='notice'>You remove [src]'s [cell.name].</span>")
-			if(can_diagnose())
-				to_chat(src, "<span class='info' style=\"font-family:Courier\">Cell removed.</span>")
 			attack_log += "\[[time_stamp()]\] <font color='orange'>Has had their [cell.name] removed by [user.name] ([user.ckey])</font>"
 			user.attack_log += "\[[time_stamp()]\] <font color='red'>Removed the [cell.name] of [name] ([ckey])</font>"
 			log_attack("<font color='red'>[user.name] ([user.ckey]) removed [src]'s [cell.name] ([ckey])</font>")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1328,10 +1328,10 @@
 	if(C)
 		C.use(amount)
 
-/mob/living/silicon/robot/set_cell_charge(var/amount)
+/mob/living/silicon/robot/drain_cell()
 	var/obj/item/weapon/cell/C = get_cell()
 	if(C)
-		C.charge = amount
+		C.charge = 0
 
 /mob/living/silicon/robot/proc/toggle_modulelock()
 	modulelock = !modulelock

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1307,17 +1307,20 @@
 	return FALSE
 
 /mob/living/silicon/robot/proc/add_cell(var/obj/item/weapon/cell/C,var/mob/user)
-	var/datum/robot_component/cellcomp = components["power cell"]
-	cellcomp.install(user,C)
+	if(components && components.len)
+		var/datum/robot_component/cellcomp = components["power cell"]
+		cellcomp.install(user,C)
 
 /mob/living/silicon/robot/proc/clear_cell()
-	var/datum/robot_component/cellcomp = components["power cell"]
-	cellcomp.wrapped = null
+	if(components && components.len)
+		var/datum/robot_component/cellcomp = components["power cell"]
+		cellcomp.wrapped = null
 
 /mob/living/silicon/robot/get_cell()
-	var/datum/robot_component/cellcomp = components["power cell"]
-	if(cellcomp)
-		return cellcomp.wrapped
+	if(components && components.len)
+		var/datum/robot_component/cellcomp = components["power cell"]
+		if(cellcomp)
+			return cellcomp.wrapped
 
 /mob/living/silicon/robot/proc/get_cell_charge()
 	var/obj/item/weapon/cell/cell = get_cell()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1264,7 +1264,7 @@
 		component.electronics_damage = 0
 		component.brute_damage = 0
 		component.installed = COMPONENT_INSTALLED
-		if(C == "power cell")
+		if(istype(component.type,/datum/robot_component/cell))
 			if(!component.wrapped)
 				component.wrapped = new(src)
 			var/obj/item/weapon/cell/cell = component.wrapped
@@ -1322,10 +1322,6 @@
 		if(cellcomp)
 			return cellcomp.wrapped
 
-/mob/living/silicon/robot/proc/get_cell_charge()
-	var/obj/item/weapon/cell/cell = get_cell()
-	return cell ? cell.charge : 0
-
 /mob/living/silicon/robot/proc/get_cell_charge_fraction()
 	var/obj/item/weapon/cell/cell = get_cell()
 	return cell ? cell.charge/cell.maxcharge : 0
@@ -1333,11 +1329,6 @@
 /mob/living/silicon/robot/proc/get_cell_maxcharge()
 	var/obj/item/weapon/cell/cell = get_cell()
 	return cell ? cell.maxcharge : 0
-
-/mob/living/silicon/robot/proc/use_cell_charge(var/amount)
-	var/obj/item/weapon/cell/cell = get_cell()
-	if(cell)
-		return cell.use(amount)
 
 /mob/living/silicon/robot/proc/drain_cell()
 	var/obj/item/weapon/cell/cell = get_cell()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1335,7 +1335,7 @@
 /mob/living/silicon/robot/proc/use_cell_charge(var/amount)
 	var/obj/item/weapon/cell/cell = get_cell()
 	if(cell)
-		cell.use(amount)
+		return cell.use(amount)
 
 /mob/living/silicon/robot/proc/drain_cell()
 	var/obj/item/weapon/cell/cell = get_cell()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1298,10 +1298,40 @@
 /mob/living/silicon/robot/hasFullAccess()
 	return FALSE
 
+/mob/living/silicon/robot/proc/add_cell(var/obj/item/weapon/cell/C,var/mob/user)
+	var/datum/robot_component/C = components["power cell"]
+	C.install(user,C)
+
+/mob/living/silicon/robot/proc/clear_cell(var/obj/item/weapon/cell/C,var/mob/user)
+	var/datum/robot_component/C = components["power cell"]
+	C.wrapped = null
+
 /mob/living/silicon/robot/get_cell()
 	var/datum/robot_component/C = components["power cell"]
 	if(C)
 		return C.wrapped
+
+/mob/living/silicon/robot/get_cell_charge()
+	var/obj/item/weapon/cell/C = get_cell()
+	return C ? C.charge : 0
+
+/mob/living/silicon/robot/get_cell_charge_fraction()
+	var/obj/item/weapon/cell/C = get_cell()
+	return C ? C.charge/C.maxcharge : 0
+
+/mob/living/silicon/robot/get_cell_maxcharge()
+	var/obj/item/weapon/cell/C = get_cell()
+	return C ? C.maxcharge : 0
+
+/mob/living/silicon/robot/use_cell_charge(var/amount)
+	var/obj/item/weapon/cell/C = get_cell()
+	if(C)
+		C.use(amount)
+
+/mob/living/silicon/robot/set_cell_charge(var/amount)
+	var/obj/item/weapon/cell/C = get_cell()
+	if(C)
+		C.charge = amount
 
 /mob/living/silicon/robot/proc/toggle_modulelock()
 	modulelock = !modulelock
@@ -1309,8 +1339,7 @@
 
 //Currently only used for borg movement, to avoid awkward situations where borgs with RTG or basic cells are always slowed down
 /mob/living/silicon/robot/proc/get_percentage_power_for_movement()
-	var/obj/item/weapon/cell/cell = get_cell()
-	return cell ? clamp(round(cell.maxcharge/4), 0, SILI_LOW_TRIGGER) : 0
+	clamp(round(get_cell_maxcharge()/4), 0, SILI_LOW_TRIGGER)
 
 /mob/living/silicon/robot/ignite()
 	if(module && locate(/obj/item/borg/fire_shield, module.modules))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -130,8 +130,8 @@
 
 	// Create all the robot parts.
 	for(var/V in components)
-		var/type = components[V]
-		components[V] = new type(src)
+		var/comptype = components[V]
+		components[V] = new comptype(src)
 		var/datum/robot_component/C = components[V]
 		C.installed = COMPONENT_INSTALLED
 		C.wrapped = new C.external_type

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -210,6 +210,7 @@
 			if(initial(I.isupgrade))
 				I = new NC
 				C.installed = COMPONENT_INSTALLED
+				C.upgraded = TRUE
 				qdel(C.wrapped)
 				C.wrapped = I
 				C.vulnerability = I.vulnerability
@@ -616,20 +617,9 @@
 		for(var/V in components)
 			var/datum/robot_component/C = components[V]
 			if(!C.installed && istype(W, C.external_type))
-				var/obj/item/robot_parts/robot_component/I = W
-				C.installed = COMPONENT_INSTALLED
-				C.wrapped = W
-				C.electronics_damage = I.electronics_damage
-				C.brute_damage = I.brute_damage
-				C.vulnerability = I.vulnerability
-				C.install()
+				C.install(user,W)
 				user.drop_item(W)
 				W.forceMove(null)
-
-				to_chat(usr, "<span class='notice'>You install the [W.name].</span>")
-				if(can_diagnose())
-					to_chat(src, "<span class='info' style=\"font-family:Courier\">New [W.name] installed.</span>")
-
 				return
 
 	if(iswelder(W))
@@ -698,24 +688,9 @@
 				if(!remove)
 					return
 				var/datum/robot_component/C = components[remove]
-				if(istype(C.wrapped, /obj/item/broken_device))
-					var/obj/item/broken_device/I = C.wrapped
-					to_chat(user, "You remove \the [I].")
-					if(can_diagnose())
-						to_chat(src, "<span class='info' style=\"font-family:Courier\">Destroyed [C] removed.</span>")
-					I.forceMove(loc)
-				else
-					var/obj/item/robot_parts/robot_component/I = C.wrapped
-					I.brute_damage = C.brute_damage
-					I.electronics_damage = C.electronics_damage
-					to_chat(user, "You remove \the [I].")
-					if(can_diagnose())
-						to_chat(src, "<span class='info' style=\"font-family:Courier\">Functional [I.name] removed.</span>")
-					I.forceMove(loc)
-
-				if(C.installed == COMPONENT_INSTALLED)
-					C.uninstall()
-				C.installed = FALSE
+				if(C.wrapped)
+					C.wrapped.forceMove(loc)
+				C.uninstall(user)
 
 		else
 			if(locked)
@@ -839,6 +814,9 @@
 	else if(istype(W, /obj/item/device/camera_bug))
 		help_shake_act(user)
 		return FALSE
+
+	else if(istype(W, /obj/item/weapon/storage/bag/gadgets/part_replacer))
+		return exchange_parts(user, W)
 
 	else
 		if(W.force > 0)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -707,7 +707,11 @@
 			to_chat(user, "Close the panel first.")
 			return
 		var/datum/robot_component/C = components["power cell"]
-		C.install(user)
+		user.drop_item(W, src)
+		if(cell)
+			C.uninstall(user)
+			user.put_in_hands(cell)
+		C.install(user,W)
 		updateicon()
 
 	else if(iswiretool(W))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -43,12 +43,12 @@
 
 	// Components are basically robot organs.
 	var/list/components = list(
-		"actuator" = /datum/robot_component/actuator
-		"radio" = /datum/robot_component/radio
-		"power cell" = /datum/robot_component/cell
-		"diagnosis unit" = /datum/robot_component/diagnosis_unit
-		"camera" = /datum/robot_component/camera
-		"comms" = /datum/robot_component/binary_communication
+		"actuator" = /datum/robot_component/actuator,
+		"radio" = /datum/robot_component/radio,
+		"power cell" = /datum/robot_component/cell,
+		"diagnosis unit" = /datum/robot_component/diagnosis_unit,
+		"camera" = /datum/robot_component/camera,
+		"comms" = /datum/robot_component/binary_communication,
 		"armour" = /datum/robot_component/armour
 	)
 	var/component_extension = null

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1302,6 +1302,9 @@
 	return FALSE
 
 /mob/living/silicon/robot/get_cell()
+	var/datum/robot_component/C = components["power cell"]
+	if(C)
+		return C.wrapped
 	return cell
 
 /mob/living/silicon/robot/proc/toggle_modulelock()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -244,7 +244,7 @@
 		sensor = null
 
 /mob/living/silicon/robot/proc/getModules()
-	return getAvailableRobotModules()
+	return getAvailableRobotModules(src)
 
 // /vg/: Enable forcing module type
 /mob/living/silicon/robot/proc/pick_module(var/forced_module=null)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -714,7 +714,6 @@
 			C.uninstall(user)
 			user.put_in_hands(cell)
 		C.install(user,W)
-		updateicon()
 
 	else if(iswiretool(W))
 		if(wiresexposed)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -277,8 +277,6 @@
 		choose_icon()
 
 	SetEmagged(emagged) // Update emag status and give/take emag modules away
-	if(check_rights(R_ADMIN))
-		throw_alert(SCREEN_ALARM_ROBOT_RESET, /obj/abstract/screen/alert/robot/reset_self, 0)
 
 /mob/living/silicon/robot/proc/set_module_sprites(var/list/new_sprites)
 	if(new_sprites && new_sprites.len)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1339,7 +1339,8 @@
 
 //Currently only used for borg movement, to avoid awkward situations where borgs with RTG or basic cells are always slowed down
 /mob/living/silicon/robot/proc/get_percentage_power_for_movement()
-	clamp(round(get_cell_maxcharge()/4), 0, SILI_LOW_TRIGGER)
+	var/obj/item/weapon/cell/cell = get_cell()
+	clamp(round(cell.maxcharge/4), 0, SILI_LOW_TRIGGER)
 
 /mob/living/silicon/robot/ignite()
 	if(module && locate(/obj/item/borg/fire_shield, module.modules))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -130,7 +130,8 @@
 
 	// Create all the robot parts.
 	for(var/V in components)
-		components[V] = new components[V](src)
+		var/type = components[V]
+		components[V] = new type(src)
 		var/datum/robot_component/C = components[V]
 		C.installed = COMPONENT_INSTALLED
 		C.wrapped = new C.external_type

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -37,7 +37,6 @@
 	var/mob/living/silicon/ai/connected_ai = null
 	var/AIlink = TRUE //Do we start linked to an AI?
 
-	var/obj/item/weapon/cell/cell = null
 	var/cell_type = /obj/item/weapon/cell/high/cyborg //The cell_type we're actually using.
 
 	var/obj/machinery/camera/camera = null
@@ -123,13 +122,10 @@
 
 	initialize_components()
 	// Create all the robot parts.
-	for(var/V in components) if(V != "power cell")
+	for(var/V in components)
 		var/datum/robot_component/C = components[V]
 		C.installed = COMPONENT_INSTALLED
 		C.wrapped = new C.external_type
-
-	if(!cell)
-		cell = new cell_type(src)
 
 	updateicon()
 
@@ -145,11 +141,6 @@
 		spawn(1)
 			mind.store_memory("Frequencies list: <br/><b>Command:</b> [COMM_FREQ] <br/> <b>Security:</b> [SEC_FREQ] <br/> <b>Medical:</b> [MED_FREQ] <br/> <b>Science:</b> [SCI_FREQ] <br/> <b>Engineering:</b> [ENG_FREQ] <br/> <b>Service:</b> [SER_FREQ] <b>Cargo:</b> [SUP_FREQ]<br/> <b>AI private:</b> [AIPRIV_FREQ]<br/>", category=MIND_MEMORY_GENERAL, forced=TRUE)
 		stored_freqs = 1
-
-	if(cell)
-		var/datum/robot_component/cell_component = components["power cell"]
-		cell_component.wrapped = cell
-		cell_component.installed = COMPONENT_INSTALLED
 
 	playsound(src, startup_sound, 75, startup_vary)
 
@@ -419,6 +410,7 @@
 
 // this function displays the cyborgs current cell charge in the stat panel
 /mob/living/silicon/robot/proc/show_cell_power()
+	var/obj/item/weapon/cell/cell = get_cell()
 	if(cell)
 		stat(null, text("Charge Left: [cell.charge]/[cell.maxcharge]"))
 	else
@@ -653,7 +645,7 @@
 
 	else if(iscrowbar(W))	// crowbar means open or close the cover
 		if(opened)
-			if(cell)
+			if(get_cell())
 				to_chat(user, "You close the cover.")
 				if(can_diagnose())
 					to_chat(src, "<span class='info' style=\"font-family:Courier\">Cover closed.</span>")
@@ -708,6 +700,7 @@
 			return
 		var/datum/robot_component/C = components["power cell"]
 		user.drop_item(W, src)
+		var/obj/item/weapon/cell/cell = get_cell()
 		if(cell)
 			C.uninstall(user)
 			user.put_in_hands(cell)
@@ -720,14 +713,14 @@
 		else
 			to_chat(user, "You can't reach the wiring.")
 
-	else if(W.is_screwdriver(user) && opened && !cell)	// haxing
+	else if(W.is_screwdriver(user) && opened && !get_cell())	// haxing
 		wiresexposed = !wiresexposed
 		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
 		if(can_diagnose())
 			to_chat(src, "<span class='info' style=\"font-family:Courier\">Internal wiring [wiresexposed ? "exposed" : "unexposed"].</span>")
 		updateicon()
 
-	else if(W.is_screwdriver(user) && opened && cell)	// radio
+	else if(W.is_screwdriver(user) && opened && get_cell())	// radio
 		if(radio)
 			radio.attackby(W,user)//Push it to the radio to let it handle everything
 			if(can_diagnose())
@@ -896,6 +889,7 @@
 
 	if(opened && !wiresexposed && (!istype(user, /mob/living/silicon)))
 		var/datum/robot_component/cell_component = components["power cell"]
+		var/obj/item/weapon/cell/cell = get_cell()
 		if(cell)
 			cell_component.uninstall(user,TRUE)
 			cell.updateicon()
@@ -969,6 +963,7 @@
 /mob/living/silicon/robot/proc/updateicon(var/overlay_layer = ABOVE_LIGHTING_LAYER, var/overlay_plane = ABOVE_LIGHTING_PLANE)
 	overlays.Cut()
 	update_fire()
+	var/obj/item/weapon/cell/cell = get_cell()
 	if(!stat && cell != null)
 		eyes = image(icon,"eyes-[icon_state]", overlay_layer)
 		eyes.plane = overlay_plane
@@ -1261,10 +1256,12 @@
 		component.electronics_damage = 0
 		component.brute_damage = 0
 		component.installed = COMPONENT_INSTALLED
-	if(!cell)
-		cell = new(src)
-	cell.maxcharge = max(15000, cell.maxcharge)
-	cell.charge = cell.maxcharge
+		if(C == "power cell")
+			if(!component.wrapped)
+				component.wrapped = new(src)
+			var/obj/item/weapon/cell/cell = component.wrapped
+			cell.maxcharge = max(15000, cell.maxcharge)
+			cell.charge = cell.maxcharge
 	..()
 	updatehealth()
 
@@ -1305,7 +1302,6 @@
 	var/datum/robot_component/C = components["power cell"]
 	if(C)
 		return C.wrapped
-	return cell
 
 /mob/living/silicon/robot/proc/toggle_modulelock()
 	modulelock = !modulelock
@@ -1313,7 +1309,8 @@
 
 //Currently only used for borg movement, to avoid awkward situations where borgs with RTG or basic cells are always slowed down
 /mob/living/silicon/robot/proc/get_percentage_power_for_movement()
-	return clamp(round(cell.maxcharge/4), 0, SILI_LOW_TRIGGER)
+	var/obj/item/weapon/cell/cell = get_cell()
+	return cell ? clamp(round(cell.maxcharge/4), 0, SILI_LOW_TRIGGER) : 0
 
 /mob/living/silicon/robot/ignite()
 	if(module && locate(/obj/item/borg/fire_shield, module.modules))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -781,8 +781,8 @@
 		help_shake_act(user)
 		return FALSE
 
-	else if(istype(W, /obj/item/weapon/storage/bag/gadgets/part_replacer))
-		return exchange_parts(user, W)
+	/*else if(istype(W, /obj/item/weapon/storage/bag/gadgets/part_replacer))
+		return exchange_parts(user, W)*/
 
 	else
 		if(W.force > 0)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1299,39 +1299,39 @@
 	return FALSE
 
 /mob/living/silicon/robot/proc/add_cell(var/obj/item/weapon/cell/C,var/mob/user)
-	var/datum/robot_component/C = components["power cell"]
-	C.install(user,C)
+	var/datum/robot_component/cellcomp = components["power cell"]
+	cellcomp.install(user,C)
 
-/mob/living/silicon/robot/proc/clear_cell(var/obj/item/weapon/cell/C,var/mob/user)
-	var/datum/robot_component/C = components["power cell"]
-	C.wrapped = null
+/mob/living/silicon/robot/proc/clear_cell()
+	var/datum/robot_component/cellcomp = components["power cell"]
+	cellcomp.wrapped = null
 
 /mob/living/silicon/robot/get_cell()
-	var/datum/robot_component/C = components["power cell"]
-	if(C)
-		return C.wrapped
+	var/datum/robot_component/cellcomp = components["power cell"]
+	if(cellcomp)
+		return cellcomp.wrapped
 
 /mob/living/silicon/robot/get_cell_charge()
-	var/obj/item/weapon/cell/C = get_cell()
-	return C ? C.charge : 0
+	var/obj/item/weapon/cell/cell = get_cell()
+	return cell ? cell.charge : 0
 
 /mob/living/silicon/robot/get_cell_charge_fraction()
-	var/obj/item/weapon/cell/C = get_cell()
-	return C ? C.charge/C.maxcharge : 0
+	var/obj/item/weapon/cell/cell = get_cell()
+	return cell ? cell.charge/cell.maxcharge : 0
 
 /mob/living/silicon/robot/get_cell_maxcharge()
-	var/obj/item/weapon/cell/C = get_cell()
-	return C ? C.maxcharge : 0
+	var/obj/item/weapon/cell/cell = get_cell()
+	return cell ? cell.maxcharge : 0
 
 /mob/living/silicon/robot/use_cell_charge(var/amount)
-	var/obj/item/weapon/cell/C = get_cell()
-	if(C)
-		C.use(amount)
+	var/obj/item/weapon/cell/cell = get_cell()
+	if(cell)
+		cell.use(amount)
 
 /mob/living/silicon/robot/drain_cell()
-	var/obj/item/weapon/cell/C = get_cell()
-	if(C)
-		C.charge = 0
+	var/obj/item/weapon/cell/cell = get_cell()
+	if(cell)
+		cell.charge = 0
 
 /mob/living/silicon/robot/proc/toggle_modulelock()
 	modulelock = !modulelock

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -99,8 +99,8 @@
 		var/absorb_burn = burn*shield.shield_level
 		var/cost = (absorb_brute+absorb_burn)*100
 
-		use_cell_charge(cost)
-		if(get_cell_charge() <= 0)
+		use_cell_charge(src,cost)
+		if(get_cell_charge(src) <= 0)
 			drain_cell()
 			to_chat(src, "<span class='warning'>Your shield has overloaded!</span>")
 		else
@@ -145,8 +145,8 @@
 		var/absorb_burn = burn*shield.shield_level
 		var/cost = (absorb_brute+absorb_burn)*100
 
-		use_cell_charge(cost)
-		if(get_cell_charge() <= 0)
+		use_cell_charge(src,cost)
+		if(get_cell_charge(src) <= 0)
 			drain_cell()
 			to_chat(src, "<span class='warning'>Your shield has overloaded!</span>")
 		else

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -99,9 +99,9 @@
 		var/absorb_burn = burn*shield.shield_level
 		var/cost = (absorb_brute+absorb_burn)*100
 
-		cell.charge -= cost
-		if(cell.charge <= 0)
-			cell.charge = 0
+		use_cell_charge(cost)
+		if(get_cell_charge() <= 0)
+			set_cell_charge(0)
 			to_chat(src, "<span class='warning'>Your shield has overloaded!</span>")
 		else
 			brute -= absorb_brute
@@ -145,9 +145,9 @@
 		var/absorb_burn = burn*shield.shield_level
 		var/cost = (absorb_brute+absorb_burn)*100
 
-		cell.charge -= cost
-		if(cell.charge <= 0)
-			cell.charge = 0
+		use_cell_charge(cost)
+		if(get_cell_charge() <= 0)
+			set_cell_charge(0)
 			to_chat(src, "<span class='warning'>Your shield has overloaded!</span>")
 		else
 			brute -= absorb_brute

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -101,7 +101,7 @@
 
 		use_cell_charge(cost)
 		if(get_cell_charge() <= 0)
-			set_cell_charge(0)
+			drain_cell()
 			to_chat(src, "<span class='warning'>Your shield has overloaded!</span>")
 		else
 			brute -= absorb_brute
@@ -147,7 +147,7 @@
 
 		use_cell_charge(cost)
 		if(get_cell_charge() <= 0)
-			set_cell_charge(0)
+			drain_cell()
 			to_chat(src, "<span class='warning'>Your shield has overloaded!</span>")
 		else
 			brute -= absorb_brute

--- a/code/modules/mob/living/silicon/robot/robot_hud.dm
+++ b/code/modules/mob/living/silicon/robot/robot_hud.dm
@@ -9,8 +9,8 @@
 
 	handle_health_hud()
 
-	if(cell)
-		var/cellcharge = cell.charge/cell.maxcharge
+	if(get_cell())
+		var/cellcharge = get_cell_charge_fraction()
 		switch(cellcharge)
 			if(0.5 to INFINITY)
 				clear_alert(SCREEN_ALARM_ROBOT_CELL)

--- a/code/modules/mob/living/silicon/robot/robot_inventory.dm
+++ b/code/modules/mob/living/silicon/robot/robot_inventory.dm
@@ -292,7 +292,7 @@
 /mob/living/silicon/robot/put_in_hands(var/obj/item/W)
 	if(!W)
 		return FALSE
-	if(get_cell_charge() <= ROBOT_LOW_POWER)
+	if(get_cell_charge(src) <= ROBOT_LOW_POWER)
 		drop_from_inventory(W)
 		return FALSE
 	for(var/obj/item/weapon/gripper/G in get_all_slots())

--- a/code/modules/mob/living/silicon/robot/robot_inventory.dm
+++ b/code/modules/mob/living/silicon/robot/robot_inventory.dm
@@ -292,7 +292,7 @@
 /mob/living/silicon/robot/put_in_hands(var/obj/item/W)
 	if(!W)
 		return FALSE
-	if(cell && cell.charge <= ROBOT_LOW_POWER)
+	if(get_cell_charge() <= ROBOT_LOW_POWER)
 		drop_from_inventory(W)
 		return FALSE
 	for(var/obj/item/weapon/gripper/G in get_all_slots())
@@ -314,7 +314,7 @@
 	if(client)
 		client.screen -= contents
 		for(var/obj/I in contents)
-			if(I!=cell && I!=radio && I!=camera && I!=mmi && I!=rbPDA && I!=aicamera)
+			if(I!=get_cell() && I!=radio && I!=camera && I!=mmi && I!=rbPDA && I!=aicamera)
 				client.screen += I
 	if(module_state_1)
 		module_state_1:screen_loc = ui_inv1

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -41,7 +41,7 @@
 		if(module_active && istype(module_active,/obj/item/borg/combat/mobility))
 			. *= SILICON_MOBILITY_MODULE_SPEED_MODIFIER
 		var/low_movement_speed_trigger = get_percentage_power_for_movement()
-		var/cellcharge = get_cell_charge()
+		var/cellcharge = get_cell_charge(src)
 		if(cellcharge <= low_movement_speed_trigger) //25% of the cell OR 25% of a normal cell, whatever is lower
 			if(cellcharge <= 0)
 				. *= SILICON_NO_CELL_SLOWDOWN

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -32,7 +32,7 @@
 
 /mob/living/silicon/robot/movement_tally_multiplier()
 	. = ..()
-	if(is_component_functioning("power cell") && cell)
+	if(is_component_functioning("power cell") && get_cell())
 		var/timeofday = world.timeofday
 		if((timeofday - last_tase_timeofday) < SILICON_TASER_SLOWDOWN_DURATION)
 			. *= SILICON_TASER_SLOWDOWN_MULTIPLIER
@@ -41,12 +41,13 @@
 		if(module_active && istype(module_active,/obj/item/borg/combat/mobility))
 			. *= SILICON_MOBILITY_MODULE_SPEED_MODIFIER
 		var/low_movement_speed_trigger = get_percentage_power_for_movement()
-		if(cell.charge <= low_movement_speed_trigger) //25% of the cell OR 25% of a normal cell, whatever is lower
-			if(cell.charge <= 0)
+		var/cellcharge = get_cell_charge()
+		if(cellcharge <= low_movement_speed_trigger) //25% of the cell OR 25% of a normal cell, whatever is lower
+			if(cellcharge <= 0)
 				. *= SILICON_NO_CELL_SLOWDOWN
 			else
 				//This should be +1.4 at the trigger point and +2 at maximum
-				. += SILI_LOW_SLOW + 0.6*(low_movement_speed_trigger-cell.charge)/low_movement_speed_trigger
+				. += SILI_LOW_SLOW + 0.6*(low_movement_speed_trigger-cellcharge)/low_movement_speed_trigger
 		else
 			if(module)
 				. *= module.speed_modifier

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -42,7 +42,7 @@
 		charge_tick = 0
 		if(!power_supply)
 			return 0
-		if(recharges_borg_cell && isrobot(loc) && !use_borg_cellcharge(src.loc,charge_cost))
+		if(recharges_borg_cell && isrobot(loc) && !use_cell_charge(src.loc,charge_cost))
 			return 0
 		power_supply.give(charge_cost*recharge_mult)
 		update_icon()
@@ -79,7 +79,7 @@
 	if(in_chamber)
 		return 1
 	if(uses_borg_cell && isrobot(loc))
-		if(!use_borg_cellcharge(src.loc,charge_cost))
+		if(!use_cell_charge(src.loc,charge_cost))
 			return 0
 	else if(!power_supply || !power_supply.use(charge_cost))
 		return 0

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -19,13 +19,16 @@
 	var/icon_charge_multiple = 25 //Spacing of the charge level sprites
 	var/charge_tick = 0
 	var/recharge_time = 0 //Time it takes for shots to recharge (in ticks)
+	var/recharge_mult = 1
+	var/uses_borg_cell = FALSE
+	var/recharges_borg_cell = FALSE
 
-/obj/item/weapon/gun/energy/advdisintegrator/New()
+/obj/item/weapon/gun/energy/New()
 	..()
 	if(recharge_time)
 		processing_objects.Add(src)
 
-/obj/item/weapon/gun/energy/advdisintegrator/Destroy()
+/obj/item/weapon/gun/energy/Destroy()
 	if(recharge_time)
 		processing_objects.Remove(src)
 	..()
@@ -38,9 +41,9 @@
 		charge_tick = 0
 		if(!power_supply)
 			return 0
-		if(isrobot(loc) && !use_borg_cellcharge(src.loc,charge_cost))
+		if(recharges_borg_cell && isrobot(loc) && !use_borg_cellcharge(src.loc,charge_cost))
 			return 0
-		power_supply.give(charge_cost)
+		power_supply.give(charge_cost*recharge_mult)
 		update_icon()
 		return 1
 
@@ -66,7 +69,7 @@
 /obj/item/weapon/gun/energy/process_chambered()
 	if(in_chamber)
 		return 1
-	if(isrobot(loc))
+	if(uses_borg_cell && isrobot(loc))
 		if(!use_borg_cellcharge(src.loc,charge_cost))
 			return 0
 	else if(!power_supply || !power_supply.use(charge_cost))

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -38,7 +38,9 @@
 		charge_tick = 0
 		if(!power_supply)
 			return 0
-		power_supply.give(100)
+		if(isrobot(loc) && !use_borg_cellcharge(src.loc,charge_cost))
+			return 0
+		power_supply.give(charge_cost)
 		update_icon()
 		return 1
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -22,6 +22,7 @@
 	var/recharge_mult = 1
 	var/uses_borg_cell = FALSE
 	var/recharges_borg_cell = FALSE
+	var/borg_restocks = FALSE
 
 /obj/item/weapon/gun/energy/New()
 	..()
@@ -46,6 +47,14 @@
 		power_supply.give(charge_cost*recharge_mult)
 		update_icon()
 		return 1
+
+/obj/item/weapon/gun/energy/restock()
+	if(borg_restocks)
+		if(power_supply.charge < power_supply.maxcharge)
+			power_supply.give(charge_cost)
+			update_icon()
+		else
+			charge_tick = 0
 
 /obj/item/weapon/gun/energy/get_cell()
 	return power_supply

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -17,6 +17,20 @@
 	var/modifystate
 	var/charge_states = 1 //if the gun changes icon states depending on charge, this is 1. Uses a var so it can be changed easily
 	var/icon_charge_multiple = 25 //Spacing of the charge level sprites
+	var/charge_tick = 0
+	var/recharge_time = 0 //Time it takes for shots to recharge (in ticks)
+
+/obj/item/weapon/gun/energy/process()
+	if(recharge_time)
+		charge_tick++
+		if(charge_tick < recharge_time)
+			return 0
+		charge_tick = 0
+		if(!power_supply)
+			return 0
+		power_supply.give(100)
+		update_icon()
+		return 1
 
 /obj/item/weapon/gun/energy/get_cell()
 	return power_supply
@@ -40,9 +54,10 @@
 /obj/item/weapon/gun/energy/process_chambered()
 	if(in_chamber)
 		return 1
-	if(!power_supply)
-		return 0
-	if(!power_supply.use(charge_cost))
+	if(isrobot(loc))
+		if(!use_borg_cellcharge(src.loc,charge_cost))
+			return 0
+	else if(!power_supply || !power_supply.use(charge_cost))
 		return 0
 	if(!projectile_type)
 		return 0

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -20,6 +20,16 @@
 	var/charge_tick = 0
 	var/recharge_time = 0 //Time it takes for shots to recharge (in ticks)
 
+/obj/item/weapon/gun/energy/advdisintegrator/New()
+	..()
+	if(recharge_time)
+		processing_objects.Add(src)
+
+/obj/item/weapon/gun/energy/advdisintegrator/Destroy()
+	if(recharge_time)
+		processing_objects.Remove(src)
+	..()
+
 /obj/item/weapon/gun/energy/process()
 	if(recharge_time)
 		charge_tick++

--- a/code/modules/projectiles/guns/energy/disintegrator.dm
+++ b/code/modules/projectiles/guns/energy/disintegrator.dm
@@ -103,14 +103,5 @@
 /obj/item/weapon/gun/energy/advdisintegrator/isHandgun()
 	return TRUE
 
-/obj/item/weapon/gun/energy/advdisintegrator/New()
-	..()
-	processing_objects.Add(src)
-
-
-/obj/item/weapon/gun/energy/advdisintegrator/Destroy()
-	processing_objects.Remove(src)
-	..()
-
 /obj/item/weapon/gun/energy/advdisintegrator/dissolvable() // Can't be destroyed by polyacid
 	return 0

--- a/code/modules/projectiles/guns/energy/disintegrator.dm
+++ b/code/modules/projectiles/guns/energy/disintegrator.dm
@@ -98,9 +98,7 @@
 	projectile_type = "/obj/item/projectile/beam/scorchray/atomizationray"
 	origin_tech = Tc_COMBAT + "=5;" + Tc_MATERIALS + "=3" + Tc_POWERSTORAGE + "=4"
 	fire_delay = 0.6 SECONDS // Barely noticeable, mostly here to allow the firing noise .ogg to finish ~0.55 seconds
-
-	var/charge_tick = 0
-	var/charge_wait = 4 // This one charges itself like the Captain's laser, at the cost of fun alternate modes
+	recharge_time = 4 // This one charges itself like the Captain's laser, at the cost of fun alternate modes
 
 /obj/item/weapon/gun/energy/advdisintegrator/isHandgun()
 	return TRUE
@@ -113,17 +111,6 @@
 /obj/item/weapon/gun/energy/advdisintegrator/Destroy()
 	processing_objects.Remove(src)
 	..()
-
-/obj/item/weapon/gun/energy/advdisintegrator/process()
-	charge_tick++
-	if(charge_tick < charge_wait)
-		return 0
-	charge_tick = 0
-	if(!power_supply)
-		return 0
-	power_supply.give(100)
-	update_icon()
-	return 1
 
 /obj/item/weapon/gun/energy/advdisintegrator/dissolvable() // Can't be destroyed by polyacid
 	return 0

--- a/code/modules/projectiles/guns/energy/disintegrator.dm
+++ b/code/modules/projectiles/guns/energy/disintegrator.dm
@@ -99,6 +99,7 @@
 	origin_tech = Tc_COMBAT + "=5;" + Tc_MATERIALS + "=3" + Tc_POWERSTORAGE + "=4"
 	fire_delay = 0.6 SECONDS // Barely noticeable, mostly here to allow the firing noise .ogg to finish ~0.55 seconds
 	recharge_time = 4 // This one charges itself like the Captain's laser, at the cost of fun alternate modes
+	recharge_mult = 2
 
 /obj/item/weapon/gun/energy/advdisintegrator/isHandgun()
 	return TRUE

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -195,15 +195,6 @@
 /obj/item/weapon/gun/energy/laser/cyborg
 	recharge_time = 3
 
-/obj/item/weapon/gun/energy/laser/cyborg/New()
-	..()
-	processing_objects.Add(src)
-
-
-/obj/item/weapon/gun/energy/laser/cyborg/Destroy()
-	processing_objects.Remove(src)
-	..()
-
 /obj/item/weapon/gun/energy/laser/cyborg/process() //Every [recharge_time] ticks, recharge a shot for the cyborg
 	charge_tick++
 	if(charge_tick < recharge_time)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -195,20 +195,6 @@
 /obj/item/weapon/gun/energy/laser/cyborg
 	recharge_time = 3
 
-/obj/item/weapon/gun/energy/laser/cyborg/process() //Every [recharge_time] ticks, recharge a shot for the cyborg
-	charge_tick++
-	if(charge_tick < recharge_time)
-		return 0
-	charge_tick = 0
-
-	if(!power_supply)
-		return 0 //sanity
-	if(use_borg_cellcharge(src.loc,charge_cost)) //Take power from the borg...
-		power_supply.give(charge_cost) // ...to recharge the shot
-
-	update_icon()
-	return 1
-
 /obj/item/weapon/gun/energy/laser/cyborg/restock()
 	if(power_supply.charge < power_supply.maxcharge)
 		power_supply.give(charge_cost)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -225,11 +225,8 @@
 
 	if(!power_supply)
 		return 0 //sanity
-	if(isrobot(src.loc))
-		var/mob/living/silicon/robot/R = src.loc
-		if(R && R.cell)
-			R.cell.use(charge_cost) 		//Take power from the borg...
-			power_supply.give(charge_cost)	//... to recharge the shot
+	if(use_borg_cellcharge(src.loc,charge_cost)) //Take power from the borg...
+		power_supply.give(charge_cost) // ...to recharge the shot
 
 	update_icon()
 	return 1
@@ -263,11 +260,9 @@
 /obj/item/weapon/gun/energy/laser/cannon/cyborg/process_chambered()
 	if(in_chamber)
 		return 1
-	if(isrobot(src.loc))
-		var/mob/living/silicon/robot/R = src.loc
-		if(R && R.cell && R.cell.use(250))
-			in_chamber = new/obj/item/projectile/beam/heavylaser(src)
-			return 1
+	if(use_borg_cellcharge(src.loc,250))
+		in_chamber = new/obj/item/projectile/beam/heavylaser(src)
+		return 1
 	return 0
 
 /obj/item/weapon/gun/energy/laser/cannon/cyborg/restock()

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -161,9 +161,8 @@
 	desc = "This is an antique laser gun. All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy. On the item is an image of Space Station 13. The station is exploding."
 	force = 10
 	origin_tech = null
-	var/charge_tick = 0
-	var/charge_wait = 4
 	projectile_type = "/obj/item/projectile/beam/captain"
+	recharge_time = 4
 
 /obj/item/weapon/gun/energy/laser/captain/isHandgun()
 	return TRUE
@@ -176,18 +175,6 @@
 /obj/item/weapon/gun/energy/laser/captain/Destroy()
 	processing_objects.Remove(src)
 	..()
-
-
-/obj/item/weapon/gun/energy/laser/captain/process()
-	charge_tick++
-	if(charge_tick < charge_wait)
-		return 0
-	charge_tick = 0
-	if(!power_supply)
-		return 0
-	power_supply.give(100)
-	update_icon()
-	return 1
 
 /obj/item/weapon/gun/energy/laser/captain/alien
 	name = "alien gun"
@@ -206,7 +193,7 @@
 	return 0*/
 
 /obj/item/weapon/gun/energy/laser/cyborg
-	var/charge_tick = 0
+	recharge_time = 3
 
 /obj/item/weapon/gun/energy/laser/cyborg/New()
 	..()
@@ -219,7 +206,7 @@
 
 /obj/item/weapon/gun/energy/laser/cyborg/process() //Every [recharge_time] ticks, recharge a shot for the cyborg
 	charge_tick++
-	if(charge_tick < 3)
+	if(charge_tick < recharge_time)
 		return 0
 	charge_tick = 0
 
@@ -257,13 +244,8 @@
 		power_supply.charge = 0
 		update_icon()
 
-/obj/item/weapon/gun/energy/laser/cannon/cyborg/process_chambered()
-	if(in_chamber)
-		return 1
-	if(use_borg_cellcharge(src.loc,250))
-		in_chamber = new/obj/item/projectile/beam/heavylaser(src)
-		return 1
-	return 0
+/obj/item/weapon/gun/energy/laser/cannon/cyborg
+	charge_cost = 250
 
 /obj/item/weapon/gun/energy/laser/cannon/cyborg/restock()
 	if(power_supply.charge < power_supply.maxcharge)
@@ -463,7 +445,7 @@
 	charge_cost = 1000	//one shot per charge
 	fire_sound = null
 	projectile_type = "/obj/item/projectile/beam/combustion"
-	charge_wait = 2	//40 seconds to fully charge
+	recharge_time = 2	//40 seconds to fully charge
 	slot_flags = 0
 	w_class = W_CLASS_HUGE
 	var/charged = TRUE

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -179,21 +179,9 @@
 /obj/item/weapon/gun/energy/laser/captain/alien
 	name = "alien gun"
 
-
-
-/*/obj/item/weapon/gun/energy/laser/cyborg/load_into_chamber()
-	if(in_chamber)
-		return 1
-	if(isrobot(src.loc))
-		var/mob/living/silicon/robot/R = src.loc
-		if(R && R.cell)
-			R.cell.use(100)
-			in_chamber = new/obj/item/projectile/beam(src)
-			return 1
-	return 0*/
-
 /obj/item/weapon/gun/energy/laser/cyborg
 	recharge_time = 3
+	recharges_borg_cell = TRUE
 
 /obj/item/weapon/gun/energy/laser/cyborg/restock()
 	if(power_supply.charge < power_supply.maxcharge)
@@ -201,7 +189,6 @@
 		update_icon()
 	else
 		charge_tick = 0
-
 
 /obj/item/weapon/gun/energy/laser/cannon
 	name = "laser cannon"
@@ -223,6 +210,7 @@
 
 /obj/item/weapon/gun/energy/laser/cannon/cyborg
 	charge_cost = 250
+	uses_borg_cell = TRUE
 
 /obj/item/weapon/gun/energy/laser/cannon/cyborg/restock()
 	if(power_supply.charge < power_supply.maxcharge)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -182,13 +182,7 @@
 /obj/item/weapon/gun/energy/laser/cyborg
 	recharge_time = 3
 	recharges_borg_cell = TRUE
-
-/obj/item/weapon/gun/energy/laser/cyborg/restock()
-	if(power_supply.charge < power_supply.maxcharge)
-		power_supply.give(charge_cost)
-		update_icon()
-	else
-		charge_tick = 0
+	borg_restocks = TRUE
 
 /obj/item/weapon/gun/energy/laser/cannon
 	name = "laser cannon"
@@ -211,11 +205,7 @@
 /obj/item/weapon/gun/energy/laser/cannon/cyborg
 	charge_cost = 250
 	uses_borg_cell = TRUE
-
-/obj/item/weapon/gun/energy/laser/cannon/cyborg/restock()
-	if(power_supply.charge < power_supply.maxcharge)
-		power_supply.give(charge_cost)
-		update_icon()
+	borg_restocks = TRUE
 
 /obj/item/weapon/gun/energy/xray
 	name = "xray laser gun"

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -56,8 +56,8 @@
 	rechargeable = FALSE
 	non_rechargeable_reason = "<span class='notice'>Your gun's recharge port was removed to make room for a miniaturized reactor.</span>"
 	clowned = UNCLOWN
+	recharge_time
 	var/core_stability = 10
-	var/charge_tick = 0
 
 /obj/item/weapon/gun/energy/gun/nuclear/New()
 	..()
@@ -75,7 +75,7 @@
 			update_icon()
 	if(power_supply && core_stability > 0)
 		charge_tick++
-		if(charge_tick < 4)
+		if(charge_tick < recharge_time)
 			return
 		charge_tick = 0
 		if(power_supply.charge < power_supply.maxcharge)

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -56,17 +56,12 @@
 	rechargeable = FALSE
 	non_rechargeable_reason = "<span class='notice'>Your gun's recharge port was removed to make room for a miniaturized reactor.</span>"
 	clowned = UNCLOWN
-	recharge_time
+	recharge_time = 4
 	var/core_stability = 10
 
 /obj/item/weapon/gun/energy/gun/nuclear/New()
 	..()
-	processing_objects.Add(src)
 	update_icon()
-
-/obj/item/weapon/gun/energy/gun/nuclear/Destroy()
-	processing_objects.Remove(src)
-	..()
 
 /obj/item/weapon/gun/energy/gun/nuclear/process()
 	if (core_stability < 10)

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -34,6 +34,7 @@
 
 /obj/item/weapon/gun/energy/pulse_rifle/cyborg
 	projectile_type = "/obj/item/projectile/beam"
+	uses_borg_cell = TRUE
 
 /obj/item/weapon/gun/energy/pulse_rifle/destroyer
 	name = "pulse destroyer"

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -35,12 +35,9 @@
 /obj/item/weapon/gun/energy/pulse_rifle/cyborg/process_chambered()
 	if(in_chamber)
 		return 1
-	if(isrobot(src.loc))
-		var/mob/living/silicon/robot/R = src.loc
-		if(R && R.cell)
-			R.cell.use(charge_cost)
-			in_chamber = new/obj/item/projectile/beam(src)
-			return 1
+	if(use_borg_cellcharge(src.loc,charge_cost))
+		in_chamber = new/obj/item/projectile/beam(src)
+		return 1
 	return 0
 
 

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -32,14 +32,8 @@
 			to_chat(user, "<span class='warning'>\The [src] is now set to DESTROY.</span>")
 			projectile_type = "/obj/item/projectile/beam/pulse"
 
-/obj/item/weapon/gun/energy/pulse_rifle/cyborg/process_chambered()
-	if(in_chamber)
-		return 1
-	if(use_borg_cellcharge(src.loc,charge_cost))
-		in_chamber = new/obj/item/projectile/beam(src)
-		return 1
-	return 0
-
+/obj/item/weapon/gun/energy/pulse_rifle/cyborg
+	projectile_type = "/obj/item/projectile/beam"
 
 /obj/item/weapon/gun/energy/pulse_rifle/destroyer
 	name = "pulse destroyer"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -427,18 +427,8 @@
 	clumsy_check = 0 //Admin spawn only, might as well let clowns use it.
 	recharge_time = 5
 
-/obj/item/weapon/gun/energy/meteorgun/New()
-	..()
-	processing_objects.Add(src)
-
-
-/obj/item/weapon/gun/energy/meteorgun/Destroy()
-	processing_objects.Remove(src)
-	..()
-
 /obj/item/weapon/gun/energy/meteorgun/update_icon()
 	return
-
 
 /obj/item/weapon/gun/energy/meteorgun/pen
 	name = "meteor pen"
@@ -538,6 +528,7 @@
 	cell_type = "/obj/item/weapon/cell/miningborg"
 	charge_cost = 50
 	recharge_time = 3
+	recharges_borg_cell = TRUE
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/cyborg/restock()
 	if(power_supply.charge < power_supply.maxcharge)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -529,13 +529,7 @@
 	charge_cost = 50
 	recharge_time = 3
 	recharges_borg_cell = TRUE
-
-/obj/item/weapon/gun/energy/kinetic_accelerator/cyborg/restock()
-	if(power_supply.charge < power_supply.maxcharge)
-		power_supply.give(charge_cost)
-		update_icon()
-	else
-		charge_tick = 0
+	borg_restocks = TRUE
 
 /obj/item/weapon/gun/energy/radgun
 	name = "radgun"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -604,15 +604,6 @@
 /obj/item/weapon/gun/energy/radgun/isHandgun()
 	return TRUE
 
-/obj/item/weapon/gun/energy/radgun/New()
-	..()
-	processing_objects.Add(src)
-
-
-/obj/item/weapon/gun/energy/radgun/Destroy()
-	processing_objects.Remove(src)
-	..()
-
 /obj/item/weapon/gun/energy/ricochet
 	name = "ricochet rifle"
 	desc = "They say that these were originally designed for duck games. Not that there's any duck in this part of space."

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -587,11 +587,8 @@
 
 	if(!power_supply)
 		return 0 //sanity
-	if(isrobot(src.loc))
-		var/mob/living/silicon/robot/R = src.loc
-		if(R && R.cell)
-			R.cell.use(charge_cost) 		//Take power from the borg...
-			power_supply.give(charge_cost)	//... to recharge the shot
+	if(use_borg_cellcharge(src.loc,charge_cost)) //Take power from the borg...
+		power_supply.give(charge_cost) // ...to recharge the shot
 
 	update_icon()
 	return 1

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -84,7 +84,7 @@
 	origin_tech = null
 	clumsy_check = 0
 	honor_check = 0
-	var/charge_tick = 0
+	recharge_time = 4
 
 
 /obj/item/weapon/gun/energy/staff/New()
@@ -99,7 +99,7 @@
 
 /obj/item/weapon/gun/energy/staff/process()
 	charge_tick++
-	if(charge_tick < 4)
+	if(charge_tick < recharge_time)
 		return 0
 	charge_tick = 0
 	if(!power_supply)
@@ -446,8 +446,7 @@
 	charge_cost = 100
 	cell_type = "/obj/item/weapon/cell/potato"
 	clumsy_check = 0 //Admin spawn only, might as well let clowns use it.
-	var/charge_tick = 0
-	var/recharge_time = 5 //Time it takes for shots to recharge (in ticks)
+	recharge_time = 5
 
 /obj/item/weapon/gun/energy/meteorgun/New()
 	..()
@@ -457,15 +456,6 @@
 /obj/item/weapon/gun/energy/meteorgun/Destroy()
 	processing_objects.Remove(src)
 	..()
-
-/obj/item/weapon/gun/energy/meteorgun/process()
-	charge_tick++
-	if(charge_tick < recharge_time)
-		return 0
-	charge_tick = 0
-	if(!power_supply)
-		return 0
-	power_supply.give(100)
 
 /obj/item/weapon/gun/energy/meteorgun/update_icon()
 	return
@@ -568,7 +558,7 @@
 	projectile_type = "/obj/item/projectile/kinetic"
 	cell_type = "/obj/item/weapon/cell/miningborg"
 	charge_cost = 50
-	var/charge_tick = 0
+	recharge_time = 3
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/cyborg/New()
 	..()
@@ -581,7 +571,7 @@
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/cyborg/process() //Every [recharge_time] ticks, recharge a shot for the cyborg
 	charge_tick++
-	if(charge_tick < 3)
+	if(charge_tick < recharge_time)
 		return 0
 	charge_tick = 0
 
@@ -608,7 +598,7 @@
 	inhand_states = list("left_hand" = 'icons/mob/in-hand/left/guninhands_left.dmi', "right_hand" = 'icons/mob/in-hand/right/guninhands_right.dmi')
 	fire_sound = 'sound/weapons/radgun.ogg'
 	charge_cost = 100
-	var/charge_tick = 0
+	recharge_time = 4
 	projectile_type = "/obj/item/projectile/energy/rad"
 
 /obj/item/weapon/gun/energy/radgun/isHandgun()
@@ -622,17 +612,6 @@
 /obj/item/weapon/gun/energy/radgun/Destroy()
 	processing_objects.Remove(src)
 	..()
-
-/obj/item/weapon/gun/energy/radgun/process()
-	charge_tick++
-	if(charge_tick < 4)
-		return 0
-	charge_tick = 0
-	if(!power_supply)
-		return 0
-	power_supply.give(100)
-	update_icon()
-	return 1
 
 /obj/item/weapon/gun/energy/ricochet
 	name = "ricochet rifle"
@@ -801,7 +780,7 @@
 	origin_tech = Tc_MATERIALS + "=5;" + Tc_POWERSTORAGE + "=4;" + Tc_COMBAT + "=5"
 	fire_delay = 0
 	projectile_type = "/obj/item/projectile/spur"
-	var/charge_tick = 0
+	recharge_time = 2
 
 /obj/item/weapon/gun/energy/polarstar/spur/New()
 	..()
@@ -814,7 +793,7 @@
 
 /obj/item/weapon/gun/energy/polarstar/spur/process()
 	charge_tick++
-	if(charge_tick < 2)
+	if(charge_tick < recharge_time)
 		return 0
 	charge_tick = 0
 	if(!power_supply)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -86,27 +86,6 @@
 	honor_check = 0
 	recharge_time = 4
 
-
-/obj/item/weapon/gun/energy/staff/New()
-	..()
-	processing_objects.Add(src)
-
-
-/obj/item/weapon/gun/energy/staff/Destroy()
-	processing_objects.Remove(src)
-	..()
-
-
-/obj/item/weapon/gun/energy/staff/process()
-	charge_tick++
-	if(charge_tick < recharge_time)
-		return 0
-	charge_tick = 0
-	if(!power_supply)
-		return 0
-	power_supply.give(200)
-	return 1
-
 /obj/item/weapon/gun/energy/staff/update_icon()
 	return
 
@@ -560,29 +539,6 @@
 	charge_cost = 50
 	recharge_time = 3
 
-/obj/item/weapon/gun/energy/kinetic_accelerator/cyborg/New()
-	..()
-	processing_objects.Add(src)
-
-
-/obj/item/weapon/gun/energy/kinetic_accelerator/cyborg/Destroy()
-	processing_objects.Remove(src)
-	..()
-
-/obj/item/weapon/gun/energy/kinetic_accelerator/cyborg/process() //Every [recharge_time] ticks, recharge a shot for the cyborg
-	charge_tick++
-	if(charge_tick < recharge_time)
-		return 0
-	charge_tick = 0
-
-	if(!power_supply)
-		return 0 //sanity
-	if(use_borg_cellcharge(src.loc,charge_cost)) //Take power from the borg...
-		power_supply.give(charge_cost) // ...to recharge the shot
-
-	update_icon()
-	return 1
-
 /obj/item/weapon/gun/energy/kinetic_accelerator/cyborg/restock()
 	if(power_supply.charge < power_supply.maxcharge)
 		power_supply.give(charge_cost)
@@ -773,25 +729,10 @@
 	projectile_type = "/obj/item/projectile/spur"
 	recharge_time = 2
 
-/obj/item/weapon/gun/energy/polarstar/spur/New()
-	..()
-	processing_objects.Add(src)
-
-
-/obj/item/weapon/gun/energy/polarstar/spur/Destroy()
-	processing_objects.Remove(src)
-	..()
-
 /obj/item/weapon/gun/energy/polarstar/spur/process()
-	charge_tick++
-	if(charge_tick < recharge_time)
-		return 0
-	charge_tick = 0
-	if(!power_supply)
-		return 0
-	power_supply.give(100)
-	levelChange()
-	return 1
+	. = ..()
+	if(.)
+		levelChange()
 
 #undef SPUR_FULL_POWER
 #undef SPUR_HIGH_POWER

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -20,6 +20,7 @@
 /obj/item/weapon/gun/energy/taser/cyborg
 	cell_type = "/obj/item/weapon/cell/secborg"
 	recharge_time = 10 //Time it takes for shots to recharge (in ticks)
+	recharges_borg_cell = TRUE
 	borg_restocks = TRUE
 
 /obj/item/weapon/gun/energy/taser/team_security

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -25,8 +25,7 @@
 	charge_cost = 100
 	projectile_type = "/obj/item/projectile/energy/electrode"
 	cell_type = "/obj/item/weapon/cell/secborg"
-	var/charge_tick = 0
-	var/recharge_time = 10 //Time it takes for shots to recharge (in ticks)
+	recharge_time = 10 //Time it takes for shots to recharge (in ticks)
 
 /obj/item/weapon/gun/energy/taser/cyborg/New()
 	..()
@@ -117,7 +116,7 @@
 	cell_type = "/obj/item/weapon/cell/crap"
 	rechargeable = FALSE
 	non_rechargeable_reason = "<span class='notice'>Your gun's recharge port was removed to make room for a miniaturized reactor.</span>"
-	var/charge_tick = 0
+	recharge_time = 4
 
 /obj/item/weapon/gun/energy/crossbow/isHandgun()
 	return TRUE
@@ -126,22 +125,9 @@
 	..()
 	processing_objects.Add(src)
 
-
 /obj/item/weapon/gun/energy/crossbow/Destroy()
 	processing_objects.Remove(src)
 	..()
-
-
-/obj/item/weapon/gun/energy/crossbow/process()
-	charge_tick++
-	if(charge_tick < 4)
-		return 0
-	charge_tick = 0
-	if(!power_supply)
-		return 0
-	power_supply.give(100)
-	return 1
-
 
 /obj/item/weapon/gun/energy/crossbow/update_icon()
 	return

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -45,11 +45,8 @@
 
 	if(!power_supply)
 		return 0 //sanity
-	if(isrobot(src.loc))
-		var/mob/living/silicon/robot/R = src.loc
-		if(R && R.cell)
-			R.cell.use(charge_cost) 		//Take power from the borg...
-			power_supply.give(charge_cost)	//... to recharge the shot
+	if(use_borg_cellcharge(src.loc,charge_cost)) //Take power from the borg...
+		power_supply.give(charge_cost) // ...to recharge the shot
 
 	update_icon()
 	return 1

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -20,13 +20,7 @@
 /obj/item/weapon/gun/energy/taser/cyborg
 	cell_type = "/obj/item/weapon/cell/secborg"
 	recharge_time = 10 //Time it takes for shots to recharge (in ticks)
-
-/obj/item/weapon/gun/energy/taser/cyborg/restock()
-	if(power_supply.charge < power_supply.maxcharge)
-		power_supply.give(charge_cost)
-		update_icon()
-	else
-		charge_tick = 0
+	borg_restocks = TRUE
 
 /obj/item/weapon/gun/energy/taser/team_security
 	name = "\improper Team Security sniper taser gun"

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -27,20 +27,6 @@
 	cell_type = "/obj/item/weapon/cell/secborg"
 	recharge_time = 10 //Time it takes for shots to recharge (in ticks)
 
-/obj/item/weapon/gun/energy/taser/cyborg/process() //Every [recharge_time] ticks, recharge a shot for the cyborg
-	charge_tick++
-	if(charge_tick < recharge_time)
-		return 0
-	charge_tick = 0
-
-	if(!power_supply)
-		return 0 //sanity
-	if(use_borg_cellcharge(src.loc,charge_cost)) //Take power from the borg...
-		power_supply.give(charge_cost) // ...to recharge the shot
-
-	update_icon()
-	return 1
-
 /obj/item/weapon/gun/energy/taser/cyborg/restock()
 	if(power_supply.charge < power_supply.maxcharge)
 		power_supply.give(charge_cost)

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -18,12 +18,6 @@
 	projectile_type = "/obj/item/projectile/ricochet/taser"
 
 /obj/item/weapon/gun/energy/taser/cyborg
-	name = "taser gun"
-	desc = "A small, low capacity gun used for non-lethal takedowns."
-	icon_state = "taser"
-	fire_sound = 'sound/weapons/Taser.ogg'
-	charge_cost = 100
-	projectile_type = "/obj/item/projectile/energy/electrode"
 	cell_type = "/obj/item/weapon/cell/secborg"
 	recharge_time = 10 //Time it takes for shots to recharge (in ticks)
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -27,15 +27,6 @@
 	cell_type = "/obj/item/weapon/cell/secborg"
 	recharge_time = 10 //Time it takes for shots to recharge (in ticks)
 
-/obj/item/weapon/gun/energy/taser/cyborg/New()
-	..()
-	processing_objects.Add(src)
-
-
-/obj/item/weapon/gun/energy/taser/cyborg/Destroy()
-	processing_objects.Remove(src)
-	..()
-
 /obj/item/weapon/gun/energy/taser/cyborg/process() //Every [recharge_time] ticks, recharge a shot for the cyborg
 	charge_tick++
 	if(charge_tick < recharge_time)

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -92,14 +92,6 @@
 /obj/item/weapon/gun/energy/crossbow/isHandgun()
 	return TRUE
 
-/obj/item/weapon/gun/energy/crossbow/New()
-	..()
-	processing_objects.Add(src)
-
-/obj/item/weapon/gun/energy/crossbow/Destroy()
-	processing_objects.Remove(src)
-	..()
-
 /obj/item/weapon/gun/energy/crossbow/update_icon()
 	return
 

--- a/code/modules/projectiles/guns/energy/tag.dm
+++ b/code/modules/projectiles/guns/energy/tag.dm
@@ -13,7 +13,7 @@
 	nymph_check = 0
 	hulk_check = 0
 	golem_check = 0
-	var/charge_tick = 0
+	recharge_time = 4
 	var/score = 0
 	var/last_disable_time = -1
 
@@ -104,17 +104,6 @@
 /obj/item/weapon/gun/energy/tag/Destroy()
 	processing_objects.Remove(src)
 	..()
-
-/obj/item/weapon/gun/energy/tag/process()
-	charge_tick++
-	if(charge_tick < 4)
-		return 0
-	charge_tick = 0
-	if(!power_supply)
-		return 0
-	power_supply.give(100)
-	update_icon()
-	return 1
 
 /obj/item/weapon/gun/energy/tag/proc/cooldown(var/time)
 	if (time > 0)

--- a/code/modules/projectiles/guns/energy/tag.dm
+++ b/code/modules/projectiles/guns/energy/tag.dm
@@ -98,12 +98,7 @@
 
 /obj/item/weapon/gun/energy/tag/New()
 	..()
-	processing_objects.Add(src)
 	makeLaser()
-
-/obj/item/weapon/gun/energy/tag/Destroy()
-	processing_objects.Remove(src)
-	..()
 
 /obj/item/weapon/gun/energy/tag/proc/cooldown(var/time)
 	if (time > 0)

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -290,7 +290,7 @@
 			spawn(5)
 				reagents.trans_to(M, gulp_size)
 
-		if(use_borg_cellcharge(user,30)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
+		if(use_cell_charge(user,30)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
 			var/refill = reagents.get_master_reagent_id()
 			spawn(600)
 				reagents.add_reagent(refill, gulp_size)

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -290,7 +290,7 @@
 			spawn(5)
 				reagents.trans_to(M, gulp_size)
 
-		if(use_borg_cellcharge(30)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
+		if(use_borg_cellcharge(user,30)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
 			var/refill = reagents.get_master_reagent_id()
 			spawn(600)
 				reagents.add_reagent(refill, gulp_size)

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -290,9 +290,7 @@
 			spawn(5)
 				reagents.trans_to(M, gulp_size)
 
-		if(isrobot(user)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
-			var/mob/living/silicon/robot/bro = user
-			bro.cell.use(30)
+		if(use_borg_cellcharge(30)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
 			var/refill = reagents.get_master_reagent_id()
 			spawn(600)
 				reagents.add_reagent(refill, gulp_size)

--- a/code/modules/tgui/states.dm
+++ b/code/modules/tgui/states.dm
@@ -80,7 +80,7 @@
 /mob/living/silicon/robot/shared_ui_interaction(src_object)
 	// Disable UIs if the object isn't installed in the borg AND the borg is either locked, has a dead cell, or no cell.
 	var/atom/device = src_object
-	if((istype(device) && device.loc != src) && (!cell || cell.charge <= 0 || lockdown))
+	if((istype(device) && device.loc != src) && (get_cell_charge() <= 0 || lockdown))
 		return UI_DISABLED
 	return UI_INTERACTIVE
 

--- a/maps/randomvaults/mothership_lab.dm
+++ b/maps/randomvaults/mothership_lab.dm
@@ -1691,10 +1691,7 @@
 			user.stuttering = 10
 			user.Knockdown(10)
 			if(isrobot(user))
-				var/mob/living/silicon/robot/R = user
-				var/obj/item/weapon/cell/Rcell = R.get_cell()
-				if(Rcell)
-					Rcell.charge -= 20
+				use_cell_charge(user,20)
 			else
 				B.deductcharge(1)
 			user.visible_message( \

--- a/maps/randomvaults/mothership_lab.dm
+++ b/maps/randomvaults/mothership_lab.dm
@@ -1692,7 +1692,9 @@
 			user.Knockdown(10)
 			if(isrobot(user))
 				var/mob/living/silicon/robot/R = user
-				R.cell.charge -= 20
+				var/obj/item/weapon/cell/Rcell = R.get_cell()
+				if(Rcell)
+					Rcell.charge -= 20
 			else
 				B.deductcharge(1)
 			user.visible_message( \


### PR DESCRIPTION
[cleanup][consistency]

## What this does
fullfils the journey of a long todo of removing the "cell" variable from borgs and makes it part of their components
makes the install() and uninstall() procs of components now actually do something.
creates procs that standardise getting and using borg cell charge when they use items.
adds code support for using part exchangers on borg, the original idea of this PR before i got sidetracked doing this, with a commented out demonstration to bring the atomicity back to this PR.
deletes non-MMI stuff created inside qdel()'d borgs, as to free up these objects from memory.
standardises energy guns being used by borgs by removing a lot of duplicate code, while keeping functionalities for each. introduces a recharge rate var for all energy guns, only makes them process if this is set above 0.
adds the ability for admins to be any robot module they want, for testing purposes.

## Why it's good
code is cleaner, easier to read, easier to maintain, consistent.

## How it was tested
being a borg, (since a lot of stuff related to power cells is just passive, like looking at your charge level) selecting security module, firing the taser, selecting crisis module, using its hypospray, recharging in recharging stations, removing the cell from the borg, removing the components, putting everything back in, deleting the borg, building a MoMMI, building a SAMMI, building a borg, using the robotics computer, using an autoborger, firing rechargable guns.

## Changelog
:cl:
 * rscadd: Admins can now select all possible robot modules as a cyborg.
 * rscadd: Robot electric arms, hug modules, fire axes, hyposprays, batons, RCDs, energy guns and refillable drinks now warn the player by text when shutting down from lack of charge.
 * spellcheck: Cyborg light replacers now have a proper space before the amount of glass generated.
 * spellcheck: Recharge stations now have consistent formatting for cell replacement or upgrade information.
