### PR TITLE
Fix AI Eye sound behaviour and some ghosting issues

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1556,6 +1556,10 @@ var/alien_ship_location = 1 // 0 = base , 1 = mine
 
 	tomob.ghostize(0) //boot the old mob out
 
+	if (sound_zone_manager)
+		// flush sounds from old ghost before assigning ckey
+		sound_zone_manager.unregister_listener(frommob)
+
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] has put [frommob.ckey] in control of [tomob.name].</span>")
 	log_admin("[key_name(usr)] stuffed [frommob.ckey] into [tomob.name].")
 	feedback_add_details("admin_verb","CGD")

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -262,8 +262,6 @@ Works together with spawning an observer, noted above.
 		if (deafmute)
 			ghostype = /mob/dead/observer/deafmute
 		var/mob/dead/observer/ghost = new ghostype(src, flags)	//Transfer safety to observer spawning proc.
-		if (sound_zone_manager)
-			sound_zone_manager.unregister_listener(src)
 		var/timetocheck = timeofdeath
 		if (isbrain(src))
 			var/mob/living/carbon/brain/brainmob = src

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -115,6 +115,15 @@ var/creating_arena = FALSE
 
 		mind = body.mind	//we don't transfer the mind but we keep a reference to it.
 
+		if (sound_zone_manager && body)
+			// client is null in Logout so need to flush old sounds here
+			// ghost registering as a listener happens in Login
+			sound_zone_manager.unregister_listener(body)
+			// AI Eye picks up sounds separately so disgusting special handling here... heaven forgive me
+			var/mob/living/silicon/ai/ai = body
+			if (istype(ai))
+				sound_zone_manager.unregister_listener(ai.eyeobj)
+
 	if(!T)
 		T = pick(latejoin)			//Safety in case we cannot find the body's position
 	loc = T

--- a/code/modules/mob/dead/observer/verbs.dm
+++ b/code/modules/mob/dead/observer/verbs.dm
@@ -30,6 +30,11 @@
 			to_chat(usr, "<span class='warning'>The astral cord that ties your body and your spirit has been severed. You are likely to wander the realm beyond until your body is finally dead and thus reunited with you.</span>")
 			return
 	completely_untransmogrify()
+
+	if (sound_zone_manager)
+		// flush any sounds the ghost can hear
+		sound_zone_manager.unregister_listener(src)
+
 	mind.current.key = key
 	mind.isScrying = 0
 	return 1

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -18,9 +18,6 @@
 	if(iscultist(src) && hud_used && !hud_used.cult_Act_display)
 		hud_used.cult_hud()
 
-	// Register as something able to receive sounds from sound_emitters
-	if (sound_zone_manager)
-		sound_zone_manager.register_listener(src)
 
 	//Round specific stuff like hud updates
 	if(ticker && ticker.mode)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -41,6 +41,7 @@
 			for(destination = destination.loc; !isturf(destination); destination = destination.loc);
 
 		forceEnter(destination)
+		INVOKE_EVENT(src, /event/moved, "mover" = src)
 
 		cameranet.visibility(src)
 		if(ai.client && ai.client.eye != src) // Set the eye to us and give the AI the sight & visibility flags it needs.
@@ -89,6 +90,8 @@
 /mob/living/silicon/ai/Destroy()
 	if(eyeobj)
 		eyeobj.ai = null
+		if (sound_zone_manager)
+			sound_zone_manager.unregister_listener(eyeobj)
 		QDEL_NULL(eyeobj) // No AI, no Eye
 	..()
 
@@ -192,6 +195,10 @@
 	eyeobj.ai = src
 	refresh_eyeobj_name()
 	eyeobj.forceMove(loc)
+	if (sound_zone_manager)
+		sound_zone_manager.unregister_listener(src)
+		sound_zone_manager.register_listener(eyeobj)
+		eyeobj.sound_endpoint = src
 
 /mob/living/silicon/ai/proc/refresh_eyeobj_name()
 	eyeobj.name = "[name] (AI Eye)"

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -24,6 +24,11 @@
 	client.CAN_MOVE_DIAGONALLY = TRUE
 	client.screen += aistatic
 
+	if (sound_zone_manager)
+		sound_zone_manager.unregister_listener(src)
+		if (eyeobj)
+			sound_zone_manager.register_listener(eyeobj)
+
 /mob/living/silicon/ai/proc/show_intro_text()
 	to_chat(src, "<B>You are playing the station's AI. The AI cannot move, but can interact with many objects while viewing them (through cameras).</B>")
 	to_chat(src, "<B>To look at other parts of the station, click on yourself to get a camera menu.</B>")

--- a/code/modules/mob/living/silicon/ai/logout.dm
+++ b/code/modules/mob/living/silicon/ai/logout.dm
@@ -1,5 +1,9 @@
 /mob/living/silicon/ai/Logout()
+	if (sound_zone_manager && eyeobj)
+		sound_zone_manager.unregister_listener(eyeobj)
+
 	..()
+
 	for(var/obj/machinery/ai_status_display/O in machines) //change status
 		O.mode = 0
 

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -115,6 +115,10 @@
 	client.media.open()
 	client.media.update_music()
 
+	// Register as something able to receive sounds from sound_emitters
+	if (sound_zone_manager)
+		sound_zone_manager.register_listener(src)
+
 	register_event(/event/mob_area_changed, src, nameof(src::OnMobAreaChanged()))
 
 	if(spell_masters)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -511,6 +511,7 @@
 			var/obj/structure/stairs/up_stairs = locate(/obj/structure/stairs) in T
 			if(up_stairs && up_stairs.dir == mob.dir)
 				up_stairs.Bumped(mob)
+			INVOKE_EVENT(mob, /event/moved, "mover" = mob)
 			mob.delayNextMove(movedelay)
 		if(INCORPOREAL_ETHEREAL, INCORPOREAL_ETHEREAL_IMPROVED) //Jaunting, without needing to be done through relaymove
 			var/jaunt_type = mob.incorporeal_move

--- a/code/modules/sound/sound_emitter.dm
+++ b/code/modules/sound/sound_emitter.dm
@@ -7,6 +7,11 @@
 /mob
 	var/list/current_sound_emitters = list()
 	var/last_sound_zone_hash = null
+	// proxy for when the sound needs to be sent to some other mob, e.g. aiEye mob movement needs sounds sent to AI Core mob
+	//  this is because the AI Eye client is null and mob/proc/operator<< tries to send to client
+	var/mob/sound_endpoint = null
+/mob/New()
+	sound_endpoint = src
 
 /datum/sound_emitter
 	var/atom/source = null
@@ -88,7 +93,7 @@
 	for (var/mob/player in vicinity)
 		var/sound/PS = apply_player_effects(copy_sound(S), player)
 		if (PS.volume)
-			player << PS
+			player.sound_endpoint << PS
 
 /datum/sound_emitter/proc/is_currently_playing()
 	return ((active_key != null) && (channel != null))
@@ -108,7 +113,7 @@
 	S.status |= SOUND_UPDATE
 	for (var/mob/player in hearers)
 		S = apply_player_effects(copy_sound(S), player)
-		player << S
+		player.sound_endpoint << S
 
 /datum/sound_emitter/proc/stop()
 	if (!channel)
@@ -166,7 +171,7 @@
 		S.channel = channel.value
 		S = apply_env_effects(copy_sound(S))
 		S = apply_player_effects(S, player)
-		player << S
+		player.sound_endpoint << S
 
 /datum/sound_emitter/proc/on_exit_range(mob/player)
 	hearers -= player
@@ -176,7 +181,7 @@
 	var/sound/nullsound = sound(file = null)
 	nullsound.channel = channel.value
 	nullsound.status = SOUND_UPDATE | SOUND_MUTE
-	player << nullsound
+	player.sound_endpoint << nullsound
 
 /datum/sound_emitter/proc/contains(turf/T)
 	if (!T)
@@ -235,7 +240,7 @@
 		S.status = SOUND_UPDATE | SOUND_MUTE
 	S.channel = channel.value
 	for (var/mob/player in hearers)
-		player << S
+		player.sound_endpoint << S
 
 /datum/sound_emitter/proc/apply_player_effects(sound/s, var/mob/player)
 	if (player.is_deaf())
@@ -281,7 +286,7 @@
 	apply_env_effects(S)
 	apply_player_effects(S, player)
 	S.status |= SOUND_UPDATE
-	player << S
+	player.sound_endpoint << S
 
 /datum/sound_emitter/proc/players_in_range()
 	var/list/in_range = list()

--- a/code/modules/sound/sound_zone_manager.dm
+++ b/code/modules/sound/sound_zone_manager.dm
@@ -136,6 +136,10 @@ var/global/datum/sound_zone_manager/sound_zone_manager = new
 
 	player.register_event(/event/moved, src, nameof(src::on_player_move()))
 	on_player_move(player)
+	player.sound_endpoint = player
+	if (istype(player, /mob/camera/aiEye))
+		var/mob/camera/aiEye/eye = player
+		eye.sound_endpoint = eye.ai
 
 /datum/sound_zone_manager/proc/unregister_listener(mob/player)
 	var/h = player.last_sound_zone_hash
@@ -150,6 +154,7 @@ var/global/datum/sound_zone_manager/sound_zone_manager = new
 	var/list/emitters = player.current_sound_emitters.Copy()
 	for (var/datum/sound_emitter/E in emitters)
 		E.on_exit_range(player)
+	player.sound_endpoint = null
 
 /datum/sound_zone_manager/proc/update_listener(mob/player)
 	var/newHash = hash_coord(player.x, player.y, player.z)
@@ -171,7 +176,9 @@ var/global/datum/sound_zone_manager/sound_zone_manager = new
 	player.last_sound_zone_hash = newHash
 
 /datum/sound_zone_manager/proc/on_player_move(mob/mover)
-	if (!mover || !mover.client)
+	if (!mover)
+		return
+	if (!mover.client && !mover.sound_endpoint) // nowhere to send the sound
 		return
 
 	var/turf/location = mover.loc


### PR DESCRIPTION
## What this does
- Fix AI eye not correctly picking up sounds
  - AI eye now raises move events too
- Implements `/mob/var/sound_endpoint` to which sounds are sent: this is `src` by default but can be overridden in cases where the `/mob` being controlled does not have a `client` to which sounds should be sent (i.e. AI Eye has the AI Core as an endpoint)
- Fixes a few issues with ghosting due to `client` being `null` in `Logout`
- Fixes an issue where an admin assigning a ghost to a mob can result in stuck sound channels if the ghost was in range of emitters but the target mob was not
- ghosts now raise /event/moved when they move
  - this lets them hear things that emit constant sounds
- fixes a bug where environmental sounds that started playing near a ghost could get stuck for that ghost

## Why it's good
AI players won't suffer earrape, ghosting should behave more consistently, ghosts can hear environmental sounds

## How it was tested
a lot of debug lines, joining as AI and flying around and ghosting/reentering in various scenarios

## Changelog
 * bugfix: Ghosts can hear environmental sounds
 * bugfix: AI players should no longer encounter distorted audio when flying around
 * bugfix: Ghosting and re-entering body behaves more consistently

## Note:
Closing #37926 as this change includes it

## Future planned changes:
- Encapsulate instances of setting `A.ckey = B.ckey` to keep sound zone registration and deregistration in one place rather than smearing it across random places in the code
  - This is necessary because changing `ckey` invokes `Logout` and `Login`, we can't flush channels a `client` can hear from `Logout` because the `client` is already `null` by that time. As a result sounds that `B` could hear will be stuck. Flushing needs to happen before the `ckey` is reassigned.
  - Alternatively - and perhaps much more robustly - `current_sound_emitters` should be tracked on the `client` rather than on a `mob`. This will be adjacent to eventual per-`client` sound channel management planned in a future change.
- Remove typecheck in `sound_zone_manager/proc/register_listener` for AI and add a defaulted parameter for handling cases of a divergent `sound_endpoint`