### PR TITLE
Ghosts can hear environmental sounds

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -262,8 +262,6 @@ Works together with spawning an observer, noted above.
 		if (deafmute)
 			ghostype = /mob/dead/observer/deafmute
 		var/mob/dead/observer/ghost = new ghostype(src, flags)	//Transfer safety to observer spawning proc.
-		if (sound_zone_manager)
-			sound_zone_manager.unregister_listener(src)
 		var/timetocheck = timeofdeath
 		if (isbrain(src))
 			var/mob/living/carbon/brain/brainmob = src

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -18,9 +18,6 @@
 	if(iscultist(src) && hud_used && !hud_used.cult_Act_display)
 		hud_used.cult_hud()
 
-	// Register as something able to receive sounds from sound_emitters
-	if (sound_zone_manager)
-		sound_zone_manager.register_listener(src)
 
 	//Round specific stuff like hud updates
 	if(ticker && ticker.mode)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -115,6 +115,10 @@
 	client.media.open()
 	client.media.update_music()
 
+	// Register as something able to receive sounds from sound_emitters
+	if (sound_zone_manager)
+		sound_zone_manager.register_listener(src)
+
 	register_event(/event/mob_area_changed, src, nameof(src::OnMobAreaChanged()))
 
 	if(spell_masters)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -511,6 +511,7 @@
 			var/obj/structure/stairs/up_stairs = locate(/obj/structure/stairs) in T
 			if(up_stairs && up_stairs.dir == mob.dir)
 				up_stairs.Bumped(mob)
+			INVOKE_EVENT(mob, /event/moved, "mover" = mob)
 			mob.delayNextMove(movedelay)
 		if(INCORPOREAL_ETHEREAL, INCORPOREAL_ETHEREAL_IMPROVED) //Jaunting, without needing to be done through relaymove
 			var/jaunt_type = mob.incorporeal_move


### PR DESCRIPTION
\>ghosts werent receiving sounds in testing
\>find out ghosts don't raise move events
\>decide not to touch it
\>main pr gets merged
\>suddenly decide to touch it
\>it wasnt that hard actually

## What this does
- ghosts now raise `/event/moved` when they move
- this lets them hear things that emit constant sounds
- fixes a bug where environmental sounds that started playing near a ghost could get stuck for that ghost

## Why it's good
obsgang won't whine

## How it was tested
started local, ghosted, heard sounds

## Changelog

 * bugfix: Ghosts can hear environmental sounds
 
## Note:
There is another `INVOKE_EVENT` in `mob_movement.dm` that is incorrect - the case for jaunting wizards doesn't pass a `"mover"` argument so any listeners will get a null `mover`. I opted not to change it in this PR but will raise an issue pending testing, it's been doing that for 4 years and no one noticed either because the event has zero listeners anyway or because there were no significant noticeable effects

## Note2:
~~In draft status until an issue with moving rapidly between emitters leading to distortion (probably on shared channels) is resolved, this is noticeable by AI players~~ This is a separate issue that only affects AI as far as I can tell, due to how the AI eye mob works