### PR TITLE
Disables Dynamic+

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -230,6 +230,8 @@
 	// tg asset cdn via webroot systme. Currently unused.
 	var/asset_cdn_webroot = ""
 	var/asset_cdn_url = ""
+	//Is Dynamic+ Enabled
+	var/dynamic_plus = FALSE
 
 
 /datum/configuration/New()
@@ -734,6 +736,8 @@
 					hardcore_mode = value
 				if("humans_speak")
 					voice_noises = 1
+				if("dynamic_plus")
+					config.dynamic_plus = TRUE
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 

--- a/code/datums/gamemode/dynamic/dynamic_rulesets.dm
+++ b/code/datums/gamemode/dynamic/dynamic_rulesets.dm
@@ -166,7 +166,7 @@
 
 	result = previous_rounds_odds_reduction(result)
 
-	if (weight_category in mode.ruleset_category_weights)
+	if (config.dynamic_plus && (weight_category in mode.ruleset_category_weights))
 		result *= mode.ruleset_category_weights[weight_category]
 
 	if (mode.highlander_rulesets_favoured && (flags & HIGHLANDER_RULESET))

--- a/config-example/config.txt
+++ b/config-example/config.txt
@@ -397,6 +397,3 @@ BRANCH_HEAD .git/refs/heads/Bleeding-Edge
 
 ## Location of rsc string
 # RSCSTRING
-
-# Is dynamic+ enabled, allowing persistence to adjust antag weights?
-# DYNAMIC_PLUS

--- a/config-example/config.txt
+++ b/config-example/config.txt
@@ -397,3 +397,6 @@ BRANCH_HEAD .git/refs/heads/Bleeding-Edge
 
 ## Location of rsc string
 # RSCSTRING
+
+# Is dynamic+ enabled, allowing persistence to adjust antag weights?
+# DYNAMIC_PLUS

--- a/config-example/game_options.txt
+++ b/config-example/game_options.txt
@@ -43,7 +43,7 @@ RESPAWN_DELAY 30
 ## These values get directly added to values and totals in-game. To speed things up make the number negative, to slow things down, make the number positive.
 
 
-## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied. 
+## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied.
 RUN_DELAY 0
 WALK_DELAY 0
 
@@ -87,3 +87,6 @@ HARDCORE_MODE 0
 
 # Whether when people talk, some voice noises are played
 # HUMANS_SPEAK
+
+# Is dynamic+ enabled, allowing persistence to adjust antag weights?
+# DYNAMIC_PLUS


### PR DESCRIPTION
# It's too much!

## What this does
This adds a configuration option that allows the enabling and disabling of the Dynamic+ experimental feature, which increases the weights of antagonists based on when they were last seen.

By default, this is off.

## Why it's good
Because it's a band aid to a bigger problem, it's not. But hopefully this may help the feeling that you're getting bombarded with a variety of different antags of questionable quality every single round.

## How it was tested
Compiled, tested with setting on and setting off.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * experiment: Disabled Dynamic+, antags no longer have a infintely increasing chance to be fired if they haven't fired in a while.
